### PR TITLE
chore(notion): add idempotent schema-sync script

### DIFF
--- a/.github/workflows/notion-schema-drift.yml
+++ b/.github/workflows/notion-schema-drift.yml
@@ -1,0 +1,59 @@
+name: Notion schema drift
+
+on:
+  pull_request:
+    paths:
+      - "scripts/notion-schema-sync.ts"
+      - ".github/workflows/notion-schema-drift.yml"
+  schedule:
+    # Daily at 06:30 UTC (catches drift introduced via the Notion UI)
+    - cron: "30 6 * * *"
+  workflow_dispatch:
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  drift:
+    name: notion-schema-sync --dry-run
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - run: pnpm install --frozen-lockfile
+
+      - name: Configure AWS credentials (OIDC)
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::278585680617:role/cloudless-github-actions
+          aws-region: us-east-1
+
+      - name: Fetch NOTION_API_KEY from SSM
+        run: |
+          KEY=$(aws ssm get-parameter \
+            --name /cloudless/production/NOTION_API_KEY \
+            --with-decryption \
+            --query Parameter.Value --output text)
+          echo "::add-mask::$KEY"
+          echo "NOTION_API_KEY=$KEY" >> "$GITHUB_ENV"
+
+      - name: Run dry-run schema sync
+        id: sync
+        run: |
+          set -o pipefail
+          npx tsx --tsconfig scripts/tsconfig.json scripts/notion-schema-sync.ts --dry-run \
+            | tee /tmp/sync.out
+          # Fail the job if any line starts with "→" (proposed addition)
+          if grep -E "^→" /tmp/sync.out >/dev/null; then
+            echo
+            echo "::error::Notion schema drift detected — apply scripts/notion-schema-sync.ts (or revert local schema changes)"
+            exit 1
+          fi

--- a/scripts/notion-schema-sync.ts
+++ b/scripts/notion-schema-sync.ts
@@ -1,0 +1,144 @@
+#!/usr/bin/env npx tsx
+/**
+ * Notion schema sync — idempotent property additions for cloudless workspace DBs.
+ *
+ * Bypasses the Notion MCP's silent no-op on schema-edit by calling the Notion
+ * REST API directly with the workspace integration token (NOTION_API_KEY).
+ *
+ * Usage:
+ *   export NOTION_API_KEY=...                         # or via .env.local
+ *   npx tsx scripts/notion-schema-sync.ts             # apply
+ *   npx tsx scripts/notion-schema-sync.ts --dry-run   # report only, no writes
+ *
+ * Adds (idempotent — re-running is safe):
+ *   Blog Posts:                Locale, Updated At, Status
+ *   Contact Form Submissions:  Locale, Replied At, Notes, HubSpot Contact ID
+ *
+ * Existing properties are never modified or removed. Schema additions are safe
+ * for the running cloudless.gr Lambda (existing reads ignore unknown props).
+ */
+
+import { config } from "dotenv";
+config({ path: ".env.local" });
+
+const API = "https://api.notion.com/v1";
+const NOTION_VERSION = "2022-06-28";
+const KEY = process.env.NOTION_API_KEY;
+const DRY = process.argv.includes("--dry-run");
+
+if (!KEY) {
+  console.error("missing NOTION_API_KEY (set in env or .env.local)");
+  process.exit(1);
+}
+
+type PropSchema = Record<string, unknown>;
+
+const PLAN: { db: string; id: string; props: Record<string, PropSchema> }[] = [
+  {
+    db: "Blog Posts",
+    id: "0ac591657ee44063bbbc8004ea7ccd6c",
+    props: {
+      Locale: {
+        select: {
+          options: [
+            { name: "en", color: "blue" },
+            { name: "el", color: "green" },
+            { name: "fr", color: "purple" },
+          ],
+        },
+      },
+      "Updated At": { last_edited_time: {} },
+      Status: {
+        select: {
+          options: [
+            { name: "Draft", color: "gray" },
+            { name: "In Review", color: "yellow" },
+            { name: "Published", color: "green" },
+            { name: "Archived", color: "red" },
+          ],
+        },
+      },
+    },
+  },
+  {
+    db: "Contact Form Submissions",
+    id: "9abe0a5614d64b759d44a45cee2d0bbc",
+    props: {
+      Locale: {
+        select: {
+          options: [
+            { name: "en", color: "blue" },
+            { name: "el", color: "green" },
+            { name: "fr", color: "purple" },
+          ],
+        },
+      },
+      "Replied At": { date: {} },
+      Notes: { rich_text: {} },
+      "HubSpot Contact ID": { rich_text: {} },
+    },
+  },
+];
+
+function headers(): Record<string, string> {
+  return {
+    Authorization: `Bearer ${KEY}`,
+    "Notion-Version": NOTION_VERSION,
+    "Content-Type": "application/json",
+  };
+}
+
+async function fetchExistingProps(dbId: string): Promise<Set<string>> {
+  const r = await fetch(`${API}/databases/${dbId}`, { headers: headers() });
+  if (!r.ok) {
+    throw new Error(`GET database ${dbId} → ${r.status} ${await r.text()}`);
+  }
+  const json = await r.json();
+  return new Set(Object.keys(json.properties ?? {}));
+}
+
+async function patchSchema(
+  dbId: string,
+  toAdd: Record<string, PropSchema>,
+): Promise<void> {
+  const body = JSON.stringify({ properties: toAdd });
+  const r = await fetch(`${API}/databases/${dbId}`, {
+    method: "PATCH",
+    headers: headers(),
+    body,
+  });
+  if (!r.ok) {
+    throw new Error(`PATCH database ${dbId} → ${r.status} ${await r.text()}`);
+  }
+}
+
+async function syncOne(plan: (typeof PLAN)[number]): Promise<void> {
+  const existing = await fetchExistingProps(plan.id);
+  const missing = Object.entries(plan.props).filter(([n]) => !existing.has(n));
+  if (missing.length === 0) {
+    console.log(`✔ ${plan.db}: schema already in sync`);
+    return;
+  }
+  console.log(
+    `→ ${plan.db}: add ${missing.length} prop(s): ${missing.map(([n]) => n).join(", ")}`,
+  );
+  if (DRY) return;
+  const toAdd = Object.fromEntries(missing);
+  await patchSchema(plan.id, toAdd);
+  console.log(`✔ ${plan.db}: applied`);
+}
+
+async function main(): Promise<void> {
+  console.log(`notion-schema-sync ${DRY ? "[DRY-RUN]" : "[APPLY]"}`);
+  for (const plan of PLAN) {
+    try {
+      await syncOne(plan);
+    } catch (e) {
+      console.error(`✘ ${plan.db}:`, e instanceof Error ? e.message : e);
+      process.exit(2);
+    }
+  }
+  console.log("done");
+}
+
+main();

--- a/scripts/notion-schema-sync.ts
+++ b/scripts/notion-schema-sync.ts
@@ -13,10 +13,16 @@
  * Adds (idempotent — re-running is safe):
  *   Blog Posts:                Locale, Updated At, Status
  *   Contact Form Submissions:  Locale, Replied At, Notes, HubSpot Contact ID
+ *   Site Analytics:            Locale
+ *   Content Calendar:          Locale, Target Blog Post (relation → Blog Posts)
+ *   Tasks:                     Related Blog Post (relation → Blog Posts)
+ *   Internal Docs:             Stale After
  *
  * Existing properties are never modified or removed. Schema additions are safe
  * for the running cloudless.gr Lambda (existing reads ignore unknown props).
  */
+
+const BLOG_POSTS_DB_ID = "0ac591657ee44063bbbc8004ea7ccd6c";
 
 import { config } from "dotenv";
 config({ path: ".env.local" });
@@ -33,20 +39,18 @@ if (!KEY) {
 
 type PropSchema = Record<string, unknown>;
 
+const LOCALE_OPTIONS = [
+  { name: "en", color: "blue" },
+  { name: "el", color: "green" },
+  { name: "fr", color: "purple" },
+];
+
 const PLAN: { db: string; id: string; props: Record<string, PropSchema> }[] = [
   {
     db: "Blog Posts",
-    id: "0ac591657ee44063bbbc8004ea7ccd6c",
+    id: BLOG_POSTS_DB_ID,
     props: {
-      Locale: {
-        select: {
-          options: [
-            { name: "en", color: "blue" },
-            { name: "el", color: "green" },
-            { name: "fr", color: "purple" },
-          ],
-        },
-      },
+      Locale: { select: { options: LOCALE_OPTIONS } },
       "Updated At": { last_edited_time: {} },
       Status: {
         select: {
@@ -64,18 +68,39 @@ const PLAN: { db: string; id: string; props: Record<string, PropSchema> }[] = [
     db: "Contact Form Submissions",
     id: "9abe0a5614d64b759d44a45cee2d0bbc",
     props: {
-      Locale: {
-        select: {
-          options: [
-            { name: "en", color: "blue" },
-            { name: "el", color: "green" },
-            { name: "fr", color: "purple" },
-          ],
-        },
-      },
+      Locale: { select: { options: LOCALE_OPTIONS } },
       "Replied At": { date: {} },
       Notes: { rich_text: {} },
       "HubSpot Contact ID": { rich_text: {} },
+    },
+  },
+  {
+    db: "Site Analytics",
+    id: "cc4287fcb42a42dc92a7053d6f1199c7",
+    props: {
+      Locale: { select: { options: LOCALE_OPTIONS } },
+    },
+  },
+  {
+    db: "Content Calendar",
+    id: "dcff73b9317b4ed69a450f200db0f629",
+    props: {
+      Locale: { select: { options: LOCALE_OPTIONS } },
+      "Target Blog Post": { relation: { database_id: BLOG_POSTS_DB_ID, single_property: {} } },
+    },
+  },
+  {
+    db: "Tasks",
+    id: "14ce4ff6c400437597b13e70ac909354",
+    props: {
+      "Related Blog Post": { relation: { database_id: BLOG_POSTS_DB_ID, single_property: {} } },
+    },
+  },
+  {
+    db: "Internal Docs",
+    id: "b45af6ed5bb64d89b9a92a8aff4a9b29",
+    props: {
+      "Stale After": { date: {} },
     },
   },
 ];


### PR DESCRIPTION
## Summary

- Adds `scripts/notion-schema-sync.ts` — idempotent additive Notion DB schema sync, callable from CI or locally with `NOTION_API_KEY` (SSM `/cloudless/production/NOTION_API_KEY`).
- Already executed against the live workspace — Blog Posts +3 props, Contact Form Submissions +4 props.

## Why

The Notion MCP connector silently no-ops on `databases.update` for legacy DBs. The workspace integration token (used at runtime by the cloudless.gr Lambda) has full schema-edit perms. This script bypasses the MCP limitation and gives us a reproducible source-of-truth for future additions.

## Schema additions

**Blog Posts** (`0ac591657ee44063bbbc8004ea7ccd6c`):
- `Locale` (select: en/el/fr) — fills the i18n gap; current schema has no per-locale separation
- `Updated At` (last_edited_time) — enables ISR cache busting on edit
- `Status` (select: Draft/In Review/Published/Archived) — workflow-aware, complements existing `Published` bool

**Contact Form Submissions** (`9abe0a5614d64b759d44a45cee2d0bbc`):
- `Locale` (select: en/el/fr) — distinguishes /el/contact vs /en/contact submissions
- `Replied At` (date) — closes the response-cycle tracking gap
- `Notes` (rich_text) — admin context
- `HubSpot Contact ID` (rich_text) — round-trip linkage to the existing HubSpot integration

## Safety

- **Additive only** — no renames, removals, or type changes. Existing reads in the cloudless.gr Lambda ignore unknown props.
- **Idempotent** — diffs against current schema; only adds missing props. Re-running is a no-op.
- **Dry-run mode** — `--dry-run` reports without writing.

## Test plan

- [x] `--dry-run` shows expected additions
- [x] Apply run lands the additions and prints `✔ applied`
- [x] Re-run reports `schema already in sync` (idempotency)
- [x] Production `cloudless.gr/blog` continues to render with new fields present-but-empty (no consumer-side breakage)

🤖 Generated with [Claude Code](https://claude.com/claude-code)