### PR TITLE
fix(ci): switch ARM build jobs to self-hosted Pi runner

### DIFF
--- a/.github/workflows/build-pi-image.yml
+++ b/.github/workflows/build-pi-image.yml
@@ -50,10 +50,10 @@ concurrency:
 jobs:
   build-and-push:
     name: build arm64 + push to ECR
-    # GitHub-hosted ARM runner — native arm64, no QEMU. First build ~5-10 min,
-    # subsequent cached builds ~2-3 min. Cross-compile via QEMU on x86 runners
-    # was unviable (pnpm install alone exceeded 60min).
-    runs-on: ubuntu-24.04-arm
+    # Self-hosted Pi runner (arm64 native) — no QEMU, no paid GH runner minutes.
+    # Cross-compile via QEMU on x86 runners was unviable (pnpm install alone
+    # exceeded 60min); GH-hosted ARM runner costs money and hit billing limits.
+    runs-on: [self-hosted, omv, pi]
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.3.1

--- a/.github/workflows/deploy-pi.yml
+++ b/.github/workflows/deploy-pi.yml
@@ -35,8 +35,8 @@ env:
 jobs:
   build-and-push:
     name: Build arm64 image and push to ECR
-    # GitHub-hosted native arm64 runner — no QEMU, and no build load on the Pi.
-    runs-on: ubuntu-24.04-arm
+    # Self-hosted Pi runner (arm64 native) — no QEMU, no paid GH runner minutes.
+    runs-on: [self-hosted, omv, pi]
     outputs:
       short_sha: ${{ steps.check_ecr.outputs.short_sha }}
       image_exists: ${{ steps.check_ecr.outputs.exists }}


### PR DESCRIPTION
## Summary
- Switches `build-pi-image.yml` and `deploy-pi.yml` build jobs from `ubuntu-24.04-arm` (paid GH runner, 2x Linux rate) to `[self-hosted, omv, pi]` (arm64 native, free)
- Eliminates the paid runner cost that hit the account billing cap
- Aligns with the intended design documented in CLAUDE.md

## Root cause
All 7 workflow failures share the same message: "The job was not started because recent account payments have failed". The `ubuntu-24.04-arm` paid ARM runner triggered the GitHub account billing limit.

## What this fixes
- `build pi image` -- now runs on Pi self-hosted
- `Deploy to Pi (ECR + k3s rollout)` build job -- now runs on Pi self-hosted

## What still needs the GitHub billing fix
These workflows use `ubuntu-latest` and will recover automatically once the payment method at github.com/settings/billing is updated:
- `Deploy to Production` (SST deploy)
- `Secret Leakage Audit` (Gitleaks)
- `CodeQL Security Analysis`
- `SHA drift detector`
- `Teardown Staging Environment`

Generated with Claude Code