### PR TITLE
fix(auth): route fetch-with-auth through getAuthModule (silences "Amplify not configured" on /en)

### DIFF
--- a/src/lib/fetch-with-auth.ts
+++ b/src/lib/fetch-with-auth.ts
@@ -1,12 +1,26 @@
 /**
- * Fetch wrapper that automatically adds JWT token from Cognito
- * For use on the client side in authenticated pages
+ * Fetch wrapper that automatically adds JWT token from Cognito.
+ * For use on the client side in authenticated pages.
+ *
+ * IMPORTANT: This module MUST NOT statically import from `aws-amplify/auth`.
+ * Anything that statically imports this file would also pull in the ~2 MB
+ * aws-amplify runtime into the initial bundle, AND — because aws-amplify
+ * auto-initializes its credentials provider on first load — would surface
+ * the
+ *
+ *   "Amplify has not been configured. Please call Amplify.configure() ..."
+ *
+ * warning on every page that consumes a fetchWithAuth caller, before the
+ * configure side-effect in `@/lib/amplify-config` has run.
+ *
+ * Route all auth-module access through `getAuthModule()` (which awaits the
+ * config side-effect before handing back `aws-amplify/auth`). See the
+ * long doc comment in `src/lib/amplify-config.ts` for the contract.
  */
-
-import { fetchAuthSession } from "aws-amplify/auth";
 
 export async function fetchWithAuth(url: string, init?: RequestInit): Promise<Response> {
   try {
+    const { fetchAuthSession } = await (await import("@/lib/amplify-config")).getAuthModule();
     const session = await fetchAuthSession();
     const idToken = session.tokens?.idToken?.toString();
 


### PR DESCRIPTION
## Symptom

After PRs #306/#307, the browser console on \`/en\` (and any page that ends up rendering an authenticated fetch helper) still shows:

\`\`\`
Amplify has not been configured. Please call Amplify.configure() before using this service.
\`\`\`

## Root cause

\`src/lib/fetch-with-auth.ts\` statically imported \`fetchAuthSession\` from \`aws-amplify/auth\` at the top of the file:

\`\`\`ts
import { fetchAuthSession } from \"aws-amplify/auth\";
\`\`\`

Any component that imports \`fetchWithAuth\` (\`WorkspaceContext\`, \`/dashboard/page.tsx\`, the portal waiting room client) pulls \`aws-amplify\` into the bundle at parse time. \`aws-amplify\` auto-initializes its credentials provider on first load → fires the \"not configured\" warning before our \`Amplify.configure()\` side-effect in \`amplify-config.ts\` gets a chance to run.

PR #307's \`getAuthModule()\` helper guarantees \`configure\` runs before the auth module is handed back — but only for callers that USE the helper. \`fetch-with-auth.ts\` was the only remaining holdout still using the static import.

## Fix

Replace the static import with the lazy \`getAuthModule()\` call (the same pattern AuthContext now uses for all 12 of its auth-helper sites):

\`\`\`ts
const { fetchAuthSession } = await (await import(\"@/lib/amplify-config\")).getAuthModule();
\`\`\`

## Verification

- \`grep -rn '^import.*from \"aws-amplify' src/\` should now return only \`amplify-config.ts\` (the file that owns the side-effect).
- Local dev console on \`/en\` should no longer log the warning during initial page load or HMR cycles.

## Bundle-size impact

Zero. \`fetchWithAuth\` was already async, so adding one more await for the lazy import doesn't change the call shape. And the static \`aws-amplify\` import that used to be at module-parse time is now lazy — keeping the ~2 MB aws-amplify runtime out of pages that don't actually call \`fetchWithAuth()\`.

## Re: the other console messages from the user's report

| Message | Verdict |
|---|---|
| \"Download the React DevTools\" | React's informational nudge when the extension isn't installed. Ignore. |
| \"A listener indicated an asynchronous response by returning true...\" | Browser-extension content script bug, not ours. Ignore. |
| Preload warnings for CSS chunks + woff2 fonts | Next.js dev-mode artifact. The CSS warning specifically lists \`[root-of-the-server]__0fa~cia._.css\` — that's Turbopack's per-route chunk hashing. In production builds with proper code-splitting these don't fire. Not worth a code change. |

🤖 Generated with [Claude Code](https://claude.com/claude-code)