### PR TITLE
fix(hydration): restore mount-deferred pattern in HubSpotScript

### DIFF
--- a/src/components/HubSpotScript.tsx
+++ b/src/components/HubSpotScript.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import Script from "next/script";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 
 const HS_PORTAL_ID = process.env.NEXT_PUBLIC_HUBSPOT_PORTAL_ID ?? "";
 
@@ -10,11 +10,18 @@ const HS_PORTAL_ID = process.env.NEXT_PUBLIC_HUBSPOT_PORTAL_ID ?? "";
 const PRODUCTION_HOSTS = new Set(["cloudless.gr", "www.cloudless.gr"]);
 
 export function HubSpotScript({ nonce }: Readonly<{ nonce?: string }>) {
-  // Lazy initializer runs once on mount (client-only), avoiding React #418:
-  // null→<Script> hydration mismatch when getServerSnapshot=false ran during SSR.
-  const [shouldLoad] = useState(
-    () => HS_PORTAL_ID.length > 0 && PRODUCTION_HOSTS.has(globalThis.location?.hostname ?? "")
-  );
+  // Mount-deferred: SSR and the initial hydration pass both render null.
+  // Reading globalThis.location during a lazy useState initializer runs during
+  // SSR (server: undefined) AND during client hydration (browser: real hostname),
+  // which produces a server/client mismatch and triggers React error #418.
+  const [shouldLoad, setShouldLoad] = useState(false);
+
+  useEffect(() => {
+    if (HS_PORTAL_ID.length > 0 && PRODUCTION_HOSTS.has(globalThis.location.hostname)) {
+      // eslint-disable-next-line react-hooks/set-state-in-effect
+      setShouldLoad(true);
+    }
+  }, []);
 
   if (!shouldLoad) return null;
   return (


### PR DESCRIPTION
## Summary
- Restores the correct `useState(false) + useEffect` pattern in `HubSpotScript.tsx` that was discarded during conflict resolution in commit e054291
- Fixes React error #418 (`pageerror`) on cloudless.gr that causes `e2e/k3s/assets.spec.ts:27` to fail

## Root Cause
The lazy `useState` initializer was reading `globalThis.location?.hostname` during render — this runs during **both SSR** (where `location` is undefined → `shouldLoad=false`) **and client hydration** (where `location.hostname = "cloudless.gr"` → `shouldLoad=true`). Under React 19 streaming (Lambda), this fiber-tree divergence surfaces as error #418.

## Fix
Mount-deferred pattern: `useState(false) + useEffect` ensures both server and client agree on `shouldLoad=false` during the initial render/hydration pass. The effect fires post-hydration and enables the HubSpot script only on production hostnames.

## Test plan
- [ ] k3s-e2e `assets.spec.ts:27` "no fatal page errors" should pass after deploy
- [ ] HubSpot script still loads on cloudless.gr and www.cloudless.gr
- [ ] HubSpot does NOT load on localhost or pi-origin

https://claude.ai/code/session_012EjQpQGyt6SeSfRNNRRr6j