### PR TITLE
fix(python): security hardening across all Python scripts

### DIFF
--- a/infrastructure/pi-alert-api/mqtt_publish.py
+++ b/infrastructure/pi-alert-api/mqtt_publish.py
@@ -74,7 +74,7 @@ def _publish_sync(msgs: list[dict]) -> None:
 
 
 async def _publish_async(msgs: list[dict]) -> None:
-    loop = asyncio.get_event_loop()
+    loop = asyncio.get_running_loop()
     await loop.run_in_executor(_executor, _publish_sync, msgs)
 
 

--- a/infrastructure/pi-alert-api/tls_check.py
+++ b/infrastructure/pi-alert-api/tls_check.py
@@ -69,7 +69,7 @@ def _get_cert_expiry(hostname: str, port: int = 443, timeout: float = 10.0) -> d
 async def _check_domain(hostname: str) -> None:
     """Check one domain and log the result. Fires alerts via logger for now;
     wire into receive_alert() in main.py if in-process calls are preferred."""
-    loop = asyncio.get_event_loop()
+    loop = asyncio.get_running_loop()
     expiry = await loop.run_in_executor(None, _get_cert_expiry, hostname)
 
     if expiry is None:

--- a/scripts/fix-pi-ssm-permission.py
+++ b/scripts/fix-pi-ssm-permission.py
@@ -1,3 +1,4 @@
+import os
 #!/usr/bin/env python3
 """
 Grant ssm:GetParametersByPath to the cloudless-pi-standby IAM user.
@@ -41,7 +42,7 @@ import sys
 import boto3
 from botocore.exceptions import ClientError
 
-ACCOUNT_ID = "278585680617"
+ACCOUNT_ID = os.environ.get("AWS_ACCOUNT_ID", "278585680617")
 IAM_USER = "cloudless-pi-standby"
 POLICY_NAME = "PiStandbySSMRead"
 SSM_PATH = "/cloudless/production"

--- a/scripts/grant-ci-iam-permissions.py
+++ b/scripts/grant-ci-iam-permissions.py
@@ -52,7 +52,7 @@ from typing import List
 import boto3
 from botocore.exceptions import ClientError
 
-ACCOUNT_ID = "278585680617"
+ACCOUNT_ID = os.environ.get("AWS_ACCOUNT_ID", "278585680617")
 PI_IMAGE_REPO = "cloudless-pi-app"
 PI_IMAGE_REGION = "us-east-1"
 SST_ROLE_PREFIX = "cloudl-production-"
@@ -84,10 +84,23 @@ DEPLOY_POLICY = {
                 "iam:DeleteRole",
                 "iam:UpdateRole",
                 "iam:UpdateAssumeRolePolicy",
-                # Pass roles to Lambda/etc.
-                "iam:PassRole",
             ],
-            "Resource": f"arn:aws:iam::*:role/{SST_ROLE_PREFIX}*",
+            "Resource": f"arn:aws:iam::{ACCOUNT_ID}:role/{SST_ROLE_PREFIX}*",
+        },
+        {
+            "Sid": "AllowSSTPassRole",
+            "Effect": "Allow",
+            "Action": "iam:PassRole",
+            "Resource": f"arn:aws:iam::{ACCOUNT_ID}:role/{SST_ROLE_PREFIX}*",
+            "Condition": {
+                "StringEquals": {
+                    "iam:PassedToService": [
+                        "lambda.amazonaws.com",
+                        "cloudformation.amazonaws.com",
+                        "apigateway.amazonaws.com",
+                    ]
+                }
+            },
         },
         {
             "Sid": "AllowPolicySimulation",

--- a/scripts/pi-routines/dep-major-audit.py
+++ b/scripts/pi-routines/dep-major-audit.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 """Monthly major dependency version audit for cloudless.gr — posts to Slack."""
-import subprocess, json, datetime, urllib.request, urllib.parse
+import subprocess, json, datetime, urllib.request, urllib.parse, re
 
 def ssm(key):
     r = subprocess.run(
@@ -8,14 +8,22 @@ def ssm(key):
          '--with-decryption', '--query', 'Parameter.Value', '--output', 'text',
          '--region', 'us-east-1'],
         capture_output=True, text=True)
-    return r.stdout.strip()
+    if r.returncode != 0:
+        raise RuntimeError(f"SSM lookup failed for {key!r}: {r.stderr.strip()}")
+    value = r.stdout.strip()
+    if not value:
+        raise RuntimeError(f"SSM returned empty value for {key!r}")
+    return value
 
 def slack_post(token, channel, text):
     body = json.dumps({'channel': channel, 'text': text}).encode()
     req = urllib.request.Request(
         'https://slack.com/api/chat.postMessage', data=body,
         headers={'Authorization': f'Bearer {token}', 'Content-Type': 'application/json'})
-    urllib.request.urlopen(req)
+    with urllib.request.urlopen(req) as r:
+        resp = json.loads(r.read())
+    if not resp.get('ok'):
+        raise RuntimeError(f"Slack API error: {resp.get('error', 'unknown')}")
 
 token = ssm('SLACK_BOT_TOKEN')
 channel = ssm('SLACK_DEFAULT_CHANNEL')
@@ -41,7 +49,7 @@ upgrades = 0
 for name in KEY_PKGS:
     if name not in all_deps:
         continue
-    installed = all_deps[name].lstrip('^~>=')
+    installed = re.sub(r'^[\^~>=<]+', '', all_deps[name])
     try:
         enc = urllib.parse.quote(name, safe='@%')
         with urllib.request.urlopen(

--- a/scripts/pi-routines/integration-health.py
+++ b/scripts/pi-routines/integration-health.py
@@ -8,14 +8,22 @@ def ssm(key):
          '--with-decryption', '--query', 'Parameter.Value', '--output', 'text',
          '--region', 'us-east-1'],
         capture_output=True, text=True)
-    return r.stdout.strip()
+    if r.returncode != 0:
+        raise RuntimeError(f"SSM lookup failed for {key!r}: {r.stderr.strip()}")
+    value = r.stdout.strip()
+    if not value:
+        raise RuntimeError(f"SSM returned empty value for {key!r}")
+    return value
 
 def slack_post(token, channel, text):
     body = json.dumps({'channel': channel, 'text': text}).encode()
     req = urllib.request.Request(
         'https://slack.com/api/chat.postMessage', data=body,
         headers={'Authorization': f'Bearer {token}', 'Content-Type': 'application/json'})
-    urllib.request.urlopen(req)
+    with urllib.request.urlopen(req) as r:
+        resp = json.loads(r.read())
+    if not resp.get('ok'):
+        raise RuntimeError(f"Slack API error: {resp.get('error', 'unknown')}")
 
 def api_check(url, headers=None):
     try:

--- a/scripts/pi-routines/sentry-digest.py
+++ b/scripts/pi-routines/sentry-digest.py
@@ -8,14 +8,22 @@ def ssm(key):
          '--with-decryption', '--query', 'Parameter.Value', '--output', 'text',
          '--region', 'us-east-1'],
         capture_output=True, text=True)
-    return r.stdout.strip()
+    if r.returncode != 0:
+        raise RuntimeError(f"SSM lookup failed for {key!r}: {r.stderr.strip()}")
+    value = r.stdout.strip()
+    if not value:
+        raise RuntimeError(f"SSM returned empty value for {key!r}")
+    return value
 
 def slack_post(token, channel, text):
     body = json.dumps({'channel': channel, 'text': text}).encode()
     req = urllib.request.Request(
         'https://slack.com/api/chat.postMessage', data=body,
         headers={'Authorization': f'Bearer {token}', 'Content-Type': 'application/json'})
-    urllib.request.urlopen(req)
+    with urllib.request.urlopen(req) as r:
+        resp = json.loads(r.read())
+    if not resp.get('ok'):
+        raise RuntimeError(f"Slack API error: {resp.get('error', 'unknown')}")
 
 def sentry_get(path, sentry_token):
     req = urllib.request.Request(

--- a/scripts/pi-routines/ssl-domain-check.py
+++ b/scripts/pi-routines/ssl-domain-check.py
@@ -8,14 +8,22 @@ def ssm(key):
          '--with-decryption', '--query', 'Parameter.Value', '--output', 'text',
          '--region', 'us-east-1'],
         capture_output=True, text=True)
-    return r.stdout.strip()
+    if r.returncode != 0:
+        raise RuntimeError(f"SSM lookup failed for {key!r}: {r.stderr.strip()}")
+    value = r.stdout.strip()
+    if not value:
+        raise RuntimeError(f"SSM returned empty value for {key!r}")
+    return value
 
 def slack_post(token, channel, text):
     body = json.dumps({'channel': channel, 'text': text}).encode()
     req = urllib.request.Request(
         'https://slack.com/api/chat.postMessage', data=body,
         headers={'Authorization': f'Bearer {token}', 'Content-Type': 'application/json'})
-    urllib.request.urlopen(req)
+    with urllib.request.urlopen(req) as r:
+        resp = json.loads(r.read())
+    if not resp.get('ok'):
+        raise RuntimeError(f"Slack API error: {resp.get('error', 'unknown')}")
 
 def ssl_expiry(host):
     ctx = ssl.create_default_context()
@@ -24,7 +32,7 @@ def ssl_expiry(host):
         cert = s.getpeercert()
     exp_str = cert['notAfter']  # e.g. 'May 30 12:00:00 2026 GMT'
     exp = datetime.datetime.strptime(exp_str, '%b %d %H:%M:%S %Y %Z')
-    return exp, (exp - datetime.datetime.utcnow()).days
+    return exp, (exp - datetime.datetime.now(datetime.timezone.utc).replace(tzinfo=None)).days
 
 token = ssm('SLACK_BOT_TOKEN')
 channel = ssm('SLACK_DEFAULT_CHANNEL')

--- a/scripts/pi-routines/stale-branches.py
+++ b/scripts/pi-routines/stale-branches.py
@@ -8,7 +8,12 @@ def ssm(key):
          '--with-decryption', '--query', 'Parameter.Value', '--output', 'text',
          '--region', 'us-east-1'],
         capture_output=True, text=True)
-    return r.stdout.strip()
+    if r.returncode != 0:
+        raise RuntimeError(f"SSM lookup failed for {key!r}: {r.stderr.strip()}")
+    value = r.stdout.strip()
+    if not value:
+        raise RuntimeError(f"SSM returned empty value for {key!r}")
+    return value
 
 def gh(path, token, data=None):
     method = 'POST' if data else 'GET'
@@ -25,12 +30,15 @@ def slack_post(token, channel, text):
     req = urllib.request.Request(
         'https://slack.com/api/chat.postMessage', data=body,
         headers={'Authorization': f'Bearer {token}', 'Content-Type': 'application/json'})
-    urllib.request.urlopen(req)
+    with urllib.request.urlopen(req) as r:
+        resp = json.loads(r.read())
+    if not resp.get('ok'):
+        raise RuntimeError(f"Slack API error: {resp.get('error', 'unknown')}")
 
 gh_token = ssm('GITHUB_TOKEN')
 slack_token = ssm('SLACK_BOT_TOKEN')
 channel = ssm('SLACK_DEFAULT_CHANNEL')
-today = datetime.datetime.utcnow()
+today = datetime.datetime.now(datetime.timezone.utc).replace(tzinfo=None)
 cutoff = today - datetime.timedelta(days=21)
 repo = 'Themis128/cloudless.gr'
 protected = {'main', 'master', 'develop', 'staging'}
@@ -45,6 +53,8 @@ req = urllib.request.Request(
     headers={'Authorization': f'bearer {gh_token}', 'Content-Type': 'application/json'})
 with urllib.request.urlopen(req) as r:
     gql_data = json.loads(r.read())
+if 'errors' in gql_data:
+    raise RuntimeError(f"GitHub GraphQL error: {gql_data['errors']}")
 branches = gql_data['data']['repository']['refs']['nodes']
 
 # Open PR branches (exclude from stale list)

--- a/tools/mcp-security-scanner/py/prompt_injection_analyzer.py
+++ b/tools/mcp-security-scanner/py/prompt_injection_analyzer.py
@@ -9,7 +9,7 @@ import json
 import re
 import sys
 
-PROMPT_INJECTION_PATTERNS = [
+_RAW_PATTERNS = [
     {
         'id': 'mcp-008-prompt-injection-directive',
         'message': 'Prompt contains explicit injection directive.',
@@ -28,6 +28,13 @@ PROMPT_INJECTION_PATTERNS = [
         ),
     },
 ]
+
+# Pre-compile patterns at module load time for performance
+PROMPT_INJECTION_PATTERNS = [
+    {**entry, 'regex': re.compile(entry['pattern'], re.IGNORECASE | re.MULTILINE)}
+    for entry in _RAW_PATTERNS
+]
+
 
 
 def analyze_text(text):
@@ -60,10 +67,11 @@ def main():
 
     if args.json:
         print(json.dumps(findings))
-        return
+    else:
+        for finding in findings:
+            print(f"{finding['id']}:{finding['line']} - {finding['message']}")
 
-    for finding in findings:
-        print(f"{finding['id']}:{finding['line']} - {finding['message']}")
+    sys.exit(1 if findings else 0)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Summary

Security and reliability hardening across all 10 Python files in the repo.

### Changes

**pi-routines (5 files)**
- SSM `subprocess.run()` now checks `returncode` and raises `RuntimeError` on failure or empty value — previously silent failures would pass empty strings as tokens
- `slack_post()` now reads the response body and checks the `ok` field — previously fire-and-forget
- `stale-branches.py`: `datetime.utcnow()` → `datetime.now(timezone.utc)` (deprecated in 3.12); GraphQL error field check added
- `dep-major-audit.py`: `str.lstrip('^~>=')'` bug (strips individual chars, not prefix) → `re.sub(r'^\[\^~>=<]+', '', s)`; added `import re`
- `ssl-domain-check.py`: same `utcnow()` fix

**infrastructure/pi-alert-api**
- `mqtt_publish.py`: `asyncio.get_event_loop()` → `get_running_loop()` (deprecated in 3.10, raises in 3.12 inside coroutines)
- `tls_check.py`: same fix

**tools/mcp-security-scanner**
- `prompt_injection_analyzer.py`: regexes pre-compiled at module load (not inside every `analyze_text` call); `main()` now calls `sys.exit(1)` when findings exist so CI gates work

**scripts**
- `grant-ci-iam-permissions.py`: split `iam:PassRole` into its own statement with `iam:PassedToService` condition (lambda, cloudformation, apigateway); replaced wildcard `arn:aws:iam::*:role/` with explicit account ID; `ACCOUNT_ID` reads from `AWS_ACCOUNT_ID` env var with fallback
- `fix-pi-ssm-permission.py`: same `ACCOUNT_ID` env-var fix