### PR TITLE
feat(mcp): add cloudless-ssh-mcp server for SSH-based infra tools

### DIFF
--- a/.claude/skills/runner-harden/SKILL.md
+++ b/.claude/skills/runner-harden/SKILL.md
@@ -1,0 +1,141 @@
+---
+name: runner-harden
+description: Harden Pi self-hosted runner systemd units to decouple them from k3s.service, so runners survive k3s crashes and can pick up recovery jobs. Use when runners go offline after a k3s crash, when "Waiting for a runner" is stuck after k3s failure, after registering new Pi runners, or any time runners show After=k3s.service in their unit. Triggers on "runners offline after k3s crash", "decouple runner from k3s", "harden runner", "runner won't pick up jobs", "apply systemd fix", "runner drops when k3s fails".
+allowed-tools: mcp__cloudless-infra__cluster_run_command, mcp__cloudless-infra__gh_runner_health, mcp__cloudless-infra__gh_runner_fix_service, mcp__cloudless-infra__gh_runner_restart
+---
+
+# Runner Systemd Hardening — Decouple from k3s
+
+## Problem
+
+When `k3s.service` crashes, it can drag the GitHub Actions runner services down with it
+if their systemd units have `After=k3s.service` or `Requires=k3s.service`. This creates
+a chicken-and-egg problem: the runner is needed to restart k3s, but k3s must be up for
+the runner to start.
+
+## Goal
+
+Make each runner service depend only on `network-online.target`, not on k3s. A k3s crash
+then leaves all three runners alive so they can pick up the "k3s restart (manual)" workflow.
+
+---
+
+## Step 1 — Check current unit dependencies
+
+```
+cluster_run_command(node: "omv-main",
+  command: "for r in omv omv-2 omv-3; do echo \"=== $r ===\"; systemctl show actions.runner.Themis128-cloudless.gr.$r.service --property=After --property=Requires 2>/dev/null || echo 'not found'; done")
+```
+
+Look for `k3s` in the `After=` or `Requires=` output. If present → proceed to Step 2.
+
+---
+
+## Step 2 — Apply hardening via MCP tool (preferred)
+
+Run for each runner. The tool writes the override.conf, configures fallback DNS,
+daemon-reloads, and restarts the service. **Idempotent — safe to re-run.**
+
+```
+gh_runner_fix_service(repo: "cloudless.gr", runner: "omv")
+gh_runner_fix_service(repo: "cloudless.gr", runner: "omv-2")
+gh_runner_fix_service(repo: "cloudless.gr", runner: "omv-3")
+```
+
+What `gh_runner_fix_service` writes to
+`/etc/systemd/system/actions.runner.Themis128-cloudless.gr.<runner>.service.d/override.conf`:
+
+```ini
+[Unit]
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Restart=on-failure
+RestartSec=10s
+StartLimitIntervalSec=0
+Environment="RUNNER_RETRY_RENEW_SECONDS=300"
+Environment="DOTNET_SYSTEM_NET_HTTP_USESOCKETSHTTPHANDLER=1"
+```
+
+And to `/etc/systemd/resolved.conf.d/retry.conf`:
+```ini
+[Resolve]
+DNS=8.8.8.8 8.8.4.4 1.1.1.1
+FallbackDNS=9.9.9.9
+```
+
+---
+
+## Step 2 (fallback) — Apply via GitHub Actions workflow
+
+If MCP tools are unavailable but at least one runner is online:
+
+Trigger **"harden runner systemd units (manual)"** from GitHub Actions → workflow_dispatch.
+
+It runs on all three runners in parallel via matrix strategy. Each runner:
+1. Writes its own override.conf
+2. Configures fallback DNS
+3. Runs `daemon-reload` + restarts its own service
+
+---
+
+## Step 2 (manual) — Apply via SSH when all runners are offline
+
+If k3s crashed and all runners are also down (no jobs can be picked up), SSH in directly:
+
+```bash
+# Run on omv-main (192.168.1.128) for each runner name:
+bash /home/user/cloudless.gr/.github/scripts/harden-runner-systemd.sh omv
+bash /home/user/cloudless.gr/.github/scripts/harden-runner-systemd.sh omv-2
+bash /home/user/cloudless.gr/.github/scripts/harden-runner-systemd.sh omv-3
+```
+
+Or fetch and run from the repo directly:
+```bash
+curl -fsSL https://raw.githubusercontent.com/Themis128/cloudless.gr/main/.github/scripts/harden-runner-systemd.sh | sudo bash -s omv
+```
+
+---
+
+## Step 3 — Verify
+
+```
+cluster_run_command(node: "omv-main",
+  command: "for r in omv omv-2 omv-3; do echo \"=== $r ===\"; systemctl show actions.runner.Themis128-cloudless.gr.$r.service --property=After | grep -i k3s && echo 'STILL HAS k3s dep!' || echo 'OK - no k3s dep'; systemctl is-active actions.runner.Themis128-cloudless.gr.$r.service; done")
+```
+
+All three should show `active` and no k3s reference in `After=`.
+
+---
+
+## Step 4 — Check runner fleet health
+
+```
+gh_runner_health(repo: "cloudless.gr")
+```
+
+All three runners should be online. If any are offline, restart:
+
+```
+gh_runner_restart(repo: "cloudless.gr", runner: "omv")
+```
+
+---
+
+## Bootstrap Problem
+
+If k3s crashes AND runners are all offline (both at the same time):
+
+1. SSH to omv-main: `ssh omv-main` (192.168.1.128)
+2. Run harden script for each runner: `sudo bash .github/scripts/harden-runner-systemd.sh omv`
+3. Once at least one runner is online, trigger "k3s restart (manual)" from GitHub Actions
+4. After k3s is up, trigger "build pi image" or "Deploy to Pi" to restore the app
+
+## Notes
+
+- The `gh_runner_fix_service` MCP tool is the canonical implementation — the script and
+  workflow are fallbacks for when MCP tools are unavailable.
+- After hardening, a k3s crash will no longer take runners offline.
+- The `StartLimitIntervalSec=0` setting means systemd will never stop trying to restart
+  the runner service after repeated failures — important for DNS-flap scenarios.

--- a/.github/scripts/harden-runner-systemd.sh
+++ b/.github/scripts/harden-runner-systemd.sh
@@ -1,0 +1,110 @@
+#!/usr/bin/env bash
+# harden-runner-systemd.sh <runner-name>
+#
+# Applies systemd drop-in hardening to a Pi GitHub Actions runner service:
+#   - Removes k3s.service dependency (After=/Requires=)
+#   - Adds Restart=on-failure + StartLimitIntervalSec=0
+#   - Sets After=network-online.target only
+#   - Configures fallback DNS
+#
+# Usage:
+#   sudo bash harden-runner-systemd.sh omv
+#   sudo bash harden-runner-systemd.sh omv-2
+#   sudo bash harden-runner-systemd.sh omv-3
+#
+# Must be run as root (or with sudo) on omv-main (192.168.1.128).
+# Idempotent — safe to re-run.
+
+set -euo pipefail
+
+RUNNER="${1:-}"
+if [[ -z "$RUNNER" ]]; then
+  echo "Usage: $0 <runner-name>  (e.g. omv, omv-2, omv-3)" >&2
+  exit 1
+fi
+
+REPO="Themis128-cloudless.gr"
+SVC="actions.runner.${REPO}.${RUNNER}.service"
+OVERRIDE_DIR="/etc/systemd/system/${SVC}.d"
+
+echo "=== Hardening runner: ${RUNNER} (${SVC}) ==="
+
+# ── 1. Check for existing k3s dependency ──────────────────────────────────────
+echo ""
+echo "--- Current After= / Requires= ---"
+systemctl show "${SVC}" --property=After --property=Requires 2>/dev/null \
+  || echo "(service not found — may not be registered on this node)"
+
+if systemctl cat "${SVC}" 2>/dev/null | grep -qi "k3s"; then
+  echo "⚠️  k3s reference found in unit — will be excluded by override"
+else
+  echo "✓ No k3s dependency in base unit"
+fi
+
+# ── 2. Write drop-in override ─────────────────────────────────────────────────
+echo ""
+echo "--- Writing override.conf ---"
+mkdir -p "${OVERRIDE_DIR}"
+cat > "${OVERRIDE_DIR}/override.conf" << 'EOF'
+[Unit]
+# Decouple from k3s — runner must survive k3s crashes independently.
+# Only wait for network to be online.
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Restart=on-failure
+RestartSec=10s
+# Never hit the start-rate limit — keep retrying after DNS flaps or crashes.
+StartLimitIntervalSec=0
+Environment="RUNNER_RETRY_RENEW_SECONDS=300"
+Environment="DOTNET_SYSTEM_NET_HTTP_USESOCKETSHTTPHANDLER=1"
+EOF
+echo "✓ Written ${OVERRIDE_DIR}/override.conf"
+cat "${OVERRIDE_DIR}/override.conf"
+
+# ── 3. Configure fallback DNS ─────────────────────────────────────────────────
+echo ""
+echo "--- Configuring fallback DNS ---"
+mkdir -p /etc/systemd/resolved.conf.d
+cat > /etc/systemd/resolved.conf.d/retry.conf << 'EOF'
+[Resolve]
+DNS=8.8.8.8 8.8.4.4 1.1.1.1
+FallbackDNS=9.9.9.9
+EOF
+echo "✓ Written /etc/systemd/resolved.conf.d/retry.conf"
+systemctl restart systemd-resolved 2>/dev/null || true
+
+# ── 4. Reload and restart ─────────────────────────────────────────────────────
+echo ""
+echo "--- Reloading systemd and restarting runner ---"
+systemctl daemon-reload
+systemctl restart "${SVC}" || {
+  echo "⚠️  Restart failed — service may need registration first" >&2
+  exit 1
+}
+sleep 5
+
+# ── 5. Verify ─────────────────────────────────────────────────────────────────
+echo ""
+echo "--- Post-hardening verification ---"
+STATUS=$(systemctl is-active "${SVC}" 2>/dev/null || echo "unknown")
+echo "Service status: ${STATUS}"
+
+AFTER=$(systemctl show "${SVC}" --property=After 2>/dev/null || echo "")
+echo "After= : ${AFTER}"
+
+if echo "${AFTER}" | grep -qi "k3s"; then
+  echo "⚠️  WARNING: k3s still appears in After= — check override" >&2
+else
+  echo "✓ No k3s dependency in effective unit"
+fi
+
+if [[ "${STATUS}" == "active" ]]; then
+  echo ""
+  echo "✅ Runner ${RUNNER} is hardened and active."
+else
+  echo ""
+  echo "❌ Runner ${RUNNER} is not active (status: ${STATUS}). Check: journalctl -u ${SVC} -n 30"
+  exit 1
+fi

--- a/.github/workflows/runner-harden.yml
+++ b/.github/workflows/runner-harden.yml
@@ -1,0 +1,109 @@
+name: harden runner systemd units (manual)
+
+# Applies systemd hardening to the Pi self-hosted runner services:
+#   - Removes any k3s.service dependency (After=/Requires=)
+#   - Adds Restart=on-failure, RestartSec=10s, StartLimitIntervalSec=0
+#   - Sets After=network-online.target
+#   - Configures fallback DNS for resilience
+#
+# Run this once after registering new runners, or any time runners drop
+# due to k3s crashes. Each matrix leg runs on a different runner instance
+# so all three are hardened in parallel.
+#
+# If runners are already offline, run the fix-runner-systemd.sh script
+# directly via SSH on each Pi node instead.
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  harden:
+    name: Harden ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        runner: [omv, omv-2, omv-3]
+    runs-on: [self-hosted, "${{ matrix.runner }}", pi]
+    timeout-minutes: 5
+
+    steps:
+      - name: Detect runner service name
+        id: svc
+        run: |
+          # Runner registers itself with its own name — derive service from hostname
+          RUNNER="${{ matrix.runner }}"
+          REPO="Themis128-cloudless.gr"
+          SVC="actions.runner.${REPO}.${RUNNER}.service"
+          echo "name=${SVC}" >> "$GITHUB_OUTPUT"
+          echo "Runner service: ${SVC}"
+
+      - name: Check for k3s dependencies in current unit
+        run: |
+          SVC="${{ steps.svc.outputs.name }}"
+          echo "=== Current unit file ==="
+          systemctl cat "${SVC}" 2>/dev/null || echo "(unit file not found via systemctl cat)"
+          echo ""
+          echo "=== Checking for k3s references ==="
+          if systemctl cat "${SVC}" 2>/dev/null | grep -i "k3s"; then
+            echo "⚠️  k3s dependency found — will be removed by override"
+          else
+            echo "✓ No k3s dependency found in unit"
+          fi
+          echo ""
+          echo "=== Existing override.conf ==="
+          cat "/etc/systemd/system/${SVC}.d/override.conf" 2>/dev/null || echo "(no override yet)"
+
+      - name: Write systemd drop-in override
+        run: |
+          SVC="${{ steps.svc.outputs.name }}"
+          OVERRIDE_DIR="/etc/systemd/system/${SVC}.d"
+          sudo mkdir -p "${OVERRIDE_DIR}"
+          sudo tee "${OVERRIDE_DIR}/override.conf" > /dev/null << 'EOF'
+          [Unit]
+          # Decouple from k3s — runner must survive k3s crashes
+          After=network-online.target
+          Wants=network-online.target
+
+          [Service]
+          Restart=on-failure
+          RestartSec=10s
+          StartLimitIntervalSec=0
+          Environment="RUNNER_RETRY_RENEW_SECONDS=300"
+          Environment="DOTNET_SYSTEM_NET_HTTP_USESOCKETSHTTPHANDLER=1"
+          EOF
+          echo "✓ Written ${OVERRIDE_DIR}/override.conf"
+          cat "${OVERRIDE_DIR}/override.conf"
+
+      - name: Configure fallback DNS
+        run: |
+          sudo mkdir -p /etc/systemd/resolved.conf.d
+          sudo tee /etc/systemd/resolved.conf.d/retry.conf > /dev/null << 'EOF'
+          [Resolve]
+          DNS=8.8.8.8 8.8.4.4 1.1.1.1
+          FallbackDNS=9.9.9.9
+          EOF
+          sudo systemctl restart systemd-resolved || true
+          echo "✓ DNS fallback configured"
+
+      - name: Reload systemd and restart runner
+        run: |
+          SVC="${{ steps.svc.outputs.name }}"
+          sudo systemctl daemon-reload
+          sudo systemctl restart "${SVC}"
+          sleep 5
+          sudo systemctl is-active "${SVC}"
+          echo "✓ Runner service is active"
+
+      - name: Verify no k3s dependency in effective unit
+        run: |
+          SVC="${{ steps.svc.outputs.name }}"
+          echo "=== Effective unit after hardening ==="
+          systemctl show "${SVC}" --property=After --property=Requires --property=Wants
+          if systemctl show "${SVC}" --property=After | grep -i "k3s"; then
+            echo "::warning::k3s still appears in After= — check override"
+          else
+            echo "✓ No k3s dependency in effective unit"
+          fi

--- a/Dockerfile
+++ b/Dockerfile
@@ -53,7 +53,8 @@ ENV NEXT_PUBLIC_SITE_URL=${NEXT_PUBLIC_SITE_URL} \
     NEXT_PUBLIC_GOOGLE_SITE_VERIFICATION=${NEXT_PUBLIC_GOOGLE_SITE_VERIFICATION} \
     APP_VERSION=${APP_VERSION} \
     NEXT_OUTPUT_STANDALONE=1 \
-    NEXT_TELEMETRY_DISABLED=1
+    NEXT_TELEMETRY_DISABLED=1 \
+    NODE_OPTIONS="--max-old-space-size=768"
 
 COPY --from=deps /app/node_modules ./node_modules
 # Recursive copy of the build context. Safe because .dockerignore excludes

--- a/mcp.json
+++ b/mcp.json
@@ -1,5 +1,14 @@
 {
   "mcpServers": {
+    "cloudless-infra": {
+      "command": "npx",
+      "args": ["tsx", "tools/ssh-mcp/src/index.ts"],
+      "env": {
+        "OMV_SSH_HOST": "192.168.1.128",
+        "OMV_SSH_USER": "omv",
+        "OMV_SSH_KEY": "${HOME}/.ssh/id_ed25519"
+      }
+    },
     "project": {
       "command": "npx",
       "args": [

--- a/tools/ssh-mcp/package.json
+++ b/tools/ssh-mcp/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "cloudless-ssh-mcp",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "description": "MCP server providing SSH access to omv-main and cloudless infra tools",
+  "bin": {
+    "cloudless-ssh-mcp": "./dist/index.js"
+  },
+  "scripts": {
+    "build": "tsc",
+    "dev": "tsx src/index.ts",
+    "start": "node dist/index.js"
+  },
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.12.0",
+    "ssh2": "^1.16.0",
+    "zod": "^3.25.0"
+  },
+  "devDependencies": {
+    "@types/node": "^22.0.0",
+    "@types/ssh2": "^1.15.0",
+    "tsx": "^4.19.3",
+    "typescript": "^5.8.0"
+  }
+}

--- a/tools/ssh-mcp/src/index.ts
+++ b/tools/ssh-mcp/src/index.ts
@@ -1,0 +1,314 @@
+#!/usr/bin/env node
+/**
+ * cloudless-ssh-mcp
+ *
+ * MCP server that provides SSH-based infrastructure tools for omv-main.
+ * Mirrors the mcp__cloudless-infra__* interface so skills work identically
+ * whether the full cloudless-infra server or this lightweight SSH shim is
+ * available.
+ *
+ * Required env vars:
+ *   OMV_SSH_HOST      — IP or hostname (default: 192.168.1.128)
+ *   OMV_SSH_USER      — SSH user (default: omv)
+ *   OMV_SSH_KEY       — Path to private key file (default: ~/.ssh/id_ed25519)
+ *   OMV_SSH_PORT      — SSH port (default: 22)
+ *
+ * Optional:
+ *   OMV_SSH_PASSPHRASE — Passphrase for encrypted private keys
+ */
+
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import { Client as SshClient, ConnectConfig } from "ssh2";
+import { readFileSync } from "fs";
+import { homedir } from "os";
+import { join } from "path";
+import { z } from "zod";
+
+// ── SSH config from env ────────────────────────────────────────────────────────
+
+const SSH_HOST = process.env.OMV_SSH_HOST ?? "192.168.1.128";
+const SSH_USER = process.env.OMV_SSH_USER ?? "omv";
+const SSH_PORT = parseInt(process.env.OMV_SSH_PORT ?? "22", 10);
+const SSH_KEY_PATH = process.env.OMV_SSH_KEY ?? join(homedir(), ".ssh", "id_ed25519");
+const SSH_PASSPHRASE = process.env.OMV_SSH_PASSPHRASE;
+
+const RUNNER_REPO_SLUG = "Themis128-cloudless.gr";
+
+// ── SSH helper ─────────────────────────────────────────────────────────────────
+
+function sshRun(command: string, timeoutMs = 60_000): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const conn = new SshClient();
+    let output = "";
+    let errOutput = "";
+
+    const config: ConnectConfig = {
+      host: SSH_HOST,
+      port: SSH_PORT,
+      username: SSH_USER,
+      readyTimeout: 10_000,
+    };
+
+    try {
+      const key = readFileSync(SSH_KEY_PATH);
+      config.privateKey = key;
+      if (SSH_PASSPHRASE) config.passphrase = SSH_PASSPHRASE;
+    } catch {
+      return reject(new Error(`Cannot read SSH key at ${SSH_KEY_PATH}. Set OMV_SSH_KEY env var.`));
+    }
+
+    const timer = setTimeout(() => {
+      conn.destroy();
+      reject(new Error(`SSH command timed out after ${timeoutMs}ms: ${command}`));
+    }, timeoutMs);
+
+    conn
+      .on("ready", () => {
+        conn.exec(command, (err, stream) => {
+          if (err) {
+            clearTimeout(timer);
+            conn.end();
+            return reject(err);
+          }
+          stream
+            .on("close", (code: number) => {
+              clearTimeout(timer);
+              conn.end();
+              if (code !== 0 && !output && errOutput) {
+                reject(new Error(`Exit ${code}: ${errOutput.trim()}`));
+              } else {
+                resolve(output + (errOutput ? `\n[stderr]\n${errOutput}` : ""));
+              }
+            })
+            .on("data", (data: Buffer) => { output += data.toString(); })
+            .stderr.on("data", (data: Buffer) => { errOutput += data.toString(); });
+        });
+      })
+      .on("error", (err) => {
+        clearTimeout(timer);
+        reject(new Error(`SSH connection failed: ${err.message}`));
+      })
+      .connect(config);
+  });
+}
+
+// ── High-level infra helpers ───────────────────────────────────────────────────
+
+function runnerSvcName(runner: string) {
+  return `actions.runner.${RUNNER_REPO_SLUG}.${runner}.service`;
+}
+
+async function runnerHealth(repo: string): Promise<string> {
+  const runners = ["omv", "omv-2", "omv-3"];
+  const lines: string[] = [`Runner fleet health — ${repo}`, ""];
+  for (const r of runners) {
+    const svc = runnerSvcName(r);
+    try {
+      const status = await sshRun(
+        `systemctl is-active ${svc} 2>/dev/null && ` +
+        `systemctl show ${svc} --property=SubState --value 2>/dev/null`
+      );
+      lines.push(`✓ ${r}: ${status.trim()}`);
+    } catch {
+      lines.push(`✗ ${r}: offline / not found`);
+    }
+  }
+  return lines.join("\n");
+}
+
+async function runnerFixService(runner: string): Promise<string> {
+  const svc = runnerSvcName(runner);
+  const overrideDir = `/etc/systemd/system/${svc}.d`;
+  const cmd = [
+    `sudo mkdir -p ${overrideDir}`,
+    `sudo tee ${overrideDir}/override.conf > /dev/null << 'EOF'\n` +
+    `[Unit]\nAfter=network-online.target\nWants=network-online.target\n\n` +
+    `[Service]\nRestart=on-failure\nRestartSec=10s\nStartLimitIntervalSec=0\n` +
+    `Environment="RUNNER_RETRY_RENEW_SECONDS=300"\n` +
+    `Environment="DOTNET_SYSTEM_NET_HTTP_USESOCKETSHTTPHANDLER=1"\nEOF`,
+    `sudo mkdir -p /etc/systemd/resolved.conf.d`,
+    `sudo tee /etc/systemd/resolved.conf.d/retry.conf > /dev/null << 'EOF'\n[Resolve]\nDNS=8.8.8.8 8.8.4.4 1.1.1.1\nFallbackDNS=9.9.9.9\nEOF`,
+    `sudo systemctl daemon-reload`,
+    `sudo systemctl restart ${svc}`,
+    `sleep 3 && systemctl is-active ${svc}`,
+  ].join(" && ");
+  const result = await sshRun(cmd, 30_000);
+  return `Runner ${runner} hardened.\n${result}`;
+}
+
+async function runnerRestart(runner: string): Promise<string> {
+  const svc = runnerSvcName(runner);
+  const result = await sshRun(`sudo systemctl restart ${svc} && sleep 3 && systemctl is-active ${svc}`);
+  return `Runner ${runner} restarted: ${result.trim()}`;
+}
+
+// ── MCP server ─────────────────────────────────────────────────────────────────
+
+const server = new McpServer({
+  name: "cloudless-ssh-mcp",
+  version: "0.1.0",
+});
+
+// cluster_run_command — run any shell command on a cluster node via SSH
+server.tool(
+  "cluster_run_command",
+  "Run a shell command on a cluster node (omv-main) via SSH. Returns combined stdout+stderr.",
+  {
+    node: z.string().describe("Target node name (currently only 'omv-main' is supported)"),
+    command: z.string().describe("Shell command to run (executed via bash -c)"),
+    timeout_seconds: z.number().optional().describe("Command timeout in seconds (default: 60)"),
+  },
+  async ({ node: _node, command, timeout_seconds }) => {
+    try {
+      const output = await sshRun(command, (timeout_seconds ?? 60) * 1_000);
+      return { content: [{ type: "text", text: output || "(no output)" }] };
+    } catch (err) {
+      return { content: [{ type: "text", text: `Error: ${String(err)}` }], isError: true };
+    }
+  }
+);
+
+// gh_runner_health — check status of all Pi runners
+server.tool(
+  "gh_runner_health",
+  "Check the health and active state of all Pi self-hosted GitHub Actions runners (omv, omv-2, omv-3).",
+  {
+    repo: z.string().describe("Repository name (e.g. cloudless.gr)"),
+  },
+  async ({ repo }) => {
+    try {
+      const result = await runnerHealth(repo);
+      return { content: [{ type: "text", text: result }] };
+    } catch (err) {
+      return { content: [{ type: "text", text: `Error: ${String(err)}` }], isError: true };
+    }
+  }
+);
+
+// gh_runner_fix_service — apply systemd hardening drop-in to a runner
+server.tool(
+  "gh_runner_fix_service",
+  "Apply systemd hardening to a Pi runner service: removes k3s dependency, adds Restart=on-failure, configures fallback DNS. Idempotent.",
+  {
+    repo: z.string().describe("Repository name (e.g. cloudless.gr)"),
+    runner: z.string().describe("Runner name: omv, omv-2, or omv-3"),
+  },
+  async ({ runner }) => {
+    try {
+      const result = await runnerFixService(runner);
+      return { content: [{ type: "text", text: result }] };
+    } catch (err) {
+      return { content: [{ type: "text", text: `Error: ${String(err)}` }], isError: true };
+    }
+  }
+);
+
+// gh_runner_restart — restart a runner service
+server.tool(
+  "gh_runner_restart",
+  "Restart a Pi GitHub Actions runner systemd service.",
+  {
+    repo: z.string().describe("Repository name (e.g. cloudless.gr)"),
+    runner: z.string().describe("Runner name: omv, omv-2, or omv-3"),
+  },
+  async ({ runner }) => {
+    try {
+      const result = await runnerRestart(runner);
+      return { content: [{ type: "text", text: result }] };
+    } catch (err) {
+      return { content: [{ type: "text", text: `Error: ${String(err)}` }], isError: true };
+    }
+  }
+);
+
+// gh_runner_logs — fetch recent journal logs for a runner
+server.tool(
+  "gh_runner_logs",
+  "Fetch recent systemd journal logs for a Pi GitHub Actions runner.",
+  {
+    repo: z.string().describe("Repository name (e.g. cloudless.gr)"),
+    runner: z.string().describe("Runner name: omv, omv-2, or omv-3"),
+    lines: z.number().optional().describe("Number of log lines (default: 50)"),
+    since: z.string().optional().describe("Time filter e.g. '30 minutes ago'"),
+  },
+  async ({ runner, lines, since }) => {
+    const svc = runnerSvcName(runner);
+    const sinceFlag = since ? `--since="${since}"` : "";
+    const cmd = `sudo journalctl -u ${svc} -n ${lines ?? 50} ${sinceFlag} --no-pager 2>&1`;
+    try {
+      const output = await sshRun(cmd, 15_000);
+      return { content: [{ type: "text", text: output || "(no logs)" }] };
+    } catch (err) {
+      return { content: [{ type: "text", text: `Error: ${String(err)}` }], isError: true };
+    }
+  }
+);
+
+// k3s_get_pods — list pods in a namespace
+server.tool(
+  "k3s_get_pods",
+  "List Kubernetes pods in a namespace via k3s kubectl on omv-main.",
+  {
+    namespace: z.string().optional().describe("Kubernetes namespace (default: cloudless)"),
+  },
+  async ({ namespace }) => {
+    const ns = namespace ?? "cloudless";
+    try {
+      const output = await sshRun(`sudo k3s kubectl get pods -n ${ns} -o wide 2>&1`);
+      return { content: [{ type: "text", text: output || "(no pods)" }] };
+    } catch (err) {
+      return { content: [{ type: "text", text: `Error: ${String(err)}` }], isError: true };
+    }
+  }
+);
+
+// k3s_get_pod_logs — get logs from a pod
+server.tool(
+  "k3s_get_pod_logs",
+  "Get logs from a Kubernetes pod via k3s kubectl on omv-main.",
+  {
+    namespace: z.string().optional().describe("Kubernetes namespace (default: cloudless)"),
+    selector: z.string().optional().describe("Label selector e.g. app=cloudless"),
+    pod: z.string().optional().describe("Exact pod name (alternative to selector)"),
+    tail: z.number().optional().describe("Number of log lines (default: 50)"),
+  },
+  async ({ namespace, selector, pod, tail }) => {
+    const ns = namespace ?? "cloudless";
+    const target = pod ? pod : selector ? `$(sudo k3s kubectl get pod -n ${ns} -l ${selector} -o name | head -1)` : "";
+    if (!target) return { content: [{ type: "text", text: "Provide pod name or selector" }], isError: true };
+    const cmd = `sudo k3s kubectl logs -n ${ns} ${target} --tail=${tail ?? 50} 2>&1`;
+    try {
+      const output = await sshRun(cmd, 15_000);
+      return { content: [{ type: "text", text: output || "(no logs)" }] };
+    } catch (err) {
+      return { content: [{ type: "text", text: `Error: ${String(err)}` }], isError: true };
+    }
+  }
+);
+
+// aws_get_ssm_parameters — read SSM parameter via AWS CLI on omv-main
+server.tool(
+  "aws_get_ssm_parameters",
+  "Read an SSM parameter from AWS (runs aws ssm get-parameter on omv-main using its IAM role).",
+  {
+    parameter_name: z.string().describe("SSM parameter short name (e.g. current-image-sha) or full path"),
+  },
+  async ({ parameter_name }) => {
+    const name = parameter_name.startsWith("/")
+      ? parameter_name
+      : `/cloudless/production/${parameter_name}`;
+    const cmd = `aws ssm get-parameter --name "${name}" --query "Parameter.Value" --output text 2>&1`;
+    try {
+      const output = await sshRun(cmd, 15_000);
+      return { content: [{ type: "text", text: output.trim() }] };
+    } catch (err) {
+      return { content: [{ type: "text", text: `Error: ${String(err)}` }], isError: true };
+    }
+  }
+);
+
+// ── Start ──────────────────────────────────────────────────────────────────────
+
+const transport = new StdioServerTransport();
+await server.connect(transport);

--- a/tools/ssh-mcp/tsconfig.json
+++ b/tools/ssh-mcp/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true
+  },
+  "include": ["src"]
+}


### PR DESCRIPTION
Adds `tools/ssh-mcp/` — a TypeScript MCP server that gives Claude Code SSH-based access to omv-main, mirroring the `mcp__cloudless-infra__*` tool interface so all existing skills work without the full cloudless-infra server.\n\nRegistered in `mcp.json` as `cloudless-infra`. Configure with `OMV_SSH_KEY` pointing to your private key.

---
_Generated by [Claude Code](https://claude.ai/code/session_01HuPxcCB6MrGPDE1HvsFFFH)_