### PR TITLE
ops(r53): add push trigger + idempotency to health-check recreation

### DIFF
--- a/.github/workflows/recreate-r53-hc.yml
+++ b/.github/workflows/recreate-r53-hc.yml
@@ -11,6 +11,10 @@ name: Recreate Route 53 health checks
 
 on:
   workflow_dispatch:
+  push:
+    branches: [main]
+    paths:
+      - ".github/workflows/recreate-r53-hc.yml"
 
 permissions:
   id-token: write
@@ -42,6 +46,26 @@ jobs:
         id: hc
         run: |
           set -euo pipefail
+
+          # Idempotency: if tagged health checks already exist, reuse them.
+          ALL_HCS=$(aws route53 list-health-checks --output json | jq -r '.HealthChecks[].Id')
+          for hc_id in $ALL_HCS; do
+            name_tag=$(aws route53 list-tags-for-resource \
+              --resource-type healthcheck --resource-id "$hc_id" \
+              --query 'ResourceTagSet.Tags[?Key==`Name`].Value' --output text 2>/dev/null || true)
+            if [[ "$name_tag" == "cloudless-primary-cloudfront" ]]; then
+              EXISTING_PRIMARY="$hc_id"
+            elif [[ "$name_tag" == "cloudless-secondary-apigw" ]]; then
+              EXISTING_SECONDARY="$hc_id"
+            fi
+          done
+
+          if [[ -n "${EXISTING_PRIMARY:-}" && -n "${EXISTING_SECONDARY:-}" ]]; then
+            echo "Health checks already exist — skipping creation."
+            echo "primary_id=$EXISTING_PRIMARY"   >> "$GITHUB_OUTPUT"
+            echo "secondary_id=$EXISTING_SECONDARY" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
 
           # PRIMARY — HTTPS probe via cloudless.gr (CloudFront)
           PRIMARY_JSON=$(aws route53 create-health-check \


### PR DESCRIPTION
## Summary
- `workflow_dispatch` can't be triggered from the GitHub MCP integration; adds `on.push.paths` on the workflow's own path so merging this PR fires the job automatically.
- Adds idempotency: checks for existing health checks tagged `cloudless-primary-cloudfront` / `cloudless-secondary-apigw` before creating; reuses them if found (prevents duplicate $0.50/mo checks on re-runs).

## What happens on merge
1. Merge triggers `recreate-r53-hc.yml` via the push event.
2. Workflow creates two HTTPS/30s health checks (or reuses tagged ones if they already exist).
3. Patches `sst.config.ts` lines 281–282 with the new IDs on a fresh branch.
4. Opens a follow-up PR for the `sst.config.ts` change.
5. Posts the new IDs to issue #382.

https://claude.ai/code/session_01P169EPm5yifeTKoCwsvGEV

---
_Generated by [Claude Code](https://claude.ai/code/session_01P169EPm5yifeTKoCwsvGEV)_