### PR TITLE
fix(css): restore Prettier formatting on theme-v2.css gradient

### DIFF
--- a/src/app/theme-v2.css
+++ b/src/app/theme-v2.css
@@ -68,8 +68,7 @@
   --gradient-hero:
     radial-gradient(circle at 20% 0%, #d6f0f6 0%, transparent 50%),
     radial-gradient(circle at 80% 10%, #e3e9ff 0%, transparent 50%),
-    radial-gradient(circle at 50% 100%, #fbf8ff 0%, transparent 60%),
-    var(--surface-canvas);
+    radial-gradient(circle at 50% 100%, #fbf8ff 0%, transparent 60%), var(--surface-canvas);
 }
 
 /* ──────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- PR #281 introduced a Stylelint-targeted line break in `--gradient-hero` that conflicts with Prettier's `printWidth` rule.
- Prettier is the merge-gating check (Lint & Format), so its formatting wins.
- The `srgb` → `sRGB` casing change is preserved (Prettier doesn't touch value keywords).

Main's Lint & Format would currently fail on this file; this PR restores green.

## Test plan
- [x] `pnpm exec prettier --check src/app/theme-v2.css` passes locally
- [ ] Lint & Format CI passes