### PR TITLE
chore(ops): confirm Prometheus rules healthy after tune

### DIFF
--- a/scripts/cluster-doctor.sh
+++ b/scripts/cluster-doctor.sh
@@ -121,3 +121,5 @@ else
 fi
 
 printf "\n_End of snapshot._\n"
+
+# confirm-after-tune 20260601T141522Z


### PR DESCRIPTION
Re-fires cluster-doctor to confirm no rules remain in `health != ok` after `prometheus:tune` deleted the 3 heavy apiserver SLO rule groups. Result on #382.

https://claude.ai/code/session_01WoLaMUxTAygraKUTy7JTT8

---
_Generated by [Claude Code](https://claude.ai/code/session_01WoLaMUxTAygraKUTy7JTT8)_