### PR TITLE
feat(brand): cloud silhouette logomark + wordmark + favicons

### DIFF
--- a/src/app/apple-icon.tsx
+++ b/src/app/apple-icon.tsx
@@ -1,0 +1,46 @@
+/**
+ * Apple touch icon (180×180) — iOS home-screen, Safari pinned tabs, etc.
+ *
+ * Renders the cloud silhouette on a soft sky-tinted background that matches
+ * the v2 hero gradient mesh. Apple icons render with rounded corners on
+ * iOS automatically, so the visual rectangle is fine.
+ *
+ * Reference: https://nextjs.org/docs/app/api-reference/file-conventions/metadata/app-icons
+ */
+
+import { ImageResponse } from "next/og";
+
+export const dynamic = "force-static";
+export const size = { width: 180, height: 180 };
+export const contentType = "image/png";
+
+export default function AppleIcon() {
+  return new ImageResponse(
+    (
+      <div
+        style={{
+          width: "100%",
+          height: "100%",
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "center",
+          background:
+            "linear-gradient(135deg, #d6f0f6 0%, #e3e9ff 60%, #fbf8ff 100%)",
+        }}
+      >
+        <svg
+          width="140"
+          height="105"
+          viewBox="0 0 32 24"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M6 22 A6 6 0 0 1 6 10 A4 4 0 0 1 10.5 7 A7 7 0 0 1 23 5.2 A6 6 0 0 1 28.5 14 A5 5 0 0 1 26 22 Z"
+            fill="#0a7785"
+          />
+        </svg>
+      </div>
+    ),
+    { ...size },
+  );
+}

--- a/src/app/icon.tsx
+++ b/src/app/icon.tsx
@@ -1,0 +1,45 @@
+/**
+ * Favicon (32×32) — Next.js Metadata API icon generator.
+ *
+ * Renders the v2 cloud silhouette filled with the calm-cloud accent
+ * (#0a7785). Bundled at build time so the favicon ships from the same
+ * source of truth as the in-app brand mark.
+ *
+ * Reference: https://nextjs.org/docs/app/api-reference/file-conventions/metadata/app-icons
+ */
+
+import { ImageResponse } from "next/og";
+
+export const dynamic = "force-static";
+export const size = { width: 32, height: 32 };
+export const contentType = "image/png";
+
+export default function Icon() {
+  return new ImageResponse(
+    (
+      <div
+        style={{
+          width: "100%",
+          height: "100%",
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "center",
+          background: "transparent",
+        }}
+      >
+        <svg
+          width="28"
+          height="21"
+          viewBox="0 0 32 24"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M6 22 A6 6 0 0 1 6 10 A4 4 0 0 1 10.5 7 A7 7 0 0 1 23 5.2 A6 6 0 0 1 28.5 14 A5 5 0 0 1 26 22 Z"
+            fill="#0a7785"
+          />
+        </svg>
+      </div>
+    ),
+    { ...size },
+  );
+}

--- a/src/components/CloudMark.tsx
+++ b/src/components/CloudMark.tsx
@@ -1,0 +1,68 @@
+/**
+ * CloudMark — the cloudless.gr brand logomark.
+ *
+ * Design: literal cloud silhouette, flat-stylised. Three rounded humps
+ * (small left, large center, medium right) over a flat base. Single fill
+ * color via currentColor so it picks up the parent text color.
+ *
+ * Reference register: Stripe Atlas / Linear / Resend — flat icon, clean
+ * geometry, single accent color, no gradient or stroke detail.
+ *
+ * The viewBox is 32×24 (4:3) so the cloud reads as wider than tall, the way
+ * a real cloud silhouette does. For square uses (favicon, app icon), wrap
+ * in a square container with padding.
+ */
+
+interface CloudMarkProps {
+  size?: number;
+  className?: string;
+  /** When true, paint the cloud with --accent regardless of currentColor. */
+  accent?: boolean;
+  "aria-label"?: string;
+}
+
+export default function CloudMark({
+  size = 28,
+  className = "",
+  accent = false,
+  ...rest
+}: CloudMarkProps) {
+  const ariaLabel = rest["aria-label"];
+  const role = ariaLabel ? "img" : "presentation";
+  const labelProps = ariaLabel
+    ? { "aria-label": ariaLabel, role }
+    : { "aria-hidden": true };
+
+  return (
+    <svg
+      width={size}
+      height={(size * 24) / 32}
+      viewBox="0 0 32 24"
+      xmlns="http://www.w3.org/2000/svg"
+      className={className}
+      style={accent ? { color: "var(--accent)" } : undefined}
+      {...labelProps}
+    >
+      {/*
+        Path geometry — 3 stacked arcs joined by tangent curves to form a
+        cloud silhouette. Built bottom-up:
+          M 4 22  → start at left base
+          A arc up over the small left hump
+          A arc up over the larger center hump (the tallest at y≈4)
+          A arc up over the medium right hump
+          A arc down to the right base
+          H 4    close along the flat bottom
+      */}
+      <path
+        d="M6 22
+           A6 6 0 0 1 6 10
+           A4 4 0 0 1 10.5 7
+           A7 7 0 0 1 23 5.2
+           A6 6 0 0 1 28.5 14
+           A5 5 0 0 1 26 22
+           Z"
+        fill="currentColor"
+      />
+    </svg>
+  );
+}

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -2,6 +2,7 @@
 
 import { Link } from "@/i18n/navigation";
 import NewsletterForm from "@/components/NewsletterForm";
+import Logo from "@/components/Logo";
 import { translate } from "@/lib/i18n";
 import { useCurrentLocale } from "@/lib/use-locale";
 import { useCookieConsent } from "@/context/CookieConsentContext";
@@ -18,9 +19,10 @@ export default function Footer() {
           <div>
             <Link
               href="/"
-              className="font-heading text-lg font-bold text-white"
+              className="text-white transition-opacity hover:opacity-90"
+              aria-label="cloudless.gr — home"
             >
-              cloudless<span className="text-neon-cyan">.gr</span>
+              <Logo variant="wordmark" size="sm" />
             </Link>
             <p className="mt-3 text-sm leading-relaxed text-slate-400">
               {translate(

--- a/src/components/Logo.tsx
+++ b/src/components/Logo.tsx
@@ -1,0 +1,61 @@
+/**
+ * Logo — the brand wordmark.
+ *
+ * Three variants:
+ *   - "wordmark" (default): CloudMark + "cloudless.gr" text
+ *   - "mark":               CloudMark only (use for tight spaces)
+ *   - "text":               text only (rarely needed; SEO/print fallback)
+ *
+ * The wordmark uses the heading font and follows the v2 spec: brand text
+ * in --ink-primary, ".gr" suffix in --accent. The mark color flows from
+ * currentColor so it adapts to the surrounding text color (white in dark
+ * navbar, --ink-primary in light marketing pages).
+ */
+
+import CloudMark from "@/components/CloudMark";
+
+interface LogoProps {
+  variant?: "wordmark" | "mark" | "text";
+  size?: "sm" | "md" | "lg";
+  className?: string;
+}
+
+const SIZES = {
+  sm: { mark: 20, text: "text-base" },
+  md: { mark: 24, text: "text-xl" },
+  lg: { mark: 32, text: "text-2xl" },
+};
+
+export default function Logo({
+  variant = "wordmark",
+  size = "md",
+  className = "",
+}: LogoProps) {
+  const s = SIZES[size];
+
+  if (variant === "mark") {
+    return (
+      <CloudMark
+        size={s.mark}
+        className={className}
+        aria-label="cloudless.gr"
+      />
+    );
+  }
+
+  return (
+    <span
+      className={`inline-flex items-center gap-2 ${className}`}
+      aria-label="cloudless.gr"
+    >
+      {variant === "wordmark" && (
+        <CloudMark size={s.mark} aria-hidden />
+      )}
+      <span
+        className={`font-heading ${s.text} font-bold tracking-tight`}
+      >
+        cloudless<span className="text-neon-cyan">.gr</span>
+      </span>
+    </span>
+  );
+}

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -4,6 +4,7 @@ import { useState, useRef, useEffect } from "react";
 import { Link } from "@/i18n/navigation";
 import CartButton from "@/components/store/CartButton";
 import LocaleSwitcher from "@/components/LocaleSwitcher";
+import Logo from "@/components/Logo";
 import { translate } from "@/lib/i18n";
 import { useCurrentLocale } from "@/lib/use-locale";
 import { useAuth } from "@/context/AuthContext";
@@ -48,12 +49,10 @@ export default function Navbar() {
           {/* Logo */}
           <Link
             href="/"
-            className="group glitch flex shrink-0 items-center gap-2"
+            className="group flex shrink-0 items-center text-white transition-opacity hover:opacity-90"
+            aria-label="cloudless.gr — home"
           >
-            <CloudIcon />
-            <span className="font-heading text-xl font-bold tracking-tight text-white">
-              cloudless<span className="text-neon-cyan">.gr</span>
-            </span>
+            <Logo variant="wordmark" size="md" />
           </Link>
 
           {/* Desktop Nav */}
@@ -295,22 +294,4 @@ export default function Navbar() {
   );
 }
 
-function CloudIcon() {
-  return (
-    <svg
-      width="28"
-      height="28"
-      viewBox="0 0 32 32"
-      fill="none"
-      className="text-neon-cyan"
-    >
-      <path
-        d="M8 24a6 6 0 01-.84-11.94A8 8 0 0123.29 14 5 5 0 0124 24H8z"
-        stroke="currentColor"
-        strokeWidth="2"
-        strokeLinecap="round"
-        strokeLinejoin="round"
-      />
-    </svg>
-  );
-}
+// CloudIcon removed — replaced by the shared <Logo /> component.

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -275,6 +275,6 @@ export function proxy(request: NextRequest) {
 export const config = {
   matcher: [
     // Match all request paths except static files, Next.js internals, and PWA assets
-    "/((?!_next/static|_next/image|favicon.ico|sw\\.js|manifest\\.webmanifest|offline\\.html|sitemap\\.xml|robots\\.txt|opengraph-image|twitter-image|.*\\.(?:svg|png|jpg|jpeg|gif|webp|ico|html)$).*)",
+    "/((?!_next/static|_next/image|favicon.ico|sw\\.js|manifest\\.webmanifest|offline\\.html|sitemap\\.xml|robots\\.txt|opengraph-image|twitter-image|icon|apple-icon|.*\\.(?:svg|png|jpg|jpeg|gif|webp|ico|html)$).*)",
   ],
 };


### PR DESCRIPTION
## What

Flat-stylised cloud silhouette in the v2 calm-cloud accent (Linear / Stripe Atlas register: clean geometry, single fill, no neon).

Replaces the literal text-only `cloudless.gr` in the navbar/footer with a proper brand mark + wordmark, and ships matching favicon and iOS home-screen icon.

## Files

- `src/components/CloudMark.tsx` — pure SVG cloud silhouette (32×24, three rounded humps, currentColor fill)
- `src/components/Logo.tsx` — wordmark wrapper combining mark + `cloudless.gr` text. Variants: `wordmark` / `mark` / `text`. Sizes: sm / md / lg
- `src/app/icon.tsx` — 32×32 favicon via Next.js Metadata API (ImageResponse, force-static)
- `src/app/apple-icon.tsx` — 180×180 iOS touch icon, gradient-mesh bg matching the v2 hero
- `src/components/Navbar.tsx` — replaces inline outline-only CloudIcon with `<Logo variant=wordmark size=md />`. Old CloudIcon function removed.
- `src/components/Footer.tsx` — same swap, `size=sm` for the smaller footer treatment
- `src/proxy.ts` — adds `icon` + `apple-icon` to the next-intl middleware matcher exclusion (same fix class as #54 sitemap.xml and #56 og-image)

## Verified locally

- `pnpm lint`, `pnpm typecheck` clean
- Live dev server returned 200 on `/icon` (732 B PNG) and `/apple-icon` (3650 B PNG) after the matcher fix
- Brand wordmark renders in navbar and footer; old CloudIcon path is gone from rendered HTML