### PR TITLE
fix(tests): sync inline script trailing-comma style with lib; complete truncated test

### DIFF
--- a/__tests__/detect-sha-drift.test.ts
+++ b/__tests__/detect-sha-drift.test.ts
@@ -120,4 +120,7 @@ describe("evaluateDrift", () => {
       snap({ cloudSsmModifiedAt: OLD, piSsmModifiedAt: OLD, cloud: FULL_B, pi: FULL_B }),
       NOW,
     );
-    expe
+    expect(r.withinGrace).toBe(false);
+    expect(r.drifted).toBe(true);
+  });
+});

--- a/scripts/detect-sha-drift.mts
+++ b/scripts/detect-sha-drift.mts
@@ -69,30 +69,24 @@ function shaEquivalent(a: string | null, b: string | null): boolean {
 function classifySurface(
   name: "cloud" | "pi",
   expected: string,
-  actual: string | null,
+  actual: string | null
 ): SurfaceStatus {
   const matches = shaEquivalent(expected, actual);
   let reason = "matches expected";
   if (actual === null) reason = "endpoint unreachable or no version field";
   else if (actual === "0.1.0" || actual === "dev") {
-    reason =
-      "APP_VERSION not wired to deploy SHA — surface still serves the static fallback";
+    reason = "APP_VERSION not wired to deploy SHA — surface still serves the static fallback";
   } else if (!matches) reason = "SHA differs from SSM source of truth";
   return { name, actual, matches, reason };
 }
 
-function evaluateDrift(
-  snapshot: DriftSnapshot,
-  now: number = Date.now(),
-): DriftReport {
+function evaluateDrift(snapshot: DriftSnapshot, now: number = Date.now()): DriftReport {
   // Use the most recent SSM write across both surfaces for the grace window.
   const dates = [snapshot.cloudSsmModifiedAt, snapshot.piSsmModifiedAt].filter(
-    (d): d is Date => d !== null,
+    (d): d is Date => d !== null
   );
   const latestModified =
-    dates.length > 0
-      ? new Date(Math.max(...dates.map((d) => d.getTime())))
-      : null;
+    dates.length > 0 ? new Date(Math.max(...dates.map((d) => d.getTime()))) : null;
   const ageMs = latestModified ? now - latestModified.getTime() : null;
   const withinGrace = ageMs !== null && ageMs < GRACE_WINDOW_MS;
   const surfaces: SurfaceStatus[] = [


### PR DESCRIPTION
Follows up on #262.

Two issues crept into main during the merge of #262:

1. **Truncated \__tests__/detect-sha-drift.test.ts\** - the last test body was cut off at \xpe\ (parse error). Appended the missing \xpect\ calls and closing braces so the file parses correctly.

2. **Parity mismatch in \scripts/detect-sha-drift.mts\** - \prettier\ reformatted \src/lib/sha-drift.ts\ (removed trailing commas, inlined long signatures) but the inline copy in the script was not updated to match. The parity test (\sha-drift-inline-parity.test.ts\) enforces equivalence after comment/whitespace normalization — trailing commas are NOT stripped — so the mismatch caused Unit Tests to fail.

This PR syncs the inline copy and completes the truncated test so CI is fully green.