### PR TITLE
fix(ci): standardize Pi deploy SHA tag, add paths filter, fix HA sync run tracking

### DIFF
--- a/.github/workflows/deploy-pi.yml
+++ b/.github/workflows/deploy-pi.yml
@@ -3,10 +3,18 @@ name: Deploy to Pi (ECR + k3s rollout)
 on:
   push:
     branches: [main]
-    paths-ignore:
-      - "**.md"
-      - ".claude/**"
-      - "docs/**"
+    paths:
+      - 'src/**'
+      - 'public/**'
+      - 'package.json'
+      - 'pnpm-lock.yaml'
+      - 'pnpm-workspace.yaml'
+      - 'next.config.ts'
+      - 'patches/**'
+      - 'Dockerfile'
+      - '.dockerignore'
+      - '.github/workflows/deploy-pi.yml'
+      - '.github/workflows/build-pi-image.yml'
   workflow_dispatch:
 
 concurrency:
@@ -30,7 +38,7 @@ jobs:
     # GitHub-hosted native arm64 runner — no QEMU, and no build load on the Pi.
     runs-on: ubuntu-24.04-arm
     outputs:
-      sha: ${{ github.sha }}
+      short_sha: ${{ steps.check_ecr.outputs.short_sha }}
       image_exists: ${{ steps.check_ecr.outputs.exists }}
 
     steps:
@@ -49,18 +57,20 @@ jobs:
       - name: Check if image tag already exists in ECR
         id: check_ecr
         run: |
+          SHORT_SHA="${GITHUB_SHA::12}"
           if aws ecr describe-images \
             --repository-name ${{ env.ECR_REPOSITORY }} \
-            --image-ids imageTag=${{ github.sha }} \
+            --image-ids imageTag="${SHORT_SHA}" \
             --region ${{ env.AWS_REGION }} \
             --query 'imageDetails[0].imageTags' \
-            --output text 2>/dev/null | grep -q "${{ github.sha }}"; then
+            --output text 2>/dev/null | grep -q "${SHORT_SHA}"; then
             echo "exists=true" >> "$GITHUB_OUTPUT"
-            echo "Image ${{ github.sha }} already in ECR — skipping build."
+            echo "Image ${SHORT_SHA} already in ECR — skipping build."
           else
             echo "exists=false" >> "$GITHUB_OUTPUT"
-            echo "Image ${{ github.sha }} not found — will build and push."
+            echo "Image ${SHORT_SHA} not found — will build and push."
           fi
+          echo "short_sha=${SHORT_SHA}" >> "$GITHUB_OUTPUT"
 
       - name: Set up QEMU (arm64 emulation)
         if: steps.check_ecr.outputs.exists != 'true'
@@ -85,7 +95,7 @@ jobs:
           push: true
           # SHA tag only — ECR has immutable tags, :latest is never pushed.
           # Rollout uses kubectl set image with this SHA for pinned, reproducible deploys.
-          tags: ${{ env.ECR_REGISTRY }}/${{ env.ECR_REPOSITORY }}:${{ github.sha }}
+          tags: ${{ env.ECR_REGISTRY }}/${{ env.ECR_REPOSITORY }}:${{ steps.check_ecr.outputs.short_sha }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
           build-args: |
@@ -103,7 +113,7 @@ jobs:
         run: |
           aws ssm put-parameter \
             --name "/cloudless/production/current-image-sha" \
-            --value "${{ github.sha }}" \
+            --value "${{ steps.check_ecr.outputs.short_sha }}" \
             --type String --overwrite
 
 
@@ -139,7 +149,7 @@ jobs:
       - name: Set image and roll out
         run: |
           kubectl set image deployment/${{ env.K3S_DEPLOYMENT }} \
-            ${{ env.K3S_DEPLOYMENT }}=${{ env.ECR_REGISTRY }}/${{ env.ECR_REPOSITORY }}:${{ needs.build-and-push.outputs.sha }} \
+            ${{ env.K3S_DEPLOYMENT }}=${{ env.ECR_REGISTRY }}/${{ env.ECR_REPOSITORY }}:${{ needs.build-and-push.outputs.short_sha }} \
             -n ${{ env.K3S_NAMESPACE }}
           kubectl rollout status deployment/${{ env.K3S_DEPLOYMENT }} \
             -n ${{ env.K3S_NAMESPACE }} --timeout=420s

--- a/.github/workflows/ha-sync-orchestrator.yml
+++ b/.github/workflows/ha-sync-orchestrator.yml
@@ -66,6 +66,7 @@ jobs:
             core.setOutput('active', active ? 'true' : 'false');
 
       - name: dispatch pi image build for deploy SHA
+        id: dispatch
         if: steps.check.outputs.exists != 'true' && steps.check.outputs.active != 'true'
         uses: actions/github-script@v7
         with:
@@ -80,23 +81,42 @@ jobs:
             // We dispatch at the branch (always valid) and pass the exact SHA
             // as target_sha input so build-pi-image.yml checks out the right
             // commit regardless of whether the branch has since advanced.
-            //
-            // The wait-loop below filters by head_sha === deploySha. In the
-            // normal sequential-deploy case the branch tip equals deploySha at
-            // dispatch time, so head_sha will match. In a rapid-push scenario
-            // the wait-loop may time out; the subsequent orchestrator run for
-            // the newer SHA will succeed and that image is correct.
+            const dispatchedAt = new Date().toISOString();
             await github.rest.actions.createWorkflowDispatch({
               owner,
               repo,
               workflow_id: 'build-pi-image.yml',
               ref: deployBranch,
-              inputs: {
-                target_sha: deploySha,
-              },
+              inputs: { target_sha: deploySha },
             });
-
             core.info(`Dispatched build-pi-image.yml for ${deploySha} via ref=${deployBranch}`);
+
+            // Capture the run ID by polling for the newly-created run. The
+            // dispatch API is fire-and-forget (no run ID in the response), so
+            // we wait up to 30s for the run to appear, then store its ID.
+            // Tracking by run ID instead of head_sha makes the wait-loop below
+            // immune to rapid pushes that advance the branch before the build
+            // completes (the old head_sha filter would silently miss the run).
+            function sleep(ms) { return new Promise(r => setTimeout(r, ms)); }
+            let runId = null;
+            for (let i = 0; i < 10; i++) {
+              await sleep(3000);
+              const { data } = await github.rest.actions.listWorkflowRuns({
+                owner, repo, workflow_id: 'build-pi-image.yml',
+                event: 'workflow_dispatch', per_page: 10,
+              });
+              const found = data.workflow_runs.find(
+                r => new Date(r.created_at) >= new Date(dispatchedAt)
+              );
+              if (found) { runId = found.id; break; }
+            }
+            if (runId) {
+              core.info(`Captured dispatched run ID: ${runId}`);
+              core.setOutput('run_id', String(runId));
+            } else {
+              core.warning('Could not capture dispatched run ID — wait step will fall back to SHA filter');
+              core.setOutput('run_id', '');
+            }
 
       - name: wait for pi build completion
         if: steps.check.outputs.exists != 'true'
@@ -105,49 +125,61 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
             const deploySha = '${{ steps.meta.outputs.sha }}';
+            const dispatchedRunId = Number('${{ steps.dispatch.outputs.run_id }}') || 0;
             const { owner, repo } = context.repo;
 
-            // Pi builds frequently spend 20-30 min queued on the omv
-            // self-hosted runner before doing ~1 min of work. 45 min covers
-            // a worst-case queue without bailing on healthy builds.
+            // Pi builds frequently spend 20-30 min queued on the GitHub ARM
+            // runner before doing ~2-3 min of actual work. 45 min covers the
+            // worst-case queue without bailing on healthy builds.
             const maxAttempts = 180; // 45m at 15s intervals
             const delayMs = 15000;
-
-            function sleep(ms) {
-              return new Promise((resolve) => setTimeout(resolve, ms));
-            }
+            function sleep(ms) { return new Promise(r => setTimeout(r, ms)); }
 
             for (let attempt = 1; attempt <= maxAttempts; attempt++) {
-              const response = await github.rest.actions.listWorkflowRuns({
-                owner,
-                repo,
-                workflow_id: 'build-pi-image.yml',
-                per_page: 50,
-              });
+              // Prefer tracking by run ID (immune to branch-tip advances).
+              // Fall back to head_sha filter when the dispatch step couldn't
+              // capture the ID (e.g. the build already existed and was active).
+              if (dispatchedRunId) {
+                const { data: run } = await github.rest.actions.getWorkflowRun({
+                  owner, repo, run_id: dispatchedRunId,
+                });
+                if (run.conclusion === 'success') {
+                  core.info(`Pi build completed successfully: ${run.html_url}`);
+                  return;
+                }
+                if (run.status !== 'completed') {
+                  core.info(`Attempt ${attempt}: run ${dispatchedRunId} still ${run.status}`);
+                  await sleep(delayMs);
+                  continue;
+                }
+                core.setFailed(`Pi build run ${dispatchedRunId} ended with conclusion=${run.conclusion}. URL: ${run.html_url}`);
+                return;
+              }
 
+              // Fallback: filter by head_sha (original behaviour, works when
+              // the build was already active and no dispatch was needed).
+              const response = await github.rest.actions.listWorkflowRuns({
+                owner, repo, workflow_id: 'build-pi-image.yml', per_page: 50,
+              });
               const candidates = response.data.workflow_runs
-                .filter((run) => run.head_sha === deploySha)
+                .filter(r => r.head_sha === deploySha)
                 .sort((a, b) => new Date(b.created_at) - new Date(a.created_at));
 
-              const success = candidates.find((run) => run.conclusion === 'success');
+              const success = candidates.find(r => r.conclusion === 'success');
               if (success) {
                 core.info(`Pi build completed successfully: ${success.html_url}`);
                 return;
               }
-
-              const active = candidates.find((run) => run.status !== 'completed');
+              const active = candidates.find(r => r.status !== 'completed');
               if (active) {
-                core.info(`Attempt ${attempt}: waiting on active run ${active.id} ${active.html_url}`);
+                core.info(`Attempt ${attempt}: waiting on active run ${active.id}`);
                 await sleep(delayMs);
                 continue;
               }
-
               if (candidates.length > 0) {
-                const latest = candidates[0];
-                core.setFailed(`Pi build has no successful run for SHA ${deploySha}. Latest conclusion=${latest.conclusion}. Run: ${latest.html_url}`);
+                core.setFailed(`Pi build for SHA ${deploySha} ended with: ${candidates[0].conclusion}`);
                 return;
               }
-
               core.info(`Attempt ${attempt}: no run found yet for SHA ${deploySha}`);
               await sleep(delayMs);
             }


### PR DESCRIPTION
## Summary

- **Fix 1 -- tag format mismatch**: `deploy-pi.yml` was tagging ECR images with the full 40-char SHA while `build-pi-image.yml` uses 12-char short SHA. The ECR short-circuit check in `deploy-pi.yml` never matched an image already pushed by `build-pi-image.yml`, causing a full redundant arm64 rebuild on every shared push to main.

- **Fix 2 -- paths filter**: `deploy-pi.yml` used `paths-ignore` (only excluding `.md`/docs), so commits like `.gitignore` changes triggered a full rebuild + k3s rollout unnecessarily. Now uses the same explicit `paths` list as `build-pi-image.yml`.

- **Fix 3 -- HA sync orchestrator SHA polling**: after `createWorkflowDispatch`, the orchestrator polled for the dispatched build by `head_sha === deploySha`. When main advances before the build completes (rapid pushes), `head_sha` is the new tip, not `deploySha`, so the loop timed out after 45 min. Fixed by capturing the dispatched run ID immediately after dispatch and waiting by run ID instead. Falls back to the old SHA filter when dispatch was skipped (build already existed/active).

## Test plan

- [ ] Merge to main and verify `deploy-pi.yml` does NOT trigger on a docs/infra-only commit
- [ ] Verify next app-code push uses the 12-char tag in ECR and `kubectl set image`
- [ ] Verify HA sync orchestrator completes in <5 min on next rapid double-push scenario

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>