### PR TITLE
fix(cluster-doctor): check cloudless namespace for cloudless deployment

### DIFF
--- a/scripts/cluster-doctor.sh
+++ b/scripts/cluster-doctor.sh
@@ -120,30 +120,29 @@ else
   printf "_could not fetch /api/v1/rules (empty response)_\n"
 fi
 
-section "cloudless app: deployment (k3s standby E2E target)"
-k -n default get deploy cloudless -o wide | fence
-printf "Resource limits + env:\n"
-kubectl -n default get deploy cloudless \
-  -o jsonpath='{range .spec.template.spec.containers[*]}{.name}{"\n  limits="}{.resources.limits}{"\n  requests="}{.resources.requests}{"\n"}{end}' \
+section "cloudless app: deployment (k3s standby E2E target — ns cloudless)"
+k -n cloudless get deploy cloudless -o wide | fence
+printf "Resource limits + image:\n"
+kubectl -n cloudless get deploy cloudless \
+  -o jsonpath='{range .spec.template.spec.containers[*]}{.name}{"\n  image="}{.image}{"\n  limits="}{.resources.limits}{"\n  requests="}{.resources.requests}{"\n"}{end}' \
   2>/dev/null | fence
 
-section "cloudless app: pods"
-k -n default get pods -l app=cloudless -o wide | fence
+section "cloudless app: all pods in ns cloudless"
+k -n cloudless get pods -o wide | fence
 printf "Container states:\n"
-kubectl -n default get pods -l app=cloudless -o jsonpath='{range .items[*]}{.metadata.name}{":\n"}{range .status.containerStatuses[*]}{"  restarts="}{.restartCount}{" ready="}{.ready}{" waiting="}{.state.waiting.reason}{" lastTerminated="}{.lastState.terminated.reason}{"(exit "}{.lastState.terminated.exitCode}{")\n"}{end}{end}' \
+kubectl -n cloudless get pods -o jsonpath='{range .items[*]}{.metadata.name}{":\n"}{range .status.containerStatuses[*]}{"  restarts="}{.restartCount}{" ready="}{.ready}{" waiting="}{.state.waiting.reason}{" lastTerminated="}{.lastState.terminated.reason}{"(exit "}{.lastState.terminated.exitCode}{")\n"}{end}{end}' \
   2>/dev/null | fence
 
-section "cloudless app: recent events"
-kubectl -n default get events --sort-by=.lastTimestamp --field-selector=involvedObject.kind=Pod 2>/dev/null \
-  | grep -i cloudless | tail -20 | fence
+section "cloudless app: recent events (ns cloudless)"
+kubectl -n cloudless get events --sort-by=.lastTimestamp 2>/dev/null | tail -20 | fence
 
 section "cloudless app: logs (last 40 lines)"
-k -n default logs deploy/cloudless --tail=40 | fence
+k -n cloudless logs deploy/cloudless --tail=40 | fence
 
 section "cloudless app: logs (previous container, last 40 lines)"
-pod=$(kubectl -n default get pods -l app=cloudless -o name 2>/dev/null | head -1)
-[ -n "$pod" ] && k -n default logs "$pod" --previous --tail=40 | fence || printf "_no cloudless pod found_\n"
+pod=$(kubectl -n cloudless get pods -l app=cloudless -o name 2>/dev/null | head -1)
+[ -n "$pod" ] && k -n cloudless logs "$pod" --previous --tail=40 | fence || printf "_no cloudless pod found_\n"
 
 printf "\n_End of snapshot._\n"
 
-# diagnose-cloudless-e2e-failure 20260602
+# fix-cloudless-ns-20260602


### PR DESCRIPTION
The `cloudless` app deploys to namespace `cloudless` (per `K3S_NAMESPACE: cloudless` in `deploy-pi.yml`), not `default`. The previous doctor section used `-n default` and got `not found` every time. This also adds the image SHA to the output so we can see which ECR tag is running.

https://claude.ai/code/session_01PHsA9s3tK2thgSJVwEGuWq

---
_Generated by [Claude Code](https://claude.ai/code/session_01PHsA9s3tK2thgSJVwEGuWq)_