### PR TITLE
feat(ops): pi-auth-logs — dump app auth wiring + next-auth error

### DIFF
--- a/.github/workflows/pi-auth-logs.yml
+++ b/.github/workflows/pi-auth-logs.yml
@@ -1,0 +1,37 @@
+name: Pi auth logs (diagnose next-auth error)
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [main]
+    paths:
+      - ".github/workflows/pi-auth-logs.yml"
+      - "scripts/pi-auth-logs.sh"
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  logs:
+    runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ github.token }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v4.3.1
+      - name: Connect to tailnet
+        uses: tailscale/github-action@0263d9e6d793eaefcf1de98ff7fde47abe6664d3 # v3.2.4
+        with:
+          authkey: ${{ secrets.TS_AUTHKEY }}
+      - name: Configure kubectl
+        run: |
+          mkdir -p ~/.kube
+          echo "${{ secrets.KUBECONFIG_B64 }}" | base64 -d > ~/.kube/config
+          chmod 600 ~/.kube/config
+      - name: Collect
+        run: bash scripts/pi-auth-logs.sh 2>&1 | tee pal.log
+      - name: Post to tracking issue
+        if: always()
+        run: |
+          { echo "# Pi auth logs — $(date -u '+%F %T')Z"; echo; echo '```'; cat pal.log 2>/dev/null || echo '(no log)'; echo '```'; } > c.md
+          gh issue comment 382 --repo "${{ github.repository }}" --body-file c.md

--- a/scripts/pi-auth-logs.sh
+++ b/scripts/pi-auth-logs.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+#
+# pi-auth-logs.sh — show the k3s cloudless app's auth wiring + the actual
+# next-auth error in its logs (read-only), to pin down why auth fails on the Pi.
+
+set -uo pipefail
+NS="${NS:-cloudless}"
+DEP="${DEP:-cloudless}"
+command -v kubectl >/dev/null 2>&1 || { echo "kubectl not found"; exit 1; }
+
+echo "== pi-auth-logs $(date -u '+%F %T')Z =="
+echo "## deployment envFrom:"
+kubectl -n "$NS" get deploy "$DEP" -o jsonpath='{range .spec.template.spec.containers[0].envFrom[*]}{"  "}{.secretRef.name}{"\n"}{end}' 2>&1
+
+echo "## cloudless-app-auth secret — key names + non-secret values:"
+kubectl -n "$NS" get secret cloudless-app-auth -o jsonpath='{.data}' 2>/dev/null | grep -oE '"[^"]+":' | tr -d '":,' | sed 's/^/    /'
+for k in KEYCLOAK_ISSUER KEYCLOAK_CLIENT_ID AUTH_URL AUTH_TRUST_HOST; do
+  v=$(kubectl -n "$NS" get secret cloudless-app-auth -o jsonpath="{.data.$k}" 2>/dev/null | base64 -d 2>/dev/null)
+  printf '    %s = %s\n' "$k" "$v"
+done
+
+echo "## pods:"
+kubectl -n "$NS" get pods -l 'app.kubernetes.io/name=cloudless' -o wide 2>/dev/null || kubectl -n "$NS" get pods -o wide 2>&1 | grep -E "^NAME|cloudless" | grep -v keycloak
+
+echo "## trigger an auth call then tail logs for the error:"
+curl -sS -m 8 -o /dev/null "https://pi-origin.cloudless.gr/api/auth/providers" 2>/dev/null || true
+sleep 2
+kubectl -n "$NS" logs "deploy/$DEP" --tail=120 --all-containers 2>&1 \
+  | grep -iE 'auth|error|keycloak|configuration|untrustedhost|trusthost|fetch failed|discovery|ECONN|ENOTFOUND|getServerSession|MissingSecret' \
+  | tail -40 | sed 's/^/    /'
+echo "_end pi-auth-logs_"


### PR DESCRIPTION
Read-only probe: dumps the cloudless deployment's `envFrom`, the `cloudless-app-auth` secret key names + non-secret values (issuer/client_id/`AUTH_URL`/`AUTH_TRUST_HOST`), pods, and the **actual next-auth error from the pod logs** — to pin down why Pi auth still returns "server configuration" (confirm whether `AUTH_TRUST_HOST` was the fix or there's another cause like pod→Keycloak discovery egress). Posts to #382.

https://claude.ai/code/session_01WoLaMUxTAygraKUTy7JTT8

---
_Generated by [Claude Code](https://claude.ai/code/session_01WoLaMUxTAygraKUTy7JTT8)_