### PR TITLE
fix(test): stub STRIPE_SECRET_KEY="" in store-products tests to prevent real Stripe calls

### DIFF
--- a/__tests__/lib-coverage-gaps.test.ts
+++ b/__tests__/lib-coverage-gaps.test.ts
@@ -83,7 +83,8 @@ describe("notion-esp32.ts", () => {
 // ── store-products.ts ─────────────────────────────────────────────────────────
 
 describe("store-products.ts", () => {
-  beforeEach(() => { vi.clearAllMocks(); vi.resetModules(); });
+  beforeEach(() => { vi.clearAllMocks(); vi.resetModules(); vi.stubEnv("STRIPE_SECRET_KEY", ""); });
+  afterEach(() => { vi.unstubAllEnvs(); });
 
   it("getProductById returns undefined for unknown id", async () => {
     const { getProductById } = await import("@/lib/store-products");

--- a/src/lib/stripe.ts
+++ b/src/lib/stripe.ts
@@ -6,10 +6,6 @@ let stripeInstance: Stripe | null = null;
 export async function getStripe(): Promise<Stripe | null> {
   if (stripeInstance) return stripeInstance;
 
-  // In test environments, skip real Stripe initialization to prevent network
-  // calls during unit tests (mirrors the ssm-config.ts NODE_ENV=test guard).
-  if (process.env.NODE_ENV === "test") return null;
-
   const config = await getConfig();
   if (!config.STRIPE_SECRET_KEY) return null;
 


### PR DESCRIPTION
## Summary

- Reverts the `NODE_ENV === "test"` guard added in #497 (it broke `stripe-lib.test.ts`)
- Instead, adds `vi.stubEnv("STRIPE_SECRET_KEY", "")` in the `store-products.ts` describe block's `beforeEach` so the "not configured" tests genuinely test the no-Stripe path without making real API calls
- Adds matching `afterEach(() => vi.unstubAllEnvs())` to clean up

## Root cause

`lib-coverage-gaps.test.ts`'s `store-products.ts` describe block didn't clear `STRIPE_SECRET_KEY`, so when it's present in the runner environment the tests hit the live Stripe API and time out. `stripe-lib.test.ts` correctly mocks both `ssm-config` and `stripe` so it's unaffected.

## Test plan

- [ ] All tests in `lib-coverage-gaps.test.ts` pass — `getProducts` and `getProductByIdAsync` tests run in ~1ms
- [ ] All tests in `stripe-lib.test.ts` pass — `getStripe` instance and `listRecentCheckoutSessions` tests unaffected

https://claude.ai/code/session_01PHsA9s3tK2thgSJVwEGuWq

---
_Generated by [Claude Code](https://claude.ai/code/session_01PHsA9s3tK2thgSJVwEGuWq)_