### PR TITLE
fix(email): extract nested ternary in notifyTeam (SonarCloud S3358)

### DIFF
--- a/src/lib/email.ts
+++ b/src/lib/email.ts
@@ -335,13 +335,13 @@ export async function notifyTeam(subject: string, body: string): Promise<void> {
     // regex backtracking patterns that static analysers flag as ReDoS-prone.
     text: body
       .split("<")
-      .map((seg, i) =>
-        i === 0
-          ? seg
-          : seg.includes(">")
-            ? seg.slice(seg.indexOf(">") + 1)
-            : "",
-      )
+      .map((seg, i) => {
+        // First segment is plain text before any tag — keep as-is.
+        if (i === 0) return seg;
+        // Later segments start mid-tag: drop up to and including the ">".
+        if (seg.includes(">")) return seg.slice(seg.indexOf(">") + 1);
+        return "";
+      })
       .join(""),
   });
 }


### PR DESCRIPTION
Resolves SonarCloud `typescript:S3358` (*Ternary operators should not be nested*) in `src/lib/email.ts`.

The plain-text HTML-stripping `.map()` callback in `notifyTeam` used a nested ternary:
`i === 0 ? seg : seg.includes('>') ? seg.slice(...) : ''`.

Rewritten as a block body with guard `if` returns — **identical logic**, no nesting, more readable.

Generated with Claude Code