### PR TITLE
fix: correct SSM import path in getSlackConfigAsync

### DIFF
--- a/src/lib/integrations.ts
+++ b/src/lib/integrations.ts
@@ -120,7 +120,7 @@ export async function getSlackConfigAsync(): Promise<SlackConfig> {
   // SSM fallback when signing secret is missing from env
   if (!signingSecret) {
     try {
-      const { getConfig } = await import('@/lib/config');
+      const { getConfig } = await import('@/lib/ssm-config');
       const ssmCfg = await getConfig();
       signingSecret = (ssmCfg as Record<string, string>).SLACK_SIGNING_SECRET ?? '';
       if (!token) token = (ssmCfg as Record<string, string>).SLACK_BOT_TOKEN ?? '';


### PR DESCRIPTION
## Summary

- PR #23 introduced  with a dynamic import of , but that module doesn't exist — the correct path is .
- This one-line fix changes the import so the SSM fallback actually works at runtime.

## What was wrong



## Test plan

- [ ] Deploy to dev/staging and trigger a Slack command without env-level  — verify SSM fallback retrieves the secret
- [ ] Confirm no runtime  errors in CloudWatch logs