### PR TITLE
style: fix prettier formatting breaking CI Lint &amp; Format on main

### DIFF
--- a/src/app/[locale]/store/[id]/page.tsx
+++ b/src/app/[locale]/store/[id]/page.tsx
@@ -64,10 +64,7 @@ export default async function ProductPage({
       <section className="bg-void-light border-neon-cyan/10 border-b">
         <div className="mx-auto max-w-6xl px-6 py-4">
           <nav className="flex items-center gap-2 font-mono text-sm text-slate-500">
-            <Link
-              href="/store"
-              className="hover:text-neon-cyan text-xs transition-colors"
-            >
+            <Link href="/store" className="hover:text-neon-cyan text-xs transition-colors">
               Store
             </Link>
             <span className="text-slate-700">/</span>

--- a/src/app/api/auth/resend-verification/route.ts
+++ b/src/app/api/auth/resend-verification/route.ts
@@ -76,10 +76,7 @@ export async function POST(req: Request) {
   } catch (err) {
     // Log but still return ok — never reveal whether the address exists, and
     // the caller can't act on an internal failure anyway.
-    console.error(
-      "[auth/resend-verification]",
-      err instanceof Error ? err.message : String(err)
-    );
+    console.error("[auth/resend-verification]", err instanceof Error ? err.message : String(err));
   }
 
   return NextResponse.json({ ok: true });


### PR DESCRIPTION
## Problem
Two files from the just-merged user-flow fixes (#535, #538) weren't prettier-formatted, so the CI **Lint & Format** (`format:check`) job is red on `main` (seen on CI #927). My pre-merge checks ran `eslint` but not `prettier --check` — that gap let these through.

## Fix
- `store/[id]/page.tsx`: collapse the now-short `<Link href="/store">` onto fewer lines (became short after the locale-prefix fix).
- `resend-verification/route.ts`: collapse the `console.error(...)` to one line.

Formatting-only; no behavior change.

## Verified
- `prettier --check "src/**/*.{ts,tsx,css,json}"` → **All matched files use Prettier code style!**
- `eslint` clean on both files.

https://claude.ai/code/session_01SFLAFG395WWQcyj69toXbT

---
_Generated by [Claude Code](https://claude.ai/code/session_01SFLAFG395WWQcyj69toXbT)_