### PR TITLE
fix: prevent duplicate release tags

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,18 @@ jobs:
           VERSION=$(node -p "require('./package.json').version")
           echo "tag=v${VERSION}-build.${{ github.event.workflow_run.run_number }}" >> "$GITHUB_OUTPUT"
 
+      - name: Check if tag already exists
+        id: check_tag
+        run: |
+          if git ls-remote --tags origin "refs/tags/${{ steps.version.outputs.tag }}" | grep -q .; then
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+            echo "⚠️ Tag ${{ steps.version.outputs.tag }} already exists — skipping release."
+          else
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Create release
+        if: steps.check_tag.outputs.exists != 'true'
         uses: actions/github-script@v7
         with:
           script: |


### PR DESCRIPTION
The Release workflow was failing with HTTP 422 (Validation Failed) because tags like v0.1.0-build.153 could collide when the deploy workflow is re-run with the same run_number.

## What changed

Added a **Check if tag already exists** step before the release step. It uses git ls-remote --tags to query the remote. If the tag is already present, the release step is skipped gracefully via an if condition instead of failing with a 422.

## Test plan

- Re-run a completed Deploy to Production workflow — the Release workflow should detect the existing tag and skip without error.
- A fresh deploy with a new run_number should still create a release as before.
