### PR TITLE
fix(store): link checkout to account (send auth token) + surface checkout errors

### DIFF
--- a/src/components/store/CartSlideOver.tsx
+++ b/src/components/store/CartSlideOver.tsx
@@ -4,11 +4,13 @@ import { useCart } from "@/context/CartContext";
 import { useState } from "react";
 import { formatPrice } from "@/lib/format-price";
 import ProductIcon from "@/components/store/ProductIcon";
+import { fetchWithAuth } from "@/lib/fetch-with-auth";
 
 export default function CartSlideOver() {
   const { items, isOpen, closeCart, removeItem, updateQuantity, totalPrice, totalItems } =
     useCart();
   const [isCheckingOut, setIsCheckingOut] = useState(false);
+  const [checkoutError, setCheckoutError] = useState<string | null>(null);
 
   const hasSubscription = items.some((item) => item.product.recurring);
   const hasOneTime = items.some((item) => !item.product.recurring);
@@ -16,8 +18,13 @@ export default function CartSlideOver() {
 
   const handleCheckout = async () => {
     setIsCheckingOut(true);
+    setCheckoutError(null);
     try {
-      const res = await fetch("/api/checkout", {
+      // fetchWithAuth attaches the Keycloak id_token when signed in, so the
+      // checkout route can pre-fill customer_email and tag the session with
+      // userId — linking the order to the account. Anonymous carts still work
+      // (no token → anonymous checkout).
+      const res = await fetchWithAuth("/api/checkout", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
@@ -27,12 +34,15 @@ export default function CartSlideOver() {
           })),
         }),
       });
-      const data = await res.json();
-      if (data.url) {
+      const data = (await res.json().catch(() => ({}))) as { url?: string; error?: string };
+      if (res.ok && data.url) {
         window.location.href = data.url;
+        return;
       }
+      // Surface the failure instead of silently resetting the button.
+      setCheckoutError(data.error ?? "Checkout failed. Please try again.");
     } catch {
-      alert("Checkout failed. Please try again.");
+      setCheckoutError("Checkout failed. Please try again.");
     } finally {
       setIsCheckingOut(false);
     }
@@ -154,6 +164,14 @@ export default function CartSlideOver() {
                 <p className="text-neon-magenta bg-neon-magenta/10 border-neon-magenta/20 rounded-lg border px-3 py-2 font-mono text-xs">
                   Subscriptions and one-time items can&apos;t be purchased together. Please remove
                   one type before checking out.
+                </p>
+              )}
+              {checkoutError && (
+                <p
+                  role="alert"
+                  className="text-neon-magenta bg-neon-magenta/10 border-neon-magenta/20 rounded-lg border px-3 py-2 font-mono text-xs"
+                >
+                  {checkoutError}
                 </p>
               )}
               <button


### PR DESCRIPTION
Fixes finding **#3** from the user-flow report.

## Problems
1. **Orders weren't linked to the account.** `CartSlideOver.handleCheckout` used a plain `fetch` with no `Authorization` header, so `/api/checkout` saw no user → `customer_email` wasn't pre-filled and `userId` wasn't added to the session metadata. The purchase only showed up in the buyer's dashboard if they happened to type their exact account email at Stripe.
2. **Silent failure.** `if (data.url)` did nothing on a non-OK response (e.g. `503` Stripe-not-configured, `400`); the spinner just reset with no message. The `catch` only fired on network errors.

## Fix
- Use **`fetchWithAuth`** so the Keycloak `id_token` is attached when signed in. The checkout route already reads it (`getTokenFromHeader` → `verifyToken` → `customer_email` + `userId` metadata), so this completes the linkage. Anonymous carts still work (no token → anonymous checkout).
- Surface the failure inline (`role="alert"`) with the server's error message instead of silently resetting.

## Tests
No regressions: `checkout-api` (12) + `cart-context` (10) suites pass. `tsc`/`eslint` clean. (Route logic unchanged; change is client-side.)

https://claude.ai/code/session_01SFLAFG395WWQcyj69toXbT

---
_Generated by [Claude Code](https://claude.ai/code/session_01SFLAFG395WWQcyj69toXbT)_