### PR TITLE
fix(ci): move ECR refresh login BEFORE setup-buildx (real fix for 401)

### DIFF
--- a/.github/workflows/build-pi-image.yml
+++ b/.github/workflows/build-pi-image.yml
@@ -162,25 +162,28 @@ jobs:
 
       - name: remove stale buildx builder
         if: steps.existing.outputs.exists != 'true' || github.event_name == 'pull_request'
+        # Also force-remove ALL builders (active or not). On a self-hosted
+        # Pi runner an active builder from a prior run holds the stale
+        # docker config snapshot in its buildkit container.
         run: |
           docker buildx rm --all-inactive --force 2>/dev/null || true
+          docker buildx ls --format json 2>/dev/null \
+            | python3 -c 'import sys,json; [print(json.loads(l).get("Name","")) for l in sys.stdin if l.strip()]' \
+            | grep -vE '^(default|)$' \
+            | xargs -r -n1 docker buildx rm --force 2>/dev/null || true
+
+      # PR #308 put the login AFTER setup-buildx, which doesn't work:
+      # docker/setup-buildx-action launches a buildkit CONTAINER, and
+      # buildkit snapshots ~/.docker/config.json at container-create time.
+      # A login after that is invisible to buildkit. Put the refresh
+      # BEFORE setup-buildx so the new container starts with fresh creds.
+      - name: refresh ECR login (before buildx boots)
+        if: github.event_name != 'pull_request' && (steps.existing.outputs.exists != 'true')
+        uses: aws-actions/amazon-ecr-login@fa648b43de3d4d023bcb3f89ed6940096949c419 # v2
 
       - name: set up Buildx
         if: steps.existing.outputs.exists != 'true' || github.event_name == 'pull_request'
         uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
-
-      # Re-login to ECR immediately before the build step so buildkit picks
-      # up a fresh token. Without this, a stale buildkit credential helper
-      # state (left over from a previous run on the same self-hosted Pi
-      # runner) can hand the build a 401 partway through the layer push —
-      # which manifested on 2026-05-29 as:
-      #   "failed to push ...: 401 Unauthorized"
-      # 15 seconds into the export. The earlier login (line ~90) is still
-      # needed for the `aws ecr describe-images` short-circuit step, so we
-      # don't remove it — we just add a fresh login right before the build.
-      - name: refresh ECR login (for buildx)
-        if: github.event_name != 'pull_request' && (steps.existing.outputs.exists != 'true')
-        uses: aws-actions/amazon-ecr-login@fa648b43de3d4d023bcb3f89ed6940096949c419 # v2
 
       - name: compute tags
         id: tags

--- a/.github/workflows/deploy-pi.yml
+++ b/.github/workflows/deploy-pi.yml
@@ -80,18 +80,18 @@ jobs:
         with:
           platforms: arm64
 
+      # PR #308 put the login AFTER setup-buildx, which doesn't work:
+      # docker/setup-buildx-action launches a buildkit CONTAINER, and
+      # buildkit snapshots ~/.docker/config.json at container-create time.
+      # A login after that is invisible to buildkit. Put the refresh
+      # BEFORE setup-buildx so the new container starts with fresh creds.
+      - name: refresh ECR login (before buildx boots)
+        if: steps.check_ecr.outputs.exists != 'true'
+        uses: aws-actions/amazon-ecr-login@fa648b43de3d4d023bcb3f89ed6940096949c419 # v2
+
       - name: Set up Docker Buildx
         if: steps.check_ecr.outputs.exists != 'true'
         uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
-
-      # Re-login to ECR immediately before the build step so buildkit picks
-      # up a fresh token. Mirrors the same fix in build-pi-image.yml —
-      # without this, a stale buildkit credential helper state on the
-      # self-hosted Pi runner can hand the build a 401 Unauthorized 15s
-      # into the layer push.
-      - name: refresh ECR login (for buildx)
-        if: steps.check_ecr.outputs.exists != 'true'
-        uses: aws-actions/amazon-ecr-login@fa648b43de3d4d023bcb3f89ed6940096949c419 # v2
 
       - name: ensure local cache dirs exist
         if: steps.check_ecr.outputs.exists != 'true'


### PR DESCRIPTION
## Why PR #308 didn't work

PR #308 added a refresh ECR login AFTER \`docker/setup-buildx-action\`, expecting buildkit to pick up the fresh token. It doesn't.

\`docker/setup-buildx-action\` launches a **buildkit container** that snapshots \`~/.docker/config.json\` at create-time. Any \`docker login\` after that container is running is invisible to buildkit — it keeps using the stale token from whichever previous run of this self-hosted Pi runner left a cached config.

PR #308's CI check on its own branch was a false positive: PR events skip the push step, so the 401 never had a chance to fire. Once merged to main, sha=\`bc5ebdb2\`'s build-pi-image hit the same:

\`\`\`
ERROR: failed to push ...: unexpected status from HEAD request to .../v2/cloudless-pi-app/blobs/sha256:...: 401 Unauthorized
\`\`\`

## Real fix

1. **Move the refresh login BEFORE \`setup-buildx\`** so the new buildkit container starts with a fresh \`~/.docker/config.json\`.
2. **Strengthen the \"remove stale buildx builder\" step** to force-remove ALL buildx builders (not just inactive ones). On a self-hosted runner, an active builder from a prior run holds the stale config snapshot in its buildkit container.

Applied to both pipelines: \`build-pi-image.yml\` + \`deploy-pi.yml\`.

## Test plan

Unlike PR #308, this fix will be **manually validated** by dispatching \`build pi image\` from this branch via \`workflow_dispatch\` — which honors the \`push: true\` condition (since event_name != 'pull_request') and exercises the full failure path.

- [ ] Manual dispatch of build-pi-image from this branch succeeds (passes layer push without 401)
- [ ] Merged → next push to main does NOT hit 401

🤖 Generated with [Claude Code](https://claude.com/claude-code)