### PR TITLE
chore: re-trigger cluster doctor (post-API-recovery check)

### DIFF
--- a/scripts/cluster-doctor.sh
+++ b/scripts/cluster-doctor.sh
@@ -154,4 +154,4 @@ pod=$(kubectl -n cloudless get pods -l app=cloudless -o name 2>/dev/null | head 
 
 printf "\n_End of snapshot._\n"
 
-# re-trigger-doctor-20260602c
+# re-trigger-doctor-20260602d


### PR DESCRIPTION
Fires cluster-doctor.yml to get a clean snapshot after the k3s API server recovered from the post-cleanup load spike.

---
_Generated by [Claude Code](https://claude.ai/code/session_01PHsA9s3tK2thgSJVwEGuWq)_