### PR TITLE
fix: rename duplicate cfg variable in esp32/notion-sync route

### DIFF
--- a/src/app/api/admin/esp32/notion-sync/route.ts
+++ b/src/app/api/admin/esp32/notion-sync/route.ts
@@ -54,8 +54,8 @@ export async function GET(request: NextRequest) {
 export async function POST(request: NextRequest) {
   // Allow either an authenticated admin OR a server-to-server cron call with
   // the shared secret. Cron path is used by cron-invoker.ts in Lambda.
-  const cfg = await getConfig().catch(() => null);
-  const cronSecret = cfg?.CRON_SECRET ?? process.env.CRON_SECRET;
+  const ssmCfg = await getConfig().catch(() => null);
+  const cronSecret = ssmCfg?.CRON_SECRET ?? process.env.CRON_SECRET;
   const headerSecret = request.headers.get("x-cron-secret");
   const isCron =
     cronSecret &&


### PR DESCRIPTION
## Summary

- Renames the SSM config variable from `cfg` to `ssmCfg` in the `POST` handler of `esp32/notion-sync/route.ts`
- Fixes TS2451 "Cannot redeclare block-scoped variable 'cfg'" caught by `pnpm typecheck`
- The duplicate was introduced by the previous security hardening commit that added SSM-backed `CRON_SECRET` lookup alongside the existing `getEsp32NotionConfig()` call (both used `cfg`)

## Test plan
- [x] `pnpm typecheck` — clean
- [x] `pnpm lint` — clean
- [x] `pnpm test --run` — 6 failed / 168 passed (same pre-existing failures as on main, no regressions)

https://claude.ai/code/session_01PHsA9s3tK2thgSJVwEGuWq

---
_Generated by [Claude Code](https://claude.ai/code/session_01PHsA9s3tK2thgSJVwEGuWq)_