### PR TITLE
ci: move non-cluster workflows to GitHub-hosted runners

### DIFF
--- a/.github/workflows/a11y-audit.yml
+++ b/.github/workflows/a11y-audit.yml
@@ -20,7 +20,7 @@ env:
 jobs:
   axe-playwright:
     name: Playwright A11y Checks
-    runs-on: [self-hosted, omv]
+    runs-on: ubuntu-latest
     timeout-minutes: 15
     env:
       NEXT_PUBLIC_COGNITO_USER_POOL_ID: ${{ secrets.NEXT_PUBLIC_COGNITO_USER_POOL_ID }}

--- a/.github/workflows/api-contract-audit.yml
+++ b/.github/workflows/api-contract-audit.yml
@@ -23,7 +23,7 @@ env:
 jobs:
   contract-tests:
     name: API Contract Test Suite
-    runs-on: [self-hosted, omv]
+    runs-on: ubuntu-latest
     timeout-minutes: 12
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/bundle-budget.yml
+++ b/.github/workflows/bundle-budget.yml
@@ -19,7 +19,7 @@ env:
 jobs:
   bundle:
     name: Bundle Budget
-    runs-on: [self-hosted, omv]
+    runs-on: ubuntu-latest
     timeout-minutes: 12
     env:
       NEXT_PUBLIC_COGNITO_USER_POOL_ID: ${{ secrets.NEXT_PUBLIC_COGNITO_USER_POOL_ID }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ permissions:
 jobs:
   lint:
     name: Lint
-    runs-on: [self-hosted, omv]
+    runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@v6
@@ -54,7 +54,7 @@ jobs:
 
   typecheck:
     name: Type Check
-    runs-on: [self-hosted, omv]
+    runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@v6
@@ -70,7 +70,7 @@ jobs:
 
   format:
     name: Format Check
-    runs-on: [self-hosted, omv]
+    runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@v6
@@ -86,7 +86,7 @@ jobs:
 
   build:
     name: Build
-    runs-on: [self-hosted, omv]
+    runs-on: ubuntu-latest
     timeout-minutes: 30
     env:
       NEXT_PUBLIC_COGNITO_USER_POOL_ID: ${{ secrets.NEXT_PUBLIC_COGNITO_USER_POOL_ID }}
@@ -110,7 +110,7 @@ jobs:
 
   test:
     name: Unit Tests
-    runs-on: [self-hosted, omv]
+    runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -26,7 +26,7 @@ permissions:
 jobs:
   analyze:
     name: Analyze
-    runs-on: [self-hosted, omv]
+    runs-on: ubuntu-latest
     timeout-minutes: 10
 
     strategy:

--- a/.github/workflows/core-web-vitals-audit.yml
+++ b/.github/workflows/core-web-vitals-audit.yml
@@ -16,7 +16,7 @@ jobs:
   audit:
     name: Route-level Lighthouse
     if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
-    runs-on: [self-hosted, omv]
+    runs-on: ubuntu-latest
     timeout-minutes: 12
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -11,7 +11,7 @@ permissions:
 jobs:
   automerge:
     name: Auto-merge patch/minor
-    runs-on: [self-hosted, omv]
+    runs-on: ubuntu-latest
     if: github.actor == 'dependabot[bot]'
 
     steps:

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -11,7 +11,7 @@ permissions:
 jobs:
   dependency-review:
     name: Dependency Risk Review
-    runs-on: [self-hosted, omv]
+    runs-on: ubuntu-latest
     timeout-minutes: 8
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -30,7 +30,7 @@ permissions:
 jobs:
   deploy:
     name: Deploy
-    runs-on: [self-hosted, omv]
+    runs-on: ubuntu-latest
     timeout-minutes: 40
     environment:
       name: production

--- a/.github/workflows/devcontainer.yml
+++ b/.github/workflows/devcontainer.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   build:
     name: Build & Validate
-    runs-on: [self-hosted, omv]
+    runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
       - name: Checkout

--- a/.github/workflows/ecr-lifecycle.yml
+++ b/.github/workflows/ecr-lifecycle.yml
@@ -10,7 +10,7 @@ env:
 jobs:
   ecr-cleanup:
     name: Set lifecycle policy and prune old images
-    runs-on: [self-hosted, omv]
+    runs-on: ubuntu-latest
     steps:
       - name: Configure AWS credentials (OIDC)
         uses: aws-actions/configure-aws-credentials@v4

--- a/.github/workflows/ha-sync-orchestrator.yml
+++ b/.github/workflows/ha-sync-orchestrator.yml
@@ -21,7 +21,7 @@ concurrency:
 jobs:
   ensure-pi-build:
     if: github.event.workflow_run.conclusion == 'success'
-    runs-on: [self-hosted, omv]
+    runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
       - name: resolve deploy metadata

--- a/.github/workflows/i18n-audit.yml
+++ b/.github/workflows/i18n-audit.yml
@@ -19,7 +19,7 @@ env:
 jobs:
   i18n:
     name: Locale Parity and Placeholder Consistency
-    runs-on: [self-hosted, omv]
+    runs-on: ubuntu-latest
     timeout-minutes: 8
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/k3s-e2e.yml
+++ b/.github/workflows/k3s-e2e.yml
@@ -53,7 +53,7 @@ jobs:
     if: |
       github.event_name != 'workflow_run' ||
       github.event.workflow_run.conclusion == 'success'
-    runs-on: [self-hosted, omv]
+    runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -11,7 +11,7 @@ permissions:
 jobs:
   label:
     name: Auto-label
-    runs-on: [self-hosted, omv]
+    runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
       - uses: actions/labeler@v5

--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -19,7 +19,7 @@ env:
 jobs:
   audit:
     name: Performance Audit
-    runs-on: [self-hosted, omv]
+    runs-on: ubuntu-latest
     if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
     timeout-minutes: 10
 

--- a/.github/workflows/links-audit.yml
+++ b/.github/workflows/links-audit.yml
@@ -16,7 +16,7 @@ permissions:
 jobs:
   links:
     name: Markdown Link Checker
-    runs-on: [self-hosted, omv]
+    runs-on: ubuntu-latest
     timeout-minutes: 8
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/mcp-security-scan.yml
+++ b/.github/workflows/mcp-security-scan.yml
@@ -15,7 +15,7 @@ env:
 jobs:
   scan:
     name: Run MCP security scanner
-    runs-on: [self-hosted, omv]
+    runs-on: ubuntu-latest
     # Informational only — scanner flags normal Next.js patterns (template
     # literals, process.env refs, console.error) as false positives.
     # Results are visible in the Actions log but do not block deploys.

--- a/.github/workflows/monthly-security-audit.yml
+++ b/.github/workflows/monthly-security-audit.yml
@@ -16,7 +16,7 @@ env:
 jobs:
   audit:
     name: Dependency Audit
-    runs-on: [self-hosted, omv]
+    runs-on: ubuntu-latest
     timeout-minutes: 10
 
     steps:

--- a/.github/workflows/notion-docs-sitemap.yml
+++ b/.github/workflows/notion-docs-sitemap.yml
@@ -18,7 +18,7 @@ env:
 jobs:
   sync:
     name: Sync Notion docs & blog slugs into sitemap
-    runs-on: [self-hosted, omv]
+    runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/notion-schema-check.yml
+++ b/.github/workflows/notion-schema-check.yml
@@ -19,7 +19,7 @@ env:
 jobs:
   validate:
     name: Validate Notion DB schemas
-    runs-on: [self-hosted, omv]
+    runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/notion-schema-drift.yml
+++ b/.github/workflows/notion-schema-drift.yml
@@ -19,7 +19,7 @@ permissions:
 jobs:
   drift:
     name: notion-schema-sync --dry-run
-    runs-on: [self-hosted, omv]
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
 

--- a/.github/workflows/pi-tls-cert-check.yml
+++ b/.github/workflows/pi-tls-cert-check.yml
@@ -45,7 +45,7 @@ env:
 jobs:
   probe:
     name: Probe SECONDARY failover
-    runs-on: [self-hosted, omv]
+    runs-on: ubuntu-latest
     timeout-minutes: 3
     steps:
       - name: TLS handshake + cert validity

--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -16,7 +16,7 @@ concurrency:
 jobs:
   review:
     name: Claude code review
-    runs-on: [self-hosted, omv]
+    runs-on: ubuntu-latest
     # Skip bots, dependabot, and revert branches
     if: |
       github.actor != 'dependabot[bot]' &&

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -26,7 +26,7 @@ permissions:
 jobs:
   preview:
     name: Deploy Preview
-    runs-on: [self-hosted, omv]
+    runs-on: ubuntu-latest
     timeout-minutes: 20
 
     steps:

--- a/.github/workflows/pwa-audit.yml
+++ b/.github/workflows/pwa-audit.yml
@@ -20,7 +20,7 @@ env:
 jobs:
   pwa:
     name: Service Worker Runtime Tests
-    runs-on: [self-hosted, omv]
+    runs-on: ubuntu-latest
     timeout-minutes: 8
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ permissions:
 jobs:
   release:
     name: Create GitHub Release
-    runs-on: [self-hosted, omv]
+    runs-on: ubuntu-latest
     if: github.event.workflow_run.conclusion == 'success'
 
     steps:

--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -18,7 +18,7 @@ permissions:
 jobs:
   gitleaks:
     name: Gitleaks Scan
-    runs-on: [self-hosted, omv]
+    runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/seo-hygiene.yml
+++ b/.github/workflows/seo-hygiene.yml
@@ -19,7 +19,7 @@ env:
 jobs:
   seo:
     name: Link Text and SEO Baseline
-    runs-on: [self-hosted, omv]
+    runs-on: ubuntu-latest
     timeout-minutes: 8
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/sha-drift-detector.yml
+++ b/.github/workflows/sha-drift-detector.yml
@@ -33,7 +33,7 @@ concurrency:
 jobs:
   detect:
     name: detect-sha-drift
-    runs-on: [self-hosted, omv]
+    runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/slack-manifest-apply.yml
+++ b/.github/workflows/slack-manifest-apply.yml
@@ -22,7 +22,7 @@ on:
 jobs:
   apply-manifest:
     name: Apply Slack Manifest
-    runs-on: [self-hosted, omv]
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -12,7 +12,7 @@ permissions:
 jobs:
   stale:
     name: Close Stale
-    runs-on: [self-hosted, omv]
+    runs-on: ubuntu-latest
     timeout-minutes: 5
     env:
       FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"

--- a/.github/workflows/structured-data-audit.yml
+++ b/.github/workflows/structured-data-audit.yml
@@ -19,7 +19,7 @@ env:
 jobs:
   schema:
     name: JSON-LD Tests
-    runs-on: [self-hosted, omv]
+    runs-on: ubuntu-latest
     timeout-minutes: 8
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/teardown-staging.yml
+++ b/.github/workflows/teardown-staging.yml
@@ -23,7 +23,7 @@ permissions:
 jobs:
   teardown:
     name: Destroy Staging Stack
-    runs-on: [self-hosted, omv]
+    runs-on: ubuntu-latest
     timeout-minutes: 15
 
     steps:

--- a/.github/workflows/weekly-gsc-sync.yml
+++ b/.github/workflows/weekly-gsc-sync.yml
@@ -16,7 +16,7 @@ permissions:
 jobs:
   sync:
     name: Sync GSC data to Notion
-    runs-on: [self-hosted, omv]
+    runs-on: ubuntu-latest
     timeout-minutes: 10
 
     env:


### PR DESCRIPTION
## Summary

`cloudless.gr` is a **public repo** — GitHub-hosted runners are free and unlimited. Yet all 42 workflows were pinned to `[self-hosted, omv]`, funnelling every CI job through 3 runners on a single Pi 5. With multiple open PRs this produced a **26+ run backlog**.

This moves every workflow that does **not** need cluster LAN access to `ubuntu-latest` — 39 job entries across 35 files.

## What stays self-hosted (and why)

| Workflow | Reason |
|----------|--------|
| `deploy-pi.yml` | `rollout` job runs `kubectl` / `sudo ctr` against the local k3s API (`192.168.1.128:6443`) |
| `build-pi-image.yml` | Builds arm64 natively on the Pi; QEMU cross-build on x86 is unviable (`pnpm install` alone >60 min) |

Both are `push`-triggered, so they never contributed to the PR-queue flood anyway.

## What moved to `ubuntu-latest`

CI (lint/typecheck/format/build/test), CodeQL, every audit (a11y, api-contract, bundle-budget, core-web-vitals, i18n, links, pwa, seo-hygiene, structured-data, mcp-security), `deploy`, `preview`, `teardown-staging`, `k3s-e2e`, `ha-sync-orchestrator`, `pi-tls-cert-check`, `sha-drift-detector`, `ecr-lifecycle`, `notion-*`, `labeler`, `pr-review`, `dependabot-automerge`, `release`, `stale`, `slack-manifest-apply`, `weekly-gsc-sync`, `monthly-security-audit`, `devcontainer`.

Note: `k3s-e2e` and `ha-sync-orchestrator` have "k3s" in their names but use only the GitHub API and the **public** `cloudless.online` URL — no cluster LAN. `pi-tls-cert-check` probes a **public** APIGW host. All verified by reading each file.

## Why it is safe

- All referenced secrets are repo secrets — available on any runner.
- AWS auth is OIDC — works from GitHub-hosted (the canonical OIDC environment).
- `cache: pnpm` and `actions/cache` already present where needed.
- Jobs run **faster** on dedicated x64 hosted runners than on a 3-way-shared Pi.

## Effect

- PR-triggered jobs on the Pi: ~20 → 0
- Backlog: 26 deep → none
- The 3 Pi runners now serve only the ~2 cluster-bound workflows and never queue.

## Test plan

- [ ] This PR's own CI runs on `ubuntu-latest` and passes
- [ ] `deploy-pi.yml` still resolves to a self-hosted runner on next push to main
- [ ] No queue depth >1 per Pi runner after merge

Generated with Claude Code