### PR TITLE
fix(headers): remove web-share from Permissions-Policy

### DIFF
--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -250,7 +250,6 @@ function addSecurityHeaders(response: NextResponse, nonce: string): void {
       "screen-wake-lock=()",
       "serial=()",
       "usb=()",
-      "web-share=(self)",
       "xr-spatial-tracking=()",
     ].join(", "),
   );


### PR DESCRIPTION
## Summary

- Removes `web-share=(self)` from the `Permissions-Policy` response header.

Chromium logs `Unrecognized feature: 'web-share'` for this directive on every page load. The app has no `navigator.share()` call anywhere in `src/`, so the allowlist entry serves no purpose.

## Test plan

- [ ] Dev server: no `Permissions-Policy` warning in browser console on page load

https://claude.ai/code/session_012EjQpQGyt6SeSfRNNRRr6j