### PR TITLE
docs(mcp): cloud session SSH setup instructions + OMV_SSH_KEY_CONTENTS forwarding

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,7 +33,18 @@ When spawning sub-agents, follow these rules for optimal orchestration:
 - Agents return a **single summary message** — raw tool output stays out of the main context.
 - Use `run_in_background: true` only for genuinely independent work that does not block the next step.
 
-## Deployment to Pi (cloudless.online)
+## Cloud Session SSH Setup (one-time)
+
+The `cloudless-infra` MCP server connects to `omv-main` via SSH. In **local** sessions it reads `~/.ssh/id_ed25519` automatically. In **cloud** sessions (code.claude.com) the key file isn't present — supply it as a base64 secret instead:
+
+1. On your local machine: `base64 -w0 ~/.ssh/id_ed25519 | pbcopy`  (Linux: omit `| pbcopy`, copy manually)
+2. In the Claude Code web UI → session settings → **Environment → Secrets** → add:
+   - Name: `OMV_SSH_KEY_CONTENTS`
+   - Value: the base64 string from step 1
+
+Once set, `cluster_run_command`, `gh_runner_health`, `k3s_get_pods` and all other `mcp__cloudless-infra__*` tools become available in every cloud session. The Tailscale IP `100.113.41.119` is already baked into `mcp.json` so no host configuration is needed.
+
+## Deployment to Pi
 
 **Workflow:** `.github/workflows/deploy-pi.yml` — triggers on every push to `main`.
 

--- a/mcp.json
+++ b/mcp.json
@@ -6,7 +6,8 @@
       "env": {
         "OMV_SSH_HOST_TAILSCALE": "100.113.41.119",
         "OMV_SSH_USER": "omv",
-        "OMV_SSH_KEY": "${HOME}/.ssh/id_ed25519"
+        "OMV_SSH_KEY": "${HOME}/.ssh/id_ed25519",
+        "OMV_SSH_KEY_CONTENTS": "${OMV_SSH_KEY_CONTENTS}"
       }
     },
     "project": {


### PR DESCRIPTION
## Summary
- Adds a **Cloud Session SSH Setup** section to `CLAUDE.md` with the exact one-time steps needed to make `mcp__cloudless-infra__*` tools work in cloud sessions (base64-encode the key, add it as `OMV_SSH_KEY_CONTENTS` session secret)
- Explicitly threads `OMV_SSH_KEY_CONTENTS` through the `mcp.json` env block so the MCP server process receives it even if Claude Code's env inheritance doesn't forward it automatically

## After merging
Run this on your local machine once and paste the output as a session secret:
```bash
base64 -w0 ~/.ssh/id_ed25519
```
Secret name: `OMV_SSH_KEY_CONTENTS`

https://claude.ai/code/session_013v8Wcfcsb9ahGTtzaouyn8

---
_Generated by [Claude Code](https://claude.ai/code/session_013v8Wcfcsb9ahGTtzaouyn8)_