### PR TITLE
chore(ops): re-run cluster-doctor for post-fix Keycloak snapshot

### DIFF
--- a/scripts/cluster-doctor.sh
+++ b/scripts/cluster-doctor.sh
@@ -68,3 +68,5 @@ pod=$(kubectl -n "$NAMESPACE" get pods -l app="$DEPLOYMENT" -o name 2>/dev/null 
 [ -n "$pod" ] && k -n "$NAMESPACE" logs "$pod" --previous --tail=40 | fence || printf "_no pod found via label app=%s_\n" "$DEPLOYMENT"
 
 printf "\n_End of snapshot._\n"
+
+# re-run 20260601T133536Z


### PR DESCRIPTION
Re-fires `cluster-doctor` (path-filtered) to capture a fresh snapshot on issue #382 after the corrected Keycloak fix (#384), confirming the 768Mi limit landed and the new pod is starting rather than OOMing.

https://claude.ai/code/session_01WoLaMUxTAygraKUTy7JTT8

---
_Generated by [Claude Code](https://claude.ai/code/session_01WoLaMUxTAygraKUTy7JTT8)_