### PR TITLE
security: harden user/profile, admin/users, subscribe, esp32/notion-sync

### DIFF
--- a/src/app/api/admin/esp32/notion-sync/route.ts
+++ b/src/app/api/admin/esp32/notion-sync/route.ts
@@ -14,6 +14,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { requireAdmin } from "@/lib/api-auth";
 import { safeEqual } from "@/lib/cron-auth";
+import { getConfig } from "@/lib/ssm-config";
 import {
   isEsp32NotionConfigured,
   getEsp32NotionConfig,
@@ -53,7 +54,8 @@ export async function GET(request: NextRequest) {
 export async function POST(request: NextRequest) {
   // Allow either an authenticated admin OR a server-to-server cron call with
   // the shared secret. Cron path is used by cron-invoker.ts in Lambda.
-  const cronSecret = process.env.CRON_SECRET;
+  const cfg = await getConfig().catch(() => null);
+  const cronSecret = cfg?.CRON_SECRET ?? process.env.CRON_SECRET;
   const headerSecret = request.headers.get("x-cron-secret");
   const isCron =
     cronSecret &&

--- a/src/app/api/admin/users/route.ts
+++ b/src/app/api/admin/users/route.ts
@@ -124,7 +124,7 @@ export async function GET(request: NextRequest) {
 
     return NextResponse.json({ users, count: users.length });
   } catch (err) {
-    console.error("Failed to list Keycloak users:", err);
+    console.error("Failed to list Keycloak users:", err instanceof Error ? err.message : String(err));
     return NextResponse.json({ error: "Failed to list users" }, { status: 500 });
   }
 }
@@ -146,6 +146,12 @@ export async function POST(request: NextRequest) {
 
     if (!action || !userId) {
       return NextResponse.json({ error: "action and username required" }, { status: 400 });
+    }
+
+    // Validate userId is a Keycloak UUID before interpolating into API paths
+    const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+    if (!UUID_RE.test(userId)) {
+      return NextResponse.json({ error: "Invalid user id" }, { status: 400 });
     }
 
     if (action === "disable") {
@@ -183,7 +189,7 @@ export async function POST(request: NextRequest) {
 
     return NextResponse.json({ error: "Unknown action" }, { status: 400 });
   } catch (err) {
-    console.error("Failed to modify Keycloak user:", err);
+    console.error("Failed to modify Keycloak user:", err instanceof Error ? err.message : String(err));
     return NextResponse.json({ error: "Failed to modify user" }, { status: 500 });
   }
 }

--- a/src/app/api/admin/users/route.ts
+++ b/src/app/api/admin/users/route.ts
@@ -41,6 +41,7 @@ async function getAdminToken(): Promise<string> {
     method: "POST",
     headers: { "Content-Type": "application/x-www-form-urlencoded" },
     body: body.toString(),
+    signal: AbortSignal.timeout(10_000),
   });
   if (!res.ok) throw new Error(`Keycloak admin token failed: ${res.status}`);
   const data = (await res.json()) as { access_token: string };
@@ -55,6 +56,7 @@ function kcFetch(path: string, token: string, init?: RequestInit) {
       "Content-Type": "application/json",
       ...(init?.headers as Record<string, string> | undefined),
     },
+    signal: AbortSignal.timeout(10_000),
   });
 }
 

--- a/src/app/api/subscribe/route.ts
+++ b/src/app/api/subscribe/route.ts
@@ -57,7 +57,7 @@ export async function POST(request: Request) {
 
     return Response.json({ success: true });
   } catch (error) {
-    console.error("Subscribe error:", error);
+    console.error("Subscribe error:", error instanceof Error ? error.message : String(error));
     return Response.json({ error: "Failed to subscribe. Please try again." }, { status: 500 });
   }
 }

--- a/src/app/api/user/profile/route.ts
+++ b/src/app/api/user/profile/route.ts
@@ -63,6 +63,7 @@ export async function POST(req: Request) {
   try {
     const res = await globalThis.fetch(accountUrl, {
       headers: { ...authHeader, Accept: "application/json" },
+      signal: AbortSignal.timeout(10_000),
     });
     if (!res.ok) {
       return NextResponse.json(
@@ -104,6 +105,7 @@ export async function POST(req: Request) {
       method: "POST",
       headers: { ...authHeader, "Content-Type": "application/json" },
       body: JSON.stringify(payload),
+      signal: AbortSignal.timeout(10_000),
     });
     if (res.ok) {
       return NextResponse.json({ ok: true });


### PR DESCRIPTION
## Summary

Security hardening found during deep API audit:

- **`/api/user/profile`** — added `AbortSignal.timeout(10_000)` to both Keycloak Account API fetches (GET + POST); missing timeout allowed a hung Keycloak to stall the Lambda indefinitely
- **`/api/admin/users`** — added UUID regex validation on `userId` before interpolating into Keycloak Admin API paths (prevents path-traversal to unintended endpoints); narrowed exception logging to `.message` only (raw `err` could carry Keycloak `error_description` with realm internals)
- **`/api/subscribe`** — narrowed exception logging to `.message` only
- **`/api/admin/esp32/notion-sync`** — read `CRON_SECRET` from `getConfig()` (SSM) with `process.env` fallback; bare `process.env.CRON_SECRET` is always empty on Lambda where secrets live in SSM, silently breaking the cron bypass path

## Test plan

- [ ] `GET /api/user/profile` — returns profile when Keycloak is up; times out cleanly if Keycloak is unreachable
- [ ] `POST /api/user/profile` — updates profile; times out cleanly
- [ ] `POST /api/admin/users` with a non-UUID `username` — returns 400 Invalid user id
- [ ] `POST /api/admin/users` with valid UUID — promote/demote/disable/enable works as before
- [ ] `POST /api/subscribe` — successful subscribe returns `{ success: true }`; errors log only message string in CloudWatch
- [ ] `POST /api/admin/esp32/notion-sync` with `X-Cron-Secret` header — cron bypass works on Lambda (secret now comes from SSM)

https://claude.ai/code/session_01PHsA9s3tK2thgSJVwEGuWq

---
_Generated by [Claude Code](https://claude.ai/code/session_01PHsA9s3tK2thgSJVwEGuWq)_