### PR TITLE
ops: redeploy in-cluster Keycloak autoheal (cron-independent self-heal)

### DIFF
--- a/.github/workflows/keycloak-autoheal-deploy.yml
+++ b/.github/workflows/keycloak-autoheal-deploy.yml
@@ -1,4 +1,6 @@
 name: Keycloak autoheal — deploy in-cluster self-healer
+# re-trigger: 2026-06-02 — auth was down hours w/ no in-cluster heal; re-apply +
+# kick the healer and report CronJob/pod state to #382 to find why it stalled.
 
 # Re-triggered 2026-06-02 23:1x — verify the healer after the k3s restart, now
 # that the control plane is back and the image (alpine/k8s:1.35.5) is valid.


### PR DESCRIPTION
## Why
Today's Keycloak OOM CrashLoop kept `auth.cloudless.gr` down for **hours** because the GitHub `*/15` `keycloak:ensure` cron is throttled to ~hourly (run history shows 60–100 min gaps). The durable fix is the **in-cluster** autoheal CronJob (`k8s/cluster-protection/keycloak-autoheal.yaml`, `*/5`, runs on k3s's own scheduler — no GitHub-cron / tailnet dependency). It exists (merged in #557/#566) but was evidently **not active**, or its jobs were failing.

## What
Re-runs the **idempotent** `keycloak-autoheal-deploy.yml`, which:
1. re-applies the 768Mi source-of-truth manifest,
2. (re)applies the autoheal CronJob + least-privilege RBAC,
3. kicks the healer once immediately,
4. **reports CronJob + pod state + auth discovery to issue #382** — so we can see *why* the in-cluster healer stalled.

Auth is already restored (via `restore-keycloak.yml`); this makes the recovery **autonomous** going forward.

https://claude.ai/code/session_01SFLAFG395WWQcyj69toXbT

---
_Generated by [Claude Code](https://claude.ai/code/session_01SFLAFG395WWQcyj69toXbT)_