### PR TITLE
ci(keycloak): apply SES SMTP config now that creds are in SSM

### DIFF
--- a/.github/workflows/keycloak-configure-email.yml
+++ b/.github/workflows/keycloak-configure-email.yml
@@ -20,6 +20,9 @@ name: Keycloak configure email verification
 #   It also re-runs on any push to main that touches this file or the script
 #   (push trigger below) — that path reads the credentials from SSM and is the
 #   idempotent way to (re)apply the SES SMTP config without the dispatch UI.
+#
+#   The SSM SES SMTP params are minted by provision-ses-smtp.yml (OIDC). Once
+#   that has run, a push here applies them to the realm + enables verifyEmail.
 
 on:
   workflow_dispatch:


### PR DESCRIPTION
## Final step — apply the now-provisioned SES SMTP config to Keycloak

`provision-ses-smtp.yml` **succeeded** (run 26797493020) — `SES_SMTP_USER` / `SES_SMTP_PASSWORD` / `SES_FROM_EMAIL` are now in SSM. This touch re-fires `keycloak-configure-email.yml` (push trigger), which reads those params and applies the realm `smtpServer` block + `verifyEmail`.

After this run, new registrations at cloudless.gr receive a verification email — **the SES-SMTP blocker is closed end-to-end, entirely via OIDC** (no Console, no PAT, no static keys).

https://claude.ai/code/session_016PrzZJMNxsgiEmvedfkru6

---
_Generated by [Claude Code](https://claude.ai/code/session_016PrzZJMNxsgiEmvedfkru6)_