### PR TITLE
fix(k8s): bump monitoring-quota limits.memory 2Gi → 3Gi

### DIFF
--- a/k8s/cluster-protection/limit-ranges.yaml
+++ b/k8s/cluster-protection/limit-ranges.yaml
@@ -42,9 +42,11 @@ spec:
     # Total of all pods' requests in this namespace. Sized for
     # Prometheus + Loki + Grafana + Alertmanager + node-exporter +
     # operator + kube-state-metrics with the limits in
-    # monitoring-resources.yaml.
+    # monitoring-resources.yaml. Prometheus alone holds 1.5Gi limit;
+    # the sum of all monitoring pod limits is ~2.6Gi, so the limit
+    # ceiling must be ≥ 3Gi to allow rollouts. (See 2026-05-29 audit.)
     requests.memory: "1.5Gi"
-    limits.memory: "2Gi"
+    limits.memory: "3Gi"
     requests.cpu: "1"
     limits.cpu: "4"
     # Cap pod count so a runaway ReplicaSet can't proliferate.


### PR DESCRIPTION
## Summary
Discovered during 2026-05-29 cluster audit: the live monitoring pods
already carry total `limits.memory` of 2,652 MiB (Prometheus alone is
1,500 MiB). The quota was capped at 2 GiB, which made any rolling
update fail admission:

\`\`\`
exceeded quota: monitoring-quota, requested: limits.memory=1Gi,
used: limits.memory=1536Mi, limited: limits.memory=2Gi
\`\`\`

Raising to 3 GiB allows one in-flight surge replica during rollouts.
Quota was patched live on omv as part of the audit; this PR makes the
manifest source-of-truth match.

## Test plan
- [ ] CI Build passes
- [ ] After merge, future re-apply of \`apply-all-guardrails.sh\` does not regress the quota back to 2 GiB