### PR TITLE
ops(cluster): add CSP + Traefik middleware probe to cluster-doctor

### DIFF
--- a/scripts/cluster-doctor.sh
+++ b/scripts/cluster-doctor.sh
@@ -277,6 +277,21 @@ else
   printf "  (GH_TOKEN not set — skipping runner check)\n"
 fi
 
+section "pi-origin.cloudless.gr — full response headers"
+printf "GET https://pi-origin.cloudless.gr/api/health (showing all response headers):\n"
+curl -sI --max-time 10 https://pi-origin.cloudless.gr/api/health 2>/dev/null | fence \
+  || printf "  (curl failed or timed out)\n"
+printf "content-security-policy specifically: "
+csp_val=$(curl -sI --max-time 10 https://pi-origin.cloudless.gr/api/health 2>/dev/null \
+  | grep -i '^content-security-policy:' | head -1)
+[ -n "$csp_val" ] && printf "**PRESENT** — %s\n" "$csp_val" || printf "**MISSING**\n"
+
+section "Traefik middlewares (all namespaces)"
+k get middlewares.traefik.io --all-namespaces -o yaml 2>/dev/null | fence
+
+section "Traefik IngressRoutes (namespace: ${CLOUDLESS_NS})"
+k -n "$CLOUDLESS_NS" get ingressroutes.traefik.io -o yaml 2>/dev/null | fence
+
 printf "\n_End of snapshot._\n"
 
-# re-trigger-doctor-20260602f-memquota
+# re-trigger-doctor-20260602g-csp-probe


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- Adds `curl -sI pi-origin.cloudless.gr/api/health` to cluster-doctor to dump all response headers and specifically check whether `Content-Security-Policy` is present or absent on the direct Pi/Traefik path
- Adds `kubectl get middlewares.traefik.io --all-namespaces` to reveal any Traefik middleware that may be stripping or overwriting the CSP header
- Adds `kubectl get ingressroutes.traefik.io -n cloudless` to show which middlewares are attached to the cloudless IngressRoute

## Why

The k3s standby E2E test `smoke.spec.ts` ("response signature is the cloudless.gr Next.js app") is failing because `isLikelyAppResponse()` returns `false` — meaning the `Content-Security-Policy` header is missing from `pi-origin.cloudless.gr` responses. The primary `cloudless.gr` path has CSP (security-headers.spec.ts passes), but the direct Pi path does not.

This diagnostic run will confirm whether Traefik is stripping/overwriting the CSP or whether `src/proxy.ts` isn't running as Next.js middleware on the Pi image.

## Test plan

- [ ] Trigger cluster-doctor workflow (auto-triggered by push to `scripts/cluster-doctor.sh`)
- [ ] Read results posted to issue #382
- [ ] Confirm CSP presence/absence and Traefik middleware config
- [ ] Apply actual fix in follow-up commit

https://claude.ai/code/session_013sTDMVEYibee8tbXxrwjzo
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_013sTDMVEYibee8tbXxrwjzo)_