### PR TITLE
fix(infra): raise Keycloak max HTTP header size to 64K (fix 431 at login)

### DIFF
--- a/k8s/cluster-protection/memory-relief-2026-05-31.yaml
+++ b/k8s/cluster-protection/memory-relief-2026-05-31.yaml
@@ -143,7 +143,7 @@ spec:
         - name: keycloak
           env:
             - name: JAVA_OPTS_APPEND
-              value: "-Xms128m -Xmx512m -Djdk.reflect.useDirectMethodHandle=false"
+              value: "-Xms128m -Xmx512m -Djdk.reflect.useDirectMethodHandle=false -Dquarkus.http.limits.max-header-size=64K"
           resources:
             requests: { memory: 384Mi, cpu: 100m }
             limits:   { memory: 768Mi, cpu: 1 }

--- a/scripts/keycloak-ensure.sh
+++ b/scripts/keycloak-ensure.sh
@@ -30,7 +30,7 @@ REALM="${REALM:-master}"
 CLIENT_ID="${CLIENT_ID:-cloudless-app}"
 ADMIN_EMAIL="${ADMIN_EMAIL:-tbaltzakis@cloudless.gr}"
 MEM_LIMIT="${MEM_LIMIT:-768Mi}"
-HEAP="${HEAP:--Xms128m -Xmx512m -Djdk.reflect.useDirectMethodHandle=false}"
+HEAP="${HEAP:--Xms128m -Xmx512m -Djdk.reflect.useDirectMethodHandle=false -Dquarkus.http.limits.max-header-size=64K}"
 DISCOVERY="${DISCOVERY:-https://auth.cloudless.gr/realms/master/.well-known/openid-configuration}"
 
 command -v kubectl >/dev/null 2>&1 || { echo "error: kubectl not found / no cluster access"; exit 1; }

--- a/scripts/restore-keycloak.sh
+++ b/scripts/restore-keycloak.sh
@@ -22,7 +22,7 @@ DEPLOYMENT="${DEPLOYMENT:-keycloak}"
 DISCOVERY="${DISCOVERY:-https://auth.cloudless.gr/realms/master/.well-known/openid-configuration}"
 MEM_LIMIT="${MEM_LIMIT:-768Mi}"
 MEM_REQUEST="${MEM_REQUEST:-384Mi}"
-HEAP="${HEAP:--Xms128m -Xmx512m -Djdk.reflect.useDirectMethodHandle=false}"
+HEAP="${HEAP:--Xms128m -Xmx512m -Djdk.reflect.useDirectMethodHandle=false -Dquarkus.http.limits.max-header-size=64K}"
 
 log() { printf '[restore-kc] %s\n' "$*"; }
 run() { log "\$ $*"; "$@"; log "(exit $?)"; }


### PR DESCRIPTION
Fixes the **HTTP 431 "Request headers are too large"** on the Keycloak update-password page. Keycloak's default ~8K header limit was exceeded by accumulated cookies (`AUTH_SESSION_ID`/`KC_RESTART`/`KEYCLOAK_IDENTITY` piled up across login retries). Adds `-Dquarkus.http.limits.max-header-size=64K` to `JAVA_OPTS_APPEND` in the memory-relief manifest, `restore-keycloak.sh`, and `keycloak-ensure.sh` (applied **and** self-healed). Merging re-fires `restore-keycloak` to patch + restart Keycloak with the new option.

(Immediate user workaround meanwhile: log in from an incognito window / clear `auth.cloudless.gr` cookies.)

https://claude.ai/code/session_01WoLaMUxTAygraKUTy7JTT8

---
_Generated by [Claude Code](https://claude.ai/code/session_01WoLaMUxTAygraKUTy7JTT8)_