### PR TITLE
ci: add cache-cleanup workflow to prune stale Actions caches

### DIFF
--- a/.github/workflows/cache-cleanup.yml
+++ b/.github/workflows/cache-cleanup.yml
@@ -1,0 +1,85 @@
+name: Cache Cleanup
+
+on:
+  schedule:
+    # Daily at 04:17 UTC — off-peak and off the top-of-hour cron spike.
+    - cron: "17 4 * * *"
+  workflow_dispatch:
+
+permissions:
+  # Actions cache deletion requires actions:write.
+  actions: write
+  contents: read
+
+concurrency:
+  group: cache-cleanup
+  cancel-in-progress: false
+
+jobs:
+  prune:
+    name: Prune stale caches
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Prune PR-scoped + stale buildkit caches
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+
+          pr_cutoff=$(date -u -d '3 days ago' +%Y-%m-%dT%H:%M:%SZ)
+          blob_cutoff=$(date -u -d '7 days ago' +%Y-%m-%dT%H:%M:%SZ)
+
+          total_reclaimed=0
+          total_deleted=0
+
+          delete_cache() {
+            local id="$1" size="$2"
+            if gh api -X DELETE "/repos/${REPO}/actions/caches/${id}" >/dev/null 2>&1; then
+              total_reclaimed=$((total_reclaimed + size))
+              total_deleted=$((total_deleted + 1))
+            fi
+          }
+
+          echo "== PR-scoped caches not used since $pr_cutoff =="
+          while IFS=$'\t' read -r id size key ref; do
+            [[ -z "$id" ]] && continue
+            echo "  $ref :: $key :: $((size / 1024 / 1024)) MB"
+            delete_cache "$id" "$size"
+          done < <(
+            gh api -X GET "/repos/${REPO}/actions/caches" \
+              --paginate \
+              --jq '.actions_caches[]
+                | select(.ref | startswith("refs/pull/"))
+                | select(.last_accessed_at < "'"$pr_cutoff"'")
+                | "\(.id)\t\(.size_in_bytes)\t\(.key)\t\(.ref)"'
+          )
+
+          echo
+          echo "== buildkit blobs not used since $blob_cutoff =="
+          while IFS=$'\t' read -r id size key; do
+            [[ -z "$id" ]] && continue
+            echo "  $key :: $((size / 1024 / 1024)) MB"
+            delete_cache "$id" "$size"
+          done < <(
+            gh api -X GET "/repos/${REPO}/actions/caches" \
+              --paginate \
+              --jq '.actions_caches[]
+                | select(.key | startswith("buildkit-blob-"))
+                | select(.last_accessed_at < "'"$blob_cutoff"'")
+                | "\(.id)\t\(.size_in_bytes)\t\(.key)"'
+          )
+
+          echo
+          echo "== Summary =="
+          echo "Reclaimed $((total_reclaimed / 1024 / 1024)) MB across $total_deleted caches"
+
+          {
+            echo "## Cache Cleanup"
+            echo
+            echo "Reclaimed **$((total_reclaimed / 1024 / 1024)) MB** across **$total_deleted** caches."
+            echo
+            echo "- PR-scoped cutoff: \`$pr_cutoff\`"
+            echo "- buildkit-blob cutoff: \`$blob_cutoff\`"
+          } >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## Summary
- Add `.github/workflows/cache-cleanup.yml` — daily scheduled prune of stale GitHub Actions caches.
- Two passes: PR-scoped caches not used in 3 days, then `buildkit-blob-*` caches not used in 7 days.
- Logs per-cache deletions and writes a totals summary to `$GITHUB_STEP_SUMMARY`.

## Why
The repo's Actions cache hit **9.99 / 10 GB**. Two patterns dominate:
- `node-cache-Linux-arm64-pnpm-…` @ 210 MB is duplicated per ref — main + 5 PR refs = ~1.3 GB even though the cache key is identical (GH stores a copy per scope by design).
- BuildKit layers from `deploy-pi.yml` pile up over weeks; some haven't been touched in days but still count against quota.

With this workflow:
- Closed PRs stop leaving 210 MB ghost caches behind 3+ days after merge.
- Pi image-build layers older than a week get pruned automatically.

## Trigger the immediate cleanup
After merge:
```bash
gh workflow run "Cache Cleanup"
```
or fire from the Actions tab → "Cache Cleanup" → "Run workflow".

## Test plan
- [ ] Merge, then `workflow_dispatch` once → confirm it deletes the existing PR-scoped node-caches (215, 217, 218, 220) and reports the reclaimed MB total.
- [ ] Re-check the cache page in Settings → Actions → Caches: total should drop below ~9 GB.
- [ ] Wait for next scheduled run (04:17 UTC) → confirm green on its own.

---
_Generated by [Claude Code](https://claude.ai/code/session_0191YVKTm8mraSax73M1ToKM)_