### PR TITLE
feat(scripts): gh-secrets — delete repo Actions secrets via API (no UI access needed)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -743,7 +743,7 @@ These are the recommended next layers to build toward an AI-powered marketing pl
 ### Phase 1 — Foundation (Data Collection)
 - [ ] Activate Meta Pixel + CAPI (see `meta-account-runbook.md`) — blocked by Meta advertising restriction
 - [x] Wire `notion-analytics.ts` `trackEvent()` to all key user actions (blog views, doc views, form submits) — done 2026-04-21
-- [ ] Set up weekly GSC digest to Slack (script exists: `scripts/weekly-gsc-sync.ts`)
+- [x] Set up weekly GSC digest to Slack — `weekly-gsc-sync.yml` runs `scripts/weekly-gsc-sync.ts` on a Monday cron and posts a Block Kit success/failure digest to Slack (`SLACK_WEBHOOK_URL`); data lands in `NOTION_GSC_REPORTS_DB_ID`
 
 ### Phase 2 — Lead Intelligence
 - [x] HubSpot deal automation: contact form → contact upsert already live; deal creation via `createDeal()` added 2026-04-21
@@ -751,7 +751,7 @@ These are the recommended next layers to build toward an AI-powered marketing pl
 - [x] Stripe → HubSpot: create deal on checkout (via `checkout.session.completed` webhook) — done 2026-04-21
 
 ### Phase 3 — AI Content & Automation
-- [ ] AI blog post generation pipeline: brief in Notion → draft via LLM → publish to Notion blog DB
+- [x] AI blog post generation pipeline: `weekly-article-draft.yml` runs `scripts/generate-weekly-article.ts` (Anthropic → `NOTION_BLOG_DB_ID`) on a Monday cron, three hours ahead of the publisher window for human review
 - [ ] AI-powered SEO suggestions: GSC data → LLM analysis → content recommendations in admin
 - [ ] Automated email sequences (post-signup, post-purchase) via SES templates
 

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "devcontainer:doctor": "bash scripts/devcontainer-doctor.sh",
     "devcontainer:stop": "bash scripts/devcontainer-stop.sh",
     "notion:test": "tsx --tsconfig scripts/tsconfig.json scripts/notion-test.ts",
+    "gh:secrets": "tsx --tsconfig scripts/tsconfig.json scripts/gh-secrets.ts",
     "gsc:sync": "tsx --tsconfig scripts/tsconfig.json scripts/weekly-gsc-sync.ts",
     "newsletter:draft": "tsx --tsconfig scripts/tsconfig.json scripts/generate-weekly-article.ts",
     "newsletter:send": "tsx --tsconfig scripts/tsconfig.json scripts/publish-and-send-newsletter.ts",

--- a/scripts/gh-secrets.ts
+++ b/scripts/gh-secrets.ts
@@ -1,0 +1,198 @@
+/**
+ * gh-secrets — audit & delete GitHub Actions repository secrets via the REST API.
+ *
+ * Why this exists: deleting a repo secret normally means clicking through
+ * Settings → Secrets and variables → Actions. Anyone without UI access to that
+ * page (but holding a token that can manage secrets) can use this instead.
+ *
+ * It is deliberately cautious:
+ *   - `delete` is DRY-RUN by default; nothing is removed without `--apply`.
+ *   - Before deleting a secret it runs `git grep` for that secret name across
+ *     the repo and REFUSES if anything still references it (override: `--force`).
+ *   - With no names given, `delete` targets the two stale static AWS keys that
+ *     OIDC replaced (AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY).
+ *
+ * Auth:
+ *   GITHUB_TOKEN   a token authorised to manage Actions secrets on the repo:
+ *                    - classic PAT with the `repo` scope, OR
+ *                    - fine-grained PAT with "Secrets" repository permission = Read & write.
+ *                  (The default Actions GITHUB_TOKEN CANNOT manage secrets.)
+ *
+ * Usage:
+ *   GITHUB_TOKEN=... pnpm exec tsx --tsconfig scripts/tsconfig.json scripts/gh-secrets.ts list
+ *   GITHUB_TOKEN=... pnpm exec tsx --tsconfig scripts/tsconfig.json scripts/gh-secrets.ts delete            # dry-run, default AWS keys
+ *   GITHUB_TOKEN=... pnpm exec tsx --tsconfig scripts/tsconfig.json scripts/gh-secrets.ts delete --apply     # actually delete the AWS keys
+ *   GITHUB_TOKEN=... pnpm exec tsx --tsconfig scripts/tsconfig.json scripts/gh-secrets.ts delete FOO BAR --apply
+ *
+ * Flags:
+ *   --apply              perform the deletion (default is dry-run)
+ *   --force              delete even if the secret is still referenced in the repo
+ *   --owner <owner>      repo owner   (default: Themis128 or $GH_OWNER)
+ *   --repo  <repo>       repo name    (default: cloudless.gr or $GH_REPO)
+ */
+import process from "node:process";
+import { execFileSync } from "node:child_process";
+
+const API = "https://api.github.com";
+const DEFAULT_TARGETS = ["AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY"];
+
+interface Options {
+  command: string;
+  names: string[];
+  apply: boolean;
+  force: boolean;
+  owner: string;
+  repo: string;
+}
+
+function parseArgs(argv: string[]): Options {
+  const opts: Options = {
+    command: "",
+    names: [],
+    apply: false,
+    force: false,
+    owner: process.env.GH_OWNER ?? "Themis128",
+    repo: process.env.GH_REPO ?? "cloudless.gr",
+  };
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    if (arg === "--apply") opts.apply = true;
+    else if (arg === "--force") opts.force = true;
+    else if (arg === "--owner") opts.owner = argv[++i] ?? opts.owner;
+    else if (arg === "--repo") opts.repo = argv[++i] ?? opts.repo;
+    else if (!opts.command) opts.command = arg;
+    else opts.names.push(arg);
+  }
+  return opts;
+}
+
+function token(): string {
+  const t = process.env.GITHUB_TOKEN;
+  if (!t) {
+    throw new Error(
+      "GITHUB_TOKEN is not set. Provide a PAT that can manage Actions secrets " +
+        "(classic `repo` scope, or fine-grained 'Secrets: Read & write')."
+    );
+  }
+  return t;
+}
+
+async function gh(path: string, init: RequestInit = {}): Promise<Response> {
+  return globalThis.fetch(`${API}${path}`, {
+    ...init,
+    headers: {
+      Authorization: `Bearer ${token()}`,
+      Accept: "application/vnd.github+json",
+      "X-GitHub-Api-Version": "2022-11-28",
+      ...(init.headers ?? {}),
+    },
+    signal: AbortSignal.timeout(15000),
+  });
+}
+
+interface SecretEntry {
+  name: string;
+  updated_at: string;
+}
+
+async function listSecrets(o: Options): Promise<SecretEntry[]> {
+  const res = await gh(`/repos/${o.owner}/${o.repo}/actions/secrets?per_page=100`);
+  if (!res.ok) {
+    throw new Error(`List failed: HTTP ${res.status} ${await res.text()}`);
+  }
+  const body = (await res.json()) as { secrets: SecretEntry[] };
+  return body.secrets;
+}
+
+/** True when the secret name still appears anywhere in the tracked tree. */
+function isReferenced(name: string): boolean {
+  try {
+    // git grep exits 0 when matches found, 1 when none. Exclude self-documenting files.
+    const out = execFileSync(
+      "git",
+      ["grep", "-l", "--fixed-strings", name, "--", ".github", "src", "scripts", "infrastructure", "k8s"],
+      { encoding: "utf8" }
+    ).trim();
+    // Ignore matches that are only in this very tool / its docs.
+    const hits = out.split("\n").filter((f) => f && f !== "scripts/gh-secrets.ts");
+    return hits.length > 0;
+  } catch (err) {
+    // exit code 1 = no matches → not referenced. Anything else, surface it.
+    if (err && typeof err === "object" && "status" in err && (err as { status: number }).status === 1) {
+      return false;
+    }
+    throw err;
+  }
+}
+
+async function deleteSecret(o: Options, name: string): Promise<void> {
+  const res = await gh(`/repos/${o.owner}/${o.repo}/actions/secrets/${encodeURIComponent(name)}`, {
+    method: "DELETE",
+  });
+  if (res.status === 204) return;
+  if (res.status === 404) {
+    console.log(`  · ${name}: already absent (404) — nothing to do`);
+    return;
+  }
+  throw new Error(`Delete ${name} failed: HTTP ${res.status} ${await res.text()}`);
+}
+
+async function runList(o: Options): Promise<void> {
+  const secrets = await listSecrets(o);
+  console.log(`Secrets on ${o.owner}/${o.repo} (${secrets.length}):`);
+  for (const s of secrets) console.log(`  ${s.name}  (updated ${s.updated_at})`);
+}
+
+async function runDelete(o: Options): Promise<void> {
+  const targets = o.names.length > 0 ? o.names : DEFAULT_TARGETS;
+  const existing = new Set((await listSecrets(o)).map((s) => s.name));
+
+  console.log(
+    `${o.apply ? "DELETING" : "DRY-RUN (pass --apply to delete)"} on ${o.owner}/${o.repo}:`
+  );
+
+  let failures = 0;
+  for (const name of targets) {
+    if (!existing.has(name)) {
+      console.log(`  · ${name}: not present — skipping`);
+      continue;
+    }
+    if (!o.force && isReferenced(name)) {
+      console.error(`  ✗ ${name}: still referenced in the repo — refusing (use --force to override)`);
+      failures++;
+      continue;
+    }
+    if (!o.apply) {
+      console.log(`  → ${name}: would delete (safe — no references found)`);
+      continue;
+    }
+    try {
+      await deleteSecret(o, name);
+      console.log(`  ✓ ${name}: deleted`);
+    } catch (err) {
+      console.error(`  ✗ ${name}: ${(err as Error).message}`);
+      failures++;
+    }
+  }
+  if (failures > 0) process.exitCode = 1;
+}
+
+async function main(): Promise<void> {
+  const o = parseArgs(process.argv.slice(2));
+  switch (o.command) {
+    case "list":
+      await runList(o);
+      break;
+    case "delete":
+      await runDelete(o);
+      break;
+    default:
+      console.error("Usage: gh-secrets <list|delete> [names...] [--apply] [--force] [--owner X] [--repo Y]");
+      process.exitCode = 2;
+  }
+}
+
+main().catch((err: unknown) => {
+  console.error((err as Error).message);
+  process.exitCode = 1;
+});


### PR DESCRIPTION
## What

A small, dependency-free CLI (`scripts/gh-secrets.ts`, wired as `pnpm gh:secrets`) that lists and deletes a repo's **GitHub Actions secrets via the REST API** — for when you hold a capable token but don't have UI access to *Settings → Secrets and variables → Actions*.

Built to retire the stale static AWS keys (`AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY`) that OIDC already replaced, but it works for any secret.

## Safety

- `delete` is **dry-run by default**; nothing is removed without `--apply`.
- Before deleting, it runs `git grep` for the secret name and **refuses if anything still references it** (override: `--force`). Verified: the two AWS keys have zero references in `.github/`, `src`, `scripts`, `infrastructure`, `k8s`.
- With no names given, `delete` targets the two stale AWS keys.

## Usage

```bash
# read-only audit
GITHUB_TOKEN=<pat> pnpm gh:secrets list

# dry-run (default) — shows what would be deleted
GITHUB_TOKEN=<pat> pnpm gh:secrets delete

# actually delete the two stale AWS keys
GITHUB_TOKEN=<pat> pnpm gh:secrets delete --apply
```

Token must be a classic PAT with `repo` scope, or a fine-grained PAT with **Secrets: Read & write**. (The default Actions `GITHUB_TOKEN` cannot manage secrets.)

## Verification

- `tsc --noEmit` clean.
- Auth-guard fires before any network call when `GITHUB_TOKEN` is unset.
- Reference guard confirmed to find zero real references to the AWS keys.

https://claude.ai/code/session_01PCDg4YjuRYErYRyvXzp1Ho

---
_Generated by [Claude Code](https://claude.ai/code/session_01PCDg4YjuRYErYRyvXzp1Ho)_