### PR TITLE
fix(auth): middleware reads chunked session cookie → admin lands on /admin

### DIFF
--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -20,11 +20,19 @@ function stripLocale(pathname: string): string {
 async function readAuthToken(
   req: NextRequest,
 ): Promise<{ valid: boolean; isAdmin: boolean }> {
-  const sessionCookie =
-    req.cookies.get("__Secure-authjs.session-token")?.value ??
-    req.cookies.get("authjs.session-token")?.value;
+  // The session JWT stores the Keycloak access/id/refresh tokens, so it
+  // exceeds the 4096-byte cookie limit and next-auth CHUNKS it into
+  // `<name>.0`, `<name>.1`, … — the unchunked `<name>` cookie then does not
+  // exist. Detect either form (base cookie OR first chunk) before paying for
+  // the getToken dynamic import; getToken's SessionStore reassembles the
+  // chunks itself. Checking only the base name treated logged-in admins as
+  // anonymous and bounced them to /auth/login instead of /admin.
+  const baseNames = ["__Secure-authjs.session-token", "authjs.session-token"];
+  const hasSession = baseNames.some(
+    (n) => req.cookies.get(n) ?? req.cookies.get(`${n}.0`),
+  );
 
-  if (!sessionCookie) return { valid: false, isAdmin: false };
+  if (!hasSession) return { valid: false, isAdmin: false };
 
   try {
     const { getToken } = await import("next-auth/jwt");


### PR DESCRIPTION
## The real root cause

The admin token *did* carry `groups:["admin"]` (verified) and `AuthContext` saw the admin correctly — yet the post-login middleware never landed them on `/admin`. Reason: the session JWT stores the Keycloak access/id/refresh tokens, pushing it well past the **4096-byte cookie limit**, so next-auth **chunks** the cookie into `__Secure-authjs.session-token.0`, `.1`, … The unchunked base cookie then doesn't exist.

`proxy.ts:readAuthToken` had a precheck that only looked for the **base** cookie name and early-returned `valid:false` when it was absent — so middleware treated the logged-in admin as anonymous and bounced them to `/auth/login` instead of `/admin`. `getToken`'s `SessionStore` already reassembles the chunks; the precheck just needed to also detect the first chunk (`<name>.0`).

This is why every layer looked correct in isolation:
- Keycloak token: has `groups:["admin"]` ✅
- `auth.ts` jwt/session callbacks: set groups ✅
- `AuthContext` / `api-auth.ts`: use server-side `auth()`, which reassembles chunks ✅
- **`proxy.ts` middleware: read the raw cookie and missed the chunks ❌ ← fixed here**

## Fix

Detect either the base cookie or the `.0` chunk before the `getToken` import; `getToken` reassembles the rest. Typecheck passes.

https://claude.ai/code/session_01WoLaMUxTAygraKUTy7JTT8

---
_Generated by [Claude Code](https://claude.ai/code/session_01WoLaMUxTAygraKUTy7JTT8)_