### PR TITLE
feat(ci): OIDC provisioner for SES SMTP creds (unblocks Keycloak email verification)

### DIFF
--- a/.github/workflows/provision-ses-smtp.yml
+++ b/.github/workflows/provision-ses-smtp.yml
@@ -1,0 +1,64 @@
+name: Provision SES SMTP credentials
+
+# One-shot provisioner for the SES SMTP credential Keycloak needs to send
+# registration verification emails. Uses the OIDC deploy role (no static keys,
+# no PAT). Idempotent: skips if the SSM params already exist.
+#
+# After it succeeds, trigger keycloak-configure-email.yml to apply the creds to
+# the realm (or it runs automatically on its own next push).
+#
+# Requires AWS_DEPLOY_ROLE_ARN to allow: iam:GetUser, iam:CreateUser,
+# iam:PutUserPolicy, iam:ListAccessKeys, iam:CreateAccessKey,
+# iam:DeleteAccessKey, ssm:GetParameter, ssm:PutParameter. If it lacks
+# iam:CreateUser the run fails cleanly with the exact missing permission.
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [main]
+    paths:
+      - ".github/workflows/provision-ses-smtp.yml"
+      - "scripts/provision-ses-smtp.sh"
+
+permissions:
+  id-token: write
+  contents: read
+  issues: write
+
+concurrency:
+  group: provision-ses-smtp
+  cancel-in-progress: false
+
+jobs:
+  provision:
+    runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ github.token }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v4.3.1
+
+      - name: Configure AWS credentials (OIDC)
+        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4
+        with:
+          role-to-assume: ${{ secrets.AWS_DEPLOY_ROLE_ARN }}
+          aws-region: us-east-1
+
+      - name: Provision SES SMTP creds into SSM
+        id: provision
+        env:
+          AWS_REGION: us-east-1
+        run: bash scripts/provision-ses-smtp.sh 2>&1 | tee provision.log
+
+      - name: Post result to tracking issue
+        if: always()
+        run: |
+          {
+            echo "# SES SMTP provisioning — $(date -u '+%F %T')Z"
+            echo ""
+            echo "**Status:** ${{ job.status }}"
+            echo ""
+            echo '```'
+            cat provision.log 2>/dev/null || echo '(no log)'
+            echo '```'
+          } > c.md
+          gh issue comment 382 --repo "${{ github.repository }}" --body-file c.md

--- a/scripts/provision-ses-smtp.sh
+++ b/scripts/provision-ses-smtp.sh
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+#
+# Provision SES SMTP credentials for Keycloak email verification and store them
+# in SSM, so keycloak-configure-email.yml can apply them to the realm.
+#
+# Runs in CI under the OIDC deploy role (AWS_DEPLOY_ROLE_ARN) — no static keys,
+# no PAT. It:
+#   1. Ensures a dedicated IAM user (cloudless-ses-smtp) with a minimal
+#      ses:SendRawEmail / ses:SendEmail inline policy.
+#   2. Creates an access key and derives the region-specific SES SMTP password
+#      from the secret (AWS's documented SigV4-based algorithm).
+#   3. Writes /cloudless/production/SES_SMTP_USER (String),
+#      /cloudless/production/SES_SMTP_PASSWORD (SecureString), and
+#      /cloudless/production/SES_FROM_EMAIL (String, only if absent).
+#
+# Idempotent: if SES_SMTP_USER + SES_SMTP_PASSWORD already exist in SSM, it
+# exits early without minting a new key. Fails cleanly (non-zero) with a precise
+# message if the deploy role lacks the required IAM permissions.
+set -uo pipefail
+
+REGION="${AWS_REGION:-us-east-1}"
+IAM_USER="${SES_SMTP_IAM_USER:-cloudless-ses-smtp}"
+FROM_DEFAULT="${SES_FROM_DEFAULT:-noreply@cloudless.gr}"
+P_USER="/cloudless/production/SES_SMTP_USER"
+P_PASS="/cloudless/production/SES_SMTP_PASSWORD"
+P_FROM="/cloudless/production/SES_FROM_EMAIL"
+
+ssm_get() { aws ssm get-parameter --name "$1" ${2:+--with-decryption} --query 'Parameter.Value' --output text 2>/dev/null || true; }
+
+# 1) Idempotency — skip if creds already provisioned.
+EXISTING_USER="$(ssm_get "$P_USER")"
+EXISTING_PASS="$(ssm_get "$P_PASS" decrypt)"
+if [ -n "$EXISTING_USER" ] && [ -n "$EXISTING_PASS" ]; then
+  echo "✓ SES SMTP credentials already present in SSM (user=${EXISTING_USER}). Nothing to do."
+  exit 0
+fi
+
+echo "→ SES SMTP creds not in SSM; provisioning via IAM user '${IAM_USER}' (region ${REGION})"
+
+# 2) Ensure IAM user (idempotent).
+if aws iam get-user --user-name "$IAM_USER" >/dev/null 2>&1; then
+  echo "  • IAM user ${IAM_USER} already exists"
+else
+  if ! aws iam create-user --user-name "$IAM_USER" \
+        --tags Key=managed-by,Value=provision-ses-smtp.yml Key=purpose,Value=keycloak-smtp >/dev/null 2>err.txt; then
+    echo "::error::Could not create IAM user ${IAM_USER}."
+    echo "The OIDC deploy role (AWS_DEPLOY_ROLE_ARN) lacks iam:CreateUser. Either grant"
+    echo "iam:CreateUser/CreateAccessKey/PutUserPolicy + ssm:PutParameter to that role,"
+    echo "or create the SES SMTP credential manually in AWS Console → SES → SMTP Settings."
+    sed 's/^/  aws: /' err.txt >&2 || true
+    exit 1
+  fi
+  echo "  • created IAM user ${IAM_USER}"
+fi
+
+# 3) Minimal send-only policy.
+aws iam put-user-policy --user-name "$IAM_USER" --policy-name ses-send \
+  --policy-document '{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Action":["ses:SendRawEmail","ses:SendEmail"],"Resource":"*"}]}' \
+  >/dev/null 2>err.txt || { echo "::error::iam:PutUserPolicy failed"; sed 's/^/  aws: /' err.txt >&2; exit 1; }
+
+# 4) Create an access key. (Cap at 2 keys/user; prune oldest if needed.)
+KEYS_JSON="$(aws iam list-access-keys --user-name "$IAM_USER" --query 'AccessKeyMetadata[].AccessKeyId' --output text 2>/dev/null || true)"
+if [ "$(printf '%s\n' "$KEYS_JSON" | wc -w)" -ge 2 ]; then
+  OLDEST="$(aws iam list-access-keys --user-name "$IAM_USER" --query 'sort_by(AccessKeyMetadata,&CreateDate)[0].AccessKeyId' --output text)"
+  echo "  • pruning oldest access key ${OLDEST} (2-key limit)"
+  aws iam delete-access-key --user-name "$IAM_USER" --access-key-id "$OLDEST" >/dev/null 2>&1 || true
+fi
+
+CREATE_JSON="$(aws iam create-access-key --user-name "$IAM_USER" --output json 2>err.txt)" || {
+  echo "::error::iam:CreateAccessKey failed"; sed 's/^/  aws: /' err.txt >&2; exit 1; }
+AK_ID="$(printf '%s' "$CREATE_JSON" | python3 -c 'import sys,json;print(json.load(sys.stdin)["AccessKey"]["AccessKeyId"])')"
+AK_SECRET="$(printf '%s' "$CREATE_JSON" | python3 -c 'import sys,json;print(json.load(sys.stdin)["AccessKey"]["SecretAccessKey"])')"
+echo "::add-mask::$AK_SECRET"
+echo "  • created access key ${AK_ID}"
+
+# 5) Derive the SES SMTP password (AWS documented algorithm, region-specific).
+SMTP_PASSWORD="$(python3 - "$AK_SECRET" "$REGION" <<'PY'
+import sys, hmac, hashlib, base64
+secret, region = sys.argv[1], sys.argv[2]
+def sign(key, msg): return hmac.new(key, msg.encode("utf-8"), hashlib.sha256).digest()
+sig = sign(("AWS4" + secret).encode("utf-8"), "11111111")
+sig = sign(sig, region)
+sig = sign(sig, "ses")
+sig = sign(sig, "aws4_request")
+sig = sign(sig, "SendRawEmail")
+print(base64.b64encode(bytes([0x04]) + sig).decode("utf-8"))
+PY
+)"
+echo "::add-mask::$SMTP_PASSWORD"
+
+# 6) Write SSM params.
+aws ssm put-parameter --name "$P_USER" --type String --overwrite --value "$AK_ID" \
+  --description "SES SMTP username (IAM access key id) for Keycloak — provision-ses-smtp.yml" >/dev/null
+aws ssm put-parameter --name "$P_PASS" --type SecureString --overwrite --value "$SMTP_PASSWORD" \
+  --description "SES SMTP password (derived) for Keycloak — provision-ses-smtp.yml" >/dev/null
+if [ -z "$(ssm_get "$P_FROM")" ]; then
+  aws ssm put-parameter --name "$P_FROM" --type String --overwrite --value "$FROM_DEFAULT" \
+    --description "SES verified From address for Keycloak verification emails" >/dev/null
+  echo "  • set ${P_FROM}=${FROM_DEFAULT}"
+fi
+
+echo "✓ SES SMTP credentials provisioned to SSM (user=${AK_ID}). configure-email can now apply them."


### PR DESCRIPTION
## Closes the SES-SMTP blocker autonomously (no Console, no PAT, no static keys)

You asked me to address the SES-SMTP issue. The blocker was: the SES SMTP credential must exist, and creating it needed AWS access I don't have. This provisions it **via the existing OIDC deploy role** instead.

`scripts/provision-ses-smtp.sh` + `provision-ses-smtp.yml`:
1. ensure a minimal send-only IAM user (`cloudless-ses-smtp`, `ses:SendRawEmail`/`SendEmail`),
2. create an access key + derive the region-specific SES SMTP password (AWS's documented SigV4 algorithm — self-tested),
3. write `SES_SMTP_USER` / `SES_SMTP_PASSWORD` (SecureString) / `SES_FROM_EMAIL` to SSM.

Then `keycloak-configure-email.yml` applies them and verification emails start sending.

**Safety properties:**
- Uses OIDC (`AWS_DEPLOY_ROLE_ARN`) — consistent with every other workflow.
- **Grants no new privileges** — only exercises what the deploy role already has. If it lacks `iam:CreateUser`, the run **fails cleanly with the exact missing permission** (no partial state); granting IAM rights remains your decision.
- Idempotent — skips if creds already in SSM.
- Reuses the app's verified sender (`SES_FROM_EMAIL`, default `noreply@cloudless.gr`).

Merging triggers the run (path filter); I'll report whether it provisioned or surfaced the precise IAM gap.

https://claude.ai/code/session_016PrzZJMNxsgiEmvedfkru6

---
_Generated by [Claude Code](https://claude.ai/code/session_016PrzZJMNxsgiEmvedfkru6)_