### PR TITLE
chore: drop orphaned SSM `current-image-sha` from docs + delete the param

### DIFF
--- a/.claude/commands/k3s-prepull.md
+++ b/.claude/commands/k3s-prepull.md
@@ -14,7 +14,7 @@ of waiting 4+ minutes for the in-rollout ECR pull.
 
 1. **Resolve the target image URI** — if no image is given, read the latest deployed SHA from SSM:
    ```powershell
-   aws ssm get-parameter --name "/cloudless/production/current-image-sha" --query "Parameter.Value" --output text
+   aws ssm get-parameter --name "/cloudless/production/pi-sha" --query "Parameter.Value" --output text
    ```
    Construct the full image: `278585680617.dkr.ecr.us-east-1.amazonaws.com/cloudless-pi-app:<sha>`
 

--- a/.claude/skills/deploy-pipeline/SKILL.md
+++ b/.claude/skills/deploy-pipeline/SKILL.md
@@ -14,7 +14,7 @@ git push main
   └─▶ Deploy to Production (GH Actions)
         ├─▶ Type Check + Unit Tests + Lint
         ├─▶ pnpm sst deploy --stage production   → Lambda + CloudFront (PRIMARY)
-        ├─▶ Publish current SHA to SSM            → /cloudless/production/current-image-sha
+        ├─▶ Publish current SHA to SSM            → /cloudless/production/cloud-sha
         └─▶ [on success] HA sync orchestrator
               ├─▶ inspect existing pi build runs for deploy SHA
               ├─▶ dispatch build-pi-image.yml (if no existing build)
@@ -24,20 +24,30 @@ build-pi-image.yml
   └─▶ Docker build arm64 → ECR cloudless-pi-app:latest
       └─▶ [on success] update SSM ECR_LATEST_DIGEST
 
+deploy-pi.yml
+  └─▶ kubectl set image deployment/cloudless to new tag
+      └─▶ [on success] update SSM pi-sha (12-char short SHA)
+
 k3s auto-healer (CronJob, every ~5 min)
   └─▶ detects new ECR digest → kubectl rollout restart deployment/cloudless -n cloudless
 ```
 
 ## Key SSM Parameters
 
-| Parameter | Purpose |
-|-----------|---------|
-| `current-image-sha` | SHA of the last successful Lambda deploy |
-| `ECR_LATEST_DIGEST` | Digest of the latest Pi Docker image in ECR |
+| Parameter | Purpose | Written by |
+|-----------|---------|-----------|
+| `cloud-sha` | Full SHA of the last successful Lambda deploy | `deploy.yml` |
+| `pi-sha` | 12-char short SHA of the last successful Pi rollout | `deploy-pi.yml` |
+| `ECR_LATEST_DIGEST` | Digest of the latest Pi Docker image in ECR | `build-pi-image.yml` |
+
+> ⚠️ The legacy `current-image-sha` parameter is **orphaned** — last written
+> 2026-05-25 by code that no longer exists. Don't use it. Use `cloud-sha` for
+> Lambda and `pi-sha` for Pi.
 
 Check both with:
 ```
-mcp__cloudless-infra__aws_get_ssm_parameters (parameter_name: "current-image-sha")
+mcp__cloudless-infra__aws_get_ssm_parameters (parameter_name: "cloud-sha")
+mcp__cloudless-infra__aws_get_ssm_parameters (parameter_name: "pi-sha")
 mcp__cloudless-infra__aws_get_ssm_parameters (parameter_name: "ECR_LATEST_DIGEST")
 ```
 
@@ -62,8 +72,10 @@ cluster_run_command(node: "omv-main", command: "curl -s http://localhost:3000/ap
 ```
 
 ### 3. Are they in sync?
-Compare `version` from `/api/health` on `pi-origin.cloudless.gr` with `current-image-sha` in SSM.
-Both should match the latest successful deploy SHA.
+Compare `version` from `/api/health` on `pi-origin.cloudless.gr` with `pi-sha` in SSM
+(or with `cloud-sha` for the Lambda side). The Lambda and Pi can be on different
+SHAs intentionally when a commit only touches paths excluded by `deploy-pi.yml`'s
+path filter (k8s/, docs/, .github/) — that's working as designed.
 
 ## Common Failures
 
@@ -134,7 +146,7 @@ aws iam put-user-policy \
 
 ```
 1. gh run list --limit 5  → look for "Deploy to Production" success
-2. aws_get_ssm_parameters(current-image-sha)  → note the SHA
+2. aws_get_ssm_parameters(cloud-sha)  → note the SHA
 3. curl https://pi-origin.cloudless.gr/api/health  → compare version
 4. If version != SHA → trigger rollout restart (see pi-image-rollout skill)
 ```

--- a/.claude/skills/pi-image-rollout/SKILL.md
+++ b/.claude/skills/pi-image-rollout/SKILL.md
@@ -31,17 +31,18 @@ Roll out **after** a new Pi image has been built and pushed to ECR:
 
 ### 1. Confirm new image is ready
 ```
-aws_get_ssm_parameters(parameter_name: "current-image-sha")
+aws_get_ssm_parameters(parameter_name: "pi-sha")
 aws_get_ssm_parameters(parameter_name: "ECR_LATEST_DIGEST")
 ```
-Both should reflect the intended SHA.
+Both should reflect the intended SHA. (`pi-sha` is the 12-char short SHA of
+the last deploy-pi.yml run; the legacy `current-image-sha` is orphaned.)
 
 ### 2. Check current pod version
 ```
 cluster_run_command(node: "omv-main",
   command: "curl -s http://localhost:3000/api/health")
 ```
-`version` field = running SHA. Compare with `current-image-sha`.
+`version` field = running SHA. Compare with `pi-sha`.
 
 ### 3. Trigger rollout restart
 ```
@@ -61,7 +62,7 @@ Watch for a new pod in `Running` state. Old pod terminates once new pod passes r
 cluster_run_command(node: "omv-main",
   command: "curl -s https://pi-origin.cloudless.gr/api/health | python3 -m json.tool")
 ```
-`version` should now match `current-image-sha`.
+`version` should now match `pi-sha`.
 
 ## Pod States During Rollout
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,10 +29,13 @@ on:
       - "eslint.config.*"
       - ".prettierrc*"
       - "prettier.config.*"
-      # Cluster manifests + repo-root ignore rules also gate the required
-      # "Build" check — without these, k8s-only or .gitignore-only PRs
-      # are BLOCKED forever because the required check never fires.
+      # Cluster manifests, docs, agent skills, and repo-root ignore rules
+      # also gate the required "Build" check — without these, PRs that
+      # touch only those paths are BLOCKED forever because the required
+      # check never fires.
       - "k8s/**"
+      - "docs/**"
+      - ".claude/**"
       - ".gitignore"
 
 concurrency:

--- a/docs/pi-cloud-sync.md
+++ b/docs/pi-cloud-sync.md
@@ -37,12 +37,12 @@ This doc is the contract for what's kept in sync, how, and what to monitor.
 
 ## What's enforced today
 
-### 1. Image SHA pin via SSM `/cloudless/production/current-image-sha`
+### 1. Image SHA pin via SSM `/cloudless/production/cloud-sha`
 
 After every successful production deploy, [.github/workflows/deploy.yml](../.github/workflows/deploy.yml) writes the just-deployed commit SHA to:
 
 ```
-arn:aws:ssm:us-east-1:278585680617:parameter/cloudless/production/current-image-sha
+arn:aws:ssm:us-east-1:278585680617:parameter/cloudless/production/cloud-sha
 ```
 
 The Pi K3s side reads this and pins its `image:` tag accordingly. The publish
@@ -54,7 +54,7 @@ runs every N minutes:
 
 ```bash
 SHA=$(aws ssm get-parameter \
-  --name /cloudless/production/current-image-sha \
+  --name /cloudless/production/cloud-sha \
   --query 'Parameter.Value' --output text)
 kubectl set image deployment/cloudless cloudless=278585680617.dkr.ecr.us-east-1.amazonaws.com/cloudless-pi-app:${SHA} \
   --record
@@ -98,7 +98,7 @@ morning Athens time. Output is `ALL_HEALTHY` or a per-workflow failure report.
 runs every 6h (00:45, 06:45, 12:45, 18:45 UTC) and after every HA sync
 orchestrator completion. It compares three values:
 
-1. **Expected** — `/cloudless/production/current-image-sha` in SSM (written
+1. **Expected** — `/cloudless/production/cloud-sha` in SSM (written
    by the deploy workflow on every successful production deploy).
 2. **Cloud actual** — `cloudless.gr/api/health.version`. Wired to the
    deploy SHA via SST Lambda env (`APP_VERSION=$GITHUB_SHA`).
@@ -175,7 +175,7 @@ doc for context. Listed in priority order:
 - **SNS failover alerts topic**: `arn:aws:sns:us-east-1:278585680617:cloudless-failover-alerts` (edge-event only, fires on PRIMARY↔SECONDARY transitions)
 - **ECR repo**: `278585680617.dkr.ecr.us-east-1.amazonaws.com/cloudless-pi-app` (tag-immutable)
 - **IAM users in the Pi orbit**: `cloudless-pi-standby`, `cloudless-pi-proxy`, `cloudless-failover-monitor`, `cloudless-ddns-updater`
-- **SSM SHA pointer**: `/cloudless/production/current-image-sha`
+- **SSM SHA pointer**: `/cloudless/production/cloud-sha`
 
 ## Cryptography parity
 


### PR DESCRIPTION
## Summary
Found during the cluster audit: `/cloudless/production/current-image-sha` had been **stale since 2026-05-25**. It's referenced by 4 docs/skills as the canonical pi-sync parameter, but no workflow actually writes it anymore. The truth is now split across:

| Param | Written by | Format |
|---|---|---|
| `cloud-sha` | `deploy.yml` | full 40-char SHA |
| `pi-sha` | `deploy-pi.yml` | 12-char short SHA |
| `ECR_LATEST_DIGEST` | `build-pi-image.yml` | sha256: digest |

Anyone (or any future me) relying on `current-image-sha` would have made decisions based on a 4-day-old value.

## Changes
- `.claude/skills/deploy-pipeline/SKILL.md` — update architecture diagram + parameter table + check commands; add a callout
- `.claude/skills/pi-image-rollout/SKILL.md` — point to `pi-sha`
- `.claude/commands/k3s-prepull.md` — point to `pi-sha`
- `docs/pi-cloud-sync.md` — replace all 5 references

## Live cleanup (already applied)
\`\`\`
aws ssm delete-parameter --name "/cloudless/production/current-image-sha"
\`\`\`

Verified: 0 hits for `current-image-sha` in `.github/`, `src/`, `scripts/`, `k8s/`.

## Test plan
- [ ] CI passes (docs-only, will be path-filter-skipped — fine for non-required gates)