### PR TITLE
fix(tests): repair main after #456 parallel security pass (2 red tests)

### DIFF
--- a/__tests__/auth-register-api.test.ts
+++ b/__tests__/auth-register-api.test.ts
@@ -183,7 +183,7 @@ describe("POST /api/auth/register", () => {
     expect(body.error).toMatch(/already exists/i);
   });
 
-  it("returns 400 with Keycloak errorMessage on password policy violation", async () => {
+  it("returns a generic 400 on Keycloak failure without leaking its errorMessage", async () => {
     fetchMock.mockResolvedValueOnce(tokenOk()).mockResolvedValueOnce({
       ok: false,
       status: 400,
@@ -194,7 +194,9 @@ describe("POST /api/auth/register", () => {
     const res = await POST(req({ email: "a@b.com", password: "password1" }));
     expect(res.status).toBe(400);
     const body = (await res.json()) as { error: string };
-    expect(body.error).toBe("Password does not meet policy requirements");
+    // Sanitised: raw Keycloak realm/LDAP detail must NOT reach the caller.
+    expect(body.error).toBe("Registration failed");
+    expect(body.error).not.toContain("policy");
   });
 
   it("returns 400 with fallback message when Keycloak gives no errorMessage", async () => {

--- a/__tests__/chat-api.test.ts
+++ b/__tests__/chat-api.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { NextRequest } from "next/server";
+import { resetRateLimitStore } from "@/lib/rate-limit";
 
 // ---------------------------------------------------------------------------
 // Hoist mocks
@@ -103,6 +104,10 @@ async function readSseText(res: Response): Promise<string> {
 describe("POST /api/chat", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    // /api/chat gained an in-handler rate limit (10/min/IP) backed by a
+    // module-level store. getClientIp returns a fixed IP in tests, so without
+    // resetting, requests accumulate across tests and later ones get 429.
+    resetRateLimitStore();
   });
 
   it("returns 400 when messages array is missing", async () => {


### PR DESCRIPTION
## Restores green `main` after a parallel security PR (#456)

While verifying the convergence of this session's security work with **#456** (a concurrent security pass from another session), I found **`main` was RED** — 2 tests failing because #456 changed behavior without updating their expectations:

1. **`auth-register-api`** — #456 correctly sanitised the register route to return a generic `"Registration failed"` instead of echoing Keycloak's `errorMessage` (no realm/LDAP leak). The test still asserted the old leaked message. → Updated expectation to the sanitised string, plus an assertion that the internal detail is NOT present.
2. **`chat-api`** — #456 added an in-handler rate limit (`10/min/IP`) on `/api/chat` backed by a module-level store. `getClientIp` returns a fixed IP in tests, so requests accumulated across the file and the iteration-cap test received `429` instead of `200`. → Reset the shared store in `beforeEach` (real state isolation via the lib's `resetRateLimitStore`, not a mock shim — per the project testing policy).

Both fixes preserve #456's (correct) security behavior; only stale test expectations / test isolation were repaired.

## Test plan
- [x] `pnpm test` — 2082 pass (was 2 failed | 2080 passed on main)
- [ ] CI green

https://claude.ai/code/session_016PrzZJMNxsgiEmvedfkru6

---
_Generated by [Claude Code](https://claude.ai/code/session_016PrzZJMNxsgiEmvedfkru6)_