### PR TITLE
ops(k3s): re-wire Pi Keycloak auth — restore AUTH_URL + AUTH_TRUST_HOST

### DIFF
--- a/.github/workflows/wire-pi-keycloak.yml
+++ b/.github/workflows/wire-pi-keycloak.yml
@@ -1,5 +1,5 @@
 name: Wire Pi Keycloak auth (k3s standby)
-# re-triggered 2026-06-02 — restore AUTH_TRUST_HOST=true in cloudless-app-auth secret
+# re-triggered 2026-06-02b — re-wire AUTH_URL + AUTH_TRUST_HOST (empty after keycloak ensure)
 
 # Gives the k3s `cloudless` app working next-auth/Keycloak by sourcing
 # AUTH_SECRET/KEYCLOAK_* from SSM (same as the Lambda), storing them in a k8s


### PR DESCRIPTION
Triggers `wire-pi-keycloak.yml` to re-populate `cloudless-app-auth` from SSM and restart the Pi cloudless deployment with the correct auth env vars.

**Problem:** cluster-doctor snapshot (17:59Z) shows `AUTH_URL=` and `AUTH_TRUST_HOST=` are empty in the cloudless deployment. Without these, next-auth on the Pi standby path returns `UntrustedHost` errors and Keycloak login fails.

**Fix:** re-run `wire-pi-keycloak` (path-triggered workflow) which pulls current SSM values (`/cloudless/production/*`), stores them in `cloudless-app-auth`, ensures `envFrom` on the deployment, and restarts. Posts result to issue #382.

https://claude.ai/code/session_013sTDMVEYibee8tbXxrwjzo

---
_Generated by [Claude Code](https://claude.ai/code/session_013sTDMVEYibee8tbXxrwjzo)_