### PR TITLE
ops(cluster): fix analytics-restore workflow — raise Metabase limit to 1Gi

### DIFF
--- a/.github/workflows/analytics-restore.yml
+++ b/.github/workflows/analytics-restore.yml
@@ -19,9 +19,9 @@ on:
   workflow_dispatch:
     inputs:
       metabase_mem_limit:
-        description: "Metabase memory limit (default: 600Mi)"
+        description: "Metabase memory limit (default: 1Gi)"
         required: false
-        default: "600Mi"
+        default: "1Gi"
 
 permissions:
   contents: read
@@ -33,7 +33,7 @@ jobs:
     timeout-minutes: 15
     env:
       GH_TOKEN: ${{ github.token }}
-      METABASE_MEM_LIMIT: ${{ github.event.inputs.metabase_mem_limit || '600Mi' }}
+      METABASE_MEM_LIMIT: ${{ github.event.inputs.metabase_mem_limit || '1Gi' }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v4.3.1
 


### PR DESCRIPTION
## Summary
- The workflow `env` block was forcing `METABASE_MEM_LIMIT=600Mi` on every push trigger (`github.event.inputs` is empty for non-dispatch runs), silently overriding the `1Gi` default set in `scripts/analytics-restore.sh`
- Metabase OOMKilled 34 times at 600Mi — the 15:47Z analytics-restore run confirmed the patch target was still `600Mi`
- Raises the workflow default to `1Gi` to match the script

## Test plan
- [ ] Merged commit triggers analytics-restore workflow (path filter: `.github/workflows/analytics-restore.yml`)
- [ ] Workflow patches Metabase to 1Gi and reports success to issue #382

https://claude.ai/code/session_01PHsA9s3tK2thgSJVwEGuWq

---
_Generated by [Claude Code](https://claude.ai/code/session_01PHsA9s3tK2thgSJVwEGuWq)_