### PR TITLE
fix(keycloak): fix finalize-admin websocket close 1006 + kick stalled crons

### DIFF
--- a/.github/workflows/cluster-doctor.yml
+++ b/.github/workflows/cluster-doctor.yml
@@ -1,5 +1,5 @@
 name: Cluster doctor (read-only diagnostics)
-# triggered 2026-06-02T07:28 — pi-origin CSP failure triage, React hydration check
+# triggered 2026-06-02T19:XX — post-restart AUTH_URL + Traefik CSP confirmation
 
 # Read-only visibility into the omv k3s cluster from CI. Runs scripts/cluster-
 # doctor.sh over Tailscale + KUBECONFIG_B64 and posts the snapshot as a comment

--- a/.github/workflows/keycloak-ensure.yml
+++ b/.github/workflows/keycloak-ensure.yml
@@ -1,4 +1,5 @@
 name: Keycloak ensure (self-heal auth to last working state)
+# re-triggered 2026-06-02 — kick stalled cron (no schedule run since 18:17Z)
 
 # Reconciles auth to its known-good state (Keycloak up + memory fit, realm flags,
 # cloudless-app groups mapper, admin group + membership). Runs on a schedule so a

--- a/.github/workflows/keycloak-finalize-admin.yml
+++ b/.github/workflows/keycloak-finalize-admin.yml
@@ -1,4 +1,5 @@
 name: keycloak-finalize-admin — set permanent admin password (no browser login needed)
+# re-triggered 2026-06-02b — fix websocket close 1006: replace -i heredoc with separate non-interactive exec calls
 
 # Sets a permanent admin password for tbaltzakis@cloudless.gr using the
 # Keycloak pod's own internal service admin credentials (never exposed, never

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,10 +6,11 @@ These require access outside GitHub and cannot be automated from a cloud session
 
 | Item | Status | Action |
 |------|--------|--------|
-| `OMV_SSH_KEY` | **SET** ✅ | Key for `tbaltzakis@omv` (host omv, user tbaltzakis). SSH workflows updated to `PI_USER: "tbaltzakis"`. k3s watchdog install pending (run `k3s-watchdog-deploy.yml`). |
-| SES SMTP | **IAM BLOCKED** | `GitHubActionsOIDC` role lacks `iam:CreateUser`. `grant-ses-iam-permissions.yml` tries `iam:PutRolePolicy` to self-grant. If that also fails: AWS Console → IAM → role `GitHubActionsOIDC` → add inline policy for `iam:CreateUser` scoped to `arn:aws:iam::278585680617:user/cloudless-ses-smtp`. Then touch `provision-ses-smtp.yml` to trigger. |
+| `OMV_SSH_KEY` | **SET** ✅ | Key for `tbaltzakis@omv` (host omv, user tbaltzakis). SSH workflows updated to `PI_USER: "tbaltzakis"`. k3s watchdog (`Restart=always`) deployed 2026-06-02T18:56Z — auto-restart active. |
+| SES SMTP | **IAM BLOCKED** | `GitHubActionsOIDC` role lacks `iam:CreateUser`. AWS Console → IAM → role `GitHubActionsOIDC` → add inline policy (exact JSON in issue #382 comment 2026-06-02T18:55Z). Then touch `provision-ses-smtp.yml` to trigger. |
 | ESP32 page content | **PARTIAL RESTORE** | Full content requires Notion UI: open page → ••• → Page history → restore pre-15:19 UTC 2026-06-02. ESP32 Devices + Telemetry databases (IDs confirmed correct, integration has access) are **empty** — no data was ever populated there to restore. |
-| Admin password | **ACTION REQUIRED** | Temp login posted to GitHub issue #382 (2026-06-02 17:18Z). Login at auth.cloudless.gr with `tbaltzakis@cloudless.gr` + temp password from #382. Keycloak forces password change on first login. |
+| Admin password | **PENDING VERIFICATION** | `keycloak-finalize-admin.yml` re-ran 2026-06-02T19:09Z with fixed exec pattern. Check issue #382 for new `PERM_LOGIN` credentials. Login at https://auth.cloudless.gr with `tbaltzakis@cloudless.gr` + password from latest finalize-admin comment. |
+| Cloudflare HA LB | **TOKEN NEEDED** | `setup-cloudflare-lb.yml` (merged PR #548) needs `CLOUDFLARE_API_TOKEN` — add as repo secret or SSM `/cloudless/production/CLOUDFLARE_API_TOKEN` with scopes: Zone:Read, Load Balancing Monitors/Pools+Load Balancers:Edit, DNS:Edit (zone cloudless.gr). Then `workflow_dispatch` or touch the workflow to apply. |
 
 ## Testing Policy
 

--- a/scripts/keycloak-finalize-admin.sh
+++ b/scripts/keycloak-finalize-admin.sh
@@ -13,6 +13,9 @@
 #
 # After this runs, the admin can log into auth.cloudless.gr immediately without
 # being forced to change the password.
+#
+# Fix vs v1: uses separate non-interactive kubectl exec calls (no -i + heredoc)
+# to avoid websocket close 1006 (abnormal closure) that killed v1.
 
 set -uo pipefail
 
@@ -21,57 +24,46 @@ DEPLOYMENT="${DEPLOYMENT:-keycloak}"
 REALM="${REALM:-master}"
 ADMIN_EMAIL="${ADMIN_EMAIL:-tbaltzakis@cloudless.gr}"
 ISSUE="${ISSUE:-382}"
+K=/opt/keycloak/bin/kcadm.sh
 
 command -v kubectl >/dev/null 2>&1 || { echo "error: kubectl not found"; exit 1; }
 POD=$(kubectl -n "$NAMESPACE" get pod -l app="$DEPLOYMENT" \
   -o jsonpath='{.items[0].metadata.name}' 2>/dev/null)
 [ -n "$POD" ] || { echo "error: no $DEPLOYMENT pod in ns/$NAMESPACE"; exit 1; }
+echo "POD=$POD"
 
-# Generate permanent password. Print it FIRST (same pattern as bootstrap-admin)
-# so it appears in the log captured by the workflow and posted to issue #382.
-# This is a private repo / private issue — acceptable security model.
+# Generate permanent password and print it first so it appears in the GitHub
+# Actions log (captured and posted to issue #382 by the workflow).
+# Private repo / private issue — acceptable security model.
 PERM_PASSWORD="Cld-$(head -c 16 /dev/urandom | base64 | tr -dc 'A-Za-z0-9' | head -c 14)-Zz9!"
 echo "PERM_LOGIN email=${ADMIN_EMAIL} password=${PERM_PASSWORD}"
-echo "pod=${POD} realm=${REALM}"
+echo "realm=${REALM}"
 
-kubectl -n "$NAMESPACE" exec -i "$POD" -- \
-  env NU="$ADMIN_EMAIL" NP="$PERM_PASSWORD" RL="$REALM" bash -s <<'EOS'
-set -u
-K=/opt/keycloak/bin/kcadm.sh
+# Step 1 — authenticate kcadm using the pod's own service-admin credentials.
+# No -i flag: non-interactive exec, no stdin, no websocket issue.
+kubectl -n "$NAMESPACE" exec "$POD" -- bash -c \
+  'AU="${KEYCLOAK_ADMIN:-${KC_BOOTSTRAP_ADMIN_USERNAME:-admin}}"; AP="${KEYCLOAK_ADMIN_PASSWORD:-${KC_BOOTSTRAP_ADMIN_PASSWORD:-}}"; '"$K"' config credentials --server http://localhost:8080 --realm master --user "$AU" --password "$AP" >/dev/null 2>&1 && echo "ADMIN_AUTH=ok" || { echo "ADMIN_AUTH=failed"; exit 1; }'
 
-# Authenticate using the pod's own internal admin (not the user's password)
-AU="${KEYCLOAK_ADMIN:-${KC_BOOTSTRAP_ADMIN_USERNAME:-admin}}"
-AP="${KEYCLOAK_ADMIN_PASSWORD:-${KC_BOOTSTRAP_ADMIN_PASSWORD:-}}"
-$K config credentials \
-  --server http://localhost:8080 \
-  --realm master \
-  --user "$AU" \
-  --password "$AP" >/dev/null 2>&1 || { echo "ADMIN_AUTH=failed"; exit 1; }
-echo "ADMIN_AUTH=ok"
-
-# Get user ID
-USERID=$(  $K get users -r "$RL" -q username="$NU" --format csv --noquotes 2>/dev/null \
-         | head -1 | cut -d, -f1)
-[ -n "$USERID" ] || { echo "USER_NOT_FOUND=$NU"; exit 1; }
+# Step 2 — look up the target user's ID.
+USERID=$(kubectl -n "$NAMESPACE" exec "$POD" -- \
+  "$K" get users -r "$REALM" -q "username=${ADMIN_EMAIL}" \
+  --format csv --noquotes 2>/dev/null \
+  | head -1 | cut -d, -f1)
+[ -n "$USERID" ] || { echo "USER_NOT_FOUND=${ADMIN_EMAIL}"; exit 1; }
 echo "USER_FOUND=$USERID"
 
-# Set PERMANENT password (--temporary=false → no forced change on login)
-$K set-password -r "$RL" --userid "$USERID" \
-  --new-password "$NP" --temporary=false >/dev/null 2>&1 \
-  && echo "PASSWORD=set_permanent" || echo "PASSWORD=failed"
+# Step 3 — set permanent password (--temporary=false → no forced change on login).
+kubectl -n "$NAMESPACE" exec "$POD" -- \
+  "$K" set-password -r "$REALM" --userid "$USERID" \
+  --new-password "$PERM_PASSWORD" --temporary=false \
+  && echo "PASSWORD=set_permanent" || { echo "PASSWORD=failed"; exit 1; }
 
-# Clear UPDATE_PASSWORD required action if present
-$K update "users/$USERID" -r "$RL" -s 'requiredActions=[]' >/dev/null 2>&1 \
+# Step 4 — clear UPDATE_PASSWORD required action.
+kubectl -n "$NAMESPACE" exec "$POD" -- \
+  "$K" update "users/$USERID" -r "$REALM" -s 'requiredActions=[]' \
   && echo "REQUIRED_ACTIONS=cleared" || echo "REQUIRED_ACTIONS=clear_failed"
-
-# Confirm user state
-$K get "users/$USERID" -r "$RL" --format csv --noquotes 2>/dev/null \
-  | head -1 | grep -oE 'emailVerified=\w+|enabled=\w+' || true
-
-echo "DONE"
-EOS
 
 echo ""
 echo "=== keycloak-finalize-admin complete ==="
 echo "PERMANENT_CREDENTIALS email=${ADMIN_EMAIL}"
-echo "(password masked — check issue #${ISSUE} for login details)"
+echo "(password logged above — check issue #${ISSUE} comment)"


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- **Fix `keycloak-finalize-admin.sh`**: replace `kubectl exec -i pod -- bash -s <<'EOS'` heredoc pattern with separate non-interactive `kubectl exec` calls. The old pattern caused websocket close 1006 (abnormal closure) which meant the password was generated and logged but never actually set in the pod.
- **Kick stalled crons**: bump trigger comments in `keycloak-ensure.yml` and `cluster-doctor.yml` — both crons stalled at 18:17Z UTC after the k3s restart disrupted scheduling; the path-push trigger fires them immediately on merge.
- **CLAUDE.md**: update k3s watchdog status (deployed), admin password status (pending verification), add Cloudflare LB token requirement.

## What each workflow does when this merges

| Workflow | Trigger | Expected output |
|----------|---------|-----------------|
| `keycloak-finalize-admin.yml` | path push (script changed) | Posts new `PERM_LOGIN` credentials to issue #382 |
| `keycloak-ensure.yml` | path push (comment bump) | Reconciles Keycloak auth; silent if already correct |
| `cluster-doctor.yml` | path push (comment bump) | Posts snapshot with `AUTH_URL=https://cloudless.gr` confirmation |

## Test plan

- [ ] Issue #382 receives a new `# Keycloak admin finalized` comment with `ADMIN_AUTH=ok`, `PASSWORD=set_permanent`, `REQUIRED_ACTIONS=cleared`
- [ ] Admin can log in at https://auth.cloudless.gr with `tbaltzakis@cloudless.gr` + new password (no forced change)
- [ ] Issue #382 receives cluster-doctor snapshot showing `AUTH_URL=https://cloudless.gr` in cloudless deployment env

https://claude.ai/code/session_013sTDMVEYibee8tbXxrwjzo
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_013sTDMVEYibee8tbXxrwjzo)_