### PR TITLE
feat(ops): keycloak:ensure — self-heal auth to last working state (cron)

### DIFF
--- a/.claude/skills/cluster-incident-response/SKILL.md
+++ b/.claude/skills/cluster-incident-response/SKILL.md
@@ -44,6 +44,8 @@ offline during cluster incidents and the job queues forever).
 | `.github/workflows/restore-keycloak.yml` | Runs `keycloak:restore` on a hosted runner, posts the log to #382. Trigger by editing the workflow file. |
 | `pnpm prometheus:tune` (`scripts/prometheus-tune.sh`) | Deletes the heavy kube-apiserver SLO/burnrate/availability PrometheusRules that time out and trip `PrometheusRuleFailures`; reports remaining failing rules. |
 | `.github/workflows/prometheus-tune.yml` | Runs `prometheus:tune` on a hosted runner, posts the log to #382. Trigger by editing the workflow file. |
+| `pnpm keycloak:ensure` (`scripts/keycloak-ensure.sh`) | **Self-heal**: idempotent reconciler that restores auth to its known-good state — OOM-recovers Keycloak (768Mi + `-Xmx512m`), and fixes realm flags + the cloudless-app `groups` mapper (`full.path=false`) + admin group/membership. Reports only what it `CORRECTED`. |
+| `.github/workflows/keycloak-ensure.yml` | Runs `keycloak:ensure` on a **cron (`*/15`)** + dispatch + push; posts to #382 only when it corrects drift or auth is still broken (silent on healthy runs). This is the auto-recovery that brings auth back to the last working condition. |
 
 ## Triage workflow
 

--- a/.github/workflows/keycloak-ensure.yml
+++ b/.github/workflows/keycloak-ensure.yml
@@ -1,0 +1,66 @@
+name: Keycloak ensure (self-heal auth to last working state)
+
+# Reconciles auth to its known-good state (Keycloak up + memory fit, realm flags,
+# cloudless-app groups mapper, admin group + membership). Runs on a schedule so a
+# break self-heals within ~15 min, on demand, and after the script changes.
+# Posts to issue #382 ONLY when it corrects drift or auth is still broken — a
+# clean run stays silent (no noise).
+
+on:
+  schedule:
+    - cron: "*/15 * * * *"
+  workflow_dispatch:
+  push:
+    branches: [main]
+    paths:
+      - ".github/workflows/keycloak-ensure.yml"
+      - "scripts/keycloak-ensure.sh"
+
+permissions:
+  contents: read
+  issues: write
+
+concurrency:
+  group: keycloak-ensure
+  cancel-in-progress: false
+
+jobs:
+  ensure:
+    runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ github.token }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v4.3.1
+
+      - name: Connect to tailnet
+        uses: tailscale/github-action@0263d9e6d793eaefcf1de98ff7fde47abe6664d3 # v3.2.4
+        with:
+          authkey: ${{ secrets.TS_AUTHKEY }}
+
+      - name: Configure kubectl
+        run: |
+          mkdir -p ~/.kube
+          echo "${{ secrets.KUBECONFIG_B64 }}" | base64 -d > ~/.kube/config
+          chmod 600 ~/.kube/config
+
+      - name: Reconcile
+        id: reconcile
+        run: |
+          set -uo pipefail
+          bash scripts/keycloak-ensure.sh > ensure.log 2>&1
+          rc=$?
+          echo "rc=$rc" >> "$GITHUB_OUTPUT"
+          # Report only when something was corrected or auth is still broken.
+          if grep -qE '^CORRECTED:|^FIX |HEALTHY=no' ensure.log; then
+            echo "report=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "report=false" >> "$GITHUB_OUTPUT"
+          fi
+          cat ensure.log
+          exit "$rc"
+
+      - name: Report drift / failure to tracking issue
+        if: always() && steps.reconcile.outputs.report == 'true'
+        run: |
+          { echo "# Keycloak ensure — $(date -u '+%F %T')Z (self-heal acted)"; echo; echo '```'; cat ensure.log 2>/dev/null || echo '(no log)'; echo '```'; } > c.md
+          gh issue comment 382 --repo "${{ github.repository }}" --body-file c.md

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "keycloak:create-user": "bash scripts/keycloak-create-user.sh",
     "keycloak:enable-signup": "bash scripts/keycloak-enable-signup.sh",
     "keycloak:configure-admin": "bash scripts/keycloak-configure-admin.sh",
+    "keycloak:ensure": "bash scripts/keycloak-ensure.sh",
     "keycloak:apply": "tsx --tsconfig scripts/tsconfig.json scripts/keycloak-apply.ts",
     "keycloak:apply:dry": "tsx --tsconfig scripts/tsconfig.json scripts/keycloak-apply.ts --dry-run",
     "mcp-security-scan": "cd tools/mcp-security-scanner && npm install && npm run scan -- --path \"../../src/**/*.{ts,tsx,js,jsx,py,md}\"",

--- a/scripts/keycloak-ensure.sh
+++ b/scripts/keycloak-ensure.sh
@@ -1,0 +1,138 @@
+#!/usr/bin/env bash
+#
+# keycloak-ensure.sh — reconcile auth to its KNOWN-GOOD ("last working") state.
+#
+# Idempotent self-healing: detects drift/outage and restores it. Safe to run on a
+# schedule. Each correction is recorded; if nothing was wrong it changes nothing.
+#
+#   Desired state (the "last working condition"):
+#     • Keycloak pod fits its heap: limit >= 768Mi, JAVA_OPTS_APPEND -Xmx512m
+#       (the 2026-06-01 OOM fix) and auth.cloudless.gr discovery returns 200.
+#     • realm: registrationAllowed=true, resetPasswordAllowed=true,
+#       loginWithEmailAllowed=true.
+#     • cloudless-app client has a `groups` membership mapper with full.path=false,
+#       claim.name=groups, id+access token claims (so isAdmin() sees "admin").
+#     • admin group exists and ADMIN_EMAIL is a member.
+#
+# Recovery phase uses kubectl (patch+rollout); reconcile phase uses kcadm INSIDE
+# the keycloak pod (admin password never leaves the pod). The keycloak image has
+# no awk/jq — parse kcadm CSV with grep/cut.
+#
+# Exit 0 if healthy at the end (with or without corrections), 1 if still broken.
+# Env: ADMIN_EMAIL (default tbaltzakis@cloudless.gr), CLIENT_ID (cloudless-app),
+#      MEM_LIMIT (768Mi), NAMESPACE/DEPLOYMENT/REALM, DISCOVERY.
+
+set -uo pipefail
+
+NAMESPACE="${NAMESPACE:-keycloak}"
+DEPLOYMENT="${DEPLOYMENT:-keycloak}"
+REALM="${REALM:-master}"
+CLIENT_ID="${CLIENT_ID:-cloudless-app}"
+ADMIN_EMAIL="${ADMIN_EMAIL:-tbaltzakis@cloudless.gr}"
+MEM_LIMIT="${MEM_LIMIT:-768Mi}"
+HEAP="${HEAP:--Xms128m -Xmx512m -Djdk.reflect.useDirectMethodHandle=false}"
+DISCOVERY="${DISCOVERY:-https://auth.cloudless.gr/realms/master/.well-known/openid-configuration}"
+
+command -v kubectl >/dev/null 2>&1 || { echo "error: kubectl not found / no cluster access"; exit 1; }
+
+CHANGES=0
+note() { CHANGES=$((CHANGES+1)); echo "CORRECTED: $*"; }
+code() { curl -sS -m 8 -o /dev/null -w '%{http_code}' "$DISCOVERY" 2>/dev/null || echo 000; }
+
+echo "== keycloak-ensure $(date -u '+%F %T')Z =="
+
+# ── Phase 1: liveness / OOM recovery ────────────────────────────────────────
+LIMIT=$(kubectl -n "$NAMESPACE" get deploy "$DEPLOYMENT" \
+  -o jsonpath='{.spec.template.spec.containers[0].resources.limits.memory}' 2>/dev/null)
+DISC=$(code)
+echo "discovery=$DISC deploy_limit=$LIMIT"
+if [ "$DISC" != "200" ] || [ "$LIMIT" = "384Mi" ] || [ "$LIMIT" = "480Mi" ]; then
+  note "Keycloak unhealthy (discovery=$DISC, limit=$LIMIT) — restoring memory + restart"
+  kubectl -n "$NAMESPACE" patch limitrange default-container-limits --type=merge -p \
+    '{"spec":{"limits":[{"type":"Container","max":{"memory":"1Gi","cpu":"2"},"default":{"memory":"512Mi","cpu":"1"},"defaultRequest":{"memory":"128Mi","cpu":"100m"}}]}}' >/dev/null 2>&1 || true
+  PATCH=$(printf '{"spec":{"template":{"spec":{"containers":[{"name":"%s","resources":{"requests":{"memory":"384Mi","cpu":"100m"},"limits":{"memory":"%s","cpu":"1"}},"env":[{"name":"JAVA_OPTS_APPEND","value":"%s"}]}]}}}}' "$DEPLOYMENT" "$MEM_LIMIT" "$HEAP")
+  kubectl -n "$NAMESPACE" patch deploy "$DEPLOYMENT" --type=strategic -p "$PATCH" >/dev/null 2>&1
+  kubectl -n "$NAMESPACE" rollout restart "deploy/$DEPLOYMENT" >/dev/null 2>&1
+  kubectl -n "$NAMESPACE" rollout status "deploy/$DEPLOYMENT" --timeout=210s >/dev/null 2>&1 || true
+  for _ in $(seq 1 18); do DISC=$(code); [ "$DISC" = "200" ] && break; sleep 10; done
+  echo "after recovery: discovery=$DISC"
+fi
+
+if [ "$DISC" != "200" ]; then
+  echo "HEALTHY=no (Keycloak still not 200 after recovery)"; echo "CHANGES=$CHANGES"; exit 1
+fi
+
+# ── Phase 2: config reconcile (in-pod kcadm) ────────────────────────────────
+POD=$(kubectl -n "$NAMESPACE" get pod -l app="$DEPLOYMENT" -o jsonpath='{.items[0].metadata.name}' 2>/dev/null)
+RECON=$(kubectl -n "$NAMESPACE" exec -i "$POD" -- env \
+  RL="$REALM" CID="$CLIENT_ID" NU="$ADMIN_EMAIL" bash -s <<'EOS'
+set -u
+K=/opt/keycloak/bin/kcadm.sh
+csv() { $K get "$@" --format csv --noquotes 2>/dev/null; }
+AU="${KEYCLOAK_ADMIN:-${KC_BOOTSTRAP_ADMIN_USERNAME:-admin}}"
+AP="${KEYCLOAK_ADMIN_PASSWORD:-${KC_BOOTSTRAP_ADMIN_PASSWORD:-}}"
+$K config credentials --server http://localhost:8080 --realm master --user "$AU" --password "$AP" >/dev/null 2>&1 \
+  || { echo "RECON_ADMIN_AUTH=failed"; exit 0; }
+
+# realm flags
+rf() { csv "realms/$RL" --fields "$1" | head -1; }
+for kv in registrationAllowed=true resetPasswordAllowed=true loginWithEmailAllowed=true; do
+  k=${kv%=*}; want=${kv#*=}
+  cur=$(rf "$k")
+  if [ "$cur" != "$want" ]; then
+    $K update "realms/$RL" -s "$k=$want" >/dev/null 2>&1 && echo "FIX realm.$k: $cur -> $want"
+  fi
+done
+
+# admin group
+GID=$(csv groups -r "$RL" -q search=admin --fields id,name | grep -iE ',admin$' | head -1 | cut -d, -f1)
+[ -z "$GID" ] && { $K create groups -r "$RL" -s name=admin >/dev/null 2>&1; GID=$(csv groups -r "$RL" -q search=admin --fields id,name | grep -iE ',admin$' | head -1 | cut -d, -f1); echo "FIX admin group: created"; }
+
+# cloudless-app groups mapper (correct config)
+CUUID=$(csv clients -r "$RL" -q clientId="$CID" --fields id | head -1)
+MJSON='{"name":"groups","protocol":"openid-connect","protocolMapper":"oidc-group-membership-mapper","config":{"full.path":"false","id.token.claim":"true","access.token.claim":"true","userinfo.token.claim":"true","claim.name":"groups"}}'
+if [ -n "$CUUID" ]; then
+  MID=$(csv "clients/$CUUID/protocol-mappers/models" -r "$RL" --fields id,name | grep ',groups$' | head -1 | cut -d, -f1)
+  ok=0
+  if [ -n "$MID" ]; then
+    CFG=$($K get "clients/$CUUID/protocol-mappers/models/$MID" -r "$RL" 2>/dev/null)
+    printf '%s' "$CFG" | grep -qE '"full.path"[ ]*:[ ]*"false"' \
+      && printf '%s' "$CFG" | grep -qE '"claim.name"[ ]*:[ ]*"groups"' \
+      && printf '%s' "$CFG" | grep -qE '"id.token.claim"[ ]*:[ ]*"true"' \
+      && printf '%s' "$CFG" | grep -qE '"access.token.claim"[ ]*:[ ]*"true"' && ok=1
+  fi
+  if [ "$ok" != "1" ]; then
+    [ -n "$MID" ] && $K delete "clients/$CUUID/protocol-mappers/models/$MID" -r "$RL" >/dev/null 2>&1
+    printf '%s' "$MJSON" > /tmp/gm.json
+    $K create "clients/$CUUID/protocol-mappers/models" -r "$RL" -f /tmp/gm.json >/dev/null 2>&1 \
+      && echo "FIX groups mapper on $CID: set correct config"
+  fi
+else
+  echo "WARN client $CID not found (cannot ensure mapper)"
+fi
+
+# admin user membership
+USERID=$(csv users -r "$RL" -q username="$NU" --fields id | head -1)
+if [ -z "$USERID" ]; then
+  USERID=$($K create users -r "$RL" -s username="$NU" -s email="$NU" -s enabled=true -s emailVerified=true -i 2>/dev/null)
+  echo "FIX admin user $NU: created"
+fi
+if [ -n "$USERID" ] && ! csv "groups/$GID/members" -r "$RL" --fields id | grep -qx "$USERID"; then
+  $K update "users/$USERID/groups/$GID" -r "$RL" -s realm="$RL" -s userId="$USERID" -s groupId="$GID" -n >/dev/null 2>&1 \
+    && echo "FIX admin membership: added $NU"
+fi
+echo "RECON_OK"
+EOS
+)
+echo "$RECON"
+# Count in-pod corrections (lines beginning FIX).
+FIXES=$(printf '%s\n' "$RECON" | grep -c '^FIX ' || true)
+CHANGES=$((CHANGES + FIXES))
+
+FINAL=$(code)
+echo "final discovery=$FINAL CHANGES=$CHANGES"
+if [ "$FINAL" = "200" ]; then
+  [ "$CHANGES" -eq 0 ] && echo "HEALTHY=yes (no drift)" || echo "HEALTHY=yes (restored; $CHANGES correction(s))"
+  exit 0
+fi
+echo "HEALTHY=no"; exit 1


### PR DESCRIPTION
A self-healing reconciler that restores auth to its **known-good ("last working") state** automatically if it breaks.

**`pnpm keycloak:ensure`** (`scripts/keycloak-ensure.sh`) — idempotent:
- **Recovery:** if `auth.cloudless.gr` discovery ≠ 200 or the deploy limit is the old `384/480Mi`, re-apply the `768Mi` + `JAVA_OPTS_APPEND=-Xmx512m` patch and `rollout restart` (the OOM fix).
- **Reconcile (kcadm in-pod):** realm flags (`registrationAllowed`/`resetPasswordAllowed`/`loginWithEmailAllowed`), the `cloudless-app` `groups` mapper (`full.path=false`, `claim.name=groups`, id+access token claims), the `admin` group, and `tbaltzakis@cloudless.gr` membership.
- Records each correction; a clean run changes nothing. Exit 0 healthy / 1 broken.

**`keycloak-ensure.yml`** runs it on **cron `*/15`** (+ dispatch + push) over Tailscale, and posts to #382 **only** when it corrects drift or auth is still broken — healthy runs stay silent. So if auth breaks again (OOM, mapper drift, realm flag flipped), it heals back to the last working condition within ~15 min.

https://claude.ai/code/session_01WoLaMUxTAygraKUTy7JTT8

---
_Generated by [Claude Code](https://claude.ai/code/session_01WoLaMUxTAygraKUTy7JTT8)_