### PR TITLE
fix(sonar): replace void ctx.resume() with .catch() — trigger full CI on GH runners

### DIFF
--- a/src/lib/sound-effects.ts
+++ b/src/lib/sound-effects.ts
@@ -37,7 +37,7 @@ function playTone({
     if (!ctx) return;
 
     if (ctx.state === "suspended") {
-      void ctx.resume();
+      ctx.resume().catch(() => {});
     }
 
     const oscillator = ctx.createOscillator();


### PR DESCRIPTION
## Summary

- Fixes SonarCloud S3699 (`sonarjs/void-use`): `void ctx.resume()` in `src/lib/sound-effects.ts` replaced with `ctx.resume().catch(() => {})` per the documented fix pattern in CLAUDE.md.

## CI coverage this PR triggers

Since this touches `src/**`, it fires:
- **CI** (lint, typecheck, build, unit tests) — on ubuntu-latest (GH-hosted) if `RUNNER_GENERIC` is unset
- **MCP security scan**
- On merge → **CodeQL**, **secret-scan**

> **Note for repo admin**: Now that the repo is public, GH-hosted runners are free. If `RUNNER_GENERIC` is currently set to the Pi self-hosted cluster, clear it via:
> ```bash
> .github/scripts/toggle-runner.sh hosted
> ```
> or delete the `RUNNER_GENERIC` variable in GitHub → Settings → Secrets and variables → Actions → Variables.

https://claude.ai/code/session_013v8Wcfcsb9ahGTtzaouyn8

---
_Generated by [Claude Code](https://claude.ai/code/session_013v8Wcfcsb9ahGTtzaouyn8)_