### PR TITLE
fix(dashboard): read profile/preferences back from Keycloak so saves stick

### DIFF
--- a/__tests__/user-profile-api.test.ts
+++ b/__tests__/user-profile-api.test.ts
@@ -89,3 +89,65 @@ describe("POST /api/user/profile", () => {
     expect((await res.json()).error).toMatch(/Failed to update profile/);
   });
 });
+
+describe("GET /api/user/profile", () => {
+  it("401 when there is no session/accessToken", async () => {
+    authMock.mockResolvedValue(null);
+    const { GET } = await import("@/app/api/user/profile/route");
+    const res = await GET();
+    expect(res.status).toBe(401);
+  });
+
+  it("reads name + company/phone/preferences back from Keycloak", async () => {
+    authMock.mockResolvedValue({ user: { id: "u1", email: "u@x.gr" }, accessToken: "tok" });
+    vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({
+          firstName: "Baltzakis",
+          lastName: "Themistoklis",
+          email: "u@x.gr",
+          attributes: {
+            company: ["cloudless.gr"],
+            phone: ["+30123"],
+            preferences: [JSON.stringify({ theme: "light", language: "el" })],
+          },
+        }),
+        { status: 200 }
+      )
+    );
+    const { GET } = await import("@/app/api/user/profile/route");
+    const res = await GET();
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({
+      name: "Baltzakis Themistoklis",
+      email: "u@x.gr",
+      company: "cloudless.gr",
+      phone: "+30123",
+      preferences: { theme: "light", language: "el" },
+    });
+  });
+
+  it("ignores malformed stored preferences and still returns the profile", async () => {
+    authMock.mockResolvedValue({ user: { id: "u1" }, accessToken: "tok" });
+    vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({ firstName: "A", attributes: { preferences: ["{not-json"] } }),
+        { status: 200 }
+      )
+    );
+    const { GET } = await import("@/app/api/user/profile/route");
+    const res = await GET();
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.name).toBe("A");
+    expect(body.preferences).toBeUndefined();
+  });
+
+  it("502 when the account cannot be read", async () => {
+    authMock.mockResolvedValue({ user: { id: "u1" }, accessToken: "tok" });
+    vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(new Response(null, { status: 500 }));
+    const { GET } = await import("@/app/api/user/profile/route");
+    const res = await GET();
+    expect(res.status).toBe(502);
+  });
+});

--- a/src/app/api/user/profile/route.ts
+++ b/src/app/api/user/profile/route.ts
@@ -24,6 +24,66 @@ function splitName(name: string): { firstName: string; lastName?: string } {
 }
 
 /**
+ * GET /api/user/profile
+ *
+ * Reads the signed-in user's Keycloak profile (name + company/phone/preferences
+ * attributes) so the dashboard can display previously-saved values. Without
+ * this, the session only carries name/email and the Profile/Settings forms
+ * render blank on every load — making saves look like they never stuck.
+ *
+ * Like POST, this must run server-side: a browser → Keycloak Account API call
+ * is cross-origin and CORS-blocked.
+ */
+export async function GET() {
+  const session = await auth();
+  const accessToken = session?.accessToken;
+  if (!session?.user || !accessToken) {
+    return NextResponse.json({ error: "Not authenticated" }, { status: 401 });
+  }
+
+  const KC_ISSUER = process.env.KEYCLOAK_ISSUER ?? process.env.NEXT_PUBLIC_KEYCLOAK_ISSUER ?? "";
+  if (!KC_ISSUER) {
+    return NextResponse.json({ error: "Auth not configured" }, { status: 500 });
+  }
+
+  try {
+    const res = await globalThis.fetch(`${KC_ISSUER}/account`, {
+      headers: { Authorization: `Bearer ${accessToken}`, Accept: "application/json" },
+      signal: AbortSignal.timeout(10_000),
+    });
+    if (!res.ok) {
+      return NextResponse.json(
+        { error: "Could not read profile", status: res.status },
+        { status: 502 }
+      );
+    }
+    const acct = (await res.json()) as KcAccount;
+    const attrs = acct.attributes ?? {};
+    const name = [acct.firstName, acct.lastName].filter(Boolean).join(" ").trim();
+
+    let preferences: unknown;
+    const rawPrefs = attrs.preferences?.[0];
+    if (rawPrefs) {
+      try {
+        preferences = JSON.parse(rawPrefs);
+      } catch {
+        // Ignore malformed stored preferences — fall back to client defaults.
+      }
+    }
+
+    return NextResponse.json({
+      name: name || undefined,
+      email: acct.email ?? session.user.email ?? undefined,
+      company: attrs.company?.[0],
+      phone: attrs.phone?.[0],
+      preferences,
+    });
+  } catch {
+    return NextResponse.json({ error: "Could not reach auth server" }, { status: 502 });
+  }
+}
+
+/**
  * POST /api/user/profile
  *
  * Updates the signed-in user's Keycloak profile (name + company/phone

--- a/src/context/AuthContext.tsx
+++ b/src/context/AuthContext.tsx
@@ -77,6 +77,34 @@ function isAdminFromSession(user: { groups?: string[]; roles?: string[] }): bool
   );
 }
 
+/**
+ * Pull the user's Keycloak profile attributes (company/phone/preferences) that
+ * the session token does not carry, merging them onto the base user. Returns
+ * the base unchanged on any failure so auth state never depends on it. Without
+ * this, the Profile/Settings forms render blank on every load even after a save.
+ */
+async function enrichWithProfile(base: AuthUser): Promise<AuthUser> {
+  try {
+    const res = await globalThis.fetch("/api/user/profile");
+    if (!res.ok) return base;
+    const p = (await res.json()) as {
+      name?: string;
+      company?: string;
+      phone?: string;
+      preferences?: Partial<UserPreferences>;
+    };
+    return {
+      ...base,
+      name: p.name ?? base.name,
+      company: p.company ?? base.company,
+      phone: p.phone ?? base.phone,
+      preferences: { ...base.preferences, ...(p.preferences ?? {}) },
+    };
+  } catch {
+    return base;
+  }
+}
+
 interface AuthProviderProps {
   readonly children: ReactNode;
 }
@@ -115,13 +143,17 @@ export function AuthProvider({ children }: AuthProviderProps) {
       }
 
       if (data?.user) {
-        setUser({
+        const base: AuthUser = {
           username: data.user.id ?? data.user.email ?? "",
           email: data.user.email ?? undefined,
           name: data.user.name ?? undefined,
           preferences: { ...DEFAULT_PREFERENCES },
-        });
+        };
         setIsAdmin(isAdminFromSession(data.user));
+        // Enrich with Keycloak profile attributes (company/phone/preferences)
+        // the session JWT doesn't carry, so saved values render instead of
+        // blanks. Best-effort — falls back to the session-only user.
+        setUser(await enrichWithProfile(base));
       } else {
         setUser(null);
         setIsAdmin(false);

--- a/src/context/AuthContext.tsx
+++ b/src/context/AuthContext.tsx
@@ -19,6 +19,9 @@ const DEFAULT_PREFERENCES: UserPreferences = {
   emailMarketing: false,
 };
 
+/** Same-origin route that reads (GET) and writes (POST) Keycloak profile attributes. */
+const PROFILE_ENDPOINT = "/api/user/profile";
+
 export interface AuthUser {
   username: string;
   email?: string;
@@ -85,7 +88,7 @@ function isAdminFromSession(user: { groups?: string[]; roles?: string[] }): bool
  */
 async function enrichWithProfile(base: AuthUser): Promise<AuthUser> {
   try {
-    const res = await globalThis.fetch("/api/user/profile");
+    const res = await globalThis.fetch(PROFILE_ENDPOINT);
     if (!res.ok) return base;
     const p = (await res.json()) as {
       name?: string;
@@ -235,7 +238,7 @@ export function AuthProvider({ children }: AuthProviderProps) {
     // Keycloak's Account API (auth.cloudless.gr) is cross-origin and is blocked
     // by CORS → the opaque "Failed to fetch". The server route uses the user's
     // access token to update Keycloak with no CORS constraint.
-    const res = await globalThis.fetch("/api/user/profile", {
+    const res = await globalThis.fetch(PROFILE_ENDPOINT, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify(attrs),
@@ -265,7 +268,7 @@ export function AuthProvider({ children }: AuthProviderProps) {
     setUser((prev) => (prev ? { ...prev, preferences: merged } : prev));
     // Persist via our same-origin route (browser → Keycloak is CORS-blocked).
     try {
-      await globalThis.fetch("/api/user/profile", {
+      await globalThis.fetch(PROFILE_ENDPOINT, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ preferences: merged }),


### PR DESCRIPTION
Fixes finding **#2** from the user-flow report (`docs/user-flow-simulation.md`): profile & preferences were **write-only**.

## Problem
The session JWT only carries `name` + `email`. Nothing read `company`, `phone`, or `preferences` back from Keycloak, so the Profile form showed blank company/phone and the Settings page reset language + notification toggles on every reload — saves *looked* like they didn't stick (they did persist in Keycloak).

## Fix
- **`GET /api/user/profile`** — reads `name`/`company`/`phone`/`preferences` from the Keycloak Account API server-side (a browser→Keycloak call is cross-origin/CORS-blocked, same reason POST is server-side). Returns `502` gracefully if the account can't be read.
- **`AuthContext`** — on load, enriches the user with those attributes (best-effort; falls back to the session-only user on any failure). Because the dashboard gates children on `isLoading`, the Profile/Settings forms now mount with real values — no form-state-sync hacks needed.

## Tests
Added 4 GET cases to `__tests__/user-profile-api.test.ts` (auth gate, full read-back incl. parsed preferences, malformed-prefs tolerance, 502). Full run: **31 passed** (profile API + both auth-context suites). `tsc --noEmit` clean, `eslint` clean.

https://claude.ai/code/session_01SFLAFG395WWQcyj69toXbT

---
_Generated by [Claude Code](https://claude.ai/code/session_01SFLAFG395WWQcyj69toXbT)_