### PR TITLE
ci: revert deploy.yml to ubuntu-latest (SST hangs on ARM)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -27,12 +27,11 @@ permissions:
 jobs:
   deploy:
     name: Deploy
-    # Pinned to ubuntu-latest. SST + CDK synth + Sentry sourcemap upload
-    # do not fit on an ARM Pi runner under cold-deploy conditions — the
-    # Deploy (SST) step hung past the 40 min timeout when we tried the
-    # failover pattern here (2026-05-23, run 26321031309). See
-    # docs/runners.md "Workflows that stay GitHub-hosted".
-    runs-on: ${{ fromJSON(vars.RUNNER_GENERIC || '"ubuntu-latest"') }}
+    # Intentionally NOT using RUNNER_GENERIC — SST + CDK synth + Sentry sourcemap
+    # upload hang on ARM Pi runners (timed out at 40 min, run 26321031309, 2026-05-23).
+    # This job stays on ubuntu-latest; it will be unavailable during billing locks.
+    # See docs/runners.md "Workflows that stay GitHub-hosted".
+    runs-on: ubuntu-latest
     timeout-minutes: 40
     environment:
       name: production


### PR DESCRIPTION
SST deploy timed out on Pi ARM runner (run 26321031309). The bulk RUNNER_GENERIC migration accidentally overwrote the intentional exception. Reverts deploy.yml to ubuntu-latest with a clear comment explaining why.