### PR TITLE
feat(keycloak): in-cluster auto-heal for OOM/CrashLoop

### DIFF
--- a/.github/workflows/keycloak-autoheal-deploy.yml
+++ b/.github/workflows/keycloak-autoheal-deploy.yml
@@ -1,0 +1,113 @@
+name: Keycloak autoheal — deploy in-cluster self-healer
+
+# Installs the in-cluster Keycloak self-healer (k8s/cluster-protection/
+# keycloak-autoheal.yaml) AND remediates the current state in one shot:
+#   1. apply the 768Mi source-of-truth manifest (immediate OOM fix + rollout)
+#   2. apply the autoheal CronJob + RBAC (prevents recurrence, runs every 5m
+#      on the cluster's own scheduler — no GitHub-cron / tailnet dependency)
+#   3. kick the healer once immediately
+#   4. report keycloak pod state + auth.cloudless.gr discovery to issue #382
+#
+# Idempotent — safe to re-run. Triggered on push to its own files, or manually.
+#
+# Auth: Tailscale (TS_AUTHKEY) + KUBECONFIG_B64 (system:admin), same as the
+# other cluster-ops workflows.
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [main]
+    paths:
+      - ".github/workflows/keycloak-autoheal-deploy.yml"
+      - "k8s/cluster-protection/keycloak-autoheal.yaml"
+
+permissions:
+  contents: read
+  issues: write
+
+concurrency:
+  group: keycloak-autoheal-deploy
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ github.token }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v4.3.1
+
+      - name: Connect to tailnet
+        uses: tailscale/github-action@0263d9e6d793eaefcf1de98ff7fde47abe6664d3 # v3.2.4
+        with:
+          authkey: ${{ secrets.TS_AUTHKEY }}
+
+      - name: Configure kubectl
+        run: |
+          mkdir -p ~/.kube
+          echo "${{ secrets.KUBECONFIG_B64 }}" | base64 -d > ~/.kube/config
+          chmod 600 ~/.kube/config
+
+      - name: 1. Immediate fix — apply 768Mi source-of-truth manifest
+        run: |
+          set -uo pipefail
+          echo "=== keycloak deploy BEFORE ===" | tee heal.log
+          kubectl -n keycloak get deploy keycloak \
+            -o jsonpath='{.spec.template.spec.containers[0].resources}' 2>&1 | tee -a heal.log; echo | tee -a heal.log
+          echo "" | tee -a heal.log
+          echo "== apply memory-relief (768Mi + -Xmx512m) ==" | tee -a heal.log
+          kubectl apply -f k8s/cluster-protection/memory-relief-2026-05-31.yaml 2>&1 | tee -a heal.log || true
+
+      - name: 2. Install in-cluster self-healer (CronJob + RBAC)
+        run: |
+          set -uo pipefail
+          echo "" | tee -a heal.log
+          echo "== apply keycloak-autoheal ==" | tee -a heal.log
+          kubectl apply -f k8s/cluster-protection/keycloak-autoheal.yaml 2>&1 | tee -a heal.log || true
+
+      - name: 3. Run the healer once now
+        run: |
+          set -uo pipefail
+          JOB="kc-heal-init-$(date +%s)"
+          echo "" | tee -a heal.log
+          echo "== kick $JOB from cronjob/keycloak-autoheal ==" | tee -a heal.log
+          kubectl -n keycloak create job --from=cronjob/keycloak-autoheal "$JOB" 2>&1 | tee -a heal.log || true
+          kubectl -n keycloak wait --for=condition=complete "job/$JOB" --timeout=150s 2>&1 | tee -a heal.log || true
+          echo "" | tee -a heal.log
+          echo "== healer logs ==" | tee -a heal.log
+          kubectl -n keycloak logs "job/$JOB" --tail=40 2>&1 | tee -a heal.log || true
+
+      - name: 4. Verify keycloak recovered
+        run: |
+          set -uo pipefail
+          echo "" | tee -a heal.log
+          echo "== rollout status (3m) ==" | tee -a heal.log
+          kubectl -n keycloak rollout status deploy/keycloak --timeout=180s 2>&1 | tee -a heal.log || true
+          echo "" | tee -a heal.log
+          echo "=== keycloak deploy AFTER ===" | tee -a heal.log
+          kubectl -n keycloak get deploy keycloak \
+            -o jsonpath='{.spec.template.spec.containers[0].resources}' 2>&1 | tee -a heal.log; echo | tee -a heal.log
+          echo "" | tee -a heal.log
+          echo "=== pods ===" | tee -a heal.log
+          kubectl -n keycloak get pods -l app=keycloak -o wide 2>&1 | tee -a heal.log || true
+          echo "" | tee -a heal.log
+          echo "=== cronjob ===" | tee -a heal.log
+          kubectl -n keycloak get cronjob keycloak-autoheal 2>&1 | tee -a heal.log || true
+          echo "" | tee -a heal.log
+          DISC=$(curl -s -o /dev/null -w '%{http_code}' --max-time 15 \
+            https://auth.cloudless.gr/realms/master/.well-known/openid-configuration || echo "000")
+          echo "auth.cloudless.gr discovery: HTTP ${DISC} (200 = up)" | tee -a heal.log
+
+      - name: Post result to tracking issue
+        if: always()
+        run: |
+          {
+            echo "# Keycloak autoheal deploy — $(date -u '+%F %T')Z"
+            echo ""
+            echo "**Job:** ${{ job.status }}"
+            echo ""
+            echo '```'
+            cat heal.log 2>/dev/null || echo '(no log)'
+            echo '```'
+          } > c.md
+          gh issue comment 382 --repo "${{ github.repository }}" --body-file c.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -137,12 +137,19 @@ instead — see the **`cluster-incident-response`** skill for the full playbook.
     admin, and posts the temp login to #382; the human logs in once and Keycloak
     forces `UPDATE_PASSWORD`. (A temporary password fails a direct-grant check —
     that's expected; no `LOGIN_VERIFIED`.) **Never commit a password to git.**
-- **Self-heal:** `pnpm keycloak:ensure` (`keycloak-ensure.yml`, **cron `*/15`**)
-  reconciles auth to the last-working state — OOM-recovers Keycloak (768Mi /
-  `-Xmx512m`), fixes realm flags + the `cloudless-app` groups mapper + admin
-  group/membership, **and restores the Pi `cloudless` app's auth wiring** (the
-  `cloudless-app-auth` secret + `envFrom`) if it stops serving the keycloak
-  provider; posts to #382 only when it corrects drift or auth is broken.
+- **Self-heal (GitHub layer):** `pnpm keycloak:ensure` (`keycloak-ensure.yml`,
+  **cron `*/15`**) reconciles auth to the last-working state — OOM-recovers
+  Keycloak (768Mi / `-Xmx512m`), fixes realm flags + the `cloudless-app` groups
+  mapper + admin group/membership, **and restores the Pi `cloudless` app's auth
+  wiring** (the `cloudless-app-auth` secret + `envFrom`) if it stops serving the
+  keycloak provider; posts to #382 only when it corrects drift or auth is broken.
+- **Self-heal (in-cluster layer):** `k8s/cluster-protection/keycloak-autoheal.yaml`
+  — a CronJob (`*/5`) + least-privilege RBAC in ns `keycloak` that runs the OOM
+  reconcile on the **cluster's own scheduler**, so it heals even when GitHub's
+  cron/CI or the tailnet is down (the gap that let the `*/15` cron stall). It
+  re-sizes the deploy to 768Mi + `-Xmx512m`, lifts the LimitRange ceiling, and
+  deletes OOM-stuck pods (only when the spec is already correct, so it never
+  masks a non-memory crash). Deploy/remediate with `keycloak-autoheal-deploy.yml`.
 - **Pi/k3s app auth (HA standby):** the `cloudless` deployment needs runtime env
   `AUTH_SECRET` + `KEYCLOAK_ISSUER`(**realm `master`**, not the stale SSM value
   `cloudless`) + `KEYCLOAK_CLIENT_ID`/`KEYCLOAK_CLIENT_SECRET` + **`AUTH_TRUST_HOST=true`**

--- a/k8s/cluster-protection/keycloak-autoheal.yaml
+++ b/k8s/cluster-protection/keycloak-autoheal.yaml
@@ -1,0 +1,183 @@
+# Keycloak self-healer — in-cluster auto-fix for the OOM/CrashLoop failure mode.
+#
+# WHY THIS EXISTS
+#   The durable fix for Keycloak's OOMKill (size the container to its -Xmx512m
+#   heap → 768Mi limit) already lives in memory-relief-2026-05-31.yaml, and a
+#   GitHub-side self-heal exists (keycloak-ensure.yml, cron */15). But that cron
+#   runs on GitHub's scheduler, which silently stalls/disables on low-activity
+#   repos and needs Tailscale + a CI runner to be up — exactly what may be flaky
+#   during a cluster incident. This CronJob runs the same reconcile ON THE
+#   CLUSTER ITSELF (k3s scheduler, in-cluster API access), so Keycloak heals
+#   autonomously with no dependency on GitHub, CI, or the tailnet.
+#
+# WHAT IT DOES (every 5 min, idempotent, least-privilege to ns/keycloak)
+#   1. Ensure the namespace LimitRange ceiling is ≥ 1Gi (so the deploy may
+#      request a 768Mi limit).
+#   2. If the keycloak Deployment's container memory limit ≠ 768Mi, patch it to
+#      768Mi + set the operative heap var JAVA_OPTS_APPEND=-Xmx512m. The
+#      Deployment controller then rolls a corrected ReplicaSet.
+#   3. Only when the spec is ALREADY correct, delete any keycloak pod stuck from
+#      a prior OOMKill so it restarts clean (never touches a pod crashing for a
+#      non-memory reason — we don't mask real bugs).
+#
+# VERIFY
+#   kubectl -n keycloak get cronjob keycloak-autoheal
+#   kubectl -n keycloak logs -l app=keycloak-autoheal --tail=40
+# TRIGGER ONCE
+#   kubectl -n keycloak create job --from=cronjob/keycloak-autoheal kc-heal-$(date +%s)
+#
+# Applied by .github/workflows/keycloak-autoheal-deploy.yml.
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: keycloak-autoheal
+  namespace: keycloak
+  labels:
+    app: keycloak-autoheal
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: keycloak-autoheal
+  namespace: keycloak
+  labels:
+    app: keycloak-autoheal
+rules:
+  # Read + patch the keycloak Deployment (memory limit + heap env).
+  - apiGroups: ["apps"]
+    resources: ["deployments"]
+    verbs: ["get", "list", "patch"]
+  # Read pods + delete OOM-stuck ones to force a clean restart.
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["get", "list", "delete"]
+  # Keep the namespace LimitRange ceiling high enough for the 768Mi limit.
+  - apiGroups: [""]
+    resources: ["limitranges"]
+    verbs: ["get", "list", "patch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: keycloak-autoheal
+  namespace: keycloak
+  labels:
+    app: keycloak-autoheal
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: keycloak-autoheal
+subjects:
+  - kind: ServiceAccount
+    name: keycloak-autoheal
+    namespace: keycloak
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: keycloak-autoheal
+  namespace: keycloak
+  labels:
+    app: keycloak-autoheal
+spec:
+  schedule: "*/5 * * * *"
+  startingDeadlineSeconds: 120
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 2
+  failedJobsHistoryLimit: 3
+  jobTemplate:
+    spec:
+      activeDeadlineSeconds: 120
+      backoffLimit: 1
+      template:
+        metadata:
+          labels:
+            app: keycloak-autoheal
+        spec:
+          serviceAccountName: keycloak-autoheal
+          restartPolicy: Never
+          # Tolerate the control-plane node taint if present — the healer must
+          # be schedulable even when the cluster is under pressure.
+          tolerations:
+            - operator: Exists
+          securityContext:
+            runAsNonRoot: true
+            seccompProfile:
+              type: RuntimeDefault
+          containers:
+            - name: heal
+              # Multi-arch (arm64) kubectl image with a shell. In-cluster config
+              # is auto-detected from the mounted ServiceAccount token — no
+              # kubeconfig needed. If this tag ever fails to pull, swap for
+              # rancher/kubectl:v1.31.4 (also multi-arch).
+              image: bitnami/kubectl:1.31
+              imagePullPolicy: IfNotPresent
+              env:
+                # kubectl writes its discovery cache under $HOME/.kube — point it
+                # at the writable emptyDir so readOnlyRootFilesystem holds.
+                - name: HOME
+                  value: /tmp
+              command: ["bash", "-c"]
+              args:
+                - |
+                  set -uo pipefail
+                  NS=keycloak DEP=keycloak WANT=768Mi
+                  HEAP='-Xms128m -Xmx512m -Djdk.reflect.useDirectMethodHandle=false -Dquarkus.http.limits.max-header-size=64K'
+                  log(){ echo "[autoheal $(date -u +%H:%M:%S)] $*"; }
+
+                  # 1) LimitRange ceiling ≥ 1Gi
+                  if kubectl -n "$NS" patch limitrange default-container-limits --type=merge -p \
+                       '{"spec":{"limits":[{"type":"Container","max":{"memory":"1Gi","cpu":"2"},"default":{"memory":"512Mi","cpu":"1"},"defaultRequest":{"memory":"128Mi","cpu":"100m"}}]}}' >/dev/null 2>&1; then
+                    log "limitrange ensured (max 1Gi)"
+                  else
+                    log "limitrange patch skipped (absent or unchanged)"
+                  fi
+
+                  # 2) Deployment memory limit + operative heap var
+                  CUR=$(kubectl -n "$NS" get deploy "$DEP" -o jsonpath='{.spec.template.spec.containers[0].resources.limits.memory}' 2>/dev/null || true)
+                  if [ "$CUR" != "$WANT" ]; then
+                    log "deploy memory limit is '${CUR:-<none>}' (want $WANT) — patching + setting -Xmx512m"
+                    if kubectl -n "$NS" patch deploy "$DEP" --type=strategic -p \
+                         "{\"spec\":{\"template\":{\"spec\":{\"containers\":[{\"name\":\"$DEP\",\"resources\":{\"requests\":{\"memory\":\"384Mi\",\"cpu\":\"100m\"},\"limits\":{\"memory\":\"$WANT\",\"cpu\":\"1\"}},\"env\":[{\"name\":\"JAVA_OPTS_APPEND\",\"value\":\"$HEAP\"}]}]}}}}"; then
+                      log "patched deploy -> $WANT (Deployment will roll a corrected pod)"
+                    else
+                      log "deploy patch FAILED"
+                    fi
+                  else
+                    log "deploy memory limit already $WANT — ok"
+                  fi
+
+                  # 3) Clear pods stuck from a prior OOMKill (only when spec is
+                  #    already correct, so a non-memory crash is never masked).
+                  NOWCUR=$(kubectl -n "$NS" get deploy "$DEP" -o jsonpath='{.spec.template.spec.containers[0].resources.limits.memory}' 2>/dev/null || true)
+                  if [ "$NOWCUR" = "$WANT" ]; then
+                    OOM=$(kubectl -n "$NS" get pods -l app="$DEP" -o go-template='{{range .items}}{{$n:=.metadata.name}}{{range .status.containerStatuses}}{{with .lastState.terminated}}{{if eq .reason "OOMKilled"}}{{$n}}{{"\n"}}{{end}}{{end}}{{end}}{{end}}' 2>/dev/null || true)
+                    if [ -n "${OOM// /}" ]; then
+                      for p in $OOM; do
+                        log "deleting OOM-stuck pod $p to force a clean restart"
+                        kubectl -n "$NS" delete pod "$p" --grace-period=10 >/dev/null 2>&1 || true
+                      done
+                    else
+                      log "no OOM-stuck pods"
+                    fi
+                  fi
+                  log "reconcile complete"
+              resources:
+                requests:
+                  cpu: 10m
+                  memory: 24Mi
+                limits:
+                  cpu: 200m
+                  memory: 64Mi
+              securityContext:
+                allowPrivilegeEscalation: false
+                readOnlyRootFilesystem: true
+                capabilities:
+                  drop: ["ALL"]
+              volumeMounts:
+                - name: tmp
+                  mountPath: /tmp
+          volumes:
+            - name: tmp
+              emptyDir: {}


### PR DESCRIPTION
## Problem

Keycloak has been OOMKilling (container limit 384Mi vs its `-Xmx512m` heap) → CrashLoopBackOff → `auth.cloudless.gr` 503. The durable 768Mi fix is already committed (`memory-relief-2026-05-31.yaml`) and a GitHub-side self-heal exists (`keycloak-ensure.yml`, cron `*/15`) — but that cron runs on **GitHub's scheduler**, which stalls/disables on low-activity repos and needs CI + the tailnet up. Exactly what's unreliable during a cluster incident (its own header says "kick stalled cron").

## Auto-fix: an in-cluster self-healer

A CronJob that runs the OOM reconcile on **k3s's own scheduler** — no GitHub/CI/tailnet dependency.

- **`k8s/cluster-protection/keycloak-autoheal.yaml`** — CronJob (`*/5`) + ServiceAccount + least-privilege Role/RoleBinding scoped to ns `keycloak`. Each run, idempotently:
  1. lifts the LimitRange ceiling to 1Gi,
  2. patches the `keycloak` deploy to **768Mi limit + `JAVA_OPTS_APPEND=-Xmx512m`** if drifted (Deployment then rolls a corrected pod),
  3. deletes pods stuck from a prior **OOMKill** — but **only when the spec is already correct**, so a non-memory crash is never masked.
  - Tiny footprint (24Mi req / 64Mi limit), non-root, read-only rootfs, `/tmp` emptyDir for kubectl cache.
- **`.github/workflows/keycloak-autoheal-deploy.yml`** — applies the 768Mi source-of-truth manifest (**immediate fix**), installs the healer, kicks it once, then verifies pod state + `auth.cloudless.gr` discovery → posts to issue #382. Idempotent; push-path + `workflow_dispatch`.
- **CLAUDE.md** — documents the two-layer (GitHub + in-cluster) self-heal.

## Rollout

Merging fires the deploy workflow → it remediates the **current** outage (apply 768Mi + restart) and installs the autoheal CronJob that prevents recurrence autonomously. Result is posted to #382.

> Note: `kubectl apply`/`patch`/`delete` go through the API server (not the kubelet), so this works even with the kubelet `exec` 502s seen in #382. If the omv node itself is down, the deploy step will surface that — node recovery is a separate concern.

https://claude.ai/code/session_016PrzZJMNxsgiEmvedfkru6

---
_Generated by [Claude Code](https://claude.ai/code/session_016PrzZJMNxsgiEmvedfkru6)_