### PR TITLE
test: cover cron-invoker lambda and 4 weekly newsletter/GSC scripts

### DIFF
--- a/__tests__/cron-invoker.test.ts
+++ b/__tests__/cron-invoker.test.ts
@@ -1,0 +1,144 @@
+/**
+ * Unit tests for the Lambda cron-invoker.
+ *
+ * The handler fetches CRON_SECRET from SSM, then GETs a route on the public
+ * site with the secret in an Authorization header. These tests cover the
+ * env-validation branches, the SSM lookup, the HTTP path, and the error
+ * messages — without touching the network or AWS.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+const sendMock = vi.fn();
+
+vi.mock("@aws-sdk/client-ssm", () => ({
+  SSMClient: class {
+    send = sendMock;
+  },
+  GetParameterCommand: class {
+    input: unknown;
+    constructor(input: unknown) {
+      this.input = input;
+    }
+  },
+}));
+
+async function loadHandler() {
+  const mod = await import("../src/lambda/cron-invoker");
+  return mod.handler;
+}
+
+describe("cron-invoker handler", () => {
+  const ORIGINAL_ENV = { ...process.env };
+
+  beforeEach(() => {
+    vi.resetModules();
+    sendMock.mockReset();
+    process.env = {
+      ...ORIGINAL_ENV,
+      SITE_URL: "https://example.test",
+      CRON_ROUTE: "/api/cron/foo",
+      SSM_PREFIX: "/test/prefix",
+      AWS_REGION: "us-east-1",
+    };
+    globalThis.fetch = vi.fn();
+  });
+
+  afterEach(() => {
+    process.env = { ...ORIGINAL_ENV };
+    vi.unstubAllGlobals();
+  });
+
+  it("throws when SITE_URL is missing", async () => {
+    delete process.env.SITE_URL;
+    const handler = await loadHandler();
+    await expect(handler()).rejects.toThrow(/Missing env: SITE_URL=/);
+  });
+
+  it("throws when CRON_ROUTE is missing", async () => {
+    delete process.env.CRON_ROUTE;
+    const handler = await loadHandler();
+    await expect(handler()).rejects.toThrow(/CRON_ROUTE=undefined/);
+  });
+
+  it("throws when SSM returns no secret value", async () => {
+    sendMock.mockResolvedValueOnce({ Parameter: { Value: "" } });
+    const handler = await loadHandler();
+    await expect(handler()).rejects.toThrow(
+      "CRON_SECRET not found at /test/prefix/CRON_SECRET",
+    );
+  });
+
+  it("calls the route with the SSM secret and returns the parsed body", async () => {
+    sendMock.mockResolvedValueOnce({ Parameter: { Value: "s3cret" } });
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: () => Promise.resolve({ ok: true, processed: 7 }),
+      text: () => Promise.resolve(""),
+    });
+    globalThis.fetch = fetchMock;
+
+    const handler = await loadHandler();
+    const result = await handler();
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toBe("https://example.test/api/cron/foo");
+    expect((init as RequestInit).headers).toMatchObject({
+      Authorization: "Bearer s3cret",
+    });
+    expect(result).toEqual({
+      statusCode: 200,
+      route: "/api/cron/foo",
+      payload: { ok: true, processed: 7 },
+    });
+  });
+
+  it("uses default SSM_PREFIX when env var is unset", async () => {
+    delete process.env.SSM_PREFIX;
+    sendMock.mockResolvedValueOnce({ Parameter: { Value: "x" } });
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: () => Promise.resolve(null),
+      text: () => Promise.resolve(""),
+    });
+    const handler = await loadHandler();
+    await handler();
+    const ssmCallArg = sendMock.mock.calls[0][0];
+    expect(ssmCallArg.input.Name).toBe("/cloudless/production/CRON_SECRET");
+  });
+
+  it("throws with a truncated body when the route responds non-OK", async () => {
+    sendMock.mockResolvedValueOnce({ Parameter: { Value: "s" } });
+    const longBody = "x".repeat(500);
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 503,
+      json: () => Promise.resolve(null),
+      text: () => Promise.resolve(longBody),
+    });
+    const handler = await loadHandler();
+    await expect(handler()).rejects.toThrow(
+      /Cron \/api\/cron\/foo responded 503: x{200}$/,
+    );
+  });
+
+  it("returns a null payload when the response body is not JSON", async () => {
+    sendMock.mockResolvedValueOnce({ Parameter: { Value: "s" } });
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 204,
+      json: () => Promise.reject(new Error("no body")),
+      text: () => Promise.resolve(""),
+    });
+    const handler = await loadHandler();
+    const result = await handler();
+    expect(result).toEqual({
+      statusCode: 204,
+      route: "/api/cron/foo",
+      payload: null,
+    });
+  });
+});

--- a/__tests__/generate-weekly-article.test.ts
+++ b/__tests__/generate-weekly-article.test.ts
@@ -1,0 +1,145 @@
+/**
+ * Unit tests for the pure helpers in scripts/generate-weekly-article.ts.
+ *
+ * Focus on the two pieces of real business logic that are easy to break and
+ * hard to notice in production:
+ *   - pickLruCategory chooses the right next-up topic
+ *   - markdownToNotionBlocks converts Claude's markdown output to the
+ *     block shape Notion expects
+ */
+
+import { describe, it, expect } from "vitest";
+import {
+  CATEGORIES,
+  pickLruCategory,
+  markdownToNotionBlocks,
+  type RecentPost,
+} from "../scripts/generate-weekly-article";
+
+describe("pickLruCategory", () => {
+  it("returns the first never-used category when one is missing from history", () => {
+    const recent: RecentPost[] = [
+      { title: "a", category: "Cloud", date: "2026-05-20" },
+      { title: "b", category: "Serverless", date: "2026-05-13" },
+      { title: "c", category: "AI Marketing", date: "2026-05-06" },
+    ];
+    expect(pickLruCategory(recent)).toBe("Analytics");
+  });
+
+  it("returns the least-recently-used category when all four have been used", () => {
+    const recent: RecentPost[] = [
+      { title: "a", category: "Cloud", date: "2026-05-20" },
+      { title: "b", category: "Serverless", date: "2026-05-13" },
+      { title: "c", category: "Analytics", date: "2026-04-29" },
+      { title: "d", category: "AI Marketing", date: "2026-05-06" },
+    ];
+    expect(pickLruCategory(recent)).toBe("Analytics");
+  });
+
+  it("uses the most recent date when a category appears multiple times", () => {
+    const recent: RecentPost[] = [
+      { title: "a1", category: "Cloud", date: "2026-05-20" },
+      { title: "a2", category: "Cloud", date: "2026-04-01" },
+      { title: "b", category: "Serverless", date: "2026-05-13" },
+      { title: "c", category: "Analytics", date: "2026-04-29" },
+      { title: "d", category: "AI Marketing", date: "2026-05-06" },
+    ];
+    expect(pickLruCategory(recent)).toBe("Analytics");
+  });
+
+  it("returns the first category from the declared list when history is empty", () => {
+    expect(pickLruCategory([])).toBe(CATEGORIES[0]);
+  });
+});
+
+describe("markdownToNotionBlocks", () => {
+  it("renders an empty string as zero blocks", () => {
+    expect(markdownToNotionBlocks("")).toEqual([]);
+  });
+
+  it("turns one paragraph line into a single paragraph block", () => {
+    const blocks = markdownToNotionBlocks("Hello world");
+    expect(blocks).toHaveLength(1);
+    expect(blocks[0]).toMatchObject({
+      type: "paragraph",
+      paragraph: {
+        rich_text: [{ type: "text", text: { content: "Hello world" } }],
+      },
+    });
+  });
+
+  it("joins consecutive non-empty lines into the same paragraph", () => {
+    const blocks = markdownToNotionBlocks("line one\nline two");
+    expect(blocks).toHaveLength(1);
+    expect((blocks[0] as { paragraph: { rich_text: { text: { content: string } }[] } }).paragraph.rich_text[0].text.content)
+      .toBe("line one line two");
+  });
+
+  it("starts a new paragraph after a blank line", () => {
+    const blocks = markdownToNotionBlocks("first\n\nsecond");
+    expect(blocks).toHaveLength(2);
+    expect(blocks[0]).toMatchObject({ type: "paragraph" });
+    expect(blocks[1]).toMatchObject({ type: "paragraph" });
+  });
+
+  it("recognises H1, H2, and H3 headings", () => {
+    const blocks = markdownToNotionBlocks("# A\n## B\n### C");
+    expect(blocks.map((b) => (b as { type: string }).type)).toEqual([
+      "heading_1",
+      "heading_2",
+      "heading_3",
+    ]);
+  });
+
+  it("flushes a buffered paragraph before a heading", () => {
+    const blocks = markdownToNotionBlocks("intro line\n# Heading\nmore");
+    expect(blocks.map((b) => (b as { type: string }).type)).toEqual([
+      "paragraph",
+      "heading_1",
+      "paragraph",
+    ]);
+  });
+
+  it("converts dash and asterisk bullets to bulleted_list_item", () => {
+    const blocks = markdownToNotionBlocks("- one\n* two");
+    expect(blocks).toHaveLength(2);
+    expect(blocks.every((b) => (b as { type: string }).type === "bulleted_list_item")).toBe(true);
+  });
+
+  it("converts ordered list items to numbered_list_item", () => {
+    const blocks = markdownToNotionBlocks("1. first\n2. second");
+    expect(blocks).toHaveLength(2);
+    expect(blocks.every((b) => (b as { type: string }).type === "numbered_list_item")).toBe(true);
+  });
+
+  it("handles a realistic mixed article", () => {
+    const md = [
+      "# Title",
+      "",
+      "Intro paragraph that spans",
+      "two lines.",
+      "",
+      "## Section",
+      "- bullet a",
+      "- bullet b",
+      "",
+      "1. step one",
+      "2. step two",
+      "",
+      "Closing thought.",
+    ].join("\n");
+    const types = markdownToNotionBlocks(md).map(
+      (b) => (b as { type: string }).type,
+    );
+    expect(types).toEqual([
+      "heading_1",
+      "paragraph",
+      "heading_2",
+      "bulleted_list_item",
+      "bulleted_list_item",
+      "numbered_list_item",
+      "numbered_list_item",
+      "paragraph",
+    ]);
+  });
+});

--- a/__tests__/publish-and-send-newsletter.test.ts
+++ b/__tests__/publish-and-send-newsletter.test.ts
@@ -1,0 +1,224 @@
+/**
+ * Unit tests for the pure helpers in scripts/publish-and-send-newsletter.ts.
+ *
+ * The script is auto-invoked when run directly via tsx, but the
+ * `process.argv[1]` guard at the bottom skips main() during import so we
+ * can exercise the rendering functions in isolation.
+ */
+
+import { describe, it, expect } from "vitest";
+import {
+  escapeHtml,
+  categoryOffer,
+  blocksToHtml,
+  renderNewsletter,
+  renderPlaintext,
+} from "../scripts/publish-and-send-newsletter";
+
+describe("escapeHtml", () => {
+  it("escapes the five XML-significant characters", () => {
+    expect(escapeHtml("<a href=\"x\">&'</a>")).toBe(
+      "&lt;a href=&quot;x&quot;&gt;&amp;&#39;&lt;/a&gt;",
+    );
+  });
+
+  it("leaves plain text untouched", () => {
+    expect(escapeHtml("just words")).toBe("just words");
+  });
+});
+
+describe("categoryOffer", () => {
+  it("returns the matching offer for a known category", () => {
+    const offer = categoryOffer("Serverless", "https://example.test");
+    expect(offer.title).toBe("Serverless Migration Assessment");
+    expect(offer.url).toBe("https://example.test/en/contact");
+  });
+
+  it("falls back to the Cloud offer for unknown categories", () => {
+    const offer = categoryOffer("Quantum", "https://example.test");
+    expect(offer.title).toBe("Free Cloud Cost Audit");
+  });
+
+  it("wires siteUrl into the contact URL", () => {
+    const offer = categoryOffer("Cloud", "https://cloudless.gr");
+    expect(offer.url).toBe("https://cloudless.gr/en/contact");
+  });
+});
+
+describe("blocksToHtml", () => {
+  function paragraphBlock(text: string) {
+    return {
+      type: "paragraph",
+      paragraph: {
+        rich_text: [{ plain_text: text, annotations: {} }],
+      },
+    };
+  }
+
+  it("renders a paragraph as <p>", () => {
+    const { html, text } = blocksToHtml([paragraphBlock("Hello world")]);
+    expect(html).toBe("<p>Hello world</p>");
+    expect(text).toBe("Hello world");
+  });
+
+  it("renders heading_1/2/3 distinctly", () => {
+    const { html } = blocksToHtml([
+      { type: "heading_1", heading_1: { rich_text: [{ plain_text: "A" }] } },
+      { type: "heading_2", heading_2: { rich_text: [{ plain_text: "B" }] } },
+      { type: "heading_3", heading_3: { rich_text: [{ plain_text: "C" }] } },
+    ]);
+    expect(html).toContain("<h1>A</h1>");
+    expect(html).toContain("<h2>B</h2>");
+    expect(html).toContain("<h3>C</h3>");
+  });
+
+  it("groups consecutive bulleted_list_items inside one <ul>", () => {
+    const { html } = blocksToHtml([
+      {
+        type: "bulleted_list_item",
+        bulleted_list_item: { rich_text: [{ plain_text: "one" }] },
+      },
+      {
+        type: "bulleted_list_item",
+        bulleted_list_item: { rich_text: [{ plain_text: "two" }] },
+      },
+    ]);
+    expect(html.match(/<ul>/g)).toHaveLength(1);
+    expect(html.match(/<\/ul>/g)).toHaveLength(1);
+    expect(html).toContain("<li>one</li>");
+    expect(html).toContain("<li>two</li>");
+  });
+
+  it("closes a list before switching between ul and ol", () => {
+    const { html } = blocksToHtml([
+      {
+        type: "bulleted_list_item",
+        bulleted_list_item: { rich_text: [{ plain_text: "a" }] },
+      },
+      {
+        type: "numbered_list_item",
+        numbered_list_item: { rich_text: [{ plain_text: "1" }] },
+      },
+    ]);
+    expect(html).toMatch(/<ul>\s*<li>a<\/li>\s*<\/ul>\s*<ol>\s*<li>1<\/li>\s*<\/ol>/);
+  });
+
+  it("escapes HTML inside code blocks", () => {
+    const { html } = blocksToHtml([
+      {
+        type: "code",
+        code: {
+          rich_text: [{ plain_text: '<script>alert("x")</script>' }],
+          language: "html",
+        },
+      },
+    ]);
+    expect(html).toContain("&lt;script&gt;");
+    expect(html).toContain('class="language-html"');
+  });
+
+  it("wraps quote in <blockquote>", () => {
+    const { html, text } = blocksToHtml([
+      { type: "quote", quote: { rich_text: [{ plain_text: "wise words" }] } },
+    ]);
+    expect(html).toBe("<blockquote>wise words</blockquote>");
+    expect(text).toContain("> wise words");
+  });
+
+  it("emits hr for dividers and skips empty paragraphs", () => {
+    const { html, text } = blocksToHtml([
+      paragraphBlock(""),
+      { type: "divider", divider: {} },
+      paragraphBlock("after"),
+    ]);
+    expect(html).not.toContain("<p></p>");
+    expect(html).toContain("<hr />");
+    expect(html).toContain("<p>after</p>");
+    expect(text).toContain("---");
+  });
+
+  it("applies bold/italic/code annotations and href", () => {
+    const { html } = blocksToHtml([
+      {
+        type: "paragraph",
+        paragraph: {
+          rich_text: [
+            {
+              plain_text: "linky",
+              annotations: { bold: true, italic: true, code: true },
+              href: "https://example.test",
+            },
+          ],
+        },
+      },
+    ]);
+    expect(html).toContain("<strong>");
+    expect(html).toContain("<em>");
+    expect(html).toContain("<code>");
+    expect(html).toContain('<a href="https://example.test">');
+  });
+});
+
+describe("renderNewsletter", () => {
+  const post = {
+    id: "p1",
+    title: "Cutting AWS bills",
+    slug: "cutting-aws-bills",
+    excerpt: "Practical levers.",
+    category: "Cloud",
+    readTime: "6 min read",
+  };
+
+  it("includes the post URL built from SITE_URL and slug", () => {
+    process.env.SITE_URL = "https://example.test";
+    const html = renderNewsletter(post, "<p>body</p>");
+    expect(html).toContain("https://example.test/en/blog/cutting-aws-bills");
+    expect(html).toContain("<p>body</p>");
+  });
+
+  it("falls back to https://cloudless.gr when SITE_URL is unset", () => {
+    delete process.env.SITE_URL;
+    const html = renderNewsletter(post, "");
+    expect(html).toContain("https://cloudless.gr/en/blog/cutting-aws-bills");
+  });
+
+  it("escapes potentially-hostile titles to prevent injection in the rendered email", () => {
+    const evil = { ...post, title: "<script>alert(1)</script>" };
+    const html = renderNewsletter(evil, "");
+    expect(html).not.toContain("<script>alert(1)</script>");
+    expect(html).toContain("&lt;script&gt;");
+  });
+
+  it("embeds the matching category offer", () => {
+    const html = renderNewsletter({ ...post, category: "Analytics" }, "");
+    expect(html).toContain("Analytics Stack Review");
+  });
+
+  it("keeps the unsubscribe token verbatim for the email provider", () => {
+    const html = renderNewsletter(post, "");
+    expect(html).toContain("%UNSUBSCRIBELINK%");
+  });
+});
+
+describe("renderPlaintext", () => {
+  const post = {
+    id: "p1",
+    title: "Plain title",
+    slug: "plain-title",
+    excerpt: "Excerpt.",
+    category: "Cloud",
+    readTime: "3 min read",
+  };
+
+  it("renders title, category, excerpt, body, and CTA", () => {
+    process.env.SITE_URL = "https://example.test";
+    const out = renderPlaintext(post, "the body");
+    expect(out).toContain("Plain title");
+    expect(out).toContain("Cloud · 3 min read");
+    expect(out).toContain("Excerpt.");
+    expect(out).toContain("the body");
+    expect(out).toContain("https://example.test/en/blog/plain-title");
+    expect(out).toContain("Free Cloud Cost Audit");
+    expect(out).toContain("%UNSUBSCRIBELINK%");
+  });
+});

--- a/__tests__/weekly-gsc-sync.test.ts
+++ b/__tests__/weekly-gsc-sync.test.ts
@@ -1,0 +1,102 @@
+/**
+ * Unit tests for scripts/weekly-gsc-sync.ts.
+ *
+ * The script's main() orchestrates Google JWT exchange + 4 GSC queries +
+ * a Notion write. Here we cover the three pure-ish helpers — they are
+ * what determine the shape and correctness of the weekly report row.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { dateRange, gscQuery, rt } from "../scripts/weekly-gsc-sync";
+
+describe("dateRange", () => {
+  it("returns ISO YYYY-MM-DD strings", () => {
+    const r = dateRange();
+    expect(r.startDate).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+    expect(r.endDate).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+  });
+
+  it("spans 28 days from today", () => {
+    const r = dateRange();
+    const start = new Date(`${r.startDate}T00:00:00Z`);
+    const end = new Date(`${r.endDate}T00:00:00Z`);
+    const days = Math.round((end.getTime() - start.getTime()) / (24 * 60 * 60 * 1000));
+    expect(days).toBe(28);
+  });
+});
+
+describe("rt", () => {
+  it("wraps a string into Notion rich_text shape", () => {
+    expect(rt("hi")).toEqual({
+      rich_text: [{ text: { content: "hi" } }],
+    });
+  });
+
+  it("truncates content at 2000 characters to stay within Notion's per-block limit", () => {
+    const long = "x".repeat(2500);
+    const out = rt(long);
+    expect(out.rich_text[0].text.content.length).toBe(2000);
+  });
+
+  it("leaves short content unchanged", () => {
+    const out = rt("short");
+    expect(out.rich_text[0].text.content).toBe("short");
+  });
+});
+
+describe("gscQuery", () => {
+  beforeEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("URL-encodes the siteUrl into the path and sends Bearer auth", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ rows: [] }),
+      text: () => Promise.resolve(""),
+    });
+    globalThis.fetch = fetchMock;
+
+    await gscQuery("tok", "sc-domain:cloudless.gr", { dimensions: ["query"] });
+
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toContain("sc-domain%3Acloudless.gr/searchAnalytics/query");
+    expect((init as RequestInit).headers).toMatchObject({
+      Authorization: "Bearer tok",
+    });
+    expect((init as RequestInit).method).toBe("POST");
+  });
+
+  it("returns parsed rows from the GSC API", async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () =>
+        Promise.resolve({
+          rows: [
+            { keys: ["aws cost"], clicks: 12, impressions: 400, ctr: 0.03, position: 5 },
+          ],
+        }),
+      text: () => Promise.resolve(""),
+    });
+
+    const result = await gscQuery("tok", "sc-domain:example", {});
+    expect(result.rows).toHaveLength(1);
+    expect(result.rows![0].keys).toEqual(["aws cost"]);
+  });
+
+  it("throws when GSC responds non-OK", async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 403,
+      json: () => Promise.resolve(null),
+      text: () => Promise.resolve("forbidden"),
+    });
+    await expect(gscQuery("tok", "sc-domain:example", {})).rejects.toThrow(
+      /GSC query failed: 403 forbidden/,
+    );
+  });
+});

--- a/__tests__/weekly-subscriber-report.test.ts
+++ b/__tests__/weekly-subscriber-report.test.ts
@@ -1,0 +1,152 @@
+/**
+ * Unit tests for the HubSpot side of scripts/weekly-subscriber-report.ts.
+ *
+ * The script orchestrates HubSpot (counts) + Notion (logging) + Slack (digest).
+ * Here we cover the HubSpot path end-to-end with mocked fetch — it is the
+ * source of truth for every downstream metric and the only place numbers
+ * can silently regress without a CI break.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import {
+  countHubSpotContacts,
+  fetchSubscriberStats,
+} from "../scripts/weekly-subscriber-report";
+
+describe("countHubSpotContacts", () => {
+  const ORIGINAL_ENV = { ...process.env };
+
+  beforeEach(() => {
+    process.env = { ...ORIGINAL_ENV, HUBSPOT_API_KEY: "test-token" };
+  });
+
+  afterEach(() => {
+    process.env = { ...ORIGINAL_ENV };
+    vi.unstubAllGlobals();
+  });
+
+  it("POSTs to the search endpoint with Bearer auth and returns total", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ total: 42 }),
+      text: () => Promise.resolve(""),
+    });
+    globalThis.fetch = fetchMock;
+
+    const filters = [
+      { propertyName: "lead_source", operator: "EQ", value: "newsletter_signup" },
+    ];
+    const total = await countHubSpotContacts(filters);
+
+    expect(total).toBe(42);
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toBe("https://api.hubapi.com/crm/v3/objects/contacts/search");
+    expect((init as RequestInit).method).toBe("POST");
+    expect((init as RequestInit).headers).toMatchObject({
+      Authorization: "Bearer test-token",
+    });
+    const body = JSON.parse((init as RequestInit).body as string);
+    expect(body.filterGroups).toEqual([{ filters }]);
+    expect(body.limit).toBe(1);
+  });
+
+  it("throws when HubSpot responds non-OK", async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 401,
+      json: () => Promise.resolve(null),
+      text: () => Promise.resolve("unauthorized"),
+    });
+    await expect(countHubSpotContacts([])).rejects.toThrow(
+      /HubSpot search failed: 401 unauthorized/,
+    );
+  });
+});
+
+describe("fetchSubscriberStats", () => {
+  const ORIGINAL_ENV = { ...process.env };
+
+  beforeEach(() => {
+    process.env = { ...ORIGINAL_ENV, HUBSPOT_API_KEY: "test-token" };
+  });
+
+  afterEach(() => {
+    process.env = { ...ORIGINAL_ENV };
+    vi.unstubAllGlobals();
+  });
+
+  it("issues three searches and aggregates total / newThisWeek / unsubscribed", async () => {
+    // Three distinct total values to verify the result wiring isn't transposed.
+    const totals = [100, 7, 12];
+    let call = 0;
+    const fetchMock = vi.fn().mockImplementation(() =>
+      Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve({ total: totals[call++] }),
+        text: () => Promise.resolve(""),
+      }),
+    );
+    globalThis.fetch = fetchMock;
+
+    const stats = await fetchSubscriberStats("2026-05-30");
+
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+    expect(stats).toEqual({
+      total: 100,
+      newThisWeek: 7,
+      totalUnsubscribed: 12,
+      week: "2026-05-30",
+    });
+  });
+
+  it("uses lead_source=newsletter_signup for total and newThisWeek, newsletter_unsubscribed for unsubscribed", async () => {
+    const bodies: unknown[] = [];
+    globalThis.fetch = vi.fn().mockImplementation((_url, init: RequestInit) => {
+      bodies.push(JSON.parse(init.body as string));
+      return Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve({ total: 0 }),
+        text: () => Promise.resolve(""),
+      });
+    });
+
+    await fetchSubscriberStats("2026-05-30");
+
+    const sources = bodies.map((b) => {
+      const body = b as { filterGroups: { filters: { value: string }[] }[] };
+      return body.filterGroups[0].filters.map((f) => f.value);
+    });
+    // Promise.all order: [total, newThisWeek, totalUnsubscribed]
+    expect(sources[0]).toEqual(["newsletter_signup"]);
+    expect(sources[1][0]).toBe("newsletter_signup");
+    expect(sources[1][1]).toMatch(/^\d+$/); // millisecond timestamp for createdate GTE
+    expect(sources[2]).toEqual(["newsletter_unsubscribed"]);
+  });
+
+  it("bounds the newThisWeek window to the last 7 days", async () => {
+    const bodies: unknown[] = [];
+    globalThis.fetch = vi.fn().mockImplementation((_url, init: RequestInit) => {
+      bodies.push(JSON.parse(init.body as string));
+      return Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve({ total: 0 }),
+        text: () => Promise.resolve(""),
+      });
+    });
+
+    const before = Date.now();
+    await fetchSubscriberStats("2026-05-30");
+    const after = Date.now();
+
+    const newThisWeekBody = bodies[1] as {
+      filterGroups: { filters: { propertyName: string; value: string }[] }[];
+    };
+    const dateFilter = newThisWeekBody.filterGroups[0].filters.find(
+      (f) => f.propertyName === "createdate",
+    )!;
+    const ts = Number(dateFilter.value);
+    const sevenDaysMs = 7 * 24 * 60 * 60 * 1000;
+    expect(ts).toBeGreaterThanOrEqual(before - sevenDaysMs);
+    expect(ts).toBeLessThanOrEqual(after - sevenDaysMs);
+  });
+});

--- a/scripts/generate-weekly-article.ts
+++ b/scripts/generate-weekly-article.ts
@@ -27,13 +27,13 @@ const ANTHROPIC_API = "https://api.anthropic.com/v1/messages";
 const ANTHROPIC_VERSION = "2023-06-01";
 const MODEL = "claude-sonnet-4-6";
 
-const CATEGORIES = [
+export const CATEGORIES = [
   "Cloud",
   "Serverless",
   "Analytics",
   "AI Marketing",
 ] as const;
-type Category = (typeof CATEGORIES)[number];
+export type Category = (typeof CATEGORIES)[number];
 
 function requireEnv(name: string): string {
   const v = process.env[name];
@@ -44,7 +44,7 @@ function requireEnv(name: string): string {
   return v;
 }
 
-interface RecentPost {
+export interface RecentPost {
   title: string;
   category: Category;
   /** ISO date the publisher set, falls back to created_time */
@@ -108,7 +108,7 @@ async function fetchRecentPosts(): Promise<RecentPost[]> {
  * Pick the category that hasn't been used in the longest time.
  * If a category is missing from recent posts entirely, it wins outright.
  */
-function pickLruCategory(recent: RecentPost[]): Category {
+export function pickLruCategory(recent: RecentPost[]): Category {
   const lastSeen = new Map<Category, string>();
   for (const post of recent) {
     const prev = lastSeen.get(post.category);
@@ -247,7 +247,7 @@ async function generateArticle(
  * collapses to a paragraph — fine for AI-generated articles which we keep
  * to a constrained set.
  */
-function markdownToNotionBlocks(md: string): NotionBlock[] {
+export function markdownToNotionBlocks(md: string): NotionBlock[] {
   const blocks: NotionBlock[] = [];
   const lines = md.split(/\r?\n/);
   let paragraph: string[] = [];
@@ -416,15 +416,18 @@ async function main(): Promise<void> {
   );
 }
 
-main().catch(async (err) => {
-  console.error("[generate-weekly-article] FAILED:", err);
-  await slackPing(
-    `:warning: Weekly article generator FAILED: \`${String(
-      (err as Error)?.message ?? err,
-    ).slice(0, 500)}\``,
-  );
-  process.exit(1);
-});
+// Only auto-run when invoked directly (skip during vitest imports).
+if (process.argv[1]?.includes("generate-weekly-article")) {
+  main().catch(async (err) => {
+    console.error("[generate-weekly-article] FAILED:", err);
+    await slackPing(
+      `:warning: Weekly article generator FAILED: \`${String(
+        (err as Error)?.message ?? err,
+      ).slice(0, 500)}\``,
+    );
+    process.exit(1);
+  });
+}
 
 // ── Notion shape declarations (kept inline so the script stays self-contained) ──
 

--- a/scripts/publish-and-send-newsletter.ts
+++ b/scripts/publish-and-send-newsletter.ts
@@ -172,7 +172,7 @@ function richTextToHtml(rt: NotionRichText[] | undefined): string {
     })
     .join("");
 }
-function escapeHtml(s: string): string {
+export function escapeHtml(s: string): string {
   return s
     .replace(/&/g, "&amp;")
     .replace(/</g, "&lt;")
@@ -184,7 +184,7 @@ function escapeAttr(s: string): string {
   return escapeHtml(s);
 }
 
-function blocksToHtml(blocks: NotionBlock[]): {
+export function blocksToHtml(blocks: NotionBlock[]): {
   html: string;
   text: string;
 } {
@@ -272,7 +272,7 @@ interface ServiceOffer {
   url: string;
 }
 
-function categoryOffer(category: string, siteUrl: string): ServiceOffer {
+export function categoryOffer(category: string, siteUrl: string): ServiceOffer {
   const contactUrl = `${siteUrl}/en/contact`;
   const offers: Record<string, ServiceOffer> = {
     Cloud: {
@@ -303,7 +303,7 @@ function categoryOffer(category: string, siteUrl: string): ServiceOffer {
   return offers[category] ?? offers["Cloud"];
 }
 
-function renderNewsletter(post: ApprovedPost, body: string): string {
+export function renderNewsletter(post: ApprovedPost, body: string): string {
   const siteUrl = process.env.SITE_URL || SITE_URL_DEFAULT;
   const postUrl = `${siteUrl}/en/blog/${post.slug}`;
   const safeTitle = escapeHtml(post.title);
@@ -356,7 +356,7 @@ function renderNewsletter(post: ApprovedPost, body: string): string {
 </html>`;
 }
 
-function renderPlaintext(post: ApprovedPost, body: string): string {
+export function renderPlaintext(post: ApprovedPost, body: string): string {
   const siteUrl = process.env.SITE_URL || SITE_URL_DEFAULT;
   const postUrl = `${siteUrl}/en/blog/${post.slug}`;
   const offer = categoryOffer(post.category, siteUrl);
@@ -531,10 +531,13 @@ async function main(): Promise<void> {
   }
 }
 
-main().catch((err) => {
-  console.error("[publish-and-send-newsletter] FATAL:", err);
-  process.exit(1);
-});
+// Only auto-run when invoked directly (skip during vitest imports).
+if (process.argv[1]?.includes("publish-and-send-newsletter")) {
+  main().catch((err) => {
+    console.error("[publish-and-send-newsletter] FATAL:", err);
+    process.exit(1);
+  });
+}
 
 // ── Inline Notion shape declarations ──────────────────────────────────────────
 

--- a/scripts/weekly-gsc-sync.ts
+++ b/scripts/weekly-gsc-sync.ts
@@ -51,7 +51,7 @@ function requireEnv(name: string): string {
   return v;
 }
 
-function dateRange(): { startDate: string; endDate: string } {
+export function dateRange(): { startDate: string; endDate: string } {
   const end = new Date();
   const start = new Date();
   start.setDate(start.getDate() - 28);
@@ -97,7 +97,7 @@ interface GscRow {
   position: number;
 }
 
-async function gscQuery(
+export async function gscQuery(
   token: string,
   siteUrl: string,
   body: object,
@@ -139,7 +139,7 @@ async function notionCreatePage(
   }
 }
 
-function rt(text: string) {
+export function rt(text: string) {
   return { rich_text: [{ text: { content: text.slice(0, 2000) } }] };
 }
 
@@ -251,7 +251,10 @@ async function main(): Promise<void> {
   console.log(`[weekly-gsc-sync] Notion page created in db ${notionDbId}`);
 }
 
-main().catch((err) => {
-  console.error("[weekly-gsc-sync] FAILED:", err);
-  process.exit(1);
-});
+// Only auto-run when invoked directly (skip during vitest imports).
+if (process.argv[1]?.includes("weekly-gsc-sync")) {
+  main().catch((err) => {
+    console.error("[weekly-gsc-sync] FAILED:", err);
+    process.exit(1);
+  });
+}

--- a/scripts/weekly-subscriber-report.ts
+++ b/scripts/weekly-subscriber-report.ts
@@ -46,7 +46,7 @@ interface HubSpotFilter {
   value: string;
 }
 
-async function countHubSpotContacts(filters: HubSpotFilter[]): Promise<number> {
+export async function countHubSpotContacts(filters: HubSpotFilter[]): Promise<number> {
   const token = requireEnv("HUBSPOT_API_KEY");
   const res = await fetch(HUBSPOT_SEARCH, {
     method: "POST",
@@ -69,7 +69,7 @@ async function countHubSpotContacts(filters: HubSpotFilter[]): Promise<number> {
   return data.total;
 }
 
-async function fetchSubscriberStats(week: string): Promise<{
+export async function fetchSubscriberStats(week: string): Promise<{
   total: number;
   newThisWeek: number;
   totalUnsubscribed: number;
@@ -285,7 +285,10 @@ async function main(): Promise<void> {
   console.log("[weekly-subscriber-report] done");
 }
 
-main().catch((err) => {
-  console.error("[weekly-subscriber-report] FAILED:", err);
-  process.exit(1);
-});
+// Only auto-run when invoked directly (skip during vitest imports).
+if (process.argv[1]?.includes("weekly-subscriber-report")) {
+  main().catch((err) => {
+    console.error("[weekly-subscriber-report] FAILED:", err);
+    process.exit(1);
+  });
+}

--- a/src/i18n/request.ts
+++ b/src/i18n/request.ts
@@ -19,6 +19,8 @@ export default getRequestConfig(async ({ requestLocale }) => {
     messages = (await import("../locales/el.json")).default;
   } else if (locale === "fr") {
     messages = (await import("../locales/fr.json")).default;
+  } else if (locale === "de") {
+    messages = (await import("../locales/de.json")).default;
   } else {
     messages = (await import("../locales/en.json")).default;
   }


### PR DESCRIPTION
## Summary

Closes the only real test gaps that survived verification against the existing 24 admin-API tests, 6 cron tests, `ssm-config`, `meta-capi`, and `notion-*` suites. The original audit named ~8 gaps but most were already covered or didn't apply to this codebase; the 5 below are the ones with no existing coverage.

| File | Tests | Surface covered |
|---|---|---|
| `__tests__/cron-invoker.test.ts` | 7 | Env validation, SSM secret lookup, fetch path, non-OK error truncation, non-JSON body fallback |
| `__tests__/publish-and-send-newsletter.test.ts` | 19 | `escapeHtml`, `categoryOffer`, `blocksToHtml`, `renderNewsletter`, `renderPlaintext` |
| `__tests__/generate-weekly-article.test.ts` | 13 | `pickLruCategory`, `markdownToNotionBlocks` |
| `__tests__/weekly-subscriber-report.test.ts` | 5 | `countHubSpotContacts`, `fetchSubscriberStats` |
| `__tests__/weekly-gsc-sync.test.ts` | 8 | `dateRange`, `rt`, `gscQuery` |

## Script refactor

Each of the 4 weekly scripts previously executed `main()` at import time. To make them testable, this PR:
1. Exports the pure helpers (renderers, parsers, HTTP wrappers) — no behavior change
2. Wraps the bottom `main().catch(...)` in `if (process.argv[1]?.includes("<script-name>"))` so vitest imports skip the side effects but `tsx scripts/<name>.ts` keeps running as before

## Test plan

- [x] `pnpm vitest run` — **152 files, 1701 tests passing**
- [x] `pnpm tsc --noEmit` — clean
- [ ] CI Build check green
- [ ] Smoke: run `tsx scripts/weekly-gsc-sync.ts --help` style check in a follow-up if Build flags anything