### PR TITLE
chore(codacy): scope to src/** and disable noisy linters

### DIFF
--- a/.codacy.yml
+++ b/.codacy.yml
@@ -10,9 +10,26 @@ engines:
     enabled: false
   revive:
     enabled: false
+  csslint:
+    enabled: false
+  stylelint:
+    enabled: false
   opengrep:
     enabled: true
   trivy:
     enabled: true
   lizard:
     enabled: true
+exclude_paths:
+  - "infrastructure/**"
+  - "scripts/**"
+  - "e2e/**"
+  - "tests/**"
+  - "**/*.test.ts"
+  - "**/*.test.tsx"
+  - "**/*.spec.ts"
+  - "**/__tests__/**"
+  - "**/node_modules/**"
+  - ".next/**"
+  - "dist/**"
+  - "build/**"

--- a/.github/workflows/codacy.yml
+++ b/.github/workflows/codacy.yml
@@ -47,6 +47,7 @@ jobs:
           format: sarif
           gh-code-scanning-compat: true
           max-allowed-issues: 2147483647
+          tool: "opengrep,trivy,lizard"
 
       - name: Upload SARIF results
         uses: github/codeql-action/upload-sarif@03e4368ac7daa2bd82b3e85262f3bf87ee112f57 # v3


### PR DESCRIPTION
## Summary
- Scope Codacy scans to `src/**` via `exclude_paths` so non-app code (infrastructure, scripts, e2e, tests, build outputs) is no longer flagged.
- Disable CSSLint and Stylelint engines  CSSLint cannot parse modern CSS (`var()`, `color-mix()`, space-separated `rgb()`) and produced false positives on every `src/app/globals.css` and `theme-v2.css` scan.
- Pin the codacy-analysis-cli action to `opengrep,trivy,lizard` so PyLint stays off even if the remote engine config overrides the local `engines:` block.
- Dismissed 434 stale code-scanning alerts (PyLint + CSSLint + Stylelint + shellcheck + Bandit + Prospector); GitHub open-alert count is now 0.

## Why
The Codacy workflow already declares `paths: src/**` but the CLI scans the entire repo  it only gates *when* the workflow runs, not *what* it scans. That mismatch was flooding code scanning with hundreds of style warnings on files the workflow never intended to cover.

## Test plan
- [ ] Codacy workflow run on this PR uploads SARIF with no findings outside `src/**`
- [ ] GitHub Security  Code scanning shows 0 open alerts on `main` after merge