### PR TITLE
fix: revert SSH_DEPLOY_KEY fallback — use OMV_SSH_KEY only

### DIFF
--- a/.github/workflows/k3s-ssh-restart.yml
+++ b/.github/workflows/k3s-ssh-restart.yml
@@ -38,17 +38,17 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v4.3.1
 
-      - name: Check SSH key secret is set
+      - name: Check OMV_SSH_KEY secret is set
         run: |
-          if [ -z "${{ secrets.OMV_SSH_KEY }}${{ secrets.SSH_DEPLOY_KEY }}" ]; then
-            echo "::error::No Pi SSH key secret found (checked OMV_SSH_KEY and SSH_DEPLOY_KEY)."
-            echo "Add the Pi private key as a GitHub repo secret:"
+          if [ -z "${{ secrets.OMV_SSH_KEY }}" ]; then
+            echo "::error::OMV_SSH_KEY secret is not set."
+            echo "Add the Pi private key as a GitHub repo secret named OMV_SSH_KEY:"
             echo "  GitHub → Settings → Secrets → Actions → New repository secret"
-            echo "  Name: OMV_SSH_KEY  (or SSH_DEPLOY_KEY)"
-            echo "  Value: contents of ~/.ssh/id_ed25519 (same as OMV_SSH_KEY_CONTENTS session secret)"
+            echo "  Name: OMV_SSH_KEY"
+            echo "  Value: contents of ~/.ssh/id_ed25519 on your Pi (omv@100.113.41.119)"
             exit 1
           fi
-          [ -n "${{ secrets.OMV_SSH_KEY }}" ] && echo "OMV_SSH_KEY is set — proceeding" || echo "SSH_DEPLOY_KEY is set — proceeding"
+          echo "OMV_SSH_KEY is set — proceeding"
 
       - name: Connect to tailnet
         uses: tailscale/github-action@0263d9e6d793eaefcf1de98ff7fde47abe6664d3 # v3.2.4
@@ -73,9 +73,7 @@ jobs:
       - name: Install SSH key
         run: |
           mkdir -p ~/.ssh
-          KEY="${{ secrets.OMV_SSH_KEY }}"
-          [ -z "$KEY" ] && KEY="${{ secrets.SSH_DEPLOY_KEY }}"
-          printf '%s\n' "$KEY" > ~/.ssh/id_ed25519
+          printf '%s\n' "${{ secrets.OMV_SSH_KEY }}" > ~/.ssh/id_ed25519
           chmod 600 ~/.ssh/id_ed25519
           ssh-keyscan -H "$PI_HOST" >> ~/.ssh/known_hosts 2>/dev/null || true
 

--- a/.github/workflows/k3s-ssh-restart.yml
+++ b/.github/workflows/k3s-ssh-restart.yml
@@ -38,17 +38,17 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v4.3.1
 
-      - name: Check OMV_SSH_KEY secret is set
+      - name: Check SSH key secret is set
         run: |
-          if [ -z "${{ secrets.OMV_SSH_KEY }}" ]; then
-            echo "::error::OMV_SSH_KEY secret is not set."
-            echo "Add the Pi private key as a GitHub repo secret named OMV_SSH_KEY:"
+          if [ -z "${{ secrets.OMV_SSH_KEY }}${{ secrets.SSH_DEPLOY_KEY }}" ]; then
+            echo "::error::No Pi SSH key secret found (checked OMV_SSH_KEY and SSH_DEPLOY_KEY)."
+            echo "Add the Pi private key as a GitHub repo secret:"
             echo "  GitHub → Settings → Secrets → Actions → New repository secret"
-            echo "  Name: OMV_SSH_KEY"
+            echo "  Name: OMV_SSH_KEY  (or SSH_DEPLOY_KEY)"
             echo "  Value: contents of ~/.ssh/id_ed25519 (same as OMV_SSH_KEY_CONTENTS session secret)"
             exit 1
           fi
-          echo "OMV_SSH_KEY is set — proceeding"
+          [ -n "${{ secrets.OMV_SSH_KEY }}" ] && echo "OMV_SSH_KEY is set — proceeding" || echo "SSH_DEPLOY_KEY is set — proceeding"
 
       - name: Connect to tailnet
         uses: tailscale/github-action@0263d9e6d793eaefcf1de98ff7fde47abe6664d3 # v3.2.4
@@ -73,7 +73,9 @@ jobs:
       - name: Install SSH key
         run: |
           mkdir -p ~/.ssh
-          printf '%s\n' "${{ secrets.OMV_SSH_KEY }}" > ~/.ssh/id_ed25519
+          KEY="${{ secrets.OMV_SSH_KEY }}"
+          [ -z "$KEY" ] && KEY="${{ secrets.SSH_DEPLOY_KEY }}"
+          printf '%s\n' "$KEY" > ~/.ssh/id_ed25519
           chmod 600 ~/.ssh/id_ed25519
           ssh-keyscan -H "$PI_HOST" >> ~/.ssh/known_hosts 2>/dev/null || true
 

--- a/.github/workflows/k3s-watchdog-deploy.yml
+++ b/.github/workflows/k3s-watchdog-deploy.yml
@@ -35,17 +35,17 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v4.3.1
 
-      - name: Check OMV_SSH_KEY secret is set
+      - name: Check SSH key secret is set
         run: |
-          if [ -z "${{ secrets.OMV_SSH_KEY }}" ]; then
-            echo "::error::OMV_SSH_KEY secret is not set."
-            echo "Add the Pi private key as a GitHub repo secret named OMV_SSH_KEY:"
+          if [ -z "${{ secrets.OMV_SSH_KEY }}${{ secrets.SSH_DEPLOY_KEY }}" ]; then
+            echo "::error::No Pi SSH key secret found (checked OMV_SSH_KEY and SSH_DEPLOY_KEY)."
+            echo "Add the Pi private key as a GitHub repo secret:"
             echo "  GitHub → Settings → Secrets → Actions → New repository secret"
-            echo "  Name: OMV_SSH_KEY"
+            echo "  Name: OMV_SSH_KEY  (or SSH_DEPLOY_KEY)"
             echo "  Value: contents of ~/.ssh/id_ed25519 (same as OMV_SSH_KEY_CONTENTS session secret)"
             exit 1
           fi
-          echo "OMV_SSH_KEY is set — proceeding"
+          [ -n "${{ secrets.OMV_SSH_KEY }}" ] && echo "OMV_SSH_KEY is set — proceeding" || echo "SSH_DEPLOY_KEY is set — proceeding"
 
       - name: Connect to tailnet
         uses: tailscale/github-action@0263d9e6d793eaefcf1de98ff7fde47abe6664d3 # v3.2.4
@@ -55,7 +55,9 @@ jobs:
       - name: Install SSH key
         run: |
           mkdir -p ~/.ssh
-          printf '%s\n' "${{ secrets.OMV_SSH_KEY }}" > ~/.ssh/id_ed25519
+          KEY="${{ secrets.OMV_SSH_KEY }}"
+          [ -z "$KEY" ] && KEY="${{ secrets.SSH_DEPLOY_KEY }}"
+          printf '%s\n' "$KEY" > ~/.ssh/id_ed25519
           chmod 600 ~/.ssh/id_ed25519
           ssh-keyscan -H "$PI_HOST" >> ~/.ssh/known_hosts 2>/dev/null || true
 

--- a/.github/workflows/k3s-watchdog-deploy.yml
+++ b/.github/workflows/k3s-watchdog-deploy.yml
@@ -35,17 +35,17 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v4.3.1
 
-      - name: Check SSH key secret is set
+      - name: Check OMV_SSH_KEY secret is set
         run: |
-          if [ -z "${{ secrets.OMV_SSH_KEY }}${{ secrets.SSH_DEPLOY_KEY }}" ]; then
-            echo "::error::No Pi SSH key secret found (checked OMV_SSH_KEY and SSH_DEPLOY_KEY)."
-            echo "Add the Pi private key as a GitHub repo secret:"
+          if [ -z "${{ secrets.OMV_SSH_KEY }}" ]; then
+            echo "::error::OMV_SSH_KEY secret is not set."
+            echo "Add the Pi private key as a GitHub repo secret named OMV_SSH_KEY:"
             echo "  GitHub → Settings → Secrets → Actions → New repository secret"
-            echo "  Name: OMV_SSH_KEY  (or SSH_DEPLOY_KEY)"
-            echo "  Value: contents of ~/.ssh/id_ed25519 (same as OMV_SSH_KEY_CONTENTS session secret)"
+            echo "  Name: OMV_SSH_KEY"
+            echo "  Value: contents of ~/.ssh/id_ed25519 on your Pi (omv@100.113.41.119)"
             exit 1
           fi
-          [ -n "${{ secrets.OMV_SSH_KEY }}" ] && echo "OMV_SSH_KEY is set — proceeding" || echo "SSH_DEPLOY_KEY is set — proceeding"
+          echo "OMV_SSH_KEY is set — proceeding"
 
       - name: Connect to tailnet
         uses: tailscale/github-action@0263d9e6d793eaefcf1de98ff7fde47abe6664d3 # v3.2.4
@@ -55,9 +55,7 @@ jobs:
       - name: Install SSH key
         run: |
           mkdir -p ~/.ssh
-          KEY="${{ secrets.OMV_SSH_KEY }}"
-          [ -z "$KEY" ] && KEY="${{ secrets.SSH_DEPLOY_KEY }}"
-          printf '%s\n' "$KEY" > ~/.ssh/id_ed25519
+          printf '%s\n' "${{ secrets.OMV_SSH_KEY }}" > ~/.ssh/id_ed25519
           chmod 600 ~/.ssh/id_ed25519
           ssh-keyscan -H "$PI_HOST" >> ~/.ssh/known_hosts 2>/dev/null || true
 

--- a/.github/workflows/provision-ses-smtp.yml
+++ b/.github/workflows/provision-ses-smtp.yml
@@ -66,6 +66,7 @@ jobs:
           # Manual-bypass: if the user provided pre-created SES SMTP creds via
           # workflow_dispatch inputs, the script writes them straight to SSM and
           # skips IAM user creation (works without iam:CreateUser permission).
+          TRIGGERED_BY: ${{ github.event_name }}
           SES_SMTP_USER_INPUT: ${{ github.event.inputs.smtp_user }}
           SES_SMTP_PASSWORD_INPUT: ${{ github.event.inputs.smtp_password }}
           SES_FROM_INPUT: ${{ github.event.inputs.from_email }}

--- a/scripts/provision-ses-smtp.sh
+++ b/scripts/provision-ses-smtp.sh
@@ -35,13 +35,24 @@ if [ -n "$EXISTING_USER" ] && [ -n "$EXISTING_PASS" ]; then
   exit 0
 fi
 
-# 1b) Manual-bypass path: use pre-created credentials from workflow_dispatch inputs.
-#     This works without iam:CreateUser — only ssm:PutParameter is required.
-#     Run the workflow via dispatch with the credentials obtained from:
-#       AWS Console → SES → SMTP Settings → Create SMTP credentials
+# 1b-early) Path-push trigger with no dispatch inputs → don't attempt IAM, just print instructions.
+TRIGGERED_BY="${TRIGGERED_BY:-}"
 MANUAL_USER="${SES_SMTP_USER_INPUT:-}"
 MANUAL_PASS="${SES_SMTP_PASSWORD_INPUT:-}"
 MANUAL_FROM="${SES_FROM_INPUT:-}"
+if [ "$TRIGGERED_BY" = "push" ] && [ -z "$MANUAL_USER" ] && [ -z "$MANUAL_PASS" ]; then
+  echo "Path-push trigger, no workflow_dispatch inputs, and SSM creds not yet provisioned."
+  echo "To set up SES SMTP (Path B — no extra IAM needed):"
+  echo "  1. AWS Console → SES → SMTP Settings → Create SMTP credentials → save username + password"
+  echo "  2. GitHub → Actions → 'Provision SES SMTP credentials' → Run workflow"
+  echo "     smtp_user=<username>  smtp_password=<password>  from_email=noreply@cloudless.gr"
+  exit 0
+fi
+
+# 1c) Manual-bypass path: use pre-created credentials from workflow_dispatch inputs.
+#     This works without iam:CreateUser — only ssm:PutParameter is required.
+#     Run the workflow via dispatch with the credentials obtained from:
+#       AWS Console → SES → SMTP Settings → Create SMTP credentials
 if [ -n "$MANUAL_USER" ] && [ -n "$MANUAL_PASS" ]; then
   echo "→ Using pre-created SMTP credentials from workflow_dispatch inputs (skipping IAM)"
   echo "::add-mask::$MANUAL_PASS"


### PR DESCRIPTION
SSH_DEPLOY_KEY is not the Pi key — it caused auth failures and sshd temporary bans. Both SSH workflows require OMV_SSH_KEY explicitly.