### PR TITLE
fix(ci): add missing space before pin comment in 3 workflows

### DIFF
--- a/.github/workflows/ecr-lifecycle.yml
+++ b/.github/workflows/ecr-lifecycle.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ${{ fromJSON(vars.RUNNER_GENERIC || '"ubuntu-latest"') }}
     steps:
       - name: Configure AWS credentials (OIDC)
-        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a# v4
+        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4
         with:
           role-to-assume: ${{ secrets.AWS_DEPLOY_ROLE_ARN }}
           aws-region: ${{ env.AWS_REGION }}

--- a/.github/workflows/k3s-e2e.yml
+++ b/.github/workflows/k3s-e2e.yml
@@ -60,7 +60,7 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
-      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1# v4
+      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
 
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:

--- a/.github/workflows/notion-schema-drift.yml
+++ b/.github/workflows/notion-schema-drift.yml
@@ -32,7 +32,7 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
-      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1# v4
+      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
 
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:


### PR DESCRIPTION
## Summary
PR #289's pinning script had a bug: when the original `uses:` line had no trailing whitespace before EOL, the trailing `# v4` comment was appended **directly** to the SHA with no separator (`@<sha># v4`). GitHub then parses the ref as `<sha># v4` and fails with:

\`\`\`
Unable to resolve action `pnpm/action-setup@b906…# v4`, unable to find version `b906…# v4`
\`\`\`

Surfaced after `k3s standby E2E` failed on the latest main push.

## Files
- `.github/workflows/ecr-lifecycle.yml` — `aws-actions/configure-aws-credentials`
- `.github/workflows/k3s-e2e.yml` — `pnpm/action-setup`
- `.github/workflows/notion-schema-drift.yml` — `pnpm/action-setup`

## Test plan
- [x] `grep -rn '@[0-9a-f]\{40\}#' .github/workflows/` returns zero hits after the fix
- [ ] `k3s standby E2E` reruns successfully on next push