### PR TITLE
feat(ai): analytics agent orchestration API + PDF export

### DIFF
--- a/.codacy/codacy.yaml
+++ b/.codacy/codacy.yaml
@@ -1,9 +1,9 @@
 runtimes:
     - dart@3.7.2
+    - go@1.24.13
+    - java@17.0.10
     - node@22.2.0
     - python@3.11.11
-    - java@17.0.10
-    - go@1.24.13
 tools:
     - dartanalyzer@3.7.2
     - eslint@8.57.0

--- a/__tests__/admin-ai-analytics-orchestration-api.test.ts
+++ b/__tests__/admin-ai-analytics-orchestration-api.test.ts
@@ -1,0 +1,192 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { NextRequest } from "next/server";
+
+const { getConfigMock, getSnapshotMock, runOrchestrationMock } = vi.hoisted(() => ({
+  getConfigMock: vi.fn(),
+  getSnapshotMock: vi.fn(),
+  runOrchestrationMock: vi.fn(),
+}));
+
+vi.mock("jose", async () => {
+  const actual = await vi.importActual<typeof import("jose")>("jose");
+  return {
+    ...actual,
+    jwtVerify: async (jwt: string) => {
+      const parts = jwt.split(".");
+      if (parts.length !== 3) throw new Error("Invalid JWT structure");
+      const payload = JSON.parse(Buffer.from(parts[1], "base64").toString("utf-8"));
+      if (payload.exp && Date.now() >= payload.exp * 1000) throw new Error("JWT expired");
+      return { payload, protectedHeader: { alg: "RS256" } };
+    },
+  };
+});
+
+vi.mock("@/lib/ssm-config", () => ({
+  getConfig: getConfigMock,
+}));
+
+vi.mock("@/lib/stripe-analytics-read", () => ({
+  getStripeAnalyticsSnapshot: getSnapshotMock,
+}));
+
+vi.mock("@/lib/analytics-agent-orchestrator", () => ({
+  runAnalyticsAgentOrchestration: runOrchestrationMock,
+}));
+
+function makeAdminToken(): string {
+  const payload = {
+    sub: "test-admin-sub",
+    email: "admin@cloudless.gr",
+    "cognito:groups": ["admin"],
+    token_use: "id",
+    aud: "test-client-id",
+    iss: "https://cognito-idp.us-east-1.amazonaws.com/us-east-1_TestPool",
+    iat: Math.floor(Date.now() / 1000) - 60,
+    exp: Math.floor(Date.now() / 1000) + 3600,
+  };
+  const header = Buffer.from(JSON.stringify({ alg: "RS256", typ: "JWT" })).toString(
+    "base64url",
+  );
+  const body = Buffer.from(JSON.stringify(payload)).toString("base64url");
+  return `${header}.${body}.fake-sig`;
+}
+
+function adminReq(body?: Record<string, unknown>): NextRequest {
+  return new NextRequest("http://localhost/api/admin/ai/analytics-orchestration", {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${makeAdminToken()}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify(body ?? {}),
+  });
+}
+
+function unauthReq(): NextRequest {
+  return new NextRequest("http://localhost/api/admin/ai/analytics-orchestration", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({}),
+  });
+}
+
+describe("POST /api/admin/ai/analytics-orchestration", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    getConfigMock.mockResolvedValue({ ANTHROPIC_API_KEY: "test-anthropic-key" });
+    getSnapshotMock.mockResolvedValue({
+      windowDays: 30,
+      generatedAt: new Date().toISOString(),
+      totals: { events: 3, revenueMinor: 4500, processed: 2, failed: 1 },
+      byCategory: { checkout: { events: 2, revenueMinor: 4500 } },
+      byStatus: { processed: 2, handler_failed: 1 },
+      byCurrency: { eur: 4500 },
+      dailyTrend: [
+        { day: "2026-05-01", revenueMinor: 2000, events: 1, processed: 1, failed: 0 },
+        { day: "2026-05-02", revenueMinor: 2500, events: 2, processed: 1, failed: 1 },
+      ],
+    });
+    runOrchestrationMock.mockResolvedValue({
+      workflow: [
+        { step: "collect_data", status: "completed", details: "ok" },
+        { step: "preprocess_data", status: "completed", details: "ok" },
+        { step: "generate_insights", status: "completed", details: "ok" },
+        { step: "prepare_connectors", status: "completed", details: "ok" },
+      ],
+      snapshot: {
+        windowDays: 30,
+        generatedAt: new Date().toISOString(),
+        totals: { events: 3, revenueMinor: 4500, processed: 2, failed: 1 },
+        byCategory: { checkout: { events: 2, revenueMinor: 4500 } },
+        byStatus: { processed: 2, handler_failed: 1 },
+        byCurrency: { eur: 4500 },
+        dailyTrend: [],
+      },
+      preprocessed: {
+        windowDays: 30,
+        hasData: true,
+        failureRatePct: 33.33,
+        processedRatePct: 66.67,
+        averageRevenuePerEventMinor: 1500,
+        averageDailyRevenueMinor: 2250,
+        averageDailyEvents: 1.5,
+        revenuePerProcessedEventMinor: 2250,
+        topRevenueCategories: [
+          { category: "checkout", events: 2, revenueMinor: 4500, revenueSharePct: 100 },
+        ],
+        topFailureDays: [{ day: "2026-05-02", failed: 1, events: 2, failureRatePct: 50 }],
+        strongestRevenueDays: [{ day: "2026-05-02", revenueMinor: 2500, events: 2 }],
+        momentum: {
+          comparisonWindowDays: 2,
+          recentRevenueMinor: 4500,
+          priorRevenueMinor: null,
+          revenueDeltaPct: null,
+          recentFailureRatePct: 33.33,
+          priorFailureRatePct: null,
+          failureRateDeltaPct: null,
+        },
+        dataQuality: { sparseWindow: true, notes: ["Sample size is sparse for the selected window."] },
+      },
+      report: {
+        executiveSummary: "test summary",
+        keyInsights: ["a", "b"],
+        risks: ["r1"],
+        nextMoves: [],
+        scenarioOutcomes: [],
+      },
+      connectorPayloads: [],
+    });
+  });
+
+  it("returns 401 when not authenticated", async () => {
+    const { POST } = await import("@/app/api/admin/ai/analytics-orchestration/route");
+    const response = await POST(unauthReq());
+    expect(response.status).toBe(401);
+  });
+
+  it("returns 400 when windowDays is invalid", async () => {
+    const { POST } = await import("@/app/api/admin/ai/analytics-orchestration/route");
+    const response = await POST(adminReq({ windowDays: 0 }));
+    expect(response.status).toBe(400);
+  });
+
+  it("returns 503 when ANTHROPIC_API_KEY is missing", async () => {
+    getConfigMock.mockResolvedValue({});
+    const { POST } = await import("@/app/api/admin/ai/analytics-orchestration/route");
+    const response = await POST(adminReq({ windowDays: 30 }));
+    expect(response.status).toBe(503);
+  });
+
+  it("returns orchestrated analytics report with connector payloads", async () => {
+    const { POST } = await import("@/app/api/admin/ai/analytics-orchestration/route");
+    const response = await POST(
+      adminReq({
+        windowDays: 14,
+        connectors: ["quicksight", "powerbi"],
+        goals: ["Increase retained revenue"],
+      }),
+    );
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(getSnapshotMock).toHaveBeenCalledWith(14);
+    expect(runOrchestrationMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        connectors: ["quicksight", "powerbi"],
+        goals: ["Increase retained revenue"],
+      }),
+    );
+    expect(data.report).toBeDefined();
+    expect(data.workflow).toBeDefined();
+  });
+
+  it("returns 500 when orchestration step fails", async () => {
+    runOrchestrationMock.mockRejectedValue(new Error("orchestration boom"));
+    const { POST } = await import("@/app/api/admin/ai/analytics-orchestration/route");
+    const response = await POST(adminReq({ windowDays: 30 }));
+    const body = await response.json();
+
+    expect(response.status).toBe(500);
+    expect(body.error).toContain("orchestration boom");
+  });
+});

--- a/__tests__/admin-ai-analytics-orchestration-api.test.ts
+++ b/__tests__/admin-ai-analytics-orchestration-api.test.ts
@@ -1,11 +1,13 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { NextRequest } from "next/server";
 
-const { getConfigMock, getSnapshotMock, runOrchestrationMock } = vi.hoisted(() => ({
-  getConfigMock: vi.fn(),
-  getSnapshotMock: vi.fn(),
-  runOrchestrationMock: vi.fn(),
-}));
+const { getConfigMock, getSnapshotMock, runOrchestrationMock } = vi.hoisted(
+  () => ({
+    getConfigMock: vi.fn(),
+    getSnapshotMock: vi.fn(),
+    runOrchestrationMock: vi.fn(),
+  }),
+);
 
 vi.mock("jose", async () => {
   const actual = await vi.importActual<typeof import("jose")>("jose");
@@ -14,8 +16,11 @@ vi.mock("jose", async () => {
     jwtVerify: async (jwt: string) => {
       const parts = jwt.split(".");
       if (parts.length !== 3) throw new Error("Invalid JWT structure");
-      const payload = JSON.parse(Buffer.from(parts[1], "base64").toString("utf-8"));
-      if (payload.exp && Date.now() >= payload.exp * 1000) throw new Error("JWT expired");
+      const payload = JSON.parse(
+        Buffer.from(parts[1], "base64").toString("utf-8"),
+      );
+      if (payload.exp && Date.now() >= payload.exp * 1000)
+        throw new Error("JWT expired");
       return { payload, protectedHeader: { alg: "RS256" } };
     },
   };
@@ -44,36 +49,44 @@ function makeAdminToken(): string {
     iat: Math.floor(Date.now() / 1000) - 60,
     exp: Math.floor(Date.now() / 1000) + 3600,
   };
-  const header = Buffer.from(JSON.stringify({ alg: "RS256", typ: "JWT" })).toString(
-    "base64url",
-  );
+  const header = Buffer.from(
+    JSON.stringify({ alg: "RS256", typ: "JWT" }),
+  ).toString("base64url");
   const body = Buffer.from(JSON.stringify(payload)).toString("base64url");
   return `${header}.${body}.fake-sig`;
 }
 
 function adminReq(body?: Record<string, unknown>): NextRequest {
-  return new NextRequest("http://localhost/api/admin/ai/analytics-orchestration", {
-    method: "POST",
-    headers: {
-      Authorization: `Bearer ${makeAdminToken()}`,
-      "Content-Type": "application/json",
+  return new NextRequest(
+    "http://localhost/api/admin/ai/analytics-orchestration",
+    {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${makeAdminToken()}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(body ?? {}),
     },
-    body: JSON.stringify(body ?? {}),
-  });
+  );
 }
 
 function unauthReq(): NextRequest {
-  return new NextRequest("http://localhost/api/admin/ai/analytics-orchestration", {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({}),
-  });
+  return new NextRequest(
+    "http://localhost/api/admin/ai/analytics-orchestration",
+    {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({}),
+    },
+  );
 }
 
 describe("POST /api/admin/ai/analytics-orchestration", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    getConfigMock.mockResolvedValue({ ANTHROPIC_API_KEY: "test-anthropic-key" });
+    getConfigMock.mockResolvedValue({
+      ANTHROPIC_API_KEY: "test-anthropic-key",
+    });
     getSnapshotMock.mockResolvedValue({
       windowDays: 30,
       generatedAt: new Date().toISOString(),
@@ -82,8 +95,20 @@ describe("POST /api/admin/ai/analytics-orchestration", () => {
       byStatus: { processed: 2, handler_failed: 1 },
       byCurrency: { eur: 4500 },
       dailyTrend: [
-        { day: "2026-05-01", revenueMinor: 2000, events: 1, processed: 1, failed: 0 },
-        { day: "2026-05-02", revenueMinor: 2500, events: 2, processed: 1, failed: 1 },
+        {
+          day: "2026-05-01",
+          revenueMinor: 2000,
+          events: 1,
+          processed: 1,
+          failed: 0,
+        },
+        {
+          day: "2026-05-02",
+          revenueMinor: 2500,
+          events: 2,
+          processed: 1,
+          failed: 1,
+        },
       ],
     });
     runOrchestrationMock.mockResolvedValue({
@@ -112,10 +137,19 @@ describe("POST /api/admin/ai/analytics-orchestration", () => {
         averageDailyEvents: 1.5,
         revenuePerProcessedEventMinor: 2250,
         topRevenueCategories: [
-          { category: "checkout", events: 2, revenueMinor: 4500, revenueSharePct: 100 },
+          {
+            category: "checkout",
+            events: 2,
+            revenueMinor: 4500,
+            revenueSharePct: 100,
+          },
         ],
-        topFailureDays: [{ day: "2026-05-02", failed: 1, events: 2, failureRatePct: 50 }],
-        strongestRevenueDays: [{ day: "2026-05-02", revenueMinor: 2500, events: 2 }],
+        topFailureDays: [
+          { day: "2026-05-02", failed: 1, events: 2, failureRatePct: 50 },
+        ],
+        strongestRevenueDays: [
+          { day: "2026-05-02", revenueMinor: 2500, events: 2 },
+        ],
         momentum: {
           comparisonWindowDays: 2,
           recentRevenueMinor: 4500,
@@ -125,7 +159,10 @@ describe("POST /api/admin/ai/analytics-orchestration", () => {
           priorFailureRatePct: null,
           failureRateDeltaPct: null,
         },
-        dataQuality: { sparseWindow: true, notes: ["Sample size is sparse for the selected window."] },
+        dataQuality: {
+          sparseWindow: true,
+          notes: ["Sample size is sparse for the selected window."],
+        },
       },
       report: {
         executiveSummary: "test summary",
@@ -139,26 +176,30 @@ describe("POST /api/admin/ai/analytics-orchestration", () => {
   });
 
   it("returns 401 when not authenticated", async () => {
-    const { POST } = await import("@/app/api/admin/ai/analytics-orchestration/route");
+    const { POST } =
+      await import("@/app/api/admin/ai/analytics-orchestration/route");
     const response = await POST(unauthReq());
     expect(response.status).toBe(401);
   });
 
   it("returns 400 when windowDays is invalid", async () => {
-    const { POST } = await import("@/app/api/admin/ai/analytics-orchestration/route");
+    const { POST } =
+      await import("@/app/api/admin/ai/analytics-orchestration/route");
     const response = await POST(adminReq({ windowDays: 0 }));
     expect(response.status).toBe(400);
   });
 
   it("returns 503 when ANTHROPIC_API_KEY is missing", async () => {
     getConfigMock.mockResolvedValue({});
-    const { POST } = await import("@/app/api/admin/ai/analytics-orchestration/route");
+    const { POST } =
+      await import("@/app/api/admin/ai/analytics-orchestration/route");
     const response = await POST(adminReq({ windowDays: 30 }));
     expect(response.status).toBe(503);
   });
 
   it("returns orchestrated analytics report with connector payloads", async () => {
-    const { POST } = await import("@/app/api/admin/ai/analytics-orchestration/route");
+    const { POST } =
+      await import("@/app/api/admin/ai/analytics-orchestration/route");
     const response = await POST(
       adminReq({
         windowDays: 14,
@@ -182,7 +223,8 @@ describe("POST /api/admin/ai/analytics-orchestration", () => {
 
   it("returns 500 when orchestration step fails", async () => {
     runOrchestrationMock.mockRejectedValue(new Error("orchestration boom"));
-    const { POST } = await import("@/app/api/admin/ai/analytics-orchestration/route");
+    const { POST } =
+      await import("@/app/api/admin/ai/analytics-orchestration/route");
     const response = await POST(adminReq({ windowDays: 30 }));
     const body = await response.json();
 

--- a/__tests__/admin-ai-analytics-orchestration-pdf-api.test.ts
+++ b/__tests__/admin-ai-analytics-orchestration-pdf-api.test.ts
@@ -1,0 +1,188 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { NextRequest } from "next/server";
+
+const { getConfigMock, getSnapshotMock, runOrchestrationMock } = vi.hoisted(() => ({
+  getConfigMock: vi.fn(),
+  getSnapshotMock: vi.fn(),
+  runOrchestrationMock: vi.fn(),
+}));
+
+vi.mock("jose", async () => {
+  const actual = await vi.importActual<typeof import("jose")>("jose");
+  return {
+    ...actual,
+    jwtVerify: async (jwt: string) => {
+      const parts = jwt.split(".");
+      if (parts.length !== 3) throw new Error("Invalid JWT structure");
+      const payload = JSON.parse(Buffer.from(parts[1], "base64").toString("utf-8"));
+      if (payload.exp && Date.now() >= payload.exp * 1000) throw new Error("JWT expired");
+      return { payload, protectedHeader: { alg: "RS256" } };
+    },
+  };
+});
+
+vi.mock("@/lib/ssm-config", () => ({
+  getConfig: getConfigMock,
+}));
+
+vi.mock("@/lib/stripe-analytics-read", () => ({
+  getStripeAnalyticsSnapshot: getSnapshotMock,
+}));
+
+vi.mock("@/lib/analytics-agent-orchestrator", () => ({
+  runAnalyticsAgentOrchestration: runOrchestrationMock,
+}));
+
+function makeAdminToken(): string {
+  const payload = {
+    sub: "test-admin-sub",
+    email: "admin@cloudless.gr",
+    "cognito:groups": ["admin"],
+    token_use: "id",
+    aud: "test-client-id",
+    iss: "https://cognito-idp.us-east-1.amazonaws.com/us-east-1_TestPool",
+    iat: Math.floor(Date.now() / 1000) - 60,
+    exp: Math.floor(Date.now() / 1000) + 3600,
+  };
+  const header = Buffer.from(JSON.stringify({ alg: "RS256", typ: "JWT" })).toString("base64url");
+  const body = Buffer.from(JSON.stringify(payload)).toString("base64url");
+  return `${header}.${body}.fake-sig`;
+}
+
+function adminReq(body?: Record<string, unknown>): NextRequest {
+  return new NextRequest("http://localhost/api/admin/ai/analytics-orchestration/pdf", {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${makeAdminToken()}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify(body ?? {}),
+  });
+}
+
+describe("POST /api/admin/ai/analytics-orchestration/pdf", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    getConfigMock.mockResolvedValue({ ANTHROPIC_API_KEY: "test-anthropic-key" });
+    getSnapshotMock.mockResolvedValue({
+      windowDays: 30,
+      generatedAt: "2026-05-03T12:00:00.000Z",
+      totals: { events: 3, revenueMinor: 4500, processed: 2, failed: 1 },
+      byCategory: { checkout: { events: 2, revenueMinor: 4500 } },
+      byStatus: { processed: 2, handler_failed: 1 },
+      byCurrency: { eur: 4500 },
+      dailyTrend: [
+        { day: "2026-05-01", revenueMinor: 2000, events: 1, processed: 1, failed: 0 },
+        { day: "2026-05-02", revenueMinor: 2500, events: 2, processed: 1, failed: 1 },
+      ],
+    });
+    runOrchestrationMock.mockResolvedValue({
+      workflow: [
+        { step: "collect_data", status: "completed", details: "ok" },
+        { step: "preprocess_data", status: "completed", details: "ok" },
+        { step: "generate_insights", status: "completed", details: "ok" },
+        { step: "prepare_connectors", status: "completed", details: "ok" },
+      ],
+      snapshot: {
+        windowDays: 30,
+        generatedAt: "2026-05-03T12:00:00.000Z",
+        totals: { events: 3, revenueMinor: 4500, processed: 2, failed: 1 },
+        byCategory: { checkout: { events: 2, revenueMinor: 4500 } },
+        byStatus: { processed: 2, handler_failed: 1 },
+        byCurrency: { eur: 4500 },
+        dailyTrend: [],
+      },
+      preprocessed: {
+        windowDays: 30,
+        hasData: true,
+        failureRatePct: 33.33,
+        processedRatePct: 66.67,
+        averageRevenuePerEventMinor: 1500,
+        averageDailyRevenueMinor: 2250,
+        averageDailyEvents: 1.5,
+        revenuePerProcessedEventMinor: 2250,
+        topRevenueCategories: [
+          { category: "checkout", events: 2, revenueMinor: 4500, revenueSharePct: 100 },
+        ],
+        topFailureDays: [{ day: "2026-05-02", failed: 1, events: 2, failureRatePct: 50 }],
+        strongestRevenueDays: [{ day: "2026-05-02", revenueMinor: 2500, events: 2 }],
+        momentum: {
+          comparisonWindowDays: 2,
+          recentRevenueMinor: 4500,
+          priorRevenueMinor: null,
+          revenueDeltaPct: null,
+          recentFailureRatePct: 33.33,
+          priorFailureRatePct: null,
+          failureRateDeltaPct: null,
+        },
+        dataQuality: { sparseWindow: true, notes: ["Sample size is sparse for the selected window."] },
+      },
+      report: {
+        executiveSummary: "test summary",
+        keyInsights: ["a", "b"],
+        risks: ["r1"],
+        nextMoves: [
+          {
+            move: "Investigate failures",
+            rationale: "Failures are recoverable",
+            expectedOutcome: "Lower failure rate",
+            confidence: "high",
+            timeframeDays: 7,
+          },
+        ],
+        scenarioOutcomes: [
+          {
+            scenario: "Reduce failures",
+            expectedRevenueDeltaPct: 3,
+            expectedConversionDeltaPct: 2,
+          },
+        ],
+      },
+      connectorPayloads: [
+        {
+          connector: "quicksight",
+          datasets: {
+            dailyTrend: [],
+            categoryBreakdown: { checkout: { events: 2, revenueMinor: 4500 } },
+            statusBreakdown: { processed: 2, handler_failed: 1 },
+            currencyBreakdown: { eur: 4500 },
+          },
+          summaryMetrics: {
+            failureRatePct: 33.33,
+            processedRatePct: 66.67,
+            averageRevenuePerEventMinor: 1500,
+            revenueDeltaPct: null,
+            failureRateDeltaPct: null,
+            topRevenueCategories: ["checkout"],
+            dataQualityNotes: ["Sample size is sparse for the selected window."],
+          },
+          chartRecommendations: ["Line chart: daily revenue and failed events trend"],
+          serviceHints: ["Use SPICE ingestion for daily snapshots."],
+        },
+      ],
+    });
+  });
+
+  it("returns a PDF download", async () => {
+    const { POST } = await import("@/app/api/admin/ai/analytics-orchestration/pdf/route");
+    const response = await POST(adminReq({ reportTitle: "Executive Stripe Report" }));
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("Content-Type")).toBe("application/pdf");
+    expect(response.headers.get("Content-Disposition")).toContain(
+      "analytics-report-2026-05-03.pdf",
+    );
+
+    const body = new Uint8Array(await response.arrayBuffer());
+    expect(body.length).toBeGreaterThan(500);
+  });
+
+  it("returns 400 for invalid input", async () => {
+    const { POST } = await import("@/app/api/admin/ai/analytics-orchestration/pdf/route");
+    const response = await POST(adminReq({ reportTitle: "   ", connectors: [] }));
+    const body = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(body.error).toContain("reportTitle cannot be empty");
+  });
+});

--- a/__tests__/admin-ai-analytics-orchestration-pdf-api.test.ts
+++ b/__tests__/admin-ai-analytics-orchestration-pdf-api.test.ts
@@ -1,11 +1,13 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { NextRequest } from "next/server";
 
-const { getConfigMock, getSnapshotMock, runOrchestrationMock } = vi.hoisted(() => ({
-  getConfigMock: vi.fn(),
-  getSnapshotMock: vi.fn(),
-  runOrchestrationMock: vi.fn(),
-}));
+const { getConfigMock, getSnapshotMock, runOrchestrationMock } = vi.hoisted(
+  () => ({
+    getConfigMock: vi.fn(),
+    getSnapshotMock: vi.fn(),
+    runOrchestrationMock: vi.fn(),
+  }),
+);
 
 vi.mock("jose", async () => {
   const actual = await vi.importActual<typeof import("jose")>("jose");
@@ -14,8 +16,11 @@ vi.mock("jose", async () => {
     jwtVerify: async (jwt: string) => {
       const parts = jwt.split(".");
       if (parts.length !== 3) throw new Error("Invalid JWT structure");
-      const payload = JSON.parse(Buffer.from(parts[1], "base64").toString("utf-8"));
-      if (payload.exp && Date.now() >= payload.exp * 1000) throw new Error("JWT expired");
+      const payload = JSON.parse(
+        Buffer.from(parts[1], "base64").toString("utf-8"),
+      );
+      if (payload.exp && Date.now() >= payload.exp * 1000)
+        throw new Error("JWT expired");
       return { payload, protectedHeader: { alg: "RS256" } };
     },
   };
@@ -44,26 +49,33 @@ function makeAdminToken(): string {
     iat: Math.floor(Date.now() / 1000) - 60,
     exp: Math.floor(Date.now() / 1000) + 3600,
   };
-  const header = Buffer.from(JSON.stringify({ alg: "RS256", typ: "JWT" })).toString("base64url");
+  const header = Buffer.from(
+    JSON.stringify({ alg: "RS256", typ: "JWT" }),
+  ).toString("base64url");
   const body = Buffer.from(JSON.stringify(payload)).toString("base64url");
   return `${header}.${body}.fake-sig`;
 }
 
 function adminReq(body?: Record<string, unknown>): NextRequest {
-  return new NextRequest("http://localhost/api/admin/ai/analytics-orchestration/pdf", {
-    method: "POST",
-    headers: {
-      Authorization: `Bearer ${makeAdminToken()}`,
-      "Content-Type": "application/json",
+  return new NextRequest(
+    "http://localhost/api/admin/ai/analytics-orchestration/pdf",
+    {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${makeAdminToken()}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(body ?? {}),
     },
-    body: JSON.stringify(body ?? {}),
-  });
+  );
 }
 
 describe("POST /api/admin/ai/analytics-orchestration/pdf", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    getConfigMock.mockResolvedValue({ ANTHROPIC_API_KEY: "test-anthropic-key" });
+    getConfigMock.mockResolvedValue({
+      ANTHROPIC_API_KEY: "test-anthropic-key",
+    });
     getSnapshotMock.mockResolvedValue({
       windowDays: 30,
       generatedAt: "2026-05-03T12:00:00.000Z",
@@ -72,8 +84,20 @@ describe("POST /api/admin/ai/analytics-orchestration/pdf", () => {
       byStatus: { processed: 2, handler_failed: 1 },
       byCurrency: { eur: 4500 },
       dailyTrend: [
-        { day: "2026-05-01", revenueMinor: 2000, events: 1, processed: 1, failed: 0 },
-        { day: "2026-05-02", revenueMinor: 2500, events: 2, processed: 1, failed: 1 },
+        {
+          day: "2026-05-01",
+          revenueMinor: 2000,
+          events: 1,
+          processed: 1,
+          failed: 0,
+        },
+        {
+          day: "2026-05-02",
+          revenueMinor: 2500,
+          events: 2,
+          processed: 1,
+          failed: 1,
+        },
       ],
     });
     runOrchestrationMock.mockResolvedValue({
@@ -102,10 +126,19 @@ describe("POST /api/admin/ai/analytics-orchestration/pdf", () => {
         averageDailyEvents: 1.5,
         revenuePerProcessedEventMinor: 2250,
         topRevenueCategories: [
-          { category: "checkout", events: 2, revenueMinor: 4500, revenueSharePct: 100 },
+          {
+            category: "checkout",
+            events: 2,
+            revenueMinor: 4500,
+            revenueSharePct: 100,
+          },
         ],
-        topFailureDays: [{ day: "2026-05-02", failed: 1, events: 2, failureRatePct: 50 }],
-        strongestRevenueDays: [{ day: "2026-05-02", revenueMinor: 2500, events: 2 }],
+        topFailureDays: [
+          { day: "2026-05-02", failed: 1, events: 2, failureRatePct: 50 },
+        ],
+        strongestRevenueDays: [
+          { day: "2026-05-02", revenueMinor: 2500, events: 2 },
+        ],
         momentum: {
           comparisonWindowDays: 2,
           recentRevenueMinor: 4500,
@@ -115,7 +148,10 @@ describe("POST /api/admin/ai/analytics-orchestration/pdf", () => {
           priorFailureRatePct: null,
           failureRateDeltaPct: null,
         },
-        dataQuality: { sparseWindow: true, notes: ["Sample size is sparse for the selected window."] },
+        dataQuality: {
+          sparseWindow: true,
+          notes: ["Sample size is sparse for the selected window."],
+        },
       },
       report: {
         executiveSummary: "test summary",
@@ -154,9 +190,13 @@ describe("POST /api/admin/ai/analytics-orchestration/pdf", () => {
             revenueDeltaPct: null,
             failureRateDeltaPct: null,
             topRevenueCategories: ["checkout"],
-            dataQualityNotes: ["Sample size is sparse for the selected window."],
+            dataQualityNotes: [
+              "Sample size is sparse for the selected window.",
+            ],
           },
-          chartRecommendations: ["Line chart: daily revenue and failed events trend"],
+          chartRecommendations: [
+            "Line chart: daily revenue and failed events trend",
+          ],
           serviceHints: ["Use SPICE ingestion for daily snapshots."],
         },
       ],
@@ -164,8 +204,11 @@ describe("POST /api/admin/ai/analytics-orchestration/pdf", () => {
   });
 
   it("returns a PDF download", async () => {
-    const { POST } = await import("@/app/api/admin/ai/analytics-orchestration/pdf/route");
-    const response = await POST(adminReq({ reportTitle: "Executive Stripe Report" }));
+    const { POST } =
+      await import("@/app/api/admin/ai/analytics-orchestration/pdf/route");
+    const response = await POST(
+      adminReq({ reportTitle: "Executive Stripe Report" }),
+    );
 
     expect(response.status).toBe(200);
     expect(response.headers.get("Content-Type")).toBe("application/pdf");
@@ -178,8 +221,11 @@ describe("POST /api/admin/ai/analytics-orchestration/pdf", () => {
   });
 
   it("returns 400 for invalid input", async () => {
-    const { POST } = await import("@/app/api/admin/ai/analytics-orchestration/pdf/route");
-    const response = await POST(adminReq({ reportTitle: "   ", connectors: [] }));
+    const { POST } =
+      await import("@/app/api/admin/ai/analytics-orchestration/pdf/route");
+    const response = await POST(
+      adminReq({ reportTitle: "   ", connectors: [] }),
+    );
     const body = await response.json();
 
     expect(response.status).toBe(400);

--- a/__tests__/analytics-agent-orchestrator.test.ts
+++ b/__tests__/analytics-agent-orchestrator.test.ts
@@ -14,9 +14,8 @@ describe("analytics-agent-orchestrator", () => {
   });
 
   it("preprocesses trend and category metrics before orchestration", async () => {
-    const { preprocessStripeAnalyticsSnapshot } = await import(
-      "@/lib/analytics-agent-orchestrator"
-    );
+    const { preprocessStripeAnalyticsSnapshot } =
+      await import("@/lib/analytics-agent-orchestrator");
 
     const result = preprocessStripeAnalyticsSnapshot({
       windowDays: 7,
@@ -29,13 +28,55 @@ describe("analytics-agent-orchestrator", () => {
       byStatus: { processed: 8, handler_failed: 2 },
       byCurrency: { eur: 10000 },
       dailyTrend: [
-        { day: "2026-04-27", revenueMinor: 1000, events: 1, processed: 1, failed: 0 },
-        { day: "2026-04-28", revenueMinor: 500, events: 1, processed: 0, failed: 1 },
-        { day: "2026-04-29", revenueMinor: 1500, events: 2, processed: 2, failed: 0 },
-        { day: "2026-04-30", revenueMinor: 2000, events: 2, processed: 2, failed: 0 },
-        { day: "2026-05-01", revenueMinor: 2500, events: 2, processed: 2, failed: 0 },
-        { day: "2026-05-02", revenueMinor: 1000, events: 1, processed: 0, failed: 1 },
-        { day: "2026-05-03", revenueMinor: 1500, events: 1, processed: 1, failed: 0 },
+        {
+          day: "2026-04-27",
+          revenueMinor: 1000,
+          events: 1,
+          processed: 1,
+          failed: 0,
+        },
+        {
+          day: "2026-04-28",
+          revenueMinor: 500,
+          events: 1,
+          processed: 0,
+          failed: 1,
+        },
+        {
+          day: "2026-04-29",
+          revenueMinor: 1500,
+          events: 2,
+          processed: 2,
+          failed: 0,
+        },
+        {
+          day: "2026-04-30",
+          revenueMinor: 2000,
+          events: 2,
+          processed: 2,
+          failed: 0,
+        },
+        {
+          day: "2026-05-01",
+          revenueMinor: 2500,
+          events: 2,
+          processed: 2,
+          failed: 0,
+        },
+        {
+          day: "2026-05-02",
+          revenueMinor: 1000,
+          events: 1,
+          processed: 0,
+          failed: 1,
+        },
+        {
+          day: "2026-05-03",
+          revenueMinor: 1500,
+          events: 1,
+          processed: 1,
+          failed: 0,
+        },
       ],
     });
 
@@ -55,9 +96,8 @@ describe("analytics-agent-orchestrator", () => {
 
   it("falls back to deterministic insights when Claude returns invalid JSON", async () => {
     callClaudeMock.mockResolvedValue("not json");
-    const { runAnalyticsAgentOrchestration } = await import(
-      "@/lib/analytics-agent-orchestrator"
-    );
+    const { runAnalyticsAgentOrchestration } =
+      await import("@/lib/analytics-agent-orchestrator");
 
     const result = await runAnalyticsAgentOrchestration({
       snapshot: {
@@ -71,10 +111,34 @@ describe("analytics-agent-orchestrator", () => {
         byStatus: { processed: 3, handler_failed: 1 },
         byCurrency: { eur: 8000 },
         dailyTrend: [
-          { day: "2026-04-30", revenueMinor: 2000, events: 1, processed: 1, failed: 0 },
-          { day: "2026-05-01", revenueMinor: 1000, events: 1, processed: 0, failed: 1 },
-          { day: "2026-05-02", revenueMinor: 2500, events: 1, processed: 1, failed: 0 },
-          { day: "2026-05-03", revenueMinor: 2500, events: 1, processed: 1, failed: 0 },
+          {
+            day: "2026-04-30",
+            revenueMinor: 2000,
+            events: 1,
+            processed: 1,
+            failed: 0,
+          },
+          {
+            day: "2026-05-01",
+            revenueMinor: 1000,
+            events: 1,
+            processed: 0,
+            failed: 1,
+          },
+          {
+            day: "2026-05-02",
+            revenueMinor: 2500,
+            events: 1,
+            processed: 1,
+            failed: 0,
+          },
+          {
+            day: "2026-05-03",
+            revenueMinor: 2500,
+            events: 1,
+            processed: 1,
+            failed: 0,
+          },
         ],
       },
       connectors: ["quicksight", "metabase"],
@@ -92,8 +156,8 @@ describe("analytics-agent-orchestrator", () => {
     expect(result.preprocessed.failureRatePct).toBe(25);
     expect(result.report.executiveSummary).toContain("Processed 3 of 4 events");
     expect(result.connectorPayloads).toHaveLength(2);
-    expect(result.connectorPayloads[0].summaryMetrics.topRevenueCategories[0]).toBe(
-      "checkout",
-    );
+    expect(
+      result.connectorPayloads[0].summaryMetrics.topRevenueCategories[0],
+    ).toBe("checkout");
   });
 });

--- a/__tests__/analytics-agent-orchestrator.test.ts
+++ b/__tests__/analytics-agent-orchestrator.test.ts
@@ -1,0 +1,99 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { callClaudeMock } = vi.hoisted(() => ({
+  callClaudeMock: vi.fn(),
+}));
+
+vi.mock("@/lib/anthropic", () => ({
+  callClaude: callClaudeMock,
+}));
+
+describe("analytics-agent-orchestrator", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("preprocesses trend and category metrics before orchestration", async () => {
+    const { preprocessStripeAnalyticsSnapshot } = await import(
+      "@/lib/analytics-agent-orchestrator"
+    );
+
+    const result = preprocessStripeAnalyticsSnapshot({
+      windowDays: 7,
+      generatedAt: "2026-05-03T12:00:00.000Z",
+      totals: { events: 10, revenueMinor: 10000, processed: 8, failed: 2 },
+      byCategory: {
+        checkout: { events: 6, revenueMinor: 7000 },
+        subscription: { events: 4, revenueMinor: 3000 },
+      },
+      byStatus: { processed: 8, handler_failed: 2 },
+      byCurrency: { eur: 10000 },
+      dailyTrend: [
+        { day: "2026-04-27", revenueMinor: 1000, events: 1, processed: 1, failed: 0 },
+        { day: "2026-04-28", revenueMinor: 500, events: 1, processed: 0, failed: 1 },
+        { day: "2026-04-29", revenueMinor: 1500, events: 2, processed: 2, failed: 0 },
+        { day: "2026-04-30", revenueMinor: 2000, events: 2, processed: 2, failed: 0 },
+        { day: "2026-05-01", revenueMinor: 2500, events: 2, processed: 2, failed: 0 },
+        { day: "2026-05-02", revenueMinor: 1000, events: 1, processed: 0, failed: 1 },
+        { day: "2026-05-03", revenueMinor: 1500, events: 1, processed: 1, failed: 0 },
+      ],
+    });
+
+    expect(result.failureRatePct).toBe(20);
+    expect(result.processedRatePct).toBe(80);
+    expect(result.averageRevenuePerEventMinor).toBe(1000);
+    expect(result.topRevenueCategories[0]).toMatchObject({
+      category: "checkout",
+      revenueMinor: 7000,
+      revenueSharePct: 70,
+    });
+    expect(result.topFailureDays[0]).toMatchObject({
+      day: "2026-04-28",
+      failed: 1,
+    });
+  });
+
+  it("falls back to deterministic insights when Claude returns invalid JSON", async () => {
+    callClaudeMock.mockResolvedValue("not json");
+    const { runAnalyticsAgentOrchestration } = await import(
+      "@/lib/analytics-agent-orchestrator"
+    );
+
+    const result = await runAnalyticsAgentOrchestration({
+      snapshot: {
+        windowDays: 14,
+        generatedAt: "2026-05-03T12:00:00.000Z",
+        totals: { events: 4, revenueMinor: 8000, processed: 3, failed: 1 },
+        byCategory: {
+          checkout: { events: 3, revenueMinor: 7000 },
+          subscription: { events: 1, revenueMinor: 1000 },
+        },
+        byStatus: { processed: 3, handler_failed: 1 },
+        byCurrency: { eur: 8000 },
+        dailyTrend: [
+          { day: "2026-04-30", revenueMinor: 2000, events: 1, processed: 1, failed: 0 },
+          { day: "2026-05-01", revenueMinor: 1000, events: 1, processed: 0, failed: 1 },
+          { day: "2026-05-02", revenueMinor: 2500, events: 1, processed: 1, failed: 0 },
+          { day: "2026-05-03", revenueMinor: 2500, events: 1, processed: 1, failed: 0 },
+        ],
+      },
+      connectors: ["quicksight", "metabase"],
+      apiKey: "test-key",
+      goals: ["Reduce payment failures"],
+    });
+
+    expect(callClaudeMock).toHaveBeenCalledOnce();
+    expect(result.workflow.map((step) => step.step)).toEqual([
+      "collect_data",
+      "preprocess_data",
+      "generate_insights",
+      "prepare_connectors",
+    ]);
+    expect(result.preprocessed.failureRatePct).toBe(25);
+    expect(result.report.executiveSummary).toContain("Processed 3 of 4 events");
+    expect(result.connectorPayloads).toHaveLength(2);
+    expect(result.connectorPayloads[0].summaryMetrics.topRevenueCategories[0]).toBe(
+      "checkout",
+    );
+  });
+});

--- a/docs/AI_ANALYTICS_ORCHESTRATION.md
+++ b/docs/AI_ANALYTICS_ORCHESTRATION.md
@@ -1,0 +1,218 @@
+# AI Analytics Orchestration
+
+This flow turns the Stripe DynamoDB event ledger into an admin-only analytics pipeline with preprocessing, Claude insight generation, connector-ready payloads, and PDF export.
+
+## Endpoints
+
+- `POST /api/admin/ai/analytics-orchestration`
+- `POST /api/admin/ai/analytics-orchestration/pdf`
+
+Both endpoints require an admin JWT via `requireAdmin`.
+
+## Workflow
+
+The orchestration runs four explicit stages:
+
+1. `collect_data`
+   Reads the selected analytics window from `STRIPE_TRANSACTIONS_TABLE` using the `ByDayAndTime` GSI when available, with a filtered scan fallback.
+
+2. `preprocess_data`
+   Computes operational metrics before Claude sees the data:
+   - failure and processed rates
+   - average revenue per event and per processed event
+   - top revenue categories
+   - strongest revenue days
+   - top failure days
+   - recent-window vs prior-window momentum
+   - data quality notes for sparse samples and multi-currency windows
+
+3. `generate_insights`
+   Calls Claude with the compressed analytics package and returns strict JSON containing:
+   - executive summary
+   - key insights
+   - risks
+   - recommended next moves
+   - scenario outcomes
+
+4. `prepare_connectors`
+   Produces connector-ready payloads for:
+   - `quicksight`
+   - `powerbi`
+   - `tableau`
+   - `lookerstudio`
+   - `metabase`
+
+## Request Body
+
+```json
+{
+  "windowDays": 30,
+  "connectors": ["quicksight", "powerbi"],
+  "goals": [
+    "Increase net retained revenue",
+    "Reduce payment failure rate"
+  ],
+  "reportTitle": "Stripe Analytics Report"
+}
+```
+
+### Validation
+
+- `windowDays`: integer from `1` to `365`
+- `connectors`: optional array from the allowed connector set above
+- `goals`: optional array of non-empty strings
+- `reportTitle`: optional non-empty string, used by the PDF endpoint
+
+## JSON Response Shape
+
+```json
+{
+  "workflow": [
+    { "step": "collect_data", "status": "completed", "details": "..." },
+    { "step": "preprocess_data", "status": "completed", "details": "..." },
+    { "step": "generate_insights", "status": "completed", "details": "..." },
+    { "step": "prepare_connectors", "status": "completed", "details": "..." }
+  ],
+  "snapshot": {
+    "windowDays": 30,
+    "generatedAt": "2026-05-03T00:00:00.000Z",
+    "totals": {
+      "events": 0,
+      "revenueMinor": 0,
+      "processed": 0,
+      "failed": 0
+    },
+    "byCategory": {},
+    "byStatus": {},
+    "byCurrency": {},
+    "dailyTrend": []
+  },
+  "preprocessed": {
+    "windowDays": 30,
+    "hasData": false,
+    "failureRatePct": 0,
+    "processedRatePct": 0,
+    "averageRevenuePerEventMinor": 0,
+    "averageDailyRevenueMinor": 0,
+    "averageDailyEvents": 0,
+    "revenuePerProcessedEventMinor": 0,
+    "topRevenueCategories": [],
+    "topFailureDays": [],
+    "strongestRevenueDays": [],
+    "momentum": {
+      "comparisonWindowDays": 0,
+      "recentRevenueMinor": 0,
+      "priorRevenueMinor": null,
+      "revenueDeltaPct": null,
+      "recentFailureRatePct": 0,
+      "priorFailureRatePct": null,
+      "failureRateDeltaPct": null
+    },
+    "dataQuality": {
+      "sparseWindow": false,
+      "notes": []
+    }
+  },
+  "report": {
+    "executiveSummary": "...",
+    "keyInsights": ["..."],
+    "risks": ["..."],
+    "nextMoves": [
+      {
+        "move": "...",
+        "rationale": "...",
+        "expectedOutcome": "...",
+        "confidence": "high",
+        "timeframeDays": 14
+      }
+    ],
+    "scenarioOutcomes": [
+      {
+        "scenario": "...",
+        "expectedRevenueDeltaPct": 4,
+        "expectedConversionDeltaPct": 3
+      }
+    ]
+  },
+  "connectorPayloads": [
+    {
+      "connector": "quicksight",
+      "datasets": {
+        "dailyTrend": [],
+        "categoryBreakdown": {},
+        "statusBreakdown": {},
+        "currencyBreakdown": {}
+      },
+      "summaryMetrics": {
+        "failureRatePct": 0,
+        "processedRatePct": 0,
+        "averageRevenuePerEventMinor": 0,
+        "revenueDeltaPct": null,
+        "failureRateDeltaPct": null,
+        "topRevenueCategories": [],
+        "dataQualityNotes": []
+      },
+      "chartRecommendations": ["..."],
+      "serviceHints": ["..."]
+    }
+  ]
+}
+```
+
+## PDF Export
+
+`POST /api/admin/ai/analytics-orchestration/pdf` runs the same orchestration pipeline and returns a generated PDF download with:
+
+- overview KPIs
+- executive summary
+- key insights
+- risks
+- recommended moves
+- scenario outcomes
+- connector notes
+- data quality notes when present
+
+The response headers are:
+
+- `Content-Type: application/pdf`
+- `Content-Disposition: attachment; filename="analytics-report-YYYY-MM-DD.pdf"`
+- `Cache-Control: no-store`
+
+## DynamoDB Analytics Fields
+
+The orchestration expects the webhook ledger to persist:
+
+- `eventId`
+- `eventType`
+- `eventDay`
+- `tagCategory`
+- `tagStage`
+- `stageCategory`
+- `processingStatus`
+- `receivedAt`
+- `amountMinor`
+- `currency`
+- `expiresAt`
+
+Primary analytics access is via the following GSIs when present:
+
+- `ByTypeAndTime`
+- `ByCategoryAndTime`
+- `ByStageAndTime`
+- `ByStageCategoryAndTime`
+- `ByStatusAndTime`
+- `ByDayAndTime`
+- `ByCustomerAndTime`
+
+## Failure Modes
+
+- `401`: missing or invalid admin auth
+- `400`: invalid body schema
+- `503`: `ANTHROPIC_API_KEY` missing
+- `500`: analytics read, orchestration, or PDF generation failure
+
+## Operational Use
+
+- Use the JSON endpoint to feed dashboards, BI ingestion, and downstream automation.
+- Use the PDF endpoint for executive reviews, weekly reporting, or offline distribution.
+- Compare projected scenario outcomes against the next reporting window to close the loop on actual impact.

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "lucide-react": "^1.11.0",
     "next": "16.2.4",
     "next-intl": "^4.9.1",
+    "pdf-lib": "^1.17.1",
     "react": "19.2.4",
     "react-dom": "19.2.4",
     "stripe": "^21.0.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -72,6 +72,9 @@ importers:
       next-intl:
         specifier: ^4.9.1
         version: 4.9.1(next@16.2.4(patch_hash=59450d84631e1e11fdce7b379520ab4987d6899b290b472e391c35ae0cbed788)(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)(typescript@5.9.3)
+      pdf-lib:
+        specifier: ^1.17.1
+        version: 1.17.1
       react:
         specifier: 19.2.4
         version: 19.2.4
@@ -1389,6 +1392,12 @@ packages:
   '@parcel/watcher@2.5.6':
     resolution: {integrity: sha512-tmmZ3lQxAe/k/+rNnXQRawJ4NjxO2hqiOLTHvWchtGZULp4RyFeh6aU4XdOYBFe2KE1oShQTv4AblOs2iOrNnQ==}
     engines: {node: '>= 10.0.0'}
+
+  '@pdf-lib/standard-fonts@1.0.0':
+    resolution: {integrity: sha512-hU30BK9IUN/su0Mn9VdlVKsWBS6GyhVfqjwl1FjZN4TxP6cCw0jP2w7V3Hf5uX7M0AZJ16vey9yE0ny7Sa59ZA==}
+
+  '@pdf-lib/upng@1.0.1':
+    resolution: {integrity: sha512-dQK2FUMQtowVP00mtIksrlZhdFXQZPC+taih1q4CvPZ5vqdxR/LKBaFg0oAfzd1GlHZXXSPdQfzQnt+ViGvEIQ==}
 
   '@playwright/test@1.59.1':
     resolution: {integrity: sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==}
@@ -4185,6 +4194,9 @@ packages:
     resolution: {integrity: sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==}
     engines: {node: '>=10'}
 
+  pako@1.0.11:
+    resolution: {integrity: sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==}
+
   parent-module@1.0.1:
     resolution: {integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==}
     engines: {node: '>=6'}
@@ -4213,6 +4225,9 @@ packages:
 
   pathe@2.0.3:
     resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
+
+  pdf-lib@1.17.1:
+    resolution: {integrity: sha512-V/mpyJAoTsN4cnP31vc0wfNA1+p20evqqnap0KLoRUN0Yk/p3wN52DOEsL4oBFcLdb76hlpKPtzJIgo67j/XLw==}
 
   pg-int8@1.0.1:
     resolution: {integrity: sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==}
@@ -4813,6 +4828,9 @@ packages:
 
   tsconfig-paths@3.15.0:
     resolution: {integrity: sha512-2Ac2RgzDe/cn48GvOe3M+o82pEFewD3UPbyoUHHdKasHwJKjds4fLXWf/Ux5kATBKN20oaFGu+jbElp1pos0mg==}
+
+  tslib@1.14.1:
+    resolution: {integrity: sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==}
 
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
@@ -7074,6 +7092,14 @@ snapshots:
       '@parcel/watcher-win32-arm64': 2.5.6
       '@parcel/watcher-win32-ia32': 2.5.6
       '@parcel/watcher-win32-x64': 2.5.6
+
+  '@pdf-lib/standard-fonts@1.0.0':
+    dependencies:
+      pako: 1.0.11
+
+  '@pdf-lib/upng@1.0.1':
+    dependencies:
+      pako: 1.0.11
 
   '@playwright/test@1.59.1':
     dependencies:
@@ -10055,6 +10081,8 @@ snapshots:
     dependencies:
       p-limit: 3.1.0
 
+  pako@1.0.11: {}
+
   parent-module@1.0.1:
     dependencies:
       callsites: 3.1.0
@@ -10077,6 +10105,13 @@ snapshots:
       minipass: 7.1.3
 
   pathe@2.0.3: {}
+
+  pdf-lib@1.17.1:
+    dependencies:
+      '@pdf-lib/standard-fonts': 1.0.0
+      '@pdf-lib/upng': 1.0.1
+      pako: 1.0.11
+      tslib: 1.14.1
 
   pg-int8@1.0.1: {}
 
@@ -10685,6 +10720,8 @@ snapshots:
       json5: 1.0.2
       minimist: 1.2.8
       strip-bom: 3.0.0
+
+  tslib@1.14.1: {}
 
   tslib@2.8.1: {}
 

--- a/src/app/api/admin/ai/analytics-orchestration/_shared.ts
+++ b/src/app/api/admin/ai/analytics-orchestration/_shared.ts
@@ -1,0 +1,83 @@
+import { NextRequest, NextResponse } from "next/server";
+import { requireAdmin } from "@/lib/api-auth";
+import { getAnthropicApiKey } from "@/lib/anthropic";
+import {
+  runAnalyticsAgentOrchestration,
+  type AnalyticsConnector,
+  type AnalyticsOrchestrationResult,
+} from "@/lib/analytics-agent-orchestrator";
+import { parseAnalyticsOrchestrationRequestBody } from "@/lib/analytics-orchestration-input";
+import {
+  getStripeAnalyticsSnapshot,
+  type StripeAnalyticsSnapshot,
+} from "@/lib/stripe-analytics-read";
+
+export interface PreparedOrchestration {
+  snapshot: StripeAnalyticsSnapshot;
+  orchestration: AnalyticsOrchestrationResult;
+  reportTitle: string;
+}
+
+export type PrepareResult =
+  | { ok: true; data: PreparedOrchestration }
+  | { ok: false; response: NextResponse };
+
+const DEFAULT_CONNECTORS: AnalyticsConnector[] = ["quicksight", "powerbi"];
+
+export async function prepareOrchestration(
+  request: NextRequest,
+  failureMessage: string,
+): Promise<PrepareResult> {
+  const auth = await requireAdmin(request);
+  if (!auth.ok) return { ok: false, response: auth.response };
+
+  let windowDays = 30;
+  let connectors: AnalyticsConnector[] = DEFAULT_CONNECTORS;
+  let goals: string[] = [];
+  let reportTitle = "Stripe Analytics Report";
+
+  try {
+    ({ windowDays, connectors, goals, reportTitle } =
+      parseAnalyticsOrchestrationRequestBody(await request.json()));
+  } catch (error) {
+    return {
+      ok: false,
+      response: NextResponse.json(
+        { error: error instanceof Error ? error.message : "Invalid input" },
+        { status: 400 },
+      ),
+    };
+  }
+
+  const apiKey = await getAnthropicApiKey();
+  if (!apiKey) {
+    return {
+      ok: false,
+      response: NextResponse.json(
+        { error: "ANTHROPIC_API_KEY not configured." },
+        { status: 503 },
+      ),
+    };
+  }
+
+  try {
+    const snapshot = await getStripeAnalyticsSnapshot(windowDays);
+    const orchestration = await runAnalyticsAgentOrchestration({
+      snapshot,
+      connectors: [...connectors],
+      apiKey,
+      goals,
+    });
+    return { ok: true, data: { snapshot, orchestration, reportTitle } };
+  } catch (error) {
+    return {
+      ok: false,
+      response: NextResponse.json(
+        {
+          error: error instanceof Error ? error.message : failureMessage,
+        },
+        { status: 500 },
+      ),
+    };
+  }
+}

--- a/src/app/api/admin/ai/analytics-orchestration/pdf/route.ts
+++ b/src/app/api/admin/ai/analytics-orchestration/pdf/route.ts
@@ -1,71 +1,26 @@
-import { NextRequest, NextResponse } from "next/server";
-import { requireAdmin } from "@/lib/api-auth";
-import { getAnthropicApiKey } from "@/lib/anthropic";
-import {
-  runAnalyticsAgentOrchestration,
-  type AnalyticsConnector,
-} from "@/lib/analytics-agent-orchestrator";
-import { parseAnalyticsOrchestrationRequestBody } from "@/lib/analytics-orchestration-input";
+import { NextRequest } from "next/server";
 import { renderAnalyticsReportPdf } from "@/lib/analytics-report-pdf";
-import { getStripeAnalyticsSnapshot } from "@/lib/stripe-analytics-read";
+import { prepareOrchestration } from "../_shared";
 
 export async function POST(request: NextRequest) {
-  const auth = await requireAdmin(request);
-  if (!auth.ok) return auth.response;
+  const prepared = await prepareOrchestration(
+    request,
+    "Analytics PDF export failed.",
+  );
+  if (!prepared.ok) return prepared.response;
 
-  let windowDays = 30;
-  let connectors: AnalyticsConnector[] = ["quicksight", "powerbi"];
-  let goals: string[] = [];
-  let reportTitle = "Stripe Analytics Report";
+  const { snapshot, orchestration, reportTitle } = prepared.data;
+  const pdf = await renderAnalyticsReportPdf({
+    reportTitle,
+    result: orchestration,
+  });
 
-  try {
-    ({ windowDays, connectors, goals, reportTitle } =
-      parseAnalyticsOrchestrationRequestBody(await request.json()));
-  } catch (error) {
-    return NextResponse.json(
-      { error: error instanceof Error ? error.message : "Invalid input" },
-      { status: 400 },
-    );
-  }
-
-  const apiKey = await getAnthropicApiKey();
-  if (!apiKey) {
-    return NextResponse.json(
-      { error: "ANTHROPIC_API_KEY not configured." },
-      { status: 503 },
-    );
-  }
-
-  try {
-    const snapshot = await getStripeAnalyticsSnapshot(windowDays);
-    const orchestration = await runAnalyticsAgentOrchestration({
-      snapshot,
-      connectors: [...connectors],
-      apiKey,
-      goals,
-    });
-    const pdf = await renderAnalyticsReportPdf({
-      reportTitle,
-      result: orchestration,
-    });
-
-    return new Response(Buffer.from(pdf), {
-      status: 200,
-      headers: {
-        "Content-Type": "application/pdf",
-        "Content-Disposition": `attachment; filename="analytics-report-${snapshot.generatedAt.slice(0, 10)}.pdf"`,
-        "Cache-Control": "no-store",
-      },
-    });
-  } catch (error) {
-    return NextResponse.json(
-      {
-        error:
-          error instanceof Error
-            ? error.message
-            : "Analytics PDF export failed.",
-      },
-      { status: 500 },
-    );
-  }
+  return new Response(Buffer.from(pdf), {
+    status: 200,
+    headers: {
+      "Content-Type": "application/pdf",
+      "Content-Disposition": `attachment; filename="analytics-report-${snapshot.generatedAt.slice(0, 10)}.pdf"`,
+      "Cache-Control": "no-store",
+    },
+  });
 }

--- a/src/app/api/admin/ai/analytics-orchestration/pdf/route.ts
+++ b/src/app/api/admin/ai/analytics-orchestration/pdf/route.ts
@@ -1,0 +1,71 @@
+import { NextRequest, NextResponse } from "next/server";
+import { requireAdmin } from "@/lib/api-auth";
+import { getAnthropicApiKey } from "@/lib/anthropic";
+import {
+  runAnalyticsAgentOrchestration,
+  type AnalyticsConnector,
+} from "@/lib/analytics-agent-orchestrator";
+import { parseAnalyticsOrchestrationRequestBody } from "@/lib/analytics-orchestration-input";
+import { renderAnalyticsReportPdf } from "@/lib/analytics-report-pdf";
+import { getStripeAnalyticsSnapshot } from "@/lib/stripe-analytics-read";
+
+export async function POST(request: NextRequest) {
+  const auth = await requireAdmin(request);
+  if (!auth.ok) return auth.response;
+
+  let windowDays = 30;
+  let connectors: AnalyticsConnector[] = ["quicksight", "powerbi"];
+  let goals: string[] = [];
+  let reportTitle = "Stripe Analytics Report";
+
+  try {
+    ({ windowDays, connectors, goals, reportTitle } =
+      parseAnalyticsOrchestrationRequestBody(await request.json()));
+  } catch (error) {
+    return NextResponse.json(
+      { error: error instanceof Error ? error.message : "Invalid input" },
+      { status: 400 },
+    );
+  }
+
+  const apiKey = await getAnthropicApiKey();
+  if (!apiKey) {
+    return NextResponse.json(
+      { error: "ANTHROPIC_API_KEY not configured." },
+      { status: 503 },
+    );
+  }
+
+  try {
+    const snapshot = await getStripeAnalyticsSnapshot(windowDays);
+    const orchestration = await runAnalyticsAgentOrchestration({
+      snapshot,
+      connectors: [...connectors],
+      apiKey,
+      goals,
+    });
+    const pdf = await renderAnalyticsReportPdf({
+      reportTitle,
+      result: orchestration,
+    });
+
+    return new Response(Buffer.from(pdf), {
+      status: 200,
+      headers: {
+        "Content-Type": "application/pdf",
+        "Content-Disposition": `attachment; filename="analytics-report-${snapshot.generatedAt.slice(0, 10)}.pdf"`,
+        "Cache-Control": "no-store",
+      },
+    });
+  } catch (error) {
+    return NextResponse.json(
+      {
+        error:
+          error instanceof Error
+            ? error.message
+            : "Analytics PDF export failed.",
+      },
+      { status: 500 },
+    );
+  }
+}

--- a/src/app/api/admin/ai/analytics-orchestration/route.ts
+++ b/src/app/api/admin/ai/analytics-orchestration/route.ts
@@ -1,59 +1,12 @@
 import { NextRequest, NextResponse } from "next/server";
-import { requireAdmin } from "@/lib/api-auth";
-import { getAnthropicApiKey } from "@/lib/anthropic";
-import {
-  runAnalyticsAgentOrchestration,
-  type AnalyticsConnector,
-} from "@/lib/analytics-agent-orchestrator";
-import { parseAnalyticsOrchestrationRequestBody } from "@/lib/analytics-orchestration-input";
-import { getStripeAnalyticsSnapshot } from "@/lib/stripe-analytics-read";
+import { prepareOrchestration } from "./_shared";
 
 export async function POST(request: NextRequest) {
-  const auth = await requireAdmin(request);
-  if (!auth.ok) return auth.response;
+  const prepared = await prepareOrchestration(
+    request,
+    "Analytics orchestration failed.",
+  );
+  if (!prepared.ok) return prepared.response;
 
-  let windowDays = 30;
-  let connectors: AnalyticsConnector[] = ["quicksight", "powerbi"];
-  let goals: string[] = [];
-
-  try {
-    ({ windowDays, connectors, goals } = parseAnalyticsOrchestrationRequestBody(
-      await request.json(),
-    ));
-  } catch (error) {
-    return NextResponse.json(
-      { error: error instanceof Error ? error.message : "Invalid input" },
-      { status: 400 },
-    );
-  }
-
-  const apiKey = await getAnthropicApiKey();
-  if (!apiKey) {
-    return NextResponse.json(
-      { error: "ANTHROPIC_API_KEY not configured." },
-      { status: 503 },
-    );
-  }
-
-  try {
-    const snapshot = await getStripeAnalyticsSnapshot(windowDays);
-    const orchestration = await runAnalyticsAgentOrchestration({
-      snapshot,
-      connectors: [...connectors],
-      apiKey,
-      goals,
-    });
-
-    return NextResponse.json(orchestration);
-  } catch (error) {
-    return NextResponse.json(
-      {
-        error:
-          error instanceof Error
-            ? error.message
-            : "Analytics orchestration failed.",
-      },
-      { status: 500 },
-    );
-  }
+  return NextResponse.json(prepared.data.orchestration);
 }

--- a/src/app/api/admin/ai/analytics-orchestration/route.ts
+++ b/src/app/api/admin/ai/analytics-orchestration/route.ts
@@ -1,0 +1,59 @@
+import { NextRequest, NextResponse } from "next/server";
+import { requireAdmin } from "@/lib/api-auth";
+import { getAnthropicApiKey } from "@/lib/anthropic";
+import {
+  runAnalyticsAgentOrchestration,
+  type AnalyticsConnector,
+} from "@/lib/analytics-agent-orchestrator";
+import { parseAnalyticsOrchestrationRequestBody } from "@/lib/analytics-orchestration-input";
+import { getStripeAnalyticsSnapshot } from "@/lib/stripe-analytics-read";
+
+export async function POST(request: NextRequest) {
+  const auth = await requireAdmin(request);
+  if (!auth.ok) return auth.response;
+
+  let windowDays = 30;
+  let connectors: AnalyticsConnector[] = ["quicksight", "powerbi"];
+  let goals: string[] = [];
+
+  try {
+    ({ windowDays, connectors, goals } = parseAnalyticsOrchestrationRequestBody(
+      await request.json(),
+    ));
+  } catch (error) {
+    return NextResponse.json(
+      { error: error instanceof Error ? error.message : "Invalid input" },
+      { status: 400 },
+    );
+  }
+
+  const apiKey = await getAnthropicApiKey();
+  if (!apiKey) {
+    return NextResponse.json(
+      { error: "ANTHROPIC_API_KEY not configured." },
+      { status: 503 },
+    );
+  }
+
+  try {
+    const snapshot = await getStripeAnalyticsSnapshot(windowDays);
+    const orchestration = await runAnalyticsAgentOrchestration({
+      snapshot,
+      connectors: [...connectors],
+      apiKey,
+      goals,
+    });
+
+    return NextResponse.json(orchestration);
+  } catch (error) {
+    return NextResponse.json(
+      {
+        error:
+          error instanceof Error
+            ? error.message
+            : "Analytics orchestration failed.",
+      },
+      { status: 500 },
+    );
+  }
+}

--- a/src/lib/analytics-agent-orchestrator.ts
+++ b/src/lib/analytics-agent-orchestrator.ts
@@ -187,15 +187,23 @@ export function preprocessStripeAnalyticsSnapshot(
       : [];
   const recentTotals = sumTrend(recentWindow);
   const priorTotals = sumTrend(priorWindow);
-  const recentFailureRatePct = percentage(recentTotals.failed, recentTotals.events);
+  const recentFailureRatePct = percentage(
+    recentTotals.failed,
+    recentTotals.events,
+  );
   const priorFailureRatePct =
-    priorWindow.length > 0 ? percentage(priorTotals.failed, priorTotals.events) : null;
+    priorWindow.length > 0
+      ? percentage(priorTotals.failed, priorTotals.events)
+      : null;
   const topRevenueCategories = Object.entries(snapshot.byCategory)
     .map(([category, metrics]) => ({
       category,
       events: metrics.events,
       revenueMinor: metrics.revenueMinor,
-      revenueSharePct: percentage(metrics.revenueMinor, snapshot.totals.revenueMinor),
+      revenueSharePct: percentage(
+        metrics.revenueMinor,
+        snapshot.totals.revenueMinor,
+      ),
     }))
     .sort(
       (left, right) =>
@@ -212,7 +220,8 @@ export function preprocessStripeAnalyticsSnapshot(
     }))
     .sort(
       (left, right) =>
-        right.failed - left.failed || right.failureRatePct - left.failureRatePct,
+        right.failed - left.failed ||
+        right.failureRatePct - left.failureRatePct,
     )
     .slice(0, 5);
   const strongestRevenueDays = sortedTrend
@@ -233,7 +242,10 @@ export function preprocessStripeAnalyticsSnapshot(
     windowDays: snapshot.windowDays,
     hasData,
     failureRatePct: percentage(snapshot.totals.failed, snapshot.totals.events),
-    processedRatePct: percentage(snapshot.totals.processed, snapshot.totals.events),
+    processedRatePct: percentage(
+      snapshot.totals.processed,
+      snapshot.totals.events,
+    ),
     averageRevenuePerEventMinor:
       snapshot.totals.events > 0
         ? round(snapshot.totals.revenueMinor / snapshot.totals.events)
@@ -256,7 +268,8 @@ export function preprocessStripeAnalyticsSnapshot(
     momentum: {
       comparisonWindowDays,
       recentRevenueMinor: recentTotals.revenueMinor,
-      priorRevenueMinor: priorWindow.length > 0 ? priorTotals.revenueMinor : null,
+      priorRevenueMinor:
+        priorWindow.length > 0 ? priorTotals.revenueMinor : null,
       revenueDeltaPct:
         priorWindow.length > 0 && priorTotals.revenueMinor > 0
           ? percentage(
@@ -330,7 +343,8 @@ function defaultReport(
   snapshot: StripeAnalyticsSnapshot,
   preprocessed: PreprocessedAnalyticsSummary,
 ): AnalyticsNarrativeReport {
-  const topCategory = preprocessed.topRevenueCategories[0]?.category ?? "checkout";
+  const topCategory =
+    preprocessed.topRevenueCategories[0]?.category ?? "checkout";
   const revenueDelta = preprocessed.momentum.revenueDeltaPct;
   const deltaSummary =
     revenueDelta === null
@@ -407,8 +421,14 @@ function parseClaudeJson(text: string): AnalyticsNarrativeReport | null {
           .map((value) => {
             if (!value || typeof value !== "object") return null;
             const candidate = value as Record<string, unknown>;
-            const confidence = String(candidate.confidence ?? "medium").toLowerCase();
-            if (confidence !== "low" && confidence !== "medium" && confidence !== "high") {
+            const confidence = String(
+              candidate.confidence ?? "medium",
+            ).toLowerCase();
+            if (
+              confidence !== "low" &&
+              confidence !== "medium" &&
+              confidence !== "high"
+            ) {
               return null;
             }
 
@@ -423,9 +443,8 @@ function parseClaudeJson(text: string): AnalyticsNarrativeReport | null {
                 : 7,
             } satisfies RecommendedMove;
           })
-          .filter(
-            (value): value is RecommendedMove =>
-              Boolean(value?.move && value?.rationale && value?.expectedOutcome),
+          .filter((value): value is RecommendedMove =>
+            Boolean(value?.move && value?.rationale && value?.expectedOutcome),
           )
       : [];
     const scenarioOutcomes = Array.isArray(parsed.scenarioOutcomes)
@@ -435,8 +454,12 @@ function parseClaudeJson(text: string): AnalyticsNarrativeReport | null {
             const candidate = value as Record<string, unknown>;
             return {
               scenario: String(candidate.scenario ?? "").trim(),
-              expectedRevenueDeltaPct: round(Number(candidate.expectedRevenueDeltaPct ?? 0)),
-              expectedConversionDeltaPct: round(Number(candidate.expectedConversionDeltaPct ?? 0)),
+              expectedRevenueDeltaPct: round(
+                Number(candidate.expectedRevenueDeltaPct ?? 0),
+              ),
+              expectedConversionDeltaPct: round(
+                Number(candidate.expectedConversionDeltaPct ?? 0),
+              ),
             };
           })
           .filter(
@@ -447,7 +470,11 @@ function parseClaudeJson(text: string): AnalyticsNarrativeReport | null {
           )
       : [];
 
-    if (!executiveSummary || keyInsights.length === 0 || nextMoves.length === 0) {
+    if (
+      !executiveSummary ||
+      keyInsights.length === 0 ||
+      nextMoves.length === 0
+    ) {
       return null;
     }
 
@@ -468,33 +495,34 @@ function buildConnectorPayload(
   snapshot: StripeAnalyticsSnapshot,
   preprocessed: PreprocessedAnalyticsSummary,
 ): ConnectorPayload {
-  const chartRecommendationsByConnector: Record<AnalyticsConnector, string[]> = {
-    quicksight: [
-      "Line chart: daily revenue and failed events trend",
-      "Stacked bar: category revenue contribution",
-      "KPI tiles: processed %, failed %, total revenue",
-    ],
-    powerbi: [
-      "Combo chart: daily events vs revenue",
-      "Treemap: category share by revenue",
-      "Funnel: processed vs failed event flow",
-    ],
-    tableau: [
-      "Dual-axis time series for revenue and failures",
-      "Heatmap of day-of-week vs category volume",
-      "Pareto chart of category impact",
-    ],
-    lookerstudio: [
-      "Scorecards for totals and fail rate",
-      "Time series for revenue trajectory",
-      "Pie chart for category split",
-    ],
-    metabase: [
-      "Dashboard cards for weekly KPIs",
-      "Area chart for volume and revenue",
-      "Bar chart for processing status breakdown",
-    ],
-  };
+  const chartRecommendationsByConnector: Record<AnalyticsConnector, string[]> =
+    {
+      quicksight: [
+        "Line chart: daily revenue and failed events trend",
+        "Stacked bar: category revenue contribution",
+        "KPI tiles: processed %, failed %, total revenue",
+      ],
+      powerbi: [
+        "Combo chart: daily events vs revenue",
+        "Treemap: category share by revenue",
+        "Funnel: processed vs failed event flow",
+      ],
+      tableau: [
+        "Dual-axis time series for revenue and failures",
+        "Heatmap of day-of-week vs category volume",
+        "Pareto chart of category impact",
+      ],
+      lookerstudio: [
+        "Scorecards for totals and fail rate",
+        "Time series for revenue trajectory",
+        "Pie chart for category split",
+      ],
+      metabase: [
+        "Dashboard cards for weekly KPIs",
+        "Area chart for volume and revenue",
+        "Bar chart for processing status breakdown",
+      ],
+    };
 
   const serviceHintsByConnector: Record<AnalyticsConnector, string[]> = {
     quicksight: [
@@ -533,7 +561,9 @@ function buildConnectorPayload(
       averageRevenuePerEventMinor: preprocessed.averageRevenuePerEventMinor,
       revenueDeltaPct: preprocessed.momentum.revenueDeltaPct,
       failureRateDeltaPct: preprocessed.momentum.failureRateDeltaPct,
-      topRevenueCategories: preprocessed.topRevenueCategories.map((entry) => entry.category),
+      topRevenueCategories: preprocessed.topRevenueCategories.map(
+        (entry) => entry.category,
+      ),
       dataQualityNotes: preprocessed.dataQuality.notes,
     },
     chartRecommendations: chartRecommendationsByConnector[connector],
@@ -563,17 +593,22 @@ export async function runAnalyticsAgentOrchestration(params: {
     },
   ];
 
-  const raw = await callClaude(buildUserPrompt(snapshot, preprocessed, goals), apiKey, {
-    model: "claude-sonnet-4-6",
-    maxTokens: 1500,
-    system: buildSystemPrompt(),
-  });
+  const raw = await callClaude(
+    buildUserPrompt(snapshot, preprocessed, goals),
+    apiKey,
+    {
+      model: "claude-sonnet-4-6",
+      maxTokens: 1500,
+      system: buildSystemPrompt(),
+    },
+  );
 
   const report = parseClaudeJson(raw) ?? defaultReport(snapshot, preprocessed);
   workflow.push({
     step: "generate_insights",
     status: "completed",
-    details: "Generated executive narrative, next moves, and scenario outcomes.",
+    details:
+      "Generated executive narrative, next moves, and scenario outcomes.",
   });
 
   const connectorPayloads = connectors.map((connector) =>

--- a/src/lib/analytics-agent-orchestrator.ts
+++ b/src/lib/analytics-agent-orchestrator.ts
@@ -1,0 +1,595 @@
+import { callClaude } from "@/lib/anthropic";
+import type { StripeAnalyticsSnapshot } from "@/lib/stripe-analytics-read";
+
+export type AnalyticsConnector =
+  | "quicksight"
+  | "powerbi"
+  | "tableau"
+  | "lookerstudio"
+  | "metabase";
+
+export interface RecommendedMove {
+  move: string;
+  rationale: string;
+  expectedOutcome: string;
+  confidence: "low" | "medium" | "high";
+  timeframeDays: number;
+}
+
+export interface AnalyticsNarrativeReport {
+  executiveSummary: string;
+  keyInsights: string[];
+  risks: string[];
+  nextMoves: RecommendedMove[];
+  scenarioOutcomes: Array<{
+    scenario: string;
+    expectedRevenueDeltaPct: number;
+    expectedConversionDeltaPct: number;
+  }>;
+}
+
+export interface PreprocessedAnalyticsSummary {
+  windowDays: number;
+  hasData: boolean;
+  failureRatePct: number;
+  processedRatePct: number;
+  averageRevenuePerEventMinor: number;
+  averageDailyRevenueMinor: number;
+  averageDailyEvents: number;
+  revenuePerProcessedEventMinor: number;
+  topRevenueCategories: Array<{
+    category: string;
+    events: number;
+    revenueMinor: number;
+    revenueSharePct: number;
+  }>;
+  topFailureDays: Array<{
+    day: string;
+    failed: number;
+    events: number;
+    failureRatePct: number;
+  }>;
+  strongestRevenueDays: Array<{
+    day: string;
+    revenueMinor: number;
+    events: number;
+  }>;
+  momentum: {
+    comparisonWindowDays: number;
+    recentRevenueMinor: number;
+    priorRevenueMinor: number | null;
+    revenueDeltaPct: number | null;
+    recentFailureRatePct: number;
+    priorFailureRatePct: number | null;
+    failureRateDeltaPct: number | null;
+  };
+  dataQuality: {
+    sparseWindow: boolean;
+    notes: string[];
+  };
+}
+
+export interface ConnectorPayload {
+  connector: AnalyticsConnector;
+  datasets: {
+    dailyTrend: StripeAnalyticsSnapshot["dailyTrend"];
+    categoryBreakdown: StripeAnalyticsSnapshot["byCategory"];
+    statusBreakdown: StripeAnalyticsSnapshot["byStatus"];
+    currencyBreakdown: StripeAnalyticsSnapshot["byCurrency"];
+  };
+  summaryMetrics: {
+    failureRatePct: number;
+    processedRatePct: number;
+    averageRevenuePerEventMinor: number;
+    revenueDeltaPct: number | null;
+    failureRateDeltaPct: number | null;
+    topRevenueCategories: string[];
+    dataQualityNotes: string[];
+  };
+  chartRecommendations: string[];
+  serviceHints: string[];
+}
+
+export interface AnalyticsOrchestrationResult {
+  workflow: Array<{
+    step: string;
+    status: "completed";
+    details: string;
+  }>;
+  snapshot: StripeAnalyticsSnapshot;
+  preprocessed: PreprocessedAnalyticsSummary;
+  report: AnalyticsNarrativeReport;
+  connectorPayloads: ConnectorPayload[];
+}
+
+function round(value: number, digits: number = 2): number {
+  if (!Number.isFinite(value)) return 0;
+  return Number(value.toFixed(digits));
+}
+
+function percentage(numerator: number, denominator: number): number {
+  if (denominator <= 0) return 0;
+  return round((numerator / denominator) * 100);
+}
+
+function buildSystemPrompt(): string {
+  return [
+    "You are an executive analytics copilot for cloudless.gr.",
+    "You must output strict JSON only, no markdown, no prose outside JSON.",
+    "Focus on business outcomes, causal insight hypotheses, risk-adjusted recommendations, and concrete next moves.",
+    "Use only the supplied data and derived metrics.",
+    "If uncertainty exists or the sample is sparse, surface that in risks instead of inventing certainty.",
+  ].join(" ");
+}
+
+function buildDataQualityNotes(
+  snapshot: StripeAnalyticsSnapshot,
+  hasData: boolean,
+): { sparseWindow: boolean; notes: string[] } {
+  const notes: string[] = [];
+  if (!hasData) {
+    notes.push("No events were recorded in the selected window.");
+  }
+
+  const sparseWindow =
+    snapshot.totals.events > 0 &&
+    snapshot.totals.events < Math.max(5, snapshot.windowDays / 2);
+  if (sparseWindow) {
+    notes.push(
+      "Sample size is sparse for the selected window, so directionally useful trends may be noisier than usual.",
+    );
+  }
+
+  const currencies = Object.keys(snapshot.byCurrency);
+  if (currencies.length > 1) {
+    notes.push(
+      "Revenue spans multiple currencies, so totals should be treated as ledger totals rather than FX-normalized business revenue.",
+    );
+  }
+
+  if (snapshot.totals.processed === 0 && snapshot.totals.events > 0) {
+    notes.push(
+      "No processed events were recorded, which likely indicates either a live issue or a partial ingest window.",
+    );
+  }
+
+  return { sparseWindow, notes };
+}
+
+function sumTrend(points: StripeAnalyticsSnapshot["dailyTrend"]): {
+  revenueMinor: number;
+  events: number;
+  failed: number;
+} {
+  return points.reduce(
+    (accumulator, point) => ({
+      revenueMinor: accumulator.revenueMinor + point.revenueMinor,
+      events: accumulator.events + point.events,
+      failed: accumulator.failed + point.failed,
+    }),
+    { revenueMinor: 0, events: 0, failed: 0 },
+  );
+}
+
+export function preprocessStripeAnalyticsSnapshot(
+  snapshot: StripeAnalyticsSnapshot,
+): PreprocessedAnalyticsSummary {
+  const hasData = snapshot.totals.events > 0;
+  const sortedTrend = [...snapshot.dailyTrend].sort((left, right) =>
+    left.day.localeCompare(right.day),
+  );
+  const comparisonWindowDays = Math.min(7, sortedTrend.length);
+  const recentWindow =
+    comparisonWindowDays > 0 ? sortedTrend.slice(-comparisonWindowDays) : [];
+  const priorWindow =
+    comparisonWindowDays > 0
+      ? sortedTrend.slice(-comparisonWindowDays * 2, -comparisonWindowDays)
+      : [];
+  const recentTotals = sumTrend(recentWindow);
+  const priorTotals = sumTrend(priorWindow);
+  const recentFailureRatePct = percentage(recentTotals.failed, recentTotals.events);
+  const priorFailureRatePct =
+    priorWindow.length > 0 ? percentage(priorTotals.failed, priorTotals.events) : null;
+  const topRevenueCategories = Object.entries(snapshot.byCategory)
+    .map(([category, metrics]) => ({
+      category,
+      events: metrics.events,
+      revenueMinor: metrics.revenueMinor,
+      revenueSharePct: percentage(metrics.revenueMinor, snapshot.totals.revenueMinor),
+    }))
+    .sort(
+      (left, right) =>
+        right.revenueMinor - left.revenueMinor || right.events - left.events,
+    )
+    .slice(0, 5);
+  const topFailureDays = sortedTrend
+    .filter((point) => point.failed > 0)
+    .map((point) => ({
+      day: point.day,
+      failed: point.failed,
+      events: point.events,
+      failureRatePct: percentage(point.failed, point.events),
+    }))
+    .sort(
+      (left, right) =>
+        right.failed - left.failed || right.failureRatePct - left.failureRatePct,
+    )
+    .slice(0, 5);
+  const strongestRevenueDays = sortedTrend
+    .filter((point) => point.revenueMinor > 0)
+    .sort(
+      (left, right) =>
+        right.revenueMinor - left.revenueMinor || right.events - left.events,
+    )
+    .slice(0, 5)
+    .map((point) => ({
+      day: point.day,
+      revenueMinor: point.revenueMinor,
+      events: point.events,
+    }));
+  const dataQuality = buildDataQualityNotes(snapshot, hasData);
+
+  return {
+    windowDays: snapshot.windowDays,
+    hasData,
+    failureRatePct: percentage(snapshot.totals.failed, snapshot.totals.events),
+    processedRatePct: percentage(snapshot.totals.processed, snapshot.totals.events),
+    averageRevenuePerEventMinor:
+      snapshot.totals.events > 0
+        ? round(snapshot.totals.revenueMinor / snapshot.totals.events)
+        : 0,
+    averageDailyRevenueMinor:
+      snapshot.dailyTrend.length > 0
+        ? round(snapshot.totals.revenueMinor / snapshot.dailyTrend.length)
+        : 0,
+    averageDailyEvents:
+      snapshot.dailyTrend.length > 0
+        ? round(snapshot.totals.events / snapshot.dailyTrend.length)
+        : 0,
+    revenuePerProcessedEventMinor:
+      snapshot.totals.processed > 0
+        ? round(snapshot.totals.revenueMinor / snapshot.totals.processed)
+        : 0,
+    topRevenueCategories,
+    topFailureDays,
+    strongestRevenueDays,
+    momentum: {
+      comparisonWindowDays,
+      recentRevenueMinor: recentTotals.revenueMinor,
+      priorRevenueMinor: priorWindow.length > 0 ? priorTotals.revenueMinor : null,
+      revenueDeltaPct:
+        priorWindow.length > 0 && priorTotals.revenueMinor > 0
+          ? percentage(
+              recentTotals.revenueMinor - priorTotals.revenueMinor,
+              priorTotals.revenueMinor,
+            )
+          : null,
+      recentFailureRatePct,
+      priorFailureRatePct,
+      failureRateDeltaPct:
+        priorFailureRatePct !== null
+          ? round(recentFailureRatePct - priorFailureRatePct)
+          : null,
+    },
+    dataQuality,
+  };
+}
+
+function buildUserPrompt(
+  snapshot: StripeAnalyticsSnapshot,
+  preprocessed: PreprocessedAnalyticsSummary,
+  goals: string[],
+): string {
+  const promptPayload = {
+    goals:
+      goals.length > 0
+        ? goals
+        : [
+            "Increase qualified revenue",
+            "Reduce payment failures",
+            "Surface next best operational moves",
+          ],
+    preprocessed,
+    totals: snapshot.totals,
+    byCategory: snapshot.byCategory,
+    byStatus: snapshot.byStatus,
+    byCurrency: snapshot.byCurrency,
+    recentDailyTrend: snapshot.dailyTrend.slice(-14),
+  };
+
+  return `Analyze this Stripe transaction analytics package and produce strategic guidance.
+
+Return strict JSON with this exact shape:
+{
+  "executiveSummary": "string",
+  "keyInsights": ["string", "string"],
+  "risks": ["string", "string"],
+  "nextMoves": [
+    {
+      "move": "string",
+      "rationale": "string",
+      "expectedOutcome": "string",
+      "confidence": "low|medium|high",
+      "timeframeDays": 7
+    }
+  ],
+  "scenarioOutcomes": [
+    {
+      "scenario": "string",
+      "expectedRevenueDeltaPct": 0,
+      "expectedConversionDeltaPct": 0
+    }
+  ]
+}
+
+Analytics package:
+${JSON.stringify(promptPayload, null, 2)}`;
+}
+
+function defaultReport(
+  snapshot: StripeAnalyticsSnapshot,
+  preprocessed: PreprocessedAnalyticsSummary,
+): AnalyticsNarrativeReport {
+  const topCategory = preprocessed.topRevenueCategories[0]?.category ?? "checkout";
+  const revenueDelta = preprocessed.momentum.revenueDeltaPct;
+  const deltaSummary =
+    revenueDelta === null
+      ? "Recent momentum is still stabilizing because there is not enough prior-window history for a clean comparison."
+      : revenueDelta >= 0
+        ? `Revenue momentum is up ${revenueDelta}% versus the prior comparison window.`
+        : `Revenue momentum is down ${Math.abs(revenueDelta)}% versus the prior comparison window.`;
+
+  return {
+    executiveSummary: `Processed ${snapshot.totals.processed} of ${snapshot.totals.events} events across ${snapshot.windowDays} days. Failure rate is ${preprocessed.failureRatePct}%. ${deltaSummary}`,
+    keyInsights: [
+      `Top revenue category is ${topCategory}${preprocessed.topRevenueCategories[0] ? ` at ${preprocessed.topRevenueCategories[0].revenueSharePct}% of tracked revenue` : ""}.`,
+      `Average revenue per event is ${preprocessed.averageRevenuePerEventMinor} minor units, with ${preprocessed.averageDailyEvents} events per day on average.`,
+      `Recent failure rate is ${preprocessed.momentum.recentFailureRatePct}%${preprocessed.momentum.failureRateDeltaPct !== null ? `, a ${preprocessed.momentum.failureRateDeltaPct >= 0 ? "rise" : "drop"} of ${Math.abs(preprocessed.momentum.failureRateDeltaPct)} points versus the prior window` : ""}.`,
+    ],
+    risks:
+      preprocessed.dataQuality.notes.length > 0
+        ? preprocessed.dataQuality.notes
+        : [
+            "The current dataset is narrow enough that operational changes should be validated against another window before broad rollout.",
+          ],
+    nextMoves: [
+      {
+        move: "Triage failed-payment spikes by day and recovery path",
+        rationale:
+          "Failure concentration by day usually points to a recoverable operational issue in billing, retries, or fraud rules.",
+        expectedOutcome:
+          "Lower failed event share and faster recovered revenue within the next cycle.",
+        confidence: "high",
+        timeframeDays: 7,
+      },
+      {
+        move: `Scale acquisition and retention effort around ${topCategory}`,
+        rationale:
+          "The strongest category signal should receive the next budget or funnel optimization pass before weaker cohorts.",
+        expectedOutcome:
+          "Higher revenue efficiency and stronger conversion mix in the next planning window.",
+        confidence: "medium",
+        timeframeDays: 14,
+      },
+    ],
+    scenarioOutcomes: [
+      {
+        scenario: "Reduce failed events by 15%",
+        expectedRevenueDeltaPct: 3,
+        expectedConversionDeltaPct: 2,
+      },
+      {
+        scenario: `Improve ${topCategory} conversion flow by 10%`,
+        expectedRevenueDeltaPct: 5,
+        expectedConversionDeltaPct: 3,
+      },
+    ],
+  };
+}
+
+function parseClaudeJson(text: string): AnalyticsNarrativeReport | null {
+  const cleaned = text.replaceAll(/```json\n?|\n?```/g, "").trim();
+
+  try {
+    const parsed = JSON.parse(cleaned) as Record<string, unknown>;
+    const executiveSummary =
+      typeof parsed.executiveSummary === "string"
+        ? parsed.executiveSummary.trim()
+        : "";
+    const keyInsights = Array.isArray(parsed.keyInsights)
+      ? parsed.keyInsights.map((value) => String(value).trim()).filter(Boolean)
+      : [];
+    const risks = Array.isArray(parsed.risks)
+      ? parsed.risks.map((value) => String(value).trim()).filter(Boolean)
+      : [];
+    const nextMoves = Array.isArray(parsed.nextMoves)
+      ? parsed.nextMoves
+          .map((value) => {
+            if (!value || typeof value !== "object") return null;
+            const candidate = value as Record<string, unknown>;
+            const confidence = String(candidate.confidence ?? "medium").toLowerCase();
+            if (confidence !== "low" && confidence !== "medium" && confidence !== "high") {
+              return null;
+            }
+
+            const timeframeDays = Number(candidate.timeframeDays);
+            return {
+              move: String(candidate.move ?? "").trim(),
+              rationale: String(candidate.rationale ?? "").trim(),
+              expectedOutcome: String(candidate.expectedOutcome ?? "").trim(),
+              confidence,
+              timeframeDays: Number.isFinite(timeframeDays)
+                ? Math.max(1, Math.trunc(timeframeDays))
+                : 7,
+            } satisfies RecommendedMove;
+          })
+          .filter(
+            (value): value is RecommendedMove =>
+              Boolean(value?.move && value?.rationale && value?.expectedOutcome),
+          )
+      : [];
+    const scenarioOutcomes = Array.isArray(parsed.scenarioOutcomes)
+      ? parsed.scenarioOutcomes
+          .map((value) => {
+            if (!value || typeof value !== "object") return null;
+            const candidate = value as Record<string, unknown>;
+            return {
+              scenario: String(candidate.scenario ?? "").trim(),
+              expectedRevenueDeltaPct: round(Number(candidate.expectedRevenueDeltaPct ?? 0)),
+              expectedConversionDeltaPct: round(Number(candidate.expectedConversionDeltaPct ?? 0)),
+            };
+          })
+          .filter(
+            (
+              value,
+            ): value is AnalyticsNarrativeReport["scenarioOutcomes"][number] =>
+              Boolean(value?.scenario),
+          )
+      : [];
+
+    if (!executiveSummary || keyInsights.length === 0 || nextMoves.length === 0) {
+      return null;
+    }
+
+    return {
+      executiveSummary,
+      keyInsights,
+      risks,
+      nextMoves,
+      scenarioOutcomes,
+    };
+  } catch {
+    return null;
+  }
+}
+
+function buildConnectorPayload(
+  connector: AnalyticsConnector,
+  snapshot: StripeAnalyticsSnapshot,
+  preprocessed: PreprocessedAnalyticsSummary,
+): ConnectorPayload {
+  const chartRecommendationsByConnector: Record<AnalyticsConnector, string[]> = {
+    quicksight: [
+      "Line chart: daily revenue and failed events trend",
+      "Stacked bar: category revenue contribution",
+      "KPI tiles: processed %, failed %, total revenue",
+    ],
+    powerbi: [
+      "Combo chart: daily events vs revenue",
+      "Treemap: category share by revenue",
+      "Funnel: processed vs failed event flow",
+    ],
+    tableau: [
+      "Dual-axis time series for revenue and failures",
+      "Heatmap of day-of-week vs category volume",
+      "Pareto chart of category impact",
+    ],
+    lookerstudio: [
+      "Scorecards for totals and fail rate",
+      "Time series for revenue trajectory",
+      "Pie chart for category split",
+    ],
+    metabase: [
+      "Dashboard cards for weekly KPIs",
+      "Area chart for volume and revenue",
+      "Bar chart for processing status breakdown",
+    ],
+  };
+
+  const serviceHintsByConnector: Record<AnalyticsConnector, string[]> = {
+    quicksight: [
+      "Use SPICE ingestion for daily snapshots.",
+      "Schedule refresh every 15 minutes for near-real-time ops.",
+    ],
+    powerbi: [
+      "Use incremental refresh by eventDay.",
+      "Publish a semantic model for executive and ops views.",
+    ],
+    tableau: [
+      "Create an extract partitioned by eventDay.",
+      "Publish the datasource for finance and growth teams.",
+    ],
+    lookerstudio: [
+      "Materialize daily aggregates to reduce query load.",
+      "Blend the dataset with acquisition sources for CAC-to-revenue views.",
+    ],
+    metabase: [
+      "Persist model questions for weekly reviews.",
+      "Set alerts on fail-rate threshold breaches.",
+    ],
+  };
+
+  return {
+    connector,
+    datasets: {
+      dailyTrend: snapshot.dailyTrend,
+      categoryBreakdown: snapshot.byCategory,
+      statusBreakdown: snapshot.byStatus,
+      currencyBreakdown: snapshot.byCurrency,
+    },
+    summaryMetrics: {
+      failureRatePct: preprocessed.failureRatePct,
+      processedRatePct: preprocessed.processedRatePct,
+      averageRevenuePerEventMinor: preprocessed.averageRevenuePerEventMinor,
+      revenueDeltaPct: preprocessed.momentum.revenueDeltaPct,
+      failureRateDeltaPct: preprocessed.momentum.failureRateDeltaPct,
+      topRevenueCategories: preprocessed.topRevenueCategories.map((entry) => entry.category),
+      dataQualityNotes: preprocessed.dataQuality.notes,
+    },
+    chartRecommendations: chartRecommendationsByConnector[connector],
+    serviceHints: serviceHintsByConnector[connector],
+  };
+}
+
+export async function runAnalyticsAgentOrchestration(params: {
+  snapshot: StripeAnalyticsSnapshot;
+  connectors: AnalyticsConnector[];
+  apiKey: string;
+  goals?: string[];
+}): Promise<AnalyticsOrchestrationResult> {
+  const { snapshot, connectors, apiKey } = params;
+  const goals = params.goals ?? [];
+  const preprocessed = preprocessStripeAnalyticsSnapshot(snapshot);
+  const workflow: AnalyticsOrchestrationResult["workflow"] = [
+    {
+      step: "collect_data",
+      status: "completed",
+      details: `Collected ${snapshot.totals.events} events across ${snapshot.windowDays} days.`,
+    },
+    {
+      step: "preprocess_data",
+      status: "completed",
+      details: `Computed failure rate ${preprocessed.failureRatePct}% and ranked ${preprocessed.topRevenueCategories.length} revenue categories.`,
+    },
+  ];
+
+  const raw = await callClaude(buildUserPrompt(snapshot, preprocessed, goals), apiKey, {
+    model: "claude-sonnet-4-6",
+    maxTokens: 1500,
+    system: buildSystemPrompt(),
+  });
+
+  const report = parseClaudeJson(raw) ?? defaultReport(snapshot, preprocessed);
+  workflow.push({
+    step: "generate_insights",
+    status: "completed",
+    details: "Generated executive narrative, next moves, and scenario outcomes.",
+  });
+
+  const connectorPayloads = connectors.map((connector) =>
+    buildConnectorPayload(connector, snapshot, preprocessed),
+  );
+  workflow.push({
+    step: "prepare_connectors",
+    status: "completed",
+    details: `Prepared ${connectorPayloads.length} connector payload${connectorPayloads.length === 1 ? "" : "s"}.`,
+  });
+
+  return {
+    workflow,
+    snapshot,
+    preprocessed,
+    report,
+    connectorPayloads,
+  };
+}

--- a/src/lib/analytics-orchestration-input.ts
+++ b/src/lib/analytics-orchestration-input.ts
@@ -39,7 +39,8 @@ function normalizeConnectors(value: unknown): AnalyticsConnector[] {
 export function parseAnalyticsOrchestrationRequestBody(
   body: unknown,
 ): AnalyticsOrchestrationInput {
-  const payload = body && typeof body === "object" && !Array.isArray(body) ? body : {};
+  const payload =
+    body && typeof body === "object" && !Array.isArray(body) ? body : {};
   const record = payload as Record<string, unknown>;
 
   let windowDays = 30;
@@ -60,7 +61,9 @@ export function parseAnalyticsOrchestrationRequestBody(
     ? record.goals.map((value) => String(value).trim()).filter(Boolean)
     : [];
   const reportTitle =
-    record.reportTitle === undefined ? "Stripe Analytics Report" : String(record.reportTitle).trim();
+    record.reportTitle === undefined
+      ? "Stripe Analytics Report"
+      : String(record.reportTitle).trim();
 
   if (!reportTitle) {
     throw new Error("reportTitle cannot be empty");

--- a/src/lib/analytics-orchestration-input.ts
+++ b/src/lib/analytics-orchestration-input.ts
@@ -1,0 +1,75 @@
+import type { AnalyticsConnector } from "@/lib/analytics-agent-orchestrator";
+
+export const ALLOWED_ANALYTICS_CONNECTORS: AnalyticsConnector[] = [
+  "quicksight",
+  "powerbi",
+  "tableau",
+  "lookerstudio",
+  "metabase",
+];
+
+export const DEFAULT_ANALYTICS_CONNECTORS: AnalyticsConnector[] = [
+  "quicksight",
+  "powerbi",
+];
+
+export interface AnalyticsOrchestrationInput {
+  windowDays: number;
+  connectors: AnalyticsConnector[];
+  goals: string[];
+  reportTitle: string;
+}
+
+function normalizeConnectors(value: unknown): AnalyticsConnector[] {
+  if (!Array.isArray(value) || value.length === 0) {
+    return [...DEFAULT_ANALYTICS_CONNECTORS];
+  }
+
+  const deduped = new Set<AnalyticsConnector>();
+  for (const entry of value) {
+    const normalized = String(entry).trim().toLowerCase() as AnalyticsConnector;
+    if (ALLOWED_ANALYTICS_CONNECTORS.includes(normalized)) {
+      deduped.add(normalized);
+    }
+  }
+
+  return Array.from(deduped);
+}
+
+export function parseAnalyticsOrchestrationRequestBody(
+  body: unknown,
+): AnalyticsOrchestrationInput {
+  const payload = body && typeof body === "object" && !Array.isArray(body) ? body : {};
+  const record = payload as Record<string, unknown>;
+
+  let windowDays = 30;
+  if (record.windowDays !== undefined) {
+    const parsed = Number(record.windowDays);
+    if (!Number.isFinite(parsed) || parsed < 1 || parsed > 365) {
+      throw new Error("windowDays must be between 1 and 365");
+    }
+    windowDays = Math.trunc(parsed);
+  }
+
+  const connectors = normalizeConnectors(record.connectors);
+  if (connectors.length === 0) {
+    throw new Error("At least one valid connector is required");
+  }
+
+  const goals = Array.isArray(record.goals)
+    ? record.goals.map((value) => String(value).trim()).filter(Boolean)
+    : [];
+  const reportTitle =
+    record.reportTitle === undefined ? "Stripe Analytics Report" : String(record.reportTitle).trim();
+
+  if (!reportTitle) {
+    throw new Error("reportTitle cannot be empty");
+  }
+
+  return {
+    windowDays,
+    connectors,
+    goals,
+    reportTitle,
+  };
+}

--- a/src/lib/analytics-report-pdf.ts
+++ b/src/lib/analytics-report-pdf.ts
@@ -131,7 +131,7 @@ function drawSectionTitle(params: {
   text: string;
   font: PDFFont;
 }): DrawState {
-  let state = ensureSpace(params.pdf, params.state, 28);
+  const state = ensureSpace(params.pdf, params.state, 28);
   state.page.drawText(params.text, {
     x: PAGE_MARGIN,
     y: state.y,
@@ -231,7 +231,12 @@ export async function renderAnalyticsReportPdf(params: {
   });
   state = { ...state, y: state.y - 8 };
 
-  state = drawSectionTitle({ pdf, state, text: "Key Insights", font: boldFont });
+  state = drawSectionTitle({
+    pdf,
+    state,
+    text: "Key Insights",
+    font: boldFont,
+  });
   state = drawBulletList({
     pdf,
     state,

--- a/src/lib/analytics-report-pdf.ts
+++ b/src/lib/analytics-report-pdf.ts
@@ -1,0 +1,319 @@
+import {
+  PDFDocument,
+  StandardFonts,
+  rgb,
+  type PDFFont,
+  type PDFPage,
+} from "pdf-lib";
+import type { AnalyticsOrchestrationResult } from "@/lib/analytics-agent-orchestrator";
+
+const PAGE_WIDTH = 595.28;
+const PAGE_HEIGHT = 841.89;
+const PAGE_MARGIN = 50;
+const BODY_SIZE = 11;
+const BODY_LINE_HEIGHT = 15;
+const SECTION_SIZE = 14;
+const TITLE_SIZE = 20;
+const SUBTITLE_SIZE = 10;
+const MAX_TEXT_WIDTH = PAGE_WIDTH - PAGE_MARGIN * 2;
+
+interface DrawState {
+  page: PDFPage;
+  y: number;
+}
+
+function wrapText(
+  text: string,
+  font: PDFFont,
+  size: number,
+  maxWidth: number,
+): string[] {
+  const words = text.replace(/\s+/g, " ").trim().split(" ");
+  if (words.length === 1 && words[0] === "") return [""];
+
+  const lines: string[] = [];
+  let current = "";
+
+  for (const word of words) {
+    const candidate = current ? `${current} ${word}` : word;
+    if (font.widthOfTextAtSize(candidate, size) <= maxWidth) {
+      current = candidate;
+      continue;
+    }
+
+    if (current) {
+      lines.push(current);
+      current = word;
+      continue;
+    }
+
+    let segment = "";
+    for (const character of word) {
+      const nextSegment = `${segment}${character}`;
+      if (font.widthOfTextAtSize(nextSegment, size) <= maxWidth) {
+        segment = nextSegment;
+      } else {
+        lines.push(segment);
+        segment = character;
+      }
+    }
+    current = segment;
+  }
+
+  if (current) lines.push(current);
+  return lines;
+}
+
+function newPage(pdf: PDFDocument): DrawState {
+  return {
+    page: pdf.addPage([PAGE_WIDTH, PAGE_HEIGHT]),
+    y: PAGE_HEIGHT - PAGE_MARGIN,
+  };
+}
+
+function ensureSpace(
+  pdf: PDFDocument,
+  state: DrawState,
+  neededHeight: number,
+): DrawState {
+  if (state.y - neededHeight >= PAGE_MARGIN) return state;
+  return newPage(pdf);
+}
+
+function drawLines(params: {
+  pdf: PDFDocument;
+  state: DrawState;
+  lines: string[];
+  font: PDFFont;
+  size: number;
+  lineHeight: number;
+  color?: ReturnType<typeof rgb>;
+}): DrawState {
+  let state = params.state;
+  for (const line of params.lines) {
+    state = ensureSpace(params.pdf, state, params.lineHeight);
+    state.page.drawText(line, {
+      x: PAGE_MARGIN,
+      y: state.y,
+      size: params.size,
+      font: params.font,
+      color: params.color ?? rgb(0.12, 0.14, 0.18),
+    });
+    state = { ...state, y: state.y - params.lineHeight };
+  }
+  return state;
+}
+
+function drawParagraph(params: {
+  pdf: PDFDocument;
+  state: DrawState;
+  text: string;
+  font: PDFFont;
+  size?: number;
+  lineHeight?: number;
+}): DrawState {
+  const size = params.size ?? BODY_SIZE;
+  const lineHeight = params.lineHeight ?? BODY_LINE_HEIGHT;
+  const lines = wrapText(params.text, params.font, size, MAX_TEXT_WIDTH);
+  return drawLines({
+    pdf: params.pdf,
+    state: params.state,
+    lines,
+    font: params.font,
+    size,
+    lineHeight,
+  });
+}
+
+function drawSectionTitle(params: {
+  pdf: PDFDocument;
+  state: DrawState;
+  text: string;
+  font: PDFFont;
+}): DrawState {
+  let state = ensureSpace(params.pdf, params.state, 28);
+  state.page.drawText(params.text, {
+    x: PAGE_MARGIN,
+    y: state.y,
+    size: SECTION_SIZE,
+    font: params.font,
+    color: rgb(0.02, 0.59, 0.91),
+  });
+  return { ...state, y: state.y - 22 };
+}
+
+function drawBulletList(params: {
+  pdf: PDFDocument;
+  state: DrawState;
+  items: string[];
+  font: PDFFont;
+}): DrawState {
+  let state = params.state;
+  for (const item of params.items) {
+    state = drawParagraph({
+      pdf: params.pdf,
+      state,
+      text: `- ${item}`,
+      font: params.font,
+    });
+  }
+  return state;
+}
+
+function formatMinorUnits(amountMinor: number): string {
+  return new Intl.NumberFormat("en-IE", {
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  }).format(amountMinor / 100);
+}
+
+export async function renderAnalyticsReportPdf(params: {
+  reportTitle?: string;
+  result: AnalyticsOrchestrationResult;
+}): Promise<Uint8Array> {
+  const title = params.reportTitle?.trim() || "Stripe Analytics Report";
+  const { result } = params;
+  const pdf = await PDFDocument.create();
+  const regularFont = await pdf.embedFont(StandardFonts.Helvetica);
+  const boldFont = await pdf.embedFont(StandardFonts.HelveticaBold);
+  let state = newPage(pdf);
+
+  state.page.drawText(title, {
+    x: PAGE_MARGIN,
+    y: state.y,
+    size: TITLE_SIZE,
+    font: boldFont,
+    color: rgb(0.08, 0.1, 0.16),
+  });
+  state = { ...state, y: state.y - 24 };
+  state.page.drawText(
+    `Generated ${new Date(result.snapshot.generatedAt).toLocaleString("en-IE", {
+      timeZone: "UTC",
+    })} UTC`,
+    {
+      x: PAGE_MARGIN,
+      y: state.y,
+      size: SUBTITLE_SIZE,
+      font: regularFont,
+      color: rgb(0.35, 0.39, 0.45),
+    },
+  );
+  state = { ...state, y: state.y - 24 };
+
+  state = drawSectionTitle({ pdf, state, text: "Overview", font: boldFont });
+  state = drawBulletList({
+    pdf,
+    state,
+    font: regularFont,
+    items: [
+      `Window: ${result.snapshot.windowDays} days`,
+      `Events: ${result.snapshot.totals.events}`,
+      `Processed: ${result.snapshot.totals.processed}`,
+      `Failed: ${result.snapshot.totals.failed}`,
+      `Tracked revenue: ${formatMinorUnits(result.snapshot.totals.revenueMinor)} major units`,
+      `Failure rate: ${result.preprocessed.failureRatePct}%`,
+      `Processed rate: ${result.preprocessed.processedRatePct}%`,
+    ],
+  });
+  state = { ...state, y: state.y - 8 };
+
+  state = drawSectionTitle({
+    pdf,
+    state,
+    text: "Executive Summary",
+    font: boldFont,
+  });
+  state = drawParagraph({
+    pdf,
+    state,
+    text: result.report.executiveSummary,
+    font: regularFont,
+  });
+  state = { ...state, y: state.y - 8 };
+
+  state = drawSectionTitle({ pdf, state, text: "Key Insights", font: boldFont });
+  state = drawBulletList({
+    pdf,
+    state,
+    items: result.report.keyInsights,
+    font: regularFont,
+  });
+  state = { ...state, y: state.y - 8 };
+
+  state = drawSectionTitle({ pdf, state, text: "Risks", font: boldFont });
+  state = drawBulletList({
+    pdf,
+    state,
+    items: result.report.risks,
+    font: regularFont,
+  });
+  state = { ...state, y: state.y - 8 };
+
+  state = drawSectionTitle({
+    pdf,
+    state,
+    text: "Recommended Moves",
+    font: boldFont,
+  });
+  state = drawBulletList({
+    pdf,
+    state,
+    font: regularFont,
+    items: result.report.nextMoves.map(
+      (move) =>
+        `${move.move} (${move.confidence}, ${move.timeframeDays}d): ${move.expectedOutcome}`,
+    ),
+  });
+  state = { ...state, y: state.y - 8 };
+
+  state = drawSectionTitle({
+    pdf,
+    state,
+    text: "Scenario Outcomes",
+    font: boldFont,
+  });
+  state = drawBulletList({
+    pdf,
+    state,
+    font: regularFont,
+    items: result.report.scenarioOutcomes.map(
+      (scenario) =>
+        `${scenario.scenario}: revenue ${scenario.expectedRevenueDeltaPct}%, conversion ${scenario.expectedConversionDeltaPct}%`,
+    ),
+  });
+  state = { ...state, y: state.y - 8 };
+
+  state = drawSectionTitle({
+    pdf,
+    state,
+    text: "Connector Payloads",
+    font: boldFont,
+  });
+  state = drawBulletList({
+    pdf,
+    state,
+    font: regularFont,
+    items: result.connectorPayloads.map(
+      (payload) =>
+        `${payload.connector}: ${payload.chartRecommendations[0] ?? "Dashboard ready"}`,
+    ),
+  });
+
+  if (result.preprocessed.dataQuality.notes.length > 0) {
+    state = { ...state, y: state.y - 8 };
+    state = drawSectionTitle({
+      pdf,
+      state,
+      text: "Data Quality Notes",
+      font: boldFont,
+    });
+    state = drawBulletList({
+      pdf,
+      state,
+      font: regularFont,
+      items: result.preprocessed.dataQuality.notes,
+    });
+  }
+
+  return pdf.save();
+}

--- a/src/lib/stripe-analytics-read.ts
+++ b/src/lib/stripe-analytics-read.ts
@@ -1,0 +1,232 @@
+import {
+  DynamoDBClient,
+  QueryCommand,
+  ScanCommand,
+  type AttributeValue,
+} from "@aws-sdk/client-dynamodb";
+import { resolveDynamoEndpoint } from "@/lib/stripe-transactions";
+
+const REGION = process.env.AWS_REGION || "us-east-1";
+
+let dynamoClient: DynamoDBClient | null = null;
+
+function getDynamoClient(): DynamoDBClient {
+  if (!dynamoClient) {
+    dynamoClient = new DynamoDBClient({
+      region: REGION,
+      endpoint: resolveDynamoEndpoint(),
+    });
+  }
+  return dynamoClient;
+}
+
+function getTransactionsTableName(): string {
+  const tableName = process.env.STRIPE_TRANSACTIONS_TABLE?.trim();
+  if (tableName) return tableName;
+  throw new Error("STRIPE_TRANSACTIONS_TABLE is not configured");
+}
+
+function attrToString(value?: AttributeValue): string | undefined {
+  if (!value) return undefined;
+  if ("S" in value) return value.S;
+  return undefined;
+}
+
+function attrToNumber(value?: AttributeValue): number | undefined {
+  if (!value) return undefined;
+  if ("N" in value) {
+    const numberValue = Number(value.N);
+    return Number.isFinite(numberValue) ? numberValue : undefined;
+  }
+  return undefined;
+}
+
+function toDayString(date: Date): string {
+  return date.toISOString().slice(0, 10);
+}
+
+function getDayRange(days: number): string[] {
+  const range: string[] = [];
+  const now = new Date();
+  for (let index = days - 1; index >= 0; index -= 1) {
+    const date = new Date(now);
+    date.setUTCDate(date.getUTCDate() - index);
+    range.push(toDayString(date));
+  }
+  return range;
+}
+
+function deriveDay(item: Record<string, AttributeValue>): string | undefined {
+  const explicitDay = attrToString(item.eventDay);
+  if (explicitDay) return explicitDay;
+
+  const stripeCreatedAt = attrToNumber(item.stripeCreatedAt);
+  if (typeof stripeCreatedAt === "number") {
+    return toDayString(new Date(stripeCreatedAt * 1000));
+  }
+
+  const receivedAt = attrToNumber(item.receivedAt);
+  if (typeof receivedAt === "number") {
+    return toDayString(new Date(receivedAt));
+  }
+
+  return undefined;
+}
+
+export interface DailyAnalyticsPoint {
+  day: string;
+  revenueMinor: number;
+  events: number;
+  processed: number;
+  failed: number;
+}
+
+export interface StripeAnalyticsSnapshot {
+  windowDays: number;
+  generatedAt: string;
+  totals: {
+    events: number;
+    revenueMinor: number;
+    processed: number;
+    failed: number;
+  };
+  byCategory: Record<string, { events: number; revenueMinor: number }>;
+  byStatus: Record<string, number>;
+  byCurrency: Record<string, number>;
+  dailyTrend: DailyAnalyticsPoint[];
+}
+
+function emptySnapshot(days: number): StripeAnalyticsSnapshot {
+  return {
+    windowDays: days,
+    generatedAt: new Date().toISOString(),
+    totals: {
+      events: 0,
+      revenueMinor: 0,
+      processed: 0,
+      failed: 0,
+    },
+    byCategory: {},
+    byStatus: {},
+    byCurrency: {},
+    dailyTrend: getDayRange(days).map((day) => ({
+      day,
+      revenueMinor: 0,
+      events: 0,
+      processed: 0,
+      failed: 0,
+    })),
+  };
+}
+
+function applyItem(snapshot: StripeAnalyticsSnapshot, item: Record<string, AttributeValue>): void {
+  const day = deriveDay(item);
+  const category = attrToString(item.tagCategory) || "other";
+  const status = attrToString(item.processingStatus) || "unknown";
+  const currency = attrToString(item.currency) || "unknown";
+  const amountMinor = attrToNumber(item.amountMinor) || 0;
+
+  snapshot.totals.events += 1;
+  snapshot.totals.revenueMinor += amountMinor;
+
+  if (status === "processed") snapshot.totals.processed += 1;
+  if (status === "handler_failed") snapshot.totals.failed += 1;
+
+  if (!snapshot.byCategory[category]) {
+    snapshot.byCategory[category] = { events: 0, revenueMinor: 0 };
+  }
+  snapshot.byCategory[category].events += 1;
+  snapshot.byCategory[category].revenueMinor += amountMinor;
+
+  snapshot.byStatus[status] = (snapshot.byStatus[status] || 0) + 1;
+  snapshot.byCurrency[currency] = (snapshot.byCurrency[currency] || 0) + amountMinor;
+
+  if (!day) return;
+  const point = snapshot.dailyTrend.find((entry) => entry.day === day);
+  if (!point) return;
+
+  point.events += 1;
+  point.revenueMinor += amountMinor;
+  if (status === "processed") point.processed += 1;
+  if (status === "handler_failed") point.failed += 1;
+}
+
+function isMissingIndexError(error: unknown): boolean {
+  if (!error || typeof error !== "object") return false;
+  const message = "message" in error ? String(error.message || "") : "";
+  const name = "name" in error ? String(error.name || "") : "";
+  return (
+    name.includes("ValidationException") ||
+    message.includes("Query condition missed key schema element") ||
+    message.includes("The table does not have the specified index")
+  );
+}
+
+async function queryByDayOrScan(days: number): Promise<Array<Record<string, AttributeValue>>> {
+  const tableName = getTransactionsTableName();
+  const client = getDynamoClient();
+  const dayRange = getDayRange(days);
+  const allItems: Array<Record<string, AttributeValue>> = [];
+
+  try {
+    for (const day of dayRange) {
+      let lastEvaluatedKey: Record<string, AttributeValue> | undefined;
+      do {
+        const response = await client.send(
+          new QueryCommand({
+            TableName: tableName,
+            IndexName: "ByDayAndTime",
+            KeyConditionExpression: "eventDay = :eventDay",
+            ExpressionAttributeValues: {
+              ":eventDay": { S: day },
+            },
+            ExclusiveStartKey: lastEvaluatedKey,
+          }),
+        );
+
+        if (response.Items) allItems.push(...response.Items);
+        lastEvaluatedKey = response.LastEvaluatedKey;
+      } while (lastEvaluatedKey);
+    }
+    return allItems;
+  } catch (error) {
+    if (!isMissingIndexError(error)) throw error;
+  }
+
+  const thresholdMs = Date.now() - days * 24 * 60 * 60 * 1000;
+  let lastEvaluatedKey: Record<string, AttributeValue> | undefined;
+
+  do {
+    const response = await client.send(
+      new ScanCommand({
+        TableName: tableName,
+        ProjectionExpression:
+          "eventDay, stripeCreatedAt, tagCategory, processingStatus, currency, amountMinor, receivedAt",
+        FilterExpression: "receivedAt >= :threshold",
+        ExpressionAttributeValues: {
+          ":threshold": { N: `${thresholdMs}` },
+        },
+        ExclusiveStartKey: lastEvaluatedKey,
+      }),
+    );
+
+    if (response.Items) allItems.push(...response.Items);
+    lastEvaluatedKey = response.LastEvaluatedKey;
+  } while (lastEvaluatedKey);
+
+  return allItems;
+}
+
+export async function getStripeAnalyticsSnapshot(
+  inputDays: number = 30,
+): Promise<StripeAnalyticsSnapshot> {
+  const days = Math.max(1, Math.min(365, Math.trunc(inputDays)));
+  const snapshot = emptySnapshot(days);
+  const items = await queryByDayOrScan(days);
+
+  for (const item of items) {
+    applyItem(snapshot, item);
+  }
+
+  return snapshot;
+}

--- a/src/lib/stripe-analytics-read.ts
+++ b/src/lib/stripe-analytics-read.ts
@@ -119,7 +119,10 @@ function emptySnapshot(days: number): StripeAnalyticsSnapshot {
   };
 }
 
-function applyItem(snapshot: StripeAnalyticsSnapshot, item: Record<string, AttributeValue>): void {
+function applyItem(
+  snapshot: StripeAnalyticsSnapshot,
+  item: Record<string, AttributeValue>,
+): void {
   const day = deriveDay(item);
   const category = attrToString(item.tagCategory) || "other";
   const status = attrToString(item.processingStatus) || "unknown";
@@ -139,7 +142,8 @@ function applyItem(snapshot: StripeAnalyticsSnapshot, item: Record<string, Attri
   snapshot.byCategory[category].revenueMinor += amountMinor;
 
   snapshot.byStatus[status] = (snapshot.byStatus[status] || 0) + 1;
-  snapshot.byCurrency[currency] = (snapshot.byCurrency[currency] || 0) + amountMinor;
+  snapshot.byCurrency[currency] =
+    (snapshot.byCurrency[currency] || 0) + amountMinor;
 
   if (!day) return;
   const point = snapshot.dailyTrend.find((entry) => entry.day === day);
@@ -162,7 +166,9 @@ function isMissingIndexError(error: unknown): boolean {
   );
 }
 
-async function queryByDayOrScan(days: number): Promise<Array<Record<string, AttributeValue>>> {
+async function queryByDayOrScan(
+  days: number,
+): Promise<Array<Record<string, AttributeValue>>> {
   const tableName = getTransactionsTableName();
   const client = getDynamoClient();
   const dayRange = getDayRange(days);

--- a/src/lib/stripe-transactions.ts
+++ b/src/lib/stripe-transactions.ts
@@ -9,6 +9,7 @@ import type Stripe from "stripe";
 
 const REGION = process.env.AWS_REGION || "us-east-1";
 const APP_SOURCE_TAG = "cloudless.gr";
+const ANALYTICS_RETENTION_DAYS = 400;
 
 let dynamoClient: DynamoDBClient | null = null;
 
@@ -84,6 +85,14 @@ export function getStripeEventTags(eventType: string): StripeEventTags {
   };
 }
 
+function toEventDay(unixSeconds: number): string {
+  return new Date(unixSeconds * 1000).toISOString().slice(0, 10);
+}
+
+function toExpiryEpoch(unixSeconds: number): number {
+  return unixSeconds + ANALYTICS_RETENTION_DAYS * 24 * 60 * 60;
+}
+
 function buildItem(event: Stripe.Event): Record<string, AttributeValue> {
   const object = event.data.object as unknown as Record<string, unknown>;
   const amountMinor =
@@ -99,6 +108,8 @@ function buildItem(event: Stripe.Event): Record<string, AttributeValue> {
   const customerEmail = asString(object.customer_email);
   const mode = asString(object.mode);
   const tags = getStripeEventTags(event.type);
+  const eventDay = toEventDay(event.created);
+  const stageCategory = `${tags.tagStage}#${tags.tagCategory}`;
 
   const item: Record<string, AttributeValue> = {
     eventId: { S: event.id },
@@ -106,8 +117,11 @@ function buildItem(event: Stripe.Event): Record<string, AttributeValue> {
     tagSource: { S: tags.tagSource },
     tagStage: { S: tags.tagStage },
     tagCategory: { S: tags.tagCategory },
+    stageCategory: { S: stageCategory },
+    eventDay: { S: eventDay },
     receivedAt: { N: `${Date.now()}` },
     stripeCreatedAt: { N: `${event.created}` },
+    expiresAt: { N: `${toExpiryEpoch(event.created)}` },
     processingStatus: { S: "received" },
     livemode: { BOOL: event.livemode },
     payloadJson: { S: toJson(event.data.object) },

--- a/sst.config.ts
+++ b/sst.config.ts
@@ -80,6 +80,9 @@ export default {
         eventType: "string",
         tagCategory: "string",
         tagStage: "string",
+        stageCategory: "string",
+        eventDay: "string",
+        customerId: "string",
         processingStatus: "string",
         receivedAt: "number",
       },
@@ -88,7 +91,10 @@ export default {
         ByTypeAndTime: { hashKey: "eventType", rangeKey: "receivedAt" },
         ByCategoryAndTime: { hashKey: "tagCategory", rangeKey: "receivedAt" },
         ByStageAndTime: { hashKey: "tagStage", rangeKey: "receivedAt" },
+        ByStageCategoryAndTime: { hashKey: "stageCategory", rangeKey: "receivedAt" },
         ByStatusAndTime: { hashKey: "processingStatus", rangeKey: "receivedAt" },
+        ByDayAndTime: { hashKey: "eventDay", rangeKey: "receivedAt" },
+        ByCustomerAndTime: { hashKey: "customerId", rangeKey: "receivedAt" },
       },
     });
 


### PR DESCRIPTION
## Summary
- Adds analytics agent orchestrator with Stripe read layer
- New admin API routes for AI analytics orchestration + PDF export
- Tests and docs covering the orchestration flow

## Test plan
- [ ] `pnpm test __tests__/analytics-agent-orchestrator.test.ts`
- [ ] `pnpm test __tests__/admin-ai-analytics-orchestration-api.test.ts`
- [ ] `pnpm test __tests__/admin-ai-analytics-orchestration-pdf-api.test.ts`
- [ ] Manual: hit `/api/admin/ai/analytics-orchestration` and `/pdf` with admin auth
- [ ] Verify PDF renders without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)