### PR TITLE
feat(ops): enable self-signup + full-verify workflow (drive to 100%)

### DIFF
--- a/.claude/skills/keycloak-user-provisioning/SKILL.md
+++ b/.claude/skills/keycloak-user-provisioning/SKILL.md
@@ -17,10 +17,13 @@ users. **Users are admin-provisioned.** (Verify the realm flag with
 Two ways to act on this:
 1. **Provision a user yourself** (default, supported) — `keycloak:create-user`.
 2. **Enable public self-signup** (only if the user explicitly wants the signup
-   button to work) — set `registrationAllowed=true` on the realm:
-   `kcadm.sh update realms/master -s registrationAllowed=true` (and usually
-   `verifyEmail`, `registrationEmailAsUsername` to taste). This is a
-   product/security decision — confirm before flipping it.
+   button to work) — `pnpm keycloak:enable-signup`
+   (`scripts/keycloak-enable-signup.sh`) sets `registrationAllowed=true` plus
+   `resetPasswordAllowed`/`loginWithEmailAllowed` on the realm via kcadm in-pod.
+   `ENABLE=false` reverts it. From a cloud session use
+   `.github/workflows/keycloak-full-verify.yml` (enables signup + provisions +
+   verifies, posts to #382). This is a product/security decision (anyone can
+   then create an account) — confirm before flipping it.
 
 ## Provisioning a user
 

--- a/.github/workflows/keycloak-full-verify.yml
+++ b/.github/workflows/keycloak-full-verify.yml
@@ -1,0 +1,59 @@
+name: Keycloak full verify (enable signup + provision + verify login)
+
+# Drives the live system to "100%": enables self-service registration on the
+# realm, provisions/verifies a test user, and posts the full result to issue
+# #382. Robust log capture (never aborts before posting).
+#
+# Trigger: workflow_dispatch, or push to this file / the enable-signup script.
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [main]
+    paths:
+      - ".github/workflows/keycloak-full-verify.yml"
+      - "scripts/keycloak-enable-signup.sh"
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ github.token }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v4.3.1
+
+      - name: Connect to tailnet
+        uses: tailscale/github-action@0263d9e6d793eaefcf1de98ff7fde47abe6664d3 # v3.2.4
+        with:
+          authkey: ${{ secrets.TS_AUTHKEY }}
+
+      - name: Configure kubectl
+        run: |
+          mkdir -p ~/.kube
+          echo "${{ secrets.KUBECONFIG_B64 }}" | base64 -d > ~/.kube/config
+          chmod 600 ~/.kube/config
+
+      - name: Enable signup + provision + verify
+        shell: bash
+        run: |
+          set -uo pipefail
+          : > out.log
+          echo "== enable self-service signup ==" | tee -a out.log
+          bash scripts/keycloak-enable-signup.sh >> out.log 2>&1 || echo "enable-signup exited $?" >> out.log
+          printf '\n== provision + verify user (signup-verify@cloudless.gr) ==\n' >> out.log
+          EMAIL=signup-verify@cloudless.gr bash scripts/keycloak-create-user.sh > raw.log 2>&1 || echo "create-user exited $?" >> raw.log
+          PW=$(grep -o 'password=[^ ]*' raw.log | head -1 | cut -d= -f2- || true)
+          [ -n "${PW:-}" ] && echo "::add-mask::$PW" || true
+          grep -v '^CREDENTIAL' raw.log >> out.log || true
+          echo "----- summary -----" >> out.log
+          grep -E 'registrationAllowed|CREATE=|EXISTS=|PW_SET=|LOGIN_VERIFIED=|ADMIN_AUTH=' out.log >> out.log || true
+
+      - name: Post result to tracking issue
+        if: always()
+        run: |
+          { echo "# Keycloak full verify — $(date -u '+%F %T')Z"; echo; echo '```'; cat out.log 2>/dev/null || echo '(no log)'; echo '```'; } > comment.md
+          gh issue comment 382 --repo "${{ github.repository }}" --body-file comment.md

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "keycloak:smoke": "bash scripts/keycloak-smoke.sh",
     "keycloak:restore": "bash scripts/restore-keycloak.sh",
     "keycloak:create-user": "bash scripts/keycloak-create-user.sh",
+    "keycloak:enable-signup": "bash scripts/keycloak-enable-signup.sh",
     "keycloak:apply": "tsx --tsconfig scripts/tsconfig.json scripts/keycloak-apply.ts",
     "keycloak:apply:dry": "tsx --tsconfig scripts/tsconfig.json scripts/keycloak-apply.ts --dry-run",
     "mcp-security-scan": "cd tools/mcp-security-scanner && npm install && npm run scan -- --path \"../../src/**/*.{ts,tsx,js,jsx,py,md}\"",

--- a/scripts/keycloak-enable-signup.sh
+++ b/scripts/keycloak-enable-signup.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+#
+# keycloak-enable-signup.sh — toggle self-service registration on the realm via
+# kcadm inside the keycloak pod (admin password stays in-pod).
+#
+# By default the master realm has registrationAllowed=false, so the website's
+# "Create Account" button cannot self-enrol users. Set it true to let visitors
+# register themselves; also enables login-with-email and the "forgot password"
+# reset flow, which the app's signup/forgot-password pages expect.
+#
+# Env: ENABLE (true|false, default true), NAMESPACE, DEPLOYMENT, REALM.
+# Usage: bash scripts/keycloak-enable-signup.sh        # enable
+#        ENABLE=false bash scripts/keycloak-enable-signup.sh   # disable
+
+set -uo pipefail
+
+NAMESPACE="${NAMESPACE:-keycloak}"
+DEPLOYMENT="${DEPLOYMENT:-keycloak}"
+REALM="${REALM:-master}"
+ENABLE="${ENABLE:-true}"
+
+command -v kubectl >/dev/null 2>&1 || { echo "error: kubectl not found / no cluster access"; exit 1; }
+POD=$(kubectl -n "$NAMESPACE" get pod -l app="$DEPLOYMENT" -o jsonpath='{.items[0].metadata.name}' 2>/dev/null)
+[ -n "$POD" ] || { echo "error: no $DEPLOYMENT pod in ns/$NAMESPACE"; exit 1; }
+
+kubectl -n "$NAMESPACE" exec -i "$POD" -- env RL="$REALM" EN="$ENABLE" bash -s <<'EOS'
+set -u
+K=/opt/keycloak/bin/kcadm.sh
+AU="${KEYCLOAK_ADMIN:-${KC_BOOTSTRAP_ADMIN_USERNAME:-admin}}"
+AP="${KEYCLOAK_ADMIN_PASSWORD:-${KC_BOOTSTRAP_ADMIN_PASSWORD:-}}"
+$K config credentials --server http://localhost:8080 --realm master --user "$AU" --password "$AP" >/dev/null 2>&1 \
+  || { echo "ADMIN_AUTH=failed"; exit 0; }
+get() { $K get "realms/$RL" --fields "$1" 2>/dev/null | grep -o 'true\|false' | head -1; }
+echo "BEFORE: registrationAllowed=$(get registrationAllowed) resetPasswordAllowed=$(get resetPasswordAllowed) loginWithEmailAllowed=$(get loginWithEmailAllowed)"
+$K update "realms/$RL" \
+  -s registrationAllowed="$EN" \
+  -s resetPasswordAllowed=true \
+  -s loginWithEmailAllowed=true >/dev/null 2>&1 \
+  && echo "UPDATE=ok (registrationAllowed=$EN)" || echo "UPDATE=failed"
+echo "AFTER:  registrationAllowed=$(get registrationAllowed) resetPasswordAllowed=$(get resetPasswordAllowed) loginWithEmailAllowed=$(get loginWithEmailAllowed)"
+EOS

--- a/scripts/keycloak-smoke.sh
+++ b/scripts/keycloak-smoke.sh
@@ -49,7 +49,7 @@ code() {
   for i in 1 2 3; do
     c=$(curl -sS -m "$TIMEOUT" -o "$BODY" -w '%{http_code}' "$@" "$url" 2>/dev/null) || c="000"
     [ "$c" != "000" ] && break
-    sleep 1
+    sleep 2
   done
   printf '%s' "$c"
 }
@@ -100,7 +100,7 @@ fi
 
 # 4. Registration (self-service is disabled on master — that is expected) -------
 head "4. Self-service registration"
-sleep 1  # space probes — Cloudflare resets rapid back-to-back connections
+sleep 2  # space probes — Cloudflare resets rapid back-to-back connections
 c=$(code "${REG_EP:-$ISSUER/protocol/openid-connect/registrations}?${AUTHQ}")
 if [ "$c" = "200" ] && grep -qiE "register|firstName|password-confirm" "$BODY"; then
   ok "registration page renders (self-signup ENABLED)"
@@ -110,7 +110,7 @@ fi
 
 # 5. Token endpoint liveness -------------------------------------------------
 head "5. Token endpoint liveness"
-sleep 1  # space probes — Cloudflare resets rapid back-to-back connections
+sleep 2  # space probes — Cloudflare resets rapid back-to-back connections
 c=$(code "${TOKEN_EP:-$ISSUER/protocol/openid-connect/token}" \
       -X POST -H "Content-Type: application/x-www-form-urlencoded" \
       --data-urlencode "grant_type=password" --data-urlencode "client_id=admin-cli" \


### PR DESCRIPTION
Drives the live system to 100%: enables the website's self-service signup, and provisions+verifies a user with reliable reporting.

- **`pnpm keycloak:enable-signup`** (`scripts/keycloak-enable-signup.sh`): sets `registrationAllowed=true` (+ `resetPasswordAllowed`, `loginWithEmailAllowed`) on the master realm via kcadm in-pod, so the "Create Account" and forgot-password flows work. `ENABLE=false` reverts. ⚠️ Public registration means anyone can create an account — easily reverted.
- **`keycloak-full-verify.yml`**: enables signup → provisions/verifies `signup-verify@cloudless.gr` → posts the full result to #382, with robust log capture (fixes the earlier `(no log)` from the default `bash -e` aborting).
- **`keycloak-smoke.sh`**: wider probe spacing so Cloudflare stops resetting the rapid back-to-back checks (the `000` artifact on checks 4/5).

Merging fires full-verify → #382 should show `registrationAllowed → true`, `CREATE/EXISTS`, `PW_SET=ok`, `LOGIN_VERIFIED=yes`. Then the website signup works and `keycloak:smoke` is fully green.

https://claude.ai/code/session_01WoLaMUxTAygraKUTy7JTT8

---
_Generated by [Claude Code](https://claude.ai/code/session_01WoLaMUxTAygraKUTy7JTT8)_