### PR TITLE
fix(admin): subscriptions 500 — Stripe expand exceeded 4 levels

### DIFF
--- a/src/app/api/admin/subscriptions/route.ts
+++ b/src/app/api/admin/subscriptions/route.ts
@@ -31,7 +31,11 @@ export async function GET(request: NextRequest) {
       status:
         status === "all" ? undefined : (status as "active" | "past_due" | "canceled" | "trialing"),
       limit,
-      expand: ["data.customer", "data.items.data.price.product"],
+      // Stripe allows expanding at most 4 levels deep. "data.items.data.price"
+      // is already 4 (data→items→data→price); adding ".product" makes 5 and
+      // Stripe rejects the whole request → the list 500s. Stop at price and
+      // fall back to price.nickname for the plan name below.
+      expand: ["data.customer", "data.items.data.price"],
     });
 
     const subscriptions: AdminSubscription[] = subs.data.map((sub) => {


### PR DESCRIPTION
Found via a live admin-API sweep: `/admin/subscriptions` returned 500 "Failed to fetch subscriptions".

Cause: `stripe.subscriptions.list` expanded `data.items.data.price.product` — **5 levels**, but Stripe caps `expand` at **4 levels**, so it rejected the whole request. (Orders works because it expands only 2 levels.) Fixed by expanding to `data.items.data.price` (4) and falling back to `price.nickname` for the plan name (the code already had that fallback).

tsc/lint/prettier clean. Will verify live (`/admin/subscriptions` → 200) after deploy.

https://claude.ai/code/session_01WoLaMUxTAygraKUTy7JTT8

---
_Generated by [Claude Code](https://claude.ai/code/session_01WoLaMUxTAygraKUTy7JTT8)_