### PR TITLE
fix(k8s): bump monitoring-quota limits.memory 3Gi → 4Gi (step 3 of the same audit)

### DIFF
--- a/k8s/cluster-protection/limit-ranges.yaml
+++ b/k8s/cluster-protection/limit-ranges.yaml
@@ -56,7 +56,13 @@ spec:
     requests.memory: "1.5Gi"
     limits.memory: "4Gi"
     requests.cpu: "1"
-    limits.cpu: "4"
+    # limits.cpu was 4; bumped to 6 on 2026-05-29 after the k3s restart
+    # for the etcd-s3 IAM rotation. Bringing Prometheus + Alertmanager
+    # back from their `Completed` state pushed `used.limits.cpu` to
+    # 4900m which exceeded the 4 cap and caused admission rejection of
+    # the Prometheus pod recreation. 6 cap leaves headroom for one
+    # rolling-update surge replica of the heaviest workload.
+    limits.cpu: "6"
     # Cap pod count so a runaway ReplicaSet can't proliferate.
     pods: "20"
 

--- a/k8s/cluster-protection/limit-ranges.yaml
+++ b/k8s/cluster-protection/limit-ranges.yaml
@@ -41,12 +41,20 @@ spec:
   hard:
     # Total of all pods' requests in this namespace. Sized for
     # Prometheus + Loki + Grafana + Alertmanager + node-exporter +
-    # operator + kube-state-metrics with the limits in
-    # monitoring-resources.yaml. Prometheus alone holds 1.5Gi limit;
-    # the sum of all monitoring pod limits is ~2.6Gi, so the limit
-    # ceiling must be ≥ 3Gi to allow rollouts. (See 2026-05-29 audit.)
+    # operator + kube-state-metrics + promtail with the limits in
+    # monitoring-resources.yaml.
+    #
+    # Audit history:
+    # - 2026-05-29 first bump 2Gi → 3Gi: Prometheus (1.5Gi) alone made
+    #   the 2Gi limit incapable of accommodating any rolling update
+    #   surge replica.
+    # - 2026-05-29 second bump 3Gi → 4Gi: after restoring the full
+    #   stack (Loki + Grafana + monitoring-operator scaled back from
+    #   0 → 1), the steady-state sum hit 3036 Mi and Loki's 656 Mi
+    #   request was admission-rejected. 4 Gi gives ~1 Gi rolling-update
+    #   surge headroom.
     requests.memory: "1.5Gi"
-    limits.memory: "3Gi"
+    limits.memory: "4Gi"
     requests.cpu: "1"
     limits.cpu: "4"
     # Cap pod count so a runaway ReplicaSet can't proliferate.


### PR DESCRIPTION
Live monitoring stack now consumes 3036 Mi limits.memory. Restoring Loki (656 Mi) was rejected by the 3 Gi quota. Bump to 4 Gi gives ~1 Gi rolling-update surge headroom. Quota already patched live during the omv-ha audit.