### PR TITLE
ops: trigger cluster-doctor — auth.cloudless.gr 503, confirm Keycloak OOM state

### DIFF
--- a/.github/workflows/cluster-doctor.yml
+++ b/.github/workflows/cluster-doctor.yml
@@ -1,5 +1,5 @@
 name: Cluster doctor (read-only diagnostics)
-# triggered 2026-06-02T19:XX — post-restart AUTH_URL + Traefik CSP confirmation
+# triggered 2026-06-02T22:5X — auth.cloudless.gr 503 live; confirm Keycloak OOM/limit state
 
 # Read-only visibility into the omv k3s cluster from CI. Runs scripts/cluster-
 # doctor.sh over Tailscale + KUBECONFIG_B64 and posts the snapshot as a comment


### PR DESCRIPTION
## Why
Live check: `auth.cloudless.gr` OIDC discovery returns **HTTP 503** — Keycloak is down (login/registration broken; `cloudless.gr` itself is up). The #382 snapshots show the cause: Keycloak OOM CrashLoop, container capped at **384Mi** vs `JAVA_OPTS_APPEND=-Xmx512m` (the regression CLAUDE.md documents — JVM container below `-Xmx` + ~200Mi non-heap).

## What
Bumps the `cluster-doctor.yml` trigger comment to run the **read-only** diagnostics snapshot (no cluster mutation) and post current Keycloak pod state — limits/heap, restart count, OOMKilled status, recent events — to issue #382, so we confirm the live state before deciding on remediation.

https://claude.ai/code/session_01SFLAFG395WWQcyj69toXbT

---
_Generated by [Claude Code](https://claude.ai/code/session_01SFLAFG395WWQcyj69toXbT)_