### PR TITLE
fix(ops): surface Route 53 health-check AWS errors verbatim

### DIFF
--- a/scripts/aws-cost-reduction.sh
+++ b/scripts/aws-cost-reduction.sh
@@ -223,7 +223,10 @@ do_r53() {
       c_warn "  health-check $hc — PERMISSION DENIED (add route53:GetHealthCheck to caller role)"
       continue
     fi
-    cfg="$(echo "$raw" | jq -r '.' 2>/dev/null || echo '{}')"
+    if ! cfg="$(echo "$raw" | jq -r '.' 2>/dev/null)"; then
+      c_warn "  health-check $hc — AWS error: $(echo "$raw" | head -1)"
+      continue
+    fi
     local typ interval str
     typ="$(echo "$cfg" | jq -r '.Type // "?"')"
     interval="$(echo "$cfg" | jq -r '.RequestInterval // "?"')"


### PR DESCRIPTION
## Summary

`do_r53()` previously fell through to `type=? interval=?s` whenever `get-health-check` returned a non-JSON response (e.g. `NoSuchHealthCheck`, `AccessDenied`). Now tries to parse with `jq` and, on failure, prints the first line of the raw AWS error so the actual cause is visible in the audit output.

Before:
```
health-check e239ad5c-...  type=? interval=?s no-match
```

After (when health check doesn't exist):
```
health-check e239ad5c-... — AWS error: An error occurred (NoSuchHealthCheck) ...
```

## Test plan
- [ ] Merge triggers `cost-audit.yml` run #3
- [ ] Route 53 section now shows the actual AWS error for both health checks

https://claude.ai/code/session_01P169EPm5yifeTKoCwsvGEV

---
_Generated by [Claude Code](https://claude.ai/code/session_01P169EPm5yifeTKoCwsvGEV)_