### PR TITLE
fix(auth): admin login lands on /admin + verify token groups + SSM issuer

### DIFF
--- a/.github/workflows/keycloak-verify-admin.yml
+++ b/.github/workflows/keycloak-verify-admin.yml
@@ -1,0 +1,78 @@
+name: Keycloak verify admin (token groups + SSM issuer)
+
+# Two things, no login required:
+#   1. Prove the cloudless-app id token Keycloak WOULD issue for the admin
+#      carries groups:["admin"] (via evaluate-scopes example-token) → so the
+#      /admin gate + post-login resolver route them to /admin, not /dashboard.
+#   2. Fix the stale SSM /cloudless/production/KEYCLOAK_ISSUER (was `cloudless`,
+#      must be the realm `master` issuer URL) so wire-pi/self-heal never re-pin
+#      a broken value.
+# Posts the result to issue #382.
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [main]
+    paths:
+      - ".github/workflows/keycloak-verify-admin.yml"
+      - "scripts/keycloak-verify-admin.sh"
+
+permissions:
+  contents: read
+  issues: write
+
+concurrency:
+  group: keycloak-verify-admin
+  cancel-in-progress: false
+
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ github.token }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v4.3.1
+
+      - name: Connect to tailnet
+        uses: tailscale/github-action@0263d9e6d793eaefcf1de98ff7fde47abe6664d3 # v3.2.4
+        with:
+          authkey: ${{ secrets.TS_AUTHKEY }}
+
+      - name: Configure kubectl
+        run: |
+          mkdir -p ~/.kube
+          echo "${{ secrets.KUBECONFIG_B64 }}" | base64 -d > ~/.kube/config
+          chmod 600 ~/.kube/config
+
+      - name: Verify admin token carries groups:[admin]
+        run: |
+          set -uo pipefail
+          bash scripts/keycloak-verify-admin.sh 2>&1 | tee verify.log
+
+      - name: Fix stale SSM KEYCLOAK_ISSUER (cloudless -> master)
+        run: |
+          set -uo pipefail
+          AK=$(kubectl -n cloudless get secret pi-standby-aws-creds -o jsonpath='{.data.AWS_ACCESS_KEY_ID}' | base64 -d)
+          SK=$(kubectl -n cloudless get secret pi-standby-aws-creds -o jsonpath='{.data.AWS_SECRET_ACCESS_KEY}' | base64 -d)
+          echo "::add-mask::$AK"; echo "::add-mask::$SK"
+          export AWS_ACCESS_KEY_ID="$AK" AWS_SECRET_ACCESS_KEY="$SK" AWS_REGION=us-east-1
+          WANT="https://auth.cloudless.gr/realms/master"
+          NAME="/cloudless/production/KEYCLOAK_ISSUER"
+          CUR=$(aws ssm get-parameter --name "$NAME" --query 'Parameter.Value' --output text 2>/dev/null || echo "")
+          {
+            echo "## SSM $NAME"
+            echo "before: ${CUR:-<unset>}"
+            if [ "$CUR" = "$WANT" ]; then
+              echo "result: ALREADY_CORRECT (no change)"
+            else
+              aws ssm put-parameter --name "$NAME" --value "$WANT" --type String --overwrite >/dev/null 2>&1 \
+                && echo "after:  $WANT" && echo "result: UPDATED" \
+                || echo "result: PUT_FAILED"
+            fi
+          } | tee -a verify.log
+
+      - name: Post result to tracking issue
+        if: always()
+        run: |
+          { echo "# Keycloak verify admin — $(date -u '+%F %T')Z"; echo; echo '```'; cat verify.log 2>/dev/null || echo '(no log)'; echo '```'; } > c.md
+          gh issue comment 382 --repo "${{ github.repository }}" --body-file c.md

--- a/scripts/keycloak-verify-admin.sh
+++ b/scripts/keycloak-verify-admin.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+#
+# keycloak-verify-admin.sh — prove (without a login) that the admin's cloudless-app
+# token carries groups:["admin"], so the /admin gate + post-login resolver route
+# them correctly. Uses Keycloak's evaluate-scopes example-token endpoint via kcadm.
+
+set -uo pipefail
+NS="${NS:-keycloak}"; DEP="${DEP:-keycloak}"; RL="${RL:-master}"
+CID="${CID:-cloudless-app}"; ADMIN_EMAIL="${ADMIN_EMAIL:-tbaltzakis@cloudless.gr}"
+command -v kubectl >/dev/null 2>&1 || { echo "kubectl not found"; exit 1; }
+POD=$(kubectl -n "$NS" get pod -l app="$DEP" -o jsonpath='{.items[0].metadata.name}' 2>/dev/null)
+[ -n "$POD" ] || { echo "no $DEP pod"; exit 1; }
+
+kubectl -n "$NS" exec -i "$POD" -- env RL="$RL" CID="$CID" NU="$ADMIN_EMAIL" bash -s <<'EOS'
+set -u
+K=/opt/keycloak/bin/kcadm.sh
+csv() { $K get "$@" --format csv --noquotes 2>/dev/null; }
+AU="${KEYCLOAK_ADMIN:-${KC_BOOTSTRAP_ADMIN_USERNAME:-admin}}"
+AP="${KEYCLOAK_ADMIN_PASSWORD:-${KC_BOOTSTRAP_ADMIN_PASSWORD:-}}"
+$K config credentials --server http://localhost:8080 --realm master --user "$AU" --password "$AP" >/dev/null 2>&1 || { echo "ADMIN_AUTH=failed"; exit 0; }
+CUUID=$(csv clients -r "$RL" -q clientId="$CID" --fields id | head -1)
+USERID=$(csv users -r "$RL" -q username="$NU" --fields id | head -1)
+echo "client=$CID($CUUID) user=$NU($USERID)"
+echo "group memberships:"; csv "users/$USERID/groups" -r "$RL" --fields name | sed 's/^/  /'
+echo "--- example id token cloudless-app would issue for $NU ---"
+TOK=$($K get "clients/$CUUID/evaluate-scopes/generate-example-id-token" -r "$RL" -q "userId=$USERID" -q "scope=openid" 2>&1)
+echo "$TOK" | grep -A4 '"groups"' || echo "  (no groups claim in example token)"
+if echo "$TOK" | tr -d ' \n' | grep -q '"groups":\["admin"\]\|"groups":\[.*"admin".*\]'; then
+  echo "RESULT=PASS (token carries groups including 'admin' -> isAdmin() true)"
+else
+  echo "RESULT=FAIL (groups/admin not in token)"
+fi
+EOS

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -322,6 +322,20 @@ async function handlePageRoute(
   const bare = stripLocale(pathname);
   const locale = getLocaleFromPath(pathname);
   const prefix = `/${locale}`;
+
+  // Post-login resolver: the Keycloak sign-in callbackUrl can't know isAdmin
+  // before the session exists, so it lands here. Decide in middleware (clean
+  // 307, no page render) — admins → /admin, everyone else → /dashboard.
+  if (bare === "/auth/post-login") {
+    const { valid, isAdmin: hasAdminGroup } = await readAuthToken(request);
+    if (!valid) {
+      return NextResponse.redirect(new URL(`${prefix}/auth/login`, request.url));
+    }
+    return NextResponse.redirect(
+      new URL(`${prefix}${hasAdminGroup ? "/admin" : "/dashboard"}`, request.url),
+    );
+  }
+
   const isAdminPath = bare === "/admin" || bare.startsWith("/admin/");
   const isDashboardPath = bare === "/dashboard" || bare.startsWith("/dashboard/");
 


### PR DESCRIPTION
## Summary

Closes out the admin-login incident work:

- **Post-login redirect** — admins now land on `/admin` after Keycloak login. The sign-in `callbackUrl` can't know `isAdmin` before the session exists, so it routes through `/auth/post-login`, resolved in middleware (clean 307) → `/admin` for the `admin` group, `/dashboard` otherwise. Server-component fallback page included.
- **431 fix** — Keycloak `max-header-size=64K` (cookie bloat at login).
- **`keycloak:verify-admin`** (new) — proves, without a login, that the `cloudless-app` id token Keycloak would issue for `tbaltzakis@cloudless.gr` carries `groups:["admin"]` (via the evaluate-scopes example-token endpoint), and fixes the stale SSM `KEYCLOAK_ISSUER` (`cloudless` → realm `master` URL) so wire-pi/self-heal never re-pin a broken issuer. Posts results to #382.

## Verification

The `keycloak-verify-admin` workflow runs on merge (path-trigger) and posts `RESULT=PASS/FAIL` + the SSM before/after to issue #382.

https://claude.ai/code/session_01WoLaMUxTAygraKUTy7JTT8

---
_Generated by [Claude Code](https://claude.ai/code/session_01WoLaMUxTAygraKUTy7JTT8)_