### PR TITLE
fix(instrumentation): downgrade cold-start SSM log from warn to log

### DIFF
--- a/src/instrumentation.ts
+++ b/src/instrumentation.ts
@@ -43,7 +43,7 @@ async function loadSsmParams(prefix: string): Promise<Map<string, string>> {
 }
 
 async function fireDeployNotification(prefix: string, params: Map<string, string>): Promise<void> {
-  console.warn(`[Instrumentation] Loaded ${params.size} SSM parameters from ${prefix}`);
+  console.log(`[Instrumentation] Loaded ${params.size} SSM parameters from ${prefix}`);
   const version = process.env.NEXT_PUBLIC_APP_VERSION ?? "unknown";
   const stage = process.env.SST_STAGE ?? process.env.NODE_ENV ?? "production";
   if (version === "unknown" || version === lastNotifiedVersion) return;


### PR DESCRIPTION
## Summary

- `instrumentation.ts:46`: `console.warn` on successful SSM load fired on every Lambda cold start and counted toward the `ServerlessWarnings` CloudWatch alarm — alarm triggered at 22:50 UTC today with 4 warnings (4 cold starts)
- Changed to `console.log` since it is informational, not a warning
- Actual failure case (`slackDeployNotify failed`) keeps `console.warn`

## Root cause

In Lambda + CloudWatch Logs, `console.warn()` emits a `WARN`-level log line. The `SERVERLESS-APP_MAIN-Warnings` alarm filters for `WARN` and counts them. The SSM load success message on every cold start was generating false-positive alarm triggers.

## Test plan

- [ ] After deploy: Lambda cold starts no longer appear in `ServerlessWarnings` metric
- [ ] `ServerlessWarnings` alarm returns to OK state

https://claude.ai/code/session_012EjQpQGyt6SeSfRNNRRr6j