### PR TITLE
feat(ops): keycloak:create-user tool + keycloak-user-provisioning skill

### DIFF
--- a/.claude/skills/keycloak-user-provisioning/SKILL.md
+++ b/.claude/skills/keycloak-user-provisioning/SKILL.md
@@ -1,0 +1,77 @@
+---
+name: keycloak-user-provisioning
+description: Create / manage cloudless.gr Keycloak users when self-service signup is disabled. Use when the user says "create a user", "add an account", "sign me up", "make an admin user", "register a user", "the signup button doesn't work", or wants to verify login/registration on the live site. Covers admin-provisioning via kcadm in-pod, the admin-group gate, and enabling self-registration.
+argument-hint: "email, e.g. someone@cloudless.gr [--admin]"
+---
+
+# Keycloak User Provisioning — cloudless.gr
+
+## The key fact: self-service registration is DISABLED
+
+On the **master** realm, `registrationAllowed` is **off** — the hosted
+`/realms/master/protocol/openid-connect/registrations` page returns the login
+screen (HTTP 400), and the website's "Create Account" button cannot self-enrol
+users. **Users are admin-provisioned.** (Verify the realm flag with
+`pnpm keycloak:smoke` — check 4.)
+
+Two ways to act on this:
+1. **Provision a user yourself** (default, supported) — `keycloak:create-user`.
+2. **Enable public self-signup** (only if the user explicitly wants the signup
+   button to work) — set `registrationAllowed=true` on the realm:
+   `kcadm.sh update realms/master -s registrationAllowed=true` (and usually
+   `verifyEmail`, `registrationEmailAsUsername` to taste). This is a
+   product/security decision — confirm before flipping it.
+
+## Provisioning a user
+
+`pnpm keycloak:create-user` (`scripts/keycloak-create-user.sh`) runs `kcadm.sh`
+**inside the keycloak pod**, so the admin password never leaves the cluster. It
+is idempotent (an existing username is reused; only password / group are reset)
+and verifies the new password authenticates via an `admin-cli` direct grant.
+
+```bash
+EMAIL=user@cloudless.gr  bash scripts/keycloak-create-user.sh           # regular user
+EMAIL=admin@cloudless.gr ADMIN=1 bash scripts/keycloak-create-user.sh    # app admin
+EMAIL=x@y TEMPORARY=1 bash scripts/keycloak-create-user.sh               # must reset on first login
+```
+
+Env: `EMAIL` (required), `PASSWORD` (generated if unset — printed on a
+`CREDENTIAL ...` line that the workflow strips before posting), `ADMIN=1`
+(add to the `admin` group), `TEMPORARY=1`, `NAMESPACE`/`DEPLOYMENT`/`REALM`.
+
+### From a cloud session (no kubectl)
+
+Use the **`.github/workflows/keycloak-create-user.yml`** workflow — hosted runner
++ Tailscale + `KUBECONFIG_B64`, posts a redacted result (no password) to issue
+**#382**. `workflow_dispatch` takes `email`/`admin`/`temporary` inputs; a
+path-filtered push (editing the workflow or the script) runs it with the default
+idempotent email `signup-verify@cloudless.gr`. (The GitHub MCP here cannot
+`workflow_dispatch` — trigger via a push, or have the user click Run.) See the
+**cluster-incident-response** skill for the general workflow→#382 pattern.
+
+## How "admin" is decided
+
+App admin = membership of the Keycloak **`admin` group** (surfaced as the
+`groups` claim). `src/lib/api-auth.ts` `isAdmin()` and `src/proxy.ts` gate on it;
+`ADMIN=1` adds the user to that group. A plain user reaches `/dashboard` only.
+
+## Verifying login actually works
+
+Keycloak's `cloudless-app` client **enforces PKCE** and **disallows direct
+access grants**, so you cannot password-grant against `cloudless-app`. Verify a
+provisioned user with a direct grant against **`admin-cli`** (the script does
+this → `LOGIN_VERIFIED=yes`). The real website login is the auth-code+PKCE flow:
+`POST /api/auth/signin/keycloak` (with CSRF) → `302` to
+`auth.cloudless.gr/.../openid-connect/auth?...code_challenge_method=S256`. A bare
+**GET** to that endpoint returns `error=Configuration` — that is a test artifact,
+not a bug (next-auth POSTs with PKCE).
+
+## Reference
+
+- Realm `master`, IdP `https://auth.cloudless.gr`, app client `cloudless-app`
+  (public, PKCE), manager client `cloudless-manager`. Admin creds in SSM
+  `/cloudless/production/KEYCLOAK_ADMIN_{USER,PASSWORD}` and in the keycloak pod
+  env (used in-pod by the script). Never print or commit them.
+- Existing e2e provisioning: `scripts/e2e-keycloak-provision.sh`
+  (`pnpm e2e:keycloak`) creates `e2e-user@` / `e2e-admin@` and writes `.env.e2e`.
+- Companion: `tools/keycloak-cli/keycloak.sh` and the `keycloak-ops` skill.

--- a/.github/workflows/keycloak-create-user.yml
+++ b/.github/workflows/keycloak-create-user.yml
@@ -1,20 +1,36 @@
-name: Keycloak create test user (verify provisioning + login)
+name: Keycloak create user (admin-provision + verify login)
 
-# Creates a test user in the master realm via kcadm.sh inside the keycloak pod
-# (admin password stays in-pod, never printed), verifies the account exists and
-# that its password authenticates, and posts a redacted result to issue #382.
+# Admin-provisions a Keycloak user via scripts/keycloak-create-user.sh (kcadm
+# inside the keycloak pod; admin password never leaves the pod) and verifies the
+# password authenticates. Self-service registration is disabled on the master
+# realm, so this is the supported "create a user" path.
 #
-# Self-service registration is disabled on the master realm, so users are
-# admin-provisioned — this is the supported "create a user" path.
+# Idempotent: the default email is reused across runs (password reset + re-verify)
+# so re-triggering does not pile up test users.
 #
-# Trigger: workflow_dispatch, or push to this file on main.
+# Trigger: workflow_dispatch (custom email/admin), or push to this file / the
+# script on main (uses the default verify email).
 
 on:
   workflow_dispatch:
+    inputs:
+      email:
+        description: "Email/username to provision"
+        required: true
+        default: "signup-verify@cloudless.gr"
+      admin:
+        description: "Add to the admin group (app admin)"
+        type: boolean
+        default: false
+      temporary:
+        description: "Password must be reset on first login"
+        type: boolean
+        default: false
   push:
     branches: [main]
     paths:
       - ".github/workflows/keycloak-create-user.yml"
+      - "scripts/keycloak-create-user.sh"
 
 permissions:
   contents: read
@@ -25,7 +41,12 @@ jobs:
     runs-on: ubuntu-latest
     env:
       GH_TOKEN: ${{ github.token }}
+      EMAIL: ${{ github.event.inputs.email || 'signup-verify@cloudless.gr' }}
+      ADMIN: ${{ github.event.inputs.admin == 'true' && '1' || '0' }}
+      TEMPORARY: ${{ github.event.inputs.temporary == 'true' && '1' || '0' }}
     steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v4.3.1
+
       - name: Connect to tailnet
         uses: tailscale/github-action@0263d9e6d793eaefcf1de98ff7fde47abe6664d3 # v3.2.4
         with:
@@ -37,48 +58,18 @@ jobs:
           echo "${{ secrets.KUBECONFIG_B64 }}" | base64 -d > ~/.kube/config
           chmod 600 ~/.kube/config
 
-      - name: Create + verify user via kcadm
+      - name: Provision + verify user
         run: |
           set -uo pipefail
-          TS=$(date -u +%Y%m%d%H%M%S)
-          NEWUSER="signup-test-${TS}@cloudless.gr"
-          NEWPASS="Sg9!$(head -c 18 /dev/urandom | base64 | tr -dc 'A-Za-z0-9')xY7"
-          POD=$(kubectl -n keycloak get pod -l app=keycloak -o jsonpath='{.items[0].metadata.name}')
-          echo "pod=$POD newuser=$NEWUSER"
+          bash scripts/keycloak-create-user.sh 2>&1 | tee raw.log
+          # Mask the generated password in the Actions log.
+          PW=$(grep -o 'password=[^ ]*' raw.log | head -1 | cut -d= -f2-)
+          [ -n "$PW" ] && echo "::add-mask::$PW"
+          # Strip CREDENTIAL lines before posting to the public issue.
+          grep -v '^CREDENTIAL' raw.log > post.log || true
 
-          OUT=$(kubectl -n keycloak exec -i "$POD" -- env NU="$NEWUSER" NP="$NEWPASS" bash -s <<'EOS'
-          set -u
-          KCADM=/opt/keycloak/bin/kcadm.sh
-          AU="${KEYCLOAK_ADMIN:-${KC_BOOTSTRAP_ADMIN_USERNAME:-admin}}"
-          AP="${KEYCLOAK_ADMIN_PASSWORD:-${KC_BOOTSTRAP_ADMIN_PASSWORD:-}}"
-          if ! $KCADM config credentials --server http://localhost:8080 --realm master --user "$AU" --password "$AP" >/dev/null 2>&1; then
-            echo "ADMIN_AUTH_FAILED (no usable admin creds in pod env)"; exit 0
-          fi
-          ID=$($KCADM create users -r master -s username="$NU" -s email="$NU" -s enabled=true -s emailVerified=true -s firstName=Signup -s lastName=Test -i 2>/dev/null) || { echo "CREATE_FAILED"; exit 0; }
-          echo "USER_ID=$ID"
-          $KCADM set-password -r master --userid "$ID" --new-password "$NP" >/dev/null 2>&1 && echo "PASSWORD_SET=yes" || echo "PASSWORD_SET=no"
-          echo "ACCOUNT:"; $KCADM get "users/$ID" -r master --fields username,email,enabled,emailVerified 2>/dev/null
-          # Verify the new user's password authenticates (admin-cli allows direct grant in master).
-          if curl -sS -m 8 -d "grant_type=password&client_id=admin-cli&username=$NU&password=$NP" \
-               http://localhost:8080/realms/master/protocol/openid-connect/token | grep -q '"access_token"'; then
-            echo "LOGIN_VERIFIED=yes (password authenticates against Keycloak)"
-          else
-            echo "LOGIN_VERIFIED=no"
-          fi
-          EOS
-          )
-          echo "$OUT"
-
-          {
-            echo "# Keycloak create-user — $(date -u '+%F %T')Z"
-            echo
-            echo "Created (admin-provisioned; self-registration is disabled on master realm):"
-            echo
-            echo "- **Username/email:** \`${NEWUSER}\`"
-            echo "- Password: generated in-job, **not logged**"
-            echo
-            echo '```'
-            echo "$OUT" | grep -vi 'password'
-            echo '```'
-          } > user.md
-          gh issue comment 382 --repo "${{ github.repository }}" --body-file user.md
+      - name: Post result to tracking issue
+        if: always()
+        run: |
+          { echo "# Keycloak create-user — $(date -u '+%F %T')Z (email: \`${EMAIL}\`)"; echo; echo '```'; cat post.log 2>/dev/null || echo '(no log)'; echo '```'; } > comment.md
+          gh issue comment 382 --repo "${{ github.repository }}" --body-file comment.md

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "keycloak:doctor": "bash tools/keycloak-cli/keycloak.sh doctor",
     "keycloak:smoke": "bash scripts/keycloak-smoke.sh",
     "keycloak:restore": "bash scripts/restore-keycloak.sh",
+    "keycloak:create-user": "bash scripts/keycloak-create-user.sh",
     "keycloak:apply": "tsx --tsconfig scripts/tsconfig.json scripts/keycloak-apply.ts",
     "keycloak:apply:dry": "tsx --tsconfig scripts/tsconfig.json scripts/keycloak-apply.ts --dry-run",
     "mcp-security-scan": "cd tools/mcp-security-scanner && npm install && npm run scan -- --path \"../../src/**/*.{ts,tsx,js,jsx,py,md}\"",

--- a/scripts/keycloak-create-user.sh
+++ b/scripts/keycloak-create-user.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+#
+# keycloak-create-user.sh — admin-provision a Keycloak user via kcadm, run inside
+# the keycloak pod so the admin password never leaves the cluster.
+#
+# Self-service registration is DISABLED on the master realm (the hosted
+# /registrations page returns the login screen), so users are admin-provisioned.
+# This is the supported "create a user" path; the e2e suite uses the same idea
+# (scripts/e2e-keycloak-provision.sh).
+#
+# Idempotent: an existing user (matched by username/email) is reused — only its
+# password (and optional admin-group membership) is (re)set.
+#
+# Env:
+#   EMAIL       (required)  username + email of the account
+#   PASSWORD    (optional)  generated if unset; printed on a `CREDENTIAL` line
+#   ADMIN       (1)         add to the Keycloak `admin` group (→ app admin)
+#   TEMPORARY   (1)         password must be reset on first login
+#   NAMESPACE / DEPLOYMENT / REALM   (default keycloak / keycloak / master)
+#
+# Usage:
+#   EMAIL=user@cloudless.gr bash scripts/keycloak-create-user.sh
+#   EMAIL=admin@cloudless.gr ADMIN=1 bash scripts/keycloak-create-user.sh
+#
+# Requires a kubectl context with exec on the keycloak pod (the
+# keycloak-create-user.yml workflow supplies one via Tailscale + KUBECONFIG_B64).
+
+set -uo pipefail
+
+: "${EMAIL:?set EMAIL=user@domain}"
+NAMESPACE="${NAMESPACE:-keycloak}"
+DEPLOYMENT="${DEPLOYMENT:-keycloak}"
+REALM="${REALM:-master}"
+ADMIN="${ADMIN:-0}"
+TEMPORARY="${TEMPORARY:-0}"
+# Default password: alphanumeric (no shell/url-special chars) + complexity tail.
+PASSWORD="${PASSWORD:-$(head -c 24 /dev/urandom | base64 | tr -dc 'A-Za-z0-9' | head -c 20)Aa1}"
+
+command -v kubectl >/dev/null 2>&1 || { echo "error: kubectl not found / no cluster access"; exit 1; }
+POD=$(kubectl -n "$NAMESPACE" get pod -l app="$DEPLOYMENT" -o jsonpath='{.items[0].metadata.name}' 2>/dev/null)
+[ -n "$POD" ] || { echo "error: no $DEPLOYMENT pod in ns/$NAMESPACE"; exit 1; }
+
+# Lines starting with CREDENTIAL carry secrets — the workflow strips them before
+# posting to the tracking issue, but a local run shows them so you can log in.
+echo "CREDENTIAL email=$EMAIL password=$PASSWORD"
+echo "pod=$POD realm=$REALM admin=$ADMIN temporary=$TEMPORARY"
+
+kubectl -n "$NAMESPACE" exec -i "$POD" -- env \
+  NU="$EMAIL" NP="$PASSWORD" RL="$REALM" AD="$ADMIN" TMP="$TEMPORARY" bash -s <<'EOS'
+set -u
+K=/opt/keycloak/bin/kcadm.sh
+UUID='[0-9a-f]\{8\}-[0-9a-f]\{4\}-[0-9a-f]\{4\}-[0-9a-f]\{4\}-[0-9a-f]\{12\}'
+AU="${KEYCLOAK_ADMIN:-${KC_BOOTSTRAP_ADMIN_USERNAME:-admin}}"
+AP="${KEYCLOAK_ADMIN_PASSWORD:-${KC_BOOTSTRAP_ADMIN_PASSWORD:-}}"
+$K config credentials --server http://localhost:8080 --realm master --user "$AU" --password "$AP" >/dev/null 2>&1 \
+  || { echo "ADMIN_AUTH=failed (no usable admin creds in pod env)"; exit 0; }
+echo "ADMIN_AUTH=ok"
+
+ID=$($K get users -r "$RL" -q username="$NU" --fields id 2>/dev/null | grep -o "$UUID" | head -1)
+if [ -z "$ID" ]; then
+  ID=$($K create users -r "$RL" -s username="$NU" -s email="$NU" -s enabled=true -s emailVerified=true -i 2>/dev/null) \
+    || { echo "CREATE=failed"; exit 0; }
+  echo "CREATE=ok id=$ID"
+else
+  echo "EXISTS=ok id=$ID"
+fi
+
+TF=false; [ "$TMP" = "1" ] && TF=true
+$K set-password -r "$RL" --userid "$ID" --new-password "$NP" --temporary=$TF >/dev/null 2>&1 \
+  && echo "PW_SET=ok(temporary=$TF)" || echo "PW_SET=failed"
+
+if [ "$AD" = "1" ]; then
+  GID=$($K get groups -r "$RL" --fields id,name 2>/dev/null \
+        | awk -v RS='}' '/"name"[ ]*:[ ]*"admin"/' | grep -o "$UUID" | head -1)
+  if [ -n "$GID" ]; then
+    $K update "users/$ID/groups/$GID" -r "$RL" -s realm="$RL" -s userId="$ID" -s groupId="$GID" -n >/dev/null 2>&1 \
+      && echo "ADMIN_GROUP=added" || echo "ADMIN_GROUP=failed"
+  else
+    echo "ADMIN_GROUP=group_not_found"
+  fi
+fi
+
+echo "ACCOUNT:"; $K get "users/$ID" -r "$RL" --fields username,email,enabled,emailVerified 2>/dev/null
+
+# Verify the password authenticates (admin-cli allows direct grant in master).
+CODE=$(curl -sS -m 8 -o /tmp/tok.json -w '%{http_code}' \
+  --data-urlencode "grant_type=password" --data-urlencode "client_id=admin-cli" \
+  --data-urlencode "username=$NU" --data-urlencode "password=$NP" \
+  "http://localhost:8080/realms/$RL/protocol/openid-connect/token" 2>/dev/null)
+if grep -q access_token /tmp/tok.json 2>/dev/null; then
+  echo "LOGIN_VERIFIED=yes (password authenticates against Keycloak)"
+else
+  echo "LOGIN_VERIFIED=no (http=$CODE $(grep -o '\"error[^,}]*' /tmp/tok.json 2>/dev/null | head -1))"
+fi
+EOS


### PR DESCRIPTION
Turns this session's one-shot user-creation job into a reusable, idempotent **tool + skill**.

**Tool** — `pnpm keycloak:create-user` (`scripts/keycloak-create-user.sh`): admin-provisions a Keycloak user via `kcadm` inside the pod (admin password stays in-pod). Idempotent on email, supports `ADMIN=1` (admin group) and `TEMPORARY=1`, and **fixes the login verification** (URL-encoded `admin-cli` direct grant → `LOGIN_VERIFIED`). Local runs print the password on a `CREDENTIAL` line.

**Workflow** — `keycloak-create-user.yml`: `workflow_dispatch` with `email`/`admin`/`temporary` inputs, plus a path-triggered push that uses an **idempotent default email** (`signup-verify@cloudless.gr`) so re-runs don't pile up test users. Masks the password and posts a redacted result to #382.

**Skill** — `.claude/skills/keycloak-user-provisioning`: documents that self-service registration is disabled (admin-provisioned), the admin-group gate, how to verify login (`cloudless-app` enforces PKCE / disallows direct grant → verify via `admin-cli`; the real flow is POST+CSRF → PKCE handoff), and how to optionally enable public self-signup.

Merging re-fires the provisioning on the idempotent `signup-verify@cloudless.gr` user → this time it should report `LOGIN_VERIFIED=yes` to #382.

https://claude.ai/code/session_01WoLaMUxTAygraKUTy7JTT8

---
_Generated by [Claude Code](https://claude.ai/code/session_01WoLaMUxTAygraKUTy7JTT8)_