### PR TITLE
ci: move arm64 builds to GitHub-hosted ubuntu-24.04-arm runners

### DIFF
--- a/.github/workflows/build-pi-image.yml
+++ b/.github/workflows/build-pi-image.yml
@@ -53,7 +53,7 @@ jobs:
     # GitHub-hosted ARM runner — native arm64, no QEMU. First build ~5-10 min,
     # subsequent cached builds ~2-3 min. Cross-compile via QEMU on x86 runners
     # was unviable (pnpm install alone exceeded 60min).
-    runs-on: [self-hosted, omv, pi]
+    runs-on: ubuntu-24.04-arm
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4 # v6.0.2

--- a/.github/workflows/deploy-pi.yml
+++ b/.github/workflows/deploy-pi.yml
@@ -27,7 +27,9 @@ env:
 jobs:
   build-and-push:
     name: Build arm64 image and push to ECR
-    runs-on: [self-hosted, omv, pi]
+    # GitHub-hosted native arm64 runner — no QEMU, and no build load on the
+    # Pi. Only the rollout job below needs a self-hosted runner (local k3s API).
+    runs-on: ubuntu-24.04-arm
     outputs:
       sha: ${{ github.sha }}
       image_exists: ${{ steps.check_ecr.outputs.exists }}


### PR DESCRIPTION
## Summary

The infra health check found the self-hosted runners' **arm64 image builds** drove omv-main to **load 18** and **starved out k3s** — the whole cluster went down.

This moves the heavy builds to **GitHub-hosted `ubuntu-24.04-arm`** — native arm64, no QEMU, **zero build load on the Pi**:

- `build-pi-image.yml` → `ubuntu-24.04-arm` (its own comment already described this as the intended setup — the `runs-on` just never matched it)
- `deploy-pi.yml` **build-and-push** job → `ubuntu-24.04-arm`

### Stays self-hosted

`deploy-pi.yml`'s **`rollout`** job keeps `[self-hosted, omv, pi]` — it runs `kubectl`/`ctr` against the local k3s API (`192.168.1.128:6443`) and genuinely needs the Pi. But it's lightweight (~30 s, no build) and cannot starve the cluster.

## Net effect

All heavy CI + build load is now off the Pi. The self-hosted runners only handle the lightweight k3s rollout step — no more cluster-killing contention.

## Test plan

- [ ] Next push to `main`: `build-pi-image` / `deploy-pi build` run on `ubuntu-24.04-arm`
- [ ] `deploy-pi rollout` still resolves to a Pi runner and completes
- [ ] omv-main load stays low during a deploy

Generated with Claude Code