### PR TITLE
fix(i18n): load de.json so German locale stops falling back to English

### DIFF
--- a/src/i18n/request.ts
+++ b/src/i18n/request.ts
@@ -19,6 +19,8 @@ export default getRequestConfig(async ({ requestLocale }) => {
     messages = (await import("../locales/el.json")).default;
   } else if (locale === "fr") {
     messages = (await import("../locales/fr.json")).default;
+  } else if (locale === "de") {
+    messages = (await import("../locales/de.json")).default;
   } else {
     messages = (await import("../locales/en.json")).default;
   }


### PR DESCRIPTION
## Summary
- `src/i18n/routing.ts` lists `de` as a supported locale and `src/locales/de.json` ships ~26KB of German strings, but `src/i18n/request.ts` only branched on `en`/`el`/`fr` — German visitors silently received English messages.
- One-line fix: add a `de` branch to the request config so the existing translation file is actually loaded.

## Test plan
- [ ] CI `Build` check green
- [ ] Manually load `/de/` route in preview and confirm German strings render (spot-check the hero / nav)