### PR TITLE
fix(auth): surface forgot-password link in Keycloak login mode

### DIFF
--- a/src/app/[locale]/auth/login/page.tsx
+++ b/src/app/[locale]/auth/login/page.tsx
@@ -165,6 +165,14 @@ function LoginContent() {
                   ? t("auth.signingIn", "Signing In...")
                   : t("auth.continueWithKeycloak", "Continue with Keycloak")}
               </button>
+              <div className="flex justify-center">
+                <Link
+                  href="/auth/forgot-password"
+                  className="text-neon-cyan/70 hover:text-neon-cyan font-mono text-sm transition-colors"
+                >
+                  {t("auth.forgotPassword", "Forgot Password?")}
+                </Link>
+              </div>
             </form>
           ) : (
             <form onSubmit={handleLogin} className="space-y-5">


### PR DESCRIPTION
Fixes finding **#5** from the user-flow report: the forgot-password link is unreachable in production.

## Problem
The "Forgot Password?" link only rendered in the **legacy** email/password branch of the login form. In production (`NEXT_PUBLIC_KEYCLOAK_ISSUER` set), the login page shows only the "Continue with Keycloak" button — so `/auth/forgot-password` (which works — it redirects to Keycloak's `reset-credentials` page) had **no link pointing to it**.

## Fix
Add the `/auth/forgot-password` link under the Keycloak sign-in button, using the existing i18n `<Link>` and the existing `auth.forgotPassword` translation key.

`tsc --noEmit` clean, `eslint` clean.

https://claude.ai/code/session_01SFLAFG395WWQcyj69toXbT

---
_Generated by [Claude Code](https://claude.ai/code/session_01SFLAFG395WWQcyj69toXbT)_