### PR TITLE
fix(keycloak): valid healer image + stop cycling Keycloak

### DIFF
--- a/.github/workflows/keycloak-autoheal-deploy.yml
+++ b/.github/workflows/keycloak-autoheal-deploy.yml
@@ -73,13 +73,23 @@ jobs:
           echo "== ensure LimitRange ceiling (1Gi) ==" | tee -a heal.log
           kubectl -n keycloak patch limitrange default-container-limits --type=merge -p \
             '{"spec":{"limits":[{"type":"Container","max":{"memory":"1Gi","cpu":"2"},"default":{"memory":"512Mi","cpu":"1"},"defaultRequest":{"memory":"128Mi","cpu":"100m"}}]}}' 2>&1 | tee -a heal.log || true
-          echo "== patch keycloak deploy (768Mi + -Xmx512m) ==" | tee -a heal.log
+          echo "== patch keycloak deploy (only if limit drifted) ==" | tee -a heal.log
           # Direct strategic patch of just the keycloak Deployment — the
           # memory-relief manifest holds PARTIAL deploy specs (no selector/image)
           # meant as patches, so `kubectl apply` of the whole file is invalid.
-          kubectl -n keycloak patch deploy keycloak --type=strategic -p \
-            '{"spec":{"template":{"spec":{"containers":[{"name":"keycloak","resources":{"requests":{"memory":"384Mi","cpu":"100m"},"limits":{"memory":"768Mi","cpu":"1"}},"env":[{"name":"JAVA_OPTS_APPEND","value":"-Xms128m -Xmx512m -Djdk.reflect.useDirectMethodHandle=false -Dquarkus.http.limits.max-header-size=64K"}]}]}}}}' \
-            2>&1 | tee -a heal.log || true
+          # CONDITIONAL: only patch when the limit is wrong. Patching
+          # unconditionally rolls a new pod every run (e.g. an -Xms delta), which
+          # needlessly cycles a healthy Keycloak — the bug that 503'd it before.
+          CUR=$(kubectl -n keycloak get deploy keycloak \
+            -o jsonpath='{.spec.template.spec.containers[0].resources.limits.memory}' 2>/dev/null || true)
+          if [ "$CUR" != "768Mi" ]; then
+            echo "limit is '${CUR:-<none>}' — patching to 768Mi + -Xmx512m" | tee -a heal.log
+            kubectl -n keycloak patch deploy keycloak --type=strategic -p \
+              '{"spec":{"template":{"spec":{"containers":[{"name":"keycloak","resources":{"requests":{"memory":"384Mi","cpu":"100m"},"limits":{"memory":"768Mi","cpu":"1"}},"env":[{"name":"JAVA_OPTS_APPEND","value":"-Xms128m -Xmx512m -Djdk.reflect.useDirectMethodHandle=false -Dquarkus.http.limits.max-header-size=64K"}]}]}}}}' \
+              2>&1 | tee -a heal.log || true
+          else
+            echo "limit already 768Mi — no patch, no rollout (Keycloak left undisturbed)" | tee -a heal.log
+          fi
 
       - name: 2. Install in-cluster self-healer (CronJob + RBAC)
         run: |

--- a/k8s/cluster-protection/keycloak-autoheal.yaml
+++ b/k8s/cluster-protection/keycloak-autoheal.yaml
@@ -99,10 +99,9 @@ spec:
         spec:
           serviceAccountName: keycloak-autoheal
           restartPolicy: Never
-          # Pin to omv — the node Keycloak runs on, where the kubectl image is
-          # already cached, so the healer never stalls on a first-time pull.
-          nodeSelector:
-            kubernetes.io/hostname: omv
+          # No nodeSelector: the healer talks to the API server (not the kubelet),
+          # so it can run on any node. Letting it schedule freely means it still
+          # works if the node Keycloak lives on is the one under pressure.
           # Tolerate the control-plane node taint if present — the healer must
           # be schedulable even when the cluster is under pressure.
           tolerations:
@@ -113,11 +112,13 @@ spec:
               type: RuntimeDefault
           containers:
             - name: heal
-              # Multi-arch (arm64) kubectl image with a shell. In-cluster config
-              # is auto-detected from the mounted ServiceAccount token — no
-              # kubeconfig needed. If this tag ever fails to pull, swap for
-              # rancher/kubectl:v1.31.4 (also multi-arch).
-              image: bitnami/kubectl:1.31
+              # alpine/k8s bundles kubectl + bash on a multi-arch (arm64) base.
+              # Chosen because it's ALREADY used by cluster-alerts.yaml on this
+              # cluster (proven to pull on the omv arm64 node) and matches the
+              # k3s 1.35 server. In-cluster config is auto-detected from the
+              # mounted ServiceAccount token — no kubeconfig needed.
+              # (Earlier bitnami/kubectl:1.31 was an invalid tag — never existed.)
+              image: alpine/k8s:1.35.5
               imagePullPolicy: IfNotPresent
               env:
                 # kubectl writes its discovery cache under $HOME/.kube — point it


### PR DESCRIPTION
The 22:58 cluster-doctor snapshot exposed two bugs in the autoheal work:

1. **`bitnami/kubectl:1.31` never existed** (Docker Hub returns 0 tags) — the healer pod was `ImagePullBackOff`, so the CronJob was installed but non-functional (my earlier "cached on omv" assumption was wrong). Switch to **`alpine/k8s:1.35.5`**: confirmed multi-arch (**arm64**), bundles kubectl + bash, **already used by `cluster-alerts.yaml`** on this cluster (proven to pull on omv), matches the k3s 1.35 server. Also dropped the omv `nodeSelector` so the healer can schedule anywhere (more resilient when omv is under load).
2. **The deploy's immediate patch cycled Keycloak.** It patched unconditionally; the live `-Xms192m` vs manifest `-Xms128m` delta rolled a new pod **every run**, needlessly cycling a healthy Keycloak (which 503'd it). Now **conditional** — only patches when the memory limit ≠ 768Mi; otherwise no-op, Keycloak undisturbed.

⚠️ **Heads-up beyond this PR:** the snapshot shows the **omv k3s control plane flapping** (`100.113.41.119:6443 connection refused`) and Keycloak currently **503** (new pod not becoming ready). That's a node/control-plane incident the auto-heal CronJob does **not** address — flagged separately to the user.

https://claude.ai/code/session_016PrzZJMNxsgiEmvedfkru6

---
_Generated by [Claude Code](https://claude.ai/code/session_016PrzZJMNxsgiEmvedfkru6)_