### PR TITLE
ops: SSH-restart k3s on omv — control plane unreachable (apiserver down, 530s)

### DIFF
--- a/.github/workflows/k3s-ssh-restart.yml
+++ b/.github/workflows/k3s-ssh-restart.yml
@@ -17,8 +17,10 @@ name: k3s-ssh-restart — recover k3s API server via SSH when cluster tools fail
 # If OMV_SSH_KEY is not set, the SSH step will fail immediately with a clear
 # message; set the secret and re-trigger.
 #
-# Re-triggered 2026-06-02 22:5x — omv control plane flapping (6443 connection
-# refused in cluster-doctor 22:58), Keycloak 503, new keycloak pod not ready.
+# Re-triggered 2026-06-03 00:1x — omv control plane DOWN: apiserver 6443
+# unreachable (autoheal deploy stuck on "wait for cluster API"), and Cloudflare
+# returns 530 for auth/pi-origin/grafana (all omv-fronted services). Lambda
+# cloudless.gr unaffected. SSH-restart k3s and wait for the apiserver.
 
 on:
   push:


### PR DESCRIPTION
## Why
The omv k3s **control plane is down**:
- apiserver `100.113.41.119:6443` unreachable — `keycloak-autoheal-deploy` run #7 is stuck on its "Wait for cluster API" preflight.
- Cloudflare returns **530** for `auth.cloudless.gr`, `pi-origin.cloudless.gr`, and `grafana.cloudless.gr` (all omv-fronted services), confirmed across 3 checks.
- Lambda `cloudless.gr` = 200 (HA primary unaffected).

This is the deeper fault behind the Keycloak 503/OOM symptoms — the in-cluster self-heal can't install into an unreachable cluster.

## What
Triggers `k3s-ssh-restart.yml` (its documented use case: "connection refused on 6443 / all kubectl ServiceUnavailable"). It SSHes to omv via `OMV_SSH_KEY`, restarts k3s, waits for the apiserver to return, and reports to issue #382 — bypassing the dead apiserver.

Authorized by the operator. After the control plane is back, I'll re-run the autoheal deploy to land the in-cluster CronJob and verify auth.

https://claude.ai/code/session_01SFLAFG395WWQcyj69toXbT

---
_Generated by [Claude Code](https://claude.ai/code/session_01SFLAFG395WWQcyj69toXbT)_