### PR TITLE
feat(ops): domain-decommission toolkit + skill (retire cloudless.online safely)

### DIFF
--- a/.claude/skills/domain-decommission/SKILL.md
+++ b/.claude/skills/domain-decommission/SKILL.md
@@ -1,0 +1,78 @@
+---
+name: domain-decommission
+description: Safely retire a domain's cloud footprint — Route 53 health checks + Cloudflare DNS records — and silence the monitors that still probe it. Use when a domain has been migrated away (e.g. cloudless.online → cloudless.gr) and is still generating DNS-change / health-check alerts, or the user says "retire cloudless.online", "stop the DNS alerts", "decommission the old domain", "clean up the dead domain". Drives the cleanup through a path-triggered GitHub workflow (OIDC + SSM) that reports to issue #382; report-only by default.
+argument-hint: "domain to retire, e.g. cloudless.online"
+---
+
+# Domain decommission — cloudless.gr
+
+Retire a migrated-away domain's **Route 53 health checks** and **Cloudflare DNS
+records** from a session with no AWS/Cloudflare console — the same OIDC + SSM +
+issue-#382 pattern as the rest of the ops tooling here. Report-only by default;
+deletes only on an explicit `apply`.
+
+## Why this exists
+
+`cloudless.online` was migrated to `cloudless.gr` and its DNS delegation pulled,
+but leftover **Route 53 health checks**, **Cloudflare DNS records**, and
+**in-cluster monitors** that still probe it keep firing DNS-change /
+health-check alerts. This toolkit retires the AWS + Cloudflare side cleanly.
+
+## The single most important safety rule
+
+**Never delete a health check by a hardcoded id.** The id
+`30a69f1c-8d48-49bd-9067-cabec979478b` is the **cloudless.gr HA *secondary*
+(Pi/APIGW failover) health check** defined in `sst.config.ts` — it belongs to
+the *active* cloudless.gr failover, not cloudless.online. Deleting it breaks
+cloudless.gr's failover to the Pi. The `omv-ha` cleanup tool hardcodes this id;
+**ours does not** — it matches health checks by `FullyQualifiedDomainName`
+ending in the target domain, and hard-guards that id (see `PROTECTED_HEALTH_CHECKS`).
+
+## Tools (in repo)
+
+| Command / Workflow | What it does |
+| --- | --- |
+| `pnpm domain:decommission` (`scripts/domain-decommission.sh`) | Report (default) or apply. Lists/deletes Route 53 health checks whose FQDN is `$DOMAIN` (or `*.{DOMAIN}`), and Cloudflare DNS records in `$DOMAIN`'s zone. Scoped by name; protected ids are skipped. `DOMAIN=`, `MODE=report\|apply`, `CONFIRM=1`. |
+| `.github/workflows/domain-decommission.yml` | Runs it on a hosted runner via OIDC (`AWS_DEPLOY_ROLE_ARN`), reads `CLOUDFLARE_API_TOKEN` from SSM, posts the result to **#382**. `workflow_dispatch` inputs `domain` + `apply`; a push to the workflow/script is **report-only**. |
+
+## Run order
+
+1. **Report first.** Dispatch `domain-decommission.yml` with `apply=false`
+   (or merge a touch to the script — push is always report-only). Read the
+   `#382` comment: it lists every Route 53 health check + Cloudflare record
+   scoped to the domain, and flags the protected id.
+2. **Confirm the list is correct** — every FQDN/record is genuinely the retired
+   domain, and the protected cloudless.gr secondary is shown as *skipped*.
+3. **Apply.** Dispatch again with `apply=true` (→ `MODE=apply CONFIRM=1`). It
+   deletes only the listed, non-protected resources and re-reports to #382.
+
+## Prerequisites / gotchas
+
+- **AWS:** the OIDC deploy role needs `route53:ListHealthChecks` (report) and
+  `route53:DeleteHealthCheck` (apply). Per `aws-iam-audit`, health-check
+  deletion historically needed a temporary inline-policy escalation on
+  `cloudless-ops-role` — if apply returns `AccessDenied`, grant
+  `route53:DeleteHealthCheck` (and revoke after).
+- **Cloudflare:** set `/cloudless/production/CLOUDFLARE_API_TOKEN` (scoped
+  `Zone:Read` + `Zone.DNS:Edit`) in SSM. Without it the Cloudflare step skips
+  with a warning (Route 53 still runs). The `cloudless.online` ACM cert is
+  Cloudflare-owned and **cannot** be deleted by us — leave it (see aws-iam-audit).
+- **In-cluster monitors live elsewhere.** The probes that actually generate the
+  recurring alerts are in **other repos**, not cloudless.gr:
+  - `omv-ha` → `k8s/health-monitor/health-monitor.yaml` (curls
+    `https://cloudless.online/api/health` → the `health-monitor` / `cluster-health-check`
+    Error pods).
+  - `OMV` → `docs/phase1-acceptance.md` uptime-kuma monitor on the same URL.
+  - `raspberry-pi-monitoring-stack` → Grafana dashboards referencing the CF zone,
+    and most likely the DNS-record snapshot monitor that emits the "DNS changes
+    detected" alerts.
+  This toolkit can't reach those (GitHub scope = cloudless.gr). Clean them in
+  their own repo/session, or via the `omv-ha` `cloudless-infra` MCP.
+
+## Reading results
+
+```
+mcp__github__issue_read(method="get_comments", owner="Themis128",
+  repo="cloudless.gr", issue_number=382)
+```
+The newest "Domain decommission —" comment is the latest run.

--- a/.github/workflows/domain-decommission.yml
+++ b/.github/workflows/domain-decommission.yml
@@ -1,0 +1,82 @@
+name: Domain decommission (Route 53 + Cloudflare)
+
+# Retire a domain's Route 53 health checks + Cloudflare DNS records, scoped
+# strictly to that domain. Built to wind down cloudless.online (migrated to
+# cloudless.gr) and stop the recurring DNS-monitor alerts.
+#
+# SAFE BY DEFAULT: a push to this file / the script runs in REPORT mode (lists
+# what would be removed, deletes nothing). To actually delete, dispatch with
+# apply=true — and even then the protected cloudless.gr HA secondary health
+# check (30a69f1c) is never touched (guarded in the script).
+#
+# Auth: OIDC deploy role (AWS_DEPLOY_ROLE_ARN) for Route 53; CLOUDFLARE_API_TOKEN
+# read from SSM /cloudless/production/* for the DNS-record cleanup.
+
+on:
+  workflow_dispatch:
+    inputs:
+      domain:
+        description: "Domain to decommission"
+        required: false
+        default: "cloudless.online"
+      apply:
+        description: "Actually delete (true) or report only (false)"
+        type: boolean
+        required: false
+        default: false
+  push:
+    branches: [main]
+    paths:
+      - ".github/workflows/domain-decommission.yml"
+      - "scripts/domain-decommission.sh"
+
+permissions:
+  id-token: write
+  contents: read
+  issues: write
+
+concurrency:
+  group: domain-decommission
+  cancel-in-progress: false
+
+jobs:
+  decommission:
+    runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ github.token }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v4.3.1
+
+      - name: Configure AWS credentials (OIDC)
+        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4
+        with:
+          role-to-assume: ${{ secrets.AWS_DEPLOY_ROLE_ARN }}
+          aws-region: us-east-1
+
+      - name: Decommission
+        id: run
+        env:
+          AWS_REGION: us-east-1
+          # push trigger → always report-only; dispatch → honour the apply input.
+          DOMAIN: ${{ github.event.inputs.domain || 'cloudless.online' }}
+          MODE: ${{ github.event.inputs.apply == 'true' && 'apply' || 'report' }}
+          CONFIRM: ${{ github.event.inputs.apply == 'true' && '1' || '0' }}
+        run: |
+          set -o pipefail
+          bash scripts/domain-decommission.sh 2>&1 | tee decommission.log
+
+      - name: Post result to tracking issue
+        if: always()
+        run: |
+          {
+            echo "# Domain decommission — $(date -u '+%F %T')Z"
+            echo ""
+            echo "**Domain:** ${{ github.event.inputs.domain || 'cloudless.online' }}"
+            echo "**Mode:** ${{ github.event.inputs.apply == 'true' && 'apply (deletes)' || 'report-only' }}"
+            echo "**Job:** ${{ job.status }}"
+            echo ""
+            echo '```'
+            cat decommission.log 2>/dev/null || echo '(no log)'
+            echo '```'
+          } > c.md
+          gh issue comment 382 --repo "${{ github.repository }}" --body-file c.md

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "notion:test": "tsx --tsconfig scripts/tsconfig.json scripts/notion-test.ts",
     "gh:secrets": "tsx --tsconfig scripts/tsconfig.json scripts/gh-secrets.ts",
     "ses:provision": "tsx --tsconfig scripts/tsconfig.json scripts/provision-ses-smtp.ts",
+    "domain:decommission": "bash scripts/domain-decommission.sh",
     "gsc:sync": "tsx --tsconfig scripts/tsconfig.json scripts/weekly-gsc-sync.ts",
     "newsletter:draft": "tsx --tsconfig scripts/tsconfig.json scripts/generate-weekly-article.ts",
     "newsletter:send": "tsx --tsconfig scripts/tsconfig.json scripts/publish-and-send-newsletter.ts",

--- a/scripts/domain-decommission.sh
+++ b/scripts/domain-decommission.sh
@@ -1,0 +1,127 @@
+#!/usr/bin/env bash
+#
+# domain-decommission.sh — safely retire a domain's AWS Route 53 health checks
+# and Cloudflare DNS records, scoped strictly to that domain.
+#
+# Built to retire cloudless.online (migrated to cloudless.gr) without the recurring
+# DNS-monitor alerts, but generalised: pass DOMAIN=<zone> for any domain.
+#
+# SAFETY (read this before changing anything):
+#   - DISCOVERY-FIRST. Default MODE=report only lists what *would* be removed;
+#     nothing is deleted unless MODE=apply AND CONFIRM=1.
+#   - SCOPED BY NAME. Route 53 health checks are matched by their
+#     FullyQualifiedDomainName ending in the target DOMAIN; Cloudflare records are
+#     matched by the DOMAIN's own zone. We never delete by a hardcoded id.
+#   - PROTECTED IDS. The cloudless.gr HA *secondary* health check
+#     30a69f1c-8d48-49bd-9067-cabec979478b (SECONDARY=Pi/APIGW failover, see
+#     sst.config.ts / docs/cluster-overload-runbook.md) is NEVER deletable here —
+#     it belongs to the ACTIVE cloudless.gr failover, not cloudless.online.
+#
+# Credentials (supplied by domain-decommission.yml in CI):
+#   - AWS: OIDC deploy role (route53:ListHealthChecks + DeleteHealthCheck for apply).
+#   - Cloudflare: CLOUDFLARE_API_TOKEN, read from SSM /cloudless/production/* or env.
+set -uo pipefail
+
+DOMAIN="${DOMAIN:-cloudless.online}"
+MODE="${MODE:-report}"           # report | apply
+CONFIRM="${CONFIRM:-0}"          # apply requires CONFIRM=1
+AWS_REGION="${AWS_REGION:-us-east-1}"
+
+# Health-check ids that must never be deleted by this tool, with reason.
+PROTECTED_HEALTH_CHECKS="30a69f1c-8d48-49bd-9067-cabec979478b"  # cloudless.gr HA secondary
+
+is_apply() { [ "$MODE" = "apply" ] && [ "$CONFIRM" = "1" ]; }
+log() { echo "[decommission:${DOMAIN}] $*"; }
+
+log "mode=$MODE confirm=$CONFIRM (apply deletes only when MODE=apply + CONFIRM=1)"
+command -v aws >/dev/null 2>&1 || { log "WARN: aws CLI not found — skipping Route 53"; }
+command -v jq  >/dev/null 2>&1 || { log "ERROR: jq required"; exit 1; }
+
+# ---------------------------------------------------------------------------
+# 1) Route 53 health checks scoped to this domain
+# ---------------------------------------------------------------------------
+r53_deleted=0; r53_found=0
+if command -v aws >/dev/null 2>&1; then
+  HC_JSON="$(aws route53 list-health-checks --output json 2>/tmp/r53.err || true)"
+  if [ -z "$HC_JSON" ]; then
+    log "Route 53: list-health-checks returned nothing — $(tr '\n' ' ' </tmp/r53.err)"
+  else
+    # Match health checks whose FQDN is the domain or a subdomain of it.
+    mapfile -t HCS < <(printf '%s' "$HC_JSON" | jq -r --arg d "$DOMAIN" '
+      .HealthChecks[]
+      | select((.HealthCheckConfig.FullyQualifiedDomainName // "")
+               | ascii_downcase | (. == $d or endswith("." + $d)))
+      | "\(.Id)\t\(.HealthCheckConfig.FullyQualifiedDomainName)\t\(.HealthCheckConfig.Type)"')
+    for row in "${HCS[@]:-}"; do
+      [ -z "$row" ] && continue
+      id="${row%%	*}"; rest="${row#*	}"; fqdn="${rest%%	*}"
+      r53_found=$((r53_found+1))
+      if printf '%s' "$PROTECTED_HEALTH_CHECKS" | grep -qw "$id"; then
+        log "Route 53: PROTECTED health check $id ($fqdn) — skipping (cloudless.gr failover)"
+        continue
+      fi
+      if is_apply; then
+        if aws route53 delete-health-check --health-check-id "$id" 2>/tmp/del.err; then
+          log "Route 53: DELETED health check $id ($fqdn)"; r53_deleted=$((r53_deleted+1))
+        else
+          log "Route 53: delete $id FAILED — $(tr '\n' ' ' </tmp/del.err)"
+        fi
+      else
+        log "Route 53: would delete health check $id ($fqdn) [report-only]"
+      fi
+    done
+    [ "$r53_found" -eq 0 ] && log "Route 53: no health checks scoped to $DOMAIN"
+  fi
+fi
+
+# ---------------------------------------------------------------------------
+# 2) Cloudflare DNS records in this domain's zone
+# ---------------------------------------------------------------------------
+cf_deleted=0; cf_found=0
+CF_TOKEN="${CLOUDFLARE_API_TOKEN:-}"
+if [ -z "$CF_TOKEN" ] && command -v aws >/dev/null 2>&1; then
+  CF_TOKEN="$(aws ssm get-parameter --name /cloudless/production/CLOUDFLARE_API_TOKEN \
+              --with-decryption --query 'Parameter.Value' --output text 2>/dev/null || true)"
+fi
+if [ -z "$CF_TOKEN" ]; then
+  log "Cloudflare: no CLOUDFLARE_API_TOKEN (env or SSM) — skipping DNS-record cleanup."
+  log "Cloudflare: set /cloudless/production/CLOUDFLARE_API_TOKEN (Zone:DNS:Edit, Zone:Read) to enable."
+else
+  cf() { curl -fsS -H "Authorization: Bearer $CF_TOKEN" -H "Content-Type: application/json" "$@"; }
+  ZONE_ID="$(cf "https://api.cloudflare.com/client/v4/zones?name=${DOMAIN}" 2>/dev/null \
+             | jq -r '.result[0].id // empty')"
+  if [ -z "$ZONE_ID" ]; then
+    log "Cloudflare: no zone found for $DOMAIN (already removed, or token lacks Zone:Read)."
+  else
+    log "Cloudflare: zone $DOMAIN = $ZONE_ID"
+    mapfile -t RECS < <(cf "https://api.cloudflare.com/client/v4/zones/${ZONE_ID}/dns_records?per_page=100" 2>/dev/null \
+                        | jq -r '.result[] | "\(.id)\t\(.type)\t\(.name)"')
+    for row in "${RECS[@]:-}"; do
+      [ -z "$row" ] && continue
+      rid="${row%%	*}"; rest="${row#*	}"; rtype="${rest%%	*}"; rname="${rest##*	}"
+      cf_found=$((cf_found+1))
+      if is_apply; then
+        if cf -X DELETE "https://api.cloudflare.com/client/v4/zones/${ZONE_ID}/dns_records/${rid}" >/dev/null 2>&1; then
+          log "Cloudflare: DELETED $rtype $rname ($rid)"; cf_deleted=$((cf_deleted+1))
+        else
+          log "Cloudflare: delete $rtype $rname FAILED"
+        fi
+      else
+        log "Cloudflare: would delete $rtype $rname ($rid) [report-only]"
+      fi
+    done
+    [ "$cf_found" -eq 0 ] && log "Cloudflare: zone $DOMAIN has no DNS records"
+  fi
+fi
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+log "──────── summary for $DOMAIN ────────"
+log "Route 53 health checks: found=$r53_found deleted=$r53_deleted"
+log "Cloudflare DNS records: found=$cf_found deleted=$cf_deleted"
+if ! is_apply; then
+  log "REPORT-ONLY. Re-run with MODE=apply CONFIRM=1 (or the workflow's apply=true input) to delete."
+fi
+log "NOTE: in-cluster monitors that probe $DOMAIN (omv-ha k8s/health-monitor.yaml, OMV"
+log "      uptime-kuma) live in other repos — clean them there; this tool only handles R53 + Cloudflare."


### PR DESCRIPTION
## Tools + skill to retire `cloudless.online` safely

You asked for the tooling to address the cloudless.online cleanup. Built into `cloudless.gr` (which I can edit), following the repo's OIDC + SSM + issue-#382 pattern:

**`scripts/domain-decommission.sh`** — `report` (default) / `apply`. Deletes **only** Route 53 health checks whose `FullyQualifiedDomainName` is the target domain (or `*.domain`) and Cloudflare DNS records in that domain's zone. Discovery-first, idempotent.

**`.github/workflows/domain-decommission.yml`** — OIDC (`AWS_DEPLOY_ROLE_ARN`) for Route 53, `CLOUDFLARE_API_TOKEN` from SSM for Cloudflare; posts to **#382**. `workflow_dispatch` inputs `domain` + `apply`; a **push is report-only** (safe).

**`.claude/skills/domain-decommission/SKILL.md`** — the playbook + safety rules.

**`package.json`** — `pnpm domain:decommission`.

### The key safety improvement over the existing omv-ha tool
The `omv-ha` cleanup **hardcodes deleting health-check `30a69f1c`** — but that id is the **cloudless.gr HA *secondary* (Pi/APIGW failover) check** (`sst.config.ts`, `docs/cluster-overload-runbook.md`). Deleting it breaks cloudless.gr failover. This tool **matches by FQDN** and **hard-guards that id** (`PROTECTED_HEALTH_CHECKS`), so it can't.

### Behaviour
- **Default = report-only**, deletes nothing. Merging this fires the workflow in report mode → lists the real cloudless.online R53/CF resources to #382.
- **Apply** requires `workflow_dispatch` with `apply=true`.
- Cloudflare step needs `/cloudless/production/CLOUDFLARE_API_TOKEN` in SSM (skips with a warning otherwise; R53 still runs).
- In-cluster monitors (omv-ha `health-monitor.yaml`, OMV uptime-kuma, raspberry-pi-monitoring-stack) live in other repos — documented in the skill; out of this repo's scope.

- [x] `bash -n` + `py`/`yaml` validated; report-mode dry-run is a safe no-op

https://claude.ai/code/session_016PrzZJMNxsgiEmvedfkru6

---
_Generated by [Claude Code](https://claude.ai/code/session_016PrzZJMNxsgiEmvedfkru6)_