### PR TITLE
feat(design): Phase 3.x — light mode for /blog /contact /store /docs + legal

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,13 +1,24 @@
 @import "tailwindcss";
+@import "./theme-v2.css";
 
+/**
+ * Design tokens — v1 names retained as Tailwind theme aliases, but their
+ * resolved values now come from the v2 ("Calm Cloud") palette in theme-v2.css.
+ * This bridge lets every existing utility (bg-void, text-neon-cyan, etc.)
+ * pick up the new palette without touching component code.
+ *
+ * Phase 2 ships the dark variant of v2 only — marketing pages remain dark
+ * to avoid breaking text-white-on-dark contrasts. Phase 3 introduces light
+ * mode page by page.
+ */
 @theme inline {
-  /* ── Cyberpunk Palette ── */
-  --color-void: #0a0a0f;
-  --color-void-light: #12121a;
-  --color-void-lighter: #1a1a2e;
+  /* ── Surfaces (was "void" family) ── */
+  --color-void: var(--surface-canvas);
+  --color-void-light: var(--surface-subtle);
+  --color-void-lighter: var(--surface-raised);
 
-  /* Keep brand blues but add neon variants */
-  --color-navy: #0f172a;
+  /* Brand blues — kept for legacy refs, but slightly softened */
+  --color-navy: #0f1822;
   --color-navy-light: #1e293b;
   --color-navy-lighter: #334155;
   --color-electric: #3b82f6;
@@ -17,11 +28,13 @@
   --color-cyan-dark: #0891b2;
   --color-cyan-light: #22d3ee;
 
-  /* Neon accents */
-  --color-neon-cyan: #00fff5;
-  --color-neon-magenta: #ff00ff;
-  --color-neon-green: #00ff41;
-  --color-neon-blue: #4d7cff;
+  /* Neon accents — collapsed onto the single v2 accent.
+     glow-* utilities still reference hardcoded literals; they will
+     be tamed in Phase 5 cleanup. */
+  --color-neon-cyan: var(--accent);
+  --color-neon-magenta: var(--accent);
+  --color-neon-green: var(--success);
+  --color-neon-blue: var(--accent);
 
   /* Neutrals */
   --color-slate-50: #f8fafc;
@@ -33,11 +46,11 @@
   --color-slate-600: #475569;
   --color-slate-700: #334155;
 
-  /* Semantic */
-  --color-background: #0a0a0f;
-  --color-foreground: #e2e8f0;
-  --color-muted: #94a3b8;
-  --color-accent: #00fff5;
+  /* Semantic — bridged to v2 */
+  --color-background: var(--surface-canvas);
+  --color-foreground: var(--ink-primary);
+  --color-muted: var(--ink-muted);
+  --color-accent: var(--accent);
 
   /* Fonts */
   --font-heading: var(--font-instrument-sans);
@@ -357,25 +370,30 @@ h6 {
   pointer-events: none;
 }
 
-/* ── Form inputs — cyber theme ── */
+/* ── Form inputs — bridged to v2 surface tokens ── */
 input,
 textarea,
 select {
-  background: rgba(10, 10, 15, 0.8) !important;
-  border-color: rgba(0, 255, 245, 0.15) !important;
-  color: #e2e8f0 !important;
+  background-color: var(--surface-raised);
+  border-color: var(--border-subtle);
+  color: var(--ink-primary);
+  border-radius: var(--radius-md);
+  transition:
+    border-color var(--motion-base) var(--ease-default),
+    box-shadow var(--motion-base) var(--ease-default);
 }
 
 input::placeholder,
 textarea::placeholder {
-  color: #475569 !important;
+  color: var(--ink-muted);
 }
 
 input:focus,
 textarea:focus,
 select:focus {
-  border-color: rgba(0, 255, 245, 0.5) !important;
-  box-shadow: 0 0 10px rgba(0, 255, 245, 0.15) !important;
+  outline: none;
+  border-color: var(--accent);
+  box-shadow: 0 0 0 3px var(--accent-soft);
 }
 
 /* ── Reduced motion ── */

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,8 @@
 import type { Metadata } from "next";
 import { Instrument_Sans, Work_Sans, Geist_Mono } from "next/font/google";
 import Script from "next/script";
+import { headers } from "next/headers";
+import { themeForRoute } from "@/components/ThemeProvider";
 import "./globals.css";
 
 const META_PIXEL_ID = process.env.NEXT_PUBLIC_META_PIXEL_ID ?? "";
@@ -65,16 +67,21 @@ export const metadata: Metadata = {
   },
 };
 
-export default function RootLayout({
+export default async function RootLayout({
   children,
 }: Readonly<{
   children: React.ReactNode;
 }>) {
+  // Pathname is forwarded via x-pathname by middleware (src/proxy.ts).
+  // Falls back to "/" for routes outside the matcher (which we don't render).
+  const pathname = (await headers()).get("x-pathname") ?? "/";
+  const theme = themeForRoute(pathname);
+
   return (
     <html
       lang="en"
       data-scroll-behavior="smooth"
-      data-theme="dark"
+      data-theme={theme}
       className={`${instrumentSans.variable} ${workSans.variable} ${geistMono.variable} h-full antialiased`}
     >
       <body className="flex min-h-full flex-col" suppressHydrationWarning>

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -74,6 +74,7 @@ export default function RootLayout({
     <html
       lang="en"
       data-scroll-behavior="smooth"
+      data-theme="dark"
       className={`${instrumentSans.variable} ${workSans.variable} ${geistMono.variable} h-full antialiased`}
     >
       <body className="flex min-h-full flex-col" suppressHydrationWarning>

--- a/src/app/theme-v2.css
+++ b/src/app/theme-v2.css
@@ -250,3 +250,103 @@
     transform: none !important;
   }
 }
+
+/* ──────────────────────────────────────────────────────────────────
+   LIGHT-MODE UTILITY OVERRIDES — Phase 3
+   When [data-theme="light"] is set on a subtree, retarget the most-used
+   dark-only Tailwind colour utilities to v2 light tokens so the existing
+   markup reads correctly without component changes.
+   These are written as descendant selectors so [data-theme="dark"] children
+   (e.g. TerminalBlock) opt out automatically.
+   ────────────────────────────────────────────────────────────────── */
+
+[data-theme="light"] .text-white {
+  color: var(--ink-primary);
+}
+[data-theme="light"] .text-slate-100,
+[data-theme="light"] .text-slate-200 {
+  color: var(--ink-primary);
+}
+[data-theme="light"] .text-slate-300,
+[data-theme="light"] .text-slate-400 {
+  color: var(--ink-body);
+}
+[data-theme="light"] .text-slate-500,
+[data-theme="light"] .text-slate-600 {
+  color: var(--ink-muted);
+}
+
+/* Card backgrounds — slate-800/900 reads as a card on dark; on light we want
+   subtle elevation, not a slab. */
+[data-theme="light"] .bg-slate-800,
+[data-theme="light"] .bg-slate-900 {
+  background-color: var(--surface-subtle);
+}
+[data-theme="light"] .bg-slate-800\/50,
+[data-theme="light"] .bg-slate-900\/50 {
+  background-color: color-mix(in srgb, var(--surface-subtle) 50%, transparent);
+}
+
+/* Borders */
+[data-theme="light"] .border-slate-700,
+[data-theme="light"] .border-slate-800 {
+  border-color: var(--border-subtle);
+}
+[data-theme="light"] .border-slate-600 {
+  border-color: var(--border-strong);
+}
+
+/* Glow utilities — disabled on light. They only read on dark backgrounds. */
+[data-theme="light"] .glow-cyan,
+[data-theme="light"] .glow-magenta,
+[data-theme="light"] .glow-blue,
+[data-theme="light"] .glow-green {
+  text-shadow: none;
+}
+[data-theme="light"] .box-glow-cyan,
+[data-theme="light"] .box-glow-electric,
+[data-theme="light"] .box-glow-magenta {
+  box-shadow: var(--shadow-md);
+}
+
+/* Scanlines / cyber-grid / dot-matrix — also dark-only effects. */
+[data-theme="light"] .scanlines::after,
+[data-theme="light"] .scan-line::before {
+  display: none;
+}
+[data-theme="light"] .cyber-grid,
+[data-theme="light"] .cyber-grid-dense,
+[data-theme="light"] .dot-matrix {
+  background-image: none;
+}
+
+/* neon-border — keep the border but use the calmer accent without the glow halo. */
+[data-theme="light"] .neon-border {
+  border-color: var(--border-subtle);
+}
+[data-theme="light"] .neon-border:hover {
+  border-color: var(--accent);
+  box-shadow: var(--shadow-md);
+}
+
+/* Mobile tap highlight — accent-soft instead of high-saturation cyan. */
+[data-theme="light"] {
+  -webkit-tap-highlight-color: color-mix(
+    in srgb,
+    var(--accent) 18%,
+    transparent
+  );
+}
+
+/* Selection — calmer accent on light. */
+[data-theme="light"] ::selection {
+  background-color: var(--accent);
+  color: var(--accent-on);
+}
+
+/* Body itself — when the html data-theme="light", the body should use the
+   v2 surface, not the dark void. */
+[data-theme="light"] body {
+  background: var(--surface-canvas);
+  color: var(--ink-primary);
+}

--- a/src/app/theme-v2.css
+++ b/src/app/theme-v2.css
@@ -350,3 +350,39 @@
   background: var(--surface-canvas);
   color: var(--ink-primary);
 }
+
+/* Inline placeholder utilities — forms put placeholder:text-slate-{500,600}
+   directly on inputs, which overrides the global form rule. Re-target. */
+[data-theme="light"] .placeholder\:text-slate-500::placeholder,
+[data-theme="light"] .placeholder\:text-slate-600::placeholder,
+[data-theme="light"] .placeholder\:text-slate-700::placeholder {
+  color: var(--ink-muted);
+}
+
+/* kbd / code chips often use bg-void-lighter + border-slate-700, which already
+   alias correctly via @theme. Make sure their text reads on a light surface. */
+[data-theme="light"] kbd,
+[data-theme="light"] .kbd {
+  background-color: var(--surface-subtle);
+  border-color: var(--border-subtle);
+  color: var(--ink-body);
+}
+
+/* Hero / section "ambient" gradient overlays — pages use absolutely-positioned
+   div with from-neon-cyan/10 to-neon-magenta/10 for atmosphere. With both
+   neons collapsed onto a single accent these become a flat tint, which is too
+   strong on a light surface. Soften. */
+[data-theme="light"] .absolute.inset-0.bg-gradient-to-r,
+[data-theme="light"] .absolute.inset-0.bg-gradient-to-br,
+[data-theme="light"] .absolute.inset-0.bg-gradient-to-b {
+  opacity: 0.35;
+}
+
+/* Decorative numbered badges (the 01/02/03 service cards) — bg-neon-cyan/10
+   reads as a faint cyan card on dark. On light it disappears; bump contrast. */
+[data-theme="light"] [class*="bg-neon-cyan/"],
+[data-theme="light"] [class*="bg-neon-magenta/"],
+[data-theme="light"] [class*="bg-neon-green/"],
+[data-theme="light"] [class*="bg-neon-blue/"] {
+  background-color: var(--accent-soft);
+}

--- a/src/components/TerminalBlock.tsx
+++ b/src/components/TerminalBlock.tsx
@@ -12,7 +12,11 @@ export default function TerminalBlock({
   className = "",
 }: TerminalBlockProps) {
   return (
+    // data-theme="dark" pins the terminal block to dark-mode tokens even when
+    // its parent route is light. Terminal aesthetic is intentional and the
+    // syntax-highlighting palette only reads correctly on a dark surface.
     <div
+      data-theme="dark"
       className={`neon-border bg-void/90 overflow-hidden rounded-lg backdrop-blur-sm ${className}`}
     >
       {/* Title bar */}

--- a/src/components/ThemeProvider.tsx
+++ b/src/components/ThemeProvider.tsx
@@ -29,14 +29,26 @@ export function themeForRoute(pathname: string): Theme {
     return "dark";
   }
 
-  // Marketing routes flipped to light, one at a time.
-  const lightRoutes = ["/services"];
+  // Marketing routes flipped to light, one prefix at a time.
+  // The homepage stays dark for now — Phase 4 redesigns the hero with the
+  // gradient-mesh and at that point the homepage flips together with the
+  // hero refresh. /auth and /dashboard stay dark by intent.
+  const lightRoutes = [
+    "/services",
+    "/blog",
+    "/contact",
+    "/store",
+    "/docs",
+    "/privacy",
+    "/terms",
+    "/cookies",
+    "/refund",
+  ];
   if (lightRoutes.some((p) => stripped === p || stripped.startsWith(p + "/"))) {
     return "light";
   }
 
-  // Everything else (homepage, blog, store, contact, docs, auth, dashboard)
-  // stays on the v2 dark palette until its own Phase 3 PR.
+  // Everything else (homepage, auth, dashboard) stays on v2 dark.
   return "dark";
 }
 

--- a/src/components/ThemeProvider.tsx
+++ b/src/components/ThemeProvider.tsx
@@ -16,16 +16,27 @@ type Theme = "light" | "dark";
 /**
  * Decide which theme a given pathname should render with.
  *
- * Phase 2 default: every route renders dark. Flip individual prefixes to
- * "light" as their primitives are migrated in Phase 3.
+ * Phase 3 in progress: /services is the first marketing route flipped to
+ * light. Other marketing routes follow once we've watched /services in
+ * production and adjusted any leftover dark-only utilities.
  */
 export function themeForRoute(pathname: string): Theme {
+  // Strip locale prefix so the same rules apply across en/el/fr.
+  const stripped = pathname.replace(/^\/(?:en|el|fr)(?=\/|$)/, "") || "/";
+
   // Admin always dark. Long sessions, low ambient light, stays dark forever.
-  if (pathname.startsWith("/admin") || pathname.includes("/admin/")) {
+  if (stripped === "/admin" || stripped.startsWith("/admin/")) {
     return "dark";
   }
 
-  // Phase 2: marketing routes also dark, awaiting Phase 3 light-mode rollout.
+  // Marketing routes flipped to light, one at a time.
+  const lightRoutes = ["/services"];
+  if (lightRoutes.some((p) => stripped === p || stripped.startsWith(p + "/"))) {
+    return "light";
+  }
+
+  // Everything else (homepage, blog, store, contact, docs, auth, dashboard)
+  // stays on the v2 dark palette until its own Phase 3 PR.
   return "dark";
 }
 

--- a/src/components/ThemeProvider.tsx
+++ b/src/components/ThemeProvider.tsx
@@ -1,0 +1,50 @@
+/**
+ * ThemeProvider — sets data-theme on <html> based on the current route.
+ *
+ * Phase 2 ships dark for every route to keep text-white-on-dark contrasts
+ * working. Phase 3 introduces light mode page-by-page by changing the
+ * `themeForRoute()` mapping below — no component code needs to change,
+ * tokens flip via theme-v2.css [data-theme="light"] block.
+ *
+ * This is rendered server-side in src/app/layout.tsx so the initial HTML
+ * already has the right data-theme attribute and there is no first-paint
+ * flash when JS hydrates.
+ */
+
+type Theme = "light" | "dark";
+
+/**
+ * Decide which theme a given pathname should render with.
+ *
+ * Phase 2 default: every route renders dark. Flip individual prefixes to
+ * "light" as their primitives are migrated in Phase 3.
+ */
+export function themeForRoute(pathname: string): Theme {
+  // Admin always dark. Long sessions, low ambient light, stays dark forever.
+  if (pathname.startsWith("/admin") || pathname.includes("/admin/")) {
+    return "dark";
+  }
+
+  // Phase 2: marketing routes also dark, awaiting Phase 3 light-mode rollout.
+  return "dark";
+}
+
+/**
+ * Returns just the data-theme attribute value, suitable to spread onto
+ * the root <html> element from a Server Component.
+ *
+ * Usage in src/app/layout.tsx:
+ *   import { themeForRoute } from "@/components/ThemeProvider";
+ *   import { headers } from "next/headers";
+ *   ...
+ *   const pathname = (await headers()).get("x-pathname") ?? "/";
+ *   const theme = themeForRoute(pathname);
+ *   return <html lang="en" data-theme={theme}>...
+ *
+ * Or, simpler: hard-code "dark" on <html> in Phase 2 and call this from
+ * Phase 3 once the route-aware logic actually has light routes to switch
+ * between.
+ */
+export function dataThemeAttr(pathname: string): { "data-theme": Theme } {
+  return { "data-theme": themeForRoute(pathname) };
+}

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -253,6 +253,11 @@ export function proxy(request: NextRequest) {
     }
   }
 
+  // Forward the pathname as a request header so server components (root
+  // layout) can call themeForRoute() and render <html data-theme=...>
+  // server-side with no first-paint flash. next/headers reads request-side.
+  request.headers.set("x-pathname", pathname);
+
   const response = intlMiddleware(request);
   addSecurityHeaders(response);
   return response;


### PR DESCRIPTION
## Phase 3.x — Marketing surface goes light

Extends [#54](https://github.com/Themis128/cloudless.gr/pull/54) (which only flipped `/services`) to the rest of the marketing pages. **Stacks on #54 → #53.** Merge in order: `#53 → #54 → this`.

### Light after this PR
- `/services` (already in #54)
- `/blog`, `/contact`, `/store`, `/docs`
- `/privacy`, `/terms`, `/cookies`, `/refund` (legal pages — same content treatment as marketing)

### Stays dark, by intent
- `/` — Phase 4 redesigns the hero with the gradient mesh **then** flips
- `/auth/*` — auth chrome consistency
- `/dashboard`, `/admin/*` — long-session UIs prefer dark

### Additional CSS overrides
The Phase 3 override set covered the common cases. This PR fills small gaps:
- `placeholder:text-slate-{500,600,700}` inline placeholder utilities (Newsletter, Contact, Store search)
- `kbd` / `.kbd` elements (used in CommandPalette)
- Ambient gradient overlays (`.absolute.inset-0.bg-gradient-to-{r,br,b}`) — opacity dialled to 0.35 so the cyan tint doesn't dominate light surfaces
- `bg-neon-cyan/X` decorative badges retargeted to `--accent-soft` so they stay visible without neon halo

No component code changes — purely route table + CSS.

### Verification
- `pnpm lint` ✅
- `pnpm typecheck` ✅
- Local `pnpm build` still hits the pre-existing `useContext` error from missing public Cognito env vars in prerender (same as `main`). Production CI deploy passes the build.

### Files
- `src/components/ThemeProvider.tsx` — extends `lightRoutes` array
- `src/app/theme-v2.css` — five additional `[data-theme="light"]` rules