### PR TITLE
feat(cron): add EventBridge cron schedules + 512MB server Lambda

### DIFF
--- a/src/app/api/cron/voice-brief/route.ts
+++ b/src/app/api/cron/voice-brief/route.ts
@@ -10,6 +10,17 @@ import { getStripe } from "@/lib/stripe";
 import { isCronAuthorized, cronUnauthorized } from "@/lib/cron-auth";
 import { mapIntegrationError } from "@/lib/api-errors";
 
+function now() {
+  return new Date();
+}
+
+function getWeekNumber(d: Date): number {
+  const date = new Date(Date.UTC(d.getFullYear(), d.getMonth(), d.getDate()));
+  date.setUTCDate(date.getUTCDate() + 4 - (date.getUTCDay() || 7));
+  const yearStart = new Date(Date.UTC(date.getUTCFullYear(), 0, 1));
+  return Math.ceil(((date.getTime() - yearStart.getTime()) / 86400000 + 1) / 7);
+}
+
 async function safeCall<T>(fn: () => Promise<T>): Promise<T | null> {
   try {
     return await fn();
@@ -154,17 +165,6 @@ export async function GET(request: NextRequest) {
     text: enhancedText,
     generatedAt: new Date().toISOString(),
   });
-}
-
-function now() {
-  return new Date();
-}
-
-function getWeekNumber(d: Date): number {
-  const date = new Date(Date.UTC(d.getFullYear(), d.getMonth(), d.getDate()));
-  date.setUTCDate(date.getUTCDate() + 4 - (date.getUTCDay() || 7));
-  const yearStart = new Date(Date.UTC(date.getUTCFullYear(), 0, 1));
-  return Math.ceil(((date.getTime() - yearStart.getTime()) / 86400000 + 1) / 7);
 }
 
 export const runtime = "nodejs";

--- a/src/lambda/cron-invoker.ts
+++ b/src/lambda/cron-invoker.ts
@@ -18,7 +18,8 @@ export async function handler() {
     }),
   );
   const secret = Parameter?.Value;
-  if (!secret) throw new Error(`CRON_SECRET not found at ${ssmPrefix}/CRON_SECRET`);
+  if (!secret)
+    throw new Error(`CRON_SECRET not found at ${ssmPrefix}/CRON_SECRET`);
 
   const res = await fetch(`${siteUrl}${route}`, {
     headers: { Authorization: `Bearer ${secret}` },
@@ -27,7 +28,9 @@ export async function handler() {
 
   if (!res.ok) {
     const body = await res.text().catch(() => "");
-    throw new Error(`Cron ${route} responded ${res.status}: ${body.slice(0, 200)}`);
+    throw new Error(
+      `Cron ${route} responded ${res.status}: ${body.slice(0, 200)}`,
+    );
   }
 
   const payload = await res.json().catch(() => null);

--- a/src/lambda/cron-invoker.ts
+++ b/src/lambda/cron-invoker.ts
@@ -1,0 +1,35 @@
+import { SSMClient, GetParameterCommand } from "@aws-sdk/client-ssm";
+
+const ssm = new SSMClient({ region: process.env.AWS_REGION ?? "us-east-1" });
+
+export async function handler() {
+  const siteUrl = process.env.SITE_URL;
+  const ssmPrefix = process.env.SSM_PREFIX ?? "/cloudless/production";
+  const route = process.env.CRON_ROUTE;
+
+  if (!siteUrl || !route) {
+    throw new Error(`Missing env: SITE_URL=${siteUrl}, CRON_ROUTE=${route}`);
+  }
+
+  const { Parameter } = await ssm.send(
+    new GetParameterCommand({
+      Name: `${ssmPrefix}/CRON_SECRET`,
+      WithDecryption: true,
+    }),
+  );
+  const secret = Parameter?.Value;
+  if (!secret) throw new Error(`CRON_SECRET not found at ${ssmPrefix}/CRON_SECRET`);
+
+  const res = await fetch(`${siteUrl}${route}`, {
+    headers: { Authorization: `Bearer ${secret}` },
+    signal: AbortSignal.timeout(55_000),
+  });
+
+  if (!res.ok) {
+    const body = await res.text().catch(() => "");
+    throw new Error(`Cron ${route} responded ${res.status}: ${body.slice(0, 200)}`);
+  }
+
+  const payload = await res.json().catch(() => null);
+  return { statusCode: res.status, route, payload };
+}

--- a/sst.config.ts
+++ b/sst.config.ts
@@ -91,8 +91,14 @@ export default {
         ByTypeAndTime: { hashKey: "eventType", rangeKey: "receivedAt" },
         ByCategoryAndTime: { hashKey: "tagCategory", rangeKey: "receivedAt" },
         ByStageAndTime: { hashKey: "tagStage", rangeKey: "receivedAt" },
-        ByStageCategoryAndTime: { hashKey: "stageCategory", rangeKey: "receivedAt" },
-        ByStatusAndTime: { hashKey: "processingStatus", rangeKey: "receivedAt" },
+        ByStageCategoryAndTime: {
+          hashKey: "stageCategory",
+          rangeKey: "receivedAt",
+        },
+        ByStatusAndTime: {
+          hashKey: "processingStatus",
+          rangeKey: "receivedAt",
+        },
         ByDayAndTime: { hashKey: "eventDay", rangeKey: "receivedAt" },
         ByCustomerAndTime: { hashKey: "customerId", rangeKey: "receivedAt" },
       },
@@ -110,7 +116,11 @@ export default {
         dns: false,
         cert: "arn:aws:acm:us-east-1:278585680617:certificate/f505905a-97b4-46b0-a2b0-fb1900f425b2",
       },
-      environment: buildSiteEnvironment(stage, isProd, stripeTransactionsTable.name),
+      environment: buildSiteEnvironment(
+        stage,
+        isProd,
+        stripeTransactionsTable.name,
+      ),
       link: [stripeTransactionsTable],
       permissions: [
         {
@@ -234,7 +244,8 @@ export default {
       const apigwZoneId = "Z1UJRXOUMOOFQ8"; // APIGW regional, us-east-1
       const apexCfDomain = "d3k7muo3c6lw6s.cloudfront.net";
       const wwwCfDomain = "dgrxxatzrgxfi.cloudfront.net";
-      const apexApigwDomain = "d-uy6dmk95il.execute-api.us-east-1.amazonaws.com";
+      const apexApigwDomain =
+        "d-uy6dmk95il.execute-api.us-east-1.amazonaws.com";
       const wwwApigwDomain = "d-2msx2z5q7d.execute-api.us-east-1.amazonaws.com";
 
       // IMPORTANT — pre-deploy migration required.

--- a/sst.config.ts
+++ b/sst.config.ts
@@ -125,7 +125,7 @@ export default {
       ],
       warm: isProd ? 5 : 0,
       server: {
-        memory: "1024 MB",
+        memory: "512 MB",
         architecture: "arm64",
         runtime: "nodejs22.x",
         timeout: "30 seconds",
@@ -146,6 +146,60 @@ export default {
         wait: true,
       },
     });
+
+    // ---------------------------------------------------------------------
+    // Cron jobs (production only)
+    // ---------------------------------------------------------------------
+    // Each cron triggers src/lambda/cron-invoker.ts, which fetches
+    // CRON_SECRET from SSM and POSTs to the corresponding API route.
+    // Schedules are in UTC; Athens is UTC+2 (EET) / UTC+3 (EEST summer).
+    if (isProd) {
+      const ssmPrefix = "/cloudless/production";
+      const cronJobConfig = (route: string) => ({
+        handler: "src/lambda/cron-invoker.handler",
+        memory: "256 MB",
+        timeout: "60 seconds",
+        architecture: "arm64" as const,
+        runtime: "nodejs22.x" as const,
+        environment: {
+          SITE_URL: site.url,
+          SSM_PREFIX: ssmPrefix,
+          CRON_ROUTE: route,
+        },
+        permissions: [
+          {
+            actions: ["ssm:GetParameter"],
+            resources: [
+              `arn:aws:ssm:us-east-1:278585680617:parameter${ssmPrefix}/CRON_SECRET`,
+            ],
+          },
+        ],
+      });
+
+      // Daily 01:00 UTC — flush event queue, weekly rollup, archive old events
+      new sst.aws.Cron("CronAnalyticsRollup", {
+        schedule: "cron(0 1 * * ? *)",
+        job: cronJobConfig("/api/cron/analytics-rollup"),
+      });
+
+      // Weekdays 06:00 UTC (≈08:00-09:00 Athens) — Google Calendar daily agenda to Slack
+      new sst.aws.Cron("CronCalendarDigest", {
+        schedule: "cron(0 6 ? * MON-FRI *)",
+        job: cronJobConfig("/api/cron/calendar-digest"),
+      });
+
+      // Sunday 02:00 UTC — delete generated reports older than 90 days
+      new sst.aws.Cron("CronReportCleanup", {
+        schedule: "cron(0 2 ? * SUN *)",
+        job: cronJobConfig("/api/cron/report-cleanup"),
+      });
+
+      // Monday 05:00 UTC (≈07:00-08:00 Athens) — assemble + store weekly voice brief
+      new sst.aws.Cron("CronVoiceBrief", {
+        schedule: "cron(0 5 ? * MON *)",
+        job: cronJobConfig("/api/cron/voice-brief"),
+      });
+    }
 
     // ---------------------------------------------------------------------
     // Route 53 failover records (production only)


### PR DESCRIPTION
## Summary
- Add 4 `sst.aws.Cron` EventBridge schedules (analytics-rollup, calendar-digest, report-cleanup, voice-brief)
- New shared `src/lambda/cron-invoker.ts` Lambda: reads CRON_SECRET from SSM, calls target API route with Bearer auth
- Reduce server Lambda memory: 1024 MB to 512 MB
- Fix voice-brief route: move now() and getWeekNumber() before first usage

## Test plan
- [ ] sst deploy --stage production completes without errors
- [ ] 4 EventBridge rules visible in AWS Console
- [ ] Manually trigger CronAnalyticsRollup and verify 200 response
- [ ] /api/cron/voice-brief executes without reference errors

Generated with Claude Code