### PR TITLE
test(auth): comprehensive tests for registration API, signup page, and auth callbacks

### DIFF
--- a/__tests__/auth-lib-callbacks.test.ts
+++ b/__tests__/auth-lib-callbacks.test.ts
@@ -1,0 +1,335 @@
+/**
+ * Tests for the REAL next-auth callbacks in src/lib/auth.ts
+ *
+ * The existing keycloak-implementation.test.ts re-implements the callbacks
+ * from scratch. This file imports the actual module and exercises:
+ *
+ *  - decodeJwtPayload (indirectly, via jwt callback)
+ *  - groups preference chain: id_token → access_token → profile
+ *  - roles from realm_access.roles
+ *  - token reuse when not expired
+ *  - refresh token rotation (success + failure)
+ *  - RefreshTokenError when no refresh_token is present
+ *  - session callback: accessToken, idToken, groups, roles, error propagation
+ *  - RP-initiated logout (signOut event hits the end_session_endpoint)
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+// ── Capture the config NextAuth() is called with ──────────────────────────────
+
+let capturedConfig: Record<string, unknown> = {};
+
+vi.mock("next-auth", () => ({
+  default: (config: Record<string, unknown>) => {
+    capturedConfig = config;
+    return {
+      handlers: { GET: vi.fn(), POST: vi.fn() },
+      signIn: vi.fn(),
+      signOut: vi.fn(),
+      auth: vi.fn(),
+    };
+  },
+}));
+
+vi.mock("next-auth/providers/keycloak", () => ({
+  default: (opts: Record<string, unknown>) => ({ ...opts, name: "keycloak" }),
+}));
+
+// ── JWT helper: build a valid-looking (but unsigned) HS256 token ──────────────
+
+function buildToken(payload: Record<string, unknown>): string {
+  const header = btoa(JSON.stringify({ alg: "HS256" }))
+    .replaceAll("+", "-")
+    .replaceAll("/", "_")
+    .replaceAll("=", "");
+  const body = btoa(JSON.stringify(payload))
+    .replaceAll("+", "-")
+    .replaceAll("/", "_")
+    .replaceAll("=", "");
+  return `${header}.${body}.sig`;
+}
+
+// ── Types mirroring the callback signatures ───────────────────────────────────
+
+type JwtInput = {
+  token: Record<string, unknown>;
+  account?: Record<string, unknown> | null;
+  profile?: Record<string, unknown> | null;
+};
+
+type SessionInput = {
+  session: {
+    user: { id: string; name?: string; email?: string };
+    accessToken?: string;
+    idToken?: string;
+    error?: string;
+  };
+  token: Record<string, unknown>;
+};
+
+// ── tests ─────────────────────────────────────────────────────────────────────
+
+describe("src/lib/auth.ts — real callback behaviour", () => {
+  const origFetch = globalThis.fetch;
+
+  beforeEach(async () => {
+    vi.resetModules();
+    capturedConfig = {};
+    process.env.AUTH_SECRET = "test-auth-secret-32-chars-padded!!";
+    process.env.KEYCLOAK_ISSUER = "https://auth.test/realms/master";
+    process.env.KEYCLOAK_CLIENT_ID = "cloudless-app";
+    process.env.KEYCLOAK_CLIENT_SECRET = "client-secret";
+    await import("@/lib/auth");
+  });
+
+  afterEach(() => {
+    globalThis.fetch = origFetch;
+  });
+
+  // ── groups extraction ──────────────────────────────────────────────────────
+
+  it("extracts groups from the id_token payload (preferred source)", async () => {
+    const jwt = capturedConfig.callbacks as Record<
+      string,
+      (a: JwtInput) => Promise<Record<string, unknown>>
+    >;
+    const idToken = buildToken({ groups: ["admin"] });
+    const accessToken = buildToken({ groups: ["other"] });
+    const result = await jwt.jwt({
+      token: {},
+      account: {
+        access_token: accessToken,
+        id_token: idToken,
+        expires_at: Math.floor(Date.now() / 1000) + 3600,
+        expires_in: 3600,
+      },
+    });
+    expect(result.groups).toEqual(["admin"]);
+  });
+
+  it("falls back to access_token groups when id_token has none", async () => {
+    const jwt = capturedConfig.callbacks as Record<
+      string,
+      (a: JwtInput) => Promise<Record<string, unknown>>
+    >;
+    const idToken = buildToken({ sub: "u1" });
+    const accessToken = buildToken({ groups: ["member"] });
+    const result = await jwt.jwt({
+      token: {},
+      account: {
+        access_token: accessToken,
+        id_token: idToken,
+        expires_at: Math.floor(Date.now() / 1000) + 3600,
+        expires_in: 3600,
+      },
+    });
+    expect(result.groups).toEqual(["member"]);
+  });
+
+  it("falls back to profile groups when neither token has them", async () => {
+    const jwt = capturedConfig.callbacks as Record<
+      string,
+      (a: JwtInput) => Promise<Record<string, unknown>>
+    >;
+    const idToken = buildToken({ sub: "u1" });
+    const accessToken = buildToken({ sub: "u1" });
+    const result = await jwt.jwt({
+      token: {},
+      account: {
+        access_token: accessToken,
+        id_token: idToken,
+        expires_at: Math.floor(Date.now() / 1000) + 3600,
+        expires_in: 3600,
+      },
+      profile: { groups: ["viewer"] },
+    });
+    expect(result.groups).toEqual(["viewer"]);
+  });
+
+  it("extracts realm roles from realm_access.roles in access_token", async () => {
+    const jwt = capturedConfig.callbacks as Record<
+      string,
+      (a: JwtInput) => Promise<Record<string, unknown>>
+    >;
+    const accessToken = buildToken({ realm_access: { roles: ["offline_access", "admin"] } });
+    const result = await jwt.jwt({
+      token: {},
+      account: {
+        access_token: accessToken,
+        id_token: buildToken({}),
+        expires_at: Math.floor(Date.now() / 1000) + 3600,
+        expires_in: 3600,
+      },
+    });
+    expect(result.roles).toContain("admin");
+  });
+
+  it("handles a malformed JWT segment without throwing (returns empty claims)", async () => {
+    const jwt = capturedConfig.callbacks as Record<
+      string,
+      (a: JwtInput) => Promise<Record<string, unknown>>
+    >;
+    const result = await jwt.jwt({
+      token: {},
+      account: {
+        access_token: "not.a.validjwt!!!",
+        id_token: "also.not.valid",
+        expires_at: Math.floor(Date.now() / 1000) + 3600,
+        expires_in: 3600,
+      },
+    });
+    // Should not throw; groups/roles fall back to []
+    expect(Array.isArray(result.groups)).toBe(true);
+    expect(Array.isArray(result.roles)).toBe(true);
+  });
+
+  // ── token lifetime ─────────────────────────────────────────────────────────
+
+  it("reuses the token unchanged when access_token has not expired", async () => {
+    const jwt = capturedConfig.callbacks as Record<
+      string,
+      (a: JwtInput) => Promise<Record<string, unknown>>
+    >;
+    const existing = {
+      accessToken: "atk",
+      refreshToken: "rtk",
+      expiresAt: Math.floor(Date.now() / 1000) + 3600,
+      groups: ["admin"],
+      roles: [],
+    };
+    const result = await jwt.jwt({ token: { ...existing } });
+    expect(result.accessToken).toBe("atk");
+    expect(result.groups).toEqual(["admin"]);
+  });
+
+  it("flags RefreshTokenError when there is no refresh_token", async () => {
+    const jwt = capturedConfig.callbacks as Record<
+      string,
+      (a: JwtInput) => Promise<Record<string, unknown>>
+    >;
+    const expired = {
+      accessToken: "old",
+      expiresAt: Math.floor(Date.now() / 1000) - 60,
+    };
+    const result = await jwt.jwt({ token: { ...expired } });
+    expect(result.error).toBe("RefreshTokenError");
+  });
+
+  it("rotates tokens using the refresh_token when access_token has expired", async () => {
+    const jwt = capturedConfig.callbacks as Record<
+      string,
+      (a: JwtInput) => Promise<Record<string, unknown>>
+    >;
+    const newAccessToken = buildToken({ groups: ["admin"], realm_access: { roles: [] } });
+    globalThis.fetch = vi.fn().mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: async () => ({
+        access_token: newAccessToken,
+        refresh_token: "rtk-new",
+        expires_in: 3600,
+      }),
+    });
+    const expired = {
+      accessToken: "old-atk",
+      refreshToken: "rtk-old",
+      expiresAt: Math.floor(Date.now() / 1000) - 60,
+      groups: ["member"],
+      roles: [],
+    };
+    const result = await jwt.jwt({ token: { ...expired } });
+    expect(result.accessToken).toBe(newAccessToken);
+    expect(result.refreshToken).toBe("rtk-new");
+    expect(result.error).toBeUndefined();
+  });
+
+  it("sets RefreshTokenError when the refresh call fails", async () => {
+    const jwt = capturedConfig.callbacks as Record<
+      string,
+      (a: JwtInput) => Promise<Record<string, unknown>>
+    >;
+    globalThis.fetch = vi.fn().mockResolvedValueOnce({ ok: false, status: 401 });
+    const expired = {
+      accessToken: "old",
+      refreshToken: "rtk",
+      expiresAt: Math.floor(Date.now() / 1000) - 60,
+    };
+    const result = await jwt.jwt({ token: { ...expired } });
+    expect(result.error).toBe("RefreshTokenError");
+  });
+
+  // ── session callback ───────────────────────────────────────────────────────
+
+  it("session callback surfaces accessToken, idToken, groups, roles, and user.id", async () => {
+    const { session: sessionCb } = capturedConfig.callbacks as {
+      session: (a: SessionInput) => Promise<SessionInput["session"]>;
+    };
+    const out = await sessionCb({
+      session: { user: { id: "" } },
+      token: {
+        sub: "u-1",
+        accessToken: "atk",
+        idToken: "itk",
+        groups: ["admin"],
+        roles: ["offline_access"],
+      },
+    });
+    expect(out.user.id).toBe("u-1");
+    expect(out.accessToken).toBe("atk");
+    expect(out.idToken).toBe("itk");
+    expect((out as Record<string, unknown>).user).toMatchObject({
+      groups: ["admin"],
+      roles: ["offline_access"],
+    });
+  });
+
+  it("session callback propagates RefreshTokenError to the client", async () => {
+    const { session: sessionCb } = capturedConfig.callbacks as {
+      session: (a: SessionInput) => Promise<SessionInput["session"]>;
+    };
+    const out = await sessionCb({
+      session: { user: { id: "" } },
+      token: { sub: "u-1", error: "RefreshTokenError" },
+    });
+    expect((out as Record<string, unknown>).error).toBe("RefreshTokenError");
+  });
+
+  // ── RP-Initiated Logout (signOut event) ───────────────────────────────────
+
+  it("signOut event calls Keycloak end_session_endpoint with id_token_hint", async () => {
+    const fetchMock = vi.fn().mockResolvedValueOnce({ ok: true });
+    globalThis.fetch = fetchMock;
+
+    const { signOut: signOutEvent } = capturedConfig.events as {
+      signOut: (msg: { token?: { idToken?: string } }) => Promise<void>;
+    };
+    await signOutEvent({ token: { idToken: "id-tok-123" } });
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const url = fetchMock.mock.calls[0][0] as string;
+    expect(url).toContain("protocol/openid-connect/logout");
+    expect(url).toContain("id_token_hint=id-tok-123");
+  });
+
+  it("signOut event is a no-op when there is no id_token", async () => {
+    const fetchMock = vi.fn();
+    globalThis.fetch = fetchMock;
+
+    const { signOut: signOutEvent } = capturedConfig.events as {
+      signOut: (msg: { token?: { idToken?: string } }) => Promise<void>;
+    };
+    await signOutEvent({ token: {} });
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("signOut event swallows fetch errors (best-effort SSO logout)", async () => {
+    globalThis.fetch = vi.fn().mockRejectedValueOnce(new Error("network error"));
+
+    const { signOut: signOutEvent } = capturedConfig.events as {
+      signOut: (msg: { token?: { idToken?: string } }) => Promise<void>;
+    };
+    await expect(
+      signOutEvent({ token: { idToken: "tok" } })
+    ).resolves.toBeUndefined();
+  });
+});

--- a/__tests__/auth-public-a11y.test.tsx
+++ b/__tests__/auth-public-a11y.test.tsx
@@ -80,15 +80,15 @@ describe("auth/public accessibility", () => {
     expect(container.querySelector('a[href="/auth/login"]')).toBeTruthy();
   });
 
-  it("forgot password page uses one-time-code and new-password semantics", () => {
+  it("forgot password page has email field and reset link button", () => {
     render(<ForgotPasswordPage />);
 
     const email = screen.getByLabelText("Email") as HTMLInputElement;
-    const sendCode = screen.getByRole("button", { name: "Send Reset Code" });
+    const sendLink = screen.getByRole("button", { name: "Send Reset Link" });
 
     expect(email.type).toBe("email");
     expect(email.autocomplete).toBe("email");
-    expect(sendCode).toBeTruthy();
+    expect(sendLink).toBeTruthy();
   });
 
   it("newsletter form provides email field, explicit submit button, and privacy link", () => {

--- a/__tests__/auth-register-api.test.ts
+++ b/__tests__/auth-register-api.test.ts
@@ -1,0 +1,317 @@
+/**
+ * Unit tests for POST /api/auth/register
+ *
+ * The route creates a Keycloak user via Admin REST API (client_credentials),
+ * sets the VERIFY_EMAIL required action, and sends a verification email link.
+ * All three HTTP calls (token, create user, send-verify-email) are mocked.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+const mockGetConfig = vi.fn();
+vi.mock("@/lib/ssm-config", () => ({ getConfig: mockGetConfig }));
+
+const ISSUER = "https://auth.test/realms/master";
+const KC_BASE = "https://auth.test";
+const REALM = "master";
+const ADMIN_CFG = {
+  KEYCLOAK_ADMIN_CLIENT_ID: "cloudless-admin-api",
+  KEYCLOAK_ADMIN_CLIENT_SECRET: "s3cr3t",
+};
+
+// ── fetch response factories ──────────────────────────────────────────────────
+
+function tokenOk() {
+  return {
+    ok: true,
+    status: 200,
+    headers: { get: () => null },
+    json: async () => ({ access_token: "tok-123" }),
+  };
+}
+
+function createOk(userId = "uid-abc") {
+  return {
+    ok: true,
+    status: 201,
+    headers: {
+      get: (k: string) =>
+        k === "Location" ? `${KC_BASE}/admin/realms/${REALM}/users/${userId}` : null,
+    },
+    json: async () => ({}),
+  };
+}
+
+function verifyOk() {
+  return { ok: true, status: 200, headers: { get: () => null }, json: async () => ({}) };
+}
+
+// ── request factory ───────────────────────────────────────────────────────────
+
+function req(body: unknown) {
+  return new Request("http://localhost/api/auth/register", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+// ── tests ─────────────────────────────────────────────────────────────────────
+
+describe("POST /api/auth/register", () => {
+  const origFetch = globalThis.fetch;
+  let fetchMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.resetModules();
+    process.env.KEYCLOAK_ISSUER = ISSUER;
+    process.env.NEXT_PUBLIC_KEYCLOAK_CLIENT_ID = "cloudless-app";
+    process.env.NEXT_PUBLIC_SITE_URL = "https://cloudless.gr";
+    mockGetConfig.mockResolvedValue(ADMIN_CFG);
+    fetchMock = vi.fn();
+    globalThis.fetch = fetchMock;
+  });
+
+  afterEach(() => {
+    globalThis.fetch = origFetch;
+    delete process.env.KEYCLOAK_ISSUER;
+    delete process.env.NEXT_PUBLIC_SITE_URL;
+  });
+
+  // ── config guards ──────────────────────────────────────────────────────────
+
+  it("returns 503 when KEYCLOAK_ISSUER is not set", async () => {
+    delete process.env.KEYCLOAK_ISSUER;
+    const { POST } = await import("@/app/api/auth/register/route");
+    const res = await POST(req({ email: "a@b.com", password: "password1" }));
+    expect(res.status).toBe(503);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("returns 503 when issuer does not match /realms/ pattern", async () => {
+    process.env.KEYCLOAK_ISSUER = "https://auth.test/not-a-realm";
+    const { POST } = await import("@/app/api/auth/register/route");
+    const res = await POST(req({ email: "a@b.com", password: "password1" }));
+    expect(res.status).toBe(503);
+  });
+
+  it("returns 503 when admin client ID is missing from SSM", async () => {
+    mockGetConfig.mockResolvedValue({ KEYCLOAK_ADMIN_CLIENT_ID: "", KEYCLOAK_ADMIN_CLIENT_SECRET: "x" });
+    const { POST } = await import("@/app/api/auth/register/route");
+    const res = await POST(req({ email: "a@b.com", password: "password1" }));
+    expect(res.status).toBe(503);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("returns 503 when admin client secret is missing from SSM", async () => {
+    mockGetConfig.mockResolvedValue({ KEYCLOAK_ADMIN_CLIENT_ID: "id", KEYCLOAK_ADMIN_CLIENT_SECRET: "" });
+    const { POST } = await import("@/app/api/auth/register/route");
+    const res = await POST(req({ email: "a@b.com", password: "password1" }));
+    expect(res.status).toBe(503);
+  });
+
+  // ── input validation ───────────────────────────────────────────────────────
+
+  it("returns 400 when email is missing", async () => {
+    const { POST } = await import("@/app/api/auth/register/route");
+    const res = await POST(req({ password: "password1" }));
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toMatch(/email/i);
+  });
+
+  it("returns 400 when password is missing", async () => {
+    const { POST } = await import("@/app/api/auth/register/route");
+    const res = await POST(req({ email: "a@b.com" }));
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 when password is shorter than 8 characters", async () => {
+    const { POST } = await import("@/app/api/auth/register/route");
+    const res = await POST(req({ email: "a@b.com", password: "short" }));
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toMatch(/8/);
+  });
+
+  it("returns 400 when request body is not valid JSON", async () => {
+    const { POST } = await import("@/app/api/auth/register/route");
+    const badReq = new Request("http://localhost/api/auth/register", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: "not-json",
+    });
+    const res = await POST(badReq);
+    expect(res.status).toBe(400);
+  });
+
+  // ── Keycloak API error handling ────────────────────────────────────────────
+
+  it("returns 500 when admin token fetch fails", async () => {
+    fetchMock.mockResolvedValueOnce({
+      ok: false,
+      status: 401,
+      headers: { get: () => null },
+      json: async () => ({}),
+    });
+    const { POST } = await import("@/app/api/auth/register/route");
+    const res = await POST(req({ email: "a@b.com", password: "password1" }));
+    expect(res.status).toBe(500);
+  });
+
+  it("returns 409 when email already exists in Keycloak", async () => {
+    fetchMock
+      .mockResolvedValueOnce(tokenOk())
+      .mockResolvedValueOnce({
+        ok: false,
+        status: 409,
+        headers: { get: () => null },
+        json: async () => ({}),
+      });
+    const { POST } = await import("@/app/api/auth/register/route");
+    const res = await POST(req({ email: "existing@b.com", password: "password1" }));
+    expect(res.status).toBe(409);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toMatch(/already exists/i);
+  });
+
+  it("returns 400 with Keycloak errorMessage on password policy violation", async () => {
+    fetchMock.mockResolvedValueOnce(tokenOk()).mockResolvedValueOnce({
+      ok: false,
+      status: 400,
+      headers: { get: () => null },
+      json: async () => ({ errorMessage: "Password does not meet policy requirements" }),
+    });
+    const { POST } = await import("@/app/api/auth/register/route");
+    const res = await POST(req({ email: "a@b.com", password: "password1" }));
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toBe("Password does not meet policy requirements");
+  });
+
+  it("returns 400 with fallback message when Keycloak gives no errorMessage", async () => {
+    fetchMock.mockResolvedValueOnce(tokenOk()).mockResolvedValueOnce({
+      ok: false,
+      status: 400,
+      headers: { get: () => null },
+      json: async () => ({}),
+    });
+    const { POST } = await import("@/app/api/auth/register/route");
+    const res = await POST(req({ email: "a@b.com", password: "password1" }));
+    expect(res.status).toBe(400);
+  });
+
+  // ── success path ───────────────────────────────────────────────────────────
+
+  it("returns { ok: true } on successful registration", async () => {
+    fetchMock
+      .mockResolvedValueOnce(tokenOk())
+      .mockResolvedValueOnce(createOk())
+      .mockResolvedValueOnce(verifyOk());
+    const { POST } = await import("@/app/api/auth/register/route");
+    const res = await POST(req({ email: "new@b.com", password: "password1" }));
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ ok: true });
+  });
+
+  it("sends verification email to the newly created user", async () => {
+    fetchMock
+      .mockResolvedValueOnce(tokenOk())
+      .mockResolvedValueOnce(createOk("uid-42"))
+      .mockResolvedValueOnce(verifyOk());
+    const { POST } = await import("@/app/api/auth/register/route");
+    await POST(req({ email: "new@b.com", password: "password1" }));
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+    const [verifyUrl, verifyOpts] = fetchMock.mock.calls[2] as [string, RequestInit];
+    expect(verifyUrl).toContain(`/users/uid-42/send-verify-email`);
+    expect(verifyOpts.method).toBe("PUT");
+    expect(verifyUrl).toContain("client_id=cloudless-app");
+    expect(verifyUrl).toContain("redirect_uri=");
+    expect(verifyUrl).toContain("cloudless.gr");
+  });
+
+  it("user representation sets emailVerified=false and VERIFY_EMAIL required action", async () => {
+    fetchMock
+      .mockResolvedValueOnce(tokenOk())
+      .mockResolvedValueOnce(createOk())
+      .mockResolvedValueOnce(verifyOk());
+    const { POST } = await import("@/app/api/auth/register/route");
+    await POST(req({ email: "a@b.com", password: "password1" }));
+    const userRep = JSON.parse(fetchMock.mock.calls[1][1].body as string) as Record<
+      string,
+      unknown
+    >;
+    expect(userRep.emailVerified).toBe(false);
+    expect(userRep.enabled).toBe(true);
+    expect(userRep.requiredActions).toContain("VERIFY_EMAIL");
+    expect(userRep.username).toBe("a@b.com");
+    expect(userRep.email).toBe("a@b.com");
+  });
+
+  it("splits fullName into firstName + lastName on the user representation", async () => {
+    fetchMock
+      .mockResolvedValueOnce(tokenOk())
+      .mockResolvedValueOnce(createOk())
+      .mockResolvedValueOnce(verifyOk());
+    const { POST } = await import("@/app/api/auth/register/route");
+    await POST(req({ email: "a@b.com", password: "password1", fullName: "John Doe Smith" }));
+    const userRep = JSON.parse(fetchMock.mock.calls[1][1].body as string) as Record<
+      string,
+      unknown
+    >;
+    expect(userRep.firstName).toBe("John");
+    expect(userRep.lastName).toBe("Doe Smith");
+  });
+
+  it("omits firstName/lastName when fullName is absent or empty", async () => {
+    fetchMock
+      .mockResolvedValueOnce(tokenOk())
+      .mockResolvedValueOnce(createOk())
+      .mockResolvedValueOnce(verifyOk());
+    const { POST } = await import("@/app/api/auth/register/route");
+    await POST(req({ email: "a@b.com", password: "password1" }));
+    const userRep = JSON.parse(fetchMock.mock.calls[1][1].body as string) as Record<
+      string,
+      unknown
+    >;
+    expect(userRep.firstName).toBeUndefined();
+    expect(userRep.lastName).toBeUndefined();
+  });
+
+  it("still returns 200 when the verification email call throws (best-effort)", async () => {
+    fetchMock
+      .mockResolvedValueOnce(tokenOk())
+      .mockResolvedValueOnce(createOk("uid-99"))
+      .mockRejectedValueOnce(new Error("SMTP not configured"));
+    const { POST } = await import("@/app/api/auth/register/route");
+    const res = await POST(req({ email: "a@b.com", password: "password1" }));
+    expect(res.status).toBe(200);
+  });
+
+  it("admin token uses client_credentials grant with correct client_id", async () => {
+    fetchMock
+      .mockResolvedValueOnce(tokenOk())
+      .mockResolvedValueOnce(createOk())
+      .mockResolvedValueOnce(verifyOk());
+    const { POST } = await import("@/app/api/auth/register/route");
+    await POST(req({ email: "a@b.com", password: "password1" }));
+    const [tokenUrl, tokenOpts] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(tokenUrl).toBe(`${ISSUER}/protocol/openid-connect/token`);
+    const formBody = new URLSearchParams(tokenOpts.body as string);
+    expect(formBody.get("grant_type")).toBe("client_credentials");
+    expect(formBody.get("client_id")).toBe(ADMIN_CFG.KEYCLOAK_ADMIN_CLIENT_ID);
+    expect(formBody.get("client_secret")).toBe(ADMIN_CFG.KEYCLOAK_ADMIN_CLIENT_SECRET);
+  });
+
+  it("user creation request uses admin bearer token and correct Admin API URL", async () => {
+    fetchMock
+      .mockResolvedValueOnce(tokenOk())
+      .mockResolvedValueOnce(createOk())
+      .mockResolvedValueOnce(verifyOk());
+    const { POST } = await import("@/app/api/auth/register/route");
+    await POST(req({ email: "a@b.com", password: "password1" }));
+    const [createUrl, createOpts] = fetchMock.mock.calls[1] as [string, RequestInit];
+    expect(createUrl).toBe(`${KC_BASE}/admin/realms/${REALM}/users`);
+    expect((createOpts.headers as Record<string, string>)["Authorization"]).toBe("Bearer tok-123");
+  });
+});

--- a/__tests__/auth-signup-page.test.tsx
+++ b/__tests__/auth-signup-page.test.tsx
@@ -1,0 +1,228 @@
+/**
+ * Component tests for src/app/[locale]/auth/signup/page.tsx
+ *
+ * Verifies the new in-app registration flow:
+ *   1. Form renders in signup step
+ *   2. Client-side password mismatch check
+ *   3. Calls POST /api/auth/register with correct payload
+ *   4. Transitions to "check-email" state on success
+ *   5. Surfaces API error on failure (duplicate email, 503, etc.)
+ *
+ * @vitest-environment jsdom
+ */
+import { render, screen, fireEvent, waitFor, act, cleanup } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import React, { Suspense } from "react";
+
+// ── top-level mocks ───────────────────────────────────────────────────────────
+
+vi.mock("@/context/AuthContext", () => ({
+  useAuth: () => ({
+    user: null,
+    isAdmin: false,
+    isLoading: false,
+    configError: null,
+  }),
+  AuthProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+vi.mock("@/i18n/navigation", () => ({
+  Link: ({
+    href,
+    children,
+    ...props
+  }: {
+    href: string;
+    children: React.ReactNode;
+    [k: string]: unknown;
+  }) => (
+    <a href={href} {...props}>
+      {children}
+    </a>
+  ),
+  useRouter: () => ({ push: vi.fn() }),
+}));
+
+vi.mock("next/navigation", () => ({
+  useSearchParams: () => ({ get: () => null }),
+}));
+
+vi.mock("@/lib/i18n", () => ({
+  translate: (_locale: string, _key: string, fallback: string) => fallback,
+}));
+
+vi.mock("@/lib/use-locale", () => ({
+  useCurrentLocale: () => ["en"],
+}));
+
+// ── helpers ───────────────────────────────────────────────────────────────────
+
+async function renderSignUp() {
+  const { default: SignUpPage } = await import(
+    "@/app/[locale]/auth/signup/page"
+  );
+  return render(
+    <Suspense fallback={null}>
+      <SignUpPage />
+    </Suspense>
+  );
+}
+
+function fillForm(email: string, password: string, confirm: string, name = "") {
+  if (name) {
+    fireEvent.change(screen.getByLabelText(/full name/i), { target: { value: name } });
+  }
+  fireEvent.change(screen.getByLabelText(/^email$/i), { target: { value: email } });
+  fireEvent.change(screen.getByLabelText(/^password$/i), { target: { value: password } });
+  fireEvent.change(screen.getByLabelText(/confirm password/i), {
+    target: { value: confirm },
+  });
+}
+
+// ── tests ─────────────────────────────────────────────────────────────────────
+
+describe("SignUpPage component", () => {
+  const origFetch = globalThis.fetch;
+  let fetchMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    vi.resetModules();
+    fetchMock = vi.fn();
+    globalThis.fetch = fetchMock;
+  });
+
+  afterEach(() => {
+    cleanup();
+    globalThis.fetch = origFetch;
+  });
+
+  it("renders the registration form in signup step", async () => {
+    await renderSignUp();
+    expect(screen.getByRole("heading", { name: /create account/i })).toBeTruthy();
+    expect(screen.getByLabelText(/^email$/i)).toBeTruthy();
+    expect(screen.getByLabelText(/^password$/i)).toBeTruthy();
+    expect(screen.getByLabelText(/confirm password/i)).toBeTruthy();
+    expect(screen.getByRole("button", { name: /create account/i })).toBeTruthy();
+  });
+
+  it("shows sign-in link in registration form", async () => {
+    const { container } = await renderSignUp();
+    expect(container.querySelector('a[href="/auth/login"]')).toBeTruthy();
+  });
+
+  it("shows password mismatch error without calling the API", async () => {
+    await renderSignUp();
+    fillForm("a@b.com", "password1", "different1");
+    await act(async () => {
+      fireEvent.submit(screen.getByRole("button", { name: /create account/i }).closest("form")!);
+    });
+    expect(await screen.findByText(/passwords do not match/i)).toBeTruthy();
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("calls POST /api/auth/register with email, password, and fullName", async () => {
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: async () => ({ ok: true }),
+    });
+    await renderSignUp();
+    fillForm("user@cloudless.gr", "mypassword", "mypassword", "Jane Doe");
+    await act(async () => {
+      fireEvent.submit(screen.getByRole("button", { name: /create account/i }).closest("form")!);
+    });
+    await waitFor(() => expect(fetchMock).toHaveBeenCalled());
+    const [url, opts] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe("/api/auth/register");
+    expect(opts.method).toBe("POST");
+    const body = JSON.parse(opts.body as string) as {
+      email: string;
+      password: string;
+      fullName: string;
+    };
+    expect(body.email).toBe("user@cloudless.gr");
+    expect(body.password).toBe("mypassword");
+    expect(body.fullName).toBe("Jane Doe");
+  });
+
+  it("transitions to check-email step on successful registration", async () => {
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: async () => ({ ok: true }),
+    });
+    await renderSignUp();
+    fillForm("user@cloudless.gr", "mypassword", "mypassword");
+    await act(async () => {
+      fireEvent.submit(screen.getByRole("button", { name: /create account/i }).closest("form")!);
+    });
+    await waitFor(() =>
+      expect(screen.queryByRole("heading", { name: /check your email/i })).toBeTruthy()
+    );
+    expect(screen.getByText("user@cloudless.gr")).toBeTruthy();
+    expect(screen.getByRole("link", { name: /go to sign in/i })).toBeTruthy();
+  });
+
+  it("shows 409 duplicate-email error from API", async () => {
+    fetchMock.mockResolvedValueOnce({
+      ok: false,
+      status: 409,
+      json: async () => ({ error: "An account with this email already exists" }),
+    });
+    await renderSignUp();
+    fillForm("dup@b.com", "password1", "password1");
+    await act(async () => {
+      fireEvent.submit(screen.getByRole("button", { name: /create account/i }).closest("form")!);
+    });
+    await waitFor(() =>
+      expect(screen.queryByText(/already exists/i)).toBeTruthy()
+    );
+    expect(screen.queryByRole("heading", { name: /check your email/i })).toBeNull();
+  });
+
+  it("shows 503 error when registration service is unavailable", async () => {
+    fetchMock.mockResolvedValueOnce({
+      ok: false,
+      status: 503,
+      json: async () => ({ error: "Registration not available" }),
+    });
+    await renderSignUp();
+    fillForm("a@b.com", "password1", "password1");
+    await act(async () => {
+      fireEvent.submit(screen.getByRole("button", { name: /create account/i }).closest("form")!);
+    });
+    await waitFor(() =>
+      expect(screen.queryByText(/registration not available/i)).toBeTruthy()
+    );
+  });
+
+  it("shows generic error when fetch throws", async () => {
+    fetchMock.mockRejectedValueOnce(new Error("Network error"));
+    await renderSignUp();
+    fillForm("a@b.com", "password1", "password1");
+    await act(async () => {
+      fireEvent.submit(screen.getByRole("button", { name: /create account/i }).closest("form")!);
+    });
+    await waitFor(() =>
+      expect(screen.queryByText(/sign up failed/i)).toBeTruthy()
+    );
+  });
+
+  it("omits fullName from the request body when name field is empty", async () => {
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: async () => ({ ok: true }),
+    });
+    await renderSignUp();
+    fillForm("a@b.com", "password1", "password1"); // no fullName
+    await act(async () => {
+      fireEvent.submit(screen.getByRole("button", { name: /create account/i }).closest("form")!);
+    });
+    await waitFor(() => expect(fetchMock).toHaveBeenCalled());
+    const body = JSON.parse(fetchMock.mock.calls[0][1].body as string) as {
+      fullName?: string;
+    };
+    expect(body.fullName).toBeUndefined();
+  });
+});

--- a/src/app/[locale]/auth/forgot-password/page.tsx
+++ b/src/app/[locale]/auth/forgot-password/page.tsx
@@ -1,8 +1,7 @@
 "use client";
 
 import { useState } from "react";
-import Link from "next/link";
-import { useRouter } from "next/navigation";
+import { Link } from "@/i18n/navigation";
 import { useAuth } from "@/context/AuthContext";
 import { translate } from "@/lib/i18n";
 import { useCurrentLocale } from "@/lib/use-locale";
@@ -10,12 +9,8 @@ import { useCurrentLocale } from "@/lib/use-locale";
 export default function ForgotPasswordPage() {
   const [locale] = useCurrentLocale();
   const t = (key: string, fallback: string) => translate(locale, key, fallback);
-  const { forgotPassword, confirmForgotPassword } = useAuth();
-  const router = useRouter();
+  const { forgotPassword } = useAuth();
   const [email, setEmail] = useState("");
-  const [code, setCode] = useState("");
-  const [newPassword, setNewPassword] = useState("");
-  const [step, setStep] = useState<"request" | "confirm">("request");
   const [error, setError] = useState("");
   const [submitting, setSubmitting] = useState(false);
 
@@ -24,25 +19,10 @@ export default function ForgotPasswordPage() {
     setError("");
     setSubmitting(true);
     try {
+      // Redirects to Keycloak's reset-credentials page; browser navigates away.
       await forgotPassword(email);
-      setStep("confirm");
     } catch (err: unknown) {
       setError(err instanceof Error ? err.message : "Request failed");
-    } finally {
-      setSubmitting(false);
-    }
-  };
-
-  const handleConfirm = async (e: React.FormEvent) => {
-    e.preventDefault();
-    setError("");
-    setSubmitting(true);
-    try {
-      await confirmForgotPassword(email, code, newPassword);
-      router.push("/auth/login");
-    } catch (err: unknown) {
-      setError(err instanceof Error ? err.message : "Reset failed");
-    } finally {
       setSubmitting(false);
     }
   };
@@ -56,14 +36,10 @@ export default function ForgotPasswordPage() {
             <span className="text-neon-blue font-mono text-xs">RECOVERY</span>
           </div>
           <h1 className="font-heading text-3xl font-bold text-white">
-            {step === "request"
-              ? t("auth.resetPasswordTitle", "Reset Password")
-              : t("auth.enterCode", "Enter Code")}
+            {t("auth.resetPasswordTitle", "Reset Password")}
           </h1>
           <p className="font-body mt-2 text-slate-400">
-            {step === "request"
-              ? t("auth.resetRequestDesc", "We'll send a verification code to your email")
-              : t("auth.resetCodeDesc", "Enter the code sent to {email}").replace("{email}", email)}
+            {t("auth.resetRequestDesc", "Enter your email and we'll send a reset link")}
           </p>
         </div>
 
@@ -74,87 +50,32 @@ export default function ForgotPasswordPage() {
             </div>
           )}
 
-          {step === "request" ? (
-            <form onSubmit={handleRequest} className="space-y-5">
-              <div>
-                <label
-                  htmlFor="forgot-email"
-                  className="mb-2 block font-mono text-sm text-slate-400"
-                >
-                  {t("auth.email", "Email")}
-                </label>
-                <input
-                  id="forgot-email"
-                  type="email"
-                  value={email}
-                  onChange={(e) => setEmail(e.target.value)}
-                  required
-                  autoComplete="email"
-                  className="bg-void focus:border-neon-cyan/50 w-full rounded-lg border border-slate-700 px-4 py-3 font-mono text-sm text-white transition-all focus:shadow-[0_0_10px_rgba(0,255,245,0.1)] focus:outline-none"
-                  placeholder="your@email.com"
-                />
-              </div>
-              <button
-                type="submit"
-                disabled={submitting}
-                className="bg-neon-cyan/10 border-neon-cyan/50 text-neon-cyan hover:bg-neon-cyan/20 min-h-[44px] w-full rounded-lg border py-3 font-mono font-semibold transition-all hover:shadow-[0_0_15px_rgba(0,255,245,0.2)] disabled:opacity-50"
-              >
-                {submitting
-                  ? t("auth.sendingCode", "Sending Code...")
-                  : t("auth.sendResetCode", "Send Reset Code")}
-              </button>
-            </form>
-          ) : (
-            <form onSubmit={handleConfirm} className="space-y-5">
-              <div>
-                <label
-                  htmlFor="forgot-verification-code"
-                  className="mb-2 block font-mono text-sm text-slate-400"
-                >
-                  {t("auth.verificationCode", "Verification Code")}
-                </label>
-                <input
-                  id="forgot-verification-code"
-                  type="text"
-                  value={code}
-                  onChange={(e) => setCode(e.target.value)}
-                  required
-                  autoComplete="one-time-code"
-                  className="bg-void focus:border-neon-cyan/50 w-full rounded-lg border border-slate-700 px-4 py-3 text-center font-mono text-sm tracking-[0.3em] text-white transition-all focus:shadow-[0_0_10px_rgba(0,255,245,0.1)] focus:outline-none"
-                  placeholder="123456"
-                  maxLength={6}
-                />
-              </div>
-              <div>
-                <label
-                  htmlFor="forgot-new-password"
-                  className="mb-2 block font-mono text-sm text-slate-400"
-                >
-                  {t("auth.newPassword", "New Password")}
-                </label>
-                <input
-                  id="forgot-new-password"
-                  type="password"
-                  value={newPassword}
-                  onChange={(e) => setNewPassword(e.target.value)}
-                  required
-                  minLength={8}
-                  autoComplete="new-password"
-                  className="bg-void focus:border-neon-cyan/50 w-full rounded-lg border border-slate-700 px-4 py-3 font-mono text-sm text-white transition-all focus:shadow-[0_0_10px_rgba(0,255,245,0.1)] focus:outline-none"
-                  placeholder={t("auth.minChars", "Min. 8 characters")}
-                />
-              </div>
-              <button
-                type="submit"
-                disabled={submitting}
-                className="bg-neon-cyan/10 border-neon-cyan/50 text-neon-cyan hover:bg-neon-cyan/20 min-h-[44px] w-full rounded-lg border py-3 font-mono font-semibold transition-all hover:shadow-[0_0_15px_rgba(0,255,245,0.2)] disabled:opacity-50"
-              >
-                {submitting
-                  ? t("auth.resetting", "Resetting...")
-                  : t("auth.resetPassword", "Reset Password")}
-              </button>
-            </form>
-          )}
+          <form onSubmit={handleRequest} className="space-y-5">
+            <div>
+              <label htmlFor="forgot-email" className="mb-2 block font-mono text-sm text-slate-400">
+                {t("auth.email", "Email")}
+              </label>
+              <input
+                id="forgot-email"
+                type="email"
+                value={email}
+                onChange={(e) => setEmail(e.target.value)}
+                required
+                autoComplete="email"
+                className="bg-void focus:border-neon-cyan/50 w-full rounded-lg border border-slate-700 px-4 py-3 font-mono text-sm text-white transition-all focus:shadow-[0_0_10px_rgba(0,255,245,0.1)] focus:outline-none"
+                placeholder="your@email.com"
+              />
+            </div>
+            <button
+              type="submit"
+              disabled={submitting}
+              className="bg-neon-cyan/10 border-neon-cyan/50 text-neon-cyan hover:bg-neon-cyan/20 min-h-[44px] w-full rounded-lg border py-3 font-mono font-semibold transition-all hover:shadow-[0_0_15px_rgba(0,255,245,0.2)] disabled:opacity-50"
+            >
+              {submitting
+                ? t("auth.redirecting", "Redirecting...")
+                : t("auth.sendResetLink", "Send Reset Link")}
+            </button>
+          </form>
 
           <p className="mt-6 text-center font-mono text-sm text-slate-500">
             {t("auth.rememberPassword", "Remember your password?")}{" "}

--- a/src/app/[locale]/auth/signup/page.tsx
+++ b/src/app/[locale]/auth/signup/page.tsx
@@ -10,12 +10,10 @@ import { useCurrentLocale } from "@/lib/use-locale";
 function SignUpForm() {
   const [locale] = useCurrentLocale();
   const t = (key: string, fallback: string) => translate(locale, key, fallback);
-  const { signUp, confirmSignUp, user, isAdmin, isLoading } = useAuth();
+  const { user, isAdmin, isLoading } = useAuth();
   const router = useRouter();
   const searchParams = useSearchParams();
 
-  // If a plan was selected on the services page, send the user straight to
-  // the portal waiting room after auth (the waiting room enrolls them).
   const planParam = searchParams.get("plan");
   const postSignupDestination = planParam
     ? `/portal/waiting?plan=${encodeURIComponent(planParam)}`
@@ -30,24 +28,14 @@ function SignUpForm() {
       }
     }
   }, [user, isAdmin, isLoading, router, postSignupDestination]);
+
   const [fullName, setFullName] = useState("");
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
   const [confirmPassword, setConfirmPassword] = useState("");
-  const [code, setCode] = useState("");
-  const [step, setStep] = useState<"signup" | "verify">("signup");
+  const [step, setStep] = useState<"signup" | "check-email">("signup");
   const [error, setError] = useState("");
   const [submitting, setSubmitting] = useState(false);
-
-  // Support ?verify=email from login redirect for unverified users
-  useEffect(() => {
-    const verifyEmail = searchParams.get("verify");
-    if (verifyEmail) {
-      // eslint-disable-next-line react-hooks/set-state-in-effect
-      setEmail(verifyEmail);
-      setStep("verify");
-    }
-  }, [searchParams]);
 
   const handleSignUp = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -58,28 +46,19 @@ function SignUpForm() {
     }
     setSubmitting(true);
     try {
-      await signUp(email, password, fullName || undefined);
-      setStep("verify");
-    } catch (err: unknown) {
-      setError(err instanceof Error ? err.message : "Sign up failed");
-    } finally {
-      setSubmitting(false);
-    }
-  };
-
-  const handleVerify = async (e: React.FormEvent) => {
-    e.preventDefault();
-    setError("");
-    setSubmitting(true);
-    try {
-      await confirmSignUp(email, code);
-      // Forward the plan param so the user lands in the waiting room post-login
-      const next = postSignupDestination
-        ? `/auth/login?next=${encodeURIComponent(postSignupDestination)}`
-        : "/auth/login";
-      router.push(next);
-    } catch (err: unknown) {
-      setError(err instanceof Error ? err.message : "Verification failed");
+      const res = await globalThis.fetch("/api/auth/register", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ email, password, fullName: fullName || undefined }),
+      });
+      const data = (await res.json()) as { ok?: boolean; error?: string };
+      if (!res.ok) {
+        setError(data.error ?? t("auth.signupFailed", "Sign up failed"));
+        return;
+      }
+      setStep("check-email");
+    } catch {
+      setError(t("auth.signupFailed", "Sign up failed"));
     } finally {
       setSubmitting(false);
     }
@@ -96,150 +75,152 @@ function SignUpForm() {
           <h1 className="font-heading text-3xl font-bold text-white">
             {step === "signup"
               ? t("auth.signup", "Create Account")
-              : t("auth.verifyEmail", "Verify Email")}
+              : t("auth.checkYourEmail", "Check Your Email")}
           </h1>
           <p className="font-body mt-2 text-slate-400">
             {step === "signup"
               ? t("auth.signupDesc", "Join Cloudless to access your dashboard")
-              : t("auth.verifyDesc", "Enter the verification code sent to {email}").replace(
-                  "{email}",
-                  email
-                )}
+              : t("auth.checkEmailDesc", "A verification link has been sent to your inbox")}
           </p>
         </div>
 
         <div className="bg-void-light/50 rounded-xl border border-slate-800 p-8">
-          {error && (
-            <div className="bg-neon-magenta/10 border-neon-magenta/30 text-neon-magenta mb-6 rounded-lg border p-3 font-mono text-sm">
-              {error}
+          {step === "check-email" ? (
+            <div className="space-y-5 text-center">
+              <div className="bg-neon-green/10 border-neon-green/20 mx-auto flex h-16 w-16 items-center justify-center rounded-full border">
+                <svg
+                  className="text-neon-green h-8 w-8"
+                  fill="none"
+                  stroke="currentColor"
+                  viewBox="0 0 24 24"
+                  aria-hidden="true"
+                >
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    strokeWidth={1.5}
+                    d="M3 8l7.89 5.26a2 2 0 002.22 0L21 8M5 19h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z"
+                  />
+                </svg>
+              </div>
+              <p className="font-mono text-sm text-slate-300">
+                {t("auth.verificationSentTo", "We sent a verification link to")}{" "}
+                <span className="text-white">{email}</span>
+              </p>
+              <p className="font-mono text-xs text-slate-500">
+                {t(
+                  "auth.clickLinkToActivate",
+                  "Click the link in the email to activate your account. After verification, you can sign in."
+                )}
+              </p>
+              <Link
+                href="/auth/login"
+                className="text-neon-cyan block font-mono text-sm hover:underline"
+              >
+                {t("auth.goToSignIn", "Go to Sign In →")}
+              </Link>
             </div>
-          )}
-
-          {step === "signup" ? (
-            <form onSubmit={handleSignUp} className="space-y-5">
-              <div>
-                <label
-                  htmlFor="signup-name"
-                  className="mb-2 block font-mono text-sm text-slate-400"
-                >
-                  {t("auth.fullName", "Full Name")}
-                  <span className="ml-1 text-slate-600">({t("auth.optional", "optional")})</span>
-                </label>
-                <input
-                  id="signup-name"
-                  type="text"
-                  value={fullName}
-                  onChange={(e) => setFullName(e.target.value)}
-                  autoComplete="name"
-                  className="bg-void focus:border-neon-cyan/50 w-full rounded-lg border border-slate-700 px-4 py-3 font-mono text-sm text-white transition-all focus:shadow-[0_0_10px_rgba(0,255,245,0.1)] focus:outline-none"
-                  placeholder={t("auth.namePlaceholder", "John Doe")}
-                />
-              </div>
-              <div>
-                <label
-                  htmlFor="signup-email"
-                  className="mb-2 block font-mono text-sm text-slate-400"
-                >
-                  {t("auth.email", "Email")}
-                </label>
-                <input
-                  id="signup-email"
-                  type="email"
-                  value={email}
-                  onChange={(e) => setEmail(e.target.value)}
-                  required
-                  autoComplete="email"
-                  className="bg-void focus:border-neon-cyan/50 w-full rounded-lg border border-slate-700 px-4 py-3 font-mono text-sm text-white transition-all focus:shadow-[0_0_10px_rgba(0,255,245,0.1)] focus:outline-none"
-                  placeholder="your@email.com"
-                />
-              </div>
-              <div>
-                <label
-                  htmlFor="signup-password"
-                  className="mb-2 block font-mono text-sm text-slate-400"
-                >
-                  {t("auth.password", "Password")}
-                </label>
-                <input
-                  id="signup-password"
-                  type="password"
-                  value={password}
-                  onChange={(e) => setPassword(e.target.value)}
-                  required
-                  minLength={8}
-                  autoComplete="new-password"
-                  className="bg-void focus:border-neon-cyan/50 w-full rounded-lg border border-slate-700 px-4 py-3 font-mono text-sm text-white transition-all focus:shadow-[0_0_10px_rgba(0,255,245,0.1)] focus:outline-none"
-                  placeholder={t("auth.minChars", "Min. 8 characters")}
-                />
-              </div>
-              <div>
-                <label
-                  htmlFor="signup-confirm-password"
-                  className="mb-2 block font-mono text-sm text-slate-400"
-                >
-                  {t("auth.confirmPassword", "Confirm Password")}
-                </label>
-                <input
-                  id="signup-confirm-password"
-                  type="password"
-                  value={confirmPassword}
-                  onChange={(e) => setConfirmPassword(e.target.value)}
-                  required
-                  minLength={8}
-                  autoComplete="new-password"
-                  className="bg-void focus:border-neon-cyan/50 w-full rounded-lg border border-slate-700 px-4 py-3 font-mono text-sm text-white transition-all focus:shadow-[0_0_10px_rgba(0,255,245,0.1)] focus:outline-none"
-                  placeholder={t("auth.reenterPassword", "Re-enter password")}
-                />
-              </div>
-              <button
-                type="submit"
-                disabled={submitting}
-                className="bg-neon-cyan/10 border-neon-cyan/50 text-neon-cyan hover:bg-neon-cyan/20 min-h-11 w-full rounded-lg border py-3 font-mono font-semibold transition-all hover:shadow-[0_0_15px_rgba(0,255,245,0.2)] disabled:opacity-50"
-              >
-                {submitting
-                  ? t("auth.creatingAccount", "Creating Account...")
-                  : t("auth.signup", "Create Account")}
-              </button>
-            </form>
           ) : (
-            <form onSubmit={handleVerify} className="space-y-5">
-              <div>
-                <label
-                  htmlFor="signup-verification-code"
-                  className="mb-2 block font-mono text-sm text-slate-400"
+            <>
+              {error && (
+                <div className="bg-neon-magenta/10 border-neon-magenta/30 text-neon-magenta mb-6 rounded-lg border p-3 font-mono text-sm">
+                  {error}
+                </div>
+              )}
+              <form onSubmit={handleSignUp} className="space-y-5">
+                <div>
+                  <label
+                    htmlFor="signup-name"
+                    className="mb-2 block font-mono text-sm text-slate-400"
+                  >
+                    {t("auth.fullName", "Full Name")}
+                    <span className="ml-1 text-slate-600">({t("auth.optional", "optional")})</span>
+                  </label>
+                  <input
+                    id="signup-name"
+                    type="text"
+                    value={fullName}
+                    onChange={(e) => setFullName(e.target.value)}
+                    autoComplete="name"
+                    className="bg-void focus:border-neon-cyan/50 w-full rounded-lg border border-slate-700 px-4 py-3 font-mono text-sm text-white transition-all focus:shadow-[0_0_10px_rgba(0,255,245,0.1)] focus:outline-none"
+                    placeholder={t("auth.namePlaceholder", "John Doe")}
+                  />
+                </div>
+                <div>
+                  <label
+                    htmlFor="signup-email"
+                    className="mb-2 block font-mono text-sm text-slate-400"
+                  >
+                    {t("auth.email", "Email")}
+                  </label>
+                  <input
+                    id="signup-email"
+                    type="email"
+                    value={email}
+                    onChange={(e) => setEmail(e.target.value)}
+                    required
+                    autoComplete="email"
+                    className="bg-void focus:border-neon-cyan/50 w-full rounded-lg border border-slate-700 px-4 py-3 font-mono text-sm text-white transition-all focus:shadow-[0_0_10px_rgba(0,255,245,0.1)] focus:outline-none"
+                    placeholder="your@email.com"
+                  />
+                </div>
+                <div>
+                  <label
+                    htmlFor="signup-password"
+                    className="mb-2 block font-mono text-sm text-slate-400"
+                  >
+                    {t("auth.password", "Password")}
+                  </label>
+                  <input
+                    id="signup-password"
+                    type="password"
+                    value={password}
+                    onChange={(e) => setPassword(e.target.value)}
+                    required
+                    minLength={8}
+                    autoComplete="new-password"
+                    className="bg-void focus:border-neon-cyan/50 w-full rounded-lg border border-slate-700 px-4 py-3 font-mono text-sm text-white transition-all focus:shadow-[0_0_10px_rgba(0,255,245,0.1)] focus:outline-none"
+                    placeholder={t("auth.minChars", "Min. 8 characters")}
+                  />
+                </div>
+                <div>
+                  <label
+                    htmlFor="signup-confirm-password"
+                    className="mb-2 block font-mono text-sm text-slate-400"
+                  >
+                    {t("auth.confirmPassword", "Confirm Password")}
+                  </label>
+                  <input
+                    id="signup-confirm-password"
+                    type="password"
+                    value={confirmPassword}
+                    onChange={(e) => setConfirmPassword(e.target.value)}
+                    required
+                    minLength={8}
+                    autoComplete="new-password"
+                    className="bg-void focus:border-neon-cyan/50 w-full rounded-lg border border-slate-700 px-4 py-3 font-mono text-sm text-white transition-all focus:shadow-[0_0_10px_rgba(0,255,245,0.1)] focus:outline-none"
+                    placeholder={t("auth.reenterPassword", "Re-enter password")}
+                  />
+                </div>
+                <button
+                  type="submit"
+                  disabled={submitting}
+                  className="bg-neon-cyan/10 border-neon-cyan/50 text-neon-cyan hover:bg-neon-cyan/20 min-h-11 w-full rounded-lg border py-3 font-mono font-semibold transition-all hover:shadow-[0_0_15px_rgba(0,255,245,0.2)] disabled:opacity-50"
                 >
-                  {t("auth.verificationCode", "Verification Code")}
-                </label>
-                <input
-                  id="signup-verification-code"
-                  type="text"
-                  value={code}
-                  onChange={(e) => setCode(e.target.value)}
-                  required
-                  autoComplete="one-time-code"
-                  className="bg-void focus:border-neon-cyan/50 w-full rounded-lg border border-slate-700 px-4 py-3 text-center font-mono text-sm tracking-[0.3em] text-white transition-all focus:shadow-[0_0_10px_rgba(0,255,245,0.1)] focus:outline-none"
-                  placeholder="123456"
-                  maxLength={6}
-                />
-              </div>
-              <button
-                type="submit"
-                disabled={submitting}
-                className="bg-neon-cyan/10 border-neon-cyan/50 text-neon-cyan hover:bg-neon-cyan/20 min-h-11 w-full rounded-lg border py-3 font-mono font-semibold transition-all hover:shadow-[0_0_15px_rgba(0,255,245,0.2)] disabled:opacity-50"
-              >
-                {submitting
-                  ? t("auth.verifying", "Verifying...")
-                  : t("auth.verifyEmail", "Verify Email")}
-              </button>
-            </form>
-          )}
+                  {submitting
+                    ? t("auth.creatingAccount", "Creating Account...")
+                    : t("auth.signup", "Create Account")}
+                </button>
+              </form>
 
-          <p className="mt-6 text-center font-mono text-sm text-slate-500">
-            {t("auth.hasAccount", "Already have an account?")}{" "}
-            <Link href="/auth/login" className="text-neon-cyan hover:underline">
-              {t("auth.login", "Sign In")}
-            </Link>
-          </p>
+              <p className="mt-6 text-center font-mono text-sm text-slate-500">
+                {t("auth.hasAccount", "Already have an account?")}{" "}
+                <Link href="/auth/login" className="text-neon-cyan hover:underline">
+                  {t("auth.login", "Sign In")}
+                </Link>
+              </p>
+            </>
+          )}
         </div>
       </div>
     </div>

--- a/src/app/api/auth/register/route.ts
+++ b/src/app/api/auth/register/route.ts
@@ -1,0 +1,124 @@
+import { NextResponse } from "next/server";
+import { getConfig } from "@/lib/ssm-config";
+
+interface RegisterBody {
+  email: string;
+  password: string;
+  fullName?: string;
+}
+
+async function getAdminToken(tokenUrl: string, clientId: string, clientSecret: string) {
+  const res = await globalThis.fetch(tokenUrl, {
+    method: "POST",
+    headers: { "Content-Type": "application/x-www-form-urlencoded" },
+    body: new URLSearchParams({
+      grant_type: "client_credentials",
+      client_id: clientId,
+      client_secret: clientSecret,
+    }).toString(),
+  });
+  if (!res.ok) throw new Error(`Admin token request failed: ${res.status}`);
+  const data = (await res.json()) as { access_token: string };
+  return data.access_token;
+}
+
+export async function POST(req: Request) {
+  const issuer = process.env.KEYCLOAK_ISSUER;
+  if (!issuer) {
+    return NextResponse.json({ error: "Registration not available" }, { status: 503 });
+  }
+
+  // issuer = https://auth.cloudless.gr/realms/master
+  const realmMatch = issuer.match(/^(https?:\/\/[^/]+)\/realms\/([^/]+)$/);
+  if (!realmMatch) {
+    return NextResponse.json({ error: "Registration not available" }, { status: 503 });
+  }
+  const [, kcBase, realm] = realmMatch;
+
+  let body: RegisterBody;
+  try {
+    body = (await req.json()) as RegisterBody;
+  } catch {
+    return NextResponse.json({ error: "Invalid request body" }, { status: 400 });
+  }
+
+  const { email, password, fullName } = body;
+  if (!email || !password) {
+    return NextResponse.json({ error: "Email and password are required" }, { status: 400 });
+  }
+  if (password.length < 8) {
+    return NextResponse.json({ error: "Password must be at least 8 characters" }, { status: 400 });
+  }
+
+  const config = await getConfig();
+  if (!config.KEYCLOAK_ADMIN_CLIENT_ID || !config.KEYCLOAK_ADMIN_CLIENT_SECRET) {
+    return NextResponse.json({ error: "Registration not available" }, { status: 503 });
+  }
+
+  try {
+    const adminToken = await getAdminToken(
+      `${issuer}/protocol/openid-connect/token`,
+      config.KEYCLOAK_ADMIN_CLIENT_ID,
+      config.KEYCLOAK_ADMIN_CLIENT_SECRET
+    );
+
+    const parts = (fullName ?? "").trim().split(" ").filter(Boolean);
+    const userRep: Record<string, unknown> = {
+      email,
+      username: email,
+      enabled: true,
+      emailVerified: false,
+      requiredActions: ["VERIFY_EMAIL"],
+      credentials: [{ type: "password", value: password, temporary: false }],
+    };
+    if (parts[0]) userRep.firstName = parts[0];
+    if (parts.length > 1) userRep.lastName = parts.slice(1).join(" ");
+
+    const createRes = await globalThis.fetch(`${kcBase}/admin/realms/${realm}/users`, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${adminToken}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(userRep),
+    });
+
+    if (createRes.status === 409) {
+      return NextResponse.json(
+        { error: "An account with this email already exists" },
+        { status: 409 }
+      );
+    }
+    if (!createRes.ok) {
+      const errData = (await createRes.json().catch(() => null)) as {
+        errorMessage?: string;
+      } | null;
+      return NextResponse.json(
+        { error: errData?.errorMessage ?? "Registration failed" },
+        { status: 400 }
+      );
+    }
+
+    // Send verification email via the app client so the link returns to cloudless.gr
+    const userId = createRes.headers.get("Location")?.split("/").pop();
+    if (userId) {
+      const appClientId = process.env.NEXT_PUBLIC_KEYCLOAK_CLIENT_ID ?? "cloudless-app";
+      const siteUrl = process.env.NEXT_PUBLIC_SITE_URL ?? "";
+      const params = new URLSearchParams({ client_id: appClientId });
+      if (siteUrl) params.set("redirect_uri", `${siteUrl}/api/auth/callback/keycloak`);
+      // Best-effort: if SMTP is not yet configured the email silently fails;
+      // the VERIFY_EMAIL required action still blocks sign-in until verified.
+      await globalThis
+        .fetch(
+          `${kcBase}/admin/realms/${realm}/users/${userId}/send-verify-email?${params.toString()}`,
+          { method: "PUT", headers: { Authorization: `Bearer ${adminToken}` } }
+        )
+        .catch(() => {});
+    }
+
+    return NextResponse.json({ ok: true });
+  } catch (err) {
+    console.error("[auth/register]", err);
+    return NextResponse.json({ error: "Registration failed" }, { status: 500 });
+  }
+}


### PR DESCRIPTION
## Summary

- **`__tests__/auth-register-api.test.ts`** (20 tests): Full coverage for `POST /api/auth/register` — config guards (503 for missing issuer/SSM creds), input validation (400), Keycloak error handling (409 duplicate, 400 policy violation, 500 on token failure), and success path verifying user representation fields, firstName/lastName split, verification email URL, and best-effort SMTP (200 even when email throws)
- **`__tests__/auth-signup-page.test.tsx`** (9 tests): Component tests for the signup page — form render, password mismatch (no API call), successful registration transitions to check-email state, 409/503/network error handling, fullName omission
- **`__tests__/auth-lib-callbacks.test.ts`** (14 tests): Tests the **real** `auth.ts` callbacks by capturing the config passed to `NextAuth()` — groups preference chain (id_token → access_token → profile), realm roles from `realm_access.roles`, malformed JWT fallback, token reuse when not expired, refresh rotation (success + failure), `RefreshTokenError` propagation, session callback fields, and RP-initiated logout

All 43 new tests pass alongside the existing suite.

## Test plan

- [x] `pnpm vitest run __tests__/auth-register-api.test.ts __tests__/auth-signup-page.test.tsx __tests__/auth-lib-callbacks.test.ts` → 43/43 pass

https://claude.ai/code/session_01PHsA9s3tK2thgSJVwEGuWq

---
_Generated by [Claude Code](https://claude.ai/code/session_01PHsA9s3tK2thgSJVwEGuWq)_