### PR TITLE
fix(notion): precise page search — don't overwrite unrelated pages

### DIFF
--- a/scripts/notion-update-cluster-docs.sh
+++ b/scripts/notion-update-cluster-docs.sh
@@ -7,10 +7,11 @@
 # Uses NOTION_API_KEY secret.
 #
 # Behaviour:
-#   1. Search Notion for an existing "Cluster Operations" / "Cluster Doctor"
-#      page accessible to the integration.
-#   2. If found: clear its blocks and replace with fresh markdown.
-#   3. If not found: create a new standalone page with the content.
+#   1. Search Notion for a page whose title is specifically about cluster
+#      operations/runbooks. Excludes pages that merely contain the word
+#      "cluster" in an unrelated context (e.g. ESP32 watchdog hardware pages).
+#   2. If found: replace its blocks with the current runbook content.
+#   3. If not found: create a new page titled "Cluster Operations Runbook".
 #   4. Post the result (page URL) to GitHub issue #382.
 
 set -uo pipefail
@@ -27,271 +28,195 @@ note() { printf "[notion-update] %s\n" "$*"; }
 note "=== notion-update-cluster-docs $(date -u '+%F %T')Z ==="
 
 # ---------------------------------------------------------------------------
-# Step 1: Search for an existing cluster ops page
+# Step 1: Search for existing cluster ops runbook page (exact matches only)
+# We only accept pages whose title unambiguously identifies a cluster ops doc.
+# We exclude pages about ESP32/ESPHome/hardware that happen to mention cluster.
 # ---------------------------------------------------------------------------
-note "Searching Notion for existing cluster operations page..."
+note "Searching Notion for existing cluster operations runbook..."
 
-SEARCH_RESULT=$(curl -sS -X POST "https://api.notion.com/v1/search" \
-  "${HEADERS[@]}" \
-  -d '{
-    "query": "Cluster Operations",
-    "filter": { "value": "page", "property": "object" },
-    "page_size": 10
-  }')
+EXCLUDE_WORDS='["esp32", "esphome", "sensor", "temperature", "humidity", "device", "firmware", "watchdog hardware", "iot"]'
+REQUIRED_PHRASES='["cluster operation", "k3s runbook", "cluster incident", "cluster doctor runbook", "cluster ops runbook"]'
 
-PAGE_ID=$(echo "$SEARCH_RESULT" | python3 -c "
+PAGE_ID=""
+PAGE_URL=""
+PAGE_TITLE=""
+
+for QUERY in "Cluster Operations Runbook" "Cluster Operations" "k3s Runbook" "Cluster Incident Response Runbook"; do
+  SEARCH_RESULT=$(curl -sS -X POST "https://api.notion.com/v1/search" \
+    "${HEADERS[@]}" \
+    -d "{\"query\": \"${QUERY}\", \"filter\": {\"value\": \"page\", \"property\": \"object\"}, \"page_size\": 10}")
+
+  MATCH=$(echo "$SEARCH_RESULT" | python3 -c "
 import json, sys
 data = json.load(sys.stdin)
+exclude = ['esp32', 'esphome', 'sensor', 'temperature', 'humidity', 'device', 'firmware', 'iot']
+required = ['cluster operation', 'k3s runbook', 'cluster incident', 'cluster doctor runbook', 'cluster ops runbook']
 for r in data.get('results', []):
     props = r.get('properties', {})
     for k, v in props.items():
         if v.get('type') == 'title':
-            title = ''.join(t.get('plain_text','') for t in v.get('title',[]))
-            if any(kw in title.lower() for kw in ['cluster', 'incident', 'runbook', 'k3s', 'infrastructure']):
-                print(r['id'])
+            title = ''.join(t.get('plain_text','') for t in v.get('title',[])).lower()
+            if any(ex in title for ex in exclude):
+                continue
+            if any(req in title for req in required):
+                print(r['id'] + '|' + r.get('url','') + '|' + title)
                 sys.exit(0)
 " 2>/dev/null || echo "")
 
-# Also try "k3s" and "incident" searches if first came up empty
-if [ -z "$PAGE_ID" ]; then
-  for QUERY in "k3s cluster" "incident response" "cluster doctor" "infrastructure runbook"; do
-    SEARCH_RESULT=$(curl -sS -X POST "https://api.notion.com/v1/search" \
-      "${HEADERS[@]}" \
-      -d "{\"query\": \"${QUERY}\", \"filter\": {\"value\": \"page\", \"property\": \"object\"}, \"page_size\": 5}")
-    PAGE_ID=$(echo "$SEARCH_RESULT" | python3 -c "
-import json, sys
-data = json.load(sys.stdin)
-for r in data.get('results', []):
-    props = r.get('properties', {})
-    for k, v in props.items():
-        if v.get('type') == 'title':
-            title = ''.join(t.get('plain_text','') for t in v.get('title',[]))
-            if any(kw in title.lower() for kw in ['cluster', 'incident', 'runbook', 'k3s', 'infra', 'ops', 'doctor']):
-                print(r['id'])
-                sys.exit(0)
-" 2>/dev/null || echo "")
-    if [ -n "$PAGE_ID" ]; then
-      break
-    fi
-  done
-fi
+  if [ -n "$MATCH" ]; then
+    PAGE_ID=$(echo "$MATCH" | cut -d'|' -f1)
+    PAGE_URL=$(echo "$MATCH" | cut -d'|' -f2)
+    PAGE_TITLE=$(echo "$MATCH" | cut -d'|' -f3)
+    break
+  fi
+done
 
 # ---------------------------------------------------------------------------
-# Step 2: Build the markdown content
+# Step 2: Build the runbook content as Notion blocks
 # ---------------------------------------------------------------------------
 TODAY=$(date -u '+%Y-%m-%d')
-CONTENT=$(cat <<'MARKDOWN'
-# Cluster Operations — cloudless.gr (omv k3s)
 
-> **Last updated:** REPLACE_DATE
-> Runbook for the omv k3s cluster. Driven exclusively through GitHub Actions workflows — no direct kubectl/SSH from cloud sessions.
-
----
-
-## Service Map (13 services, 6 tiers)
-
-| Tier | Namespace | Service | Memory limit | OOM risk |
-|---|---|---|---|---|
-| Auth | keycloak | keycloak | 768Mi | CRITICAL — JVM -Xmx512m |
-| Auth | keycloak | postgres | — | Low |
-| App | cloudless | cloudless | — | Low |
-| App | ntfy | ntfy | 96Mi → 128Mi | Medium (tight) |
-| App | n8n | n8n | 256Mi | Low |
-| Monitoring | monitoring | prometheus | 700Mi | Low |
-| Monitoring | monitoring | grafana | 256Mi | Low |
-| Monitoring | monitoring | alertmanager | 128Mi | Low |
-| Monitoring | monitoring | loki | 400Mi | Medium |
-| Analytics | analytics | metabase | 400Mi → 600Mi | HIGH — JVM -Xmx320m |
-| Analytics | analytics | duckdb-api | 1500Mi | Low |
-| Infra | monitoring | etcd-defrag | CronJob | — |
-| Infra | monitoring | cluster-alerts | CronJob | — |
-
----
-
-## Cluster Doctor (6-tier diagnostics)
-
-Trigger: edit `scripts/cluster-doctor.sh` → PR → squash-merge → wait 2 min → read [issue #382](https://github.com/themis128/cloudless.gr/issues/382).
-
-**Workflow:** `.github/workflows/cluster-doctor.yml`
-
-Tiers covered:
-1. **Auth** — Keycloak (pods/logs/limits/heap env/drift) + PostgreSQL
-2. **App** — cloudless (AUTH_URL + envFrom) + ntfy + n8n
-3. **Monitoring** — Prometheus rules + Grafana HTTP + Alertmanager + Loki
-4. **Analytics** — Metabase + DuckDB API (pods + memory limits)
-5. **Infra** — nodes + etcd-defrag last 3 runs + maintenance CronJobs
-6. **External** — Public HTTP surfaces (Lambda/Keycloak/Grafana) + GitHub runners
-
----
-
-## Recovery Tools
-
-| Symptom | Tool | Trigger |
-|---|---|---|
-| auth.cloudless.gr 503 / Keycloak OOM | `restore-keycloak.yml` | edit the workflow file |
-| Keycloak drift (every 15 min auto-heal) | `keycloak-ensure.yml` | cron + push |
-| Metabase OOMKilled / CrashLoop | `analytics-restore.yml` | edit workflow or script |
-| DuckDB API high restarts / OOM | `analytics-restore.yml` | edit workflow or script |
-| ntfy Error / CrashLoopBackOff | `ntfy-restore.yml` | edit workflow or script |
-| PrometheusRuleFailures | `prometheus-tune.yml` | edit the workflow file |
-| k3s API server connection refused | `k3s-ssh-restart.yml` | requires OMV_SSH_KEY secret |
-| k3s watchdog install | `k3s-watchdog-deploy.yml` | requires OMV_SSH_KEY secret |
-
----
-
-## Memory Sizing Rules
-
-- **Never cap a JVM container below -Xmx + ~200Mi non-heap.**
-- Keycloak 26.2: 768Mi limit for -Xmx512m heap. Heap var = `JAVA_OPTS_APPEND` (not `JAVA_OPTS_KC_HEAP`).
-- Metabase: 600Mi limit for -Xmx480m heap (400Mi original = OOMKill risk on heavy queries).
-- ntfy: 128Mi (96Mi original is too tight for any spike).
-
----
-
-## Failure Mode Decision Table
-
-| Symptom | Likely cause | Tool |
-|---|---|---|
-| auth.cloudless.gr HTTP 503 | Keycloak OOMKilled / CrashLoop | restore-keycloak.yml |
-| Doctor: connection refused on port 6443 | k3s process stopped | k3s-ssh-restart.yml |
-| Doctor: ServiceUnavailable on port 6443 | k3s starting / overloaded | wait 2–5 min, re-doctor |
-| PrometheusRuleFailures alert | kube-apiserver-burnrate rules timing out | prometheus-tune.yml |
-| PrometheusKubernetesListWatchFailures | Prometheus can't reach k3s API | run doctor; if API down → k3s-ssh-restart.yml |
-| Metabase OOMKilled / CrashLoop | JVM heap exceeds 400Mi limit | analytics-restore.yml (patches to 600Mi) |
-| DuckDB API high restarts | Memory spike from heavy query | analytics-restore.yml (restarts DuckDB) |
-| ntfy Error / CrashLoopBackOff | OOM (96Mi) or exit 1 | ntfy-restore.yml |
-| Grafana unreachable (503) | Pod crash or OOM | restart via remediate workflow |
-
----
-
-## Key Incidents
-
-| Date | Summary | Fix |
-|---|---|---|
-| 2026-05-31 | memory-relief PR capped Keycloak at 384Mi → OOMKill loop | Patched to 768Mi + -Xmx512m |
-| 2026-06-01 | Keycloak 503 ~8h, login/registration down | restore-keycloak.yml |
-| 2026-06-02 | k3s API server crash → PrometheusKubernetesListWatchFailures | Self-resolved; watchdog install pending (needs OMV_SSH_KEY) |
-
----
-
-## Pending Setup
-
-- [ ] Add `OMV_SSH_KEY` GitHub repo secret (Pi's `~/.ssh/id_ed25519`) to enable SSH-based recovery
-- [ ] Run `k3s-watchdog-deploy.yml` once OMV_SSH_KEY is set — installs Restart=always systemd drop-in
-- [ ] SES SMTP: AWS Console → SES → SMTP Settings → Create SMTP credentials → run `provision-ses-smtp` workflow
-
----
-
-*Auto-updated by [notion-update-cluster-docs.yml](https://github.com/themis128/cloudless.gr/blob/main/.github/workflows/notion-update-cluster-docs.yml)*
-MARKDOWN
-)
-
-CONTENT="${CONTENT/REPLACE_DATE/$TODAY}"
-
-# ---------------------------------------------------------------------------
-# Step 3: Update existing page or create new one
-# ---------------------------------------------------------------------------
-if [ -n "$PAGE_ID" ]; then
-  note "Found existing page: ${PAGE_ID} — updating via markdown API..."
-
-  # Retrieve current title for logging
-  PAGE_META=$(curl -sS "https://api.notion.com/v1/pages/${PAGE_ID}" "${HEADERS[@]}")
-  PAGE_TITLE=$(echo "$PAGE_META" | python3 -c "
+build_blocks() {
+python3 -c "
 import json, sys
-data = json.load(sys.stdin)
-props = data.get('properties', {})
-for k, v in props.items():
-    if v.get('type') == 'title':
-        print(''.join(t.get('plain_text','') for t in v.get('title',[])))
-        break
-" 2>/dev/null || echo "unknown")
-  PAGE_URL=$(echo "$PAGE_META" | python3 -c "import json,sys; print(json.load(sys.stdin).get('url',''))" 2>/dev/null || echo "")
 
+today = sys.argv[1]
+
+def p(text):
+    return {'object':'block','type':'paragraph','paragraph':{'rich_text':[{'text':{'content':text}}]}}
+def h1(text):
+    return {'object':'block','type':'heading_1','heading_1':{'rich_text':[{'text':{'content':text}}]}}
+def h2(text):
+    return {'object':'block','type':'heading_2','heading_2':{'rich_text':[{'text':{'content':text}}]}}
+def h3(text):
+    return {'object':'block','type':'heading_3','heading_3':{'rich_text':[{'text':{'content':text}}]}}
+def bul(text):
+    return {'object':'block','type':'bulleted_list_item','bulleted_list_item':{'rich_text':[{'text':{'content':text}}]}}
+def todo(text, checked=False):
+    return {'object':'block','type':'to_do','to_do':{'rich_text':[{'text':{'content':text}}],'checked':checked}}
+def divider():
+    return {'object':'block','type':'divider','divider':{}}
+def code(text, lang='bash'):
+    return {'object':'block','type':'code','code':{'rich_text':[{'text':{'content':text}}],'language':lang}}
+
+blocks = [
+    h1('Cluster Operations — cloudless.gr (omv k3s)'),
+    p(f'Last updated: {today}  |  Pi: omv / 192.168.1.128 / Tailscale 100.113.41.119'),
+    p('Runbook for the omv k3s cluster. Driven entirely through GitHub Actions — no direct kubectl/SSH from cloud sessions.'),
+    divider(),
+    h2('Service Map (13 services, 6 tiers)'),
+    p('Tier 1 — Auth'),
+    bul('keycloak/keycloak — 768Mi — CRITICAL (JVM -Xmx512m)'),
+    bul('keycloak/postgres — Low OOM risk'),
+    p('Tier 2 — App'),
+    bul('cloudless/cloudless — standby (Low)'),
+    bul('ntfy/ntfy — 96Mi → 128Mi — Medium (tight)'),
+    bul('n8n/n8n — 256Mi — Low'),
+    p('Tier 3 — Monitoring'),
+    bul('monitoring/prometheus — 700Mi — Low'),
+    bul('monitoring/grafana — 256Mi — Low'),
+    bul('monitoring/alertmanager — 128Mi — Low'),
+    bul('monitoring/loki — 400Mi — Medium'),
+    p('Tier 4 — Analytics'),
+    bul('analytics/metabase — 400Mi → 600Mi — HIGH (JVM -Xmx320m)'),
+    bul('analytics/duckdb-api — 1500Mi — Low'),
+    p('Tier 5 — Infra CronJobs'),
+    bul('monitoring/etcd-defrag — weekly'),
+    bul('monitoring/cluster-alerts — nightly'),
+    divider(),
+    h2('Cluster Doctor (6-tier diagnostics)'),
+    p('Trigger: edit scripts/cluster-doctor.sh → PR → squash-merge → wait 2 min → read GitHub issue #382'),
+    bul('Tier 1: Auth — Keycloak pods/logs/limits/heap env/drift + PostgreSQL'),
+    bul('Tier 2: App — cloudless AUTH_URL/envFrom + ntfy + n8n'),
+    bul('Tier 3: Monitoring — Prometheus rules + Grafana HTTP + Alertmanager + Loki'),
+    bul('Tier 4: Analytics — Metabase + DuckDB API pods + memory limits'),
+    bul('Tier 5: Infra — nodes + etcd-defrag last 3 runs + CronJobs'),
+    bul('Tier 6: External — public HTTP surfaces (Lambda/Keycloak/Grafana) + GitHub runners'),
+    divider(),
+    h2('Recovery Tools'),
+    h3('Auth'),
+    bul('restore-keycloak.yml — Keycloak OOM/CrashLoop (patches to 768Mi + -Xmx512m)'),
+    bul('keycloak-ensure.yml — Self-heal cron every 15 min (realm flags + groups mapper + admin wiring)'),
+    h3('Analytics'),
+    bul('analytics-restore.yml — Metabase OOMKilled (patches to 600Mi + -Xmx480m) or DuckDB API restart'),
+    h3('App'),
+    bul('ntfy-restore.yml — ntfy Error/CrashLoop (patches to 128Mi if OOMKilled, force-restarts)'),
+    h3('Monitoring'),
+    bul('prometheus-tune.yml — PrometheusRuleFailures (removes heavy kube-apiserver-burnrate SLO rules)'),
+    h3('Infrastructure (requires OMV_SSH_KEY secret)'),
+    bul('k3s-ssh-restart.yml — k3s process stopped (connection refused on port 6443)'),
+    bul('k3s-watchdog-deploy.yml — install Restart=always systemd drop-in on Pi (one-time)'),
+    divider(),
+    h2('Failure Mode Decision Table'),
+    bul('auth.cloudless.gr HTTP 503 → Keycloak OOM → restore-keycloak.yml'),
+    bul('connection refused on port 6443 → k3s process stopped → k3s-ssh-restart.yml'),
+    bul('ServiceUnavailable on port 6443 → k3s starting → wait 2-5 min, re-doctor'),
+    bul('PrometheusRuleFailures → kube-apiserver-burnrate timeout → prometheus-tune.yml'),
+    bul('PrometheusKubernetesListWatchFailures → Prometheus cannot reach k3s API → run doctor; if API down → k3s-ssh-restart.yml'),
+    bul('Metabase OOMKilled/CrashLoop → JVM heap exceeds 400Mi → analytics-restore.yml (→600Mi)'),
+    bul('DuckDB API high restarts → memory spike → analytics-restore.yml (restart)'),
+    bul('ntfy Error/CrashLoopBackOff → OOM or exit 1 → ntfy-restore.yml'),
+    bul('Grafana 503 → pod crash → restart via remediate workflow'),
+    divider(),
+    h2('Memory Sizing Rules'),
+    bul('NEVER cap a JVM container below -Xmx + ~200Mi non-heap'),
+    bul('Keycloak 26.2: 768Mi limit | -Xmx512m | heap var = JAVA_OPTS_APPEND (NOT JAVA_OPTS_KC_HEAP)'),
+    bul('Metabase: 600Mi limit | -Xmx480m (400Mi original = OOMKill risk on heavy queries)'),
+    bul('ntfy: 128Mi (96Mi = too tight for any traffic spike)'),
+    divider(),
+    h2('Key Incidents'),
+    bul('2026-05-31: memory-relief PR capped Keycloak at 384Mi → OOMKill loop — Fix: patched to 768Mi'),
+    bul('2026-06-01: Keycloak 503 ~8h, login/registration down — Fix: restore-keycloak.yml'),
+    bul('2026-06-02: k3s API crash → PrometheusKubernetesListWatchFailures — Self-resolved; watchdog pending'),
+    divider(),
+    h2('Pending Setup'),
+    todo('Add OMV_SSH_KEY GitHub repo secret (Pi ~/.ssh/id_ed25519) to enable SSH recovery workflows'),
+    todo('Run k3s-watchdog-deploy.yml once OMV_SSH_KEY is set — installs Restart=always on Pi'),
+    todo('SES SMTP: AWS Console → SES → SMTP Settings → Create credentials → run provision-ses-smtp workflow'),
+    divider(),
+    p(f'Auto-updated {today} by notion-update-cluster-docs.yml'),
+]
+print(json.dumps({'children': blocks[:100]}))
+" "$TODAY"
+}
+
+# ---------------------------------------------------------------------------
+# Step 3: Update existing page or create a new one
+# ---------------------------------------------------------------------------
+BLOCKS_JSON=$(build_blocks)
+
+if [ -n "$PAGE_ID" ]; then
+  note "Found existing runbook page: ${PAGE_ID}"
   note "  Title: ${PAGE_TITLE}"
   note "  URL:   ${PAGE_URL}"
+  note "  Replacing blocks..."
 
-  # Try markdown patch endpoint (Notion API 2025+)
-  MD_PAYLOAD=$(python3 -c "import json, sys; print(json.dumps({'markdown': sys.stdin.read()}))" <<< "$CONTENT")
-  PATCH_RESULT=$(curl -sS -X PATCH "https://api.notion.com/v1/pages/${PAGE_ID}/markdown" \
-    "${HEADERS[@]}" \
-    -d "$MD_PAYLOAD")
-
-  PATCH_STATUS=$(echo "$PATCH_RESULT" | python3 -c "import json,sys; d=json.load(sys.stdin); print(d.get('object','error'))" 2>/dev/null || echo "error")
-
-  if [ "$PATCH_STATUS" = "page" ]; then
-    note "  SUCCESS: page updated via markdown API"
-    ACTION="updated"
-  else
-    # Fallback: replace blocks manually
-    note "  Markdown API not available (${PATCH_STATUS}), falling back to block replacement..."
-
-    # Clear existing blocks
-    BLOCKS=$(curl -sS "https://api.notion.com/v1/blocks/${PAGE_ID}/children?page_size=100" "${HEADERS[@]}")
-    BLOCK_IDS=$(echo "$BLOCKS" | python3 -c "
+  # Delete existing blocks first
+  EXISTING=$(curl -sS "https://api.notion.com/v1/blocks/${PAGE_ID}/children?page_size=100" "${HEADERS[@]}")
+  echo "$EXISTING" | python3 -c "
 import json, sys
 data = json.load(sys.stdin)
 for b in data.get('results', []):
     print(b['id'])
-" 2>/dev/null || echo "")
+" 2>/dev/null | while IFS= read -r BID; do
+    curl -sS -X DELETE "https://api.notion.com/v1/blocks/${BID}" "${HEADERS[@]}" >/dev/null
+  done
+  note "  Existing blocks cleared"
 
-    if [ -n "$BLOCK_IDS" ]; then
-      while IFS= read -r BID; do
-        curl -sS -X DELETE "https://api.notion.com/v1/blocks/${BID}" "${HEADERS[@]}" >/dev/null
-      done <<< "$BLOCK_IDS"
-      note "  Cleared existing blocks"
-    fi
-
-    # Append fresh content as simple paragraphs (paragraph fallback)
-    # Build blocks from content lines
-    BLOCKS_JSON=$(python3 -c "
-import json, sys
-
-content = sys.stdin.read()
-blocks = []
-for line in content.split('\n'):
-    stripped = line.strip()
-    if not stripped:
-        continue
-    if stripped.startswith('# ') and not stripped.startswith('## '):
-        blocks.append({'object':'block','type':'heading_1','heading_1':{'rich_text':[{'text':{'content':stripped[2:]}}]}})
-    elif stripped.startswith('## '):
-        blocks.append({'object':'block','type':'heading_2','heading_2':{'rich_text':[{'text':{'content':stripped[3:]}}]}})
-    elif stripped.startswith('### '):
-        blocks.append({'object':'block','type':'heading_3','heading_3':{'rich_text':[{'text':{'content':stripped[4:]}}]}})
-    elif stripped.startswith('- [ ] '):
-        blocks.append({'object':'block','type':'to_do','to_do':{'rich_text':[{'text':{'content':stripped[6:]}}],'checked':False}})
-    elif stripped.startswith('- '):
-        blocks.append({'object':'block','type':'bulleted_list_item','bulleted_list_item':{'rich_text':[{'text':{'content':stripped[2:]}}]}})
-    elif stripped.startswith('> '):
-        blocks.append({'object':'block','type':'quote','quote':{'rich_text':[{'text':{'content':stripped[2:]}}]}})
-    elif stripped.startswith('|') or stripped.startswith('---') or stripped == '---':
-        blocks.append({'object':'block','type':'paragraph','paragraph':{'rich_text':[{'text':{'content':stripped}}]}})
-    else:
-        blocks.append({'object':'block','type':'paragraph','paragraph':{'rich_text':[{'text':{'content':stripped}}]}})
-
-# Notion allows max 100 blocks per append
-print(json.dumps({'children': blocks[:100]}))
-" <<< "$CONTENT")
-
-    APPEND_RESULT=$(curl -sS -X PATCH "https://api.notion.com/v1/blocks/${PAGE_ID}/children" \
-      "${HEADERS[@]}" \
-      -d "$BLOCKS_JSON")
-    APPEND_STATUS=$(echo "$APPEND_RESULT" | python3 -c "import json,sys; d=json.load(sys.stdin); print(d.get('object','error'))" 2>/dev/null || echo "error")
-    note "  Block append status: ${APPEND_STATUS}"
-    ACTION="updated (block fallback)"
-  fi
+  APPEND_RESULT=$(curl -sS -X PATCH "https://api.notion.com/v1/blocks/${PAGE_ID}/children" \
+    "${HEADERS[@]}" \
+    -d "$BLOCKS_JSON")
+  STATUS=$(echo "$APPEND_RESULT" | python3 -c "import json,sys; print(json.load(sys.stdin).get('object','error'))" 2>/dev/null || echo "error")
+  note "  Append status: ${STATUS}"
+  ACTION="updated"
 
 else
-  # No matching page found — create a new standalone page
-  note "No existing cluster ops page found — creating new page..."
+  note "No existing runbook found — creating new 'Cluster Operations Runbook' page..."
 
-  # Find a parent: try to find any accessible page to use as parent,
-  # otherwise create at workspace root (not supported by API — need a parent page)
-  # We'll find the first accessible page as parent
+  # Find a parent page to nest under
   ALL_PAGES=$(curl -sS -X POST "https://api.notion.com/v1/search" \
     "${HEADERS[@]}" \
     -d '{"filter":{"value":"page","property":"object"},"page_size":5}')
-
   PARENT_ID=$(echo "$ALL_PAGES" | python3 -c "
 import json, sys
 data = json.load(sys.stdin)
@@ -301,18 +226,16 @@ if results:
 " 2>/dev/null || echo "")
 
   if [ -z "$PARENT_ID" ]; then
-    note "ERROR: No accessible Notion pages found — cannot create new page (integration needs to be added to at least one page)"
-    note "Please share a Notion page with the integration at: https://www.notion.so/"
+    note "ERROR: No accessible Notion pages to use as parent. Share a page with the integration first."
     exit 1
   fi
 
   CREATE_PAYLOAD=$(python3 -c "
 import json, sys
-parent_id = sys.argv[1]
 payload = {
-    'parent': {'page_id': parent_id},
+    'parent': {'page_id': sys.argv[1]},
     'properties': {
-        'title': {'title': [{'text': {'content': 'Cluster Operations — cloudless.gr (omv k3s)'}}]}
+        'title': {'title': [{'text': {'content': 'Cluster Operations Runbook — cloudless.gr (omv k3s)'}}]}
     }
 }
 print(json.dumps(payload))
@@ -321,46 +244,16 @@ print(json.dumps(payload))
   CREATE_RESULT=$(curl -sS -X POST "https://api.notion.com/v1/pages" \
     "${HEADERS[@]}" \
     -d "$CREATE_PAYLOAD")
-
   PAGE_ID=$(echo "$CREATE_RESULT" | python3 -c "import json,sys; print(json.load(sys.stdin).get('id',''))" 2>/dev/null || echo "")
   PAGE_URL=$(echo "$CREATE_RESULT" | python3 -c "import json,sys; print(json.load(sys.stdin).get('url',''))" 2>/dev/null || echo "")
 
   if [ -z "$PAGE_ID" ]; then
-    note "ERROR: Failed to create Notion page"
+    note "ERROR: Failed to create page"
     echo "$CREATE_RESULT"
     exit 1
   fi
 
   note "  Created page: ${PAGE_ID}"
-  note "  URL: ${PAGE_URL}"
-
-  # Append content blocks
-  BLOCKS_JSON=$(python3 -c "
-import json, sys
-
-content = sys.stdin.read()
-blocks = []
-for line in content.split('\n'):
-    stripped = line.strip()
-    if not stripped:
-        continue
-    if stripped.startswith('# ') and not stripped.startswith('## '):
-        blocks.append({'object':'block','type':'heading_1','heading_1':{'rich_text':[{'text':{'content':stripped[2:]}}]}})
-    elif stripped.startswith('## '):
-        blocks.append({'object':'block','type':'heading_2','heading_2':{'rich_text':[{'text':{'content':stripped[3:]}}]}})
-    elif stripped.startswith('### '):
-        blocks.append({'object':'block','type':'heading_3','heading_3':{'rich_text':[{'text':{'content':stripped[4:]}}]}})
-    elif stripped.startswith('- [ ] '):
-        blocks.append({'object':'block','type':'to_do','to_do':{'rich_text':[{'text':{'content':stripped[6:]}}],'checked':False}})
-    elif stripped.startswith('- '):
-        blocks.append({'object':'block','type':'bulleted_list_item','bulleted_list_item':{'rich_text':[{'text':{'content':stripped[2:]}}]}})
-    elif stripped.startswith('> '):
-        blocks.append({'object':'block','type':'quote','quote':{'rich_text':[{'text':{'content':stripped[2:]}}]}})
-    else:
-        blocks.append({'object':'block','type':'paragraph','paragraph':{'rich_text':[{'text':{'content':stripped}}]}})
-
-print(json.dumps({'children': blocks[:100]}))
-" <<< "$CONTENT")
 
   APPEND_RESULT=$(curl -sS -X PATCH "https://api.notion.com/v1/blocks/${PAGE_ID}/children" \
     "${HEADERS[@]}" \


### PR DESCRIPTION
## Problem
Previous run of `notion-update-cluster-docs.yml` overwrote the **ESP32 ESPHome Watchdog** page because it matched the word "cluster" in the title. That page needs to be restored from Notion page history (••• → Page history → restore pre-15:19 UTC version).

## Fix
- Search now requires exact phrases: `cluster operation`, `k3s runbook`, `cluster incident`, `cluster doctor runbook`
- Explicitly excludes pages containing: `esp32`, `esphome`, `sensor`, `device`, `firmware`, `iot`
- Creates a new **"Cluster Operations Runbook"** page if nothing matches
- Full script rewrite with cleaner block-building logic

https://claude.ai/code/session_012EjQpQGyt6SeSfRNNRRr6j