### PR TITLE
ci(ops): revert push trigger on k3s-recover

### DIFF
--- a/.github/workflows/k3s-recover.yml
+++ b/.github/workflows/k3s-recover.yml
@@ -12,10 +12,6 @@ name: k3s full recovery (hosted runner)
 
 on:
   workflow_dispatch:
-  push:
-    branches: [main]
-    paths:
-      - '.github/workflows/k3s-recover.yml'
 
 permissions:
   contents: read


### PR DESCRIPTION
Removes the temporary push trigger added to fire the k3s recovery. Workflow is back to workflow_dispatch only.

---
_Generated by [Claude Code](https://claude.ai/code/session_01HuPxcCB6MrGPDE1HvsFFFH)_