### PR TITLE
Keycloak finalize-admin: password dispatch input + SSM fallback + export workflow

### DIFF
--- a/.github/workflows/keycloak-export-admin-password.yml
+++ b/.github/workflows/keycloak-export-admin-password.yml
@@ -1,0 +1,92 @@
+name: Keycloak — export admin password from pod to SSM
+
+# One-time bootstrap utility: reads KC_BOOTSTRAP_ADMIN_PASSWORD from inside the
+# Keycloak pod (where it lives as an env var) and stores it to SSM so that all
+# future REST-API-based workflows (finalize-admin, configure-email, ensure) can
+# authenticate without needing the ADMIN_BOOTSTRAP_PASSWORD GitHub Secret.
+#
+# Run this ONCE when the k3s API server is healthy. After that, the password
+# lives in SSM /cloudless/production/KEYCLOAK_ADMIN_PASSWORD and keycloak-ensure
+# and keycloak-finalize-admin work autonomously.
+#
+# Requires: TS_AUTHKEY, KUBECONFIG_B64, AWS_DEPLOY_ROLE_ARN secrets.
+
+on:
+  workflow_dispatch:
+
+permissions:
+  id-token: write   # OIDC → AWS ssm:PutParameter
+  contents: read
+  issues: write
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
+jobs:
+  export:
+    runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ github.token }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v4.3.1
+
+      - name: Connect to tailnet
+        uses: tailscale/github-action@0263d9e6d793eaefcf1de98ff7fde47abe6664d3 # v3.2.4
+        with:
+          authkey: ${{ secrets.TS_AUTHKEY }}
+
+      - name: Configure kubectl
+        run: |
+          mkdir -p ~/.kube
+          echo "${{ secrets.KUBECONFIG_B64 }}" | base64 -d > ~/.kube/config
+          chmod 600 ~/.kube/config
+
+      - name: Configure AWS credentials (OIDC)
+        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4
+        with:
+          role-to-assume: ${{ secrets.AWS_DEPLOY_ROLE_ARN }}
+          aws-region: us-east-1
+
+      - name: Extract admin password from pod and store to SSM
+        env:
+          AWS_DEFAULT_REGION: us-east-1
+        run: |
+          set -uo pipefail
+          NAMESPACE=keycloak
+          DEPLOYMENT=keycloak
+
+          POD=$(kubectl -n "$NAMESPACE" get pod -l app="$DEPLOYMENT" \
+            -o jsonpath='{.items[0].metadata.name}' 2>/dev/null)
+          [ -n "$POD" ] || { echo "error: no keycloak pod in ns/$NAMESPACE"; exit 1; }
+          echo "pod=$POD"
+
+          # Read the bootstrap admin password from the pod's env vars
+          PW=$(kubectl -n "$NAMESPACE" exec "$POD" -- \
+            bash -c 'echo "${KEYCLOAK_ADMIN_PASSWORD:-${KC_BOOTSTRAP_ADMIN_PASSWORD:-}}"' 2>/dev/null)
+          [ -n "$PW" ] || { echo "error: KC_BOOTSTRAP_ADMIN_PASSWORD is empty in the pod"; exit 1; }
+          echo "::add-mask::$PW"
+
+          # Verify it works against the REST API
+          TOKEN=$(curl -sf --max-time 15 \
+            -X POST "https://auth.cloudless.gr/realms/master/protocol/openid-connect/token" \
+            -H "Content-Type: application/x-www-form-urlencoded" \
+            --data-urlencode "client_id=admin-cli" \
+            --data-urlencode "username=admin" \
+            --data-urlencode "password=${PW}" \
+            --data-urlencode "grant_type=password" 2>/dev/null \
+            | python3 -c 'import sys,json; d=json.load(sys.stdin); print(d.get("access_token",""))' || true)
+          [ -n "$TOKEN" ] || { echo "error: password from pod does not authenticate to REST API"; exit 1; }
+          echo "REST_AUTH=ok (password verified against auth.cloudless.gr)"
+
+          # Store to SSM
+          aws ssm put-parameter \
+            --name /cloudless/production/KEYCLOAK_ADMIN_PASSWORD \
+            --type SecureString \
+            --overwrite \
+            --value "$PW" \
+            --description "Keycloak bootstrap admin password — stored by keycloak-export-admin-password workflow" \
+            >/dev/null
+          echo "SSM_WRITE=done (/cloudless/production/KEYCLOAK_ADMIN_PASSWORD)"
+          echo ""
+          echo "All future REST-API keycloak workflows will now read from SSM automatically."
+          echo "No ADMIN_BOOTSTRAP_PASSWORD GitHub Secret required."

--- a/.github/workflows/keycloak-finalize-admin.yml
+++ b/.github/workflows/keycloak-finalize-admin.yml
@@ -21,8 +21,13 @@ on:
         description: "Admin email (default: tbaltzakis@cloudless.gr)"
         required: false
         default: "tbaltzakis@cloudless.gr"
+      keycloak_admin_password:
+        description: "Keycloak internal admin password (overrides ADMIN_BOOTSTRAP_PASSWORD secret and SSM)"
+        required: false
+        default: ""
 
 permissions:
+  id-token: write   # OIDC → AWS for SSM fallback
   contents: read
   issues: write
 
@@ -43,10 +48,43 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v4.3.1
 
+      - name: Configure AWS credentials (OIDC — for SSM fallback)
+        if: ${{ github.event.inputs.keycloak_admin_password == '' && secrets.ADMIN_BOOTSTRAP_PASSWORD == '' }}
+        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4
+        with:
+          role-to-assume: ${{ secrets.AWS_DEPLOY_ROLE_ARN }}
+          aws-region: us-east-1
+        continue-on-error: true
+
+      - name: Resolve Keycloak admin password (input → secret → SSM)
+        id: resolve
+        env:
+          INPUT_PW: ${{ github.event.inputs.keycloak_admin_password }}
+          SECRET_PW: ${{ secrets.ADMIN_BOOTSTRAP_PASSWORD }}
+          AWS_DEFAULT_REGION: us-east-1
+        run: |
+          set -uo pipefail
+          PW="${INPUT_PW:-}"
+          if [ -z "$PW" ]; then PW="${SECRET_PW:-}"; fi
+          if [ -z "$PW" ]; then
+            PW=$(aws ssm get-parameter \
+              --name /cloudless/production/KEYCLOAK_ADMIN_PASSWORD \
+              --with-decryption --query 'Parameter.Value' --output text 2>/dev/null || true)
+          fi
+          if [ -z "$PW" ]; then
+            echo "::error::No Keycloak admin password found. Provide it via:"
+            echo "  1. workflow_dispatch keycloak_admin_password input"
+            echo "  2. ADMIN_BOOTSTRAP_PASSWORD GitHub Secret"
+            echo "  3. SSM /cloudless/production/KEYCLOAK_ADMIN_PASSWORD"
+            exit 1
+          fi
+          echo "::add-mask::$PW"
+          echo "pw=$PW" >> "$GITHUB_OUTPUT"
+
       - name: Finalize admin account (permanent password + realm-admin via REST API)
         shell: bash
         env:
-          KEYCLOAK_ADMIN_PASSWORD: ${{ secrets.ADMIN_BOOTSTRAP_PASSWORD }}
+          KEYCLOAK_ADMIN_PASSWORD: ${{ steps.resolve.outputs.pw }}
           ADMIN_EMAIL: ${{ github.event.inputs.admin_email || 'tbaltzakis@cloudless.gr' }}
         run: |
           set -o pipefail


### PR DESCRIPTION
## Summary

- **`keycloak-finalize-admin.yml`**: adds `keycloak_admin_password` dispatch input so the admin password can be pasted directly. Resolves password in priority order: dispatch input → `ADMIN_BOOTSTRAP_PASSWORD` secret → SSM `/cloudless/production/KEYCLOAK_ADMIN_PASSWORD`.
- **`keycloak-export-admin-password.yml`** (new): one-time bootstrap workflow — when k3s API is healthy, reads `KC_BOOTSTRAP_ADMIN_PASSWORD` from inside the Keycloak pod, verifies it against the REST API, and stores it to SSM. After this runs once, all REST-API keycloak workflows are self-sufficient.

## How to unblock right now

The k3s API server is down (`connection refused on 100.113.41.119:6443`). Options:

**Option A — if you know the Keycloak internal admin password:**
Trigger `keycloak-finalize-admin.yml` via `workflow_dispatch` and paste the password in the `keycloak_admin_password` input.

**Option B — when k3s API recovers:**
Trigger `keycloak-export-admin-password.yml` once (requires Tailscale + k3s access). It stores the password to SSM permanently — all subsequent `keycloak-ensure` and `keycloak-finalize-admin` runs work without any manual step.

https://claude.ai/code/session_013sTDMVEYibee8tbXxrwjzo

---
_Generated by [Claude Code](https://claude.ai/code/session_013sTDMVEYibee8tbXxrwjzo)_