### PR TITLE
fix(profile): restore admin email + never clobber email on save

### DIFF
--- a/.github/workflows/keycloak-set-email.yml
+++ b/.github/workflows/keycloak-set-email.yml
@@ -1,0 +1,62 @@
+name: Keycloak set admin email
+
+# Ensures the admin Keycloak user has its email set + verified (a blank email
+# blocks email-keyed features like the purchases lookup). Idempotent. Posts to #382.
+
+on:
+  workflow_dispatch:
+    inputs:
+      username:
+        description: "Keycloak username"
+        required: false
+        default: "tbaltzakis@cloudless.gr"
+      email:
+        description: "Email to set"
+        required: false
+        default: "tbaltzakis@cloudless.gr"
+  push:
+    branches: [main]
+    paths:
+      - ".github/workflows/keycloak-set-email.yml"
+      - "scripts/keycloak-set-admin-email.sh"
+
+permissions:
+  contents: read
+  issues: write
+
+concurrency:
+  group: keycloak-set-email
+  cancel-in-progress: false
+
+jobs:
+  set-email:
+    runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ github.token }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v4.3.1
+
+      - name: Connect to tailnet
+        uses: tailscale/github-action@0263d9e6d793eaefcf1de98ff7fde47abe6664d3 # v3.2.4
+        with:
+          authkey: ${{ secrets.TS_AUTHKEY }}
+
+      - name: Configure kubectl
+        run: |
+          mkdir -p ~/.kube
+          echo "${{ secrets.KUBECONFIG_B64 }}" | base64 -d > ~/.kube/config
+          chmod 600 ~/.kube/config
+
+      - name: Set admin email
+        env:
+          USERNAME: ${{ github.event.inputs.username || 'tbaltzakis@cloudless.gr' }}
+          EMAIL: ${{ github.event.inputs.email || 'tbaltzakis@cloudless.gr' }}
+        run: |
+          set -uo pipefail
+          bash scripts/keycloak-set-admin-email.sh 2>&1 | tee email.log
+
+      - name: Post result to tracking issue
+        if: always()
+        run: |
+          { echo "# Keycloak set admin email — $(date -u '+%F %T')Z"; echo; echo '```'; cat email.log 2>/dev/null || echo '(no log)'; echo '```'; } > c.md
+          gh issue comment 382 --repo "${{ github.repository }}" --body-file c.md

--- a/scripts/keycloak-set-admin-email.sh
+++ b/scripts/keycloak-set-admin-email.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+#
+# keycloak-set-admin-email.sh — ensure a Keycloak user has its email set +
+# verified. The website keys several features (purchases lookup, calendar) off
+# the user's email claim; a blank email blocks them. Idempotent.
+#
+# Runs kcadm inside the keycloak pod (admin password never leaves the cluster).
+set -uo pipefail
+NS="${NS:-keycloak}"; DEP="${DEP:-keycloak}"; RL="${RL:-master}"
+USERNAME="${USERNAME:-tbaltzakis@cloudless.gr}"
+EMAIL="${EMAIL:-tbaltzakis@cloudless.gr}"
+command -v kubectl >/dev/null 2>&1 || { echo "kubectl not found"; exit 1; }
+POD=$(kubectl -n "$NS" get pod -l app="$DEP" -o jsonpath='{.items[0].metadata.name}' 2>/dev/null)
+[ -n "$POD" ] || { echo "no $DEP pod"; exit 1; }
+
+kubectl -n "$NS" exec -i "$POD" -- env RL="$RL" NU="$USERNAME" EM="$EMAIL" bash -s <<'EOS'
+set -u
+K=/opt/keycloak/bin/kcadm.sh
+AU="${KEYCLOAK_ADMIN:-${KC_BOOTSTRAP_ADMIN_USERNAME:-admin}}"
+AP="${KEYCLOAK_ADMIN_PASSWORD:-${KC_BOOTSTRAP_ADMIN_PASSWORD:-}}"
+$K config credentials --server http://localhost:8080 --realm master --user "$AU" --password "$AP" >/dev/null 2>&1 || { echo "ADMIN_AUTH=failed"; exit 7; }
+# NB: $UID is a bash readonly builtin — use USERID.
+USERID=$($K get users -r "$RL" -q username="$NU" --fields id --format csv --noquotes | head -1)
+[ -n "$USERID" ] || { echo "USER_NOT_FOUND=$NU"; exit 1; }
+echo "user=$NU id=$USERID"
+echo -n "before: "; $K get "users/$USERID" -r "$RL" --fields email,emailVerified --format csv --noquotes
+$K update "users/$USERID" -r "$RL" -s "email=$EM" -s 'emailVerified=true' && echo "SET_OK" || echo "SET_FAIL"
+echo -n "after:  "; $K get "users/$USERID" -r "$RL" --fields email,emailVerified --format csv --noquotes
+echo -n "RESULT="; $K get "users/$USERID" -r "$RL" --fields email --format csv --noquotes | grep -qi "$EM" && echo "PASS" || echo "FAIL"
+EOS

--- a/src/app/api/user/profile/route.ts
+++ b/src/app/api/user/profile/route.ts
@@ -56,16 +56,28 @@ export async function POST(req: Request) {
   const accountUrl = `${KC_ISSUER}/account`;
   const authHeader = { Authorization: `Bearer ${accessToken}` };
 
-  // Read the current account so we merge (not clobber) existing attributes.
-  let current: KcAccount = {};
+  // Read the current account FIRST so we merge (not clobber) existing fields.
+  // The Account API POST is a full update — omitting email/attributes can blank
+  // them — so if we can't read the current state we must NOT write.
+  let current: KcAccount;
   try {
     const res = await globalThis.fetch(accountUrl, {
       headers: { ...authHeader, Accept: "application/json" },
     });
-    if (res.ok) current = (await res.json()) as KcAccount;
+    if (!res.ok) {
+      return NextResponse.json(
+        { error: "Could not read current profile", status: res.status },
+        { status: 502 }
+      );
+    }
+    current = (await res.json()) as KcAccount;
   } catch {
-    // fall through with empty current; the POST below is the source of truth
+    return NextResponse.json({ error: "Could not reach auth server" }, { status: 502 });
   }
+
+  // Never blank the email: it is read-only in the UI, so always preserve it
+  // (fall back to the session's email if the account representation omits it).
+  const preservedEmail = current.email ?? session.user.email ?? undefined;
 
   const attributes: KcAttributes = { ...(current.attributes ?? {}) };
   if (body.company !== undefined) attributes.company = [body.company];
@@ -78,7 +90,7 @@ export async function POST(req: Request) {
   const payload: KcAccount = {
     firstName: current.firstName,
     lastName: current.lastName,
-    email: current.email,
+    email: preservedEmail,
     attributes,
   };
   if (body.name) {


### PR DESCRIPTION
## Restores the admin's email + prevents future blanking

While verifying the purchases fix I found the Keycloak user `tbaltzakis@cloudless.gr` had a **blank email** (the username is email-like but the email field was empty; `email_verified:false`). The purchases page only fetches when `user.email` is set, so this blocks it — and it was most likely blanked by an early bare Account-API write during my testing.

- **`keycloak:set-email`** (workflow + `scripts/keycloak-set-admin-email.sh`): sets + verifies the user's email via kcadm in-pod. Idempotent. Posts to #382.
- **Hardened `/api/user/profile`**: now reads the current account **first** and refuses to write if it can't (the Account API POST is a full update — a partial write blanks fields), and always preserves the existing email (read-only in the UI, with a session fallback).

Route unit tests still pass; tsc/lint/prettier clean.

https://claude.ai/code/session_01WoLaMUxTAygraKUTy7JTT8

---
_Generated by [Claude Code](https://claude.ai/code/session_01WoLaMUxTAygraKUTy7JTT8)_