### PR TITLE
ops: full-coverage cluster doctor + analytics/ntfy recovery tools

### DIFF
--- a/.claude/skills/analytics-stack/SKILL.md
+++ b/.claude/skills/analytics-stack/SKILL.md
@@ -1,0 +1,115 @@
+---
+name: analytics-stack
+description: Diagnose and recover the analytics namespace on the omv k3s cluster — Metabase, DuckDB API, Grafana, Loki, Alertmanager. Use when Metabase is down/OOMKilled, DuckDB API is crashing, Grafana is unreachable, analytics dashboards return errors, or the user says "fix analytics", "Metabase is down", "DuckDB crash", "Grafana 503", "charts broken". Covers both kubectl-based recovery (via analytics-restore.yml) and monitoring-stack triage.
+---
+
+# Analytics Stack — cloudless.gr (omv k3s)
+
+The analytics namespace on the omv k3s cluster runs two services: **Metabase** (BI dashboards / admin analytics) and **DuckDB API** (query engine). Monitoring lives in the **monitoring** namespace: **Prometheus**, **Grafana**, **Alertmanager**, **Loki**.
+
+## Service Map
+
+| Service | Namespace | Deploy/SS | Memory limit | OOM risk |
+|---|---|---|---|---|
+| Metabase | analytics | `metabase` | 400Mi (restore: 600Mi) | **HIGH** — JVM with `-Xmx320m` |
+| DuckDB API | analytics | `duckdb-api` | 1500Mi | Low (Go/DuckDB) |
+| Grafana | monitoring | `kube-prom-grafana` | 256Mi | Low |
+| Alertmanager | monitoring | `monitoring-alertmanager` | 128Mi | Low |
+| Loki | monitoring | `loki` (StatefulSet) | 400Mi | Medium |
+| Prometheus | monitoring | `prometheus-monitoring-prometheus-0` | 700Mi (StatefulSet) | Low |
+
+## Recovery Workflows
+
+| Symptom | Tool |
+|---|---|
+| Metabase OOMKilled / CrashLoopBackOff | `analytics-restore.yml` |
+| DuckDB API high restarts / OOMKilled | `analytics-restore.yml` |
+| ntfy Error / CrashLoopBackOff | `ntfy-restore.yml` |
+| Grafana unreachable (HTTP 503) | `restore-keycloak.yml` → cluster doctor to check; Grafana pod restart via `kubectl -n monitoring rollout restart deploy/kube-prom-grafana` wrapped in a remediate workflow |
+| Prometheus rule failures | `prometheus-tune.yml` |
+
+**Trigger analytics-restore**: edit `.github/workflows/analytics-restore.yml` → PR → squash-merge. The workflow runs on `ubuntu-latest` via Tailscale + `KUBECONFIG_B64`, posts result to **issue #382**.
+
+## Metabase Memory Sizing
+
+Metabase (JVM) is the most likely OOM victim in the analytics namespace.
+
+| Limit | `-Xmx` | Status |
+|---|---|---|
+| 400Mi | 320m | Original — tight, can OOMKill on heavy queries |
+| 600Mi | 480m | `analytics-restore.sh` default — fits comfortably |
+| 1Gi | 800m | Maximum if the node can afford it |
+
+**Rule: never set Metabase container limit below `-Xmx` + 128Mi.**
+
+The `memory-relief-2026-05-31.yaml` manifest caps Metabase at 400Mi. If you're seeing OOMKills, run `analytics-restore.yml` which patches to 600Mi automatically. Update the manifest to match after the fix sticks.
+
+## Checking Analytics Health
+
+Run the cluster doctor (touch `scripts/cluster-doctor.sh` → PR → merge) — the doctor now covers Tier 4 Analytics sections: Metabase pods, DuckDB API pods, and their resource limits.
+
+Quick manual checks (run from a Tailscale-connected host with kubectl):
+```bash
+# Pod health
+kubectl -n analytics get pods -o wide
+
+# Metabase restart count
+kubectl -n analytics get pods -l app=metabase -o jsonpath='{.items[0].status.containerStatuses[0].restartCount}'
+
+# Metabase logs
+kubectl -n analytics logs deploy/metabase --tail=40
+
+# DuckDB API logs
+kubectl -n analytics logs deploy/duckdb-api --tail=20
+```
+
+## Grafana
+
+Grafana lives in the `monitoring` namespace. The HTTP endpoint `https://grafana.cloudless.gr/api/health` returns `{"database":"ok"}` when healthy (HTTP 200).
+
+If Grafana is unreachable:
+1. Check if the pod is running: `kubectl -n monitoring get pods -l app.kubernetes.io/name=grafana`
+2. Check restarts / OOM: `kubectl -n monitoring describe pod -l app.kubernetes.io/name=grafana`
+3. Restart: `kubectl -n monitoring rollout restart deploy/kube-prom-grafana`
+4. Grafana limit is 256Mi — if OOMKilling, patch to 384Mi (same pattern as Keycloak restore)
+
+## Loki
+
+Loki (log aggregation) is a StatefulSet in `monitoring`. It ingests logs from promtail running on both Pi nodes.
+
+- **OOM risk**: Medium — Loki limit is 400Mi. If it OOMKills, log ingestion stops but metrics/alerting continue.
+- **Recovery**: `kubectl -n monitoring rollout restart statefulset/loki`
+- **Disk**: Loki stores chunks on a PVC; check with `kubectl -n monitoring get pvc`
+
+## ntfy
+
+ntfy (push notification server) is in the `ntfy` namespace with a 96Mi limit. It's been observed in Error state with 34+ restarts (2026-06-01 snapshot).
+
+**Recovery**: trigger `ntfy-restore.yml` — patches to 128Mi if OOMKilled, restarts, posts to #382.
+
+## Troubleshooting
+
+### Metabase shows `(no log)` or is unreachable in Grafana dashboards
+
+1. Run cluster doctor to get pod state
+2. If OOMKilled: trigger `analytics-restore.yml` (touch the file → PR → merge)
+3. After restore, check Metabase is Running before using dashboards
+
+### DuckDB API returns 503 or query timeouts
+
+1. `kubectl -n analytics logs deploy/duckdb-api --tail=40` — look for OOM or Go panic
+2. If OOMKilled: trigger `analytics-restore.yml` (restarts DuckDB API)
+3. If query timeout: check if a large analytics job is running (`kubectl -n analytics get pods`)
+
+### Grafana shows no data / datasource error
+
+Usually means Prometheus is not reachable from Grafana. Check:
+1. Prometheus pod is Running: `kubectl -n monitoring get pods -l app.kubernetes.io/name=prometheus`
+2. Prometheus rules health: cluster doctor Tier 3 section
+3. If `PrometheusRuleFailures` is firing: trigger `prometheus-tune.yml`
+
+### ntfy push notifications stopped arriving
+
+1. Check ntfy pod: `kubectl -n ntfy get pods`
+2. If in Error/CrashLoopBackOff: trigger `ntfy-restore.yml`
+3. Check ntfy logs: `kubectl -n ntfy logs deploy/ntfy --tail=40`

--- a/.claude/skills/cluster-incident-response/SKILL.md
+++ b/.claude/skills/cluster-incident-response/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: cluster-incident-response
-description: Diagnose and recover omv k3s cluster outages from a cloud session that has NO kubectl/ssh/aws. Use when auth.cloudless.gr returns 503, a pod is OOMKilled/CrashLoopBackOff, login is down, PrometheusRuleFailures fires, PrometheusKubernetesListWatchFailures fires, k3s API server is down, or the user says "fix what's broken on the cluster", "is the cluster healthy", "recover Keycloak". Drives cluster ops through path-triggered GitHub workflows (hosted runner + Tailscale + KUBECONFIG_B64) that post diagnostics to issue #382.
-argument-hint: "what's broken, e.g. 'keycloak 503', 'PrometheusRuleFailures', 'PrometheusKubernetesListWatchFailures', 'k3s API server down'"
+description: Diagnose and recover omv k3s cluster outages from a cloud session that has NO kubectl/ssh/aws. Use when auth.cloudless.gr returns 503, a pod is OOMKilled/CrashLoopBackOff, login is down, PrometheusRuleFailures fires, PrometheusKubernetesListWatchFailures fires, k3s API server is down, Metabase/DuckDB/ntfy/Grafana/Loki is down, or the user says "fix what's broken on the cluster", "is the cluster healthy", "recover Keycloak", "analytics down", "Grafana unreachable", "ntfy not working". Drives cluster ops through path-triggered GitHub workflows (hosted runner + Tailscale + KUBECONFIG_B64) that post diagnostics to issue #382.
+argument-hint: "what's broken, e.g. 'keycloak 503', 'Metabase OOM', 'ntfy crash', 'PrometheusRuleFailures', 'k3s API server down'"
 ---
 
 # Cluster Incident Response — cloudless.gr (omv k3s)
@@ -33,22 +33,43 @@ Workflow runner billing can break — `ubuntu-latest` + Tailscale is the robust
 path; do **not** pin recovery to `[self-hosted, omv, pi]` (those runners go
 offline during cluster incidents and the job queues forever).
 
+## Cluster Service Map
+
+| Tier | Namespace | Service | Memory limit | OOM risk |
+|---|---|---|---|---|
+| Auth | keycloak | keycloak | 768Mi | **CRITICAL** — JVM `-Xmx512m` |
+| Auth | keycloak | postgres | — | Low |
+| App | cloudless | cloudless | — | Low |
+| App | ntfy | ntfy | 96Mi | Medium (tight) |
+| App | n8n | n8n | 256Mi | Low |
+| Monitoring | monitoring | prometheus | 700Mi | Low |
+| Monitoring | monitoring | grafana | 256Mi | Low |
+| Monitoring | monitoring | alertmanager | 128Mi | Low |
+| Monitoring | monitoring | loki | 400Mi | Medium |
+| Analytics | analytics | metabase | 400Mi | **HIGH** — JVM `-Xmx320m` |
+| Analytics | analytics | duckdb-api | 1500Mi | Low |
+| Infra | monitoring | etcd-defrag | CronJob | — |
+| Infra | monitoring | cluster-alerts | CronJob | — |
+
 ## Tools (all in repo)
 
 | Command / Workflow | What it does |
 | --- | --- |
-| `pnpm cluster:doctor` (`scripts/cluster-doctor.sh`) | Read-only diagnostics: node memory/pressure, non-Running pods, a target deploy's pods/limits/events/logs, OOMKilled/CrashLoop, container field-managers & ownership, **Prometheus pod + failing rules** (`/api/v1/rules` via a throwaway curl pod, parsed with `jq`). |
+| `pnpm cluster:doctor` (`scripts/cluster-doctor.sh`) | **Full 6-tier diagnostics** — Auth (Keycloak+Postgres), App (cloudless+ntfy+n8n), Monitoring (Prometheus+Grafana+Alertmanager+Loki+rules), Analytics (Metabase+DuckDB), Infra (nodes+etcd+CronJobs), External (HTTP surfaces+runners). Posts to #382. |
 | `.github/workflows/cluster-doctor.yml` | Runs the doctor on a hosted runner over Tailscale, posts the snapshot to **#382**. Trigger by editing `scripts/cluster-doctor.sh` or the workflow. |
-| `pnpm keycloak:smoke` (`scripts/keycloak-smoke.sh`) | Credential-free verification of the live login+registration surface (discovery, JWKS, hosted login, registration, token endpoint, next-auth provider, app→Keycloak handoff). |
-| `pnpm keycloak:restore` (`scripts/restore-keycloak.sh`) | Direct strategic-merge **patch** of the keycloak deploy (size container to fit heap), restart, verify, with before/after/revert-check logging. |
+| `pnpm keycloak:smoke` (`scripts/keycloak-smoke.sh`) | Credential-free verification of the live login+registration surface (discovery, JWKS, hosted login, registration, token endpoint, next-auth provider). |
+| `pnpm keycloak:restore` (`scripts/restore-keycloak.sh`) | Direct strategic-merge **patch** of the keycloak deploy (768Mi + `-Xmx512m`), restart, verify. |
 | `.github/workflows/restore-keycloak.yml` | Runs `keycloak:restore` on a hosted runner, posts the log to #382. Trigger by editing the workflow file. |
-| `pnpm prometheus:tune` (`scripts/prometheus-tune.sh`) | Deletes the heavy kube-apiserver SLO/burnrate/availability PrometheusRules that time out and trip `PrometheusRuleFailures`; reports remaining failing rules. |
-| `.github/workflows/prometheus-tune.yml` | Runs `prometheus:tune` on a hosted runner, posts the log to #382. Trigger by editing the workflow file. |
-| `pnpm keycloak:ensure` (`scripts/keycloak-ensure.sh`) | **Self-heal**: idempotent reconciler that restores auth to its known-good state — OOM-recovers Keycloak (768Mi + `-Xmx512m`), fixes realm flags + the cloudless-app `groups` mapper (`full.path=false`) + admin group/membership, **and restores the Pi `cloudless` app's auth wiring** (`cloudless-app-auth` secret + `envFrom`). Reports only what it `CORRECTED`. |
-| `.github/workflows/keycloak-ensure.yml` | Runs `keycloak:ensure` on a **cron (`*/15`)** + dispatch + push; posts to #382 only when it corrects drift or auth is still broken (silent on healthy runs). |
-| `.github/workflows/k3s-ssh-restart.yml` | **SSH-based k3s restart** — runs on `ubuntu-latest`, connects via Tailscale, SSHes to Pi with `OMV_SSH_KEY` secret, restarts k3s, waits for port 6443, posts result to #382. Requires `OMV_SSH_KEY` repo secret. |
-| `.github/workflows/k3s-restart.yml` | **Runner-based k3s restart** — runs on `[self-hosted, omv, build]`. Only works when the Pi host is up but the runner is alive. Falls back to queued-forever when Pi is down. Prefer `k3s-ssh-restart.yml`. |
-| `.github/workflows/k3s-watchdog-deploy.yml` | Deploys `scripts/k3s-watchdog-install.sh` to the Pi via SSH — installs a systemd override (`Restart=always`, no start limit) so k3s auto-recovers without manual intervention. |
+| `pnpm keycloak:ensure` (`scripts/keycloak-ensure.sh`) | **Self-heal** cron: restores Keycloak 768Mi+heap, realm flags, groups mapper, admin group/membership, Pi cloudless app auth wiring. Posts to #382 only when it corrects drift. |
+| `.github/workflows/keycloak-ensure.yml` | Runs `keycloak:ensure` on **cron `*/15`** + push. |
+| `pnpm prometheus:tune` (`scripts/prometheus-tune.sh`) | Removes heavy kube-apiserver burnrate/SLO PrometheusRules that time out and trip `PrometheusRuleFailures`. |
+| `.github/workflows/prometheus-tune.yml` | Runs `prometheus:tune` on a hosted runner, posts the log to #382. |
+| `scripts/analytics-restore.sh` | Recovers OOMKilled Metabase (patches to 600Mi + restarts) and DuckDB API (restarts if high restarts). |
+| `.github/workflows/analytics-restore.yml` | Runs `analytics-restore.sh` on a hosted runner, posts to #382. Trigger by editing the workflow. |
+| `scripts/ntfy-restore.sh` | Recovers ntfy from Error/CrashLoopBackOff — patches memory to 128Mi if OOMKilled, restarts. |
+| `.github/workflows/ntfy-restore.yml` | Runs `ntfy-restore.sh` on a hosted runner, posts to #382. Trigger by editing the workflow. |
+| `.github/workflows/k3s-ssh-restart.yml` | **SSH-based k3s restart** — Tailscale + `OMV_SSH_KEY` secret → SSH to Pi → restart k3s → wait for port 6443. Requires `OMV_SSH_KEY` repo secret. |
+| `.github/workflows/k3s-watchdog-deploy.yml` | Deploys `scripts/k3s-watchdog-install.sh` to the Pi via SSH — installs `Restart=always` systemd drop-in so k3s auto-recovers. Requires `OMV_SSH_KEY`. |
 
 ## Triage workflow
 
@@ -56,64 +77,63 @@ offline during cluster incidents and the job queues forever).
    → PR → squash-merge), wait ~2 min, read #382. Never guess pod state; the
    doctor is your eyes.
 2. **Classify the failure mode** — see decision table below.
-3. **Apply the fix** by editing the relevant manifest/script and re-triggering
-   the workflow (path filter). Read the posted log to confirm it stuck.
-4. **Verify** end-to-end (`keycloak:smoke`, or curl the discovery endpoint).
+3. **Apply the fix** by editing the relevant workflow file → PR → squash-merge.
+   Read the posted log to confirm it stuck.
+4. **Verify** (`keycloak:smoke`, HTTP check, re-doctor).
 
 ## Failure mode decision table
 
 | Symptom | Likely cause | Tool |
 |---|---|---|
-| `auth.cloudless.gr` HTTP 503 | Keycloak pod OOMKilled / CrashLoop | `keycloak:restore` → `keycloak:smoke` |
-| `auth.cloudless.gr` HTTP 000000 (no TCP) | k3s API server down AND cloudflared tunnel broken | `k3s-ssh-restart` → re-doctor |
-| Doctor: `connection refused` on `100.113.41.119:6443` | k3s API server process not listening — Pi host is UP (TCP RST means host is reachable via Tailscale), k3s service has stopped | `k3s-ssh-restart.yml` (if `OMV_SSH_KEY` set) or physical intervention |
-| Doctor: `ServiceUnavailable` on `100.113.41.119:6443` | k3s API server starting / overloaded / etcd under pressure | Wait 2–5 min and re-doctor; if persistent, `k3s-ssh-restart.yml` |
-| Doctor: all kubectl = `connection refused` AND runner job queued forever | Pi host is completely down (power loss / kernel panic) | Physical access or out-of-band reboot |
-| `PrometheusRuleFailures` alert | Heavy `kube-apiserver-burnrate.rules` group timing out | `pnpm prometheus:tune` |
-| `PrometheusKubernetesListWatchFailures` alert | Prometheus cannot list-watch the k8s API server — **almost always means the k3s API server is down** | Run doctor first; if API down → `k3s-ssh-restart.yml` |
-| Pod `OOMKilled` (exit 137) | Memory limit too low | Raise limit via `kubectl patch` in a cluster-remediate style workflow |
-| Pod `CrashLoopBackOff` + probe `connection refused` | Usually still OOMing during startup | Same as OOMKilled |
+| `auth.cloudless.gr` HTTP 503 | Keycloak OOMKilled / CrashLoop | `restore-keycloak.yml` → `keycloak:smoke` |
+| `auth.cloudless.gr` HTTP 000000 (no TCP) | k3s API server down AND Cloudflare tunnel broken | `k3s-ssh-restart.yml` → re-doctor |
+| Doctor: `connection refused` on port 6443 | k3s process stopped (Pi host UP via Tailscale) | `k3s-ssh-restart.yml` (needs `OMV_SSH_KEY`) |
+| Doctor: `ServiceUnavailable` on port 6443 | k3s starting / overloaded — wait 2–5 min | Re-doctor; if persistent → `k3s-ssh-restart.yml` |
+| Doctor: all kubectl = `connection refused` + runner queued forever | Pi host completely down (power/kernel panic) | Physical access or out-of-band reboot |
+| `PrometheusRuleFailures` alert | `kube-apiserver-burnrate.rules` timing out | `prometheus-tune.yml` |
+| `PrometheusKubernetesListWatchFailures` alert | Prometheus can't reach k3s API | Run doctor first; if API down → `k3s-ssh-restart.yml` |
+| Keycloak OOMKilled / 79+ restarts / limit=384Mi | Memory cap too low | `restore-keycloak.yml` (patches to 768Mi) |
+| Metabase OOMKilled / CrashLoop | JVM heap exceeds 400Mi container limit | `analytics-restore.yml` (patches to 600Mi) |
+| DuckDB API high restarts / OOMKilled | Memory spike from heavy query | `analytics-restore.yml` (restarts DuckDB) |
+| Grafana unreachable (HTTP 503) | Pod crash or OOM (256Mi limit) | `kubectl -n monitoring rollout restart deploy/kube-prom-grafana` (via remediate workflow) |
+| ntfy in Error / CrashLoopBackOff | Exit 1 or OOM (96Mi limit is tight) | `ntfy-restore.yml` (restart + optional limit raise) |
+| Pod `OOMKilled` (exit 137) — any service | Memory limit too low for workload | Patch limit up via strategic-merge patch in a workflow |
+| etcd `Failed compaction` in k3s logs | etcd boltdb growing toward quota (no defrag) | Trigger `etcd-defrag` CronJob manually |
 
 ## Distinguishing `PrometheusRuleFailures` from `PrometheusKubernetesListWatchFailures`
 
-These are **two different alerts** requiring different fixes:
+- **`PrometheusRuleFailures`** = Prometheus is running, talks to the API server, but a specific alerting rule times out (`kube-apiserver-burnrate.rules` — multi-day `rate()` over high-cardinality metrics). Fix: `prometheus-tune.yml`.
 
-- **`PrometheusRuleFailures`** = Prometheus is running and can talk to the API server, but a specific alerting rule fails to evaluate (e.g. `kube-apiserver-burnrate.rules` — multi-day `rate()` over high-cardinality metrics → `context deadline exceeded`). Fix: `pnpm prometheus:tune`.
-
-- **`PrometheusKubernetesListWatchFailures`** = Prometheus pod is running but cannot reach the Kubernetes API server to discover/watch resources (`GET /api/v1/nodes`, `/api/v1/pods`, etc. all fail). The alert fires from inside the cluster (pod IP `10.42.x.x`), which means pods are still running, but the k3s API server process has crashed or is returning `ServiceUnavailable`. Fix: restart k3s.
+- **`PrometheusKubernetesListWatchFailures`** = Prometheus pod is running but cannot reach the Kubernetes API server at all (k3s process crashed or returning `ServiceUnavailable`). Fix: restart k3s.
 
 ## Decoding `connection refused` vs `ServiceUnavailable`
 
 | Error | What it means |
 |---|---|
-| `dial tcp 100.113.41.119:6443: connect: connection refused` | Pi host is reachable via Tailscale (TCP RST received), but nothing is listening on port 6443 — k3s server process has stopped |
-| `Error from server (ServiceUnavailable): the server is currently unable to handle the request` | k3s is listening but the API server is overloaded or starting up — may self-recover in 2–5 min |
-| `connection timed out` or no response | Pi host itself unreachable — Tailscale on Pi may be down, or Pi lost power/network |
+| `dial tcp 100.113.41.119:6443: connect: connection refused` | Pi host reachable (TCP RST), k3s process stopped |
+| `Error from server (ServiceUnavailable)` | k3s listening but overloaded / starting up — may self-recover |
+| `connection timed out` / no response | Pi host unreachable — Tailscale down, power loss |
 
 ## SSH recovery path (requires `OMV_SSH_KEY` repo secret)
 
-The most reliable recovery when k3s is down. Requires `OMV_SSH_KEY` (the Pi's
-private key, base64-encoded or raw) stored as a GitHub repo secret.
-
 **Add the secret once:**
-1. Go to GitHub → Settings → Secrets → Actions → New repository secret
+1. GitHub → Settings → Secrets → Actions → New repository secret
 2. Name: `OMV_SSH_KEY`
-3. Value: the private key for `omv@100.113.41.119` (same key as `OMV_SSH_KEY_CONTENTS` in the Claude Code session secrets)
+3. Value: `cat ~/.ssh/id_ed25519` on the Pi (`omv@100.113.41.119`)
 
-**Trigger the restart:** edit `.github/workflows/k3s-ssh-restart.yml` → PR → squash-merge. The workflow SSHes in, restarts k3s, waits for port 6443, and posts the result to #382.
+**Trigger:** edit `.github/workflows/k3s-ssh-restart.yml` → PR → squash-merge.
 
-## Hard-won lessons (do not relearn these the hard way)
+## Hard-won lessons
 
-- **Never cap a JVM container below its `-Xmx` + non-heap working set.** Keycloak
-  26.2 (Quarkus) needs heap **plus ~180–220 MiB** non-heap. A 384 MiB cap on a
-  `-Xmx512m` heap → `OOMKilled` crash-loop. Size: 512 MiB heap → 768 MiB limit.
+- **Never cap a JVM container below `-Xmx` + non-heap working set.** Keycloak 26.2 needs 512Mi heap + ~200Mi non-heap → 768Mi limit. Metabase needs 320Mi heap + 128Mi → 450Mi minimum (use 600Mi).
 - **Keycloak's operative heap variable is `JAVA_OPTS_APPEND`, not `JAVA_OPTS_KC_HEAP`.** Patching the wrong one is a silent no-op.
 - **`kubectl apply -f <manifest>` from CI did not stick** while a direct `kubectl patch` did. Prefer strategic-merge patch for recovery.
-- **`error=Configuration` on a GET to `/api/auth/signin/keycloak` is NOT a bug.** Real login is POST+CSRF → `302` with `code_challenge_method=S256`.
-- **`PrometheusRuleFailures` ≠ `PrometheusKubernetesListWatchFailures`.** See decision table above. Running `pnpm prometheus:tune` does nothing for list-watch failures.
-- **`[self-hosted, omv, build]` runners are systemd services on the Pi host**, not k8s pods. They survive k3s crashes — but they also go offline when the Pi itself crashes or loses power. If the job queues for >2 min, the Pi is down.
-- **The watchdog is the durable fix.** Run `k3s-watchdog-deploy.yml` once to install `Restart=always` on the k3s systemd unit. This auto-recovers k3s crashes without any manual intervention.
-- **`PrometheusKubernetesListWatchFailures` self-resolves** once k3s API server is back up — Prometheus reconnects automatically within a few minutes.
+- **`PrometheusRuleFailures` ≠ `PrometheusKubernetesListWatchFailures`.** See decision table. `prometheus:tune` does nothing for list-watch failures.
+- **`[self-hosted, omv, build]` runners survive k3s crashes** (systemd service, not k8s pod) but go offline when the Pi itself crashes. If job queues >2 min, the Pi is down.
+- **The watchdog is the durable fix** — install it once with `k3s-watchdog-deploy.yml` (`OMV_SSH_KEY` required) to prevent future manual k3s restarts.
+- **`PrometheusKubernetesListWatchFailures` self-resolves** once k3s API is back up (Prometheus reconnects automatically).
+- **ntfy at 96Mi is fragile** — any spike crashes it. `ntfy-restore.yml` raises to 128Mi by default.
+- **Metabase at 400Mi can OOMKill** on heavy dashboard queries. `analytics-restore.yml` patches to 600Mi safely.
 
 ## Reading results
 
@@ -121,11 +141,13 @@ private key, base64-encoded or raw) stored as a GitHub repo secret.
 mcp__github__issue_read(method="get_comments", owner="themis128",
   repo="cloudless.gr", issue_number=382, perPage=1, page=<last>)
 ```
-Comments are chronological; the newest snapshot/log is the last page.
+Comments are chronological; newest snapshot/log is the last page.
 
 ## Reference
 
-- Keycloak deploy: ns `keycloak`, deploy `keycloak`, image `quay.io/keycloak/keycloak:26.2`, fronted by a Cloudflare tunnel.
-- Pi control-plane: `omv` / `192.168.1.128` / Tailscale `100.113.41.119`. k3s kubeconfig: `/etc/rancher/k3s/k3s.yaml`.
-- App login path: CloudFront → Lambda (primary) + Pi origin both serve `/api/auth/*`; both hand off to Keycloak once it is up.
-- Incident 2026-06-01: Keycloak OOM (384Mi → 768Mi fix). Incident 2026-06-02: k3s API server crash → `PrometheusKubernetesListWatchFailures` + `auth.cloudless.gr` 000000.
+- Keycloak: ns `keycloak`, deploy `keycloak`, image `quay.io/keycloak/keycloak:26.2`, fronted by Cloudflare tunnel.
+- Pi control-plane: `omv` / `192.168.1.128` / Tailscale `100.113.41.119`. kubeconfig: `/etc/rancher/k3s/k3s.yaml`.
+- Analytics: ns `analytics` — `metabase` (400Mi→600Mi), `duckdb-api` (1500Mi).
+- Monitoring: ns `monitoring` — prometheus (700Mi), grafana (256Mi), loki (400Mi), alertmanager (128Mi).
+- App services: ntfy (96Mi→128Mi), n8n (256Mi), cloudless (standby).
+- Incident 2026-06-01: Keycloak OOM (384Mi → 768Mi fix). Incident 2026-06-02: k3s API crash → `PrometheusKubernetesListWatchFailures`.

--- a/.github/workflows/analytics-restore.yml
+++ b/.github/workflows/analytics-restore.yml
@@ -1,0 +1,68 @@
+name: analytics-restore — recover OOMKilled Metabase or DuckDB API
+
+# Recovers analytics-namespace workloads (Metabase, DuckDB API) from OOM crashes.
+#
+# Trigger by touching this file or scripts/analytics-restore.sh, or via dispatch.
+#
+# When to use:
+#   - Metabase is in CrashLoopBackOff / OOMKilled
+#   - DuckDB API has high restart count
+#   - cluster-doctor shows analytics pods not Running
+#   - analytics.cloudless.gr or Grafana dashboards return errors
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - ".github/workflows/analytics-restore.yml"
+      - "scripts/analytics-restore.sh"
+  workflow_dispatch:
+    inputs:
+      metabase_mem_limit:
+        description: "Metabase memory limit (default: 600Mi)"
+        required: false
+        default: "600Mi"
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  restore:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    env:
+      GH_TOKEN: ${{ github.token }}
+      METABASE_MEM_LIMIT: ${{ github.event.inputs.metabase_mem_limit || '600Mi' }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v4.3.1
+
+      - name: Connect to tailnet
+        uses: tailscale/github-action@0263d9e6d793eaefcf1de98ff7fde47abe6664d3 # v3.2.4
+        with:
+          authkey: ${{ secrets.TS_AUTHKEY }}
+
+      - name: Configure kubectl
+        run: |
+          mkdir -p ~/.kube
+          echo "${{ secrets.KUBECONFIG_B64 }}" | base64 -d > ~/.kube/config
+          chmod 600 ~/.kube/config
+
+      - name: Run analytics-restore
+        id: restore
+        run: |
+          set -o pipefail
+          bash scripts/analytics-restore.sh 2>&1 | tee restore.log
+
+      - name: Post result to tracking issue
+        if: always()
+        run: |
+          {
+            echo "# Analytics restore — $(date -u '+%Y-%m-%d %H:%M:%SZ')"
+            echo ""
+            echo "**Status:** ${{ job.status }}"
+            echo ""
+            echo '```'
+            cat restore.log 2>/dev/null || echo "(no log)"
+            echo '```'
+          } | gh issue comment 382 --repo "$GITHUB_REPOSITORY" --body-file -

--- a/.github/workflows/ntfy-restore.yml
+++ b/.github/workflows/ntfy-restore.yml
@@ -1,0 +1,67 @@
+name: ntfy-restore — recover ntfy from CrashLoopBackOff or Error
+
+# Recovers ntfy (push notification server) from Error / CrashLoopBackOff state.
+#
+# Trigger by touching this file or scripts/ntfy-restore.sh, or via dispatch.
+#
+# When to use:
+#   - cluster-doctor shows ntfy in Error or CrashLoopBackOff
+#   - ntfy has restart count > 5
+#   - Push notifications to mobile are not arriving
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - ".github/workflows/ntfy-restore.yml"
+      - "scripts/ntfy-restore.sh"
+  workflow_dispatch:
+    inputs:
+      ntfy_mem_limit:
+        description: "ntfy memory limit (default: 128Mi; current live limit is 96Mi)"
+        required: false
+        default: "128Mi"
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  restore:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    env:
+      GH_TOKEN: ${{ github.token }}
+      NTFY_MEM_LIMIT: ${{ github.event.inputs.ntfy_mem_limit || '128Mi' }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v4.3.1
+
+      - name: Connect to tailnet
+        uses: tailscale/github-action@0263d9e6d793eaefcf1de98ff7fde47abe6664d3 # v3.2.4
+        with:
+          authkey: ${{ secrets.TS_AUTHKEY }}
+
+      - name: Configure kubectl
+        run: |
+          mkdir -p ~/.kube
+          echo "${{ secrets.KUBECONFIG_B64 }}" | base64 -d > ~/.kube/config
+          chmod 600 ~/.kube/config
+
+      - name: Run ntfy-restore
+        id: restore
+        run: |
+          set -o pipefail
+          bash scripts/ntfy-restore.sh 2>&1 | tee restore.log
+
+      - name: Post result to tracking issue
+        if: always()
+        run: |
+          {
+            echo "# ntfy restore — $(date -u '+%Y-%m-%d %H:%M:%SZ')"
+            echo ""
+            echo "**Status:** ${{ job.status }}"
+            echo ""
+            echo '```'
+            cat restore.log 2>/dev/null || echo "(no log)"
+            echo '```'
+          } | gh issue comment 382 --repo "$GITHUB_REPOSITORY" --body-file -

--- a/scripts/analytics-restore.sh
+++ b/scripts/analytics-restore.sh
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+#
+# analytics-restore.sh — recover OOMKilled or crash-looping analytics workloads
+# (Metabase and DuckDB API) in the analytics namespace.
+#
+# What it does:
+#   1. Checks Metabase and DuckDB API pod states
+#   2. If Metabase is OOMKilled/CrashLooping, patches its memory limit up
+#      (default: 600Mi, current cap is 400Mi which is tight for the JVM)
+#   3. Restarts affected deployments and waits for Ready
+#   4. Reports before/after state
+#
+# Idempotent — safe to re-run. Only patches if the live state needs it.
+#
+# Env overrides:
+#   METABASE_MEM_LIMIT   (default: 600Mi)
+#   METABASE_JAVA_OPTS   (default: -Xmx480m -Xms128m)
+#   DUCKDB_MEM_LIMIT     (default: 1500Mi — already generous, only raise if needed)
+#   ANALYTICS_NS         (default: analytics)
+
+set -uo pipefail
+
+NS="${ANALYTICS_NS:-analytics}"
+METABASE_MEM_LIMIT="${METABASE_MEM_LIMIT:-600Mi}"
+METABASE_JAVA_OPTS="${METABASE_JAVA_OPTS:--Xmx480m -Xms128m}"
+DUCKDB_MEM_LIMIT="${DUCKDB_MEM_LIMIT:-1500Mi}"
+
+note() { printf "[analytics-restore] %s\n" "$*"; }
+k() { kubectl "$@" 2>&1 || true; }
+
+note "=== analytics-restore $(date -u '+%F %T')Z ==="
+
+pod_last_exit() {
+  kubectl -n "$NS" get pods -l "app=$1" \
+    -o jsonpath='{.items[0].status.containerStatuses[0].lastState.terminated.reason}' \
+    2>/dev/null || echo ""
+}
+pod_restarts() {
+  kubectl -n "$NS" get pods -l "app=$1" \
+    -o jsonpath='{.items[0].status.containerStatuses[0].restartCount}' \
+    2>/dev/null || echo "0"
+}
+deploy_live_limit() {
+  kubectl -n "$NS" get deploy "$1" \
+    -o jsonpath='{.spec.template.spec.containers[0].resources.limits.memory}' \
+    2>/dev/null || echo "unknown"
+}
+deploy_ready() {
+  kubectl -n "$NS" get deploy "$1" \
+    -o jsonpath='{.status.readyReplicas}' 2>/dev/null || echo "0"
+}
+
+# ── Metabase ──────────────────────────────────────────────────────────────────
+MB_RESTARTS=$(pod_restarts metabase)
+MB_EXIT=$(pod_last_exit metabase)
+MB_LIMIT=$(deploy_live_limit metabase)
+
+note "Metabase: restarts=${MB_RESTARTS} lastExit=${MB_EXIT:-none} liveLimit=${MB_LIMIT}"
+
+if [ "$MB_EXIT" = "OOMKilled" ] || [ "${MB_RESTARTS:-0}" -gt 3 ] || [ "$MB_LIMIT" = "400Mi" ]; then
+  note "Metabase needs recovery (OOMKilled or limit=400Mi) → patching to ${METABASE_MEM_LIMIT}"
+  PATCH=$(printf '{"spec":{"template":{"spec":{"containers":[{"name":"metabase","resources":{"requests":{"memory":"256Mi","cpu":"100m"},"limits":{"memory":"%s","cpu":"1"}},"env":[{"name":"JAVA_OPTS","value":"%s"},{"name":"MB_JETTY_MAXTHREADS","value":"20"}]}]}}}}' \
+    "$METABASE_MEM_LIMIT" "$METABASE_JAVA_OPTS")
+  kubectl -n "$NS" patch deploy metabase --type=strategic -p "$PATCH" >/dev/null 2>&1 && \
+    note "  patched Metabase → ${METABASE_MEM_LIMIT} / ${METABASE_JAVA_OPTS}" || \
+    note "  WARNING: patch failed"
+  kubectl -n "$NS" rollout restart deploy/metabase >/dev/null 2>&1
+  note "  waiting for Metabase rollout (up to 3 min)..."
+  kubectl -n "$NS" rollout status deploy/metabase --timeout=180s >/dev/null 2>&1 || true
+  note "  after rollout: limit=$(deploy_live_limit metabase) ready=$(deploy_ready metabase)"
+else
+  note "Metabase OK — no recovery needed"
+fi
+
+# ── DuckDB API ────────────────────────────────────────────────────────────────
+DB_RESTARTS=$(pod_restarts duckdb-api)
+DB_EXIT=$(pod_last_exit duckdb-api)
+DB_LIMIT=$(deploy_live_limit duckdb-api)
+
+note "DuckDB API: restarts=${DB_RESTARTS} lastExit=${DB_EXIT:-none} liveLimit=${DB_LIMIT}"
+
+if [ "$DB_EXIT" = "OOMKilled" ] || [ "${DB_RESTARTS:-0}" -gt 5 ]; then
+  note "DuckDB API OOMKilled → restarting (limit already ${DB_LIMIT})"
+  kubectl -n "$NS" rollout restart deploy/duckdb-api >/dev/null 2>&1
+  note "  waiting for DuckDB API rollout (up to 2 min)..."
+  kubectl -n "$NS" rollout status deploy/duckdb-api --timeout=120s >/dev/null 2>&1 || true
+  note "  after rollout: ready=$(deploy_ready duckdb-api)"
+else
+  note "DuckDB API OK — no recovery needed"
+fi
+
+# ── Summary ───────────────────────────────────────────────────────────────────
+note ""
+note "=== Final state ==="
+kubectl -n "$NS" get pods -o wide 2>&1 || true
+note ""
+note "=== DONE ==="

--- a/scripts/cluster-doctor.sh
+++ b/scripts/cluster-doctor.sh
@@ -1,158 +1,280 @@
 #!/usr/bin/env bash
 #
-# cluster-doctor.sh — read-only diagnostics for the omv k3s cluster, with a
-# focus on why Keycloak (auth.cloudless.gr) might be down. [triggered 2026-06-02T-listwatch]
+# cluster-doctor.sh — comprehensive read-only diagnostics for the omv k3s cluster.
 #
-# Emits a Markdown report to stdout. Every kubectl call is best-effort (|| true)
-# so the report is always produced even when individual objects are missing.
-# Requires a kubectl context pointed at the cluster (the cluster-doctor.yml
-# workflow supplies one via Tailscale + KUBECONFIG_B64).
+# Covers every service tier:
+#   Tier 1 — Auth     : Keycloak, PostgreSQL
+#   Tier 2 — App      : cloudless, ntfy, n8n
+#   Tier 3 — Monitoring: Prometheus, Grafana, Alertmanager, Loki
+#   Tier 4 — Analytics : Metabase, DuckDB API
+#   Tier 5 — Infra    : Nodes, etcd-defrag, maintenance CronJobs
+#   Tier 6 — External : Public HTTP surfaces, GitHub runners
+#
+# Emits Markdown to stdout. Every kubectl/curl call is best-effort (|| true)
+# so the report always completes even when individual objects are missing.
 #
 # Usage:
 #   bash scripts/cluster-doctor.sh
-#   NAMESPACE=keycloak DEPLOYMENT=keycloak bash scripts/cluster-doctor.sh
+#
+# Env overrides:
+#   KC_NS, KC_DEPLOY, PROM_NS, ANALYTICS_NS, CLOUDLESS_NS, DISCOVERY
 
 set -uo pipefail
 
-NAMESPACE="${NAMESPACE:-keycloak}"
-DEPLOYMENT="${DEPLOYMENT:-keycloak}"
+KC_NS="${KC_NS:-keycloak}"
+KC_DEPLOY="${KC_DEPLOY:-keycloak}"
+PROM_NS="${PROM_NS:-monitoring}"
+ANALYTICS_NS="${ANALYTICS_NS:-analytics}"
+CLOUDLESS_NS="${CLOUDLESS_NS:-cloudless}"
 DISCOVERY="${DISCOVERY:-https://auth.cloudless.gr/realms/master/.well-known/openid-configuration}"
+GRAFANA_URL="${GRAFANA_URL:-https://grafana.cloudless.gr/api/health}"
+LAMBDA_URL="${LAMBDA_URL:-https://cloudless.gr/api/health}"
 
 k() { kubectl "$@" 2>&1 || true; }
 section() { printf "\n## %s\n\n" "$*"; }
 fence()  { printf '```\n'; cat; printf '```\n'; }
+http_check() { curl -sS -m 8 -o /dev/null -w '%{http_code}' "$1" 2>/dev/null || echo 000; }
+pod_states() {
+  local ns="$1" selector="$2"
+  kubectl -n "$ns" get pods -l "$selector" \
+    -o jsonpath='{range .items[*]}{.metadata.name}{":\n"}{range .status.containerStatuses[*]}{"  "}{.name}{": restarts="}{.restartCount}{" ready="}{.ready}{" waiting="}{.state.waiting.reason}{" lastExit="}{.lastState.terminated.reason}{"(exit "}{.lastState.terminated.exitCode}{")\n"}{end}{end}' \
+    2>&1 || true
+}
+deploy_limits() {
+  local ns="$1" deploy="$2"
+  kubectl -n "$ns" get deploy "$deploy" \
+    -o jsonpath='{range .spec.template.spec.containers[*]}{.name}{"\n  limits="}{.resources.limits}{"\n  requests="}{.resources.requests}{"\n"}{end}' \
+    2>/dev/null || true
+}
 
 printf "# Cluster snapshot — %s\n" "$(date -u '+%Y-%m-%d %H:%M:%SZ')"
 
+# ═══════════════════════════════════════════════════════════════════════════════
+# TIER 1 — AUTH
+# ═══════════════════════════════════════════════════════════════════════════════
+
 section "auth.cloudless.gr"
-code=$(curl -sS -m 8 -o /dev/null -w '%{http_code}' "$DISCOVERY" 2>/dev/null || echo 000)
-printf "OIDC discovery: **HTTP %s** (200 = up)\n" "$code"
+kc_http=$(http_check "$DISCOVERY")
+printf "OIDC discovery: **HTTP %s** (200 = up)\n" "$kc_http"
+
+section "Keycloak: deployment"
+k -n "$KC_NS" get deploy "$KC_DEPLOY" -o wide | fence
+printf "Limits + heap:\n"
+deploy_limits "$KC_NS" "$KC_DEPLOY" | fence
+
+section "Keycloak: pods"
+k -n "$KC_NS" get pods -o wide | fence
+printf "Container states:\n"
+pod_states "$KC_NS" "app=${KC_DEPLOY}" | fence
+
+section "Keycloak: recent events"
+kubectl -n "$KC_NS" get events --sort-by=.lastTimestamp 2>/dev/null | tail -15 | fence
+
+section "Keycloak: logs (last 30 lines)"
+k -n "$KC_NS" logs "deploy/$KC_DEPLOY" --tail=30 | fence
+
+section "Keycloak: previous container logs (crash cause)"
+pod=$(kubectl -n "$KC_NS" get pods -l app="$KC_DEPLOY" -o name 2>/dev/null | head -1)
+[ -n "$pod" ] \
+  && k -n "$KC_NS" logs "$pod" --previous --tail=30 | fence \
+  || printf "_no pod found via label app=%s_\n" "$KC_DEPLOY"
+
+section "Keycloak: memory limit drift"
+live=$(kubectl -n "$KC_NS" get deploy "$KC_DEPLOY" \
+  -o jsonpath='{.spec.template.spec.containers[0].resources.limits.memory}' 2>&1)
+last_applied=$(kubectl -n "$KC_NS" get deploy "$KC_DEPLOY" \
+  -o jsonpath='{.metadata.annotations.kubectl\.kubernetes\.io/last-applied-configuration}' \
+  2>/dev/null | grep -oE '"memory":"[^"]*"' | tail -1)
+printf "live limit: %s\n" "$live"
+printf "last-applied limit: %s\n" "$last_applied"
+[ "$live" = "384Mi" ] && printf "\n**WARNING: Keycloak is still at 384Mi — will OOMKill. Run keycloak:restore.**\n"
+
+section "PostgreSQL (keycloak/postgres)"
+k -n "$KC_NS" get pods -l app=postgres -o wide | fence
+printf "Container states:\n"
+pod_states "$KC_NS" "app=postgres" | fence
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# TIER 2 — APP SERVICES
+# ═══════════════════════════════════════════════════════════════════════════════
+
+section "cloudless app (k3s standby — ns ${CLOUDLESS_NS})"
+k -n "$CLOUDLESS_NS" get deploy cloudless -o wide | fence
+printf "Limits + image:\n"
+kubectl -n "$CLOUDLESS_NS" get deploy cloudless \
+  -o jsonpath='{range .spec.template.spec.containers[*]}{.name}{"\n  image="}{.image}{"\n  limits="}{.resources.limits}{"\n  requests="}{.resources.requests}{"\n"}{end}' \
+  2>/dev/null | fence
+printf "envFrom secrets: "
+kubectl -n "$CLOUDLESS_NS" get deploy cloudless \
+  -o jsonpath='{range .spec.template.spec.containers[*]}{range .envFrom[*]}{.secretRef.name}{" "}{end}{end}' \
+  2>/dev/null
+printf "\nAUTH_URL=%s  AUTH_TRUST_HOST=%s\n" \
+  "$(kubectl -n "$CLOUDLESS_NS" get deploy cloudless -o jsonpath='{.spec.template.spec.containers[0].env[?(@.name=="AUTH_URL")].value}' 2>/dev/null)" \
+  "$(kubectl -n "$CLOUDLESS_NS" get deploy cloudless -o jsonpath='{.spec.template.spec.containers[0].env[?(@.name=="AUTH_TRUST_HOST")].value}' 2>/dev/null)"
+
+section "cloudless app: pods"
+k -n "$CLOUDLESS_NS" get pods -o wide | fence
+printf "Container states:\n"
+pod_states "$CLOUDLESS_NS" "app=cloudless" | fence
+
+section "ntfy (push notifications)"
+k -n ntfy get deploy -o wide 2>/dev/null | fence
+printf "Container states:\n"
+pod_states ntfy "app=ntfy" | fence
+printf "Limits:\n"
+deploy_limits ntfy ntfy 2>/dev/null | fence
+
+section "n8n (workflow automation)"
+k -n n8n get deploy -o wide 2>/dev/null | fence
+printf "Container states:\n"
+pod_states n8n "app=n8n" | fence
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# TIER 3 — MONITORING STACK
+# ═══════════════════════════════════════════════════════════════════════════════
+
+section "Prometheus: pods"
+k -n "$PROM_NS" get pods -l app.kubernetes.io/name=prometheus -o wide | fence
+printf "Container states:\n"
+pod_states "$PROM_NS" "app.kubernetes.io/name=prometheus" | fence
+printf "Prometheus memory limit: %s\n" \
+  "$(kubectl -n "$PROM_NS" get sts -l app.kubernetes.io/name=prometheus \
+    -o jsonpath='{.items[0].spec.template.spec.containers[?(@.name=="prometheus")].resources.limits.memory}' 2>&1)"
+
+section "Prometheus: failing rules"
+kubectl -n "$PROM_NS" run "promq-$$" --image=curlimages/curl:8.11.1 \
+  --restart=Never --rm -i --quiet \
+  --command -- curl -sS --max-time 12 \
+  "http://prometheus-operated.${PROM_NS}.svc:9090/api/v1/rules" \
+  2>/dev/null > /tmp/promrules.json || true
+if [ -s /tmp/promrules.json ]; then
+  jq -r '
+    [ .data.groups[]
+      | .name as $g | .rules[]
+      | select((.health != "ok") or ((.lastError // "") != ""))
+      | "[\($g)] \(.name)  health=\(.health)\n    lastError: \(.lastError // "")"
+    ] as $bad
+    | if ($bad|length)==0 then "all rules healthy (no eval failures right now)"
+      else $bad[] end
+  ' /tmp/promrules.json 2>&1 | fence
+  printf "rule groups: %s, rules: %s\n" \
+    "$(jq '.data.groups|length' /tmp/promrules.json 2>/dev/null)" \
+    "$(jq '[.data.groups[].rules[]]|length' /tmp/promrules.json 2>/dev/null)"
+else
+  printf "_could not fetch /api/v1/rules_\n"
+fi
+
+section "Grafana"
+k -n "$PROM_NS" get deploy -l "app.kubernetes.io/name=grafana" -o wide 2>/dev/null | fence
+printf "Container states:\n"
+kubectl -n "$PROM_NS" get pods -l "app.kubernetes.io/name=grafana" \
+  -o jsonpath='{range .items[*]}{.metadata.name}{":\n"}{range .status.containerStatuses[*]}{"  "}{.name}{": restarts="}{.restartCount}{" ready="}{.ready}{" lastExit="}{.lastState.terminated.reason}{"\n"}{end}{end}' \
+  2>&1 | fence
+grafana_http=$(http_check "$GRAFANA_URL")
+printf "grafana.cloudless.gr/api/health: **HTTP %s** (200 = up)\n" "$grafana_http"
+
+section "Alertmanager"
+k -n "$PROM_NS" get pods -l "app.kubernetes.io/name=alertmanager" -o wide | fence
+printf "Container states:\n"
+pod_states "$PROM_NS" "app.kubernetes.io/name=alertmanager" | fence
+
+section "Loki"
+k -n "$PROM_NS" get statefulsets loki -o wide 2>/dev/null | fence
+printf "Container states:\n"
+kubectl -n "$PROM_NS" get pods -l "app.kubernetes.io/name=loki" \
+  -o jsonpath='{range .items[*]}{.metadata.name}{":\n"}{range .status.containerStatuses[*]}{"  "}{.name}{": restarts="}{.restartCount}{" ready="}{.ready}{" lastExit="}{.lastState.terminated.reason}{"\n"}{end}{end}' \
+  2>&1 | fence
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# TIER 4 — ANALYTICS STACK
+# ═══════════════════════════════════════════════════════════════════════════════
+
+section "Metabase (analytics/metabase)"
+k -n "$ANALYTICS_NS" get deploy metabase -o wide 2>/dev/null | fence
+printf "Container states:\n"
+pod_states "$ANALYTICS_NS" "app=metabase" | fence
+printf "Limits:\n"
+deploy_limits "$ANALYTICS_NS" metabase 2>/dev/null | fence
+
+section "DuckDB API (analytics/duckdb-api)"
+k -n "$ANALYTICS_NS" get deploy duckdb-api -o wide 2>/dev/null | fence
+printf "Container states:\n"
+pod_states "$ANALYTICS_NS" "app=duckdb-api" | fence
+printf "Limits:\n"
+deploy_limits "$ANALYTICS_NS" duckdb-api 2>/dev/null | fence
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# TIER 5 — INFRASTRUCTURE
+# ═══════════════════════════════════════════════════════════════════════════════
 
 section "Nodes"
 k get nodes -o wide | fence
 k top nodes | fence
 
-section "Node memory pressure / conditions"
+section "Node conditions + allocated resources"
 for n in $(kubectl get nodes -o name 2>/dev/null | sed 's#node/##'); do
   printf "### %s\n" "$n"
   kubectl describe node "$n" 2>/dev/null \
-    | grep -iE "MemoryPressure|DiskPressure|PIDPressure|Allocated resources|memory " \
-    | head -20 | fence
+    | grep -iE "MemoryPressure|DiskPressure|PIDPressure|Allocated resources:|memory\s|cpu\s" \
+    | head -15 | fence
 done
 
 section "Pods not Running/Completed (all namespaces)"
 k get pods -A --field-selector=status.phase!=Running 2>/dev/null \
   | grep -vE "Completed|Succeeded" | fence
 
-section "Keycloak: deployment"
-k -n "$NAMESPACE" get deploy "$DEPLOYMENT" -o wide | fence
-printf "Resource limits/requests + heap env:\n"
-kubectl -n "$NAMESPACE" get deploy "$DEPLOYMENT" \
-  -o jsonpath='{range .spec.template.spec.containers[*]}{.name}{"\n  limits="}{.resources.limits}{"\n  requests="}{.resources.requests}{"\n  env="}{range .env[*]}{.name}{"="}{.value}{" "}{end}{"\n"}{end}' \
+section "etcd-defrag: last 3 runs"
+k -n "$PROM_NS" get jobs -l app=etcd-defrag \
+  --sort-by=.metadata.creationTimestamp 2>/dev/null | tail -4 | fence
+printf "Last defrag log (tail 10):\n"
+k -n "$PROM_NS" logs -l app=etcd-defrag --tail=10 2>/dev/null | fence
+
+section "Maintenance CronJobs (recent failures)"
+k -n maintenance get cronjobs 2>/dev/null | fence
+k -n maintenance get jobs --sort-by=.metadata.creationTimestamp 2>/dev/null \
+  | tail -10 | fence
+printf "Recent failed jobs:\n"
+kubectl -n maintenance get jobs \
+  -o jsonpath='{range .items[?(@.status.failed>0)]}{.metadata.name}{" failed="}{.status.failed}{" start="}{.status.startTime}{"\n"}{end}' \
   2>/dev/null | fence
 
-section "Keycloak: pods"
-k -n "$NAMESPACE" get pods -o wide | fence
-printf "Container states (waiting/last-terminated reasons — look for OOMKilled / CrashLoopBackOff):\n"
-kubectl -n "$NAMESPACE" get pods -o jsonpath='{range .items[*]}{.metadata.name}{":\n"}{range .status.containerStatuses[*]}{"  restarts="}{.restartCount}{" ready="}{.ready}{" waiting="}{.state.waiting.reason}{" lastTerminated="}{.lastState.terminated.reason}{"(exit "}{.lastState.terminated.exitCode}{")\n"}{end}{end}' \
-  2>/dev/null | fence
+section "Cluster-alerts CronJob (Slack error notifier)"
+k -n "$PROM_NS" get cronjob cluster-alerts 2>/dev/null | fence
+k -n "$PROM_NS" get jobs -l app=cluster-alerts \
+  --sort-by=.metadata.creationTimestamp 2>/dev/null | tail -4 | fence
 
-section "Keycloak: recent events"
-kubectl -n "$NAMESPACE" get events --sort-by=.lastTimestamp 2>/dev/null | tail -25 | fence
+# ═══════════════════════════════════════════════════════════════════════════════
+# TIER 6 — EXTERNAL / OBSERVABILITY
+# ═══════════════════════════════════════════════════════════════════════════════
 
-section "Keycloak: logs (current, last 40 lines)"
-k -n "$NAMESPACE" logs "deploy/$DEPLOYMENT" --tail=40 | fence
-
-section "Keycloak: logs (previous container, last 40 lines — crash cause)"
-pod=$(kubectl -n "$NAMESPACE" get pods -l app="$DEPLOYMENT" -o name 2>/dev/null | head -1)
-[ -n "$pod" ] && k -n "$NAMESPACE" logs "$pod" --previous --tail=40 | fence || printf "_no pod found via label app=%s_\n" "$DEPLOYMENT"
-
-section "Identity & write permissions (can the CI kubeconfig recover Keycloak?)"
-printf "whoami: %s\n" "$(kubectl auth whoami 2>&1 | tr '\n' ' ')"
-for verb in get patch update; do
-  printf "  can-i %-6s deployments -n %s : %s\n" "$verb" "$NAMESPACE" "$(kubectl auth can-i "$verb" deployments -n "$NAMESPACE" 2>&1)"
+section "Public HTTP surfaces"
+for entry in \
+  "Lambda /api/health|${LAMBDA_URL}" \
+  "Lambda /api/auth/session|https://cloudless.gr/api/auth/session" \
+  "Keycloak OIDC|${DISCOVERY}" \
+  "Keycloak JWKS|https://auth.cloudless.gr/realms/master/protocol/openid-connect/certs" \
+  "Grafana|${GRAFANA_URL}"
+do
+  IFS='|' read -r label url <<< "$entry"
+  code=$(http_check "$url")
+  icon="✓"; [ "$code" != "200" ] && icon="✗"
+  printf "%s  %-35s HTTP %s\n" "$icon" "$label" "$code"
 done
-printf "  can-i patch  limitranges -n %s : %s\n" "$NAMESPACE" "$(kubectl auth can-i patch limitranges -n "$NAMESPACE" 2>&1)"
-printf "  can-i create deployments/rollout (restart) -n %s : %s\n" "$NAMESPACE" "$(kubectl auth can-i patch deployments -n "$NAMESPACE" --subresource=scale 2>&1)"
 
-section "Keycloak: rollout history (did a restart ever roll a new ReplicaSet?)"
-k -n "$NAMESPACE" rollout history "deploy/$DEPLOYMENT" | fence
+section "Identity & write permissions (can CI kubeconfig recover services?)"
+printf "whoami: %s\n" "$(kubectl auth whoami 2>&1 | tr '\n' ' ')"
+for ns in "$KC_NS" "$PROM_NS" "$ANALYTICS_NS" ntfy n8n; do
+  printf "  %-12s patch deployments: %s\n" "$ns" \
+    "$(kubectl auth can-i patch deployments -n "$ns" 2>&1)"
+done
 
-section "Keycloak deploy: ownership — who reconciles it (Helm/Argo/Flux)?"
-printf "managed-by label: %s\n" "$(kubectl -n "$NAMESPACE" get deploy "$DEPLOYMENT" -o jsonpath='{.metadata.labels.app\.kubernetes\.io/managed-by}' 2>&1)"
-printf "ownerReferences:  %s\n" "$(kubectl -n "$NAMESPACE" get deploy "$DEPLOYMENT" -o jsonpath='{.metadata.ownerReferences}' 2>&1)"
-printf "GitOps annotations:\n"
-kubectl -n "$NAMESPACE" get deploy "$DEPLOYMENT" -o jsonpath='{.metadata.annotations}' 2>/dev/null \
-  | tr ',' '\n' | grep -iE "helm|argocd|fluxcd|kustomize\.toolkit|reconcile|managed-by" | fence
-printf "field managers (who last wrote each field):\n"
-kubectl -n "$NAMESPACE" get deploy "$DEPLOYMENT" -o jsonpath='{range .metadata.managedFields[*]}{.manager}{" ("}{.operation}{", "}{.apiVersion}{")\n"}{end}' 2>&1 | fence
-printf "live container[0] memory limit: %s\n" "$(kubectl -n "$NAMESPACE" get deploy "$DEPLOYMENT" -o jsonpath='{.spec.template.spec.containers[0].resources.limits.memory}' 2>&1)"
-printf "last-applied (kubectl apply) memory limit: %s\n" "$(kubectl -n "$NAMESPACE" get deploy "$DEPLOYMENT" -o jsonpath='{.metadata.annotations.kubectl\.kubernetes\.io/last-applied-configuration}' 2>/dev/null | grep -oE '\"memory\":\"[0-9]+Mi\"' | tail -1)"
-
-# ── Prometheus health (PrometheusRuleFailures triage) ───────────────────────
-PROM_NS="${PROM_NS:-monitoring}"
-section "Prometheus: pods (restarts / OOM — is it starved like Keycloak was?)"
-k -n "$PROM_NS" get pods -l app.kubernetes.io/name=prometheus -o wide | fence
-printf "container states:\n"
-kubectl -n "$PROM_NS" get pods -l app.kubernetes.io/name=prometheus -o jsonpath='{range .items[*]}{.metadata.name}{"\n"}{range .status.containerStatuses[*]}{"  "}{.name}{": restarts="}{.restartCount}{" ready="}{.ready}{" lastTerminated="}{.lastState.terminated.reason}{"\n"}{end}{end}' 2>&1 | fence
-printf "prometheus container memory limit: %s\n" "$(kubectl -n "$PROM_NS" get sts -l app.kubernetes.io/name=prometheus -o jsonpath='{.items[0].spec.template.spec.containers[?(@.name=="prometheus")].resources.limits.memory}' 2>&1)"
-
-section "Prometheus: failing rules (health != ok) + lastError"
-# Curl the rules API from an in-cluster pod, parse with jq on the runner.
-kubectl -n "$PROM_NS" run "promq-$$" --image=curlimages/curl:8.11.1 --restart=Never --rm -i --quiet \
-  --command -- curl -sS --max-time 12 "http://prometheus-operated.${PROM_NS}.svc:9090/api/v1/rules" 2>/dev/null \
-  > /tmp/promrules.json || true
-if [ -s /tmp/promrules.json ]; then
-  jq -r '
-    [ .data.groups[]
-      | .name as $g
-      | .rules[]
-      | select((.health != "ok") or ((.lastError // "") != ""))
-      | "[\($g)] \(.name)  health=\(.health)  type=\(.type)\n    lastError: \(.lastError // "")"
-    ] as $bad
-    | if ($bad|length)==0 then "all rules healthy (no eval failures right now)"
-      else $bad[] end
-  ' /tmp/promrules.json 2>&1 | fence
-  printf "rule groups total: %s, rules total: %s\n" \
-    "$(jq '.data.groups|length' /tmp/promrules.json 2>/dev/null)" \
-    "$(jq '[.data.groups[].rules[]]|length' /tmp/promrules.json 2>/dev/null)"
+section "GitHub Actions runners"
+if command -v gh >/dev/null 2>&1 && [ -n "${GH_TOKEN:-}" ]; then
+  gh api repos/Themis128/cloudless.gr/actions/runners --jq \
+    '.runners[] | "  \(if .status=="online" then "✓" else "✗" end)  \(.name)  \(.status)  \(if .busy then "busy" else "idle" end)  labels=\([.labels[].name] | join(","))"' \
+    2>/dev/null || printf "  (gh auth or token missing)\n"
 else
-  printf "_could not fetch /api/v1/rules (empty response)_\n"
+  printf "  (GH_TOKEN not set — skipping runner check)\n"
 fi
 
-section "cloudless app: deployment (k3s standby E2E target — ns cloudless)"
-k -n cloudless get deploy cloudless -o wide | fence
-printf "Resource limits + image:\n"
-kubectl -n cloudless get deploy cloudless \
-  -o jsonpath='{range .spec.template.spec.containers[*]}{.name}{"\n  image="}{.image}{"\n  limits="}{.resources.limits}{"\n  requests="}{.resources.requests}{"\n"}{end}' \
-  2>/dev/null | fence
-printf "Env vars (pi-origin 403 triage — HOSTNAME, AUTH_URL, APP_VERSION, envFrom):\n"
-kubectl -n cloudless get deploy cloudless \
-  -o jsonpath='{range .spec.template.spec.containers[*]}{range .env[*]}{.name}{"="}{.value}{"\n"}{end}{end}' \
-  2>/dev/null | fence
-printf "envFrom secrets: "
-kubectl -n cloudless get deploy cloudless \
-  -o jsonpath='{range .spec.template.spec.containers[*]}{range .envFrom[*]}{.secretRef.name}{" "}{end}{end}' \
-  2>/dev/null
-printf "\n"
-
-section "cloudless app: all pods in ns cloudless"
-k -n cloudless get pods -o wide | fence
-printf "Container states:\n"
-kubectl -n cloudless get pods -o jsonpath='{range .items[*]}{.metadata.name}{":\n"}{range .status.containerStatuses[*]}{"  restarts="}{.restartCount}{" ready="}{.ready}{" waiting="}{.state.waiting.reason}{" lastTerminated="}{.lastState.terminated.reason}{"(exit "}{.lastState.terminated.exitCode}{")\n"}{end}{end}' \
-  2>/dev/null | fence
-
-section "cloudless app: recent events (ns cloudless)"
-kubectl -n cloudless get events --sort-by=.lastTimestamp 2>/dev/null | tail -20 | fence
-
-section "cloudless app: logs (last 40 lines)"
-k -n cloudless logs deploy/cloudless --tail=40 | fence
-
-section "cloudless app: logs (previous container, last 40 lines)"
-pod=$(kubectl -n cloudless get pods -l app=cloudless -o name 2>/dev/null | head -1)
-[ -n "$pod" ] && k -n cloudless logs "$pod" --previous --tail=40 | fence || printf "_no cloudless pod found_\n"
-
 printf "\n_End of snapshot._\n"
-
-# re-trigger-doctor-20260602d
-# triggered 2026-06-02 14:09:45Z

--- a/scripts/ntfy-restore.sh
+++ b/scripts/ntfy-restore.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+#
+# ntfy-restore.sh — recover ntfy (push notification server) from Error or
+# CrashLoopBackOff state.
+#
+# ntfy is small but has been observed crashing with exit 1 after 34+ restarts
+# (cluster snapshot 2026-06-01). The default 96Mi limit from memory-relief
+# is tight — this script raises it if the pod is OOMKilling.
+#
+# What it does:
+#   1. Checks ntfy pod state and restart count
+#   2. If OOMKilled: raises memory limit (default: 128Mi)
+#   3. If generic Error/CrashLoop: force-restarts the deployment
+#   4. Waits for Ready and reports
+#
+# Idempotent — safe to re-run.
+#
+# Env overrides:
+#   NTFY_MEM_LIMIT   (default: 128Mi)
+#   NTFY_NS          (default: ntfy)
+
+set -uo pipefail
+
+NS="${NTFY_NS:-ntfy}"
+NTFY_MEM_LIMIT="${NTFY_MEM_LIMIT:-128Mi}"
+
+note() { printf "[ntfy-restore] %s\n" "$*"; }
+k() { kubectl "$@" 2>&1 || true; }
+
+note "=== ntfy-restore $(date -u '+%F %T')Z ==="
+
+RESTARTS=$(kubectl -n "$NS" get pods -l app=ntfy \
+  -o jsonpath='{.items[0].status.containerStatuses[0].restartCount}' \
+  2>/dev/null || echo "0")
+LAST_EXIT=$(kubectl -n "$NS" get pods -l app=ntfy \
+  -o jsonpath='{.items[0].status.containerStatuses[0].lastState.terminated.reason}' \
+  2>/dev/null || echo "")
+WAIT_REASON=$(kubectl -n "$NS" get pods -l app=ntfy \
+  -o jsonpath='{.items[0].status.containerStatuses[0].state.waiting.reason}' \
+  2>/dev/null || echo "")
+LIVE_LIMIT=$(kubectl -n "$NS" get deploy ntfy \
+  -o jsonpath='{.spec.template.spec.containers[0].resources.limits.memory}' \
+  2>/dev/null || echo "unknown")
+
+note "ntfy: restarts=${RESTARTS} lastExit=${LAST_EXIT:-none} waiting=${WAIT_REASON:-none} liveLimit=${LIVE_LIMIT}"
+
+printf "\n=== ntfy logs (last 20 lines before restore) ===\n"
+k -n "$NS" logs deploy/ntfy --tail=20 || true
+
+PATCHED=0
+if [ "$LAST_EXIT" = "OOMKilled" ]; then
+  note "OOMKilled → raising memory limit to ${NTFY_MEM_LIMIT}"
+  PATCH=$(printf '{"spec":{"template":{"spec":{"containers":[{"name":"ntfy","resources":{"requests":{"memory":"32Mi","cpu":"10m"},"limits":{"memory":"%s","cpu":"200m"}}}]}}}}' \
+    "$NTFY_MEM_LIMIT")
+  kubectl -n "$NS" patch deploy ntfy --type=strategic -p "$PATCH" >/dev/null 2>&1 && \
+    note "  patched ntfy → ${NTFY_MEM_LIMIT}" || note "  WARNING: patch failed"
+  PATCHED=1
+fi
+
+if [ "$LAST_EXIT" = "Error" ] || [ "$WAIT_REASON" = "CrashLoopBackOff" ] || \
+   [ "${RESTARTS:-0}" -gt 5 ] || [ "$PATCHED" = "1" ]; then
+  note "Restarting ntfy deployment..."
+  kubectl -n "$NS" rollout restart deploy/ntfy >/dev/null 2>&1
+  note "Waiting for ntfy rollout (up to 90s)..."
+  kubectl -n "$NS" rollout status deploy/ntfy --timeout=90s >/dev/null 2>&1 || true
+else
+  note "ntfy appears healthy — forcing restart to clear any stale state"
+  kubectl -n "$NS" rollout restart deploy/ntfy >/dev/null 2>&1
+  kubectl -n "$NS" rollout status deploy/ntfy --timeout=90s >/dev/null 2>&1 || true
+fi
+
+printf "\n=== ntfy pod state after restore ===\n"
+kubectl -n "$NS" get pods -o wide 2>&1 || true
+READY=$(kubectl -n "$NS" get deploy ntfy \
+  -o jsonpath='{.status.readyReplicas}' 2>/dev/null || echo "0")
+note "ready replicas: ${READY:-0}"
+
+note ""
+note "=== DONE ==="


### PR DESCRIPTION
## Summary

### cluster-doctor.sh — 6-tier rewrite
Previously only covered Keycloak + Prometheus + cloudless app. Now covers every service on the cluster:

| Tier | Services |
|---|---|
| 1 Auth | Keycloak (pods/logs/limits/memory drift), PostgreSQL |
| 2 App | cloudless (envFrom/AUTH_URL wiring), ntfy, n8n |
| 3 Monitoring | Prometheus (pods + rules), **Grafana HTTP check**, Alertmanager, Loki |
| 4 Analytics | Metabase (limits/pods), DuckDB API |
| 5 Infra | Nodes, **etcd-defrag last 3 runs**, maintenance CronJobs, cluster-alerts CronJob |
| 6 External | **Public HTTP surfaces** (Lambda/Keycloak/Grafana), **GitHub runners** |

### New recovery workflows
- `analytics-restore.yml` + `scripts/analytics-restore.sh` — patches Metabase 400Mi→600Mi on OOMKill, restarts DuckDB API
- `ntfy-restore.yml` + `scripts/ntfy-restore.sh` — patches ntfy 96Mi→128Mi on OOMKill, force-restarts

### New/updated skills
- `analytics-stack` — new skill covering Metabase/DuckDB/Grafana/Loki sizing, OOM patterns, recovery
- `cluster-incident-response` — expanded service map (13 services), full failure-mode decision table

## Test plan
- [ ] Trigger cluster doctor (touch `scripts/cluster-doctor.sh`) — verify all 6 tiers appear in #382
- [ ] Verify `analytics-restore.yml` shows in Actions workflow list
- [ ] Verify `ntfy-restore.yml` shows in Actions workflow list

https://claude.ai/code/session_012EjQpQGyt6SeSfRNNRRr6j