### PR TITLE
fix(profile): save profile via same-origin route (fix "Failed to fetch")

### DIFF
--- a/__tests__/user-profile-api.test.ts
+++ b/__tests__/user-profile-api.test.ts
@@ -1,0 +1,91 @@
+/**
+ * /api/user/profile — updates the signed-in user's Keycloak profile through a
+ * same-origin server route (the browser cannot call Keycloak's Account API
+ * directly due to CORS → "Failed to fetch"). These tests verify the auth gate
+ * and that name → firstName/lastName + company/phone attributes are sent to
+ * Keycloak's Account API, merging existing attributes rather than clobbering.
+ *
+ * @vitest-environment node
+ */
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+const authMock = vi.fn();
+vi.mock("@/lib/auth", () => ({ auth: authMock }));
+
+function makeReq(body: unknown): Request {
+  return new Request("http://localhost/api/user/profile", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+beforeEach(() => {
+  authMock.mockReset();
+  vi.restoreAllMocks();
+  // setup.ts deletes KEYCLOAK_ISSUER in its beforeEach; restore it here.
+  vi.stubEnv("KEYCLOAK_ISSUER", "https://auth.test/realms/master");
+});
+
+describe("POST /api/user/profile", () => {
+  it("401 when there is no session/accessToken", async () => {
+    authMock.mockResolvedValue(null);
+    const { POST } = await import("@/app/api/user/profile/route");
+    const res = await POST(makeReq({ name: "A B" }));
+    expect(res.status).toBe(401);
+  });
+
+  it("updates name + attributes and merges existing attributes", async () => {
+    authMock.mockResolvedValue({ user: { id: "u1" }, accessToken: "tok-abc" });
+
+    const fetchMock = vi
+      .spyOn(globalThis, "fetch")
+      // 1) GET current account (existing attributes to merge)
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            firstName: "Old",
+            lastName: "Name",
+            email: "u@x.gr",
+            attributes: { locale: ["en"] },
+          }),
+          { status: 200 }
+        )
+      )
+      // 2) POST update
+      .mockResolvedValueOnce(new Response(null, { status: 204 }));
+
+    const { POST } = await import("@/app/api/user/profile/route");
+    const res = await POST(
+      makeReq({ name: "Baltzakis Themistoklis", company: "cloudless.gr", phone: "+30123" })
+    );
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ ok: true });
+
+    // Inspect the POST call (2nd fetch).
+    const [url, init] = fetchMock.mock.calls[1];
+    expect(url).toBe("https://auth.test/realms/master/account");
+    expect((init as RequestInit).method).toBe("POST");
+    const sent = JSON.parse((init as RequestInit).body as string);
+    expect(sent.firstName).toBe("Baltzakis");
+    expect(sent.lastName).toBe("Themistoklis");
+    expect(sent.attributes).toMatchObject({
+      locale: ["en"], // merged, not clobbered
+      company: ["cloudless.gr"],
+      phone: ["+30123"],
+    });
+  });
+
+  it("surfaces Keycloak validation errors instead of an opaque failure", async () => {
+    authMock.mockResolvedValue({ user: { id: "u1" }, accessToken: "tok-abc" });
+    vi.spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(new Response(JSON.stringify({ attributes: {} }), { status: 200 }))
+      .mockResolvedValueOnce(new Response("attribute not supported", { status: 400 }));
+
+    const { POST } = await import("@/app/api/user/profile/route");
+    const res = await POST(makeReq({ company: "x" }));
+    expect(res.status).toBe(400);
+    expect((await res.json()).error).toMatch(/Failed to update profile/);
+  });
+});

--- a/src/app/api/user/profile/route.ts
+++ b/src/app/api/user/profile/route.ts
@@ -1,0 +1,109 @@
+import { NextResponse } from "next/server";
+import { auth } from "@/lib/auth";
+
+export const dynamic = "force-dynamic";
+
+interface ProfileBody {
+  name?: string;
+  company?: string;
+  phone?: string;
+  preferences?: unknown;
+}
+
+type KcAttributes = Record<string, string[]>;
+interface KcAccount {
+  firstName?: string;
+  lastName?: string;
+  email?: string;
+  attributes?: KcAttributes;
+}
+
+function splitName(name: string): { firstName: string; lastName?: string } {
+  const [first, ...rest] = name.trim().split(/\s+/);
+  return { firstName: first ?? "", lastName: rest.length ? rest.join(" ") : undefined };
+}
+
+/**
+ * POST /api/user/profile
+ *
+ * Updates the signed-in user's Keycloak profile (name + company/phone
+ * attributes, and optional preferences). This MUST run server-side: the
+ * browser cannot call Keycloak's Account REST API directly because that is a
+ * cross-origin request (cloudless.gr → auth.cloudless.gr) which Keycloak does
+ * not send CORS headers for — the browser blocks it and the client sees the
+ * opaque "Failed to fetch". Server→Keycloak has no CORS constraint, and the
+ * user's access_token (aud: account) is accepted by the Account API.
+ */
+export async function POST(req: Request) {
+  const session = await auth();
+  const accessToken = session?.accessToken;
+  if (!session?.user || !accessToken) {
+    return NextResponse.json({ error: "Not authenticated" }, { status: 401 });
+  }
+
+  const KC_ISSUER = process.env.KEYCLOAK_ISSUER ?? process.env.NEXT_PUBLIC_KEYCLOAK_ISSUER ?? "";
+  if (!KC_ISSUER) {
+    return NextResponse.json({ error: "Auth not configured" }, { status: 500 });
+  }
+
+  let body: ProfileBody;
+  try {
+    body = (await req.json()) as ProfileBody;
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+
+  const accountUrl = `${KC_ISSUER}/account`;
+  const authHeader = { Authorization: `Bearer ${accessToken}` };
+
+  // Read the current account so we merge (not clobber) existing attributes.
+  let current: KcAccount = {};
+  try {
+    const res = await globalThis.fetch(accountUrl, {
+      headers: { ...authHeader, Accept: "application/json" },
+    });
+    if (res.ok) current = (await res.json()) as KcAccount;
+  } catch {
+    // fall through with empty current; the POST below is the source of truth
+  }
+
+  const attributes: KcAttributes = { ...(current.attributes ?? {}) };
+  if (body.company !== undefined) attributes.company = [body.company];
+  if (body.phone !== undefined && body.phone !== "") attributes.phone = [body.phone];
+  else if (body.phone === "") delete attributes.phone;
+  if (body.preferences !== undefined) {
+    attributes.preferences = [JSON.stringify(body.preferences)];
+  }
+
+  const payload: KcAccount = {
+    firstName: current.firstName,
+    lastName: current.lastName,
+    email: current.email,
+    attributes,
+  };
+  if (body.name) {
+    const { firstName, lastName } = splitName(body.name);
+    payload.firstName = firstName;
+    payload.lastName = lastName;
+  }
+
+  try {
+    const res = await globalThis.fetch(accountUrl, {
+      method: "POST",
+      headers: { ...authHeader, "Content-Type": "application/json" },
+      body: JSON.stringify(payload),
+    });
+    if (res.ok) {
+      return NextResponse.json({ ok: true });
+    }
+    // Surface Keycloak's validation message (e.g. an attribute not allowed by
+    // the realm user profile) instead of an opaque failure.
+    const detail = await res.text().catch(() => "");
+    return NextResponse.json(
+      { error: "Failed to update profile", status: res.status, detail: detail.slice(0, 500) },
+      { status: res.status === 400 ? 400 : 502 }
+    );
+  } catch {
+    return NextResponse.json({ error: "Failed to reach auth server" }, { status: 502 });
+  }
+}

--- a/src/context/AuthContext.tsx
+++ b/src/context/AuthContext.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { createContext, useContext, useState, useEffect, useCallback, type ReactNode } from "react";
-import { signIn as nextAuthSignIn, signOut as nextAuthSignOut, getSession } from "next-auth/react";
+import { signIn as nextAuthSignIn, signOut as nextAuthSignOut } from "next-auth/react";
 
 interface UserPreferences {
   theme: "system" | "dark" | "light";
@@ -199,30 +199,19 @@ export function AuthProvider({ children }: AuthProviderProps) {
     company?: string;
     phone?: string;
   }) => {
-    const session = await getSession();
-    if (!session?.accessToken) throw new Error("Not authenticated");
-
-    const issuer = process.env.NEXT_PUBLIC_KEYCLOAK_ISSUER ?? "";
-    const body: Record<string, unknown> = {};
-    if (attrs.name) {
-      const [first, ...rest] = attrs.name.split(" ");
-      body.firstName = first;
-      if (rest.length) body.lastName = rest.join(" ");
-    }
-    if (attrs.phone) body.attributes = { phone: [attrs.phone] };
-    if (attrs.company) {
-      body.attributes = { ...(body.attributes as object), company: [attrs.company] };
-    }
-
-    const res = await globalThis.fetch(`${issuer}/account`, {
+    // Go through our own same-origin API route. A direct browser fetch to
+    // Keycloak's Account API (auth.cloudless.gr) is cross-origin and is blocked
+    // by CORS → the opaque "Failed to fetch". The server route uses the user's
+    // access token to update Keycloak with no CORS constraint.
+    const res = await globalThis.fetch("/api/user/profile", {
       method: "POST",
-      headers: {
-        Authorization: `Bearer ${session.accessToken as string}`,
-        "Content-Type": "application/json",
-      },
-      body: JSON.stringify(body),
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(attrs),
     });
-    if (!res.ok) throw new Error(`Failed to update profile: ${res.status}`);
+    if (!res.ok) {
+      const data = (await res.json().catch(() => null)) as { error?: string } | null;
+      throw new Error(data?.error ?? `Failed to update profile: ${res.status}`);
+    }
 
     setUser((prev) =>
       prev
@@ -242,20 +231,12 @@ export function AuthProvider({ children }: AuthProviderProps) {
       ...prefs,
     };
     setUser((prev) => (prev ? { ...prev, preferences: merged } : prev));
-    // Persist to Keycloak user attributes if possible
+    // Persist via our same-origin route (browser → Keycloak is CORS-blocked).
     try {
-      const session = await getSession();
-      if (!session?.accessToken) return;
-      const issuer = process.env.NEXT_PUBLIC_KEYCLOAK_ISSUER ?? "";
-      await globalThis.fetch(`${issuer}/account`, {
+      await globalThis.fetch("/api/user/profile", {
         method: "POST",
-        headers: {
-          Authorization: `Bearer ${session.accessToken as string}`,
-          "Content-Type": "application/json",
-        },
-        body: JSON.stringify({
-          attributes: { preferences: [JSON.stringify(merged)] },
-        }),
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ preferences: merged }),
       });
     } catch {
       // Non-fatal — preferences are kept in local state


### PR DESCRIPTION
## The bug in the screenshot

The dashboard **profile** page showed **"Failed to fetch"** on Save. `AuthContext.updateProfile` (and `updatePreferences`) called Keycloak's Account API directly from the **browser**:

```ts
fetch(`${NEXT_PUBLIC_KEYCLOAK_ISSUER}/account`, { method: "POST", headers: { Authorization: `Bearer …` } })
```

That's a cross-origin request (`cloudless.gr` → `auth.cloudless.gr`). Keycloak's Account API doesn't return CORS headers for `cloudless.gr`, so the browser blocks the preflight and the client gets the opaque `TypeError: Failed to fetch` — it never reaches the server, so it's not a 401/403.

## Fix

New same-origin route **`POST /api/user/profile`** that runs server-side (no browser CORS) and uses the user's access token (`aud: account`) to update Keycloak's Account API. It:
- merges existing attributes (doesn't clobber),
- maps `name` → `firstName`/`lastName`, writes `company`/`phone`,
- surfaces Keycloak validation errors instead of an opaque failure.

`AuthContext.updateProfile`/`updatePreferences` now POST to this route.

## Verification
- **Live, server-side**: `GET /account` → **200**, `POST /account` (name + company + phone) → **204** with the real user token. The blocker really was browser CORS.
- Unit tests: auth gate (401), attribute merge + name split, and error surfacing. tsc/lint/prettier clean.

https://claude.ai/code/session_01WoLaMUxTAygraKUTy7JTT8

---
_Generated by [Claude Code](https://claude.ai/code/session_01WoLaMUxTAygraKUTy7JTT8)_