### PR TITLE
fix(ci): close unterminated JSON in deploy-failed Slack notify step

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -153,4 +153,5 @@ jobs:
                 {\"type\": \"section\", \"text\": {\"type\": \"mrkdwn\", \"text\": \"*Stage:* \`production\`\n*Commit:* \`${GITHUB_SHA::7}\`\n*Actor:* ${{ github.actor }}\"}},
                 {\"type\": \"context\", \"elements\": [{\"type\": \"mrkdwn\", \"text\": \"<${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View workflow run>\"}]}
               ]
+            }"
             


### PR DESCRIPTION
## Problem
The `Notify Slack — deploy failed` step in `deploy.yml` opens its curl payload with `-d "{ …` but **never closes it** with a matching `}"` (the deploy-**succeeded** step does, at line 142). So on any deploy failure the step aborted with:
```
/home/runner/work/_temp/….sh: line 3: unexpected EOF while looking for matching `"'
##[error]Process completed with exit code 2.
```
Net effect: the Slack failure alert never fires — observed on Deploy run #779.

## Fix
Add the missing closing `}"` to the deploy-failed step, matching the succeeded step exactly.

## Validation
- ✅ `deploy.yml` parses (`yaml.safe_load`)
- ✅ all three Slack notify `run` blocks pass `bash -n` after simulating `${{ }}` substitution (the failed step previously errored)

## ⚠️ Scope note — this does NOT make the deploy green
The deploy job itself still fails **earlier**, at the SST/Pulumi step, on a stale Route 53 hosted zone:
```
reading Route 53 Hosted Zone (Z079608614L53CC4EAZM3): couldn't find resource
```
That's a separate, infra-level issue (`sst.config.ts:280` hardcodes a zone ID that AWS no longer finds) and needs the correct current zone ID or a decision to remove/relookup the records — tracked separately. This PR just ensures that when a deploy fails, the failure **notification** actually sends.

https://claude.ai/code/session_01SFLAFG395WWQcyj69toXbT

---
_Generated by [Claude Code](https://claude.ai/code/session_01SFLAFG395WWQcyj69toXbT)_