### PR TITLE
fix(iam): extend Bedrock IAM resources to cover cross-region inference

### DIFF
--- a/sst.config.ts
+++ b/sst.config.ts
@@ -140,7 +140,11 @@ export default {
           // The us.* prefix is required for cross-region inference profiles.
           actions: ["bedrock:InvokeModel", "bedrock:Converse"],
           resources: [
+            // Foundation model — all US regions (cross-region inference routes through any of these)
             "arn:aws:bedrock:us-east-1::foundation-model/anthropic.claude-3-5-haiku-20241022-v1:0",
+            "arn:aws:bedrock:us-east-2::foundation-model/anthropic.claude-3-5-haiku-20241022-v1:0",
+            "arn:aws:bedrock:us-west-2::foundation-model/anthropic.claude-3-5-haiku-20241022-v1:0",
+            // Cross-region inference profile (us.* prefix routes to any US region)
             "arn:aws:bedrock:us-east-1:278585680617:inference-profile/us.anthropic.claude-3-5-haiku-20241022-v1:0",
           ],
         },


### PR DESCRIPTION
## Root cause

CloudWatch alarm `SERVERLESS-APP_MAIN-Errors` fired due to `AccessDeniedException` on Bedrock chat invocations.

The Lambda role had `bedrock:InvokeModel` scoped only to `us-east-1` resources. However, the model ID `us.anthropic.claude-3-5-haiku-20241022-v1:0` uses the `us.*` cross-region inference prefix, which routes requests through any US Bedrock region (`us-east-1`, `us-east-2`, `us-west-2`). When Bedrock routed a request to `us-east-2`, the IAM policy had no matching resource and the call was denied.

## Fix

Added `us-east-2` and `us-west-2` foundation-model ARNs to the SST permission resources alongside the existing `us-east-1` entry. The inference-profile ARN already uses the account-level format which covers all regions.

## Error from logs
```
AccessDeniedException: User: arn:aws:sts::278585680617:assumed-role/cloudless-production-CloudlessSiteServerUseast1Role-shcxozkd/...
is not authorized to perform: bedrock:InvokeModel on resource:
arn:aws:bedrock:us-east-2::foundation-model/anthropic.claude-3-5-haiku-20241022-v1:0
```