### PR TITLE
fix(admin/users): add AbortSignal.timeout to Keycloak admin fetch calls

### DIFF
--- a/src/app/api/admin/users/route.ts
+++ b/src/app/api/admin/users/route.ts
@@ -41,6 +41,7 @@ async function getAdminToken(): Promise<string> {
     method: "POST",
     headers: { "Content-Type": "application/x-www-form-urlencoded" },
     body: body.toString(),
+    signal: AbortSignal.timeout(10_000),
   });
   if (!res.ok) throw new Error(`Keycloak admin token failed: ${res.status}`);
   const data = (await res.json()) as { access_token: string };
@@ -55,6 +56,7 @@ function kcFetch(path: string, token: string, init?: RequestInit) {
       "Content-Type": "application/json",
       ...(init?.headers as Record<string, string> | undefined),
     },
+    signal: AbortSignal.timeout(10_000),
   });
 }
 


### PR DESCRIPTION
Adds `AbortSignal.timeout(10_000)` to both the admin token request and the `kcFetch` wrapper in `admin/users/route.ts`, matching the pattern already applied to `auth/register` in the security fixes PR.

---
_Generated by [Claude Code](https://claude.ai/code/session_01PHsA9s3tK2thgSJVwEGuWq)_