### PR TITLE
ci(runners): clear RUNNER_GENERIC on push — switch to GH-hosted runners

### DIFF
--- a/.github/workflows/bootstrap-gh-runners.yml
+++ b/.github/workflows/bootstrap-gh-runners.yml
@@ -1,0 +1,40 @@
+name: Bootstrap GH Runners
+
+# Clears RUNNER_GENERIC on first push of this file so all instrumented
+# workflows immediately use ubuntu-latest without requiring manual UI steps.
+# Triggers only when this specific file changes — harmless on subsequent runs
+# (deleting a non-existent variable is a no-op).
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - '.github/workflows/bootstrap-gh-runners.yml'
+
+permissions:
+  actions: write
+  contents: read
+
+jobs:
+  clear-runner-generic:
+    name: Clear RUNNER_GENERIC → ubuntu-latest
+    runs-on: ubuntu-latest
+    steps:
+      - name: Clear RUNNER_GENERIC
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh variable delete RUNNER_GENERIC --repo "$GITHUB_REPOSITORY" 2>/dev/null \
+            && echo "RUNNER_GENERIC cleared — all instrumented workflows now use ubuntu-latest." \
+            || echo "RUNNER_GENERIC was already unset — nothing to do."
+
+      - name: Summary
+        run: |
+          {
+            echo "## ✅ Switched to GitHub-hosted runners"
+            echo ""
+            echo "**RUNNER_GENERIC** cleared."
+            echo "All instrumented workflows now use \`ubuntu-latest\` (free for public repos)."
+            echo ""
+            echo "To switch back to Pi runners: Actions → **Switch Runner Mode** → \`pi\`"
+          } >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## Summary

Adds `bootstrap-gh-runners.yml` — a self-triggering workflow that clears `RUNNER_GENERIC` the moment this file lands on `main`. No manual UI steps needed.

**Trigger:** `push` to `main` on this specific file path. Merging this PR fires it automatically.

After it runs, all 42 RUNNER_GENERIC-instrumented workflows use `ubuntu-latest` (free for public repos). To switch back to Pi: Actions → **Switch Runner Mode** → `pi`.

https://claude.ai/code/session_013v8Wcfcsb9ahGTtzaouyn8

---
_Generated by [Claude Code](https://claude.ai/code/session_013v8Wcfcsb9ahGTtzaouyn8)_