### PR TITLE
chore: post-cleanup cluster doctor verification

### DIFF
--- a/scripts/cluster-doctor.sh
+++ b/scripts/cluster-doctor.sh
@@ -154,4 +154,4 @@ pod=$(kubectl -n cloudless get pods -l app=cloudless -o name 2>/dev/null | head 
 
 printf "\n_End of snapshot._\n"
 
-# re-trigger-doctor-20260602b
+# re-trigger-doctor-20260602c


### PR DESCRIPTION
Triggers cluster-doctor.yml to verify post-cleanup state (ntfy, maintenance, cloudless ns, keycloak).

---
_Generated by [Claude Code](https://claude.ai/code/session_01PHsA9s3tK2thgSJVwEGuWq)_