### PR TITLE
ci: extend path filter so Build runs on root-config PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,15 @@ on:
       - 'tsconfig.json'
       - 'mcp.json'
       - '.github/workflows/**'
+      # Root-level config that affects build/lint/quality gates.
+      # Without these, PRs editing only these files hang on the required
+      # "Build" check because CI never triggers.
+      - '.codacy/**'
+      - '.sonarcloud.properties'
+      - '.eslintrc*'
+      - 'eslint.config.*'
+      - '.prettierrc*'
+      - 'prettier.config.*'
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true


### PR DESCRIPTION
## Summary
- Branch protection requires the \`Build\` check, but \`ci.yml\` only triggers when specific paths change. PRs editing only root-level config (\`.codacy/**\`, \`.sonarcloud.properties\`, \`.eslintrc*\`, etc.) never trigger \`Build\` and therefore can't merge — see the deadlock on PRs #97 and #98.
- Extends the \`pull_request.paths\` filter so config-only changes also trigger CI.

## Test plan
- [ ] This PR itself touches \`.github/workflows/**\` (already in the filter), so CI \`Build\` should fire and pass.
- [ ] After merge, rebase or push #97 / #98; verify \`Build\` runs on those config-only PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)