### PR TITLE
ci: pin cluster-bound workflows to dedicated pi runner label

### DIFF
--- a/.github/workflows/build-pi-image.yml
+++ b/.github/workflows/build-pi-image.yml
@@ -53,7 +53,7 @@ jobs:
     # GitHub-hosted ARM runner — native arm64, no QEMU. First build ~5-10 min,
     # subsequent cached builds ~2-3 min. Cross-compile via QEMU on x86 runners
     # was unviable (pnpm install alone exceeded 60min).
-    runs-on: [self-hosted, omv]
+    runs-on: [self-hosted, omv, pi]
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/deploy-pi.yml
+++ b/.github/workflows/deploy-pi.yml
@@ -27,7 +27,7 @@ env:
 jobs:
   build-and-push:
     name: Build arm64 image and push to ECR
-    runs-on: [self-hosted, omv]
+    runs-on: [self-hosted, omv, pi]
     outputs:
       sha: ${{ github.sha }}
       image_exists: ${{ steps.check_ecr.outputs.exists }}
@@ -110,7 +110,7 @@ jobs:
     # to the local k3s API (192.168.1.128:6443) without any VPN or tunnel.
     # Runs even if image already existed (build skipped) so re-dispatch always
     # repoints the deployment to the correct SHA.
-    runs-on: [self-hosted, omv]
+    runs-on: [self-hosted, omv, pi]
     needs: build-and-push
     if: always() && needs.build-and-push.result != 'cancelled' && (needs.build-and-push.result == 'success' || needs.build-and-push.outputs.image_exists == 'true')
 


### PR DESCRIPTION
## Summary

Prep for adding an extra self-hosted runner (interim CI capacity while GitHub-hosted runners are billing-locked — see #166).

`deploy-pi.yml` and `build-pi-image.yml` are the **only** workflows that genuinely require a Pi runner:
- `deploy-pi.yml` — runs `kubectl` / `sudo ctr` against the local k3s API (`192.168.1.128:6443`)
- `build-pi-image.yml` — builds `linux/arm64` natively

Every workflow currently shares `[self-hosted, omv]`, so any extra self-hosted runner (e.g. an x64 laptop) would become eligible for these two jobs and **fail** them.

## Change

- The 3 Pi runners now also carry a `pi` label (added via the runners API — already live).
- These two workflows are pinned to `[self-hosted, omv, pi]` → Pi-exclusive.
- CI/audit workflows stay on `[self-hosted, omv]` → can be served by any added runner.

## Ordering

The `pi` label is **already on all 3 Pi runners**, so this is safe to merge immediately — the runners match `[self-hosted, omv, pi]` right now.

## Test plan

- [ ] After merge, next push to main: `deploy-pi` + `build-pi-image` still resolve to a Pi runner
- [ ] An added non-Pi `omv`-labelled runner never picks up these two workflows

Generated with Claude Code