### PR TITLE
ops: trigger cluster-doctor snapshot (investigate KubeMemoryOvercommit)

### DIFF
--- a/scripts/cluster-doctor.sh
+++ b/scripts/cluster-doctor.sh
@@ -279,4 +279,4 @@ fi
 
 printf "\n_End of snapshot._\n"
 
-# re-trigger-doctor-20260602e
+# re-trigger-doctor-20260602f-memquota


### PR DESCRIPTION
Bumps the `cluster-doctor.sh` re-trigger marker to fire the path-filtered `push` workflow, producing a fresh **read-only** cluster snapshot to issue #382 — to diagnose the `KubeMemoryOvercommit` / `KUBEMEMORYQUOTAOVERCOMMIT` warning. No cluster mutation.

https://claude.ai/code/session_01SFLAFG395WWQcyj69toXbT

---
_Generated by [Claude Code](https://claude.ai/code/session_01SFLAFG395WWQcyj69toXbT)_