### PR TITLE
test(auth): fix stale keycloak signOut assertion to unbreak Unit Tests CI

### DIFF
--- a/__tests__/keycloak-auth.test.ts
+++ b/__tests__/keycloak-auth.test.ts
@@ -50,7 +50,10 @@ describe("keycloak-auth.ts — real module", () => {
   it("signOut delegates to next-auth signOut with callbackUrl=/", async () => {
     const { keycloakAuthModule } = await import("@/lib/keycloak-auth");
     await keycloakAuthModule.signOut();
-    expect(mockNextAuthSignOut).toHaveBeenCalledWith({ callbackUrl: "/", redirect: true });
+    // redirect:false is intentional — signOut performs RP-Initiated Logout by
+    // redirecting to Keycloak's end_session_endpoint itself, so next-auth must
+    // not redirect first (that would skip the SSO-cookie invalidation).
+    expect(mockNextAuthSignOut).toHaveBeenCalledWith({ callbackUrl: "/", redirect: false });
   });
 
   it("signUp redirects to Keycloak registrations URL with email pre-filled", async () => {


### PR DESCRIPTION
## What

Fixes the **Unit Tests** CI check, red on `main` since #357 (every PR has merged through it red).

## Root cause

One stale assertion in `__tests__/keycloak-auth.test.ts > signOut delegates to next-auth signOut`:

- The test (added in #353) expects `nextAuthSignOut` to be called with `redirect: true`.
- #357 changed `signOut` in `src/lib/keycloak-auth.ts` to perform **RP-Initiated Logout**: it calls `nextAuthSignOut({ callbackUrl: "/", redirect: false })` and then manually redirects to Keycloak's `end_session_endpoint` with `id_token_hint`, invalidating the SSO cookie server-side. Letting next-auth redirect first would skip that step.

The implementation is correct; the test was left behind. Updated the expectation to `redirect: false` with a comment explaining why.

## Verification

```
pnpm test:ci  →  168 files / 2019 tests passed  (was 1 failed | 2018 passed)
```

Single-line change to one test file; no production code touched.

https://claude.ai/code/session_01WoLaMUxTAygraKUTy7JTT8

---
_Generated by [Claude Code](https://claude.ai/code/session_01WoLaMUxTAygraKUTy7JTT8)_