### PR TITLE
fix(deploy): resolve cloudless.gr Route 53 zone by name instead of stale hardcoded ID

### DIFF
--- a/sst.config.ts
+++ b/sst.config.ts
@@ -277,7 +277,17 @@ export default {
     // ID is the well-known constant Z2FDTNDATAQYW2 for all alias records.
     // APIGW regional has its own well-known zone ID Z1UJRXOUMOOFQ8.
     if (isProd) {
-      const zoneId = "Z079608614L53CC4EAZM3"; // cloudless.gr hosted zone
+      // Resolve the hosted zone by name rather than hardcoding its ID. The
+      // cloudless.gr zone has been recreated before, leaving a stale literal
+      // (Z079608614L53CC4EAZM3) that failed the deploy with
+      // "reading Route 53 Hosted Zone … couldn't find resource". Awaiting the
+      // data source yields a concrete string, which the Route 53 record
+      // `import:` IDs below require (they cannot take a Pulumi Output).
+      const zone = await aws.route53.getZone({
+        name: "cloudless.gr",
+        privateZone: false,
+      });
+      const zoneId = zone.zoneId; // cloudless.gr hosted zone (resolved live)
       const healthCheckId = "3805ab54-0238-4ab1-870f-7ad9caf43a91"; // PRIMARY (CloudFront)
       const secondaryHealthCheckId = "1069b339-6066-4a5c-a1b1-6bc7c9376977"; // SECONDARY (APIGW frontend)
       const cfZoneId = "Z2FDTNDATAQYW2";


### PR DESCRIPTION
## Problem
Production deploy (`Deploy to Production`) has been failing on **every** push to `main` at the SST/Pulumi step:
```
Error  ApexSecondary aws:route53:Record
reading Route 53 Hosted Zone (Z079608614L53CC4EAZM3): couldn't find resource: provider=aws@7.20.0
```
All 8 apex/www A+AAAA failover records reference a **hardcoded** hosted-zone ID (`sst.config.ts:280`) that AWS no longer finds. The cloudless.gr zone was recreated at some point; commit `bc2cbaf` refreshed the *health-check* IDs but left the *zone* ID stale.

## Fix (per maintainer decision: dynamic lookup)
Replace the literal with a name-based lookup and use the awaited result's `.zoneId` for both the record `zoneId` and the 8 Pulumi `import:` IDs:
```ts
const zone = await aws.route53.getZone({ name: "cloudless.gr", privateZone: false });
const zoneId = zone.zoneId;
```
- `run()` is already `async`, and `getZone` (the Promise form, not `getZoneOutput`) resolves to a **concrete string** — required because the `import:` option cannot take a Pulumi `Output`.
- Self-heals against any future zone recreation, so this class of breakage can't recur.

## Validation
- ✅ Only `sst.config.ts` changed; no stale-ID references remain except in an explanatory comment.
- ⚠️ Cannot be fully typechecked/deployed from the dev session (SST vendors `@pulumi/aws` only at deploy time and there's no AWS access here). The real proof is the next `Deploy to Production` run going green — please watch run output after merge. If `getZone` instead errors with *"no matching Route53Zone found"*, that means cloudless.gr has **no** Route 53 zone at all (DNS fully on Cloudflare) and we'd switch to removing these records.

## Related
- #524 fixes the broken deploy-failed Slack notifier (separate concern; doesn't affect the deploy outcome).

https://claude.ai/code/session_01SFLAFG395WWQcyj69toXbT

---
_Generated by [Claude Code](https://claude.ai/code/session_01SFLAFG395WWQcyj69toXbT)_