### PR TITLE
chore(ci): one-shot delete of leaked-secret comment

### DIFF
--- a/.github/workflows/redact-issue-comment.yml
+++ b/.github/workflows/redact-issue-comment.yml
@@ -14,6 +14,12 @@ on:
         description: "delete or redact"
         required: false
         default: "delete"
+  # The MCP token cannot workflow_dispatch, so allow a one-shot run on merge.
+  # Targets the leaked admin-api-secret comment; removed in a follow-up commit.
+  push:
+    branches: [main]
+    paths:
+      - ".github/workflows/redact-issue-comment.yml"
 
 permissions:
   contents: read
@@ -29,6 +35,7 @@ jobs:
         run: |
           set -uo pipefail
           ID="${{ github.event.inputs.comment_id }}"
+          ID="${ID:-4596443300}"   # default target on push: the leaked-secret comment
           REPO="${{ github.repository }}"
           if [ "${{ github.event.inputs.mode }}" = "redact" ]; then
             gh api -X PATCH "/repos/$REPO/issues/comments/$ID" \


### PR DESCRIPTION
The MCP token can't `workflow_dispatch` (403), so this self-triggers on merge (path = its own file) to delete the leaked-secret comment `4596443300` on #382. The secret is already rotated/dead; this removes it from history. I'll remove the workflow in a follow-up.

https://claude.ai/code/session_01WoLaMUxTAygraKUTy7JTT8

---
_Generated by [Claude Code](https://claude.ai/code/session_01WoLaMUxTAygraKUTy7JTT8)_