### PR TITLE
fix(ops): distinguish empty HC list from list-health-checks call failure

### DIFF
--- a/scripts/aws-cost-reduction.sh
+++ b/scripts/aws-cost-reduction.sh
@@ -217,11 +217,13 @@ do_r53() {
   hc_json="$(aws route53 list-health-checks --output json 2>&1)" || true
   if echo "$hc_json" | grep -qi "AccessDenied\|not authorized\|is not authorized"; then
     c_warn "  route53:ListHealthChecks denied — add it to the caller role to audit health checks."
+  elif ! echo "$hc_json" | jq -e '.HealthChecks' > /dev/null 2>&1; then
+    c_warn "  list-health-checks unexpected response: $(echo "$hc_json" | grep -m1 '.' || echo '(empty)')"
   else
     local count
-    count="$(echo "$hc_json" | jq -r '.HealthChecks | length' 2>/dev/null || echo 0)"
+    count="$(echo "$hc_json" | jq -r '.HealthChecks | length')"
     if [[ "$count" == "0" ]]; then
-      c_ok "  No health checks found in account."
+      c_ok "  No health checks found in account (sst.config.ts HC IDs e239ad5c/30a69f1c are stale)."
     else
       while IFS= read -r hc; do
         local hc_id cfg typ interval str_match


### PR DESCRIPTION
## Summary

- Run #5 showed "No health checks found in account" but we couldn't tell if `list-health-checks` succeeded (truly 0 HCs) or if `jq` silently failed on a non-JSON error response (the `|| echo 0` masked it)
- Add an explicit `jq -e '.HealthChecks'` validity check: if the response isn't valid JSON with a `.HealthChecks` key, show the raw error verbatim
- If the list is genuinely empty, note the stale `sst.config.ts` HC IDs so the finding is actionable
- Remove the now-redundant `2>/dev/null || echo 0` fallback

## Test plan

- [ ] Merge triggers Run #6
- [ ] Route 53 section will either show the actual error (if `list-health-checks` was failing silently) OR confirm "No health checks found" with the stale-ID note (if the account genuinely has 0 health checks)

https://claude.ai/code/session_01P169EPm5yifeTKoCwsvGEV


---
_Generated by [Claude Code](https://claude.ai/code/session_01P169EPm5yifeTKoCwsvGEV)_