### PR TITLE
fix(deploy): unblock production deploy — gate deleted R53 zone + fix Slack notify

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -153,4 +153,4 @@ jobs:
                 {\"type\": \"section\", \"text\": {\"type\": \"mrkdwn\", \"text\": \"*Stage:* \`production\`\n*Commit:* \`${GITHUB_SHA::7}\`\n*Actor:* ${{ github.actor }}\"}},
                 {\"type\": \"context\", \"elements\": [{\"type\": \"mrkdwn\", \"text\": \"<${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View workflow run>\"}]}
               ]
-            
+            }"

--- a/sst.config.ts
+++ b/sst.config.ts
@@ -276,7 +276,21 @@ export default {
     // secondary when the PRIMARY health check fails. CloudFront's hosted zone
     // ID is the well-known constant Z2FDTNDATAQYW2 for all alias records.
     // APIGW regional has its own well-known zone ID Z1UJRXOUMOOFQ8.
-    if (isProd) {
+    //
+    // INCIDENT 2026-06-02: the cloudless.gr hosted zone Z079608614L53CC4EAZM3
+    // was deleted out-of-band (a casualty of concurrent R53 health-check /
+    // cost-cleanup work) between deploy #773 (14:26, last green) and #775
+    // (15:11). With the zone gone, every `import:` below fails to refresh
+    // ("reading Route 53 Hosted Zone ...: couldn't find resource") and blocks
+    // ALL production deploys. These records are therefore gated OFF by default
+    // so deploys can proceed; failover is currently handled at the
+    // Cloudflare/CloudFront layer (see .claude/commands/ha-failover.md).
+    //
+    // TO RE-ENABLE: recreate the hosted zone, update `zoneId` (a recreated zone
+    // gets a NEW id) and the `import:` IDs + `healthCheckId`s to match the live
+    // resources, then set the deploy env var ENABLE_R53_FAILOVER=1.
+    const enableR53Failover = process.env.ENABLE_R53_FAILOVER === "1";
+    if (isProd && enableR53Failover) {
       const zoneId = "Z079608614L53CC4EAZM3"; // cloudless.gr hosted zone
       const healthCheckId = "3805ab54-0238-4ab1-870f-7ad9caf43a91"; // PRIMARY (CloudFront)
       const secondaryHealthCheckId = "1069b339-6066-4a5c-a1b1-6bc7c9376977"; // SECONDARY (APIGW frontend)


### PR DESCRIPTION
## Why

Production deploys have failed on **every run since #773** (last green, `aeebc890` @ 14:26). The latest run #780 (`e427d179`) fails identically:

```
reading Route 53 Hosted Zone (Z079608614L53CC4EAZM3): couldn't find resource: provider=aws@7.20.0
  Error  ApexPrimary / ApexSecondary / WwwPrimary / WwwSecondary / *AAAA  aws:route53:Record
##[error]Process completed with exit code 1
```

The cloudless.gr hosted zone `Z079608614L53CC4EAZM3` was **deleted out-of-band** between #773 (14:26) and #775 (15:11) — a casualty of the concurrent R53 health-check / cost-cleanup work in that window (`bc2cbaf` only swapped health-check IDs *within* the records; it did not fix the missing zone). With the zone gone, all 8 imported `aws.route53.Record` resources fail to refresh and abort the entire SST deploy.

A second, compounding bug: the **"Notify Slack — deploy failed"** step's `curl -d` JSON was truncated (missing the closing `}"`), so every failed deploy *also* exited 2 with `unexpected EOF while looking for matching "`.

## What

- **`sst.config.ts`** — gate the 8 Route 53 failover records behind an opt-in `ENABLE_R53_FAILOVER` flag (default **off**). This removes nothing from AWS (the zone is already gone); failover is currently served at the Cloudflare/CloudFront layer. The incident and re-enable steps are documented inline.
- **`.github/workflows/deploy.yml`** — close the truncated Slack "deploy failed" payload to match the started/succeeded steps.

## Re-enabling R53 failover later

Recreate the hosted zone, update `zoneId` (a recreated zone gets a **new** id) + the `import:` IDs + `healthCheckId`s to match the live resources, then set `ENABLE_R53_FAILOVER=1` in the deploy env.

https://claude.ai/code/session_016PrzZJMNxsgiEmvedfkru6

---
_Generated by [Claude Code](https://claude.ai/code/session_016PrzZJMNxsgiEmvedfkru6)_