### PR TITLE
fix(gh-secrets): scope reference guard to workflow consumption

### DIFF
--- a/scripts/gh-secrets.ts
+++ b/scripts/gh-secrets.ts
@@ -104,20 +104,20 @@ async function listSecrets(o: Options): Promise<SecretEntry[]> {
   return body.secrets;
 }
 
-/** True when the secret name still appears anywhere in the tracked tree. */
+/**
+ * True when any workflow under `.github` still consumes this secret as
+ * `secrets.NAME`. We scope to workflow consumption deliberately: a GitHub
+ * Actions secret is "in use" only if a workflow reads it. Placeholder mentions
+ * in `.env.example`, docs, or script comments do not count.
+ */
 function isReferenced(name: string): boolean {
   try {
-    // git grep exits 0 when matches found, 1 when none. Exclude self-documenting files.
-    const out = execFileSync(
-      "git",
-      ["grep", "-l", "--fixed-strings", name, "--", ".github", "src", "scripts", "infrastructure", "k8s"],
-      { encoding: "utf8" }
-    ).trim();
-    // Ignore matches that are only in this very tool / its docs.
-    const hits = out.split("\n").filter((f) => f && f !== "scripts/gh-secrets.ts");
-    return hits.length > 0;
+    // git grep exits 0 when a match is found, 1 when none. -q suppresses output.
+    execFileSync("git", ["grep", "-q", "--fixed-strings", `secrets.${name}`, "--", ".github"], {
+      stdio: "ignore",
+    });
+    return true;
   } catch (err) {
-    // exit code 1 = no matches → not referenced. Anything else, surface it.
     if (err && typeof err === "object" && "status" in err && (err as { status: number }).status === 1) {
       return false;
     }


### PR DESCRIPTION
## What

Follow-up hardening to the `gh-secrets` tool merged in #339.

The reference guard previously grepped `src` / `scripts` / `infrastructure` / `k8s` for the **bare secret name**. That produced a false positive: `scripts/fix-pi-ssm-permission.py` documents `AWS_ACCESS_KEY_ID` as placeholder text, so the tool would mark the secret as "in use" and **refuse to delete the very keys it was built to remove** (without `--force`).

A GitHub Actions secret is only "in use" when a **workflow reads it**, so the guard now greps `.github` for `secrets.NAME`. Verified: `secrets.AWS_ACCESS_KEY_ID` / `secrets.AWS_SECRET_ACCESS_KEY` appear in **zero** workflows, so deletion is allowed by default (as intended).

Also drops the stdout parsing in favour of `git grep -q`, which removes an implicit-any on the (now-deleted) filter callback.

## Verify

- `tsc --noEmit` clean.
- `git grep -q "secrets.AWS_ACCESS_KEY_ID" -- .github` → no match (guard allows delete).

https://claude.ai/code/session_01PCDg4YjuRYErYRyvXzp1Ho

---
_Generated by [Claude Code](https://claude.ai/code/session_01PCDg4YjuRYErYRyvXzp1Ho)_