### PR TITLE
ci: move ha-sync-orchestrator to GitHub-hosted runner (billing resolved)

### DIFF
--- a/.github/workflows/ha-sync-orchestrator.yml
+++ b/.github/workflows/ha-sync-orchestrator.yml
@@ -21,7 +21,7 @@ concurrency:
 jobs:
   ensure-pi-build:
     if: github.event.workflow_run.conclusion == 'success'
-    runs-on: [self-hosted, omv]
+    runs-on: ubuntu-latest
     # Pi builds can sit queued on the self-hosted runner for 30+ min on a busy
     # day before doing ~1 min of actual work. Job timeout must cover the
     # combined Pi-build wait (max ~45 min, see below) plus the k3s-rollout


### PR DESCRIPTION
## Summary

Billing issue is **resolved** — GitHub-hosted runners are available again.

The runs-on revert in #171 never actually landed (only its dependency-review fix merged), so `main` has had 33 of 34 non-cluster workflows on `ubuntu-latest` the whole time. `ha-sync-orchestrator.yml` was the lone straggler still on `[self-hosted, omv]`. This flips it — completing the move of all non-cluster CI to GitHub-hosted runners.

## Why this matters

The infra health check found the self-hosted runners' CI load (Next.js builds, zstd compression, `Runner.Worker`) drove **omv-main to load 13+** and **starved out k3s** (the cluster went down). Moving per-PR CI off the Pi removes that contention — the Pi runners now only handle occasional `deploy-pi` / `build-pi-image` jobs.

## Stays self-hosted

`deploy-pi.yml` and `build-pi-image.yml` keep `[self-hosted, omv, pi]` — they need the local k3s API (`192.168.1.128:6443`) and native arm64.

## Test plan

- [ ] This PR's CI runs on `ubuntu-latest` and passes (proves billing is unlocked)
- [ ] omv-main load drops once per-PR CI stops landing on the Pi

Generated with Claude Code