### PR TITLE
chore(cluster): apply memory-relief manifest to fix Keycloak last-applied drift

### DIFF
--- a/.github/workflows/sync-keycloak-manifest.yml
+++ b/.github/workflows/sync-keycloak-manifest.yml
@@ -1,0 +1,84 @@
+name: Sync Keycloak manifest (fix last-applied drift)
+
+# Applies k8s/cluster-protection/memory-relief-2026-05-31.yaml to the cluster
+# so the kubectl last-applied-configuration annotation matches the repo source of
+# truth (768Mi limit). Without this, a future `kubectl apply` from the old
+# annotation would silently revert Keycloak back to 512Mi.
+#
+# Safe to re-run: kubectl apply is idempotent. Keycloak will do a brief rolling
+# restart only if the env or resources differ from what's live.
+#
+# Trigger: push to main touching this file.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - ".github/workflows/sync-keycloak-manifest.yml"
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ github.token }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v4.3.1
+
+      - name: Connect to tailnet
+        uses: tailscale/github-action@0263d9e6d793eaefcf1de98ff7fde47abe6664d3 # v3.2.4
+        with:
+          authkey: ${{ secrets.TS_AUTHKEY }}
+
+      - name: Configure kubectl
+        run: |
+          mkdir -p ~/.kube
+          echo "${{ secrets.KUBECONFIG_B64 }}" | base64 -d > ~/.kube/config
+          chmod 600 ~/.kube/config
+
+      - name: Apply manifest
+        id: apply
+        run: |
+          set -euo pipefail
+          echo "== Before ==" | tee log.md
+          kubectl get deployment keycloak -n keycloak \
+            -o jsonpath='{.spec.template.spec.containers[0].resources}' | tee -a log.md; echo
+          echo "" >> log.md
+
+          echo "== kubectl apply ==" | tee -a log.md
+          kubectl apply -f k8s/cluster-protection/memory-relief-2026-05-31.yaml 2>&1 | tee -a log.md
+
+          echo "" >> log.md
+          echo "== Rollout status (keycloak) ==" | tee -a log.md
+          kubectl rollout status deployment/keycloak -n keycloak --timeout=3m 2>&1 | tee -a log.md
+
+          echo "" >> log.md
+          echo "== After ==" | tee -a log.md
+          kubectl get deployment keycloak -n keycloak \
+            -o jsonpath='{.spec.template.spec.containers[0].resources}' | tee -a log.md; echo
+          echo "" >> log.md
+
+          echo "== last-applied-configuration memory limit ==" | tee -a log.md
+          kubectl get deployment keycloak -n keycloak \
+            -o jsonpath='{.metadata.annotations.kubectl\.kubernetes\.io/last-applied-configuration}' \
+            | python3 -c "import sys,json; d=json.load(sys.stdin); c=d['spec']['template']['spec']['containers'][0]; print('memory limit:', c['resources']['limits']['memory'])" \
+            2>&1 | tee -a log.md
+
+          echo "" >> log.md
+          echo "== OIDC discovery ==" | tee -a log.md
+          STATUS=$(curl -sf -o /dev/null -w "%{http_code}" https://auth.cloudless.gr/realms/master/.well-known/openid-configuration 2>/dev/null || echo "error")
+          echo "HTTP $STATUS (200=up)" | tee -a log.md
+
+      - name: Post result to tracking issue
+        if: always()
+        run: |
+          {
+            echo "# Keycloak manifest sync — $(date -u '+%Y-%m-%d %H:%M:%SZ')"
+            echo ""
+            echo '```'
+            cat log.md
+            echo '```'
+          } | gh issue comment 382 --repo "$GITHUB_REPOSITORY" --body-file -


### PR DESCRIPTION
## Problem

The live Keycloak container runs `768Mi` (correct) but `kubectl.kubernetes.io/last-applied-configuration` still says `512Mi` from a stale earlier apply. A future `kubectl apply -f memory-relief-2026-05-31.yaml` would silently revert the limit to `512Mi` → OOMKill crash-loop again.

## Fix

New one-shot workflow (`sync-keycloak-manifest.yml`) that:
1. Applies `k8s/cluster-protection/memory-relief-2026-05-31.yaml` (already correct at `768Mi`)
2. Waits for `kubectl rollout status` to confirm Keycloak is ready
3. Reads back the `last-applied-configuration` annotation to confirm it now shows `768Mi`
4. Checks OIDC discovery HTTP 200
5. Posts the full log to issue #382

The manifest apply is idempotent. Keycloak will do a brief rolling restart only if env or resources differ.

https://claude.ai/code/session_01PHsA9s3tK2thgSJVwEGuWq

---
_Generated by [Claude Code](https://claude.ai/code/session_01PHsA9s3tK2thgSJVwEGuWq)_