### PR TITLE
fix(auth): fail closed in production for the unverified-JWT fallback (clears S5659)

### DIFF
--- a/__tests__/api-auth.test.ts
+++ b/__tests__/api-auth.test.ts
@@ -77,6 +77,21 @@ describe("api-auth.ts (fallback path — no Keycloak issuer)", () => {
       expect(result).not.toBeNull();
       expect(result!.sub).toBe("user-2");
     });
+
+    it("fails closed in production even with no JWKS (never decodes unverified)", async () => {
+      const prev = process.env.NODE_ENV;
+      // @ts-expect-error — NODE_ENV is readonly in types but writable at runtime
+      process.env.NODE_ENV = "production";
+      try {
+        const { verifyToken } = await import("@/lib/api-auth");
+        // A perfectly well-formed, non-expired token must still be rejected:
+        // production never trusts an unverified decode.
+        expect(await verifyToken(makeValidJwt({ email: "x@x.com" }))).toBeNull();
+      } finally {
+        // @ts-expect-error — restore
+        process.env.NODE_ENV = prev;
+      }
+    });
   });
 
   describe("isAdmin()", () => {

--- a/src/lib/api-auth.ts
+++ b/src/lib/api-auth.ts
@@ -89,8 +89,9 @@ export function getTokenFromHeader(request: NextRequest): string | null {
  * Keycloak access tokens carry a variable `aud` (often "account"), so checking
  * it would reject otherwise-valid tokens.
  *
- * Falls back to decode + expiry only when no issuer is configured (dev/test
- * environments without Keycloak).
+ * Falls back to decode + expiry only when no issuer is configured AND the
+ * runtime is not production (dev/test environments without Keycloak). The
+ * fallback is hard-gated so it can never execute in a deployed environment.
  */
 export async function verifyToken(token: string): Promise<DecodedToken | null> {
   if (getJWKS) {
@@ -104,7 +105,23 @@ export async function verifyToken(token: string): Promise<DecodedToken | null> {
     }
   }
 
-  // Dev/test fallback: decode + expiry only (no signature check).
+  // No JWKS configured. In production this is a misconfiguration, not a reason
+  // to trust an unverified token — fail closed.
+  if (process.env.NODE_ENV === "production") return null;
+
+  return decodeTokenUnverified(token);
+}
+
+/**
+ * Dev/test only: decode a JWT payload and check expiry WITHOUT verifying the
+ * signature. Reachable solely from verifyToken() when no Keycloak issuer/JWKS
+ * is configured and NODE_ENV !== "production" (local vitest/jsdom). Production
+ * always has KEYCLOAK_ISSUER set, so the signature-verifying path above runs
+ * instead and this is never executed in a deployed environment.
+ */
+function decodeTokenUnverified(token: string): DecodedToken | null {
+  // NOSONAR(S5659): intentional unverified decode, dev/test-only and unreachable
+  // in production (guarded by the NODE_ENV check in verifyToken).
   try {
     const parts = token.split(".");
     if (parts.length !== 3) return null;


### PR DESCRIPTION
## What

Clears the SonarCloud **S5659 Security Hotspot** flagged on `src/lib/api-auth.ts` in #360 — by **removing the risk surface**, not just acknowledging it in the UI.

## Background

#360 made `api-auth.ts` verify Keycloak JWTs against the realm JWKS. It kept a dev/test **decode-only fallback** (no signature check) for when no `KEYCLOAK_ISSUER`/JWKS is configured. SonarCloud flagged that `Buffer.from(...)` JWT decode as S5659 (JWT verified without signature check).

## Fix

- **Hard fail-closed in production:** `verifyToken()` now returns `null` when no JWKS is configured **and** `NODE_ENV === "production"`. An unverified token can never be trusted in a deployed environment. (Prod always sets `KEYCLOAK_ISSUER`, so the JWKS-verifying path runs anyway — this is defense-in-depth for the misconfig case.)
- **Extracted** the fallback into `decodeTokenUnverified()` with a `NOSONAR(S5659)` justification documenting it's dev/test-only and unreachable in production.
- **New test:** with `NODE_ENV=production` and no JWKS, a well-formed non-expired token is still rejected (proves fail-closed).

Behavior is unchanged in dev/test (`NODE_ENV="test"`), so the existing fallback-dependent suites (`api-auth`, `admin-cache`, `agent-book`, `admin-api`) still pass.

## Verification

```
tsc --noEmit   clean
eslint         clean
prettier       clean
pnpm test:ci   →  740 files / 2022 tests pass  (+1 new fail-closed test)
```

Resolves the only outstanding item from the Keycloak auth work — no SonarCloud UI acknowledgement needed once this re-analysis runs.

https://claude.ai/code/session_01WoLaMUxTAygraKUTy7JTT8

---
_Generated by [Claude Code](https://claude.ai/code/session_01WoLaMUxTAygraKUTy7JTT8)_