### PR TITLE
fix(security): validate esp32 device_id + pin Slack responseUrl host

### DIFF
--- a/src/app/api/admin/esp32/route.ts
+++ b/src/app/api/admin/esp32/route.ts
@@ -3,6 +3,16 @@ import { NextRequest, NextResponse } from "next/server";
 
 const ALERT_API = process.env.ALERT_API_URL ?? "http://192.168.1.128:30800";
 
+/**
+ * Device IDs are short slugs. Validate before interpolating into the upstream
+ * proxy URL so a crafted `device_id` (path traversal, encoded slashes) can't
+ * alter the request target. Falls back to the default on anything invalid.
+ */
+function safeDeviceId(raw: string | null): string {
+  const id = raw ?? "esp32-leds";
+  return /^[a-zA-Z0-9_-]{1,64}$/.test(id) ? id : "esp32-leds";
+}
+
 function isPrivateLanUrl(url: string): boolean {
   try {
     const { hostname } = new URL(url);
@@ -50,7 +60,7 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
 
   const { searchParams } = request.nextUrl;
   const action = searchParams.get("action");
-  const deviceId = searchParams.get("device_id") ?? "esp32-leds";
+  const deviceId = safeDeviceId(searchParams.get("device_id"));
 
   switch (action) {
     case "devices": {
@@ -109,7 +119,7 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
 
   const { searchParams } = request.nextUrl;
   const action = searchParams.get("action");
-  const deviceId = searchParams.get("device_id") ?? "esp32-leds";
+  const deviceId = safeDeviceId(searchParams.get("device_id"));
   const body = await request.text();
   const headers = { "Content-Type": "application/json" };
 
@@ -135,7 +145,7 @@ export async function PUT(request: NextRequest): Promise<NextResponse> {
   }
 
   const { searchParams } = request.nextUrl;
-  const deviceId = searchParams.get("device_id") ?? "esp32-leds";
+  const deviceId = safeDeviceId(searchParams.get("device_id"));
   const body = await request.text();
 
   return proxyRequest(`/api/esp32/${deviceId}/config`, {

--- a/src/app/api/slack/interactions/route.ts
+++ b/src/app/api/slack/interactions/route.ts
@@ -336,6 +336,10 @@ async function postDeployAsync(payload: SlackInteractionPayload): Promise<void> 
 }
 
 async function refreshOrdersAsync(responseUrl: string): Promise<void> {
+  // `responseUrl` comes from the (signature-verified) Slack payload, but we
+  // still pin it to Slack's response-URL host so a forged-but-signed payload
+  // can't turn this into an SSRF primitive against an internal target.
+  if (!responseUrl.startsWith("https://hooks.slack.com/")) return;
   try {
     const { orders } = await listRecentCheckoutSessions(5);
     const lines = orders.map((o) => {


### PR DESCRIPTION
## Security audit MEDIUM follow-ups

- 🟡 **`admin/esp32`** — `device_id` (query param) was interpolated into the upstream proxy URL unvalidated. Now validated `^[a-zA-Z0-9_-]{1,64}$` before use (path-traversal / encoded-slash defence). Admin-gated already; defence in depth.
- 🟡 **`slack/interactions`** — `responseUrl` from the Slack payload is now pinned to `https://hooks.slack.com/` before `fetch`, so a forged-but-signed payload can't turn `refreshOrdersAsync` into an SSRF primitive.

**Third MEDIUM (portal token) intentionally NOT changed:** tokens are issued via `randomUUID()` (122-bit, 36 chars), so the `length < 10` read guard is just a sanity floor — raising it to 32 would be pointless and risk 404ing existing live client portals.

## Test plan
- [x] `pnpm test` — 2082 pass (incl. esp32, slack interactions)
- [ ] CI green

https://claude.ai/code/session_016PrzZJMNxsgiEmvedfkru6

---
_Generated by [Claude Code](https://claude.ai/code/session_016PrzZJMNxsgiEmvedfkru6)_