### PR TITLE
fix: ses-smtp post-step reporting + cluster-doctor AUTH_URL check

### DIFF
--- a/.github/workflows/ses-smtp-from-secret.yml
+++ b/.github/workflows/ses-smtp-from-secret.yml
@@ -148,13 +148,18 @@ jobs:
       - name: Post result to tracking issue
         if: always()
         run: |
-          SKIPPED="${{ steps.ssm.outputs.skipped || 'false' }}"
+          SSM_CONCLUSION="${{ steps.ssm.conclusion }}"
+          SKIPPED_OUTPUT="${{ steps.ssm.outputs.skipped }}"
           JOB="${{ job.status }}"
           {
             echo "# SES SMTP → Keycloak email config — $(date -u '+%F %T')Z"
             echo ""
             echo "**Status:** $JOB"
-            if [ "$SKIPPED" = "true" ]; then
+            if [ "$SSM_CONCLUSION" = "skipped" ]; then
+              echo "**SSM write:** skipped (prerequisite step failed — secrets not configured)"
+              echo ""
+              echo "**Next step:** add \`SES_SMTP_USER\` and \`SES_SMTP_PASSWORD\` as GitHub Secrets, then re-trigger."
+            elif [ "$SKIPPED_OUTPUT" = "true" ]; then
               echo "**SSM write:** skipped (creds already present — use force=true to overwrite)"
             else
               echo "**SSM write:** done (user: ${SSM_USER:-<from secret>})"

--- a/.github/workflows/wire-pi-keycloak.yml
+++ b/.github/workflows/wire-pi-keycloak.yml
@@ -1,5 +1,5 @@
 name: Wire Pi Keycloak auth (k3s standby)
-# re-triggered 2026-06-02b — re-wire AUTH_URL + AUTH_TRUST_HOST (empty after keycloak ensure)
+# re-triggered 2026-06-02c — re-wire after confirming doctor reads from secret (not direct env)
 
 # Gives the k3s `cloudless` app working next-auth/Keycloak by sourcing
 # AUTH_SECRET/KEYCLOAK_* from SSM (same as the Lambda), storing them in a k8s

--- a/scripts/cluster-doctor.sh
+++ b/scripts/cluster-doctor.sh
@@ -108,9 +108,18 @@ printf "envFrom secrets: "
 kubectl -n "$CLOUDLESS_NS" get deploy cloudless \
   -o jsonpath='{range .spec.template.spec.containers[*]}{range .envFrom[*]}{.secretRef.name}{" "}{end}{end}' \
   2>/dev/null
-printf "\nAUTH_URL=%s  AUTH_TRUST_HOST=%s\n" \
-  "$(kubectl -n "$CLOUDLESS_NS" get deploy cloudless -o jsonpath='{.spec.template.spec.containers[0].env[?(@.name=="AUTH_URL")].value}' 2>/dev/null)" \
-  "$(kubectl -n "$CLOUDLESS_NS" get deploy cloudless -o jsonpath='{.spec.template.spec.containers[0].env[?(@.name=="AUTH_TRUST_HOST")].value}' 2>/dev/null)"
+# AUTH_URL/AUTH_TRUST_HOST live in the cloudless-app-auth envFrom secret, not
+# in the deployment's direct .env array — read from the secret as the source of truth.
+_auth_url="$(kubectl -n "$CLOUDLESS_NS" get secret cloudless-app-auth \
+  -o jsonpath='{.data.AUTH_URL}' 2>/dev/null | base64 -d 2>/dev/null || true)"
+_auth_trust="$(kubectl -n "$CLOUDLESS_NS" get secret cloudless-app-auth \
+  -o jsonpath='{.data.AUTH_TRUST_HOST}' 2>/dev/null | base64 -d 2>/dev/null || true)"
+# Fall back to direct env check (in case the secret approach fails)
+[ -z "$_auth_url" ] && _auth_url="$(kubectl -n "$CLOUDLESS_NS" get deploy cloudless \
+  -o jsonpath='{.spec.template.spec.containers[0].env[?(@.name=="AUTH_URL")].value}' 2>/dev/null)"
+[ -z "$_auth_trust" ] && _auth_trust="$(kubectl -n "$CLOUDLESS_NS" get deploy cloudless \
+  -o jsonpath='{.spec.template.spec.containers[0].env[?(@.name=="AUTH_TRUST_HOST")].value}' 2>/dev/null)"
+printf "\nAUTH_URL=%s  AUTH_TRUST_HOST=%s\n" "$_auth_url" "$_auth_trust"
 
 section "cloudless app: pods"
 k -n "$CLOUDLESS_NS" get pods -o wide | fence


### PR DESCRIPTION
## Summary

- **`ses-smtp-from-secret.yml`**: Fix misleading post-step reporting. When `SES_SMTP_USER`/`SES_SMTP_PASSWORD` GitHub Secrets are not set, the validate step fails and the SSM step is skipped entirely. The old `steps.ssm.outputs.skipped || 'false'` fallback evaluated to `false` when the step was skipped, incorrectly showing "SSM write: done". Now checks `steps.ssm.conclusion == 'skipped'` and shows a clear "prerequisite step failed — secrets not configured" message with next steps.

- **`scripts/cluster-doctor.sh`**: Fix `AUTH_URL`/`AUTH_TRUST_HOST` monitoring. These env vars are stored in the `cloudless-app-auth` Secret via `envFrom`, not as direct env entries on the deployment spec. The old `kubectl get deploy` jsonpath always returned empty for `envFrom`-sourced vars, making them appear unwired even when correctly set. Now reads from the secret directly with a fallback to the direct env check.

- **`wire-pi-keycloak.yml`**: Bump trigger comment to re-run the wire (confirming secret has the correct values after the doctor fix).

## Test plan

- [ ] Verify next cluster-doctor snapshot shows `AUTH_URL=https://cloudless.gr  AUTH_TRUST_HOST=true`
- [ ] Verify ses-smtp-from-secret workflow shows "prerequisite step failed" when secrets are missing

https://claude.ai/code/session_013sTDMVEYibee8tbXxrwjzo

---
_Generated by [Claude Code](https://claude.ai/code/session_013sTDMVEYibee8tbXxrwjzo)_