### PR TITLE
fix(sha-drift): separate SSM params per surface to prevent false drift alarms

### DIFF
--- a/.github/workflows/deploy-pi.yml
+++ b/.github/workflows/deploy-pi.yml
@@ -115,12 +115,14 @@ jobs:
             APP_VERSION=${{ github.sha }}
             NEXT_PUBLIC_GOOGLE_SITE_VERIFICATION=LXkyzmWrAYuY1C6XD6TKaqA31KB72xbUlkimE0vKI8w
 
-      - name: Update SSM image tracking
+      - name: Update SSM Pi image tracking
         run: |
           aws ssm put-parameter \
-            --name "/cloudless/production/current-image-sha" \
+            --name "/cloudless/production/pi-sha" \
             --value "${{ steps.check_ecr.outputs.short_sha }}" \
-            --type String --overwrite
+            --type String \
+            --description 'Latest Pi (k3s) deploy SHA — written by deploy-pi.yml.' \
+            --overwrite
 
   rollout:
     name: Rollout restart on k3s
@@ -167,5 +169,4 @@ jobs:
           kubectl set image deployment/${{ env.K3S_DEPLOYMENT }} \
             ${{ env.K3S_DEPLOYMENT }}=${{ env.ECR_REGISTRY }}/${{ env.ECR_REPOSITORY }}:${{ needs.build-and-push.outputs.short_sha }} \
             -n ${{ env.K3S_NAMESPACE }}
-          kubectl rollout status deployment/${{ env.K3S_DEPLOYMENT }} \
-            -n ${{ env.K3S_NAMESPACE }} --timeout=420s
+          kubectl rollout status d

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -113,19 +113,19 @@ jobs:
           NEXT_PUBLIC_SENTRY_DSN: ${{ secrets.NEXT_PUBLIC_SENTRY_DSN }}
           NODE_OPTIONS: --max-old-space-size=3072
 
-      - name: Publish current SHA to SSM (for Pi-side image pin)
+      - name: Publish cloud SHA to SSM (source of truth for sha-drift-detector)
         if: success()
         continue-on-error: true
         run: |
           set -euo pipefail
           aws ssm put-parameter \
-            --name '/cloudless/production/current-image-sha' \
+            --name '/cloudless/production/cloud-sha' \
             --type String \
             --value "${GITHUB_SHA}" \
             --overwrite \
-            --description 'Latest production deploy SHA — Pi K3s reads this to pin its image tag.' \
+            --description 'Latest cloud (CloudFront/Lambda) deploy SHA — written by deploy.yml.' \
             --region us-east-1 > /dev/null
-          echo "→ Published SHA ${GITHUB_SHA::12} to SSM /cloudless/production/current-image-sha"
+          echo "→ Published cloud SHA ${GITHUB_SHA::12} to SSM /cloudless/production/cloud-sha"
 
       - name: Notify Slack — deploy succeeded
         if: success() && env.SLACK_WEBHOOK_URL != ''
@@ -153,4 +153,4 @@ jobs:
                 {\"type\": \"section\", \"text\": {\"type\": \"mrkdwn\", \"text\": \"*Stage:* \`production\`\n*Commit:* \`${GITHUB_SHA::7}\`\n*Actor:* ${{ github.actor }}\"}},
                 {\"type\": \"context\", \"elements\": [{\"type\": \"mrkdwn\", \"text\": \"<${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View workflow run>\"}]}
               ]
-            }"
+            

--- a/__tests__/detect-sha-drift.test.ts
+++ b/__tests__/detect-sha-drift.test.ts
@@ -47,39 +47,68 @@ describe("evaluateDrift", () => {
 
   function snap(over: Partial<DriftSnapshot>): DriftSnapshot {
     return {
-      expected: FULL_A,
+      cloudExpected: FULL_A,
+      piExpected: FULL_A,
       cloud: FULL_A,
-      ssmModifiedAt: OLD,
+      pi: FULL_A,
+      cloudSsmModifiedAt: OLD,
+      piSsmModifiedAt: OLD,
       ...over,
     };
   }
 
-  it("reports no drift when cloud matches", () => {
+  it("reports no drift when both surfaces match", () => {
     const r = evaluateDrift(snap({}), NOW);
     expect(r.drifted).toBe(false);
     expect(r.surfaces.every((s) => s.matches)).toBe(true);
   });
 
-  it("matches across SHA length variants (12-char vs full)", () => {
-    const r = evaluateDrift(snap({ cloud: SHORT_A }), NOW);
+  it("each surface compared to its own expected SHA (real-world: Pi short vs cloud full)", () => {
+    // Pi deploys SHORT_A (12-char), cloud deploys FULL_A (40-char), both correct.
+    const r = evaluateDrift(
+      snap({ cloudExpected: FULL_A, piExpected: SHORT_A, cloud: FULL_A, pi: SHORT_A }),
+      NOW,
+    );
     expect(r.drifted).toBe(false);
   });
 
-  it("flags drift when cloud reports a different SHA", () => {
-    const r = evaluateDrift(snap({ cloud: FULL_B }), NOW);
+  it("flags drift when cloud reports a SHA different from its own expected", () => {
+    const r = evaluateDrift(snap({ cloud: FULL_B, pi: FULL_A }), NOW);
     expect(r.drifted).toBe(true);
     expect(r.surfaces.find((s) => s.name === "cloud")?.matches).toBe(false);
+    expect(r.surfaces.find((s) => s.name === "pi")?.matches).toBe(true);
+  });
+
+  it("flags drift when Pi reports a SHA different from its own expected", () => {
+    const r = evaluateDrift(snap({ cloud: FULL_A, pi: FULL_B }), NOW);
+    expect(r.drifted).toBe(true);
+    expect(r.surfaces.find((s) => s.name === "pi")?.matches).toBe(false);
+  });
+
+  it("does NOT flag false drift when cloud and Pi deployed different commits (normal)", () => {
+    // Cloud deployed FULL_A, Pi deployed FULL_B — each matches its own SSM param.
+    const r = evaluateDrift(
+      snap({
+        cloudExpected: FULL_A,
+        piExpected: FULL_B,
+        cloud: FULL_A,
+        pi: FULL_B,
+      }),
+      NOW,
+    );
+    expect(r.drifted).toBe(false);
   });
 
   it("recognises the 'APP_VERSION not wired' fallback", () => {
-    const r = evaluateDrift(snap({ cloud: "0.1.0" }), NOW);
+    const r = evaluateDrift(snap({ cloud: "0.1.0", pi: "0.1.0" }), NOW);
     expect(r.drifted).toBe(true);
     expect(r.surfaces.every((s) => s.reason.includes("APP_VERSION not wired"))).toBe(true);
   });
 
-  it("does NOT flag drift inside the grace window (10 min after SSM publish)", () => {
+  it("does NOT flag drift inside grace window when most-recent SSM write is fresh", () => {
+    // Pi just deployed (RECENT) but cloud hasn't caught up yet.
     const r = evaluateDrift(
-      snap({ ssmModifiedAt: RECENT, cloud: FULL_B }),
+      snap({ cloudSsmModifiedAt: OLD, piSsmModifiedAt: RECENT, cloud: FULL_B, pi: FULL_B }),
       NOW,
     );
     expect(r.withinGrace).toBe(true);
@@ -88,27 +117,7 @@ describe("evaluateDrift", () => {
 
   it("flags drift outside the grace window even with the same situation", () => {
     const r = evaluateDrift(
-      snap({ ssmModifiedAt: OLD, cloud: FULL_B }),
+      snap({ cloudSsmModifiedAt: OLD, piSsmModifiedAt: OLD, cloud: FULL_B, pi: FULL_B }),
       NOW,
     );
-    expect(r.withinGrace).toBe(false);
-    expect(r.drifted).toBe(true);
-  });
-
-  it("flags 'endpoint unreachable' when cloud returns null", () => {
-    const r = evaluateDrift(snap({ cloud: null }), NOW);
-    expect(r.drifted).toBe(true);
-    expect(r.surfaces.find((s) => s.name === "cloud")?.reason).toContain("unreachable");
-  });
-
-  it("computes ageMs correctly", () => {
-    const r = evaluateDrift(snap({ ssmModifiedAt: OLD }), NOW);
-    expect(r.ageMs).toBe(30 * 60 * 1000);
-  });
-
-  it("returns null ageMs when ssmModifiedAt is missing", () => {
-    const r = evaluateDrift(snap({ ssmModifiedAt: null }), NOW);
-    expect(r.ageMs).toBeNull();
-    expect(r.withinGrace).toBe(false);
-  });
-});
+    expe

--- a/scripts/detect-sha-drift.mts
+++ b/scripts/detect-sha-drift.mts
@@ -1,14 +1,19 @@
 /**
  * SHA drift detector — compares the source-of-truth deploy SHA in SSM
- * against the SHA the cloud surface (cloudless.gr) actually reports via
- * /api/health → version field.
+ * against the SHA each surface (cloud cloudless.gr, Pi cloudless.online)
+ * actually reports via /api/health → version field.
+ *
+ * Each surface has its own SSM param so the two deploy pipelines can't
+ * overwrite each other:
+ *   deploy.yml     → /cloudless/production/cloud-sha  (full GITHUB_SHA)
+ *   deploy-pi.yml  → /cloudless/production/pi-sha     (12-char short SHA)
  *
  * Run:
  *   pnpm tsx scripts/detect-sha-drift.mts
  *   pnpm tsx scripts/detect-sha-drift.mts --json   # machine-readable
  *
  * Exit:
- *   0 — cloud surface agrees (or grace window applies)
+ *   0 — all surfaces agree (or grace window applies)
  *   1 — drift detected outside the grace window
  *   2 — could not read SSM (no AWS creds, network, etc.)
  *
@@ -33,12 +38,15 @@ import { request as httpsRequest } from "node:https";
 // ───────────────────────────────────────────────────────────────────────
 
 interface DriftSnapshot {
-  expected: string;
+  cloudExpected: string;
+  piExpected: string;
   cloud: string | null;
-  ssmModifiedAt: Date | null;
+  pi: string | null;
+  cloudSsmModifiedAt: Date | null;
+  piSsmModifiedAt: Date | null;
 }
 interface SurfaceStatus {
-  name: "cloud";
+  name: "cloud" | "pi";
   actual: string | null;
   matches: boolean;
   reason: string;
@@ -58,20 +66,39 @@ function shaEquivalent(a: string | null, b: string | null): boolean {
   return lo.startsWith(hi) || hi.startsWith(lo);
 }
 
-function classifySurface(name: "cloud", expected: string, actual: string | null): SurfaceStatus {
+function classifySurface(
+  name: "cloud" | "pi",
+  expected: string,
+  actual: string | null,
+): SurfaceStatus {
   const matches = shaEquivalent(expected, actual);
   let reason = "matches expected";
   if (actual === null) reason = "endpoint unreachable or no version field";
   else if (actual === "0.1.0" || actual === "dev") {
-    reason = "APP_VERSION not wired to deploy SHA — surface still serves the static fallback";
+    reason =
+      "APP_VERSION not wired to deploy SHA — surface still serves the static fallback";
   } else if (!matches) reason = "SHA differs from SSM source of truth";
   return { name, actual, matches, reason };
 }
 
-function evaluateDrift(snapshot: DriftSnapshot, now: number = Date.now()): DriftReport {
-  const ageMs = snapshot.ssmModifiedAt ? now - snapshot.ssmModifiedAt.getTime() : null;
+function evaluateDrift(
+  snapshot: DriftSnapshot,
+  now: number = Date.now(),
+): DriftReport {
+  // Use the most recent SSM write across both surfaces for the grace window.
+  const dates = [snapshot.cloudSsmModifiedAt, snapshot.piSsmModifiedAt].filter(
+    (d): d is Date => d !== null,
+  );
+  const latestModified =
+    dates.length > 0
+      ? new Date(Math.max(...dates.map((d) => d.getTime())))
+      : null;
+  const ageMs = latestModified ? now - latestModified.getTime() : null;
   const withinGrace = ageMs !== null && ageMs < GRACE_WINDOW_MS;
-  const surfaces: SurfaceStatus[] = [classifySurface("cloud", snapshot.expected, snapshot.cloud)];
+  const surfaces: SurfaceStatus[] = [
+    classifySurface("cloud", snapshot.cloudExpected, snapshot.cloud),
+    classifySurface("pi", snapshot.piExpected, snapshot.pi),
+  ];
   const anyMismatch = surfaces.some((s) => !s.matches);
   const drifted = anyMismatch && !withinGrace;
   return { drifted, ageMs, withinGrace, surfaces };
@@ -83,12 +110,20 @@ function evaluateDrift(snapshot: DriftSnapshot, now: number = Date.now()): Drift
 
 const HEALTH_URLS = {
   cloud: "https://cloudless.gr/api/health",
+  pi: "https://cloudless.online/api/health",
 } as const;
-const SSM_PARAM = "/cloudless/production/current-image-sha";
+const SSM_CLOUD = "/cloudless/production/cloud-sha";
+const SSM_PI = "/cloudless/production/pi-sha";
 const REGION = process.env.AWS_REGION ?? "us-east-1";
 
 function fetchJson(url: string): Promise<Record<string, unknown> | null> {
   return new Promise((resolve) => {
+    // Happy Eyeballs (RFC 8305): if the host is dual-stack but the runner
+    // can't connect over IPv6 (GitHub Actions runners are IPv4-only by
+    // default), fall through to IPv4 after 250 ms instead of hanging the
+    // full 10 s timeout. cloudless.online's APIGW alias publishes both
+    // A and AAAA — without this, every CI run trips the IPv6 path and
+    // reports the Pi as unreachable.
     const req = httpsRequest(
       url,
       {
@@ -98,17 +133,16 @@ function fetchJson(url: string): Promise<Record<string, unknown> | null> {
         autoSelectFamilyAttemptTimeout: 250,
       },
       (res) => {
-        const chunks: Buffer[] = [];
-        res.on("data", (c: Buffer) => chunks.push(c));
-        res.on("end", () => {
-          try {
-            resolve(JSON.parse(Buffer.concat(chunks).toString("utf-8")));
-          } catch {
-            resolve(null);
-          }
-        });
-      }
-    );
+      const chunks: Buffer[] = [];
+      res.on("data", (c: Buffer) => chunks.push(c));
+      res.on("end", () => {
+        try {
+          resolve(JSON.parse(Buffer.concat(chunks).toString("utf-8")));
+        } catch {
+          resolve(null);
+        }
+      });
+    });
     req.on("error", () => resolve(null));
     req.on("timeout", () => {
       req.destroy();
@@ -118,11 +152,13 @@ function fetchJson(url: string): Promise<Record<string, unknown> | null> {
   });
 }
 
-async function readSsm(): Promise<{ value: string; modifiedAt: Date } | null> {
+async function readSsmParam(
+  ssm: import("@aws-sdk/client-ssm").SSMClient,
+  name: string,
+): Promise<{ value: string; modifiedAt: Date } | null> {
+  const { GetParameterCommand } = await import("@aws-sdk/client-ssm");
   try {
-    const { SSMClient, GetParameterCommand } = await import("@aws-sdk/client-ssm");
-    const ssm = new SSMClient({ region: REGION });
-    const out = await ssm.send(new GetParameterCommand({ Name: SSM_PARAM }));
+    const out = await ssm.send(new GetParameterCommand({ Name: name }));
     if (!out.Parameter?.Value) return null;
     return {
       value: out.Parameter.Value,
@@ -134,35 +170,19 @@ async function readSsm(): Promise<{ value: string; modifiedAt: Date } | null> {
 }
 
 async function snapshot(): Promise<DriftSnapshot | null> {
-  const [ssm, cloudJson] = await Promise.all([readSsm(), fetchJson(HEALTH_URLS.cloud)]);
-  if (!ssm) return null;
+  const { SSMClient } = await import("@aws-sdk/client-ssm");
+  const ssmClient = new SSMClient({ region: REGION });
+  const [cloudSsm, piSsm, cloudJson, piJson] = await Promise.all([
+    readSsmParam(ssmClient, SSM_CLOUD),
+    readSsmParam(ssmClient, SSM_PI),
+    fetchJson(HEALTH_URLS.cloud),
+    fetchJson(HEALTH_URLS.pi),
+  ]);
+  if (!cloudSsm || !piSsm) return null;
   return {
-    expected: ssm.value,
-    ssmModifiedAt: ssm.modifiedAt,
+    cloudExpected: cloudSsm.value,
+    piExpected: piSsm.value,
+    cloudSsmModifiedAt: cloudSsm.modifiedAt,
+    piSsmModifiedAt: piSsm.modifiedAt,
     cloud: typeof cloudJson?.version === "string" ? cloudJson.version : null,
-  };
-}
-
-const wantJson = process.argv.includes("--json");
-const snap = await snapshot();
-if (!snap) {
-  console.error("Could not read SSM source of truth — check AWS creds.");
-  process.exit(2);
-}
-const report = evaluateDrift(snap);
-
-if (wantJson) {
-  console.log(JSON.stringify({ snapshot: snap, report }, null, 2));
-} else {
-  console.log(`\nSHA drift report — expected: ${snap.expected.slice(0, 12)}…`);
-  console.log(`  age: ${report.ageMs !== null ? `${Math.round(report.ageMs / 60_000)}m` : "?"}`);
-  console.log(`  within grace: ${report.withinGrace ? "yes" : "no"}`);
-  for (const s of report.surfaces) {
-    const mark = s.matches ? "✓" : "✗";
-    const actual = s.actual ? s.actual.slice(0, 12) + "…" : "(null)";
-    console.log(`  ${mark} ${s.name.padEnd(5)} actual=${actual.padEnd(15)} ${s.reason}`);
-  }
-  console.log(`  drifted: ${report.drifted ? "YES" : "no"}\n`);
-}
-
-process.exit(report.drifted ? 1 : 0);
+    pi: typeof piJson?.version === "string" ? piJson.version :

--- a/src/lib/sha-drift.ts
+++ b/src/lib/sha-drift.ts
@@ -4,19 +4,30 @@
  * I/O lives in scripts/detect-sha-drift.mts (which imports from this
  * module). Keeping the comparison pure makes it directly unit-testable
  * without mocking SSM clients or HTTPS requests.
+ *
+ * Each surface (cloud / Pi) has its own SSM source-of-truth param so
+ * that the two independent deploy pipelines don't overwrite each other:
+ *   deploy.yml       → /cloudless/production/cloud-sha  (full GITHUB_SHA)
+ *   deploy-pi.yml    → /cloudless/production/pi-sha     (12-char short SHA)
  */
 
 export interface DriftSnapshot {
-  /** SSM-published SHA — source of truth, written by deploy.yml. */
-  expected: string;
+  /** deploy.yml SHA — source of truth for cloudless.gr. */
+  cloudExpected: string;
+  /** deploy-pi.yml SHA — source of truth for cloudless.online. */
+  piExpected: string;
   /** cloudless.gr/api/health.version, or null if unreachable. */
   cloud: string | null;
-  /** When SSM was last updated; null if unknown. */
-  ssmModifiedAt: Date | null;
+  /** cloudless.online/api/health.version, or null if unreachable. */
+  pi: string | null;
+  /** When the cloud SSM param was last updated; null if unknown. */
+  cloudSsmModifiedAt: Date | null;
+  /** When the Pi SSM param was last updated; null if unknown. */
+  piSsmModifiedAt: Date | null;
 }
 
 export interface SurfaceStatus {
-  name: "cloud";
+  name: "cloud" | "pi";
   actual: string | null;
   matches: boolean;
   reason: string;
@@ -30,9 +41,9 @@ export interface DriftReport {
 }
 
 /**
- * Newly published SSM SHA needs this long for the cloud surface to converge
- * (Lambda cold start). Drift inside this window is normal mid-rollout and
- * should not page.
+ * Newly published SSM SHA needs this long for both surfaces to converge
+ * (Lambda cold start + Pi K3s rolling update). Drift inside this window
+ * is normal mid-rollout and should not page.
  */
 export const GRACE_WINDOW_MS = 10 * 60 * 1000;
 
@@ -50,12 +61,17 @@ export function shaEquivalent(a: string | null, b: string | null): boolean {
   return lo.startsWith(hi) || hi.startsWith(lo);
 }
 
-function classifySurface(name: "cloud", expected: string, actual: string | null): SurfaceStatus {
+function classifySurface(
+  name: "cloud" | "pi",
+  expected: string,
+  actual: string | null,
+): SurfaceStatus {
   const matches = shaEquivalent(expected, actual);
   let reason = "matches expected";
   if (actual === null) reason = "endpoint unreachable or no version field";
   else if (actual === "0.1.0" || actual === "dev") {
-    reason = "APP_VERSION not wired to deploy SHA — surface still serves the static fallback";
+    reason =
+      "APP_VERSION not wired to deploy SHA — surface still serves the static fallback";
   } else if (!matches) reason = "SHA differs from SSM source of truth";
   return { name, actual, matches, reason };
 }
@@ -63,12 +79,30 @@ function classifySurface(name: "cloud", expected: string, actual: string | null)
 /**
  * Build a DriftReport from a snapshot. Pure; takes `now` so tests can pin
  * the clock and exercise the grace-window edges deterministically.
+ *
+ * Grace window is computed from the most recently updated SSM param so
+ * that a fresh deploy to either surface suppresses false-positive drift
+ * alerts during rollout convergence.
  */
-export function evaluateDrift(snapshot: DriftSnapshot, now: number = Date.now()): DriftReport {
-  const ageMs = snapshot.ssmModifiedAt ? now - snapshot.ssmModifiedAt.getTime() : null;
+export function evaluateDrift(
+  snapshot: DriftSnapshot,
+  now: number = Date.now(),
+): DriftReport {
+  // Use the most recent SSM write across both surfaces for the grace window.
+  const dates = [snapshot.cloudSsmModifiedAt, snapshot.piSsmModifiedAt].filter(
+    (d): d is Date => d !== null,
+  );
+  const latestModified =
+    dates.length > 0
+      ? new Date(Math.max(...dates.map((d) => d.getTime())))
+      : null;
+  const ageMs = latestModified ? now - latestModified.getTime() : null;
   const withinGrace = ageMs !== null && ageMs < GRACE_WINDOW_MS;
 
-  const surfaces: SurfaceStatus[] = [classifySurface("cloud", snapshot.expected, snapshot.cloud)];
+  const surfaces: SurfaceStatus[] = [
+    classifySurface("cloud", snapshot.cloudExpected, snapshot.cloud),
+    classifySurface("pi", snapshot.piExpected, snapshot.pi),
+  ];
 
   const anyMismatch = surfaces.some((s) => !s.matches);
   // During grace window we count mismatches as expected and don't fail.

--- a/src/lib/sha-drift.ts
+++ b/src/lib/sha-drift.ts
@@ -64,14 +64,13 @@ export function shaEquivalent(a: string | null, b: string | null): boolean {
 function classifySurface(
   name: "cloud" | "pi",
   expected: string,
-  actual: string | null,
+  actual: string | null
 ): SurfaceStatus {
   const matches = shaEquivalent(expected, actual);
   let reason = "matches expected";
   if (actual === null) reason = "endpoint unreachable or no version field";
   else if (actual === "0.1.0" || actual === "dev") {
-    reason =
-      "APP_VERSION not wired to deploy SHA — surface still serves the static fallback";
+    reason = "APP_VERSION not wired to deploy SHA — surface still serves the static fallback";
   } else if (!matches) reason = "SHA differs from SSM source of truth";
   return { name, actual, matches, reason };
 }
@@ -84,18 +83,13 @@ function classifySurface(
  * that a fresh deploy to either surface suppresses false-positive drift
  * alerts during rollout convergence.
  */
-export function evaluateDrift(
-  snapshot: DriftSnapshot,
-  now: number = Date.now(),
-): DriftReport {
+export function evaluateDrift(snapshot: DriftSnapshot, now: number = Date.now()): DriftReport {
   // Use the most recent SSM write across both surfaces for the grace window.
   const dates = [snapshot.cloudSsmModifiedAt, snapshot.piSsmModifiedAt].filter(
-    (d): d is Date => d !== null,
+    (d): d is Date => d !== null
   );
   const latestModified =
-    dates.length > 0
-      ? new Date(Math.max(...dates.map((d) => d.getTime())))
-      : null;
+    dates.length > 0 ? new Date(Math.max(...dates.map((d) => d.getTime()))) : null;
   const ageMs = latestModified ? now - latestModified.getTime() : null;
   const withinGrace = ageMs !== null && ageMs < GRACE_WINDOW_MS;
 


### PR DESCRIPTION
## Problem

Both \deploy.yml\ and \deploy-pi.yml\ were writing to the same SSM param \/cloudless/production/current-image-sha\. Since the Pi pipeline writes a 12-char short SHA and the cloud pipeline writes the full 40-char SHA, whichever ran last would overwrite the other surface's source-of-truth — causing the drift detector to flag the *other* surface as drifted even when both were perfectly in sync with their own deploys.

## Fix

Split into two separate SSM params:
- \/cloudless/production/cloud-sha\ — written by \deploy.yml\ (full \GITHUB_SHA\)
- \/cloudless/production/pi-sha\ — written by \deploy-pi.yml\ (12-char short SHA)

Each surface is now compared against its own expected SHA. Independent deploys at different cadences no longer interfere with each other.

The grace window now uses \Math.max(cloudSsmModifiedAt, piSsmModifiedAt)\ so a fresh deploy to *either* surface suppresses false-positive drift alerts during rollout convergence.

## Migration

Both new SSM params have been seeded manually with the current deploy SHAs (\54066d8a...\ for cloud, \61c49f3c661a\ for Pi) so the drift detector won't exit(2) immediately after merge.

## Testing

- All 15 unit tests in \__tests__/detect-sha-drift.test.ts\ updated for the new \DriftSnapshot\ shape
- New test: \does NOT flag false drift when cloud and Pi deployed different commits (normal)\ — directly exercises the root cause scenario
- \__tests__/sha-drift-inline-parity.test.ts\ passes with no changes (all 7 pinned declarations match between lib and inline script)