### PR TITLE
chore: trigger cluster doctor — post k3s crash check

### DIFF
--- a/scripts/cluster-doctor.sh
+++ b/scripts/cluster-doctor.sh
@@ -155,3 +155,4 @@ pod=$(kubectl -n cloudless get pods -l app=cloudless -o name 2>/dev/null | head 
 printf "\n_End of snapshot._\n"
 
 # re-trigger-doctor-20260602d
+# triggered 2026-06-02 14:09:45Z


### PR DESCRIPTION
Trigger cluster-doctor.yml to get current k3s + Keycloak state.