### PR TITLE
ci(keycloak): trigger configure-email to apply/verify SES SMTP from SSM

### DIFF
--- a/.github/workflows/keycloak-configure-email.yml
+++ b/.github/workflows/keycloak-configure-email.yml
@@ -16,6 +16,10 @@ name: Keycloak configure email verification
 #
 #   Then trigger this workflow via workflow_dispatch (leave inputs blank to read
 #   from SSM, or paste the credentials directly in the inputs).
+#
+#   It also re-runs on any push to main that touches this file or the script
+#   (push trigger below) — that path reads the credentials from SSM and is the
+#   idempotent way to (re)apply the SES SMTP config without the dispatch UI.
 
 on:
   workflow_dispatch:


### PR DESCRIPTION
## Purpose

Triggers `keycloak-configure-email.yml` (via its `push.paths` trigger) to **apply/verify the SES SMTP + email-verification config** for Keycloak registrations.

On a push trigger the workflow reads `SES_SMTP_USER` / `SES_SMTP_PASSWORD` / `SES_FROM_EMAIL` from SSM and applies the realm `smtpServer` block + `verifyEmail`. If the SSM creds are present, this completes the open SES-SMTP item (registration verification emails will send). If absent, the run **fails cleanly** with a clear AWS-Console remediation message — definitively confirming the blocker.

The doc edit itself clarifies the push-trigger route (idempotent re-apply from SSM when the dispatch UI isn't available).

https://claude.ai/code/session_016PrzZJMNxsgiEmvedfkru6

---
_Generated by [Claude Code](https://claude.ai/code/session_016PrzZJMNxsgiEmvedfkru6)_