### PR TITLE
ci: opt 16 ARM-safe workflows into RUNNER_GENERIC failover

### DIFF
--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -11,7 +11,7 @@ permissions:
 jobs:
   automerge:
     name: Auto-merge patch/minor
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(vars.RUNNER_GENERIC || '"ubuntu-latest"') }}
     if: github.actor == 'dependabot[bot]'
 
     steps:

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -23,7 +23,7 @@ concurrency:
 jobs:
   dependency-review:
     name: Dependency Risk Review
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(vars.RUNNER_GENERIC || '"ubuntu-latest"') }}
     timeout-minutes: 8
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/ecr-lifecycle.yml
+++ b/.github/workflows/ecr-lifecycle.yml
@@ -10,7 +10,7 @@ env:
 jobs:
   ecr-cleanup:
     name: Set lifecycle policy and prune old images
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(vars.RUNNER_GENERIC || '"ubuntu-latest"') }}
     steps:
       - name: Configure AWS credentials (OIDC)
         uses: aws-actions/configure-aws-credentials@v4 # v4

--- a/.github/workflows/i18n-audit.yml
+++ b/.github/workflows/i18n-audit.yml
@@ -22,7 +22,7 @@ concurrency:
 jobs:
   i18n:
     name: Locale Parity and Placeholder Consistency
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(vars.RUNNER_GENERIC || '"ubuntu-latest"') }}
     timeout-minutes: 8
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/monthly-security-audit.yml
+++ b/.github/workflows/monthly-security-audit.yml
@@ -13,7 +13,7 @@ permissions:
 jobs:
   audit:
     name: Dependency Audit
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(vars.RUNNER_GENERIC || '"ubuntu-latest"') }}
     timeout-minutes: 10
 
     steps:

--- a/.github/workflows/notion-docs-sitemap.yml
+++ b/.github/workflows/notion-docs-sitemap.yml
@@ -18,7 +18,7 @@ env:
 jobs:
   sync:
     name: Sync Notion docs & blog slugs into sitemap
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(vars.RUNNER_GENERIC || '"ubuntu-latest"') }}
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/notion-schema-check.yml
+++ b/.github/workflows/notion-schema-check.yml
@@ -19,7 +19,7 @@ env:
 jobs:
   validate:
     name: Validate Notion DB schemas
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(vars.RUNNER_GENERIC || '"ubuntu-latest"') }}
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/notion-schema-drift.yml
+++ b/.github/workflows/notion-schema-drift.yml
@@ -25,7 +25,7 @@ concurrency:
 jobs:
   drift:
     name: notion-schema-sync --dry-run
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(vars.RUNNER_GENERIC || '"ubuntu-latest"') }}
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ permissions:
 jobs:
   release:
     name: Create GitHub Release
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(vars.RUNNER_GENERIC || '"ubuntu-latest"') }}
     if: github.event.workflow_run.conclusion == 'success'
 
     steps:

--- a/.github/workflows/slack-manifest-apply.yml
+++ b/.github/workflows/slack-manifest-apply.yml
@@ -22,7 +22,7 @@ on:
 jobs:
   apply-manifest:
     name: Apply Slack Manifest
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(vars.RUNNER_GENERIC || '"ubuntu-latest"') }}
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -12,7 +12,7 @@ permissions:
 jobs:
   stale:
     name: Close Stale
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(vars.RUNNER_GENERIC || '"ubuntu-latest"') }}
     timeout-minutes: 5
     env:
       FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"

--- a/.github/workflows/teardown-staging.yml
+++ b/.github/workflows/teardown-staging.yml
@@ -23,7 +23,7 @@ permissions:
 jobs:
   teardown:
     name: Destroy Staging Stack
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(vars.RUNNER_GENERIC || '"ubuntu-latest"') }}
     timeout-minutes: 15
 
     steps:

--- a/.github/workflows/weekly-article-draft.yml
+++ b/.github/workflows/weekly-article-draft.yml
@@ -17,7 +17,7 @@ permissions:
 jobs:
   draft:
     name: Generate weekly blog draft
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(vars.RUNNER_GENERIC || '"ubuntu-latest"') }}
     timeout-minutes: 10
 
     env:

--- a/.github/workflows/weekly-gsc-sync.yml
+++ b/.github/workflows/weekly-gsc-sync.yml
@@ -16,7 +16,7 @@ permissions:
 jobs:
   sync:
     name: Sync GSC data to Notion
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(vars.RUNNER_GENERIC || '"ubuntu-latest"') }}
     timeout-minutes: 10
 
     env:

--- a/.github/workflows/weekly-newsletter.yml
+++ b/.github/workflows/weekly-newsletter.yml
@@ -18,7 +18,7 @@ permissions:
 jobs:
   publish:
     name: Publish approved posts and send newsletter
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(vars.RUNNER_GENERIC || '"ubuntu-latest"') }}
     timeout-minutes: 15
 
     env:

--- a/.github/workflows/weekly-subscriber-report.yml
+++ b/.github/workflows/weekly-subscriber-report.yml
@@ -18,7 +18,7 @@ permissions:
 jobs:
   report:
     name: Post weekly subscriber report
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(vars.RUNNER_GENERIC || '"ubuntu-latest"') }}
     timeout-minutes: 10
 
     env:

--- a/docs/runners.md
+++ b/docs/runners.md
@@ -68,6 +68,22 @@ These read `vars.RUNNER_GENERIC` and fail over automatically:
 - `mcp-security-scan.yml` (pure JS/TS scanner, ARM-safe; informational-only via `continue-on-error: true`)
 - `codeql.yml` (CodeQL CLI v4 supports linux-arm64 for JS/TS analysis)
 - `preview.yml` (SST/CDK — prior Pi attempt in run [`26321031309`] hung past timeout under cold-deploy; retrying with 40-min timeout)
+- `dependabot-automerge.yml`
+- `dependency-review.yml`
+- `ecr-lifecycle.yml`
+- `i18n-audit.yml`
+- `monthly-security-audit.yml`
+- `notion-docs-sitemap.yml`
+- `notion-schema-check.yml`
+- `notion-schema-drift.yml`
+- `release.yml`
+- `slack-manifest-apply.yml`
+- `stale.yml`
+- `teardown-staging.yml`
+- `weekly-article-draft.yml`
+- `weekly-gsc-sync.yml`
+- `weekly-newsletter.yml`
+- `weekly-subscriber-report.yml`
 
 ## Workflows that stay GitHub-hosted
 


### PR DESCRIPTION
## Summary

Migrates 16 ARM-safe workflows from hard-pinned `runs-on: ubuntu-latest` into the existing `RUNNER_GENERIC` failover pattern documented in `docs/runners.md`. Behaviour is identical when `RUNNER_GENERIC` is unset (default: ubuntu-latest); when flipped to Pi via `.github/scripts/toggle-runner.sh pi` these workflows now route to the Pi build runners instead of instant-failing during a GitHub-hosted runner outage.

## Why

PR #210 surfaced a real GitHub-hosted runner outage where 8+ workflows hit the *"the job was not started because recent account payments have failed"* path and instant-failed in 2–4 seconds, blocking unrelated merges. CLAUDE.md's failover playbook only worked for workflows that had previously opted into `RUNNER_GENERIC`. This PR extends the opt-in to every workflow whose tooling is ARM-safe.

## Migrated workflows

| Workflow | Tooling |
|---|---|
| `dependabot-automerge.yml` | dependabot/fetch-metadata action |
| `dependency-review.yml` | GitHub dependency-review action |
| `ecr-lifecycle.yml` | AWS API |
| `i18n-audit.yml` | pure pnpm + node |
| `monthly-security-audit.yml` | pnpm + node + artifacts |
| `notion-docs-sitemap.yml` | Notion API |
| `notion-schema-check.yml` | pure (checkout only) |
| `notion-schema-drift.yml` | pnpm + node + AWS SSM |
| `release.yml` | github-script |
| `slack-manifest-apply.yml` | Slack API |
| `stale.yml` | actions/stale |
| `teardown-staging.yml` | pnpm + AWS API |
| `weekly-article-draft.yml` | pure pnpm + node |
| `weekly-gsc-sync.yml` | pnpm + Google API |
| `weekly-newsletter.yml` | pnpm + node |
| `weekly-subscriber-report.yml` | pnpm + node |

## Not migrated (intentional)

These stay pinned to `ubuntu-latest` because they genuinely need x86_64 / system Chrome / SST cold-deploy headroom:

- `deploy.yml`, `lighthouse.yml`, `k3s-e2e.yml`, `core-web-vitals-audit.yml`, `pwa-audit.yml`, `devcontainer.yml`

Pi-pinned by design (cluster jobs) stays pinned: `build-pi-image.yml`, `deploy-pi.yml` (build-and-push).

## How this was produced

Via the new `workflow-failover-migrate` skill audit (Pattern 1). The skill codified the lessons from PR #210's debugging cycle, including that **job-level `continue-on-error: true` does NOT flip the per-job check conclusion that branch protection reads** — only step-level does.

## Risk

Zero behaviour change when `RUNNER_GENERIC` is unset (the current default for this repo). Migration only activates when the toggle script is flipped to Pi. Each workflow is a single-line YAML change.

## Test plan

- [x] All 16 files contain the exact same one-line replacement (verified post-edit).
- [x] `docs/runners.md` reflects the new opt-in list.
- [ ] After merge, flip `RUNNER_GENERIC` to Pi during the next hosted outage and confirm each previously-hard-pinned workflow runs on Pi runners.

---
_Generated by [Claude Code](https://claude.ai/code/session_0191YVKTm8mraSax73M1ToKM)_