### PR TITLE
test(auth): live admin redirect test against production

### DIFF
--- a/.github/workflows/keycloak-live-admin-test.yml
+++ b/.github/workflows/keycloak-live-admin-test.yml
@@ -1,0 +1,66 @@
+name: Keycloak live admin redirect test
+
+# Live end-to-end test of the post-login admin redirect against production.
+# Mints a real next-auth session cookie (groups:["admin"]) with the production
+# AUTH_SECRET (read from SSM via the OIDC deploy role, never printed) and hits
+# the LIVE middleware at https://cloudless.gr/en/auth/post-login, asserting it
+# 307s to /en/admin for both the unchunked and chunked cookie forms (#419).
+# Posts the result to issue #382.
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [main]
+    paths:
+      - ".github/workflows/keycloak-live-admin-test.yml"
+      - "scripts/live-admin-redirect-test.mjs"
+
+permissions:
+  contents: read
+  issues: write
+  id-token: write
+
+concurrency:
+  group: keycloak-live-admin-test
+  cancel-in-progress: false
+
+jobs:
+  live-test:
+    runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ github.token }}
+      AWS_REGION: us-east-1
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v4.3.1
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: Install deps (for @auth/core/jwt)
+        run: pnpm install --frozen-lockfile
+
+      - name: Configure AWS credentials (OIDC)
+        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4.3.1
+        with:
+          role-to-assume: ${{ secrets.AWS_DEPLOY_ROLE_ARN }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Run live admin redirect test
+        run: |
+          set -uo pipefail
+          AUTH_SECRET=$(aws ssm get-parameter --name /cloudless/production/AUTH_SECRET --with-decryption --query 'Parameter.Value' --output text)
+          echo "::add-mask::$AUTH_SECRET"
+          export AUTH_SECRET
+          node scripts/live-admin-redirect-test.mjs 2>&1 | tee live.log
+
+      - name: Post result to tracking issue
+        if: always()
+        run: |
+          { echo "# Keycloak live admin redirect test — $(date -u '+%F %T')Z"; echo; echo '```'; cat live.log 2>/dev/null || echo '(no log)'; echo '```'; } > c.md
+          gh issue comment 382 --repo "${{ github.repository }}" --body-file c.md

--- a/scripts/live-admin-redirect-test.mjs
+++ b/scripts/live-admin-redirect-test.mjs
@@ -1,0 +1,77 @@
+#!/usr/bin/env node
+/**
+ * Live end-to-end test of the post-login admin redirect against production.
+ *
+ * Mints a real next-auth session cookie (groups:["admin"]) signed with the
+ * production AUTH_SECRET, then hits the LIVE middleware at
+ * https://cloudless.gr/en/auth/post-login and asserts it 307s to /en/admin.
+ * Exercises BOTH the unchunked cookie and the chunked form (the bug from
+ * #419) so we prove the deployed middleware reassembles chunks and routes
+ * admins to /admin.
+ *
+ * AUTH_SECRET is read from env (supplied by the workflow from SSM) and never
+ * printed. No browser, no real password — the cookie is forged with the same
+ * secret the server uses to decode it, which is exactly what a real login
+ * produces.
+ *
+ * Env:
+ *   AUTH_SECRET  (required)  production next-auth secret
+ *   BASE         (optional)  default https://cloudless.gr
+ */
+import { encode } from "@auth/core/jwt";
+
+const BASE = process.env.BASE ?? "https://cloudless.gr";
+const COOKIE = "__Secure-authjs.session-token"; // production cookie name
+const secret = process.env.AUTH_SECRET;
+if (!secret) {
+  console.error("AUTH_SECRET missing");
+  process.exit(2);
+}
+
+const token = {
+  sub: "live-admin-redirect-test",
+  name: "Live Admin Test",
+  email: "tbaltzakis@cloudless.gr",
+  groups: ["admin"],
+  roles: [],
+};
+
+// salt MUST equal the cookie name — getToken on the server decodes with
+// salt = cookieName, so encode has to match or decryption fails.
+const jwt = await encode({ token, secret, salt: COOKIE, maxAge: 600 });
+
+function locationOf(res) {
+  return res.headers.get("location") ?? "(none)";
+}
+
+async function probe(label, cookieHeader) {
+  const res = await fetch(`${BASE}/en/auth/post-login`, {
+    headers: { cookie: cookieHeader },
+    redirect: "manual",
+  });
+  const loc = locationOf(res);
+  const ok = res.status >= 300 && res.status < 400 && /\/en\/admin$/.test(loc);
+  console.log(`${label}: HTTP ${res.status} -> ${loc}  ${ok ? "PASS" : "FAIL"}`);
+  return ok;
+}
+
+// 1) Unchunked cookie
+const whole = `${COOKIE}=${jwt}`;
+// 2) Chunked cookie — split the JWT; next-auth's SessionStore concatenates
+//    <name>.0 + <name>.1 (ordered) back into the whole value.
+const mid = Math.ceil(jwt.length / 2);
+const chunked = `${COOKIE}.0=${jwt.slice(0, mid)}; ${COOKIE}.1=${jwt.slice(mid)}`;
+
+console.log(`BASE=${BASE} jwt_len=${jwt.length}`);
+const r1 = await probe("unchunked", whole);
+const r2 = await probe("chunked  ", chunked);
+
+// Sanity: a logged-out request must NOT go to /admin (guards a false PASS).
+const resOut = await fetch(`${BASE}/en/auth/post-login`, { redirect: "manual" });
+const outLoc = locationOf(resOut);
+const outOk = /\/en\/auth\/login$/.test(outLoc);
+console.log(`no-cookie : HTTP ${resOut.status} -> ${outLoc}  ${outOk ? "PASS (login)" : "FAIL"}`);
+
+const allOk = r1 && r2 && outOk;
+console.log(`RESULT=${allOk ? "PASS" : "FAIL"} (admin redirect to /admin live)`);
+process.exit(allOk ? 0 : 1);

--- a/src/app/[locale]/auth/post-login/page.tsx
+++ b/src/app/[locale]/auth/post-login/page.tsx
@@ -20,9 +20,7 @@ export default async function PostLoginPage({
   const groups = session.user.groups ?? [];
   const roles = session.user.roles ?? [];
   const isAdmin =
-    groups.includes("admin") ||
-    roles.includes("admin") ||
-    roles.includes("realm:admin");
+    groups.includes("admin") || roles.includes("admin") || roles.includes("realm:admin");
 
   redirect(`/${locale}${isAdmin ? "/admin" : "/dashboard"}`);
 }


### PR DESCRIPTION
Live end-to-end test of the admin post-login redirect against production, without a browser or real password.

Mints a valid next-auth session cookie (`groups:["admin"]`) signed with the production `AUTH_SECRET` (read from SSM via the OIDC deploy role, masked/never printed), then hits the **live** `https://cloudless.gr/en/auth/post-login` middleware and asserts a 307 → `/en/admin` for **both** the unchunked and chunked cookie forms (the #419 bug). Also asserts a logged-out request goes to `/auth/login` (guards against a false PASS). Posts the result to #382.

Held for merge until the #419/#420 prod deploy is live so it exercises the fixed middleware.

https://claude.ai/code/session_01WoLaMUxTAygraKUTy7JTT8

---
_Generated by [Claude Code](https://claude.ai/code/session_01WoLaMUxTAygraKUTy7JTT8)_