### PR TITLE
fix: use GH_PAT for release creation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,6 +40,7 @@ jobs:
         if: steps.check_tag.outputs.exists != 'true'
         uses: actions/github-script@v8
         with:
+          github-token: ${{ secrets.GH_PAT }}
           script: |
             const tag = '${{ steps.version.outputs.tag }}';
             const runUrl = '${{ github.event.workflow_run.html_url }}';


### PR DESCRIPTION
Fixes 'Resource not accessible by integration' error when creating GitHub releases after deploy. Uses GH_PAT instead of default GITHUB_TOKEN.