### PR TITLE
fix(ci): use get-login-password|docker login to bypass credential-store on Pi runners

### DIFF
--- a/.github/workflows/deploy-pi.yml
+++ b/.github/workflows/deploy-pi.yml
@@ -127,20 +127,19 @@ jobs:
             APP_VERSION=${{ github.sha }}
             NEXT_PUBLIC_GOOGLE_SITE_VERIFICATION=LXkyzmWrAYuY1C6XD6TKaqA31KB72xbUlkimE0vKI8w
 
-      # Re-login immediately before push — ECR tokens expire after ~12 min
-      # and the build step can take longer than that on a cold cache.
-      - name: Re-login to ECR before push
-        if: steps.check_ecr.outputs.exists != 'true'
-        uses: aws-actions/amazon-ecr-login@fa648b43de3d4d023bcb3f89ed6940096949c419 # v2
-
-      # Push via dockerd's own registry client (not buildkit). dockerd
-      # re-reads ~/.docker/config.json for every push and does not
-      # perform buildkit's manifest-HEAD dance against ECR.
+      # Login + push in one step — avoids credential-store issues on self-hosted
+      # Pi runners where `amazon-ecr-login` writes to secretservice/pass but
+      # dockerd reads only ~/.docker/config.json.
+      # `aws ecr get-login-password | docker login --password-stdin` writes
+      # directly to config.json, bypassing any credential helper.
       - name: Push to ECR
         if: steps.check_ecr.outputs.exists != 'true'
         run: |
           set -euo pipefail
           TAG="${{ env.ECR_REGISTRY }}/${{ env.ECR_REPOSITORY }}:${{ steps.check_ecr.outputs.short_sha }}"
+          echo "==> docker login via get-login-password"
+          aws ecr get-login-password --region ${{ env.AWS_REGION }} \
+            | docker login --username AWS --password-stdin ${{ env.ECR_REGISTRY }}
           echo "==> docker push ${TAG}"
           docker push "${TAG}"
 


### PR DESCRIPTION
## Summary

- The `amazon-ecr-login` action succeeds but writes credentials to the OS credential store (secretservice/pass) on self-hosted Pi runners
- `docker push` reads only `~/.docker/config.json`, so it sees no credentials → `no basic auth credentials`
- Fix: replace the action with `aws ecr get-login-password | docker login --password-stdin` which writes directly to `config.json`

## Root cause trail
- PR #318: added re-login step before push → ran, completed silently, push still failed
- This confirms token expiry was never the issue — the credential store was always the culprit

## Test plan
- [ ] Merge and watch deploy-pi run — `Push to ECR` step should log `Login Succeeded` then push layers
- [ ] Job 2 rollout should complete

🤖 Generated with [Claude Code](https://claude.com/claude-code)