### PR TITLE
fix(hydration): disable SSR for ChatWidget - fixes React #418 on homepage

### DIFF
--- a/src/app/[locale]/layout.tsx
+++ b/src/app/[locale]/layout.tsx
@@ -16,7 +16,7 @@ import CookieConsent from "@/components/CookieConsent";
 import GoogleAnalyticsConsent from "@/components/GoogleAnalyticsConsent";
 
 const CartSlideOver = dynamic(() => import("@/components/store/CartSlideOver"));
-const ChatWidget = dynamic(() => import("@/components/ChatWidget"));
+const ChatWidget = dynamic(() => import("@/components/ChatWidget"), { ssr: false });
 import ClientDecorators from "@/components/ClientDecorators";
 
 type Props = {

--- a/src/components/ChatWidget.tsx
+++ b/src/components/ChatWidget.tsx
@@ -21,9 +21,9 @@ const SUGGESTIONS = [
 
 export default function ChatWidget() {
   const [open, setOpen] = useState(false);
-  const [messages, setMessages] = useState<Message[]>([
+  const [messages, setMessages] = useState<Message[]>(() => [
     {
-      id: newId(),
+      id: "initial-assistant-msg",
       role: "assistant",
       content:
         "Hi! I'm the Cloudless assistant. Ask me anything about our cloud, serverless, or AI marketing services.",


### PR DESCRIPTION
## Problem

React error #418 (hydration mismatch) was firing on every homepage load, breaking two k3s standby E2E tests:
- `assets.spec.ts:47` — *no fatal page errors on homepage load* (captures `pageerror` events)
- `style.spec.ts:169` — *footer is rendered on live app* (DOM detaches due to React re-render triggered by hydration error)

### Root cause

`ChatWidget` was imported with `dynamic(() => import(...))` — **without `{ ssr: false }`** — so Next.js SSR'd it on the server. The component's `useState` initialiser called `crypto.randomUUID()` in the render phase:

```ts
const [messages, setMessages] = useState<Message[]>([
  { id: newId(), ... }  // different UUID on server vs client
]);
```

Server rendered UUID-A; client hydration rendered UUID-B. React saw mismatched virtual DOM keys, threw hydration error #418 (`args[]=text&args[]=`), triggered a full re-render, and detached the footer from the DOM.

## Fix

1. Add `{ ssr: false }` to the `ChatWidget` dynamic import in `layout.tsx` — widget is client-only, SSR provides no benefit.
2. Replace the unstable `newId()` initialiser with a stable literal id `'initial-assistant-msg'` — the initial message is a singleton, so a stable key is correct and avoids any future similar issue.

## Pattern used in this project

`TrainingBanner` and `HubSpotScript` both had identical bugs (documented in their comments) and were already fixed. This fix uses `ssr: false` since `ChatWidget` has no SEO value.

## Tests

E2E tests `assets.spec.ts:47` and `style.spec.ts:169` should pass once CI deploys this build to the k3s standby cluster.
