### PR TITLE
feat(ci): add runner failover from GH-hosted to self-hosted Pi build cluster

### DIFF
--- a/.github/scripts/register-build-runner.sh
+++ b/.github/scripts/register-build-runner.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+# Register a second GitHub Actions runner on a Pi host with the `build` label.
+#
+# Usage:
+#   On each of omv, omv-2, omv-3:
+#     curl -fsSL https://raw.githubusercontent.com/Themis128/cloudless.gr/main/.github/scripts/register-build-runner.sh | bash -s -- <REG_TOKEN> <RUNNER_NAME>
+#   Or local:
+#     ./register-build-runner.sh <REG_TOKEN> <RUNNER_NAME>
+#
+# Get REG_TOKEN from:
+#   https://github.com/Themis128/cloudless.gr/settings/actions/runners → New self-hosted runner
+#
+# RUNNER_NAME should be like: omv-build, omv-2-build, omv-3-build
+#
+# This installs the runner in ~/actions-runner-build/ (separate from the existing
+# ~/actions-runner/ which holds the `pi`-labelled cluster runner), so both can
+# run concurrently on the same host.
+
+set -euo pipefail
+
+REG_TOKEN="${1:?registration token required}"
+RUNNER_NAME="${2:?runner name required, e.g. omv-build}"
+REPO_URL="https://github.com/Themis128/cloudless.gr"
+RUNNER_VERSION="2.334.0"
+LABELS="omv,build"          # self-hosted + Linux + ARM64 are added automatically
+WORK_DIR="$HOME/actions-runner-build"
+
+ARCH="$(uname -m)"
+case "$ARCH" in
+  aarch64|arm64) PKG_ARCH="arm64" ;;
+  x86_64)        PKG_ARCH="x64" ;;
+  *) echo "Unsupported arch: $ARCH" >&2; exit 1 ;;
+esac
+
+echo "==> Installing runner '${RUNNER_NAME}' in ${WORK_DIR}"
+mkdir -p "${WORK_DIR}"
+cd "${WORK_DIR}"
+
+if [[ ! -f ./config.sh ]]; then
+  PKG="actions-runner-linux-${PKG_ARCH}-${RUNNER_VERSION}.tar.gz"
+  echo "==> Downloading ${PKG}"
+  curl -fsSL -o "${PKG}" \
+    "https://github.com/actions/runner/releases/download/v${RUNNER_VERSION}/${PKG}"
+  tar xzf "${PKG}"
+  rm -f "${PKG}"
+fi
+
+# Register (unattended, so it doesn't prompt)
+./config.sh \
+  --url "${REPO_URL}" \
+  --token "${REG_TOKEN}" \
+  --name "${RUNNER_NAME}" \
+  --labels "${LABELS}" \
+  --work _work \
+  --unattended \
+  --replace
+
+# Install as a systemd service so it restarts on reboot.
+# svc.sh derives the service name from the runner config; both profiles
+# (~/actions-runner and ~/actions-runner-build) get distinct service names
+# so they coexist cleanly.
+sudo ./svc.sh install "${USER}"
+sudo ./svc.sh start
+
+echo
+echo "==> Done. Verify with:"
+echo "    sudo ./svc.sh status"
+echo "    gh api repos/Themis128/cloudless.gr/actions/runners \\"
+echo "      --jq '.runners[] | {name, status, labels: [.labels[].name]}'"

--- a/.github/scripts/toggle-runner.sh
+++ b/.github/scripts/toggle-runner.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+# Toggle CI between GitHub-hosted runners and the self-hosted Pi `build` cluster.
+#
+# Why this exists:
+#   GitHub Actions has no native runner-failover. When GitHub billing breaks
+#   or hosted-runner capacity is exhausted, every workflow targeted at
+#   `ubuntu-latest` fails fast with "the job was not started because recent
+#   account payments have failed". Flipping the `RUNNER_GENERIC` repo variable
+#   re-routes all instrumented workflows to the Pi runners on their next run.
+#
+# Usage:
+#   .github/scripts/toggle-runner.sh status   # show current setting + runner inventory
+#   .github/scripts/toggle-runner.sh pi       # route generic jobs to Pi build runners
+#   .github/scripts/toggle-runner.sh hosted   # route generic jobs back to ubuntu-latest (clears the var)
+#
+# Notes:
+#   - Already-queued jobs are NOT re-routed; cancel + re-run them after toggling.
+#   - Workflows must opt in by using:
+#       runs-on: ${{ fromJSON(vars.RUNNER_GENERIC || '"ubuntu-latest"') }}
+#   - Jobs that genuinely require x86_64 or more RAM than a Pi has (Lighthouse,
+#     CodeQL, heavy Playwright matrices) should keep a hard `runs-on: ubuntu-latest`.
+
+set -euo pipefail
+
+REPO="${REPO:-Themis128/cloudless.gr}"
+VAR_NAME="RUNNER_GENERIC"
+PI_VALUE='["self-hosted","omv","build"]'
+
+cmd="${1:-status}"
+
+show_runners() {
+  echo
+  echo "Registered runners:"
+  gh api "repos/${REPO}/actions/runners" \
+    --jq '.runners[] | "  - \(.name): \(.status)\(if .busy then " (busy)" else "" end) — [\([.labels[].name] | join(","))]"' \
+    || echo "  (unable to query — check gh auth)"
+}
+
+show_status() {
+  current=$(gh variable list --repo "${REPO}" --json name,value \
+    --jq ".[] | select(.name == \"${VAR_NAME}\") | .value" 2>/dev/null || true)
+  if [[ -z "${current}" ]]; then
+    echo "Mode: HOSTED (ubuntu-latest)  —  ${VAR_NAME} is unset"
+  else
+    echo "Mode: SELF-HOSTED  —  ${VAR_NAME}=${current}"
+  fi
+  show_runners
+}
+
+case "${cmd}" in
+  status)
+    show_status
+    ;;
+  pi|self-hosted)
+    echo "==> Setting ${VAR_NAME}=${PI_VALUE} on ${REPO}"
+    gh variable set "${VAR_NAME}" --repo "${REPO}" --body "${PI_VALUE}"
+    echo "==> Done. Cancel + re-run any queued workflows to pick up the change."
+    show_status
+    ;;
+  hosted|gh|github)
+    echo "==> Clearing ${VAR_NAME} on ${REPO} (back to ubuntu-latest)"
+    gh variable delete "${VAR_NAME}" --repo "${REPO}" 2>/dev/null || true
+    show_status
+    ;;
+  *)
+    echo "Usage: $0 [status|pi|hosted]" >&2
+    exit 2
+    ;;
+esac

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,27 +4,27 @@ on:
   pull_request:
     branches: [main]
     paths:
-      - 'src/**'
-      - 'public/**'
-      - 'e2e/**'
-      - '__tests__/**'
-      - 'sst.config.ts'
-      - 'next.config.ts'
-      - 'package.json'
-      - 'pnpm-lock.yaml'
-      - 'tsconfig.json'
-      - 'mcp.json'
-      - '.mcp.json'
-      - '.github/workflows/**'
+      - "src/**"
+      - "public/**"
+      - "e2e/**"
+      - "__tests__/**"
+      - "sst.config.ts"
+      - "next.config.ts"
+      - "package.json"
+      - "pnpm-lock.yaml"
+      - "tsconfig.json"
+      - "mcp.json"
+      - ".mcp.json"
+      - ".github/workflows/**"
       # Root-level config that affects build/lint/quality gates.
       # Without these, PRs editing only these files hang on the required
       # "Build" check because CI never triggers.
-      - '.codacy/**'
-      - '.sonarcloud.properties'
-      - '.eslintrc*'
-      - 'eslint.config.*'
-      - '.prettierrc*'
-      - 'prettier.config.*'
+      - ".codacy/**"
+      - ".sonarcloud.properties"
+      - ".eslintrc*"
+      - "eslint.config.*"
+      - ".prettierrc*"
+      - "prettier.config.*"
 
 concurrency:
   group: ci-${{ github.head_ref }}
@@ -36,7 +36,10 @@ permissions:
 jobs:
   lint:
     name: Lint
-    runs-on: ubuntu-latest
+    # Failover-capable: defaults to ubuntu-latest. Flip via
+    #   .github/scripts/toggle-runner.sh pi
+    # when GH-hosted billing/capacity is broken.
+    runs-on: ${{ fromJSON(vars.RUNNER_GENERIC || '"ubuntu-latest"') }}
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@v4
@@ -52,7 +55,7 @@ jobs:
 
   typecheck:
     name: Type Check
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(vars.RUNNER_GENERIC || '"ubuntu-latest"') }}
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@v4
@@ -68,7 +71,7 @@ jobs:
 
   format:
     name: Format Check
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(vars.RUNNER_GENERIC || '"ubuntu-latest"') }}
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@v4
@@ -84,7 +87,7 @@ jobs:
 
   build:
     name: Build
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(vars.RUNNER_GENERIC || '"ubuntu-latest"') }}
     timeout-minutes: 30
     env:
       NEXT_PUBLIC_COGNITO_USER_POOL_ID: ${{ secrets.NEXT_PUBLIC_COGNITO_USER_POOL_ID }}
@@ -108,7 +111,7 @@ jobs:
 
   test:
     name: Unit Tests
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(vars.RUNNER_GENERIC || '"ubuntu-latest"') }}
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/deploy-pi.yml
+++ b/.github/workflows/deploy-pi.yml
@@ -4,17 +4,17 @@ on:
   push:
     branches: [main]
     paths:
-      - 'src/**'
-      - 'public/**'
-      - 'package.json'
-      - 'pnpm-lock.yaml'
-      - 'pnpm-workspace.yaml'
-      - 'next.config.ts'
-      - 'patches/**'
-      - 'Dockerfile'
-      - '.dockerignore'
-      - '.github/workflows/deploy-pi.yml'
-      - '.github/workflows/build-pi-image.yml'
+      - "src/**"
+      - "public/**"
+      - "package.json"
+      - "pnpm-lock.yaml"
+      - "pnpm-workspace.yaml"
+      - "next.config.ts"
+      - "patches/**"
+      - "Dockerfile"
+      - ".dockerignore"
+      - ".github/workflows/deploy-pi.yml"
+      - ".github/workflows/build-pi-image.yml"
   workflow_dispatch:
 
 concurrency:
@@ -22,7 +22,7 @@ concurrency:
   cancel-in-progress: true
 
 permissions:
-  id-token: write  # required for OIDC
+  id-token: write # required for OIDC
   contents: read
 
 env:
@@ -116,12 +116,17 @@ jobs:
             --value "${{ steps.check_ecr.outputs.short_sha }}" \
             --type String --overwrite
 
-
   rollout:
     name: Rollout restart on k3s
     # GH-hosted runner joins tailnet, uses KUBECONFIG_B64 to call k3s API
-    # directly over Tailscale — no SSH hop, no self-hosted runner dependency.
-    runs-on: ubuntu-latest
+    # directly over Tailscale — no SSH hop required.
+    # Failover-capable: when GH-hosted billing is broken, flip
+    #   .github/scripts/toggle-runner.sh pi
+    # to route this onto the self-hosted Pi build runners. The Pi runners are
+    # already inside the local network and can reach the k3s API directly
+    # (192.168.1.128:6443) without Tailscale, so the tailnet step becomes a
+    # no-op on them.
+    runs-on: ${{ fromJSON(vars.RUNNER_GENERIC || '"ubuntu-latest"') }}
     needs: build-and-push
     if: always() && needs.build-and-push.result != 'cancelled' && (needs.build-and-push.result == 'success' || needs.build-and-push.outputs.image_exists == 'true')
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,15 +4,15 @@ on:
   push:
     branches: [main]
     paths:
-      - 'src/**'
-      - '__tests__/**'
-      - 'public/**'
-      - 'sst.config.ts'
-      - 'next.config.ts'
-      - 'package.json'
-      - 'pnpm-lock.yaml'
-      - 'tsconfig.json'
-      - '.github/workflows/**'
+      - "src/**"
+      - "__tests__/**"
+      - "public/**"
+      - "sst.config.ts"
+      - "next.config.ts"
+      - "package.json"
+      - "pnpm-lock.yaml"
+      - "tsconfig.json"
+      - ".github/workflows/**"
   workflow_dispatch:
 
 concurrency:
@@ -27,7 +27,10 @@ permissions:
 jobs:
   deploy:
     name: Deploy
-    runs-on: ubuntu-latest
+    # Failover-capable: flip via `.github/scripts/toggle-runner.sh pi`
+    # when hosted billing is down. SST deploy is mostly network-bound (S3, CFN
+    # waits) so a Pi runner is acceptable as a last resort.
+    runs-on: ${{ fromJSON(vars.RUNNER_GENERIC || '"ubuntu-latest"') }}
     timeout-minutes: 40
     environment:
       name: production

--- a/.github/workflows/ha-sync-orchestrator.yml
+++ b/.github/workflows/ha-sync-orchestrator.yml
@@ -21,7 +21,7 @@ concurrency:
 jobs:
   ensure-pi-build:
     if: github.event.workflow_run.conclusion == 'success'
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(vars.RUNNER_GENERIC || '"ubuntu-latest"') }}
     # Pi builds can sit queued on the self-hosted runner for 30+ min on a busy
     # day before doing ~1 min of actual work. Job timeout must cover the
     # combined Pi-build wait (max ~45 min, see below) plus the k3s-rollout

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -17,7 +17,7 @@ concurrency:
 jobs:
   label:
     name: Auto-label
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(vars.RUNNER_GENERIC || '"ubuntu-latest"') }}
     timeout-minutes: 5
     steps:
       - uses: actions/labeler@v4

--- a/.github/workflows/links-audit.yml
+++ b/.github/workflows/links-audit.yml
@@ -24,7 +24,7 @@ concurrency:
 jobs:
   links:
     name: Markdown Link Checker
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(vars.RUNNER_GENERIC || '"ubuntu-latest"') }}
     timeout-minutes: 8
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/pi-tls-cert-check.yml
+++ b/.github/workflows/pi-tls-cert-check.yml
@@ -28,7 +28,7 @@ name: Pi TLS Cert Check
 
 on:
   schedule:
-    - cron: '30 */6 * * *'
+    - cron: "30 */6 * * *"
   workflow_dispatch:
 
 permissions:
@@ -38,14 +38,14 @@ env:
   # APIGW custom domain backing the SECONDARY failover (apex). The www
   # variant has its own custom domain (d-2msx2z5q7d.execute-api...);
   # apex covers the canonical traffic.
-  APIGW_HOST: 'd-uy6dmk95il.execute-api.us-east-1.amazonaws.com'
-  SNI: 'cloudless.gr'
+  APIGW_HOST: "d-uy6dmk95il.execute-api.us-east-1.amazonaws.com"
+  SNI: "cloudless.gr"
   MIN_DAYS_REMAINING: 14
 
 jobs:
   probe:
     name: Probe SECONDARY failover
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(vars.RUNNER_GENERIC || '"ubuntu-latest"') }}
     timeout-minutes: 3
     steps:
       - name: TLS handshake + cert validity

--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -16,7 +16,10 @@ concurrency:
 jobs:
   review:
     name: Claude code review
-    runs-on: ubuntu-latest
+    # Failover-capable: defaults to ubuntu-latest. Flip via
+    #   .github/scripts/toggle-runner.sh pi
+    # when GH-hosted billing is broken.
+    runs-on: ${{ fromJSON(vars.RUNNER_GENERIC || '"ubuntu-latest"') }}
     # Skip bots, dependabot, and revert branches
     if: |
       github.actor != 'dependabot[bot]' &&
@@ -26,7 +29,7 @@ jobs:
     permissions:
       contents: read
       pull-requests: write
-      id-token: write  # for OIDC → AWS (to fetch ANTHROPIC_API_KEY from SSM)
+      id-token: write # for OIDC → AWS (to fetch ANTHROPIC_API_KEY from SSM)
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -21,7 +21,7 @@ concurrency:
 jobs:
   gitleaks:
     name: Gitleaks Scan
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(vars.RUNNER_GENERIC || '"ubuntu-latest"') }}
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/sha-drift-detector.yml
+++ b/.github/workflows/sha-drift-detector.yml
@@ -14,12 +14,12 @@ on:
     # Every 6h on the half-hour (00:30, 06:30, 12:30, 18:30 UTC).
     # Spaced 15 min off the Pi TLS cert check so they don't share a
     # runner slot.
-    - cron: '45 */6 * * *'
+    - cron: "45 */6 * * *"
   workflow_dispatch:
   workflow_run:
     # Also after a deploy completes — gives the most useful signal
     # (right when convergence should be happening).
-    workflows: ['HA sync orchestrator']
+    workflows: ["HA sync orchestrator"]
     types: [completed]
 
 permissions:
@@ -33,7 +33,10 @@ concurrency:
 jobs:
   detect:
     name: detect-sha-drift
-    runs-on: ubuntu-latest
+    # Failover-capable: defaults to ubuntu-latest. Flip via
+    #   .github/scripts/toggle-runner.sh pi
+    # to route onto the self-hosted build runners when billing is broken.
+    runs-on: ${{ fromJSON(vars.RUNNER_GENERIC || '"ubuntu-latest"') }}
     timeout-minutes: 5
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/sha-drift-watchdog.yml
+++ b/.github/workflows/sha-drift-watchdog.yml
@@ -6,7 +6,7 @@ name: SHA drift watchdog
 
 on:
   schedule:
-    - cron: '*/15 * * * *'
+    - cron: "*/15 * * * *"
   workflow_dispatch:
 
 permissions:
@@ -16,7 +16,7 @@ permissions:
 jobs:
   recheck:
     name: recheck-if-drifted
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(vars.RUNNER_GENERIC || '"ubuntu-latest"') }}
     timeout-minutes: 2
     steps:
       - name: Re-trigger drift detector if last run failed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,20 +11,24 @@
 When spawning sub-agents, follow these rules for optimal orchestration:
 
 ### When to use agents
+
 - Use `subagent_type: "Explore"` for **read-only codebase searches** (grep, find, file reads). This protects the main context window.
 - Use `subagent_type: "general-purpose"` for **multi-step research + write tasks** that are independent of the main thread.
 - Use `subagent_type: "Plan"` before large refactors to get an implementation plan.
 
 ### Parallel dispatch
+
 - Launch **independent agents in a single message** (multiple Agent tool calls in one response) so they run concurrently.
 - Only run agents sequentially when one's output is required as input for the next.
 
 ### Prompt discipline
+
 - Keep agent prompts **short and focused** — long prompts cause "Prompt is too long" errors.
 - Give each agent exactly one task. If a search covers many files, split it into 2–3 agents with non-overlapping file lists.
 - For file searches: prefer direct `Bash` grep/find when the pattern is simple and the target set is small (≤ 5 files). Reserve agents for broader, open-ended exploration.
 
 ### Context protection
+
 - Agents return a **single summary message** — raw tool output stays out of the main context.
 - Use `run_in_background: true` only for genuinely independent work that does not block the next step.
 
@@ -40,6 +44,18 @@ When spawning sub-agents, follow these rules for optimal orchestration:
 - **SSM config** (API keys, Notion DB IDs, etc.) is fetched at runtime by the app via `getIntegrationsAsync()` using the `pi-standby-aws-creds` k8s Secret.
 
 **GitHub Secrets needed:** `AWS_DEPLOY_ROLE_ARN`, `NEXT_PUBLIC_SITE_URL`, `NEXT_PUBLIC_COGNITO_USER_POOL_ID`, `NEXT_PUBLIC_COGNITO_CLIENT_ID`, `NEXT_PUBLIC_HUBSPOT_PORTAL_ID`, `NEXT_PUBLIC_SENTRY_DSN`, `NEXT_PUBLIC_META_PIXEL_ID`
+
+## CI Runner Failover
+
+When GH-hosted runner billing/capacity breaks, flip the `RUNNER_GENERIC` repo variable to re-route most workflows onto the self-hosted Pi `build` cluster:
+
+```bash
+.github/scripts/toggle-runner.sh status   # show mode + runner inventory
+.github/scripts/toggle-runner.sh pi       # → ["self-hosted","omv","build"]
+.github/scripts/toggle-runner.sh hosted   # → unset (ubuntu-latest)
+```
+
+Instrumented workflows use `runs-on: ${{ fromJSON(vars.RUNNER_GENERIC || '"ubuntu-latest"') }}`. See [`docs/runners.md`](docs/runners.md) for the full design, the list of opted-in workflows, the ones that stay GH-hosted (Lighthouse, k3s-e2e, CodeQL — they need x86_64/Chrome), and the registration steps for the `omv,build` runner profile on each Pi host.
 
 ## SonarCloud
 
@@ -57,18 +73,19 @@ The app uses `localePrefix: "always"` — every route requires a locale prefix (
 
 ```ts
 // ✅ Correct
-import { Link, useRouter, usePathname, redirect } from "@/i18n/navigation"
-router.push("/admin")         // → /en/admin  ✓
+import { Link, useRouter, usePathname, redirect } from "@/i18n/navigation";
+router.push("/admin"); // → /en/admin  ✓
 
 // ❌ Wrong — produces 404
-import Link from "next/link"
-router.push("/en/admin")      // → /en/en/admin  ✗
+import Link from "next/link";
+router.push("/en/admin"); // → /en/en/admin  ✗
 ```
 
 **Middleware redirect params must use the bare (locale-stripped) path:**
+
 ```ts
 // ✅
-loginUrl.searchParams.set("redirect", bare)      // "/admin"
+loginUrl.searchParams.set("redirect", bare); // "/admin"
 // ❌
-loginUrl.searchParams.set("redirect", pathname)  // "/en/admin" → double-locale after router.push
+loginUrl.searchParams.set("redirect", pathname); // "/en/admin" → double-locale after router.push
 ```

--- a/docs/runners.md
+++ b/docs/runners.md
@@ -1,0 +1,131 @@
+# CI Runner Failover
+
+GitHub Actions has no native runner failover — when GitHub-hosted billing
+breaks or hosted capacity is exhausted, `runs-on: ubuntu-latest` jobs are
+rejected by the GitHub control plane _before_ any YAML runs, so a workflow
+cannot self-detect or recover from it.
+
+This repo gets the same practical result by combining:
+
+1. A **repo variable** (`RUNNER_GENERIC`) that resolves into the `runs-on`
+   field at queue time via `fromJSON()`.
+2. A **second runner profile** on each Pi host (labels `omv,build`),
+   running alongside the existing `pi`-labelled cluster runner.
+3. A **one-command toggle** that flips every instrumented workflow between
+   GitHub-hosted and Pi-hosted runners.
+
+## How the toggle works
+
+Instrumented workflows declare:
+
+```yaml
+runs-on: ${{ fromJSON(vars.RUNNER_GENERIC || '"ubuntu-latest"') }}
+```
+
+| `RUNNER_GENERIC` value          | Effective `runs-on`               |
+| ------------------------------- | --------------------------------- |
+| _unset_ (default)               | `ubuntu-latest`                   |
+| `["self-hosted","omv","build"]` | self-hosted Pi build runners      |
+| `["self-hosted","omv","foo"]`   | any matching label set you define |
+
+`fromJSON('"ubuntu-latest"')` resolves to the string literal; `fromJSON('[...]')`
+resolves to the array. Both shapes are accepted by `runs-on`.
+
+## Toggling
+
+```bash
+# Show current state + runner inventory
+.github/scripts/toggle-runner.sh status
+
+# Route generic jobs to the Pi build runners
+.github/scripts/toggle-runner.sh pi
+
+# Route them back to ubuntu-latest (clears the variable)
+.github/scripts/toggle-runner.sh hosted
+```
+
+**Already-queued jobs are not re-routed** — cancel and re-run them after
+flipping. New runs pick up the new value immediately.
+
+## Workflows opted in
+
+These read `vars.RUNNER_GENERIC` and fail over automatically:
+
+- `ci.yml` (lint, typecheck, format, build, test)
+- `deploy.yml` (SST → AWS Lambda)
+- `deploy-pi.yml` (the `rollout` job — `build-and-push` stays pinned to `[self-hosted, omv, pi]`)
+- `ha-sync-orchestrator.yml`
+- `pi-tls-cert-check.yml`
+- `pr-review.yml`
+- `sha-drift-detector.yml`
+- `sha-drift-watchdog.yml`
+
+## Workflows that stay GitHub-hosted
+
+These pin `runs-on: ubuntu-latest` because they need x86_64, a system
+Chromium, or more RAM than a Pi 4/5 has:
+
+- `lighthouse.yml` — needs system Chrome; ARM has no official Chromium binary in the runner image.
+- `k3s-e2e.yml` — Playwright + browser deps; runs against the live Pi standby so adding Pi-side load is also counterproductive.
+- `codeql.yml` — heavy memory + x86_64 analyzer.
+
+When billing is broken, these stay red until billing is fixed. They are
+**not** in the deploy critical path.
+
+## Setting up the second runner profile on each Pi host
+
+The existing runner (`~/actions-runner`, labels `omv,pi`) stays put. We add a
+second runner (`~/actions-runner-build`, labels `omv,build`) so cluster jobs
+and generic jobs don't queue behind each other.
+
+On each of `omv`, `omv-2`, `omv-3`:
+
+1. Generate a registration token at
+   <https://github.com/Themis128/cloudless.gr/settings/actions/runners> →
+   **New self-hosted runner**.
+2. Run the bootstrap script (token expires in 1 hour, so do it inline):
+   ```bash
+   ./.github/scripts/register-build-runner.sh <REG_TOKEN> omv-build
+   #                                                       omv-2-build
+   #                                                       omv-3-build
+   ```
+3. Verify all six runners online:
+   ```bash
+   gh api repos/Themis128/cloudless.gr/actions/runners \
+     --jq '.runners[] | {name, status, labels: [.labels[].name]}'
+   ```
+
+You should end up with two runners per host:
+
+| Host  | Runner name   | Labels                                  |
+| ----- | ------------- | --------------------------------------- |
+| omv   | `omv`         | `self-hosted, Linux, ARM64, omv, pi`    |
+| omv   | `omv-build`   | `self-hosted, Linux, ARM64, omv, build` |
+| omv-2 | `omv-2`       | `self-hosted, Linux, ARM64, omv, pi`    |
+| omv-2 | `omv-2-build` | `self-hosted, Linux, ARM64, omv, build` |
+| omv-3 | `omv-3`       | `self-hosted, Linux, ARM64, omv, pi`    |
+| omv-3 | `omv-3-build` | `self-hosted, Linux, ARM64, omv, build` |
+
+The `pi` label is reserved for cluster-bound jobs (the `build-and-push` job in
+`deploy-pi.yml`) and must never overlap with `build` — that gating is what
+keeps a future non-Pi host added to the `omv` group from accidentally taking
+a deploy job it can't run.
+
+## Caveat: Pi runners share resources with production
+
+Pi 4/5 hosts also run the `cloudless` k3s pod that serves `cloudless.online`.
+Heavy CI concurrency on the `build` runner will degrade prod latency. If you
+flip to `pi` mode for more than a short outage window, consider:
+
+- A `nice -n 19` wrapper on the runner systemd unit
+- `cpuset.cpus` cgroup limit on the runner service
+- Reducing CI concurrency by setting a smaller `jobs.<id>.strategy.max-parallel`
+
+For a short billing-block outage, none of this is needed — flip, ship the
+critical PR, flip back.
+
+## References
+
+- [GitHub Docs — Choosing the runner for a job](https://docs.github.com/en/actions/using-jobs/choosing-the-runner-for-a-job)
+- [GitHub Docs — Configuring the self-hosted runner application as a service](https://docs.github.com/en/actions/hosting-your-own-runners/managing-self-hosted-runners/configuring-the-self-hosted-runner-application-as-a-service)
+- [GitHub Community — Dynamic runs-on labelling (Discussion #49302)](https://github.com/orgs/community/discussions/49302)


### PR DESCRIPTION
## Summary

GitHub Actions has no native runner failover. When GH-hosted billing breaks (current state — see [Billing & licensing](https://github.com/settings/billing)) or hosted capacity is exhausted, every \`ubuntu-latest\` job is rejected by the GH control plane **before any YAML runs**, so workflows can't self-detect or recover from it.

This PR gets the same practical result by combining:

1. A repo variable (\`RUNNER_GENERIC\`) that resolves into \`runs-on\` via \`fromJSON()\` at queue time.
2. A second runner profile on each Pi host (labels \`omv,build\`) running alongside the existing \`omv,pi\` cluster runner.
3. A one-command toggle.

### How it works

Instrumented workflows declare:
\`\`\`yaml
runs-on: \${{ fromJSON(vars.RUNNER_GENERIC || '\"ubuntu-latest\"') }}
\`\`\`

| \`RUNNER_GENERIC\` value         | Effective \`runs-on\`               |
| ------------------------------ | --------------------------------- |
| _unset_ (default)              | \`ubuntu-latest\`                   |
| \`[\"self-hosted\",\"omv\",\"build\"]\` | self-hosted Pi build runners      |

\`fromJSON('\"ubuntu-latest\"')\` resolves to the string literal; \`fromJSON('[...]')\` resolves to the array. Both shapes are accepted by \`runs-on\`.

### Toggling

\`\`\`bash
.github/scripts/toggle-runner.sh status   # show mode + runner inventory
.github/scripts/toggle-runner.sh pi       # → [\"self-hosted\",\"omv\",\"build\"]
.github/scripts/toggle-runner.sh hosted   # → unset (back to ubuntu-latest)
\`\`\`

### Opted-in workflows

| Workflow                          | Why                                            |
| --------------------------------- | ---------------------------------------------- |
| \`ci.yml\`                          | lint/typecheck/format/build/test               |
| \`deploy.yml\`                      | SST → AWS Lambda (network-bound, Pi-safe)       |
| \`deploy-pi.yml\` (\`rollout\` job)    | unblocks current stuck-rollout failure mode    |
| \`ha-sync-orchestrator.yml\`        | currently red because of billing               |
| \`pi-tls-cert-check.yml\`           | currently red because of billing               |
| \`pr-review.yml\`                   | Claude code review                             |
| \`sha-drift-detector.yml\`          | currently red because of billing               |
| \`sha-drift-watchdog.yml\`          | currently red because of billing               |

### Stays GH-hosted (need x86_64 / Chrome / heavy RAM)

- \`lighthouse.yml\` — system Chrome; ARM has no official Chromium in the runner image
- \`k3s-e2e.yml\` — Playwright + browser deps; runs against the live Pi standby (adding load to Pi is counter-productive)
- \`codeql.yml\` — heavy memory + x86_64 analyzer

### Also adds

- \`.github/scripts/register-build-runner.sh\` — bootstraps the \`omv,build\` runner profile alongside the existing \`omv,pi\` cluster runner. Two runners per host, distinct service names, coexisting cleanly.
- \`docs/runners.md\` — full design, opted-in list, caveats (Pi runners share resources with prod), references.
- \`CLAUDE.md\` — short pointer to the toggle commands.

## Why this matters today

Production is at \`5225fb44\`, but the analytics page crash fix is in \`8eb027b3\` (PR #202). The current deploy is stuck because the \`rollout\` job needs \`ubuntu-latest\` and GH billing is blocked. Once this PR lands and you flip \`PI\` mode, the queued rollout — and every other currently-red workflow — can land on the Pi cluster.

## Test plan

- [ ] CI passes on this PR (validates the \`fromJSON\` expression by actually running through it for the \`build\`/\`lint\`/etc. jobs in default = ubuntu-latest mode)
- [ ] After merge: register \`omv-build\` runner on \`omv\` via \`./.github/scripts/register-build-runner.sh <TOKEN> omv-build\`
- [ ] \`.github/scripts/toggle-runner.sh pi\` and re-run the failed \`sha-drift-detector\` — verify it lands on \`omv-build\` and passes
- [ ] \`.github/scripts/toggle-runner.sh hosted\` once GH billing is restored, verify next run lands on \`ubuntu-latest\`

## References

- [GitHub Docs — Choosing the runner for a job](https://docs.github.com/en/actions/using-jobs/choosing-the-runner-for-a-job)
- [GitHub Community — Dynamic runs-on labelling (#49302)](https://github.com/orgs/community/discussions/49302)
- [GitHub Community — \"job was not started… payments have failed\" (#151956)](https://github.com/orgs/community/discussions/151956)

🤖 Generated with [Claude Code](https://claude.com/claude-code)