### PR TITLE
perf(home): restore revalidate=3600 on [locale] page

### DIFF
--- a/src/app/[locale]/page.tsx
+++ b/src/app/[locale]/page.tsx
@@ -13,11 +13,7 @@ import ClientParticleField from "@/components/ClientParticleField";
 import StatCounter from "@/components/StatCounter";
 import SocialLinks from "@/components/SocialLinks";
 
-// Force-dynamic temporarily — turbopack prerender hits a "cannot read length of undefined"
-// inside framework frames during static generation. Switching to dynamic SSR unblocks the
-// build; revisit once the upstream issue is identified.
-// TODO(perf): restore `export const revalidate = 3600;` once prerender works.
-export const dynamic = "force-dynamic";
+export const revalidate = 3600;
 
 function stepColorClass(color: string): string {
   if (color === "cyan")


### PR DESCRIPTION
## Summary
- Restore `export const revalidate = 3600;` on `src/app/[locale]/page.tsx`.
- Drop the `dynamic = "force-dynamic"` opt-out and the explanatory comment that's no longer accurate.

## Why
The TODO comment said:
> Force-dynamic temporarily — turbopack prerender hits a "cannot read length of undefined" inside framework frames during static generation. Switching to dynamic SSR unblocks the build; revisit once the upstream issue is identified.
> TODO(perf): restore `export const revalidate = 3600;` once prerender works.

On Next 16.2.6 the prerender crash no longer reproduces:
```
$ pnpm next build
…
✓ Compiled successfully
exit 0
```

The page is still reported as `ƒ` (Dynamic) in the build summary because `getServerLocale()` reads cookies under the hood. That means `revalidate` won't promote the route to full ISR/SSG by itself, but it does enable fetch-data caching within the route for one hour, which is the perf goal the original TODO was after.

Promoting the route to true `●` (SSG) would require dropping `getServerLocale()` in favour of the `[locale]` route param + `generateStaticParams`. Out of scope here — separate follow-up.

## Test plan
- [x] `pnpm next build` exits 0, no Turbopack crash, no new warnings.
- [ ] Local: open `/en`, `/el`, `/fr` on the dev server — content renders identically (locale comes from the URL via middleware → next-intl context, same path as before).
- [ ] Post-deploy: check fetch-data observability — repeat requests within the hour should hit cached fetches rather than re-fetching.

---
_Generated by [Claude Code](https://claude.ai/code/session_0191YVKTm8mraSax73M1ToKM)_