### PR TITLE
docs(ha): report mode prints the Actions-UI apply steps

### DIFF
--- a/scripts/setup-cloudflare-lb.sh
+++ b/scripts/setup-cloudflare-lb.sh
@@ -237,5 +237,8 @@ if [ "$APPLY" = "1" ]; then
   log "   Verify: curl -sI https://${DOMAIN}/api/health  (200), then watch a"
   log "   forced-AWS-5xx flip to the Pi standby in the LB Analytics tab."
 else
-  log "== REPORT ONLY — nothing changed. Re-run with MODE=apply CONFIRM=1 to apply."
+  log "== REPORT ONLY — nothing changed."
+  log "   To apply the plan above (creates the LB + cuts apex/www DNS over):"
+  log "   GitHub -> Actions -> 'Cloudflare HA load balancer' -> Run workflow"
+  log "   -> set apply = true. Result + verification are posted back to #382."
 fi


### PR DESCRIPTION
Small follow-up to #548/#549. `workflow_dispatch` isn't available from the automation token (403), so the **apply** (production DNS cutover) is launched from the GitHub Actions UI. This makes the report-only footer spell out those exact steps, so the issue-#382 comment is self-contained on mobile. The push also re-runs the dry run to re-check token/entitlement state.

https://claude.ai/code/session_016PrzZJMNxsgiEmvedfkru6

---
_Generated by [Claude Code](https://claude.ai/code/session_016PrzZJMNxsgiEmvedfkru6)_