### PR TITLE
fix(admin): /admin/users via least-privilege Keycloak service account

### DIFF
--- a/.github/workflows/keycloak-admin-api-client.yml
+++ b/.github/workflows/keycloak-admin-api-client.yml
@@ -1,0 +1,60 @@
+name: Keycloak admin-api service client
+
+# Creates/ensures the least-privilege `cloudless-admin-api` Keycloak client
+# (service account: view-users/query-users/query-groups) and writes its secret
+# to SSM so /api/admin/users can list users without the master admin password.
+# Posts result to #382. The client secret is masked and never logged/posted.
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [main]
+    paths:
+      - ".github/workflows/keycloak-admin-api-client.yml"
+      - "scripts/keycloak-create-admin-api-client.sh"
+
+permissions:
+  contents: read
+  issues: write
+  id-token: write
+
+concurrency:
+  group: keycloak-admin-api-client
+  cancel-in-progress: false
+
+jobs:
+  ensure:
+    runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ github.token }}
+      AWS_REGION: us-east-1
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v4.3.1
+
+      - name: Connect to tailnet
+        uses: tailscale/github-action@0263d9e6d793eaefcf1de98ff7fde47abe6664d3 # v3.2.4
+        with:
+          authkey: ${{ secrets.TS_AUTHKEY }}
+
+      - name: Configure kubectl
+        run: |
+          mkdir -p ~/.kube
+          echo "${{ secrets.KUBECONFIG_B64 }}" | base64 -d > ~/.kube/config
+          chmod 600 ~/.kube/config
+
+      - name: Configure AWS credentials (OIDC, for SSM write)
+        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4.3.1
+        with:
+          role-to-assume: ${{ secrets.AWS_DEPLOY_ROLE_ARN }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Create admin-api client + write SSM
+        run: |
+          set -uo pipefail
+          bash scripts/keycloak-create-admin-api-client.sh 2>&1 | tee client.log
+
+      - name: Post result to tracking issue
+        if: always()
+        run: |
+          { echo "# Keycloak admin-api client — $(date -u '+%F %T')Z"; echo; echo '```'; cat client.log 2>/dev/null || echo '(no log)'; echo '```'; } > c.md
+          gh issue comment 382 --repo "${{ github.repository }}" --body-file c.md

--- a/scripts/keycloak-create-admin-api-client.sh
+++ b/scripts/keycloak-create-admin-api-client.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+#
+# keycloak-create-admin-api-client.sh — create/ensure a least-privilege Keycloak
+# service-account client the website uses to list users in the admin panel.
+#
+# Why: /api/admin/users needs a Keycloak admin token. Using the master admin
+# password from the app is over-privileged; instead we use a confidential
+# client (cloudless-admin-api) whose service account holds ONLY view-users /
+# query-users / query-groups. Its secret is written to SSM so the app reads it
+# at runtime (KEYCLOAK_ADMIN_CLIENT_ID / KEYCLOAK_ADMIN_CLIENT_SECRET).
+#
+# Runs kcadm inside the keycloak pod (admin password never leaves the cluster)
+# and writes SSM from the CI runner (OIDC creds). The client secret is captured
+# silently and masked — never printed to logs or posted anywhere.
+set -uo pipefail
+NS="${NS:-keycloak}"; DEP="${DEP:-keycloak}"; RL="${RL:-master}"
+CID="${CID:-cloudless-admin-api}"
+SSM_PREFIX="${SSM_PREFIX:-/cloudless/production}"
+command -v kubectl >/dev/null 2>&1 || { echo "kubectl not found"; exit 1; }
+command -v aws >/dev/null 2>&1 || { echo "aws not found"; exit 1; }
+POD=$(kubectl -n "$NS" get pod -l app="$DEP" -o jsonpath='{.items[0].metadata.name}' 2>/dev/null)
+[ -n "$POD" ] || { echo "no $DEP pod"; exit 1; }
+
+echo "== 1) ensure client + service-account roles (in-pod) =="
+kubectl -n "$NS" exec -i "$POD" -- env RL="$RL" CID="$CID" bash -s <<'EOS'
+set -u
+K=/opt/keycloak/bin/kcadm.sh
+AU="${KEYCLOAK_ADMIN:-${KC_BOOTSTRAP_ADMIN_USERNAME:-admin}}"
+AP="${KEYCLOAK_ADMIN_PASSWORD:-${KC_BOOTSTRAP_ADMIN_PASSWORD:-}}"
+$K config credentials --server http://localhost:8080 --realm master --user "$AU" --password "$AP" >/dev/null 2>&1 || { echo "ADMIN_AUTH=failed"; exit 7; }
+EXIST=$($K get clients -r "$RL" -q clientId="$CID" --fields id --format csv --noquotes | head -1)
+if [ -z "$EXIST" ]; then
+  $K create clients -r "$RL" \
+    -s clientId="$CID" -s enabled=true -s publicClient=false \
+    -s serviceAccountsEnabled=true -s standardFlowEnabled=false \
+    -s directAccessGrantsEnabled=false \
+    -s 'description=Least-privilege service account for admin user-management API' >/dev/null 2>&1 \
+    && echo "client created" || echo "client create failed"
+else
+  echo "client already exists ($EXIST)"
+fi
+# Grant ONLY the read roles needed to list/search users + groups.
+$K add-roles -r "$RL" --uusername "service-account-$CID" --cclientid realm-management \
+  --rolename view-users --rolename query-users --rolename query-groups --rolename view-groups >/dev/null 2>&1 \
+  && echo "roles granted" || echo "roles grant (already present or partial)"
+echo -n "effective realm-management roles: "
+$K get-roles -r "$RL" --uusername "service-account-$CID" --cclientid realm-management --effective --fields name --format csv --noquotes 2>/dev/null | tr '\n' ' '
+echo
+EOS
+
+echo "== 2) capture client secret (silent) =="
+SECRET=$(kubectl -n "$NS" exec -i "$POD" -- env RL="$RL" CID="$CID" bash -s <<'EOS'
+K=/opt/keycloak/bin/kcadm.sh
+AU="${KEYCLOAK_ADMIN:-${KC_BOOTSTRAP_ADMIN_USERNAME:-admin}}"
+AP="${KEYCLOAK_ADMIN_PASSWORD:-${KC_BOOTSTRAP_ADMIN_PASSWORD:-}}"
+$K config credentials --server http://localhost:8080 --realm master --user "$AU" --password "$AP" >/dev/null 2>&1
+UUID=$($K get clients -r "$RL" -q clientId="$CID" --fields id --format csv --noquotes | head -1)
+$K get "clients/$UUID/client-secret" -r "$RL" | grep -o '"value"[^,}]*' | head -1 | cut -d'"' -f4
+EOS
+)
+echo "::add-mask::$SECRET"
+if [ -z "$SECRET" ]; then echo "RESULT=FAIL (no client secret)"; exit 1; fi
+echo "secret captured (len ${#SECRET}, masked)"
+
+echo "== 3) write SSM (id + secret) =="
+aws ssm put-parameter --name "$SSM_PREFIX/KEYCLOAK_ADMIN_CLIENT_ID" --value "$CID" --type String --overwrite >/dev/null 2>&1 \
+  && echo "  $SSM_PREFIX/KEYCLOAK_ADMIN_CLIENT_ID = $CID" || { echo "PUT id FAILED"; exit 1; }
+aws ssm put-parameter --name "$SSM_PREFIX/KEYCLOAK_ADMIN_CLIENT_SECRET" --value "$SECRET" --type SecureString --overwrite >/dev/null 2>&1 \
+  && echo "  $SSM_PREFIX/KEYCLOAK_ADMIN_CLIENT_SECRET = (SecureString, set)" || { echo "PUT secret FAILED"; exit 1; }
+
+# Note: the keycloak image has no curl, so the client_credentials grant is
+# verified live via /api/admin/users after the app picks up the SSM values.
+echo "RESULT=PASS (cloudless-admin-api ready + SSM written; app reads creds from SSM)"

--- a/src/app/api/admin/users/route.ts
+++ b/src/app/api/admin/users/route.ts
@@ -1,17 +1,27 @@
 import { NextRequest, NextResponse } from "next/server";
 import { requireAdmin } from "@/lib/api-auth";
+import { getConfig } from "@/lib/ssm-config";
 
 const KC_BASE = process.env.KEYCLOAK_ISSUER ?? process.env.NEXT_PUBLIC_KEYCLOAK_ISSUER ?? "";
 const KC_REALM = KC_BASE ? (KC_BASE.split("/realms/")[1] ?? "master") : "master";
 const KC_ADMIN = KC_BASE ? KC_BASE.replace(`/realms/${KC_REALM}`, "") : "";
 const ADMIN_URL = `${KC_ADMIN}/admin/realms/${KC_REALM}`;
 
-/** Obtain a short-lived admin token using client-credentials (service account). */
+/**
+ * Obtain a short-lived Keycloak admin token. Prefers a confidential
+ * service-account client (client_credentials) whose creds live in SSM — on
+ * Lambda/Pi they are NOT in process.env, which is why the env-only path 500'd.
+ * Falls back to the resource-owner password grant only if no client secret is
+ * configured (e.g. local dev with env vars).
+ */
 async function getAdminToken(): Promise<string> {
-  const clientId = process.env.KEYCLOAK_ADMIN_CLIENT_ID ?? "admin-cli";
-  const clientSecret = process.env.KEYCLOAK_ADMIN_CLIENT_SECRET ?? "";
-  const adminUser = process.env.KEYCLOAK_ADMIN_USER ?? "";
-  const adminPass = process.env.KEYCLOAK_ADMIN_PASSWORD ?? "";
+  const cfg = await getConfig().catch(() => null);
+  const clientId =
+    cfg?.KEYCLOAK_ADMIN_CLIENT_ID || process.env.KEYCLOAK_ADMIN_CLIENT_ID || "admin-cli";
+  const clientSecret =
+    cfg?.KEYCLOAK_ADMIN_CLIENT_SECRET || process.env.KEYCLOAK_ADMIN_CLIENT_SECRET || "";
+  const adminUser = cfg?.KEYCLOAK_ADMIN_USER || process.env.KEYCLOAK_ADMIN_USER || "";
+  const adminPass = cfg?.KEYCLOAK_ADMIN_PASSWORD || process.env.KEYCLOAK_ADMIN_PASSWORD || "";
 
   // Prefer client-credentials, fall back to resource-owner password for admin-cli
   const body = clientSecret

--- a/src/lib/ssm-config.ts
+++ b/src/lib/ssm-config.ts
@@ -25,6 +25,10 @@ interface AppConfig {
   AUTH_SECRET: string;
   KEYCLOAK_ADMIN_USER: string;
   KEYCLOAK_ADMIN_PASSWORD: string;
+  /** Confidential service-account client for admin user-management routes
+   * (least-privilege: view-users/query-users), preferred over the master admin. */
+  KEYCLOAK_ADMIN_CLIENT_ID: string;
+  KEYCLOAK_ADMIN_CLIENT_SECRET: string;
   // Optional integrations
   SLACK_WEBHOOK_URL: string;
   SLACK_BOT_TOKEN: string;
@@ -125,10 +129,7 @@ async function fetchSsmParams(): Promise<Map<string, string>> {
 }
 
 function validateRequiredKeys(params: Map<string, string>): void {
-  const required = [
-    "STRIPE_SECRET_KEY",
-    "STRIPE_WEBHOOK_SECRET",
-  ] as const;
+  const required = ["STRIPE_SECRET_KEY", "STRIPE_WEBHOOK_SECRET"] as const;
   const missing: string[] = [];
   for (const key of required) {
     if (!params.get(key)) {
@@ -164,6 +165,8 @@ function buildConfigFromParams(params: Map<string, string>): AppConfig {
     AUTH_SECRET: params.get("AUTH_SECRET") ?? "",
     KEYCLOAK_ADMIN_USER: params.get("KEYCLOAK_ADMIN_USER") ?? "",
     KEYCLOAK_ADMIN_PASSWORD: params.get("KEYCLOAK_ADMIN_PASSWORD") ?? "",
+    KEYCLOAK_ADMIN_CLIENT_ID: params.get("KEYCLOAK_ADMIN_CLIENT_ID") ?? "",
+    KEYCLOAK_ADMIN_CLIENT_SECRET: params.get("KEYCLOAK_ADMIN_CLIENT_SECRET") ?? "",
     SLACK_WEBHOOK_URL: params.get("SLACK_WEBHOOK_URL") ?? "",
     SLACK_BOT_TOKEN: params.get("SLACK_BOT_TOKEN") ?? "",
     SLACK_SIGNING_SECRET: params.get("SLACK_SIGNING_SECRET") ?? "",
@@ -237,6 +240,8 @@ function buildConfigFromEnv(): AppConfig {
     AUTH_SECRET: process.env.AUTH_SECRET || "",
     KEYCLOAK_ADMIN_USER: process.env.KEYCLOAK_ADMIN_USER || "",
     KEYCLOAK_ADMIN_PASSWORD: process.env.KEYCLOAK_ADMIN_PASSWORD || "",
+    KEYCLOAK_ADMIN_CLIENT_ID: process.env.KEYCLOAK_ADMIN_CLIENT_ID || "",
+    KEYCLOAK_ADMIN_CLIENT_SECRET: process.env.KEYCLOAK_ADMIN_CLIENT_SECRET || "",
     SLACK_WEBHOOK_URL: process.env.SLACK_WEBHOOK_URL || "",
     SLACK_BOT_TOKEN: process.env.SLACK_BOT_TOKEN || "",
     SLACK_SIGNING_SECRET: process.env.SLACK_SIGNING_SECRET || "",


### PR DESCRIPTION
Implements the chosen approach (dedicated least-privilege service account) for the `/admin/users` 500.

**Cause:** the route read Keycloak admin creds from `process.env`, which are empty on Lambda/Pi (they live in SSM) → `getAdminToken()` failed → 500.

**Fix (least privilege):**
- New confidential Keycloak client **`cloudless-admin-api`** whose service account holds **only** `view-users` / `query-users` / `query-groups` / `view-groups` — no master admin password in the app.
- `scripts/keycloak-create-admin-api-client.sh` + `keycloak-admin-api-client.yml`: create the client + roles via kcadm in-pod, **capture the secret silently (masked, never logged/posted)**, and write `KEYCLOAK_ADMIN_CLIENT_ID`/`KEYCLOAK_ADMIN_CLIENT_SECRET` to SSM via the OIDC role.
- `ssm-config.ts`: expose the two new keys.
- `/admin/users` route: read client creds from SSM config (prefer `client_credentials`), env fallback for local dev.

**Verify:** workflow posts RESULT to #382; after deploy I'll confirm `/admin/users` → 200 live.

https://claude.ai/code/session_01WoLaMUxTAygraKUTy7JTT8

---
_Generated by [Claude Code](https://claude.ai/code/session_01WoLaMUxTAygraKUTy7JTT8)_