### PR TITLE
fix(ci): mirror provenance/sbom fix into deploy-pi.yml

### DIFF
--- a/.github/workflows/deploy-pi.yml
+++ b/.github/workflows/deploy-pi.yml
@@ -104,6 +104,11 @@ jobs:
           tags: ${{ env.ECR_REGISTRY }}/${{ env.ECR_REPOSITORY }}:${{ steps.check_ecr.outputs.short_sha }}
           cache-from: type=local,src=/opt/docker-cache
           cache-to: type=local,dest=/opt/docker-cache,mode=max
+          # Disable provenance/SBOM attestation manifests — they require a
+          # separate Buildx session push that times out on the Pi runner when
+          # ECR is slow (no active session / context deadline exceeded).
+          provenance: false
+          sbom: false
           build-args: |
             NEXT_PUBLIC_SITE_URL=${{ secrets.NEXT_PUBLIC_SITE_URL }}
             NEXT_PUBLIC_STAGE=production


### PR DESCRIPTION
## Summary

deploy-pi.yml's Build and push step was missing the \`provenance: false\` / \`sbom: false\` settings that build-pi-image.yml got in fa65262d. The attestation manifest push opens a second Buildx session that times out on the Pi runner when ECR is slow, failing the deploy with:

> ERROR: failed to push ...: no active session ...: context deadline exceeded

Both Pi build pipelines should behave identically.

## Test plan

- [ ] Next Pi deploy after merge completes the push step without session timeout

🤖 Generated with [Claude Code](https://claude.com/claude-code)