### PR TITLE
feat(mcp): add Notion MCP server to project mcp.json

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,7 @@ on:
       - 'package.json'
       - 'pnpm-lock.yaml'
       - 'tsconfig.json'
+      - 'mcp.json'
       - '.github/workflows/**'
 
 env:

--- a/mcp.json
+++ b/mcp.json
@@ -15,6 +15,17 @@
         "mcp-tool-shop"
       ],
       "autoStart": true
+    },
+    "notion": {
+      "command": "npx",
+      "args": [
+        "-y",
+        "@notionhq/notion-mcp-server"
+      ],
+      "env": {
+        "OPENAPI_MCP_HEADERS": "{\"Authorization\":\"Bearer ${NOTION_API_KEY}\",\"Notion-Version\":\"2022-06-28\"}"
+      },
+      "autoStart": true
     }
   }
 }


### PR DESCRIPTION
## Summary
Adds the official `@notionhq/notion-mcp-server` to `mcp.json` so Claude Code, Cursor, and MCP Manager all expose authenticated access to the cloudless.gr Notion workspace from the IDE.

The Notion API key is referenced as `${NOTION_API_KEY}` (already in `.env.local` for every dev environment) — no secret is committed.

## How it works
- `@notionhq/notion-mcp-server` exposes the Notion API as MCP tools (search, read pages/databases, create/update content).
- The `OPENAPI_MCP_HEADERS` env var carries the auth header in the format the server expects.
- `autoStart: true` matches the convention of the other entries in `mcp.json`.

## Test plan
- [ ] CI green
- [ ] After merging, restart MCP Manager / Claude Code; the `notion` server shows up and connects without auth errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)