### PR TITLE
feat(ops): prometheus:tune tool + cluster-incident-response skill (fix PrometheusRuleFailures)

### DIFF
--- a/.claude/skills/cluster-incident-response/SKILL.md
+++ b/.claude/skills/cluster-incident-response/SKILL.md
@@ -1,0 +1,111 @@
+---
+name: cluster-incident-response
+description: Diagnose and recover omv k3s cluster outages from a cloud session that has NO kubectl/ssh/aws. Use when auth.cloudless.gr returns 503, a pod is OOMKilled/CrashLoopBackOff, login is down, PrometheusRuleFailures fires, or the user says "fix what's broken on the cluster", "is the cluster healthy", "recover Keycloak". Drives cluster ops through path-triggered GitHub workflows (hosted runner + Tailscale + KUBECONFIG_B64) that post diagnostics to issue #382, plus the cluster:doctor / keycloak:smoke / keycloak:restore scripts.
+argument-hint: "what's broken, e.g. 'keycloak 503' or 'PrometheusRuleFailures'"
+---
+
+# Cluster Incident Response — cloudless.gr (omv k3s)
+
+Recover the omv k3s cluster when you're in a **cloud session with no direct
+cluster access** — no `kubectl`, `ssh`, `aws`, no `OMV_SSH_KEY_CONTENTS`, and the
+tailnet API (`100.113.41.119:6443`) is blocked by the network policy. You drive
+the cluster entirely through **GitHub Actions workflows** that run on a hosted
+runner, reach k3s over Tailscale, and **report back into GitHub issue #382**.
+
+## The core constraint & pattern
+
+You cannot run kubectl from the session, and the GitHub MCP here **cannot
+dispatch `workflow_dispatch`**. So every cluster action is triggered by a
+**path-filtered `push` to `main`**: a workflow has
+
+```yaml
+on:
+  push: { branches: [main], paths: [".github/workflows/<wf>.yml"] }
+```
+
+and editing/merging that file fires it. Workflows run on `ubuntu-latest`,
+connect with `tailscale/github-action` (`TS_AUTHKEY`), configure kubectl from
+the `KUBECONFIG_B64` secret (it is **`system:admin`** — full write), do the
+work, and `gh issue comment 382` the result so you can read it via
+`mcp__github__issue_read(method=get_comments, issue_number=382)`.
+
+Workflow runner billing can break — `ubuntu-latest` + Tailscale is the robust
+path; do **not** pin recovery to `[self-hosted, omv, pi]` (those runners go
+offline during cluster incidents and the job queues forever).
+
+## Tools (all in repo)
+
+| Command / Workflow | What it does |
+| --- | --- |
+| `pnpm cluster:doctor` (`scripts/cluster-doctor.sh`) | Read-only diagnostics: node memory/pressure, non-Running pods, a target deploy's pods/limits/events/logs, OOMKilled/CrashLoop, container field-managers & ownership, **Prometheus pod + failing rules** (`/api/v1/rules` via a throwaway curl pod, parsed with `jq`). |
+| `.github/workflows/cluster-doctor.yml` | Runs the doctor on a hosted runner over Tailscale, posts the snapshot to **#382**. Trigger by editing `scripts/cluster-doctor.sh` or the workflow. |
+| `pnpm keycloak:smoke` (`scripts/keycloak-smoke.sh`) | Credential-free verification of the live login+registration surface (discovery, JWKS, hosted login, registration, token endpoint, next-auth provider, app→Keycloak handoff). |
+| `pnpm keycloak:restore` (`scripts/restore-keycloak.sh`) | Direct strategic-merge **patch** of the keycloak deploy (size container to fit heap), restart, verify, with before/after/revert-check logging. |
+| `.github/workflows/restore-keycloak.yml` | Runs `keycloak:restore` on a hosted runner, posts the log to #382. Trigger by editing the workflow file. |
+| `pnpm prometheus:tune` (`scripts/prometheus-tune.sh`) | Deletes the heavy kube-apiserver SLO/burnrate/availability PrometheusRules that time out and trip `PrometheusRuleFailures`; reports remaining failing rules. |
+| `.github/workflows/prometheus-tune.yml` | Runs `prometheus:tune` on a hosted runner, posts the log to #382. Trigger by editing the workflow file. |
+
+## Triage workflow
+
+1. **See the cluster** — fire `cluster-doctor` (edit `scripts/cluster-doctor.sh`
+   → PR → squash-merge), wait ~2 min, read #382. Never guess pod state; the
+   doctor is your eyes.
+2. **Classify** the broken pod: `OOMKilled (exit 137)` = memory; `Error/Completed`
+   = app/config; `CrashLoopBackOff` with probe `connection refused` = process
+   never reaches ready (often still OOM during startup).
+3. **Apply the fix** by editing the relevant manifest/script and re-triggering
+   the workflow (path filter). Read the posted log to confirm it stuck (the
+   restore script prints `before / immediately-after / +15s revert-check`).
+4. **Verify** end-to-end (`keycloak:smoke`, or curl the discovery endpoint).
+
+## Hard-won lessons (do not relearn these the hard way)
+
+- **Never cap a JVM container below its `-Xmx` + non-heap working set.** Keycloak
+  26.2 (Quarkus) needs heap **plus ~180–220 MiB** non-heap (metaspace, threads,
+  code cache, GC, startup augmentation). A 384 MiB cap on a `-Xmx512m` heap →
+  `OOMKilled` crash-loop → `auth.cloudless.gr` 503. Size the container to the
+  heap (512 MiB heap → 768 MiB limit). Actual RSS is ~500 MiB regardless of the
+  ceiling, and a higher *limit* does not raise real usage — it only stops the
+  kernel OOMKill.
+- **Keycloak's operative heap variable is `JAVA_OPTS_APPEND`, not
+  `JAVA_OPTS_KC_HEAP`.** Patching the wrong one is a silent no-op. Verify with
+  the doctor's deploy `env` dump.
+- **`kubectl apply -f <manifest>` from CI did not stick** while a direct
+  `kubectl patch` did — and the deploy's `last-applied-configuration` revealed
+  the apply never reached it. Prefer a direct strategic-merge **patch** of the
+  single object for recovery; confirm with a revert-check (re-read after 15 s).
+- **error=Configuration on a GET to `/api/auth/signin/keycloak` is NOT a bug.**
+  next-auth's real flow is **POST + CSRF**; that returns `302 → auth.cloudless.gr/
+  …/openid-connect/auth?…code_challenge_method=S256`. Always test login with the
+  POST+CSRF flow, not a bare GET.
+- **`PrometheusRuleFailures` is usually a specific broken rule, not memory** —
+  but check first: the doctor shows the prometheus pod restarts/OOM and the
+  failing rule's `lastError`. Only raise Prometheus's memory if it is actually
+  OOMing. The known offender here is the kube-prometheus-stack
+  **`kube-apiserver-burnrate.rules`** group (e.g. `apiserver_request:burnrate3d`):
+  multi-day `rate()` over high-cardinality `apiserver_request_total` →
+  `expanding series: context deadline exceeded`. Fix with `pnpm prometheus:tune`
+  (deletes the heavy apiserver SLO/burnrate/availability rule groups — unused on
+  this homelab). Durable fix: Helm values
+  `defaultRules.rules.kubeApiserverBurnrate/Availability/Slos: false`.
+- **Watch omv memory.** Node limits are oversubscribed (>130%); raising one
+  pod's ceiling is fine (limits ≠ usage) but confirm `MemoryPressure: False`
+  and node memory headroom in the doctor before/after.
+
+## Reading results
+
+```
+mcp__github__issue_read(method="get_comments", owner="themis128",
+  repo="cloudless.gr", issue_number=382, perPage=1, page=<last>)
+```
+Comments are chronological; the newest snapshot/log is the last page.
+
+## Reference
+
+- Incident writeup & memory math: `docs/cluster-memory-relief-2026-05-31.md`
+  (the "Correction (2026-06-01)" section).
+- Keycloak deploy: ns `keycloak`, deploy `keycloak`, image
+  `quay.io/keycloak/keycloak:26.2`, fronted by a Cloudflare tunnel (503 "no
+  available server" = origin/pod down).
+- App login path: CloudFront → Lambda (primary) and the Pi origin both serve
+  `/api/auth/*`; both hand off to Keycloak correctly once it is up.

--- a/.github/workflows/prometheus-tune.yml
+++ b/.github/workflows/prometheus-tune.yml
@@ -1,0 +1,48 @@
+name: Prometheus tune (stop PrometheusRuleFailures)
+
+# Disables the heavy kube-apiserver SLO/burnrate/availability recording rules
+# that time out on the small omv Prometheus (1 CPU / 500Mi) and trip the
+# PrometheusRuleFailures alert. Runs scripts/prometheus-tune.sh on a hosted
+# runner over Tailscale + KUBECONFIG_B64, and posts the result to issue #382.
+#
+# Trigger: workflow_dispatch, or push to this file / the tune script on main.
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [main]
+    paths:
+      - ".github/workflows/prometheus-tune.yml"
+      - "scripts/prometheus-tune.sh"
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  tune:
+    runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ github.token }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v4.3.1
+
+      - name: Connect to tailnet
+        uses: tailscale/github-action@0263d9e6d793eaefcf1de98ff7fde47abe6664d3 # v3.2.4
+        with:
+          authkey: ${{ secrets.TS_AUTHKEY }}
+
+      - name: Configure kubectl
+        run: |
+          mkdir -p ~/.kube
+          echo "${{ secrets.KUBECONFIG_B64 }}" | base64 -d > ~/.kube/config
+          chmod 600 ~/.kube/config
+
+      - name: Tune Prometheus rules
+        run: bash scripts/prometheus-tune.sh 2>&1 | tee prom-tune.log
+
+      - name: Post result to tracking issue
+        if: always()
+        run: |
+          { echo '# Prometheus tune — '"$(date -u '+%Y-%m-%d %H:%M:%SZ')"; echo; echo '```'; cat prom-tune.log 2>/dev/null || echo '(no log)'; echo '```'; } > prom-comment.md
+          gh issue comment 382 --repo "${{ github.repository }}" --body-file prom-comment.md

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "dev:restart:clean": "bash scripts/dev-server-restart.sh --clean",
     "cluster:health": "bash scripts/cluster-health-snapshot.sh",
     "cluster:doctor": "bash scripts/cluster-doctor.sh",
+    "prometheus:tune": "bash scripts/prometheus-tune.sh",
     "lambda:audit": "bash scripts/lambda-env-audit.sh",
     "e2e:smoke": "bash scripts/e2e-smart-run.sh smoke",
     "e2e:full": "bash scripts/e2e-smart-run.sh full",

--- a/scripts/cluster-doctor.sh
+++ b/scripts/cluster-doctor.sh
@@ -98,20 +98,26 @@ kubectl -n "$PROM_NS" get pods -l app.kubernetes.io/name=prometheus -o jsonpath=
 printf "prometheus container memory limit: %s\n" "$(kubectl -n "$PROM_NS" get sts -l app.kubernetes.io/name=prometheus -o jsonpath='{.items[0].spec.template.spec.containers[?(@.name=="prometheus")].resources.limits.memory}' 2>&1)"
 
 section "Prometheus: failing rules (health != ok) + lastError"
-kubectl -n "$PROM_NS" run promq-$$ --image=curlimages/curl:8.11.1 --restart=Never --rm -i --quiet \
+# Curl the rules API from an in-cluster pod, parse with jq on the runner.
+kubectl -n "$PROM_NS" run "promq-$$" --image=curlimages/curl:8.11.1 --restart=Never --rm -i --quiet \
   --command -- curl -sS --max-time 12 "http://prometheus-operated.${PROM_NS}.svc:9090/api/v1/rules" 2>/dev/null \
-  | python3 -c '
-import json,sys
-try:
-    d=json.load(sys.stdin)
-except Exception as e:
-    print(f"could not parse rules API: {e}"); sys.exit(0)
-bad=[]
-for g in d.get("data",{}).get("groups",[]):
-    for r in g.get("rules",[]):
-        if r.get("health")!="ok" or r.get("lastError"):
-            bad.append(f"[{g.get(\"name\")}] {r.get(\"name\")}: health={r.get(\"health\")} error={r.get(\"lastError\")}")
-print("\n".join(bad) if bad else "all rules healthy (no eval failures right now)")
-' 2>&1 | fence
+  > /tmp/promrules.json || true
+if [ -s /tmp/promrules.json ]; then
+  jq -r '
+    [ .data.groups[]
+      | .name as $g
+      | .rules[]
+      | select((.health != "ok") or ((.lastError // "") != ""))
+      | "[\($g)] \(.name)  health=\(.health)  type=\(.type)\n    lastError: \(.lastError // "")"
+    ] as $bad
+    | if ($bad|length)==0 then "all rules healthy (no eval failures right now)"
+      else $bad[] end
+  ' /tmp/promrules.json 2>&1 | fence
+  printf "rule groups total: %s, rules total: %s\n" \
+    "$(jq '.data.groups|length' /tmp/promrules.json 2>/dev/null)" \
+    "$(jq '[.data.groups[].rules[]]|length' /tmp/promrules.json 2>/dev/null)"
+else
+  printf "_could not fetch /api/v1/rules (empty response)_\n"
+fi
 
 printf "\n_End of snapshot._\n"

--- a/scripts/prometheus-tune.sh
+++ b/scripts/prometheus-tune.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+#
+# prometheus-tune.sh — stop PrometheusRuleFailures on the small omv cluster.
+#
+# Root cause (cluster-doctor, issue #382): the kube-prometheus-stack apiserver
+# SLO recording rules (group kube-apiserver-burnrate.rules, e.g.
+# apiserver_request:burnrate3d) run multi-day rate() over high-cardinality
+# apiserver_request_total series. On a Pi (1 CPU / 500Mi Prometheus) they exceed
+# the rule evaluation timeout → "expanding series: context deadline exceeded" →
+# prometheus_rule_evaluation_failures_total increments → PrometheusRuleFailures.
+#
+# These SLO/burnrate/availability rules are for large-scale apiserver SLO
+# dashboards that this homelab does not use (the monitoring stack is being
+# slimmed to cluster-health-only — see prometheus-slim.yaml). Disabling them
+# stops the failures AND lightens Prometheus CPU/memory.
+#
+# This deletes the PrometheusRule objects that contain the heavy groups. It is
+# idempotent (missing = already done) and reversible: a `helm upgrade` of the
+# kube-prometheus-stack recreates them, so the durable fix is the Helm values
+# (defaultRules.rules.kubeApiserverBurnrate/Availability/Slos: false) — applied
+# wherever that release is managed.
+#
+# Requires a kubectl context with delete on prometheusrules in the monitoring
+# namespace (the prometheus-tune.yml workflow supplies one via KUBECONFIG_B64).
+#
+# Usage: bash scripts/prometheus-tune.sh
+
+set -uo pipefail
+
+PROM_NS="${PROM_NS:-monitoring}"
+HEAVY_GROUPS=(
+  "kube-apiserver-burnrate.rules"
+  "kube-apiserver-availability.rules"
+  "kube-apiserver-slos"
+)
+
+log() { printf '[prom-tune] %s\n' "$*"; }
+command -v kubectl >/dev/null 2>&1 || { echo "error: kubectl not found"; exit 1; }
+
+log "whoami: $(kubectl auth whoami 2>&1 | tr '\n' ' ')"
+
+deleted=0
+for grp in "${HEAVY_GROUPS[@]}"; do
+  # Find every PrometheusRule whose spec contains this heavy group.
+  mapfile -t crs < <(kubectl -n "$PROM_NS" get prometheusrule -o json 2>/dev/null \
+    | jq -r --arg g "$grp" '.items[] | select((.spec.groups // [])[].name == $g) | .metadata.name' \
+    | sort -u)
+  if [ "${#crs[@]}" -eq 0 ]; then
+    log "group '$grp': no PrometheusRule found (already disabled?)"
+    continue
+  fi
+  for cr in "${crs[@]}"; do
+    [ -z "$cr" ] && continue
+    log "deleting PrometheusRule '$cr' (contains heavy group '$grp')"
+    kubectl -n "$PROM_NS" delete prometheusrule "$cr" --ignore-not-found && deleted=$((deleted+1))
+  done
+done
+log "deleted $deleted PrometheusRule object(s)."
+
+# Give Prometheus a moment to reload rules, then report remaining failures.
+sleep 20
+log "Remaining rules with health != ok:"
+kubectl -n "$PROM_NS" run "promq-$$" --image=curlimages/curl:8.11.1 --restart=Never --rm -i --quiet \
+  --command -- curl -sS --max-time 12 "http://prometheus-operated.${PROM_NS}.svc:9090/api/v1/rules" 2>/dev/null \
+  > /tmp/promrules.json || true
+if [ -s /tmp/promrules.json ]; then
+  jq -r '
+    [ .data.groups[] | .name as $g | .rules[]
+      | select((.health != "ok") or ((.lastError // "") != ""))
+      | "[\($g)] \(.name): \(.lastError // "")" ] as $bad
+    | if ($bad|length)==0 then "  ✓ all rules healthy" else $bad[] end
+  ' /tmp/promrules.json 2>&1
+else
+  log "  (could not re-fetch /api/v1/rules)"
+fi


### PR DESCRIPTION
## The broken rule (from cluster-doctor #382)
```
[kube-apiserver-burnrate.rules] apiserver_request:burnrate3d  health=err
  lastError: expanding series: context deadline exceeded
```
Not memory (Prometheus is 2/2, not OOMing). The kube-prometheus-stack apiserver **SLO/burnrate/availability** recording rules run multi-day `rate()` over high-cardinality `apiserver_request_total` and time out on the 1-CPU/500Mi Pi Prometheus → `PrometheusRuleFailures`. They're SLO-dashboard rules unused on this homelab (stack is slimmed to cluster-health-only).

## Tools created
- **`pnpm prometheus:tune`** (`scripts/prometheus-tune.sh`) — deletes the heavy apiserver SLO/burnrate/availability `PrometheusRule` objects (idempotent, reversible) and reports any remaining failing rules. Also lightens Prometheus load (helps omv memory).
- **`.github/workflows/prometheus-tune.yml`** — runs it on a hosted runner over Tailscale, posts the log to #382.
- **`.claude/skills/cluster-incident-response`** — skill packaging the whole cloud-session recovery pattern (path-triggered workflows → issue #382), the `cluster:doctor`/`keycloak:smoke`/`keycloak:restore`/`prometheus:tune` tools, and the hard-won lessons (never cap a JVM below `-Xmx`+non-heap; Keycloak's heap var is `JAVA_OPTS_APPEND`; direct-patch beats apply for recovery; test login with POST+CSRF not GET; this PrometheusRuleFailures root cause).

Merging fires the tune (path filter) → result on #382. Durable fix noted in the script: Helm values `defaultRules.rules.kubeApiserver{Burnrate,Availability,Slos}: false`.

https://claude.ai/code/session_01WoLaMUxTAygraKUTy7JTT8

---
_Generated by [Claude Code](https://claude.ai/code/session_01WoLaMUxTAygraKUTy7JTT8)_