### PR TITLE
feat(sst): Route 53 failover routing for cloudless.gr (primary CF / secondary Pi)

### DIFF
--- a/scripts/migrate-route53-failover.sh
+++ b/scripts/migrate-route53-failover.sh
@@ -1,0 +1,223 @@
+#!/usr/bin/env bash
+# migrate-route53-failover.sh
+#
+# One-shot, idempotent-ish migration: convert the simple alias records on
+# cloudless.gr / www.cloudless.gr (apex+www, A+AAAA, currently managed by SST
+# via sst.aws.dns()) into Route 53 failover records (PRIMARY=CloudFront,
+# SECONDARY=Pi WAN). Performed as a SINGLE atomic
+# `change-resource-record-sets` call so there is zero DNS gap.
+#
+# Run this ONCE, manually, BEFORE merging PR #90 + running `sst deploy`.
+# After this script succeeds, SST's `aws.route53.Record` resources in
+# sst.config.ts (with `import:` directives) will adopt the records on first
+# deploy and reconcile them thereafter. No drift.
+#
+# Pi has no IPv6, so AAAA SECONDARY is intentionally omitted. While the
+# primary is healthy, AAAA resolves normally; if the primary fails, IPv6
+# clients get NXDOMAIN/SERVFAIL on AAAA but A still flips to the Pi v4 IP,
+# and most dual-stack clients fall back to v4.
+#
+# Records before (4):
+#   cloudless.gr        A    -> alias d3k7muo3c6lw6s.cloudfront.net (simple)
+#   cloudless.gr        AAAA -> alias d3k7muo3c6lw6s.cloudfront.net (simple)
+#   www.cloudless.gr    A    -> alias dgrxxatzrgxfi.cloudfront.net (simple)
+#   www.cloudless.gr    AAAA -> alias dgrxxatzrgxfi.cloudfront.net (simple)
+#
+# Records after (6):
+#   cloudless.gr        A    primary   alias d3k7muo3c6lw6s.cloudfront.net  + healthcheck
+#   cloudless.gr        A    secondary 150.228.63.192 (TTL 60)
+#   cloudless.gr        AAAA primary   alias d3k7muo3c6lw6s.cloudfront.net  + healthcheck
+#   www.cloudless.gr    A    primary   alias dgrxxatzrgxfi.cloudfront.net   + healthcheck
+#   www.cloudless.gr    A    secondary 150.228.63.192 (TTL 60)
+#   www.cloudless.gr    AAAA primary   alias dgrxxatzrgxfi.cloudfront.net   + healthcheck
+#
+# Cost impact: $0 (Route 53 records are billed per query, not per record).
+
+set -euo pipefail
+
+ZONE_ID="Z079608614L53CC4EAZM3"
+HEALTH_CHECK_ID="e239ad5c-dd17-40d7-8045-a153715168cf"
+CF_ZONE_ID="Z2FDTNDATAQYW2"
+APEX_CF="d3k7muo3c6lw6s.cloudfront.net"
+WWW_CF="dgrxxatzrgxfi.cloudfront.net"
+PI_WAN_IP="150.228.63.192"
+PROFILE="${AWS_PROFILE:-cloudless}"
+
+echo "==> Verifying current zone state on $ZONE_ID..."
+aws --profile "$PROFILE" route53 list-resource-record-sets \
+  --hosted-zone-id "$ZONE_ID" \
+  --query "ResourceRecordSets[?(Name=='cloudless.gr.'||Name=='www.cloudless.gr.') && (Type=='A'||Type=='AAAA')]" \
+  > /tmp/r53-pre-migration.json
+echo "    Pre-migration state saved to /tmp/r53-pre-migration.json"
+cat /tmp/r53-pre-migration.json
+
+# Sanity-check: refuse to run if records are already failover-style
+if grep -q '"SetIdentifier"' /tmp/r53-pre-migration.json; then
+  echo "ERROR: At least one record already has a SetIdentifier (failover-style)."
+  echo "       Migration appears to have been run already. Aborting to be safe."
+  exit 1
+fi
+
+CHANGE_BATCH=$(cat <<JSON
+{
+  "Comment": "Migrate cloudless.gr apex+www A/AAAA from simple alias to failover (PRIMARY=CloudFront, SECONDARY=Pi). Atomic.",
+  "Changes": [
+    {
+      "Action": "DELETE",
+      "ResourceRecordSet": {
+        "Name": "cloudless.gr.",
+        "Type": "A",
+        "AliasTarget": {
+          "HostedZoneId": "$CF_ZONE_ID",
+          "DNSName": "$APEX_CF.",
+          "EvaluateTargetHealth": true
+        }
+      }
+    },
+    {
+      "Action": "DELETE",
+      "ResourceRecordSet": {
+        "Name": "cloudless.gr.",
+        "Type": "AAAA",
+        "AliasTarget": {
+          "HostedZoneId": "$CF_ZONE_ID",
+          "DNSName": "$APEX_CF.",
+          "EvaluateTargetHealth": true
+        }
+      }
+    },
+    {
+      "Action": "DELETE",
+      "ResourceRecordSet": {
+        "Name": "www.cloudless.gr.",
+        "Type": "A",
+        "AliasTarget": {
+          "HostedZoneId": "$CF_ZONE_ID",
+          "DNSName": "$WWW_CF.",
+          "EvaluateTargetHealth": true
+        }
+      }
+    },
+    {
+      "Action": "DELETE",
+      "ResourceRecordSet": {
+        "Name": "www.cloudless.gr.",
+        "Type": "AAAA",
+        "AliasTarget": {
+          "HostedZoneId": "$CF_ZONE_ID",
+          "DNSName": "$WWW_CF.",
+          "EvaluateTargetHealth": true
+        }
+      }
+    },
+    {
+      "Action": "CREATE",
+      "ResourceRecordSet": {
+        "Name": "cloudless.gr.",
+        "Type": "A",
+        "SetIdentifier": "primary",
+        "Failover": "PRIMARY",
+        "HealthCheckId": "$HEALTH_CHECK_ID",
+        "AliasTarget": {
+          "HostedZoneId": "$CF_ZONE_ID",
+          "DNSName": "$APEX_CF.",
+          "EvaluateTargetHealth": false
+        }
+      }
+    },
+    {
+      "Action": "CREATE",
+      "ResourceRecordSet": {
+        "Name": "cloudless.gr.",
+        "Type": "A",
+        "SetIdentifier": "secondary",
+        "Failover": "SECONDARY",
+        "TTL": 60,
+        "ResourceRecords": [{"Value": "$PI_WAN_IP"}]
+      }
+    },
+    {
+      "Action": "CREATE",
+      "ResourceRecordSet": {
+        "Name": "cloudless.gr.",
+        "Type": "AAAA",
+        "SetIdentifier": "primary",
+        "Failover": "PRIMARY",
+        "HealthCheckId": "$HEALTH_CHECK_ID",
+        "AliasTarget": {
+          "HostedZoneId": "$CF_ZONE_ID",
+          "DNSName": "$APEX_CF.",
+          "EvaluateTargetHealth": false
+        }
+      }
+    },
+    {
+      "Action": "CREATE",
+      "ResourceRecordSet": {
+        "Name": "www.cloudless.gr.",
+        "Type": "A",
+        "SetIdentifier": "primary",
+        "Failover": "PRIMARY",
+        "HealthCheckId": "$HEALTH_CHECK_ID",
+        "AliasTarget": {
+          "HostedZoneId": "$CF_ZONE_ID",
+          "DNSName": "$WWW_CF.",
+          "EvaluateTargetHealth": false
+        }
+      }
+    },
+    {
+      "Action": "CREATE",
+      "ResourceRecordSet": {
+        "Name": "www.cloudless.gr.",
+        "Type": "A",
+        "SetIdentifier": "secondary",
+        "Failover": "SECONDARY",
+        "TTL": 60,
+        "ResourceRecords": [{"Value": "$PI_WAN_IP"}]
+      }
+    },
+    {
+      "Action": "CREATE",
+      "ResourceRecordSet": {
+        "Name": "www.cloudless.gr.",
+        "Type": "AAAA",
+        "SetIdentifier": "primary",
+        "Failover": "PRIMARY",
+        "HealthCheckId": "$HEALTH_CHECK_ID",
+        "AliasTarget": {
+          "HostedZoneId": "$CF_ZONE_ID",
+          "DNSName": "$WWW_CF.",
+          "EvaluateTargetHealth": false
+        }
+      }
+    }
+  ]
+}
+JSON
+)
+
+echo "$CHANGE_BATCH" > /tmp/r53-failover-change-batch.json
+echo "==> Change batch written to /tmp/r53-failover-change-batch.json"
+
+echo "==> Submitting atomic change..."
+CHANGE_ID=$(aws --profile "$PROFILE" route53 change-resource-record-sets \
+  --hosted-zone-id "$ZONE_ID" \
+  --change-batch "file:///tmp/r53-failover-change-batch.json" \
+  --query 'ChangeInfo.Id' --output text)
+echo "    Change submitted: $CHANGE_ID"
+
+echo "==> Waiting for INSYNC..."
+aws --profile "$PROFILE" route53 wait resource-record-sets-changed --id "$CHANGE_ID"
+echo "    INSYNC."
+
+echo "==> Verifying post-migration state..."
+aws --profile "$PROFILE" route53 list-resource-record-sets \
+  --hosted-zone-id "$ZONE_ID" \
+  --query "ResourceRecordSets[?(Name=='cloudless.gr.'||Name=='www.cloudless.gr.') && (Type=='A'||Type=='AAAA')]" \
+  --output json
+
+echo
+echo "==> Migration complete."
+echo "    Next: merge PR #90, then run 'pnpm sst deploy --stage production'."
+echo "    SST will adopt the records via the 'import:' directives in sst.config.ts."

--- a/sst.config.ts
+++ b/sst.config.ts
@@ -95,61 +95,134 @@ export default {
       const apexCfDomain = "d3k7muo3c6lw6s.cloudfront.net";
       const wwwCfDomain = "dgrxxatzrgxfi.cloudfront.net";
 
-      // Apex — PRIMARY (CloudFront alias)
-      new aws.route53.Record("ApexPrimary", {
-        zoneId,
-        name: "cloudless.gr",
-        type: "A",
-        setIdentifier: "primary",
-        failoverRoutingPolicies: [{ type: "PRIMARY" }],
-        healthCheckId,
-        aliases: [
-          {
-            name: apexCfDomain,
-            zoneId: cfZoneId,
-            evaluateTargetHealth: false,
-          },
-        ],
-      });
+      // IMPORTANT — pre-deploy migration required.
+      // The Route 53 records below are *adopted*, not *created*, on first
+      // deploy. Before merging this PR + running `sst deploy`, the operator
+      // must run `scripts/migrate-route53-failover.sh` to atomically convert
+      // the four pre-existing simple alias records (apex+www × A+AAAA) into
+      // the six failover records declared here. The `import:` resource option
+      // tells Pulumi to read state from R53 instead of creating duplicates
+      // (which would fail with "RRSet already exists"). Pulumi import ID
+      // format for Route 53 records:  ZONEID_NAME_TYPE_SETIDENTIFIER
+      // (underscore-separated).
+      //
+      // Pi has no IPv6, so AAAA SECONDARY is intentionally omitted. While the
+      // primary is healthy, AAAA resolves normally; if the primary fails,
+      // dual-stack clients fall back to v4 via the A SECONDARY.
 
-      // Apex — SECONDARY (Pi A record)
-      new aws.route53.Record("ApexSecondary", {
-        zoneId,
-        name: "cloudless.gr",
-        type: "A",
-        setIdentifier: "secondary",
-        failoverRoutingPolicies: [{ type: "SECONDARY" }],
-        ttl: 60,
-        records: [piWanIp],
-      });
+      // Apex — PRIMARY A (CloudFront alias)
+      new aws.route53.Record(
+        "ApexPrimary",
+        {
+          zoneId,
+          name: "cloudless.gr",
+          type: "A",
+          setIdentifier: "primary",
+          failoverRoutingPolicies: [{ type: "PRIMARY" }],
+          healthCheckId,
+          aliases: [
+            {
+              name: apexCfDomain,
+              zoneId: cfZoneId,
+              evaluateTargetHealth: false,
+            },
+          ],
+        },
+        { import: `${zoneId}_cloudless.gr_A_primary` },
+      );
 
-      // www — PRIMARY (CloudFront alias)
-      new aws.route53.Record("WwwPrimary", {
-        zoneId,
-        name: "www.cloudless.gr",
-        type: "A",
-        setIdentifier: "primary",
-        failoverRoutingPolicies: [{ type: "PRIMARY" }],
-        healthCheckId,
-        aliases: [
-          {
-            name: wwwCfDomain,
-            zoneId: cfZoneId,
-            evaluateTargetHealth: false,
-          },
-        ],
-      });
+      // Apex — SECONDARY A (Pi A record)
+      new aws.route53.Record(
+        "ApexSecondary",
+        {
+          zoneId,
+          name: "cloudless.gr",
+          type: "A",
+          setIdentifier: "secondary",
+          failoverRoutingPolicies: [{ type: "SECONDARY" }],
+          ttl: 60,
+          records: [piWanIp],
+        },
+        { import: `${zoneId}_cloudless.gr_A_secondary` },
+      );
 
-      // www — SECONDARY (Pi A record)
-      new aws.route53.Record("WwwSecondary", {
-        zoneId,
-        name: "www.cloudless.gr",
-        type: "A",
-        setIdentifier: "secondary",
-        failoverRoutingPolicies: [{ type: "SECONDARY" }],
-        ttl: 60,
-        records: [piWanIp],
-      });
+      // Apex — PRIMARY AAAA (CloudFront alias). No SECONDARY — Pi has no v6.
+      new aws.route53.Record(
+        "ApexPrimaryAAAA",
+        {
+          zoneId,
+          name: "cloudless.gr",
+          type: "AAAA",
+          setIdentifier: "primary",
+          failoverRoutingPolicies: [{ type: "PRIMARY" }],
+          healthCheckId,
+          aliases: [
+            {
+              name: apexCfDomain,
+              zoneId: cfZoneId,
+              evaluateTargetHealth: false,
+            },
+          ],
+        },
+        { import: `${zoneId}_cloudless.gr_AAAA_primary` },
+      );
+
+      // www — PRIMARY A (CloudFront alias)
+      new aws.route53.Record(
+        "WwwPrimary",
+        {
+          zoneId,
+          name: "www.cloudless.gr",
+          type: "A",
+          setIdentifier: "primary",
+          failoverRoutingPolicies: [{ type: "PRIMARY" }],
+          healthCheckId,
+          aliases: [
+            {
+              name: wwwCfDomain,
+              zoneId: cfZoneId,
+              evaluateTargetHealth: false,
+            },
+          ],
+        },
+        { import: `${zoneId}_www.cloudless.gr_A_primary` },
+      );
+
+      // www — SECONDARY A (Pi A record)
+      new aws.route53.Record(
+        "WwwSecondary",
+        {
+          zoneId,
+          name: "www.cloudless.gr",
+          type: "A",
+          setIdentifier: "secondary",
+          failoverRoutingPolicies: [{ type: "SECONDARY" }],
+          ttl: 60,
+          records: [piWanIp],
+        },
+        { import: `${zoneId}_www.cloudless.gr_A_secondary` },
+      );
+
+      // www — PRIMARY AAAA (CloudFront alias). No SECONDARY — Pi has no v6.
+      new aws.route53.Record(
+        "WwwPrimaryAAAA",
+        {
+          zoneId,
+          name: "www.cloudless.gr",
+          type: "AAAA",
+          setIdentifier: "primary",
+          failoverRoutingPolicies: [{ type: "PRIMARY" }],
+          healthCheckId,
+          aliases: [
+            {
+              name: wwwCfDomain,
+              zoneId: cfZoneId,
+              evaluateTargetHealth: false,
+            },
+          ],
+        },
+        { import: `${zoneId}_www.cloudless.gr_AAAA_primary` },
+      );
     }
 
     return {

--- a/sst.config.ts
+++ b/sst.config.ts
@@ -1,17 +1,26 @@
-/* global $app, sst */
+/* global $app, sst, aws */
 
 /// <reference path="./.sst/platform/config.d.ts" />
 
 export default {
   app(input) {
+    const stage = input?.stage ?? "";
     return {
       name: "cloudless",
-      removal: input?.stage === "production" ? "retain" : "remove",
-      protect: ["production"].includes(input?.stage ?? ""),
+      removal: stage === "production" ? "retain" : "remove",
+      protect: ["production"].includes(stage),
       home: "aws",
       providers: {
         aws: {
           region: "us-east-1",
+          defaultTags: {
+            tags: {
+              Project: "cloudless",
+              Environment: stage || "unknown",
+              Owner: "tbaltzakis",
+              ManagedBy: "sst",
+            },
+          },
         },
       },
     };
@@ -25,11 +34,15 @@ export default {
     const isProd = stage === "production";
 
     const site = new sst.aws.Nextjs("CloudlessSite", {
-      // Domain: cloudless.gr with existing Route53 zone + ACM cert
+      // Domain: cloudless.gr with existing Route53 zone + ACM cert.
+      // dns: false — we manage Route 53 records explicitly below to support
+      // failover routing (PRIMARY=CloudFront, SECONDARY=Pi). If we left this
+      // as `sst.aws.dns()`, SST would create plain alias records and clobber
+      // the failover SetIdentifier on every deploy.
       domain: {
         name: isProd ? "cloudless.gr" : `${stage}.cloudless.gr`,
         redirects: isProd ? ["www.cloudless.gr"] : [],
-        dns: sst.aws.dns(),
+        dns: false,
         cert: "arn:aws:acm:us-east-1:278585680617:certificate/f505905a-97b4-46b0-a2b0-fb1900f425b2",
       },
       environment: {
@@ -62,6 +75,82 @@ export default {
         wait: true,
       },
     });
+
+    // ---------------------------------------------------------------------
+    // Route 53 failover records (production only)
+    // ---------------------------------------------------------------------
+    // Architecture: cloudless.gr is dual-homed.
+    //   - PRIMARY: CloudFront distributions (this SST stack), health-checked
+    //     against https://cloudless.gr/api/health
+    //   - SECONDARY: Pi 5 standby at WAN 150.228.63.192 (cloudless.online HA)
+    //
+    // Route 53 returns the primary while it's healthy and flips to the
+    // secondary when the health check fails. CloudFront's hosted zone ID is
+    // the well-known constant Z2FDTNDATAQYW2 for all alias records.
+    if (isProd) {
+      const zoneId = "Z079608614L53CC4EAZM3"; // cloudless.gr hosted zone
+      const healthCheckId = "e239ad5c-dd17-40d7-8045-a153715168cf";
+      const piWanIp = "150.228.63.192";
+      const cfZoneId = "Z2FDTNDATAQYW2";
+      const apexCfDomain = "d3k7muo3c6lw6s.cloudfront.net";
+      const wwwCfDomain = "dgrxxatzrgxfi.cloudfront.net";
+
+      // Apex — PRIMARY (CloudFront alias)
+      new aws.route53.Record("ApexPrimary", {
+        zoneId,
+        name: "cloudless.gr",
+        type: "A",
+        setIdentifier: "primary",
+        failoverRoutingPolicies: [{ type: "PRIMARY" }],
+        healthCheckId,
+        aliases: [
+          {
+            name: apexCfDomain,
+            zoneId: cfZoneId,
+            evaluateTargetHealth: false,
+          },
+        ],
+      });
+
+      // Apex — SECONDARY (Pi A record)
+      new aws.route53.Record("ApexSecondary", {
+        zoneId,
+        name: "cloudless.gr",
+        type: "A",
+        setIdentifier: "secondary",
+        failoverRoutingPolicies: [{ type: "SECONDARY" }],
+        ttl: 60,
+        records: [piWanIp],
+      });
+
+      // www — PRIMARY (CloudFront alias)
+      new aws.route53.Record("WwwPrimary", {
+        zoneId,
+        name: "www.cloudless.gr",
+        type: "A",
+        setIdentifier: "primary",
+        failoverRoutingPolicies: [{ type: "PRIMARY" }],
+        healthCheckId,
+        aliases: [
+          {
+            name: wwwCfDomain,
+            zoneId: cfZoneId,
+            evaluateTargetHealth: false,
+          },
+        ],
+      });
+
+      // www — SECONDARY (Pi A record)
+      new aws.route53.Record("WwwSecondary", {
+        zoneId,
+        name: "www.cloudless.gr",
+        type: "A",
+        setIdentifier: "secondary",
+        failoverRoutingPolicies: [{ type: "SECONDARY" }],
+        ttl: 60,
+        records: [piWanIp],
+      });
+    }
 
     return {
       url: site.url,


### PR DESCRIPTION
## Summary

Dual-home `cloudless.gr` across CloudFront (primary) and the Pi 5 standby
on `cloudless.online` (secondary, WAN `150.228.63.192`) using Route 53
**failover routing** anchored on the existing health check
`e239ad5c-dd17-40d7-8045-a153715168cf` (`HTTPS GET cloudless.gr/api/health`,
30s, threshold 3, currently healthy across all 16 R53 checker regions).

Bundles three steps of the cloudless HA build:

- **2.3** Primary failover record (CloudFront alias, healthCheckId)
- **2.4** Secondary failover record (A → Pi WAN IP)
- **4.1** Provider-level `defaultTags` on the AWS provider

## Why bundled into one PR

`sst.aws.dns()` has no failover-routing surface. If we hand-applied the
failover records via `aws-cli` and left `dns: sst.aws.dns()` in the SST
config, the next `sst deploy` would silently revert them to plain alias
records (drift). The fix is to set `dns: false` and declare the four
Route 53 records explicitly in `sst.config.ts`, alongside the tags work
that also lives in this same provider block.

## Changes (`sst.config.ts`)

1. `providers.aws.defaultTags`:
   - `Project=cloudless`, `Environment=<stage>`, `Owner=tbaltzakis`, `ManagedBy=sst`
   - Note: Route 53 record sets are not taggable by AWS design — Lambda,
     CloudFront, S3, etc pick up these tags automatically.
2. `domain.dns: false` on the `Nextjs` site (was `sst.aws.dns()`).
3. Four `aws.route53.Record` resources, production-only (gated by `if (isProd)`):

| Logical name      | Name              | Type | SetId    | Failover  | Target                                 | HealthCheck |
|-------------------|-------------------|------|----------|-----------|----------------------------------------|-------------|
| `ApexPrimary`     | `cloudless.gr`    | A    | primary  | PRIMARY   | alias `d3k7muo3c6lw6s.cloudfront.net`  | yes         |
| `ApexSecondary`   | `cloudless.gr`    | A    | secondary| SECONDARY | `150.228.63.192` (TTL 60)              | no          |
| `WwwPrimary`      | `www.cloudless.gr`| A    | primary  | PRIMARY   | alias `dgrxxatzrgxfi.cloudfront.net`   | yes         |
| `WwwSecondary`    | `www.cloudless.gr`| A    | secondary| SECONDARY | `150.228.63.192` (TTL 60)              | no          |

CloudFront alias zone ID is the well-known constant `Z2FDTNDATAQYW2`.

## Pre-merge checklist (flagged guesses to verify)

These are values I extrapolated; please confirm before merging:

- [ ] **`dns: false` syntax.** Per SST v3 docs `dns` accepts `false` to
      disable record management. If this stage of SST rejects literal
      `false`, swap to omitting the `dns` key and adding
      `// @ts-expect-error` if needed, or use `dns: undefined`.
- [ ] **`failoverRoutingPolicies` shape on the Pulumi/Terraform AWS
      provider that SST wraps.** I used the array form
      `[{ type: "PRIMARY" }]`. If the provider expects the singular
      `failoverRoutingPolicy: { type: "PRIMARY" }`, rename and re-run
      `sst diff`.
- [ ] **No conflicting existing apex/www records.** SST currently
      manages `cloudless.gr` + `www.cloudless.gr` A aliases via
      `sst.aws.dns()`. After flipping to `dns: false`, `sst deploy` will
      try to *create* the new failover records; if R53 still has the
      old plain aliases owned by SST state, the create will fail with
      `RRSet already exists`. Two options:
        a. Delete the old records in R53 first, then deploy.
        b. Run `sst refresh` so SST drops them from state, then deploy.

## Test plan

- [ ] `pnpm sst diff --stage production` — review the four new
      `aws:route53:Record` adds and the deletion of the SST-managed
      plain alias records.
- [ ] `pnpm sst deploy --stage production`.
- [ ] `aws --profile cloudless route53 list-resource-record-sets --hosted-zone-id Z079608614L53CC4EAZM3 --query "ResourceRecordSets[?Name=='cloudless.gr.'||Name=='www.cloudless.gr.']"`
      — expect 4 records, two SetIdentifiers per name, primary has
      HealthCheckId, secondary doesn't.
- [ ] `dig +short cloudless.gr A` — should resolve to a CloudFront IP
      while primary is healthy.
- [ ] **Failover test** (orchestrator step 2.5):
      temporarily break `/api/health` on the primary, watch
      `dig +short cloudless.gr A` flip to `150.228.63.192` within ~90s,
      restore primary, watch it flip back.

## Hard rules respected

- No EC2 introduced.
- Cost impact: $0 (Route 53 records are billed per query, no per-record
  fee; the health check at $0.50/mo was billed in step 2.2).
- `Project=cloudless` tags via `defaultTags`.

## Cross-references

- State file: `/home/tbaltzakis/cloudless-build-state.md` — steps 2.3,
  2.4, 4.1 to flip IN-PROGRESS on PR open, DONE on merge+deploy.
- Decision log entry `2026-05-02: SST-failover-PR pivot`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)