### PR TITLE
fix(auth): close Amplify init-order race in AuthContext

### DIFF
--- a/src/context/AuthContext.tsx
+++ b/src/context/AuthContext.tsx
@@ -4,6 +4,13 @@ import { createContext, useContext, useState, useEffect, useCallback, type React
 
 // aws-amplify is imported lazily inside each async function so the ~2 MB
 // module is excluded from the initial JS bundle, reducing TBT on public pages.
+//
+// Every aws-amplify/auth import is paired with @/lib/amplify-config inside a
+// Promise.all() so Amplify.configure() (which runs as the config module's
+// side-effect) is guaranteed to have landed before any auth call. Without the
+// pairing, an auth helper invoked during HMR or first paint could win the race
+// against the config import and produce:
+//   "Amplify has not been configured. Please call Amplify.configure() ..."
 
 interface UserPreferences {
   theme: "system" | "dark" | "light";
@@ -139,7 +146,10 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       let preferences = { ...DEFAULT_PREFERENCES };
 
       try {
-        const { fetchUserAttributes } = await import("aws-amplify/auth");
+        const [{ fetchUserAttributes }] = await Promise.all([
+          import("aws-amplify/auth"),
+          import("@/lib/amplify-config"),
+        ]);
         const attrs = await fetchUserAttributes();
         name = attrs.name || attrs.given_name || undefined;
         phone = attrs.phone_number || undefined;
@@ -165,7 +175,10 @@ export function AuthProvider({ children }: { children: ReactNode }) {
 
   const checkAuth = useCallback(async () => {
     try {
-      const { getCurrentUser, fetchAuthSession } = await import("aws-amplify/auth");
+      const [{ getCurrentUser, fetchAuthSession }] = await Promise.all([
+        import("aws-amplify/auth"),
+        import("@/lib/amplify-config"),
+      ]);
       const currentUser = await getCurrentUser();
       const email = currentUser.signInDetails?.loginId;
       const profile = await loadUserProfile(currentUser.username, email);
@@ -228,7 +241,10 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   }, [checkAuth]);
 
   const handleSignIn = async (email: string, password: string): Promise<SignInResult> => {
-    const { signIn: amplifySignIn, signOut: amplifySignOut } = await import("aws-amplify/auth");
+    const [{ signIn: amplifySignIn, signOut: amplifySignOut }] = await Promise.all([
+      import("aws-amplify/auth"),
+      import("@/lib/amplify-config"),
+    ]);
     try {
       const result = await amplifySignIn({ username: email, password });
 
@@ -258,7 +274,10 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   };
 
   const handleSignUp = async (email: string, password: string, name?: string) => {
-    const { signUp: amplifySignUp } = await import("aws-amplify/auth");
+    const [{ signUp: amplifySignUp }] = await Promise.all([
+      import("aws-amplify/auth"),
+      import("@/lib/amplify-config"),
+    ]);
     try {
       const userAttributes: Record<string, string> = { email };
       if (name?.trim()) userAttributes.name = name.trim();
@@ -273,14 +292,20 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   };
 
   const handleSignOut = async () => {
-    const { signOut: amplifySignOut } = await import("aws-amplify/auth");
+    const [{ signOut: amplifySignOut }] = await Promise.all([
+      import("aws-amplify/auth"),
+      import("@/lib/amplify-config"),
+    ]);
     await amplifySignOut();
     setUser(null);
     setIsAdmin(false);
   };
 
   const handleConfirmSignUp = async (email: string, code: string) => {
-    const { confirmSignUp: amplifyConfirmSignUp } = await import("aws-amplify/auth");
+    const [{ confirmSignUp: amplifyConfirmSignUp }] = await Promise.all([
+      import("aws-amplify/auth"),
+      import("@/lib/amplify-config"),
+    ]);
     try {
       await amplifyConfirmSignUp({ username: email, confirmationCode: code });
     } catch (err) {
@@ -289,7 +314,10 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   };
 
   const handleForgotPassword = async (email: string) => {
-    const { resetPassword: amplifyResetPassword } = await import("aws-amplify/auth");
+    const [{ resetPassword: amplifyResetPassword }] = await Promise.all([
+      import("aws-amplify/auth"),
+      import("@/lib/amplify-config"),
+    ]);
     try {
       await amplifyResetPassword({ username: email });
     } catch (err) {
@@ -298,7 +326,10 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   };
 
   const handleConfirmForgotPassword = async (email: string, code: string, newPassword: string) => {
-    const { confirmResetPassword: amplifyConfirmResetPassword } = await import("aws-amplify/auth");
+    const [{ confirmResetPassword: amplifyConfirmResetPassword }] = await Promise.all([
+      import("aws-amplify/auth"),
+      import("@/lib/amplify-config"),
+    ]);
     try {
       await amplifyConfirmResetPassword({
         username: email,
@@ -311,7 +342,10 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   };
 
   const handleCompleteNewPassword = async (newPassword: string) => {
-    const { confirmSignIn: amplifyConfirmSignIn } = await import("aws-amplify/auth");
+    const [{ confirmSignIn: amplifyConfirmSignIn }] = await Promise.all([
+      import("aws-amplify/auth"),
+      import("@/lib/amplify-config"),
+    ]);
     try {
       const result = await amplifyConfirmSignIn({
         challengeResponse: newPassword,
@@ -336,7 +370,10 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       if (attrs.company !== undefined) updates["custom:company"] = attrs.company;
 
       if (Object.keys(updates).length > 0) {
-        const { updateUserAttributes } = await import("aws-amplify/auth");
+        const [{ updateUserAttributes }] = await Promise.all([
+          import("aws-amplify/auth"),
+          import("@/lib/amplify-config"),
+        ]);
         await updateUserAttributes({ userAttributes: updates });
       }
 
@@ -361,7 +398,10 @@ export function AuthProvider({ children }: { children: ReactNode }) {
         ...(user?.preferences ?? DEFAULT_PREFERENCES),
         ...prefs,
       };
-      const { updateUserAttributes } = await import("aws-amplify/auth");
+      const [{ updateUserAttributes }] = await Promise.all([
+        import("aws-amplify/auth"),
+        import("@/lib/amplify-config"),
+      ]);
       await updateUserAttributes({
         userAttributes: {
           "custom:preferences": JSON.stringify(merged),

--- a/src/lib/amplify-config.ts
+++ b/src/lib/amplify-config.ts
@@ -17,7 +17,9 @@ import { Amplify } from "aws-amplify";
 const userPoolId = process.env.NEXT_PUBLIC_COGNITO_USER_POOL_ID ?? "";
 const userPoolClientId = process.env.NEXT_PUBLIC_COGNITO_CLIENT_ID ?? "";
 
-if (userPoolId && userPoolClientId) {
+const isConfigured = Boolean(userPoolId && userPoolClientId);
+
+if (isConfigured) {
   Amplify.configure(
     {
       Auth: {
@@ -33,5 +35,25 @@ if (userPoolId && userPoolClientId) {
 
 /** Returns true when Amplify has been configured with valid Cognito credentials. */
 export function configureAmplify(): boolean {
-  return Boolean(userPoolId && userPoolClientId);
+  return isConfigured;
+}
+
+/**
+ * Awaitable handle that any consumer of `aws-amplify/auth` MUST await before
+ * the first auth call. Guarantees Amplify.configure() has run regardless of
+ * which lazy-import path landed first.
+ *
+ * Why this exists: AuthContext lazy-imports both `@/lib/amplify-config` (which
+ * runs Amplify.configure as a module side-effect) and `aws-amplify/auth` (which
+ * needs configure to have already run). Without a barrier, a sibling component
+ * calling an auth helper during first paint can hit Amplify before configure
+ * lands, producing:
+ *   "Amplify has not been configured. Please call Amplify.configure() ..."
+ *
+ * Importing this module is the synchronization barrier: the side-effect block
+ * above runs at module-load, then awaiting `ensureAmplifyConfigured()` from
+ * anywhere is a no-op promise — but it forces the import to resolve first.
+ */
+export function ensureAmplifyConfigured(): Promise<boolean> {
+  return Promise.resolve(isConfigured);
 }


### PR DESCRIPTION
## Summary

Closes the \`Amplify has not been configured. Please call Amplify.configure() before using this service\` warning that surfaces in the browser console during dev-server HMR (and could theoretically fire on first paint in production).

## Root cause

\`AuthContext\` lazy-imports two modules independently:

1. \`@/lib/amplify-config\` — runs \`Amplify.configure()\` as a module side-effect at load time
2. \`aws-amplify/auth\` — the auth helper functions (consume the config)

There's no ordering guarantee between the two. During HMR a stale auth handle can grab \`aws-amplify/auth\` before the config import lands, triggering the warning on every auth call.

## Fix

Every \`import("aws-amplify/auth")\` is paired with \`import("@/lib/amplify-config")\` inside \`Promise.all([...])\`:

\`\`\`ts
const [{ getCurrentUser, fetchAuthSession }] = await Promise.all([
  import("aws-amplify/auth"),
  import("@/lib/amplify-config"),
]);
\`\`\`

- The config module's \`Amplify.configure()\` runs as before (module side-effect at load).
- Auth helpers can't be invoked until that module has resolved at least once.
- Both imports load in parallel — wall-clock equivalent to the original single import.
- No bundle-size regression — Webpack dedupes module instances; subsequent calls are cache hits.

Also added \`ensureAmplifyConfigured()\` to \`amplify-config.ts\` as a stable public handle for any code path outside \`AuthContext\` that needs the same guarantee.

## Bundle-size impact

None. The whole point of the original lazy load was to keep \`aws-amplify\` (~2 MB) out of the initial bundle on public pages. This patch preserves that — both lazy imports still only fire when an auth helper is actually called by a user (login, logout, profile fetch, etc.). Public pages stay fully amplify-free.

## Test plan
- [x] Type check passes on touched files (\`npx tsc --noEmit\`)
- [ ] Local: navigate to \`/en\` and check console — no \"Amplify has not been configured\" warning
- [ ] Local: signin / signout flow still works
- [ ] Lighthouse on \`/en\` shouldn't regress (bundle size unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)