### PR TITLE
chore: update stale comments in analytics-restore.sh (600Mi→1Gi)

### DIFF
--- a/scripts/analytics-restore.sh
+++ b/scripts/analytics-restore.sh
@@ -6,15 +6,15 @@
 # What it does:
 #   1. Checks Metabase and DuckDB API pod states
 #   2. If Metabase is OOMKilled/CrashLooping, patches its memory limit up
-#      (default: 600Mi, current cap is 400Mi which is tight for the JVM)
+#      (default: 1Gi; JVM needs heap + ~200Mi non-heap — never cap below -Xmx)
 #   3. Restarts affected deployments and waits for Ready
 #   4. Reports before/after state
 #
 # Idempotent — safe to re-run. Only patches if the live state needs it.
 #
 # Env overrides:
-#   METABASE_MEM_LIMIT   (default: 600Mi)
-#   METABASE_JAVA_OPTS   (default: -Xmx480m -Xms128m)
+#   METABASE_MEM_LIMIT   (default: 1Gi)
+#   METABASE_JAVA_OPTS   (default: -Xmx768m -Xms128m)
 #   DUCKDB_MEM_LIMIT     (default: 1500Mi — already generous, only raise if needed)
 #   ANALYTICS_NS         (default: analytics)
 


### PR DESCRIPTION
Stale comments in analytics-restore.sh still said `600Mi`/`400Mi`/`-Xmx480m` after the memory limit was raised to 1Gi. No functional change.

https://claude.ai/code/session_01PHsA9s3tK2thgSJVwEGuWq

---
_Generated by [Claude Code](https://claude.ai/code/session_01PHsA9s3tK2thgSJVwEGuWq)_