### PR TITLE
fix: resolve all pre-existing test failures (174/174 pass)

### DIFF
--- a/__tests__/admin-api.test.ts
+++ b/__tests__/admin-api.test.ts
@@ -490,19 +490,19 @@ describe("POST /api/admin/users", () => {
   });
 
   it("returns 400 when action is missing", async () => {
-    const res = await postAction({ username: "user-1" });
+    const res = await postAction({ username: "00000000-0000-0000-0000-000000000001" });
     expect(res.status).toBe(400);
   });
 
   it("disable action succeeds", async () => {
-    const res = await postAction({ action: "disable", username: "user-1" });
+    const res = await postAction({ action: "disable", username: "00000000-0000-0000-0000-000000000001" });
     expect(res.status).toBe(200);
     const data = await res.json();
     expect(data.success).toBe(true);
   });
 
   it("enable action succeeds", async () => {
-    const res = await postAction({ action: "enable", username: "user-1" });
+    const res = await postAction({ action: "enable", username: "00000000-0000-0000-0000-000000000001" });
     expect(res.status).toBe(200);
     const data = await res.json();
     expect(data.success).toBe(true);
@@ -511,7 +511,7 @@ describe("POST /api/admin/users", () => {
   it("promote action succeeds", async () => {
     const res = await postAction({
       action: "promote",
-      username: "user-1",
+      username: "00000000-0000-0000-0000-000000000001",
       groupName: "admin",
     });
     expect(res.status).toBe(200);
@@ -520,7 +520,7 @@ describe("POST /api/admin/users", () => {
   });
 
   it("returns 400 for unknown action", async () => {
-    const res = await postAction({ action: "nuke", username: "user-1" });
+    const res = await postAction({ action: "nuke", username: "00000000-0000-0000-0000-000000000001" });
     expect(res.status).toBe(400);
   });
 });

--- a/__tests__/admin-users-orders-ops-api.test.ts
+++ b/__tests__/admin-users-orders-ops-api.test.ts
@@ -212,7 +212,7 @@ describe("POST /api/admin/users", () => {
     const { POST } = await import("@/app/api/admin/users/route");
     const res = await POST(adminReq("http://localhost/api/admin/users", {
       method: "POST",
-      body: { action: "disable", username: "uuid-test-user" },
+      body: { action: "disable", username: "00000000-0000-0000-0000-000000000001" },
     }));
     const data = await res.json();
     expect(res.status).toBe(200);
@@ -223,7 +223,7 @@ describe("POST /api/admin/users", () => {
     const { POST } = await import("@/app/api/admin/users/route");
     const res = await POST(adminReq("http://localhost/api/admin/users", {
       method: "POST",
-      body: { action: "promote", username: "uuid-test-user" },
+      body: { action: "promote", username: "00000000-0000-0000-0000-000000000001" },
     }));
     const data = await res.json();
     expect(res.status).toBe(200);
@@ -234,7 +234,7 @@ describe("POST /api/admin/users", () => {
     const { POST } = await import("@/app/api/admin/users/route");
     const res = await POST(adminReq("http://localhost/api/admin/users", {
       method: "POST",
-      body: { action: "nuke", username: "uuid-test-user" },
+      body: { action: "nuke", username: "00000000-0000-0000-0000-000000000001" },
     }));
     const data = await res.json();
     expect(res.status).toBe(400);

--- a/__tests__/dashboard-settings-live-preview.test.tsx
+++ b/__tests__/dashboard-settings-live-preview.test.tsx
@@ -2,7 +2,14 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import { useAuth } from "@/context/AuthContext";
 
-// next/link is fine in jsdom; only the locale + auth hooks need mocking.
+// Mock @/i18n/navigation so the Link component doesn't need an IntlProvider.
+vi.mock("@/i18n/navigation", () => ({
+  Link: ({ children, href, ...props }: { children: React.ReactNode; href: string; [key: string]: unknown }) => (
+    <a href={String(href)} {...props}>{children}</a>
+  ),
+  useRouter: () => ({ push: () => {}, replace: () => {}, back: () => {} }),
+  usePathname: () => "/",
+}));
 vi.mock("@/context/AuthContext", () => ({ useAuth: vi.fn() }));
 vi.mock("@/lib/use-locale", () => ({
   useCurrentLocale: () => ["en", () => {}],

--- a/__tests__/store-components.test.tsx
+++ b/__tests__/store-components.test.tsx
@@ -14,9 +14,10 @@ beforeEach(() => {
   localStorage.clear();
 });
 
-// Mock next/link to render a plain anchor
-vi.mock("next/link", () => ({
-  default: ({
+// Mock @/i18n/navigation (locale-aware Link) to render a plain anchor.
+// StoreGrid uses Link from @/i18n/navigation since the migration from next/link.
+vi.mock("@/i18n/navigation", () => ({
+  Link: ({
     children,
     href,
     ...props
@@ -25,10 +26,12 @@ vi.mock("next/link", () => ({
     href: string;
     [key: string]: unknown;
   }) => (
-    <a href={href} {...props}>
+    <a href={String(href)} {...props}>
       {children}
     </a>
   ),
+  useRouter: () => ({ push: () => {}, replace: () => {}, back: () => {} }),
+  usePathname: () => "/",
 }));
 
 const mockProduct: StoreProduct = {

--- a/__tests__/stubs/next-navigation-stub.js
+++ b/__tests__/stubs/next-navigation-stub.js
@@ -1,0 +1,34 @@
+/**
+ * ESM stub for next/navigation — Vitest alias target.
+ *
+ * next-intl imports `next/navigation` as a bare ESM specifier.
+ * Vitest cannot resolve the CJS file in ESM context. This stub provides
+ * no-op implementations sufficient for component rendering tests.
+ */
+
+export const useRouter = () => ({
+  push: () => {},
+  replace: () => {},
+  back: () => {},
+  forward: () => {},
+  refresh: () => {},
+  prefetch: () => {},
+});
+
+export const usePathname = () => "/";
+
+export const useParams = () => ({});
+
+export const useSearchParams = () => new URLSearchParams();
+
+export const redirect = (url) => {
+  throw new Error(`redirect: ${url}`);
+};
+
+export const permanentRedirect = (url) => {
+  throw new Error(`permanentRedirect: ${url}`);
+};
+
+export const notFound = () => {
+  throw new Error("notFound");
+};

--- a/src/app/api/admin/esp32/notion-sync/route.ts
+++ b/src/app/api/admin/esp32/notion-sync/route.ts
@@ -54,8 +54,8 @@ export async function GET(request: NextRequest) {
 export async function POST(request: NextRequest) {
   // Allow either an authenticated admin OR a server-to-server cron call with
   // the shared secret. Cron path is used by cron-invoker.ts in Lambda.
-  const cfg = await getConfig().catch(() => null);
-  const cronSecret = cfg?.CRON_SECRET ?? process.env.CRON_SECRET;
+  const ssmCfg = await getConfig().catch(() => null);
+  const cronSecret = ssmCfg?.CRON_SECRET ?? process.env.CRON_SECRET;
   const headerSecret = request.headers.get("x-cron-secret");
   const isCron =
     cronSecret &&

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -26,6 +26,13 @@ export default defineConfig({
         __dirname,
         "__tests__/stubs/next-server-stub.js",
       ),
+      // next-intl's react-client navigation helpers import `next/navigation`
+      // as a bare ESM specifier which Vitest can't resolve from the CJS dist.
+      // This stub provides no-op hook implementations for component tests.
+      "next/navigation": path.resolve(
+        __dirname,
+        "__tests__/stubs/next-navigation-stub.js",
+      ),
       // @aws-sdk/client-cognito-identity-provider is not installed; tests that
       // need it supply their own vi.mock() — the stub prevents Vite's import
       // analysis from failing when the route file is dynamically imported.
@@ -68,7 +75,7 @@ export default defineConfig({
       deps: {
         // next-auth imports next/server as bare ESM specifier. Inlining lets
         // Vitest pre-transform the import through its alias map.
-        inline: ["next-auth", "@auth/core"],
+        inline: ["next-auth", "@auth/core", "next-intl"],
       },
     },
     maxWorkers: 2,


### PR DESCRIPTION
## Summary

- Add `next/navigation` Vitest stub + alias so `next-intl`'s ESM navigation helpers can resolve their dependency in jsdom
- Add `next-intl` to `server.deps.inline` so its imports go through Vitest's alias map
- Mock `@/i18n/navigation` in `store-components` and `dashboard-settings` tests to avoid `IntlProvider` requirement
- Update admin API tests to use valid UUID values (`00000000-0000-0000-0000-000000000001`) so they pass the UUID path-traversal guard added in the security hardening PR

## Before / After

| File | Before | After |
|---|---|---|
| `store-components.test.tsx` | FAIL — `Cannot find module 'next/navigation'` | ✅ 34/34 |
| `dashboard-settings-live-preview.test.tsx` | FAIL — `Cannot find module 'next/navigation'` | ✅ 3/3 |
| `admin-api.test.ts` | FAIL — 400 (UUID rejection) instead of 200 | ✅ 51/51 |
| `admin-users-orders-ops-api.test.ts` | FAIL — 400 (UUID rejection) instead of 200 | ✅ 16/16 |
| **Total suite** | 6 files failed, 11 tests failed | **174/174 files, 2082/2082 tests** |

## Test plan
- [x] `pnpm test --run` — 174 passed / 0 failed

https://claude.ai/code/session_01PHsA9s3tK2thgSJVwEGuWq

---
_Generated by [Claude Code](https://claude.ai/code/session_01PHsA9s3tK2thgSJVwEGuWq)_