### PR TITLE
fix(ci): increase Node heap for tsc on ARM runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,6 +69,8 @@ jobs:
           cache: pnpm
       - run: pnpm install --frozen-lockfile
       - run: pnpm typecheck
+        env:
+          NODE_OPTIONS: --max-old-space-size=3072
 
   format:
     name: Format Check


### PR DESCRIPTION
## Summary
- pnpm typecheck was OOM-killing on Pi ARM runners (default ~1.5 GB heap exhausted by tsc)
- Sets NODE_OPTIONS=--max-old-space-size=3072 only on the CI typecheck step -- local runs unaffected
- Fixes the recurring Type Check failure on self-hosted omv-build/omv-2-build runners

## Test plan
- [ ] Type Check passes on Pi runner without OOM
- [ ] All other CI jobs unaffected

Generated with Claude Code