### PR TITLE
ci(ops): trigger k3s recovery run [auto-revert follows]

### DIFF
--- a/.github/workflows/k3s-recover.yml
+++ b/.github/workflows/k3s-recover.yml
@@ -12,6 +12,10 @@ name: k3s full recovery (hosted runner)
 
 on:
   workflow_dispatch:
+  push:
+    branches: [main]
+    paths:
+      - '.github/workflows/k3s-recover.yml'
 
 permissions:
   contents: read


### PR DESCRIPTION
Adds a push trigger to k3s-recover.yml so merging this PR fires the recovery workflow immediately on the Pi runners. A follow-up commit will revert the push trigger, leaving only workflow_dispatch.

---
_Generated by [Claude Code](https://claude.ai/code/session_01HuPxcCB6MrGPDE1HvsFFFH)_