### PR TITLE
fix(test): guard getStripe() against real API calls in NODE_ENV=test

### DIFF
--- a/src/lib/stripe.ts
+++ b/src/lib/stripe.ts
@@ -6,6 +6,10 @@ let stripeInstance: Stripe | null = null;
 export async function getStripe(): Promise<Stripe | null> {
   if (stripeInstance) return stripeInstance;
 
+  // In test environments, skip real Stripe initialization to prevent network
+  // calls during unit tests (mirrors the ssm-config.ts NODE_ENV=test guard).
+  if (process.env.NODE_ENV === "test") return null;
+
   const config = await getConfig();
   if (!config.STRIPE_SECRET_KEY) return null;
 


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- `getStripe()` in `src/lib/stripe.ts` now returns `null` immediately when `NODE_ENV === "test"`, mirroring the existing guard in `ssm-config.ts`
- Fixes the 15s timeout on `getProducts resolves to defaultProducts when not configured` and `getProductByIdAsync returns product asynchronously` in `__tests__/lib-coverage-gaps.test.ts` (CI run #890)
- Root cause: when `STRIPE_SECRET_KEY` is present in the runner environment, `getStripe()` constructed a real Stripe client and `listStripeProducts()` made a live HTTPS request that timed out in CI

## Test plan

- [ ] `pnpm test:ci` passes — both previously-failing tests now take ~1ms instead of timing out
- [ ] `getStripe()` tests in `stripe-transactions.test.ts` are unaffected (they mock `@/lib/stripe-transactions` at the module level, not `getStripe()` directly)

https://claude.ai/code/session_01PHsA9s3tK2thgSJVwEGuWq
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01PHsA9s3tK2thgSJVwEGuWq)_