### PR TITLE
feat(ops): keycloak-create-user — admin-provision a user + verify login

### DIFF
--- a/.github/workflows/keycloak-create-user.yml
+++ b/.github/workflows/keycloak-create-user.yml
@@ -1,0 +1,84 @@
+name: Keycloak create test user (verify provisioning + login)
+
+# Creates a test user in the master realm via kcadm.sh inside the keycloak pod
+# (admin password stays in-pod, never printed), verifies the account exists and
+# that its password authenticates, and posts a redacted result to issue #382.
+#
+# Self-service registration is disabled on the master realm, so users are
+# admin-provisioned — this is the supported "create a user" path.
+#
+# Trigger: workflow_dispatch, or push to this file on main.
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [main]
+    paths:
+      - ".github/workflows/keycloak-create-user.yml"
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  create-user:
+    runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ github.token }}
+    steps:
+      - name: Connect to tailnet
+        uses: tailscale/github-action@0263d9e6d793eaefcf1de98ff7fde47abe6664d3 # v3.2.4
+        with:
+          authkey: ${{ secrets.TS_AUTHKEY }}
+
+      - name: Configure kubectl
+        run: |
+          mkdir -p ~/.kube
+          echo "${{ secrets.KUBECONFIG_B64 }}" | base64 -d > ~/.kube/config
+          chmod 600 ~/.kube/config
+
+      - name: Create + verify user via kcadm
+        run: |
+          set -uo pipefail
+          TS=$(date -u +%Y%m%d%H%M%S)
+          NEWUSER="signup-test-${TS}@cloudless.gr"
+          NEWPASS="Sg9!$(head -c 18 /dev/urandom | base64 | tr -dc 'A-Za-z0-9')xY7"
+          POD=$(kubectl -n keycloak get pod -l app=keycloak -o jsonpath='{.items[0].metadata.name}')
+          echo "pod=$POD newuser=$NEWUSER"
+
+          OUT=$(kubectl -n keycloak exec -i "$POD" -- env NU="$NEWUSER" NP="$NEWPASS" bash -s <<'EOS'
+          set -u
+          KCADM=/opt/keycloak/bin/kcadm.sh
+          AU="${KEYCLOAK_ADMIN:-${KC_BOOTSTRAP_ADMIN_USERNAME:-admin}}"
+          AP="${KEYCLOAK_ADMIN_PASSWORD:-${KC_BOOTSTRAP_ADMIN_PASSWORD:-}}"
+          if ! $KCADM config credentials --server http://localhost:8080 --realm master --user "$AU" --password "$AP" >/dev/null 2>&1; then
+            echo "ADMIN_AUTH_FAILED (no usable admin creds in pod env)"; exit 0
+          fi
+          ID=$($KCADM create users -r master -s username="$NU" -s email="$NU" -s enabled=true -s emailVerified=true -s firstName=Signup -s lastName=Test -i 2>/dev/null) || { echo "CREATE_FAILED"; exit 0; }
+          echo "USER_ID=$ID"
+          $KCADM set-password -r master --userid "$ID" --new-password "$NP" >/dev/null 2>&1 && echo "PASSWORD_SET=yes" || echo "PASSWORD_SET=no"
+          echo "ACCOUNT:"; $KCADM get "users/$ID" -r master --fields username,email,enabled,emailVerified 2>/dev/null
+          # Verify the new user's password authenticates (admin-cli allows direct grant in master).
+          if curl -sS -m 8 -d "grant_type=password&client_id=admin-cli&username=$NU&password=$NP" \
+               http://localhost:8080/realms/master/protocol/openid-connect/token | grep -q '"access_token"'; then
+            echo "LOGIN_VERIFIED=yes (password authenticates against Keycloak)"
+          else
+            echo "LOGIN_VERIFIED=no"
+          fi
+          EOS
+          )
+          echo "$OUT"
+
+          {
+            echo "# Keycloak create-user — $(date -u '+%F %T')Z"
+            echo
+            echo "Created (admin-provisioned; self-registration is disabled on master realm):"
+            echo
+            echo "- **Username/email:** \`${NEWUSER}\`"
+            echo "- Password: generated in-job, **not logged**"
+            echo
+            echo '```'
+            echo "$OUT" | grep -vi 'password'
+            echo '```'
+          } > user.md
+          gh issue comment 382 --repo "${{ github.repository }}" --body-file user.md


### PR DESCRIPTION
Verifies user creation + login on the live system. **Self-service registration is disabled on the master realm** (the hosted `/registrations` page returns 400 + the login screen), so users are **admin-provisioned** — this is the supported path.

The workflow runs `kcadm.sh` inside the keycloak pod (admin password stays in-pod, never printed), creates `signup-test-<ts>@cloudless.gr` (enabled, emailVerified), sets a generated password, confirms the account, and verifies that password **authenticates against Keycloak**. Posts a **redacted** result (username + outcome, no password) to #382.

Merging fires it; I'll report the created username + `LOGIN_VERIFIED`.

https://claude.ai/code/session_01WoLaMUxTAygraKUTy7JTT8

---
_Generated by [Claude Code](https://claude.ai/code/session_01WoLaMUxTAygraKUTy7JTT8)_