### PR TITLE
fix(e2e): align Navbar accent-bar assertions with v2 design (h-px → h-0.5)

### DIFF
--- a/e2e/k3s/style.spec.ts
+++ b/e2e/k3s/style.spec.ts
@@ -77,12 +77,11 @@ test.describe("k3s Navbar style", () => {
     const className = await header.getAttribute("class") ?? "";
     expect(className, "header should have Tailwind sticky class").toContain("sticky");
 
-    // First child div inside <header> is the 1-px neon-cyan accent bar (h-px)
+    // First child div inside <header> is the 2-px neon-cyan accent bar (h-0.5)
     const accentBar = header.locator("div").first();
     await expect(accentBar).toBeVisible();
-    // Use class check for height too — subpixel rendering may report <1px on HiDPI
     const accentClass = await accentBar.getAttribute("class") ?? "";
-    expect(accentClass, "accent bar should have h-px class").toContain("h-px");
+    expect(accentClass, "accent bar should have h-0.5 class").toContain("h-0.5");
   });
 
   test("logo link is visible", async ({ page }) => {

--- a/e2e/style.spec.ts
+++ b/e2e/style.spec.ts
@@ -68,13 +68,13 @@ test.describe("Navbar style", () => {
     );
     expect(position).toBe("sticky");
 
-    // First child div is the 1-px accent bar (h-px Tailwind utility)
+    // First child div is the 2-px accent bar (h-0.5 Tailwind utility)
     const accentBar = header.locator("div").first();
     await expect(accentBar).toBeVisible();
     const height = await accentBar.evaluate(
       (el) => getComputedStyle(el).height,
     );
-    expect(parseFloat(height)).toBeCloseTo(1, 0);
+    expect(parseFloat(height)).toBeCloseTo(2, 0);
   });
 
   test("logo link is visible and points to homepage", async ({ page }) => {


### PR DESCRIPTION
## Summary
- After homepage v2 (#283), the sticky-header accent bar changed from `h-px` (1px) → `h-0.5` (2px)
- Two e2e specs were left asserting the old height, failing `k3s standby E2E` on every push to main
- Pre-existing rot — same family as #286

## Files
- `e2e/style.spec.ts` — expected computed height ≈ 1px; now 2px
- `e2e/k3s/style.spec.ts` — expected className to contain `h-px`; now `h-0.5`

## Test plan
- [ ] CI required checks pass
- [ ] k3s standby E2E workflow goes from FAILURE → SUCCESS on main after merge