### PR TITLE
feat(keycloak): email verification on registration via SES SMTP

### DIFF
--- a/.github/workflows/keycloak-configure-email.yml
+++ b/.github/workflows/keycloak-configure-email.yml
@@ -1,0 +1,145 @@
+name: Keycloak configure email verification
+
+# Sets the realm SMTP server (AWS SES) and enables email verification for new
+# registrations. After this runs, every new user who registers at cloudless.gr
+# receives a verification email; they must click the link before signing in.
+#
+# How to get SES SMTP credentials:
+#   AWS Console → SES → SMTP Settings → Create SMTP credentials
+#   This creates a dedicated IAM user. The SMTP username = IAM access key ID.
+#   The SMTP password is the *derived* SES credential shown once at creation time
+#   (NOT the raw IAM secret key — AWS derives it internally).
+#
+#   Store them in SSM:
+#     /cloudless/production/SES_SMTP_USER     (not secret — can be plaintext)
+#     /cloudless/production/SES_SMTP_PASSWORD (SecureString)
+#
+#   Then trigger this workflow via workflow_dispatch (leave inputs blank to read
+#   from SSM, or paste the credentials directly in the inputs).
+
+on:
+  workflow_dispatch:
+    inputs:
+      smtp_user:
+        description: "SES SMTP username (leave blank to read from SSM)"
+        required: false
+        default: ""
+      smtp_password:
+        description: "SES SMTP password (leave blank to read from SSM)"
+        required: false
+        default: ""
+      from_email:
+        description: "From email address (leave blank to read SES_FROM_EMAIL from SSM)"
+        required: false
+        default: ""
+  push:
+    branches: [main]
+    paths:
+      - ".github/workflows/keycloak-configure-email.yml"
+      - "scripts/keycloak-configure-email.sh"
+
+permissions:
+  contents: read
+  issues: write
+
+concurrency:
+  group: keycloak-configure-email
+  cancel-in-progress: false
+
+jobs:
+  configure-email:
+    runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ github.token }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v4.3.1
+
+      - name: Connect to tailnet
+        uses: tailscale/github-action@0263d9e6d793eaefcf1de98ff7fde47abe6664d3 # v3.2.4
+        with:
+          authkey: ${{ secrets.TS_AUTHKEY }}
+
+      - name: Configure kubectl
+        run: |
+          mkdir -p ~/.kube
+          echo "${{ secrets.KUBECONFIG_B64 }}" | base64 -d > ~/.kube/config
+          chmod 600 ~/.kube/config
+
+      - name: Resolve SMTP credentials from inputs or SSM
+        id: creds
+        env:
+          INPUT_SMTP_USER: ${{ github.event.inputs.smtp_user }}
+          INPUT_SMTP_PASSWORD: ${{ github.event.inputs.smtp_password }}
+          INPUT_FROM_EMAIL: ${{ github.event.inputs.from_email }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          AWS_DEFAULT_REGION: us-east-1
+        run: |
+          set -uo pipefail
+          # Use inline inputs if provided; otherwise fall back to SSM
+          SMTP_USER="${INPUT_SMTP_USER:-}"
+          SMTP_PASSWORD="${INPUT_SMTP_PASSWORD:-}"
+          FROM_EMAIL="${INPUT_FROM_EMAIL:-}"
+          if [ -z "$SMTP_USER" ]; then
+            SMTP_USER=$(aws ssm get-parameter \
+              --name /cloudless/production/SES_SMTP_USER \
+              --query 'Parameter.Value' --output text 2>/dev/null || true)
+          fi
+          if [ -z "$SMTP_PASSWORD" ]; then
+            SMTP_PASSWORD=$(aws ssm get-parameter \
+              --name /cloudless/production/SES_SMTP_PASSWORD \
+              --with-decryption --query 'Parameter.Value' --output text 2>/dev/null || true)
+          fi
+          if [ -z "$FROM_EMAIL" ]; then
+            FROM_EMAIL=$(aws ssm get-parameter \
+              --name /cloudless/production/SES_FROM_EMAIL \
+              --query 'Parameter.Value' --output text 2>/dev/null || true)
+          fi
+          if [ -z "$SMTP_USER" ] || [ -z "$SMTP_PASSWORD" ]; then
+            echo "ERROR: SMTP credentials not found in inputs or SSM."
+            echo "Create SES SMTP credentials in AWS Console → SES → SMTP Settings"
+            echo "then store as SSM params /cloudless/production/SES_SMTP_{USER,PASSWORD}"
+            exit 1
+          fi
+          if [ -z "$FROM_EMAIL" ]; then
+            echo "ERROR: FROM_EMAIL not found — ensure /cloudless/production/SES_FROM_EMAIL exists in SSM"
+            exit 1
+          fi
+          # Mask secrets in log output
+          echo "::add-mask::$SMTP_PASSWORD"
+          # Export to next step via GITHUB_ENV
+          {
+            echo "SMTP_USER=$SMTP_USER"
+            echo "SMTP_PASSWORD=$SMTP_PASSWORD"
+            echo "FROM_EMAIL=$FROM_EMAIL"
+          } >> "$GITHUB_ENV"
+          echo "smtp_user=$SMTP_USER" >> "$GITHUB_OUTPUT"
+          echo "from_email=$FROM_EMAIL" >> "$GITHUB_OUTPUT"
+
+      - name: Configure SMTP + enable email verification
+        env:
+          SMTP_USER: ${{ env.SMTP_USER }}
+          SMTP_PASSWORD: ${{ env.SMTP_PASSWORD }}
+          FROM_EMAIL: ${{ env.FROM_EMAIL }}
+        run: |
+          set -uo pipefail
+          bash scripts/keycloak-configure-email.sh 2>&1 | tee email-cfg.log
+
+      - name: Post result to tracking issue
+        if: always()
+        run: |
+          SMTP_USER="${{ steps.creds.outputs.smtp_user }}"
+          FROM_EMAIL="${{ steps.creds.outputs.from_email }}"
+          STATUS="${{ job.status }}"
+          {
+            echo "# Keycloak email verification config — $(date -u '+%F %T')Z"
+            echo ""
+            echo "**Status:** $STATUS"
+            echo "**SMTP user:** ${SMTP_USER:-<from input>}"
+            echo "**From email:** ${FROM_EMAIL:-<from input>}"
+            echo ""
+            echo '```'
+            cat email-cfg.log 2>/dev/null || echo '(no log)'
+            echo '```'
+          } > c.md
+          gh issue comment 382 --repo "${{ github.repository }}" --body-file c.md

--- a/scripts/keycloak-configure-email.sh
+++ b/scripts/keycloak-configure-email.sh
@@ -1,0 +1,104 @@
+#!/usr/bin/env bash
+#
+# keycloak-configure-email.sh — configure Keycloak realm SMTP (AWS SES) and
+# enable email verification for new registrations.
+#
+# What this does:
+#   1. Sets the realm smtpServer block to use AWS SES SMTP
+#   2. Enables verifyEmail on the realm (new users must verify before signing in)
+#   3. Ensures the VERIFY_EMAIL required action is enabled + set as default
+#      (so it applies automatically to every new registration)
+#
+# Credentials are read from env vars. The CI workflow reads them from SSM or
+# from workflow_dispatch inputs and injects them before calling this script.
+#
+# Required env:
+#   SMTP_USER      — SES SMTP username (= IAM access key ID for the SES SMTP user)
+#   SMTP_PASSWORD  — SES SMTP password (derived SES SMTP credential, NOT the IAM secret key)
+#   FROM_EMAIL     — from address, e.g. noreply@cloudless.gr
+#
+# Optional env:
+#   SMTP_HOST      — default email-smtp.us-east-1.amazonaws.com
+#   SMTP_PORT      — default 587
+#   FROM_NAME      — display name, default "Cloudless"
+#   NAMESPACE, DEPLOYMENT, REALM
+
+set -uo pipefail
+
+NAMESPACE="${NAMESPACE:-keycloak}"
+DEPLOYMENT="${DEPLOYMENT:-keycloak}"
+REALM="${REALM:-master}"
+SMTP_HOST="${SMTP_HOST:-email-smtp.us-east-1.amazonaws.com}"
+SMTP_PORT="${SMTP_PORT:-587}"
+FROM_NAME="${FROM_NAME:-Cloudless}"
+
+# --- validate required vars ---
+: "${SMTP_USER:?SMTP_USER is required (SES SMTP IAM access key ID)}"
+: "${SMTP_PASSWORD:?SMTP_PASSWORD is required (derived SES SMTP credential)}"
+: "${FROM_EMAIL:?FROM_EMAIL is required (e.g. noreply@cloudless.gr)}"
+
+command -v kubectl >/dev/null 2>&1 || { echo "error: kubectl not found / no cluster access"; exit 1; }
+POD=$(kubectl -n "$NAMESPACE" get pod -l app="$DEPLOYMENT" -o jsonpath='{.items[0].metadata.name}' 2>/dev/null)
+[ -n "$POD" ] || { echo "error: no $DEPLOYMENT pod in ns/$NAMESPACE"; exit 1; }
+echo "== keycloak-configure-email $(date -u '+%F %T')Z =="
+echo "pod=$POD realm=$REALM smtp_host=$SMTP_HOST:$SMTP_PORT from=$FROM_EMAIL"
+
+kubectl -n "$NAMESPACE" exec -i "$POD" -- \
+  env RL="$REALM" \
+      SH="$SMTP_HOST" SP="$SMTP_PORT" SU="$SMTP_USER" SW="$SMTP_PASSWORD" \
+      FE="$FROM_EMAIL" FN="$FROM_NAME" \
+  bash -s <<'EOS'
+set -uo pipefail
+K=/opt/keycloak/bin/kcadm.sh
+AU="${KEYCLOAK_ADMIN:-${KC_BOOTSTRAP_ADMIN_USERNAME:-admin}}"
+AP="${KEYCLOAK_ADMIN_PASSWORD:-${KC_BOOTSTRAP_ADMIN_PASSWORD:-}}"
+$K config credentials --server http://localhost:8080 --realm master --user "$AU" --password "$AP" >/dev/null 2>&1 \
+  || { echo "ADMIN_AUTH=failed"; exit 1; }
+echo "ADMIN_AUTH=ok"
+
+# Build the SMTP JSON block (Python to handle any special chars in the password)
+SMTP_JSON=$(python3 - "$SH" "$SP" "$SU" "$SW" "$FE" "$FN" <<'PY'
+import sys, json
+host, port, user, pw, from_email, from_name = sys.argv[1:]
+print(json.dumps({
+  "host": host,
+  "port": port,
+  "ssl": "false",
+  "starttls": "true",
+  "auth": "true",
+  "user": user,
+  "password": pw,
+  "from": from_email,
+  "fromDisplayName": from_name,
+  "replyTo": "",
+  "replyToDisplayName": "",
+  "envelopeFrom": ""
+}))
+PY
+)
+
+# Apply the smtpServer block + enable verifyEmail
+$K update "realms/$RL" -s "smtpServer=$SMTP_JSON" >/dev/null 2>&1 \
+  && echo "SMTP=configured" || { echo "SMTP=failed"; exit 1; }
+
+$K update "realms/$RL" -s verifyEmail=true >/dev/null 2>&1 \
+  && echo "VERIFY_EMAIL=enabled" || echo "VERIFY_EMAIL=failed (non-fatal)"
+
+# Ensure VERIFY_EMAIL required action is enabled and set as default
+# (default=true means it's automatically assigned to new registrations)
+$K update "realms/$RL/authentication/required-actions/VERIFY_EMAIL" \
+  -s enabled=true -s defaultAction=true >/dev/null 2>&1 \
+  && echo "REQUIRED_ACTION=enabled+default" || echo "REQUIRED_ACTION=update failed (non-fatal)"
+
+echo "DONE"
+EOS
+
+echo "=== email verification configured ==="
+echo ""
+echo "What happens now:"
+echo "  1. New users who register at cloudless.gr will receive a verification email"
+echo "  2. The email contains a link — clicking it verifies their account"
+echo "  3. Until verified, users cannot sign in to the application"
+echo ""
+echo "Test: register at https://cloudless.gr/auth/register with a real email address"
+echo "To test SMTP only: ./tools/keycloak-cli/keycloak.sh smtp-test"

--- a/scripts/keycloak-ensure.sh
+++ b/scripts/keycloak-ensure.sh
@@ -76,13 +76,33 @@ $K config credentials --server http://localhost:8080 --realm master --user "$AU"
 
 # realm flags
 rf() { csv "realms/$RL" --fields "$1" | head -1; }
-for kv in registrationAllowed=true resetPasswordAllowed=true loginWithEmailAllowed=true; do
+for kv in registrationAllowed=true resetPasswordAllowed=true loginWithEmailAllowed=true verifyEmail=true; do
   k=${kv%=*}; want=${kv#*=}
   cur=$(rf "$k")
   if [ "$cur" != "$want" ]; then
     $K update "realms/$RL" -s "$k=$want" >/dev/null 2>&1 && echo "FIX realm.$k: $cur -> $want"
   fi
 done
+
+# VERIFY_EMAIL required action — ensure enabled+default so new registrations get it
+VA=$($K get "realms/$RL/authentication/required-actions/VERIFY_EMAIL" -r "$RL" 2>/dev/null || true)
+if printf '%s' "$VA" | grep -q '"enabled"'; then
+  en=$(printf '%s' "$VA" | grep -o '"enabled"[^,}]*' | head -1 | grep -o 'true\|false')
+  da=$(printf '%s' "$VA" | grep -o '"defaultAction"[^,}]*' | head -1 | grep -o 'true\|false')
+  if [ "$en" != "true" ] || [ "$da" != "true" ]; then
+    $K update "realms/$RL/authentication/required-actions/VERIFY_EMAIL" \
+      -s enabled=true -s defaultAction=true >/dev/null 2>&1 \
+      && echo "FIX VERIFY_EMAIL required action: enabled=$en->true defaultAction=$da->true"
+  fi
+fi
+
+# SMTP health check — warn if missing but do not overwrite (password would be wiped)
+SMTP_HOST=$($K get "realms/$RL" -r "$RL" --fields smtpServer 2>/dev/null \
+  | grep -o '"host":"[^"]*"' | head -1 | cut -d'"' -f4 || true)
+if [ -z "$SMTP_HOST" ]; then
+  echo "WARN: realm SMTP not configured — email verification emails cannot be sent."
+  echo "WARN: run .github/workflows/keycloak-configure-email.yml to set up SES SMTP."
+fi
 
 # admin group
 GID=$(csv groups -r "$RL" -q search=admin --fields id,name | grep -iE ',admin$' | head -1 | cut -d, -f1)

--- a/src/app/[locale]/admin/users/page.tsx
+++ b/src/app/[locale]/admin/users/page.tsx
@@ -182,8 +182,8 @@ export default function AdminUsersPage() {
         <div className="bg-void-light/50 rounded-xl border border-red-900/30 p-6 text-center">
           <p className="font-mono text-sm text-red-400">{error}</p>
           <p className="mt-2 text-xs text-slate-500">
-            Check that KEYCLOAK_ADMIN_USER and KEYCLOAK_ADMIN_PASSWORD are set in SSM and that
-            the Keycloak admin REST API is reachable.
+            Check that KEYCLOAK_ADMIN_USER and KEYCLOAK_ADMIN_PASSWORD are set in SSM and that the
+            Keycloak admin REST API is reachable.
           </p>
         </div>
       ) : (
@@ -325,7 +325,9 @@ export default function AdminUsersPage() {
 
       <p className="mt-4 font-mono text-xs text-slate-600">
         Powered by{" "}
-        <span className="text-slate-500">Keycloak · {process.env.NEXT_PUBLIC_KEYCLOAK_ISSUER ?? "not configured"}</span>
+        <span className="text-slate-500">
+          Keycloak · {process.env.NEXT_PUBLIC_KEYCLOAK_ISSUER ?? "not configured"}
+        </span>
       </p>
     </div>
   );


### PR DESCRIPTION
## What this does

After merging + running the one-time workflow, every new user who registers at cloudless.gr receives a verification email. They must click the secure link before they can sign in.

## Changes

- **`scripts/keycloak-configure-email.sh`** — configures the realm `smtpServer` block (AWS SES SMTP), sets `verifyEmail=true`, and marks the `VERIFY_EMAIL` required action as enabled + default so it's applied to every new registration automatically
- **`.github/workflows/keycloak-configure-email.yml`** — `workflow_dispatch` that reads SES SMTP credentials from inputs or SSM, then runs the script. Posts result to issue #382.
- **`scripts/keycloak-ensure.sh`** — adds `verifyEmail=true` to the desired state (self-heal cron maintains it), ensures the VERIFY_EMAIL required action stays enabled+default, adds a warning if SMTP is not yet configured

## How the verification flow works

1. User fills in the registration form at `cloudless.gr/auth/register`
2. Keycloak creates the account but immediately intercepts with a "check your email" screen
3. A verification email (from `SES_FROM_EMAIL`) is sent containing a one-time secure link
4. User clicks the link → Keycloak marks the account verified → redirected into the app
5. Until verified, signing in is blocked

(This is a signed link, not a numeric code — the same pattern used by GitHub, Google, etc.)

## Prerequisites before running the workflow

1. **Create SES SMTP credentials** in the AWS Console:
   `SES → SMTP Settings → Create SMTP credentials`
   This creates a dedicated IAM user. Copy the SMTP username and the derived password (shown once).

2. **Store in SSM** (or paste directly into the workflow_dispatch inputs):
   ```
   /cloudless/production/SES_SMTP_USER      (plaintext)
   /cloudless/production/SES_SMTP_PASSWORD  (SecureString)
   ```

3. **Trigger the workflow**: Actions → "Keycloak configure email verification" → Run workflow (leave inputs blank to read from SSM)

4. **Test**: register with a real email at `https://cloudless.gr/auth/register`

## Test plan
- [ ] Run `keycloak-configure-email.yml` workflow with valid SES SMTP creds
- [ ] Workflow posts `SMTP=configured VERIFY_EMAIL=enabled` to issue #382
- [ ] Register a new account — verification email arrives within seconds
- [ ] Clicking the link in the email grants access to the app
- [ ] Existing admin account (`tbaltzakis@cloudless.gr`) is unaffected

https://claude.ai/code/session_01PHsA9s3tK2thgSJVwEGuWq

---
_Generated by [Claude Code](https://claude.ai/code/session_01PHsA9s3tK2thgSJVwEGuWq)_