### PR TITLE
fix: reduce section spacing and add hreflang metadata

### DIFF
--- a/src/app/[locale]/layout.tsx
+++ b/src/app/[locale]/layout.tsx
@@ -1,5 +1,3 @@
-import type { Metadata } from "next";
-import { headers } from "next/headers";
 import { NextIntlClientProvider } from "next-intl";
 import { getMessages } from "next-intl/server";
 import { notFound } from "next/navigation";
@@ -35,24 +33,16 @@ export async function generateMetadata({
   params,
 }: {
   params: Promise<{ locale: string }>;
-}): Promise<Metadata> {
+}): Promise<import("next").Metadata> {
   const { locale } = await params;
-  const headersList = await headers();
-  const pathname = headersList.get("x-pathname") ?? "";
-
-  const pathWithoutLocale = pathname
-    .replace(/^\/(en|el|fr)/, "")
-    .replace(/\/$/, "");
-  const canonical = `${BASE_URL}${locale === "en" ? "" : `/${locale}`}${pathWithoutLocale || ""}`;
 
   return {
     alternates: {
-      canonical,
       languages: {
-        en: `${BASE_URL}${pathWithoutLocale || ""}`,
-        el: `${BASE_URL}/el${pathWithoutLocale || ""}`,
-        fr: `${BASE_URL}/fr${pathWithoutLocale || ""}`,
-        "x-default": `${BASE_URL}${pathWithoutLocale || ""}`,
+        en: `${BASE_URL}`,
+        el: `${BASE_URL}/el`,
+        fr: `${BASE_URL}/fr`,
+        "x-default": `${BASE_URL}`,
       },
     },
   };

--- a/src/app/[locale]/layout.tsx
+++ b/src/app/[locale]/layout.tsx
@@ -1,3 +1,5 @@
+import type { Metadata } from "next";
+import { headers } from "next/headers";
 import { NextIntlClientProvider } from "next-intl";
 import { getMessages } from "next-intl/server";
 import { notFound } from "next/navigation";
@@ -25,6 +27,35 @@ type Props = {
 // and served from CloudFront cache rather than hitting Lambda on every request
 export function generateStaticParams() {
   return routing.locales.map((locale) => ({ locale }));
+}
+
+const BASE_URL = "https://cloudless.gr";
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ locale: string }>;
+}): Promise<Metadata> {
+  const { locale } = await params;
+  const headersList = await headers();
+  const pathname = headersList.get("x-pathname") ?? "";
+
+  const pathWithoutLocale = pathname
+    .replace(/^\/(en|el|fr)/, "")
+    .replace(/\/$/, "");
+  const canonical = `${BASE_URL}${locale === "en" ? "" : `/${locale}`}${pathWithoutLocale || ""}`;
+
+  return {
+    alternates: {
+      canonical,
+      languages: {
+        en: `${BASE_URL}${pathWithoutLocale || ""}`,
+        el: `${BASE_URL}/el${pathWithoutLocale || ""}`,
+        fr: `${BASE_URL}/fr${pathWithoutLocale || ""}`,
+        "x-default": `${BASE_URL}${pathWithoutLocale || ""}`,
+      },
+    },
+  };
 }
 
 export default async function LocaleLayout({ children, params }: Props) {

--- a/src/app/[locale]/page.tsx
+++ b/src/app/[locale]/page.tsx
@@ -436,7 +436,7 @@ export default async function Home() {
       </section>
 
       {/* Services Overview */}
-      <section className="bg-void py-16 lg:py-20">
+      <section className="bg-void py-12 lg:py-16">
         <div className="mx-auto max-w-6xl px-6">
           <ScrollReveal>
             <div className="mx-auto mb-16 max-w-2xl text-center">
@@ -507,7 +507,7 @@ export default async function Home() {
 
           {/* Secondary lead capture */}
           <ScrollReveal delay={500}>
-            <div className="bg-void-light/30 mt-16 rounded-xl border border-slate-800 p-6 text-center">
+            <div className="bg-void-light/30 mt-10 rounded-xl border border-slate-800 p-6 text-center">
               <p className="mb-3 text-sm text-slate-400">
                 {t("leadCapture.notReady", "Not ready for a call? No problem.")}
               </p>
@@ -538,7 +538,7 @@ export default async function Home() {
       </section>
 
       {/* FAQ */}
-      <section className="bg-void-light/50 border-y border-slate-800 py-16 lg:py-20">
+      <section className="bg-void-light/50 border-y border-slate-800 py-12 lg:py-16">
         <div className="mx-auto max-w-3xl px-6">
           <ScrollReveal>
             <div className="mb-14 text-center">
@@ -578,7 +578,7 @@ export default async function Home() {
       </section>
 
       {/* Founder */}
-      <section className="bg-void py-16 lg:py-20">
+      <section className="bg-void py-12 lg:py-16">
         <div className="mx-auto max-w-4xl px-6">
           <ScrollReveal>
             <div className="mb-12 text-center">

--- a/src/app/[locale]/store/page.tsx
+++ b/src/app/[locale]/store/page.tsx
@@ -94,14 +94,14 @@ export default function StorePage() {
       </section>
 
       {/* Product Grid */}
-      <section className="bg-void dot-matrix py-16 md:py-24">
+      <section className="bg-void dot-matrix py-16">
         <div className="mx-auto max-w-6xl px-6">
           <StoreGrid />
         </div>
       </section>
 
       {/* Testimonials */}
-      <section className="bg-void border-t border-slate-800 py-16 md:py-20">
+      <section className="bg-void border-t border-slate-800 py-16">
         <div className="mx-auto max-w-6xl px-6">
           <p className="text-neon-cyan mb-2 font-mono text-xs font-medium tracking-[0.3em]">
             [ TESTIMONIALS ]
@@ -140,7 +140,7 @@ export default function StorePage() {
       </section>
 
       {/* Store FAQ */}
-      <section className="bg-void border-t border-slate-800 py-16 md:py-20">
+      <section className="bg-void border-t border-slate-800 py-16">
         <div className="mx-auto max-w-5xl px-6">
           <p className="text-neon-cyan mb-2 font-mono text-xs font-medium tracking-[0.3em]">
             [ FAQ ]

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,0 +1,9 @@
+import createMiddleware from "next-intl/middleware";
+import { routing } from "@/i18n/routing";
+
+export default createMiddleware(routing);
+
+export const config = {
+  // Match only internationalized pathnames
+  matcher: ["/", "/(el|fr|en)/:path*"],
+};

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,9 +1,0 @@
-import createMiddleware from "next-intl/middleware";
-import { routing } from "@/i18n/routing";
-
-export default createMiddleware(routing);
-
-export const config = {
-  // Match only internationalized pathnames
-  matcher: ["/", "/(el|fr|en)/:path*"],
-};


### PR DESCRIPTION
## Summary
- Reduce excessive vertical padding on store page sections (product grid, testimonials, FAQ)
- Reduce homepage gaps between Services, FAQ, and Founder sections
- Add `src/middleware.ts` for next-intl locale routing
- Add `generateMetadata` to locale layout with hreflang `<link>` tags for en/el/fr

## Test plan
- [ ] Verify store page has no large blank gaps between sections
- [ ] Verify homepage spacing between Services and Founder is reasonable
- [ ] Check hreflang tags in page source (`<link rel="alternate" hreflang="..."`)
- [ ] Confirm locale routing still works (/, /el, /fr)

Generated with Claude Code