### PR TITLE
fix(ci): drop sudo from pnpm store pin — use $HOME path

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,9 +49,8 @@ jobs:
           dest: ~/setup-pnpm-${{ runner.name }}
       - name: pin pnpm store to persistent local path
         run: |
-          sudo mkdir -p /opt/pnpm-store
-          sudo chmod 777 /opt/pnpm-store
-          pnpm config set store-dir /opt/pnpm-store
+          mkdir -p "$HOME/.pnpm-store"
+          pnpm config set store-dir "$HOME/.pnpm-store"
       - uses: actions/setup-node@v4
         with:
           node-version: 22
@@ -71,9 +70,8 @@ jobs:
           dest: ~/setup-pnpm-${{ runner.name }}
       - name: pin pnpm store to persistent local path
         run: |
-          sudo mkdir -p /opt/pnpm-store
-          sudo chmod 777 /opt/pnpm-store
-          pnpm config set store-dir /opt/pnpm-store
+          mkdir -p "$HOME/.pnpm-store"
+          pnpm config set store-dir "$HOME/.pnpm-store"
       - uses: actions/setup-node@v4
         with:
           node-version: 22
@@ -102,9 +100,8 @@ jobs:
           dest: ~/setup-pnpm-${{ runner.name }}
       - name: pin pnpm store to persistent local path
         run: |
-          sudo mkdir -p /opt/pnpm-store
-          sudo chmod 777 /opt/pnpm-store
-          pnpm config set store-dir /opt/pnpm-store
+          mkdir -p "$HOME/.pnpm-store"
+          pnpm config set store-dir "$HOME/.pnpm-store"
       - uses: actions/setup-node@v4
         with:
           node-version: 22
@@ -123,9 +120,8 @@ jobs:
           dest: ~/setup-pnpm-${{ runner.name }}
       - name: pin pnpm store to persistent local path
         run: |
-          sudo mkdir -p /opt/pnpm-store
-          sudo chmod 777 /opt/pnpm-store
-          pnpm config set store-dir /opt/pnpm-store
+          mkdir -p "$HOME/.pnpm-store"
+          pnpm config set store-dir "$HOME/.pnpm-store"
       - uses: actions/setup-node@v4
         with:
           node-version: 22


### PR DESCRIPTION
## Summary

- `sudo mkdir -p /opt/pnpm-store` was failing on Pi runners that don't have passwordless sudo
- Replaced with `mkdir -p "$HOME/.pnpm-store"` — no elevated permissions needed
- Fixes Build, Type Check, Lint & Format, and Unit Tests jobs that were all blocked on this step

## Test plan

- [ ] Build check passes on Pi runner
- [ ] Type Check passes on Pi runner

🤖 Generated with [Claude Code](https://claude.com/claude-code)