### PR TITLE
security: fix 4 critical API vulnerabilities

### DIFF
--- a/src/app/api/auth/register/route.ts
+++ b/src/app/api/auth/register/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from "next/server";
 import { getConfig } from "@/lib/ssm-config";
 import { isValidEmail } from "@/lib/validation";
+import { rateLimit, getClientIp } from "@/lib/rate-limit";
 
 interface RegisterBody {
   email: string;
@@ -17,6 +18,7 @@ async function getAdminToken(tokenUrl: string, clientId: string, clientSecret: s
       client_id: clientId,
       client_secret: clientSecret,
     }).toString(),
+    signal: AbortSignal.timeout(10_000),
   });
   if (!res.ok) throw new Error(`Admin token request failed: ${res.status}`);
   const data = (await res.json()) as { access_token: string };
@@ -24,6 +26,9 @@ async function getAdminToken(tokenUrl: string, clientId: string, clientSecret: s
 }
 
 export async function POST(req: Request) {
+  const rl = rateLimit(`register:${getClientIp(req)}`, 5, 10 * 60_000);
+  if (!rl.ok) return rl.response;
+
   const issuer = process.env.KEYCLOAK_ISSUER;
   if (!issuer) {
     return NextResponse.json({ error: "Registration not available" }, { status: 503 });
@@ -87,6 +92,7 @@ export async function POST(req: Request) {
         "Content-Type": "application/json",
       },
       body: JSON.stringify(userRep),
+      signal: AbortSignal.timeout(10_000),
     });
 
     if (createRes.status === 409) {
@@ -96,13 +102,7 @@ export async function POST(req: Request) {
       );
     }
     if (!createRes.ok) {
-      const errData = (await createRes.json().catch(() => null)) as {
-        errorMessage?: string;
-      } | null;
-      return NextResponse.json(
-        { error: errData?.errorMessage ?? "Registration failed" },
-        { status: 400 }
-      );
+      return NextResponse.json({ error: "Registration failed" }, { status: 400 });
     }
 
     // Send verification email via the app client so the link returns to cloudless.gr
@@ -117,14 +117,14 @@ export async function POST(req: Request) {
       await globalThis
         .fetch(
           `${kcBase}/admin/realms/${realm}/users/${userId}/send-verify-email?${params.toString()}`,
-          { method: "PUT", headers: { Authorization: `Bearer ${adminToken}` } }
+          { method: "PUT", headers: { Authorization: `Bearer ${adminToken}` }, signal: AbortSignal.timeout(8_000) }
         )
         .catch(() => {});
     }
 
     return NextResponse.json({ ok: true });
   } catch (err) {
-    console.error("[auth/register]", err);
+    console.error("[auth/register]", err instanceof Error ? err.message : String(err));
     return NextResponse.json({ error: "Registration failed" }, { status: 500 });
   }
 }

--- a/src/app/api/chat/route.ts
+++ b/src/app/api/chat/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest } from "next/server";
 import { escapeHtml } from "@/lib/escape-html";
 import { runBedrockChatLoop } from "@/lib/bedrock-chat";
+import { rateLimit, getClientIp } from "@/lib/rate-limit";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
@@ -108,6 +109,9 @@ function sseStreamFromText(text: string): ReadableStream<Uint8Array> {
 // ---------------------------------------------------------------------------
 
 export async function POST(request: NextRequest) {
+  const rl = rateLimit(`chat:${getClientIp(request)}`, 10, 60_000);
+  if (!rl.ok) return rl.response;
+
   let messages: { role: "user" | "assistant"; content: string }[];
   try {
     const body = await request.json();

--- a/src/app/api/portal/[token]/route.ts
+++ b/src/app/api/portal/[token]/route.ts
@@ -38,7 +38,8 @@ export async function GET(
 
   const { token } = await params;
 
-  if (!token || token.length < 10) {
+  const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+  if (!token || !UUID_RE.test(token)) {
     return NextResponse.json({ error: "Invalid token" }, { status: 401 });
   }
 

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -88,6 +88,11 @@ const RATE_LIMITS: Record<string, { windowMs: number; max: number }> = {
   "/api/crm/contact": { windowMs: 60_000, max: 3 },
   // LLM proxy — each call hits the Anthropic API and costs money. Tighter cap.
   "/api/chat": { windowMs: 60_000, max: 12 },
+  // Public analytics tracking — writes to Notion on every call. Cap matches in-handler limit.
+  "/api/track": { windowMs: 60_000, max: 30 },
+  // Mass-email sender — shared-secret-authenticated but one call triggers SES
+  // sends to all subscribers. 1 per hour is enough for any legitimate newsletter.
+  "/api/newsletter/send": { windowMs: 3_600_000, max: 1 },
 };
 
 // Admin endpoints are JWT-auth-gated, but we still rate-limit them to cap


### PR DESCRIPTION
## Critical fixes

**`/api/chat` — no rate limit on Lambda path**
The proxy rate-limits this at 12/min for the Pi deployment, but Lambda requests bypass the proxy entirely. Added in-handler `rateLimit()` at 10/min/IP so both paths are protected. Without this, anyone could hammer AWS Bedrock and run up costs.

**`/api/auth/register` — error leak + exception logging + no rate limit**
- Keycloak's raw `errorMessage` was echoed to clients (`errData?.errorMessage`), which can contain internal realm names, LDAP config, and user-ID details. Now returns a fixed `"Registration failed"` string.
- The catch block logged the full exception object; the admin token is in scope at that point. Now logs only `err.message`.
- No in-handler rate limit (proxy-only). Added 5 attempts / 10 min / IP.

**`/api/portal/[token]` — length floor of 10 allows brute-force**
A 10-char token would pass validation. Portal tokens are UUIDs — enforcing the full UUID format with a regex eliminates the 10-char enumeration window.

**`/api/newsletter/send` — missing from proxy RATE_LIMITS**
Secret-authenticated mass-email endpoint was absent from the Pi proxy cap table. Added at 1/hour which is sufficient for any legitimate newsletter send.

---
_Generated by [Claude Code](https://claude.ai/code/session_01PHsA9s3tK2thgSJVwEGuWq)_