### PR TITLE
fix: correct TypeScript cast in integrations.ts

### DIFF
--- a/src/lib/integrations.ts
+++ b/src/lib/integrations.ts
@@ -122,9 +122,9 @@ export async function getSlackConfigAsync(): Promise<SlackConfig> {
     try {
       const { getConfig } = await import('@/lib/ssm-config');
       const ssmCfg = await getConfig();
-      signingSecret = (ssmCfg as Record<string, string>).SLACK_SIGNING_SECRET ?? '';
-      if (!token) token = (ssmCfg as Record<string, string>).SLACK_BOT_TOKEN ?? '';
-      if (!webhookUrl) webhookUrl = (ssmCfg as Record<string, string>).SLACK_WEBHOOK_URL ?? '';
+      signingSecret = (ssmCfg as unknown as Record<string, string>).SLACK_SIGNING_SECRET ?? '';
+      if (!token) token = (ssmCfg as unknown as Record<string, string>).SLACK_BOT_TOKEN ?? '';
+      if (!webhookUrl) webhookUrl = (ssmCfg as unknown as Record<string, string>).SLACK_WEBHOOK_URL ?? '';
     } catch (err) {
       console.warn('[Slack] SSM fallback failed:', err);
     }


### PR DESCRIPTION
## Summary
- Fixes TS type error blocking deploy on lines 125-127 of 
-  to  cast needs intermediate 
- Unblocks production deploy pipeline

## Changes
Changed  →  on 3 lines in .

## Test plan
- [ ] TypeScript compilation passes (node_modules/@types/chai/index.d.ts(1991,10): error TS1005: ')' expected.
node_modules/@types/react/index.d.ts(597,2): error TS1005: '}' expected.)
- [ ] Deploy pipeline succeeds