### PR TITLE
fix(ci): sync build-pi-image.yml with Keycloak migration + ECR cred fix

### DIFF
--- a/.github/workflows/build-pi-image.yml
+++ b/.github/workflows/build-pi-image.yml
@@ -232,8 +232,8 @@ jobs:
             APP_VERSION=${{ steps.sha.outputs.full }}
             NEXT_PUBLIC_SITE_URL=https://cloudless.gr
             NEXT_PUBLIC_STAGE=production
-            NEXT_PUBLIC_COGNITO_USER_POOL_ID=${{ secrets.NEXT_PUBLIC_COGNITO_USER_POOL_ID }}
-            NEXT_PUBLIC_COGNITO_CLIENT_ID=${{ secrets.NEXT_PUBLIC_COGNITO_CLIENT_ID }}
+            NEXT_PUBLIC_KEYCLOAK_ISSUER=https://auth.cloudless.gr/realms/master
+            NEXT_PUBLIC_KEYCLOAK_CLIENT_ID=cloudless-app
             NEXT_PUBLIC_HUBSPOT_PORTAL_ID=${{ secrets.NEXT_PUBLIC_HUBSPOT_PORTAL_ID }}
             NEXT_PUBLIC_SENTRY_DSN=${{ secrets.NEXT_PUBLIC_SENTRY_DSN }}
             NEXT_PUBLIC_META_PIXEL_ID=${{ secrets.NEXT_PUBLIC_META_PIXEL_ID }}
@@ -241,10 +241,17 @@ jobs:
 
       # Push each tag with dockerd's own registry client (not buildkit).
       # See the long comment on the `build (load to dockerd)` step above.
+      #
+      # Use get-login-password | docker login (not the amazon-ecr-login action)
+      # because the action writes to secretservice/pass on Pi runners while
+      # dockerd reads only ~/.docker/config.json. Same fix as deploy-pi.yml
+      # (commit 26f5fdd).
       - name: push to ECR
         if: github.event_name != 'pull_request' && (steps.existing.outputs.exists != 'true')
         run: |
           set -euo pipefail
+          aws ecr get-login-password --region "${AWS_REGION}" \
+            | docker login --username AWS --password-stdin "${ECR_REGISTRY}"
           IFS=',' read -ra TAGS <<< "${{ steps.tags.outputs.tags }}"
           for tag in "${TAGS[@]}"; do
             echo "==> docker push ${tag}"


### PR DESCRIPTION
## Summary

- **Build-args mismatch**: `build-pi-image.yml` still passed the retired `NEXT_PUBLIC_COGNITO_*` secrets as Docker build-args after `a34d07d` dropped those `ARG` instructions from the Dockerfile in favour of `NEXT_PUBLIC_KEYCLOAK_ISSUER` / `NEXT_PUBLIC_KEYCLOAK_CLIENT_ID`. Aligned with `deploy-pi.yml` and the Dockerfile.
- **ECR push auth**: `deploy-pi.yml` was fixed (`26f5fdd`) to use `aws ecr get-login-password | docker login --password-stdin` before `docker push` because `amazon-ecr-login` writes to `secretservice/pass` on Pi runners while dockerd only reads `~/.docker/config.json`. The same fix was missing from `build-pi-image.yml`'s push step, causing 401 failures on the Pi runner.

## Root cause of the HA sync orchestrator failure

The screenshot from the failing "HA sync orchestrator" run: the `wait for pi build completion` step timed out/failed at 27m 23s because the dispatched `build-pi-image.yml` run itself was failing at the ECR push step (auth error — same credential-store issue fixed in `deploy-pi.yml` by `26f5fdd` but not ported here).

## Test plan

- [ ] Merge → merge triggers a push to `main` which triggers `build pi image`
- [ ] Verify the build completes successfully (no ECR 401)
- [ ] Verify the HA sync orchestrator subsequently succeeds for this SHA
- [ ] Re-dispatch `build-pi-image.yml` manually for latest SHA if needed to sync Pi standby

https://claude.ai/code/session_01PHsA9s3tK2thgSJVwEGuWq

---
_Generated by [Claude Code](https://claude.ai/code/session_01PHsA9s3tK2thgSJVwEGuWq)_