### PR TITLE
fix(k3s): remove CSP from Traefik secure-headers to fix standby E2E smoke test

### DIFF
--- a/.github/workflows/fix-traefik-csp.yml
+++ b/.github/workflows/fix-traefik-csp.yml
@@ -1,0 +1,60 @@
+name: Fix Traefik CSP middleware (one-shot)
+
+# Removes Content-Security-Policy from the Traefik secure-headers middleware
+# in the cloudless namespace so the Next.js app's own full CSP passes through.
+#
+# Root cause: Traefik customResponseHeaders was overwriting the Next.js CSP
+# with a simplified version that lacked object-src 'none' and *.sentry.io,
+# causing the k3s standby E2E smoke test (isLikelyAppResponse) to fail.
+#
+# Triggered by merging this file. Re-runnable via workflow_dispatch.
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [main]
+    paths:
+      - ".github/workflows/fix-traefik-csp.yml"
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  fix:
+    name: Patch secure-headers middleware
+    runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ github.token }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v4.3.1
+
+      - name: Connect to tailnet
+        uses: tailscale/github-action@0263d9e6d793eaefcf1de98ff7fde47abe6664d3 # v3.2.4
+        with:
+          authkey: ${{ secrets.TS_AUTHKEY }}
+
+      - name: Configure kubectl
+        run: |
+          mkdir -p ~/.kube
+          echo "${{ secrets.KUBECONFIG_B64 }}" | base64 -d > ~/.kube/config
+          chmod 600 ~/.kube/config
+
+      - name: Patch Traefik middleware
+        run: bash scripts/fix-traefik-csp.sh 2>&1 | tee fix.log
+
+      - name: Post result to tracking issue
+        if: always()
+        run: |
+          STATUS="success"
+          grep -q "ERROR:" fix.log 2>/dev/null && STATUS="failure" || true
+          {
+            echo "# Traefik CSP fix — $(date -u '+%Y-%m-%d %H:%M:%SZ')"
+            echo ""
+            echo "**Status:** $STATUS"
+            echo ""
+            echo '```'
+            cat fix.log 2>/dev/null || echo '(no log)'
+            echo '```'
+          } > fix-comment.md
+          gh issue comment 382 --repo "${{ github.repository }}" --body-file fix-comment.md

--- a/scripts/cluster-doctor.sh
+++ b/scripts/cluster-doctor.sh
@@ -277,6 +277,21 @@ else
   printf "  (GH_TOKEN not set — skipping runner check)\n"
 fi
 
+section "pi-origin.cloudless.gr — full response headers"
+printf "GET https://pi-origin.cloudless.gr/api/health (showing all response headers):\n"
+curl -sI --max-time 10 https://pi-origin.cloudless.gr/api/health 2>/dev/null | fence \
+  || printf "  (curl failed or timed out)\n"
+printf "content-security-policy specifically: "
+csp_val=$(curl -sI --max-time 10 https://pi-origin.cloudless.gr/api/health 2>/dev/null \
+  | grep -i '^content-security-policy:' | head -1)
+[ -n "$csp_val" ] && printf "**PRESENT** — %s\n" "$csp_val" || printf "**MISSING**\n"
+
+section "Traefik middlewares (all namespaces)"
+k get middlewares.traefik.io --all-namespaces -o yaml 2>/dev/null | fence
+
+section "Traefik IngressRoutes (namespace: ${CLOUDLESS_NS})"
+k -n "$CLOUDLESS_NS" get ingressroutes.traefik.io -o yaml 2>/dev/null | fence
+
 printf "\n_End of snapshot._\n"
 
-# re-trigger-doctor-20260602f-memquota
+# re-trigger-doctor-20260602g-csp-probe

--- a/scripts/fix-traefik-csp.sh
+++ b/scripts/fix-traefik-csp.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# One-shot: remove Content-Security-Policy from the Traefik secure-headers
+# middleware in the cloudless namespace so the Next.js app's own full CSP
+# (with object-src 'none', connect-src *.sentry.io, and per-request nonces)
+# passes through to clients instead of being overwritten by the simplified
+# Traefik version.
+#
+# Root cause: Traefik customResponseHeaders overwrites backend response headers.
+# The simplified CSP in secure-headers was missing object-src and sentry.io,
+# causing isLikelyAppResponse() in e2e/k3s/_helpers.ts to return false and
+# failing the k3s standby smoke test.
+
+set -euo pipefail
+
+NS="${CLOUDLESS_NS:-cloudless}"
+MW="secure-headers"
+
+echo "[fix-traefik-csp] === fix-traefik-csp $(date -u '+%Y-%m-%d %H:%M:%SZ') ==="
+echo "[fix-traefik-csp] Namespace: $NS  Middleware: $MW"
+
+echo "[fix-traefik-csp] Current CSP in middleware:"
+kubectl -n "$NS" get middleware "$MW" \
+  -o jsonpath='{.spec.headers.customResponseHeaders.Content-Security-Policy}' 2>&1 || true
+echo ""
+
+echo "[fix-traefik-csp] Patching: removing Content-Security-Policy from customResponseHeaders..."
+kubectl -n "$NS" patch middleware "$MW" --type=json \
+  -p='[{"op":"remove","path":"/spec/headers/customResponseHeaders/Content-Security-Policy"}]' \
+  2>&1 || { echo "[fix-traefik-csp] ERROR: patch failed"; exit 1; }
+
+echo "[fix-traefik-csp] Patch applied. Verifying middleware spec:"
+kubectl -n "$NS" get middleware "$MW" -o yaml 2>&1 | grep -A20 "customResponseHeaders:" || true
+
+echo "[fix-traefik-csp] Probing pi-origin.cloudless.gr/api/health for updated CSP..."
+csp_val=$(curl -sI --max-time 15 https://pi-origin.cloudless.gr/api/health 2>/dev/null \
+  | grep -i '^content-security-policy:' | head -1 || true)
+if [ -n "$csp_val" ]; then
+  echo "[fix-traefik-csp] CSP header: $csp_val"
+  if echo "$csp_val" | grep -q "object-src 'none'"; then
+    echo "[fix-traefik-csp] PASS: object-src 'none' present — Next.js CSP is now served"
+  else
+    echo "[fix-traefik-csp] WARNING: object-src 'none' still missing — may need a pod restart"
+  fi
+else
+  echo "[fix-traefik-csp] (could not read CSP from pi-origin — check manually)"
+fi
+
+echo "[fix-traefik-csp] === DONE ==="


### PR DESCRIPTION
## Summary

- Traefik's `secure-headers` middleware in the `cloudless` namespace uses `customResponseHeaders` to set `Content-Security-Policy`, which **overwrites** the full CSP generated by Next.js `proxy.ts`
- The simplified Traefik CSP lacks `object-src 'none'` and `connect-src https://*.sentry.io`, causing `isLikelyAppResponse()` in `e2e/k3s/_helpers.ts` to return `false`
- This breaks the k3s standby E2E smoke test: `"response signature is the cloudless.gr Next.js app"`

**Root cause confirmed** from cluster-doctor output (issue #382, 17:59:10Z):
- `x-nonce` header present → Next.js `proxy.ts` IS running correctly
- CSP is the simplified Traefik version, not the full Next.js version with nonces

**Fix**: One-shot workflow `fix-traefik-csp.yml` that patches the Traefik middleware on merge:
```bash
kubectl -n cloudless patch middleware secure-headers --type=json \
  -p='[{"op":"remove","path":"/spec/headers/customResponseHeaders/Content-Security-Policy"}]'
```

After the patch, the Next.js app's own CSP passes through — including `object-src 'none'`, `connect-src ... https://*.sentry.io`, `frame-ancestors 'none'`, and per-request nonces — making `isLikelyAppResponse()` return `true`.

## Test plan

- [ ] Merge triggers `fix-traefik-csp.yml` workflow
- [ ] Workflow patches Traefik middleware and posts result to issue #382
- [ ] `curl -sI https://pi-origin.cloudless.gr/api/health | grep content-security-policy` shows `object-src 'none'` and `*.sentry.io`
- [ ] Re-run k3s-e2e workflow → smoke.spec.ts passes

https://claude.ai/code/session_013sTDMVEYibee8tbXxrwjzo

---
_Generated by [Claude Code](https://claude.ai/code/session_013sTDMVEYibee8tbXxrwjzo)_