### PR TITLE
fix(auth): redirect bare GET signin to login (silence ServerlessErrors noise)

### DIFF
--- a/__tests__/auth-route.test.ts
+++ b/__tests__/auth-route.test.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+// Mock @/lib/auth so the route doesn't boot real next-auth.
+const realGet = vi.fn(() => new Response("real", { status: 200 }));
+const realPost = vi.fn(() => new Response("real", { status: 200 }));
+vi.mock("@/lib/auth", () => ({ handlers: { GET: realGet, POST: realPost } }));
+
+describe("auth route GET guard (ServerlessErrors hardening)", () => {
+  beforeEach(() => realGet.mockClear());
+
+  it("redirects a bare GET /api/auth/signin/<provider> to the login page", async () => {
+    const { GET } = await import("@/app/api/auth/[...nextauth]/route");
+    const res = await GET(new NextRequest("https://cloudless.gr/api/auth/signin/keycloak"));
+    expect(res.status).toBe(302);
+    expect(res.headers.get("location")).toContain("/auth/login");
+    // The real next-auth handler (which logs error=Configuration) is NOT invoked.
+    expect(realGet).not.toHaveBeenCalled();
+  });
+
+  it("passes provider callbacks (GET /api/auth/callback/*) to the real handler", async () => {
+    const { GET } = await import("@/app/api/auth/[...nextauth]/route");
+    await GET(new NextRequest("https://cloudless.gr/api/auth/callback/keycloak?code=abc"));
+    expect(realGet).toHaveBeenCalledTimes(1);
+  });
+
+  it("passes the providers/session endpoints to the real handler", async () => {
+    const { GET } = await import("@/app/api/auth/[...nextauth]/route");
+    await GET(new NextRequest("https://cloudless.gr/api/auth/providers"));
+    expect(realGet).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/app/api/auth/[...nextauth]/route.ts
+++ b/src/app/api/auth/[...nextauth]/route.ts
@@ -1,2 +1,24 @@
 import { handlers } from "@/lib/auth";
-export const { GET, POST } = handlers;
+import { NextResponse } from "next/server";
+import type { NextRequest } from "next/server";
+
+export const { POST } = handlers;
+
+// A bare GET to /api/auth/signin/<provider> is NOT a real sign-in — Auth.js v5
+// sign-in is POST + CSRF (the app uses signIn("keycloak"), which POSTs). next-auth
+// logs an `[auth][error] Configuration` for such GETs, and crawlers / uptime
+// probes hit them — that ERROR line is what drives the CloudWatch
+// `SERVERLESS-APP_MAIN-Errors` (CloudlessApp/ServerlessErrors) alarm.
+//
+// Redirect those GETs to the login page instead. We do NOT silence Configuration
+// errors globally: genuine failures still surface on the POST sign-in path, so a
+// real IdP outage still trips the alarm. Provider callbacks (/api/auth/callback/*)
+// are GETs and are deliberately left to the real handler.
+const SIGNIN_PROVIDER = /^\/api\/auth\/signin\/[^/]+\/?$/;
+
+export function GET(request: NextRequest): Response | Promise<Response> {
+  if (SIGNIN_PROVIDER.test(request.nextUrl.pathname)) {
+    return NextResponse.redirect(new URL("/auth/login", request.nextUrl.origin), 302);
+  }
+  return (handlers.GET as (req: Request) => Response | Promise<Response>)(request);
+}


### PR DESCRIPTION
**Follow-up #1** — stop the `SERVERLESS-APP_MAIN-Errors` alarm noise at the source.

A GET to `/api/auth/signin/<provider>` isn't a real sign-in (Auth.js v5 sign-in is POST+CSRF; the app uses `signIn("keycloak")` which POSTs). next-auth logs `[auth][error] Configuration` on such GETs, and crawlers/uptime probes hit them — that `ERROR` line is what the `CloudlessApp/ServerlessErrors` CloudWatch Logs metric filter counts.

This redirects those GETs to `/auth/login`. It does **not** silence Configuration errors globally — genuine failures still surface on the POST sign-in path, so a real IdP outage still alarms. Provider callbacks (`/api/auth/callback/*`) and `providers`/`session`/`csrf` pass through to the real handler.

Verified: `eslint` clean, `pnpm typecheck` ✓, new `__tests__/auth-route.test.ts` (3 tests) ✓ — redirect on `/signin/keycloak`, pass-through on `/callback/keycloak` and `/providers`.

https://claude.ai/code/session_01WoLaMUxTAygraKUTy7JTT8

---
_Generated by [Claude Code](https://claude.ai/code/session_01WoLaMUxTAygraKUTy7JTT8)_