### PR TITLE
perf: reduce TTFB, LCP, and TBT via ISR, lazy loading, and font preload

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -15,6 +15,10 @@ const nextConfig: NextConfig = {
       { protocol: "https", hostname: "images.unsplash.com" },
     ],
   },
+  experimental: {
+    // Tree-shake heavy barrel packages — reduces client bundle for Amplify, GSAP, cmdk
+    optimizePackageImports: ["aws-amplify", "gsap", "cmdk", "lenis"],
+  },
 };
 
 const configured = withNextIntl(nextConfig) as NextConfig & {

--- a/src/app/[locale]/layout.tsx
+++ b/src/app/[locale]/layout.tsx
@@ -1,6 +1,7 @@
 import { NextIntlClientProvider } from "next-intl";
 import { getMessages } from "next-intl/server";
 import { notFound } from "next/navigation";
+import dynamic from "next/dynamic";
 import { routing } from "@/i18n/routing";
 import Navbar from "@/components/Navbar";
 import Footer from "@/components/Footer";
@@ -9,18 +10,36 @@ import { AuthProvider } from "@/context/AuthContext";
 import CartSlideOver from "@/components/store/CartSlideOver";
 import JsonLd from "@/components/JsonLd";
 import { getOrganizationSchema } from "@/lib/structured-data";
-import LenisProvider from "@/components/LenisProvider";
 import ServiceWorkerRegistration from "@/components/ServiceWorkerRegistration";
-import CommandPalette from "@/components/CommandPalette";
-import NeonCursor from "@/components/NeonCursor";
-import KonamiEasterEgg from "@/components/KonamiEasterEgg";
 import { CookieConsentProvider } from "@/context/CookieConsentContext";
 import CookieConsent from "@/components/CookieConsent";
+
+// Decorative / interaction-only components deferred until after hydration
+// to keep main-thread work off the critical path (reduces TBT)
+const LenisInitializer = dynamic(
+  () => import("@/components/LenisInitializer"),
+  { ssr: false },
+);
+const CommandPalette = dynamic(() => import("@/components/CommandPalette"), {
+  ssr: false,
+});
+const NeonCursor = dynamic(() => import("@/components/NeonCursor"), {
+  ssr: false,
+});
+const KonamiEasterEgg = dynamic(() => import("@/components/KonamiEasterEgg"), {
+  ssr: false,
+});
 
 type Props = {
   children: React.ReactNode;
   params: Promise<{ locale: string }>;
 };
+
+// Pre-generate all locale segments so ISR-eligible pages are built once
+// and served from CloudFront cache rather than hitting Lambda on every request
+export function generateStaticParams() {
+  return routing.locales.map((locale) => ({ locale }));
+}
 
 export default async function LocaleLayout({ children, params }: Props) {
   const { locale } = await params;
@@ -38,18 +57,17 @@ export default async function LocaleLayout({ children, params }: Props) {
       <AuthProvider>
         <CartProvider>
           <CookieConsentProvider>
-            <LenisProvider>
-              <JsonLd data={getOrganizationSchema()} />
-              <Navbar />
-              <main className="flex-1">{children}</main>
-              <Footer />
-              <CartSlideOver />
-              <ServiceWorkerRegistration />
-              <CommandPalette />
-              <NeonCursor />
-              <KonamiEasterEgg />
-              <CookieConsent />
-            </LenisProvider>
+            <JsonLd data={getOrganizationSchema()} />
+            <Navbar />
+            <main className="flex-1">{children}</main>
+            <Footer />
+            <CartSlideOver />
+            <ServiceWorkerRegistration />
+            <LenisInitializer />
+            <CommandPalette />
+            <NeonCursor />
+            <KonamiEasterEgg />
+            <CookieConsent />
           </CookieConsentProvider>
         </CartProvider>
       </AuthProvider>

--- a/src/app/[locale]/page.tsx
+++ b/src/app/[locale]/page.tsx
@@ -1,6 +1,6 @@
 import { Link } from "@/i18n/navigation";
+import dynamic from "next/dynamic";
 import ScrollReveal from "@/components/ScrollReveal";
-import ParticleField from "@/components/ParticleField";
 import TypingText from "@/components/TypingText";
 import TerminalBlock from "@/components/TerminalBlock";
 import JsonLd from "@/components/JsonLd";
@@ -8,6 +8,15 @@ import { getBreadcrumbSchema, getFAQSchema } from "@/lib/structured-data";
 import HolographicCard from "@/components/HolographicCard";
 import { translate, translateArray } from "@/lib/i18n";
 import { getServerLocale } from "@/lib/server-locale";
+
+// Defer particle canvas — decorative, O(n²) per frame; does not affect LCP
+const ParticleField = dynamic(() => import("@/components/ParticleField"), {
+  ssr: false,
+  loading: () => null,
+});
+
+// ISR: render once per hour, served from CloudFront cache (avoids Lambda cold start on every hit)
+export const revalidate = 3600;
 
 const terminalLines = [
   "$ cloudless deploy --env production",

--- a/src/app/[locale]/services/page.tsx
+++ b/src/app/[locale]/services/page.tsx
@@ -11,6 +11,8 @@ import {
 import { translate } from "@/lib/i18n";
 import { getServerLocale } from "@/lib/server-locale";
 
+export const revalidate = 86400; // static content — rebuild once per day
+
 export const metadata: Metadata = {
   title: "Services",
   description:

--- a/src/app/[locale]/store/page.tsx
+++ b/src/app/[locale]/store/page.tsx
@@ -3,6 +3,8 @@ import StoreGrid from "@/components/store/StoreGrid";
 import JsonLd from "@/components/JsonLd";
 import { getFAQSchema } from "@/lib/structured-data";
 
+export const revalidate = 3600; // products change infrequently; cache for 1h
+
 export const metadata: Metadata = {
   title: "Store",
   description:

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -18,8 +18,8 @@ const geistMono = Geist_Mono({
   variable: "--font-geist-mono",
   subsets: ["latin"],
   display: "swap",
-  // Not rendered above-the-fold; skip preload to avoid "preloaded but not used" warning
-  preload: false,
+  // Hero badge, CTAs, and TerminalBlock all use font-mono above-the-fold
+  preload: true,
 });
 
 export const metadata: Metadata = {

--- a/src/components/LenisInitializer.tsx
+++ b/src/components/LenisInitializer.tsx
@@ -1,0 +1,28 @@
+"use client";
+
+import { useEffect } from "react";
+import Lenis from "lenis";
+
+export default function LenisInitializer() {
+  useEffect(() => {
+    const lenis = new Lenis({
+      duration: 1.2,
+      easing: (t: number) => Math.min(1, 1.001 - Math.pow(2, -10 * t)),
+      smoothWheel: true,
+    });
+
+    function raf(time: number) {
+      lenis.raf(time);
+      requestAnimationFrame(raf);
+    }
+
+    const id = requestAnimationFrame(raf);
+
+    return () => {
+      cancelAnimationFrame(id);
+      lenis.destroy();
+    };
+  }, []);
+
+  return null;
+}

--- a/sst.config.ts
+++ b/sst.config.ts
@@ -50,7 +50,7 @@ export default {
         NOTION_TASKS_DB_ID: "14ce4ff6c400437597b13e70ac909354",
         NOTION_ANALYTICS_DB_ID: "cc4287fcb42a42dc92a7053d6f1199c7",
       },
-      warm: isProd ? 2 : 0,
+      warm: isProd ? 5 : 0,
       server: {
         memory: "1024 MB",
         architecture: "arm64",


### PR DESCRIPTION
## Summary
Addresses three Lighthouse performance issues: TTFB 3.2s, LCP >2.5s, TBT 800ms.

**TTFB** - Bumped SST warm 2->5, added ISR revalidation, added generateStaticParams
**LCP** - Fixed Geist_Mono preload to true (used above fold)
**TBT** - Dynamic imports for decoratives, optimizePackageImports for heavy deps

## Test plan
- [ ] Lighthouse: confirm TTFB, LCP, TBT improvements
- [ ] Lenis smooth scroll works
- [ ] CommandPalette, ParticleField, NeonCursor still work

Generated with Claude Code