### PR TITLE
ci: harden SSM digest write — remove continue-on-error

### DIFF
--- a/.github/workflows/build-pi-image.yml
+++ b/.github/workflows/build-pi-image.yml
@@ -181,10 +181,6 @@ jobs:
       # Works for both fresh builds and short-circuit re-runs (SHA tag exists).
       - name: record ECR digest in SSM
         if: github.event_name != 'pull_request'
-        # Non-fatal: cloudless-github-actions lacks ssm:PutParameter until the
-        # IAM policy is updated. The webhook step below covers real-time sync;
-        # this step is a best-effort fallback for the CronJob.
-        continue-on-error: true
         run: |
           set -euo pipefail
           SHA="${GITHUB_SHA::12}"


### PR DESCRIPTION
## Summary
- Removes  from the **record ECR digest in SSM** step
-  role is being granted  on 
- Step must now fail the workflow if SSM write fails

## Test plan
- [ ] IAM policy applied
- [ ] Trigger  manually → SSM step passes
- [ ] Verify SSM parameter updated
- [ ] Verify image-sync CronJob picks up new digest

🤖 Generated with [Claude Code](https://claude.com/claude-code)