### PR TITLE
fix(ci): split buildx-build from docker-push to dodge ECR 401 bug (fixes #310)

### DIFF
--- a/.github/workflows/build-pi-image.yml
+++ b/.github/workflows/build-pi-image.yml
@@ -169,19 +169,6 @@ jobs:
         if: steps.existing.outputs.exists != 'true' || github.event_name == 'pull_request'
         uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
 
-      # Re-login to ECR immediately before the build step so buildkit picks
-      # up a fresh token. Without this, a stale buildkit credential helper
-      # state (left over from a previous run on the same self-hosted Pi
-      # runner) can hand the build a 401 partway through the layer push —
-      # which manifested on 2026-05-29 as:
-      #   "failed to push ...: 401 Unauthorized"
-      # 15 seconds into the export. The earlier login (line ~90) is still
-      # needed for the `aws ecr describe-images` short-circuit step, so we
-      # don't remove it — we just add a fresh login right before the build.
-      - name: refresh ECR login (for buildx)
-        if: github.event_name != 'pull_request' && (steps.existing.outputs.exists != 'true')
-        uses: aws-actions/amazon-ecr-login@fa648b43de3d4d023bcb3f89ed6940096949c419 # v2
-
       - name: compute tags
         id: tags
         if: steps.existing.outputs.exists != 'true' || github.event_name == 'pull_request'
@@ -200,14 +187,39 @@ jobs:
             echo "tags=${ECR_REGISTRY}/${ECR_REPO}:${SHA}" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: build (and push if main)
+      # Build with load:true (not push:true). Loads the built image into
+      # the local dockerd image store. Push happens in the next step via a
+      # plain `docker push`.
+      #
+      # Why this split:
+      #   docker/build-push-action with push:true delegates the push to
+      #   buildkit, which has a known 401 bug against AWS ECR — after the
+      #   layer upload succeeds it does a HEAD on the manifest blob path
+      #   and ECR rate-limits that as 401 Unauthorized (the auth token's
+      #   path-scope vs the HEAD path mismatch). This caused the
+      #   2026-05-29 build-pi-image failures.
+      #
+      #   `docker push`, by contrast, uses dockerd's own registry client
+      #   which (a) re-reads ~/.docker/config.json on every push, (b) does
+      #   not perform the buildkit-specific HEAD/manifest dance.
+      #   amazon-ecr-login (step ~92) populated the docker auth helper
+      #   with a fresh ECR token in this same job, so dockerd has valid
+      #   credentials for the push.
+      #
+      # Earlier attempts that did NOT work:
+      #   PR #308 — added a second amazon-ecr-login AFTER setup-buildx.
+      #             Insufficient: buildkit still hits 401 on the manifest
+      #             finalization HEAD because that's a buildkit-side issue,
+      #             not a token-staleness one.
+      - name: build (load to dockerd)
         if: steps.existing.outputs.exists != 'true' || github.event_name == 'pull_request'
         uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
         with:
           context: .
           file: ./Dockerfile
           platforms: linux/arm64
-          push: ${{ steps.tags.outputs.push == 'true' }}
+          load: true
+          push: false
           tags: ${{ steps.tags.outputs.tags }}
           cache-from: type=local,src=/opt/docker-cache
           cache-to: type=local,dest=/opt/docker-cache,mode=max
@@ -226,6 +238,18 @@ jobs:
             NEXT_PUBLIC_SENTRY_DSN=${{ secrets.NEXT_PUBLIC_SENTRY_DSN }}
             NEXT_PUBLIC_META_PIXEL_ID=${{ secrets.NEXT_PUBLIC_META_PIXEL_ID }}
             NEXT_PUBLIC_GOOGLE_SITE_VERIFICATION=LXkyzmWrAYuY1C6XD6TKaqA31KB72xbUlkimE0vKI8w
+
+      # Push each tag with dockerd's own registry client (not buildkit).
+      # See the long comment on the `build (load to dockerd)` step above.
+      - name: push to ECR
+        if: github.event_name != 'pull_request' && (steps.existing.outputs.exists != 'true')
+        run: |
+          set -euo pipefail
+          IFS=',' read -ra TAGS <<< "${{ steps.tags.outputs.tags }}"
+          for tag in "${TAGS[@]}"; do
+            echo "==> docker push ${tag}"
+            docker push "${tag}"
+          done
 
       # Record the pushed image digest in SSM so the Pi's image-sync CronJob
       # can compare without needing ecr:DescribeImages (omv-main-cli is

--- a/.github/workflows/deploy-pi.yml
+++ b/.github/workflows/deploy-pi.yml
@@ -84,15 +84,6 @@ jobs:
         if: steps.check_ecr.outputs.exists != 'true'
         uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
 
-      # Re-login to ECR immediately before the build step so buildkit picks
-      # up a fresh token. Mirrors the same fix in build-pi-image.yml —
-      # without this, a stale buildkit credential helper state on the
-      # self-hosted Pi runner can hand the build a 401 Unauthorized 15s
-      # into the layer push.
-      - name: refresh ECR login (for buildx)
-        if: steps.check_ecr.outputs.exists != 'true'
-        uses: aws-actions/amazon-ecr-login@fa648b43de3d4d023bcb3f89ed6940096949c419 # v2
-
       - name: ensure local cache dirs exist
         if: steps.check_ecr.outputs.exists != 'true'
         run: |
@@ -103,13 +94,18 @@ jobs:
         if: steps.check_ecr.outputs.exists != 'true'
         run: docker pull node:22-alpine
 
-      - name: Build and push Docker image
+      # Build with load:true (not push:true) — see the long comment in
+      # build-pi-image.yml for the rationale. Push happens via plain
+      # `docker push` in the next step, bypassing the buildkit/ECR
+      # manifest-HEAD bug that caused the 2026-05-29 401 failures.
+      - name: Build and load to dockerd
         if: steps.check_ecr.outputs.exists != 'true'
         uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
         with:
           context: .
           platforms: linux/arm64
-          push: true
+          load: true
+          push: false
           # SHA tag only — ECR has immutable tags, :latest is never pushed.
           # Rollout uses kubectl set image with this SHA for pinned, reproducible deploys.
           tags: ${{ env.ECR_REGISTRY }}/${{ env.ECR_REPOSITORY }}:${{ steps.check_ecr.outputs.short_sha }}
@@ -130,6 +126,17 @@ jobs:
             NEXT_PUBLIC_META_PIXEL_ID=${{ secrets.NEXT_PUBLIC_META_PIXEL_ID }}
             APP_VERSION=${{ github.sha }}
             NEXT_PUBLIC_GOOGLE_SITE_VERIFICATION=LXkyzmWrAYuY1C6XD6TKaqA31KB72xbUlkimE0vKI8w
+
+      # Push via dockerd's own registry client (not buildkit). dockerd
+      # re-reads ~/.docker/config.json for every push and does not
+      # perform buildkit's manifest-HEAD dance against ECR.
+      - name: Push to ECR
+        if: steps.check_ecr.outputs.exists != 'true'
+        run: |
+          set -euo pipefail
+          TAG="${{ env.ECR_REGISTRY }}/${{ env.ECR_REPOSITORY }}:${{ steps.check_ecr.outputs.short_sha }}"
+          echo "==> docker push ${TAG}"
+          docker push "${TAG}"
 
       - name: Update SSM Pi image tracking
         run: |


### PR DESCRIPTION
## Closes #310

Real fix for the recurring \`401 Unauthorized\` failures in \`build pi image\` + \`Deploy to Pi (ECR + k3s rollout)\`.

## Root cause

After re-examining the build log on [run 26650503209](https://github.com/Themis128/cloudless.gr/actions/runs/26650503209), the timeline is:

\`\`\`
#21 exporting to image
#21 exporting layers 4.1s done            ← layer upload succeeded
#21 exporting manifest sha256:...  done
#21 pushing layers 1.4s done              ← layer push succeeded
#21 ERROR: failed to push ...: unexpected status from HEAD request
                                         to .../v2/cloudless-pi-app/blobs/sha256:4856048a... : 401 Unauthorized
\`\`\`

The 401 fires **after** the layer push succeeds. Buildkit then does a HEAD on a blob path to finalize the manifest, and AWS ECR returns 401 on that specific path with the same token that just succeeded for the layer push.

This is a known buildkit/ECR interaction — the auth token's path-scope vs the HEAD path mismatch causes ECR to reject the request.

## Earlier attempts that were wrong

- **PR #308 (merged):** added a refresh \`amazon-ecr-login\` AFTER \`setup-buildx\`. Assumed the cause was token staleness. Wrong — token is fresh; ECR rejects the manifest-HEAD specifically.
- **PR #309 (closed):** moved the refresh login BEFORE \`setup-buildx\`. Same wrong premise.

I couldn't validate either from a PR branch because OIDC trust policy correctly restricts \`sts:AssumeRoleWithWebIdentity\` to \`ref:refs/heads/main\`.

## This fix

Split \`docker/build-push-action\` into two steps:

1. **Build with \`load: true\`** — image goes into local dockerd image store, no push.
2. **\`docker push <tag>\`** in shell — uses dockerd's own registry client.

### Why this works

dockerd's registry client:
- re-reads \`~/.docker/config.json\` on every push (no stale state)
- does NOT perform buildkit's manifest-HEAD dance against ECR
- uses the standard registry-v2 layer upload protocol that ECR handles correctly

\`amazon-ecr-login\` (earlier in the workflow) populated the docker auth helper with a fresh ECR token, so dockerd has valid credentials for the push without additional setup.

Reverts the misleading \"refresh ECR login (for buildx)\" step added by PR #308 — that step was a non-fix and the explanatory comment claimed a stale-token cause that isn't actually what fails.

## Validation strategy

**Cannot be validated from this PR branch** — the OIDC trust policy on \`cloudless-github-actions\` rejects \`sts:AssumeRoleWithWebIdentity\` for any sub not matching \`ref:refs/heads/main\`. The PR-event CI run will exercise the build path (\`load: true\`) but skip push entirely.

Final validation happens on the **first push to main after merge**.

If this fix is also wrong, the next things to try (in priority order):
1. Pin \`docker/build-push-action\` to v5.x (v7.x has more aggressive OCI manifest behavior that ECR rejects).
2. Install \`docker-credential-ecr-login\` on the Pi runner so the cred-helper does the auth dance natively.
3. Switch to \`aws ecr get-login-password | docker login\` directly, dropping \`amazon-ecr-login\`.

## Files changed
- \`.github/workflows/build-pi-image.yml\` — multi-tag loop in shell
- \`.github/workflows/deploy-pi.yml\` — single SHA tag

🤖 Generated with [Claude Code](https://claude.com/claude-code)