### PR TITLE
fix(auth): lazy-load aws-amplify SDK to fully silence not-configured warning

### DIFF
--- a/__tests__/amplify-config.test.ts
+++ b/__tests__/amplify-config.test.ts
@@ -13,17 +13,18 @@ describe("amplify-config.ts", () => {
     delete process.env.NEXT_PUBLIC_COGNITO_CLIENT_ID;
   });
 
-  it("configureAmplify returns false when env vars are missing", async () => {
+  it("configureAmplify resolves false when env vars are missing", async () => {
     const { configureAmplify } = await import("@/lib/amplify-config");
-    expect(configureAmplify()).toBe(false);
+    await expect(configureAmplify()).resolves.toBe(false);
   });
 
-  it("configureAmplify returns true when both env vars are set", async () => {
+  it("configureAmplify resolves true when both env vars are set", async () => {
     process.env.NEXT_PUBLIC_COGNITO_USER_POOL_ID = "us-east-1_TestPool";
     process.env.NEXT_PUBLIC_COGNITO_CLIENT_ID = "test-client-id";
 
     vi.resetModules();
     const { configureAmplify } = await import("@/lib/amplify-config");
-    expect(configureAmplify()).toBe(true);
+    await expect(configureAmplify()).resolves.toBe(true);
+    expect(mockAmplifyConfigureFn).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/context/AuthContext.tsx
+++ b/src/context/AuthContext.tsx
@@ -206,7 +206,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       let ok: boolean;
       try {
         const { configureAmplify } = await import("@/lib/amplify-config");
-        ok = configureAmplify();
+        ok = await configureAmplify();
       } catch (err) {
         if (!cancelled) {
           console.error("Amplify configuration failed:", err);

--- a/src/lib/amplify-config.ts
+++ b/src/lib/amplify-config.ts
@@ -1,67 +1,78 @@
 "use client";
 
-import { Amplify } from "aws-amplify";
-
 /**
- * Configure AWS Amplify with Cognito User Pool credentials.
+ * Single entry point for configuring AWS Amplify and loading
+ * `aws-amplify/auth` in a way that guarantees `Amplify.configure()` runs
+ * before any auth helper (signIn, getCurrentUser, fetchAuthSession, ...)
+ * is invoked.
  *
- * Called at module load time (not inside useEffect) so the config is in place
- * before any auth function (signIn, getCurrentUser, ...) is invoked.
+ * Why this file does NOT statically import `aws-amplify`:
+ *   A static `import { Amplify } from "aws-amplify"` loads the ~2 MB SDK
+ *   eagerly AND registers internal Hub listeners during module init.
+ *   Those listeners can dispatch auth events before our synchronous
+ *   `Amplify.configure(...)` call lands on the singleton, surfacing:
  *
- * NEXT_PUBLIC_* vars are inlined by Next.js at build/dev-server start,
- * so process.env.NEXT_PUBLIC_* always resolves on the client without needing
- * globalThis.process?.env.
+ *     "Amplify has not been configured. Please call Amplify.configure() ..."
+ *
+ *   on the console twice under React StrictMode's dev double-mount.
+ *
+ *   Loading the SDK lazily inside `ensureConfigured()` collapses load +
+ *   configure into a single microtask — by the time the returned promise
+ *   resolves, the singleton config is provably in place.
+ *
+ *   NEXT_PUBLIC_* vars are inlined by Next.js at build / dev-server start,
+ *   so process.env.NEXT_PUBLIC_* always resolves on the client.
  */
+
 const userPoolId = process.env.NEXT_PUBLIC_COGNITO_USER_POOL_ID ?? "";
 const userPoolClientId = process.env.NEXT_PUBLIC_COGNITO_CLIENT_ID ?? "";
+const hasCognitoEnv = Boolean(userPoolId && userPoolClientId);
 
-const isConfigured = Boolean(userPoolId && userPoolClientId);
+let configurePromise: Promise<boolean> | null = null;
 
-if (isConfigured) {
-  Amplify.configure(
-    {
-      Auth: {
-        Cognito: {
-          userPoolId,
-          userPoolClientId,
+function ensureConfigured(): Promise<boolean> {
+  if (configurePromise) return configurePromise;
+
+  if (!hasCognitoEnv) {
+    configurePromise = Promise.resolve(false);
+    return configurePromise;
+  }
+
+  configurePromise = (async () => {
+    const { Amplify } = await import("aws-amplify");
+    Amplify.configure(
+      {
+        Auth: {
+          Cognito: {
+            userPoolId,
+            userPoolClientId,
+          },
         },
       },
-    },
-    { ssr: true }
-  );
+      { ssr: true }
+    );
+    return true;
+  })();
+
+  return configurePromise;
 }
 
-/** Returns true when Amplify has been configured with valid Cognito credentials. */
-export function configureAmplify(): boolean {
-  return isConfigured;
+/** Resolves to true when Amplify is (now) configured with Cognito credentials. */
+export function configureAmplify(): Promise<boolean> {
+  return ensureConfigured();
 }
 
 /**
- * Single entry point for loading `aws-amplify/auth` in a way that guarantees
- * `Amplify.configure()` has executed first.
- *
- * Why this exists:
- *   AuthContext lazy-imports `aws-amplify/auth` to keep the ~2 MB module out
- *   of the initial public-page bundle (preserved here — this function still
- *   uses dynamic `import()`). But the auth helpers are useless until
- *   `Amplify.configure()` has run. Without an explicit barrier a caller
- *   could grab `signIn` etc. before the config side-effect lands and hit:
- *     "Amplify has not been configured. Please call Amplify.configure() …"
- *
- * How the guarantee works:
- *   `await import("./amplify-config")` resolves only after THIS module's
- *   top-level body has executed (the `Amplify.configure()` call above).
- *   We chain the auth import off that resolution, so by the time the auth
- *   module's exports are handed back, configure has provably run.
- *
- *   Bundle-size impact: zero — both imports are dynamic, so `aws-amplify`
- *   stays out of the public-page bundle. Webpack also dedupes module
- *   instances, so subsequent calls are cache hits (no extra wall-clock).
+ * Returns the `aws-amplify/auth` module, guaranteed to be loaded AFTER
+ * `Amplify.configure()` has run. Repeat calls are cache hits (Webpack
+ * dedupes the dynamic import).
  */
 export async function getAuthModule(): Promise<typeof import("aws-amplify/auth")> {
-  // Re-import self so the module-load side-effect (Amplify.configure) is
-  // observably complete before the auth import is awaited. Cheap on repeat
-  // calls — Webpack returns the cached module record.
-  await import("./amplify-config");
+  const ok = await ensureConfigured();
+  if (!ok) {
+    throw new Error(
+      "Amplify is not configured: NEXT_PUBLIC_COGNITO_USER_POOL_ID / NEXT_PUBLIC_COGNITO_CLIENT_ID are missing."
+    );
+  }
   return import("aws-amplify/auth");
 }


### PR DESCRIPTION
## Summary
- Collapse the `aws-amplify` SDK import and `Amplify.configure()` call into one async function (`ensureConfigured`) inside [src/lib/amplify-config.ts](src/lib/amplify-config.ts), so the SDK is loaded only when env is present AND configure provably runs before anything else touches the singleton.
- `configureAmplify()` now returns `Promise<boolean>`; updated [src/context/AuthContext.tsx](src/context/AuthContext.tsx) to `await` it.
- Updated unit tests to assert the new async contract.

## Why
PR #313 routed `fetch-with-auth` through `getAuthModule`, but the `"Amplify has not been configured"` warning still surfaced twice on `/en/auth/login` under React StrictMode. Root cause: the static `import { Amplify } from "aws-amplify"` at the top of `amplify-config.ts` eagerly loads the ~2 MB SDK and registers internal Hub listeners during module init, which can dispatch auth events *before* the synchronous `Amplify.configure(...)` call lands.

Loading the SDK inside the same promise as `configure()` makes the two steps atomic from the caller's perspective.

## Test plan
- [x] `pnpm vitest run __tests__/amplify-config.test.ts` — 2/2 passing
- [x] Local dev: `http://localhost:4000/en/auth/login` shows zero Amplify warnings, login form renders, no console errors
- [ ] CI green