### PR TITLE
fix(auth): resolve /auth/post-login in middleware (clean 307 to /admin)

### DIFF
--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -322,6 +322,20 @@ async function handlePageRoute(
   const bare = stripLocale(pathname);
   const locale = getLocaleFromPath(pathname);
   const prefix = `/${locale}`;
+
+  // Post-login resolver: the Keycloak sign-in callbackUrl can't know isAdmin
+  // before the session exists, so it lands here. Decide in middleware (clean
+  // 307, no page render) — admins → /admin, everyone else → /dashboard.
+  if (bare === "/auth/post-login") {
+    const { valid, isAdmin: hasAdminGroup } = await readAuthToken(request);
+    if (!valid) {
+      return NextResponse.redirect(new URL(`${prefix}/auth/login`, request.url));
+    }
+    return NextResponse.redirect(
+      new URL(`${prefix}${hasAdminGroup ? "/admin" : "/dashboard"}`, request.url),
+    );
+  }
+
   const isAdminPath = bare === "/admin" || bare.startsWith("/admin/");
   const isDashboardPath = bare === "/dashboard" || bare.startsWith("/dashboard/");
 


### PR DESCRIPTION
Hardens the post-login redirect. The page-based `redirect()` streams a 200 loading-shell to non-JS clients (the redirect only fires client-side via RSC). Move the decision into `proxy.ts` middleware — it already reads the auth token — so `/auth/post-login` returns a **clean 307** to `/admin` (admins) or `/dashboard`, no page render, JS-independent. The page stays as a fallback.

Verified: `eslint` clean, `pnpm typecheck` ✓. Deploys to both Lambda + Pi.

https://claude.ai/code/session_01WoLaMUxTAygraKUTy7JTT8

---
_Generated by [Claude Code](https://claude.ai/code/session_01WoLaMUxTAygraKUTy7JTT8)_