### PR TITLE
feat(ops): domain-decommission accepts CLOUDFLARE_API_TOKEN repo secret

### DIFF
--- a/.claude/skills/domain-decommission/SKILL.md
+++ b/.claude/skills/domain-decommission/SKILL.md
@@ -53,9 +53,11 @@ ending in the target domain, and hard-guards that id (see `PROTECTED_HEALTH_CHEC
   deletion historically needed a temporary inline-policy escalation on
   `cloudless-ops-role` — if apply returns `AccessDenied`, grant
   `route53:DeleteHealthCheck` (and revoke after).
-- **Cloudflare:** set `/cloudless/production/CLOUDFLARE_API_TOKEN` (scoped
-  `Zone:Read` + `Zone.DNS:Edit`) in SSM. Without it the Cloudflare step skips
-  with a warning (Route 53 still runs). The `cloudless.online` ACM cert is
+- **Cloudflare:** the workflow reads the token from the **`CLOUDFLARE_API_TOKEN`
+  repo secret** first (add it in GitHub → Settings → Secrets — no AWS access
+  needed), and falls back to SSM `/cloudless/production/CLOUDFLARE_API_TOKEN`.
+  Scope the token `Zone:Read` + `Zone.DNS:Edit`. Without either, the Cloudflare
+  step skips with a warning (Route 53 still runs). The `cloudless.online` ACM cert is
   Cloudflare-owned and **cannot** be deleted by us — leave it (see aws-iam-audit).
 - **In-cluster monitors live elsewhere.** The probes that actually generate the
   recurring alerts are in **other repos**, not cloudless.gr:

--- a/.github/workflows/domain-decommission.yml
+++ b/.github/workflows/domain-decommission.yml
@@ -9,8 +9,9 @@ name: Domain decommission (Route 53 + Cloudflare)
 # apply=true — and even then the protected cloudless.gr HA secondary health
 # check (30a69f1c) is never touched (guarded in the script).
 #
-# Auth: OIDC deploy role (AWS_DEPLOY_ROLE_ARN) for Route 53; CLOUDFLARE_API_TOKEN
-# read from SSM /cloudless/production/* for the DNS-record cleanup.
+# Auth: OIDC deploy role (AWS_DEPLOY_ROLE_ARN) for Route 53. Cloudflare token
+# comes from the CLOUDFLARE_API_TOKEN repo secret (add in the GitHub UI — no AWS
+# needed), falling back to SSM /cloudless/production/CLOUDFLARE_API_TOKEN.
 
 on:
   workflow_dispatch:
@@ -61,6 +62,10 @@ jobs:
           DOMAIN: ${{ github.event.inputs.domain || 'cloudless.online' }}
           MODE: ${{ github.event.inputs.apply == 'true' && 'apply' || 'report' }}
           CONFIRM: ${{ github.event.inputs.apply == 'true' && '1' || '0' }}
+          # Cloudflare token: prefer a repo secret (add it in the GitHub UI — no
+          # AWS access needed); the script falls back to SSM
+          # /cloudless/production/CLOUDFLARE_API_TOKEN if this is empty.
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
         run: |
           set -o pipefail
           bash scripts/domain-decommission.sh 2>&1 | tee decommission.log


### PR DESCRIPTION
## Remove the AWS-access dependency for the Cloudflare half of `domain-decommission`

The Cloudflare DNS cleanup previously required writing `/cloudless/production/CLOUDFLARE_API_TOKEN` to SSM (needs AWS access). This wires the workflow to read the token from the **`CLOUDFLARE_API_TOKEN` repo secret** first — addable in **GitHub → Settings → Secrets** with no AWS access — falling back to SSM.

The script already prefers `CLOUDFLARE_API_TOKEN` from env over SSM, so this just plumbs `secrets.CLOUDFLARE_API_TOKEN` into the step env. Skill + workflow header updated to document it.

### Net effect — the Cloudflare half is now fully self-service
1. Add `CLOUDFLARE_API_TOKEN` (scope `Zone:Read` + `Zone.DNS:Edit`) as a repo secret (UI, no AWS).
2. Dispatch `domain-decommission.yml` with `apply=false` → review the `cloudless.online` DNS records in #382 → then `apply=true`.

(Route 53 side is already confirmed clean from the report run; the protected cloudless.gr failover check stays guarded.)

- [x] workflow YAML validated

https://claude.ai/code/session_016PrzZJMNxsgiEmvedfkru6

---
_Generated by [Claude Code](https://claude.ai/code/session_016PrzZJMNxsgiEmvedfkru6)_