### PR TITLE
feat(ops): app-auth-doctor — discover SSM auth param names

### DIFF
--- a/.github/workflows/app-auth-doctor.yml
+++ b/.github/workflows/app-auth-doctor.yml
@@ -34,6 +34,19 @@ jobs:
           chmod 600 ~/.kube/config
       - name: Diagnose
         run: bash scripts/app-auth-doctor.sh 2>&1 | tee aad.log
+      - name: Discover SSM param names (auth) via pi-standby-aws-creds
+        run: |
+          set -uo pipefail
+          # Read the cluster's AWS creds (same ones the app uses for SSM); use them
+          # only to LIST parameter names — values are never printed.
+          AK=$(kubectl -n cloudless get secret pi-standby-aws-creds -o jsonpath='{.data.AWS_ACCESS_KEY_ID}' 2>/dev/null | base64 -d || true)
+          SK=$(kubectl -n cloudless get secret pi-standby-aws-creds -o jsonpath='{.data.AWS_SECRET_ACCESS_KEY}' 2>/dev/null | base64 -d || true)
+          [ -n "$AK" ] && echo "::add-mask::$AK"; [ -n "$SK" ] && echo "::add-mask::$SK"
+          if [ -z "$AK" ] || [ -z "$SK" ]; then echo "## SSM: could not read pi-standby-aws-creds (keys may differ)"; kubectl -n cloudless get secret pi-standby-aws-creds -o jsonpath='{.data}' | grep -oE '"[^"]+":' | tr -d '":,' | sed 's/^/  key: /'; exit 0; fi
+          export AWS_ACCESS_KEY_ID="$AK" AWS_SECRET_ACCESS_KEY="$SK" AWS_REGION=us-east-1
+          echo "## SSM /cloudless/production param NAMES matching AUTH|KEYCLOAK|NEXTAUTH:" | tee -a aad.log
+          aws ssm get-parameters-by-path --path /cloudless/production --recursive --query 'Parameters[].Name' --output text 2>&1 \
+            | tr '\t' '\n' | grep -iE 'AUTH_SECRET|KEYCLOAK|NEXTAUTH' | sed 's/^/  /' | tee -a aad.log || echo "  (none / aws error)" | tee -a aad.log
       - name: Post to tracking issue
         if: always()
         run: |


### PR DESCRIPTION
Extends app-auth-doctor to confirm the SSM source for wiring Keycloak onto the Pi standby: reads `pi-standby-aws-creds` (the app's own SSM creds, masked) and lists `/cloudless/production` parameter **names** matching `AUTH_SECRET|KEYCLOAK|NEXTAUTH` — values never printed. This tells me the exact params to source (especially the shared `AUTH_SECRET`) before creating the secret + wiring envFrom on the deployment.

https://claude.ai/code/session_01WoLaMUxTAygraKUTy7JTT8

---
_Generated by [Claude Code](https://claude.ai/code/session_01WoLaMUxTAygraKUTy7JTT8)_