### PR TITLE
ops: re-run Keycloak autoheal deploy after k3s restart (apiserver back)

### DIFF
--- a/.github/workflows/keycloak-autoheal-deploy.yml
+++ b/.github/workflows/keycloak-autoheal-deploy.yml
@@ -1,6 +1,7 @@
 name: Keycloak autoheal — deploy in-cluster self-healer
-# re-trigger: 2026-06-02 — auth was down hours w/ no in-cluster heal; re-apply +
-# kick the healer and report CronJob/pod state to #382 to find why it stalled.
+# re-trigger: 2026-06-03 — post k3s-ssh-restart (apiserver back 00:18); the prior
+# autoheal deploy was blocked on the unreachable apiserver. Re-apply + install the
+# CronJob + kick the healer now that the control plane is up; report state to #382.
 
 # Re-triggered 2026-06-02 23:1x — verify the healer after the k3s restart, now
 # that the control plane is back and the image (alpine/k8s:1.35.5) is valid.


### PR DESCRIPTION
## Why
`k3s-ssh-restart.yml` recovered the omv control plane (apiserver healthy at 00:18). The earlier `keycloak-autoheal-deploy` run was blocked on the unreachable apiserver ("Wait for cluster API"). Now that the control plane is back, re-run it to land the in-cluster self-healer.

## What
Re-triggers the idempotent autoheal deploy: re-apply Keycloak 768Mi, install the `keycloak-autoheal` CronJob + RBAC, kick the healer once, and report keycloak pod state + auth discovery to issue #382.

Note: public surfaces (auth/pi-origin/grafana) were still 530 immediately after the restart — the cloudflared tunnel + workload pods re-establish over a few minutes on the Pi. This deploy both completes the original self-heal task and confirms the cluster is usable.

https://claude.ai/code/session_01SFLAFG395WWQcyj69toXbT

---
_Generated by [Claude Code](https://claude.ai/code/session_01SFLAFG395WWQcyj69toXbT)_