### PR TITLE
fix(ci): harden Pi sync webhook + rollout reliability

### DIFF
--- a/.github/workflows/build-pi-image.yml
+++ b/.github/workflows/build-pi-image.yml
@@ -227,13 +227,27 @@ jobs:
           SECRET: ${{ secrets.SYNC_HMAC_SECRET }}
         run: |
           set -euo pipefail
+          # Guard: secret must be set or the receiver will reject with 401
+          # and the Pi will silently miss the sync nudge.
+          if [ -z "${SECRET:-}" ]; then
+            echo "::warning::SYNC_HMAC_SECRET is not configured — Pi sync webhook skipped (Pi will poll on its normal schedule)"
+            exit 0
+          fi
           BODY=$(jq -nc \
             --arg sha "$GITHUB_SHA" \
             --argjson ts "$(date +%s)" \
             '{job:"image-sync", ts:$ts, sha:$sha}')
-          SIG="sha256=$(printf '%s' "$BODY" | openssl dgst -sha256 -hmac "$SECRET" | awk '{print $2}')"
+          HASH=$(printf '%s' "$BODY" | openssl dgst -sha256 -hmac "$SECRET" | awk '{print $2}')
+          if [ -z "$HASH" ]; then
+            echo "::warning::HMAC computation produced empty result — skipping webhook"
+            exit 0
+          fi
+          SIG="sha256=${HASH}"
           echo "POST /_sync/image (sha=${GITHUB_SHA::8})"
-          curl -fsS --max-time 10 \
+          # 30s timeout covers DERP-relay round-trips; 2 retries handle transient
+          # Tailscale Funnel hiccups. Total worst-case: ~75s, still non-blocking
+          # because continue-on-error: true — Pi falls back to its 60s poll.
+          curl -fsS --max-time 30 --retry 2 --retry-delay 5 \
             -X POST "https://omv.tail8eb71.ts.net/_sync/image" \
             -H "Content-Type: application/json" \
             -H "X-Hub-Signature-256: $SIG" \

--- a/.github/workflows/deploy-pi.yml
+++ b/.github/workflows/deploy-pi.yml
@@ -82,9 +82,15 @@ jobs:
         if: steps.check_ecr.outputs.exists != 'true'
         uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
 
-      - name: Prune stale buildx cache
+      - name: ensure local cache dirs exist
         if: steps.check_ecr.outputs.exists != 'true'
-        run: docker buildx prune -f --filter until=48h || true
+        run: |
+          sudo mkdir -p /opt/docker-cache
+          sudo chmod 777 /opt/docker-cache
+
+      - name: warm base image into Docker daemon cache
+        if: steps.check_ecr.outputs.exists != 'true'
+        run: docker pull node:22-alpine
 
       - name: Build and push Docker image
         if: steps.check_ecr.outputs.exists != 'true'
@@ -96,8 +102,8 @@ jobs:
           # SHA tag only — ECR has immutable tags, :latest is never pushed.
           # Rollout uses kubectl set image with this SHA for pinned, reproducible deploys.
           tags: ${{ env.ECR_REGISTRY }}/${{ env.ECR_REPOSITORY }}:${{ steps.check_ecr.outputs.short_sha }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          cache-from: type=local,src=/opt/docker-cache
+          cache-to: type=local,dest=/opt/docker-cache,mode=max
           build-args: |
             NEXT_PUBLIC_SITE_URL=${{ secrets.NEXT_PUBLIC_SITE_URL }}
             NEXT_PUBLIC_STAGE=production
@@ -132,6 +138,11 @@ jobs:
 
     steps:
       - name: Connect to tailnet
+        # continue-on-error: Pi runners are already Tailscale nodes — if
+        # tailscale-action fails to re-auth the existing daemon (e.g. ephemeral
+        # key consumed), the runner's pre-existing Tailscale connection still
+        # routes kubectl traffic to 100.113.41.119:6443 correctly.
+        continue-on-error: true
         uses: tailscale/github-action@0263d9e6d793eaefcf1de98ff7fde47abe6664d3 # v3.2.4
         with:
           authkey: ${{ secrets.TS_AUTHKEY }}


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- **Pin `deploy.yml` back to `ubuntu-latest`** — SST + CDK synth hung past the 40min timeout on ARM Pi runners (run 26321031309); documented in `docs/runners.md`
- **Harden `build-pi-image.yml` sync webhook** — guard against empty `SYNC_HMAC_SECRET`, increase timeout 10s→30s, add `--retry 2` for Tailscale Funnel hiccups
- **Fix `deploy-pi.yml` Tailscale re-auth** — add `continue-on-error: true` to "Connect to tailnet" step; Pi runners are already Tailscale nodes, re-auth failure was hard-failing the rollout job unnecessarily
- **Align `deploy-pi.yml` Docker cache** — switch from `type=gha` to `type=local` + pre-pull `node:22-alpine` (parity with `build-pi-image.yml` from PR #219)
- **Add 3 new Claude skills** — `api-security-audit`, `sonarcloud-triage`, `pr-conflict-resolve`

## Root causes fixed

### Sync webhook silent failures
`SYNC_HMAC_SECRET` not set → empty HMAC key → receiver returns 401 → `curl -f` fails → `continue-on-error` swallows → Pi never gets the sync nudge. Fixed with an explicit guard that emits a clear `::warning::` and exits cleanly.

### Rollout job failing on Pi runners (RUNNER_GENERIC mode)
`tailscale/github-action` running on a Pi runner (already a Tailscale node) can fail to re-auth with an ephemeral key. The runner's pre-existing Tailscale connection still routes kubectl traffic correctly, but the step was hard-failing the entire rollout job. Fixed with `continue-on-error: true`.

## Test plan

- [ ] Verify `build-pi-image.yml` "trigger Pi sync-webhook" step shows `::warning::` in logs when `SYNC_HMAC_SECRET` is unset (simulate by temporarily removing the secret, or verify log output on next push to main)
- [ ] Verify rollout job completes on both GH-hosted and Pi runner targets
- [ ] Verify `deploy.yml` runs on `ubuntu-latest` (not Pi runners)

https://claude.ai/code/session_01HuPxcCB6MrGPDE1HvsFFFH
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HuPxcCB6MrGPDE1HvsFFFH)_