### PR TITLE
chore(cluster): comprehensive cleanup — stuck pods, deployment restarts, KC annotation

### DIFF
--- a/.github/workflows/cluster-remediate.yml
+++ b/.github/workflows/cluster-remediate.yml
@@ -1,13 +1,15 @@
-name: Cluster remediate (ntfy restart + Keycloak annotation fix)
+name: Cluster cleanup — stuck pods, CronJob residue, deployment restarts
 
-# Round 2 (2026-06-02): ntfy rolling restart succeeded (new pod 1/1 Running).
-# Remaining work:
-#   1. Delete stuck old ntfy Error pod (9d old, 34 restarts, causes SQLite
-#      "database is locked" because it holds a file handle on the shared PVC)
-#   2. Fix Keycloak last-applied-configuration annotation (shows 1Gi, should
-#      be 768Mi to match the live container and the manifest)
+# Comprehensive cluster hygiene run triggered on push to this file.
+# Idempotent — safe to re-run. Posts results to tracking issue #382.
 #
-# Trigger: push to main touching this file.
+# What this does:
+#   1. ntfy     — force-delete stuck Error/Evicted pods (SQLite-lock holder)
+#   2. maintenance — delete Error CronJob pods (cluster-health-check residue)
+#   3. cloudless ns — rollout restart cloudless-manager + oauth2-proxy
+#                     (resets restart counters accumulated from node reboots)
+#   4. keycloak — re-pin last-applied annotation to match live 768Mi limit
+#                 (prevents a future `kubectl apply` from rolling back to 384Mi)
 
 on:
   push:
@@ -20,7 +22,7 @@ permissions:
   issues: write
 
 jobs:
-  remediate:
+  cleanup:
     runs-on: ubuntu-latest
     env:
       GH_TOKEN: ${{ github.token }}
@@ -38,73 +40,184 @@ jobs:
           echo "${{ secrets.KUBECONFIG_B64 }}" | base64 -d > ~/.kube/config
           chmod 600 ~/.kube/config
 
-      - name: Clean stuck ntfy Error pods
+      - name: 1. ntfy — force-delete stuck Error/Evicted pods
         run: |
           set -uo pipefail
+          {
+            echo "## ntfy — force-delete stuck pods"
+            echo ""
+            echo "### before"
+            kubectl -n ntfy get pods -o wide 2>&1 || true
 
-          echo "=== ntfy — current pods ===" | tee ntfy.log
-          timeout 15s kubectl -n ntfy get pods -o wide 2>&1 | tee -a ntfy.log || true
+            echo ""
+            STUCK=$(kubectl -n ntfy get pods --no-headers 2>/dev/null \
+              | awk '/Error|Evicted|OOMKilled/{print $1}' || true)
+            if [ -n "${STUCK}" ]; then
+              echo "Pods to delete: ${STUCK}"
+              for POD in ${STUCK}; do
+                # Strip finalizers first so kubelet can't block the delete.
+                kubectl -n ntfy patch pod "${POD}" \
+                  -p '{"metadata":{"finalizers":[]}}' \
+                  --type=merge 2>&1 || true
+                kubectl -n ntfy delete pod "${POD}" \
+                  --grace-period=0 --force --ignore-not-found 2>&1 || true
+              done
+            else
+              echo "No stuck pods found — already clean."
+            fi
 
-          echo "" >> ntfy.log
-          echo "=== ntfy — deleting Error/Evicted pods (no-wait, force) ===" | tee -a ntfy.log
-          STUCK=$(timeout 10s kubectl -n ntfy get pods 2>/dev/null | awk '/Error|Evicted/{print $1}' || true)
-          if [ -n "${STUCK}" ]; then
-            echo "Deleting: ${STUCK}" | tee -a ntfy.log
-            echo "${STUCK}" | xargs kubectl -n ntfy delete pod --ignore-not-found --wait=false --grace-period=0 2>&1 | tee -a ntfy.log
-          else
-            echo "No Error/Evicted pods found" | tee -a ntfy.log
-          fi
+            echo ""
+            echo "### after"
+            sleep 5
+            kubectl -n ntfy get pods -o wide 2>&1 || true
 
-          echo "" >> ntfy.log
-          echo "=== ntfy — after cleanup ===" | tee -a ntfy.log
-          timeout 15s kubectl -n ntfy get pods -o wide 2>&1 | tee -a ntfy.log || true
+            echo ""
+            echo "### ntfy deployment logs (tail 10)"
+            kubectl -n ntfy logs deployment/ntfy --tail=10 2>&1 || true
+          } | tee ntfy.log
 
-          echo "" >> ntfy.log
-          echo "=== ntfy — recent logs (database lock check) ===" | tee -a ntfy.log
-          timeout 20s kubectl -n ntfy logs deployment/ntfy --tail=10 2>&1 | tee -a ntfy.log || true
-
-      - name: Fix Keycloak last-applied annotation
+      - name: 2. maintenance — delete Error CronJob pods
         run: |
           set -uo pipefail
+          {
+            echo "## maintenance ns — Error CronJob pods"
+            echo ""
+            echo "### before"
+            kubectl -n maintenance get pods 2>&1 || true
 
-          echo "=== Keycloak annotation — before ===" | tee kc.log
-          kubectl -n keycloak get deployment keycloak \
-            -o jsonpath='{.metadata.annotations.kubectl\.kubernetes\.io/last-applied-configuration}' \
-            2>/dev/null \
-            | python3 -c "import sys,json; d=json.load(sys.stdin); c=d['spec']['template']['spec']['containers'][0]; print('memory limit:', c['resources']['limits']['memory'])" \
-            2>&1 | tee -a kc.log \
-            || echo "(no annotation or parse error)" | tee -a kc.log
+            echo ""
+            STUCK=$(kubectl -n maintenance get pods --no-headers 2>/dev/null \
+              | awk '/Error|Evicted|OOMKilled/{print $1}' || true)
+            if [ -n "${STUCK}" ]; then
+              echo "Deleting: ${STUCK}"
+              echo "${STUCK}" | xargs kubectl -n maintenance delete pod \
+                --ignore-not-found --wait=false 2>&1 || true
+            else
+              echo "No Error pods in maintenance ns."
+            fi
 
-          echo "" >> kc.log
-          echo "=== Keycloak annotation — patching to 768Mi ===" | tee -a kc.log
-          KC_ANN='{"apiVersion":"apps/v1","kind":"Deployment","metadata":{"annotations":{},"name":"keycloak","namespace":"keycloak"},"spec":{"template":{"spec":{"containers":[{"env":[{"name":"JAVA_OPTS_APPEND","value":"-Xms128m -Xmx512m -Djdk.reflect.useDirectMethodHandle=false -Dquarkus.http.limits.max-header-size=64K"}],"name":"keycloak","resources":{"limits":{"cpu":1,"memory":"768Mi"},"requests":{"cpu":"100m","memory":"384Mi"}}}]}}}}'
-          kubectl -n keycloak annotate deployment keycloak \
-            "kubectl.kubernetes.io/last-applied-configuration=${KC_ANN}" \
-            --overwrite \
-            2>&1 | tee -a kc.log
+            echo ""
+            echo "### after"
+            sleep 3
+            kubectl -n maintenance get pods 2>&1 || true
+          } | tee maintenance.log
 
-          echo "" >> kc.log
-          echo "=== Keycloak annotation — after ===" | tee -a kc.log
-          kubectl -n keycloak get deployment keycloak \
-            -o jsonpath='{.metadata.annotations.kubectl\.kubernetes\.io/last-applied-configuration}' \
-            2>/dev/null \
-            | python3 -c "import sys,json; d=json.load(sys.stdin); c=d['spec']['template']['spec']['containers'][0]; print('memory limit:', c['resources']['limits']['memory'])" \
-            2>&1 | tee -a kc.log \
-            || echo "(parse error)" | tee -a kc.log
+      - name: 3. cloudless ns — rollout restart cloudless-manager + oauth2-proxy
+        run: |
+          set -uo pipefail
+          {
+            echo "## cloudless ns — rollout restart"
+            echo ""
+            echo "### before"
+            kubectl -n cloudless get pods -o wide 2>&1 || true
+
+            echo ""
+            for DEPLOY in cloudless-manager oauth2-proxy; do
+              echo "--- kubectl rollout restart deploy/${DEPLOY} -n cloudless ---"
+              kubectl -n cloudless rollout restart deploy/"${DEPLOY}" 2>&1 || true
+            done
+
+            echo ""
+            echo "### waiting for rollouts to finish (90s)..."
+            for DEPLOY in cloudless-manager oauth2-proxy; do
+              kubectl -n cloudless rollout status deploy/"${DEPLOY}" \
+                --timeout=90s 2>&1 || true
+            done
+
+            echo ""
+            echo "### after"
+            kubectl -n cloudless get pods -o wide 2>&1 || true
+            echo ""
+            echo "### container states (restart counters should be 0)"
+            kubectl -n cloudless get pods -o jsonpath=\
+'{range .items[*]}{.metadata.name}{"\n"}{range .status.containerStatuses[*]}{"  restarts="}{.restartCount}{" ready="}{.ready}{"\n"}{end}{end}' \
+              2>&1 || true
+          } | tee cloudless.log
+
+      - name: 4. keycloak — fix last-applied annotation (384Mi → 768Mi)
+        run: |
+          set -uo pipefail
+          {
+            echo "## keycloak annotation"
+            echo ""
+            echo "### live limit (should be 768Mi)"
+            kubectl -n keycloak get deployment keycloak \
+              -o jsonpath='{.spec.template.spec.containers[0].resources.limits.memory}' \
+              2>&1 || true
+
+            echo ""
+            echo "### last-applied limit (before patch)"
+            kubectl -n keycloak get deployment keycloak \
+              -o jsonpath='{.metadata.annotations.kubectl\.kubernetes\.io/last-applied-configuration}' \
+              2>/dev/null \
+              | python3 -c "
+import sys, json
+try:
+  d = json.load(sys.stdin)
+  c = d['spec']['template']['spec']['containers'][0]
+  print('memory limit:', c['resources']['limits']['memory'])
+except Exception as e:
+  print('parse error:', e)
+" 2>&1 || true
+
+            echo ""
+            echo "### patching annotation to 768Mi..."
+            KC_ANN=$(kubectl -n keycloak get deployment keycloak -o json 2>/dev/null \
+              | python3 -c "
+import sys, json
+d = json.load(sys.stdin)
+# Build a minimal last-applied-configuration that reflects the live state.
+c = d['spec']['template']['spec']['containers'][0]
+ann = {
+  'apiVersion': 'apps/v1',
+  'kind': 'Deployment',
+  'metadata': {'name': 'keycloak', 'namespace': 'keycloak', 'annotations': {}},
+  'spec': {'template': {'spec': {'containers': [{
+    'name': c['name'],
+    'image': c['image'],
+    'env': c.get('env', []),
+    'resources': c['resources'],
+  }]}}}
+}
+print(json.dumps(ann))
+" 2>/dev/null || echo '')
+
+            if [ -n "${KC_ANN}" ]; then
+              kubectl -n keycloak annotate deployment keycloak \
+                "kubectl.kubernetes.io/last-applied-configuration=${KC_ANN}" \
+                --overwrite 2>&1 || true
+              echo "Annotation updated."
+            else
+              echo "Could not build annotation payload — skipping."
+            fi
+
+            echo ""
+            echo "### last-applied limit (after patch)"
+            kubectl -n keycloak get deployment keycloak \
+              -o jsonpath='{.metadata.annotations.kubectl\.kubernetes\.io/last-applied-configuration}' \
+              2>/dev/null \
+              | python3 -c "
+import sys, json
+try:
+  d = json.load(sys.stdin)
+  c = d['spec']['template']['spec']['containers'][0]
+  print('memory limit:', c['resources']['limits']['memory'])
+except Exception as e:
+  print('parse error:', e)
+" 2>&1 || true
+          } | tee keycloak.log
 
       - name: Post results to tracking issue
         if: always()
         run: |
           {
-            echo "# Cluster remediation round 3 — $(date -u '+%Y-%m-%d %H:%M:%SZ')"
+            echo "# Cluster cleanup — $(date -u '+%Y-%m-%d %H:%M:%SZ')"
             echo ""
-            echo "## ntfy stuck pod cleanup"
-            echo '```'
-            cat ntfy.log 2>/dev/null || echo "(no ntfy log)"
-            echo '```'
-            echo ""
-            echo "## Keycloak annotation"
-            echo '```'
-            cat kc.log 2>/dev/null || echo "(no keycloak annotation log)"
-            echo '```'
+            for section in ntfy maintenance cloudless keycloak; do
+              echo "## ${section}"
+              echo '```'
+              cat "${section}.log" 2>/dev/null || echo "(no log)"
+              echo '```'
+              echo ""
+            done
           } | gh issue comment 382 --repo "$GITHUB_REPOSITORY" --body-file -

--- a/scripts/cluster-doctor.sh
+++ b/scripts/cluster-doctor.sh
@@ -120,30 +120,29 @@ else
   printf "_could not fetch /api/v1/rules (empty response)_\n"
 fi
 
-section "cloudless app: deployment (k3s standby E2E target)"
-k -n default get deploy cloudless -o wide | fence
-printf "Resource limits + env:\n"
-kubectl -n default get deploy cloudless \
-  -o jsonpath='{range .spec.template.spec.containers[*]}{.name}{"\n  limits="}{.resources.limits}{"\n  requests="}{.resources.requests}{"\n"}{end}' \
+section "cloudless app: deployment (k3s standby E2E target — ns cloudless)"
+k -n cloudless get deploy cloudless -o wide | fence
+printf "Resource limits + image:\n"
+kubectl -n cloudless get deploy cloudless \
+  -o jsonpath='{range .spec.template.spec.containers[*]}{.name}{"\n  image="}{.image}{"\n  limits="}{.resources.limits}{"\n  requests="}{.resources.requests}{"\n"}{end}' \
   2>/dev/null | fence
 
-section "cloudless app: pods"
-k -n default get pods -l app=cloudless -o wide | fence
+section "cloudless app: all pods in ns cloudless"
+k -n cloudless get pods -o wide | fence
 printf "Container states:\n"
-kubectl -n default get pods -l app=cloudless -o jsonpath='{range .items[*]}{.metadata.name}{":\n"}{range .status.containerStatuses[*]}{"  restarts="}{.restartCount}{" ready="}{.ready}{" waiting="}{.state.waiting.reason}{" lastTerminated="}{.lastState.terminated.reason}{"(exit "}{.lastState.terminated.exitCode}{")\n"}{end}{end}' \
+kubectl -n cloudless get pods -o jsonpath='{range .items[*]}{.metadata.name}{":\n"}{range .status.containerStatuses[*]}{"  restarts="}{.restartCount}{" ready="}{.ready}{" waiting="}{.state.waiting.reason}{" lastTerminated="}{.lastState.terminated.reason}{"(exit "}{.lastState.terminated.exitCode}{")\n"}{end}{end}' \
   2>/dev/null | fence
 
-section "cloudless app: recent events"
-kubectl -n default get events --sort-by=.lastTimestamp --field-selector=involvedObject.kind=Pod 2>/dev/null \
-  | grep -i cloudless | tail -20 | fence
+section "cloudless app: recent events (ns cloudless)"
+kubectl -n cloudless get events --sort-by=.lastTimestamp 2>/dev/null | tail -20 | fence
 
 section "cloudless app: logs (last 40 lines)"
-k -n default logs deploy/cloudless --tail=40 | fence
+k -n cloudless logs deploy/cloudless --tail=40 | fence
 
 section "cloudless app: logs (previous container, last 40 lines)"
-pod=$(kubectl -n default get pods -l app=cloudless -o name 2>/dev/null | head -1)
-[ -n "$pod" ] && k -n default logs "$pod" --previous --tail=40 | fence || printf "_no cloudless pod found_\n"
+pod=$(kubectl -n cloudless get pods -l app=cloudless -o name 2>/dev/null | head -1)
+[ -n "$pod" ] && k -n cloudless logs "$pod" --previous --tail=40 | fence || printf "_no cloudless pod found_\n"
 
 printf "\n_End of snapshot._\n"
 
-# diagnose-cloudless-e2e-failure 20260602
+# fix-cloudless-ns-20260602


### PR DESCRIPTION
## Summary

- **ntfy**: patch finalizers then force-delete stuck Error/Evicted pods (SQLite lock on shared PVC)
- **maintenance**: delete Error CronJob pods (`cluster-health-check` residue, 36h old)
- **cloudless**: rollout restart `cloudless-manager` (31 restarts) + `oauth2-proxy` (63 restarts) — both are healthy but accumulating restart-count noise from node reboots (exit 255)
- **keycloak**: rebuild `last-applied-configuration` annotation from live state so it reflects 768Mi (previously stuck at 384Mi, risking a future `kubectl apply` rollback to the OOM-triggering limit)

## How it triggers

Editing this workflow file and merging to `main` fires the path-filtered push trigger → `ubuntu-latest` runner joins tailnet via `TS_AUTHKEY`, configures `kubectl` from `KUBECONFIG_B64` (`system:admin`), runs all 4 cleanup steps, posts results to issue #382.

## Test plan

- [ ] Merge triggers `cluster-remediate` workflow on `ubuntu-latest`
- [ ] Workflow completes and posts log to issue #382
- [ ] ntfy: no Error pods remain in `ntfy` namespace
- [ ] maintenance: no Error pods remain in `maintenance` namespace  
- [ ] cloudless-manager + oauth2-proxy: restart count resets to 0
- [ ] keycloak: `last-applied` annotation shows `768Mi`

https://claude.ai/code/session_01PHsA9s3tK2thgSJVwEGuWq

---
_Generated by [Claude Code](https://claude.ai/code/session_01PHsA9s3tK2thgSJVwEGuWq)_