### PR TITLE
ops: cluster recovery tools & skills — SSH restart, watchdog, email setup

### DIFF
--- a/.claude/skills/cluster-incident-response/SKILL.md
+++ b/.claude/skills/cluster-incident-response/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: cluster-incident-response
-description: Diagnose and recover omv k3s cluster outages from a cloud session that has NO kubectl/ssh/aws. Use when auth.cloudless.gr returns 503, a pod is OOMKilled/CrashLoopBackOff, login is down, PrometheusRuleFailures fires, or the user says "fix what's broken on the cluster", "is the cluster healthy", "recover Keycloak". Drives cluster ops through path-triggered GitHub workflows (hosted runner + Tailscale + KUBECONFIG_B64) that post diagnostics to issue #382, plus the cluster:doctor / keycloak:smoke / keycloak:restore scripts.
-argument-hint: "what's broken, e.g. 'keycloak 503' or 'PrometheusRuleFailures'"
+description: Diagnose and recover omv k3s cluster outages from a cloud session that has NO kubectl/ssh/aws. Use when auth.cloudless.gr returns 503, a pod is OOMKilled/CrashLoopBackOff, login is down, PrometheusRuleFailures fires, PrometheusKubernetesListWatchFailures fires, k3s API server is down, or the user says "fix what's broken on the cluster", "is the cluster healthy", "recover Keycloak". Drives cluster ops through path-triggered GitHub workflows (hosted runner + Tailscale + KUBECONFIG_B64) that post diagnostics to issue #382.
+argument-hint: "what's broken, e.g. 'keycloak 503', 'PrometheusRuleFailures', 'PrometheusKubernetesListWatchFailures', 'k3s API server down'"
 ---
 
 # Cluster Incident Response — cloudless.gr (omv k3s)
@@ -44,55 +44,76 @@ offline during cluster incidents and the job queues forever).
 | `.github/workflows/restore-keycloak.yml` | Runs `keycloak:restore` on a hosted runner, posts the log to #382. Trigger by editing the workflow file. |
 | `pnpm prometheus:tune` (`scripts/prometheus-tune.sh`) | Deletes the heavy kube-apiserver SLO/burnrate/availability PrometheusRules that time out and trip `PrometheusRuleFailures`; reports remaining failing rules. |
 | `.github/workflows/prometheus-tune.yml` | Runs `prometheus:tune` on a hosted runner, posts the log to #382. Trigger by editing the workflow file. |
-| `pnpm keycloak:ensure` (`scripts/keycloak-ensure.sh`) | **Self-heal**: idempotent reconciler that restores auth to its known-good state — OOM-recovers Keycloak (768Mi + `-Xmx512m`), fixes realm flags + the cloudless-app `groups` mapper (`full.path=false`) + admin group/membership, **and restores the Pi `cloudless` app's auth wiring** (`cloudless-app-auth` secret + `envFrom`: AUTH_SECRET/KEYCLOAK_*(realm master)/AUTH_TRUST_HOST/AUTH_URL, via `wire-pi-keycloak.sh`) if it stops serving the keycloak provider. Reports only what it `CORRECTED`. |
-| `.github/workflows/keycloak-ensure.yml` | Runs `keycloak:ensure` on a **cron (`*/15`)** + dispatch + push; posts to #382 only when it corrects drift or auth is still broken (silent on healthy runs). This is the auto-recovery that brings auth back to the last working condition. |
+| `pnpm keycloak:ensure` (`scripts/keycloak-ensure.sh`) | **Self-heal**: idempotent reconciler that restores auth to its known-good state — OOM-recovers Keycloak (768Mi + `-Xmx512m`), fixes realm flags + the cloudless-app `groups` mapper (`full.path=false`) + admin group/membership, **and restores the Pi `cloudless` app's auth wiring** (`cloudless-app-auth` secret + `envFrom`). Reports only what it `CORRECTED`. |
+| `.github/workflows/keycloak-ensure.yml` | Runs `keycloak:ensure` on a **cron (`*/15`)** + dispatch + push; posts to #382 only when it corrects drift or auth is still broken (silent on healthy runs). |
+| `.github/workflows/k3s-ssh-restart.yml` | **SSH-based k3s restart** — runs on `ubuntu-latest`, connects via Tailscale, SSHes to Pi with `OMV_SSH_KEY` secret, restarts k3s, waits for port 6443, posts result to #382. Requires `OMV_SSH_KEY` repo secret. |
+| `.github/workflows/k3s-restart.yml` | **Runner-based k3s restart** — runs on `[self-hosted, omv, build]`. Only works when the Pi host is up but the runner is alive. Falls back to queued-forever when Pi is down. Prefer `k3s-ssh-restart.yml`. |
+| `.github/workflows/k3s-watchdog-deploy.yml` | Deploys `scripts/k3s-watchdog-install.sh` to the Pi via SSH — installs a systemd override (`Restart=always`, no start limit) so k3s auto-recovers without manual intervention. |
 
 ## Triage workflow
 
 1. **See the cluster** — fire `cluster-doctor` (edit `scripts/cluster-doctor.sh`
    → PR → squash-merge), wait ~2 min, read #382. Never guess pod state; the
    doctor is your eyes.
-2. **Classify** the broken pod: `OOMKilled (exit 137)` = memory; `Error/Completed`
-   = app/config; `CrashLoopBackOff` with probe `connection refused` = process
-   never reaches ready (often still OOM during startup).
+2. **Classify the failure mode** — see decision table below.
 3. **Apply the fix** by editing the relevant manifest/script and re-triggering
-   the workflow (path filter). Read the posted log to confirm it stuck (the
-   restore script prints `before / immediately-after / +15s revert-check`).
+   the workflow (path filter). Read the posted log to confirm it stuck.
 4. **Verify** end-to-end (`keycloak:smoke`, or curl the discovery endpoint).
+
+## Failure mode decision table
+
+| Symptom | Likely cause | Tool |
+|---|---|---|
+| `auth.cloudless.gr` HTTP 503 | Keycloak pod OOMKilled / CrashLoop | `keycloak:restore` → `keycloak:smoke` |
+| `auth.cloudless.gr` HTTP 000000 (no TCP) | k3s API server down AND cloudflared tunnel broken | `k3s-ssh-restart` → re-doctor |
+| Doctor: `connection refused` on `100.113.41.119:6443` | k3s API server process not listening — Pi host is UP (TCP RST means host is reachable via Tailscale), k3s service has stopped | `k3s-ssh-restart.yml` (if `OMV_SSH_KEY` set) or physical intervention |
+| Doctor: `ServiceUnavailable` on `100.113.41.119:6443` | k3s API server starting / overloaded / etcd under pressure | Wait 2–5 min and re-doctor; if persistent, `k3s-ssh-restart.yml` |
+| Doctor: all kubectl = `connection refused` AND runner job queued forever | Pi host is completely down (power loss / kernel panic) | Physical access or out-of-band reboot |
+| `PrometheusRuleFailures` alert | Heavy `kube-apiserver-burnrate.rules` group timing out | `pnpm prometheus:tune` |
+| `PrometheusKubernetesListWatchFailures` alert | Prometheus cannot list-watch the k8s API server — **almost always means the k3s API server is down** | Run doctor first; if API down → `k3s-ssh-restart.yml` |
+| Pod `OOMKilled` (exit 137) | Memory limit too low | Raise limit via `kubectl patch` in a cluster-remediate style workflow |
+| Pod `CrashLoopBackOff` + probe `connection refused` | Usually still OOMing during startup | Same as OOMKilled |
+
+## Distinguishing `PrometheusRuleFailures` from `PrometheusKubernetesListWatchFailures`
+
+These are **two different alerts** requiring different fixes:
+
+- **`PrometheusRuleFailures`** = Prometheus is running and can talk to the API server, but a specific alerting rule fails to evaluate (e.g. `kube-apiserver-burnrate.rules` — multi-day `rate()` over high-cardinality metrics → `context deadline exceeded`). Fix: `pnpm prometheus:tune`.
+
+- **`PrometheusKubernetesListWatchFailures`** = Prometheus pod is running but cannot reach the Kubernetes API server to discover/watch resources (`GET /api/v1/nodes`, `/api/v1/pods`, etc. all fail). The alert fires from inside the cluster (pod IP `10.42.x.x`), which means pods are still running, but the k3s API server process has crashed or is returning `ServiceUnavailable`. Fix: restart k3s.
+
+## Decoding `connection refused` vs `ServiceUnavailable`
+
+| Error | What it means |
+|---|---|
+| `dial tcp 100.113.41.119:6443: connect: connection refused` | Pi host is reachable via Tailscale (TCP RST received), but nothing is listening on port 6443 — k3s server process has stopped |
+| `Error from server (ServiceUnavailable): the server is currently unable to handle the request` | k3s is listening but the API server is overloaded or starting up — may self-recover in 2–5 min |
+| `connection timed out` or no response | Pi host itself unreachable — Tailscale on Pi may be down, or Pi lost power/network |
+
+## SSH recovery path (requires `OMV_SSH_KEY` repo secret)
+
+The most reliable recovery when k3s is down. Requires `OMV_SSH_KEY` (the Pi's
+private key, base64-encoded or raw) stored as a GitHub repo secret.
+
+**Add the secret once:**
+1. Go to GitHub → Settings → Secrets → Actions → New repository secret
+2. Name: `OMV_SSH_KEY`
+3. Value: the private key for `omv@100.113.41.119` (same key as `OMV_SSH_KEY_CONTENTS` in the Claude Code session secrets)
+
+**Trigger the restart:** edit `.github/workflows/k3s-ssh-restart.yml` → PR → squash-merge. The workflow SSHes in, restarts k3s, waits for port 6443, and posts the result to #382.
 
 ## Hard-won lessons (do not relearn these the hard way)
 
 - **Never cap a JVM container below its `-Xmx` + non-heap working set.** Keycloak
-  26.2 (Quarkus) needs heap **plus ~180–220 MiB** non-heap (metaspace, threads,
-  code cache, GC, startup augmentation). A 384 MiB cap on a `-Xmx512m` heap →
-  `OOMKilled` crash-loop → `auth.cloudless.gr` 503. Size the container to the
-  heap (512 MiB heap → 768 MiB limit). Actual RSS is ~500 MiB regardless of the
-  ceiling, and a higher *limit* does not raise real usage — it only stops the
-  kernel OOMKill.
-- **Keycloak's operative heap variable is `JAVA_OPTS_APPEND`, not
-  `JAVA_OPTS_KC_HEAP`.** Patching the wrong one is a silent no-op. Verify with
-  the doctor's deploy `env` dump.
-- **`kubectl apply -f <manifest>` from CI did not stick** while a direct
-  `kubectl patch` did — and the deploy's `last-applied-configuration` revealed
-  the apply never reached it. Prefer a direct strategic-merge **patch** of the
-  single object for recovery; confirm with a revert-check (re-read after 15 s).
-- **error=Configuration on a GET to `/api/auth/signin/keycloak` is NOT a bug.**
-  next-auth's real flow is **POST + CSRF**; that returns `302 → auth.cloudless.gr/
-  …/openid-connect/auth?…code_challenge_method=S256`. Always test login with the
-  POST+CSRF flow, not a bare GET.
-- **`PrometheusRuleFailures` is usually a specific broken rule, not memory** —
-  but check first: the doctor shows the prometheus pod restarts/OOM and the
-  failing rule's `lastError`. Only raise Prometheus's memory if it is actually
-  OOMing. The known offender here is the kube-prometheus-stack
-  **`kube-apiserver-burnrate.rules`** group (e.g. `apiserver_request:burnrate3d`):
-  multi-day `rate()` over high-cardinality `apiserver_request_total` →
-  `expanding series: context deadline exceeded`. Fix with `pnpm prometheus:tune`
-  (deletes the heavy apiserver SLO/burnrate/availability rule groups — unused on
-  this homelab). Durable fix: Helm values
-  `defaultRules.rules.kubeApiserverBurnrate/Availability/Slos: false`.
-- **Watch omv memory.** Node limits are oversubscribed (>130%); raising one
-  pod's ceiling is fine (limits ≠ usage) but confirm `MemoryPressure: False`
-  and node memory headroom in the doctor before/after.
+  26.2 (Quarkus) needs heap **plus ~180–220 MiB** non-heap. A 384 MiB cap on a
+  `-Xmx512m` heap → `OOMKilled` crash-loop. Size: 512 MiB heap → 768 MiB limit.
+- **Keycloak's operative heap variable is `JAVA_OPTS_APPEND`, not `JAVA_OPTS_KC_HEAP`.** Patching the wrong one is a silent no-op.
+- **`kubectl apply -f <manifest>` from CI did not stick** while a direct `kubectl patch` did. Prefer strategic-merge patch for recovery.
+- **`error=Configuration` on a GET to `/api/auth/signin/keycloak` is NOT a bug.** Real login is POST+CSRF → `302` with `code_challenge_method=S256`.
+- **`PrometheusRuleFailures` ≠ `PrometheusKubernetesListWatchFailures`.** See decision table above. Running `pnpm prometheus:tune` does nothing for list-watch failures.
+- **`[self-hosted, omv, build]` runners are systemd services on the Pi host**, not k8s pods. They survive k3s crashes — but they also go offline when the Pi itself crashes or loses power. If the job queues for >2 min, the Pi is down.
+- **The watchdog is the durable fix.** Run `k3s-watchdog-deploy.yml` once to install `Restart=always` on the k3s systemd unit. This auto-recovers k3s crashes without any manual intervention.
+- **`PrometheusKubernetesListWatchFailures` self-resolves** once k3s API server is back up — Prometheus reconnects automatically within a few minutes.
 
 ## Reading results
 
@@ -104,10 +125,7 @@ Comments are chronological; the newest snapshot/log is the last page.
 
 ## Reference
 
-- Incident writeup & memory math: `docs/cluster-memory-relief-2026-05-31.md`
-  (the "Correction (2026-06-01)" section).
-- Keycloak deploy: ns `keycloak`, deploy `keycloak`, image
-  `quay.io/keycloak/keycloak:26.2`, fronted by a Cloudflare tunnel (503 "no
-  available server" = origin/pod down).
-- App login path: CloudFront → Lambda (primary) and the Pi origin both serve
-  `/api/auth/*`; both hand off to Keycloak correctly once it is up.
+- Keycloak deploy: ns `keycloak`, deploy `keycloak`, image `quay.io/keycloak/keycloak:26.2`, fronted by a Cloudflare tunnel.
+- Pi control-plane: `omv` / `192.168.1.128` / Tailscale `100.113.41.119`. k3s kubeconfig: `/etc/rancher/k3s/k3s.yaml`.
+- App login path: CloudFront → Lambda (primary) + Pi origin both serve `/api/auth/*`; both hand off to Keycloak once it is up.
+- Incident 2026-06-01: Keycloak OOM (384Mi → 768Mi fix). Incident 2026-06-02: k3s API server crash → `PrometheusKubernetesListWatchFailures` + `auth.cloudless.gr` 000000.

--- a/.claude/skills/ses-email-setup/SKILL.md
+++ b/.claude/skills/ses-email-setup/SKILL.md
@@ -1,0 +1,129 @@
+---
+name: ses-email-setup
+description: Set up AWS SES SMTP credentials and configure Keycloak email verification for cloudless.gr. Use when email verification is broken, new users don't receive verification emails, the provision-ses-smtp workflow is failing, keycloak-configure-email is failing, or the user asks to "enable email verification", "set up SES SMTP", "configure Keycloak email", or "fix email not sending". Covers both the automated (iam:CreateUser) and manual (dispatch inputs) credential paths.
+---
+
+# SES SMTP + Keycloak Email Verification — cloudless.gr
+
+Keycloak sends email verification messages to new registrations via **AWS SES SMTP**.
+Two workflows handle the setup end-to-end:
+
+| Workflow | Script | What it does |
+|---|---|---|
+| `provision-ses-smtp.yml` | `scripts/provision-ses-smtp.sh` | Creates SES SMTP credentials (IAM user OR manual bypass) and writes them to SSM |
+| `keycloak-configure-email.yml` | `scripts/keycloak-configure-email.sh` | Reads creds from SSM and applies SMTP config + `verifyEmail` to the Keycloak realm via REST admin API |
+
+## SSM parameters
+
+All three must exist for email to work:
+
+| Parameter | Type | Value |
+|---|---|---|
+| `/cloudless/production/SES_SMTP_USER` | String | IAM access key ID (looks like `AKIA…`) |
+| `/cloudless/production/SES_SMTP_PASSWORD` | SecureString | Derived SES SMTP credential (NOT the raw IAM secret key) |
+| `/cloudless/production/SES_FROM_EMAIL` | String | Verified sender address, e.g. `noreply@cloudless.gr` |
+
+## Path A — Automated (requires `iam:CreateUser` on the deploy role)
+
+Trigger by pushing a change to `provision-ses-smtp.yml` or `scripts/provision-ses-smtp.sh`.
+The workflow uses the OIDC deploy role to create an IAM user `cloudless-ses-smtp`,
+mint an access key, derive the SMTP password, and write all three SSM params.
+
+**Currently blocked**: the OIDC role (`GitHubActionsOIDC`) lacks `iam:CreateUser`.
+To unblock, add these permissions to the deploy role in IAM:
+```
+iam:GetUser, iam:CreateUser, iam:PutUserPolicy,
+iam:ListAccessKeys, iam:CreateAccessKey, iam:DeleteAccessKey
+```
+
+## Path B — Manual bypass (no extra IAM permissions needed)
+
+Use this path when the OIDC role lacks `iam:CreateUser` or when you already have
+SES SMTP credentials from a previous setup.
+
+**Step 1 — Create credentials in AWS Console:**
+1. Go to **AWS Console → SES → SMTP Settings → Create SMTP credentials**
+2. This creates an IAM user and shows the credentials **once** — save them immediately:
+   - **SMTP username**: looks like `AKIA…` (this is the IAM access key ID)
+   - **SMTP password**: a long base64 string (the SES-derived credential — NOT the raw secret key)
+
+**Step 2 — Store in SSM via workflow dispatch:**
+1. Go to **GitHub → Actions → "Provision SES SMTP credentials" → Run workflow**
+2. Fill in the inputs:
+   - `smtp_user`: the SMTP username from step 1
+   - `smtp_password`: the SMTP password from step 1
+   - `from_email`: (optional) `noreply@cloudless.gr`
+3. Click **Run workflow**
+
+The workflow writes the credentials directly to SSM (`ssm:PutParameter` only — no IAM operations).
+
+## Step 3 — Apply to Keycloak realm
+
+After SSM params are written, `keycloak-configure-email.yml` runs automatically
+(it's path-triggered on the provision script). Or trigger manually by pushing a
+touch to `scripts/keycloak-configure-email.sh`.
+
+The script uses the **Keycloak REST admin API** (no kubectl required):
+- Authenticates with `KEYCLOAK_ADMIN_PASSWORD` (from `ADMIN_BOOTSTRAP_PASSWORD` secret)
+- `PUT /admin/realms/master` — sets `smtpServer` block + `verifyEmail: true`
+- `PUT /admin/realms/master/authentication/required-actions/VERIFY_EMAIL` — enables + sets as default
+
+**Works even when k3s API server is down** — only requires `auth.cloudless.gr` to return HTTP 200.
+
+## Troubleshooting
+
+### `(no log)` in the Keycloak email config result
+
+The "Resolve SMTP credentials" step failed before the script ran. Causes:
+1. SSM params don't exist → run `provision-ses-smtp.yml` first (Path B)
+2. OIDC step failed → check AWS deploy role permissions
+
+### `ADMIN_AUTH=failed` in the configure-email log
+
+`KEYCLOAK_ADMIN_PASSWORD` is wrong or `auth.cloudless.gr` is unreachable.
+- Check `ADMIN_BOOTSTRAP_PASSWORD` GitHub secret is set correctly
+- Verify `auth.cloudless.gr` returns HTTP 200: `curl -o /dev/null -w "%{http_code}" https://auth.cloudless.gr/realms/master`
+
+### `SMTP=failed (HTTP 401)`
+
+Bad credentials — the SMTP password stored in SSM is wrong. Delete the SSM params
+and re-run Path B with correct credentials:
+```bash
+aws ssm delete-parameter --name /cloudless/production/SES_SMTP_USER
+aws ssm delete-parameter --name /cloudless/production/SES_SMTP_PASSWORD
+```
+Then trigger `provision-ses-smtp.yml` via dispatch with fresh credentials.
+
+### `SMTP=failed (HTTP 400)`
+
+The `smtpServer` JSON payload was rejected by Keycloak. Check that the SMTP host/port
+(`email-smtp.us-east-1.amazonaws.com:587`) is correct and `FROM_EMAIL` is a verified
+SES sender address.
+
+### New users don't receive verification emails
+
+After email config succeeds, verify the Keycloak realm settings:
+```bash
+# Quick check via REST (no kubectl needed)
+curl -s https://auth.cloudless.gr/realms/master | python3 -c \
+  "import sys,json; d=json.load(sys.stdin); print('verifyEmail:', d.get('verifyEmail'))"
+```
+Should return `verifyEmail: True`. If False, re-trigger `keycloak-configure-email.yml`.
+
+Also verify the `FROM_EMAIL` address is verified in SES (AWS Console → SES → Verified identities).
+
+## Idempotency
+
+Both `provision-ses-smtp.sh` and `keycloak-configure-email.sh` are idempotent:
+- Provision: exits early with "Nothing to do" if SSM params already exist
+- Configure: safe to re-run — just overwrites the existing realm SMTP config
+
+## What email verification does
+
+Once configured:
+1. New users who register at `https://cloudless.gr/auth/register` receive a verification email
+2. The email contains a one-time link — clicking it verifies the account
+3. Until verified, users **cannot sign in** to the application
+4. Existing users (created before email verification was enabled) are unaffected
+
+To disable email verification: `pnpm keycloak:enable-signup` sets `verifyEmail=false`.

--- a/.github/workflows/k3s-ssh-restart.yml
+++ b/.github/workflows/k3s-ssh-restart.yml
@@ -1,0 +1,131 @@
+name: k3s-ssh-restart — recover k3s API server via SSH when cluster tools fail
+
+# Triggered by pushing to this file. Runs on ubuntu-latest, connects to the Pi
+# via Tailscale, SSHes with OMV_SSH_KEY secret, restarts k3s, waits for the
+# API server to come back, and posts the full log to tracking issue #382.
+#
+# Use this when:
+#   - cluster-doctor shows "connection refused" on 100.113.41.119:6443
+#   - cluster-doctor shows "ServiceUnavailable" for all kubectl commands
+#   - PrometheusKubernetesListWatchFailures alert is firing
+#   - k3s-restart.yml (self-hosted runner path) queued forever (Pi runners offline)
+#
+# Requires: OMV_SSH_KEY repo secret — the private key for omv@100.113.41.119.
+# To add: GitHub → Settings → Secrets → Actions → New secret → OMV_SSH_KEY
+# Value: the private key contents (same as OMV_SSH_KEY_CONTENTS session secret).
+#
+# If OMV_SSH_KEY is not set, the SSH step will fail immediately with a clear
+# message; set the secret and re-trigger.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - ".github/workflows/k3s-ssh-restart.yml"
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  ssh-restart:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    env:
+      GH_TOKEN: ${{ github.token }}
+      PI_HOST: "100.113.41.119"
+      PI_USER: "omv"
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v4.3.1
+
+      - name: Check OMV_SSH_KEY secret is set
+        run: |
+          if [ -z "${{ secrets.OMV_SSH_KEY }}" ]; then
+            echo "::error::OMV_SSH_KEY secret is not set."
+            echo "Add the Pi private key as a GitHub repo secret named OMV_SSH_KEY:"
+            echo "  GitHub → Settings → Secrets → Actions → New repository secret"
+            echo "  Name: OMV_SSH_KEY"
+            echo "  Value: contents of ~/.ssh/id_ed25519 (same as OMV_SSH_KEY_CONTENTS session secret)"
+            exit 1
+          fi
+          echo "OMV_SSH_KEY is set — proceeding"
+
+      - name: Connect to tailnet
+        uses: tailscale/github-action@0263d9e6d793eaefcf1de98ff7fde47abe6664d3 # v3.2.4
+        with:
+          authkey: ${{ secrets.TS_AUTHKEY }}
+
+      - name: Verify Pi is reachable via Tailscale
+        run: |
+          echo "=== tailscale ping ===" | tee ssh-restart.log
+          tailscale ping --c=3 "$PI_HOST" 2>&1 | tee -a ssh-restart.log || true
+          echo "" | tee -a ssh-restart.log
+          echo "=== port 22 check ===" | tee -a ssh-restart.log
+          nc -zv -w5 "$PI_HOST" 22 2>&1 | tee -a ssh-restart.log \
+            && echo "port 22: OPEN" | tee -a ssh-restart.log \
+            || { echo "port 22: REFUSED — Pi may be down"; tee -a ssh-restart.log <<< "port 22 refused"; }
+          echo "" | tee -a ssh-restart.log
+          echo "=== port 6443 check (before) ===" | tee -a ssh-restart.log
+          nc -zv -w3 "$PI_HOST" 6443 2>&1 | tee -a ssh-restart.log \
+            && echo "port 6443: listening (k3s may already be up)" | tee -a ssh-restart.log \
+            || echo "port 6443: not listening (expected — k3s is down)" | tee -a ssh-restart.log
+
+      - name: Install SSH key
+        run: |
+          mkdir -p ~/.ssh
+          printf '%s\n' "${{ secrets.OMV_SSH_KEY }}" > ~/.ssh/id_ed25519
+          chmod 600 ~/.ssh/id_ed25519
+          ssh-keyscan -H "$PI_HOST" >> ~/.ssh/known_hosts 2>/dev/null || true
+
+      - name: Restart k3s via SSH
+        run: |
+          echo "" | tee -a ssh-restart.log
+          echo "=== SSH: k3s status BEFORE ===" | tee -a ssh-restart.log
+          ssh -i ~/.ssh/id_ed25519 -o StrictHostKeyChecking=no -o ConnectTimeout=10 \
+            "$PI_USER@$PI_HOST" \
+            "sudo systemctl status k3s --no-pager 2>&1 | head -15" \
+            2>&1 | tee -a ssh-restart.log || true
+
+          echo "" | tee -a ssh-restart.log
+          echo "=== SSH: restarting k3s ===" | tee -a ssh-restart.log
+          ssh -i ~/.ssh/id_ed25519 -o StrictHostKeyChecking=no -o ConnectTimeout=10 \
+            "$PI_USER@$PI_HOST" \
+            "sudo systemctl restart k3s 2>&1; echo restart_exit=\$?" \
+            2>&1 | tee -a ssh-restart.log
+
+      - name: Wait for k3s API to become healthy
+        run: |
+          echo "" | tee -a ssh-restart.log
+          echo "=== waiting for port 6443 (up to 90s) ===" | tee -a ssh-restart.log
+          for i in $(seq 1 18); do
+            if nc -zv -w3 "$PI_HOST" 6443 2>/dev/null; then
+              echo "port 6443 listening after ${i}×5s" | tee -a ssh-restart.log
+              break
+            fi
+            echo "  ${i}/18 — waiting 5s..." | tee -a ssh-restart.log
+            sleep 5
+          done
+
+          echo "" | tee -a ssh-restart.log
+          echo "=== SSH: k3s status AFTER ===" | tee -a ssh-restart.log
+          ssh -i ~/.ssh/id_ed25519 -o StrictHostKeyChecking=no -o ConnectTimeout=10 \
+            "$PI_USER@$PI_HOST" \
+            "sudo systemctl status k3s --no-pager 2>&1 | head -15; \
+             echo ''; \
+             sudo kubectl --kubeconfig /etc/rancher/k3s/k3s.yaml get nodes 2>&1 | head -10; \
+             echo ''; \
+             echo 'non-running pods (if any):'; \
+             sudo kubectl --kubeconfig /etc/rancher/k3s/k3s.yaml get pods -A \
+               --field-selector=status.phase!=Running,status.phase!=Succeeded 2>&1 | head -20" \
+            2>&1 | tee -a ssh-restart.log || true
+
+      - name: Post result to tracking issue
+        if: always()
+        run: |
+          {
+            echo "# k3s SSH restart — $(date -u '+%Y-%m-%d %H:%M:%SZ')"
+            echo ""
+            echo '```'
+            cat ssh-restart.log 2>/dev/null || echo "(no log)"
+            echo '```'
+          } | gh issue comment 382 --repo "$GITHUB_REPOSITORY" --body-file -

--- a/.github/workflows/k3s-watchdog-deploy.yml
+++ b/.github/workflows/k3s-watchdog-deploy.yml
@@ -1,0 +1,85 @@
+name: k3s-watchdog-deploy — install Restart=always systemd override on Pi
+
+# Deploys scripts/k3s-watchdog-install.sh to the Pi via SSH.
+# The script writes a systemd drop-in that sets Restart=always + removes start
+# limits so k3s auto-recovers from crashes without manual intervention.
+#
+# Run this ONCE after any k3s crash to prevent future outages.
+#
+# Triggers:
+#   - Push to main touching this file or the install script
+#   - Manually via workflow_dispatch
+#
+# Requires: OMV_SSH_KEY repo secret — the private key for omv@100.113.41.119.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - ".github/workflows/k3s-watchdog-deploy.yml"
+      - "scripts/k3s-watchdog-install.sh"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  deploy-watchdog:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    env:
+      GH_TOKEN: ${{ github.token }}
+      PI_HOST: "100.113.41.119"
+      PI_USER: "omv"
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v4.3.1
+
+      - name: Check OMV_SSH_KEY secret is set
+        run: |
+          if [ -z "${{ secrets.OMV_SSH_KEY }}" ]; then
+            echo "::error::OMV_SSH_KEY secret is not set."
+            echo "Add the Pi private key as a GitHub repo secret named OMV_SSH_KEY:"
+            echo "  GitHub → Settings → Secrets → Actions → New repository secret"
+            echo "  Name: OMV_SSH_KEY"
+            echo "  Value: contents of ~/.ssh/id_ed25519 (same as OMV_SSH_KEY_CONTENTS session secret)"
+            exit 1
+          fi
+          echo "OMV_SSH_KEY is set — proceeding"
+
+      - name: Connect to tailnet
+        uses: tailscale/github-action@0263d9e6d793eaefcf1de98ff7fde47abe6664d3 # v3.2.4
+        with:
+          authkey: ${{ secrets.TS_AUTHKEY }}
+
+      - name: Install SSH key
+        run: |
+          mkdir -p ~/.ssh
+          printf '%s\n' "${{ secrets.OMV_SSH_KEY }}" > ~/.ssh/id_ed25519
+          chmod 600 ~/.ssh/id_ed25519
+          ssh-keyscan -H "$PI_HOST" >> ~/.ssh/known_hosts 2>/dev/null || true
+
+      - name: Copy watchdog install script to Pi
+        run: |
+          scp -i ~/.ssh/id_ed25519 -o StrictHostKeyChecking=no \
+            scripts/k3s-watchdog-install.sh \
+            "$PI_USER@$PI_HOST:/tmp/k3s-watchdog-install.sh"
+
+      - name: Run watchdog install on Pi
+        run: |
+          echo "=== k3s watchdog deploy $(date -u '+%F %T')Z ===" | tee watchdog-deploy.log
+          ssh -i ~/.ssh/id_ed25519 -o StrictHostKeyChecking=no -o ConnectTimeout=10 \
+            "$PI_USER@$PI_HOST" \
+            "chmod +x /tmp/k3s-watchdog-install.sh && bash /tmp/k3s-watchdog-install.sh" \
+            2>&1 | tee -a watchdog-deploy.log
+
+      - name: Post result to tracking issue
+        if: always()
+        run: |
+          {
+            echo "# k3s watchdog deploy — $(date -u '+%Y-%m-%d %H:%M:%SZ')"
+            echo ""
+            echo '```'
+            cat watchdog-deploy.log 2>/dev/null || echo "(no log)"
+            echo '```'
+          } | gh issue comment 382 --repo "$GITHUB_REPOSITORY" --body-file -

--- a/scripts/k3s-watchdog-install.sh
+++ b/scripts/k3s-watchdog-install.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+#
+# k3s-watchdog-install.sh — strengthen the k3s systemd service so it
+# auto-recovers from crashes without manual intervention.
+#
+# What it does:
+#   1. Writes a systemd drop-in that sets Restart=always + removes start limits
+#   2. Enables the k3s service for auto-start on boot
+#   3. Reloads systemd and confirms the active state
+#
+# Idempotent — safe to re-run. Requires sudo (run via CI or directly on Pi).
+#
+# After this runs, k3s will:
+#   - Restart automatically 30s after any crash (no manual intervention needed)
+#   - Restart indefinitely (no start limit — won't stop retrying after N failures)
+#   - Auto-start on Pi reboot
+#
+# This addresses PrometheusKubernetesListWatchFailures and related cluster
+# incidents caused by k3s process crashes.
+
+set -uo pipefail
+
+OVERRIDE_DIR="/etc/systemd/system/k3s.service.d"
+OVERRIDE_FILE="${OVERRIDE_DIR}/restart-always.conf"
+
+echo "=== k3s watchdog install $(date -u '+%F %T')Z ==="
+
+# Check k3s is installed
+if ! systemctl list-units --full --all 2>/dev/null | grep -q "k3s.service"; then
+  echo "ERROR: k3s.service not found — is k3s installed on this host?"
+  exit 1
+fi
+
+echo "k3s.service found"
+
+# Write the drop-in override
+echo "writing drop-in: ${OVERRIDE_FILE}"
+sudo mkdir -p "$OVERRIDE_DIR"
+sudo tee "$OVERRIDE_FILE" > /dev/null <<'EOF'
+[Service]
+# Auto-restart k3s on any failure, indefinitely, with a 30s back-off.
+# Removes the default start limit so k3s never stops retrying after N crashes.
+Restart=always
+RestartSec=30s
+StartLimitBurst=0
+StartLimitIntervalSec=0
+EOF
+
+echo "drop-in written:"
+cat "$OVERRIDE_FILE"
+echo ""
+
+# Reload systemd to pick up the override
+sudo systemctl daemon-reload
+echo "daemon-reload: done"
+
+# Ensure k3s starts on boot
+sudo systemctl enable k3s 2>&1
+echo "k3s: enabled for auto-start on boot"
+
+# Show current state
+echo ""
+echo "=== k3s current state ==="
+sudo systemctl status k3s --no-pager 2>&1 | head -20 || true
+
+echo ""
+echo "=== effective restart config ==="
+sudo systemctl show k3s --property=Restart,RestartSec,StartLimitBurst,StartLimitIntervalSec 2>&1
+
+echo ""
+echo "=== DONE ==="
+echo "k3s will now restart automatically (Restart=always, RestartSec=30s, no start limit)."
+echo "No further manual intervention needed after a k3s crash."


### PR DESCRIPTION
## Summary

- **`k3s-ssh-restart.yml`** — ubuntu-latest workflow that connects via Tailscale + `OMV_SSH_KEY` secret, SSHes to Pi, restarts k3s, waits for port 6443, posts full log to issue #382. Works even when Pi self-hosted runners are offline.
- **`k3s-watchdog-deploy.yml`** — deploys `k3s-watchdog-install.sh` to Pi via SCP+SSH, installs `Restart=always` systemd drop-in so k3s auto-recovers from crashes without intervention.
- **`scripts/k3s-watchdog-install.sh`** — writes `/etc/systemd/system/k3s.service.d/restart-always.conf` (`Restart=always`, `RestartSec=30s`, `StartLimitBurst=0`), enables k3s on boot.
- **`ses-email-setup` skill** — new skill covering SES SMTP provisioning (automated IAM path + manual bypass via dispatch inputs), SSM parameters, Keycloak REST API config, and troubleshooting guide.
- **`cluster-incident-response` skill update** — adds `PrometheusKubernetesListWatchFailures` patterns, failure-mode decision table, `connection refused` vs `ServiceUnavailable` interpretation, SSH recovery path, and watchdog references.

## Context

Created in response to the 2026-06-02 k3s API server crash incident:
- k3s process stopped → `PrometheusKubernetesListWatchFailures` fired → `auth.cloudless.gr` unreachable
- Pi self-hosted runner also offline → `k3s-restart.yml` queued forever
- SSH path (`k3s-ssh-restart.yml`) is the robust recovery when runners are down

## Test plan

- [ ] Add `OMV_SSH_KEY` repo secret (GitHub → Settings → Secrets → Actions)
- [ ] After Pi recovers: trigger `k3s-watchdog-deploy.yml` by pushing a touch to this workflow file
- [ ] Verify watchdog is installed: `systemctl show k3s --property=Restart` → `Restart=always`

https://claude.ai/code/session_012EjQpQGyt6SeSfRNNRRr6j