### PR TITLE
fix(auth): stop benign Configuration error from flapping the ServerlessErrors alarm

### DIFF
--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -207,6 +207,22 @@ const nextAuthResult = hasAuthSecret
         },
       },
       session: { strategy: "jwt" },
+      // Suppress the benign next-auth "Configuration" error that fires on a bare
+      // GET to /api/auth/signin/keycloak (health probes, crawlers, link
+      // unfurlers). Real sign-in POSTs with CSRF and is unaffected. That log
+      // line is what the CloudWatch `CloudlessApp/ServerlessErrors` metric
+      // filter counts, so dropping it stops the noisy SERVERLESS-APP_MAIN-Errors
+      // alarm from flapping on non-events. We only swallow it when Keycloak is
+      // *actually* configured — if the env below is missing the error is a real
+      // misconfiguration and still logs (and still trips the metric).
+      logger: {
+        error(error: Error) {
+          const tag = `${error?.name ?? ""} ${(error as { type?: string })?.type ?? ""}`;
+          const kcConfigured = !!(KC_ISSUER && KC_CLIENT_ID && KC_CLIENT_SECRET);
+          if (tag.includes("Configuration") && kcConfigured) return;
+          console.error(`[auth][error] ${error?.message ?? error}`);
+        },
+      },
       pages: {
         signIn: "/auth/login",
         error: "/auth/login",


### PR DESCRIPTION
## What
The CloudWatch alarm **`SERVERLESS-APP_MAIN-Errors`** keeps flapping ALARM→OK on non-events. Its metric (`CloudlessApp/ServerlessErrors`, a Logs metric filter) counts next-auth `[auth][error] Configuration` lines, which fire on a **bare GET** to `/api/auth/signin/keycloak` (health probes, crawlers, link unfurlers). Real sign-in POSTs with CSRF and is unaffected — so these are false alarms.

## Fix
Add a next-auth `logger` in `src/lib/auth.ts` that drops **only** the `Configuration` error, and **only when Keycloak is actually configured** (`KEYCLOAK_ISSUER` / `KEYCLOAK_CLIENT_ID` / `KEYCLOAK_CLIENT_SECRET` all present). If that env is missing, the error is a genuine misconfiguration and still logs (and still trips the metric). All other auth errors are logged unchanged, so a real Keycloak outage (e.g. the 2026-06-01 OOM) still surfaces.

## Verification
- `tsc --noEmit` → 0 errors project-wide
- `eslint src/lib/auth.ts` → clean
- No auth unit tests exist to update

## Optional follow-up (console, not in this PR)
The alarm threshold (1 error / 5 min) is also very low; it can be raised independently with `aws cloudwatch put-metric-alarm`. This PR removes the source of the noise regardless.

https://claude.ai/code/session_01NcSkJjzxABqYH8jAfDurRt

---
_Generated by [Claude Code](https://claude.ai/code/session_01NcSkJjzxABqYH8jAfDurRt)_