### PR TITLE
chore: drop retired cloudless.online from live scripts/config

### DIFF
--- a/infrastructure/pi-alert-api/main.py
+++ b/infrastructure/pi-alert-api/main.py
@@ -436,7 +436,7 @@ SCRIPTS: dict[str, dict] = {
         "danger":      False,
     },
     "restart_cloudless_app": {
-        "label":       "Restart cloudless.online pod",
+        "label":       "Restart cloudless app pod",
         "description": "kubectl rollout restart deployment/cloudless-app -n cloudless",
         "danger":      False,
     },

--- a/infrastructure/pi-alert-api/tls_check.py
+++ b/infrastructure/pi-alert-api/tls_check.py
@@ -11,7 +11,7 @@ Severity ladder:
   ≤  3 days            → CERT_EXPIRING_CRITICAL (critical)
   expired              → CERT_EXPIRED (critical)
 
-Monitored domains (updated 2026-05-24 — retired cloudless.online domains removed):
+Monitored domains:
   cloudless.gr
   manage.cloudless.gr
   grafana.cloudless.gr

--- a/scripts/post-deploy-esp32-verify.ps1
+++ b/scripts/post-deploy-esp32-verify.ps1
@@ -1,6 +1,6 @@
 # Post-deploy verification for the ESP32 ↔ Notion mirror.
 #
-# Runs against the deployed cloudless.online (or any reachable origin you
+# Runs against the deployed cloudless.gr (or any reachable origin you
 # pass via -Origin). Verifies the new admin sync endpoint round-trips.
 #
 # Prereqs:
@@ -10,11 +10,11 @@
 #     `await (await import('aws-amplify/auth')).fetchAuthSession().then(s => s.tokens.idToken.toString())`
 #
 # Usage:
-#   pwsh -File scripts/post-deploy-esp32-verify.ps1 -Origin https://cloudless.online -IdToken "<TOKEN>"
+#   pwsh -File scripts/post-deploy-esp32-verify.ps1 -Origin https://cloudless.gr -IdToken "<TOKEN>"
 
 param(
     [Parameter(Mandatory = $true)] [string] $IdToken,
-    [string] $Origin = "https://cloudless.online"
+    [string] $Origin = "https://cloudless.gr"
 )
 
 $ErrorActionPreference = "Stop"


### PR DESCRIPTION
## Retire `cloudless.online` — clean up live leftovers

`cloudless.online` is decommissioned (migrated to `cloudless.gr`; DNS delegation removed, domain no longer resolves). The app/config/tests already had **zero** references; this cleans the remaining **active/usable** ones so nothing points a runnable tool at the dead domain:

- **`scripts/post-deploy-esp32-verify.ps1`** — default `-Origin` + usage example `https://cloudless.online` → `https://cloudless.gr` (the live host serving the admin esp32 endpoint).
- **`infrastructure/pi-alert-api/main.py`** — button label "Restart cloudless.online pod" → "Restart cloudless app pod" (matches the `cloudless-app` deployment in ns `cloudless`).
- **`infrastructure/pi-alert-api/tls_check.py`** — dropped the `cloudless.online` aside from the monitored-domains comment (already `.gr`-only).

### Deliberately preserved (removing them would be the *unsafe* option)
- `docs/pull-requests/2026-05-22-esp32-notion-mirror.md` — **historical PR record** (don't rewrite history).
- `scripts/finalize-cowork-followups-2026-05-22.ps1` — **dated, already-run one-shot**.
- `.claude/commands/aws-iam-audit.md` — the `cloudless.online` ACM cert note is **still accurate** (Cloudflare-owned, un-deletable) and stops someone re-flagging that cert.

### Note
The recurring DNS-change alerts come from an **external** monitor (not in this repo) — to stop them, remove `cloudless.online` from that watchlist.

- [x] Python files compile (`py_compile`)

https://claude.ai/code/session_016PrzZJMNxsgiEmvedfkru6

---
_Generated by [Claude Code](https://claude.ai/code/session_016PrzZJMNxsgiEmvedfkru6)_