### PR TITLE
fix: privacy link a11y + CSP allowlist Google Fonts

### DIFF
--- a/src/components/ContactFormSection.tsx
+++ b/src/components/ContactFormSection.tsx
@@ -205,7 +205,7 @@ export default function ContactFormSection() {
                     )}{" "}
                     <Link
                       href="/privacy"
-                      className="text-neon-cyan hover:underline"
+                      className="text-neon-cyan underline underline-offset-2"
                     >
                       {t("legal.privacyTitle", "Privacy Policy")}
                     </Link>

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -124,9 +124,14 @@ function cleanupStaleEntries() {
 const CSP_REPORT_ONLY = [
   "default-src 'self'",
   "script-src 'self' 'unsafe-inline' 'unsafe-eval' https://js.stripe.com https://m.stripe.com https://connect.facebook.net https://browser.sentry-cdn.com https://js.hsforms.net https://js.hs-scripts.com",
-  "style-src 'self' 'unsafe-inline'",
+  // fonts.googleapis.com is allowlisted because next/font/google emits a
+  // @font-face stylesheet whose src URLs hit Google's CDN even though the
+  // font binaries themselves are self-hosted under /_next/static/media.
+  "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com",
   "img-src 'self' data: blob: https:",
-  "font-src 'self' data:",
+  // fonts.gstatic.com — Google Fonts binary CDN. next/font/google falls back
+  // to it for the woff2 files when the build cannot inline them.
+  "font-src 'self' data: https://fonts.gstatic.com",
   "connect-src 'self' https://api.stripe.com https://m.stripe.com https://*.sentry.io https://*.ingest.sentry.io https://www.facebook.com https://cognito-idp.us-east-1.amazonaws.com https://cognito-identity.us-east-1.amazonaws.com https://api.hubapi.com",
   "frame-src https://js.stripe.com https://hooks.stripe.com https://www.facebook.com",
   "worker-src 'self' blob:",


### PR DESCRIPTION
Two real findings post-Phase-6.3:

- **A11y** — Privacy Policy link in the contact form label had only `hover:underline`. axe rule `link-in-text-block` flagged it as a serious violation: links inside body text must be distinguishable without color. Changed to always-visible underline.
- **CSP** — Live browser console reported violations from `fonts.googleapis.com` and `fonts.gstatic.com` (next/font/google emits a remote @font-face stylesheet + falls back to gstatic for woff2). Allowlisted both in style-src and font-src.

'p.css ERR_ADDRESS_INVALID' was also seen in console — separate routing/preload issue not addressed here.