### PR TITLE
feat(coverage): emit source maps in coverage mode for V8 → src remapping

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -4,6 +4,18 @@ import createNextIntlPlugin from "next-intl/plugin";
 
 const withNextIntl = createNextIntlPlugin("./src/i18n/request.ts");
 
+// Coverage mode — set by the E2E coverage harness (scripts/e2e-with-env.sh
+// runs `next dev --webpack` with COVERAGE=1 + NODE_V8_COVERAGE). We deliberately
+// DO NOT use SWC/Istanbul pre-instrumentation: Istanbul requires Babel, and
+// switching off SWC breaks Server Actions on the App Router
+// (vercel/next.js#53901). The documented best practice is V8 native coverage
+// (NODE_V8_COVERAGE for the server + Playwright CDP for the browser), which only
+// works if full, external source maps are emitted so the V8 byte-offsets can be
+// remapped back to the original TS by monocart. The default dev devtool
+// (eval-source-map) is not resolvable post-hoc, so we force `source-map` here.
+const COVERAGE =
+  process.env.COVERAGE === "1" || process.env.NEXT_PUBLIC_COVERAGE === "1";
+
 const nextConfig: NextConfig = {
   // Compression of HTTP responses (gzip via the Next.js server). On Lambda
   // the compression is applied before CloudFront passes through; on the Pi
@@ -13,6 +25,22 @@ const nextConfig: NextConfig = {
   compress: true,
   // Strip the X-Powered-By: Next.js header — small attack-surface reduction.
   poweredByHeader: false,
+  // Emit browser source maps so Playwright CDP coverage of /_next/static chunks
+  // can be remapped to src/. Only in coverage mode — production stays map-free
+  // (source maps are uploaded to Sentry separately during the SST deploy).
+  ...(COVERAGE ? { productionBrowserSourceMaps: true } : {}),
+  // Full external source maps for the `next dev --webpack` coverage server, so
+  // both server (NODE_V8_COVERAGE) and client (CDP) V8 coverage resolve to the
+  // original TS. Ignored under Turbopack (normal dev/build) — webpack() only
+  // runs in webpack mode — so this is a no-op outside coverage runs.
+  ...(COVERAGE
+    ? {
+        webpack: (config: { devtool?: string | false }) => {
+          config.devtool = "source-map";
+          return config;
+        },
+      }
+    : {}),
   // For Docker builds (Pi HA standby): emit a self-contained .next/standalone
   // bundle. SST/Vercel deploys leave this unset.
   output: process.env.NEXT_OUTPUT_STANDALONE === "1" ? "standalone" : undefined,


### PR DESCRIPTION
## Summary

Completes the E2E coverage fix from #436 (which corrected the monocart entry filters). The remaining gap was that **V8 native coverage can't be remapped to `src/` without source maps** — that's why the merged report stayed empty.

## What I checked (per the request)

SWC/Istanbul instrumentation **does not exist** in the repo (no `swc-plugin-coverage-instrument`, no babel config, and `NEXT_PUBLIC_COVERAGE`/`__coverage__` were referenced nowhere). I researched whether to add it and found it's the **wrong approach for the App Router**:

- Istanbul requires Babel; disabling SWC **breaks Server Actions** ([vercel/next.js#53901](https://github.com/vercel/next.js/discussions/53901), and the author of `nextcov`).
- On bleeding-edge **Next 16.2.6** the SWC Wasm plugin's `swc_core` ABI almost certainly wouldn't match.

The documented best practice is **V8 native coverage** (`NODE_V8_COVERAGE` server + Playwright CDP client) — exactly what this repo already uses — **with source maps enabled** so byte-offsets resolve to original TS.

## Change

Strictly gated on `COVERAGE` / `NEXT_PUBLIC_COVERAGE` (set by `scripts/e2e-with-env.sh`):
- `productionBrowserSourceMaps: true` → browser chunks carry maps so CDP coverage of `/_next/static` resolves to `src/`.
- `webpack.devtool = "source-map"` → full external maps for the `next dev --webpack` coverage server.

The `webpack()` hook **only runs in webpack mode**, so it's a no-op under Turbopack (normal dev/build) — **production builds are byte-for-byte unchanged** (prod maps still upload to Sentry via SST).

## Test plan
- [x] `next.config.ts` typechecks clean (the only `tsc` errors are stale `.next/dev/types/` stubs, regenerated in CI)
- [x] Config composition verified: `COVERAGE=1` adds both keys; production shape unchanged
- [ ] CI E2E coverage run produces non-zero `src/`-mapped client coverage (the payoff of #436 + this)

https://claude.ai/code/session_016PrzZJMNxsgiEmvedfkru6

---
_Generated by [Claude Code](https://claude.ai/code/session_016PrzZJMNxsgiEmvedfkru6)_