### PR TITLE
fix(next): externalize AWS SDK clients to fix Turbopack subpath resolution

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -16,6 +16,17 @@ const nextConfig: NextConfig = {
   // For Docker builds (Pi HA standby): emit a self-contained .next/standalone
   // bundle. SST/Vercel deploys leave this unset.
   output: process.env.NEXT_OUTPUT_STANDALONE === "1" ? "standalone" : undefined,
+  // Turbopack (Next 16) fails to resolve `@smithy/core/*` subpath exports
+  // through pnpm's hoisted layout on Windows. Externalize the AWS SDK
+  // clients so Next uses Node's native resolver instead of bundling them.
+  serverExternalPackages: [
+    "@aws-sdk/client-bedrock-runtime",
+    "@aws-sdk/client-cognito-identity-provider",
+    "@aws-sdk/client-dynamodb",
+    "@aws-sdk/client-ses",
+    "@aws-sdk/client-sesv2",
+    "@aws-sdk/client-ssm",
+  ],
   // In WSL dev, set NEXT_DIST_DIR to a native Linux path (e.g. ~/next-cloudless)
   // to avoid the slow NTFS→WSL filesystem benchmark warning.
   // Production and CI leave this unset so the default .next dir is used.


### PR DESCRIPTION
## Summary
- Externalize `@aws-sdk/client-*` packages via `serverExternalPackages` so Next.js / Turbopack stops trying to bundle their `@smithy/core/*` subpath imports through pnpm's hoisted `node_modules`.

## Why
Local dev on Windows fails with:
```
Module not found: Can't resolve '@smithy/core/client'
  ./node_modules/@aws-sdk/client-ssm/dist-es/SSMClient.js
```
The `@smithy/core@3.24.3` package does export `./client` in its `package.json`. The breakage is on the Turbopack side — it doesn't follow the subpath export through pnpm's symlinked layout on Windows. Listing the SDK clients in `serverExternalPackages` makes Next.js use Node's native resolver, sidestepping the bundler entirely on the server.

## Test plan
- [x] Local: delete `.next`, `pnpm dev`, hit a route that imports `@/lib/ssm-config` (e.g. `/api/user/purchases`) — no `Module not found`.
- [x] CI: `pnpm build` + `pnpm typecheck` stay green.
- [x] Lambda + Pi deploys: no runtime change (these packages were already shipped via node_modules; only the bundler step changes).

---
_Generated by [Claude Code](https://claude.ai/code/session_0191YVKTm8mraSax73M1ToKM)_