### PR TITLE
security(ci): pin every third-party action to a full-length SHA

### DIFF
--- a/.github/workflows/a11y-audit.yml
+++ b/.github/workflows/a11y-audit.yml
@@ -28,7 +28,7 @@ jobs:
       NEXT_PUBLIC_HUBSPOT_PORTAL_ID: ${{ secrets.NEXT_PUBLIC_HUBSPOT_PORTAL_ID }}
     steps:
       - uses: actions/checkout@v6
-      - uses: pnpm/action-setup@v5
+      - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5
       - uses: actions/setup-node@v6
         with:
           node-version: 22

--- a/.github/workflows/api-contract-audit.yml
+++ b/.github/workflows/api-contract-audit.yml
@@ -27,7 +27,7 @@ jobs:
     timeout-minutes: 12
     steps:
       - uses: actions/checkout@v6
-      - uses: pnpm/action-setup@v5
+      - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5
       - uses: actions/setup-node@v6
         with:
           node-version: 22

--- a/.github/workflows/bundle-budget.yml
+++ b/.github/workflows/bundle-budget.yml
@@ -32,7 +32,7 @@ jobs:
       BUNDLE_MAX_KB: "1900"
     steps:
       - uses: actions/checkout@v6
-      - uses: pnpm/action-setup@v5
+      - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5
       - uses: actions/setup-node@v6
         with:
           node-version: 22

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,7 @@ jobs:
     timeout-minutes: 5
     steps:
       - uses: actions/checkout@v6
-      - uses: pnpm/action-setup@v5
+      - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5
       - uses: actions/setup-node@v6
         with:
           node-version: 22
@@ -56,7 +56,7 @@ jobs:
     timeout-minutes: 5
     steps:
       - uses: actions/checkout@v6
-      - uses: pnpm/action-setup@v5
+      - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5
       - uses: actions/setup-node@v6
         with:
           node-version: 22
@@ -70,7 +70,7 @@ jobs:
     timeout-minutes: 5
     steps:
       - uses: actions/checkout@v6
-      - uses: pnpm/action-setup@v5
+      - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5
       - uses: actions/setup-node@v6
         with:
           node-version: 22
@@ -92,7 +92,7 @@ jobs:
       NEXT_PUBLIC_SENTRY_DSN: ${{ secrets.NEXT_PUBLIC_SENTRY_DSN }}
     steps:
       - uses: actions/checkout@v6
-      - uses: pnpm/action-setup@v5
+      - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5
       - uses: actions/setup-node@v6
         with:
           node-version: 22
@@ -106,7 +106,7 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v6
-      - uses: pnpm/action-setup@v5
+      - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5
       - uses: actions/setup-node@v6
         with:
           node-version: 22

--- a/.github/workflows/core-web-vitals-audit.yml
+++ b/.github/workflows/core-web-vitals-audit.yml
@@ -22,7 +22,7 @@ jobs:
       - uses: actions/checkout@v6
       - name: Run Lighthouse on key routes
         id: lhci
-        uses: treosh/lighthouse-ci-action@v12
+        uses: treosh/lighthouse-ci-action@3e7e23fb74242897f95c0ba9cabad3d0227b9b18 # v12
         with:
           urls: |
             https://cloudless.gr

--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
       - name: Fetch Dependabot metadata
         id: meta
-        uses: dependabot/fetch-metadata@v3
+        uses: dependabot/fetch-metadata@25dd0e34f4fe68f24cc83900b1fe3fe149efef98 # v3
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/deploy-pi.yml
+++ b/.github/workflows/deploy-pi.yml
@@ -37,13 +37,13 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Configure AWS credentials (OIDC)
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4
         with:
           role-to-assume: ${{ secrets.AWS_DEPLOY_ROLE_ARN }}
           aws-region: ${{ env.AWS_REGION }}
 
       - name: Login to Amazon ECR
-        uses: aws-actions/amazon-ecr-login@v2
+        uses: aws-actions/amazon-ecr-login@fa648b43de3d4d023bcb3f89ed6940096949c419 # v2
 
       - name: Check if image tag already exists in ECR
         id: check_ecr
@@ -63,13 +63,13 @@ jobs:
 
       - name: Set up QEMU (arm64 emulation)
         if: steps.check_ecr.outputs.exists != 'true'
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3
         with:
           platforms: arm64
 
       - name: Set up Docker Buildx
         if: steps.check_ecr.outputs.exists != 'true'
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
 
       - name: Prune stale buildx cache
         if: steps.check_ecr.outputs.exists != 'true'
@@ -77,7 +77,7 @@ jobs:
 
       - name: Build and push Docker image
         if: steps.check_ecr.outputs.exists != 'true'
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
           context: .
           platforms: linux/arm64
@@ -116,7 +116,7 @@ jobs:
 
     steps:
       - name: Configure AWS credentials (OIDC)
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4
         with:
           role-to-assume: ${{ secrets.AWS_DEPLOY_ROLE_ARN }}
           aws-region: ${{ env.AWS_REGION }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -47,7 +47,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v5
+        uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5
 
       - name: Setup Node.js
         uses: actions/setup-node@v6
@@ -76,7 +76,7 @@ jobs:
           grep "CACHE_VERSION" public/sw.js
 
       - name: Configure AWS credentials (OIDC)
-        uses: aws-actions/configure-aws-credentials@v6
+        uses: aws-actions/configure-aws-credentials@d979d5b3a71173a29b74b5b88418bfda9437d885 # v6
         with:
           role-to-assume: ${{ secrets.AWS_DEPLOY_ROLE_ARN }}
           aws-region: us-east-1

--- a/.github/workflows/devcontainer.yml
+++ b/.github/workflows/devcontainer.yml
@@ -18,10 +18,10 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4
 
       - name: Build dev container image
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7
         with:
           context: .
           file: .devcontainer/Dockerfile

--- a/.github/workflows/ecr-lifecycle.yml
+++ b/.github/workflows/ecr-lifecycle.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: [self-hosted, omv]
     steps:
       - name: Configure AWS credentials (OIDC)
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4
         with:
           role-to-assume: ${{ secrets.AWS_DEPLOY_ROLE_ARN }}
           aws-region: ${{ env.AWS_REGION }}

--- a/.github/workflows/i18n-audit.yml
+++ b/.github/workflows/i18n-audit.yml
@@ -23,7 +23,7 @@ jobs:
     timeout-minutes: 8
     steps:
       - uses: actions/checkout@v6
-      - uses: pnpm/action-setup@v5
+      - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5
       - uses: actions/setup-node@v6
         with:
           node-version: 22

--- a/.github/workflows/k3s-e2e.yml
+++ b/.github/workflows/k3s-e2e.yml
@@ -58,7 +58,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
 
       - uses: actions/setup-node@v4
         with:

--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -28,7 +28,7 @@ jobs:
 
       - name: Run Lighthouse
         id: lighthouse
-        uses: treosh/lighthouse-ci-action@v12
+        uses: treosh/lighthouse-ci-action@3e7e23fb74242897f95c0ba9cabad3d0227b9b18 # v12
         with:
           urls: |
             ${{ github.event.inputs.url || 'https://cloudless.gr' }}

--- a/.github/workflows/links-audit.yml
+++ b/.github/workflows/links-audit.yml
@@ -21,7 +21,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - name: Check links
-        uses: lycheeverse/lychee-action@v2
+        uses: lycheeverse/lychee-action@8646ba30535128ac92d33dfc9133794bfdd9b411 # v2
         with:
           args: >-
             --verbose

--- a/.github/workflows/monthly-security-audit.yml
+++ b/.github/workflows/monthly-security-audit.yml
@@ -24,7 +24,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v5
+        uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5
 
       - name: Setup Node.js
         uses: actions/setup-node@v6

--- a/.github/workflows/notion-schema-drift.yml
+++ b/.github/workflows/notion-schema-drift.yml
@@ -23,7 +23,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
 
       - uses: actions/setup-node@v4
         with:
@@ -33,7 +33,7 @@ jobs:
       - run: pnpm install --frozen-lockfile
 
       - name: Configure AWS credentials (OIDC)
-        uses: aws-actions/configure-aws-credentials@v6
+        uses: aws-actions/configure-aws-credentials@d979d5b3a71173a29b74b5b88418bfda9437d885 # v6
         with:
           role-to-assume: arn:aws:iam::278585680617:role/cloudless-github-actions
           aws-region: us-east-1

--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -33,7 +33,7 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
         with:
           version: 9
 
@@ -47,7 +47,7 @@ jobs:
 
       # Reuse the OIDC role already configured for deploys
       - name: Configure AWS credentials (OIDC)
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4
         with:
           role-to-assume: ${{ secrets.AWS_DEPLOY_ROLE_ARN }}
           aws-region: us-east-1

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -31,7 +31,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v6
-      - uses: pnpm/action-setup@v5
+      - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5
       - uses: actions/setup-node@v6
         with:
           node-version: 22
@@ -41,7 +41,7 @@ jobs:
       - name: Configure AWS credentials
         id: awscreds
         continue-on-error: true
-        uses: aws-actions/configure-aws-credentials@v6
+        uses: aws-actions/configure-aws-credentials@d979d5b3a71173a29b74b5b88418bfda9437d885 # v6
         with:
           role-to-assume: ${{ secrets.AWS_DEPLOY_ROLE_ARN }}
           role-session-name: gha-preview-${{ github.run_id }}
@@ -66,7 +66,7 @@ jobs:
 
       - name: Comment PR with preview URL
         if: steps.deploy.outputs.url != ''
-        uses: marocchino/sticky-pull-request-comment@v3
+        uses: marocchino/sticky-pull-request-comment@d4d6b0936434b21bc8345ad45a440c5f7d2c40ff # v3
         with:
           header: preview-url
           message: |

--- a/.github/workflows/pwa-audit.yml
+++ b/.github/workflows/pwa-audit.yml
@@ -24,7 +24,7 @@ jobs:
     timeout-minutes: 8
     steps:
       - uses: actions/checkout@v6
-      - uses: pnpm/action-setup@v5
+      - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5
       - uses: actions/setup-node@v6
         with:
           node-version: 22

--- a/.github/workflows/seo-hygiene.yml
+++ b/.github/workflows/seo-hygiene.yml
@@ -23,7 +23,7 @@ jobs:
     timeout-minutes: 8
     steps:
       - uses: actions/checkout@v6
-      - uses: pnpm/action-setup@v5
+      - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5
       - uses: actions/setup-node@v6
         with:
           node-version: 22

--- a/.github/workflows/sha-drift-detector.yml
+++ b/.github/workflows/sha-drift-detector.yml
@@ -38,7 +38,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
 
       - uses: actions/setup-node@v4
         with:
@@ -48,7 +48,7 @@ jobs:
       - run: pnpm install --frozen-lockfile
 
       - name: configure AWS credentials (OIDC)
-        uses: aws-actions/configure-aws-credentials@v6
+        uses: aws-actions/configure-aws-credentials@d979d5b3a71173a29b74b5b88418bfda9437d885 # v6
         with:
           role-to-assume: arn:aws:iam::278585680617:role/cloudless-github-actions
           aws-region: us-east-1

--- a/.github/workflows/structured-data-audit.yml
+++ b/.github/workflows/structured-data-audit.yml
@@ -23,7 +23,7 @@ jobs:
     timeout-minutes: 8
     steps:
       - uses: actions/checkout@v6
-      - uses: pnpm/action-setup@v5
+      - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5
       - uses: actions/setup-node@v6
         with:
           node-version: 22

--- a/.github/workflows/teardown-staging.yml
+++ b/.github/workflows/teardown-staging.yml
@@ -31,7 +31,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v5
+        uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5
 
       - name: Setup Node.js
         uses: actions/setup-node@v6
@@ -45,7 +45,7 @@ jobs:
       - name: Configure AWS credentials
         id: awscreds
         continue-on-error: true
-        uses: aws-actions/configure-aws-credentials@v6
+        uses: aws-actions/configure-aws-credentials@d979d5b3a71173a29b74b5b88418bfda9437d885 # v6
         with:
           role-to-assume: ${{ secrets.AWS_DEPLOY_ROLE_ARN }}
           role-session-name: gha-teardown-${{ github.run_id }}
@@ -67,7 +67,7 @@ jobs:
 
       - name: Comment on PR
         if: steps.awscreds.outcome == 'success'
-        uses: marocchino/sticky-pull-request-comment@v3
+        uses: marocchino/sticky-pull-request-comment@d4d6b0936434b21bc8345ad45a440c5f7d2c40ff # v3
         with:
           header: preview-url
           message: |

--- a/.github/workflows/weekly-gsc-sync.yml
+++ b/.github/workflows/weekly-gsc-sync.yml
@@ -33,7 +33,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v5
+        uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5
 
       - name: Setup Node.js
         uses: actions/setup-node@v6


### PR DESCRIPTION
## Summary

Codacy/Opengrep was flagging third-party actions referenced by floating tags (e.g. \`pnpm/action-setup@v5\`, \`treosh/lighthouse-ci-action@v12\`) as a supply-chain risk. Tag refs can be moved — a compromised maintainer account could redirect a tag to a malicious commit without breaking any existing workflow. SHA pinning makes each reference immutable.

Mechanical change across **24 files**. For every line of the form

\`\`\`yaml
uses: <third-party>/<repo>@<ref>
\`\`\`

where \`<ref>\` is not already a 40-char SHA, the ref is resolved to its current commit SHA and rewritten as

\`\`\`yaml
uses: <third-party>/<repo>@<sha> # <original-ref>
\`\`\`

The trailing comment keeps the version legible for humans.

### Scope

| Touched | Skipped |
|---|---|
| pnpm/, treosh/, dependabot/, aws-actions/, docker/, gitleaks/, lycheeverse/, marocchino/ | actions/* (GitHub-owned), github/* (GitHub-owned), local actions (\`./...\`) |

### Resolutions used

| Action | Original ref | Resolved SHA |
|---|---|---|
| aws-actions/amazon-ecr-login | v2 | fa648b43de3d4d023bcb3f89ed6940096949c419 |
| aws-actions/configure-aws-credentials | v4 | 7474bc4690e29a8392af63c5b98e7449536d5c3a |
| aws-actions/configure-aws-credentials | v6 | d979d5b3a71173a29b74b5b88418bfda9437d885 |
| dependabot/fetch-metadata | v3 | 25dd0e34f4fe68f24cc83900b1fe3fe149efef98 |
| docker/build-push-action | v6 | 10e90e3645eae34f1e60eeb005ba3a3d33f178e8 |
| docker/build-push-action | v7 | bcafcacb16a39f128d818304e6c9c0c18556b85f |
| docker/setup-buildx-action | v3 | 8d2750c68a42422c14e847fe6c8ac0403b4cbd6f |
| docker/setup-buildx-action | v4 | 4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd |
| docker/setup-qemu-action | v3 | c7c53464625b32c7a7e944ae62b3e17d2b600130 |
| lycheeverse/lychee-action | v2 | 8646ba30535128ac92d33dfc9133794bfdd9b411 |
| marocchino/sticky-pull-request-comment | v3 | d4d6b0936434b21bc8345ad45a440c5f7d2c40ff |
| pnpm/action-setup | v4 | b906affcce14559ad1aafd4ab0e942779e9f58b1 |
| pnpm/action-setup | v5 | fc06bc1257f339d1d5d8b3a19a8cae5388b55320 |
| treosh/lighthouse-ci-action | v12 | 3e7e23fb74242897f95c0ba9cabad3d0227b9b18 |

### Merge order

Conflicts widely with #151 and #156. Merge **after** those two — this PR is intentionally last.

To bump a pinned action: re-resolve via the GitHub API, or have Dependabot's github-actions ecosystem auto-PR new SHAs.

## Test plan

- [ ] All YAML files parse (\`python3 -c 'import yaml; yaml.safe_load(...)'\`) — passed locally
- [ ] Every workflow run resolves the SHA-pinned action (failure here would be visible as "Reference does not exist" in the run log)
- [ ] Codacy/Opengrep \`third-party-action-not-pinned-to-commit-sha\` finding count drops to zero on this branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)