### PR TITLE
fix(notion): prevent duplicate pages and populate ESP32 DB data

### DIFF
--- a/.github/workflows/notion-restore-esp32.yml
+++ b/.github/workflows/notion-restore-esp32.yml
@@ -32,8 +32,8 @@ jobs:
     env:
       GH_TOKEN: ${{ github.token }}
       NOTION_API_KEY: ${{ secrets.NOTION_API_KEY }}
-      NOTION_ESP32_DEVICES_DB_ID: ${{ secrets.NOTION_ESP32_DEVICES_DB_ID }}
-      NOTION_ESP32_TELEMETRY_DB_ID: ${{ secrets.NOTION_ESP32_TELEMETRY_DB_ID }}
+      NOTION_ESP32_DEVICES_DB_ID: 022b2212-995b-4e29-8c3c-900297b435b9
+      NOTION_ESP32_TELEMETRY_DB_ID: 3214d53d-90ff-4b7a-81c3-f689a92ee167
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v4.3.1

--- a/.github/workflows/notion-update-cluster-docs.yml
+++ b/.github/workflows/notion-update-cluster-docs.yml
@@ -26,6 +26,7 @@ jobs:
     env:
       GH_TOKEN: ${{ github.token }}
       NOTION_API_KEY: ${{ secrets.NOTION_API_KEY }}
+      CLUSTER_OPS_PAGE_ID: ${{ vars.CLUSTER_OPS_PAGE_ID }}
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v4.3.1

--- a/.github/workflows/secrets-check.yml
+++ b/.github/workflows/secrets-check.yml
@@ -4,17 +4,6 @@ name: secrets-check — verify critical repo secrets are set
 # Posts a checklist to issue #382 so the operator knows what's missing.
 #
 # Trigger by editing this file, or run via workflow_dispatch.
-#
-# Checks (non-empty test only — values are never logged):
-#   TS_AUTHKEY       — Tailscale auth key (cluster ops over VPN)
-#   KUBECONFIG_B64   — k3s kubeconfig (system:admin)
-#   OMV_SSH_KEY      — Pi SSH private key (k3s restart + watchdog deploy)
-#   NOTION_API_KEY   — Notion integration token
-#   AWS_DEPLOY_ROLE_ARN — OIDC role for ECR push + SSM
-#   SES_SMTP_USER    — SES SMTP credentials (email verification)
-#   SES_SMTP_PASSWORD
-#   GH_PAT           — GitHub PAT (cross-repo push, session auto-push)
-#   ADMIN_BOOTSTRAP_PASSWORD — Keycloak admin bootstrap
 
 on:
   push:
@@ -37,7 +26,6 @@ jobs:
     timeout-minutes: 5
     env:
       GH_TOKEN: ${{ github.token }}
-      # Pass each secret — empty string if not set (GitHub replaces unset secrets with "")
       TS_AUTHKEY: ${{ secrets.TS_AUTHKEY }}
       KUBECONFIG_B64: ${{ secrets.KUBECONFIG_B64 }}
       OMV_SSH_KEY: ${{ secrets.OMV_SSH_KEY }}
@@ -53,64 +41,14 @@ jobs:
 
       - name: Check secrets
         id: check
+        run: bash scripts/secrets-check.sh 2>&1 | tee check.log
+
+      - name: Build checklist report
+        if: always()
         run: |
-          bash scripts/secrets-check.sh 2>&1 | tee check.log
+          TIMESTAMP=$(date -u '+%Y-%m-%d %H:%M:%SZ')
+          python3 scripts/secrets-check-report.py check.log "$TIMESTAMP" > report.md
 
       - name: Post checklist to tracking issue
         if: always()
-        run: |
-          # Build a markdown checklist from the check output
-          BODY=$(python3 -c "
-import sys
-
-lines = open('check.log').read().splitlines()
-ok = []
-missing = []
-for line in lines:
-    if line.startswith('ok:'):
-        ok.append(line[3:])
-    elif line.startswith('missing:'):
-        missing.append(line[8:])
-
-print('# Secrets health check — $(date -u \"+%Y-%m-%d %H:%M:%SZ\")')
-print('')
-print(f'**{len(ok)} set / {len(missing)} missing**')
-print('')
-
-descriptions = {
-    'TS_AUTHKEY': 'Tailscale auth key — cluster ops over VPN (tailscale.com/admin/settings/keys)',
-    'KUBECONFIG_B64': 'k3s kubeconfig system:admin — base64-encoded /etc/rancher/k3s/k3s.yaml',
-    'OMV_SSH_KEY': 'Pi SSH private key — enables k3s-ssh-restart + k3s-watchdog-deploy workflows',
-    'NOTION_API_KEY': 'Notion integration token — cluster docs, blog, submissions',
-    'AWS_DEPLOY_ROLE_ARN': 'OIDC deploy role — ECR push + SSM parameter access',
-    'SES_SMTP_USER': 'SES SMTP username — email verification (AWS Console → SES → SMTP Settings)',
-    'SES_SMTP_PASSWORD': 'SES SMTP password — email verification',
-    'GH_PAT': 'GitHub PAT repo scope — cloud session auto-push on stop hook',
-    'ADMIN_BOOTSTRAP_PASSWORD': 'Keycloak admin bootstrap password for keycloak-bootstrap-admin workflow',
-}
-
-for s in ok:
-    print(f'- [x] \`{s}\` — {descriptions.get(s, \"set\")}')
-for s in missing:
-    print(f'- [ ] \`{s}\` — ⚠️ MISSING — {descriptions.get(s, \"not set\")}')
-
-if missing:
-    print('')
-    print('## How to add missing secrets')
-    print('GitHub → repo Settings → Secrets and variables → Actions → New repository secret')
-    if 'OMV_SSH_KEY' in missing:
-        print('')
-        print('### OMV_SSH_KEY')
-        print('1. On the Pi: \`cat ~/.ssh/id_ed25519\` (or generate: \`ssh-keygen -t ed25519\`)')
-        print('2. Add the Pi public key to \`~/.ssh/authorized_keys\` on the Pi itself')
-        print('3. Paste the **private key** content (-----BEGIN OPENSSH PRIVATE KEY----- ... -----END OPENSSH PRIVATE KEY-----) as \`OMV_SSH_KEY\`')
-        print('4. Once set, trigger \`k3s-watchdog-deploy.yml\` to install the Restart=always systemd drop-in')
-    if 'SES_SMTP_USER' in missing or 'SES_SMTP_PASSWORD' in missing:
-        print('')
-        print('### SES_SMTP_USER + SES_SMTP_PASSWORD')
-        print('1. AWS Console → SES → SMTP Settings → Create SMTP credentials')
-        print('2. Save the username and password shown (only shown once)')
-        print('3. Add as \`SES_SMTP_USER\` and \`SES_SMTP_PASSWORD\` repo secrets')
-        print('4. Trigger \`provision-ses-smtp.yml\` via workflow_dispatch with those values')
-")
-          echo "$BODY" | gh issue comment 382 --repo "$GITHUB_REPOSITORY" --body-file -
+        run: gh issue comment 382 --repo "$GITHUB_REPOSITORY" --body-file report.md

--- a/scripts/notion-update-cluster-docs.sh
+++ b/scripts/notion-update-cluster-docs.sh
@@ -28,48 +28,84 @@ note() { printf "[notion-update] %s\n" "$*"; }
 note "=== notion-update-cluster-docs $(date -u '+%F %T')Z ==="
 
 # ---------------------------------------------------------------------------
-# Step 1: Search for existing cluster ops runbook page (exact matches only)
-# We only accept pages whose title unambiguously identifies a cluster ops doc.
-# We exclude pages about ESP32/ESPHome/hardware that happen to mention cluster.
+# Step 1: Find the canonical cluster ops runbook page.
+#
+# Priority order:
+#   a) CLUSTER_OPS_PAGE_ID env var (set as a GitHub repo variable) — direct lookup,
+#      avoids search entirely and prevents duplicate page creation
+#   b) Known page IDs from previous successful runs (direct GET, no search needed)
+#   c) Title search (last resort, only if direct lookups fail)
 # ---------------------------------------------------------------------------
-note "Searching Notion for existing cluster operations runbook..."
-
-EXCLUDE_WORDS='["esp32", "esphome", "sensor", "temperature", "humidity", "device", "firmware", "watchdog hardware", "iot"]'
-REQUIRED_PHRASES='["cluster operation", "k3s runbook", "cluster incident", "cluster doctor runbook", "cluster ops runbook"]'
+note "Locating cluster operations runbook page..."
 
 PAGE_ID=""
 PAGE_URL=""
 PAGE_TITLE=""
 
-for QUERY in "Cluster Operations Runbook" "Cluster Operations" "k3s Runbook" "Cluster Incident Response Runbook"; do
-  SEARCH_RESULT=$(curl -sS -X POST "https://api.notion.com/v1/search" \
-    "${HEADERS[@]}" \
-    -d "{\"query\": \"${QUERY}\", \"filter\": {\"value\": \"page\", \"property\": \"object\"}, \"page_size\": 10}")
+# Known page IDs from previous successful runs (most recent first)
+KNOWN_IDS=(
+  "${CLUSTER_OPS_PAGE_ID:-}"                   # repo variable — canonical
+  "3737d82c-410a-8130-b90d-c55017e86059"       # created 2026-06-02 run 2
+  "3737d82c-410a-81e5-bb2c-fcd31e49d57c"       # created 2026-06-02 run 1 (may be empty)
+)
 
-  MATCH=$(echo "$SEARCH_RESULT" | python3 -c "
+for KID in "${KNOWN_IDS[@]}"; do
+  [ -z "$KID" ] && continue
+  RESP=$(curl -sS "https://api.notion.com/v1/pages/${KID}" "${HEADERS[@]}")
+  OBJ=$(echo "$RESP" | python3 -c "import json,sys; print(json.load(sys.stdin).get('object',''))" 2>/dev/null || echo "")
+  if [ "$OBJ" = "page" ]; then
+    ARCHIVED=$(echo "$RESP" | python3 -c "import json,sys; print(json.load(sys.stdin).get('archived',True))" 2>/dev/null || echo "True")
+    if [ "$ARCHIVED" = "False" ]; then
+      PAGE_ID="$KID"
+      PAGE_URL=$(echo "$RESP" | python3 -c "import json,sys; print(json.load(sys.stdin).get('url',''))" 2>/dev/null || echo "")
+      PAGE_TITLE=$(echo "$RESP" | python3 -c "
+import json,sys
+d=json.load(sys.stdin)
+for v in d.get('properties',{}).values():
+    if v.get('type')=='title':
+        print(''.join(t.get('plain_text','') for t in v.get('title',[])))
+        break
+" 2>/dev/null || echo "known page")
+      note "  Found via direct lookup: ${PAGE_ID} (${PAGE_TITLE})"
+      break
+    fi
+  fi
+done
+
+# Fallback: title search (only if none of the known IDs worked)
+if [ -z "$PAGE_ID" ]; then
+  note "  No known page found — searching by title..."
+  for QUERY in "Cluster Operations Runbook" "Cluster Operations" "k3s Runbook"; do
+    SEARCH_RESULT=$(curl -sS -X POST "https://api.notion.com/v1/search" \
+      "${HEADERS[@]}" \
+      -d "{\"query\": \"${QUERY}\", \"filter\": {\"value\": \"page\", \"property\": \"object\"}, \"page_size\": 10}")
+
+    MATCH=$(echo "$SEARCH_RESULT" | python3 -c "
 import json, sys
 data = json.load(sys.stdin)
 exclude = ['esp32', 'esphome', 'sensor', 'temperature', 'humidity', 'device', 'firmware', 'iot']
 required = ['cluster operation', 'k3s runbook', 'cluster incident', 'cluster doctor runbook', 'cluster ops runbook']
 for r in data.get('results', []):
+    if r.get('archived'): continue
     props = r.get('properties', {})
     for k, v in props.items():
         if v.get('type') == 'title':
             title = ''.join(t.get('plain_text','') for t in v.get('title',[])).lower()
-            if any(ex in title for ex in exclude):
-                continue
+            if any(ex in title for ex in exclude): continue
             if any(req in title for req in required):
                 print(r['id'] + '|' + r.get('url','') + '|' + title)
                 sys.exit(0)
 " 2>/dev/null || echo "")
 
-  if [ -n "$MATCH" ]; then
-    PAGE_ID=$(echo "$MATCH" | cut -d'|' -f1)
-    PAGE_URL=$(echo "$MATCH" | cut -d'|' -f2)
-    PAGE_TITLE=$(echo "$MATCH" | cut -d'|' -f3)
-    break
-  fi
-done
+    if [ -n "$MATCH" ]; then
+      PAGE_ID=$(echo "$MATCH" | cut -d'|' -f1)
+      PAGE_URL=$(echo "$MATCH" | cut -d'|' -f2)
+      PAGE_TITLE=$(echo "$MATCH" | cut -d'|' -f3)
+      note "  Found via search: ${PAGE_ID}"
+      break
+    fi
+  done
+fi
 
 # ---------------------------------------------------------------------------
 # Step 2: Build the runbook content as Notion blocks

--- a/scripts/notion-update-cluster-docs.sh
+++ b/scripts/notion-update-cluster-docs.sh
@@ -77,10 +77,14 @@ done
 TODAY=$(date -u '+%Y-%m-%d')
 
 build_blocks() {
-python3 -c "
+# Write blocks JSON to a temp file to avoid shell variable expansion issues
+# with special characters (em-dashes, arrows, etc.)
+local outfile="${1:-/tmp/notion-blocks.json}"
+python3 - "$TODAY" "$outfile" <<'PYEOF'
 import json, sys
 
 today = sys.argv[1]
+outfile = sys.argv[2]
 
 def p(text):
     return {'object':'block','type':'paragraph','paragraph':{'rich_text':[{'text':{'content':text}}]}}
@@ -176,14 +180,16 @@ blocks = [
     divider(),
     p(f'Auto-updated {today} by notion-update-cluster-docs.yml'),
 ]
-print(json.dumps({'children': blocks[:100]}))
-" "$TODAY"
+with open(outfile, 'w') as f:
+    json.dump({'children': blocks[:100]}, f)
+PYEOF
 }
 
 # ---------------------------------------------------------------------------
 # Step 3: Update existing page or create a new one
 # ---------------------------------------------------------------------------
-BLOCKS_JSON=$(build_blocks)
+BLOCKS_FILE="/tmp/notion-blocks-$$.json"
+build_blocks "$BLOCKS_FILE"
 
 if [ -n "$PAGE_ID" ]; then
   note "Found existing runbook page: ${PAGE_ID}"
@@ -231,8 +237,11 @@ for b in data.get('results', []):
 
   APPEND_RESULT=$(curl -sS -X PATCH "https://api.notion.com/v1/blocks/${PAGE_ID}/children" \
     "${HEADERS[@]}" \
-    -d "$BLOCKS_JSON")
-  STATUS=$(echo "$APPEND_RESULT" | python3 -c "import json,sys; print(json.load(sys.stdin).get('object','error'))" 2>/dev/null || echo "error")
+    --data "@${BLOCKS_FILE}")
+  STATUS=$(echo "$APPEND_RESULT" | python3 -c "import json,sys; d=json.load(sys.stdin); print(d.get('object') or d.get('code','error'))" 2>/dev/null || echo "error")
+  if [ "$STATUS" = "error" ]; then
+    note "  Append ERROR: $(echo "$APPEND_RESULT" | python3 -c "import json,sys; print(json.load(sys.stdin).get('message','unknown'))" 2>/dev/null)"
+  fi
   note "  Append status: ${STATUS}"
   ACTION="updated"
 
@@ -283,8 +292,9 @@ print(json.dumps(payload))
 
   APPEND_RESULT=$(curl -sS -X PATCH "https://api.notion.com/v1/blocks/${PAGE_ID}/children" \
     "${HEADERS[@]}" \
-    -d "$BLOCKS_JSON")
-  note "  Content appended"
+    --data "@${BLOCKS_FILE}")
+  STATUS=$(echo "$APPEND_RESULT" | python3 -c "import json,sys; d=json.load(sys.stdin); print(d.get('object') or d.get('code','error'))" 2>/dev/null || echo "error")
+  note "  Content appended (status: ${STATUS})"
   ACTION="created"
 fi
 

--- a/scripts/secrets-check-report.py
+++ b/scripts/secrets-check-report.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python3
+"""Generate a markdown secrets-check report from check.log output."""
+import sys
+
+log_file = sys.argv[1]
+timestamp = sys.argv[2] if len(sys.argv) > 2 else ""
+
+lines = open(log_file).read().splitlines()
+ok = []
+missing = []
+for line in lines:
+    if line.startswith("ok:"):
+        ok.append(line[3:])
+    elif line.startswith("missing:"):
+        missing.append(line[8:])
+
+descriptions = {
+    "TS_AUTHKEY": "Tailscale auth key — cluster ops over VPN (tailscale.com/admin/settings/keys)",
+    "KUBECONFIG_B64": "k3s kubeconfig system:admin — base64-encoded /etc/rancher/k3s/k3s.yaml",
+    "OMV_SSH_KEY": "Pi SSH private key — enables k3s-ssh-restart + k3s-watchdog-deploy workflows",
+    "NOTION_API_KEY": "Notion integration token — cluster docs, blog, submissions",
+    "AWS_DEPLOY_ROLE_ARN": "OIDC deploy role — ECR push + SSM parameter access",
+    "SES_SMTP_USER": "SES SMTP username — email verification (AWS Console → SES → SMTP Settings)",
+    "SES_SMTP_PASSWORD": "SES SMTP password — email verification",
+    "GH_PAT": "GitHub PAT repo scope — cloud session auto-push on stop hook",
+    "ADMIN_BOOTSTRAP_PASSWORD": "Keycloak admin bootstrap password for keycloak-bootstrap-admin workflow",
+}
+
+print(f"# Secrets health check — {timestamp}")
+print()
+print(f"**{len(ok)} set / {len(missing)} missing**")
+print()
+
+for s in ok:
+    print(f"- [x] `{s}` — {descriptions.get(s, 'set')}")
+for s in missing:
+    print(f"- [ ] `{s}` — ⚠️ MISSING — {descriptions.get(s, 'not set')}")
+
+if missing:
+    print()
+    print("## How to add missing secrets")
+    print("GitHub → repo Settings → Secrets and variables → Actions → New repository secret")
+    if "OMV_SSH_KEY" in missing:
+        print()
+        print("### OMV_SSH_KEY")
+        print("1. On the Pi: `cat ~/.ssh/id_ed25519` (or generate: `ssh-keygen -t ed25519`)")
+        print("2. Ensure `~/.ssh/authorized_keys` contains the public key on the Pi")
+        print("3. Paste the **private key** (-----BEGIN OPENSSH PRIVATE KEY----- block) as `OMV_SSH_KEY`")
+        print("4. Once set, trigger `k3s-watchdog-deploy.yml` to install the Restart=always drop-in")
+    if "SES_SMTP_USER" in missing or "SES_SMTP_PASSWORD" in missing:
+        print()
+        print("### SES_SMTP_USER + SES_SMTP_PASSWORD")
+        print("1. AWS Console → SES → SMTP Settings → Create SMTP credentials")
+        print("2. Save the username and password (only shown once)")
+        print("3. Add as `SES_SMTP_USER` and `SES_SMTP_PASSWORD` repo secrets")
+        print("4. Trigger `provision-ses-smtp.yml` via workflow_dispatch with those values")


### PR DESCRIPTION
## Summary
- \`notion-update-cluster-docs.sh\`: priority lookup uses \`CLUSTER_OPS_PAGE_ID\` repo variable + known IDs before falling back to Notion search — prevents duplicate cluster runbook page creation caused by Notion search indexing lag on newly-created pages
- \`notion-update-cluster-docs.yml\`: passes \`CLUSTER_OPS_PAGE_ID\` from repo var so the script always finds the canonical page
- \`notion-restore-esp32.yml\`: hardcodes ESP32 DB IDs directly (not sensitive config — were missing as secrets causing 0 rows returned during ESP32 page restore)

## Test plan
- [ ] Merge triggers notion-update-cluster-docs workflow (path-triggered)
- [ ] Workflow finds existing page via direct lookup (not search)
- [ ] No new duplicate cluster runbook pages created
- [ ] Check result in issue #382

https://claude.ai/code/session_012EjQpQGyt6SeSfRNNRRr6j