### PR TITLE
fix(infra): size Keycloak container to fit its real -Xmx512m heap (correct the OOM fix)

### DIFF
--- a/.github/workflows/restore-keycloak.yml
+++ b/.github/workflows/restore-keycloak.yml
@@ -5,6 +5,7 @@ name: Restore Keycloak (one-shot recovery)
 # corrected limits from k8s/cluster-protection/memory-relief-2026-05-31.yaml and
 # restarts the keycloak Deployment.
 #
+# Re-run trigger: 2026-06-01 — apply corrected JAVA_OPTS_APPEND/limit fix.
 # Runs on a GitHub-hosted runner and reaches the omv k3s API over Tailscale +
 # KUBECONFIG_B64 — the same access path as deploy-pi.yml's rollout job. This is
 # deliberately NOT pinned to the self-hosted omv runners, so the recovery still

--- a/docs/cluster-memory-relief-2026-05-31.md
+++ b/docs/cluster-memory-relief-2026-05-31.md
@@ -62,7 +62,7 @@ Plus ESP32 hardware reset:
 | Workload | Before | After | Δ |
 |---|---|---|---|
 | Metabase | 927 MiB | ≤ 400 MiB | -527 MiB |
-| Keycloak | 494 MiB | ≤ 480 MiB | -14 MiB |
+| Keycloak | 494 MiB | ≤ 768 MiB ceiling (~500 MiB actual) | 0 MiB |
 | Home Assistant | 314 MiB | 0 (scaled to 0) | -314 MiB |
 | Oncall (engine+celery+db+redis) | ~900 MiB | 0 (scaled to 0) | -900 MiB |
 | **Total** | | | **≈ -1.75 GiB** |
@@ -72,26 +72,36 @@ single digits, and bring k3s API back to fully responsive.
 
 ## Correction (2026-06-01): Keycloak OOM crash-loop
 
-The original cap of **384 MiB** (with a `-Xmx320m` heap) was too tight: a
-320 MiB JVM heap plus Quarkus non-heap memory (metaspace, thread stacks, code
-cache, GC structures ≈ 180-220 MiB) exceeds 384 MiB, so the kernel OOMKilled
-Keycloak on startup. It entered `CrashLoopBackOff` and `auth.cloudless.gr`
-served `503 "no available server"` (Cloudflare tunnel origin down) — taking
-login, registration, and password-reset offline while the rest of the cluster
-stayed healthy.
+The 384 MiB cap took Keycloak — and therefore login, registration, and
+password-reset — offline for ~8 hours (`auth.cloudless.gr` → `503 "no available
+server"`) while the rest of the cluster stayed healthy.
 
-Fix: heap lowered to `-Xmx256m` and the container limit raised to **480 MiB**,
-leaving ~224 MiB of non-heap headroom. Net reclaim vs. the original uncapped
-494 MiB is smaller (-14 MiB) but Keycloak stays up. Reliability of the IdP
-outweighs the few extra MiB. Apply with:
+Root cause, verified against the live cluster via `cluster-doctor` (issue #382):
+
+- The keycloak pod was `OOMKilled` (exit 137), 79 restarts over ~8 h.
+- Its heap is set by **`JAVA_OPTS_APPEND="-Xms192m -Xmx512m …"`**, **not**
+  `JAVA_OPTS_KC_HEAP`. The memory-relief change capped the container at 384 MiB
+  but never touched that 512 MiB heap, so the JVM could not fit → instant OOM.
+- A first remediation that patched `JAVA_OPTS_KC_HEAP` (→ `-Xmx256m`, limit
+  480 MiB) was a **no-op**: that variable is not what this deployment uses, and
+  480 MiB still cannot hold a 512 MiB heap.
+
+Real fix (this change): set the operative variable `JAVA_OPTS_APPEND` explicitly
+and size the container to hold the 512 MiB heap plus ~200 MiB of JVM non-heap:
+`requests 384 MiB`, `limits 768 MiB`, and raise the namespace `LimitRange` max
+768 MiB → 1 GiB. The pod's actual RSS is ~500 MiB regardless of the ceiling and
+the node has no memory pressure, so the higher limit does not increase real
+usage — it only stops the kernel OOMKill. Net: Keycloak's footprint is unchanged
+from before the incident; the lesson is **never cap a JVM container below its
+`-Xmx` + non-heap working set.**
+
+Apply with `pnpm keycloak:restore` (or, on omv-main with a live k3s API):
 
 ```bash
-# On omv-main (needs a responsive k3s API):
 kubectl apply -f k8s/cluster-protection/memory-relief-2026-05-31.yaml
 kubectl -n keycloak rollout restart deploy/keycloak
-kubectl -n keycloak rollout status  deploy/keycloak --timeout=180s
-# Verify: curl -sS -o /dev/null -w '%{http_code}\n' \
-#   https://auth.cloudless.gr/realms/master/.well-known/openid-configuration
+kubectl -n keycloak rollout status  deploy/keycloak --timeout=240s
+# Verify: pnpm keycloak:smoke   (or curl the OIDC discovery endpoint)
 ```
 
 ## How to apply

--- a/k8s/cluster-protection/memory-relief-2026-05-31.yaml
+++ b/k8s/cluster-protection/memory-relief-2026-05-31.yaml
@@ -33,7 +33,10 @@ spec:
     - type: Container
       default:        { memory: 512Mi, cpu: 1 }
       defaultRequest: { memory: 128Mi, cpu: 100m }
-      max:            { memory: 768Mi, cpu: 2 }
+      # max raised 768Mi → 1Gi: Keycloak 26.2 runs a -Xmx512m heap, which needs
+      # a ~768Mi container ceiling (heap + JVM non-heap). 768Mi as the max left
+      # no room above the pod's own limit, so allow 1Gi headroom.
+      max:            { memory: 1Gi, cpu: 2 }
 
 ---
 apiVersion: v1
@@ -112,15 +115,22 @@ spec:
             limits:   { memory: 400Mi, cpu: 1 }
 
 ---
-# Keycloak — 494 Mi → 480 Mi cap. JVM heap set via JAVA_OPTS_KC_HEAP.
+# Keycloak — size the container to FIT the JVM heap, do not starve it.
 #
-# IMPORTANT: the container limit MUST leave room for JVM non-heap memory
-# (Quarkus metaspace ~130-150 Mi, thread stacks, code cache, direct buffers,
-# GC structures — together ~180-220 Mi). The previous values (-Xmx320m under a
-# 384 Mi limit) left only ~64 Mi for all of that, so Keycloak was OOMKilled on
-# startup → CrashLoopBackOff → auth.cloudless.gr returned 503. A 256 Mi heap
-# under a 480 Mi limit gives ~224 Mi of non-heap headroom, which fits.
-# (-Xmx makes -XX:MaxRAMPercentage dead config, so it is dropped.)
+# Verified in-cluster (cluster-doctor snapshot, issue #382): the live keycloak
+# Deployment runs its heap via JAVA_OPTS_APPEND="-Xms192m -Xmx512m …", NOT via
+# JAVA_OPTS_KC_HEAP. The original memory-relief capped the container at 384Mi
+# WITHOUT lowering that 512Mi heap, so the JVM could never fit → OOMKilled on
+# startup (exit 137), 79 restarts over ~8h, auth.cloudless.gr 503. An earlier
+# attempt to patch JAVA_OPTS_KC_HEAP was a no-op because that variable is not
+# what this deployment uses.
+#
+# Fix: set the operative variable (JAVA_OPTS_APPEND) explicitly and size the
+# container to hold a 512Mi heap plus ~200Mi of JVM non-heap (Quarkus metaspace,
+# thread stacks, code cache, GC, plus a startup-augmentation spike). The pod's
+# actual RSS is ~500Mi regardless of the ceiling, and the node has no memory
+# pressure, so raising the limit does not increase real usage — it only stops
+# the kernel OOMKill. (-Xms reduced 192m→128m so idle commits less.)
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -132,11 +142,11 @@ spec:
       containers:
         - name: keycloak
           env:
-            - name: JAVA_OPTS_KC_HEAP
-              value: "-Xms64m -Xmx256m"
+            - name: JAVA_OPTS_APPEND
+              value: "-Xms128m -Xmx512m -Djdk.reflect.useDirectMethodHandle=false"
           resources:
-            requests: { memory: 256Mi, cpu: 100m }
-            limits:   { memory: 480Mi, cpu: 1 }
+            requests: { memory: 384Mi, cpu: 100m }
+            limits:   { memory: 768Mi, cpu: 1 }
 
 ---
 # n8n — 117 Mi → 256 Mi cap (keep headroom for workflow spikes)


### PR DESCRIPTION
## What the cluster-doctor revealed (issue #382)

```
keycloak pod: 0/1 Running, 79 restarts, lastTerminated=OOMKilled (exit 137)
limits.memory: 384Mi
env: JAVA_OPTS_APPEND=-Xms192m -Xmx512m -Djdk.reflect.useDirectMethodHandle=false
```

The live deployment sets its heap via **`JAVA_OPTS_APPEND=-Xmx512m`**, not `JAVA_OPTS_KC_HEAP`. So:
- The 384Mi cap could never hold a 512Mi heap → OOMKilled on startup, 79× over ~8h → `auth.cloudless.gr` 503.
- My earlier fix (#378) patched `JAVA_OPTS_KC_HEAP` → **no-op** (wrong variable); 480Mi still can't hold 512Mi anyway.

## Correct fix
- Set the operative var `JAVA_OPTS_APPEND` explicitly (`-Xmx512m`, `-Xms` lowered 192m→128m)
- Size the container to fit: `requests 384Mi`, `limits 768Mi`
- Raise the keycloak namespace `LimitRange` max `768Mi → 1Gi`

Actual Keycloak RSS is ~500Mi and the node has **no memory pressure** (73% used), so the higher ceiling doesn't increase real usage — it just stops the kernel OOMKill. Footprint is effectively unchanged from before the incident.

Merging re-fires the `restore-keycloak` workflow (it touches that file), which applies this manifest + rolls Keycloak. My session monitor will then auto-run `keycloak:smoke`, and `cluster-doctor` can re-confirm pod health on #382.

https://claude.ai/code/session_01WoLaMUxTAygraKUTy7JTT8

---
_Generated by [Claude Code](https://claude.ai/code/session_01WoLaMUxTAygraKUTy7JTT8)_