### PR TITLE
fix(tests): align webhook + subscribe tests with #362 status changes

### DIFF
--- a/__tests__/hubspot-webhook-api.test.ts
+++ b/__tests__/hubspot-webhook-api.test.ts
@@ -20,7 +20,7 @@ describe("POST /api/webhooks/hubspot", () => {
     vi.clearAllMocks();
   });
 
-  it("fails closed with 500 when HUBSPOT_CLIENT_SECRET is not configured", async () => {
+  it("fails closed with 401 when HUBSPOT_CLIENT_SECRET is not configured", async () => {
     getIntegrationsAsyncMock.mockResolvedValue({
       HUBSPOT_CLIENT_SECRET: "",
       HUBSPOT_API_KEY: "",
@@ -29,7 +29,7 @@ describe("POST /api/webhooks/hubspot", () => {
     const { POST } = await import("@/app/api/webhooks/hubspot/route");
     const res = await POST(makeRequest(JSON.stringify([])));
 
-    expect(res.status).toBe(500);
+    expect(res.status).toBe(401);
     const data = await res.json();
     expect(data.error).toBe("Webhook not configured");
   });

--- a/__tests__/stripe-webhook-api.test.ts
+++ b/__tests__/stripe-webhook-api.test.ts
@@ -72,14 +72,14 @@ describe("POST /api/webhooks/stripe", () => {
     expect(data.error).toContain("stripe-signature");
   });
 
-  it("returns 503 when webhook secret is not configured", async () => {
+  it("returns 401 when webhook secret is not configured", async () => {
     getConfigMock.mockResolvedValueOnce({ STRIPE_WEBHOOK_SECRET: "" });
 
     const { POST } = await import("@/app/api/webhooks/stripe/route");
     const response = await POST(makeRequest("{}", "sig_1"));
     const data = await response.json();
 
-    expect(response.status).toBe(503);
+    expect(response.status).toBe(401);
     expect(data.error).toContain("Webhook not configured");
   });
 
@@ -124,7 +124,7 @@ describe("POST /api/webhooks/stripe", () => {
       "buyer@cloudless.gr",
       "cs_test_1",
       129900,
-      "eur",
+      "eur"
     );
   });
 
@@ -192,10 +192,7 @@ describe("POST /api/webhooks/stripe", () => {
 
     expect(response.status).toBe(500);
     expect(data.error).toContain("Webhook handler failed");
-    expect(markStripeEventFailedMock).toHaveBeenCalledWith(
-      "evt_handler_fail",
-      "mail down",
-    );
+    expect(markStripeEventFailedMock).toHaveBeenCalledWith("evt_handler_fail", "mail down");
   });
 
   it("handles invoice.payment_failed and sends customer/team notifications", async () => {
@@ -219,10 +216,7 @@ describe("POST /api/webhooks/stripe", () => {
 
     expect(response.status).toBe(200);
     expect(data.received).toBe(true);
-    expect(sendPaymentFailureNoticeMock).toHaveBeenCalledWith(
-      "buyer@cloudless.gr",
-      "in_test_1",
-    );
+    expect(sendPaymentFailureNoticeMock).toHaveBeenCalledWith("buyer@cloudless.gr", "in_test_1");
     expect(notifyTeamMock).toHaveBeenCalledTimes(1);
   });
 });

--- a/__tests__/subscribe-api.test.ts
+++ b/__tests__/subscribe-api.test.ts
@@ -75,19 +75,14 @@ describe("POST /api/subscribe", () => {
     await POST(makeRequest({ email: "hello@cloudless.gr" }));
 
     expect(setNewsletterStatusMock).toHaveBeenCalledTimes(1);
-    expect(setNewsletterStatusMock).toHaveBeenCalledWith(
-      "hello@cloudless.gr",
-      "newsletter_signup",
-    );
+    expect(setNewsletterStatusMock).toHaveBeenCalledWith("hello@cloudless.gr", "newsletter_signup");
   });
 
   it("clears SES suppression so a re-subscriber can receive email", async () => {
     const { POST } = await import("@/app/api/subscribe/route");
     await POST(makeRequest({ email: "hello@cloudless.gr" }));
 
-    expect(removeFromSuppressionListMock).toHaveBeenCalledWith(
-      "hello@cloudless.gr",
-    );
+    expect(removeFromSuppressionListMock).toHaveBeenCalledWith("hello@cloudless.gr");
   });
 
   it("still returns success when the HubSpot update fails", async () => {
@@ -100,13 +95,15 @@ describe("POST /api/subscribe", () => {
     expect(notifyTeamMock).toHaveBeenCalledTimes(1);
   });
 
-  it("returns 500 when team notification fails", async () => {
+  it("still returns success when team notification fails (fire-and-forget)", async () => {
+    // notifyTeam() is fire-and-forget — an SES/HubSpot outage must NOT fail the
+    // subscriber. The HubSpot contact upsert (setNewsletterStatus) is the only
+    // awaited side effect; team-notify and Slack are best-effort.
     notifyTeamMock.mockRejectedValueOnce(new Error("ses-down"));
     const { POST } = await import("@/app/api/subscribe/route");
     const response = await POST(makeRequest({ email: "hello@cloudless.gr" }));
-    const data = await response.json();
 
-    expect(response.status).toBe(500);
-    expect(data.error).toContain("Failed to subscribe");
+    expect(response.status).toBe(200);
+    expect(notifyTeamMock).toHaveBeenCalledTimes(1);
   });
 });


### PR DESCRIPTION
## What

Fixes the **Unit Tests** check, which went red on `main` after #362 merged (`9d13f76`). #362 changed three route behaviors but left three unit tests asserting the old behavior.

## Root cause

#362's route changes vs. the stale test assertions:

| Route | #362 changed | Test still asserted |
| --- | --- | --- |
| `webhooks/hubspot` "not configured" | 500 → **401** | `toBe(500)` ❌ |
| `webhooks/stripe` "not configured" | 503 → **401** | `toBe(503)` ❌ |
| `subscribe` `notifyTeam()` | now fire-and-forget | `notifyTeam` reject → `toBe(500)` ❌ |

## Fix

- `__tests__/hubspot-webhook-api.test.ts` — expect **401** (+ title updated)
- `__tests__/stripe-webhook-api.test.ts` — expect **401** (+ title updated)
- `__tests__/subscribe-api.test.ts` — rewrote "returns 500 when team notification fails" to assert the subscriber still gets **200** (an SES/HubSpot outage is swallowed by the fire-and-forget `notifyTeam().catch()`), with a comment explaining the intent.

Tests only — no production code touched. The route behavior shipped in #362 is preserved; this just makes the unit suite reflect it.

## Verification

```
pnpm test:ci   →  740 files / 2021 tests pass  (was 3 failing)
eslint         clean
prettier       clean
```

https://claude.ai/code/session_01WoLaMUxTAygraKUTy7JTT8

---
_Generated by [Claude Code](https://claude.ai/code/session_01WoLaMUxTAygraKUTy7JTT8)_