### PR TITLE
ci: concurrency groups + path filters to cut queue churn

### DIFF
--- a/.github/workflows/a11y-audit.yml
+++ b/.github/workflows/a11y-audit.yml
@@ -17,6 +17,12 @@ permissions:
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
+concurrency:
+  # Cancel earlier in-flight runs for the same branch on a new push. The PR
+  # only cares about the latest commit, so older queued runs are wasted.
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   axe-playwright:
     name: Playwright A11y Checks

--- a/.github/workflows/a11y-audit.yml
+++ b/.github/workflows/a11y-audit.yml
@@ -8,7 +8,9 @@ on:
       - 'public/**'
       - 'package.json'
       - 'pnpm-lock.yaml'
-      - '.github/workflows/**'
+      # Self-reference only — editing unrelated workflows should not
+      # trigger the 15-min Playwright a11y run.
+      - '.github/workflows/a11y-audit.yml'
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/api-contract-audit.yml
+++ b/.github/workflows/api-contract-audit.yml
@@ -20,6 +20,12 @@ permissions:
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
+concurrency:
+  # Cancel earlier in-flight runs for the same branch on a new push. The PR
+  # only cares about the latest commit, so older queued runs are wasted.
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   contract-tests:
     name: API Contract Test Suite

--- a/.github/workflows/bundle-budget.yml
+++ b/.github/workflows/bundle-budget.yml
@@ -16,6 +16,12 @@ permissions:
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
+concurrency:
+  # Cancel earlier in-flight runs for the same branch on a new push. The PR
+  # only cares about the latest commit, so older queued runs are wasted.
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   bundle:
     name: Bundle Budget

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -23,6 +23,12 @@ permissions:
   actions: read
   contents: read
 
+concurrency:
+  # Cancel earlier in-flight runs for the same branch on a new push. The PR
+  # only cares about the latest commit, so older queued runs are wasted.
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   analyze:
     name: Analyze

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -3,10 +3,22 @@ name: Dependency Review Audit
 on:
   pull_request:
     branches: [main]
+    # Only review dependencies when dep files actually change. Code-only PRs
+    # cannot introduce a new GPL transitive or vulnerable package.
+    paths:
+      - 'package.json'
+      - 'pnpm-lock.yaml'
+      - 'pnpm-workspace.yaml'
 
 permissions:
   contents: read
   pull-requests: read
+
+concurrency:
+  # Cancel earlier in-flight runs for the same branch on a new push. The PR
+  # only cares about the latest commit, so older queued runs are wasted.
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   dependency-review:

--- a/.github/workflows/devcontainer.yml
+++ b/.github/workflows/devcontainer.yml
@@ -8,6 +8,12 @@ on:
     paths: ['.devcontainer/**']
   workflow_dispatch:
 
+concurrency:
+  # Cancel earlier in-flight runs for the same branch on a new push. The PR
+  # only cares about the latest commit, so older queued runs are wasted.
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     name: Build & Validate

--- a/.github/workflows/i18n-audit.yml
+++ b/.github/workflows/i18n-audit.yml
@@ -16,6 +16,12 @@ permissions:
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
+concurrency:
+  # Cancel earlier in-flight runs for the same branch on a new push. The PR
+  # only cares about the latest commit, so older queued runs are wasted.
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   i18n:
     name: Locale Parity and Placeholder Consistency

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -8,6 +8,12 @@ permissions:
   contents: read
   pull-requests: write
 
+concurrency:
+  # Cancel earlier in-flight runs for the same branch on a new push. The PR
+  # only cares about the latest commit, so older queued runs are wasted.
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   label:
     name: Auto-label

--- a/.github/workflows/links-audit.yml
+++ b/.github/workflows/links-audit.yml
@@ -13,6 +13,12 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  # Cancel earlier in-flight runs for the same branch on a new push. The PR
+  # only cares about the latest commit, so older queued runs are wasted.
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   links:
     name: Markdown Link Checker

--- a/.github/workflows/links-audit.yml
+++ b/.github/workflows/links-audit.yml
@@ -7,7 +7,9 @@ on:
       - "**/*.md"
       - "docs/**"
       - "README.md"
-      - ".github/workflows/**"
+      # Self-reference only — markdown changes already match **/*.md above,
+      # so editing unrelated workflows need not re-run the link checker.
+      - ".github/workflows/links-audit.yml"
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/mcp-security-scan.yml
+++ b/.github/workflows/mcp-security-scan.yml
@@ -2,8 +2,18 @@ name: MCP Security Scan
 
 on:
   pull_request:
+    # Scanner only inspects src/**/*.{ts,tsx,js,jsx,py,md}, so non-source PRs
+    # (docs, workflow tweaks, .env templates) can skip the scan.
+    paths:
+      - 'src/**'
+      - 'tools/mcp-security-scanner/**'
+      - '.github/workflows/mcp-security-scan.yml'
   push:
     branches: [main]
+    paths:
+      - 'src/**'
+      - 'tools/mcp-security-scanner/**'
+      - '.github/workflows/mcp-security-scan.yml'
   workflow_dispatch:
 
 permissions:
@@ -11,6 +21,12 @@ permissions:
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
+concurrency:
+  # Cancel earlier in-flight runs for the same branch on a new push. The PR
+  # only cares about the latest commit, so older queued runs are wasted.
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   scan:

--- a/.github/workflows/notion-schema-drift.yml
+++ b/.github/workflows/notion-schema-drift.yml
@@ -16,6 +16,12 @@ permissions:
   id-token: write
   contents: read
 
+concurrency:
+  # Cancel earlier in-flight runs for the same branch on a new push. The PR
+  # only cares about the latest commit, so older queued runs are wasted.
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   drift:
     name: notion-schema-sync --dry-run

--- a/.github/workflows/pwa-audit.yml
+++ b/.github/workflows/pwa-audit.yml
@@ -17,6 +17,12 @@ permissions:
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
+concurrency:
+  # Cancel earlier in-flight runs for the same branch on a new push. The PR
+  # only cares about the latest commit, so older queued runs are wasted.
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   pwa:
     name: Service Worker Runtime Tests

--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -15,6 +15,12 @@ permissions:
   pull-requests: read
   security-events: write
 
+concurrency:
+  # Cancel earlier in-flight runs for the same branch on a new push. The PR
+  # only cares about the latest commit, so older queued runs are wasted.
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   gitleaks:
     name: Gitleaks Scan

--- a/.github/workflows/seo-hygiene.yml
+++ b/.github/workflows/seo-hygiene.yml
@@ -16,6 +16,12 @@ permissions:
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
+concurrency:
+  # Cancel earlier in-flight runs for the same branch on a new push. The PR
+  # only cares about the latest commit, so older queued runs are wasted.
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   seo:
     name: Link Text and SEO Baseline

--- a/.github/workflows/structured-data-audit.yml
+++ b/.github/workflows/structured-data-audit.yml
@@ -16,6 +16,12 @@ permissions:
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
+concurrency:
+  # Cancel earlier in-flight runs for the same branch on a new push. The PR
+  # only cares about the latest commit, so older queued runs are wasted.
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   schema:
     name: JSON-LD Tests


### PR DESCRIPTION
## Summary

Cherry-pick of `28bed88d` onto current main. Directly addresses runner queue flooding observed with multiple open PRs.

- Adds `concurrency: {group: ..., cancel-in-progress: true}` to 15 PR-triggered audit workflows
- Adds path filters to `dependency-review` and `mcp-security-scan` so they only run when relevant files change
- Eliminates redundant queued runs when PRs are updated rapidly

## Workflows updated

`a11y-audit`, `api-contract-audit`, `bundle-budget`, `codeql`, `dependency-review`, `devcontainer`, `i18n-audit`, `labeler`, `links-audit`, `mcp-security-scan`, `notion-schema-drift`, `pwa-audit`, `secret-scan`, `seo-hygiene`, `structured-data-audit`

## Test plan

- [ ] Open a PR, push 2-3 commits rapidly — only the latest run should remain active per workflow
- [ ] Verify `dependency-review` and `mcp-security-scan` skip on non-source changes (e.g. docs-only PR)
- [ ] All 3 self-hosted runners stay available (no queue depth > 1 per runner)

Generated with Claude Code