### PR TITLE
chore(sonarcloud): narrow analysis scope to src/

### DIFF
--- a/.sonarcloud.properties
+++ b/.sonarcloud.properties
@@ -1,7 +1,15 @@
 # SonarCloud configuration
 # https://docs.sonarcloud.io/advanced-setup/analysis-parameters/
 
+# Restrict source analysis to the actual application sources.
+# This prevents SonarCloud from counting large repository files,
+# generated content, and non-source directories toward the org-wide line limit.
+sonar.sources=src
+
 # Exclude test files from Copy-Paste Detection (CPD).
 # Test suites intentionally repeat describe/it/expect/vi.mock patterns
 # across multiple files — this is not meaningful duplication.
 sonar.cpd.exclusions=**/__tests__/**,**/*.test.ts,**/*.test.tsx,**/*.spec.ts,**/*.spec.tsx
+
+# Exclude non-source directories and support files from analysis.
+sonar.exclusions=**/node_modules/**,**/.next/**,**/dist/**,**/public/**,**/docs/**,**/scripts/**,**/.github/**,**/*.lock,**/*.yml,**/*.yaml,**/*.md,**/*.json


### PR DESCRIPTION
## Summary
- Set \`sonar.sources=src\` so SonarCloud's line count reflects actual app code, not the whole repo (helps stay under the org-wide line limit).
- Add \`sonar.exclusions\` for generated/support paths: \`node_modules\`, \`.next\`, \`dist\`, \`public\`, \`docs\`, \`scripts\`, \`.github\`, lockfiles, YAML, Markdown, JSON.
- Existing CPD exclusion for test files preserved.

## Test plan
- [ ] CI Build check passes
- [ ] Next SonarCloud analysis on this PR shows reduced line count and no new false-positive issues from outside \`src/\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)