### PR TITLE
ops(cluster): run analytics-restore on self-hosted runner — fix k3s API access

### DIFF
--- a/.github/workflows/analytics-restore.yml
+++ b/.github/workflows/analytics-restore.yml
@@ -19,9 +19,9 @@ on:
   workflow_dispatch:
     inputs:
       metabase_mem_limit:
-        description: "Metabase memory limit (default: 600Mi)"
+        description: "Metabase memory limit (default: 1Gi)"
         required: false
-        default: "600Mi"
+        default: "1Gi"
 
 permissions:
   contents: read
@@ -33,7 +33,7 @@ jobs:
     timeout-minutes: 15
     env:
       GH_TOKEN: ${{ github.token }}
-      METABASE_MEM_LIMIT: ${{ github.event.inputs.metabase_mem_limit || '600Mi' }}
+      METABASE_MEM_LIMIT: ${{ github.event.inputs.metabase_mem_limit || '1Gi' }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v4.3.1
 

--- a/.github/workflows/analytics-restore.yml
+++ b/.github/workflows/analytics-restore.yml
@@ -29,24 +29,16 @@ permissions:
 
 jobs:
   restore:
-    runs-on: ubuntu-latest
+    # Runs on the Pi host as a systemd service — stays alive when k3s crashes.
+    # Uses local kubectl (/etc/rancher/k3s/k3s.yaml) — no Tailscale needed.
+    # If this job queues forever the Pi itself is down; cancel and reboot manually.
+    runs-on: [self-hosted, omv, build]
     timeout-minutes: 15
     env:
       GH_TOKEN: ${{ github.token }}
       METABASE_MEM_LIMIT: ${{ github.event.inputs.metabase_mem_limit || '1Gi' }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v4.3.1
-
-      - name: Connect to tailnet
-        uses: tailscale/github-action@0263d9e6d793eaefcf1de98ff7fde47abe6664d3 # v3.2.4
-        with:
-          authkey: ${{ secrets.TS_AUTHKEY }}
-
-      - name: Configure kubectl
-        run: |
-          mkdir -p ~/.kube
-          echo "${{ secrets.KUBECONFIG_B64 }}" | base64 -d > ~/.kube/config
-          chmod 600 ~/.kube/config
 
       - name: Run analytics-restore
         id: restore

--- a/scripts/analytics-restore.sh
+++ b/scripts/analytics-restore.sh
@@ -25,6 +25,9 @@ METABASE_MEM_LIMIT="${METABASE_MEM_LIMIT:-1Gi}"
 METABASE_JAVA_OPTS="${METABASE_JAVA_OPTS:--Xmx768m -Xms128m}"
 DUCKDB_MEM_LIMIT="${DUCKDB_MEM_LIMIT:-1500Mi}"
 
+KUBECONFIG="${KUBECONFIG:-/etc/rancher/k3s/k3s.yaml}"
+export KUBECONFIG
+
 note() { printf "[analytics-restore] %s\n" "$*"; }
 k() { kubectl "$@" 2>&1 || true; }
 
@@ -57,7 +60,7 @@ MB_LIMIT=$(deploy_live_limit metabase)
 
 note "Metabase: restarts=${MB_RESTARTS} lastExit=${MB_EXIT:-none} liveLimit=${MB_LIMIT}"
 
-if [ "$MB_EXIT" = "OOMKilled" ] || [ "${MB_RESTARTS:-0}" -gt 3 ] || [ "$MB_LIMIT" = "400Mi" ] || [ "$MB_LIMIT" = "600Mi" ]; then
+if [ "$MB_EXIT" = "OOMKilled" ] || [ "${MB_RESTARTS:-0}" -gt 3 ] || [ "$MB_LIMIT" = "400Mi" ] || [ "$MB_LIMIT" = "600Mi" ] || [ "$MB_LIMIT" = "unknown" ]; then
   note "Metabase needs recovery (OOMKilled or limit≤600Mi) → patching to ${METABASE_MEM_LIMIT}"
   PATCH=$(printf '{"spec":{"template":{"spec":{"containers":[{"name":"metabase","resources":{"requests":{"memory":"256Mi","cpu":"100m"},"limits":{"memory":"%s","cpu":"1"}},"env":[{"name":"JAVA_OPTS","value":"%s"},{"name":"MB_JETTY_MAXTHREADS","value":"20"}]}]}}}}' \
     "$METABASE_MEM_LIMIT" "$METABASE_JAVA_OPTS")


### PR DESCRIPTION
## Summary
- After the k3s restart at 15:47Z, `ubuntu-latest` runners can't reach `100.113.41.119:6443` via Tailscale (connection refused). Script reports `restarts=0 liveLimit=unknown` → "OK — no recovery needed", silently skipping the 1Gi patch.
- Switch analytics-restore to `[self-hosted, omv, build]` (same as k3s-restart) — this runner uses local kubectl via `/etc/rancher/k3s/k3s.yaml` and is unaffected by Tailscale routing issues. It survives k3s crashes as it's a separate systemd service.
- Remove Tailscale + KUBECONFIG_B64 steps entirely from the workflow.
- Default `KUBECONFIG` in the script to the local k3s kubeconfig.
- Add `liveLimit=unknown` to the recovery trigger condition so a kubectl failure doesn't silently look like "OK".

## Test plan
- [ ] Merged commit triggers analytics-restore on self-hosted runner
- [ ] Script reads actual Metabase state (liveLimit=600Mi or unknown) and patches to 1Gi
- [ ] Issue #382 shows successful patch and Metabase ready=1

https://claude.ai/code/session_01PHsA9s3tK2thgSJVwEGuWq

---
_Generated by [Claude Code](https://claude.ai/code/session_01PHsA9s3tK2thgSJVwEGuWq)_