### PR TITLE
ops: ESP32 page restore + secrets-check workflow + omv-ssh-key-setup skill

### DIFF
--- a/.claude/skills/omv-ssh-key-setup/SKILL.md
+++ b/.claude/skills/omv-ssh-key-setup/SKILL.md
@@ -1,0 +1,157 @@
+---
+name: omv-ssh-key-setup
+description: Set up the OMV_SSH_KEY GitHub repo secret to enable SSH-based k3s recovery and watchdog deployment. Use when k3s-ssh-restart.yml or k3s-watchdog-deploy.yml fail with "OMV_SSH_KEY not set", when the user says "add the SSH key", "enable watchdog", "install k3s watchdog", or "set up SSH recovery". Covers generating the key, adding it to authorized_keys, storing it as a GitHub repo secret, and triggering the watchdog deploy.
+argument-hint: "e.g. 'add OMV_SSH_KEY', 'install watchdog', 'k3s SSH recovery not working'"
+---
+
+# OMV_SSH_KEY Setup & k3s Watchdog Deploy
+
+This skill covers adding the `OMV_SSH_KEY` GitHub repo secret that enables the
+two SSH-based cluster recovery workflows:
+
+| Workflow | What it does |
+|---|---|
+| `k3s-ssh-restart.yml` | SSH to Pi → restart k3s → wait for port 6443 → post to #382 |
+| `k3s-watchdog-deploy.yml` | SSH to Pi → install `Restart=always` systemd drop-in → k3s auto-recovers on crash |
+
+---
+
+## Prerequisite: SSH key on the Pi
+
+The Pi's SSH user is `omv` at Tailscale IP `100.113.41.119`.
+
+**If a key already exists:**
+```bash
+# On the Pi — check for existing keys
+ls ~/.ssh/id_ed25519  # or id_rsa
+cat ~/.ssh/id_ed25519  # ← this is what you'll paste into GitHub
+```
+
+**If no key exists, generate one:**
+```bash
+# On the Pi
+ssh-keygen -t ed25519 -C "omv-pi-ssh-key" -f ~/.ssh/id_ed25519 -N ""
+cat ~/.ssh/id_ed25519.pub >> ~/.ssh/authorized_keys
+chmod 600 ~/.ssh/authorized_keys
+```
+
+---
+
+## Add OMV_SSH_KEY to GitHub
+
+1. On the Pi: `cat ~/.ssh/id_ed25519` — copy the full output, including the header and footer:
+   ```
+   -----BEGIN OPENSSH PRIVATE KEY-----
+   b3BlbnNzaC1rZXktdjEAAAAA...
+   -----END OPENSSH PRIVATE KEY-----
+   ```
+2. GitHub → repo `Themis128/cloudless.gr` → **Settings** → **Secrets and variables** → **Actions** → **New repository secret**
+3. Name: `OMV_SSH_KEY`
+4. Value: paste the private key content
+5. Click **Add secret**
+
+---
+
+## Verify connectivity (optional but recommended)
+
+From a machine with Tailscale active:
+```bash
+ssh -i ~/.ssh/id_ed25519 omv@100.113.41.119 "echo connected"
+```
+Should print `connected`. If it fails:
+- Check `sshd` is running: `systemctl status ssh`
+- Check `~/.ssh/authorized_keys` contains the public key
+- Check firewall: `ufw status` — port 22 must be open
+
+---
+
+## Deploy the k3s Watchdog (one-time, after OMV_SSH_KEY is set)
+
+The watchdog installs a systemd drop-in that restarts k3s automatically
+whenever it crashes — eliminating future manual `k3s-ssh-restart` runs.
+
+**Trigger:**
+1. Edit `.github/workflows/k3s-watchdog-deploy.yml` (touch a comment)
+2. Create PR → squash-merge
+3. Watch issue #382 for the result
+
+**What it installs** (`/etc/systemd/system/k3s.service.d/restart-always.conf`):
+```ini
+[Service]
+Restart=always
+RestartSec=30s
+StartLimitBurst=0
+StartLimitIntervalSec=0
+```
+
+After install, k3s will restart within 30 seconds of any crash — no manual intervention needed.
+
+---
+
+## Use k3s-ssh-restart manually (when k3s is stopped)
+
+Symptom: cluster doctor shows `connection refused on port 6443`.
+
+**Trigger:**
+1. Edit `.github/workflows/k3s-ssh-restart.yml` (touch a comment or whitespace)
+2. Create PR → squash-merge
+3. Watch issue #382 for result (~90s)
+
+**What it does:**
+1. Connects to tailnet via `TS_AUTHKEY`
+2. SSH to `omv@100.113.41.119` using `OMV_SSH_KEY`
+3. Runs `sudo systemctl restart k3s`
+4. Waits up to 90s for port 6443 to respond
+5. Reports to #382
+
+---
+
+## Troubleshooting
+
+### "Permission denied, please try again" / "Too many authentication failures"
+
+- The key in `OMV_SSH_KEY` doesn't match any entry in `~/.ssh/authorized_keys` on the Pi
+- Re-check the public key: `cat ~/.ssh/id_ed25519.pub` should appear in `~/.ssh/authorized_keys`
+- If sshd banned the runner IP (fail2ban): wait 10 min or `sudo fail2ban-client unban <IP>`
+
+### "OMV_SSH_KEY not set — skipping SSH steps"
+
+- The secret isn't set in GitHub. Follow the "Add OMV_SSH_KEY to GitHub" steps above.
+
+### Workflow queues forever (>2 min) without starting
+
+- The Pi is completely down (power loss, kernel panic)
+- The `ubuntu-latest` runner doesn't need the Pi to start — only the SSH step does
+- If the job queues: this is a runner quota issue, not a Pi issue
+- Check runner quota at: GitHub → repo → Settings → Actions → Runners
+
+### Watchdog installed but k3s still doesn't restart
+
+- Verify the drop-in: `systemctl cat k3s | grep Restart`
+- `systemctl daemon-reload && systemctl enable k3s` must have run (watchdog-deploy does this)
+- Check: `journalctl -u k3s -n 20` for startup errors
+
+---
+
+## One-liner status check (from Pi SSH session)
+
+```bash
+# Is k3s running?
+systemctl is-active k3s
+
+# Is watchdog installed?
+systemctl cat k3s | grep -A3 "restart-always"
+
+# Last restart time
+systemctl show k3s --property=ActiveEnterTimestamp
+```
+
+---
+
+## Reference
+
+- Pi SSH: `omv@100.113.41.119` (Tailscale)
+- k3s service: `k3s.service`
+- Watchdog drop-in: `/etc/systemd/system/k3s.service.d/restart-always.conf`
+- Workflows: `k3s-ssh-restart.yml`, `k3s-watchdog-deploy.yml`
+- Required secrets: `OMV_SSH_KEY` (this guide), `TS_AUTHKEY` (Tailscale key)

--- a/.github/workflows/notion-restore-esp32.yml
+++ b/.github/workflows/notion-restore-esp32.yml
@@ -1,0 +1,62 @@
+name: notion-restore-esp32 — reconstruct overwritten ESP32 watchdog page
+
+# Reconstructs the ESP32 ESPHome Watchdog page (3677d82c-410a-81e4-a6db-e9ae89578fda)
+# that was accidentally overwritten on 2026-06-02 by notion-update-cluster-docs.
+#
+# What it does:
+#   - Restores the correct page title
+#   - Reads ESP32 Devices and Telemetry databases to rebuild what it can
+#   - Adds a banner pointing to page history for full content restore
+#   - Posts result to issue #382
+#
+# NOTE: For a perfect restore, use Notion page history:
+#   Open page → ••• → Page history → restore version before 15:19 UTC 2026-06-02
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - ".github/workflows/notion-restore-esp32.yml"
+      - "scripts/notion-restore-esp32.sh"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  restore:
+    name: Restore ESP32 Watchdog Notion page
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    env:
+      GH_TOKEN: ${{ github.token }}
+      NOTION_API_KEY: ${{ secrets.NOTION_API_KEY }}
+      NOTION_ESP32_DEVICES_DB_ID: ${{ secrets.NOTION_ESP32_DEVICES_DB_ID }}
+      NOTION_ESP32_TELEMETRY_DB_ID: ${{ secrets.NOTION_ESP32_TELEMETRY_DB_ID }}
+
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v4.3.1
+
+      - name: Run notion-restore-esp32
+        id: restore
+        run: |
+          set -o pipefail
+          bash scripts/notion-restore-esp32.sh 2>&1 | tee restore.log
+
+      - name: Post result to tracking issue
+        if: always()
+        run: |
+          {
+            echo "# ESP32 page restore — $(date -u '+%Y-%m-%d %H:%M:%SZ')"
+            echo ""
+            echo "**Status:** ${{ job.status }}"
+            echo ""
+            echo '```'
+            cat restore.log 2>/dev/null || echo "(no log)"
+            echo '```'
+            echo ""
+            echo "**Page:** https://www.notion.so/ESP32-ESPHome-Watchdog-Pi-Cluster-Monitor-v2-3677d82c410a81e4a6dbe9ae89578fda"
+            echo ""
+            echo "> ⚠️ For full content: open page → ••• → Page history → restore version before 15:19 UTC 2026-06-02"
+          } | gh issue comment 382 --repo "$GITHUB_REPOSITORY" --body-file -

--- a/.github/workflows/secrets-check.yml
+++ b/.github/workflows/secrets-check.yml
@@ -1,0 +1,116 @@
+name: secrets-check — verify critical repo secrets are set
+
+# Checks all secrets needed for cluster ops, Notion, email, and CI.
+# Posts a checklist to issue #382 so the operator knows what's missing.
+#
+# Trigger by editing this file, or run via workflow_dispatch.
+#
+# Checks (non-empty test only — values are never logged):
+#   TS_AUTHKEY       — Tailscale auth key (cluster ops over VPN)
+#   KUBECONFIG_B64   — k3s kubeconfig (system:admin)
+#   OMV_SSH_KEY      — Pi SSH private key (k3s restart + watchdog deploy)
+#   NOTION_API_KEY   — Notion integration token
+#   AWS_DEPLOY_ROLE_ARN — OIDC role for ECR push + SSM
+#   SES_SMTP_USER    — SES SMTP credentials (email verification)
+#   SES_SMTP_PASSWORD
+#   GH_PAT           — GitHub PAT (cross-repo push, session auto-push)
+#   ADMIN_BOOTSTRAP_PASSWORD — Keycloak admin bootstrap
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - ".github/workflows/secrets-check.yml"
+      - "scripts/secrets-check.sh"
+  workflow_dispatch:
+  schedule:
+    - cron: "0 8 * * 1"  # Weekly Monday 08:00 UTC
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  check:
+    name: Check critical secrets
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    env:
+      GH_TOKEN: ${{ github.token }}
+      # Pass each secret — empty string if not set (GitHub replaces unset secrets with "")
+      TS_AUTHKEY: ${{ secrets.TS_AUTHKEY }}
+      KUBECONFIG_B64: ${{ secrets.KUBECONFIG_B64 }}
+      OMV_SSH_KEY: ${{ secrets.OMV_SSH_KEY }}
+      NOTION_API_KEY: ${{ secrets.NOTION_API_KEY }}
+      AWS_DEPLOY_ROLE_ARN: ${{ secrets.AWS_DEPLOY_ROLE_ARN }}
+      SES_SMTP_USER: ${{ secrets.SES_SMTP_USER }}
+      SES_SMTP_PASSWORD: ${{ secrets.SES_SMTP_PASSWORD }}
+      GH_PAT: ${{ secrets.GH_PAT }}
+      ADMIN_BOOTSTRAP_PASSWORD: ${{ secrets.ADMIN_BOOTSTRAP_PASSWORD }}
+
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v4.3.1
+
+      - name: Check secrets
+        id: check
+        run: |
+          bash scripts/secrets-check.sh 2>&1 | tee check.log
+
+      - name: Post checklist to tracking issue
+        if: always()
+        run: |
+          # Build a markdown checklist from the check output
+          BODY=$(python3 -c "
+import sys
+
+lines = open('check.log').read().splitlines()
+ok = []
+missing = []
+for line in lines:
+    if line.startswith('ok:'):
+        ok.append(line[3:])
+    elif line.startswith('missing:'):
+        missing.append(line[8:])
+
+print('# Secrets health check — $(date -u \"+%Y-%m-%d %H:%M:%SZ\")')
+print('')
+print(f'**{len(ok)} set / {len(missing)} missing**')
+print('')
+
+descriptions = {
+    'TS_AUTHKEY': 'Tailscale auth key — cluster ops over VPN (tailscale.com/admin/settings/keys)',
+    'KUBECONFIG_B64': 'k3s kubeconfig system:admin — base64-encoded /etc/rancher/k3s/k3s.yaml',
+    'OMV_SSH_KEY': 'Pi SSH private key — enables k3s-ssh-restart + k3s-watchdog-deploy workflows',
+    'NOTION_API_KEY': 'Notion integration token — cluster docs, blog, submissions',
+    'AWS_DEPLOY_ROLE_ARN': 'OIDC deploy role — ECR push + SSM parameter access',
+    'SES_SMTP_USER': 'SES SMTP username — email verification (AWS Console → SES → SMTP Settings)',
+    'SES_SMTP_PASSWORD': 'SES SMTP password — email verification',
+    'GH_PAT': 'GitHub PAT repo scope — cloud session auto-push on stop hook',
+    'ADMIN_BOOTSTRAP_PASSWORD': 'Keycloak admin bootstrap password for keycloak-bootstrap-admin workflow',
+}
+
+for s in ok:
+    print(f'- [x] \`{s}\` — {descriptions.get(s, \"set\")}')
+for s in missing:
+    print(f'- [ ] \`{s}\` — ⚠️ MISSING — {descriptions.get(s, \"not set\")}')
+
+if missing:
+    print('')
+    print('## How to add missing secrets')
+    print('GitHub → repo Settings → Secrets and variables → Actions → New repository secret')
+    if 'OMV_SSH_KEY' in missing:
+        print('')
+        print('### OMV_SSH_KEY')
+        print('1. On the Pi: \`cat ~/.ssh/id_ed25519\` (or generate: \`ssh-keygen -t ed25519\`)')
+        print('2. Add the Pi public key to \`~/.ssh/authorized_keys\` on the Pi itself')
+        print('3. Paste the **private key** content (-----BEGIN OPENSSH PRIVATE KEY----- ... -----END OPENSSH PRIVATE KEY-----) as \`OMV_SSH_KEY\`')
+        print('4. Once set, trigger \`k3s-watchdog-deploy.yml\` to install the Restart=always systemd drop-in')
+    if 'SES_SMTP_USER' in missing or 'SES_SMTP_PASSWORD' in missing:
+        print('')
+        print('### SES_SMTP_USER + SES_SMTP_PASSWORD')
+        print('1. AWS Console → SES → SMTP Settings → Create SMTP credentials')
+        print('2. Save the username and password shown (only shown once)')
+        print('3. Add as \`SES_SMTP_USER\` and \`SES_SMTP_PASSWORD\` repo secrets')
+        print('4. Trigger \`provision-ses-smtp.yml\` via workflow_dispatch with those values')
+")
+          echo "$BODY" | gh issue comment 382 --repo "$GITHUB_REPOSITORY" --body-file -

--- a/scripts/notion-restore-esp32.sh
+++ b/scripts/notion-restore-esp32.sh
@@ -1,0 +1,213 @@
+#!/usr/bin/env bash
+#
+# notion-restore-esp32.sh — reconstruct the ESP32 ESPHome Watchdog page
+# that was accidentally overwritten by notion-update-cluster-docs on 2026-06-02.
+#
+# Page ID: 3677d82c-410a-81e4-a6db-e9ae89578fda
+# Original title: ESP32 ESPHome Watchdog — Pi Cluster Monitor (v2)
+#
+# This script:
+#   1. Reads the ESP32 Devices and Telemetry Notion databases to populate
+#      what it can from structured data
+#   2. Rebuilds a page skeleton with known facts about the ESPHome watchdog
+#   3. Adds a banner asking the user to verify content from page history
+#
+# For a perfect restore: Notion UI → page → ··· → Page history → restore
+# the version from before 2026-06-02 15:19 UTC.
+
+set -uo pipefail
+
+NOTION_VERSION="2022-06-28"
+HEADERS=(
+  -H "Authorization: Bearer ${NOTION_API_KEY}"
+  -H "Notion-Version: ${NOTION_VERSION}"
+  -H "Content-Type: application/json"
+)
+
+TARGET_PAGE_ID="3677d82c-410a-81e4-a6db-e9ae89578fda"
+DEVICES_DB_ID="${NOTION_ESP32_DEVICES_DB_ID:-022b2212-995b-4e29-8c3c-900297b435b9}"
+TELEMETRY_DB_ID="${NOTION_ESP32_TELEMETRY_DB_ID:-3214d53d-90ff-4b7a-81c3-f689a92ee167}"
+
+note() { printf "[esp32-restore] %s\n" "$*"; }
+
+note "=== notion-restore-esp32 $(date -u '+%F %T')Z ==="
+note "Target page: ${TARGET_PAGE_ID}"
+
+# ---------------------------------------------------------------------------
+# Step 1: Read ESP32 Devices DB
+# ---------------------------------------------------------------------------
+note "Reading ESP32 Devices database..."
+DEVICES_RAW=$(curl -sS -X POST "https://api.notion.com/v1/databases/${DEVICES_DB_ID}/query" \
+  "${HEADERS[@]}" \
+  -d '{"page_size": 100}')
+
+DEVICES_INFO=$(echo "$DEVICES_RAW" | python3 -c "
+import json, sys
+data = json.load(sys.stdin)
+rows = []
+for r in data.get('results', []):
+    props = r.get('properties', {})
+    row = {}
+    for k, v in props.items():
+        t = v.get('type','')
+        if t == 'title':
+            row[k] = ''.join(x.get('plain_text','') for x in v.get('title',[]))
+        elif t == 'rich_text':
+            row[k] = ''.join(x.get('plain_text','') for x in v.get('rich_text',[]))
+        elif t == 'select':
+            row[k] = (v.get('select') or {}).get('name','')
+        elif t == 'checkbox':
+            row[k] = str(v.get('checkbox', False))
+        elif t == 'url':
+            row[k] = v.get('url','') or ''
+    rows.append(row)
+print(json.dumps(rows, indent=2))
+" 2>/dev/null || echo "[]")
+
+note "  Devices rows: $(echo "$DEVICES_INFO" | python3 -c 'import json,sys; print(len(json.load(sys.stdin)))' 2>/dev/null)"
+
+# ---------------------------------------------------------------------------
+# Step 2: Read ESP32 Telemetry DB (recent entries)
+# ---------------------------------------------------------------------------
+note "Reading ESP32 Telemetry database (last 10 entries)..."
+TELEMETRY_RAW=$(curl -sS -X POST "https://api.notion.com/v1/databases/${TELEMETRY_DB_ID}/query" \
+  "${HEADERS[@]}" \
+  -d '{"page_size": 10, "sorts": [{"timestamp": "created_time", "direction": "descending"}]}')
+
+TELEMETRY_INFO=$(echo "$TELEMETRY_RAW" | python3 -c "
+import json, sys
+data = json.load(sys.stdin)
+rows = []
+for r in data.get('results', []):
+    props = r.get('properties', {})
+    row = {'_created': r.get('created_time','')}
+    for k, v in props.items():
+        t = v.get('type','')
+        if t == 'title':
+            row[k] = ''.join(x.get('plain_text','') for x in v.get('title',[]))
+        elif t == 'rich_text':
+            row[k] = ''.join(x.get('plain_text','') for x in v.get('rich_text',[]))
+        elif t == 'number':
+            row[k] = str(v.get('number',''))
+        elif t == 'select':
+            row[k] = (v.get('select') or {}).get('name','')
+        elif t == 'date':
+            row[k] = (v.get('date') or {}).get('start','')
+    rows.append(row)
+print(json.dumps(rows, indent=2))
+" 2>/dev/null || echo "[]")
+
+note "  Telemetry rows fetched: $(echo "$TELEMETRY_INFO" | python3 -c 'import json,sys; print(len(json.load(sys.stdin)))' 2>/dev/null)"
+
+# ---------------------------------------------------------------------------
+# Step 3: Restore page title first
+# ---------------------------------------------------------------------------
+note "Restoring page title..."
+TITLE_PATCH=$(python3 -c "
+import json
+payload = {
+    'properties': {
+        'title': {'title': [{'text': {'content': 'ESP32 ESPHome Watchdog — Pi Cluster Monitor (v2)'}}]}
+    }
+}
+print(json.dumps(payload))
+")
+curl -sS -X PATCH "https://api.notion.com/v1/pages/${TARGET_PAGE_ID}" \
+  "${HEADERS[@]}" \
+  -d "$TITLE_PATCH" >/dev/null
+note "  Title restored"
+
+# ---------------------------------------------------------------------------
+# Step 4: Clear overwritten blocks and rebuild from known data
+# ---------------------------------------------------------------------------
+note "Clearing overwritten blocks..."
+EXISTING=$(curl -sS "https://api.notion.com/v1/blocks/${TARGET_PAGE_ID}/children?page_size=100" "${HEADERS[@]}")
+echo "$EXISTING" | python3 -c "
+import json, sys
+data = json.load(sys.stdin)
+for b in data.get('results', []):
+    print(b['id'])
+" 2>/dev/null | while IFS= read -r BID; do
+  curl -sS -X DELETE "https://api.notion.com/v1/blocks/${BID}" "${HEADERS[@]}" >/dev/null
+done
+note "  Cleared"
+
+# ---------------------------------------------------------------------------
+# Step 5: Rebuild page content from DB data + known facts
+# ---------------------------------------------------------------------------
+note "Rebuilding page content..."
+
+NEW_BLOCKS=$(python3 -c "
+import json, sys
+
+devices = json.loads(sys.argv[1])
+telemetry = json.loads(sys.argv[2])
+
+def p(text):
+    return {'object':'block','type':'paragraph','paragraph':{'rich_text':[{'text':{'content':text}}]}}
+def h1(text):
+    return {'object':'block','type':'heading_1','heading_1':{'rich_text':[{'text':{'content':text}}]}}
+def h2(text):
+    return {'object':'block','type':'heading_2','heading_2':{'rich_text':[{'text':{'content':text}}]}}
+def bul(text):
+    return {'object':'block','type':'bulleted_list_item','bulleted_list_item':{'rich_text':[{'text':{'content':text}}]}}
+def callout(text, emoji='⚠️'):
+    return {'object':'block','type':'callout','callout':{'rich_text':[{'text':{'content':text}}],'icon':{'type':'emoji','emoji':emoji}}}
+def divider():
+    return {'object':'block','type':'divider','divider':{}}
+
+blocks = [
+    callout('CONTENT PARTIALLY RESTORED — 2026-06-02: This page was accidentally overwritten by notion-update-cluster-docs.yml. The prose documentation was lost. For the full original content: open ••• menu → Page history → restore version before 15:19 UTC on 2026-06-02. The structured database data below was reconstructed from the ESP32 Devices and Telemetry databases.', '⚠️'),
+    divider(),
+    h1('ESP32 ESPHome Watchdog — Pi Cluster Monitor (v2)'),
+    p('Hardware watchdog for the omv k3s cluster Pi nodes. Runs ESPHome firmware on ESP32 hardware to monitor cluster health and trigger physical resets if the Pi becomes unresponsive.'),
+    divider(),
+]
+
+# Devices section
+blocks.append(h2('Registered Devices'))
+if devices:
+    for d in devices:
+        name = next((v for k,v in d.items() if k.lower() in ['name','device','title'] and v), None)
+        if name:
+            details = ', '.join(f'{k}: {v}' for k,v in d.items() if k not in ['name','device','title'] and v and k != '_created')
+            blocks.append(bul(f'{name}' + (f' — {details}' if details else '')))
+else:
+    blocks.append(bul('(No devices found in database — check NOTION_ESP32_DEVICES_DB_ID)'))
+
+blocks.append(divider())
+
+# Telemetry section
+blocks.append(h2('Recent Telemetry'))
+if telemetry:
+    for t in telemetry[:5]:
+        created = t.get('_created','')[:16].replace('T',' ')
+        name = next((v for k,v in t.items() if k.lower() in ['name','device','title'] and v), 'entry')
+        details = ', '.join(f'{k}: {v}' for k,v in t.items() if k not in ['name','device','title','_created'] and v)
+        blocks.append(bul(f'[{created}] {name}' + (f' — {details}' if details else '')))
+else:
+    blocks.append(bul('(No recent telemetry — check NOTION_ESP32_TELEMETRY_DB_ID)'))
+
+blocks.append(divider())
+blocks.append(h2('Recovery Note'))
+blocks.append(p('To fully restore this page, use Notion page history:'))
+blocks.append(bul('Open this page in Notion'))
+blocks.append(bul('Click ••• (more menu) in the top right'))
+blocks.append(bul('Click Page history'))
+blocks.append(bul('Find the version from before 2026-06-02 15:19 UTC'))
+blocks.append(bul('Click Restore'))
+
+print(json.dumps({'children': blocks[:100]}))
+" "$DEVICES_INFO" "$TELEMETRY_INFO")
+
+APPEND_RESULT=$(curl -sS -X PATCH "https://api.notion.com/v1/blocks/${TARGET_PAGE_ID}/children" \
+  "${HEADERS[@]}" \
+  -d "$NEW_BLOCKS")
+STATUS=$(echo "$APPEND_RESULT" | python3 -c "import json,sys; print(json.load(sys.stdin).get('object','error'))" 2>/dev/null || echo "error")
+note "  Append status: ${STATUS}"
+
+PAGE_URL="https://www.notion.so/ESP32-ESPHome-Watchdog-Pi-Cluster-Monitor-v2-3677d82c410a81e4a6dbe9ae89578fda"
+note ""
+note "=== DONE ==="
+note "Restored (partial): ${PAGE_URL}"
+note "ACTION REQUIRED: Open page → ••• → Page history → restore pre-15:19 UTC 2026-06-02 version for full content"

--- a/scripts/notion-update-cluster-docs.sh
+++ b/scripts/notion-update-cluster-docs.sh
@@ -191,7 +191,33 @@ if [ -n "$PAGE_ID" ]; then
   note "  URL:   ${PAGE_URL}"
   note "  Replacing blocks..."
 
-  # Delete existing blocks first
+  # Safety check: confirm the page title before clearing.
+  # We already verified title matches during search, but double-check
+  # that we're not about to wipe an unrelated page.
+  LIVE_TITLE=$(curl -sS "https://api.notion.com/v1/pages/${PAGE_ID}" "${HEADERS[@]}" | \
+    python3 -c "
+import json,sys
+d=json.load(sys.stdin)
+for v in d.get('properties',{}).values():
+    if v.get('type')=='title':
+        print(''.join(t.get('plain_text','') for t in v.get('title',[])).lower())
+        break
+" 2>/dev/null || echo "")
+  REQUIRED_PHRASES=("cluster operation" "k3s runbook" "cluster incident" "cluster doctor runbook" "cluster ops runbook")
+  SAFE=0
+  for PHRASE in "${REQUIRED_PHRASES[@]}"; do
+    if [[ "$LIVE_TITLE" == *"$PHRASE"* ]]; then
+      SAFE=1
+      break
+    fi
+  done
+  if [ "$SAFE" = "0" ]; then
+    note "  SAFETY ABORT: live page title '${LIVE_TITLE}' does not match cluster ops phrases."
+    note "  Refusing to overwrite. Check PAGE_ID or update REQUIRED_PHRASES."
+    exit 1
+  fi
+
+  # Delete existing blocks
   EXISTING=$(curl -sS "https://api.notion.com/v1/blocks/${PAGE_ID}/children?page_size=100" "${HEADERS[@]}")
   echo "$EXISTING" | python3 -c "
 import json, sys

--- a/scripts/secrets-check.sh
+++ b/scripts/secrets-check.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+#
+# secrets-check.sh — verify all critical GitHub repo secrets are set.
+# Posts a checklist to issue #382 so the operator knows what's missing.
+#
+# Secrets checked:
+#   Cluster ops:  TS_AUTHKEY, KUBECONFIG_B64, OMV_SSH_KEY
+#   Notifications: NOTION_API_KEY
+#   Email:        SES_SMTP_USER, SES_SMTP_PASSWORD (or SSM path)
+#   CI:           GH_PAT, AWS_DEPLOY_ROLE_ARN
+#
+# Each secret is tested for non-empty value only (never logged).
+
+set -uo pipefail
+
+note() { printf "[secrets-check] %s\n" "$*"; }
+
+note "=== secrets-check $(date -u '+%F %T')Z ==="
+
+check() {
+  local name="$1"
+  local value="${2:-}"
+  if [ -n "$value" ]; then
+    echo "ok:${name}"
+  else
+    echo "missing:${name}"
+  fi
+}
+
+# Core cluster operations
+check "TS_AUTHKEY"        "${TS_AUTHKEY:-}"
+check "KUBECONFIG_B64"    "${KUBECONFIG_B64:-}"
+check "OMV_SSH_KEY"       "${OMV_SSH_KEY:-}"
+
+# Notion
+check "NOTION_API_KEY"    "${NOTION_API_KEY:-}"
+
+# AWS / Deploy
+check "AWS_DEPLOY_ROLE_ARN"  "${AWS_DEPLOY_ROLE_ARN:-}"
+
+# SES SMTP (either direct or via SSM)
+check "SES_SMTP_USER"     "${SES_SMTP_USER:-}"
+check "SES_SMTP_PASSWORD" "${SES_SMTP_PASSWORD:-}"
+
+# GitHub
+check "GH_PAT"            "${GH_PAT:-}"
+check "ADMIN_BOOTSTRAP_PASSWORD" "${ADMIN_BOOTSTRAP_PASSWORD:-}"


### PR DESCRIPTION
## Summary

### 1. ESP32 page restore
- `scripts/notion-restore-esp32.sh` + `notion-restore-esp32.yml` — reconstructs the ESP32 ESPHome Watchdog page that was overwritten on 2026-06-02 by re-reading Devices/Telemetry DBs and adding a recovery banner. Trigger by merging this PR.

### 2. Secrets health-check
- `scripts/secrets-check.sh` + `secrets-check.yml` — checks all 9 critical secrets (TS_AUTHKEY, KUBECONFIG_B64, **OMV_SSH_KEY**, SES_SMTP_USER/PASSWORD, etc.), posts a checklist with setup instructions to issue #382. Runs weekly Monday 08:00 UTC.

### 3. OMV SSH key skill
- `.claude/skills/omv-ssh-key-setup/SKILL.md` — step-by-step guide: generate key on Pi, add to authorized_keys, add `OMV_SSH_KEY` repo secret, deploy watchdog, troubleshoot failures.

### 4. Safety guard in notion-update-cluster-docs.sh
- Before clearing blocks, verifies the live page title actually matches cluster ops phrases. Aborts if it would overwrite an unrelated page.

https://claude.ai/code/session_012EjQpQGyt6SeSfRNNRRr6j