### PR TITLE
ci: fix self-hosted runner failures (checkout@v4, Dockerfile patches, stale node_modules)

### DIFF
--- a/.github/workflows/a11y-audit.yml
+++ b/.github/workflows/a11y-audit.yml
@@ -27,9 +27,9 @@ jobs:
       NEXT_PUBLIC_COGNITO_CLIENT_ID: ${{ secrets.NEXT_PUBLIC_COGNITO_CLIENT_ID }}
       NEXT_PUBLIC_HUBSPOT_PORTAL_ID: ${{ secrets.NEXT_PUBLIC_HUBSPOT_PORTAL_ID }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v5
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@v4
         with:
           node-version: 22
           cache: pnpm

--- a/.github/workflows/api-contract-audit.yml
+++ b/.github/workflows/api-contract-audit.yml
@@ -26,9 +26,9 @@ jobs:
     runs-on: [self-hosted, omv]
     timeout-minutes: 12
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v5
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@v4
         with:
           node-version: 22
           cache: pnpm

--- a/.github/workflows/bundle-budget.yml
+++ b/.github/workflows/bundle-budget.yml
@@ -31,12 +31,14 @@ jobs:
       #     /portal/[token] timeline, admin pending-clients UI, lucide-react icons (~25KB).
       BUNDLE_MAX_KB: "1900"
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v5
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@v4
         with:
           node-version: 22
           cache: pnpm
+      - name: Clean stale workspace
+        run: rm -rf node_modules .next
       - run: pnpm install --frozen-lockfile
       - run: pnpm build
       - run: node scripts/audit/check-bundle-budget.mjs

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,11 +41,11 @@ jobs:
     runs-on: [self-hosted, omv]
     timeout-minutes: 20
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v5
         with:
           dest: ~/setup-pnpm-${{ runner.name }}
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@v4
         with:
           node-version: 22
           cache: pnpm
@@ -57,11 +57,11 @@ jobs:
     runs-on: [self-hosted, omv]
     timeout-minutes: 20
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v5
         with:
           dest: ~/setup-pnpm-${{ runner.name }}
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@v4
         with:
           node-version: 22
           cache: pnpm
@@ -73,11 +73,11 @@ jobs:
     runs-on: [self-hosted, omv]
     timeout-minutes: 20
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v5
         with:
           dest: ~/setup-pnpm-${{ runner.name }}
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@v4
         with:
           node-version: 22
           cache: pnpm
@@ -97,11 +97,11 @@ jobs:
       SENTRY_PROJECT: cloudless-gr
       NEXT_PUBLIC_SENTRY_DSN: ${{ secrets.NEXT_PUBLIC_SENTRY_DSN }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v5
         with:
           dest: ~/setup-pnpm-${{ runner.name }}
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@v4
         with:
           node-version: 22
           cache: pnpm
@@ -113,11 +113,11 @@ jobs:
     runs-on: [self-hosted, omv]
     timeout-minutes: 20
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v5
         with:
           dest: ~/setup-pnpm-${{ runner.name }}
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@v4
         with:
           node-version: 22
           cache: pnpm

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -35,7 +35,7 @@ jobs:
         language: ['javascript-typescript']
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v4
 
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v4

--- a/.github/workflows/core-web-vitals-audit.yml
+++ b/.github/workflows/core-web-vitals-audit.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: [self-hosted, omv]
     timeout-minutes: 12
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v4
       - name: Run Lighthouse on key routes
         id: lhci
         uses: treosh/lighthouse-ci-action@v12

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: [self-hosted, omv]
     timeout-minutes: 8
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v4
       - name: Review dependencies
         uses: actions/dependency-review-action@v4
         with:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -44,13 +44,13 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v4
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v5
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v4
         with:
           node-version: 22
           cache: pnpm

--- a/.github/workflows/devcontainer.yml
+++ b/.github/workflows/devcontainer.yml
@@ -15,7 +15,7 @@ jobs:
     timeout-minutes: 20
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v4
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4

--- a/.github/workflows/i18n-audit.yml
+++ b/.github/workflows/i18n-audit.yml
@@ -22,9 +22,9 @@ jobs:
     runs-on: [self-hosted, omv]
     timeout-minutes: 8
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v5
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@v4
         with:
           node-version: 22
           cache: pnpm

--- a/.github/workflows/k3s-e2e.yml
+++ b/.github/workflows/k3s-e2e.yml
@@ -56,7 +56,7 @@ jobs:
     runs-on: [self-hosted, omv]
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v4
 
       - uses: pnpm/action-setup@v4
 

--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -24,7 +24,7 @@ jobs:
     timeout-minutes: 10
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v4
 
       - name: Run Lighthouse
         id: lighthouse

--- a/.github/workflows/links-audit.yml
+++ b/.github/workflows/links-audit.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: [self-hosted, omv]
     timeout-minutes: 8
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v4
       - name: Check links
         uses: lycheeverse/lychee-action@v2
         with:

--- a/.github/workflows/mcp-security-scan.yml
+++ b/.github/workflows/mcp-security-scan.yml
@@ -22,10 +22,10 @@ jobs:
     continue-on-error: true
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v4
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v4
         with:
           node-version: 22
 

--- a/.github/workflows/monthly-security-audit.yml
+++ b/.github/workflows/monthly-security-audit.yml
@@ -21,13 +21,13 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v4
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v5
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v4
         with:
           node-version: 22
           cache: pnpm

--- a/.github/workflows/notion-docs-sitemap.yml
+++ b/.github/workflows/notion-docs-sitemap.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: [self-hosted, omv]
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v4
         with:
           ref: main
 

--- a/.github/workflows/notion-schema-check.yml
+++ b/.github/workflows/notion-schema-check.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: [self-hosted, omv]
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v4
 
       - name: Validate Blog DB schema
         if: ${{ env.NOTION_BLOG_DB_ID != '' }}

--- a/.github/workflows/notion-schema-drift.yml
+++ b/.github/workflows/notion-schema-drift.yml
@@ -21,7 +21,7 @@ jobs:
     name: notion-schema-sync --dry-run
     runs-on: [self-hosted, omv]
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v4
 
       - uses: pnpm/action-setup@v4
 

--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -29,13 +29,13 @@ jobs:
       id-token: write  # for OIDC → AWS (to fetch ANTHROPIC_API_KEY from SSM)
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
       - uses: pnpm/action-setup@v5
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@v4
         with:
           node-version: 22
           cache: pnpm

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -30,9 +30,9 @@ jobs:
     timeout-minutes: 20
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v5
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@v4
         with:
           node-version: 22
           cache: pnpm

--- a/.github/workflows/pwa-audit.yml
+++ b/.github/workflows/pwa-audit.yml
@@ -23,9 +23,9 @@ jobs:
     runs-on: [self-hosted, omv]
     timeout-minutes: 8
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v5
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@v4
         with:
           node-version: 22
           cache: pnpm

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ jobs:
     if: github.event.workflow_run.conclusion == 'success'
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
 

--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: [self-hosted, omv]
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - name: Run Gitleaks

--- a/.github/workflows/seo-hygiene.yml
+++ b/.github/workflows/seo-hygiene.yml
@@ -22,9 +22,9 @@ jobs:
     runs-on: [self-hosted, omv]
     timeout-minutes: 8
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v5
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@v4
         with:
           node-version: 22
       - name: Check descriptive link text

--- a/.github/workflows/sha-drift-detector.yml
+++ b/.github/workflows/sha-drift-detector.yml
@@ -36,11 +36,11 @@ jobs:
     runs-on: [self-hosted, omv]
     timeout-minutes: 5
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v4
 
       - uses: pnpm/action-setup@v5
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@v4
         with:
           node-version: 22
           cache: pnpm

--- a/.github/workflows/structured-data-audit.yml
+++ b/.github/workflows/structured-data-audit.yml
@@ -22,9 +22,9 @@ jobs:
     runs-on: [self-hosted, omv]
     timeout-minutes: 8
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v5
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@v4
         with:
           node-version: 22
           cache: pnpm

--- a/.github/workflows/teardown-staging.yml
+++ b/.github/workflows/teardown-staging.yml
@@ -28,13 +28,13 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v4
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v5
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v4
         with:
           node-version: 22
           cache: pnpm

--- a/.github/workflows/weekly-gsc-sync.yml
+++ b/.github/workflows/weekly-gsc-sync.yml
@@ -30,13 +30,13 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v4
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v5
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v4
         with:
           node-version: 22
           cache: pnpm

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,6 @@ ARG PNPM_VERSION
 RUN corepack enable && corepack prepare pnpm@${PNPM_VERSION} --activate
 WORKDIR /app
 COPY package.json pnpm-lock.yaml pnpm-workspace.yaml .npmrc ./
-COPY patches ./patches
 RUN --mount=type=cache,id=pnpm-store,target=/root/.local/share/pnpm/store \
     pnpm install --frozen-lockfile --prefer-offline
 


### PR DESCRIPTION
## Summary

- **actions/checkout@v6 to @v4 in all 28 workflows** — the self-hosted legion runner binary only supports up to node20; checkout@v6 requires node24, causing every job on legion/omv to fail at setup with "using: node24 is not supported"
- **Remove COPY patches ./patches from Dockerfile** — the patches/ directory does not exist in the repo; caused build pi image to fail with a Docker checksum error on every push to main
- **actions/setup-node@v6 to @v4 in 16 workflows** — same node24 incompatibility
- **Clean stale workspace in bundle-budget.yml** — adds rm -rf node_modules .next before pnpm install to prevent ERR_PNPM_JSON_PARSE from corrupted packages left behind on the self-hosted runner

## Affected workflows (6 failures fixed)
- Secret Leakage Audit, Accessibility Audit, Notion schema drift, Notion to Sitemap Sync: fixed by checkout/setup-node downgrade
- build pi image: fixed by removing missing patches/ COPY
- Bundle Budget Audit: fixed by workspace cleanup step

## Test plan
- [ ] Secret Leakage Audit passes on next push
- [ ] Accessibility Audit passes on next PR
- [ ] Notion schema drift passes
- [ ] Notion to Sitemap Sync passes
- [ ] build pi image completes without Docker checksum error
- [ ] Bundle Budget Audit completes without ERR_PNPM_JSON_PARSE

Generated with [Claude Code](https://claude.com/claude-code)