### PR TITLE
fix(k8s): cluster-alerts — alpine/k8s image, bot-token Slack, and 2 Python bugs

### DIFF
--- a/k8s/cluster-protection/alerts/cluster-alerts.yaml
+++ b/k8s/cluster-protection/alerts/cluster-alerts.yaml
@@ -5,15 +5,24 @@
 # fired into #errors within ~5 min: "keycloak/keycloak-* CrashLoopBackOff x97"
 # and "analytics/duckdb-api-* CrashLoopBackOff x108".
 #
-# Scope: read-only over Events + Pods cluster-wide. Posts to a SLACK_WEBHOOK_URL
-# stored in the `cluster-alerts-secret` Secret in the `monitoring` namespace.
+# Scope: read-only over Events + Pods cluster-wide. Posts to #errors via the
+# Slack chat.postMessage API using the `cloudless_bot` bot token stored in the
+# `cluster-alerts-secret` Secret in the `monitoring` namespace.
 #
-# Prereq (one-time): create the secret with the Slack incoming-webhook URL
-# already used by the Next.js app (mirror it from SSM
-# /cloudless/production/slack-webhook-url):
+# Why bot token vs incoming webhook: the legacy SLACK_WEBHOOK_URL in SSM is
+# dead (Slack returns `no_service`). The bot token is the live path the Next.js
+# app uses for per-channel routing; it survives webhook rotation.
 #
+# Prereq (one-time): mirror the bot token from SSM into a cluster secret:
+#
+#   BOT=$(aws ssm get-parameter --region us-east-1 \
+#     --name /cloudless/production/SLACK_BOT_TOKEN \
+#     --with-decryption --query Parameter.Value --output text)
 #   kubectl -n monitoring create secret generic cluster-alerts-secret \
-#     --from-literal=SLACK_WEBHOOK_URL='https://hooks.slack.com/services/…'
+#     --from-literal=SLACK_BOT_TOKEN="$BOT"
+#
+# Also: invite @cloudless_bot to #errors once: `/invite @cloudless_bot` in
+# that channel — otherwise chat.postMessage returns not_in_channel.
 #
 # Apply:
 #   kubectl apply -f k8s/cluster-protection/alerts/cluster-alerts.yaml
@@ -89,11 +98,14 @@ spec:
                   memory: 128Mi
                   cpu: 200m
               env:
-                - name: SLACK_WEBHOOK_URL
+                - name: SLACK_BOT_TOKEN
                   valueFrom:
                     secretKeyRef:
                       name: cluster-alerts-secret
-                      key: SLACK_WEBHOOK_URL
+                      key: SLACK_BOT_TOKEN
+                # The channel to post into. Default #errors.
+                - name: SLACK_CHANNEL
+                  value: "#errors"
                 # Look back this many minutes for events; matches the schedule
                 # plus 1 min buffer to catch events at the boundary.
                 - name: WINDOW_MIN
@@ -105,10 +117,11 @@ spec:
                   set -eo pipefail
                   STAMP="$(date -u '+%Y-%m-%dT%H:%M:%SZ')"
 
-                  if [ -z "${SLACK_WEBHOOK_URL:-}" ]; then
-                    echo "[${STAMP}] SLACK_WEBHOOK_URL not set — exiting noop"
+                  if [ -z "${SLACK_BOT_TOKEN:-}" ]; then
+                    echo "[${STAMP}] SLACK_BOT_TOKEN not set — exiting noop"
                     exit 0
                   fi
+                  : "${SLACK_CHANNEL:=#errors}"
 
                   # ── 1. Crash-loop pods cluster-wide ─────────────────────────
                   CRASH_LOOP="$(kubectl get pods -A \
@@ -164,13 +177,22 @@ spec:
                   # JSON-encode BODY via stdin so we don't depend on env-var
                   # propagation through `cmd VAR=val` (which sets a python argv,
                   # not an env entry, in many shells/images).
-                  PAYLOAD="$(printf '%s' "${BODY}" | python3 -c 'import json,sys; print(json.dumps({"text": sys.stdin.read()}))')"
+                  PAYLOAD="$(printf '%s' "${BODY}" | python3 -c '
+                  import json,os,sys
+                  print(json.dumps({"channel": os.environ.get("SLACK_CHANNEL","#errors"), "text": sys.stdin.read()}))
+                  ')"
 
-                  echo "[${STAMP}] posting alert to Slack"
+                  echo "[${STAMP}] posting alert to Slack channel ${SLACK_CHANNEL}"
                   echo "${BODY}" | head -50
-                  curl -sS -X POST -H 'Content-Type: application/json' \
+                  RESP="$(curl -sS -X POST https://slack.com/api/chat.postMessage \
+                    -H "Authorization: Bearer ${SLACK_BOT_TOKEN}" \
+                    -H 'Content-Type: application/json; charset=utf-8' \
                     --data "${PAYLOAD}" \
-                    --max-time 8 \
-                    "${SLACK_WEBHOOK_URL}" \
-                    || { echo "[${STAMP}] Slack POST failed"; exit 1; }
-                  echo "[${STAMP}] alert posted"
+                    --max-time 8 || echo '{"ok":false,"error":"curl_failed"}')"
+                  OK="$(printf '%s' "${RESP}" | python3 -c 'import json,sys; print(json.load(sys.stdin).get("ok"))')"
+                  if [ "${OK}" = "True" ]; then
+                    echo "[${STAMP}] alert posted"
+                  else
+                    echo "[${STAMP}] Slack post failed: ${RESP}"
+                    exit 1
+                  fi

--- a/k8s/cluster-protection/alerts/cluster-alerts.yaml
+++ b/k8s/cluster-protection/alerts/cluster-alerts.yaml
@@ -161,7 +161,10 @@ spec:
                   [ -n "${OOM}" ]        && BODY="${BODY}\n*OOMKilled (last terminate):*\n\`\`\`${OOM}\`\`\`"
                   [ -n "${EVENTS}" ]     && BODY="${BODY}\n*Recent warnings:*\n\`\`\`${EVENTS}\`\`\`"
 
-                  PAYLOAD="$(python3 -c 'import json,os; print(json.dumps({"text": os.environ["B"]}))' B="${BODY}")"
+                  # JSON-encode BODY via stdin so we don't depend on env-var
+                  # propagation through `cmd VAR=val` (which sets a python argv,
+                  # not an env entry, in many shells/images).
+                  PAYLOAD="$(printf '%s' "${BODY}" | python3 -c 'import json,sys; print(json.dumps({"text": sys.stdin.read()}))')"
 
                   echo "[${STAMP}] posting alert to Slack"
                   echo "${BODY}" | head -50

--- a/k8s/cluster-protection/alerts/cluster-alerts.yaml
+++ b/k8s/cluster-protection/alerts/cluster-alerts.yaml
@@ -144,7 +144,9 @@ spec:
                           continue
                       msg = (e.get("message") or "").splitlines()[0][:200]
                       obj = e.get("involvedObject",{})
-                      out.append(f"{e.get(\"metadata\",{}).get(\"namespace\",\"-\")}/{obj.get(\"name\",\"?\")} {reason}: {msg}")
+                      ns = e.get("metadata", {}).get("namespace", "-")
+                      nm = obj.get("name", "?")
+                      out.append(f"{ns}/{nm} {reason}: {msg}")
                   print("\n".join(out[-15:]))
                   ' || true)"
 

--- a/k8s/cluster-protection/alerts/cluster-alerts.yaml
+++ b/k8s/cluster-protection/alerts/cluster-alerts.yaml
@@ -77,7 +77,10 @@ spec:
           restartPolicy: Never
           containers:
             - name: scanner
-              image: bitnami/kubectl:1.31
+              # alpine/k8s bundles kubectl + curl + jq + python3 in one image.
+              # Matches the cluster's k3s minor version (v1.35.x). bitnami/kubectl
+              # was withdrawn from Docker Hub mid-2026.
+              image: alpine/k8s:1.35.5
               resources:
                 requests:
                   memory: 32Mi


### PR DESCRIPTION
## Summary
Fast-follow on #290. After deploying to the live cluster, found 4 real issues:

1. **`bitnami/kubectl:1.31` no longer exists** — Bitnami withdrew the public mirror mid-2026. Swap to `alpine/k8s:1.35.5` (bundles kubectl + curl + jq + python3, matches the running k3s minor).
2. **f-string SyntaxError** — escaped doubles in `f"…{e.get(\\"metadata\\",…)}…"` didn't survive YAML→shell→python. Extract `ns`, `nm` to local vars.
3. **`KeyError: 'B'`** — `python3 -c '…' B="…"` passes a positional argv, not an env var. Switch to stdin via `printf '%s' "$BODY" | python3 -c '… sys.stdin.read() …'`.
4. **Webhook delivery dead** — SSM `SLACK_WEBHOOK_URL` returns `no_service`. Switch to `SLACK_BOT_TOKEN` + `chat.postMessage`, routing to `#errors`.

## Test plan
- [x] Server-side dry-run apply
- [x] e2e tested on live cluster — scanner found real CrashLoopBackOff + quota events, posted well-formed payload
- [ ] **MANUAL ACTION REQUIRED**: in Slack workspace `wwwcloudlessgr`, invite `@cloudless_bot` to `#errors` (`/invite @cloudless_bot`) — `chat.postMessage` returns `not_in_channel` otherwise
- [ ] After invite: un-suspend CronJob — `kubectl -n monitoring patch cronjob cluster-alerts -p '{"spec":{"suspend":false}}'`
- [ ] Verify next scheduled run lands in #errors

## Known related issues surfaced
- The SSM `SLACK_WEBHOOK_URL` parameter at `/cloudless/production/SLACK_WEBHOOK_URL` is dead. The app's `slack-notify.ts` falls back to bot token so user-facing flows are OK, but the SSM param should be rotated or deleted.
- `cloudless_bot` lacks `channels:read`/`groups:read` scopes — needed if we later want runtime channel discovery.