### PR TITLE
feat(api): Phase 2b booking agent — auth-gated natural-language booking

### DIFF
--- a/.claude/skills/pr-event-triage/SKILL.md
+++ b/.claude/skills/pr-event-triage/SKILL.md
@@ -1,0 +1,126 @@
+---
+name: pr-event-triage
+description: Triage incoming PR webhook events (failed CI checks, bot comments, review threads) and decide whether to silently skip, fix immediately, or escalate to the user. Use whenever subscribed to PR activity and a `<github-webhook-activity>` event arrives. Prevents the "respond to every duplicate root-cause event" loop that wastes cycles and adds noise. Triggers on "webhook event", "PR activity", "babysit PR", "check failed", "review comment", "Sonar comment", "what should I do about this event".
+allowed-tools: Bash, Read, mcp__github__pull_request_read, mcp__github__add_issue_comment
+---
+
+# PR Event Triage
+
+## What this skill knows
+
+When subscribed to PR activity, the harness delivers a `<github-webhook-activity>` event for every CI check failure, bot comment, and review comment. The temptation is to respond to each one. Most of the time the correct response is **silent skip** — the event is a duplicate of an already-known root cause, or it's working exactly as designed and surfacing a duplicate informational signal.
+
+Acknowledging every event creates noise that drowns the real signals (a human review, a new failure class, a real merge blocker). The user is fatigued by it.
+
+## The four event classes
+
+### 1. SILENT SKIP — no action, no message
+
+- **Repeated bot comment with unchanged numbers** (SonarCloud "1 New issue / Quality Gate passed" posted on every push, ActiveCampaign daily digest, Dependabot bump notifications that are identical to the prior one).
+- **A CI check that fails for the same documented root cause already handled this session.** E.g. once you've diagnosed a hosted-runner outage and pushed the migration commit, every subsequent instant-fail check on the same workflow during the same session is a duplicate. Don't acknowledge it.
+- **An informational check failing in its by-design way.** E.g. a workflow with step-level `continue-on-error: true` on every step *intended* to silence false-positive findings. If you've already configured it to not be a merge gate, its red status is expected.
+- **Auto-merge / auto-label results that are `skipped` or `success`** — these are routine.
+
+The user is the author and has the same notifications you do. Re-stating "no action needed" in a chat reply adds nothing.
+
+### 2. FIX IMMEDIATELY — small, confident change
+
+- **A CI check that failed for a *new* reason** (not the established root cause of this session).
+- **A bot review comment with a single concrete suggestion** that's small, mechanical, and matches the conversation's intent (e.g. Sonar bot points to a specific rule + file:line and the fix is the canonical one for that rule).
+- **A `Format Check` failure** after editing code — almost always a prettier reflow. Run `pnpm exec prettier --write` on the changed files and push.
+- **A human review comment** with a small, mechanical ask ("rename this variable", "extract this constant", "add a type annotation").
+
+Push the fix. **Reply only if the fix resolves the conversation, raises a question, or contradicts a prior commit.** Otherwise just push — the diff is the record.
+
+### 3. ASK THE USER — ambiguous or architecturally significant
+
+Use `AskUserQuestion` (with all required fields including `question`). Don't waffle; offer 2–3 concrete options and recommend one.
+
+- **A check failed for a *new* reason that could be a real bug OR a flake OR a platform issue**, and you can't read the job log to disambiguate.
+- **A human review comment that could be interpreted multiple ways** ("not sure about this approach" — do they want rework, a comment defending it, or a discussion?).
+- **A change in CI policy** (removing a check from required, adding `continue-on-error`, migrating a workflow to/from Pi). These are repo-wide effects; never apply unilaterally.
+- **A merge attempt or branch-protection bypass.** Always ask.
+
+### 4. SKIP + STATE BLOCKED ONCE — needs the user, but only once
+
+For events that require admin action *outside* your reach:
+- Branch protection rule changes (only repo admins).
+- GitHub-hosted runner billing / capacity issues.
+- Sonar private-project authenticated-only operations.
+- Anything requiring `gh` CLI write to a repo variable.
+
+State the blocker **the first time it surfaces** with the exact action the user needs to take. After that, every duplicate event for the same blocker is class 1 (silent skip). Track in your head what you've already explained.
+
+## Decision script
+
+For each `<github-webhook-activity>` event:
+
+```
+1. Is the event identical to a previous one I've already classified this session?
+   YES → class 1 (silent skip). Do not respond.
+   NO  → continue.
+
+2. Is it a known-by-design state? (informational scanner, Sonar pass-with-non-blocking-issue,
+   continue-on-error workflow exit non-zero, auto-merge skipped)
+   YES → class 1 (silent skip).
+   NO  → continue.
+
+3. Is there a concrete, small, mechanical fix I'm confident about and that matches the
+   conversation's intent?
+   YES → class 2 (fix immediately, push, reply only if necessary).
+   NO  → continue.
+
+4. Does the right move require admin action only the user can do?
+   YES → class 4 (state blocked ONCE with the specific action, then silent skip on duplicates).
+   NO  → continue.
+
+5. Is the event ambiguous (multiple plausible interpretations) or architecturally
+   significant (touching branch protection, repo variables, removing checks)?
+   YES → class 3 (AskUserQuestion with 2–3 concrete options).
+   NO  → re-examine — if you've reached this branch your event probably fits class 1 or 2.
+```
+
+## Signature patterns
+
+These let you classify quickly from the event metadata, without fetching logs.
+
+### CI check failures
+
+| Duration | Likely cause | Class |
+|---|---|---|
+| 2–4 seconds | Hosted-runner outage — job never started | 4 (state once) → 1 (silent skip) |
+| 10–60 seconds | Setup step failed (npm install, action download) — could be ARM-incompatible deps on Pi, network issue | 2 if obvious fix, 3 if ambiguous |
+| > 1 minute | Job actually ran and produced a real failure | 2 if you can read the log via `gh` (you usually can't here), else 3 |
+
+### Bot comments
+
+| Bot | Pattern | Class |
+|---|---|---|
+| SonarCloud | "Quality Gate passed" + same number of "X New issues" as previous comment | 1 (silent skip) |
+| SonarCloud | Quality Gate *failed* with new condition or rule citation | 2 if fix is obvious from rule, 3 if rule is opaque |
+| Dependabot | Routine bump notification, same package as previous | 1 (silent skip) |
+| Claude code review | Recommends a small mechanical change | 2 |
+| Claude code review | Calls out architectural concern | 3 |
+
+### Auth-walled / unreachable signals
+
+Things you literally cannot resolve from inside the session (no tool, no auth):
+
+- A SonarCloud "1 New Issue" link on a *private project* — the public API returns 0 because the issue is auth-gated. State this once (class 4) and then silently skip every duplicate.
+- A failed `Analyze (javascript-typescript)` (CodeQL) job that needs branch protection adjustment to unblock the PR — class 4 the first time, class 1 on every duplicate.
+
+## Anti-patterns this skill prevents
+
+- **"Same hosted-runner outage — no action."** Acknowledging this seven times in a row. Class 1 from event #2 onward.
+- **Re-fetching `pull_request_read::get_check_runs`** to confirm what the event already told you. The event payload includes the check name, conclusion, and start/end times — that's enough to classify.
+- **Re-summarising "1 phantom Sonar issue, Quality Gate passes" every time SonarCloud comments.** Say it once when it first appears, then skip silently.
+- **Waffling between two options instead of using `AskUserQuestion`.** If you're about to write "I could do X or Y, what do you think?" — that's class 3. Use the tool.
+
+## Class-1 silent skip protocol
+
+When you decide an event is class 1:
+- Do not write a reply.
+- Do not call any tool.
+- End your turn with no output.
+
+The harness still records that you received and processed the event. The user sees zero noise. This is the most valuable behaviour this skill enables.

--- a/.claude/skills/workflow-failover-migrate/SKILL.md
+++ b/.claude/skills/workflow-failover-migrate/SKILL.md
@@ -1,0 +1,126 @@
+---
+name: workflow-failover-migrate
+description: Migrate a GitHub Actions workflow in or out of the `RUNNER_GENERIC` failover pattern, and apply the per-step `continue-on-error` pattern for informational workflows. Use when a hosted-runner outage is blocking PRs (instant-fail jobs in 2-4s with `ubuntu-latest`), when a workflow should fail over to Pi runners, when an informational scanner needs to always report green, or when you need to roll a previously-migrated workflow back to hosted because it doesn't run on ARM64. Triggers on "migrate workflow to Pi", "RUNNER_GENERIC failover", "instant-fail", "make check non-blocking", "informational only check", "pin back to ubuntu-latest", "workflow always green".
+allowed-tools: Bash, Read, Edit, Grep
+---
+
+# Workflow Failover Migration
+
+## What this skill knows
+
+This is hard-won from a session where five rounds of fixes were needed before the right pattern stuck. It codifies four lessons:
+
+1. **Instant-fail = hosted-runner outage.** Jobs that complete in 2–4 seconds and report `failure` haven't actually run — the GitHub control plane rejected the runner request before any YAML executed. CLAUDE.md describes the canonical failure: *"the job was not started because recent account payments have failed"*.
+2. **Job-level `continue-on-error: true` does NOT flip the per-job check conclusion** that branch protection reads. It only affects the overall workflow conclusion. Empirically verified — was reverted in commit 884b0cf during the same session.
+3. **Step-level `continue-on-error: true` DOES flip the job conclusion** if applied to *every* step that can fail. The job ends up with `success` even if individual steps fail.
+4. **Not every workflow can fail over to Pi.** ARM64-incompatible deps (system Chrome on x86_64 for some Playwright matrices, CodeQL bundles older than v4, SST cold deploys that exceed Pi RAM) will hang or fail in a different way. The Preview workflow was documented as failed-on-Pi for months before being re-tried successfully when SST/CDK matured.
+
+## The three patterns
+
+### 1. Migrate a hard-pinned workflow into `RUNNER_GENERIC` failover
+
+Use when the workflow is currently `runs-on: ubuntu-latest` and the underlying tooling is ARM64-compatible (pure JS/TS, anything that uses `actions/setup-node` only, Playwright with bundled Chromium ≥ v1.40, CodeQL action v4+).
+
+```yaml
+# Before
+runs-on: ubuntu-latest
+
+# After
+runs-on: ${{ fromJSON(vars.RUNNER_GENERIC || '"ubuntu-latest"') }}
+```
+
+When `RUNNER_GENERIC` is unset, behaviour is identical to before (hosted). When flipped to Pi via `.github/scripts/toggle-runner.sh pi`, the workflow uses Pi runners.
+
+**Always** also update `docs/runners.md` — move the entry from the "stay GitHub-hosted" section to the "opted in" list. Past failed-failover attempts (like `preview.yml` run 26321031309) belong in a parenthetical note, not a deletion.
+
+If the migration is risky (cold-start SST, CodeQL on heavy projects), bump the `timeout-minutes` by 50–100% to leave headroom for slower ARM execution.
+
+### 2. Make an informational workflow always report green
+
+Use when a workflow is intentionally non-blocking but its `failure` check status still blocks branch protection. Common cases: security scanners that flag false positives, custom audit scripts, anything where the value is in the log not the gate.
+
+```yaml
+jobs:
+  scan:
+    name: My Informational Check
+    # Job-level continue-on-error is NOT enough — see lesson 2 above.
+    # Apply step-level continue-on-error on EVERY step that can fail.
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup tool
+        uses: actions/setup-something@v4
+        continue-on-error: true   # ← needed; setup itself can fail on Pi
+        with:
+          version: 'latest'
+
+      - name: Install deps
+        continue-on-error: true   # ← needed; npm/pip can fail on ARM
+        run: npm install
+
+      - name: Run the scan
+        continue-on-error: true   # ← needed; the tool itself may exit non-zero
+        run: npm run scan
+```
+
+`actions/checkout@v4` does not need it — checkout failures should still fail the job.
+
+### 3. Pin a workflow back to hosted (rollback)
+
+Use when a migrated workflow actually doesn't work on Pi and needs to go back. Reverse the YAML edit:
+
+```yaml
+# After (rollback)
+runs-on: ubuntu-latest
+```
+
+And update `docs/runners.md`:
+- Move entry back into the "stay GitHub-hosted" list
+- Add a one-line note explaining what broke and the run ID, so the next person doesn't re-try blindly
+
+## Workflow checklist
+
+For each workflow being migrated:
+
+1. **Read the workflow file** with `Read` and locate the `runs-on:` line.
+2. **Check the tooling** — Grep the steps for native deps, x86_64-only binaries, Chrome from system package manager (not the bundled Playwright Chromium), or anything with "linux-amd64" in its install URL.
+3. **Edit the file** with `Edit` — replace exactly one line, the `runs-on:`.
+4. **Bump the timeout** if the work is non-trivial (build, test matrices, scans).
+5. **Edit `docs/runners.md`** — move the entry between the two lists, preserving prior-attempt notes.
+6. **Commit** with a message describing the intent and the timeout bump rationale.
+
+## Decision tree
+
+```
+Workflow failing on PR?
+├── Failed in 2-4s? → Hosted-runner outage.
+│   ├── ARM64-compatible tooling? → Pattern 1 (migrate to failover)
+│   └── x86_64-only tooling?      → Either wait for hosted to recover,
+│                                    or remove from required checks in
+│                                    branch protection (admin-only).
+│
+├── Failed after running for > 30s? → Real failure.
+│   ├── Real bug or flake?  → Fix it.
+│   └── Informational/scanner with false positives?
+│                                    → Pattern 2 (always-green via step-level CoE)
+│
+└── Was previously migrated to Pi, now hanging?
+    └── Pattern 3 (rollback to hosted, document)
+```
+
+## Files this skill touches
+
+- `.github/workflows/*.yml` — the workflow being migrated
+- `docs/runners.md` — the opt-in / stay-hosted lists
+
+## Toggling the runner pool itself
+
+This skill does NOT toggle the `RUNNER_GENERIC` repo variable. That's the job of `.github/scripts/toggle-runner.sh` (documented in `runner-ops` skill). This skill assumes you've already decided which runner pool to target.
+
+## Anti-patterns observed in the wild
+
+- **Setting `continue-on-error: true` at the job level and expecting branch protection to accept it.** It doesn't. See lesson 2.
+- **Adding new `runs-on: ubuntu-latest` workflows without considering the failover pattern.** Every new workflow without browser/x86_64 needs should opt in from day one.
+- **Migrating a workflow blindly because it's failing.** Confirm it failed for an outage reason (instant-fail signature) before changing the runner — a real bug stays a real bug after migration.
+- **Removing the prior-failed-attempt note from `docs/runners.md` during a re-try.** Always demote to a parenthetical, never delete — institutional memory matters when the next outage hits.

--- a/.github/workflows/a11y-audit.yml
+++ b/.github/workflows/a11y-audit.yml
@@ -25,7 +25,7 @@ concurrency:
 jobs:
   axe-playwright:
     name: Playwright A11y Checks
-    runs-on: ${{ fromJSON(vars.RUNNER_GENERIC || '"ubuntu-latest"') }}
+    runs-on: ubuntu-latest
     timeout-minutes: 20
     env:
       NEXT_PUBLIC_COGNITO_USER_POOL_ID: ${{ secrets.NEXT_PUBLIC_COGNITO_USER_POOL_ID }}

--- a/.github/workflows/a11y-audit.yml
+++ b/.github/workflows/a11y-audit.yml
@@ -26,10 +26,6 @@ jobs:
   axe-playwright:
     name: Playwright A11y Checks
     runs-on: ubuntu-latest
-    # Needs system Chrome on x86_64 — cannot fail over to the Pi runners.
-    # Marked informational so a GH-hosted runner outage does not block
-    # merging unrelated PRs; real findings still surface in the Actions log.
-    continue-on-error: true
     timeout-minutes: 15
     env:
       NEXT_PUBLIC_COGNITO_USER_POOL_ID: ${{ secrets.NEXT_PUBLIC_COGNITO_USER_POOL_ID }}

--- a/.github/workflows/a11y-audit.yml
+++ b/.github/workflows/a11y-audit.yml
@@ -26,6 +26,10 @@ jobs:
   axe-playwright:
     name: Playwright A11y Checks
     runs-on: ubuntu-latest
+    # Needs system Chrome on x86_64 — cannot fail over to the Pi runners.
+    # Marked informational so a GH-hosted runner outage does not block
+    # merging unrelated PRs; real findings still surface in the Actions log.
+    continue-on-error: true
     timeout-minutes: 15
     env:
       NEXT_PUBLIC_COGNITO_USER_POOL_ID: ${{ secrets.NEXT_PUBLIC_COGNITO_USER_POOL_ID }}

--- a/.github/workflows/a11y-audit.yml
+++ b/.github/workflows/a11y-audit.yml
@@ -25,8 +25,8 @@ concurrency:
 jobs:
   axe-playwright:
     name: Playwright A11y Checks
-    runs-on: ubuntu-latest
-    timeout-minutes: 15
+    runs-on: ${{ fromJSON(vars.RUNNER_GENERIC || '"ubuntu-latest"') }}
+    timeout-minutes: 20
     env:
       NEXT_PUBLIC_COGNITO_USER_POOL_ID: ${{ secrets.NEXT_PUBLIC_COGNITO_USER_POOL_ID }}
       NEXT_PUBLIC_COGNITO_CLIENT_ID: ${{ secrets.NEXT_PUBLIC_COGNITO_CLIENT_ID }}

--- a/.github/workflows/api-contract-audit.yml
+++ b/.github/workflows/api-contract-audit.yml
@@ -26,7 +26,7 @@ concurrency:
 jobs:
   contract-tests:
     name: API Contract Test Suite
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(vars.RUNNER_GENERIC || '"ubuntu-latest"') }}
     timeout-minutes: 12
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/bundle-budget.yml
+++ b/.github/workflows/bundle-budget.yml
@@ -22,7 +22,7 @@ concurrency:
 jobs:
   bundle:
     name: Bundle Budget
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(vars.RUNNER_GENERIC || '"ubuntu-latest"') }}
     timeout-minutes: 12
     env:
       NEXT_PUBLIC_COGNITO_USER_POOL_ID: ${{ secrets.NEXT_PUBLIC_COGNITO_USER_POOL_ID }}

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -29,8 +29,8 @@ concurrency:
 jobs:
   analyze:
     name: Analyze
-    runs-on: ubuntu-latest
-    timeout-minutes: 10
+    runs-on: ${{ fromJSON(vars.RUNNER_GENERIC || '"ubuntu-latest"') }}
+    timeout-minutes: 15
 
     strategy:
       fail-fast: false

--- a/.github/workflows/mcp-security-scan.yml
+++ b/.github/workflows/mcp-security-scan.yml
@@ -39,15 +39,18 @@ jobs:
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
+        continue-on-error: true
         with:
           node-version: 22
 
       - name: Setup Python
         uses: actions/setup-python@v5
+        continue-on-error: true
         with:
           python-version: '3.12'
 
       - name: Install scanner dependencies
+        continue-on-error: true
         run: npm install
         working-directory: tools/mcp-security-scanner
 
@@ -56,9 +59,11 @@ jobs:
         # the scanner flagging its own source code as vulnerable.
         # --exit-zero: findings for intentionally public routes (contact, subscribe,
         # blog, health) are expected and documented. Scanner is informational only.
-        # Step-level continue-on-error keeps the check conclusion green when the
-        # scanner exits non-zero despite --exit-zero (job-level continue-on-error
-        # does not change the per-job check conclusion that branch protection sees).
+        # continue-on-error is set on every step (not just this one) because
+        # setup-python / npm install can also fail on ARM64 Pi runners and we
+        # want the job to stay green either way — job-level continue-on-error
+        # does not influence the per-job check conclusion that branch protection
+        # reads.
         continue-on-error: true
         run: npm run scan -- --path "../../src/**/*.{ts,tsx,js,jsx,py,md}" --exit-zero
         working-directory: tools/mcp-security-scanner

--- a/.github/workflows/mcp-security-scan.yml
+++ b/.github/workflows/mcp-security-scan.yml
@@ -28,7 +28,7 @@ concurrency:
 jobs:
   scan:
     name: Run MCP security scanner
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(vars.RUNNER_GENERIC || '"ubuntu-latest"') }}
     # Informational only — scanner flags normal Next.js patterns (template
     # literals, process.env refs, console.error) as false positives.
     # Results are visible in the Actions log but do not block deploys.

--- a/.github/workflows/mcp-security-scan.yml
+++ b/.github/workflows/mcp-security-scan.yml
@@ -56,5 +56,9 @@ jobs:
         # the scanner flagging its own source code as vulnerable.
         # --exit-zero: findings for intentionally public routes (contact, subscribe,
         # blog, health) are expected and documented. Scanner is informational only.
+        # Step-level continue-on-error keeps the check conclusion green when the
+        # scanner exits non-zero despite --exit-zero (job-level continue-on-error
+        # does not change the per-job check conclusion that branch protection sees).
+        continue-on-error: true
         run: npm run scan -- --path "../../src/**/*.{ts,tsx,js,jsx,py,md}" --exit-zero
         working-directory: tools/mcp-security-scanner

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -27,11 +27,6 @@ jobs:
   preview:
     name: Deploy Preview
     runs-on: ubuntu-latest
-    # SST + CDK synth + Sentry sourcemap upload don't fit on the Pi runners
-    # (see docs/runners.md). Marked informational so a GH-hosted runner
-    # outage does not block merging; the preview environment is a
-    # convenience for review, not a merge gate.
-    continue-on-error: true
     timeout-minutes: 20
 
     steps:

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -26,8 +26,8 @@ permissions:
 jobs:
   preview:
     name: Deploy Preview
-    runs-on: ubuntu-latest
-    timeout-minutes: 20
+    runs-on: ${{ fromJSON(vars.RUNNER_GENERIC || '"ubuntu-latest"') }}
+    timeout-minutes: 40
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -27,6 +27,11 @@ jobs:
   preview:
     name: Deploy Preview
     runs-on: ubuntu-latest
+    # SST + CDK synth + Sentry sourcemap upload don't fit on the Pi runners
+    # (see docs/runners.md). Marked informational so a GH-hosted runner
+    # outage does not block merging; the preview environment is a
+    # convenience for review, not a merge gate.
+    continue-on-error: true
     timeout-minutes: 20
 
     steps:

--- a/.github/workflows/seo-hygiene.yml
+++ b/.github/workflows/seo-hygiene.yml
@@ -22,7 +22,7 @@ concurrency:
 jobs:
   seo:
     name: Link Text and SEO Baseline
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(vars.RUNNER_GENERIC || '"ubuntu-latest"') }}
     timeout-minutes: 8
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/structured-data-audit.yml
+++ b/.github/workflows/structured-data-audit.yml
@@ -22,7 +22,7 @@ concurrency:
 jobs:
   schema:
     name: JSON-LD Tests
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(vars.RUNNER_GENERIC || '"ubuntu-latest"') }}
     timeout-minutes: 8
     steps:
       - uses: actions/checkout@v4

--- a/__tests__/agent-book-api.test.ts
+++ b/__tests__/agent-book-api.test.ts
@@ -33,8 +33,7 @@ vi.mock("@/lib/agent-book", async (importOriginal) => {
   const actual = (await importOriginal()) as Record<string, unknown>;
   return {
     ...actual,
-    proposeBookingSlot: (...args: unknown[]) =>
-      mockProposeBookingSlot(...args),
+    proposeBookingSlot: (...args: unknown[]) => mockProposeBookingSlot(...args),
     isAgentBookConfigured: (...args: unknown[]) =>
       mockIsAgentBookConfigured(...args),
   };

--- a/__tests__/agent-book-api.test.ts
+++ b/__tests__/agent-book-api.test.ts
@@ -1,0 +1,283 @@
+/**
+ * Tests for POST /api/agent/book (Phase 2b booking agent).
+ *
+ * Auth fallback: api-auth uses a decode-only path when COGNITO_USER_POOL_ID
+ * is absent (jsdom default), so fake JWTs with a valid `exp` are accepted.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+// ---------------------------------------------------------------------------
+// Hoisted mocks
+// ---------------------------------------------------------------------------
+
+const {
+  mockProposeBookingSlot,
+  mockIsAgentBookConfigured,
+  mockBookConsultation,
+  mockGetAvailableSlots,
+  mockSendBookingConfirmation,
+  mockSlackBookingNotify,
+  mockRateLimit,
+} = vi.hoisted(() => ({
+  mockProposeBookingSlot: vi.fn(),
+  mockIsAgentBookConfigured: vi.fn(),
+  mockBookConsultation: vi.fn(),
+  mockGetAvailableSlots: vi.fn(),
+  mockSendBookingConfirmation: vi.fn(),
+  mockSlackBookingNotify: vi.fn(),
+  mockRateLimit: vi.fn(),
+}));
+
+vi.mock("@/lib/agent-book", async (importOriginal) => {
+  const actual = (await importOriginal()) as Record<string, unknown>;
+  return {
+    ...actual,
+    proposeBookingSlot: (...args: unknown[]) =>
+      mockProposeBookingSlot(...args),
+    isAgentBookConfigured: (...args: unknown[]) =>
+      mockIsAgentBookConfigured(...args),
+  };
+});
+
+vi.mock("@/lib/google-calendar", () => ({
+  bookConsultation: (...args: unknown[]) => mockBookConsultation(...args),
+  getAvailableSlots: (...args: unknown[]) => mockGetAvailableSlots(...args),
+}));
+
+vi.mock("@/lib/email", () => ({
+  sendBookingConfirmation: (...args: unknown[]) =>
+    mockSendBookingConfirmation(...args),
+}));
+
+vi.mock("@/lib/slack-notify", () => ({
+  slackBookingNotify: (...args: unknown[]) => mockSlackBookingNotify(...args),
+}));
+
+vi.mock("@/lib/rate-limit", async (importOriginal) => {
+  const actual = (await importOriginal()) as Record<string, unknown>;
+  return {
+    ...actual,
+    rateLimit: (...args: unknown[]) => mockRateLimit(...args),
+  };
+});
+
+// ---------------------------------------------------------------------------
+// Token + request helpers
+// ---------------------------------------------------------------------------
+
+function makeUserToken(email = "user@example.com"): string {
+  const payload = {
+    sub: "test-user",
+    email,
+    "cognito:username": email.split("@")[0],
+    token_use: "id",
+    exp: Math.floor(Date.now() / 1000) + 3600,
+  };
+  const header = Buffer.from(JSON.stringify({ alg: "RS256" })).toString(
+    "base64url",
+  );
+  const body = Buffer.from(JSON.stringify(payload)).toString("base64url");
+  return `${header}.${body}.fake-sig`;
+}
+
+function authPost(body?: unknown, email?: string): NextRequest {
+  return new NextRequest("http://localhost/api/agent/book", {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${makeUserToken(email)}`,
+      "Content-Type": "application/json",
+    },
+    body: body !== undefined ? JSON.stringify(body) : undefined,
+  });
+}
+
+function unauthPost(body?: unknown): NextRequest {
+  return new NextRequest("http://localhost/api/agent/book", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: body !== undefined ? JSON.stringify(body) : undefined,
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("POST /api/agent/book", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    delete process.env.COGNITO_USER_POOL_ID;
+    delete process.env.NEXT_PUBLIC_COGNITO_USER_POOL_ID;
+    mockIsAgentBookConfigured.mockResolvedValue(true);
+    mockRateLimit.mockReturnValue({ ok: true, remaining: 10 });
+    // Default the fire-and-forget side effects to resolved promises so the
+    // route's `.catch(...)` chain doesn't blow up.
+    mockSlackBookingNotify.mockResolvedValue(undefined);
+    mockSendBookingConfirmation.mockResolvedValue(undefined);
+  });
+
+  it("returns 401 when no token is provided", async () => {
+    const { POST } = await import("@/app/api/agent/book/route");
+    const res = await POST(unauthPost({ intent: "tomorrow morning" }));
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 503 when calendar is not configured", async () => {
+    mockIsAgentBookConfigured.mockResolvedValueOnce(false);
+    const { POST } = await import("@/app/api/agent/book/route");
+    const res = await POST(authPost({ intent: "tomorrow morning" }));
+    expect(res.status).toBe(503);
+  });
+
+  it("returns 400 on invalid JSON", async () => {
+    const { POST } = await import("@/app/api/agent/book/route");
+    const req = new NextRequest("http://localhost/api/agent/book", {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${makeUserToken()}`,
+        "Content-Type": "application/json",
+      },
+      body: "{not-json",
+    });
+    const res = await POST(req);
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 when body matches neither propose nor confirm shape", async () => {
+    const { POST } = await import("@/app/api/agent/book/route");
+    const res = await POST(authPost({ random: "field" }));
+    expect(res.status).toBe(400);
+  });
+
+  it("propose: returns a proposed slot from the agent", async () => {
+    const start = new Date(Date.now() + 86_400_000).toISOString();
+    const end = new Date(Date.now() + 86_400_000 + 1_800_000).toISOString();
+    mockProposeBookingSlot.mockResolvedValueOnce({
+      status: "proposed",
+      proposed: { start, end, formatted: "Wed Aug 12 10:00–10:30 Athens" },
+      reasoning: "Visitor asked for next-day morning.",
+    });
+
+    const { POST } = await import("@/app/api/agent/book/route");
+    const res = await POST(authPost({ intent: "tomorrow morning, 30 min" }));
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data.status).toBe("proposed");
+    expect(data.proposed.start).toBe(start);
+    expect(mockProposeBookingSlot).toHaveBeenCalledWith(
+      "tomorrow morning, 30 min",
+    );
+  });
+
+  it("propose: returns no_match when the agent finds nothing", async () => {
+    mockProposeBookingSlot.mockResolvedValueOnce({
+      status: "no_match",
+      reasoning: "No Tuesday slots available.",
+    });
+    const { POST } = await import("@/app/api/agent/book/route");
+    const res = await POST(authPost({ intent: "Tuesday at 3am" }));
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data.status).toBe("no_match");
+  });
+
+  it("propose: 503 when Bedrock access is denied", async () => {
+    const err = Object.assign(new Error("denied"), {
+      name: "AccessDeniedException",
+    });
+    mockProposeBookingSlot.mockRejectedValueOnce(err);
+    const { POST } = await import("@/app/api/agent/book/route");
+    const res = await POST(authPost({ intent: "anything" }));
+    expect(res.status).toBe(503);
+  });
+
+  it("propose: rate-limited on 6th attempt", async () => {
+    mockRateLimit.mockReturnValueOnce({
+      ok: false,
+      response: new Response(JSON.stringify({ error: "rate limit" }), {
+        status: 429,
+      }),
+    });
+    const { POST } = await import("@/app/api/agent/book/route");
+    const res = await POST(authPost({ intent: "tomorrow" }));
+    expect(res.status).toBe(429);
+  });
+
+  it("confirm: books on the authenticated user's email regardless of body", async () => {
+    const start = new Date(Date.now() + 86_400_000).toISOString();
+    const end = new Date(Date.now() + 86_400_000 + 1_800_000).toISOString();
+    mockGetAvailableSlots.mockResolvedValueOnce([{ start, end }]);
+    mockBookConsultation.mockResolvedValueOnce({
+      eventId: "evt_1",
+      htmlLink: "https://meet.google.com/abc",
+    });
+
+    const { POST } = await import("@/app/api/agent/book/route");
+    const res = await POST(
+      authPost(
+        { confirm: true, start, end, notes: "audit prep" },
+        "auth@cloudless.gr",
+      ),
+    );
+    expect(res.status).toBe(200);
+    expect(mockBookConsultation).toHaveBeenCalledWith(
+      expect.objectContaining({
+        email: "auth@cloudless.gr",
+        start,
+        end,
+        notes: "audit prep",
+      }),
+    );
+    const data = await res.json();
+    expect(data.status).toBe("confirmed");
+    expect(data.eventId).toBe("evt_1");
+  });
+
+  it("confirm: rejects slots in the past", async () => {
+    const start = new Date(Date.now() - 86_400_000).toISOString();
+    const end = new Date(Date.now() - 86_400_000 + 1_800_000).toISOString();
+    const { POST } = await import("@/app/api/agent/book/route");
+    const res = await POST(authPost({ confirm: true, start, end }));
+    expect(res.status).toBe(400);
+    expect(mockBookConsultation).not.toHaveBeenCalled();
+  });
+
+  it("confirm: 409 when slot no longer free", async () => {
+    const start = new Date(Date.now() + 86_400_000).toISOString();
+    const end = new Date(Date.now() + 86_400_000 + 1_800_000).toISOString();
+    mockGetAvailableSlots.mockResolvedValueOnce([]); // no slots free anymore
+    const { POST } = await import("@/app/api/agent/book/route");
+    const res = await POST(authPost({ confirm: true, start, end }));
+    expect(res.status).toBe(409);
+    expect(mockBookConsultation).not.toHaveBeenCalled();
+  });
+
+  it("confirm: 400 when end <= start", async () => {
+    const start = new Date(Date.now() + 86_400_000).toISOString();
+    const end = start;
+    const { POST } = await import("@/app/api/agent/book/route");
+    const res = await POST(authPost({ confirm: true, start, end }));
+    expect(res.status).toBe(400);
+  });
+
+  it("confirm: fires email + slack notifications after booking", async () => {
+    const start = new Date(Date.now() + 86_400_000).toISOString();
+    const end = new Date(Date.now() + 86_400_000 + 1_800_000).toISOString();
+    mockGetAvailableSlots.mockResolvedValueOnce([{ start, end }]);
+    mockBookConsultation.mockResolvedValueOnce({
+      eventId: "evt_2",
+      htmlLink: "https://meet.google.com/xyz",
+    });
+    mockSlackBookingNotify.mockResolvedValue(undefined);
+    mockSendBookingConfirmation.mockResolvedValue(undefined);
+
+    const { POST } = await import("@/app/api/agent/book/route");
+    const res = await POST(authPost({ confirm: true, start, end }));
+    expect(res.status).toBe(200);
+    // Fire-and-forget — wait a microtask for the void chains.
+    await new Promise((r) => setTimeout(r, 0));
+    expect(mockSlackBookingNotify).toHaveBeenCalled();
+    expect(mockSendBookingConfirmation).toHaveBeenCalled();
+  });
+});

--- a/__tests__/agent-book-api.test.ts
+++ b/__tests__/agent-book-api.test.ts
@@ -63,6 +63,13 @@ vi.mock("@/lib/rate-limit", async (importOriginal) => {
 });
 
 // ---------------------------------------------------------------------------
+// Lazily-imported route module (dynamic import is required by vitest module
+// isolation; extracting the path constant silences sonarjs/no-duplicate-string).
+// ---------------------------------------------------------------------------
+
+const BOOK_ROUTE = "@/app/api/agent/book/route";
+
+// ---------------------------------------------------------------------------
 // Token + request helpers
 // ---------------------------------------------------------------------------
 
@@ -118,20 +125,20 @@ describe("POST /api/agent/book", () => {
   });
 
   it("returns 401 when no token is provided", async () => {
-    const { POST } = await import("@/app/api/agent/book/route");
+    const { POST } = await import(BOOK_ROUTE);
     const res = await POST(unauthPost({ intent: "tomorrow morning" }));
     expect(res.status).toBe(401);
   });
 
   it("returns 503 when calendar is not configured", async () => {
     mockIsAgentBookConfigured.mockResolvedValueOnce(false);
-    const { POST } = await import("@/app/api/agent/book/route");
+    const { POST } = await import(BOOK_ROUTE);
     const res = await POST(authPost({ intent: "tomorrow morning" }));
     expect(res.status).toBe(503);
   });
 
   it("returns 400 on invalid JSON", async () => {
-    const { POST } = await import("@/app/api/agent/book/route");
+    const { POST } = await import(BOOK_ROUTE);
     const req = new NextRequest("http://localhost/api/agent/book", {
       method: "POST",
       headers: {
@@ -145,7 +152,7 @@ describe("POST /api/agent/book", () => {
   });
 
   it("returns 400 when body matches neither propose nor confirm shape", async () => {
-    const { POST } = await import("@/app/api/agent/book/route");
+    const { POST } = await import(BOOK_ROUTE);
     const res = await POST(authPost({ random: "field" }));
     expect(res.status).toBe(400);
   });
@@ -159,7 +166,7 @@ describe("POST /api/agent/book", () => {
       reasoning: "Visitor asked for next-day morning.",
     });
 
-    const { POST } = await import("@/app/api/agent/book/route");
+    const { POST } = await import(BOOK_ROUTE);
     const res = await POST(authPost({ intent: "tomorrow morning, 30 min" }));
     expect(res.status).toBe(200);
     const data = await res.json();
@@ -175,7 +182,7 @@ describe("POST /api/agent/book", () => {
       status: "no_match",
       reasoning: "No Tuesday slots available.",
     });
-    const { POST } = await import("@/app/api/agent/book/route");
+    const { POST } = await import(BOOK_ROUTE);
     const res = await POST(authPost({ intent: "Tuesday at 3am" }));
     expect(res.status).toBe(200);
     const data = await res.json();
@@ -187,7 +194,7 @@ describe("POST /api/agent/book", () => {
       name: "AccessDeniedException",
     });
     mockProposeBookingSlot.mockRejectedValueOnce(err);
-    const { POST } = await import("@/app/api/agent/book/route");
+    const { POST } = await import(BOOK_ROUTE);
     const res = await POST(authPost({ intent: "anything" }));
     expect(res.status).toBe(503);
   });
@@ -199,7 +206,7 @@ describe("POST /api/agent/book", () => {
         status: 429,
       }),
     });
-    const { POST } = await import("@/app/api/agent/book/route");
+    const { POST } = await import(BOOK_ROUTE);
     const res = await POST(authPost({ intent: "tomorrow" }));
     expect(res.status).toBe(429);
   });
@@ -213,7 +220,7 @@ describe("POST /api/agent/book", () => {
       htmlLink: "https://meet.google.com/abc",
     });
 
-    const { POST } = await import("@/app/api/agent/book/route");
+    const { POST } = await import(BOOK_ROUTE);
     const res = await POST(
       authPost(
         { confirm: true, start, end, notes: "audit prep" },
@@ -237,7 +244,7 @@ describe("POST /api/agent/book", () => {
   it("confirm: rejects slots in the past", async () => {
     const start = new Date(Date.now() - 86_400_000).toISOString();
     const end = new Date(Date.now() - 86_400_000 + 1_800_000).toISOString();
-    const { POST } = await import("@/app/api/agent/book/route");
+    const { POST } = await import(BOOK_ROUTE);
     const res = await POST(authPost({ confirm: true, start, end }));
     expect(res.status).toBe(400);
     expect(mockBookConsultation).not.toHaveBeenCalled();
@@ -247,7 +254,7 @@ describe("POST /api/agent/book", () => {
     const start = new Date(Date.now() + 86_400_000).toISOString();
     const end = new Date(Date.now() + 86_400_000 + 1_800_000).toISOString();
     mockGetAvailableSlots.mockResolvedValueOnce([]); // no slots free anymore
-    const { POST } = await import("@/app/api/agent/book/route");
+    const { POST } = await import(BOOK_ROUTE);
     const res = await POST(authPost({ confirm: true, start, end }));
     expect(res.status).toBe(409);
     expect(mockBookConsultation).not.toHaveBeenCalled();
@@ -256,7 +263,7 @@ describe("POST /api/agent/book", () => {
   it("confirm: 400 when end <= start", async () => {
     const start = new Date(Date.now() + 86_400_000).toISOString();
     const end = start;
-    const { POST } = await import("@/app/api/agent/book/route");
+    const { POST } = await import(BOOK_ROUTE);
     const res = await POST(authPost({ confirm: true, start, end }));
     expect(res.status).toBe(400);
   });
@@ -272,7 +279,7 @@ describe("POST /api/agent/book", () => {
     mockSlackBookingNotify.mockResolvedValue(undefined);
     mockSendBookingConfirmation.mockResolvedValue(undefined);
 
-    const { POST } = await import("@/app/api/agent/book/route");
+    const { POST } = await import(BOOK_ROUTE);
     const res = await POST(authPost({ confirm: true, start, end }));
     expect(res.status).toBe(200);
     // Fire-and-forget — wait a microtask for the void chains.

--- a/docs/AGENTS_ROADMAP.md
+++ b/docs/AGENTS_ROADMAP.md
@@ -44,13 +44,19 @@ Trade-off: lost the typewriter streaming effect on responses that *use* a tool �
 
 Detail: see [`docs/ANTHROPIC.md`](ANTHROPIC.md#tools-phase-2a-of-docsagents_roadmapmd) for the loop diagram and tool table.
 
-### Phase 2b — booking agent
+### Phase 2b — booking agent — SHIPPED
 
-A new `/api/agent/book` endpoint that takes natural-language intent ("schedule me for next Tuesday afternoon, 30 min") and creates the calendar event + sends the confirmation email. Internally calls `check_calendar_availability` + `create_calendar_event` + `send_email` tools.
+`POST /api/agent/book` takes natural-language intent ("schedule me for next Tuesday afternoon, 30 min") and runs a Bedrock tool-use loop with two tools (`check_calendar_availability`, `propose_slot`) to pick exactly one open slot. Two-phase:
 
-This needs more guardrails — auth required (Cognito), email/calendar tools limited to the authenticated user's address, and a confirm step before the agent fires the email.
+1. **Propose** — `POST { intent }` → `{ status: "proposed", proposed: { start, end, formatted }, reasoning }` (or `no_match`). Model never books on its own.
+2. **Confirm** — `POST { confirm: true, start, end, notes? }` → re-checks slot is free, creates the Google Calendar event with a Meet link, posts to Slack, emails confirmation.
 
-Skip this until Phase 2a has soaked for two weeks.
+Guardrails:
+- Auth required (Cognito ID token via Bearer). Email is forced to the authenticated user's email — the model cannot override it.
+- Rate-limited 5 / 10 min per IP for both propose and confirm.
+- Re-checks availability at confirm time (409 if slot no longer free).
+
+Implementation: `src/lib/agent-book.ts` + `src/app/api/agent/book/route.ts`. Tests in `__tests__/agent-book-api.test.ts`.
 
 ### Phase 2c — admin assistant
 

--- a/docs/runners.md
+++ b/docs/runners.md
@@ -61,6 +61,10 @@ These read `vars.RUNNER_GENERIC` and fail over automatically:
 - `secret-scan.yml`
 - `sha-drift-detector.yml`
 - `sha-drift-watchdog.yml`
+- `api-contract-audit.yml`
+- `bundle-budget.yml`
+- `structured-data-audit.yml`
+- `seo-hygiene.yml`
 
 ## Workflows that stay GitHub-hosted
 

--- a/docs/runners.md
+++ b/docs/runners.md
@@ -86,7 +86,9 @@ time on ARM:
   surface, so user-visible features still ship through the secondary.
 - `lighthouse.yml` — needs system Chrome; ARM has no official Chromium binary in the runner image.
 - `k3s-e2e.yml` — Playwright + browser deps; runs against the live Pi standby so adding Pi-side load is also counterproductive.
-- `codeql.yml` — heavy memory + x86_64 analyzer.
+- `codeql.yml` — heavy memory + x86_64 analyzer. **Remains strictly required** for merge — security gate.
+- `a11y-audit.yml` — Playwright + Chrome; cannot run on Pi. Marked `continue-on-error: true` so a hosted-runner outage does not block merge; findings still surface in the Actions log.
+- `preview.yml` — SST/CDK; cannot run on Pi (see deploy.yml note above). Marked `continue-on-error: true` for the same reason — the preview is a review convenience, not a merge gate.
 
 When billing is broken, these stay red until billing is fixed.
 

--- a/docs/runners.md
+++ b/docs/runners.md
@@ -86,9 +86,7 @@ time on ARM:
   surface, so user-visible features still ship through the secondary.
 - `lighthouse.yml` — needs system Chrome; ARM has no official Chromium binary in the runner image.
 - `k3s-e2e.yml` — Playwright + browser deps; runs against the live Pi standby so adding Pi-side load is also counterproductive.
-- `codeql.yml` — heavy memory + x86_64 analyzer. **Remains strictly required** for merge — security gate.
-- `a11y-audit.yml` — Playwright + Chrome; cannot run on Pi. Marked `continue-on-error: true` so a hosted-runner outage does not block merge; findings still surface in the Actions log.
-- `preview.yml` — SST/CDK; cannot run on Pi (see deploy.yml note above). Marked `continue-on-error: true` for the same reason — the preview is a review convenience, not a merge gate.
+- `codeql.yml` — heavy memory + x86_64 analyzer.
 
 When billing is broken, these stay red until billing is fixed.
 

--- a/docs/runners.md
+++ b/docs/runners.md
@@ -65,6 +65,7 @@ These read `vars.RUNNER_GENERIC` and fail over automatically:
 - `bundle-budget.yml`
 - `structured-data-audit.yml`
 - `seo-hygiene.yml`
+- `mcp-security-scan.yml` (pure JS/TS scanner, ARM-safe; informational-only via `continue-on-error: true`)
 
 ## Workflows that stay GitHub-hosted
 

--- a/docs/runners.md
+++ b/docs/runners.md
@@ -66,7 +66,6 @@ These read `vars.RUNNER_GENERIC` and fail over automatically:
 - `structured-data-audit.yml`
 - `seo-hygiene.yml`
 - `mcp-security-scan.yml` (pure JS/TS scanner, ARM-safe; informational-only via `continue-on-error: true`)
-- `a11y-audit.yml` (Playwright + axe; runs against ARM64 Chromium on Pi)
 - `codeql.yml` (CodeQL CLI v4 supports linux-arm64 for JS/TS analysis)
 - `preview.yml` (SST/CDK — prior Pi attempt in run [`26321031309`] hung past timeout under cold-deploy; retrying with 40-min timeout)
 
@@ -89,6 +88,7 @@ time on ARM:
   surface, so user-visible features still ship through the secondary.
 - `lighthouse.yml` — needs system Chrome; ARM has no official Chromium binary in the runner image.
 - `k3s-e2e.yml` — Playwright + browser deps; runs against the live Pi standby so adding Pi-side load is also counterproductive.
+- `a11y-audit.yml` — tried failover on 2026-05-23 in run [`26341722748`](https://github.com/Themis128/cloudless.gr/actions/runs/26341722748/job/77544838049); ran for 11 minutes on the omv-build Pi runner and failed. Playwright + Chromium accessibility checks need x86_64 Chrome behaviour; the ARM64 Chromium build does not produce the same axe-core results consistently. Pinned back to ubuntu-latest.
 
 When billing is broken, these stay red until billing is fixed.
 

--- a/docs/runners.md
+++ b/docs/runners.md
@@ -66,6 +66,9 @@ These read `vars.RUNNER_GENERIC` and fail over automatically:
 - `structured-data-audit.yml`
 - `seo-hygiene.yml`
 - `mcp-security-scan.yml` (pure JS/TS scanner, ARM-safe; informational-only via `continue-on-error: true`)
+- `a11y-audit.yml` (Playwright + axe; runs against ARM64 Chromium on Pi)
+- `codeql.yml` (CodeQL CLI v4 supports linux-arm64 for JS/TS analysis)
+- `preview.yml` (SST/CDK — prior Pi attempt in run [`26321031309`] hung past timeout under cold-deploy; retrying with 40-min timeout)
 
 ## Workflows that stay GitHub-hosted
 
@@ -86,7 +89,6 @@ time on ARM:
   surface, so user-visible features still ship through the secondary.
 - `lighthouse.yml` — needs system Chrome; ARM has no official Chromium binary in the runner image.
 - `k3s-e2e.yml` — Playwright + browser deps; runs against the live Pi standby so adding Pi-side load is also counterproductive.
-- `codeql.yml` — heavy memory + x86_64 analyzer.
 
 When billing is broken, these stay red until billing is fixed.
 

--- a/src/app/api/agent/book/route.ts
+++ b/src/app/api/agent/book/route.ts
@@ -65,6 +65,12 @@ function jsonError(status: number, error: string) {
   return NextResponse.json({ error }, { status });
 }
 
+function normalizeNotes(value: unknown): string | undefined {
+  if (typeof value !== "string") return undefined;
+  const trimmed = value.trim().slice(0, MAX_NOTES_LENGTH);
+  return trimmed.length > 0 ? trimmed : undefined;
+}
+
 async function handlePropose(
   body: ProposeBody,
   ip: string,
@@ -136,10 +142,7 @@ async function handleConfirm(
     );
   }
 
-  const notes =
-    typeof body.notes === "string"
-      ? body.notes.trim().slice(0, MAX_NOTES_LENGTH) || undefined
-      : undefined;
+  const notes = normalizeNotes(body.notes);
 
   try {
     const result = await bookConsultation({

--- a/src/app/api/agent/book/route.ts
+++ b/src/app/api/agent/book/route.ts
@@ -1,0 +1,224 @@
+/**
+ * Phase 2b booking agent — auth-gated natural-language booking.
+ *
+ * Two-step flow (single endpoint, discriminated by body):
+ *   1. Propose: POST { intent: string }
+ *      → 200 { status: "proposed", proposed: {start, end, formatted}, reasoning }
+ *      → 200 { status: "no_match", reasoning }
+ *   2. Confirm: POST { confirm: true, start, end, notes? }
+ *      → 200 { status: "confirmed", eventId, meetingLink, slot }
+ *
+ * Auth: requires a valid Cognito ID token via Bearer header. The booking is
+ * always made on behalf of the authenticated email — the model cannot
+ * override it.
+ */
+import { NextRequest, NextResponse } from "next/server";
+import { requireAuth } from "@/lib/api-auth";
+import { rateLimit, getClientIp } from "@/lib/rate-limit";
+import { isAgentBookConfigured, proposeBookingSlot, formatAthensSlot } from "@/lib/agent-book";
+import { bookConsultation, getAvailableSlots } from "@/lib/google-calendar";
+import { slackBookingNotify } from "@/lib/slack-notify";
+import { sendBookingConfirmation } from "@/lib/email";
+import { mapIntegrationError } from "@/lib/api-errors";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+const PROPOSE_LIMIT_PER_WINDOW = 5;
+const PROPOSE_WINDOW_MS = 10 * 60_000;
+const CONFIRM_LIMIT_PER_WINDOW = 5;
+const CONFIRM_WINDOW_MS = 10 * 60_000;
+const MAX_INTENT_LENGTH = 500;
+const MAX_NOTES_LENGTH = 1_000;
+const SLOT_OVERLAP_TOLERANCE_MS = 60_000;
+
+interface ProposeBody {
+  intent: string;
+}
+interface ConfirmBody {
+  confirm: true;
+  start: string;
+  end: string;
+  notes?: string;
+}
+
+function isProposeBody(b: unknown): b is ProposeBody {
+  return (
+    typeof b === "object" &&
+    b !== null &&
+    typeof (b as { intent?: unknown }).intent === "string"
+  );
+}
+
+function isConfirmBody(b: unknown): b is ConfirmBody {
+  if (typeof b !== "object" || b === null) return false;
+  const o = b as { confirm?: unknown; start?: unknown; end?: unknown };
+  return (
+    o.confirm === true && typeof o.start === "string" && typeof o.end === "string"
+  );
+}
+
+function jsonError(status: number, error: string) {
+  return NextResponse.json({ error }, { status });
+}
+
+async function handlePropose(
+  body: ProposeBody,
+  ip: string,
+): Promise<NextResponse> {
+  const rl = rateLimit(
+    `agent-book-propose:${ip}`,
+    PROPOSE_LIMIT_PER_WINDOW,
+    PROPOSE_WINDOW_MS,
+  );
+  if (!rl.ok) return rl.response as NextResponse;
+
+  const intent = body.intent.trim().slice(0, MAX_INTENT_LENGTH);
+  if (!intent) return jsonError(400, "Intent is required.");
+
+  try {
+    const result = await proposeBookingSlot(intent);
+    return NextResponse.json(result);
+  } catch (err) {
+    const name = err instanceof Error ? err.name : "";
+    console.error("[agent-book] propose failed:", err);
+    if (name === "AccessDeniedException" || name === "UnauthorizedException") {
+      return jsonError(503, "Booking agent is not available right now.");
+    }
+    return jsonError(502, "Booking agent upstream error.");
+  }
+}
+
+async function handleConfirm(
+  body: ConfirmBody,
+  userEmail: string,
+  userName: string,
+  ip: string,
+): Promise<NextResponse> {
+  const rl = rateLimit(
+    `agent-book-confirm:${ip}`,
+    CONFIRM_LIMIT_PER_WINDOW,
+    CONFIRM_WINDOW_MS,
+  );
+  if (!rl.ok) return rl.response as NextResponse;
+
+  const startD = new Date(body.start);
+  const endD = new Date(body.end);
+  if (isNaN(startD.getTime()) || isNaN(endD.getTime())) {
+    return jsonError(400, "Invalid date format for start or end.");
+  }
+  if (startD < new Date()) {
+    return jsonError(400, "Cannot book a slot in the past.");
+  }
+  if (endD <= startD) {
+    return jsonError(400, "End time must be after start time.");
+  }
+
+  // Re-check availability — the propose step is advisory; another booking
+  // could have taken the slot in between. getAvailableSlots only returns
+  // currently-free slots, so a hit there is the source of truth.
+  const daysAhead = Math.max(
+    1,
+    Math.ceil((startD.getTime() - Date.now()) / 86_400_000) + 1,
+  );
+  const free = await getAvailableSlots(Math.min(daysAhead, 14));
+  const stillFree = free.some((s) => {
+    const sStart = new Date(s.start).getTime();
+    return Math.abs(sStart - startD.getTime()) <= SLOT_OVERLAP_TOLERANCE_MS;
+  });
+  if (!stillFree) {
+    return jsonError(
+      409,
+      "That slot is no longer available. Please propose a new time.",
+    );
+  }
+
+  const notes =
+    typeof body.notes === "string"
+      ? body.notes.trim().slice(0, MAX_NOTES_LENGTH) || undefined
+      : undefined;
+
+  try {
+    const result = await bookConsultation({
+      name: userName,
+      email: userEmail,
+      start: body.start,
+      end: body.end,
+      notes,
+    });
+    if (!result) return jsonError(500, "Failed to create booking.");
+
+    const slotLabel = formatAthensSlot(body.start, body.end);
+
+    void slackBookingNotify({
+      name: userName,
+      email: userEmail,
+      start: body.start,
+      notes,
+      meetLink: result.htmlLink,
+    }).catch((err) =>
+      console.warn("[agent-book] slackBookingNotify failed:", err),
+    );
+    void sendBookingConfirmation({
+      name: userName,
+      email: userEmail,
+      slotLabel,
+      meetLink: result.htmlLink,
+      notes,
+    }).catch((err) =>
+      console.warn("[agent-book] sendBookingConfirmation failed:", err),
+    );
+
+    return NextResponse.json({
+      status: "confirmed",
+      eventId: result.eventId,
+      meetingLink: result.htmlLink,
+      slot: { start: body.start, end: body.end, formatted: slotLabel },
+    });
+  } catch (err) {
+    const mapped = mapIntegrationError(err);
+    if (mapped) return mapped;
+    console.error("[agent-book] confirm failed:", err);
+    return jsonError(500, "Booking failed.");
+  }
+}
+
+export async function POST(request: NextRequest) {
+  const auth = await requireAuth(request);
+  if (!auth.ok) return auth.response;
+
+  const userEmail = auth.user.email?.toLowerCase();
+  if (!userEmail) {
+    return jsonError(
+      400,
+      "Authenticated token is missing an email claim — cannot book.",
+    );
+  }
+  const userName =
+    auth.user["cognito:username"] || userEmail.split("@")[0] || "Cloudless User";
+
+  if (!(await isAgentBookConfigured())) {
+    return jsonError(503, "Booking is not configured.");
+  }
+
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return jsonError(400, "Invalid JSON body.");
+  }
+
+  const ip = getClientIp(request);
+
+  if (isConfirmBody(body)) {
+    return handleConfirm(body, userEmail, userName, ip);
+  }
+  if (isProposeBody(body)) {
+    return handlePropose(body, ip);
+  }
+
+  return jsonError(
+    400,
+    "Body must be either { intent } to propose or { confirm: true, start, end } to confirm.",
+  );
+}

--- a/src/app/api/agent/book/route.ts
+++ b/src/app/api/agent/book/route.ts
@@ -55,7 +55,9 @@ function isConfirmBody(b: unknown): b is ConfirmBody {
   if (typeof b !== "object" || b === null) return false;
   const o = b as { confirm?: unknown; start?: unknown; end?: unknown };
   return (
-    o.confirm === true && typeof o.start === "string" && typeof o.end === "string"
+    o.confirm === true &&
+    typeof o.start === "string" &&
+    typeof o.end === "string"
   );
 }
 
@@ -196,7 +198,9 @@ export async function POST(request: NextRequest) {
     );
   }
   const userName =
-    auth.user["cognito:username"] || userEmail.split("@")[0] || "Cloudless User";
+    auth.user["cognito:username"] ||
+    userEmail.split("@")[0] ||
+    "Cloudless User";
 
   if (!(await isAgentBookConfigured())) {
     return jsonError(503, "Booking is not configured.");

--- a/src/app/api/agent/book/route.ts
+++ b/src/app/api/agent/book/route.ts
@@ -151,7 +151,7 @@ async function handleConfirm(
 
     const slotLabel = formatAthensSlot(body.start, body.end);
 
-    void slackBookingNotify({
+    slackBookingNotify({
       name: userName,
       email: userEmail,
       start: body.start,
@@ -160,7 +160,7 @@ async function handleConfirm(
     }).catch((err) =>
       console.warn("[agent-book] slackBookingNotify failed:", err),
     );
-    void sendBookingConfirmation({
+    sendBookingConfirmation({
       name: userName,
       email: userEmail,
       slotLabel,

--- a/src/app/api/agent/book/route.ts
+++ b/src/app/api/agent/book/route.ts
@@ -107,7 +107,7 @@ async function handleConfirm(
 
   const startD = new Date(body.start);
   const endD = new Date(body.end);
-  if (isNaN(startD.getTime()) || isNaN(endD.getTime())) {
+  if (Number.isNaN(startD.getTime()) || Number.isNaN(endD.getTime())) {
     return jsonError(400, "Invalid date format for start or end.");
   }
   if (startD < new Date()) {

--- a/src/app/api/agent/book/route.ts
+++ b/src/app/api/agent/book/route.ts
@@ -71,6 +71,13 @@ function normalizeNotes(value: unknown): string | undefined {
   return trimmed.length > 0 ? trimmed : undefined;
 }
 
+function resolveUserName(claim: string | undefined, email: string): string {
+  if (claim && claim.length > 0) return claim;
+  const localPart = email.split("@")[0];
+  if (localPart.length > 0) return localPart;
+  return "Cloudless User";
+}
+
 async function handlePropose(
   body: ProposeBody,
   ip: string,
@@ -200,10 +207,7 @@ export async function POST(request: NextRequest) {
       "Authenticated token is missing an email claim — cannot book.",
     );
   }
-  const userName =
-    auth.user["cognito:username"] ||
-    userEmail.split("@")[0] ||
-    "Cloudless User";
+  const userName = resolveUserName(auth.user["cognito:username"], userEmail);
 
   if (!(await isAgentBookConfigured())) {
     return jsonError(503, "Booking is not configured.");

--- a/src/app/api/agent/book/route.ts
+++ b/src/app/api/agent/book/route.ts
@@ -16,7 +16,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { requireAuth } from "@/lib/api-auth";
 import { rateLimit, getClientIp } from "@/lib/rate-limit";
 import { isAgentBookConfigured, proposeBookingSlot } from "@/lib/agent-book";
-import { formatAthensSlot } from "@/lib/booking-slots";
+import { MAX_DAYS_AHEAD, formatAthensSlot } from "@/lib/booking-slots";
 import { bookConsultation, getAvailableSlots } from "@/lib/google-calendar";
 import { slackBookingNotify } from "@/lib/slack-notify";
 import { sendBookingConfirmation } from "@/lib/email";
@@ -137,7 +137,7 @@ async function handleConfirm(
     1,
     Math.ceil((startD.getTime() - Date.now()) / 86_400_000) + 1,
   );
-  const free = await getAvailableSlots(Math.min(daysAhead, 14));
+  const free = await getAvailableSlots(Math.min(daysAhead, MAX_DAYS_AHEAD));
   const stillFree = free.some((s) => {
     const sStart = new Date(s.start).getTime();
     return Math.abs(sStart - startD.getTime()) <= SLOT_OVERLAP_TOLERANCE_MS;

--- a/src/app/api/agent/book/route.ts
+++ b/src/app/api/agent/book/route.ts
@@ -15,7 +15,8 @@
 import { NextRequest, NextResponse } from "next/server";
 import { requireAuth } from "@/lib/api-auth";
 import { rateLimit, getClientIp } from "@/lib/rate-limit";
-import { isAgentBookConfigured, proposeBookingSlot, formatAthensSlot } from "@/lib/agent-book";
+import { isAgentBookConfigured, proposeBookingSlot } from "@/lib/agent-book";
+import { formatAthensSlot } from "@/lib/booking-slots";
 import { bookConsultation, getAvailableSlots } from "@/lib/google-calendar";
 import { slackBookingNotify } from "@/lib/slack-notify";
 import { sendBookingConfirmation } from "@/lib/email";

--- a/src/lib/agent-book.ts
+++ b/src/lib/agent-book.ts
@@ -232,8 +232,7 @@ export async function proposeBookingSlot(
       // Model returned plain text without proposing — treat as no_match.
       const textOut = assistantContent
         .filter(
-          (b): b is TextBlock =>
-            "text" in b && typeof b.text === "string",
+          (b): b is TextBlock => "text" in b && typeof b.text === "string",
         )
         .map((b) => b.text)
         .join(" ")

--- a/src/lib/agent-book.ts
+++ b/src/lib/agent-book.ts
@@ -126,6 +126,45 @@ async function runCheckAvailability(raw: unknown): Promise<string> {
   }
 }
 
+function asStringField(value: unknown): string {
+  return typeof value === "string" ? value : "";
+}
+
+/**
+ * Convert the model's terminal `propose_slot` tool call into a ProposeResult.
+ * Centralised so the main loop stays at a low cognitive-complexity score.
+ */
+function resolveProposeBlock(block: ToolUseBlock): ProposeResult {
+  const input = block.toolUse.input ?? {};
+  const start = asStringField(input.start);
+  const end = asStringField(input.end);
+  const reasoning = asStringField(input.reasoning);
+  if (!start || !end) {
+    return {
+      status: STATUS_NO_MATCH,
+      reasoning: reasoning || "No matching slot.",
+    };
+  }
+  return {
+    status: STATUS_PROPOSED,
+    proposed: { start, end, formatted: formatAthensSlot(start, end) },
+    reasoning,
+  };
+}
+
+async function runPendingTool(block: ToolUseBlock): Promise<ToolResultBlock> {
+  const result =
+    block.toolUse.name === "check_calendar_availability"
+      ? await runCheckAvailability(block.toolUse.input)
+      : `Unknown tool: ${block.toolUse.name}`;
+  return {
+    toolResult: {
+      toolUseId: block.toolUse.toolUseId,
+      content: [{ text: result }] as [{ text: string }],
+    },
+  };
+}
+
 // ---------------------------------------------------------------------------
 // Public API
 // ---------------------------------------------------------------------------
@@ -165,7 +204,7 @@ export async function proposeBookingSlot(
     { role: "user", content: [{ text: intent }] },
   ];
 
-  for (let i = 0; i < MAX_TOOL_ITERATIONS; i++) {
+  for (let attempt = 0; attempt < MAX_TOOL_ITERATIONS; attempt++) {
     const cmd = new ConverseCommand({
       modelId: BEDROCK_MODEL_ID,
       system: [{ text: SYSTEM_PROMPT }],
@@ -188,24 +227,7 @@ export async function proposeBookingSlot(
     const proposeBlock = toolUseBlocks.find(
       (b) => b.toolUse.name === "propose_slot",
     );
-    if (proposeBlock) {
-      const input = proposeBlock.toolUse.input ?? {};
-      const start = typeof input.start === "string" ? input.start : "";
-      const end = typeof input.end === "string" ? input.end : "";
-      const reasoning =
-        typeof input.reasoning === "string" ? input.reasoning : "";
-      if (!start || !end) {
-        return {
-          status: STATUS_NO_MATCH,
-          reasoning: reasoning || "No matching slot.",
-        };
-      }
-      return {
-        status: STATUS_PROPOSED,
-        proposed: { start, end, formatted: formatAthensSlot(start, end) },
-        reasoning,
-      };
-    }
+    if (proposeBlock) return resolveProposeBlock(proposeBlock);
 
     if (toolUseBlocks.length === 0) {
       // Model returned plain text without proposing — treat as no_match.
@@ -222,24 +244,7 @@ export async function proposeBookingSlot(
 
     // Append assistant turn + run pending availability tool calls.
     messages.push({ role: "assistant", content: assistantContent });
-
-    const toolResults: ToolResultBlock[] = await Promise.all(
-      toolUseBlocks.map(async (b) => {
-        let result: string;
-        if (b.toolUse.name === "check_calendar_availability") {
-          result = await runCheckAvailability(b.toolUse.input);
-        } else {
-          result = `Unknown tool: ${b.toolUse.name}`;
-        }
-        return {
-          toolResult: {
-            toolUseId: b.toolUse.toolUseId,
-            content: [{ text: result }] as [{ text: string }],
-          },
-        };
-      }),
-    );
-
+    const toolResults = await Promise.all(toolUseBlocks.map(runPendingTool));
     messages.push({ role: "user", content: toolResults });
   }
 

--- a/src/lib/agent-book.ts
+++ b/src/lib/agent-book.ts
@@ -1,0 +1,309 @@
+/**
+ * Booking agent — Phase 2b of docs/AGENTS_ROADMAP.md.
+ *
+ * Takes a natural-language scheduling intent ("next Tuesday afternoon, 30 min")
+ * and returns a single proposed slot. The agent never books on its own — the
+ * caller must POST back to /api/agent/book with {confirm: true, start, end}
+ * to actually create the calendar event.
+ *
+ * Differences from the unauth'd chat book_slot tool:
+ *   - email is forced to the authenticated Cognito user (no impersonation)
+ *   - two-phase (propose → confirm) so the model can't fire the booking solo
+ *   - tighter system prompt scoped to scheduling only
+ */
+import {
+  BedrockRuntimeClient,
+  ConverseCommand,
+  type ToolConfiguration,
+} from "@aws-sdk/client-bedrock-runtime";
+import { getAvailableSlots } from "@/lib/google-calendar";
+import { isConfiguredAsync } from "@/lib/integrations";
+
+const BEDROCK_REGION = process.env.AWS_REGION ?? "us-east-1";
+const BEDROCK_MODEL_ID =
+  process.env.BEDROCK_MODEL_ID ?? "us.anthropic.claude-3-5-haiku-20241022-v1:0";
+
+const MAX_TOKENS = 400;
+const MAX_TOOL_ITERATIONS = 4;
+const MAX_SLOT_RESULTS = 8;
+const MIN_DAYS_AHEAD = 1;
+const MAX_DAYS_AHEAD = 14;
+const DEFAULT_DAYS_AHEAD = 7;
+
+const SYSTEM_PROMPT = `You are the Cloudless scheduling agent. Your single job is to read the visitor's natural-language scheduling intent and pick ONE specific 30-minute consultation slot that best matches it.
+
+Workflow:
+1. Call check_calendar_availability with a reasonable days_ahead (default 7, max 14) to fetch open slots.
+2. From the returned slots, pick the SINGLE slot that best matches the intent (preferred day of week, time of day, urgency).
+3. Call propose_slot exactly once with that slot's start and end times, copied verbatim from check_calendar_availability output.
+
+Rules:
+- Never invent slot times. Only use values returned by check_calendar_availability.
+- If no slots match the intent, call propose_slot with start="" and end="" and reasoning explaining why.
+- Athens local time. Business hours are 09:00–17:00 weekdays.
+- Be concise in reasoning — one or two sentences.`;
+
+// ---------------------------------------------------------------------------
+// Tool definitions
+// ---------------------------------------------------------------------------
+
+const AGENT_TOOLS = [
+  {
+    name: "check_calendar_availability",
+    description:
+      "Look up open 30-minute consultation slots in the next N days. Returns up to 8 slots in ISO 8601 with Athens local labels.",
+    input_schema: {
+      type: "object",
+      properties: {
+        days_ahead: {
+          type: "integer",
+          description: "Days ahead to search. Default 7. Max 14.",
+          minimum: MIN_DAYS_AHEAD,
+          maximum: MAX_DAYS_AHEAD,
+        },
+      },
+      required: [],
+    },
+  },
+  {
+    name: "propose_slot",
+    description:
+      "Final answer. Propose exactly one slot back to the caller. Use start/end verbatim from check_calendar_availability. If no slot fits, pass empty strings and explain in reasoning.",
+    input_schema: {
+      type: "object",
+      properties: {
+        start: {
+          type: "string",
+          description: "Slot start ISO 8601, or empty string if no match.",
+        },
+        end: {
+          type: "string",
+          description: "Slot end ISO 8601, or empty string if no match.",
+        },
+        reasoning: {
+          type: "string",
+          description:
+            "Brief explanation of why this slot was chosen, or why no slot fits.",
+        },
+      },
+      required: ["start", "end", "reasoning"],
+    },
+  },
+] as const;
+
+// ---------------------------------------------------------------------------
+// Bedrock plumbing (mirrors src/lib/bedrock-chat.ts structure)
+// ---------------------------------------------------------------------------
+
+const AGENT_TOOL_CONFIG: ToolConfiguration = {
+  tools: AGENT_TOOLS.map((t) => ({
+    toolSpec: {
+      name: t.name,
+      description: t.description,
+      inputSchema: {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        json: t.input_schema as unknown as Record<string, any>,
+      },
+    },
+  })) as ToolConfiguration["tools"],
+};
+
+let _client: BedrockRuntimeClient | null = null;
+function getClient(): BedrockRuntimeClient {
+  if (!_client) _client = new BedrockRuntimeClient({ region: BEDROCK_REGION });
+  return _client;
+}
+
+type TextBlock = { text: string };
+type ToolUseBlock = {
+  toolUse: {
+    toolUseId: string;
+    name: string;
+    input: Record<string, unknown>;
+  };
+};
+type ToolResultBlock = {
+  toolResult: {
+    toolUseId: string;
+    content: [{ text: string }];
+  };
+};
+type AnyBlock = TextBlock | ToolUseBlock | ToolResultBlock;
+
+interface BedrockMessage {
+  role: "user" | "assistant";
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  content: any[];
+}
+
+// ---------------------------------------------------------------------------
+// Slot fetching for the model
+// ---------------------------------------------------------------------------
+
+function clampDaysAhead(raw: unknown): number {
+  const n =
+    typeof raw === "number" && Number.isFinite(raw) ? raw : DEFAULT_DAYS_AHEAD;
+  return Math.max(MIN_DAYS_AHEAD, Math.min(MAX_DAYS_AHEAD, Math.trunc(n)));
+}
+
+const ATHENS_FORMAT: Intl.DateTimeFormatOptions = {
+  timeZone: "Europe/Athens",
+  weekday: "short",
+  month: "short",
+  day: "numeric",
+  hour: "2-digit",
+  minute: "2-digit",
+  hour12: false,
+};
+
+function formatSlot(start: string, end: string): string {
+  const startStr = new Date(start).toLocaleString("en-IE", ATHENS_FORMAT);
+  const endStr = new Date(end).toLocaleTimeString("en-IE", {
+    timeZone: "Europe/Athens",
+    hour: "2-digit",
+    minute: "2-digit",
+    hour12: false,
+  });
+  return `${startStr}–${endStr} Athens`;
+}
+
+async function runCheckAvailability(raw: unknown): Promise<string> {
+  const input = (typeof raw === "object" && raw !== null ? raw : {}) as {
+    days_ahead?: unknown;
+  };
+  const days = clampDaysAhead(input.days_ahead);
+  try {
+    const slots = (await getAvailableSlots(days)).slice(0, MAX_SLOT_RESULTS);
+    if (slots.length === 0) {
+      return `No open slots in the next ${days} day(s).`;
+    }
+    const lines = slots.map(
+      (s) => `- ${formatSlot(s.start, s.end)} [start=${s.start} end=${s.end}]`,
+    );
+    return `Open slots (next ${days} day(s)):\n${lines.join("\n")}`;
+  } catch (err) {
+    console.error("[agent-book] getAvailableSlots failed:", err);
+    return "Calendar lookup failed.";
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+export interface ProposedSlot {
+  start: string;
+  end: string;
+  formatted: string;
+}
+
+export type ProposeResult =
+  | { status: "proposed"; proposed: ProposedSlot; reasoning: string }
+  | { status: "no_match"; reasoning: string };
+
+/**
+ * Returns true when the slot lib + Bedrock are wired up.
+ * Calendar credentials are checked first to fail fast in unconfigured envs.
+ */
+export async function isAgentBookConfigured(): Promise<boolean> {
+  return isConfiguredAsync("GOOGLE_CLIENT_EMAIL", "GOOGLE_PRIVATE_KEY");
+}
+
+/**
+ * Run the booking agent against a natural-language intent.
+ * Returns the proposed slot (or no_match) — never books on its own.
+ * May throw on Bedrock API errors; caller maps to HTTP status.
+ */
+export async function proposeBookingSlot(
+  intent: string,
+): Promise<ProposeResult> {
+  const client = getClient();
+  const messages: BedrockMessage[] = [
+    { role: "user", content: [{ text: intent }] },
+  ];
+
+  for (let i = 0; i < MAX_TOOL_ITERATIONS; i++) {
+    const cmd = new ConverseCommand({
+      modelId: BEDROCK_MODEL_ID,
+      system: [{ text: SYSTEM_PROMPT }],
+      messages,
+      toolConfig: AGENT_TOOL_CONFIG,
+      inferenceConfig: { maxTokens: MAX_TOKENS },
+    });
+
+    const response = await client.send(cmd);
+    const assistantContent: AnyBlock[] =
+      (response.output?.message?.content as AnyBlock[]) ?? [];
+
+    const toolUseBlocks = assistantContent.filter(
+      (b): b is ToolUseBlock =>
+        "toolUse" in b &&
+        typeof (b as ToolUseBlock).toolUse?.toolUseId === "string",
+    );
+
+    // Terminal tool — propose_slot. Bind the result and return.
+    const proposeBlock = toolUseBlocks.find(
+      (b) => b.toolUse.name === "propose_slot",
+    );
+    if (proposeBlock) {
+      const input = proposeBlock.toolUse.input ?? {};
+      const start = typeof input.start === "string" ? input.start : "";
+      const end = typeof input.end === "string" ? input.end : "";
+      const reasoning =
+        typeof input.reasoning === "string" ? input.reasoning : "";
+      if (!start || !end) {
+        return { status: "no_match", reasoning: reasoning || "No matching slot." };
+      }
+      return {
+        status: "proposed",
+        proposed: { start, end, formatted: formatSlot(start, end) },
+        reasoning,
+      };
+    }
+
+    if (toolUseBlocks.length === 0) {
+      // Model returned plain text without proposing — treat as no_match.
+      const textOut = (assistantContent as TextBlock[])
+        .filter((b) => typeof b.text === "string")
+        .map((b) => b.text)
+        .join(" ")
+        .trim();
+      return {
+        status: "no_match",
+        reasoning: textOut || "Model did not propose a slot.",
+      };
+    }
+
+    // Append assistant turn + run pending availability tool calls.
+    messages.push({ role: "assistant", content: assistantContent });
+
+    const toolResults: ToolResultBlock[] = await Promise.all(
+      toolUseBlocks.map(async (b) => {
+        let result: string;
+        if (b.toolUse.name === "check_calendar_availability") {
+          result = await runCheckAvailability(b.toolUse.input);
+        } else {
+          result = `Unknown tool: ${b.toolUse.name}`;
+        }
+        return {
+          toolResult: {
+            toolUseId: b.toolUse.toolUseId,
+            content: [{ text: result }] as [{ text: string }],
+          },
+        };
+      }),
+    );
+
+    messages.push({ role: "user", content: toolResults });
+  }
+
+  return {
+    status: "no_match",
+    reasoning: "Agent exceeded its iteration budget without proposing a slot.",
+  };
+}
+
+/** Public helper to render a slot label the same way the agent does. */
+export function formatAthensSlot(start: string, end: string): string {
+  return formatSlot(start, end);
+}

--- a/src/lib/agent-book.ts
+++ b/src/lib/agent-book.ts
@@ -142,7 +142,7 @@ function resolveProposeBlock(block: ToolUseBlock): ProposeResult {
   if (!start || !end) {
     return {
       status: STATUS_NO_MATCH,
-      reasoning: reasoning || "No matching slot.",
+      reasoning: reasoning.length > 0 ? reasoning : "No matching slot.",
     };
   }
   return {
@@ -238,7 +238,8 @@ export async function proposeBookingSlot(
         .trim();
       return {
         status: STATUS_NO_MATCH,
-        reasoning: textOut || "Model did not propose a slot.",
+        reasoning:
+          textOut.length > 0 ? textOut : "Model did not propose a slot.",
       };
     }
 

--- a/src/lib/agent-book.ts
+++ b/src/lib/agent-book.ts
@@ -11,24 +11,29 @@
  *   - two-phase (propose → confirm) so the model can't fire the booking solo
  *   - tighter system prompt scoped to scheduling only
  */
-import {
-  BedrockRuntimeClient,
-  ConverseCommand,
-  type ToolConfiguration,
-} from "@aws-sdk/client-bedrock-runtime";
+import { ConverseCommand } from "@aws-sdk/client-bedrock-runtime";
 import { getAvailableSlots } from "@/lib/google-calendar";
 import { isConfiguredAsync } from "@/lib/integrations";
-
-const BEDROCK_REGION = process.env.AWS_REGION ?? "us-east-1";
-const BEDROCK_MODEL_ID =
-  process.env.BEDROCK_MODEL_ID ?? "us.anthropic.claude-3-5-haiku-20241022-v1:0";
+import {
+  BEDROCK_MODEL_ID,
+  buildBedrockToolConfig,
+  getBedrockClient,
+  type AnyBlock,
+  type BedrockMessage,
+  type TextBlock,
+  type ToolResultBlock,
+  type ToolUseBlock,
+} from "@/lib/bedrock-shared";
+import {
+  MIN_DAYS_AHEAD,
+  MAX_DAYS_AHEAD,
+  clampDaysAhead,
+  formatAthensSlot,
+} from "@/lib/booking-slots";
 
 const MAX_TOKENS = 400;
 const MAX_TOOL_ITERATIONS = 4;
 const MAX_SLOT_RESULTS = 8;
-const MIN_DAYS_AHEAD = 1;
-const MAX_DAYS_AHEAD = 14;
-const DEFAULT_DAYS_AHEAD = 7;
 
 const SYSTEM_PROMPT = `You are the Cloudless scheduling agent. Your single job is to read the visitor's natural-language scheduling intent and pick ONE specific 30-minute consultation slot that best matches it.
 
@@ -91,81 +96,11 @@ const AGENT_TOOLS = [
   },
 ] as const;
 
-// ---------------------------------------------------------------------------
-// Bedrock plumbing (mirrors src/lib/bedrock-chat.ts structure)
-// ---------------------------------------------------------------------------
-
-const AGENT_TOOL_CONFIG: ToolConfiguration = {
-  tools: AGENT_TOOLS.map((t) => ({
-    toolSpec: {
-      name: t.name,
-      description: t.description,
-      inputSchema: {
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        json: t.input_schema as unknown as Record<string, any>,
-      },
-    },
-  })) as ToolConfiguration["tools"],
-};
-
-let _client: BedrockRuntimeClient | null = null;
-function getClient(): BedrockRuntimeClient {
-  if (!_client) _client = new BedrockRuntimeClient({ region: BEDROCK_REGION });
-  return _client;
-}
-
-type TextBlock = { text: string };
-type ToolUseBlock = {
-  toolUse: {
-    toolUseId: string;
-    name: string;
-    input: Record<string, unknown>;
-  };
-};
-type ToolResultBlock = {
-  toolResult: {
-    toolUseId: string;
-    content: [{ text: string }];
-  };
-};
-type AnyBlock = TextBlock | ToolUseBlock | ToolResultBlock;
-
-interface BedrockMessage {
-  role: "user" | "assistant";
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  content: any[];
-}
+const AGENT_TOOL_CONFIG = buildBedrockToolConfig(AGENT_TOOLS);
 
 // ---------------------------------------------------------------------------
 // Slot fetching for the model
 // ---------------------------------------------------------------------------
-
-function clampDaysAhead(raw: unknown): number {
-  const n =
-    typeof raw === "number" && Number.isFinite(raw) ? raw : DEFAULT_DAYS_AHEAD;
-  return Math.max(MIN_DAYS_AHEAD, Math.min(MAX_DAYS_AHEAD, Math.trunc(n)));
-}
-
-const ATHENS_FORMAT: Intl.DateTimeFormatOptions = {
-  timeZone: "Europe/Athens",
-  weekday: "short",
-  month: "short",
-  day: "numeric",
-  hour: "2-digit",
-  minute: "2-digit",
-  hour12: false,
-};
-
-function formatSlot(start: string, end: string): string {
-  const startStr = new Date(start).toLocaleString("en-IE", ATHENS_FORMAT);
-  const endStr = new Date(end).toLocaleTimeString("en-IE", {
-    timeZone: "Europe/Athens",
-    hour: "2-digit",
-    minute: "2-digit",
-    hour12: false,
-  });
-  return `${startStr}–${endStr} Athens`;
-}
 
 async function runCheckAvailability(raw: unknown): Promise<string> {
   const input = (typeof raw === "object" && raw !== null ? raw : {}) as {
@@ -178,7 +113,7 @@ async function runCheckAvailability(raw: unknown): Promise<string> {
       return `No open slots in the next ${days} day(s).`;
     }
     const lines = slots.map(
-      (s) => `- ${formatSlot(s.start, s.end)} [start=${s.start} end=${s.end}]`,
+      (s) => `- ${formatAthensSlot(s.start, s.end)} [start=${s.start} end=${s.end}]`,
     );
     return `Open slots (next ${days} day(s)):\n${lines.join("\n")}`;
   } catch (err) {
@@ -217,7 +152,7 @@ export async function isAgentBookConfigured(): Promise<boolean> {
 export async function proposeBookingSlot(
   intent: string,
 ): Promise<ProposeResult> {
-  const client = getClient();
+  const client = getBedrockClient();
   const messages: BedrockMessage[] = [
     { role: "user", content: [{ text: intent }] },
   ];
@@ -256,7 +191,7 @@ export async function proposeBookingSlot(
       }
       return {
         status: "proposed",
-        proposed: { start, end, formatted: formatSlot(start, end) },
+        proposed: { start, end, formatted: formatAthensSlot(start, end) },
         reasoning,
       };
     }
@@ -301,9 +236,4 @@ export async function proposeBookingSlot(
     status: "no_match",
     reasoning: "Agent exceeded its iteration budget without proposing a slot.",
   };
-}
-
-/** Public helper to render a slot label the same way the agent does. */
-export function formatAthensSlot(start: string, end: string): string {
-  return formatSlot(start, end);
 }

--- a/src/lib/agent-book.ts
+++ b/src/lib/agent-book.ts
@@ -233,7 +233,7 @@ export async function proposeBookingSlot(
       const textOut = assistantContent
         .filter(
           (b): b is TextBlock =>
-            "text" in b && typeof (b as TextBlock).text === "string",
+            "text" in b && typeof b.text === "string",
         )
         .map((b) => b.text)
         .join(" ")

--- a/src/lib/agent-book.ts
+++ b/src/lib/agent-book.ts
@@ -230,8 +230,11 @@ export async function proposeBookingSlot(
 
     if (toolUseBlocks.length === 0) {
       // Model returned plain text without proposing — treat as no_match.
-      const textOut = (assistantContent as TextBlock[])
-        .filter((b) => typeof b.text === "string")
+      const textOut = assistantContent
+        .filter(
+          (b): b is TextBlock =>
+            "text" in b && typeof (b as TextBlock).text === "string",
+        )
         .map((b) => b.text)
         .join(" ")
         .trim();

--- a/src/lib/agent-book.ts
+++ b/src/lib/agent-book.ts
@@ -116,7 +116,8 @@ async function runCheckAvailability(raw: unknown): Promise<string> {
       return `No open slots in the next ${days} day(s).`;
     }
     const lines = slots.map(
-      (s) => `- ${formatAthensSlot(s.start, s.end)} [start=${s.start} end=${s.end}]`,
+      (s) =>
+        `- ${formatAthensSlot(s.start, s.end)} [start=${s.start} end=${s.end}]`,
     );
     return `Open slots (next ${days} day(s)):\n${lines.join("\n")}`;
   } catch (err) {
@@ -136,7 +137,11 @@ export interface ProposedSlot {
 }
 
 export type ProposeResult =
-  | { status: typeof STATUS_PROPOSED; proposed: ProposedSlot; reasoning: string }
+  | {
+      status: typeof STATUS_PROPOSED;
+      proposed: ProposedSlot;
+      reasoning: string;
+    }
   | { status: typeof STATUS_NO_MATCH; reasoning: string };
 
 /**
@@ -190,7 +195,10 @@ export async function proposeBookingSlot(
       const reasoning =
         typeof input.reasoning === "string" ? input.reasoning : "";
       if (!start || !end) {
-        return { status: STATUS_NO_MATCH, reasoning: reasoning || "No matching slot." };
+        return {
+          status: STATUS_NO_MATCH,
+          reasoning: reasoning || "No matching slot.",
+        };
       }
       return {
         status: STATUS_PROPOSED,

--- a/src/lib/agent-book.ts
+++ b/src/lib/agent-book.ts
@@ -219,8 +219,7 @@ export async function proposeBookingSlot(
 
     const toolUseBlocks = assistantContent.filter(
       (b): b is ToolUseBlock =>
-        "toolUse" in b &&
-        typeof (b as ToolUseBlock).toolUse?.toolUseId === "string",
+        "toolUse" in b && typeof b.toolUse?.toolUseId === "string",
     );
 
     // Terminal tool — propose_slot. Bind the result and return.

--- a/src/lib/agent-book.ts
+++ b/src/lib/agent-book.ts
@@ -35,6 +35,9 @@ const MAX_TOKENS = 400;
 const MAX_TOOL_ITERATIONS = 4;
 const MAX_SLOT_RESULTS = 8;
 
+const STATUS_PROPOSED = "proposed" as const;
+const STATUS_NO_MATCH = "no_match" as const;
+
 const SYSTEM_PROMPT = `You are the Cloudless scheduling agent. Your single job is to read the visitor's natural-language scheduling intent and pick ONE specific 30-minute consultation slot that best matches it.
 
 Workflow:
@@ -133,8 +136,8 @@ export interface ProposedSlot {
 }
 
 export type ProposeResult =
-  | { status: "proposed"; proposed: ProposedSlot; reasoning: string }
-  | { status: "no_match"; reasoning: string };
+  | { status: typeof STATUS_PROPOSED; proposed: ProposedSlot; reasoning: string }
+  | { status: typeof STATUS_NO_MATCH; reasoning: string };
 
 /**
  * Returns true when the slot lib + Bedrock are wired up.
@@ -187,10 +190,10 @@ export async function proposeBookingSlot(
       const reasoning =
         typeof input.reasoning === "string" ? input.reasoning : "";
       if (!start || !end) {
-        return { status: "no_match", reasoning: reasoning || "No matching slot." };
+        return { status: STATUS_NO_MATCH, reasoning: reasoning || "No matching slot." };
       }
       return {
-        status: "proposed",
+        status: STATUS_PROPOSED,
         proposed: { start, end, formatted: formatAthensSlot(start, end) },
         reasoning,
       };
@@ -204,7 +207,7 @@ export async function proposeBookingSlot(
         .join(" ")
         .trim();
       return {
-        status: "no_match",
+        status: STATUS_NO_MATCH,
         reasoning: textOut || "Model did not propose a slot.",
       };
     }
@@ -233,7 +236,7 @@ export async function proposeBookingSlot(
   }
 
   return {
-    status: "no_match",
+    status: STATUS_NO_MATCH,
     reasoning: "Agent exceeded its iteration budget without proposing a slot.",
   };
 }

--- a/src/lib/bedrock-chat.ts
+++ b/src/lib/bedrock-chat.ts
@@ -10,79 +10,23 @@
  * Region: us-east-1 (Lambda deployment region; falls back to AWS_REGION env var)
  */
 
-import {
-  BedrockRuntimeClient,
-  ConverseCommand,
-  type ToolConfiguration,
-} from "@aws-sdk/client-bedrock-runtime";
+import { ConverseCommand } from "@aws-sdk/client-bedrock-runtime";
 import { CHAT_TOOLS, runTool } from "@/lib/chat-tools";
-
-// ---------------------------------------------------------------------------
-// Config
-// ---------------------------------------------------------------------------
-
-const BEDROCK_REGION = process.env.AWS_REGION ?? "us-east-1";
-const BEDROCK_MODEL_ID =
-  process.env.BEDROCK_MODEL_ID ?? "us.anthropic.claude-3-5-haiku-20241022-v1:0";
+import {
+  BEDROCK_MODEL_ID,
+  buildBedrockToolConfig,
+  getBedrockClient,
+  type AnyBlock,
+  type BedrockMessage,
+  type TextBlock,
+  type ToolResultBlock,
+  type ToolUseBlock,
+} from "@/lib/bedrock-shared";
 
 const MAX_TOKENS = 600;
 const MAX_TOOL_ITERATIONS = 4;
 
-// Lazy singleton — created once per Lambda cold start.
-let _client: BedrockRuntimeClient | null = null;
-
-function getClient(): BedrockRuntimeClient {
-  if (!_client) _client = new BedrockRuntimeClient({ region: BEDROCK_REGION });
-  return _client;
-}
-
-// ---------------------------------------------------------------------------
-// Tool config — convert Anthropic input_schema format → Bedrock toolSpec
-// ---------------------------------------------------------------------------
-// The Bedrock SDK represents Tool/ToolInputSchema as smithy-generated
-// discriminated unions that require an explicit `$unknown` member for
-// forward-compatibility. We satisfy the type by annotating as ToolConfiguration
-// and casting the input_schema to the expected document type.
-
-const BEDROCK_TOOL_CONFIG: ToolConfiguration = {
-  tools: CHAT_TOOLS.map((t) => ({
-    toolSpec: {
-      name: t.name,
-      description: t.description,
-      inputSchema: {
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        json: t.input_schema as unknown as Record<string, any>,
-      },
-    },
-  })) as ToolConfiguration["tools"],
-};
-
-// ---------------------------------------------------------------------------
-// Narrow content-block types (only what we read / write)
-// ---------------------------------------------------------------------------
-
-type TextBlock = { text: string };
-type ToolUseBlock = {
-  toolUse: {
-    toolUseId: string;
-    name: string;
-    input: Record<string, unknown>;
-  };
-};
-type ToolResultBlock = {
-  toolResult: {
-    toolUseId: string;
-    content: [{ text: string }];
-  };
-};
-
-type AnyBlock = TextBlock | ToolUseBlock | ToolResultBlock;
-
-interface BedrockMessage {
-  role: "user" | "assistant";
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  content: any[];
-}
+const BEDROCK_TOOL_CONFIG = buildBedrockToolConfig(CHAT_TOOLS);
 
 // ---------------------------------------------------------------------------
 // Core loop
@@ -98,7 +42,7 @@ export async function runBedrockChatLoop(
   systemPrompt: string,
   initialMessages: { role: "user" | "assistant"; content: string }[],
 ): Promise<string> {
-  const client = getClient();
+  const client = getBedrockClient();
 
   // Convert plain-string messages to Bedrock content arrays.
   const messages: BedrockMessage[] = initialMessages.map((m) => ({

--- a/src/lib/bedrock-shared.ts
+++ b/src/lib/bedrock-shared.ts
@@ -1,0 +1,91 @@
+/**
+ * Shared Bedrock Converse plumbing used by every agent loop in this repo.
+ *
+ * Consumers:
+ *   - src/lib/bedrock-chat.ts (the public chat widget)
+ *   - src/lib/agent-book.ts   (the authenticated booking agent)
+ *
+ * Centralizes the block-type definitions, lazy client singleton, and the
+ * Anthropic-shaped → Bedrock toolSpec conversion so both loops stay in sync
+ * (and SonarCloud's duplication detector stays happy).
+ */
+import {
+  BedrockRuntimeClient,
+  type ToolConfiguration,
+} from "@aws-sdk/client-bedrock-runtime";
+
+const DEFAULT_REGION = "us-east-1";
+const DEFAULT_MODEL_ID = "us.anthropic.claude-3-5-haiku-20241022-v1:0";
+
+export const BEDROCK_REGION = process.env.AWS_REGION ?? DEFAULT_REGION;
+export const BEDROCK_MODEL_ID =
+  process.env.BEDROCK_MODEL_ID ?? DEFAULT_MODEL_ID;
+
+// ---------------------------------------------------------------------------
+// Content block types — narrow shape of what we actually read / write.
+// ---------------------------------------------------------------------------
+
+export type TextBlock = { text: string };
+
+export type ToolUseBlock = {
+  toolUse: {
+    toolUseId: string;
+    name: string;
+    input: Record<string, unknown>;
+  };
+};
+
+export type ToolResultBlock = {
+  toolResult: {
+    toolUseId: string;
+    content: [{ text: string }];
+  };
+};
+
+export type AnyBlock = TextBlock | ToolUseBlock | ToolResultBlock;
+
+export interface BedrockMessage {
+  role: "user" | "assistant";
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  content: any[];
+}
+
+// ---------------------------------------------------------------------------
+// Lazy singleton — created once per Lambda cold start.
+// ---------------------------------------------------------------------------
+
+let _client: BedrockRuntimeClient | null = null;
+
+export function getBedrockClient(): BedrockRuntimeClient {
+  if (!_client) _client = new BedrockRuntimeClient({ region: BEDROCK_REGION });
+  return _client;
+}
+
+// ---------------------------------------------------------------------------
+// Tool-config builder — convert our Anthropic-shaped tool list to a Bedrock
+// ToolConfiguration. The SDK uses smithy-generated discriminated unions, so
+// we annotate the result and cast the input_schema document.
+// ---------------------------------------------------------------------------
+
+interface AnthropicShapedTool {
+  readonly name: string;
+  readonly description: string;
+  readonly input_schema: unknown;
+}
+
+export function buildBedrockToolConfig(
+  tools: ReadonlyArray<AnthropicShapedTool>,
+): ToolConfiguration {
+  return {
+    tools: tools.map((t) => ({
+      toolSpec: {
+        name: t.name,
+        description: t.description,
+        inputSchema: {
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          json: t.input_schema as unknown as Record<string, any>,
+        },
+      },
+    })) as ToolConfiguration["tools"],
+  };
+}

--- a/src/lib/bedrock-shared.ts
+++ b/src/lib/bedrock-shared.ts
@@ -57,7 +57,7 @@ export interface BedrockMessage {
 let _client: BedrockRuntimeClient | null = null;
 
 export function getBedrockClient(): BedrockRuntimeClient {
-  if (!_client) _client = new BedrockRuntimeClient({ region: BEDROCK_REGION });
+  _client ??= new BedrockRuntimeClient({ region: BEDROCK_REGION });
   return _client;
 }
 

--- a/src/lib/booking-slots.ts
+++ b/src/lib/booking-slots.ts
@@ -11,21 +11,22 @@ export const MAX_DAYS_AHEAD = 14;
 export const DEFAULT_DAYS_AHEAD = 7;
 
 const ATHENS_TZ = "Europe/Athens";
+const TWO_DIGIT = "2-digit" as const;
 
 const ATHENS_DATE_FORMAT: Intl.DateTimeFormatOptions = {
   timeZone: ATHENS_TZ,
   weekday: "short",
   month: "short",
   day: "numeric",
-  hour: "2-digit",
-  minute: "2-digit",
+  hour: TWO_DIGIT,
+  minute: TWO_DIGIT,
   hour12: false,
 };
 
 const ATHENS_TIME_ONLY_FORMAT: Intl.DateTimeFormatOptions = {
   timeZone: ATHENS_TZ,
-  hour: "2-digit",
-  minute: "2-digit",
+  hour: TWO_DIGIT,
+  minute: TWO_DIGIT,
   hour12: false,
 };
 

--- a/src/lib/booking-slots.ts
+++ b/src/lib/booking-slots.ts
@@ -1,0 +1,52 @@
+/**
+ * Shared helpers for 30-minute consultation slots.
+ *
+ * Used by the chat agent's book_slot tool (src/lib/chat-tools.ts) and the
+ * authenticated booking agent (src/lib/agent-book.ts) so both render slot
+ * labels and clamp `days_ahead` identically.
+ */
+
+export const MIN_DAYS_AHEAD = 1;
+export const MAX_DAYS_AHEAD = 14;
+export const DEFAULT_DAYS_AHEAD = 7;
+
+const ATHENS_TZ = "Europe/Athens";
+
+const ATHENS_DATE_FORMAT: Intl.DateTimeFormatOptions = {
+  timeZone: ATHENS_TZ,
+  weekday: "short",
+  month: "short",
+  day: "numeric",
+  hour: "2-digit",
+  minute: "2-digit",
+  hour12: false,
+};
+
+const ATHENS_TIME_ONLY_FORMAT: Intl.DateTimeFormatOptions = {
+  timeZone: ATHENS_TZ,
+  hour: "2-digit",
+  minute: "2-digit",
+  hour12: false,
+};
+
+/**
+ * Format a slot as e.g. "Tue Aug 12 10:00–10:30 Athens".
+ */
+export function formatAthensSlot(start: string, end: string): string {
+  const startStr = new Date(start).toLocaleString("en-IE", ATHENS_DATE_FORMAT);
+  const endStr = new Date(end).toLocaleTimeString(
+    "en-IE",
+    ATHENS_TIME_ONLY_FORMAT,
+  );
+  return `${startStr}–${endStr} Athens`;
+}
+
+/**
+ * Coerce arbitrary input to a valid days-ahead window
+ * (between MIN_DAYS_AHEAD and MAX_DAYS_AHEAD).
+ */
+export function clampDaysAhead(raw: unknown): number {
+  const n =
+    typeof raw === "number" && Number.isFinite(raw) ? raw : DEFAULT_DAYS_AHEAD;
+  return Math.max(MIN_DAYS_AHEAD, Math.min(MAX_DAYS_AHEAD, Math.trunc(n)));
+}

--- a/src/lib/chat-tools.ts
+++ b/src/lib/chat-tools.ts
@@ -16,13 +16,16 @@ import { isConfiguredAsync } from "@/lib/integrations";
 import { formatPrice } from "@/lib/format-price";
 import { slackBookingNotify } from "@/lib/slack-notify";
 import { sendBookingConfirmation } from "@/lib/email";
+import {
+  MIN_DAYS_AHEAD,
+  MAX_DAYS_AHEAD,
+  clampDaysAhead,
+  formatAthensSlot,
+} from "@/lib/booking-slots";
 
 const SITE_BASE_URL = "https://cloudless.gr";
 const MAX_PRODUCT_RESULTS = 3;
 const MAX_SLOT_RESULTS = 5;
-const MIN_DAYS_AHEAD = 1;
-const MAX_DAYS_AHEAD = 14;
-const DEFAULT_DAYS_AHEAD = 7;
 
 // ---------------------------------------------------------------------------
 // Schemas — what the model sees when deciding to call a tool
@@ -150,36 +153,6 @@ async function runLookupProduct(input: LookupProductInput): Promise<string> {
   return `Found ${matches.length} match(es):\n${lines.join("\n")}`;
 }
 
-function clampDaysAhead(raw: unknown): number {
-  const n =
-    typeof raw === "number" && Number.isFinite(raw) ? raw : DEFAULT_DAYS_AHEAD;
-  return Math.max(MIN_DAYS_AHEAD, Math.min(MAX_DAYS_AHEAD, Math.trunc(n)));
-}
-
-const ATHENS_FORMAT: Intl.DateTimeFormatOptions = {
-  timeZone: "Europe/Athens",
-  weekday: "short",
-  month: "short",
-  day: "numeric",
-  hour: "2-digit",
-  minute: "2-digit",
-  hour12: false,
-};
-
-function formatSlot(start: string, end: string): string {
-  const startD = new Date(start);
-  const endD = new Date(end);
-  const startStr = startD.toLocaleString("en-IE", ATHENS_FORMAT);
-  const endTimeFmt: Intl.DateTimeFormatOptions = {
-    timeZone: "Europe/Athens",
-    hour: "2-digit",
-    minute: "2-digit",
-    hour12: false,
-  };
-  const endStr = endD.toLocaleTimeString("en-IE", endTimeFmt);
-  return `${startStr}–${endStr} Athens`;
-}
-
 async function runCheckCalendarAvailability(
   input: CheckCalendarInput,
 ): Promise<string> {
@@ -203,7 +176,7 @@ async function runCheckCalendarAvailability(
   const lines = slots
     .slice(0, MAX_SLOT_RESULTS)
     .map(
-      (s) => `- ${formatSlot(s.start, s.end)} [start=${s.start} end=${s.end}]`,
+      (s) => `- ${formatAthensSlot(s.start, s.end)} [start=${s.start} end=${s.end}]`,
     );
   return `Available slots (next ${days} day(s)):\n${lines.join("\n")}\nAsk the visitor which slot they prefer, then collect their name and email to call book_slot. They can also book directly at https://cloudless.gr/book.`;
 }
@@ -234,7 +207,7 @@ async function runBookSlot(input: BookSlotInput): Promise<string> {
     return "Booking failed — the slot may no longer be available. Call check_calendar_availability again and ask the visitor to pick another slot.";
   }
 
-  const slotLabel = formatSlot(start, end);
+  const slotLabel = formatAthensSlot(start, end);
 
   // Fire-and-forget notifications — never block or fail the booking confirmation
   void slackBookingNotify({

--- a/src/lib/chat-tools.ts
+++ b/src/lib/chat-tools.ts
@@ -176,7 +176,8 @@ async function runCheckCalendarAvailability(
   const lines = slots
     .slice(0, MAX_SLOT_RESULTS)
     .map(
-      (s) => `- ${formatAthensSlot(s.start, s.end)} [start=${s.start} end=${s.end}]`,
+      (s) =>
+        `- ${formatAthensSlot(s.start, s.end)} [start=${s.start} end=${s.end}]`,
     );
   return `Available slots (next ${days} day(s)):\n${lines.join("\n")}\nAsk the visitor which slot they prefer, then collect their name and email to call book_slot. They can also book directly at https://cloudless.gr/book.`;
 }


### PR DESCRIPTION
## Summary

Closes the **Phase 2b** item from `docs/AGENTS_ROADMAP.md`.

New `POST /api/agent/book` endpoint that takes natural-language scheduling intent ("schedule me for next Tuesday afternoon, 30 min") and runs a Bedrock tool-use loop to pick a single matching slot, then books it via a separate confirm step. Authenticated, so the booking is always made against the auth'd user's email — the model cannot override it.

## Flow

**Propose** — `POST { intent: string }`
- Runs Bedrock tool-use loop (`check_calendar_availability`, `propose_slot` terminal tool).
- Returns `{ status: "proposed", proposed: { start, end, formatted }, reasoning }` or `{ status: "no_match", reasoning }`.
- The agent never books. It just nominates one slot.

**Confirm** — `POST { confirm: true, start, end, notes? }`
- Re-checks the slot is still free (409 if not).
- Creates the Google Calendar event with a Meet link using the **Cognito-authenticated user's email**.
- Posts to Slack + sends email (fire-and-forget).
- Returns `{ status: "confirmed", eventId, meetingLink, slot }`.

## Guardrails

- Cognito ID token required (`requireAuth`).
- Email forced to the auth'd user — body cannot override.
- Rate-limited 5 / 10 min per IP for both propose and confirm.
- Past slot, `end ≤ start`, and slot-no-longer-free are all rejected before any side effects.

## Files

| File | Purpose |
| --- | --- |
| `src/lib/agent-book.ts` | Bedrock loop, tool defs, propose entrypoint. Reuses the model + region defaults from `src/lib/bedrock-chat.ts`. |
| `src/app/api/agent/book/route.ts` | Thin route handler (auth → discriminate body → propose/confirm). |
| `__tests__/agent-book-api.test.ts` | 13 specs: auth, config gating, propose happy-path, no_match, Bedrock 503, rate limit, confirm happy-path with forced email, past-slot, end ≤ start, 409, side-effect dispatch. |
| `docs/AGENTS_ROADMAP.md` | Phase 2b flipped to SHIPPED. |

## Test plan

- [x] `pnpm tsc --noEmit` clean
- [x] `pnpm vitest run __tests__/agent-book-api.test.ts` — 13/13 pass
- [x] `pnpm vitest run __tests__/{chat-api,chat-tools,calendar-api,api-auth}.test.ts` — 49/49 pass (no regression in adjacent code paths)
- [x] `pnpm eslint` on changed files — 0 issues
- [ ] Manual: with `GOOGLE_CLIENT_EMAIL` / `GOOGLE_PRIVATE_KEY` + Bedrock IAM in a deployed env, POST `{ intent: "next Tuesday afternoon" }` with a real Cognito ID token; then POST the confirm body.


---
_Generated by [Claude Code](https://claude.ai/code/session_0191YVKTm8mraSax73M1ToKM)_