### PR TITLE
fix(cluster): remediate Prometheus OOM, ntfy crash-loop, Keycloak annotation

### DIFF
--- a/.github/workflows/cluster-remediate.yml
+++ b/.github/workflows/cluster-remediate.yml
@@ -1,0 +1,144 @@
+name: Cluster remediate (ntfy restart + Keycloak annotation fix)
+
+# Fixes two issues identified by cluster-doctor (2026-06-02):
+#   1. ntfy deployment in Error/CrashLoop state (96Mi limit, 34 restarts)
+#      — patches memory to 192Mi if OOMKilled, then rolling-restarts
+#   2. Keycloak last-applied-configuration annotation shows stale value
+#      — writes correct annotation via kubectl patch (JSON Patch)
+#
+# Trigger: push to main touching this file.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - ".github/workflows/cluster-remediate.yml"
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  remediate:
+    runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ github.token }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v4.3.1
+
+      - name: Connect to tailnet
+        uses: tailscale/github-action@0263d9e6d793eaefcf1de98ff7fde47abe6664d3 # v3.2.4
+        with:
+          authkey: ${{ secrets.TS_AUTHKEY }}
+
+      - name: Configure kubectl
+        run: |
+          mkdir -p ~/.kube
+          echo "${{ secrets.KUBECONFIG_B64 }}" | base64 -d > ~/.kube/config
+          chmod 600 ~/.kube/config
+
+      - name: Fix ntfy
+        id: fix_ntfy
+        run: |
+          set -uo pipefail
+
+          echo "=== ntfy — before ===" | tee ntfy.log
+          kubectl -n ntfy get pods -o wide 2>&1 | tee -a ntfy.log
+
+          echo "" >> ntfy.log
+          echo "=== ntfy — container states ===" | tee -a ntfy.log
+          kubectl -n ntfy get pods \
+            -o jsonpath='{range .items[*]}{.metadata.name}{":\n"}{range .status.containerStatuses[*]}{"  restarts="}{.restartCount}{" ready="}{.ready}{" lastExit="}{.lastState.terminated.exitCode}{" reason="}{.lastState.terminated.reason}{"\n"}{end}{end}' \
+            2>/dev/null | tee -a ntfy.log; echo
+
+          echo "" >> ntfy.log
+          echo "=== ntfy — recent logs ===" | tee -a ntfy.log
+          kubectl -n ntfy logs deployment/ntfy --tail=30 2>&1 | tee -a ntfy.log || true
+
+          # Detect OOMKilled (exit 137 or reason=OOMKilled)
+          OOMKILLED=$(kubectl -n ntfy get pods \
+            -o jsonpath='{range .items[*]}{range .status.containerStatuses[*]}{.lastState.terminated.reason}{"\n"}{end}{end}' \
+            2>/dev/null | grep -c OOMKilled || true)
+          EXIT137=$(kubectl -n ntfy get pods \
+            -o jsonpath='{range .items[*]}{range .status.containerStatuses[*]}{.lastState.terminated.exitCode}{"\n"}{end}{end}' \
+            2>/dev/null | grep -c '^137$' || true)
+
+          if [ "${OOMKILLED:-0}" -gt 0 ] || [ "${EXIT137:-0}" -gt 0 ]; then
+            echo "" >> ntfy.log
+            echo "=== ntfy — OOMKilled detected; patching memory 96Mi → 192Mi ===" | tee -a ntfy.log
+            kubectl -n ntfy patch deployment ntfy \
+              --type=strategic-merge-patch \
+              -p '{"spec":{"template":{"spec":{"containers":[{"name":"ntfy","resources":{"limits":{"memory":"192Mi","cpu":"200m"},"requests":{"memory":"48Mi","cpu":"10m"}}}]}}}}' \
+              2>&1 | tee -a ntfy.log
+          else
+            echo "" >> ntfy.log
+            echo "=== ntfy — no OOMKill signature; skipping memory patch ===" | tee -a ntfy.log
+          fi
+
+          echo "" >> ntfy.log
+          echo "=== ntfy — rolling restart ===" | tee -a ntfy.log
+          kubectl -n ntfy rollout restart deployment/ntfy 2>&1 | tee -a ntfy.log
+          kubectl -n ntfy rollout status deployment/ntfy --timeout=3m 2>&1 | tee -a ntfy.log || true
+
+          echo "" >> ntfy.log
+          echo "=== ntfy — after ===" | tee -a ntfy.log
+          kubectl -n ntfy get pods -o wide 2>&1 | tee -a ntfy.log
+
+      - name: Fix Keycloak last-applied annotation
+        id: fix_kc_annotation
+        run: |
+          set -uo pipefail
+
+          echo "=== Keycloak annotation — before ===" | tee kc.log
+          kubectl -n keycloak get deployment keycloak \
+            -o jsonpath='{.metadata.annotations.kubectl\.kubernetes\.io/last-applied-configuration}' \
+            2>/dev/null \
+            | python3 -c "import sys,json; d=json.load(sys.stdin); c=d['spec']['template']['spec']['containers'][0]; print('memory limit:', c['resources']['limits']['memory'])" \
+            2>&1 | tee -a kc.log \
+            || echo "(no last-applied-configuration annotation or parse error)" | tee -a kc.log
+
+          echo "" >> kc.log
+          echo "=== Keycloak annotation — patching ===" | tee -a kc.log
+          python3 -c "
+import json
+manifest = {
+  'apiVersion': 'apps/v1',
+  'kind': 'Deployment',
+  'metadata': {'annotations': {}, 'name': 'keycloak', 'namespace': 'keycloak'},
+  'spec': {'template': {'spec': {'containers': [{'env': [{'name': 'JAVA_OPTS_APPEND', 'value': '-Xms128m -Xmx512m -Djdk.reflect.useDirectMethodHandle=false -Dquarkus.http.limits.max-header-size=64K'}], 'name': 'keycloak', 'resources': {'limits': {'cpu': 1, 'memory': '768Mi'}, 'requests': {'cpu': '100m', 'memory': '384Mi'}}}]}}}
+}
+patch = [{'op': 'add', 'path': '/metadata/annotations/kubectl.kubernetes.io~1last-applied-configuration', 'value': json.dumps(manifest) + chr(10)}]
+with open('/tmp/kc-patch.json', 'w') as f:
+    json.dump(patch, f)
+print('patch written')
+"
+          kubectl -n keycloak patch deployment keycloak \
+            --type=json \
+            -p "$(cat /tmp/kc-patch.json)" \
+            2>&1 | tee -a kc.log
+
+          echo "" >> kc.log
+          echo "=== Keycloak annotation — after ===" | tee -a kc.log
+          kubectl -n keycloak get deployment keycloak \
+            -o jsonpath='{.metadata.annotations.kubectl\.kubernetes\.io/last-applied-configuration}' \
+            2>/dev/null \
+            | python3 -c "import sys,json; d=json.load(sys.stdin); c=d['spec']['template']['spec']['containers'][0]; print('memory limit:', c['resources']['limits']['memory'])" \
+            2>&1 | tee -a kc.log \
+            || echo "(parse error)" | tee -a kc.log
+
+      - name: Post results to tracking issue
+        if: always()
+        run: |
+          {
+            echo "# Cluster remediation — $(date -u '+%Y-%m-%d %H:%M:%SZ')"
+            echo ""
+            echo "## ntfy"
+            echo '```'
+            cat ntfy.log 2>/dev/null || echo "(no ntfy log)"
+            echo '```'
+            echo ""
+            echo "## Keycloak annotation"
+            echo '```'
+            cat kc.log 2>/dev/null || echo "(no keycloak annotation log)"
+            echo '```'
+          } | gh issue comment 382 --repo "$GITHUB_REPOSITORY" --body-file -

--- a/scripts/cluster-doctor.sh
+++ b/scripts/cluster-doctor.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 #
 # cluster-doctor.sh — read-only diagnostics for the omv k3s cluster, with a
-# focus on why Keycloak (auth.cloudless.gr) might be down.
+# focus on why Keycloak (auth.cloudless.gr) might be down. [triggered 2026-06-02]
 #
 # Emits a Markdown report to stdout. Every kubectl call is best-effort (|| true)
 # so the report is always produced even when individual objects are missing.

--- a/scripts/prometheus-tune.sh
+++ b/scripts/prometheus-tune.sh
@@ -73,3 +73,30 @@ if [ -s /tmp/promrules.json ]; then
 else
   log "  (could not re-fetch /api/v1/rules)"
 fi
+
+# ── Bump Prometheus container memory limit (500Mi → 750Mi) to stop OOMKills ─
+log "Patching Prometheus StatefulSet memory limit to 750Mi..."
+PROM_STS=$(kubectl -n "$PROM_NS" get sts -l app.kubernetes.io/name=prometheus \
+  -o jsonpath='{.items[0].metadata.name}' 2>/dev/null || true)
+if [ -n "${PROM_STS:-}" ]; then
+  CURRENT_MEM=$(kubectl -n "$PROM_NS" get sts "$PROM_STS" \
+    -o jsonpath='{.spec.template.spec.containers[?(@.name=="prometheus")].resources.limits.memory}' \
+    2>/dev/null || true)
+  log "  current limit: ${CURRENT_MEM:-unknown}"
+  if [ "${CURRENT_MEM:-}" = "750Mi" ]; then
+    log "  already 750Mi — skipping patch"
+  else
+    kubectl -n "$PROM_NS" patch sts "$PROM_STS" \
+      --type=strategic-merge-patch \
+      -p '{"spec":{"template":{"spec":{"containers":[{"name":"prometheus","resources":{"limits":{"memory":"750Mi"},"requests":{"memory":"512Mi"}}}]}}}}' \
+      && log "  patched → 750Mi limit / 512Mi request" \
+      || log "  WARNING: StatefulSet patch failed"
+    kubectl -n "$PROM_NS" rollout status sts/"$PROM_STS" --timeout=3m 2>&1 | tail -5 || true
+    NEW_MEM=$(kubectl -n "$PROM_NS" get sts "$PROM_STS" \
+      -o jsonpath='{.spec.template.spec.containers[?(@.name=="prometheus")].resources.limits.memory}' \
+      2>/dev/null || true)
+    log "  confirmed new limit: ${NEW_MEM:-unknown}"
+  fi
+else
+  log "  WARNING: no Prometheus StatefulSet found (label app.kubernetes.io/name=prometheus)"
+fi


### PR DESCRIPTION
## Summary

- **Prometheus OOM**: `prometheus-tune.sh` now patches the StatefulSet memory limit from 500Mi → 750Mi after removing heavy apiserver SLO rules (3 OOMKills recorded)
- **ntfy crash-loop**: `cluster-remediate.yml` detects OOMKill (exit 137), patches limit 96Mi → 192Mi, then rolling-restarts and confirms rollout
- **Keycloak annotation drift**: same workflow writes the correct `last-applied-configuration` annotation (768Mi) via `kubectl patch --type=json`, bypassing the partial-spec selector immutability error that broke `kubectl apply`

## Two workflows fire on merge to main

1. `prometheus-tune.yml` — triggered by `scripts/prometheus-tune.sh` path change
2. `cluster-remediate.yml` — triggered by its own path change

Both post results to issue #382.

https://claude.ai/code/session_01PHsA9s3tK2thgSJVwEGuWq

---
_Generated by [Claude Code](https://claude.ai/code/session_01PHsA9s3tK2thgSJVwEGuWq)_