### PR TITLE
ops(prometheus): silence intrinsic KubeMemoryOvercommit alert on omv cluster

### DIFF
--- a/scripts/prometheus-tune.sh
+++ b/scripts/prometheus-tune.sh
@@ -19,6 +19,17 @@
 # cause — the heavy rule groups saturate Prometheus CPU and load the apiserver,
 # starving its service-discovery watches; removing them clears the SD timeouts.
 #
+# 2026-06-02 (b): also strips the intrinsic overcommit alerts
+# (KubeMemoryOvercommit / KubeCPUOvercommit) from the kubernetes-resources
+# group. On this asymmetric 2-node cluster (omv 8GiB vs omv-ha ~1GiB) the HA
+# branch of the overcommit expression is permanently true — losing omv means
+# omv-ha can't hold the rescheduled requests — so the alert fires forever with
+# no actionable fix. Stripping the two alerts (keeping the rest of the group)
+# silences the noise via the kubectl/workflow path (the comprehensive
+# k8s/cluster-protection/apply-prometheus-rule-tuning.sh does the same over SSH,
+# which a cloud session can't use). Idempotent: re-stripping a missing alert
+# is a no-op.
+#
 # This deletes the PrometheusRule objects that contain the heavy groups. It is
 # idempotent (missing = already done) and reversible: a `helm upgrade` of the
 # kube-prometheus-stack recreates them, so the durable fix is the Helm values
@@ -61,6 +72,34 @@ for grp in "${HEAVY_GROUPS[@]}"; do
   done
 done
 log "deleted $deleted PrometheusRule object(s)."
+
+# ── Strip intrinsic overcommit alerts from the kubernetes-resources group ─────
+# KubeMemoryOvercommit / KubeCPUOvercommit are permanently true on this
+# asymmetric 2-node cluster (see header). Remove just those alerts; keep the
+# rest of every group they live in. Discover the owning PrometheusRule(s) by
+# alert presence so we don't hardcode the chart's object name.
+STRIP_ALERTS=("KubeMemoryOvercommit" "KubeCPUOvercommit")
+drop_json=$(printf '%s\n' "${STRIP_ALERTS[@]}" | jq -R . | jq -s .)
+mapfile -t res_crs < <(kubectl -n "$PROM_NS" get prometheusrule -o json 2>/dev/null \
+  | jq -r --argjson drop "$drop_json" \
+    '.items[] | select(any((.spec.groups // [])[].rules[]?; (.alert // "") as $a | ($drop | index($a)))) | .metadata.name' \
+  | sort -u)
+if [ "${#res_crs[@]}" -eq 0 ]; then
+  log "overcommit: no PrometheusRule contains ${STRIP_ALERTS[*]} (already stripped?)"
+else
+  for cr in "${res_crs[@]}"; do
+    [ -z "$cr" ] && continue
+    log "stripping ${STRIP_ALERTS[*]} from PrometheusRule '$cr'"
+    if kubectl -n "$PROM_NS" get prometheusrule "$cr" -o json \
+      | jq --argjson drop "$drop_json" \
+        '{spec: {groups: (.spec.groups | map(.rules |= map(select((.alert // "") as $a | ($drop | index($a)) | not))))}}' \
+      | kubectl -n "$PROM_NS" patch prometheusrule "$cr" --type=merge --patch-file=/dev/stdin; then
+      log "  ✓ patched '$cr'"
+    else
+      log "  WARNING: patch of '$cr' failed"
+    fi
+  done
+fi
 
 # Give Prometheus a moment to reload rules, then report remaining failures.
 sleep 20


### PR DESCRIPTION
## What
Silences the benign **`KubeMemoryOvercommit`** alert (and its sibling `KubeCPUOvercommit`) by stripping them from the `kubernetes-resources` PrometheusRule group on the omv cluster.

## Why
On this asymmetric 2-node cluster (omv 8 GiB vs omv-ha ~1 GiB), the HA branch of the overcommit expression is **permanently true** — if omv is lost, omv-ha can't hold the rescheduled requests. There's no actionable fix without more hardware, so it's pure Slack noise. `k8s/cluster-protection/apply-prometheus-rule-tuning.sh` already documents this and strips it — but that script runs over **SSH**, which a cloud session can't use.

## How
Adds the strip to the **kubectl-based** `scripts/prometheus-tune.sh`, which runs via the existing `prometheus-tune.yml` workflow (Tailscale + `KUBECONFIG_B64`, posts results to issue #382). Merging this to `main` touches `scripts/prometheus-tune.sh`, which **triggers that workflow** to apply it live.

- Discovers the owning PrometheusRule by **alert presence** (no hardcoded chart object name).
- Removes only the two overcommit alerts; keeps the rest of every group.
- **Idempotent** — re-stripping a missing alert is a no-op.

## Verified (offline)
- `bash -n scripts/prometheus-tune.sh` clean.
- jq discovery + patch filters validated against a mock PrometheusRule: only the right object is selected, both overcommit alerts removed, other alerts + recording rules preserved.

> Note: like the rest of the tuning, this is reversed by a `helm upgrade` of kube-prometheus-stack; the durable fix is the chart's `defaultRules` values. Stripping matches the existing operational pattern.

https://claude.ai/code/session_01SFLAFG395WWQcyj69toXbT

---
_Generated by [Claude Code](https://claude.ai/code/session_01SFLAFG395WWQcyj69toXbT)_