### PR TITLE
chore: update GitHub Actions to latest versions

### DIFF
--- a/.github/workflows/devcontainer.yml
+++ b/.github/workflows/devcontainer.yml
@@ -15,13 +15,13 @@ jobs:
     timeout-minutes: 20
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Build dev container image
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: .devcontainer/Dockerfile

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,7 +38,7 @@ jobs:
 
       - name: Create release
         if: steps.check_tag.outputs.exists != 'true'
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const tag = '${{ steps.version.outputs.tag }}';

--- a/.github/workflows/seo-hygiene.yml
+++ b/.github/workflows/seo-hygiene.yml
@@ -20,7 +20,7 @@ jobs:
     timeout-minutes: 8
     steps:
       - uses: actions/checkout@v6
-      - uses: pnpm/action-setup@a8198c4bff370c8506180b035930dea56dbd5288
+      - uses: pnpm/action-setup@v5
       - uses: actions/setup-node@v6
         with:
           node-version: 22


### PR DESCRIPTION
## Summary

Updates 5 outdated GitHub Actions across 3 workflow files to their latest major versions:

| Action | File | Old | New |
|--------|------|-----|-----|
| actions/checkout | devcontainer.yml | v4 | v6 |
| docker/setup-buildx-action | devcontainer.yml | v3 | v4 |
| docker/build-push-action | devcontainer.yml | v6 | v7 |
| actions/github-script | release.yml | v7 | v8 |
| pnpm/action-setup | seo-hygiene.yml | pinned SHA | v5 |

These updates move all actions to Node.js 24-compatible runners, avoiding upcoming deprecation warnings for Node.js 16/20 runtimes.

## Already current (no change needed)
- actions/checkout@v6, actions/setup-node@v6, pnpm/action-setup@v5, aws-actions/configure-aws-credentials@v6, actions/labeler@v5, actions/stale@v9, dependabot/fetch-metadata@v2, actions/dependency-review-action@v4, github/codeql-action/*@v3, lycheeverse/lychee-action@v2, treosh/lighthouse-ci-action@v12, marocchino/sticky-pull-request-comment@v2

## Test plan
- [ ] Verify devcontainer build workflow passes
- [ ] Verify release workflow passes
- [ ] Verify SEO hygiene workflow passes
