### PR TITLE
ci(deploy): cancel stale deploy runs on new push

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -17,7 +17,7 @@ on:
 
 concurrency:
   group: deploy-production
-  cancel-in-progress: false
+  cancel-in-progress: true
 
 permissions:
   id-token: write


### PR DESCRIPTION
Flip cancel-in-progress to true so a new push immediately cancels any queued or in-progress deploy rather than serializing behind it. Latest commit always wins.