### PR TITLE
chore(cluster): trigger doctor — PrometheusKubernetesListWatchFailures

### DIFF
--- a/scripts/cluster-doctor.sh
+++ b/scripts/cluster-doctor.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 #
 # cluster-doctor.sh — read-only diagnostics for the omv k3s cluster, with a
-# focus on why Keycloak (auth.cloudless.gr) might be down. [triggered 2026-06-02]
+# focus on why Keycloak (auth.cloudless.gr) might be down. [triggered 2026-06-02T-listwatch]
 #
 # Emits a Markdown report to stdout. Every kubectl call is best-effort (|| true)
 # so the report is always produced even when individual objects are missing.


### PR DESCRIPTION
Trigger cluster-doctor workflow to diagnose PrometheusKubernetesListWatchFailures alert firing on 10.42.0.25:9090.

https://claude.ai/code/session_012EjQpQGyt6SeSfRNNRRr6j