### PR TITLE
feat(ops): AWS cost audit workflow — read-only report to issue #382

### DIFF
--- a/.github/workflows/cost-audit.yml
+++ b/.github/workflows/cost-audit.yml
@@ -1,0 +1,68 @@
+name: AWS cost audit (read-only report)
+# Reads current state of billable AWS services and posts a snapshot to the
+# tracking issue. No changes are applied — DRY_RUN=1, no DO_* flags set.
+#
+# Trigger: push to main when this file changes (first merge fires it), or
+# workflow_dispatch for ad-hoc runs.
+
+on:
+  workflow_dispatch:
+    inputs:
+      issue:
+        description: "Issue number to post the report to"
+        required: false
+        default: "382"
+  push:
+    branches: [main]
+    paths:
+      - ".github/workflows/cost-audit.yml"
+      - "scripts/aws-cost-reduction.sh"
+
+permissions:
+  id-token: write
+  contents: read
+  issues: write
+
+jobs:
+  audit:
+    name: AWS cost audit
+    runs-on: ubuntu-latest
+    env:
+      AWS_REGION: us-east-1
+      ISSUE: ${{ github.event.inputs.issue || '382' }}
+      GH_TOKEN: ${{ github.token }}
+
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v4.3.1
+
+      - name: Configure AWS credentials (OIDC)
+        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4.3.1
+        with:
+          role-to-assume: ${{ secrets.AWS_DEPLOY_ROLE_ARN }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Run cost audit (read-only)
+        run: |
+          bash scripts/aws-cost-reduction.sh 2>&1 | tee audit-raw.txt
+        env:
+          DRY_RUN: "1"
+          AUDIT_ALL: "1"
+
+      - name: Format report for GitHub
+        if: always()
+        run: |
+          {
+            printf '## AWS cost audit — %s\n\n' "$(date -u '+%Y-%m-%d %H:%M UTC')"
+            printf '**Branch/SHA:** `%s` / `%s`\n\n' "${{ github.ref_name }}" "${{ github.sha }}"
+            printf '<details><summary>Full audit output</summary>\n\n```\n'
+            # Strip ANSI colour codes so the markdown renders cleanly
+            sed 's/\x1b\[[0-9;]*m//g' audit-raw.txt
+            printf '```\n\n</details>\n'
+          } > report.md
+
+      - name: Post report to tracking issue
+        if: always()
+        run: |
+          gh issue comment "$ISSUE" \
+            --repo "${{ github.repository }}" \
+            --body-file report.md


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/cost-audit.yml`: runs `scripts/aws-cost-reduction.sh` in audit-only mode (`DRY_RUN=1`, no `DO_*` flags) via OIDC on `ubuntu-latest`
- Strips ANSI colour codes and posts a formatted Markdown report as a comment on issue #382
- Triggers on push to `main` when this file or the audit script changes, plus `workflow_dispatch` for ad-hoc runs

## Test plan

- [ ] Merge triggers the workflow on main
- [ ] Workflow authenticates to AWS via OIDC (`AWS_DEPLOY_ROLE_ARN`)
- [ ] Audit output (WorkMail, KMS, Route 53, CloudTrail/Config/Secrets/SSM warnings) appears as a comment on issue #382
- [ ] No AWS mutations — all flags remain at defaults (`DRY_RUN=1`)

https://claude.ai/code/session_01P169EPm5yifeTKoCwsvGEV

---
_Generated by [Claude Code](https://claude.ai/code/session_01P169EPm5yifeTKoCwsvGEV)_