### PR TITLE
ci(deploy): SSH to omv-main via Tailscale instead of direct k3s API

### DIFF
--- a/.github/workflows/deploy-pi.yml
+++ b/.github/workflows/deploy-pi.yml
@@ -106,19 +106,28 @@ jobs:
             --value "${{ github.sha }}" \
             --type String --overwrite
 
+
   rollout:
     name: Rollout restart on k3s
-    # Runs on the self-hosted omv runner — same machine as k3s.
-    # No Tailscale tunnel or remote kubeconfig needed.
-    runs-on: [self-hosted, omv]
+    # GH-hosted runner joins tailnet, SSHes to omv-main, runs kubectl locally.
+    # Avoids exposing k3s port 6443 over Tailscale.
+    runs-on: ubuntu-latest
     needs: build-and-push
     if: always() && needs.build-and-push.result != 'cancelled' && (needs.build-and-push.result == 'success' || needs.build-and-push.outputs.image_exists == 'true')
 
     steps:
+      - name: Connect to tailnet
+        uses: tailscale/github-action@v3
+        with:
+          authkey: ${{ secrets.TS_AUTHKEY }}
+      - name: Set up SSH deploy key
+        run: |
+          install -m 600 /dev/null ~/.ssh/deploy_key
+          echo "${{ secrets.SSH_DEPLOY_KEY }}" > ~/.ssh/deploy_key
       - name: Set image and roll out
         run: |
-          sudo k3s kubectl set image deployment/${{ env.K3S_DEPLOYMENT }} \
-            ${{ env.K3S_DEPLOYMENT }}=${{ env.ECR_REGISTRY }}/${{ env.ECR_REPOSITORY }}:${{ needs.build-and-push.outputs.sha }} \
-            -n ${{ env.K3S_NAMESPACE }}
-          sudo k3s kubectl rollout status deployment/${{ env.K3S_DEPLOYMENT }} \
-            -n ${{ env.K3S_NAMESPACE }} --timeout=420s
+          ssh -o StrictHostKeyChecking=no -i ~/.ssh/deploy_key \
+            tbaltzakis@100.113.41.119 bash << 'REMOTE'
+          sudo k3s kubectl set image deployment/${{ env.K3S_DEPLOYMENT }} ${{ env.K3S_DEPLOYMENT }}=${{ env.ECR_REGISTRY }}/${{ env.ECR_REPOSITORY }}:${{ needs.build-and-push.outputs.sha }} -n ${{ env.K3S_NAMESPACE }}
+          sudo k3s kubectl rollout status deployment/${{ env.K3S_DEPLOYMENT }} -n ${{ env.K3S_NAMESPACE }} --timeout=420s
+          REMOTE


### PR DESCRIPTION
Port 6443 unreachable from GH runner over Tailscale (i/o timeout). Fix: Tailscale for network + SSH (port 22) to run kubectl locally on omv-main. Uses new SSH_DEPLOY_KEY secret. Quoted heredoc passes fully-expanded image ref to remote bash.