### PR TITLE
feat(design): Phase 2 — bridge tokens to v2 (calmer dark)

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,13 +1,24 @@
 @import "tailwindcss";
+@import "./theme-v2.css";
 
+/**
+ * Design tokens — v1 names retained as Tailwind theme aliases, but their
+ * resolved values now come from the v2 ("Calm Cloud") palette in theme-v2.css.
+ * This bridge lets every existing utility (bg-void, text-neon-cyan, etc.)
+ * pick up the new palette without touching component code.
+ *
+ * Phase 2 ships the dark variant of v2 only — marketing pages remain dark
+ * to avoid breaking text-white-on-dark contrasts. Phase 3 introduces light
+ * mode page by page.
+ */
 @theme inline {
-  /* ── Cyberpunk Palette ── */
-  --color-void: #0a0a0f;
-  --color-void-light: #12121a;
-  --color-void-lighter: #1a1a2e;
+  /* ── Surfaces (was "void" family) ── */
+  --color-void: var(--surface-canvas);
+  --color-void-light: var(--surface-subtle);
+  --color-void-lighter: var(--surface-raised);
 
-  /* Keep brand blues but add neon variants */
-  --color-navy: #0f172a;
+  /* Brand blues — kept for legacy refs, but slightly softened */
+  --color-navy: #0f1822;
   --color-navy-light: #1e293b;
   --color-navy-lighter: #334155;
   --color-electric: #3b82f6;
@@ -17,11 +28,13 @@
   --color-cyan-dark: #0891b2;
   --color-cyan-light: #22d3ee;
 
-  /* Neon accents */
-  --color-neon-cyan: #00fff5;
-  --color-neon-magenta: #ff00ff;
-  --color-neon-green: #00ff41;
-  --color-neon-blue: #4d7cff;
+  /* Neon accents — collapsed onto the single v2 accent.
+     glow-* utilities still reference hardcoded literals; they will
+     be tamed in Phase 5 cleanup. */
+  --color-neon-cyan: var(--accent);
+  --color-neon-magenta: var(--accent);
+  --color-neon-green: var(--success);
+  --color-neon-blue: var(--accent);
 
   /* Neutrals */
   --color-slate-50: #f8fafc;
@@ -33,11 +46,11 @@
   --color-slate-600: #475569;
   --color-slate-700: #334155;
 
-  /* Semantic */
-  --color-background: #0a0a0f;
-  --color-foreground: #e2e8f0;
-  --color-muted: #94a3b8;
-  --color-accent: #00fff5;
+  /* Semantic — bridged to v2 */
+  --color-background: var(--surface-canvas);
+  --color-foreground: var(--ink-primary);
+  --color-muted: var(--ink-muted);
+  --color-accent: var(--accent);
 
   /* Fonts */
   --font-heading: var(--font-instrument-sans);
@@ -357,25 +370,30 @@ h6 {
   pointer-events: none;
 }
 
-/* ── Form inputs — cyber theme ── */
+/* ── Form inputs — bridged to v2 surface tokens ── */
 input,
 textarea,
 select {
-  background: rgba(10, 10, 15, 0.8) !important;
-  border-color: rgba(0, 255, 245, 0.15) !important;
-  color: #e2e8f0 !important;
+  background-color: var(--surface-raised);
+  border-color: var(--border-subtle);
+  color: var(--ink-primary);
+  border-radius: var(--radius-md);
+  transition:
+    border-color var(--motion-base) var(--ease-default),
+    box-shadow var(--motion-base) var(--ease-default);
 }
 
 input::placeholder,
 textarea::placeholder {
-  color: #475569 !important;
+  color: var(--ink-muted);
 }
 
 input:focus,
 textarea:focus,
 select:focus {
-  border-color: rgba(0, 255, 245, 0.5) !important;
-  box-shadow: 0 0 10px rgba(0, 255, 245, 0.15) !important;
+  outline: none;
+  border-color: var(--accent);
+  box-shadow: 0 0 0 3px var(--accent-soft);
 }
 
 /* ── Reduced motion ── */

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -74,6 +74,7 @@ export default function RootLayout({
     <html
       lang="en"
       data-scroll-behavior="smooth"
+      data-theme="dark"
       className={`${instrumentSans.variable} ${workSans.variable} ${geistMono.variable} h-full antialiased`}
     >
       <body className="flex min-h-full flex-col" suppressHydrationWarning>

--- a/src/components/ThemeProvider.tsx
+++ b/src/components/ThemeProvider.tsx
@@ -1,0 +1,50 @@
+/**
+ * ThemeProvider — sets data-theme on <html> based on the current route.
+ *
+ * Phase 2 ships dark for every route to keep text-white-on-dark contrasts
+ * working. Phase 3 introduces light mode page-by-page by changing the
+ * `themeForRoute()` mapping below — no component code needs to change,
+ * tokens flip via theme-v2.css [data-theme="light"] block.
+ *
+ * This is rendered server-side in src/app/layout.tsx so the initial HTML
+ * already has the right data-theme attribute and there is no first-paint
+ * flash when JS hydrates.
+ */
+
+type Theme = "light" | "dark";
+
+/**
+ * Decide which theme a given pathname should render with.
+ *
+ * Phase 2 default: every route renders dark. Flip individual prefixes to
+ * "light" as their primitives are migrated in Phase 3.
+ */
+export function themeForRoute(pathname: string): Theme {
+  // Admin always dark. Long sessions, low ambient light, stays dark forever.
+  if (pathname.startsWith("/admin") || pathname.includes("/admin/")) {
+    return "dark";
+  }
+
+  // Phase 2: marketing routes also dark, awaiting Phase 3 light-mode rollout.
+  return "dark";
+}
+
+/**
+ * Returns just the data-theme attribute value, suitable to spread onto
+ * the root <html> element from a Server Component.
+ *
+ * Usage in src/app/layout.tsx:
+ *   import { themeForRoute } from "@/components/ThemeProvider";
+ *   import { headers } from "next/headers";
+ *   ...
+ *   const pathname = (await headers()).get("x-pathname") ?? "/";
+ *   const theme = themeForRoute(pathname);
+ *   return <html lang="en" data-theme={theme}>...
+ *
+ * Or, simpler: hard-code "dark" on <html> in Phase 2 and call this from
+ * Phase 3 once the route-aware logic actually has light routes to switch
+ * between.
+ */
+export function dataThemeAttr(pathname: string): { "data-theme": Theme } {
+  return { "data-theme": themeForRoute(pathname) };
+}


### PR DESCRIPTION
## Phase 2 of the Calm Cloud rebrand

This PR implements the **token bridge** that retargets the whole site from cyberpunk to v2 dark. Production rendering shifts to the calmer palette without any component code changes — every existing Tailwind utility (`bg-void`, `text-neon-cyan`, etc.) now resolves to a v2 value.

### What changes visually
- Background goes from `#0a0a0f` to `#0b0f15` (slightly bluer, less black)
- Cyan accent dialled from `#00fff5` to `#22d3e6` (still cyan-family, calmer)
- Magenta / blue / green neon variants collapsed to a single accent + semantic success
- Form inputs lose the `!important` overrides and gain a softer `accent-soft` focus ring instead of a glow

### What stays (intentionally for this PR)
- `glow-*`, `scanlines`, `cyber-grid`, `neon-border`, `glitch`, `typing-cursor` — still active. Their hardcoded `#00fff5` glow colour is now slightly more saturated than the rest of the UI; acceptable for this phase. **Phase 5** cleanup tames or removes them.
- `text-white` and `text-slate-*` literals on dark backgrounds — unchanged because dark stays everywhere in Phase 2.
- The Meta Pixel layout snippet from `5031e34e`.

### What ships next
- **Phase 3** — flip marketing routes to `data-theme="light"` via `themeForRoute()` in `src/components/ThemeProvider.tsx`. Done one prefix at a time so we can review each route before merging.
- **Phase 4** — replace `dot-matrix`/`scanlines` on hero sections with the gradient-mesh `--gradient-hero` token.
- **Phase 5** — admin restyle, plus delete deprecated v1 utilities.

### Verification
- `pnpm lint` ✅
- `pnpm typecheck` ✅
- `pnpm build` fails locally with a pre-existing `useContext` prerender error caused by missing public Cognito env vars — same error reproduces on `main` HEAD. Not introduced here.
- Production CI deploy on the previous commit (`8c70aa57`) succeeded — same SST/OpenNext pipeline will run for this branch.

### Files
- `src/app/globals.css` — imports `theme-v2.css`, rewrites `@theme inline` token resolution
- `src/app/theme-v2.css` (already in main from Phase 1) — no change
- `src/app/layout.tsx` — adds `data-theme="dark"` on `<html>`
- `src/components/ThemeProvider.tsx` (new) — `themeForRoute()` helper for Phase 3