### PR TITLE
fix: prettier-format 4 files left unformatted by #283/#284

### DIFF
--- a/__tests__/components.test.tsx
+++ b/__tests__/components.test.tsx
@@ -223,7 +223,7 @@ describe("Navbar", () => {
     fireEvent.click(view.getByLabelText("Toggle menu"));
 
     // Mobile menu should be visible (opacity-100)
-    const mobileMenu = container.querySelector(".lg\\:hidden.bg-void\\/95");
+    const mobileMenu = container.querySelector(".lg\\:hidden.overflow-x-hidden");
     expect(mobileMenu?.className).toContain("opacity-100");
 
     // Cart row visible in mobile menu
@@ -243,7 +243,7 @@ describe("Navbar", () => {
     if (mobileLink) fireEvent.click(mobileLink);
 
     // Menu should be collapsed (opacity-0)
-    const mobileMenu = container.querySelector(".lg\\:hidden.bg-void\\/95");
+    const mobileMenu = container.querySelector(".lg\\:hidden.overflow-x-hidden");
     expect(mobileMenu?.className).toContain("opacity-0");  });
 
   it("renders Sign In CTA in both desktop and mobile when unauthenticated", () => {
@@ -261,7 +261,7 @@ describe("Navbar", () => {
     fireEvent.click(within(container).getByLabelText("Toggle menu"));
 
     // Mobile nav links should have min-h-[44px] or min-h-11 class (both equal 44px)
-    const mobileMenu = container.querySelector(".lg\\:hidden.bg-void\\/95");
+    const mobileMenu = container.querySelector(".lg\\:hidden.overflow-x-hidden");
     const links = mobileMenu?.querySelectorAll("a");
     const linksWithMinHeight = Array.from(links ?? []).filter(
       (a) => a.className.includes("min-h-[44px]") || a.className.includes("min-h-11"),

--- a/src/app/[locale]/page.tsx
+++ b/src/app/[locale]/page.tsx
@@ -199,10 +199,7 @@ export default async function Home({
       <JsonLd data={getFAQSchema(faqs)} />
 
       {/* ── Hero ── */}
-      <section
-        className="relative overflow-hidden"
-        style={{ background: "var(--gradient-hero)" }}
-      >
+      <section className="relative overflow-hidden" style={{ background: "var(--gradient-hero)" }}>
         <div className="relative z-10 mx-auto max-w-6xl px-6 py-20 md:py-28 lg:py-32">
           <div className="grid grid-cols-1 items-center gap-12 lg:grid-cols-2">
             {/* Left — copy */}
@@ -219,7 +216,10 @@ export default async function Home({
                 <span className="relative flex h-2 w-2">
                   <span
                     className="absolute inline-flex h-full w-full rounded-full opacity-75"
-                    style={{ background: "var(--success)", animation: "ping 2.4s cubic-bezier(0,0,0.2,1) infinite" }}
+                    style={{
+                      background: "var(--success)",
+                      animation: "ping 2.4s cubic-bezier(0,0,0.2,1) infinite",
+                    }}
                   />
                   <span
                     className="relative inline-flex h-2 w-2 rounded-full"
@@ -283,13 +283,15 @@ export default async function Home({
                 style={{ color: "var(--ink-muted)" }}
               >
                 <span>{t("hero.microCopy1", "No commitment. Actionable insights in 30 min.")}</span>
-                <span className="hidden sm:inline" style={{ color: "var(--border-strong)" }}>•</span>
+                <span className="hidden sm:inline" style={{ color: "var(--border-strong)" }}>
+                  •
+                </span>
                 <span>{t("hero.microCopy2", "Transparent pricing. No lock-in.")}</span>
               </div>
             </div>
 
             {/* Right — Grafana dashboard */}
-            <div className="animate-fade-in-up hidden lg:block delay-200">
+            <div className="animate-fade-in-up hidden delay-200 lg:block">
               <CloudCockpit />
             </div>
           </div>
@@ -333,10 +335,16 @@ export default async function Home({
                     {g.icon}
                   </span>
                   <div>
-                    <p className="font-mono text-sm font-semibold" style={{ color: "var(--ink-primary)" }}>
+                    <p
+                      className="font-mono text-sm font-semibold"
+                      style={{ color: "var(--ink-primary)" }}
+                    >
                       {g.title}
                     </p>
-                    <p className="mt-1 text-xs leading-relaxed" style={{ color: "var(--ink-muted)" }}>
+                    <p
+                      className="mt-1 text-xs leading-relaxed"
+                      style={{ color: "var(--ink-muted)" }}
+                    >
                       {g.desc}
                     </p>
                   </div>
@@ -528,10 +536,7 @@ export default async function Home({
       </section>
 
       {/* ── Services Overview ── */}
-      <section
-        className="py-20 lg:py-24"
-        style={{ background: "var(--surface-subtle)" }}
-      >
+      <section className="py-20 lg:py-24" style={{ background: "var(--surface-subtle)" }}>
         <div className="mx-auto max-w-6xl px-6">
           <ScrollReveal>
             <div className="mx-auto mb-12 max-w-2xl text-center">
@@ -593,7 +598,10 @@ export default async function Home({
                   <p className="mt-3 text-sm leading-relaxed" style={{ color: "var(--ink-body)" }}>
                     {service.description}
                   </p>
-                  <p className="mt-3 font-mono text-xs italic" style={{ color: "var(--ink-muted)" }}>
+                  <p
+                    className="mt-3 font-mono text-xs italic"
+                    style={{ color: "var(--ink-muted)" }}
+                  >
                     {service.perfectFor}
                   </p>
                 </div>
@@ -634,7 +642,10 @@ export default async function Home({
               <p className="mb-3 text-sm" style={{ color: "var(--ink-muted)" }}>
                 {t("leadCapture.notReady", "Not ready for a call? No problem.")}
               </p>
-              <p className="mb-4 font-mono text-sm font-semibold" style={{ color: "var(--ink-primary)" }}>
+              <p
+                className="mb-4 font-mono text-sm font-semibold"
+                style={{ color: "var(--ink-primary)" }}
+              >
                 {t(
                   "leadCapture.playbookTitle",
                   "Get our free Cloud Migration Playbook — the exact framework we use with clients."
@@ -678,7 +689,9 @@ export default async function Home({
                 style={{ color: "var(--ink-primary)" }}
               >
                 {t("faq.title", "Common")}{" "}
-                <span style={{ color: "var(--accent)" }}>{t("faq.titleHighlight", "questions")}</span>
+                <span style={{ color: "var(--accent)" }}>
+                  {t("faq.titleHighlight", "questions")}
+                </span>
               </h2>
             </div>
           </ScrollReveal>
@@ -728,10 +741,7 @@ export default async function Home({
       </section>
 
       {/* ── Founder ── */}
-      <section
-        className="py-20 lg:py-24"
-        style={{ background: "var(--surface-subtle)" }}
-      >
+      <section className="py-20 lg:py-24" style={{ background: "var(--surface-subtle)" }}>
         <div className="mx-auto max-w-4xl px-6">
           <ScrollReveal>
             <div className="mb-12 text-center">
@@ -746,7 +756,9 @@ export default async function Home({
                 style={{ color: "var(--ink-primary)" }}
               >
                 {t("founder.title", "Meet the")}{" "}
-                <span style={{ color: "var(--accent)" }}>{t("founder.titleHighlight", "founder")}</span>
+                <span style={{ color: "var(--accent)" }}>
+                  {t("founder.titleHighlight", "founder")}
+                </span>
               </h2>
             </div>
           </ScrollReveal>
@@ -776,7 +788,10 @@ export default async function Home({
                   </span>
                 </div>
                 <div className="flex-1 text-center md:text-left">
-                  <h3 className="font-heading text-xl font-bold" style={{ color: "var(--ink-primary)" }}>
+                  <h3
+                    className="font-heading text-xl font-bold"
+                    style={{ color: "var(--ink-primary)" }}
+                  >
                     {t("founder.name", "Themistoklis Baltzakis")}
                   </h3>
                   <p className="mt-1 font-mono text-sm" style={{ color: "var(--accent)" }}>
@@ -808,9 +823,7 @@ export default async function Home({
               style={{ color: "var(--ink-primary)" }}
             >
               {t("cta.title", "Ready to go")}{" "}
-              <span style={{ color: "var(--accent)" }}>
-                {t("cta.titleHighlight", "cloudless")}
-              </span>
+              <span style={{ color: "var(--accent)" }}>{t("cta.titleHighlight", "cloudless")}</span>
               ?
             </h2>
             <p className="mx-auto mb-4 max-w-xl text-xl" style={{ color: "var(--ink-body)" }}>

--- a/src/components/CloudCockpit.tsx
+++ b/src/components/CloudCockpit.tsx
@@ -39,7 +39,10 @@ function LiveDot({ color = T.ok }: { color?: string }) {
 function TimeSeries() {
   const series = useMemo(
     () => ({
-      p95: [14, 12, 13, 18, 15, 11, 12, 14, 22, 16, 13, 12, 10, 11, 13, 17, 14, 12, 11, 13, 19, 12, 11, 12],
+      p95: [
+        14, 12, 13, 18, 15, 11, 12, 14, 22, 16, 13, 12, 10, 11, 13, 17, 14, 12, 11, 13, 19, 12, 11,
+        12,
+      ],
       p50: [6, 5, 5, 7, 6, 5, 5, 6, 8, 7, 5, 5, 4, 5, 5, 7, 6, 5, 4, 5, 7, 5, 5, 5],
     }),
     []
@@ -57,8 +60,7 @@ function TimeSeries() {
   const yFor = (v: number) => H - padB - ((v - min) / (max - min)) * (H - padT - padB);
   const toPath = (arr: number[]) =>
     arr.map((v, i) => `${i === 0 ? "M" : "L"}${xFor(i)},${yFor(v)}`).join(" ");
-  const areaPath =
-    toPath(series.p95) + ` L${xFor(n - 1)},${H - padB} L${xFor(0)},${H - padB} Z`;
+  const areaPath = toPath(series.p95) + ` L${xFor(n - 1)},${H - padB} L${xFor(0)},${H - padB} Z`;
 
   const [cursor, setCursor] = useState(n - 1);
   useEffect(() => {
@@ -101,8 +103,26 @@ function TimeSeries() {
             textTransform: "none",
           }}
         >
-          <i style={{ width: 8, height: 8, borderRadius: 2, background: T.accent, display: "inline-block" }} /> p95
-          <i style={{ width: 8, height: 8, borderRadius: 2, background: T.secondary, display: "inline-block" }} /> p50
+          <i
+            style={{
+              width: 8,
+              height: 8,
+              borderRadius: 2,
+              background: T.accent,
+              display: "inline-block",
+            }}
+          />{" "}
+          p95
+          <i
+            style={{
+              width: 8,
+              height: 8,
+              borderRadius: 2,
+              background: T.secondary,
+              display: "inline-block",
+            }}
+          />{" "}
+          p50
         </span>
       </div>
       <svg width="100%" height={H} viewBox={`0 0 ${W} ${H}`} preserveAspectRatio="none">
@@ -144,7 +164,13 @@ function TimeSeries() {
         <text x={W - padR - 4} y={yFor(20) - 4} fontSize="9" textAnchor="end" fill={T.warn}>
           SLO 20ms
         </text>
-        <path d={toPath(series.p50)} fill="none" stroke={T.secondary} strokeWidth="1.3" strokeOpacity="0.85" />
+        <path
+          d={toPath(series.p50)}
+          fill="none"
+          stroke={T.secondary}
+          strokeWidth="1.3"
+          strokeOpacity="0.85"
+        />
         <path d={areaPath} fill="url(#cc-area)" />
         <path
           d={toPath(series.p95)}
@@ -154,7 +180,15 @@ function TimeSeries() {
           strokeLinecap="round"
           strokeLinejoin="round"
         />
-        <line x1={cx} x2={cx} y1={padT} y2={H - padB} stroke={T.gridAxis} strokeWidth="1" strokeDasharray="2 3" />
+        <line
+          x1={cx}
+          x2={cx}
+          y1={padT}
+          y2={H - padB}
+          stroke={T.gridAxis}
+          strokeWidth="1"
+          strokeDasharray="2 3"
+        />
         <circle cx={cx} cy={yFor(series.p95[cursor])} r="3" fill={T.accent} />
         <circle cx={cx} cy={yFor(series.p95[cursor])} r="6" fill={T.accent} opacity="0.20" />
         <g
@@ -229,11 +263,18 @@ export default function CloudCockpit() {
       >
         <div style={{ display: "flex", flexDirection: "column" }}>
           <span
-            style={{ fontSize: 10, letterSpacing: "0.2em", color: T.textMuted, textTransform: "uppercase" }}
+            style={{
+              fontSize: 10,
+              letterSpacing: "0.2em",
+              color: T.textMuted,
+              textTransform: "uppercase",
+            }}
           >
             Dashboard
           </span>
-          <span style={{ fontSize: 12, fontWeight: 600, color: T.text }}>Production · api.cloudless.gr</span>
+          <span style={{ fontSize: 12, fontWeight: 600, color: T.text }}>
+            Production · api.cloudless.gr
+          </span>
         </div>
         <div style={{ marginLeft: "auto", display: "flex", alignItems: "center", gap: 8 }}>
           <span style={chip}>Last 24h ▾</span>
@@ -267,21 +308,49 @@ export default function CloudCockpit() {
             value: "12",
             unit: "ms",
             color: T.accent,
-            sub: <span style={{ display: "inline-flex", alignItems: "center", gap: 4, fontSize: 10, color: T.ok }}>▼ −18% · 24h</span>,
+            sub: (
+              <span
+                style={{
+                  display: "inline-flex",
+                  alignItems: "center",
+                  gap: 4,
+                  fontSize: 10,
+                  color: T.ok,
+                }}
+              >
+                ▼ −18% · 24h
+              </span>
+            ),
           },
           {
             label: "Uptime · 30d",
             value: "99.987",
             unit: "%",
             color: T.ok,
-            sub: <span style={{ fontSize: 10, color: T.textDim, fontVariantNumeric: "tabular-nums" }}>SLO 99.9% · target met</span>,
+            sub: (
+              <span style={{ fontSize: 10, color: T.textDim, fontVariantNumeric: "tabular-nums" }}>
+                SLO 99.9% · target met
+              </span>
+            ),
           },
           {
             label: "Error Rate",
             value: "0.04",
             unit: "%",
             color: T.ok,
-            sub: <span style={{ display: "inline-flex", alignItems: "center", gap: 4, fontSize: 10, color: T.ok }}>▼ −40% · week</span>,
+            sub: (
+              <span
+                style={{
+                  display: "inline-flex",
+                  alignItems: "center",
+                  gap: 4,
+                  fontSize: 10,
+                  color: T.ok,
+                }}
+              >
+                ▼ −40% · week
+              </span>
+            ),
           },
         ].map(({ label, value, unit, color, sub }) => (
           <div
@@ -317,7 +386,9 @@ export default function CloudCockpit() {
               }}
             >
               {value}
-              <span style={{ fontSize: unit === "ms" ? 11 : 14, color: T.textDim, fontWeight: 400 }}>
+              <span
+                style={{ fontSize: unit === "ms" ? 11 : 14, color: T.textDim, fontWeight: 400 }}
+              >
                 {unit}
               </span>
             </span>

--- a/src/components/CloudMark.tsx
+++ b/src/components/CloudMark.tsx
@@ -21,7 +21,8 @@ interface CloudMarkProps {
   "aria-label"?: string;
 }
 
-const CLOUD_PATH = "M6 22 A6 6 0 0 1 6 10 A4 4 0 0 1 10.5 7 A7 7 0 0 1 23 5.2 A6 6 0 0 1 28.5 14 A5 5 0 0 1 26 22 Z";
+const CLOUD_PATH =
+  "M6 22 A6 6 0 0 1 6 10 A4 4 0 0 1 10.5 7 A7 7 0 0 1 23 5.2 A6 6 0 0 1 28.5 14 A5 5 0 0 1 26 22 Z";
 
 export default function CloudMark({
   size = 28,

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -210,7 +210,9 @@ export default function Navbar() {
                 style={{ color: "var(--ink-body)" }}
                 onClick={() => setMobileOpen(false)}
               >
-                <span style={{ color: "var(--accent)", opacity: 0.5 }} className="mr-2">&gt;</span>
+                <span style={{ color: "var(--accent)", opacity: 0.5 }} className="mr-2">
+                  &gt;
+                </span>
                 {translate(locale, link.key, link.fallback)}
               </Link>
             ))}


### PR DESCRIPTION
## Summary
- Pre-existing Prettier rot on `main` from the homepage v2 migration (#283) + stylelint revert (#284) merging without `pnpm format:check` passing
- Currently blocks every new PR on the required `Lint & Format` check (PR #285 is BLOCKED on this)
- This PR runs `prettier --write` on the 4 affected files and nothing else

## Files
- `src/app/[locale]/page.tsx`
- `src/components/CloudCockpit.tsx`
- `src/components/CloudMark.tsx`
- `src/components/Navbar.tsx`

## Test plan
- [ ] CI `Lint & Format` passes (was failing on main itself)
- [ ] After merge, rebase #285 onto main and confirm it goes from BLOCKED → MERGEABLE