### PR TITLE
fix(keycloak): grant realm-admin role so admin can access Keycloak console

### DIFF
--- a/.github/workflows/keycloak-finalize-admin.yml
+++ b/.github/workflows/keycloak-finalize-admin.yml
@@ -1,5 +1,5 @@
 name: keycloak-finalize-admin — set permanent admin password (no browser login needed)
-# re-triggered 2026-06-02b — fix websocket close 1006: replace -i heredoc with separate non-interactive exec calls
+# re-triggered 2026-06-02c — add realm-admin role grant so user can access Keycloak Admin Console
 
 # Sets a permanent admin password for tbaltzakis@cloudless.gr using the
 # Keycloak pod's own internal service admin credentials (never exposed, never

--- a/.github/workflows/ses-smtp-from-secret.yml
+++ b/.github/workflows/ses-smtp-from-secret.yml
@@ -148,13 +148,18 @@ jobs:
       - name: Post result to tracking issue
         if: always()
         run: |
-          SKIPPED="${{ steps.ssm.outputs.skipped || 'false' }}"
+          SSM_CONCLUSION="${{ steps.ssm.conclusion }}"
+          SKIPPED_OUTPUT="${{ steps.ssm.outputs.skipped }}"
           JOB="${{ job.status }}"
           {
             echo "# SES SMTP → Keycloak email config — $(date -u '+%F %T')Z"
             echo ""
             echo "**Status:** $JOB"
-            if [ "$SKIPPED" = "true" ]; then
+            if [ "$SSM_CONCLUSION" = "skipped" ]; then
+              echo "**SSM write:** skipped (prerequisite step failed — secrets not configured)"
+              echo ""
+              echo "**Next step:** add \`SES_SMTP_USER\` and \`SES_SMTP_PASSWORD\` as GitHub Secrets, then re-trigger."
+            elif [ "$SKIPPED_OUTPUT" = "true" ]; then
               echo "**SSM write:** skipped (creds already present — use force=true to overwrite)"
             else
               echo "**SSM write:** done (user: ${SSM_USER:-<from secret>})"

--- a/.github/workflows/wire-pi-keycloak.yml
+++ b/.github/workflows/wire-pi-keycloak.yml
@@ -1,5 +1,5 @@
 name: Wire Pi Keycloak auth (k3s standby)
-# re-triggered 2026-06-02b — re-wire AUTH_URL + AUTH_TRUST_HOST (empty after keycloak ensure)
+# re-triggered 2026-06-02c — re-wire after confirming doctor reads from secret (not direct env)
 
 # Gives the k3s `cloudless` app working next-auth/Keycloak by sourcing
 # AUTH_SECRET/KEYCLOAK_* from SSM (same as the Lambda), storing them in a k8s

--- a/scripts/cluster-doctor.sh
+++ b/scripts/cluster-doctor.sh
@@ -108,9 +108,18 @@ printf "envFrom secrets: "
 kubectl -n "$CLOUDLESS_NS" get deploy cloudless \
   -o jsonpath='{range .spec.template.spec.containers[*]}{range .envFrom[*]}{.secretRef.name}{" "}{end}{end}' \
   2>/dev/null
-printf "\nAUTH_URL=%s  AUTH_TRUST_HOST=%s\n" \
-  "$(kubectl -n "$CLOUDLESS_NS" get deploy cloudless -o jsonpath='{.spec.template.spec.containers[0].env[?(@.name=="AUTH_URL")].value}' 2>/dev/null)" \
-  "$(kubectl -n "$CLOUDLESS_NS" get deploy cloudless -o jsonpath='{.spec.template.spec.containers[0].env[?(@.name=="AUTH_TRUST_HOST")].value}' 2>/dev/null)"
+# AUTH_URL/AUTH_TRUST_HOST live in the cloudless-app-auth envFrom secret, not
+# in the deployment's direct .env array — read from the secret as the source of truth.
+_auth_url="$(kubectl -n "$CLOUDLESS_NS" get secret cloudless-app-auth \
+  -o jsonpath='{.data.AUTH_URL}' 2>/dev/null | base64 -d 2>/dev/null || true)"
+_auth_trust="$(kubectl -n "$CLOUDLESS_NS" get secret cloudless-app-auth \
+  -o jsonpath='{.data.AUTH_TRUST_HOST}' 2>/dev/null | base64 -d 2>/dev/null || true)"
+# Fall back to direct env check (in case the secret approach fails)
+[ -z "$_auth_url" ] && _auth_url="$(kubectl -n "$CLOUDLESS_NS" get deploy cloudless \
+  -o jsonpath='{.spec.template.spec.containers[0].env[?(@.name=="AUTH_URL")].value}' 2>/dev/null)"
+[ -z "$_auth_trust" ] && _auth_trust="$(kubectl -n "$CLOUDLESS_NS" get deploy cloudless \
+  -o jsonpath='{.spec.template.spec.containers[0].env[?(@.name=="AUTH_TRUST_HOST")].value}' 2>/dev/null)"
+printf "\nAUTH_URL=%s  AUTH_TRUST_HOST=%s\n" "$_auth_url" "$_auth_trust"
 
 section "cloudless app: pods"
 k -n "$CLOUDLESS_NS" get pods -o wide | fence

--- a/scripts/keycloak-finalize-admin.sh
+++ b/scripts/keycloak-finalize-admin.sh
@@ -63,6 +63,13 @@ kubectl -n "$NAMESPACE" exec "$POD" -- \
   "$K" update "users/$USERID" -r "$REALM" -s 'requiredActions=[]' \
   && echo "REQUIRED_ACTIONS=cleared" || echo "REQUIRED_ACTIONS=clear_failed"
 
+# Step 5 — grant realm-admin role so the user can access the Keycloak Admin Console.
+# Without this the user sees "You do not have permission" at auth.cloudless.gr/admin.
+kubectl -n "$NAMESPACE" exec "$POD" -- \
+  "$K" add-roles -r "$REALM" --uusername "$ADMIN_EMAIL" \
+  --cclientid realm-management --rolename realm-admin 2>/dev/null \
+  && echo "REALM_ADMIN=granted" || echo "REALM_ADMIN=grant_failed_or_already_set"
+
 echo ""
 echo "=== keycloak-finalize-admin complete ==="
 echo "PERMANENT_CREDENTIALS email=${ADMIN_EMAIL}"


### PR DESCRIPTION
## Problem

`tbaltzakis@cloudless.gr` logs into `auth.cloudless.gr` successfully but the Keycloak Admin Console shows **"You do not have permission. Please contact your administrator."**

Root cause: `keycloak-finalize-admin.sh` set the permanent password and cleared `UPDATE_PASSWORD`, but never granted the `realm-management:realm-admin` client role. Without that role, Keycloak blocks admin console access even for a valid user.

## Fix

Add step 5 to `keycloak-finalize-admin.sh`:
```bash
kcadm add-roles -r master --uusername tbaltzakis@cloudless.gr \
  --cclientid realm-management --rolename realm-admin
```

Bump workflow trigger comment → re-runs automatically on merge.

## After this lands

The `keycloak-finalize-admin.yml` workflow re-runs, sets `REALM_ADMIN=granted`, and posts the result to issue #382. Reload `auth.cloudless.gr/admin` — full Keycloak admin console access should work immediately (no re-login needed if already authenticated, or log out and back in).

https://claude.ai/code/session_013sTDMVEYibee8tbXxrwjzo

---
_Generated by [Claude Code](https://claude.ai/code/session_013sTDMVEYibee8tbXxrwjzo)_