### PR TITLE
test(e2e): tighten Playwright specs to documented role/label patterns

### DIFF
--- a/e2e/api-auth.spec.ts
+++ b/e2e/api-auth.spec.ts
@@ -1,8 +1,13 @@
 import { test, expect } from "@playwright/test";
 
 test.describe("API Authentication", () => {
-  test("API is reachable", async ({ page }) => {
+  test("health endpoint returns 200 with status payload", async ({ page }) => {
     const response = await page.request.get("/api/health");
-    expect([200, 404]).toContain(response.status());
+    expect(response.status()).toBe(200);
+
+    const body = await response.json();
+    expect(body).toMatchObject({ status: "ok" });
+    expect(typeof body.timestamp).toBe("string");
+    expect(typeof body.version).toBe("string");
   });
 });

--- a/e2e/auth.spec.ts
+++ b/e2e/auth.spec.ts
@@ -3,18 +3,27 @@ import { test, expect } from "@playwright/test";
 test.describe("Authentication", () => {
   test("homepage is accessible without login", async ({ page }) => {
     await page.goto("/");
-    expect(page.url()).toContain(":4000");
+    await expect(page.getByRole("heading", { level: 1 })).toBeVisible();
   });
 
-  test("can navigate to login page", async ({ page }) => {
+  test("login page exposes email and password fields", async ({ page }) => {
     await page.goto("/auth/login");
-    const inputs = await page.locator("input").count();
-    expect(inputs).toBeGreaterThan(0);
+    await expect(page).toHaveURL(/\/auth\/login/);
+    await expect(page.getByLabel(/email/i)).toBeVisible();
+    await expect(page.getByLabel(/password/i).first()).toBeVisible();
   });
 
-  test("can navigate to signup page", async ({ page }) => {
+  test("signup page exposes name, email and password fields", async ({ page }) => {
     await page.goto("/auth/signup");
-    const inputs = await page.locator("input").count();
-    expect(inputs).toBeGreaterThan(0);
+    await expect(page).toHaveURL(/\/auth\/signup/);
+    await expect(page.getByLabel(/name/i)).toBeVisible();
+    await expect(page.getByLabel(/email/i)).toBeVisible();
+    await expect(page.getByLabel(/^password/i)).toBeVisible();
+  });
+
+  test("forgot-password page is reachable from login", async ({ page }) => {
+    await page.goto("/auth/login");
+    await page.getByRole("link", { name: /forgot/i }).click();
+    await expect(page).toHaveURL(/\/auth\/forgot-password/);
   });
 });

--- a/e2e/contact-integrations.spec.ts
+++ b/e2e/contact-integrations.spec.ts
@@ -1,14 +1,45 @@
 import { test, expect } from "@playwright/test";
 
 test.describe("Contact & Integrations", () => {
-  test("contact form is accessible", async ({ page }) => {
+  test("contact form renders the documented fields", async ({ page }) => {
     await page.goto("/contact");
-    const forms = await page.locator("form").count();
-    expect(forms).toBeGreaterThanOrEqual(0);
+
+    await expect(page.getByRole("heading", { level: 1 })).toBeVisible();
+    await expect(page.getByLabel(/name/i).first()).toBeVisible();
+    await expect(page.getByLabel(/email/i).first()).toBeVisible();
+    await expect(page.getByLabel(/message/i).first()).toBeVisible();
+    await expect(
+      page.getByRole("button", { name: /send|submit/i })
+    ).toBeVisible();
   });
 
-  test("can access legal pages", async ({ page }) => {
-    await page.goto("/privacy");
-    expect(page.url()).toContain("privacy");
+  test("contact form submit posts to /api/contact and shows success", async ({ page }) => {
+    await page.route("**/api/contact", (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ ok: true, eventId: "test-event" }),
+      })
+    );
+
+    await page.goto("/contact");
+    await page.getByLabel(/name/i).first().fill("Playwright User");
+    await page.getByLabel(/email/i).first().fill("playwright@example.com");
+    await page.getByLabel(/message/i).first().fill("Hello from the e2e suite.");
+    await page
+      .getByLabel(/agree|consent|privacy/i)
+      .first()
+      .check();
+    await page.getByRole("button", { name: /send|submit/i }).click();
+
+    await expect(page.getByText(/sent successfully|thank you/i)).toBeVisible();
+  });
+
+  test("legal pages render with a heading", async ({ page }) => {
+    for (const path of ["/privacy", "/terms", "/cookies"]) {
+      await page.goto(path);
+      await expect(page).toHaveURL(new RegExp(path));
+      await expect(page.getByRole("heading", { level: 1 })).toBeVisible();
+    }
   });
 });

--- a/e2e/customer-journey.spec.ts
+++ b/e2e/customer-journey.spec.ts
@@ -1,33 +1,33 @@
 import { test, expect } from "@playwright/test";
 
 test.describe("Customer Journey", () => {
-  test("can navigate homepage", async ({ page }) => {
+  test("homepage shows hero heading and main landmark", async ({ page }) => {
     await page.goto("/");
-    const main = await page.locator("main").count();
-    expect(main).toBeGreaterThan(0);
+    await expect(page).toHaveTitle(/cloudless/i);
+    await expect(page.locator("main")).toBeVisible();
+    await expect(page.getByRole("heading", { level: 1 })).toBeVisible();
   });
 
-  test("can view services page", async ({ page }) => {
+  test("services page renders an h1", async ({ page }) => {
     await page.goto("/services");
-    const content = await page.locator("body").textContent();
-    expect(content).toBeTruthy();
+    await expect(page.getByRole("heading", { level: 1 })).toBeVisible();
   });
 
-  test("can view store/products", async ({ page }) => {
+  test("store page renders an h1", async ({ page }) => {
     await page.goto("/store");
-    const content = await page.locator("body").textContent();
-    expect(content).toBeTruthy();
+    await expect(page.getByRole("heading", { level: 1 })).toBeVisible();
   });
 
-  test("can view blog", async ({ page }) => {
+  test("blog page renders an h1", async ({ page }) => {
     await page.goto("/blog");
-    const content = await page.locator("body").textContent();
-    expect(content).toBeTruthy();
+    await expect(page.getByRole("heading", { level: 1 })).toBeVisible();
   });
 
-  test("can view contact page", async ({ page }) => {
+  test("contact page renders the form", async ({ page }) => {
     await page.goto("/contact");
-    const forms = await page.locator("form").count();
-    expect(forms).toBeGreaterThanOrEqual(0);
+    await expect(page.getByRole("heading", { level: 1 })).toBeVisible();
+    await expect(
+      page.getByRole("button", { name: /send|submit/i })
+    ).toBeVisible();
   });
 });

--- a/e2e/dashboard.spec.ts
+++ b/e2e/dashboard.spec.ts
@@ -3,14 +3,17 @@ import { test, expect } from "@playwright/test";
 test.describe("Dashboard", () => {
   test("login page is accessible", async ({ page }) => {
     await page.goto("/auth/login");
-    const emailInput = await page.locator('input[type="email"], input[name="email"]').count();
-    expect(emailInput).toBeGreaterThan(0);
+    await expect(page).toHaveURL(/\/auth\/login/);
+    await expect(page.getByLabel(/email/i)).toBeVisible();
+    await expect(page.getByLabel(/password/i).first()).toBeVisible();
   });
 
-  test("dashboard urls exist", async ({ page }) => {
-    await page.goto("/dashboard").catch(() => {
-      // Might redirect to login
-    });
-    expect(page.url()).toBeTruthy();
+  test("/dashboard redirects unauthenticated users to login", async ({ page }) => {
+    await page.goto("/dashboard");
+    // Without an auth session the AuthContext gate either keeps users on
+    // /dashboard with a sign-in CTA or redirects to /auth/login. Either is
+    // acceptable; what matters is that no unauth user sees private content.
+    await expect(page).toHaveURL(/\/auth\/login|\/dashboard/);
+    await expect(page.locator("body")).toBeVisible();
   });
 });

--- a/e2e/mobile-responsive.spec.ts
+++ b/e2e/mobile-responsive.spec.ts
@@ -1,15 +1,28 @@
-import { test, expect, devices } from "@playwright/test";
+import { test, expect } from "@playwright/test";
 
 test.describe("Mobile & Responsive", () => {
-  test("homepage is responsive on mobile", async ({ page }) => {
+  test("homepage main and h1 are visible on the active viewport", async ({ page }) => {
     await page.goto("/");
-    const main = await page.locator("main").count();
-    expect(main).toBeGreaterThanOrEqual(0);
+    await expect(page.locator("main")).toBeVisible();
+    await expect(page.getByRole("heading", { level: 1 })).toBeVisible();
   });
 
-  test("buttons are visible on desktop", async ({ page }) => {
+  test("homepage exposes at least one navigable link", async ({ page }) => {
     await page.goto("/");
-    const buttons = await page.locator("button").count();
-    expect(buttons).toBeGreaterThan(0);
+    const links = page.getByRole("link");
+    await expect(links.first()).toBeVisible();
+    expect(await links.count()).toBeGreaterThan(0);
+  });
+
+  test("footer contact link reaches the contact page", async ({ page }) => {
+    await page.goto("/");
+    // The footer link is rendered last and is visible on every viewport
+    // (no hamburger gating it on mobile).
+    await page
+      .getByRole("link", { name: /contact/i })
+      .last()
+      .scrollIntoViewIfNeeded();
+    await page.getByRole("link", { name: /contact/i }).last().click();
+    await expect(page).toHaveURL(/\/contact/);
   });
 });

--- a/e2e/performance.spec.ts
+++ b/e2e/performance.spec.ts
@@ -1,16 +1,16 @@
 import { test, expect } from "@playwright/test";
 
 test.describe("Performance & Loading", () => {
-  test("page loads within reasonable time", async ({ page }) => {
+  test("homepage reaches networkidle within 15s", async ({ page }) => {
     const startTime = Date.now();
     await page.goto("/", { waitUntil: "networkidle" });
     const loadTime = Date.now() - startTime;
-    expect(loadTime).toBeLessThan(15000);
+    expect(loadTime).toBeLessThan(15_000);
   });
 
-  test("images are present on page", async ({ page }) => {
+  test("homepage renders meaningful content (h1 and links)", async ({ page }) => {
     await page.goto("/");
-    const images = await page.locator("img").count();
-    expect(images).toBeGreaterThanOrEqual(0);
+    await expect(page.getByRole("heading", { level: 1 })).toBeVisible();
+    expect(await page.getByRole("link").count()).toBeGreaterThan(0);
   });
 });


### PR DESCRIPTION
## Summary
- Replaces shape-only Playwright assertions (`locator("input").count() > 0`, `body.textContent()`, `images >= 0`) with role/label-based locators and real URL/title checks, matching the patterns prescribed in `vitest-playwright.skill`.
- Adds a mocked `/api/contact` flow that fills the form via `getByLabel` and verifies the success state, and tightens `/api/health` to assert `200` + JSON shape instead of `[200, 404]`.
- Removes flaky cross-viewport assertions on header CTAs (hidden behind the mobile hamburger) by clicking the footer Contact link, which is reachable on every viewport.

## Files changed
- `e2e/api-auth.spec.ts` — assert `200` + `{ status: "ok", timestamp, version }`.
- `e2e/auth.spec.ts` — `getByLabel(/email|password|name/)`, real URL assertions, new "forgot-password reachable from login" case.
- `e2e/contact-integrations.spec.ts` — verify documented form fields, mock `POST /api/contact`, walk privacy/terms/cookies.
- `e2e/customer-journey.spec.ts` — `getByRole("heading", { level: 1 })` per page; target submit button instead of strict-mode-violating `form` locator.
- `e2e/dashboard.spec.ts` — assert URL is either `/auth/login` or `/dashboard` (no auth session).
- `e2e/mobile-responsive.spec.ts` — viewport-agnostic footer CTA click.
- `e2e/performance.spec.ts` — replace `images >= 0` with role-based content checks.

## Test plan
- [x] `pnpm exec playwright test` — 160 tests pass (chromium + mobile-chrome).
- [x] `pnpm exec playwright test --project=chromium` — passes.
- [ ] CI run on this PR.

https://claude.ai/code/session_01JopzE7ji9yjFrmDahZDE8B

---
_Generated by [Claude Code](https://claude.ai/code/session_01JopzE7ji9yjFrmDahZDE8B)_