### PR TITLE
fix(keycloak): pin autoheal to omv (cached image) + widen preflight

### DIFF
--- a/.github/workflows/keycloak-autoheal-deploy.yml
+++ b/.github/workflows/keycloak-autoheal-deploy.yml
@@ -51,7 +51,9 @@ jobs:
       - name: Wait for cluster API (tolerate transient tailnet blips)
         run: |
           set -uo pipefail
-          for i in 1 2 3 4 5 6; do
+          # ~6 min total — CI→API over the tailnet has flapped for >3 min at a
+          # time (the cluster stays up via the Cloudflare tunnel meanwhile).
+          for i in 1 2 3 4 5 6 7 8; do
             if kubectl get ns keycloak >/dev/null 2>&1; then
               echo "cluster API reachable (attempt $i)"; exit 0
             fi

--- a/k8s/cluster-protection/keycloak-autoheal.yaml
+++ b/k8s/cluster-protection/keycloak-autoheal.yaml
@@ -88,7 +88,9 @@ spec:
   failedJobsHistoryLimit: 3
   jobTemplate:
     spec:
-      activeDeadlineSeconds: 120
+      # Generous deadline: a cold image pull on the Pi can take >150s; once the
+      # image is cached (see nodeSelector below) a run finishes in a few seconds.
+      activeDeadlineSeconds: 300
       backoffLimit: 1
       template:
         metadata:
@@ -97,6 +99,10 @@ spec:
         spec:
           serviceAccountName: keycloak-autoheal
           restartPolicy: Never
+          # Pin to omv — the node Keycloak runs on, where the kubectl image is
+          # already cached, so the healer never stalls on a first-time pull.
+          nodeSelector:
+            kubernetes.io/hostname: omv
           # Tolerate the control-plane node taint if present — the healer must
           # be schedulable even when the cluster is under pressure.
           tolerations:


### PR DESCRIPTION
De-risks the healer's first-run image pull (per request) — but the **safe** way. Rather than swap to `rancher/kubectl`, whose shell and exact tag I can't verify offline (an unverified image risks `ImagePullBackOff`, worse than a slow pull), I keep the proven bash image and make the pull a non-issue:

- **Pin the autoheal Job to node `omv`** via `nodeSelector` — that's where Keycloak runs and where run #2 already pulled `bitnami/kubectl`, so the image is **cached there** and the healer never stalls on a cold pull. Mirrors the existing `etcd-defrag` CronJob pattern.
- **`activeDeadlineSeconds` 120 → 300** as headroom for any cold pull.
- **Widen the deploy preflight 6 → 8 retries (~6 min)** — CI→API over the tailnet flapped for >3 min during run #3 (cluster stayed up via the Cloudflare tunnel the whole time), which aborted it before it could verify the healer.

Net effect: the next deploy run should both survive the tailnet flakiness and show the healer pod completing fast with its log output. The `rancher/kubectl` fallback is still documented inline if `bitnami/kubectl` ever fails to pull.

https://claude.ai/code/session_016PrzZJMNxsgiEmvedfkru6

---
_Generated by [Claude Code](https://claude.ai/code/session_016PrzZJMNxsgiEmvedfkru6)_