### PR TITLE
fix(ops): skip leading blank line in Route 53 AWS error output

### DIFF
--- a/scripts/aws-cost-reduction.sh
+++ b/scripts/aws-cost-reduction.sh
@@ -224,7 +224,7 @@ do_r53() {
       continue
     fi
     if ! cfg="$(echo "$raw" | jq -r '.' 2>/dev/null)"; then
-      c_warn "  health-check $hc — AWS error: $(echo "$raw" | head -1)"
+      c_warn "  health-check $hc — AWS error: $(echo "$raw" | grep -m1 '.' || echo '(empty response)')"
       continue
     fi
     local typ interval str


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- Run #3 showed `health-check <id> — AWS error: ` with a blank error message
- Root cause: the AWS CLI error output starts with a leading blank line when captured via process substitution; `head -1` returned that empty first line
- Fix: replace `head -1` with `grep -m1 '.'` which skips blank lines and returns the first non-empty line; `|| echo '(empty response)'` handles the rare case where the output is truly empty

## Test plan

- [ ] Merge triggers Run #4 of `cost-audit.yml`
- [ ] Route 53 section should now show the actual AWS error text (expected: `NoSuchHealthCheck` — the hardcoded health-check IDs from the May 2026 analysis may be stale)

https://claude.ai/code/session_01P169EPm5yifeTKoCwsvGEV
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01P169EPm5yifeTKoCwsvGEV)_