### PR TITLE
ops(keycloak): verify autoheal after k3s recovery

### DIFF
--- a/.github/workflows/keycloak-autoheal-deploy.yml
+++ b/.github/workflows/keycloak-autoheal-deploy.yml
@@ -1,5 +1,8 @@
 name: Keycloak autoheal — deploy in-cluster self-healer
 
+# Re-triggered 2026-06-02 23:1x — verify the healer after the k3s restart, now
+# that the control plane is back and the image (alpine/k8s:1.35.5) is valid.
+#
 # Installs the in-cluster Keycloak self-healer (k8s/cluster-protection/
 # keycloak-autoheal.yaml) AND remediates the current state in one shot:
 #   1. apply the 768Mi source-of-truth manifest (immediate OOM fix + rollout)


### PR DESCRIPTION
Closes the loop on the auto-heal verification (per your "verify after recovery" choice). The k3s-ssh-restart recovered the omv control plane — `auth.cloudless.gr` is back to **200/200**. This re-triggers `keycloak-autoheal-deploy` so the #382 report shows the healer pod pulling the valid `alpine/k8s:1.35.5` image and running. Step-1 now no-ops (limit already 768Mi), so Keycloak is left undisturbed.

https://claude.ai/code/session_016PrzZJMNxsgiEmvedfkru6

---
_Generated by [Claude Code](https://claude.ai/code/session_016PrzZJMNxsgiEmvedfkru6)_