### PR TITLE
fix(test): restore green main — bundle-optimization for CartSlideOver client boundary

### DIFF
--- a/__tests__/bundle-optimization.test.ts
+++ b/__tests__/bundle-optimization.test.ts
@@ -13,13 +13,27 @@ interface BudgetEntry {
 }
 
 describe("bundle optimization", () => {
-  it("layout.tsx lazy-loads CartSlideOver via next/dynamic", () => {
-    const src = readFileSync(
+  it("layout.tsx lazy-loads CartSlideOver via the ClientCartSlideOver boundary", () => {
+    // layout.tsx is a Server Component, so the ssr:false dynamic() boundary for
+    // CartSlideOver lives in the ClientCartSlideOver client wrapper (PR #481,
+    // fixes a React #418 hydration crash in prod). The layout must use that
+    // wrapper and never statically import the heavy CartSlideOver directly.
+    const layout = readFileSync(
       path.resolve("src/app/[locale]/layout.tsx"),
       "utf-8",
     );
-    expect(src).toContain("next/dynamic");
-    expect(src).not.toMatch(/^import CartSlideOver from/m);
+    expect(layout).toContain("ClientCartSlideOver");
+    expect(layout).not.toMatch(/^import CartSlideOver from/m);
+
+    // The optimization itself: CartSlideOver is still code-split via next/dynamic
+    // with ssr:false in the client wrapper.
+    const wrapper = readFileSync(
+      path.resolve("src/components/ClientCartSlideOver.tsx"),
+      "utf-8",
+    );
+    expect(wrapper).toContain("next/dynamic");
+    expect(wrapper).toMatch(/dynamic\(\(\) => import\("@\/components\/store\/CartSlideOver"\)/);
+    expect(wrapper).toContain("ssr: false");
   });
 
   it("ClientDecorators lazy-loads CommandPalette, NeonCursor, KonamiEasterEgg", () => {


### PR DESCRIPTION
## Restores green `main` — fixes the CI Unit Tests failure (run #881)

`bundle-optimization.test.ts` went red: it asserts `src/app/[locale]/layout.tsx` contains `next/dynamic`, but **PR #481** correctly moved the `CartSlideOver` `ssr:false` `dynamic()` boundary into the **`ClientCartSlideOver`** client wrapper.

Why #481 was right: `layout.tsx` is a **Server Component**, and an `ssr:false` `dynamic()` there caused a **React #418 hydration crash in prod (Lambda)**. The wrapper moves the boundary to a client component. The bundle optimization (code-splitting `CartSlideOver`) is **preserved** — just relocated.

So the production code is correct; the **test expectation was stale**. Updated it to guard the optimization in its new home (per the project testing policy — stale-expectation fix, not a mock shim):
- `layout.tsx` uses `ClientCartSlideOver` and never statically imports the heavy `CartSlideOver`.
- `ClientCartSlideOver.tsx` code-splits `CartSlideOver` via `next/dynamic` with `ssr: false` (now asserts the exact import target too — stronger than before).

## Test plan
- [x] `pnpm test` — **2082 / 2082** (was 1 failed | 2081)
- [ ] CI Unit Tests green

https://claude.ai/code/session_016PrzZJMNxsgiEmvedfkru6

---
_Generated by [Claude Code](https://claude.ai/code/session_016PrzZJMNxsgiEmvedfkru6)_