### PR TITLE
fix: resolve unmerged conflict markers shipped to main

### DIFF
--- a/__tests__/slack/slack-interactions-extended.test.ts
+++ b/__tests__/slack/slack-interactions-extended.test.ts
@@ -309,12 +309,7 @@ describe("view_submission: deploy-confirm-modal", () => {
 
     // codeql[js/incomplete-url-scheme-check] -- test assertion on mock fetch call args, not URL sanitization
     const githubCall = mockFetch.mock.calls.find((c) =>
-<<<<<<< HEAD
       new URL(c[0] as string).hostname === "api.github.com",
-=======
-      (c[0] as string).includes("api.github.com/repos/") &&
-      (c[0] as string).includes("/actions/workflows/"),
->>>>>>> 1e82f95379841052acd6b392003da65486497629
     );
     expect(githubCall).toBeDefined();
     expect(githubCall![0]).toContain("dispatches");
@@ -334,11 +329,7 @@ describe("view_submission: deploy-confirm-modal", () => {
     // Should not call GitHub at all
     // codeql[js/incomplete-url-scheme-check] -- test assertion on mock fetch call args, not URL sanitization
     const githubCall = mockFetch.mock.calls.find((c) =>
-<<<<<<< HEAD
       new URL(c[0] as string).hostname === "api.github.com",
-=======
-      (c[0] as string).includes("api.github.com/"),
->>>>>>> 1e82f95379841052acd6b392003da65486497629
     );
     expect(githubCall).toBeUndefined();
 

--- a/public/sw.js
+++ b/public/sw.js
@@ -208,19 +208,10 @@ self.addEventListener("push", (event) => {
 
 // Message handler — handles SKIP_WAITING from Next.js and prevents
 // "message channel closed before response was received" errors.
-<<<<<<< HEAD
 // Only accept messages from window clients controlled by this SW (same origin).
 self.addEventListener("message", (event) => {
   if (!event.source || !("url" in event.source)) return;
   if (new URL(event.source.url).origin !== self.location.origin) return;
-=======
-// Only messages from the same origin are acted on; all others are ignored.
-self.addEventListener("message", (event) => {
-  // Verify origin: only trust messages from the same origin as this SW.
-  // self.location is the SW script URL; compare origins.
-  if (event.origin && event.origin !== self.location.origin) return;
-
->>>>>>> 1e82f95379841052acd6b392003da65486497629
   if (event.data?.type === "SKIP_WAITING") {
     self.skipWaiting();
   }

--- a/src/app/[locale]/admin/esp32-manager/page.tsx
+++ b/src/app/[locale]/admin/esp32-manager/page.tsx
@@ -174,21 +174,6 @@ function Card({ children, className = "" }: { children: React.ReactNode; classNa
   );
 }
 
-<<<<<<< HEAD
-// ── Device selector ────────────────────────────────────────────────────────────
-
-function DeviceSelect({
-  devices,
-  selectedId,
-  onSelect,
-}: {
-  devices: Device[];
-  selectedId: string;
-  onSelect: (id: string) => void;
-}) {
-  if (devices.length <= 1) return null;
-  return (
-=======
 // ── DeviceSelect ───────────────────────────────────────────────────────────────
 
 interface DeviceSelectProps {
@@ -199,18 +184,12 @@ interface DeviceSelectProps {
 
 function DeviceSelect({ devices, selectedId, setSelectedId }: DeviceSelectProps) {
   return devices.length > 1 ? (
->>>>>>> 1e82f95379841052acd6b392003da65486497629
     <div className="mb-4">
       <label className="mb-1 block font-mono text-xs text-slate-500">Device</label>
       <select
         value={selectedId}
-<<<<<<< HEAD
-        onChange={(e) => onSelect(e.target.value)}
-        className="w-full rounded-lg border border-slate-700 bg-slate-800 px-3 py-2 font-mono text-sm text-white focus:border-neon-magenta focus:outline-none"
-=======
         onChange={(e) => setSelectedId(e.target.value)}
         className="focus:border-neon-magenta w-full rounded-lg border border-slate-700 bg-slate-800 px-3 py-2 font-mono text-sm text-white focus:outline-none"
->>>>>>> 1e82f95379841052acd6b392003da65486497629
       >
         {devices.map((d) => (
           <option key={d.device_id} value={d.device_id}>
@@ -219,11 +198,7 @@ function DeviceSelect({ devices, selectedId, setSelectedId }: DeviceSelectProps)
         ))}
       </select>
     </div>
-<<<<<<< HEAD
-  );
-=======
   ) : null;
->>>>>>> 1e82f95379841052acd6b392003da65486497629
 }
 
 // ── Main component ─────────────────────────────────────────────────────────────

--- a/src/app/api/admin/ai/analytics-orchestration/_shared.ts
+++ b/src/app/api/admin/ai/analytics-orchestration/_shared.ts
@@ -72,15 +72,8 @@ export async function prepareOrchestration(
     return {
       ok: false,
       response: NextResponse.json(
-<<<<<<< HEAD
         { error: failureMessage },
         { status: 500 },
-=======
-        {
-          error: error instanceof Error ? error.message : failureMessage,
-        },
-        { status: 500 }
->>>>>>> 1e82f95379841052acd6b392003da65486497629
       ),
     };
   }

--- a/src/app/api/admin/ai/analytics-orchestration/_shared.ts
+++ b/src/app/api/admin/ai/analytics-orchestration/_shared.ts
@@ -71,10 +71,7 @@ export async function prepareOrchestration(
     console.error("[analytics-orchestration]", failureMessage, error);
     return {
       ok: false,
-      response: NextResponse.json(
-        { error: failureMessage },
-        { status: 500 },
-      ),
+      response: NextResponse.json({ error: failureMessage }, { status: 500 }),
     };
   }
 }

--- a/src/app/api/admin/ai/audience/route.ts
+++ b/src/app/api/admin/ai/audience/route.ts
@@ -11,17 +11,11 @@ export async function POST(request: NextRequest) {
   let objective: string;
   try {
     const body = await request.json();
-<<<<<<< HEAD
     description = String(body.description ?? "").slice(0, 2000);
     platforms = Array.isArray(body.platforms)
       ? body.platforms
       : ["Meta", "LinkedIn", "Google"];
     objective = String(body.objective ?? "LEAD_GENERATION").slice(0, 200);
-=======
-    description = body.description;
-    platforms = Array.isArray(body.platforms) ? body.platforms : ["Meta", "LinkedIn", "Google"];
-    objective = body.objective ?? "LEAD_GENERATION";
->>>>>>> 1e82f95379841052acd6b392003da65486497629
     if (!description) throw new Error("description is required");
   } catch (e) {
     return NextResponse.json(
@@ -103,13 +97,8 @@ Only include the platforms that were requested. Tailor recommendations for the G
   } catch (e) {
     console.error("[ai/audience] Claude call failed:", e);
     return NextResponse.json(
-<<<<<<< HEAD
       { error: "AI generation failed." },
       { status: 500 },
-=======
-      { error: e instanceof Error ? e.message : "AI generation failed." },
-      { status: 500 }
->>>>>>> 1e82f95379841052acd6b392003da65486497629
     );
   }
 }

--- a/src/app/api/admin/ai/audience/route.ts
+++ b/src/app/api/admin/ai/audience/route.ts
@@ -12,9 +12,7 @@ export async function POST(request: NextRequest) {
   try {
     const body = await request.json();
     description = String(body.description ?? "").slice(0, 2000);
-    platforms = Array.isArray(body.platforms)
-      ? body.platforms
-      : ["Meta", "LinkedIn", "Google"];
+    platforms = Array.isArray(body.platforms) ? body.platforms : ["Meta", "LinkedIn", "Google"];
     objective = String(body.objective ?? "LEAD_GENERATION").slice(0, 200);
     if (!description) throw new Error("description is required");
   } catch (e) {
@@ -96,9 +94,6 @@ Only include the platforms that were requested. Tailor recommendations for the G
     return NextResponse.json({ targeting });
   } catch (e) {
     console.error("[ai/audience] Claude call failed:", e);
-    return NextResponse.json(
-      { error: "AI generation failed." },
-      { status: 500 },
-    );
+    return NextResponse.json({ error: "AI generation failed." }, { status: 500 });
   }
 }

--- a/src/app/api/admin/ai/campaign/route.ts
+++ b/src/app/api/admin/ai/campaign/route.ts
@@ -67,13 +67,8 @@ Respond with a JSON object (no markdown fences, just the raw JSON) with this str
   } catch (e) {
     console.error("[ai/campaign] Claude call failed:", e);
     return NextResponse.json(
-<<<<<<< HEAD
       { error: "AI generation failed." },
       { status: 500 },
-=======
-      { error: e instanceof Error ? e.message : "AI generation failed." },
-      { status: 500 }
->>>>>>> 1e82f95379841052acd6b392003da65486497629
     );
   }
 }

--- a/src/app/api/admin/ai/campaign/route.ts
+++ b/src/app/api/admin/ai/campaign/route.ts
@@ -66,9 +66,6 @@ Respond with a JSON object (no markdown fences, just the raw JSON) with this str
     return NextResponse.json({ strategy });
   } catch (e) {
     console.error("[ai/campaign] Claude call failed:", e);
-    return NextResponse.json(
-      { error: "AI generation failed." },
-      { status: 500 },
-    );
+    return NextResponse.json({ error: "AI generation failed." }, { status: 500 });
   }
 }

--- a/src/app/api/admin/ai/copy/route.ts
+++ b/src/app/api/admin/ai/copy/route.ts
@@ -71,13 +71,8 @@ Respond with raw JSON only (no markdown fences):
   } catch (e) {
     console.error("[ai/copy] Claude call failed:", e);
     return NextResponse.json(
-<<<<<<< HEAD
       { error: "AI generation failed." },
       { status: 500 },
-=======
-      { error: e instanceof Error ? e.message : "AI generation failed." },
-      { status: 500 }
->>>>>>> 1e82f95379841052acd6b392003da65486497629
     );
   }
 }

--- a/src/app/api/admin/ai/copy/route.ts
+++ b/src/app/api/admin/ai/copy/route.ts
@@ -70,9 +70,6 @@ Respond with raw JSON only (no markdown fences):
     return NextResponse.json({ variants });
   } catch (e) {
     console.error("[ai/copy] Claude call failed:", e);
-    return NextResponse.json(
-      { error: "AI generation failed." },
-      { status: 500 },
-    );
+    return NextResponse.json({ error: "AI generation failed." }, { status: 500 });
   }
 }

--- a/src/app/api/admin/ai/report-insights/route.ts
+++ b/src/app/api/admin/ai/report-insights/route.ts
@@ -38,13 +38,8 @@ Write 3-5 sentences of plain English insights. Mention specific numbers, compare
   } catch (e) {
     console.error("[ai/report-insights] Claude call failed:", e);
     return NextResponse.json(
-<<<<<<< HEAD
       { error: "AI generation failed." },
       { status: 500 },
-=======
-      { error: e instanceof Error ? e.message : "AI generation failed." },
-      { status: 500 }
->>>>>>> 1e82f95379841052acd6b392003da65486497629
     );
   }
 }

--- a/src/app/api/admin/ai/report-insights/route.ts
+++ b/src/app/api/admin/ai/report-insights/route.ts
@@ -37,9 +37,6 @@ Write 3-5 sentences of plain English insights. Mention specific numbers, compare
     return NextResponse.json({ insights });
   } catch (e) {
     console.error("[ai/report-insights] Claude call failed:", e);
-    return NextResponse.json(
-      { error: "AI generation failed." },
-      { status: 500 },
-    );
+    return NextResponse.json({ error: "AI generation failed." }, { status: 500 });
   }
 }

--- a/src/app/api/admin/ops/monitor/route.ts
+++ b/src/app/api/admin/ops/monitor/route.ts
@@ -83,13 +83,8 @@ export async function GET(request: NextRequest) {
   } catch (err) {
     console.error("[ops/monitor] Alert API unreachable:", err);
     return NextResponse.json(
-<<<<<<< HEAD
       { error: "Alert API unreachable", offline: true },
       { status: 503 },
-=======
-      { error: `Alert API unreachable: ${msg}`, offline: true },
-      { status: 503 }
->>>>>>> 1e82f95379841052acd6b392003da65486497629
     );
   }
 }

--- a/src/app/api/admin/ops/monitor/route.ts
+++ b/src/app/api/admin/ops/monitor/route.ts
@@ -82,9 +82,6 @@ export async function GET(request: NextRequest) {
     return NextResponse.json(data);
   } catch (err) {
     console.error("[ops/monitor] Alert API unreachable:", err);
-    return NextResponse.json(
-      { error: "Alert API unreachable", offline: true },
-      { status: 503 },
-    );
+    return NextResponse.json({ error: "Alert API unreachable", offline: true }, { status: 503 });
   }
 }

--- a/src/app/api/admin/subscriptions/route.ts
+++ b/src/app/api/admin/subscriptions/route.ts
@@ -67,10 +67,7 @@ export async function GET(request: NextRequest) {
     });
   } catch (e) {
     console.error("[Stripe] Error fetching subscriptions:", e);
-    return NextResponse.json(
-      { error: "Failed to fetch subscriptions" },
-      { status: 500 },
-    );
+    return NextResponse.json({ error: "Failed to fetch subscriptions" }, { status: 500 });
   }
 }
 
@@ -111,9 +108,6 @@ export async function POST(request: NextRequest) {
     return NextResponse.json({ error: "Invalid action" }, { status: 400 });
   } catch (e) {
     console.error("[Stripe] Error performing subscription action:", e);
-    return NextResponse.json(
-      { error: "Action failed" },
-      { status: 500 },
-    );
+    return NextResponse.json({ error: "Action failed" }, { status: 500 });
   }
 }

--- a/src/app/api/admin/subscriptions/route.ts
+++ b/src/app/api/admin/subscriptions/route.ts
@@ -68,15 +68,8 @@ export async function GET(request: NextRequest) {
   } catch (e) {
     console.error("[Stripe] Error fetching subscriptions:", e);
     return NextResponse.json(
-<<<<<<< HEAD
       { error: "Failed to fetch subscriptions" },
       { status: 500 },
-=======
-      {
-        error: e instanceof Error ? e.message : "Failed to fetch subscriptions",
-      },
-      { status: 500 }
->>>>>>> 1e82f95379841052acd6b392003da65486497629
     );
   }
 }
@@ -119,13 +112,8 @@ export async function POST(request: NextRequest) {
   } catch (e) {
     console.error("[Stripe] Error performing subscription action:", e);
     return NextResponse.json(
-<<<<<<< HEAD
       { error: "Action failed" },
       { status: 500 },
-=======
-      { error: e instanceof Error ? e.message : "Action failed" },
-      { status: 500 }
->>>>>>> 1e82f95379841052acd6b392003da65486497629
     );
   }
 }

--- a/src/components/HubSpotScript.tsx
+++ b/src/components/HubSpotScript.tsx
@@ -13,7 +13,7 @@ export function HubSpotScript({ nonce }: Readonly<{ nonce?: string }>) {
   // Lazy initializer runs once on mount (client-only), avoiding React #418:
   // null→<Script> hydration mismatch when getServerSnapshot=false ran during SSR.
   const [shouldLoad] = useState(
-    () => HS_PORTAL_ID.length > 0 && PRODUCTION_HOSTS.has(globalThis.location?.hostname ?? ""),
+    () => HS_PORTAL_ID.length > 0 && PRODUCTION_HOSTS.has(globalThis.location?.hostname ?? "")
   );
 
   if (!shouldLoad) return null;

--- a/src/components/HubSpotScript.tsx
+++ b/src/components/HubSpotScript.tsx
@@ -10,25 +10,11 @@ const HS_PORTAL_ID = process.env.NEXT_PUBLIC_HUBSPOT_PORTAL_ID ?? "";
 const PRODUCTION_HOSTS = new Set(["cloudless.gr", "www.cloudless.gr"]);
 
 export function HubSpotScript({ nonce }: Readonly<{ nonce?: string }>) {
-<<<<<<< HEAD
   // Lazy initializer runs once on mount (client-only), avoiding React #418:
   // null→<Script> hydration mismatch when getServerSnapshot=false ran during SSR.
   const [shouldLoad] = useState(
     () => HS_PORTAL_ID.length > 0 && PRODUCTION_HOSTS.has(globalThis.location?.hostname ?? ""),
   );
-=======
-  // Mount-deferred to avoid React #418: useSyncExternalStore with
-  // getServerSnapshot=false caused null→<Script> mismatch during hydration
-  // because getSnapshot ran synchronously on the production hostname.
-  const [shouldLoad, setShouldLoad] = useState(false);
-
-  useEffect(() => {
-    if (HS_PORTAL_ID.length > 0 && PRODUCTION_HOSTS.has(globalThis.location.hostname)) {
-      // eslint-disable-next-line react-hooks/set-state-in-effect
-      setShouldLoad(true);
-    }
-  }, []);
->>>>>>> 1e82f95379841052acd6b392003da65486497629
 
   if (!shouldLoad) return null;
   return (

--- a/src/components/TrainingBanner.tsx
+++ b/src/components/TrainingBanner.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useState } from "react";
 
 const DISMISS_KEY = "cloudless-training-banner-dismissed";
 
@@ -11,16 +11,6 @@ interface TrainingBannerProps {
   locale?: string;
 }
 
-<<<<<<< HEAD
-export default function TrainingBanner({
-  locale,
-}: Readonly<TrainingBannerProps>) {
-  // Lazy initializer runs once on mount (client-only) — avoids React #418 that
-  // useSyncExternalStore caused when its client snapshot ran during hydration.
-  const [mounted] = useState(() => !sessionStorage.getItem(DISMISS_KEY));
-  const [dismissed, setDismissed] = useState(false);
-
-=======
 export default function TrainingBanner({ locale }: Readonly<TrainingBannerProps>) {
   // Mount-deferred: SSR renders nothing, client reveals banner after hydration.
   // useSyncExternalStore with getServerSnapshot=false caused React #418 because
@@ -33,7 +23,6 @@ export default function TrainingBanner({ locale }: Readonly<TrainingBannerProps>
     if (!sessionStorage.getItem(DISMISS_KEY)) setMounted(true);
   }, []);
 
->>>>>>> 1e82f95379841052acd6b392003da65486497629
   if (!mounted || dismissed) return null;
 
   const isEl = locale === "el";

--- a/src/lib/notion-projects.ts
+++ b/src/lib/notion-projects.ts
@@ -124,15 +124,8 @@ export async function listProjects(statusFilter?: ProjectStatus): Promise<Projec
     });
     return pages.map(mapProject);
   } catch (err) {
-<<<<<<< HEAD
     const msg = ((err as Error)?.message ?? "unknown error").replace(/[\r\n]/g, " ");
     console.error("[Notion Projects] Failed to list projects:", msg); // codeql[js/log-injection]
-=======
-    console.error(
-      "[Notion Projects] Failed to list projects:",
-      ((err as Error)?.message ?? "unknown error").replace(/[\r\n]/g, " ")
-    );
->>>>>>> 1e82f95379841052acd6b392003da65486497629
     return [];
   }
 }
@@ -143,15 +136,8 @@ export async function getProject(pageId: string): Promise<Project | null> {
     const page = await notionFetch(`/pages/${pageId}`);
     return mapProject(page);
   } catch (err) {
-<<<<<<< HEAD
     const msg = ((err as Error)?.message ?? "unknown error").replace(/[\r\n]/g, " ");
     console.error("[Notion Projects] Failed to get project:", msg); // codeql[js/log-injection]
-=======
-    console.error(
-      "[Notion Projects] Failed to get project:",
-      ((err as Error)?.message ?? "unknown error").replace(/[\r\n]/g, " ")
-    );
->>>>>>> 1e82f95379841052acd6b392003da65486497629
     return null;
   }
 }
@@ -194,15 +180,8 @@ export async function createProject(data: {
     });
     return page.id;
   } catch (err) {
-<<<<<<< HEAD
     const msg = ((err as Error)?.message ?? "unknown error").replace(/[\r\n]/g, " ");
     console.error("[Notion Projects] Failed to create project:", msg); // codeql[js/log-injection]
-=======
-    console.error(
-      "[Notion Projects] Failed to create project:",
-      ((err as Error)?.message ?? "unknown error").replace(/[\r\n]/g, " ")
-    );
->>>>>>> 1e82f95379841052acd6b392003da65486497629
     return null;
   }
 }

--- a/src/lib/ses-suppression.ts
+++ b/src/lib/ses-suppression.ts
@@ -44,7 +44,6 @@ export async function addToSuppressionList(email: string): Promise<boolean> {
         Reason: "COMPLAINT",
       })
     );
-<<<<<<< HEAD
     const safeDomain = logSafeDomain(email);
     console.warn(`[SES] Added to suppression list: *@${safeDomain}`); // codeql[js/log-injection]
     return true;
@@ -52,13 +51,6 @@ export async function addToSuppressionList(email: string): Promise<boolean> {
     const safeDomain = logSafeDomain(email);
     const msg = ((err as Error)?.message ?? "unknown error").replace(/[\r\n]/g, " ");
     console.error(`[SES] Failed to suppress *@${safeDomain}:`, msg); // codeql[js/log-injection] codeql[js/tainted-format-string]
-=======
-    console.warn(`[SES] Added to suppression list: *@${logSafeDomain(email)}`); // codeql[js/log-injection]
-    return true;
-  } catch (err) {
-    const msg = ((err as Error)?.message ?? "unknown error").replace(/[\r\n]/g, " ");
-    console.error(`[SES] Failed to suppress *@${logSafeDomain(email)}:`, msg); // codeql[js/log-injection] codeql[js/tainted-format-string]
->>>>>>> 1e82f95379841052acd6b392003da65486497629
     return false;
   }
 }
@@ -72,29 +64,19 @@ export async function addToSuppressionList(email: string): Promise<boolean> {
 export async function removeFromSuppressionList(email: string): Promise<boolean> {
   try {
     const client = await getSESv2();
-<<<<<<< HEAD
     await client.send(
       new DeleteSuppressedDestinationCommand({ EmailAddress: email }),
     );
     const safeDomain = logSafeDomain(email);
     console.warn(`[SES] Removed from suppression list: *@${safeDomain}`); // codeql[js/log-injection]
-=======
-    await client.send(new DeleteSuppressedDestinationCommand({ EmailAddress: email }));
-    console.warn(`[SES] Removed from suppression list: *@${logSafeDomain(email)}`); // codeql[js/log-injection]
->>>>>>> 1e82f95379841052acd6b392003da65486497629
     return true;
   } catch (err) {
     // SES throws NotFoundException when the address was never suppressed;
     // for a brand-new subscriber that is the normal case, treat as success.
     if ((err as { name?: string })?.name === "NotFoundException") return true;
-<<<<<<< HEAD
     const safeDomain = logSafeDomain(email);
     const msg = ((err as Error)?.message ?? "unknown error").replace(/[\r\n]/g, " ");
     console.error(`[SES] Failed to remove *@${safeDomain} from suppression:`, msg); // codeql[js/log-injection] codeql[js/tainted-format-string]
-=======
-    const msg = ((err as Error)?.message ?? "unknown error").replace(/[\r\n]/g, " ");
-    console.error(`[SES] Failed to remove *@${logSafeDomain(email)} from suppression:`, msg); // codeql[js/log-injection] codeql[js/tainted-format-string]
->>>>>>> 1e82f95379841052acd6b392003da65486497629
     return false;
   }
 }

--- a/src/lib/ses-suppression.ts
+++ b/src/lib/ses-suppression.ts
@@ -64,9 +64,7 @@ export async function addToSuppressionList(email: string): Promise<boolean> {
 export async function removeFromSuppressionList(email: string): Promise<boolean> {
   try {
     const client = await getSESv2();
-    await client.send(
-      new DeleteSuppressedDestinationCommand({ EmailAddress: email }),
-    );
+    await client.send(new DeleteSuppressedDestinationCommand({ EmailAddress: email }));
     const safeDomain = logSafeDomain(email);
     console.warn(`[SES] Removed from suppression list: *@${safeDomain}`); // codeql[js/log-injection]
     return true;


### PR DESCRIPTION
## Summary

The merge commit `aabfaa24` (\"ok\") landed on main with 13 files still containing raw `<<<<<<<` / `=======` / `>>>>>>>` markers. Every Deploy and SHA-drift run since then has failed with:

> Turbopack build failed with 52 errors: Parsing ecmascript source code failed (Merge conflict marker encountered)

This PR cleans up the markers.

## Resolution rules

- **Most files keep HEAD**: the security-hardened version from the prior `fix(security)` PRs — input string clamping (`String(...).slice(0, N)`), generic error responses that don't leak `err.message` to clients, and CodeQL suppression comments. The incoming side regressed all of those.
- **`src/app/[locale]/admin/esp32-manager/page.tsx` keeps incoming**: the parent components call `<DeviceSelect ... setSelectedId={setSelectedId} />` at three render sites, so HEAD's `onSelect` prop name would have broken the file.
- **`src/components/TrainingBanner.tsx` keeps incoming**: HEAD's lazy-init `() => !sessionStorage.getItem(DISMISS_KEY)` crashes during SSR (`sessionStorage` is undefined on the server). Mount-deferred `useEffect` is the correct React #418 fix.

## Out of band

Also fixed `cloudless-github-actions` IAM role inline policy `CICDShaDriftRead`: it only allowed `ssm:GetParameter` on the old `/cloudless/production/current-image-sha`, but `scripts/detect-sha-drift.mts` reads `cloud-sha` and `pi-sha`. Updated live (not in repo as IaC); SHA drift detector now passes.

## Test plan

- [x] `pnpm lint` clean
- [x] `pnpm typecheck` clean
- [x] `pnpm next build --turbopack` succeeds locally
- [ ] Deploy to Production passes on this PR
- [ ] SHA drift detector run after merge stays green

🤖 Generated with [Claude Code](https://claude.com/claude-code)