### PR TITLE
fix(security): close audit-tail items (error reflection + log hygiene)

### DIFF
--- a/src/app/api/admin/reports/generate/route.ts
+++ b/src/app/api/admin/reports/generate/route.ts
@@ -62,8 +62,11 @@ export async function POST(request: NextRequest) {
       throw new Error("clientName, dateStart, dateEnd required");
   } catch (e) {
     const _r = mapIntegrationError(e); if (_r) return _r;
+    // Surface only our own validation message; genericise anything else (e.g.
+    // a JSON.parse error) so raw exception text is never reflected to clients.
+    const isValidation = e instanceof Error && e.message.includes("required");
     return NextResponse.json(
-      { error: e instanceof Error ? e.message : "Invalid input" },
+      { error: isValidation ? (e as Error).message : "Invalid input" },
       { status: 400 },
     );
   }

--- a/src/app/api/calendar/book/route.ts
+++ b/src/app/api/calendar/book/route.ts
@@ -13,7 +13,9 @@ import { rateLimit, getClientIp } from "@/lib/rate-limit";
 import { mapIntegrationError } from "@/lib/api-errors";
 
 export async function POST(request: Request) {
-  // Rate limit: 5 booking attempts per IP per 10 minutes
+  // Two intentional layers (not a mismatch): proxy.ts caps bursts at 3/60s,
+  // while this in-route limit caps *sustained* booking abuse at 5 per 10 min
+  // (tighter over a 10-min window than the proxy's burst rule).
   const ip = getClientIp(request);
   const rl = rateLimit(`calendar-book:${ip}`, 5, 10 * 60_000);
   if (!rl.ok) return rl.response;

--- a/src/app/api/chat/route.ts
+++ b/src/app/api/chat/route.ts
@@ -121,7 +121,9 @@ export async function POST(request: NextRequest) {
     finalText = await runBedrockChatLoop(SYSTEM_PROMPT, messages);
   } catch (err) {
     const name = err instanceof Error ? err.name : "";
-    console.error("[chat] bedrock loop failed:", err);
+    // Log name + message only — never the full error object, which may carry
+    // SDK request context (region, model ARN, partial auth headers) into logs.
+    console.error("[chat] bedrock loop failed:", name, err instanceof Error ? err.message : String(err));
     // Access/auth errors → config issue on our side; surface as 503.
     // Transient errors (throttling, model unavailable, etc.) → 502.
     if (name === "AccessDeniedException" || name === "UnauthorizedException") {


### PR DESCRIPTION
## Audit-tail cleanups (LOW severity, completes the security sweep)

- **`admin/reports/generate`** — surface only our own `"...required"` validation message; genericise anything else (e.g. a `JSON.parse` error) so raw exception text is never reflected to clients.
- **`chat`** — log `err.name + err.message` only, never the full error object (which can carry Bedrock SDK request context — region, model ARN, partial auth — into logs).
- **`calendar/book`** — clarifying comment that the proxy burst limit (3/60s) and the in-route sustained limit (5/10min) are **intentional layers**, not a mismatch. No behaviour change (the route's sustained cap is the tighter one and stays).

## Test plan
- [x] `pnpm test` — 2082 pass
- [ ] CI green

With this, every actionable finding from the API security audit is closed. The only remaining item is **SES-SMTP provisioning** (ops/AWS, your side).

https://claude.ai/code/session_016PrzZJMNxsgiEmvedfkru6

---
_Generated by [Claude Code](https://claude.ai/code/session_016PrzZJMNxsgiEmvedfkru6)_