### PR TITLE
fix(sha-drift): remove Pi surface — cloudless.online decommissioned

### DIFF
--- a/__tests__/detect-sha-drift.test.ts
+++ b/__tests__/detect-sha-drift.test.ts
@@ -49,46 +49,37 @@ describe("evaluateDrift", () => {
     return {
       expected: FULL_A,
       cloud: FULL_A,
-      pi: FULL_A,
       ssmModifiedAt: OLD,
       ...over,
     };
   }
 
-  it("reports no drift when both surfaces match", () => {
+  it("reports no drift when cloud matches", () => {
     const r = evaluateDrift(snap({}), NOW);
     expect(r.drifted).toBe(false);
     expect(r.surfaces.every((s) => s.matches)).toBe(true);
   });
 
-  it("matches across SHA length variants (12-char Pi, full cloud)", () => {
-    const r = evaluateDrift(snap({ cloud: FULL_A, pi: SHORT_A }), NOW);
+  it("matches across SHA length variants (12-char vs full)", () => {
+    const r = evaluateDrift(snap({ cloud: SHORT_A }), NOW);
     expect(r.drifted).toBe(false);
   });
 
   it("flags drift when cloud reports a different SHA", () => {
-    const r = evaluateDrift(snap({ cloud: FULL_B, pi: FULL_A }), NOW);
+    const r = evaluateDrift(snap({ cloud: FULL_B }), NOW);
     expect(r.drifted).toBe(true);
     expect(r.surfaces.find((s) => s.name === "cloud")?.matches).toBe(false);
-    expect(r.surfaces.find((s) => s.name === "pi")?.matches).toBe(true);
-  });
-
-  it("flags drift when Pi reports a different SHA", () => {
-    const r = evaluateDrift(snap({ cloud: FULL_A, pi: FULL_B }), NOW);
-    expect(r.drifted).toBe(true);
-    expect(r.surfaces.find((s) => s.name === "pi")?.matches).toBe(false);
   });
 
   it("recognises the 'APP_VERSION not wired' fallback", () => {
-    const r = evaluateDrift(snap({ cloud: "0.1.0", pi: "0.1.0" }), NOW);
+    const r = evaluateDrift(snap({ cloud: "0.1.0" }), NOW);
     expect(r.drifted).toBe(true);
     expect(r.surfaces.every((s) => s.reason.includes("APP_VERSION not wired"))).toBe(true);
   });
 
   it("does NOT flag drift inside the grace window (10 min after SSM publish)", () => {
-    // Both surfaces still showing the OLD SHA right after a new publish — expected.
     const r = evaluateDrift(
-      snap({ ssmModifiedAt: RECENT, cloud: FULL_B, pi: FULL_B }),
+      snap({ ssmModifiedAt: RECENT, cloud: FULL_B }),
       NOW,
     );
     expect(r.withinGrace).toBe(true);
@@ -97,15 +88,15 @@ describe("evaluateDrift", () => {
 
   it("flags drift outside the grace window even with the same situation", () => {
     const r = evaluateDrift(
-      snap({ ssmModifiedAt: OLD, cloud: FULL_B, pi: FULL_B }),
+      snap({ ssmModifiedAt: OLD, cloud: FULL_B }),
       NOW,
     );
     expect(r.withinGrace).toBe(false);
     expect(r.drifted).toBe(true);
   });
 
-  it("flags 'endpoint unreachable' when a surface returns null", () => {
-    const r = evaluateDrift(snap({ cloud: null, pi: FULL_A }), NOW);
+  it("flags 'endpoint unreachable' when cloud returns null", () => {
+    const r = evaluateDrift(snap({ cloud: null }), NOW);
     expect(r.drifted).toBe(true);
     expect(r.surfaces.find((s) => s.name === "cloud")?.reason).toContain("unreachable");
   });

--- a/scripts/detect-sha-drift.mts
+++ b/scripts/detect-sha-drift.mts
@@ -1,14 +1,14 @@
 /**
  * SHA drift detector — compares the source-of-truth deploy SHA in SSM
- * against the SHA each surface (cloud cloudless.gr, Pi cloudless.online)
- * actually reports via /api/health → version field.
+ * against the SHA the cloud surface (cloudless.gr) actually reports via
+ * /api/health → version field.
  *
  * Run:
  *   pnpm tsx scripts/detect-sha-drift.mts
  *   pnpm tsx scripts/detect-sha-drift.mts --json   # machine-readable
  *
  * Exit:
- *   0 — all surfaces agree (or grace window applies)
+ *   0 — cloud surface agrees (or grace window applies)
  *   1 — drift detected outside the grace window
  *   2 — could not read SSM (no AWS creds, network, etc.)
  *
@@ -35,11 +35,10 @@ import { request as httpsRequest } from "node:https";
 interface DriftSnapshot {
   expected: string;
   cloud: string | null;
-  pi: string | null;
   ssmModifiedAt: Date | null;
 }
 interface SurfaceStatus {
-  name: "cloud" | "pi";
+  name: "cloud";
   actual: string | null;
   matches: boolean;
   reason: string;
@@ -60,7 +59,7 @@ function shaEquivalent(a: string | null, b: string | null): boolean {
 }
 
 function classifySurface(
-  name: "cloud" | "pi",
+  name: "cloud",
   expected: string,
   actual: string | null,
 ): SurfaceStatus {
@@ -84,7 +83,6 @@ function evaluateDrift(
   const withinGrace = ageMs !== null && ageMs < GRACE_WINDOW_MS;
   const surfaces: SurfaceStatus[] = [
     classifySurface("cloud", snapshot.expected, snapshot.cloud),
-    classifySurface("pi", snapshot.expected, snapshot.pi),
   ];
   const anyMismatch = surfaces.some((s) => !s.matches);
   const drifted = anyMismatch && !withinGrace;
@@ -97,19 +95,12 @@ function evaluateDrift(
 
 const HEALTH_URLS = {
   cloud: "https://cloudless.gr/api/health",
-  pi: "https://cloudless.online/api/health",
 } as const;
 const SSM_PARAM = "/cloudless/production/current-image-sha";
 const REGION = process.env.AWS_REGION ?? "us-east-1";
 
 function fetchJson(url: string): Promise<Record<string, unknown> | null> {
   return new Promise((resolve) => {
-    // Happy Eyeballs (RFC 8305): if the host is dual-stack but the runner
-    // can't connect over IPv6 (GitHub Actions runners are IPv4-only by
-    // default), fall through to IPv4 after 250 ms instead of hanging the
-    // full 10 s timeout. cloudless.online's APIGW alias publishes both
-    // A and AAAA — without this, every CI run trips the IPv6 path and
-    // reports the Pi as unreachable.
     const req = httpsRequest(
       url,
       {
@@ -154,17 +145,15 @@ async function readSsm(): Promise<{ value: string; modifiedAt: Date } | null> {
 }
 
 async function snapshot(): Promise<DriftSnapshot | null> {
-  const [ssm, cloudJson, piJson] = await Promise.all([
+  const [ssm, cloudJson] = await Promise.all([
     readSsm(),
     fetchJson(HEALTH_URLS.cloud),
-    fetchJson(HEALTH_URLS.pi),
   ]);
   if (!ssm) return null;
   return {
     expected: ssm.value,
     ssmModifiedAt: ssm.modifiedAt,
     cloud: typeof cloudJson?.version === "string" ? cloudJson.version : null,
-    pi: typeof piJson?.version === "string" ? piJson.version : null,
   };
 }
 

--- a/src/lib/sha-drift.ts
+++ b/src/lib/sha-drift.ts
@@ -11,14 +11,12 @@ export interface DriftSnapshot {
   expected: string;
   /** cloudless.gr/api/health.version, or null if unreachable. */
   cloud: string | null;
-  /** Pi cluster /api/health.version, or null if unreachable. */
-  pi: string | null;
   /** When SSM was last updated; null if unknown. */
   ssmModifiedAt: Date | null;
 }
 
 export interface SurfaceStatus {
-  name: "cloud" | "pi";
+  name: "cloud";
   actual: string | null;
   matches: boolean;
   reason: string;
@@ -32,9 +30,9 @@ export interface DriftReport {
 }
 
 /**
- * Newly published SSM SHA needs this long for both surfaces to converge
- * (Lambda cold start + Pi K3s rolling update). Drift inside this window
- * is normal mid-rollout and should not page.
+ * Newly published SSM SHA needs this long for the cloud surface to converge
+ * (Lambda cold start). Drift inside this window is normal mid-rollout and
+ * should not page.
  */
 export const GRACE_WINDOW_MS = 10 * 60 * 1000;
 
@@ -53,7 +51,7 @@ export function shaEquivalent(a: string | null, b: string | null): boolean {
 }
 
 function classifySurface(
-  name: "cloud" | "pi",
+  name: "cloud",
   expected: string,
   actual: string | null,
 ): SurfaceStatus {
@@ -82,7 +80,6 @@ export function evaluateDrift(
 
   const surfaces: SurfaceStatus[] = [
     classifySurface("cloud", snapshot.expected, snapshot.cloud),
-    classifySurface("pi", snapshot.expected, snapshot.pi),
   ];
 
   const anyMismatch = surfaces.some((s) => !s.matches);


### PR DESCRIPTION
## Summary

- **Root cause**: SHA drift detector permanently failing because it checks `https://cloudless.online/api/health` for the Pi surface, but that domain was removed in PR #234 (`chore: remove all cloudless.online references`)
- Removes `pi` field from `DriftSnapshot`, `SurfaceStatus.name`, `evaluateDrift`, `snapshot()`, and `HEALTH_URLS` — detector now watches only the `cloud` (cloudless.gr) surface
- Inline parity between `src/lib/sha-drift.ts` and `scripts/detect-sha-drift.mts` maintained (parity test will verify)
- Pi rollout correctness is enforced by the `deploy-pi` workflow itself, not the drift detector

## Test plan
- [x] Unit tests updated to drop Pi-specific cases (`snap()` no longer includes `pi`, removed "flags drift when Pi reports a different SHA" test)
- [x] Parity test (`sha-drift-inline-parity.test.ts`) unchanged — auto-verifies lib/script sync
- [x] All existing grace-window, ageMs, and cloud-surface tests preserved

Generated with Claude Code