### PR TITLE
fix: restore truncated slack-interactions-extended.test.ts

### DIFF
--- a/__tests__/slack/slack-interactions-extended.test.ts
+++ b/__tests__/slack/slack-interactions-extended.test.ts
@@ -376,4 +376,14 @@ describe("view_submission: deploy-confirm-modal", () => {
     });
     verifyOk(payload);
 
-    await POST(makeRequest(
+    await POST(makeRequest(payload));
+    await new Promise((r) => setTimeout(r, 50));
+
+    const deployPost = mockFetch.mock.calls.find((c) =>
+      (c[0] as string).includes("chat.postMessage"),
+    );
+    expect(deployPost![1].body as string).toContain("U777");
+
+    delete process.env.GITHUB_TOKEN;
+  });
+});


### PR DESCRIPTION
CodeQL commit eef5f8f3 truncated this file at line 378, cutting the last 8 lines. Fixes PARSE_ERROR 'Expected ) but found EOF' causing 0 tests to run.