### PR TITLE
feat: ESP32 DB discovery workflow, keycloak bootstrap trigger, CLAUDE.md checklist

### DIFF
--- a/.github/workflows/keycloak-bootstrap-admin.yml
+++ b/.github/workflows/keycloak-bootstrap-admin.yml
@@ -7,6 +7,7 @@ name: Keycloak bootstrap admin (no secret needed)
 # own password. The real password is never committed, never a secret.
 #
 # Trigger: workflow_dispatch, or push to this file / the script on main.
+# Last triggered: 2026-06-02 (ADMIN_BOOTSTRAP_PASSWORD secret not set)
 
 on:
   workflow_dispatch:

--- a/.github/workflows/notion-discover-esp32.yml
+++ b/.github/workflows/notion-discover-esp32.yml
@@ -1,0 +1,52 @@
+name: notion-discover-esp32 — find ESP32 databases in Notion
+
+# Diagnostic: lists all Notion databases accessible to the integration,
+# searches for ESP32/devices/telemetry pages, and tests the hardcoded DB IDs
+# from notion-restore-esp32.sh. Results posted to issue #382.
+#
+# Run once to confirm whether the Notion integration can see the ESP32
+# databases. If the hardcoded IDs return "object_not_found", share those
+# databases with the Cloudless Notion integration in the Notion UI.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - ".github/workflows/notion-discover-esp32.yml"
+      - "scripts/notion-discover-esp32.sh"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  discover:
+    name: Discover ESP32 databases in Notion
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    env:
+      GH_TOKEN: ${{ github.token }}
+      NOTION_API_KEY: ${{ secrets.NOTION_API_KEY }}
+
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v4.3.1
+
+      - name: Run notion-discover-esp32
+        id: discover
+        run: |
+          set -o pipefail
+          bash scripts/notion-discover-esp32.sh 2>&1 | tee discover.log
+
+      - name: Post result to tracking issue
+        if: always()
+        run: |
+          {
+            echo "# Notion ESP32 database discovery — $(date -u '+%Y-%m-%d %H:%M:%SZ')"
+            echo ""
+            echo "**Status:** ${{ job.status }}"
+            echo ""
+            echo '```'
+            cat discover.log 2>/dev/null || echo "(no log)"
+            echo '```'
+          } | gh issue comment 382 --repo "$GITHUB_REPOSITORY" --body-file -

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,17 @@
 # Claude Code — Project Memory
 
+## Pending One-Time Setup (human action required)
+
+These require access outside GitHub and cannot be automated from a cloud session.
+
+| Item | Status | Action |
+|------|--------|--------|
+| `OMV_SSH_KEY` | **MISSING** | On Pi: `cat ~/.ssh/id_ed25519` → GitHub repo Settings → Secrets → `OMV_SSH_KEY`. Then `k3s-watchdog-deploy.yml` auto-triggers. |
+| SES SMTP | **MISSING** | AWS Console → SES → SMTP Settings → Create SMTP credentials. Then GitHub Actions → "Provision SES SMTP credentials" → Run workflow with `smtp_user` + `smtp_password` inputs. |
+| ESP32 Notion DBs | **DB ACCESS UNKNOWN** | Open ESP32 Devices + Telemetry databases in Notion → Share → invite Cloudless integration. Run `notion-discover-esp32.yml` to confirm. |
+| ESP32 page content | **PARTIAL RESTORE** | Full content requires Notion UI: open page → ••• → Page history → restore pre-15:19 UTC 2026-06-02. |
+| Admin password | **TEMP LOGIN in #382** | After `keycloak-bootstrap-admin.yml` run: login with temp credentials from issue #382, then Keycloak forces password update. |
+
 ## Testing Policy
 
 **Never fix test failures by adding mock code.** When a test fails, fix the actual production code so the test passes naturally. Do not add `vi.mocked(...)`, `mockReturnValue`, `mockResolvedValue`, or any other mock overrides to patch a failing test. If the test expectation is wrong (e.g. it expects old behavior that changed), update the expectation — but never shim production behavior with mocks.

--- a/scripts/notion-discover-esp32.sh
+++ b/scripts/notion-discover-esp32.sh
@@ -1,0 +1,116 @@
+#!/usr/bin/env bash
+#
+# notion-discover-esp32.sh — find ESP32 databases accessible to the Notion integration.
+#
+# The notion-restore-esp32 workflow returned 0 rows because the Notion integration
+# may not have access to the ESP32 Devices / Telemetry databases, or the IDs are wrong.
+#
+# This script:
+#   1. Lists all pages and databases accessible to the integration
+#   2. Filters for anything ESP32/devices/telemetry related
+#   3. Reports all database IDs found so the restore script can be updated
+
+set -uo pipefail
+
+NOTION_VERSION="2022-06-28"
+HEADERS=(
+  -H "Authorization: Bearer ${NOTION_API_KEY}"
+  -H "Notion-Version: ${NOTION_VERSION}"
+  -H "Content-Type: application/json"
+)
+
+note() { printf "[esp32-discover] %s\n" "$*"; }
+
+note "=== notion-discover-esp32 $(date -u '+%F %T')Z ==="
+
+# ---------------------------------------------------------------------------
+# Step 1: Search for all databases accessible to the integration
+# ---------------------------------------------------------------------------
+note "Querying all accessible databases..."
+DB_RESULT=$(curl -sS -X POST "https://api.notion.com/v1/search" \
+  "${HEADERS[@]}" \
+  -d '{"filter":{"value":"database","property":"object"},"page_size":100}')
+
+ALL_DBS=$(echo "$DB_RESULT" | python3 -c "
+import json, sys
+data = json.load(sys.stdin)
+results = data.get('results', [])
+print(f'Total databases accessible: {len(results)}')
+for r in results:
+    rid = r.get('id','')
+    title = ''
+    title_prop = r.get('title', [])
+    if title_prop:
+        title = ''.join(t.get('plain_text','') for t in title_prop)
+    else:
+        for v in r.get('properties', {}).values():
+            if v.get('type') == 'title':
+                title = ''.join(t.get('plain_text','') for t in v.get('title', []))
+                break
+    archived = r.get('archived', False)
+    print(f'  DB: {rid} | {title} | archived={archived}')
+" 2>/dev/null || echo "  (parse error)")
+
+note "$ALL_DBS"
+
+# ---------------------------------------------------------------------------
+# Step 2: Search specifically for ESP32 / devices / telemetry pages
+# ---------------------------------------------------------------------------
+note ""
+note "Searching for ESP32 / devices / telemetry pages..."
+for QUERY in "ESP32" "Devices" "Telemetry" "ESPHome" "Watchdog"; do
+  RESULT=$(curl -sS -X POST "https://api.notion.com/v1/search" \
+    "${HEADERS[@]}" \
+    -d "{\"query\": \"${QUERY}\", \"page_size\": 10}")
+
+  MATCHES=$(echo "$RESULT" | python3 -c "
+import json, sys
+data = json.load(sys.stdin)
+for r in data.get('results', []):
+    rid = r.get('id','')
+    obj = r.get('object','')
+    archived = r.get('archived', False)
+    title = ''
+    if obj == 'database':
+        for t in r.get('title', []):
+            title += t.get('plain_text','')
+    else:
+        for v in r.get('properties', {}).values():
+            if v.get('type') == 'title':
+                title = ''.join(t.get('plain_text','') for t in v.get('title', []))
+                break
+    if title or rid:
+        print(f'  {obj}: {rid} | {title} | archived={archived}')
+" 2>/dev/null || echo "  (no matches)")
+
+  note "Query '${QUERY}': ${MATCHES:-no matches}"
+done
+
+# ---------------------------------------------------------------------------
+# Step 3: Try the hardcoded DB IDs from notion-restore-esp32.sh directly
+# ---------------------------------------------------------------------------
+note ""
+note "Testing hardcoded DB IDs from restore script..."
+for DB_ID in "022b2212-995b-4e29-8c3c-900297b435b9" "3214d53d-90ff-4b7a-81c3-f689a92ee167"; do
+  RESP=$(curl -sS -X POST "https://api.notion.com/v1/databases/${DB_ID}/query" \
+    "${HEADERS[@]}" \
+    -d '{"page_size":1}')
+  OBJ=$(echo "$RESP" | python3 -c "import json,sys; d=json.load(sys.stdin); print(d.get('object',''))" 2>/dev/null || echo "")
+  if [ "$OBJ" = "list" ]; then
+    COUNT=$(echo "$RESP" | python3 -c "import json,sys; print(len(json.load(sys.stdin).get('results',[])))" 2>/dev/null || echo "?")
+    note "  DB ${DB_ID}: ACCESSIBLE (returned ${COUNT} rows)"
+  else
+    CODE=$(echo "$RESP" | python3 -c "import json,sys; print(json.load(sys.stdin).get('code','unknown'))" 2>/dev/null || echo "unknown")
+    MSG=$(echo "$RESP" | python3 -c "import json,sys; print(json.load(sys.stdin).get('message',''))" 2>/dev/null || echo "")
+    note "  DB ${DB_ID}: NOT accessible (${CODE}: ${MSG})"
+  fi
+done
+
+note ""
+note "=== DONE ==="
+note "If the hardcoded IDs are 'object_not_found': the Notion integration needs"
+note "to be shared with those databases in the Notion UI:"
+note "  1. Open ESP32 Devices database in Notion"
+note "  2. Click Share → invite the Cloudless Notion integration"
+note "  3. Repeat for ESP32 Telemetry database"
+note "  4. Re-run notion-restore-esp32 workflow"


### PR DESCRIPTION
## Summary
- `scripts/notion-discover-esp32.sh` + `notion-discover-esp32.yml`: diagnostic workflow that lists all Notion databases accessible to the integration and tests the hardcoded ESP32 DB IDs — helps identify whether the "0 rows" issue is wrong IDs or missing Notion sharing
- `keycloak-bootstrap-admin.yml`: touched to trigger path-based run → generates temp admin password in-cluster and posts to #382 (addresses missing `ADMIN_BOOTSTRAP_PASSWORD` secret)
- `CLAUDE.md`: added "Pending One-Time Setup" table with status for OMV_SSH_KEY, SES SMTP, ESP32 Notion DBs, ESP32 page restore, and admin password

## Test plan
- [ ] Merge triggers notion-discover-esp32 workflow and keycloak-bootstrap-admin workflow
- [ ] Check issue #382 for ESP32 DB accessibility report
- [ ] Check issue #382 for keycloak bootstrap temp login
- [ ] OMV_SSH_KEY and SES SMTP still require manual user action (documented in CLAUDE.md)

https://claude.ai/code/session_012EjQpQGyt6SeSfRNNRRr6j