### PR TITLE
fix(auth): SSR-side Cognito config to defeat Turbopack env-inlining bug

### DIFF
--- a/__tests__/amplify-config.test.ts
+++ b/__tests__/amplify-config.test.ts
@@ -13,18 +13,17 @@ describe("amplify-config.ts", () => {
     delete process.env.NEXT_PUBLIC_COGNITO_CLIENT_ID;
   });
 
-  it("configureAmplify resolves false when env vars are missing", async () => {
+  it("configureAmplify returns false when env vars are missing", async () => {
     const { configureAmplify } = await import("@/lib/amplify-config");
-    await expect(configureAmplify()).resolves.toBe(false);
+    expect(configureAmplify()).toBe(false);
   });
 
-  it("configureAmplify resolves true when both env vars are set", async () => {
+  it("configureAmplify returns true when both env vars are set", async () => {
     process.env.NEXT_PUBLIC_COGNITO_USER_POOL_ID = "us-east-1_TestPool";
     process.env.NEXT_PUBLIC_COGNITO_CLIENT_ID = "test-client-id";
 
     vi.resetModules();
     const { configureAmplify } = await import("@/lib/amplify-config");
-    await expect(configureAmplify()).resolves.toBe(true);
-    expect(mockAmplifyConfigureFn).toHaveBeenCalledTimes(1);
+    expect(configureAmplify()).toBe(true);
   });
 });

--- a/__tests__/amplify-config.test.ts
+++ b/__tests__/amplify-config.test.ts
@@ -9,21 +9,46 @@ vi.mock("aws-amplify", () => ({
 describe("amplify-config.ts", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    delete process.env.NEXT_PUBLIC_COGNITO_USER_POOL_ID;
-    delete process.env.NEXT_PUBLIC_COGNITO_CLIENT_ID;
-  });
-
-  it("configureAmplify returns false when env vars are missing", async () => {
-    const { configureAmplify } = await import("@/lib/amplify-config");
-    expect(configureAmplify()).toBe(false);
-  });
-
-  it("configureAmplify returns true when both env vars are set", async () => {
-    process.env.NEXT_PUBLIC_COGNITO_USER_POOL_ID = "us-east-1_TestPool";
-    process.env.NEXT_PUBLIC_COGNITO_CLIENT_ID = "test-client-id";
-
     vi.resetModules();
-    const { configureAmplify } = await import("@/lib/amplify-config");
-    expect(configureAmplify()).toBe(true);
+  });
+
+  it("configureAmplifyWith returns false when credentials are empty", async () => {
+    const { configureAmplifyWith, isAmplifyConfigured } = await import("@/lib/amplify-config");
+    expect(configureAmplifyWith({ userPoolId: "", userPoolClientId: "" })).toBe(false);
+    expect(isAmplifyConfigured()).toBe(false);
+    expect(mockAmplifyConfigureFn).not.toHaveBeenCalled();
+  });
+
+  it("configureAmplifyWith returns true and calls Amplify.configure once", async () => {
+    const { configureAmplifyWith, isAmplifyConfigured } = await import("@/lib/amplify-config");
+
+    expect(
+      configureAmplifyWith({
+        userPoolId: "us-east-1_TestPool",
+        userPoolClientId: "test-client-id",
+      })
+    ).toBe(true);
+    expect(isAmplifyConfigured()).toBe(true);
+    expect(mockAmplifyConfigureFn).toHaveBeenCalledTimes(1);
+    expect(mockAmplifyConfigureFn).toHaveBeenCalledWith(
+      {
+        Auth: {
+          Cognito: {
+            userPoolId: "us-east-1_TestPool",
+            userPoolClientId: "test-client-id",
+          },
+        },
+      },
+      { ssr: true }
+    );
+
+    // Idempotent — repeated calls do not re-invoke Amplify.configure.
+    expect(
+      configureAmplifyWith({
+        userPoolId: "us-east-1_TestPool",
+        userPoolClientId: "test-client-id",
+      })
+    ).toBe(true);
+    expect(mockAmplifyConfigureFn).toHaveBeenCalledTimes(1);
   });
 });

--- a/__tests__/auth-context.test.ts
+++ b/__tests__/auth-context.test.ts
@@ -1,9 +1,9 @@
 /**
  * AuthContext / amplify-config guard tests
  *
- * Reproduces the "Amplify has not been configured" browser error pattern
- * (AuthContext.tsx:241). Root cause: callers invoke getAuthModule() before
- * configureAmplify() returns true, or env vars are absent in the environment.
+ * Verifies the prop-driven configuration path:
+ * Server Component reads NEXT_PUBLIC_COGNITO_* and passes them as a
+ * cognitoConfig prop to AuthProvider, which calls configureAmplifyWith().
  *
  * Tests use real module code where possible. Mocks are limited to the
  * aws-amplify SDK boundary (we can't call real Cognito in unit tests).
@@ -11,103 +11,96 @@
 
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 
-// ── helpers ──────────────────────────────────────────────────────────────────
+// ── configureAmplifyWith ──────────────────────────────────────────────────────
 
-/** Temporarily set Cognito env vars for one test. */
-async function withCognitoEnv<T>(
-  userPoolId: string,
-  clientId: string,
-  fn: () => Promise<T>,
-): Promise<T> {
-  const prev = {
-    pool: process.env.NEXT_PUBLIC_COGNITO_USER_POOL_ID,
-    client: process.env.NEXT_PUBLIC_COGNITO_CLIENT_ID,
-  };
-  process.env.NEXT_PUBLIC_COGNITO_USER_POOL_ID = userPoolId;
-  process.env.NEXT_PUBLIC_COGNITO_CLIENT_ID = clientId;
-  try {
-    return await fn();
-  } finally {
-    if (prev.pool === undefined) delete process.env.NEXT_PUBLIC_COGNITO_USER_POOL_ID;
-    else process.env.NEXT_PUBLIC_COGNITO_USER_POOL_ID = prev.pool;
-    if (prev.client === undefined) delete process.env.NEXT_PUBLIC_COGNITO_CLIENT_ID;
-    else process.env.NEXT_PUBLIC_COGNITO_CLIENT_ID = prev.client;
-  }
-}
-
-// ── configureAmplify ─────────────────────────────────────────────────────────
-
-describe("configureAmplify()", () => {
+describe("configureAmplifyWith()", () => {
   beforeEach(() => {
     vi.resetModules();
-    delete process.env.NEXT_PUBLIC_COGNITO_USER_POOL_ID;
-    delete process.env.NEXT_PUBLIC_COGNITO_CLIENT_ID;
+    vi.clearAllMocks();
   });
 
   afterEach(() => vi.restoreAllMocks());
 
-  it("returns false when both Cognito env vars are absent", async () => {
+  it("returns false when both credentials are empty", async () => {
     vi.mock("aws-amplify", () => ({ Amplify: { configure: vi.fn() } }));
-    const { configureAmplify } = await import("@/lib/amplify-config");
-    expect(configureAmplify()).toBe(false);
+    const { configureAmplifyWith, isAmplifyConfigured } = await import(
+      "@/lib/amplify-config"
+    );
+    expect(configureAmplifyWith({ userPoolId: "", userPoolClientId: "" })).toBe(false);
+    expect(isAmplifyConfigured()).toBe(false);
   });
 
-  it("returns false when only COGNITO_USER_POOL_ID is set", async () => {
-    await withCognitoEnv("us-east-1_testPool", "", async () => {
-      vi.resetModules();
-      vi.mock("aws-amplify", () => ({ Amplify: { configure: vi.fn() } }));
-      const { configureAmplify } = await import("@/lib/amplify-config");
-      expect(configureAmplify()).toBe(false);
-    });
+  it("returns false when only userPoolId is set", async () => {
+    vi.mock("aws-amplify", () => ({ Amplify: { configure: vi.fn() } }));
+    const { configureAmplifyWith } = await import("@/lib/amplify-config");
+    expect(
+      configureAmplifyWith({ userPoolId: "us-east-1_testPool", userPoolClientId: "" })
+    ).toBe(false);
   });
 
-  it("returns false when only COGNITO_CLIENT_ID is set", async () => {
-    await withCognitoEnv("", "testClientId", async () => {
-      vi.resetModules();
-      vi.mock("aws-amplify", () => ({ Amplify: { configure: vi.fn() } }));
-      const { configureAmplify } = await import("@/lib/amplify-config");
-      expect(configureAmplify()).toBe(false);
-    });
+  it("returns false when only userPoolClientId is set", async () => {
+    vi.mock("aws-amplify", () => ({ Amplify: { configure: vi.fn() } }));
+    const { configureAmplifyWith } = await import("@/lib/amplify-config");
+    expect(
+      configureAmplifyWith({ userPoolId: "", userPoolClientId: "testClientId" })
+    ).toBe(false);
   });
 
-  it("returns true when both Cognito env vars are set", async () => {
-    await withCognitoEnv("us-east-1_testPool", "testClientId", async () => {
-      vi.resetModules();
-      vi.mock("aws-amplify", () => ({ Amplify: { configure: vi.fn() } }));
-      const { configureAmplify } = await import("@/lib/amplify-config");
-      expect(configureAmplify()).toBe(true);
-    });
+  it("returns true and flips isAmplifyConfigured() to true when both credentials are set", async () => {
+    vi.mock("aws-amplify", () => ({ Amplify: { configure: vi.fn() } }));
+    const { configureAmplifyWith, isAmplifyConfigured } = await import(
+      "@/lib/amplify-config"
+    );
+
+    expect(
+      configureAmplifyWith({
+        userPoolId: "us-east-1_testPool",
+        userPoolClientId: "testClientId",
+      })
+    ).toBe(true);
+    expect(isAmplifyConfigured()).toBe(true);
+
+    // Idempotent — repeated calls still return true and don't reset state.
+    expect(
+      configureAmplifyWith({
+        userPoolId: "us-east-1_testPool",
+        userPoolClientId: "testClientId",
+      })
+    ).toBe(true);
+    expect(isAmplifyConfigured()).toBe(true);
   });
 });
 
 // ── getAuthModule ─────────────────────────────────────────────────────────────
 
 describe("getAuthModule()", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+  });
+
   afterEach(() => vi.restoreAllMocks());
 
-  it("resolves with auth functions when env vars are set", async () => {
-    await withCognitoEnv("us-east-1_testPool", "testClientId", async () => {
-      vi.resetModules();
-      vi.mock("aws-amplify", () => ({ Amplify: { configure: vi.fn() } }));
-      vi.mock("aws-amplify/auth", () => ({
-        signIn: vi.fn(),
-        signOut: vi.fn(),
-        getCurrentUser: vi.fn(),
-        fetchAuthSession: vi.fn(),
-        fetchUserAttributes: vi.fn(),
-        confirmSignIn: vi.fn(),
-        signUp: vi.fn(),
-        confirmSignUp: vi.fn(),
-        resetPassword: vi.fn(),
-        confirmResetPassword: vi.fn(),
-        updateUserAttributes: vi.fn(),
-      }));
-      const { getAuthModule } = await import("@/lib/amplify-config");
-      const auth = await getAuthModule();
-      expect(typeof auth.signIn).toBe("function");
-      expect(typeof auth.getCurrentUser).toBe("function");
-      expect(typeof auth.fetchAuthSession).toBe("function");
-    });
+  it("resolves with auth functions", async () => {
+    vi.mock("aws-amplify", () => ({ Amplify: { configure: vi.fn() } }));
+    vi.mock("aws-amplify/auth", () => ({
+      signIn: vi.fn(),
+      signOut: vi.fn(),
+      getCurrentUser: vi.fn(),
+      fetchAuthSession: vi.fn(),
+      fetchUserAttributes: vi.fn(),
+      confirmSignIn: vi.fn(),
+      signUp: vi.fn(),
+      confirmSignUp: vi.fn(),
+      resetPassword: vi.fn(),
+      confirmResetPassword: vi.fn(),
+      updateUserAttributes: vi.fn(),
+    }));
+    const { getAuthModule } = await import("@/lib/amplify-config");
+    const auth = await getAuthModule();
+    expect(typeof auth.signIn).toBe("function");
+    expect(typeof auth.getCurrentUser).toBe("function");
+    expect(typeof auth.fetchAuthSession).toBe("function");
   });
 
   it("fetchAuthSession result has the shape AuthContext expects", async () => {
@@ -126,7 +119,6 @@ describe("getAuthModule()", () => {
       },
     };
 
-    // Simulate AuthContext's token extraction
     const idToken = mockSession.tokens?.idToken?.toString();
     expect(idToken).toBeTruthy();
 
@@ -149,14 +141,12 @@ describe("getAuthModule()", () => {
 // ── AuthContext init guard contract ──────────────────────────────────────────
 
 describe("AuthContext init guard contract", () => {
-  afterEach(() => vi.restoreAllMocks());
-
-  it("when configureAmplify returns false, checkAuth must not be called", () => {
+  it("when configureAmplifyWith returns false, checkAuth must not be called", () => {
     // Mirrors the guard in AuthContext.tsx:
     //   if (!ok) { setConfigError(...); return; }
     //   checkAuth();
     const checkAuth = vi.fn();
-    const configured = false; // simulates configureAmplify() returning false
+    const configured = false;
 
     if (!configured) {
       // set configError + return — checkAuth never called
@@ -167,7 +157,7 @@ describe("AuthContext init guard contract", () => {
     expect(checkAuth).not.toHaveBeenCalled();
   });
 
-  it("when configureAmplify returns true, checkAuth is called", () => {
+  it("when configureAmplifyWith returns true, checkAuth is called", () => {
     const checkAuth = vi.fn();
     const configured = true;
 
@@ -181,8 +171,6 @@ describe("AuthContext init guard contract", () => {
   });
 
   it("checkAuth catches getAuthModule errors and sets configError (no crash)", async () => {
-    // Reproduces AuthContext.checkAuth error path — the "Amplify not configured"
-    // warning is caught here and surfaced as configError, not an uncaught throw.
     const amplifyError = new Error(
       "Amplify has not been configured. Please call Amplify.configure() before using this service.",
     );
@@ -190,9 +178,7 @@ describe("AuthContext init guard contract", () => {
     let configError: string | null = null;
     let user: unknown = null;
 
-    // Simulate checkAuth body
     try {
-      // getAuthModule throws → caught → configError set
       throw amplifyError;
     } catch (err) {
       configError = err instanceof Error ? err.message : "unknown";
@@ -201,28 +187,5 @@ describe("AuthContext init guard contract", () => {
 
     expect(configError).toContain("Amplify has not been configured");
     expect(user).toBeNull();
-  });
-
-  it("multiple 'Amplify not configured' errors are idempotent — configError stays set", async () => {
-    // AuthContext's useEffect runs once, but if Amplify was never configured
-    // and the component re-renders, configError should remain non-null.
-    let configError: string | null = null;
-
-    const setConfigError = (msg: string) => {
-      configError = msg;
-    };
-
-    // Simulate two consecutive failures
-    for (let i = 0; i < 2; i++) {
-      try {
-        throw new Error("Amplify has not been configured.");
-      } catch (err) {
-        if (!configError) {
-          setConfigError(err instanceof Error ? err.message : "unknown");
-        }
-      }
-    }
-
-    expect(configError).toContain("Amplify has not been configured");
   });
 });

--- a/next.config.ts
+++ b/next.config.ts
@@ -61,8 +61,15 @@ const nextConfig: NextConfig = {
     minimumCacheTTL: 60 * 60 * 24 * 30,
   },
   experimental: {
-    // Tree-shake heavy barrel packages — reduces client bundle for Amplify, GSAP, cmdk
-    optimizePackageImports: ["aws-amplify", "gsap", "cmdk", "lenis", "lucide-react", "three", "@react-three/drei"],
+    // Tree-shake heavy barrel packages — reduces client bundle for GSAP, cmdk, etc.
+    // NOTE: aws-amplify is intentionally NOT in this list. Turbopack's
+    // optimizePackageImports rewrites `import { Amplify } from "aws-amplify"`
+    // and `import { signIn } from "aws-amplify/auth"` to different submodule
+    // paths whose Amplify singletons can end up *separate*, so the
+    // configure() that ran via the first path is invisible to the auth
+    // helpers loaded via the second — surfacing "Auth UserPool not configured"
+    // at signIn time even when configure provably ran.
+    optimizePackageImports: ["gsap", "cmdk", "lenis", "lucide-react", "three", "@react-three/drei"],
   },
 };
 

--- a/src/app/[locale]/layout.tsx
+++ b/src/app/[locale]/layout.tsx
@@ -66,9 +66,18 @@ export default async function LocaleLayout({ children, params }: Props) {
   // Load messages for NextIntlClientProvider
   const messages = await getMessages();
 
+  // Read Cognito env on the SERVER. Turbopack (Next 16) does not inline
+  // process.env.NEXT_PUBLIC_* into dynamically-imported client modules, so
+  // the values are sourced here at SSR time (where process.env works
+  // natively) and passed to AuthProvider as a prop.
+  const cognitoConfig = {
+    userPoolId: process.env.NEXT_PUBLIC_COGNITO_USER_POOL_ID ?? "",
+    userPoolClientId: process.env.NEXT_PUBLIC_COGNITO_CLIENT_ID ?? "",
+  };
+
   return (
     <NextIntlClientProvider locale={locale} messages={messages}>
-      <AuthProvider>
+      <AuthProvider cognitoConfig={cognitoConfig}>
         <CartProvider>
           <CookieConsentProvider>
             <GoogleAnalyticsConsent />

--- a/src/context/AuthContext.tsx
+++ b/src/context/AuthContext.tsx
@@ -206,7 +206,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       let ok: boolean;
       try {
         const { configureAmplify } = await import("@/lib/amplify-config");
-        ok = await configureAmplify();
+        ok = configureAmplify();
       } catch (err) {
         if (!cancelled) {
           console.error("Amplify configuration failed:", err);

--- a/src/context/AuthContext.tsx
+++ b/src/context/AuthContext.tsx
@@ -127,7 +127,17 @@ function decodeJwtPayload(token: string): Record<string, unknown> {
   }
 }
 
-export function AuthProvider({ children }: { children: ReactNode }) {
+interface AuthProviderProps {
+  children: ReactNode;
+  /**
+   * Cognito config sourced from the Server Component layout (where
+   * process.env is readable). Empty strings here surface configError and
+   * keep auth helpers disabled.
+   */
+  cognitoConfig: { userPoolId: string; userPoolClientId: string };
+}
+
+export function AuthProvider({ children, cognitoConfig }: AuthProviderProps) {
   const [user, setUser] = useState<AuthUser | null>(null);
   const [isAdmin, setIsAdmin] = useState(false);
   const [isLoading, setIsLoading] = useState(true);
@@ -205,8 +215,8 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     const init = async () => {
       let ok: boolean;
       try {
-        const { configureAmplify } = await import("@/lib/amplify-config");
-        ok = configureAmplify();
+        const { configureAmplifyWith } = await import("@/lib/amplify-config");
+        ok = configureAmplifyWith(cognitoConfig);
       } catch (err) {
         if (!cancelled) {
           console.error("Amplify configuration failed:", err);
@@ -231,7 +241,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     return () => {
       cancelled = true;
     };
-  }, [checkAuth]);
+  }, [checkAuth, cognitoConfig]);
 
   const handleSignIn = async (email: string, password: string): Promise<SignInResult> => {
     const { signIn: amplifySignIn, signOut: amplifySignOut } = await (

--- a/src/lib/amplify-config.ts
+++ b/src/lib/amplify-config.ts
@@ -5,63 +5,69 @@ import { Amplify } from "aws-amplify";
 /**
  * Configure AWS Amplify with Cognito User Pool credentials.
  *
- * Called at module load time (not inside useEffect) so the config is in place
- * before any auth function (signIn, getCurrentUser, ...) is invoked.
+ * IMPORTANT — Why this module does NOT read `process.env.NEXT_PUBLIC_*` directly:
+ *   Turbopack (Next 16) does not inline `process.env.NEXT_PUBLIC_*` references
+ *   inside client modules that are reached via a dynamic `import()` chain.
+ *   They are emitted as runtime reads against next.js' `process.js` polyfill,
+ *   whose `.env` is empty on the client — which left userPoolId / userPoolClientId
+ *   as empty strings, `Amplify.configure()` was skipped, and sign-in failed
+ *   with "Auth UserPool not configured."
  *
- * NEXT_PUBLIC_* vars are inlined by Next.js at build/dev-server start,
- * so process.env.NEXT_PUBLIC_* always resolves on the client without needing
- * globalThis.process?.env.
+ * Fix: the caller (Server Component in `[locale]/layout.tsx`) reads the env
+ * at SSR — where process.env works natively — and passes the values to
+ * `AuthProvider`, which calls `configureAmplifyWith()` synchronously in its
+ * mount effect, before any auth helper runs.
+ *
+ * The configure call here is synchronous (no await) so it lands on the
+ * Amplify singleton before `getAuthModule()` returns the auth helpers —
+ * matching aws-amplify v6's read-singleton-eagerly behavior.
  */
-const userPoolId = process.env.NEXT_PUBLIC_COGNITO_USER_POOL_ID ?? "";
-const userPoolClientId = process.env.NEXT_PUBLIC_COGNITO_CLIENT_ID ?? "";
 
-const isConfigured = Boolean(userPoolId && userPoolClientId);
+export interface AmplifyAuthConfig {
+  userPoolId: string;
+  userPoolClientId: string;
+}
 
-if (isConfigured) {
+let configured = false;
+
+/**
+ * Apply the Cognito config to the Amplify singleton. Idempotent — safe to
+ * call multiple times (StrictMode dev double-mount, repeated renders).
+ * Returns true when Amplify is now configured with non-empty credentials.
+ */
+export function configureAmplifyWith(config: AmplifyAuthConfig): boolean {
+  if (configured) return true;
+  if (!config.userPoolId || !config.userPoolClientId) return false;
+
   Amplify.configure(
     {
       Auth: {
         Cognito: {
-          userPoolId,
-          userPoolClientId,
+          userPoolId: config.userPoolId,
+          userPoolClientId: config.userPoolClientId,
         },
       },
     },
     { ssr: true }
   );
+  configured = true;
+  return true;
 }
 
-/** Returns true when Amplify has been configured with valid Cognito credentials. */
-export function configureAmplify(): boolean {
-  return isConfigured;
+/** True when configureAmplifyWith() has successfully run at least once. */
+export function isAmplifyConfigured(): boolean {
+  return configured;
 }
 
 /**
- * Single entry point for loading `aws-amplify/auth` in a way that guarantees
- * `Amplify.configure()` has executed first.
+ * Returns the `aws-amplify/auth` module. Callers must ensure
+ * `configureAmplifyWith()` has already run (it happens in AuthProvider's
+ * mount effect) before invoking auth helpers like signIn / fetchAuthSession.
  *
- * Why this exists:
- *   AuthContext lazy-imports `aws-amplify/auth` to keep the ~2 MB module out
- *   of the initial public-page bundle (preserved here — this function still
- *   uses dynamic `import()`). But the auth helpers are useless until
- *   `Amplify.configure()` has run. Without an explicit barrier a caller
- *   could grab `signIn` etc. before the config side-effect lands and hit:
- *     "Amplify has not been configured. Please call Amplify.configure() …"
- *
- * How the guarantee works:
- *   `await import("./amplify-config")` resolves only after THIS module's
- *   top-level body has executed (the `Amplify.configure()` call above).
- *   We chain the auth import off that resolution, so by the time the auth
- *   module's exports are handed back, configure has provably run.
- *
- *   Bundle-size impact: zero — both imports are dynamic, so `aws-amplify`
- *   stays out of the public-page bundle. Webpack also dedupes module
- *   instances, so subsequent calls are cache hits (no extra wall-clock).
+ * Bundle-size note: this dynamic import keeps the ~2 MB aws-amplify auth
+ * runtime out of the initial public-page bundle. Webpack/Turbopack dedupe
+ * the module so repeat calls are cache hits.
  */
 export async function getAuthModule(): Promise<typeof import("aws-amplify/auth")> {
-  // Re-import self so the module-load side-effect (Amplify.configure) is
-  // observably complete before the auth import is awaited. Cheap on repeat
-  // calls — Webpack returns the cached module record.
-  await import("./amplify-config");
   return import("aws-amplify/auth");
 }

--- a/src/lib/amplify-config.ts
+++ b/src/lib/amplify-config.ts
@@ -1,78 +1,67 @@
 "use client";
 
-/**
- * Single entry point for configuring AWS Amplify and loading
- * `aws-amplify/auth` in a way that guarantees `Amplify.configure()` runs
- * before any auth helper (signIn, getCurrentUser, fetchAuthSession, ...)
- * is invoked.
- *
- * Why this file does NOT statically import `aws-amplify`:
- *   A static `import { Amplify } from "aws-amplify"` loads the ~2 MB SDK
- *   eagerly AND registers internal Hub listeners during module init.
- *   Those listeners can dispatch auth events before our synchronous
- *   `Amplify.configure(...)` call lands on the singleton, surfacing:
- *
- *     "Amplify has not been configured. Please call Amplify.configure() ..."
- *
- *   on the console twice under React StrictMode's dev double-mount.
- *
- *   Loading the SDK lazily inside `ensureConfigured()` collapses load +
- *   configure into a single microtask — by the time the returned promise
- *   resolves, the singleton config is provably in place.
- *
- *   NEXT_PUBLIC_* vars are inlined by Next.js at build / dev-server start,
- *   so process.env.NEXT_PUBLIC_* always resolves on the client.
- */
+import { Amplify } from "aws-amplify";
 
+/**
+ * Configure AWS Amplify with Cognito User Pool credentials.
+ *
+ * Called at module load time (not inside useEffect) so the config is in place
+ * before any auth function (signIn, getCurrentUser, ...) is invoked.
+ *
+ * NEXT_PUBLIC_* vars are inlined by Next.js at build/dev-server start,
+ * so process.env.NEXT_PUBLIC_* always resolves on the client without needing
+ * globalThis.process?.env.
+ */
 const userPoolId = process.env.NEXT_PUBLIC_COGNITO_USER_POOL_ID ?? "";
 const userPoolClientId = process.env.NEXT_PUBLIC_COGNITO_CLIENT_ID ?? "";
-const hasCognitoEnv = Boolean(userPoolId && userPoolClientId);
 
-let configurePromise: Promise<boolean> | null = null;
+const isConfigured = Boolean(userPoolId && userPoolClientId);
 
-function ensureConfigured(): Promise<boolean> {
-  if (configurePromise) return configurePromise;
-
-  if (!hasCognitoEnv) {
-    configurePromise = Promise.resolve(false);
-    return configurePromise;
-  }
-
-  configurePromise = (async () => {
-    const { Amplify } = await import("aws-amplify");
-    Amplify.configure(
-      {
-        Auth: {
-          Cognito: {
-            userPoolId,
-            userPoolClientId,
-          },
+if (isConfigured) {
+  Amplify.configure(
+    {
+      Auth: {
+        Cognito: {
+          userPoolId,
+          userPoolClientId,
         },
       },
-      { ssr: true }
-    );
-    return true;
-  })();
-
-  return configurePromise;
+    },
+    { ssr: true }
+  );
 }
 
-/** Resolves to true when Amplify is (now) configured with Cognito credentials. */
-export function configureAmplify(): Promise<boolean> {
-  return ensureConfigured();
+/** Returns true when Amplify has been configured with valid Cognito credentials. */
+export function configureAmplify(): boolean {
+  return isConfigured;
 }
 
 /**
- * Returns the `aws-amplify/auth` module, guaranteed to be loaded AFTER
- * `Amplify.configure()` has run. Repeat calls are cache hits (Webpack
- * dedupes the dynamic import).
+ * Single entry point for loading `aws-amplify/auth` in a way that guarantees
+ * `Amplify.configure()` has executed first.
+ *
+ * Why this exists:
+ *   AuthContext lazy-imports `aws-amplify/auth` to keep the ~2 MB module out
+ *   of the initial public-page bundle (preserved here — this function still
+ *   uses dynamic `import()`). But the auth helpers are useless until
+ *   `Amplify.configure()` has run. Without an explicit barrier a caller
+ *   could grab `signIn` etc. before the config side-effect lands and hit:
+ *     "Amplify has not been configured. Please call Amplify.configure() …"
+ *
+ * How the guarantee works:
+ *   `await import("./amplify-config")` resolves only after THIS module's
+ *   top-level body has executed (the `Amplify.configure()` call above).
+ *   We chain the auth import off that resolution, so by the time the auth
+ *   module's exports are handed back, configure has provably run.
+ *
+ *   Bundle-size impact: zero — both imports are dynamic, so `aws-amplify`
+ *   stays out of the public-page bundle. Webpack also dedupes module
+ *   instances, so subsequent calls are cache hits (no extra wall-clock).
  */
 export async function getAuthModule(): Promise<typeof import("aws-amplify/auth")> {
-  const ok = await ensureConfigured();
-  if (!ok) {
-    throw new Error(
-      "Amplify is not configured: NEXT_PUBLIC_COGNITO_USER_POOL_ID / NEXT_PUBLIC_COGNITO_CLIENT_ID are missing."
-    );
-  }
+  // Re-import self so the module-load side-effect (Amplify.configure) is
+  // observably complete before the auth import is awaited. Cheap on repeat
+  // calls — Webpack returns the cached module record.
+  await import("./amplify-config");
   return import("aws-amplify/auth");
 }


### PR DESCRIPTION
## Summary
Fixes "Auth UserPool not configured" at signIn caused by Turbopack (Next 16) refusing to inline `process.env.NEXT_PUBLIC_*` inside dynamically-imported client modules. Replaces the broken client-side env read with an SSR-side prop chain plus a revert of [#324](https://github.com/Themis128/cloudless.gr/pull/324)'s lazy-load (whose async path made the race worse).

## Root cause
- Turbopack emits `process.env.NEXT_PUBLIC_X` references in dynamically-imported client modules as runtime reads against `next/dist/build/polyfills/process.js`, whose `.env` is empty on the client.
- `src/lib/amplify-config.ts` was reaching for `NEXT_PUBLIC_COGNITO_USER_POOL_ID` / `NEXT_PUBLIC_COGNITO_CLIENT_ID` there  both came back `""`, `Amplify.configure()` was skipped, signIn failed.
- `optimizePackageImports: ["aws-amplify"]` was an additional risk vector: barrel rewrite can give `aws-amplify` and `aws-amplify/auth` separate Amplify singletons, so a `configure()` on one path is invisible to the other.

## Changes
- [src/app/[locale]/layout.tsx](src/app/[locale]/layout.tsx)  Server Component reads `process.env.NEXT_PUBLIC_COGNITO_*` and passes a `cognitoConfig` prop to `AuthProvider`.
- [src/context/AuthContext.tsx](src/context/AuthContext.tsx)  `AuthProvider` accepts `cognitoConfig`, calls `configureAmplifyWith(...)` synchronously in its mount effect.
- [src/lib/amplify-config.ts](src/lib/amplify-config.ts)  no longer reads `process.env`; exposes `configureAmplifyWith()` / `isAmplifyConfigured()` / `getAuthModule()`.
- [next.config.ts](next.config.ts)  removed `aws-amplify` from `optimizePackageImports`.
- Test files updated to the new contract (15/15 passing).

## Verification
- `pnpm vitest run __tests__/amplify-config.test.ts __tests__/auth-context.test.ts __tests__/fetch-with-auth.test.ts`  15/15 green.
- Local `http://localhost:4000/en/auth/login`: Cognito pool id reaches the SSR'd HTML, zero "Amplify has not been configured" warnings, signIn no longer throws "Auth UserPool not configured" (gets through to Cognito's input validation).

## Test plan
- [ ] CI green
- [ ] Smoke check signIn against real Cognito on a feature deploy