### PR TITLE
feat(auth): in-app Keycloak registration + fix dead Cognito UI

### DIFF
--- a/__tests__/auth-public-a11y.test.tsx
+++ b/__tests__/auth-public-a11y.test.tsx
@@ -80,15 +80,15 @@ describe("auth/public accessibility", () => {
     expect(container.querySelector('a[href="/auth/login"]')).toBeTruthy();
   });
 
-  it("forgot password page uses one-time-code and new-password semantics", () => {
+  it("forgot password page has email field and reset link button", () => {
     render(<ForgotPasswordPage />);
 
     const email = screen.getByLabelText("Email") as HTMLInputElement;
-    const sendCode = screen.getByRole("button", { name: "Send Reset Code" });
+    const sendLink = screen.getByRole("button", { name: "Send Reset Link" });
 
     expect(email.type).toBe("email");
     expect(email.autocomplete).toBe("email");
-    expect(sendCode).toBeTruthy();
+    expect(sendLink).toBeTruthy();
   });
 
   it("newsletter form provides email field, explicit submit button, and privacy link", () => {

--- a/src/app/[locale]/auth/forgot-password/page.tsx
+++ b/src/app/[locale]/auth/forgot-password/page.tsx
@@ -1,8 +1,7 @@
 "use client";
 
 import { useState } from "react";
-import Link from "next/link";
-import { useRouter } from "next/navigation";
+import { Link } from "@/i18n/navigation";
 import { useAuth } from "@/context/AuthContext";
 import { translate } from "@/lib/i18n";
 import { useCurrentLocale } from "@/lib/use-locale";
@@ -10,12 +9,8 @@ import { useCurrentLocale } from "@/lib/use-locale";
 export default function ForgotPasswordPage() {
   const [locale] = useCurrentLocale();
   const t = (key: string, fallback: string) => translate(locale, key, fallback);
-  const { forgotPassword, confirmForgotPassword } = useAuth();
-  const router = useRouter();
+  const { forgotPassword } = useAuth();
   const [email, setEmail] = useState("");
-  const [code, setCode] = useState("");
-  const [newPassword, setNewPassword] = useState("");
-  const [step, setStep] = useState<"request" | "confirm">("request");
   const [error, setError] = useState("");
   const [submitting, setSubmitting] = useState(false);
 
@@ -24,25 +19,10 @@ export default function ForgotPasswordPage() {
     setError("");
     setSubmitting(true);
     try {
+      // Redirects to Keycloak's reset-credentials page; browser navigates away.
       await forgotPassword(email);
-      setStep("confirm");
     } catch (err: unknown) {
       setError(err instanceof Error ? err.message : "Request failed");
-    } finally {
-      setSubmitting(false);
-    }
-  };
-
-  const handleConfirm = async (e: React.FormEvent) => {
-    e.preventDefault();
-    setError("");
-    setSubmitting(true);
-    try {
-      await confirmForgotPassword(email, code, newPassword);
-      router.push("/auth/login");
-    } catch (err: unknown) {
-      setError(err instanceof Error ? err.message : "Reset failed");
-    } finally {
       setSubmitting(false);
     }
   };
@@ -56,14 +36,10 @@ export default function ForgotPasswordPage() {
             <span className="text-neon-blue font-mono text-xs">RECOVERY</span>
           </div>
           <h1 className="font-heading text-3xl font-bold text-white">
-            {step === "request"
-              ? t("auth.resetPasswordTitle", "Reset Password")
-              : t("auth.enterCode", "Enter Code")}
+            {t("auth.resetPasswordTitle", "Reset Password")}
           </h1>
           <p className="font-body mt-2 text-slate-400">
-            {step === "request"
-              ? t("auth.resetRequestDesc", "We'll send a verification code to your email")
-              : t("auth.resetCodeDesc", "Enter the code sent to {email}").replace("{email}", email)}
+            {t("auth.resetRequestDesc", "Enter your email and we'll send a reset link")}
           </p>
         </div>
 
@@ -74,87 +50,32 @@ export default function ForgotPasswordPage() {
             </div>
           )}
 
-          {step === "request" ? (
-            <form onSubmit={handleRequest} className="space-y-5">
-              <div>
-                <label
-                  htmlFor="forgot-email"
-                  className="mb-2 block font-mono text-sm text-slate-400"
-                >
-                  {t("auth.email", "Email")}
-                </label>
-                <input
-                  id="forgot-email"
-                  type="email"
-                  value={email}
-                  onChange={(e) => setEmail(e.target.value)}
-                  required
-                  autoComplete="email"
-                  className="bg-void focus:border-neon-cyan/50 w-full rounded-lg border border-slate-700 px-4 py-3 font-mono text-sm text-white transition-all focus:shadow-[0_0_10px_rgba(0,255,245,0.1)] focus:outline-none"
-                  placeholder="your@email.com"
-                />
-              </div>
-              <button
-                type="submit"
-                disabled={submitting}
-                className="bg-neon-cyan/10 border-neon-cyan/50 text-neon-cyan hover:bg-neon-cyan/20 min-h-[44px] w-full rounded-lg border py-3 font-mono font-semibold transition-all hover:shadow-[0_0_15px_rgba(0,255,245,0.2)] disabled:opacity-50"
-              >
-                {submitting
-                  ? t("auth.sendingCode", "Sending Code...")
-                  : t("auth.sendResetCode", "Send Reset Code")}
-              </button>
-            </form>
-          ) : (
-            <form onSubmit={handleConfirm} className="space-y-5">
-              <div>
-                <label
-                  htmlFor="forgot-verification-code"
-                  className="mb-2 block font-mono text-sm text-slate-400"
-                >
-                  {t("auth.verificationCode", "Verification Code")}
-                </label>
-                <input
-                  id="forgot-verification-code"
-                  type="text"
-                  value={code}
-                  onChange={(e) => setCode(e.target.value)}
-                  required
-                  autoComplete="one-time-code"
-                  className="bg-void focus:border-neon-cyan/50 w-full rounded-lg border border-slate-700 px-4 py-3 text-center font-mono text-sm tracking-[0.3em] text-white transition-all focus:shadow-[0_0_10px_rgba(0,255,245,0.1)] focus:outline-none"
-                  placeholder="123456"
-                  maxLength={6}
-                />
-              </div>
-              <div>
-                <label
-                  htmlFor="forgot-new-password"
-                  className="mb-2 block font-mono text-sm text-slate-400"
-                >
-                  {t("auth.newPassword", "New Password")}
-                </label>
-                <input
-                  id="forgot-new-password"
-                  type="password"
-                  value={newPassword}
-                  onChange={(e) => setNewPassword(e.target.value)}
-                  required
-                  minLength={8}
-                  autoComplete="new-password"
-                  className="bg-void focus:border-neon-cyan/50 w-full rounded-lg border border-slate-700 px-4 py-3 font-mono text-sm text-white transition-all focus:shadow-[0_0_10px_rgba(0,255,245,0.1)] focus:outline-none"
-                  placeholder={t("auth.minChars", "Min. 8 characters")}
-                />
-              </div>
-              <button
-                type="submit"
-                disabled={submitting}
-                className="bg-neon-cyan/10 border-neon-cyan/50 text-neon-cyan hover:bg-neon-cyan/20 min-h-[44px] w-full rounded-lg border py-3 font-mono font-semibold transition-all hover:shadow-[0_0_15px_rgba(0,255,245,0.2)] disabled:opacity-50"
-              >
-                {submitting
-                  ? t("auth.resetting", "Resetting...")
-                  : t("auth.resetPassword", "Reset Password")}
-              </button>
-            </form>
-          )}
+          <form onSubmit={handleRequest} className="space-y-5">
+            <div>
+              <label htmlFor="forgot-email" className="mb-2 block font-mono text-sm text-slate-400">
+                {t("auth.email", "Email")}
+              </label>
+              <input
+                id="forgot-email"
+                type="email"
+                value={email}
+                onChange={(e) => setEmail(e.target.value)}
+                required
+                autoComplete="email"
+                className="bg-void focus:border-neon-cyan/50 w-full rounded-lg border border-slate-700 px-4 py-3 font-mono text-sm text-white transition-all focus:shadow-[0_0_10px_rgba(0,255,245,0.1)] focus:outline-none"
+                placeholder="your@email.com"
+              />
+            </div>
+            <button
+              type="submit"
+              disabled={submitting}
+              className="bg-neon-cyan/10 border-neon-cyan/50 text-neon-cyan hover:bg-neon-cyan/20 min-h-[44px] w-full rounded-lg border py-3 font-mono font-semibold transition-all hover:shadow-[0_0_15px_rgba(0,255,245,0.2)] disabled:opacity-50"
+            >
+              {submitting
+                ? t("auth.redirecting", "Redirecting...")
+                : t("auth.sendResetLink", "Send Reset Link")}
+            </button>
+          </form>
 
           <p className="mt-6 text-center font-mono text-sm text-slate-500">
             {t("auth.rememberPassword", "Remember your password?")}{" "}

--- a/src/app/[locale]/auth/signup/page.tsx
+++ b/src/app/[locale]/auth/signup/page.tsx
@@ -10,12 +10,10 @@ import { useCurrentLocale } from "@/lib/use-locale";
 function SignUpForm() {
   const [locale] = useCurrentLocale();
   const t = (key: string, fallback: string) => translate(locale, key, fallback);
-  const { signUp, confirmSignUp, user, isAdmin, isLoading } = useAuth();
+  const { user, isAdmin, isLoading } = useAuth();
   const router = useRouter();
   const searchParams = useSearchParams();
 
-  // If a plan was selected on the services page, send the user straight to
-  // the portal waiting room after auth (the waiting room enrolls them).
   const planParam = searchParams.get("plan");
   const postSignupDestination = planParam
     ? `/portal/waiting?plan=${encodeURIComponent(planParam)}`
@@ -30,24 +28,14 @@ function SignUpForm() {
       }
     }
   }, [user, isAdmin, isLoading, router, postSignupDestination]);
+
   const [fullName, setFullName] = useState("");
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
   const [confirmPassword, setConfirmPassword] = useState("");
-  const [code, setCode] = useState("");
-  const [step, setStep] = useState<"signup" | "verify">("signup");
+  const [step, setStep] = useState<"signup" | "check-email">("signup");
   const [error, setError] = useState("");
   const [submitting, setSubmitting] = useState(false);
-
-  // Support ?verify=email from login redirect for unverified users
-  useEffect(() => {
-    const verifyEmail = searchParams.get("verify");
-    if (verifyEmail) {
-      // eslint-disable-next-line react-hooks/set-state-in-effect
-      setEmail(verifyEmail);
-      setStep("verify");
-    }
-  }, [searchParams]);
 
   const handleSignUp = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -58,28 +46,19 @@ function SignUpForm() {
     }
     setSubmitting(true);
     try {
-      await signUp(email, password, fullName || undefined);
-      setStep("verify");
-    } catch (err: unknown) {
-      setError(err instanceof Error ? err.message : "Sign up failed");
-    } finally {
-      setSubmitting(false);
-    }
-  };
-
-  const handleVerify = async (e: React.FormEvent) => {
-    e.preventDefault();
-    setError("");
-    setSubmitting(true);
-    try {
-      await confirmSignUp(email, code);
-      // Forward the plan param so the user lands in the waiting room post-login
-      const next = postSignupDestination
-        ? `/auth/login?next=${encodeURIComponent(postSignupDestination)}`
-        : "/auth/login";
-      router.push(next);
-    } catch (err: unknown) {
-      setError(err instanceof Error ? err.message : "Verification failed");
+      const res = await globalThis.fetch("/api/auth/register", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ email, password, fullName: fullName || undefined }),
+      });
+      const data = (await res.json()) as { ok?: boolean; error?: string };
+      if (!res.ok) {
+        setError(data.error ?? t("auth.signupFailed", "Sign up failed"));
+        return;
+      }
+      setStep("check-email");
+    } catch {
+      setError(t("auth.signupFailed", "Sign up failed"));
     } finally {
       setSubmitting(false);
     }
@@ -96,150 +75,152 @@ function SignUpForm() {
           <h1 className="font-heading text-3xl font-bold text-white">
             {step === "signup"
               ? t("auth.signup", "Create Account")
-              : t("auth.verifyEmail", "Verify Email")}
+              : t("auth.checkYourEmail", "Check Your Email")}
           </h1>
           <p className="font-body mt-2 text-slate-400">
             {step === "signup"
               ? t("auth.signupDesc", "Join Cloudless to access your dashboard")
-              : t("auth.verifyDesc", "Enter the verification code sent to {email}").replace(
-                  "{email}",
-                  email
-                )}
+              : t("auth.checkEmailDesc", "A verification link has been sent to your inbox")}
           </p>
         </div>
 
         <div className="bg-void-light/50 rounded-xl border border-slate-800 p-8">
-          {error && (
-            <div className="bg-neon-magenta/10 border-neon-magenta/30 text-neon-magenta mb-6 rounded-lg border p-3 font-mono text-sm">
-              {error}
+          {step === "check-email" ? (
+            <div className="space-y-5 text-center">
+              <div className="bg-neon-green/10 border-neon-green/20 mx-auto flex h-16 w-16 items-center justify-center rounded-full border">
+                <svg
+                  className="text-neon-green h-8 w-8"
+                  fill="none"
+                  stroke="currentColor"
+                  viewBox="0 0 24 24"
+                  aria-hidden="true"
+                >
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    strokeWidth={1.5}
+                    d="M3 8l7.89 5.26a2 2 0 002.22 0L21 8M5 19h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z"
+                  />
+                </svg>
+              </div>
+              <p className="font-mono text-sm text-slate-300">
+                {t("auth.verificationSentTo", "We sent a verification link to")}{" "}
+                <span className="text-white">{email}</span>
+              </p>
+              <p className="font-mono text-xs text-slate-500">
+                {t(
+                  "auth.clickLinkToActivate",
+                  "Click the link in the email to activate your account. After verification, you can sign in."
+                )}
+              </p>
+              <Link
+                href="/auth/login"
+                className="text-neon-cyan block font-mono text-sm hover:underline"
+              >
+                {t("auth.goToSignIn", "Go to Sign In →")}
+              </Link>
             </div>
-          )}
-
-          {step === "signup" ? (
-            <form onSubmit={handleSignUp} className="space-y-5">
-              <div>
-                <label
-                  htmlFor="signup-name"
-                  className="mb-2 block font-mono text-sm text-slate-400"
-                >
-                  {t("auth.fullName", "Full Name")}
-                  <span className="ml-1 text-slate-600">({t("auth.optional", "optional")})</span>
-                </label>
-                <input
-                  id="signup-name"
-                  type="text"
-                  value={fullName}
-                  onChange={(e) => setFullName(e.target.value)}
-                  autoComplete="name"
-                  className="bg-void focus:border-neon-cyan/50 w-full rounded-lg border border-slate-700 px-4 py-3 font-mono text-sm text-white transition-all focus:shadow-[0_0_10px_rgba(0,255,245,0.1)] focus:outline-none"
-                  placeholder={t("auth.namePlaceholder", "John Doe")}
-                />
-              </div>
-              <div>
-                <label
-                  htmlFor="signup-email"
-                  className="mb-2 block font-mono text-sm text-slate-400"
-                >
-                  {t("auth.email", "Email")}
-                </label>
-                <input
-                  id="signup-email"
-                  type="email"
-                  value={email}
-                  onChange={(e) => setEmail(e.target.value)}
-                  required
-                  autoComplete="email"
-                  className="bg-void focus:border-neon-cyan/50 w-full rounded-lg border border-slate-700 px-4 py-3 font-mono text-sm text-white transition-all focus:shadow-[0_0_10px_rgba(0,255,245,0.1)] focus:outline-none"
-                  placeholder="your@email.com"
-                />
-              </div>
-              <div>
-                <label
-                  htmlFor="signup-password"
-                  className="mb-2 block font-mono text-sm text-slate-400"
-                >
-                  {t("auth.password", "Password")}
-                </label>
-                <input
-                  id="signup-password"
-                  type="password"
-                  value={password}
-                  onChange={(e) => setPassword(e.target.value)}
-                  required
-                  minLength={8}
-                  autoComplete="new-password"
-                  className="bg-void focus:border-neon-cyan/50 w-full rounded-lg border border-slate-700 px-4 py-3 font-mono text-sm text-white transition-all focus:shadow-[0_0_10px_rgba(0,255,245,0.1)] focus:outline-none"
-                  placeholder={t("auth.minChars", "Min. 8 characters")}
-                />
-              </div>
-              <div>
-                <label
-                  htmlFor="signup-confirm-password"
-                  className="mb-2 block font-mono text-sm text-slate-400"
-                >
-                  {t("auth.confirmPassword", "Confirm Password")}
-                </label>
-                <input
-                  id="signup-confirm-password"
-                  type="password"
-                  value={confirmPassword}
-                  onChange={(e) => setConfirmPassword(e.target.value)}
-                  required
-                  minLength={8}
-                  autoComplete="new-password"
-                  className="bg-void focus:border-neon-cyan/50 w-full rounded-lg border border-slate-700 px-4 py-3 font-mono text-sm text-white transition-all focus:shadow-[0_0_10px_rgba(0,255,245,0.1)] focus:outline-none"
-                  placeholder={t("auth.reenterPassword", "Re-enter password")}
-                />
-              </div>
-              <button
-                type="submit"
-                disabled={submitting}
-                className="bg-neon-cyan/10 border-neon-cyan/50 text-neon-cyan hover:bg-neon-cyan/20 min-h-11 w-full rounded-lg border py-3 font-mono font-semibold transition-all hover:shadow-[0_0_15px_rgba(0,255,245,0.2)] disabled:opacity-50"
-              >
-                {submitting
-                  ? t("auth.creatingAccount", "Creating Account...")
-                  : t("auth.signup", "Create Account")}
-              </button>
-            </form>
           ) : (
-            <form onSubmit={handleVerify} className="space-y-5">
-              <div>
-                <label
-                  htmlFor="signup-verification-code"
-                  className="mb-2 block font-mono text-sm text-slate-400"
+            <>
+              {error && (
+                <div className="bg-neon-magenta/10 border-neon-magenta/30 text-neon-magenta mb-6 rounded-lg border p-3 font-mono text-sm">
+                  {error}
+                </div>
+              )}
+              <form onSubmit={handleSignUp} className="space-y-5">
+                <div>
+                  <label
+                    htmlFor="signup-name"
+                    className="mb-2 block font-mono text-sm text-slate-400"
+                  >
+                    {t("auth.fullName", "Full Name")}
+                    <span className="ml-1 text-slate-600">({t("auth.optional", "optional")})</span>
+                  </label>
+                  <input
+                    id="signup-name"
+                    type="text"
+                    value={fullName}
+                    onChange={(e) => setFullName(e.target.value)}
+                    autoComplete="name"
+                    className="bg-void focus:border-neon-cyan/50 w-full rounded-lg border border-slate-700 px-4 py-3 font-mono text-sm text-white transition-all focus:shadow-[0_0_10px_rgba(0,255,245,0.1)] focus:outline-none"
+                    placeholder={t("auth.namePlaceholder", "John Doe")}
+                  />
+                </div>
+                <div>
+                  <label
+                    htmlFor="signup-email"
+                    className="mb-2 block font-mono text-sm text-slate-400"
+                  >
+                    {t("auth.email", "Email")}
+                  </label>
+                  <input
+                    id="signup-email"
+                    type="email"
+                    value={email}
+                    onChange={(e) => setEmail(e.target.value)}
+                    required
+                    autoComplete="email"
+                    className="bg-void focus:border-neon-cyan/50 w-full rounded-lg border border-slate-700 px-4 py-3 font-mono text-sm text-white transition-all focus:shadow-[0_0_10px_rgba(0,255,245,0.1)] focus:outline-none"
+                    placeholder="your@email.com"
+                  />
+                </div>
+                <div>
+                  <label
+                    htmlFor="signup-password"
+                    className="mb-2 block font-mono text-sm text-slate-400"
+                  >
+                    {t("auth.password", "Password")}
+                  </label>
+                  <input
+                    id="signup-password"
+                    type="password"
+                    value={password}
+                    onChange={(e) => setPassword(e.target.value)}
+                    required
+                    minLength={8}
+                    autoComplete="new-password"
+                    className="bg-void focus:border-neon-cyan/50 w-full rounded-lg border border-slate-700 px-4 py-3 font-mono text-sm text-white transition-all focus:shadow-[0_0_10px_rgba(0,255,245,0.1)] focus:outline-none"
+                    placeholder={t("auth.minChars", "Min. 8 characters")}
+                  />
+                </div>
+                <div>
+                  <label
+                    htmlFor="signup-confirm-password"
+                    className="mb-2 block font-mono text-sm text-slate-400"
+                  >
+                    {t("auth.confirmPassword", "Confirm Password")}
+                  </label>
+                  <input
+                    id="signup-confirm-password"
+                    type="password"
+                    value={confirmPassword}
+                    onChange={(e) => setConfirmPassword(e.target.value)}
+                    required
+                    minLength={8}
+                    autoComplete="new-password"
+                    className="bg-void focus:border-neon-cyan/50 w-full rounded-lg border border-slate-700 px-4 py-3 font-mono text-sm text-white transition-all focus:shadow-[0_0_10px_rgba(0,255,245,0.1)] focus:outline-none"
+                    placeholder={t("auth.reenterPassword", "Re-enter password")}
+                  />
+                </div>
+                <button
+                  type="submit"
+                  disabled={submitting}
+                  className="bg-neon-cyan/10 border-neon-cyan/50 text-neon-cyan hover:bg-neon-cyan/20 min-h-11 w-full rounded-lg border py-3 font-mono font-semibold transition-all hover:shadow-[0_0_15px_rgba(0,255,245,0.2)] disabled:opacity-50"
                 >
-                  {t("auth.verificationCode", "Verification Code")}
-                </label>
-                <input
-                  id="signup-verification-code"
-                  type="text"
-                  value={code}
-                  onChange={(e) => setCode(e.target.value)}
-                  required
-                  autoComplete="one-time-code"
-                  className="bg-void focus:border-neon-cyan/50 w-full rounded-lg border border-slate-700 px-4 py-3 text-center font-mono text-sm tracking-[0.3em] text-white transition-all focus:shadow-[0_0_10px_rgba(0,255,245,0.1)] focus:outline-none"
-                  placeholder="123456"
-                  maxLength={6}
-                />
-              </div>
-              <button
-                type="submit"
-                disabled={submitting}
-                className="bg-neon-cyan/10 border-neon-cyan/50 text-neon-cyan hover:bg-neon-cyan/20 min-h-11 w-full rounded-lg border py-3 font-mono font-semibold transition-all hover:shadow-[0_0_15px_rgba(0,255,245,0.2)] disabled:opacity-50"
-              >
-                {submitting
-                  ? t("auth.verifying", "Verifying...")
-                  : t("auth.verifyEmail", "Verify Email")}
-              </button>
-            </form>
-          )}
+                  {submitting
+                    ? t("auth.creatingAccount", "Creating Account...")
+                    : t("auth.signup", "Create Account")}
+                </button>
+              </form>
 
-          <p className="mt-6 text-center font-mono text-sm text-slate-500">
-            {t("auth.hasAccount", "Already have an account?")}{" "}
-            <Link href="/auth/login" className="text-neon-cyan hover:underline">
-              {t("auth.login", "Sign In")}
-            </Link>
-          </p>
+              <p className="mt-6 text-center font-mono text-sm text-slate-500">
+                {t("auth.hasAccount", "Already have an account?")}{" "}
+                <Link href="/auth/login" className="text-neon-cyan hover:underline">
+                  {t("auth.login", "Sign In")}
+                </Link>
+              </p>
+            </>
+          )}
         </div>
       </div>
     </div>

--- a/src/app/api/auth/register/route.ts
+++ b/src/app/api/auth/register/route.ts
@@ -1,0 +1,124 @@
+import { NextResponse } from "next/server";
+import { getConfig } from "@/lib/ssm-config";
+
+interface RegisterBody {
+  email: string;
+  password: string;
+  fullName?: string;
+}
+
+async function getAdminToken(tokenUrl: string, clientId: string, clientSecret: string) {
+  const res = await globalThis.fetch(tokenUrl, {
+    method: "POST",
+    headers: { "Content-Type": "application/x-www-form-urlencoded" },
+    body: new URLSearchParams({
+      grant_type: "client_credentials",
+      client_id: clientId,
+      client_secret: clientSecret,
+    }).toString(),
+  });
+  if (!res.ok) throw new Error(`Admin token request failed: ${res.status}`);
+  const data = (await res.json()) as { access_token: string };
+  return data.access_token;
+}
+
+export async function POST(req: Request) {
+  const issuer = process.env.KEYCLOAK_ISSUER;
+  if (!issuer) {
+    return NextResponse.json({ error: "Registration not available" }, { status: 503 });
+  }
+
+  // issuer = https://auth.cloudless.gr/realms/master
+  const realmMatch = issuer.match(/^(https?:\/\/[^/]+)\/realms\/([^/]+)$/);
+  if (!realmMatch) {
+    return NextResponse.json({ error: "Registration not available" }, { status: 503 });
+  }
+  const [, kcBase, realm] = realmMatch;
+
+  let body: RegisterBody;
+  try {
+    body = (await req.json()) as RegisterBody;
+  } catch {
+    return NextResponse.json({ error: "Invalid request body" }, { status: 400 });
+  }
+
+  const { email, password, fullName } = body;
+  if (!email || !password) {
+    return NextResponse.json({ error: "Email and password are required" }, { status: 400 });
+  }
+  if (password.length < 8) {
+    return NextResponse.json({ error: "Password must be at least 8 characters" }, { status: 400 });
+  }
+
+  const config = await getConfig();
+  if (!config.KEYCLOAK_ADMIN_CLIENT_ID || !config.KEYCLOAK_ADMIN_CLIENT_SECRET) {
+    return NextResponse.json({ error: "Registration not available" }, { status: 503 });
+  }
+
+  try {
+    const adminToken = await getAdminToken(
+      `${issuer}/protocol/openid-connect/token`,
+      config.KEYCLOAK_ADMIN_CLIENT_ID,
+      config.KEYCLOAK_ADMIN_CLIENT_SECRET
+    );
+
+    const parts = (fullName ?? "").trim().split(" ").filter(Boolean);
+    const userRep: Record<string, unknown> = {
+      email,
+      username: email,
+      enabled: true,
+      emailVerified: false,
+      requiredActions: ["VERIFY_EMAIL"],
+      credentials: [{ type: "password", value: password, temporary: false }],
+    };
+    if (parts[0]) userRep.firstName = parts[0];
+    if (parts.length > 1) userRep.lastName = parts.slice(1).join(" ");
+
+    const createRes = await globalThis.fetch(`${kcBase}/admin/realms/${realm}/users`, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${adminToken}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(userRep),
+    });
+
+    if (createRes.status === 409) {
+      return NextResponse.json(
+        { error: "An account with this email already exists" },
+        { status: 409 }
+      );
+    }
+    if (!createRes.ok) {
+      const errData = (await createRes.json().catch(() => null)) as {
+        errorMessage?: string;
+      } | null;
+      return NextResponse.json(
+        { error: errData?.errorMessage ?? "Registration failed" },
+        { status: 400 }
+      );
+    }
+
+    // Send verification email via the app client so the link returns to cloudless.gr
+    const userId = createRes.headers.get("Location")?.split("/").pop();
+    if (userId) {
+      const appClientId = process.env.NEXT_PUBLIC_KEYCLOAK_CLIENT_ID ?? "cloudless-app";
+      const siteUrl = process.env.NEXT_PUBLIC_SITE_URL ?? "";
+      const params = new URLSearchParams({ client_id: appClientId });
+      if (siteUrl) params.set("redirect_uri", `${siteUrl}/api/auth/callback/keycloak`);
+      // Best-effort: if SMTP is not yet configured the email silently fails;
+      // the VERIFY_EMAIL required action still blocks sign-in until verified.
+      await globalThis
+        .fetch(
+          `${kcBase}/admin/realms/${realm}/users/${userId}/send-verify-email?${params.toString()}`,
+          { method: "PUT", headers: { Authorization: `Bearer ${adminToken}` } }
+        )
+        .catch(() => {});
+    }
+
+    return NextResponse.json({ ok: true });
+  } catch (err) {
+    console.error("[auth/register]", err);
+    return NextResponse.json({ error: "Registration failed" }, { status: 500 });
+  }
+}


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- **New `POST /api/auth/register`** — creates users via Keycloak Admin API (client_credentials), sets `VERIFY_EMAIL` required action, and sends a verification email **link** (not a code). Best-effort SMTP: the required action still gates sign-in even if SMTP isn't configured yet.
- **Signup page** — replaces dead Cognito-style 6-digit code-entry step with a proper "Check Your Email" confirmation that shows the target address and a "Go to Sign In →" link. User stays on cloudless.gr throughout.
- **Forgot-password page** — removes dead Cognito confirm step (code + new-password inputs that could never appear since `forgotPassword()` navigates the browser away immediately). Fixes two CRITICAL locale-aware navigation violations: `next/link` and `next/navigation` → `@/i18n/navigation`.

## Why

The previous signup page had a two-step flow copied from Cognito:
1. Form → `signUp()` which immediately redirected the browser to Keycloak's hosted registration page
2. `setStep("verify")` — **unreachable dead code** (browser had already navigated away)

The verify step showed a Cognito-style numeric code input that could never be submitted, because Keycloak uses email links, not codes.

The forgot-password page had the same pattern: `forgotPassword()` navigated away, making the entire confirm step dead code, and used `next/link`/`next/navigation` (produces double-locale 404s).

## Test plan

- [ ] `pnpm vitest run` — 61 auth tests pass
- [ ] `pnpm tsc --noEmit` — no errors
- [ ] Register at `/auth/signup` with a real email → "Check Your Email" state appears after submit
- [ ] After SES SMTP workflow runs: verification email arrives with a link (not a code)
- [ ] Clicking the link signs the user in
- [ ] `/auth/forgot-password` → enter email → redirected to Keycloak reset-credentials page (no dead step 2)

https://claude.ai/code/session_01PHsA9s3tK2thgSJVwEGuWq
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01PHsA9s3tK2thgSJVwEGuWq)_