### PR TITLE
fix(ci): enable SST deploy on Pi fleet (NODE_OPTIONS heap fix)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -27,11 +27,9 @@ permissions:
 jobs:
   deploy:
     name: Deploy
-    # Intentionally NOT using RUNNER_GENERIC — SST + CDK synth + Sentry sourcemap
-    # upload hang on ARM Pi runners (timed out at 40 min, run 26321031309, 2026-05-23).
-    # This job stays on ubuntu-latest; it will be unavailable during billing locks.
-    # See docs/runners.md "Workflows that stay GitHub-hosted".
-    runs-on: ubuntu-latest
+    # RUNNER_GENERIC-capable. CDK synth previously hung on ARM (run 26321031309)
+    # due to Node heap exhaustion — fixed by NODE_OPTIONS on the Deploy step below.
+    runs-on: ${{ fromJSON(vars.RUNNER_GENERIC || '"ubuntu-latest"') }}
     timeout-minutes: 40
     environment:
       name: production
@@ -107,6 +105,7 @@ jobs:
           SENTRY_ORG: baltzakisthemiscom
           SENTRY_PROJECT: cloudless-gr
           NEXT_PUBLIC_SENTRY_DSN: ${{ secrets.NEXT_PUBLIC_SENTRY_DSN }}
+          NODE_OPTIONS: --max-old-space-size=3072
 
       - name: Publish current SHA to SSM (for Pi-side image pin)
         if: success()


### PR DESCRIPTION
CDK synth during sst deploy exhausts the ~1.5 GB default JS heap on ARM runners -- same root cause as the tsc OOM fixed in 14704cd5.

Fix: add NODE_OPTIONS: --max-old-space-size=3072 to the Deploy step and switch runs-on back to RUNNER_GENERIC.

Before: deploy.yml hardcoded ubuntu-latest -- dead during billing locks.
After: runs on Pi fleet, CDK synth gets 3 GB heap (Pi 5 has 7.9 GB total).