### PR TITLE
fix(store): stop locale double-prefix on product page links (404 on el/fr/de)

### DIFF
--- a/src/app/[locale]/store/[id]/page.tsx
+++ b/src/app/[locale]/store/[id]/page.tsx
@@ -14,7 +14,6 @@ import ProductIcon from "@/components/store/ProductIcon";
 import JsonLd from "@/components/JsonLd";
 import { formatPrice } from "@/lib/format-price";
 import { getProductSchema, getBreadcrumbSchema } from "@/lib/structured-data";
-import { routing } from "@/i18n/routing";
 
 export async function generateMetadata({
   params,
@@ -35,9 +34,7 @@ export default async function ProductPage({
 }: {
   params: Promise<{ locale: string; id: string }>;
 }) {
-  const { locale, id } = await params;
-  const localePath = (path: string) =>
-    locale === routing.defaultLocale ? path : `/${locale}${path}`;
+  const { id } = await params;
   const product = getProductById(id);
 
   if (!product) notFound();
@@ -68,7 +65,7 @@ export default async function ProductPage({
         <div className="mx-auto max-w-6xl px-6 py-4">
           <nav className="flex items-center gap-2 font-mono text-sm text-slate-500">
             <Link
-              href={localePath("/store")}
+              href="/store"
               className="hover:text-neon-cyan text-xs transition-colors"
             >
               Store
@@ -156,7 +153,7 @@ export default async function ProductPage({
               {related.map((rel) => (
                 <Link
                   key={rel.id}
-                  href={localePath(`/store/${rel.id}`)}
+                  href={`/store/${rel.id}`}
                   className="group neon-border bg-void-light/50 overflow-hidden rounded-lg transition-all duration-300 hover:-translate-y-1 active:scale-[0.98]"
                 >
                   <div className="bg-void-lighter relative aspect-[4/3] overflow-hidden">


### PR DESCRIPTION
Fixes finding **#4** from the user-flow report: locale double-prefix on the product page.

## Problem
`store/[id]/page.tsx` built link targets with a `localePath()` helper (which prepends `/el`, `/fr`, … for non-default locales) **and** passed them to the i18n `<Link>` from `@/i18n/navigation`, which prepends the locale **again**. Result: `/el/el/store`, `/el/el/store/{id}`. The breadcrumb "Store" link and all related-product links **404'd on el/fr/de**; English (default) was unaffected.

## Fix
Pass **bare** paths (`/store`, `/store/${rel.id}`) to the i18n `<Link>` (it handles the locale prefix), and remove the now-unused `localePath` helper, the `routing` import, and the `locale` param destructure.

## Scope check
Grepped the codebase for the same anti-pattern — the only other `localePath` is on the homepage, where it's an SEO canonical-URL map (absolute URLs for `alternates`), not passed to a `<Link>`. So this was the only occurrence.

`tsc --noEmit` clean, `eslint` clean.

https://claude.ai/code/session_01SFLAFG395WWQcyj69toXbT

---
_Generated by [Claude Code](https://claude.ai/code/session_01SFLAFG395WWQcyj69toXbT)_