### PR TITLE
feat(ops): configure-admin accepts password via workflow_dispatch input

### DIFF
--- a/.github/workflows/keycloak-configure-admin.yml
+++ b/.github/workflows/keycloak-configure-admin.yml
@@ -15,6 +15,11 @@ name: Keycloak configure admin (single admin + groups mapper)
 
 on:
   workflow_dispatch:
+    inputs:
+      password:
+        description: "Admin password to set for tbaltzakis@cloudless.gr (typed here, never stored in git; masked in logs)"
+        required: false
+        default: ""
   push:
     branches: [main]
     paths:
@@ -31,7 +36,9 @@ jobs:
     env:
       GH_TOKEN: ${{ github.token }}
       ADMIN_EMAIL: tbaltzakis@cloudless.gr
-      ADMIN_PASSWORD: ${{ secrets.ADMIN_BOOTSTRAP_PASSWORD }}
+      # Password source priority: the workflow_dispatch input (typed in the UI),
+      # else the ADMIN_BOOTSTRAP_PASSWORD repo secret. Never committed to git.
+      ADMIN_PASSWORD: ${{ github.event.inputs.password != '' && github.event.inputs.password || secrets.ADMIN_BOOTSTRAP_PASSWORD }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v4.3.1
 


### PR DESCRIPTION
Adds a `password` workflow_dispatch input so the admin password can be set by running the workflow from the Actions UI (typed in, masked in logs, never committed). When a password is present, the script sets it, verifies login, and enforces single-admin (only `tbaltzakis@cloudless.gr`). Falls back to the `ADMIN_BOOTSTRAP_PASSWORD` secret.

https://claude.ai/code/session_01WoLaMUxTAygraKUTy7JTT8

---
_Generated by [Claude Code](https://claude.ai/code/session_01WoLaMUxTAygraKUTy7JTT8)_