### PR TITLE
fix(cluster): add timeout to kubectl logs in cluster-remediate

### DIFF
--- a/.github/workflows/cluster-remediate.yml
+++ b/.github/workflows/cluster-remediate.yml
@@ -61,7 +61,7 @@ jobs:
 
           echo "" >> ntfy.log
           echo "=== ntfy — recent logs (database lock check) ===" | tee -a ntfy.log
-          kubectl -n ntfy logs deployment/ntfy --tail=10 2>&1 | tee -a ntfy.log || true
+          timeout 20s kubectl -n ntfy logs deployment/ntfy --tail=10 2>&1 | tee -a ntfy.log || true
 
       - name: Fix Keycloak last-applied annotation
         run: |


### PR DESCRIPTION
The current run of cluster-remediate (run #26794894187) is stuck on step 5 — `kubectl logs deployment/ntfy --tail=10` is blocking indefinitely when the pod hasn't produced logs yet.

Adding `timeout 20s` before the logs command so the step always completes within a bounded time.

https://claude.ai/code/session_01PHsA9s3tK2thgSJVwEGuWq

---
_Generated by [Claude Code](https://claude.ai/code/session_01PHsA9s3tK2thgSJVwEGuWq)_