### PR TITLE
fix(ci): repair secrets-check.yml YAML startup failure

### DIFF
--- a/.github/workflows/secrets-check.yml
+++ b/.github/workflows/secrets-check.yml
@@ -61,56 +61,56 @@ jobs:
         run: |
           # Build a markdown checklist from the check output
           BODY=$(python3 -c "
-import sys
+          import sys
 
-lines = open('check.log').read().splitlines()
-ok = []
-missing = []
-for line in lines:
-    if line.startswith('ok:'):
-        ok.append(line[3:])
-    elif line.startswith('missing:'):
-        missing.append(line[8:])
+          lines = open('check.log').read().splitlines()
+          ok = []
+          missing = []
+          for line in lines:
+              if line.startswith('ok:'):
+                  ok.append(line[3:])
+              elif line.startswith('missing:'):
+                  missing.append(line[8:])
 
-print('# Secrets health check — $(date -u \"+%Y-%m-%d %H:%M:%SZ\")')
-print('')
-print(f'**{len(ok)} set / {len(missing)} missing**')
-print('')
+          print('# Secrets health check — $(date -u \"+%Y-%m-%d %H:%M:%SZ\")')
+          print('')
+          print(f'**{len(ok)} set / {len(missing)} missing**')
+          print('')
 
-descriptions = {
-    'TS_AUTHKEY': 'Tailscale auth key — cluster ops over VPN (tailscale.com/admin/settings/keys)',
-    'KUBECONFIG_B64': 'k3s kubeconfig system:admin — base64-encoded /etc/rancher/k3s/k3s.yaml',
-    'OMV_SSH_KEY': 'Pi SSH private key — enables k3s-ssh-restart + k3s-watchdog-deploy workflows',
-    'NOTION_API_KEY': 'Notion integration token — cluster docs, blog, submissions',
-    'AWS_DEPLOY_ROLE_ARN': 'OIDC deploy role — ECR push + SSM parameter access',
-    'SES_SMTP_USER': 'SES SMTP username — email verification (AWS Console → SES → SMTP Settings)',
-    'SES_SMTP_PASSWORD': 'SES SMTP password — email verification',
-    'GH_PAT': 'GitHub PAT repo scope — cloud session auto-push on stop hook',
-    'ADMIN_BOOTSTRAP_PASSWORD': 'Keycloak admin bootstrap password for keycloak-bootstrap-admin workflow',
-}
+          descriptions = {
+              'TS_AUTHKEY': 'Tailscale auth key — cluster ops over VPN (tailscale.com/admin/settings/keys)',
+              'KUBECONFIG_B64': 'k3s kubeconfig system:admin — base64-encoded /etc/rancher/k3s/k3s.yaml',
+              'OMV_SSH_KEY': 'Pi SSH private key — enables k3s-ssh-restart + k3s-watchdog-deploy workflows',
+              'NOTION_API_KEY': 'Notion integration token — cluster docs, blog, submissions',
+              'AWS_DEPLOY_ROLE_ARN': 'OIDC deploy role — ECR push + SSM parameter access',
+              'SES_SMTP_USER': 'SES SMTP username — email verification (AWS Console → SES → SMTP Settings)',
+              'SES_SMTP_PASSWORD': 'SES SMTP password — email verification',
+              'GH_PAT': 'GitHub PAT repo scope — cloud session auto-push on stop hook',
+              'ADMIN_BOOTSTRAP_PASSWORD': 'Keycloak admin bootstrap password for keycloak-bootstrap-admin workflow',
+          }
 
-for s in ok:
-    print(f'- [x] \`{s}\` — {descriptions.get(s, \"set\")}')
-for s in missing:
-    print(f'- [ ] \`{s}\` — ⚠️ MISSING — {descriptions.get(s, \"not set\")}')
+          for s in ok:
+              print(f'- [x] \`{s}\` — {descriptions.get(s, \"set\")}')
+          for s in missing:
+              print(f'- [ ] \`{s}\` — ⚠️ MISSING — {descriptions.get(s, \"not set\")}')
 
-if missing:
-    print('')
-    print('## How to add missing secrets')
-    print('GitHub → repo Settings → Secrets and variables → Actions → New repository secret')
-    if 'OMV_SSH_KEY' in missing:
-        print('')
-        print('### OMV_SSH_KEY')
-        print('1. On the Pi: \`cat ~/.ssh/id_ed25519\` (or generate: \`ssh-keygen -t ed25519\`)')
-        print('2. Add the Pi public key to \`~/.ssh/authorized_keys\` on the Pi itself')
-        print('3. Paste the **private key** content (-----BEGIN OPENSSH PRIVATE KEY----- ... -----END OPENSSH PRIVATE KEY-----) as \`OMV_SSH_KEY\`')
-        print('4. Once set, trigger \`k3s-watchdog-deploy.yml\` to install the Restart=always systemd drop-in')
-    if 'SES_SMTP_USER' in missing or 'SES_SMTP_PASSWORD' in missing:
-        print('')
-        print('### SES_SMTP_USER + SES_SMTP_PASSWORD')
-        print('1. AWS Console → SES → SMTP Settings → Create SMTP credentials')
-        print('2. Save the username and password shown (only shown once)')
-        print('3. Add as \`SES_SMTP_USER\` and \`SES_SMTP_PASSWORD\` repo secrets')
-        print('4. Trigger \`provision-ses-smtp.yml\` via workflow_dispatch with those values')
-")
+          if missing:
+              print('')
+              print('## How to add missing secrets')
+              print('GitHub → repo Settings → Secrets and variables → Actions → New repository secret')
+              if 'OMV_SSH_KEY' in missing:
+                  print('')
+                  print('### OMV_SSH_KEY')
+                  print('1. On the Pi: \`cat ~/.ssh/id_ed25519\` (or generate: \`ssh-keygen -t ed25519\`)')
+                  print('2. Add the Pi public key to \`~/.ssh/authorized_keys\` on the Pi itself')
+                  print('3. Paste the **private key** content (-----BEGIN OPENSSH PRIVATE KEY----- ... -----END OPENSSH PRIVATE KEY-----) as \`OMV_SSH_KEY\`')
+                  print('4. Once set, trigger \`k3s-watchdog-deploy.yml\` to install the Restart=always systemd drop-in')
+              if 'SES_SMTP_USER' in missing or 'SES_SMTP_PASSWORD' in missing:
+                  print('')
+                  print('### SES_SMTP_USER + SES_SMTP_PASSWORD')
+                  print('1. AWS Console → SES → SMTP Settings → Create SMTP credentials')
+                  print('2. Save the username and password shown (only shown once)')
+                  print('3. Add as \`SES_SMTP_USER\` and \`SES_SMTP_PASSWORD\` repo secrets')
+                  print('4. Trigger \`provision-ses-smtp.yml\` via workflow_dispatch with those values')
+          ")
           echo "$BODY" | gh issue comment 382 --repo "$GITHUB_REPOSITORY" --body-file -


### PR DESCRIPTION
## Problem

The new `secrets-check.yml` workflow (added in commit `a084c10` from another session) fails as a **startup failure** — 0s duration, no jobs, status Failure — so the secrets health check never runs.

**Root cause:** In the `Post checklist to tracking issue` step, the embedded Python program (`BODY=$(python3 -c "…")`) was pasted at **column 0**. The `run: |` block scalar is indented 10 spaces, so the un-indented `import sys` line terminates the block scalar and YAML fails to parse the file:

```
YAML parse error, line 64: could not find expected ':'
```

## Fix

Indent the embedded Python (the heredoc body) to the block-scalar level. YAML strips the common 10-space prefix uniformly, so:
- the workflow now parses, and
- Python's *relative* indentation is preserved (the interpreter still sees a valid program).

Also vendors `scripts/secrets-check.sh` (the script the workflow invokes), since it lives in the same orphan commit.

## Validation
- ✅ `yaml.safe_load` parses the workflow
- ✅ `bash -n scripts/secrets-check.sh` clean
- ✅ embedded Python compiles via `ast.parse` after simulating YAML block-scalar stripping

## Note on provenance
The broken commit `a084c10` is **not on `main`** and not on any pushed branch tip — it's an in-progress/orphan commit from a separate session, so there was no branch to fix in place. This PR re-introduces just the `secrets-check` pair (workflow + script) in a corrected form. If that other session later pushes its own branch, expect an overlap on these two files — take this PR's version of `secrets-check.yml`.

https://claude.ai/code/session_01SFLAFG395WWQcyj69toXbT

---
_Generated by [Claude Code](https://claude.ai/code/session_01SFLAFG395WWQcyj69toXbT)_