### PR TITLE
fix(esp32-watchdog): bump probe timeout to 8s; correct README

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,14 +29,15 @@ on:
       - "eslint.config.*"
       - ".prettierrc*"
       - "prettier.config.*"
-      # Cluster manifests, docs, agent skills, and repo-root ignore rules
-      # also gate the required "Build" check — without these, PRs that
-      # touch only those paths are BLOCKED forever because the required
-      # check never fires.
+      # Cluster manifests, docs, agent skills, repo-root ignore rules, and
+      # infrastructure firmware/k8s configs also gate the required "Build"
+      # check — without these, PRs that touch only those paths are BLOCKED
+      # forever because the required check never fires.
       - "k8s/**"
       - "docs/**"
       - ".claude/**"
       - ".gitignore"
+      - "infrastructure/**"
 
 concurrency:
   group: ci-${{ github.head_ref }}

--- a/infrastructure/esp32-watchdog/README.md
+++ b/infrastructure/esp32-watchdog/README.md
@@ -1,8 +1,12 @@
 # ESP32 Cluster Watchdog
 
-**Board:** ESP32-S3-DevKitC-1 **v1.1** (RGB LED → GPIO38)  
-**Port:** COM3  
+**Board:** ESP32-S3-DevKitC-1 **v1.0** (RGB LED → GPIO48)  
+**Port:** COM3 (VID_303A / PID_4001)
 **Static IP after flash:** `192.168.1.201`
+
+> Pin reference: v1.0 boards have the onboard RGB LED on **GPIO48**. v1.1 boards
+> moved it to GPIO38. Do **not** swap the YAML pin without confirming the
+> physical board revision (silkscreen).
 
 ## What it does
 

--- a/infrastructure/esp32-watchdog/esphome/cloudless-watchdog.yaml
+++ b/infrastructure/esp32-watchdog/esphome/cloudless-watchdog.yaml
@@ -132,9 +132,13 @@ prometheus:
 # HTTP requests — ntfy alerts + health probes
 # ---------------------------------------------------------------------------
 http_request:
-  timeout: 5s     # 5 s — sufficient for LAN probes + HTTPS (verify_ssl:false = lightweight TLS)
-                  # MUST be < CONFIG_ESP_TASK_WDT_TIMEOUT_S (10 s) to avoid watchdog resets
-                  # when a probe target silently drops packets (no RST, no ICMP reject)
+  # 8 s — accommodates cold Cloudflare TLS handshake to https://cloudless.gr
+  # which can take 1–2 s on the ESP32's 240 MHz CPU. Previous 5 s was producing
+  # false-positive "AWS UNREACHABLE" alerts (probe times out → on_error fires
+  # even though the endpoint actually returns HTTP 200 in ~1.2 s when warm).
+  # MUST stay < CONFIG_ESP_TASK_WDT_TIMEOUT_S (10 s) to avoid watchdog resets
+  # when a probe target silently drops packets (no RST, no ICMP reject).
+  timeout: 8s
   verify_ssl: false
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Live diagnostic from `http://192.168.1.201:9101/metrics` showed `cloudless.gr (AWS) reachable = 0` with 3 cumulative probe failures, while `curl https://cloudless.gr/api/health` from WSL returned HTTP 200 in ~1.2s. Root cause: `http_request.timeout = 5s` too tight for cold Cloudflare TLS handshake on a 240 MHz ESP32.
- Bumped to **8s** (stays under `CONFIG_ESP_TASK_WDT_TIMEOUT_S = 10s` so the watchdog still catches real hangs).
- README header corrected: board is **v1.0 / GPIO48**, not v1.1 / GPIO38. YAML and Notion v2 spec both agree on v1.0.

## Notion-side updates (already applied)
- v2 watchdog page changelog gained a 2026-05-29 entry.
- Two stale "action required" notices marked resolved:
  - `tls_check.py` already monitors `.gr` domains (verified at `infrastructure/pi-alert-api/tls_check.py:42-45`)
  - The "IP conflict at .201" was a doc error — `.160` (MicroPython) and `.201` (ESPHome) are distinct devices

## Test plan
- [ ] CI Build passes
- [ ] After merge, reflash via OTA: `esphome run cloudless-watchdog.yaml`
- [ ] Within 60s, `curl http://192.168.1.201:9101/metrics | grep cloudless_gr__aws__reachable` should show `1.000000`
- [ ] `omv` / `omv-ha` probes still 1 (no regression on LAN probes)