### PR TITLE
fix(keycloak): robust finalize-admin + realm-admin in ensure cron

### DIFF
--- a/.github/workflows/keycloak-finalize-admin.yml
+++ b/.github/workflows/keycloak-finalize-admin.yml
@@ -1,5 +1,5 @@
 name: keycloak-finalize-admin — set permanent admin password (no browser login needed)
-# re-triggered 2026-06-02c — add realm-admin role grant so user can access Keycloak Admin Console
+# re-triggered 2026-06-02d — fix pipe-masks-exit-code, add pod-lookup retry, re-run after apiserver recovery
 
 # Sets a permanent admin password for tbaltzakis@cloudless.gr using the
 # Keycloak pod's own internal service admin credentials (never exposed, never
@@ -49,7 +49,10 @@ jobs:
           chmod 600 ~/.kube/config
 
       - name: Finalize admin account (permanent password, clear UPDATE_PASSWORD)
-        run: bash scripts/keycloak-finalize-admin.sh 2>&1 | tee finalize.log
+        shell: bash
+        run: |
+          set -o pipefail
+          bash scripts/keycloak-finalize-admin.sh 2>&1 | tee finalize.log
 
       - name: Post new credentials to tracking issue
         if: always()

--- a/scripts/keycloak-ensure.sh
+++ b/scripts/keycloak-ensure.sh
@@ -141,6 +141,11 @@ if [ -n "$USERID" ] && ! csv "groups/$GID/members" -r "$RL" --fields id | grep -
   $K update "users/$USERID/groups/$GID" -r "$RL" -s realm="$RL" -s userId="$USERID" -s groupId="$GID" -n >/dev/null 2>&1 \
     && echo "FIX admin membership: added $NU"
 fi
+
+# realm-admin client role — required to access Keycloak Admin Console at auth.cloudless.gr/admin
+# kcadm add-roles is idempotent: if the role is already granted it does nothing (exits 0).
+$K add-roles -r "$RL" --uusername "$NU" --cclientid realm-management --rolename realm-admin >/dev/null 2>&1 \
+  || echo "WARN realm-admin grant returned non-zero (role may already be granted or user missing)"
 echo "RECON_OK"
 EOS
 )

--- a/scripts/keycloak-finalize-admin.sh
+++ b/scripts/keycloak-finalize-admin.sh
@@ -27,9 +27,19 @@ ISSUE="${ISSUE:-382}"
 K=/opt/keycloak/bin/kcadm.sh
 
 command -v kubectl >/dev/null 2>&1 || { echo "error: kubectl not found"; exit 1; }
-POD=$(kubectl -n "$NAMESPACE" get pod -l app="$DEPLOYMENT" \
-  -o jsonpath='{.items[0].metadata.name}' 2>/dev/null)
-[ -n "$POD" ] || { echo "error: no $DEPLOYMENT pod in ns/$NAMESPACE"; exit 1; }
+
+# Retry pod lookup up to 5×10s in case the apiserver is briefly unavailable.
+POD=""
+for _i in 1 2 3 4 5; do
+  POD=$(kubectl -n "$NAMESPACE" get pod -l app="$DEPLOYMENT" \
+    -o jsonpath='{.items[0].metadata.name}' 2>&1)
+  # success if POD looks like a pod name (not an error message)
+  printf '%s' "$POD" | grep -qvE '^(error|Error|connection|the server)' && [ -n "$POD" ] && break
+  echo "pod lookup attempt $_i failed: $POD — retrying in 10s..."
+  POD=""
+  sleep 10
+done
+[ -n "$POD" ] || { echo "error: no $DEPLOYMENT pod in ns/$NAMESPACE after 5 attempts"; exit 1; }
 echo "POD=$POD"
 
 # Generate permanent password and print it first so it appears in the GitHub


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- **`keycloak-finalize-admin.sh`**: replace silent `2>/dev/null` pod lookup with a 5×10s retry loop that prints errors. Previous run failed silently with `error: no keycloak pod in ns/keycloak` because the apiserver was briefly unavailable post-rollout — no output appeared in the issue comment.
- **`keycloak-finalize-admin.yml`**: add `set -o pipefail` to the run shell so `bash script | tee` properly propagates the script's exit code. Previously, `tee` exiting 0 masked script failures, making the step appear green.
- **`keycloak-ensure.sh`**: add `realm-management:realm-admin` client role grant to Phase 2 reconcile. The 15-min cron now idempotently ensures the admin user always has Keycloak Admin Console access. `kcadm add-roles` is a no-op if the role is already granted.

## Test plan

- [ ] `keycloak-finalize-admin.yml` re-triggers on merge, retries pod lookup, sets permanent password, grants realm-admin, posts `REALM_ADMIN=granted` to issue #382
- [ ] Next `keycloak-ensure` cron run shows no error for realm-admin grant
- [ ] `auth.cloudless.gr/admin` loads the Admin Console without "You do not have permission"

https://claude.ai/code/session_013sTDMVEYibee8tbXxrwjzo
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_013sTDMVEYibee8tbXxrwjzo)_