### PR TITLE
fix(tests): restore truncated sw.js and slack test — regression from #264

### DIFF
--- a/__tests__/slack/slack-interactions-extended.test.ts
+++ b/__tests__/slack/slack-interactions-extended.test.ts
@@ -376,4 +376,14 @@ describe("view_submission: deploy-confirm-modal", () => {
     });
     verifyOk(payload);
 
-    await POST(makeRequest(
+    await POST(makeRequest(payload));
+    await new Promise((r) => setTimeout(r, 50));
+
+    const deployPost = mockFetch.mock.calls.find((c) =>
+      (c[0] as string).includes("chat.postMessage"),
+    );
+    expect(deployPost![1].body as string).toContain("U777");
+
+    delete process.env.GITHUB_TOKEN;
+  });
+});


### PR DESCRIPTION
## Summary

PR #264 accidentally committed both files truncated mid-statement (no newline at EOF, content cut off), which broke all unit test runs that import those files:

- `public/sw.js` — ended at `event.wait` (missing the entire `notificationclick` handler body)
- `__tests__/slack/slack-interactions-extended.test.ts` — ended at `await POST(makeRequest(` (missing the last 11 lines: assertions, cleanup, and closing braces)

Restores the complete content in both files. The security fixes from #264 (origin check in the SW `message` handler, URL path checks in test assertions) are preserved.

## Test plan

- [ ] `pnpm test:ci` passes (Unit Tests check green)
- [ ] `public/sw.js` syntax is valid — no `Unexpected end of input` error in sw-runtime tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)