### PR TITLE
ops(cluster): k3s-restart workflow — recover API server after crash

### DIFF
--- a/.github/workflows/k3s-restart.yml
+++ b/.github/workflows/k3s-restart.yml
@@ -1,0 +1,88 @@
+name: k3s restart — recover API server after crash
+
+# Triggered by pushing a change to this file. Runs on the omv build runner
+# (a systemd service on the Pi host — survives k3s crashes). Restarts the
+# k3s server service, waits for the API to become healthy, then posts the
+# result to tracking issue #382.
+#
+# ONLY use this when the k3s API server is unresponsive (connection refused
+# on port 6443). Safe to re-run — `systemctl restart k3s` is idempotent.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - ".github/workflows/k3s-restart.yml"
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  restart-k3s:
+    # Runs on the Pi host as a systemd service — stays alive when k3s crashes.
+    # If this job queues forever the Pi itself is down; cancel and reboot manually.
+    runs-on: [self-hosted, omv, build]
+    timeout-minutes: 10
+    env:
+      GH_TOKEN: ${{ github.token }}
+    steps:
+      - name: Check current k3s status
+        run: |
+          echo "=== k3s status BEFORE restart ===" | tee k3s.log
+          sudo systemctl status k3s --no-pager 2>&1 | tee -a k3s.log || true
+          echo "" | tee -a k3s.log
+          echo "=== port 6443 check BEFORE ===" | tee -a k3s.log
+          ss -tlnp 2>/dev/null | grep 6443 | tee -a k3s.log || echo "(6443 not listening)" | tee -a k3s.log
+
+      - name: Restart k3s
+        run: |
+          echo "" | tee -a k3s.log
+          echo "=== restarting k3s ===" | tee -a k3s.log
+          sudo systemctl restart k3s 2>&1 | tee -a k3s.log
+          echo "restart command exited: $?" | tee -a k3s.log
+
+      - name: Wait for API server to become healthy
+        run: |
+          echo "" | tee -a k3s.log
+          echo "=== waiting for port 6443 (up to 60s) ===" | tee -a k3s.log
+          for i in $(seq 1 12); do
+            if ss -tlnp 2>/dev/null | grep -q 6443; then
+              echo "API server listening after ${i}×5s" | tee -a k3s.log
+              break
+            fi
+            echo "  ${i}/12 — waiting 5s..." | tee -a k3s.log
+            sleep 5
+          done
+
+          echo "" | tee -a k3s.log
+          echo "=== k3s status AFTER restart ===" | tee -a k3s.log
+          sudo systemctl status k3s --no-pager 2>&1 | tee -a k3s.log || true
+
+          echo "" | tee -a k3s.log
+          echo "=== port 6443 check AFTER ===" | tee -a k3s.log
+          ss -tlnp 2>/dev/null | grep 6443 | tee -a k3s.log || echo "(6443 still not listening — FAIL)" | tee -a k3s.log
+
+      - name: Quick API health check (kubectl)
+        run: |
+          echo "" | tee -a k3s.log
+          echo "=== kubectl cluster-info ===" | tee -a k3s.log
+          # k3s ships kubectl and writes the kubeconfig to /etc/rancher/k3s/k3s.yaml
+          sudo kubectl --kubeconfig /etc/rancher/k3s/k3s.yaml cluster-info 2>&1 | tee -a k3s.log || true
+
+          echo "" | tee -a k3s.log
+          echo "=== all pods (non-Running) ===" | tee -a k3s.log
+          sudo kubectl --kubeconfig /etc/rancher/k3s/k3s.yaml get pods -A \
+            --field-selector='status.phase!=Running,status.phase!=Succeeded' \
+            2>&1 | tee -a k3s.log || true
+
+      - name: Post result to tracking issue
+        if: always()
+        run: |
+          {
+            echo "# k3s restart — $(date -u '+%Y-%m-%d %H:%M:%SZ')"
+            echo ""
+            echo '```'
+            cat k3s.log 2>/dev/null || echo "(no log)"
+            echo '```'
+          } | gh issue comment 382 --repo "$GITHUB_REPOSITORY" --body-file -


### PR DESCRIPTION
## What

Adds a path-triggered workflow that restarts the k3s server process on the Pi host when the API server crashes.

**Triggered now to recover the current `PrometheusKubernetesListWatchFailures` incident** — k3s API server at `100.113.41.119:6443` is returning connection refused.

## How it works

- Runs on `[self-hosted, omv, build]` — a systemd service on the Pi host that survives k3s crashes
- `sudo systemctl restart k3s`
- Polls until port 6443 is listening (up to 60s)
- Runs `kubectl cluster-info` + non-Running pod check using the local `/etc/rancher/k3s/k3s.yaml` kubeconfig
- Posts the full log to tracking issue #382

If the job queues forever, the Pi itself is down and physical intervention is needed.

https://claude.ai/code/session_012EjQpQGyt6SeSfRNNRRr6j