### PR TITLE
feat(auth): resend-verification endpoint + signup button (unblock stranded users)

### DIFF
--- a/__tests__/auth-resend-verification-api.test.ts
+++ b/__tests__/auth-resend-verification-api.test.ts
@@ -1,0 +1,140 @@
+/**
+ * Unit tests for POST /api/auth/resend-verification
+ *
+ * Re-sends the Keycloak verification email for an existing, not-yet-verified
+ * user. Uses the Admin REST API (client_credentials → search by email →
+ * send-verify-email). Always responds { ok: true } to avoid account
+ * enumeration. All HTTP calls are mocked.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+const mockGetConfig = vi.fn();
+vi.mock("@/lib/ssm-config", () => ({ getConfig: mockGetConfig }));
+
+const ISSUER = "https://auth.test/realms/master";
+const REALM = "master";
+const ADMIN_CFG = {
+  KEYCLOAK_ADMIN_CLIENT_ID: "cloudless-admin-api",
+  KEYCLOAK_ADMIN_CLIENT_SECRET: "s3cr3t",
+};
+
+function tokenOk() {
+  return { ok: true, status: 200, headers: { get: () => null }, json: async () => ({ access_token: "tok-123" }) };
+}
+function searchOk(users: unknown[]) {
+  return { ok: true, status: 200, headers: { get: () => null }, json: async () => users };
+}
+function verifyOk() {
+  return { ok: true, status: 200, headers: { get: () => null }, json: async () => ({}) };
+}
+function req(body: unknown) {
+  return new Request("http://localhost/api/auth/resend-verification", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+describe("POST /api/auth/resend-verification", () => {
+  const origFetch = globalThis.fetch;
+  let fetchMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.resetModules();
+    process.env.KEYCLOAK_ISSUER = ISSUER;
+    process.env.NEXT_PUBLIC_KEYCLOAK_CLIENT_ID = "cloudless-app";
+    process.env.NEXT_PUBLIC_SITE_URL = "https://cloudless.gr";
+    mockGetConfig.mockResolvedValue(ADMIN_CFG);
+    fetchMock = vi.fn();
+    globalThis.fetch = fetchMock;
+  });
+
+  afterEach(() => {
+    globalThis.fetch = origFetch;
+    delete process.env.KEYCLOAK_ISSUER;
+    delete process.env.NEXT_PUBLIC_SITE_URL;
+  });
+
+  it("returns 503 when KEYCLOAK_ISSUER is not set", async () => {
+    delete process.env.KEYCLOAK_ISSUER;
+    const { POST } = await import("@/app/api/auth/resend-verification/route");
+    const res = await POST(req({ email: "a@b.com" }));
+    expect(res.status).toBe(503);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("returns 503 when issuer does not match the /realms/ pattern", async () => {
+    process.env.KEYCLOAK_ISSUER = "https://auth.test/not-a-realm";
+    const { POST } = await import("@/app/api/auth/resend-verification/route");
+    expect((await POST(req({ email: "a@b.com" }))).status).toBe(503);
+  });
+
+  it("returns 503 when admin client credentials are missing from SSM", async () => {
+    mockGetConfig.mockResolvedValue({ KEYCLOAK_ADMIN_CLIENT_ID: "", KEYCLOAK_ADMIN_CLIENT_SECRET: "x" });
+    const { POST } = await import("@/app/api/auth/resend-verification/route");
+    expect((await POST(req({ email: "a@b.com" }))).status).toBe(503);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 for a malformed email (never reaches Keycloak)", async () => {
+    const { POST } = await import("@/app/api/auth/resend-verification/route");
+    const res = await POST(req({ email: "not-an-email" }));
+    expect(res.status).toBe(400);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 when the body is not valid JSON", async () => {
+    const { POST } = await import("@/app/api/auth/resend-verification/route");
+    const bad = new Request("http://localhost/api/auth/resend-verification", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: "nope",
+    });
+    expect((await POST(bad)).status).toBe(400);
+  });
+
+  it("re-sends the verify email for an existing unverified user", async () => {
+    fetchMock
+      .mockResolvedValueOnce(tokenOk())
+      .mockResolvedValueOnce(searchOk([{ id: "uid-7", emailVerified: false }]))
+      .mockResolvedValueOnce(verifyOk());
+    const { POST } = await import("@/app/api/auth/resend-verification/route");
+    const res = await POST(req({ email: "u@b.com" }));
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ ok: true });
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+    const [verifyUrl, verifyOpts] = fetchMock.mock.calls[2] as [string, RequestInit];
+    expect(verifyUrl).toContain(`/admin/realms/${REALM}/users/uid-7/send-verify-email`);
+    expect(verifyOpts.method).toBe("PUT");
+    expect(verifyUrl).toContain("client_id=cloudless-app");
+    expect(verifyUrl).toContain("redirect_uri=");
+  });
+
+  it("does NOT re-send for an already-verified user (still ok)", async () => {
+    fetchMock
+      .mockResolvedValueOnce(tokenOk())
+      .mockResolvedValueOnce(searchOk([{ id: "uid-8", emailVerified: true }]));
+    const { POST } = await import("@/app/api/auth/resend-verification/route");
+    const res = await POST(req({ email: "v@b.com" }));
+    expect(res.status).toBe(200);
+    expect(fetchMock).toHaveBeenCalledTimes(2); // token + search, no send-verify
+  });
+
+  it("returns ok without sending when the email is unknown (no enumeration)", async () => {
+    fetchMock.mockResolvedValueOnce(tokenOk()).mockResolvedValueOnce(searchOk([]));
+    const { POST } = await import("@/app/api/auth/resend-verification/route");
+    const res = await POST(req({ email: "missing@b.com" }));
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ ok: true });
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("returns ok even when the admin token fetch fails (never leaks)", async () => {
+    fetchMock.mockResolvedValueOnce({ ok: false, status: 401, headers: { get: () => null }, json: async () => ({}) });
+    const { POST } = await import("@/app/api/auth/resend-verification/route");
+    const res = await POST(req({ email: "a@b.com" }));
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ ok: true });
+  });
+});

--- a/src/app/[locale]/auth/signup/page.tsx
+++ b/src/app/[locale]/auth/signup/page.tsx
@@ -36,6 +36,8 @@ function SignUpForm() {
   const [step, setStep] = useState<"signup" | "check-email">("signup");
   const [error, setError] = useState("");
   const [submitting, setSubmitting] = useState(false);
+  const [resending, setResending] = useState(false);
+  const [resent, setResent] = useState(false);
 
   const handleSignUp = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -61,6 +63,24 @@ function SignUpForm() {
       setError(t("auth.signupFailed", "Sign up failed"));
     } finally {
       setSubmitting(false);
+    }
+  };
+
+  const handleResend = async () => {
+    setResending(true);
+    try {
+      // The endpoint always returns ok (anti-enumeration), so a successful
+      // request is all we can confirm to the user.
+      await globalThis.fetch("/api/auth/resend-verification", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ email }),
+      });
+      setResent(true);
+    } catch {
+      // Keep the button available so the user can retry.
+    } finally {
+      setResending(false);
     }
   };
 
@@ -113,6 +133,23 @@ function SignUpForm() {
                   "Click the link in the email to activate your account. After verification, you can sign in."
                 )}
               </p>
+              <div className="space-y-2">
+                <p className="font-mono text-xs text-slate-500">
+                  {t("auth.didntGetEmail", "Didn't get the email?")}
+                </p>
+                <button
+                  type="button"
+                  onClick={handleResend}
+                  disabled={resending || resent}
+                  className="bg-void-light/60 hover:border-neon-cyan/40 min-h-11 w-full rounded-lg border border-slate-700 py-2.5 font-mono text-sm text-slate-300 transition-all disabled:opacity-60"
+                >
+                  {resending
+                    ? t("auth.resending", "Resending…")
+                    : resent
+                      ? t("auth.verificationResent", "Verification email sent ✓")
+                      : t("auth.resendVerification", "Resend verification email")}
+                </button>
+              </div>
               <Link
                 href="/auth/login"
                 className="text-neon-cyan block font-mono text-sm hover:underline"

--- a/src/app/api/auth/register/route.ts
+++ b/src/app/api/auth/register/route.ts
@@ -2,27 +2,12 @@ import { NextResponse } from "next/server";
 import { getConfig } from "@/lib/ssm-config";
 import { isValidEmail } from "@/lib/validation";
 import { rateLimit, getClientIp } from "@/lib/rate-limit";
+import { getAdminToken, parseRealm, sendVerifyEmail } from "@/lib/keycloak-admin";
 
 interface RegisterBody {
   email: string;
   password: string;
   fullName?: string;
-}
-
-async function getAdminToken(tokenUrl: string, clientId: string, clientSecret: string) {
-  const res = await globalThis.fetch(tokenUrl, {
-    method: "POST",
-    headers: { "Content-Type": "application/x-www-form-urlencoded" },
-    body: new URLSearchParams({
-      grant_type: "client_credentials",
-      client_id: clientId,
-      client_secret: clientSecret,
-    }).toString(),
-    signal: AbortSignal.timeout(10_000),
-  });
-  if (!res.ok) throw new Error(`Admin token request failed: ${res.status}`);
-  const data = (await res.json()) as { access_token: string };
-  return data.access_token;
 }
 
 export async function POST(req: Request) {
@@ -35,11 +20,11 @@ export async function POST(req: Request) {
   }
 
   // issuer = https://auth.cloudless.gr/realms/master
-  const realmMatch = issuer.match(/^(https?:\/\/[^/]+)\/realms\/([^/]+)$/);
-  if (!realmMatch) {
+  const parsed = parseRealm(issuer);
+  if (!parsed) {
     return NextResponse.json({ error: "Registration not available" }, { status: 503 });
   }
-  const [, kcBase, realm] = realmMatch;
+  const { kcBase, realm } = parsed;
 
   let body: RegisterBody;
   try {
@@ -105,25 +90,13 @@ export async function POST(req: Request) {
       return NextResponse.json({ error: "Registration failed" }, { status: 400 });
     }
 
-    // Send verification email via the app client so the link returns to cloudless.gr
+    // Send verification email via the app client so the link returns to
+    // cloudless.gr. Best-effort: if SMTP is not yet configured the email
+    // silently fails; the VERIFY_EMAIL required action still blocks sign-in
+    // until the user verifies (recoverable via /api/auth/resend-verification).
     const userId = createRes.headers.get("Location")?.split("/").pop();
     if (userId) {
-      const appClientId = process.env.NEXT_PUBLIC_KEYCLOAK_CLIENT_ID ?? "cloudless-app";
-      const siteUrl = process.env.NEXT_PUBLIC_SITE_URL ?? "";
-      const params = new URLSearchParams({ client_id: appClientId });
-      if (siteUrl) params.set("redirect_uri", `${siteUrl}/api/auth/callback/keycloak`);
-      // Best-effort: if SMTP is not yet configured the email silently fails;
-      // the VERIFY_EMAIL required action still blocks sign-in until verified.
-      await globalThis
-        .fetch(
-          `${kcBase}/admin/realms/${realm}/users/${userId}/send-verify-email?${params.toString()}`,
-          {
-            method: "PUT",
-            headers: { Authorization: `Bearer ${adminToken}` },
-            signal: AbortSignal.timeout(8_000),
-          }
-        )
-        .catch(() => {});
+      await sendVerifyEmail(kcBase, realm, adminToken, userId).catch(() => {});
     }
 
     return NextResponse.json({ ok: true });

--- a/src/app/api/auth/resend-verification/route.ts
+++ b/src/app/api/auth/resend-verification/route.ts
@@ -1,0 +1,113 @@
+import { NextResponse } from "next/server";
+import { getConfig } from "@/lib/ssm-config";
+import { isValidEmail } from "@/lib/validation";
+import { rateLimit, getClientIp } from "@/lib/rate-limit";
+
+/**
+ * POST /api/auth/resend-verification
+ *
+ * Re-sends the Keycloak account-verification email for a not-yet-verified user.
+ * Without this, a user created by /api/auth/register who never received the
+ * first email (e.g. SMTP hiccup) is permanently stuck — the VERIFY_EMAIL
+ * required action blocks sign-in and there was no way to re-trigger the send.
+ *
+ * To avoid account enumeration this always responds { ok: true } regardless of
+ * whether the email maps to an existing/unverified user.
+ */
+interface ResendBody {
+  email: string;
+}
+
+const UNAVAILABLE = NextResponse.json({ error: "Not available" }, { status: 503 });
+
+async function getAdminToken(tokenUrl: string, clientId: string, clientSecret: string) {
+  const res = await globalThis.fetch(tokenUrl, {
+    method: "POST",
+    headers: { "Content-Type": "application/x-www-form-urlencoded" },
+    body: new URLSearchParams({
+      grant_type: "client_credentials",
+      client_id: clientId,
+      client_secret: clientSecret,
+    }).toString(),
+    signal: AbortSignal.timeout(10_000),
+  });
+  if (!res.ok) throw new Error(`Admin token request failed: ${res.status}`);
+  const data = (await res.json()) as { access_token: string };
+  return data.access_token;
+}
+
+/** Best-effort: find an unverified user by email and re-send the verify email. */
+async function resendForEmail(
+  kcBase: string,
+  realm: string,
+  adminToken: string,
+  email: string
+): Promise<void> {
+  const auth = { Authorization: `Bearer ${adminToken}` };
+  const searchRes = await globalThis.fetch(
+    `${kcBase}/admin/realms/${realm}/users?email=${encodeURIComponent(email)}&exact=true`,
+    { headers: auth, signal: AbortSignal.timeout(10_000) }
+  );
+  if (!searchRes.ok) return;
+
+  const users = (await searchRes.json()) as Array<{ id: string; emailVerified?: boolean }>;
+  const user = users[0];
+  // Only re-send when the account exists and is still unverified.
+  if (!user || user.emailVerified) return;
+
+  const appClientId = process.env.NEXT_PUBLIC_KEYCLOAK_CLIENT_ID ?? "cloudless-app";
+  const siteUrl = process.env.NEXT_PUBLIC_SITE_URL ?? "";
+  const params = new URLSearchParams({ client_id: appClientId });
+  if (siteUrl) params.set("redirect_uri", `${siteUrl}/api/auth/callback/keycloak`);
+
+  await globalThis
+    .fetch(
+      `${kcBase}/admin/realms/${realm}/users/${user.id}/send-verify-email?${params.toString()}`,
+      { method: "PUT", headers: auth, signal: AbortSignal.timeout(8_000) }
+    )
+    .catch(() => {});
+}
+
+export async function POST(req: Request) {
+  const rl = rateLimit(`resend-verify:${getClientIp(req)}`, 5, 10 * 60_000);
+  if (!rl.ok) return rl.response;
+
+  const issuer = process.env.KEYCLOAK_ISSUER;
+  if (!issuer) return UNAVAILABLE;
+  const realmMatch = issuer.match(/^(https?:\/\/[^/]+)\/realms\/([^/]+)$/);
+  if (!realmMatch) return UNAVAILABLE;
+  const [, kcBase, realm] = realmMatch;
+
+  let body: ResendBody;
+  try {
+    body = (await req.json()) as ResendBody;
+  } catch {
+    return NextResponse.json({ error: "Invalid request body" }, { status: 400 });
+  }
+  if (!isValidEmail(body.email)) {
+    return NextResponse.json({ error: "Invalid email address" }, { status: 400 });
+  }
+
+  const config = await getConfig();
+  if (!config.KEYCLOAK_ADMIN_CLIENT_ID || !config.KEYCLOAK_ADMIN_CLIENT_SECRET) {
+    return UNAVAILABLE;
+  }
+
+  try {
+    const adminToken = await getAdminToken(
+      `${issuer}/protocol/openid-connect/token`,
+      config.KEYCLOAK_ADMIN_CLIENT_ID,
+      config.KEYCLOAK_ADMIN_CLIENT_SECRET
+    );
+    await resendForEmail(kcBase, realm, adminToken, body.email);
+  } catch (err) {
+    // Log but still return ok — never reveal whether the address exists, and
+    // the caller can't act on an internal failure anyway.
+    console.error(
+      "[auth/resend-verification]",
+      err instanceof Error ? err.message : String(err)
+    );
+  }
+
+  return NextResponse.json({ ok: true });
+}

--- a/src/app/api/auth/resend-verification/route.ts
+++ b/src/app/api/auth/resend-verification/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from "next/server";
 import { getConfig } from "@/lib/ssm-config";
 import { isValidEmail } from "@/lib/validation";
 import { rateLimit, getClientIp } from "@/lib/rate-limit";
+import { getAdminToken, parseRealm, sendVerifyEmail } from "@/lib/keycloak-admin";
 
 /**
  * POST /api/auth/resend-verification
@@ -20,22 +21,6 @@ interface ResendBody {
 
 const UNAVAILABLE = NextResponse.json({ error: "Not available" }, { status: 503 });
 
-async function getAdminToken(tokenUrl: string, clientId: string, clientSecret: string) {
-  const res = await globalThis.fetch(tokenUrl, {
-    method: "POST",
-    headers: { "Content-Type": "application/x-www-form-urlencoded" },
-    body: new URLSearchParams({
-      grant_type: "client_credentials",
-      client_id: clientId,
-      client_secret: clientSecret,
-    }).toString(),
-    signal: AbortSignal.timeout(10_000),
-  });
-  if (!res.ok) throw new Error(`Admin token request failed: ${res.status}`);
-  const data = (await res.json()) as { access_token: string };
-  return data.access_token;
-}
-
 /** Best-effort: find an unverified user by email and re-send the verify email. */
 async function resendForEmail(
   kcBase: string,
@@ -43,10 +28,9 @@ async function resendForEmail(
   adminToken: string,
   email: string
 ): Promise<void> {
-  const auth = { Authorization: `Bearer ${adminToken}` };
   const searchRes = await globalThis.fetch(
     `${kcBase}/admin/realms/${realm}/users?email=${encodeURIComponent(email)}&exact=true`,
-    { headers: auth, signal: AbortSignal.timeout(10_000) }
+    { headers: { Authorization: `Bearer ${adminToken}` }, signal: AbortSignal.timeout(10_000) }
   );
   if (!searchRes.ok) return;
 
@@ -55,17 +39,7 @@ async function resendForEmail(
   // Only re-send when the account exists and is still unverified.
   if (!user || user.emailVerified) return;
 
-  const appClientId = process.env.NEXT_PUBLIC_KEYCLOAK_CLIENT_ID ?? "cloudless-app";
-  const siteUrl = process.env.NEXT_PUBLIC_SITE_URL ?? "";
-  const params = new URLSearchParams({ client_id: appClientId });
-  if (siteUrl) params.set("redirect_uri", `${siteUrl}/api/auth/callback/keycloak`);
-
-  await globalThis
-    .fetch(
-      `${kcBase}/admin/realms/${realm}/users/${user.id}/send-verify-email?${params.toString()}`,
-      { method: "PUT", headers: auth, signal: AbortSignal.timeout(8_000) }
-    )
-    .catch(() => {});
+  await sendVerifyEmail(kcBase, realm, adminToken, user.id).catch(() => {});
 }
 
 export async function POST(req: Request) {
@@ -74,9 +48,8 @@ export async function POST(req: Request) {
 
   const issuer = process.env.KEYCLOAK_ISSUER;
   if (!issuer) return UNAVAILABLE;
-  const realmMatch = issuer.match(/^(https?:\/\/[^/]+)\/realms\/([^/]+)$/);
-  if (!realmMatch) return UNAVAILABLE;
-  const [, kcBase, realm] = realmMatch;
+  const realm = parseRealm(issuer);
+  if (!realm) return UNAVAILABLE;
 
   let body: ResendBody;
   try {
@@ -99,7 +72,7 @@ export async function POST(req: Request) {
       config.KEYCLOAK_ADMIN_CLIENT_ID,
       config.KEYCLOAK_ADMIN_CLIENT_SECRET
     );
-    await resendForEmail(kcBase, realm, adminToken, body.email);
+    await resendForEmail(realm.kcBase, realm.realm, adminToken, body.email);
   } catch (err) {
     // Log but still return ok — never reveal whether the address exists, and
     // the caller can't act on an internal failure anyway.

--- a/src/lib/keycloak-admin.ts
+++ b/src/lib/keycloak-admin.ts
@@ -1,0 +1,66 @@
+/**
+ * Shared Keycloak Admin REST helpers used by the email-bound auth routes
+ * (register, resend-verification). Centralised so the client_credentials token
+ * exchange and the verify-email trigger live in one place (no duplication).
+ */
+
+/** Split a Keycloak issuer URL (`https://host/realms/<realm>`) into base + realm. */
+export function parseRealm(issuer: string): { kcBase: string; realm: string } | null {
+  const m = issuer.match(/^(https?:\/\/[^/]+)\/realms\/([^/]+)$/);
+  if (!m) return null;
+  return { kcBase: m[1], realm: m[2] };
+}
+
+/** Obtain an admin access token via the client_credentials grant. */
+export async function getAdminToken(
+  tokenUrl: string,
+  clientId: string,
+  clientSecret: string
+): Promise<string> {
+  const res = await globalThis.fetch(tokenUrl, {
+    method: "POST",
+    headers: { "Content-Type": "application/x-www-form-urlencoded" },
+    body: new URLSearchParams({
+      grant_type: "client_credentials",
+      client_id: clientId,
+      client_secret: clientSecret,
+    }).toString(),
+    signal: AbortSignal.timeout(10_000),
+  });
+  if (!res.ok) throw new Error(`Admin token request failed: ${res.status}`);
+  const data = (await res.json()) as { access_token: string };
+  return data.access_token;
+}
+
+/**
+ * Query string for send-verify-email: the verification link returns to the app
+ * (cloudless.gr) via the app client, not Keycloak's default account console.
+ */
+function verifyEmailParams(): string {
+  const appClientId = process.env.NEXT_PUBLIC_KEYCLOAK_CLIENT_ID ?? "cloudless-app";
+  const siteUrl = process.env.NEXT_PUBLIC_SITE_URL ?? "";
+  const params = new URLSearchParams({ client_id: appClientId });
+  if (siteUrl) params.set("redirect_uri", `${siteUrl}/api/auth/callback/keycloak`);
+  return params.toString();
+}
+
+/**
+ * Trigger Keycloak's verification email for a user. Callers decide how to treat
+ * failure (both current callers are best-effort and swallow errors, since the
+ * VERIFY_EMAIL required action still blocks sign-in until the user verifies).
+ */
+export async function sendVerifyEmail(
+  kcBase: string,
+  realm: string,
+  adminToken: string,
+  userId: string
+): Promise<void> {
+  await globalThis.fetch(
+    `${kcBase}/admin/realms/${realm}/users/${userId}/send-verify-email?${verifyEmailParams()}`,
+    {
+      method: "PUT",
+      headers: { Authorization: `Bearer ${adminToken}` },
+      signal: AbortSignal.timeout(8_000),
+    }
+  );
+}


### PR DESCRIPTION
Fixes finding **#1** from the user-flow report: a new user whose verification email never arrives is permanently stranded (the `VERIFY_EMAIL` required action blocks sign-in, with no resend path).

## What
- **`POST /api/auth/resend-verification`** — looks the user up by email via the Keycloak Admin API (`client_credentials`) and re-sends the verify email **only** when the account exists and is still unverified. Rate-limited (5 / 10 min) and **always responds `{ ok: true }`** to avoid account enumeration. Mirrors the existing `register` route's patterns.
- **Signup "check your email" screen** — adds a "Resend verification email" button (with resending/sent states).

## Tests
`__tests__/auth-resend-verification-api.test.ts` — 9 cases: config guards (issuer/realm/admin creds), email + JSON validation, send path, skip-when-verified, unknown-email (no enumeration), and no-leak on admin-token failure. **All pass.** `tsc`/`eslint` clean.

## Scope note
This is the **recovery path only**. Making the *first* email reliably send still depends on Keycloak SMTP (SES) being configured — separate infra, covered by the `ses-email-setup` runbook.

https://claude.ai/code/session_01SFLAFG395WWQcyj69toXbT

---
_Generated by [Claude Code](https://claude.ai/code/session_01SFLAFG395WWQcyj69toXbT)_