### PR TITLE
fix(ops): kubectl-free email config + SMTP manual-bypass for iam:CreateUser

### DIFF
--- a/.github/workflows/keycloak-configure-email.yml
+++ b/.github/workflows/keycloak-configure-email.yml
@@ -65,20 +65,8 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v4.3.1
 
-      - name: Connect to tailnet
-        uses: tailscale/github-action@0263d9e6d793eaefcf1de98ff7fde47abe6664d3 # v3.2.4
-        with:
-          authkey: ${{ secrets.TS_AUTHKEY }}
-
-      - name: Configure kubectl
-        run: |
-          mkdir -p ~/.kube
-          echo "${{ secrets.KUBECONFIG_B64 }}" | base64 -d > ~/.kube/config
-          chmod 600 ~/.kube/config
-
-      # This repo is OIDC-only (no static AWS keys); the original workflow used
-      # non-existent secrets.AWS_ACCESS_KEY_ID/SECRET, so the SSM reads always
-      # failed. Assume the same deploy role the rest of CI uses.
+      # Uses the Keycloak REST admin API — no Tailscale or kubectl required.
+      # Works even when the k3s API server is down or flapping.
       - name: Configure AWS credentials (OIDC)
         if: github.event.inputs.smtp_user == '' || github.event.inputs.smtp_password == ''
         uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4
@@ -141,6 +129,7 @@ jobs:
           SMTP_USER: ${{ env.SMTP_USER }}
           SMTP_PASSWORD: ${{ env.SMTP_PASSWORD }}
           FROM_EMAIL: ${{ env.FROM_EMAIL }}
+          KEYCLOAK_ADMIN_PASSWORD: ${{ secrets.ADMIN_BOOTSTRAP_PASSWORD }}
         run: |
           set -uo pipefail
           bash scripts/keycloak-configure-email.sh 2>&1 | tee email-cfg.log

--- a/.github/workflows/provision-ses-smtp.yml
+++ b/.github/workflows/provision-ses-smtp.yml
@@ -14,6 +14,19 @@ name: Provision SES SMTP credentials
 
 on:
   workflow_dispatch:
+    inputs:
+      smtp_user:
+        description: "Pre-created SES SMTP username (access key ID from AWS Console → SES → SMTP Settings). Leave blank to auto-provision via IAM."
+        required: false
+        default: ""
+      smtp_password:
+        description: "Pre-created SES SMTP password (derived credential shown at creation time — NOT the IAM secret key). Leave blank to auto-provision."
+        required: false
+        default: ""
+      from_email:
+        description: "Verified From address, e.g. noreply@cloudless.gr. Leave blank to keep existing or use default."
+        required: false
+        default: ""
   push:
     branches: [main]
     paths:
@@ -50,6 +63,12 @@ jobs:
         id: provision
         env:
           AWS_REGION: us-east-1
+          # Manual-bypass: if the user provided pre-created SES SMTP creds via
+          # workflow_dispatch inputs, the script writes them straight to SSM and
+          # skips IAM user creation (works without iam:CreateUser permission).
+          SES_SMTP_USER_INPUT: ${{ github.event.inputs.smtp_user }}
+          SES_SMTP_PASSWORD_INPUT: ${{ github.event.inputs.smtp_password }}
+          SES_FROM_INPUT: ${{ github.event.inputs.from_email }}
         run: |
           # pipefail is required: without it, `script | tee` returns tee's exit
           # code (0) and masks the script's failure, falsely marking the job green.

--- a/scripts/keycloak-configure-email.sh
+++ b/scripts/keycloak-configure-email.sh
@@ -3,31 +3,35 @@
 # keycloak-configure-email.sh — configure Keycloak realm SMTP (AWS SES) and
 # enable email verification for new registrations.
 #
-# What this does:
-#   1. Sets the realm smtpServer block to use AWS SES SMTP
-#   2. Enables verifyEmail on the realm (new users must verify before signing in)
-#   3. Ensures the VERIFY_EMAIL required action is enabled + set as default
-#      (so it applies automatically to every new registration)
+# Uses the Keycloak REST admin API directly (no kubectl / no k3s API server
+# required). Works even when the cluster API server is down or flapping.
 #
-# Credentials are read from env vars. The CI workflow reads them from SSM or
-# from workflow_dispatch inputs and injects them before calling this script.
+# What this does:
+#   1. Authenticates to the Keycloak admin REST API
+#   2. Sets the realm smtpServer block to use AWS SES SMTP
+#   3. Enables verifyEmail on the realm (new users must verify before signing in)
+#   4. Enables the VERIFY_EMAIL required action as the default (auto-assigned to
+#      every new registration)
 #
 # Required env:
-#   SMTP_USER      — SES SMTP username (= IAM access key ID for the SES SMTP user)
-#   SMTP_PASSWORD  — SES SMTP password (derived SES SMTP credential, NOT the IAM secret key)
-#   FROM_EMAIL     — from address, e.g. noreply@cloudless.gr
+#   SMTP_USER             — SES SMTP username (IAM access key ID)
+#   SMTP_PASSWORD         — SES SMTP password (derived SES credential)
+#   FROM_EMAIL            — from address, e.g. noreply@cloudless.gr
+#   KEYCLOAK_ADMIN_PASSWORD — Keycloak admin password
 #
 # Optional env:
-#   SMTP_HOST      — default email-smtp.us-east-1.amazonaws.com
-#   SMTP_PORT      — default 587
-#   FROM_NAME      — display name, default "Cloudless"
-#   NAMESPACE, DEPLOYMENT, REALM
+#   KEYCLOAK_ADMIN        — admin username (default: admin)
+#   KEYCLOAK_URL          — base URL (default: https://auth.cloudless.gr)
+#   SMTP_HOST             — default email-smtp.us-east-1.amazonaws.com
+#   SMTP_PORT             — default 587
+#   FROM_NAME             — display name, default "Cloudless"
+#   REALM                 — default master
 
 set -uo pipefail
 
-NAMESPACE="${NAMESPACE:-keycloak}"
-DEPLOYMENT="${DEPLOYMENT:-keycloak}"
 REALM="${REALM:-master}"
+KEYCLOAK_URL="${KEYCLOAK_URL:-https://auth.cloudless.gr}"
+KEYCLOAK_ADMIN="${KEYCLOAK_ADMIN:-admin}"
 SMTP_HOST="${SMTP_HOST:-email-smtp.us-east-1.amazonaws.com}"
 SMTP_PORT="${SMTP_PORT:-587}"
 FROM_NAME="${FROM_NAME:-Cloudless}"
@@ -36,28 +40,26 @@ FROM_NAME="${FROM_NAME:-Cloudless}"
 : "${SMTP_USER:?SMTP_USER is required (SES SMTP IAM access key ID)}"
 : "${SMTP_PASSWORD:?SMTP_PASSWORD is required (derived SES SMTP credential)}"
 : "${FROM_EMAIL:?FROM_EMAIL is required (e.g. noreply@cloudless.gr)}"
+: "${KEYCLOAK_ADMIN_PASSWORD:?KEYCLOAK_ADMIN_PASSWORD is required}"
 
-command -v kubectl >/dev/null 2>&1 || { echo "error: kubectl not found / no cluster access"; exit 1; }
-POD=$(kubectl -n "$NAMESPACE" get pod -l app="$DEPLOYMENT" -o jsonpath='{.items[0].metadata.name}' 2>/dev/null)
-[ -n "$POD" ] || { echo "error: no $DEPLOYMENT pod in ns/$NAMESPACE"; exit 1; }
 echo "== keycloak-configure-email $(date -u '+%F %T')Z =="
-echo "pod=$POD realm=$REALM smtp_host=$SMTP_HOST:$SMTP_PORT from=$FROM_EMAIL"
+echo "url=$KEYCLOAK_URL realm=$REALM smtp_host=$SMTP_HOST:$SMTP_PORT from=$FROM_EMAIL"
 
-kubectl -n "$NAMESPACE" exec -i "$POD" -- \
-  env RL="$REALM" \
-      SH="$SMTP_HOST" SP="$SMTP_PORT" SU="$SMTP_USER" SW="$SMTP_PASSWORD" \
-      FE="$FROM_EMAIL" FN="$FROM_NAME" \
-  bash -s <<'EOS'
-set -uo pipefail
-K=/opt/keycloak/bin/kcadm.sh
-AU="${KEYCLOAK_ADMIN:-${KC_BOOTSTRAP_ADMIN_USERNAME:-admin}}"
-AP="${KEYCLOAK_ADMIN_PASSWORD:-${KC_BOOTSTRAP_ADMIN_PASSWORD:-}}"
-$K config credentials --server http://localhost:8080 --realm master --user "$AU" --password "$AP" >/dev/null 2>&1 \
-  || { echo "ADMIN_AUTH=failed"; exit 1; }
+# --- 1) Obtain admin access token ---
+TOKEN=$(curl -sf --max-time 15 \
+  -X POST "${KEYCLOAK_URL}/realms/master/protocol/openid-connect/token" \
+  -H "Content-Type: application/x-www-form-urlencoded" \
+  --data-urlencode "client_id=admin-cli" \
+  --data-urlencode "username=${KEYCLOAK_ADMIN}" \
+  --data-urlencode "password=${KEYCLOAK_ADMIN_PASSWORD}" \
+  --data-urlencode "grant_type=password" \
+  2>&1) || { echo "ADMIN_AUTH=failed (curl error: $TOKEN)"; exit 1; }
+TOKEN=$(printf '%s' "$TOKEN" | python3 -c 'import sys,json; d=json.load(sys.stdin); print(d.get("access_token",""))' 2>/dev/null || true)
+[ -n "$TOKEN" ] || { echo "ADMIN_AUTH=failed (empty token — wrong password or Keycloak unreachable)"; exit 1; }
 echo "ADMIN_AUTH=ok"
 
-# Build the SMTP JSON block (Python to handle any special chars in the password)
-SMTP_JSON=$(python3 - "$SH" "$SP" "$SU" "$SW" "$FE" "$FN" <<'PY'
+# --- 2) Build smtpServer JSON ---
+SMTP_JSON=$(python3 - "$SMTP_HOST" "$SMTP_PORT" "$SMTP_USER" "$SMTP_PASSWORD" "$FROM_EMAIL" "$FROM_NAME" <<'PY'
 import sys, json
 host, port, user, pw, from_email, from_name = sys.argv[1:]
 print(json.dumps({
@@ -77,28 +79,49 @@ print(json.dumps({
 PY
 )
 
-# Apply the smtpServer block + enable verifyEmail
-$K update "realms/$RL" -s "smtpServer=$SMTP_JSON" >/dev/null 2>&1 \
-  && echo "SMTP=configured" || { echo "SMTP=failed"; exit 1; }
+# --- 3) Apply smtpServer config to realm ---
+HTTP=$(curl -sf --max-time 15 -o /dev/null -w "%{http_code}" \
+  -X PUT "${KEYCLOAK_URL}/admin/realms/${REALM}" \
+  -H "Authorization: Bearer ${TOKEN}" \
+  -H "Content-Type: application/json" \
+  -d "{\"smtpServer\": ${SMTP_JSON}}")
+[ "$HTTP" = "204" ] && echo "SMTP=configured (HTTP 204)" \
+  || { echo "SMTP=failed (HTTP ${HTTP})"; exit 1; }
 
-$K update "realms/$RL" -s verifyEmail=true >/dev/null 2>&1 \
-  && echo "VERIFY_EMAIL=enabled" || echo "VERIFY_EMAIL=failed (non-fatal)"
+# --- 4) Enable verifyEmail on the realm ---
+HTTP=$(curl -sf --max-time 15 -o /dev/null -w "%{http_code}" \
+  -X PUT "${KEYCLOAK_URL}/admin/realms/${REALM}" \
+  -H "Authorization: Bearer ${TOKEN}" \
+  -H "Content-Type: application/json" \
+  -d '{"verifyEmail": true}')
+[ "$HTTP" = "204" ] && echo "VERIFY_EMAIL=enabled" \
+  || echo "VERIFY_EMAIL=failed (HTTP ${HTTP}) — non-fatal"
 
-# Ensure VERIFY_EMAIL required action is enabled and set as default
-# (default=true means it's automatically assigned to new registrations)
-$K update "realms/$RL/authentication/required-actions/VERIFY_EMAIL" \
-  -s enabled=true -s defaultAction=true >/dev/null 2>&1 \
-  && echo "REQUIRED_ACTION=enabled+default" || echo "REQUIRED_ACTION=update failed (non-fatal)"
+# --- 5) Enable VERIFY_EMAIL required action as default ---
+# GET current state first so we preserve all existing fields
+RA=$(curl -sf --max-time 15 \
+  "${KEYCLOAK_URL}/admin/realms/${REALM}/authentication/required-actions/VERIFY_EMAIL" \
+  -H "Authorization: Bearer ${TOKEN}" 2>/dev/null || true)
+if [ -n "$RA" ]; then
+  PATCHED=$(printf '%s' "$RA" | python3 -c \
+    'import sys,json; d=json.load(sys.stdin); d["enabled"]=True; d["defaultAction"]=True; print(json.dumps(d))')
+  HTTP=$(curl -sf --max-time 15 -o /dev/null -w "%{http_code}" \
+    -X PUT "${KEYCLOAK_URL}/admin/realms/${REALM}/authentication/required-actions/VERIFY_EMAIL" \
+    -H "Authorization: Bearer ${TOKEN}" \
+    -H "Content-Type: application/json" \
+    -d "$PATCHED")
+  [ "$HTTP" = "204" ] && echo "REQUIRED_ACTION=enabled+default" \
+    || echo "REQUIRED_ACTION=update failed (HTTP ${HTTP}) — non-fatal"
+else
+  echo "REQUIRED_ACTION=skipped (could not fetch current state)"
+fi
 
-echo "DONE"
-EOS
-
+echo ""
 echo "=== email verification configured ==="
 echo ""
 echo "What happens now:"
-echo "  1. New users who register at cloudless.gr will receive a verification email"
+echo "  1. New users who register at cloudless.gr receive a verification email"
 echo "  2. The email contains a link — clicking it verifies their account"
 echo "  3. Until verified, users cannot sign in to the application"
 echo ""
-echo "Test: register at https://cloudless.gr/auth/register with a real email address"
-echo "To test SMTP only: ./tools/keycloak-cli/keycloak.sh smtp-test"
+echo "Test: register at https://cloudless.gr/auth/register with a real email"

--- a/scripts/provision-ses-smtp.sh
+++ b/scripts/provision-ses-smtp.sh
@@ -35,6 +35,33 @@ if [ -n "$EXISTING_USER" ] && [ -n "$EXISTING_PASS" ]; then
   exit 0
 fi
 
+# 1b) Manual-bypass path: use pre-created credentials from workflow_dispatch inputs.
+#     This works without iam:CreateUser — only ssm:PutParameter is required.
+#     Run the workflow via dispatch with the credentials obtained from:
+#       AWS Console → SES → SMTP Settings → Create SMTP credentials
+MANUAL_USER="${SES_SMTP_USER_INPUT:-}"
+MANUAL_PASS="${SES_SMTP_PASSWORD_INPUT:-}"
+MANUAL_FROM="${SES_FROM_INPUT:-}"
+if [ -n "$MANUAL_USER" ] && [ -n "$MANUAL_PASS" ]; then
+  echo "→ Using pre-created SMTP credentials from workflow_dispatch inputs (skipping IAM)"
+  echo "::add-mask::$MANUAL_PASS"
+  aws ssm put-parameter --name "$P_USER" --type String --overwrite --value "$MANUAL_USER" \
+    --description "SES SMTP username — manually provisioned" >/dev/null
+  aws ssm put-parameter --name "$P_PASS" --type SecureString --overwrite --value "$MANUAL_PASS" \
+    --description "SES SMTP password (derived) — manually provisioned" >/dev/null
+  if [ -n "$MANUAL_FROM" ]; then
+    aws ssm put-parameter --name "$P_FROM" --type String --overwrite --value "$MANUAL_FROM" \
+      --description "SES verified From address — manually provisioned" >/dev/null
+    echo "  • set ${P_FROM}=${MANUAL_FROM}"
+  elif [ -z "$(ssm_get "$P_FROM")" ]; then
+    aws ssm put-parameter --name "$P_FROM" --type String --overwrite --value "$FROM_DEFAULT" \
+      --description "SES verified From address — default" >/dev/null
+    echo "  • set ${P_FROM}=${FROM_DEFAULT} (default)"
+  fi
+  echo "✓ SES SMTP credentials written to SSM (user=${MANUAL_USER}). Trigger keycloak-configure-email to apply."
+  exit 0
+fi
+
 echo "→ SES SMTP creds not in SSM; provisioning via IAM user '${IAM_USER}' (region ${REGION})"
 
 # 2) Ensure IAM user (idempotent).


### PR DESCRIPTION
## Problem

Two independent failures blocked Keycloak email verification:

1. **`provision-ses-smtp`** — OIDC role lacks `iam:CreateUser` → can't auto-create `cloudless-ses-smtp` IAM user → no SES SMTP credentials in SSM

2. **`keycloak-configure-email`** — used `kubectl exec` to run `kcadm.sh` inside the pod. When k3s API server is `ServiceUnavailable` (as it was today), this silently exits with `(no log)` even if SMTP creds were available

## Fix

### `keycloak-configure-email.sh` (rewrite)
Switched from `kubectl exec + kcadm.sh` to the **Keycloak REST admin API via `curl`**. No kubectl or cluster API server access needed — works as long as `auth.cloudless.gr` returns HTTP 200. Gets admin credentials from `KEYCLOAK_ADMIN_PASSWORD` env var.

### `keycloak-configure-email.yml`
- Dropped Tailscale and kubectl steps (no longer needed)
- Injects `KEYCLOAK_ADMIN_PASSWORD` from `ADMIN_BOOTSTRAP_PASSWORD` secret

### `provision-ses-smtp.yml`
Added `workflow_dispatch` inputs (`smtp_user`, `smtp_password`, `from_email`). When provided, the script bypasses IAM user creation entirely.

### `provision-ses-smtp.sh`
If `SES_SMTP_USER_INPUT` + `SES_SMTP_PASSWORD_INPUT` are set, writes them directly to SSM and exits — no IAM operations, only `ssm:PutParameter` required.

## How to unblock email verification now

1. **AWS Console → SES → SMTP Settings → Create SMTP credentials** — creates `cloudless-ses-smtp` IAM user, gives access key ID + SMTP password (shown once)
2. **GitHub → Actions → Provision SES SMTP → Run workflow** — paste the credentials into the inputs
3. Email config runs automatically on next push (or re-trigger manually)

https://claude.ai/code/session_012EjQpQGyt6SeSfRNNRRr6j