### PR TITLE
fix(cluster): fix YAML parse error in cluster-remediate.yml

### DIFF
--- a/.github/workflows/cluster-remediate.yml
+++ b/.github/workflows/cluster-remediate.yml
@@ -1,10 +1,10 @@
 name: Cluster remediate (ntfy restart + Keycloak annotation fix)
 
 # Fixes two issues identified by cluster-doctor (2026-06-02):
-#   1. ntfy deployment in Error/CrashLoop state (96Mi limit, 34 restarts)
+#   1. ntfy in Error/CrashLoop state (96Mi limit, 34 restarts)
 #      — patches memory to 192Mi if OOMKilled, then rolling-restarts
-#   2. Keycloak last-applied-configuration annotation shows stale value
-#      — writes correct annotation via kubectl patch (JSON Patch)
+#   2. Keycloak last-applied-configuration annotation stale
+#      — writes correct 768Mi annotation via kubectl patch (JSON Patch)
 #
 # Trigger: push to main touching this file.
 
@@ -38,7 +38,6 @@ jobs:
           chmod 600 ~/.kube/config
 
       - name: Fix ntfy
-        id: fix_ntfy
         run: |
           set -uo pipefail
 
@@ -55,7 +54,6 @@ jobs:
           echo "=== ntfy — recent logs ===" | tee -a ntfy.log
           kubectl -n ntfy logs deployment/ntfy --tail=30 2>&1 | tee -a ntfy.log || true
 
-          # Detect OOMKilled (exit 137 or reason=OOMKilled)
           OOMKILLED=$(kubectl -n ntfy get pods \
             -o jsonpath='{range .items[*]}{range .status.containerStatuses[*]}{.lastState.terminated.reason}{"\n"}{end}{end}' \
             2>/dev/null | grep -c OOMKilled || true)
@@ -71,8 +69,7 @@ jobs:
               -p '{"spec":{"template":{"spec":{"containers":[{"name":"ntfy","resources":{"limits":{"memory":"192Mi","cpu":"200m"},"requests":{"memory":"48Mi","cpu":"10m"}}}]}}}}' \
               2>&1 | tee -a ntfy.log
           else
-            echo "" >> ntfy.log
-            echo "=== ntfy — no OOMKill signature; skipping memory patch ===" | tee -a ntfy.log
+            echo "=== ntfy — no OOMKill detected; skipping memory patch ===" | tee -a ntfy.log
           fi
 
           echo "" >> ntfy.log
@@ -85,7 +82,6 @@ jobs:
           kubectl -n ntfy get pods -o wide 2>&1 | tee -a ntfy.log
 
       - name: Fix Keycloak last-applied annotation
-        id: fix_kc_annotation
         run: |
           set -uo pipefail
 
@@ -95,23 +91,11 @@ jobs:
             2>/dev/null \
             | python3 -c "import sys,json; d=json.load(sys.stdin); c=d['spec']['template']['spec']['containers'][0]; print('memory limit:', c['resources']['limits']['memory'])" \
             2>&1 | tee -a kc.log \
-            || echo "(no last-applied-configuration annotation or parse error)" | tee -a kc.log
+            || echo "(no last-applied-configuration annotation)" | tee -a kc.log
 
           echo "" >> kc.log
           echo "=== Keycloak annotation — patching ===" | tee -a kc.log
-          python3 -c "
-import json
-manifest = {
-  'apiVersion': 'apps/v1',
-  'kind': 'Deployment',
-  'metadata': {'annotations': {}, 'name': 'keycloak', 'namespace': 'keycloak'},
-  'spec': {'template': {'spec': {'containers': [{'env': [{'name': 'JAVA_OPTS_APPEND', 'value': '-Xms128m -Xmx512m -Djdk.reflect.useDirectMethodHandle=false -Dquarkus.http.limits.max-header-size=64K'}], 'name': 'keycloak', 'resources': {'limits': {'cpu': 1, 'memory': '768Mi'}, 'requests': {'cpu': '100m', 'memory': '384Mi'}}}]}}}
-}
-patch = [{'op': 'add', 'path': '/metadata/annotations/kubectl.kubernetes.io~1last-applied-configuration', 'value': json.dumps(manifest) + chr(10)}]
-with open('/tmp/kc-patch.json', 'w') as f:
-    json.dump(patch, f)
-print('patch written')
-"
+          python3 -c "import json; m={'apiVersion':'apps/v1','kind':'Deployment','metadata':{'annotations':{},'name':'keycloak','namespace':'keycloak'},'spec':{'template':{'spec':{'containers':[{'env':[{'name':'JAVA_OPTS_APPEND','value':'-Xms128m -Xmx512m -Djdk.reflect.useDirectMethodHandle=false -Dquarkus.http.limits.max-header-size=64K'}],'name':'keycloak','resources':{'limits':{'cpu':1,'memory':'768Mi'},'requests':{'cpu':'100m','memory':'384Mi'}}}]}}}}};p=[{'op':'add','path':'/metadata/annotations/kubectl.kubernetes.io~1last-applied-configuration','value':json.dumps(m)+chr(10)}];open('/tmp/kc-patch.json','w').write(json.dumps(p));print('patch written')"
           kubectl -n keycloak patch deployment keycloak \
             --type=json \
             -p "$(cat /tmp/kc-patch.json)" \


### PR DESCRIPTION
Fixes the YAML parse error that caused `cluster-remediate.yml` to fail immediately (0 jobs queued).

Root cause: multiline `python3 -c "..."` block had Python lines (`import json` etc.) at column 0, which the YAML block scalar parser interpreted as ending the `run:` block. Replaced all multiline Python with single-line one-liners.

This re-enables the ntfy + Keycloak annotation fix that was intended to run in PR #445.

https://claude.ai/code/session_01PHsA9s3tK2thgSJVwEGuWq

---
_Generated by [Claude Code](https://claude.ai/code/session_01PHsA9s3tK2thgSJVwEGuWq)_