### PR TITLE
ops(cluster): trigger k3s-ssh-restart for flapping omv control plane

### DIFF
--- a/.github/workflows/k3s-ssh-restart.yml
+++ b/.github/workflows/k3s-ssh-restart.yml
@@ -16,6 +16,9 @@ name: k3s-ssh-restart — recover k3s API server via SSH when cluster tools fail
 #
 # If OMV_SSH_KEY is not set, the SSH step will fail immediately with a clear
 # message; set the secret and re-trigger.
+#
+# Re-triggered 2026-06-02 22:5x — omv control plane flapping (6443 connection
+# refused in cluster-doctor 22:58), Keycloak 503, new keycloak pod not ready.
 
 on:
   push:


### PR DESCRIPTION
Fires `k3s-ssh-restart.yml` (path-triggered) to recover the flapping omv control plane — per your "restart k3s on omv now" decision.

cluster-doctor 22:58 showed `100.113.41.119:6443 connection refused` across the board, Keycloak 503, the new keycloak pod stuck `0/1` not-ready. The Pi self-hosted runners are offline during the incident, so this uses the **SSH path** (hosted runner + Tailscale + `OMV_SSH_KEY`) which `systemctl restart k3s` on omv and waits for the API to return, posting the log to #382.

Recovery only — no app changes.

https://claude.ai/code/session_016PrzZJMNxsgiEmvedfkru6

---
_Generated by [Claude Code](https://claude.ai/code/session_016PrzZJMNxsgiEmvedfkru6)_