### PR TITLE
fix(tests): address IDE diagnostics (Response no-undef, S4325 assertions)

### DIFF
--- a/__tests__/bundle-optimization.test.ts
+++ b/__tests__/bundle-optimization.test.ts
@@ -43,11 +43,13 @@ describe("bundle optimization", () => {
     // separate Bundle Budget Audit workflow instead.
     const globalEntry = budget.find((b) => b.path === "/*");
     expect(globalEntry).toBeDefined();
-    expect(globalEntry!.timings).toBeDefined();
-    expect(globalEntry!.timings!.length).toBeGreaterThan(0);
+    if (!globalEntry) throw new Error("globalEntry missing");
+    expect(globalEntry.timings).toBeDefined();
+    expect(globalEntry.timings?.length).toBeGreaterThan(0);
 
     const storeEntry = budget.find((b) => b.path === "/store");
     expect(storeEntry).toBeDefined();
-    expect(storeEntry!.timings).toBeDefined();
+    if (!storeEntry) throw new Error("storeEntry missing");
+    expect(storeEntry.timings).toBeDefined();
   });
 });

--- a/__tests__/fetch-with-auth.test.ts
+++ b/__tests__/fetch-with-auth.test.ts
@@ -25,7 +25,7 @@ describe("fetch-with-auth.ts", () => {
     mockFetchAuthSession.mockResolvedValueOnce({
       tokens: { idToken: { toString: () => "test-token-abc" } },
     });
-    const mockResponse = new Response(JSON.stringify({ ok: true }), { status: 200 });
+    const mockResponse = new globalThis.Response(JSON.stringify({ ok: true }), { status: 200 });
     vi.mocked(globalThis.fetch).mockResolvedValueOnce(mockResponse);
 
     const { fetchWithAuth } = await import("@/lib/fetch-with-auth");
@@ -44,7 +44,7 @@ describe("fetch-with-auth.ts", () => {
     mockFetchAuthSession.mockResolvedValueOnce({
       tokens: { idToken: { toString: () => "tok" } },
     });
-    vi.mocked(globalThis.fetch).mockResolvedValueOnce(new Response("{}", { status: 200 }));
+    vi.mocked(globalThis.fetch).mockResolvedValueOnce(new globalThis.Response("{}", { status: 200 }));
 
     const { fetchWithAuth } = await import("@/lib/fetch-with-auth");
     await fetchWithAuth("/api/test", {


### PR DESCRIPTION
## Summary

- **`fetch-with-auth.test.ts`**: `new Response(...)` → `new globalThis.Response(...)` — ESLint `no-undef` fires because the test file runs in a non-DOM context where `Response` isn't automatically in scope
- **`bundle-optimization.test.ts`**: non-null assertions (`!`) on `globalEntry` and `storeEntry` → explicit `if (!x) throw` guards — SonarJS S4325 (unnecessary assertion since the type is already non-nullable after the `expect().toBeDefined()` call)

🤖 Generated with [Claude Code](https://claude.com/claude-code)