### PR TITLE
fix(auth): admins land on /admin after login (post-login resolver)

### DIFF
--- a/src/app/[locale]/auth/login/page.tsx
+++ b/src/app/[locale]/auth/login/page.tsx
@@ -54,11 +54,13 @@ function LoginContent() {
     setSubmitting(true);
     try {
       if (USE_KEYCLOAK) {
+        // isAdmin is false here (not signed in yet), so we can't decide the
+        // landing page now. Send users through /auth/post-login, which reads the
+        // established session server-side and routes admins → /admin, else
+        // → /dashboard. A real ?next= deep-link still wins.
         const callbackUrl = nextParam?.startsWith("/")
           ? normalizeRedirectPath(nextParam)
-          : isAdmin
-            ? "/admin"
-            : "/dashboard";
+          : "/auth/post-login";
         await nextAuthSignIn("keycloak", { callbackUrl });
         return;
       }

--- a/src/app/[locale]/auth/post-login/page.tsx
+++ b/src/app/[locale]/auth/post-login/page.tsx
@@ -1,0 +1,28 @@
+import { redirect } from "next/navigation";
+import { auth } from "@/lib/auth";
+
+// Post-login landing resolver. next-auth's callbackUrl is fixed at sign-in time
+// (before the session exists), so we can't decide admin-vs-dashboard there. The
+// Keycloak sign-in sends users here; this reads the now-established session and
+// routes admins to /admin, everyone else to /dashboard. Server-side → no flash.
+export const dynamic = "force-dynamic";
+
+export default async function PostLoginPage({
+  params,
+}: Readonly<{ params: Promise<{ locale: string }> }>) {
+  const { locale } = await params;
+  const session = await auth();
+
+  if (!session?.user) {
+    redirect(`/${locale}/auth/login`);
+  }
+
+  const groups = session.user.groups ?? [];
+  const roles = session.user.roles ?? [];
+  const isAdmin =
+    groups.includes("admin") ||
+    roles.includes("admin") ||
+    roles.includes("realm:admin");
+
+  redirect(`/${locale}${isAdmin ? "/admin" : "/dashboard"}`);
+}


### PR DESCRIPTION
**Bug:** after Keycloak login, admins land on `/dashboard` instead of `/admin`. The sign-in `callbackUrl` was computed from `isAdmin`, but `isAdmin` is `false` at click time (not signed in yet) → it always resolved to `/dashboard`.

**Fix:** add a server-side `/auth/post-login` resolver that reads the now-established session's `groups`/`roles` and redirects admins → `/admin`, everyone else → `/dashboard`. The Keycloak sign-in now uses it as the default `callbackUrl` (a real `?next=` deep-link still wins). Server-side `redirect` → no client flash; works identically on Lambda + Pi.

Verified: `eslint` clean, `pnpm typecheck` ✓.

https://claude.ai/code/session_01WoLaMUxTAygraKUTy7JTT8

---
_Generated by [Claude Code](https://claude.ai/code/session_01WoLaMUxTAygraKUTy7JTT8)_