### PR TITLE
fix: add rate limiting to POST /api/unsubscribe and correct GHA actio…

### DIFF
--- a/.github/workflows/weekly-newsletter.yml
+++ b/.github/workflows/weekly-newsletter.yml
@@ -31,13 +31,13 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v4
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v5
+        uses: pnpm/action-setup@v4
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v4
         with:
           node-version: 22
           cache: pnpm

--- a/.github/workflows/weekly-subscriber-report.yml
+++ b/.github/workflows/weekly-subscriber-report.yml
@@ -28,13 +28,13 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v4
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v5
+        uses: pnpm/action-setup@v4
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v4
         with:
           node-version: 22
           cache: pnpm

--- a/src/app/api/unsubscribe/route.ts
+++ b/src/app/api/unsubscribe/route.ts
@@ -12,6 +12,10 @@ import { rateLimit, getClientIp } from "@/lib/rate-limit";
  * Also notifies the team for audit purposes.
  */
 export async function POST(request: Request) {
+  const ip = getClientIp(request);
+  const rl = rateLimit(`unsubscribe:${ip}`, 5, 60_000);
+  if (!rl.ok) return rl.response;
+
   try {
     const { email } = await request.json();
 
@@ -132,8 +136,4 @@ function unsubscribePage(emailOrMessage: string, success: boolean): string {
   <div class="card">
     <h1>${success ? "Unsubscribed" : "Error"}</h1>
     <p>${success ? `<strong>${escapeHtml(emailOrMessage)}</strong> has been removed from our newsletter.` : escapeHtml(emailOrMessage)}</p>
-    <p style="margin-top: 1.5rem;"><a href="https://cloudless.gr">← Back to cloudless.gr</a></p>
-  </div>
-</body>
-</html>`;
-}
+  

--- a/src/app/api/unsubscribe/route.ts
+++ b/src/app/api/unsubscribe/route.ts
@@ -135,5 +135,9 @@ function unsubscribePage(emailOrMessage: string, success: boolean): string {
 <body>
   <div class="card">
     <h1>${success ? "Unsubscribed" : "Error"}</h1>
-    <p>${success ? `<strong>${escapeHtml(emailOrMessage)}</strong> has been removed from our newsletter.` : escapeHtml(emailOrMessage)}</p>
-  
+    <p>${success ? "<strong>" + escapeHtml(emailOrMessage) + "</strong> has been removed from our newsletter." : escapeHtml(emailOrMessage)}</p>
+    <p style="margin-top: 1.5rem;"><a href="https://cloudless.gr">← Back to cloudless.gr</a></p>
+  </div>
+</body>
+</html>`;
+}


### PR DESCRIPTION
…n versions

- POST /api/unsubscribe was missing rate limiting unlike the GET handler and the subscribe route; add rateLimit(5 req/min per IP) matching the GET handler's existing limit
- weekly-newsletter.yml and weekly-subscriber-report.yml referenced actions/checkout@v6, actions/setup-node@v6, and pnpm/action-setup@v5 which don't exist; downgrade all to @v4 matching every other workflow

## Summary

<!-- One-paragraph description of what this PR does and why. -->

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / code quality
- [ ] Performance improvement
- [ ] Dependency update
- [ ] CI / DevOps
- [ ] Documentation

## Related issues

Closes #

## Testing

<!-- Describe how this was tested. Check all that apply. -->

- [ ] Unit tests added / updated (`pnpm test:ci`)
- [ ] E2E tests added / updated (`pnpm test:e2e`)
- [ ] Manually tested in browser
- [ ] No tests required (explain why):

## Checklist

- [ ] `pnpm lint` passes
- [ ] `pnpm typecheck` passes
- [ ] `pnpm build` passes
- [ ] New strings added to all three locale files (`en.json`, `el.json`, `fr.json`)
- [ ] No secrets or sensitive values committed
- [ ] AGENTS.md updated if architecture changed
