### PR TITLE
fix(ci): refresh ECR login right before buildx push to prevent 401

### DIFF
--- a/.github/workflows/build-pi-image.yml
+++ b/.github/workflows/build-pi-image.yml
@@ -169,6 +169,19 @@ jobs:
         if: steps.existing.outputs.exists != 'true' || github.event_name == 'pull_request'
         uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
 
+      # Re-login to ECR immediately before the build step so buildkit picks
+      # up a fresh token. Without this, a stale buildkit credential helper
+      # state (left over from a previous run on the same self-hosted Pi
+      # runner) can hand the build a 401 partway through the layer push —
+      # which manifested on 2026-05-29 as:
+      #   "failed to push ...: 401 Unauthorized"
+      # 15 seconds into the export. The earlier login (line ~90) is still
+      # needed for the `aws ecr describe-images` short-circuit step, so we
+      # don't remove it — we just add a fresh login right before the build.
+      - name: refresh ECR login (for buildx)
+        if: github.event_name != 'pull_request' && (steps.existing.outputs.exists != 'true')
+        uses: aws-actions/amazon-ecr-login@fa648b43de3d4d023bcb3f89ed6940096949c419 # v2
+
       - name: compute tags
         id: tags
         if: steps.existing.outputs.exists != 'true' || github.event_name == 'pull_request'

--- a/.github/workflows/deploy-pi.yml
+++ b/.github/workflows/deploy-pi.yml
@@ -84,6 +84,15 @@ jobs:
         if: steps.check_ecr.outputs.exists != 'true'
         uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
 
+      # Re-login to ECR immediately before the build step so buildkit picks
+      # up a fresh token. Mirrors the same fix in build-pi-image.yml —
+      # without this, a stale buildkit credential helper state on the
+      # self-hosted Pi runner can hand the build a 401 Unauthorized 15s
+      # into the layer push.
+      - name: refresh ECR login (for buildx)
+        if: steps.check_ecr.outputs.exists != 'true'
+        uses: aws-actions/amazon-ecr-login@fa648b43de3d4d023bcb3f89ed6940096949c419 # v2
+
       - name: ensure local cache dirs exist
         if: steps.check_ecr.outputs.exists != 'true'
         run: |


### PR DESCRIPTION
## Symptom

The 2026-05-29T16:39 \`build pi image\` run on \`main\` (sha=6251537a) failed with:

\`\`\`
ERROR: failed to build: failed to solve: failed to push 278585680617.dkr.ecr.us-east-1.amazonaws.com/cloudless-pi-app:6251537aac44:
  unexpected status from HEAD request to .../v2/cloudless-pi-app/blobs/sha256:2d608f48b26f54edd7120a9b1cf8599d4b2a582c63819978e42ed2bd859f7f52: 401 Unauthorized
\`\`\`

The build started at 16:39:28 and the 401 fired at 16:39:43 — only 15 seconds into the layer push. That's well within the OIDC token's 1-hour TTL, so the token wasn't expired.

## Root cause

Buildkit's credential helper holds stale state across runs on the same self-hosted Pi runner:

1. \`aws-actions/configure-aws-credentials\` mints a fresh OIDC session (works)
2. \`aws-actions/amazon-ecr-login\` writes a fresh ECR token into \`~/.docker/config.json\` (works)
3. \`docker/setup-buildx-action\` boots buildkit (which caches the docker auth state)
4. \`docker/build-push-action\` calls into buildkit, which then uses the cached token …
5. … which was sometimes a token from the previous run on the same Pi.

## Fix

Add a second \`aws-actions/amazon-ecr-login@v2\` step immediately after \`setup-buildx-action\` and before \`docker/build-push-action\`. This guarantees buildkit picks up the freshly-minted token.

The earlier login is kept — it runs against \`aws ecr describe-images\` for the short-circuit check, which uses the AWS SDK directly and doesn't share state with buildkit.

Same fix applied to both pipelines:
- \`.github/workflows/build-pi-image.yml\` (push-to-main + manual)
- \`.github/workflows/deploy-pi.yml\` (push-to-main rollout)

## Test plan
- [x] YAML still validates
- [ ] Next push to main: build-pi-image completes successfully end-to-end
- [ ] Deploy-pi rollout completes successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)