### PR TITLE
feat(ops): probe Keycloak deploy ownership (find what reverts the apply)

### DIFF
--- a/scripts/cluster-doctor.sh
+++ b/scripts/cluster-doctor.sh
@@ -78,4 +78,15 @@ printf "  can-i create deployments/rollout (restart) -n %s : %s\n" "$NAMESPACE" 
 section "Keycloak: rollout history (did a restart ever roll a new ReplicaSet?)"
 k -n "$NAMESPACE" rollout history "deploy/$DEPLOYMENT" | fence
 
+section "Keycloak deploy: ownership — who reconciles it (Helm/Argo/Flux)?"
+printf "managed-by label: %s\n" "$(kubectl -n "$NAMESPACE" get deploy "$DEPLOYMENT" -o jsonpath='{.metadata.labels.app\.kubernetes\.io/managed-by}' 2>&1)"
+printf "ownerReferences:  %s\n" "$(kubectl -n "$NAMESPACE" get deploy "$DEPLOYMENT" -o jsonpath='{.metadata.ownerReferences}' 2>&1)"
+printf "GitOps annotations:\n"
+kubectl -n "$NAMESPACE" get deploy "$DEPLOYMENT" -o jsonpath='{.metadata.annotations}' 2>/dev/null \
+  | tr ',' '\n' | grep -iE "helm|argocd|fluxcd|kustomize\.toolkit|reconcile|managed-by" | fence
+printf "field managers (who last wrote each field):\n"
+kubectl -n "$NAMESPACE" get deploy "$DEPLOYMENT" -o jsonpath='{range .metadata.managedFields[*]}{.manager}{" ("}{.operation}{", "}{.apiVersion}{")\n"}{end}' 2>&1 | fence
+printf "live container[0] memory limit: %s\n" "$(kubectl -n "$NAMESPACE" get deploy "$DEPLOYMENT" -o jsonpath='{.spec.template.spec.containers[0].resources.limits.memory}' 2>&1)"
+printf "last-applied (kubectl apply) memory limit: %s\n" "$(kubectl -n "$NAMESPACE" get deploy "$DEPLOYMENT" -o jsonpath='{.metadata.annotations.kubectl\.kubernetes\.io/last-applied-configuration}' 2>/dev/null | grep -oE '\"memory\":\"[0-9]+Mi\"' | tail -1)"
+
 printf "\n_End of snapshot._\n"


### PR DESCRIPTION
RBAC is fine (kubeconfig is `system:admin`), yet the keycloak deployment stays at 384Mi/`-Xmx512m` while rollout revisions churn — classic signature of an external reconciler (Helm/Argo/Flux) reverting the `kubectl apply`. Adds ownership diagnostics to the doctor: managed-by label, owner refs, GitOps annotations, field managers, and live-vs-last-applied memory limit. Re-fires on merge; result lands on #382.

https://claude.ai/code/session_01WoLaMUxTAygraKUTy7JTT8

---
_Generated by [Claude Code](https://claude.ai/code/session_01WoLaMUxTAygraKUTy7JTT8)_