### PR TITLE
feat(ops): keycloak:ensure self-heals the Pi app auth wiring too

### DIFF
--- a/.claude/skills/cluster-incident-response/SKILL.md
+++ b/.claude/skills/cluster-incident-response/SKILL.md
@@ -44,7 +44,7 @@ offline during cluster incidents and the job queues forever).
 | `.github/workflows/restore-keycloak.yml` | Runs `keycloak:restore` on a hosted runner, posts the log to #382. Trigger by editing the workflow file. |
 | `pnpm prometheus:tune` (`scripts/prometheus-tune.sh`) | Deletes the heavy kube-apiserver SLO/burnrate/availability PrometheusRules that time out and trip `PrometheusRuleFailures`; reports remaining failing rules. |
 | `.github/workflows/prometheus-tune.yml` | Runs `prometheus:tune` on a hosted runner, posts the log to #382. Trigger by editing the workflow file. |
-| `pnpm keycloak:ensure` (`scripts/keycloak-ensure.sh`) | **Self-heal**: idempotent reconciler that restores auth to its known-good state — OOM-recovers Keycloak (768Mi + `-Xmx512m`), and fixes realm flags + the cloudless-app `groups` mapper (`full.path=false`) + admin group/membership. Reports only what it `CORRECTED`. |
+| `pnpm keycloak:ensure` (`scripts/keycloak-ensure.sh`) | **Self-heal**: idempotent reconciler that restores auth to its known-good state — OOM-recovers Keycloak (768Mi + `-Xmx512m`), fixes realm flags + the cloudless-app `groups` mapper (`full.path=false`) + admin group/membership, **and restores the Pi `cloudless` app's auth wiring** (`cloudless-app-auth` secret + `envFrom`: AUTH_SECRET/KEYCLOAK_*(realm master)/AUTH_TRUST_HOST/AUTH_URL, via `wire-pi-keycloak.sh`) if it stops serving the keycloak provider. Reports only what it `CORRECTED`. |
 | `.github/workflows/keycloak-ensure.yml` | Runs `keycloak:ensure` on a **cron (`*/15`)** + dispatch + push; posts to #382 only when it corrects drift or auth is still broken (silent on healthy runs). This is the auto-recovery that brings auth back to the last working condition. |
 
 ## Triage workflow

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -116,8 +116,20 @@ instead — see the **`cluster-incident-response`** skill for the full playbook.
     that's expected; no `LOGIN_VERIFIED`.) **Never commit a password to git.**
 - **Self-heal:** `pnpm keycloak:ensure` (`keycloak-ensure.yml`, **cron `*/15`**)
   reconciles auth to the last-working state — OOM-recovers Keycloak (768Mi /
-  `-Xmx512m`) and fixes realm flags + the `cloudless-app` groups mapper + admin
-  group/membership; posts to #382 only when it corrects drift or auth is broken.
+  `-Xmx512m`), fixes realm flags + the `cloudless-app` groups mapper + admin
+  group/membership, **and restores the Pi `cloudless` app's auth wiring** (the
+  `cloudless-app-auth` secret + `envFrom`) if it stops serving the keycloak
+  provider; posts to #382 only when it corrects drift or auth is broken.
+- **Pi/k3s app auth (HA standby):** the `cloudless` deployment needs runtime env
+  `AUTH_SECRET` + `KEYCLOAK_ISSUER`(**realm `master`**, not the stale SSM value
+  `cloudless`) + `KEYCLOAK_CLIENT_ID`/`KEYCLOAK_CLIENT_SECRET` + **`AUTH_TRUST_HOST=true`**
+  + `AUTH_URL=https://cloudless.gr` — else next-auth returns `{}` (no AUTH_SECRET)
+  or a "server configuration"/`UntrustedHost` error. Wire it with
+  `pnpm keycloak:wire-pi` style (`scripts/wire-pi-keycloak.sh` → `wire-pi-keycloak.yml`):
+  pulls values from SSM `/cloudless/production/*`, pins realm to `master`, stores
+  them in `cloudless-app-auth`, adds `envFrom` (keeping `pi-standby-aws-creds`),
+  restarts. `NEXT_PUBLIC_KEYCLOAK_ISSUER` is build-time → the Pi login *page*
+  button still needs the `--build-arg` in `deploy-pi.yml`.
 - **CloudWatch `SERVERLESS-APP_MAIN-Errors`** (custom metric
   `CloudlessApp/ServerlessErrors`) is a **CloudWatch Logs metric filter** on the
   Lambda log group — NOT Sentry (Sentry had 0). It counts next-auth

--- a/scripts/keycloak-ensure.sh
+++ b/scripts/keycloak-ensure.sh
@@ -129,6 +129,27 @@ echo "$RECON"
 FIXES=$(printf '%s\n' "$RECON" | grep -c '^FIX ' || true)
 CHANGES=$((CHANGES + FIXES))
 
+# ── Phase 3: Pi `cloudless` app auth wiring (HA standby) ────────────────────
+# next-auth on the k3s app needs AUTH_SECRET/KEYCLOAK_*(realm master)/AUTH_TRUST_HOST
+# (cloudless-app-auth secret + envFrom). If the app stops serving the keycloak
+# provider (secret deleted, envFrom dropped on a manifest re-apply, etc.), restore
+# it by re-running the wire tool. Cheap HTTP check when healthy; only acts on break.
+PI_PROV=$(curl -sS -m 8 "https://pi-origin.cloudless.gr/api/auth/providers" 2>/dev/null || echo "")
+if printf '%s' "$PI_PROV" | grep -q '"keycloak"'; then
+  echo "PI_APP_AUTH=ok"
+else
+  note "Pi cloudless app not serving the keycloak provider — restoring auth wiring"
+  AK=$(kubectl -n cloudless get secret pi-standby-aws-creds -o jsonpath='{.data.AWS_ACCESS_KEY_ID}' 2>/dev/null | base64 -d 2>/dev/null || true)
+  SK=$(kubectl -n cloudless get secret pi-standby-aws-creds -o jsonpath='{.data.AWS_SECRET_ACCESS_KEY}' 2>/dev/null | base64 -d 2>/dev/null || true)
+  [ -n "$AK" ] && echo "::add-mask::$AK"; [ -n "$SK" ] && echo "::add-mask::$SK"
+  HERE="$(cd "$(dirname "$0")" && pwd)"
+  if [ -n "$AK" ] && [ -n "$SK" ] && command -v aws >/dev/null 2>&1 && [ -f "$HERE/wire-pi-keycloak.sh" ]; then
+    AWS_ACCESS_KEY_ID="$AK" AWS_SECRET_ACCESS_KEY="$SK" AWS_REGION=us-east-1 bash "$HERE/wire-pi-keycloak.sh" || echo "  (wire-pi-keycloak returned non-zero)"
+  else
+    echo "  (cannot auto-restore Pi app auth: need aws CLI + pi-standby-aws-creds + wire-pi-keycloak.sh)"
+  fi
+fi
+
 FINAL=$(code)
 echo "final discovery=$FINAL CHANGES=$CHANGES"
 if [ "$FINAL" = "200" ]; then


### PR DESCRIPTION
Extends the `keycloak:ensure` self-heal reconciler (cron `*/15`) to also restore the **Pi `cloudless` app's auth wiring** if it breaks. If `pi-origin` stops serving the `keycloak` provider (secret deleted, `envFrom` dropped on a manifest re-apply, config drift), it re-runs `wire-pi-keycloak.sh` — pulls values from SSM, pins realm `master`, sets `AUTH_TRUST_HOST`/`AUTH_URL`, recreates `cloudless-app-auth` + `envFrom`, restarts. Cheap HTTP check when healthy; only acts on breakage; counts as a `CORRECTED` drift (so it posts to #382). Docs updated (skill + CLAUDE.md: Pi app auth requirements + stale-SSM-realm note).

Now all auth layers self-heal to the last working state: Keycloak (OOM/realm/mapper/admin) **and** the Pi standby app auth.

https://claude.ai/code/session_01WoLaMUxTAygraKUTy7JTT8

---
_Generated by [Claude Code](https://claude.ai/code/session_01WoLaMUxTAygraKUTy7JTT8)_