### PR TITLE
ci: add Codacy Security Scan workflow

### DIFF
--- a/.github/workflows/codacy.yml
+++ b/.github/workflows/codacy.yml
@@ -1,0 +1,54 @@
+name: Codacy Security Scan
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'src/**'
+      - '.github/workflows/codacy.yml'
+  pull_request:
+    branches: [main]
+    paths:
+      - 'src/**'
+      - '.github/workflows/codacy.yml'
+  workflow_dispatch:
+  schedule:
+    - cron: '29 15 * * 4' # Every Thursday at 15:29 UTC
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  codacy-security-scan:
+    name: Codacy Security Scan
+    runs-on: ${{ fromJSON(vars.RUNNER_GENERIC || '"ubuntu-latest"') }}
+    timeout-minutes: 15
+    permissions:
+      contents: read
+      security-events: write
+      actions: read
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Run Codacy Analysis CLI
+        uses: codacy/codacy-analysis-cli-action@d840f886c4bd4edc059706d09c6a1586111c540b
+        with:
+          verbose: true
+          output: results.sarif
+          format: sarif
+          gh-code-scanning-compat: true
+          max-allowed-issues: 2147483647
+
+      - name: Upload SARIF results
+        uses: github/codeql-action/upload-sarif@v4
+        with:
+          sarif_file: results.sarif


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/codacy.yml` — Codacy Analysis CLI runs on every push/PR touching `src/**`, plus a weekly Thursday schedule
- SARIF results uploaded to GitHub Advanced Security so findings appear in the Security tab alongside CodeQL
- No `CODACY_PROJECT_TOKEN` needed — omitted to use Codacy's default configurations (works for public repos without a token)

## Adjustments from the upstream template

| Change | Reason |
|---|---|
| Removed `project-token` | Not required for default-config public-repo runs |
| Added `workflow_dispatch` | On-demand runs without a push |
| Added `paths: src/**` filter | Skip runs on doc/config-only changes |
| Added `concurrency` group + cancel | Avoid duplicate in-flight runs |
| `checkout@v6`, `upload-sarif@v4` | Aligned with existing CI action versions |
| `runs-on: RUNNER_GENERIC` | Consistent with all other workflows |
| `timeout-minutes: 15` | Matches CodeQL workflow |

## Test plan

- [ ] Workflow appears under Actions tab after merge
- [ ] Manual `workflow_dispatch` run completes and uploads SARIF
- [ ] Findings (if any) appear in Security → Code scanning

🤖 Generated with [Claude Code](https://claude.com/claude-code)