### PR TITLE
ops: restore Keycloak — auth.cloudless.gr 503 (OOM CrashLoop, resize to 768Mi)

### DIFF
--- a/.github/workflows/restore-keycloak.yml
+++ b/.github/workflows/restore-keycloak.yml
@@ -4,7 +4,9 @@ name: Restore Keycloak (one-shot recovery)
 # Keycloak OOM-crash-looping (384Mi container under a -Xmx512m heap). Directly
 # patches the keycloak Deployment to fit the heap and restarts it.
 #
-# Re-run trigger: 2026-06-01b — direct patch + self-reporting to issue #382.
+# Re-run trigger: 2026-06-02c — auth.cloudless.gr 503 (OIDC+JWKS), Keycloak OOM
+# CrashLoop persisting; */15 ensure cron not recovering it. Direct-patch to
+# 768Mi and restart; self-reports to issue #382.
 # Runs on a GitHub-hosted runner and reaches the omv k3s API over Tailscale +
 # KUBECONFIG_B64 — the same access path as deploy-pi.yml's rollout job. This is
 # deliberately NOT pinned to the self-hosted omv runners, so the recovery still


### PR DESCRIPTION
## Why
`cluster-doctor` run #26 confirms **Keycloak OIDC + JWKS return HTTP 503** (auth.cloudless.gr down) while every other workload is healthy. Root cause is the documented **384Mi container cap vs `-Xmx512m` heap** OOM CrashLoop, and the `*/15` `keycloak:ensure` cron is **not** recovering it.

## What
Bumps the `restore-keycloak.yml` trigger comment to fire the one-shot recovery: direct-patch the Keycloak Deployment to **768Mi** (fits the heap + non-heap), restart, and self-report to issue #382. Runs on a hosted runner over Tailscale + `KUBECONFIG_B64` (not pinned to on-prem runners, so it works during cluster incidents).

Authorized by the operator after the doctor report.

https://claude.ai/code/session_01SFLAFG395WWQcyj69toXbT

---
_Generated by [Claude Code](https://claude.ai/code/session_01SFLAFG395WWQcyj69toXbT)_