### PR TITLE
fix: ignore sst remove failure when staging stage does not exist

### DIFF
--- a/.github/workflows/teardown-staging.yml
+++ b/.github/workflows/teardown-staging.yml
@@ -60,7 +60,7 @@ jobs:
 
       - name: Destroy staging stack
         if: steps.awscreds.outcome == 'success'
-        run: pnpm sst remove --stage staging --yes
+        run: pnpm sst remove --stage staging --yes || true
         env:
           # Pass branch name so SST can locate the correct named stage if needed
           PR_BRANCH: ${{ github.head_ref }}


### PR DESCRIPTION
Appends || true to sst remove in teardown-staging.yml so it does not fail when the staging stack was never deployed or already removed.