### PR TITLE
feat(ses): pnpm ses:provision — AWS SDK provisioner for Keycloak SMTP creds

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "devcontainer:stop": "bash scripts/devcontainer-stop.sh",
     "notion:test": "tsx --tsconfig scripts/tsconfig.json scripts/notion-test.ts",
     "gh:secrets": "tsx --tsconfig scripts/tsconfig.json scripts/gh-secrets.ts",
+    "ses:provision": "tsx --tsconfig scripts/tsconfig.json scripts/provision-ses-smtp.ts",
     "gsc:sync": "tsx --tsconfig scripts/tsconfig.json scripts/weekly-gsc-sync.ts",
     "newsletter:draft": "tsx --tsconfig scripts/tsconfig.json scripts/generate-weekly-article.ts",
     "newsletter:send": "tsx --tsconfig scripts/tsconfig.json scripts/publish-and-send-newsletter.ts",
@@ -107,6 +108,7 @@
     "stripe": "^22.2.0"
   },
   "devDependencies": {
+    "@aws-sdk/client-iam": "3.1053.0",
     "@axe-core/playwright": "^4.11.3",
     "@parcel/watcher": "^2.5.6",
     "@playwright/test": "^1.60.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -77,6 +77,9 @@ importers:
         specifier: ^22.2.0
         version: 22.2.0(@types/node@25.9.1)
     devDependencies:
+      '@aws-sdk/client-iam':
+        specifier: 3.1053.0
+        version: 3.1053.0
       '@axe-core/playwright':
         specifier: ^4.11.3
         version: 4.11.3(playwright-core@1.60.0)
@@ -227,6 +230,10 @@ packages:
 
   '@aws-sdk/client-dynamodb@3.1057.0':
     resolution: {integrity: sha512-S0feh4mSWsqxQ8SGWIqAX5CQ9w+wBFxpNx4QVNy4rfQVMY6PvPuWT6kolfIHqMoIvuVGd9zD71BvzCK3CHip8Q==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/client-iam@3.1053.0':
+    resolution: {integrity: sha512-K8twwQta96O4Y4OUuk97n+SnA5OiPm759uR2Ffbm3a2/vQGMg2BcAQwFV+wwG9hj64+tus02AGH9dyuzRKJnKA==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/client-lambda@3.1057.0':
@@ -5053,6 +5060,19 @@ snapshots:
       '@aws-sdk/credential-provider-node': 3.972.47
       '@aws-sdk/dynamodb-codec': 3.973.15
       '@aws-sdk/middleware-endpoint-discovery': 3.972.15
+      '@aws-sdk/types': 3.973.9
+      '@smithy/core': 3.24.5
+      '@smithy/fetch-http-handler': 5.4.5
+      '@smithy/node-http-handler': 4.7.5
+      '@smithy/types': 4.14.2
+      tslib: 2.8.1
+
+  '@aws-sdk/client-iam@3.1053.0':
+    dependencies:
+      '@aws-crypto/sha256-browser': 5.2.0
+      '@aws-crypto/sha256-js': 5.2.0
+      '@aws-sdk/core': 3.974.15
+      '@aws-sdk/credential-provider-node': 3.972.47
       '@aws-sdk/types': 3.973.9
       '@smithy/core': 3.24.5
       '@smithy/fetch-http-handler': 5.4.5

--- a/scripts/provision-ses-smtp.ts
+++ b/scripts/provision-ses-smtp.ts
@@ -1,0 +1,181 @@
+/**
+ * Provision SES SMTP credentials for Keycloak email verification — AWS SDK v3
+ * version of scripts/provision-ses-smtp.sh (no AWS CLI needed, just node creds).
+ *
+ *   pnpm ses:provision        # uses your ambient AWS creds (env / SSO / profile)
+ *
+ * Does exactly the "SES → SMTP Settings → Create SMTP credentials" Console flow:
+ *   1. ensures a minimal send-only IAM user (cloudless-ses-smtp),
+ *   2. creates an access key + derives the region-specific SES SMTP password
+ *      (AWS's documented SigV4 algorithm),
+ *   3. writes SES_SMTP_USER / SES_SMTP_PASSWORD (SecureString) / SES_FROM_EMAIL
+ *      to /cloudless/production/* in SSM.
+ *
+ * Idempotent: exits early if the SMTP params already exist in SSM. Fails with a
+ * clear message (exit 1) if the caller's IAM identity lacks iam:CreateUser.
+ *
+ * Requires the running identity to allow: iam:GetUser, iam:CreateUser,
+ * iam:PutUserPolicy, iam:ListAccessKeys, iam:CreateAccessKey,
+ * iam:DeleteAccessKey, ssm:GetParameter, ssm:PutParameter (+ kms:Decrypt for
+ * the SecureString read-back).
+ */
+import { createHmac } from "node:crypto";
+import {
+  IAMClient,
+  GetUserCommand,
+  CreateUserCommand,
+  PutUserPolicyCommand,
+  ListAccessKeysCommand,
+  CreateAccessKeyCommand,
+  DeleteAccessKeyCommand,
+} from "@aws-sdk/client-iam";
+import { SSMClient, GetParameterCommand, PutParameterCommand } from "@aws-sdk/client-ssm";
+
+const REGION = process.env.AWS_REGION ?? process.env.AWS_DEFAULT_REGION ?? "us-east-1";
+const IAM_USER = process.env.SES_SMTP_IAM_USER ?? "cloudless-ses-smtp";
+const FROM_DEFAULT = process.env.SES_FROM_DEFAULT ?? "noreply@cloudless.gr";
+const P_USER = "/cloudless/production/SES_SMTP_USER";
+const P_PASS = "/cloudless/production/SES_SMTP_PASSWORD";
+const P_FROM = "/cloudless/production/SES_FROM_EMAIL";
+
+const iam = new IAMClient({ region: REGION });
+const ssm = new SSMClient({ region: REGION });
+
+/** AWS's documented derivation of the SES SMTP password from an IAM secret key. */
+function deriveSmtpPassword(secretKey: string, region: string): string {
+  const sign = (key: Buffer | string, msg: string) =>
+    createHmac("sha256", key).update(msg, "utf8").digest();
+  let sig: Buffer = sign(`AWS4${secretKey}`, "11111111");
+  for (const part of [region, "ses", "aws4_request", "SendRawEmail"]) sig = sign(sig, part);
+  return Buffer.concat([Buffer.from([0x04]), sig]).toString("base64");
+}
+
+async function ssmGet(name: string, decrypt = false): Promise<string> {
+  try {
+    const r = await ssm.send(new GetParameterCommand({ Name: name, WithDecryption: decrypt }));
+    return r.Parameter?.Value ?? "";
+  } catch {
+    return "";
+  }
+}
+
+function errName(e: unknown): string {
+  return (e as { name?: string })?.name ?? "Error";
+}
+
+async function main(): Promise<void> {
+  // 1) Idempotency.
+  const [existingUser, existingPass] = await Promise.all([ssmGet(P_USER), ssmGet(P_PASS, true)]);
+  if (existingUser && existingPass) {
+    console.log(`✓ SES SMTP credentials already in SSM (user=${existingUser}). Nothing to do.`);
+    return;
+  }
+  console.log(`→ Provisioning SES SMTP creds via IAM user '${IAM_USER}' (region ${REGION})`);
+
+  // 2) Ensure IAM user.
+  try {
+    await iam.send(new GetUserCommand({ UserName: IAM_USER }));
+    console.log(`  • IAM user ${IAM_USER} already exists`);
+  } catch (e) {
+    if (errName(e) !== "NoSuchEntityException") throw e;
+    try {
+      await iam.send(
+        new CreateUserCommand({
+          UserName: IAM_USER,
+          Tags: [
+            { Key: "managed-by", Value: "provision-ses-smtp" },
+            { Key: "purpose", Value: "keycloak-smtp" },
+          ],
+        })
+      );
+      console.log(`  • created IAM user ${IAM_USER}`);
+    } catch (ce) {
+      if (errName(ce) === "AccessDenied" || errName(ce) === "AccessDeniedException") {
+        console.error(
+          `✗ Denied iam:CreateUser. Grant iam:CreateUser/CreateAccessKey/PutUserPolicy +\n` +
+            `  ssm:PutParameter to the running identity, or create the SES SMTP credential\n` +
+            `  in AWS Console → SES → SMTP Settings.`
+        );
+        process.exit(1);
+      }
+      throw ce;
+    }
+  }
+
+  // 3) Minimal send-only policy.
+  await iam.send(
+    new PutUserPolicyCommand({
+      UserName: IAM_USER,
+      PolicyName: "ses-send",
+      PolicyDocument: JSON.stringify({
+        Version: "2012-10-17",
+        Statement: [{ Effect: "Allow", Action: ["ses:SendRawEmail", "ses:SendEmail"], Resource: "*" }],
+      }),
+    })
+  );
+
+  // 4) Create an access key (prune oldest if at the 2-key limit).
+  const keys = await iam.send(new ListAccessKeysCommand({ UserName: IAM_USER }));
+  const meta = keys.AccessKeyMetadata ?? [];
+  if (meta.length >= 2) {
+    const oldest = [...meta].sort(
+      (a, b) => (a.CreateDate?.getTime() ?? 0) - (b.CreateDate?.getTime() ?? 0)
+    )[0];
+    if (oldest?.AccessKeyId) {
+      console.log(`  • pruning oldest access key ${oldest.AccessKeyId} (2-key limit)`);
+      await iam.send(
+        new DeleteAccessKeyCommand({ UserName: IAM_USER, AccessKeyId: oldest.AccessKeyId })
+      );
+    }
+  }
+  const created = await iam.send(new CreateAccessKeyCommand({ UserName: IAM_USER }));
+  const akId = created.AccessKey?.AccessKeyId;
+  const akSecret = created.AccessKey?.SecretAccessKey;
+  if (!akId || !akSecret) throw new Error("CreateAccessKey returned no credentials");
+  console.log(`  • created access key ${akId}`);
+
+  // 5) Derive the SMTP password.
+  const smtpPassword = deriveSmtpPassword(akSecret, REGION);
+
+  // 6) Write SSM params.
+  await ssm.send(
+    new PutParameterCommand({
+      Name: P_USER,
+      Type: "String",
+      Overwrite: true,
+      Value: akId,
+      Description: "SES SMTP username (IAM access key id) for Keycloak — provision-ses-smtp",
+    })
+  );
+  await ssm.send(
+    new PutParameterCommand({
+      Name: P_PASS,
+      Type: "SecureString",
+      Overwrite: true,
+      Value: smtpPassword,
+      Description: "SES SMTP password (derived) for Keycloak — provision-ses-smtp",
+    })
+  );
+  if (!(await ssmGet(P_FROM))) {
+    await ssm.send(
+      new PutParameterCommand({
+        Name: P_FROM,
+        Type: "String",
+        Overwrite: true,
+        Value: FROM_DEFAULT,
+        Description: "SES verified From address for Keycloak verification emails",
+      })
+    );
+    console.log(`  • set ${P_FROM}=${FROM_DEFAULT}`);
+  }
+
+  console.log(
+    `✓ SES SMTP credentials provisioned to SSM (user=${akId}).\n` +
+      `  Next: trigger keycloak-configure-email.yml to apply them to the realm.`
+  );
+}
+
+main().catch((e) => {
+  console.error(`✗ provision-ses-smtp failed: ${errName(e)}: ${(e as Error)?.message ?? e}`);
+  process.exit(1);
+});


### PR DESCRIPTION
## `pnpm ses:provision` — AWS SDK provisioner for the Keycloak SMTP credential

A Node/`@aws-sdk` v3 version of `scripts/provision-ses-smtp.sh`, runnable as one word wherever your AWS credentials live (no AWS CLI needed):

```bash
pnpm ses:provision        # uses ambient AWS creds (env / SSO / profile / CloudShell)
```

It performs the **"SES → SMTP Settings → Create SMTP credentials"** Console flow programmatically:
1. ensures a minimal send-only IAM user (`cloudless-ses-smtp`, `ses:SendRawEmail`/`SendEmail`),
2. creates an access key + derives the region-specific SMTP password (AWS's SigV4 algorithm),
3. writes `SES_SMTP_USER` / `SES_SMTP_PASSWORD` (SecureString) / `SES_FROM_EMAIL` to SSM.

Idempotent (skips if creds already in SSM); exits `1` with a clear message if the identity lacks `iam:CreateUser`.

- Adds `@aws-sdk/client-iam` as a **devDependency** (version-matched to the installed `client-ssm`, `3.1053.0`) — no app-runtime impact.
- `client-ssm` reused (already a dependency).

## Test plan
- [x] `tsc --noEmit` clean on the script
- [x] `pnpm ses:provision` runs and fails cleanly with `CredentialsProviderError` when no AWS creds are present (proves wiring; proceeds past it where creds exist)
- [ ] CI green

Once run (locally / CloudShell / CI-with-perms), `keycloak-configure-email.yml` applies the creds and verification emails send — closing the SES-SMTP item.

https://claude.ai/code/session_016PrzZJMNxsgiEmvedfkru6

---
_Generated by [Claude Code](https://claude.ai/code/session_016PrzZJMNxsgiEmvedfkru6)_