### PR TITLE
fix(ci): pipefail in provision-ses-smtp (it falsely reported success)

### DIFF
--- a/.github/workflows/provision-ses-smtp.yml
+++ b/.github/workflows/provision-ses-smtp.yml
@@ -47,7 +47,11 @@ jobs:
         id: provision
         env:
           AWS_REGION: us-east-1
-        run: bash scripts/provision-ses-smtp.sh 2>&1 | tee provision.log
+        run: |
+          # pipefail is required: without it, `script | tee` returns tee's exit
+          # code (0) and masks the script's failure, falsely marking the job green.
+          set -o pipefail
+          bash scripts/provision-ses-smtp.sh 2>&1 | tee provision.log
 
       - name: Post result to tracking issue
         if: always()


### PR DESCRIPTION
## Honesty fix + correct diagnosis of the SES-SMTP blocker

While verifying the SES chain end-to-end, I caught that the provisioner **falsely reported success**. Root cause: the provision step ran `bash script | tee provision.log` under `bash -e` **without `pipefail`**, so `tee`'s exit (0) masked the script's `exit 1`. The run was denied `iam:CreateUser`, the script exited 1, but the step + `job.status` reported **success** and posted "Status: success" to #382. No SSM params were ever written.

This adds `set -o pipefail` so the real failure surfaces.

## The actual, now-confirmed blocker
The OIDC deploy role can authenticate, but is **not authorized for `iam:CreateUser`**:
```
AccessDenied: assumed-role/GitHubActionsOIDC is not authorized to perform:
iam:CreateUser on resource: .../user/cloudless-ses-smtp
```
So the fully-automated path is blocked on an **IAM privilege grant** (`iam:CreateUser`/`CreateAccessKey`/`PutUserPolicy`) — a deliberate security decision, not something to grant reflexively to CI.

https://claude.ai/code/session_016PrzZJMNxsgiEmvedfkru6

---
_Generated by [Claude Code](https://claude.ai/code/session_016PrzZJMNxsgiEmvedfkru6)_