### PR TITLE
fix(docker): cap Node.js heap to 768 MB during Pi build to prevent OOM

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -53,7 +53,8 @@ ENV NEXT_PUBLIC_SITE_URL=${NEXT_PUBLIC_SITE_URL} \
     NEXT_PUBLIC_GOOGLE_SITE_VERIFICATION=${NEXT_PUBLIC_GOOGLE_SITE_VERIFICATION} \
     APP_VERSION=${APP_VERSION} \
     NEXT_OUTPUT_STANDALONE=1 \
-    NEXT_TELEMETRY_DISABLED=1
+    NEXT_TELEMETRY_DISABLED=1 \
+    NODE_OPTIONS="--max-old-space-size=768"
 
 COPY --from=deps /app/node_modules ./node_modules
 # Recursive copy of the build context. Safe because .dockerignore excludes


### PR DESCRIPTION
TypeScript checking was killed with \"The operation was canceled\" on the Pi arm64 runner because Node.js grabbed too much RAM while k3s was running concurrently. Sets `NODE_OPTIONS=--max-old-space-size=768` on the builder stage to cap heap allocation and prevent the OOM kill.

---
_Generated by [Claude Code](https://claude.ai/code/session_01HuPxcCB6MrGPDE1HvsFFFH)_