### PR TITLE
feat(chat): log tool invocations for CloudWatch soak metrics (issue #104)

### DIFF
--- a/src/app/api/chat/route.ts
+++ b/src/app/api/chat/route.ts
@@ -155,6 +155,9 @@ async function executeToolBlocks(
     (b): b is Extract<ContentBlock, { type: "tool_use" }> =>
       b.type === "tool_use",
   );
+  // Log each tool invocation so CloudWatch Logs Insights can count tool-call
+  // rates per session (required for Phase 2a soak metrics — see issue #104).
+  toolUses.forEach((b) => console.info("[chat] tool_use", b.name));
   return Promise.all(
     toolUses.map(async (b) => ({
       type: "tool_result" as const,

--- a/src/lib/email.ts
+++ b/src/lib/email.ts
@@ -205,7 +205,13 @@ export async function notifyTeam(subject: string, body: string): Promise<void> {
     // regex backtracking patterns that static analysers flag as ReDoS-prone.
     text: body
       .split("<")
-      .map((seg, i) => (i === 0 ? seg : seg.includes(">") ? seg.slice(seg.indexOf(">") + 1) : ""))
+      .map((seg, i) =>
+        i === 0
+          ? seg
+          : seg.includes(">")
+            ? seg.slice(seg.indexOf(">") + 1)
+            : "",
+      )
       .join(""),
   });
 }


### PR DESCRIPTION
## Summary

Addresses the two actionable gaps from the Phase 2a soak report (issue #104).

### 1. Tool-use instrumentation ✅
Adds `console.info('[chat] tool_use', b.name)` in `executeToolBlocks()` before the `Promise.all`. This enables CloudWatch Logs Insights queries like:

```
filter @message like '[chat] tool_use'
| stats count(*) by bin(5m)
```

to count tool-call rates per time window.

### 2. CLOUDLESS-GR-1 (stale Sentry noise) ✅
Investigation confirms `src/middleware.ts` does **not** exist in the repo. The Sentry issue was triggered by a transient dev-session artifact and no longer reproduces. No code change needed — resolved by closing the Sentry issue.

Closes #104