### PR TITLE
docs: AWS cost-reduction analysis (May 2026 invoice)

### DIFF
--- a/docs/aws-cost-reduction.md
+++ b/docs/aws-cost-reduction.md
@@ -138,8 +138,26 @@ websites were never the expensive part.
 
 ## How to execute
 
-This session has **no `aws` CLI and the AWS API is blocked by the network
-policy**, so these changes can't be applied from here. Two paths:
+A ready-to-run, audit-first script implements every item:
+**[`scripts/aws-cost-reduction.sh`](../scripts/aws-cost-reduction.sh)**.
+
+- Run with **no flags** → audits only (prints current state + estimated savings,
+  changes nothing).
+- Each **reversible** cut is gated behind its own flag and `DRY_RUN=0`:
+  - `DO_CLOUDTRAIL=1` — drop Insights + data events, keep one free trail (item 2)
+  - `DO_SECRETS=1` — copy each secret to free SSM SecureString (item 3; add
+    `CONFIRM_DELETE=1` to schedule 30-day-recoverable deletion)
+  - `DO_CONFIG=1` — stop the Config recorder (item 4)
+  - `DO_SSM=1` — downgrade advanced parameters to free standard tier (item 7)
+- **Destructive / business-decision** items (WorkMail mailbox deletion, KMS key
+  deletion, Route 53 health-check recreation) are **audit-only** — the script
+  prints the exact command but never runs it.
+
+It refuses to mutate unless the caller is authenticated to account
+`278585680617`. Must run from a machine/CI with AWS reachability — **this repo's
+cloud Claude sessions can't reach the AWS API** (blocked by the network policy).
+
+Two paths overall:
 
 1. **Console / CLI** (fastest for the one-off cuts above) — run the deletes and
    reconfigurations directly. Items 1, 2, 4, 5, 6 are console actions.

--- a/docs/aws-cost-reduction.md
+++ b/docs/aws-cost-reduction.md
@@ -7,24 +7,42 @@ AWS account `278585680617`.
 - **Net charges (pre-tax):** USD 18.19
 - Annualized: ≈ **USD 218/yr net** (≈ USD 270/yr incl. VAT)
 
+## Scope
+
+This is **one AWS account hosting two apps**:
+
+- **cloudless.gr** — Next.js on SST (Lambda + CloudFront), with the Pi k3s standby.
+- **baltzakisthemis.com** — the portfolio app (on Amplify / CloudFront; Amplify
+  shows $0.00 = free tier).
+
+The invoice is account-wide, so it sums both apps plus shared/peripheral
+services. Two hard constraints from the owner:
+
+- **Keep WorkMail** (`tbaltzakis@cloudless.gr`) — it is a required mailbox, so
+  its $4.00/mo is **fixed cost, not a saving**.
+- **Lose no functionality** in either app.
+
+Every cut below is account-wide peripheral spend — none of it touches either
+app's runtime or the mailbox.
+
 ## TL;DR
 
 **The actual web apps cost almost nothing to run.** The Lambda + CloudFront +
-API Gateway + DynamoDB + ECR runtime that serves cloudless.gr totals **~$0.50/mo
-net**. Roughly **90% of the bill is peripheral services** — a mailbox, audit
-logging, secrets, a config recorder, encryption keys, DNS health checks — none
-of which serve a single page request.
+API Gateway + DynamoDB + ECR runtime that serves both apps totals **~$0.50/mo
+net**. The rest is the required mailbox ($4.00, kept) plus peripheral services —
+audit logging, secrets, a config recorder, encryption keys, DNS health checks —
+none of which serve a single page request.
 
-So: **yes, the bill can be cut by ~50–60% with zero impact on the websites.**
-The savings are proportional, not large in absolute terms (the whole bill is
-~$18/mo net).
+So: **yes — keeping WorkMail and full functionality, the bill can still be cut
+~35–40% (~$6–7/mo).** The savings are proportional, not large in absolute terms
+(the whole bill is ~$18/mo net).
 
 ## Full breakdown (net "Charges", pre-VAT)
 
 | Service | Net $ | % | What it actually is | Serves the web apps? |
 |---|--:|--:|---|---|
-| Amazon Route 53 | 4.22 | 23% | 1 hosted zone + HA failover health checks | Partly |
-| **Amazon WorkMail** | **4.00** | **22%** | **Email mailbox hosting ($4/user/mo)** | ❌ No |
+| Amazon Route 53 | 4.22 | 23% | 2 hosted zones (cloudless.gr + portfolio) + HA health checks | Partly |
+| Amazon WorkMail | 4.00 | 22% | Mailbox `tbaltzakis@cloudless.gr` — **KEEP (required)** | ❌ No |
 | **AWS CloudTrail** | **2.31** | **13%** | Audit-log trail (1st management trail is free) | ❌ No |
 | AWS KMS | 2.13 | 12% | Customer-managed encryption keys ($1/key/mo) | Indirect |
 | Amazon SES | 1.93 | 11% | Transactional email (contact form, signup) | ✅ Yes |
@@ -49,21 +67,17 @@ The savings are proportional, not large in absolute terms (the whole bill is
 ## Recommended cuts — ranked by safety × savings
 
 These are ordered so the safest, most decoupled-from-functionality wins come
-first. None of items 1–6 touch the code that serves the websites.
+first. None of them touch the code that serves either app, and none touch the
+mailbox.
 
-### 1. WorkMail → migrate the mailbox off AWS — saves up to **$4.00/mo ($48/yr)**
-WorkMail is mailbox hosting billed per user. It is **not** part of any web app —
-the site sends mail through **SES**, not WorkMail. If the WorkMail mailbox is a
-real inbox you read, migrate it to a free/cheaper provider:
-- **Zoho Mail** (free tier, custom domain), or
-- **Forward-only** via SES inbound + [ImprovMX]/Cloudflare Email Routing → an
-  existing Gmail, $0.
-- If the mailbox is unused, just delete the WorkMail organization.
+### WorkMail — KEEP (required), $4.00/mo fixed
+`tbaltzakis@cloudless.gr` is a mailbox the owner must keep. WorkMail is a flat
+$4/user/mo with no usage-based component, so there is **nothing to trim here**
+without dropping the mailbox — which we are not doing. Treat the $4.00 as a
+fixed floor. (It is unrelated to the apps: the sites send mail via **SES**, not
+WorkMail.)
 
-This is the single biggest line and the cleanest cut. **Decision needed:** is
-the mailbox actively used?
-
-### 2. CloudTrail → keep one free trail, drop the rest — saves up to **~$2.30/mo**
+### 1. CloudTrail → keep one free trail, drop the rest — saves up to **~$2.30/mo**
 The **first** trail logging **management events is free**. A $2.31 charge means
 one of: a second trail, **data-event** logging (S3/Lambda object-level), or
 **CloudTrail Insights**. Keep a single management-events trail (free) and
@@ -72,22 +86,22 @@ security/audit control — see `docs/security/`. Reducing it lowers audit
 granularity, so confirm it's not required for a compliance posture you care
 about.
 
-### 3. Secrets Manager → migrate to SSM Parameter Store — saves **$1.20/mo ($14/yr)**
+### 2. Secrets Manager → migrate to SSM Parameter Store — saves **$1.20/mo ($14/yr)**
 Secrets Manager is $0.40/secret/mo; **SSM SecureString parameters are free**
 (and KMS-encrypted with the free AWS-managed key). The app **already** reads its
 config from SSM `/cloudless/production/*` (`src/lib/ssm-config.ts`, `sst.config.ts`).
 Move the ~3 Secrets Manager entries to SSM SecureString and update any
 `secretsmanager:GetSecretValue` callers. This also removes their KMS request
-load (helps item 5).
+load (helps item 4).
 
-### 4. AWS Config → scope down or disable the recorder — saves up to **$0.84/mo**
+### 3. AWS Config → scope down or disable the recorder — saves up to **$0.84/mo**
 Config bills $0.003 per configuration item recorded. For an account this small
 it's pure overhead unless you specifically need a compliance timeline. Either
 disable the recorder, or scope it to a handful of resource types / daily
 snapshot instead of continuous recording. **Caveat:** same as CloudTrail — it's
 a governance control, not functionality.
 
-### 5. KMS → audit for orphaned customer-managed keys — saves **~$1–2/mo**
+### 4. KMS → audit for orphaned customer-managed keys — saves **~$1–2/mo**
 Each customer-managed key (CMK) is $1/mo whether used or not. $2.13 ≈ 2 CMKs +
 request volume. Audit `aws kms list-keys` for keys with no recent usage, and
 prefer **AWS-managed keys (free)** wherever a CMK isn't strictly required (S3,
@@ -95,7 +109,7 @@ SES, SQS default encryption all work with AWS-managed keys). Deleting one
 orphaned CMK saves $12/yr. **Do not** delete a key still referenced by SES, S3
 bucket encryption, or Secrets Manager without re-keying first.
 
-### 6. Route 53 → trim health-check features — saves **~$1–2/mo**
+### 5. Route 53 → trim health-check features — saves **~$1–2/mo**
 The hosted zone itself is $0.50/mo (unavoidable — it's your DNS). The rest is the
 **two HA failover health checks** (PRIMARY=CloudFront, SECONDARY=Pi/APIGW, see
 `sst.config.ts`) plus optional features (HTTPS, string-matching, fast 10s
@@ -106,12 +120,12 @@ interval each add ~$1/mo). Options:
   secondary health check saves ~$0.50–1.50/mo — **but you lose the documented
   HA failover** (`/ha-failover`, `/ha-status`). Trade-off, not free.
 
-### 7. Systems Manager → downgrade advanced parameters — saves **~$0.30/mo**
+### 6. Systems Manager → downgrade advanced parameters — saves **~$0.30/mo**
 Standard SSM parameters are free; **advanced** parameters are $0.05/mo each.
 $0.33 suggests a few advanced params (or Session Manager logging). Downgrade any
 advanced parameter that doesn't need >4KB or parameter policies.
 
-### 8. S3 → lifecycle-expire old versions — saves a few cents
+### 7. S3 → lifecycle-expire old versions — saves a few cents
 $0.64 is mostly SST deploy artifacts and old object versions. Add a lifecycle
 rule to expire noncurrent versions after 30 days. Minor, but free to set up.
 
@@ -126,15 +140,17 @@ rule to expire noncurrent versions after 30 days. Minor, but free to set up.
 
 ## Projected result
 
-Applying items 1–6 conservatively:
+Applying items 1–5 conservatively:
 
 | | Net/mo | Incl. VAT/mo | Annual (net) |
 |---|--:|--:|--:|
 | Today | $18.19 | $22.56 | $218 |
-| After cuts | **~$7–8** | **~$9–10** | **~$90** |
+| WorkMail (kept, fixed) | $4.00 | $4.96 | $48 |
+| After cuts (incl. WorkMail) | **~$11–12** | **~$14–15** | **~$140** |
 
-≈ **55–60% reduction, with no change to any website's behavior** — because the
-websites were never the expensive part.
+≈ **35–40% reduction, with no change to either app's behavior and WorkMail
+intact** — because the apps were never the expensive part. (Of the ~$6–7
+trimmed, none comes from app runtime or the mailbox.)
 
 ## How to execute
 
@@ -144,14 +160,14 @@ A ready-to-run, audit-first script implements every item:
 - Run with **no flags** → audits only (prints current state + estimated savings,
   changes nothing).
 - Each **reversible** cut is gated behind its own flag and `DRY_RUN=0`:
-  - `DO_CLOUDTRAIL=1` — drop Insights + data events, keep one free trail (item 2)
-  - `DO_SECRETS=1` — copy each secret to free SSM SecureString (item 3; add
+  - `DO_CLOUDTRAIL=1` — drop Insights + data events, keep one free trail (item 1)
+  - `DO_SECRETS=1` — copy each secret to free SSM SecureString (item 2; add
     `CONFIRM_DELETE=1` to schedule 30-day-recoverable deletion)
-  - `DO_CONFIG=1` — stop the Config recorder (item 4)
-  - `DO_SSM=1` — downgrade advanced parameters to free standard tier (item 7)
-- **Destructive / business-decision** items (WorkMail mailbox deletion, KMS key
-  deletion, Route 53 health-check recreation) are **audit-only** — the script
-  prints the exact command but never runs it.
+  - `DO_CONFIG=1` — stop the Config recorder (item 3)
+  - `DO_SSM=1` — downgrade advanced parameters to free standard tier (item 6)
+- **Destructive / business-decision** items (KMS key deletion, Route 53
+  health-check recreation) are **audit-only** — the script prints the exact
+  command but never runs it. WorkMail is reported as **KEEP** (no action).
 
 It refuses to mutate unless the caller is authenticated to account
 `278585680617`. Must run from a machine/CI with AWS reachability — **this repo's
@@ -159,14 +175,13 @@ cloud Claude sessions can't reach the AWS API** (blocked by the network policy).
 
 Two paths overall:
 
-1. **Console / CLI** (fastest for the one-off cuts above) — run the deletes and
-   reconfigurations directly. Items 1, 2, 4, 5, 6 are console actions.
-2. **IaC** — items 3 (Secrets→SSM) and any Route 53 health-check change should
+1. **Console / CLI** (fastest for the one-off cuts above) — run the
+   reconfigurations directly. Items 1, 3, 4, 5, 6 are console actions.
+2. **IaC** — item 2 (Secrets→SSM) and any Route 53 health-check change should
    be reflected in `sst.config.ts` / wherever the resource is declared so they
    don't drift back.
 
 **Decisions only you can make** (each trades a few $/mo against
 functionality/security/effort):
-- Is the **WorkMail** mailbox actively used? (item 1)
-- Do you need the **CloudTrail** / **Config** audit trail for compliance? (items 2, 4)
-- Is the **Pi HA failover** worth its Route 53 health-check cost? (item 6)
+- Do you need the **CloudTrail** / **Config** audit trail for compliance? (items 1, 3)
+- Is the **Pi HA failover** worth its Route 53 health-check cost? (item 5)

--- a/docs/aws-cost-reduction.md
+++ b/docs/aws-cost-reduction.md
@@ -1,0 +1,154 @@
+# AWS Cost Reduction Analysis
+
+Based on VAT invoice **EUINGR26-58586** (billing period **May 1–31, 2026**),
+AWS account `278585680617`.
+
+- **Total billed:** USD 22.56 (incl. 24% VAT)
+- **Net charges (pre-tax):** USD 18.19
+- Annualized: ≈ **USD 218/yr net** (≈ USD 270/yr incl. VAT)
+
+## TL;DR
+
+**The actual web apps cost almost nothing to run.** The Lambda + CloudFront +
+API Gateway + DynamoDB + ECR runtime that serves cloudless.gr totals **~$0.50/mo
+net**. Roughly **90% of the bill is peripheral services** — a mailbox, audit
+logging, secrets, a config recorder, encryption keys, DNS health checks — none
+of which serve a single page request.
+
+So: **yes, the bill can be cut by ~50–60% with zero impact on the websites.**
+The savings are proportional, not large in absolute terms (the whole bill is
+~$18/mo net).
+
+## Full breakdown (net "Charges", pre-VAT)
+
+| Service | Net $ | % | What it actually is | Serves the web apps? |
+|---|--:|--:|---|---|
+| Amazon Route 53 | 4.22 | 23% | 1 hosted zone + HA failover health checks | Partly |
+| **Amazon WorkMail** | **4.00** | **22%** | **Email mailbox hosting ($4/user/mo)** | ❌ No |
+| **AWS CloudTrail** | **2.31** | **13%** | Audit-log trail (1st management trail is free) | ❌ No |
+| AWS KMS | 2.13 | 12% | Customer-managed encryption keys ($1/key/mo) | Indirect |
+| Amazon SES | 1.93 | 11% | Transactional email (contact form, signup) | ✅ Yes |
+| **AWS Secrets Manager** | **1.20** | 7% | ~3 secrets × $0.40/mo | Indirect |
+| **AWS Config** | **0.84** | 5% | Continuous resource-change recorder | ❌ No |
+| Amazon S3 | 0.64 | 4% | Object storage (deploy artifacts / assets) | Partly |
+| AWS Systems Manager | 0.33 | 2% | Parameters / sessions | ✅ Yes |
+| Amazon CloudFront | 0.17 | 1% | CDN for the site | ✅ Yes |
+| AWS Lambda | 0.13 | <1% | Next.js server runtime | ✅ Yes |
+| Amazon API Gateway | 0.13 | <1% | Pi failover (SECONDARY) frontend | ✅ Yes |
+| AmazonCloudWatch | 0.08 | <1% | Logs/metrics | ✅ Yes |
+| ECR | 0.06 | <1% | Pi container image registry | ✅ Yes |
+| DynamoDB | 0.01 | <1% | Stripe transactions table | ✅ Yes |
+| Cost Explorer | 0.01 | <1% | Billing analytics API | — |
+| Glue, Cognito, SNS, SQS, Amplify, ACM, Data Transfer | 0.00 | 0% | idle / free-tier | — |
+| **Net total** | **18.19** | | | |
+
+> Note: the "AWS Service Charges" page totals USD 22.56 because it includes the
+> $4.37 VAT. The $18.19 figure is the pre-tax sum of the per-service "Charges"
+> lines and is the number to optimize.
+
+## Recommended cuts — ranked by safety × savings
+
+These are ordered so the safest, most decoupled-from-functionality wins come
+first. None of items 1–6 touch the code that serves the websites.
+
+### 1. WorkMail → migrate the mailbox off AWS — saves up to **$4.00/mo ($48/yr)**
+WorkMail is mailbox hosting billed per user. It is **not** part of any web app —
+the site sends mail through **SES**, not WorkMail. If the WorkMail mailbox is a
+real inbox you read, migrate it to a free/cheaper provider:
+- **Zoho Mail** (free tier, custom domain), or
+- **Forward-only** via SES inbound + [ImprovMX]/Cloudflare Email Routing → an
+  existing Gmail, $0.
+- If the mailbox is unused, just delete the WorkMail organization.
+
+This is the single biggest line and the cleanest cut. **Decision needed:** is
+the mailbox actively used?
+
+### 2. CloudTrail → keep one free trail, drop the rest — saves up to **~$2.30/mo**
+The **first** trail logging **management events is free**. A $2.31 charge means
+one of: a second trail, **data-event** logging (S3/Lambda object-level), or
+**CloudTrail Insights**. Keep a single management-events trail (free) and
+disable data events / Insights / any duplicate trail. **Caveat:** this is a
+security/audit control — see `docs/security/`. Reducing it lowers audit
+granularity, so confirm it's not required for a compliance posture you care
+about.
+
+### 3. Secrets Manager → migrate to SSM Parameter Store — saves **$1.20/mo ($14/yr)**
+Secrets Manager is $0.40/secret/mo; **SSM SecureString parameters are free**
+(and KMS-encrypted with the free AWS-managed key). The app **already** reads its
+config from SSM `/cloudless/production/*` (`src/lib/ssm-config.ts`, `sst.config.ts`).
+Move the ~3 Secrets Manager entries to SSM SecureString and update any
+`secretsmanager:GetSecretValue` callers. This also removes their KMS request
+load (helps item 5).
+
+### 4. AWS Config → scope down or disable the recorder — saves up to **$0.84/mo**
+Config bills $0.003 per configuration item recorded. For an account this small
+it's pure overhead unless you specifically need a compliance timeline. Either
+disable the recorder, or scope it to a handful of resource types / daily
+snapshot instead of continuous recording. **Caveat:** same as CloudTrail — it's
+a governance control, not functionality.
+
+### 5. KMS → audit for orphaned customer-managed keys — saves **~$1–2/mo**
+Each customer-managed key (CMK) is $1/mo whether used or not. $2.13 ≈ 2 CMKs +
+request volume. Audit `aws kms list-keys` for keys with no recent usage, and
+prefer **AWS-managed keys (free)** wherever a CMK isn't strictly required (S3,
+SES, SQS default encryption all work with AWS-managed keys). Deleting one
+orphaned CMK saves $12/yr. **Do not** delete a key still referenced by SES, S3
+bucket encryption, or Secrets Manager without re-keying first.
+
+### 6. Route 53 → trim health-check features — saves **~$1–2/mo**
+The hosted zone itself is $0.50/mo (unavoidable — it's your DNS). The rest is the
+**two HA failover health checks** (PRIMARY=CloudFront, SECONDARY=Pi/APIGW, see
+`sst.config.ts`) plus optional features (HTTPS, string-matching, fast 10s
+interval each add ~$1/mo). Options:
+- Drop **fast interval** (30s instead of 10s) and **string matching** on the
+  health checks → keeps failover working, shaves the per-feature surcharges.
+- If the Pi SECONDARY failover path isn't worth maintaining, removing the
+  secondary health check saves ~$0.50–1.50/mo — **but you lose the documented
+  HA failover** (`/ha-failover`, `/ha-status`). Trade-off, not free.
+
+### 7. Systems Manager → downgrade advanced parameters — saves **~$0.30/mo**
+Standard SSM parameters are free; **advanced** parameters are $0.05/mo each.
+$0.33 suggests a few advanced params (or Session Manager logging). Downgrade any
+advanced parameter that doesn't need >4KB or parameter policies.
+
+### 8. S3 → lifecycle-expire old versions — saves a few cents
+$0.64 is mostly SST deploy artifacts and old object versions. Add a lifecycle
+rule to expire noncurrent versions after 30 days. Minor, but free to set up.
+
+## What to leave alone (this **is** the functionality)
+
+- **SES ($1.93)** — transactional email for contact forms / signup. Cheap per
+  message; cutting it breaks email. Keep.
+- **Lambda / API Gateway / CloudFront / DynamoDB / ECR / CloudWatch (~$0.60
+  total)** — the live site + Pi failover + chat widget. Already optimized
+  (arm64, 512 MB, right-sized). Nothing to cut.
+- **ACM, SNS, SQS, Cognito, Amplify, Glue, Data Transfer** — already $0.
+
+## Projected result
+
+Applying items 1–6 conservatively:
+
+| | Net/mo | Incl. VAT/mo | Annual (net) |
+|---|--:|--:|--:|
+| Today | $18.19 | $22.56 | $218 |
+| After cuts | **~$7–8** | **~$9–10** | **~$90** |
+
+≈ **55–60% reduction, with no change to any website's behavior** — because the
+websites were never the expensive part.
+
+## How to execute
+
+This session has **no `aws` CLI and the AWS API is blocked by the network
+policy**, so these changes can't be applied from here. Two paths:
+
+1. **Console / CLI** (fastest for the one-off cuts above) — run the deletes and
+   reconfigurations directly. Items 1, 2, 4, 5, 6 are console actions.
+2. **IaC** — items 3 (Secrets→SSM) and any Route 53 health-check change should
+   be reflected in `sst.config.ts` / wherever the resource is declared so they
+   don't drift back.
+
+**Decisions only you can make** (each trades a few $/mo against
+functionality/security/effort):
+- Is the **WorkMail** mailbox actively used? (item 1)
+- Do you need the **CloudTrail** / **Config** audit trail for compliance? (items 2, 4)
+- Is the **Pi HA failover** worth its Route 53 health-check cost? (item 6)

--- a/docs/workmail-outlook-setup.md
+++ b/docs/workmail-outlook-setup.md
@@ -1,0 +1,126 @@
+# Connecting WorkMail (`tbaltzakis@cloudless.gr`) to Outlook
+
+Goal: read and send the WorkMail mailbox from the Outlook client. **WorkMail
+keeps hosting the mailbox** (the $4/mo stays) — Outlook is just the client. No
+MX/DNS migration required.
+
+> Region note: WorkMail endpoints are region-specific. This account's other
+> services are in **us-east-1**, so the endpoints below assume `us-east-1`.
+> Confirm first (Step 1) — if the org is in `us-west-2` or `eu-west-1`, swap the
+> region in every `*.mail.<region>.awsapps.com` hostname.
+
+---
+
+## Step 0 — Prerequisites (run from a machine with `aws` CLI + creds)
+
+This Claude session has no `aws` CLI and the AWS API is network-blocked, so run
+these yourself. They confirm the org/region, the user, and set a password.
+
+```bash
+REGION=us-east-1
+
+# 1. Find the WorkMail organization id + region (try other regions if empty)
+aws workmail list-organizations --region "$REGION"
+
+ORG=m-xxxxxxxxxxxxxxxx   # OrganizationId from the output above
+
+# 2. Find the user id for tbaltzakis@cloudless.gr and confirm State=ENABLED
+aws workmail list-users --organization-id "$ORG" --region "$REGION" \
+  --query "Users[?contains(Email,'tbaltzakis')].[Id,Email,State]" --output table
+
+USER=xxxxxxxx-xxxx-...   # the user Id from above
+
+# 3. Set/reset the mailbox password (you'll type this into Outlook)
+aws workmail reset-password --organization-id "$ORG" --user-id "$USER" \
+  --password 'CHOOSE-A-STRONG-PASSWORD' --region "$REGION"
+```
+
+Also verify protocol access is allowed:
+
+- **Console → WorkMail → Organization → Access control rules.** The default rule
+  allows all protocols. If a rule blocks `IMAP`/`WebMail`/`ActiveSync`/`EWS`,
+  add an allow rule (or confirm the default is present) so Outlook can connect.
+
+---
+
+## Step 1 — Pick a connection method
+
+| Method | Gets you | Best for |
+| --- | --- | --- |
+| **Exchange (EWS / Autodiscover)** | Mail **+ Calendar + Contacts**, server-side folders | Classic Outlook for Windows (recommended) |
+| **IMAP + SMTP** | Mail + folders only (no calendar/contacts) | New Outlook for Windows, Outlook for Mac, any IMAP client |
+
+---
+
+## Step 2A — Classic Outlook for Windows (Exchange, full features)
+
+1. **File → Add Account**, type `tbaltzakis@cloudless.gr`, click **Connect**.
+2. If it can't auto-discover, choose **Exchange** / **advanced setup** and when
+   prompted for the server use the EWS endpoint:
+   ```
+   https://ews.mail.us-east-1.awsapps.com/EWS/Exchange.asmx
+   ```
+3. Credentials when prompted:
+   - **User name:** `tbaltzakis@cloudless.gr` (the full address)
+   - **Password:** the one set in Step 0
+4. Finish. Mail, calendar, and contacts sync.
+
+**Optional — make auto-discovery "just work"** (and for any future users on the
+domain): add a CNAME in the `cloudless.gr` Route 53 zone
+(`Z079608614L53CC4EAZM3`):
+
+```
+autodiscover.cloudless.gr.  CNAME  autodiscover.mail.us-east-1.awsapps.com.
+```
+
+Then Outlook's automatic setup finds the server with no manual EWS URL.
+
+---
+
+## Step 2B — IMAP + SMTP (new Outlook / Mac / any client)
+
+Add an account and choose **IMAP** (advanced/manual setup). Settings:
+
+| Setting | Value |
+| --- | --- |
+| Email / Username | `tbaltzakis@cloudless.gr` |
+| Password | the one set in Step 0 |
+| **IMAP** incoming server | `imap.mail.us-east-1.awsapps.com` |
+| IMAP port / security | `993` / SSL-TLS |
+| **SMTP** outgoing server | `smtp.mail.us-east-1.awsapps.com` |
+| SMTP port / security | `465` / SSL-TLS (or `587` / STARTTLS) |
+| SMTP auth | Yes — same username + password |
+
+---
+
+## Step 3 — Verify
+
+- Send a test message to an external address and reply back in; confirm both
+  directions in Outlook.
+- (Exchange path) Confirm the calendar and contacts folders appear.
+- The WorkMail web client (`https://<alias>.awsapps.com/mail`) and Outlook now
+  show the same mailbox — they're the same server-side store.
+
+---
+
+## Reference — WorkMail endpoints (us-east-1)
+
+| Protocol | Endpoint | Port / notes |
+| --- | --- | --- |
+| IMAP | `imap.mail.us-east-1.awsapps.com` | 993 SSL |
+| SMTP | `smtp.mail.us-east-1.awsapps.com` | 465 SSL / 587 STARTTLS |
+| EWS (Exchange) | `https://ews.mail.us-east-1.awsapps.com/EWS/Exchange.asmx` | — |
+| Autodiscover | `https://autodiscover.mail.us-east-1.awsapps.com/autodiscover/autodiscover.xml` | — |
+| ActiveSync (mobile) | `https://mobile.mail.us-east-1.awsapps.com` | phones/tablets |
+| Web client | `https://<alias>.awsapps.com/mail` | browser |
+
+For `us-west-2` / `eu-west-1`, substitute the region in every hostname.
+
+---
+
+## Cost note
+
+This keeps WorkMail, so the **$4.00/mo is unchanged** — it's the right call when
+the mailbox must stay and you just want Outlook as the client. The separate
+cost-reduction work (CloudTrail, Secrets Manager, Config, KMS, Route 53, SSM)
+is unaffected; see [`aws-cost-reduction.md`](./aws-cost-reduction.md).

--- a/scripts/aws-cost-reduction.sh
+++ b/scripts/aws-cost-reduction.sh
@@ -254,7 +254,7 @@ main() {
   [[ "${DO_SECRETS:-0}"    == "1" ]] && do_secrets    || c_warn "Secrets:    set DO_SECRETS=1 to migrate to SSM."
   [[ "${DO_CONFIG:-0}"     == "1" ]] && do_config     || c_warn "Config:     set DO_CONFIG=1 to stop the recorder."
   [[ "${DO_SSM:-0}"        == "1" ]] && do_ssm        || c_warn "SSM:        set DO_SSM=1 to downgrade advanced params."
-  c_hdr "Done. Projected steady-state: ~\$7-8/mo net (from \$18.19). See docs/aws-cost-reduction.md."
+  c_hdr "Done. Projected steady-state: ~\$11-12/mo net (from \$18.19, WorkMail kept). See docs/aws-cost-reduction.md."
 }
 
 main "$@"

--- a/scripts/aws-cost-reduction.sh
+++ b/scripts/aws-cost-reduction.sh
@@ -1,0 +1,263 @@
+#!/usr/bin/env bash
+#
+# aws-cost-reduction.sh — execute the cost cuts from docs/aws-cost-reduction.md
+# against AWS account 278585680617 (us-east-1).
+#
+# Source bill: VAT invoice EUINGR26-58586, May 2026 — USD 18.19 net / 22.56 incl.
+# The web-app runtime (Lambda+CloudFront+APIGW+DynamoDB+ECR) is ~$0.50/mo; the
+# rest is peripheral services. This script targets the peripheral spend ONLY —
+# it never touches the Next.js site, its CloudFront/Lambda, DynamoDB, or SES.
+#
+# DESIGN: audit-first and safe by default.
+#   - With no flags it ONLY AUDITS: prints current state + estimated savings.
+#   - Each reversible cut is gated by its own DO_* flag.
+#   - Nothing destructive (mailbox/key/secret deletion) ever runs automatically;
+#     those print the exact command for a human to run with CONFIRM_DELETE=1.
+#   - DRY_RUN=1 (default) prints mutating commands instead of running them.
+#
+# Requirements: awscli v2, credentials with read + the relevant write perms,
+# `jq`. Run from a machine/CI that can reach the AWS API (this repo's cloud
+# Claude sessions CANNOT — the network policy blocks it).
+#
+# Usage:
+#   ./scripts/aws-cost-reduction.sh                 # audit only (no changes)
+#   DRY_RUN=0 DO_CLOUDTRAIL=1 ./scripts/aws-cost-reduction.sh   # apply trail cut
+#   DRY_RUN=0 DO_CONFIG=1     ./scripts/aws-cost-reduction.sh   # stop Config recorder
+#   DRY_RUN=0 DO_SECRETS=1    ./scripts/aws-cost-reduction.sh   # copy secrets -> SSM
+#   DRY_RUN=0 DO_SSM=1        ./scripts/aws-cost-reduction.sh   # downgrade advanced params
+#   DO_KMS=1 DO_WORKMAIL=1 DO_R53=1 ./scripts/aws-cost-reduction.sh  # audit-only items
+#
+set -euo pipefail
+
+REGION="${AWS_REGION:-us-east-1}"
+ACCOUNT="278585680617"
+DRY_RUN="${DRY_RUN:-1}"
+SSM_MIGRATE_PREFIX="${SSM_MIGRATE_PREFIX:-/cloudless/production/migrated}"
+# Route 53 (from sst.config.ts)
+ZONE_ID="Z079608614L53CC4EAZM3"
+PRIMARY_HC="e239ad5c-dd17-40d7-8045-a153715168cf"
+SECONDARY_HC="30a69f1c-8d48-49bd-9067-cabec979478b"
+
+c_hdr() { printf '\n\033[1;36m== %s ==\033[0m\n' "$*"; }
+c_ok()  { printf '\033[0;32m%s\033[0m\n' "$*"; }
+c_warn(){ printf '\033[0;33m%s\033[0m\n' "$*"; }
+c_run() {
+  # Run a mutating aws command, honoring DRY_RUN.
+  if [[ "$DRY_RUN" == "1" ]]; then
+    printf '  \033[0;90m[dry-run] %s\033[0m\n' "$*"
+  else
+    printf '  \033[0;35m[apply] %s\033[0m\n' "$*"
+    "$@"
+  fi
+}
+
+require() { command -v "$1" >/dev/null 2>&1 || { echo "FATAL: '$1' not found"; exit 1; }; }
+require aws
+require jq
+
+acct_check() {
+  local got
+  got="$(aws sts get-caller-identity --query Account --output text 2>/dev/null || true)"
+  if [[ "$got" != "$ACCOUNT" ]]; then
+    c_warn "Caller account is '$got', expected $ACCOUNT. Set the right profile/role before applying."
+    [[ "$DRY_RUN" == "1" ]] || { echo "Refusing to mutate the wrong account."; exit 1; }
+  else
+    c_ok "Authenticated to account $ACCOUNT."
+  fi
+}
+
+# --------------------------------------------------------------------------
+# 1. WorkMail  ($4.00/mo) — AUDIT ONLY (mailbox deletion is a business call)
+# --------------------------------------------------------------------------
+do_workmail() {
+  c_hdr "WorkMail (\$4.00/mo) — audit"
+  # WorkMail lives in specific regions; try the common one + the configured one.
+  local wm_region="${WORKMAIL_REGION:-us-east-1}"
+  local orgs
+  orgs="$(aws workmail list-organizations --region "$wm_region" --output json 2>/dev/null || echo '{}')"
+  if [[ "$(echo "$orgs" | jq -r '.OrganizationSummaries // [] | length')" == "0" ]]; then
+    c_warn "No WorkMail orgs in $wm_region (try WORKMAIL_REGION=eu-west-1, etc.). If the \$4 line persists, find the region in the console."
+    return
+  fi
+  echo "$orgs" | jq -r '.OrganizationSummaries[] | "  org \(.OrganizationId) \(.Alias) state=\(.State)"'
+  echo "$orgs" | jq -r '.OrganizationSummaries[].OrganizationId' | while read -r org; do
+    local users
+    users="$(aws workmail list-users --organization-id "$org" --region "$wm_region" --output json 2>/dev/null || echo '{}')"
+    echo "$users" | jq -r '.Users[]? | "    user \(.Email // .Name) state=\(.State) enabled=\(.UserRole // "?")"'
+  done
+  c_warn "DECISION: is this mailbox actively read? Options (run manually):"
+  echo "    # forward-only alternative: Cloudflare Email Routing / ImprovMX -> Gmail (\$0)"
+  echo "    # then disable the user (stops the \$4/user charge, keeps the org):"
+  echo "    #   aws workmail deregister-from-work-mail --organization-id <ORG> --entity-id <USER> --region $wm_region"
+  echo "    # or delete the whole org (DESTRUCTIVE):"
+  echo "    #   aws workmail delete-organization --organization-id <ORG> --delete-directory --region $wm_region"
+}
+
+# --------------------------------------------------------------------------
+# 2. CloudTrail  (~$2.31/mo) — keep ONE free management trail, drop the rest
+# --------------------------------------------------------------------------
+do_cloudtrail() {
+  c_hdr "CloudTrail (~\$2.31/mo) — keep one free management trail"
+  local trails
+  trails="$(aws cloudtrail list-trails --region "$REGION" --output json | jq -r '.Trails[].TrailARN')"
+  if [[ -z "$trails" ]]; then c_warn "No trails found."; return; fi
+  local keep=""
+  while read -r arn; do
+    [[ -z "$arn" ]] && continue
+    local name insight selectors datacount
+    name="$(aws cloudtrail get-trail --name "$arn" --region "$REGION" --query 'Trail.Name' --output text 2>/dev/null || echo '?')"
+    insight="$(aws cloudtrail get-insight-selectors --trail-name "$arn" --region "$REGION" --output json 2>/dev/null | jq -r '.InsightSelectors // [] | length' || echo 0)"
+    selectors="$(aws cloudtrail get-event-selectors --trail-name "$arn" --region "$REGION" --output json 2>/dev/null || echo '{}')"
+    datacount="$(echo "$selectors" | jq '[(.EventSelectors // [])[].DataResources // [] | length] | add // 0' 2>/dev/null || echo 0)"
+    datacount=$(( datacount + $(echo "$selectors" | jq '[(.AdvancedEventSelectors // [])[] | select(any(.FieldSelectors[]?; .Field=="resources.type"))] | length' 2>/dev/null || echo 0) ))
+    echo "  trail $name  insights=$insight  data-event-rules=$datacount"
+    if [[ -z "$keep" ]]; then
+      keep="$arn"
+      c_ok "  -> keeping '$name' as the free management-events trail"
+    fi
+    # Drop CloudTrail Insights (billed per event analyzed) on every trail.
+    if [[ "$insight" != "0" ]]; then
+      c_run aws cloudtrail put-insight-selectors --trail-name "$arn" --region "$REGION" --insight-selectors '[]'
+    fi
+    # Strip data-event logging (the main cost driver) — revert management events to the free default.
+    if [[ "$datacount" != "0" ]]; then
+      c_run aws cloudtrail put-event-selectors --trail-name "$arn" --region "$REGION" \
+        --event-selectors '[{"ReadWriteType":"All","IncludeManagementEvents":true,"DataResources":[]}]'
+    fi
+  done <<< "$trails"
+  c_warn "Note: a 2nd+ trail (beyond the one kept) is itself billable. Review and delete extras manually:"
+  echo "    #   aws cloudtrail delete-trail --name <ARN> --region $REGION"
+}
+
+# --------------------------------------------------------------------------
+# 3. Secrets Manager  ($1.20/mo) — copy each secret to free SSM SecureString
+#    (additive + reversible; deletion only with CONFIRM_DELETE=1)
+# --------------------------------------------------------------------------
+do_secrets() {
+  c_hdr "Secrets Manager (\$1.20/mo) — migrate to SSM SecureString (free)"
+  local secrets
+  secrets="$(aws secretsmanager list-secrets --region "$REGION" --output json | jq -r '.SecretList[].Name')"
+  if [[ -z "$secrets" ]]; then c_warn "No secrets found."; return; fi
+  while read -r name; do
+    [[ -z "$name" ]] && continue
+    local target
+    target="${SSM_MIGRATE_PREFIX}/$(basename "$name")"
+    echo "  secret '$name' -> SSM SecureString '$target'"
+    if [[ "$DRY_RUN" == "1" ]]; then
+      printf '    \033[0;90m[dry-run] copy value to %s\033[0m\n' "$target"
+    else
+      local val
+      val="$(aws secretsmanager get-secret-value --secret-id "$name" --region "$REGION" --query SecretString --output text)"
+      aws ssm put-parameter --name "$target" --type SecureString --value "$val" --overwrite --region "$REGION" >/dev/null
+      c_ok "    copied."
+    fi
+    if [[ "${CONFIRM_DELETE:-0}" == "1" ]]; then
+      c_run aws secretsmanager delete-secret --secret-id "$name" --region "$REGION" --recovery-window-in-days 30
+    else
+      echo "    (kept; re-run with CONFIRM_DELETE=1 to schedule 30-day-recoverable deletion)"
+    fi
+  done <<< "$secrets"
+  c_warn "After migrating: update any external consumer to read SSM '$SSM_MIGRATE_PREFIX/*' (the app already reads SSM)."
+}
+
+# --------------------------------------------------------------------------
+# 4. AWS Config  (~$0.84/mo) — stop the recorder (reversible)
+# --------------------------------------------------------------------------
+do_config() {
+  c_hdr "AWS Config (~\$0.84/mo) — stop continuous recorder"
+  local recorders
+  recorders="$(aws configservice describe-configuration-recorders --region "$REGION" --output json | jq -r '.ConfigurationRecorders[].name')"
+  if [[ -z "$recorders" ]]; then c_warn "No Config recorder in $REGION."; return; fi
+  while read -r r; do
+    [[ -z "$r" ]] && continue
+    echo "  recorder '$r' -> stop"
+    c_run aws configservice stop-configuration-recorder --configuration-recorder-name "$r" --region "$REGION"
+  done <<< "$recorders"
+  c_warn "Reversible: 'start-configuration-recorder' resumes it. Delete the delivery channel/recorder only if you're sure you never want the audit timeline."
+}
+
+# --------------------------------------------------------------------------
+# 5. KMS  (~$2.13/mo) — AUDIT ONLY (deleting a key in use breaks encryption)
+# --------------------------------------------------------------------------
+do_kms() {
+  c_hdr "KMS (~\$2.13/mo) — audit customer-managed keys (\$1/key/mo)"
+  aws kms list-keys --region "$REGION" --output json | jq -r '.Keys[].KeyId' | while read -r kid; do
+    local meta mgr state alias
+    meta="$(aws kms describe-key --key-id "$kid" --region "$REGION" --output json 2>/dev/null || echo '{}')"
+    mgr="$(echo "$meta" | jq -r '.KeyMetadata.KeyManager')"
+    [[ "$mgr" != "CUSTOMER" ]] && continue   # AWS-managed keys are free; skip
+    state="$(echo "$meta" | jq -r '.KeyMetadata.KeyState')"
+    alias="$(aws kms list-aliases --key-id "$kid" --region "$REGION" --query 'Aliases[0].AliasName' --output text 2>/dev/null || echo '-')"
+    echo "  CMK $kid  state=$state  alias=$alias  (\$1/mo)"
+  done
+  c_warn "For each CMK NOT referenced by SES/S3/Secrets Manager/SQS, schedule deletion (DESTRUCTIVE, 30-day window):"
+  echo "    #   aws kms schedule-key-deletion --key-id <KEY> --pending-window-in-days 30 --region $REGION"
+  echo "    # Prefer switching the consuming service to its free AWS-managed key first."
+}
+
+# --------------------------------------------------------------------------
+# 6. Route 53  (~$4.22/mo) — AUDIT ONLY (health-check features are immutable;
+#    changing them means recreate + edit sst.config.ts — do that in a PR)
+# --------------------------------------------------------------------------
+do_r53() {
+  c_hdr "Route 53 (~\$4.22/mo) — audit zone + HA health checks"
+  echo "  hosted zone $ZONE_ID = \$0.50/mo (unavoidable — it's your DNS)"
+  for hc in "$PRIMARY_HC" "$SECONDARY_HC"; do
+    local cfg
+    cfg="$(aws route53 get-health-check --health-check-id "$hc" --query 'HealthCheck.HealthCheckConfig' --output json 2>/dev/null || echo '{}')"
+    local typ interval str
+    typ="$(echo "$cfg" | jq -r '.Type // "?"')"
+    interval="$(echo "$cfg" | jq -r '.RequestInterval // "?"')"
+    str="$(echo "$cfg" | jq -r 'if .SearchString then "string-match" else "no-match" end')"
+    echo "  health-check $hc  type=$typ interval=${interval}s $str"
+  done
+  c_warn "Surcharges: HTTPS +\$1, string-match +\$1, fast(10s) interval +\$1 — each per check, per month."
+  c_warn "Type & interval are IMMUTABLE on a health check. To drop fast-interval/string-match you must"
+  c_warn "recreate the check and update its healthCheckId in sst.config.ts. Open a PR for that — do not"
+  c_warn "delete a check here or the failover records (sst.config.ts) will reference a missing ID."
+}
+
+# --------------------------------------------------------------------------
+# 7. Systems Manager  (~$0.33/mo) — downgrade advanced params to free standard
+# --------------------------------------------------------------------------
+do_ssm() {
+  c_hdr "Systems Manager (~\$0.33/mo) — downgrade advanced parameters"
+  local params
+  params="$(aws ssm describe-parameters --region "$REGION" --parameter-filters 'Key=Tier,Values=Advanced' --output json 2>/dev/null | jq -r '.Parameters[].Name' || true)"
+  if [[ -z "$params" ]]; then c_ok "No advanced-tier parameters. Nothing to do."; return; fi
+  while read -r p; do
+    [[ -z "$p" ]] && continue
+    local size
+    size="$(aws ssm get-parameter --name "$p" --with-decryption --region "$REGION" --query 'Parameter.Value' --output text 2>/dev/null | wc -c)"
+    if (( size > 4096 )); then
+      c_warn "  '$p' is ${size}B (>4KB) — must stay Advanced. Skipped."
+      continue
+    fi
+    echo "  '$p' (${size}B) -> Standard tier"
+    if [[ "$DRY_RUN" == "1" ]]; then
+      printf '    \033[0;90m[dry-run] put-parameter --tier Standard --overwrite\033[0m\n'
+    else
+      local typ val
+      typ="$(aws ssm get-parameter --name "$p" --region "$REGION" --query 'Parameter.Type' --output text)"
+      val="$(aws ssm get-parameter --name "$p" --with-decryption --region "$REGION" --query 'Parameter.Value' --output text)"
+      aws ssm put-parameter --name "$p" --type "$typ" --value "$val" --tier Standard --overwrite --region "$REGION" >/dev/null
+      c_ok "    downgraded."
+    fi
+  done <<< "$params"
+}
+
+main() {
+  c_hdr "AWS cost reduction — account $ACCOUNT region $REGION  (DRY_RUN=$DRY_RUN)"
+  acct_check
+  # Audit-only items always run (read-only). Reversible cuts run only when flagged.
+  [[ "${DO_WORKMAIL:-0}"   == "1" || "${AUDIT_ALL:-1}" == "1" ]] && do_workmail   || true
+  [[ "${DO_KMS:-0}"        == "1" || "${AUDIT_ALL:-1}" == "1" ]] && do_kms        || true
+  [[ "${DO_R53:-0}"        == "1" || "${AUDIT_ALL:-1}" == "1" ]] && do_r53        || true
+  [[ "${DO_CLOUDTRAIL:-0}" == "1" ]] && do_cloudtrail || c_warn "CloudTrail: set DO_CLOUDTRAIL=1 to apply the trail cut."
+  [[ "${DO_SECRETS:-0}"    == "1" ]] && do_secrets    || c_warn "Secrets:    set DO_SECRETS=1 to migrate to SSM."
+  [[ "${DO_CONFIG:-0}"     == "1" ]] && do_config     || c_warn "Config:     set DO_CONFIG=1 to stop the recorder."
+  [[ "${DO_SSM:-0}"        == "1" ]] && do_ssm        || c_warn "SSM:        set DO_SSM=1 to downgrade advanced params."
+  c_hdr "Done. Projected steady-state: ~\$7-8/mo net (from \$18.19). See docs/aws-cost-reduction.md."
+}
+
+main "$@"

--- a/scripts/aws-cost-reduction.sh
+++ b/scripts/aws-cost-reduction.sh
@@ -67,7 +67,7 @@ acct_check() {
 }
 
 # --------------------------------------------------------------------------
-# 1. WorkMail  ($4.00/mo) — AUDIT ONLY (mailbox deletion is a business call)
+# 1. WorkMail  ($4.00/mo) — KEEP (required mailbox tbaltzakis@cloudless.gr)
 # --------------------------------------------------------------------------
 do_workmail() {
   c_hdr "WorkMail (\$4.00/mo) — audit"
@@ -85,12 +85,9 @@ do_workmail() {
     users="$(aws workmail list-users --organization-id "$org" --region "$wm_region" --output json 2>/dev/null || echo '{}')"
     echo "$users" | jq -r '.Users[]? | "    user \(.Email // .Name) state=\(.State) enabled=\(.UserRole // "?")"'
   done
-  c_warn "DECISION: is this mailbox actively read? Options (run manually):"
-  echo "    # forward-only alternative: Cloudflare Email Routing / ImprovMX -> Gmail (\$0)"
-  echo "    # then disable the user (stops the \$4/user charge, keeps the org):"
-  echo "    #   aws workmail deregister-from-work-mail --organization-id <ORG> --entity-id <USER> --region $wm_region"
-  echo "    # or delete the whole org (DESTRUCTIVE):"
-  echo "    #   aws workmail delete-organization --organization-id <ORG> --delete-directory --region $wm_region"
+  c_ok "KEEP: tbaltzakis@cloudless.gr is a required mailbox. WorkMail is a flat"
+  c_ok "      \$4/user/mo with no usage component — nothing to trim without dropping"
+  c_ok "      the mailbox. Treat the \$4.00 as fixed cost. No action taken."
 }
 
 # --------------------------------------------------------------------------


### PR DESCRIPTION
Adds `docs/aws-cost-reduction.md` — a per-service breakdown of VAT invoice **EUINGR26-58586** (May 2026, $18.19 net / $22.56 incl VAT) with ranked, safety-first cost cuts.

## Key finding
The actual web-app runtime (Lambda + CloudFront + API Gateway + DynamoDB + ECR) is only **~$0.50/mo**. ~90% of the bill is peripheral services that serve no page requests:

| Candidate | Net/mo | Action |
|---|--:|---|
| WorkMail | $4.00 | Migrate/delete mailbox (site uses SES, not WorkMail) |
| CloudTrail | $2.31 | Keep one free management trail, drop data events/Insights |
| Secrets Manager | $1.20 | Migrate ~3 secrets to free SSM SecureString |
| Config | $0.84 | Scope down or disable recorder |
| KMS | $2.13 | Audit/remove orphaned CMKs |
| Route 53 | $4.22 | Trim HA health-check features |

Projected: **~55–60% reduction (~$7–8/mo net) with no change to any site's behavior.**

## Notes
- Items 2, 4, 6 trade against security/HA posture — flagged as decisions for the owner.
- This session has no `aws` CLI / blocked AWS API, so the doc is the actionable plan, not applied changes.

https://claude.ai/code/session_01NcSkJjzxABqYH8jAfDurRt

---
_Generated by [Claude Code](https://claude.ai/code/session_01NcSkJjzxABqYH8jAfDurRt)_