### PR TITLE
feat(ops): wire-pi-keycloak — working Keycloak auth on the k3s standby

### DIFF
--- a/.github/workflows/wire-pi-keycloak.yml
+++ b/.github/workflows/wire-pi-keycloak.yml
@@ -1,0 +1,47 @@
+name: Wire Pi Keycloak auth (k3s standby)
+
+# Gives the k3s `cloudless` app working next-auth/Keycloak by sourcing
+# AUTH_SECRET/KEYCLOAK_* from SSM (same as the Lambda), storing them in a k8s
+# Secret, wiring envFrom on the deployment, and restarting. Posts result to #382.
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [main]
+    paths:
+      - ".github/workflows/wire-pi-keycloak.yml"
+      - "scripts/wire-pi-keycloak.sh"
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  wire:
+    runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ github.token }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v4.3.1
+      - name: Connect to tailnet
+        uses: tailscale/github-action@0263d9e6d793eaefcf1de98ff7fde47abe6664d3 # v3.2.4
+        with:
+          authkey: ${{ secrets.TS_AUTHKEY }}
+      - name: Configure kubectl
+        run: |
+          mkdir -p ~/.kube
+          echo "${{ secrets.KUBECONFIG_B64 }}" | base64 -d > ~/.kube/config
+          chmod 600 ~/.kube/config
+      - name: Wire Keycloak auth onto the Pi deployment
+        run: |
+          set -uo pipefail
+          AK=$(kubectl -n cloudless get secret pi-standby-aws-creds -o jsonpath='{.data.AWS_ACCESS_KEY_ID}' | base64 -d)
+          SK=$(kubectl -n cloudless get secret pi-standby-aws-creds -o jsonpath='{.data.AWS_SECRET_ACCESS_KEY}' | base64 -d)
+          echo "::add-mask::$AK"; echo "::add-mask::$SK"
+          export AWS_ACCESS_KEY_ID="$AK" AWS_SECRET_ACCESS_KEY="$SK" AWS_REGION=us-east-1
+          bash scripts/wire-pi-keycloak.sh 2>&1 | tee wire.log
+      - name: Post result to tracking issue
+        if: always()
+        run: |
+          { echo "# Wire Pi Keycloak — $(date -u '+%F %T')Z"; echo; echo '```'; cat wire.log 2>/dev/null || echo '(no log)'; echo '```'; } > c.md
+          gh issue comment 382 --repo "${{ github.repository }}" --body-file c.md

--- a/scripts/wire-pi-keycloak.sh
+++ b/scripts/wire-pi-keycloak.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+#
+# wire-pi-keycloak.sh — give the k3s `cloudless` app working Keycloak auth.
+#
+# The Pi standby's deployment has no AUTH_SECRET/KEYCLOAK_* env, so next-auth runs
+# in disabled fallback mode (providers={}, no login handoff). This reads those
+# values from SSM (/cloudless/production/* — the SAME source the Lambda uses, so
+# AUTH_SECRET matches and failover sessions stay valid), stores them in a k8s
+# Secret, wires it onto the deployment via envFrom (preserving pi-standby-aws-creds),
+# and restarts. Values are masked; never printed or committed.
+#
+# Requires: kubectl (cluster-admin) + aws CLI + AWS creds in env (the workflow
+# sources them from the pi-standby-aws-creds secret).
+#
+# NOTE: NEXT_PUBLIC_KEYCLOAK_ISSUER is build-time (baked into the client bundle),
+# so the login *page* button still needs a Pi image rebuild (deploy-pi build-arg).
+# This fixes the server-side auth API (providers, OIDC callback, session) — the
+# part that matters for HA failover.
+
+set -uo pipefail
+NS="${NS:-cloudless}"
+DEP="${DEP:-cloudless}"
+SECRET="${SECRET:-cloudless-app-auth}"
+SSM_PREFIX="${SSM_PREFIX:-/cloudless/production}"
+export AWS_REGION="${AWS_REGION:-us-east-1}"
+
+command -v kubectl >/dev/null 2>&1 || { echo "kubectl not found"; exit 1; }
+command -v aws >/dev/null 2>&1 || { echo "aws CLI not found"; exit 1; }
+
+get() { aws ssm get-parameter --name "$SSM_PREFIX/$1" --with-decryption --query 'Parameter.Value' --output text 2>/dev/null; }
+AUTH_SECRET=$(get AUTH_SECRET)
+KC_ISSUER=$(get KEYCLOAK_ISSUER)
+KC_CID=$(get KEYCLOAK_CLIENT_ID)
+KC_SECRET=$(get KEYCLOAK_CLIENT_SECRET)
+for v in "$AUTH_SECRET" "$KC_SECRET" "$KC_CID"; do [ -n "$v" ] && echo "::add-mask::$v"; done
+
+if [ -z "$AUTH_SECRET" ] || [ -z "$KC_ISSUER" ] || [ -z "$KC_CID" ]; then
+  echo "ERROR: missing SSM values (AUTH_SECRET/ISSUER/CLIENT_ID). Aborting, no changes."; exit 1
+fi
+echo "fetched from SSM: AUTH_SECRET(len=${#AUTH_SECRET}) ISSUER=$KC_ISSUER CLIENT_ID(len=${#KC_CID}) CLIENT_SECRET(len=${#KC_SECRET})"
+
+echo "creating/updating secret $SECRET in ns/$NS"
+kubectl -n "$NS" create secret generic "$SECRET" \
+  --from-literal=AUTH_SECRET="$AUTH_SECRET" \
+  --from-literal=KEYCLOAK_ISSUER="$KC_ISSUER" \
+  --from-literal=KEYCLOAK_CLIENT_ID="$KC_CID" \
+  --from-literal=KEYCLOAK_CLIENT_SECRET="$KC_SECRET" \
+  --dry-run=client -o yaml | kubectl apply -f - >/dev/null && echo "secret applied"
+
+# Strategic-merge patch: merge into the named container; include BOTH envFrom
+# entries (envFrom is a list and gets replaced) so we keep pi-standby-aws-creds.
+echo "wiring envFrom on deploy/$DEP (preserving pi-standby-aws-creds)"
+kubectl -n "$NS" patch deploy "$DEP" --type=strategic -p \
+  "{\"spec\":{\"template\":{\"spec\":{\"containers\":[{\"name\":\"$DEP\",\"envFrom\":[{\"secretRef\":{\"name\":\"pi-standby-aws-creds\"}},{\"secretRef\":{\"name\":\"$SECRET\"}}]}]}}}}" \
+  >/dev/null && echo "deployment patched"
+
+kubectl -n "$NS" rollout restart "deploy/$DEP" >/dev/null
+kubectl -n "$NS" rollout status "deploy/$DEP" --timeout=180s || echo "rollout status timed out (continuing)"
+
+echo "envFrom now:"
+kubectl -n "$NS" get deploy "$DEP" -o jsonpath='{range .spec.template.spec.containers[0].envFrom[*]}{.secretRef.name}{"\n"}{end}' 2>&1 | sed 's/^/  /'
+
+echo "verifying pi-origin auth (allow warm-up)…"
+for i in $(seq 1 12); do
+  P=$(curl -sS -m 8 "https://pi-origin.cloudless.gr/api/auth/providers" 2>/dev/null || echo "")
+  if printf '%s' "$P" | grep -q '"keycloak"'; then echo "PROVIDERS=ok (keycloak listed)"; break; fi
+  sleep 10
+done
+LOC=$(curl -sS -m 8 -c /tmp/pj -o /dev/null -w '' "https://pi-origin.cloudless.gr/api/auth/csrf" 2>/dev/null; \
+  CT=$(curl -sS -m 8 -b /tmp/pj "https://pi-origin.cloudless.gr/api/auth/csrf" | grep -o '"csrfToken":"[^"]*"' | cut -d'"' -f4); \
+  curl -sS -m 8 -b /tmp/pj -o /dev/null -w '%{redirect_url}' --data-urlencode "csrfToken=$CT" --data-urlencode "callbackUrl=/en/dashboard" "https://pi-origin.cloudless.gr/api/auth/signin/keycloak" 2>/dev/null)
+case "$LOC" in
+  *auth.cloudless.gr*openid-connect/auth*) echo "HANDOFF=ok (302 -> Keycloak PKCE)";;
+  *) echo "HANDOFF=check (got: ${LOC:-empty})";;
+esac
+echo "DONE wiring Pi Keycloak auth."


### PR DESCRIPTION
Gives the k3s `cloudless` standby working next-auth/Keycloak (it was in disabled fallback mode — `providers={}`, no handoff).

- Sources `AUTH_SECRET` + `KEYCLOAK_ISSUER`/`CLIENT_ID`/`CLIENT_SECRET` from **SSM `/cloudless/production/*`** (confirmed present; same source as the Lambda → `AUTH_SECRET` matches so HA-failover sessions validate).
- Stores them in k8s Secret `cloudless-app-auth`, wires `envFrom` on the deployment **preserving `pi-standby-aws-creds`**, and `rollout restart`.
- Verifies `pi-origin` lists the `keycloak` provider + a `302 → Keycloak PKCE` handoff. Values masked; never printed/committed.
- AWS creds read transiently from the in-cluster `pi-standby-aws-creds` secret (masked).

Note: `NEXT_PUBLIC_KEYCLOAK_ISSUER` is build-time, so the login *page* button on the Pi still needs an image rebuild (deploy-pi build-arg) — follow-up; this fixes the server-side auth API that matters for failover.

Merging runs it → result on #382.

https://claude.ai/code/session_01WoLaMUxTAygraKUTy7JTT8

---
_Generated by [Claude Code](https://claude.ai/code/session_01WoLaMUxTAygraKUTy7JTT8)_