### PR TITLE
fix(dashboard): Stripe purchases gate (SSM) + declare company/phone profile attrs

### DIFF
--- a/.github/workflows/keycloak-profile-attrs.yml
+++ b/.github/workflows/keycloak-profile-attrs.yml
@@ -1,0 +1,51 @@
+name: Keycloak declare profile attrs (company, phone)
+
+# Declares `company` and `phone` in the realm's declarative user profile so the
+# website personalization page can persist them (Keycloak 26 silently drops
+# undeclared attributes on write). Idempotent. Posts result to issue #382.
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [main]
+    paths:
+      - ".github/workflows/keycloak-profile-attrs.yml"
+      - "scripts/keycloak-add-profile-attrs.sh"
+
+permissions:
+  contents: read
+  issues: write
+
+concurrency:
+  group: keycloak-profile-attrs
+  cancel-in-progress: false
+
+jobs:
+  declare:
+    runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ github.token }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v4.3.1
+
+      - name: Connect to tailnet
+        uses: tailscale/github-action@0263d9e6d793eaefcf1de98ff7fde47abe6664d3 # v3.2.4
+        with:
+          authkey: ${{ secrets.TS_AUTHKEY }}
+
+      - name: Configure kubectl
+        run: |
+          mkdir -p ~/.kube
+          echo "${{ secrets.KUBECONFIG_B64 }}" | base64 -d > ~/.kube/config
+          chmod 600 ~/.kube/config
+
+      - name: Declare company + phone in user profile
+        run: |
+          set -uo pipefail
+          bash scripts/keycloak-add-profile-attrs.sh 2>&1 | tee attrs.log
+
+      - name: Post result to tracking issue
+        if: always()
+        run: |
+          { echo "# Keycloak profile attrs — $(date -u '+%F %T')Z"; echo; echo '```'; cat attrs.log 2>/dev/null || echo '(no log)'; echo '```'; } > c.md
+          gh issue comment 382 --repo "${{ github.repository }}" --body-file c.md

--- a/scripts/keycloak-add-profile-attrs.sh
+++ b/scripts/keycloak-add-profile-attrs.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+#
+# keycloak-add-profile-attrs.sh — declare `company` and `phone` in the realm's
+# declarative user profile so the website personalization page can persist them.
+#
+# Keycloak 26 only stores attributes that are declared in the user profile; an
+# undeclared attribute is silently dropped on write (the Account API returns
+# 200/204 but nothing persists). firstName/lastName are built-ins and already
+# work; company/phone need declaring with user-edit permission.
+#
+# Runs on a CI runner with kubectl (the keycloak image has no jq/python, so we
+# GET the profile out of the pod, edit it here, and PUT it back via kcadm -f).
+set -uo pipefail
+NS="${NS:-keycloak}"; DEP="${DEP:-keycloak}"; RL="${RL:-master}"
+command -v kubectl >/dev/null 2>&1 || { echo "kubectl not found"; exit 1; }
+command -v python3 >/dev/null 2>&1 || { echo "python3 not found"; exit 1; }
+POD=$(kubectl -n "$NS" get pod -l app="$DEP" -o jsonpath='{.items[0].metadata.name}' 2>/dev/null)
+[ -n "$POD" ] || { echo "no $DEP pod"; exit 1; }
+
+# kcadm auth, run inside the pod (admin password never leaves the cluster).
+KCAUTH='AU="${KEYCLOAK_ADMIN:-${KC_BOOTSTRAP_ADMIN_USERNAME:-admin}}"; AP="${KEYCLOAK_ADMIN_PASSWORD:-${KC_BOOTSTRAP_ADMIN_PASSWORD:-}}"; /opt/keycloak/bin/kcadm.sh config credentials --server http://localhost:8080 --realm master --user "$AU" --password "$AP" >/dev/null 2>&1 || { echo ADMIN_AUTH=failed; exit 7; }'
+
+echo "== 1) GET current user profile =="
+kubectl -n "$NS" exec "$POD" -- bash -c "$KCAUTH; /opt/keycloak/bin/kcadm.sh get users/profile -r $RL" > /tmp/profile.json || { echo "GET failed"; exit 1; }
+python3 -c "import json;d=json.load(open('/tmp/profile.json'));print('current attrs:',[a.get('name') for a in d.get('attributes',[])])" || { echo "profile parse failed"; cat /tmp/profile.json; exit 1; }
+
+echo "== 2) ensure company + phone are declared =="
+python3 - > /tmp/profile.new.json 2>/tmp/changed <<'PY'
+import json, sys
+d = json.load(open("/tmp/profile.json"))
+attrs = d.setdefault("attributes", [])
+names = {a.get("name") for a in attrs}
+def mk(name, display):
+    return {
+        "name": name,
+        "displayName": display,
+        "permissions": {"view": ["user", "admin"], "edit": ["user", "admin"]},
+        "multivalued": False,
+        "validations": {},
+    }
+changed = False
+for n, disp in [("phone", "Phone"), ("company", "Company")]:
+    if n not in names:
+        attrs.append(mk(n, disp)); changed = True
+print(json.dumps(d))
+sys.stderr.write("CHANGED" if changed else "NOCHANGE")
+PY
+CHG=$(cat /tmp/changed)
+echo "decision: $CHG"
+if [ "$CHG" = "NOCHANGE" ]; then
+  echo "RESULT=PASS (company + phone already declared)"
+  exit 0
+fi
+
+echo "== 3) PUT updated profile =="
+kubectl -n "$NS" exec -i "$POD" -- bash -c "$KCAUTH; cat > /tmp/p.json; /opt/keycloak/bin/kcadm.sh update users/profile -r $RL -f /tmp/p.json && echo UPDATE_OK || echo UPDATE_FAIL" < /tmp/profile.new.json
+
+echo "== 4) verify =="
+kubectl -n "$NS" exec "$POD" -- bash -c "$KCAUTH; /opt/keycloak/bin/kcadm.sh get users/profile -r $RL" \
+  | python3 -c "import sys,json;d=json.load(sys.stdin);n=[a.get('name') for a in d.get('attributes',[])];print('final attrs:',n);print('RESULT=PASS' if ('phone' in n and 'company' in n) else 'RESULT=FAIL')"

--- a/src/app/api/user/purchases/route.ts
+++ b/src/app/api/user/purchases/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
-import { isConfigured } from "@/lib/integrations";
+import { isConfiguredAsync } from "@/lib/integrations";
 import type Stripe from "stripe";
 import { getStripe } from "@/lib/stripe";
 import { requireAuth } from "@/lib/api-auth";
@@ -22,7 +22,11 @@ export async function GET(req: NextRequest) {
     return NextResponse.json({ error: "No email in token" }, { status: 400 });
   }
 
-  if (!isConfigured("STRIPE_SECRET_KEY")) {
+  // Use the SSM-aware async check: on Lambda/Pi the Stripe keys live in SSM
+  // (fetched at runtime), not process.env, so the sync isConfigured() would
+  // wrongly report "not configured" and the page shows "Payment system is
+  // being set up" even though Stripe works.
+  if (!(await isConfiguredAsync("STRIPE_SECRET_KEY"))) {
     return NextResponse.json({ error: "Stripe not configured" }, { status: 503 });
   }
 


### PR DESCRIPTION
## Two dashboard fixes

### 1. "Stripe not configured" on the Purchases page
`/api/user/purchases` gated on the **sync** `isConfigured("STRIPE_SECRET_KEY")`, which reads only `process.env`. On Lambda/Pi the Stripe keys live in **SSM** (fetched at runtime), so the gate falsely returned 503 → the page showed *"Payment system is being set up"*.

Verified live that Stripe **is** configured server-side: `/api/admin/orders` returns real checkout sessions. So this is purely the sync-vs-async gate bug. Switched to the SSM-aware `isConfiguredAsync()` (the documented choice for API routes; `getStripe()` already uses SSM).

### 2. Personalization: company/phone didn't persist
Keycloak 26 uses a declarative user profile and silently drops attributes that aren't declared (firstName/lastName are built-ins and already saved; company/phone were dropped). Adds `keycloak:profile-attrs` (workflow + `scripts/keycloak-add-profile-attrs.sh`) to declare `company` and `phone` as user-editable. Idempotent; posts to #382.

## Verification
- Stripe: confirmed server-side Stripe works (admin/orders live). tsc/lint/prettier clean.
- Profile attrs: runs on merge; verifies the final attribute list includes phone+company.

https://claude.ai/code/session_01WoLaMUxTAygraKUTy7JTT8

---
_Generated by [Claude Code](https://claude.ai/code/session_01WoLaMUxTAygraKUTy7JTT8)_