### PR TITLE
fix: prettier format all src files + fix slack webhook retry

### DIFF
--- a/scripts/detect-sha-drift.mts
+++ b/scripts/detect-sha-drift.mts
@@ -58,32 +58,20 @@ function shaEquivalent(a: string | null, b: string | null): boolean {
   return lo.startsWith(hi) || hi.startsWith(lo);
 }
 
-function classifySurface(
-  name: "cloud",
-  expected: string,
-  actual: string | null,
-): SurfaceStatus {
+function classifySurface(name: "cloud", expected: string, actual: string | null): SurfaceStatus {
   const matches = shaEquivalent(expected, actual);
   let reason = "matches expected";
   if (actual === null) reason = "endpoint unreachable or no version field";
   else if (actual === "0.1.0" || actual === "dev") {
-    reason =
-      "APP_VERSION not wired to deploy SHA — surface still serves the static fallback";
+    reason = "APP_VERSION not wired to deploy SHA — surface still serves the static fallback";
   } else if (!matches) reason = "SHA differs from SSM source of truth";
   return { name, actual, matches, reason };
 }
 
-function evaluateDrift(
-  snapshot: DriftSnapshot,
-  now: number = Date.now(),
-): DriftReport {
-  const ageMs = snapshot.ssmModifiedAt
-    ? now - snapshot.ssmModifiedAt.getTime()
-    : null;
+function evaluateDrift(snapshot: DriftSnapshot, now: number = Date.now()): DriftReport {
+  const ageMs = snapshot.ssmModifiedAt ? now - snapshot.ssmModifiedAt.getTime() : null;
   const withinGrace = ageMs !== null && ageMs < GRACE_WINDOW_MS;
-  const surfaces: SurfaceStatus[] = [
-    classifySurface("cloud", snapshot.expected, snapshot.cloud),
-  ];
+  const surfaces: SurfaceStatus[] = [classifySurface("cloud", snapshot.expected, snapshot.cloud)];
   const anyMismatch = surfaces.some((s) => !s.matches);
   const drifted = anyMismatch && !withinGrace;
   return { drifted, ageMs, withinGrace, surfaces };
@@ -110,16 +98,17 @@ function fetchJson(url: string): Promise<Record<string, unknown> | null> {
         autoSelectFamilyAttemptTimeout: 250,
       },
       (res) => {
-      const chunks: Buffer[] = [];
-      res.on("data", (c: Buffer) => chunks.push(c));
-      res.on("end", () => {
-        try {
-          resolve(JSON.parse(Buffer.concat(chunks).toString("utf-8")));
-        } catch {
-          resolve(null);
-        }
-      });
-    });
+        const chunks: Buffer[] = [];
+        res.on("data", (c: Buffer) => chunks.push(c));
+        res.on("end", () => {
+          try {
+            resolve(JSON.parse(Buffer.concat(chunks).toString("utf-8")));
+          } catch {
+            resolve(null);
+          }
+        });
+      }
+    );
     req.on("error", () => resolve(null));
     req.on("timeout", () => {
       req.destroy();
@@ -145,10 +134,7 @@ async function readSsm(): Promise<{ value: string; modifiedAt: Date } | null> {
 }
 
 async function snapshot(): Promise<DriftSnapshot | null> {
-  const [ssm, cloudJson] = await Promise.all([
-    readSsm(),
-    fetchJson(HEALTH_URLS.cloud),
-  ]);
+  const [ssm, cloudJson] = await Promise.all([readSsm(), fetchJson(HEALTH_URLS.cloud)]);
   if (!ssm) return null;
   return {
     expected: ssm.value,
@@ -169,9 +155,7 @@ if (wantJson) {
   console.log(JSON.stringify({ snapshot: snap, report }, null, 2));
 } else {
   console.log(`\nSHA drift report — expected: ${snap.expected.slice(0, 12)}…`);
-  console.log(
-    `  age: ${report.ageMs !== null ? `${Math.round(report.ageMs / 60_000)}m` : "?"}`,
-  );
+  console.log(`  age: ${report.ageMs !== null ? `${Math.round(report.ageMs / 60_000)}m` : "?"}`);
   console.log(`  within grace: ${report.withinGrace ? "yes" : "no"}`);
   for (const s of report.surfaces) {
     const mark = s.matches ? "✓" : "✗";

--- a/src/app/[locale]/admin/AdminLayoutClient.tsx
+++ b/src/app/[locale]/admin/AdminLayoutClient.tsx
@@ -132,7 +132,7 @@ function NavList({
     <nav className="space-y-4">
       {adminGroups.map((group) => (
         <div key={group.label}>
-          <p className="px-3 pb-1.5 font-mono text-[10px] uppercase tracking-widest text-slate-600">
+          <p className="px-3 pb-1.5 font-mono text-[10px] tracking-widest text-slate-600 uppercase">
             {group.label}
           </p>
           <div className="space-y-0.5">
@@ -144,27 +144,13 @@ function NavList({
                   : "text-slate-400 hover:bg-void-lighter/50 hover:text-white"
               }`;
               return external ? (
-                <a
-                  key={href}
-                  href={href}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className={cls}
-                >
+                <a key={href} href={href} target="_blank" rel="noopener noreferrer" className={cls}>
                   <Icon size={15} className="shrink-0" />
                   {label}
-                  <ExternalLink
-                    size={11}
-                    className="ml-auto shrink-0 opacity-40"
-                  />
+                  <ExternalLink size={11} className="ml-auto shrink-0 opacity-40" />
                 </a>
               ) : (
-                <Link
-                  key={href}
-                  href={href}
-                  onClick={onLinkClick}
-                  className={cls}
-                >
+                <Link key={href} href={href} onClick={onLinkClick} className={cls}>
                   <Icon size={15} className="shrink-0" />
                   {label}
                 </Link>
@@ -177,11 +163,7 @@ function NavList({
   );
 }
 
-export default function AdminLayoutClient({
-  children,
-}: {
-  readonly children: React.ReactNode;
-}) {
+export default function AdminLayoutClient({ children }: { readonly children: React.ReactNode }) {
   const { user, isAdmin, isLoading } = useAuth();
   const router = useRouter();
   const pathname = usePathname();
@@ -212,9 +194,7 @@ export default function AdminLayoutClient({
 
   const isActive = (href: string) => {
     if (href === "/admin")
-      return (
-        pathname === "/admin" || Boolean(pathname?.match(/^\/[a-z]{2}\/admin$/))
-      );
+      return pathname === "/admin" || Boolean(pathname?.match(/^\/[a-z]{2}\/admin$/));
     const path = (pathname ?? "").replace(/^\/[a-z]{2}(?=\/)/, "");
     return path === href;
   };
@@ -227,9 +207,7 @@ export default function AdminLayoutClient({
           <div className="mx-auto flex max-w-7xl items-center justify-between gap-2 px-4 py-2 sm:px-6 lg:px-8">
             <div className="flex items-center gap-2">
               <span className="bg-neon-magenta h-2 w-2 animate-pulse rounded-full" />
-              <span className="text-neon-magenta font-mono text-xs">
-                ADMIN PANEL
-              </span>
+              <span className="text-neon-magenta font-mono text-xs">ADMIN PANEL</span>
             </div>
             {/* Mobile hamburger */}
             <button
@@ -239,13 +217,7 @@ export default function AdminLayoutClient({
               onClick={() => setDrawerOpen(true)}
               className="text-neon-magenta p-1 lg:hidden"
             >
-              <svg
-                width="20"
-                height="20"
-                fill="none"
-                stroke="currentColor"
-                strokeWidth="2"
-              >
+              <svg width="20" height="20" fill="none" stroke="currentColor" strokeWidth="2">
                 <path d="M3 5h14M3 10h14M3 15h14" />
               </svg>
             </button>
@@ -279,13 +251,7 @@ export default function AdminLayoutClient({
               onClick={() => setDrawerOpen(false)}
               className="p-1 text-slate-400 hover:text-white"
             >
-              <svg
-                width="18"
-                height="18"
-                fill="none"
-                stroke="currentColor"
-                strokeWidth="2"
-              >
+              <svg width="18" height="18" fill="none" stroke="currentColor" strokeWidth="2">
                 <path d="M4 4l10 10M14 4L4 14" />
               </svg>
             </button>
@@ -293,18 +259,13 @@ export default function AdminLayoutClient({
 
           {/* Workspace switcher at top */}
           <div className="border-b border-slate-800 px-4 py-3">
-            <p className="mb-1 font-mono text-xs text-slate-500">
-              {user.email || user.username}
-            </p>
+            <p className="mb-1 font-mono text-xs text-slate-500">{user.email || user.username}</p>
             <WorkspaceSwitcher />
           </div>
 
           {/* Scrollable nav */}
           <div className="flex-1 overflow-y-auto px-3 py-4">
-            <NavList
-              isActive={isActive}
-              onLinkClick={() => setDrawerOpen(false)}
-            />
+            <NavList isActive={isActive} onLinkClick={() => setDrawerOpen(false)} />
           </div>
         </div>
 

--- a/src/app/[locale]/admin/ab-tests/page.tsx
+++ b/src/app/[locale]/admin/ab-tests/page.tsx
@@ -75,9 +75,7 @@ export default function ABTestsPage() {
   }
 
   function setTrafficSplit(id: string, value: number) {
-    setFlags((prev) =>
-      prev.map((f) => (f.id === id ? { ...f, trafficSplit: value } : f)),
-    );
+    setFlags((prev) => prev.map((f) => (f.id === id ? { ...f, trafficSplit: value } : f)));
   }
 
   async function resetAll() {
@@ -107,13 +105,9 @@ export default function ABTestsPage() {
         <div>
           <div className="bg-neon-yellow/10 border-neon-yellow/20 mb-4 inline-flex items-center gap-2 rounded-full border px-3 py-1.5">
             <span className="bg-neon-yellow h-2 w-2 animate-pulse rounded-full" />
-            <span className="text-neon-yellow font-mono text-xs">
-              A/B TESTS
-            </span>
+            <span className="text-neon-yellow font-mono text-xs">A/B TESTS</span>
           </div>
-          <h1 className="font-heading text-2xl font-bold text-white">
-            A/B Test Manager
-          </h1>
+          <h1 className="font-heading text-2xl font-bold text-white">A/B Test Manager</h1>
           <p className="font-body mt-1 text-slate-400">
             Toggle feature flags and traffic splits for live experiments.
           </p>
@@ -141,19 +135,15 @@ export default function ABTestsPage() {
       {/* Summary */}
       <div className="mb-6 grid grid-cols-3 gap-3">
         <div className="bg-void-light/50 rounded-xl border border-slate-800 px-4 py-3">
-          <div className="font-mono text-xl font-bold text-white">
-            {flags.length}
-          </div>
+          <div className="font-mono text-xl font-bold text-white">{flags.length}</div>
           <div className="font-mono text-xs text-slate-500">Total flags</div>
         </div>
         <div className="bg-void-light/50 rounded-xl border border-slate-800 px-4 py-3">
-          <div className="text-neon-green font-mono text-xl font-bold">
-            {activeCount}
-          </div>
+          <div className="text-neon-green font-mono text-xl font-bold">{activeCount}</div>
           <div className="font-mono text-xs text-slate-500">Active tests</div>
         </div>
         <div className="bg-void-light/50 rounded-xl border border-slate-800 px-4 py-3">
-          <div className="text-slate-400 font-mono text-xl font-bold">
+          <div className="font-mono text-xl font-bold text-slate-400">
             {flags.length - activeCount}
           </div>
           <div className="font-mono text-xs text-slate-500">Inactive</div>
@@ -185,41 +175,28 @@ export default function ABTestsPage() {
 
       <div className="space-y-3">
         {flags.map((flag) => (
-          <div
-            key={flag.id}
-            className="bg-void-light/50 rounded-xl border border-slate-800 p-5"
-          >
+          <div key={flag.id} className="bg-void-light/50 rounded-xl border border-slate-800 p-5">
             <div className="flex items-start justify-between gap-4">
               <div className="min-w-0 flex-1">
                 <div className="flex items-center gap-3">
-                  <span className="font-heading font-semibold text-white">
-                    {flag.name}
-                  </span>
+                  <span className="font-heading font-semibold text-white">{flag.name}</span>
                   <span
                     className={`font-mono text-xs ${flag.enabled ? "text-neon-green" : "text-slate-600"}`}
                   >
                     {flag.enabled ? "LIVE" : "OFF"}
                   </span>
                 </div>
-                <p className="font-body mt-1 text-sm text-slate-400">
-                  {flag.description}
-                </p>
+                <p className="font-body mt-1 text-sm text-slate-400">{flag.description}</p>
                 <div className="mt-3 flex flex-wrap gap-3">
                   <div className="rounded-lg border border-slate-700 px-3 py-1.5">
-                    <div className="font-mono text-xs text-slate-500">
-                      Variant A
-                    </div>
-                    <div className="font-mono text-xs text-white">
-                      {flag.variants.a}
-                    </div>
+                    <div className="font-mono text-xs text-slate-500">Variant A</div>
+                    <div className="font-mono text-xs text-white">{flag.variants.a}</div>
                   </div>
-                  <div className="rounded-lg border border-neon-yellow/20 bg-neon-yellow/5 px-3 py-1.5">
-                    <div className="font-mono text-xs text-neon-yellow">
+                  <div className="border-neon-yellow/20 bg-neon-yellow/5 rounded-lg border px-3 py-1.5">
+                    <div className="text-neon-yellow font-mono text-xs">
                       Variant B ({flag.trafficSplit}% traffic)
                     </div>
-                    <div className="font-mono text-xs text-white">
-                      {flag.variants.b}
-                    </div>
+                    <div className="font-mono text-xs text-white">{flag.variants.b}</div>
                   </div>
                 </div>
               </div>
@@ -229,16 +206,14 @@ export default function ABTestsPage() {
                   onChange={(v) => updateFlag(flag.id, { enabled: v })}
                 />
                 {saving === flag.id && (
-                  <span className="font-mono text-xs text-slate-500">
-                    Saving…
-                  </span>
+                  <span className="font-mono text-xs text-slate-500">Saving…</span>
                 )}
               </div>
             </div>
 
             {/* Traffic split slider */}
             <div className="mt-4 flex items-center gap-3">
-              <span className="font-mono text-xs text-slate-500 w-16">
+              <span className="w-16 font-mono text-xs text-slate-500">
                 Split: {flag.trafficSplit}%
               </span>
               <input
@@ -247,17 +222,15 @@ export default function ABTestsPage() {
                 max={100}
                 step={5}
                 value={flag.trafficSplit}
-                onChange={(e) =>
-                  setTrafficSplit(flag.id, Number(e.target.value))
-                }
+                onChange={(e) => setTrafficSplit(flag.id, Number(e.target.value))}
                 onMouseUp={(e) =>
                   updateFlag(flag.id, {
                     trafficSplit: Number((e.target as HTMLInputElement).value),
                   })
                 }
-                className="flex-1 accent-neon-yellow h-1.5 cursor-pointer rounded-full"
+                className="accent-neon-yellow h-1.5 flex-1 cursor-pointer rounded-full"
               />
-              <span className="font-mono text-xs text-slate-500 w-16 text-right">
+              <span className="w-16 text-right font-mono text-xs text-slate-500">
                 B: {flag.trafficSplit}%
               </span>
             </div>

--- a/src/app/[locale]/admin/ai-assistant/page.tsx
+++ b/src/app/[locale]/admin/ai-assistant/page.tsx
@@ -19,9 +19,7 @@ export default function AIAssistantPage() {
   const [brief, setBrief] = useState("");
   const [budget, setBudget] = useState("");
   const [targetAudience, setTargetAudience] = useState("");
-  const [strategy, setStrategy] = useState<Record<string, unknown> | null>(
-    null,
-  );
+  const [strategy, setStrategy] = useState<Record<string, unknown> | null>(null);
 
   // Copy
   const [service, setService] = useState("");
@@ -88,13 +86,9 @@ export default function AIAssistantPage() {
       <div className="mb-8">
         <div className="border-neon-magenta/20 bg-neon-magenta/10 mb-4 inline-flex items-center gap-2 rounded-full border px-3 py-1.5">
           <span className="bg-neon-magenta h-2 w-2 animate-pulse rounded-full" />
-          <span className="text-neon-magenta font-mono text-xs">
-            AI ASSISTANT
-          </span>
+          <span className="text-neon-magenta font-mono text-xs">AI ASSISTANT</span>
         </div>
-        <h1 className="font-heading text-2xl font-bold text-white">
-          AI Campaign Assistant
-        </h1>
+        <h1 className="font-heading text-2xl font-bold text-white">AI Campaign Assistant</h1>
         <p className="font-body mt-1 text-slate-400">
           Generate campaign strategies and ad copy with Claude AI.
         </p>
@@ -132,9 +126,7 @@ export default function AIAssistantPage() {
             onSubmit={generateStrategy}
             className="bg-void-light/50 space-y-4 rounded-xl border border-slate-800 p-6"
           >
-            <h2 className="font-mono text-sm font-semibold text-white">
-              Campaign Brief
-            </h2>
+            <h2 className="font-mono text-sm font-semibold text-white">Campaign Brief</h2>
             <div>
               <label htmlFor="brief" className="mb-1 block font-mono text-xs text-slate-400">
                 What do you want to promote?
@@ -163,7 +155,10 @@ export default function AIAssistantPage() {
                 />
               </div>
               <div>
-                <label htmlFor="targetAudience" className="mb-1 block font-mono text-xs text-slate-400">
+                <label
+                  htmlFor="targetAudience"
+                  className="mb-1 block font-mono text-xs text-slate-400"
+                >
                   Target Audience
                 </label>
                 <input
@@ -186,9 +181,7 @@ export default function AIAssistantPage() {
 
           {strategy && (
             <div className="bg-void-light/50 rounded-xl border border-slate-800 p-6">
-              <h2 className="mb-4 font-mono text-sm font-semibold text-white">
-                Strategy
-              </h2>
+              <h2 className="mb-4 font-mono text-sm font-semibold text-white">Strategy</h2>
               <StrategyDisplay strategy={strategy} />
             </div>
           )}
@@ -201,9 +194,7 @@ export default function AIAssistantPage() {
             onSubmit={generateCopy}
             className="bg-void-light/50 space-y-4 rounded-xl border border-slate-800 p-6"
           >
-            <h2 className="font-mono text-sm font-semibold text-white">
-              Ad Copy Brief
-            </h2>
+            <h2 className="font-mono text-sm font-semibold text-white">Ad Copy Brief</h2>
             <div>
               <label htmlFor="service" className="mb-1 block font-mono text-xs text-slate-400">
                 Service / Product
@@ -245,17 +236,13 @@ export default function AIAssistantPage() {
                   onChange={(e) => setObjective(e.target.value)}
                   className="w-full rounded-lg border border-slate-700 bg-slate-900 px-3 py-2 font-mono text-sm text-white focus:outline-none"
                 >
-                  {[
-                    "awareness",
-                    "lead_generation",
-                    "conversions",
-                    "traffic",
-                    "engagement",
-                  ].map((o) => (
-                    <option key={o} value={o}>
-                      {o.replace("_", " ")}
-                    </option>
-                  ))}
+                  {["awareness", "lead_generation", "conversions", "traffic", "engagement"].map(
+                    (o) => (
+                      <option key={o} value={o}>
+                        {o.replace("_", " ")}
+                      </option>
+                    )
+                  )}
                 </select>
               </div>
             </div>
@@ -291,9 +278,7 @@ export default function AIAssistantPage() {
                   className="bg-void-light/50 rounded-xl border border-slate-800 p-4"
                 >
                   <div className="mb-2 flex items-center justify-between">
-                    <span className="font-mono text-xs text-slate-500">
-                      Variant {i + 1}
-                    </span>
+                    <span className="font-mono text-xs text-slate-500">Variant {i + 1}</span>
                     <span className="rounded-full border border-slate-700 px-2 py-0.5 font-mono text-[10px] text-slate-400">
                       {v.tone}
                     </span>
@@ -304,9 +289,7 @@ export default function AIAssistantPage() {
                     </p>
                   )}
                   <p className="font-mono text-xs text-slate-300">{v.body}</p>
-                  <p className="mt-2 font-mono text-xs font-bold text-white">
-                    {v.cta}
-                  </p>
+                  <p className="mt-2 font-mono text-xs font-bold text-white">{v.cta}</p>
                 </div>
               ))}
             </div>
@@ -320,7 +303,7 @@ export default function AIAssistantPage() {
 function StrategyDisplay({ strategy }: { readonly strategy: Record<string, unknown> }) {
   if (strategy.raw !== undefined && strategy.raw !== null) {
     return (
-      <pre className="whitespace-pre-wrap font-mono text-xs text-slate-300">
+      <pre className="font-mono text-xs whitespace-pre-wrap text-slate-300">
         {typeof strategy.raw === "string" ? strategy.raw : JSON.stringify(strategy.raw, null, 2)}
       </pre>
     );
@@ -340,9 +323,7 @@ function StrategyDisplay({ strategy }: { readonly strategy: Record<string, unkno
     <div className="space-y-4">
       {platforms.length > 0 && (
         <div>
-          <p className="mb-2 font-mono text-xs text-slate-500">
-            Recommended Platforms
-          </p>
+          <p className="mb-2 font-mono text-xs text-slate-500">Recommended Platforms</p>
           <div className="flex flex-wrap gap-2">
             {platforms.map((p) => (
               <span
@@ -358,9 +339,7 @@ function StrategyDisplay({ strategy }: { readonly strategy: Record<string, unkno
       {Boolean(strategy.campaign_objective) && (
         <div>
           <p className="mb-1 font-mono text-xs text-slate-500">Objective</p>
-          <p className="font-mono text-sm text-white">
-            {String(strategy.campaign_objective)}
-          </p>
+          <p className="font-mono text-sm text-white">{String(strategy.campaign_objective)}</p>
         </div>
       )}
       {Object.keys(budgetSplit).length > 0 && (
@@ -369,9 +348,7 @@ function StrategyDisplay({ strategy }: { readonly strategy: Record<string, unkno
           <div className="space-y-1">
             {Object.entries(budgetSplit).map(([p, pct]) => (
               <div key={p} className="flex items-center gap-3">
-                <span className="w-24 font-mono text-xs text-slate-400">
-                  {p}
-                </span>
+                <span className="w-24 font-mono text-xs text-slate-400">{p}</span>
                 <div className="h-1.5 flex-1 rounded-full bg-slate-800">
                   <div
                     className="bg-neon-magenta h-1.5 rounded-full"
@@ -387,18 +364,14 @@ function StrategyDisplay({ strategy }: { readonly strategy: Record<string, unkno
       {Boolean(strategy.timeline) && (
         <div>
           <p className="mb-1 font-mono text-xs text-slate-500">Timeline</p>
-          <p className="font-mono text-xs text-white">
-            {String(strategy.timeline)}
-          </p>
+          <p className="font-mono text-xs text-white">{String(strategy.timeline)}</p>
         </div>
       )}
       {copySuggestions?.headline && (
         <div>
-          <p className="mb-2 font-mono text-xs text-slate-500">
-            Headline Suggestions
-          </p>
+          <p className="mb-2 font-mono text-xs text-slate-500">Headline Suggestions</p>
           <ul className="space-y-1">
-              {copySuggestions.headline.map((h, i) => (
+            {copySuggestions.headline.map((h, i) => (
               <li key={`headline-${i}`} className="font-mono text-xs text-slate-300">
                 {i + 1}. {h}
               </li>

--- a/src/app/[locale]/admin/analytics/page.tsx
+++ b/src/app/[locale]/admin/analytics/page.tsx
@@ -85,11 +85,7 @@ function StatCard({
   return (
     <div className="bg-void-light/50 rounded-xl border border-slate-800 p-4">
       <p className="font-mono text-[10px] text-slate-500">{label}</p>
-      <p
-        className={`font-heading mt-1 text-xl font-bold ${accent ?? "text-white"}`}
-      >
-        {value}
-      </p>
+      <p className={`font-heading mt-1 text-xl font-bold ${accent ?? "text-white"}`}>{value}</p>
     </div>
   );
 }
@@ -214,22 +210,21 @@ function OverviewTab({
 
       {web && (
         <div>
-          <p className="mb-3 font-mono text-xs text-slate-500">
-            Organic search summary
-          </p>
+          <p className="mb-3 font-mono text-xs text-slate-500">Organic search summary</p>
           <div className="grid grid-cols-2 gap-4 sm:grid-cols-4">
             <StatCard label="Clicks (organic)" value={web.clicks?.toLocaleString() ?? "—"} />
             <StatCard label="Impressions" value={web.impressions?.toLocaleString() ?? "—"} />
             <StatCard label="CTR" value={web ? pct(web.ctr) : "—"} />
-            <StatCard label="Position" value={web?.position != null ? web.position.toFixed(1) : "—"} />
+            <StatCard
+              label="Position"
+              value={web?.position != null ? web.position.toFixed(1) : "—"}
+            />
           </div>
         </div>
       )}
 
       <div className="bg-void-light/50 rounded-xl border border-slate-800 p-5">
-        <p className="mb-3 font-mono text-xs text-slate-500">
-          Explore deeper
-        </p>
+        <p className="mb-3 font-mono text-xs text-slate-500">Explore deeper</p>
         <div className="flex flex-wrap gap-2">
           {(["keywords", "pages", "history", "ctr"] as Tab[]).map((t) => (
             <button
@@ -273,7 +268,7 @@ async function handleTabFetch<T>(
   setLoading: (v: boolean) => void,
   setError: (v: string | null) => void,
   markFetched: () => void,
-  extractFn: (json: Record<string, unknown>) => T,
+  extractFn: (json: Record<string, unknown>) => T
 ) {
   setLoading(true);
   setError(null);
@@ -349,10 +344,8 @@ export default function AdminAnalyticsPage() {
   });
   const [fetchedTabs, setFetchedTabs] = useState<Set<Tab>>(new Set());
 
-  const setLoading = (t: Tab, v: boolean) =>
-    setLoadingTab((p) => ({ ...p, [t]: v }));
-  const setError = (t: Tab, v: string | null) =>
-    setErrors((p) => ({ ...p, [t]: v }));
+  const setLoading = (t: Tab, v: boolean) => setLoadingTab((p) => ({ ...p, [t]: v }));
+  const setError = (t: Tab, v: string | null) => setErrors((p) => ({ ...p, [t]: v }));
   const markFetched = (t: Tab) => setFetchedTabs((p) => new Set(p).add(t));
 
   const fetchOverview = useCallback(async () => {
@@ -372,49 +365,61 @@ export default function AdminAnalyticsPage() {
     }
   }, []);
 
-  const fetchKeywords = useCallback(() =>
-    handleTabFetch(
-      "keywords",
-      "/api/admin/analytics/keywords?limit=50",
-      setKeywords as (d: unknown) => void,
-      (v) => setLoading("keywords", v),
-      (v) => setError("keywords", v),
-      () => markFetched("keywords"),
-      (j) => (j.keywords ?? []) as Keyword[],
-    ), []);
+  const fetchKeywords = useCallback(
+    () =>
+      handleTabFetch(
+        "keywords",
+        "/api/admin/analytics/keywords?limit=50",
+        setKeywords as (d: unknown) => void,
+        (v) => setLoading("keywords", v),
+        (v) => setError("keywords", v),
+        () => markFetched("keywords"),
+        (j) => (j.keywords ?? []) as Keyword[]
+      ),
+    []
+  );
 
-  const fetchPages = useCallback(() =>
-    handleTabFetch(
-      "pages",
-      "/api/admin/analytics/pages?limit=25",
-      setPages as (d: unknown) => void,
-      (v) => setLoading("pages", v),
-      (v) => setError("pages", v),
-      () => markFetched("pages"),
-      (j) => (j.pages ?? []) as Page[],
-    ), []);
+  const fetchPages = useCallback(
+    () =>
+      handleTabFetch(
+        "pages",
+        "/api/admin/analytics/pages?limit=25",
+        setPages as (d: unknown) => void,
+        (v) => setLoading("pages", v),
+        (v) => setError("pages", v),
+        () => markFetched("pages"),
+        (j) => (j.pages ?? []) as Page[]
+      ),
+    []
+  );
 
-  const fetchHistory = useCallback(() =>
-    handleTabFetch(
-      "history",
-      "/api/admin/analytics/history?weeks=16",
-      setHistory as (d: unknown) => void,
-      (v) => setLoading("history", v),
-      (v) => setError("history", v),
-      () => markFetched("history"),
-      (j) => (j.history ?? []) as HistoryPoint[],
-    ), []);
+  const fetchHistory = useCallback(
+    () =>
+      handleTabFetch(
+        "history",
+        "/api/admin/analytics/history?weeks=16",
+        setHistory as (d: unknown) => void,
+        (v) => setLoading("history", v),
+        (v) => setError("history", v),
+        () => markFetched("history"),
+        (j) => (j.history ?? []) as HistoryPoint[]
+      ),
+    []
+  );
 
-  const fetchCtr = useCallback(() =>
-    handleTabFetch(
-      "ctr",
-      "/api/admin/analytics/ctr-opportunities?limit=40",
-      setOpportunities as (d: unknown) => void,
-      (v) => setLoading("ctr", v),
-      (v) => setError("ctr", v),
-      () => markFetched("ctr"),
-      (j) => (j.opportunities ?? []) as CtrOpportunity[],
-    ), []);
+  const fetchCtr = useCallback(
+    () =>
+      handleTabFetch(
+        "ctr",
+        "/api/admin/analytics/ctr-opportunities?limit=40",
+        setOpportunities as (d: unknown) => void,
+        (v) => setLoading("ctr", v),
+        (v) => setError("ctr", v),
+        () => markFetched("ctr"),
+        (j) => (j.opportunities ?? []) as CtrOpportunity[]
+      ),
+    []
+  );
 
   // Lazy-load: only fetch when tab is first opened
   useEffect(() => {
@@ -428,15 +433,7 @@ export default function AdminAnalyticsPage() {
       };
       fetchers[tab]();
     }
-  }, [
-    tab,
-    fetchedTabs,
-    fetchOverview,
-    fetchKeywords,
-    fetchPages,
-    fetchHistory,
-    fetchCtr,
-  ]);
+  }, [tab, fetchedTabs, fetchOverview, fetchKeywords, fetchPages, fetchHistory, fetchCtr]);
 
   const currentLoading = loadingTab[tab];
   const currentError = errors[tab];
@@ -465,12 +462,9 @@ export default function AdminAnalyticsPage() {
           <span className="bg-neon-magenta h-2 w-2 animate-pulse rounded-full" />
           <span className="text-neon-magenta font-mono text-xs">ANALYTICS</span>
         </div>
-        <h1 className="font-heading text-2xl font-bold text-white">
-          SEO & Analytics
-        </h1>
+        <h1 className="font-heading text-2xl font-bold text-white">SEO & Analytics</h1>
         <p className="font-body mt-1 text-slate-400">
-          Performance data from Google Search Console — clicks, impressions,
-          rankings.
+          Performance data from Google Search Console — clicks, impressions, rankings.
         </p>
       </div>
 
@@ -509,36 +503,61 @@ function KeywordsTab({ keywords }: { readonly keywords: Keyword[] }) {
         <h3 className="font-mono text-xs font-medium text-slate-400">
           Top {keywords.length} Keywords by Clicks
         </h3>
-        <span className="font-mono text-[10px] text-slate-600">
-          Google Search Console
-        </span>
+        <span className="font-mono text-[10px] text-slate-600">Google Search Console</span>
       </div>
       <div className="overflow-x-auto">
         <table className="w-full text-sm">
           <thead>
             <tr className="border-b border-slate-800">
-              <th className="px-6 py-3 text-left font-mono text-xs font-medium text-slate-500">#</th>
-              <th className="px-6 py-3 text-left font-mono text-xs font-medium text-slate-500">Keyword</th>
-              <th className="px-6 py-3 text-right font-mono text-xs font-medium text-slate-500">Clicks</th>
-              <th className="px-6 py-3 text-right font-mono text-xs font-medium text-slate-500">Impr.</th>
-              <th className="px-6 py-3 text-right font-mono text-xs font-medium text-slate-500">CTR</th>
-              <th className="px-6 py-3 text-right font-mono text-xs font-medium text-slate-500">Pos.</th>
+              <th className="px-6 py-3 text-left font-mono text-xs font-medium text-slate-500">
+                #
+              </th>
+              <th className="px-6 py-3 text-left font-mono text-xs font-medium text-slate-500">
+                Keyword
+              </th>
+              <th className="px-6 py-3 text-right font-mono text-xs font-medium text-slate-500">
+                Clicks
+              </th>
+              <th className="px-6 py-3 text-right font-mono text-xs font-medium text-slate-500">
+                Impr.
+              </th>
+              <th className="px-6 py-3 text-right font-mono text-xs font-medium text-slate-500">
+                CTR
+              </th>
+              <th className="px-6 py-3 text-right font-mono text-xs font-medium text-slate-500">
+                Pos.
+              </th>
             </tr>
           </thead>
           <tbody>
             {keywords.map((kw, i) => (
-              <tr key={`kw-${i}`} className="hover:bg-void-lighter/30 border-b border-slate-800/50 transition-colors">
+              <tr
+                key={`kw-${i}`}
+                className="hover:bg-void-lighter/30 border-b border-slate-800/50 transition-colors"
+              >
                 <td className="px-6 py-3 font-mono text-xs text-slate-600">{i + 1}</td>
                 <td className="px-6 py-3 text-white">{kw.keyword}</td>
-                <td className="px-6 py-3 text-right font-mono text-sm text-white">{(kw.clicks ?? 0).toLocaleString()}</td>
-                <td className="px-6 py-3 text-right font-mono text-xs text-slate-400">{(kw.impressions ?? 0).toLocaleString()}</td>
-                <td className={`px-6 py-3 text-right font-mono text-xs ${ctrColor(kw.ctr)}`}>{pct(kw.ctr)}</td>
-                <td className={`px-6 py-3 text-right font-mono text-sm font-semibold ${positionColor(kw.position)}`}>#{kw.position != null ? kw.position.toFixed(1) : "—"}</td>
+                <td className="px-6 py-3 text-right font-mono text-sm text-white">
+                  {(kw.clicks ?? 0).toLocaleString()}
+                </td>
+                <td className="px-6 py-3 text-right font-mono text-xs text-slate-400">
+                  {(kw.impressions ?? 0).toLocaleString()}
+                </td>
+                <td className={`px-6 py-3 text-right font-mono text-xs ${ctrColor(kw.ctr)}`}>
+                  {pct(kw.ctr)}
+                </td>
+                <td
+                  className={`px-6 py-3 text-right font-mono text-sm font-semibold ${positionColor(kw.position)}`}
+                >
+                  #{kw.position != null ? kw.position.toFixed(1) : "—"}
+                </td>
               </tr>
             ))}
             {keywords.length === 0 && (
               <tr>
-                <td colSpan={6} className="px-6 py-12 text-center font-mono text-slate-600">No keyword data available</td>
+                <td colSpan={6} className="px-6 py-12 text-center font-mono text-slate-600">
+                  No keyword data available
+                </td>
               </tr>
             )}
           </tbody>
@@ -562,39 +581,74 @@ function PagesTab({ pages }: { readonly pages: Page[] }) {
   return (
     <div className="bg-void-light/50 overflow-hidden rounded-xl border border-slate-800">
       <div className="flex items-center justify-between border-b border-slate-800 px-6 py-3">
-        <h3 className="font-mono text-xs font-medium text-slate-400">Top {pages.length} Pages by Clicks</h3>
+        <h3 className="font-mono text-xs font-medium text-slate-400">
+          Top {pages.length} Pages by Clicks
+        </h3>
         <span className="font-mono text-[10px] text-slate-600">Google Search Console</span>
       </div>
       <div className="overflow-x-auto">
         <table className="w-full text-sm">
           <thead>
             <tr className="border-b border-slate-800">
-              <th className="px-6 py-3 text-left font-mono text-xs font-medium text-slate-500">#</th>
-              <th className="px-6 py-3 text-left font-mono text-xs font-medium text-slate-500">Page</th>
-              <th className="px-6 py-3 text-right font-mono text-xs font-medium text-slate-500">Clicks</th>
-              <th className="px-6 py-3 text-right font-mono text-xs font-medium text-slate-500">Impr.</th>
-              <th className="px-6 py-3 text-right font-mono text-xs font-medium text-slate-500">CTR</th>
-              <th className="px-6 py-3 text-right font-mono text-xs font-medium text-slate-500">Pos.</th>
+              <th className="px-6 py-3 text-left font-mono text-xs font-medium text-slate-500">
+                #
+              </th>
+              <th className="px-6 py-3 text-left font-mono text-xs font-medium text-slate-500">
+                Page
+              </th>
+              <th className="px-6 py-3 text-right font-mono text-xs font-medium text-slate-500">
+                Clicks
+              </th>
+              <th className="px-6 py-3 text-right font-mono text-xs font-medium text-slate-500">
+                Impr.
+              </th>
+              <th className="px-6 py-3 text-right font-mono text-xs font-medium text-slate-500">
+                CTR
+              </th>
+              <th className="px-6 py-3 text-right font-mono text-xs font-medium text-slate-500">
+                Pos.
+              </th>
             </tr>
           </thead>
           <tbody>
             {pages.map((pg, i) => (
-              <tr key={`page-${i}`} className="hover:bg-void-lighter/30 border-b border-slate-800/50 transition-colors">
+              <tr
+                key={`page-${i}`}
+                className="hover:bg-void-lighter/30 border-b border-slate-800/50 transition-colors"
+              >
                 <td className="px-6 py-3 font-mono text-xs text-slate-600">{i + 1}</td>
                 <td className="px-6 py-3">
-                  <a href={pg.page} target="_blank" rel="noopener noreferrer" className="text-neon-cyan truncate font-mono text-xs hover:underline" title={pg.page}>
+                  <a
+                    href={pg.page}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="text-neon-cyan truncate font-mono text-xs hover:underline"
+                    title={pg.page}
+                  >
                     {formatPageUrl(pg.page)}
                   </a>
                 </td>
-                <td className="px-6 py-3 text-right font-mono text-sm text-white">{(pg.clicks ?? 0).toLocaleString()}</td>
-                <td className="px-6 py-3 text-right font-mono text-xs text-slate-400">{(pg.impressions ?? 0).toLocaleString()}</td>
-                <td className={`px-6 py-3 text-right font-mono text-xs ${ctrColor(pg.ctr)}`}>{pct(pg.ctr)}</td>
-                <td className={`px-6 py-3 text-right font-mono text-sm font-semibold ${positionColor(pg.position)}`}>#{pg.position != null ? pg.position.toFixed(1) : "—"}</td>
+                <td className="px-6 py-3 text-right font-mono text-sm text-white">
+                  {(pg.clicks ?? 0).toLocaleString()}
+                </td>
+                <td className="px-6 py-3 text-right font-mono text-xs text-slate-400">
+                  {(pg.impressions ?? 0).toLocaleString()}
+                </td>
+                <td className={`px-6 py-3 text-right font-mono text-xs ${ctrColor(pg.ctr)}`}>
+                  {pct(pg.ctr)}
+                </td>
+                <td
+                  className={`px-6 py-3 text-right font-mono text-sm font-semibold ${positionColor(pg.position)}`}
+                >
+                  #{pg.position != null ? pg.position.toFixed(1) : "—"}
+                </td>
               </tr>
             ))}
             {pages.length === 0 && (
               <tr>
-                <td colSpan={6} className="px-6 py-12 text-center font-mono text-slate-600">No page data available</td>
+                <td colSpan={6} className="px-6 py-12 text-center font-mono text-slate-600">
+                  No page data available
+                </td>
               </tr>
             )}
           </tbody>
@@ -620,14 +674,14 @@ function HistoryTab({ history }: { readonly history: HistoryPoint[] }) {
       <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
         <div className="bg-void-light/50 rounded-xl border border-slate-800 p-5">
           <p className="mb-1 font-mono text-xs text-slate-500">Clicks (16 weeks)</p>
-          <p className="font-heading mb-3 text-2xl font-bold text-neon-magenta">
+          <p className="font-heading text-neon-magenta mb-3 text-2xl font-bold">
             {history.reduce((s, h) => s + (h.clicks ?? 0), 0).toLocaleString()}
           </p>
           <Sparkline data={history} field="clicks" />
         </div>
         <div className="bg-void-light/50 rounded-xl border border-slate-800 p-5">
           <p className="mb-1 font-mono text-xs text-slate-500">Impressions (16 weeks)</p>
-          <p className="font-heading mb-3 text-2xl font-bold text-neon-cyan">
+          <p className="font-heading text-neon-cyan mb-3 text-2xl font-bold">
             {history.reduce((s, h) => s + (h.impressions ?? 0), 0).toLocaleString()}
           </p>
           <Sparkline data={history} field="impressions" />
@@ -642,23 +696,49 @@ function HistoryTab({ history }: { readonly history: HistoryPoint[] }) {
           <table className="w-full text-sm">
             <thead>
               <tr className="border-b border-slate-800">
-                <th className="px-6 py-3 text-left font-mono text-xs font-medium text-slate-500">Week of</th>
-                <th className="px-6 py-3 text-right font-mono text-xs font-medium text-slate-500">Clicks</th>
-                <th className="px-6 py-3 text-right font-mono text-xs font-medium text-slate-500">Impressions</th>
-                <th className="px-6 py-3 text-right font-mono text-xs font-medium text-slate-500">CTR</th>
-                <th className="px-6 py-3 text-right font-mono text-xs font-medium text-slate-500">Avg Pos.</th>
+                <th className="px-6 py-3 text-left font-mono text-xs font-medium text-slate-500">
+                  Week of
+                </th>
+                <th className="px-6 py-3 text-right font-mono text-xs font-medium text-slate-500">
+                  Clicks
+                </th>
+                <th className="px-6 py-3 text-right font-mono text-xs font-medium text-slate-500">
+                  Impressions
+                </th>
+                <th className="px-6 py-3 text-right font-mono text-xs font-medium text-slate-500">
+                  CTR
+                </th>
+                <th className="px-6 py-3 text-right font-mono text-xs font-medium text-slate-500">
+                  Avg Pos.
+                </th>
               </tr>
             </thead>
             <tbody>
               {[...history].reverse().map((h, i) => (
-                <tr key={`hist-${i}`} className="hover:bg-void-lighter/30 border-b border-slate-800/50 transition-colors">
+                <tr
+                  key={`hist-${i}`}
+                  className="hover:bg-void-lighter/30 border-b border-slate-800/50 transition-colors"
+                >
                   <td className="px-6 py-3 font-mono text-xs text-slate-300">
-                    {new Date(h.date).toLocaleDateString("en-IE", { month: "short", day: "numeric" })}
+                    {new Date(h.date).toLocaleDateString("en-IE", {
+                      month: "short",
+                      day: "numeric",
+                    })}
                   </td>
-                  <td className="px-6 py-3 text-right font-mono text-sm text-white">{(h.clicks ?? 0).toLocaleString()}</td>
-                  <td className="px-6 py-3 text-right font-mono text-xs text-slate-400">{(h.impressions ?? 0).toLocaleString()}</td>
-                  <td className={`px-6 py-3 text-right font-mono text-xs ${ctrColor(h.ctr)}`}>{pct(h.ctr)}</td>
-                  <td className={`px-6 py-3 text-right font-mono text-xs ${positionColor(h.position)}`}>{h.position != null ? h.position.toFixed(1) : "—"}</td>
+                  <td className="px-6 py-3 text-right font-mono text-sm text-white">
+                    {(h.clicks ?? 0).toLocaleString()}
+                  </td>
+                  <td className="px-6 py-3 text-right font-mono text-xs text-slate-400">
+                    {(h.impressions ?? 0).toLocaleString()}
+                  </td>
+                  <td className={`px-6 py-3 text-right font-mono text-xs ${ctrColor(h.ctr)}`}>
+                    {pct(h.ctr)}
+                  </td>
+                  <td
+                    className={`px-6 py-3 text-right font-mono text-xs ${positionColor(h.position)}`}
+                  >
+                    {h.position != null ? h.position.toFixed(1) : "—"}
+                  </td>
                 </tr>
               ))}
             </tbody>
@@ -674,43 +754,75 @@ function HistoryTab({ history }: { readonly history: HistoryPoint[] }) {
 function CtrTab({ opportunities }: { readonly opportunities: CtrOpportunity[] }) {
   return (
     <div className="space-y-4">
-      <div className="bg-yellow-950/20 rounded-xl border border-yellow-900/30 p-4">
+      <div className="rounded-xl border border-yellow-900/30 bg-yellow-950/20 p-4">
         <p className="font-mono text-xs text-yellow-400">
-          ⚡ These keywords rank position 4–20 with high impressions but low CTR (&lt;5%). Improving your title/meta description for these queries could significantly boost organic traffic.
+          ⚡ These keywords rank position 4–20 with high impressions but low CTR (&lt;5%). Improving
+          your title/meta description for these queries could significantly boost organic traffic.
         </p>
       </div>
 
       <div className="bg-void-light/50 overflow-hidden rounded-xl border border-slate-800">
         <div className="flex items-center justify-between border-b border-slate-800 px-6 py-3">
-          <h3 className="font-mono text-xs font-medium text-slate-400">{opportunities.length} CTR Opportunities</h3>
+          <h3 className="font-mono text-xs font-medium text-slate-400">
+            {opportunities.length} CTR Opportunities
+          </h3>
           <span className="font-mono text-[10px] text-slate-600">Sorted by potential</span>
         </div>
         <div className="overflow-x-auto">
           <table className="w-full text-sm">
             <thead>
               <tr className="border-b border-slate-800">
-                <th className="px-6 py-3 text-left font-mono text-xs font-medium text-slate-500">Keyword</th>
-                <th className="px-6 py-3 text-right font-mono text-xs font-medium text-slate-500">Pos.</th>
-                <th className="px-6 py-3 text-right font-mono text-xs font-medium text-slate-500">Impr.</th>
-                <th className="px-6 py-3 text-right font-mono text-xs font-medium text-slate-500">Current CTR</th>
-                <th className="px-6 py-3 text-right font-mono text-xs font-medium text-slate-500">Clicks</th>
-                <th className="px-6 py-3 text-right font-mono text-xs font-medium text-slate-500">Potential ↑</th>
+                <th className="px-6 py-3 text-left font-mono text-xs font-medium text-slate-500">
+                  Keyword
+                </th>
+                <th className="px-6 py-3 text-right font-mono text-xs font-medium text-slate-500">
+                  Pos.
+                </th>
+                <th className="px-6 py-3 text-right font-mono text-xs font-medium text-slate-500">
+                  Impr.
+                </th>
+                <th className="px-6 py-3 text-right font-mono text-xs font-medium text-slate-500">
+                  Current CTR
+                </th>
+                <th className="px-6 py-3 text-right font-mono text-xs font-medium text-slate-500">
+                  Clicks
+                </th>
+                <th className="px-6 py-3 text-right font-mono text-xs font-medium text-slate-500">
+                  Potential ↑
+                </th>
               </tr>
             </thead>
             <tbody>
               {opportunities.map((opp, i) => (
-                <tr key={`ctr-${i}`} className="hover:bg-void-lighter/30 border-b border-slate-800/50 transition-colors">
+                <tr
+                  key={`ctr-${i}`}
+                  className="hover:bg-void-lighter/30 border-b border-slate-800/50 transition-colors"
+                >
                   <td className="px-6 py-3 text-white">{opp.keyword}</td>
-                  <td className={`px-6 py-3 text-right font-mono text-xs ${positionColor(opp.position)}`}>#{opp.position != null ? opp.position.toFixed(1) : "—"}</td>
-                  <td className="px-6 py-3 text-right font-mono text-xs text-slate-400">{(opp.impressions ?? 0).toLocaleString()}</td>
-                  <td className="px-6 py-3 text-right font-mono text-xs text-red-400">{pct(opp.ctr)}</td>
-                  <td className="px-6 py-3 text-right font-mono text-xs text-slate-400">{(opp.clicks ?? 0).toLocaleString()}</td>
-                  <td className="px-6 py-3 text-right font-mono text-xs text-neon-green font-semibold">+{(opp.potentialClicks ?? 0).toLocaleString()} clicks</td>
+                  <td
+                    className={`px-6 py-3 text-right font-mono text-xs ${positionColor(opp.position)}`}
+                  >
+                    #{opp.position != null ? opp.position.toFixed(1) : "—"}
+                  </td>
+                  <td className="px-6 py-3 text-right font-mono text-xs text-slate-400">
+                    {(opp.impressions ?? 0).toLocaleString()}
+                  </td>
+                  <td className="px-6 py-3 text-right font-mono text-xs text-red-400">
+                    {pct(opp.ctr)}
+                  </td>
+                  <td className="px-6 py-3 text-right font-mono text-xs text-slate-400">
+                    {(opp.clicks ?? 0).toLocaleString()}
+                  </td>
+                  <td className="text-neon-green px-6 py-3 text-right font-mono text-xs font-semibold">
+                    +{(opp.potentialClicks ?? 0).toLocaleString()} clicks
+                  </td>
                 </tr>
               ))}
               {opportunities.length === 0 && (
                 <tr>
-                  <td colSpan={6} className="px-6 py-12 text-center font-mono text-slate-600">No CTR opportunities found — your CTRs look healthy!</td>
+                  <td colSpan={6} className="px-6 py-12 text-center font-mono text-slate-600">
+                    No CTR opportunities found — your CTRs look healthy!
+                  </td>
                 </tr>
               )}
             </tbody>

--- a/src/app/[locale]/admin/analytics/unified/page.tsx
+++ b/src/app/[locale]/admin/analytics/unified/page.tsx
@@ -53,12 +53,8 @@ function KpiCard({
   return (
     <div className="bg-void-light/50 rounded-xl border border-slate-800 p-5">
       <div className={`font-mono text-2xl font-bold ${color}`}>{value}</div>
-      <div className="font-heading mt-1 text-sm font-medium text-white">
-        {label}
-      </div>
-      {sub && (
-        <div className="font-mono mt-0.5 text-xs text-slate-500">{sub}</div>
-      )}
+      <div className="font-heading mt-1 text-sm font-medium text-white">{label}</div>
+      {sub && <div className="mt-0.5 font-mono text-xs text-slate-500">{sub}</div>}
     </div>
   );
 }
@@ -74,13 +70,10 @@ function SectionHeader({
 }>) {
   return (
     <div className="mb-3 flex items-center justify-between">
-      <h2 className="font-heading text-sm font-semibold uppercase tracking-widest text-slate-500">
+      <h2 className="font-heading text-sm font-semibold tracking-widest text-slate-500 uppercase">
         {icon} {title}
       </h2>
-      <Link
-        href={href}
-        className="font-mono text-xs text-slate-500 transition hover:text-white"
-      >
+      <Link href={href} className="font-mono text-xs text-slate-500 transition hover:text-white">
         View full →
       </Link>
     </div>
@@ -112,8 +105,7 @@ export default function UnifiedAnalyticsPage() {
         const json: UnifiedData = await res.json();
         if (!cancelled) setData(json);
       } catch (e) {
-        if (!cancelled)
-          setError(e instanceof Error ? e.message : "Failed to load");
+        if (!cancelled) setError(e instanceof Error ? e.message : "Failed to load");
       } finally {
         if (!cancelled) setLoading(false);
       }
@@ -131,13 +123,9 @@ export default function UnifiedAnalyticsPage() {
         <div>
           <div className="bg-neon-green/10 border-neon-green/20 mb-4 inline-flex items-center gap-2 rounded-full border px-3 py-1.5">
             <span className="bg-neon-green h-2 w-2 animate-pulse rounded-full" />
-            <span className="text-neon-green font-mono text-xs">
-              UNIFIED ANALYTICS
-            </span>
+            <span className="text-neon-green font-mono text-xs">UNIFIED ANALYTICS</span>
           </div>
-          <h1 className="font-heading text-2xl font-bold text-white">
-            Unified Dashboard
-          </h1>
+          <h1 className="font-heading text-2xl font-bold text-white">Unified Dashboard</h1>
           <p className="font-body mt-1 text-slate-400">
             All KPIs in one view — SEO, revenue, pipeline, and email.
           </p>
@@ -205,11 +193,7 @@ export default function UnifiedAnalyticsPage() {
 
           {/* SEO */}
           <div>
-            <SectionHeader
-              title="Search Performance"
-              icon="🔍"
-              href="/admin/analytics"
-            />
+            <SectionHeader title="Search Performance" icon="🔍" href="/admin/analytics" />
             {data.seo ? (
               <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
                 <KpiCard
@@ -241,11 +225,7 @@ export default function UnifiedAnalyticsPage() {
 
           {/* Pipeline */}
           <div>
-            <SectionHeader
-              title="Sales Pipeline"
-              icon="🔀"
-              href="/admin/pipeline"
-            />
+            <SectionHeader title="Sales Pipeline" icon="🔀" href="/admin/pipeline" />
             {data.pipeline ? (
               <div className="grid grid-cols-2 gap-3 sm:grid-cols-3">
                 <KpiCard
@@ -259,25 +239,16 @@ export default function UnifiedAnalyticsPage() {
                   color="text-neon-magenta"
                 />
                 <div className="bg-void-light/50 rounded-xl border border-slate-800 p-5">
-                  <div className="font-heading mb-2 text-xs font-semibold uppercase tracking-widest text-slate-500">
+                  <div className="font-heading mb-2 text-xs font-semibold tracking-widest text-slate-500 uppercase">
                     By Stage
                   </div>
                   <div className="space-y-1">
-                    {Object.entries(data.pipeline.byStage).map(
-                      ([stage, { count }]) => (
-                        <div
-                          key={stage}
-                          className="flex justify-between font-mono text-xs"
-                        >
-                          <span className="truncate text-slate-400">
-                            {stage}
-                          </span>
-                          <span className="text-neon-magenta ml-2 shrink-0">
-                            {count}
-                          </span>
-                        </div>
-                      ),
-                    )}
+                    {Object.entries(data.pipeline.byStage).map(([stage, { count }]) => (
+                      <div key={stage} className="flex justify-between font-mono text-xs">
+                        <span className="truncate text-slate-400">{stage}</span>
+                        <span className="text-neon-magenta ml-2 shrink-0">{count}</span>
+                      </div>
+                    ))}
                   </div>
                 </div>
               </div>
@@ -288,11 +259,7 @@ export default function UnifiedAnalyticsPage() {
 
           {/* Email */}
           <div>
-            <SectionHeader
-              title="Email Marketing"
-              icon="📧"
-              href="/admin/email"
-            />
+            <SectionHeader title="Email Marketing" icon="📧" href="/admin/email" />
             {data.email ? (
               <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
                 <KpiCard

--- a/src/app/[locale]/admin/blog/page.tsx
+++ b/src/app/[locale]/admin/blog/page.tsx
@@ -68,12 +68,8 @@ export default function AdminBlogPage() {
             <span className="bg-neon-cyan h-2 w-2 animate-pulse rounded-full" />
             <span className="text-neon-cyan font-mono text-xs">BLOG</span>
           </div>
-          <h1 className="font-heading text-2xl font-bold text-white">
-            Blog Posts
-          </h1>
-          <p className="font-body mt-1 text-slate-400">
-            All posts from your Notion blog database.
-          </p>
+          <h1 className="font-heading text-2xl font-bold text-white">Blog Posts</h1>
+          <p className="font-body mt-1 text-slate-400">All posts from your Notion blog database.</p>
         </div>
         <button
           type="button"
@@ -95,11 +91,7 @@ export default function AdminBlogPage() {
         <div className="mb-4 flex items-center gap-2">
           {(["all", "published", "draft"] as Filter[]).map((f) => {
             const count =
-              f === "all"
-                ? posts.length
-                : f === "published"
-                  ? publishedCount
-                  : draftCount;
+              f === "all" ? posts.length : f === "published" ? publishedCount : draftCount;
             return (
               <button
                 key={f}
@@ -112,9 +104,7 @@ export default function AdminBlogPage() {
                 }`}
               >
                 {FILTER_LABELS[f]}
-                <span className="ml-1.5 font-mono text-[10px] opacity-60">
-                  {count}
-                </span>
+                <span className="ml-1.5 font-mono text-[10px] opacity-60">{count}</span>
               </button>
             );
           })}
@@ -126,7 +116,7 @@ export default function AdminBlogPage() {
           {[1, 2, 3, 4].map((i) => (
             <div
               key={i}
-              className="animate-pulse rounded-xl border border-slate-800 bg-void-light/50 p-5"
+              className="bg-void-light/50 animate-pulse rounded-xl border border-slate-800 p-5"
             >
               <div className="mb-2 h-4 w-2/3 rounded bg-slate-700/60" />
               <div className="h-3 w-1/3 rounded bg-slate-800/80" />
@@ -136,36 +126,24 @@ export default function AdminBlogPage() {
       )}
 
       {!loading && !error && filtered.length === 0 && (
-        <div className="rounded-xl border border-slate-800 bg-void-light/30 py-12 text-center">
+        <div className="bg-void-light/30 rounded-xl border border-slate-800 py-12 text-center">
           <p className="font-mono text-sm text-slate-500">
-            {posts.length === 0
-              ? "No posts in Notion yet."
-              : "No posts match this filter."}
+            {posts.length === 0 ? "No posts in Notion yet." : "No posts match this filter."}
           </p>
         </div>
       )}
 
       {!loading && filtered.length > 0 && (
-        <div className="overflow-hidden rounded-xl border border-slate-800 bg-void-light/50">
+        <div className="bg-void-light/50 overflow-hidden rounded-xl border border-slate-800">
           <div className="overflow-x-auto">
             <table className="w-full text-sm">
               <thead>
                 <tr className="border-b border-slate-800">
-                  <th className="px-5 py-3 text-left font-mono text-xs text-slate-500">
-                    Title
-                  </th>
-                  <th className="px-5 py-3 text-left font-mono text-xs text-slate-500">
-                    Category
-                  </th>
-                  <th className="px-5 py-3 text-left font-mono text-xs text-slate-500">
-                    Date
-                  </th>
-                  <th className="px-5 py-3 text-left font-mono text-xs text-slate-500">
-                    Status
-                  </th>
-                  <th className="px-5 py-3 text-left font-mono text-xs text-slate-500">
-                    Tags
-                  </th>
+                  <th className="px-5 py-3 text-left font-mono text-xs text-slate-500">Title</th>
+                  <th className="px-5 py-3 text-left font-mono text-xs text-slate-500">Category</th>
+                  <th className="px-5 py-3 text-left font-mono text-xs text-slate-500">Date</th>
+                  <th className="px-5 py-3 text-left font-mono text-xs text-slate-500">Status</th>
+                  <th className="px-5 py-3 text-left font-mono text-xs text-slate-500">Tags</th>
                   <th className="px-5 py-3 text-right font-mono text-xs text-slate-500">
                     Read Time
                   </th>
@@ -184,17 +162,11 @@ export default function AdminBlogPage() {
                             FEATURED
                           </span>
                         )}
-                        <span className="font-medium text-white">
-                          {post.title || "(Untitled)"}
-                        </span>
+                        <span className="font-medium text-white">{post.title || "(Untitled)"}</span>
                       </div>
-                      <p className="mt-0.5 font-mono text-[10px] text-slate-600">
-                        {post.slug}
-                      </p>
+                      <p className="mt-0.5 font-mono text-[10px] text-slate-600">{post.slug}</p>
                     </td>
-                    <td className="px-5 py-3 font-mono text-xs text-slate-400">
-                      {post.category}
-                    </td>
+                    <td className="px-5 py-3 font-mono text-xs text-slate-400">{post.category}</td>
                     <td className="px-5 py-3 font-mono text-xs text-slate-400">
                       {formatDate(post.date)}
                     </td>

--- a/src/app/[locale]/admin/calendar/page.tsx
+++ b/src/app/[locale]/admin/calendar/page.tsx
@@ -2,11 +2,7 @@
 
 import { fetchWithAuth } from "@/lib/fetch-with-auth";
 import { useEffect, useState } from "react";
-import type {
-  CalendarItem,
-  CalendarItemType,
-  CalendarPlatform,
-} from "@/lib/content-calendar";
+import type { CalendarItem, CalendarItemType, CalendarPlatform } from "@/lib/content-calendar";
 import { CALENDAR_ITEM_COLORS, PLATFORM_LABELS } from "@/lib/content-calendar";
 
 const DAYS = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
@@ -47,9 +43,7 @@ export default function CalendarPage() {
     const firstDay = `${year}-${String(month + 1).padStart(2, "0")}-01`;
     const lastDay = `${year}-${String(month + 1).padStart(2, "0")}-${new Date(year, month + 1, 0).getDate()}`;
     try {
-      const res = await fetchWithAuth(
-        `/api/admin/calendar?from=${firstDay}&to=${lastDay}`,
-      );
+      const res = await fetchWithAuth(`/api/admin/calendar?from=${firstDay}&to=${lastDay}`);
       if (!res.ok) return;
       const data = await res.json();
       setItems(data.items ?? []);
@@ -131,13 +125,9 @@ export default function CalendarPage() {
       <div className="mb-8">
         <div className="border-neon-cyan/20 bg-neon-cyan/10 mb-4 inline-flex items-center gap-2 rounded-full border px-3 py-1.5">
           <span className="bg-neon-cyan h-2 w-2 animate-pulse rounded-full" />
-          <span className="text-neon-cyan font-mono text-xs">
-            CONTENT CALENDAR
-          </span>
+          <span className="text-neon-cyan font-mono text-xs">CONTENT CALENDAR</span>
         </div>
-        <h1 className="font-heading text-2xl font-bold text-white">
-          Content Calendar
-        </h1>
+        <h1 className="font-heading text-2xl font-bold text-white">Content Calendar</h1>
         <p className="font-body mt-1 text-slate-400">
           Schedule and manage content across all channels.
         </p>
@@ -148,7 +138,7 @@ export default function CalendarPage() {
           <button
             type="button"
             onClick={prevMonth}
-            className="font-mono text-slate-400 hover:text-white transition-colors px-2"
+            className="px-2 font-mono text-slate-400 transition-colors hover:text-white"
           >
             ‹
           </button>
@@ -158,7 +148,7 @@ export default function CalendarPage() {
           <button
             type="button"
             onClick={nextMonth}
-            className="font-mono text-slate-400 hover:text-white transition-colors px-2"
+            className="px-2 font-mono text-slate-400 transition-colors hover:text-white"
           >
             ›
           </button>
@@ -179,14 +169,12 @@ export default function CalendarPage() {
               : null;
             const dayItems = dateStr ? (itemsByDate[dateStr] ?? []) : [];
             const isToday =
-              day === today.getDate() &&
-              month === today.getMonth() &&
-              year === today.getFullYear();
+              day === today.getDate() && month === today.getMonth() && year === today.getFullYear();
 
             return (
               <div
                 key={idx}
-                className={`bg-void min-h-[80px] p-1.5 ${day ? "cursor-pointer hover:bg-slate-800/30 transition-colors" : ""}`}
+                className={`bg-void min-h-[80px] p-1.5 ${day ? "cursor-pointer transition-colors hover:bg-slate-800/30" : ""}`}
                 onClick={() => {
                   if (!day || !dateStr) return;
                   setSelectedDate(dateStr);
@@ -258,23 +246,17 @@ export default function CalendarPage() {
             </div>
             <form onSubmit={handleCreate} className="space-y-4">
               <div>
-                <label className="mb-1 block font-mono text-xs text-slate-400">
-                  Title
-                </label>
+                <label className="mb-1 block font-mono text-xs text-slate-400">Title</label>
                 <input
                   required
                   value={form.title}
-                  onChange={(e) =>
-                    setForm((f) => ({ ...f, title: e.target.value }))
-                  }
+                  onChange={(e) => setForm((f) => ({ ...f, title: e.target.value }))}
                   className="w-full rounded-lg border border-slate-700 bg-slate-900 px-3 py-2 font-mono text-sm text-white focus:border-slate-500 focus:outline-none"
                 />
               </div>
               <div className="grid grid-cols-2 gap-3">
                 <div>
-                  <label className="mb-1 block font-mono text-xs text-slate-400">
-                    Type
-                  </label>
+                  <label className="mb-1 block font-mono text-xs text-slate-400">Type</label>
                   <select
                     value={form.type}
                     onChange={(e) =>
@@ -293,9 +275,7 @@ export default function CalendarPage() {
                   </select>
                 </div>
                 <div>
-                  <label className="mb-1 block font-mono text-xs text-slate-400">
-                    Platform
-                  </label>
+                  <label className="mb-1 block font-mono text-xs text-slate-400">Platform</label>
                   <select
                     value={form.platform}
                     onChange={(e) =>
@@ -306,25 +286,19 @@ export default function CalendarPage() {
                     }
                     className="w-full rounded-lg border border-slate-700 bg-slate-900 px-3 py-2 font-mono text-xs text-white focus:outline-none"
                   >
-                    {(Object.keys(PLATFORM_LABELS) as CalendarPlatform[]).map(
-                      (p) => (
-                        <option key={p} value={p}>
-                          {PLATFORM_LABELS[p]}
-                        </option>
-                      ),
-                    )}
+                    {(Object.keys(PLATFORM_LABELS) as CalendarPlatform[]).map((p) => (
+                      <option key={p} value={p}>
+                        {PLATFORM_LABELS[p]}
+                      </option>
+                    ))}
                   </select>
                 </div>
               </div>
               <div>
-                <label className="mb-1 block font-mono text-xs text-slate-400">
-                  Notes
-                </label>
+                <label className="mb-1 block font-mono text-xs text-slate-400">Notes</label>
                 <textarea
                   value={form.notes}
-                  onChange={(e) =>
-                    setForm((f) => ({ ...f, notes: e.target.value }))
-                  }
+                  onChange={(e) => setForm((f) => ({ ...f, notes: e.target.value }))}
                   rows={2}
                   className="w-full rounded-lg border border-slate-700 bg-slate-900 px-3 py-2 font-mono text-xs text-white focus:border-slate-500 focus:outline-none"
                 />

--- a/src/app/[locale]/admin/campaigns/google/page.tsx
+++ b/src/app/[locale]/admin/campaigns/google/page.tsx
@@ -32,14 +32,9 @@ export default function GoogleCampaignsPage() {
 
   const totalImpressions = campaigns.reduce((s, c) => s + (c.impressions ?? 0), 0);
   const totalClicks = campaigns.reduce((s, c) => s + (c.clicks ?? 0), 0);
-  const totalCost = campaigns.reduce(
-    (s, c) => s + Number.parseFloat(String(c.cost ?? 0)),
-    0,
-  );
+  const totalCost = campaigns.reduce((s, c) => s + Number.parseFloat(String(c.cost ?? 0)), 0);
   const avgCtr =
-    totalImpressions > 0
-      ? ((totalClicks / totalImpressions) * 100).toFixed(2)
-      : "0.00";
+    totalImpressions > 0 ? ((totalClicks / totalImpressions) * 100).toFixed(2) : "0.00";
 
   return (
     <div className="space-y-6">
@@ -52,9 +47,7 @@ export default function GoogleCampaignsPage() {
 
       <div className="bg-void-light/50 overflow-hidden rounded-xl border border-slate-800">
         <div className="border-b border-slate-800 px-6 py-3">
-          <h3 className="font-mono text-xs font-medium text-slate-400">
-            Google Ads Campaigns
-          </h3>
+          <h3 className="font-mono text-xs font-medium text-slate-400">Google Ads Campaigns</h3>
         </div>
         <div className="overflow-x-auto">
           <table className="w-full text-sm">
@@ -100,10 +93,7 @@ export default function GoogleCampaignsPage() {
               ))}
               {campaigns.length === 0 && (
                 <tr>
-                  <td
-                    colSpan={5}
-                    className="px-6 py-12 text-center font-mono text-slate-600"
-                  >
+                  <td colSpan={5} className="px-6 py-12 text-center font-mono text-slate-600">
                     No Google Ads campaigns found.
                   </td>
                 </tr>
@@ -133,9 +123,7 @@ function StatusBadge({ status }: { readonly status: string }) {
         ? "text-yellow-400 border-yellow-400/30"
         : "text-slate-500 border-slate-600";
   return (
-    <span
-      className={`rounded-full border px-2 py-0.5 font-mono text-[10px] uppercase ${color}`}
-    >
+    <span className={`rounded-full border px-2 py-0.5 font-mono text-[10px] uppercase ${color}`}>
       {status}
     </span>
   );

--- a/src/app/[locale]/admin/campaigns/linkedin/page.tsx
+++ b/src/app/[locale]/admin/campaigns/linkedin/page.tsx
@@ -63,8 +63,7 @@ export default function LinkedInPage() {
           <p className="font-mono text-sm text-yellow-400">
             LinkedIn is not configured. Add{" "}
             <code className="text-yellow-300">LINKEDIN_ACCESS_TOKEN</code> and{" "}
-            <code className="text-yellow-300">LINKEDIN_AD_ACCOUNT_ID</code> to
-            AWS SSM.
+            <code className="text-yellow-300">LINKEDIN_AD_ACCOUNT_ID</code> to AWS SSM.
           </p>
         </div>
       </div>
@@ -79,17 +78,12 @@ export default function LinkedInPage() {
           <span className="h-2 w-2 animate-pulse rounded-full bg-blue-400" />
           <span className="font-mono text-xs text-blue-400">LINKEDIN</span>
         </div>
-        <h1 className="font-heading text-2xl font-bold text-white">
-          LinkedIn Campaigns
-        </h1>
+        <h1 className="font-heading text-2xl font-bold text-white">LinkedIn Campaigns</h1>
       </div>
 
       {insights && (
         <div className="mb-8 grid grid-cols-4 gap-4">
-          <MetricCard
-            label="Impressions"
-            value={insights.impressions.toLocaleString()}
-          />
+          <MetricCard label="Impressions" value={insights.impressions.toLocaleString()} />
           <MetricCard label="Clicks" value={insights.clicks.toLocaleString()} />
           <MetricCard
             label="Spend"
@@ -106,39 +100,23 @@ export default function LinkedInPage() {
           <table className="w-full">
             <thead>
               <tr className="border-b border-slate-800 bg-slate-900/50">
-                <th className="px-4 py-3 text-left font-mono text-xs text-slate-500">
-                  Campaign
-                </th>
-                <th className="px-4 py-3 text-left font-mono text-xs text-slate-500">
-                  Status
-                </th>
-                <th className="px-4 py-3 text-left font-mono text-xs text-slate-500">
-                  Objective
-                </th>
-                <th className="px-4 py-3 text-right font-mono text-xs text-slate-500">
-                  Budget
-                </th>
+                <th className="px-4 py-3 text-left font-mono text-xs text-slate-500">Campaign</th>
+                <th className="px-4 py-3 text-left font-mono text-xs text-slate-500">Status</th>
+                <th className="px-4 py-3 text-left font-mono text-xs text-slate-500">Objective</th>
+                <th className="px-4 py-3 text-right font-mono text-xs text-slate-500">Budget</th>
               </tr>
             </thead>
             <tbody className="divide-y divide-slate-800">
               {campaigns.length === 0 && (
                 <tr>
-                  <td
-                    colSpan={4}
-                    className="py-8 text-center font-mono text-sm text-slate-600"
-                  >
+                  <td colSpan={4} className="py-8 text-center font-mono text-sm text-slate-600">
                     No campaigns found.
                   </td>
                 </tr>
               )}
               {campaigns.map((c) => (
-                <tr
-                  key={c.id}
-                  className="hover:bg-slate-800/30 transition-colors"
-                >
-                  <td className="px-4 py-3 font-mono text-sm text-white">
-                    {c.name}
-                  </td>
+                <tr key={c.id} className="transition-colors hover:bg-slate-800/30">
+                  <td className="px-4 py-3 font-mono text-sm text-white">{c.name}</td>
                   <td className="px-4 py-3">
                     <span
                       className={`rounded-full border px-2 py-0.5 font-mono text-[10px] ${c.status === "ACTIVE" ? "border-neon-green/30 text-neon-green" : "border-slate-700 text-slate-500"}`}
@@ -146,13 +124,9 @@ export default function LinkedInPage() {
                       {c.status}
                     </span>
                   </td>
-                  <td className="px-4 py-3 font-mono text-xs text-slate-400">
-                    {c.objectiveType}
-                  </td>
+                  <td className="px-4 py-3 font-mono text-xs text-slate-400">{c.objectiveType}</td>
                   <td className="px-4 py-3 text-right font-mono text-sm text-slate-300">
-                    {c.totalBudget
-                      ? `${c.totalBudget.amount} ${c.totalBudget.currencyCode}`
-                      : "—"}
+                    {c.totalBudget ? `${c.totalBudget.amount} ${c.totalBudget.currencyCode}` : "—"}
                   </td>
                 </tr>
               ))}
@@ -189,9 +163,7 @@ function MetricCard({ label, value }: { readonly label: string; readonly value: 
 function Spinner({ color = "border-neon-cyan" }: { readonly color?: string }) {
   return (
     <div className="flex items-center gap-3 text-slate-400">
-      <div
-        className={`h-4 w-4 animate-spin rounded-full border-2 ${color} border-t-transparent`}
-      />
+      <div className={`h-4 w-4 animate-spin rounded-full border-2 ${color} border-t-transparent`} />
       <span className="font-mono text-sm">Loading...</span>
     </div>
   );

--- a/src/app/[locale]/admin/campaigns/page.tsx
+++ b/src/app/[locale]/admin/campaigns/page.tsx
@@ -8,12 +8,7 @@ const REFRESH_INTERVAL = 30_000;
 
 type PlatformId = "tiktok" | "linkedin" | "x" | "google" | "meta";
 type IntegrationId = "tiktok" | "linkedin" | "x" | "google_ads" | "meta";
-type ConnectionStatus =
-  | "configured"
-  | "not_configured"
-  | "degraded"
-  | "error"
-  | "unknown";
+type ConnectionStatus = "configured" | "not_configured" | "degraded" | "error" | "unknown";
 
 interface PlatformDef {
   id: PlatformId;
@@ -173,9 +168,7 @@ async function fetchStatusMap(): Promise<
         message?: string;
       }>;
     };
-    const map: Partial<
-      Record<IntegrationId, { status: ConnectionStatus; message?: string }>
-    > = {};
+    const map: Partial<Record<IntegrationId, { status: ConnectionStatus; message?: string }>> = {};
     for (const i of data.integrations ?? []) {
       map[i.id as IntegrationId] = { status: i.status, message: i.message };
     }
@@ -188,15 +181,13 @@ async function fetchStatusMap(): Promise<
 async function fetchPlatformStats(
   platform: PlatformDef,
   start: string,
-  end: string,
+  end: string
 ): Promise<PlatformStats> {
   const stats = emptyStats();
 
   const [campaignsRes, insightsRes] = await Promise.allSettled([
     fetchWithAuth(`/api/admin/campaigns/${platform.id}`),
-    fetchWithAuth(
-      `/api/admin/campaigns/${platform.id}/insights?start=${start}&end=${end}`,
-    ),
+    fetchWithAuth(`/api/admin/campaigns/${platform.id}/insights?start=${start}&end=${end}`),
   ]);
 
   if (campaignsRes.status === "fulfilled" && campaignsRes.value.ok) {
@@ -220,11 +211,7 @@ async function fetchPlatformStats(
   return stats;
 }
 
-function applyInsights(
-  id: PlatformId,
-  data: unknown,
-  stats: PlatformStats,
-): void {
+function applyInsights(id: PlatformId, data: unknown, stats: PlatformStats): void {
   if (!data || typeof data !== "object") return;
   const root = data as Record<string, unknown>;
 
@@ -328,13 +315,10 @@ function useCampaignsHub() {
           s.status = conn.status;
           s.statusMessage = conn.message;
           return [p.id, s] as const;
-        }),
+        })
       );
 
-      const stats = Object.fromEntries(entries) as Record<
-        PlatformId,
-        PlatformStats
-      >;
+      const stats = Object.fromEntries(entries) as Record<PlatformId, PlatformStats>;
       setHub({ stats, fetchedAt: new Date().toISOString() });
       setError(null);
     } catch (err) {
@@ -377,13 +361,9 @@ export default function CampaignsDashboard() {
         <div>
           <div className="border-neon-magenta/20 bg-neon-magenta/10 mb-4 inline-flex items-center gap-2 rounded-full border px-3 py-1.5">
             <span className="bg-neon-magenta h-2 w-2 animate-pulse rounded-full" />
-            <span className="text-neon-magenta font-mono text-xs">
-              CAMPAIGNS
-            </span>
+            <span className="text-neon-magenta font-mono text-xs">CAMPAIGNS</span>
           </div>
-          <h1 className="font-heading text-2xl font-bold text-white">
-            Campaign Manager
-          </h1>
+          <h1 className="font-heading text-2xl font-bold text-white">Campaign Manager</h1>
           <p className="font-body mt-1 text-slate-400">
             Manage paid campaigns across all advertising platforms.
           </p>
@@ -415,14 +395,9 @@ export default function CampaignsDashboard() {
       <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
         {platforms.map((p) => {
           const stats = hub.stats[p.id];
-          const card = (
-            <PlatformCard platform={p} stats={stats} loading={loading} />
-          );
+          const card = <PlatformCard platform={p} stats={stats} loading={loading} />;
           return p.disabled ? (
-            <div
-              key={p.href}
-              className={`rounded-xl border p-5 transition-all ${p.color}`}
-            >
+            <div key={p.href} className={`rounded-xl border p-5 transition-all ${p.color}`}>
               {card}
             </div>
           ) : (
@@ -438,9 +413,7 @@ export default function CampaignsDashboard() {
       </div>
 
       <div className="mt-8 rounded-xl border border-slate-800 bg-slate-900/20 p-5">
-        <h2 className="font-heading mb-2 font-semibold text-white">
-          Quick Links
-        </h2>
+        <h2 className="font-heading mb-2 font-semibold text-white">Quick Links</h2>
         <div className="flex flex-wrap gap-3">
           <Link
             href="/admin/calendar"
@@ -491,13 +464,7 @@ function computeTotals(stats: Record<PlatformId, PlatformStats>): Totals {
   return { connected, totalPlatforms, activeCampaigns, impressions, clicks };
 }
 
-function TotalsStrip({
-  totals,
-  loading,
-}: {
-  readonly totals: Totals;
-  readonly loading: boolean;
-}) {
+function TotalsStrip({ totals, loading }: { readonly totals: Totals; readonly loading: boolean }) {
   return (
     <div className="mb-6 grid grid-cols-2 gap-3 sm:grid-cols-4">
       <Tile
@@ -510,16 +477,8 @@ function TotalsStrip({
         value={formatNumber(totals.activeCampaigns)}
         loading={loading}
       />
-      <Tile
-        label="Impressions (MTD)"
-        value={formatNumber(totals.impressions)}
-        loading={loading}
-      />
-      <Tile
-        label="Clicks (MTD)"
-        value={formatNumber(totals.clicks)}
-        loading={loading}
-      />
+      <Tile label="Impressions (MTD)" value={formatNumber(totals.impressions)} loading={loading} />
+      <Tile label="Clicks (MTD)" value={formatNumber(totals.clicks)} loading={loading} />
     </div>
   );
 }
@@ -535,15 +494,11 @@ function Tile({
 }) {
   return (
     <div className="rounded-xl border border-slate-800 bg-slate-900/20 p-4">
-      <p className="font-mono text-[10px] uppercase tracking-widest text-slate-600">
-        {label}
-      </p>
+      <p className="font-mono text-[10px] tracking-widest text-slate-600 uppercase">{label}</p>
       {loading ? (
         <div className="mt-2 h-6 w-16 animate-pulse rounded bg-slate-800/60" />
       ) : (
-        <p className="font-heading mt-1 text-xl font-bold text-white">
-          {value}
-        </p>
+        <p className="font-heading mt-1 text-xl font-bold text-white">{value}</p>
       )}
     </div>
   );
@@ -558,19 +513,14 @@ function PlatformCard({
   readonly stats: PlatformStats;
   readonly loading: boolean;
 }) {
-  const showKpis =
-    !platform.disabled && stats.status === "configured" && !loading;
+  const showKpis = !platform.disabled && stats.status === "configured" && !loading;
   return (
     <>
       <div className="mb-3 flex items-center justify-between gap-3">
         <div className="flex items-center gap-3">
-          <span className={`font-mono text-lg font-bold ${platform.badge}`}>
-            {platform.icon}
-          </span>
+          <span className={`font-mono text-lg font-bold ${platform.badge}`}>{platform.icon}</span>
           <div>
-            <p className={`font-mono text-sm font-semibold ${platform.badge}`}>
-              {platform.name}
-            </p>
+            <p className={`font-mono text-sm font-semibold ${platform.badge}`}>{platform.name}</p>
             {platform.disabled && (
               <span className="rounded-full border border-yellow-900/30 bg-yellow-950/20 px-2 py-0.5 font-mono text-[9px] text-yellow-600">
                 PENDING
@@ -580,15 +530,10 @@ function PlatformCard({
         </div>
         <div
           className="flex items-center gap-1.5"
-          title={
-            stats.statusMessage ??
-            STATUS_LABEL[stats.status]
-          }
+          title={stats.statusMessage ?? STATUS_LABEL[stats.status]}
         >
-          <span
-            className={`h-2 w-2 rounded-full ${STATUS_DOT_CLASS[stats.status]}`}
-          />
-          <span className="font-mono text-[9px] uppercase tracking-wider text-slate-500">
+          <span className={`h-2 w-2 rounded-full ${STATUS_DOT_CLASS[stats.status]}`} />
+          <span className="font-mono text-[9px] tracking-wider text-slate-500 uppercase">
             {STATUS_LABEL[stats.status]}
           </span>
         </div>
@@ -600,28 +545,17 @@ function PlatformCard({
         <div className="mt-4 grid grid-cols-2 gap-2 border-t border-slate-800/60 pt-3">
           <Kpi
             label="Active"
-            value={
-              stats.activeCampaigns === null ? "—" : formatNumber(stats.activeCampaigns)
-            }
+            value={stats.activeCampaigns === null ? "—" : formatNumber(stats.activeCampaigns)}
           />
           <Kpi
             label="Spend MTD"
-            value={
-              stats.spend
-                ? formatMoney(stats.spend.amount, stats.spend.currency)
-                : "—"
-            }
+            value={stats.spend ? formatMoney(stats.spend.amount, stats.spend.currency) : "—"}
           />
           <Kpi
             label="Impressions"
-            value={
-              stats.impressions === null ? "—" : formatNumber(stats.impressions)
-            }
+            value={stats.impressions === null ? "—" : formatNumber(stats.impressions)}
           />
-          <Kpi
-            label="Clicks"
-            value={stats.clicks === null ? "—" : formatNumber(stats.clicks)}
-          />
+          <Kpi label="Clicks" value={stats.clicks === null ? "—" : formatNumber(stats.clicks)} />
         </div>
       ) : null}
       {loading && !platform.disabled && (
@@ -641,9 +575,7 @@ function PlatformCard({
 function Kpi({ label, value }: { readonly label: string; readonly value: string }) {
   return (
     <div>
-      <p className="font-mono text-[9px] uppercase tracking-wider text-slate-600">
-        {label}
-      </p>
+      <p className="font-mono text-[9px] tracking-wider text-slate-600 uppercase">{label}</p>
       <p className="font-mono text-sm font-semibold text-white">{value}</p>
     </div>
   );

--- a/src/app/[locale]/admin/campaigns/tiktok/page.tsx
+++ b/src/app/[locale]/admin/campaigns/tiktok/page.tsx
@@ -84,33 +84,19 @@ export default function TikTokPage() {
           <span className="h-2 w-2 animate-pulse rounded-full bg-pink-400" />
           <span className="font-mono text-xs text-pink-400">TIKTOK</span>
         </div>
-        <h1 className="font-heading text-2xl font-bold text-white">
-          TikTok Campaigns
-        </h1>
+        <h1 className="font-heading text-2xl font-bold text-white">TikTok Campaigns</h1>
       </div>
 
       {insights && (
         <div className="mb-8 grid grid-cols-3 gap-4 sm:grid-cols-6">
-          <MetricCard
-            label="Spend"
-            value={`$${Number.parseFloat(insights.spend).toFixed(2)}`}
-          />
+          <MetricCard label="Spend" value={`$${Number.parseFloat(insights.spend).toFixed(2)}`} />
           <MetricCard
             label="Impressions"
             value={Number.parseInt(insights.impressions).toLocaleString()}
           />
-          <MetricCard
-            label="Clicks"
-            value={Number.parseInt(insights.clicks).toLocaleString()}
-          />
-          <MetricCard
-            label="CTR"
-            value={`${Number.parseFloat(insights.ctr).toFixed(2)}%`}
-          />
-          <MetricCard
-            label="CPC"
-            value={`$${Number.parseFloat(insights.cpc).toFixed(2)}`}
-          />
+          <MetricCard label="Clicks" value={Number.parseInt(insights.clicks).toLocaleString()} />
+          <MetricCard label="CTR" value={`${Number.parseFloat(insights.ctr).toFixed(2)}%`} />
+          <MetricCard label="CPC" value={`$${Number.parseFloat(insights.cpc).toFixed(2)}`} />
           <MetricCard
             label="Conversions"
             value={Number.parseInt(insights.conversions).toLocaleString()}
@@ -120,19 +106,12 @@ export default function TikTokPage() {
 
       <CampaignTable loading={loading} error={error}>
         {campaigns.map((c) => (
-          <tr
-            key={c.campaign_id}
-            className="hover:bg-slate-800/30 transition-colors"
-          >
-            <td className="px-4 py-3 font-mono text-sm text-white">
-              {c.campaign_name}
-            </td>
+          <tr key={c.campaign_id} className="transition-colors hover:bg-slate-800/30">
+            <td className="px-4 py-3 font-mono text-sm text-white">{c.campaign_name}</td>
             <td className="px-4 py-3">
               <StatusBadge status={c.status} />
             </td>
-            <td className="px-4 py-3 font-mono text-xs text-slate-400">
-              {c.objective_type}
-            </td>
+            <td className="px-4 py-3 font-mono text-xs text-slate-400">{c.objective_type}</td>
             <td className="px-4 py-3 text-right font-mono text-sm text-slate-300">
               {c.budget ? `$${Number.parseFloat(c.budget).toLocaleString()}` : "—"}
             </td>
@@ -159,18 +138,10 @@ function CampaignTable({
       <table className="w-full">
         <thead>
           <tr className="border-b border-slate-800 bg-slate-900/50">
-            <th className="px-4 py-3 text-left font-mono text-xs text-slate-500">
-              Campaign
-            </th>
-            <th className="px-4 py-3 text-left font-mono text-xs text-slate-500">
-              Status
-            </th>
-            <th className="px-4 py-3 text-left font-mono text-xs text-slate-500">
-              Objective
-            </th>
-            <th className="px-4 py-3 text-right font-mono text-xs text-slate-500">
-              Budget
-            </th>
+            <th className="px-4 py-3 text-left font-mono text-xs text-slate-500">Campaign</th>
+            <th className="px-4 py-3 text-left font-mono text-xs text-slate-500">Status</th>
+            <th className="px-4 py-3 text-left font-mono text-xs text-slate-500">Objective</th>
+            <th className="px-4 py-3 text-right font-mono text-xs text-slate-500">Budget</th>
           </tr>
         </thead>
         <tbody className="divide-y divide-slate-800">{children}</tbody>
@@ -184,9 +155,7 @@ function StatusBadge({ status }: { readonly status: string }) {
   return (
     <span
       className={`rounded-full border px-2 py-0.5 font-mono text-[10px] ${
-        isActive
-          ? "border-neon-green/30 text-neon-green"
-          : "border-slate-700 text-slate-500"
+        isActive ? "border-neon-green/30 text-neon-green" : "border-slate-700 text-slate-500"
       }`}
     >
       {isActive ? "Active" : "Paused"}

--- a/src/app/[locale]/admin/campaigns/x/page.tsx
+++ b/src/app/[locale]/admin/campaigns/x/page.tsx
@@ -61,8 +61,7 @@ export default function XPage() {
         <BackLink />
         <div className="rounded-xl border border-yellow-900/30 bg-yellow-950/10 p-6">
           <p className="font-mono text-sm text-yellow-400">
-            X is not configured. Add <code className="text-yellow-300">X_API_KEY</code> to
-            AWS SSM.
+            X is not configured. Add <code className="text-yellow-300">X_API_KEY</code> to AWS SSM.
           </p>
         </div>
       </div>
@@ -77,17 +76,12 @@ export default function XPage() {
           <span className="h-2 w-2 animate-pulse rounded-full bg-sky-400" />
           <span className="font-mono text-xs text-sky-400">X (TWITTER)</span>
         </div>
-        <h1 className="font-heading text-2xl font-bold text-white">
-          X Campaigns
-        </h1>
+        <h1 className="font-heading text-2xl font-bold text-white">X Campaigns</h1>
       </div>
 
       {insights && (
         <div className="mb-8 grid grid-cols-4 gap-4">
-          <MetricCard
-            label="Impressions"
-            value={insights.impressions.toLocaleString()}
-          />
+          <MetricCard label="Impressions" value={insights.impressions.toLocaleString()} />
           <MetricCard label="Clicks" value={insights.clicks.toLocaleString()} />
           <MetricCard
             label="Spend"
@@ -104,42 +98,26 @@ export default function XPage() {
           <table className="w-full">
             <thead>
               <tr className="border-b border-slate-800 bg-slate-900/50">
-                <th className="px-4 py-3 text-left font-mono text-xs text-slate-500">
-                  Campaign
-                </th>
-                <th className="px-4 py-3 text-left font-mono text-xs text-slate-500">
-                  Status
-                </th>
+                <th className="px-4 py-3 text-left font-mono text-xs text-slate-500">Campaign</th>
+                <th className="px-4 py-3 text-left font-mono text-xs text-slate-500">Status</th>
                 <th className="px-4 py-3 text-right font-mono text-xs text-slate-500">
                   Impressions
                 </th>
-                <th className="px-4 py-3 text-right font-mono text-xs text-slate-500">
-                  Clicks
-                </th>
-                <th className="px-4 py-3 text-right font-mono text-xs text-slate-500">
-                  Cost
-                </th>
+                <th className="px-4 py-3 text-right font-mono text-xs text-slate-500">Clicks</th>
+                <th className="px-4 py-3 text-right font-mono text-xs text-slate-500">Cost</th>
               </tr>
             </thead>
             <tbody className="divide-y divide-slate-800">
               {campaigns.length === 0 && (
                 <tr>
-                  <td
-                    colSpan={5}
-                    className="py-8 text-center font-mono text-sm text-slate-600"
-                  >
+                  <td colSpan={5} className="py-8 text-center font-mono text-sm text-slate-600">
                     No X campaigns found.
                   </td>
                 </tr>
               )}
               {campaigns.map((c) => (
-                <tr
-                  key={c.id}
-                  className="hover:bg-slate-800/30 transition-colors"
-                >
-                  <td className="px-4 py-3 font-mono text-sm text-white">
-                    {c.name}
-                  </td>
+                <tr key={c.id} className="transition-colors hover:bg-slate-800/30">
+                  <td className="px-4 py-3 font-mono text-sm text-white">{c.name}</td>
                   <td className="px-4 py-3">
                     <span
                       className={`rounded-full border px-2 py-0.5 font-mono text-[10px] ${c.status === "ACTIVE" ? "border-neon-green/30 text-neon-green" : "border-slate-700 text-slate-500"}`}
@@ -191,7 +169,7 @@ function MetricCard({ label, value }: { readonly label: string; readonly value: 
 function Spinner() {
   return (
     <div className="flex items-center gap-3 py-4 text-slate-400">
-      <div className="h-4 w-4 animate-spin rounded-full border-2 border-neon-cyan border-t-transparent" />
+      <div className="border-neon-cyan h-4 w-4 animate-spin rounded-full border-2 border-t-transparent" />
       <span className="font-mono text-sm">Loading...</span>
     </div>
   );

--- a/src/app/[locale]/admin/client-portals/page.tsx
+++ b/src/app/[locale]/admin/client-portals/page.tsx
@@ -2,10 +2,7 @@
 
 import { fetchWithAuth } from "@/lib/fetch-with-auth";
 import { useEffect, useState } from "react";
-import type {
-  ClientPortal,
-  PortalStep,
-} from "@/app/api/admin/client-portals/route";
+import type { ClientPortal, PortalStep } from "@/app/api/admin/client-portals/route";
 import type { PendingClient } from "@/lib/pending-clients";
 
 const STEP_STATUS_OPTIONS: {
@@ -30,15 +27,12 @@ function StepManager({
   const [commentAuthor, setCommentAuthor] = useState("Cloudless Team");
   const [submitting, setSubmitting] = useState<string | null>(null);
   const [expanded, setExpanded] = useState<string | null>(
-    portal.steps.find((s) => s.status === "in-progress")?.id ?? null,
+    portal.steps.find((s) => s.status === "in-progress")?.id ?? null
   );
   const [newStepName, setNewStepName] = useState("");
   const [addingStep, setAddingStep] = useState(false);
 
-  async function updateStepStatus(
-    stepId: string,
-    status: PortalStep["status"],
-  ) {
+  async function updateStepStatus(stepId: string, status: PortalStep["status"]) {
     await fetchWithAuth("/api/admin/client-portals", {
       method: "PATCH",
       headers: { "Content-Type": "application/json" },
@@ -76,8 +70,7 @@ function StepManager({
   }
 
   async function deleteComment(stepId: string, commentId: string) {
-    if (!confirm("Delete this comment? The client will no longer see it."))
-      return;
+    if (!confirm("Delete this comment? The client will no longer see it.")) return;
     await fetchWithAuth("/api/admin/client-portals", {
       method: "PATCH",
       headers: { "Content-Type": "application/json" },
@@ -131,7 +124,7 @@ function StepManager({
       <div className="flex items-center gap-2">
         <label
           htmlFor="portal-comment-author"
-          className="font-mono text-xs text-slate-500 shrink-0"
+          className="shrink-0 font-mono text-xs text-slate-500"
         >
           Comment as:
         </label>
@@ -140,22 +133,17 @@ function StepManager({
           type="text"
           value={commentAuthor}
           onChange={(e) => setCommentAuthor(e.target.value)}
-          className="rounded-lg border border-slate-700 bg-void px-2 py-1 font-mono text-xs text-white placeholder-slate-600 focus:border-neon-blue/50 focus:outline-none"
+          className="bg-void focus:border-neon-blue/50 rounded-lg border border-slate-700 px-2 py-1 font-mono text-xs text-white placeholder-slate-600 focus:outline-none"
           placeholder="Cloudless Team"
         />
       </div>
 
       {portal.steps.map((step, idx) => {
         const isOpen = expanded === step.id;
-        const statusCfg = STEP_STATUS_OPTIONS.find(
-          (o) => o.value === step.status,
-        );
+        const statusCfg = STEP_STATUS_OPTIONS.find((o) => o.value === step.status);
 
         return (
-          <div
-            key={step.id}
-            className="rounded-xl border border-slate-800 bg-void-light/20"
-          >
+          <div key={step.id} className="bg-void-light/20 rounded-xl border border-slate-800">
             {/* Step header */}
             <div
               role="button"
@@ -170,25 +158,20 @@ function StepManager({
                 }
               }}
             >
-              <span className="font-mono text-xs text-slate-600 w-5 shrink-0">
+              <span className="w-5 shrink-0 font-mono text-xs text-slate-600">
                 {String(idx + 1).padStart(2, "0")}
               </span>
-              <span className="flex-1 font-mono text-sm text-white truncate">
-                {step.name}
-              </span>
+              <span className="flex-1 truncate font-mono text-sm text-white">{step.name}</span>
 
               {/* Status selector */}
               <select
                 value={step.status}
                 onChange={(e) => {
                   e.stopPropagation();
-                  updateStepStatus(
-                    step.id,
-                    e.target.value as PortalStep["status"],
-                  );
+                  updateStepStatus(step.id, e.target.value as PortalStep["status"]);
                 }}
                 onClick={(e) => e.stopPropagation()}
-                className={`rounded-lg border border-slate-700 bg-void px-2 py-1 font-mono text-xs focus:outline-none ${statusCfg?.color ?? "text-slate-400"}`}
+                className={`bg-void rounded-lg border border-slate-700 px-2 py-1 font-mono text-xs focus:outline-none ${statusCfg?.color ?? "text-slate-400"}`}
               >
                 {STEP_STATUS_OPTIONS.map((o) => (
                   <option key={o.value} value={o.value} className="text-white">
@@ -220,11 +203,7 @@ function StepManager({
                   stroke="currentColor"
                   strokeWidth={2}
                 >
-                  <path
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                    d="M6 18L18 6M6 6l12 12"
-                  />
+                  <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
                 </svg>
               </button>
 
@@ -235,25 +214,21 @@ function StepManager({
                 stroke="currentColor"
                 strokeWidth={2}
               >
-                <path
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                  d="M9 5l7 7-7 7"
-                />
+                <path strokeLinecap="round" strokeLinejoin="round" d="M9 5l7 7-7 7" />
               </svg>
             </div>
 
             {/* Comments + compose */}
             {isOpen && (
-              <div className="border-t border-slate-800 px-4 py-4 space-y-4">
+              <div className="space-y-4 border-t border-slate-800 px-4 py-4">
                 {step.comments.length > 0 ? (
                   <div className="space-y-3">
                     {step.comments.map((c) => (
                       <div key={c.id} className="group flex gap-3">
-                        <div className="flex h-7 w-7 shrink-0 items-center justify-center rounded-full border border-slate-700 bg-void font-mono text-[10px] uppercase text-slate-400">
+                        <div className="bg-void flex h-7 w-7 shrink-0 items-center justify-center rounded-full border border-slate-700 font-mono text-[10px] text-slate-400 uppercase">
                           {c.author.slice(0, 2)}
                         </div>
-                        <div className="flex-1 min-w-0">
+                        <div className="min-w-0 flex-1">
                           <div className="flex items-baseline gap-2">
                             <span className="font-mono text-xs font-semibold text-slate-300">
                               {c.author}
@@ -267,14 +242,14 @@ function StepManager({
                               })}
                             </span>
                           </div>
-                          <p className="mt-0.5 text-sm text-slate-400 whitespace-pre-wrap">
+                          <p className="mt-0.5 text-sm whitespace-pre-wrap text-slate-400">
                             {c.text}
                           </p>
                         </div>
                         <button
                           type="button"
                           onClick={() => deleteComment(step.id, c.id)}
-                          className="shrink-0 rounded p-1 text-slate-700 opacity-0 transition hover:text-red-400 group-hover:opacity-100"
+                          className="shrink-0 rounded p-1 text-slate-700 opacity-0 transition group-hover:opacity-100 hover:text-red-400"
                           title="Delete comment"
                         >
                           <svg
@@ -295,9 +270,7 @@ function StepManager({
                     ))}
                   </div>
                 ) : (
-                  <p className="font-mono text-xs text-slate-600">
-                    No comments yet for this step.
-                  </p>
+                  <p className="font-mono text-xs text-slate-600">No comments yet for this step.</p>
                 )}
 
                 {/* Add comment */}
@@ -318,15 +291,13 @@ function StepManager({
                       }
                     }}
                     placeholder="Add an update for the client… (Ctrl+Enter to send)"
-                    className="flex-1 resize-none rounded-lg border border-slate-700 bg-void px-3 py-2 font-mono text-xs text-white placeholder-slate-600 focus:border-neon-blue/50 focus:outline-none"
+                    className="bg-void focus:border-neon-blue/50 flex-1 resize-none rounded-lg border border-slate-700 px-3 py-2 font-mono text-xs text-white placeholder-slate-600 focus:outline-none"
                   />
                   <button
                     type="button"
-                    disabled={
-                      submitting === step.id || !commentDraft[step.id]?.trim()
-                    }
+                    disabled={submitting === step.id || !commentDraft[step.id]?.trim()}
                     onClick={() => submitComment(step.id)}
-                    className="self-end rounded-lg border border-neon-blue/30 px-3 py-2 font-mono text-xs text-neon-blue transition hover:border-neon-blue/60 disabled:opacity-40"
+                    className="border-neon-blue/30 text-neon-blue hover:border-neon-blue/60 self-end rounded-lg border px-3 py-2 font-mono text-xs transition disabled:opacity-40"
                   >
                     {submitting === step.id ? "..." : "Send"}
                   </button>
@@ -347,7 +318,7 @@ function StepManager({
             if (e.key === "Enter") addStep();
           }}
           placeholder="Add custom step…"
-          className="flex-1 rounded-lg border border-slate-700 bg-void px-3 py-2 font-mono text-xs text-white placeholder-slate-600 focus:border-neon-blue/50 focus:outline-none"
+          className="bg-void focus:border-neon-blue/50 flex-1 rounded-lg border border-slate-700 px-3 py-2 font-mono text-xs text-white placeholder-slate-600 focus:outline-none"
         />
         <button
           type="button"
@@ -374,15 +345,9 @@ function PendingClients({ onApproved }: Readonly<{ onApproved: () => void }>) {
       const res = await fetchWithAuth("/api/admin/pending-clients");
       if (!res.ok) throw new Error(`HTTP ${res.status}`);
       const data = await res.json();
-      setClients(
-        (data.clients ?? []).filter(
-          (c: PendingClient) => c.status === "waiting",
-        ),
-      );
+      setClients((data.clients ?? []).filter((c: PendingClient) => c.status === "waiting"));
     } catch (e) {
-      setError(
-        e instanceof Error ? e.message : "Failed to load pending clients",
-      );
+      setError(e instanceof Error ? e.message : "Failed to load pending clients");
     } finally {
       setLoading(false);
     }
@@ -412,8 +377,7 @@ function PendingClients({ onApproved }: Readonly<{ onApproved: () => void }>) {
   }
 
   async function decline(client: PendingClient) {
-    if (!confirm(`Decline ${client.email}? They'll need to sign up again.`))
-      return;
+    if (!confirm(`Decline ${client.email}? They'll need to sign up again.`)) return;
     try {
       await fetchWithAuth("/api/admin/pending-clients", {
         method: "DELETE",
@@ -449,8 +413,7 @@ function PendingClients({ onApproved }: Readonly<{ onApproved: () => void }>) {
         </span>
         <div>
           <h2 className="font-heading text-base font-semibold text-yellow-200">
-            {clients.length} client{clients.length === 1 ? "" : "s"} waiting for
-            portal access
+            {clients.length} client{clients.length === 1 ? "" : "s"} waiting for portal access
           </h2>
           <p className="font-mono text-xs text-yellow-700">
             Review their order and click Approve to create their portal.
@@ -475,11 +438,7 @@ function PendingClients({ onApproved }: Readonly<{ onApproved: () => void }>) {
                 <span className="font-heading text-sm font-semibold text-white">
                   {c.name || c.email}
                 </span>
-                {c.name && (
-                  <span className="font-mono text-xs text-slate-500">
-                    {c.email}
-                  </span>
-                )}
+                {c.name && <span className="font-mono text-xs text-slate-500">{c.email}</span>}
               </div>
               <div className="mt-1 flex flex-wrap items-center gap-2">
                 <span className="rounded-full border border-yellow-900/40 bg-yellow-950/20 px-2 py-0.5 font-mono text-[10px] text-yellow-400">
@@ -513,11 +472,9 @@ function PendingClients({ onApproved }: Readonly<{ onApproved: () => void }>) {
                 type="button"
                 disabled={approving === c.email}
                 onClick={() => approve(c)}
-                className="rounded-lg border border-neon-green/40 bg-neon-green/10 px-4 py-1.5 font-mono text-xs font-semibold text-neon-green transition hover:bg-neon-green/20 disabled:opacity-50"
+                className="border-neon-green/40 bg-neon-green/10 text-neon-green hover:bg-neon-green/20 rounded-lg border px-4 py-1.5 font-mono text-xs font-semibold transition disabled:opacity-50"
               >
-                {approving === c.email
-                  ? "Creating portal…"
-                  : "Approve & Create Portal"}
+                {approving === c.email ? "Creating portal…" : "Approve & Create Portal"}
               </button>
             </div>
           </div>
@@ -586,12 +543,7 @@ export default function ClientPortalsPage() {
   }
 
   async function revoke(token: string) {
-    if (
-      !confirm(
-        "Revoke this portal link? The client will lose access immediately.",
-      )
-    )
-      return;
+    if (!confirm("Revoke this portal link? The client will lose access immediately.")) return;
     try {
       await fetchWithAuth("/api/admin/client-portals", {
         method: "DELETE",
@@ -621,16 +573,12 @@ export default function ClientPortalsPage() {
       <div className="mb-8">
         <div className="border-neon-blue/20 bg-neon-blue/10 mb-4 inline-flex items-center gap-2 rounded-full border px-3 py-1.5">
           <span className="bg-neon-blue h-2 w-2 animate-pulse rounded-full" />
-          <span className="text-neon-blue font-mono text-xs">
-            CLIENT ACCESS
-          </span>
+          <span className="text-neon-blue font-mono text-xs">CLIENT ACCESS</span>
         </div>
-        <h1 className="font-heading text-2xl font-bold text-white">
-          Client Portals
-        </h1>
+        <h1 className="font-heading text-2xl font-bold text-white">Client Portals</h1>
         <p className="font-body mt-1 text-slate-400">
-          Generate secure portal links. Clients see their project timeline,
-          step-by-step updates, invoices, and subscription — no account needed.
+          Generate secure portal links. Clients see their project timeline, step-by-step updates,
+          invoices, and subscription — no account needed.
         </p>
       </div>
 
@@ -638,34 +586,27 @@ export default function ClientPortalsPage() {
       <PendingClients onApproved={load} />
 
       {/* Create form */}
-      <div className="mb-8 rounded-xl border border-slate-800 bg-void-light/30 p-6">
-        <h2 className="font-heading mb-4 text-sm font-semibold text-white">
-          Generate New Portal
-        </h2>
+      <div className="bg-void-light/30 mb-8 rounded-xl border border-slate-800 p-6">
+        <h2 className="font-heading mb-4 text-sm font-semibold text-white">Generate New Portal</h2>
         <form onSubmit={create} className="space-y-3">
           <div className="grid gap-3 sm:grid-cols-3">
             <div>
-              <label
-                htmlFor="cp-label"
-                className="font-mono mb-1 block text-xs text-slate-500"
-              >
+              <label htmlFor="cp-label" className="mb-1 block font-mono text-xs text-slate-500">
                 Label
               </label>
               <input
                 id="cp-label"
                 type="text"
                 value={form.label}
-                onChange={(e) =>
-                  setForm((f) => ({ ...f, label: e.target.value }))
-                }
+                onChange={(e) => setForm((f) => ({ ...f, label: e.target.value }))}
                 placeholder="e.g. Acme Corp — Cloud Migration"
-                className="w-full rounded-lg border border-slate-700 bg-void px-3 py-2 font-mono text-sm text-white placeholder-slate-600 focus:border-neon-blue/50 focus:outline-none"
+                className="bg-void focus:border-neon-blue/50 w-full rounded-lg border border-slate-700 px-3 py-2 font-mono text-sm text-white placeholder-slate-600 focus:outline-none"
               />
             </div>
             <div>
               <label
                 htmlFor="cp-client-email"
-                className="font-mono mb-1 block text-xs text-slate-500"
+                className="mb-1 block font-mono text-xs text-slate-500"
               >
                 Client Email
               </label>
@@ -673,17 +614,15 @@ export default function ClientPortalsPage() {
                 id="cp-client-email"
                 type="email"
                 value={form.clientEmail}
-                onChange={(e) =>
-                  setForm((f) => ({ ...f, clientEmail: e.target.value }))
-                }
+                onChange={(e) => setForm((f) => ({ ...f, clientEmail: e.target.value }))}
                 placeholder="client@example.com"
-                className="w-full rounded-lg border border-slate-700 bg-void px-3 py-2 font-mono text-sm text-white placeholder-slate-600 focus:border-neon-blue/50 focus:outline-none"
+                className="bg-void focus:border-neon-blue/50 w-full rounded-lg border border-slate-700 px-3 py-2 font-mono text-sm text-white placeholder-slate-600 focus:outline-none"
               />
             </div>
             <div>
               <label
                 htmlFor="cp-client-name"
-                className="font-mono mb-1 block text-xs text-slate-500"
+                className="mb-1 block font-mono text-xs text-slate-500"
               >
                 Client Name (optional)
               </label>
@@ -691,25 +630,21 @@ export default function ClientPortalsPage() {
                 id="cp-client-name"
                 type="text"
                 value={form.clientName}
-                onChange={(e) =>
-                  setForm((f) => ({ ...f, clientName: e.target.value }))
-                }
+                onChange={(e) => setForm((f) => ({ ...f, clientName: e.target.value }))}
                 placeholder="Jane Doe"
-                className="w-full rounded-lg border border-slate-700 bg-void px-3 py-2 font-mono text-sm text-white placeholder-slate-600 focus:border-neon-blue/50 focus:outline-none"
+                className="bg-void focus:border-neon-blue/50 w-full rounded-lg border border-slate-700 px-3 py-2 font-mono text-sm text-white placeholder-slate-600 focus:outline-none"
               />
             </div>
           </div>
           <p className="font-mono text-[10px] text-slate-600">
-            Portal is created with 6 default steps matching the Cloudless
-            workflow. You can customise steps after creation.
+            Portal is created with 6 default steps matching the Cloudless workflow. You can
+            customise steps after creation.
           </p>
-          {formError && (
-            <p className="font-mono text-xs text-red-400">{formError}</p>
-          )}
+          {formError && <p className="font-mono text-xs text-red-400">{formError}</p>}
           <button
             type="submit"
             disabled={creating}
-            className="rounded-lg border border-neon-blue/30 px-5 py-2 font-mono text-xs text-neon-blue transition hover:border-neon-blue/60 disabled:opacity-50"
+            className="border-neon-blue/30 text-neon-blue hover:border-neon-blue/60 rounded-lg border px-5 py-2 font-mono text-xs transition disabled:opacity-50"
           >
             {creating ? "Generating…" : "Generate Portal Link"}
           </button>
@@ -727,19 +662,17 @@ export default function ClientPortalsPage() {
           {["cp-skel-1", "cp-skel-2", "cp-skel-3"].map((k) => (
             <div
               key={k}
-              className="h-20 animate-pulse rounded-xl border border-slate-800 bg-void-light/30"
+              className="bg-void-light/30 h-20 animate-pulse rounded-xl border border-slate-800"
             />
           ))}
         </div>
       )}
 
       {!loading && portals.length === 0 && (
-        <div className="rounded-xl border border-slate-800 bg-void-light/30 px-6 py-12 text-center">
+        <div className="bg-void-light/30 rounded-xl border border-slate-800 px-6 py-12 text-center">
           <div className="mb-3 text-4xl">🔗</div>
-          <p className="font-heading text-sm text-slate-400">
-            No portals created yet.
-          </p>
-          <p className="font-mono mt-1 text-xs text-slate-600">
+          <p className="font-heading text-sm text-slate-400">No portals created yet.</p>
+          <p className="mt-1 font-mono text-xs text-slate-600">
             Generate a portal above to share with a client.
           </p>
         </div>
@@ -749,14 +682,12 @@ export default function ClientPortalsPage() {
         <div className="space-y-3">
           {portals.map((portal) => {
             const isOpen = expanded === portal.token;
-            const completedSteps = portal.steps.filter(
-              (s) => s.status === "completed",
-            ).length;
+            const completedSteps = portal.steps.filter((s) => s.status === "completed").length;
 
             return (
               <div
                 key={portal.token}
-                className={`rounded-xl border bg-void-light/30 transition-colors ${
+                className={`bg-void-light/30 rounded-xl border transition-colors ${
                   isOpen ? "border-neon-blue/30" : "border-slate-800"
                 }`}
               >
@@ -776,9 +707,7 @@ export default function ClientPortalsPage() {
                 >
                   <div className="min-w-0 flex-1">
                     <div className="flex items-center gap-2">
-                      <div className="font-heading font-semibold text-white">
-                        {portal.label}
-                      </div>
+                      <div className="font-heading font-semibold text-white">{portal.label}</div>
                       {portal.steps.length > 0 && (
                         <span className="font-mono text-[10px] text-slate-500">
                           {completedSteps}/{portal.steps.length} steps
@@ -786,9 +715,7 @@ export default function ClientPortalsPage() {
                       )}
                     </div>
                     <div className="mt-0.5 flex flex-wrap gap-3">
-                      <span className="font-mono text-xs text-slate-400">
-                        {portal.clientEmail}
-                      </span>
+                      <span className="font-mono text-xs text-slate-400">{portal.clientEmail}</span>
                       {portal.clientName && (
                         <span className="font-mono text-xs text-slate-500">
                           {portal.clientName}
@@ -803,7 +730,7 @@ export default function ClientPortalsPage() {
                     {portal.steps.length > 0 && (
                       <div className="mt-2 h-1 w-40 overflow-hidden rounded-full bg-slate-800">
                         <div
-                          className="h-full rounded-full bg-gradient-to-r from-neon-cyan to-neon-green transition-all"
+                          className="from-neon-cyan to-neon-green h-full rounded-full bg-gradient-to-r transition-all"
                           style={{
                             width: `${Math.round((completedSteps / portal.steps.length) * 100)}%`,
                           }}
@@ -840,11 +767,7 @@ export default function ClientPortalsPage() {
                       stroke="currentColor"
                       strokeWidth={2}
                     >
-                      <path
-                        strokeLinecap="round"
-                        strokeLinejoin="round"
-                        d="M9 5l7 7-7 7"
-                      />
+                      <path strokeLinecap="round" strokeLinejoin="round" d="M9 5l7 7-7 7" />
                     </svg>
                   </div>
                 </div>
@@ -865,7 +788,7 @@ export default function ClientPortalsPage() {
       )}
 
       {/* In-app help — how the portal flow works */}
-      <details className="mt-12 group rounded-xl border border-slate-800 bg-void-light/20 open:border-neon-cyan/30">
+      <details className="group bg-void-light/20 open:border-neon-cyan/30 mt-12 rounded-xl border border-slate-800">
         <summary className="flex cursor-pointer list-none items-center gap-3 px-5 py-4 text-sm font-semibold text-white [&::-webkit-details-marker]:hidden">
           <span className="bg-neon-cyan/15 border-neon-cyan/30 flex h-7 w-7 items-center justify-center rounded-full border text-base">
             ?
@@ -878,123 +801,89 @@ export default function ClientPortalsPage() {
             stroke="currentColor"
             strokeWidth={2}
           >
-            <path
-              strokeLinecap="round"
-              strokeLinejoin="round"
-              d="M9 5l7 7-7 7"
-            />
+            <path strokeLinecap="round" strokeLinejoin="round" d="M9 5l7 7-7 7" />
           </svg>
         </summary>
-        <div className="border-t border-slate-800 px-5 py-5 space-y-4 text-sm leading-relaxed text-slate-300">
+        <div className="space-y-4 border-t border-slate-800 px-5 py-5 text-sm leading-relaxed text-slate-300">
           <div>
-            <p className="font-mono text-xs tracking-widest text-neon-cyan uppercase mb-2">
+            <p className="text-neon-cyan mb-2 font-mono text-xs tracking-widest uppercase">
               The flow, end-to-end
             </p>
             <ol className="ml-5 list-decimal space-y-2 text-slate-400">
               <li>
                 Client clicks a service or bundle CTA on{" "}
-                <code className="rounded bg-void px-1 text-neon-cyan">
-                  /services
-                </code>{" "}
-                — they get sent to{" "}
-                <code className="rounded bg-void px-1 text-neon-cyan">
-                  /auth/signup?plan=...
-                </code>
+                <code className="bg-void text-neon-cyan rounded px-1">/services</code> — they get
+                sent to{" "}
+                <code className="bg-void text-neon-cyan rounded px-1">/auth/signup?plan=...</code>
               </li>
               <li>
                 Cognito sign-up + email verification → client lands in{" "}
-                <code className="rounded bg-void px-1 text-neon-cyan">
-                  /portal/waiting
-                </code>
+                <code className="bg-void text-neon-cyan rounded px-1">/portal/waiting</code>
               </li>
               <li>
-                Waiting room creates a pending entry. <strong>You</strong> get a
-                Slack ping +{" "}
-                <code className="rounded bg-void px-1 text-neon-cyan">
-                  tbaltzakis@cloudless.gr
-                </code>{" "}
+                Waiting room creates a pending entry. <strong>You</strong> get a Slack ping +{" "}
+                <code className="bg-void text-neon-cyan rounded px-1">tbaltzakis@cloudless.gr</code>{" "}
                 email with the client&rsquo;s name, email, and plan.
               </li>
               <li>
                 You see them in the &ldquo;
                 <span className="text-yellow-400">⏳ N clients waiting</span>
                 &rdquo; section above. One click on{" "}
-                <span className="text-neon-green">
-                  Approve & Create Portal
-                </span>{" "}
-                creates the portal with 6 default steps and emails the client a
-                link to{" "}
-                <code className="rounded bg-void px-1 text-neon-cyan">
-                  /portal/[token]
-                </code>{" "}
-                from{" "}
-                <code className="rounded bg-void px-1 text-neon-cyan">
-                  noreply@cloudless.gr
-                </code>
-                .
+                <span className="text-neon-green">Approve & Create Portal</span> creates the portal
+                with 6 default steps and emails the client a link to{" "}
+                <code className="bg-void text-neon-cyan rounded px-1">/portal/[token]</code> from{" "}
+                <code className="bg-void text-neon-cyan rounded px-1">noreply@cloudless.gr</code>.
               </li>
               <li>
-                Manage the project from the expanded portal card below — set
-                step statuses (pending → in-progress → completed), post comments
-                that appear in the client&rsquo;s timeline, add custom steps if
-                needed.
+                Manage the project from the expanded portal card below — set step statuses (pending
+                → in-progress → completed), post comments that appear in the client&rsquo;s
+                timeline, add custom steps if needed.
               </li>
             </ol>
           </div>
 
           <div>
-            <p className="font-mono text-xs tracking-widest text-neon-cyan uppercase mb-2">
+            <p className="text-neon-cyan mb-2 font-mono text-xs tracking-widest uppercase">
               Default project steps
             </p>
             <p className="text-slate-400">
-              Free Audit → Proposal & Scope → Setup & Kickoff → Implementation →
-              Review & Feedback → Delivery & Handoff. You can rename, reorder
-              (delete + re-add), or add custom steps per portal.
+              Free Audit → Proposal & Scope → Setup & Kickoff → Implementation → Review & Feedback →
+              Delivery & Handoff. You can rename, reorder (delete + re-add), or add custom steps per
+              portal.
             </p>
           </div>
 
           <div>
-            <p className="font-mono text-xs tracking-widest text-neon-cyan uppercase mb-2">
+            <p className="text-neon-cyan mb-2 font-mono text-xs tracking-widest uppercase">
               What the client sees
             </p>
             <ul className="ml-5 list-disc space-y-1 text-slate-400">
+              <li>Visual project timeline (horizontal on desktop, vertical on mobile)</li>
+              <li>Per-step status indicator and your comment thread per step</li>
+              <li>Linked Stripe subscriptions and paid invoices (if their email is in Stripe)</li>
               <li>
-                Visual project timeline (horizontal on desktop, vertical on
-                mobile)
-              </li>
-              <li>
-                Per-step status indicator and your comment thread per step
-              </li>
-              <li>
-                Linked Stripe subscriptions and paid invoices (if their email is
-                in Stripe)
-              </li>
-              <li>
-                Live updates — they don&rsquo;t need to refresh; their portal
-                polls for changes
+                Live updates — they don&rsquo;t need to refresh; their portal polls for changes
               </li>
             </ul>
           </div>
 
           <div>
-            <p className="font-mono text-xs tracking-widest text-neon-cyan uppercase mb-2">
+            <p className="text-neon-cyan mb-2 font-mono text-xs tracking-widest uppercase">
               Storage and security
             </p>
             <p className="text-slate-400">
               Pending clients live in SSM at{" "}
-              <code className="rounded bg-void px-1 text-neon-cyan">
+              <code className="bg-void text-neon-cyan rounded px-1">
                 /cloudless/PENDING_CLIENTS_JSON
               </code>
               ; portals at{" "}
-              <code className="rounded bg-void px-1 text-neon-cyan">
+              <code className="bg-void text-neon-cyan rounded px-1">
                 /cloudless/CLIENT_PORTALS_JSON
               </code>
               . The portal token is a UUID v4 (
-              <code className="rounded bg-void px-1 text-neon-cyan">
-                crypto.randomUUID
-              </code>
-              ) — anyone with the link can view that client&rsquo;s portal, so
-              share it via email only. Use Revoke to invalidate immediately.
+              <code className="bg-void text-neon-cyan rounded px-1">crypto.randomUUID</code>) —
+              anyone with the link can view that client&rsquo;s portal, so share it via email only.
+              Use Revoke to invalidate immediately.
             </p>
           </div>
         </div>

--- a/src/app/[locale]/admin/crm/companies/page.tsx
+++ b/src/app/[locale]/admin/crm/companies/page.tsx
@@ -4,8 +4,7 @@ import React, { useEffect, useState, useCallback } from "react";
 import { fetchWithAuth } from "@/lib/fetch-with-auth";
 
 const REFRESH_INTERVAL = 10_000;
-const TH_CLASS =
-  "px-6 py-3 text-left font-mono text-xs font-medium text-slate-500";
+const TH_CLASS = "px-6 py-3 text-left font-mono text-xs font-medium text-slate-500";
 
 interface Company {
   id: string;
@@ -114,9 +113,7 @@ export default function AdminCompaniesPage() {
                   key={c.id}
                   className="hover:bg-void-lighter/30 border-b border-slate-800/50 transition-colors"
                 >
-                  <td className="px-6 py-4 font-medium text-white">
-                    {c.properties.name || "—"}
-                  </td>
+                  <td className="px-6 py-4 font-medium text-white">{c.properties.name || "—"}</td>
                   <td className="text-neon-cyan px-6 py-4 font-mono text-xs">
                     {c.properties.domain ? (
                       <a
@@ -132,28 +129,19 @@ export default function AdminCompaniesPage() {
                     )}
                   </td>
                   <td className="px-6 py-4 text-slate-300">
-                    {[c.properties.city, c.properties.country]
-                      .filter(Boolean)
-                      .join(", ") || "—"}
+                    {[c.properties.city, c.properties.country].filter(Boolean).join(", ") || "—"}
                   </td>
                   <td className="px-6 py-4 font-mono text-slate-500">
                     {c.properties.createdate
-                      ? new Date(c.properties.createdate).toLocaleDateString(
-                          "en-IE",
-                        )
+                      ? new Date(c.properties.createdate).toLocaleDateString("en-IE")
                       : "—"}
                   </td>
                 </tr>
               ))}
               {filtered.length === 0 && (
                 <tr>
-                  <td
-                    colSpan={4}
-                    className="px-6 py-12 text-center font-mono text-slate-600"
-                  >
-                    {search
-                      ? "No companies match your search"
-                      : "No companies yet"}
+                  <td colSpan={4} className="px-6 py-12 text-center font-mono text-slate-600">
+                    {search ? "No companies match your search" : "No companies yet"}
                   </td>
                 </tr>
               )}
@@ -172,12 +160,8 @@ export default function AdminCompaniesPage() {
             <span className="bg-neon-magenta h-2 w-2 animate-pulse rounded-full" />
             <span className="text-neon-magenta font-mono text-xs">CRM</span>
           </div>
-          <h1 className="font-heading text-2xl font-bold text-white">
-            Companies
-          </h1>
-          <p className="font-body mt-1 text-slate-400">
-            Company accounts synced from HubSpot.
-          </p>
+          <h1 className="font-heading text-2xl font-bold text-white">Companies</h1>
+          <p className="font-body mt-1 text-slate-400">Company accounts synced from HubSpot.</p>
         </div>
         <div className="flex shrink-0 flex-col items-end gap-1">
           <button
@@ -207,9 +191,7 @@ export default function AdminCompaniesPage() {
         <div className="bg-void-light/50 rounded-xl border border-slate-800 p-4">
           <p className="font-mono text-xs text-slate-500">With Domain</p>
           <p className="font-heading text-neon-cyan mt-1 text-2xl font-bold">
-            {loading
-              ? "…"
-              : companies.filter((c) => c.properties.domain).length}
+            {loading ? "…" : companies.filter((c) => c.properties.domain).length}
           </p>
         </div>
       </div>
@@ -221,7 +203,7 @@ export default function AdminCompaniesPage() {
           placeholder="Search by name, domain, or location…"
           value={search}
           onChange={(e) => setSearch(e.target.value)}
-          className="bg-void-light focus:border-neon-magenta/50 w-full max-w-md rounded-lg border border-slate-800 px-4 py-3 font-mono text-sm text-white transition-colors placeholder:text-slate-[...]"
+          className="bg-void-light focus:border-neon-magenta/50 placeholder:text-slate-[...] w-full max-w-md rounded-lg border border-slate-800 px-4 py-3 font-mono text-sm text-white transition-colors"
         />
       </div>
 

--- a/src/app/[locale]/admin/crm/page.tsx
+++ b/src/app/[locale]/admin/crm/page.tsx
@@ -43,9 +43,7 @@ export default function AdminCRMPage() {
         const data = await res.json();
         setContacts(data.contacts ?? []);
       } catch (err) {
-        setError(
-          err instanceof Error ? err.message : "Failed to load contacts",
-        );
+        setError(err instanceof Error ? err.message : "Failed to load contacts");
       } finally {
         setLoading(false);
       }
@@ -124,41 +122,31 @@ export default function AdminCRMPage() {
                   className="hover:bg-void-lighter/30 border-b border-slate-800/50 transition-colors"
                 >
                   <td className="px-6 py-4 text-white">
-                    {[c.properties.firstname, c.properties.lastname]
-                      .filter(Boolean)
-                      .join(" ") || "—"}
+                    {[c.properties.firstname, c.properties.lastname].filter(Boolean).join(" ") ||
+                      "—"}
                   </td>
                   <td className="text-neon-cyan px-6 py-4 font-mono text-xs">
                     {c.properties.email ?? "—"}
                   </td>
-                  <td className="px-6 py-4 text-slate-300">
-                    {c.properties.company || "—"}
-                  </td>
+                  <td className="px-6 py-4 text-slate-300">{c.properties.company || "—"}</td>
                   <td className="px-6 py-4">
                     <span
-                      className={`rounded-full px-2 py-0.5 font-mono text-[10px] ${leadStatusClasses[c.properties.hs_lead_status ?? ""] ?? "text-slate-400 bg-slate-800/50"}`}
+                      className={`rounded-full px-2 py-0.5 font-mono text-[10px] ${leadStatusClasses[c.properties.hs_lead_status ?? ""] ?? "bg-slate-800/50 text-slate-400"}`}
                     >
                       {c.properties.hs_lead_status ?? "—"}
                     </span>
                   </td>
                   <td className="px-6 py-4 font-mono text-slate-500">
                     {c.properties.createdate
-                      ? new Date(c.properties.createdate).toLocaleDateString(
-                          "en-IE",
-                        )
+                      ? new Date(c.properties.createdate).toLocaleDateString("en-IE")
                       : "—"}
                   </td>
                 </tr>
               ))}
               {filtered.length === 0 && (
                 <tr>
-                  <td
-                    colSpan={5}
-                    className="px-6 py-12 text-center font-mono text-slate-600"
-                  >
-                    {search
-                      ? "No contacts match your search"
-                      : "No contacts yet"}
+                  <td colSpan={5} className="px-6 py-12 text-center font-mono text-slate-600">
+                    {search ? "No contacts match your search" : "No contacts yet"}
                   </td>
                 </tr>
               )}
@@ -176,12 +164,8 @@ export default function AdminCRMPage() {
           <span className="bg-neon-magenta h-2 w-2 animate-pulse rounded-full" />
           <span className="text-neon-magenta font-mono text-xs">CRM</span>
         </div>
-        <h1 className="font-heading text-2xl font-bold text-white">
-          CRM Contacts
-        </h1>
-        <p className="font-body mt-1 text-slate-400">
-          Leads and contacts synced from HubSpot.
-        </p>
+        <h1 className="font-heading text-2xl font-bold text-white">CRM Contacts</h1>
+        <p className="font-body mt-1 text-slate-400">Leads and contacts synced from HubSpot.</p>
       </div>
 
       {/* Stats */}
@@ -195,10 +179,7 @@ export default function AdminCRMPage() {
         <div className="bg-void-light/50 rounded-xl border border-slate-800 p-4">
           <p className="font-mono text-xs text-slate-500">New Leads</p>
           <p className="font-heading text-neon-cyan mt-1 text-2xl font-bold">
-            {loading
-              ? "…"
-              : contacts.filter((c) => c.properties.hs_lead_status === "NEW")
-                  .length}
+            {loading ? "…" : contacts.filter((c) => c.properties.hs_lead_status === "NEW").length}
           </p>
         </div>
         <div className="bg-void-light/50 rounded-xl border border-slate-800 p-4">
@@ -206,9 +187,7 @@ export default function AdminCRMPage() {
           <p className="font-heading text-neon-magenta mt-1 text-2xl font-bold">
             {loading
               ? "…"
-              : contacts.filter(
-                  (c) => c.properties.hs_lead_status === "OPEN_DEAL",
-                ).length}
+              : contacts.filter((c) => c.properties.hs_lead_status === "OPEN_DEAL").length}
           </p>
         </div>
       </div>

--- a/src/app/[locale]/admin/crm/tickets/page.tsx
+++ b/src/app/[locale]/admin/crm/tickets/page.tsx
@@ -4,8 +4,7 @@ import React, { useEffect, useState, useCallback } from "react";
 import { fetchWithAuth } from "@/lib/fetch-with-auth";
 
 const REFRESH_INTERVAL = 10_000;
-const TH_CLASS =
-  "px-6 py-3 text-left font-mono text-xs font-medium text-slate-500";
+const TH_CLASS = "px-6 py-3 text-left font-mono text-xs font-medium text-slate-500";
 
 interface Ticket {
   id: string;
@@ -85,9 +84,7 @@ export default function AdminTicketsPage() {
     return (t.properties.subject ?? "").toLowerCase().includes(q);
   });
 
-  const open = tickets.filter(
-    (t) => t.properties.hs_pipeline_stage !== "4",
-  ).length;
+  const open = tickets.filter((t) => t.properties.hs_pipeline_stage !== "4").length;
 
   let mainContent: React.ReactElement;
   if (loading) {
@@ -122,8 +119,7 @@ export default function AdminTicketsPage() {
             </thead>
             <tbody>
               {filtered.map((t) => {
-                const priority =
-                  t.properties.hs_ticket_priority?.toUpperCase() ?? "";
+                const priority = t.properties.hs_ticket_priority?.toUpperCase() ?? "";
                 const stage = t.properties.hs_pipeline_stage ?? "";
                 return (
                   <tr
@@ -131,14 +127,12 @@ export default function AdminTicketsPage() {
                     className="hover:bg-void-lighter/30 border-b border-slate-800/50 transition-colors"
                   >
                     <td className="max-w-xs px-6 py-4 text-white">
-                      <span className="line-clamp-2">
-                        {t.properties.subject || "—"}
-                      </span>
+                      <span className="line-clamp-2">{t.properties.subject || "—"}</span>
                     </td>
                     <td className="px-6 py-4">
                       {priority ? (
                         <span
-                          className={`rounded-full px-2 py-0.5 font-mono text-[10px] ${priorityClasses[priority] ?? "text-slate-400 bg-slate-800/50"}`}
+                          className={`rounded-full px-2 py-0.5 font-mono text-[10px] ${priorityClasses[priority] ?? "bg-slate-800/50 text-slate-400"}`}
                         >
                           {priority}
                         </span>
@@ -148,16 +142,14 @@ export default function AdminTicketsPage() {
                     </td>
                     <td className="px-6 py-4">
                       <span
-                        className={`rounded-full px-2 py-0.5 font-mono text-[10px] ${stage === "4" ? "text-neon-green bg-neon-green/10" : "text-yellow-400 bg-yellow-400/10"}`}
+                        className={`rounded-full px-2 py-0.5 font-mono text-[10px] ${stage === "4" ? "text-neon-green bg-neon-green/10" : "bg-yellow-400/10 text-yellow-400"}`}
                       >
                         {stageLabels[stage] ?? (stage || "—")}
                       </span>
                     </td>
                     <td className="px-6 py-4 font-mono text-slate-500">
                       {t.properties.createdate
-                        ? new Date(t.properties.createdate).toLocaleDateString(
-                            "en-IE",
-                          )
+                        ? new Date(t.properties.createdate).toLocaleDateString("en-IE")
                         : "—"}
                     </td>
                   </tr>
@@ -165,10 +157,7 @@ export default function AdminTicketsPage() {
               })}
               {filtered.length === 0 && (
                 <tr>
-                  <td
-                    colSpan={4}
-                    className="px-6 py-12 text-center font-mono text-slate-600"
-                  >
+                  <td colSpan={4} className="px-6 py-12 text-center font-mono text-slate-600">
                     {search ? "No tickets match your search" : "No tickets yet"}
                   </td>
                 </tr>
@@ -188,9 +177,7 @@ export default function AdminTicketsPage() {
             <span className="bg-neon-magenta h-2 w-2 animate-pulse rounded-full" />
             <span className="text-neon-magenta font-mono text-xs">CRM</span>
           </div>
-          <h1 className="font-heading text-2xl font-bold text-white">
-            Support Tickets
-          </h1>
+          <h1 className="font-heading text-2xl font-bold text-white">Support Tickets</h1>
           <p className="font-body mt-1 text-slate-400">
             Customer support tickets synced from HubSpot.
           </p>

--- a/src/app/[locale]/admin/docs/page.tsx
+++ b/src/app/[locale]/admin/docs/page.tsx
@@ -44,12 +44,8 @@ export default function AdminDocsPage() {
             <span className="bg-neon-cyan h-2 w-2 animate-pulse rounded-full" />
             <span className="text-neon-cyan font-mono text-xs">DOCS</span>
           </div>
-          <h1 className="font-heading text-2xl font-bold text-white">
-            Documentation
-          </h1>
-          <p className="font-body mt-1 text-slate-400">
-            All docs from your Notion docs database.
-          </p>
+          <h1 className="font-heading text-2xl font-bold text-white">Documentation</h1>
+          <p className="font-body mt-1 text-slate-400">All docs from your Notion docs database.</p>
         </div>
         <button
           type="button"
@@ -71,8 +67,7 @@ export default function AdminDocsPage() {
         <div className="mb-4 flex items-center gap-4">
           <div className="flex items-center gap-3">
             <span className="font-mono text-xs text-slate-500">
-              <span className="text-neon-green">{publishedCount}</span>{" "}
-              published &nbsp;·&nbsp;
+              <span className="text-neon-green">{publishedCount}</span> published &nbsp;·&nbsp;
               <span className="text-slate-400">{draftCount}</span> drafts
             </span>
           </div>
@@ -83,9 +78,7 @@ export default function AdminDocsPage() {
               onChange={(e) => setShowDrafts(e.target.checked)}
               className="rounded border-slate-600"
             />
-            <span className="font-mono text-xs text-slate-400">
-              Show drafts
-            </span>
+            <span className="font-mono text-xs text-slate-400">Show drafts</span>
           </label>
         </div>
       )}
@@ -95,7 +88,7 @@ export default function AdminDocsPage() {
           {[1, 2, 3].map((i) => (
             <div
               key={i}
-              className="animate-pulse rounded-xl border border-slate-800 bg-void-light/50 p-5"
+              className="bg-void-light/50 animate-pulse rounded-xl border border-slate-800 p-5"
             >
               <div className="mb-2 h-4 w-1/3 rounded bg-slate-700/60" />
               <div className="space-y-2">
@@ -109,7 +102,7 @@ export default function AdminDocsPage() {
       )}
 
       {!loading && !error && filtered.length === 0 && (
-        <div className="rounded-xl border border-slate-800 bg-void-light/30 py-12 text-center">
+        <div className="bg-void-light/30 rounded-xl border border-slate-800 py-12 text-center">
           <p className="font-mono text-sm text-slate-500">
             {docs.length === 0 ? "No docs in Notion yet." : "No docs to show."}
           </p>
@@ -119,18 +112,14 @@ export default function AdminDocsPage() {
       {!loading && filtered.length > 0 && (
         <div className="space-y-6">
           {categories.map((category) => {
-            const categoryDocs = filtered.filter(
-              (d) => d.category === category,
-            );
+            const categoryDocs = filtered.filter((d) => d.category === category);
             return (
               <div
                 key={category}
-                className="rounded-xl border border-slate-800 bg-void-light/50 overflow-hidden"
+                className="bg-void-light/50 overflow-hidden rounded-xl border border-slate-800"
               >
-                <div className="border-b border-slate-800 px-5 py-3 flex items-center justify-between">
-                  <h2 className="font-mono text-xs font-semibold text-white">
-                    {category}
-                  </h2>
+                <div className="flex items-center justify-between border-b border-slate-800 px-5 py-3">
+                  <h2 className="font-mono text-xs font-semibold text-white">{category}</h2>
                   <span className="font-mono text-[10px] text-slate-600">
                     {categoryDocs.length} doc
                     {categoryDocs.length !== 1 ? "s" : ""}
@@ -144,15 +133,15 @@ export default function AdminDocsPage() {
                     >
                       <div className="min-w-0 flex-1">
                         <div className="flex items-center gap-2">
-                          <span className="font-mono text-xs text-slate-500 w-6 shrink-0">
+                          <span className="w-6 shrink-0 font-mono text-xs text-slate-500">
                             {doc.order}
                           </span>
-                          <span className="font-medium text-white text-sm truncate">
+                          <span className="truncate text-sm font-medium text-white">
                             {doc.title || "(Untitled)"}
                           </span>
                         </div>
                         {doc.description && (
-                          <p className="mt-0.5 ml-8 font-mono text-[10px] text-slate-600 truncate">
+                          <p className="mt-0.5 ml-8 truncate font-mono text-[10px] text-slate-600">
                             {doc.description}
                           </p>
                         )}
@@ -188,8 +177,8 @@ export default function AdminDocsPage() {
             );
           })}
           <p className="text-right font-mono text-[10px] text-slate-600">
-            {filtered.length} doc{filtered.length !== 1 ? "s" : ""} across{" "}
-            {categories.length} categor{categories.length !== 1 ? "ies" : "y"}
+            {filtered.length} doc{filtered.length !== 1 ? "s" : ""} across {categories.length}{" "}
+            categor{categories.length !== 1 ? "ies" : "y"}
           </p>
         </div>
       )}

--- a/src/app/[locale]/admin/email/page.tsx
+++ b/src/app/[locale]/admin/email/page.tsx
@@ -55,9 +55,7 @@ export default function EmailPage() {
     setLoading(true);
     setError(null);
     try {
-      const res = await fetchWithAuth(
-        `/api/admin/email/contacts?tab=${t}&limit=100`,
-      );
+      const res = await fetchWithAuth(`/api/admin/email/contacts?tab=${t}&limit=100`);
       if (res.status === 503) {
         setNotConfigured(true);
         return;
@@ -82,8 +80,8 @@ export default function EmailPage() {
         <PageHeader />
         <div className="rounded-xl border border-yellow-900/30 bg-yellow-950/10 p-6">
           <p className="font-mono text-sm text-yellow-400">
-            HubSpot is not configured. Add{" "}
-            <code className="text-yellow-300">HUBSPOT_API_KEY</code> to AWS SSM.
+            HubSpot is not configured. Add <code className="text-yellow-300">HUBSPOT_API_KEY</code>{" "}
+            to AWS SSM.
           </p>
         </div>
       </div>
@@ -101,13 +99,9 @@ export default function EmailPage() {
         <div className="mb-8 inline-flex items-center gap-6 rounded-xl border border-slate-800 bg-slate-900/50 px-6 py-4">
           <div>
             <p className="font-mono text-xs text-slate-500">
-              {tab === "subscribers"
-                ? "Newsletter Subscribers"
-                : "CRM Contacts"}
+              {tab === "subscribers" ? "Newsletter Subscribers" : "CRM Contacts"}
             </p>
-            <p className="font-mono text-2xl font-bold text-white">
-              {data.total.toLocaleString()}
-            </p>
+            <p className="font-mono text-2xl font-bold text-white">{data.total.toLocaleString()}</p>
           </div>
           <div className="h-8 w-px bg-slate-800" />
           <p className="font-mono text-xs text-slate-600">
@@ -133,9 +127,7 @@ export default function EmailPage() {
             type="button"
             onClick={() => setTab(id)}
             className={`flex-1 rounded-md px-3 py-2 font-mono text-xs transition-all ${
-              tab === id
-                ? "bg-neon-cyan/10 text-neon-cyan"
-                : "text-slate-500 hover:text-slate-300"
+              tab === id ? "bg-neon-cyan/10 text-neon-cyan" : "text-slate-500 hover:text-slate-300"
             }`}
           >
             {label}
@@ -161,20 +153,12 @@ export default function EmailPage() {
           <table className="w-full">
             <thead>
               <tr className="border-b border-slate-800 bg-slate-900/50">
-                <th className="px-4 py-3 text-left font-mono text-xs text-slate-500">
-                  Email
-                </th>
-                <th className="px-4 py-3 text-left font-mono text-xs text-slate-500">
-                  Name
-                </th>
+                <th className="px-4 py-3 text-left font-mono text-xs text-slate-500">Email</th>
+                <th className="px-4 py-3 text-left font-mono text-xs text-slate-500">Name</th>
                 {tab === "contacts" && (
-                  <th className="px-4 py-3 text-left font-mono text-xs text-slate-500">
-                    Stage
-                  </th>
+                  <th className="px-4 py-3 text-left font-mono text-xs text-slate-500">Stage</th>
                 )}
-                <th className="px-4 py-3 text-left font-mono text-xs text-slate-500">
-                  Added
-                </th>
+                <th className="px-4 py-3 text-left font-mono text-xs text-slate-500">Added</th>
               </tr>
             </thead>
             <tbody className="divide-y divide-slate-800">
@@ -190,43 +174,29 @@ export default function EmailPage() {
               )}
               {contacts.map((c) => {
                 const p = c.properties;
-                const name = [p.firstname, p.lastname]
-                  .filter(Boolean)
-                  .join(" ");
+                const name = [p.firstname, p.lastname].filter(Boolean).join(" ");
                 const stage = p.lifecyclestage ?? "";
                 return (
-                  <tr
-                    key={c.id}
-                    className="transition-colors hover:bg-slate-800/30"
-                  >
-                    <td className="px-4 py-3 font-mono text-sm text-white">
-                      {p.email ?? "—"}
-                    </td>
-                    <td className="px-4 py-3 font-mono text-sm text-slate-300">
-                      {name || "—"}
-                    </td>
+                  <tr key={c.id} className="transition-colors hover:bg-slate-800/30">
+                    <td className="px-4 py-3 font-mono text-sm text-white">{p.email ?? "—"}</td>
+                    <td className="px-4 py-3 font-mono text-sm text-slate-300">{name || "—"}</td>
                     {tab === "contacts" && (
                       <td className="px-4 py-3">
                         {stage ? (
                           <span
                             className={`rounded-full border px-2 py-0.5 font-mono text-[10px] ${
-                              LIFECYCLE_BADGE[stage] ??
-                              "border-slate-700 text-slate-500"
+                              LIFECYCLE_BADGE[stage] ?? "border-slate-700 text-slate-500"
                             }`}
                           >
                             {LIFECYCLE_LABEL[stage] ?? stage}
                           </span>
                         ) : (
-                          <span className="font-mono text-xs text-slate-600">
-                            —
-                          </span>
+                          <span className="font-mono text-xs text-slate-600">—</span>
                         )}
                       </td>
                     )}
                     <td className="px-4 py-3 font-mono text-xs text-slate-500">
-                      {p.createdate
-                        ? new Date(p.createdate).toLocaleDateString("en-IE")
-                        : "—"}
+                      {p.createdate ? new Date(p.createdate).toLocaleDateString("en-IE") : "—"}
                     </td>
                   </tr>
                 );
@@ -244,9 +214,7 @@ function PageHeader() {
     <div className="mb-8">
       <div className="bg-neon-cyan/10 border-neon-cyan/20 mb-4 inline-flex items-center gap-2 rounded-full border px-3 py-1.5">
         <span className="bg-neon-cyan h-2 w-2 animate-pulse rounded-full" />
-        <span className="text-neon-cyan font-mono text-xs">
-          EMAIL MARKETING
-        </span>
+        <span className="text-neon-cyan font-mono text-xs">EMAIL MARKETING</span>
       </div>
       <h1 className="font-heading text-2xl font-bold text-white">Email</h1>
       <p className="font-body mt-1 text-slate-400">

--- a/src/app/[locale]/admin/error.tsx
+++ b/src/app/[locale]/admin/error.tsx
@@ -18,15 +18,11 @@ export default function AdminError({
     <div className="flex flex-1 items-center justify-center px-6 py-24">
       <div className="max-w-md text-center">
         <p className="text-neon-magenta font-mono text-5xl font-bold">ERROR</p>
-        <h1 className="font-heading mt-4 text-2xl font-bold text-white">
-          Admin panel error
-        </h1>
+        <h1 className="font-heading mt-4 text-2xl font-bold text-white">Admin panel error</h1>
         <p className="mt-3 font-mono text-sm text-slate-400">
           Something went wrong in the admin panel.
           {error.digest && (
-            <span className="mt-1 block text-slate-600">
-              digest: {error.digest}
-            </span>
+            <span className="mt-1 block text-slate-600">digest: {error.digest}</span>
           )}
         </p>
         <div className="mt-8 flex justify-center gap-3">

--- a/src/app/[locale]/admin/errors/page.tsx
+++ b/src/app/[locale]/admin/errors/page.tsx
@@ -50,7 +50,7 @@ const ACTION_LABELS: Record<string, string> = {
 
 async function performErrorAction(
   id: string,
-  status: "resolved" | "ignored" | "unresolved",
+  status: "resolved" | "ignored" | "unresolved"
 ): Promise<string> {
   const res = await fetchWithAuth(`/api/admin/ops/errors/${id}`, {
     method: "PUT",
@@ -97,10 +97,7 @@ export default function AdminErrorsPage() {
     fetchErrors();
   }, [fetchErrors]);
 
-  const handleAction = async (
-    id: string,
-    status: "resolved" | "ignored" | "unresolved",
-  ) => {
+  const handleAction = async (id: string, status: "resolved" | "ignored" | "unresolved") => {
     setActionLoading(`${status}-${id}`);
     setActionMsg(null);
     try {
@@ -142,9 +139,7 @@ export default function AdminErrorsPage() {
         </div>
         <div className="flex items-start justify-between gap-4">
           <div>
-            <h1 className="font-heading text-2xl font-bold text-white">
-              Error Monitoring
-            </h1>
+            <h1 className="font-heading text-2xl font-bold text-white">Error Monitoring</h1>
             <p className="font-body mt-1 text-slate-400">
               Unresolved Sentry issues — resolve or ignore directly from here.
             </p>
@@ -184,11 +179,7 @@ export default function AdminErrorsPage() {
         <div className="bg-void-light/50 rounded-xl border border-slate-800 p-4">
           <p className="font-mono text-xs text-slate-500">Total Events</p>
           <p className="font-heading mt-1 text-2xl font-bold text-slate-300">
-            {loading
-              ? "…"
-              : issues
-                  .reduce((s, i) => s + Number(i.count || 0), 0)
-                  .toLocaleString()}
+            {loading ? "…" : issues.reduce((s, i) => s + Number(i.count || 0), 0).toLocaleString()}
           </p>
         </div>
       </div>
@@ -196,21 +187,19 @@ export default function AdminErrorsPage() {
       {/* Filter tabs */}
       {!loading && !error && issues.length > 0 && (
         <div className="mb-4 flex flex-wrap gap-2">
-          {(["all", "fatal", "error", "warning", "info"] as FilterLevel[]).map(
-            (lvl) => (
-              <button
-                key={lvl}
-                onClick={() => setFilter(lvl)}
-                className={`min-h-[34px] rounded-lg border px-3 py-1 font-mono text-xs transition-all ${
-                  filter === lvl
-                    ? "bg-neon-magenta/10 text-neon-magenta border-neon-magenta/20"
-                    : "border-slate-800 text-slate-500 hover:border-slate-700 hover:text-white"
-                }`}
-              >
-                {lvl} ({counts[lvl]})
-              </button>
-            ),
-          )}
+          {(["all", "fatal", "error", "warning", "info"] as FilterLevel[]).map((lvl) => (
+            <button
+              key={lvl}
+              onClick={() => setFilter(lvl)}
+              className={`min-h-[34px] rounded-lg border px-3 py-1 font-mono text-xs transition-all ${
+                filter === lvl
+                  ? "bg-neon-magenta/10 text-neon-magenta border-neon-magenta/20"
+                  : "border-slate-800 text-slate-500 hover:border-slate-700 hover:text-white"
+              }`}
+            >
+              {lvl} ({counts[lvl]})
+            </button>
+          ))}
         </div>
       )}
 
@@ -239,18 +228,12 @@ export default function AdminErrorsPage() {
       ) : issues.length === 0 ? (
         <div className="bg-void-light/50 rounded-xl border border-slate-800 p-12 text-center">
           <p className="text-neon-green text-4xl">✓</p>
-          <p className="font-heading mt-4 text-lg font-semibold text-white">
-            All Clear
-          </p>
-          <p className="mt-1 text-sm text-slate-500">
-            No unresolved issues in Sentry.
-          </p>
+          <p className="font-heading mt-4 text-lg font-semibold text-white">All Clear</p>
+          <p className="mt-1 text-sm text-slate-500">No unresolved issues in Sentry.</p>
         </div>
       ) : visible.length === 0 ? (
         <div className="bg-void-light/50 rounded-xl border border-slate-800 p-8 text-center">
-          <p className="font-mono text-sm text-slate-500">
-            No issues at this level.
-          </p>
+          <p className="font-mono text-sm text-slate-500">No issues at this level.</p>
         </div>
       ) : (
         <div className="space-y-3">
@@ -258,8 +241,7 @@ export default function AdminErrorsPage() {
             const isActing = actionLoading !== null;
             const dotClass = levelDot[issue.level] ?? "bg-slate-600";
             const labelClass =
-              levelClasses[issue.level] ??
-              "text-slate-400 bg-slate-800/50 border-slate-700";
+              levelClasses[issue.level] ?? "text-slate-400 bg-slate-800/50 border-slate-700";
 
             return (
               <div
@@ -268,7 +250,7 @@ export default function AdminErrorsPage() {
               >
                 <div className="flex flex-wrap items-start gap-3">
                   {/* Level dot + badge */}
-                  <div className="mt-1 shrink-0 flex items-center gap-2">
+                  <div className="mt-1 flex shrink-0 items-center gap-2">
                     <span className={`h-2 w-2 rounded-full ${dotClass}`} />
                     <span
                       className={`rounded-full border px-2 py-0.5 font-mono text-[10px] ${labelClass}`}
@@ -286,11 +268,9 @@ export default function AdminErrorsPage() {
                       {issue.culprit || "unknown location"}
                     </p>
                     <p className="mt-1 font-mono text-[10px] text-slate-600">
-                      First:{" "}
-                      {new Date(issue.firstSeen).toLocaleDateString("en-IE")}
+                      First: {new Date(issue.firstSeen).toLocaleDateString("en-IE")}
                       {" · "}
-                      Last:{" "}
-                      {new Date(issue.lastSeen).toLocaleDateString("en-IE")}
+                      Last: {new Date(issue.lastSeen).toLocaleDateString("en-IE")}
                     </p>
                   </div>
 
@@ -299,25 +279,19 @@ export default function AdminErrorsPage() {
                     <p className="font-mono text-sm font-bold text-white">
                       {Number(issue.count).toLocaleString()}
                     </p>
-                    <p className="font-mono text-[10px] text-slate-600">
-                      events
-                    </p>
+                    <p className="font-mono text-[10px] text-slate-600">events</p>
                   </div>
                 </div>
 
                 {/* Actions */}
                 <div className="mt-4 flex flex-wrap items-center gap-2 border-t border-slate-800/60 pt-3">
-                  <span className="font-mono text-[10px] text-slate-600 mr-1">
-                    Actions:
-                  </span>
+                  <span className="mr-1 font-mono text-[10px] text-slate-600">Actions:</span>
                   <button
                     onClick={() => handleAction(issue.id, "resolved")}
                     disabled={isActing}
-                    className="min-h-[30px] rounded-lg border border-neon-green/20 px-3 py-1 font-mono text-[11px] text-neon-green transition-colors hover:bg-neon-green/10 disabled:opacity-40"
+                    className="border-neon-green/20 text-neon-green hover:bg-neon-green/10 min-h-[30px] rounded-lg border px-3 py-1 font-mono text-[11px] transition-colors disabled:opacity-40"
                   >
-                    {actionLoading === `resolved-${issue.id}`
-                      ? "…"
-                      : "✓ Resolve"}
+                    {actionLoading === `resolved-${issue.id}` ? "…" : "✓ Resolve"}
                   </button>
                   <button
                     onClick={() => handleAction(issue.id, "ignored")}
@@ -330,7 +304,7 @@ export default function AdminErrorsPage() {
                     href={`https://sentry.io/organizations/${process.env.NEXT_PUBLIC_SENTRY_ORG ?? ""}/issues/${issue.id}/`}
                     target="_blank"
                     rel="noopener noreferrer"
-                    className="min-h-[30px] inline-flex items-center rounded-lg border border-slate-800 px-3 py-1 font-mono text-[11px] text-slate-500 transition-colors hover:border-slate-700 hover:text-white"
+                    className="inline-flex min-h-[30px] items-center rounded-lg border border-slate-800 px-3 py-1 font-mono text-[11px] text-slate-500 transition-colors hover:border-slate-700 hover:text-white"
                   >
                     ↗ Sentry
                   </a>
@@ -343,8 +317,8 @@ export default function AdminErrorsPage() {
 
       {!loading && issues.length > 0 && (
         <p className="mt-4 font-mono text-[10px] text-slate-600">
-          Showing {visible.length} of {issues.length} unresolved issues ·
-          Resolving removes from this list immediately
+          Showing {visible.length} of {issues.length} unresolved issues · Resolving removes from
+          this list immediately
         </p>
       )}
     </div>

--- a/src/app/[locale]/admin/esp32-manager/page.tsx
+++ b/src/app/[locale]/admin/esp32-manager/page.tsx
@@ -33,12 +33,48 @@ const SEV: Record<
   Severity,
   { bg: string; ring: string; text: string; label: string; dot: string }
 > = {
-  ok:       { bg: "bg-emerald-500/10", ring: "ring-emerald-500/40", text: "text-emerald-400", label: "OK",       dot: "bg-emerald-500" },
-  info:     { bg: "bg-blue-500/10",    ring: "ring-blue-500/40",    text: "text-blue-400",    label: "Info",     dot: "bg-blue-400"    },
-  warning:  { bg: "bg-amber-500/10",   ring: "ring-amber-500/40",   text: "text-amber-400",   label: "Warning",  dot: "bg-amber-400"   },
-  error:    { bg: "bg-orange-500/10",  ring: "ring-orange-500/40",  text: "text-orange-400",  label: "Error",    dot: "bg-orange-400"  },
-  high:     { bg: "bg-red-500/10",     ring: "ring-red-500/40",     text: "text-red-400",     label: "High",     dot: "bg-red-400"     },
-  critical: { bg: "bg-red-700/20",     ring: "ring-red-500/60",     text: "text-red-300",     label: "Critical", dot: "bg-red-500"     },
+  ok: {
+    bg: "bg-emerald-500/10",
+    ring: "ring-emerald-500/40",
+    text: "text-emerald-400",
+    label: "OK",
+    dot: "bg-emerald-500",
+  },
+  info: {
+    bg: "bg-blue-500/10",
+    ring: "ring-blue-500/40",
+    text: "text-blue-400",
+    label: "Info",
+    dot: "bg-blue-400",
+  },
+  warning: {
+    bg: "bg-amber-500/10",
+    ring: "ring-amber-500/40",
+    text: "text-amber-400",
+    label: "Warning",
+    dot: "bg-amber-400",
+  },
+  error: {
+    bg: "bg-orange-500/10",
+    ring: "ring-orange-500/40",
+    text: "text-orange-400",
+    label: "Error",
+    dot: "bg-orange-400",
+  },
+  high: {
+    bg: "bg-red-500/10",
+    ring: "ring-red-500/40",
+    text: "text-red-400",
+    label: "High",
+    dot: "bg-red-400",
+  },
+  critical: {
+    bg: "bg-red-700/20",
+    ring: "ring-red-500/60",
+    text: "text-red-300",
+    label: "Critical",
+    dot: "bg-red-500",
+  },
 };
 
 function fmtUptime(s?: number): string {
@@ -70,8 +106,7 @@ function fmtTs(iso?: string): string {
 function RssiBar({ rssi }: { rssi?: number }) {
   if (!rssi) return <span className="font-mono text-xs text-slate-500">—</span>;
   const pct = Math.max(0, Math.min(100, ((rssi + 100) / 70) * 100));
-  const color =
-    pct > 60 ? "bg-emerald-500" : pct > 30 ? "bg-amber-500" : "bg-red-500";
+  const color = pct > 60 ? "bg-emerald-500" : pct > 30 ? "bg-amber-500" : "bg-red-500";
   return (
     <div className="flex items-center gap-2">
       <div className="h-1.5 w-20 overflow-hidden rounded-full bg-slate-700">
@@ -86,9 +121,7 @@ function StatusChip({ stale }: { stale: boolean }) {
   return (
     <span
       className={`inline-flex items-center gap-1.5 rounded-full px-2 py-0.5 font-mono text-xs ${
-        stale
-          ? "bg-amber-500/10 text-amber-400"
-          : "bg-emerald-500/10 text-emerald-400"
+        stale ? "bg-amber-500/10 text-amber-400" : "bg-emerald-500/10 text-emerald-400"
       }`}
     >
       <span
@@ -105,11 +138,7 @@ function Feedback({ msg }: { msg: string }) {
   if (!msg) return null;
   const ok = msg.startsWith("✓");
   return (
-    <p
-      className={`mt-2 font-mono text-xs ${ok ? "text-emerald-400" : "text-red-400"}`}
-    >
-      {msg}
-    </p>
+    <p className={`mt-2 font-mono text-xs ${ok ? "text-emerald-400" : "text-red-400"}`}>{msg}</p>
   );
 }
 
@@ -128,7 +157,7 @@ function TabBtn({
       onClick={onClick}
       className={`rounded-lg px-4 py-2 font-mono text-sm transition-all ${
         active
-          ? "bg-neon-magenta/15 text-neon-magenta ring-1 ring-neon-magenta/30"
+          ? "bg-neon-magenta/15 text-neon-magenta ring-neon-magenta/30 ring-1"
           : "text-slate-400 hover:bg-slate-800 hover:text-white"
       }`}
     >
@@ -174,38 +203,35 @@ export default function Esp32ManagerPage() {
 
   // ── API helpers ──────────────────────────────────────────────────────────────
 
-  const call = useCallback(
-    async (path: string, opts?: RequestInit) => {
-      try {
-        const res = await fetchWithAuth(path, opts);
-        const json = await res.json();
-        if (json?.offline) { setOffline(true); return null; }
-        setOffline(false);
-        return json;
-      } catch {
+  const call = useCallback(async (path: string, opts?: RequestInit) => {
+    try {
+      const res = await fetchWithAuth(path, opts);
+      const json = await res.json();
+      if (json?.offline) {
         setOffline(true);
         return null;
       }
-    },
-    [],
-  );
+      setOffline(false);
+      return json;
+    } catch {
+      setOffline(true);
+      return null;
+    }
+  }, []);
 
   const sendCmd = useCallback(
     async (action: string, value?: unknown) => {
       setLedFeedback("");
-      const res = await call(
-        `/api/admin/esp32?action=command&device_id=${selectedId}`,
-        {
-          method: "POST",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ action, value }),
-        },
-      );
+      const res = await call(`/api/admin/esp32?action=command&device_id=${selectedId}`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ action, value }),
+      });
       const msg = res?.ok ? `✓ ${action} sent` : "✗ Command failed";
       setLedFeedback(msg);
       setTimeout(() => setLedFeedback(""), 3500);
     },
-    [call, selectedId],
+    [call, selectedId]
   );
 
   // ── Devices tab ──────────────────────────────────────────────────────────────
@@ -217,7 +243,9 @@ export default function Esp32ManagerPage() {
 
   useEffect(() => {
     loadDevices().catch(() => {});
-    const t = setInterval(() => { loadDevices().catch(() => {}); }, POLL_MS);
+    const t = setInterval(() => {
+      loadDevices().catch(() => {});
+    }, POLL_MS);
     return () => clearInterval(t);
   }, [loadDevices]);
 
@@ -226,7 +254,10 @@ export default function Esp32ManagerPage() {
   const loadConfig = useCallback(async () => {
     setConfigLoading(true);
     const data = await call(`/api/admin/esp32?action=config&device_id=${selectedId}`);
-    if (data && !data.offline) { setConfig(data); setConfigDirty(false); }
+    if (data && !data.offline) {
+      setConfig(data);
+      setConfigDirty(false);
+    }
     setConfigLoading(false);
   }, [call, selectedId]);
 
@@ -238,14 +269,11 @@ export default function Esp32ManagerPage() {
     if (!config) return;
     setConfigLoading(true);
     setConfigFeedback("");
-    const res = await call(
-      `/api/admin/esp32?action=config&device_id=${selectedId}`,
-      {
-        method: "PUT",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify(config),
-      },
-    );
+    const res = await call(`/api/admin/esp32?action=config&device_id=${selectedId}`, {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(config),
+    });
     setConfigLoading(false);
     const msg = res?.ok ? "✓ Config saved & published to device" : "✗ Save failed";
     setConfigFeedback(msg);
@@ -284,7 +312,7 @@ export default function Esp32ManagerPage() {
         <select
           value={selectedId}
           onChange={(e) => setSelectedId(e.target.value)}
-          className="w-full rounded-lg border border-slate-700 bg-slate-800 px-3 py-2 font-mono text-sm text-white focus:border-neon-magenta focus:outline-none"
+          className="focus:border-neon-magenta w-full rounded-lg border border-slate-700 bg-slate-800 px-3 py-2 font-mono text-sm text-white focus:outline-none"
         >
           {devices.map((d) => (
             <option key={d.device_id} value={d.device_id}>
@@ -316,10 +344,18 @@ export default function Esp32ManagerPage() {
 
       {/* Tab bar */}
       <div className="flex flex-wrap gap-2">
-        <TabBtn active={tab === "devices"} onClick={() => setTab("devices")}>Devices</TabBtn>
-        <TabBtn active={tab === "led"}     onClick={() => setTab("led")}>LED Control</TabBtn>
-        <TabBtn active={tab === "config"}  onClick={() => setTab("config")}>Config</TabBtn>
-        <TabBtn active={tab === "ota"}     onClick={() => setTab("ota")}>OTA Update</TabBtn>
+        <TabBtn active={tab === "devices"} onClick={() => setTab("devices")}>
+          Devices
+        </TabBtn>
+        <TabBtn active={tab === "led"} onClick={() => setTab("led")}>
+          LED Control
+        </TabBtn>
+        <TabBtn active={tab === "config"} onClick={() => setTab("config")}>
+          Config
+        </TabBtn>
+        <TabBtn active={tab === "ota"} onClick={() => setTab("ota")}>
+          OTA Update
+        </TabBtn>
       </div>
 
       {/* ── Devices tab ─────────────────────────────────────────────────────── */}
@@ -361,7 +397,9 @@ export default function Esp32ManagerPage() {
                     </div>
                     <div className="flex items-center justify-between">
                       <dt className="font-mono text-xs text-slate-500">Signal</dt>
-                      <dd><RssiBar rssi={d.rssi} /></dd>
+                      <dd>
+                        <RssiBar rssi={d.rssi} />
+                      </dd>
                     </div>
                     <div className="flex items-center justify-between">
                       <dt className="font-mono text-xs text-slate-500">Uptime</dt>
@@ -369,7 +407,9 @@ export default function Esp32ManagerPage() {
                     </div>
                     <div className="flex items-center justify-between">
                       <dt className="font-mono text-xs text-slate-500">Free RAM</dt>
-                      <dd className="font-mono text-xs text-slate-300">{fmtRam(d.free_ram_bytes)}</dd>
+                      <dd className="font-mono text-xs text-slate-300">
+                        {fmtRam(d.free_ram_bytes)}
+                      </dd>
                     </div>
                     <div className="flex items-center justify-between">
                       <dt className="font-mono text-xs text-slate-500">Firmware</dt>
@@ -377,7 +417,9 @@ export default function Esp32ManagerPage() {
                     </div>
                     <div className="flex items-center justify-between">
                       <dt className="font-mono text-xs text-slate-500">Last seen</dt>
-                      <dd className="font-mono text-xs text-slate-300">{fmtTs(d.last_heartbeat)}</dd>
+                      <dd className="font-mono text-xs text-slate-300">
+                        {fmtTs(d.last_heartbeat)}
+                      </dd>
                     </div>
                   </dl>
                 </Card>
@@ -419,7 +461,10 @@ export default function Esp32ManagerPage() {
             <div className="flex flex-wrap gap-3">
               <button
                 type="button"
-                onClick={() => { sendCmd("led_mute", !isMuted); setIsMuted((m) => !m); }}
+                onClick={() => {
+                  sendCmd("led_mute", !isMuted);
+                  setIsMuted((m) => !m);
+                }}
                 className={`rounded-lg px-4 py-2 font-mono text-sm ring-1 transition-all hover:scale-105 active:scale-95 ${
                   isMuted
                     ? "bg-blue-500/10 text-blue-400 ring-blue-500/30"
@@ -459,10 +504,11 @@ export default function Esp32ManagerPage() {
               onChange={(e) => setBrightness(Number(e.target.value))}
               onMouseUp={() => sendCmd("set_brightness", brightness)}
               onTouchEnd={() => sendCmd("set_brightness", brightness)}
-              className="w-full accent-neon-magenta"
+              className="accent-neon-magenta w-full"
             />
             <div className="mt-1 flex justify-between font-mono text-xs text-slate-600">
-              <span>0</span><span>255</span>
+              <span>0</span>
+              <span>255</span>
             </div>
           </Card>
 
@@ -496,7 +542,8 @@ export default function Esp32ManagerPage() {
           ) : config ? (
             <Card>
               <p className="mb-4 font-mono text-xs text-slate-500">
-                Config is published as a retained MQTT message — device applies it on next boot/reconnect.
+                Config is published as a retained MQTT message — device applies it on next
+                boot/reconnect.
               </p>
               <div className="space-y-5">
                 {/* Brightness */}
@@ -511,10 +558,10 @@ export default function Esp32ManagerPage() {
                     max={255}
                     value={config.brightness}
                     onChange={(e) => {
-                      setConfig((c) => c ? { ...c, brightness: Number(e.target.value) } : c);
+                      setConfig((c) => (c ? { ...c, brightness: Number(e.target.value) } : c));
                       setConfigDirty(true);
                     }}
-                    className="w-full accent-neon-magenta"
+                    className="accent-neon-magenta w-full"
                   />
                 </div>
 
@@ -529,25 +576,25 @@ export default function Esp32ManagerPage() {
                     max={3600}
                     value={config.heartbeat_interval_s}
                     onChange={(e) => {
-                      setConfig((c) => c ? { ...c, heartbeat_interval_s: Number(e.target.value) } : c);
+                      setConfig((c) =>
+                        c ? { ...c, heartbeat_interval_s: Number(e.target.value) } : c
+                      );
                       setConfigDirty(true);
                     }}
-                    className="w-full rounded-lg border border-slate-700 bg-slate-800 px-3 py-2 font-mono text-sm text-white focus:border-neon-magenta focus:outline-none"
+                    className="focus:border-neon-magenta w-full rounded-lg border border-slate-700 bg-slate-800 px-3 py-2 font-mono text-sm text-white focus:outline-none"
                   />
                 </div>
 
                 {/* MQTT QoS */}
                 <div>
-                  <label className="mb-1 block font-mono text-xs text-slate-400">
-                    MQTT QoS
-                  </label>
+                  <label className="mb-1 block font-mono text-xs text-slate-400">MQTT QoS</label>
                   <select
                     value={config.mqtt_qos}
                     onChange={(e) => {
-                      setConfig((c) => c ? { ...c, mqtt_qos: Number(e.target.value) } : c);
+                      setConfig((c) => (c ? { ...c, mqtt_qos: Number(e.target.value) } : c));
                       setConfigDirty(true);
                     }}
-                    className="w-full rounded-lg border border-slate-700 bg-slate-800 px-3 py-2 font-mono text-sm text-white focus:border-neon-magenta focus:outline-none"
+                    className="focus:border-neon-magenta w-full rounded-lg border border-slate-700 bg-slate-800 px-3 py-2 font-mono text-sm text-white focus:outline-none"
                   >
                     <option value={0}>0 — At most once</option>
                     <option value={1}>1 — At least once</option>
@@ -558,7 +605,7 @@ export default function Esp32ManagerPage() {
                   type="button"
                   onClick={saveConfig}
                   disabled={!configDirty || configLoading}
-                  className="w-full rounded-lg bg-neon-magenta/15 py-2.5 font-mono text-sm text-neon-magenta ring-1 ring-neon-magenta/30 transition-all hover:bg-neon-magenta/25 disabled:cursor-not-allowed disabled:opacity-40"
+                  className="bg-neon-magenta/15 text-neon-magenta ring-neon-magenta/30 hover:bg-neon-magenta/25 w-full rounded-lg py-2.5 font-mono text-sm ring-1 transition-all disabled:cursor-not-allowed disabled:opacity-40"
                 >
                   {configLoading ? "Saving…" : "Save & publish to device"}
                 </button>
@@ -599,7 +646,7 @@ export default function Esp32ManagerPage() {
                   placeholder="https://example.com/firmware/esp32.bin"
                   value={otaUrl}
                   onChange={(e) => setOtaUrl(e.target.value)}
-                  className="w-full rounded-lg border border-slate-700 bg-slate-800 px-3 py-2 font-mono text-sm text-white placeholder-slate-600 focus:border-neon-magenta focus:outline-none"
+                  className="focus:border-neon-magenta w-full rounded-lg border border-slate-700 bg-slate-800 px-3 py-2 font-mono text-sm text-white placeholder-slate-600 focus:outline-none"
                 />
               </div>
 
@@ -612,14 +659,14 @@ export default function Esp32ManagerPage() {
                   placeholder="e.g. 4.1"
                   value={otaVersion}
                   onChange={(e) => setOtaVersion(e.target.value)}
-                  className="w-full rounded-lg border border-slate-700 bg-slate-800 px-3 py-2 font-mono text-sm text-white placeholder-slate-600 focus:border-neon-magenta focus:outline-none"
+                  className="focus:border-neon-magenta w-full rounded-lg border border-slate-700 bg-slate-800 px-3 py-2 font-mono text-sm text-white placeholder-slate-600 focus:outline-none"
                 />
               </div>
 
               <div className="rounded-lg bg-amber-500/10 p-3 ring-1 ring-amber-500/20">
                 <p className="font-mono text-xs text-amber-400">
-                  ⚠ The device will go offline during flash (~30 s). LEDs will glow cyan.
-                  Ensure the firmware URL is reachable from the Pi LAN (192.168.1.x).
+                  ⚠ The device will go offline during flash (~30 s). LEDs will glow cyan. Ensure the
+                  firmware URL is reachable from the Pi LAN (192.168.1.x).
                 </p>
               </div>
 
@@ -627,7 +674,7 @@ export default function Esp32ManagerPage() {
                 type="button"
                 onClick={triggerOta}
                 disabled={!otaUrl.trim() || otaLoading}
-                className="w-full rounded-lg bg-neon-magenta/15 py-2.5 font-mono text-sm text-neon-magenta ring-1 ring-neon-magenta/30 transition-all hover:bg-neon-magenta/25 disabled:cursor-not-allowed disabled:opacity-40"
+                className="bg-neon-magenta/15 text-neon-magenta ring-neon-magenta/30 hover:bg-neon-magenta/25 w-full rounded-lg py-2.5 font-mono text-sm ring-1 transition-all disabled:cursor-not-allowed disabled:opacity-40"
               >
                 {otaLoading ? "Sending OTA command…" : "⬆ Trigger OTA update"}
               </button>
@@ -639,9 +686,13 @@ export default function Esp32ManagerPage() {
           <Card className="border-slate-800/50">
             <p className="mb-2 font-mono text-xs text-slate-500">Tips</p>
             <ul className="space-y-1 font-mono text-xs text-slate-500">
-              <li>• Upload your <code>.bin</code> to S3 or GitHub Releases and paste the URL above.</li>
+              <li>
+                • Upload your <code>.bin</code> to S3 or GitHub Releases and paste the URL above.
+              </li>
               <li>• Compile in Arduino IDE: Sketch → Export Compiled Binary.</li>
-              <li>• Current firmware: <strong className="text-slate-300">v4.0</strong></li>
+              <li>
+                • Current firmware: <strong className="text-slate-300">v4.0</strong>
+              </li>
             </ul>
           </Card>
         </div>

--- a/src/app/[locale]/admin/esp32/page.tsx
+++ b/src/app/[locale]/admin/esp32/page.tsx
@@ -118,12 +118,7 @@ function rssiBar(rssi: number | null): { width: string; color: string } {
   if (rssi == null) return { width: "0%", color: "bg-slate-600" };
   // RSSI typically -30 (excellent) to -90 (poor)
   const pct = Math.max(0, Math.min(100, ((rssi + 90) / 60) * 100));
-  const color =
-    rssi >= -60
-      ? "bg-neon-green"
-      : rssi >= -75
-        ? "bg-yellow-400"
-        : "bg-red-400";
+  const color = rssi >= -60 ? "bg-neon-green" : rssi >= -75 ? "bg-yellow-400" : "bg-red-400";
   return { width: `${pct.toFixed(0)}%`, color };
 }
 
@@ -136,8 +131,8 @@ export default function AdminEsp32Page() {
   const [error, setError] = useState<string | null>(null);
   const [offline, setOffline] = useState(false);
   const [wsLogs, setWsLogs] = useState<LogEntry[]>([]);
-  const [wsStatus, setWsStatus] = useState<"connecting" | "open" | "closed">(
-    () => (getAlertApiWsUrl() ? "connecting" : "closed"),
+  const [wsStatus, setWsStatus] = useState<"connecting" | "open" | "closed">(() =>
+    getAlertApiWsUrl() ? "connecting" : "closed"
   );
   const [logFilter, setLogFilter] = useState<string>("ALL");
   const wsRef = useRef<WebSocket | null>(null);
@@ -170,9 +165,7 @@ export default function AdminEsp32Page() {
         const allAlerts: Alert[] = await alertsRes.json();
         // Filter to only ESP32 alerts
         const esp32Alerts = Array.isArray(allAlerts)
-          ? allAlerts.filter(
-              (a) => a.host === "esp32" || a.code.startsWith("ESP32_"),
-            )
+          ? allAlerts.filter((a) => a.host === "esp32" || a.code.startsWith("ESP32_"))
           : [];
         setAlerts(esp32Alerts);
       }
@@ -222,9 +215,7 @@ export default function AdminEsp32Page() {
             };
             setWsLogs((prev) => {
               const next = [...prev, entry];
-              return next.length > MAX_WS_LINES
-                ? next.slice(-MAX_WS_LINES)
-                : next;
+              return next.length > MAX_WS_LINES ? next.slice(-MAX_WS_LINES) : next;
             });
           } catch {
             // non-JSON frame
@@ -259,8 +250,7 @@ export default function AdminEsp32Page() {
   const activeAlerts = alerts.filter((a) => a.status !== "RESOLVED");
   const resolvedAlerts = alerts.filter((a) => a.status === "RESOLVED");
 
-  const filteredLogs =
-    logFilter === "ALL" ? wsLogs : wsLogs.filter((l) => l.level === logFilter);
+  const filteredLogs = logFilter === "ALL" ? wsLogs : wsLogs.filter((l) => l.level === logFilter);
 
   const rssi = rssiBar(esp32?.rssi ?? null);
 
@@ -276,9 +266,7 @@ export default function AdminEsp32Page() {
         </div>
         <div className="flex items-start justify-between gap-4">
           <div>
-            <h1 className="font-heading text-2xl font-bold text-white">
-              ESP32 Dashboard
-            </h1>
+            <h1 className="font-heading text-2xl font-bold text-white">ESP32 Dashboard</h1>
             <p className="font-body mt-1 text-slate-400">
               Hardware status · Out-of-band log stream · Alert history
             </p>
@@ -314,20 +302,18 @@ export default function AdminEsp32Page() {
       ) : esp32 ? (
         <>
           {/* ── Hardware Status ────────────────────────────────────────────── */}
-          <h2 className="font-heading mb-3 text-sm font-semibold uppercase tracking-widest text-slate-500">
+          <h2 className="font-heading mb-3 text-sm font-semibold tracking-widest text-slate-500 uppercase">
             Hardware
           </h2>
-          <div className="mb-6 bg-void-light/50 rounded-xl border border-slate-800 p-6">
+          <div className="bg-void-light/50 mb-6 rounded-xl border border-slate-800 p-6">
             {/* Online indicator */}
             <div className="mb-5 flex items-center gap-3">
               <span
-                className={`h-3 w-3 rounded-full ${esp32.stale ? "bg-yellow-400 animate-pulse" : "bg-neon-green animate-pulse"}`}
+                className={`h-3 w-3 rounded-full ${esp32.stale ? "animate-pulse bg-yellow-400" : "bg-neon-green animate-pulse"}`}
               />
-              <span className="font-mono text-sm font-bold text-white">
-                ESP32 Alert Manager
-              </span>
+              <span className="font-mono text-sm font-bold text-white">ESP32 Alert Manager</span>
               <span
-                className={`ml-auto rounded px-2 py-0.5 font-mono text-xs font-semibold ${esp32.stale ? "text-yellow-400 bg-yellow-950/30" : "text-neon-green bg-neon-green/10"}`}
+                className={`ml-auto rounded px-2 py-0.5 font-mono text-xs font-semibold ${esp32.stale ? "bg-yellow-950/30 text-yellow-400" : "text-neon-green bg-neon-green/10"}`}
               >
                 {esp32.stale ? "STALE" : "LIVE"}
               </span>
@@ -336,24 +322,16 @@ export default function AdminEsp32Page() {
             {/* Metric grid */}
             <div className="grid grid-cols-2 gap-4 sm:grid-cols-3 lg:grid-cols-4">
               <div>
-                <p className="font-mono text-[10px] text-slate-500">
-                  IP Address
-                </p>
-                <p className="font-mono text-sm text-white">
-                  {esp32.ip ?? "—"}
-                </p>
+                <p className="font-mono text-[10px] text-slate-500">IP Address</p>
+                <p className="font-mono text-sm text-white">{esp32.ip ?? "—"}</p>
               </div>
               <div>
                 <p className="font-mono text-[10px] text-slate-500">Firmware</p>
-                <p className="font-mono text-sm text-white">
-                  {esp32.firmware_ver ?? "—"}
-                </p>
+                <p className="font-mono text-sm text-white">{esp32.firmware_ver ?? "—"}</p>
               </div>
               <div>
                 <p className="font-mono text-[10px] text-slate-500">Uptime</p>
-                <p className="font-mono text-sm text-white">
-                  {fmtUptime(esp32.uptime_s)}
-                </p>
+                <p className="font-mono text-sm text-white">{fmtUptime(esp32.uptime_s)}</p>
               </div>
               <div>
                 <p className="font-mono text-[10px] text-slate-500">Free RAM</p>
@@ -368,29 +346,17 @@ export default function AdminEsp32Page() {
                 </p>
               </div>
               <div>
-                <p className="font-mono text-[10px] text-slate-500">
-                  Last Heartbeat
-                </p>
-                <p className="font-mono text-xs text-white">
-                  {fmtTs(esp32.last_heartbeat)}
-                </p>
+                <p className="font-mono text-[10px] text-slate-500">Last Heartbeat</p>
+                <p className="font-mono text-xs text-white">{fmtTs(esp32.last_heartbeat)}</p>
               </div>
               <div>
-                <p className="font-mono text-[10px] text-slate-500">
-                  Online Since
-                </p>
-                <p className="font-mono text-xs text-white">
-                  {fmtTs(esp32.started_at)}
-                </p>
+                <p className="font-mono text-[10px] text-slate-500">Online Since</p>
+                <p className="font-mono text-xs text-white">{fmtTs(esp32.started_at)}</p>
               </div>
               {esp32.device_id && (
                 <div className="col-span-2">
-                  <p className="font-mono text-[10px] text-slate-500">
-                    Device ID
-                  </p>
-                  <p className="font-mono text-xs text-slate-300">
-                    {esp32.device_id}
-                  </p>
+                  <p className="font-mono text-[10px] text-slate-500">Device ID</p>
+                  <p className="font-mono text-xs text-slate-300">{esp32.device_id}</p>
                 </div>
               )}
             </div>
@@ -398,9 +364,7 @@ export default function AdminEsp32Page() {
             {/* RSSI bar */}
             <div className="mt-5">
               <div className="mb-1.5 flex items-center justify-between">
-                <p className="font-mono text-[10px] text-slate-500">
-                  WiFi Signal (RSSI)
-                </p>
+                <p className="font-mono text-[10px] text-slate-500">WiFi Signal (RSSI)</p>
                 <p className="font-mono text-xs text-slate-400">
                   {esp32.rssi != null ? `${esp32.rssi} dBm` : "—"}
                 </p>
@@ -419,38 +383,27 @@ export default function AdminEsp32Page() {
           </div>
 
           {/* ── ESP32 Alerts ───────────────────────────────────────────────── */}
-          <h2 className="font-heading mb-3 text-sm font-semibold uppercase tracking-widest text-slate-500">
+          <h2 className="font-heading mb-3 text-sm font-semibold tracking-widest text-slate-500 uppercase">
             Active Alerts ({activeAlerts.length})
           </h2>
           <div className="mb-6 space-y-3">
             {activeAlerts.length === 0 ? (
               <div className="bg-void-light/50 rounded-xl border border-slate-800 p-8 text-center">
                 <p className="text-neon-green text-3xl">✓</p>
-                <p className="font-heading mt-3 font-semibold text-white">
-                  All Clear
-                </p>
-                <p className="mt-1 font-mono text-xs text-slate-500">
-                  No active ESP32 alerts.
-                </p>
+                <p className="font-heading mt-3 font-semibold text-white">All Clear</p>
+                <p className="mt-1 font-mono text-xs text-slate-500">No active ESP32 alerts.</p>
               </div>
             ) : (
               activeAlerts.map((alert) => {
                 const cls = SEV_COLOR[alert.severity] ?? SEV_COLOR.info;
                 const dot = SEV_DOT[alert.severity] ?? "bg-slate-500";
                 return (
-                  <div
-                    key={alert.id}
-                    className={`rounded-xl border p-5 ${cls}`}
-                  >
+                  <div key={alert.id} className={`rounded-xl border p-5 ${cls}`}>
                     <div className="flex flex-wrap items-start gap-3">
-                      <span
-                        className={`mt-1.5 h-2.5 w-2.5 shrink-0 rounded-full ${dot}`}
-                      />
+                      <span className={`mt-1.5 h-2.5 w-2.5 shrink-0 rounded-full ${dot}`} />
                       <div className="min-w-0 flex-1">
                         <div className="flex flex-wrap items-center gap-2">
-                          <span className="font-mono text-sm font-bold">
-                            {alert.code}
-                          </span>
+                          <span className="font-mono text-sm font-bold">{alert.code}</span>
                           <span className="rounded border border-current/30 px-1.5 py-0.5 font-mono text-[10px] opacity-70">
                             {alert.status}
                           </span>
@@ -458,12 +411,9 @@ export default function AdminEsp32Page() {
                             ×{alert.count}
                           </span>
                         </div>
-                        <p className="mt-0.5 font-mono text-xs opacity-80">
-                          {alert.message}
-                        </p>
+                        <p className="mt-0.5 font-mono text-xs opacity-80">{alert.message}</p>
                         <p className="mt-1 font-mono text-[10px] opacity-50">
-                          First: {fmtTs(alert.first_seen)} · Last:{" "}
-                          {fmtTs(alert.last_seen)}
+                          First: {fmtTs(alert.first_seen)} · Last: {fmtTs(alert.last_seen)}
                         </p>
                       </div>
                     </div>
@@ -475,7 +425,7 @@ export default function AdminEsp32Page() {
 
           {resolvedAlerts.length > 0 && (
             <>
-              <h2 className="font-heading mb-3 text-sm font-semibold uppercase tracking-widest text-slate-500">
+              <h2 className="font-heading mb-3 text-sm font-semibold tracking-widest text-slate-500 uppercase">
                 Resolved ({resolvedAlerts.length})
               </h2>
               <div className="mb-6 space-y-2">
@@ -484,10 +434,8 @@ export default function AdminEsp32Page() {
                     key={alert.id}
                     className="bg-void-light/30 flex flex-wrap items-center gap-3 rounded-xl border border-slate-800/60 px-4 py-3 opacity-60"
                   >
-                    <span className="h-2 w-2 rounded-full bg-neon-green" />
-                    <span className="font-mono text-xs font-bold text-slate-300">
-                      {alert.code}
-                    </span>
+                    <span className="bg-neon-green h-2 w-2 rounded-full" />
+                    <span className="font-mono text-xs font-bold text-slate-300">{alert.code}</span>
                     <span className="ml-auto font-mono text-[10px] text-slate-600">
                       {fmtTs(alert.last_seen)}
                     </span>
@@ -500,7 +448,7 @@ export default function AdminEsp32Page() {
       ) : null}
 
       {/* ── Live Log Stream ───────────────────────────────────────────────── */}
-      <h2 className="font-heading mb-3 text-sm font-semibold uppercase tracking-widest text-slate-500">
+      <h2 className="font-heading mb-3 text-sm font-semibold tracking-widest text-slate-500 uppercase">
         Live Log Stream
       </h2>
 
@@ -512,19 +460,19 @@ export default function AdminEsp32Page() {
             onClick={() => setLogFilter(lvl)}
             className={`rounded px-2.5 py-1 font-mono text-[10px] transition-colors ${
               logFilter === lvl
-                ? "bg-neon-cyan/20 text-neon-cyan border border-neon-cyan/40"
+                ? "bg-neon-cyan/20 text-neon-cyan border-neon-cyan/40 border"
                 : "border border-slate-800 text-slate-500 hover:text-slate-300"
             }`}
           >
             {lvl}
           </button>
         ))}
-        <span className="ml-auto font-mono text-[10px] text-slate-600 self-center">
+        <span className="ml-auto self-center font-mono text-[10px] text-slate-600">
           {filteredLogs.length} lines
         </span>
       </div>
 
-      <div className="bg-void-light/50 rounded-xl border border-slate-800 overflow-hidden">
+      <div className="bg-void-light/50 overflow-hidden rounded-xl border border-slate-800">
         {/* WS status bar */}
         <div className="flex items-center gap-2 border-b border-slate-800 px-4 py-2">
           <span
@@ -532,7 +480,7 @@ export default function AdminEsp32Page() {
               wsStatus === "open"
                 ? "bg-neon-green animate-pulse"
                 : wsStatus === "connecting"
-                  ? "bg-yellow-400 animate-pulse"
+                  ? "animate-pulse bg-yellow-400"
                   : "bg-red-400"
             }`}
           />
@@ -559,24 +507,17 @@ export default function AdminEsp32Page() {
             </p>
           ) : (
             filteredLogs.map((entry, i) => (
-              <div
-                key={i}
-                className={`flex gap-3 ${entry.historic ? "opacity-50" : ""}`}
-              >
+              <div key={i} className={`flex gap-3 ${entry.historic ? "opacity-50" : ""}`}>
                 <span className="shrink-0 text-slate-600 select-none">
                   {new Date(entry.ts).toLocaleTimeString("en-IE", {
                     timeZone: "Europe/Athens",
                     hour12: false,
                   })}
                 </span>
-                <span
-                  className={`shrink-0 w-12 ${LOG_COLOR[entry.level] ?? "text-slate-400"}`}
-                >
+                <span className={`w-12 shrink-0 ${LOG_COLOR[entry.level] ?? "text-slate-400"}`}>
                   {entry.level}
                 </span>
-                <span className="text-slate-300 break-all">
-                  {entry.message}
-                </span>
+                <span className="break-all text-slate-300">{entry.message}</span>
               </div>
             ))
           )}
@@ -586,8 +527,8 @@ export default function AdminEsp32Page() {
 
       <p className="mt-4 font-mono text-[10px] text-slate-600">
         Polls every {POLL_INTERVAL / 1000}s
-        {getAlertApiWsUrl() ? " · WebSocket reconnects automatically" : ""}·
-        Last fetched: {esp32 ? fmtTs(esp32.last_heartbeat) : "—"}
+        {getAlertApiWsUrl() ? " · WebSocket reconnects automatically" : ""}· Last fetched:{" "}
+        {esp32 ? fmtTs(esp32.last_heartbeat) : "—"}
       </p>
     </div>
   );

--- a/src/app/[locale]/admin/hubspot/page.tsx
+++ b/src/app/[locale]/admin/hubspot/page.tsx
@@ -4,10 +4,8 @@ import { useEffect, useState, useCallback } from "react";
 import { fetchWithAuth } from "@/lib/fetch-with-auth";
 
 const REFRESH_INTERVAL = 10_000;
-const SECTION_LABEL_CLASS =
-  "mb-3 font-mono text-[10px] uppercase tracking-widest text-slate-600";
-const TH_CLASS =
-  "px-6 py-3 text-left font-mono text-xs font-medium text-slate-500";
+const SECTION_LABEL_CLASS = "mb-3 font-mono text-[10px] uppercase tracking-widest text-slate-600";
+const TH_CLASS = "px-6 py-3 text-left font-mono text-xs font-medium text-slate-500";
 const COLOR_WHITE = "text-white";
 const RECENT_CONTACTS_LIMIT = 5;
 
@@ -66,17 +64,14 @@ interface Stats {
 function computeContactStats(contacts: Contact[]): Stats["contacts"] {
   return {
     total: contacts.length,
-    newLeads: contacts.filter((c) => c.properties.hs_lead_status === "NEW")
-      .length,
-    qualified: contacts.filter(
-      (c) => c.properties.hs_lead_status === "OPEN_DEAL",
-    ).length,
+    newLeads: contacts.filter((c) => c.properties.hs_lead_status === "NEW").length,
+    qualified: contacts.filter((c) => c.properties.hs_lead_status === "OPEN_DEAL").length,
     recent: contacts
       .slice()
       .sort(
         (a, b) =>
           new Date(b.properties.createdate ?? 0).getTime() -
-          new Date(a.properties.createdate ?? 0).getTime(),
+          new Date(a.properties.createdate ?? 0).getTime()
       )
       .slice(0, RECENT_CONTACTS_LIMIT),
   };
@@ -87,7 +82,7 @@ function computeDealStats(deals: Deal[]): Stats["deals"] {
     total: deals.length,
     pipelineValue: deals.reduce(
       (sum, d) => sum + (Number.parseFloat(d.properties.amount ?? "0") || 0),
-      0,
+      0
     ),
     won: deals.filter((d) => d.properties.dealstage === "closedwon").length,
   };
@@ -192,11 +187,7 @@ function RecentLeadsTable({
     );
   }
   if (contacts.length === 0) {
-    return (
-      <p className="px-6 py-12 text-center font-mono text-slate-600">
-        No contacts yet
-      </p>
-    );
+    return <p className="px-6 py-12 text-center font-mono text-slate-600">No contacts yet</p>;
   }
   return (
     <div className="overflow-x-auto">
@@ -216,23 +207,19 @@ function RecentLeadsTable({
               className="hover:bg-void-lighter/30 border-b border-slate-800/50 transition-colors"
             >
               <td className="px-6 py-4 text-white">
-                {[c.properties.firstname, c.properties.lastname]
-                  .filter(Boolean)
-                  .join(" ") || "—"}
+                {[c.properties.firstname, c.properties.lastname].filter(Boolean).join(" ") || "—"}
               </td>
               <td className="text-neon-cyan px-6 py-4 font-mono text-xs">
                 {c.properties.email ?? "—"}
               </td>
               <td className="px-6 py-4">
-                <span className="rounded-full bg-neon-cyan/10 px-2 py-0.5 font-mono text-[10px] text-neon-cyan">
+                <span className="bg-neon-cyan/10 text-neon-cyan rounded-full px-2 py-0.5 font-mono text-[10px]">
                   {c.properties.hs_lead_status ?? "—"}
                 </span>
               </td>
               <td className="px-6 py-4 font-mono text-slate-500">
                 {c.properties.createdate
-                  ? new Date(c.properties.createdate).toLocaleDateString(
-                      "en-IE",
-                    )
+                  ? new Date(c.properties.createdate).toLocaleDateString("en-IE")
                   : "—"}
               </td>
             </tr>
@@ -255,9 +242,7 @@ export default function HubSpotOverviewPage() {
             <span className="bg-neon-magenta h-2 w-2 animate-pulse rounded-full" />
             <span className="text-neon-magenta font-mono text-xs">HUBSPOT</span>
           </div>
-          <h1 className="font-heading text-2xl font-bold text-white">
-            HubSpot Overview
-          </h1>
+          <h1 className="font-heading text-2xl font-bold text-white">HubSpot Overview</h1>
           <p className="font-body mt-1 text-slate-400">
             Live snapshot of your CRM — contacts, deals, and support tickets.
           </p>
@@ -321,11 +306,7 @@ export default function HubSpotOverviewPage() {
               value={loading ? "…" : fmt(stats.deals.pipelineValue)}
               color="text-neon-green"
             />
-            <StatCard
-              label="Won"
-              value={loading ? "…" : stats.deals.won}
-              color="text-neon-cyan"
-            />
+            <StatCard label="Won" value={loading ? "…" : stats.deals.won} color="text-neon-cyan" />
           </div>
 
           <p className={SECTION_LABEL_CLASS}>Support Tickets</p>
@@ -344,10 +325,7 @@ export default function HubSpotOverviewPage() {
 
           <p className={SECTION_LABEL_CLASS}>Recent Leads</p>
           <div className="bg-void-light/50 overflow-hidden rounded-xl border border-slate-800">
-            <RecentLeadsTable
-              loading={loading}
-              contacts={stats.contacts.recent}
-            />
+            <RecentLeadsTable loading={loading} contacts={stats.contacts.recent} />
           </div>
         </>
       )}

--- a/src/app/[locale]/admin/integrations/page.tsx
+++ b/src/app/[locale]/admin/integrations/page.tsx
@@ -144,8 +144,7 @@ export default function IntegrationsPage() {
           setCheckedAt(data.checkedAt);
         }
       } catch (err) {
-        if (!cancelled)
-          setError(err instanceof Error ? err.message : "Failed to load");
+        if (!cancelled) setError(err instanceof Error ? err.message : "Failed to load");
       } finally {
         if (!cancelled) setLoading(false);
       }
@@ -166,13 +165,9 @@ export default function IntegrationsPage() {
         <div>
           <div className="bg-neon-magenta/10 border-neon-magenta/20 mb-4 inline-flex items-center gap-2 rounded-full border px-3 py-1.5">
             <span className="bg-neon-magenta h-2 w-2 animate-pulse rounded-full" />
-            <span className="text-neon-magenta font-mono text-xs">
-              INTEGRATIONS
-            </span>
+            <span className="text-neon-magenta font-mono text-xs">INTEGRATIONS</span>
           </div>
-          <h1 className="font-heading text-2xl font-bold text-white">
-            Integrations
-          </h1>
+          <h1 className="font-heading text-2xl font-bold text-white">Integrations</h1>
           <p className="font-body mt-1 text-slate-400">
             Live status of all external services connected to Cloudless.
           </p>
@@ -202,9 +197,7 @@ export default function IntegrationsPage() {
               key={label}
               className="bg-void-light/50 rounded-xl border border-slate-800 px-4 py-3"
             >
-              <div className={`font-mono text-xl font-bold ${cls}`}>
-                {count}
-              </div>
+              <div className={`font-mono text-xl font-bold ${cls}`}>{count}</div>
               <div className="font-mono text-xs text-slate-500">{label}</div>
             </div>
           ))}
@@ -232,7 +225,7 @@ export default function IntegrationsPage() {
       <div className="space-y-6">
         {categories.map((category) => (
           <div key={category}>
-            <h2 className="font-heading mb-3 text-sm font-semibold uppercase tracking-widest text-slate-500">
+            <h2 className="font-heading mb-3 text-sm font-semibold tracking-widest text-slate-500 uppercase">
               {category}
             </h2>
             <div className="divide-y divide-slate-800 overflow-hidden rounded-xl border border-slate-800">
@@ -245,20 +238,14 @@ export default function IntegrationsPage() {
                     <span
                       className={`h-2.5 w-2.5 shrink-0 rounded-full ${STATUS_DOT[row.status]}`}
                     />
-                    <span className="font-heading truncate font-medium text-white">
-                      {row.name}
-                    </span>
+                    <span className="font-heading truncate font-medium text-white">{row.name}</span>
                   </div>
 
                   <div className="flex items-center gap-3 pl-5 sm:pl-0">
                     {row.message && (
-                      <span className="font-mono text-xs text-slate-500">
-                        {row.message}
-                      </span>
+                      <span className="font-mono text-xs text-slate-500">{row.message}</span>
                     )}
-                    <span
-                      className={`shrink-0 font-mono text-xs ${STATUS_TEXT[row.status]}`}
-                    >
+                    <span className={`shrink-0 font-mono text-xs ${STATUS_TEXT[row.status]}`}>
                       {STATUS_LABEL[row.status]}
                     </span>
                     {row.status !== "configured" && (
@@ -266,7 +253,7 @@ export default function IntegrationsPage() {
                         href={row.setupUrl}
                         target="_blank"
                         rel="noopener noreferrer"
-                        className="shrink-0 rounded-lg border border-slate-700 px-3 py-1 font-mono text-xs text-slate-300 transition-all hover:border-neon-magenta/50 hover:text-white"
+                        className="hover:border-neon-magenta/50 shrink-0 rounded-lg border border-slate-700 px-3 py-1 font-mono text-xs text-slate-300 transition-all hover:text-white"
                       >
                         Connect
                       </a>

--- a/src/app/[locale]/admin/kpi/page.tsx
+++ b/src/app/[locale]/admin/kpi/page.tsx
@@ -48,12 +48,8 @@ function KpiCard({
   return (
     <div className="bg-void-light/50 rounded-xl border border-slate-800 p-5">
       <div className={`font-mono text-2xl font-bold ${color}`}>{value}</div>
-      <div className="font-heading mt-1 text-sm font-medium text-white">
-        {label}
-      </div>
-      {sub && (
-        <div className="font-mono mt-0.5 text-xs text-slate-500">{sub}</div>
-      )}
+      <div className="font-heading mt-1 text-sm font-medium text-white">{label}</div>
+      {sub && <div className="mt-0.5 font-mono text-xs text-slate-500">{sub}</div>}
     </div>
   );
 }
@@ -65,7 +61,7 @@ function SectionHeader({
 }: Readonly<{ title: string; icon: string; href: string }>) {
   return (
     <div className="mb-4 flex items-center justify-between">
-      <h2 className="font-heading text-sm font-semibold uppercase tracking-widest text-slate-500">
+      <h2 className="font-heading text-sm font-semibold tracking-widest text-slate-500 uppercase">
         {icon} {title}
       </h2>
       <Link
@@ -84,7 +80,7 @@ function Skeleton() {
       {[1, 2, 3, 4].map((i) => (
         <div
           key={i}
-          className="animate-pulse rounded-xl border border-slate-800 bg-void-light/50 p-5"
+          className="bg-void-light/50 animate-pulse rounded-xl border border-slate-800 p-5"
         >
           <div className="mb-2 h-7 w-20 rounded bg-slate-700/60" />
           <div className="h-4 w-28 rounded bg-slate-800/80" />
@@ -118,8 +114,7 @@ export default function KpiDashboard() {
     load();
   }, [load]);
 
-  const fmt = (n: number | undefined | null) =>
-    n == null ? "—" : n.toLocaleString();
+  const fmt = (n: number | undefined | null) => (n == null ? "—" : n.toLocaleString());
 
   return (
     <div>
@@ -128,13 +123,9 @@ export default function KpiDashboard() {
         <div>
           <div className="bg-neon-cyan/10 border-neon-cyan/20 mb-4 inline-flex items-center gap-2 rounded-full border px-3 py-1.5">
             <span className="bg-neon-cyan h-2 w-2 animate-pulse rounded-full" />
-            <span className="text-neon-cyan font-mono text-xs">
-              KPI_DASHBOARD
-            </span>
+            <span className="text-neon-cyan font-mono text-xs">KPI_DASHBOARD</span>
           </div>
-          <h1 className="font-heading text-2xl font-bold text-white">
-            KPI Dashboard
-          </h1>
+          <h1 className="font-heading text-2xl font-bold text-white">KPI Dashboard</h1>
           <p className="font-body mt-1 text-slate-400">
             Consolidated view — GSC · Notion analytics · Projects · Tasks
           </p>
@@ -204,11 +195,7 @@ export default function KpiDashboard() {
 
           {/* Notion site analytics */}
           <section>
-            <SectionHeader
-              title="Site Events (7 days)"
-              icon="📈"
-              href="/admin/notion/analytics"
-            />
+            <SectionHeader title="Site Events (7 days)" icon="📈" href="/admin/notion/analytics" />
             {data.analytics ? (
               <>
                 <div className="mb-4 grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
@@ -235,19 +222,16 @@ export default function KpiDashboard() {
                 </div>
                 {data.analytics.topPages.length > 0 && (
                   <div className="bg-void-light/30 rounded-xl border border-slate-800 p-4">
-                    <p className="font-mono mb-3 text-[10px] uppercase tracking-widest text-slate-500">
+                    <p className="mb-3 font-mono text-[10px] tracking-widest text-slate-500 uppercase">
                       Top Pages
                     </p>
                     <div className="space-y-1.5">
                       {data.analytics.topPages.slice(0, 5).map((p) => (
-                        <div
-                          key={p.page}
-                          className="flex items-center justify-between gap-4"
-                        >
-                          <span className="font-mono truncate text-xs text-slate-400">
+                        <div key={p.page} className="flex items-center justify-between gap-4">
+                          <span className="truncate font-mono text-xs text-slate-400">
                             {p.page || "/"}
                           </span>
-                          <span className="text-neon-cyan font-mono shrink-0 text-xs">
+                          <span className="text-neon-cyan shrink-0 font-mono text-xs">
                             {fmt(p.count)}
                           </span>
                         </div>
@@ -257,19 +241,13 @@ export default function KpiDashboard() {
                 )}
               </>
             ) : (
-              <p className="font-mono text-sm text-slate-600">
-                Notion Analytics not configured.
-              </p>
+              <p className="font-mono text-sm text-slate-600">Notion Analytics not configured.</p>
             )}
           </section>
 
           {/* Projects */}
           <section>
-            <SectionHeader
-              title="Projects"
-              icon="📋"
-              href="/admin/notion/projects"
-            />
+            <SectionHeader title="Projects" icon="📋" href="/admin/notion/projects" />
             <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
               <KpiCard
                 label="Total Projects"
@@ -312,19 +290,13 @@ export default function KpiDashboard() {
               <KpiCard
                 label="Overdue"
                 value={fmt(data.tasks.overdueCount)}
-                color={
-                  (data.tasks.overdueCount ?? 0) > 0
-                    ? "text-red-400"
-                    : "text-neon-green"
-                }
+                color={(data.tasks.overdueCount ?? 0) > 0 ? "text-red-400" : "text-neon-green"}
               />
               <KpiCard
                 label="Blocked"
                 value={fmt(data.tasks.summary["Blocked"])}
                 color={
-                  (data.tasks.summary["Blocked"] ?? 0) > 0
-                    ? "text-neon-magenta"
-                    : "text-slate-500"
+                  (data.tasks.summary["Blocked"] ?? 0) > 0 ? "text-neon-magenta" : "text-slate-500"
                 }
               />
             </div>

--- a/src/app/[locale]/admin/loading.tsx
+++ b/src/app/[locale]/admin/loading.tsx
@@ -4,9 +4,7 @@ export default function AdminLoading() {
       <div className="border-neon-magenta/20 bg-neon-magenta/5 border-b">
         <div className="mx-auto flex max-w-7xl items-center gap-2 px-4 py-2 sm:px-6 lg:px-8">
           <span className="bg-neon-magenta h-2 w-2 animate-pulse rounded-full" />
-          <span className="text-neon-magenta font-mono text-xs">
-            ADMIN PANEL
-          </span>
+          <span className="text-neon-magenta font-mono text-xs">ADMIN PANEL</span>
         </div>
       </div>
 

--- a/src/app/[locale]/admin/monitor/page.tsx
+++ b/src/app/[locale]/admin/monitor/page.tsx
@@ -143,9 +143,7 @@ export default function AdminMonitorPage() {
   const [error, setError] = useState<string | null>(null);
   const [offline, setOffline] = useState(false);
   const [logs, setLogs] = useState<LogEntry[]>([]);
-  const [wsStatus, setWsStatus] = useState<"connecting" | "open" | "closed">(
-    "connecting",
-  );
+  const [wsStatus, setWsStatus] = useState<"connecting" | "open" | "closed">("connecting");
   const wsRef = useRef<WebSocket | null>(null);
   const logEndRef = useRef<HTMLDivElement>(null);
 
@@ -217,9 +215,7 @@ export default function AdminMonitorPage() {
             };
             setLogs((prev) => {
               const next = [...prev, entry];
-              return next.length > MAX_LOG_LINES
-                ? next.slice(-MAX_LOG_LINES)
-                : next;
+              return next.length > MAX_LOG_LINES ? next.slice(-MAX_LOG_LINES) : next;
             });
           } catch {
             // non-JSON frame, ignore
@@ -265,9 +261,7 @@ export default function AdminMonitorPage() {
         </div>
         <div className="flex items-start justify-between gap-4">
           <div>
-            <h1 className="font-heading text-2xl font-bold text-white">
-              Infrastructure Monitor
-            </h1>
+            <h1 className="font-heading text-2xl font-bold text-white">Infrastructure Monitor</h1>
             <p className="font-body mt-1 text-slate-400">
               Pi cluster · ESP32 sensor · Alert API v2.0 · Live log stream
             </p>
@@ -286,8 +280,8 @@ export default function AdminMonitorPage() {
       {offline && (
         <div className="mb-6 rounded-xl border border-yellow-900/40 bg-yellow-950/20 px-5 py-4">
           <p className="font-mono text-sm text-yellow-400">
-            ⚠ Alert API unreachable — Pi may be offline or this deployment does
-            not have local network access.
+            ⚠ Alert API unreachable — Pi may be offline or this deployment does not have local
+            network access.
           </p>
           <p className="mt-1 font-mono text-xs text-slate-500">
             Dashboard data available only from the K3s Pi cluster.
@@ -324,12 +318,9 @@ export default function AdminMonitorPage() {
               </p>
             </div>
             <div className="bg-void-light/50 rounded-xl border border-slate-800 p-4">
-              <p className="font-mono text-xs text-slate-500">
-                Critical / High
-              </p>
+              <p className="font-mono text-xs text-slate-500">Critical / High</p>
               <p className="font-heading mt-1 text-2xl font-bold text-red-400">
-                {(status.alerts.by_severity.critical ?? 0) +
-                  (status.alerts.by_severity.high ?? 0)}
+                {(status.alerts.by_severity.critical ?? 0) + (status.alerts.by_severity.high ?? 0)}
               </p>
             </div>
             <div className="bg-void-light/50 rounded-xl border border-slate-800 p-4">
@@ -343,31 +334,22 @@ export default function AdminMonitorPage() {
           </div>
 
           {/* ── Pi Nodes ──────────────────────────────────────────────────── */}
-          <h2 className="font-heading mb-3 text-sm font-semibold uppercase tracking-widest text-slate-500">
+          <h2 className="font-heading mb-3 text-sm font-semibold tracking-widest text-slate-500 uppercase">
             Pi Nodes
           </h2>
           <div className="mb-6 grid gap-4 sm:grid-cols-2">
             {Object.entries(status.pis).map(([name, pi]) => (
-              <div
-                key={name}
-                className="bg-void-light/50 rounded-xl border border-slate-800 p-5"
-              >
+              <div key={name} className="bg-void-light/50 rounded-xl border border-slate-800 p-5">
                 <div className="flex items-center gap-3">
-                  <span
-                    className={`h-3 w-3 rounded-full ${piStatusDot(pi.status)}`}
-                  />
-                  <span className="font-mono text-sm font-bold text-white">
-                    {name}
-                  </span>
+                  <span className={`h-3 w-3 rounded-full ${piStatusDot(pi.status)}`} />
+                  <span className="font-mono text-sm font-bold text-white">{name}</span>
                   <span
                     className={`ml-auto font-mono text-xs font-semibold ${STATUS_COLOR[pi.status] ?? "text-slate-400"}`}
                   >
                     {pi.status.toUpperCase()}
                   </span>
                 </div>
-                <p className="mt-1.5 font-mono text-xs text-slate-500">
-                  {pi.ip}
-                </p>
+                <p className="mt-1.5 font-mono text-xs text-slate-500">{pi.ip}</p>
                 {pi.alerts.length > 0 && (
                   <div className="mt-3 flex flex-wrap gap-1.5">
                     {pi.alerts.map((code) => (
@@ -385,17 +367,15 @@ export default function AdminMonitorPage() {
           </div>
 
           {/* ── ESP32 ─────────────────────────────────────────────────────── */}
-          <h2 className="font-heading mb-3 text-sm font-semibold uppercase tracking-widest text-slate-500">
+          <h2 className="font-heading mb-3 text-sm font-semibold tracking-widest text-slate-500 uppercase">
             ESP32 Sensor
           </h2>
-          <div className="mb-6 bg-void-light/50 rounded-xl border border-slate-800 p-5">
-            <div className="flex items-center gap-3 mb-4">
+          <div className="bg-void-light/50 mb-6 rounded-xl border border-slate-800 p-5">
+            <div className="mb-4 flex items-center gap-3">
               <span
-                className={`h-3 w-3 rounded-full ${status.esp32.stale ? "bg-yellow-400 animate-pulse" : "bg-neon-green animate-pulse"}`}
+                className={`h-3 w-3 rounded-full ${status.esp32.stale ? "animate-pulse bg-yellow-400" : "bg-neon-green animate-pulse"}`}
               />
-              <span className="font-mono text-sm font-bold text-white">
-                ESP32 Alert Manager
-              </span>
+              <span className="font-mono text-sm font-bold text-white">ESP32 Alert Manager</span>
               <span
                 className={`ml-auto font-mono text-xs font-semibold ${status.esp32.stale ? "text-yellow-400" : "text-neon-green"}`}
               >
@@ -408,10 +388,7 @@ export default function AdminMonitorPage() {
                 { label: "Firmware", value: status.esp32.firmware_ver ?? "—" },
                 {
                   label: "RSSI",
-                  value:
-                    status.esp32.rssi != null
-                      ? `${status.esp32.rssi} dBm`
-                      : "—",
+                  value: status.esp32.rssi != null ? `${status.esp32.rssi} dBm` : "—",
                 },
                 { label: "Uptime", value: fmtUptime(status.esp32.uptime_s) },
                 {
@@ -421,9 +398,7 @@ export default function AdminMonitorPage() {
                 { label: "Last HB", value: fmtTs(status.esp32.last_heartbeat) },
               ].map(({ label, value }) => (
                 <div key={label}>
-                  <p className="font-mono text-[10px] text-slate-500">
-                    {label}
-                  </p>
+                  <p className="font-mono text-[10px] text-slate-500">{label}</p>
                   <p className="font-mono text-xs text-white">{value}</p>
                 </div>
               ))}
@@ -431,38 +406,27 @@ export default function AdminMonitorPage() {
           </div>
 
           {/* ── Active Alerts ─────────────────────────────────────────────── */}
-          <h2 className="font-heading mb-3 text-sm font-semibold uppercase tracking-widest text-slate-500">
+          <h2 className="font-heading mb-3 text-sm font-semibold tracking-widest text-slate-500 uppercase">
             Active Alerts ({activeAlerts.length})
           </h2>
           <div className="mb-6 space-y-3">
             {activeAlerts.length === 0 ? (
               <div className="bg-void-light/50 rounded-xl border border-slate-800 p-8 text-center">
                 <p className="text-neon-green text-3xl">✓</p>
-                <p className="font-heading mt-3 font-semibold text-white">
-                  All Clear
-                </p>
-                <p className="mt-1 font-mono text-xs text-slate-500">
-                  No active alerts.
-                </p>
+                <p className="font-heading mt-3 font-semibold text-white">All Clear</p>
+                <p className="mt-1 font-mono text-xs text-slate-500">No active alerts.</p>
               </div>
             ) : (
               activeAlerts.map((alert) => {
                 const cls = SEV_COLOR[alert.severity] ?? SEV_COLOR.info;
                 const dot = SEV_DOT[alert.severity] ?? "bg-slate-500";
                 return (
-                  <div
-                    key={alert.id}
-                    className={`rounded-xl border p-5 ${cls}`}
-                  >
+                  <div key={alert.id} className={`rounded-xl border p-5 ${cls}`}>
                     <div className="flex flex-wrap items-start gap-3">
-                      <span
-                        className={`mt-1.5 h-2.5 w-2.5 shrink-0 rounded-full ${dot}`}
-                      />
+                      <span className={`mt-1.5 h-2.5 w-2.5 shrink-0 rounded-full ${dot}`} />
                       <div className="min-w-0 flex-1">
                         <div className="flex flex-wrap items-center gap-2">
-                          <span className="font-mono text-sm font-bold">
-                            {alert.code}
-                          </span>
+                          <span className="font-mono text-sm font-bold">{alert.code}</span>
                           <span className="rounded border border-current/30 px-1.5 py-0.5 font-mono text-[10px] opacity-70">
                             {alert.status}
                           </span>
@@ -470,12 +434,9 @@ export default function AdminMonitorPage() {
                             {alert.severity}
                           </span>
                         </div>
-                        <p className="mt-0.5 font-mono text-xs opacity-80">
-                          {alert.message}
-                        </p>
+                        <p className="mt-0.5 font-mono text-xs opacity-80">{alert.message}</p>
                         <p className="mt-1 font-mono text-[10px] opacity-50">
-                          {alert.host} · {alert.service} · ×{alert.count} ·{" "}
-                          {fmtTs(alert.last_seen)}
+                          {alert.host} · {alert.service} · ×{alert.count} · {fmtTs(alert.last_seen)}
                         </p>
                       </div>
                     </div>
@@ -488,7 +449,7 @@ export default function AdminMonitorPage() {
           {/* ── Recently Resolved ─────────────────────────────────────────── */}
           {resolvedAlerts.length > 0 && (
             <>
-              <h2 className="font-heading mb-3 text-sm font-semibold uppercase tracking-widest text-slate-500">
+              <h2 className="font-heading mb-3 text-sm font-semibold tracking-widest text-slate-500 uppercase">
                 Recently Resolved ({resolvedAlerts.length})
               </h2>
               <div className="mb-6 space-y-2">
@@ -497,13 +458,9 @@ export default function AdminMonitorPage() {
                     key={alert.id}
                     className="bg-void-light/30 flex flex-wrap items-center gap-3 rounded-xl border border-slate-800/60 px-4 py-3 opacity-60"
                   >
-                    <span className="h-2 w-2 rounded-full bg-neon-green" />
-                    <span className="font-mono text-xs font-bold text-slate-300">
-                      {alert.code}
-                    </span>
-                    <span className="font-mono text-[10px] text-slate-500">
-                      {alert.host}
-                    </span>
+                    <span className="bg-neon-green h-2 w-2 rounded-full" />
+                    <span className="font-mono text-xs font-bold text-slate-300">{alert.code}</span>
+                    <span className="font-mono text-[10px] text-slate-500">{alert.host}</span>
                     <span className="ml-auto font-mono text-[10px] text-slate-600">
                       {fmtTs(alert.last_seen)}
                     </span>
@@ -516,14 +473,14 @@ export default function AdminMonitorPage() {
       ) : null}
 
       {/* ── Live Log Stream ───────────────────────────────────────────────── */}
-      <h2 className="font-heading mb-3 text-sm font-semibold uppercase tracking-widest text-slate-500">
+      <h2 className="font-heading mb-3 text-sm font-semibold tracking-widest text-slate-500 uppercase">
         Live Log Stream
       </h2>
-      <div className="bg-void-light/50 rounded-xl border border-slate-800 overflow-hidden">
+      <div className="bg-void-light/50 overflow-hidden rounded-xl border border-slate-800">
         {/* WS status bar */}
         <div className="flex items-center gap-2 border-b border-slate-800 px-4 py-2">
           <span
-            className={`h-2 w-2 rounded-full ${wsStatus === "open" ? "bg-neon-green animate-pulse" : wsStatus === "connecting" ? "bg-yellow-400 animate-pulse" : "bg-red-400"}`}
+            className={`h-2 w-2 rounded-full ${wsStatus === "open" ? "bg-neon-green animate-pulse" : wsStatus === "connecting" ? "animate-pulse bg-yellow-400" : "bg-red-400"}`}
           />
           <span className="font-mono text-[10px] text-slate-500">
             {wsStatus === "open"
@@ -548,13 +505,11 @@ export default function AdminMonitorPage() {
                   })}
                 </span>
                 <span
-                  className={`shrink-0 w-12 ${LOG_LEVEL_COLOR[entry.level] ?? "text-slate-400"}`}
+                  className={`w-12 shrink-0 ${LOG_LEVEL_COLOR[entry.level] ?? "text-slate-400"}`}
                 >
                   {entry.level}
                 </span>
-                <span className="text-slate-300 break-all">
-                  {entry.message}
-                </span>
+                <span className="break-all text-slate-300">{entry.message}</span>
               </div>
             ))
           )}
@@ -563,8 +518,8 @@ export default function AdminMonitorPage() {
       </div>
 
       <p className="mt-4 font-mono text-[10px] text-slate-600">
-        Auto-refreshes every {POLL_INTERVAL / 1000}s · WebSocket reconnects
-        automatically · Last fetched: {status ? fmtTs(status.timestamp) : "—"}
+        Auto-refreshes every {POLL_INTERVAL / 1000}s · WebSocket reconnects automatically · Last
+        fetched: {status ? fmtTs(status.timestamp) : "—"}
       </p>
     </div>
   );

--- a/src/app/[locale]/admin/notifications/page.tsx
+++ b/src/app/[locale]/admin/notifications/page.tsx
@@ -36,20 +36,14 @@ export default function NotificationsPage() {
       <div className="mb-8">
         <div className="border-neon-magenta/20 bg-neon-magenta/10 mb-4 inline-flex items-center gap-2 rounded-full border px-3 py-1.5">
           <span className="bg-neon-magenta h-2 w-2 animate-pulse rounded-full" />
-          <span className="text-neon-magenta font-mono text-xs">
-            NOTIFICATIONS
-          </span>
+          <span className="text-neon-magenta font-mono text-xs">NOTIFICATIONS</span>
         </div>
-        <h1 className="font-heading text-2xl font-bold text-white">
-          Notifications
-        </h1>
+        <h1 className="font-heading text-2xl font-bold text-white">Notifications</h1>
       </div>
 
       {notifications.length === 0 ? (
         <div className="rounded-xl border border-slate-800 p-12 text-center">
-          <p className="font-mono text-sm text-slate-500">
-            No notifications yet.
-          </p>
+          <p className="font-mono text-sm text-slate-500">No notifications yet.</p>
         </div>
       ) : (
         <div className="space-y-3">
@@ -64,12 +58,8 @@ export default function NotificationsPage() {
             >
               <div className="mb-1 flex items-center justify-between">
                 <div className="flex items-center gap-2">
-                  {!n.read && (
-                    <span className="bg-neon-magenta h-2 w-2 rounded-full" />
-                  )}
-                  <span className="font-mono text-sm font-semibold text-white">
-                    {n.title}
-                  </span>
+                  {!n.read && <span className="bg-neon-magenta h-2 w-2 rounded-full" />}
+                  <span className="font-mono text-sm font-semibold text-white">{n.title}</span>
                 </div>
                 <span className="font-mono text-[10px] text-slate-500">
                   {new Date(n.createdAt).toLocaleDateString()}

--- a/src/app/[locale]/admin/notion/analytics/page.tsx
+++ b/src/app/[locale]/admin/notion/analytics/page.tsx
@@ -69,9 +69,7 @@ export default function AnalyticsDashboardPage() {
     setLoading(true);
     setError(null);
     try {
-      const res = await fetchWithAuth(
-        `/api/admin/notion/analytics?days=${days}`,
-      );
+      const res = await fetchWithAuth(`/api/admin/notion/analytics?days=${days}`);
       if (!res.ok) throw new Error(`HTTP ${res.status}`);
       const data = (await res.json()) as AnalyticsSummary;
       setSummary(data);
@@ -88,15 +86,7 @@ export default function AnalyticsDashboardPage() {
   }, [load]);
 
   // Bar chart helper — renders a simple horizontal bar
-  const Bar = ({
-    value,
-    max,
-    color,
-  }: {
-    value: number;
-    max: number;
-    color: string;
-  }) => (
+  const Bar = ({ value, max, color }: { value: number; max: number; color: string }) => (
     <div className="h-2 flex-1 overflow-hidden rounded-full bg-slate-800">
       <div
         className={`h-full rounded-full transition-all ${color}`}
@@ -112,16 +102,11 @@ export default function AnalyticsDashboardPage() {
         <div>
           <div className="bg-neon-green/10 border-neon-green/20 mb-4 inline-flex items-center gap-2 rounded-full border px-3 py-1.5">
             <span className="bg-neon-green h-2 w-2 animate-pulse rounded-full" />
-            <span className="text-neon-green font-mono text-xs">
-              NOTION_ANALYTICS
-            </span>
+            <span className="text-neon-green font-mono text-xs">NOTION_ANALYTICS</span>
           </div>
-          <h1 className="font-heading text-2xl font-bold text-white">
-            Site Analytics
-          </h1>
+          <h1 className="font-heading text-2xl font-bold text-white">Site Analytics</h1>
           <p className="font-body mt-1 text-slate-400">
-            Event tracking and visitor insights from your Notion analytics
-            database.
+            Event tracking and visitor insights from your Notion analytics database.
           </p>
         </div>
         <div className="flex gap-2">
@@ -164,7 +149,7 @@ export default function AnalyticsDashboardPage() {
           {[1, 2, 3, 4].map((i) => (
             <div
               key={i}
-              className="animate-pulse rounded-xl border border-slate-800 bg-void-light/50 p-5"
+              className="bg-void-light/50 animate-pulse rounded-xl border border-slate-800 p-5"
             >
               <div className="mb-2 h-3 w-20 rounded bg-slate-700/60" />
               <div className="h-8 w-16 rounded bg-slate-800/80" />
@@ -178,18 +163,16 @@ export default function AnalyticsDashboardPage() {
         <>
           {/* KPI Cards */}
           <div className="mb-8 grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
-            <div className="rounded-xl border border-neon-cyan/20 bg-void-light/50 p-5">
+            <div className="border-neon-cyan/20 bg-void-light/50 rounded-xl border p-5">
               <p className="font-mono text-xs text-slate-500">Total Events</p>
-              <p className="font-heading mt-1 text-3xl font-bold text-neon-cyan">
+              <p className="font-heading text-neon-cyan mt-1 text-3xl font-bold">
                 {summary.totalEvents.toLocaleString()}
               </p>
-              <p className="mt-1 font-mono text-xs text-slate-600">
-                Last {days} days
-              </p>
+              <p className="mt-1 font-mono text-xs text-slate-600">Last {days} days</p>
             </div>
-            <div className="rounded-xl border border-neon-green/20 bg-void-light/50 p-5">
+            <div className="border-neon-green/20 bg-void-light/50 rounded-xl border p-5">
               <p className="font-mono text-xs text-slate-500">Page Views</p>
-              <p className="font-heading mt-1 text-3xl font-bold text-neon-green">
+              <p className="font-heading text-neon-green mt-1 text-3xl font-bold">
                 {(summary.byType.page_view ?? 0).toLocaleString()}
               </p>
               <p className="mt-1 font-mono text-xs text-slate-600">
@@ -198,18 +181,14 @@ export default function AnalyticsDashboardPage() {
                   : "—"}
               </p>
             </div>
-            <div className="rounded-xl border border-neon-magenta/20 bg-void-light/50 p-5">
-              <p className="font-mono text-xs text-slate-500">
-                Form Submissions
-              </p>
-              <p className="font-heading mt-1 text-3xl font-bold text-neon-magenta">
+            <div className="border-neon-magenta/20 bg-void-light/50 rounded-xl border p-5">
+              <p className="font-mono text-xs text-slate-500">Form Submissions</p>
+              <p className="font-heading text-neon-magenta mt-1 text-3xl font-bold">
                 {(summary.byType.form_submit ?? 0).toLocaleString()}
               </p>
-              <p className="mt-1 font-mono text-xs text-slate-600">
-                Conversion events
-              </p>
+              <p className="mt-1 font-mono text-xs text-slate-600">Conversion events</p>
             </div>
-            <div className="rounded-xl border border-yellow-500/20 bg-void-light/50 p-5">
+            <div className="bg-void-light/50 rounded-xl border border-yellow-500/20 p-5">
               <p className="font-mono text-xs text-slate-500">Errors</p>
               <p
                 className={`font-heading mt-1 text-3xl font-bold ${(summary.byType.error ?? 0) > 0 ? "text-red-400" : "text-neon-green"}`}
@@ -217,19 +196,15 @@ export default function AnalyticsDashboardPage() {
                 {(summary.byType.error ?? 0).toLocaleString()}
               </p>
               <p className="mt-1 font-mono text-xs text-slate-600">
-                {(summary.byType.error ?? 0) === 0
-                  ? "All clear"
-                  : "Needs attention"}
+                {(summary.byType.error ?? 0) === 0 ? "All clear" : "Needs attention"}
               </p>
             </div>
           </div>
 
           <div className="grid gap-6 lg:grid-cols-2">
             {/* Events by Type */}
-            <div className="rounded-xl border border-slate-800 bg-void-light/50 p-6">
-              <h2 className="font-heading mb-4 font-semibold text-white">
-                Events by Type
-              </h2>
+            <div className="bg-void-light/50 rounded-xl border border-slate-800 p-6">
+              <h2 className="font-heading mb-4 font-semibold text-white">Events by Type</h2>
               <div className="space-y-3">
                 {Object.entries(summary.byType)
                   .sort(([, a], [, b]) => b - a)
@@ -250,18 +225,14 @@ export default function AnalyticsDashboardPage() {
                     );
                   })}
                 {Object.keys(summary.byType).length === 0 && (
-                  <p className="py-4 text-center font-mono text-xs text-slate-600">
-                    No events yet
-                  </p>
+                  <p className="py-4 text-center font-mono text-xs text-slate-600">No events yet</p>
                 )}
               </div>
             </div>
 
             {/* Top Pages */}
-            <div className="rounded-xl border border-slate-800 bg-void-light/50 p-6">
-              <h2 className="font-heading mb-4 font-semibold text-white">
-                Top Pages
-              </h2>
+            <div className="bg-void-light/50 rounded-xl border border-slate-800 p-6">
+              <h2 className="font-heading mb-4 font-semibold text-white">Top Pages</h2>
               <div className="space-y-3">
                 {summary.topPages.map(({ page, count }, i) => {
                   const max = summary.topPages[0]?.count ?? 1;
@@ -281,18 +252,14 @@ export default function AnalyticsDashboardPage() {
                   );
                 })}
                 {summary.topPages.length === 0 && (
-                  <p className="py-4 text-center font-mono text-xs text-slate-600">
-                    No page data
-                  </p>
+                  <p className="py-4 text-center font-mono text-xs text-slate-600">No page data</p>
                 )}
               </div>
             </div>
 
             {/* Top Sources */}
-            <div className="rounded-xl border border-slate-800 bg-void-light/50 p-6">
-              <h2 className="font-heading mb-4 font-semibold text-white">
-                Top Sources
-              </h2>
+            <div className="bg-void-light/50 rounded-xl border border-slate-800 p-6">
+              <h2 className="font-heading mb-4 font-semibold text-white">Top Sources</h2>
               <div className="space-y-3">
                 {summary.topSources.map(({ source, count }, i) => {
                   const max = summary.topSources[0]?.count ?? 1;
@@ -320,15 +287,13 @@ export default function AnalyticsDashboardPage() {
             </div>
 
             {/* Recent Events */}
-            <div className="rounded-xl border border-slate-800 bg-void-light/50 p-6">
-              <h2 className="font-heading mb-4 font-semibold text-white">
-                Recent Events
-              </h2>
+            <div className="bg-void-light/50 rounded-xl border border-slate-800 p-6">
+              <h2 className="font-heading mb-4 font-semibold text-white">Recent Events</h2>
               <div className="max-h-80 space-y-2 overflow-y-auto pr-1">
                 {summary.recentEvents.slice(0, 15).map((event) => (
                   <div
                     key={event.id}
-                    className="flex items-center gap-2 rounded-lg border border-slate-700/40 bg-void/40 px-3 py-2"
+                    className="bg-void/40 flex items-center gap-2 rounded-lg border border-slate-700/40 px-3 py-2"
                   >
                     <span
                       className={`shrink-0 rounded-full border px-1.5 py-0.5 font-mono text-[8px] ${TYPE_COLORS[event.type] ?? TYPE_COLORS.page_view}`}
@@ -361,10 +326,8 @@ export default function AnalyticsDashboardPage() {
 
       {/* Empty state */}
       {!loading && !error && !summary && (
-        <div className="rounded-xl border border-slate-800 bg-void-light/30 p-12 text-center">
-          <p className="font-mono text-slate-500">
-            No analytics data available.
-          </p>
+        <div className="bg-void-light/30 rounded-xl border border-slate-800 p-12 text-center">
+          <p className="font-mono text-slate-500">No analytics data available.</p>
           <p className="font-body mt-2 text-sm text-slate-600">
             Events will appear here once the tracking is active.
           </p>

--- a/src/app/[locale]/admin/notion/page.tsx
+++ b/src/app/[locale]/admin/notion/page.tsx
@@ -57,9 +57,7 @@ export default function NotionSubmissionsPage() {
       };
       setSubmissions(data.submissions ?? []);
     } catch (err) {
-      setError(
-        err instanceof Error ? err.message : "Failed to load submissions",
-      );
+      setError(err instanceof Error ? err.message : "Failed to load submissions");
     } finally {
       setLoading(false);
     }
@@ -79,9 +77,7 @@ export default function NotionSubmissionsPage() {
         body: JSON.stringify({ pageId, status }),
       });
       if (!res.ok) throw new Error(`HTTP ${res.status}`);
-      setSubmissions((prev) =>
-        prev.map((s) => (s.id === pageId ? { ...s, status } : s)),
-      );
+      setSubmissions((prev) => prev.map((s) => (s.id === pageId ? { ...s, status } : s)));
     } catch (err) {
       console.error("Failed to update status:", err);
     } finally {
@@ -96,13 +92,9 @@ export default function NotionSubmissionsPage() {
         <div>
           <div className="bg-neon-magenta/10 border-neon-magenta/20 mb-4 inline-flex items-center gap-2 rounded-full border px-3 py-1.5">
             <span className="bg-neon-magenta h-2 w-2 animate-pulse rounded-full" />
-            <span className="text-neon-magenta font-mono text-xs">
-              NOTION_SUBMISSIONS
-            </span>
+            <span className="text-neon-magenta font-mono text-xs">NOTION_SUBMISSIONS</span>
           </div>
-          <h1 className="font-heading text-2xl font-bold text-white">
-            Contact Submissions
-          </h1>
+          <h1 className="font-heading text-2xl font-bold text-white">Contact Submissions</h1>
           <p className="font-body mt-1 text-slate-400">
             Form submissions stored in your Notion database.
           </p>
@@ -125,9 +117,9 @@ export default function NotionSubmissionsPage() {
 
       {/* Empty */}
       {!loading && !error && submissions.length === 0 && (
-        <div className="rounded-xl border border-slate-800 bg-void-light/30 p-12 text-center">
+        <div className="bg-void-light/30 rounded-xl border border-slate-800 p-12 text-center">
           <p className="font-mono text-slate-500">No submissions yet.</p>
-          <p className="mt-2 font-body text-sm text-slate-600">
+          <p className="font-body mt-2 text-sm text-slate-600">
             Submissions will appear here once the contact form is used.
           </p>
         </div>
@@ -139,7 +131,7 @@ export default function NotionSubmissionsPage() {
           {[1, 2, 3].map((i) => (
             <div
               key={i}
-              className="animate-pulse rounded-xl border border-slate-800 bg-void-light/50 p-5"
+              className="bg-void-light/50 animate-pulse rounded-xl border border-slate-800 p-5"
             >
               <div className="mb-3 flex items-center justify-between">
                 <div className="h-4 w-36 rounded bg-slate-700/60" />
@@ -157,18 +149,14 @@ export default function NotionSubmissionsPage() {
           {submissions.map((sub) => (
             <div
               key={sub.id}
-              className="rounded-xl border border-slate-800 bg-void-light/50 p-5 transition-all"
+              className="bg-void-light/50 rounded-xl border border-slate-800 p-5 transition-all"
             >
               {/* Row header */}
               <div className="flex flex-wrap items-start gap-3">
                 <div className="min-w-0 flex-1">
                   <div className="flex flex-wrap items-center gap-2">
-                    <span className="font-heading font-semibold text-white">
-                      {sub.name}
-                    </span>
-                    <span className="font-mono text-xs text-slate-500">
-                      {sub.email}
-                    </span>
+                    <span className="font-heading font-semibold text-white">{sub.name}</span>
+                    <span className="font-mono text-xs text-slate-500">{sub.email}</span>
                     {sub.company && (
                       <span className="rounded bg-slate-800 px-2 py-0.5 font-mono text-xs text-slate-400">
                         {sub.company}
@@ -192,10 +180,8 @@ export default function NotionSubmissionsPage() {
                   <select
                     value={sub.status}
                     disabled={updating === sub.id}
-                    onChange={(e) =>
-                      updateStatus(sub.id, e.target.value as StatusValue)
-                    }
-                    className="rounded border border-slate-700 bg-void px-2 py-1 font-mono text-xs text-slate-300 focus:border-neon-magenta/50 focus:outline-none disabled:opacity-50"
+                    onChange={(e) => updateStatus(sub.id, e.target.value as StatusValue)}
+                    className="bg-void focus:border-neon-magenta/50 rounded border border-slate-700 px-2 py-1 font-mono text-xs text-slate-300 focus:outline-none disabled:opacity-50"
                   >
                     <option value="New">New</option>
                     <option value="In Review">In Review</option>
@@ -203,10 +189,8 @@ export default function NotionSubmissionsPage() {
                   </select>
 
                   <button
-                    onClick={() =>
-                      setExpanded(expanded === sub.id ? null : sub.id)
-                    }
-                    className="text-slate-500 hover:text-slate-300 font-mono text-xs transition-colors"
+                    onClick={() => setExpanded(expanded === sub.id ? null : sub.id)}
+                    className="font-mono text-xs text-slate-500 transition-colors hover:text-slate-300"
                   >
                     {expanded === sub.id ? "▲ hide" : "▼ show"}
                   </button>
@@ -215,8 +199,8 @@ export default function NotionSubmissionsPage() {
 
               {/* Expanded message */}
               {expanded === sub.id && (
-                <div className="mt-4 rounded-lg border border-slate-700/50 bg-void/60 p-4">
-                  <p className="font-body whitespace-pre-wrap text-sm leading-relaxed text-slate-300">
+                <div className="bg-void/60 mt-4 rounded-lg border border-slate-700/50 p-4">
+                  <p className="font-body text-sm leading-relaxed whitespace-pre-wrap text-slate-300">
                     {sub.message}
                   </p>
                   {sub.url && (

--- a/src/app/[locale]/admin/notion/projects/page.tsx
+++ b/src/app/[locale]/admin/notion/projects/page.tsx
@@ -19,12 +19,7 @@ interface Project {
   url: string;
 }
 
-type ProjectStatus =
-  | "Planning"
-  | "In Progress"
-  | "On Hold"
-  | "Completed"
-  | "Cancelled";
+type ProjectStatus = "Planning" | "In Progress" | "On Hold" | "Completed" | "Cancelled";
 type ProjectPriority = "Critical" | "High" | "Medium" | "Low";
 
 const STATUS_STYLES: Record<string, string> = {
@@ -63,8 +58,7 @@ function formatDate(iso: string) {
 }
 
 function isOverdue(dueDate: string, status: string): boolean {
-  if (!dueDate || status === "Completed" || status === "Cancelled")
-    return false;
+  if (!dueDate || status === "Completed" || status === "Cancelled") return false;
   return new Date(dueDate) < new Date();
 }
 
@@ -91,7 +85,7 @@ function ProgressInput({
     <div className="flex items-center gap-2">
       <div className="h-1.5 w-24 overflow-hidden rounded-full bg-slate-800">
         <div
-          className="h-full rounded-full bg-neon-cyan transition-all"
+          className="bg-neon-cyan h-full rounded-full transition-all"
           style={{ width: `${progress}%` }}
         />
       </div>
@@ -103,7 +97,7 @@ function ProgressInput({
         disabled={disabled}
         onChange={(e) => onProgressChange(projectId, clampProgress(e.target.value))}
         onBlur={(e) => onBlur(projectId, clampProgress(e.target.value))}
-        className="w-12 rounded border border-slate-700 bg-void px-1 py-0.5 text-center font-mono text-xs text-slate-300 focus:border-neon-cyan/50 focus:outline-none disabled:opacity-50"
+        className="bg-void focus:border-neon-cyan/50 w-12 rounded border border-slate-700 px-1 py-0.5 text-center font-mono text-xs text-slate-300 focus:outline-none disabled:opacity-50"
       />
       <span className="font-mono text-[10px] text-slate-600">%</span>
     </div>
@@ -159,9 +153,7 @@ export default function ProjectsPage() {
         body: JSON.stringify({ pageId, status }),
       });
       if (!res.ok) throw new Error(`HTTP ${res.status}`);
-      setProjects((prev) =>
-        prev.map((p) => (p.id === pageId ? { ...p, status } : p)),
-      );
+      setProjects((prev) => prev.map((p) => (p.id === pageId ? { ...p, status } : p)));
     } catch (err) {
       console.error("Failed to update status:", err);
     } finally {
@@ -178,9 +170,7 @@ export default function ProjectsPage() {
         body: JSON.stringify({ pageId, progress }),
       });
       if (!res.ok) throw new Error(`HTTP ${res.status}`);
-      setProjects((prev) =>
-        prev.map((p) => (p.id === pageId ? { ...p, progress } : p)),
-      );
+      setProjects((prev) => prev.map((p) => (p.id === pageId ? { ...p, progress } : p)));
     } catch (err) {
       console.error("Failed to update progress:", err);
     } finally {
@@ -223,8 +213,7 @@ export default function ProjectsPage() {
     "Completed",
     "Cancelled",
   ];
-  const countByStatus = (s: string) =>
-    projects.filter((p) => p.status === s).length;
+  const countByStatus = (s: string) => projects.filter((p) => p.status === s).length;
 
   return (
     <div>
@@ -233,13 +222,9 @@ export default function ProjectsPage() {
         <div>
           <div className="bg-neon-cyan/10 border-neon-cyan/20 mb-4 inline-flex items-center gap-2 rounded-full border px-3 py-1.5">
             <span className="bg-neon-cyan h-2 w-2 animate-pulse rounded-full" />
-            <span className="text-neon-cyan font-mono text-xs">
-              NOTION_PROJECTS
-            </span>
+            <span className="text-neon-cyan font-mono text-xs">NOTION_PROJECTS</span>
           </div>
-          <h1 className="font-heading text-2xl font-bold text-white">
-            Projects
-          </h1>
+          <h1 className="font-heading text-2xl font-bold text-white">Projects</h1>
           <p className="font-body mt-1 text-slate-400">
             Manage projects from your Notion workspace.
           </p>
@@ -291,23 +276,19 @@ export default function ProjectsPage() {
       {/* Create form */}
       {showCreate && (
         <div className="bg-void-light/50 mb-6 rounded-xl border border-slate-800 p-6">
-          <h3 className="font-heading mb-4 font-semibold text-white">
-            Create Project
-          </h3>
+          <h3 className="font-heading mb-4 font-semibold text-white">Create Project</h3>
           <div className="grid gap-4 sm:grid-cols-2">
             <input
               type="text"
               placeholder="Project name *"
               value={newName}
               onChange={(e) => setNewName(e.target.value)}
-              className="bg-void rounded-lg border border-slate-700 px-3 py-2 font-mono text-sm text-white placeholder-slate-600 focus:border-neon-cyan/50 focus:outline-none"
+              className="bg-void focus:border-neon-cyan/50 rounded-lg border border-slate-700 px-3 py-2 font-mono text-sm text-white placeholder-slate-600 focus:outline-none"
             />
             <select
               value={newPriority}
-              onChange={(e) =>
-                setNewPriority(e.target.value as ProjectPriority)
-              }
-              className="bg-void rounded-lg border border-slate-700 px-3 py-2 font-mono text-sm text-white focus:border-neon-cyan/50 focus:outline-none"
+              onChange={(e) => setNewPriority(e.target.value as ProjectPriority)}
+              className="bg-void focus:border-neon-cyan/50 rounded-lg border border-slate-700 px-3 py-2 font-mono text-sm text-white focus:outline-none"
             >
               <option value="Critical">Critical</option>
               <option value="High">High</option>
@@ -317,7 +298,7 @@ export default function ProjectsPage() {
             <select
               value={newType}
               onChange={(e) => setNewType(e.target.value)}
-              className="bg-void rounded-lg border border-slate-700 px-3 py-2 font-mono text-sm text-white focus:border-neon-cyan/50 focus:outline-none"
+              className="bg-void focus:border-neon-cyan/50 rounded-lg border border-slate-700 px-3 py-2 font-mono text-sm text-white focus:outline-none"
             >
               <option value="Client">Client</option>
               <option value="Internal">Internal</option>
@@ -328,14 +309,14 @@ export default function ProjectsPage() {
               placeholder="Owner"
               value={newOwner}
               onChange={(e) => setNewOwner(e.target.value)}
-              className="bg-void rounded-lg border border-slate-700 px-3 py-2 font-mono text-sm text-white placeholder-slate-600 focus:border-neon-cyan/50 focus:outline-none"
+              className="bg-void focus:border-neon-cyan/50 rounded-lg border border-slate-700 px-3 py-2 font-mono text-sm text-white placeholder-slate-600 focus:outline-none"
             />
             <textarea
               placeholder="Description"
               value={newDescription}
               onChange={(e) => setNewDescription(e.target.value)}
               rows={2}
-              className="bg-void col-span-full rounded-lg border border-slate-700 px-3 py-2 font-mono text-sm text-white placeholder-slate-600 focus:border-neon-cyan/50 focus:outline-none"
+              className="bg-void focus:border-neon-cyan/50 col-span-full rounded-lg border border-slate-700 px-3 py-2 font-mono text-sm text-white placeholder-slate-600 focus:outline-none"
             />
           </div>
           <div className="mt-4 flex gap-2">
@@ -369,7 +350,7 @@ export default function ProjectsPage() {
           {[1, 2, 3].map((i) => (
             <div
               key={i}
-              className="animate-pulse rounded-xl border border-slate-800 bg-void-light/50 p-5"
+              className="bg-void-light/50 animate-pulse rounded-xl border border-slate-800 p-5"
             >
               <div className="mb-3 h-4 w-48 rounded bg-slate-700/60" />
               <div className="h-3 w-32 rounded bg-slate-800/80" />
@@ -380,7 +361,7 @@ export default function ProjectsPage() {
 
       {/* Empty */}
       {!loading && !error && projects.length === 0 && (
-        <div className="rounded-xl border border-slate-800 bg-void-light/30 p-12 text-center">
+        <div className="bg-void-light/30 rounded-xl border border-slate-800 p-12 text-center">
           <p className="font-mono text-slate-500">No projects found.</p>
           <p className="font-body mt-2 text-sm text-slate-600">
             Create your first project above or add one in Notion.
@@ -397,9 +378,7 @@ export default function ProjectsPage() {
               <div
                 key={project.id}
                 className={`rounded-xl border p-5 transition-all hover:border-slate-700 ${
-                  overdue
-                    ? "border-red-500/20 bg-red-500/5"
-                    : "border-slate-800 bg-void-light/50"
+                  overdue ? "border-red-500/20 bg-red-500/5" : "bg-void-light/50 border-slate-800"
                 }`}
               >
                 <div className="flex flex-wrap items-start gap-3">
@@ -410,9 +389,7 @@ export default function ProjectsPage() {
                       >
                         {PRIORITY_ICONS[project.priority] ?? "◆"}
                       </span>
-                      <h3 className="font-heading font-semibold text-white">
-                        {project.name}
-                      </h3>
+                      <h3 className="font-heading font-semibold text-white">{project.name}</h3>
                       {overdue && (
                         <span className="rounded bg-red-500/20 px-1.5 py-0.5 font-mono text-[9px] text-red-400">
                           OVERDUE
@@ -423,16 +400,14 @@ export default function ProjectsPage() {
                       </span>
                     </div>
                     {project.description && (
-                      <p className="font-body mt-1 text-sm text-slate-500 line-clamp-1">
+                      <p className="font-body mt-1 line-clamp-1 text-sm text-slate-500">
                         {project.description}
                       </p>
                     )}
                     <div className="mt-2 flex flex-wrap gap-3 font-mono text-xs text-slate-600">
                       {project.owner && <span>Owner: {project.owner}</span>}
                       <span>Start: {formatDate(project.startDate)}</span>
-                      {project.dueDate && (
-                        <span>Due: {formatDate(project.dueDate)}</span>
-                      )}
+                      {project.dueDate && <span>Due: {formatDate(project.dueDate)}</span>}
                       {project.budget !== null && (
                         <span>Budget: €{project.budget.toLocaleString()}</span>
                       )}
@@ -450,13 +425,8 @@ export default function ProjectsPage() {
                       <select
                         value={project.status}
                         disabled={updating === project.id}
-                        onChange={(e) =>
-                          updateStatus(
-                            project.id,
-                            e.target.value as ProjectStatus,
-                          )
-                        }
-                        className="rounded border border-slate-700 bg-void px-2 py-1 font-mono text-xs text-slate-300 focus:border-neon-cyan/50 focus:outline-none disabled:opacity-50"
+                        onChange={(e) => updateStatus(project.id, e.target.value as ProjectStatus)}
+                        className="bg-void focus:border-neon-cyan/50 rounded border border-slate-700 px-2 py-1 font-mono text-xs text-slate-300 focus:outline-none disabled:opacity-50"
                       >
                         {statuses.map((s) => (
                           <option key={s} value={s}>
@@ -473,7 +443,7 @@ export default function ProjectsPage() {
                       disabled={updating === project.id}
                       onProgressChange={(id, val) =>
                         setProjects((prev) =>
-                          prev.map((p) => (p.id === id ? { ...p, progress: val } : p)),
+                          prev.map((p) => (p.id === id ? { ...p, progress: val } : p))
                         )
                       }
                       onBlur={updateProgress}

--- a/src/app/[locale]/admin/notion/status/page.tsx
+++ b/src/app/[locale]/admin/notion/status/page.tsx
@@ -44,10 +44,10 @@ const DB_LINKS: Record<string, string> = {
 function StatusBadge({ ok, label }: { ok: boolean; label: string }) {
   return (
     <span
-      className={`inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-xs font-medium border ${
+      className={`inline-flex items-center gap-1 rounded-full border px-2 py-0.5 text-xs font-medium ${
         ok
           ? "bg-neon-green/10 text-neon-green border-neon-green/30"
-          : "bg-red-500/10 text-red-400 border-red-500/30"
+          : "border-red-500/30 bg-red-500/10 text-red-400"
       }`}
     >
       <span
@@ -71,10 +71,7 @@ function CellValue({ value }: { value: unknown }) {
     return (
       <span className="flex flex-wrap gap-1">
         {value.map((v, i) => (
-          <span
-            key={i}
-            className="rounded bg-slate-700/50 px-1.5 py-0.5 text-xs text-slate-300"
-          >
+          <span key={i} className="rounded bg-slate-700/50 px-1.5 py-0.5 text-xs text-slate-300">
             {String(v)}
           </span>
         ))}
@@ -82,10 +79,7 @@ function CellValue({ value }: { value: unknown }) {
     );
   const str = String(value);
   return (
-    <span
-      className="truncate max-w-[200px] inline-block align-bottom"
-      title={str}
-    >
+    <span className="inline-block max-w-[200px] truncate align-bottom" title={str}>
       {str.length > 60 ? str.slice(0, 57) + "..." : str}
     </span>
   );
@@ -105,17 +99,14 @@ function DatabaseCard({
   const icon = DB_ICONS[db.name] ?? "\u{1F4CB}";
 
   // Get column headers from first sample row
-  const columns =
-    db.sample.length > 0
-      ? Object.keys(db.sample[0]).filter((k) => k !== "id")
-      : [];
+  const columns = db.sample.length > 0 ? Object.keys(db.sample[0]).filter((k) => k !== "id") : [];
 
   return (
-    <div className="rounded-lg border border-slate-700/50 bg-slate-800/40 overflow-hidden">
+    <div className="overflow-hidden rounded-lg border border-slate-700/50 bg-slate-800/40">
       {/* Header */}
       <button
         onClick={onToggle}
-        className="w-full flex items-center justify-between px-5 py-4 hover:bg-slate-700/20 transition-colors"
+        className="flex w-full items-center justify-between px-5 py-4 transition-colors hover:bg-slate-700/20"
       >
         <div className="flex items-center gap-3">
           <span className="text-xl">{icon}</span>
@@ -135,9 +126,7 @@ function DatabaseCard({
             </span>
           )}
         </div>
-        <span
-          className={`text-slate-400 transition-transform ${expanded ? "rotate-180" : ""}`}
-        >
+        <span className={`text-slate-400 transition-transform ${expanded ? "rotate-180" : ""}`}>
           {"\u25BC"}
         </span>
       </button>
@@ -145,7 +134,7 @@ function DatabaseCard({
       {/* Error */}
       {db.error && (
         <div className="px-5 pb-3">
-          <div className="rounded bg-red-500/10 border border-red-500/20 px-3 py-2 text-sm text-red-400">
+          <div className="rounded border border-red-500/20 bg-red-500/10 px-3 py-2 text-sm text-red-400">
             {db.error}
           </div>
         </div>
@@ -154,27 +143,25 @@ function DatabaseCard({
       {/* Not configured hint */}
       {!db.configured && expanded && (
         <div className="px-5 pb-4">
-          <div className="rounded bg-yellow-500/10 border border-yellow-500/20 px-3 py-2 text-sm text-yellow-400">
+          <div className="rounded border border-yellow-500/20 bg-yellow-500/10 px-3 py-2 text-sm text-yellow-400">
             Set{" "}
-            <code className="bg-slate-700 px-1 rounded">
-              NOTION_{db.name.toUpperCase()}_DB_ID
-            </code>{" "}
-            in <code className="bg-slate-700 px-1 rounded">.env.local</code> and
-            share the database with your integration.
+            <code className="rounded bg-slate-700 px-1">NOTION_{db.name.toUpperCase()}_DB_ID</code>{" "}
+            in <code className="rounded bg-slate-700 px-1">.env.local</code> and share the database
+            with your integration.
           </div>
         </div>
       )}
 
       {/* Data table */}
       {expanded && db.connected && db.sample.length > 0 && (
-        <div className="px-5 pb-4 overflow-x-auto">
-          <table className="w-full text-sm border-collapse">
+        <div className="overflow-x-auto px-5 pb-4">
+          <table className="w-full border-collapse text-sm">
             <thead>
               <tr>
                 {columns.map((col) => (
                   <th
                     key={col}
-                    className="text-left px-2 py-1.5 text-xs font-medium text-slate-400 uppercase tracking-wider border-b border-slate-700/50"
+                    className="border-b border-slate-700/50 px-2 py-1.5 text-left text-xs font-medium tracking-wider text-slate-400 uppercase"
                   >
                     {col}
                   </th>
@@ -199,10 +186,7 @@ function DatabaseCard({
           {db.count >= 5 && (
             <p className="mt-2 text-xs text-slate-500">
               Showing first 5 rows.{" "}
-              <a
-                href={DB_LINKS[db.name] ?? "#"}
-                className="text-neon-cyan hover:underline"
-              >
+              <a href={DB_LINKS[db.name] ?? "#"} className="text-neon-cyan hover:underline">
                 View all {"\u2192"}
               </a>
             </p>
@@ -212,9 +196,7 @@ function DatabaseCard({
 
       {expanded && db.connected && db.sample.length === 0 && (
         <div className="px-5 pb-4">
-          <p className="text-sm text-slate-500 italic">
-            Database is empty {"\u2014"} no rows yet.
-          </p>
+          <p className="text-sm text-slate-500 italic">Database is empty {"\u2014"} no rows yet.</p>
         </div>
       )}
     </div>
@@ -238,9 +220,7 @@ export default function NotionStatusPage() {
       const json: StatusResponse = await res.json();
       setData(json);
       // Auto-expand connected databases
-      const connected = new Set(
-        json.databases.filter((d) => d.connected).map((d) => d.name),
-      );
+      const connected = new Set(json.databases.filter((d) => d.connected).map((d) => d.name));
       setExpandedDbs(connected);
     } catch (err: unknown) {
       setError(err instanceof Error ? err.message : "Failed to load");
@@ -264,16 +244,15 @@ export default function NotionStatusPage() {
   };
 
   const connectedCount = data?.databases.filter((d) => d.connected).length ?? 0;
-  const configuredCount =
-    data?.databases.filter((d) => d.configured).length ?? 0;
+  const configuredCount = data?.databases.filter((d) => d.configured).length ?? 0;
   const totalDbs = data?.databases.length ?? 0;
 
   return (
-    <div className="min-h-screen bg-bg-void text-white">
+    <div className="bg-bg-void min-h-screen text-white">
       <div className="mx-auto max-w-5xl px-4 py-8">
         {/* Header */}
         <div className="mb-8">
-          <h1 className="text-3xl font-bold bg-gradient-to-r from-neon-cyan to-neon-magenta bg-clip-text text-transparent">
+          <h1 className="from-neon-cyan to-neon-magenta bg-gradient-to-r bg-clip-text text-3xl font-bold text-transparent">
             Notion Integration Status
           </h1>
           <p className="mt-2 text-slate-400">
@@ -284,7 +263,7 @@ export default function NotionStatusPage() {
         {/* Loading */}
         {loading && (
           <div className="flex items-center justify-center py-20">
-            <div className="h-8 w-8 animate-spin rounded-full border-2 border-neon-cyan border-t-transparent" />
+            <div className="border-neon-cyan h-8 w-8 animate-spin rounded-full border-2 border-t-transparent" />
             <span className="ml-3 text-slate-400">Connecting to Notion...</span>
           </div>
         )}
@@ -293,10 +272,7 @@ export default function NotionStatusPage() {
         {error && !loading && (
           <div className="rounded-lg border border-red-500/30 bg-red-500/10 px-4 py-3 text-red-400">
             {error}
-            <button
-              onClick={load}
-              className="ml-3 underline hover:text-red-300"
-            >
+            <button onClick={load} className="ml-3 underline hover:text-red-300">
               Retry
             </button>
           </div>
@@ -306,22 +282,19 @@ export default function NotionStatusPage() {
           <>
             {/* Auth status */}
             <div className="mb-6 rounded-lg border border-slate-700/50 bg-slate-800/40 px-5 py-4">
-              <div className="flex items-center justify-between flex-wrap gap-3">
+              <div className="flex flex-wrap items-center justify-between gap-3">
                 <div className="flex items-center gap-3">
                   <span className="text-xl">{"\u{1F512}"}</span>
                   <span className="font-medium text-white">Authentication</span>
                   {data.authenticated ? (
-                    <StatusBadge
-                      ok={true}
-                      label={`Connected as ${data.botName}`}
-                    />
+                    <StatusBadge ok={true} label={`Connected as ${data.botName}`} />
                   ) : (
                     <StatusBadge ok={false} label="Not Authenticated" />
                   )}
                 </div>
                 <button
                   onClick={load}
-                  className="rounded-md border border-slate-600 px-3 py-1.5 text-sm text-slate-300 hover:bg-slate-700/50 transition-colors"
+                  className="rounded-md border border-slate-600 px-3 py-1.5 text-sm text-slate-300 transition-colors hover:bg-slate-700/50"
                 >
                   {"\u21BB"} Refresh
                 </button>
@@ -335,20 +308,12 @@ export default function NotionStatusPage() {
             {data.authenticated && (
               <div className="mb-6 grid grid-cols-3 gap-4">
                 <div className="rounded-lg border border-slate-700/50 bg-slate-800/40 px-4 py-3 text-center">
-                  <div className="text-2xl font-bold text-neon-cyan">
-                    {totalDbs}
-                  </div>
-                  <div className="text-xs text-slate-400 uppercase tracking-wider">
-                    Databases
-                  </div>
+                  <div className="text-neon-cyan text-2xl font-bold">{totalDbs}</div>
+                  <div className="text-xs tracking-wider text-slate-400 uppercase">Databases</div>
                 </div>
                 <div className="rounded-lg border border-slate-700/50 bg-slate-800/40 px-4 py-3 text-center">
-                  <div className="text-2xl font-bold text-neon-green">
-                    {configuredCount}
-                  </div>
-                  <div className="text-xs text-slate-400 uppercase tracking-wider">
-                    Configured
-                  </div>
+                  <div className="text-neon-green text-2xl font-bold">{configuredCount}</div>
+                  <div className="text-xs tracking-wider text-slate-400 uppercase">Configured</div>
                 </div>
                 <div className="rounded-lg border border-slate-700/50 bg-slate-800/40 px-4 py-3 text-center">
                   <div
@@ -356,9 +321,7 @@ export default function NotionStatusPage() {
                   >
                     {connectedCount}
                   </div>
-                  <div className="text-xs text-slate-400 uppercase tracking-wider">
-                    Connected
-                  </div>
+                  <div className="text-xs tracking-wider text-slate-400 uppercase">Connected</div>
                 </div>
               </div>
             )}
@@ -380,12 +343,10 @@ export default function NotionStatusPage() {
             {/* Setup instructions when not authenticated */}
             {!data.authenticated && (
               <div className="rounded-lg border border-yellow-500/30 bg-yellow-500/5 px-5 py-4">
-                <h2 className="text-lg font-semibold text-yellow-400 mb-3">
-                  Setup Instructions
-                </h2>
+                <h2 className="mb-3 text-lg font-semibold text-yellow-400">Setup Instructions</h2>
                 <ol className="space-y-2 text-sm text-slate-300">
                   <li>
-                    <span className="text-neon-cyan font-mono mr-2">1.</span>
+                    <span className="text-neon-cyan mr-2 font-mono">1.</span>
                     Go to{" "}
                     <a
                       href="https://www.notion.so/my-integrations"
@@ -398,28 +359,27 @@ export default function NotionStatusPage() {
                     and create an Internal Integration
                   </li>
                   <li>
-                    <span className="text-neon-cyan font-mono mr-2">2.</span>
+                    <span className="text-neon-cyan mr-2 font-mono">2.</span>
                     Copy the secret token
                   </li>
                   <li>
-                    <span className="text-neon-cyan font-mono mr-2">3.</span>
+                    <span className="text-neon-cyan mr-2 font-mono">3.</span>
                     Open{" "}
-                    <code className="bg-slate-700 px-1.5 py-0.5 rounded text-xs">
+                    <code className="rounded bg-slate-700 px-1.5 py-0.5 text-xs">
                       .env.local
                     </code>{" "}
                     and set{" "}
-                    <code className="bg-slate-700 px-1.5 py-0.5 rounded text-xs">
+                    <code className="rounded bg-slate-700 px-1.5 py-0.5 text-xs">
                       NOTION_API_KEY=your_secret_here
                     </code>
                   </li>
                   <li>
-                    <span className="text-neon-cyan font-mono mr-2">4.</span>
-                    In Notion, open each database {"\u2192"}{" "}
-                    <strong>...</strong> {"\u2192"} <strong>Connections</strong>{" "}
-                    {"\u2192"} add your integration
+                    <span className="text-neon-cyan mr-2 font-mono">4.</span>
+                    In Notion, open each database {"\u2192"} <strong>...</strong> {"\u2192"}{" "}
+                    <strong>Connections</strong> {"\u2192"} add your integration
                   </li>
                   <li>
-                    <span className="text-neon-cyan font-mono mr-2">5.</span>
+                    <span className="text-neon-cyan mr-2 font-mono">5.</span>
                     Restart the dev server and refresh this page
                   </li>
                 </ol>

--- a/src/app/[locale]/admin/notion/submissions/page.tsx
+++ b/src/app/[locale]/admin/notion/submissions/page.tsx
@@ -41,30 +41,22 @@ export default function SubmissionsPage() {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [updating, setUpdating] = useState<string | null>(null);
-  const [filter, setFilter] = useState<"all" | "New" | "In Review" | "Done">(
-    "all",
-  );
+  const [filter, setFilter] = useState<"all" | "New" | "In Review" | "Done">("all");
   const [expanded, setExpanded] = useState<string | null>(null);
 
   const load = useCallback(async () => {
     setLoading(true);
     setError(null);
     try {
-      const res = await fetchWithAuth(
-        "/api/admin/notion/submissions?limit=100",
-      );
+      const res = await fetchWithAuth("/api/admin/notion/submissions?limit=100");
       if (!res.ok) {
         const data = await res.json().catch(() => ({}));
-        throw new Error(
-          (data as { error?: string }).error ?? `HTTP ${res.status}`,
-        );
+        throw new Error((data as { error?: string }).error ?? `HTTP ${res.status}`);
       }
       const data = (await res.json()) as { submissions: Submission[] };
       setSubmissions(data.submissions ?? []);
     } catch (err) {
-      setError(
-        err instanceof Error ? err.message : "Failed to load submissions",
-      );
+      setError(err instanceof Error ? err.message : "Failed to load submissions");
     } finally {
       setLoading(false);
     }
@@ -75,10 +67,7 @@ export default function SubmissionsPage() {
     load();
   }, [load]);
 
-  const updateStatus = async (
-    pageId: string,
-    status: "New" | "In Review" | "Done",
-  ) => {
+  const updateStatus = async (pageId: string, status: "New" | "In Review" | "Done") => {
     setUpdating(pageId);
     try {
       const res = await fetchWithAuth("/api/admin/notion/submissions", {
@@ -87,9 +76,7 @@ export default function SubmissionsPage() {
         body: JSON.stringify({ pageId, status }),
       });
       if (!res.ok) throw new Error(`HTTP ${res.status}`);
-      setSubmissions((prev) =>
-        prev.map((s) => (s.id === pageId ? { ...s, status } : s)),
-      );
+      setSubmissions((prev) => prev.map((s) => (s.id === pageId ? { ...s, status } : s)));
     } catch (err) {
       console.error("Failed to update submission:", err);
     } finally {
@@ -97,10 +84,7 @@ export default function SubmissionsPage() {
     }
   };
 
-  const filtered =
-    filter === "all"
-      ? submissions
-      : submissions.filter((s) => s.status === filter);
+  const filtered = filter === "all" ? submissions : submissions.filter((s) => s.status === filter);
 
   const counts = {
     New: submissions.filter((s) => s.status === "New").length,
@@ -115,13 +99,9 @@ export default function SubmissionsPage() {
         <div>
           <div className="bg-neon-cyan/10 border-neon-cyan/20 mb-4 inline-flex items-center gap-2 rounded-full border px-3 py-1.5">
             <span className="bg-neon-cyan h-2 w-2 animate-pulse rounded-full" />
-            <span className="text-neon-cyan font-mono text-xs">
-              NOTION_SUBMISSIONS
-            </span>
+            <span className="text-neon-cyan font-mono text-xs">NOTION_SUBMISSIONS</span>
           </div>
-          <h1 className="font-heading text-2xl font-bold text-white">
-            Contact Submissions
-          </h1>
+          <h1 className="font-heading text-2xl font-bold text-white">Contact Submissions</h1>
           <p className="font-body mt-1 text-slate-400">
             Incoming leads and contact form entries from cloudless.gr.
           </p>
@@ -144,7 +124,7 @@ export default function SubmissionsPage() {
             className={`rounded-xl border p-4 text-left transition-all ${
               filter === s
                 ? STATUS_STYLES[s]
-                : "border-slate-800 bg-void-light/30 text-slate-400 hover:border-slate-700"
+                : "bg-void-light/30 border-slate-800 text-slate-400 hover:border-slate-700"
             }`}
           >
             <div className="font-mono text-2xl font-bold">{counts[s]}</div>
@@ -186,7 +166,7 @@ export default function SubmissionsPage() {
           {[...Array(5)].map((_, i) => (
             <div
               key={i}
-              className="animate-pulse rounded-xl border border-slate-800 bg-void-light/30 p-4"
+              className="bg-void-light/30 animate-pulse rounded-xl border border-slate-800 p-4"
             >
               <div className="flex items-center gap-4">
                 <div className="h-4 w-32 rounded bg-slate-700/60" />
@@ -200,11 +180,9 @@ export default function SubmissionsPage() {
 
       {/* Empty state */}
       {!loading && filtered.length === 0 && !error && (
-        <div className="rounded-xl border border-slate-800 bg-void-light/30 p-12 text-center">
+        <div className="bg-void-light/30 rounded-xl border border-slate-800 p-12 text-center">
           <p className="font-mono text-slate-500">
-            {filter === "all"
-              ? "No submissions yet."
-              : `No submissions with status "${filter}".`}
+            {filter === "all" ? "No submissions yet." : `No submissions with status "${filter}".`}
           </p>
         </div>
       )}
@@ -215,30 +193,26 @@ export default function SubmissionsPage() {
           {filtered.map((sub) => (
             <div
               key={sub.id}
-              className="rounded-xl border border-slate-800 bg-void-light/30 overflow-hidden"
+              className="bg-void-light/30 overflow-hidden rounded-xl border border-slate-800"
             >
               {/* Row */}
               <button
                 onClick={() => setExpanded(expanded === sub.id ? null : sub.id)}
-                className="flex w-full items-center gap-4 px-5 py-4 text-left hover:bg-white/[0.02] transition-colors"
+                className="flex w-full items-center gap-4 px-5 py-4 text-left transition-colors hover:bg-white/[0.02]"
               >
                 <div className="min-w-0 flex-1">
                   <div className="flex items-center gap-3">
-                    <span className="font-medium text-white truncate">
-                      {sub.name}
-                    </span>
+                    <span className="truncate font-medium text-white">{sub.name}</span>
                     {sub.company && (
-                      <span className="font-mono text-xs text-slate-500 truncate">
+                      <span className="truncate font-mono text-xs text-slate-500">
                         {sub.company}
                       </span>
                     )}
                   </div>
                   <div className="mt-0.5 flex items-center gap-3">
-                    <span className="font-mono text-xs text-slate-500">
-                      {sub.email}
-                    </span>
+                    <span className="font-mono text-xs text-slate-500">{sub.email}</span>
                     {sub.service && (
-                      <span className="rounded bg-neon-cyan/5 px-1.5 py-0.5 font-mono text-[10px] text-neon-cyan/60">
+                      <span className="bg-neon-cyan/5 text-neon-cyan/60 rounded px-1.5 py-0.5 font-mono text-[10px]">
                         {sub.service}
                       </span>
                     )}
@@ -250,13 +224,13 @@ export default function SubmissionsPage() {
                   </div>
                 </div>
 
-                <div className="flex items-center gap-3 shrink-0">
+                <div className="flex shrink-0 items-center gap-3">
                   <span
                     className={`rounded-full border px-2.5 py-1 font-mono text-[10px] ${STATUS_STYLES[sub.status] ?? ""}`}
                   >
                     {sub.status}
                   </span>
-                  <span className="text-slate-600 font-mono text-xs">
+                  <span className="font-mono text-xs text-slate-600">
                     {expanded === sub.id ? "▲" : "▼"}
                   </span>
                 </div>
@@ -267,18 +241,14 @@ export default function SubmissionsPage() {
                 <div className="border-t border-slate-800 px-5 py-4">
                   {sub.message && (
                     <div className="mb-4">
-                      <p className="font-mono text-xs text-slate-500 mb-1">
-                        Message
-                      </p>
-                      <p className="font-body text-sm text-slate-300 whitespace-pre-wrap">
+                      <p className="mb-1 font-mono text-xs text-slate-500">Message</p>
+                      <p className="font-body text-sm whitespace-pre-wrap text-slate-300">
                         {sub.message}
                       </p>
                     </div>
                   )}
                   <div className="flex items-center gap-3">
-                    <span className="font-mono text-xs text-slate-500">
-                      Update status:
-                    </span>
+                    <span className="font-mono text-xs text-slate-500">Update status:</span>
                     {VALID_STATUSES.map((s) => (
                       <button
                         key={s}
@@ -295,7 +265,7 @@ export default function SubmissionsPage() {
                     ))}
                     <a
                       href={`mailto:${sub.email}`}
-                      className="ml-auto text-neon-cyan/70 hover:text-neon-cyan font-mono text-xs transition-colors"
+                      className="text-neon-cyan/70 hover:text-neon-cyan ml-auto font-mono text-xs transition-colors"
                     >
                       Reply →
                     </a>

--- a/src/app/[locale]/admin/notion/tasks/page.tsx
+++ b/src/app/[locale]/admin/notion/tasks/page.tsx
@@ -19,28 +19,12 @@ interface Task {
   url: string;
 }
 
-type TaskStatus =
-  | "Backlog"
-  | "To Do"
-  | "In Progress"
-  | "In Review"
-  | "Done"
-  | "Blocked";
+type TaskStatus = "Backlog" | "To Do" | "In Progress" | "In Review" | "Done" | "Blocked";
 type TaskPriority = "Urgent" | "High" | "Medium" | "Low";
 
-const COLUMNS: TaskStatus[] = [
-  "Backlog",
-  "To Do",
-  "In Progress",
-  "In Review",
-  "Done",
-  "Blocked",
-];
+const COLUMNS: TaskStatus[] = ["Backlog", "To Do", "In Progress", "In Review", "Done", "Blocked"];
 
-const COLUMN_STYLES: Record<
-  string,
-  { border: string; header: string; dot: string }
-> = {
+const COLUMN_STYLES: Record<string, { border: string; header: string; dot: string }> = {
   Backlog: {
     border: "border-slate-700",
     header: "text-slate-400",
@@ -111,9 +95,7 @@ export default function TasksKanbanPage() {
   const [error, setError] = useState<string | null>(null);
   const [updating, setUpdating] = useState<string | null>(null);
   const [showCreate, setShowCreate] = useState(false);
-  const [viewMode, setViewMode] = useState<"kanban" | "list" | "sprint">(
-    "kanban",
-  );
+  const [viewMode, setViewMode] = useState<"kanban" | "list" | "sprint">("kanban");
   const [selectedSprint, setSelectedSprint] = useState<string>("all");
   const [bulkSelected, setBulkSelected] = useState<Set<string>>(new Set());
   const [bulkStatus, setBulkStatus] = useState<TaskStatus>("To Do");
@@ -156,9 +138,7 @@ export default function TasksKanbanPage() {
         body: JSON.stringify({ pageId, status }),
       });
       if (!res.ok) throw new Error(`HTTP ${res.status}`);
-      setTasks((prev) =>
-        prev.map((t) => (t.id === pageId ? { ...t, status } : t)),
-      );
+      setTasks((prev) => prev.map((t) => (t.id === pageId ? { ...t, status } : t)));
     } catch (err) {
       console.error("Failed to update task:", err);
     } finally {
@@ -175,13 +155,11 @@ export default function TasksKanbanPage() {
           method: "PATCH",
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify({ pageId: id, status: bulkStatus }),
-        }),
+        })
       );
       await Promise.all(promises);
       setTasks((prev) =>
-        prev.map((t) =>
-          bulkSelected.has(t.id) ? { ...t, status: bulkStatus } : t,
-        ),
+        prev.map((t) => (bulkSelected.has(t.id) ? { ...t, status: bulkStatus } : t))
       );
       setBulkSelected(new Set());
     } catch (err) {
@@ -222,9 +200,7 @@ export default function TasksKanbanPage() {
   };
 
   // Get unique sprints
-  const sprints = [
-    ...new Set(tasks.map((t) => t.sprint).filter(Boolean)),
-  ] as string[];
+  const sprints = [...new Set(tasks.map((t) => t.sprint).filter(Boolean))] as string[];
 
   // Filter tasks
   const filteredTasks =
@@ -234,17 +210,13 @@ export default function TasksKanbanPage() {
         ? tasks.filter((t) => isOverdue(t.dueDate, t.status))
         : tasks.filter((t) => t.sprint === selectedSprint);
 
-  const tasksByStatus = (status: string) =>
-    filteredTasks.filter((t) => t.status === status);
-  const overdueCount = tasks.filter((t) =>
-    isOverdue(t.dueDate, t.status),
-  ).length;
+  const tasksByStatus = (status: string) => filteredTasks.filter((t) => t.status === status);
+  const overdueCount = tasks.filter((t) => isOverdue(t.dueDate, t.status)).length;
 
   // Sprint progress
   const sprintTotal = filteredTasks.length;
   const sprintDone = filteredTasks.filter((t) => t.status === "Done").length;
-  const sprintPercent =
-    sprintTotal > 0 ? Math.round((sprintDone / sprintTotal) * 100) : 0;
+  const sprintPercent = sprintTotal > 0 ? Math.round((sprintDone / sprintTotal) * 100) : 0;
 
   const toggleBulk = (id: string) => {
     setBulkSelected((prev) => {
@@ -261,9 +233,7 @@ export default function TasksKanbanPage() {
     return (
       <div
         className={`group rounded-lg border p-3 transition-all hover:border-slate-600 ${
-          overdue
-            ? "border-red-500/30 bg-red-500/5"
-            : "border-slate-700/50 bg-void/60"
+          overdue ? "border-red-500/30 bg-red-500/5" : "bg-void/60 border-slate-700/50"
         }`}
       >
         <div className="flex items-start justify-between gap-2">
@@ -274,7 +244,7 @@ export default function TasksKanbanPage() {
                   type="checkbox"
                   checked={bulkSelected.has(task.id)}
                   onChange={() => toggleBulk(task.id)}
-                  className="mr-1 accent-neon-cyan"
+                  className="accent-neon-cyan mr-1"
                 />
               )}
               {task.type && (
@@ -282,9 +252,7 @@ export default function TasksKanbanPage() {
                   {TYPE_ICONS[task.type] ?? "•"}
                 </span>
               )}
-              <h4 className="truncate text-sm font-medium text-white">
-                {task.task}
-              </h4>
+              <h4 className="truncate text-sm font-medium text-white">{task.task}</h4>
               {overdue && (
                 <span className="ml-1 rounded bg-red-500/20 px-1 py-0.5 font-mono text-[8px] text-red-400">
                   OVERDUE
@@ -292,7 +260,7 @@ export default function TasksKanbanPage() {
               )}
             </div>
             {task.description && (
-              <p className="font-body mt-1 text-xs text-slate-500 line-clamp-2">
+              <p className="font-body mt-1 line-clamp-2 text-xs text-slate-500">
                 {task.description}
               </p>
             )}
@@ -302,7 +270,7 @@ export default function TasksKanbanPage() {
               href={task.url}
               target="_blank"
               rel="noopener noreferrer"
-              className="shrink-0 text-slate-600 opacity-0 transition-all hover:text-slate-400 group-hover:opacity-100"
+              className="shrink-0 text-slate-600 opacity-0 transition-all group-hover:opacity-100 hover:text-slate-400"
             >
               <svg
                 width="12"
@@ -330,14 +298,12 @@ export default function TasksKanbanPage() {
             </span>
           )}
           {task.sprint && (
-            <span className="rounded bg-neon-blue/5 px-1.5 py-0.5 font-mono text-[9px] text-neon-blue/60">
+            <span className="bg-neon-blue/5 text-neon-blue/60 rounded px-1.5 py-0.5 font-mono text-[9px]">
               {task.sprint}
             </span>
           )}
           {task.dueDate && (
-            <span
-              className={`font-mono text-[9px] ${overdue ? "text-red-400" : "text-slate-600"}`}
-            >
+            <span className={`font-mono text-[9px] ${overdue ? "text-red-400" : "text-slate-600"}`}>
               {formatDate(task.dueDate)}
             </span>
           )}
@@ -346,12 +312,12 @@ export default function TasksKanbanPage() {
         <div className="mt-2 flex items-center justify-between">
           <div className="flex flex-wrap gap-1">
             {task.project && (
-              <span className="rounded bg-neon-cyan/5 px-1.5 py-0.5 font-mono text-[9px] text-neon-cyan/60">
+              <span className="bg-neon-cyan/5 text-neon-cyan/60 rounded px-1.5 py-0.5 font-mono text-[9px]">
                 {task.project}
               </span>
             )}
             {task.assignee && (
-              <span className="rounded bg-neon-magenta/5 px-1.5 py-0.5 font-mono text-[9px] text-neon-magenta/60">
+              <span className="bg-neon-magenta/5 text-neon-magenta/60 rounded px-1.5 py-0.5 font-mono text-[9px]">
                 {task.assignee}
               </span>
             )}
@@ -359,10 +325,8 @@ export default function TasksKanbanPage() {
           <select
             value={task.status}
             disabled={updating === task.id || updating === "bulk"}
-            onChange={(e) =>
-              updateStatus(task.id, e.target.value as TaskStatus)
-            }
-            className="rounded border border-slate-700 bg-void px-1 py-0.5 font-mono text-[9px] text-slate-400 focus:border-neon-cyan/50 focus:outline-none disabled:opacity-50"
+            onChange={(e) => updateStatus(task.id, e.target.value as TaskStatus)}
+            className="bg-void focus:border-neon-cyan/50 rounded border border-slate-700 px-1 py-0.5 font-mono text-[9px] text-slate-400 focus:outline-none disabled:opacity-50"
           >
             {COLUMNS.map((s) => (
               <option key={s} value={s}>
@@ -395,13 +359,9 @@ export default function TasksKanbanPage() {
         <div>
           <div className="bg-neon-magenta/10 border-neon-magenta/20 mb-4 inline-flex items-center gap-2 rounded-full border px-3 py-1.5">
             <span className="bg-neon-magenta h-2 w-2 animate-pulse rounded-full" />
-            <span className="text-neon-magenta font-mono text-xs">
-              NOTION_TASKS
-            </span>
+            <span className="text-neon-magenta font-mono text-xs">NOTION_TASKS</span>
           </div>
-          <h1 className="font-heading text-2xl font-bold text-white">
-            Task Board
-          </h1>
+          <h1 className="font-heading text-2xl font-bold text-white">Task Board</h1>
           <p className="font-body mt-1 text-slate-400">
             Kanban view of your Notion tasks database.
           </p>
@@ -501,7 +461,7 @@ export default function TasksKanbanPage() {
             <div className="ml-auto flex items-center gap-2">
               <div className="h-1.5 w-32 overflow-hidden rounded-full bg-slate-800">
                 <div
-                  className="h-full rounded-full bg-neon-green transition-all"
+                  className="bg-neon-green h-full rounded-full transition-all"
                   style={{ width: `${sprintPercent}%` }}
                 />
               </div>
@@ -515,14 +475,12 @@ export default function TasksKanbanPage() {
 
       {/* Bulk actions */}
       {viewMode === "list" && bulkSelected.size > 0 && (
-        <div className="mb-4 flex items-center gap-3 rounded-lg border border-neon-cyan/20 bg-neon-cyan/5 p-3">
-          <span className="font-mono text-xs text-neon-cyan">
-            {bulkSelected.size} selected
-          </span>
+        <div className="border-neon-cyan/20 bg-neon-cyan/5 mb-4 flex items-center gap-3 rounded-lg border p-3">
+          <span className="text-neon-cyan font-mono text-xs">{bulkSelected.size} selected</span>
           <select
             value={bulkStatus}
             onChange={(e) => setBulkStatus(e.target.value as TaskStatus)}
-            className="rounded border border-slate-700 bg-void px-2 py-1 font-mono text-xs text-slate-300 focus:outline-none"
+            className="bg-void rounded border border-slate-700 px-2 py-1 font-mono text-xs text-slate-300 focus:outline-none"
           >
             {COLUMNS.map((s) => (
               <option key={s} value={s}>
@@ -533,7 +491,7 @@ export default function TasksKanbanPage() {
           <button
             onClick={bulkUpdateStatus}
             disabled={updating === "bulk"}
-            className="rounded border border-neon-cyan/30 bg-neon-cyan/10 px-3 py-1 font-mono text-xs text-neon-cyan transition-colors hover:bg-neon-cyan/20 disabled:opacity-50"
+            className="border-neon-cyan/30 bg-neon-cyan/10 text-neon-cyan hover:bg-neon-cyan/20 rounded border px-3 py-1 font-mono text-xs transition-colors disabled:opacity-50"
           >
             {updating === "bulk" ? "Updating…" : "Update All"}
           </button>
@@ -549,21 +507,19 @@ export default function TasksKanbanPage() {
       {/* Create form */}
       {showCreate && (
         <div className="bg-void-light/50 mb-6 rounded-xl border border-slate-800 p-6">
-          <h3 className="font-heading mb-4 font-semibold text-white">
-            Create Task
-          </h3>
+          <h3 className="font-heading mb-4 font-semibold text-white">Create Task</h3>
           <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
             <input
               type="text"
               placeholder="Task title *"
               value={newTask}
               onChange={(e) => setNewTask(e.target.value)}
-              className="bg-void sm:col-span-2 lg:col-span-3 rounded-lg border border-slate-700 px-3 py-2 font-mono text-sm text-white placeholder-slate-600 focus:border-neon-magenta/50 focus:outline-none"
+              className="bg-void focus:border-neon-magenta/50 rounded-lg border border-slate-700 px-3 py-2 font-mono text-sm text-white placeholder-slate-600 focus:outline-none sm:col-span-2 lg:col-span-3"
             />
             <select
               value={newPriority}
               onChange={(e) => setNewPriority(e.target.value as TaskPriority)}
-              className="bg-void rounded-lg border border-slate-700 px-3 py-2 font-mono text-sm text-white focus:border-neon-magenta/50 focus:outline-none"
+              className="bg-void focus:border-neon-magenta/50 rounded-lg border border-slate-700 px-3 py-2 font-mono text-sm text-white focus:outline-none"
             >
               <option value="Urgent">Urgent</option>
               <option value="High">High</option>
@@ -573,7 +529,7 @@ export default function TasksKanbanPage() {
             <select
               value={newType}
               onChange={(e) => setNewType(e.target.value)}
-              className="bg-void rounded-lg border border-slate-700 px-3 py-2 font-mono text-sm text-white focus:border-neon-magenta/50 focus:outline-none"
+              className="bg-void focus:border-neon-magenta/50 rounded-lg border border-slate-700 px-3 py-2 font-mono text-sm text-white focus:outline-none"
             >
               <option value="">Type (optional)</option>
               <option value="Feature">Feature</option>
@@ -587,20 +543,20 @@ export default function TasksKanbanPage() {
               placeholder="Project"
               value={newProject}
               onChange={(e) => setNewProject(e.target.value)}
-              className="bg-void rounded-lg border border-slate-700 px-3 py-2 font-mono text-sm text-white placeholder-slate-600 focus:border-neon-magenta/50 focus:outline-none"
+              className="bg-void focus:border-neon-magenta/50 rounded-lg border border-slate-700 px-3 py-2 font-mono text-sm text-white placeholder-slate-600 focus:outline-none"
             />
             <input
               type="text"
               placeholder="Assignee"
               value={newAssignee}
               onChange={(e) => setNewAssignee(e.target.value)}
-              className="bg-void rounded-lg border border-slate-700 px-3 py-2 font-mono text-sm text-white placeholder-slate-600 focus:border-neon-magenta/50 focus:outline-none"
+              className="bg-void focus:border-neon-magenta/50 rounded-lg border border-slate-700 px-3 py-2 font-mono text-sm text-white placeholder-slate-600 focus:outline-none"
             />
             <input
               type="date"
               value={newDueDate}
               onChange={(e) => setNewDueDate(e.target.value)}
-              className="bg-void rounded-lg border border-slate-700 px-3 py-2 font-mono text-sm text-white focus:border-neon-magenta/50 focus:outline-none"
+              className="bg-void focus:border-neon-magenta/50 rounded-lg border border-slate-700 px-3 py-2 font-mono text-sm text-white focus:outline-none"
             />
           </div>
           <div className="mt-4 flex gap-2">
@@ -634,7 +590,7 @@ export default function TasksKanbanPage() {
           {COLUMNS.map((col) => (
             <div
               key={col}
-              className="animate-pulse rounded-xl border border-slate-800 bg-void-light/30 p-4"
+              className="bg-void-light/30 animate-pulse rounded-xl border border-slate-800 p-4"
             >
               <div className="mb-3 h-4 w-20 rounded bg-slate-700/60" />
               <div className="space-y-2">
@@ -658,17 +614,10 @@ export default function TasksKanbanPage() {
             const style = COLUMN_STYLES[col];
             const colTasks = tasksByStatus(col);
             return (
-              <div
-                key={col}
-                className={`rounded-xl border bg-void-light/20 p-3 ${style.border}`}
-              >
+              <div key={col} className={`bg-void-light/20 rounded-xl border p-3 ${style.border}`}>
                 <div className="mb-3 flex items-center gap-2">
                   <span className={`h-2 w-2 rounded-full ${style.dot}`} />
-                  <span
-                    className={`font-mono text-xs font-semibold ${style.header}`}
-                  >
-                    {col}
-                  </span>
+                  <span className={`font-mono text-xs font-semibold ${style.header}`}>{col}</span>
                   <span className="ml-auto rounded-full bg-slate-800 px-1.5 py-0.5 font-mono text-[10px] text-slate-500">
                     {colTasks.length}
                   </span>
@@ -678,9 +627,7 @@ export default function TasksKanbanPage() {
                     <TaskCard key={task.id} task={task} />
                   ))}
                   {colTasks.length === 0 && (
-                    <p className="py-4 text-center font-mono text-[10px] text-slate-700">
-                      Empty
-                    </p>
+                    <p className="py-4 text-center font-mono text-[10px] text-slate-700">Empty</p>
                   )}
                 </div>
               </div>
@@ -693,10 +640,8 @@ export default function TasksKanbanPage() {
       {!loading && viewMode === "sprint" && (
         <div className="space-y-6">
           {sprints.length === 0 ? (
-            <div className="rounded-xl border border-slate-800 bg-void-light/30 p-12 text-center">
-              <p className="font-mono text-slate-500">
-                No sprints assigned to tasks yet.
-              </p>
+            <div className="bg-void-light/30 rounded-xl border border-slate-800 p-12 text-center">
+              <p className="font-mono text-slate-500">No sprints assigned to tasks yet.</p>
               <p className="font-body mt-2 text-sm text-slate-600">
                 Add a Sprint property to your tasks in Notion.
               </p>
@@ -704,23 +649,17 @@ export default function TasksKanbanPage() {
           ) : (
             sprints.map((sprint) => {
               const sprintTasks = tasks.filter((t) => t.sprint === sprint);
-              const done = sprintTasks.filter(
-                (t) => t.status === "Done",
-              ).length;
+              const done = sprintTasks.filter((t) => t.status === "Done").length;
               const pct =
-                sprintTasks.length > 0
-                  ? Math.round((done / sprintTasks.length) * 100)
-                  : 0;
+                sprintTasks.length > 0 ? Math.round((done / sprintTasks.length) * 100) : 0;
               return (
                 <div
                   key={sprint}
-                  className="rounded-xl border border-slate-800 bg-void-light/30 p-5"
+                  className="bg-void-light/30 rounded-xl border border-slate-800 p-5"
                 >
                   <div className="mb-4 flex items-center justify-between">
                     <div className="flex items-center gap-3">
-                      <h3 className="font-heading font-semibold text-white">
-                        {sprint}
-                      </h3>
+                      <h3 className="font-heading font-semibold text-white">{sprint}</h3>
                       <span className="font-mono text-xs text-slate-500">
                         {done}/{sprintTasks.length} done
                       </span>
@@ -732,9 +671,7 @@ export default function TasksKanbanPage() {
                           style={{ width: `${pct}%` }}
                         />
                       </div>
-                      <span className="font-mono text-xs text-slate-500">
-                        {pct}%
-                      </span>
+                      <span className="font-mono text-xs text-slate-500">{pct}%</span>
                     </div>
                   </div>
                   <div className="grid gap-2 sm:grid-cols-2 lg:grid-cols-3">
@@ -752,7 +689,7 @@ export default function TasksKanbanPage() {
             const unassigned = tasks.filter((t) => !t.sprint);
             if (unassigned.length === 0) return null;
             return (
-              <div className="rounded-xl border border-slate-700/50 bg-void-light/20 p-5">
+              <div className="bg-void-light/20 rounded-xl border border-slate-700/50 p-5">
                 <h3 className="font-heading mb-4 font-semibold text-slate-400">
                   No Sprint ({unassigned.length})
                 </h3>
@@ -771,7 +708,7 @@ export default function TasksKanbanPage() {
       {!loading && viewMode === "list" && (
         <div className="space-y-2">
           {filteredTasks.length === 0 && (
-            <div className="rounded-xl border border-slate-800 bg-void-light/30 p-12 text-center">
+            <div className="bg-void-light/30 rounded-xl border border-slate-800 p-12 text-center">
               <p className="font-mono text-slate-500">No tasks found.</p>
             </div>
           )}
@@ -781,7 +718,7 @@ export default function TasksKanbanPage() {
               className={`flex flex-wrap items-center gap-3 rounded-lg border px-4 py-3 ${
                 isOverdue(task.dueDate, task.status)
                   ? "border-red-500/20 bg-red-500/5"
-                  : "border-slate-800 bg-void-light/50"
+                  : "bg-void-light/50 border-slate-800"
               }`}
             >
               <input
@@ -791,9 +728,7 @@ export default function TasksKanbanPage() {
                 className="accent-neon-cyan"
               />
               <span className="text-xs">{TYPE_ICONS[task.type] ?? "•"}</span>
-              <span className="min-w-0 flex-1 text-sm font-medium text-white">
-                {task.task}
-              </span>
+              <span className="min-w-0 flex-1 text-sm font-medium text-white">{task.task}</span>
               {isOverdue(task.dueDate, task.status) && (
                 <span className="rounded bg-red-500/20 px-1.5 py-0.5 font-mono text-[9px] text-red-400">
                   OVERDUE
@@ -805,27 +740,19 @@ export default function TasksKanbanPage() {
                 {task.priority}
               </span>
               {task.sprint && (
-                <span className="font-mono text-[10px] text-neon-blue/60">
-                  {task.sprint}
-                </span>
+                <span className="text-neon-blue/60 font-mono text-[10px]">{task.sprint}</span>
               )}
               {task.project && (
-                <span className="font-mono text-[10px] text-slate-500">
-                  {task.project}
-                </span>
+                <span className="font-mono text-[10px] text-slate-500">{task.project}</span>
               )}
               {task.assignee && (
-                <span className="font-mono text-[10px] text-neon-magenta/60">
-                  {task.assignee}
-                </span>
+                <span className="text-neon-magenta/60 font-mono text-[10px]">{task.assignee}</span>
               )}
               <select
                 value={task.status}
                 disabled={updating === task.id || updating === "bulk"}
-                onChange={(e) =>
-                  updateStatus(task.id, e.target.value as TaskStatus)
-                }
-                className="rounded border border-slate-700 bg-void px-2 py-1 font-mono text-[10px] text-slate-300 focus:border-neon-magenta/50 focus:outline-none disabled:opacity-50"
+                onChange={(e) => updateStatus(task.id, e.target.value as TaskStatus)}
+                className="bg-void focus:border-neon-magenta/50 rounded border border-slate-700 px-2 py-1 font-mono text-[10px] text-slate-300 focus:outline-none disabled:opacity-50"
               >
                 {COLUMNS.map((s) => (
                   <option key={s} value={s}>

--- a/src/app/[locale]/admin/orders/page.tsx
+++ b/src/app/[locale]/admin/orders/page.tsx
@@ -70,9 +70,7 @@ export default function AdminOrdersPage() {
           <span className="bg-neon-magenta h-2 w-2 animate-pulse rounded-full" />
           <span className="text-neon-magenta font-mono text-xs">ORDERS</span>
         </div>
-        <h1 className="font-heading text-2xl font-bold text-white">
-          Order Management
-        </h1>
+        <h1 className="font-heading text-2xl font-bold text-white">Order Management</h1>
         <p className="font-body mt-1 text-slate-400">
           Live data from Stripe — checkout sessions and subscriptions.
         </p>
@@ -93,13 +91,9 @@ export default function AdminOrdersPage() {
           </p>
         </div>
         <div className="bg-void-light/50 rounded-xl border border-slate-800 p-4">
-          <p className="font-mono text-xs text-slate-500">
-            Active Subscriptions
-          </p>
+          <p className="font-mono text-xs text-slate-500">Active Subscriptions</p>
           <p className="font-heading text-neon-cyan mt-1 text-2xl font-bold">
-            {loading
-              ? "…"
-              : subscriptions.filter((s) => s.status === "active").length}
+            {loading ? "…" : subscriptions.filter((s) => s.status === "active").length}
           </p>
         </div>
       </div>
@@ -168,9 +162,7 @@ export default function AdminOrdersPage() {
                     <td className="text-neon-cyan px-6 py-4 font-mono text-xs">
                       {order.id.slice(0, 20)}…
                     </td>
-                    <td className="px-6 py-4 font-mono text-white">
-                      {order.email}
-                    </td>
+                    <td className="px-6 py-4 font-mono text-white">{order.email}</td>
                     <td className="max-w-[200px] truncate px-6 py-4 text-slate-300">
                       {order.items.map((i) => i.description).join(", ") || "—"}
                     </td>
@@ -179,7 +171,7 @@ export default function AdminOrdersPage() {
                     </td>
                     <td className="px-6 py-4">
                       <span
-                        className={`rounded-full px-2 py-0.5 font-mono text-[10px] ${statusClasses[order.status] ?? "text-slate-400 bg-slate-800/50"}`}
+                        className={`rounded-full px-2 py-0.5 font-mono text-[10px] ${statusClasses[order.status] ?? "bg-slate-800/50 text-slate-400"}`}
                       >
                         {order.status}
                       </span>
@@ -191,10 +183,7 @@ export default function AdminOrdersPage() {
                 ))}
                 {orders.length === 0 && (
                   <tr>
-                    <td
-                      colSpan={6}
-                      className="px-6 py-12 text-center font-mono text-slate-600"
-                    >
+                    <td colSpan={6} className="px-6 py-12 text-center font-mono text-slate-600">
                       No orders yet
                     </td>
                   </tr>
@@ -241,25 +230,20 @@ export default function AdminOrdersPage() {
                     </td>
                     <td className="px-6 py-4">
                       <span
-                        className={`rounded-full px-2 py-0.5 font-mono text-[10px] ${statusClasses[sub.status] ?? "text-slate-400 bg-slate-800/50"}`}
+                        className={`rounded-full px-2 py-0.5 font-mono text-[10px] ${statusClasses[sub.status] ?? "bg-slate-800/50 text-slate-400"}`}
                       >
                         {sub.status}
                         {sub.cancelAtPeriodEnd ? " (canceling)" : ""}
                       </span>
                     </td>
                     <td className="px-6 py-4 font-mono text-slate-500">
-                      {new Date(sub.currentPeriodEnd).toLocaleDateString(
-                        "en-IE",
-                      )}
+                      {new Date(sub.currentPeriodEnd).toLocaleDateString("en-IE")}
                     </td>
                   </tr>
                 ))}
                 {subscriptions.length === 0 && (
                   <tr>
-                    <td
-                      colSpan={5}
-                      className="px-6 py-12 text-center font-mono text-slate-600"
-                    >
+                    <td colSpan={5} className="px-6 py-12 text-center font-mono text-slate-600">
                       No subscriptions yet
                     </td>
                   </tr>

--- a/src/app/[locale]/admin/page.tsx
+++ b/src/app/[locale]/admin/page.tsx
@@ -19,9 +19,7 @@ const adminCards = [
     href: "/admin/orders",
     statKey: "orders" as const,
     render: (s: DashStats) =>
-      s.orders
-        ? `${s.orders.total} orders · €${s.orders.revenue.toFixed(0)}`
-        : "View →",
+      s.orders ? `${s.orders.total} orders · €${s.orders.revenue.toFixed(0)}` : "View →",
   },
   {
     title: "CRM Contacts",
@@ -30,9 +28,7 @@ const adminCards = [
     href: "/admin/crm",
     statKey: "contacts" as const,
     render: (s: DashStats) =>
-      s.contacts
-        ? `${s.contacts.total} contact${s.contacts.total === 1 ? "" : "s"}`
-        : "View →",
+      s.contacts ? `${s.contacts.total} contact${s.contacts.total === 1 ? "" : "s"}` : "View →",
   },
   {
     title: "SEO & Analytics",
@@ -48,8 +44,7 @@ const adminCards = [
     icon: "⚠",
     href: "/admin/errors",
     statKey: "errors" as const,
-    render: (s: DashStats) =>
-      s.errors ? `${s.errors.total} unresolved` : "View →",
+    render: (s: DashStats) => (s.errors ? `${s.errors.total} unresolved` : "View →"),
   },
   {
     title: "Notifications",
@@ -129,13 +124,12 @@ export default function AdminDashboard() {
   useEffect(() => {
     async function fetchStats() {
       try {
-        const [ordersRes, contactsRes, errorsRes, healthRes] =
-          await Promise.allSettled([
-            fetchWithAuth("/api/admin/orders?limit=50"),
-            fetchWithAuth("/api/admin/crm/contacts?limit=1"),
-            fetchWithAuth("/api/admin/ops/errors"),
-            fetchWithAuth("/api/health"),
-          ]);
+        const [ordersRes, contactsRes, errorsRes, healthRes] = await Promise.allSettled([
+          fetchWithAuth("/api/admin/orders?limit=50"),
+          fetchWithAuth("/api/admin/crm/contacts?limit=1"),
+          fetchWithAuth("/api/admin/ops/errors"),
+          fetchWithAuth("/api/health"),
+        ]);
 
         const orders =
           ordersRes.status === "fulfilled" && ordersRes.value.ok
@@ -160,17 +154,14 @@ export default function AdminDashboard() {
                 total: orders.orders?.length ?? 0,
                 revenue:
                   orders.orders?.reduce(
-                    (sum: number, o: { amount: number }) =>
-                      sum + (o.amount ?? 0),
-                    0,
+                    (sum: number, o: { amount: number }) => sum + (o.amount ?? 0),
+                    0
                   ) ?? 0,
               }
             : null,
           contacts: contacts ? { total: contacts.total ?? 0 } : null,
           errors: errors ? { total: errors.total ?? 0 } : null,
-          health: health
-            ? { status: health.status, version: health.version }
-            : null,
+          health: health ? { status: health.status, version: health.version } : null,
         });
       } catch {
         /* stats are best-effort */
@@ -187,16 +178,10 @@ export default function AdminDashboard() {
       <div className="mb-8">
         <div className="bg-neon-magenta/10 border-neon-magenta/20 mb-4 inline-flex items-center gap-2 rounded-full border px-3 py-1.5">
           <span className="bg-neon-magenta h-2 w-2 animate-pulse rounded-full" />
-          <span className="text-neon-magenta font-mono text-xs">
-            ADMIN_DASH
-          </span>
+          <span className="text-neon-magenta font-mono text-xs">ADMIN_DASH</span>
         </div>
-        <h1 className="font-heading text-2xl font-bold text-white">
-          Admin Dashboard
-        </h1>
-        <p className="font-body mt-1 text-slate-400">
-          Manage your Cloudless platform.
-        </p>
+        <h1 className="font-heading text-2xl font-bold text-white">Admin Dashboard</h1>
+        <p className="font-body mt-1 text-slate-400">Manage your Cloudless platform.</p>
       </div>
 
       <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
@@ -208,19 +193,13 @@ export default function AdminDashboard() {
                   {card.icon}
                 </div>
                 {loading ? (
-                  <span className="bg-slate-800/50 h-4 w-16 animate-pulse rounded" />
+                  <span className="h-4 w-16 animate-pulse rounded bg-slate-800/50" />
                 ) : (
-                  <span className="text-neon-green font-mono text-xs">
-                    {card.render(stats)}
-                  </span>
+                  <span className="text-neon-green font-mono text-xs">{card.render(stats)}</span>
                 )}
               </div>
-              <h3 className="font-heading mb-1 font-semibold text-white">
-                {card.title}
-              </h3>
-              <p className="font-body text-sm text-slate-500">
-                {card.description}
-              </p>
+              <h3 className="font-heading mb-1 font-semibold text-white">{card.title}</h3>
+              <p className="font-body text-sm text-slate-500">{card.description}</p>
             </div>
           </Link>
         ))}
@@ -228,9 +207,7 @@ export default function AdminDashboard() {
 
       {/* System Status */}
       <div className="bg-void-light/50 mt-8 rounded-xl border border-slate-800 p-6">
-        <h2 className="font-heading mb-4 font-semibold text-white">
-          System Status
-        </h2>
+        <h2 className="font-heading mb-4 font-semibold text-white">System Status</h2>
         <div className="grid grid-cols-1 gap-4 sm:grid-cols-3">
           {[
             {
@@ -261,9 +238,7 @@ export default function AdminDashboard() {
               <span
                 className={`h-2 w-2 rounded-full ${item.ok ? "bg-neon-green" : "bg-slate-600"}`}
               />
-              <span className="font-mono text-sm text-slate-400">
-                {item.label}
-              </span>
+              <span className="font-mono text-sm text-slate-400">{item.label}</span>
               <span
                 className={`ml-auto font-mono text-xs ${item.ok ? "text-neon-green" : "text-slate-500"}`}
               >

--- a/src/app/[locale]/admin/pipeline/page.tsx
+++ b/src/app/[locale]/admin/pipeline/page.tsx
@@ -77,14 +77,11 @@ export default function PipelinePage() {
   async function moveDeal(dealId: string, stageId: string) {
     setMovingDeal(dealId);
     try {
-      const res = await fetchWithAuth(
-        `/api/admin/pipeline/deals/${dealId}/move`,
-        {
-          method: "POST",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ stageId }),
-        },
-      );
+      const res = await fetchWithAuth(`/api/admin/pipeline/deals/${dealId}/move`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ stageId }),
+      });
       if (!res.ok) throw new Error("Move failed");
       await load();
     } catch {
@@ -94,13 +91,9 @@ export default function PipelinePage() {
     }
   }
 
-  const allStages =
-    pipelines[0]?.stages?.sort((a, b) => a.displayOrder - b.displayOrder) ?? [];
+  const allStages = pipelines[0]?.stages?.sort((a, b) => a.displayOrder - b.displayOrder) ?? [];
 
-  const stageIds =
-    allStages.length > 0
-      ? allStages.map((s) => s.id)
-      : Object.keys(dealsByStage);
+  const stageIds = allStages.length > 0 ? allStages.map((s) => s.id) : Object.keys(dealsByStage);
 
   return (
     <div>
@@ -109,21 +102,15 @@ export default function PipelinePage() {
           <span className="bg-neon-cyan h-2 w-2 animate-pulse rounded-full" />
           <span className="text-neon-cyan font-mono text-xs">PIPELINE</span>
         </div>
-        <h1 className="font-heading text-2xl font-bold text-white">
-          Lead Pipeline
-        </h1>
-        <p className="font-body mt-1 text-slate-400">
-          HubSpot deal pipeline kanban board.
-        </p>
+        <h1 className="font-heading text-2xl font-bold text-white">Lead Pipeline</h1>
+        <p className="font-body mt-1 text-slate-400">HubSpot deal pipeline kanban board.</p>
       </div>
 
       {stats && (
         <div className="mb-8 grid grid-cols-2 gap-4 sm:grid-cols-3">
           <div className="bg-void-light/50 rounded-xl border border-slate-800 p-4">
             <p className="font-mono text-xs text-slate-500">Total Deals</p>
-            <p className="mt-1 font-mono text-2xl font-bold text-white">
-              {stats.totalDeals}
-            </p>
+            <p className="mt-1 font-mono text-2xl font-bold text-white">{stats.totalDeals}</p>
           </div>
           <div className="bg-void-light/50 rounded-xl border border-slate-800 p-4">
             <p className="font-mono text-xs text-slate-500">Pipeline Value</p>
@@ -157,18 +144,12 @@ export default function PipelinePage() {
 
       {!loading && !error && (
         <div className="overflow-x-auto pb-4">
-          <div
-            className="flex gap-4"
-            style={{ minWidth: `${stageIds.length * 280}px` }}
-          >
+          <div className="flex gap-4" style={{ minWidth: `${stageIds.length * 280}px` }}>
             {stageIds.map((stageId) => {
-              const stageLabel =
-                allStages.find((s) => s.id === stageId)?.label ?? stageId;
+              const stageLabel = allStages.find((s) => s.id === stageId)?.label ?? stageId;
               const deals = (dealsByStage[stageId] ?? []) as Deal[];
-              const colStyle =
-                STAGE_COLORS[stageId] ?? "border-slate-700/30 bg-slate-800/10";
-              const labelStyle =
-                STAGE_LABEL_COLORS[stageId] ?? "text-slate-300";
+              const colStyle = STAGE_COLORS[stageId] ?? "border-slate-700/30 bg-slate-800/10";
+              const labelStyle = STAGE_LABEL_COLORS[stageId] ?? "text-slate-300";
 
               return (
                 <div
@@ -176,9 +157,7 @@ export default function PipelinePage() {
                   className={`flex w-64 shrink-0 flex-col rounded-xl border p-3 ${colStyle}`}
                 >
                   <div className="mb-3 flex items-center justify-between">
-                    <span
-                      className={`font-mono text-xs font-semibold ${labelStyle}`}
-                    >
+                    <span className={`font-mono text-xs font-semibold ${labelStyle}`}>
                       {stageLabel}
                     </span>
                     <span className="rounded-full bg-slate-800 px-2 py-0.5 font-mono text-[10px] text-slate-400">

--- a/src/app/[locale]/admin/projects/page.tsx
+++ b/src/app/[locale]/admin/projects/page.tsx
@@ -2,12 +2,7 @@
 
 import { fetchWithAuth } from "@/lib/fetch-with-auth";
 import { useEffect, useState } from "react";
-import type {
-  Project,
-  Task,
-  ProjectStatus,
-  TaskStatus,
-} from "@/lib/notion-projects";
+import type { Project, Task, ProjectStatus, TaskStatus } from "@/lib/notion-projects";
 
 type Tab = "projects" | "tasks";
 
@@ -45,9 +40,9 @@ function ProgressBar({ value }: { value: number }) {
   const pct = Math.max(0, Math.min(100, value));
   return (
     <div className="flex items-center gap-2">
-      <div className="h-1.5 w-20 rounded-full bg-slate-800 overflow-hidden">
+      <div className="h-1.5 w-20 overflow-hidden rounded-full bg-slate-800">
         <div
-          className="h-full rounded-full bg-neon-cyan transition-all"
+          className="bg-neon-cyan h-full rounded-full transition-all"
           style={{ width: `${pct}%` }}
         />
       </div>
@@ -76,9 +71,7 @@ export default function AdminProjectsPage() {
       const data = await res.json();
       setProjects(data.projects ?? []);
     } catch (err) {
-      setErrorProjects(
-        err instanceof Error ? err.message : "Failed to load projects",
-      );
+      setErrorProjects(err instanceof Error ? err.message : "Failed to load projects");
     } finally {
       setLoadingProjects(false);
     }
@@ -94,9 +87,7 @@ export default function AdminProjectsPage() {
       setTasks(data.tasks ?? []);
       setFetchedTasks(true);
     } catch (err) {
-      setErrorTasks(
-        err instanceof Error ? err.message : "Failed to load tasks",
-      );
+      setErrorTasks(err instanceof Error ? err.message : "Failed to load tasks");
     } finally {
       setLoadingTasks(false);
     }
@@ -122,9 +113,7 @@ export default function AdminProjectsPage() {
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ pageId: id, status }),
       });
-      setProjects((prev) =>
-        prev.map((p) => (p.id === id ? { ...p, status } : p)),
-      );
+      setProjects((prev) => prev.map((p) => (p.id === id ? { ...p, status } : p)));
     } finally {
       setUpdatingId(null);
     }
@@ -151,9 +140,7 @@ export default function AdminProjectsPage() {
           <span className="bg-neon-cyan h-2 w-2 animate-pulse rounded-full" />
           <span className="text-neon-cyan font-mono text-xs">PROJECTS</span>
         </div>
-        <h1 className="font-heading text-2xl font-bold text-white">
-          Projects & Tasks
-        </h1>
+        <h1 className="font-heading text-2xl font-bold text-white">Projects & Tasks</h1>
         <p className="font-body mt-1 text-slate-400">
           Manage projects and tasks from your Notion workspace.
         </p>
@@ -165,7 +152,7 @@ export default function AdminProjectsPage() {
             key={t}
             type="button"
             onClick={() => setTab(t)}
-            className={`rounded-lg border px-4 py-1.5 font-mono text-xs transition-all capitalize ${
+            className={`rounded-lg border px-4 py-1.5 font-mono text-xs capitalize transition-all ${
               tab === t
                 ? "border-neon-cyan/30 bg-neon-cyan/10 text-neon-cyan"
                 : "border-slate-800 text-slate-500 hover:border-slate-700 hover:text-white"
@@ -186,7 +173,7 @@ export default function AdminProjectsPage() {
             if (tab === "projects") loadProjects();
             else loadTasks();
           }}
-          className="ml-auto rounded-lg border border-slate-700 px-3 py-1.5 font-mono text-xs text-slate-400 hover:text-white transition-colors"
+          className="ml-auto rounded-lg border border-slate-700 px-3 py-1.5 font-mono text-xs text-slate-400 transition-colors hover:text-white"
         >
           ↺ Refresh
         </button>
@@ -204,7 +191,7 @@ export default function AdminProjectsPage() {
               {[1, 2, 3].map((i) => (
                 <div
                   key={i}
-                  className="animate-pulse rounded-xl border border-slate-800 bg-void-light/50 p-5"
+                  className="bg-void-light/50 animate-pulse rounded-xl border border-slate-800 p-5"
                 >
                   <div className="mb-2 h-4 w-1/2 rounded bg-slate-700/60" />
                   <div className="h-3 w-1/4 rounded bg-slate-800/80" />
@@ -213,14 +200,12 @@ export default function AdminProjectsPage() {
             </div>
           )}
           {!loadingProjects && projects.length === 0 && !errorProjects && (
-            <div className="rounded-xl border border-slate-800 bg-void-light/30 py-12 text-center">
-              <p className="font-mono text-sm text-slate-500">
-                No projects in Notion yet.
-              </p>
+            <div className="bg-void-light/30 rounded-xl border border-slate-800 py-12 text-center">
+              <p className="font-mono text-sm text-slate-500">No projects in Notion yet.</p>
             </div>
           )}
           {!loadingProjects && projects.length > 0 && (
-            <div className="overflow-hidden rounded-xl border border-slate-800 bg-void-light/50">
+            <div className="bg-void-light/50 overflow-hidden rounded-xl border border-slate-800">
               <div className="overflow-x-auto">
                 <table className="w-full text-sm">
                   <thead>
@@ -240,9 +225,7 @@ export default function AdminProjectsPage() {
                       <th className="px-5 py-3 text-left font-mono text-xs text-slate-500">
                         Owner
                       </th>
-                      <th className="px-5 py-3 text-left font-mono text-xs text-slate-500">
-                        Due
-                      </th>
+                      <th className="px-5 py-3 text-left font-mono text-xs text-slate-500">Due</th>
                     </tr>
                   </thead>
                   <tbody>
@@ -252,13 +235,9 @@ export default function AdminProjectsPage() {
                         className="hover:bg-void-lighter/20 border-b border-slate-800/50 transition-colors"
                       >
                         <td className="px-5 py-3">
-                          <div className="font-medium text-white">
-                            {p.name || "(Untitled)"}
-                          </div>
+                          <div className="font-medium text-white">{p.name || "(Untitled)"}</div>
                           {p.type && (
-                            <div className="font-mono text-[10px] text-slate-600">
-                              {p.type}
-                            </div>
+                            <div className="font-mono text-[10px] text-slate-600">{p.type}</div>
                           )}
                         </td>
                         <td className="px-5 py-3">
@@ -266,12 +245,9 @@ export default function AdminProjectsPage() {
                             value={p.status}
                             disabled={updatingId === p.id}
                             onChange={(e) =>
-                              updateProjectStatus(
-                                p.id,
-                                e.target.value as ProjectStatus,
-                              )
+                              updateProjectStatus(p.id, e.target.value as ProjectStatus)
                             }
-                            className={`rounded border bg-void px-2 py-1 font-mono text-[10px] focus:outline-none disabled:opacity-50 ${PROJECT_STATUS_COLORS[p.status] ?? "border-slate-700 text-slate-400"}`}
+                            className={`bg-void rounded border px-2 py-1 font-mono text-[10px] focus:outline-none disabled:opacity-50 ${PROJECT_STATUS_COLORS[p.status] ?? "border-slate-700 text-slate-400"}`}
                           >
                             {(
                               [
@@ -291,9 +267,7 @@ export default function AdminProjectsPage() {
                         <td className="px-5 py-3">
                           <ProgressBar value={p.progress} />
                         </td>
-                        <td className="px-5 py-3 font-mono text-xs text-slate-400">
-                          {p.priority}
-                        </td>
+                        <td className="px-5 py-3 font-mono text-xs text-slate-400">{p.priority}</td>
                         <td className="px-5 py-3 font-mono text-xs text-slate-400">
                           {p.owner || "—"}
                         </td>
@@ -325,7 +299,7 @@ export default function AdminProjectsPage() {
               {[1, 2, 3, 4].map((i) => (
                 <div
                   key={i}
-                  className="animate-pulse rounded-xl border border-slate-800 bg-void-light/50 p-4"
+                  className="bg-void-light/50 animate-pulse rounded-xl border border-slate-800 p-4"
                 >
                   <div className="mb-1.5 h-3.5 w-1/2 rounded bg-slate-700/60" />
                   <div className="h-3 w-1/4 rounded bg-slate-800/80" />
@@ -333,25 +307,18 @@ export default function AdminProjectsPage() {
               ))}
             </div>
           )}
-          {!loadingTasks &&
-            fetchedTasks &&
-            tasks.length === 0 &&
-            !errorTasks && (
-              <div className="rounded-xl border border-slate-800 bg-void-light/30 py-12 text-center">
-                <p className="font-mono text-sm text-slate-500">
-                  No tasks in Notion yet.
-                </p>
-              </div>
-            )}
+          {!loadingTasks && fetchedTasks && tasks.length === 0 && !errorTasks && (
+            <div className="bg-void-light/30 rounded-xl border border-slate-800 py-12 text-center">
+              <p className="font-mono text-sm text-slate-500">No tasks in Notion yet.</p>
+            </div>
+          )}
           {!loadingTasks && tasks.length > 0 && (
-            <div className="overflow-hidden rounded-xl border border-slate-800 bg-void-light/50">
+            <div className="bg-void-light/50 overflow-hidden rounded-xl border border-slate-800">
               <div className="overflow-x-auto">
                 <table className="w-full text-sm">
                   <thead>
                     <tr className="border-b border-slate-800">
-                      <th className="px-5 py-3 text-left font-mono text-xs text-slate-500">
-                        Task
-                      </th>
+                      <th className="px-5 py-3 text-left font-mono text-xs text-slate-500">Task</th>
                       <th className="px-5 py-3 text-left font-mono text-xs text-slate-500">
                         Status
                       </th>
@@ -361,12 +328,8 @@ export default function AdminProjectsPage() {
                       <th className="px-5 py-3 text-left font-mono text-xs text-slate-500">
                         Assignee
                       </th>
-                      <th className="px-5 py-3 text-left font-mono text-xs text-slate-500">
-                        Type
-                      </th>
-                      <th className="px-5 py-3 text-left font-mono text-xs text-slate-500">
-                        Due
-                      </th>
+                      <th className="px-5 py-3 text-left font-mono text-xs text-slate-500">Type</th>
+                      <th className="px-5 py-3 text-left font-mono text-xs text-slate-500">Due</th>
                     </tr>
                   </thead>
                   <tbody>
@@ -376,9 +339,7 @@ export default function AdminProjectsPage() {
                         className="hover:bg-void-lighter/20 border-b border-slate-800/50 transition-colors"
                       >
                         <td className="px-5 py-3">
-                          <div className="font-medium text-white">
-                            {t.task || "(Untitled)"}
-                          </div>
+                          <div className="font-medium text-white">{t.task || "(Untitled)"}</div>
                           {t.estimate && (
                             <span className="mt-0.5 inline-block rounded bg-slate-800 px-1.5 py-0.5 font-mono text-[9px] text-slate-500">
                               {t.estimate}
@@ -389,13 +350,8 @@ export default function AdminProjectsPage() {
                           <select
                             value={t.status}
                             disabled={updatingId === t.id}
-                            onChange={(e) =>
-                              updateTaskStatus(
-                                t.id,
-                                e.target.value as TaskStatus,
-                              )
-                            }
-                            className={`rounded border bg-void px-2 py-1 font-mono text-[10px] focus:outline-none disabled:opacity-50 ${TASK_STATUS_COLORS[t.status] ?? "border-slate-700 text-slate-400"}`}
+                            onChange={(e) => updateTaskStatus(t.id, e.target.value as TaskStatus)}
+                            className={`bg-void rounded border px-2 py-1 font-mono text-[10px] focus:outline-none disabled:opacity-50 ${TASK_STATUS_COLORS[t.status] ?? "border-slate-700 text-slate-400"}`}
                           >
                             {(
                               [
@@ -413,9 +369,7 @@ export default function AdminProjectsPage() {
                             ))}
                           </select>
                         </td>
-                        <td className="px-5 py-3 font-mono text-xs text-slate-400">
-                          {t.priority}
-                        </td>
+                        <td className="px-5 py-3 font-mono text-xs text-slate-400">{t.priority}</td>
                         <td className="px-5 py-3 font-mono text-xs text-slate-400">
                           {t.assignee || "—"}
                         </td>

--- a/src/app/[locale]/admin/settings/page.tsx
+++ b/src/app/[locale]/admin/settings/page.tsx
@@ -43,23 +43,16 @@ export default function AdminSettingsPage() {
           <span className="bg-neon-magenta h-2 w-2 animate-pulse rounded-full" />
           <span className="text-neon-magenta font-mono text-xs">SETTINGS</span>
         </div>
-        <h1 className="font-heading text-2xl font-bold text-white">
-          Site Settings
-        </h1>
-        <p className="font-body mt-1 text-slate-400">
-          Configure your Cloudless platform settings.
-        </p>
+        <h1 className="font-heading text-2xl font-bold text-white">Site Settings</h1>
+        <p className="font-body mt-1 text-slate-400">Configure your Cloudless platform settings.</p>
       </div>
 
       <div className="space-y-6">
         {/* Cache Management */}
         <div className="bg-void-light/50 rounded-xl border border-slate-800 p-6">
-          <h2 className="font-heading mb-1 font-semibold text-white">
-            Cache Management
-          </h2>
+          <h2 className="font-heading mb-1 font-semibold text-white">Cache Management</h2>
           <p className="mb-4 text-xs text-slate-500">
-            The Notion in-memory cache speeds up page loads. Clear it after
-            manual Notion changes.
+            The Notion in-memory cache speeds up page loads. Clear it after manual Notion changes.
           </p>
 
           {cacheMsg && (
@@ -95,22 +88,14 @@ export default function AdminSettingsPage() {
 
         {/* Danger Zone */}
         <div className="rounded-xl border border-red-900/30 bg-red-950/10 p-6">
-          <h2 className="font-heading mb-2 font-semibold text-red-400">
-            Danger Zone
-          </h2>
-          <p className="mb-4 text-xs text-slate-500">
-            Irreversible actions. Proceed with caution.
-          </p>
+          <h2 className="font-heading mb-2 font-semibold text-red-400">Danger Zone</h2>
+          <p className="mb-4 text-xs text-slate-500">Irreversible actions. Proceed with caution.</p>
           <div className="flex flex-wrap gap-2">
             <button
               type="button"
               className="min-h-[44px] rounded-lg border border-red-900/50 px-4 py-2.5 font-mono text-xs text-red-400 transition-all hover:bg-red-950/30"
               onClick={() => {
-                if (
-                  window.confirm(
-                    "Delete all Notion cache? Active requests will re-fetch.",
-                  )
-                ) {
+                if (window.confirm("Delete all Notion cache? Active requests will re-fetch.")) {
                   handleClearCache();
                 }
               }}

--- a/src/app/[locale]/admin/subscriptions/page.tsx
+++ b/src/app/[locale]/admin/subscriptions/page.tsx
@@ -44,9 +44,7 @@ export default function SubscriptionsPage() {
     setError(null);
     setActionMessage(null);
     try {
-      const res = await fetchWithAuth(
-        `/api/admin/subscriptions?status=${status}&limit=50`,
-      );
+      const res = await fetchWithAuth(`/api/admin/subscriptions?status=${status}&limit=50`);
       if (!res.ok) throw new Error(`HTTP ${res.status}`);
       const data = await res.json();
       setSubscriptions(data.subscriptions ?? []);
@@ -94,9 +92,7 @@ export default function SubscriptionsPage() {
       });
       const data = await res.json();
       if (data.ok) {
-        setActionMessage(
-          "Subscription scheduled for cancellation at period end.",
-        );
+        setActionMessage("Subscription scheduled for cancellation at period end.");
         load(statusFilter);
       } else {
         setActionMessage(data.error ?? "Cancellation failed");
@@ -121,13 +117,9 @@ export default function SubscriptionsPage() {
         <div>
           <div className="border-neon-blue/20 bg-neon-blue/10 mb-4 inline-flex items-center gap-2 rounded-full border px-3 py-1.5">
             <span className="bg-neon-blue h-2 w-2 animate-pulse rounded-full" />
-            <span className="text-neon-blue font-mono text-xs">
-              STRIPE BILLING
-            </span>
+            <span className="text-neon-blue font-mono text-xs">STRIPE BILLING</span>
           </div>
-          <h1 className="font-heading text-2xl font-bold text-white">
-            Subscriptions
-          </h1>
+          <h1 className="font-heading text-2xl font-bold text-white">Subscriptions</h1>
           <p className="font-body mt-1 text-slate-400">
             Manage recurring billing, access customer portals, and monitor MRR.
           </p>
@@ -144,25 +136,25 @@ export default function SubscriptionsPage() {
 
       {/* Summary cards */}
       <div className="mb-6 grid grid-cols-2 gap-4 sm:grid-cols-4">
-        <div className="rounded-xl border border-slate-800 bg-void-light/30 p-4">
+        <div className="bg-void-light/30 rounded-xl border border-slate-800 p-4">
           <div className="font-mono text-xs text-slate-500">Active</div>
           <div className="font-heading mt-1 text-2xl font-bold text-white">
             {subscriptions.filter((s) => s.status === "active").length}
           </div>
         </div>
-        <div className="rounded-xl border border-slate-800 bg-void-light/30 p-4">
+        <div className="bg-void-light/30 rounded-xl border border-slate-800 p-4">
           <div className="font-mono text-xs text-slate-500">Trialing</div>
-          <div className="font-heading mt-1 text-2xl font-bold text-neon-blue">
+          <div className="font-heading text-neon-blue mt-1 text-2xl font-bold">
             {subscriptions.filter((s) => s.status === "trialing").length}
           </div>
         </div>
-        <div className="rounded-xl border border-slate-800 bg-void-light/30 p-4">
+        <div className="bg-void-light/30 rounded-xl border border-slate-800 p-4">
           <div className="font-mono text-xs text-slate-500">Past Due</div>
           <div className="font-heading mt-1 text-2xl font-bold text-yellow-400">
             {subscriptions.filter((s) => s.status === "past_due").length}
           </div>
         </div>
-        <div className="rounded-xl border border-slate-800 bg-void-light/30 p-4">
+        <div className="bg-void-light/30 rounded-xl border border-slate-800 p-4">
           <div className="font-mono text-xs text-slate-500">Est. MRR</div>
           <div className="font-heading mt-1 text-2xl font-bold text-green-400">
             {(totalMRR / 100).toLocaleString("en-IE", {
@@ -176,15 +168,7 @@ export default function SubscriptionsPage() {
 
       {/* Status filter */}
       <div className="mb-4 flex flex-wrap gap-2">
-        {(
-          [
-            "active",
-            "trialing",
-            "past_due",
-            "canceled",
-            "all",
-          ] as StatusFilter[]
-        ).map((s) => (
+        {(["active", "trialing", "past_due", "canceled", "all"] as StatusFilter[]).map((s) => (
           <button
             key={s}
             type="button"
@@ -217,19 +201,17 @@ export default function SubscriptionsPage() {
           {["sub-1", "sub-2", "sub-3", "sub-4"].map((k) => (
             <div
               key={k}
-              className="h-20 animate-pulse rounded-xl border border-slate-800 bg-void-light/30"
+              className="bg-void-light/30 h-20 animate-pulse rounded-xl border border-slate-800"
             />
           ))}
         </div>
       )}
 
       {!loading && subscriptions.length === 0 && (
-        <div className="rounded-xl border border-slate-800 bg-void-light/30 px-6 py-12 text-center">
+        <div className="bg-void-light/30 rounded-xl border border-slate-800 px-6 py-12 text-center">
           <div className="mb-3 text-4xl">💳</div>
-          <p className="font-heading text-sm text-slate-400">
-            No subscriptions found.
-          </p>
-          <p className="font-mono mt-1 text-xs text-slate-600">
+          <p className="font-heading text-sm text-slate-400">No subscriptions found.</p>
+          <p className="mt-1 font-mono text-xs text-slate-600">
             {statusFilter === "all"
               ? "Your Stripe account has no subscriptions yet."
               : `No ${statusFilter.replace("_", " ")} subscriptions.`}
@@ -240,14 +222,12 @@ export default function SubscriptionsPage() {
       {!loading && subscriptions.length > 0 && (
         <div className="space-y-3">
           {subscriptions.map((sub) => {
-            const statusClass =
-              STATUS_COLORS[sub.status] ?? "text-slate-400 border-slate-700";
-            const busy =
-              actionLoading === sub.id || actionLoading === sub.customerId;
+            const statusClass = STATUS_COLORS[sub.status] ?? "text-slate-400 border-slate-700";
+            const busy = actionLoading === sub.id || actionLoading === sub.customerId;
             return (
               <div
                 key={sub.id}
-                className="rounded-xl border border-slate-800 bg-void-light/30 p-4 transition hover:border-slate-700"
+                className="bg-void-light/30 rounded-xl border border-slate-800 p-4 transition hover:border-slate-700"
               >
                 <div className="flex flex-wrap items-start justify-between gap-3">
                   <div className="min-w-0">
@@ -256,9 +236,7 @@ export default function SubscriptionsPage() {
                         {sub.customerEmail ?? sub.customerId}
                       </span>
                       {sub.customerName && (
-                        <span className="font-mono text-xs text-slate-500">
-                          {sub.customerName}
-                        </span>
+                        <span className="font-mono text-xs text-slate-500">{sub.customerName}</span>
                       )}
                       <span
                         className={`rounded-full border px-2 py-0.5 font-mono text-[10px] ${statusClass}`}
@@ -292,7 +270,7 @@ export default function SubscriptionsPage() {
                       type="button"
                       onClick={() => openPortal(sub.customerId)}
                       disabled={busy}
-                      className="rounded-lg border border-neon-blue/30 px-3 py-1.5 font-mono text-xs text-neon-blue transition hover:border-neon-blue/60 disabled:opacity-50"
+                      className="border-neon-blue/30 text-neon-blue hover:border-neon-blue/60 rounded-lg border px-3 py-1.5 font-mono text-xs transition disabled:opacity-50"
                     >
                       {actionLoading === sub.customerId ? "Opening…" : "Portal"}
                     </button>

--- a/src/app/[locale]/admin/users/page.tsx
+++ b/src/app/[locale]/admin/users/page.tsx
@@ -101,14 +101,12 @@ export default function AdminUsersPage() {
     (u) =>
       u.email.toLowerCase().includes(search.toLowerCase()) ||
       u.name.toLowerCase().includes(search.toLowerCase()) ||
-      u.company.toLowerCase().includes(search.toLowerCase()),
+      u.company.toLowerCase().includes(search.toLowerCase())
   );
 
   const adminCount = users.filter((u) => u.role === "admin").length;
   const activeCount = users.filter((u) => u.status === "active").length;
-  const unconfirmedCount = users.filter(
-    (u) => u.userStatus !== "CONFIRMED",
-  ).length;
+  const unconfirmedCount = users.filter((u) => u.userStatus !== "CONFIRMED").length;
 
   return (
     <div>
@@ -117,9 +115,7 @@ export default function AdminUsersPage() {
           <span className="bg-neon-magenta h-2 w-2 animate-pulse rounded-full" />
           <span className="text-neon-magenta font-mono text-xs">USERS</span>
         </div>
-        <h1 className="font-heading text-2xl font-bold text-white">
-          User Management
-        </h1>
+        <h1 className="font-heading text-2xl font-bold text-white">User Management</h1>
         <p className="font-body mt-1 text-slate-400">
           Cognito user pool — manage accounts, roles, and access.
         </p>
@@ -186,8 +182,8 @@ export default function AdminUsersPage() {
         <div className="bg-void-light/50 rounded-xl border border-red-900/30 p-6 text-center">
           <p className="font-mono text-sm text-red-400">{error}</p>
           <p className="mt-2 text-xs text-slate-500">
-            Make sure COGNITO_USER_POOL_ID is configured and the Lambda/server
-            has cognito-idp permissions.
+            Make sure COGNITO_USER_POOL_ID is configured and the Lambda/server has cognito-idp
+            permissions.
           </p>
         </div>
       ) : (
@@ -229,9 +225,7 @@ export default function AdminUsersPage() {
                           {(user.name || user.email || "U")[0].toUpperCase()}
                         </div>
                         <div className="min-w-0">
-                          <p className="truncate font-mono text-sm text-white">
-                            {user.email}
-                          </p>
+                          <p className="truncate font-mono text-sm text-white">{user.email}</p>
                           {user.name && (
                             <p className="truncate text-xs text-slate-500">
                               {user.name}
@@ -263,7 +257,7 @@ export default function AdminUsersPage() {
                     {/* Cognito status */}
                     <td className="px-6 py-4">
                       <span
-                        className={`rounded-full px-2 py-0.5 font-mono text-[10px] ${userStatusClasses[user.userStatus] ?? "text-slate-400 bg-slate-800/50"}`}
+                        className={`rounded-full px-2 py-0.5 font-mono text-[10px] ${userStatusClasses[user.userStatus] ?? "bg-slate-800/50 text-slate-400"}`}
                       >
                         {user.userStatus}
                       </span>
@@ -271,9 +265,7 @@ export default function AdminUsersPage() {
 
                     {/* Joined */}
                     <td className="px-6 py-4 font-mono text-slate-500">
-                      {user.created
-                        ? new Date(user.created).toLocaleDateString("en-IE")
-                        : "—"}
+                      {user.created ? new Date(user.created).toLocaleDateString("en-IE") : "—"}
                     </td>
 
                     {/* Actions */}
@@ -281,53 +273,37 @@ export default function AdminUsersPage() {
                       <div className="flex gap-1.5">
                         {user.status === "active" ? (
                           <button
-                            onClick={() =>
-                              handleAction("disable", user.username)
-                            }
+                            onClick={() => handleAction("disable", user.username)}
                             disabled={actionLoading !== null}
                             className="min-h-[32px] rounded-lg border border-red-900/30 px-2 py-1 font-mono text-[10px] text-red-400 transition-colors hover:bg-red-400/10 disabled:opacity-50"
                           >
-                            {actionLoading === `disable-${user.username}`
-                              ? "…"
-                              : "Disable"}
+                            {actionLoading === `disable-${user.username}` ? "…" : "Disable"}
                           </button>
                         ) : (
                           <button
-                            onClick={() =>
-                              handleAction("enable", user.username)
-                            }
+                            onClick={() => handleAction("enable", user.username)}
                             disabled={actionLoading !== null}
-                            className="min-h-[32px] rounded-lg border border-neon-green/20 px-2 py-1 font-mono text-[10px] text-neon-green transition-colors hover:bg-neon-green/10 disabled:opacity-50"
+                            className="border-neon-green/20 text-neon-green hover:bg-neon-green/10 min-h-[32px] rounded-lg border px-2 py-1 font-mono text-[10px] transition-colors disabled:opacity-50"
                           >
-                            {actionLoading === `enable-${user.username}`
-                              ? "…"
-                              : "Enable"}
+                            {actionLoading === `enable-${user.username}` ? "…" : "Enable"}
                           </button>
                         )}
 
                         {user.role === "user" ? (
                           <button
-                            onClick={() =>
-                              handleAction("promote", user.username)
-                            }
+                            onClick={() => handleAction("promote", user.username)}
                             disabled={actionLoading !== null}
                             className="border-neon-magenta/20 text-neon-magenta hover:bg-neon-magenta/10 min-h-[32px] rounded-lg border px-2 py-1 font-mono text-[10px] transition-colors disabled:opacity-50"
                           >
-                            {actionLoading === `promote-${user.username}`
-                              ? "…"
-                              : "→ Admin"}
+                            {actionLoading === `promote-${user.username}` ? "…" : "→ Admin"}
                           </button>
                         ) : (
                           <button
-                            onClick={() =>
-                              handleAction("demote", user.username)
-                            }
+                            onClick={() => handleAction("demote", user.username)}
                             disabled={actionLoading !== null}
                             className="min-h-[32px] rounded-lg border border-slate-700 px-2 py-1 font-mono text-[10px] text-slate-400 transition-colors hover:bg-slate-800 disabled:opacity-50"
                           >
-                            {actionLoading === `demote-${user.username}`
-                              ? "…"
-                              : "→ User"}
+                            {actionLoading === `demote-${user.username}` ? "…" : "→ User"}
                           </button>
                         )}
                       </div>
@@ -336,10 +312,7 @@ export default function AdminUsersPage() {
                 ))}
                 {filtered.length === 0 && (
                   <tr>
-                    <td
-                      colSpan={6}
-                      className="px-6 py-12 text-center font-mono text-slate-600"
-                    >
+                    <td colSpan={6} className="px-6 py-12 text-center font-mono text-slate-600">
                       {search ? "No users match your search" : "No users found"}
                     </td>
                   </tr>

--- a/src/app/[locale]/admin/voice-brief/page.tsx
+++ b/src/app/[locale]/admin/voice-brief/page.tsx
@@ -82,13 +82,9 @@ export default function VoiceBriefPage() {
         <div>
           <div className="border-neon-blue/20 bg-neon-blue/10 mb-4 inline-flex items-center gap-2 rounded-full border px-3 py-1.5">
             <span className="bg-neon-blue h-2 w-2 animate-pulse rounded-full" />
-            <span className="text-neon-blue font-mono text-xs">
-              AI VOICE BRIEF
-            </span>
+            <span className="text-neon-blue font-mono text-xs">AI VOICE BRIEF</span>
           </div>
-          <h1 className="font-heading text-2xl font-bold text-white">
-            Weekly Voice Brief
-          </h1>
+          <h1 className="font-heading text-2xl font-bold text-white">Weekly Voice Brief</h1>
           <p className="font-body mt-1 text-slate-400">
             AI-generated spoken summary of your KPIs — powered by Claude.
           </p>
@@ -98,7 +94,7 @@ export default function VoiceBriefPage() {
             type="button"
             onClick={generate}
             disabled={generating}
-            className="rounded-lg border border-neon-blue/30 px-4 py-2 font-mono text-xs text-neon-blue transition hover:border-neon-blue/60 disabled:opacity-50"
+            className="border-neon-blue/30 text-neon-blue hover:border-neon-blue/60 rounded-lg border px-4 py-2 font-mono text-xs transition disabled:opacity-50"
           >
             {generating ? "Generating…" : "Generate Now"}
           </button>
@@ -124,12 +120,10 @@ export default function VoiceBriefPage() {
       )}
 
       {!loading && !brief && (
-        <div className="rounded-xl border border-slate-800 bg-void-light/30 px-6 py-12 text-center">
+        <div className="bg-void-light/30 rounded-xl border border-slate-800 px-6 py-12 text-center">
           <div className="mb-3 text-4xl">🎙️</div>
-          <p className="font-heading text-sm text-slate-400">
-            No brief generated yet.
-          </p>
-          <p className="font-mono mt-1 text-xs text-slate-600">
+          <p className="font-heading text-sm text-slate-400">No brief generated yet.</p>
+          <p className="mt-1 font-mono text-xs text-slate-600">
             Click Generate Now to create your first AI voice brief.
           </p>
         </div>
@@ -159,7 +153,7 @@ export default function VoiceBriefPage() {
                 className={`flex h-12 w-12 shrink-0 items-center justify-center rounded-full border transition ${
                   playing
                     ? "border-neon-blue/50 bg-neon-blue/10 text-neon-blue"
-                    : "border-slate-700 bg-slate-800 text-white hover:border-neon-blue/40"
+                    : "hover:border-neon-blue/40 border-slate-700 bg-slate-800 text-white"
                 }`}
               >
                 {playing ? "⏹" : "▶"}
@@ -168,26 +162,22 @@ export default function VoiceBriefPage() {
                 <div className="font-heading text-sm font-semibold text-white">
                   {playing ? "Playing…" : "Play Brief"}
                 </div>
-                <div className="font-mono text-xs text-slate-500">
-                  Browser speech synthesis
-                </div>
+                <div className="font-mono text-xs text-slate-500">Browser speech synthesis</div>
               </div>
             </div>
 
             {/* Transcript */}
-            <div className="rounded-lg border border-slate-700 bg-void/50 p-4">
-              <div className="font-mono mb-2 text-xs uppercase tracking-widest text-slate-500">
+            <div className="bg-void/50 rounded-lg border border-slate-700 p-4">
+              <div className="mb-2 font-mono text-xs tracking-widest text-slate-500 uppercase">
                 Transcript
               </div>
-              <p className="font-body leading-relaxed text-slate-300">
-                {brief.text}
-              </p>
+              <p className="font-body leading-relaxed text-slate-300">{brief.text}</p>
             </div>
           </div>
 
           <p className="font-mono text-xs text-slate-600">
-            Briefs are auto-generated weekly via the /api/cron/voice-brief
-            endpoint. Schedule it in vercel.json.
+            Briefs are auto-generated weekly via the /api/cron/voice-brief endpoint. Schedule it in
+            vercel.json.
           </p>
         </div>
       )}

--- a/src/app/[locale]/admin/workspaces/page.tsx
+++ b/src/app/[locale]/admin/workspaces/page.tsx
@@ -66,9 +66,7 @@ export default function WorkspacesPage() {
       setForm({ name: "", description: "", adminEmails: "" });
       load();
     } catch (e) {
-      setFormError(
-        e instanceof Error ? e.message : "Failed to create workspace",
-      );
+      setFormError(e instanceof Error ? e.message : "Failed to create workspace");
     } finally {
       setCreating(false);
     }
@@ -136,44 +134,35 @@ export default function WorkspacesPage() {
           <span className="bg-neon-blue h-2 w-2 animate-pulse rounded-full" />
           <span className="text-neon-blue font-mono text-xs">MULTI-TENANT</span>
         </div>
-        <h1 className="font-heading text-2xl font-bold text-white">
-          Workspaces
-        </h1>
+        <h1 className="font-heading text-2xl font-bold text-white">Workspaces</h1>
         <p className="font-body mt-1 text-slate-400">
-          Manage isolated workspaces for different clients or brands. Switch
-          between them using the sidebar selector.
+          Manage isolated workspaces for different clients or brands. Switch between them using the
+          sidebar selector.
         </p>
       </div>
 
       {/* Create form */}
-      <div className="mb-8 rounded-xl border border-slate-800 bg-void-light/30 p-6">
-        <h2 className="font-heading mb-4 text-sm font-semibold text-white">
-          Create Workspace
-        </h2>
+      <div className="bg-void-light/30 mb-8 rounded-xl border border-slate-800 p-6">
+        <h2 className="font-heading mb-4 text-sm font-semibold text-white">Create Workspace</h2>
         <form onSubmit={create} className="space-y-3">
           <div className="grid gap-3 sm:grid-cols-2">
             <div>
-              <label
-                htmlFor="ws-name"
-                className="font-mono mb-1 block text-xs text-slate-500"
-              >
+              <label htmlFor="ws-name" className="mb-1 block font-mono text-xs text-slate-500">
                 Name
               </label>
               <input
                 id="ws-name"
                 type="text"
                 value={form.name}
-                onChange={(e) =>
-                  setForm((f) => ({ ...f, name: e.target.value }))
-                }
+                onChange={(e) => setForm((f) => ({ ...f, name: e.target.value }))}
                 placeholder="Acme Corp"
-                className="w-full rounded-lg border border-slate-700 bg-void px-3 py-2 font-mono text-sm text-white placeholder-slate-600 focus:border-neon-blue/50 focus:outline-none"
+                className="bg-void focus:border-neon-blue/50 w-full rounded-lg border border-slate-700 px-3 py-2 font-mono text-sm text-white placeholder-slate-600 focus:outline-none"
               />
             </div>
             <div>
               <label
                 htmlFor="ws-admin-emails"
-                className="font-mono mb-1 block text-xs text-slate-500"
+                className="mb-1 block font-mono text-xs text-slate-500"
               >
                 Admin Emails (comma-separated)
               </label>
@@ -181,39 +170,30 @@ export default function WorkspacesPage() {
                 id="ws-admin-emails"
                 type="text"
                 value={form.adminEmails}
-                onChange={(e) =>
-                  setForm((f) => ({ ...f, adminEmails: e.target.value }))
-                }
+                onChange={(e) => setForm((f) => ({ ...f, adminEmails: e.target.value }))}
                 placeholder="admin@acme.com, manager@acme.com"
-                className="w-full rounded-lg border border-slate-700 bg-void px-3 py-2 font-mono text-sm text-white placeholder-slate-600 focus:border-neon-blue/50 focus:outline-none"
+                className="bg-void focus:border-neon-blue/50 w-full rounded-lg border border-slate-700 px-3 py-2 font-mono text-sm text-white placeholder-slate-600 focus:outline-none"
               />
             </div>
           </div>
           <div>
-            <label
-              htmlFor="ws-description"
-              className="font-mono mb-1 block text-xs text-slate-500"
-            >
+            <label htmlFor="ws-description" className="mb-1 block font-mono text-xs text-slate-500">
               Description (optional)
             </label>
             <input
               id="ws-description"
               type="text"
               value={form.description}
-              onChange={(e) =>
-                setForm((f) => ({ ...f, description: e.target.value }))
-              }
+              onChange={(e) => setForm((f) => ({ ...f, description: e.target.value }))}
               placeholder="Main production workspace for Acme Corp"
-              className="w-full rounded-lg border border-slate-700 bg-void px-3 py-2 font-mono text-sm text-white placeholder-slate-600 focus:border-neon-blue/50 focus:outline-none"
+              className="bg-void focus:border-neon-blue/50 w-full rounded-lg border border-slate-700 px-3 py-2 font-mono text-sm text-white placeholder-slate-600 focus:outline-none"
             />
           </div>
-          {formError && (
-            <p className="font-mono text-xs text-red-400">{formError}</p>
-          )}
+          {formError && <p className="font-mono text-xs text-red-400">{formError}</p>}
           <button
             type="submit"
             disabled={creating}
-            className="rounded-lg border border-neon-blue/30 px-5 py-2 font-mono text-xs text-neon-blue transition hover:border-neon-blue/60 disabled:opacity-50"
+            className="border-neon-blue/30 text-neon-blue hover:border-neon-blue/60 rounded-lg border px-5 py-2 font-mono text-xs transition disabled:opacity-50"
           >
             {creating ? "Creating…" : "Create Workspace"}
           </button>
@@ -231,19 +211,17 @@ export default function WorkspacesPage() {
           {["skel-1", "skel-2", "skel-3"].map((k) => (
             <div
               key={k}
-              className="h-24 animate-pulse rounded-xl border border-slate-800 bg-void-light/30"
+              className="bg-void-light/30 h-24 animate-pulse rounded-xl border border-slate-800"
             />
           ))}
         </div>
       )}
 
       {!loading && workspaces.length === 0 && (
-        <div className="rounded-xl border border-slate-800 bg-void-light/30 px-6 py-12 text-center">
+        <div className="bg-void-light/30 rounded-xl border border-slate-800 px-6 py-12 text-center">
           <div className="mb-3 text-4xl">🏢</div>
-          <p className="font-heading text-sm text-slate-400">
-            No workspaces yet.
-          </p>
-          <p className="font-mono mt-1 text-xs text-slate-600">
+          <p className="font-heading text-sm text-slate-400">No workspaces yet.</p>
+          <p className="mt-1 font-mono text-xs text-slate-600">
             Create your first workspace above.
           </p>
         </div>
@@ -257,7 +235,7 @@ export default function WorkspacesPage() {
               className={`rounded-xl border p-4 transition ${
                 ws.id === current?.id
                   ? "border-neon-magenta/30 bg-neon-magenta/5"
-                  : "border-slate-800 bg-void-light/30 hover:border-slate-700"
+                  : "bg-void-light/30 border-slate-800 hover:border-slate-700"
               }`}
             >
               {editingId === ws.id ? (
@@ -266,10 +244,8 @@ export default function WorkspacesPage() {
                     <input
                       type="text"
                       value={editForm.name}
-                      onChange={(e) =>
-                        setEditForm((f) => ({ ...f, name: e.target.value }))
-                      }
-                      className="rounded-lg border border-slate-700 bg-void px-3 py-2 font-mono text-sm text-white focus:border-neon-blue/50 focus:outline-none"
+                      onChange={(e) => setEditForm((f) => ({ ...f, name: e.target.value }))}
+                      className="bg-void focus:border-neon-blue/50 rounded-lg border border-slate-700 px-3 py-2 font-mono text-sm text-white focus:outline-none"
                     />
                     <input
                       type="text"
@@ -281,7 +257,7 @@ export default function WorkspacesPage() {
                         }))
                       }
                       placeholder="admin@acme.com"
-                      className="rounded-lg border border-slate-700 bg-void px-3 py-2 font-mono text-sm text-white focus:border-neon-blue/50 focus:outline-none"
+                      className="bg-void focus:border-neon-blue/50 rounded-lg border border-slate-700 px-3 py-2 font-mono text-sm text-white focus:outline-none"
                     />
                   </div>
                   <input
@@ -293,13 +269,13 @@ export default function WorkspacesPage() {
                         description: e.target.value,
                       }))
                     }
-                    className="w-full rounded-lg border border-slate-700 bg-void px-3 py-2 font-mono text-sm text-white focus:border-neon-blue/50 focus:outline-none"
+                    className="bg-void focus:border-neon-blue/50 w-full rounded-lg border border-slate-700 px-3 py-2 font-mono text-sm text-white focus:outline-none"
                   />
                   <div className="flex gap-2">
                     <button
                       type="button"
                       onClick={() => save(ws.id)}
-                      className="rounded-lg border border-neon-blue/30 px-4 py-1.5 font-mono text-xs text-neon-blue hover:border-neon-blue/60"
+                      className="border-neon-blue/30 text-neon-blue hover:border-neon-blue/60 rounded-lg border px-4 py-1.5 font-mono text-xs"
                     >
                       Save
                     </button>
@@ -316,31 +292,26 @@ export default function WorkspacesPage() {
                 <div className="flex flex-wrap items-start justify-between gap-3">
                   <div>
                     <div className="flex items-center gap-2">
-                      <span className="font-heading font-semibold text-white">
-                        {ws.name}
-                      </span>
+                      <span className="font-heading font-semibold text-white">{ws.name}</span>
                       {ws.id === current?.id && (
-                        <span className="rounded-full border border-neon-magenta/30 bg-neon-magenta/10 px-2 py-0.5 font-mono text-[10px] text-neon-magenta">
+                        <span className="border-neon-magenta/30 bg-neon-magenta/10 text-neon-magenta rounded-full border px-2 py-0.5 font-mono text-[10px]">
                           active
                         </span>
                       )}
                     </div>
-                    <div className="font-mono mt-0.5 text-xs text-slate-500">
+                    <div className="mt-0.5 font-mono text-xs text-slate-500">
                       slug: <span className="text-slate-400">{ws.slug}</span>
                     </div>
                     {ws.description && (
-                      <p className="font-body mt-1 text-xs text-slate-500">
-                        {ws.description}
-                      </p>
+                      <p className="font-body mt-1 text-xs text-slate-500">{ws.description}</p>
                     )}
                     {ws.adminEmails.length > 0 && (
-                      <p className="font-mono mt-1 text-xs text-slate-600">
+                      <p className="mt-1 font-mono text-xs text-slate-600">
                         admins: {ws.adminEmails.join(", ")}
                       </p>
                     )}
-                    <p className="font-mono mt-1 text-xs text-slate-700">
-                      created{" "}
-                      {new Date(ws.createdAt).toLocaleDateString("en-IE")}
+                    <p className="mt-1 font-mono text-xs text-slate-700">
+                      created {new Date(ws.createdAt).toLocaleDateString("en-IE")}
                     </p>
                   </div>
                   <div className="flex gap-2">

--- a/src/app/[locale]/auth/forgot-password/page.tsx
+++ b/src/app/[locale]/auth/forgot-password/page.tsx
@@ -62,14 +62,8 @@ export default function ForgotPasswordPage() {
           </h1>
           <p className="font-body mt-2 text-slate-400">
             {step === "request"
-              ? t(
-                  "auth.resetRequestDesc",
-                  "We'll send a verification code to your email",
-                )
-              : t(
-                  "auth.resetCodeDesc",
-                  "Enter the code sent to {email}",
-                ).replace("{email}", email)}
+              ? t("auth.resetRequestDesc", "We'll send a verification code to your email")
+              : t("auth.resetCodeDesc", "Enter the code sent to {email}").replace("{email}", email)}
           </p>
         </div>
 

--- a/src/app/[locale]/auth/layout.tsx
+++ b/src/app/[locale]/auth/layout.tsx
@@ -1,9 +1,5 @@
 export const dynamic = "force-dynamic";
 
-export default function AuthLayout({
-  children,
-}: {
-  children: React.ReactNode;
-}) {
+export default function AuthLayout({ children }: { children: React.ReactNode }) {
   return <>{children}</>;
 }

--- a/src/app/[locale]/auth/login/page.tsx
+++ b/src/app/[locale]/auth/login/page.tsx
@@ -91,21 +91,14 @@ function LoginContent() {
         <div className="mb-8 text-center">
           <div className="bg-neon-cyan/10 border-neon-cyan/20 mb-4 inline-flex items-center gap-2 rounded-full border px-3 py-1.5">
             <span className="bg-neon-cyan h-2 w-2 animate-pulse rounded-full" />
-            <span className="text-neon-cyan font-mono text-xs">
-              SECURE_AUTH
-            </span>
+            <span className="text-neon-cyan font-mono text-xs">SECURE_AUTH</span>
           </div>
           <h1 className="font-heading text-3xl font-bold text-white">
-            {needsNewPassword
-              ? t("auth.newPassword", "New Password")
-              : t("auth.login", "Sign In")}
+            {needsNewPassword ? t("auth.newPassword", "New Password") : t("auth.login", "Sign In")}
           </h1>
           <p className="font-body mt-2 text-slate-400">
             {needsNewPassword
-              ? t(
-                  "auth.newPasswordDesc",
-                  "You must set a new password before continuing.",
-                )
+              ? t("auth.newPasswordDesc", "You must set a new password before continuing.")
               : t("auth.loginDesc", "Sign in to your Cloudless account")}
           </p>
         </div>
@@ -200,9 +193,7 @@ function LoginContent() {
                 disabled={submitting}
                 className="bg-neon-cyan/10 border-neon-cyan/50 text-neon-cyan hover:bg-neon-cyan/20 min-h-[44px] w-full rounded-lg border py-3 font-mono font-semibold transition-all hover:shadow-[0_0_15px_rgba(0,255,245,0.2)] disabled:opacity-50"
               >
-                {submitting
-                  ? t("auth.signingIn", "Signing In...")
-                  : t("auth.login", "Sign In")}
+                {submitting ? t("auth.signingIn", "Signing In...") : t("auth.login", "Sign In")}
               </button>
             </form>
           )}
@@ -210,10 +201,7 @@ function LoginContent() {
           {!needsNewPassword && (
             <p className="mt-6 text-center font-mono text-sm text-slate-500">
               {t("auth.noAccount", "Don't have an account?")}{" "}
-              <Link
-                href="/auth/signup"
-                className="text-neon-cyan hover:underline"
-              >
+              <Link href="/auth/signup" className="text-neon-cyan hover:underline">
                 {t("auth.signup", "Create Account")}
               </Link>
             </p>

--- a/src/app/[locale]/auth/signup/page.tsx
+++ b/src/app/[locale]/auth/signup/page.tsx
@@ -101,10 +101,10 @@ function SignUpForm() {
           <p className="font-body mt-2 text-slate-400">
             {step === "signup"
               ? t("auth.signupDesc", "Join Cloudless to access your dashboard")
-              : t(
-                  "auth.verifyDesc",
-                  "Enter the verification code sent to {email}",
-                ).replace("{email}", email)}
+              : t("auth.verifyDesc", "Enter the verification code sent to {email}").replace(
+                  "{email}",
+                  email
+                )}
           </p>
         </div>
 
@@ -123,9 +123,7 @@ function SignUpForm() {
                   className="mb-2 block font-mono text-sm text-slate-400"
                 >
                   {t("auth.fullName", "Full Name")}
-                  <span className="ml-1 text-slate-600">
-                    ({t("auth.optional", "optional")})
-                  </span>
+                  <span className="ml-1 text-slate-600">({t("auth.optional", "optional")})</span>
                 </label>
                 <input
                   id="signup-name"

--- a/src/app/[locale]/blog/[slug]/opengraph-image.tsx
+++ b/src/app/[locale]/blog/[slug]/opengraph-image.tsx
@@ -30,8 +30,7 @@ export default async function Image({
   return new ImageResponse(
     <div
       style={{
-        background:
-          "linear-gradient(135deg, #0a0a0f 0%, #12121a 50%, #1a1a2e 100%)",
+        background: "linear-gradient(135deg, #0a0a0f 0%, #12121a 50%, #1a1a2e 100%)",
         width: "100%",
         height: "100%",
         display: "flex",
@@ -123,23 +122,18 @@ export default async function Image({
         }}
       >
         <div style={{ display: "flex", alignItems: "baseline", gap: 6 }}>
-          <span style={{ fontSize: 28, color: "#ffffff", fontWeight: 800 }}>
-            cloudless
-          </span>
-          <span style={{ fontSize: 28, color: "#00fff5", fontWeight: 800 }}>
-            .gr
-          </span>
+          <span style={{ fontSize: 28, color: "#ffffff", fontWeight: 800 }}>cloudless</span>
+          <span style={{ fontSize: 28, color: "#00fff5", fontWeight: 800 }}>.gr</span>
         </div>
         <div
           style={{
             width: 120,
             height: 2,
-            background:
-              "linear-gradient(90deg, transparent, #00fff5, transparent)",
+            background: "linear-gradient(90deg, transparent, #00fff5, transparent)",
           }}
         />
       </div>
     </div>,
-    { width: 1200, height: 630 },
+    { width: 1200, height: 630 }
   );
 }

--- a/src/app/[locale]/blog/[slug]/page.tsx
+++ b/src/app/[locale]/blog/[slug]/page.tsx
@@ -3,11 +3,7 @@ export const dynamic = "force-dynamic";
 import type { Metadata } from "next";
 import { Link } from "@/i18n/navigation";
 import { notFound } from "next/navigation";
-import {
-  posts as staticPosts,
-  getPostBySlug as getStaticPost,
-  formatDate,
-} from "@/lib/blog";
+import { posts as staticPosts, getPostBySlug as getStaticPost, formatDate } from "@/lib/blog";
 import {
   getPostBySlug as getNotionPost,
   getPostWithToc,
@@ -42,7 +38,7 @@ function renderInline(text: string): React.ReactNode[] {
       parts.push(
         <strong key={key++} className="font-semibold text-white">
           {match[2]}
-        </strong>,
+        </strong>
       );
     } else if (match[3]) {
       parts.push(
@@ -51,7 +47,7 @@ function renderInline(text: string): React.ReactNode[] {
           className="text-neon-cyan bg-neon-cyan/5 border-neon-cyan/10 rounded border px-1.5 py-0.5 font-mono text-xs"
         >
           {match[3]}
-        </code>,
+        </code>
       );
     } else if (match[4] && match[5]) {
       parts.push(
@@ -63,7 +59,7 @@ function renderInline(text: string): React.ReactNode[] {
           rel={match[5].startsWith("http") ? "noopener noreferrer" : undefined}
         >
           {match[4]}
-        </a>,
+        </a>
       );
     }
     last = match.index + match[0].length;
@@ -77,9 +73,7 @@ function renderInline(text: string): React.ReactNode[] {
 /** Render a block of text — handles bullet lists and plain paragraphs */
 function renderBlock(block: string, keyPrefix: number) {
   const lines = block.split("\n");
-  const isList = lines.every(
-    (l) => l.trim().startsWith("- ") || l.trim() === "",
-  );
+  const isList = lines.every((l) => l.trim().startsWith("- ") || l.trim() === "");
 
   if (isList) {
     const items = lines.filter((l) => l.trim().startsWith("- "));
@@ -120,7 +114,7 @@ export async function generateStaticParams() {
   const allSlugs = new Set([...notionSlugs, ...staticPosts.map((p) => p.slug)]);
 
   return Array.from(allSlugs).flatMap((slug) =>
-    ["en", "el", "fr"].map((locale) => ({ locale, slug })),
+    ["en", "el", "fr"].map((locale) => ({ locale, slug }))
   );
 }
 
@@ -215,40 +209,30 @@ export default async function BlogPostPage({ params }: Props) {
                 href="/blog"
                 className="hover:text-neon-cyan mb-6 inline-flex items-center gap-2 font-mono text-sm text-slate-500 transition-colors"
               >
-                <svg
-                  width="14"
-                  height="14"
-                  fill="none"
-                  stroke="currentColor"
-                  strokeWidth="2"
-                >
+                <svg width="14" height="14" fill="none" stroke="currentColor" strokeWidth="2">
                   <path d="M11 7H3M7 3L3 7l4 4" />
                 </svg>
                 Back to Blog
               </Link>
-              {notionPost.coverImage &&
-                notionPost.coverImage.startsWith("http") && (
-                  <div className="mb-6 overflow-hidden rounded-xl">
-                    {/* eslint-disable-next-line @next/next/no-img-element */}
-                    <img
-                      src={notionPost.coverImage}
-                      alt={notionPost.title}
-                      className="h-56 w-full object-cover md:h-72"
-                      onError={(e) => {
-                        (e.currentTarget as HTMLImageElement).style.display =
-                          "none";
-                      }}
-                    />
-                  </div>
-                )}
+              {notionPost.coverImage && notionPost.coverImage.startsWith("http") && (
+                <div className="mb-6 overflow-hidden rounded-xl">
+                  {/* eslint-disable-next-line @next/next/no-img-element */}
+                  <img
+                    src={notionPost.coverImage}
+                    alt={notionPost.title}
+                    className="h-56 w-full object-cover md:h-72"
+                    onError={(e) => {
+                      (e.currentTarget as HTMLImageElement).style.display = "none";
+                    }}
+                  />
+                </div>
+              )}
               <div className="mb-4 flex items-center gap-3">
                 <span className="bg-neon-cyan/10 text-neon-cyan border-neon-cyan/20 rounded-full border px-3 py-1 font-mono text-[10px] font-medium">
                   {notionPost.category || "Blog"}
                 </span>
                 {notionPost.readTime && (
-                  <span className="font-mono text-xs text-slate-600">
-                    {notionPost.readTime}
-                  </span>
+                  <span className="font-mono text-xs text-slate-600">{notionPost.readTime}</span>
                 )}
               </div>
               <h1 className="font-heading animate-fade-in-up text-3xl leading-tight font-bold md:text-4xl lg:text-5xl">
@@ -259,9 +243,7 @@ export default async function BlogPostPage({ params }: Props) {
                   {formatDate(notionPost.date)}
                 </time>
                 {notionPost.author && (
-                  <span className="font-mono text-sm text-slate-500">
-                    by {notionPost.author}
-                  </span>
+                  <span className="font-mono text-sm text-slate-500">by {notionPost.author}</span>
                 )}
               </div>
               {notionPost.tags.length > 0 && (
@@ -270,7 +252,7 @@ export default async function BlogPostPage({ params }: Props) {
                     <Link
                       key={tag}
                       href={`/blog?tag=${encodeURIComponent(tag)}`}
-                      className="rounded border border-slate-700 bg-slate-800/50 px-2.5 py-0.5 font-mono text-[10px] text-slate-500 transition-colors hover:border-neon-cyan/30 hover:text-neon-cyan"
+                      className="hover:border-neon-cyan/30 hover:text-neon-cyan rounded border border-slate-700 bg-slate-800/50 px-2.5 py-0.5 font-mono text-[10px] text-slate-500 transition-colors"
                     >
                       {tag}
                     </Link>
@@ -306,10 +288,10 @@ export default async function BlogPostPage({ params }: Props) {
                           <li key={entry.blockId}>
                             <a
                               href={`#${entry.blockId}`}
-                              className={`block border-l-2 border-transparent py-1 text-sm transition-colors hover:border-neon-cyan/50 hover:text-slate-200 ${
+                              className={`hover:border-neon-cyan/50 block border-l-2 border-transparent py-1 text-sm transition-colors hover:text-slate-200 ${
                                 entry.level === 2
                                   ? "pl-4 text-slate-400"
-                                  : "pl-7 text-slate-500 text-xs"
+                                  : "pl-7 text-xs text-slate-500"
                               }`}
                             >
                               {entry.text}
@@ -325,9 +307,7 @@ export default async function BlogPostPage({ params }: Props) {
               {/* Related Posts */}
               {related.length > 0 && (
                 <div className="mx-auto mt-16 max-w-3xl">
-                  <h2 className="font-heading mb-6 text-xl font-bold text-white">
-                    Related Posts
-                  </h2>
+                  <h2 className="font-heading mb-6 text-xl font-bold text-white">Related Posts</h2>
                   <div className="grid grid-cols-1 gap-4 sm:grid-cols-3">
                     {related.map((rp) => (
                       <Link
@@ -343,12 +323,10 @@ export default async function BlogPostPage({ params }: Props) {
                         >
                           {rp.category}
                         </span>
-                        <h3 className="font-heading group-hover:text-neon-cyan text-sm font-semibold text-white transition-colors line-clamp-2">
+                        <h3 className="font-heading group-hover:text-neon-cyan line-clamp-2 text-sm font-semibold text-white transition-colors">
                           {rp.title}
                         </h3>
-                        <p className="mt-1.5 text-xs text-slate-500 line-clamp-2">
-                          {rp.excerpt}
-                        </p>
+                        <p className="mt-1.5 line-clamp-2 text-xs text-slate-500">{rp.excerpt}</p>
                       </Link>
                     ))}
                   </div>
@@ -362,8 +340,7 @@ export default async function BlogPostPage({ params }: Props) {
                     Need help implementing this?
                   </h3>
                   <p className="mt-2 text-sm text-slate-400">
-                    Book a free 30-minute audit and we&apos;ll show you exactly
-                    where to start.
+                    Book a free 30-minute audit and we&apos;ll show you exactly where to start.
                   </p>
                   <Link
                     href="/contact"
@@ -415,13 +392,7 @@ export default async function BlogPostPage({ params }: Props) {
             href="/blog"
             className="hover:text-neon-cyan mb-6 inline-flex items-center gap-2 font-mono text-sm text-slate-500 transition-colors"
           >
-            <svg
-              width="14"
-              height="14"
-              fill="none"
-              stroke="currentColor"
-              strokeWidth="2"
-            >
+            <svg width="14" height="14" fill="none" stroke="currentColor" strokeWidth="2">
               <path d="M11 7H3M7 3L3 7l4 4" />
             </svg>
             Back to Blog
@@ -430,9 +401,7 @@ export default async function BlogPostPage({ params }: Props) {
             <span className="bg-neon-cyan/10 text-neon-cyan border-neon-cyan/20 rounded-full border px-3 py-1 font-mono text-[10px] font-medium">
               {post.category}
             </span>
-            <span className="font-mono text-xs text-slate-600">
-              {post.readTime}
-            </span>
+            <span className="font-mono text-xs text-slate-600">{post.readTime}</span>
           </div>
           <h1 className="font-heading animate-fade-in-up text-3xl leading-tight font-bold md:text-4xl lg:text-5xl">
             {post.title}
@@ -476,8 +445,7 @@ export default async function BlogPostPage({ params }: Props) {
               Need help implementing this?
             </h3>
             <p className="mt-2 text-sm text-slate-400">
-              Book a free 30-minute audit and we&apos;ll show you exactly where
-              to start.
+              Book a free 30-minute audit and we&apos;ll show you exactly where to start.
             </p>
             <Link
               href="/contact"

--- a/src/app/[locale]/blog/error.tsx
+++ b/src/app/[locale]/blog/error.tsx
@@ -18,9 +18,7 @@ export default function BlogError({
     <section className="bg-void flex flex-1 items-center justify-center px-6 py-24">
       <div className="max-w-md text-center">
         <p className="text-neon-magenta font-mono text-5xl font-bold">ERROR</p>
-        <h1 className="font-heading mt-4 text-2xl font-bold text-white">
-          Blog error
-        </h1>
+        <h1 className="font-heading mt-4 text-2xl font-bold text-white">Blog error</h1>
         <p className="mt-3 font-mono text-sm text-slate-400">
           Something went wrong loading the blog. Please try again.
         </p>

--- a/src/app/[locale]/blog/loading.tsx
+++ b/src/app/[locale]/blog/loading.tsx
@@ -30,14 +30,11 @@ export default function BlogLoading() {
           </div>
 
           {/* Sidebar skeleton */}
-          <div className="hidden lg:block space-y-6">
+          <div className="hidden space-y-6 lg:block">
             <div className="bg-void-light/30 animate-pulse rounded-xl border border-slate-800 p-6">
               <div className="bg-void-light/50 mb-4 h-4 w-24 rounded" />
               {Array.from({ length: 5 }).map((_, i) => (
-                <div
-                  key={i}
-                  className="bg-void-light/50 mb-2 h-4 w-full rounded"
-                />
+                <div key={i} className="bg-void-light/50 mb-2 h-4 w-full rounded" />
               ))}
             </div>
           </div>

--- a/src/app/[locale]/blog/opengraph-image.tsx
+++ b/src/app/[locale]/blog/opengraph-image.tsx
@@ -8,8 +8,7 @@ export default function Image() {
   return new ImageResponse(
     <div
       style={{
-        background:
-          "linear-gradient(135deg, #0a0a0f 0%, #12121a 50%, #1a1a2e 100%)",
+        background: "linear-gradient(135deg, #0a0a0f 0%, #12121a 50%, #1a1a2e 100%)",
         width: "100%",
         height: "100%",
         display: "flex",
@@ -101,8 +100,7 @@ export default function Image() {
           maxWidth: 700,
         }}
       >
-        Cloud strategies, web development tips, and digital transformation
-        insights
+        Cloud strategies, web development tips, and digital transformation insights
       </div>
 
       {/* Footer */}
@@ -115,23 +113,18 @@ export default function Image() {
         }}
       >
         <div style={{ display: "flex", alignItems: "baseline", gap: 6 }}>
-          <span style={{ fontSize: 28, color: "#ffffff", fontWeight: 800 }}>
-            cloudless
-          </span>
-          <span style={{ fontSize: 28, color: "#00fff5", fontWeight: 800 }}>
-            .gr
-          </span>
+          <span style={{ fontSize: 28, color: "#ffffff", fontWeight: 800 }}>cloudless</span>
+          <span style={{ fontSize: 28, color: "#00fff5", fontWeight: 800 }}>.gr</span>
         </div>
         <div
           style={{
             width: 120,
             height: 2,
-            background:
-              "linear-gradient(90deg, transparent, #00fff5, transparent)",
+            background: "linear-gradient(90deg, transparent, #00fff5, transparent)",
           }}
         />
       </div>
     </div>,
-    { width: 1200, height: 630 },
+    { width: 1200, height: 630 }
   );
 }

--- a/src/app/[locale]/blog/page.tsx
+++ b/src/app/[locale]/blog/page.tsx
@@ -25,12 +25,10 @@ export const metadata: Metadata = {
 const categoryColors: Record<string, string> = {
   Cloud: "bg-neon-cyan/10 text-neon-cyan border border-neon-cyan/20",
   Serverless: "bg-neon-green/10 text-neon-green border border-neon-green/20",
-  Analytics:
-    "bg-neon-magenta/10 text-neon-magenta border border-neon-magenta/20",
+  Analytics: "bg-neon-magenta/10 text-neon-magenta border border-neon-magenta/20",
   "AI Marketing": "bg-neon-blue/10 text-neon-blue border border-neon-blue/20",
   DevOps: "bg-neon-green/10 text-neon-green border border-neon-green/20",
-  Security:
-    "bg-neon-magenta/10 text-neon-magenta border border-neon-magenta/20",
+  Security: "bg-neon-magenta/10 text-neon-magenta border border-neon-magenta/20",
   Architecture: "bg-neon-cyan/10 text-neon-cyan border border-neon-cyan/20",
 };
 
@@ -38,26 +36,15 @@ const PER_PAGE = 10;
 
 type SearchParams = Promise<{ [key: string]: string | string[] | undefined }>;
 
-export default async function BlogPage({
-  searchParams,
-}: {
-  searchParams: SearchParams;
-}) {
+export default async function BlogPage({ searchParams }: { searchParams: SearchParams }) {
   const locale = await getServerLocale();
   const t = (key: string, fallback: string) => translate(locale, key, fallback);
   const resolvedParams = await searchParams;
-  const currentPage = Math.max(
-    1,
-    parseInt(String(resolvedParams.page ?? "1"), 10) || 1,
-  );
+  const currentPage = Math.max(1, parseInt(String(resolvedParams.page ?? "1"), 10) || 1);
   const activeCategory =
-    typeof resolvedParams.category === "string"
-      ? resolvedParams.category
-      : null;
-  const activeTag =
-    typeof resolvedParams.tag === "string" ? resolvedParams.tag : null;
-  const searchQuery =
-    typeof resolvedParams.q === "string" ? resolvedParams.q : "";
+    typeof resolvedParams.category === "string" ? resolvedParams.category : null;
+  const activeTag = typeof resolvedParams.tag === "string" ? resolvedParams.tag : null;
+  const searchQuery = typeof resolvedParams.q === "string" ? resolvedParams.q : "";
 
   // Fetch from Notion when configured, otherwise fall back to static posts
   const useNotion = isConfigured("NOTION_API_KEY", "NOTION_BLOG_DB_ID");
@@ -103,7 +90,7 @@ export default async function BlogPage({
       (p) =>
         p.title.toLowerCase().includes(q) ||
         p.excerpt.toLowerCase().includes(q) ||
-        p.tags.some((t) => t.toLowerCase().includes(q)),
+        p.tags.some((t) => t.toLowerCase().includes(q))
     );
   }
 
@@ -118,10 +105,7 @@ export default async function BlogPage({
   // Pagination
   const total = filteredPosts.length;
   const totalPages = Math.ceil(total / PER_PAGE);
-  const posts = filteredPosts.slice(
-    (currentPage - 1) * PER_PAGE,
-    currentPage * PER_PAGE,
-  );
+  const posts = filteredPosts.slice((currentPage - 1) * PER_PAGE, currentPage * PER_PAGE);
 
   const categories = Object.entries(categoryCounts).sort((a, b) => b[1] - a[1]);
   const tags = Object.entries(tagCounts).sort((a, b) => b[1] - a[1]);
@@ -178,26 +162,22 @@ export default async function BlogPage({
           <p className="animate-fade-in-up mt-6 max-w-xl text-lg text-slate-400 delay-200">
             {t(
               "blog.subtitle",
-              "Cloud architecture, serverless, analytics, and AI marketing — written for founders and technical teams who want to move fast.",
+              "Cloud architecture, serverless, analytics, and AI marketing — written for founders and technical teams who want to move fast."
             )}
           </p>
 
           {/* Search bar */}
-          <form
-            action=""
-            method="get"
-            className="animate-scale-in mt-8 max-w-md delay-300"
-          >
+          <form action="" method="get" className="animate-scale-in mt-8 max-w-md delay-300">
             <div className="relative">
               <input
                 type="text"
                 name="q"
                 defaultValue={searchQuery}
                 placeholder={t("blog.searchPlaceholder", "Search posts…")}
-                className="w-full rounded-lg border border-slate-700 bg-void-light/50 px-4 py-2.5 pl-10 font-mono text-sm text-white placeholder-slate-600 backdrop-blur-sm transition-colors focus:border-neon-cyan/50 focus:outline-none"
+                className="bg-void-light/50 focus:border-neon-cyan/50 w-full rounded-lg border border-slate-700 px-4 py-2.5 pl-10 font-mono text-sm text-white placeholder-slate-600 backdrop-blur-sm transition-colors focus:outline-none"
               />
               <svg
-                className="absolute left-3 top-1/2 -translate-y-1/2 text-slate-600"
+                className="absolute top-1/2 left-3 -translate-y-1/2 text-slate-600"
                 width="16"
                 height="16"
                 fill="none"
@@ -227,7 +207,7 @@ export default async function BlogPage({
                   {searchQuery && (
                     <Link
                       href={filterUrl({ q: null })}
-                      className="inline-flex items-center gap-1 rounded-full border border-neon-cyan/20 bg-neon-cyan/10 px-2.5 py-1 font-mono text-xs text-neon-cyan transition-colors hover:bg-neon-cyan/20"
+                      className="border-neon-cyan/20 bg-neon-cyan/10 text-neon-cyan hover:bg-neon-cyan/20 inline-flex items-center gap-1 rounded-full border px-2.5 py-1 font-mono text-xs transition-colors"
                     >
                       &quot;{searchQuery}&quot; ✕
                     </Link>
@@ -235,7 +215,7 @@ export default async function BlogPage({
                   {activeCategory && (
                     <Link
                       href={filterUrl({ category: null })}
-                      className="inline-flex items-center gap-1 rounded-full border border-neon-cyan/20 bg-neon-cyan/10 px-2.5 py-1 font-mono text-xs text-neon-cyan transition-colors hover:bg-neon-cyan/20"
+                      className="border-neon-cyan/20 bg-neon-cyan/10 text-neon-cyan hover:bg-neon-cyan/20 inline-flex items-center gap-1 rounded-full border px-2.5 py-1 font-mono text-xs transition-colors"
                     >
                       {activeCategory} ✕
                     </Link>
@@ -243,7 +223,7 @@ export default async function BlogPage({
                   {activeTag && (
                     <Link
                       href={filterUrl({ tag: null })}
-                      className="inline-flex items-center gap-1 rounded-full border border-neon-magenta/20 bg-neon-magenta/10 px-2.5 py-1 font-mono text-xs text-neon-magenta transition-colors hover:bg-neon-magenta/20"
+                      className="border-neon-magenta/20 bg-neon-magenta/10 text-neon-magenta hover:bg-neon-magenta/20 inline-flex items-center gap-1 rounded-full border px-2.5 py-1 font-mono text-xs transition-colors"
                     >
                       #{activeTag} ✕
                     </Link>
@@ -260,15 +240,12 @@ export default async function BlogPage({
               {/* Results count */}
               {filteredPosts.length !== allPosts.length && (
                 <p className="mb-4 font-mono text-xs text-slate-500">
-                  {total}{" "}
-                  {total !== 1
-                    ? t("blog.results", "results")
-                    : t("blog.result", "result")}
+                  {total} {total !== 1 ? t("blog.results", "results") : t("blog.result", "result")}
                 </p>
               )}
 
               {posts.length === 0 ? (
-                <div className="rounded-xl border border-slate-800 bg-void-light/30 p-12 text-center">
+                <div className="bg-void-light/30 rounded-xl border border-slate-800 p-12 text-center">
                   <p className="font-mono text-slate-500">
                     {t("blog.noPostsFound", "No posts found.")}
                   </p>
@@ -306,9 +283,7 @@ export default async function BlogPage({
                           >
                             {post.category}
                           </span>
-                          <span className="font-mono text-xs text-slate-600">
-                            {post.readTime}
-                          </span>
+                          <span className="font-mono text-xs text-slate-600">{post.readTime}</span>
                         </div>
                         <h2 className="font-heading group-hover:text-neon-cyan text-xl font-bold text-white transition-colors">
                           {post.title}
@@ -364,30 +339,28 @@ export default async function BlogPage({
                   {currentPage > 1 && (
                     <Link
                       href={pageUrl(currentPage - 1)}
-                      className="rounded-lg border border-slate-700 px-3 py-2 font-mono text-xs text-slate-400 transition-colors hover:border-neon-cyan/30 hover:text-neon-cyan"
+                      className="hover:border-neon-cyan/30 hover:text-neon-cyan rounded-lg border border-slate-700 px-3 py-2 font-mono text-xs text-slate-400 transition-colors"
                     >
                       {t("blog.prevPage", "← Prev")}
                     </Link>
                   )}
-                  {Array.from({ length: totalPages }, (_, i) => i + 1).map(
-                    (page) => (
-                      <Link
-                        key={page}
-                        href={pageUrl(page)}
-                        className={`rounded-lg border px-3 py-2 font-mono text-xs transition-colors ${
-                          page === currentPage
-                            ? "border-neon-cyan/50 bg-neon-cyan/10 text-neon-cyan"
-                            : "border-slate-700 text-slate-500 hover:border-slate-600 hover:text-slate-300"
-                        }`}
-                      >
-                        {page}
-                      </Link>
-                    ),
-                  )}
+                  {Array.from({ length: totalPages }, (_, i) => i + 1).map((page) => (
+                    <Link
+                      key={page}
+                      href={pageUrl(page)}
+                      className={`rounded-lg border px-3 py-2 font-mono text-xs transition-colors ${
+                        page === currentPage
+                          ? "border-neon-cyan/50 bg-neon-cyan/10 text-neon-cyan"
+                          : "border-slate-700 text-slate-500 hover:border-slate-600 hover:text-slate-300"
+                      }`}
+                    >
+                      {page}
+                    </Link>
+                  ))}
                   {currentPage < totalPages && (
                     <Link
                       href={pageUrl(currentPage + 1)}
-                      className="rounded-lg border border-slate-700 px-3 py-2 font-mono text-xs text-slate-400 transition-colors hover:border-neon-cyan/30 hover:text-neon-cyan"
+                      className="hover:border-neon-cyan/30 hover:text-neon-cyan rounded-lg border border-slate-700 px-3 py-2 font-mono text-xs text-slate-400 transition-colors"
                     >
                       {t("blog.nextPage", "Next →")}
                     </Link>
@@ -413,16 +386,14 @@ export default async function BlogPage({
                               href={filterUrl({
                                 category: activeCategory === cat ? null : cat,
                               })}
-                              className={`flex items-center justify-between rounded px-2 py-1.5 font-body text-sm transition-colors ${
+                              className={`font-body flex items-center justify-between rounded px-2 py-1.5 text-sm transition-colors ${
                                 activeCategory === cat
                                   ? "text-neon-cyan bg-neon-cyan/5"
                                   : "text-slate-400 hover:text-slate-200"
                               }`}
                             >
                               <span>{cat}</span>
-                              <span className="font-mono text-[10px] text-slate-600">
-                                {count}
-                              </span>
+                              <span className="font-mono text-[10px] text-slate-600">{count}</span>
                             </Link>
                           </li>
                         ))}

--- a/src/app/[locale]/case-studies/[slug]/page.tsx
+++ b/src/app/[locale]/case-studies/[slug]/page.tsx
@@ -24,13 +24,8 @@ const BASE_URL = "https://cloudless.gr";
 
 export async function generateStaticParams() {
   try {
-    const configured = await isConfiguredAsync(
-      "NOTION_API_KEY",
-      "NOTION_CASE_STUDIES_DB_ID",
-    );
-    const slugs = configured
-      ? await getAllCaseStudySlugs()
-      : staticCaseStudies.map((c) => c.slug);
+    const configured = await isConfiguredAsync("NOTION_API_KEY", "NOTION_CASE_STUDIES_DB_ID");
+    const slugs = configured ? await getAllCaseStudySlugs() : staticCaseStudies.map((c) => c.slug);
     return slugs.map((slug) => ({ slug }));
   } catch {
     return staticCaseStudies.map((c) => ({ slug: c.slug }));
@@ -78,14 +73,9 @@ export async function generateMetadata({
 // Data loading
 // ---------------------------------------------------------------------------
 
-async function loadCaseStudy(
-  slug: string,
-): Promise<CaseStudyWithContent | null> {
+async function loadCaseStudy(slug: string): Promise<CaseStudyWithContent | null> {
   try {
-    const configured = await isConfiguredAsync(
-      "NOTION_API_KEY",
-      "NOTION_CASE_STUDIES_DB_ID",
-    );
+    const configured = await isConfiguredAsync("NOTION_API_KEY", "NOTION_CASE_STUDIES_DB_ID");
     if (configured) return await getCaseStudyBySlug(slug);
     const cs = staticCaseStudies.find((c) => c.slug === slug);
     return cs ? { ...cs, html: "" } : null;
@@ -99,11 +89,7 @@ async function loadCaseStudy(
 // Page
 // ---------------------------------------------------------------------------
 
-export default async function CaseStudyPage({
-  params,
-}: {
-  params: Promise<{ slug: string }>;
-}) {
+export default async function CaseStudyPage({ params }: { params: Promise<{ slug: string }> }) {
   const { slug } = await params;
   const cs = await loadCaseStudy(slug);
   if (!cs) notFound();
@@ -118,7 +104,7 @@ export default async function CaseStudyPage({
         ])}
       />
       {/* Hero */}
-      <section className="px-4 pb-12 pt-24">
+      <section className="px-4 pt-24 pb-12">
         <div className="mx-auto max-w-4xl">
           <ScrollReveal>
             <Link
@@ -173,9 +159,7 @@ export default async function CaseStudyPage({
                   key={m.label}
                   className="rounded-2xl border border-[#00fff5]/20 bg-[#00fff5]/5 p-6 text-center"
                 >
-                  <div className="mb-1 text-3xl font-bold text-[#00fff5]">
-                    {m.value}
-                  </div>
+                  <div className="mb-1 text-3xl font-bold text-[#00fff5]">{m.value}</div>
                   <div className="text-sm text-gray-400">{m.label}</div>
                 </div>
               ))}
@@ -199,9 +183,7 @@ export default async function CaseStudyPage({
             {cs.challenge && (
               <ScrollReveal>
                 <div className="rounded-2xl border border-white/10 bg-white/5 p-8">
-                  <h2 className="mb-4 text-2xl font-bold text-[#00fff5]">
-                    The Challenge
-                  </h2>
+                  <h2 className="mb-4 text-2xl font-bold text-[#00fff5]">The Challenge</h2>
                   <p className="text-gray-300">{cs.challenge}</p>
                 </div>
               </ScrollReveal>
@@ -210,9 +192,7 @@ export default async function CaseStudyPage({
             {cs.solution && (
               <ScrollReveal>
                 <div className="rounded-2xl border border-white/10 bg-white/5 p-8">
-                  <h2 className="mb-4 text-2xl font-bold text-[#00fff5]">
-                    Our Approach
-                  </h2>
+                  <h2 className="mb-4 text-2xl font-bold text-[#00fff5]">Our Approach</h2>
                   <p className="text-gray-300">{cs.solution}</p>
                 </div>
               </ScrollReveal>
@@ -221,9 +201,7 @@ export default async function CaseStudyPage({
             {cs.results && (
               <ScrollReveal>
                 <div className="rounded-2xl border border-[#00fff5]/20 bg-[#00fff5]/5 p-8">
-                  <h2 className="mb-4 text-2xl font-bold text-[#00fff5]">
-                    Results
-                  </h2>
+                  <h2 className="mb-4 text-2xl font-bold text-[#00fff5]">Results</h2>
                   <p className="text-gray-300">{cs.results}</p>
                 </div>
               </ScrollReveal>
@@ -236,8 +214,7 @@ export default async function CaseStudyPage({
           <div className="mt-16 rounded-2xl border border-[#00fff5]/20 bg-[#00fff5]/5 p-8 text-center">
             <h2 className="mb-3 text-2xl font-bold">Want similar results?</h2>
             <p className="mb-6 text-gray-400">
-              Book a free 30-minute call and let&apos;s talk about your cloud
-              setup.
+              Book a free 30-minute call and let&apos;s talk about your cloud setup.
             </p>
             <Link
               href="/contact"

--- a/src/app/[locale]/case-studies/page.tsx
+++ b/src/app/[locale]/case-studies/page.tsx
@@ -5,11 +5,7 @@ import type { Metadata } from "next";
 import Image from "next/image";
 import { Link } from "@/i18n/navigation";
 import ScrollReveal from "@/components/ScrollReveal";
-import {
-  getCaseStudies,
-  staticCaseStudies,
-  type CaseStudy,
-} from "@/lib/notion-case-studies";
+import { getCaseStudies, staticCaseStudies, type CaseStudy } from "@/lib/notion-case-studies";
 import { isConfiguredAsync } from "@/lib/integrations";
 
 const BASE_URL = "https://cloudless.gr";
@@ -39,10 +35,7 @@ export const metadata: Metadata = {
 
 async function loadCaseStudies(): Promise<CaseStudy[]> {
   try {
-    const configured = await isConfiguredAsync(
-      "NOTION_API_KEY",
-      "NOTION_CASE_STUDIES_DB_ID",
-    );
+    const configured = await isConfiguredAsync("NOTION_API_KEY", "NOTION_CASE_STUDIES_DB_ID");
     return configured ? await getCaseStudies() : staticCaseStudies;
   } catch {
     return staticCaseStudies;
@@ -79,10 +72,7 @@ function CaseStudyCard({ cs }: { cs: CaseStudy }) {
 
         <div className="mb-2 flex flex-wrap gap-2">
           {cs.services.map((s) => (
-            <span
-              key={s}
-              className="rounded-full bg-[#00fff5]/10 px-3 py-1 text-xs text-[#00fff5]"
-            >
+            <span key={s} className="rounded-full bg-[#00fff5]/10 px-3 py-1 text-xs text-[#00fff5]">
               {s}
             </span>
           ))}
@@ -91,9 +81,7 @@ function CaseStudyCard({ cs }: { cs: CaseStudy }) {
           </span>
         </div>
 
-        <h2 className="mb-2 text-xl font-bold text-white group-hover:text-[#00fff5]">
-          {cs.title}
-        </h2>
+        <h2 className="mb-2 text-xl font-bold text-white group-hover:text-[#00fff5]">{cs.title}</h2>
         <p className="mb-4 flex-1 text-sm text-gray-400">{cs.summary}</p>
 
         {cs.metrics.length > 0 && (
@@ -114,16 +102,15 @@ export default async function CaseStudiesPage() {
   return (
     <main className="min-h-screen bg-[#0a0a0f] text-white">
       {/* Hero */}
-      <section className="px-4 pb-16 pt-24 text-center">
+      <section className="px-4 pt-24 pb-16 text-center">
         <ScrollReveal>
           <span className="mb-4 inline-block rounded-full border border-[#00fff5]/30 bg-[#00fff5]/10 px-4 py-1 text-sm text-[#00fff5]">
             Results that speak for themselves
           </span>
           <h1 className="mb-4 text-4xl font-bold md:text-5xl">Case Studies</h1>
           <p className="mx-auto max-w-2xl text-lg text-gray-400">
-            Real engagements, real numbers. Here&apos;s how Cloudless helped
-            businesses reduce cloud spend, modernise infrastructure, and ship
-            faster.
+            Real engagements, real numbers. Here&apos;s how Cloudless helped businesses reduce cloud
+            spend, modernise infrastructure, and ship faster.
           </p>
         </ScrollReveal>
       </section>
@@ -134,10 +121,7 @@ export default async function CaseStudiesPage() {
           <ScrollReveal>
             <div className="rounded-2xl border border-white/10 bg-white/5 p-12 text-center">
               <p className="text-gray-400">Case studies coming soon.</p>
-              <Link
-                href="/contact"
-                className="mt-4 inline-block text-[#00fff5] hover:underline"
-              >
+              <Link href="/contact" className="mt-4 inline-block text-[#00fff5] hover:underline">
                 Book a free consultation →
               </Link>
             </div>

--- a/src/app/[locale]/contact/opengraph-image.tsx
+++ b/src/app/[locale]/contact/opengraph-image.tsx
@@ -39,8 +39,7 @@ export default function ContactOGImage() {
           right: "-60px",
           width: "520px",
           height: "520px",
-          background:
-            "radial-gradient(circle, rgba(0,212,255,0.10) 0%, transparent 65%)",
+          background: "radial-gradient(circle, rgba(0,212,255,0.10) 0%, transparent 65%)",
           borderRadius: "50%",
         }}
       />
@@ -146,6 +145,6 @@ export default function ContactOGImage() {
         </span>
       </div>
     </div>,
-    { ...size },
+    { ...size }
   );
 }

--- a/src/app/[locale]/contact/page.tsx
+++ b/src/app/[locale]/contact/page.tsx
@@ -32,13 +32,13 @@ export default async function ContactPage() {
           <p className="animate-shimmer-text mb-3 font-mono text-xs font-medium tracking-[0.3em]">
             [ CONTACT ]
           </p>
-          <h1 className="animate-fade-in-up delay-100 font-heading text-3xl leading-tight font-bold md:text-5xl">
+          <h1 className="animate-fade-in-up font-heading text-3xl leading-tight font-bold delay-100 md:text-5xl">
             {t("contact.title", "Get in Touch")}
           </h1>
-          <p className="animate-fade-in-up delay-200 mt-4 max-w-xl text-lg text-slate-400">
+          <p className="animate-fade-in-up mt-4 max-w-xl text-lg text-slate-400 delay-200">
             {t(
               "contact.subtitle",
-              "Ready to go cloudless? Tell us about your project and we'll get back to you within 24 hours.",
+              "Ready to go cloudless? Tell us about your project and we'll get back to you within 24 hours."
             )}
           </p>
         </div>

--- a/src/app/[locale]/cookies/CookiePolicyPageClient.tsx
+++ b/src/app/[locale]/cookies/CookiePolicyPageClient.tsx
@@ -19,12 +19,8 @@ function Section({
 }) {
   return (
     <section id={id} className="scroll-mt-24">
-      <h2 className="text-neon-cyan/80 mb-4 font-heading text-xl font-bold text-white">
-        {title}
-      </h2>
-      <div className="space-y-3 text-sm leading-relaxed text-slate-300">
-        {children}
-      </div>
+      <h2 className="text-neon-cyan/80 font-heading mb-4 text-xl font-bold text-white">{title}</h2>
+      <div className="space-y-3 text-sm leading-relaxed text-slate-300">{children}</div>
     </section>
   );
 }
@@ -81,7 +77,7 @@ export default function CookiePolicyPage() {
             <p className="text-neon-cyan/70 mb-4 font-mono text-xs tracking-widest">
               {t("legal.legalDocument", "LEGAL DOCUMENT")}
             </p>
-            <h1 className="mb-4 font-heading text-3xl font-bold text-white lg:text-4xl">
+            <h1 className="font-heading mb-4 text-3xl font-bold text-white lg:text-4xl">
               {t("legal.cookiePolicyTitle", "Cookie Policy")}
             </h1>
             <p className="mb-2 font-mono text-xs text-slate-500">
@@ -90,7 +86,7 @@ export default function CookiePolicyPage() {
             <p className="mb-12 text-sm leading-relaxed text-slate-400">
               {t(
                 "legal.cookiePolicyIntro",
-                "This Cookie Policy explains what cookies are, how Cloudless uses them on cloudless.gr, and how you can manage your preferences. It complements our Privacy Policy and complies with the EU ePrivacy Directive (2002/58/EC) and GDPR.",
+                "This Cookie Policy explains what cookies are, how Cloudless uses them on cloudless.gr, and how you can manage your preferences. It complements our Privacy Policy and complies with the EU ePrivacy Directive (2002/58/EC) and GDPR."
               )}
             </p>
           </ScrollReveal>
@@ -104,7 +100,7 @@ export default function CookiePolicyPage() {
                 <p>
                   {t(
                     "legal.whatAreCookies",
-                    'Cookies are small text files stored on your device when you visit a website. They help the site remember your preferences, understand how you use it, and improve your experience. Cookies may be "session" (deleted when you close your browser) or "persistent" (stored for a set period).',
+                    'Cookies are small text files stored on your device when you visit a website. They help the site remember your preferences, understand how you use it, and improve your experience. Cookies may be "session" (deleted when you close your browser) or "persistent" (stored for a set period).'
                   )}
                 </p>
               </Section>
@@ -121,7 +117,7 @@ export default function CookiePolicyPage() {
                 <p>
                   {t(
                     "legal.necessaryCookiesDesc",
-                    "Required for the website to function. They enable core features like page navigation, secure areas, and consent management. These cannot be disabled.",
+                    "Required for the website to function. They enable core features like page navigation, secure areas, and consent management. These cannot be disabled."
                   )}
                 </p>
                 <p className="font-semibold text-white">
@@ -130,7 +126,7 @@ export default function CookiePolicyPage() {
                 <p>
                   {t(
                     "legal.analyticsCookiesDesc",
-                    "Help us understand how visitors interact with our site by collecting anonymised data about page visits, traffic sources, and user behaviour. Only set with your explicit consent.",
+                    "Help us understand how visitors interact with our site by collecting anonymised data about page visits, traffic sources, and user behaviour. Only set with your explicit consent."
                   )}
                 </p>
                 <p className="font-semibold text-white">
@@ -139,7 +135,7 @@ export default function CookiePolicyPage() {
                 <p>
                   {t(
                     "legal.marketingCookiesDesc",
-                    "Used to track visitors across websites and display relevant advertisements. These cookies help measure the effectiveness of advertising campaigns. Only set with your explicit consent.",
+                    "Used to track visitors across websites and display relevant advertisements. These cookies help measure the effectiveness of advertising campaigns. Only set with your explicit consent."
                   )}
                 </p>
               </Section>
@@ -193,7 +189,7 @@ export default function CookiePolicyPage() {
                 <p className="mt-3 text-xs text-slate-500">
                   {t(
                     "legal.cookieTableNote",
-                    "This table will be updated as we add analytics or marketing integrations. Currently, no third-party analytics or marketing cookies are set.",
+                    "This table will be updated as we add analytics or marketing integrations. Currently, no third-party analytics or marketing cookies are set."
                   )}
                 </p>
               </Section>
@@ -202,15 +198,12 @@ export default function CookiePolicyPage() {
             <ScrollReveal>
               <Section
                 id="manage-cookies"
-                title={t(
-                  "legal.manageCookiesTitle",
-                  "4. Managing Your Preferences",
-                )}
+                title={t("legal.manageCookiesTitle", "4. Managing Your Preferences")}
               >
                 <p>
                   {t(
                     "legal.manageCookies",
-                    'You can change your cookie preferences at any time by clicking the button below, or via the "Cookie Settings" link in our website footer.',
+                    'You can change your cookie preferences at any time by clicking the button below, or via the "Cookie Settings" link in our website footer.'
                   )}
                 </p>
                 <button
@@ -223,32 +216,23 @@ export default function CookiePolicyPage() {
                 <p className="mt-4">
                   {t(
                     "legal.browserSettings",
-                    "You can also control cookies through your browser settings. Most browsers allow you to block or delete cookies. Note that blocking all cookies may affect site functionality.",
+                    "You can also control cookies through your browser settings. Most browsers allow you to block or delete cookies. Note that blocking all cookies may affect site functionality."
                   )}
                 </p>
               </Section>
             </ScrollReveal>
 
             <ScrollReveal>
-              <Section
-                id="more-info"
-                title={t("legal.moreInfoTitle", "5. More Information")}
-              >
+              <Section id="more-info" title={t("legal.moreInfoTitle", "5. More Information")}>
                 <p>
-                  {t(
-                    "legal.moreInfo",
-                    "For more details about how we handle your data, see our",
-                  )}{" "}
-                  <Link
-                    href="/privacy"
-                    className="text-neon-cyan hover:underline"
-                  >
+                  {t("legal.moreInfo", "For more details about how we handle your data, see our")}{" "}
+                  <Link href="/privacy" className="text-neon-cyan hover:underline">
                     {t("legal.privacyTitle", "Privacy Policy")}
                   </Link>
                   {". "}
                   {t(
                     "legal.moreInfoContact",
-                    "If you have questions about our use of cookies, contact us at tbaltzakis@cloudless.gr.",
+                    "If you have questions about our use of cookies, contact us at tbaltzakis@cloudless.gr."
                   )}
                 </p>
               </Section>

--- a/src/app/[locale]/dashboard/DashboardLayoutClient.tsx
+++ b/src/app/[locale]/dashboard/DashboardLayoutClient.tsx
@@ -12,11 +12,7 @@ const sidebarLinks = [
   { href: "/dashboard/settings", label: "Settings", icon: "⚙" },
 ];
 
-export default function DashboardLayoutClient({
-  children,
-}: {
-  children: React.ReactNode;
-}) {
+export default function DashboardLayoutClient({ children }: { children: React.ReactNode }) {
   const { user, isLoading } = useAuth();
   const router = useRouter();
   const pathname = usePathname();
@@ -42,7 +38,7 @@ export default function DashboardLayoutClient({
           <aside className="shrink-0 lg:w-64">
             <div className="bg-void-light/50 rounded-xl border border-slate-800 p-4">
               <div className="mb-4 border-b border-slate-800 pb-4">
-                <div className="bg-neon-cyan/10 border-neon-cyan/30 text-neon-cyan mb-2 flex h-10 w-10 items-center justify-center rounded-full border font-heading text-lg font-bold">
+                <div className="bg-neon-cyan/10 border-neon-cyan/30 text-neon-cyan font-heading mb-2 flex h-10 w-10 items-center justify-center rounded-full border text-lg font-bold">
                   {(user.name || user.email || "U")[0].toUpperCase()}
                 </div>
                 <p className="truncate font-mono text-sm font-medium text-white">

--- a/src/app/[locale]/dashboard/consultations/page.tsx
+++ b/src/app/[locale]/dashboard/consultations/page.tsx
@@ -65,18 +65,13 @@ export default function ConsultationsPage() {
       <div className="mb-8">
         <div className="bg-neon-cyan/10 border-neon-cyan/20 mb-4 inline-flex items-center gap-2 rounded-full border px-3 py-1.5">
           <span className="bg-neon-cyan h-2 w-2 animate-pulse rounded-full" />
-          <span className="text-neon-cyan font-mono text-xs">
-            CONSULTATIONS
-          </span>
+          <span className="text-neon-cyan font-mono text-xs">CONSULTATIONS</span>
         </div>
         <h1 className="font-heading text-2xl font-bold text-white">
           {t("dashboard.consultations", "Consultations")}
         </h1>
         <p className="font-body mt-1 text-slate-400">
-          {t(
-            "dashboard.consultationsDesc",
-            "Your booked and past consultation sessions.",
-          )}
+          {t("dashboard.consultationsDesc", "Your booked and past consultation sessions.")}
         </p>
       </div>
 
@@ -108,9 +103,7 @@ export default function ConsultationsPage() {
                 : "border border-slate-800 text-slate-500 hover:border-slate-700 hover:text-white"
             }`}
           >
-            {t === "upcoming"
-              ? `Upcoming (${upcoming.length})`
-              : `Past (${past.length})`}
+            {t === "upcoming" ? `Upcoming (${upcoming.length})` : `Past (${past.length})`}
           </button>
         ))}
       </div>
@@ -125,9 +118,7 @@ export default function ConsultationsPage() {
             📅
           </div>
           <h2 className="font-heading mb-2 font-semibold text-white">
-            {tab === "upcoming"
-              ? "No upcoming consultations"
-              : "No past consultations"}
+            {tab === "upcoming" ? "No upcoming consultations" : "No past consultations"}
           </h2>
           <p className="font-body mx-auto max-w-md text-sm text-slate-500">
             {tab === "upcoming"
@@ -148,7 +139,7 @@ export default function ConsultationsPage() {
           {displayed.map((c) => (
             <div
               key={c.id}
-              className="bg-void-light/50 rounded-xl border border-slate-800 p-5 transition-all hover:border-neon-cyan/20"
+              className="bg-void-light/50 hover:border-neon-cyan/20 rounded-xl border border-slate-800 p-5 transition-all"
             >
               <div className="flex flex-wrap items-start justify-between gap-3">
                 <div className="min-w-0 flex-1">
@@ -199,8 +190,8 @@ export default function ConsultationsPage() {
 
       {!configured && !loading && (
         <p className="mt-4 font-mono text-[10px] text-slate-600">
-          Calendar integration is being set up. Consultations will sync
-          automatically once configured.
+          Calendar integration is being set up. Consultations will sync automatically once
+          configured.
         </p>
       )}
     </div>

--- a/src/app/[locale]/dashboard/error.tsx
+++ b/src/app/[locale]/dashboard/error.tsx
@@ -18,9 +18,7 @@ export default function DashboardError({
     <section className="bg-void flex flex-1 items-center justify-center px-6 py-24">
       <div className="max-w-md text-center">
         <p className="text-neon-magenta font-mono text-5xl font-bold">ERROR</p>
-        <h1 className="font-heading mt-4 text-2xl font-bold text-white">
-          Dashboard error
-        </h1>
+        <h1 className="font-heading mt-4 text-2xl font-bold text-white">Dashboard error</h1>
         <p className="mt-3 font-mono text-sm text-slate-400">
           Something went wrong loading your dashboard.
         </p>

--- a/src/app/[locale]/dashboard/layout.tsx
+++ b/src/app/[locale]/dashboard/layout.tsx
@@ -2,10 +2,6 @@ export const dynamic = "force-dynamic";
 
 import DashboardLayoutClient from "./DashboardLayoutClient";
 
-export default function DashboardLayout({
-  children,
-}: {
-  children: React.ReactNode;
-}) {
+export default function DashboardLayout({ children }: { children: React.ReactNode }) {
   return <DashboardLayoutClient>{children}</DashboardLayoutClient>;
 }

--- a/src/app/[locale]/dashboard/loading.tsx
+++ b/src/app/[locale]/dashboard/loading.tsx
@@ -7,9 +7,7 @@ export default function DashboardLoading() {
           <span className="bg-neon-cyan h-2 w-2 animate-pulse rounded-full [animation-delay:150ms]" />
           <span className="bg-neon-cyan h-2 w-2 animate-pulse rounded-full [animation-delay:300ms]" />
         </div>
-        <p className="mt-4 font-mono text-sm text-slate-500">
-          Loading dashboard...
-        </p>
+        <p className="mt-4 font-mono text-sm text-slate-500">Loading dashboard...</p>
       </div>
     </section>
   );

--- a/src/app/[locale]/dashboard/page.tsx
+++ b/src/app/[locale]/dashboard/page.tsx
@@ -16,7 +16,7 @@ interface DashboardStats {
 
 async function fetchDashboardStats(
   setStats: (s: DashboardStats) => void,
-  setLoading: (v: boolean) => void,
+  setLoading: (v: boolean) => void
 ): Promise<void> {
   const [purchasesRes, consultationsRes] = await Promise.allSettled([
     fetchWithAuth("/api/user/purchases"),
@@ -34,20 +34,15 @@ async function fetchDashboardStats(
     const subs = data.subscriptions ?? [];
     totalOrders = purchases.length;
     totalSpent = purchases
-      .filter(
-        (p: { status: string }) =>
-          p.status === "paid" || p.status === "complete",
-      )
+      .filter((p: { status: string }) => p.status === "paid" || p.status === "complete")
       .reduce((sum: number, p: { amount: number }) => sum + p.amount, 0);
-    activeSubscriptions = subs.filter(
-      (s: { status: string }) => s.status === "active",
-    ).length;
+    activeSubscriptions = subs.filter((s: { status: string }) => s.status === "active").length;
   }
 
   if (consultationsRes.status === "fulfilled" && consultationsRes.value.ok) {
     const data = await consultationsRes.value.json();
     upcomingConsultations = (data.consultations ?? []).filter(
-      (c: { status: string }) => c.status === "upcoming",
+      (c: { status: string }) => c.status === "upcoming"
     ).length;
   }
 
@@ -85,10 +80,7 @@ export default function DashboardPage() {
   const dashboardCards = [
     {
       title: t("dashboard.profile", "Profile"),
-      description: t(
-        "dashboard.profileCardDesc",
-        "Update your name, company, and contact info",
-      ),
+      description: t("dashboard.profileCardDesc", "Update your name, company, and contact info"),
       icon: "◉",
       href: "/dashboard/profile",
       accent: "cyan" as const,
@@ -117,10 +109,7 @@ export default function DashboardPage() {
     },
     {
       title: t("dashboard.settings", "Settings"),
-      description: t(
-        "dashboard.settingsCardDesc",
-        "Theme, language, and notification preferences",
-      ),
+      description: t("dashboard.settingsCardDesc", "Theme, language, and notification preferences"),
       icon: "⚙",
       href: "/dashboard/settings",
       accent: "magenta" as const,
@@ -209,12 +198,8 @@ export default function DashboardPage() {
                   {card.icon}
                 </div>
               </div>
-              <h3 className="font-heading mb-1 font-semibold text-white">
-                {card.title}
-              </h3>
-              <p className="font-body text-sm text-slate-500">
-                {card.description}
-              </p>
+              <h3 className="font-heading mb-1 font-semibold text-white">{card.title}</h3>
+              <p className="font-body text-sm text-slate-500">{card.description}</p>
             </Link>
           );
         })}

--- a/src/app/[locale]/dashboard/profile/page.tsx
+++ b/src/app/[locale]/dashboard/profile/page.tsx
@@ -54,20 +54,16 @@ export default function ProfilePage() {
 
       {/* Avatar / Identity */}
       <div className="bg-void-light/50 mb-6 flex items-center gap-5 rounded-xl border border-slate-800 p-6">
-        <div className="bg-neon-cyan/10 border-neon-cyan/30 text-neon-cyan flex h-16 w-16 shrink-0 items-center justify-center rounded-full border-2 font-heading text-2xl font-bold">
+        <div className="bg-neon-cyan/10 border-neon-cyan/30 text-neon-cyan font-heading flex h-16 w-16 shrink-0 items-center justify-center rounded-full border-2 text-2xl font-bold">
           {(user?.name || user?.email || "U")[0].toUpperCase()}
         </div>
         <div className="min-w-0">
-          <p className="truncate font-heading text-lg font-semibold text-white">
+          <p className="font-heading truncate text-lg font-semibold text-white">
             {user?.name || user?.email?.split("@")[0] || "User"}
           </p>
-          <p className="text-neon-cyan truncate font-mono text-sm">
-            {user?.email}
-          </p>
+          <p className="text-neon-cyan truncate font-mono text-sm">{user?.email}</p>
           {user?.company && (
-            <p className="mt-0.5 truncate text-xs text-slate-500">
-              {user.company}
-            </p>
+            <p className="mt-0.5 truncate text-xs text-slate-500">{user.company}</p>
           )}
         </div>
       </div>
@@ -133,10 +129,7 @@ export default function ProfilePage() {
                 onChange={(e) => setCompany(e.target.value)}
                 autoComplete="organization"
                 className="bg-void-light focus:border-neon-cyan/50 w-full rounded-lg border border-slate-800 px-4 py-3 font-mono text-sm text-white transition-colors focus:outline-none"
-                placeholder={t(
-                  "dashboard.companyPlaceholder",
-                  "Your company or organization",
-                )}
+                placeholder={t("dashboard.companyPlaceholder", "Your company or organization")}
               />
             </div>
             <div>
@@ -166,9 +159,7 @@ export default function ProfilePage() {
             disabled={saving}
             className="bg-neon-cyan/10 border-neon-cyan/50 text-neon-cyan hover:bg-neon-cyan/20 min-h-11 rounded-lg border px-6 py-2.5 font-mono text-sm font-semibold transition-all hover:shadow-[0_0_25px_rgba(0,255,245,0.2)] disabled:opacity-50"
           >
-            {saving
-              ? t("common.saving", "Saving…")
-              : t("common.saveChanges", "Save Changes")}
+            {saving ? t("common.saving", "Saving…") : t("common.saveChanges", "Save Changes")}
           </button>
           {saved && (
             <span className="text-neon-green animate-fade-in-up font-mono text-xs">

--- a/src/app/[locale]/dashboard/purchases/page.tsx
+++ b/src/app/[locale]/dashboard/purchases/page.tsx
@@ -41,7 +41,7 @@ async function fetchPurchasesData(
   setPurchases: (p: Purchase[]) => void,
   setSubscriptions: (s: Subscription[]) => void,
   setError: (e: string | null) => void,
-  setLoading: (v: boolean) => void,
+  setLoading: (v: boolean) => void
 ): Promise<void> {
   try {
     const res = await fetchWithAuth("/api/user/purchases");
@@ -93,10 +93,7 @@ export default function PurchasesPage() {
           {t("dashboard.purchases", "Your Purchases")}
         </h1>
         <p className="font-body mt-1 text-slate-400">
-          {t(
-            "dashboard.purchasesDesc",
-            "View and manage orders placed with your account.",
-          )}
+          {t("dashboard.purchasesDesc", "View and manage orders placed with your account.")}
         </p>
       </div>
 
@@ -115,13 +112,9 @@ export default function PurchasesPage() {
           </p>
         </div>
         <div className="bg-void-light/50 rounded-xl border border-slate-800 p-4">
-          <p className="font-mono text-xs text-slate-500">
-            Active Subscriptions
-          </p>
+          <p className="font-mono text-xs text-slate-500">Active Subscriptions</p>
           <p className="font-heading text-neon-cyan mt-1 text-2xl font-bold">
-            {loading
-              ? "…"
-              : subscriptions.filter((s) => s.status === "active").length}
+            {loading ? "…" : subscriptions.filter((s) => s.status === "active").length}
           </p>
         </div>
       </div>
@@ -164,12 +157,9 @@ export default function PurchasesPage() {
             <div className="bg-neon-cyan/10 border-neon-cyan/20 mx-auto mb-4 flex h-14 w-14 items-center justify-center rounded-lg border text-2xl">
               ◇
             </div>
-            <h2 className="font-heading mb-2 font-semibold text-white">
-              No purchases yet
-            </h2>
+            <h2 className="font-heading mb-2 font-semibold text-white">No purchases yet</h2>
             <p className="font-body mx-auto max-w-md text-sm text-slate-500">
-              When you buy services or products from our store, they&apos;ll
-              appear here.
+              When you buy services or products from our store, they&apos;ll appear here.
             </p>
             <Link
               href="/store"
@@ -183,15 +173,14 @@ export default function PurchasesPage() {
             {purchases.map((p) => (
               <div
                 key={p.id}
-                className="bg-void-light/50 rounded-xl border border-slate-800 p-5 transition-all hover:border-neon-cyan/20"
+                className="bg-void-light/50 hover:border-neon-cyan/20 rounded-xl border border-slate-800 p-5 transition-all"
               >
                 <div className="flex flex-wrap items-start justify-between gap-3">
                   <div className="min-w-0 flex-1">
                     <div className="flex items-center gap-2">
                       <span
                         className={`shrink-0 rounded-full px-2 py-0.5 font-mono text-[10px] ${
-                          statusClasses[p.status] ??
-                          "bg-slate-800/50 text-slate-400"
+                          statusClasses[p.status] ?? "bg-slate-800/50 text-slate-400"
                         }`}
                       >
                         {p.status}
@@ -205,10 +194,7 @@ export default function PurchasesPage() {
                         <p key={i} className="font-mono text-sm text-white">
                           {item.name}
                           {item.quantity > 1 && (
-                            <span className="text-slate-500">
-                              {" "}
-                              ×{item.quantity}
-                            </span>
+                            <span className="text-slate-500"> ×{item.quantity}</span>
                           )}
                         </p>
                       ))}
@@ -216,8 +202,7 @@ export default function PurchasesPage() {
                   </div>
                   <div className="shrink-0 text-right">
                     <p className="font-heading text-lg font-bold text-white">
-                      {p.currency === "EUR" ? "€" : p.currency}{" "}
-                      {p.amount.toFixed(2)}
+                      {p.currency === "EUR" ? "€" : p.currency} {p.amount.toFixed(2)}
                     </p>
                   </div>
                 </div>
@@ -227,27 +212,22 @@ export default function PurchasesPage() {
         )
       ) : subscriptions.length === 0 ? (
         <div className="bg-void-light/50 rounded-xl border border-slate-800 p-12 text-center">
-          <p className="font-heading mb-2 font-semibold text-white">
-            No subscriptions
-          </p>
-          <p className="font-body text-sm text-slate-500">
-            Active subscriptions will appear here.
-          </p>
+          <p className="font-heading mb-2 font-semibold text-white">No subscriptions</p>
+          <p className="font-body text-sm text-slate-500">Active subscriptions will appear here.</p>
         </div>
       ) : (
         <div className="space-y-3">
           {subscriptions.map((sub) => (
             <div
               key={sub.id}
-              className="bg-void-light/50 rounded-xl border border-slate-800 p-5 transition-all hover:border-neon-cyan/20"
+              className="bg-void-light/50 hover:border-neon-cyan/20 rounded-xl border border-slate-800 p-5 transition-all"
             >
               <div className="flex flex-wrap items-start justify-between gap-3">
                 <div>
                   <div className="flex items-center gap-2">
                     <span
                       className={`rounded-full px-2 py-0.5 font-mono text-[10px] ${
-                        statusClasses[sub.status] ??
-                        "bg-slate-800/50 text-slate-400"
+                        statusClasses[sub.status] ?? "bg-slate-800/50 text-slate-400"
                       }`}
                     >
                       {sub.status}
@@ -268,8 +248,7 @@ export default function PurchasesPage() {
                 </div>
                 <div className="text-right">
                   <p className="font-mono text-xs text-slate-500">
-                    Renews{" "}
-                    {new Date(sub.currentPeriodEnd).toLocaleDateString("en-IE")}
+                    Renews {new Date(sub.currentPeriodEnd).toLocaleDateString("en-IE")}
                   </p>
                 </div>
               </div>

--- a/src/app/[locale]/dashboard/settings/page.tsx
+++ b/src/app/[locale]/dashboard/settings/page.tsx
@@ -16,12 +16,8 @@ export default function SettingsPage() {
   const [theme, setTheme] = useState(prefs?.theme ?? "dark");
   const [language, setLanguage] = useState(prefs?.language ?? "en");
   const [emailOrders, setEmailOrders] = useState(prefs?.emailOrders ?? true);
-  const [emailNewsletter, setEmailNewsletter] = useState(
-    prefs?.emailNewsletter ?? false,
-  );
-  const [emailMarketing, setEmailMarketing] = useState(
-    prefs?.emailMarketing ?? false,
-  );
+  const [emailNewsletter, setEmailNewsletter] = useState(prefs?.emailNewsletter ?? false);
+  const [emailMarketing, setEmailMarketing] = useState(prefs?.emailMarketing ?? false);
   const [saving, setSaving] = useState(false);
   const [saved, setSaved] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -43,9 +39,7 @@ export default function SettingsPage() {
       setSaved(true);
       setTimeout(() => setSaved(false), 3000);
     } catch (err) {
-      setError(
-        err instanceof Error ? err.message : "Failed to save preferences",
-      );
+      setError(err instanceof Error ? err.message : "Failed to save preferences");
     } finally {
       setSaving(false);
     }
@@ -74,10 +68,7 @@ export default function SettingsPage() {
           {t("dashboard.settings", "Settings")}
         </h1>
         <p className="font-body mt-1 text-slate-400">
-          {t(
-            "dashboard.settingsDesc",
-            "Manage your preferences and notifications.",
-          )}
+          {t("dashboard.settingsDesc", "Manage your preferences and notifications.")}
         </p>
       </div>
 
@@ -157,10 +148,7 @@ export default function SettingsPage() {
               {
                 id: "email-orders",
                 label: t("dashboard.orderUpdates", "Order updates"),
-                desc: t(
-                  "dashboard.orderUpdatesDesc",
-                  "Confirmations, shipping, and delivery",
-                ),
+                desc: t("dashboard.orderUpdatesDesc", "Confirmations, shipping, and delivery"),
                 checked: emailOrders,
                 onChange: setEmailOrders,
               },
@@ -169,7 +157,7 @@ export default function SettingsPage() {
                 label: t("dashboard.newsletter", "Newsletter"),
                 desc: t(
                   "dashboard.newsletterDesc",
-                  "Cloud tips, serverless patterns & growth hacks",
+                  "Cloud tips, serverless patterns & growth hacks"
                 ),
                 checked: emailNewsletter,
                 onChange: setEmailNewsletter,
@@ -177,10 +165,7 @@ export default function SettingsPage() {
               {
                 id: "email-marketing",
                 label: t("dashboard.productUpdates", "Product updates"),
-                desc: t(
-                  "dashboard.productUpdatesDesc",
-                  "New services and features",
-                ),
+                desc: t("dashboard.productUpdatesDesc", "New services and features"),
                 checked: emailMarketing,
                 onChange: setEmailMarketing,
               },
@@ -196,9 +181,7 @@ export default function SettingsPage() {
                   className="accent-neon-cyan mt-1"
                 />
                 <div>
-                  <span className="block font-mono text-sm text-white">
-                    {pref.label}
-                  </span>
+                  <span className="block font-mono text-sm text-white">{pref.label}</span>
                   <span className="text-xs text-slate-500">{pref.desc}</span>
                 </div>
               </label>
@@ -213,28 +196,17 @@ export default function SettingsPage() {
           </h2>
           <div className="space-y-2">
             <div className="flex items-center justify-between">
-              <span className="font-mono text-xs text-slate-500">
-                {t("auth.email", "Email")}
-              </span>
-              <span className="text-neon-cyan font-mono text-sm">
-                {user?.email ?? "—"}
-              </span>
+              <span className="font-mono text-xs text-slate-500">{t("auth.email", "Email")}</span>
+              <span className="text-neon-cyan font-mono text-sm">{user?.email ?? "—"}</span>
             </div>
             <div className="flex items-center justify-between">
-              <span className="font-mono text-xs text-slate-500">
-                {t("auth.fullName", "Name")}
-              </span>
-              <span className="font-mono text-sm text-white">
-                {user?.name || "—"}
-              </span>
+              <span className="font-mono text-xs text-slate-500">{t("auth.fullName", "Name")}</span>
+              <span className="font-mono text-sm text-white">{user?.name || "—"}</span>
             </div>
           </div>
           <p className="mt-3 font-mono text-[10px] text-slate-600">
             To update your name, company, or phone, visit your{" "}
-            <Link
-              href="/dashboard/profile"
-              className="text-neon-cyan hover:underline"
-            >
+            <Link href="/dashboard/profile" className="text-neon-cyan hover:underline">
               Profile
             </Link>
             .
@@ -248,9 +220,7 @@ export default function SettingsPage() {
             disabled={saving}
             className="bg-neon-cyan/10 border-neon-cyan/50 text-neon-cyan hover:bg-neon-cyan/20 min-h-11 rounded-lg border px-6 py-2.5 font-mono text-sm font-semibold transition-all hover:shadow-[0_0_25px_rgba(0,255,245,0.2)] disabled:opacity-50"
           >
-            {saving
-              ? t("common.saving", "Saving…")
-              : t("common.saveChanges", "Save Changes")}
+            {saving ? t("common.saving", "Saving…") : t("common.saveChanges", "Save Changes")}
           </button>
           {saved && (
             <span className="text-neon-green animate-fade-in-up font-mono text-xs">

--- a/src/app/[locale]/docs/[slug]/opengraph-image.tsx
+++ b/src/app/[locale]/docs/[slug]/opengraph-image.tsx
@@ -27,8 +27,7 @@ export default async function Image({
   return new ImageResponse(
     <div
       style={{
-        background:
-          "linear-gradient(135deg, #0a0a0f 0%, #0f1a12 50%, #0a1a1a 100%)",
+        background: "linear-gradient(135deg, #0a0a0f 0%, #0f1a12 50%, #0a1a1a 100%)",
         width: "100%",
         height: "100%",
         display: "flex",
@@ -120,23 +119,18 @@ export default async function Image({
         }}
       >
         <div style={{ display: "flex", alignItems: "baseline", gap: 6 }}>
-          <span style={{ fontSize: 28, color: "#ffffff", fontWeight: 800 }}>
-            cloudless
-          </span>
-          <span style={{ fontSize: 28, color: "#00fff5", fontWeight: 800 }}>
-            .gr
-          </span>
+          <span style={{ fontSize: 28, color: "#ffffff", fontWeight: 800 }}>cloudless</span>
+          <span style={{ fontSize: 28, color: "#00fff5", fontWeight: 800 }}>.gr</span>
         </div>
         <div
           style={{
             width: 120,
             height: 2,
-            background:
-              "linear-gradient(90deg, transparent, #00fff5, transparent)",
+            background: "linear-gradient(90deg, transparent, #00fff5, transparent)",
           }}
         />
       </div>
     </div>,
-    { width: 1200, height: 630 },
+    { width: 1200, height: 630 }
   );
 }

--- a/src/app/[locale]/docs/[slug]/page.tsx
+++ b/src/app/[locale]/docs/[slug]/page.tsx
@@ -24,9 +24,7 @@ export async function generateStaticParams() {
   if (!isConfigured("NOTION_API_KEY", "NOTION_DOCS_DB_ID")) return [];
 
   const docs = await getDocs();
-  return docs.flatMap((doc) =>
-    ["en", "el", "fr"].map((locale) => ({ locale, slug: doc.slug })),
-  );
+  return docs.flatMap((doc) => ["en", "el", "fr"].map((locale) => ({ locale, slug: doc.slug })));
 }
 
 export async function generateMetadata({ params }: Props): Promise<Metadata> {
@@ -99,7 +97,7 @@ export default async function DocPage({ params }: Props) {
                         <li key={d.id}>
                           <Link
                             href={`/docs/${d.slug}`}
-                            className={`block rounded px-2 py-1.5 font-body text-sm transition-colors ${
+                            className={`font-body block rounded px-2 py-1.5 text-sm transition-colors ${
                               d.slug === slug
                                 ? "text-neon-cyan bg-neon-cyan/5"
                                 : "text-slate-400 hover:text-slate-200"
@@ -119,10 +117,7 @@ export default async function DocPage({ params }: Props) {
             <main className="min-w-0 flex-1">
               {/* Breadcrumb */}
               <div className="mb-6 flex items-center gap-2 font-mono text-xs text-slate-500">
-                <Link
-                  href="/docs"
-                  className="hover:text-slate-300 transition-colors"
-                >
+                <Link href="/docs" className="transition-colors hover:text-slate-300">
                   Docs
                 </Link>
                 <span>/</span>
@@ -140,9 +135,7 @@ export default async function DocPage({ params }: Props) {
                   {doc.title}
                 </h1>
                 {doc.description && (
-                  <p className="font-body mt-3 text-lg text-slate-400">
-                    {doc.description}
-                  </p>
+                  <p className="font-body mt-3 text-lg text-slate-400">{doc.description}</p>
                 )}
               </div>
 
@@ -152,22 +145,11 @@ export default async function DocPage({ params }: Props) {
                 <div className="min-w-0 flex-1">
                   {content?.html ? (
                     <div
-                      className="prose prose-invert prose-sm md:prose-base max-w-none
-                        prose-headings:font-heading prose-headings:text-white
-                        prose-p:text-slate-300 prose-p:leading-relaxed
-                        prose-a:text-neon-cyan prose-a:no-underline hover:prose-a:underline
-                        prose-code:text-neon-cyan prose-code:bg-neon-cyan/5 prose-code:border prose-code:border-neon-cyan/10 prose-code:rounded prose-code:px-1.5 prose-code:py-0.5 prose-code:font-mono prose-code:text-xs
-                        prose-pre:bg-void-light/60 prose-pre:border prose-pre:border-slate-700
-                        prose-blockquote:border-neon-cyan/40 prose-blockquote:text-slate-400
-                        prose-hr:border-slate-800
-                        prose-strong:text-white
-                        prose-li:text-slate-300"
+                      className="prose prose-invert prose-sm md:prose-base prose-headings:font-heading prose-headings:text-white prose-p:text-slate-300 prose-p:leading-relaxed prose-a:text-neon-cyan prose-a:no-underline hover:prose-a:underline prose-code:text-neon-cyan prose-code:bg-neon-cyan/5 prose-code:border prose-code:border-neon-cyan/10 prose-code:rounded prose-code:px-1.5 prose-code:py-0.5 prose-code:font-mono prose-code:text-xs prose-pre:bg-void-light/60 prose-pre:border prose-pre:border-slate-700 prose-blockquote:border-neon-cyan/40 prose-blockquote:text-slate-400 prose-hr:border-slate-800 prose-strong:text-white prose-li:text-slate-300 max-w-none"
                       dangerouslySetInnerHTML={{ __html: content.html }}
                     />
                   ) : (
-                    <p className="font-mono text-slate-500">
-                      No content available.
-                    </p>
+                    <p className="font-mono text-slate-500">No content available.</p>
                   )}
                 </div>
 
@@ -183,7 +165,7 @@ export default async function DocPage({ params }: Props) {
                           <li key={entry.blockId}>
                             <a
                               href={`#${entry.blockId}`}
-                              className={`block border-l-2 border-transparent py-1 text-sm transition-colors hover:border-neon-cyan/50 hover:text-slate-200 ${
+                              className={`hover:border-neon-cyan/50 block border-l-2 border-transparent py-1 text-sm transition-colors hover:text-slate-200 ${
                                 entry.level === 2
                                   ? "pl-4 text-slate-400"
                                   : "pl-7 text-xs text-slate-500"

--- a/src/app/[locale]/docs/loading.tsx
+++ b/src/app/[locale]/docs/loading.tsx
@@ -7,10 +7,7 @@ export default function DocsLoading() {
           <aside className="hidden w-56 flex-none lg:block">
             <div className="space-y-4">
               {Array.from({ length: 6 }).map((_, i) => (
-                <div
-                  key={i}
-                  className="bg-void-light/50 h-4 animate-pulse rounded"
-                />
+                <div key={i} className="bg-void-light/50 h-4 animate-pulse rounded" />
               ))}
             </div>
           </aside>

--- a/src/app/[locale]/docs/opengraph-image.tsx
+++ b/src/app/[locale]/docs/opengraph-image.tsx
@@ -39,8 +39,7 @@ export default function DocListingOGImage() {
           right: "-80px",
           width: "600px",
           height: "600px",
-          background:
-            "radial-gradient(circle, rgba(0,212,255,0.12) 0%, transparent 65%)",
+          background: "radial-gradient(circle, rgba(0,212,255,0.12) 0%, transparent 65%)",
           borderRadius: "50%",
         }}
       />
@@ -146,6 +145,6 @@ export default function DocListingOGImage() {
         </span>
       </div>
     </div>,
-    { ...size },
+    { ...size }
   );
 }

--- a/src/app/[locale]/docs/page.tsx
+++ b/src/app/[locale]/docs/page.tsx
@@ -32,14 +32,9 @@ const VERIFICATION_STYLES: Record<string, { badge: string; icon: string }> = {
   },
 };
 
-export default async function DocsPage({
-  searchParams,
-}: {
-  searchParams: SearchParams;
-}) {
+export default async function DocsPage({ searchParams }: { searchParams: SearchParams }) {
   const resolvedParams = await searchParams;
-  const searchQuery =
-    typeof resolvedParams.q === "string" ? resolvedParams.q : "";
+  const searchQuery = typeof resolvedParams.q === "string" ? resolvedParams.q : "";
   const filterVerification =
     typeof resolvedParams.status === "string" ? resolvedParams.status : null;
 
@@ -51,9 +46,7 @@ export default async function DocsPage({
   if (searchQuery) {
     const q = searchQuery.toLowerCase();
     docs = docs.filter(
-      (d) =>
-        d.title.toLowerCase().includes(q) ||
-        d.description.toLowerCase().includes(q),
+      (d) => d.title.toLowerCase().includes(q) || d.description.toLowerCase().includes(q)
     );
   }
 
@@ -66,15 +59,11 @@ export default async function DocsPage({
   const categories = Object.keys(grouped);
 
   // Verification stats
-  const verifiedCount = allDocs.filter(
-    (d) => d.verificationStatus === "Verified",
-  ).length;
+  const verifiedCount = allDocs.filter((d) => d.verificationStatus === "Verified").length;
   const needsReviewCount = allDocs.filter(
-    (d) => d.verificationStatus === "Needs re-verification",
+    (d) => d.verificationStatus === "Needs re-verification"
   ).length;
-  const unverifiedCount = allDocs.filter(
-    (d) => d.verificationStatus === "Unverified",
-  ).length;
+  const unverifiedCount = allDocs.filter((d) => d.verificationStatus === "Unverified").length;
 
   function filterUrl(params: Record<string, string | null>) {
     const search = new URLSearchParams();
@@ -113,26 +102,21 @@ export default async function DocsPage({
             </span>
           </h1>
           <p className="animate-fade-in-up mt-4 max-w-xl text-lg text-slate-400 delay-200">
-            Everything you need to integrate, configure, and extend the
-            Cloudless platform.
+            Everything you need to integrate, configure, and extend the Cloudless platform.
           </p>
 
           {/* Search */}
-          <form
-            action=""
-            method="get"
-            className="animate-fade-in-up mt-6 max-w-md delay-300"
-          >
+          <form action="" method="get" className="animate-fade-in-up mt-6 max-w-md delay-300">
             <div className="relative">
               <input
                 type="text"
                 name="q"
                 defaultValue={searchQuery}
                 placeholder="Search docs…"
-                className="w-full rounded-lg border border-slate-700 bg-void-light/50 px-4 py-2.5 pl-10 font-mono text-sm text-white placeholder-slate-600 backdrop-blur-sm transition-colors focus:border-neon-cyan/50 focus:outline-none"
+                className="bg-void-light/50 focus:border-neon-cyan/50 w-full rounded-lg border border-slate-700 px-4 py-2.5 pl-10 font-mono text-sm text-white placeholder-slate-600 backdrop-blur-sm transition-colors focus:outline-none"
               />
               <svg
-                className="absolute left-3 top-1/2 -translate-y-1/2 text-slate-600"
+                className="absolute top-1/2 left-3 -translate-y-1/2 text-slate-600"
                 width="16"
                 height="16"
                 fill="none"
@@ -179,9 +163,7 @@ export default async function DocsPage({
               <Link
                 href={filterUrl({
                   status:
-                    filterVerification === "Needs re-verification"
-                      ? null
-                      : "Needs re-verification",
+                    filterVerification === "Needs re-verification" ? null : "Needs re-verification",
                 })}
                 className={`rounded-full border px-3 py-1 font-mono text-xs transition-colors ${
                   filterVerification === "Needs re-verification"
@@ -193,8 +175,7 @@ export default async function DocsPage({
               </Link>
               <Link
                 href={filterUrl({
-                  status:
-                    filterVerification === "Unverified" ? null : "Unverified",
+                  status: filterVerification === "Unverified" ? null : "Unverified",
                 })}
                 className={`rounded-full border px-3 py-1 font-mono text-xs transition-colors ${
                   filterVerification === "Unverified"
@@ -215,7 +196,7 @@ export default async function DocsPage({
               </span>
               <Link
                 href={filterUrl({ q: null })}
-                className="inline-flex items-center gap-1 rounded-full border border-neon-cyan/20 bg-neon-cyan/10 px-2.5 py-1 font-mono text-xs text-neon-cyan transition-colors hover:bg-neon-cyan/20"
+                className="border-neon-cyan/20 bg-neon-cyan/10 text-neon-cyan hover:bg-neon-cyan/20 inline-flex items-center gap-1 rounded-full border px-2.5 py-1 font-mono text-xs transition-colors"
               >
                 &quot;{searchQuery}&quot; ✕
               </Link>
@@ -223,7 +204,7 @@ export default async function DocsPage({
           )}
 
           {docs.length === 0 ? (
-            <div className="rounded-xl border border-slate-800 bg-void-light/30 p-12 text-center">
+            <div className="bg-void-light/30 rounded-xl border border-slate-800 p-12 text-center">
               <p className="font-mono text-slate-500">
                 {searchQuery || filterVerification
                   ? "No docs match your filters."
@@ -242,9 +223,7 @@ export default async function DocsPage({
             <div className="space-y-12">
               {categories.map((category) => (
                 <div key={category}>
-                  <h2 className="font-heading mb-6 text-xl font-semibold text-white">
-                    {category}
-                  </h2>
+                  <h2 className="font-heading mb-6 text-xl font-semibold text-white">{category}</h2>
                   <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
                     {(grouped[category] as WikiDocRecord[]).map((doc) => {
                       const vStyle =
@@ -272,7 +251,7 @@ export default async function DocsPage({
                               {doc.title}
                             </h3>
                             {doc.description && (
-                              <p className="font-body text-sm text-slate-400 line-clamp-2">
+                              <p className="font-body line-clamp-2 text-sm text-slate-400">
                                 {doc.description}
                               </p>
                             )}
@@ -286,9 +265,7 @@ export default async function DocsPage({
                               {doc.lastVerified && (
                                 <span className="font-mono text-[9px] text-slate-600">
                                   Verified:{" "}
-                                  {new Date(
-                                    doc.lastVerified,
-                                  ).toLocaleDateString("en-GB", {
+                                  {new Date(doc.lastVerified).toLocaleDateString("en-GB", {
                                     day: "2-digit",
                                     month: "short",
                                     year: "numeric",

--- a/src/app/[locale]/not-found.tsx
+++ b/src/app/[locale]/not-found.tsx
@@ -3,12 +3,7 @@ export const dynamic = "force-dynamic";
 import { headers } from "next/headers";
 import { getLocale } from "next-intl/server";
 import { Link } from "@/i18n/navigation";
-import {
-  translate,
-  type Locale,
-  isSupportedLocale,
-  defaultLocale,
-} from "@/lib/i18n";
+import { translate, type Locale, isSupportedLocale, defaultLocale } from "@/lib/i18n";
 
 const FALLBACK = {
   title: "Page not found",
@@ -53,9 +48,7 @@ export default async function LocaleNotFound() {
         <p className="text-neon-magenta glow-magenta animate-neon-pulse font-mono text-7xl font-bold">
           404
         </p>
-        <h1 className="font-heading mt-4 text-3xl font-bold text-white">
-          {m.title}
-        </h1>
+        <h1 className="font-heading mt-4 text-3xl font-bold text-white">{m.title}</h1>
         <p className="mt-3 font-mono text-sm text-slate-400">{m.body}</p>
         <Link
           href="/"

--- a/src/app/[locale]/page.tsx
+++ b/src/app/[locale]/page.tsx
@@ -16,10 +16,8 @@ import SocialLinks from "@/components/SocialLinks";
 export const revalidate = 3600;
 
 function stepColorClass(color: string): string {
-  if (color === "cyan")
-    return "bg-neon-cyan/10 border-neon-cyan/20 text-neon-cyan";
-  if (color === "magenta")
-    return "bg-neon-magenta/10 border-neon-magenta/20 text-neon-magenta";
+  if (color === "cyan") return "bg-neon-cyan/10 border-neon-cyan/20 text-neon-cyan";
+  if (color === "magenta") return "bg-neon-magenta/10 border-neon-magenta/20 text-neon-magenta";
   return "bg-neon-green/10 border-neon-green/20 text-neon-green";
 }
 
@@ -78,18 +76,15 @@ export default async function Home({
   const services = [
     {
       icon: "01",
-      title: t(
-        "servicesSection.service1Title",
-        "Cloud Architecture & Migration",
-      ),
+      title: t("servicesSection.service1Title", "Cloud Architecture & Migration"),
       description: t(
         "servicesSection.service1Desc",
-        "Design and migrate your infrastructure to AWS, GCP, or Azure with zero downtime. Scalable, secure, cost-optimized.",
+        "Design and migrate your infrastructure to AWS, GCP, or Azure with zero downtime. Scalable, secure, cost-optimized."
       ),
       tag: t("servicesSection.service1Tag", "CLOUD"),
       perfectFor: t(
         "servicesSection.service1For",
-        "For teams paying €500+/mo for infrastructure they can't explain.",
+        "For teams paying €500+/mo for infrastructure they can't explain."
       ),
     },
     {
@@ -97,12 +92,12 @@ export default async function Home({
       title: t("servicesSection.service2Title", "Serverless Development"),
       description: t(
         "servicesSection.service2Desc",
-        "Build event-driven applications that scale automatically and cost nothing when idle. Lambda, API Gateway, DynamoDB.",
+        "Build event-driven applications that scale automatically and cost nothing when idle. Lambda, API Gateway, DynamoDB."
       ),
       tag: t("servicesSection.service2Tag", "SERVERLESS"),
       perfectFor: t(
         "servicesSection.service2For",
-        "For founders tired of paying for servers that sit idle 90% of the time.",
+        "For founders tired of paying for servers that sit idle 90% of the time."
       ),
     },
     {
@@ -110,12 +105,12 @@ export default async function Home({
       title: t("servicesSection.service3Title", "Data Analytics & Dashboards"),
       description: t(
         "servicesSection.service3Desc",
-        "Turn raw data into actionable insights with custom dashboards, pipelines, and real-time reporting.",
+        "Turn raw data into actionable insights with custom dashboards, pipelines, and real-time reporting."
       ),
       tag: t("servicesSection.service3Tag", "ANALYTICS"),
       perfectFor: t(
         "servicesSection.service3For",
-        "For teams making decisions on gut feeling instead of data.",
+        "For teams making decisions on gut feeling instead of data."
       ),
     },
     {
@@ -123,12 +118,12 @@ export default async function Home({
       title: t("servicesSection.service4Title", "AI & Digital Marketing"),
       description: t(
         "servicesSection.service4Desc",
-        "AI-powered campaigns, SEO, content strategy, and performance marketing that drives measurable growth.",
+        "AI-powered campaigns, SEO, content strategy, and performance marketing that drives measurable growth."
       ),
       tag: t("servicesSection.service4Tag", "AI"),
       perfectFor: t(
         "servicesSection.service4For",
-        "For startups spending on ads with no idea what's actually working.",
+        "For startups spending on ads with no idea what's actually working."
       ),
     },
   ];
@@ -145,42 +140,42 @@ export default async function Home({
       question: t("faq.q1", "How much will this actually cost me?"),
       answer: t(
         "faq.a1",
-        "Individual services range from €800 to €2,400 depending on scope. The full bundle is €3,600/month. For context: hiring a single cloud engineer in-house costs €5K–€8K/month. A CTO + marketer + data analyst? €20K+/month. We replace all three for a fraction of the cost — and you can cancel anytime.",
+        "Individual services range from €800 to €2,400 depending on scope. The full bundle is €3,600/month. For context: hiring a single cloud engineer in-house costs €5K–€8K/month. A CTO + marketer + data analyst? €20K+/month. We replace all three for a fraction of the cost — and you can cancel anytime."
       ),
     },
     {
       question: t("faq.q2", "Who is this for? Am I the right fit?"),
       answer: t(
         "faq.a2",
-        "We work best with startups and SMBs that are past the MVP stage — typically 2–20 person teams doing €50K–€500K in revenue. You have a product that works but your infrastructure is duct tape, your marketing is guesswork, and you don't have a CTO to fix it. If that sounds familiar, the free audit will tell you exactly what to do next.",
+        "We work best with startups and SMBs that are past the MVP stage — typically 2–20 person teams doing €50K–€500K in revenue. You have a product that works but your infrastructure is duct tape, your marketing is guesswork, and you don't have a CTO to fix it. If that sounds familiar, the free audit will tell you exactly what to do next."
       ),
     },
     {
       question: t("faq.q3", "What if I want to leave?"),
       answer: t(
         "faq.a3",
-        "Leave whenever you want. Month-to-month, no lock-in, no exit fees. Your code, infrastructure, and data are always yours — fully documented and handoff-ready. We're not in the business of holding your code hostage.",
+        "Leave whenever you want. Month-to-month, no lock-in, no exit fees. Your code, infrastructure, and data are always yours — fully documented and handoff-ready. We're not in the business of holding your code hostage."
       ),
     },
     {
       question: t("faq.q4", "How quickly can I see results?"),
       answer: t(
         "faq.a4",
-        "Measurable progress within 14 days of kickoff. Cloud migrations show cost savings immediately. Marketing campaigns deliver initial data within two weeks. We guarantee it — or we keep working until you see it.",
+        "Measurable progress within 14 days of kickoff. Cloud migrations show cost savings immediately. Marketing campaigns deliver initial data within two weeks. We guarantee it — or we keep working until you see it."
       ),
     },
     {
       question: t("faq.q5", "What does the free audit include?"),
       answer: t(
         "faq.a5",
-        "A 30-minute call where we review your current infrastructure, marketing setup, or both. You'll get a concrete action plan with specific recommendations — no pitch, no pressure. Most founders say it's the most useful 30 minutes they've spent on their tech stack.",
+        "A 30-minute call where we review your current infrastructure, marketing setup, or both. You'll get a concrete action plan with specific recommendations — no pitch, no pressure. Most founders say it's the most useful 30 minutes they've spent on their tech stack."
       ),
     },
     {
       question: t("faq.q6", "Can I trust a new agency with my infrastructure?"),
       answer: t(
         "faq.a6",
-        "Fair question. We're backed by AWS certifications (check our Credly badges), open-source contributions on GitHub, and 8+ years of hands-on cloud architecture. The free audit is zero-risk — you'll see our thinking and decide if it's worth going further. We'd rather lose a deal than overpromise.",
+        "Fair question. We're backed by AWS certifications (check our Credly badges), open-source contributions on GitHub, and 8+ years of hands-on cloud architecture. The free audit is zero-risk — you'll see our thinking and decide if it's worth going further. We'd rather lose a deal than overpromise."
       ),
     },
   ];
@@ -191,7 +186,7 @@ export default async function Home({
       title: t("guarantees.resultsTitle", "Results in 14 Days"),
       desc: t(
         "guarantees.resultsDesc",
-        "Measurable progress within two weeks of kickoff — or we keep working until you see it.",
+        "Measurable progress within two weeks of kickoff — or we keep working until you see it."
       ),
     },
     {
@@ -199,7 +194,7 @@ export default async function Home({
       title: t("guarantees.noLockInTitle", "No Lock-in Contracts"),
       desc: t(
         "guarantees.noLockInDesc",
-        "Month-to-month. Cancel anytime. We earn your business every month.",
+        "Month-to-month. Cancel anytime. We earn your business every month."
       ),
     },
     {
@@ -207,7 +202,7 @@ export default async function Home({
       title: t("guarantees.yourCodeTitle", "Your Code Is Yours"),
       desc: t(
         "guarantees.yourCodeDesc",
-        "Full documentation, handoff-ready. We build it and you own it — always.",
+        "Full documentation, handoff-ready. We build it and you own it — always."
       ),
     },
   ];
@@ -221,11 +216,7 @@ export default async function Home({
 
   return (
     <>
-      <JsonLd
-        data={getBreadcrumbSchema([
-          { name: "Home", url: "https://cloudless.gr" },
-        ])}
-      />
+      <JsonLd data={getBreadcrumbSchema([{ name: "Home", url: "https://cloudless.gr" }])} />
       <JsonLd data={getFAQSchema(faqs)} />
 
       {/* Hero */}
@@ -266,7 +257,7 @@ export default async function Home({
               <p className="animate-fade-in-up mt-8 max-w-xl text-lg leading-relaxed text-slate-300 delay-200 md:text-xl">
                 {t(
                   "hero.subtitle",
-                  "Enterprise cloud? You can't afford it. DIY infrastructure? You shouldn't. We're the third way — serverless, data-driven growth, and scaling that actually fits a 2–20 person team.",
+                  "Enterprise cloud? You can't afford it. DIY infrastructure? You shouldn't. We're the third way — serverless, data-driven growth, and scaling that actually fits a 2–20 person team."
                 )}{" "}
                 <span className="text-neon-cyan font-medium">
                   {t("hero.subtitleHighlight", "Finally.")}
@@ -288,16 +279,9 @@ export default async function Home({
               </div>
               {/* CTA microcopy */}
               <div className="animate-fade-in-up mt-4 flex flex-col gap-6 font-mono text-xs text-slate-500 delay-300 sm:flex-row">
-                <span>
-                  {t(
-                    "hero.microCopy1",
-                    "No commitment. Actionable insights in 30 min.",
-                  )}
-                </span>
+                <span>{t("hero.microCopy1", "No commitment. Actionable insights in 30 min.")}</span>
                 <span className="hidden sm:inline">•</span>
-                <span>
-                  {t("hero.microCopy2", "Transparent pricing. No lock-in.")}
-                </span>
+                <span>{t("hero.microCopy2", "Transparent pricing. No lock-in.")}</span>
               </div>
             </div>
 
@@ -336,12 +320,8 @@ export default async function Home({
                     {g.icon}
                   </span>
                   <div>
-                    <p className="font-mono text-sm font-semibold text-white">
-                      {g.title}
-                    </p>
-                    <p className="mt-1 text-xs leading-relaxed text-slate-400">
-                      {g.desc}
-                    </p>
+                    <p className="font-mono text-sm font-semibold text-white">{g.title}</p>
+                    <p className="mt-1 text-xs leading-relaxed text-slate-400">{g.desc}</p>
                   </div>
                 </div>
               </ScrollReveal>
@@ -372,7 +352,7 @@ export default async function Home({
             {/* Connector line — desktop only */}
             <div
               aria-hidden="true"
-              className="absolute top-8 left-[calc(16.67%+1.5rem)] right-[calc(16.67%+1.5rem)] hidden h-px bg-gradient-to-r from-transparent via-slate-700 to-transparent md:block"
+              className="absolute top-8 right-[calc(16.67%+1.5rem)] left-[calc(16.67%+1.5rem)] hidden h-px bg-gradient-to-r from-transparent via-slate-700 to-transparent md:block"
             />
             {(
               [
@@ -382,7 +362,7 @@ export default async function Home({
                   title: t("process.step1Title", "Free Audit"),
                   desc: t(
                     "process.step1Desc",
-                    "30-minute call. We review your infrastructure and marketing, identify quick wins, and give you a concrete action plan — no commitment required.",
+                    "30-minute call. We review your infrastructure and marketing, identify quick wins, and give you a concrete action plan — no commitment required."
                   ),
                 },
                 {
@@ -391,7 +371,7 @@ export default async function Home({
                   title: t("process.step2Title", "Choose your scope"),
                   desc: t(
                     "process.step2Desc",
-                    "Pick one service or bundle all four for 30% savings. We align on deliverables, timeline, and what 'done' looks like before any work starts.",
+                    "Pick one service or bundle all four for 30% savings. We align on deliverables, timeline, and what 'done' looks like before any work starts."
                   ),
                 },
                 {
@@ -400,7 +380,7 @@ export default async function Home({
                   title: t("process.step3Title", "Results in 14 days"),
                   desc: t(
                     "process.step3Desc",
-                    "We kick off immediately. Measurable progress within two weeks — cost savings, live infrastructure, first campaign data. We keep working until you see it.",
+                    "We kick off immediately. Measurable progress within two weeks — cost savings, live infrastructure, first campaign data. We keep working until you see it."
                   ),
                 },
               ] as const
@@ -412,12 +392,8 @@ export default async function Home({
                   >
                     {item.step}
                   </div>
-                  <h3 className="font-heading mb-2 font-semibold text-white">
-                    {item.title}
-                  </h3>
-                  <p className="text-sm leading-relaxed text-slate-400">
-                    {item.desc}
-                  </p>
+                  <h3 className="font-heading mb-2 font-semibold text-white">{item.title}</h3>
+                  <p className="text-sm leading-relaxed text-slate-400">{item.desc}</p>
                 </div>
               </ScrollReveal>
             ))}
@@ -433,23 +409,18 @@ export default async function Home({
               {/* Avatar — swap src for /images/founder.jpg once photo is added */}
               <div className="from-neon-cyan/30 to-neon-magenta/30 shrink-0 rounded-full bg-gradient-to-br p-0.5">
                 <div className="bg-void-light flex h-16 w-16 items-center justify-center rounded-full">
-                  <span className="font-heading text-neon-cyan text-xl font-bold">
-                    TB
-                  </span>
+                  <span className="font-heading text-neon-cyan text-xl font-bold">TB</span>
                 </div>
               </div>
               {/* Copy */}
               <div className="flex-1 text-center md:text-left">
                 <p className="text-sm leading-relaxed text-slate-300">
                   <span className="font-semibold text-white">
-                    {t(
-                      "credibility.builtBy",
-                      "Built by Themistoklis Baltzakis",
-                    )}
+                    {t("credibility.builtBy", "Built by Themistoklis Baltzakis")}
                   </span>{" "}
                   {t(
                     "credibility.bio",
-                    "— AWS Certified Cloud Architect, 8+ years building serverless infrastructure and growth systems. I started cloudless.gr because startups deserve enterprise-grade cloud without the enterprise price or the enterprise BS.",
+                    "— AWS Certified Cloud Architect, 8+ years building serverless infrastructure and growth systems. I started cloudless.gr because startups deserve enterprise-grade cloud without the enterprise price or the enterprise BS."
                   )}
                 </p>
                 <div className="mt-3 flex flex-wrap items-center justify-center gap-3 md:justify-start">
@@ -470,10 +441,7 @@ export default async function Home({
                     ↗ {t("credibility.badgeOss", "Open-Source Contributor")}
                   </a>
                   <span className="bg-neon-magenta/10 border-neon-magenta/20 text-neon-magenta inline-flex items-center gap-1.5 rounded-full border px-2.5 py-1 font-mono text-[10px]">
-                    {t(
-                      "credibility.badgeCapacity",
-                      "Now accepting 5 clients for Q2 2026",
-                    )}
+                    {t("credibility.badgeCapacity", "Now accepting 5 clients for Q2 2026")}
                   </span>
                 </div>
               </div>
@@ -501,7 +469,7 @@ export default async function Home({
               <p className="mt-4 text-lg text-slate-400">
                 {t(
                   "servicesSection.subtitle",
-                  "From infrastructure to marketing, we cover the full stack of modern business growth.",
+                  "From infrastructure to marketing, we cover the full stack of modern business growth."
                 )}
               </p>
             </div>
@@ -563,7 +531,7 @@ export default async function Home({
               <p className="mb-4 font-mono text-sm font-semibold text-white">
                 {t(
                   "leadCapture.playbookTitle",
-                  "Get our free Cloud Migration Playbook — the exact framework we use with clients.",
+                  "Get our free Cloud Migration Playbook — the exact framework we use with clients."
                 )}
               </p>
               <Link
@@ -571,13 +539,7 @@ export default async function Home({
                 className="bg-neon-magenta/10 border-neon-magenta/30 text-neon-magenta hover:bg-neon-magenta/20 inline-flex items-center gap-2 rounded-lg border px-6 py-2.5 font-mono text-sm font-semibold transition-all duration-300 hover:shadow-[0_0_15px_rgba(255,0,255,0.1)]"
               >
                 {t("leadCapture.playbookCta", "Download the Playbook")}
-                <svg
-                  width="14"
-                  height="14"
-                  fill="none"
-                  stroke="currentColor"
-                  strokeWidth="2"
-                >
+                <svg width="14" height="14" fill="none" stroke="currentColor" strokeWidth="2">
                   <path d="M7 1v10M3 8l4 4 4-4" />
                 </svg>
               </Link>
@@ -596,9 +558,7 @@ export default async function Home({
               </p>
               <h2 className="font-heading text-3xl font-bold text-white md:text-4xl">
                 {t("faq.title", "Common")}{" "}
-                <span className="text-neon-cyan">
-                  {t("faq.titleHighlight", "questions")}
-                </span>
+                <span className="text-neon-cyan">{t("faq.titleHighlight", "questions")}</span>
               </h2>
             </div>
           </ScrollReveal>
@@ -644,9 +604,7 @@ export default async function Home({
               </p>
               <h2 className="font-heading text-3xl font-bold text-white md:text-4xl">
                 {t("founder.title", "Meet the")}{" "}
-                <span className="text-neon-cyan">
-                  {t("founder.titleHighlight", "founder")}
-                </span>
+                <span className="text-neon-cyan">{t("founder.titleHighlight", "founder")}</span>
               </h2>
             </div>
           </ScrollReveal>
@@ -656,9 +614,7 @@ export default async function Home({
               <div className="flex flex-col items-center gap-8 md:flex-row md:items-start">
                 {/* Avatar */}
                 <div className="bg-neon-cyan/10 border-neon-cyan/20 flex h-24 w-24 shrink-0 items-center justify-center rounded-xl border">
-                  <span className="font-heading text-neon-cyan text-3xl font-bold">
-                    TB
-                  </span>
+                  <span className="font-heading text-neon-cyan text-3xl font-bold">TB</span>
                 </div>
 
                 {/* Bio */}
@@ -672,15 +628,12 @@ export default async function Home({
                   <p className="mt-4 text-sm leading-relaxed text-slate-400">
                     {t(
                       "founder.bio",
-                      "Certified cloud architect with hands-on experience in AWS, serverless architectures, data analytics, and AI-powered marketing. I help startups and SMBs build infrastructure that scales without the enterprise overhead.",
+                      "Certified cloud architect with hands-on experience in AWS, serverless architectures, data analytics, and AI-powered marketing. I help startups and SMBs build infrastructure that scales without the enterprise overhead."
                     )}
                   </p>
 
                   {/* Social links */}
-                  <SocialLinks
-                    size="md"
-                    className="mt-6 justify-center md:justify-start"
-                  />
+                  <SocialLinks size="md" className="mt-6 justify-center md:justify-start" />
                 </div>
               </div>
             </div>
@@ -704,13 +657,13 @@ export default async function Home({
             <p className="mx-auto mb-4 max-w-xl text-xl text-slate-400">
               {t(
                 "cta.subtitle",
-                "Book a free 30-minute audit. We'll review your current setup and show you exactly where you're overpaying, underperforming, or both.",
+                "Book a free 30-minute audit. We'll review your current setup and show you exactly where you're overpaying, underperforming, or both."
               )}
             </p>
             <p className="mx-auto mb-8 max-w-lg text-sm text-slate-500">
               {t(
                 "cta.subtext",
-                "No pitch. No commitment. Just actionable insights you can use even if you never talk to us again.",
+                "No pitch. No commitment. Just actionable insights you can use even if you never talk to us again."
               )}
             </p>
             <div className="flex flex-col justify-center gap-4 sm:flex-row">

--- a/src/app/[locale]/privacy/page.tsx
+++ b/src/app/[locale]/privacy/page.tsx
@@ -27,12 +27,8 @@ function Section({
 }) {
   return (
     <section id={id} className="scroll-mt-24">
-      <h2 className="text-neon-cyan/80 mb-4 font-heading text-xl font-bold text-white">
-        {title}
-      </h2>
-      <div className="space-y-3 text-sm leading-relaxed text-slate-300">
-        {children}
-      </div>
+      <h2 className="text-neon-cyan/80 font-heading mb-4 text-xl font-bold text-white">{title}</h2>
+      <div className="space-y-3 text-sm leading-relaxed text-slate-300">{children}</div>
     </section>
   );
 }
@@ -58,7 +54,7 @@ export default async function PrivacyPolicyPage() {
             <p className="text-neon-cyan/70 mb-4 font-mono text-xs tracking-widest">
               {t("legal.legalDocument", "LEGAL DOCUMENT")}
             </p>
-            <h1 className="mb-4 font-heading text-3xl font-bold text-white lg:text-4xl">
+            <h1 className="font-heading mb-4 text-3xl font-bold text-white lg:text-4xl">
               {t("legal.privacyTitle", "Privacy Policy")}
             </h1>
             <p className="mb-2 font-mono text-xs text-slate-500">
@@ -67,21 +63,18 @@ export default async function PrivacyPolicyPage() {
             <p className="mb-12 text-sm leading-relaxed text-slate-400">
               {t(
                 "legal.privacyIntro",
-                'This Privacy Policy explains how Cloudless ("we", "us", "our") collects, uses, discloses, and safeguards your information when you visit cloudless.gr and use our services. We are committed to protecting your privacy in compliance with the EU General Data Protection Regulation (GDPR), the ePrivacy Directive, and the California Consumer Privacy Act (CCPA/CPRA).',
+                'This Privacy Policy explains how Cloudless ("we", "us", "our") collects, uses, discloses, and safeguards your information when you visit cloudless.gr and use our services. We are committed to protecting your privacy in compliance with the EU General Data Protection Regulation (GDPR), the ePrivacy Directive, and the California Consumer Privacy Act (CCPA/CPRA).'
               )}
             </p>
           </ScrollReveal>
 
           <div className="space-y-10">
             <ScrollReveal>
-              <Section
-                id="controller"
-                title={t("legal.controllerTitle", "1. Data Controller")}
-              >
+              <Section id="controller" title={t("legal.controllerTitle", "1. Data Controller")}>
                 <p>
                   {t(
                     "legal.controllerText",
-                    "The data controller responsible for your personal data is Cloudless, operated by Themistoklis Baltzakis, based in Greece, EU. For data protection inquiries, contact us at:",
+                    "The data controller responsible for your personal data is Cloudless, operated by Themistoklis Baltzakis, based in Greece, EU. For data protection inquiries, contact us at:"
                   )}
                 </p>
                 <p className="font-mono text-xs">
@@ -93,33 +86,24 @@ export default async function PrivacyPolicyPage() {
             <ScrollReveal>
               <Section
                 id="data-collected"
-                title={t(
-                  "legal.dataCollectedTitle",
-                  "2. Information We Collect",
-                )}
+                title={t("legal.dataCollectedTitle", "2. Information We Collect")}
               >
                 <p className="font-semibold text-white">
-                  {t(
-                    "legal.dataProvidedTitle",
-                    "Information you provide directly:",
-                  )}
+                  {t("legal.dataProvidedTitle", "Information you provide directly:")}
                 </p>
                 <p>
                   {t(
                     "legal.dataProvided",
-                    "Name, email address, company name, and message content when you submit our contact form. Email address when you subscribe to our newsletter. Account credentials when you register. Payment information when you purchase products or services (processed by Stripe — we never store card details).",
+                    "Name, email address, company name, and message content when you submit our contact form. Email address when you subscribe to our newsletter. Account credentials when you register. Payment information when you purchase products or services (processed by Stripe — we never store card details)."
                   )}
                 </p>
                 <p className="font-semibold text-white">
-                  {t(
-                    "legal.dataAutoTitle",
-                    "Information collected automatically:",
-                  )}
+                  {t("legal.dataAutoTitle", "Information collected automatically:")}
                 </p>
                 <p>
                   {t(
                     "legal.dataAuto",
-                    "IP address (anonymised for analytics), browser type and version, device type, operating system, pages visited, time spent on pages, referring URL. This data is only collected if you consent to analytics cookies.",
+                    "IP address (anonymised for analytics), browser type and version, device type, operating system, pages visited, time spent on pages, referring URL. This data is only collected if you consent to analytics cookies."
                   )}
                 </p>
               </Section>
@@ -128,36 +112,27 @@ export default async function PrivacyPolicyPage() {
             <ScrollReveal>
               <Section
                 id="legal-basis"
-                title={t(
-                  "legal.legalBasisTitle",
-                  "3. Legal Basis for Processing (GDPR)",
-                )}
+                title={t("legal.legalBasisTitle", "3. Legal Basis for Processing (GDPR)")}
               >
                 <p>
                   {t(
                     "legal.legalBasis",
-                    "We process your personal data on the following legal bases: (a) Consent — for newsletter subscriptions, analytics cookies, and marketing cookies. You may withdraw consent at any time. (b) Contract performance — to fulfil orders and deliver services you have purchased. (c) Legitimate interest — for fraud prevention, security, and improving our services. (d) Legal obligation — for tax and accounting records required by Greek and EU law.",
+                    "We process your personal data on the following legal bases: (a) Consent — for newsletter subscriptions, analytics cookies, and marketing cookies. You may withdraw consent at any time. (b) Contract performance — to fulfil orders and deliver services you have purchased. (c) Legitimate interest — for fraud prevention, security, and improving our services. (d) Legal obligation — for tax and accounting records required by Greek and EU law."
                   )}
                 </p>
               </Section>
             </ScrollReveal>
 
             <ScrollReveal>
-              <Section
-                id="cookies"
-                title={t("legal.cookiesTitle", "4. Cookies & Tracking")}
-              >
+              <Section id="cookies" title={t("legal.cookiesTitle", "4. Cookies & Tracking")}>
                 <p>
                   {t(
                     "legal.cookiesText",
-                    "We use cookies in three categories: (1) Necessary cookies — required for the site to function (session management, consent preferences, security). These cannot be disabled. (2) Analytics cookies — help us understand how visitors use the site. Only set with your consent. (3) Marketing cookies — used for targeted advertising. Only set with your consent. You can manage your preferences at any time via the cookie settings link in our footer, or in your browser settings.",
+                    "We use cookies in three categories: (1) Necessary cookies — required for the site to function (session management, consent preferences, security). These cannot be disabled. (2) Analytics cookies — help us understand how visitors use the site. Only set with your consent. (3) Marketing cookies — used for targeted advertising. Only set with your consent. You can manage your preferences at any time via the cookie settings link in our footer, or in your browser settings."
                   )}
                 </p>
                 <p>
-                  <Link
-                    href="/cookies"
-                    className="text-neon-cyan hover:underline"
-                  >
+                  <Link href="/cookies" className="text-neon-cyan hover:underline">
                     {t("legal.fullCookiePolicy", "Read our full Cookie Policy")}
                   </Link>
                 </p>
@@ -165,14 +140,11 @@ export default async function PrivacyPolicyPage() {
             </ScrollReveal>
 
             <ScrollReveal>
-              <Section
-                id="data-use"
-                title={t("legal.dataUseTitle", "5. How We Use Your Data")}
-              >
+              <Section id="data-use" title={t("legal.dataUseTitle", "5. How We Use Your Data")}>
                 <p>
                   {t(
                     "legal.dataUse",
-                    "We use your data to: respond to your contact form enquiries, process and fulfil orders, send newsletter updates (only with consent), improve our website and services, comply with legal obligations, prevent fraud and ensure security, and — with consent — personalise content and advertising.",
+                    "We use your data to: respond to your contact form enquiries, process and fulfil orders, send newsletter updates (only with consent), improve our website and services, comply with legal obligations, prevent fraud and ensure security, and — with consent — personalise content and advertising."
                   )}
                 </p>
               </Section>
@@ -181,15 +153,12 @@ export default async function PrivacyPolicyPage() {
             <ScrollReveal>
               <Section
                 id="data-sharing"
-                title={t(
-                  "legal.dataSharingTitle",
-                  "6. Data Sharing & Third Parties",
-                )}
+                title={t("legal.dataSharingTitle", "6. Data Sharing & Third Parties")}
               >
                 <p>
                   {t(
                     "legal.dataSharing",
-                    "We share data only with processors that are necessary to deliver our services: Stripe (payment processing, US — EU-US Data Privacy Framework certified), Amazon Web Services (hosting and email via SES, EU region), and AWS Cognito (authentication). We do not sell your personal data. Each third-party processor is bound by a Data Processing Agreement (DPA) and processes data only on our instructions.",
+                    "We share data only with processors that are necessary to deliver our services: Stripe (payment processing, US — EU-US Data Privacy Framework certified), Amazon Web Services (hosting and email via SES, EU region), and AWS Cognito (authentication). We do not sell your personal data. Each third-party processor is bound by a Data Processing Agreement (DPA) and processes data only on our instructions."
                   )}
                 </p>
               </Section>
@@ -198,123 +167,96 @@ export default async function PrivacyPolicyPage() {
             <ScrollReveal>
               <Section
                 id="data-transfers"
-                title={t(
-                  "legal.dataTransfersTitle",
-                  "7. International Data Transfers",
-                )}
+                title={t("legal.dataTransfersTitle", "7. International Data Transfers")}
               >
                 <p>
                   {t(
                     "legal.dataTransfers",
-                    "Some of our processors (e.g. Stripe) are based in the United States. These transfers are protected by the EU-US Data Privacy Framework, Standard Contractual Clauses (SCCs), or your explicit consent, in accordance with GDPR Chapter V.",
+                    "Some of our processors (e.g. Stripe) are based in the United States. These transfers are protected by the EU-US Data Privacy Framework, Standard Contractual Clauses (SCCs), or your explicit consent, in accordance with GDPR Chapter V."
                   )}
                 </p>
               </Section>
             </ScrollReveal>
 
             <ScrollReveal>
-              <Section
-                id="retention"
-                title={t("legal.retentionTitle", "8. Data Retention")}
-              >
+              <Section id="retention" title={t("legal.retentionTitle", "8. Data Retention")}>
                 <p>
                   {t(
                     "legal.retention",
-                    "Contact form submissions: 2 years, then deleted. Newsletter subscriptions: until you unsubscribe. Purchase records: 7 years (Greek tax law requirement). Account data: until you request deletion. Analytics data: 14 months (anonymised). Cookie consent records: 1 year.",
+                    "Contact form submissions: 2 years, then deleted. Newsletter subscriptions: until you unsubscribe. Purchase records: 7 years (Greek tax law requirement). Account data: until you request deletion. Analytics data: 14 months (anonymised). Cookie consent records: 1 year."
                   )}
                 </p>
               </Section>
             </ScrollReveal>
 
             <ScrollReveal>
-              <Section
-                id="your-rights"
-                title={t("legal.yourRightsTitle", "9. Your Rights")}
-              >
+              <Section id="your-rights" title={t("legal.yourRightsTitle", "9. Your Rights")}>
                 <p className="font-semibold text-white">
-                  {t(
-                    "legal.gdprRightsTitle",
-                    "Under the GDPR, you have the right to:",
-                  )}
+                  {t("legal.gdprRightsTitle", "Under the GDPR, you have the right to:")}
                 </p>
                 <p>
                   {t(
                     "legal.gdprRights",
-                    'Access — request a copy of your personal data. Rectification — correct inaccurate data. Erasure — request deletion of your data ("right to be forgotten"). Restriction — limit how we process your data. Portability — receive your data in a machine-readable format. Objection — object to processing based on legitimate interest. Withdraw consent — at any time, without affecting prior processing.',
+                    'Access — request a copy of your personal data. Rectification — correct inaccurate data. Erasure — request deletion of your data ("right to be forgotten"). Restriction — limit how we process your data. Portability — receive your data in a machine-readable format. Objection — object to processing based on legitimate interest. Withdraw consent — at any time, without affecting prior processing.'
                   )}
                 </p>
                 <p className="font-semibold text-white">
-                  {t(
-                    "legal.ccpaRightsTitle",
-                    "Under the CCPA/CPRA (California residents):",
-                  )}
+                  {t("legal.ccpaRightsTitle", "Under the CCPA/CPRA (California residents):")}
                 </p>
                 <p>
                   {t(
                     "legal.ccpaRights",
-                    "Right to know what personal data we collect and why. Right to delete your personal data. Right to opt out of the sale of personal data (we do not sell your data). Right to non-discrimination for exercising your privacy rights.",
+                    "Right to know what personal data we collect and why. Right to delete your personal data. Right to opt out of the sale of personal data (we do not sell your data). Right to non-discrimination for exercising your privacy rights."
                   )}
                 </p>
                 <p>
                   {t(
                     "legal.rightsExercise",
-                    "To exercise any of these rights, email us at tbaltzakis@cloudless.gr. We will respond within 30 days (GDPR) or 45 days (CCPA).",
+                    "To exercise any of these rights, email us at tbaltzakis@cloudless.gr. We will respond within 30 days (GDPR) or 45 days (CCPA)."
                   )}
                 </p>
               </Section>
             </ScrollReveal>
 
             <ScrollReveal>
-              <Section
-                id="children"
-                title={t("legal.childrenTitle", "10. Children's Privacy")}
-              >
+              <Section id="children" title={t("legal.childrenTitle", "10. Children's Privacy")}>
                 <p>
                   {t(
                     "legal.children",
-                    "Our services are not directed at children under 16. We do not knowingly collect personal data from children. If you believe we have inadvertently collected such data, please contact us immediately.",
+                    "Our services are not directed at children under 16. We do not knowingly collect personal data from children. If you believe we have inadvertently collected such data, please contact us immediately."
                   )}
                 </p>
               </Section>
             </ScrollReveal>
 
             <ScrollReveal>
-              <Section
-                id="security"
-                title={t("legal.securityTitle", "11. Data Security")}
-              >
+              <Section id="security" title={t("legal.securityTitle", "11. Data Security")}>
                 <p>
                   {t(
                     "legal.security",
-                    "We implement appropriate technical and organisational measures to protect your data, including: HTTPS/TLS encryption in transit, encryption at rest for stored data, access controls and authentication, regular security reviews, and incident response procedures.",
+                    "We implement appropriate technical and organisational measures to protect your data, including: HTTPS/TLS encryption in transit, encryption at rest for stored data, access controls and authentication, regular security reviews, and incident response procedures."
                   )}
                 </p>
               </Section>
             </ScrollReveal>
 
             <ScrollReveal>
-              <Section
-                id="complaints"
-                title={t("legal.complaintsTitle", "12. Complaints")}
-              >
+              <Section id="complaints" title={t("legal.complaintsTitle", "12. Complaints")}>
                 <p>
                   {t(
                     "legal.complaints",
-                    "If you believe we have not handled your data correctly, you have the right to lodge a complaint with the Hellenic Data Protection Authority (HDPA) at www.dpa.gr, or your local supervisory authority if you reside in another EU/EEA country.",
+                    "If you believe we have not handled your data correctly, you have the right to lodge a complaint with the Hellenic Data Protection Authority (HDPA) at www.dpa.gr, or your local supervisory authority if you reside in another EU/EEA country."
                   )}
                 </p>
               </Section>
             </ScrollReveal>
 
             <ScrollReveal>
-              <Section
-                id="changes"
-                title={t("legal.changesTitle", "13. Changes to This Policy")}
-              >
+              <Section id="changes" title={t("legal.changesTitle", "13. Changes to This Policy")}>
                 <p>
                   {t(
                     "legal.changes",
-                    'We may update this Privacy Policy from time to time. Material changes will be communicated via a notice on our website. The "Last updated" date at the top reflects the most recent revision.',
+                    'We may update this Privacy Policy from time to time. Material changes will be communicated via a notice on our website. The "Last updated" date at the top reflects the most recent revision.'
                   )}
                 </p>
               </Section>

--- a/src/app/[locale]/refund/page.tsx
+++ b/src/app/[locale]/refund/page.tsx
@@ -25,12 +25,8 @@ function Section({
 }) {
   return (
     <section id={id} className="scroll-mt-24">
-      <h2 className="text-neon-cyan/80 mb-4 font-heading text-xl font-bold text-white">
-        {title}
-      </h2>
-      <div className="space-y-3 text-sm leading-relaxed text-slate-300">
-        {children}
-      </div>
+      <h2 className="text-neon-cyan/80 font-heading mb-4 text-xl font-bold text-white">{title}</h2>
+      <div className="space-y-3 text-sm leading-relaxed text-slate-300">{children}</div>
     </section>
   );
 }
@@ -57,7 +53,7 @@ export default async function RefundPolicyPage() {
             <p className="text-neon-cyan/70 mb-4 font-mono text-xs tracking-widest">
               {t("legal.legalDocument", "LEGAL DOCUMENT")}
             </p>
-            <h1 className="mb-4 font-heading text-3xl font-bold text-white lg:text-4xl">
+            <h1 className="font-heading mb-4 text-3xl font-bold text-white lg:text-4xl">
               {t("legal.refundTitle", "Refund & Returns Policy")}
             </h1>
             <p className="mb-2 font-mono text-xs text-slate-500">
@@ -66,7 +62,7 @@ export default async function RefundPolicyPage() {
             <p className="mb-12 text-sm leading-relaxed text-slate-400">
               {t(
                 "legal.refundIntro",
-                "We want you to be completely satisfied with your purchase. This policy outlines your rights regarding refunds and returns, including the EU 14-day right of withdrawal.",
+                "We want you to be completely satisfied with your purchase. This policy outlines your rights regarding refunds and returns, including the EU 14-day right of withdrawal."
               )}
             </p>
           </ScrollReveal>
@@ -77,25 +73,25 @@ export default async function RefundPolicyPage() {
                 id="eu-withdrawal"
                 title={t(
                   "legal.euWithdrawalTitle",
-                  "1. EU Right of Withdrawal (14-Day Cooling-Off Period)",
+                  "1. EU Right of Withdrawal (14-Day Cooling-Off Period)"
                 )}
               >
                 <p>
                   {t(
                     "legal.euWithdrawal",
-                    "If you are a consumer in the European Union, you have the right to withdraw from a purchase within 14 calendar days without giving any reason, as guaranteed by the Consumer Rights Directive (2011/83/EU).",
+                    "If you are a consumer in the European Union, you have the right to withdraw from a purchase within 14 calendar days without giving any reason, as guaranteed by the Consumer Rights Directive (2011/83/EU)."
                   )}
                 </p>
                 <p>
                   {t(
                     "legal.euWithdrawalPeriod",
-                    "The withdrawal period expires 14 days after the day of the conclusion of the contract (for services) or the day you receive the goods (for physical products).",
+                    "The withdrawal period expires 14 days after the day of the conclusion of the contract (for services) or the day you receive the goods (for physical products)."
                   )}
                 </p>
                 <p>
                   {t(
                     "legal.euWithdrawalHow",
-                    "To exercise your right of withdrawal, send a clear statement (e.g. by email) to tbaltzakis@cloudless.gr. You may use the model withdrawal form below, but it is not obligatory.",
+                    "To exercise your right of withdrawal, send a clear statement (e.g. by email) to tbaltzakis@cloudless.gr. You may use the model withdrawal form below, but it is not obligatory."
                   )}
                 </p>
               </Section>
@@ -104,22 +100,16 @@ export default async function RefundPolicyPage() {
             <ScrollReveal>
               <Section
                 id="withdrawal-form"
-                title={t(
-                  "legal.withdrawalFormTitle",
-                  "2. Model Withdrawal Form",
-                )}
+                title={t("legal.withdrawalFormTitle", "2. Model Withdrawal Form")}
               >
                 <div className="bg-void rounded-lg border border-slate-700 p-4 font-mono text-xs">
                   <p className="mb-2 text-slate-300">
-                    {t(
-                      "legal.withdrawalFormTo",
-                      "To: Cloudless — tbaltzakis@cloudless.gr",
-                    )}
+                    {t("legal.withdrawalFormTo", "To: Cloudless — tbaltzakis@cloudless.gr")}
                   </p>
                   <p className="mb-2 text-slate-300">
                     {t(
                       "legal.withdrawalFormBody",
-                      "I hereby give notice that I withdraw from my contract for the provision of the following service/product: [describe]. Ordered on: [date]. Consumer name: [your name]. Consumer address: [your address]. Date: [today's date]. Signature (if sent on paper): ___",
+                      "I hereby give notice that I withdraw from my contract for the provision of the following service/product: [describe]. Ordered on: [date]. Consumer name: [your name]. Consumer address: [your address]. Date: [today's date]. Signature (if sent on paper): ___"
                     )}
                   </p>
                 </div>
@@ -129,15 +119,12 @@ export default async function RefundPolicyPage() {
             <ScrollReveal>
               <Section
                 id="exceptions"
-                title={t(
-                  "legal.exceptionsTitle",
-                  "3. Exceptions to the Right of Withdrawal",
-                )}
+                title={t("legal.exceptionsTitle", "3. Exceptions to the Right of Withdrawal")}
               >
                 <p>
                   {t(
                     "legal.exceptions",
-                    "The right of withdrawal does not apply in the following cases, as permitted by Article 16 of Directive 2011/83/EU: (a) Digital content — once you have started downloading or accessing digital content, provided you gave prior express consent and acknowledged that you lose the right of withdrawal. (b) Fully performed services — if the service has been fully performed and you gave prior express consent and acknowledged that you lose the right of withdrawal once the contract is fully performed. (c) Personalised services — services made to your specifications or clearly personalised to your business needs.",
+                    "The right of withdrawal does not apply in the following cases, as permitted by Article 16 of Directive 2011/83/EU: (a) Digital content — once you have started downloading or accessing digital content, provided you gave prior express consent and acknowledged that you lose the right of withdrawal. (b) Fully performed services — if the service has been fully performed and you gave prior express consent and acknowledged that you lose the right of withdrawal once the contract is fully performed. (c) Personalised services — services made to your specifications or clearly personalised to your business needs."
                   )}
                 </p>
               </Section>
@@ -151,7 +138,7 @@ export default async function RefundPolicyPage() {
                 <p>
                   {t(
                     "legal.refundProcess",
-                    "If you exercise your right of withdrawal, we will reimburse all payments received from you within 14 days of receiving your withdrawal notice. We will use the same payment method you used for the initial transaction (Stripe refund to your original card). No fees will be charged for the refund.",
+                    "If you exercise your right of withdrawal, we will reimburse all payments received from you within 14 days of receiving your withdrawal notice. We will use the same payment method you used for the initial transaction (Stripe refund to your original card). No fees will be charged for the refund."
                   )}
                 </p>
               </Section>
@@ -160,72 +147,54 @@ export default async function RefundPolicyPage() {
             <ScrollReveal>
               <Section
                 id="service-issues"
-                title={t(
-                  "legal.serviceIssuesTitle",
-                  "5. Service Quality Issues",
-                )}
+                title={t("legal.serviceIssuesTitle", "5. Service Quality Issues")}
               >
                 <p>
                   {t(
                     "legal.serviceIssues",
-                    "If you are dissatisfied with a service we delivered, please contact us within 30 days of delivery. We will work with you to resolve the issue, which may include: re-performing part of the service at no extra cost, providing a partial refund proportional to the issue, or offering a credit toward future services.",
+                    "If you are dissatisfied with a service we delivered, please contact us within 30 days of delivery. We will work with you to resolve the issue, which may include: re-performing part of the service at no extra cost, providing a partial refund proportional to the issue, or offering a credit toward future services."
                   )}
                 </p>
               </Section>
             </ScrollReveal>
 
             <ScrollReveal>
-              <Section
-                id="subscriptions"
-                title={t("legal.subscriptionsTitle", "6. Subscriptions")}
-              >
+              <Section id="subscriptions" title={t("legal.subscriptionsTitle", "6. Subscriptions")}>
                 <p>
                   {t(
                     "legal.subscriptions",
-                    "For subscription-based services, you may cancel at any time. Cancellation takes effect at the end of the current billing period. No refunds are provided for partial billing periods unless required by law. The 14-day right of withdrawal applies to the initial subscription purchase.",
+                    "For subscription-based services, you may cancel at any time. Cancellation takes effect at the end of the current billing period. No refunds are provided for partial billing periods unless required by law. The 14-day right of withdrawal applies to the initial subscription purchase."
                   )}
                 </p>
               </Section>
             </ScrollReveal>
 
             <ScrollReveal>
-              <Section
-                id="us-customers"
-                title={t("legal.usCustomersTitle", "7. US Customers")}
-              >
+              <Section id="us-customers" title={t("legal.usCustomersTitle", "7. US Customers")}>
                 <p>
                   {t(
                     "legal.usCustomers",
-                    "While US federal law does not mandate a cooling-off period for online purchases, we extend the same 14-day refund policy to all customers regardless of location, subject to the same exceptions listed above.",
+                    "While US federal law does not mandate a cooling-off period for online purchases, we extend the same 14-day refund policy to all customers regardless of location, subject to the same exceptions listed above."
                   )}
                 </p>
               </Section>
             </ScrollReveal>
 
             <ScrollReveal>
-              <Section
-                id="refund-contact"
-                title={t("legal.refundContactTitle", "8. Contact Us")}
-              >
+              <Section id="refund-contact" title={t("legal.refundContactTitle", "8. Contact Us")}>
                 <p>
                   {t(
                     "legal.refundContact",
-                    "To request a refund or discuss a service issue, email us at tbaltzakis@cloudless.gr. We aim to respond within 2 business days.",
+                    "To request a refund or discuss a service issue, email us at tbaltzakis@cloudless.gr. We aim to respond within 2 business days."
                   )}
                 </p>
                 <p>
                   {t("legal.refundSeeAlso", "See also:")}{" "}
-                  <Link
-                    href="/terms"
-                    className="text-neon-cyan hover:underline"
-                  >
+                  <Link href="/terms" className="text-neon-cyan hover:underline">
                     {t("legal.termsTitle", "Terms of Service")}
                   </Link>
                   {" | "}
-                  <Link
-                    href="/privacy"
-                    className="text-neon-cyan hover:underline"
-                  >
+                  <Link href="/privacy" className="text-neon-cyan hover:underline">
                     {t("legal.privacyTitle", "Privacy Policy")}
                   </Link>
                 </p>

--- a/src/app/[locale]/services/opengraph-image.tsx
+++ b/src/app/[locale]/services/opengraph-image.tsx
@@ -8,8 +8,7 @@ export default function Image() {
   return new ImageResponse(
     <div
       style={{
-        background:
-          "linear-gradient(135deg, #0a0a0f 0%, #12121a 50%, #1a1a2e 100%)",
+        background: "linear-gradient(135deg, #0a0a0f 0%, #12121a 50%, #1a1a2e 100%)",
         width: "100%",
         height: "100%",
         display: "flex",
@@ -101,8 +100,7 @@ export default function Image() {
           maxWidth: 700,
         }}
       >
-        Cloud infrastructure, web applications, and digital solutions tailored
-        for your business
+        Cloud infrastructure, web applications, and digital solutions tailored for your business
       </div>
 
       {/* Footer */}
@@ -115,23 +113,18 @@ export default function Image() {
         }}
       >
         <div style={{ display: "flex", alignItems: "baseline", gap: 6 }}>
-          <span style={{ fontSize: 28, color: "#ffffff", fontWeight: 800 }}>
-            cloudless
-          </span>
-          <span style={{ fontSize: 28, color: "#00fff5", fontWeight: 800 }}>
-            .gr
-          </span>
+          <span style={{ fontSize: 28, color: "#ffffff", fontWeight: 800 }}>cloudless</span>
+          <span style={{ fontSize: 28, color: "#00fff5", fontWeight: 800 }}>.gr</span>
         </div>
         <div
           style={{
             width: 120,
             height: 2,
-            background:
-              "linear-gradient(90deg, transparent, #00fff5, transparent)",
+            background: "linear-gradient(90deg, transparent, #00fff5, transparent)",
           }}
         />
       </div>
     </div>,
-    { width: 1200, height: 630 },
+    { width: 1200, height: 630 }
   );
 }

--- a/src/app/[locale]/services/page.tsx
+++ b/src/app/[locale]/services/page.tsx
@@ -5,11 +5,7 @@ import { Link } from "@/i18n/navigation";
 import ScrollReveal from "@/components/ScrollReveal";
 import TerminalBlock from "@/components/TerminalBlock";
 import JsonLd from "@/components/JsonLd";
-import {
-  getServiceSchema,
-  getBreadcrumbSchema,
-  getFAQSchema,
-} from "@/lib/structured-data";
+import { getServiceSchema, getBreadcrumbSchema, getFAQSchema } from "@/lib/structured-data";
 import { translate } from "@/lib/i18n";
 import { getServerLocale } from "@/lib/server-locale";
 import StatCounter from "@/components/StatCounter";
@@ -73,15 +69,15 @@ const getServices = (t: (key: string, fallback: string) => string) => [
     planKey: "cloud",
     outcome: t(
       "servicesPage.s1Outcome",
-      "Typically saves €15K–€50K/year in infrastructure costs alone.",
+      "Typically saves €15K–€50K/year in infrastructure costs alone."
     ),
     perfectFor: t(
       "servicesSection.service1For",
-      "For teams paying €500+/mo for infrastructure they can't explain.",
+      "For teams paying €500+/mo for infrastructure they can't explain."
     ),
     description: t(
       "servicesSection.service1Desc",
-      "Design resilient, cost-optimised cloud infrastructure on AWS, GCP, or Azure. We handle architecture blueprints, zero-downtime migrations, and Infrastructure as Code — so your team ships faster with less risk.",
+      "Design resilient, cost-optimised cloud infrastructure on AWS, GCP, or Azure. We handle architecture blueprints, zero-downtime migrations, and Infrastructure as Code — so your team ships faster with less risk."
     ),
     features: [
       "AWS / GCP / Azure architecture design",
@@ -118,15 +114,15 @@ const getServices = (t: (key: string, fallback: string) => string) => [
     planKey: "serverless",
     outcome: t(
       "servicesPage.s2Outcome",
-      "Up to 60–80% infrastructure savings. Pay only when code actually runs.",
+      "Up to 60–80% infrastructure savings. Pay only when code actually runs."
     ),
     perfectFor: t(
       "servicesSection.service2For",
-      "For founders tired of paying for servers that sit idle 90% of the time.",
+      "For founders tired of paying for servers that sit idle 90% of the time."
     ),
     description: t(
       "servicesSection.service2Desc",
-      "Build event-driven apps that scale to zero and explode to millions — without managing a single server. Lambda, API Gateway, DynamoDB, Step Functions — we wire it all together with CI/CD from day one.",
+      "Build event-driven apps that scale to zero and explode to millions — without managing a single server. Lambda, API Gateway, DynamoDB, Step Functions — we wire it all together with CI/CD from day one."
     ),
     features: [
       "Event-driven application design",
@@ -163,15 +159,15 @@ const getServices = (t: (key: string, fallback: string) => string) => [
     planKey: "analytics",
     outcome: t(
       "servicesPage.s3Outcome",
-      "Replace gut-feeling decisions with real data. 10x faster insights from your existing data.",
+      "Replace gut-feeling decisions with real data. 10x faster insights from your existing data."
     ),
     perfectFor: t(
       "servicesSection.service3For",
-      "For teams making decisions on gut feeling instead of data.",
+      "For teams making decisions on gut feeling instead of data."
     ),
     description: t(
       "servicesSection.service3Desc",
-      "Turn raw data into decisions. Custom ETL pipelines, real-time dashboards, and BI reporting — all built on modern data stacks so your metrics are always fresh and always actionable.",
+      "Turn raw data into decisions. Custom ETL pipelines, real-time dashboards, and BI reporting — all built on modern data stacks so your metrics are always fresh and always actionable."
     ),
     features: [
       "Custom analytics dashboards",
@@ -208,15 +204,15 @@ const getServices = (t: (key: string, fallback: string) => string) => [
     planKey: "marketing",
     outcome: t(
       "servicesPage.s4Outcome",
-      "Typically 3x organic traffic growth. Know exactly which channels are converting.",
+      "Typically 3x organic traffic growth. Know exactly which channels are converting."
     ),
     perfectFor: t(
       "servicesSection.service4For",
-      "For startups spending on ads with no idea what's actually working.",
+      "For startups spending on ads with no idea what's actually working."
     ),
     description: t(
       "servicesSection.service4Desc",
-      "AI-powered content, SEO, paid ads, and social automation — driven by real data, not guesswork. We build growth engines that compound month over month.",
+      "AI-powered content, SEO, paid ads, and social automation — driven by real data, not guesswork. We build growth engines that compound month over month."
     ),
     features: [
       "AI-powered content strategy",
@@ -253,15 +249,15 @@ const getServices = (t: (key: string, fallback: string) => string) => [
     planKey: "web",
     outcome: t(
       "servicesPage.s5Outcome",
-      "Launch a fast, on-brand site in 4 weeks. Conversion-focused from day one.",
+      "Launch a fast, on-brand site in 4 weeks. Conversion-focused from day one."
     ),
     perfectFor: t(
       "servicesSection.service5For",
-      "For founders with a Wix/Squarespace site that doesn't convert.",
+      "For founders with a Wix/Squarespace site that doesn't convert."
     ),
     description: t(
       "servicesSection.service5Desc",
-      "Custom-designed marketing sites and web apps built on Next.js. Lighthouse scores in the high 90s, accessible by default, and wired to your CRM and analytics out of the box.",
+      "Custom-designed marketing sites and web apps built on Next.js. Lighthouse scores in the high 90s, accessible by default, and wired to your CRM and analytics out of the box."
     ),
     features: [
       "Custom design — no themes or templates",
@@ -298,15 +294,15 @@ const getServices = (t: (key: string, fallback: string) => string) => [
     planKey: "hosting",
     outcome: t(
       "servicesPage.s6Outcome",
-      "99.9% uptime, automatic backups, security patches handled. You sleep, we monitor.",
+      "99.9% uptime, automatic backups, security patches handled. You sleep, we monitor."
     ),
     perfectFor: t(
       "servicesSection.service6For",
-      "For teams whose site keeps breaking and nobody owns the infrastructure.",
+      "For teams whose site keeps breaking and nobody owns the infrastructure."
     ),
     description: t(
       "servicesSection.service6Desc",
-      "Production hosting on AWS or Vercel with monitoring, backups, security patches, and on-call response baked in. Your site stays fast, secure, and online — without you ever opening a console.",
+      "Production hosting on AWS or Vercel with monitoring, backups, security patches, and on-call response baked in. Your site stays fast, secure, and online — without you ever opening a console."
     ),
     features: [
       "AWS / Vercel managed hosting",
@@ -340,44 +336,38 @@ const getServicesFaqs = (t: (key: string, fallback: string) => string) => [
     question: t("servicesPage.faq1Q", "How much will I actually save?"),
     answer: t(
       "servicesPage.faq1A",
-      "Cloud Architecture projects typically save €15K–€50K/year in infrastructure costs. Serverless cuts hosting bills by up to 60–80%. The full bundle at €3,600/mo replaces €20K+ in salaries. The free audit gives you exact numbers for your specific setup.",
+      "Cloud Architecture projects typically save €15K–€50K/year in infrastructure costs. Serverless cuts hosting bills by up to 60–80%. The full bundle at €3,600/mo replaces €20K+ in salaries. The free audit gives you exact numbers for your specific setup."
     ),
   },
   {
     question: t(
       "servicesPage.faq2Q",
-      "What's the difference between hiring a CTO and using Cloudless?",
+      "What's the difference between hiring a CTO and using Cloudless?"
     ),
     answer: t(
       "servicesPage.faq2A",
-      "A CTO costs €8K–€12K/month in salary alone, needs 3–6 months to ramp up, and handles strategy but not execution. We deliver architecture, development, analytics, and marketing — execution from day one, at a fraction of the cost. And you can cancel anytime.",
+      "A CTO costs €8K–€12K/month in salary alone, needs 3–6 months to ramp up, and handles strategy but not execution. We deliver architecture, development, analytics, and marketing — execution from day one, at a fraction of the cost. And you can cancel anytime."
     ),
   },
   {
-    question: t(
-      "servicesPage.faq3Q",
-      "Can you work with our existing infrastructure?",
-    ),
+    question: t("servicesPage.faq3Q", "Can you work with our existing infrastructure?"),
     answer: t(
       "servicesPage.faq3A",
-      "Absolutely. We start with an audit of your current setup and create a phased migration plan. No rip-and-replace — we improve what you have and build from there.",
+      "Absolutely. We start with an audit of your current setup and create a phased migration plan. No rip-and-replace — we improve what you have and build from there."
     ),
   },
   {
     question: t("servicesPage.faq4Q", "What happens after the project ends?"),
     answer: t(
       "servicesPage.faq4A",
-      "Everything we build is yours — fully documented, handoff-ready, and built with standard tools (Terraform, AWS CDK, GitHub Actions). Your next engineer picks it up without calling us.",
+      "Everything we build is yours — fully documented, handoff-ready, and built with standard tools (Terraform, AWS CDK, GitHub Actions). Your next engineer picks it up without calling us."
     ),
   },
   {
-    question: t(
-      "servicesPage.faq5Q",
-      "How do I know this will work for my business?",
-    ),
+    question: t("servicesPage.faq5Q", "How do I know this will work for my business?"),
     answer: t(
       "servicesPage.faq5A",
-      "The free audit tells you. In 30 minutes, we review your setup and give you a concrete action plan with specific ROI estimates. Most founders say it's the most useful 30 minutes they've spent on their tech stack — even if they never hire us.",
+      "The free audit tells you. In 30 minutes, we review your setup and give you a concrete action plan with specific ROI estimates. Most founders say it's the most useful 30 minutes they've spent on their tech stack — even if they never hire us."
     ),
   },
 ];
@@ -486,45 +476,41 @@ export default async function ServicesPage() {
             </span>
             {t("servicesPage.badge", "Transparent Pricing")}
           </div>
-          <h1 className="animate-fade-in-up delay-100 font-heading text-3xl leading-tight font-bold md:text-5xl">
+          <h1 className="animate-fade-in-up font-heading text-3xl leading-tight font-bold delay-100 md:text-5xl">
             {t("servicesPage.title", "No hidden fees.")}{" "}
             <span className="from-neon-cyan to-neon-magenta bg-gradient-to-r bg-clip-text text-transparent">
               {t("servicesPage.titleHighlight", "Real results.")}
             </span>
           </h1>
-          <p className="animate-fade-in-up delay-200 mt-4 max-w-xl text-lg text-slate-400">
+          <p className="animate-fade-in-up mt-4 max-w-xl text-lg text-slate-400 delay-200">
             {t(
               "servicesPage.subtitle",
-              "Pick what you need or bundle everything for 30% savings. No lock-in contracts — your code is always yours.",
+              "Pick what you need or bundle everything for 30% savings. No lock-in contracts — your code is always yours."
             )}
           </p>
         </div>
       </section>
 
       {/* ── The System — 3-step process indicator ───────────── */}
-      <section className="border-b border-slate-800 bg-void-light/20 py-10">
+      <section className="bg-void-light/20 border-b border-slate-800 py-10">
         <div className="mx-auto max-w-6xl px-6">
           <p className="mb-7 text-center font-mono text-xs tracking-[0.3em] text-slate-500">
             [ HOW IT WORKS ]
           </p>
           <div className="relative flex flex-col items-center gap-8 sm:flex-row sm:items-start sm:justify-between">
             {/* Connector line — desktop only */}
-            <div className="absolute top-5 left-[calc(16.67%+2rem)] right-[calc(16.67%+2rem)] hidden h-px bg-gradient-to-r from-neon-cyan/40 via-neon-magenta/40 to-neon-green/40 sm:block" />
+            <div className="from-neon-cyan/40 via-neon-magenta/40 to-neon-green/40 absolute top-5 right-[calc(16.67%+2rem)] left-[calc(16.67%+2rem)] hidden h-px bg-gradient-to-r sm:block" />
 
             {/* Step 1 */}
             <a
               href="#audit"
               className="group relative flex flex-1 flex-col items-center text-center"
             >
-              <div className="relative z-10 mb-3 flex h-10 w-10 items-center justify-center rounded-full border border-neon-cyan/30 bg-void font-mono text-sm font-bold text-neon-cyan ring-1 ring-neon-cyan/20 transition-all duration-200 group-hover:bg-neon-cyan/10 group-hover:scale-110">
+              <div className="border-neon-cyan/30 bg-void text-neon-cyan ring-neon-cyan/20 group-hover:bg-neon-cyan/10 relative z-10 mb-3 flex h-10 w-10 items-center justify-center rounded-full border font-mono text-sm font-bold ring-1 transition-all duration-200 group-hover:scale-110">
                 01
               </div>
-              <span className="font-mono text-xs font-semibold text-neon-cyan">
-                Free Audit
-              </span>
-              <span className="mt-1 text-xs text-slate-500">
-                30-min strategy call
-              </span>
+              <span className="text-neon-cyan font-mono text-xs font-semibold">Free Audit</span>
+              <span className="mt-1 text-xs text-slate-500">30-min strategy call</span>
             </a>
 
             {/* Step 2 — active (this page) */}
@@ -532,16 +518,14 @@ export default async function ServicesPage() {
               href="#services"
               className="group relative flex flex-1 flex-col items-center text-center"
             >
-              <div className="relative z-10 mb-3 flex h-10 w-10 items-center justify-center rounded-full border border-neon-magenta bg-neon-magenta/15 font-mono text-sm font-bold text-neon-magenta ring-2 ring-neon-magenta/25 transition-all duration-200 group-hover:bg-neon-magenta/25">
+              <div className="border-neon-magenta bg-neon-magenta/15 text-neon-magenta ring-neon-magenta/25 group-hover:bg-neon-magenta/25 relative z-10 mb-3 flex h-10 w-10 items-center justify-center rounded-full border font-mono text-sm font-bold ring-2 transition-all duration-200">
                 02
               </div>
-              <span className="font-mono text-xs font-semibold text-neon-magenta">
+              <span className="text-neon-magenta font-mono text-xs font-semibold">
                 Choose Your Scope
               </span>
-              <span className="mt-1 text-xs text-slate-500">
-                Services or bundle
-              </span>
-              <span className="mt-1.5 rounded-full bg-neon-magenta/10 px-2 py-0.5 font-mono text-[9px] text-neon-magenta">
+              <span className="mt-1 text-xs text-slate-500">Services or bundle</span>
+              <span className="bg-neon-magenta/10 text-neon-magenta mt-1.5 rounded-full px-2 py-0.5 font-mono text-[9px]">
                 You are here
               </span>
             </a>
@@ -551,35 +535,30 @@ export default async function ServicesPage() {
               href="#results"
               className="group relative flex flex-1 flex-col items-center text-center"
             >
-              <div className="relative z-10 mb-3 flex h-10 w-10 items-center justify-center rounded-full border border-neon-green/30 bg-void font-mono text-sm font-bold text-neon-green ring-1 ring-neon-green/20 transition-all duration-200 group-hover:bg-neon-green/10 group-hover:scale-110">
+              <div className="border-neon-green/30 bg-void text-neon-green ring-neon-green/20 group-hover:bg-neon-green/10 relative z-10 mb-3 flex h-10 w-10 items-center justify-center rounded-full border font-mono text-sm font-bold ring-1 transition-all duration-200 group-hover:scale-110">
                 03
               </div>
-              <span className="font-mono text-xs font-semibold text-neon-green">
+              <span className="text-neon-green font-mono text-xs font-semibold">
                 Results in 14 Days
               </span>
-              <span className="mt-1 text-xs text-slate-500">
-                Measurable progress
-              </span>
+              <span className="mt-1 text-xs text-slate-500">Measurable progress</span>
             </a>
           </div>
         </div>
       </section>
 
       {/* ── Step 1: Free Audit ──────────────────────────────── */}
-      <section
-        id="audit"
-        className="scroll-mt-24 bg-void border-b border-slate-800 py-20 lg:py-24"
-      >
+      <section id="audit" className="bg-void scroll-mt-24 border-b border-slate-800 py-20 lg:py-24">
         <div className="mx-auto max-w-6xl px-6">
           <ScrollReveal>
             <div className="flex flex-col items-start gap-10 lg:flex-row lg:items-center lg:gap-20">
               {/* Text */}
               <div className="flex-1">
                 <div className="mb-4 flex items-center gap-3">
-                  <span className="flex h-8 w-8 items-center justify-center rounded-full border border-neon-cyan/30 bg-neon-cyan/10 font-mono text-xs font-bold text-neon-cyan">
+                  <span className="border-neon-cyan/30 bg-neon-cyan/10 text-neon-cyan flex h-8 w-8 items-center justify-center rounded-full border font-mono text-xs font-bold">
                     01
                   </span>
-                  <span className="font-mono text-xs tracking-[0.15em] text-neon-cyan">
+                  <span className="text-neon-cyan font-mono text-xs tracking-[0.15em]">
                     FREE AUDIT
                   </span>
                 </div>
@@ -587,9 +566,8 @@ export default async function ServicesPage() {
                   Start with a free 30-min strategy call
                 </h2>
                 <p className="mt-3 leading-relaxed text-slate-400">
-                  No pitch. No commitment. We review your current setup,
-                  identify quick wins, and give you a concrete action plan —
-                  completely free.
+                  No pitch. No commitment. We review your current setup, identify quick wins, and
+                  give you a concrete action plan — completely free.
                 </p>
                 <ul className="mt-6 space-y-3">
                   {[
@@ -597,22 +575,15 @@ export default async function ServicesPage() {
                     "Specific ROI estimates for your setup",
                     "Prioritised action plan you keep regardless",
                   ].map((item) => (
-                    <li
-                      key={item}
-                      className="flex items-start gap-3 text-sm text-slate-300"
-                    >
+                    <li key={item} className="flex items-start gap-3 text-sm text-slate-300">
                       <svg
-                        className="mt-0.5 h-5 w-5 shrink-0 text-neon-cyan"
+                        className="text-neon-cyan mt-0.5 h-5 w-5 shrink-0"
                         fill="none"
                         viewBox="0 0 24 24"
                         stroke="currentColor"
                         strokeWidth={2.5}
                       >
-                        <path
-                          strokeLinecap="round"
-                          strokeLinejoin="round"
-                          d="M5 13l4 4L19 7"
-                        />
+                        <path strokeLinecap="round" strokeLinejoin="round" d="M5 13l4 4L19 7" />
                       </svg>
                       {item}
                     </li>
@@ -621,7 +592,7 @@ export default async function ServicesPage() {
                 <div className="mt-8">
                   <Link
                     href="/contact"
-                    className="group/link inline-flex items-center gap-2 rounded-lg border border-neon-cyan/50 bg-neon-cyan/10 px-6 py-3 font-mono text-sm font-semibold text-neon-cyan transition-all duration-300 hover:bg-neon-cyan/20"
+                    className="group/link border-neon-cyan/50 bg-neon-cyan/10 text-neon-cyan hover:bg-neon-cyan/20 inline-flex items-center gap-2 rounded-lg border px-6 py-3 font-mono text-sm font-semibold transition-all duration-300"
                   >
                     Book Free Audit
                     <Arrow />
@@ -631,16 +602,12 @@ export default async function ServicesPage() {
 
               {/* Audit card */}
               <div className="w-full lg:w-80">
-                <div className="rounded-xl border border-slate-800 bg-void-light/50 p-6">
+                <div className="bg-void-light/50 rounded-xl border border-slate-800 p-6">
                   <div className="mb-5 flex items-center gap-2">
-                    <span className="h-2 w-2 animate-pulse rounded-full bg-neon-green" />
-                    <span className="font-mono text-xs text-slate-400">
-                      Available now
-                    </span>
+                    <span className="bg-neon-green h-2 w-2 animate-pulse rounded-full" />
+                    <span className="font-mono text-xs text-slate-400">Available now</span>
                   </div>
-                  <p className="font-mono text-sm font-semibold text-white">
-                    What you get:
-                  </p>
+                  <p className="font-mono text-sm font-semibold text-white">What you get:</p>
                   <div className="mt-4 space-y-2.5">
                     {[
                       { icon: "⏱", text: "30-min video call" },
@@ -650,16 +617,14 @@ export default async function ServicesPage() {
                     ].map(({ icon, text }) => (
                       <div
                         key={text}
-                        className="flex items-center gap-3 rounded-lg border border-slate-800 bg-void/50 px-3 py-2.5"
+                        className="bg-void/50 flex items-center gap-3 rounded-lg border border-slate-800 px-3 py-2.5"
                       >
                         <span className="text-base">{icon}</span>
-                        <span className="font-mono text-xs text-slate-300">
-                          {text}
-                        </span>
+                        <span className="font-mono text-xs text-slate-300">{text}</span>
                       </div>
                     ))}
                   </div>
-                  <p className="mt-5 text-center font-mono text-xs text-neon-green">
+                  <p className="text-neon-green mt-5 text-center font-mono text-xs">
                     No credit card. No obligation.
                   </p>
                 </div>
@@ -670,14 +635,14 @@ export default async function ServicesPage() {
       </section>
 
       {/* ── Step 2: Choose Your Scope — header ──────────────── */}
-      <section id="services" className="scroll-mt-24 bg-void pt-16 pb-4">
+      <section id="services" className="bg-void scroll-mt-24 pt-16 pb-4">
         <div className="mx-auto max-w-6xl px-6">
           <div className="flex items-start gap-4">
-            <span className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full border border-neon-magenta/30 bg-neon-magenta/10 font-mono text-xs font-bold text-neon-magenta">
+            <span className="border-neon-magenta/30 bg-neon-magenta/10 text-neon-magenta flex h-8 w-8 shrink-0 items-center justify-center rounded-full border font-mono text-xs font-bold">
               02
             </span>
             <div>
-              <span className="font-mono text-xs tracking-[0.15em] text-neon-magenta">
+              <span className="text-neon-magenta font-mono text-xs tracking-[0.15em]">
                 CHOOSE YOUR SCOPE
               </span>
               <p className="mt-1 text-sm text-slate-500">
@@ -709,9 +674,7 @@ export default async function ServicesPage() {
                       <span
                         className={`inline-flex items-center gap-2 px-3 py-1.5 ${colors.badge} rounded-full border font-mono text-xs font-medium`}
                       >
-                        <span
-                          className={`h-1.5 w-1.5 rounded-full ${colors.dot} animate-pulse`}
-                        />
+                        <span className={`h-1.5 w-1.5 rounded-full ${colors.dot} animate-pulse`} />
                         {service.tag}
                       </span>
                     </div>
@@ -719,19 +682,14 @@ export default async function ServicesPage() {
                     <h2 className="font-heading text-2xl leading-tight font-bold text-white md:text-3xl">
                       {service.title}
                     </h2>
-                    <p className="mt-3 leading-relaxed text-slate-400">
-                      {service.description}
-                    </p>
+                    <p className="mt-3 leading-relaxed text-slate-400">{service.description}</p>
                     <p className="text-neon-magenta/70 mt-2 font-mono text-xs italic">
                       {service.perfectFor}
                     </p>
 
                     <ul className="mt-6 space-y-3">
                       {service.features.map((feature) => (
-                        <li
-                          key={feature}
-                          className="flex items-start gap-3 text-sm text-slate-300"
-                        >
+                        <li key={feature} className="flex items-start gap-3 text-sm text-slate-300">
                           <svg
                             className={`h-5 w-5 ${colors.check} mt-0.5 shrink-0`}
                             fill="none"
@@ -739,11 +697,7 @@ export default async function ServicesPage() {
                             stroke="currentColor"
                             strokeWidth={2.5}
                           >
-                            <path
-                              strokeLinecap="round"
-                              strokeLinejoin="round"
-                              d="M5 13l4 4L19 7"
-                            />
+                            <path strokeLinecap="round" strokeLinejoin="round" d="M5 13l4 4L19 7" />
                           </svg>
                           {feature}
                         </li>
@@ -768,9 +722,7 @@ export default async function ServicesPage() {
                     </p>
                     <div className="mt-4 flex items-center gap-6">
                       <div>
-                        <span
-                          className={`font-mono text-2xl font-bold ${colors.price}`}
-                        >
+                        <span className={`font-mono text-2xl font-bold ${colors.price}`}>
                           {service.price}
                         </span>
                         <span className="ml-2 font-mono text-xs text-slate-500">
@@ -788,9 +740,7 @@ export default async function ServicesPage() {
                   </div>
 
                   {/* Visual column — terminal + stats grid */}
-                  <div
-                    className={`space-y-4 ${isReversed ? "lg:order-1" : ""}`}
-                  >
+                  <div className={`space-y-4 ${isReversed ? "lg:order-1" : ""}`}>
                     <TerminalBlock
                       lines={service.terminal}
                       title={`cloudless-cli — ${service.tag.toLowerCase()}`}
@@ -808,9 +758,7 @@ export default async function ServicesPage() {
                             valueClassName={`font-mono text-xl font-bold ${colors.statValue}`}
                             showLabel={false}
                           />
-                          <div className="mt-1 font-mono text-xs text-slate-500">
-                            {stat.label}
-                          </div>
+                          <div className="mt-1 font-mono text-xs text-slate-500">{stat.label}</div>
                         </div>
                       ))}
                     </div>
@@ -836,7 +784,7 @@ export default async function ServicesPage() {
               <p className="mt-3 text-slate-400">
                 {t(
                   "servicesPage.compareSubtitle",
-                  "All four services. One team. One engagement. 30% less.",
+                  "All four services. One team. One engagement. 30% less."
                 )}
               </p>
             </div>
@@ -845,33 +793,27 @@ export default async function ServicesPage() {
               className="overflow-x-auto rounded-xl border border-slate-800"
               tabIndex={0}
               role="region"
-              aria-label={t(
-                "servicesPage.compareTableLabel",
-                "Service comparison table",
-              )}
+              aria-label={t("servicesPage.compareTableLabel", "Service comparison table")}
             >
               <table className="w-full min-w-[540px] text-left">
                 <thead>
-                  <tr className="border-b border-slate-800 bg-void-light/30">
+                  <tr className="bg-void-light/30 border-b border-slate-800">
                     <th className="px-5 py-4 font-mono text-xs tracking-widest text-slate-500">
                       {t("servicesPage.compareColService", "SERVICE")}
                     </th>
                     <th className="px-5 py-4 font-mono text-xs tracking-widest text-slate-500">
                       {t("servicesPage.compareColIndividual", "INDIVIDUAL")}
                     </th>
-                    <th className="bg-neon-cyan/5 px-5 py-4 font-mono text-xs tracking-widest text-neon-cyan">
+                    <th className="bg-neon-cyan/5 text-neon-cyan px-5 py-4 font-mono text-xs tracking-widest">
                       {t("servicesPage.compareColBundle", "FULL BUNDLE")}{" "}
-                      <span className="ml-1 text-neon-magenta">★</span>
+                      <span className="text-neon-magenta ml-1">★</span>
                     </th>
                   </tr>
                 </thead>
                 <tbody className="divide-y divide-slate-800">
                   {[
                     {
-                      label: t(
-                        "servicesPage.cRow1",
-                        "Cloud Architecture & Migration",
-                      ),
+                      label: t("servicesPage.cRow1", "Cloud Architecture & Migration"),
                       individual: "€2,000+ / project",
                       bundle: true,
                     },
@@ -881,10 +823,7 @@ export default async function ServicesPage() {
                       bundle: true,
                     },
                     {
-                      label: t(
-                        "servicesPage.cRow3",
-                        "Data Analytics & Dashboards",
-                      ),
+                      label: t("servicesPage.cRow3", "Data Analytics & Dashboards"),
                       individual: "€2,400+ / project",
                       bundle: true,
                     },
@@ -894,10 +833,7 @@ export default async function ServicesPage() {
                       bundle: true,
                     },
                     {
-                      label: t(
-                        "servicesPage.cRow4b",
-                        "Web Design & Development",
-                      ),
+                      label: t("servicesPage.cRow4b", "Web Design & Development"),
                       individual: "€1,800+ / project",
                       bundle: true,
                     },
@@ -907,14 +843,8 @@ export default async function ServicesPage() {
                       bundle: true,
                     },
                     {
-                      label: t(
-                        "servicesPage.cRow5",
-                        "Cross-service integration",
-                      ),
-                      individual: t(
-                        "servicesPage.cRow5Individual",
-                        "Separate engagement",
-                      ),
+                      label: t("servicesPage.cRow5", "Cross-service integration"),
+                      individual: t("servicesPage.cRow5Individual", "Separate engagement"),
                       bundle: true,
                     },
                     {
@@ -923,28 +853,17 @@ export default async function ServicesPage() {
                       bundle: true,
                     },
                     {
-                      label: t(
-                        "servicesPage.cRow7",
-                        "Results in 14 days guarantee",
-                      ),
-                      individual: t(
-                        "servicesPage.cRow7Individual",
-                        "Per service",
-                      ),
+                      label: t("servicesPage.cRow7", "Results in 14 days guarantee"),
+                      individual: t("servicesPage.cRow7Individual", "Per service"),
                       bundle: true,
                     },
                   ].map((row) => (
-                    <tr
-                      key={row.label}
-                      className="transition-colors hover:bg-void-light/20"
-                    >
-                      <td className="px-5 py-4 font-mono text-sm text-slate-300">
-                        {row.label}
-                      </td>
+                    <tr key={row.label} className="hover:bg-void-light/20 transition-colors">
+                      <td className="px-5 py-4 font-mono text-sm text-slate-300">{row.label}</td>
                       <td className="px-5 py-4 font-mono text-sm text-slate-500">
                         {row.individual}
                       </td>
-                      <td className="bg-neon-cyan/5 px-5 py-4 font-mono text-sm font-semibold text-neon-cyan">
+                      <td className="bg-neon-cyan/5 text-neon-cyan px-5 py-4 font-mono text-sm font-semibold">
                         {row.bundle ? (
                           <span className="flex items-center gap-2">
                             <svg
@@ -970,7 +889,7 @@ export default async function ServicesPage() {
                   ))}
 
                   {/* Total row */}
-                  <tr className="border-t-2 border-slate-700 bg-void-light/40">
+                  <tr className="bg-void-light/40 border-t-2 border-slate-700">
                     <td className="px-5 py-5 font-mono text-sm font-bold text-white">
                       {t("servicesPage.compareTotal", "Total")}
                     </td>
@@ -979,22 +898,17 @@ export default async function ServicesPage() {
                         €9,500+
                       </span>
                       <p className="font-mono text-xs text-slate-500">
-                        {t(
-                          "servicesPage.compareSeparately",
-                          "if purchased separately",
-                        )}
+                        {t("servicesPage.compareSeparately", "if purchased separately")}
                       </p>
                     </td>
                     <td className="bg-neon-cyan/5 px-5 py-5">
                       <div className="flex items-baseline gap-2">
-                        <span className="font-mono text-2xl font-bold text-neon-cyan">
-                          €3,600
-                        </span>
+                        <span className="text-neon-cyan font-mono text-2xl font-bold">€3,600</span>
                         <span className="font-mono text-xs text-slate-500">
                           {t("servicesPage.perMonth", "/month")}
                         </span>
                       </div>
-                      <span className="mt-1 inline-block rounded-full bg-neon-magenta/10 px-2.5 py-0.5 font-mono text-xs text-neon-magenta">
+                      <span className="bg-neon-magenta/10 text-neon-magenta mt-1 inline-block rounded-full px-2.5 py-0.5 font-mono text-xs">
                         {t("servicesPage.bundleSave", "SAVE 30%")}
                       </span>
                     </td>
@@ -1023,7 +937,7 @@ export default async function ServicesPage() {
               <p className="mt-3 leading-relaxed text-slate-400">
                 {t(
                   "servicesPage.bundleDesc",
-                  "Get all four services bundled together. Cloud infrastructure, serverless apps, analytics dashboards, and AI marketing — everything your business needs to scale.",
+                  "Get all four services bundled together. Cloud infrastructure, serverless apps, analytics dashboards, and AI marketing — everything your business needs to scale."
                 )}
               </p>
               <p className="bg-void/50 mt-3 rounded-lg border border-slate-700 p-3 text-sm text-slate-300">
@@ -1032,15 +946,12 @@ export default async function ServicesPage() {
                 </span>{" "}
                 {t(
                   "servicesPage.bundleAltDesc",
-                  "A CTO (~€8K/mo) + marketer (~€4K/mo) + data analyst (~€3K/mo) + cloud engineer (~€5K/mo) =",
+                  "A CTO (~€8K/mo) + marketer (~€4K/mo) + data analyst (~€3K/mo) + cloud engineer (~€5K/mo) ="
                 )}{" "}
                 <span className="font-semibold text-white">
                   {t("servicesPage.bundleAltTotal", "€20K+/month.")}
                 </span>{" "}
-                {t(
-                  "servicesPage.bundleAltSavings",
-                  "We replace all four for €3,600.",
-                )}
+                {t("servicesPage.bundleAltSavings", "We replace all four for €3,600.")}
               </p>
               <div className="mt-5 flex flex-wrap gap-2">
                 {[
@@ -1063,9 +974,7 @@ export default async function ServicesPage() {
                 })}
               </div>
               <div className="mt-8 flex items-baseline gap-3">
-                <span className="text-neon-cyan font-mono text-4xl font-bold">
-                  €3,600
-                </span>
+                <span className="text-neon-cyan font-mono text-4xl font-bold">€3,600</span>
                 <span className="font-mono text-sm text-slate-500">
                   {t("servicesPage.perMonth", "per month")}
                 </span>
@@ -1084,10 +993,7 @@ export default async function ServicesPage() {
 
             {/* Desktop: terminal */}
             <div className="hidden lg:block">
-              <TerminalBlock
-                lines={bundleTerminal}
-                title="cloudless-cli — bundle"
-              />
+              <TerminalBlock lines={bundleTerminal} title="cloudless-cli — bundle" />
             </div>
 
             {/* Mobile: 6-service badge grid */}
@@ -1110,19 +1016,12 @@ export default async function ServicesPage() {
               ].map((item) => {
                 const c = colorMap[item.color];
                 return (
-                  <div
-                    key={item.label}
-                    className={`rounded-xl border p-5 text-center ${c.stat}`}
-                  >
+                  <div key={item.label} className={`rounded-xl border p-5 text-center ${c.stat}`}>
                     <div className="mb-2 text-2xl">{item.icon}</div>
-                    <div
-                      className={`mb-1 font-mono text-xs font-bold ${c.statValue}`}
-                    >
+                    <div className={`mb-1 font-mono text-xs font-bold ${c.statValue}`}>
                       Included
                     </div>
-                    <div className="font-mono text-xs text-slate-400">
-                      {item.label}
-                    </div>
+                    <div className="font-mono text-xs text-slate-400">{item.label}</div>
                   </div>
                 );
               })}
@@ -1132,18 +1031,18 @@ export default async function ServicesPage() {
       </section>
 
       {/* ── Step 3: Results in 14 Days — Guarantee ──────────── */}
-      <section id="results" className="scroll-mt-24 bg-void py-20 lg:py-28">
+      <section id="results" className="bg-void scroll-mt-24 py-20 lg:py-28">
         <div className="mx-auto max-w-6xl px-6 text-center">
           <ScrollReveal>
             <div className="mb-2 flex items-center justify-center gap-3">
-              <span className="flex h-8 w-8 items-center justify-center rounded-full border border-neon-green/30 bg-neon-green/10 font-mono text-xs font-bold text-neon-green">
+              <span className="border-neon-green/30 bg-neon-green/10 text-neon-green flex h-8 w-8 items-center justify-center rounded-full border font-mono text-xs font-bold">
                 03
               </span>
-              <span className="font-mono text-xs tracking-[0.15em] text-neon-green">
+              <span className="text-neon-green font-mono text-xs tracking-[0.15em]">
                 RESULTS IN 14 DAYS
               </span>
             </div>
-            <p className="animate-shimmer-text mb-3 mt-4 font-mono text-xs tracking-[0.3em]">
+            <p className="animate-shimmer-text mt-4 mb-3 font-mono text-xs tracking-[0.3em]">
               {t("servicesPage.guaranteeLabel", "[ GUARANTEE ]")}
             </p>
             <h2 className="font-heading text-2xl font-bold text-white md:text-3xl">
@@ -1157,7 +1056,7 @@ export default async function ServicesPage() {
                 title: t("servicesPage.g1Title", "Results in 14 Days"),
                 desc: t(
                   "servicesPage.g1Desc",
-                  "See measurable progress within two weeks of kickoff — or we keep working until you do.",
+                  "See measurable progress within two weeks of kickoff — or we keep working until you do."
                 ),
               },
               {
@@ -1165,7 +1064,7 @@ export default async function ServicesPage() {
                 title: t("servicesPage.g2Title", "No Lock-in"),
                 desc: t(
                   "servicesPage.g2Desc",
-                  "Month-to-month. Cancel anytime. We earn your business every month.",
+                  "Month-to-month. Cancel anytime. We earn your business every month."
                 ),
               },
               {
@@ -1173,7 +1072,7 @@ export default async function ServicesPage() {
                 title: t("servicesPage.g3Title", "Your Code Is Yours"),
                 desc: t(
                   "servicesPage.g3Desc",
-                  "Full documentation, handoff-ready. We build it and you own it — always.",
+                  "Full documentation, handoff-ready. We build it and you own it — always."
                 ),
               },
               {
@@ -1181,7 +1080,7 @@ export default async function ServicesPage() {
                 title: t("servicesPage.g4Title", "Free Audit First"),
                 desc: t(
                   "servicesPage.g4Desc",
-                  "Every engagement starts with a no-cost review. Actionable insights in 30 minutes.",
+                  "Every engagement starts with a no-cost review. Actionable insights in 30 minutes."
                 ),
               },
             ].map((item, gi) => (
@@ -1190,9 +1089,7 @@ export default async function ServicesPage() {
                   <div className="bg-neon-green/10 border-neon-green/20 text-neon-green mx-auto mb-4 flex h-10 w-10 items-center justify-center rounded-lg border text-lg">
                     {item.icon}
                   </div>
-                  <h3 className="font-heading font-semibold text-white">
-                    {item.title}
-                  </h3>
+                  <h3 className="font-heading font-semibold text-white">{item.title}</h3>
                   <p className="mt-2 text-sm text-slate-400">{item.desc}</p>
                 </div>
               </ScrollReveal>
@@ -1259,7 +1156,7 @@ export default async function ServicesPage() {
             <p className="mx-auto mt-4 max-w-lg text-lg leading-relaxed text-slate-400">
               {t(
                 "servicesPage.ctaSubtitle",
-                "Book a free 30-minute audit call. We'll review your current setup, identify quick wins, and map out a plan — no commitment required.",
+                "Book a free 30-minute audit call. We'll review your current setup, identify quick wins, and map out a plan — no commitment required."
               )}
             </p>
             <div className="mt-8 flex flex-col items-center justify-center gap-4 sm:flex-row">

--- a/src/app/[locale]/store/[id]/page.tsx
+++ b/src/app/[locale]/store/[id]/page.tsx
@@ -102,18 +102,14 @@ export default async function ProductPage({
                 {product.name}
               </h1>
 
-              <p className="mt-4 text-lg leading-relaxed text-slate-400">
-                {product.description}
-              </p>
+              <p className="mt-4 text-lg leading-relaxed text-slate-400">{product.description}</p>
 
               <div className="mt-6 flex items-baseline gap-2">
                 <span className="text-neon-cyan glow-cyan font-mono text-3xl font-bold">
                   {formatPrice(product.price, product.currency)}
                 </span>
                 {product.recurring && (
-                  <span className="font-mono text-sm text-slate-500">
-                    /{product.interval}
-                  </span>
+                  <span className="font-mono text-sm text-slate-500">/{product.interval}</span>
                 )}
               </div>
 
@@ -125,10 +121,7 @@ export default async function ProductPage({
                   </h2>
                   <ul className="space-y-3">
                     {product.features.map((feature) => (
-                      <li
-                        key={feature}
-                        className="flex items-start gap-3 text-sm text-slate-400"
-                      >
+                      <li key={feature} className="flex items-start gap-3 text-sm text-slate-400">
                         <span className="text-neon-cyan mt-0.5 shrink-0 font-mono text-xs">
                           &#x25B8;
                         </span>
@@ -173,15 +166,11 @@ export default async function ProductPage({
                     <h3 className="font-heading group-hover:text-neon-cyan text-sm font-semibold text-white transition-colors">
                       {rel.name}
                     </h3>
-                    <p className="mt-1 line-clamp-1 text-xs text-slate-500">
-                      {rel.description}
-                    </p>
+                    <p className="mt-1 line-clamp-1 text-xs text-slate-500">{rel.description}</p>
                     <span className="text-neon-cyan mt-2 inline-block font-mono text-sm font-bold">
                       {formatPrice(rel.price, rel.currency)}
                       {rel.recurring && (
-                        <span className="ml-1 font-normal text-slate-500">
-                          /{rel.interval}
-                        </span>
+                        <span className="ml-1 font-normal text-slate-500">/{rel.interval}</span>
                       )}
                     </span>
                   </div>

--- a/src/app/[locale]/store/error.tsx
+++ b/src/app/[locale]/store/error.tsx
@@ -18,9 +18,7 @@ export default function StoreError({
     <section className="bg-void flex flex-1 items-center justify-center px-6 py-24">
       <div className="max-w-md text-center">
         <p className="text-neon-magenta font-mono text-5xl font-bold">ERROR</p>
-        <h1 className="font-heading mt-4 text-2xl font-bold text-white">
-          Store error
-        </h1>
+        <h1 className="font-heading mt-4 text-2xl font-bold text-white">Store error</h1>
         <p className="mt-3 font-mono text-sm text-slate-400">
           Something went wrong loading the store. Please try again.
         </p>

--- a/src/app/[locale]/store/opengraph-image.tsx
+++ b/src/app/[locale]/store/opengraph-image.tsx
@@ -39,8 +39,7 @@ export default function StoreOGImage() {
           right: "-60px",
           width: "560px",
           height: "560px",
-          background:
-            "radial-gradient(circle, rgba(180,0,255,0.10) 0%, transparent 65%)",
+          background: "radial-gradient(circle, rgba(180,0,255,0.10) 0%, transparent 65%)",
           borderRadius: "50%",
         }}
       />
@@ -146,6 +145,6 @@ export default function StoreOGImage() {
         </span>
       </div>
     </div>,
-    { ...size },
+    { ...size }
   );
 }

--- a/src/app/[locale]/store/page.tsx
+++ b/src/app/[locale]/store/page.tsx
@@ -82,15 +82,15 @@ export default function StorePage() {
           <p className="animate-shimmer-text mb-3 font-mono text-xs font-medium tracking-[0.3em]">
             [ STORE ]
           </p>
-          <h1 className="animate-fade-in-up delay-100 font-heading text-3xl leading-tight font-bold md:text-5xl">
+          <h1 className="animate-fade-in-up font-heading text-3xl leading-tight font-bold delay-100 md:text-5xl">
             Tools, templates &amp;{" "}
             <span className="from-neon-cyan to-neon-magenta bg-gradient-to-r bg-clip-text text-transparent">
               expert services.
             </span>
           </h1>
-          <p className="animate-fade-in-up delay-200 mt-4 max-w-xl text-lg text-slate-400">
-            Everything you need to build, scale, and market your cloud-powered
-            business. From self-serve digital products to done-for-you services.
+          <p className="animate-fade-in-up mt-4 max-w-xl text-lg text-slate-400 delay-200">
+            Everything you need to build, scale, and market your cloud-powered business. From
+            self-serve digital products to done-for-you services.
           </p>
         </div>
       </section>
@@ -116,23 +116,15 @@ export default function StorePage() {
             {testimonials.map((t, ti) => (
               <ScrollReveal key={t.name} delay={ti * 100}>
                 <div className="bg-void-light/50 hover:border-neon-cyan/30 rounded-xl border border-slate-800 p-6 transition-colors">
-                  <div className="text-neon-cyan/40 mb-3 font-serif text-3xl">
-                    &ldquo;
-                  </div>
-                  <p className="text-sm leading-relaxed text-slate-300">
-                    {t.quote}
-                  </p>
+                  <div className="text-neon-cyan/40 mb-3 font-serif text-3xl">&ldquo;</div>
+                  <p className="text-sm leading-relaxed text-slate-300">{t.quote}</p>
                   <div className="mt-6 flex items-center gap-3">
                     <div className="bg-neon-cyan/10 border-neon-cyan/20 text-neon-cyan flex h-8 w-8 items-center justify-center rounded-full border font-mono text-xs font-bold">
                       {t.name.charAt(0)}
                     </div>
                     <div>
-                      <p className="text-xs font-semibold text-white">
-                        {t.name}
-                      </p>
-                      <p className="font-mono text-[10px] text-slate-400">
-                        {t.role}
-                      </p>
+                      <p className="text-xs font-semibold text-white">{t.name}</p>
+                      <p className="font-mono text-[10px] text-slate-400">{t.role}</p>
                     </div>
                   </div>
                 </div>
@@ -157,9 +149,7 @@ export default function StorePage() {
               <ScrollReveal key={faq.question} delay={fi * 60}>
                 <details className="group bg-void open:border-neon-cyan/30 rounded-xl border border-slate-800 transition-colors">
                   <summary className="flex cursor-pointer items-center justify-between px-6 py-5 select-none">
-                    <span className="pr-4 text-sm font-semibold text-white">
-                      {faq.question}
-                    </span>
+                    <span className="pr-4 text-sm font-semibold text-white">{faq.question}</span>
                     <span className="text-neon-cyan/40 shrink-0 text-lg transition-transform group-open:rotate-45">
                       +
                     </span>

--- a/src/app/[locale]/store/success/page.tsx
+++ b/src/app/[locale]/store/success/page.tsx
@@ -62,9 +62,7 @@ export default function SuccessPage() {
       <section className="bg-void scanlines relative py-20 md:py-28">
         <div className="cyber-grid absolute inset-0 opacity-20" />
         <div className="relative z-10 mx-auto max-w-3xl px-6 text-center">
-          <div className="text-neon-cyan glow-cyan mb-6 font-mono text-6xl">
-            &#x2713;
-          </div>
+          <div className="text-neon-cyan glow-cyan mb-6 font-mono text-6xl">&#x2713;</div>
           <h1 className="font-heading text-3xl font-bold text-white md:text-4xl">
             Order{" "}
             <span className="from-neon-cyan to-neon-green bg-gradient-to-r bg-clip-text text-transparent">
@@ -72,8 +70,8 @@ export default function SuccessPage() {
             </span>
           </h1>
           <p className="mx-auto mt-4 max-w-xl text-lg leading-relaxed text-slate-400">
-            Thanks for your purchase. A confirmation email with your order
-            details and any download links is on its way.
+            Thanks for your purchase. A confirmation email with your order details and any download
+            links is on its way.
           </p>
         </div>
       </section>
@@ -97,16 +95,10 @@ export default function SuccessPage() {
                 <div
                   className={`h-10 w-10 ${accentClasses[step.accent].box} mb-4 flex items-center justify-center rounded-lg border text-lg`}
                 >
-                  <span className={accentClasses[step.accent].text}>
-                    {step.icon}
-                  </span>
+                  <span className={accentClasses[step.accent].text}>{step.icon}</span>
                 </div>
-                <h3 className="mb-2 text-sm font-semibold text-white">
-                  {step.title}
-                </h3>
-                <p className="text-xs leading-relaxed text-slate-400">
-                  {step.description}
-                </p>
+                <h3 className="mb-2 text-sm font-semibold text-white">{step.title}</h3>
+                <p className="text-xs leading-relaxed text-slate-400">{step.description}</p>
               </div>
             ))}
           </div>
@@ -118,10 +110,7 @@ export default function SuccessPage() {
         <div className="mx-auto max-w-3xl px-6 text-center">
           <p className="mb-6 font-mono text-sm text-slate-500">
             Questions? Reach us at{" "}
-            <a
-              href="mailto:tbaltzakis@cloudless.gr"
-              className="text-neon-cyan hover:underline"
-            >
+            <a href="mailto:tbaltzakis@cloudless.gr" className="text-neon-cyan hover:underline">
               tbaltzakis@cloudless.gr
             </a>
           </p>

--- a/src/app/[locale]/terms/page.tsx
+++ b/src/app/[locale]/terms/page.tsx
@@ -25,12 +25,8 @@ function Section({
 }) {
   return (
     <section id={id} className="scroll-mt-24">
-      <h2 className="text-neon-cyan/80 mb-4 font-heading text-xl font-bold text-white">
-        {title}
-      </h2>
-      <div className="space-y-3 text-sm leading-relaxed text-slate-300">
-        {children}
-      </div>
+      <h2 className="text-neon-cyan/80 font-heading mb-4 text-xl font-bold text-white">{title}</h2>
+      <div className="space-y-3 text-sm leading-relaxed text-slate-300">{children}</div>
     </section>
   );
 }
@@ -54,7 +50,7 @@ export default async function TermsPage() {
             <p className="text-neon-cyan/70 mb-4 font-mono text-xs tracking-widest">
               {t("legal.legalDocument", "LEGAL DOCUMENT")}
             </p>
-            <h1 className="mb-4 font-heading text-3xl font-bold text-white lg:text-4xl">
+            <h1 className="font-heading mb-4 text-3xl font-bold text-white lg:text-4xl">
               {t("legal.termsTitle", "Terms of Service")}
             </h1>
             <p className="mb-2 font-mono text-xs text-slate-500">
@@ -63,49 +59,40 @@ export default async function TermsPage() {
             <p className="mb-12 text-sm leading-relaxed text-slate-400">
               {t(
                 "legal.termsIntro",
-                'These Terms of Service ("Terms") govern your access to and use of cloudless.gr and all services and products offered by Cloudless ("we", "us", "our"). By using our website or purchasing our services, you agree to these Terms. If you do not agree, please do not use our services.',
+                'These Terms of Service ("Terms") govern your access to and use of cloudless.gr and all services and products offered by Cloudless ("we", "us", "our"). By using our website or purchasing our services, you agree to these Terms. If you do not agree, please do not use our services.'
               )}
             </p>
           </ScrollReveal>
 
           <div className="space-y-10">
             <ScrollReveal>
-              <Section
-                id="provider"
-                title={t("legal.providerTitle", "1. Service Provider")}
-              >
+              <Section id="provider" title={t("legal.providerTitle", "1. Service Provider")}>
                 <p>
                   {t(
                     "legal.providerText",
-                    "Cloudless is operated by Themistoklis Baltzakis, based in Greece, EU. Contact: tbaltzakis@cloudless.gr. As required by the EU eCommerce Directive (2000/31/EC), our full business identification details will be published here upon formal registration.",
+                    "Cloudless is operated by Themistoklis Baltzakis, based in Greece, EU. Contact: tbaltzakis@cloudless.gr. As required by the EU eCommerce Directive (2000/31/EC), our full business identification details will be published here upon formal registration."
                   )}
                 </p>
               </Section>
             </ScrollReveal>
 
             <ScrollReveal>
-              <Section
-                id="services"
-                title={t("legal.servicesTitle", "2. Services & Products")}
-              >
+              <Section id="services" title={t("legal.servicesTitle", "2. Services & Products")}>
                 <p>
                   {t(
                     "legal.servicesText",
-                    "We offer cloud computing consultancy, serverless development, data analytics, and AI-powered digital marketing services. We also sell digital products and service packages through our online store. All prices are displayed in Euros (EUR) and include applicable VAT where required by Greek law.",
+                    "We offer cloud computing consultancy, serverless development, data analytics, and AI-powered digital marketing services. We also sell digital products and service packages through our online store. All prices are displayed in Euros (EUR) and include applicable VAT where required by Greek law."
                   )}
                 </p>
               </Section>
             </ScrollReveal>
 
             <ScrollReveal>
-              <Section
-                id="orders"
-                title={t("legal.ordersTitle", "3. Orders & Payment")}
-              >
+              <Section id="orders" title={t("legal.ordersTitle", "3. Orders & Payment")}>
                 <p>
                   {t(
                     "legal.ordersText",
-                    "When you place an order, you are making a binding offer to purchase. We confirm acceptance by sending an order confirmation email. Payment is processed securely through Stripe. We accept major credit/debit cards. Prices are final at the time of checkout and include VAT where applicable.",
+                    "When you place an order, you are making a binding offer to purchase. We confirm acceptance by sending an order confirmation email. Payment is processed securely through Stripe. We accept major credit/debit cards. Prices are final at the time of checkout and include VAT where applicable."
                   )}
                 </p>
               </Section>
@@ -114,15 +101,12 @@ export default async function TermsPage() {
             <ScrollReveal>
               <Section
                 id="withdrawal"
-                title={t(
-                  "legal.withdrawalTitle",
-                  "4. Right of Withdrawal (EU Consumers)",
-                )}
+                title={t("legal.withdrawalTitle", "4. Right of Withdrawal (EU Consumers)")}
               >
                 <p>
                   {t(
                     "legal.withdrawalText",
-                    "Under the EU Consumer Rights Directive (2011/83/EU), you have 14 calendar days from the date of purchase to withdraw from a contract without giving any reason. To exercise this right, email us at tbaltzakis@cloudless.gr with a clear statement of your decision.",
+                    "Under the EU Consumer Rights Directive (2011/83/EU), you have 14 calendar days from the date of purchase to withdraw from a contract without giving any reason. To exercise this right, email us at tbaltzakis@cloudless.gr with a clear statement of your decision."
                   )}
                 </p>
                 <p className="font-semibold text-white">
@@ -131,46 +115,34 @@ export default async function TermsPage() {
                 <p>
                   {t(
                     "legal.withdrawalExceptionsText",
-                    "The right of withdrawal does not apply to: digital content that has been accessed or downloaded (with your prior express consent and acknowledgement), fully performed services (where you agreed performance could begin within the withdrawal period), and custom/personalised services delivered to your specifications.",
+                    "The right of withdrawal does not apply to: digital content that has been accessed or downloaded (with your prior express consent and acknowledgement), fully performed services (where you agreed performance could begin within the withdrawal period), and custom/personalised services delivered to your specifications."
                   )}
                 </p>
                 <p>
-                  <Link
-                    href="/refund"
-                    className="text-neon-cyan hover:underline"
-                  >
-                    {t(
-                      "legal.fullRefundPolicy",
-                      "Read our full Refund & Returns Policy",
-                    )}
+                  <Link href="/refund" className="text-neon-cyan hover:underline">
+                    {t("legal.fullRefundPolicy", "Read our full Refund & Returns Policy")}
                   </Link>
                 </p>
               </Section>
             </ScrollReveal>
 
             <ScrollReveal>
-              <Section
-                id="delivery"
-                title={t("legal.deliveryTitle", "5. Delivery")}
-              >
+              <Section id="delivery" title={t("legal.deliveryTitle", "5. Delivery")}>
                 <p>
                   {t(
                     "legal.deliveryText",
-                    "Digital products are delivered electronically via email or dashboard access immediately after payment confirmation. Service engagements begin according to the timeline agreed in the project scope or service description. Estimated timelines are provided in good faith but are not binding unless explicitly stated.",
+                    "Digital products are delivered electronically via email or dashboard access immediately after payment confirmation. Service engagements begin according to the timeline agreed in the project scope or service description. Estimated timelines are provided in good faith but are not binding unless explicitly stated."
                   )}
                 </p>
               </Section>
             </ScrollReveal>
 
             <ScrollReveal>
-              <Section
-                id="ip"
-                title={t("legal.ipTitle", "6. Intellectual Property")}
-              >
+              <Section id="ip" title={t("legal.ipTitle", "6. Intellectual Property")}>
                 <p>
                   {t(
                     "legal.ipText",
-                    "All content on cloudless.gr — including text, code, design, logos, and graphics — is owned by Cloudless and protected by copyright and intellectual property laws. You may not reproduce, distribute, or create derivative works without our written permission. Work product delivered to clients as part of a paid service engagement is transferred to the client upon full payment, unless otherwise agreed in writing.",
+                    "All content on cloudless.gr — including text, code, design, logos, and graphics — is owned by Cloudless and protected by copyright and intellectual property laws. You may not reproduce, distribute, or create derivative works without our written permission. Work product delivered to clients as part of a paid service engagement is transferred to the client upon full payment, unless otherwise agreed in writing."
                   )}
                 </p>
               </Section>
@@ -184,21 +156,18 @@ export default async function TermsPage() {
                 <p>
                   {t(
                     "legal.liabilityText",
-                    "To the maximum extent permitted by law, Cloudless shall not be liable for any indirect, incidental, consequential, or punitive damages arising from your use of our services. Our total liability for any claim shall not exceed the amount you paid for the specific service giving rise to the claim. Nothing in these Terms excludes or limits liability for death or personal injury, fraud, or any liability that cannot be excluded under applicable law.",
+                    "To the maximum extent permitted by law, Cloudless shall not be liable for any indirect, incidental, consequential, or punitive damages arising from your use of our services. Our total liability for any claim shall not exceed the amount you paid for the specific service giving rise to the claim. Nothing in these Terms excludes or limits liability for death or personal injury, fraud, or any liability that cannot be excluded under applicable law."
                   )}
                 </p>
               </Section>
             </ScrollReveal>
 
             <ScrollReveal>
-              <Section
-                id="accounts"
-                title={t("legal.accountsTitle", "8. User Accounts")}
-              >
+              <Section id="accounts" title={t("legal.accountsTitle", "8. User Accounts")}>
                 <p>
                   {t(
                     "legal.accountsText",
-                    "You are responsible for maintaining the confidentiality of your account credentials and for all activity under your account. You must notify us immediately of any unauthorised use. We reserve the right to suspend or terminate accounts that violate these Terms.",
+                    "You are responsible for maintaining the confidentiality of your account credentials and for all activity under your account. You must notify us immediately of any unauthorised use. We reserve the right to suspend or terminate accounts that violate these Terms."
                   )}
                 </p>
               </Section>
@@ -212,7 +181,7 @@ export default async function TermsPage() {
                 <p>
                   {t(
                     "legal.acceptableUseText",
-                    "You agree not to: use our services for any unlawful purpose, attempt to gain unauthorised access to our systems, interfere with the proper functioning of the website, upload malicious code or content, impersonate any person or entity, or use automated tools to scrape or harvest data from the site.",
+                    "You agree not to: use our services for any unlawful purpose, attempt to gain unauthorised access to our systems, interfere with the proper functioning of the website, upload malicious code or content, impersonate any person or entity, or use automated tools to scrape or harvest data from the site."
                   )}
                 </p>
               </Section>
@@ -221,15 +190,12 @@ export default async function TermsPage() {
             <ScrollReveal>
               <Section
                 id="governing-law"
-                title={t(
-                  "legal.governingLawTitle",
-                  "10. Governing Law & Disputes",
-                )}
+                title={t("legal.governingLawTitle", "10. Governing Law & Disputes")}
               >
                 <p>
                   {t(
                     "legal.governingLawText",
-                    "These Terms are governed by the laws of the Hellenic Republic (Greece). Any disputes shall be resolved by the competent courts of Greece. EU consumers retain the right to bring proceedings in their country of residence. You may also use the EU Online Dispute Resolution platform at https://ec.europa.eu/odr.",
+                    "These Terms are governed by the laws of the Hellenic Republic (Greece). Any disputes shall be resolved by the competent courts of Greece. EU consumers retain the right to bring proceedings in their country of residence. You may also use the EU Online Dispute Resolution platform at https://ec.europa.eu/odr."
                   )}
                 </p>
               </Section>
@@ -238,29 +204,23 @@ export default async function TermsPage() {
             <ScrollReveal>
               <Section
                 id="terms-changes"
-                title={t(
-                  "legal.termsChangesTitle",
-                  "11. Changes to These Terms",
-                )}
+                title={t("legal.termsChangesTitle", "11. Changes to These Terms")}
               >
                 <p>
                   {t(
                     "legal.termsChanges",
-                    "We may update these Terms from time to time. Material changes will be communicated via a notice on our website. Continued use of our services after changes constitutes acceptance of the updated Terms.",
+                    "We may update these Terms from time to time. Material changes will be communicated via a notice on our website. Continued use of our services after changes constitutes acceptance of the updated Terms."
                   )}
                 </p>
               </Section>
             </ScrollReveal>
 
             <ScrollReveal>
-              <Section
-                id="contact-legal"
-                title={t("legal.contactTitle", "12. Contact")}
-              >
+              <Section id="contact-legal" title={t("legal.contactTitle", "12. Contact")}>
                 <p>
                   {t(
                     "legal.contactText",
-                    "For questions about these Terms, contact us at tbaltzakis@cloudless.gr.",
+                    "For questions about these Terms, contact us at tbaltzakis@cloudless.gr."
                   )}
                 </p>
               </Section>

--- a/src/app/[locale]/work/page.tsx
+++ b/src/app/[locale]/work/page.tsx
@@ -20,16 +20,11 @@ export const metadata: Metadata = {
 
 async function loadClientProjects(): Promise<Project[]> {
   try {
-    const ok = await isConfiguredAsync(
-      "NOTION_API_KEY",
-      "NOTION_PROJECTS_DB_ID",
-    );
+    const ok = await isConfiguredAsync("NOTION_API_KEY", "NOTION_PROJECTS_DB_ID");
     if (!ok) return [];
     const all = await listProjects();
     return all.filter(
-      (p) =>
-        p.type === "Client" &&
-        (p.status === "Completed" || p.status === "In Progress"),
+      (p) => p.type === "Client" && (p.status === "Completed" || p.status === "In Progress")
     );
   } catch {
     return [];
@@ -46,24 +41,24 @@ export default async function WorkPage() {
       <JsonLd data={getBreadcrumbSchema([{ name: "Work", url: "/work" }])} />
 
       {/* Hero */}
-      <section className="mx-auto max-w-6xl px-6 pb-16 pt-24">
+      <section className="mx-auto max-w-6xl px-6 pt-24 pb-16">
         <div className="bg-neon-magenta/10 border-neon-magenta/20 mb-6 inline-flex items-center gap-2 rounded-full border px-3 py-1.5">
           <span className="bg-neon-magenta h-2 w-2 animate-pulse rounded-full" />
           <span className="text-neon-magenta font-mono text-xs">OUR WORK</span>
         </div>
-        <h1 className="font-heading text-4xl font-bold leading-tight text-white sm:text-5xl">
+        <h1 className="font-heading text-4xl leading-tight font-bold text-white sm:text-5xl">
           Projects that <span className="text-neon-cyan">actually shipped</span>
         </h1>
         <p className="font-body mt-4 max-w-2xl text-slate-400">
-          Serverless migrations, analytics pipelines, and AI-powered marketing
-          platforms — built for teams that need to move fast.
+          Serverless migrations, analytics pipelines, and AI-powered marketing platforms — built for
+          teams that need to move fast.
         </p>
       </section>
 
       {/* Active projects */}
       {active.length > 0 && (
         <section className="mx-auto max-w-6xl px-6 pb-16">
-          <h2 className="font-mono mb-6 text-xs font-semibold uppercase tracking-widest text-slate-500">
+          <h2 className="mb-6 font-mono text-xs font-semibold tracking-widest text-slate-500 uppercase">
             ▶ Active
           </h2>
           <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
@@ -79,7 +74,7 @@ export default async function WorkPage() {
       {/* Completed projects */}
       {completed.length > 0 && (
         <section className="mx-auto max-w-6xl px-6 pb-24">
-          <h2 className="font-mono mb-6 text-xs font-semibold uppercase tracking-widest text-slate-500">
+          <h2 className="mb-6 font-mono text-xs font-semibold tracking-widest text-slate-500 uppercase">
             ✓ Completed
           </h2>
           <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
@@ -96,9 +91,7 @@ export default async function WorkPage() {
       {projects.length === 0 && (
         <section className="mx-auto max-w-6xl px-6 pb-24">
           <div className="bg-void-light/30 rounded-xl border border-slate-800 p-16 text-center">
-            <p className="font-mono text-slate-500">
-              No client projects to show yet.
-            </p>
+            <p className="font-mono text-slate-500">No client projects to show yet.</p>
             <p className="font-body mt-2 text-sm text-slate-600">
               Check back soon — we&apos;re always building.
             </p>

--- a/src/app/api/admin/ab-tests/route.ts
+++ b/src/app/api/admin/ab-tests/route.ts
@@ -14,7 +14,7 @@ async function putSSMParam(value: string): Promise<void> {
       Value: value,
       Type: "String",
       Overwrite: true,
-    }),
+    })
   );
 }
 
@@ -37,7 +37,7 @@ export async function PATCH(request: NextRequest) {
   } catch (e) {
     return NextResponse.json(
       { error: e instanceof Error ? e.message : "Invalid input" },
-      { status: 400 },
+      { status: 400 }
     );
   }
 

--- a/src/app/api/admin/ai/analytics-orchestration/_shared.ts
+++ b/src/app/api/admin/ai/analytics-orchestration/_shared.ts
@@ -26,7 +26,7 @@ const DEFAULT_CONNECTORS: AnalyticsConnector[] = ["quicksight", "powerbi"];
 
 export async function prepareOrchestration(
   request: NextRequest,
-  failureMessage: string,
+  failureMessage: string
 ): Promise<PrepareResult> {
   const auth = await requireAdmin(request);
   if (!auth.ok) return { ok: false, response: auth.response };
@@ -37,14 +37,15 @@ export async function prepareOrchestration(
   let reportTitle = "Stripe Analytics Report";
 
   try {
-    ({ windowDays, connectors, goals, reportTitle } =
-      parseAnalyticsOrchestrationRequestBody(await request.json()));
+    ({ windowDays, connectors, goals, reportTitle } = parseAnalyticsOrchestrationRequestBody(
+      await request.json()
+    ));
   } catch (error) {
     return {
       ok: false,
       response: NextResponse.json(
         { error: error instanceof Error ? error.message : "Invalid input" },
-        { status: 400 },
+        { status: 400 }
       ),
     };
   }
@@ -53,10 +54,7 @@ export async function prepareOrchestration(
   if (!apiKey) {
     return {
       ok: false,
-      response: NextResponse.json(
-        { error: "ANTHROPIC_API_KEY not configured." },
-        { status: 503 },
-      ),
+      response: NextResponse.json({ error: "ANTHROPIC_API_KEY not configured." }, { status: 503 }),
     };
   }
 
@@ -76,7 +74,7 @@ export async function prepareOrchestration(
         {
           error: error instanceof Error ? error.message : failureMessage,
         },
-        { status: 500 },
+        { status: 500 }
       ),
     };
   }

--- a/src/app/api/admin/ai/analytics-orchestration/pdf/route.ts
+++ b/src/app/api/admin/ai/analytics-orchestration/pdf/route.ts
@@ -3,10 +3,7 @@ import { renderAnalyticsReportPdf } from "@/lib/analytics-report-pdf";
 import { prepareOrchestration } from "../_shared";
 
 export async function POST(request: NextRequest) {
-  const prepared = await prepareOrchestration(
-    request,
-    "Analytics PDF export failed.",
-  );
+  const prepared = await prepareOrchestration(request, "Analytics PDF export failed.");
   if (!prepared.ok) return prepared.response;
 
   const { snapshot, orchestration, reportTitle } = prepared.data;

--- a/src/app/api/admin/ai/analytics-orchestration/route.ts
+++ b/src/app/api/admin/ai/analytics-orchestration/route.ts
@@ -2,10 +2,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { prepareOrchestration } from "./_shared";
 
 export async function POST(request: NextRequest) {
-  const prepared = await prepareOrchestration(
-    request,
-    "Analytics orchestration failed.",
-  );
+  const prepared = await prepareOrchestration(request, "Analytics orchestration failed.");
   if (!prepared.ok) return prepared.response;
 
   return NextResponse.json(prepared.data.orchestration);

--- a/src/app/api/admin/ai/audience/route.ts
+++ b/src/app/api/admin/ai/audience/route.ts
@@ -12,24 +12,19 @@ export async function POST(request: NextRequest) {
   try {
     const body = await request.json();
     description = body.description;
-    platforms = Array.isArray(body.platforms)
-      ? body.platforms
-      : ["Meta", "LinkedIn", "Google"];
+    platforms = Array.isArray(body.platforms) ? body.platforms : ["Meta", "LinkedIn", "Google"];
     objective = body.objective ?? "LEAD_GENERATION";
     if (!description) throw new Error("description is required");
   } catch (e) {
     return NextResponse.json(
       { error: e instanceof Error ? e.message : "Invalid input" },
-      { status: 400 },
+      { status: 400 }
     );
   }
 
   const apiKey = await getAnthropicApiKey();
   if (!apiKey) {
-    return NextResponse.json(
-      { error: "ANTHROPIC_API_KEY not configured." },
-      { status: 503 },
-    );
+    return NextResponse.json({ error: "ANTHROPIC_API_KEY not configured." }, { status: 503 });
   }
 
   const prompt = `You are a digital marketing targeting expert for Cloudless.gr, a Greek digital agency specialising in AI-powered marketing.
@@ -100,7 +95,7 @@ Only include the platforms that were requested. Tailor recommendations for the G
   } catch (e) {
     return NextResponse.json(
       { error: e instanceof Error ? e.message : "AI generation failed." },
-      { status: 500 },
+      { status: 500 }
     );
   }
 }

--- a/src/app/api/admin/ai/campaign/route.ts
+++ b/src/app/api/admin/ai/campaign/route.ts
@@ -18,16 +18,13 @@ export async function POST(request: NextRequest) {
   } catch (e) {
     return NextResponse.json(
       { error: e instanceof Error ? e.message : "Invalid input" },
-      { status: 400 },
+      { status: 400 }
     );
   }
 
   const apiKey = await getAnthropicApiKey();
   if (!apiKey) {
-    return NextResponse.json(
-      { error: "ANTHROPIC_API_KEY not configured." },
-      { status: 503 },
-    );
+    return NextResponse.json({ error: "ANTHROPIC_API_KEY not configured." }, { status: 503 });
   }
 
   const prompt = `You are a digital marketing expert for Cloudless.gr, a Greek digital agency specialising in AI-powered marketing services.
@@ -70,7 +67,7 @@ Respond with a JSON object (no markdown fences, just the raw JSON) with this str
   } catch (e) {
     return NextResponse.json(
       { error: e instanceof Error ? e.message : "AI generation failed." },
-      { status: 500 },
+      { status: 500 }
     );
   }
 }

--- a/src/app/api/admin/ai/copy/route.ts
+++ b/src/app/api/admin/ai/copy/route.ts
@@ -20,16 +20,13 @@ export async function POST(request: NextRequest) {
   } catch (e) {
     return NextResponse.json(
       { error: e instanceof Error ? e.message : "Invalid input" },
-      { status: 400 },
+      { status: 400 }
     );
   }
 
   const apiKey = await getAnthropicApiKey();
   if (!apiKey) {
-    return NextResponse.json(
-      { error: "ANTHROPIC_API_KEY not configured." },
-      { status: 503 },
-    );
+    return NextResponse.json({ error: "ANTHROPIC_API_KEY not configured." }, { status: 503 });
   }
 
   const CHAR_LIMITS: Record<string, { headline: number; body: number }> = {
@@ -74,7 +71,7 @@ Respond with raw JSON only (no markdown fences):
   } catch (e) {
     return NextResponse.json(
       { error: e instanceof Error ? e.message : "AI generation failed." },
-      { status: 500 },
+      { status: 500 }
     );
   }
 }

--- a/src/app/api/admin/ai/report-insights/route.ts
+++ b/src/app/api/admin/ai/report-insights/route.ts
@@ -16,16 +16,13 @@ export async function POST(request: NextRequest) {
   } catch (e) {
     return NextResponse.json(
       { error: e instanceof Error ? e.message : "Invalid input" },
-      { status: 400 },
+      { status: 400 }
     );
   }
 
   const apiKey = await getAnthropicApiKey();
   if (!apiKey) {
-    return NextResponse.json(
-      { error: "ANTHROPIC_API_KEY not configured." },
-      { status: 503 },
-    );
+    return NextResponse.json({ error: "ANTHROPIC_API_KEY not configured." }, { status: 503 });
   }
 
   const prompt = `You are a marketing analyst. Write concise, insightful commentary on this campaign performance data for a client report.
@@ -41,7 +38,7 @@ Write 3-5 sentences of plain English insights. Mention specific numbers, compare
   } catch (e) {
     return NextResponse.json(
       { error: e instanceof Error ? e.message : "AI generation failed." },
-      { status: 500 },
+      { status: 500 }
     );
   }
 }

--- a/src/app/api/admin/analytics/countries/route.ts
+++ b/src/app/api/admin/analytics/countries/route.ts
@@ -18,16 +18,10 @@ export async function GET(request: NextRequest) {
 
   const config = await getConfig();
   if (!config.GOOGLE_CLIENT_EMAIL || !config.GOOGLE_PRIVATE_KEY) {
-    return NextResponse.json(
-      { error: "Google Search Console not configured." },
-      { status: 503 },
-    );
+    return NextResponse.json({ error: "Google Search Console not configured." }, { status: 503 });
   }
 
-  const limit = Math.max(
-    1,
-    Math.min(Number(request.nextUrl.searchParams.get("limit")) || 30, 50),
-  );
+  const limit = Math.max(1, Math.min(Number(request.nextUrl.searchParams.get("limit")) || 30, 50));
 
   try {
     const countries = await getTrafficByCountry(undefined, limit);
@@ -38,9 +32,6 @@ export async function GET(request: NextRequest) {
     });
   } catch (err) {
     console.error("[GSC countries] Error:", err);
-    return NextResponse.json(
-      { error: "Failed to fetch country data." },
-      { status: 500 },
-    );
+    return NextResponse.json({ error: "Failed to fetch country data." }, { status: 500 });
   }
 }

--- a/src/app/api/admin/analytics/ctr-opportunities/route.ts
+++ b/src/app/api/admin/analytics/ctr-opportunities/route.ts
@@ -20,16 +20,10 @@ export async function GET(request: NextRequest) {
 
   const config = await getConfig();
   if (!config.GOOGLE_CLIENT_EMAIL || !config.GOOGLE_PRIVATE_KEY) {
-    return NextResponse.json(
-      { error: "Google Search Console not configured." },
-      { status: 503 },
-    );
+    return NextResponse.json({ error: "Google Search Console not configured." }, { status: 503 });
   }
 
-  const limit = Math.max(
-    1,
-    Math.min(Number(request.nextUrl.searchParams.get("limit")) || 50, 200),
-  );
+  const limit = Math.max(1, Math.min(Number(request.nextUrl.searchParams.get("limit")) || 50, 200));
 
   try {
     const opportunities = await getCtrOpportunities(undefined, limit);
@@ -40,9 +34,6 @@ export async function GET(request: NextRequest) {
     });
   } catch (err) {
     console.error("[GSC CTR opportunities] Error:", err);
-    return NextResponse.json(
-      { error: "Failed to fetch CTR opportunities." },
-      { status: 500 },
-    );
+    return NextResponse.json({ error: "Failed to fetch CTR opportunities." }, { status: 500 });
   }
 }

--- a/src/app/api/admin/analytics/devices/route.ts
+++ b/src/app/api/admin/analytics/devices/route.ts
@@ -18,10 +18,7 @@ export async function GET(request: NextRequest) {
 
   const config = await getConfig();
   if (!config.GOOGLE_CLIENT_EMAIL || !config.GOOGLE_PRIVATE_KEY) {
-    return NextResponse.json(
-      { error: "Google Search Console not configured." },
-      { status: 503 },
-    );
+    return NextResponse.json({ error: "Google Search Console not configured." }, { status: 503 });
   }
 
   try {
@@ -33,9 +30,6 @@ export async function GET(request: NextRequest) {
     });
   } catch (err) {
     console.error("[GSC devices] Error:", err);
-    return NextResponse.json(
-      { error: "Failed to fetch device data." },
-      { status: 500 },
-    );
+    return NextResponse.json({ error: "Failed to fetch device data." }, { status: 500 });
   }
 }

--- a/src/app/api/admin/analytics/history/route.ts
+++ b/src/app/api/admin/analytics/history/route.ts
@@ -9,22 +9,14 @@ export async function GET(request: NextRequest) {
 
   const config = await getConfig();
   if (!config.GOOGLE_CLIENT_EMAIL || !config.GOOGLE_PRIVATE_KEY) {
-    return NextResponse.json(
-      { error: "Google Search Console not configured." },
-      { status: 503 },
-    );
+    return NextResponse.json({ error: "Google Search Console not configured." }, { status: 503 });
   }
 
   const DEFAULT_WEEKS = 12;
   const MAX_WEEKS = 52;
   const weeks = Math.max(
     1,
-    Math.min(
-      Number(
-        request.nextUrl.searchParams.get("weeks") ?? String(DEFAULT_WEEKS),
-      ),
-      MAX_WEEKS,
-    ),
+    Math.min(Number(request.nextUrl.searchParams.get("weeks") ?? String(DEFAULT_WEEKS)), MAX_WEEKS)
   );
 
   try {
@@ -37,9 +29,6 @@ export async function GET(request: NextRequest) {
     });
   } catch (err) {
     console.error("[GSC history] Error:", err);
-    return NextResponse.json(
-      { error: "Failed to fetch history." },
-      { status: 500 },
-    );
+    return NextResponse.json({ error: "Failed to fetch history." }, { status: 500 });
   }
 }

--- a/src/app/api/admin/analytics/keywords/route.ts
+++ b/src/app/api/admin/analytics/keywords/route.ts
@@ -9,22 +9,14 @@ export async function GET(request: NextRequest) {
 
   const config = await getConfig();
   if (!config.GOOGLE_CLIENT_EMAIL || !config.GOOGLE_PRIVATE_KEY) {
-    return NextResponse.json(
-      { error: "Google Search Console not configured." },
-      { status: 503 },
-    );
+    return NextResponse.json({ error: "Google Search Console not configured." }, { status: 503 });
   }
 
   const DEFAULT_LIMIT = 20;
   const MAX_LIMIT = 100;
   const limit = Math.max(
     1,
-    Math.min(
-      Number(
-        request.nextUrl.searchParams.get("limit") ?? String(DEFAULT_LIMIT),
-      ),
-      MAX_LIMIT,
-    ),
+    Math.min(Number(request.nextUrl.searchParams.get("limit") ?? String(DEFAULT_LIMIT)), MAX_LIMIT)
   );
 
   try {
@@ -36,9 +28,6 @@ export async function GET(request: NextRequest) {
     });
   } catch (err) {
     console.error("[GSC keywords] Error:", err);
-    return NextResponse.json(
-      { error: "Failed to fetch keywords." },
-      { status: 500 },
-    );
+    return NextResponse.json({ error: "Failed to fetch keywords." }, { status: 500 });
   }
 }

--- a/src/app/api/admin/analytics/pages/route.ts
+++ b/src/app/api/admin/analytics/pages/route.ts
@@ -9,22 +9,14 @@ export async function GET(request: NextRequest) {
 
   const config = await getConfig();
   if (!config.GOOGLE_CLIENT_EMAIL || !config.GOOGLE_PRIVATE_KEY) {
-    return NextResponse.json(
-      { error: "Google Search Console not configured." },
-      { status: 503 },
-    );
+    return NextResponse.json({ error: "Google Search Console not configured." }, { status: 503 });
   }
 
   const DEFAULT_LIMIT = 25;
   const MAX_LIMIT = 100;
   const limit = Math.max(
     1,
-    Math.min(
-      Number(
-        request.nextUrl.searchParams.get("limit") ?? String(DEFAULT_LIMIT),
-      ),
-      MAX_LIMIT,
-    ),
+    Math.min(Number(request.nextUrl.searchParams.get("limit") ?? String(DEFAULT_LIMIT)), MAX_LIMIT)
   );
 
   try {
@@ -36,9 +28,6 @@ export async function GET(request: NextRequest) {
     });
   } catch (err) {
     console.error("[GSC pages] Error:", err);
-    return NextResponse.json(
-      { error: "Failed to fetch pages." },
-      { status: 500 },
-    );
+    return NextResponse.json({ error: "Failed to fetch pages." }, { status: 500 });
   }
 }

--- a/src/app/api/admin/analytics/products/route.ts
+++ b/src/app/api/admin/analytics/products/route.ts
@@ -19,16 +19,10 @@ export async function GET(request: NextRequest) {
 
   const config = await getConfig();
   if (!config.GOOGLE_CLIENT_EMAIL || !config.GOOGLE_PRIVATE_KEY) {
-    return NextResponse.json(
-      { error: "Google Search Console not configured." },
-      { status: 503 },
-    );
+    return NextResponse.json({ error: "Google Search Console not configured." }, { status: 503 });
   }
 
-  const limit = Math.max(
-    1,
-    Math.min(Number(request.nextUrl.searchParams.get("limit")) || 50, 100),
-  );
+  const limit = Math.max(1, Math.min(Number(request.nextUrl.searchParams.get("limit")) || 50, 100));
   const pattern = request.nextUrl.searchParams.get("pattern") || "/store/";
 
   try {
@@ -41,9 +35,6 @@ export async function GET(request: NextRequest) {
     });
   } catch (err) {
     console.error("[GSC products] Error:", err);
-    return NextResponse.json(
-      { error: "Failed to fetch product data." },
-      { status: 500 },
-    );
+    return NextResponse.json({ error: "Failed to fetch product data." }, { status: 500 });
   }
 }

--- a/src/app/api/admin/analytics/query-pages/route.ts
+++ b/src/app/api/admin/analytics/query-pages/route.ts
@@ -19,15 +19,12 @@ export async function GET(request: NextRequest) {
 
   const config = await getConfig();
   if (!config.GOOGLE_CLIENT_EMAIL || !config.GOOGLE_PRIVATE_KEY) {
-    return NextResponse.json(
-      { error: "Google Search Console not configured." },
-      { status: 503 },
-    );
+    return NextResponse.json({ error: "Google Search Console not configured." }, { status: 503 });
   }
 
   const limit = Math.max(
     1,
-    Math.min(Number(request.nextUrl.searchParams.get("limit")) || 100, 500),
+    Math.min(Number(request.nextUrl.searchParams.get("limit")) || 100, 500)
   );
 
   try {
@@ -39,9 +36,6 @@ export async function GET(request: NextRequest) {
     });
   } catch (err) {
     console.error("[GSC query-pages] Error:", err);
-    return NextResponse.json(
-      { error: "Failed to fetch query-page mappings." },
-      { status: 500 },
-    );
+    return NextResponse.json({ error: "Failed to fetch query-page mappings." }, { status: 500 });
   }
 }

--- a/src/app/api/admin/analytics/search-intent/route.ts
+++ b/src/app/api/admin/analytics/search-intent/route.ts
@@ -18,10 +18,7 @@ export async function GET(request: NextRequest) {
 
   const config = await getConfig();
   if (!config.GOOGLE_CLIENT_EMAIL || !config.GOOGLE_PRIVATE_KEY) {
-    return NextResponse.json(
-      { error: "Google Search Console not configured." },
-      { status: 503 },
-    );
+    return NextResponse.json({ error: "Google Search Console not configured." }, { status: 503 });
   }
 
   try {
@@ -39,9 +36,6 @@ export async function GET(request: NextRequest) {
     });
   } catch (err) {
     console.error("[GSC search-intent] Error:", err);
-    return NextResponse.json(
-      { error: "Failed to fetch search intent data." },
-      { status: 500 },
-    );
+    return NextResponse.json({ error: "Failed to fetch search intent data." }, { status: 500 });
   }
 }

--- a/src/app/api/admin/analytics/seo/route.ts
+++ b/src/app/api/admin/analytics/seo/route.ts
@@ -9,17 +9,11 @@ export async function GET(request: NextRequest) {
 
   const config = await getConfig();
   if (!config.GOOGLE_CLIENT_EMAIL || !config.GOOGLE_PRIVATE_KEY) {
-    return NextResponse.json(
-      { error: "Google Search Console not configured." },
-      { status: 503 },
-    );
+    return NextResponse.json({ error: "Google Search Console not configured." }, { status: 503 });
   }
 
   try {
-    const [snapshot, keywords] = await Promise.all([
-      getSeoSnapshot(),
-      getTopKeywords(),
-    ]);
+    const [snapshot, keywords] = await Promise.all([getSeoSnapshot(), getTopKeywords()]);
 
     return NextResponse.json({
       snapshot,
@@ -29,9 +23,6 @@ export async function GET(request: NextRequest) {
     });
   } catch (err) {
     console.error("[SEO] Error:", err);
-    return NextResponse.json(
-      { error: "Failed to fetch SEO data." },
-      { status: 500 },
-    );
+    return NextResponse.json({ error: "Failed to fetch SEO data." }, { status: 500 });
   }
 }

--- a/src/app/api/admin/analytics/web/route.ts
+++ b/src/app/api/admin/analytics/web/route.ts
@@ -9,10 +9,7 @@ export async function GET(request: NextRequest) {
 
   const config = await getConfig();
   if (!config.GOOGLE_CLIENT_EMAIL || !config.GOOGLE_PRIVATE_KEY) {
-    return NextResponse.json(
-      { error: "Google Search Console not configured." },
-      { status: 503 },
-    );
+    return NextResponse.json({ error: "Google Search Console not configured." }, { status: 503 });
   }
 
   try {
@@ -24,9 +21,6 @@ export async function GET(request: NextRequest) {
     });
   } catch (err) {
     console.error("[Web Analytics] Error:", err);
-    return NextResponse.json(
-      { error: "Failed to fetch analytics." },
-      { status: 500 },
-    );
+    return NextResponse.json({ error: "Failed to fetch analytics." }, { status: 500 });
   }
 }

--- a/src/app/api/admin/calendar/[id]/route.ts
+++ b/src/app/api/admin/calendar/[id]/route.ts
@@ -2,10 +2,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { requireAdmin } from "@/lib/api-auth";
 import { updateCalendarItem, deleteCalendarItem } from "@/lib/content-calendar";
 
-export async function PATCH(
-  request: NextRequest,
-  { params }: { params: Promise<{ id: string }> },
-) {
+export async function PATCH(request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
   const auth = await requireAdmin(request);
   if (!auth.ok) return auth.response;
 
@@ -20,7 +17,7 @@ export async function PATCH(
 
 export async function DELETE(
   request: NextRequest,
-  { params }: { params: Promise<{ id: string }> },
+  { params }: { params: Promise<{ id: string }> }
 ) {
   const auth = await requireAdmin(request);
   if (!auth.ok) return auth.response;

--- a/src/app/api/admin/calendar/create/route.ts
+++ b/src/app/api/admin/calendar/create/route.ts
@@ -15,7 +15,7 @@ export async function POST(request: NextRequest) {
   } catch (e) {
     return NextResponse.json(
       { error: e instanceof Error ? e.message : "Invalid input" },
-      { status: 400 },
+      { status: 400 }
     );
   }
 

--- a/src/app/api/admin/campaigns/google/insights/route.ts
+++ b/src/app/api/admin/campaigns/google/insights/route.ts
@@ -1,27 +1,19 @@
 import { NextRequest, NextResponse } from "next/server";
 import { requireAdmin } from "@/lib/api-auth";
-import {
-  isGoogleAdsConfigured,
-  getGoogleMetrics,
-} from "@/lib/campaigns/google-ads";
+import { isGoogleAdsConfigured, getGoogleMetrics } from "@/lib/campaigns/google-ads";
 
 export async function GET(request: NextRequest) {
   const auth = await requireAdmin(request);
   if (!auth.ok) return auth.response;
 
   if (!(await isGoogleAdsConfigured())) {
-    return NextResponse.json(
-      { error: "Google Ads not configured." },
-      { status: 503 },
-    );
+    return NextResponse.json({ error: "Google Ads not configured." }, { status: 503 });
   }
 
   const { searchParams } = new URL(request.url);
   const dateStart =
-    searchParams.get("start") ??
-    new Date(Date.now() - 30 * 86400000).toISOString().split("T")[0];
-  const dateEnd =
-    searchParams.get("end") ?? new Date().toISOString().split("T")[0];
+    searchParams.get("start") ?? new Date(Date.now() - 30 * 86400000).toISOString().split("T")[0];
+  const dateEnd = searchParams.get("end") ?? new Date().toISOString().split("T")[0];
 
   const metrics = await getGoogleMetrics(dateStart, dateEnd);
   return NextResponse.json({ metrics, fetchedAt: new Date().toISOString() });

--- a/src/app/api/admin/campaigns/google/route.ts
+++ b/src/app/api/admin/campaigns/google/route.ts
@@ -1,19 +1,13 @@
 import { NextRequest, NextResponse } from "next/server";
 import { requireAdmin } from "@/lib/api-auth";
-import {
-  isGoogleAdsConfigured,
-  listGoogleCampaigns,
-} from "@/lib/campaigns/google-ads";
+import { isGoogleAdsConfigured, listGoogleCampaigns } from "@/lib/campaigns/google-ads";
 
 export async function GET(request: NextRequest) {
   const auth = await requireAdmin(request);
   if (!auth.ok) return auth.response;
 
   if (!(await isGoogleAdsConfigured())) {
-    return NextResponse.json(
-      { error: "Google Ads not configured." },
-      { status: 503 },
-    );
+    return NextResponse.json({ error: "Google Ads not configured." }, { status: 503 });
   }
 
   try {
@@ -24,9 +18,6 @@ export async function GET(request: NextRequest) {
       fetchedAt: new Date().toISOString(),
     });
   } catch {
-    return NextResponse.json(
-      { error: "Failed to fetch Google Ads campaigns." },
-      { status: 500 },
-    );
+    return NextResponse.json({ error: "Failed to fetch Google Ads campaigns." }, { status: 500 });
   }
 }

--- a/src/app/api/admin/campaigns/linkedin/insights/route.ts
+++ b/src/app/api/admin/campaigns/linkedin/insights/route.ts
@@ -1,27 +1,19 @@
 import { NextRequest, NextResponse } from "next/server";
 import { requireAdmin } from "@/lib/api-auth";
-import {
-  isLinkedInConfigured,
-  getLinkedInInsights,
-} from "@/lib/campaigns/linkedin";
+import { isLinkedInConfigured, getLinkedInInsights } from "@/lib/campaigns/linkedin";
 
 export async function GET(request: NextRequest) {
   const auth = await requireAdmin(request);
   if (!auth.ok) return auth.response;
 
   if (!(await isLinkedInConfigured())) {
-    return NextResponse.json(
-      { error: "LinkedIn not configured." },
-      { status: 503 },
-    );
+    return NextResponse.json({ error: "LinkedIn not configured." }, { status: 503 });
   }
 
   const { searchParams } = new URL(request.url);
   const dateStart =
-    searchParams.get("start") ??
-    new Date(Date.now() - 30 * 86400000).toISOString().split("T")[0];
-  const dateEnd =
-    searchParams.get("end") ?? new Date().toISOString().split("T")[0];
+    searchParams.get("start") ?? new Date(Date.now() - 30 * 86400000).toISOString().split("T")[0];
+  const dateEnd = searchParams.get("end") ?? new Date().toISOString().split("T")[0];
 
   const insights = await getLinkedInInsights(dateStart, dateEnd);
   return NextResponse.json({ insights, fetchedAt: new Date().toISOString() });

--- a/src/app/api/admin/campaigns/linkedin/route.ts
+++ b/src/app/api/admin/campaigns/linkedin/route.ts
@@ -1,19 +1,13 @@
 import { NextRequest, NextResponse } from "next/server";
 import { requireAdmin } from "@/lib/api-auth";
-import {
-  isLinkedInConfigured,
-  listLinkedInCampaigns,
-} from "@/lib/campaigns/linkedin";
+import { isLinkedInConfigured, listLinkedInCampaigns } from "@/lib/campaigns/linkedin";
 
 export async function GET(request: NextRequest) {
   const auth = await requireAdmin(request);
   if (!auth.ok) return auth.response;
 
   if (!(await isLinkedInConfigured())) {
-    return NextResponse.json(
-      { error: "LinkedIn not configured." },
-      { status: 503 },
-    );
+    return NextResponse.json({ error: "LinkedIn not configured." }, { status: 503 });
   }
 
   try {
@@ -24,9 +18,6 @@ export async function GET(request: NextRequest) {
       fetchedAt: new Date().toISOString(),
     });
   } catch {
-    return NextResponse.json(
-      { error: "Failed to fetch LinkedIn campaigns." },
-      { status: 500 },
-    );
+    return NextResponse.json({ error: "Failed to fetch LinkedIn campaigns." }, { status: 500 });
   }
 }

--- a/src/app/api/admin/campaigns/tiktok/insights/route.ts
+++ b/src/app/api/admin/campaigns/tiktok/insights/route.ts
@@ -7,18 +7,13 @@ export async function GET(request: NextRequest) {
   if (!auth.ok) return auth.response;
 
   if (!(await isTikTokConfigured())) {
-    return NextResponse.json(
-      { error: "TikTok not configured." },
-      { status: 503 },
-    );
+    return NextResponse.json({ error: "TikTok not configured." }, { status: 503 });
   }
 
   const { searchParams } = new URL(request.url);
   const dateStart =
-    searchParams.get("start") ??
-    new Date(Date.now() - 30 * 86400000).toISOString().split("T")[0];
-  const dateEnd =
-    searchParams.get("end") ?? new Date().toISOString().split("T")[0];
+    searchParams.get("start") ?? new Date(Date.now() - 30 * 86400000).toISOString().split("T")[0];
+  const dateEnd = searchParams.get("end") ?? new Date().toISOString().split("T")[0];
 
   const insights = await getTikTokInsights(dateStart, dateEnd);
   return NextResponse.json({ insights, fetchedAt: new Date().toISOString() });

--- a/src/app/api/admin/campaigns/tiktok/route.ts
+++ b/src/app/api/admin/campaigns/tiktok/route.ts
@@ -1,19 +1,13 @@
 import { NextRequest, NextResponse } from "next/server";
 import { requireAdmin } from "@/lib/api-auth";
-import {
-  isTikTokConfigured,
-  listTikTokCampaigns,
-} from "@/lib/campaigns/tiktok";
+import { isTikTokConfigured, listTikTokCampaigns } from "@/lib/campaigns/tiktok";
 
 export async function GET(request: NextRequest) {
   const auth = await requireAdmin(request);
   if (!auth.ok) return auth.response;
 
   if (!(await isTikTokConfigured())) {
-    return NextResponse.json(
-      { error: "TikTok not configured." },
-      { status: 503 },
-    );
+    return NextResponse.json({ error: "TikTok not configured." }, { status: 503 });
   }
 
   try {
@@ -24,9 +18,6 @@ export async function GET(request: NextRequest) {
       fetchedAt: new Date().toISOString(),
     });
   } catch {
-    return NextResponse.json(
-      { error: "Failed to fetch TikTok campaigns." },
-      { status: 500 },
-    );
+    return NextResponse.json({ error: "Failed to fetch TikTok campaigns." }, { status: 500 });
   }
 }

--- a/src/app/api/admin/campaigns/x/insights/route.ts
+++ b/src/app/api/admin/campaigns/x/insights/route.ts
@@ -7,18 +7,13 @@ export async function GET(request: NextRequest) {
   if (!auth.ok) return auth.response;
 
   if (!(await isXConfigured())) {
-    return NextResponse.json(
-      { error: "X (Twitter) not configured." },
-      { status: 503 },
-    );
+    return NextResponse.json({ error: "X (Twitter) not configured." }, { status: 503 });
   }
 
   const { searchParams } = new URL(request.url);
   const dateStart =
-    searchParams.get("start") ??
-    new Date(Date.now() - 30 * 86400000).toISOString().split("T")[0];
-  const dateEnd =
-    searchParams.get("end") ?? new Date().toISOString().split("T")[0];
+    searchParams.get("start") ?? new Date(Date.now() - 30 * 86400000).toISOString().split("T")[0];
+  const dateEnd = searchParams.get("end") ?? new Date().toISOString().split("T")[0];
 
   const stats = await getXStats(dateStart, dateEnd);
   return NextResponse.json({ stats, fetchedAt: new Date().toISOString() });

--- a/src/app/api/admin/campaigns/x/route.ts
+++ b/src/app/api/admin/campaigns/x/route.ts
@@ -7,10 +7,7 @@ export async function GET(request: NextRequest) {
   if (!auth.ok) return auth.response;
 
   if (!(await isXConfigured())) {
-    return NextResponse.json(
-      { error: "X (Twitter) not configured." },
-      { status: 503 },
-    );
+    return NextResponse.json({ error: "X (Twitter) not configured." }, { status: 503 });
   }
 
   try {
@@ -21,9 +18,6 @@ export async function GET(request: NextRequest) {
       fetchedAt: new Date().toISOString(),
     });
   } catch {
-    return NextResponse.json(
-      { error: "Failed to fetch X campaigns." },
-      { status: 500 },
-    );
+    return NextResponse.json({ error: "Failed to fetch X campaigns." }, { status: 500 });
   }
 }

--- a/src/app/api/admin/client-portals/route.ts
+++ b/src/app/api/admin/client-portals/route.ts
@@ -1,10 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { requireAdmin } from "@/lib/api-auth";
-import {
-  SSMClient,
-  GetParameterCommand,
-  PutParameterCommand,
-} from "@aws-sdk/client-ssm";
+import { SSMClient, GetParameterCommand, PutParameterCommand } from "@aws-sdk/client-ssm";
 import { randomUUID } from "node:crypto";
 
 const SSM_KEY = "/cloudless/CLIENT_PORTALS_JSON";
@@ -70,7 +66,7 @@ async function writePortals(portals: ClientPortal[]): Promise<void> {
       Value: JSON.stringify(portals),
       Type: "String",
       Overwrite: true,
-    }),
+    })
   );
 }
 
@@ -93,10 +89,7 @@ export async function POST(request: NextRequest) {
     stepNames?: string[];
   };
   if (!body.clientEmail || !body.label) {
-    return NextResponse.json(
-      { error: "clientEmail and label are required" },
-      { status: 400 },
-    );
+    return NextResponse.json({ error: "clientEmail and label are required" }, { status: 400 });
   }
 
   const portals = await readPortals();
@@ -153,7 +146,7 @@ function stepNotFound() {
 
 function applyUpdateStep(
   portal: ClientPortal,
-  body: Extract<PatchAction, { action: "update-step" }>,
+  body: Extract<PatchAction, { action: "update-step" }>
 ): NextResponse | null {
   const step = portal.steps.find((s) => s.id === body.stepId);
   if (!step) return stepNotFound();
@@ -168,15 +161,12 @@ function applyUpdateStep(
 
 function applyAddComment(
   portal: ClientPortal,
-  body: Extract<PatchAction, { action: "add-comment" }>,
+  body: Extract<PatchAction, { action: "add-comment" }>
 ): NextResponse | null {
   const step = portal.steps.find((s) => s.id === body.stepId);
   if (!step) return stepNotFound();
   if (!body.text?.trim()) {
-    return NextResponse.json(
-      { error: "Comment text required" },
-      { status: 400 },
-    );
+    return NextResponse.json({ error: "Comment text required" }, { status: 400 });
   }
   step.comments.push({
     id: randomUUID(),
@@ -189,7 +179,7 @@ function applyAddComment(
 
 function applyDeleteComment(
   portal: ClientPortal,
-  body: Extract<PatchAction, { action: "delete-comment" }>,
+  body: Extract<PatchAction, { action: "delete-comment" }>
 ): NextResponse | null {
   const step = portal.steps.find((s) => s.id === body.stepId);
   if (!step) return stepNotFound();
@@ -199,7 +189,7 @@ function applyDeleteComment(
 
 function applyAddStep(
   portal: ClientPortal,
-  body: Extract<PatchAction, { action: "add-step" }>,
+  body: Extract<PatchAction, { action: "add-step" }>
 ): NextResponse | null {
   if (!body.name?.trim()) {
     return NextResponse.json({ error: "Step name required" }, { status: 400 });
@@ -215,7 +205,7 @@ function applyAddStep(
 
 function applyRenameStep(
   portal: ClientPortal,
-  body: Extract<PatchAction, { action: "rename-step" }>,
+  body: Extract<PatchAction, { action: "rename-step" }>
 ): NextResponse | null {
   const step = portal.steps.find((s) => s.id === body.stepId);
   if (!step) return stepNotFound();
@@ -223,10 +213,7 @@ function applyRenameStep(
   return null;
 }
 
-function dispatchPatch(
-  portal: ClientPortal,
-  body: PatchAction,
-): NextResponse | null {
+function dispatchPatch(portal: ClientPortal, body: PatchAction): NextResponse | null {
   switch (body.action) {
     case "update-step":
       return applyUpdateStep(portal, body);
@@ -252,10 +239,7 @@ export async function PATCH(request: NextRequest) {
 
   const body = (await request.json()) as PatchAction;
   if (!body.token || !body.action) {
-    return NextResponse.json(
-      { error: "token and action are required" },
-      { status: 400 },
-    );
+    return NextResponse.json({ error: "token and action are required" }, { status: 400 });
   }
 
   const portals = await readPortals();
@@ -278,8 +262,7 @@ export async function DELETE(request: NextRequest) {
   if (!auth.ok) return auth.response;
 
   const { token } = (await request.json()) as { token?: string };
-  if (!token)
-    return NextResponse.json({ error: "token is required" }, { status: 400 });
+  if (!token) return NextResponse.json({ error: "token is required" }, { status: 400 });
 
   const portals = await readPortals();
   const updated = portals.filter((p) => p.token !== token);

--- a/src/app/api/admin/crm/companies/route.ts
+++ b/src/app/api/admin/crm/companies/route.ts
@@ -9,10 +9,7 @@ export async function GET(request: NextRequest) {
   if (!auth.ok) return auth.response;
 
   if (!(await isHubSpotConfigured())) {
-    return NextResponse.json(
-      { error: "HubSpot not configured." },
-      { status: 503 },
-    );
+    return NextResponse.json({ error: "HubSpot not configured." }, { status: 503 });
   }
 
   try {
@@ -33,9 +30,6 @@ export async function GET(request: NextRequest) {
     const _r = mapIntegrationError(err);
     if (_r) return _r;
     console.error("[HubSpot] Error listing companies:", err);
-    return NextResponse.json(
-      { error: "Failed to fetch companies." },
-      { status: 500 },
-    );
+    return NextResponse.json({ error: "Failed to fetch companies." }, { status: 500 });
   }
 }

--- a/src/app/api/admin/crm/contacts/route.ts
+++ b/src/app/api/admin/crm/contacts/route.ts
@@ -9,10 +9,7 @@ export async function GET(request: NextRequest) {
   const auth = await requireAdmin(request);
   if (!auth.ok) return auth.response;
   if (!(await isConfiguredAsync("HUBSPOT_API_KEY"))) {
-    return NextResponse.json(
-      { error: "HubSpot not configured." },
-      { status: 503 },
-    );
+    return NextResponse.json({ error: "HubSpot not configured." }, { status: 503 });
   }
 
   try {
@@ -30,9 +27,6 @@ export async function GET(request: NextRequest) {
     const _r = mapIntegrationError(err);
     if (_r) return _r;
     console.error("[HubSpot] Error listing contacts:", err);
-    return NextResponse.json(
-      { error: "Failed to fetch contacts." },
-      { status: 500 },
-    );
+    return NextResponse.json({ error: "Failed to fetch contacts." }, { status: 500 });
   }
 }

--- a/src/app/api/admin/crm/deals/route.ts
+++ b/src/app/api/admin/crm/deals/route.ts
@@ -9,10 +9,7 @@ export async function GET(request: NextRequest) {
   if (!auth.ok) return auth.response;
 
   if (!(await isHubSpotConfigured())) {
-    return NextResponse.json(
-      { error: "HubSpot not configured." },
-      { status: 503 },
-    );
+    return NextResponse.json({ error: "HubSpot not configured." }, { status: 503 });
   }
 
   try {
@@ -33,9 +30,6 @@ export async function GET(request: NextRequest) {
     const _r = mapIntegrationError(err);
     if (_r) return _r;
     console.error("[HubSpot] Error listing deals:", err);
-    return NextResponse.json(
-      { error: "Failed to fetch deals." },
-      { status: 500 },
-    );
+    return NextResponse.json({ error: "Failed to fetch deals." }, { status: 500 });
   }
 }

--- a/src/app/api/admin/crm/owners/route.ts
+++ b/src/app/api/admin/crm/owners/route.ts
@@ -9,10 +9,7 @@ export async function GET(request: NextRequest) {
   if (!auth.ok) return auth.response;
 
   if (!(await isHubSpotConfigured())) {
-    return NextResponse.json(
-      { error: "HubSpot not configured." },
-      { status: 503 },
-    );
+    return NextResponse.json({ error: "HubSpot not configured." }, { status: 503 });
   }
 
   try {
@@ -27,9 +24,6 @@ export async function GET(request: NextRequest) {
     const _r = mapIntegrationError(err);
     if (_r) return _r;
     console.error("[HubSpot] Error listing owners:", err);
-    return NextResponse.json(
-      { error: "Failed to fetch owners." },
-      { status: 500 },
-    );
+    return NextResponse.json({ error: "Failed to fetch owners." }, { status: 500 });
   }
 }

--- a/src/app/api/admin/crm/pipelines/route.ts
+++ b/src/app/api/admin/crm/pipelines/route.ts
@@ -9,10 +9,7 @@ export async function GET(request: NextRequest) {
   if (!auth.ok) return auth.response;
 
   if (!(await isHubSpotConfigured())) {
-    return NextResponse.json(
-      { error: "HubSpot not configured." },
-      { status: 503 },
-    );
+    return NextResponse.json({ error: "HubSpot not configured." }, { status: 503 });
   }
 
   try {
@@ -31,9 +28,6 @@ export async function GET(request: NextRequest) {
     const _r = mapIntegrationError(err);
     if (_r) return _r;
     console.error("[HubSpot] Error fetching pipelines:", err);
-    return NextResponse.json(
-      { error: "Failed to fetch pipelines." },
-      { status: 500 },
-    );
+    return NextResponse.json({ error: "Failed to fetch pipelines." }, { status: 500 });
   }
 }

--- a/src/app/api/admin/crm/tickets/route.ts
+++ b/src/app/api/admin/crm/tickets/route.ts
@@ -9,10 +9,7 @@ export async function GET(request: NextRequest) {
   if (!auth.ok) return auth.response;
 
   if (!(await isHubSpotConfigured())) {
-    return NextResponse.json(
-      { error: "HubSpot not configured." },
-      { status: 503 },
-    );
+    return NextResponse.json({ error: "HubSpot not configured." }, { status: 503 });
   }
 
   try {
@@ -33,9 +30,6 @@ export async function GET(request: NextRequest) {
     const _r = mapIntegrationError(err);
     if (_r) return _r;
     console.error("[HubSpot] Error listing tickets:", err);
-    return NextResponse.json(
-      { error: "Failed to fetch tickets." },
-      { status: 500 },
-    );
+    return NextResponse.json({ error: "Failed to fetch tickets." }, { status: 500 });
   }
 }

--- a/src/app/api/admin/email/campaigns/[id]/route.ts
+++ b/src/app/api/admin/email/campaigns/[id]/route.ts
@@ -2,18 +2,12 @@ import { NextRequest, NextResponse } from "next/server";
 import { requireAdmin } from "@/lib/api-auth";
 import { isActiveCampaignConfigured, getCampaign } from "@/lib/activecampaign";
 
-export async function GET(
-  request: NextRequest,
-  { params }: { params: Promise<{ id: string }> },
-) {
+export async function GET(request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
   const auth = await requireAdmin(request);
   if (!auth.ok) return auth.response;
 
   if (!(await isActiveCampaignConfigured())) {
-    return NextResponse.json(
-      { error: "ActiveCampaign not configured." },
-      { status: 503 },
-    );
+    return NextResponse.json({ error: "ActiveCampaign not configured." }, { status: 503 });
   }
 
   const { id } = await params;

--- a/src/app/api/admin/email/lists/route.ts
+++ b/src/app/api/admin/email/lists/route.ts
@@ -7,10 +7,7 @@ export async function GET(request: NextRequest) {
   if (!auth.ok) return auth.response;
 
   if (!(await isActiveCampaignConfigured())) {
-    return NextResponse.json(
-      { error: "ActiveCampaign not configured." },
-      { status: 503 },
-    );
+    return NextResponse.json({ error: "ActiveCampaign not configured." }, { status: 503 });
   }
 
   const lists = await listACLists();

--- a/src/app/api/admin/esp32/route.ts
+++ b/src/app/api/admin/esp32/route.ts
@@ -10,7 +10,10 @@ async function proxyRequest(path: string, init?: RequestInit): Promise<NextRespo
       signal: AbortSignal.timeout(8000),
     });
     if (res.status === 404) {
-      return NextResponse.json({ error: "ESP32 management unavailable", offline: true }, { status: 503 });
+      return NextResponse.json(
+        { error: "ESP32 management unavailable", offline: true },
+        { status: 503 }
+      );
     }
     const data = await res.json();
     return NextResponse.json(data, { status: res.status });
@@ -57,7 +60,8 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
         return NextResponse.json({ error: "Pi unreachable", offline: true }, { status: 503 });
       }
     }
-    case "config":  return proxyRequest(`/api/esp32/${deviceId}/config`);
+    case "config":
+      return proxyRequest(`/api/esp32/${deviceId}/config`);
     default:
       return NextResponse.json({ error: "Unknown action" }, { status: 400 });
   }

--- a/src/app/api/admin/integrations/status/route.ts
+++ b/src/app/api/admin/integrations/status/route.ts
@@ -3,11 +3,7 @@ import { requireAdmin } from "@/lib/api-auth";
 import { getConfig } from "@/lib/ssm-config";
 import { verifyActiveCampaignToken } from "@/lib/activecampaign";
 
-export type IntegrationStatus =
-  | "configured"
-  | "not_configured"
-  | "degraded"
-  | "error";
+export type IntegrationStatus = "configured" | "not_configured" | "degraded" | "error";
 
 export type IntegrationReport = {
   id: string;
@@ -23,17 +19,13 @@ type Cfg = Awaited<ReturnType<typeof getConfig>>;
 
 async function pingHubSpot(token: string): Promise<PingResult> {
   try {
-    const res = await fetch(
-      "https://api.hubapi.com/crm/v3/objects/contacts?limit=1",
-      {
-        headers: { Authorization: `Bearer ${token}` },
-        signal: AbortSignal.timeout(5000),
-      },
-    );
+    const res = await fetch("https://api.hubapi.com/crm/v3/objects/contacts?limit=1", {
+      headers: { Authorization: `Bearer ${token}` },
+      signal: AbortSignal.timeout(5000),
+    });
     if (res.status === 401 || res.status === 403)
       return { status: "degraded", message: `Token rejected (${res.status}).` };
-    if (!res.ok)
-      return { status: "error", message: `API returned ${res.status}` };
+    if (!res.ok) return { status: "error", message: `API returned ${res.status}` };
     return { status: "configured" };
   } catch {
     return { status: "error", message: "Connection failed." };
@@ -51,8 +43,7 @@ async function pingSlack(token: string): Promise<PingResult> {
       signal: AbortSignal.timeout(5000),
     });
     const data = await res.json();
-    if (!data.ok)
-      return { status: "degraded", message: data.error ?? "auth.test failed." };
+    if (!data.ok) return { status: "degraded", message: data.error ?? "auth.test failed." };
     return { status: "configured", message: `Workspace: ${data.team}` };
   } catch {
     return { status: "error", message: "Connection failed." };
@@ -68,10 +59,8 @@ async function pingNotion(token: string): Promise<PingResult> {
       },
       signal: AbortSignal.timeout(5000),
     });
-    if (res.status === 401)
-      return { status: "degraded", message: "Token rejected (401)." };
-    if (!res.ok)
-      return { status: "error", message: `API returned ${res.status}` };
+    if (res.status === 401) return { status: "degraded", message: "Token rejected (401)." };
+    if (!res.ok) return { status: "error", message: `API returned ${res.status}` };
     return { status: "configured" };
   } catch {
     return { status: "error", message: "Connection failed." };
@@ -86,8 +75,7 @@ async function pingStripe(secretKey: string): Promise<PingResult> {
     });
     if (res.status === 401 || res.status === 403)
       return { status: "degraded", message: "Secret key rejected." };
-    if (!res.ok)
-      return { status: "error", message: `API returned ${res.status}` };
+    if (!res.ok) return { status: "error", message: `API returned ${res.status}` };
     return { status: "configured" };
   } catch {
     return { status: "error", message: "Connection failed." };
@@ -103,9 +91,7 @@ function sentryStatus(cfg: Cfg): IntegrationStatus {
 }
 
 function sentryReport(cfg: Cfg): IntegrationReport {
-  const dsnOnly = Boolean(
-    process.env.NEXT_PUBLIC_SENTRY_DSN && !cfg.SENTRY_AUTH_TOKEN,
-  );
+  const dsnOnly = Boolean(process.env.NEXT_PUBLIC_SENTRY_DSN && !cfg.SENTRY_AUTH_TOKEN);
   return {
     id: "sentry",
     name: "Sentry",
@@ -118,10 +104,7 @@ function sentryReport(cfg: Cfg): IntegrationReport {
   };
 }
 
-function tiktokStatus(
-  appReady: boolean,
-  fullyConfigured: boolean,
-): IntegrationStatus {
+function tiktokStatus(appReady: boolean, fullyConfigured: boolean): IntegrationStatus {
   if (fullyConfigured) return "configured";
   if (appReady) return "degraded";
   return "not_configured";
@@ -129,9 +112,7 @@ function tiktokStatus(
 
 function tiktokReport(cfg: Cfg): IntegrationReport {
   const appReady = Boolean(cfg.TIKTOK_APP_ID && cfg.TIKTOK_APP_SECRET);
-  const fullyConfigured = Boolean(
-    appReady && cfg.TIKTOK_ACCESS_TOKEN && cfg.TIKTOK_ADVERTISER_ID,
-  );
+  const fullyConfigured = Boolean(appReady && cfg.TIKTOK_ACCESS_TOKEN && cfg.TIKTOK_ADVERTISER_ID);
   const tiktokSetupUrl = appReady
     ? `${process.env.NEXT_PUBLIC_APP_URL}/api/admin/oauth/tiktok`
     : "https://ads.tiktok.com/marketing_api/apps";
@@ -148,10 +129,7 @@ function tiktokReport(cfg: Cfg): IntegrationReport {
   };
 }
 
-function xAdsStatus(
-  tokensReady: boolean,
-  fullyConfigured: boolean,
-): IntegrationStatus {
+function xAdsStatus(tokensReady: boolean, fullyConfigured: boolean): IntegrationStatus {
   if (fullyConfigured) return "configured";
   if (tokensReady) return "degraded";
   return "not_configured";
@@ -159,10 +137,7 @@ function xAdsStatus(
 
 function xAdsReport(cfg: Cfg): IntegrationReport {
   const tokensReady = Boolean(
-    cfg.X_API_KEY &&
-      cfg.X_ACCESS_TOKEN &&
-      cfg.X_API_SECRET &&
-      cfg.X_ACCESS_SECRET,
+    cfg.X_API_KEY && cfg.X_ACCESS_TOKEN && cfg.X_API_SECRET && cfg.X_ACCESS_SECRET
   );
   const fullyConfigured = Boolean(tokensReady && cfg.X_AD_ACCOUNT_ID);
   return {
@@ -202,9 +177,7 @@ function buildCoreReports(cfg: Cfg): IntegrationReport[] {
       name: "Google (Calendar + Search Console)",
       category: "productivity",
       status: configuredIf(
-        cfg.GOOGLE_CLIENT_EMAIL &&
-          cfg.GOOGLE_PRIVATE_KEY &&
-          cfg.GOOGLE_CALENDAR_ID,
+        cfg.GOOGLE_CLIENT_EMAIL && cfg.GOOGLE_PRIVATE_KEY && cfg.GOOGLE_CALENDAR_ID
       ),
       setupUrl: "https://console.cloud.google.com/iam-admin/serviceaccounts",
     },
@@ -224,16 +197,12 @@ function buildCoreReports(cfg: Cfg): IntegrationReport[] {
 
 function buildSocialAdsReports(cfg: Cfg): IntegrationReport[] {
   const metaConfigured = Boolean(
-    cfg.META_AD_ACCOUNT_ID && cfg.META_ACCESS_TOKEN && cfg.META_PIXEL_ID,
+    cfg.META_AD_ACCOUNT_ID && cfg.META_ACCESS_TOKEN && cfg.META_PIXEL_ID
   );
   const linkedInConfigured = Boolean(
-    cfg.LINKEDIN_ACCESS_TOKEN &&
-      cfg.LINKEDIN_AD_ACCOUNT_ID &&
-      cfg.LINKEDIN_ORGANIZATION_URN,
+    cfg.LINKEDIN_ACCESS_TOKEN && cfg.LINKEDIN_AD_ACCOUNT_ID && cfg.LINKEDIN_ORGANIZATION_URN
   );
-  const googleAdsConfigured = Boolean(
-    cfg.GOOGLE_ADS_DEVELOPER_TOKEN && cfg.GOOGLE_ADS_CUSTOMER_ID,
-  );
+  const googleAdsConfigured = Boolean(cfg.GOOGLE_ADS_DEVELOPER_TOKEN && cfg.GOOGLE_ADS_CUSTOMER_ID);
   const metaMessage = metaConfigured
     ? "Instagram Business Account ID blocked — Meta ad policy violation on account 1558125105019725. Appeal required."
     : undefined;
@@ -275,22 +244,13 @@ function buildStaticReports(cfg: Cfg): IntegrationReport[] {
 }
 
 async function buildPingedReports(cfg: Cfg): Promise<IntegrationReport[]> {
-  const [stripeResult, hubspotResult, slackResult, notionResult, acResult] =
-    await Promise.all([
-      cfg.STRIPE_SECRET_KEY
-        ? pingStripe(cfg.STRIPE_SECRET_KEY)
-        : Promise.resolve(NOT_CONFIGURED),
-      cfg.HUBSPOT_API_KEY
-        ? pingHubSpot(cfg.HUBSPOT_API_KEY)
-        : Promise.resolve(NOT_CONFIGURED),
-      cfg.SLACK_BOT_TOKEN
-        ? pingSlack(cfg.SLACK_BOT_TOKEN)
-        : Promise.resolve(NOT_CONFIGURED),
-      cfg.NOTION_API_KEY
-        ? pingNotion(cfg.NOTION_API_KEY)
-        : Promise.resolve(NOT_CONFIGURED),
-      verifyActiveCampaignToken(),
-    ]);
+  const [stripeResult, hubspotResult, slackResult, notionResult, acResult] = await Promise.all([
+    cfg.STRIPE_SECRET_KEY ? pingStripe(cfg.STRIPE_SECRET_KEY) : Promise.resolve(NOT_CONFIGURED),
+    cfg.HUBSPOT_API_KEY ? pingHubSpot(cfg.HUBSPOT_API_KEY) : Promise.resolve(NOT_CONFIGURED),
+    cfg.SLACK_BOT_TOKEN ? pingSlack(cfg.SLACK_BOT_TOKEN) : Promise.resolve(NOT_CONFIGURED),
+    cfg.NOTION_API_KEY ? pingNotion(cfg.NOTION_API_KEY) : Promise.resolve(NOT_CONFIGURED),
+    verifyActiveCampaignToken(),
+  ]);
 
   const acStatusMap: Record<string, IntegrationStatus> = {
     valid: "configured",

--- a/src/app/api/admin/kpi/route.ts
+++ b/src/app/api/admin/kpi/route.ts
@@ -2,11 +2,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { requireAdmin } from "@/lib/api-auth";
 import { getAnalyticsSummary } from "@/lib/notion-analytics";
 import { getSeoSnapshot } from "@/lib/gsc";
-import {
-  listProjects,
-  getTaskSummary,
-  getOverdueTasks,
-} from "@/lib/notion-projects";
+import { listProjects, getTaskSummary, getOverdueTasks } from "@/lib/notion-projects";
 import { isConfiguredAsync } from "@/lib/integrations";
 import { getConfig } from "@/lib/ssm-config";
 
@@ -22,29 +18,20 @@ export async function GET(request: NextRequest) {
   ]);
   const gscConf = !!(cfg.GOOGLE_CLIENT_EMAIL && cfg.GOOGLE_PRIVATE_KEY);
 
-  const [
-    analyticsResult,
-    gscResult,
-    projectsResult,
-    taskSummaryResult,
-    overdueResult,
-  ] = await Promise.allSettled([
-    analyticsConf ? getAnalyticsSummary(7) : Promise.resolve(null),
-    gscConf ? getSeoSnapshot() : Promise.resolve(null),
-    projectsConf ? listProjects() : Promise.resolve([]),
-    tasksConf ? getTaskSummary() : Promise.resolve({}),
-    tasksConf ? getOverdueTasks() : Promise.resolve([]),
-  ]);
+  const [analyticsResult, gscResult, projectsResult, taskSummaryResult, overdueResult] =
+    await Promise.allSettled([
+      analyticsConf ? getAnalyticsSummary(7) : Promise.resolve(null),
+      gscConf ? getSeoSnapshot() : Promise.resolve(null),
+      projectsConf ? listProjects() : Promise.resolve([]),
+      tasksConf ? getTaskSummary() : Promise.resolve({}),
+      tasksConf ? getOverdueTasks() : Promise.resolve([]),
+    ]);
 
-  const analytics =
-    analyticsResult.status === "fulfilled" ? analyticsResult.value : null;
+  const analytics = analyticsResult.status === "fulfilled" ? analyticsResult.value : null;
   const gsc = gscResult.status === "fulfilled" ? gscResult.value : null;
-  const projects =
-    projectsResult.status === "fulfilled" ? projectsResult.value : [];
-  const taskSummary =
-    taskSummaryResult.status === "fulfilled" ? taskSummaryResult.value : {};
-  const overdueTasks =
-    overdueResult.status === "fulfilled" ? overdueResult.value : [];
+  const projects = projectsResult.status === "fulfilled" ? projectsResult.value : [];
+  const taskSummary = taskSummaryResult.status === "fulfilled" ? taskSummaryResult.value : {};
+  const overdueTasks = overdueResult.status === "fulfilled" ? overdueResult.value : [];
 
   const projectsByStatus: Record<string, number> = {};
   for (const p of projects) {
@@ -57,9 +44,8 @@ export async function GET(request: NextRequest) {
     projects: {
       total: projects.length,
       byStatus: projectsByStatus,
-      activeCount: projects.filter(
-        (p) => p.status === "In Progress" || p.status === "Planning",
-      ).length,
+      activeCount: projects.filter((p) => p.status === "In Progress" || p.status === "Planning")
+        .length,
     },
     tasks: {
       summary: taskSummary,

--- a/src/app/api/admin/notifications/test/route.ts
+++ b/src/app/api/admin/notifications/test/route.ts
@@ -15,10 +15,9 @@ export async function POST(request: NextRequest) {
   if (!cfg.SLACK_BOT_TOKEN && !cfg.SLACK_WEBHOOK_URL) {
     return NextResponse.json(
       {
-        error:
-          "Slack not configured — set SLACK_BOT_TOKEN or SLACK_WEBHOOK_URL.",
+        error: "Slack not configured — set SLACK_BOT_TOKEN or SLACK_WEBHOOK_URL.",
       },
-      { status: 503 },
+      { status: 503 }
     );
   }
 

--- a/src/app/api/admin/notion/analytics/route.ts
+++ b/src/app/api/admin/notion/analytics/route.ts
@@ -14,20 +14,12 @@ export async function GET(request: NextRequest) {
   if (!auth.ok) return auth.response;
 
   if (!(await isConfiguredAsync("NOTION_API_KEY", "NOTION_ANALYTICS_DB_ID"))) {
-    return NextResponse.json(
-      { error: "Notion Analytics not configured" },
-      { status: 503 },
-    );
+    return NextResponse.json({ error: "Notion Analytics not configured" }, { status: 503 });
   }
 
-  const _rawDays = parseInt(
-    request.nextUrl.searchParams.get("days") ?? "7",
-    10,
-  );
+  const _rawDays = parseInt(request.nextUrl.searchParams.get("days") ?? "7", 10);
   const days = Math.max(1, Math.min(isNaN(_rawDays) ? 7 : _rawDays, 365));
-  const type = request.nextUrl.searchParams.get(
-    "type",
-  ) as AnalyticsEventType | null;
+  const type = request.nextUrl.searchParams.get("type") as AnalyticsEventType | null;
 
   if (type) {
     const events = await getRecentEvents(type);
@@ -51,10 +43,7 @@ export async function POST(request: NextRequest) {
   if (!auth.ok) return auth.response;
 
   if (!(await isConfiguredAsync("NOTION_API_KEY", "NOTION_ANALYTICS_DB_ID"))) {
-    return NextResponse.json(
-      { error: "Notion Analytics not configured" },
-      { status: 503 },
-    );
+    return NextResponse.json({ error: "Notion Analytics not configured" }, { status: 503 });
   }
 
   const body = await request.json().catch(() => ({}));
@@ -80,6 +69,6 @@ export async function POST(request: NextRequest) {
 
   return NextResponse.json(
     { error: 'Unknown action. Use "rollup", "archive", or "maintain".' },
-    { status: 400 },
+    { status: 400 }
   );
 }

--- a/src/app/api/admin/notion/blog/route.ts
+++ b/src/app/api/admin/notion/blog/route.ts
@@ -8,10 +8,7 @@ export async function GET(request: NextRequest) {
   if (!auth.ok) return auth.response;
 
   if (!(await isConfiguredAsync("NOTION_API_KEY", "NOTION_BLOG_DB_ID"))) {
-    return NextResponse.json(
-      { error: "Notion Blog not configured" },
-      { status: 503 },
-    );
+    return NextResponse.json({ error: "Notion Blog not configured" }, { status: 503 });
   }
 
   const posts = await getPosts();

--- a/src/app/api/admin/notion/comments/route.ts
+++ b/src/app/api/admin/notion/comments/route.ts
@@ -25,10 +25,7 @@ export async function GET(request: NextRequest) {
     const _r = mapIntegrationError(err);
     if (_r) return _r;
     console.error("[API] Comments error:", err);
-    return NextResponse.json(
-      { error: "Failed to fetch comments" },
-      { status: 500 },
-    );
+    return NextResponse.json({ error: "Failed to fetch comments" }, { status: 500 });
   }
 }
 
@@ -40,25 +37,19 @@ export async function POST(request: NextRequest) {
     const { page_id, text } = await request.json();
 
     if (!page_id || !text) {
-      return NextResponse.json(
-        { error: "page_id and text are required" },
-        { status: 400 },
-      );
+      return NextResponse.json({ error: "page_id and text are required" }, { status: 400 });
     }
 
     if (typeof text !== "string" || text.length > 5000) {
       return NextResponse.json(
         { error: "text must be a string no longer than 5000 characters" },
-        { status: 400 },
+        { status: 400 }
       );
     }
 
     const comment = await addComment(page_id, text);
     if (!comment) {
-      return NextResponse.json(
-        { error: "Failed to add comment" },
-        { status: 500 },
-      );
+      return NextResponse.json({ error: "Failed to add comment" }, { status: 500 });
     }
 
     return NextResponse.json({ comment }, { status: 201 });
@@ -66,9 +57,6 @@ export async function POST(request: NextRequest) {
     const _r = mapIntegrationError(err);
     if (_r) return _r;
     console.error("[API] Add comment error:", err);
-    return NextResponse.json(
-      { error: "Failed to add comment" },
-      { status: 500 },
-    );
+    return NextResponse.json({ error: "Failed to add comment" }, { status: 500 });
   }
 }

--- a/src/app/api/admin/notion/docs/route.ts
+++ b/src/app/api/admin/notion/docs/route.ts
@@ -8,10 +8,7 @@ export async function GET(request: NextRequest) {
   if (!auth.ok) return auth.response;
 
   if (!(await isConfiguredAsync("NOTION_API_KEY", "NOTION_DOCS_DB_ID"))) {
-    return NextResponse.json(
-      { error: "Notion Docs not configured" },
-      { status: 503 },
-    );
+    return NextResponse.json({ error: "Notion Docs not configured" }, { status: 503 });
   }
 
   const docs = await getDocs();

--- a/src/app/api/admin/notion/projects/route.ts
+++ b/src/app/api/admin/notion/projects/route.ts
@@ -14,15 +14,10 @@ export async function GET(request: NextRequest) {
   if (!auth.ok) return auth.response;
 
   if (!(await isConfiguredAsync("NOTION_API_KEY", "NOTION_PROJECTS_DB_ID"))) {
-    return NextResponse.json(
-      { error: "Notion Projects not configured" },
-      { status: 503 },
-    );
+    return NextResponse.json({ error: "Notion Projects not configured" }, { status: 503 });
   }
 
-  const status = request.nextUrl.searchParams.get(
-    "status",
-  ) as ProjectStatus | null;
+  const status = request.nextUrl.searchParams.get("status") as ProjectStatus | null;
   const projects = await listProjects(status ?? undefined);
   return NextResponse.json({ projects, count: projects.length });
 }
@@ -32,10 +27,7 @@ export async function POST(request: NextRequest) {
   if (!auth.ok) return auth.response;
 
   if (!(await isConfiguredAsync("NOTION_API_KEY", "NOTION_PROJECTS_DB_ID"))) {
-    return NextResponse.json(
-      { error: "Notion Projects not configured" },
-      { status: 503 },
-    );
+    return NextResponse.json({ error: "Notion Projects not configured" }, { status: 503 });
   }
 
   const body = await request.json();
@@ -43,25 +35,18 @@ export async function POST(request: NextRequest) {
     return NextResponse.json({ error: "name is required" }, { status: 400 });
   }
 
-  if (
-    typeof body.name !== "string" ||
-    body.name.trim().length === 0 ||
-    body.name.length > 200
-  ) {
+  if (typeof body.name !== "string" || body.name.trim().length === 0 || body.name.length > 200) {
     return NextResponse.json(
       {
         error: "name must be a non-empty string no longer than 200 characters",
       },
-      { status: 400 },
+      { status: 400 }
     );
   }
 
   const id = await createProject(body);
   if (!id) {
-    return NextResponse.json(
-      { error: "Failed to create project" },
-      { status: 500 },
-    );
+    return NextResponse.json({ error: "Failed to create project" }, { status: 500 });
   }
   return NextResponse.json({ id }, { status: 201 });
 }
@@ -78,31 +63,20 @@ export async function PATCH(request: NextRequest) {
   }
 
   if (status) {
-    const valid: ProjectStatus[] = [
-      "Planning",
-      "In Progress",
-      "On Hold",
-      "Completed",
-      "Cancelled",
-    ];
+    const valid: ProjectStatus[] = ["Planning", "In Progress", "On Hold", "Completed", "Cancelled"];
     if (!valid.includes(status)) {
       return NextResponse.json(
         { error: `Invalid status. Must be one of: ${valid.join(", ")}` },
-        { status: 400 },
+        { status: 400 }
       );
     }
     const ok = await updateProjectStatus(pageId, status);
-    if (!ok)
-      return NextResponse.json({ error: "Failed to update" }, { status: 500 });
+    if (!ok) return NextResponse.json({ error: "Failed to update" }, { status: 500 });
   }
 
   if (typeof progress === "number" && progress >= 0 && progress <= 100) {
     const ok = await updateProjectProgress(pageId, progress);
-    if (!ok)
-      return NextResponse.json(
-        { error: "Failed to update progress" },
-        { status: 500 },
-      );
+    if (!ok) return NextResponse.json({ error: "Failed to update progress" }, { status: 500 });
   }
 
   return NextResponse.json({ ok: true });

--- a/src/app/api/admin/notion/search/route.ts
+++ b/src/app/api/admin/notion/search/route.ts
@@ -1,12 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { requireAdmin } from "@/lib/api-auth";
 import { mapIntegrationError } from "@/lib/api-errors";
-import {
-  searchPages,
-  searchDatabases,
-  listUsers,
-  getDatabaseSchema,
-} from "@/lib/notion-search";
+import { searchPages, searchDatabases, listUsers, getDatabaseSchema } from "@/lib/notion-search";
 
 /**
  * GET /api/admin/notion/search?q=...&type=page|database&limit=20
@@ -19,12 +14,7 @@ export async function GET(request: NextRequest) {
 
   const { searchParams } = new URL(request.url);
   const q = searchParams.get("q") ?? "";
-  const type = searchParams.get("type") as
-    | "page"
-    | "database"
-    | "users"
-    | "schema"
-    | null;
+  const type = searchParams.get("type") as "page" | "database" | "users" | "schema" | null;
   const limit = Math.min(Number(searchParams.get("limit") ?? 20), 100);
 
   try {
@@ -36,10 +26,7 @@ export async function GET(request: NextRequest) {
     if (type === "schema") {
       const dbId = searchParams.get("database_id");
       if (!dbId) {
-        return NextResponse.json(
-          { error: "database_id is required" },
-          { status: 400 },
-        );
+        return NextResponse.json({ error: "database_id is required" }, { status: 400 });
       }
       const schema = await getDatabaseSchema(dbId);
       return NextResponse.json({ schema });

--- a/src/app/api/admin/notion/status/route.ts
+++ b/src/app/api/admin/notion/status/route.ts
@@ -50,11 +50,7 @@ function extractValue(prop: NotionProp): unknown {
   return fn ? fn(prop) : `(${prop.type})`;
 }
 
-async function probeDatabase(
-  name: string,
-  envKey: string,
-  limit = 5,
-): Promise<DbStatus> {
+async function probeDatabase(name: string, envKey: string, limit = 5): Promise<DbStatus> {
   const cfg = await getIntegrationsAsync();
   const dbId = cfg[envKey as keyof typeof cfg] as string | undefined;
 
@@ -104,10 +100,7 @@ async function probeDatabase(
 }
 
 function unauthenticated(error: string) {
-  return NextResponse.json(
-    { authenticated: false, error, databases: [] },
-    { status: 200 },
-  );
+  return NextResponse.json({ authenticated: false, error, databases: [] }, { status: 200 });
 }
 
 async function resolveBotName(): Promise<
@@ -126,8 +119,7 @@ async function resolveBotName(): Promise<
     const mapped = mapIntegrationError(err);
     return {
       ok: false,
-      response:
-        mapped ?? unauthenticated("NOTION_API_KEY is invalid or expired"),
+      response: mapped ?? unauthenticated("NOTION_API_KEY is invalid or expired"),
     };
   }
 }
@@ -146,17 +138,13 @@ export async function GET(request: NextRequest) {
   if (!auth.ok) return auth.response;
 
   if (!(await isConfiguredAsync("NOTION_API_KEY"))) {
-    return unauthenticated(
-      "NOTION_API_KEY not configured. Add it to .env.local",
-    );
+    return unauthenticated("NOTION_API_KEY not configured. Add it to .env.local");
   }
 
   const bot = await resolveBotName();
   if (!bot.ok) return bot.response;
 
-  const databases = await Promise.all(
-    PROBE_TARGETS.map(([name, key]) => probeDatabase(name, key)),
-  );
+  const databases = await Promise.all(PROBE_TARGETS.map(([name, key]) => probeDatabase(name, key)));
 
   return NextResponse.json({
     authenticated: true,

--- a/src/app/api/admin/notion/submissions/route.ts
+++ b/src/app/api/admin/notion/submissions/route.ts
@@ -21,13 +21,8 @@ export async function GET(request: NextRequest) {
   const auth = await requireAdmin(request);
   if (!auth.ok) return auth.response;
 
-  if (
-    !(await isConfiguredAsync("NOTION_API_KEY", "NOTION_SUBMISSIONS_DB_ID"))
-  ) {
-    return NextResponse.json(
-      { error: "Notion submissions not configured" },
-      { status: 503 },
-    );
+  if (!(await isConfiguredAsync("NOTION_API_KEY", "NOTION_SUBMISSIONS_DB_ID"))) {
+    return NextResponse.json({ error: "Notion submissions not configured" }, { status: 503 });
   }
 
   const { searchParams } = new URL(request.url);
@@ -40,10 +35,7 @@ export async function GET(request: NextRequest) {
     const _r = mapIntegrationError(err);
     if (_r) return _r;
     console.error("[Admin] Failed to list submissions:", err);
-    return NextResponse.json(
-      { error: "Failed to fetch submissions" },
-      { status: 500 },
-    );
+    return NextResponse.json({ error: "Failed to fetch submissions" }, { status: 500 });
   }
 }
 
@@ -52,10 +44,7 @@ export async function PATCH(request: NextRequest) {
   if (!auth.ok) return auth.response;
 
   if (!(await isConfiguredAsync("NOTION_API_KEY"))) {
-    return NextResponse.json(
-      { error: "Notion not configured" },
-      { status: 503 },
-    );
+    return NextResponse.json({ error: "Notion not configured" }, { status: 503 });
   }
 
   let body: { pageId?: string; status?: string };
@@ -70,39 +59,27 @@ export async function PATCH(request: NextRequest) {
   const { pageId, status } = body;
 
   if (!pageId || !status) {
-    return NextResponse.json(
-      { error: "pageId and status are required" },
-      { status: 400 },
-    );
+    return NextResponse.json({ error: "pageId and status are required" }, { status: 400 });
   }
 
   const validStatuses = ["New", "In Review", "Done"] as const;
   if (!validStatuses.includes(status as (typeof validStatuses)[number])) {
     return NextResponse.json(
       { error: `status must be one of: ${validStatuses.join(", ")}` },
-      { status: 400 },
+      { status: 400 }
     );
   }
 
   try {
-    const ok = await updateSubmissionStatus(
-      pageId,
-      status as "New" | "In Review" | "Done",
-    );
+    const ok = await updateSubmissionStatus(pageId, status as "New" | "In Review" | "Done");
     if (!ok) {
-      return NextResponse.json(
-        { error: "Failed to update status" },
-        { status: 500 },
-      );
+      return NextResponse.json({ error: "Failed to update status" }, { status: 500 });
     }
     return NextResponse.json({ success: true });
   } catch (err) {
     const _r = mapIntegrationError(err);
     if (_r) return _r;
     console.error("[Admin] Failed to update submission status:", err);
-    return NextResponse.json(
-      { error: "Failed to update submission status" },
-      { status: 500 },
-    );
+    return NextResponse.json({ error: "Failed to update submission status" }, { status: 500 });
   }
 }

--- a/src/app/api/admin/notion/tasks/route.ts
+++ b/src/app/api/admin/notion/tasks/route.ts
@@ -1,11 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { requireAdmin } from "@/lib/api-auth";
-import {
-  listTasks,
-  createTask,
-  updateTaskStatus,
-  getTaskSummary,
-} from "@/lib/notion-projects";
+import { listTasks, createTask, updateTaskStatus, getTaskSummary } from "@/lib/notion-projects";
 import type { TaskStatus } from "@/lib/notion-projects";
 import { isConfiguredAsync } from "@/lib/integrations";
 
@@ -14,10 +9,7 @@ export async function GET(request: NextRequest) {
   if (!auth.ok) return auth.response;
 
   if (!(await isConfiguredAsync("NOTION_API_KEY", "NOTION_TASKS_DB_ID"))) {
-    return NextResponse.json(
-      { error: "Notion Tasks not configured" },
-      { status: 503 },
-    );
+    return NextResponse.json({ error: "Notion Tasks not configured" }, { status: 503 });
   }
 
   const summary = request.nextUrl.searchParams.get("summary");
@@ -26,9 +18,7 @@ export async function GET(request: NextRequest) {
     return NextResponse.json({ summary: counts });
   }
 
-  const status = request.nextUrl.searchParams.get(
-    "status",
-  ) as TaskStatus | null;
+  const status = request.nextUrl.searchParams.get("status") as TaskStatus | null;
   const project = request.nextUrl.searchParams.get("project");
   const assignee = request.nextUrl.searchParams.get("assignee");
 
@@ -46,10 +36,7 @@ export async function POST(request: NextRequest) {
   if (!auth.ok) return auth.response;
 
   if (!(await isConfiguredAsync("NOTION_API_KEY", "NOTION_TASKS_DB_ID"))) {
-    return NextResponse.json(
-      { error: "Notion Tasks not configured" },
-      { status: 503 },
-    );
+    return NextResponse.json({ error: "Notion Tasks not configured" }, { status: 503 });
   }
 
   const body = await request.json();
@@ -60,16 +47,13 @@ export async function POST(request: NextRequest) {
   if (typeof body.task !== "string" || body.task.length > 500) {
     return NextResponse.json(
       { error: "task must be a string no longer than 500 characters" },
-      { status: 400 },
+      { status: 400 }
     );
   }
 
   const id = await createTask(body);
   if (!id) {
-    return NextResponse.json(
-      { error: "Failed to create task" },
-      { status: 500 },
-    );
+    return NextResponse.json({ error: "Failed to create task" }, { status: 500 });
   }
   return NextResponse.json({ id }, { status: 201 });
 }
@@ -82,33 +66,20 @@ export async function PATCH(request: NextRequest) {
   const { pageId, status } = body;
 
   if (!pageId || !status) {
-    return NextResponse.json(
-      { error: "pageId and status are required" },
-      { status: 400 },
-    );
+    return NextResponse.json({ error: "pageId and status are required" }, { status: 400 });
   }
 
-  const valid: TaskStatus[] = [
-    "Backlog",
-    "To Do",
-    "In Progress",
-    "In Review",
-    "Done",
-    "Blocked",
-  ];
+  const valid: TaskStatus[] = ["Backlog", "To Do", "In Progress", "In Review", "Done", "Blocked"];
   if (!valid.includes(status)) {
     return NextResponse.json(
       { error: `Invalid status. Must be one of: ${valid.join(", ")}` },
-      { status: 400 },
+      { status: 400 }
     );
   }
 
   const ok = await updateTaskStatus(pageId, status);
   if (!ok) {
-    return NextResponse.json(
-      { error: "Failed to update task status" },
-      { status: 500 },
-    );
+    return NextResponse.json({ error: "Failed to update task status" }, { status: 500 });
   }
   return NextResponse.json({ ok: true });
 }

--- a/src/app/api/admin/oauth/tiktok/callback/route.ts
+++ b/src/app/api/admin/oauth/tiktok/callback/route.ts
@@ -3,8 +3,7 @@ import { requireAdmin } from "@/lib/api-auth";
 import { createHmac, timingSafeEqual } from "crypto";
 import { getConfig } from "@/lib/ssm-config";
 
-const TOKEN_URL =
-  "https://business-api.tiktok.com/open_api/v1.3/oauth2/access_token/";
+const TOKEN_URL = "https://business-api.tiktok.com/open_api/v1.3/oauth2/access_token/";
 
 function escapeHtml(s: string): string {
   return s
@@ -20,10 +19,7 @@ function verifyState(state: string, secret: string): boolean {
   if (dot === -1) return false;
   const nonce = state.slice(0, dot);
   const sig = state.slice(dot + 1);
-  const expected = createHmac("sha256", secret)
-    .update(nonce)
-    .digest("hex")
-    .slice(0, 16);
+  const expected = createHmac("sha256", secret).update(nonce).digest("hex").slice(0, 16);
   const sigBuf = Buffer.from(sig, "utf-8");
   const expectedBuf = Buffer.from(expected, "utf-8");
   if (sigBuf.length !== expectedBuf.length) return false;
@@ -46,7 +42,7 @@ interface TikTokTokenResponse {
 async function exchangeCode(
   appId: string,
   secret: string,
-  authCode: string,
+  authCode: string
 ): Promise<TikTokTokenResponse> {
   const res = await fetch(TOKEN_URL, {
     method: "POST",
@@ -108,64 +104,52 @@ export async function GET(request: NextRequest) {
   }
 
   if (!authCode) {
-    return new NextResponse(
-      errorHtml("Missing auth_code in callback parameters."),
-      {
-        status: 400,
-        headers: { "Content-Type": "text/html; charset=utf-8" },
-      },
-    );
+    return new NextResponse(errorHtml("Missing auth_code in callback parameters."), {
+      status: 400,
+      headers: { "Content-Type": "text/html; charset=utf-8" },
+    });
   }
 
   const cfg = await getConfig();
 
   if (!cfg.TIKTOK_APP_ID || !cfg.TIKTOK_APP_SECRET) {
-    return new NextResponse(
-      errorHtml("TIKTOK_APP_ID or TIKTOK_APP_SECRET not configured."),
-      {
-        status: 503,
-        headers: { "Content-Type": "text/html; charset=utf-8" },
-      },
-    );
+    return new NextResponse(errorHtml("TIKTOK_APP_ID or TIKTOK_APP_SECRET not configured."), {
+      status: 503,
+      headers: { "Content-Type": "text/html; charset=utf-8" },
+    });
   }
 
   // Verify the CSRF state with the TikTok app secret only. Using CRON_SECRET
   // here would let any holder of the cron token forge a valid OAuth state.
   if (!verifyState(state, cfg.TIKTOK_APP_SECRET)) {
     return new NextResponse(
-      errorHtml(
-        "Invalid state parameter — possible CSRF. Restart the OAuth flow.",
-      ),
+      errorHtml("Invalid state parameter — possible CSRF. Restart the OAuth flow."),
       {
         status: 400,
         headers: { "Content-Type": "text/html; charset=utf-8" },
-      },
+      }
     );
   }
 
   let tokenData: TikTokTokenResponse;
   try {
-    tokenData = await exchangeCode(
-      cfg.TIKTOK_APP_ID,
-      cfg.TIKTOK_APP_SECRET,
-      authCode,
-    );
+    tokenData = await exchangeCode(cfg.TIKTOK_APP_ID, cfg.TIKTOK_APP_SECRET, authCode);
   } catch {
     return new NextResponse(
       errorHtml("Token exchange request failed. Check network connectivity."),
       {
         status: 502,
         headers: { "Content-Type": "text/html; charset=utf-8" },
-      },
+      }
     );
   }
 
   if (tokenData.code !== 0 || !tokenData.data?.access_token) {
     return new NextResponse(
       errorHtml(
-        `TikTok token exchange failed: ${tokenData.message ?? "unknown error"} (code ${tokenData.code})`,
+        `TikTok token exchange failed: ${tokenData.message ?? "unknown error"} (code ${tokenData.code})`
       ),
-      { status: 502, headers: { "Content-Type": "text/html; charset=utf-8" } },
+      { status: 502, headers: { "Content-Type": "text/html; charset=utf-8" } }
     );
   }
 

--- a/src/app/api/admin/oauth/tiktok/route.ts
+++ b/src/app/api/admin/oauth/tiktok/route.ts
@@ -9,11 +9,7 @@ function signState(nonce: string, secret: string): string {
   return createHmac("sha256", secret).update(nonce).digest("hex").slice(0, 16);
 }
 
-export function buildTikTokAuthUrl(
-  appId: string,
-  redirectUri: string,
-  state: string,
-): string {
+export function buildTikTokAuthUrl(appId: string, redirectUri: string, state: string): string {
   const params = new URLSearchParams({
     app_id: appId,
     redirect_uri: redirectUri,
@@ -30,10 +26,9 @@ export async function GET(request: NextRequest) {
   if (!cfg.TIKTOK_APP_ID || !cfg.TIKTOK_APP_SECRET) {
     return NextResponse.json(
       {
-        error:
-          "TIKTOK_APP_ID and TIKTOK_APP_SECRET must be set before starting OAuth.",
+        error: "TIKTOK_APP_ID and TIKTOK_APP_SECRET must be set before starting OAuth.",
       },
-      { status: 503 },
+      { status: 503 }
     );
   }
 

--- a/src/app/api/admin/ops/errors/[id]/route.ts
+++ b/src/app/api/admin/ops/errors/[id]/route.ts
@@ -1,10 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { requireAdmin } from "@/lib/api-auth";
-import {
-  isSentryConfigured,
-  updateIssueStatus,
-  type IssueStatus,
-} from "@/lib/sentry";
+import { isSentryConfigured, updateIssueStatus, type IssueStatus } from "@/lib/sentry";
 
 type Params = { params: Promise<{ id: string }> };
 
@@ -19,10 +15,7 @@ export async function PUT(request: NextRequest, { params }: Params) {
   if (!auth.ok) return auth.response;
 
   if (!(await isSentryConfigured())) {
-    return NextResponse.json(
-      { error: "Sentry not configured." },
-      { status: 503 },
-    );
+    return NextResponse.json({ error: "Sentry not configured." }, { status: 503 });
   }
 
   const { id } = await params;
@@ -41,7 +34,7 @@ export async function PUT(request: NextRequest, { params }: Params) {
       {
         error: `Invalid status "${status}". Must be one of: ${validStatuses.join(", ")}.`,
       },
-      { status: 400 },
+      { status: 400 }
     );
   }
 
@@ -50,7 +43,7 @@ export async function PUT(request: NextRequest, { params }: Params) {
   if (!ok) {
     return NextResponse.json(
       { error: "Failed to update issue status in Sentry." },
-      { status: 502 },
+      { status: 502 }
     );
   }
 

--- a/src/app/api/admin/ops/errors/route.ts
+++ b/src/app/api/admin/ops/errors/route.ts
@@ -1,20 +1,13 @@
 import { NextRequest, NextResponse } from "next/server";
 import { requireAdmin } from "@/lib/api-auth";
-import {
-  getUnresolvedIssues,
-  isSentryConfigured,
-  verifySentryToken,
-} from "@/lib/sentry";
+import { getUnresolvedIssues, isSentryConfigured, verifySentryToken } from "@/lib/sentry";
 
 export async function GET(request: NextRequest) {
   const auth = await requireAdmin(request);
   if (!auth.ok) return auth.response;
 
   if (!(await isSentryConfigured())) {
-    return NextResponse.json(
-      { error: "Sentry not configured." },
-      { status: 503 },
-    );
+    return NextResponse.json({ error: "Sentry not configured." }, { status: 503 });
   }
 
   const result = await getUnresolvedIssues({ limit: 20, sort: "date" }); // NOSONAR
@@ -29,13 +22,10 @@ export async function GET(request: NextRequest) {
             "Sentry token rejected — check SENTRY_AUTH_TOKEN scopes (project:read required).",
           code: "auth_rejected",
         },
-        { status: 503 },
+        { status: 503 }
       );
     }
-    return NextResponse.json(
-      { error: "Failed to fetch errors from Sentry." },
-      { status: 502 },
-    );
+    return NextResponse.json({ error: "Failed to fetch errors from Sentry." }, { status: 502 });
   }
 
   return NextResponse.json(result);

--- a/src/app/api/admin/ops/monitor/route.ts
+++ b/src/app/api/admin/ops/monitor/route.ts
@@ -30,10 +30,7 @@ export async function GET(request: NextRequest) {
   const path = RESOURCE_MAP[resource];
 
   if (!path) {
-    return NextResponse.json(
-      { error: `Unknown resource: ${resource}` },
-      { status: 400 },
-    );
+    return NextResponse.json({ error: `Unknown resource: ${resource}` }, { status: 400 });
   }
 
   // Forward optional query params (e.g. ?status=active for /api/alerts)
@@ -52,7 +49,7 @@ export async function GET(request: NextRequest) {
     if (!res.ok) {
       return NextResponse.json(
         { error: `Alert API error: HTTP ${res.status}` },
-        { status: res.status },
+        { status: res.status }
       );
     }
 
@@ -62,7 +59,7 @@ export async function GET(request: NextRequest) {
     const msg = err instanceof Error ? err.message : "Unreachable";
     return NextResponse.json(
       { error: `Alert API unreachable: ${msg}`, offline: true },
-      { status: 503 },
+      { status: 503 }
     );
   }
 }

--- a/src/app/api/admin/orders/route.ts
+++ b/src/app/api/admin/orders/route.ts
@@ -44,16 +44,12 @@ export async function GET(request: NextRequest) {
         id: sub.id,
         customer: sub.customer,
         status: sub.status,
-        plan:
-          sub.items.data[0]?.price?.nickname ??
-          sub.items.data[0]?.price?.id ??
-          "unknown",
+        plan: sub.items.data[0]?.price?.nickname ?? sub.items.data[0]?.price?.id ?? "unknown",
         amount: (sub.items.data[0]?.price?.unit_amount ?? 0) / 100,
         currency: (sub.items.data[0]?.price?.currency ?? "eur").toUpperCase(),
         interval: sub.items.data[0]?.price?.recurring?.interval ?? "month",
         currentPeriodEnd: new Date(
-          ((sub as unknown as Record<string, number>).current_period_end ?? 0) *
-            1000,
+          ((sub as unknown as Record<string, number>).current_period_end ?? 0) * 1000
         ).toISOString(),
         cancelAtPeriodEnd: sub.cancel_at_period_end,
         created: new Date((sub.created ?? 0) * 1000).toISOString(),
@@ -62,9 +58,6 @@ export async function GET(request: NextRequest) {
     });
   } catch (err) {
     console.error("[Stripe] Error fetching orders:", err);
-    return NextResponse.json(
-      { error: "Failed to fetch orders." },
-      { status: 500 },
-    );
+    return NextResponse.json({ error: "Failed to fetch orders." }, { status: 500 });
   }
 }

--- a/src/app/api/admin/pending-clients/route.ts
+++ b/src/app/api/admin/pending-clients/route.ts
@@ -7,16 +7,9 @@ import {
 } from "@/lib/pending-clients";
 import { sendEmail } from "@/lib/email";
 import { escapeHtml } from "@/lib/escape-html";
-import {
-  SSMClient,
-  GetParameterCommand,
-  PutParameterCommand,
-} from "@aws-sdk/client-ssm";
+import { SSMClient, GetParameterCommand, PutParameterCommand } from "@aws-sdk/client-ssm";
 import { randomUUID } from "node:crypto";
-import type {
-  ClientPortal,
-  PortalStep,
-} from "@/app/api/admin/client-portals/route";
+import type { ClientPortal, PortalStep } from "@/app/api/admin/client-portals/route";
 
 const PORTALS_SSM_KEY = "/cloudless/CLIENT_PORTALS_JSON";
 const REGION = process.env.AWS_REGION ?? "eu-central-1";
@@ -42,9 +35,7 @@ function makeDefaultSteps(): PortalStep[] {
 async function readPortals(): Promise<ClientPortal[]> {
   try {
     const client = new SSMClient({ region: REGION });
-    const res = await client.send(
-      new GetParameterCommand({ Name: PORTALS_SSM_KEY }),
-    );
+    const res = await client.send(new GetParameterCommand({ Name: PORTALS_SSM_KEY }));
     return JSON.parse(res.Parameter?.Value ?? "[]");
   } catch {
     return [];
@@ -59,7 +50,7 @@ async function writePortals(portals: ClientPortal[]): Promise<void> {
       Value: JSON.stringify(portals),
       Type: "String",
       Overwrite: true,
-    }),
+    })
   );
 }
 
@@ -73,9 +64,7 @@ export async function GET(request: NextRequest) {
   const sorted = [...clients].sort((a, b) => {
     if (a.status === "waiting" && b.status !== "waiting") return -1;
     if (a.status !== "waiting" && b.status === "waiting") return 1;
-    return (
-      new Date(b.submittedAt).getTime() - new Date(a.submittedAt).getTime()
-    );
+    return new Date(b.submittedAt).getTime() - new Date(a.submittedAt).getTime();
   });
   return NextResponse.json({ clients: sorted });
 }
@@ -100,19 +89,14 @@ export async function POST(request: NextRequest) {
   }
 
   const clients = await readPendingClients();
-  const pending = clients.find(
-    (c) => c.email.toLowerCase() === body.email!.toLowerCase(),
-  );
+  const pending = clients.find((c) => c.email.toLowerCase() === body.email!.toLowerCase());
   if (!pending) {
-    return NextResponse.json(
-      { error: "Pending client not found" },
-      { status: 404 },
-    );
+    return NextResponse.json({ error: "Pending client not found" }, { status: 404 });
   }
   if (pending.status === "approved" && pending.portalToken) {
     return NextResponse.json(
       { error: "Already approved", portalToken: pending.portalToken },
-      { status: 409 },
+      { status: 409 }
     );
   }
 
@@ -163,9 +147,7 @@ export async function DELETE(request: NextRequest) {
   }
 
   const clients = await readPendingClients();
-  const updated = clients.filter(
-    (c) => c.email.toLowerCase() !== email.toLowerCase(),
-  );
+  const updated = clients.filter((c) => c.email.toLowerCase() !== email.toLowerCase());
   await writePendingClients(updated);
   return NextResponse.json({ ok: true });
 }

--- a/src/app/api/admin/pipeline/board/route.ts
+++ b/src/app/api/admin/pipeline/board/route.ts
@@ -1,28 +1,18 @@
 import { NextRequest, NextResponse } from "next/server";
 import { requireAdmin } from "@/lib/api-auth";
 import { mapIntegrationError } from "@/lib/api-errors";
-import {
-  isHubSpotConfigured,
-  getDealsByStage,
-  getPipelines,
-} from "@/lib/hubspot";
+import { isHubSpotConfigured, getDealsByStage, getPipelines } from "@/lib/hubspot";
 
 export async function GET(request: NextRequest) {
   const auth = await requireAdmin(request);
   if (!auth.ok) return auth.response;
 
   if (!(await isHubSpotConfigured())) {
-    return NextResponse.json(
-      { error: "HubSpot not configured." },
-      { status: 503 },
-    );
+    return NextResponse.json({ error: "HubSpot not configured." }, { status: 503 });
   }
 
   try {
-    const [dealsByStage, pipelines] = await Promise.all([
-      getDealsByStage(),
-      getPipelines("deals"),
-    ]);
+    const [dealsByStage, pipelines] = await Promise.all([getDealsByStage(), getPipelines("deals")]);
 
     return NextResponse.json({
       dealsByStage,
@@ -32,9 +22,6 @@ export async function GET(request: NextRequest) {
   } catch (err) {
     const _r = mapIntegrationError(err);
     if (_r) return _r;
-    return NextResponse.json(
-      { error: "Failed to fetch pipeline board." },
-      { status: 500 },
-    );
+    return NextResponse.json({ error: "Failed to fetch pipeline board." }, { status: 500 });
   }
 }

--- a/src/app/api/admin/pipeline/deals/[id]/move/route.ts
+++ b/src/app/api/admin/pipeline/deals/[id]/move/route.ts
@@ -3,18 +3,12 @@ import { requireAdmin } from "@/lib/api-auth";
 import { isHubSpotConfigured, moveDealStage } from "@/lib/hubspot";
 import { mapIntegrationError } from "@/lib/api-errors";
 
-export async function POST(
-  request: NextRequest,
-  { params }: { params: Promise<{ id: string }> },
-) {
+export async function POST(request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
   const auth = await requireAdmin(request);
   if (!auth.ok) return auth.response;
 
   if (!(await isHubSpotConfigured())) {
-    return NextResponse.json(
-      { error: "HubSpot not configured." },
-      { status: 503 },
-    );
+    return NextResponse.json({ error: "HubSpot not configured." }, { status: 503 });
   }
 
   const { id } = await params;
@@ -26,27 +20,18 @@ export async function POST(
   } catch (err) {
     const _r = mapIntegrationError(err);
     if (_r) return _r;
-    return NextResponse.json(
-      { error: "stageId is required." },
-      { status: 400 },
-    );
+    return NextResponse.json({ error: "stageId is required." }, { status: 400 });
   }
 
   try {
     const deal = await moveDealStage(id, stageId);
     if (!deal) {
-      return NextResponse.json(
-        { error: "Failed to move deal." },
-        { status: 500 },
-      );
+      return NextResponse.json({ error: "Failed to move deal." }, { status: 500 });
     }
     return NextResponse.json({ deal });
   } catch (err) {
     const _r = mapIntegrationError(err);
     if (_r) return _r;
-    return NextResponse.json(
-      { error: "Failed to move deal." },
-      { status: 500 },
-    );
+    return NextResponse.json({ error: "Failed to move deal." }, { status: 500 });
   }
 }

--- a/src/app/api/admin/pipeline/deals/[id]/notes/route.ts
+++ b/src/app/api/admin/pipeline/deals/[id]/notes/route.ts
@@ -3,18 +3,12 @@ import { requireAdmin } from "@/lib/api-auth";
 import { isHubSpotConfigured, createNote, listNotes } from "@/lib/hubspot";
 import { mapIntegrationError } from "@/lib/api-errors";
 
-export async function GET(
-  request: NextRequest,
-  { params }: { params: Promise<{ id: string }> },
-) {
+export async function GET(request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
   const auth = await requireAdmin(request);
   if (!auth.ok) return auth.response;
 
   if (!(await isHubSpotConfigured())) {
-    return NextResponse.json(
-      { error: "HubSpot not configured." },
-      { status: 503 },
-    );
+    return NextResponse.json({ error: "HubSpot not configured." }, { status: 503 });
   }
 
   const { id } = await params;
@@ -22,18 +16,12 @@ export async function GET(
   return NextResponse.json({ notes });
 }
 
-export async function POST(
-  request: NextRequest,
-  { params }: { params: Promise<{ id: string }> },
-) {
+export async function POST(request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
   const auth = await requireAdmin(request);
   if (!auth.ok) return auth.response;
 
   if (!(await isHubSpotConfigured())) {
-    return NextResponse.json(
-      { error: "HubSpot not configured." },
-      { status: 503 },
-    );
+    return NextResponse.json({ error: "HubSpot not configured." }, { status: 503 });
   }
 
   const { id } = await params;
@@ -50,10 +38,7 @@ export async function POST(
 
   const note = await createNote(id, body);
   if (!note) {
-    return NextResponse.json(
-      { error: "Failed to create note." },
-      { status: 500 },
-    );
+    return NextResponse.json({ error: "Failed to create note." }, { status: 500 });
   }
   return NextResponse.json({ note });
 }

--- a/src/app/api/admin/pipeline/stats/route.ts
+++ b/src/app/api/admin/pipeline/stats/route.ts
@@ -8,10 +8,7 @@ export async function GET(request: NextRequest) {
   if (!auth.ok) return auth.response;
 
   if (!(await isHubSpotConfigured())) {
-    return NextResponse.json(
-      { error: "HubSpot not configured." },
-      { status: 503 },
-    );
+    return NextResponse.json({ error: "HubSpot not configured." }, { status: 503 });
   }
 
   try {
@@ -20,9 +17,6 @@ export async function GET(request: NextRequest) {
   } catch (err) {
     const _r = mapIntegrationError(err);
     if (_r) return _r;
-    return NextResponse.json(
-      { error: "Failed to fetch pipeline stats." },
-      { status: 500 },
-    );
+    return NextResponse.json({ error: "Failed to fetch pipeline stats." }, { status: 500 });
   }
 }

--- a/src/app/api/admin/subscriptions/route.ts
+++ b/src/app/api/admin/subscriptions/route.ts
@@ -29,9 +29,7 @@ export async function GET(request: NextRequest) {
 
     const subs = await stripe.subscriptions.list({
       status:
-        status === "all"
-          ? undefined
-          : (status as "active" | "past_due" | "canceled" | "trialing"),
+        status === "all" ? undefined : (status as "active" | "past_due" | "canceled" | "trialing"),
       limit,
       expand: ["data.customer", "data.items.data.price.product"],
     });
@@ -48,10 +46,7 @@ export async function GET(request: NextRequest) {
 
       return {
         id: sub.id,
-        customerId:
-          typeof sub.customer === "string"
-            ? sub.customer
-            : (customer?.id ?? ""),
+        customerId: typeof sub.customer === "string" ? sub.customer : (customer?.id ?? ""),
         customerEmail: customer?.email ?? null,
         customerName: customer?.name ?? null,
         status: sub.status,
@@ -59,8 +54,7 @@ export async function GET(request: NextRequest) {
         amount: price?.unit_amount ?? 0,
         currency: (price?.currency ?? "eur").toUpperCase(),
         interval: price?.recurring?.interval ?? "month",
-        currentPeriodEnd:
-          (sub as unknown as Record<string, number>).current_period_end ?? 0,
+        currentPeriodEnd: (sub as unknown as Record<string, number>).current_period_end ?? 0,
         cancelAtPeriodEnd: sub.cancel_at_period_end,
         created: sub.created as number,
       };
@@ -76,7 +70,7 @@ export async function GET(request: NextRequest) {
       {
         error: e instanceof Error ? e.message : "Failed to fetch subscriptions",
       },
-      { status: 500 },
+      { status: 500 }
     );
   }
 }
@@ -97,9 +91,7 @@ export async function POST(request: NextRequest) {
 
     if (action === "portal" && customerId) {
       const baseUrl =
-        process.env.NEXTAUTH_URL ??
-        process.env.NEXT_PUBLIC_APP_URL ??
-        "https://cloudless.gr";
+        process.env.NEXTAUTH_URL ?? process.env.NEXT_PUBLIC_APP_URL ?? "https://cloudless.gr";
       const session = await stripe.billingPortal.sessions.create({
         customer: customerId,
         return_url: `${baseUrl}/admin/subscriptions`,
@@ -121,7 +113,7 @@ export async function POST(request: NextRequest) {
   } catch (e) {
     return NextResponse.json(
       { error: e instanceof Error ? e.message : "Action failed" },
-      { status: 500 },
+      { status: 500 }
     );
   }
 }

--- a/src/app/api/admin/users/route.ts
+++ b/src/app/api/admin/users/route.ts
@@ -13,21 +13,14 @@ import {
 const REGION = process.env.AWS_REGION ?? "us-east-1";
 
 function getPoolId() {
-  return (
-    process.env.COGNITO_USER_POOL_ID ??
-    process.env.NEXT_PUBLIC_COGNITO_USER_POOL_ID ??
-    ""
-  );
+  return process.env.COGNITO_USER_POOL_ID ?? process.env.NEXT_PUBLIC_COGNITO_USER_POOL_ID ?? "";
 }
 
 function getClient() {
   return new CognitoIdentityProviderClient({ region: REGION });
 }
 
-function getAttr(
-  attrs: { Name?: string; Value?: string }[] | undefined,
-  name: string,
-): string {
+function getAttr(attrs: { Name?: string; Value?: string }[] | undefined, name: string): string {
   return attrs?.find((a) => a.Name === name)?.Value ?? "";
 }
 
@@ -38,10 +31,7 @@ export async function GET(request: NextRequest) {
   try {
     const poolId = getPoolId();
     if (!poolId) {
-      return NextResponse.json(
-        { error: "Cognito User Pool not configured" },
-        { status: 503 },
-      );
+      return NextResponse.json({ error: "Cognito User Pool not configured" }, { status: 503 });
     }
 
     const { searchParams } = new URL(request.url);
@@ -58,7 +48,7 @@ export async function GET(request: NextRequest) {
         UserPoolId: poolId,
         Limit: limit,
         ...(filter ? { Filter: `email ^= "${filter}"` } : {}),
-      }),
+      })
     );
 
     const users = await Promise.all(
@@ -69,10 +59,9 @@ export async function GET(request: NextRequest) {
             new AdminListGroupsForUserCommand({
               UserPoolId: poolId,
               Username: u.Username!,
-            }),
+            })
           );
-          isAdmin =
-            groupsRes.Groups?.some((g) => g.GroupName === "admin") ?? false;
+          isAdmin = groupsRes.Groups?.some((g) => g.GroupName === "admin") ?? false;
         } catch {
           // If group lookup fails, default to non-admin
         }
@@ -90,16 +79,13 @@ export async function GET(request: NextRequest) {
           created: u.UserCreateDate?.toISOString(),
           lastModified: u.UserLastModifiedDate?.toISOString(),
         };
-      }),
+      })
     );
 
     return NextResponse.json({ users, count: users.length });
   } catch (err) {
     console.error("Failed to list users:", err);
-    return NextResponse.json(
-      { error: "Failed to list users" },
-      { status: 500 },
-    );
+    return NextResponse.json({ error: "Failed to list users" }, { status: 500 });
   }
 }
 
@@ -110,19 +96,13 @@ export async function POST(request: NextRequest) {
   try {
     const poolId = getPoolId();
     if (!poolId) {
-      return NextResponse.json(
-        { error: "Cognito User Pool not configured" },
-        { status: 503 },
-      );
+      return NextResponse.json({ error: "Cognito User Pool not configured" }, { status: 503 });
     }
 
     const { action, username } = await request.json();
 
     if (!action || !username) {
-      return NextResponse.json(
-        { error: "action and username required" },
-        { status: 400 },
-      );
+      return NextResponse.json({ error: "action and username required" }, { status: 400 });
     }
 
     const client = getClient();
@@ -132,7 +112,7 @@ export async function POST(request: NextRequest) {
         new AdminDisableUserCommand({
           UserPoolId: poolId,
           Username: username,
-        }),
+        })
       );
       return NextResponse.json({ success: true, message: "User disabled" });
     }
@@ -142,7 +122,7 @@ export async function POST(request: NextRequest) {
         new AdminEnableUserCommand({
           UserPoolId: poolId,
           Username: username,
-        }),
+        })
       );
       return NextResponse.json({ success: true, message: "User enabled" });
     }
@@ -153,7 +133,7 @@ export async function POST(request: NextRequest) {
           UserPoolId: poolId,
           Username: username,
           GroupName: "admin",
-        }),
+        })
       );
       return NextResponse.json({
         success: true,
@@ -167,7 +147,7 @@ export async function POST(request: NextRequest) {
           UserPoolId: poolId,
           Username: username,
           GroupName: "admin",
-        }),
+        })
       );
       return NextResponse.json({
         success: true,
@@ -178,9 +158,6 @@ export async function POST(request: NextRequest) {
     return NextResponse.json({ error: "Unknown action" }, { status: 400 });
   } catch (err) {
     console.error("Failed to modify user:", err);
-    return NextResponse.json(
-      { error: "Failed to modify user" },
-      { status: 500 },
-    );
+    return NextResponse.json({ error: "Failed to modify user" }, { status: 500 });
   }
 }

--- a/src/app/api/admin/workspaces/route.ts
+++ b/src/app/api/admin/workspaces/route.ts
@@ -1,10 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { requireAdmin } from "@/lib/api-auth";
-import {
-  SSMClient,
-  GetParameterCommand,
-  PutParameterCommand,
-} from "@aws-sdk/client-ssm";
+import { SSMClient, GetParameterCommand, PutParameterCommand } from "@aws-sdk/client-ssm";
 import { randomUUID } from "node:crypto";
 
 const SSM_KEY = "/cloudless/WORKSPACES_JSON";
@@ -45,7 +41,7 @@ async function writeWorkspaces(workspaces: Workspace[]): Promise<void> {
       Value: JSON.stringify(workspaces),
       Type: "String",
       Overwrite: true,
-    }),
+    })
   );
   cachedWorkspaces = { data: workspaces, expiresAt: Date.now() + CACHE_TTL_MS };
 }
@@ -86,7 +82,7 @@ export async function POST(request: NextRequest) {
   if (workspaces.some((w) => w.slug === slug)) {
     return NextResponse.json(
       { error: "A workspace with this name already exists" },
-      { status: 409 },
+      { status: 409 }
     );
   }
 
@@ -95,9 +91,7 @@ export async function POST(request: NextRequest) {
     name: String(body.name).trim().slice(0, 100),
     slug,
     description: String(body.description ?? "").slice(0, 300),
-    adminEmails: Array.isArray(body.adminEmails)
-      ? body.adminEmails.map(String).slice(0, 20)
-      : [],
+    adminEmails: Array.isArray(body.adminEmails) ? body.adminEmails.map(String).slice(0, 20) : [],
     createdAt: new Date().toISOString(),
   };
 
@@ -118,13 +112,11 @@ export async function PATCH(request: NextRequest) {
     adminEmails?: string[];
   };
 
-  if (!body.id)
-    return NextResponse.json({ error: "id is required" }, { status: 400 });
+  if (!body.id) return NextResponse.json({ error: "id is required" }, { status: 400 });
 
   const workspaces = await readWorkspaces();
   const idx = workspaces.findIndex((w) => w.id === body.id);
-  if (idx === -1)
-    return NextResponse.json({ error: "Workspace not found" }, { status: 404 });
+  if (idx === -1) return NextResponse.json({ error: "Workspace not found" }, { status: 404 });
 
   if (body.name) {
     workspaces[idx].name = String(body.name).trim().slice(0, 100);
@@ -146,8 +138,7 @@ export async function DELETE(request: NextRequest) {
   if (!auth.ok) return auth.response;
 
   const { id } = (await request.json()) as { id?: string };
-  if (!id)
-    return NextResponse.json({ error: "id is required" }, { status: 400 });
+  if (!id) return NextResponse.json({ error: "id is required" }, { status: 400 });
 
   const workspaces = await readWorkspaces();
   const updated = workspaces.filter((w) => w.id !== id);

--- a/src/app/api/agent/book/route.ts
+++ b/src/app/api/agent/book/route.ts
@@ -45,20 +45,14 @@ interface ConfirmBody {
 
 function isProposeBody(b: unknown): b is ProposeBody {
   return (
-    typeof b === "object" &&
-    b !== null &&
-    typeof (b as { intent?: unknown }).intent === "string"
+    typeof b === "object" && b !== null && typeof (b as { intent?: unknown }).intent === "string"
   );
 }
 
 function isConfirmBody(b: unknown): b is ConfirmBody {
   if (typeof b !== "object" || b === null) return false;
   const o = b as { confirm?: unknown; start?: unknown; end?: unknown };
-  return (
-    o.confirm === true &&
-    typeof o.start === "string" &&
-    typeof o.end === "string"
-  );
+  return o.confirm === true && typeof o.start === "string" && typeof o.end === "string";
 }
 
 function jsonError(status: number, error: string) {
@@ -78,15 +72,8 @@ function resolveUserName(claim: string | undefined, email: string): string {
   return "Cloudless User";
 }
 
-async function handlePropose(
-  body: ProposeBody,
-  ip: string,
-): Promise<NextResponse> {
-  const rl = rateLimit(
-    `agent-book-propose:${ip}`,
-    PROPOSE_LIMIT_PER_WINDOW,
-    PROPOSE_WINDOW_MS,
-  );
+async function handlePropose(body: ProposeBody, ip: string): Promise<NextResponse> {
+  const rl = rateLimit(`agent-book-propose:${ip}`, PROPOSE_LIMIT_PER_WINDOW, PROPOSE_WINDOW_MS);
   if (!rl.ok) return rl.response as NextResponse;
 
   const intent = body.intent.trim().slice(0, MAX_INTENT_LENGTH);
@@ -109,13 +96,9 @@ async function handleConfirm(
   body: ConfirmBody,
   userEmail: string,
   userName: string,
-  ip: string,
+  ip: string
 ): Promise<NextResponse> {
-  const rl = rateLimit(
-    `agent-book-confirm:${ip}`,
-    CONFIRM_LIMIT_PER_WINDOW,
-    CONFIRM_WINDOW_MS,
-  );
+  const rl = rateLimit(`agent-book-confirm:${ip}`, CONFIRM_LIMIT_PER_WINDOW, CONFIRM_WINDOW_MS);
   if (!rl.ok) return rl.response as NextResponse;
 
   const startD = new Date(body.start);
@@ -133,20 +116,14 @@ async function handleConfirm(
   // Re-check availability — the propose step is advisory; another booking
   // could have taken the slot in between. getAvailableSlots only returns
   // currently-free slots, so a hit there is the source of truth.
-  const daysAhead = Math.max(
-    1,
-    Math.ceil((startD.getTime() - Date.now()) / 86_400_000) + 1,
-  );
+  const daysAhead = Math.max(1, Math.ceil((startD.getTime() - Date.now()) / 86_400_000) + 1);
   const free = await getAvailableSlots(Math.min(daysAhead, MAX_DAYS_AHEAD));
   const stillFree = free.some((s) => {
     const sStart = new Date(s.start).getTime();
     return Math.abs(sStart - startD.getTime()) <= SLOT_OVERLAP_TOLERANCE_MS;
   });
   if (!stillFree) {
-    return jsonError(
-      409,
-      "That slot is no longer available. Please propose a new time.",
-    );
+    return jsonError(409, "That slot is no longer available. Please propose a new time.");
   }
 
   const notes = normalizeNotes(body.notes);
@@ -169,18 +146,14 @@ async function handleConfirm(
       start: body.start,
       notes,
       meetLink: result.htmlLink,
-    }).catch((err) =>
-      console.warn("[agent-book] slackBookingNotify failed:", err),
-    );
+    }).catch((err) => console.warn("[agent-book] slackBookingNotify failed:", err));
     sendBookingConfirmation({
       name: userName,
       email: userEmail,
       slotLabel,
       meetLink: result.htmlLink,
       notes,
-    }).catch((err) =>
-      console.warn("[agent-book] sendBookingConfirmation failed:", err),
-    );
+    }).catch((err) => console.warn("[agent-book] sendBookingConfirmation failed:", err));
 
     return NextResponse.json({
       status: "confirmed",
@@ -202,10 +175,7 @@ export async function POST(request: NextRequest) {
 
   const userEmail = auth.user.email?.toLowerCase();
   if (!userEmail) {
-    return jsonError(
-      400,
-      "Authenticated token is missing an email claim — cannot book.",
-    );
+    return jsonError(400, "Authenticated token is missing an email claim — cannot book.");
   }
   const userName = resolveUserName(auth.user["cognito:username"], userEmail);
 
@@ -231,6 +201,6 @@ export async function POST(request: NextRequest) {
 
   return jsonError(
     400,
-    "Body must be either { intent } to propose or { confirm: true, start, end } to confirm.",
+    "Body must be either { intent } to propose or { confirm: true, start, end } to confirm."
   );
 }

--- a/src/app/api/blog/[slug]/route.ts
+++ b/src/app/api/blog/[slug]/route.ts
@@ -2,18 +2,14 @@ import { NextResponse } from "next/server";
 import { getPostBySlug } from "@/lib/notion-blog";
 import { isConfigured } from "@/lib/integrations";
 
-export async function GET(
-  _request: Request,
-  { params }: { params: Promise<{ slug: string }> },
-) {
+export async function GET(_request: Request, { params }: { params: Promise<{ slug: string }> }) {
   const { slug } = await params;
 
   if (!isConfigured("NOTION_API_KEY", "NOTION_BLOG_DB_ID")) {
     const blogModule = await import("@/lib/blog");
     const blogPosts = blogModule.posts;
     const post = blogPosts.find((p: { slug: string }) => p.slug === slug);
-    if (!post)
-      return NextResponse.json({ error: "Post not found" }, { status: 404 });
+    if (!post) return NextResponse.json({ error: "Post not found" }, { status: 404 });
     return NextResponse.json({ post, source: "static" });
   }
 
@@ -22,15 +18,13 @@ export async function GET(
     if (!post) {
       // Notion returned null — fall back to static
       const blogModule = await import("@/lib/blog");
-      const staticPost = (blogModule.posts as Array<{ slug: string }>).find(
-        (p) => p.slug === slug,
-      );
+      const staticPost = (blogModule.posts as Array<{ slug: string }>).find((p) => p.slug === slug);
       if (!staticPost) {
         return NextResponse.json({ error: "Post not found" }, { status: 404 });
       }
       return NextResponse.json(
         { post: staticPost, source: "static" },
-        { headers: { "x-blog-source": "static" } },
+        { headers: { "x-blog-source": "static" } }
       );
     }
     return NextResponse.json(
@@ -40,21 +34,19 @@ export async function GET(
           "Cache-Control": "public, s-maxage=60, stale-while-revalidate=30",
           "x-blog-source": "notion",
         },
-      },
+      }
     );
   } catch (err) {
     console.error("[Blog] Fetch post error:", err);
     // Notion threw — fall back to static
     const blogModule = await import("@/lib/blog");
-    const staticPost = (blogModule.posts as Array<{ slug: string }>).find(
-      (p) => p.slug === slug,
-    );
+    const staticPost = (blogModule.posts as Array<{ slug: string }>).find((p) => p.slug === slug);
     if (!staticPost) {
       return NextResponse.json({ error: "Post not found" }, { status: 404 });
     }
     return NextResponse.json(
       { post: staticPost, source: "static" },
-      { headers: { "x-blog-source": "static" } },
+      { headers: { "x-blog-source": "static" } }
     );
   }
 }

--- a/src/app/api/blog/posts/route.ts
+++ b/src/app/api/blog/posts/route.ts
@@ -9,7 +9,7 @@ export async function GET() {
     const blogPosts = blogModule.posts;
     return NextResponse.json(
       { posts: blogPosts, source: "static", fallbackReason: "not-configured" },
-      { headers: { "x-blog-source": "static" } },
+      { headers: { "x-blog-source": "static" } }
     );
   }
 
@@ -22,7 +22,7 @@ export async function GET() {
           "Cache-Control": "public, s-maxage=60, stale-while-revalidate=30",
           "x-blog-source": "notion",
         },
-      },
+      }
     );
   } catch (err) {
     console.error("[Blog] Fetch error:", err);
@@ -30,7 +30,7 @@ export async function GET() {
     const blogPosts = blogModule.posts;
     return NextResponse.json(
       { posts: blogPosts, source: "static", fallbackReason: "notion-error" },
-      { headers: { "x-blog-source": "static" } },
+      { headers: { "x-blog-source": "static" } }
     );
   }
 }

--- a/src/app/api/calendar/availability/route.ts
+++ b/src/app/api/calendar/availability/route.ts
@@ -4,20 +4,14 @@ import { isConfiguredAsync } from "@/lib/integrations";
 
 export async function GET(request: Request) {
   if (!(await isConfiguredAsync("GOOGLE_CLIENT_EMAIL", "GOOGLE_PRIVATE_KEY"))) {
-    return NextResponse.json(
-      { error: "Calendar booking is not yet available." },
-      { status: 503 },
-    );
+    return NextResponse.json({ error: "Calendar booking is not yet available." }, { status: 503 });
   }
 
   try {
     const { searchParams } = new URL(request.url);
     const DEFAULT_DAYS = 7;
     const MAX_DAYS = 30;
-    const days = Math.max(
-      1,
-      Math.min(Number(searchParams.get("days") || DEFAULT_DAYS), MAX_DAYS),
-    );
+    const days = Math.max(1, Math.min(Number(searchParams.get("days") || DEFAULT_DAYS), MAX_DAYS));
     const slots = await getAvailableSlots(days);
 
     return NextResponse.json(
@@ -26,13 +20,10 @@ export async function GET(request: Request) {
         headers: {
           "Cache-Control": "public, s-maxage=300, stale-while-revalidate=60", // NOSONAR — cache TTL values
         },
-      },
+      }
     );
   } catch (err) {
     console.error("[Calendar] Availability error:", err);
-    return NextResponse.json(
-      { error: "Failed to fetch availability." },
-      { status: 500 },
-    );
+    return NextResponse.json({ error: "Failed to fetch availability." }, { status: 500 });
   }
 }

--- a/src/app/api/calendar/book/route.ts
+++ b/src/app/api/calendar/book/route.ts
@@ -19,10 +19,7 @@ export async function POST(request: Request) {
   if (!rl.ok) return rl.response;
 
   if (!(await isConfiguredAsync("GOOGLE_CLIENT_EMAIL", "GOOGLE_PRIVATE_KEY"))) {
-    return NextResponse.json(
-      { error: "Calendar booking is not yet available." },
-      { status: 503 },
-    );
+    return NextResponse.json({ error: "Calendar booking is not yet available." }, { status: 503 });
   }
 
   try {
@@ -31,45 +28,30 @@ export async function POST(request: Request) {
     if (!name || !email || !start || !end) {
       return NextResponse.json(
         { error: "Name, email, start, and end are required." },
-        { status: 400 },
+        { status: 400 }
       );
     }
 
     if (!isValidEmail(email)) {
-      return NextResponse.json(
-        { error: "Invalid email address." },
-        { status: 400 },
-      );
+      return NextResponse.json({ error: "Invalid email address." }, { status: 400 });
     }
 
     const startDate = new Date(start);
     const endDate = new Date(end);
     if (isNaN(startDate.getTime()) || isNaN(endDate.getTime())) {
-      return NextResponse.json(
-        { error: "Invalid date format for start or end." },
-        { status: 400 },
-      );
+      return NextResponse.json({ error: "Invalid date format for start or end." }, { status: 400 });
     }
     if (startDate < new Date()) {
-      return NextResponse.json(
-        { error: "Cannot book a slot in the past." },
-        { status: 400 },
-      );
+      return NextResponse.json({ error: "Cannot book a slot in the past." }, { status: 400 });
     }
     if (endDate <= startDate) {
-      return NextResponse.json(
-        { error: "End time must be after start time." },
-        { status: 400 },
-      );
+      return NextResponse.json({ error: "End time must be after start time." }, { status: 400 });
     }
 
     const result = await bookConsultation({ name, email, start, end, notes });
 
     if (!result) {
-      return NextResponse.json(
-        { error: "Failed to create booking." },
-        { status: 500 },
-      );
+      return NextResponse.json({ error: "Failed to create booking." }, { status: 500 });
     }
 
     slackBookingNotify({ name, email, start, notes }).catch(() => {});
@@ -123,7 +105,7 @@ export async function POST(request: Request) {
           withScope((scope) => {
             scope.setTag("route", "calendar.book");
             captureException(err);
-          }),
+          })
         )
         .catch(() => {});
     }

--- a/src/app/api/case-studies/[slug]/route.ts
+++ b/src/app/api/case-studies/[slug]/route.ts
@@ -1,27 +1,18 @@
 import { NextResponse } from "next/server";
 import { isConfiguredAsync } from "@/lib/integrations";
-import {
-  getCaseStudyBySlug,
-  staticCaseStudies,
-} from "@/lib/notion-case-studies";
+import { getCaseStudyBySlug, staticCaseStudies } from "@/lib/notion-case-studies";
 
-export async function GET(
-  _request: Request,
-  { params }: { params: Promise<{ slug: string }> },
-) {
+export async function GET(_request: Request, { params }: { params: Promise<{ slug: string }> }) {
   const { slug } = await params;
 
-  const configured = await isConfiguredAsync(
-    "NOTION_API_KEY",
-    "NOTION_CASE_STUDIES_DB_ID",
-  );
+  const configured = await isConfiguredAsync("NOTION_API_KEY", "NOTION_CASE_STUDIES_DB_ID");
 
   if (!configured) {
     const cs = staticCaseStudies.find((c) => c.slug === slug);
     if (!cs) return NextResponse.json({ error: "Not found" }, { status: 404 });
     return NextResponse.json(
       { caseStudy: { ...cs, html: "" }, source: "static" },
-      { headers: { "x-cms-source": "static" } },
+      { headers: { "x-cms-source": "static" } }
     );
   }
 
@@ -37,13 +28,10 @@ export async function GET(
           "Cache-Control": "public, s-maxage=300, stale-while-revalidate=60",
           "x-cms-source": "notion",
         },
-      },
+      }
     );
   } catch (err) {
     console.error(`[API /case-studies/${slug}] Fetch error:`, err);
-    return NextResponse.json(
-      { error: "Failed to load case study" },
-      { status: 502 },
-    );
+    return NextResponse.json({ error: "Failed to load case study" }, { status: 502 });
   }
 }

--- a/src/app/api/case-studies/route.ts
+++ b/src/app/api/case-studies/route.ts
@@ -10,25 +10,18 @@ export async function GET(request: Request) {
   const { searchParams } = new URL(request.url);
   const featured = searchParams.get("featured") === "true";
 
-  const configured = await isConfiguredAsync(
-    "NOTION_API_KEY",
-    "NOTION_CASE_STUDIES_DB_ID",
-  );
+  const configured = await isConfiguredAsync("NOTION_API_KEY", "NOTION_CASE_STUDIES_DB_ID");
 
   if (!configured) {
-    const data = featured
-      ? staticCaseStudies.filter((c) => c.featured)
-      : staticCaseStudies;
+    const data = featured ? staticCaseStudies.filter((c) => c.featured) : staticCaseStudies;
     return NextResponse.json(
       { caseStudies: data, source: "static", fallbackReason: "not-configured" },
-      { headers: { "x-cms-source": "static" } },
+      { headers: { "x-cms-source": "static" } }
     );
   }
 
   try {
-    const caseStudies = featured
-      ? await getFeaturedCaseStudies()
-      : await getCaseStudies();
+    const caseStudies = featured ? await getFeaturedCaseStudies() : await getCaseStudies();
     return NextResponse.json(
       { caseStudies, source: "notion" },
       {
@@ -36,16 +29,14 @@ export async function GET(request: Request) {
           "Cache-Control": "public, s-maxage=120, stale-while-revalidate=60",
           "x-cms-source": "notion",
         },
-      },
+      }
     );
   } catch (err) {
     console.error("[API /case-studies] Fetch error:", err);
-    const data = featured
-      ? staticCaseStudies.filter((c) => c.featured)
-      : staticCaseStudies;
+    const data = featured ? staticCaseStudies.filter((c) => c.featured) : staticCaseStudies;
     return NextResponse.json(
       { caseStudies: data, source: "static", fallbackReason: "notion-error" },
-      { headers: { "x-cms-source": "static" } },
+      { headers: { "x-cms-source": "static" } }
     );
   }
 }

--- a/src/app/api/chat/route.ts
+++ b/src/app/api/chat/route.ts
@@ -47,9 +47,7 @@ interface RawMessage {
   content: string;
 }
 
-function parseMessages(
-  body: unknown,
-): { role: "user" | "assistant"; content: string }[] {
+function parseMessages(body: unknown): { role: "user" | "assistant"; content: string }[] {
   if (
     typeof body !== "object" ||
     body === null ||
@@ -66,7 +64,7 @@ function parseMessages(
         m !== null &&
         "role" in m &&
         "content" in m &&
-        typeof (m as RawMessage).content === "string",
+        typeof (m as RawMessage).content === "string"
     )
     .slice(-MAX_TURNS)
     .map((m): { role: "user" | "assistant"; content: string } => ({
@@ -97,9 +95,7 @@ function sseStreamFromText(text: string): ReadableStream<Uint8Array> {
   return new ReadableStream({
     start(controller) {
       for (const piece of chunkText(safe)) {
-        controller.enqueue(
-          encoder.encode(`data: ${JSON.stringify({ text: piece })}\n\n`),
-        );
+        controller.enqueue(encoder.encode(`data: ${JSON.stringify({ text: piece })}\n\n`));
       }
       controller.enqueue(encoder.encode("data: [DONE]\n\n"));
       controller.close();
@@ -131,7 +127,7 @@ export async function POST(request: NextRequest) {
     if (name === "AccessDeniedException" || name === "UnauthorizedException") {
       return Response.json(
         { error: "Chat not available right now. Please use the Contact page." },
-        { status: 503 },
+        { status: 503 }
       );
     }
     return Response.json({ error: "AI service unavailable." }, { status: 502 });

--- a/src/app/api/contact/route.ts
+++ b/src/app/api/contact/route.ts
@@ -36,17 +36,11 @@ export async function POST(request: Request) {
     const { name, email, company, service, message } = parsed;
 
     if (!name || !email || !message) {
-      return Response.json(
-        { error: "Name, email, and message are required." },
-        { status: 400 },
-      );
+      return Response.json({ error: "Name, email, and message are required." }, { status: 400 });
     }
 
     if (!isValidEmail(email)) {
-      return Response.json(
-        { error: "Invalid email address." },
-        { status: 400 },
-      );
+      return Response.json({ error: "Invalid email address." }, { status: 400 });
     }
 
     const config = await getConfig();
@@ -89,13 +83,11 @@ export async function POST(request: Request) {
       "AI & Digital Marketing": "digital-marketing",
       "Full-Stack Growth Engine (Bundle)": "full-bundle",
     };
-    const serviceSlug = service
-      ? (SERVICE_SLUG[service] ?? undefined)
-      : undefined;
+    const serviceSlug = service ? (SERVICE_SLUG[service] ?? undefined) : undefined;
 
     // Auto-reply to the visitor — fire-and-forget, never blocks response
     sendContactAcknowledgment({ name, email, service }).catch((err) =>
-      console.warn("[contact] Auto-reply failed:", err),
+      console.warn("[contact] Auto-reply failed:", err)
     );
 
     const nameParts = String(name).trim().split(" ");
@@ -142,10 +134,7 @@ export async function POST(request: Request) {
         const labels = ["slack", "hubspot", "notion"];
         results.forEach((r, i) => {
           if (r.status === "rejected") {
-            console.error(
-              "[Contact] Background task " + labels[i] + " failed:",
-              r.reason,
-            );
+            console.error("[Contact] Background task " + labels[i] + " failed:", r.reason);
           }
         });
       })
@@ -191,7 +180,7 @@ export async function POST(request: Request) {
           withScope((scope) => {
             scope.setTag("route", "contact");
             captureException(error);
-          }),
+          })
         )
         .catch(() => {});
     }

--- a/src/app/api/crm/contact/route.ts
+++ b/src/app/api/crm/contact/route.ts
@@ -15,21 +15,11 @@ export async function POST(request: Request) {
   }
 
   try {
-    const {
-      email,
-      firstname,
-      lastname,
-      company,
-      service_interest,
-      message,
-      lead_source,
-    } = await request.json();
+    const { email, firstname, lastname, company, service_interest, message, lead_source } =
+      await request.json();
 
     if (!email || !isValidEmail(email)) {
-      return NextResponse.json(
-        { error: "Valid email is required." },
-        { status: 400 },
-      );
+      return NextResponse.json({ error: "Valid email is required." }, { status: 400 });
     }
 
     // Sanitize and length-cap all string fields before sending to HubSpot
@@ -54,10 +44,7 @@ export async function POST(request: Request) {
     });
 
     if (!contactId) {
-      return NextResponse.json(
-        { error: "Failed to create contact." },
-        { status: 500 },
-      );
+      return NextResponse.json({ error: "Failed to create contact." }, { status: 500 });
     }
 
     return NextResponse.json({ success: true, contactId });
@@ -65,9 +52,6 @@ export async function POST(request: Request) {
     const _r = mapIntegrationError(err);
     if (_r) return _r;
     console.error("[CRM] Error:", err);
-    return NextResponse.json(
-      { error: "CRM operation failed." },
-      { status: 500 },
-    );
+    return NextResponse.json({ error: "CRM operation failed." }, { status: 500 });
   }
 }

--- a/src/app/api/cron/analytics-rollup/route.ts
+++ b/src/app/api/cron/analytics-rollup/route.ts
@@ -1,9 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
-import {
-  createWeeklyRollup,
-  archiveOldEvents,
-  flushEventQueue,
-} from "@/lib/notion-analytics";
+import { createWeeklyRollup, archiveOldEvents, flushEventQueue } from "@/lib/notion-analytics";
 import { SlackClient } from "@/lib/slack-notify";
 import { isCronAuthorized, cronUnauthorized } from "@/lib/cron-auth";
 
@@ -15,10 +11,7 @@ export async function GET(request: NextRequest) {
   // Flush any queued events before creating the rollup so counts are accurate
   await flushEventQueue();
 
-  const [rollupId, archiveResult] = await Promise.all([
-    createWeeklyRollup(),
-    archiveOldEvents(30),
-  ]);
+  const [rollupId, archiveResult] = await Promise.all([createWeeklyRollup(), archiveOldEvents(30)]);
 
   const lines = [
     `*Rollup:* ${rollupId ? "created" : "skipped (Notion not configured)"}`,

--- a/src/app/api/cron/report-cleanup/route.ts
+++ b/src/app/api/cron/report-cleanup/route.ts
@@ -14,14 +14,10 @@ export async function GET(request: NextRequest) {
   const now = Date.now();
 
   const stale = reports.filter(
-    (r) =>
-      r.status === "generating" &&
-      now - new Date(r.createdAt).getTime() > STALE_THRESHOLD_MS,
+    (r) => r.status === "generating" && now - new Date(r.createdAt).getTime() > STALE_THRESHOLD_MS
   );
 
-  const results = await Promise.all(
-    stale.map((r) => updateReport(r.id, { status: "error" })),
-  );
+  const results = await Promise.all(stale.map((r) => updateReport(r.id, { status: "error" })));
   const cleaned = results.filter(Boolean).length;
 
   if (cleaned > 0) {

--- a/src/app/api/cron/slack-digest/route.ts
+++ b/src/app/api/cron/slack-digest/route.ts
@@ -75,10 +75,7 @@ async function postOrderDigest(): Promise<void> {
     return o.paymentStatus === "paid" && created >= yesterdayStart;
   });
 
-  const totalAmount = yesterdaysOrders.reduce(
-    (sum, o) => sum + (o.amount ?? 0),
-    0,
-  );
+  const totalAmount = yesterdaysOrders.reduce((sum, o) => sum + (o.amount ?? 0), 0);
 
   // Use the currency of the first order, or EUR as default
   const currency = yesterdaysOrders[0]?.currency ?? "eur";
@@ -126,7 +123,7 @@ async function postOrderDigest(): Promise<void> {
 
   if (yesterdaysOrders.length > 5) {
     orderLines.push(
-      `_…and ${yesterdaysOrders.length - 5} more order${yesterdaysOrders.length - 5 === 1 ? "" : "s"}_`,
+      `_…and ${yesterdaysOrders.length - 5} more order${yesterdaysOrders.length - 5 === 1 ? "" : "s"}_`
     );
   }
 
@@ -226,10 +223,7 @@ async function postErrorDigest(): Promise<void> {
   }
 
   // Fetch live error counts and top issues concurrently.
-  const [counts, topErrors] = await Promise.all([
-    getErrorCounts(),
-    getTopErrors(3),
-  ]);
+  const [counts, topErrors] = await Promise.all([getErrorCounts(), getTopErrors(3)]);
 
   // Sentry unreachable / token invalid — still post so the channel gets a
   // daily message and operators know something is wrong.
@@ -273,10 +267,8 @@ async function postErrorDigest(): Promise<void> {
   // Build summary line.
   const parts: string[] = [];
   if (counts.fatal > 0) parts.push(`${counts.fatal} fatal`);
-  if (counts.error > 0)
-    parts.push(`${counts.error} error${counts.error === 1 ? "" : "s"}`);
-  if (counts.warning > 0)
-    parts.push(`${counts.warning} warning${counts.warning === 1 ? "" : "s"}`);
+  if (counts.error > 0) parts.push(`${counts.error} error${counts.error === 1 ? "" : "s"}`);
+  if (counts.warning > 0) parts.push(`${counts.warning} warning${counts.warning === 1 ? "" : "s"}`);
   const summaryLine = parts.join(", ");
 
   // Build top-issues list (up to 3).
@@ -367,8 +359,5 @@ async function postErrorDigest(): Promise<void> {
 // ---------------------------------------------------------------------------
 
 function slackEscape(text: string): string {
-  return text
-    .replaceAll("&", "&amp;")
-    .replaceAll("<", "&lt;")
-    .replaceAll(">", "&gt;");
+  return text.replaceAll("&", "&amp;").replaceAll("<", "&lt;").replaceAll(">", "&gt;");
 }

--- a/src/app/api/csp-report/route.ts
+++ b/src/app/api/csp-report/route.ts
@@ -61,7 +61,7 @@ function logViolation(
   blocked: string | undefined,
   source: string | undefined,
   doc: string | undefined,
-  disposition: string | undefined,
+  disposition: string | undefined
 ): void {
   // Single-line structured log so Sentry/CloudWatch can group cleanly.
   // Fields are sanitized to prevent log injection from browser-supplied values.
@@ -69,7 +69,7 @@ function logViolation(
   // codeql[js/tainted-format-string] -- fields sanitized; template literal used for structured output only
   console.warn(
     `[csp-violation] dir=${sanitizeLogField(directive)} blocked=${sanitizeLogField(blocked)} ` +
-      `source=${sanitizeLogField(source)} doc=${sanitizeLogField(doc)} disp=${sanitizeLogField(disposition)}`,
+      `source=${sanitizeLogField(source)} doc=${sanitizeLogField(doc)} disp=${sanitizeLogField(disposition)}`
   );
 }
 
@@ -87,19 +87,9 @@ export async function POST(request: NextRequest): Promise<Response> {
     for (const entry of payload as CspReportModernEntry[]) {
       if (entry?.type !== "csp-violation") continue;
       const b = entry.body ?? {};
-      logViolation(
-        b.effectiveDirective,
-        b.blockedURL,
-        b.sourceFile,
-        b.documentURL,
-        b.disposition,
-      );
+      logViolation(b.effectiveDirective, b.blockedURL, b.sourceFile, b.documentURL, b.disposition);
     }
-  } else if (
-    payload &&
-    typeof payload === "object" &&
-    "csp-report" in payload
-  ) {
+  } else if (payload && typeof payload === "object" && "csp-report" in payload) {
     // Legacy report-uri payload
     const r = (payload as CspReportLegacy)["csp-report"] ?? {};
     logViolation(
@@ -107,7 +97,7 @@ export async function POST(request: NextRequest): Promise<Response> {
       r["blocked-uri"],
       r["source-file"],
       r["document-uri"],
-      r.disposition,
+      r.disposition
     );
   }
 

--- a/src/app/api/docs/[slug]/route.ts
+++ b/src/app/api/docs/[slug]/route.ts
@@ -9,7 +9,7 @@ import { isConfigured } from "@/lib/integrations";
  */
 export async function GET(
   _request: NextRequest,
-  { params }: { params: Promise<{ slug: string }> },
+  { params }: { params: Promise<{ slug: string }> }
 ) {
   if (!isConfigured("NOTION_API_KEY", "NOTION_DOCS_DB_ID")) {
     return NextResponse.json({ error: "Docs not configured" }, { status: 503 });
@@ -25,10 +25,7 @@ export async function GET(
 
     const content = await getDocContent(doc.id);
     if (!content) {
-      return NextResponse.json(
-        { error: "Failed to load doc content" },
-        { status: 500 },
-      );
+      return NextResponse.json({ error: "Failed to load doc content" }, { status: 500 });
     }
 
     return NextResponse.json(content);

--- a/src/app/api/docs/route.ts
+++ b/src/app/api/docs/route.ts
@@ -19,9 +19,6 @@ export async function GET() {
     return NextResponse.json({ docs, grouped });
   } catch (err) {
     console.error("[Docs API] Failed to fetch docs:", err);
-    return NextResponse.json(
-      { error: "Failed to fetch docs" },
-      { status: 500 },
-    );
+    return NextResponse.json({ error: "Failed to fetch docs" }, { status: 500 });
   }
 }

--- a/src/app/api/faqs/route.ts
+++ b/src/app/api/faqs/route.ts
@@ -7,30 +7,22 @@ export async function GET(request: Request) {
   const locale = searchParams.get("locale") ?? undefined;
   const category = searchParams.get("category") ?? undefined;
 
-  const configured = await isConfiguredAsync(
-    "NOTION_API_KEY",
-    "NOTION_FAQS_DB_ID",
-  );
+  const configured = await isConfiguredAsync("NOTION_API_KEY", "NOTION_FAQS_DB_ID");
 
   if (!configured) {
     let data = locale
-      ? staticFaqs.filter(
-          (f) => f.locales.length === 0 || f.locales.includes(locale),
-        )
+      ? staticFaqs.filter((f) => f.locales.length === 0 || f.locales.includes(locale))
       : staticFaqs;
     if (category) data = data.filter((f) => f.category === category);
     return NextResponse.json(
       { faqs: data, source: "static", fallbackReason: "not-configured" },
-      { headers: { "x-cms-source": "static" } },
+      { headers: { "x-cms-source": "static" } }
     );
   }
 
   try {
     const faqs = category
-      ? await getFaqsByCategory(
-          category as Parameters<typeof getFaqsByCategory>[0],
-          locale,
-        )
+      ? await getFaqsByCategory(category as Parameters<typeof getFaqsByCategory>[0], locale)
       : await getFaqs(locale);
     return NextResponse.json(
       { faqs, source: "notion" },
@@ -39,13 +31,13 @@ export async function GET(request: Request) {
           "Cache-Control": "public, s-maxage=120, stale-while-revalidate=60",
           "x-cms-source": "notion",
         },
-      },
+      }
     );
   } catch (err) {
     console.error("[API /faqs] Fetch error:", err);
     return NextResponse.json(
       { faqs: staticFaqs, source: "static", fallbackReason: "notion-error" },
-      { headers: { "x-cms-source": "static" } },
+      { headers: { "x-cms-source": "static" } }
     );
   }
 }

--- a/src/app/api/hubspot/ticket/route.ts
+++ b/src/app/api/hubspot/ticket/route.ts
@@ -1,9 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
-import {
-  isHubSpotConfigured,
-  createTicket,
-  searchContacts,
-} from "@/lib/hubspot";
+import { isHubSpotConfigured, createTicket, searchContacts } from "@/lib/hubspot";
 import { isValidEmail } from "@/lib/validation";
 import { mapIntegrationError } from "@/lib/api-errors";
 
@@ -15,10 +11,8 @@ function parseTicketBody(body: Record<string, unknown>): {
   email: string | undefined;
   normalizedPriority: string;
 } | null {
-  const subject =
-    typeof body.subject === "string" ? body.subject.trim().slice(0, 200) : "";
-  const content =
-    typeof body.content === "string" ? body.content.trim().slice(0, 2000) : "";
+  const subject = typeof body.subject === "string" ? body.subject.trim().slice(0, 200) : "";
+  const content = typeof body.content === "string" ? body.content.trim().slice(0, 2000) : "";
   if (!subject || !content) return null;
   const email = typeof body.email === "string" ? body.email : undefined;
   const rawPriority = typeof body.priority === "string" ? body.priority : "";
@@ -29,7 +23,7 @@ function parseTicketBody(body: Record<string, unknown>): {
 }
 
 async function resolveContactId(
-  email: string,
+  email: string
 ): Promise<{ contactId: string | undefined; integrationError: NextResponse | null }> {
   try {
     const result = await searchContacts("email", email);
@@ -51,7 +45,7 @@ export async function POST(request: NextRequest) {
   if (!(await isHubSpotConfigured())) {
     return NextResponse.json(
       { error: "HubSpot ticket creation is not configured." },
-      { status: 503 },
+      { status: 503 }
     );
   }
 
@@ -62,17 +56,14 @@ export async function POST(request: NextRequest) {
     if (!parsed) {
       return NextResponse.json(
         { error: "Missing required fields: subject, content" },
-        { status: 400 },
+        { status: 400 }
       );
     }
 
     const { subject, content, email, normalizedPriority } = parsed;
 
     if (email && !isValidEmail(email)) {
-      return NextResponse.json(
-        { error: "Invalid email address." },
-        { status: 400 },
-      );
+      return NextResponse.json({ error: "Invalid email address." }, { status: 400 });
     }
 
     // Find contact by email if provided
@@ -85,13 +76,13 @@ export async function POST(request: NextRequest) {
 
     const ticket = await createTicket(
       { subject, content, hs_ticket_priority: normalizedPriority },
-      contactId,
+      contactId
     );
 
     if (!ticket) {
       return NextResponse.json(
         { error: "HubSpot ticket creation is not configured." },
-        { status: 503 },
+        { status: 503 }
       );
     }
 
@@ -104,9 +95,6 @@ export async function POST(request: NextRequest) {
     const _r = mapIntegrationError(error);
     if (_r) return _r;
     console.error("[HubSpot] Ticket error:", error);
-    return NextResponse.json(
-      { error: "Failed to create ticket." },
-      { status: 500 },
-    );
+    return NextResponse.json({ error: "Failed to create ticket." }, { status: 500 });
   }
 }

--- a/src/app/api/newsletter/send/route.ts
+++ b/src/app/api/newsletter/send/route.ts
@@ -30,7 +30,7 @@ function parsePayload(body: unknown): SendPayload | null {
 
 async function broadcast(
   recipients: string[],
-  payload: SendPayload,
+  payload: SendPayload
 ): Promise<{ sent: number; failed: number }> {
   let sent = 0;
   let failed = 0;
@@ -65,10 +65,7 @@ export async function POST(request: Request): Promise<Response> {
   const config = await getConfig();
   const secret = config.NEWSLETTER_SEND_SECRET;
   if (!secret) {
-    return Response.json(
-      { error: "Newsletter sending is not configured." },
-      { status: 503 },
-    );
+    return Response.json({ error: "Newsletter sending is not configured." }, { status: 503 });
   }
   if (request.headers.get("x-newsletter-secret") !== secret) {
     return Response.json({ error: "Unauthorized." }, { status: 401 });
@@ -83,10 +80,7 @@ export async function POST(request: Request): Promise<Response> {
 
   const payload = parsePayload(rawBody);
   if (!payload) {
-    return Response.json(
-      { error: "subject, html and text are required." },
-      { status: 400 },
-    );
+    return Response.json({ error: "subject, html and text are required." }, { status: 400 });
   }
 
   const recipients = await listNewsletterSubscribers();

--- a/src/app/api/notion-image/route.ts
+++ b/src/app/api/notion-image/route.ts
@@ -7,8 +7,7 @@ const CACHE_MAX_AGE_SECS = 3_300; // 55 min — Notion signed URLs last ~1 h
 const CACHE_SWR_SECS = 600; // stale-while-revalidate
 
 /** Notion UUIDs: 32 hex digits, optionally hyphenated (8-4-4-4-12). */
-const NOTION_ID_RE =
-  /^[0-9a-f]{8}-?[0-9a-f]{4}-?[0-9a-f]{4}-?[0-9a-f]{4}-?[0-9a-f]{12}$/i;
+const NOTION_ID_RE = /^[0-9a-f]{8}-?[0-9a-f]{4}-?[0-9a-f]{4}-?[0-9a-f]{4}-?[0-9a-f]{12}$/i;
 const ALLOWED_TYPES = new Set(["block", "cover"]);
 
 /**
@@ -43,10 +42,8 @@ export async function GET(request: NextRequest): Promise<Response> {
   const type = searchParams.get("type") ?? "block";
 
   if (!id) return new Response("Missing id", { status: 400 });
-  if (!NOTION_ID_RE.test(id))
-    return new Response("Invalid id", { status: 400 });
-  if (!ALLOWED_TYPES.has(type))
-    return new Response("Invalid type", { status: 400 });
+  if (!NOTION_ID_RE.test(id)) return new Response("Invalid id", { status: 400 });
+  if (!ALLOWED_TYPES.has(type)) return new Response("Invalid type", { status: 400 });
 
   try {
     let rawUrl: string | undefined;
@@ -56,9 +53,7 @@ export async function GET(request: NextRequest): Promise<Response> {
       rawUrl = page.cover?.type === "file" ? page.cover.file?.url : undefined;
     } else {
       const block = await notionFetch<NotionBlock>(`/blocks/${id}`);
-      const blockData = block[block.type] as
-        | { file?: { url: string } }
-        | undefined;
+      const blockData = block[block.type] as { file?: { url: string } } | undefined;
       rawUrl = blockData?.file?.url;
     }
 

--- a/src/app/api/services/route.ts
+++ b/src/app/api/services/route.ts
@@ -6,26 +6,19 @@ export async function GET(request: Request) {
   const { searchParams } = new URL(request.url);
   const category = searchParams.get("category");
 
-  const configured = await isConfiguredAsync(
-    "NOTION_API_KEY",
-    "NOTION_SERVICES_DB_ID",
-  );
+  const configured = await isConfiguredAsync("NOTION_API_KEY", "NOTION_SERVICES_DB_ID");
 
   if (!configured) {
-    const data = category
-      ? staticServices.filter((s) => s.category === category)
-      : staticServices;
+    const data = category ? staticServices.filter((s) => s.category === category) : staticServices;
     return NextResponse.json(
       { services: data, source: "static", fallbackReason: "not-configured" },
-      { headers: { "x-cms-source": "static" } },
+      { headers: { "x-cms-source": "static" } }
     );
   }
 
   try {
     const all = await getServices();
-    const services = category
-      ? all.filter((s) => s.category === category)
-      : all;
+    const services = category ? all.filter((s) => s.category === category) : all;
     return NextResponse.json(
       { services, source: "notion" },
       {
@@ -33,16 +26,14 @@ export async function GET(request: Request) {
           "Cache-Control": "public, s-maxage=120, stale-while-revalidate=60",
           "x-cms-source": "notion",
         },
-      },
+      }
     );
   } catch (err) {
     console.error("[API /services] Fetch error:", err);
-    const data = category
-      ? staticServices.filter((s) => s.category === category)
-      : staticServices;
+    const data = category ? staticServices.filter((s) => s.category === category) : staticServices;
     return NextResponse.json(
       { services: data, source: "static", fallbackReason: "notion-error" },
-      { headers: { "x-cms-source": "static" } },
+      { headers: { "x-cms-source": "static" } }
     );
   }
 }

--- a/src/app/api/slack/commands/route.ts
+++ b/src/app/api/slack/commands/route.ts
@@ -166,9 +166,7 @@ async function handleOrders(payload: SlashCommandPayload): Promise<Response> {
           },
           {
             type: "context",
-            elements: [
-              { type: "mrkdwn", text: `Requested by <@${payload.user_id}>` },
-            ],
+            elements: [{ type: "mrkdwn", text: `Requested by <@${payload.user_id}>` }],
           },
         ],
       });
@@ -275,24 +273,13 @@ async function handleChannels(payload: SlashCommandPayload): Promise<Response> {
       });
     }
 
-    const [channels, bot] = await Promise.all([
-      listChannels(token),
-      getBotInfo(token),
-    ]);
+    const [channels, bot] = await Promise.all([listChannels(token), getBotInfo(token)]);
 
-    const MANAGED = [
-      "bookings",
-      "orders",
-      "errors",
-      "deployments",
-      "contacts",
-      "subscribers",
-    ];
+    const MANAGED = ["bookings", "orders", "errors", "deployments", "contacts", "subscribers"];
 
     const rows = MANAGED.map((name) => {
       const ch = channels.find((c) => c.name === name);
-      if (!ch)
-        return `❌ \`#${name}\` — *missing* (run \`/slack-channels-setup\`)`;
+      if (!ch) return `❌ \`#${name}\` — *missing* (run \`/slack-channels-setup\`)`;
       const member = ch.is_member ? "✅ member" : "⚠️ not a member";
       return `• <#${ch.id}> — ${member}`;
     });
@@ -412,16 +399,12 @@ async function handleTicket(payload: SlashCommandPayload): Promise<Response> {
       },
     }),
     signal: AbortSignal.timeout(5_000),
-  }).catch((err) =>
-    console.error("[Slack Commands] views.open (ticket) error:", err),
-  );
+  }).catch((err) => console.error("[Slack Commands] views.open (ticket) error:", err));
 
   return new Response(null, { status: 200 });
 }
 
-async function handleAnalytics(
-  payload: SlashCommandPayload,
-): Promise<Response> {
+async function handleAnalytics(payload: SlashCommandPayload): Promise<Response> {
   try {
     const { orders, hasMore } = await listRecentCheckoutSessions(10);
 
@@ -447,9 +430,7 @@ async function handleAnalytics(
           },
           {
             type: "context",
-            elements: [
-              { type: "mrkdwn", text: `Requested by <@${payload.user_id}>` },
-            ],
+            elements: [{ type: "mrkdwn", text: `Requested by <@${payload.user_id}>` }],
           },
         ],
       });
@@ -564,9 +545,7 @@ async function handleDeploy(payload: SlashCommandPayload): Promise<Response> {
       },
     }),
     signal: AbortSignal.timeout(5_000),
-  }).catch((err) =>
-    console.error("[Slack Commands] views.open (deploy) error:", err),
-  );
+  }).catch((err) => console.error("[Slack Commands] views.open (deploy) error:", err));
 
   return new Response(null, { status: 200 });
 }

--- a/src/app/api/slack/events/route.ts
+++ b/src/app/api/slack/events/route.ts
@@ -185,8 +185,7 @@ async function handleAppMention(event: SlackEvent): Promise<void> {
 
   let text: string;
   if (userText.includes("status")) {
-    text =
-      ":white_check_mark: cloudless.gr is *online*. All systems operational.";
+    text = ":white_check_mark: cloudless.gr is *online*. All systems operational.";
   } else if (userText.includes("help")) {
     text = HELP_TEXT;
   } else {
@@ -393,7 +392,7 @@ async function handleMemberJoinedChannel(event: SlackEvent): Promise<void> {
       {
         headers: { Authorization: `Bearer ${token}` },
         signal: AbortSignal.timeout(5_000),
-      },
+      }
     );
     const infoData = (await infoRes.json()) as {
       ok: boolean;

--- a/src/app/api/slack/interactions/route.ts
+++ b/src/app/api/slack/interactions/route.ts
@@ -85,9 +85,7 @@ export async function POST(request: Request): Promise<Response> {
       return handleViewSubmission(payload);
 
     default:
-      console.warn(
-        `[Slack Interactions] Unhandled interaction type: ${payload.type}`,
-      );
+      console.warn(`[Slack Interactions] Unhandled interaction type: ${payload.type}`);
       return new Response(null, { status: 200 });
   }
 }
@@ -96,9 +94,7 @@ export async function POST(request: Request): Promise<Response> {
 // Interaction handlers
 // ---------------------------------------------------------------------------
 
-async function handleBlockActions(
-  payload: SlackInteractionPayload,
-): Promise<Response> {
+async function handleBlockActions(payload: SlackInteractionPayload): Promise<Response> {
   const actions = payload.actions ?? [];
 
   for (const action of actions) {
@@ -113,16 +109,14 @@ async function handleBlockActions(
         // Post updated order data to the response_url
         if (payload.response_url) {
           refreshOrdersAsync(payload.response_url).catch((err) =>
-            console.error("[Slack Interactions] refresh_orders failed:", err),
+            console.error("[Slack Interactions] refresh_orders failed:", err)
           );
         }
         break;
       }
 
       default:
-        console.warn(
-          `[Slack Interactions] Unhandled action_id: ${action.action_id}`,
-        );
+        console.warn(`[Slack Interactions] Unhandled action_id: ${action.action_id}`);
     }
   }
 
@@ -136,20 +130,18 @@ function handleViewSubmission(payload: SlackInteractionPayload): Response {
   switch (callbackId) {
     case "create-ticket-modal":
       postTicketAsync(payload).catch((err) =>
-        console.error("[Slack Interactions] create-ticket-modal error:", err),
+        console.error("[Slack Interactions] create-ticket-modal error:", err)
       );
       break;
 
     case "deploy-confirm-modal":
       postDeployAsync(payload).catch((err) =>
-        console.error("[Slack Interactions] deploy-confirm-modal error:", err),
+        console.error("[Slack Interactions] deploy-confirm-modal error:", err)
       );
       break;
 
     default:
-      console.warn(
-        `[Slack Interactions] Unknown view callback_id: ${callbackId}`,
-      );
+      console.warn(`[Slack Interactions] Unknown view callback_id: ${callbackId}`);
   }
 
   return new Response(null, { status: 200 });
@@ -160,10 +152,7 @@ function handleViewSubmission(payload: SlackInteractionPayload): Response {
 // ---------------------------------------------------------------------------
 
 function slackEscape(text: string): string {
-  return text
-    .replaceAll("&", "&amp;")
-    .replaceAll("<", "&lt;")
-    .replaceAll(">", "&gt;");
+  return text.replaceAll("&", "&amp;").replaceAll("<", "&lt;").replaceAll(">", "&gt;");
 }
 
 function priorityEmoji(priority: string): string {
@@ -177,25 +166,17 @@ function priorityEmoji(priority: string): string {
   }
 }
 
-async function postTicketAsync(
-  payload: SlackInteractionPayload,
-): Promise<void> {
+async function postTicketAsync(payload: SlackInteractionPayload): Promise<void> {
   const { SLACK_BOT_TOKEN: token } = await getSlackConfigAsync();
   if (!token) return;
 
   const values = payload.view?.state.values ?? {};
-  const email = slackEscape(
-    values.ticket_email?.ticket_email_input?.value ?? "",
-  );
+  const email = slackEscape(values.ticket_email?.ticket_email_input?.value ?? "");
   const issueType =
-    values.ticket_issue_type?.ticket_issue_type_select?.selected_option
-      ?.value ?? "unknown";
+    values.ticket_issue_type?.ticket_issue_type_select?.selected_option?.value ?? "unknown";
   const priority =
-    values.ticket_priority?.ticket_priority_select?.selected_option?.value ??
-    "medium";
-  const description = slackEscape(
-    values.ticket_description?.ticket_description_input?.value ?? "",
-  );
+    values.ticket_priority?.ticket_priority_select?.selected_option?.value ?? "medium";
+  const description = slackEscape(values.ticket_description?.ticket_description_input?.value ?? "");
   const emoji = priorityEmoji(priority);
   const userId = payload.user.id;
 
@@ -244,9 +225,7 @@ async function postTicketAsync(
   });
 }
 
-async function postDeployAsync(
-  payload: SlackInteractionPayload,
-): Promise<void> {
+async function postDeployAsync(payload: SlackInteractionPayload): Promise<void> {
   const { SLACK_BOT_TOKEN: token } = await getSlackConfigAsync();
   if (!token) return;
 
@@ -337,7 +316,7 @@ async function postDeployAsync(
       },
       body: JSON.stringify({ ref: "main" }),
       signal: AbortSignal.timeout(10_000),
-    },
+    }
   );
 
   if (!dispatchRes.ok) {
@@ -360,8 +339,7 @@ async function refreshOrdersAsync(responseUrl: string): Promise<void> {
   try {
     const { orders } = await listRecentCheckoutSessions(5);
     const lines = orders.map((o) => {
-      const status =
-        o.paymentStatus === "paid" ? ":white_check_mark:" : ":hourglass:";
+      const status = o.paymentStatus === "paid" ? ":white_check_mark:" : ":hourglass:";
       const amount = formatPrice(o.amount, o.currency);
       return `${status} *${amount}* — ${o.email ?? "N/A"}`;
     });

--- a/src/app/api/subscribe/route.ts
+++ b/src/app/api/subscribe/route.ts
@@ -16,10 +16,7 @@ export async function POST(request: Request) {
     const { email } = await request.json();
 
     if (!isValidEmail(email)) {
-      return Response.json(
-        { error: "Invalid email address." },
-        { status: 400 },
-      );
+      return Response.json({ error: "Invalid email address." }, { status: 400 });
     }
 
     // Clear any stale SES suppression first, so a previously-unsubscribed
@@ -41,7 +38,7 @@ export async function POST(request: Request) {
         <p style="color: #666; font-size: 12px;">
           Subscriber recorded as a HubSpot contact (lead_source: newsletter_signup).
           This notification was sent from the cloudless.gr subscribe form.
-        </p>`,
+        </p>`
       ),
       sendSubscriberWelcome(email),
     ]);
@@ -53,9 +50,6 @@ export async function POST(request: Request) {
     return Response.json({ success: true });
   } catch (error) {
     console.error("Subscribe error:", error);
-    return Response.json(
-      { error: "Failed to subscribe. Please try again." },
-      { status: 500 },
-    );
+    return Response.json({ error: "Failed to subscribe. Please try again." }, { status: 500 });
   }
 }

--- a/src/app/api/testimonials/route.ts
+++ b/src/app/api/testimonials/route.ts
@@ -10,29 +10,22 @@ export async function GET(request: Request) {
   const { searchParams } = new URL(request.url);
   const featured = searchParams.get("featured") === "true";
 
-  const configured = await isConfiguredAsync(
-    "NOTION_API_KEY",
-    "NOTION_TESTIMONIALS_DB_ID",
-  );
+  const configured = await isConfiguredAsync("NOTION_API_KEY", "NOTION_TESTIMONIALS_DB_ID");
 
   if (!configured) {
-    const data = featured
-      ? staticTestimonials.filter((t) => t.featured)
-      : staticTestimonials;
+    const data = featured ? staticTestimonials.filter((t) => t.featured) : staticTestimonials;
     return NextResponse.json(
       {
         testimonials: data,
         source: "static",
         fallbackReason: "not-configured",
       },
-      { headers: { "x-cms-source": "static" } },
+      { headers: { "x-cms-source": "static" } }
     );
   }
 
   try {
-    const testimonials = featured
-      ? await getFeaturedTestimonials()
-      : await getTestimonials();
+    const testimonials = featured ? await getFeaturedTestimonials() : await getTestimonials();
     return NextResponse.json(
       { testimonials, source: "notion" },
       {
@@ -40,16 +33,14 @@ export async function GET(request: Request) {
           "Cache-Control": "public, s-maxage=120, stale-while-revalidate=60",
           "x-cms-source": "notion",
         },
-      },
+      }
     );
   } catch (err) {
     console.error("[API /testimonials] Fetch error:", err);
-    const data = featured
-      ? staticTestimonials.filter((t) => t.featured)
-      : staticTestimonials;
+    const data = featured ? staticTestimonials.filter((t) => t.featured) : staticTestimonials;
     return NextResponse.json(
       { testimonials: data, source: "static", fallbackReason: "notion-error" },
-      { headers: { "x-cms-source": "static" } },
+      { headers: { "x-cms-source": "static" } }
     );
   }
 }

--- a/src/app/api/track/route.ts
+++ b/src/app/api/track/route.ts
@@ -3,12 +3,7 @@ import { trackEvent } from "@/lib/notion-analytics";
 import type { AnalyticsEventType } from "@/lib/notion-analytics";
 import { rateLimit, getClientIp } from "@/lib/rate-limit";
 
-const ALLOWED_TYPES: AnalyticsEventType[] = [
-  "page_view",
-  "blog_view",
-  "doc_view",
-  "form_submit",
-];
+const ALLOWED_TYPES: AnalyticsEventType[] = ["page_view", "blog_view", "doc_view", "form_submit"];
 
 /**
  * POST /api/track
@@ -38,14 +33,12 @@ export async function POST(request: NextRequest) {
   if (!ALLOWED_TYPES.includes(type)) {
     return NextResponse.json(
       { error: `Unsupported event type. Allowed: ${ALLOWED_TYPES.join(", ")}` },
-      { status: 400 },
+      { status: 400 }
     );
   }
 
-  const page =
-    typeof body.page === "string" ? body.page.slice(0, 500) : undefined;
-  const source =
-    typeof body.source === "string" ? body.source.slice(0, 200) : undefined;
+  const page = typeof body.page === "string" ? body.page.slice(0, 500) : undefined;
+  const source = typeof body.source === "string" ? body.source.slice(0, 200) : undefined;
   const referer = request.headers.get("referer") ?? undefined;
 
   // Build a human-readable event name

--- a/src/app/api/unsubscribe/route.ts
+++ b/src/app/api/unsubscribe/route.ts
@@ -20,10 +20,7 @@ export async function POST(request: Request) {
     const { email } = await request.json();
 
     if (!isValidEmail(email)) {
-      return Response.json(
-        { error: "Invalid email address." },
-        { status: 400 },
-      );
+      return Response.json({ error: "Invalid email address." }, { status: 400 });
     }
 
     // Suppress future SES sends, and flip the HubSpot contact out of the
@@ -40,10 +37,10 @@ export async function POST(request: Request) {
       <p><strong>Email:</strong> ${escapeHtml(email)}</p>
       <p><strong>SES suppressed:</strong> ${suppressed ? "Yes" : "Failed (manual removal needed)"}</p>
       <p><strong>HubSpot updated:</strong> ${hubspotUpdated ? "Yes" : "Failed (manual removal needed)"}</p>
-      <p><strong>Date:</strong> ${new Date().toISOString()}</p>`,
+      <p><strong>Date:</strong> ${new Date().toISOString()}</p>`
     ).catch(() => {});
     sendUnsubscribeConfirmation(email).catch((err) =>
-      console.warn("[unsubscribe] Confirmation email failed:", err),
+      console.warn("[unsubscribe] Confirmation email failed:", err)
     );
 
     return Response.json({
@@ -54,7 +51,7 @@ export async function POST(request: Request) {
     console.error("Unsubscribe error:", error);
     return Response.json(
       { error: "Failed to process unsubscribe request. Please try again." },
-      { status: 500 },
+      { status: 500 }
     );
   }
 }
@@ -64,23 +61,20 @@ export async function GET(request: Request) {
   const ip = getClientIp(request);
   const rl = rateLimit(`unsubscribe:${ip}`, 5, 60_000);
   if (!rl.ok) {
-    return new Response(
-      unsubscribePage("Too many requests. Please try again later.", false),
-      { status: 429, headers: { "Content-Type": "text/html; charset=utf-8" } },
-    );
+    return new Response(unsubscribePage("Too many requests. Please try again later.", false), {
+      status: 429,
+      headers: { "Content-Type": "text/html; charset=utf-8" },
+    });
   }
 
   const { searchParams } = new URL(request.url);
   const email = searchParams.get("email");
 
   if (!email || !isValidEmail(email)) {
-    return new Response(
-      unsubscribePage("Invalid or missing email address.", false),
-      {
-        status: 400,
-        headers: { "Content-Type": "text/html; charset=utf-8" },
-      },
-    );
+    return new Response(unsubscribePage("Invalid or missing email address.", false), {
+      status: 400,
+      headers: { "Content-Type": "text/html; charset=utf-8" },
+    });
   }
 
   try {
@@ -96,23 +90,20 @@ export async function GET(request: Request) {
       <p><strong>Email:</strong> ${escapeHtml(email)}</p>
       <p><strong>SES suppressed:</strong> ${suppressed ? "Yes" : "Failed"}</p>
       <p><strong>HubSpot updated:</strong> ${hubspotUpdated ? "Yes" : "Failed"}</p>
-      <p><strong>Date:</strong> ${new Date().toISOString()}</p>`,
+      <p><strong>Date:</strong> ${new Date().toISOString()}</p>`
     ).catch(() => {});
     sendUnsubscribeConfirmation(email).catch((err) =>
-      console.warn("[unsubscribe-link] Confirmation email failed:", err),
+      console.warn("[unsubscribe-link] Confirmation email failed:", err)
     );
 
     return new Response(unsubscribePage(email, true), {
       headers: { "Content-Type": "text/html; charset=utf-8" },
     });
   } catch {
-    return new Response(
-      unsubscribePage("Something went wrong. Please try again.", false),
-      {
-        status: 500,
-        headers: { "Content-Type": "text/html; charset=utf-8" },
-      },
-    );
+    return new Response(unsubscribePage("Something went wrong. Please try again.", false), {
+      status: 500,
+      headers: { "Content-Type": "text/html; charset=utf-8" },
+    });
   }
 }
 

--- a/src/app/api/user/consultations/route.ts
+++ b/src/app/api/user/consultations/route.ts
@@ -20,13 +20,7 @@ export async function GET(req: NextRequest) {
     return NextResponse.json({ error: "No email in token" }, { status: 400 });
   }
 
-  if (
-    !isConfigured(
-      "GOOGLE_SERVICE_ACCOUNT_EMAIL",
-      "GOOGLE_PRIVATE_KEY",
-      "GOOGLE_CALENDAR_ID",
-    )
-  ) {
+  if (!isConfigured("GOOGLE_SERVICE_ACCOUNT_EMAIL", "GOOGLE_PRIVATE_KEY", "GOOGLE_CALENDAR_ID")) {
     // Calendar not configured — return empty list, not an error
     return NextResponse.json({ consultations: [], configured: false });
   }
@@ -38,9 +32,6 @@ export async function GET(req: NextRequest) {
     return NextResponse.json({ consultations, configured: true });
   } catch (err) {
     console.error("Failed to fetch consultations:", err);
-    return NextResponse.json(
-      { error: "Failed to fetch consultations" },
-      { status: 500 },
-    );
+    return NextResponse.json({ error: "Failed to fetch consultations" }, { status: 500 });
   }
 }

--- a/src/app/api/user/purchases/route.ts
+++ b/src/app/api/user/purchases/route.ts
@@ -23,10 +23,7 @@ export async function GET(req: NextRequest) {
   }
 
   if (!isConfigured("STRIPE_SECRET_KEY")) {
-    return NextResponse.json(
-      { error: "Stripe not configured" },
-      { status: 503 },
-    );
+    return NextResponse.json({ error: "Stripe not configured" }, { status: 503 });
   }
 
   try {
@@ -44,7 +41,7 @@ export async function GET(req: NextRequest) {
       });
 
       const userSessions = sessions.data.filter(
-        (s) => s.customer_email?.toLowerCase() === email.toLowerCase(),
+        (s) => s.customer_email?.toLowerCase() === email.toLowerCase()
       );
 
       return NextResponse.json({
@@ -73,15 +70,13 @@ export async function GET(req: NextRequest) {
         id: sub.id,
         status: sub.status,
         currentPeriodEnd: new Date(
-          ((sub as unknown as Record<string, number>).current_period_end ?? 0) *
-            1000,
+          ((sub as unknown as Record<string, number>).current_period_end ?? 0) * 1000
         ).toISOString(),
         items: sub.items.data.map((item) => ({
           name: item.price?.product
             ? typeof item.price.product === "string"
               ? item.price.product
-              : ((item.price.product as { name?: string }).name ??
-                "Subscription")
+              : ((item.price.product as { name?: string }).name ?? "Subscription")
             : "Subscription",
           amount: (item.price?.unit_amount ?? 0) / 100,
           currency: (item.price?.currency ?? "eur").toUpperCase(),
@@ -92,10 +87,7 @@ export async function GET(req: NextRequest) {
     });
   } catch (err) {
     console.error("Failed to fetch user purchases:", err);
-    return NextResponse.json(
-      { error: "Failed to fetch purchases" },
-      { status: 500 },
-    );
+    return NextResponse.json({ error: "Failed to fetch purchases" }, { status: 500 });
   }
 }
 

--- a/src/app/api/webhooks/hubspot/route.ts
+++ b/src/app/api/webhooks/hubspot/route.ts
@@ -27,7 +27,7 @@ type HubSpotEvent = {
 async function verifySignatureV3(
   request: NextRequest,
   body: string,
-  clientSecret: string,
+  clientSecret: string
 ): Promise<boolean> {
   const signature = request.headers.get("x-hubspot-signature-v3");
   const timestamp = request.headers.get("x-hubspot-signature-timestamp");
@@ -35,9 +35,7 @@ async function verifySignatureV3(
   const age = Date.now() - Number(timestamp);
   if (Number.isNaN(age) || age > MAX_TIMESTAMP_AGE_MS || age < 0) return false;
   const input = `${request.method}${request.url}${body}${timestamp}`;
-  const expected = createHmac("sha256", clientSecret)
-    .update(input)
-    .digest("base64");
+  const expected = createHmac("sha256", clientSecret).update(input).digest("base64");
   try {
     return timingSafeEqual(Buffer.from(signature), Buffer.from(expected));
   } catch {
@@ -46,24 +44,17 @@ async function verifySignatureV3(
 }
 
 /** Allowlist of HubSpot CRM object types that may be fetched. */
-const ALLOWED_OBJECT_TYPES = new Set([
-  "contacts",
-  "deals",
-  "tickets",
-  "companies",
-]);
+const ALLOWED_OBJECT_TYPES = new Set(["contacts", "deals", "tickets", "companies"]);
 
 async function fetchObject(
   token: string,
   objectType: string,
   objectId: number,
-  properties: string[],
+  properties: string[]
 ): Promise<Record<string, string> | null> {
   // Validate objectType against allowlist to prevent request forgery
   if (!ALLOWED_OBJECT_TYPES.has(objectType)) {
-    console.warn(
-      `[HubSpot Webhook] Blocked unsupported objectType: ${objectType}`,
-    );
+    console.warn(`[HubSpot Webhook] Blocked unsupported objectType: ${objectType}`);
     return null;
   }
   try {
@@ -72,7 +63,7 @@ async function fetchObject(
       {
         headers: { Authorization: `Bearer ${token}` },
         signal: AbortSignal.timeout(5_000),
-      },
+      }
     );
     if (!res.ok) return null;
     const data = await res.json();
@@ -106,8 +97,7 @@ async function onContactCreated(token: string, id: number): Promise<void> {
     "hs_lead_status",
   ]);
 
-  const name =
-    [p?.firstname, p?.lastname].filter(Boolean).join(" ") || "Unknown";
+  const name = [p?.firstname, p?.lastname].filter(Boolean).join(" ") || "Unknown";
   const email = p?.email ?? "—";
   const company = p?.company || "—";
   const service = p?.service_interest || "—";
@@ -157,9 +147,7 @@ async function onDealCreated(token: string, id: number): Promise<void> {
   ]);
 
   const name = p?.dealname ?? "Untitled Deal";
-  const amount = p?.amount
-    ? `€${Number.parseFloat(p.amount).toLocaleString("en-IE")}`
-    : "—";
+  const amount = p?.amount ? `€${Number.parseFloat(p.amount).toLocaleString("en-IE")}` : "—";
   const stage = p?.dealstage ?? "—";
 
   await slack.post({
@@ -173,11 +161,7 @@ async function onDealCreated(token: string, id: number): Promise<void> {
         type: SECTION,
         text: {
           type: "mrkdwn",
-          text: [
-            `*Deal:* ${name}`,
-            `*Amount:* ${amount}`,
-            `*Stage:* \`${stage}\``,
-          ].join("\n"),
+          text: [`*Deal:* ${name}`, `*Amount:* ${amount}`, `*Stage:* \`${stage}\``].join("\n"),
         },
         accessory: viewButton(OPEN_IN_HUBSPOT, `${PORTAL_BASE}/deal/${id}`),
       },
@@ -201,9 +185,7 @@ async function onDealClosedWon(token: string, id: number): Promise<void> {
   const p = await fetchObject(token, "deals", id, ["dealname", "amount"]);
 
   const name = p?.dealname ?? "Untitled Deal";
-  const amount = p?.amount
-    ? `€${Number.parseFloat(p.amount).toLocaleString("en-IE")}`
-    : "";
+  const amount = p?.amount ? `€${Number.parseFloat(p.amount).toLocaleString("en-IE")}` : "";
   const closedWonText = amount
     ? `Deal closed won: ${name} — ${amount}`
     : `Deal closed won: ${name}`;
@@ -242,10 +224,7 @@ async function onDealClosedWon(token: string, id: number): Promise<void> {
 }
 
 async function onTicketCreated(token: string, id: number): Promise<void> {
-  const p = await fetchObject(token, "tickets", id, [
-    "subject",
-    "hs_ticket_priority",
-  ]);
+  const p = await fetchObject(token, "tickets", id, ["subject", "hs_ticket_priority"]);
 
   const subject = p?.subject ?? "No subject";
   const priority = (p?.hs_ticket_priority ?? "MEDIUM").toUpperCase();
@@ -269,10 +248,7 @@ async function onTicketCreated(token: string, id: number): Promise<void> {
         type: SECTION,
         text: {
           type: "mrkdwn",
-          text: [
-            `*Subject:* ${subject}`,
-            `*Priority:* ${priorityEmoji} ${priority}`,
-          ].join("\n"),
+          text: [`*Subject:* ${subject}`, `*Priority:* ${priorityEmoji} ${priority}`].join("\n"),
         },
         accessory: viewButton(OPEN_IN_HUBSPOT, `${PORTAL_BASE}/ticket/${id}`),
       },
@@ -293,12 +269,7 @@ async function onTicketCreated(token: string, id: number): Promise<void> {
 }
 
 async function onCompanyCreated(token: string, id: number): Promise<void> {
-  const p = await fetchObject(token, "companies", id, [
-    "name",
-    "domain",
-    "city",
-    "country",
-  ]);
+  const p = await fetchObject(token, "companies", id, ["name", "domain", "city", "country"]);
 
   const name = p?.name ?? "Unknown Company";
   const domain = p?.domain || "—";
@@ -315,11 +286,7 @@ async function onCompanyCreated(token: string, id: number): Promise<void> {
         type: SECTION,
         text: {
           type: "mrkdwn",
-          text: [
-            `*Company:* ${name}`,
-            `*Domain:* ${domain}`,
-            `*Location:* ${location}`,
-          ].join("\n"),
+          text: [`*Company:* ${name}`, `*Domain:* ${domain}`, `*Location:* ${location}`].join("\n"),
         },
         accessory: viewButton(OPEN_IN_HUBSPOT, `${PORTAL_BASE}/company/${id}`),
       },
@@ -372,13 +339,8 @@ export async function POST(request: NextRequest) {
   // Fail closed: without the secret we cannot verify the signature, so we must
   // reject rather than silently process unauthenticated webhook events.
   if (!clientSecret) {
-    console.error(
-      "[HubSpot Webhook] HUBSPOT_CLIENT_SECRET not configured — rejecting",
-    );
-    return NextResponse.json(
-      { error: "Webhook not configured" },
-      { status: 500 },
-    );
+    console.error("[HubSpot Webhook] HUBSPOT_CLIENT_SECRET not configured — rejecting");
+    return NextResponse.json({ error: "Webhook not configured" }, { status: 500 });
   }
 
   const valid = await verifySignatureV3(request, rawBody, clientSecret);

--- a/src/app/api/webhooks/notion/route.ts
+++ b/src/app/api/webhooks/notion/route.ts
@@ -41,13 +41,7 @@ interface WebhookPayload {
     | "project.updated"
     | "task.updated"
     | "analytics.event";
-  database:
-    | "blog"
-    | "docs"
-    | "submissions"
-    | "projects"
-    | "tasks"
-    | "analytics";
+  database: "blog" | "docs" | "submissions" | "projects" | "tasks" | "analytics";
   page_id: string;
   slug?: string;
   data?: Record<string, unknown>;
@@ -71,9 +65,7 @@ async function verifySecret(request: NextRequest): Promise<boolean> {
 async function handlePageUpdated(payload: WebhookPayload) {
   const { database, slug } = payload;
 
-  invalidateCache(
-    database === "blog" ? "blog" : database === "docs" ? "docs" : undefined,
-  );
+  invalidateCache(database === "blog" ? "blog" : database === "docs" ? "docs" : undefined);
 
   if (database === "blog") {
     revalidatePath("/blog");
@@ -95,9 +87,7 @@ async function handlePageUpdated(payload: WebhookPayload) {
 async function handlePageCreated(payload: WebhookPayload) {
   const { database, slug, data } = payload;
 
-  invalidateCache(
-    database === "blog" ? "blog" : database === "docs" ? "docs" : undefined,
-  );
+  invalidateCache(database === "blog" ? "blog" : database === "docs" ? "docs" : undefined);
 
   if (database === "blog") {
     revalidatePath("/blog");
@@ -241,10 +231,7 @@ async function handleSubmissionStatus(payload: WebhookPayload) {
 
 export async function POST(request: NextRequest) {
   if (!(await verifySecret(request))) {
-    return NextResponse.json(
-      { error: "Invalid or missing x-webhook-secret" },
-      { status: 401 },
-    );
+    return NextResponse.json({ error: "Invalid or missing x-webhook-secret" }, { status: 401 });
   }
 
   let body: WebhookPayload;
@@ -259,7 +246,7 @@ export async function POST(request: NextRequest) {
   if (!body.type || !body.database || !body.page_id) {
     return NextResponse.json(
       { error: "type, database, and page_id are required" },
-      { status: 400 },
+      { status: 400 }
     );
   }
 
@@ -286,10 +273,7 @@ export async function POST(request: NextRequest) {
         result = await handleAnalyticsEvent(body);
         break;
       default:
-        return NextResponse.json(
-          { error: `Unknown event type: ${body.type}` },
-          { status: 400 },
-        );
+        return NextResponse.json({ error: `Unknown event type: ${body.type}` }, { status: 400 });
     }
 
     return NextResponse.json({ ok: true, type: body.type, ...result });
@@ -304,13 +288,10 @@ export async function POST(request: NextRequest) {
             scope.setTag("route", "notion.webhook");
             scope.setTag("notion.event", body.type);
             captureException(err);
-          }),
+          })
         )
         .catch(() => {});
     }
-    return NextResponse.json(
-      { error: "Internal error processing webhook" },
-      { status: 500 },
-    );
+    return NextResponse.json({ error: "Internal error processing webhook" }, { status: 500 });
   }
 }

--- a/src/app/api/webhooks/stripe/route.ts
+++ b/src/app/api/webhooks/stripe/route.ts
@@ -1,18 +1,10 @@
 import { NextRequest } from "next/server";
 import { getStripe } from "@/lib/stripe";
 import { getConfig } from "@/lib/ssm-config";
-import {
-  sendOrderConfirmation,
-  sendPaymentFailureNotice,
-  notifyTeam,
-} from "@/lib/email";
+import { sendOrderConfirmation, sendPaymentFailureNotice, notifyTeam } from "@/lib/email";
 import { escapeHtml } from "@/lib/escape-html";
 import { slackOrderNotify } from "@/lib/slack-notify";
-import {
-  upsertContact,
-  createDeal,
-  associateDealWithContact,
-} from "@/lib/hubspot";
+import { upsertContact, createDeal, associateDealWithContact } from "@/lib/hubspot";
 import type Stripe from "stripe";
 import { mapIntegrationError } from "@/lib/api-errors";
 import {
@@ -28,8 +20,7 @@ async function syncHubSpotDeal(session: Stripe.Checkout.Session): Promise<void> 
     const contactId = await upsertContact({
       email: session.customer_email ?? "",
       firstname: session.customer_details?.name?.split(" ")[0] ?? "",
-      lastname:
-        session.customer_details?.name?.split(" ").slice(1).join(" ") ?? "",
+      lastname: session.customer_details?.name?.split(" ").slice(1).join(" ") ?? "",
       lead_source: "stripe_checkout",
     });
     const dealId = await createDeal({
@@ -50,21 +41,20 @@ async function syncHubSpotDeal(session: Stripe.Checkout.Session): Promise<void> 
 
 async function handleCheckoutCompleted(
   session: Stripe.Checkout.Session,
-  eventId: string,
+  eventId: string
 ): Promise<void> {
   console.warn(
-    `[Stripe] Checkout completed: ${session.id}, event: ${eventId}, payment_status: ${session.payment_status}`,
+    `[Stripe] Checkout completed: ${session.id}, event: ${eventId}, payment_status: ${session.payment_status}`
   );
 
-  const paymentCollected =
-    session.payment_status === "paid" || session.mode === "subscription";
+  const paymentCollected = session.payment_status === "paid" || session.mode === "subscription";
 
   if (session.customer_email && paymentCollected) {
     await sendOrderConfirmation(
       session.customer_email,
       session.id,
       session.amount_total ?? 0,
-      session.currency ?? "eur",
+      session.currency ?? "eur"
     );
   }
 
@@ -73,7 +63,7 @@ async function handleCheckoutCompleted(
     `<h3>New order received</h3>
     <p><strong>Customer:</strong> ${escapeHtml(session.customer_email ?? "N/A")}</p>
     <p><strong>Amount:</strong> ${((session.amount_total ?? 0) / 100).toFixed(2)} ${escapeHtml((session.currency ?? "EUR").toUpperCase())}</p>
-    <p><strong>Session:</strong> ${escapeHtml(session.id)}</p>`,
+    <p><strong>Session:</strong> ${escapeHtml(session.id)}</p>`
   );
 
   slackOrderNotify({
@@ -96,10 +86,9 @@ function invoiceCustomerString(invoice: Stripe.Invoice): string {
 
 async function handleInvoicePaymentFailed(invoice: Stripe.Invoice): Promise<void> {
   console.error(
-    `[Stripe] Invoice payment failed: ${invoice.id}, customer: ${invoiceCustomerString(invoice)}`,
+    `[Stripe] Invoice payment failed: ${invoice.id}, customer: ${invoiceCustomerString(invoice)}`
   );
-  const customerEmail =
-    typeof invoice.customer_email === "string" ? invoice.customer_email : null;
+  const customerEmail = typeof invoice.customer_email === "string" ? invoice.customer_email : null;
   if (customerEmail) {
     await sendPaymentFailureNotice(customerEmail, invoice.id ?? "unknown");
   }
@@ -108,19 +97,19 @@ async function handleInvoicePaymentFailed(invoice: Stripe.Invoice): Promise<void
     `<p style="color: #ff4444;"><strong>Payment failed</strong></p>
     <p><strong>Invoice:</strong> ${escapeHtml(invoice.id ?? "unknown")}</p>
     <p><strong>Customer:</strong> ${escapeHtml(customerEmail ?? invoiceCustomerString(invoice))}</p>
-    <p><strong>Amount:</strong> ${((invoice.amount_due ?? 0) / 100).toFixed(2)} ${escapeHtml((invoice.currency ?? "EUR").toUpperCase())}</p>`,
+    <p><strong>Amount:</strong> ${((invoice.amount_due ?? 0) / 100).toFixed(2)} ${escapeHtml((invoice.currency ?? "EUR").toUpperCase())}</p>`
   );
 }
 
 async function handleSubscriptionEvent(
   action: "created" | "updated" | "deleted",
-  sub: Stripe.Subscription,
+  sub: Stripe.Subscription
 ): Promise<void> {
   if (action === "deleted") {
     console.warn(`[Stripe] Subscription cancelled: ${sub.id}`);
     await notifyTeam(
       `[Subscription] Cancelled: ${sub.id}`,
-      `<p>Subscription cancelled.</p><p><strong>ID:</strong> ${escapeHtml(sub.id)}</p>`,
+      `<p>Subscription cancelled.</p><p><strong>ID:</strong> ${escapeHtml(sub.id)}</p>`
     );
     return;
   }
@@ -131,7 +120,7 @@ async function handleSubscriptionEvent(
     `[Subscription] ${label}: ${sub.id}`,
     `<p>Subscription ${verb}.</p>
     <p><strong>ID:</strong> ${escapeHtml(sub.id)}</p>
-    <p><strong>Status:</strong> ${escapeHtml(sub.status)}</p>`,
+    <p><strong>Status:</strong> ${escapeHtml(sub.status)}</p>`
   );
 }
 
@@ -150,7 +139,9 @@ async function handleStripeEvent(event: Stripe.Event): Promise<void> {
       await handleSubscriptionEvent("deleted", event.data.object);
       break;
     case "invoice.payment_succeeded":
-      console.warn(`[Stripe] Invoice paid: ${event.data.object.id}, amount: ${event.data.object.amount_paid}`);
+      console.warn(
+        `[Stripe] Invoice paid: ${event.data.object.id}, amount: ${event.data.object.amount_paid}`
+      );
       break;
     case "invoice.payment_failed":
       await handleInvoicePaymentFailed(event.data.object);
@@ -165,10 +156,7 @@ export async function POST(request: NextRequest) {
   const signature = request.headers.get("stripe-signature");
 
   if (!signature) {
-    return Response.json(
-      { error: "Missing stripe-signature header" },
-      { status: 400 },
-    );
+    return Response.json({ error: "Missing stripe-signature header" }, { status: 400 });
   }
 
   const config = await getConfig();
@@ -202,10 +190,7 @@ export async function POST(request: NextRequest) {
     const integrationResponse = mapIntegrationError(err);
     if (integrationResponse) return integrationResponse;
     console.error("[Stripe] Failed to persist event for analytics:", err);
-    return Response.json(
-      { error: "Transaction persistence failed" },
-      { status: 500 },
-    );
+    return Response.json({ error: "Transaction persistence failed" }, { status: 500 });
   }
 
   try {
@@ -214,8 +199,7 @@ export async function POST(request: NextRequest) {
     const integrationResponse = mapIntegrationError(err);
     if (integrationResponse) return integrationResponse;
 
-    const message =
-      err instanceof Error ? err.message : "Unknown handler error";
+    const message = err instanceof Error ? err.message : "Unknown handler error";
     await markStripeEventFailed(event.id, message).catch((markErr) => {
       console.error("[Stripe] Failed to mark event as failed:", markErr);
     });
@@ -228,7 +212,7 @@ export async function POST(request: NextRequest) {
             scope.setTag("route", "stripe.webhook");
             scope.setTag("stripe.event", event.type);
             captureException(err);
-          }),
+          })
         )
         .catch(() => {});
     }
@@ -240,9 +224,7 @@ export async function POST(request: NextRequest) {
   });
 
   if (process.env.NEXT_PUBLIC_SENTRY_DSN) {
-    await import("@sentry/nextjs")
-      .then(({ flush }) => flush(2000))
-      .catch(() => {});
+    await import("@sentry/nextjs").then(({ flush }) => flush(2000)).catch(() => {});
   }
 
   return Response.json({ received: true });

--- a/src/app/apple-icon.tsx
+++ b/src/app/apple-icon.tsx
@@ -23,22 +23,16 @@ export default function AppleIcon() {
         display: "flex",
         alignItems: "center",
         justifyContent: "center",
-        background:
-          "linear-gradient(135deg, #d6f0f6 0%, #e3e9ff 60%, #fbf8ff 100%)",
+        background: "linear-gradient(135deg, #d6f0f6 0%, #e3e9ff 60%, #fbf8ff 100%)",
       }}
     >
-      <svg
-        width="140"
-        height="105"
-        viewBox="0 0 32 24"
-        xmlns="http://www.w3.org/2000/svg"
-      >
+      <svg width="140" height="105" viewBox="0 0 32 24" xmlns="http://www.w3.org/2000/svg">
         <path
           d="M6 22 A6 6 0 0 1 6 10 A4 4 0 0 1 10.5 7 A7 7 0 0 1 23 5.2 A6 6 0 0 1 28.5 14 A5 5 0 0 1 26 22 Z"
           fill="#0a7785"
         />
       </svg>
     </div>,
-    { ...size },
+    { ...size }
   );
 }

--- a/src/app/error.tsx
+++ b/src/app/error.tsx
@@ -19,9 +19,7 @@ export default function Error({
         <p className="text-neon-magenta glow-magenta animate-neon-pulse font-mono text-5xl font-bold">
           ERROR
         </p>
-        <h1 className="font-heading mt-4 text-2xl font-bold text-white">
-          Something went wrong
-        </h1>
+        <h1 className="font-heading mt-4 text-2xl font-bold text-white">Something went wrong</h1>
         <p className="mt-3 font-mono text-sm text-slate-400">
           An unexpected error occurred. Please try again.
         </p>

--- a/src/app/global-error.tsx
+++ b/src/app/global-error.tsx
@@ -32,9 +32,7 @@ export default function GlobalError({
           >
             500
           </p>
-          <h1 style={{ marginTop: "1rem", fontSize: "1.5rem" }}>
-            Something went wrong
-          </h1>
+          <h1 style={{ marginTop: "1rem", fontSize: "1.5rem" }}>Something went wrong</h1>
           <button
             type="button"
             onClick={reset}

--- a/src/app/icon.tsx
+++ b/src/app/icon.tsx
@@ -26,18 +26,13 @@ export default function Icon() {
         background: "transparent",
       }}
     >
-      <svg
-        width="28"
-        height="21"
-        viewBox="0 0 32 24"
-        xmlns="http://www.w3.org/2000/svg"
-      >
+      <svg width="28" height="21" viewBox="0 0 32 24" xmlns="http://www.w3.org/2000/svg">
         <path
           d="M6 22 A6 6 0 0 1 6 10 A4 4 0 0 1 10.5 7 A7 7 0 0 1 23 5.2 A6 6 0 0 1 28.5 14 A5 5 0 0 1 26 22 Z"
           fill="#0a7785"
         />
       </svg>
     </div>,
-    { ...size },
+    { ...size }
   );
 }

--- a/src/app/icons/[name]/route.ts
+++ b/src/app/icons/[name]/route.ts
@@ -34,10 +34,7 @@ async function readFirstExisting(filePaths: string[]) {
   return null;
 }
 
-export async function GET(
-  _request: Request,
-  { params }: { params: Promise<{ name: string }> },
-) {
+export async function GET(_request: Request, { params }: { params: Promise<{ name: string }> }) {
   const { name } = await params;
   const filename = ICON_MAP[name];
 

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -108,11 +108,7 @@ export default async function RootLayout({
         <ChunkReloadGuard />
         {META_PIXEL_ID ? (
           <>
-            <Script
-              id="meta-pixel-init"
-              strategy="afterInteractive"
-              nonce={nonce}
-            >
+            <Script id="meta-pixel-init" strategy="afterInteractive" nonce={nonce}>
               {`
                 !function(f,b,e,v,n,t,s){if(f.fbq)return;n=f.fbq=function(){n.callMethod?
                 n.callMethod.apply(n,arguments):n.queue.push(arguments)};if(!f._fbq)f._fbq=n;
@@ -139,11 +135,7 @@ export default async function RootLayout({
         {GA_ID ? (
           <>
             {/* Consent Mode v2 — default to denied before user responds to banner */}
-            <Script
-              id="gtag-consent-init"
-              strategy="beforeInteractive"
-              nonce={nonce}
-            >{`
+            <Script id="gtag-consent-init" strategy="beforeInteractive" nonce={nonce}>{`
               window.dataLayer = window.dataLayer || [];
               function gtag(){window.dataLayer.push(arguments);}
               gtag('consent', 'default', {

--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -2,12 +2,7 @@ export const dynamic = "force-dynamic";
 
 import Link from "next/link";
 import { headers } from "next/headers";
-import {
-  translate,
-  type Locale,
-  isSupportedLocale,
-  defaultLocale,
-} from "@/lib/i18n";
+import { translate, type Locale, isSupportedLocale, defaultLocale } from "@/lib/i18n";
 
 const FALLBACK = {
   title: "Page not found",
@@ -52,9 +47,7 @@ export default async function NotFound() {
         <p className="text-neon-magenta glow-magenta animate-neon-pulse font-mono text-7xl font-bold">
           404
         </p>
-        <h1 className="font-heading mt-4 text-3xl font-bold text-white">
-          {m.title}
-        </h1>
+        <h1 className="font-heading mt-4 text-3xl font-bold text-white">{m.title}</h1>
         <p className="mt-3 font-mono text-sm text-slate-400">{m.body}</p>
         <Link
           href={homeHref}

--- a/src/app/opengraph-image.tsx
+++ b/src/app/opengraph-image.tsx
@@ -2,8 +2,7 @@ import { ImageResponse } from "next/og";
 
 export const dynamic = "force-static";
 
-export const alt =
-  "cloudless.gr Cloud Computing, Serverless, Analytics & AI Marketing";
+export const alt = "cloudless.gr Cloud Computing, Serverless, Analytics & AI Marketing";
 export const size = {
   width: 1200,
   height: 630,
@@ -14,8 +13,7 @@ export default function Image() {
   return new ImageResponse(
     <div
       style={{
-        background:
-          "linear-gradient(135deg, #0a0a0f 0%, #12121a 50%, #1a1a2e 100%)",
+        background: "linear-gradient(135deg, #0a0a0f 0%, #12121a 50%, #1a1a2e 100%)",
         width: "100%",
         height: "100%",
         display: "flex",
@@ -92,13 +90,12 @@ export default function Image() {
           style={{
             width: "200px",
             height: "2px",
-            background:
-              "linear-gradient(90deg, transparent, #00fff5, transparent)",
+            background: "linear-gradient(90deg, transparent, #00fff5, transparent)",
             marginTop: "16px",
           }}
         />
       </div>
     </div>,
-    { width: 1200, height: 630 },
+    { width: 1200, height: 630 }
   );
 }

--- a/src/app/portal/[token]/page.tsx
+++ b/src/app/portal/[token]/page.tsx
@@ -2,10 +2,7 @@
 
 import { useEffect, useState } from "react";
 import { use } from "react";
-import type {
-  PortalStep,
-  PortalComment,
-} from "@/app/api/admin/client-portals/route";
+import type { PortalStep, PortalComment } from "@/app/api/admin/client-portals/route";
 
 interface PortalProject {
   id: string;
@@ -124,7 +121,7 @@ function StepIcon({ status }: Readonly<{ status: PortalStep["status"] }>) {
   if (status === "completed") {
     return (
       <svg
-        className="h-4 w-4 text-neon-green"
+        className="text-neon-green h-4 w-4"
         fill="none"
         viewBox="0 0 24 24"
         stroke="currentColor"
@@ -135,9 +132,7 @@ function StepIcon({ status }: Readonly<{ status: PortalStep["status"] }>) {
     );
   }
   if (status === "in-progress") {
-    return (
-      <span className="h-2.5 w-2.5 rounded-full bg-neon-cyan animate-pulse" />
-    );
+    return <span className="bg-neon-cyan h-2.5 w-2.5 animate-pulse rounded-full" />;
   }
   if (status === "blocked") {
     return (
@@ -162,19 +157,17 @@ function StepIcon({ status }: Readonly<{ status: PortalStep["status"] }>) {
 function CommentCard({ comment }: Readonly<{ comment: PortalComment }>) {
   return (
     <div className="flex gap-3">
-      <div className="flex h-7 w-7 shrink-0 items-center justify-center rounded-full bg-void-lighter border border-slate-700 font-mono text-[10px] text-slate-400 uppercase">
+      <div className="bg-void-lighter flex h-7 w-7 shrink-0 items-center justify-center rounded-full border border-slate-700 font-mono text-[10px] text-slate-400 uppercase">
         {comment.author.slice(0, 2)}
       </div>
-      <div className="flex-1 min-w-0">
+      <div className="min-w-0 flex-1">
         <div className="flex items-baseline gap-2">
-          <span className="font-mono text-xs font-semibold text-slate-300">
-            {comment.author}
-          </span>
+          <span className="font-mono text-xs font-semibold text-slate-300">{comment.author}</span>
           <span className="font-mono text-[10px] text-slate-600">
             {formatRelative(comment.createdAt)}
           </span>
         </div>
-        <p className="mt-1 text-sm leading-relaxed text-slate-400 whitespace-pre-wrap">
+        <p className="mt-1 text-sm leading-relaxed whitespace-pre-wrap text-slate-400">
           {comment.text}
         </p>
       </div>
@@ -184,20 +177,17 @@ function CommentCard({ comment }: Readonly<{ comment: PortalComment }>) {
 
 function ProjectTimeline({ steps }: Readonly<{ steps: PortalStep[] }>) {
   const [expanded, setExpanded] = useState<string | null>(() => {
-    const active = steps.find(
-      (s) => s.status === "in-progress" || s.status === "blocked",
-    );
+    const active = steps.find((s) => s.status === "in-progress" || s.status === "blocked");
     return active?.id ?? null;
   });
 
   const completedCount = steps.filter((s) => s.status === "completed").length;
-  const pct =
-    steps.length > 0 ? Math.round((completedCount / steps.length) * 100) : 0;
+  const pct = steps.length > 0 ? Math.round((completedCount / steps.length) * 100) : 0;
 
   return (
     <section>
       <div className="mb-5 flex items-center justify-between">
-        <h2 className="font-mono text-xs uppercase tracking-widest text-slate-500">
+        <h2 className="font-mono text-xs tracking-widest text-slate-500 uppercase">
           Project Progress
         </h2>
         <span className="font-mono text-xs text-slate-400">
@@ -213,7 +203,7 @@ function ProjectTimeline({ steps }: Readonly<{ steps: PortalStep[] }>) {
         </div>
         <div className="h-2 w-full overflow-hidden rounded-full bg-slate-800">
           <div
-            className="h-full rounded-full bg-gradient-to-r from-neon-cyan to-neon-green transition-all duration-700"
+            className="from-neon-cyan to-neon-green h-full rounded-full bg-gradient-to-r transition-all duration-700"
             style={{ width: `${pct}%` }}
           />
         </div>
@@ -222,9 +212,9 @@ function ProjectTimeline({ steps }: Readonly<{ steps: PortalStep[] }>) {
       {/* Horizontal step bubbles — desktop */}
       <div className="relative mb-8 hidden sm:block">
         {/* Connector track */}
-        <div className="absolute top-5 left-0 right-0 h-px bg-slate-800" />
+        <div className="absolute top-5 right-0 left-0 h-px bg-slate-800" />
         <div
-          className="absolute top-5 left-0 h-px bg-gradient-to-r from-neon-cyan to-neon-green transition-all duration-700"
+          className="from-neon-cyan to-neon-green absolute top-5 left-0 h-px bg-gradient-to-r transition-all duration-700"
           style={{ width: `${pct}%` }}
         />
 
@@ -247,17 +237,15 @@ function ProjectTimeline({ steps }: Readonly<{ steps: PortalStep[] }>) {
                 >
                   <StepIcon status={step.status} />
                   {step.comments.length > 0 && (
-                    <span className="absolute -top-1 -right-1 flex h-4 w-4 items-center justify-center rounded-full bg-neon-magenta font-mono text-[9px] text-white">
+                    <span className="bg-neon-magenta absolute -top-1 -right-1 flex h-4 w-4 items-center justify-center rounded-full font-mono text-[9px] text-white">
                       {step.comments.length}
                     </span>
                   )}
                 </div>
                 {/* Label */}
                 <span
-                  className={`font-mono text-[10px] leading-tight text-center transition-colors ${
-                    isActive
-                      ? cfg.text
-                      : "text-slate-500 group-hover:text-slate-300"
+                  className={`text-center font-mono text-[10px] leading-tight transition-colors ${
+                    isActive ? cfg.text : "text-slate-500 group-hover:text-slate-300"
                   }`}
                   style={{ maxWidth: "6rem" }}
                 >
@@ -283,9 +271,7 @@ function ProjectTimeline({ steps }: Readonly<{ steps: PortalStep[] }>) {
                 onClick={() => setExpanded(isActive ? null : step.id)}
                 aria-expanded={isActive}
                 className={`group w-full rounded-xl border text-left transition-all duration-200 ${
-                  isActive
-                    ? `${cfg.ring} ${cfg.bg}`
-                    : "border-slate-800 hover:border-slate-700"
+                  isActive ? `${cfg.ring} ${cfg.bg}` : "border-slate-800 hover:border-slate-700"
                 }`}
               >
                 <div className="flex items-center gap-4 px-4 py-3.5">
@@ -296,14 +282,12 @@ function ProjectTimeline({ steps }: Readonly<{ steps: PortalStep[] }>) {
                     <StepIcon status={step.status} />
                   </div>
 
-                  <div className="flex-1 min-w-0">
+                  <div className="min-w-0 flex-1">
                     <div className="flex items-center gap-2">
-                      <span
-                        className={`font-mono text-xs text-slate-600 shrink-0`}
-                      >
+                      <span className={`shrink-0 font-mono text-xs text-slate-600`}>
                         {String(idx + 1).padStart(2, "0")}
                       </span>
-                      <span className="font-heading text-sm font-semibold text-white truncate">
+                      <span className="font-heading truncate text-sm font-semibold text-white">
                         {step.name}
                       </span>
                     </div>
@@ -345,11 +329,7 @@ function ProjectTimeline({ steps }: Readonly<{ steps: PortalStep[] }>) {
                       stroke="currentColor"
                       strokeWidth={2}
                     >
-                      <path
-                        strokeLinecap="round"
-                        strokeLinejoin="round"
-                        d="M9 5l7 7-7 7"
-                      />
+                      <path strokeLinecap="round" strokeLinejoin="round" d="M9 5l7 7-7 7" />
                     </svg>
                   </div>
                 </div>
@@ -357,9 +337,9 @@ function ProjectTimeline({ steps }: Readonly<{ steps: PortalStep[] }>) {
 
               {/* Comments panel */}
               {isActive && (
-                <div className="mt-1 rounded-xl border border-slate-800 bg-void-light/20 px-4 py-4">
+                <div className="bg-void-light/20 mt-1 rounded-xl border border-slate-800 px-4 py-4">
                   {step.comments.length === 0 ? (
-                    <p className="font-mono text-xs text-slate-600 text-center py-4">
+                    <p className="py-4 text-center font-mono text-xs text-slate-600">
                       No updates yet for this step.
                     </p>
                   ) : (
@@ -379,11 +359,7 @@ function ProjectTimeline({ steps }: Readonly<{ steps: PortalStep[] }>) {
   );
 }
 
-export default function PortalPage({
-  params,
-}: {
-  params: Promise<{ token: string }>;
-}) {
+export default function PortalPage({ params }: { params: Promise<{ token: string }> }) {
   const { token } = use(params);
   const [data, setData] = useState<PortalData | null>(null);
   const [loading, setLoading] = useState(true);
@@ -393,12 +369,8 @@ export default function PortalPage({
     async function load() {
       try {
         const res = await fetch(`/api/portal/${token}`);
-        if (res.status === 404)
-          throw new Error("This portal link is invalid or has been revoked.");
-        if (!res.ok)
-          throw new Error(
-            "Failed to load your portal. Please try again later.",
-          );
+        if (res.status === 404) throw new Error("This portal link is invalid or has been revoked.");
+        if (!res.ok) throw new Error("Failed to load your portal. Please try again later.");
         setData(await res.json());
       } catch (e) {
         setError(e instanceof Error ? e.message : "Something went wrong.");
@@ -418,20 +390,18 @@ export default function PortalPage({
             <span className="bg-neon-cyan h-2 w-2 animate-pulse rounded-full" />
             <span className="font-mono text-sm text-white">cloudless.gr</span>
           </div>
-          <span className="font-mono text-xs text-slate-500">
-            Client Portal
-          </span>
+          <span className="font-mono text-xs text-slate-500">Client Portal</span>
         </div>
       </header>
 
       <main className="mx-auto max-w-4xl px-6 py-10">
         {loading && (
           <div className="space-y-4">
-            <div className="h-10 w-64 animate-pulse rounded-lg bg-void-light/40" />
+            <div className="bg-void-light/40 h-10 w-64 animate-pulse rounded-lg" />
             {["s1", "s2", "s3", "s4"].map((k) => (
               <div
                 key={k}
-                className="h-16 animate-pulse rounded-xl border border-slate-800 bg-void-light/30"
+                className="bg-void-light/30 h-16 animate-pulse rounded-xl border border-slate-800"
               />
             ))}
           </div>
@@ -441,7 +411,7 @@ export default function PortalPage({
           <div className="rounded-xl border border-red-900/30 bg-red-950/10 px-6 py-12 text-center">
             <div className="mb-3 text-4xl">🔒</div>
             <p className="font-heading text-base text-red-400">{error}</p>
-            <p className="font-mono mt-2 text-xs text-slate-600">
+            <p className="mt-2 font-mono text-xs text-slate-600">
               Contact your project manager for a new link.
             </p>
           </div>
@@ -455,14 +425,12 @@ export default function PortalPage({
               <h1 className="font-heading mt-1 text-3xl font-bold text-white">
                 {data.client.name}
               </h1>
-              <p className="font-mono mt-1 text-sm text-slate-400">
-                {data.client.label}
-              </p>
+              <p className="mt-1 font-mono text-sm text-slate-400">{data.client.label}</p>
             </div>
 
             {/* Project Timeline — the main view */}
             {data.steps.length > 0 && (
-              <div className="rounded-2xl border border-slate-800 bg-void-light/20 p-6">
+              <div className="bg-void-light/20 rounded-2xl border border-slate-800 p-6">
                 <ProjectTimeline steps={data.steps} />
               </div>
             )}
@@ -470,23 +438,22 @@ export default function PortalPage({
             {/* Active subscriptions */}
             {data.subscriptions.length > 0 && (
               <section>
-                <h2 className="font-mono mb-3 text-xs uppercase tracking-widest text-slate-500">
+                <h2 className="mb-3 font-mono text-xs tracking-widest text-slate-500 uppercase">
                   Active Plan
                 </h2>
                 <div className="space-y-3">
                   {data.subscriptions.map((sub) => (
                     <div
                       key={sub.id}
-                      className="rounded-xl border border-slate-800 bg-void-light/30 p-4"
+                      className="bg-void-light/30 rounded-xl border border-slate-800 p-4"
                     >
                       <div className="flex flex-wrap items-center justify-between gap-3">
                         <div>
                           <span className="font-heading font-semibold text-white">
                             {sub.planName}
                           </span>
-                          <span className="font-mono ml-3 text-sm text-slate-400">
-                            {formatAmount(sub.amount, sub.currency)}/
-                            {sub.interval}
+                          <span className="ml-3 font-mono text-sm text-slate-400">
+                            {formatAmount(sub.amount, sub.currency)}/{sub.interval}
                           </span>
                         </div>
                         <div className="flex items-center gap-3">
@@ -516,40 +483,38 @@ export default function PortalPage({
             {/* Notion projects (secondary, if Notion is connected) */}
             {data.projects.length > 0 && (
               <section>
-                <h2 className="font-mono mb-3 text-xs uppercase tracking-widest text-slate-500">
+                <h2 className="mb-3 font-mono text-xs tracking-widest text-slate-500 uppercase">
                   Linked Projects
                 </h2>
                 <div className="space-y-3">
                   {data.projects.map((project) => (
                     <div
                       key={project.id}
-                      className="rounded-xl border border-slate-800 bg-void-light/30 p-4"
+                      className="bg-void-light/30 rounded-xl border border-slate-800 p-4"
                     >
                       <div className="flex flex-wrap items-start justify-between gap-3">
                         <div className="min-w-0 flex-1">
-                          <span className="font-heading font-semibold text-white truncate block">
+                          <span className="font-heading block truncate font-semibold text-white">
                             {project.name}
                           </span>
                           {typeof project.progress === "number" && (
                             <div className="mt-3">
                               <div className="mb-1 flex justify-between">
-                                <span className="font-mono text-xs text-slate-500">
-                                  Progress
-                                </span>
+                                <span className="font-mono text-xs text-slate-500">Progress</span>
                                 <span className="font-mono text-xs text-white">
                                   {project.progress}%
                                 </span>
                               </div>
                               <div className="h-1.5 w-full overflow-hidden rounded-full bg-slate-800">
                                 <div
-                                  className="h-full rounded-full bg-neon-blue transition-all"
+                                  className="bg-neon-blue h-full rounded-full transition-all"
                                   style={{ width: `${project.progress}%` }}
                                 />
                               </div>
                             </div>
                           )}
                         </div>
-                        <span className="font-mono shrink-0 rounded-full border border-slate-700 px-2 py-0.5 text-[10px] text-slate-400">
+                        <span className="shrink-0 rounded-full border border-slate-700 px-2 py-0.5 font-mono text-[10px] text-slate-400">
                           {project.status}
                         </span>
                       </div>
@@ -562,14 +527,14 @@ export default function PortalPage({
             {/* Invoices */}
             {data.invoices.length > 0 && (
               <section>
-                <h2 className="font-mono mb-3 text-xs uppercase tracking-widest text-slate-500">
+                <h2 className="mb-3 font-mono text-xs tracking-widest text-slate-500 uppercase">
                   Invoices
                 </h2>
                 <div className="space-y-2">
                   {data.invoices.map((inv) => (
                     <div
                       key={inv.id}
-                      className="flex flex-wrap items-center justify-between gap-3 rounded-lg border border-slate-800 bg-void-light/20 px-4 py-3"
+                      className="bg-void-light/20 flex flex-wrap items-center justify-between gap-3 rounded-lg border border-slate-800 px-4 py-3"
                     >
                       <div className="flex flex-wrap items-center gap-3">
                         <span className="font-mono text-sm text-white">
@@ -591,7 +556,7 @@ export default function PortalPage({
                             href={inv.pdfUrl}
                             target="_blank"
                             rel="noopener noreferrer"
-                            className="font-mono text-xs text-neon-blue hover:underline"
+                            className="text-neon-blue font-mono text-xs hover:underline"
                           >
                             PDF
                           </a>

--- a/src/app/portal/waiting/WaitingRoomClient.tsx
+++ b/src/app/portal/waiting/WaitingRoomClient.tsx
@@ -39,7 +39,7 @@ function SystemIndicator({ activeStep }: Readonly<{ activeStep: 1 | 2 | 3 }>) {
 
   return (
     <div className="relative mx-auto max-w-xl">
-      <div className="absolute top-5 left-[calc(16.67%+1.5rem)] right-[calc(16.67%+1.5rem)] hidden h-px bg-gradient-to-r from-neon-cyan/40 via-neon-magenta/40 to-neon-green/40 sm:block" />
+      <div className="from-neon-cyan/40 via-neon-magenta/40 to-neon-green/40 absolute top-5 right-[calc(16.67%+1.5rem)] left-[calc(16.67%+1.5rem)] hidden h-px bg-gradient-to-r sm:block" />
       <div className="relative flex flex-col gap-6 sm:flex-row sm:justify-between">
         {steps.map((s, i) => {
           const stepIndex = i + 1;
@@ -58,7 +58,7 @@ function SystemIndicator({ activeStep }: Readonly<{ activeStep: 1 | 2 | 3 }>) {
               className="relative z-10 flex flex-1 flex-col items-center text-center"
             >
               <div
-                className={`mb-3 flex h-10 w-10 items-center justify-center rounded-full border-2 bg-void font-mono text-sm font-bold ring-2 transition-all duration-500 ${colorRing} ${colorText}`}
+                className={`bg-void mb-3 flex h-10 w-10 items-center justify-center rounded-full border-2 font-mono text-sm font-bold ring-2 transition-all duration-500 ${colorRing} ${colorText}`}
               >
                 {isComplete ? (
                   <svg
@@ -68,24 +68,16 @@ function SystemIndicator({ activeStep }: Readonly<{ activeStep: 1 | 2 | 3 }>) {
                     stroke="currentColor"
                     strokeWidth={3}
                   >
-                    <path
-                      strokeLinecap="round"
-                      strokeLinejoin="round"
-                      d="M5 13l4 4L19 7"
-                    />
+                    <path strokeLinecap="round" strokeLinejoin="round" d="M5 13l4 4L19 7" />
                   </svg>
                 ) : (
                   s.num
                 )}
               </div>
-              <span className={`font-mono text-xs font-semibold ${colorText}`}>
-                {s.label}
-              </span>
+              <span className={`font-mono text-xs font-semibold ${colorText}`}>{s.label}</span>
               {isActive && (
                 <span className="mt-1 inline-flex items-center gap-1 font-mono text-[10px] text-slate-500">
-                  <span
-                    className={`h-1 w-1 animate-pulse rounded-full bg-${s.color}`}
-                  />
+                  <span className={`h-1 w-1 animate-pulse rounded-full bg-${s.color}`} />
                   In progress
                 </span>
               )}
@@ -111,9 +103,7 @@ function WaitingRoomContent() {
 
   useEffect(() => {
     if (!isLoading && !user) {
-      const next = encodeURIComponent(
-        "/portal/waiting" + (planParam ? `?plan=${planParam}` : ""),
-      );
+      const next = encodeURIComponent("/portal/waiting" + (planParam ? `?plan=${planParam}` : ""));
       router.push(`/auth/login?next=${next}`);
     }
   }, [user, isLoading, router, planParam]);
@@ -129,10 +119,7 @@ function WaitingRoomContent() {
 
         if (planParam && PLAN_LABELS[planParam] && !enrollAttempted.current) {
           enrollAttempted.current = true;
-          if (
-            me.status === "none" ||
-            (me.status === "waiting" && me.plan !== planParam)
-          ) {
+          if (me.status === "none" || (me.status === "waiting" && me.plan !== planParam)) {
             setEnrolling(true);
             const enrollRes = await fetchWithAuth("/api/portal/enroll", {
               method: "POST",
@@ -141,9 +128,7 @@ function WaitingRoomContent() {
             });
             if (!enrollRes.ok) {
               const data = await enrollRes.json().catch(() => ({}));
-              throw new Error(
-                data.error ?? `Enrollment failed (HTTP ${enrollRes.status})`,
-              );
+              throw new Error(data.error ?? `Enrollment failed (HTTP ${enrollRes.status})`);
             }
             const refreshed = await fetchWithAuth("/api/portal/me");
             setStatus(await refreshed.json());
@@ -226,9 +211,7 @@ function WaitingRoomContent() {
           <div className="flex flex-col items-center justify-center py-24">
             <div className="border-neon-cyan mb-6 h-10 w-10 animate-spin rounded-full border-2 border-t-transparent" />
             <p className="font-mono text-sm text-slate-400">
-              {enrolling
-                ? "Submitting your order..."
-                : "Loading your status..."}
+              {enrolling ? "Submitting your order..." : "Loading your status..."}
             </p>
           </div>
         )}
@@ -238,15 +221,12 @@ function WaitingRoomContent() {
             <div className="bg-neon-cyan/10 border-neon-cyan/20 mx-auto mb-6 flex h-16 w-16 items-center justify-center rounded-full border text-3xl">
               ✨
             </div>
-            <p className="font-mono text-xs uppercase tracking-[0.3em] text-neon-cyan mb-2">
+            <p className="text-neon-cyan mb-2 font-mono text-xs tracking-[0.3em] uppercase">
               [ ALL SET ]
             </p>
-            <h1 className="font-heading text-3xl font-bold text-white">
-              You&rsquo;re signed in
-            </h1>
+            <h1 className="font-heading text-3xl font-bold text-white">You&rsquo;re signed in</h1>
             <p className="mt-3 text-slate-400">
-              Pick a service or bundle to get started — your portal will be set
-              up right after.
+              Pick a service or bundle to get started — your portal will be set up right after.
             </p>
             <Link
               href="/services"
@@ -260,11 +240,7 @@ function WaitingRoomContent() {
                 stroke="currentColor"
                 strokeWidth={2}
               >
-                <path
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                  d="M1 7h12M8 2l5 5-5 5"
-                />
+                <path strokeLinecap="round" strokeLinejoin="round" d="M1 7h12M8 2l5 5-5 5" />
               </svg>
             </Link>
           </div>
@@ -280,16 +256,16 @@ function WaitingRoomContent() {
                 </span>
                 ORDER RECEIVED
               </div>
-              <h1 className="animate-fade-in-up delay-100 font-heading text-3xl leading-tight font-bold text-white md:text-4xl">
+              <h1 className="animate-fade-in-up font-heading text-3xl leading-tight font-bold text-white delay-100 md:text-4xl">
                 Welcome, {status.name || (user.email || "").split("@")[0]}.
               </h1>
-              <p className="animate-fade-in-up delay-200 mx-auto mt-4 max-w-lg text-slate-400">
-                Your project manager has been notified. We&rsquo;ll prepare your
-                personalized portal and email you the moment it&rsquo;s ready.
+              <p className="animate-fade-in-up mx-auto mt-4 max-w-lg text-slate-400 delay-200">
+                Your project manager has been notified. We&rsquo;ll prepare your personalized portal
+                and email you the moment it&rsquo;s ready.
               </p>
             </div>
 
-            <div className="rounded-2xl border border-slate-800 bg-void-light/30 p-8 backdrop-blur-sm">
+            <div className="bg-void-light/30 rounded-2xl border border-slate-800 p-8 backdrop-blur-sm">
               <p className="mb-7 text-center font-mono text-[10px] tracking-[0.3em] text-slate-500">
                 [ HOW IT WORKS ]
               </p>
@@ -337,24 +313,20 @@ function WaitingRoomContent() {
               ].map((item) => (
                 <div
                   key={item.title}
-                  className="rounded-xl border border-slate-800 bg-void-light/20 p-5 backdrop-blur-sm transition-all hover:border-slate-700"
+                  className="bg-void-light/20 rounded-xl border border-slate-800 p-5 backdrop-blur-sm transition-all hover:border-slate-700"
                 >
                   <div
                     className={`bg-${item.color}/10 border-${item.color}/20 mb-3 flex h-9 w-9 items-center justify-center rounded-lg border text-base`}
                   >
                     {item.icon}
                   </div>
-                  <h3 className="font-heading text-sm font-semibold text-white">
-                    {item.title}
-                  </h3>
-                  <p className="mt-1.5 text-xs leading-relaxed text-slate-500">
-                    {item.desc}
-                  </p>
+                  <h3 className="font-heading text-sm font-semibold text-white">{item.title}</h3>
+                  <p className="mt-1.5 text-xs leading-relaxed text-slate-500">{item.desc}</p>
                 </div>
               ))}
             </div>
 
-            <div className="rounded-xl border border-slate-800/50 bg-void-light/10 px-5 py-4 text-center backdrop-blur-sm">
+            <div className="bg-void-light/10 rounded-xl border border-slate-800/50 px-5 py-4 text-center backdrop-blur-sm">
               <p className="flex items-center justify-center gap-2 font-mono text-xs text-slate-500">
                 <span className="bg-neon-green h-1.5 w-1.5 animate-pulse rounded-full" />
                 Watching for portal — this page refreshes automatically
@@ -367,24 +339,20 @@ function WaitingRoomContent() {
           <div className="space-y-10 text-center">
             <div>
               <div className="relative mx-auto mb-6 flex h-24 w-24 items-center justify-center">
-                <span className="absolute inline-flex h-full w-full animate-ping rounded-full bg-neon-green/30 opacity-75" />
+                <span className="bg-neon-green/30 absolute inline-flex h-full w-full animate-ping rounded-full opacity-75" />
                 <span className="bg-neon-green/15 border-neon-green/50 relative inline-flex h-24 w-24 items-center justify-center rounded-full border-2">
                   <svg
-                    className="h-10 w-10 text-neon-green"
+                    className="text-neon-green h-10 w-10"
                     fill="none"
                     viewBox="0 0 24 24"
                     stroke="currentColor"
                     strokeWidth={3}
                   >
-                    <path
-                      strokeLinecap="round"
-                      strokeLinejoin="round"
-                      d="M5 13l4 4L19 7"
-                    />
+                    <path strokeLinecap="round" strokeLinejoin="round" d="M5 13l4 4L19 7" />
                   </svg>
                 </span>
               </div>
-              <p className="font-mono text-xs uppercase tracking-[0.3em] text-neon-green mb-3">
+              <p className="text-neon-green mb-3 font-mono text-xs tracking-[0.3em] uppercase">
                 [ PORTAL READY ]
               </p>
               <h1 className="font-heading text-3xl font-bold text-white md:text-4xl">
@@ -397,7 +365,7 @@ function WaitingRoomContent() {
               </p>
             </div>
 
-            <div className="rounded-2xl border border-slate-800 bg-void-light/30 p-8 backdrop-blur-sm">
+            <div className="bg-void-light/30 rounded-2xl border border-slate-800 p-8 backdrop-blur-sm">
               <SystemIndicator activeStep={3} />
             </div>
 
@@ -414,11 +382,7 @@ function WaitingRoomContent() {
                   stroke="currentColor"
                   strokeWidth={2}
                 >
-                  <path
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                    d="M1 7h12M8 2l5 5-5 5"
-                  />
+                  <path strokeLinecap="round" strokeLinejoin="round" d="M1 7h12M8 2l5 5-5 5" />
                 </svg>
               </a>
             )}

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -3,10 +3,7 @@ import { readFileSync } from "fs";
 import { join } from "path";
 import { posts } from "@/lib/blog";
 import { defaultProducts } from "@/lib/store-products";
-import {
-  getCaseStudies,
-  staticCaseStudies,
-} from "@/lib/notion-case-studies";
+import { getCaseStudies, staticCaseStudies } from "@/lib/notion-case-studies";
 import { isConfiguredAsync } from "@/lib/integrations";
 
 // Render sitemap.xml on each request rather than baking it at build time so
@@ -93,22 +90,17 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
   // Products don't carry an individual last-modified date; share the
   // catalogue date so it only resets when the catalogue is actually updated
   const catalogueDate = new Date(LAST_MODIFIED["/store/products"]);
-  const productPages: MetadataRoute.Sitemap = defaultProducts.map(
-    (product) => ({
-      url: `${baseUrl}/store/${product.id}`,
-      lastModified: catalogueDate,
-      changeFrequency: "monthly" as const,
-      priority: 0.5,
-    }),
-  );
+  const productPages: MetadataRoute.Sitemap = defaultProducts.map((product) => ({
+    url: `${baseUrl}/store/${product.id}`,
+    lastModified: catalogueDate,
+    changeFrequency: "monthly" as const,
+    priority: 0.5,
+  }));
 
   // Case studies (Notion-backed with static fallback)
   let caseStudyList = staticCaseStudies;
   try {
-    const configured = await isConfiguredAsync(
-      "NOTION_API_KEY",
-      "NOTION_CASE_STUDIES_DB_ID",
-    );
+    const configured = await isConfiguredAsync("NOTION_API_KEY", "NOTION_CASE_STUDIES_DB_ID");
     if (configured) caseStudyList = await getCaseStudies();
   } catch {
     // fall back to static list

--- a/src/app/theme-v2.css
+++ b/src/app/theme-v2.css
@@ -62,15 +62,13 @@
   /* Shadows — light-mode-visible elevation */
   --shadow-sm: 0 1px 2px rgb(15 24 34 / 0.04), 0 1px 1px rgb(15 24 34 / 0.06);
   --shadow-md: 0 4px 12px rgb(15 24 34 / 0.06), 0 2px 4px rgb(15 24 34 / 0.04);
-  --shadow-lg:
-    0 12px 32px rgb(15 24 34 / 0.08), 0 6px 12px rgb(15 24 34 / 0.06);
+  --shadow-lg: 0 12px 32px rgb(15 24 34 / 0.08), 0 6px 12px rgb(15 24 34 / 0.06);
 
   /* Hero gradient mesh (sky → mist → off-white) */
   --gradient-hero:
     radial-gradient(circle at 20% 0%, #d6f0f6 0%, transparent 50%),
     radial-gradient(circle at 80% 10%, #e3e9ff 0%, transparent 50%),
-    radial-gradient(circle at 50% 100%, #fbf8ff 0%, transparent 60%),
-    var(--surface-canvas);
+    radial-gradient(circle at 50% 100%, #fbf8ff 0%, transparent 60%), var(--surface-canvas);
 }
 
 /* ──────────────────────────────────────────────────────────────────
@@ -121,21 +119,9 @@
 
   /* Hero gradient mesh (deep navy + faint cyan/indigo) */
   --gradient-hero:
-    radial-gradient(
-      circle at 20% 0%,
-      rgb(34 211 230 / 0.08) 0%,
-      transparent 50%
-    ),
-    radial-gradient(
-      circle at 80% 10%,
-      rgb(99 102 241 / 0.08) 0%,
-      transparent 50%
-    ),
-    radial-gradient(
-      circle at 50% 100%,
-      rgb(168 85 247 / 0.04) 0%,
-      transparent 60%
-    ),
+    radial-gradient(circle at 20% 0%, rgb(34 211 230 / 0.08) 0%, transparent 50%),
+    radial-gradient(circle at 80% 10%, rgb(99 102 241 / 0.08) 0%, transparent 50%),
+    radial-gradient(circle at 50% 100%, rgb(168 85 247 / 0.04) 0%, transparent 60%),
     var(--surface-canvas);
 }
 
@@ -170,21 +156,9 @@
     --shadow-md: 0 4px 12px rgb(0 0 0 / 0.35);
     --shadow-lg: 0 12px 32px rgb(0 0 0 / 0.45);
     --gradient-hero:
-      radial-gradient(
-        circle at 20% 0%,
-        rgb(34 211 230 / 0.08) 0%,
-        transparent 50%
-      ),
-      radial-gradient(
-        circle at 80% 10%,
-        rgb(99 102 241 / 0.08) 0%,
-        transparent 50%
-      ),
-      radial-gradient(
-        circle at 50% 100%,
-        rgb(168 85 247 / 0.04) 0%,
-        transparent 60%
-      ),
+      radial-gradient(circle at 20% 0%, rgb(34 211 230 / 0.08) 0%, transparent 50%),
+      radial-gradient(circle at 80% 10%, rgb(99 102 241 / 0.08) 0%, transparent 50%),
+      radial-gradient(circle at 50% 100%, rgb(168 85 247 / 0.04) 0%, transparent 60%),
       var(--surface-canvas);
   }
 }
@@ -359,11 +333,7 @@
 
 /* Mobile tap highlight — accent-soft instead of high-saturation cyan. */
 [data-theme="light"] {
-  -webkit-tap-highlight-color: color-mix(
-    in srgb,
-    var(--accent) 18%,
-    transparent
-  );
+  -webkit-tap-highlight-color: color-mix(in srgb, var(--accent) 18%, transparent);
 }
 
 /* Selection — calmer accent on light. */
@@ -585,10 +555,6 @@
   [data-theme="light"] button,
   [data-theme="light"] [role="button"],
   [data-theme="light"] summary {
-    -webkit-tap-highlight-color: color-mix(
-      in srgb,
-      var(--accent) 18%,
-      transparent
-    );
+    -webkit-tap-highlight-color: color-mix(in srgb, var(--accent) 18%, transparent);
   }
 }

--- a/src/app/twitter-image.tsx
+++ b/src/app/twitter-image.tsx
@@ -16,8 +16,7 @@ export default function TwitterImage() {
         flexDirection: "column",
         justifyContent: "center",
         padding: "60px 80px",
-        background:
-          "linear-gradient(135deg, #0F172A 0%, #1E293B 50%, #0F172A 100%)",
+        background: "linear-gradient(135deg, #0F172A 0%, #1E293B 50%, #0F172A 100%)",
         fontFamily: "system-ui, sans-serif",
         position: "relative",
         overflow: "hidden",
@@ -108,8 +107,7 @@ export default function TwitterImage() {
           display: "flex",
         }}
       >
-        Cloud architecture, serverless, analytics & AI marketing for startups
-        and SMBs.
+        Cloud architecture, serverless, analytics & AI marketing for startups and SMBs.
       </div>
 
       {/* Brand */}
@@ -134,6 +132,6 @@ export default function TwitterImage() {
         </div>
       </div>
     </div>,
-    { ...size },
+    { ...size }
   );
 }

--- a/src/components/ChatWidget.tsx
+++ b/src/components/ChatWidget.tsx
@@ -48,10 +48,7 @@ export default function ChatWidget() {
     setMessages((prev) => {
       const last = prev.at(-1);
       if (!last) return prev;
-      return [
-        ...prev.slice(0, -1),
-        { id: last.id, role: "assistant", content },
-      ];
+      return [...prev.slice(0, -1), { id: last.id, role: "assistant", content }];
     });
   }
 
@@ -66,9 +63,7 @@ export default function ChatWidget() {
     });
   }
 
-  async function consumeStream(
-    reader: ReadableStreamDefaultReader<Uint8Array>,
-  ) {
+  async function consumeStream(reader: ReadableStreamDefaultReader<Uint8Array>) {
     const decoder = new TextDecoder();
     let buffer = "";
     while (true) {
@@ -107,10 +102,7 @@ export default function ChatWidget() {
     setMessages(next);
     setInput("");
     setStreaming(true);
-    setMessages((prev) => [
-      ...prev,
-      { id: newId(), role: "assistant", content: "" },
-    ]);
+    setMessages((prev) => [...prev, { id: newId(), role: "assistant", content: "" }]);
 
     try {
       const res = await fetch("/api/chat", {
@@ -120,9 +112,7 @@ export default function ChatWidget() {
       });
 
       if (!res.ok || !res.body) {
-        replaceLastAssistant(
-          "Sorry, I'm unavailable right now. Please use the Contact page.",
-        );
+        replaceLastAssistant("Sorry, I'm unavailable right now. Please use the Contact page.");
         return;
       }
 
@@ -148,24 +138,22 @@ export default function ChatWidget() {
         type="button"
         aria-label={open ? "Close chat" : "Open chat assistant"}
         onClick={() => setOpen((o) => !o)}
-        className="fixed bottom-6 right-6 z-50 flex h-14 w-14 items-center justify-center rounded-full border border-neon-green/30 bg-void shadow-lg shadow-neon-green/10 transition-all hover:border-neon-green/60 hover:shadow-neon-green/20"
+        className="border-neon-green/30 bg-void shadow-neon-green/10 hover:border-neon-green/60 hover:shadow-neon-green/20 fixed right-6 bottom-6 z-50 flex h-14 w-14 items-center justify-center rounded-full border shadow-lg transition-all"
       >
         <span className="text-xl">{open ? "✕" : "💬"}</span>
       </button>
 
       {/* Chat panel */}
       {open && (
-        <div className="fixed bottom-24 right-6 z-50 flex w-80 flex-col overflow-hidden rounded-2xl border border-slate-800 bg-void shadow-2xl sm:w-96">
+        <div className="bg-void fixed right-6 bottom-24 z-50 flex w-80 flex-col overflow-hidden rounded-2xl border border-slate-800 shadow-2xl sm:w-96">
           {/* Header */}
-          <div className="flex items-center gap-3 border-b border-slate-800 bg-void-light px-4 py-3">
-            <span className="h-2.5 w-2.5 animate-pulse rounded-full bg-neon-green" />
+          <div className="bg-void-light flex items-center gap-3 border-b border-slate-800 px-4 py-3">
+            <span className="bg-neon-green h-2.5 w-2.5 animate-pulse rounded-full" />
             <div>
               <div className="font-heading text-sm font-semibold text-white">
                 Cloudless Assistant
               </div>
-              <div className="font-mono text-xs text-slate-500">
-                Powered by Claude
-              </div>
+              <div className="font-mono text-xs text-slate-500">Powered by Claude</div>
             </div>
           </div>
 
@@ -177,9 +165,9 @@ export default function ChatWidget() {
                 className={`flex ${m.role === "user" ? "justify-end" : "justify-start"}`}
               >
                 <div
-                  className={`max-w-[85%] rounded-xl px-3 py-2 font-body text-sm leading-relaxed ${
+                  className={`font-body max-w-[85%] rounded-xl px-3 py-2 text-sm leading-relaxed ${
                     m.role === "user"
-                      ? "bg-neon-green/10 border border-neon-green/20 text-white"
+                      ? "bg-neon-green/10 border-neon-green/20 border text-white"
                       : "bg-void-light border border-slate-800 text-slate-300"
                   }`}
                 >
@@ -214,7 +202,7 @@ export default function ChatWidget() {
                   key={s}
                   type="button"
                   onClick={() => send(s)}
-                  className="rounded-full border border-slate-700 px-3 py-1 font-mono text-xs text-slate-400 transition hover:border-neon-green/40 hover:text-white"
+                  className="hover:border-neon-green/40 rounded-full border border-slate-700 px-3 py-1 font-mono text-xs text-slate-400 transition hover:text-white"
                 >
                   {s}
                 </button>
@@ -223,7 +211,7 @@ export default function ChatWidget() {
           )}
 
           {/* Input */}
-          <div className="flex items-center gap-2 border-t border-slate-800 bg-void-light px-3 py-3">
+          <div className="bg-void-light flex items-center gap-2 border-t border-slate-800 px-3 py-3">
             <input
               ref={inputRef}
               type="text"
@@ -239,7 +227,7 @@ export default function ChatWidget() {
               type="button"
               onClick={() => send(input)}
               disabled={!input.trim() || streaming}
-              className="shrink-0 rounded-lg border border-neon-green/30 px-3 py-1.5 font-mono text-xs text-neon-green transition hover:border-neon-green/60 disabled:opacity-30"
+              className="border-neon-green/30 text-neon-green hover:border-neon-green/60 shrink-0 rounded-lg border px-3 py-1.5 font-mono text-xs transition disabled:opacity-30"
             >
               Send
             </button>

--- a/src/components/ChunkReloadGuard.tsx
+++ b/src/components/ChunkReloadGuard.tsx
@@ -43,7 +43,7 @@ export default function ChunkReloadGuard() {
     // Once the page has been stable for 10s, allow a future recovery reload.
     const clearTimer = globalThis.setTimeout(
       () => sessionStorage.removeItem(CHUNK_RELOAD_FLAG),
-      10_000,
+      10_000
     );
 
     return () => {

--- a/src/components/ClientDecorators.tsx
+++ b/src/components/ClientDecorators.tsx
@@ -3,10 +3,7 @@
 import dynamic from "next/dynamic";
 import ThemePreferenceSync from "@/components/ThemePreferenceSync";
 
-const LenisInitializer = dynamic(
-  () => import("@/components/LenisInitializer"),
-  { ssr: false },
-);
+const LenisInitializer = dynamic(() => import("@/components/LenisInitializer"), { ssr: false });
 const CommandPalette = dynamic(() => import("@/components/CommandPalette"), {
   ssr: false,
 });

--- a/src/components/CloudMark.tsx
+++ b/src/components/CloudMark.tsx
@@ -29,9 +29,7 @@ export default function CloudMark({
 }: CloudMarkProps) {
   const ariaLabel = rest["aria-label"];
   const role = ariaLabel ? "img" : "presentation";
-  const labelProps = ariaLabel
-    ? { "aria-label": ariaLabel, role }
-    : { "aria-hidden": true };
+  const labelProps = ariaLabel ? { "aria-label": ariaLabel, role } : { "aria-hidden": true };
 
   return (
     <svg

--- a/src/components/CommandPalette.tsx
+++ b/src/components/CommandPalette.tsx
@@ -78,9 +78,7 @@ export default function CommandPalette() {
                   onSelect={() => navigate(item.path)}
                   className="data-[selected=true]:bg-neon-cyan/10 data-[selected=true]:text-neon-cyan flex cursor-pointer items-center gap-3 rounded-lg px-3 py-2.5 font-mono text-sm text-slate-400 transition-colors"
                 >
-                  <span className="text-neon-cyan/40 w-4 text-center text-xs">
-                    {item.icon}
-                  </span>
+                  <span className="text-neon-cyan/40 w-4 text-center text-xs">{item.icon}</span>
                   {item.label}
                 </Command.Item>
               ))}
@@ -96,9 +94,7 @@ export default function CommandPalette() {
                   onSelect={() => navigate(item.path)}
                   className="data-[selected=true]:bg-neon-magenta/10 data-[selected=true]:text-neon-magenta flex cursor-pointer items-center gap-3 rounded-lg px-3 py-2.5 font-mono text-sm text-slate-400 transition-colors"
                 >
-                  <span className="text-neon-magenta/40 w-4 text-center text-xs">
-                    {item.icon}
-                  </span>
+                  <span className="text-neon-magenta/40 w-4 text-center text-xs">{item.icon}</span>
                   {item.label}
                 </Command.Item>
               ))}

--- a/src/components/ContactFormSection.tsx
+++ b/src/components/ContactFormSection.tsx
@@ -21,9 +21,7 @@ const serviceOptions = [
 export default function ContactFormSection() {
   const [locale] = useCurrentLocale();
   const t = (key: string, fallback: string) => translate(locale, key, fallback);
-  const [status, setStatus] = useState<"idle" | "sending" | "sent" | "error">(
-    "idle",
-  );
+  const [status, setStatus] = useState<"idle" | "sending" | "sent" | "error">("idle");
 
   async function handleSubmit(e: FormEvent<HTMLFormElement>) {
     e.preventDefault();
@@ -35,8 +33,7 @@ export default function ContactFormSection() {
       email: (form.elements.namedItem("email") as HTMLInputElement).value,
       company: (form.elements.namedItem("company") as HTMLInputElement).value,
       service: (form.elements.namedItem("service") as HTMLSelectElement).value,
-      message: (form.elements.namedItem("message") as HTMLTextAreaElement)
-        .value,
+      message: (form.elements.namedItem("message") as HTMLTextAreaElement).value,
     };
 
     try {
@@ -51,11 +48,7 @@ export default function ContactFormSection() {
         } | null;
         // Browser-side Lead event with the same eventId the server sent to CAPI.
         // No-ops if the pixel is not loaded.
-        trackPixelEvent(
-          "Lead",
-          { content_name: payload.service || "contact_form" },
-          data?.eventId,
-        );
+        trackPixelEvent("Lead", { content_name: payload.service || "contact_form" }, data?.eventId);
         setStatus("sent");
         form.reset();
       } else {
@@ -75,16 +68,14 @@ export default function ContactFormSection() {
             {status === "sent" ? (
               <ScrollReveal>
                 <div className="neon-border bg-void-light rounded-lg p-10 text-center">
-                  <div className="text-neon-cyan mb-4 font-mono text-4xl">
-                    ✓
-                  </div>
+                  <div className="text-neon-cyan mb-4 font-mono text-4xl">✓</div>
                   <h2 className="font-heading text-2xl font-bold text-white">
                     {t("contact.success", "Message sent successfully!")}
                   </h2>
                   <p className="mt-2 text-slate-400">
                     {t(
                       "contact.subtitle",
-                      "Ready to go cloudless? Tell us about your project and we'll get back to you within 24 hours.",
+                      "Ready to go cloudless? Tell us about your project and we'll get back to you within 24 hours."
                     )}
                   </p>
                   <button
@@ -202,12 +193,9 @@ export default function ContactFormSection() {
                   >
                     {t(
                       "contact.privacyConsent",
-                      "I agree that my data will be processed to respond to my enquiry, as described in the",
+                      "I agree that my data will be processed to respond to my enquiry, as described in the"
                     )}{" "}
-                    <Link
-                      href="/privacy"
-                      className="text-neon-cyan underline underline-offset-2"
-                    >
+                    <Link href="/privacy" className="text-neon-cyan underline underline-offset-2">
                       {t("legal.privacyTitle", "Privacy Policy")}
                     </Link>
                     . *
@@ -215,16 +203,9 @@ export default function ContactFormSection() {
                 </div>
 
                 {status === "error" && (
-                  <p
-                    role="alert"
-                    className="text-neon-magenta font-mono text-sm"
-                  >
-                    Something went wrong. Please try again or email us directly
-                    at{" "}
-                    <a
-                      href="mailto:tbaltzakis@cloudless.gr"
-                      className="text-neon-cyan underline"
-                    >
+                  <p role="alert" className="text-neon-magenta font-mono text-sm">
+                    Something went wrong. Please try again or email us directly at{" "}
+                    <a href="mailto:tbaltzakis@cloudless.gr" className="text-neon-cyan underline">
                       tbaltzakis@cloudless.gr
                     </a>
                   </p>
@@ -247,9 +228,7 @@ export default function ContactFormSection() {
           <div className="space-y-8 lg:col-span-2">
             <ScrollReveal>
               <div className="neon-border bg-void-light/50 rounded-lg p-8">
-                <h3 className="font-heading text-lg font-bold text-white">
-                  What happens next?
-                </h3>
+                <h3 className="font-heading text-lg font-bold text-white">What happens next?</h3>
                 <ol className="mt-4 space-y-4 text-sm text-slate-400">
                   {[
                     "We review your message and get back within 24 hours.",
@@ -269,9 +248,7 @@ export default function ContactFormSection() {
 
             <ScrollReveal delay={100}>
               <div className="neon-border bg-void-light/50 rounded-lg p-8">
-                <h3 className="font-heading text-lg font-bold text-white">
-                  Direct Contact
-                </h3>
+                <h3 className="font-heading text-lg font-bold text-white">Direct Contact</h3>
                 <div className="mt-4 space-y-3 font-mono text-sm">
                   <p>
                     <span className="text-xs text-slate-500">EMAIL:</span>{" "}
@@ -288,9 +265,7 @@ export default function ContactFormSection() {
                   </p>
                   <p>
                     <span className="text-xs text-slate-500">RESPONSE:</span>{" "}
-                    <span className="text-xs text-slate-400">
-                      Within 24 hours
-                    </span>
+                    <span className="text-xs text-slate-400">Within 24 hours</span>
                   </p>
                 </div>
 

--- a/src/components/CookieConsent.tsx
+++ b/src/components/CookieConsent.tsx
@@ -2,10 +2,7 @@
 
 import { useState, useEffect, useRef, useCallback } from "react";
 import { Link } from "@/i18n/navigation";
-import {
-  useCookieConsent,
-  type CookiePreferences,
-} from "@/context/CookieConsentContext";
+import { useCookieConsent, type CookiePreferences } from "@/context/CookieConsentContext";
 import { translate } from "@/lib/i18n";
 import { useCurrentLocale } from "@/lib/use-locale";
 
@@ -73,7 +70,7 @@ export default function CookieConsent() {
 
       if (e.key === "Tab" && modalRef.current) {
         const focusable = modalRef.current.querySelectorAll<HTMLElement>(
-          'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])',
+          'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])'
         );
         if (focusable.length === 0) return;
 
@@ -96,7 +93,7 @@ export default function CookieConsent() {
     requestAnimationFrame(() => {
       if (modalRef.current) {
         const first = modalRef.current.querySelector<HTMLElement>(
-          'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])',
+          'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])'
         );
         first?.focus();
       }
@@ -115,18 +112,15 @@ export default function CookieConsent() {
         role="dialog"
         aria-modal="true"
         aria-labelledby="cookie-settings-title"
-        className="border-slate-800 bg-void-light mx-4 w-full max-w-lg rounded-xl border p-6 shadow-2xl"
+        className="bg-void-light mx-4 w-full max-w-lg rounded-xl border border-slate-800 p-6 shadow-2xl"
       >
-        <h3
-          id="cookie-settings-title"
-          className="mb-4 font-heading text-lg font-bold text-white"
-        >
+        <h3 id="cookie-settings-title" className="font-heading mb-4 text-lg font-bold text-white">
           {t("cookies.settingsTitle", "Cookie Preferences")}
         </h3>
         <p className="mb-6 text-sm text-slate-400">
           {t(
             "cookies.settingsDesc",
-            "Choose which cookies you'd like to allow. Necessary cookies are required for the site to function and cannot be disabled.",
+            "Choose which cookies you'd like to allow. Necessary cookies are required for the site to function and cannot be disabled."
           )}
         </p>
 
@@ -134,13 +128,11 @@ export default function CookieConsent() {
         <div className="mb-4 rounded-lg border border-slate-700 p-4">
           <div className={FLEX_BETWEEN}>
             <div>
-              <p className={CATEGORY_TITLE_CLASS}>
-                {t("cookies.necessary", "Necessary")}
-              </p>
+              <p className={CATEGORY_TITLE_CLASS}>{t("cookies.necessary", "Necessary")}</p>
               <p className={HELP_TEXT_CLASS}>
                 {t(
                   "cookies.necessaryDesc",
-                  "Essential for the website to function. Includes session cookies, security tokens, and consent preferences.",
+                  "Essential for the website to function. Includes session cookies, security tokens, and consent preferences."
                 )}
               </p>
             </div>
@@ -154,13 +146,11 @@ export default function CookieConsent() {
         <div className="mb-4 rounded-lg border border-slate-700 p-4">
           <div className={FLEX_BETWEEN}>
             <div className="mr-4">
-              <p className={CATEGORY_TITLE_CLASS}>
-                {t("cookies.analytics", "Analytics")}
-              </p>
+              <p className={CATEGORY_TITLE_CLASS}>{t("cookies.analytics", "Analytics")}</p>
               <p className={HELP_TEXT_CLASS}>
                 {t(
                   "cookies.analyticsDesc",
-                  "Help us understand how visitors use our site so we can improve the experience. Data is anonymised.",
+                  "Help us understand how visitors use our site so we can improve the experience. Data is anonymised."
                 )}
               </p>
             </div>
@@ -169,9 +159,7 @@ export default function CookieConsent() {
               role="switch"
               aria-checked={localPrefs.analytics}
               aria-label={t("cookies.analytics", "Analytics") + " cookies"}
-              onClick={() =>
-                setLocalPrefs((p) => ({ ...p, analytics: !p.analytics }))
-              }
+              onClick={() => setLocalPrefs((p) => ({ ...p, analytics: !p.analytics }))}
               className={`relative h-8 w-12 shrink-0 rounded-full transition-colors ${
                 localPrefs.analytics ? "bg-neon-cyan/60" : "bg-slate-700"
               }`}
@@ -189,13 +177,11 @@ export default function CookieConsent() {
         <div className="mb-6 rounded-lg border border-slate-700 p-4">
           <div className={FLEX_BETWEEN}>
             <div className="mr-4">
-              <p className={CATEGORY_TITLE_CLASS}>
-                {t("cookies.marketing", "Marketing")}
-              </p>
+              <p className={CATEGORY_TITLE_CLASS}>{t("cookies.marketing", "Marketing")}</p>
               <p className={HELP_TEXT_CLASS}>
                 {t(
                   "cookies.marketingDesc",
-                  "Used to deliver relevant ads and track campaign effectiveness across platforms.",
+                  "Used to deliver relevant ads and track campaign effectiveness across platforms."
                 )}
               </p>
             </div>
@@ -204,9 +190,7 @@ export default function CookieConsent() {
               role="switch"
               aria-checked={localPrefs.marketing}
               aria-label={t("cookies.marketing", "Marketing") + " cookies"}
-              onClick={() =>
-                setLocalPrefs((p) => ({ ...p, marketing: !p.marketing }))
-              }
+              onClick={() => setLocalPrefs((p) => ({ ...p, marketing: !p.marketing }))}
               className={`relative h-8 w-12 shrink-0 rounded-full transition-colors ${
                 localPrefs.marketing ? "bg-neon-cyan/60" : "bg-slate-700"
               }`}
@@ -262,16 +246,16 @@ export default function CookieConsent() {
           role="region"
           aria-label={t("cookies.bannerTitle", "We value your privacy")}
         >
-          <div className="border-slate-800 bg-void-light/95 mx-auto max-w-4xl rounded-xl border p-6 shadow-2xl backdrop-blur-xl">
+          <div className="bg-void-light/95 mx-auto max-w-4xl rounded-xl border border-slate-800 p-6 shadow-2xl backdrop-blur-xl">
             <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:gap-6">
               <div className="flex-1">
-                <h3 className="mb-2 font-heading text-sm font-bold text-white">
+                <h3 className="font-heading mb-2 text-sm font-bold text-white">
                   {t("cookies.bannerTitle", "We value your privacy")}
                 </h3>
                 <p className="text-xs leading-relaxed text-slate-400">
                   {t(
                     "cookies.bannerDesc",
-                    "We use cookies to improve your experience, analyse traffic, and personalise content. You can accept all cookies, reject optional ones, or customise your preferences.",
+                    "We use cookies to improve your experience, analyse traffic, and personalise content. You can accept all cookies, reject optional ones, or customise your preferences."
                   )}{" "}
                   <Link href="/cookies" className="text-neon-cyan underline">
                     {t("cookies.learnMore", "Learn more about cookies")}

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -26,16 +26,12 @@ export default function Footer() {
               <Logo variant="wordmark" size="sm" />
             </Link>
             <p className="mt-3 text-sm leading-relaxed text-slate-400">
-              {translate(
-                locale,
-                "footer.tagline",
-                "Clear skies. Zero friction.",
-              )}
+              {translate(locale, "footer.tagline", "Clear skies. Zero friction.")}
               <br />
               {translate(
                 locale,
                 "footer.description",
-                "Cloud architecture, serverless, data analytics & AI marketing for startups and SMBs.",
+                "Cloud architecture, serverless, data analytics & AI marketing for startups and SMBs."
               )}
             </p>
           </div>
@@ -164,7 +160,7 @@ export default function Footer() {
             {translate(
               locale,
               "footer.trainingNotice",
-              "This website is a training and portfolio project built for educational purposes only. It is not a commercial service and does not accept clients.",
+              "This website is a training and portfolio project built for educational purposes only. It is not a commercial service and does not accept clients."
             )}
           </p>
         </div>
@@ -175,11 +171,7 @@ export default function Footer() {
             {translate(locale, "footer.rightsReserved", "All rights reserved.")}
           </p>
           <p className="text-slate-400">
-            {translate(
-              locale,
-              "footer.builtWith",
-              "Built with Next.js & deployed on AWS",
-            )}
+            {translate(locale, "footer.builtWith", "Built with Next.js & deployed on AWS")}
           </p>
         </div>
       </div>

--- a/src/components/GoogleAnalyticsConsent.tsx
+++ b/src/components/GoogleAnalyticsConsent.tsx
@@ -21,8 +21,7 @@ export default function GoogleAnalyticsConsent() {
   const { preferences } = useCookieConsent();
 
   useEffect(() => {
-    if (typeof window === "undefined" || typeof window.gtag !== "function")
-      return;
+    if (typeof window === "undefined" || typeof window.gtag !== "function") return;
     window.gtag("consent", "update", {
       analytics_storage: preferences.analytics ? "granted" : "denied",
       ad_storage: preferences.marketing ? "granted" : "denied",

--- a/src/components/HolographicCard.tsx
+++ b/src/components/HolographicCard.tsx
@@ -7,10 +7,7 @@ interface HolographicCardProps {
   className?: string;
 }
 
-export default function HolographicCard({
-  children,
-  className = "",
-}: HolographicCardProps) {
+export default function HolographicCard({ children, className = "" }: HolographicCardProps) {
   const cardRef = useRef<HTMLDivElement>(null);
   const [style, setStyle] = useState<React.CSSProperties>({});
   const [glare, setGlare] = useState<React.CSSProperties>({});
@@ -43,8 +40,7 @@ export default function HolographicCard({
 
   const handleMouseLeave = useCallback(() => {
     setStyle({
-      transform:
-        "perspective(800px) rotateX(0deg) rotateY(0deg) scale3d(1, 1, 1)",
+      transform: "perspective(800px) rotateX(0deg) rotateY(0deg) scale3d(1, 1, 1)",
       transition: "transform 0.5s ease-out",
     });
     setGlare({ opacity: 0 });

--- a/src/components/KonamiEasterEgg.tsx
+++ b/src/components/KonamiEasterEgg.tsx
@@ -37,10 +37,9 @@ const MATRIX_TIMING_CLASS_NAMES = [
 // Precompute random animation data outside render to satisfy react-hooks/purity
 const MATRIX_RAIN_DATA = Array.from({ length: 20 }, (_, index) => ({
   columnClassName: MATRIX_COLUMN_CLASS_NAMES[index],
-  timingClassName:
-    MATRIX_TIMING_CLASS_NAMES[index % MATRIX_TIMING_CLASS_NAMES.length],
+  timingClassName: MATRIX_TIMING_CLASS_NAMES[index % MATRIX_TIMING_CLASS_NAMES.length],
   chars: Array.from({ length: 30 }, () =>
-    String.fromCharCode(0x30a0 + Math.floor(Math.random() * 96)),
+    String.fromCharCode(0x30a0 + Math.floor(Math.random() * 96))
   ).join("\n"),
 }));
 
@@ -76,7 +75,7 @@ export default function KonamiEasterEgg() {
         setIndex(0);
       }
     },
-    [index],
+    [index]
   );
 
   useEffect(() => {

--- a/src/components/LocaleSwitcher.tsx
+++ b/src/components/LocaleSwitcher.tsx
@@ -20,10 +20,7 @@ export default function LocaleSwitcher() {
   useEffect(() => {
     if (!isOpen) return;
     function handleClickOutside(e: MouseEvent) {
-      if (
-        containerRef.current &&
-        !containerRef.current.contains(e.target as Node)
-      ) {
+      if (containerRef.current && !containerRef.current.contains(e.target as Node)) {
         setIsOpen(false);
       }
     }
@@ -64,12 +61,7 @@ export default function LocaleSwitcher() {
           stroke="currentColor"
           viewBox="0 0 24 24"
         >
-          <path
-            strokeLinecap="round"
-            strokeLinejoin="round"
-            strokeWidth={2}
-            d="M19 9l-7 7-7-7"
-          />
+          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
         </svg>
       </button>
 
@@ -91,9 +83,7 @@ export default function LocaleSwitcher() {
                 aria-label={`Set language to ${localeLabels[locale]}`}
                 className="hover:bg-neon-cyan/10 active:bg-neon-cyan/20 bg-neon-cyan/10 text-neon-cyan min-h-11 w-full px-4 py-2.5 text-left text-sm font-medium transition-colors"
               >
-                <span className="mr-2 font-mono text-xs opacity-60">
-                  {localeFlags[locale]}
-                </span>
+                <span className="mr-2 font-mono text-xs opacity-60">{localeFlags[locale]}</span>
                 {localeLabels[locale]}
               </button>
             ) : (
@@ -106,12 +96,10 @@ export default function LocaleSwitcher() {
                 aria-label={`Set language to ${localeLabels[locale]}`}
                 className="hover:bg-neon-cyan/10 active:bg-neon-cyan/20 min-h-11 w-full px-4 py-2.5 text-left text-sm text-slate-300 transition-colors"
               >
-                <span className="mr-2 font-mono text-xs opacity-60">
-                  {localeFlags[locale]}
-                </span>
+                <span className="mr-2 font-mono text-xs opacity-60">{localeFlags[locale]}</span>
                 {localeLabels[locale]}
               </button>
-            ),
+            )
           )}
         </div>
       )}

--- a/src/components/Logo.tsx
+++ b/src/components/Logo.tsx
@@ -26,28 +26,15 @@ const SIZES = {
   lg: { mark: 32, text: "text-2xl" },
 };
 
-export default function Logo({
-  variant = "wordmark",
-  size = "md",
-  className = "",
-}: LogoProps) {
+export default function Logo({ variant = "wordmark", size = "md", className = "" }: LogoProps) {
   const s = SIZES[size];
 
   if (variant === "mark") {
-    return (
-      <CloudMark
-        size={s.mark}
-        className={className}
-        aria-label="cloudless.gr"
-      />
-    );
+    return <CloudMark size={s.mark} className={className} aria-label="cloudless.gr" />;
   }
 
   return (
-    <span
-      className={`inline-flex items-center gap-2 ${className}`}
-      aria-label="cloudless.gr"
-    >
+    <span className={`inline-flex items-center gap-2 ${className}`} aria-label="cloudless.gr">
       {variant === "wordmark" && <CloudMark size={s.mark} aria-hidden />}
       <span className={`font-heading ${s.text} font-bold tracking-tight`}>
         cloudless<span className="text-neon-cyan">.gr</span>

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -32,10 +32,7 @@ export default function Navbar() {
   // Close user menu on outside click
   useEffect(() => {
     function handleClickOutside(e: MouseEvent) {
-      if (
-        userMenuRef.current &&
-        !userMenuRef.current.contains(e.target as Node)
-      ) {
+      if (userMenuRef.current && !userMenuRef.current.contains(e.target as Node)) {
         setUserMenuOpen(false);
       }
     }
@@ -57,7 +54,7 @@ export default function Navbar() {
 
   return (
     <header
-      className={`sticky top-0 z-50 transition-shadow duration-200${scrolled ? " [box-shadow:var(--shadow-md)]" : ""}`}
+      className={`sticky top-0 z-50 transition-shadow duration-200${scrolled ? "[box-shadow:var(--shadow-md)]" : ""}`}
     >
       {/* QD-inspired top accent bar */}
       <div className="bg-neon-cyan h-px shadow-[0_0_10px_rgba(0,255,245,0.5)]" />
@@ -100,15 +97,10 @@ export default function Navbar() {
                       className="hover:border-neon-cyan/30 flex min-h-11 items-center gap-2 rounded-lg border border-slate-700 px-3 py-2 font-mono text-sm text-slate-300 transition-all hover:text-white"
                     >
                       <span className="bg-neon-cyan/20 border-neon-cyan/30 text-neon-cyan flex h-6 w-6 items-center justify-center rounded-full border text-xs">
-                        {(user.name ||
-                          user.email ||
-                          user.username ||
-                          "U")[0].toUpperCase()}
+                        {(user.name || user.email || user.username || "U")[0].toUpperCase()}
                       </span>
                       <span className="hidden max-w-30 truncate xl:inline">
-                        {user.name ||
-                          user.email?.split("@")[0] ||
-                          user.username}
+                        {user.name || user.email?.split("@")[0] || user.username}
                       </span>
                       <svg
                         width="12"
@@ -140,11 +132,7 @@ export default function Navbar() {
                             onClick={() => setUserMenuOpen(false)}
                             className="hover:text-neon-magenta hover:bg-neon-magenta/5 block px-4 py-2.5 font-mono text-sm text-slate-300 transition-all"
                           >
-                            {translate(
-                              locale,
-                              "navbar.adminPanel",
-                              "Admin Panel",
-                            )}
+                            {translate(locale, "navbar.adminPanel", "Admin Panel")}
                           </Link>
                         )}
                         <div className="my-1 border-t border-slate-800" />
@@ -167,11 +155,7 @@ export default function Navbar() {
                       href="/contact"
                       className="bg-accent hover:bg-accent/90 rounded-lg px-5 py-2.5 font-mono text-sm font-semibold whitespace-nowrap text-white transition-all duration-300"
                     >
-                      {translate(
-                        locale,
-                        "navbar.freeAudit",
-                        "Get a Free Audit",
-                      )}
+                      {translate(locale, "navbar.freeAudit", "Get a Free Audit")}
                     </Link>
                     <Link
                       href="/auth/login"
@@ -194,23 +178,11 @@ export default function Navbar() {
             aria-expanded={mobileOpen}
           >
             {mobileOpen ? (
-              <svg
-                width="24"
-                height="24"
-                fill="none"
-                stroke="currentColor"
-                strokeWidth="2"
-              >
+              <svg width="24" height="24" fill="none" stroke="currentColor" strokeWidth="2">
                 <path d="M6 6l12 12M6 18L18 6" />
               </svg>
             ) : (
-              <svg
-                width="24"
-                height="24"
-                fill="none"
-                stroke="currentColor"
-                strokeWidth="2"
-              >
+              <svg width="24" height="24" fill="none" stroke="currentColor" strokeWidth="2">
                 <path d="M4 6h16M4 12h16M4 18h16" />
               </svg>
             )}
@@ -220,9 +192,7 @@ export default function Navbar() {
         {/* Mobile Menu */}
         <div
           className={`bg-void/95 border-neon-cyan/10 overflow-x-hidden overflow-y-auto border-t px-6 backdrop-blur-xl transition-all duration-300 ease-in-out lg:hidden ${
-            mobileOpen
-              ? "max-h-[calc(100svh-4rem)] py-4 opacity-100"
-              : "max-h-0 py-0 opacity-0"
+            mobileOpen ? "max-h-[calc(100svh-4rem)] py-4 opacity-100" : "max-h-0 py-0 opacity-0"
           }`}
         >
           <div className="space-y-1">
@@ -230,7 +200,7 @@ export default function Navbar() {
               <Link
                 key={link.href}
                 href={link.href}
-                className="hover:text-neon-cyan active:text-neon-cyan active:scale-95 flex min-h-11 items-center py-3 font-mono text-sm font-medium text-slate-400 transition-all"
+                className="hover:text-neon-cyan active:text-neon-cyan flex min-h-11 items-center py-3 font-mono text-sm font-medium text-slate-400 transition-all active:scale-95"
                 onClick={() => setMobileOpen(false)}
               >
                 <span className="text-neon-cyan/40 mr-2">&gt;</span>
@@ -238,21 +208,15 @@ export default function Navbar() {
               </Link>
             ))}
             <div className="mt-2 flex items-center justify-between border-t border-slate-800 pt-2 pb-1">
-              <span className="font-mono text-xs text-slate-500">
-                {cartLabel}
-              </span>
+              <span className="font-mono text-xs text-slate-500">{cartLabel}</span>
               <CartButton />
             </div>
             <div className="mt-2 border-t border-slate-800 pt-1 pb-1">
-              <span className="mb-2 block font-mono text-xs text-slate-500">
-                {themeLabel}
-              </span>
+              <span className="mb-2 block font-mono text-xs text-slate-500">{themeLabel}</span>
               <ThemeSwitcherInline />
             </div>
             <div className="mt-2 border-t border-slate-800 pt-1 pb-1">
-              <span className="mb-2 block font-mono text-xs text-slate-500">
-                {languageLabel}
-              </span>
+              <span className="mb-2 block font-mono text-xs text-slate-500">{languageLabel}</span>
               <div className="flex flex-wrap gap-2">
                 {locales.map((l) => (
                   <button
@@ -297,14 +261,8 @@ export default function Navbar() {
                           className="active:text-neon-magenta flex min-h-11 items-center py-3 font-mono text-sm font-medium text-slate-400 transition-colors"
                           onClick={() => setMobileOpen(false)}
                         >
-                          <span className="text-neon-magenta/40 mr-2">
-                            &gt;
-                          </span>
-                          {translate(
-                            locale,
-                            "navbar.adminPanel",
-                            "Admin Panel",
-                          )}
+                          <span className="text-neon-magenta/40 mr-2">&gt;</span>
+                          {translate(locale, "navbar.adminPanel", "Admin Panel")}
                         </Link>
                       )}
                       <button
@@ -327,11 +285,7 @@ export default function Navbar() {
                       className="bg-accent hover:bg-accent/90 mt-2 block min-h-11 rounded-lg px-5 py-3 text-center font-mono text-sm font-semibold text-white transition-all"
                       onClick={() => setMobileOpen(false)}
                     >
-                      {translate(
-                        locale,
-                        "navbar.freeAudit",
-                        "Get a Free Audit",
-                      )}
+                      {translate(locale, "navbar.freeAudit", "Get a Free Audit")}
                     </Link>
                     <Link
                       href="/auth/login"
@@ -342,7 +296,7 @@ export default function Navbar() {
                     </Link>
                     <Link
                       href="/auth/signup"
-                      className="mt-2 block min-h-11 rounded-lg border border-slate-700 px-5 py-3 text-center font-mono text-sm font-semibold text-slate-300 transition-all hover:border-neon-cyan/30 hover:text-neon-cyan"
+                      className="hover:border-neon-cyan/30 hover:text-neon-cyan mt-2 block min-h-11 rounded-lg border border-slate-700 px-5 py-3 text-center font-mono text-sm font-semibold text-slate-300 transition-all"
                       onClick={() => setMobileOpen(false)}
                     >
                       {translate(locale, "navbar.signUp", "Sign Up")}

--- a/src/components/NewsletterForm.tsx
+++ b/src/components/NewsletterForm.tsx
@@ -31,35 +31,18 @@ export default function NewsletterForm() {
 
       if (res.ok) {
         setStatus(STATUS_SUCCESS);
-        setMessage(
-          translate(
-            locale,
-            "newsletter.success",
-            "You're in! Check your email.",
-          ),
-        );
+        setMessage(translate(locale, "newsletter.success", "You're in! Check your email."));
         setEmail("");
       } else {
         const data = await res.json().catch(() => ({}));
         setStatus(STATUS_ERROR);
         setMessage(
-          data.error ||
-            translate(
-              locale,
-              "newsletter.error",
-              "Something went wrong. Try again.",
-            ),
+          data.error || translate(locale, "newsletter.error", "Something went wrong. Try again.")
         );
       }
     } catch {
       setStatus(STATUS_ERROR);
-      setMessage(
-        translate(
-          locale,
-          "newsletter.error",
-          "Something went wrong. Try again.",
-        ),
-      );
+      setMessage(translate(locale, "newsletter.error", "Something went wrong. Try again."));
     }
   }
 
@@ -75,23 +58,15 @@ export default function NewsletterForm() {
         {translate(
           locale,
           "newsletter.subtitle",
-          "Cloud tips, cost-saving strategies, and growth hacks. No spam.",
+          "Cloud tips, cost-saving strategies, and growth hacks. No spam."
         )}
       </p>
-      <form
-        onSubmit={handleSubmit}
-        className="flex gap-2"
-        suppressHydrationWarning
-      >
+      <form onSubmit={handleSubmit} className="flex gap-2" suppressHydrationWarning>
         <input
           type="email"
           value={email}
           onChange={(e) => setEmail(e.target.value)}
-          placeholder={translate(
-            locale,
-            "newsletter.placeholder",
-            "your@email.com",
-          )}
+          placeholder={translate(locale, "newsletter.placeholder", "your@email.com")}
           required
           className="bg-void focus:border-neon-cyan/50 min-w-0 flex-1 rounded-lg border border-slate-700 px-3 py-2 font-mono text-xs text-white transition-colors placeholder:text-slate-600 focus:outline-none"
         />
@@ -109,12 +84,9 @@ export default function NewsletterForm() {
         {translate(
           locale,
           "newsletter.consent",
-          "By subscribing, you agree to receive our newsletter and accept our",
+          "By subscribing, you agree to receive our newsletter and accept our"
         )}{" "}
-        <Link
-          href="/privacy"
-          className="text-neon-cyan/60 underline hover:text-neon-cyan"
-        >
+        <Link href="/privacy" className="text-neon-cyan/60 hover:text-neon-cyan underline">
           {translate(locale, "legal.privacyTitle", "Privacy Policy")}
         </Link>
         {". "}
@@ -123,9 +95,7 @@ export default function NewsletterForm() {
       {status === STATUS_SUCCESS && (
         <p className="text-neon-green mt-2 font-mono text-xs">{message}</p>
       )}
-      {status === STATUS_ERROR && (
-        <p className="mt-2 font-mono text-xs text-red-400">{message}</p>
-      )}
+      {status === STATUS_ERROR && <p className="mt-2 font-mono text-xs text-red-400">{message}</p>}
     </div>
   );
 }

--- a/src/components/ProjectCard.tsx
+++ b/src/components/ProjectCard.tsx
@@ -80,7 +80,7 @@ export default function ProjectCard({
     >
       {/* Header row */}
       <div className="mb-4 flex items-start justify-between gap-3">
-        <h3 className="font-heading group-hover:text-neon-cyan text-base font-bold leading-snug text-white transition-colors">
+        <h3 className="font-heading group-hover:text-neon-cyan text-base leading-snug font-bold text-white transition-colors">
           {project.name}
         </h3>
         <span
@@ -94,9 +94,7 @@ export default function ProjectCard({
       <div className="mb-4">
         <div className="mb-1 flex items-center justify-between">
           <span className="font-mono text-[10px] text-slate-500">Progress</span>
-          <span className="font-mono text-[10px] text-slate-400">
-            {project.progress}%
-          </span>
+          <span className="font-mono text-[10px] text-slate-400">{project.progress}%</span>
         </div>
         <div className="h-1 w-full overflow-hidden rounded-full bg-slate-800">
           <div
@@ -137,17 +135,13 @@ export default function ProjectCard({
           >
             {project.type}
           </span>
-          <span
-            className={`font-mono text-[10px] font-semibold ${priorityColor}`}
-          >
+          <span className={`font-mono text-[10px] font-semibold ${priorityColor}`}>
             {priorityIcon} {project.priority}
           </span>
         </div>
         {(startFmt || dueFmt) && (
           <span className="font-mono text-[10px] text-slate-600">
-            {startFmt && dueFmt
-              ? `${startFmt} → ${dueFmt}`
-              : (startFmt ?? dueFmt)}
+            {startFmt && dueFmt ? `${startFmt} → ${dueFmt}` : (startFmt ?? dueFmt)}
           </span>
         )}
       </div>

--- a/src/components/PushNotificationPrompt.tsx
+++ b/src/components/PushNotificationPrompt.tsx
@@ -62,9 +62,7 @@ export default function PushNotificationPrompt() {
   return (
     <div className="animate-fade-in-up fixed right-4 bottom-4 z-50 max-w-xs md:right-6">
       <div className="border-neon-cyan/20 bg-void/95 rounded-lg border p-4 shadow-[0_0_15px_rgba(0,255,245,0.08)] backdrop-blur-xl">
-        <p className="font-mono text-sm font-semibold text-white">
-          🔔 Stay updated
-        </p>
+        <p className="font-mono text-sm font-semibold text-white">🔔 Stay updated</p>
         <p className="mt-1 text-xs text-slate-400">
           Get notified about new cloud tips and special offers.
         </p>

--- a/src/components/ScrollReveal.tsx
+++ b/src/components/ScrollReveal.tsx
@@ -8,11 +8,7 @@ interface ScrollRevealProps {
   delay?: number;
 }
 
-export default function ScrollReveal({
-  children,
-  className = "",
-  delay = 0,
-}: ScrollRevealProps) {
+export default function ScrollReveal({ children, className = "", delay = 0 }: ScrollRevealProps) {
   const ref = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
@@ -28,7 +24,7 @@ export default function ScrollReveal({
           observer.unobserve(el);
         }
       },
-      { threshold: 0.15, rootMargin: "0px 0px -40px 0px" },
+      { threshold: 0.15, rootMargin: "0px 0px -40px 0px" }
     );
 
     observer.observe(el);

--- a/src/components/ServiceWorkerRegistration.tsx
+++ b/src/components/ServiceWorkerRegistration.tsx
@@ -13,8 +13,7 @@ let hasRegisteredServiceWorker = false;
 
 export default function ServiceWorkerRegistration() {
   const [locale] = useCurrentLocale();
-  const [installPrompt, setInstallPrompt] =
-    useState<BeforeInstallPromptEvent | null>(null);
+  const [installPrompt, setInstallPrompt] = useState<BeforeInstallPromptEvent | null>(null);
   const [showBanner, setShowBanner] = useState(false);
 
   useEffect(() => {
@@ -79,7 +78,7 @@ export default function ServiceWorkerRegistration() {
               {translate(
                 locale,
                 "pwa.installDesc",
-                "Add to your home screen for offline access and a faster experience.",
+                "Add to your home screen for offline access and a faster experience."
               )}
             </p>
             <div className="mt-3 flex gap-3">

--- a/src/components/SocialLinks.tsx
+++ b/src/components/SocialLinks.tsx
@@ -19,13 +19,7 @@ const LINKS = [
     href: "https://www.linkedin.com/company/cloudless-gr",
     label: "Cloudless on LinkedIn",
     icon: (
-      <svg
-        width="16"
-        height="16"
-        viewBox="0 0 24 24"
-        fill="currentColor"
-        aria-hidden="true"
-      >
+      <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
         <path d="M20.447 20.452h-3.554v-5.569c0-1.328-.027-3.037-1.852-3.037-1.853 0-2.136 1.445-2.136 2.939v5.667H9.351V9h3.414v1.561h.046c.477-.9 1.637-1.85 3.37-1.85 3.601 0 4.267 2.37 4.267 5.455v6.286zM5.337 7.433a2.062 2.062 0 01-2.063-2.065 2.064 2.064 0 112.063 2.065zm1.782 13.019H3.555V9h3.564v11.452zM22.225 0H1.771C.792 0 0 .774 0 1.729v20.542C0 23.227.792 24 1.771 24h20.451C23.2 24 24 23.227 24 22.271V1.729C24 .774 23.2 0 22.222 0h.003z" />
       </svg>
     ),
@@ -34,13 +28,7 @@ const LINKS = [
     href: "https://github.com/cloudless-gr",
     label: "Cloudless on GitHub",
     icon: (
-      <svg
-        width="16"
-        height="16"
-        viewBox="0 0 24 24"
-        fill="currentColor"
-        aria-hidden="true"
-      >
+      <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
         <path d="M12 .297c-6.63 0-12 5.373-12 12 0 5.303 3.438 9.8 8.205 11.385.6.113.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.724-4.042-1.61-4.042-1.61C4.422 18.07 3.633 17.7 3.633 17.7c-1.087-.744.084-.729.084-.729 1.205.084 1.838 1.236 1.838 1.236 1.07 1.835 2.809 1.305 3.495.998.108-.776.417-1.305.76-1.605-2.665-.3-5.466-1.332-5.466-5.93 0-1.31.465-2.38 1.235-3.22-.135-.303-.54-1.523.105-3.176 0 0 1.005-.322 3.3 1.23.96-.267 1.98-.399 3-.405 1.02.006 2.04.138 3 .405 2.28-1.552 3.285-1.23 3.285-1.23.645 1.653.24 2.873.12 3.176.765.84 1.23 1.91 1.23 3.22 0 4.61-2.805 5.625-5.475 5.92.42.36.81 1.096.81 2.22 0 1.606-.015 2.896-.015 3.286 0 .315.21.69.825.57C20.565 22.092 24 17.592 24 12.297c0-6.627-5.373-12-12-12" />
       </svg>
     ),
@@ -52,10 +40,7 @@ const sizeClasses: Record<SocialLinksSize, string> = {
   md: "h-10 w-10",
 };
 
-export default function SocialLinks({
-  size = "sm",
-  className = "",
-}: Readonly<SocialLinksProps>) {
+export default function SocialLinks({ size = "sm", className = "" }: Readonly<SocialLinksProps>) {
   return (
     <div className={`flex items-center gap-3 ${className}`}>
       {LINKS.map(({ href, label, icon }) => (

--- a/src/components/StatCounter.tsx
+++ b/src/components/StatCounter.tsx
@@ -52,7 +52,7 @@ export default function StatCounter({
           observer.unobserve(el);
         }
       },
-      { threshold: 0.2 },
+      { threshold: 0.2 }
     );
 
     observer.observe(el);

--- a/src/components/ThemePreferenceSync.tsx
+++ b/src/components/ThemePreferenceSync.tsx
@@ -38,10 +38,7 @@ export default function ThemePreferenceSync() {
       return;
     }
 
-    if (
-      preferredTheme === "system" &&
-      typeof window.matchMedia === "function"
-    ) {
+    if (preferredTheme === "system" && typeof window.matchMedia === "function") {
       const media = window.matchMedia("(prefers-color-scheme: dark)");
       const applySystemTheme = () => {
         root.dataset.theme = media.matches ? "dark" : "light";

--- a/src/components/ThemeSwitcher.tsx
+++ b/src/components/ThemeSwitcher.tsx
@@ -5,11 +5,7 @@ import { usePathname } from "next/navigation";
 import { useAuth } from "@/context/AuthContext";
 import { translate } from "@/lib/i18n";
 import { useCurrentLocale } from "@/lib/use-locale";
-import {
-  type ThemePref,
-  useStoredPref,
-  writeStoredPref,
-} from "@/lib/theme-pref";
+import { type ThemePref, useStoredPref, writeStoredPref } from "@/lib/theme-pref";
 
 const ADMIN_PATH_RE = /^\/(?:en|el|fr|de)?\/?admin(?:\/|$)/;
 
@@ -109,10 +105,7 @@ export default function ThemeSwitcher() {
   useEffect(() => {
     if (!isOpen) return;
     function onMouse(e: MouseEvent) {
-      if (
-        containerRef.current &&
-        !containerRef.current.contains(e.target as Node)
-      )
+      if (containerRef.current && !containerRef.current.contains(e.target as Node))
         setIsOpen(false);
     }
     function onKey(e: KeyboardEvent) {
@@ -159,12 +152,7 @@ export default function ThemeSwitcher() {
           viewBox="0 0 24 24"
           aria-hidden="true"
         >
-          <path
-            strokeLinecap="round"
-            strokeLinejoin="round"
-            strokeWidth={2}
-            d="M19 9l-7 7-7-7"
-          />
+          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
         </svg>
       </button>
 
@@ -187,9 +175,7 @@ export default function ThemeSwitcher() {
                 onClick={() => handleSelect(opt.value)}
                 aria-label={`${label}: ${optLabel}`}
                 className={`hover:bg-neon-cyan/10 active:bg-neon-cyan/20 flex min-h-11 w-full items-center gap-3 px-4 py-2.5 text-left text-sm transition-colors ${
-                  selected
-                    ? "bg-neon-cyan/10 text-neon-cyan font-medium"
-                    : "text-slate-300"
+                  selected ? "bg-neon-cyan/10 text-neon-cyan font-medium" : "text-slate-300"
                 }`}
               >
                 <ThemeIcon kind={opt.iconKey} />

--- a/src/components/TrainingBanner.tsx
+++ b/src/components/TrainingBanner.tsx
@@ -11,9 +11,7 @@ interface TrainingBannerProps {
   locale?: string;
 }
 
-export default function TrainingBanner({
-  locale,
-}: Readonly<TrainingBannerProps>) {
+export default function TrainingBanner({ locale }: Readonly<TrainingBannerProps>) {
   // Mount-deferred: SSR renders nothing, client reveals banner after hydration.
   // useSyncExternalStore with getServerSnapshot=false caused React #418 because
   // the client snapshot ran synchronously during hydration, mismatch-ing null→element.
@@ -36,9 +34,7 @@ export default function TrainingBanner({
   return (
     <div
       role="note"
-      aria-label={
-        isEl ? "Σημείωση εκπαιδευτικού έργου" : "Training project notice"
-      }
+      aria-label={isEl ? "Σημείωση εκπαιδευτικού έργου" : "Training project notice"}
       className="border-b border-amber-500/30 bg-amber-500/10 px-4 py-2.5"
     >
       <div className="mx-auto flex max-w-6xl items-center justify-between gap-4">
@@ -46,33 +42,26 @@ export default function TrainingBanner({
           <span className="mr-1.5 font-bold">⚠</span>
           {isEl ? (
             <>
-              <span className="font-semibold">
-                Εκπαιδευτικό &amp; Portfolio Project
-              </span>
+              <span className="font-semibold">Εκπαιδευτικό &amp; Portfolio Project</span>
               {" — "}
-              Αυτή η ιστοσελίδα δημιουργήθηκε αποκλειστικά για εκπαιδευτικούς
-              και portfolio σκοπούς. Δεν αποτελεί εμπορική υπηρεσία, δεν παρέχει
-              πραγματικές υπηρεσίες και δεν δέχεται πελάτες.
+              Αυτή η ιστοσελίδα δημιουργήθηκε αποκλειστικά για εκπαιδευτικούς και portfolio σκοπούς.
+              Δεν αποτελεί εμπορική υπηρεσία, δεν παρέχει πραγματικές υπηρεσίες και δεν δέχεται
+              πελάτες.
               <span className="mx-2 opacity-30">·</span>
               <span className="italic opacity-50">υπό κατασκευή</span>
             </>
           ) : (
             <>
-              <span className="font-semibold">
-                Training &amp; Portfolio Project
-              </span>
+              <span className="font-semibold">Training &amp; Portfolio Project</span>
               {" — "}
-              This website is built for educational and portfolio purposes only.
-              It is not a commercial service, does not provide real services,
-              and does not accept clients.
+              This website is built for educational and portfolio purposes only. It is not a
+              commercial service, does not provide real services, and does not accept clients.
               <span className="mx-2 opacity-30">·</span>
               <span className="italic opacity-50">under construction</span>
             </>
           )}
           <span className="mx-2 opacity-20">|</span>
-          <span className="italic opacity-40">
-            &ldquo;{isEl ? QUOTE_EL : QUOTE_EN}&rdquo;
-          </span>
+          <span className="italic opacity-40">&ldquo;{isEl ? QUOTE_EL : QUOTE_EN}&rdquo;</span>
         </p>
         <button
           type="button"

--- a/src/components/TypingText.tsx
+++ b/src/components/TypingText.tsx
@@ -1,12 +1,6 @@
 "use client";
 
-import {
-  useCallback,
-  useEffect,
-  useMemo,
-  useState,
-  useSyncExternalStore,
-} from "react";
+import { useCallback, useEffect, useMemo, useState, useSyncExternalStore } from "react";
 
 interface TypingTextProps {
   texts: string[];
@@ -30,7 +24,7 @@ function useReducedMotion(): boolean {
 
   const getSnapshot = useCallback(
     () => window.matchMedia("(prefers-reduced-motion: reduce)").matches,
-    [],
+    []
   );
 
   // During SSR, assume no preference
@@ -47,10 +41,7 @@ export default function TypingText({
   pauseDuration = 2000,
   className = "",
 }: TypingTextProps) {
-  const firstText = useMemo(
-    () => initialText ?? texts[0] ?? "",
-    [initialText, texts],
-  );
+  const firstText = useMemo(() => initialText ?? texts[0] ?? "", [initialText, texts]);
   const [displayed, setDisplayed] = useState(firstText);
   const [textIndex, setTextIndex] = useState(0);
   // Start charIndex at the end of the initial text so the pause fires first

--- a/src/components/WorkspaceSwitcher.tsx
+++ b/src/components/WorkspaceSwitcher.tsx
@@ -11,8 +11,7 @@ export default function WorkspaceSwitcher() {
   useEffect(() => {
     if (!open) return;
     function close(e: MouseEvent) {
-      if (ref.current && !ref.current.contains(e.target as Node))
-        setOpen(false);
+      if (ref.current && !ref.current.contains(e.target as Node)) setOpen(false);
     }
     document.addEventListener("mousedown", close);
     return () => document.removeEventListener("mousedown", close);
@@ -25,16 +24,14 @@ export default function WorkspaceSwitcher() {
       <button
         type="button"
         onClick={() => setOpen((o) => !o)}
-        className="flex w-full items-center justify-between gap-2 rounded-lg border border-slate-800 bg-void/60 px-3 py-2 text-left transition hover:border-slate-700"
+        className="bg-void/60 flex w-full items-center justify-between gap-2 rounded-lg border border-slate-800 px-3 py-2 text-left transition hover:border-slate-700"
       >
         <div className="min-w-0">
-          <p className="font-mono truncate text-xs text-white">
+          <p className="truncate font-mono text-xs text-white">
             {current?.name ?? "Select workspace"}
           </p>
           {current?.slug && (
-            <p className="font-mono truncate text-[10px] text-slate-600">
-              {current.slug}
-            </p>
+            <p className="truncate font-mono text-[10px] text-slate-600">{current.slug}</p>
           )}
         </div>
         <svg
@@ -43,17 +40,12 @@ export default function WorkspaceSwitcher() {
           stroke="currentColor"
           viewBox="0 0 24 24"
         >
-          <path
-            strokeLinecap="round"
-            strokeLinejoin="round"
-            strokeWidth={2}
-            d="M19 9l-7 7-7-7"
-          />
+          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
         </svg>
       </button>
 
       {open && (
-        <div className="absolute top-full left-0 right-0 z-50 mt-1 overflow-hidden rounded-lg border border-slate-800 bg-[#0a0a0f] shadow-xl">
+        <div className="absolute top-full right-0 left-0 z-50 mt-1 overflow-hidden rounded-lg border border-slate-800 bg-[#0a0a0f] shadow-xl">
           {workspaces.map((ws) => (
             <button
               key={ws.id}
@@ -65,13 +57,13 @@ export default function WorkspaceSwitcher() {
               className={`flex w-full items-center gap-2 px-3 py-2.5 text-left transition ${
                 ws.id === current?.id
                   ? "bg-neon-magenta/10 text-neon-magenta"
-                  : "text-slate-300 hover:bg-void-lighter/40 hover:text-white"
+                  : "hover:bg-void-lighter/40 text-slate-300 hover:text-white"
               }`}
             >
               <span
                 className={`h-1.5 w-1.5 shrink-0 rounded-full ${ws.id === current?.id ? "bg-neon-magenta" : "bg-slate-600"}`}
               />
-              <span className="font-mono truncate text-xs">{ws.name}</span>
+              <span className="truncate font-mono text-xs">{ws.name}</span>
             </button>
           ))}
         </div>

--- a/src/components/store/AddToCartButton.tsx
+++ b/src/components/store/AddToCartButton.tsx
@@ -3,11 +3,7 @@
 import { useCart } from "@/context/CartContext";
 import type { StoreProduct } from "@/lib/store-products";
 
-export default function AddToCartButton({
-  product,
-}: {
-  product: StoreProduct;
-}) {
+export default function AddToCartButton({ product }: { product: StoreProduct }) {
   const { addItem, toggleCart } = useCart();
 
   const handleAdd = () => {

--- a/src/components/store/CartButton.tsx
+++ b/src/components/store/CartButton.tsx
@@ -25,11 +25,7 @@ export default function CartButton() {
           strokeLinejoin="round"
         />
         <path d="M3 6h18" strokeLinecap="round" strokeLinejoin="round" />
-        <path
-          d="M16 10a4 4 0 01-8 0"
-          strokeLinecap="round"
-          strokeLinejoin="round"
-        />
+        <path d="M16 10a4 4 0 01-8 0" strokeLinecap="round" strokeLinejoin="round" />
       </svg>
       {totalItems > 0 && (
         <span className="bg-neon-cyan text-void absolute -top-1 -right-1 flex h-5 w-5 items-center justify-center rounded-full text-[10px] font-bold">

--- a/src/components/store/CartSlideOver.tsx
+++ b/src/components/store/CartSlideOver.tsx
@@ -6,15 +6,8 @@ import { formatPrice } from "@/lib/format-price";
 import ProductIcon from "@/components/store/ProductIcon";
 
 export default function CartSlideOver() {
-  const {
-    items,
-    isOpen,
-    closeCart,
-    removeItem,
-    updateQuantity,
-    totalPrice,
-    totalItems,
-  } = useCart();
+  const { items, isOpen, closeCart, removeItem, updateQuantity, totalPrice, totalItems } =
+    useCart();
   const [isCheckingOut, setIsCheckingOut] = useState(false);
 
   const hasSubscription = items.some((item) => item.product.recurring);
@@ -64,9 +57,7 @@ export default function CartSlideOver() {
         <div className="flex h-full flex-col">
           {/* Header */}
           <div className="border-neon-cyan/10 flex items-center justify-between border-b px-6 py-4">
-            <h2 className="font-mono text-lg font-bold text-white">
-              Cart ({totalItems})
-            </h2>
+            <h2 className="font-mono text-lg font-bold text-white">Cart ({totalItems})</h2>
             <button
               onClick={closeCart}
               aria-label="Close cart"
@@ -89,12 +80,8 @@ export default function CartSlideOver() {
           <div className="flex-1 overflow-y-auto px-6 py-4">
             {items.length === 0 ? (
               <div className="py-12 text-center">
-                <div className="text-neon-cyan/40 mb-4 font-mono text-4xl">
-                  [ ]
-                </div>
-                <p className="font-mono text-sm text-slate-400">
-                  Your cart is empty
-                </p>
+                <div className="text-neon-cyan/40 mb-4 font-mono text-4xl">[ ]</div>
+                <p className="font-mono text-sm text-slate-400">Your cart is empty</p>
               </div>
             ) : (
               <div className="space-y-4">
@@ -105,10 +92,7 @@ export default function CartSlideOver() {
                   >
                     {/* Icon */}
                     <div className="bg-void-lighter neon-border h-16 w-16 shrink-0 overflow-hidden rounded-lg">
-                      <ProductIcon
-                        productId={item.product.id}
-                        category={item.product.category}
-                      />
+                      <ProductIcon productId={item.product.id} category={item.product.category} />
                     </div>
 
                     {/* Info */}
@@ -126,12 +110,7 @@ export default function CartSlideOver() {
                         {!item.product.recurring && (
                           <div className="flex items-center gap-1">
                             <button
-                              onClick={() =>
-                                updateQuantity(
-                                  item.product.id,
-                                  item.quantity - 1,
-                                )
-                              }
+                              onClick={() => updateQuantity(item.product.id, item.quantity - 1)}
                               className="bg-void-light hover:border-neon-cyan/30 active:border-neon-cyan/30 flex h-9 min-h-[36px] w-9 min-w-[36px] items-center justify-center rounded-lg border border-slate-700 text-sm text-slate-400 transition-colors"
                             >
                               -
@@ -140,12 +119,7 @@ export default function CartSlideOver() {
                               {item.quantity}
                             </span>
                             <button
-                              onClick={() =>
-                                updateQuantity(
-                                  item.product.id,
-                                  item.quantity + 1,
-                                )
-                              }
+                              onClick={() => updateQuantity(item.product.id, item.quantity + 1)}
                               className="bg-void-light hover:border-neon-cyan/30 active:border-neon-cyan/30 flex h-9 min-h-[36px] w-9 min-w-[36px] items-center justify-center rounded-lg border border-slate-700 text-sm text-slate-400 transition-colors"
                             >
                               +
@@ -171,17 +145,15 @@ export default function CartSlideOver() {
           {items.length > 0 && (
             <div className="border-neon-cyan/10 space-y-4 border-t px-6 py-4">
               <div className="flex items-center justify-between">
-                <span className="font-mono text-sm font-semibold text-white">
-                  Total
-                </span>
+                <span className="font-mono text-sm font-semibold text-white">Total</span>
                 <span className="text-neon-cyan glow-cyan font-mono text-xl font-bold">
                   {formatPrice(totalPrice)}
                 </span>
               </div>
               {hasMixedCart && (
                 <p className="text-neon-magenta bg-neon-magenta/10 border-neon-magenta/20 rounded-lg border px-3 py-2 font-mono text-xs">
-                  Subscriptions and one-time items can&apos;t be purchased
-                  together. Please remove one type before checking out.
+                  Subscriptions and one-time items can&apos;t be purchased together. Please remove
+                  one type before checking out.
                 </p>
               )}
               <button

--- a/src/components/store/ProductIcon.tsx
+++ b/src/components/store/ProductIcon.tsx
@@ -40,24 +40,8 @@ function CloudAuditIcon({ color }: { color: string }) {
       <circle cx="88" cy="90" r="4" fill={color} fillOpacity="0.8" />
       <circle cx="100" cy="86" r="3" fill={color} fillOpacity="0.5" />
       <circle cx="112" cy="93" r="3.5" fill={color} fillOpacity="0.6" />
-      <line
-        x1="92"
-        y1="90"
-        x2="100"
-        y2="86"
-        stroke={color}
-        strokeOpacity="0.4"
-        strokeWidth="1"
-      />
-      <line
-        x1="100"
-        y1="86"
-        x2="112"
-        y2="93"
-        stroke={color}
-        strokeOpacity="0.3"
-        strokeWidth="1"
-      />
+      <line x1="92" y1="90" x2="100" y2="86" stroke={color} strokeOpacity="0.4" strokeWidth="1" />
+      <line x1="100" y1="86" x2="112" y2="93" stroke={color} strokeOpacity="0.3" strokeWidth="1" />
       {/* Magnifier */}
       <circle
         cx="135"
@@ -78,34 +62,10 @@ function CloudAuditIcon({ color }: { color: string }) {
         strokeWidth="1.5"
       />
       {/* Corner brackets */}
-      <path
-        d="M55 55 h12"
-        stroke={color}
-        strokeOpacity="0.3"
-        strokeWidth="1.5"
-        fill="none"
-      />
-      <path
-        d="M55 55 v12"
-        stroke={color}
-        strokeOpacity="0.3"
-        strokeWidth="1.5"
-        fill="none"
-      />
-      <path
-        d="M145 135 h-12"
-        stroke={color}
-        strokeOpacity="0.3"
-        strokeWidth="1.5"
-        fill="none"
-      />
-      <path
-        d="M145 135 v-12"
-        stroke={color}
-        strokeOpacity="0.3"
-        strokeWidth="1.5"
-        fill="none"
-      />
+      <path d="M55 55 h12" stroke={color} strokeOpacity="0.3" strokeWidth="1.5" fill="none" />
+      <path d="M55 55 v12" stroke={color} strokeOpacity="0.3" strokeWidth="1.5" fill="none" />
+      <path d="M145 135 h-12" stroke={color} strokeOpacity="0.3" strokeWidth="1.5" fill="none" />
+      <path d="M145 135 v-12" stroke={color} strokeOpacity="0.3" strokeWidth="1.5" fill="none" />
       {/* Orbiting dots */}
       <circle cx="60" cy="80" r="3" fill={color} fillOpacity="0.2" />
       <circle cx="75" cy="55" r="2.5" fill={color} fillOpacity="0.3" />
@@ -143,24 +103,10 @@ function LambdaIcon({ color }: { color: string }) {
         λ
       </text>
       {/* Brackets */}
-      <text
-        x="62"
-        y="105"
-        fontFamily="monospace"
-        fontSize="28"
-        fill={color}
-        fillOpacity="0.25"
-      >
+      <text x="62" y="105" fontFamily="monospace" fontSize="28" fill={color} fillOpacity="0.25">
         {"{"}
       </text>
-      <text
-        x="128"
-        y="105"
-        fontFamily="monospace"
-        fontSize="28"
-        fill={color}
-        fillOpacity="0.25"
-      >
+      <text x="128" y="105" fontFamily="monospace" fontSize="28" fill={color} fillOpacity="0.25">
         {"}"}
       </text>
       {/* Deploy arrow */}
@@ -173,40 +119,12 @@ function LambdaIcon({ color }: { color: string }) {
         strokeOpacity="0.3"
         strokeWidth="1.5"
       />
-      <polygon
-        points="128,135 122,131 122,139"
-        fill={color}
-        fillOpacity="0.4"
-      />
+      <polygon points="128,135 122,131 122,139" fill={color} fillOpacity="0.4" />
       {/* Corner brackets */}
-      <path
-        d="M55 55 h12"
-        stroke={color}
-        strokeOpacity="0.3"
-        strokeWidth="1.5"
-        fill="none"
-      />
-      <path
-        d="M55 55 v12"
-        stroke={color}
-        strokeOpacity="0.3"
-        strokeWidth="1.5"
-        fill="none"
-      />
-      <path
-        d="M145 135 h-12"
-        stroke={color}
-        strokeOpacity="0.3"
-        strokeWidth="1.5"
-        fill="none"
-      />
-      <path
-        d="M145 135 v-12"
-        stroke={color}
-        strokeOpacity="0.3"
-        strokeWidth="1.5"
-        fill="none"
-      />
+      <path d="M55 55 h12" stroke={color} strokeOpacity="0.3" strokeWidth="1.5" fill="none" />
+      <path d="M55 55 v12" stroke={color} strokeOpacity="0.3" strokeWidth="1.5" fill="none" />
+      <path d="M145 135 h-12" stroke={color} strokeOpacity="0.3" strokeWidth="1.5" fill="none" />
+      <path d="M145 135 v-12" stroke={color} strokeOpacity="0.3" strokeWidth="1.5" fill="none" />
       {/* Orbiting dots */}
       <circle cx="55" cy="95" r="3" fill={color} fillOpacity="0.2" />
       <circle cx="100" cy="48" r="2.5" fill={color} fillOpacity="0.3" />
@@ -257,34 +175,10 @@ function AnalyticsIcon({ color }: { color: string }) {
       />
       <circle cx="124" cy="78" r="4" fill={color} fillOpacity="0.7" />
       {/* Corner brackets */}
-      <path
-        d="M55 55 h12"
-        stroke={color}
-        strokeOpacity="0.3"
-        strokeWidth="1.5"
-        fill="none"
-      />
-      <path
-        d="M55 55 v12"
-        stroke={color}
-        strokeOpacity="0.3"
-        strokeWidth="1.5"
-        fill="none"
-      />
-      <path
-        d="M145 135 h-12"
-        stroke={color}
-        strokeOpacity="0.3"
-        strokeWidth="1.5"
-        fill="none"
-      />
-      <path
-        d="M145 135 v-12"
-        stroke={color}
-        strokeOpacity="0.3"
-        strokeWidth="1.5"
-        fill="none"
-      />
+      <path d="M55 55 h12" stroke={color} strokeOpacity="0.3" strokeWidth="1.5" fill="none" />
+      <path d="M55 55 v12" stroke={color} strokeOpacity="0.3" strokeWidth="1.5" fill="none" />
+      <path d="M145 135 h-12" stroke={color} strokeOpacity="0.3" strokeWidth="1.5" fill="none" />
+      <path d="M145 135 v-12" stroke={color} strokeOpacity="0.3" strokeWidth="1.5" fill="none" />
       <circle cx="60" cy="78" r="3" fill={color} fillOpacity="0.2" />
       <circle cx="140" cy="65" r="2.5" fill={color} fillOpacity="0.25" />
       <circle cx="145" cy="110" r="2" fill={color} fillOpacity="0.2" />
@@ -326,51 +220,11 @@ function AIGrowthIcon({ color }: { color: string }) {
         />
       ))}
       {/* Connections */}
-      <line
-        x1="80"
-        y1="70"
-        x2="100"
-        y2="95"
-        stroke={color}
-        strokeOpacity="0.15"
-        strokeWidth="1"
-      />
-      <line
-        x1="120"
-        y1="70"
-        x2="100"
-        y2="95"
-        stroke={color}
-        strokeOpacity="0.15"
-        strokeWidth="1"
-      />
-      <line
-        x1="65"
-        y1="95"
-        x2="100"
-        y2="95"
-        stroke={color}
-        strokeOpacity="0.15"
-        strokeWidth="1"
-      />
-      <line
-        x1="100"
-        y1="95"
-        x2="135"
-        y2="95"
-        stroke={color}
-        strokeOpacity="0.15"
-        strokeWidth="1"
-      />
-      <line
-        x1="100"
-        y1="95"
-        x2="80"
-        y2="120"
-        stroke={color}
-        strokeOpacity="0.15"
-        strokeWidth="1"
-      />
+      <line x1="80" y1="70" x2="100" y2="95" stroke={color} strokeOpacity="0.15" strokeWidth="1" />
+      <line x1="120" y1="70" x2="100" y2="95" stroke={color} strokeOpacity="0.15" strokeWidth="1" />
+      <line x1="65" y1="95" x2="100" y2="95" stroke={color} strokeOpacity="0.15" strokeWidth="1" />
+      <line x1="100" y1="95" x2="135" y2="95" stroke={color} strokeOpacity="0.15" strokeWidth="1" />
+      <line x1="100" y1="95" x2="80" y2="120" stroke={color} strokeOpacity="0.15" strokeWidth="1" />
       <line
         x1="100"
         y1="95"
@@ -380,75 +234,19 @@ function AIGrowthIcon({ color }: { color: string }) {
         strokeOpacity="0.15"
         strokeWidth="1"
       />
-      <line
-        x1="80"
-        y1="70"
-        x2="65"
-        y2="95"
-        stroke={color}
-        strokeOpacity="0.1"
-        strokeWidth="1"
-      />
-      <line
-        x1="120"
-        y1="70"
-        x2="135"
-        y2="95"
-        stroke={color}
-        strokeOpacity="0.1"
-        strokeWidth="1"
-      />
-      <line
-        x1="65"
-        y1="95"
-        x2="80"
-        y2="120"
-        stroke={color}
-        strokeOpacity="0.1"
-        strokeWidth="1"
-      />
-      <line
-        x1="135"
-        y1="95"
-        x2="120"
-        y2="120"
-        stroke={color}
-        strokeOpacity="0.1"
-        strokeWidth="1"
-      />
+      <line x1="80" y1="70" x2="65" y2="95" stroke={color} strokeOpacity="0.1" strokeWidth="1" />
+      <line x1="120" y1="70" x2="135" y2="95" stroke={color} strokeOpacity="0.1" strokeWidth="1" />
+      <line x1="65" y1="95" x2="80" y2="120" stroke={color} strokeOpacity="0.1" strokeWidth="1" />
+      <line x1="135" y1="95" x2="120" y2="120" stroke={color} strokeOpacity="0.1" strokeWidth="1" />
       {/* Sparkle */}
       <text x="138" y="65" fontSize="14" fill={color} fillOpacity="0.5">
         &#x2726;
       </text>
       {/* Corner brackets */}
-      <path
-        d="M55 55 h12"
-        stroke={color}
-        strokeOpacity="0.3"
-        strokeWidth="1.5"
-        fill="none"
-      />
-      <path
-        d="M55 55 v12"
-        stroke={color}
-        strokeOpacity="0.3"
-        strokeWidth="1.5"
-        fill="none"
-      />
-      <path
-        d="M145 135 h-12"
-        stroke={color}
-        strokeOpacity="0.3"
-        strokeWidth="1.5"
-        fill="none"
-      />
-      <path
-        d="M145 135 v-12"
-        stroke={color}
-        strokeOpacity="0.3"
-        strokeWidth="1.5"
-        fill="none"
-      />
+      <path d="M55 55 h12" stroke={color} strokeOpacity="0.3" strokeWidth="1.5" fill="none" />
+      <path d="M55 55 v12" stroke={color} strokeOpacity="0.3" strokeWidth="1.5" fill="none" />
+      <path d="M145 135 h-12" stroke={color} strokeOpacity="0.3" strokeWidth="1.5" fill="none" />
+      <path d="M145 135 v-12" stroke={color} strokeOpacity="0.3" strokeWidth="1.5" fill="none" />
     </svg>
   );
 }
@@ -504,14 +302,7 @@ function PlaybookIcon({ color }: { color: string }) {
         />
       ))}
       {/* Migration arrow */}
-      <text
-        x="128"
-        y="98"
-        fontSize="20"
-        fill={color}
-        fillOpacity="0.5"
-        fontWeight="bold"
-      >
+      <text x="128" y="98" fontSize="20" fill={color} fillOpacity="0.5" fontWeight="bold">
         &rarr;
       </text>
       {/* Cloud target */}
@@ -540,20 +331,8 @@ function PlaybookIcon({ color }: { color: string }) {
         </text>
       ))}
       {/* Corner brackets */}
-      <path
-        d="M55 55 h12"
-        stroke={color}
-        strokeOpacity="0.3"
-        strokeWidth="1.5"
-        fill="none"
-      />
-      <path
-        d="M55 55 v12"
-        stroke={color}
-        strokeOpacity="0.3"
-        strokeWidth="1.5"
-        fill="none"
-      />
+      <path d="M55 55 h12" stroke={color} strokeOpacity="0.3" strokeWidth="1.5" fill="none" />
+      <path d="M55 55 v12" stroke={color} strokeOpacity="0.3" strokeWidth="1.5" fill="none" />
     </svg>
   );
 }
@@ -701,33 +480,10 @@ function MasterclassIcon({ color }: { color: string }) {
       {/* Play triangle */}
       <polygon points="95,86 95,104 110,95" fill={color} fillOpacity="0.6" />
       {/* Progress bar */}
-      <rect
-        x="74"
-        y="122"
-        width="52"
-        height="3"
-        rx="1.5"
-        fill={color}
-        fillOpacity="0.15"
-      />
-      <rect
-        x="74"
-        y="122"
-        width="28"
-        height="3"
-        rx="1.5"
-        fill={color}
-        fillOpacity="0.5"
-      />
+      <rect x="74" y="122" width="52" height="3" rx="1.5" fill={color} fillOpacity="0.15" />
+      <rect x="74" y="122" width="28" height="3" rx="1.5" fill={color} fillOpacity="0.5" />
       {/* Code brackets */}
-      <text
-        x="72"
-        y="140"
-        fontSize="9"
-        fill={color}
-        fillOpacity="0.3"
-        fontFamily="monospace"
-      >
+      <text x="72" y="140" fontSize="9" fill={color} fillOpacity="0.3" fontFamily="monospace">
         &lt;/&gt; 40+ lessons
       </text>
       {/* Binary */}
@@ -776,36 +532,12 @@ function DevKitIcon({ color }: { color: string }) {
         strokeWidth="1.5"
       />
       {/* Lid line */}
-      <line
-        x1="72"
-        y1="90"
-        x2="128"
-        y2="90"
-        stroke={color}
-        strokeOpacity="0.3"
-        strokeWidth="1"
-      />
+      <line x1="72" y1="90" x2="128" y2="90" stroke={color} strokeOpacity="0.3" strokeWidth="1" />
       {/* Center tape */}
-      <line
-        x1="100"
-        y1="80"
-        x2="100"
-        y2="120"
-        stroke={color}
-        strokeOpacity="0.2"
-        strokeWidth="1"
-      />
+      <line x1="100" y1="80" x2="100" y2="120" stroke={color} strokeOpacity="0.2" strokeWidth="1" />
       {/* Items peeking out */}
       <circle cx="88" cy="72" r="6" fill={color} fillOpacity="0.3" />
-      <line
-        x1="108"
-        y1="70"
-        x2="108"
-        y2="82"
-        stroke={color}
-        strokeOpacity="0.5"
-        strokeWidth="2"
-      />
+      <line x1="108" y1="70" x2="108" y2="82" stroke={color} strokeOpacity="0.5" strokeWidth="2" />
       {/* Star */}
       <text x="120" y="72" fontSize="10" fill={color} fillOpacity="0.4">
         &starf;
@@ -938,11 +670,7 @@ export default function ProductIcon({
   if (!IconComponent) {
     return (
       <div className="flex h-full w-full items-center justify-center text-6xl opacity-40">
-        {category === "service"
-          ? "\u2699"
-          : category === "digital"
-            ? "\u25C8"
-            : "\u25C9"}
+        {category === "service" ? "\u2699" : category === "digital" ? "\u25C8" : "\u25C9"}
       </div>
     );
   }

--- a/src/components/store/StoreGrid.tsx
+++ b/src/components/store/StoreGrid.tsx
@@ -13,12 +13,7 @@ import {
 import { formatPrice } from "@/lib/format-price";
 import ProductIcon from "@/components/store/ProductIcon";
 
-const categories: ("all" | ProductCategory)[] = [
-  "all",
-  "service",
-  "digital",
-  "physical",
-];
+const categories: ("all" | ProductCategory)[] = ["all", "service", "digital", "physical"];
 
 type SortOption = "default" | "price-asc" | "price-desc" | "name-asc";
 
@@ -69,13 +64,8 @@ function ProductCard({ product }: { product: StoreProduct }) {
             </p>
             <ul className="space-y-2">
               {product.features.slice(0, 4).map((f) => (
-                <li
-                  key={f}
-                  className="flex items-start gap-2 text-xs text-slate-300"
-                >
-                  <span className="text-neon-cyan mt-0.5 shrink-0">
-                    &#x25B8;
-                  </span>
+                <li key={f} className="flex items-start gap-2 text-xs text-slate-300">
+                  <span className="text-neon-cyan mt-0.5 shrink-0">&#x25B8;</span>
                   {f}
                 </li>
               ))}
@@ -96,9 +86,7 @@ function ProductCard({ product }: { product: StoreProduct }) {
             {product.name}
           </h3>
         </Link>
-        <p className="mt-2 line-clamp-2 text-sm text-slate-400">
-          {product.description}
-        </p>
+        <p className="mt-2 line-clamp-2 text-sm text-slate-400">{product.description}</p>
 
         <div className="mt-4 flex flex-wrap items-center justify-between gap-3">
           <div>
@@ -106,9 +94,7 @@ function ProductCard({ product }: { product: StoreProduct }) {
               {formatPrice(product.price, product.currency)}
             </span>
             {product.recurring && (
-              <span className="ml-1 font-mono text-sm text-slate-400">
-                /{product.interval}
-              </span>
+              <span className="ml-1 font-mono text-sm text-slate-400">/{product.interval}</span>
             )}
           </div>
           <button
@@ -124,9 +110,7 @@ function ProductCard({ product }: { product: StoreProduct }) {
 }
 
 export default function StoreGrid() {
-  const [activeCategory, setActiveCategory] = useState<"all" | ProductCategory>(
-    "all",
-  );
+  const [activeCategory, setActiveCategory] = useState<"all" | ProductCategory>("all");
   const [searchQuery, setSearchQuery] = useState("");
   const [sortBy, setSortBy] = useState<SortOption>("default");
 
@@ -142,7 +126,7 @@ export default function StoreGrid() {
         (p) =>
           p.name.toLowerCase().includes(q) ||
           p.description.toLowerCase().includes(q) ||
-          (p.features && p.features.some((f) => f.toLowerCase().includes(q))),
+          (p.features && p.features.some((f) => f.toLowerCase().includes(q)))
       );
     }
 
@@ -207,9 +191,7 @@ export default function StoreGrid() {
             }`}
           >
             {cat === "all" ? "All Products" : categoryLabels[cat]}
-            <span className="ml-2 text-[10px] opacity-60">
-              {categoryCounts[cat]}
-            </span>
+            <span className="ml-2 text-[10px] opacity-60">{categoryCounts[cat]}</span>
           </button>
         ))}
       </div>
@@ -225,9 +207,7 @@ export default function StoreGrid() {
       ) : (
         <div className="py-16 text-center">
           <div className="text-neon-cyan/40 mb-4 font-mono text-4xl">[ ]</div>
-          <p className="font-mono text-sm text-slate-400">
-            No products match your search.
-          </p>
+          <p className="font-mono text-sm text-slate-400">No products match your search.</p>
           <button
             onClick={() => {
               setSearchQuery("");

--- a/src/context/AuthContext.tsx
+++ b/src/context/AuthContext.tsx
@@ -1,13 +1,6 @@
 "use client";
 
-import {
-  createContext,
-  useContext,
-  useState,
-  useEffect,
-  useCallback,
-  type ReactNode,
-} from "react";
+import { createContext, useContext, useState, useEffect, useCallback, type ReactNode } from "react";
 
 // aws-amplify is imported lazily inside each async function so the ~2 MB
 // module is excluded from the initial JS bundle, reducing TBT on public pages.
@@ -52,17 +45,9 @@ interface AuthContextType {
   signOut: () => Promise<void>;
   confirmSignUp: (email: string, code: string) => Promise<void>;
   forgotPassword: (email: string) => Promise<void>;
-  confirmForgotPassword: (
-    email: string,
-    code: string,
-    newPassword: string,
-  ) => Promise<void>;
+  confirmForgotPassword: (email: string, code: string, newPassword: string) => Promise<void>;
   completeNewPassword: (newPassword: string) => Promise<void>;
-  updateProfile: (attrs: {
-    name?: string;
-    company?: string;
-    phone?: string;
-  }) => Promise<void>;
+  updateProfile: (attrs: { name?: string; company?: string; phone?: string }) => Promise<void>;
   updatePreferences: (prefs: Partial<UserPreferences>) => Promise<void>;
   refreshProfile: () => Promise<void>;
 }
@@ -109,10 +94,7 @@ function friendlyAuthError(err: unknown): string {
   if (name === "ExpiredCodeException") {
     return "Verification code has expired. Please request a new one.";
   }
-  if (
-    name === "LimitExceededException" ||
-    name === "TooManyRequestsException"
-  ) {
+  if (name === "LimitExceededException" || name === "TooManyRequestsException") {
     return "Too many attempts. Please wait a moment and try again.";
   }
   if (name === "InvalidPasswordException" || message.includes("password")) {
@@ -135,7 +117,7 @@ function decodeJwtPayload(token: string): Record<string, unknown> {
       atob(base64)
         .split("")
         .map((c) => "%" + ("00" + c.charCodeAt(0).toString(16)).slice(-2))
-        .join(""),
+        .join("")
     );
     return JSON.parse(jsonPayload);
   } catch {
@@ -178,13 +160,12 @@ export function AuthProvider({ children }: { children: ReactNode }) {
 
       return { username, email, name, company, phone, preferences };
     },
-    [],
+    []
   );
 
   const checkAuth = useCallback(async () => {
     try {
-      const { getCurrentUser, fetchAuthSession } =
-        await import("aws-amplify/auth");
+      const { getCurrentUser, fetchAuthSession } = await import("aws-amplify/auth");
       const currentUser = await getCurrentUser();
       const email = currentUser.signInDetails?.loginId;
       const profile = await loadUserProfile(currentUser.username, email);
@@ -196,8 +177,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
         const session = await fetchAuthSession();
         const idToken = session.tokens?.idToken?.toString();
         if (idToken) {
-          groups =
-            (decodeJwtPayload(idToken)["cognito:groups"] as string[]) ?? [];
+          groups = (decodeJwtPayload(idToken)["cognito:groups"] as string[]) ?? [];
         }
       } catch {
         // Session fetch failed (network blip). Keep existing admin state if
@@ -225,9 +205,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
         if (!cancelled) {
           console.error("Amplify configuration failed:", err);
           setConfigError(
-            err instanceof Error
-              ? err.message
-              : "Authentication configuration failed",
+            err instanceof Error ? err.message : "Authentication configuration failed"
           );
           setIsLoading(false);
         }
@@ -235,9 +213,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       }
       if (!ok) {
         if (!cancelled) {
-          setConfigError(
-            "Authentication is not configured for this environment.",
-          );
+          setConfigError("Authentication is not configured for this environment.");
           setIsLoading(false);
         }
         return;
@@ -251,19 +227,12 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     };
   }, [checkAuth]);
 
-  const handleSignIn = async (
-    email: string,
-    password: string,
-  ): Promise<SignInResult> => {
-    const { signIn: amplifySignIn, signOut: amplifySignOut } =
-      await import("aws-amplify/auth");
+  const handleSignIn = async (email: string, password: string): Promise<SignInResult> => {
+    const { signIn: amplifySignIn, signOut: amplifySignOut } = await import("aws-amplify/auth");
     try {
       const result = await amplifySignIn({ username: email, password });
 
-      if (
-        result.nextStep?.signInStep ===
-        "CONFIRM_SIGN_IN_WITH_NEW_PASSWORD_REQUIRED"
-      ) {
+      if (result.nextStep?.signInStep === "CONFIRM_SIGN_IN_WITH_NEW_PASSWORD_REQUIRED") {
         return { needsNewPassword: true };
       }
 
@@ -276,10 +245,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       }
       return {};
     } catch (err: unknown) {
-      if (
-        err instanceof Error &&
-        err.name === "UserAlreadyAuthenticatedException"
-      ) {
+      if (err instanceof Error && err.name === "UserAlreadyAuthenticatedException") {
         await amplifySignOut();
         const result = await amplifySignIn({ username: email, password });
         if (result.isSignedIn) {
@@ -291,11 +257,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     }
   };
 
-  const handleSignUp = async (
-    email: string,
-    password: string,
-    name?: string,
-  ) => {
+  const handleSignUp = async (email: string, password: string, name?: string) => {
     const { signUp: amplifySignUp } = await import("aws-amplify/auth");
     try {
       const userAttributes: Record<string, string> = { email };
@@ -318,8 +280,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   };
 
   const handleConfirmSignUp = async (email: string, code: string) => {
-    const { confirmSignUp: amplifyConfirmSignUp } =
-      await import("aws-amplify/auth");
+    const { confirmSignUp: amplifyConfirmSignUp } = await import("aws-amplify/auth");
     try {
       await amplifyConfirmSignUp({ username: email, confirmationCode: code });
     } catch (err) {
@@ -328,8 +289,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   };
 
   const handleForgotPassword = async (email: string) => {
-    const { resetPassword: amplifyResetPassword } =
-      await import("aws-amplify/auth");
+    const { resetPassword: amplifyResetPassword } = await import("aws-amplify/auth");
     try {
       await amplifyResetPassword({ username: email });
     } catch (err) {
@@ -337,13 +297,8 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     }
   };
 
-  const handleConfirmForgotPassword = async (
-    email: string,
-    code: string,
-    newPassword: string,
-  ) => {
-    const { confirmResetPassword: amplifyConfirmResetPassword } =
-      await import("aws-amplify/auth");
+  const handleConfirmForgotPassword = async (email: string, code: string, newPassword: string) => {
+    const { confirmResetPassword: amplifyConfirmResetPassword } = await import("aws-amplify/auth");
     try {
       await amplifyConfirmResetPassword({
         username: email,
@@ -356,8 +311,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   };
 
   const handleCompleteNewPassword = async (newPassword: string) => {
-    const { confirmSignIn: amplifyConfirmSignIn } =
-      await import("aws-amplify/auth");
+    const { confirmSignIn: amplifyConfirmSignIn } = await import("aws-amplify/auth");
     try {
       const result = await amplifyConfirmSignIn({
         challengeResponse: newPassword,
@@ -379,8 +333,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       const updates: Record<string, string> = {};
       if (attrs.name !== undefined) updates.name = attrs.name;
       if (attrs.phone !== undefined) updates.phone_number = attrs.phone;
-      if (attrs.company !== undefined)
-        updates["custom:company"] = attrs.company;
+      if (attrs.company !== undefined) updates["custom:company"] = attrs.company;
 
       if (Object.keys(updates).length > 0) {
         const { updateUserAttributes } = await import("aws-amplify/auth");
@@ -395,7 +348,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
               company: attrs.company ?? prev.company,
               phone: attrs.phone ?? prev.phone,
             }
-          : prev,
+          : prev
       );
     } catch (err) {
       throw new Error(friendlyAuthError(err));

--- a/src/context/CartContext.tsx
+++ b/src/context/CartContext.tsx
@@ -1,12 +1,6 @@
 "use client";
 
-import {
-  createContext,
-  useContext,
-  useEffect,
-  useReducer,
-  type ReactNode,
-} from "react";
+import { createContext, useContext, useEffect, useReducer, type ReactNode } from "react";
 import type { StoreProduct } from "@/lib/store-products";
 
 // --- Types ---
@@ -44,16 +38,12 @@ interface CartContextType extends CartState {
 export function cartReducer(state: CartState, action: CartAction): CartState {
   switch (action.type) {
     case "ADD_ITEM": {
-      const existing = state.items.find(
-        (item) => item.product.id === action.product.id,
-      );
+      const existing = state.items.find((item) => item.product.id === action.product.id);
       if (existing) {
         return {
           ...state,
           items: state.items.map((item) =>
-            item.product.id === action.product.id
-              ? { ...item, quantity: item.quantity + 1 }
-              : item,
+            item.product.id === action.product.id ? { ...item, quantity: item.quantity + 1 } : item
           ),
         };
       }
@@ -65,25 +55,19 @@ export function cartReducer(state: CartState, action: CartAction): CartState {
     case "REMOVE_ITEM":
       return {
         ...state,
-        items: state.items.filter(
-          (item) => item.product.id !== action.productId,
-        ),
+        items: state.items.filter((item) => item.product.id !== action.productId),
       };
     case "UPDATE_QUANTITY":
       if (action.quantity <= 0) {
         return {
           ...state,
-          items: state.items.filter(
-            (item) => item.product.id !== action.productId,
-          ),
+          items: state.items.filter((item) => item.product.id !== action.productId),
         };
       }
       return {
         ...state,
         items: state.items.map((item) =>
-          item.product.id === action.productId
-            ? { ...item, quantity: action.quantity }
-            : item,
+          item.product.id === action.productId ? { ...item, quantity: action.quantity } : item
         ),
       };
     case "CLEAR_CART":
@@ -145,10 +129,7 @@ export function CartProvider({ children }: { children: ReactNode }) {
   }, [state.items]);
 
   const totalItems = state.items.reduce((sum, item) => sum + item.quantity, 0);
-  const totalPrice = state.items.reduce(
-    (sum, item) => sum + item.product.price * item.quantity,
-    0,
-  );
+  const totalPrice = state.items.reduce((sum, item) => sum + item.product.price * item.quantity, 0);
 
   const value: CartContextType = {
     ...state,

--- a/src/context/CookieConsentContext.tsx
+++ b/src/context/CookieConsentContext.tsx
@@ -65,7 +65,7 @@ function writeConsentCookie(prefs: CookiePreferences): void {
       analytics: prefs.analytics,
       marketing: prefs.marketing,
       timestamp: new Date().toISOString(),
-    }),
+    })
   );
   document.cookie = `${COOKIE_NAME}=${value}; path=/; max-age=${COOKIE_MAX_AGE}; SameSite=Lax; Secure`;
 }
@@ -90,10 +90,7 @@ type ConsentAction =
   | { type: "SET_PREFERENCES"; payload: CookiePreferences }
   | { type: "MOUNT" };
 
-function consentReducer(
-  state: ConsentState,
-  action: ConsentAction,
-): ConsentState {
+function consentReducer(state: ConsentState, action: ConsentAction): ConsentState {
   switch (action.type) {
     case "HYDRATE":
       return {
@@ -130,16 +127,12 @@ export interface CookieConsentState {
   closeSettings: () => void;
 }
 
-export const CookieConsentContext = createContext<CookieConsentState | null>(
-  null,
-);
+export const CookieConsentContext = createContext<CookieConsentState | null>(null);
 
 export function useCookieConsent(): CookieConsentState {
   const ctx = useContext(CookieConsentContext);
   if (!ctx) {
-    throw new Error(
-      "useCookieConsent must be used within CookieConsentProvider",
-    );
+    throw new Error("useCookieConsent must be used within CookieConsentProvider");
   }
   return ctx;
 }
@@ -189,7 +182,7 @@ export function CookieConsentProvider({ children }: { children: ReactNode }) {
     (prefs: Partial<CookiePreferences>) => {
       persist({ ...state.preferences, ...prefs, necessary: true });
     },
-    [persist, state.preferences],
+    [persist, state.preferences]
   );
 
   const openSettings = useCallback(() => {

--- a/src/context/WorkspaceContext.tsx
+++ b/src/context/WorkspaceContext.tsx
@@ -1,13 +1,6 @@
 "use client";
 
-import {
-  createContext,
-  useCallback,
-  useContext,
-  useEffect,
-  useMemo,
-  useState,
-} from "react";
+import { createContext, useCallback, useContext, useEffect, useMemo, useState } from "react";
 import { fetchWithAuth } from "@/lib/fetch-with-auth";
 import type { Workspace } from "@/app/api/admin/workspaces/route";
 
@@ -29,9 +22,7 @@ const WorkspaceContext = createContext<WorkspaceContextValue>({
   setWorkspaces: () => {},
 });
 
-export function WorkspaceProvider({
-  children,
-}: Readonly<{ children: React.ReactNode }>) {
+export function WorkspaceProvider({ children }: Readonly<{ children: React.ReactNode }>) {
   const [workspaces, setWorkspaces] = useState<Workspace[]>([]);
   const [currentId, setCurrentId] = useState<string | null>(null);
   const [loaded, setLoaded] = useState(false);
@@ -60,9 +51,7 @@ export function WorkspaceProvider({
   useEffect(() => {
     if (currentId || workspaces.length === 0) return;
     const stored = localStorage.getItem(LS_KEY);
-    const valid = workspaces.some((w) => w.id === stored)
-      ? stored
-      : (workspaces[0]?.id ?? null);
+    const valid = workspaces.some((w) => w.id === stored) ? stored : (workspaces[0]?.id ?? null);
     if (valid) {
       // eslint-disable-next-line react-hooks/set-state-in-effect
       setCurrentId(valid);
@@ -75,19 +64,14 @@ export function WorkspaceProvider({
     localStorage.setItem(LS_KEY, id);
   }, []);
 
-  const current =
-    workspaces.find((w) => w.id === currentId) ?? workspaces[0] ?? null;
+  const current = workspaces.find((w) => w.id === currentId) ?? workspaces[0] ?? null;
 
   const value = useMemo(
     () => ({ workspaces, current, loaded, switchTo, setWorkspaces }),
-    [workspaces, current, loaded, switchTo, setWorkspaces],
+    [workspaces, current, loaded, switchTo, setWorkspaces]
   );
 
-  return (
-    <WorkspaceContext.Provider value={value}>
-      {children}
-    </WorkspaceContext.Provider>
-  );
+  return <WorkspaceContext.Provider value={value}>{children}</WorkspaceContext.Provider>;
 }
 
 export function useWorkspace() {

--- a/src/i18n/navigation.ts
+++ b/src/i18n/navigation.ts
@@ -1,5 +1,4 @@
 import { createNavigation } from "next-intl/navigation";
 import { routing } from "./routing";
 
-export const { Link, redirect, usePathname, useRouter, getPathname } =
-  createNavigation(routing);
+export const { Link, redirect, usePathname, useRouter, getPathname } = createNavigation(routing);

--- a/src/i18n/request.ts
+++ b/src/i18n/request.ts
@@ -1,13 +1,8 @@
 import { getRequestConfig } from "next-intl/server";
 import { routing } from "./routing";
 
-function isValidLocale(
-  value: string | undefined,
-): value is (typeof routing.locales)[number] {
-  return (
-    typeof value === "string" &&
-    (routing.locales as readonly string[]).includes(value)
-  );
+function isValidLocale(value: string | undefined): value is (typeof routing.locales)[number] {
+  return typeof value === "string" && (routing.locales as readonly string[]).includes(value);
 }
 
 export default getRequestConfig(async ({ requestLocale }) => {

--- a/src/instrumentation.ts
+++ b/src/instrumentation.ts
@@ -19,8 +19,7 @@
 let lastNotifiedVersion: string | undefined;
 
 async function loadSsmParams(prefix: string): Promise<Map<string, string>> {
-  const { SSMClient, GetParametersByPathCommand } =
-    await import("@aws-sdk/client-ssm");
+  const { SSMClient, GetParametersByPathCommand } = await import("@aws-sdk/client-ssm");
   const ssm = new SSMClient({ region: process.env.AWS_REGION ?? "us-east-1" });
   const params = new Map<string, string>();
   let nextToken: string | undefined;
@@ -31,7 +30,7 @@ async function loadSsmParams(prefix: string): Promise<Map<string, string>> {
         Path: prefix,
         WithDecryption: true,
         NextToken: nextToken,
-      }),
+      })
     );
     for (const p of res.Parameters ?? []) {
       const key = p.Name?.replace(`${prefix}/`, "") ?? "";
@@ -44,16 +43,14 @@ async function loadSsmParams(prefix: string): Promise<Map<string, string>> {
 }
 
 async function fireDeployNotification(prefix: string, params: Map<string, string>): Promise<void> {
-  console.warn(
-    `[Instrumentation] Loaded ${params.size} SSM parameters from ${prefix}`,
-  );
+  console.warn(`[Instrumentation] Loaded ${params.size} SSM parameters from ${prefix}`);
   const version = process.env.NEXT_PUBLIC_APP_VERSION ?? "unknown";
   const stage = process.env.SST_STAGE ?? process.env.NODE_ENV ?? "production";
   if (version === "unknown" || version === lastNotifiedVersion) return;
   lastNotifiedVersion = version;
   const { slackDeployNotify } = await import("@/lib/slack-notify");
-  slackDeployNotify({ version, stage, status: "succeeded", commitSha: version }).catch(
-    (err) => console.warn("[Instrumentation] slackDeployNotify failed:", err),
+  slackDeployNotify({ version, stage, status: "succeeded", commitSha: version }).catch((err) =>
+    console.warn("[Instrumentation] slackDeployNotify failed:", err)
   );
 }
 

--- a/src/lambda/cron-invoker.ts
+++ b/src/lambda/cron-invoker.ts
@@ -15,11 +15,10 @@ export async function handler() {
     new GetParameterCommand({
       Name: `${ssmPrefix}/CRON_SECRET`,
       WithDecryption: true,
-    }),
+    })
   );
   const secret = Parameter?.Value;
-  if (!secret)
-    throw new Error(`CRON_SECRET not found at ${ssmPrefix}/CRON_SECRET`);
+  if (!secret) throw new Error(`CRON_SECRET not found at ${ssmPrefix}/CRON_SECRET`);
 
   const res = await fetch(`${siteUrl}${route}`, {
     headers: { Authorization: `Bearer ${secret}` },
@@ -28,9 +27,7 @@ export async function handler() {
 
   if (!res.ok) {
     const body = await res.text().catch(() => "");
-    throw new Error(
-      `Cron ${route} responded ${res.status}: ${body.slice(0, 200)}`,
-    );
+    throw new Error(`Cron ${route} responded ${res.status}: ${body.slice(0, 200)}`);
   }
 
   const payload = await res.json().catch(() => null);

--- a/src/lib/ab-flags.ts
+++ b/src/lib/ab-flags.ts
@@ -52,8 +52,7 @@ export const DEFAULT_FLAGS: ABFlag[] = [
 export async function getABFlags(): Promise<ABFlag[]> {
   try {
     const cfg = await getConfig();
-    const raw = (cfg as unknown as Record<string, string | undefined>)
-      .AB_FLAGS_JSON;
+    const raw = (cfg as unknown as Record<string, string | undefined>).AB_FLAGS_JSON;
     if (raw) {
       const parsed = JSON.parse(raw) as ABFlag[];
       if (Array.isArray(parsed)) return parsed;

--- a/src/lib/activecampaign.ts
+++ b/src/lib/activecampaign.ts
@@ -8,10 +8,7 @@ async function getACConfig(): Promise<{ url: string; token: string }> {
   return { url: url.replace(/\/$/, ""), token };
 }
 
-async function acFetch(
-  path: string,
-  options: RequestInit = {},
-): Promise<Response> {
+async function acFetch(path: string, options: RequestInit = {}): Promise<Response> {
   const { url, token } = await getACConfig();
   return fetch(`${url}/api/3${path}`, {
     ...options,
@@ -63,8 +60,7 @@ export async function verifyActiveCampaignToken(): Promise<{
         message: `Token rejected (${res.status}) — account may be expired or token rotated.`,
       };
     }
-    if (!res.ok)
-      return { status: "error", message: `API returned ${res.status}` };
+    if (!res.ok) return { status: "error", message: `API returned ${res.status}` };
     return { status: "valid" };
   } catch {
     return { status: "error", message: "Connection failed." };
@@ -119,9 +115,7 @@ export interface CreateCampaignInput {
   sdate?: string;
 }
 
-export async function createCampaign(
-  input: CreateCampaignInput,
-): Promise<ACCampaign | null> {
+export async function createCampaign(input: CreateCampaignInput): Promise<ACCampaign | null> {
   try {
     const res = await acFetch("/campaigns", {
       method: "POST",

--- a/src/lib/agent-book.ts
+++ b/src/lib/agent-book.ts
@@ -90,8 +90,7 @@ const AGENT_TOOLS = [
         },
         reasoning: {
           type: "string",
-          description:
-            "Brief explanation of why this slot was chosen, or why no slot fits.",
+          description: "Brief explanation of why this slot was chosen, or why no slot fits.",
         },
       },
       required: ["start", "end", "reasoning"],
@@ -116,8 +115,7 @@ async function runCheckAvailability(raw: unknown): Promise<string> {
       return `No open slots in the next ${days} day(s).`;
     }
     const lines = slots.map(
-      (s) =>
-        `- ${formatAthensSlot(s.start, s.end)} [start=${s.start} end=${s.end}]`,
+      (s) => `- ${formatAthensSlot(s.start, s.end)} [start=${s.start} end=${s.end}]`
     );
     return `Open slots (next ${days} day(s)):\n${lines.join("\n")}`;
   } catch (err) {
@@ -196,13 +194,9 @@ export async function isAgentBookConfigured(): Promise<boolean> {
  * Returns the proposed slot (or no_match) — never books on its own.
  * May throw on Bedrock API errors; caller maps to HTTP status.
  */
-export async function proposeBookingSlot(
-  intent: string,
-): Promise<ProposeResult> {
+export async function proposeBookingSlot(intent: string): Promise<ProposeResult> {
   const client = getBedrockClient();
-  const messages: BedrockMessage[] = [
-    { role: "user", content: [{ text: intent }] },
-  ];
+  const messages: BedrockMessage[] = [{ role: "user", content: [{ text: intent }] }];
 
   for (let attempt = 0; attempt < MAX_TOOL_ITERATIONS; attempt++) {
     const cmd = new ConverseCommand({
@@ -214,33 +208,26 @@ export async function proposeBookingSlot(
     });
 
     const response = await client.send(cmd);
-    const assistantContent: AnyBlock[] =
-      (response.output?.message?.content as AnyBlock[]) ?? [];
+    const assistantContent: AnyBlock[] = (response.output?.message?.content as AnyBlock[]) ?? [];
 
     const toolUseBlocks = assistantContent.filter(
-      (b): b is ToolUseBlock =>
-        "toolUse" in b && typeof b.toolUse?.toolUseId === "string",
+      (b): b is ToolUseBlock => "toolUse" in b && typeof b.toolUse?.toolUseId === "string"
     );
 
     // Terminal tool — propose_slot. Bind the result and return.
-    const proposeBlock = toolUseBlocks.find(
-      (b) => b.toolUse.name === "propose_slot",
-    );
+    const proposeBlock = toolUseBlocks.find((b) => b.toolUse.name === "propose_slot");
     if (proposeBlock) return resolveProposeBlock(proposeBlock);
 
     if (toolUseBlocks.length === 0) {
       // Model returned plain text without proposing — treat as no_match.
       const textOut = assistantContent
-        .filter(
-          (b): b is TextBlock => "text" in b && typeof b.text === "string",
-        )
+        .filter((b): b is TextBlock => "text" in b && typeof b.text === "string")
         .map((b) => b.text)
         .join(" ")
         .trim();
       return {
         status: STATUS_NO_MATCH,
-        reasoning:
-          textOut.length > 0 ? textOut : "Model did not propose a slot.",
+        reasoning: textOut.length > 0 ? textOut : "Model did not propose a slot.",
       };
     }
 

--- a/src/lib/agent-voice-brief.ts
+++ b/src/lib/agent-voice-brief.ts
@@ -85,14 +85,12 @@ const AGENT_TOOLS = [
   },
   {
     name: "get_pipeline_stats",
-    description:
-      "Fetch HubSpot open-deal pipeline totals (deal count + total value in euros).",
+    description: "Fetch HubSpot open-deal pipeline totals (deal count + total value in euros).",
     input_schema: { type: "object", properties: {}, required: [] },
   },
   {
     name: "get_email_metrics",
-    description:
-      "Fetch the size of the newsletter subscriber list (HubSpot marketing contacts).",
+    description: "Fetch the size of the newsletter subscriber list (HubSpot marketing contacts).",
     input_schema: { type: "object", properties: {}, required: [] },
   },
   {
@@ -131,10 +129,7 @@ async function sleep(ms: number): Promise<void> {
   });
 }
 
-async function withRetry<T>(
-  fn: () => Promise<T>,
-  retries = TOOL_MAX_RETRIES,
-): Promise<T> {
+async function withRetry<T>(fn: () => Promise<T>, retries = TOOL_MAX_RETRIES): Promise<T> {
   let lastErr: unknown;
   for (let attempt = 0; attempt <= retries; attempt++) {
     try {
@@ -195,16 +190,14 @@ const TOOL_HANDLERS: Record<string, () => Promise<string>> = {
   get_email_metrics: makeToolHandler({
     toolName: "get_email_metrics",
     fetch: fetchEmailMetrics,
-    format: (e) =>
-      `Newsletter: ${e.totalContacts.toLocaleString()} subscribers.`,
+    format: (e) => `Newsletter: ${e.totalContacts.toLocaleString()} subscribers.`,
     emptyMessage: "HubSpot not configured.",
     failMessage: "Newsletter lookup failed after retries.",
   }),
   get_stripe_revenue: makeToolHandler({
     toolName: "get_stripe_revenue",
     fetch: fetchStripeMetrics,
-    format: (s) =>
-      `Stripe: ${s.orders} paid orders, €${s.revenueEuros.toFixed(0)} revenue.`,
+    format: (s) => `Stripe: ${s.orders} paid orders, €${s.revenueEuros.toFixed(0)} revenue.`,
     emptyMessage: "Stripe returned no data.",
     failMessage: "Stripe lookup failed after retries.",
   }),
@@ -223,12 +216,10 @@ function classifyOutcome(name: string, detail: string): ToolOutcome {
 
 async function runPendingTool(
   block: ToolUseBlock,
-  outcomes: ToolOutcome[],
+  outcomes: ToolOutcome[]
 ): Promise<ToolResultBlock> {
   const handler = TOOL_HANDLERS[block.toolUse.name];
-  const result = handler
-    ? await handler()
-    : `Unknown tool: ${block.toolUse.name}`;
+  const result = handler ? await handler() : `Unknown tool: ${block.toolUse.name}`;
   outcomes.push(classifyOutcome(block.toolUse.name, result));
   return {
     toolResult: {
@@ -253,9 +244,7 @@ function asString(value: unknown): string {
  * Throws on Bedrock infrastructure errors so the route handler can surface
  * a 5xx instead of writing a half-broken brief to SSM.
  */
-export async function runVoiceBriefAgent(opts?: {
-  dateLabel?: string;
-}): Promise<VoiceBriefResult> {
+export async function runVoiceBriefAgent(opts?: { dateLabel?: string }): Promise<VoiceBriefResult> {
   const client = getBedrockClient();
   const dateLabel = opts?.dateLabel ?? new Date().toISOString().slice(0, 10);
   const outcomes: ToolOutcome[] = [];
@@ -281,9 +270,7 @@ export async function runVoiceBriefAgent(opts?: {
     });
     const toolUseBlocks = pickToolUseBlocks(assistantContent);
 
-    const emitBlock = toolUseBlocks.find(
-      (b) => b.toolUse.name === "emit_brief",
-    );
+    const emitBlock = toolUseBlocks.find((b) => b.toolUse.name === "emit_brief");
     if (emitBlock) {
       const narrative = asString(emitBlock.toolUse.input?.narrative).trim();
       return {
@@ -298,18 +285,13 @@ export async function runVoiceBriefAgent(opts?: {
     if (toolUseBlocks.length === 0) {
       const textOut = joinAssistantText(assistantContent);
       return {
-        text:
-          textOut.length > 0
-            ? textOut
-            : "Agent produced no narrative this week.",
+        text: textOut.length > 0 ? textOut : "Agent produced no narrative this week.",
         sources: outcomes,
       };
     }
 
     messages.push({ role: "assistant", content: assistantContent });
-    const toolResults = await Promise.all(
-      toolUseBlocks.map((b) => runPendingTool(b, outcomes)),
-    );
+    const toolResults = await Promise.all(toolUseBlocks.map((b) => runPendingTool(b, outcomes)));
     messages.push({ role: "user", content: toolResults });
   }
 

--- a/src/lib/amplify-config.ts
+++ b/src/lib/amplify-config.ts
@@ -27,7 +27,7 @@ if (userPoolId && userPoolClientId) {
         },
       },
     },
-    { ssr: true },
+    { ssr: true }
   );
 }
 

--- a/src/lib/analytics-agent-orchestrator.ts
+++ b/src/lib/analytics-agent-orchestrator.ts
@@ -1,12 +1,7 @@
 import { callClaude } from "@/lib/anthropic";
 import type { StripeAnalyticsSnapshot } from "@/lib/stripe-analytics-read";
 
-export type AnalyticsConnector =
-  | "quicksight"
-  | "powerbi"
-  | "tableau"
-  | "lookerstudio"
-  | "metabase";
+export type AnalyticsConnector = "quicksight" | "powerbi" | "tableau" | "lookerstudio" | "metabase";
 
 export interface RecommendedMove {
   move: string;
@@ -124,7 +119,7 @@ function buildSystemPrompt(): string {
 
 function buildDataQualityNotes(
   snapshot: StripeAnalyticsSnapshot,
-  hasData: boolean,
+  hasData: boolean
 ): { sparseWindow: boolean; notes: string[] } {
   const notes: string[] = [];
   if (!hasData) {
@@ -132,24 +127,23 @@ function buildDataQualityNotes(
   }
 
   const sparseWindow =
-    snapshot.totals.events > 0 &&
-    snapshot.totals.events < Math.max(5, snapshot.windowDays / 2);
+    snapshot.totals.events > 0 && snapshot.totals.events < Math.max(5, snapshot.windowDays / 2);
   if (sparseWindow) {
     notes.push(
-      "Sample size is sparse for the selected window, so directionally useful trends may be noisier than usual.",
+      "Sample size is sparse for the selected window, so directionally useful trends may be noisier than usual."
     );
   }
 
   const currencies = Object.keys(snapshot.byCurrency);
   if (currencies.length > 1) {
     notes.push(
-      "Revenue spans multiple currencies, so totals should be treated as ledger totals rather than FX-normalized business revenue.",
+      "Revenue spans multiple currencies, so totals should be treated as ledger totals rather than FX-normalized business revenue."
     );
   }
 
   if (snapshot.totals.processed === 0 && snapshot.totals.events > 0) {
     notes.push(
-      "No processed events were recorded, which likely indicates either a live issue or a partial ingest window.",
+      "No processed events were recorded, which likely indicates either a live issue or a partial ingest window."
     );
   }
 
@@ -167,48 +161,36 @@ function sumTrend(points: StripeAnalyticsSnapshot["dailyTrend"]): {
       events: accumulator.events + point.events,
       failed: accumulator.failed + point.failed,
     }),
-    { revenueMinor: 0, events: 0, failed: 0 },
+    { revenueMinor: 0, events: 0, failed: 0 }
   );
 }
 
 export function preprocessStripeAnalyticsSnapshot(
-  snapshot: StripeAnalyticsSnapshot,
+  snapshot: StripeAnalyticsSnapshot
 ): PreprocessedAnalyticsSummary {
   const hasData = snapshot.totals.events > 0;
   const sortedTrend = [...snapshot.dailyTrend].sort((left, right) =>
-    left.day.localeCompare(right.day),
+    left.day.localeCompare(right.day)
   );
   const comparisonWindowDays = Math.min(7, sortedTrend.length);
-  const recentWindow =
-    comparisonWindowDays > 0 ? sortedTrend.slice(-comparisonWindowDays) : [];
+  const recentWindow = comparisonWindowDays > 0 ? sortedTrend.slice(-comparisonWindowDays) : [];
   const priorWindow =
     comparisonWindowDays > 0
       ? sortedTrend.slice(-comparisonWindowDays * 2, -comparisonWindowDays)
       : [];
   const recentTotals = sumTrend(recentWindow);
   const priorTotals = sumTrend(priorWindow);
-  const recentFailureRatePct = percentage(
-    recentTotals.failed,
-    recentTotals.events,
-  );
+  const recentFailureRatePct = percentage(recentTotals.failed, recentTotals.events);
   const priorFailureRatePct =
-    priorWindow.length > 0
-      ? percentage(priorTotals.failed, priorTotals.events)
-      : null;
+    priorWindow.length > 0 ? percentage(priorTotals.failed, priorTotals.events) : null;
   const topRevenueCategories = Object.entries(snapshot.byCategory)
     .map(([category, metrics]) => ({
       category,
       events: metrics.events,
       revenueMinor: metrics.revenueMinor,
-      revenueSharePct: percentage(
-        metrics.revenueMinor,
-        snapshot.totals.revenueMinor,
-      ),
+      revenueSharePct: percentage(metrics.revenueMinor, snapshot.totals.revenueMinor),
     }))
-    .sort(
-      (left, right) =>
-        right.revenueMinor - left.revenueMinor || right.events - left.events,
-    )
+    .sort((left, right) => right.revenueMinor - left.revenueMinor || right.events - left.events)
     .slice(0, 5);
   const topFailureDays = sortedTrend
     .filter((point) => point.failed > 0)
@@ -218,18 +200,11 @@ export function preprocessStripeAnalyticsSnapshot(
       events: point.events,
       failureRatePct: percentage(point.failed, point.events),
     }))
-    .sort(
-      (left, right) =>
-        right.failed - left.failed ||
-        right.failureRatePct - left.failureRatePct,
-    )
+    .sort((left, right) => right.failed - left.failed || right.failureRatePct - left.failureRatePct)
     .slice(0, 5);
   const strongestRevenueDays = sortedTrend
     .filter((point) => point.revenueMinor > 0)
-    .sort(
-      (left, right) =>
-        right.revenueMinor - left.revenueMinor || right.events - left.events,
-    )
+    .sort((left, right) => right.revenueMinor - left.revenueMinor || right.events - left.events)
     .slice(0, 5)
     .map((point) => ({
       day: point.day,
@@ -242,14 +217,9 @@ export function preprocessStripeAnalyticsSnapshot(
     windowDays: snapshot.windowDays,
     hasData,
     failureRatePct: percentage(snapshot.totals.failed, snapshot.totals.events),
-    processedRatePct: percentage(
-      snapshot.totals.processed,
-      snapshot.totals.events,
-    ),
+    processedRatePct: percentage(snapshot.totals.processed, snapshot.totals.events),
     averageRevenuePerEventMinor:
-      snapshot.totals.events > 0
-        ? round(snapshot.totals.revenueMinor / snapshot.totals.events)
-        : 0,
+      snapshot.totals.events > 0 ? round(snapshot.totals.revenueMinor / snapshot.totals.events) : 0,
     averageDailyRevenueMinor:
       snapshot.dailyTrend.length > 0
         ? round(snapshot.totals.revenueMinor / snapshot.dailyTrend.length)
@@ -268,21 +238,18 @@ export function preprocessStripeAnalyticsSnapshot(
     momentum: {
       comparisonWindowDays,
       recentRevenueMinor: recentTotals.revenueMinor,
-      priorRevenueMinor:
-        priorWindow.length > 0 ? priorTotals.revenueMinor : null,
+      priorRevenueMinor: priorWindow.length > 0 ? priorTotals.revenueMinor : null,
       revenueDeltaPct:
         priorWindow.length > 0 && priorTotals.revenueMinor > 0
           ? percentage(
               recentTotals.revenueMinor - priorTotals.revenueMinor,
-              priorTotals.revenueMinor,
+              priorTotals.revenueMinor
             )
           : null,
       recentFailureRatePct,
       priorFailureRatePct,
       failureRateDeltaPct:
-        priorFailureRatePct !== null
-          ? round(recentFailureRatePct - priorFailureRatePct)
-          : null,
+        priorFailureRatePct !== null ? round(recentFailureRatePct - priorFailureRatePct) : null,
     },
     dataQuality,
   };
@@ -291,7 +258,7 @@ export function preprocessStripeAnalyticsSnapshot(
 function buildUserPrompt(
   snapshot: StripeAnalyticsSnapshot,
   preprocessed: PreprocessedAnalyticsSummary,
-  goals: string[],
+  goals: string[]
 ): string {
   const promptPayload = {
     goals:
@@ -341,10 +308,9 @@ ${JSON.stringify(promptPayload, null, 2)}`;
 
 function defaultReport(
   snapshot: StripeAnalyticsSnapshot,
-  preprocessed: PreprocessedAnalyticsSummary,
+  preprocessed: PreprocessedAnalyticsSummary
 ): AnalyticsNarrativeReport {
-  const topCategory =
-    preprocessed.topRevenueCategories[0]?.category ?? "checkout";
+  const topCategory = preprocessed.topRevenueCategories[0]?.category ?? "checkout";
   const revenueDelta = preprocessed.momentum.revenueDeltaPct;
   const deltaSummary =
     revenueDelta === null
@@ -407,9 +373,7 @@ function parseClaudeJson(text: string): AnalyticsNarrativeReport | null {
   try {
     const parsed = JSON.parse(cleaned) as Record<string, unknown>;
     const executiveSummary =
-      typeof parsed.executiveSummary === "string"
-        ? parsed.executiveSummary.trim()
-        : "";
+      typeof parsed.executiveSummary === "string" ? parsed.executiveSummary.trim() : "";
     const keyInsights = Array.isArray(parsed.keyInsights)
       ? parsed.keyInsights.map((value) => String(value).trim()).filter(Boolean)
       : [];
@@ -421,14 +385,8 @@ function parseClaudeJson(text: string): AnalyticsNarrativeReport | null {
           .map((value) => {
             if (!value || typeof value !== "object") return null;
             const candidate = value as Record<string, unknown>;
-            const confidence = String(
-              candidate.confidence ?? "medium",
-            ).toLowerCase();
-            if (
-              confidence !== "low" &&
-              confidence !== "medium" &&
-              confidence !== "high"
-            ) {
+            const confidence = String(candidate.confidence ?? "medium").toLowerCase();
+            if (confidence !== "low" && confidence !== "medium" && confidence !== "high") {
               return null;
             }
 
@@ -444,7 +402,7 @@ function parseClaudeJson(text: string): AnalyticsNarrativeReport | null {
             } satisfies RecommendedMove;
           })
           .filter((value): value is RecommendedMove =>
-            Boolean(value?.move && value?.rationale && value?.expectedOutcome),
+            Boolean(value?.move && value?.rationale && value?.expectedOutcome)
           )
       : [];
     const scenarioOutcomes = Array.isArray(parsed.scenarioOutcomes)
@@ -454,27 +412,16 @@ function parseClaudeJson(text: string): AnalyticsNarrativeReport | null {
             const candidate = value as Record<string, unknown>;
             return {
               scenario: String(candidate.scenario ?? "").trim(),
-              expectedRevenueDeltaPct: round(
-                Number(candidate.expectedRevenueDeltaPct ?? 0),
-              ),
-              expectedConversionDeltaPct: round(
-                Number(candidate.expectedConversionDeltaPct ?? 0),
-              ),
+              expectedRevenueDeltaPct: round(Number(candidate.expectedRevenueDeltaPct ?? 0)),
+              expectedConversionDeltaPct: round(Number(candidate.expectedConversionDeltaPct ?? 0)),
             };
           })
-          .filter(
-            (
-              value,
-            ): value is AnalyticsNarrativeReport["scenarioOutcomes"][number] =>
-              Boolean(value?.scenario),
+          .filter((value): value is AnalyticsNarrativeReport["scenarioOutcomes"][number] =>
+            Boolean(value?.scenario)
           )
       : [];
 
-    if (
-      !executiveSummary ||
-      keyInsights.length === 0 ||
-      nextMoves.length === 0
-    ) {
+    if (!executiveSummary || keyInsights.length === 0 || nextMoves.length === 0) {
       return null;
     }
 
@@ -493,36 +440,35 @@ function parseClaudeJson(text: string): AnalyticsNarrativeReport | null {
 function buildConnectorPayload(
   connector: AnalyticsConnector,
   snapshot: StripeAnalyticsSnapshot,
-  preprocessed: PreprocessedAnalyticsSummary,
+  preprocessed: PreprocessedAnalyticsSummary
 ): ConnectorPayload {
-  const chartRecommendationsByConnector: Record<AnalyticsConnector, string[]> =
-    {
-      quicksight: [
-        "Line chart: daily revenue and failed events trend",
-        "Stacked bar: category revenue contribution",
-        "KPI tiles: processed %, failed %, total revenue",
-      ],
-      powerbi: [
-        "Combo chart: daily events vs revenue",
-        "Treemap: category share by revenue",
-        "Funnel: processed vs failed event flow",
-      ],
-      tableau: [
-        "Dual-axis time series for revenue and failures",
-        "Heatmap of day-of-week vs category volume",
-        "Pareto chart of category impact",
-      ],
-      lookerstudio: [
-        "Scorecards for totals and fail rate",
-        "Time series for revenue trajectory",
-        "Pie chart for category split",
-      ],
-      metabase: [
-        "Dashboard cards for weekly KPIs",
-        "Area chart for volume and revenue",
-        "Bar chart for processing status breakdown",
-      ],
-    };
+  const chartRecommendationsByConnector: Record<AnalyticsConnector, string[]> = {
+    quicksight: [
+      "Line chart: daily revenue and failed events trend",
+      "Stacked bar: category revenue contribution",
+      "KPI tiles: processed %, failed %, total revenue",
+    ],
+    powerbi: [
+      "Combo chart: daily events vs revenue",
+      "Treemap: category share by revenue",
+      "Funnel: processed vs failed event flow",
+    ],
+    tableau: [
+      "Dual-axis time series for revenue and failures",
+      "Heatmap of day-of-week vs category volume",
+      "Pareto chart of category impact",
+    ],
+    lookerstudio: [
+      "Scorecards for totals and fail rate",
+      "Time series for revenue trajectory",
+      "Pie chart for category split",
+    ],
+    metabase: [
+      "Dashboard cards for weekly KPIs",
+      "Area chart for volume and revenue",
+      "Bar chart for processing status breakdown",
+    ],
+  };
 
   const serviceHintsByConnector: Record<AnalyticsConnector, string[]> = {
     quicksight: [
@@ -561,9 +507,7 @@ function buildConnectorPayload(
       averageRevenuePerEventMinor: preprocessed.averageRevenuePerEventMinor,
       revenueDeltaPct: preprocessed.momentum.revenueDeltaPct,
       failureRateDeltaPct: preprocessed.momentum.failureRateDeltaPct,
-      topRevenueCategories: preprocessed.topRevenueCategories.map(
-        (entry) => entry.category,
-      ),
+      topRevenueCategories: preprocessed.topRevenueCategories.map((entry) => entry.category),
       dataQualityNotes: preprocessed.dataQuality.notes,
     },
     chartRecommendations: chartRecommendationsByConnector[connector],
@@ -593,26 +537,21 @@ export async function runAnalyticsAgentOrchestration(params: {
     },
   ];
 
-  const raw = await callClaude(
-    buildUserPrompt(snapshot, preprocessed, goals),
-    apiKey,
-    {
-      model: "claude-sonnet-4-6",
-      maxTokens: 1500,
-      system: buildSystemPrompt(),
-    },
-  );
+  const raw = await callClaude(buildUserPrompt(snapshot, preprocessed, goals), apiKey, {
+    model: "claude-sonnet-4-6",
+    maxTokens: 1500,
+    system: buildSystemPrompt(),
+  });
 
   const report = parseClaudeJson(raw) ?? defaultReport(snapshot, preprocessed);
   workflow.push({
     step: "generate_insights",
     status: "completed",
-    details:
-      "Generated executive narrative, next moves, and scenario outcomes.",
+    details: "Generated executive narrative, next moves, and scenario outcomes.",
   });
 
   const connectorPayloads = connectors.map((connector) =>
-    buildConnectorPayload(connector, snapshot, preprocessed),
+    buildConnectorPayload(connector, snapshot, preprocessed)
   );
   workflow.push({
     step: "prepare_connectors",

--- a/src/lib/analytics-orchestration-input.ts
+++ b/src/lib/analytics-orchestration-input.ts
@@ -8,10 +8,7 @@ export const ALLOWED_ANALYTICS_CONNECTORS: AnalyticsConnector[] = [
   "metabase",
 ];
 
-export const DEFAULT_ANALYTICS_CONNECTORS: AnalyticsConnector[] = [
-  "quicksight",
-  "powerbi",
-];
+export const DEFAULT_ANALYTICS_CONNECTORS: AnalyticsConnector[] = ["quicksight", "powerbi"];
 
 export interface AnalyticsOrchestrationInput {
   windowDays: number;
@@ -36,11 +33,8 @@ function normalizeConnectors(value: unknown): AnalyticsConnector[] {
   return Array.from(deduped);
 }
 
-export function parseAnalyticsOrchestrationRequestBody(
-  body: unknown,
-): AnalyticsOrchestrationInput {
-  const payload =
-    body && typeof body === "object" && !Array.isArray(body) ? body : {};
+export function parseAnalyticsOrchestrationRequestBody(body: unknown): AnalyticsOrchestrationInput {
+  const payload = body && typeof body === "object" && !Array.isArray(body) ? body : {};
   const record = payload as Record<string, unknown>;
 
   let windowDays = 30;

--- a/src/lib/analytics-report-pdf.ts
+++ b/src/lib/analytics-report-pdf.ts
@@ -1,10 +1,4 @@
-import {
-  PDFDocument,
-  StandardFonts,
-  rgb,
-  type PDFFont,
-  type PDFPage,
-} from "pdf-lib";
+import { PDFDocument, StandardFonts, rgb, type PDFFont, type PDFPage } from "pdf-lib";
 import type { AnalyticsOrchestrationResult } from "@/lib/analytics-agent-orchestrator";
 
 const PAGE_WIDTH = 595.28;
@@ -27,7 +21,7 @@ function splitOversizedWord(
   font: PDFFont,
   size: number,
   maxWidth: number,
-  lines: string[],
+  lines: string[]
 ): string {
   let segment = "";
   for (const character of word) {
@@ -42,12 +36,7 @@ function splitOversizedWord(
   return segment;
 }
 
-function wrapText(
-  text: string,
-  font: PDFFont,
-  size: number,
-  maxWidth: number,
-): string[] {
+function wrapText(text: string, font: PDFFont, size: number, maxWidth: number): string[] {
   const words = text.replace(/\s+/g, " ").trim().split(" ");
   if (words.length === 1 && words[0] === "") return [""];
 
@@ -81,11 +70,7 @@ function newPage(pdf: PDFDocument): DrawState {
   };
 }
 
-function ensureSpace(
-  pdf: PDFDocument,
-  state: DrawState,
-  neededHeight: number,
-): DrawState {
+function ensureSpace(pdf: PDFDocument, state: DrawState, neededHeight: number): DrawState {
   if (state.y - neededHeight >= PAGE_MARGIN) return state;
   return newPage(pdf);
 }
@@ -206,7 +191,7 @@ export async function renderAnalyticsReportPdf(params: {
       size: SUBTITLE_SIZE,
       font: regularFont,
       color: rgb(0.35, 0.39, 0.45),
-    },
+    }
   );
   state = { ...state, y: state.y - 24 };
 
@@ -275,8 +260,7 @@ export async function renderAnalyticsReportPdf(params: {
     state,
     font: regularFont,
     items: result.report.nextMoves.map(
-      (move) =>
-        `${move.move} (${move.confidence}, ${move.timeframeDays}d): ${move.expectedOutcome}`,
+      (move) => `${move.move} (${move.confidence}, ${move.timeframeDays}d): ${move.expectedOutcome}`
     ),
   });
   state = { ...state, y: state.y - 8 };
@@ -293,7 +277,7 @@ export async function renderAnalyticsReportPdf(params: {
     font: regularFont,
     items: result.report.scenarioOutcomes.map(
       (scenario) =>
-        `${scenario.scenario}: revenue ${scenario.expectedRevenueDeltaPct}%, conversion ${scenario.expectedConversionDeltaPct}%`,
+        `${scenario.scenario}: revenue ${scenario.expectedRevenueDeltaPct}%, conversion ${scenario.expectedConversionDeltaPct}%`
     ),
   });
   state = { ...state, y: state.y - 8 };
@@ -309,8 +293,7 @@ export async function renderAnalyticsReportPdf(params: {
     state,
     font: regularFont,
     items: result.connectorPayloads.map(
-      (payload) =>
-        `${payload.connector}: ${payload.chartRecommendations[0] ?? "Dashboard ready"}`,
+      (payload) => `${payload.connector}: ${payload.chartRecommendations[0] ?? "Dashboard ready"}`
     ),
   });
 

--- a/src/lib/anthropic.ts
+++ b/src/lib/anthropic.ts
@@ -21,11 +21,7 @@ const VERIFY_TIMEOUT_MS = 8_000;
 const DEFAULT_MAX_TOKENS = 1_000;
 const DEFAULT_CHAT_MODEL = "claude-3-5-haiku-latest";
 
-export type AnthropicTokenStatus =
-  | "valid"
-  | "rejected"
-  | "not_configured"
-  | "error";
+export type AnthropicTokenStatus = "valid" | "rejected" | "not_configured" | "error";
 
 const ERROR_STATUS: AnthropicTokenStatus = "error";
 
@@ -89,8 +85,7 @@ export async function verifyAnthropicKey(): Promise<{
         message: `API key rejected (${res.status}) — check key validity or billing.`,
       };
     }
-    if (!res.ok)
-      return { status: ERROR_STATUS, message: `API returned ${res.status}` };
+    if (!res.ok) return { status: ERROR_STATUS, message: `API returned ${res.status}` };
     return { status: "valid" };
   } catch {
     return { status: ERROR_STATUS, message: "Connection failed." };
@@ -118,13 +113,9 @@ export interface CallClaudeOptions {
 export async function callClaude(
   prompt: string,
   apiKey: string,
-  options: CallClaudeOptions = {},
+  options: CallClaudeOptions = {}
 ): Promise<string> {
-  const {
-    model = "claude-sonnet-4-6",
-    maxTokens = DEFAULT_MAX_TOKENS,
-    system,
-  } = options;
+  const { model = "claude-sonnet-4-6", maxTokens = DEFAULT_MAX_TOKENS, system } = options;
 
   const body: Record<string, unknown> = {
     model,

--- a/src/lib/api-errors.ts
+++ b/src/lib/api-errors.ts
@@ -17,7 +17,7 @@ export function mapIntegrationError(err: unknown): NextResponse | null {
         reason: "integration_not_configured",
         missing: err.keys,
       },
-      { status: 503 },
+      { status: 503 }
     );
   }
   return null;

--- a/src/lib/bedrock-chat.ts
+++ b/src/lib/bedrock-chat.ts
@@ -40,7 +40,7 @@ const BEDROCK_TOOL_CONFIG = buildBedrockToolConfig(CHAT_TOOLS);
  */
 export async function runBedrockChatLoop(
   systemPrompt: string,
-  initialMessages: { role: "user" | "assistant"; content: string }[],
+  initialMessages: { role: "user" | "assistant"; content: string }[]
 ): Promise<string> {
   const client = getBedrockClient();
 
@@ -61,8 +61,7 @@ export async function runBedrockChatLoop(
 
     const response = await client.send(cmd);
     const stopReason = response.stopReason;
-    const assistantContent: AnyBlock[] =
-      (response.output?.message?.content as AnyBlock[]) ?? [];
+    const assistantContent: AnyBlock[] = (response.output?.message?.content as AnyBlock[]) ?? [];
 
     if (stopReason !== "tool_use") {
       // Extract and concatenate all text blocks.
@@ -78,13 +77,10 @@ export async function runBedrockChatLoop(
     // Extract tool-use blocks and execute them in parallel.
     const toolUseBlocks = assistantContent.filter(
       (b): b is ToolUseBlock =>
-        "toolUse" in b &&
-        typeof (b as ToolUseBlock).toolUse?.toolUseId === "string",
+        "toolUse" in b && typeof (b as ToolUseBlock).toolUse?.toolUseId === "string"
     );
 
-    toolUseBlocks.forEach((b) =>
-      console.warn("[chat] tool_use", b.toolUse.name),
-    );
+    toolUseBlocks.forEach((b) => console.warn("[chat] tool_use", b.toolUse.name));
 
     const toolResults: ToolResultBlock[] = await Promise.all(
       toolUseBlocks.map(async (b) => {
@@ -95,7 +91,7 @@ export async function runBedrockChatLoop(
             content: [{ text: result }] as [{ text: string }],
           },
         };
-      }),
+      })
     );
 
     messages.push({ role: "user", content: toolResults });

--- a/src/lib/bedrock-shared.ts
+++ b/src/lib/bedrock-shared.ts
@@ -19,8 +19,7 @@ const DEFAULT_REGION = "us-east-1";
 const DEFAULT_MODEL_ID = "us.anthropic.claude-3-5-haiku-20241022-v1:0";
 
 export const BEDROCK_REGION = process.env.AWS_REGION ?? DEFAULT_REGION;
-export const BEDROCK_MODEL_ID =
-  process.env.BEDROCK_MODEL_ID ?? DEFAULT_MODEL_ID;
+export const BEDROCK_MODEL_ID = process.env.BEDROCK_MODEL_ID ?? DEFAULT_MODEL_ID;
 
 // ---------------------------------------------------------------------------
 // Content block types — narrow shape of what we actually read / write.
@@ -75,7 +74,7 @@ interface AnthropicShapedTool {
 }
 
 export function buildBedrockToolConfig(
-  tools: ReadonlyArray<AnthropicShapedTool>,
+  tools: ReadonlyArray<AnthropicShapedTool>
 ): ToolConfiguration {
   return {
     tools: tools.map((t) => ({
@@ -110,9 +109,7 @@ export interface RunBedrockTurnOptions {
  * Run one Bedrock Converse turn and return the assistant's content blocks.
  * Callers handle the loop, tool dispatch, and termination conditions.
  */
-export async function runBedrockTurn(
-  opts: RunBedrockTurnOptions,
-): Promise<AnyBlock[]> {
+export async function runBedrockTurn(opts: RunBedrockTurnOptions): Promise<AnyBlock[]> {
   const cmd = new ConverseCommand({
     modelId: BEDROCK_MODEL_ID,
     system: [{ text: opts.system }],
@@ -127,8 +124,7 @@ export async function runBedrockTurn(
 /** Filter an assistant content array to just the tool-use blocks. */
 export function pickToolUseBlocks(content: AnyBlock[]): ToolUseBlock[] {
   return content.filter(
-    (b): b is ToolUseBlock =>
-      "toolUse" in b && typeof b.toolUse?.toolUseId === "string",
+    (b): b is ToolUseBlock => "toolUse" in b && typeof b.toolUse?.toolUseId === "string"
   );
 }
 

--- a/src/lib/blog-source.ts
+++ b/src/lib/blog-source.ts
@@ -15,8 +15,7 @@ const DEFAULT_CATEGORY = "Cloud" as BlogPost["category"];
 const WORDS_PER_MINUTE = 200;
 
 function normalizeCategory(tags: string[]): BlogPost["category"] {
-  return (tags.find((tag) => tag.trim()) ??
-    DEFAULT_CATEGORY) as BlogPost["category"];
+  return (tags.find((tag) => tag.trim()) ?? DEFAULT_CATEGORY) as BlogPost["category"];
 }
 
 function estimateReadTime(text: string): string {
@@ -41,7 +40,7 @@ function extractPayloadText(payload?: Record<string, unknown>): string {
       .map((entry) =>
         typeof entry === "object" && entry !== null && "plain_text" in entry
           ? String(entry.plain_text ?? "")
-          : "",
+          : ""
       )
       .join("");
   }
@@ -52,7 +51,7 @@ function extractPayloadText(payload?: Record<string, unknown>): string {
       .map((entry) =>
         typeof entry === "object" && entry !== null && "plain_text" in entry
           ? String(entry.plain_text ?? "")
-          : "",
+          : ""
       )
       .join("");
   }
@@ -122,9 +121,7 @@ function mapNotionListingPost(post: NotionPost): BlogPost {
   };
 }
 
-function mapNotionPost(
-  post: NotionPost & { content: NotionBlock[] },
-): BlogPost {
+function mapNotionPost(post: NotionPost & { content: NotionBlock[] }): BlogPost {
   const content = blocksToContent(post.content);
   return {
     slug: post.slug,
@@ -150,9 +147,7 @@ export async function getBlogPosts(): Promise<BlogPost[]> {
   }
 }
 
-export async function getBlogPostBySlug(
-  slug: string,
-): Promise<BlogPost | undefined> {
+export async function getBlogPostBySlug(slug: string): Promise<BlogPost | undefined> {
   if (!isConfigured("NOTION_API_KEY", "NOTION_BLOG_DB_ID")) {
     return getStaticPostBySlug(slug);
   }

--- a/src/lib/booking-slots.ts
+++ b/src/lib/booking-slots.ts
@@ -35,10 +35,7 @@ const ATHENS_TIME_ONLY_FORMAT: Intl.DateTimeFormatOptions = {
  */
 export function formatAthensSlot(start: string, end: string): string {
   const startStr = new Date(start).toLocaleString("en-IE", ATHENS_DATE_FORMAT);
-  const endStr = new Date(end).toLocaleTimeString(
-    "en-IE",
-    ATHENS_TIME_ONLY_FORMAT,
-  );
+  const endStr = new Date(end).toLocaleTimeString("en-IE", ATHENS_TIME_ONLY_FORMAT);
   return `${startStr}–${endStr} Athens`;
 }
 
@@ -47,7 +44,6 @@ export function formatAthensSlot(start: string, end: string): string {
  * (between MIN_DAYS_AHEAD and MAX_DAYS_AHEAD).
  */
 export function clampDaysAhead(raw: unknown): number {
-  const n =
-    typeof raw === "number" && Number.isFinite(raw) ? raw : DEFAULT_DAYS_AHEAD;
+  const n = typeof raw === "number" && Number.isFinite(raw) ? raw : DEFAULT_DAYS_AHEAD;
   return Math.max(MIN_DAYS_AHEAD, Math.min(MAX_DAYS_AHEAD, Math.trunc(n)));
 }

--- a/src/lib/campaigns/google-ads.ts
+++ b/src/lib/campaigns/google-ads.ts
@@ -23,8 +23,7 @@ async function getServiceAccountAccessToken(): Promise<string> {
   const rawKey = process.env.GOOGLE_PRIVATE_KEY ?? "";
   const privateKey = rawKey.replace(/\\n/g, "\n");
 
-  if (!email || !privateKey)
-    throw new Error("Google service account env vars missing");
+  if (!email || !privateKey) throw new Error("Google service account env vars missing");
 
   const header = base64url(JSON.stringify({ alg: "RS256", typ: "JWT" }));
   const payload = base64url(
@@ -34,7 +33,7 @@ async function getServiceAccountAccessToken(): Promise<string> {
       aud: "https://oauth2.googleapis.com/token",
       iat: now,
       exp: now + 3600,
-    }),
+    })
   );
 
   const signer = createSign("RSA-SHA256");
@@ -52,8 +51,7 @@ async function getServiceAccountAccessToken(): Promise<string> {
   });
 
   const data = (await res.json()) as { access_token?: string; error?: string };
-  if (!data.access_token)
-    throw new Error(`Google token exchange failed: ${data.error}`);
+  if (!data.access_token) throw new Error(`Google token exchange failed: ${data.error}`);
 
   cachedToken = { value: data.access_token, expiresAt: now + 3600 };
   return data.access_token;
@@ -76,10 +74,7 @@ async function getGoogleAdsConfig(): Promise<{
   };
 }
 
-async function gadsFetch(
-  path: string,
-  options: RequestInit = {},
-): Promise<Response> {
+async function gadsFetch(path: string, options: RequestInit = {}): Promise<Response> {
   const { devToken, customerId, accessToken } = await getGoogleAdsConfig();
   return fetch(`${GOOGLE_ADS_API}${path}`, {
     ...options,
@@ -96,9 +91,7 @@ async function gadsFetch(
 export async function isGoogleAdsConfigured(): Promise<boolean> {
   try {
     const cfg = await getConfig();
-    return Boolean(
-      cfg.GOOGLE_ADS_DEVELOPER_TOKEN && cfg.GOOGLE_ADS_CUSTOMER_ID,
-    );
+    return Boolean(cfg.GOOGLE_ADS_DEVELOPER_TOKEN && cfg.GOOGLE_ADS_CUSTOMER_ID);
   } catch {
     return false;
   }
@@ -152,7 +145,7 @@ export async function listGoogleCampaigns(): Promise<GoogleCampaign[]> {
         budgetAmountMicros: r.campaignBudget?.amountMicros ?? "0",
         startDate: r.campaign.startDate,
         endDate: r.campaign.endDate,
-      }),
+      })
     );
   } catch {
     return [];
@@ -167,10 +160,7 @@ export interface GoogleMetrics {
   ctr: number;
 }
 
-export async function getGoogleMetrics(
-  dateStart: string,
-  dateEnd: string,
-): Promise<GoogleMetrics> {
+export async function getGoogleMetrics(dateStart: string, dateEnd: string): Promise<GoogleMetrics> {
   const empty: GoogleMetrics = {
     impressions: 0,
     clicks: 0,

--- a/src/lib/campaigns/linkedin.ts
+++ b/src/lib/campaigns/linkedin.ts
@@ -15,10 +15,7 @@ async function getLinkedInConfig(): Promise<{
   return { token, adAccountId, orgUrn };
 }
 
-async function liiFetch(
-  path: string,
-  options: RequestInit = {},
-): Promise<Response> {
+async function liiFetch(path: string, options: RequestInit = {}): Promise<Response> {
   const { token } = await getLinkedInConfig();
   return fetch(`${LINKEDIN_API}${path}`, {
     ...options,
@@ -56,7 +53,7 @@ export async function listLinkedInCampaigns(): Promise<LinkedInCampaign[]> {
     const { adAccountId } = await getLinkedInConfig();
     if (!adAccountId) return [];
     const res = await liiFetch(
-      `/adAccounts/${adAccountId}/adCampaigns?q=search&search.status.values[0]=ACTIVE&count=20`,
+      `/adAccounts/${adAccountId}/adCampaigns?q=search&search.status.values[0]=ACTIVE&count=20`
     );
     if (!res.ok) return [];
     const data = await res.json();
@@ -81,7 +78,7 @@ export async function listLinkedInCampaigns(): Promise<LinkedInCampaign[]> {
         totalBudget: el.totalBudget ?? null,
         createdAt: el.changeAuditStamps?.created?.time ?? 0,
         lastModifiedAt: el.changeAuditStamps?.lastModified?.time ?? 0,
-      }),
+      })
     );
   } catch {
     return [];
@@ -97,7 +94,7 @@ export interface LinkedInInsights {
 
 export async function getLinkedInInsights(
   dateStart: string,
-  dateEnd: string,
+  dateEnd: string
 ): Promise<LinkedInInsights> {
   const empty: LinkedInInsights = {
     impressions: 0,
@@ -109,7 +106,7 @@ export async function getLinkedInInsights(
     const { adAccountId } = await getLinkedInConfig();
     if (!adAccountId) return empty;
     const res = await liiFetch(
-      `/adAnalytics?q=analytics&pivot=ACCOUNT&dateRange.start.day=${dateStart.split("-")[2]}&dateRange.start.month=${dateStart.split("-")[1]}&dateRange.start.year=${dateStart.split("-")[0]}&dateRange.end.day=${dateEnd.split("-")[2]}&dateRange.end.month=${dateEnd.split("-")[1]}&dateRange.end.year=${dateEnd.split("-")[0]}&accounts[0]=urn:li:sponsoredAccount:${adAccountId}&fields=impressions,clicks,costInLocalCurrency,leads`,
+      `/adAnalytics?q=analytics&pivot=ACCOUNT&dateRange.start.day=${dateStart.split("-")[2]}&dateRange.start.month=${dateStart.split("-")[1]}&dateRange.start.year=${dateStart.split("-")[0]}&dateRange.end.day=${dateEnd.split("-")[2]}&dateRange.end.month=${dateEnd.split("-")[1]}&dateRange.end.year=${dateEnd.split("-")[0]}&accounts[0]=urn:li:sponsoredAccount:${adAccountId}&fields=impressions,clicks,costInLocalCurrency,leads`
     );
     if (!res.ok) return empty;
     const data = await res.json();

--- a/src/lib/campaigns/tiktok.ts
+++ b/src/lib/campaigns/tiktok.ts
@@ -13,10 +13,7 @@ async function getTikTokConfig(): Promise<{
   return { token, advertiserId };
 }
 
-async function ttFetch(
-  path: string,
-  options: RequestInit = {},
-): Promise<Response> {
+async function ttFetch(path: string, options: RequestInit = {}): Promise<Response> {
   const { token } = await getTikTokConfig();
   return fetch(`${TIKTOK_API}${path}`, {
     ...options,
@@ -51,9 +48,7 @@ export interface TikTokCampaign {
 export async function listTikTokCampaigns(): Promise<TikTokCampaign[]> {
   try {
     const { advertiserId } = await getTikTokConfig();
-    const res = await ttFetch(
-      `/campaign/get/?advertiser_id=${advertiserId}&page_size=20`,
-    );
+    const res = await ttFetch(`/campaign/get/?advertiser_id=${advertiserId}&page_size=20`);
     if (!res.ok) return [];
     const data = await res.json();
     return data.data?.list ?? [];
@@ -73,7 +68,7 @@ export interface TikTokInsights {
 
 export async function getTikTokInsights(
   dateStart: string,
-  dateEnd: string,
+  dateEnd: string
 ): Promise<TikTokInsights> {
   const empty: TikTokInsights = {
     spend: "0",
@@ -101,11 +96,9 @@ export async function getTikTokInsights(
     });
     if (!res.ok) return empty;
     const data = await res.json();
-    const rows: Record<string, Record<string, string>>[] =
-      data.data?.list ?? [];
+    const rows: Record<string, Record<string, string>>[] = data.data?.list ?? [];
     if (rows.length === 0) return empty;
-    const metrics: Record<string, string> =
-      (rows[0].metrics as Record<string, string>) ?? {};
+    const metrics: Record<string, string> = (rows[0].metrics as Record<string, string>) ?? {};
     return {
       spend: metrics.spend ?? "0",
       impressions: metrics.impressions ?? "0",

--- a/src/lib/campaigns/x-ads.ts
+++ b/src/lib/campaigns/x-ads.ts
@@ -11,8 +11,7 @@ async function getXConfig(): Promise<{
   adAccountId: string;
 }> {
   const cfg = await getConfig();
-  if (!cfg.X_API_KEY || !cfg.X_ACCESS_TOKEN)
-    throw new Error("X not configured");
+  if (!cfg.X_API_KEY || !cfg.X_ACCESS_TOKEN) throw new Error("X not configured");
   return {
     apiKey: cfg.X_API_KEY,
     apiSecret: cfg.X_API_SECRET,
@@ -28,7 +27,7 @@ function buildOAuthHeader(
   apiKey: string,
   apiSecret: string,
   accessToken: string,
-  accessSecret: string,
+  accessSecret: string
 ): string {
   const nonce = randomBytes(16).toString("hex");
   const ts = Math.floor(Date.now() / 1000).toString();
@@ -58,10 +57,7 @@ function buildOAuthHeader(
   return header;
 }
 
-async function xFetch(
-  path: string,
-  options: RequestInit = {},
-): Promise<Response> {
+async function xFetch(path: string, options: RequestInit = {}): Promise<Response> {
   const cfg = await getXConfig();
   const url = `${X_ADS_API}${path}`;
   const method = (options.method ?? "GET").toUpperCase();
@@ -71,7 +67,7 @@ async function xFetch(
     cfg.apiKey,
     cfg.apiSecret,
     cfg.accessToken,
-    cfg.accessSecret,
+    cfg.accessSecret
   );
   return fetch(url, {
     ...options,
@@ -106,9 +102,7 @@ export async function listXCampaigns(): Promise<XCampaign[]> {
   try {
     const { adAccountId } = await getXConfig();
     if (!adAccountId) return [];
-    const res = await xFetch(
-      `/accounts/${adAccountId}/campaigns?count=20&sort_by=created_at-desc`,
-    );
+    const res = await xFetch(`/accounts/${adAccountId}/campaigns?count=20&sort_by=created_at-desc`);
     if (!res.ok) return [];
     const data = await res.json();
     return data.data ?? [];
@@ -124,10 +118,7 @@ export interface XStats {
   engagements: number;
 }
 
-export async function getXStats(
-  dateStart: string,
-  dateEnd: string,
-): Promise<XStats> {
+export async function getXStats(dateStart: string, dateEnd: string): Promise<XStats> {
   const empty: XStats = {
     impressions: 0,
     clicks: 0,
@@ -138,7 +129,7 @@ export async function getXStats(
     const { adAccountId } = await getXConfig();
     if (!adAccountId) return empty;
     const res = await xFetch(
-      `/stats/accounts/${adAccountId}?granularity=DAY&metric_groups=ENGAGEMENT,BILLING&start_time=${dateStart}T00:00:00Z&end_time=${dateEnd}T23:59:59Z`,
+      `/stats/accounts/${adAccountId}?granularity=DAY&metric_groups=ENGAGEMENT,BILLING&start_time=${dateStart}T00:00:00Z&end_time=${dateEnd}T23:59:59Z`
     );
     if (!res.ok) return empty;
     const data = await res.json();

--- a/src/lib/chat-tools.ts
+++ b/src/lib/chat-tools.ts
@@ -57,8 +57,7 @@ export const CHAT_TOOLS = [
       properties: {
         days_ahead: {
           type: "integer",
-          description:
-            "How many days ahead to search. Defaults to 7. Capped at 14.",
+          description: "How many days ahead to search. Defaults to 7. Capped at 14.",
           minimum: MIN_DAYS_AHEAD,
           maximum: MAX_DAYS_AHEAD,
         },
@@ -79,8 +78,7 @@ export const CHAT_TOOLS = [
         },
         email: {
           type: "string",
-          description:
-            "Email address for the calendar invite and Google Meet link.",
+          description: "Email address for the calendar invite and Google Meet link.",
         },
         start: {
           type: "string",
@@ -94,8 +92,7 @@ export const CHAT_TOOLS = [
         },
         notes: {
           type: "string",
-          description:
-            "Optional notes or context the visitor shared about their needs.",
+          description: "Optional notes or context the visitor shared about their needs.",
         },
       },
       required: ["name", "email", "start", "end"],
@@ -126,8 +123,7 @@ interface BookSlotInput {
 }
 
 async function runLookupProduct(input: LookupProductInput): Promise<string> {
-  const query =
-    typeof input.query === "string" ? input.query.trim().toLowerCase() : "";
+  const query = typeof input.query === "string" ? input.query.trim().toLowerCase() : "";
   if (!query) return "No query provided.";
 
   const products = await getProducts();
@@ -137,7 +133,7 @@ async function runLookupProduct(input: LookupProductInput): Promise<string> {
         p.name.toLowerCase().includes(query) ||
         p.description.toLowerCase().includes(query) ||
         p.category.toLowerCase().includes(query) ||
-        (p.features ?? []).some((f) => f.toLowerCase().includes(query)),
+        (p.features ?? []).some((f) => f.toLowerCase().includes(query))
     )
     .slice(0, MAX_PRODUCT_RESULTS);
 
@@ -153,9 +149,7 @@ async function runLookupProduct(input: LookupProductInput): Promise<string> {
   return `Found ${matches.length} match(es):\n${lines.join("\n")}`;
 }
 
-async function runCheckCalendarAvailability(
-  input: CheckCalendarInput,
-): Promise<string> {
+async function runCheckCalendarAvailability(input: CheckCalendarInput): Promise<string> {
   if (!(await isConfiguredAsync("GOOGLE_CLIENT_EMAIL", "GOOGLE_PRIVATE_KEY"))) {
     return "Calendar booking is not yet wired up. Suggest the visitor use the Contact page to request a time.";
   }
@@ -175,10 +169,7 @@ async function runCheckCalendarAvailability(
 
   const lines = slots
     .slice(0, MAX_SLOT_RESULTS)
-    .map(
-      (s) =>
-        `- ${formatAthensSlot(s.start, s.end)} [start=${s.start} end=${s.end}]`,
-    );
+    .map((s) => `- ${formatAthensSlot(s.start, s.end)} [start=${s.start} end=${s.end}]`);
   return `Available slots (next ${days} day(s)):\n${lines.join("\n")}\nAsk the visitor which slot they prefer, then collect their name and email to call book_slot. They can also book directly at https://cloudless.gr/book.`;
 }
 
@@ -188,14 +179,11 @@ async function runBookSlot(input: BookSlotInput): Promise<string> {
   }
 
   const name = typeof input.name === "string" ? input.name.trim() : "";
-  const email =
-    typeof input.email === "string" ? input.email.trim().toLowerCase() : "";
+  const email = typeof input.email === "string" ? input.email.trim().toLowerCase() : "";
   const start = typeof input.start === "string" ? input.start.trim() : "";
   const end = typeof input.end === "string" ? input.end.trim() : "";
   const notes =
-    typeof input.notes === "string" && input.notes.trim()
-      ? input.notes.trim()
-      : undefined;
+    typeof input.notes === "string" && input.notes.trim() ? input.notes.trim() : undefined;
 
   if (!name) return "Missing visitor name. Ask them for their full name first.";
   if (!email || !email.includes("@"))
@@ -217,18 +205,14 @@ async function runBookSlot(input: BookSlotInput): Promise<string> {
     start,
     notes,
     meetLink: result.htmlLink,
-  }).catch((err) =>
-    console.warn("[chat-tools] slackBookingNotify failed:", err),
-  );
+  }).catch((err) => console.warn("[chat-tools] slackBookingNotify failed:", err));
   void sendBookingConfirmation({
     name,
     email,
     slotLabel,
     meetLink: result.htmlLink,
     notes,
-  }).catch((err) =>
-    console.warn("[chat-tools] sendBookingConfirmation failed:", err),
-  );
+  }).catch((err) => console.warn("[chat-tools] sendBookingConfirmation failed:", err));
 
   return [
     `Booking confirmed!`,
@@ -245,17 +229,16 @@ async function runBookSlot(input: BookSlotInput): Promise<string> {
  * because a thrown tool result would crash the chat loop.
  */
 export async function runTool(name: string, input: unknown): Promise<string> {
-  const safeInput = (
-    typeof input === "object" && input !== null ? input : {}
-  ) as LookupProductInput | CheckCalendarInput | BookSlotInput;
+  const safeInput = (typeof input === "object" && input !== null ? input : {}) as
+    | LookupProductInput
+    | CheckCalendarInput
+    | BookSlotInput;
   try {
     if (name === "lookup_product") {
       return await runLookupProduct(safeInput as LookupProductInput);
     }
     if (name === "check_calendar_availability") {
-      return await runCheckCalendarAvailability(
-        safeInput as CheckCalendarInput,
-      );
+      return await runCheckCalendarAvailability(safeInput as CheckCalendarInput);
     }
     if (name === "book_slot") {
       return await runBookSlot(safeInput as BookSlotInput);

--- a/src/lib/content-calendar.ts
+++ b/src/lib/content-calendar.ts
@@ -64,10 +64,7 @@ async function notionEnabled(): Promise<boolean> {
   return !!(cfg.NOTION_API_KEY && cfg.NOTION_CALENDAR_DB_ID);
 }
 
-export async function getCalendarItems(
-  from?: string,
-  to?: string,
-): Promise<CalendarItem[]> {
+export async function getCalendarItems(from?: string, to?: string): Promise<CalendarItem[]> {
   if (await notionEnabled()) {
     return (await notionGetCalendarItems(from, to)) ?? [];
   }
@@ -79,9 +76,7 @@ export async function getCalendarItems(
   });
 }
 
-export async function createCalendarItem(
-  input: Omit<CalendarItem, "id">,
-): Promise<CalendarItem> {
+export async function createCalendarItem(input: Omit<CalendarItem, "id">): Promise<CalendarItem> {
   const item: CalendarItem = {
     ...input,
     id: `cal_${Date.now()}_${Math.random().toString(36).substring(2, 7)}`,
@@ -96,7 +91,7 @@ export async function createCalendarItem(
 
 export async function updateCalendarItem(
   id: string,
-  updates: Partial<Omit<CalendarItem, "id">>,
+  updates: Partial<Omit<CalendarItem, "id">>
 ): Promise<CalendarItem | null> {
   if (await notionEnabled()) {
     const all = (await notionGetCalendarItems()) ?? [];

--- a/src/lib/email.ts
+++ b/src/lib/email.ts
@@ -57,14 +57,13 @@ export async function sendEmail(options: SendEmailOptions): Promise<void> {
             ...(extraHeaders.length ? { Headers: extraHeaders } : {}),
           },
         },
-      }),
+      })
     );
   } catch (err: unknown) {
     // AWS SDK v3 XML parser throws a deserialization error on SES success responses
     // that contain &#xD; entities. If HTTP status is 200 the email was delivered —
     // swallow the parse error and continue.
-    const meta = (err as { $metadata?: { httpStatusCode?: number } })
-      ?.$metadata;
+    const meta = (err as { $metadata?: { httpStatusCode?: number } })?.$metadata;
     if (meta?.httpStatusCode !== 200) throw err;
   }
 }
@@ -73,7 +72,7 @@ export async function sendOrderConfirmation(
   customerEmail: string,
   sessionId: string,
   amountTotal: number,
-  currency: string,
+  currency: string
 ): Promise<void> {
   const formatted = new Intl.NumberFormat(DEFAULT_LOCALE, {
     style: "currency",
@@ -126,7 +125,7 @@ export async function sendOrderConfirmation(
 
 export async function sendPaymentFailureNotice(
   customerEmail: string,
-  invoiceId: string,
+  invoiceId: string
 ): Promise<void> {
   await sendEmail({
     to: customerEmail,
@@ -161,9 +160,7 @@ export async function sendPaymentFailureNotice(
   });
 }
 
-export async function sendSubscriberWelcome(
-  subscriberEmail: string,
-): Promise<void> {
+export async function sendSubscriberWelcome(subscriberEmail: string): Promise<void> {
   const unsubscribeUrl = `https://cloudless.gr/api/unsubscribe?email=${encodeURIComponent(subscriberEmail)}`;
   const safeUnsub = escapeHtml(unsubscribeUrl);
   await sendEmail({
@@ -346,9 +343,7 @@ export async function sendContactAcknowledgment(data: {
 /**
  * Confirmation email sent when a subscriber successfully unsubscribes.
  */
-export async function sendUnsubscribeConfirmation(
-  email: string,
-): Promise<void> {
+export async function sendUnsubscribeConfirmation(email: string): Promise<void> {
   await sendEmail({
     to: email,
     subject: "You've been unsubscribed — Cloudless",

--- a/src/lib/fetch-with-auth.ts
+++ b/src/lib/fetch-with-auth.ts
@@ -5,10 +5,7 @@
 
 import { fetchAuthSession } from "aws-amplify/auth";
 
-export async function fetchWithAuth(
-  url: string,
-  init?: RequestInit,
-): Promise<Response> {
+export async function fetchWithAuth(url: string, init?: RequestInit): Promise<Response> {
   try {
     const session = await fetchAuthSession();
     const idToken = session.tokens?.idToken?.toString();

--- a/src/lib/format-price.ts
+++ b/src/lib/format-price.ts
@@ -3,10 +3,7 @@ import { DEFAULT_LOCALE, DEFAULT_CURRENCY } from "./locale-defaults";
 /**
  * Format a Stripe price amount (cents → display string).
  */
-export function formatPrice(
-  amount: number,
-  currency: string = DEFAULT_CURRENCY,
-): string {
+export function formatPrice(amount: number, currency: string = DEFAULT_CURRENCY): string {
   return new Intl.NumberFormat(DEFAULT_LOCALE, {
     style: "currency",
     currency: currency.toUpperCase(),

--- a/src/lib/google-auth.ts
+++ b/src/lib/google-auth.ts
@@ -22,8 +22,7 @@ export function createGoogleAuth(scope: string): () => Promise<string> {
     const config = await getConfig();
     const email = config.GOOGLE_CLIENT_EMAIL;
     const key = config.GOOGLE_PRIVATE_KEY;
-    if (!email || !key)
-      throw new Error("Google service account not configured");
+    if (!email || !key) throw new Error("Google service account not configured");
 
     const { SignJWT, importPKCS8 } = await import("jose");
     const now = Math.floor(Date.now() / 1000);
@@ -52,8 +51,7 @@ export function createGoogleAuth(scope: string): () => Promise<string> {
 
     cached = {
       token: data.access_token,
-      expires:
-        Date.now() + (data.expires_in - TOKEN_REFRESH_BUFFER_SECS) * 1_000,
+      expires: Date.now() + (data.expires_in - TOKEN_REFRESH_BUFFER_SECS) * 1_000,
     };
 
     return cached.token;

--- a/src/lib/google-calendar.ts
+++ b/src/lib/google-calendar.ts
@@ -16,9 +16,7 @@ const CALENDAR_TIMEZONE = "Europe/Athens";
 const DEFAULT_CALENDAR_ID = "primary";
 const DATE_PART_2_DIGIT = "2-digit";
 
-const getAccessToken = createGoogleAuth(
-  "https://www.googleapis.com/auth/calendar",
-);
+const getAccessToken = createGoogleAuth("https://www.googleapis.com/auth/calendar");
 
 /**
  * Returns the UTC offset for Europe/Athens at the given instant, in ms.
@@ -35,26 +33,14 @@ function athensOffsetMs(date: Date): number {
     second: DATE_PART_2_DIGIT,
     hour12: false,
   });
-  const p = Object.fromEntries(
-    fmt.formatToParts(date).map(({ type, value }) => [type, value]),
-  );
-  const localMs = Date.UTC(
-    +p.year,
-    +p.month - 1,
-    +p.day,
-    +p.hour % 24,
-    +p.minute,
-    +p.second,
-  );
+  const p = Object.fromEntries(fmt.formatToParts(date).map(({ type, value }) => [type, value]));
+  const localMs = Date.UTC(+p.year, +p.month - 1, +p.day, +p.hour % 24, +p.minute, +p.second);
   return localMs - date.getTime();
 }
 
 const GCAL_TIMEOUT_MS = 10_000;
 
-async function calendarFetch(
-  path: string,
-  options: RequestInit = {},
-): Promise<Response> {
+async function calendarFetch(path: string, options: RequestInit = {}): Promise<Response> {
   const token = await getAccessToken();
   const controller = new AbortController();
   const timer = setTimeout(() => controller.abort(), GCAL_TIMEOUT_MS);
@@ -78,11 +64,7 @@ interface TimeSlot {
   end: string;
 }
 
-function slotOverlapsBusy(
-  slotStart: Date,
-  slotEnd: Date,
-  busySlots: TimeSlot[],
-): boolean {
+function slotOverlapsBusy(slotStart: Date, slotEnd: Date, busySlots: TimeSlot[]): boolean {
   return busySlots.some((busy) => {
     const bs = new Date(busy.start);
     const be = new Date(busy.end);
@@ -90,20 +72,14 @@ function slotOverlapsBusy(
   });
 }
 
-function slotsForDay(
-  day: Date,
-  now: Date,
-  busySlots: TimeSlot[],
-): TimeSlot[] {
+function slotsForDay(day: Date, now: Date, busySlots: TimeSlot[]): TimeSlot[] {
   const daySlots: TimeSlot[] = [];
   for (let hour = BUSINESS_OPEN_HOUR; hour < BUSINESS_CLOSE_HOUR; hour++) {
     for (const minute of [0, SLOT_DURATION_MINUTES]) {
       const slotStart = new Date(day);
       slotStart.setUTCHours(0, 0, 0, 0);
       const offset = athensOffsetMs(slotStart);
-      slotStart.setTime(
-        slotStart.getTime() + hour * MS_PER_HOUR + minute * MS_PER_MINUTE - offset,
-      );
+      slotStart.setTime(slotStart.getTime() + hour * MS_PER_HOUR + minute * MS_PER_MINUTE - offset);
       const slotEnd = new Date(slotStart.getTime() + SLOT_DURATION_MINUTES * MS_PER_MINUTE);
       if (slotStart < now) continue;
       if (!slotOverlapsBusy(slotStart, slotEnd, busySlots)) {
@@ -114,11 +90,7 @@ function slotsForDay(
   return daySlots;
 }
 
-function buildAvailableSlots(
-  now: Date,
-  daysAhead: number,
-  busySlots: TimeSlot[],
-): TimeSlot[] {
+function buildAvailableSlots(now: Date, daysAhead: number, busySlots: TimeSlot[]): TimeSlot[] {
   const slots: TimeSlot[] = [];
   for (let d = 0; d < daysAhead; d++) {
     const day = new Date(now.getTime() + d * MS_PER_DAY);
@@ -136,10 +108,7 @@ function buildAvailableSlots(
 export async function getAvailableSlots(daysAhead = 7): Promise<TimeSlot[]> {
   // Fast-path: check env vars before SSM so tests that stub them to "" don't
   // get real credentials from SSM. Mirrors the pattern in isConfiguredAsync.
-  if (
-    process.env.GOOGLE_CLIENT_EMAIL === "" ||
-    process.env.GOOGLE_PRIVATE_KEY === ""
-  ) {
+  if (process.env.GOOGLE_CLIENT_EMAIL === "" || process.env.GOOGLE_PRIVATE_KEY === "") {
     throw new Error("Google service account not configured");
   }
 
@@ -160,8 +129,7 @@ export async function getAvailableSlots(daysAhead = 7): Promise<TimeSlot[]> {
 
   if (!freeBusyRes.ok) return [];
   const freeBusyData = await freeBusyRes.json();
-  const busySlots: TimeSlot[] =
-    freeBusyData.calendars?.[calendarId]?.busy ?? [];
+  const busySlots: TimeSlot[] = freeBusyData.calendars?.[calendarId]?.busy ?? [];
 
   // Generate 30-min slots during business hours (09:00-17:00 Europe/Athens).
   // Athens is UTC+2 (EET) in winter and UTC+3 (EEST) in summer; the offset
@@ -209,7 +177,7 @@ export async function bookConsultation(data: {
             },
           },
         }),
-      },
+      }
     );
 
     if (!res.ok) {
@@ -238,19 +206,13 @@ interface Consultation {
  * Find consultation events for a specific attendee email.
  * Searches from 90 days ago to 30 days ahead.
  */
-export async function getConsultationsByEmail(
-  email: string,
-): Promise<Consultation[]> {
+export async function getConsultationsByEmail(email: string): Promise<Consultation[]> {
   const { GOOGLE_CALENDAR_ID } = await getConfig();
   const calendarId = GOOGLE_CALENDAR_ID ?? DEFAULT_CALENDAR_ID;
 
   const now = new Date();
-  const timeMin = new Date(
-    now.getTime() - LOOKBACK_DAYS * MS_PER_DAY,
-  ).toISOString();
-  const timeMax = new Date(
-    now.getTime() + LOOKAHEAD_DAYS * MS_PER_DAY,
-  ).toISOString();
+  const timeMin = new Date(now.getTime() - LOOKBACK_DAYS * MS_PER_DAY).toISOString();
+  const timeMax = new Date(now.getTime() + LOOKAHEAD_DAYS * MS_PER_DAY).toISOString();
 
   try {
     const params = new URLSearchParams({
@@ -263,7 +225,7 @@ export async function getConsultationsByEmail(
     });
 
     const res = await calendarFetch(
-      `/calendars/${encodeURIComponent(calendarId)}/events?${params}`,
+      `/calendars/${encodeURIComponent(calendarId)}/events?${params}`
     );
 
     if (!res.ok) return [];
@@ -274,7 +236,7 @@ export async function getConsultationsByEmail(
       .filter(
         (evt: Record<string, unknown>) =>
           typeof evt.summary === "string" &&
-          (evt.summary as string).toLowerCase().includes("consultation"),
+          (evt.summary as string).toLowerCase().includes("consultation")
       )
       .map((evt: Record<string, unknown>) => {
         const start = (evt.start as { dateTime?: string })?.dateTime ?? "";
@@ -283,9 +245,8 @@ export async function getConsultationsByEmail(
           title: evt.summary as string,
           start,
           end: (evt.end as { dateTime?: string })?.dateTime ?? "",
-          meetLink: (
-            evt.conferenceData as { entryPoints?: Array<{ uri?: string }> }
-          )?.entryPoints?.[0]?.uri,
+          meetLink: (evt.conferenceData as { entryPoints?: Array<{ uri?: string }> })
+            ?.entryPoints?.[0]?.uri,
           status: new Date(start) > now ? "upcoming" : "past",
         } satisfies Consultation;
       });

--- a/src/lib/gsc.ts
+++ b/src/lib/gsc.ts
@@ -34,9 +34,7 @@ function dateRange() {
 /*  Auth                                                               */
 /* ------------------------------------------------------------------ */
 
-const getAccessToken = createGoogleAuth(
-  "https://www.googleapis.com/auth/webmasters.readonly",
-);
+const getAccessToken = createGoogleAuth("https://www.googleapis.com/auth/webmasters.readonly");
 
 /* ------------------------------------------------------------------ */
 /*  Low-level fetch                                                    */
@@ -111,9 +109,7 @@ export interface WebAnalyticsData {
 /**
  * Overall SEO performance snapshot (28-day rolling window).
  */
-export async function getSeoSnapshot(
-  siteUrl = DEFAULT_SITE,
-): Promise<SeoSnapshot | null> {
+export async function getSeoSnapshot(siteUrl = DEFAULT_SITE): Promise<SeoSnapshot | null> {
   try {
     const range = dateRange();
 
@@ -156,10 +152,7 @@ export async function getSeoSnapshot(
 /**
  * Top organic keywords sorted by clicks (28-day rolling window).
  */
-export async function getTopKeywords(
-  siteUrl = DEFAULT_SITE,
-  limit = 20,
-): Promise<KeywordData[]> {
+export async function getTopKeywords(siteUrl = DEFAULT_SITE, limit = 20): Promise<KeywordData[]> {
   try {
     const res = await gscQuery(siteUrl, {
       ...dateRange(),
@@ -206,7 +199,7 @@ export interface PageData {
  */
 export async function getPerformanceHistory(
   siteUrl = DEFAULT_SITE,
-  weeks = 12,
+  weeks = 12
 ): Promise<PerformancePoint[]> {
   try {
     const end = new Date();
@@ -239,10 +232,7 @@ export async function getPerformanceHistory(
 /**
  * Top pages by organic clicks.
  */
-export async function getTopPages(
-  siteUrl = DEFAULT_SITE,
-  limit = 25,
-): Promise<PageData[]> {
+export async function getTopPages(siteUrl = DEFAULT_SITE, limit = 25): Promise<PageData[]> {
   try {
     const res = await gscQuery(siteUrl, {
       ...dateRange(),
@@ -270,9 +260,7 @@ export async function getTopPages(
 /**
  * Top pages by organic clicks — used as a web analytics proxy.
  */
-export async function getWebAnalytics(
-  siteUrl = DEFAULT_SITE,
-): Promise<WebAnalyticsData | null> {
+export async function getWebAnalytics(siteUrl = DEFAULT_SITE): Promise<WebAnalyticsData | null> {
   try {
     const range = dateRange();
 
@@ -295,14 +283,12 @@ export async function getWebAnalytics(
     });
 
     const pagesData = pagesRes.ok ? await pagesRes.json() : {};
-    const topPages = (pagesData.rows ?? []).map(
-      (r: Record<string, unknown>) => ({
-        page: (r.keys as string[])?.[0] ?? "",
-        clicks: Math.round((r.clicks as number) ?? 0),
-        impressions: Math.round((r.impressions as number) ?? 0),
-        position: parseFloat(((r.position as number) ?? 0).toFixed(1)),
-      }),
-    );
+    const topPages = (pagesData.rows ?? []).map((r: Record<string, unknown>) => ({
+      page: (r.keys as string[])?.[0] ?? "",
+      clicks: Math.round((r.clicks as number) ?? 0),
+      impressions: Math.round((r.impressions as number) ?? 0),
+      position: parseFloat(((r.position as number) ?? 0).toFixed(1)),
+    }));
 
     return {
       clicks: Math.round(total.clicks ?? 0),
@@ -338,7 +324,7 @@ export interface CtrOpportunity {
  */
 export async function getCtrOpportunities(
   siteUrl = DEFAULT_SITE,
-  limit = 50,
+  limit = 50
 ): Promise<CtrOpportunity[]> {
   try {
     const res = await gscQuery(siteUrl, {
@@ -359,16 +345,13 @@ export async function getCtrOpportunities(
       })
       .sort(
         (a: Record<string, unknown>, b: Record<string, unknown>) =>
-          ((b.impressions as number) ?? 0) - ((a.impressions as number) ?? 0),
+          ((b.impressions as number) ?? 0) - ((a.impressions as number) ?? 0)
       )
       .slice(0, limit)
       .map((r: Record<string, unknown>) => {
         const impressions = Math.round((r.impressions as number) ?? 0);
         const clicks = Math.round((r.clicks as number) ?? 0);
-        const potentialClicks = Math.max(
-          0,
-          Math.round(impressions * 0.05) - clicks,
-        );
+        const potentialClicks = Math.max(0, Math.round(impressions * 0.05) - clicks);
         return {
           keyword: (r.keys as string[])?.[0] ?? "",
           clicks,
@@ -402,9 +385,7 @@ export interface DeviceData {
 /**
  * Search performance breakdown by device type (DESKTOP, MOBILE, TABLET).
  */
-export async function getDeviceBreakdown(
-  siteUrl = DEFAULT_SITE,
-): Promise<DeviceData[]> {
+export async function getDeviceBreakdown(siteUrl = DEFAULT_SITE): Promise<DeviceData[]> {
   try {
     const res = await gscQuery(siteUrl, {
       ...dateRange(),
@@ -448,7 +429,7 @@ export interface ProductPageData {
 export async function getProductPageMetrics(
   siteUrl = DEFAULT_SITE,
   urlPattern = "/store/",
-  limit = 50,
+  limit = 50
 ): Promise<ProductPageData[]> {
   try {
     const res = await gscQuery(siteUrl, {
@@ -505,7 +486,7 @@ export interface QueryPageMapping {
  */
 export async function getQueryPageMapping(
   siteUrl = DEFAULT_SITE,
-  limit = 100,
+  limit = 100
 ): Promise<QueryPageMapping[]> {
   try {
     const res = await gscQuery(siteUrl, {
@@ -562,7 +543,7 @@ export interface SearchIntentBreakdown {
  *  - navigational:   everything else (looking for a specific site/page)
  */
 export async function getSearchIntentBreakdown(
-  siteUrl = DEFAULT_SITE,
+  siteUrl = DEFAULT_SITE
 ): Promise<SearchIntentBreakdown> {
   const empty: SearchIntentBreakdown = {
     brand: [],
@@ -618,8 +599,7 @@ export async function getSearchIntentBreakdown(
     }
 
     // Sort each bucket by impressions descending
-    const sortByImpressions = (a: IntentKeyword, b: IntentKeyword) =>
-      b.impressions - a.impressions;
+    const sortByImpressions = (a: IntentKeyword, b: IntentKeyword) => b.impressions - a.impressions;
 
     result.brand.sort(sortByImpressions);
     result.product.sort(sortByImpressions);
@@ -651,7 +631,7 @@ export interface CountryTraffic {
  */
 export async function getTrafficByCountry(
   siteUrl = DEFAULT_SITE,
-  limit = 30,
+  limit = 30
 ): Promise<CountryTraffic[]> {
   try {
     const res = await gscQuery(siteUrl, {

--- a/src/lib/hubspot.ts
+++ b/src/lib/hubspot.ts
@@ -28,10 +28,7 @@ async function getHubSpotToken(): Promise<string> {
   throw new Error("HubSpot not configured (no token in env or SSM)");
 }
 
-async function hubspotFetch(
-  path: string,
-  options: RequestInit = {},
-): Promise<Response> {
+async function hubspotFetch(path: string, options: RequestInit = {}): Promise<Response> {
   const token = await getHubSpotToken();
 
   return fetch(`${HUBSPOT_API}${path}`, {
@@ -74,9 +71,7 @@ async function hubspotListAll<T = unknown>(path: string): Promise<T[]> {
  * Uses the email as the unique identifier.
  * Silently returns null if no HubSpot token is available.
  */
-export async function upsertContact(
-  contact: HubSpotContact,
-): Promise<string | null> {
+export async function upsertContact(contact: HubSpotContact): Promise<string | null> {
   try {
     const createRes = await hubspotFetch("/crm/v3/objects/contacts", {
       method: "POST",
@@ -109,9 +104,7 @@ export async function upsertContact(
         body: JSON.stringify({
           filterGroups: [
             {
-              filters: [
-                { propertyName: "email", operator: "EQ", value: contact.email },
-              ],
+              filters: [{ propertyName: "email", operator: "EQ", value: contact.email }],
             },
           ],
         }),
@@ -208,7 +201,7 @@ export async function listNewsletterSubscribers(): Promise<string[]> {
  */
 export async function setNewsletterStatus(
   email: string,
-  status: "newsletter_signup" | "newsletter_unsubscribed",
+  status: "newsletter_signup" | "newsletter_unsubscribed"
 ): Promise<boolean> {
   try {
     const searchRes = await hubspotFetch("/crm/v3/objects/contacts/search", {
@@ -224,18 +217,14 @@ export async function setNewsletterStatus(
       }),
     });
     const existingId = searchRes.ok
-      ? ((await searchRes.json()) as { results?: { id?: string }[] })
-          .results?.[0]?.id
+      ? ((await searchRes.json()) as { results?: { id?: string }[] }).results?.[0]?.id
       : undefined;
 
     if (existingId) {
-      const patchRes = await hubspotFetch(
-        `/crm/v3/objects/contacts/${existingId}`,
-        {
-          method: "PATCH",
-          body: JSON.stringify({ properties: { lead_source: status } }),
-        },
-      );
+      const patchRes = await hubspotFetch(`/crm/v3/objects/contacts/${existingId}`, {
+        method: "PATCH",
+        body: JSON.stringify({ properties: { lead_source: status } }),
+      });
       return patchRes.ok;
     }
 
@@ -267,7 +256,7 @@ export async function listContacts(limit = 10): Promise<unknown[]> {
     : 10;
   try {
     const res = await hubspotFetch(
-      `/crm/v3/objects/contacts?limit=${safeLimit}&properties=email,firstname,lastname,company,createdate,hs_lead_status`,
+      `/crm/v3/objects/contacts?limit=${safeLimit}&properties=email,firstname,lastname,company,createdate,hs_lead_status`
     );
     if (!res.ok) return [];
     const data = await res.json();
@@ -288,7 +277,7 @@ export async function listTickets(limit = 20): Promise<unknown[]> {
     : 20;
   try {
     const res = await hubspotFetch(
-      `/crm/v3/objects/tickets?limit=${safeLimit}&properties=subject,content,hs_pipeline,hs_pipeline_stage,hs_ticket_priority,createdate`,
+      `/crm/v3/objects/tickets?limit=${safeLimit}&properties=subject,content,hs_pipeline,hs_pipeline_stage,hs_ticket_priority,createdate`
     );
     if (!res.ok) return [];
     const data = await res.json();
@@ -314,7 +303,7 @@ interface TicketData {
  */
 export async function createTicket(
   data: TicketData,
-  contactId?: string,
+  contactId?: string
 ): Promise<{ id: string } | null> {
   const properties: Record<string, string> = {
     subject: data.subject,
@@ -385,7 +374,7 @@ export async function listCompanies(limit = 20): Promise<unknown[]> {
     : 20;
   try {
     const res = await hubspotFetch(
-      `/crm/v3/objects/companies?limit=${safeLimit}&properties=name,domain,city,country,createdate`,
+      `/crm/v3/objects/companies?limit=${safeLimit}&properties=name,domain,city,country,createdate`
     );
     if (!res.ok) return [];
     const data = await res.json();
@@ -407,7 +396,7 @@ export async function listDeals(limit = 20): Promise<unknown[]> {
     : 20;
   try {
     const res = await hubspotFetch(
-      `/crm/v3/objects/deals?limit=${safeLimit}&properties=dealname,amount,dealstage,closedate,createdate`,
+      `/crm/v3/objects/deals?limit=${safeLimit}&properties=dealname,amount,dealstage,closedate,createdate`
     );
     if (!res.ok) return [];
     const data = await res.json();
@@ -438,7 +427,7 @@ export async function listOwners(): Promise<unknown[]> {
  */
 export async function searchContacts(
   propertyName: string,
-  value: string,
+  value: string
 ): Promise<{
   total: number;
   results: Array<{ id: string; properties: Record<string, string> }>;
@@ -476,10 +465,7 @@ export async function isHubSpotConfigured(): Promise<boolean> {
 
 /* ─── Deal automation ────────────────────────────────────────────────────── */
 
-export type DealSource =
-  | "stripe_checkout"
-  | "calendar_booking"
-  | "contact_form";
+export type DealSource = "stripe_checkout" | "calendar_booking" | "contact_form";
 
 interface DealData {
   /** Human-readable deal name, e.g. "Purchase – session_xyz" */
@@ -508,14 +494,11 @@ interface DealData {
  * Fire-and-forget safe — never throws.
  */
 export async function createDeal(data: DealData): Promise<string | null> {
-  const closedate =
-    data.closedate ?? new Date().toISOString().split("T")[0] + "T00:00:00.000Z";
+  const closedate = data.closedate ?? new Date().toISOString().split("T")[0] + "T00:00:00.000Z";
 
   const properties: Record<string, string> = {
     dealname: data.dealname,
-    dealstage:
-      data.dealstage ??
-      (data.amount !== undefined ? "closedwon" : "appointmentscheduled"),
+    dealstage: data.dealstage ?? (data.amount !== undefined ? "closedwon" : "appointmentscheduled"),
     pipeline: data.pipeline ?? "default",
     closedate,
     ...(data.amount !== undefined && { amount: String(data.amount) }),
@@ -550,7 +533,7 @@ export async function createDeal(data: DealData): Promise<string | null> {
  */
 export async function updateDeal(
   id: string,
-  data: Partial<Record<string, string>>,
+  data: Partial<Record<string, string>>
 ): Promise<{ id: string } | null> {
   try {
     const res = await hubspotFetch(`/crm/v3/objects/deals/${id}`, {
@@ -567,10 +550,7 @@ export async function updateDeal(
 /**
  * Move a deal to a new pipeline stage.
  */
-export async function moveDealStage(
-  id: string,
-  stageId: string,
-): Promise<{ id: string } | null> {
+export async function moveDealStage(id: string, stageId: string): Promise<{ id: string } | null> {
   return updateDeal(id, { dealstage: stageId });
 }
 
@@ -583,7 +563,7 @@ export async function getDealsByStage(): Promise<Record<string, unknown[]>> {
     const allDeals = await hubspotListAll<{
       properties: { dealstage: string };
     }>(
-      `/crm/v3/objects/deals?properties=dealname,amount,dealstage,pipeline,closedate,createdate,hs_deal_stage_probability`,
+      `/crm/v3/objects/deals?properties=dealname,amount,dealstage,pipeline,closedate,createdate,hs_deal_stage_probability`
     );
     const grouped: Record<string, unknown[]> = {};
     for (const deal of allDeals) {
@@ -600,10 +580,7 @@ export async function getDealsByStage(): Promise<Record<string, unknown[]>> {
 /**
  * Create a note on a deal.
  */
-export async function createNote(
-  dealId: string,
-  body: string,
-): Promise<{ id: string } | null> {
+export async function createNote(dealId: string, body: string): Promise<{ id: string } | null> {
   try {
     const res = await hubspotFetch("/crm/v3/objects/notes", {
       method: "POST",
@@ -637,7 +614,7 @@ export async function createNote(
  */
 export async function createContactNote(
   contactId: string,
-  body: string,
+  body: string
 ): Promise<{ id: string } | null> {
   try {
     const res = await hubspotFetch("/crm/v3/objects/notes", {
@@ -672,14 +649,10 @@ export async function createContactNote(
  */
 export async function listNotes(dealId: string): Promise<unknown[]> {
   try {
-    const res = await hubspotFetch(
-      `/crm/v3/objects/deals/${dealId}/associations/notes`,
-    );
+    const res = await hubspotFetch(`/crm/v3/objects/deals/${dealId}/associations/notes`);
     if (!res.ok) return [];
     const assocData = await res.json();
-    const noteIds: string[] = (assocData.results ?? []).map(
-      (r: { id: string }) => r.id,
-    );
+    const noteIds: string[] = (assocData.results ?? []).map((r: { id: string }) => r.id);
     if (noteIds.length === 0) return [];
 
     // Batch read all notes in a single request instead of N individual fetches
@@ -687,9 +660,7 @@ export async function listNotes(dealId: string): Promise<unknown[]> {
       method: "POST",
       body: JSON.stringify({
         properties: ["hs_note_body", "hs_timestamp"],
-        inputs: noteIds
-          .slice(0, HUBSPOT_BATCH_NOTE_LIMIT)
-          .map((id) => ({ id })),
+        inputs: noteIds.slice(0, HUBSPOT_BATCH_NOTE_LIMIT).map((id) => ({ id })),
       }),
     });
     if (!batchRes.ok) return [];
@@ -733,20 +704,12 @@ export async function getPipelineStats(): Promise<{
  * Associate an existing deal with an existing contact.
  * Safe to call fire-and-forget — never throws.
  */
-export async function associateDealWithContact(
-  dealId: string,
-  contactId: string,
-): Promise<void> {
+export async function associateDealWithContact(dealId: string, contactId: string): Promise<void> {
   try {
-    await hubspotFetch(
-      `/crm/v4/objects/deals/${dealId}/associations/contacts/${contactId}`,
-      {
-        method: "PUT",
-        body: JSON.stringify([
-          { associationCategory: HUBSPOT_DEFINED, associationTypeId: 3 },
-        ]),
-      },
-    );
+    await hubspotFetch(`/crm/v4/objects/deals/${dealId}/associations/contacts/${contactId}`, {
+      method: "PUT",
+      body: JSON.stringify([{ associationCategory: HUBSPOT_DEFINED, associationTypeId: 3 }]),
+    });
   } catch (err) {
     console.error("[HubSpot] associateDealWithContact error:", err);
   }

--- a/src/lib/i18n.ts
+++ b/src/lib/i18n.ts
@@ -44,21 +44,13 @@ function resolve(messages: Messages, key: string): unknown {
 }
 
 /** Return a translated string for the given key, or the fallback when missing. */
-export function translate(
-  locale: Locale,
-  key: string,
-  fallback: string,
-): string {
+export function translate(locale: Locale, key: string, fallback: string): string {
   const candidate = resolve(getMessages(locale), key);
   return typeof candidate === "string" ? candidate : fallback;
 }
 
 /** Return a translated string-array for the given key, or the fallback when missing. */
-export function translateArray(
-  locale: Locale,
-  key: string,
-  fallback: string[],
-): string[] {
+export function translateArray(locale: Locale, key: string, fallback: string[]): string[] {
   const candidate = resolve(getMessages(locale), key);
   return Array.isArray(candidate) ? (candidate as string[]) : fallback;
 }

--- a/src/lib/integrations.ts
+++ b/src/lib/integrations.ts
@@ -99,8 +99,7 @@ export function getIntegrations(): IntegrationConfig {
     NOTION_FAQS_DB_ID: process.env.NOTION_FAQS_DB_ID,
     GOOGLE_CLIENT_EMAIL: process.env.GOOGLE_CLIENT_EMAIL,
     GOOGLE_SERVICE_ACCOUNT_EMAIL:
-      process.env.GOOGLE_SERVICE_ACCOUNT_EMAIL ||
-      process.env.GOOGLE_CLIENT_EMAIL,
+      process.env.GOOGLE_SERVICE_ACCOUNT_EMAIL || process.env.GOOGLE_CLIENT_EMAIL,
     GOOGLE_PRIVATE_KEY: process.env.GOOGLE_PRIVATE_KEY?.replace(/\\n/g, "\n"),
     GOOGLE_CALENDAR_ID: process.env.GOOGLE_CALENDAR_ID,
     STRIPE_SECRET_KEY: process.env.STRIPE_SECRET_KEY,
@@ -178,136 +177,75 @@ export async function getIntegrationsAsync(): Promise<IntegrationConfig> {
     const ssm = await getConfig();
 
     cachedAsync = {
-      SLACK_WEBHOOK_URL:
-        envCfg.SLACK_WEBHOOK_URL || ssm.SLACK_WEBHOOK_URL || undefined,
-      SLACK_BOT_TOKEN:
-        envCfg.SLACK_BOT_TOKEN || ssm.SLACK_BOT_TOKEN || undefined,
-      SLACK_SIGNING_SECRET:
-        envCfg.SLACK_SIGNING_SECRET || ssm.SLACK_SIGNING_SECRET || undefined,
-      HUBSPOT_API_KEY:
-        envCfg.HUBSPOT_API_KEY || ssm.HUBSPOT_API_KEY || undefined,
-      HUBSPOT_CLIENT_SECRET:
-        envCfg.HUBSPOT_CLIENT_SECRET || ssm.HUBSPOT_CLIENT_SECRET || undefined,
+      SLACK_WEBHOOK_URL: envCfg.SLACK_WEBHOOK_URL || ssm.SLACK_WEBHOOK_URL || undefined,
+      SLACK_BOT_TOKEN: envCfg.SLACK_BOT_TOKEN || ssm.SLACK_BOT_TOKEN || undefined,
+      SLACK_SIGNING_SECRET: envCfg.SLACK_SIGNING_SECRET || ssm.SLACK_SIGNING_SECRET || undefined,
+      HUBSPOT_API_KEY: envCfg.HUBSPOT_API_KEY || ssm.HUBSPOT_API_KEY || undefined,
+      HUBSPOT_CLIENT_SECRET: envCfg.HUBSPOT_CLIENT_SECRET || ssm.HUBSPOT_CLIENT_SECRET || undefined,
       NOTION_API_KEY: envCfg.NOTION_API_KEY || ssm.NOTION_API_KEY || undefined,
-      NOTION_BLOG_DB_ID:
-        envCfg.NOTION_BLOG_DB_ID || ssm.NOTION_BLOG_DB_ID || undefined,
+      NOTION_BLOG_DB_ID: envCfg.NOTION_BLOG_DB_ID || ssm.NOTION_BLOG_DB_ID || undefined,
       NOTION_SUBMISSIONS_DB_ID:
-        envCfg.NOTION_SUBMISSIONS_DB_ID ||
-        ssm.NOTION_SUBMISSIONS_DB_ID ||
-        undefined,
-      NOTION_DOCS_DB_ID:
-        envCfg.NOTION_DOCS_DB_ID || ssm.NOTION_DOCS_DB_ID || undefined,
-      NOTION_PROJECTS_DB_ID:
-        envCfg.NOTION_PROJECTS_DB_ID || ssm.NOTION_PROJECTS_DB_ID || undefined,
-      NOTION_TASKS_DB_ID:
-        envCfg.NOTION_TASKS_DB_ID || ssm.NOTION_TASKS_DB_ID || undefined,
+        envCfg.NOTION_SUBMISSIONS_DB_ID || ssm.NOTION_SUBMISSIONS_DB_ID || undefined,
+      NOTION_DOCS_DB_ID: envCfg.NOTION_DOCS_DB_ID || ssm.NOTION_DOCS_DB_ID || undefined,
+      NOTION_PROJECTS_DB_ID: envCfg.NOTION_PROJECTS_DB_ID || ssm.NOTION_PROJECTS_DB_ID || undefined,
+      NOTION_TASKS_DB_ID: envCfg.NOTION_TASKS_DB_ID || ssm.NOTION_TASKS_DB_ID || undefined,
       NOTION_ANALYTICS_DB_ID:
-        envCfg.NOTION_ANALYTICS_DB_ID ||
-        ssm.NOTION_ANALYTICS_DB_ID ||
-        undefined,
-      NOTION_CALENDAR_DB_ID:
-        envCfg.NOTION_CALENDAR_DB_ID || ssm.NOTION_CALENDAR_DB_ID || undefined,
-      NOTION_REPORTS_DB_ID:
-        envCfg.NOTION_REPORTS_DB_ID || ssm.NOTION_REPORTS_DB_ID || undefined,
+        envCfg.NOTION_ANALYTICS_DB_ID || ssm.NOTION_ANALYTICS_DB_ID || undefined,
+      NOTION_CALENDAR_DB_ID: envCfg.NOTION_CALENDAR_DB_ID || ssm.NOTION_CALENDAR_DB_ID || undefined,
+      NOTION_REPORTS_DB_ID: envCfg.NOTION_REPORTS_DB_ID || ssm.NOTION_REPORTS_DB_ID || undefined,
       NOTION_GSC_REPORTS_DB_ID:
-        envCfg.NOTION_GSC_REPORTS_DB_ID ||
-        ssm.NOTION_GSC_REPORTS_DB_ID ||
-        undefined,
+        envCfg.NOTION_GSC_REPORTS_DB_ID || ssm.NOTION_GSC_REPORTS_DB_ID || undefined,
       NOTION_TESTIMONIALS_DB_ID:
-        envCfg.NOTION_TESTIMONIALS_DB_ID ||
-        ssm.NOTION_TESTIMONIALS_DB_ID ||
-        undefined,
+        envCfg.NOTION_TESTIMONIALS_DB_ID || ssm.NOTION_TESTIMONIALS_DB_ID || undefined,
       NOTION_CASE_STUDIES_DB_ID:
-        envCfg.NOTION_CASE_STUDIES_DB_ID ||
-        ssm.NOTION_CASE_STUDIES_DB_ID ||
-        undefined,
-      NOTION_SERVICES_DB_ID:
-        envCfg.NOTION_SERVICES_DB_ID || ssm.NOTION_SERVICES_DB_ID || undefined,
-      NOTION_FAQS_DB_ID:
-        envCfg.NOTION_FAQS_DB_ID || ssm.NOTION_FAQS_DB_ID || undefined,
-      GOOGLE_CLIENT_EMAIL:
-        envCfg.GOOGLE_CLIENT_EMAIL || ssm.GOOGLE_CLIENT_EMAIL || undefined,
+        envCfg.NOTION_CASE_STUDIES_DB_ID || ssm.NOTION_CASE_STUDIES_DB_ID || undefined,
+      NOTION_SERVICES_DB_ID: envCfg.NOTION_SERVICES_DB_ID || ssm.NOTION_SERVICES_DB_ID || undefined,
+      NOTION_FAQS_DB_ID: envCfg.NOTION_FAQS_DB_ID || ssm.NOTION_FAQS_DB_ID || undefined,
+      GOOGLE_CLIENT_EMAIL: envCfg.GOOGLE_CLIENT_EMAIL || ssm.GOOGLE_CLIENT_EMAIL || undefined,
       GOOGLE_SERVICE_ACCOUNT_EMAIL:
-        envCfg.GOOGLE_SERVICE_ACCOUNT_EMAIL ||
-        ssm.GOOGLE_CLIENT_EMAIL ||
-        undefined,
-      GOOGLE_PRIVATE_KEY:
-        envCfg.GOOGLE_PRIVATE_KEY || ssm.GOOGLE_PRIVATE_KEY || undefined,
-      GOOGLE_CALENDAR_ID:
-        envCfg.GOOGLE_CALENDAR_ID || ssm.GOOGLE_CALENDAR_ID || undefined,
-      STRIPE_SECRET_KEY:
-        envCfg.STRIPE_SECRET_KEY || ssm.STRIPE_SECRET_KEY || undefined,
-      SENTRY_AUTH_TOKEN:
-        envCfg.SENTRY_AUTH_TOKEN || ssm.SENTRY_AUTH_TOKEN || undefined,
+        envCfg.GOOGLE_SERVICE_ACCOUNT_EMAIL || ssm.GOOGLE_CLIENT_EMAIL || undefined,
+      GOOGLE_PRIVATE_KEY: envCfg.GOOGLE_PRIVATE_KEY || ssm.GOOGLE_PRIVATE_KEY || undefined,
+      GOOGLE_CALENDAR_ID: envCfg.GOOGLE_CALENDAR_ID || ssm.GOOGLE_CALENDAR_ID || undefined,
+      STRIPE_SECRET_KEY: envCfg.STRIPE_SECRET_KEY || ssm.STRIPE_SECRET_KEY || undefined,
+      SENTRY_AUTH_TOKEN: envCfg.SENTRY_AUTH_TOKEN || ssm.SENTRY_AUTH_TOKEN || undefined,
       SENTRY_ORG: envCfg.SENTRY_ORG || ssm.SENTRY_ORG || DEFAULT_SENTRY_ORG,
-      SENTRY_PROJECT:
-        envCfg.SENTRY_PROJECT || ssm.SENTRY_PROJECT || DEFAULT_SENTRY_PROJECT,
-      NOTION_WEBHOOK_SECRET:
-        envCfg.NOTION_WEBHOOK_SECRET || ssm.NOTION_WEBHOOK_SECRET || undefined,
+      SENTRY_PROJECT: envCfg.SENTRY_PROJECT || ssm.SENTRY_PROJECT || DEFAULT_SENTRY_PROJECT,
+      NOTION_WEBHOOK_SECRET: envCfg.NOTION_WEBHOOK_SECRET || ssm.NOTION_WEBHOOK_SECRET || undefined,
       ACTIVECAMPAIGN_API_URL:
-        envCfg.ACTIVECAMPAIGN_API_URL ||
-        ssm.ACTIVECAMPAIGN_API_URL ||
-        undefined,
+        envCfg.ACTIVECAMPAIGN_API_URL || ssm.ACTIVECAMPAIGN_API_URL || undefined,
       ACTIVECAMPAIGN_API_TOKEN:
-        envCfg.ACTIVECAMPAIGN_API_TOKEN ||
-        ssm.ACTIVECAMPAIGN_API_TOKEN ||
-        undefined,
+        envCfg.ACTIVECAMPAIGN_API_TOKEN || ssm.ACTIVECAMPAIGN_API_TOKEN || undefined,
       GOOGLE_ADS_DEVELOPER_TOKEN:
-        envCfg.GOOGLE_ADS_DEVELOPER_TOKEN ||
-        ssm.GOOGLE_ADS_DEVELOPER_TOKEN ||
-        undefined,
+        envCfg.GOOGLE_ADS_DEVELOPER_TOKEN || ssm.GOOGLE_ADS_DEVELOPER_TOKEN || undefined,
       GOOGLE_ADS_CUSTOMER_ID:
-        envCfg.GOOGLE_ADS_CUSTOMER_ID ||
-        ssm.GOOGLE_ADS_CUSTOMER_ID ||
-        undefined,
-      LINKEDIN_CLIENT_ID:
-        envCfg.LINKEDIN_CLIENT_ID || ssm.LINKEDIN_CLIENT_ID || undefined,
+        envCfg.GOOGLE_ADS_CUSTOMER_ID || ssm.GOOGLE_ADS_CUSTOMER_ID || undefined,
+      LINKEDIN_CLIENT_ID: envCfg.LINKEDIN_CLIENT_ID || ssm.LINKEDIN_CLIENT_ID || undefined,
       LINKEDIN_CLIENT_SECRET:
-        envCfg.LINKEDIN_CLIENT_SECRET ||
-        ssm.LINKEDIN_CLIENT_SECRET ||
-        undefined,
-      LINKEDIN_ACCESS_TOKEN:
-        envCfg.LINKEDIN_ACCESS_TOKEN || ssm.LINKEDIN_ACCESS_TOKEN || undefined,
+        envCfg.LINKEDIN_CLIENT_SECRET || ssm.LINKEDIN_CLIENT_SECRET || undefined,
+      LINKEDIN_ACCESS_TOKEN: envCfg.LINKEDIN_ACCESS_TOKEN || ssm.LINKEDIN_ACCESS_TOKEN || undefined,
       LINKEDIN_AD_ACCOUNT_ID:
-        envCfg.LINKEDIN_AD_ACCOUNT_ID ||
-        ssm.LINKEDIN_AD_ACCOUNT_ID ||
-        undefined,
+        envCfg.LINKEDIN_AD_ACCOUNT_ID || ssm.LINKEDIN_AD_ACCOUNT_ID || undefined,
       LINKEDIN_ORGANIZATION_URN:
-        envCfg.LINKEDIN_ORGANIZATION_URN ||
-        ssm.LINKEDIN_ORGANIZATION_URN ||
-        undefined,
+        envCfg.LINKEDIN_ORGANIZATION_URN || ssm.LINKEDIN_ORGANIZATION_URN || undefined,
       TIKTOK_APP_ID: envCfg.TIKTOK_APP_ID || ssm.TIKTOK_APP_ID || undefined,
-      TIKTOK_APP_SECRET:
-        envCfg.TIKTOK_APP_SECRET || ssm.TIKTOK_APP_SECRET || undefined,
-      TIKTOK_ACCESS_TOKEN:
-        envCfg.TIKTOK_ACCESS_TOKEN || ssm.TIKTOK_ACCESS_TOKEN || undefined,
-      TIKTOK_ADVERTISER_ID:
-        envCfg.TIKTOK_ADVERTISER_ID || ssm.TIKTOK_ADVERTISER_ID || undefined,
+      TIKTOK_APP_SECRET: envCfg.TIKTOK_APP_SECRET || ssm.TIKTOK_APP_SECRET || undefined,
+      TIKTOK_ACCESS_TOKEN: envCfg.TIKTOK_ACCESS_TOKEN || ssm.TIKTOK_ACCESS_TOKEN || undefined,
+      TIKTOK_ADVERTISER_ID: envCfg.TIKTOK_ADVERTISER_ID || ssm.TIKTOK_ADVERTISER_ID || undefined,
       X_API_KEY: envCfg.X_API_KEY || ssm.X_API_KEY || undefined,
       X_API_SECRET: envCfg.X_API_SECRET || ssm.X_API_SECRET || undefined,
       X_ACCESS_TOKEN: envCfg.X_ACCESS_TOKEN || ssm.X_ACCESS_TOKEN || undefined,
-      X_ACCESS_SECRET:
-        envCfg.X_ACCESS_SECRET || ssm.X_ACCESS_SECRET || undefined,
-      X_AD_ACCOUNT_ID:
-        envCfg.X_AD_ACCOUNT_ID || ssm.X_AD_ACCOUNT_ID || undefined,
-      META_AD_ACCOUNT_ID:
-        envCfg.META_AD_ACCOUNT_ID || ssm.META_AD_ACCOUNT_ID || undefined,
+      X_ACCESS_SECRET: envCfg.X_ACCESS_SECRET || ssm.X_ACCESS_SECRET || undefined,
+      X_AD_ACCOUNT_ID: envCfg.X_AD_ACCOUNT_ID || ssm.X_AD_ACCOUNT_ID || undefined,
+      META_AD_ACCOUNT_ID: envCfg.META_AD_ACCOUNT_ID || ssm.META_AD_ACCOUNT_ID || undefined,
       META_PIXEL_ID: envCfg.META_PIXEL_ID || ssm.META_PIXEL_ID || undefined,
       META_CAPI_ACCESS_TOKEN:
-        envCfg.META_CAPI_ACCESS_TOKEN ||
-        ssm.META_CAPI_ACCESS_TOKEN ||
-        undefined,
-      META_ACCESS_TOKEN:
-        envCfg.META_ACCESS_TOKEN || ssm.META_ACCESS_TOKEN || undefined,
+        envCfg.META_CAPI_ACCESS_TOKEN || ssm.META_CAPI_ACCESS_TOKEN || undefined,
+      META_ACCESS_TOKEN: envCfg.META_ACCESS_TOKEN || ssm.META_ACCESS_TOKEN || undefined,
       META_PAGE_ID: envCfg.META_PAGE_ID || ssm.META_PAGE_ID || undefined,
-      ANTHROPIC_API_KEY:
-        envCfg.ANTHROPIC_API_KEY || ssm.ANTHROPIC_API_KEY || undefined,
+      ANTHROPIC_API_KEY: envCfg.ANTHROPIC_API_KEY || ssm.ANTHROPIC_API_KEY || undefined,
     };
   } catch (err) {
-    console.warn(
-      "[Integrations] SSM fallback failed, using env-only config:",
-      err,
-    );
+    console.warn("[Integrations] SSM fallback failed, using env-only config:", err);
     cachedAsync = envCfg;
   }
 
@@ -324,7 +262,7 @@ export class IntegrationNotConfiguredError extends Error {
   constructor(keys: (keyof IntegrationConfig)[]) {
     super(
       `Integration not configured: missing ${keys.join(", ")}. ` +
-        "Set the env var(s) or add them to AWS SSM under /cloudless/production/.",
+        "Set the env var(s) or add them to AWS SSM under /cloudless/production/."
     );
     this.name = "IntegrationNotConfiguredError";
     this.keys = keys;
@@ -358,9 +296,7 @@ export async function requireIntegrationAsync(
  * Async version of isConfigured() — uses SSM fallback.
  * Use in API routes instead of the sync isConfigured().
  */
-export async function isConfiguredAsync(
-  ...keys: (keyof IntegrationConfig)[]
-): Promise<boolean> {
+export async function isConfiguredAsync(...keys: (keyof IntegrationConfig)[]): Promise<boolean> {
   // Fast-path: if any env var is explicitly cleared to "" return false immediately.
   // This ensures tests that clear env vars bypass the async cache regardless of
   // any module-isolation effects from vi.mock.
@@ -404,7 +340,7 @@ export function getSlackConfig(): SlackConfig {
   if (!token && !webhookUrl) {
     console.warn(
       "[Slack] Neither SLACK_BOT_TOKEN nor SLACK_WEBHOOK_URL is set — " +
-        "Slack notifications will be skipped.",
+        "Slack notifications will be skipped."
     );
   }
 
@@ -435,15 +371,10 @@ export async function getSlackConfigAsync(): Promise<SlackConfig> {
     try {
       const { getConfig } = await import("@/lib/ssm-config");
       const ssmCfg = await getConfig();
-      signingSecret =
-        (ssmCfg as unknown as Record<string, string>).SLACK_SIGNING_SECRET ??
-        "";
-      if (!token)
-        token =
-          (ssmCfg as unknown as Record<string, string>).SLACK_BOT_TOKEN ?? "";
+      signingSecret = (ssmCfg as unknown as Record<string, string>).SLACK_SIGNING_SECRET ?? "";
+      if (!token) token = (ssmCfg as unknown as Record<string, string>).SLACK_BOT_TOKEN ?? "";
       if (!webhookUrl)
-        webhookUrl =
-          (ssmCfg as unknown as Record<string, string>).SLACK_WEBHOOK_URL ?? "";
+        webhookUrl = (ssmCfg as unknown as Record<string, string>).SLACK_WEBHOOK_URL ?? "";
     } catch (err) {
       console.warn("[Slack] SSM fallback failed:", err);
     }
@@ -452,7 +383,7 @@ export async function getSlackConfigAsync(): Promise<SlackConfig> {
   if (!token && !webhookUrl) {
     console.warn(
       "[Slack] Neither SLACK_BOT_TOKEN nor SLACK_WEBHOOK_URL is set — " +
-        "Slack notifications will be skipped.",
+        "Slack notifications will be skipped."
     );
   }
 

--- a/src/lib/integrations/http.ts
+++ b/src/lib/integrations/http.ts
@@ -56,7 +56,7 @@ export class IntegrationError extends Error {
     public readonly integration: string,
     public readonly status: number,
     public readonly body: string,
-    message?: string,
+    message?: string
   ) {
     super(message ?? `${integration} HTTP ${status}: ${body.slice(0, 200)}`);
     this.name = "IntegrationError";
@@ -92,7 +92,7 @@ async function breadcrumb(
   url: string,
   status: number,
   latencyMs: number,
-  retries: number,
+  retries: number
 ): Promise<void> {
   try {
     const Sentry = await import("@sentry/nextjs").catch(() => null);
@@ -120,7 +120,7 @@ async function handleFinalResponse<T>(
   integration: string,
   latencyMs: number,
   retries: number,
-  passthroughErrors: boolean,
+  passthroughErrors: boolean
 ): Promise<IntegrationFetchResult<T>> {
   if (!res.ok) {
     if (passthroughErrors) {
@@ -157,14 +157,9 @@ export async function integrationFetch<T = unknown>(
   integration: string,
   url: string,
   init?: RequestInit,
-  opts?: IntegrationFetchOptions,
+  opts?: IntegrationFetchOptions
 ): Promise<T> {
-  const result = await integrationFetchWithMeta<T>(
-    integration,
-    url,
-    init,
-    opts,
-  );
+  const result = await integrationFetchWithMeta<T>(integration, url, init, opts);
   return result.data;
 }
 
@@ -177,7 +172,7 @@ export async function integrationFetchWithMeta<T = unknown>(
   integration: string,
   url: string,
   init?: RequestInit,
-  opts?: IntegrationFetchOptions,
+  opts?: IntegrationFetchOptions
 ): Promise<IntegrationFetchResult<T>> {
   const timeoutMs = opts?.timeoutMs ?? 10_000;
   const maxRetries = opts?.maxRetries ?? 3;
@@ -215,10 +210,7 @@ export async function integrationFetchWithMeta<T = unknown>(
 
     // 429 / 5xx: retry with exponential backoff (429 honors Retry-After)
     if ((res.status === 429 || res.status >= 500) && attempt < maxRetries) {
-      const ra =
-        res.status === 429
-          ? parseRetryAfter(res.headers.get("Retry-After"))
-          : null;
+      const ra = res.status === 429 ? parseRetryAfter(res.headers.get("Retry-After")) : null;
       retries++;
       await sleep(ra ?? backoffMs * 2 ** attempt);
       continue;
@@ -226,32 +218,21 @@ export async function integrationFetchWithMeta<T = unknown>(
 
     const latencyMs = Date.now() - started;
     await breadcrumb(integration, url, res.status, latencyMs, retries);
-    return handleFinalResponse<T>(
-      res,
-      integration,
-      latencyMs,
-      retries,
-      passthroughErrors,
-    );
+    return handleFinalResponse<T>(res, integration, latencyMs, retries, passthroughErrors);
   }
 
   // Exhausted retries on 429/5xx — fall through to throw
   const latencyMs = Date.now() - started;
   await breadcrumb(integration, url, 0, latencyMs, retries);
   if (lastError) throw lastError;
-  throw new Error(
-    `${integration}: max retries (${maxRetries}) exceeded on ${url}`,
-  );
+  throw new Error(`${integration}: max retries (${maxRetries}) exceeded on ${url}`);
 }
 
 /**
  * Convenience: returns true if an error is an IntegrationError with a
  * specific status code. Type-narrows.
  */
-export function isIntegrationError(
-  err: unknown,
-  status?: number,
-): err is IntegrationError {
+export function isIntegrationError(err: unknown, status?: number): err is IntegrationError {
   if (!(err instanceof IntegrationError)) return false;
   if (status === undefined) return true;
   return err.status === status;

--- a/src/lib/meta-capi.ts
+++ b/src/lib/meta-capi.ts
@@ -56,10 +56,7 @@ type SendEventOptions = {
 };
 
 function sha256(value: string): string {
-  return crypto
-    .createHash("sha256")
-    .update(value.trim().toLowerCase())
-    .digest("hex");
+  return crypto.createHash("sha256").update(value.trim().toLowerCase()).digest("hex");
 }
 
 function hashMaybe(value: string | undefined): string | undefined {
@@ -109,9 +106,7 @@ function captureCapiError(err: unknown, context: Record<string, string>): void {
  * when unconfigured.
  */
 export function isCapiConfigured(): boolean {
-  return Boolean(
-    process.env.NEXT_PUBLIC_META_PIXEL_ID && process.env.META_CAPI_ACCESS_TOKEN,
-  );
+  return Boolean(process.env.NEXT_PUBLIC_META_PIXEL_ID && process.env.META_CAPI_ACCESS_TOKEN);
 }
 
 function buildUserData(opts: SendEventOptions): Record<string, unknown> {
@@ -143,7 +138,7 @@ function buildUserData(opts: SendEventOptions): Record<string, unknown> {
  */
 export async function sendCapiEvent(
   eventName: string,
-  opts: SendEventOptions,
+  opts: SendEventOptions
 ): Promise<CapiResult> {
   const pixelId = process.env.NEXT_PUBLIC_META_PIXEL_ID;
   const token = process.env.META_CAPI_ACCESS_TOKEN;
@@ -189,9 +184,7 @@ export async function sendCapiEvent(
 
     if (!res.ok) {
       const rawBody = await res.text().catch(() => "");
-      const safeBody = rawBody
-        .replaceAll(token, "[redacted-token]")
-        .slice(0, 500);
+      const safeBody = rawBody.replaceAll(token, "[redacted-token]").slice(0, 500);
       captureCapiError(new Error(`CAPI ${eventName} failed: ${res.status}`), {
         event_name: eventName,
         status: String(res.status),
@@ -203,8 +196,7 @@ export async function sendCapiEvent(
     return { ok: true, eventsReceived: json.events_received ?? 1 };
   } catch (err) {
     const isAbort =
-      err instanceof Error &&
-      (err.name === "AbortError" || err.message.includes("aborted"));
+      err instanceof Error && (err.name === "AbortError" || err.message.includes("aborted"));
     captureCapiError(err, {
       event_name: eventName,
       reason: isAbort ? "timeout" : "network_error",
@@ -228,9 +220,7 @@ export async function sendCapiEvent(
  * request, consultation booking). Call AFTER the form has been accepted
  * (e.g. after SES send in /api/contact).
  */
-export function sendLeadEvent(
-  opts: SendEventOptions & { source?: string },
-): Promise<CapiResult> {
+export function sendLeadEvent(opts: SendEventOptions & { source?: string }): Promise<CapiResult> {
   const { source, ...rest } = opts;
   return sendCapiEvent("Lead", {
     ...rest,
@@ -258,7 +248,7 @@ export function sendPurchaseEvent(
     value: number;
     currency: string;
     contents?: Array<{ id: string; quantity: number; item_price?: number }>;
-  },
+  }
 ): Promise<CapiResult> {
   const { value, currency, contents, ...rest } = opts;
   return sendCapiEvent("Purchase", {

--- a/src/lib/meta-pixel.ts
+++ b/src/lib/meta-pixel.ts
@@ -24,7 +24,7 @@ declare global {
       command: "init" | "track" | "trackCustom" | "consent",
       eventName?: string,
       params?: Record<string, unknown>,
-      options?: { eventID?: string },
+      options?: { eventID?: string }
     ) => void;
   }
 }
@@ -51,16 +51,11 @@ export function isPixelReady(): boolean {
 export function trackPixelEvent(
   eventName: string,
   params: Record<string, unknown> = {},
-  eventId?: string,
+  eventId?: string
 ): void {
   if (!isPixelReady()) return;
   try {
-    window.fbq?.(
-      "track",
-      eventName,
-      params,
-      eventId ? { eventID: eventId } : undefined,
-    );
+    window.fbq?.("track", eventName, params, eventId ? { eventID: eventId } : undefined);
   } catch (err) {
     // Pixel failures must never break the user flow.
     if (process.env.NODE_ENV !== "production") {
@@ -80,10 +75,7 @@ export function trackPixelEvent(
  * it is NOT deterministic. For deterministic dedup keys (e.g. order-based),
  * pass your own ID directly.
  */
-export function generateEventId(
-  prefix: string,
-  ...parts: (string | number)[]
-): string {
+export function generateEventId(prefix: string, ...parts: (string | number)[]): string {
   const buf = globalThis.crypto.getRandomValues(new Uint32Array(1));
   const rand = (buf[0] ?? 0).toString(36);
   return [prefix, Date.now(), rand, ...parts].filter(Boolean).join("-");

--- a/src/lib/notion-analytics.ts
+++ b/src/lib/notion-analytics.ts
@@ -8,10 +8,7 @@
  */
 
 import { notionFetch, notionFetchAll, extractText } from "@/lib/notion";
-import {
-  getIntegrationsAsync,
-  requireIntegrationAsync,
-} from "@/lib/integrations";
+import { getIntegrationsAsync, requireIntegrationAsync } from "@/lib/integrations";
 
 async function requireAnalyticsIntegration(): Promise<void> {
   await requireIntegrationAsync("NOTION_API_KEY", "NOTION_ANALYTICS_DB_ID");
@@ -93,12 +90,8 @@ async function writeEventToNotion(data: EventData): Promise<string | null> {
         properties: {
           Event: { title: [{ text: { content: data.event.slice(0, 200) } }] },
           Type: { select: { name: data.type } },
-          ...(data.page
-            ? { Page: { rich_text: [{ text: { content: data.page } }] } }
-            : {}),
-          ...(data.source
-            ? { Source: { rich_text: [{ text: { content: data.source } }] } }
-            : {}),
+          ...(data.page ? { Page: { rich_text: [{ text: { content: data.page } }] } } : {}),
+          ...(data.source ? { Source: { rich_text: [{ text: { content: data.source } }] } } : {}),
           Count: { number: data.count ?? 1 },
           Date: { date: { start: new Date().toISOString() } },
           ...(data.country
@@ -163,7 +156,7 @@ export async function trackEvent(
     country?: string;
     metadata?: Record<string, unknown>;
   },
-  _opts?: { immediate?: boolean },
+  _opts?: { immediate?: boolean }
 ): Promise<string | null> {
   return writeEventToNotion(data);
 }
@@ -173,7 +166,7 @@ export async function trackEvent(
  */
 export async function trackFormSubmission(
   formName: string,
-  source?: string,
+  source?: string
 ): Promise<string | null> {
   return trackEvent(
     {
@@ -182,17 +175,14 @@ export async function trackFormSubmission(
       page: `/contact`,
       source,
     },
-    { immediate: true },
+    { immediate: true }
   );
 }
 
 /**
  * Convenience: track a blog post view.
  */
-export async function trackBlogView(
-  slug: string,
-  source?: string,
-): Promise<string | null> {
+export async function trackBlogView(slug: string, source?: string): Promise<string | null> {
   return trackEvent(
     {
       event: `Blog: ${slug}`,
@@ -200,7 +190,7 @@ export async function trackBlogView(
       page: `/blog/${slug}`,
       source,
     },
-    { immediate: true },
+    { immediate: true }
   );
 }
 
@@ -213,24 +203,19 @@ export async function trackBlogView(
  */
 export async function getRecentEvents(
   type?: AnalyticsEventType,
-  limit = 50,
+  limit = 50
 ): Promise<AnalyticsEvent[]> {
   await requireAnalyticsIntegration();
 
   const { NOTION_ANALYTICS_DB_ID } = await getIntegrationsAsync();
   try {
-    const filter = type
-      ? { property: "Type", select: { equals: type } }
-      : undefined;
+    const filter = type ? { property: "Type", select: { equals: type } } : undefined;
 
-    const pages = await notionFetchAll(
-      `/databases/${NOTION_ANALYTICS_DB_ID}/query`,
-      {
-        ...(filter ? { filter } : {}),
-        sorts: [{ property: "Date", direction: "descending" }],
-        page_size: Math.min(limit, 100),
-      },
-    );
+    const pages = await notionFetchAll(`/databases/${NOTION_ANALYTICS_DB_ID}/query`, {
+      ...(filter ? { filter } : {}),
+      sorts: [{ property: "Date", direction: "descending" }],
+      page_size: Math.min(limit, 100),
+    });
     return pages.slice(0, limit).map(mapEvent);
   } catch (err) {
     console.error("[Notion Analytics] Failed to fetch events:", err);
@@ -243,24 +228,21 @@ export async function getRecentEvents(
  */
 export async function getEventsByDateRange(
   startDate: string,
-  endDate: string,
+  endDate: string
 ): Promise<AnalyticsEvent[]> {
   await requireAnalyticsIntegration();
 
   const { NOTION_ANALYTICS_DB_ID } = await getIntegrationsAsync();
   try {
-    const pages = await notionFetchAll(
-      `/databases/${NOTION_ANALYTICS_DB_ID}/query`,
-      {
-        filter: {
-          and: [
-            { property: "Date", date: { on_or_after: startDate } },
-            { property: "Date", date: { on_or_before: endDate } },
-          ],
-        },
-        sorts: [{ property: "Date", direction: "descending" }],
+    const pages = await notionFetchAll(`/databases/${NOTION_ANALYTICS_DB_ID}/query`, {
+      filter: {
+        and: [
+          { property: "Date", date: { on_or_after: startDate } },
+          { property: "Date", date: { on_or_before: endDate } },
+        ],
       },
-    );
+      sorts: [{ property: "Date", direction: "descending" }],
+    });
     return pages.map(mapEvent);
   } catch (err) {
     console.error("[Notion Analytics] Failed to fetch events by date:", err);
@@ -276,7 +258,7 @@ export async function getAnalyticsSummary(days = 7): Promise<AnalyticsSummary> {
   startDate.setDate(startDate.getDate() - days);
   const events = await getEventsByDateRange(
     startDate.toISOString().split("T")[0],
-    new Date().toISOString().split("T")[0],
+    new Date().toISOString().split("T")[0]
   );
 
   // Aggregate by type
@@ -327,7 +309,7 @@ export async function getAnalyticsSummary(days = 7): Promise<AnalyticsSummary> {
  * error, and weekly_rollup rows permanently.
  */
 export async function archiveOldEvents(
-  daysToKeep = 30,
+  daysToKeep = 30
 ): Promise<{ archived: number; errors: number }> {
   await requireAnalyticsIntegration();
 
@@ -344,17 +326,14 @@ export async function archiveOldEvents(
 
   for (const eventType of archivableTypes) {
     try {
-      const pages = await notionFetchAll(
-        `/databases/${NOTION_ANALYTICS_DB_ID}/query`,
-        {
-          filter: {
-            and: [
-              { property: "Type", select: { equals: eventType } },
-              { property: "Date", date: { before: cutoffStr } },
-            ],
-          },
+      const pages = await notionFetchAll(`/databases/${NOTION_ANALYTICS_DB_ID}/query`, {
+        filter: {
+          and: [
+            { property: "Type", select: { equals: eventType } },
+            { property: "Date", date: { before: cutoffStr } },
+          ],
         },
-      );
+      });
 
       for (const page of pages) {
         try {
@@ -368,17 +347,12 @@ export async function archiveOldEvents(
         }
       }
     } catch (err) {
-      console.error(
-        `[Notion Analytics] Failed to archive ${eventType} events:`,
-        err,
-      );
+      console.error(`[Notion Analytics] Failed to archive ${eventType} events:`, err);
       errors++;
     }
   }
 
-  console.warn(
-    `[Notion Analytics] Archived ${archived} old events (${errors} errors)`,
-  );
+  console.warn(`[Notion Analytics] Archived ${archived} old events (${errors} errors)`);
   return { archived, errors };
 }
 
@@ -401,6 +375,6 @@ export async function createWeeklyRollup(): Promise<string | null> {
       count: summary.totalEvents,
       metadata,
     },
-    { immediate: true },
+    { immediate: true }
   );
 }

--- a/src/lib/notion-blog.ts
+++ b/src/lib/notion-blog.ts
@@ -32,10 +32,7 @@ import {
   notionImageProxyUrl,
   type TocEntry,
 } from "@/lib/notion";
-import {
-  getIntegrationsAsync,
-  requireIntegrationAsync,
-} from "@/lib/integrations";
+import { getIntegrationsAsync, requireIntegrationAsync } from "@/lib/integrations";
 import { cached } from "@/lib/notion-cache";
 
 const BLOG_PUBLISHED_FILTER = {
@@ -103,18 +100,13 @@ function mapPage(page: any): NotionPost {
     coverImage:
       p["Cover Image"]?.url ??
       page.cover?.external?.url ??
-      (page.cover?.type === "file"
-        ? notionImageProxyUrl(page.id, "cover")
-        : undefined),
+      (page.cover?.type === "file" ? notionImageProxyUrl(page.id, "cover") : undefined),
     readTime:
-      extractText(p["Read Time"]?.rich_text) ||
-      extractText(p.ReadTime?.rich_text) ||
-      "5 min read",
+      extractText(p["Read Time"]?.rich_text) || extractText(p.ReadTime?.rich_text) || "5 min read",
     seoTitle: extractText(p["SEO Title"]?.rich_text) || undefined,
     seoDescription: extractText(p["SEO Description"]?.rich_text) || undefined,
     status: (p.Status?.select?.name ?? "") as NotionPost["status"],
-    generatedBy: (p.GeneratedBy?.select?.name ??
-      "") as NotionPost["generatedBy"],
+    generatedBy: (p.GeneratedBy?.select?.name ?? "") as NotionPost["generatedBy"],
   };
 }
 /* eslint-enable @typescript-eslint/no-explicit-any */
@@ -133,13 +125,10 @@ export async function getPosts(): Promise<NotionPost[]> {
   return cached("blog:posts", async () => {
     const { NOTION_BLOG_DB_ID } = await getIntegrationsAsync();
     try {
-      const pages = await notionFetchAll(
-        `/databases/${NOTION_BLOG_DB_ID}/query`,
-        {
-          filter: BLOG_PUBLISHED_FILTER,
-          sorts: BLOG_DATE_SORT,
-        },
-      );
+      const pages = await notionFetchAll(`/databases/${NOTION_BLOG_DB_ID}/query`, {
+        filter: BLOG_PUBLISHED_FILTER,
+        sorts: BLOG_DATE_SORT,
+      });
       return pages.map(mapPage);
     } catch (err) {
       console.error("[Notion Blog] Failed to fetch posts:", err);
@@ -156,10 +145,9 @@ export async function getAllPosts(): Promise<NotionPost[]> {
 
   const { NOTION_BLOG_DB_ID } = await getIntegrationsAsync();
   try {
-    const pages = await notionFetchAll(
-      `/databases/${NOTION_BLOG_DB_ID}/query`,
-      { sorts: BLOG_DATE_SORT },
-    );
+    const pages = await notionFetchAll(`/databases/${NOTION_BLOG_DB_ID}/query`, {
+      sorts: BLOG_DATE_SORT,
+    });
     return pages.map(mapPage);
   } catch (err) {
     console.error("[Notion Blog] Failed to fetch all posts:", err);
@@ -180,9 +168,7 @@ export async function getFeaturedPosts(): Promise<NotionPost[]> {
  * Fetch posts filtered by category.
  * Reuses the cached getPosts() result to avoid a redundant Notion query.
  */
-export async function getPostsByCategory(
-  category: string,
-): Promise<NotionPost[]> {
+export async function getPostsByCategory(category: string): Promise<NotionPost[]> {
   const posts = await getPosts();
   return posts.filter((p) => p.category === category);
 }
@@ -199,24 +185,16 @@ export async function getPostsByTag(tag: string): Promise<NotionPost[]> {
 /**
  * Fetch a single post by slug, including full rendered HTML content.
  */
-export async function getPostBySlug(
-  slug: string,
-): Promise<NotionPostWithContent | null> {
+export async function getPostBySlug(slug: string): Promise<NotionPostWithContent | null> {
   await requireBlogIntegration();
 
   const { NOTION_BLOG_DB_ID } = await getIntegrationsAsync();
   try {
-    const pages = await notionFetchAll(
-      `/databases/${NOTION_BLOG_DB_ID}/query`,
-      {
-        filter: {
-          and: [
-            { property: "Slug", rich_text: { equals: slug } },
-            BLOG_PUBLISHED_FILTER,
-          ],
-        },
+    const pages = await notionFetchAll(`/databases/${NOTION_BLOG_DB_ID}/query`, {
+      filter: {
+        and: [{ property: "Slug", rich_text: { equals: slug } }, BLOG_PUBLISHED_FILTER],
       },
-    );
+    });
 
     const page = pages[0];
     if (!page) return null;
@@ -274,7 +252,7 @@ export async function searchPosts(query: string): Promise<NotionPost[]> {
     (p) =>
       p.title.toLowerCase().includes(q) ||
       p.excerpt.toLowerCase().includes(q) ||
-      p.tags.some((t) => t.toLowerCase().includes(q)),
+      p.tags.some((t) => t.toLowerCase().includes(q))
   );
 }
 
@@ -282,10 +260,7 @@ export async function searchPosts(query: string): Promise<NotionPost[]> {
  * Get related posts based on shared tags and category.
  * Returns up to `limit` posts, excluding the current post.
  */
-export async function getRelatedPosts(
-  post: NotionPost,
-  limit = 3,
-): Promise<NotionPost[]> {
+export async function getRelatedPosts(post: NotionPost, limit = 3): Promise<NotionPost[]> {
   const allPosts = await getPosts();
   const others = allPosts.filter((p) => p.id !== post.id);
 
@@ -311,23 +286,17 @@ export async function getRelatedPosts(
  * Uses extractToc from the shared client.
  */
 export async function getPostWithToc(
-  slug: string,
+  slug: string
 ): Promise<(NotionPostWithContent & { toc: TocEntry[] }) | null> {
   await requireBlogIntegration();
 
   const { NOTION_BLOG_DB_ID } = await getIntegrationsAsync();
   try {
-    const pages = await notionFetchAll(
-      `/databases/${NOTION_BLOG_DB_ID}/query`,
-      {
-        filter: {
-          and: [
-            { property: "Slug", rich_text: { equals: slug } },
-            BLOG_PUBLISHED_FILTER,
-          ],
-        },
+    const pages = await notionFetchAll(`/databases/${NOTION_BLOG_DB_ID}/query`, {
+      filter: {
+        and: [{ property: "Slug", rich_text: { equals: slug } }, BLOG_PUBLISHED_FILTER],
       },
-    );
+    });
 
     const page = pages[0];
     if (!page) return null;
@@ -377,7 +346,7 @@ export async function getTagCounts(): Promise<Record<string, number>> {
  */
 export async function getPaginatedPosts(
   page: number,
-  perPage = 10,
+  perPage = 10
 ): Promise<{ posts: NotionPost[]; total: number; totalPages: number }> {
   const allPosts = await getPosts();
   const start = (page - 1) * perPage;

--- a/src/lib/notion-cache.ts
+++ b/src/lib/notion-cache.ts
@@ -31,7 +31,7 @@ const DEFAULT_TTL_MS = 60 * 1000; // 60 seconds
 export async function cached<T>(
   key: string,
   fetcher: () => Promise<T>,
-  ttlMs = DEFAULT_TTL_MS,
+  ttlMs = DEFAULT_TTL_MS
 ): Promise<T> {
   const now = Date.now();
   const entry = cache.get(key) as CacheEntry<T> | undefined;

--- a/src/lib/notion-calendar.ts
+++ b/src/lib/notion-calendar.ts
@@ -17,10 +17,7 @@
  */
 
 import { notionFetch } from "@/lib/notion";
-import {
-  IntegrationNotConfiguredError,
-  requireIntegrationAsync,
-} from "@/lib/integrations";
+import { IntegrationNotConfiguredError, requireIntegrationAsync } from "@/lib/integrations";
 import type { CalendarItem } from "@/lib/content-calendar";
 
 // ---------------------------------------------------------------------------
@@ -29,19 +26,10 @@ import type { CalendarItem } from "@/lib/content-calendar";
 
 async function getDb(): Promise<{ apiKey: string; dbId: string }> {
   // Empty string means explicitly disabled -- don't let SSM override a cleared env var.
-  if (
-    process.env.NOTION_API_KEY === "" ||
-    process.env.NOTION_CALENDAR_DB_ID === ""
-  ) {
-    throw new IntegrationNotConfiguredError([
-      "NOTION_API_KEY",
-      "NOTION_CALENDAR_DB_ID",
-    ]);
+  if (process.env.NOTION_API_KEY === "" || process.env.NOTION_CALENDAR_DB_ID === "") {
+    throw new IntegrationNotConfiguredError(["NOTION_API_KEY", "NOTION_CALENDAR_DB_ID"]);
   }
-  const cfg = await requireIntegrationAsync(
-    "NOTION_API_KEY",
-    "NOTION_CALENDAR_DB_ID",
-  );
+  const cfg = await requireIntegrationAsync("NOTION_API_KEY", "NOTION_CALENDAR_DB_ID");
   return { apiKey: cfg.NOTION_API_KEY!, dbId: cfg.NOTION_CALENDAR_DB_ID! };
 }
 
@@ -51,8 +39,7 @@ function rt(text: string) {
 
 function pageToItem(page: Record<string, unknown>): CalendarItem | null {
   try {
-    const p =
-      (page as { properties: Record<string, unknown> }).properties ?? {};
+    const p = (page as { properties: Record<string, unknown> }).properties ?? {};
 
     function sel(key: string): string {
       const prop = p[key] as { select?: { name?: string } } | undefined;
@@ -60,23 +47,17 @@ function pageToItem(page: Record<string, unknown>): CalendarItem | null {
     }
 
     function richText(key: string): string {
-      const prop = p[key] as
-        | { rich_text?: { plain_text?: string }[] }
-        | undefined;
+      const prop = p[key] as { rich_text?: { plain_text?: string }[] } | undefined;
       return prop?.rich_text?.map((r) => r.plain_text ?? "").join("") ?? "";
     }
 
     function title(): string {
-      const prop = p["Name"] as
-        | { title?: { plain_text?: string }[] }
-        | undefined;
+      const prop = p["Name"] as { title?: { plain_text?: string }[] } | undefined;
       return prop?.title?.map((r) => r.plain_text ?? "").join("") ?? "";
     }
 
     function dateField(key: string): { start?: string; end?: string } {
-      const prop = p[key] as
-        | { date?: { start?: string; end?: string | null } }
-        | undefined;
+      const prop = p[key] as { date?: { start?: string; end?: string | null } } | undefined;
       return { start: prop?.date?.start, end: prop?.date?.end ?? undefined };
     }
 
@@ -110,7 +91,7 @@ function pageToItem(page: Record<string, unknown>): CalendarItem | null {
 
 export async function notionGetCalendarItems(
   from?: string,
-  to?: string,
+  to?: string
 ): Promise<CalendarItem[] | null> {
   const db = await getDb();
 
@@ -132,13 +113,10 @@ export async function notionGetCalendarItems(
   }
 
   try {
-    const res = await notionFetch<{ results: unknown[] }>(
-      `/databases/${db.dbId}/query`,
-      {
-        method: "POST",
-        body: JSON.stringify(body),
-      },
-    );
+    const res = await notionFetch<{ results: unknown[] }>(`/databases/${db.dbId}/query`, {
+      method: "POST",
+      body: JSON.stringify(body),
+    });
 
     return res.results
       .map((p) => pageToItem(p as Record<string, unknown>))
@@ -148,9 +126,7 @@ export async function notionGetCalendarItems(
   }
 }
 
-export async function notionCreateCalendarItem(
-  item: CalendarItem,
-): Promise<string | null> {
+export async function notionCreateCalendarItem(item: CalendarItem): Promise<string | null> {
   const db = await getDb();
 
   const properties: Record<string, unknown> = {
@@ -184,23 +160,18 @@ export async function notionCreateCalendarItem(
   }
 }
 
-export async function notionUpdateCalendarItem(
-  item: CalendarItem,
-): Promise<boolean> {
+export async function notionUpdateCalendarItem(item: CalendarItem): Promise<boolean> {
   const db = await getDb();
 
   // Find the Notion page by CalID
   try {
-    const search = await notionFetch<{ results: { id: string }[] }>(
-      `/databases/${db.dbId}/query`,
-      {
-        method: "POST",
-        body: JSON.stringify({
-          filter: { property: "CalID", rich_text: { equals: item.id } },
-          page_size: 1,
-        }),
-      },
-    );
+    const search = await notionFetch<{ results: { id: string }[] }>(`/databases/${db.dbId}/query`, {
+      method: "POST",
+      body: JSON.stringify({
+        filter: { property: "CalID", rich_text: { equals: item.id } },
+        page_size: 1,
+      }),
+    });
 
     const pageId = search.results[0]?.id;
     if (!pageId) return false;
@@ -229,16 +200,13 @@ export async function notionDeleteCalendarItem(id: string): Promise<boolean> {
   const db = await getDb();
 
   try {
-    const search = await notionFetch<{ results: { id: string }[] }>(
-      `/databases/${db.dbId}/query`,
-      {
-        method: "POST",
-        body: JSON.stringify({
-          filter: { property: "CalID", rich_text: { equals: id } },
-          page_size: 1,
-        }),
-      },
-    );
+    const search = await notionFetch<{ results: { id: string }[] }>(`/databases/${db.dbId}/query`, {
+      method: "POST",
+      body: JSON.stringify({
+        filter: { property: "CalID", rich_text: { equals: id } },
+        page_size: 1,
+      }),
+    });
 
     const pageId = search.results[0]?.id;
     if (!pageId) return false;

--- a/src/lib/notion-case-studies.ts
+++ b/src/lib/notion-case-studies.ts
@@ -35,10 +35,7 @@ import {
   extractText,
   notionImageProxyUrl,
 } from "@/lib/notion";
-import {
-  getIntegrationsAsync,
-  requireIntegrationAsync,
-} from "@/lib/integrations";
+import { getIntegrationsAsync, requireIntegrationAsync } from "@/lib/integrations";
 import { cached } from "@/lib/notion-cache";
 
 // ---------------------------------------------------------------------------
@@ -157,9 +154,7 @@ function mapPage(page: any): CaseStudy {
     coverImage:
       p.CoverImage?.url ??
       page.cover?.external?.url ??
-      (page.cover?.type === "file"
-        ? notionImageProxyUrl(page.id, "cover")
-        : undefined),
+      (page.cover?.type === "file" ? notionImageProxyUrl(page.id, "cover") : undefined),
     tags: (p.Tags?.multi_select ?? []).map((t: any) => t.name),
     featured: p.Featured?.checkbox ?? false,
     date: p.Date?.date?.start ?? page.created_time ?? "",
@@ -180,13 +175,10 @@ export async function getCaseStudies(): Promise<CaseStudy[]> {
   return cached("case-studies:all", async () => {
     const { NOTION_CASE_STUDIES_DB_ID } = await getIntegrationsAsync();
     try {
-      const pages = await notionFetchAll(
-        `/databases/${NOTION_CASE_STUDIES_DB_ID}/query`,
-        {
-          filter: { property: "Published", checkbox: { equals: true } },
-          sorts: [{ property: "Date", direction: "descending" }],
-        },
-      );
+      const pages = await notionFetchAll(`/databases/${NOTION_CASE_STUDIES_DB_ID}/query`, {
+        filter: { property: "Published", checkbox: { equals: true } },
+        sorts: [{ property: "Date", direction: "descending" }],
+      });
       return pages.map(mapPage);
     } catch (err) {
       console.error("[Notion Case Studies] Failed to fetch:", err);
@@ -206,24 +198,19 @@ export async function getFeaturedCaseStudies(): Promise<CaseStudy[]> {
 /**
  * Fetch a single case study by slug, with full rendered HTML content.
  */
-export async function getCaseStudyBySlug(
-  slug: string,
-): Promise<CaseStudyWithContent | null> {
+export async function getCaseStudyBySlug(slug: string): Promise<CaseStudyWithContent | null> {
   await requireIntegrationAsync("NOTION_API_KEY", "NOTION_CASE_STUDIES_DB_ID");
 
   const { NOTION_CASE_STUDIES_DB_ID } = await getIntegrationsAsync();
   try {
-    const pages = await notionFetchAll(
-      `/databases/${NOTION_CASE_STUDIES_DB_ID}/query`,
-      {
-        filter: {
-          and: [
-            { property: "Slug", rich_text: { equals: slug } },
-            { property: "Published", checkbox: { equals: true } },
-          ],
-        },
+    const pages = await notionFetchAll(`/databases/${NOTION_CASE_STUDIES_DB_ID}/query`, {
+      filter: {
+        and: [
+          { property: "Slug", rich_text: { equals: slug } },
+          { property: "Published", checkbox: { equals: true } },
+        ],
       },
-    );
+    });
     const page = pages[0];
     if (!page) return null;
     const cs = mapPage(page);

--- a/src/lib/notion-comments.ts
+++ b/src/lib/notion-comments.ts
@@ -64,7 +64,7 @@ export async function listComments(blockId: string): Promise<NotionComment[]> {
     // codeql[js/log-injection] -- error message sanitized (newlines stripped)
     console.error(
       "[Notion Comments] Failed to list comments:",
-      ((err as Error)?.message ?? "unknown error").replace(/[\r\n]/g, " "),
+      ((err as Error)?.message ?? "unknown error").replace(/[\r\n]/g, " ")
     );
     return [];
   }
@@ -76,10 +76,7 @@ export async function listComments(blockId: string): Promise<NotionComment[]> {
  * Note: The Notion API only supports adding comments to pages (not blocks)
  * when using an internal integration.
  */
-export async function addComment(
-  pageId: string,
-  text: string,
-): Promise<NotionComment | null> {
+export async function addComment(pageId: string, text: string): Promise<NotionComment | null> {
   await requireIntegrationAsync("NOTION_API_KEY");
 
   try {
@@ -96,7 +93,7 @@ export async function addComment(
   } catch (err) {
     console.error(
       "[Notion Comments] Failed to add comment:",
-      (err as Error)?.message ?? "unknown error",
+      (err as Error)?.message ?? "unknown error"
     );
     return null;
   }
@@ -107,7 +104,7 @@ export async function addComment(
  */
 export async function replyToDiscussion(
   discussionId: string,
-  text: string,
+  text: string
 ): Promise<NotionComment | null> {
   await requireIntegrationAsync("NOTION_API_KEY");
 
@@ -125,7 +122,7 @@ export async function replyToDiscussion(
   } catch (err) {
     console.error(
       "[Notion Comments] Failed to reply to discussion:",
-      (err as Error)?.message ?? "unknown error",
+      (err as Error)?.message ?? "unknown error"
     );
     return null;
   }

--- a/src/lib/notion-docs.ts
+++ b/src/lib/notion-docs.ts
@@ -66,13 +66,9 @@ function mapPage(page: any): DocRecord {
   const p = page.properties ?? {};
   return {
     id: page.id,
-    slug:
-      (p.Slug?.rich_text ?? []).map((t: any) => t.plain_text).join("") ||
-      page.id,
+    slug: (p.Slug?.rich_text ?? []).map((t: any) => t.plain_text).join("") || page.id,
     title: (p.Title?.title ?? []).map((t: any) => t.plain_text).join(""),
-    description: (p.Description?.rich_text ?? [])
-      .map((t: any) => t.plain_text)
-      .join(""),
+    description: (p.Description?.rich_text ?? []).map((t: any) => t.plain_text).join(""),
     category: p.Category?.select?.name ?? "General",
     order: p.Order?.number ?? 0,
     published: p.Published?.checkbox ?? false,
@@ -91,16 +87,13 @@ function mapPage(page: any): DocRecord {
 export async function getAllDocs(): Promise<DocRecord[]> {
   const { NOTION_DOCS_DB_ID } = await requireIntegrationAsync(
     "NOTION_API_KEY",
-    "NOTION_DOCS_DB_ID",
+    "NOTION_DOCS_DB_ID"
   );
 
   try {
-    const results = await notionFetchAll<unknown>(
-      `/databases/${NOTION_DOCS_DB_ID}/query`,
-      {
-        sorts: DOCS_SORT,
-      },
-    );
+    const results = await notionFetchAll<unknown>(`/databases/${NOTION_DOCS_DB_ID}/query`, {
+      sorts: DOCS_SORT,
+    });
     /* eslint-disable @typescript-eslint/no-explicit-any */
     return (results as any[]).map(mapPage);
     /* eslint-enable @typescript-eslint/no-explicit-any */
@@ -117,18 +110,15 @@ export async function getAllDocs(): Promise<DocRecord[]> {
 export async function getDocs(): Promise<DocRecord[]> {
   const { NOTION_DOCS_DB_ID } = await requireIntegrationAsync(
     "NOTION_API_KEY",
-    "NOTION_DOCS_DB_ID",
+    "NOTION_DOCS_DB_ID"
   );
 
   return cached("docs:all", async () => {
     try {
-      const results = await notionFetchAll<unknown>(
-        `/databases/${NOTION_DOCS_DB_ID}/query`,
-        {
-          filter: DOCS_PUBLISHED_FILTER,
-          sorts: DOCS_SORT,
-        },
-      );
+      const results = await notionFetchAll<unknown>(`/databases/${NOTION_DOCS_DB_ID}/query`, {
+        filter: DOCS_PUBLISHED_FILTER,
+        sorts: DOCS_SORT,
+      });
 
       /* eslint-disable @typescript-eslint/no-explicit-any */
       return (results as any[]).map(mapPage);
@@ -147,7 +137,7 @@ export async function getDocs(): Promise<DocRecord[]> {
 export async function getDocBySlug(slug: string): Promise<DocRecord | null> {
   const { NOTION_DOCS_DB_ID } = await requireIntegrationAsync(
     "NOTION_API_KEY",
-    "NOTION_DOCS_DB_ID",
+    "NOTION_DOCS_DB_ID"
   );
 
   try {
@@ -157,14 +147,11 @@ export async function getDocBySlug(slug: string): Promise<DocRecord | null> {
         method: "POST",
         body: JSON.stringify({
           filter: {
-            and: [
-              { property: "Slug", rich_text: { equals: slug } },
-              DOCS_PUBLISHED_FILTER,
-            ],
+            and: [{ property: "Slug", rich_text: { equals: slug } }, DOCS_PUBLISHED_FILTER],
           },
           page_size: 1,
         }),
-      },
+      }
     );
 
     /* eslint-disable @typescript-eslint/no-explicit-any */
@@ -183,9 +170,7 @@ export async function getDocBySlug(slug: string): Promise<DocRecord | null> {
  * Fetch a doc's full content as rendered HTML.
  * Returns null if not found or Notion is not configured.
  */
-export async function getDocContent(
-  pageId: string,
-): Promise<DocContent | null> {
+export async function getDocContent(pageId: string): Promise<DocContent | null> {
   await requireIntegrationAsync("NOTION_API_KEY");
 
   try {
@@ -210,9 +195,7 @@ export async function getDocContent(
 /**
  * Group docs by category for sidebar navigation.
  */
-export function groupDocsByCategory(
-  docs: DocRecord[],
-): Record<string, DocRecord[]> {
+export function groupDocsByCategory(docs: DocRecord[]): Record<string, DocRecord[]> {
   return docs.reduce<Record<string, DocRecord[]>>((acc, doc) => {
     const cat = doc.category;
     if (!acc[cat]) acc[cat] = [];
@@ -246,10 +229,8 @@ function mapWikiPage(page: any): WikiDocRecord {
       p["Verification Status"]?.status?.name ??
       p["Verification Status"]?.select?.name ??
       "Unverified",
-    owner:
-      (p.Owner?.people ?? []).map((u: any) => u.name ?? "").join(", ") || "",
-    lastVerified:
-      p["Last verified"]?.date?.start ?? p["Last Verified"]?.date?.start ?? "",
+    owner: (p.Owner?.people ?? []).map((u: any) => u.name ?? "").join(", ") || "",
+    lastVerified: p["Last verified"]?.date?.start ?? p["Last Verified"]?.date?.start ?? "",
     lastEdited: page.last_edited_time ?? "",
   };
 }
@@ -262,17 +243,14 @@ function mapWikiPage(page: any): WikiDocRecord {
 export async function getWikiDocs(): Promise<WikiDocRecord[]> {
   const { NOTION_DOCS_DB_ID } = await requireIntegrationAsync(
     "NOTION_API_KEY",
-    "NOTION_DOCS_DB_ID",
+    "NOTION_DOCS_DB_ID"
   );
 
   try {
-    const results = await notionFetchAll<unknown>(
-      `/databases/${NOTION_DOCS_DB_ID}/query`,
-      {
-        filter: DOCS_PUBLISHED_FILTER,
-        sorts: DOCS_SORT,
-      },
-    );
+    const results = await notionFetchAll<unknown>(`/databases/${NOTION_DOCS_DB_ID}/query`, {
+      filter: DOCS_PUBLISHED_FILTER,
+      sorts: DOCS_SORT,
+    });
 
     /* eslint-disable @typescript-eslint/no-explicit-any */
     return (results as any[]).map(mapWikiPage);
@@ -289,22 +267,16 @@ export async function getWikiDocs(): Promise<WikiDocRecord[]> {
 export async function getDocsNeedingVerification(): Promise<WikiDocRecord[]> {
   const docs = await getWikiDocs();
   return docs.filter(
-    (d) =>
-      d.verificationStatus === "Needs re-verification" ||
-      d.verificationStatus === "Unverified",
+    (d) => d.verificationStatus === "Needs re-verification" || d.verificationStatus === "Unverified"
   );
 }
 
 /**
  * Get docs owned by a specific person.
  */
-export async function getDocsByOwner(
-  ownerName: string,
-): Promise<WikiDocRecord[]> {
+export async function getDocsByOwner(ownerName: string): Promise<WikiDocRecord[]> {
   const docs = await getWikiDocs();
-  return docs.filter((d) =>
-    d.owner.toLowerCase().includes(ownerName.toLowerCase()),
-  );
+  return docs.filter((d) => d.owner.toLowerCase().includes(ownerName.toLowerCase()));
 }
 
 /**
@@ -315,9 +287,7 @@ export async function searchDocs(query: string): Promise<DocRecord[]> {
   const docs = await getDocs();
   const q = query.toLowerCase();
   return docs.filter(
-    (d) =>
-      d.title.toLowerCase().includes(q) ||
-      d.description.toLowerCase().includes(q),
+    (d) => d.title.toLowerCase().includes(q) || d.description.toLowerCase().includes(q)
   );
 }
 
@@ -325,7 +295,7 @@ export async function searchDocs(query: string): Promise<DocRecord[]> {
  * Get doc content with table of contents.
  */
 export async function getDocContentWithToc(
-  pageId: string,
+  pageId: string
 ): Promise<(DocContent & { toc: TocEntry[] }) | null> {
   await requireIntegrationAsync("NOTION_API_KEY");
 

--- a/src/lib/notion-esp32.ts
+++ b/src/lib/notion-esp32.ts
@@ -83,10 +83,7 @@ export async function getEsp32NotionConfig(): Promise<Esp32NotionConfig> {
 
   // Fallback: in case the values move into the integrations module later.
   try {
-    const integ = (await getIntegrationsAsync()) as Record<
-      string,
-      string | undefined
-    >;
+    const integ = (await getIntegrationsAsync()) as Record<string, string | undefined>;
     return {
       devicesDbId: integ.NOTION_ESP32_DEVICES_DB_ID,
       telemetryDbId: integ.NOTION_ESP32_TELEMETRY_DB_ID,
@@ -119,10 +116,7 @@ interface NotionQueryResponse {
   results?: Array<{ id: string }>;
 }
 
-async function findDevicePageByDeviceId(
-  dbId: string,
-  deviceId: string,
-): Promise<string | null> {
+async function findDevicePageByDeviceId(dbId: string, deviceId: string): Promise<string | null> {
   const body = {
     filter: {
       property: PROP_DEVICE_ID,
@@ -130,13 +124,10 @@ async function findDevicePageByDeviceId(
     },
     page_size: 1,
   };
-  const res = await notionFetch<NotionQueryResponse>(
-    `/databases/${dbId}/query`,
-    {
-      method: "POST",
-      body: JSON.stringify(body),
-    },
-  );
+  const res = await notionFetch<NotionQueryResponse>(`/databases/${dbId}/query`, {
+    method: "POST",
+    body: JSON.stringify(body),
+  });
   return res.results?.[0]?.id ?? null;
 }
 
@@ -151,9 +142,7 @@ async function findDevicePageByDeviceId(
  * created; otherwise the existing page is patched. Returns the Notion page id
  * (or null when the feature is not configured).
  */
-export async function upsertEsp32DeviceInNotion(
-  status: Esp32Status,
-): Promise<string | null> {
+export async function upsertEsp32DeviceInNotion(status: Esp32Status): Promise<string | null> {
   const cfg = await getEsp32NotionConfig();
   if (!cfg.devicesDbId) return null;
   if (!status.device_id) return null; // can't upsert without a key
@@ -170,22 +159,16 @@ export async function upsertEsp32DeviceInNotion(
       rich_text: status.ip ? [{ text: { content: status.ip } }] : [],
     },
     Firmware: {
-      rich_text: status.firmware_ver
-        ? [{ text: { content: status.firmware_ver } }]
-        : [],
+      rich_text: status.firmware_ver ? [{ text: { content: status.firmware_ver } }] : [],
     },
     RSSI: { number: status.rssi },
     [PROP_FREE_RAM]: { number: status.free_ram_bytes },
     Uptime: { number: status.uptime_s },
-    [PROP_LAST_HEARTBEAT]:
-      heartbeat != null ? { date: { start: heartbeat } } : { date: null },
+    [PROP_LAST_HEARTBEAT]: heartbeat != null ? { date: { start: heartbeat } } : { date: null },
     Status: { select: { name: statusLabel(status) } },
   };
 
-  const existing = await findDevicePageByDeviceId(
-    cfg.devicesDbId,
-    status.device_id,
-  );
+  const existing = await findDevicePageByDeviceId(cfg.devicesDbId, status.device_id);
 
   if (existing) {
     const updated = await notionFetch<{ id: string }>(`/pages/${existing}`, {
@@ -212,9 +195,7 @@ export async function upsertEsp32DeviceInNotion(
  * here — callers are expected to forward only significant transitions
  * (alert raised / resolved), not every heartbeat.
  */
-export async function appendEsp32TelemetryToNotion(
-  alert: Esp32Alert,
-): Promise<string | null> {
+export async function appendEsp32TelemetryToNotion(alert: Esp32Alert): Promise<string | null> {
   const cfg = await getEsp32NotionConfig();
   if (!cfg.telemetryDbId) return null;
 
@@ -233,10 +214,8 @@ export async function appendEsp32TelemetryToNotion(
           rich_text: [{ text: { content: alert.message.slice(0, 2000) } }],
         },
         Status: { select: { name: alert.status || "ACTIVE" } },
-        [PROP_FIRST_SEEN]:
-          firstSeen != null ? { date: { start: firstSeen } } : { date: null },
-        [PROP_LAST_SEEN]:
-          lastSeen != null ? { date: { start: lastSeen } } : { date: null },
+        [PROP_FIRST_SEEN]: firstSeen != null ? { date: { start: firstSeen } } : { date: null },
+        [PROP_LAST_SEEN]: lastSeen != null ? { date: { start: lastSeen } } : { date: null },
       },
     }),
   });
@@ -258,16 +237,13 @@ export async function readEsp32DevicesFromNotion(): Promise<Esp32Status[]> {
   const cfg = await getEsp32NotionConfig();
   if (!cfg.devicesDbId) return [];
 
-  const res = await notionFetch<{ results?: NotionPage[] }>(
-    `/databases/${cfg.devicesDbId}/query`,
-    {
-      method: "POST",
-      body: JSON.stringify({
-        sorts: [{ property: "Last Heartbeat", direction: "descending" }],
-        page_size: 25,
-      }),
-    },
-  );
+  const res = await notionFetch<{ results?: NotionPage[] }>(`/databases/${cfg.devicesDbId}/query`, {
+    method: "POST",
+    body: JSON.stringify({
+      sorts: [{ property: "Last Heartbeat", direction: "descending" }],
+      page_size: 25,
+    }),
+  });
 
   return (res.results ?? []).map((page) => mapDevicePage(page));
 }
@@ -283,8 +259,7 @@ const PROP_LAST_SEEN = "Last seen";
 function mapDevicePage(page: any): Esp32Status {
   const p = page.properties ?? {};
   const richText = (v: unknown): string | null => {
-    const arr = (v as { rich_text?: Array<{ plain_text?: string }> })
-      ?.rich_text;
+    const arr = (v as { rich_text?: Array<{ plain_text?: string }> })?.rich_text;
     if (!arr?.length) return null;
     return arr.map((t) => t.plain_text ?? "").join("") || null;
   };

--- a/src/lib/notion-faqs.ts
+++ b/src/lib/notion-faqs.ts
@@ -116,15 +116,10 @@ function mapPage(page: any): Faq {
  * Falls back to staticFaqs when Notion is not configured.
  */
 export async function getFaqs(locale?: string): Promise<Faq[]> {
-  const configured = await isConfiguredAsync(
-    "NOTION_API_KEY",
-    "NOTION_FAQS_DB_ID",
-  );
+  const configured = await isConfiguredAsync("NOTION_API_KEY", "NOTION_FAQS_DB_ID");
   if (!configured) {
     return locale
-      ? staticFaqs.filter(
-          (f) => f.locales.length === 0 || f.locales.includes(locale),
-        )
+      ? staticFaqs.filter((f) => f.locales.length === 0 || f.locales.includes(locale))
       : staticFaqs;
   }
 
@@ -132,18 +127,13 @@ export async function getFaqs(locale?: string): Promise<Faq[]> {
   return cached(cacheKey, async () => {
     const { NOTION_FAQS_DB_ID } = await getIntegrationsAsync();
     try {
-      const pages = await notionFetchAll(
-        `/databases/${NOTION_FAQS_DB_ID}/query`,
-        {
-          filter: { property: "Published", checkbox: { equals: true } },
-          sorts: [{ property: "Order", direction: "ascending" }],
-        },
-      );
+      const pages = await notionFetchAll(`/databases/${NOTION_FAQS_DB_ID}/query`, {
+        filter: { property: "Published", checkbox: { equals: true } },
+        sorts: [{ property: "Order", direction: "ascending" }],
+      });
       const all = pages.map(mapPage);
       const filtered = locale
-        ? all.filter(
-            (f) => f.locales.length === 0 || f.locales.includes(locale),
-          )
+        ? all.filter((f) => f.locales.length === 0 || f.locales.includes(locale))
         : all;
       return filtered.length > 0 ? filtered : staticFaqs;
     } catch (err) {
@@ -156,10 +146,7 @@ export async function getFaqs(locale?: string): Promise<Faq[]> {
 /**
  * Fetch FAQs filtered by category.
  */
-export async function getFaqsByCategory(
-  category: FaqCategory,
-  locale?: string,
-): Promise<Faq[]> {
+export async function getFaqsByCategory(category: FaqCategory, locale?: string): Promise<Faq[]> {
   const faqs = await getFaqs(locale);
   return faqs.filter((f) => f.category === category);
 }

--- a/src/lib/notion-forms.ts
+++ b/src/lib/notion-forms.ts
@@ -50,12 +50,10 @@ export interface SubmissionRecord {
  * Save a contact form submission to Notion.
  * Returns the created page ID, or null if Notion is not configured.
  */
-export async function saveSubmission(
-  data: ContactSubmission,
-): Promise<string | null> {
+export async function saveSubmission(data: ContactSubmission): Promise<string | null> {
   const { NOTION_SUBMISSIONS_DB_ID } = await requireIntegrationAsync(
     "NOTION_API_KEY",
-    "NOTION_SUBMISSIONS_DB_ID",
+    "NOTION_SUBMISSIONS_DB_ID"
   );
 
   try {
@@ -71,14 +69,10 @@ export async function saveSubmission(
             email: data.email,
           },
           Company: {
-            rich_text: [
-              { text: { content: (data.company ?? "").slice(0, 200) } },
-            ],
+            rich_text: [{ text: { content: (data.company ?? "").slice(0, 200) } }],
           },
           Service: {
-            rich_text: [
-              { text: { content: (data.service ?? "").slice(0, 200) } },
-            ],
+            rich_text: [{ text: { content: (data.service ?? "").slice(0, 200) } }],
           },
           Message: {
             rich_text: [{ text: { content: data.message.slice(0, 2000) } }],
@@ -101,7 +95,7 @@ export async function saveSubmission(
     // codeql[js/log-injection] -- error message sanitized (newlines stripped)
     console.error(
       "[Notion] Failed to save submission:",
-      ((err as Error)?.message ?? "unknown error").replace(/[\r\n]/g, " "),
+      ((err as Error)?.message ?? "unknown error").replace(/[\r\n]/g, " ")
     );
     return null;
   }
@@ -116,15 +110,14 @@ export async function saveSubmission(
 export async function listSubmissions(limit = 50): Promise<SubmissionRecord[]> {
   const { NOTION_SUBMISSIONS_DB_ID } = await requireIntegrationAsync(
     "NOTION_API_KEY",
-    "NOTION_SUBMISSIONS_DB_ID",
+    "NOTION_SUBMISSIONS_DB_ID"
   );
 
   try {
     /* eslint-disable @typescript-eslint/no-explicit-any */
-    const results = await notionFetchAll<any>(
-      `/databases/${NOTION_SUBMISSIONS_DB_ID}/query`,
-      { sorts: [{ property: SUBMITTED_AT_PROP, direction: "descending" }] },
-    );
+    const results = await notionFetchAll<any>(`/databases/${NOTION_SUBMISSIONS_DB_ID}/query`, {
+      sorts: [{ property: SUBMITTED_AT_PROP, direction: "descending" }],
+    });
 
     return results.slice(0, limit).map((page: any) => {
       const p = page.properties ?? {};
@@ -132,15 +125,9 @@ export async function listSubmissions(limit = 50): Promise<SubmissionRecord[]> {
         id: page.id,
         name: (p.Name?.title ?? []).map((t: any) => t.plain_text).join(""),
         email: p.Email?.email ?? "",
-        company: (p.Company?.rich_text ?? [])
-          .map((t: any) => t.plain_text)
-          .join(""),
-        service: (p.Service?.rich_text ?? [])
-          .map((t: any) => t.plain_text)
-          .join(""),
-        message: (p.Message?.rich_text ?? [])
-          .map((t: any) => t.plain_text)
-          .join(""),
+        company: (p.Company?.rich_text ?? []).map((t: any) => t.plain_text).join(""),
+        service: (p.Service?.rich_text ?? []).map((t: any) => t.plain_text).join(""),
+        message: (p.Message?.rich_text ?? []).map((t: any) => t.plain_text).join(""),
         status: p.Status?.select?.name ?? "New",
         source: p.Source?.select?.name ?? SOURCE_CONTACT,
         submittedAt: p[SUBMITTED_AT_PROP]?.date?.start ?? page.created_time,
@@ -151,7 +138,7 @@ export async function listSubmissions(limit = 50): Promise<SubmissionRecord[]> {
   } catch (err) {
     console.error(
       "[Notion] Failed to list submissions:",
-      (err as Error)?.message ?? "unknown error",
+      (err as Error)?.message ?? "unknown error"
     );
     return [];
   }
@@ -162,7 +149,7 @@ export async function listSubmissions(limit = 50): Promise<SubmissionRecord[]> {
  */
 export async function updateSubmissionStatus(
   pageId: string,
-  status: "New" | "In Review" | "Done",
+  status: "New" | "In Review" | "Done"
 ): Promise<boolean> {
   await requireIntegrationAsync("NOTION_API_KEY");
 
@@ -180,7 +167,7 @@ export async function updateSubmissionStatus(
     // codeql[js/log-injection] -- error message sanitized (newlines stripped)
     console.error(
       "[Notion] Failed to update submission status:",
-      ((err as Error)?.message ?? "unknown error").replace(/[\r\n]/g, " "),
+      ((err as Error)?.message ?? "unknown error").replace(/[\r\n]/g, " ")
     );
     return false;
   }

--- a/src/lib/notion-projects.ts
+++ b/src/lib/notion-projects.ts
@@ -10,21 +10,13 @@
  */
 
 import { notionFetch, notionFetchAll, extractText } from "@/lib/notion";
-import {
-  getIntegrationsAsync,
-  requireIntegrationAsync,
-} from "@/lib/integrations";
+import { getIntegrationsAsync, requireIntegrationAsync } from "@/lib/integrations";
 
 // ---------------------------------------------------------------------------
 // Types
 // ---------------------------------------------------------------------------
 
-export type ProjectStatus =
-  | "Planning"
-  | "In Progress"
-  | "On Hold"
-  | "Completed"
-  | "Cancelled";
+export type ProjectStatus = "Planning" | "In Progress" | "On Hold" | "Completed" | "Cancelled";
 export type ProjectPriority = "Critical" | "High" | "Medium" | "Low";
 export type ProjectType = "Client" | "Internal" | "Maintenance";
 
@@ -44,13 +36,7 @@ export interface Project {
   url: string;
 }
 
-export type TaskStatus =
-  | "Backlog"
-  | "To Do"
-  | "In Progress"
-  | "In Review"
-  | "Done"
-  | "Blocked";
+export type TaskStatus = "Backlog" | "To Do" | "In Progress" | "In Review" | "Done" | "Blocked";
 export type TaskPriority = "Urgent" | "High" | "Medium" | "Low";
 export type TaskEstimate = "XS" | "S" | "M" | "L" | "XL";
 export type TaskType = "Feature" | "Bug" | "Chore" | "Spike" | "Design";
@@ -123,9 +109,7 @@ function mapTask(page: any): Task {
 // Projects API
 // ---------------------------------------------------------------------------
 
-export async function listProjects(
-  statusFilter?: ProjectStatus,
-): Promise<Project[]> {
+export async function listProjects(statusFilter?: ProjectStatus): Promise<Project[]> {
   await requireIntegrationAsync("NOTION_API_KEY", "NOTION_PROJECTS_DB_ID");
 
   const { NOTION_PROJECTS_DB_ID } = await getIntegrationsAsync();
@@ -134,18 +118,15 @@ export async function listProjects(
       ? { property: "Status", select: { equals: statusFilter } }
       : undefined;
 
-    const pages = await notionFetchAll(
-      `/databases/${NOTION_PROJECTS_DB_ID}/query`,
-      {
-        ...(filter ? { filter } : {}),
-        sorts: [{ property: "Priority", direction: "ascending" }],
-      },
-    );
+    const pages = await notionFetchAll(`/databases/${NOTION_PROJECTS_DB_ID}/query`, {
+      ...(filter ? { filter } : {}),
+      sorts: [{ property: "Priority", direction: "ascending" }],
+    });
     return pages.map(mapProject);
   } catch (err) {
     console.error(
       "[Notion Projects] Failed to list projects:",
-      ((err as Error)?.message ?? "unknown error").replace(/[\r\n]/g, " "),
+      ((err as Error)?.message ?? "unknown error").replace(/[\r\n]/g, " ")
     );
     return [];
   }
@@ -159,7 +140,7 @@ export async function getProject(pageId: string): Promise<Project | null> {
   } catch (err) {
     console.error(
       "[Notion Projects] Failed to get project:",
-      ((err as Error)?.message ?? "unknown error").replace(/[\r\n]/g, " "),
+      ((err as Error)?.message ?? "unknown error").replace(/[\r\n]/g, " ")
     );
     return null;
   }
@@ -191,9 +172,7 @@ export async function createProject(data: {
           ...(data.description
             ? {
                 Description: {
-                  rich_text: [
-                    { text: { content: data.description.slice(0, 2000) } },
-                  ],
+                  rich_text: [{ text: { content: data.description.slice(0, 2000) } }],
                 },
               }
             : {}),
@@ -207,16 +186,13 @@ export async function createProject(data: {
   } catch (err) {
     console.error(
       "[Notion Projects] Failed to create project:",
-      ((err as Error)?.message ?? "unknown error").replace(/[\r\n]/g, " "),
+      ((err as Error)?.message ?? "unknown error").replace(/[\r\n]/g, " ")
     );
     return null;
   }
 }
 
-export async function updateProjectStatus(
-  pageId: string,
-  status: ProjectStatus,
-): Promise<boolean> {
+export async function updateProjectStatus(pageId: string, status: ProjectStatus): Promise<boolean> {
   await requireIntegrationAsync("NOTION_API_KEY");
   try {
     await notionFetch(`/pages/${pageId}`, {
@@ -230,16 +206,13 @@ export async function updateProjectStatus(
     // codeql[js/log-injection] -- error message sanitized (newlines stripped)
     console.error(
       "[Notion Projects] Failed to update project status:",
-      ((err as Error)?.message ?? "unknown error").replace(/[\r\n]/g, " "),
+      ((err as Error)?.message ?? "unknown error").replace(/[\r\n]/g, " ")
     );
     return false;
   }
 }
 
-export async function updateProjectProgress(
-  pageId: string,
-  progress: number,
-): Promise<boolean> {
+export async function updateProjectProgress(pageId: string, progress: number): Promise<boolean> {
   await requireIntegrationAsync("NOTION_API_KEY");
   try {
     await notionFetch(`/pages/${pageId}`, {
@@ -255,7 +228,7 @@ export async function updateProjectProgress(
     // codeql[js/log-injection] -- error message sanitized (newlines stripped)
     console.error(
       "[Notion Projects] Failed to update project progress:",
-      ((err as Error)?.message ?? "unknown error").replace(/[\r\n]/g, " "),
+      ((err as Error)?.message ?? "unknown error").replace(/[\r\n]/g, " ")
     );
     return false;
   }
@@ -301,21 +274,18 @@ export async function listTasks(filters?: {
           ? conditions[0]
           : undefined;
 
-    const pages = await notionFetchAll(
-      `/databases/${NOTION_TASKS_DB_ID}/query`,
-      {
-        ...(filter ? { filter } : {}),
-        sorts: [
-          { property: "Status", direction: "ascending" },
-          { property: "Priority", direction: "ascending" },
-        ],
-      },
-    );
+    const pages = await notionFetchAll(`/databases/${NOTION_TASKS_DB_ID}/query`, {
+      ...(filter ? { filter } : {}),
+      sorts: [
+        { property: "Status", direction: "ascending" },
+        { property: "Priority", direction: "ascending" },
+      ],
+    });
     return pages.map(mapTask);
   } catch (err) {
     console.error(
       "[Notion Tasks] Failed to list tasks:",
-      ((err as Error)?.message ?? "unknown error").replace(/[\r\n]/g, " "),
+      ((err as Error)?.message ?? "unknown error").replace(/[\r\n]/g, " ")
     );
     return [];
   }
@@ -344,25 +314,17 @@ export async function createTask(data: {
           Task: { title: [{ text: { content: data.task } }] },
           Status: { select: { name: data.status ?? "To Do" } },
           Priority: { select: { name: data.priority ?? "Medium" } },
-          ...(data.project
-            ? { Project: { relation: [{ id: data.project }] } }
-            : {}),
-          ...(data.assignee
-            ? { Assignee: { people: [{ id: data.assignee }] } }
-            : {}),
+          ...(data.project ? { Project: { relation: [{ id: data.project }] } } : {}),
+          ...(data.assignee ? { Assignee: { people: [{ id: data.assignee }] } } : {}),
           ...(data.type ? { Type: { select: { name: data.type } } } : {}),
           ...(data.description
             ? {
                 Description: {
-                  rich_text: [
-                    { text: { content: data.description.slice(0, 2000) } },
-                  ],
+                  rich_text: [{ text: { content: data.description.slice(0, 2000) } }],
                 },
               }
             : {}),
-          ...(data.dueDate
-            ? { "Due Date": { date: { start: data.dueDate } } }
-            : {}),
+          ...(data.dueDate ? { "Due Date": { date: { start: data.dueDate } } } : {}),
         },
       }),
     });
@@ -370,16 +332,13 @@ export async function createTask(data: {
   } catch (err) {
     console.error(
       "[Notion Tasks] Failed to create task:",
-      ((err as Error)?.message ?? "unknown error").replace(/[\r\n]/g, " "),
+      ((err as Error)?.message ?? "unknown error").replace(/[\r\n]/g, " ")
     );
     return null;
   }
 }
 
-export async function updateTaskStatus(
-  pageId: string,
-  status: TaskStatus,
-): Promise<boolean> {
+export async function updateTaskStatus(pageId: string, status: TaskStatus): Promise<boolean> {
   await requireIntegrationAsync("NOTION_API_KEY");
   try {
     await notionFetch(`/pages/${pageId}`, {
@@ -393,7 +352,7 @@ export async function updateTaskStatus(
     // codeql[js/log-injection] -- error message sanitized (newlines stripped)
     console.error(
       "[Notion Tasks] Failed to update task status:",
-      ((err as Error)?.message ?? "unknown error").replace(/[\r\n]/g, " "),
+      ((err as Error)?.message ?? "unknown error").replace(/[\r\n]/g, " ")
     );
     return false;
   }
@@ -441,24 +400,21 @@ export async function getSprintTasks(sprintName: string): Promise<Task[]> {
 
   const { NOTION_TASKS_DB_ID } = await getIntegrationsAsync();
   try {
-    const pages = await notionFetchAll(
-      `/databases/${NOTION_TASKS_DB_ID}/query`,
-      {
-        filter: {
-          property: "Sprint",
-          rich_text: { equals: sprintName },
-        },
-        sorts: [
-          { property: "Status", direction: "ascending" },
-          { property: "Priority", direction: "ascending" },
-        ],
+    const pages = await notionFetchAll(`/databases/${NOTION_TASKS_DB_ID}/query`, {
+      filter: {
+        property: "Sprint",
+        rich_text: { equals: sprintName },
       },
-    );
+      sorts: [
+        { property: "Status", direction: "ascending" },
+        { property: "Priority", direction: "ascending" },
+      ],
+    });
     return pages.map(mapTask);
   } catch (err) {
     console.error(
       "[Notion Tasks] Failed to get sprint tasks:",
-      ((err as Error)?.message ?? "unknown error").replace(/[\r\n]/g, " "),
+      ((err as Error)?.message ?? "unknown error").replace(/[\r\n]/g, " ")
     );
     return [];
   }
@@ -468,7 +424,7 @@ export async function getSprintTasks(sprintName: string): Promise<Task[]> {
  * Get sprint progress — how many tasks are done vs total.
  */
 export async function getSprintProgress(
-  sprintName: string,
+  sprintName: string
 ): Promise<{ total: number; done: number; percent: number }> {
   const tasks = await getSprintTasks(sprintName);
   const done = tasks.filter((t) => t.status === "Done").length;
@@ -488,10 +444,7 @@ export async function getSprintProgress(
  * Move all incomplete tasks from one sprint to another.
  * Useful for sprint rollovers.
  */
-export async function rolloverSprintTasks(
-  fromSprint: string,
-  toSprint: string,
-): Promise<number> {
+export async function rolloverSprintTasks(fromSprint: string, toSprint: string): Promise<number> {
   await requireIntegrationAsync("NOTION_API_KEY");
 
   const tasks = await getSprintTasks(fromSprint);
@@ -512,7 +465,7 @@ export async function rolloverSprintTasks(
     } catch (err) {
       console.error(
         `[Notion Tasks] Failed to move task:`,
-        ((err as Error)?.message ?? "unknown error").replace(/[\r\n]/g, " "),
+        ((err as Error)?.message ?? "unknown error").replace(/[\r\n]/g, " ")
       );
     }
   }
@@ -523,10 +476,7 @@ export async function rolloverSprintTasks(
 /**
  * Bulk update status for multiple tasks.
  */
-export async function bulkUpdateTaskStatus(
-  taskIds: string[],
-  status: TaskStatus,
-): Promise<number> {
+export async function bulkUpdateTaskStatus(taskIds: string[], status: TaskStatus): Promise<number> {
   await requireIntegrationAsync("NOTION_API_KEY");
 
   let updated = 0;
@@ -547,26 +497,23 @@ export async function getOverdueTasks(): Promise<Task[]> {
   const today = new Date().toISOString().split("T")[0];
 
   try {
-    const pages = await notionFetchAll(
-      `/databases/${NOTION_TASKS_DB_ID}/query`,
-      {
-        filter: {
-          and: [
-            { property: "Due Date", date: { before: today } },
-            {
-              property: "Status",
-              select: { does_not_equal: "Done" },
-            },
-          ],
-        },
-        sorts: [{ property: "Due Date", direction: "ascending" }],
+    const pages = await notionFetchAll(`/databases/${NOTION_TASKS_DB_ID}/query`, {
+      filter: {
+        and: [
+          { property: "Due Date", date: { before: today } },
+          {
+            property: "Status",
+            select: { does_not_equal: "Done" },
+          },
+        ],
       },
-    );
+      sorts: [{ property: "Due Date", direction: "ascending" }],
+    });
     return pages.map(mapTask);
   } catch (err) {
     console.error(
       "[Notion Tasks] Failed to get overdue tasks:",
-      ((err as Error)?.message ?? "unknown error").replace(/[\r\n]/g, " "),
+      ((err as Error)?.message ?? "unknown error").replace(/[\r\n]/g, " ")
     );
     return [];
   }
@@ -598,9 +545,7 @@ export async function getProjectDashboard(projectName: string): Promise<{
   }
 
   const today = new Date().toISOString().split("T")[0];
-  const overdueTasks = tasks.filter(
-    (t) => t.dueDate && t.dueDate < today && t.status !== "Done",
-  );
+  const overdueTasks = tasks.filter((t) => t.dueDate && t.dueDate < today && t.status !== "Done");
 
   return {
     project,

--- a/src/lib/notion-reports.ts
+++ b/src/lib/notion-reports.ts
@@ -16,10 +16,7 @@
  */
 
 import { notionFetch } from "@/lib/notion";
-import {
-  IntegrationNotConfiguredError,
-  requireIntegrationAsync,
-} from "@/lib/integrations";
+import { IntegrationNotConfiguredError, requireIntegrationAsync } from "@/lib/integrations";
 import type { Report } from "@/lib/reports";
 
 // ---------------------------------------------------------------------------
@@ -28,19 +25,10 @@ import type { Report } from "@/lib/reports";
 
 async function getDb(): Promise<{ apiKey: string; dbId: string }> {
   // Empty string means explicitly disabled -- don't let SSM override a cleared env var.
-  if (
-    process.env.NOTION_API_KEY === "" ||
-    process.env.NOTION_REPORTS_DB_ID === ""
-  ) {
-    throw new IntegrationNotConfiguredError([
-      "NOTION_API_KEY",
-      "NOTION_REPORTS_DB_ID",
-    ]);
+  if (process.env.NOTION_API_KEY === "" || process.env.NOTION_REPORTS_DB_ID === "") {
+    throw new IntegrationNotConfiguredError(["NOTION_API_KEY", "NOTION_REPORTS_DB_ID"]);
   }
-  const cfg = await requireIntegrationAsync(
-    "NOTION_API_KEY",
-    "NOTION_REPORTS_DB_ID",
-  );
+  const cfg = await requireIntegrationAsync("NOTION_API_KEY", "NOTION_REPORTS_DB_ID");
   return { apiKey: cfg.NOTION_API_KEY!, dbId: cfg.NOTION_REPORTS_DB_ID! };
 }
 
@@ -50,8 +38,7 @@ function rt(text: string) {
 
 function pageToReport(page: Record<string, unknown>): Report | null {
   try {
-    const p =
-      (page as { properties: Record<string, unknown> }).properties ?? {};
+    const p = (page as { properties: Record<string, unknown> }).properties ?? {};
 
     function sel(key: string): string {
       const prop = p[key] as { select?: { name?: string } } | undefined;
@@ -59,16 +46,12 @@ function pageToReport(page: Record<string, unknown>): Report | null {
     }
 
     function richText(key: string): string {
-      const prop = p[key] as
-        | { rich_text?: { plain_text?: string }[] }
-        | undefined;
+      const prop = p[key] as { rich_text?: { plain_text?: string }[] } | undefined;
       return prop?.rich_text?.map((r) => r.plain_text ?? "").join("") ?? "";
     }
 
     function title(): string {
-      const prop = p["Name"] as
-        | { title?: { plain_text?: string }[] }
-        | undefined;
+      const prop = p["Name"] as { title?: { plain_text?: string }[] } | undefined;
       return prop?.title?.map((r) => r.plain_text ?? "").join("") ?? "";
     }
 
@@ -108,15 +91,12 @@ export async function notionListReports(): Promise<Report[] | null> {
   const db = await getDb();
 
   try {
-    const res = await notionFetch<{ results: unknown[] }>(
-      `/databases/${db.dbId}/query`,
-      {
-        method: "POST",
-        body: JSON.stringify({
-          sorts: [{ property: "CreatedAt", direction: "descending" }],
-        }),
-      },
-    );
+    const res = await notionFetch<{ results: unknown[] }>(`/databases/${db.dbId}/query`, {
+      method: "POST",
+      body: JSON.stringify({
+        sorts: [{ property: "CreatedAt", direction: "descending" }],
+      }),
+    });
 
     return res.results
       .map((p) => pageToReport(p as Record<string, unknown>))
@@ -130,16 +110,13 @@ export async function notionGetReport(id: string): Promise<Report | null> {
   const db = await getDb();
 
   try {
-    const res = await notionFetch<{ results: unknown[] }>(
-      `/databases/${db.dbId}/query`,
-      {
-        method: "POST",
-        body: JSON.stringify({
-          filter: { property: "ReportID", rich_text: { equals: id } },
-          page_size: 1,
-        }),
-      },
-    );
+    const res = await notionFetch<{ results: unknown[] }>(`/databases/${db.dbId}/query`, {
+      method: "POST",
+      body: JSON.stringify({
+        filter: { property: "ReportID", rich_text: { equals: id } },
+        page_size: 1,
+      }),
+    });
 
     const page = res.results[0];
     if (!page) return null;
@@ -149,9 +126,7 @@ export async function notionGetReport(id: string): Promise<Report | null> {
   }
 }
 
-export async function notionCreateReport(
-  report: Report,
-): Promise<string | null> {
+export async function notionCreateReport(report: Report): Promise<string | null> {
   const db = await getDb();
 
   try {
@@ -176,30 +151,23 @@ export async function notionCreateReport(
   }
 }
 
-export async function notionUpdateReport(
-  id: string,
-  updates: Partial<Report>,
-): Promise<boolean> {
+export async function notionUpdateReport(id: string, updates: Partial<Report>): Promise<boolean> {
   const db = await getDb();
 
   try {
-    const search = await notionFetch<{ results: { id: string }[] }>(
-      `/databases/${db.dbId}/query`,
-      {
-        method: "POST",
-        body: JSON.stringify({
-          filter: { property: "ReportID", rich_text: { equals: id } },
-          page_size: 1,
-        }),
-      },
-    );
+    const search = await notionFetch<{ results: { id: string }[] }>(`/databases/${db.dbId}/query`, {
+      method: "POST",
+      body: JSON.stringify({
+        filter: { property: "ReportID", rich_text: { equals: id } },
+        page_size: 1,
+      }),
+    });
 
     const pageId = search.results[0]?.id;
     if (!pageId) return false;
 
     const properties: Record<string, unknown> = {};
-    if (updates.status)
-      properties.Status = { select: { name: updates.status } };
+    if (updates.status) properties.Status = { select: { name: updates.status } };
     if (updates.sections !== undefined) {
       properties.Sections = { rich_text: rt(JSON.stringify(updates.sections)) };
     }
@@ -219,16 +187,13 @@ export async function notionDeleteReport(id: string): Promise<boolean> {
   const db = await getDb();
 
   try {
-    const search = await notionFetch<{ results: { id: string }[] }>(
-      `/databases/${db.dbId}/query`,
-      {
-        method: "POST",
-        body: JSON.stringify({
-          filter: { property: "ReportID", rich_text: { equals: id } },
-          page_size: 1,
-        }),
-      },
-    );
+    const search = await notionFetch<{ results: { id: string }[] }>(`/databases/${db.dbId}/query`, {
+      method: "POST",
+      body: JSON.stringify({
+        filter: { property: "ReportID", rich_text: { equals: id } },
+        page_size: 1,
+      }),
+    });
 
     const pageId = search.results[0]?.id;
     if (!pageId) return false;

--- a/src/lib/notion-search.ts
+++ b/src/lib/notion-search.ts
@@ -62,8 +62,7 @@ function mapSearchResult(item: any): SearchResult {
   if (isPage) {
     const props = item.properties ?? {};
     // Try common title property names
-    const titleProp =
-      props.Title?.title ?? props.Name?.title ?? props.title?.title;
+    const titleProp = props.Title?.title ?? props.Name?.title ?? props.title?.title;
     title = titleProp ? titleProp.map((t: any) => t.plain_text).join("") : "";
   } else {
     // Database title
@@ -77,11 +76,7 @@ function mapSearchResult(item: any): SearchResult {
     url: item.url ?? "",
     lastEditedTime: item.last_edited_time ?? "",
     parentType: item.parent?.type ?? "",
-    parentId:
-      item.parent?.page_id ??
-      item.parent?.database_id ??
-      item.parent?.workspace_id ??
-      "",
+    parentId: item.parent?.page_id ?? item.parent?.database_id ?? item.parent?.workspace_id ?? "",
     icon: item.icon?.emoji ?? item.icon?.external?.url ?? undefined,
   };
 }
@@ -142,7 +137,7 @@ export async function searchPages(
     limit?: number;
     sortDirection?: "ascending" | "descending";
     startCursor?: string;
-  },
+  }
 ): Promise<{ results: SearchResult[]; hasMore: boolean; nextCursor?: string }> {
   await requireIntegrationAsync("NOTION_API_KEY");
 
@@ -180,10 +175,7 @@ export async function searchPages(
       nextCursor: data.next_cursor ?? undefined,
     };
   } catch (err) {
-    console.error(
-      "[Notion Search] Failed to search:",
-      (err as Error)?.message ?? "unknown error",
-    );
+    console.error("[Notion Search] Failed to search:", (err as Error)?.message ?? "unknown error");
     return { results: [], hasMore: false };
   }
 }
@@ -191,10 +183,7 @@ export async function searchPages(
 /**
  * Search only databases.
  */
-export async function searchDatabases(
-  query: string,
-  limit = 20,
-): Promise<SearchResult[]> {
+export async function searchDatabases(query: string, limit = 20): Promise<SearchResult[]> {
   const { results } = await searchPages(query, { filter: "database", limit });
   return results;
 }
@@ -219,7 +208,7 @@ export async function listUsers(): Promise<NotionUser[]> {
   } catch (err) {
     console.error(
       "[Notion Users] Failed to list users:",
-      (err as Error)?.message ?? "unknown error",
+      (err as Error)?.message ?? "unknown error"
     );
     return [];
   }
@@ -239,7 +228,7 @@ export async function getBotUser(): Promise<NotionUser | null> {
   } catch (err) {
     console.error(
       "[Notion Users] Failed to get bot user:",
-      (err as Error)?.message ?? "unknown error",
+      (err as Error)?.message ?? "unknown error"
     );
     return null;
   }
@@ -257,10 +246,7 @@ export async function getUser(userId: string): Promise<NotionUser | null> {
     return mapUser(data);
     /* eslint-enable @typescript-eslint/no-explicit-any */
   } catch (err) {
-    console.error(
-      "[Notion Users] Failed to get user:",
-      (err as Error)?.message ?? "unknown error",
-    );
+    console.error("[Notion Users] Failed to get user:", (err as Error)?.message ?? "unknown error");
     return null;
   }
 }
@@ -273,9 +259,7 @@ export async function getUser(userId: string): Promise<NotionUser | null> {
  * Retrieve the full schema of a database — property names, types, and options.
  * Useful for building dynamic forms or admin UIs.
  */
-export async function getDatabaseSchema(
-  databaseId: string,
-): Promise<DatabaseSchema | null> {
+export async function getDatabaseSchema(databaseId: string): Promise<DatabaseSchema | null> {
   await requireIntegrationAsync("NOTION_API_KEY");
 
   try {
@@ -283,9 +267,9 @@ export async function getDatabaseSchema(
     const db = await notionFetch<any>(`/databases/${databaseId}`);
 
     const title = (db.title ?? []).map((t: any) => t.plain_text).join("");
-    const properties: DatabaseProperty[] = Object.entries(
-      db.properties ?? {},
-    ).map(([name, prop]) => mapProperty(name, prop));
+    const properties: DatabaseProperty[] = Object.entries(db.properties ?? {}).map(([name, prop]) =>
+      mapProperty(name, prop)
+    );
 
     return {
       id: db.id,
@@ -298,7 +282,7 @@ export async function getDatabaseSchema(
     // codeql[js/log-injection] -- error message sanitized (newlines stripped)
     console.error(
       "[Notion Schema] Failed to get database schema:",
-      ((err as Error)?.message ?? "unknown error").replace(/[\r\n]/g, " "),
+      ((err as Error)?.message ?? "unknown error").replace(/[\r\n]/g, " ")
     );
     return null;
   }
@@ -310,7 +294,7 @@ export async function getDatabaseSchema(
  */
 export async function getPropertyOptions(
   databaseId: string,
-  propertyName: string,
+  propertyName: string
 ): Promise<{ name: string; color?: string }[]> {
   const schema = await getDatabaseSchema(databaseId);
   if (!schema) return [];

--- a/src/lib/notion-services.ts
+++ b/src/lib/notion-services.ts
@@ -161,22 +161,16 @@ function mapPage(page: any): CloudlessService {
  * Falls back to staticServices when Notion is not configured.
  */
 export async function getServices(): Promise<CloudlessService[]> {
-  const configured = await isConfiguredAsync(
-    "NOTION_API_KEY",
-    "NOTION_SERVICES_DB_ID",
-  );
+  const configured = await isConfiguredAsync("NOTION_API_KEY", "NOTION_SERVICES_DB_ID");
   if (!configured) return staticServices;
 
   return cached("services:all", async () => {
     const { NOTION_SERVICES_DB_ID } = await getIntegrationsAsync();
     try {
-      const pages = await notionFetchAll(
-        `/databases/${NOTION_SERVICES_DB_ID}/query`,
-        {
-          filter: { property: "Published", checkbox: { equals: true } },
-          sorts: [{ property: "Order", direction: "ascending" }],
-        },
-      );
+      const pages = await notionFetchAll(`/databases/${NOTION_SERVICES_DB_ID}/query`, {
+        filter: { property: "Published", checkbox: { equals: true } },
+        sorts: [{ property: "Order", direction: "ascending" }],
+      });
       const results = pages.map(mapPage);
       return results.length > 0 ? results : staticServices;
     } catch (err) {
@@ -189,9 +183,7 @@ export async function getServices(): Promise<CloudlessService[]> {
 /**
  * Fetch a single service by slug.
  */
-export async function getServiceBySlug(
-  slug: string,
-): Promise<CloudlessService | null> {
+export async function getServiceBySlug(slug: string): Promise<CloudlessService | null> {
   const services = await getServices();
   return services.find((s) => s.slug === slug) ?? null;
 }
@@ -200,7 +192,7 @@ export async function getServiceBySlug(
  * Fetch services filtered by category.
  */
 export async function getServicesByCategory(
-  category: ServiceCategory,
+  category: ServiceCategory
 ): Promise<CloudlessService[]> {
   const services = await getServices();
   return services.filter((s) => s.category === category);

--- a/src/lib/notion-testimonials.ts
+++ b/src/lib/notion-testimonials.ts
@@ -19,10 +19,7 @@
  */
 
 import { notionFetchAll, extractText } from "@/lib/notion";
-import {
-  getIntegrationsAsync,
-  requireIntegrationAsync,
-} from "@/lib/integrations";
+import { getIntegrationsAsync, requireIntegrationAsync } from "@/lib/integrations";
 import { cached } from "@/lib/notion-cache";
 
 // ---------------------------------------------------------------------------
@@ -97,8 +94,7 @@ function mapPage(page: any): Testimonial {
     quote: extractText(p.Quote?.rich_text) || "",
     avatar: p.Avatar?.url ?? undefined,
     service: p.Service?.select?.name ?? undefined,
-    rating:
-      typeof rating === "number" ? Math.min(5, Math.max(1, rating)) : undefined,
+    rating: typeof rating === "number" ? Math.min(5, Math.max(1, rating)) : undefined,
     featured: p.Featured?.checkbox ?? false,
   };
 }
@@ -117,13 +113,10 @@ export async function getTestimonials(): Promise<Testimonial[]> {
   return cached("testimonials:all", async () => {
     const { NOTION_TESTIMONIALS_DB_ID } = await getIntegrationsAsync();
     try {
-      const pages = await notionFetchAll(
-        `/databases/${NOTION_TESTIMONIALS_DB_ID}/query`,
-        {
-          filter: { property: "Published", checkbox: { equals: true } },
-          sorts: [{ property: "Order", direction: "ascending" }],
-        },
-      );
+      const pages = await notionFetchAll(`/databases/${NOTION_TESTIMONIALS_DB_ID}/query`, {
+        filter: { property: "Published", checkbox: { equals: true } },
+        sorts: [{ property: "Order", direction: "ascending" }],
+      });
       return pages.map(mapPage);
     } catch (err) {
       console.error("[Notion Testimonials] Failed to fetch:", err);

--- a/src/lib/notion.ts
+++ b/src/lib/notion.ts
@@ -35,10 +35,7 @@ export async function notionHeaders(): Promise<Record<string, string>> {
 // Fetch wrapper
 // ---------------------------------------------------------------------------
 
-export async function notionFetch<T = unknown>(
-  path: string,
-  init?: RequestInit,
-): Promise<T> {
+export async function notionFetch<T = unknown>(path: string, init?: RequestInit): Promise<T> {
   const MAX_RETRIES = 3;
   const headers = await notionHeaders();
   if (path.includes("://") || path.startsWith("//"))
@@ -108,8 +105,7 @@ function richTextToHtml(richText: RichTextItem[]): string {
       if (t.annotations?.code) text = `<code>${text}</code>`;
       if (t.annotations?.strikethrough) text = `<s>${text}</s>`;
       if (t.annotations?.underline) text = `<u>${text}</u>`;
-      if (t.href)
-        text = `<a href="${t.href}" target="_blank" rel="noopener">${text}</a>`;
+      if (t.href) text = `<a href="${t.href}" target="_blank" rel="noopener">${text}</a>`;
 
       return text;
     })
@@ -181,12 +177,14 @@ function appendListItem(
   text: string,
   listBuffer: string[],
   listTypeRef: { current: ListTag },
-  lines: string[],
+  lines: string[]
 ): void {
   const wantedTag = type === "bulleted_list_item" ? "ul" : "ol";
   if (listTypeRef.current !== wantedTag) {
     if (listBuffer.length > 0) {
-      lines.push(`<${listTypeRef.current ?? "ul"}>${listBuffer.splice(0).join("")}</${listTypeRef.current ?? "ul"}>`);
+      lines.push(
+        `<${listTypeRef.current ?? "ul"}>${listBuffer.splice(0).join("")}</${listTypeRef.current ?? "ul"}>`
+      );
     }
     listTypeRef.current = wantedTag;
   }
@@ -196,7 +194,7 @@ function appendListItem(
 function flushListBuffer(
   listBuffer: string[],
   listTypeRef: { current: ListTag },
-  lines: string[],
+  lines: string[]
 ): void {
   if (listBuffer.length === 0) return;
   const tag = listTypeRef.current ?? "ul";
@@ -239,7 +237,7 @@ export function blocksToHtml(blocks: any[]): string {
  */
 export async function notionFetchAll<T = unknown>(
   path: string,
-  body?: Record<string, unknown>,
+  body?: Record<string, unknown>
 ): Promise<T[]> {
   const results: T[] = [];
   let cursor: string | undefined;
@@ -301,18 +299,14 @@ export interface NotionBlock {
  * Fetch all blocks under a parent, recursively expanding any block that
  * has `has_children: true` (e.g. toggle, callout, column_list).
  */
-export async function fetchBlocksDeep(
-  parentId: string,
-): Promise<NotionBlock[]> {
-  const blocks = await notionListAll<NotionBlock>(
-    `/blocks/${parentId}/children`,
-  );
+export async function fetchBlocksDeep(parentId: string): Promise<NotionBlock[]> {
+  const blocks = await notionListAll<NotionBlock>(`/blocks/${parentId}/children`);
   await Promise.all(
     blocks.map(async (block) => {
       if (block.has_children) {
         block.children = await fetchBlocksDeep(block.id);
       }
-    }),
+    })
   );
   return blocks;
 }
@@ -325,10 +319,7 @@ export async function fetchBlocksDeep(
  * Returns the local image-proxy URL for a Notion-hosted file.
  * The proxy route re-fetches the fresh signed URL on each request.
  */
-export function notionImageProxyUrl(
-  id: string,
-  type: "block" | "cover" = "block",
-): string {
+export function notionImageProxyUrl(id: string, type: "block" | "cover" = "block"): string {
   return `/api/notion-image?id=${encodeURIComponent(id)}&type=${type}`;
 }
 
@@ -342,7 +333,7 @@ export function notionImageProxyUrl(
  */
 export async function updatePage(
   pageId: string,
-  properties: Record<string, unknown>,
+  properties: Record<string, unknown>
 ): Promise<boolean> {
   try {
     await notionFetch(`/pages/${pageId}`, {
@@ -353,7 +344,7 @@ export async function updatePage(
   } catch (err) {
     console.error(
       `[Notion] Failed to update page ${pageId}:`,
-      (err as Error)?.message ?? "unknown error",
+      (err as Error)?.message ?? "unknown error"
     );
     return false;
   }
@@ -372,7 +363,7 @@ export async function archivePage(pageId: string): Promise<boolean> {
   } catch (err) {
     console.error(
       `[Notion] Failed to archive page ${pageId}:`,
-      (err as Error)?.message ?? "unknown error",
+      (err as Error)?.message ?? "unknown error"
     );
     return false;
   }
@@ -391,7 +382,7 @@ export async function restorePage(pageId: string): Promise<boolean> {
   } catch (err) {
     console.error(
       `[Notion] Failed to restore page ${pageId}:`,
-      (err as Error)?.message ?? "unknown error",
+      (err as Error)?.message ?? "unknown error"
     );
     return false;
   }
@@ -407,10 +398,7 @@ export async function restorePage(pageId: string): Promise<boolean> {
  * Append child blocks to a page or block.
  * Max 100 blocks per call (Notion API limit).
  */
-export async function appendBlocks(
-  parentId: string,
-  children: any[],
-): Promise<boolean> {
+export async function appendBlocks(parentId: string, children: any[]): Promise<boolean> {
   try {
     await notionFetch(`/blocks/${parentId}/children`, {
       method: "PATCH",
@@ -420,7 +408,7 @@ export async function appendBlocks(
   } catch (err) {
     console.error(
       `[Notion] Failed to append blocks to ${parentId}:`,
-      (err as Error)?.message ?? "unknown error",
+      (err as Error)?.message ?? "unknown error"
     );
     return false;
   }
@@ -436,7 +424,7 @@ export async function deleteBlock(blockId: string): Promise<boolean> {
   } catch (err) {
     console.error(
       `[Notion] Failed to delete block ${blockId}:`,
-      (err as Error)?.message ?? "unknown error",
+      (err as Error)?.message ?? "unknown error"
     );
     return false;
   }

--- a/src/lib/pending-clients.ts
+++ b/src/lib/pending-clients.ts
@@ -7,11 +7,7 @@
  * entry and links the portal token back here.
  */
 
-import {
-  SSMClient,
-  GetParameterCommand,
-  PutParameterCommand,
-} from "@aws-sdk/client-ssm";
+import { SSMClient, GetParameterCommand, PutParameterCommand } from "@aws-sdk/client-ssm";
 
 const SSM_KEY = "/cloudless/PENDING_CLIENTS_JSON";
 const REGION = process.env.AWS_REGION || "eu-central-1";
@@ -49,25 +45,21 @@ export const PLAN_LABELS: Record<string, string> = {
 
 export async function readPendingClients(): Promise<PendingClient[]> {
   try {
-    const res = await ssmClient.send(
-      new GetParameterCommand({ Name: SSM_KEY }),
-    );
+    const res = await ssmClient.send(new GetParameterCommand({ Name: SSM_KEY }));
     return JSON.parse(res.Parameter?.Value ?? "[]");
   } catch {
     return [];
   }
 }
 
-export async function writePendingClients(
-  clients: PendingClient[],
-): Promise<void> {
+export async function writePendingClients(clients: PendingClient[]): Promise<void> {
   await ssmClient.send(
     new PutParameterCommand({
       Name: SSM_KEY,
       Value: JSON.stringify(clients),
       Type: "String",
       Overwrite: true,
-    }),
+    })
   );
 }
 
@@ -76,12 +68,10 @@ export async function writePendingClients(
  * plan and resets to "waiting" status (only if they aren't already approved).
  */
 export async function upsertPendingClient(
-  input: Pick<PendingClient, "email" | "plan"> & Partial<PendingClient>,
+  input: Pick<PendingClient, "email" | "plan"> & Partial<PendingClient>
 ): Promise<PendingClient> {
   const clients = await readPendingClients();
-  const idx = clients.findIndex(
-    (c) => c.email.toLowerCase() === input.email.toLowerCase(),
-  );
+  const idx = clients.findIndex((c) => c.email.toLowerCase() === input.email.toLowerCase());
 
   if (idx === -1) {
     const created: PendingClient = {
@@ -117,23 +107,17 @@ export async function upsertPendingClient(
   return updated;
 }
 
-export async function findPendingByEmail(
-  email: string,
-): Promise<PendingClient | null> {
+export async function findPendingByEmail(email: string): Promise<PendingClient | null> {
   const clients = await readPendingClients();
-  return (
-    clients.find((c) => c.email.toLowerCase() === email.toLowerCase()) ?? null
-  );
+  return clients.find((c) => c.email.toLowerCase() === email.toLowerCase()) ?? null;
 }
 
 export async function approvePendingClient(
   email: string,
-  portalToken: string,
+  portalToken: string
 ): Promise<PendingClient | null> {
   const clients = await readPendingClients();
-  const idx = clients.findIndex(
-    (c) => c.email.toLowerCase() === email.toLowerCase(),
-  );
+  const idx = clients.findIndex((c) => c.email.toLowerCase() === email.toLowerCase());
   if (idx === -1) return null;
   clients[idx] = {
     ...clients[idx],

--- a/src/lib/rate-limit.ts
+++ b/src/lib/rate-limit.ts
@@ -53,7 +53,7 @@ export interface RateLimitExceeded {
 export function rateLimit(
   key: string,
   limit: number,
-  windowMs = 60_000,
+  windowMs = 60_000
 ): RateLimitResult | RateLimitExceeded {
   maybePrune(windowMs);
   const now = Date.now();
@@ -73,7 +73,7 @@ export function rateLimit(
             "X-RateLimit-Limit": String(limit),
             "X-RateLimit-Remaining": "0",
           },
-        },
+        }
       ),
     };
   }

--- a/src/lib/reports.ts
+++ b/src/lib/reports.ts
@@ -42,9 +42,7 @@ export async function listReports(): Promise<Report[]> {
   if (await notionEnabled()) {
     return (await notionListReports()) ?? [];
   }
-  return store.sort(
-    (a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime(),
-  );
+  return store.sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime());
 }
 
 export async function getReport(id: string): Promise<Report | null> {
@@ -54,9 +52,7 @@ export async function getReport(id: string): Promise<Report | null> {
   return store.find((r) => r.id === id) ?? null;
 }
 
-export async function createReport(
-  input: GenerateReportInput,
-): Promise<Report> {
+export async function createReport(input: GenerateReportInput): Promise<Report> {
   const report: Report = {
     id: `report_${Date.now()}_${Math.random().toString(36).substring(2, 7)}`,
     clientName: input.clientName,
@@ -73,10 +69,7 @@ export async function createReport(
   return report;
 }
 
-export async function updateReport(
-  id: string,
-  updates: Partial<Report>,
-): Promise<Report | null> {
+export async function updateReport(id: string, updates: Partial<Report>): Promise<Report | null> {
   if (await notionEnabled()) {
     const ok = await notionUpdateReport(id, updates);
     if (!ok) return null;

--- a/src/lib/sentry-scrub.ts
+++ b/src/lib/sentry-scrub.ts
@@ -38,8 +38,7 @@ function looksLikeToken(value: string): boolean {
   // AWS secret access key (40 chars, base64-ish)
   if (/^[A-Za-z0-9/+]{40}$/.test(value)) return true;
   // JWT (three base64url segments separated by dots)
-  if (/^[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+$/.test(value))
-    return true;
+  if (/^[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+$/.test(value)) return true;
   // GitHub PAT / OAuth token shapes
   if (/^gh[pousr]_[A-Za-z0-9]{30,}$/.test(value)) return true;
   // Stripe live keys
@@ -50,7 +49,7 @@ function looksLikeToken(value: string): boolean {
 }
 
 function redactHeaders(
-  headers: Record<string, string> | undefined,
+  headers: Record<string, string> | undefined
 ): Record<string, string> | undefined {
   if (!headers) return headers;
   const out: Record<string, string> = {};
@@ -104,9 +103,7 @@ function redactUrl(url: string): string {
   return `${url.slice(0, qIdx)}?${redactQueryString(url.slice(qIdx + 1))}`;
 }
 
-function redactCookies(
-  cookies: Record<string, string>,
-): Record<string, string> {
+function redactCookies(cookies: Record<string, string>): Record<string, string> {
   const out: Record<string, string> = {};
   for (const k of Object.keys(cookies)) out[k] = REDACT;
   return out;
@@ -122,15 +119,10 @@ function scrubRequest(req: NonNullable<ErrorEvent["request"]>): void {
   if (req.cookies !== undefined) req.cookies = redactCookies(req.cookies);
 }
 
-export function scrubEvent(
-  event: ErrorEvent,
-  _hint: EventHint,
-): ErrorEvent | null {
+export function scrubEvent(event: ErrorEvent, _hint: EventHint): ErrorEvent | null {
   if (event.request) scrubRequest(event.request);
-  if (event.extra)
-    event.extra = redactObject(event.extra) as typeof event.extra;
-  if (event.contexts)
-    event.contexts = redactObject(event.contexts) as typeof event.contexts;
+  if (event.extra) event.extra = redactObject(event.extra) as typeof event.extra;
+  if (event.contexts) event.contexts = redactObject(event.contexts) as typeof event.contexts;
   return event;
 }
 

--- a/src/lib/sentry.ts
+++ b/src/lib/sentry.ts
@@ -57,11 +57,7 @@ export type IssueStatus = "resolved" | "ignored" | "unresolved"; // NOSONAR — 
 const STATUS_RESOLVED: IssueStatus = "resolved"; // NOSONAR — constant extracted from type annotation
 const STATUS_IGNORED: IssueStatus = "ignored"; // NOSONAR — constant extracted from type annotation
 
-export type SentryTokenStatus =
-  | "valid"
-  | "rejected"
-  | "not_configured"
-  | "error";
+export type SentryTokenStatus = "valid" | "rejected" | "not_configured" | "error";
 
 // ---------------------------------------------------------------------------
 // Internal helpers
@@ -86,7 +82,7 @@ function recordRejection(status: number) {
   // Throttle the auth-error log to once per TTL window.
   if (Date.now() - lastAuthLogAt > REJECTION_CACHE_TTL_MS) {
     console.error(
-      `[Sentry] Auth error ${status} — check SENTRY_AUTH_TOKEN scopes (project:read required). Suppressing further logs for ${Math.round(REJECTION_CACHE_TTL_MS / 1000)}s.`,
+      `[Sentry] Auth error ${status} — check SENTRY_AUTH_TOKEN scopes (project:read required). Suppressing further logs for ${Math.round(REJECTION_CACHE_TTL_MS / 1000)}s.`
     );
     lastAuthLogAt = Date.now();
   }
@@ -116,10 +112,7 @@ async function getSentryConfig(): Promise<{
   };
 }
 
-async function sentryFetch<T>(
-  path: string,
-  options?: RequestInit,
-): Promise<T | null> {
+async function sentryFetch<T>(path: string, options?: RequestInit): Promise<T | null> {
   const cfg = await getSentryConfig();
   if (!cfg) return null;
 
@@ -184,13 +177,10 @@ export async function verifySentryToken(): Promise<{
   }
 
   try {
-    const res = await fetch(
-      `${SENTRY_API}/projects/${cfg.org}/${cfg.project}/`,
-      {
-        headers: { Authorization: `Bearer ${cfg.token}` },
-        signal: AbortSignal.timeout(VERIFY_TIMEOUT_MS),
-      },
-    );
+    const res = await fetch(`${SENTRY_API}/projects/${cfg.org}/${cfg.project}/`, {
+      headers: { Authorization: `Bearer ${cfg.token}` },
+      signal: AbortSignal.timeout(VERIFY_TIMEOUT_MS),
+    });
     if (res.status === 401 || res.status === 403) {
       recordRejection(res.status);
       return {
@@ -198,8 +188,7 @@ export async function verifySentryToken(): Promise<{
         message: `Token rejected (${res.status}) — check SENTRY_AUTH_TOKEN scopes (project:read required).`,
       };
     }
-    if (!res.ok)
-      return { status: "error", message: `API returned ${res.status}` };
+    if (!res.ok) return { status: "error", message: `API returned ${res.status}` };
     return { status: "valid" };
   } catch {
     return { status: "error", message: "Connection failed." };
@@ -224,7 +213,7 @@ export async function getUnresolvedIssues(
     sort?: SortField;
     query?: string;
     level?: IssueLevel;
-  } = {},
+  } = {}
 ): Promise<SentryIssueList | null> {
   const cfg = await getSentryConfig();
   if (!cfg) return null;
@@ -236,7 +225,7 @@ export async function getUnresolvedIssues(
 
   const params = new URLSearchParams({ query, sort, limit: String(limit) });
   const issues = await sentryFetch<SentryIssue[]>(
-    `/projects/${cfg.org}/${cfg.project}/issues/?${params}`,
+    `/projects/${cfg.org}/${cfg.project}/issues/?${params}`
   );
 
   if (!issues) return null;
@@ -303,10 +292,7 @@ export async function getErrorCounts(): Promise<{
  * Update issue status (resolve, ignore, or reopen).
  * Returns true on success, false on failure.
  */
-export async function updateIssueStatus(
-  issueId: string,
-  status: IssueStatus,
-): Promise<boolean> {
+export async function updateIssueStatus(issueId: string, status: IssueStatus): Promise<boolean> {
   const result = await sentryFetch<{ status: string }>(`/issues/${issueId}/`, {
     method: "PUT",
     body: JSON.stringify({ status }),
@@ -332,10 +318,7 @@ export async function ignoreIssue(issueId: string): Promise<boolean> {
  * Resolve an issue and mark it as fixed in a specific release.
  * Useful when deploying a fix — links the resolution to the release version.
  */
-export async function resolveInRelease(
-  issueId: string,
-  version: string,
-): Promise<boolean> {
+export async function resolveInRelease(issueId: string, version: string): Promise<boolean> {
   const result = await sentryFetch<{ status: string }>(`/issues/${issueId}/`, {
     method: "PUT",
     body: JSON.stringify({

--- a/src/lib/ses-suppression.ts
+++ b/src/lib/ses-suppression.ts
@@ -26,10 +26,7 @@ async function getSESv2(): Promise<SESv2Client> {
 
 /** Domain portion of an email, newline-stripped, for safe logging. */
 function logSafeDomain(email: string): string {
-  return (email.includes("@") ? email.split("@")[1] : "(no-domain)").replace(
-    /[\r\n]/g,
-    "_",
-  );
+  return (email.includes("@") ? email.split("@")[1] : "(no-domain)").replace(/[\r\n]/g, "_");
 }
 
 /**
@@ -45,16 +42,13 @@ export async function addToSuppressionList(email: string): Promise<boolean> {
       new PutSuppressedDestinationCommand({
         EmailAddress: email,
         Reason: "COMPLAINT",
-      }),
+      })
     );
     // codeql[js/log-injection] -- domain sanitized (newlines stripped) in logSafeDomain
     console.warn(`[SES] Added to suppression list: *@${logSafeDomain(email)}`);
     return true;
   } catch (err) {
-    const msg = ((err as Error)?.message ?? "unknown error").replace(
-      /[\r\n]/g,
-      " ",
-    );
+    const msg = ((err as Error)?.message ?? "unknown error").replace(/[\r\n]/g, " ");
     // codeql[js/log-injection] codeql[js/tainted-format-string] -- domain and msg sanitized (newlines stripped) above
     console.error(`[SES] Failed to suppress *@${logSafeDomain(email)}:`, msg);
     return false;
@@ -67,32 +61,20 @@ export async function addToSuppressionList(email: string): Promise<boolean> {
  * counts as success. Returns true on success, false on failure (logged,
  * not thrown).
  */
-export async function removeFromSuppressionList(
-  email: string,
-): Promise<boolean> {
+export async function removeFromSuppressionList(email: string): Promise<boolean> {
   try {
     const client = await getSESv2();
-    await client.send(
-      new DeleteSuppressedDestinationCommand({ EmailAddress: email }),
-    );
+    await client.send(new DeleteSuppressedDestinationCommand({ EmailAddress: email }));
     // codeql[js/log-injection] -- domain sanitized (newlines stripped) in logSafeDomain
-    console.warn(
-      `[SES] Removed from suppression list: *@${logSafeDomain(email)}`,
-    );
+    console.warn(`[SES] Removed from suppression list: *@${logSafeDomain(email)}`);
     return true;
   } catch (err) {
     // SES throws NotFoundException when the address was never suppressed;
     // for a brand-new subscriber that is the normal case, treat as success.
     if ((err as { name?: string })?.name === "NotFoundException") return true;
-    const msg = ((err as Error)?.message ?? "unknown error").replace(
-      /[\r\n]/g,
-      " ",
-    );
+    const msg = ((err as Error)?.message ?? "unknown error").replace(/[\r\n]/g, " ");
     // codeql[js/log-injection] codeql[js/tainted-format-string] -- domain and msg sanitized (newlines stripped) above
-    console.error(
-      `[SES] Failed to remove *@${logSafeDomain(email)} from suppression:`,
-      msg,
-    );
+    console.error(`[SES] Failed to remove *@${logSafeDomain(email)} from suppression:`, msg);
     return false;
   }
 }

--- a/src/lib/sha-drift.ts
+++ b/src/lib/sha-drift.ts
@@ -50,17 +50,12 @@ export function shaEquivalent(a: string | null, b: string | null): boolean {
   return lo.startsWith(hi) || hi.startsWith(lo);
 }
 
-function classifySurface(
-  name: "cloud",
-  expected: string,
-  actual: string | null,
-): SurfaceStatus {
+function classifySurface(name: "cloud", expected: string, actual: string | null): SurfaceStatus {
   const matches = shaEquivalent(expected, actual);
   let reason = "matches expected";
   if (actual === null) reason = "endpoint unreachable or no version field";
   else if (actual === "0.1.0" || actual === "dev") {
-    reason =
-      "APP_VERSION not wired to deploy SHA — surface still serves the static fallback";
+    reason = "APP_VERSION not wired to deploy SHA — surface still serves the static fallback";
   } else if (!matches) reason = "SHA differs from SSM source of truth";
   return { name, actual, matches, reason };
 }
@@ -69,18 +64,11 @@ function classifySurface(
  * Build a DriftReport from a snapshot. Pure; takes `now` so tests can pin
  * the clock and exercise the grace-window edges deterministically.
  */
-export function evaluateDrift(
-  snapshot: DriftSnapshot,
-  now: number = Date.now(),
-): DriftReport {
-  const ageMs = snapshot.ssmModifiedAt
-    ? now - snapshot.ssmModifiedAt.getTime()
-    : null;
+export function evaluateDrift(snapshot: DriftSnapshot, now: number = Date.now()): DriftReport {
+  const ageMs = snapshot.ssmModifiedAt ? now - snapshot.ssmModifiedAt.getTime() : null;
   const withinGrace = ageMs !== null && ageMs < GRACE_WINDOW_MS;
 
-  const surfaces: SurfaceStatus[] = [
-    classifySurface("cloud", snapshot.expected, snapshot.cloud),
-  ];
+  const surfaces: SurfaceStatus[] = [classifySurface("cloud", snapshot.expected, snapshot.cloud)];
 
   const anyMismatch = surfaces.some((s) => !s.matches);
   // During grace window we count mismatches as expected and don't fail.

--- a/src/lib/slack-admin.ts
+++ b/src/lib/slack-admin.ts
@@ -83,7 +83,7 @@ const BASE = "https://slack.com/api";
 async function slackPost(
   method: string,
   body: Record<string, unknown>,
-  token: string,
+  token: string
 ): Promise<SlackApiResponse> {
   const res = await fetch(`${BASE}/${method}`, {
     method: "POST",
@@ -100,7 +100,7 @@ async function slackPost(
 async function slackGet(
   method: string,
   params: Record<string, string>,
-  token: string,
+  token: string
 ): Promise<SlackApiResponse> {
   const qs = new URLSearchParams(params).toString();
   const res = await fetch(`${BASE}/${method}?${qs}`, {
@@ -131,10 +131,9 @@ export async function listChannels(token: string): Promise<SlackChannel[]> {
         exclude_archived: "true",
         ...(cursor ? { cursor } : {}),
       },
-      token,
+      token
     );
-    if (!res.ok)
-      throw new Error(`[SlackAdmin] conversations.list: ${res.error}`);
+    if (!res.ok) throw new Error(`[SlackAdmin] conversations.list: ${res.error}`);
     all.push(...(res.channels ?? []));
     cursor = res.response_metadata?.next_cursor ?? "";
   } while (cursor);
@@ -147,15 +146,9 @@ export async function listChannels(token: string): Promise<SlackChannel[]> {
  * member when it creates the channel.
  * Docs: https://docs.slack.dev/reference/methods/conversations.create
  */
-export async function createChannel(
-  name: string,
-  token: string,
-): Promise<SlackChannel> {
+export async function createChannel(name: string, token: string): Promise<SlackChannel> {
   const res = await slackPost("conversations.create", { name }, token);
-  if (!res.ok)
-    throw new Error(
-      `[SlackAdmin] conversations.create "${name}": ${res.error}`,
-    );
+  if (!res.ok) throw new Error(`[SlackAdmin] conversations.create "${name}": ${res.error}`);
   return res.channel!;
 }
 
@@ -166,15 +159,10 @@ export async function createChannel(
 export async function setChannelTopic(
   channelId: string,
   topic: string,
-  token: string,
+  token: string
 ): Promise<void> {
-  const res = await slackPost(
-    "conversations.setTopic",
-    { channel: channelId, topic },
-    token,
-  );
-  if (!res.ok)
-    throw new Error(`[SlackAdmin] conversations.setTopic: ${res.error}`);
+  const res = await slackPost("conversations.setTopic", { channel: channelId, topic }, token);
+  if (!res.ok) throw new Error(`[SlackAdmin] conversations.setTopic: ${res.error}`);
 }
 
 /**
@@ -182,15 +170,8 @@ export async function setChannelTopic(
  * isn't a member yet).
  * Docs: https://docs.slack.dev/reference/methods/conversations.join
  */
-export async function joinChannel(
-  channelId: string,
-  token: string,
-): Promise<void> {
-  const res = await slackPost(
-    "conversations.join",
-    { channel: channelId },
-    token,
-  );
+export async function joinChannel(channelId: string, token: string): Promise<void> {
+  const res = await slackPost("conversations.join", { channel: channelId }, token);
   if (!res.ok && res.error !== "already_in_channel") {
     throw new Error(`[SlackAdmin] conversations.join: ${res.error}`);
   }
@@ -200,17 +181,9 @@ export async function joinChannel(
  * Fetch metadata for a single channel by ID.
  * Docs: https://api.slack.com/methods/conversations.info
  */
-export async function getChannelInfo(
-  channelId: string,
-  token: string,
-): Promise<SlackChannel> {
-  const res = await slackGet(
-    "conversations.info",
-    { channel: channelId },
-    token,
-  );
-  if (!res.ok || !res.channel)
-    throw new Error(`[SlackAdmin] conversations.info: ${res.error}`);
+export async function getChannelInfo(channelId: string, token: string): Promise<SlackChannel> {
+  const res = await slackGet("conversations.info", { channel: channelId }, token);
+  if (!res.ok || !res.channel) throw new Error(`[SlackAdmin] conversations.info: ${res.error}`);
   return res.channel;
 }
 
@@ -221,15 +194,10 @@ export async function getChannelInfo(
 export async function setChannelPurpose(
   channelId: string,
   purpose: string,
-  token: string,
+  token: string
 ): Promise<void> {
-  const res = await slackPost(
-    "conversations.setPurpose",
-    { channel: channelId, purpose },
-    token,
-  );
-  if (!res.ok)
-    throw new Error(`[SlackAdmin] conversations.setPurpose: ${res.error}`);
+  const res = await slackPost("conversations.setPurpose", { channel: channelId, purpose }, token);
+  if (!res.ok) throw new Error(`[SlackAdmin] conversations.setPurpose: ${res.error}`);
 }
 
 /**
@@ -239,15 +207,10 @@ export async function setChannelPurpose(
 export async function renameChannel(
   channelId: string,
   name: string,
-  token: string,
+  token: string
 ): Promise<SlackChannel> {
-  const res = await slackPost(
-    "conversations.rename",
-    { channel: channelId, name },
-    token,
-  );
-  if (!res.ok || !res.channel)
-    throw new Error(`[SlackAdmin] conversations.rename: ${res.error}`);
+  const res = await slackPost("conversations.rename", { channel: channelId, name }, token);
+  if (!res.ok || !res.channel) throw new Error(`[SlackAdmin] conversations.rename: ${res.error}`);
   return res.channel;
 }
 
@@ -255,15 +218,8 @@ export async function renameChannel(
  * Archive a channel (bot must be a member or have channels:manage scope).
  * Docs: https://api.slack.com/methods/conversations.archive
  */
-export async function archiveChannel(
-  channelId: string,
-  token: string,
-): Promise<void> {
-  const res = await slackPost(
-    "conversations.archive",
-    { channel: channelId },
-    token,
-  );
+export async function archiveChannel(channelId: string, token: string): Promise<void> {
+  const res = await slackPost("conversations.archive", { channel: channelId }, token);
   if (!res.ok && res.error !== "already_archived")
     throw new Error(`[SlackAdmin] conversations.archive: ${res.error}`);
 }
@@ -275,7 +231,7 @@ export async function archiveChannel(
 export async function inviteToChannel(
   channelId: string,
   userIds: string[],
-  token: string,
+  token: string
 ): Promise<void> {
   const res = await slackPost(
     "conversations.invite",
@@ -283,10 +239,9 @@ export async function inviteToChannel(
       channel: channelId,
       users: userIds.join(","),
     },
-    token,
+    token
   );
-  if (!res.ok)
-    throw new Error(`[SlackAdmin] conversations.invite: ${res.error}`);
+  if (!res.ok) throw new Error(`[SlackAdmin] conversations.invite: ${res.error}`);
 }
 
 /**
@@ -297,7 +252,7 @@ export async function ensureChannel(
   name: string,
   topic: string,
   token: string,
-  existing: SlackChannel[],
+  existing: SlackChannel[]
 ): Promise<ChannelResult> {
   const found = existing.find((c) => c.name === name);
 
@@ -319,9 +274,7 @@ export async function ensureChannel(
  * Ensure all channels in SLACK_CHANNELS exist and the bot is a member.
  * Safe to call repeatedly — idempotent.
  */
-export async function ensureAllChannels(): Promise<
-  Record<SlackChannelKey, ChannelResult>
-> {
+export async function ensureAllChannels(): Promise<Record<SlackChannelKey, ChannelResult>> {
   const cfg = await getSlackConfigAsync();
   const token = cfg.SLACK_BOT_TOKEN;
   if (!token) throw new Error("[SlackAdmin] SLACK_BOT_TOKEN is not configured");

--- a/src/lib/slack-manifest.ts
+++ b/src/lib/slack-manifest.ts
@@ -53,7 +53,7 @@ function loadManifest(): Record<string, unknown> {
 async function slackPost(
   method: string,
   body: Record<string, unknown>,
-  token: string,
+  token: string
 ): Promise<ManifestApiResponse> {
   const res = await fetch(`${BASE}/${method}`, {
     method: "POST",
@@ -63,8 +63,7 @@ async function slackPost(
     },
     body: JSON.stringify(body), // codeql[js/file-data-network-request] -- manifest JSON is sent intentionally to Slack API; loaded from a versioned local config file, not user input
   });
-  if (!res.ok)
-    throw new Error(`[SlackManifest] HTTP ${res.status} on ${method}`);
+  if (!res.ok) throw new Error(`[SlackManifest] HTTP ${res.status} on ${method}`);
   return res.json() as Promise<ManifestApiResponse>;
 }
 
@@ -80,13 +79,13 @@ async function slackPost(
  * Docs: https://api.slack.com/methods/apps.manifest.validate
  */
 export async function validateManifest(
-  token: string,
+  token: string
 ): Promise<{ valid: boolean; errors: string[] }> {
   const manifest = loadManifest();
   const res = await slackPost(
     "apps.manifest.validate",
     { manifest: JSON.stringify(manifest) },
-    token,
+    token
   );
 
   if (res.ok) return { valid: true, errors: [] };
@@ -110,17 +109,16 @@ export async function validateManifest(
  */
 export async function applyManifest(
   appId: string,
-  token: string,
+  token: string
 ): Promise<{ ok: boolean; appId: string }> {
   const manifest = loadManifest();
   const res = await slackPost(
     "apps.manifest.update",
     { app_id: appId, manifest: JSON.stringify(manifest) },
-    token,
+    token
   );
 
-  if (!res.ok)
-    throw new Error(`[SlackManifest] apps.manifest.update: ${res.error}`);
+  if (!res.ok) throw new Error(`[SlackManifest] apps.manifest.update: ${res.error}`);
 
   return { ok: true, appId: res.app_id ?? appId };
 }

--- a/src/lib/slack-notify.ts
+++ b/src/lib/slack-notify.ts
@@ -71,8 +71,7 @@ export class SlackClient {
   private defaultChannel: string;
 
   constructor(opts?: { channel?: string }) {
-    this.defaultChannel =
-      opts?.channel ?? process.env.SLACK_DEFAULT_CHANNEL ?? "#general";
+    this.defaultChannel = opts?.channel ?? process.env.SLACK_DEFAULT_CHANNEL ?? "#general";
   }
 
   /** Send a Block Kit message with retry/backoff. Returns true on success. */
@@ -128,7 +127,7 @@ export class SlackClient {
   private async postOnce(
     payload: PostMessagePayload,
     token: string | undefined,
-    webhookUrl: string | undefined,
+    webhookUrl: string | undefined
   ): Promise<true | number | null> {
     if (token) {
       const apiResult = await this.postViaApi(token, {
@@ -142,7 +141,11 @@ export class SlackClient {
       if (webhookUrl) return (await this.postViaWebhook(webhookUrl, payload)) ? true : null;
       return null;
     }
-    if (webhookUrl) return (await this.postViaWebhook(webhookUrl, payload)) ? true : null;
+    if (webhookUrl) {
+      const ok = await this.postViaWebhook(webhookUrl, payload);
+      if (ok) return true;
+      throw new Error("Slack webhook request failed");
+    }
     return null;
   }
 
@@ -154,7 +157,7 @@ export class SlackClient {
    */
   private async postViaApi(
     token: string,
-    payload: PostMessagePayload,
+    payload: PostMessagePayload
   ): Promise<true | number | null> {
     const body = {
       ...payload,
@@ -187,10 +190,7 @@ export class SlackClient {
     return true;
   }
 
-  private async postViaWebhook(
-    webhookUrl: string,
-    payload: PostMessagePayload,
-  ): Promise<boolean> {
+  private async postViaWebhook(webhookUrl: string, payload: PostMessagePayload): Promise<boolean> {
     const res = await fetch(webhookUrl, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
@@ -319,11 +319,7 @@ export async function slackErrorNotify(opts: {
       sectionBlock(`*${opts.title}*\n${opts.message}`),
       ...(opts.route ? [sectionBlock(`*Route:* \`${opts.route}\``)] : []),
       ...(errText
-        ? [
-            sectionBlock(
-              `*Details:*\n\`\`\`${errText.slice(0, MAX_ERROR_TEXT_LENGTH)}\`\`\``,
-            ),
-          ]
+        ? [sectionBlock(`*Details:*\n\`\`\`${errText.slice(0, MAX_ERROR_TEXT_LENGTH)}\`\`\``)]
         : []),
       contextBlock(slackTimestamp(), "cloudless.gr"),
       divider,
@@ -371,7 +367,7 @@ export async function slackDeployNotify(opts: {
             : null,
         ]
           .filter((s): s is string => Boolean(s))
-          .join("\n"),
+          .join("\n")
       ),
       contextBlock(slackTimestamp(), "cloudless.gr deploy pipeline"),
       divider,
@@ -424,7 +420,7 @@ export async function slackContactNotify(data: {
           `*Email:* ${safeEmail}`,
           `*Company:* ${safeCompany}`,
           `*Service:* ${safeService}`,
-        ].join("\n"),
+        ].join("\n")
       ),
       divider,
       sectionBlock(`*Message:*\n${safeMessage}`),
@@ -450,7 +446,7 @@ export async function slackBookingNotify(data: {
       timeZone: "Europe/Athens",
       dateStyle: "full",
       timeStyle: "short",
-    }),
+    })
   );
   await bookingsClient.post({
     text: `📅 New consultation booked: ${safeName} (${safeEmail})`,
@@ -461,17 +457,11 @@ export async function slackBookingNotify(data: {
           `*Name:* ${safeName}`,
           `*Email:* ${safeEmail}`,
           `*Time:* ${dateStr} (Athens)`,
-          ...(data.meetLink
-            ? [`*Meet:* <${data.meetLink}|Join Google Meet>`]
-            : []),
-        ].join("\n"),
+          ...(data.meetLink ? [`*Meet:* <${data.meetLink}|Join Google Meet>`] : []),
+        ].join("\n")
       ),
       ...(data.notes
-        ? [
-            sectionBlock(
-              `*Notes:*\n${slackEscape(data.notes).slice(0, MAX_NOTES_TEXT_LENGTH)}`,
-            ),
-          ]
+        ? [sectionBlock(`*Notes:*\n${slackEscape(data.notes).slice(0, MAX_NOTES_TEXT_LENGTH)}`)]
         : []),
       contextBlock(slackTimestamp(), "cloudless.gr calendar booking"),
     ],
@@ -496,7 +486,7 @@ export async function slackOrderNotify(data: {
           `*Customer:* ${safeEmail}`,
           `*Amount:* ${data.amount}`,
           `*Session:* \`${data.sessionId.slice(0, ORDER_SESSION_DISPLAY_LENGTH)}...\``,
-        ].join("\n"),
+        ].join("\n")
       ),
       contextBlock(slackTimestamp(), "cloudless.gr stripe checkout"),
     ],
@@ -518,8 +508,5 @@ function sleep(ms: number): Promise<void> {
  * Prevents link injection (<url|text>) and @mention injection (<@here>).
  */
 function slackEscape(text: string): string {
-  return text
-    .replaceAll("&", "&amp;")
-    .replaceAll("<", "&lt;")
-    .replaceAll(">", "&gt;");
+  return text.replaceAll("&", "&amp;").replaceAll("<", "&lt;").replaceAll(">", "&gt;");
 }

--- a/src/lib/slack-users.ts
+++ b/src/lib/slack-users.ts
@@ -48,7 +48,7 @@ const BASE = "https://slack.com/api";
 async function slackGet(
   method: string,
   params: Record<string, string>,
-  token: string,
+  token: string
 ): Promise<UserApiResponse> {
   const qs = new URLSearchParams(params).toString();
   const res = await fetch(`${BASE}/${method}?${qs}`, {
@@ -62,7 +62,7 @@ async function slackGet(
 async function slackFormPost(
   method: string,
   body: Record<string, string>,
-  token: string,
+  token: string
 ): Promise<UserApiResponse> {
   const res = await fetch(`${BASE}/${method}`, {
     method: "POST",
@@ -87,10 +87,7 @@ async function slackFormPost(
  *
  * Docs: https://api.slack.com/methods/users.lookupByEmail
  */
-export async function lookupUserByEmail(
-  email: string,
-  token: string,
-): Promise<SlackUser | null> {
+export async function lookupUserByEmail(email: string, token: string): Promise<SlackUser | null> {
   const res = await slackFormPost("users.lookupByEmail", { email }, token);
   if (!res.ok) {
     if (res.error === "users_not_found") return null;
@@ -105,13 +102,9 @@ export async function lookupUserByEmail(
  *
  * Docs: https://api.slack.com/methods/users.info
  */
-export async function getUserInfo(
-  userId: string,
-  token: string,
-): Promise<SlackUser> {
+export async function getUserInfo(userId: string, token: string): Promise<SlackUser> {
   const res = await slackGet("users.info", { user: userId }, token);
-  if (!res.ok || !res.user)
-    throw new Error(`[SlackUsers] users.info: ${res.error}`);
+  if (!res.ok || !res.user) throw new Error(`[SlackUsers] users.info: ${res.error}`);
   return res.user;
 }
 
@@ -129,7 +122,7 @@ export async function listUsers(token: string): Promise<SlackUser[]> {
     const res = await slackGet(
       "users.list",
       { limit: "200", ...(cursor ? { cursor } : {}) },
-      token,
+      token
     );
     if (!res.ok) throw new Error(`[SlackUsers] users.list: ${res.error}`);
     all.push(...(res.members ?? []).filter((u) => !u.deleted));
@@ -143,10 +136,7 @@ export async function listUsers(token: string): Promise<SlackUser[]> {
  * Convenience: resolve an email to a Slack user ID.
  * Returns null if the user is not found or the email scope is missing.
  */
-export async function resolveEmailToUserId(
-  email: string,
-  token: string,
-): Promise<string | null> {
+export async function resolveEmailToUserId(email: string, token: string): Promise<string | null> {
   const user = await lookupUserByEmail(email, token);
   return user?.id ?? null;
 }

--- a/src/lib/slack-verify.ts
+++ b/src/lib/slack-verify.ts
@@ -54,7 +54,7 @@ export interface VerifyResult {
  * does not need to read it again.
  */
 export async function verifySlackRequest(
-  request: Request,
+  request: Request
 ): Promise<{ ok: true; body: string } | { ok: false; reason: string }> {
   // Fast-path: detect explicitly-cleared env var before touching the async cache.
   const envSecret = process.env.SLACK_SIGNING_SECRET;

--- a/src/lib/slack-workspace.ts
+++ b/src/lib/slack-workspace.ts
@@ -91,7 +91,7 @@ const BASE = "https://slack.com/api";
 async function slackGet(
   method: string,
   params: Record<string, string>,
-  token: string,
+  token: string
 ): Promise<Response> {
   const qs = new URLSearchParams(params).toString();
   return fetch(`${BASE}/${method}${qs ? `?${qs}` : ""}`, {
@@ -111,8 +111,7 @@ async function slackGet(
  */
 export async function getBotInfo(token?: string): Promise<BotInfo> {
   const resolvedToken = token ?? (await getSlackConfigAsync()).SLACK_BOT_TOKEN;
-  if (!resolvedToken)
-    throw new Error("[SlackWorkspace] SLACK_BOT_TOKEN is not configured");
+  if (!resolvedToken) throw new Error("[SlackWorkspace] SLACK_BOT_TOKEN is not configured");
 
   const res = await fetch(`${BASE}/auth.test`, {
     method: "POST",
@@ -141,17 +140,14 @@ export async function getBotInfo(token?: string): Promise<BotInfo> {
  */
 export async function getWorkspaceInfo(token?: string): Promise<WorkspaceInfo> {
   const resolvedToken = token ?? (await getSlackConfigAsync()).SLACK_BOT_TOKEN;
-  if (!resolvedToken)
-    throw new Error("[SlackWorkspace] SLACK_BOT_TOKEN is not configured");
+  if (!resolvedToken) throw new Error("[SlackWorkspace] SLACK_BOT_TOKEN is not configured");
 
   const res = await slackGet("team.info", {}, resolvedToken);
   const data = (await res.json()) as TeamInfoResponse;
-  if (!data.ok || !data.team)
-    throw new Error(`[SlackWorkspace] team.info: ${data.error}`);
+  if (!data.ok || !data.team) throw new Error(`[SlackWorkspace] team.info: ${data.error}`);
 
   const icon = data.team.icon;
-  const iconUrl =
-    icon.image_230 ?? icon.image_132 ?? icon.image_102 ?? icon.image_88 ?? null;
+  const iconUrl = icon.image_230 ?? icon.image_132 ?? icon.image_102 ?? icon.image_88 ?? null;
 
   return {
     id: data.team.id,

--- a/src/lib/sound-effects.ts
+++ b/src/lib/sound-effects.ts
@@ -14,8 +14,7 @@ function getAudioContext(): AudioContext | null {
 
   const AudioCtx =
     window.AudioContext ||
-    (window as typeof window & { webkitAudioContext?: typeof AudioContext })
-      .webkitAudioContext;
+    (window as typeof window & { webkitAudioContext?: typeof AudioContext }).webkitAudioContext;
 
   if (!AudioCtx) return null;
 
@@ -26,12 +25,7 @@ function getAudioContext(): AudioContext | null {
   return audioContext;
 }
 
-function playTone({
-  frequency,
-  durationMs,
-  volume = 0.04,
-  type = "sine",
-}: ToneOptions) {
+function playTone({ frequency, durationMs, volume = 0.04, type = "sine" }: ToneOptions) {
   try {
     const ctx = getAudioContext();
     if (!ctx) return;
@@ -50,10 +44,7 @@ function playTone({
     const duration = durationMs / 1000;
 
     gainNode.gain.setValueAtTime(0.0001, now);
-    gainNode.gain.exponentialRampToValueAtTime(
-      Math.max(volume, 0.0001),
-      now + 0.01,
-    );
+    gainNode.gain.exponentialRampToValueAtTime(Math.max(volume, 0.0001), now + 0.01);
     gainNode.gain.exponentialRampToValueAtTime(0.0001, now + duration);
 
     oscillator.connect(gainNode);
@@ -72,9 +63,5 @@ export function playUiClickSound() {
 
 export function playUiSuccessSound() {
   playTone({ frequency: 660, durationMs: 70, volume: 0.04, type: "sine" });
-  setTimeout(
-    () =>
-      playTone({ frequency: 990, durationMs: 90, volume: 0.04, type: "sine" }),
-    70,
-  );
+  setTimeout(() => playTone({ frequency: 990, durationMs: 90, volume: 0.04, type: "sine" }), 70);
 }

--- a/src/lib/ssm-config.ts
+++ b/src/lib/ssm-config.ts
@@ -111,7 +111,7 @@ async function fetchSsmParams(): Promise<Map<string, string>> {
         Path: SSM_PREFIX,
         WithDecryption: true,
         NextToken: nextToken,
-      }),
+      })
     );
     for (const p of res.Parameters ?? []) {
       const key = p.Name?.replace(`${SSM_PREFIX}/`, "") ?? "";
@@ -143,7 +143,7 @@ function buildConfigFromParams(params: Map<string, string>): AppConfig {
 
   if (!sesFrom.includes("@") || !sesTo.includes("@")) {
     console.warn(
-      `[SSM] SES email addresses look invalid — FROM: ${sesFrom}, TO: ${sesTo}. Using defaults.`,
+      `[SSM] SES email addresses look invalid — FROM: ${sesFrom}, TO: ${sesTo}. Using defaults.`
     );
   }
 
@@ -232,10 +232,7 @@ function buildConfigFromEnv(): AppConfig {
     SLACK_WEBHOOK_URL: process.env.SLACK_WEBHOOK_URL || "",
     SLACK_BOT_TOKEN: process.env.SLACK_BOT_TOKEN || "",
     SLACK_SIGNING_SECRET: process.env.SLACK_SIGNING_SECRET || "",
-    HUBSPOT_API_KEY:
-      process.env.HUBSPOT_API_KEY ||
-      process.env.HUBSPOT_PRIVATE_APP_TOKEN ||
-      "",
+    HUBSPOT_API_KEY: process.env.HUBSPOT_API_KEY || process.env.HUBSPOT_PRIVATE_APP_TOKEN || "",
     HUBSPOT_CLIENT_SECRET: process.env.HUBSPOT_CLIENT_SECRET || "",
     NOTION_API_KEY: process.env.NOTION_API_KEY || "",
     NOTION_BLOG_DB_ID: process.env.NOTION_BLOG_DB_ID || "",
@@ -253,10 +250,7 @@ function buildConfigFromEnv(): AppConfig {
     NOTION_SERVICES_DB_ID: process.env.NOTION_SERVICES_DB_ID || "",
     NOTION_FAQS_DB_ID: process.env.NOTION_FAQS_DB_ID || "",
     GOOGLE_CLIENT_EMAIL: process.env.GOOGLE_CLIENT_EMAIL || "",
-    GOOGLE_PRIVATE_KEY: (process.env.GOOGLE_PRIVATE_KEY || "").replace(
-      /\\n/g,
-      "\n",
-    ),
+    GOOGLE_PRIVATE_KEY: (process.env.GOOGLE_PRIVATE_KEY || "").replace(/\\n/g, "\n"),
     GOOGLE_CALENDAR_ID: process.env.GOOGLE_CALENDAR_ID || "",
     GSC_SITE_URL: process.env.GSC_SITE_URL || "sc-domain:cloudless.gr",
     SENTRY_AUTH_TOKEN: process.env.SENTRY_AUTH_TOKEN || "",
@@ -330,7 +324,7 @@ export async function getConfig(): Promise<AppConfig> {
       const errName = (err as { name?: string })?.name ?? "Error";
       console.warn(
         `[SSM] ${errName} in dev — falling back to .env.local. ` +
-          "Set AWS_PROFILE or use IAM env keys to talk to real SSM.",
+          "Set AWS_PROFILE or use IAM env keys to talk to real SSM."
       );
       cached = buildConfigFromEnv();
       cachedAt = Date.now();

--- a/src/lib/store-products-client.ts
+++ b/src/lib/store-products-client.ts
@@ -175,12 +175,7 @@ export const defaultProducts: StoreProduct[] = [
     currency: "eur",
     category: "physical",
     image: "/store/dev-kit.svg",
-    features: [
-      "Notebook",
-      "Sticker pack",
-      "Architecture cheatsheet",
-      "Free shipping EU",
-    ],
+    features: ["Notebook", "Sticker pack", "Architecture cheatsheet", "Free shipping EU"],
   },
   {
     id: "phy-tshirt",
@@ -191,12 +186,7 @@ export const defaultProducts: StoreProduct[] = [
     currency: "eur",
     category: "physical",
     image: "/store/tshirt.svg",
-    features: [
-      "100% organic cotton",
-      "Embroidered logo",
-      "All sizes",
-      "Free shipping EU",
-    ],
+    features: ["100% organic cotton", "Embroidered logo", "All sizes", "Free shipping EU"],
   },
 ];
 
@@ -212,8 +202,6 @@ export function getProductById(id: string): StoreProduct | undefined {
 /**
  * Synchronous category lookup against the default catalog.
  */
-export function getProductsByCategory(
-  category: ProductCategory,
-): StoreProduct[] {
+export function getProductsByCategory(category: ProductCategory): StoreProduct[] {
   return defaultProducts.filter((p) => p.category === category);
 }

--- a/src/lib/store-products.ts
+++ b/src/lib/store-products.ts
@@ -58,10 +58,7 @@ function mapStripeProduct(sp: StripeProduct): StoreProduct {
     image,
     features,
     recurring: sp.defaultPrice?.recurring != null,
-    interval: sp.defaultPrice?.recurring?.interval as
-      | "month"
-      | "year"
-      | undefined,
+    interval: sp.defaultPrice?.recurring?.interval as "month" | "year" | undefined,
   };
 }
 
@@ -94,15 +91,13 @@ export async function getProducts(): Promise<StoreProduct[]> {
 // Product lookups (use live data when available)
 // ---------------------------------------------------------------------------
 
-export async function getProductByIdAsync(
-  id: string,
-): Promise<StoreProduct | undefined> {
+export async function getProductByIdAsync(id: string): Promise<StoreProduct | undefined> {
   const products = await getProducts();
   return products.find((p) => p.id === id);
 }
 
 export async function getProductsByCategoryAsync(
-  category: ProductCategory,
+  category: ProductCategory
 ): Promise<StoreProduct[]> {
   const products = await getProducts();
   return products.filter((p) => p.category === category);
@@ -122,9 +117,7 @@ export function getProductById(id: string): StoreProduct | undefined {
   return defaultProducts.find((p) => p.id === id);
 }
 
-export function getProductsByCategory(
-  category: ProductCategory,
-): StoreProduct[] {
+export function getProductsByCategory(category: ProductCategory): StoreProduct[] {
   if (productCache) {
     return productCache.products.filter((p) => p.category === category);
   }
@@ -281,8 +274,7 @@ export const defaultProducts: StoreProduct[] = [
   {
     id: "phy-tshirt",
     name: "Cloudless T-Shirt",
-    description:
-      "Soft cotton developer tee with the Cloudless logo. Available in Navy and White.",
+    description: "Soft cotton developer tee with the Cloudless logo. Available in Navy and White.",
     price: 2500,
     currency: "eur",
     category: "physical",

--- a/src/lib/stripe-analytics-read.ts
+++ b/src/lib/stripe-analytics-read.ts
@@ -119,10 +119,7 @@ function emptySnapshot(days: number): StripeAnalyticsSnapshot {
   };
 }
 
-function applyItem(
-  snapshot: StripeAnalyticsSnapshot,
-  item: Record<string, AttributeValue>,
-): void {
+function applyItem(snapshot: StripeAnalyticsSnapshot, item: Record<string, AttributeValue>): void {
   const day = deriveDay(item);
   const category = attrToString(item.tagCategory) || "other";
   const status = attrToString(item.processingStatus) || "unknown";
@@ -142,8 +139,7 @@ function applyItem(
   snapshot.byCategory[category].revenueMinor += amountMinor;
 
   snapshot.byStatus[status] = (snapshot.byStatus[status] || 0) + 1;
-  snapshot.byCurrency[currency] =
-    (snapshot.byCurrency[currency] || 0) + amountMinor;
+  snapshot.byCurrency[currency] = (snapshot.byCurrency[currency] || 0) + amountMinor;
 
   if (!day) return;
   const point = snapshot.dailyTrend.find((entry) => entry.day === day);
@@ -166,9 +162,7 @@ function isMissingIndexError(error: unknown): boolean {
   );
 }
 
-async function queryByDayOrScan(
-  days: number,
-): Promise<Array<Record<string, AttributeValue>>> {
+async function queryByDayOrScan(days: number): Promise<Array<Record<string, AttributeValue>>> {
   const tableName = getTransactionsTableName();
   const client = getDynamoClient();
   const dayRange = getDayRange(days);
@@ -187,7 +181,7 @@ async function queryByDayOrScan(
               ":eventDay": { S: day },
             },
             ExclusiveStartKey: lastEvaluatedKey,
-          }),
+          })
         );
 
         if (response.Items) allItems.push(...response.Items);
@@ -213,7 +207,7 @@ async function queryByDayOrScan(
           ":threshold": { N: `${thresholdMs}` },
         },
         ExclusiveStartKey: lastEvaluatedKey,
-      }),
+      })
     );
 
     if (response.Items) allItems.push(...response.Items);
@@ -224,7 +218,7 @@ async function queryByDayOrScan(
 }
 
 export async function getStripeAnalyticsSnapshot(
-  inputDays: number = 30,
+  inputDays: number = 30
 ): Promise<StripeAnalyticsSnapshot> {
   const days = Math.max(1, Math.min(365, Math.trunc(inputDays)));
   const snapshot = emptySnapshot(days);

--- a/src/lib/stripe-transactions.ts
+++ b/src/lib/stripe-transactions.ts
@@ -18,8 +18,7 @@ export function resolveDynamoEndpoint(): string | undefined {
   if (!endpoint) return undefined;
 
   const allowInsecureLocalhost =
-    endpoint.startsWith("http://localhost") ||
-    endpoint.startsWith("http://127.0.0.1");
+    endpoint.startsWith("http://localhost") || endpoint.startsWith("http://127.0.0.1");
 
   if (!endpoint.startsWith("https://") && !allowInsecureLocalhost) {
     throw new Error("DynamoDB endpoint must use HTTPS for encrypted transit");
@@ -43,9 +42,7 @@ function asString(value: unknown): string | undefined {
 }
 
 function asNumber(value: unknown): number | undefined {
-  return typeof value === "number" && Number.isFinite(value)
-    ? value
-    : undefined;
+  return typeof value === "number" && Number.isFinite(value) ? value : undefined;
 }
 
 function toJson(value: unknown): string {
@@ -69,14 +66,12 @@ export interface StripeEventTags {
 }
 
 export function getStripeEventTags(eventType: string): StripeEventTags {
-  const stage =
-    process.env.NEXT_PUBLIC_STAGE || process.env.NODE_ENV || "unknown";
+  const stage = process.env.NEXT_PUBLIC_STAGE || process.env.NODE_ENV || "unknown";
   let tagCategory = "other";
 
   if (eventType.startsWith("checkout.")) tagCategory = "checkout";
   else if (eventType.startsWith("invoice.")) tagCategory = "invoice";
-  else if (eventType.startsWith("customer.subscription."))
-    tagCategory = "subscription";
+  else if (eventType.startsWith("customer.subscription.")) tagCategory = "subscription";
 
   return {
     tagSource: APP_SOURCE_TAG,
@@ -96,14 +91,11 @@ function toExpiryEpoch(unixSeconds: number): number {
 function buildItem(event: Stripe.Event): Record<string, AttributeValue> {
   const object = event.data.object as unknown as Record<string, unknown>;
   const amountMinor =
-    asNumber(object.amount_total) ??
-    asNumber(object.amount_due) ??
-    asNumber(object.amount_paid);
+    asNumber(object.amount_total) ?? asNumber(object.amount_due) ?? asNumber(object.amount_paid);
 
   const objectId = asString(object.id);
   const currency = asString(object.currency);
-  const paymentStatus =
-    asString(object.payment_status) ?? asString(object.status);
+  const paymentStatus = asString(object.payment_status) ?? asString(object.status);
   const customerId = asString(object.customer);
   const customerEmail = asString(object.customer_email);
   const mode = asString(object.mode);
@@ -133,8 +125,7 @@ function buildItem(event: Stripe.Event): Record<string, AttributeValue> {
   if (customerId) item.customerId = { S: customerId };
   if (customerEmail) item.customerEmail = { S: customerEmail };
   if (mode) item.checkoutMode = { S: mode };
-  if (typeof amountMinor === "number")
-    item.amountMinor = { N: `${amountMinor}` };
+  if (typeof amountMinor === "number") item.amountMinor = { N: `${amountMinor}` };
 
   return item;
 }
@@ -143,9 +134,7 @@ export interface PersistStripeEventResult {
   duplicate: boolean;
 }
 
-export async function persistStripeEvent(
-  event: Stripe.Event,
-): Promise<PersistStripeEventResult> {
+export async function persistStripeEvent(event: Stripe.Event): Promise<PersistStripeEventResult> {
   const tableName = getTransactionsTableName();
   const client = getDynamoClient();
 
@@ -155,7 +144,7 @@ export async function persistStripeEvent(
         TableName: tableName,
         Item: buildItem(event),
         ConditionExpression: "attribute_not_exists(eventId)",
-      }),
+      })
     );
     return { duplicate: false };
   } catch (error) {
@@ -182,14 +171,11 @@ export async function markStripeEventProcessed(eventId: string): Promise<void> {
         ":status": { S: "processed" },
         ":processedAt": { N: `${Date.now()}` },
       },
-    }),
+    })
   );
 }
 
-export async function markStripeEventFailed(
-  eventId: string,
-  errorMessage: string,
-): Promise<void> {
+export async function markStripeEventFailed(eventId: string, errorMessage: string): Promise<void> {
   const tableName = getTransactionsTableName();
   const client = getDynamoClient();
   await client.send(
@@ -203,6 +189,6 @@ export async function markStripeEventFailed(
         ":processedAt": { N: `${Date.now()}` },
         ":error": { S: errorMessage.slice(0, 1000) },
       },
-    }),
+    })
   );
 }

--- a/src/lib/stripe.ts
+++ b/src/lib/stripe.ts
@@ -35,7 +35,7 @@ export interface RecentOrder {
  * Used by the /cloudless-orders slash command and admin dashboard.
  */
 export async function listRecentCheckoutSessions(
-  limit: number = 10,
+  limit: number = 10
 ): Promise<{ orders: RecentOrder[]; hasMore: boolean }> {
   const stripe = await getStripe();
 

--- a/src/lib/structured-data.ts
+++ b/src/lib/structured-data.ts
@@ -42,10 +42,7 @@ export function getOrganizationSchema(): OrganizationSchema {
       "@type": "PostalAddress",
       addressCountry: "GR",
     },
-    sameAs: [
-      "https://www.linkedin.com/company/cloudless-gr",
-      "https://github.com/cloudless-gr",
-    ],
+    sameAs: ["https://www.linkedin.com/company/cloudless-gr", "https://github.com/cloudless-gr"],
   };
 }
 

--- a/src/lib/theme-pref.ts
+++ b/src/lib/theme-pref.ts
@@ -72,6 +72,6 @@ export function useStoredPref(): ThemePref | null {
   return useSyncExternalStore<ThemePref | null>(
     subscribeStored,
     readStoredPref,
-    getServerStoredPref,
+    getServerStoredPref
   );
 }

--- a/src/lib/use-locale.ts
+++ b/src/lib/use-locale.ts
@@ -31,9 +31,7 @@ export function readLocaleFromCookie(): Locale {
     .split("; ")
     .find((e) => e.startsWith("NEXT_LOCALE="))
     ?.split("=")[1];
-  return cookieLocale && isSupportedLocale(cookieLocale)
-    ? (cookieLocale as Locale)
-    : defaultLocale;
+  return cookieLocale && isSupportedLocale(cookieLocale) ? (cookieLocale as Locale) : defaultLocale;
 }
 
 export function setAppLocale(_locale: Locale): void {

--- a/src/lib/validation.ts
+++ b/src/lib/validation.ts
@@ -9,9 +9,5 @@ export const EMAIL_MAX_LENGTH = 254;
  * Validates an email address format and length.
  */
 export function isValidEmail(email: unknown): email is string {
-  return (
-    typeof email === "string" &&
-    email.length <= EMAIL_MAX_LENGTH &&
-    EMAIL_REGEX.test(email)
-  );
+  return typeof email === "string" && email.length <= EMAIL_MAX_LENGTH && EMAIL_REGEX.test(email);
 }

--- a/src/lib/voice-brief-sources.ts
+++ b/src/lib/voice-brief-sources.ts
@@ -10,11 +10,7 @@
  * the legacy path Promise.all's them and formats inline.
  */
 import { getSeoSnapshot } from "@/lib/gsc";
-import {
-  isHubSpotConfigured,
-  getPipelineStats,
-  listNewsletterSubscribers,
-} from "@/lib/hubspot";
+import { isHubSpotConfigured, getPipelineStats, listNewsletterSubscribers } from "@/lib/hubspot";
 import { getStripe } from "@/lib/stripe";
 
 export interface SeoMetrics {
@@ -67,7 +63,6 @@ export async function fetchStripeMetrics(): Promise<StripeMetrics | null> {
   const stripe = await getStripe();
   const sessions = await stripe.checkout.sessions.list({ limit: 50 });
   const paid = sessions.data.filter((s) => s.payment_status === "paid");
-  const revenueEuros =
-    paid.reduce((acc, s) => acc + (s.amount_total ?? 0), 0) / 100;
+  const revenueEuros = paid.reduce((acc, s) => acc + (s.amount_total ?? 0), 0) / 100;
   return { orders: paid.length, revenueEuros };
 }

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -38,12 +38,7 @@
   "hero": {
     "badge": "v2.0 — Now Accepting Clients",
     "titleStatic": "Clear skies.",
-    "typingTexts": [
-      "Zero friction.",
-      "Full control.",
-      "Pure speed.",
-      "Real results."
-    ],
+    "typingTexts": ["Zero friction.", "Full control.", "Pure speed.", "Real results."],
     "subtitle": "Enterprise cloud? You can't afford it. DIY infrastructure? You shouldn't. We're the third way — serverless, data-driven growth, and scaling that actually fits a 2–20 person team.",
     "subtitleHighlight": "Finally.",
     "ctaPrimary": "Get a Free Audit",

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -38,12 +38,7 @@
   "hero": {
     "badge": "v2.0 — Nouveaux clients acceptés",
     "titleStatic": "Ciel dégagé.",
-    "typingTexts": [
-      "Zéro friction.",
-      "Contrôle total.",
-      "Vitesse pure.",
-      "Résultats concrets."
-    ],
+    "typingTexts": ["Zéro friction.", "Contrôle total.", "Vitesse pure.", "Résultats concrets."],
     "subtitle": "Le cloud enterprise ? Trop cher. L'infrastructure DIY ? Trop risqué. Nous sommes la troisième voie — serverless, croissance data-driven, et mise à l'échelle adaptée aux équipes de 2 à 20 personnes.",
     "subtitleHighlight": "Enfin.",
     "ctaPrimary": "Audit Gratuit",


### PR DESCRIPTION
## Summary

- Format all 311 `src/**/*.{ts,tsx,css,json}` files (plus `scripts/detect-sha-drift.mts`) so `pnpm format:check` passes green on main
- Fix `SlackClient.postOnce`: throw on webhook failure instead of returning `null`, so `post()` retries with exponential backoff (fixes the failing unit test in `__tests__/slack/slack-notify.test.ts`)

## Test plan

- [ ] `pnpm format:check` — all matched files use Prettier code style
- [ ] `pnpm test` — 1650 tests pass, 0 failures

https://claude.ai/code/session_01HuPxcCB6MrGPDE1HvsFFFH

---
_Generated by [Claude Code](https://claude.ai/code/session_01HuPxcCB6MrGPDE1HvsFFFH)_