### PR TITLE
fix(ops): Node 24 opt-in + audit script permission-error surfacing

### DIFF
--- a/.github/workflows/build-pi-image.yml
+++ b/.github/workflows/build-pi-image.yml
@@ -35,6 +35,7 @@ on:
       - '.github/workflows/build-pi-image.yml'
 
 env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
   AWS_REGION: us-east-1
   ECR_REGISTRY: 278585680617.dkr.ecr.us-east-1.amazonaws.com
   ECR_REPO: cloudless-pi-app

--- a/.github/workflows/cost-audit.yml
+++ b/.github/workflows/cost-audit.yml
@@ -23,6 +23,9 @@ permissions:
   contents: read
   issues: write
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   audit:
     name: AWS cost audit

--- a/.github/workflows/deploy-pi-proxy.yml
+++ b/.github/workflows/deploy-pi-proxy.yml
@@ -11,6 +11,9 @@ permissions:
   id-token: write
   contents: read
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   deploy:
     name: Package and deploy cloudless-pi-proxy

--- a/.github/workflows/deploy-pi.yml
+++ b/.github/workflows/deploy-pi.yml
@@ -26,6 +26,7 @@ permissions:
   contents: read
 
 env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
   AWS_REGION: us-east-1
   ECR_REGISTRY: 278585680617.dkr.ecr.us-east-1.amazonaws.com
   ECR_REPOSITORY: cloudless-pi-app

--- a/.github/workflows/keycloak-admin-api-client.yml
+++ b/.github/workflows/keycloak-admin-api-client.yml
@@ -22,6 +22,9 @@ concurrency:
   group: keycloak-admin-api-client
   cancel-in-progress: false
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   ensure:
     runs-on: ubuntu-latest

--- a/.github/workflows/keycloak-configure-email.yml
+++ b/.github/workflows/keycloak-configure-email.yml
@@ -54,6 +54,9 @@ concurrency:
   group: keycloak-configure-email
   cancel-in-progress: false
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   configure-email:
     runs-on: ubuntu-latest

--- a/.github/workflows/keycloak-live-admin-test.yml
+++ b/.github/workflows/keycloak-live-admin-test.yml
@@ -24,6 +24,9 @@ concurrency:
   group: keycloak-live-admin-test
   cancel-in-progress: false
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   live-test:
     runs-on: ubuntu-latest

--- a/.github/workflows/keycloak-verify-admin.yml
+++ b/.github/workflows/keycloak-verify-admin.yml
@@ -29,6 +29,9 @@ concurrency:
   group: keycloak-verify-admin
   cancel-in-progress: false
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   verify:
     runs-on: ubuntu-latest

--- a/.github/workflows/provision-ses-smtp.yml
+++ b/.github/workflows/provision-ses-smtp.yml
@@ -29,6 +29,9 @@ concurrency:
   group: provision-ses-smtp
   cancel-in-progress: false
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   provision:
     runs-on: ubuntu-latest

--- a/.github/workflows/sync-ssm-to-vars.yml
+++ b/.github/workflows/sync-ssm-to-vars.yml
@@ -21,6 +21,7 @@ permissions:
   actions: write    # create/update repo variables
 
 env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
   AWS_REGION: us-east-1
   SSM_PREFIX: /cloudless/production
 

--- a/scripts/aws-cost-reduction.sh
+++ b/scripts/aws-cost-reduction.sh
@@ -178,15 +178,31 @@ do_config() {
 # --------------------------------------------------------------------------
 do_kms() {
   c_hdr "KMS (~\$2.13/mo) — audit customer-managed keys (\$1/key/mo)"
-  aws kms list-keys --region "$REGION" --output json | jq -r '.Keys[].KeyId' | while read -r kid; do
+  local key_list
+  key_list="$(aws kms list-keys --region "$REGION" --output json 2>&1)" || {
+    c_warn "  kms:ListKeys permission denied — add kms:ListKeys + kms:DescribeKey + kms:ListAliases to the caller role."
+    c_warn "  NOTE: \$2.13 charge may be API-call volume on AWS-managed keys, not CMK monthly fees."
+    c_warn "  Check: Cost Explorer → KMS → Usage Type (Request, GenerateDataKey, etc.)."
+    return
+  }
+  local found=0
+  while read -r kid; do
+    [[ -z "$kid" ]] && continue
     local meta mgr state alias
     meta="$(aws kms describe-key --key-id "$kid" --region "$REGION" --output json 2>/dev/null || echo '{}')"
-    mgr="$(echo "$meta" | jq -r '.KeyMetadata.KeyManager')"
+    mgr="$(echo "$meta" | jq -r '.KeyMetadata.KeyManager // "?"')"
     [[ "$mgr" != "CUSTOMER" ]] && continue   # AWS-managed keys are free; skip
+    found=1
     state="$(echo "$meta" | jq -r '.KeyMetadata.KeyState')"
     alias="$(aws kms list-aliases --key-id "$kid" --region "$REGION" --query 'Aliases[0].AliasName' --output text 2>/dev/null || echo '-')"
     echo "  CMK $kid  state=$state  alias=$alias  (\$1/mo)"
-  done
+  done <<< "$(echo "$key_list" | jq -r '.Keys[].KeyId')"
+  if [[ "$found" == "0" ]]; then
+    c_ok "  No customer-managed keys in $REGION."
+    c_warn "  NOTE: \$2.13 KMS charge is likely API-call volume on AWS-managed keys (not \$1/CMK/mo fees)."
+    c_warn "  Check Cost Explorer → KMS → Usage Type to confirm and identify the top calling service."
+    return
+  fi
   c_warn "For each CMK NOT referenced by SES/S3/Secrets Manager/SQS, schedule deletion (DESTRUCTIVE, 30-day window):"
   echo "    #   aws kms schedule-key-deletion --key-id <KEY> --pending-window-in-days 30 --region $REGION"
   echo "    # Prefer switching the consuming service to its free AWS-managed key first."
@@ -200,8 +216,14 @@ do_r53() {
   c_hdr "Route 53 (~\$4.22/mo) — audit zone + HA health checks"
   echo "  hosted zone $ZONE_ID = \$0.50/mo (unavoidable — it's your DNS)"
   for hc in "$PRIMARY_HC" "$SECONDARY_HC"; do
-    local cfg
-    cfg="$(aws route53 get-health-check --health-check-id "$hc" --query 'HealthCheck.HealthCheckConfig' --output json 2>/dev/null || echo '{}')"
+    local raw cfg
+    raw="$(aws route53 get-health-check --health-check-id "$hc" \
+          --query 'HealthCheck.HealthCheckConfig' --output json 2>&1)" || true
+    if echo "$raw" | grep -qi "AccessDenied\|not authorized\|is not authorized"; then
+      c_warn "  health-check $hc — PERMISSION DENIED (add route53:GetHealthCheck to caller role)"
+      continue
+    fi
+    cfg="$(echo "$raw" | jq -r '.' 2>/dev/null || echo '{}')"
     local typ interval str
     typ="$(echo "$cfg" | jq -r '.Type // "?"')"
     interval="$(echo "$cfg" | jq -r '.RequestInterval // "?"')"


### PR DESCRIPTION
## Summary

- **Node.js 24 opt-in** — adds `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true` to 10 workflows that use `configure-aws-credentials` but hadn't opted in yet (7 already had it). Deadline: June 16, 2026.
- **Audit script: permission-error surfacing** — `aws-cost-reduction.sh` previously swallowed `AccessDenied` errors in `do_kms()` and `do_r53()`, producing silent `type=?` / no-output results. Now:
  - KMS: if `kms:ListKeys` is denied → prints required IAM actions; if no CMKs found → explains the $2.13 charge is API-call volume on AWS-managed keys, not $1/CMK/mo fees
  - Route 53: if `route53:GetHealthCheck` is denied → prints which check ID needs the permission instead of silently showing `type=?`

## Test plan

- [ ] Merge triggers `cost-audit.yml` again (path filter matches `scripts/aws-cost-reduction.sh`)
- [ ] New run on issue #382 shows KMS and R53 sections with explicit permission-denied messages (until the deploy role is updated)
- [ ] No workflow regressions on the 10 updated files

https://claude.ai/code/session_01P169EPm5yifeTKoCwsvGEV

---
_Generated by [Claude Code](https://claude.ai/code/session_01P169EPm5yifeTKoCwsvGEV)_