### PR TITLE
fix(security): constant-time newsletter secret compare + stop checkout error reflection

### DIFF
--- a/src/app/api/checkout/route.ts
+++ b/src/app/api/checkout/route.ts
@@ -150,9 +150,14 @@ export async function POST(request: NextRequest) {
     // codeql[js/log-injection] -- error message sanitized (newlines stripped)
     console.error("Checkout error:", msg);
 
-    // Client errors: malformed body or unknown product → 400
-    if (/unknown product|json/i.test(msg)) {
-      return Response.json({ error: msg }, { status: 400 });
+    // Client errors: malformed body or unknown product → 400. Return a fixed,
+    // non-reflective message — never echo the raw exception text (which may
+    // carry internal product IDs / SDK internals) back to the caller.
+    if (/unknown product/i.test(msg)) {
+      return Response.json({ error: "Unknown product in cart." }, { status: 400 });
+    }
+    if (/json/i.test(msg)) {
+      return Response.json({ error: "Invalid request body." }, { status: 400 });
     }
 
     if (process.env.NEXT_PUBLIC_SENTRY_DSN) {

--- a/src/app/api/newsletter/send/route.ts
+++ b/src/app/api/newsletter/send/route.ts
@@ -1,6 +1,20 @@
+import { timingSafeEqual } from "node:crypto";
 import { sendEmail } from "@/lib/email";
 import { listNewsletterSubscribers } from "@/lib/hubspot";
 import { getConfig } from "@/lib/ssm-config";
+
+/** Constant-time secret compare — avoids leaking the token via response timing. */
+function secretsMatch(provided: string | null, expected: string): boolean {
+  if (!provided) return false;
+  const a = Buffer.from(provided);
+  const b = Buffer.from(expected);
+  if (a.length !== b.length) return false;
+  try {
+    return timingSafeEqual(a, b);
+  } catch {
+    return false;
+  }
+}
 
 // The publisher script renders this token into the newsletter footer; the
 // route swaps it for a per-recipient unsubscribe URL at send time.
@@ -67,7 +81,7 @@ export async function POST(request: Request): Promise<Response> {
   if (!secret) {
     return Response.json({ error: "Newsletter sending is not configured." }, { status: 503 });
   }
-  if (request.headers.get("x-newsletter-secret") !== secret) {
+  if (!secretsMatch(request.headers.get("x-newsletter-secret"), secret)) {
     return Response.json({ error: "Unauthorized." }, { status: 401 });
   }
 


### PR DESCRIPTION
## Security audit follow-ups (2 fixes)

From the systematic `api-security-audit` sweep of `src/app/api/**`:

- 🔴 **CRITICAL — `newsletter/send/route.ts`:** the shared `NEWSLETTER_SEND_SECRET` header was checked with plain `!==` (timing side-channel). Now uses `node:crypto` `timingSafeEqual` via a length-guarded helper (same pattern as the HubSpot webhook).
- 🟠 **HIGH — `checkout/route.ts`:** the catch block reflected the raw exception message to the client for the unknown-product / bad-JSON cases (could leak internal product IDs / SDK internals). Now returns fixed, non-reflective messages.

## Test plan
- [x] `pnpm test` — 2082 pass
- [ ] CI green

## Remaining audit findings (NOT in this PR — need your call, see PR discussion)
MEDIUM: portal bearer-token-in-URL entropy; Slack `responseUrl` not domain-validated (signature-gated); esp32 `device_id` path interpolation (admin-gated). LOW: calendar/book double rate-limit mismatch; chat error-object logging.

https://claude.ai/code/session_016PrzZJMNxsgiEmvedfkru6

---
_Generated by [Claude Code](https://claude.ai/code/session_016PrzZJMNxsgiEmvedfkru6)_