### PR TITLE
chore(cluster): trigger doctor — watchdog DOWN since 00:12 UTC

### DIFF
--- a/scripts/cluster-doctor.sh
+++ b/scripts/cluster-doctor.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 #
 # cluster-doctor.sh — read-only diagnostics for the omv k3s cluster, with a
-# focus on why Keycloak (auth.cloudless.gr) might be down.
+# focus on why Keycloak (auth.cloudless.gr) might be down. [triggered 2026-06-02]
 #
 # Emits a Markdown report to stdout. Every kubectl call is best-effort (|| true)
 # so the report is always produced even when individual objects are missing.


### PR DESCRIPTION
Trigger cluster-doctor: healthchecks.io watchdog went DOWN at 03:12+0300 (00:12 UTC). Last ensure run at 21:28 UTC showed discovery=200 and healthy. Need fresh snapshot to see current Keycloak state.

https://claude.ai/code/session_01PHsA9s3tK2thgSJVwEGuWq

---
_Generated by [Claude Code](https://claude.ai/code/session_01PHsA9s3tK2thgSJVwEGuWq)_