### PR TITLE
fix(sentry): skip OTel setup in dev to fix Turbopack require-in-the-middle crash

### DIFF
--- a/sentry.server.config.ts
+++ b/sentry.server.config.ts
@@ -5,6 +5,9 @@ Sentry.init({
   tracesSampleRate: 0.1,
   environment: process.env.NODE_ENV,
   release: process.env.NEXT_PUBLIC_APP_VERSION,
+  // Turbopack hashes require-in-the-middle at dev time, breaking OTel module patching.
+  // Skip OTel setup in dev; production Webpack builds work fine with it enabled.
+  skipOpenTelemetrySetup: process.env.NODE_ENV === "development",
   initialScope: {
     tags: {
       "aws.region": process.env.AWS_REGION ?? "us-east-1",


### PR DESCRIPTION
## Summary

- `@sentry/nextjs` v10 OpenTelemetry integration uses `require-in-the-middle` to monkey-patch Node modules at startup
- Turbopack hashes the module name to `require-in-the-middle-<hash>` at compile time but cannot resolve it at runtime
- This crashes the instrumentation hook on every `pnpm dev` start with `Failed to load external module require-in-the-middle-2ca7b9c2766f317e`

Fix: add `skipOpenTelemetrySetup: process.env.NODE_ENV === "development"` to `sentry.server.config.ts`. In dev, Sentry skips OTel module patching while keeping error capture. In production, Webpack builds load OTel normally with `skipOpenTelemetrySetup: false`.

## Test plan

- [x] Run `pnpm dev` in WSL — confirm no `require-in-the-middle` error
- [x] Confirm `Ready` without instrumentation hook crash
- [x] Production build (`pnpm build`) unaffected — `NODE_ENV === "production"` means OTel runs normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)