### PR TITLE
chore: add pi-alert-api requirements.txt and pyrightconfig.json

### DIFF
--- a/infrastructure/pi-alert-api/requirements.txt
+++ b/infrastructure/pi-alert-api/requirements.txt
@@ -1,0 +1,7 @@
+fastapi==0.111.0
+uvicorn[standard]==0.29.0
+aiosqlite==0.20.0
+httpx==0.27.0
+pydantic==2.7.1
+websockets==12.0
+paho-mqtt==1.6.1

--- a/pyrightconfig.json
+++ b/pyrightconfig.json
@@ -1,0 +1,14 @@
+{
+  "exclude": [
+    "node_modules",
+    ".next",
+    ".sst"
+  ],
+  "ignore": [
+    "infrastructure/pi-alert-api",
+    "scripts/pi-routines",
+    "scripts/fix-pi-ssm-permission.py",
+    "scripts/grant-ci-iam-permissions.py"
+  ],
+  "pythonVersion": "3.11"
+}


### PR DESCRIPTION
## What

- `infrastructure/pi-alert-api/requirements.txt` — exact package versions from the live Pi alert-api (fastapi, uvicorn, httpx, pydantic, aiosqlite, websockets, paho-mqtt) so the image build is reproducible
- `pyrightconfig.json` — tells Pyright/Pylance to ignore Pi-only paths where third-party packages run on the Pi but aren't installed in the local dev environment

## Why

VS Code was showing reportMissingImports errors for httpx, fastapi, pydantic, and paho.mqtt.publish in pi-alert-api and pi-routines files. False positives — packages exist on the Pi but not locally. The ignore directive suppresses analysis for those paths without disabling any checks globally.