### PR TITLE
ci(runners): add runner-mode workflow — switch GH/Pi runners from GitHub UI

### DIFF
--- a/.github/workflows/runner-mode.yml
+++ b/.github/workflows/runner-mode.yml
@@ -1,0 +1,64 @@
+name: Switch Runner Mode
+
+# UI-accessible alternative to .github/scripts/toggle-runner.sh for
+# sessions where gh CLI is not available (e.g. Claude Code on the web).
+# Runs on ubuntu-latest (hardcoded) so it always uses a GH-hosted runner
+# regardless of the current RUNNER_GENERIC value.
+
+on:
+  workflow_dispatch:
+    inputs:
+      mode:
+        description: "Runner pool for generic CI jobs"
+        required: true
+        type: choice
+        options:
+          - hosted   # ubuntu-latest — free for public repos
+          - pi       # self-hosted Pi build runners
+
+permissions:
+  actions: write
+  contents: read
+
+jobs:
+  switch:
+    name: Switch to ${{ inputs.mode }} runners
+    runs-on: ubuntu-latest
+    steps:
+      - name: Clear RUNNER_GENERIC (→ ubuntu-latest)
+        if: inputs.mode == 'hosted'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh variable delete RUNNER_GENERIC --repo "$GITHUB_REPOSITORY" 2>/dev/null || true
+          echo "RUNNER_GENERIC cleared — workflows will use ubuntu-latest."
+
+      - name: Set RUNNER_GENERIC (→ Pi build runners)
+        if: inputs.mode == 'pi'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh variable set RUNNER_GENERIC \
+            --body '["self-hosted","omv","build"]' \
+            --repo "$GITHUB_REPOSITORY"
+          echo "RUNNER_GENERIC set to [self-hosted, omv, build]."
+
+      - name: Print summary
+        run: |
+          if [ "${{ inputs.mode }}" = "hosted" ]; then
+            {
+              echo "## Runner mode: GitHub-hosted"
+              echo ""
+              echo "**RUNNER_GENERIC** cleared."
+              echo "All instrumented workflows now use \`ubuntu-latest\` (free for public repos)."
+            } >> "$GITHUB_STEP_SUMMARY"
+          else
+            {
+              echo "## Runner mode: Pi self-hosted"
+              echo ""
+              echo "**RUNNER_GENERIC** = \`[\"self-hosted\",\"omv\",\"build\"]\`"
+              echo "All instrumented workflows route to the Pi build runner pool."
+              echo ""
+              echo "> **Reminder:** already-queued jobs are not re-routed — cancel and re-run them."
+            } >> "$GITHUB_STEP_SUMMARY"
+          fi

--- a/docs/runners.md
+++ b/docs/runners.md
@@ -33,6 +33,8 @@ resolves to the array. Both shapes are accepted by `runs-on`.
 
 ## Toggling
 
+**From the terminal** (requires `gh` CLI):
+
 ```bash
 # Show current state + runner inventory
 .github/scripts/toggle-runner.sh status
@@ -43,6 +45,13 @@ resolves to the array. Both shapes are accepted by `runs-on`.
 # Route them back to ubuntu-latest (clears the variable)
 .github/scripts/toggle-runner.sh hosted
 ```
+
+**From GitHub UI** (no `gh` CLI required — useful in cloud sessions):
+
+Actions → **Switch Runner Mode** → Run workflow → choose `hosted` or `pi`.
+
+This runs `.github/workflows/runner-mode.yml`, which uses `GITHUB_TOKEN`
+with `actions: write` to set or clear `RUNNER_GENERIC` directly.
 
 **Already-queued jobs are not re-routed** — cancel and re-run them after
 flipping. New runs pick up the new value immediately.


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/runner-mode.yml`: a `workflow_dispatch` workflow that sets or clears `RUNNER_GENERIC` using `GITHUB_TOKEN` with `actions: write` — no local `gh` CLI needed
- Updates `docs/runners.md` to document the new UI-based toggle path

## How to switch to GH-hosted runners

**GitHub UI:** Actions → **Switch Runner Mode** → Run workflow → select `hosted`

This clears `RUNNER_GENERIC` so all 42 RUNNER_GENERIC-instrumented workflows fall back to `ubuntu-latest` (free for public repos).

## Workflows that stay on Pi regardless

These are hardcoded `[self-hosted, omv, pi]` and cannot run on GH runners:
- `build-pi-image.yml` — native ARM64 Docker build
- `deploy-pi.yml` (build-and-push job) — native ARM64 build
- `k3s-recover.yml`, `k3s-restart.yml` — local k3s cluster access
- `runner-harden.yml` — Pi runner hardening

https://claude.ai/code/session_013v8Wcfcsb9ahGTtzaouyn8

---
_Generated by [Claude Code](https://claude.ai/code/session_013v8Wcfcsb9ahGTtzaouyn8)_