### PR TITLE
fix: address Lighthouse audit issues (a11y, SEO, CLS)

### DIFF
--- a/src/components/CookieConsent.tsx
+++ b/src/components/CookieConsent.tsx
@@ -234,7 +234,7 @@ export default function CookieConsent() {
           <button
             type="button"
             onClick={handleCloseModal}
-            className="min-h-[44px] rounded-lg px-4 py-2 font-mono text-sm text-slate-500 transition-colors hover:text-slate-300"
+            className="min-h-[44px] rounded-lg px-4 py-2 font-mono text-sm text-slate-400 transition-colors hover:text-slate-300"
           >
             {t("cookies.cancel", "Cancel")}
           </button>
@@ -298,7 +298,7 @@ export default function CookieConsent() {
                     handleOpenFromBanner();
                     setShowSettings(true);
                   }}
-                  className="min-h-[44px] rounded-lg px-5 py-2 font-mono text-xs text-slate-500 transition-colors hover:text-slate-300"
+                  className="min-h-[44px] rounded-lg px-5 py-2 font-mono text-xs text-slate-400 transition-colors hover:text-slate-300"
                 >
                   {t("cookies.customise", "Customise")}
                 </button>

--- a/src/components/store/StoreGrid.tsx
+++ b/src/components/store/StoreGrid.tsx
@@ -215,6 +215,7 @@ export default function StoreGrid() {
       </div>
 
       {/* Grid */}
+      <h2 className="sr-only">Products</h2>
       {filtered.length > 0 ? (
         <div className="grid grid-cols-1 gap-8 md:grid-cols-2 lg:grid-cols-3">
           {filtered.map((product) => (


### PR DESCRIPTION
## Summary
- **CLS fix**: Added `will-change: opacity` and `contain: layout style paint` to `.animate-gradient-shift` to prevent layout shifts on homepage (CLS was 0.301)
- **SEO fix**: Changed generic "Learn more" link text to descriptive "Learn more about our cookie policy" (all locales updated)
- **A11y fix**: Added `aria-label="Sort products"` to store sort dropdown
- **A11y fix**: Improved color contrast — `text-neon-cyan/20` → `/40`, `text-slate-500` → `slate-400` on dark backgrounds
- **A11y fix**: Added `sr-only` h2 heading before product grid for proper heading hierarchy

## Lighthouse Scores Before
| Route | Perf | A11y | Best Practices | SEO |
|-------|------|------|----------------|-----|
| `/` | 50-66 | 96 | 100 | 90 |
| `/en` | 88-89 | 96 | 100 | 90 |
| `/contact` | 91 | 94 | 100 | 90 |
| `/services` | 90 | 96 | 100 | 90 |
| `/store` | 90 | 91 | 100 | 90 |

## Test plan
- [x] Verify cookie consent link text is descriptive in all 3 locales
- [ ] Verify store sort dropdown is accessible via screen reader
- [ ] Verify heading hierarchy on /store passes axe audit
- [ ] Verify gradient orbs on homepage don't cause layout shifts
- [ ] Check color contrast passes WCAG AA on empty cart and empty search states
- [ ] Run Lighthouse CI to confirm score improvements

🤖 Generated with [Claude Code](https://claude.com/claude-code)