### PR TITLE
feat(crm): HubSpot CRM dashboard pages and webhook receiver

### DIFF
--- a/src/app/[locale]/admin/AdminLayoutClient.tsx
+++ b/src/app/[locale]/admin/AdminLayoutClient.tsx
@@ -32,6 +32,8 @@ import {
   AlertTriangle,
   Bell,
   Settings,
+  LayoutGrid,
+  Ticket,
   type LucideIcon,
 } from "lucide-react";
 
@@ -48,9 +50,17 @@ const adminGroups: AdminGroup[] = [
     ],
   },
   {
+    label: "HubSpot",
+    links: [
+      { href: "/admin/hubspot", label: "Overview", Icon: LayoutGrid },
+      { href: "/admin/crm", label: "Contacts", Icon: Users },
+      { href: "/admin/crm/companies", label: "Companies", Icon: Building2 },
+      { href: "/admin/crm/tickets", label: "Tickets", Icon: Ticket },
+    ],
+  },
+  {
     label: "Clients",
     links: [
-      { href: "/admin/crm", label: "CRM", Icon: Users },
       { href: "/admin/client-portals", label: "Client Portals", Icon: Link2 },
       { href: "/admin/workspaces", label: "Workspaces", Icon: Building2 },
     ],
@@ -173,7 +183,8 @@ export default function AdminLayoutClient({
       return (
         pathname === "/admin" || Boolean(pathname?.match(/^\/[a-z]{2}\/admin$/))
       );
-    return Boolean(pathname?.includes(href));
+    const path = (pathname ?? "").replace(/^\/[a-z]{2}(?=\/)/, "");
+    return path === href;
   };
 
   return (

--- a/src/app/[locale]/admin/crm/companies/page.tsx
+++ b/src/app/[locale]/admin/crm/companies/page.tsx
@@ -1,55 +1,55 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useState, useCallback } from "react";
 
-interface Contact {
+const REFRESH_INTERVAL = 10_000;
+
+interface Company {
   id: string;
   properties: {
-    email?: string;
-    firstname?: string;
-    lastname?: string;
-    company?: string;
+    name?: string;
+    domain?: string;
+    city?: string;
+    country?: string;
     createdate?: string;
-    hs_lead_status?: string;
   };
 }
 
-const leadStatusClasses: Record<string, string> = {
-  NEW: "text-neon-cyan bg-neon-cyan/10",
-  OPEN: "text-neon-green bg-neon-green/10",
-  IN_PROGRESS: "text-yellow-400 bg-yellow-400/10",
-  QUALIFIED: "text-neon-magenta bg-neon-magenta/10",
-  UNQUALIFIED: "text-slate-400 bg-slate-800/50",
-};
-
-export default function AdminCRMPage() {
-  const [contacts, setContacts] = useState<Contact[]>([]);
+export default function AdminCompaniesPage() {
+  const [companies, setCompanies] = useState<Company[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [search, setSearch] = useState("");
+  const [refreshing, setRefreshing] = useState(false);
+  const [fetchedAt, setFetchedAt] = useState<string | null>(null);
+
+  const fetchCompanies = useCallback(async (isManual = false) => {
+    if (isManual) setRefreshing(true);
+    try {
+      const res = await fetch("/api/admin/crm/companies?limit=100");
+      if (!res.ok) {
+        if (res.status === 503) throw new Error("HubSpot not configured");
+        throw new Error(`HTTP ${res.status}`);
+      }
+      const data = await res.json();
+      setCompanies(data.companies ?? []);
+      setFetchedAt(new Date().toISOString());
+      setError(null);
+    } catch (err) {
+      setError(
+        err instanceof Error ? err.message : "Failed to load companies",
+      );
+    } finally {
+      setLoading(false);
+      setRefreshing(false);
+    }
+  }, []);
 
   useEffect(() => {
-    async function fetchContacts() {
-      try {
-        const res = await fetch("/api/admin/crm/contacts?limit=50");
-        if (!res.ok) {
-          if (res.status === 503) throw new Error("HubSpot not configured");
-          throw new Error(`HTTP ${res.status}`);
-        }
-        const data = await res.json();
-        setContacts(data.contacts ?? []);
-      } catch (err) {
-        setError(
-          err instanceof Error ? err.message : "Failed to load contacts",
-        );
-      } finally {
-        setLoading(false);
-      }
-    }
-    fetchContacts();
-    const interval = setInterval(fetchContacts, 10_000);
+    fetchCompanies();
+    const interval = setInterval(() => fetchCompanies(), REFRESH_INTERVAL);
     const onVisible = () => {
-      if (document.visibilityState === "visible") fetchContacts();
+      if (document.visibilityState === "visible") fetchCompanies();
     };
     document.addEventListener("visibilitychange", onVisible);
     window.addEventListener("focus", onVisible);
@@ -58,59 +58,65 @@ export default function AdminCRMPage() {
       document.removeEventListener("visibilitychange", onVisible);
       window.removeEventListener("focus", onVisible);
     };
-  }, []);
+  }, [fetchCompanies]);
 
-  const filtered = contacts.filter((c) => {
+  const filtered = companies.filter((c) => {
     const q = search.toLowerCase();
     const p = c.properties;
     return (
-      (p.email ?? "").toLowerCase().includes(q) ||
-      (p.firstname ?? "").toLowerCase().includes(q) ||
-      (p.lastname ?? "").toLowerCase().includes(q) ||
-      (p.company ?? "").toLowerCase().includes(q)
+      (p.name ?? "").toLowerCase().includes(q) ||
+      (p.domain ?? "").toLowerCase().includes(q) ||
+      (p.city ?? "").toLowerCase().includes(q) ||
+      (p.country ?? "").toLowerCase().includes(q)
     );
   });
 
   return (
     <div>
-      <div className="mb-8">
-        <div className="bg-neon-magenta/10 border-neon-magenta/20 mb-4 inline-flex items-center gap-2 rounded-full border px-3 py-1.5">
-          <span className="bg-neon-magenta h-2 w-2 animate-pulse rounded-full" />
-          <span className="text-neon-magenta font-mono text-xs">CRM</span>
+      <div className="mb-8 flex items-start justify-between gap-4">
+        <div>
+          <div className="bg-neon-magenta/10 border-neon-magenta/20 mb-4 inline-flex items-center gap-2 rounded-full border px-3 py-1.5">
+            <span className="bg-neon-magenta h-2 w-2 animate-pulse rounded-full" />
+            <span className="text-neon-magenta font-mono text-xs">CRM</span>
+          </div>
+          <h1 className="font-heading text-2xl font-bold text-white">
+            Companies
+          </h1>
+          <p className="font-body mt-1 text-slate-400">
+            Company accounts synced from HubSpot.
+          </p>
         </div>
-        <h1 className="font-heading text-2xl font-bold text-white">
-          CRM Contacts
-        </h1>
-        <p className="font-body mt-1 text-slate-400">
-          Leads and contacts synced from HubSpot.
-        </p>
+        <div className="flex shrink-0 flex-col items-end gap-1">
+          <button
+            type="button"
+            onClick={() => fetchCompanies(true)}
+            disabled={refreshing}
+            className="border-neon-magenta/30 text-neon-magenta hover:bg-neon-magenta/10 rounded-lg border px-3 py-1.5 font-mono text-xs transition-colors disabled:opacity-50"
+          >
+            {refreshing ? "Refreshing…" : "Refresh"}
+          </button>
+          {fetchedAt && (
+            <span className="font-mono text-[10px] text-slate-600">
+              Updated {new Date(fetchedAt).toLocaleTimeString("en-IE")}
+            </span>
+          )}
+        </div>
       </div>
 
       {/* Stats */}
-      <div className="mb-6 grid grid-cols-1 gap-4 sm:grid-cols-3">
+      <div className="mb-6 grid grid-cols-1 gap-4 sm:grid-cols-2">
         <div className="bg-void-light/50 rounded-xl border border-slate-800 p-4">
-          <p className="font-mono text-xs text-slate-500">Total Contacts</p>
+          <p className="font-mono text-xs text-slate-500">Total Companies</p>
           <p className="font-heading mt-1 text-2xl font-bold text-white">
-            {loading ? "…" : contacts.length}
+            {loading ? "…" : companies.length}
           </p>
         </div>
         <div className="bg-void-light/50 rounded-xl border border-slate-800 p-4">
-          <p className="font-mono text-xs text-slate-500">New Leads</p>
+          <p className="font-mono text-xs text-slate-500">With Domain</p>
           <p className="font-heading text-neon-cyan mt-1 text-2xl font-bold">
             {loading
               ? "…"
-              : contacts.filter((c) => c.properties.hs_lead_status === "NEW")
-                  .length}
-          </p>
-        </div>
-        <div className="bg-void-light/50 rounded-xl border border-slate-800 p-4">
-          <p className="font-mono text-xs text-slate-500">Qualified</p>
-          <p className="font-heading text-neon-magenta mt-1 text-2xl font-bold">
-            {loading
-              ? "…"
-              : contacts.filter(
-                  (c) => c.properties.hs_lead_status === "QUALIFIED",
-                ).length}
+              : companies.filter((c) => c.properties.domain).length}
           </p>
         </div>
       </div>
@@ -119,7 +125,7 @@ export default function AdminCRMPage() {
       <div className="mb-4">
         <input
           type="text"
-          placeholder="Search by name, email, or company…"
+          placeholder="Search by name, domain, or location…"
           value={search}
           onChange={(e) => setSearch(e.target.value)}
           className="bg-void-light focus:border-neon-magenta/50 w-full max-w-md rounded-lg border border-slate-800 px-4 py-3 font-mono text-sm text-white transition-colors placeholder:text-slate-600 focus:outline-none"
@@ -146,16 +152,13 @@ export default function AdminCRMPage() {
               <thead>
                 <tr className="border-b border-slate-800">
                   <th className="px-6 py-3 text-left font-mono text-xs font-medium text-slate-500">
-                    Name
-                  </th>
-                  <th className="px-6 py-3 text-left font-mono text-xs font-medium text-slate-500">
-                    Email
-                  </th>
-                  <th className="px-6 py-3 text-left font-mono text-xs font-medium text-slate-500">
                     Company
                   </th>
                   <th className="px-6 py-3 text-left font-mono text-xs font-medium text-slate-500">
-                    Lead Status
+                    Domain
+                  </th>
+                  <th className="px-6 py-3 text-left font-mono text-xs font-medium text-slate-500">
+                    Location
                   </th>
                   <th className="px-6 py-3 text-left font-mono text-xs font-medium text-slate-500">
                     Added
@@ -168,23 +171,27 @@ export default function AdminCRMPage() {
                     key={c.id}
                     className="hover:bg-void-lighter/30 border-b border-slate-800/50 transition-colors"
                   >
-                    <td className="px-6 py-4 text-white">
-                      {[c.properties.firstname, c.properties.lastname]
-                        .filter(Boolean)
-                        .join(" ") || "—"}
+                    <td className="px-6 py-4 font-medium text-white">
+                      {c.properties.name || "—"}
                     </td>
                     <td className="text-neon-cyan px-6 py-4 font-mono text-xs">
-                      {c.properties.email ?? "—"}
+                      {c.properties.domain ? (
+                        <a
+                          href={`https://${c.properties.domain}`}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          className="hover:underline"
+                        >
+                          {c.properties.domain}
+                        </a>
+                      ) : (
+                        "—"
+                      )}
                     </td>
                     <td className="px-6 py-4 text-slate-300">
-                      {c.properties.company || "—"}
-                    </td>
-                    <td className="px-6 py-4">
-                      <span
-                        className={`rounded-full px-2 py-0.5 font-mono text-[10px] ${leadStatusClasses[c.properties.hs_lead_status ?? ""] ?? "text-slate-400 bg-slate-800/50"}`}
-                      >
-                        {c.properties.hs_lead_status ?? "—"}
-                      </span>
+                      {[c.properties.city, c.properties.country]
+                        .filter(Boolean)
+                        .join(", ") || "—"}
                     </td>
                     <td className="px-6 py-4 font-mono text-slate-500">
                       {c.properties.createdate
@@ -198,12 +205,12 @@ export default function AdminCRMPage() {
                 {filtered.length === 0 && (
                   <tr>
                     <td
-                      colSpan={5}
+                      colSpan={4}
                       className="px-6 py-12 text-center font-mono text-slate-600"
                     >
                       {search
-                        ? "No contacts match your search"
-                        : "No contacts yet"}
+                        ? "No companies match your search"
+                        : "No companies yet"}
                     </td>
                   </tr>
                 )}

--- a/src/app/[locale]/admin/crm/tickets/page.tsx
+++ b/src/app/[locale]/admin/crm/tickets/page.tsx
@@ -1,0 +1,248 @@
+"use client";
+
+import { useEffect, useState, useCallback } from "react";
+
+const REFRESH_INTERVAL = 10_000;
+
+interface Ticket {
+  id: string;
+  properties: {
+    subject?: string;
+    content?: string;
+    hs_pipeline?: string;
+    hs_pipeline_stage?: string;
+    hs_ticket_priority?: string;
+    createdate?: string;
+  };
+}
+
+const priorityClasses: Record<string, string> = {
+  HIGH: "text-red-400 bg-red-400/10",
+  MEDIUM: "text-yellow-400 bg-yellow-400/10",
+  LOW: "text-neon-green bg-neon-green/10",
+};
+
+const stageLabels: Record<string, string> = {
+  "1": "New",
+  "2": "Waiting on contact",
+  "3": "Waiting on us",
+  "4": "Closed",
+};
+
+export default function AdminTicketsPage() {
+  const [tickets, setTickets] = useState<Ticket[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [search, setSearch] = useState("");
+  const [refreshing, setRefreshing] = useState(false);
+  const [fetchedAt, setFetchedAt] = useState<string | null>(null);
+
+  const fetchTickets = useCallback(async (isManual = false) => {
+    if (isManual) setRefreshing(true);
+    try {
+      const res = await fetch("/api/admin/crm/tickets?limit=100");
+      if (!res.ok) {
+        if (res.status === 503) throw new Error("HubSpot not configured");
+        throw new Error(`HTTP ${res.status}`);
+      }
+      const data = await res.json();
+      setTickets(data.tickets ?? []);
+      setFetchedAt(new Date().toISOString());
+      setError(null);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to load tickets");
+    } finally {
+      setLoading(false);
+      setRefreshing(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchTickets();
+    const interval = setInterval(() => fetchTickets(), REFRESH_INTERVAL);
+    const onVisible = () => {
+      if (document.visibilityState === "visible") fetchTickets();
+    };
+    document.addEventListener("visibilitychange", onVisible);
+    window.addEventListener("focus", onVisible);
+    return () => {
+      clearInterval(interval);
+      document.removeEventListener("visibilitychange", onVisible);
+      window.removeEventListener("focus", onVisible);
+    };
+  }, [fetchTickets]);
+
+  const filtered = tickets.filter((t) => {
+    const q = search.toLowerCase();
+    return (t.properties.subject ?? "").toLowerCase().includes(q);
+  });
+
+  const open = tickets.filter(
+    (t) => t.properties.hs_pipeline_stage !== "4",
+  ).length;
+
+  return (
+    <div>
+      <div className="mb-8 flex items-start justify-between gap-4">
+        <div>
+          <div className="bg-neon-magenta/10 border-neon-magenta/20 mb-4 inline-flex items-center gap-2 rounded-full border px-3 py-1.5">
+            <span className="bg-neon-magenta h-2 w-2 animate-pulse rounded-full" />
+            <span className="text-neon-magenta font-mono text-xs">CRM</span>
+          </div>
+          <h1 className="font-heading text-2xl font-bold text-white">
+            Support Tickets
+          </h1>
+          <p className="font-body mt-1 text-slate-400">
+            Customer support tickets synced from HubSpot.
+          </p>
+        </div>
+        <div className="flex shrink-0 flex-col items-end gap-1">
+          <button
+            type="button"
+            onClick={() => fetchTickets(true)}
+            disabled={refreshing}
+            className="border-neon-magenta/30 text-neon-magenta hover:bg-neon-magenta/10 rounded-lg border px-3 py-1.5 font-mono text-xs transition-colors disabled:opacity-50"
+          >
+            {refreshing ? "Refreshing…" : "Refresh"}
+          </button>
+          {fetchedAt && (
+            <span className="font-mono text-[10px] text-slate-600">
+              Updated {new Date(fetchedAt).toLocaleTimeString("en-IE")}
+            </span>
+          )}
+        </div>
+      </div>
+
+      {/* Stats */}
+      <div className="mb-6 grid grid-cols-1 gap-4 sm:grid-cols-3">
+        <div className="bg-void-light/50 rounded-xl border border-slate-800 p-4">
+          <p className="font-mono text-xs text-slate-500">Total Tickets</p>
+          <p className="font-heading mt-1 text-2xl font-bold text-white">
+            {loading ? "…" : tickets.length}
+          </p>
+        </div>
+        <div className="bg-void-light/50 rounded-xl border border-slate-800 p-4">
+          <p className="font-mono text-xs text-slate-500">Open</p>
+          <p className="font-heading mt-1 text-2xl font-bold text-yellow-400">
+            {loading ? "…" : open}
+          </p>
+        </div>
+        <div className="bg-void-light/50 rounded-xl border border-slate-800 p-4">
+          <p className="font-mono text-xs text-slate-500">Closed</p>
+          <p className="font-heading text-neon-green mt-1 text-2xl font-bold">
+            {loading ? "…" : tickets.length - open}
+          </p>
+        </div>
+      </div>
+
+      {/* Search */}
+      <div className="mb-4">
+        <input
+          type="text"
+          placeholder="Search by subject…"
+          value={search}
+          onChange={(e) => setSearch(e.target.value)}
+          className="bg-void-light focus:border-neon-magenta/50 w-full max-w-md rounded-lg border border-slate-800 px-4 py-3 font-mono text-sm text-white transition-colors placeholder:text-slate-600 focus:outline-none"
+        />
+      </div>
+
+      {loading ? (
+        <div className="bg-void-light/50 flex items-center justify-center rounded-xl border border-slate-800 py-16">
+          <div className="border-neon-magenta h-6 w-6 animate-spin rounded-full border-2 border-t-transparent" />
+        </div>
+      ) : error ? (
+        <div className="bg-void-light/50 rounded-xl border border-red-900/30 p-6 text-center">
+          <p className="font-mono text-sm text-red-400">{error}</p>
+          <p className="mt-2 text-xs text-slate-500">
+            {error === "HubSpot not configured"
+              ? "Set HUBSPOT_API_KEY in your environment to enable CRM."
+              : "Check your HubSpot API key configuration."}
+          </p>
+        </div>
+      ) : (
+        <div className="bg-void-light/50 overflow-hidden rounded-xl border border-slate-800">
+          <div className="overflow-x-auto">
+            <table className="w-full text-sm">
+              <thead>
+                <tr className="border-b border-slate-800">
+                  <th className="px-6 py-3 text-left font-mono text-xs font-medium text-slate-500">
+                    Subject
+                  </th>
+                  <th className="px-6 py-3 text-left font-mono text-xs font-medium text-slate-500">
+                    Priority
+                  </th>
+                  <th className="px-6 py-3 text-left font-mono text-xs font-medium text-slate-500">
+                    Stage
+                  </th>
+                  <th className="px-6 py-3 text-left font-mono text-xs font-medium text-slate-500">
+                    Created
+                  </th>
+                </tr>
+              </thead>
+              <tbody>
+                {filtered.map((t) => {
+                  const priority =
+                    t.properties.hs_ticket_priority?.toUpperCase() ?? "";
+                  const stage = t.properties.hs_pipeline_stage ?? "";
+                  return (
+                    <tr
+                      key={t.id}
+                      className="hover:bg-void-lighter/30 border-b border-slate-800/50 transition-colors"
+                    >
+                      <td className="max-w-xs px-6 py-4 text-white">
+                        <span className="line-clamp-2">
+                          {t.properties.subject || "—"}
+                        </span>
+                      </td>
+                      <td className="px-6 py-4">
+                        {priority ? (
+                          <span
+                            className={`rounded-full px-2 py-0.5 font-mono text-[10px] ${priorityClasses[priority] ?? "text-slate-400 bg-slate-800/50"}`}
+                          >
+                            {priority}
+                          </span>
+                        ) : (
+                          <span className="font-mono text-slate-600">—</span>
+                        )}
+                      </td>
+                      <td className="px-6 py-4">
+                        <span
+                          className={`rounded-full px-2 py-0.5 font-mono text-[10px] ${
+                            stage === "4"
+                              ? "text-neon-green bg-neon-green/10"
+                              : "text-yellow-400 bg-yellow-400/10"
+                          }`}
+                        >
+                          {stageLabels[stage] ?? stage || "—"}
+                        </span>
+                      </td>
+                      <td className="px-6 py-4 font-mono text-slate-500">
+                        {t.properties.createdate
+                          ? new Date(
+                              t.properties.createdate,
+                            ).toLocaleDateString("en-IE")
+                          : "—"}
+                      </td>
+                    </tr>
+                  );
+                })}
+                {filtered.length === 0 && (
+                  <tr>
+                    <td
+                      colSpan={4}
+                      className="px-6 py-12 text-center font-mono text-slate-600"
+                    >
+                      {search
+                        ? "No tickets match your search"
+                        : "No tickets yet"}
+                    </td>
+                  </tr>
+                )}
+              </tbody>
+            </table>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/app/[locale]/admin/hubspot/page.tsx
+++ b/src/app/[locale]/admin/hubspot/page.tsx
@@ -1,0 +1,361 @@
+"use client";
+
+import { useEffect, useState, useCallback } from "react";
+
+const REFRESH_INTERVAL = 10_000;
+
+interface Contact {
+  id: string;
+  properties: {
+    email?: string;
+    firstname?: string;
+    lastname?: string;
+    company?: string;
+    createdate?: string;
+    hs_lead_status?: string;
+  };
+}
+
+interface Deal {
+  id: string;
+  properties: {
+    dealname?: string;
+    amount?: string;
+    dealstage?: string;
+    closedate?: string;
+    createdate?: string;
+  };
+}
+
+interface Ticket {
+  id: string;
+  properties: {
+    subject?: string;
+    hs_pipeline_stage?: string;
+    hs_ticket_priority?: string;
+    createdate?: string;
+  };
+}
+
+interface Stats {
+  contacts: {
+    total: number;
+    newLeads: number;
+    qualified: number;
+    recent: Contact[];
+  };
+  deals: {
+    total: number;
+    pipelineValue: number;
+    won: number;
+  };
+  tickets: {
+    total: number;
+    open: number;
+  };
+  fetchedAt: string | null;
+}
+
+const priorityClasses: Record<string, string> = {
+  HIGH: "text-red-400 bg-red-400/10",
+  MEDIUM: "text-yellow-400 bg-yellow-400/10",
+  LOW: "text-neon-green bg-neon-green/10",
+};
+
+export default function HubSpotOverviewPage() {
+  const [stats, setStats] = useState<Stats>({
+    contacts: { total: 0, newLeads: 0, qualified: 0, recent: [] },
+    deals: { total: 0, pipelineValue: 0, won: 0 },
+    tickets: { total: 0, open: 0 },
+    fetchedAt: null,
+  });
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [refreshing, setRefreshing] = useState(false);
+
+  const fetchAll = useCallback(async (isManual = false) => {
+    if (isManual) setRefreshing(true);
+    try {
+      const [contactsRes, dealsRes, ticketsRes] = await Promise.all([
+        fetch("/api/admin/crm/contacts?limit=100"),
+        fetch("/api/admin/crm/deals?limit=100"),
+        fetch("/api/admin/crm/tickets?limit=100"),
+      ]);
+
+      if (!contactsRes.ok && contactsRes.status === 503) {
+        throw new Error("HubSpot not configured");
+      }
+
+      const [contactsData, dealsData, ticketsData] = await Promise.all([
+        contactsRes.ok ? contactsRes.json() : { contacts: [] },
+        dealsRes.ok ? dealsRes.json() : { deals: [] },
+        ticketsRes.ok ? ticketsRes.json() : { tickets: [] },
+      ]);
+
+      const contacts: Contact[] = contactsData.contacts ?? [];
+      const deals: Deal[] = dealsData.deals ?? [];
+      const tickets: Ticket[] = ticketsData.tickets ?? [];
+
+      const pipelineValue = deals.reduce(
+        (sum, d) => sum + (parseFloat(d.properties.amount ?? "0") || 0),
+        0,
+      );
+      const wonDeals = deals.filter(
+        (d) => d.properties.dealstage === "closedwon",
+      ).length;
+      const openTickets = tickets.filter(
+        (t) => t.properties.hs_pipeline_stage !== "4",
+      ).length;
+
+      setStats({
+        contacts: {
+          total: contacts.length,
+          newLeads: contacts.filter(
+            (c) => c.properties.hs_lead_status === "NEW",
+          ).length,
+          qualified: contacts.filter(
+            (c) => c.properties.hs_lead_status === "QUALIFIED",
+          ).length,
+          recent: contacts
+            .slice()
+            .sort(
+              (a, b) =>
+                new Date(b.properties.createdate ?? 0).getTime() -
+                new Date(a.properties.createdate ?? 0).getTime(),
+            )
+            .slice(0, 5),
+        },
+        deals: {
+          total: deals.length,
+          pipelineValue,
+          won: wonDeals,
+        },
+        tickets: {
+          total: tickets.length,
+          open: openTickets,
+        },
+        fetchedAt: new Date().toISOString(),
+      });
+      setError(null);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to load data");
+    } finally {
+      setLoading(false);
+      setRefreshing(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchAll();
+    const interval = setInterval(() => fetchAll(), REFRESH_INTERVAL);
+    const onVisible = () => {
+      if (document.visibilityState === "visible") fetchAll();
+    };
+    document.addEventListener("visibilitychange", onVisible);
+    window.addEventListener("focus", onVisible);
+    return () => {
+      clearInterval(interval);
+      document.removeEventListener("visibilitychange", onVisible);
+      window.removeEventListener("focus", onVisible);
+    };
+  }, [fetchAll]);
+
+  const fmt = (n: number) =>
+    new Intl.NumberFormat("en-US", {
+      style: "currency",
+      currency: "USD",
+      maximumFractionDigits: 0,
+    }).format(n);
+
+  return (
+    <div>
+      {/* Header */}
+      <div className="mb-8 flex items-start justify-between gap-4">
+        <div>
+          <div className="bg-neon-magenta/10 border-neon-magenta/20 mb-4 inline-flex items-center gap-2 rounded-full border px-3 py-1.5">
+            <span className="bg-neon-magenta h-2 w-2 animate-pulse rounded-full" />
+            <span className="text-neon-magenta font-mono text-xs">HUBSPOT</span>
+          </div>
+          <h1 className="font-heading text-2xl font-bold text-white">
+            HubSpot Overview
+          </h1>
+          <p className="font-body mt-1 text-slate-400">
+            Live snapshot of your CRM — contacts, deals, and support tickets.
+          </p>
+        </div>
+        <div className="flex shrink-0 flex-col items-end gap-1">
+          <button
+            type="button"
+            onClick={() => fetchAll(true)}
+            disabled={refreshing}
+            className="border-neon-magenta/30 text-neon-magenta hover:bg-neon-magenta/10 rounded-lg border px-3 py-1.5 font-mono text-xs transition-colors disabled:opacity-50"
+          >
+            {refreshing ? "Refreshing…" : "Refresh"}
+          </button>
+          {stats.fetchedAt && (
+            <span className="font-mono text-[10px] text-slate-600">
+              Updated {new Date(stats.fetchedAt).toLocaleTimeString("en-IE")}
+            </span>
+          )}
+        </div>
+      </div>
+
+      {error ? (
+        <div className="bg-void-light/50 rounded-xl border border-red-900/30 p-6 text-center">
+          <p className="font-mono text-sm text-red-400">{error}</p>
+          <p className="mt-2 text-xs text-slate-500">
+            {error === "HubSpot not configured"
+              ? "Set HUBSPOT_API_KEY in your environment to enable the CRM."
+              : "Check your HubSpot API key configuration."}
+          </p>
+        </div>
+      ) : (
+        <>
+          {/* Contacts stats */}
+          <p className="mb-3 font-mono text-[10px] uppercase tracking-widest text-slate-600">
+            Contacts
+          </p>
+          <div className="mb-6 grid grid-cols-1 gap-4 sm:grid-cols-3">
+            <StatCard
+              label="Total Contacts"
+              value={loading ? "…" : stats.contacts.total}
+              color="text-white"
+            />
+            <StatCard
+              label="New Leads"
+              value={loading ? "…" : stats.contacts.newLeads}
+              color="text-neon-cyan"
+            />
+            <StatCard
+              label="Qualified"
+              value={loading ? "…" : stats.contacts.qualified}
+              color="text-neon-magenta"
+            />
+          </div>
+
+          {/* Deals stats */}
+          <p className="mb-3 font-mono text-[10px] uppercase tracking-widest text-slate-600">
+            Deals
+          </p>
+          <div className="mb-6 grid grid-cols-1 gap-4 sm:grid-cols-3">
+            <StatCard
+              label="Total Deals"
+              value={loading ? "…" : stats.deals.total}
+              color="text-white"
+            />
+            <StatCard
+              label="Pipeline Value"
+              value={loading ? "…" : fmt(stats.deals.pipelineValue)}
+              color="text-neon-green"
+            />
+            <StatCard
+              label="Won"
+              value={loading ? "…" : stats.deals.won}
+              color="text-neon-cyan"
+            />
+          </div>
+
+          {/* Tickets stats */}
+          <p className="mb-3 font-mono text-[10px] uppercase tracking-widest text-slate-600">
+            Support Tickets
+          </p>
+          <div className="mb-8 grid grid-cols-1 gap-4 sm:grid-cols-2">
+            <StatCard
+              label="Total Tickets"
+              value={loading ? "…" : stats.tickets.total}
+              color="text-white"
+            />
+            <StatCard
+              label="Open"
+              value={loading ? "…" : stats.tickets.open}
+              color="text-yellow-400"
+            />
+          </div>
+
+          {/* Recent leads */}
+          <p className="mb-3 font-mono text-[10px] uppercase tracking-widest text-slate-600">
+            Recent Leads
+          </p>
+          <div className="bg-void-light/50 overflow-hidden rounded-xl border border-slate-800">
+            {loading ? (
+              <div className="flex items-center justify-center py-12">
+                <div className="border-neon-magenta h-6 w-6 animate-spin rounded-full border-2 border-t-transparent" />
+              </div>
+            ) : stats.contacts.recent.length === 0 ? (
+              <p className="px-6 py-12 text-center font-mono text-slate-600">
+                No contacts yet
+              </p>
+            ) : (
+              <div className="overflow-x-auto">
+                <table className="w-full text-sm">
+                  <thead>
+                    <tr className="border-b border-slate-800">
+                      <th className="px-6 py-3 text-left font-mono text-xs font-medium text-slate-500">
+                        Name
+                      </th>
+                      <th className="px-6 py-3 text-left font-mono text-xs font-medium text-slate-500">
+                        Email
+                      </th>
+                      <th className="px-6 py-3 text-left font-mono text-xs font-medium text-slate-500">
+                        Status
+                      </th>
+                      <th className="px-6 py-3 text-left font-mono text-xs font-medium text-slate-500">
+                        Added
+                      </th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {stats.contacts.recent.map((c) => (
+                      <tr
+                        key={c.id}
+                        className="hover:bg-void-lighter/30 border-b border-slate-800/50 transition-colors"
+                      >
+                        <td className="px-6 py-4 text-white">
+                          {[c.properties.firstname, c.properties.lastname]
+                            .filter(Boolean)
+                            .join(" ") || "—"}
+                        </td>
+                        <td className="text-neon-cyan px-6 py-4 font-mono text-xs">
+                          {c.properties.email ?? "—"}
+                        </td>
+                        <td className="px-6 py-4">
+                          <span className="rounded-full bg-neon-cyan/10 px-2 py-0.5 font-mono text-[10px] text-neon-cyan">
+                            {c.properties.hs_lead_status ?? "—"}
+                          </span>
+                        </td>
+                        <td className="px-6 py-4 font-mono text-slate-500">
+                          {c.properties.createdate
+                            ? new Date(
+                                c.properties.createdate,
+                              ).toLocaleDateString("en-IE")
+                            : "—"}
+                        </td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            )}
+          </div>
+        </>
+      )}
+    </div>
+  );
+}
+
+function StatCard({
+  label,
+  value,
+  color,
+}: {
+  label: string;
+  value: string | number;
+  color: string;
+}) {
+  return (
+    <div className="bg-void-light/50 rounded-xl border border-slate-800 p-4">
+      <p className="font-mono text-xs text-slate-500">{label}</p>
+      <p className={`font-heading mt-1 text-2xl font-bold ${color}`}>{value}</p>
+    </div>
+  );
+}

--- a/src/app/api/admin/crm/tickets/route.ts
+++ b/src/app/api/admin/crm/tickets/route.ts
@@ -1,0 +1,38 @@
+import { NextRequest } from "next/server";
+import { requireAdmin } from "@/lib/api-auth";
+import { NextResponse } from "next/server";
+import { isHubSpotConfigured, listTickets } from "@/lib/hubspot";
+
+export async function GET(request: NextRequest) {
+  const auth = await requireAdmin(request);
+  if (!auth.ok) return auth.response;
+
+  if (!(await isHubSpotConfigured())) {
+    return NextResponse.json(
+      { error: "HubSpot not configured." },
+      { status: 503 },
+    );
+  }
+
+  try {
+    const { searchParams } = new URL(request.url);
+    const requestedLimit = Number(searchParams.get("limit") ?? 20);
+    const limit = Number.isFinite(requestedLimit)
+      ? Math.min(Math.max(Math.trunc(requestedLimit), 1), 100)
+      : 20;
+
+    const tickets = await listTickets(limit);
+
+    return NextResponse.json({
+      tickets,
+      total: tickets.length,
+      fetchedAt: new Date().toISOString(),
+    });
+  } catch (err) {
+    console.error("[HubSpot] Error listing tickets:", err);
+    return NextResponse.json(
+      { error: "Failed to fetch tickets." },
+      { status: 500 },
+    );
+  }
+}

--- a/src/app/api/webhooks/hubspot/route.ts
+++ b/src/app/api/webhooks/hubspot/route.ts
@@ -1,0 +1,86 @@
+import { NextRequest, NextResponse } from "next/server";
+import { createHmac, timingSafeEqual } from "crypto";
+import { getIntegrationsAsync } from "@/lib/integrations";
+
+const MAX_TIMESTAMP_AGE_MS = 5 * 60 * 1000; // reject requests older than 5 min
+
+type HubSpotEvent = {
+  eventId: number;
+  subscriptionId: number;
+  portalId: number;
+  occurredAt: number;
+  subscriptionType: string;
+  objectId: number;
+  propertyName?: string;
+  propertyValue?: string;
+  changeSource?: string;
+};
+
+async function verifySignatureV3(
+  request: NextRequest,
+  body: string,
+  clientSecret: string,
+): Promise<boolean> {
+  const signature = request.headers.get("x-hubspot-signature-v3");
+  const timestamp = request.headers.get("x-hubspot-signature-timestamp");
+
+  if (!signature || !timestamp) return false;
+
+  const age = Date.now() - Number(timestamp);
+  if (isNaN(age) || age > MAX_TIMESTAMP_AGE_MS || age < 0) return false;
+
+  const input = `${request.method}${request.url}${body}${timestamp}`;
+  const expected = createHmac("sha256", clientSecret)
+    .update(input)
+    .digest("base64");
+
+  try {
+    return timingSafeEqual(Buffer.from(signature), Buffer.from(expected));
+  } catch {
+    return false;
+  }
+}
+
+export async function POST(request: NextRequest) {
+  const rawBody = await request.text();
+
+  const cfg = await getIntegrationsAsync();
+  const clientSecret = cfg.HUBSPOT_CLIENT_SECRET;
+
+  if (clientSecret) {
+    const valid = await verifySignatureV3(request, rawBody, clientSecret);
+    if (!valid) {
+      console.warn("[HubSpot Webhook] Signature verification failed");
+      return NextResponse.json({ error: "Invalid signature" }, { status: 401 });
+    }
+  } else {
+    console.warn(
+      "[HubSpot Webhook] HUBSPOT_CLIENT_SECRET not set — skipping signature check",
+    );
+  }
+
+  let events: HubSpotEvent[];
+  try {
+    const parsed = JSON.parse(rawBody);
+    events = Array.isArray(parsed) ? parsed : [parsed];
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+
+  for (const event of events) {
+    const { subscriptionType, objectId, propertyName, propertyValue, occurredAt } =
+      event;
+
+    console.info(
+      `[HubSpot Webhook] ${subscriptionType} | object=${objectId} | t=${occurredAt}`,
+      propertyName ? { propertyName, propertyValue } : undefined,
+    );
+  }
+
+  return NextResponse.json({ received: events.length });
+}
+
+// HubSpot sends a GET to verify the webhook URL during setup
+export async function GET() {
+  return NextResponse.json({ ok: true });
+}

--- a/src/lib/hubspot.ts
+++ b/src/lib/hubspot.ts
@@ -140,6 +140,27 @@ export async function listContacts(limit = 10): Promise<unknown[]> {
   }
 }
 
+/**
+ * List CRM support tickets.
+ *
+ * @param limit - Max records to return (1–100, default 20).
+ */
+export async function listTickets(limit = 20): Promise<unknown[]> {
+  const safeLimit = Number.isFinite(limit)
+    ? Math.min(Math.max(Math.trunc(limit), 1), 100)
+    : 20;
+  try {
+    const res = await hubspotFetch(
+      `/crm/v3/objects/tickets?limit=${safeLimit}&properties=subject,content,hs_pipeline,hs_pipeline_stage,hs_ticket_priority,createdate`,
+    );
+    if (!res.ok) return [];
+    const data = await res.json();
+    return data.results ?? [];
+  } catch {
+    return [];
+  }
+}
+
 /* ─── Ticket support (requires 'tickets' scope) ─────────────────── */
 
 interface TicketData {

--- a/src/lib/integrations.ts
+++ b/src/lib/integrations.ts
@@ -12,6 +12,7 @@ export interface IntegrationConfig {
   SLACK_BOT_TOKEN?: string;
   SLACK_SIGNING_SECRET?: string;
   HUBSPOT_API_KEY?: string;
+  HUBSPOT_CLIENT_SECRET?: string;
   NOTION_API_KEY?: string;
   NOTION_BLOG_DB_ID?: string;
   NOTION_SUBMISSIONS_DB_ID?: string;
@@ -73,6 +74,7 @@ export function getIntegrations(): IntegrationConfig {
     SLACK_BOT_TOKEN: process.env.SLACK_BOT_TOKEN,
     SLACK_SIGNING_SECRET: process.env.SLACK_SIGNING_SECRET,
     HUBSPOT_API_KEY: process.env.HUBSPOT_API_KEY,
+    HUBSPOT_CLIENT_SECRET: process.env.HUBSPOT_CLIENT_SECRET,
     NOTION_API_KEY: process.env.NOTION_API_KEY,
     NOTION_BLOG_DB_ID: process.env.NOTION_BLOG_DB_ID,
     NOTION_SUBMISSIONS_DB_ID: process.env.NOTION_SUBMISSIONS_DB_ID,
@@ -171,6 +173,8 @@ export async function getIntegrationsAsync(): Promise<IntegrationConfig> {
         envCfg.SLACK_SIGNING_SECRET || ssm.SLACK_SIGNING_SECRET || undefined,
       HUBSPOT_API_KEY:
         envCfg.HUBSPOT_API_KEY || ssm.HUBSPOT_API_KEY || undefined,
+      HUBSPOT_CLIENT_SECRET:
+        envCfg.HUBSPOT_CLIENT_SECRET || ssm.HUBSPOT_CLIENT_SECRET || undefined,
       NOTION_API_KEY: envCfg.NOTION_API_KEY || ssm.NOTION_API_KEY || undefined,
       NOTION_BLOG_DB_ID:
         envCfg.NOTION_BLOG_DB_ID || ssm.NOTION_BLOG_DB_ID || undefined,

--- a/src/lib/ssm-config.ts
+++ b/src/lib/ssm-config.ts
@@ -18,6 +18,7 @@ interface AppConfig {
   SLACK_BOT_TOKEN: string;
   SLACK_SIGNING_SECRET: string;
   HUBSPOT_API_KEY: string;
+  HUBSPOT_CLIENT_SECRET: string;
   NOTION_API_KEY: string;
   NOTION_BLOG_DB_ID: string;
   NOTION_WEBHOOK_SECRET: string;
@@ -102,6 +103,7 @@ function buildConfigFromEnv(): AppConfig {
       process.env.HUBSPOT_API_KEY ||
       process.env.HUBSPOT_PRIVATE_APP_TOKEN ||
       "",
+    HUBSPOT_CLIENT_SECRET: process.env.HUBSPOT_CLIENT_SECRET || "",
     NOTION_API_KEY: process.env.NOTION_API_KEY || "",
     NOTION_BLOG_DB_ID: process.env.NOTION_BLOG_DB_ID || "",
     NOTION_WEBHOOK_SECRET: process.env.NOTION_WEBHOOK_SECRET || "",
@@ -213,6 +215,7 @@ export async function getConfig(): Promise<AppConfig> {
     SLACK_BOT_TOKEN: params.get("SLACK_BOT_TOKEN") ?? "",
     SLACK_SIGNING_SECRET: params.get("SLACK_SIGNING_SECRET") ?? "",
     HUBSPOT_API_KEY: params.get("HUBSPOT_API_KEY") ?? "",
+    HUBSPOT_CLIENT_SECRET: params.get("HUBSPOT_CLIENT_SECRET") ?? "",
     NOTION_API_KEY: params.get("NOTION_API_KEY") ?? "",
     NOTION_BLOG_DB_ID: params.get("NOTION_BLOG_DB_ID") ?? "",
     NOTION_WEBHOOK_SECRET: params.get("NOTION_WEBHOOK_SECRET") ?? "",


### PR DESCRIPTION
## Summary
- New HubSpot admin section with Overview, Contacts, Companies, and Tickets pages -- all with 10s live polling
- Webhook receiver at `/api/webhooks/hubspot` with HMAC-SHA256 v3 signature verification and 5-minute replay guard
- HubSpot app already configured: webhook URL set, subscriptions active for Contact/Company/Deal/Ticket creation events

## New routes
- `/admin/hubspot` -- Overview dashboard (contacts + deals + tickets stats + recent leads)
- `/admin/crm/companies` -- Companies list with search
- `/admin/crm/tickets` -- Tickets list with priority/stage badges
- `GET /api/webhooks/hubspot` -- URL verification endpoint
- `POST /api/webhooks/hubspot` -- Webhook event receiver
- `GET /api/admin/crm/tickets` -- Tickets API backed by HubSpot

## Before merging
Set `HUBSPOT_CLIENT_SECRET=63b67005-cfc1-4628-9ac1-9c4e948bd7cb` in SSM at `/cloudless/production/HUBSPOT_CLIENT_SECRET`

Generated with [Claude Code](https://claude.com/claude-code)