### PR TITLE
fix(cron): read CRON_SECRET from SSM — cron routes work on both SST and Pi

### DIFF
--- a/__tests__/cron-auth.test.ts
+++ b/__tests__/cron-auth.test.ts
@@ -1,6 +1,13 @@
-import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { NextRequest } from "next/server";
+
+// Mock getConfig before importing cron-auth so no AWS calls are made in CI
+vi.mock("@/lib/ssm-config", () => ({
+  getConfig: vi.fn().mockResolvedValue({ CRON_SECRET: "" }),
+}));
+
 import { isCronAuthorized, cronUnauthorized } from "@/lib/cron-auth";
+import { getConfig } from "@/lib/ssm-config";
 
 function makeRequest(authHeader?: string): NextRequest {
   const headers: Record<string, string> = {};
@@ -13,41 +20,50 @@ describe("isCronAuthorized()", () => {
 
   beforeEach(() => {
     process.env.CRON_SECRET = secret;
+    vi.mocked(getConfig).mockResolvedValue({ CRON_SECRET: "" } as any);
   });
 
   afterEach(() => {
     delete process.env.CRON_SECRET;
+    vi.clearAllMocks();
   });
 
-  it("returns true when Bearer token matches CRON_SECRET", () => {
+  it("returns true when Bearer token matches CRON_SECRET", async () => {
     const req = makeRequest(`Bearer ${secret}`);
-    expect(isCronAuthorized(req)).toBe(true);
+    expect(await isCronAuthorized(req)).toBe(true);
   });
 
-  it("returns false when token does not match", () => {
+  it("returns false when token does not match", async () => {
     const req = makeRequest("Bearer wrong-token");
-    expect(isCronAuthorized(req)).toBe(false);
+    expect(await isCronAuthorized(req)).toBe(false);
   });
 
-  it("returns false when authorization header is absent", () => {
+  it("returns false when authorization header is absent", async () => {
     const req = makeRequest();
-    expect(isCronAuthorized(req)).toBe(false);
+    expect(await isCronAuthorized(req)).toBe(false);
   });
 
-  it("returns false when header is present but missing Bearer prefix", () => {
+  it("returns false when header is present but missing Bearer prefix", async () => {
     const req = makeRequest(secret);
-    expect(isCronAuthorized(req)).toBe(false);
+    expect(await isCronAuthorized(req)).toBe(false);
   });
 
-  it("returns false when CRON_SECRET is not set", () => {
+  it("returns false when CRON_SECRET is not set", async () => {
     delete process.env.CRON_SECRET;
     const req = makeRequest(`Bearer ${secret}`);
-    expect(isCronAuthorized(req)).toBe(false);
+    expect(await isCronAuthorized(req)).toBe(false);
   });
 
-  it("is case-sensitive on the token value", () => {
+  it("is case-sensitive on the token value", async () => {
     const req = makeRequest(`Bearer ${secret.toUpperCase()}`);
-    expect(isCronAuthorized(req)).toBe(false);
+    expect(await isCronAuthorized(req)).toBe(false);
+  });
+
+  it("uses SSM CRON_SECRET when available, ignoring env var", async () => {
+    vi.mocked(getConfig).mockResolvedValue({ CRON_SECRET: secret } as any);
+    delete process.env.CRON_SECRET;
+    const req = makeRequest(`Bearer ${secret}`);
+    expect(await isCronAuthorized(req)).toBe(true);
   });
 });
 

--- a/src/app/api/cron/analytics-rollup/route.ts
+++ b/src/app/api/cron/analytics-rollup/route.ts
@@ -8,7 +8,7 @@ import { SlackClient } from "@/lib/slack-notify";
 import { isCronAuthorized, cronUnauthorized } from "@/lib/cron-auth";
 
 export async function GET(request: NextRequest) {
-  if (!isCronAuthorized(request)) {
+  if (!(await isCronAuthorized(request))) {
     return cronUnauthorized();
   }
 

--- a/src/app/api/cron/calendar-digest/route.ts
+++ b/src/app/api/cron/calendar-digest/route.ts
@@ -11,7 +11,7 @@ const STATUS_EMOJI: Record<string, string> = {
 };
 
 export async function GET(request: NextRequest) {
-  if (!isCronAuthorized(request)) {
+  if (!(await isCronAuthorized(request))) {
     return cronUnauthorized();
   }
 

--- a/src/app/api/cron/report-cleanup/route.ts
+++ b/src/app/api/cron/report-cleanup/route.ts
@@ -6,7 +6,7 @@ import { isCronAuthorized, cronUnauthorized } from "@/lib/cron-auth";
 const STALE_THRESHOLD_MS = 2 * 60 * 60 * 1000;
 
 export async function GET(request: NextRequest) {
-  if (!isCronAuthorized(request)) {
+  if (!(await isCronAuthorized(request))) {
     return cronUnauthorized();
   }
 

--- a/src/app/api/cron/voice-brief/route.ts
+++ b/src/app/api/cron/voice-brief/route.ts
@@ -92,7 +92,7 @@ async function buildBriefText(
 }
 
 export async function GET(request: NextRequest) {
-  if (!isCronAuthorized(request)) {
+  if (!(await isCronAuthorized(request))) {
     return cronUnauthorized();
   }
 

--- a/src/lib/cron-auth.ts
+++ b/src/lib/cron-auth.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { timingSafeEqual } from "node:crypto";
+import { getConfig } from "@/lib/ssm-config";
 
 const BEARER_PREFIX = "Bearer ";
 
@@ -10,8 +11,9 @@ function safeEqual(a: string, b: string): boolean {
   return timingSafeEqual(aBuf, bBuf);
 }
 
-export function isCronAuthorized(request: NextRequest): boolean {
-  const expected = process.env.CRON_SECRET;
+export async function isCronAuthorized(request: NextRequest): Promise<boolean> {
+  const config = await getConfig();
+  const expected = config.CRON_SECRET || process.env.CRON_SECRET;
   if (!expected) return false;
   const header = request.headers.get("authorization");
   if (!header || !header.startsWith(BEARER_PREFIX)) return false;

--- a/src/lib/ssm-config.ts
+++ b/src/lib/ssm-config.ts
@@ -85,6 +85,8 @@ interface AppConfig {
   META_PAGE_ID: string;
   // GitHub Actions
   GITHUB_TOKEN: string;
+  // Cron auth
+  CRON_SECRET: string;
   // AI
   ANTHROPIC_API_KEY: string;
   ANTHROPIC_CHAT_MODEL: string;
@@ -171,6 +173,7 @@ function buildConfigFromEnv(): AppConfig {
     META_ACCESS_TOKEN: process.env.META_ACCESS_TOKEN || "",
     META_PAGE_ID: process.env.META_PAGE_ID || "",
     GITHUB_TOKEN: process.env.GITHUB_TOKEN || "",
+    CRON_SECRET: process.env.CRON_SECRET || "",
     ANTHROPIC_API_KEY: process.env.ANTHROPIC_API_KEY || "",
     ANTHROPIC_CHAT_MODEL: process.env.ANTHROPIC_CHAT_MODEL || "",
   };
@@ -327,6 +330,7 @@ export async function getConfig(): Promise<AppConfig> {
     META_ACCESS_TOKEN: params.get("META_ACCESS_TOKEN") ?? "",
     META_PAGE_ID: params.get("META_PAGE_ID") ?? "",
     GITHUB_TOKEN: params.get("GITHUB_TOKEN") ?? "",
+    CRON_SECRET: params.get("CRON_SECRET") ?? "",
     ANTHROPIC_API_KEY: params.get("ANTHROPIC_API_KEY") ?? "",
     ANTHROPIC_CHAT_MODEL: params.get("ANTHROPIC_CHAT_MODEL") ?? "",
   };


### PR DESCRIPTION
Fixes all 4 cron routes returning 401. isCronAuthorized now reads CRON_SECRET from SSM via getConfig() instead of process.env which was never set on either deployment. Adds CRON_SECRET to AppConfig + both config builders.