### PR TITLE
ci: run k3s rollout on hosted runner over Tailscale (remove last Pi runner)

### DIFF
--- a/.github/workflows/deploy-pi.yml
+++ b/.github/workflows/deploy-pi.yml
@@ -108,39 +108,35 @@ jobs:
 
   rollout:
     name: Rollout restart on k3s
-    # Runs on the self-hosted runner on omv-main — has direct kubectl access
-    # to the local k3s API (192.168.1.128:6443) without any VPN or tunnel.
+    # Runs on a GitHub-hosted runner that joins the tailnet via Tailscale and
+    # reaches the k3s API over it (omv-main = 100.113.41.119:6443). No
+    # self-hosted runner on the Pi is required.
     # Runs even if image already existed (build skipped) so re-dispatch always
     # repoints the deployment to the correct SHA.
-    runs-on: [self-hosted, omv, pi]
+    runs-on: ubuntu-latest
     needs: build-and-push
     if: always() && needs.build-and-push.result != 'cancelled' && (needs.build-and-push.result == 'success' || needs.build-and-push.outputs.image_exists == 'true')
 
     steps:
-      - name: Configure AWS credentials (OIDC)
-        uses: aws-actions/configure-aws-credentials@v4 # v4
+      - name: Connect to tailnet
+        uses: tailscale/github-action@v3
         with:
-          role-to-assume: ${{ secrets.AWS_DEPLOY_ROLE_ARN }}
-          aws-region: ${{ env.AWS_REGION }}
+          authkey: ${{ secrets.TS_AUTHKEY }}
 
-      - name: Pre-pull image into containerd (k8s.io namespace)
-        # Pull the image directly into the containerd namespace that k3s uses
-        # (k8s.io) before triggering the rollout. This means the pod starts
-        # immediately rather than waiting 4+ min for in-rollout ECR pull.
-        # Uses sudo ctr (bundled with k3s) which correctly handles the k8s.io
-        # namespace and ECR auth. k3s ctr and crictl both ignore ECR credentials.
+      - name: Configure kubectl
+        # KUBECONFIG_B64 is base64 of /etc/rancher/k3s/k3s.yaml with the server
+        # rewritten to the tailnet address https://100.113.41.119:6443.
         run: |
-          IMAGE="${{ env.ECR_REGISTRY }}/${{ env.ECR_REPOSITORY }}:${{ needs.build-and-push.outputs.sha }}"
-          ECR_TOKEN=$(aws ecr get-login-password --region ${{ env.AWS_REGION }})
-          echo "Pre-pulling ${IMAGE} into containerd k8s.io namespace..."
-          sudo ctr -n k8s.io images pull -u "AWS:${ECR_TOKEN}" "${IMAGE}"
-          echo "Pre-pull complete."
+          mkdir -p ~/.kube
+          echo "${{ secrets.KUBECONFIG_B64 }}" | base64 -d > ~/.kube/config
+          chmod 600 ~/.kube/config
 
-      - name: Set image and rollout
+      - name: Set image and roll out
         run: |
           kubectl set image deployment/${{ env.K3S_DEPLOYMENT }} \
             ${{ env.K3S_DEPLOYMENT }}=${{ env.ECR_REGISTRY }}/${{ env.ECR_REPOSITORY }}:${{ needs.build-and-push.outputs.sha }} \
             -n ${{ env.K3S_NAMESPACE }}
-          # Image is already local — rollout completes in <30s
+          # No local ctr pre-pull when running off-Pi — the pod pulls the image
+          # from ECR via the in-cluster ecr-cred-refresher. Allow time for that.
           kubectl rollout status deployment/${{ env.K3S_DEPLOYMENT }} \
-            -n ${{ env.K3S_NAMESPACE }} --timeout=180s
+            -n ${{ env.K3S_NAMESPACE }} --timeout=420s


### PR DESCRIPTION
## Summary

The final step to remove **all GitHub Actions runners from the Pi**. `deploy-pi`'s `rollout` job was the last thing needing a self-hosted runner.

It now runs on **`ubuntu-latest`**, joins the tailnet via `tailscale/github-action`, and reaches the k3s API over Tailscale (`omv-main = 100.113.41.119:6443` — verified: k3s listens on all interfaces, omv-main is on the tailnet).

### Changes
- `runs-on: [self-hosted, omv, pi]` → `ubuntu-latest`
- Joins tailnet, runs `kubectl` via a `KUBECONFIG_B64` secret
- Dropped the AWS-OIDC step and the `sudo ctr` containerd pre-pull (both needed local Pi access). The pod now pulls from ECR via the in-cluster `ecr-cred-refresher`; rollout timeout raised `180s → 420s`.

## ⚠️ DRAFT — needs 2 secrets before merge

This **will fail** if merged before these repo secrets exist:

| Secret | How |
|--------|-----|
| `TS_AUTHKEY` | Tailscale ephemeral, reusable, **tagged** auth key — created in your Tailscale admin console. *(Only you can mint this.)* |
| `KUBECONFIG_B64` | base64 of `/etc/rancher/k3s/k3s.yaml`, with `server:` rewritten to `https://100.113.41.119:6443` |

Once both secrets exist → mark ready → merge → **no runner remains on the Pi**.

Generated with Claude Code