### PR TITLE
fix: repair malformed .mcp.json + trigger CI on changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,7 @@ on:
       - 'pnpm-lock.yaml'
       - 'tsconfig.json'
       - 'mcp.json'
+      - '.mcp.json'
       - '.github/workflows/**'
       # Root-level config that affects build/lint/quality gates.
       # Without these, PRs editing only these files hang on the required

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,1 +1,3 @@
-mcp.json
+{
+  "mcpServers": {}
+}


### PR DESCRIPTION
## Summary
- `.mcp.json` was an 8-byte stub literally containing `mcp.json` (invalid JSON). Replaced with `{"mcpServers": {}}`.
- Added `.mcp.json` to `ci.yml` `pull_request.paths` so future edits trigger the required `Build` check.

## Why
A `.mcp.json`-only PR would otherwise never run `Build` and hang indefinitely on the required status.

🤖 Generated with [Claude Code](https://claude.com/claude-code)