### PR TITLE
chore(skill): drop omv-2-build from runner-ops skill

### DIFF
--- a/.claude/skills/runner-ops/SKILL.md
+++ b/.claude/skills/runner-ops/SKILL.md
@@ -8,19 +8,20 @@ allowed-tools: mcp__cloudless-infra__gh_runner_list, mcp__cloudless-infra__gh_ru
 
 ## Overview
 
-The `cloudless.gr` repo has three registered runners. As of 2026-05-29:
+The `cloudless.gr` repo has two registered runners. As of 2026-05-29:
 
 | Runner | Host | Labels | Status |
 |---|---|---|---|
 | `omv` | omv-main (192.168.1.128) | `self-hosted, Linux, ARM64, omv, pi` | disabled |
 | `omv-build` | omv-main (192.168.1.128) | `self-hosted, Linux, ARM64, omv, pi, build` | **active** (workdir on USB SSD) |
-| `omv-2-build` | (separate host) | `self-hosted, Linux, ARM64, omv, build` | online (lacks docker) |
 
-The `pi` label was moved off `omv` and onto `omv-build` so the unique
-combination `[self-hosted, omv, pi, build]` pins to `omv-build` only.
-`omv-2-build` lacks docker so PRs route to omv-build via the `pi` qualifier.
+`omv-2-build` was retired on 2026-05-29 — it lacked docker (Pi image
+builds couldn't land there) and went offline during the omv-main
+network event. Unregistered via `gh api --method DELETE
+/repos/.../actions/runners/<id>`.
 
-Active Pi-image build workflows use `runs-on: [self-hosted, omv, pi, build]`.
+Active Pi-image build workflows use `runs-on: [self-hosted, omv, pi, build]`
+which pins them to `omv-build` (the only runner with all three labels).
 
 **Service pattern:** `actions.runner.Themis128-{repo}.{runner}.service`
 **Example:** `actions.runner.Themis128-cloudless.gr.omv.service`


### PR DESCRIPTION
omv-2-build was retired 2026-05-29 — went offline during the network event and was unregistered via GH API DELETE. Updates the runner-ops skill to reflect the 2-runner topology.