### PR TITLE
ops(cluster): fix Metabase OOMKill (1Gi limit) + trigger k3s restart

### DIFF
--- a/.github/workflows/k3s-restart.yml
+++ b/.github/workflows/k3s-restart.yml
@@ -86,3 +86,5 @@ jobs:
             cat k3s.log 2>/dev/null || echo "(no log)"
             echo '```'
           } | gh issue comment 382 --repo "$GITHUB_REPOSITORY" --body-file -
+
+# re-trigger-20260602a

--- a/scripts/analytics-restore.sh
+++ b/scripts/analytics-restore.sh
@@ -21,8 +21,8 @@
 set -uo pipefail
 
 NS="${ANALYTICS_NS:-analytics}"
-METABASE_MEM_LIMIT="${METABASE_MEM_LIMIT:-600Mi}"
-METABASE_JAVA_OPTS="${METABASE_JAVA_OPTS:--Xmx480m -Xms128m}"
+METABASE_MEM_LIMIT="${METABASE_MEM_LIMIT:-1Gi}"
+METABASE_JAVA_OPTS="${METABASE_JAVA_OPTS:--Xmx768m -Xms128m}"
 DUCKDB_MEM_LIMIT="${DUCKDB_MEM_LIMIT:-1500Mi}"
 
 note() { printf "[analytics-restore] %s\n" "$*"; }
@@ -57,8 +57,8 @@ MB_LIMIT=$(deploy_live_limit metabase)
 
 note "Metabase: restarts=${MB_RESTARTS} lastExit=${MB_EXIT:-none} liveLimit=${MB_LIMIT}"
 
-if [ "$MB_EXIT" = "OOMKilled" ] || [ "${MB_RESTARTS:-0}" -gt 3 ] || [ "$MB_LIMIT" = "400Mi" ]; then
-  note "Metabase needs recovery (OOMKilled or limit=400Mi) → patching to ${METABASE_MEM_LIMIT}"
+if [ "$MB_EXIT" = "OOMKilled" ] || [ "${MB_RESTARTS:-0}" -gt 3 ] || [ "$MB_LIMIT" = "400Mi" ] || [ "$MB_LIMIT" = "600Mi" ]; then
+  note "Metabase needs recovery (OOMKilled or limit≤600Mi) → patching to ${METABASE_MEM_LIMIT}"
   PATCH=$(printf '{"spec":{"template":{"spec":{"containers":[{"name":"metabase","resources":{"requests":{"memory":"256Mi","cpu":"100m"},"limits":{"memory":"%s","cpu":"1"}},"env":[{"name":"JAVA_OPTS","value":"%s"},{"name":"MB_JETTY_MAXTHREADS","value":"20"}]}]}}}}' \
     "$METABASE_MEM_LIMIT" "$METABASE_JAVA_OPTS")
   kubectl -n "$NS" patch deploy metabase --type=strategic -p "$PATCH" >/dev/null 2>&1 && \


### PR DESCRIPTION
## Summary

- **Metabase OOMKill fix**: raise default in `analytics-restore.sh` from 600Mi → 1Gi / `-Xmx768m` (was OOMKilling repeatedly even after the 14:26Z restore); also trigger recovery when live limit is 600Mi
- **k3s API flap**: re-trigger `k3s-restart.yml` to clear the intermittent `ServiceUnavailable` on the API server (likely caused by memory pressure from the Metabase restart loop)

## Context (from 15:08Z snapshot)

- Metabase: 12 restarts, `OOMKilled exit 137` — 600Mi not enough
- k3s API: intermittently `ServiceUnavailable` on kubectl calls; Tailscale/public traffic unaffected
- All 5 public HTTP surfaces: HTTP 200

https://claude.ai/code/session_01PHsA9s3tK2thgSJVwEGuWq

---
_Generated by [Claude Code](https://claude.ai/code/session_01PHsA9s3tK2thgSJVwEGuWq)_