### PR TITLE
ops: re-trigger post-k3s-restart verification (cluster recovered)

### DIFF
--- a/.github/workflows/app-auth-doctor.yml
+++ b/.github/workflows/app-auth-doctor.yml
@@ -1,5 +1,6 @@
 name: App auth doctor (Pi cloudless deployment wiring)
 # re-triggered 2026-06-03 — post-deploy full-stack verification
+# re-triggered 2026-06-03T00:30Z — post-k3s-restart verification (cluster recovered)
 
 # Read-only: dumps how the k3s `cloudless` app is wired for auth (env names,
 # secrets, configmaps — never values) so we can wire Keycloak onto the standby.

--- a/.github/workflows/cluster-doctor.yml
+++ b/.github/workflows/cluster-doctor.yml
@@ -1,6 +1,7 @@
 name: Cluster doctor (read-only diagnostics)
 # triggered 2026-06-02T22:5X — auth.cloudless.gr 503 live; confirm Keycloak OOM/limit state
 # re-triggered 2026-06-03 — post-deploy full-stack verification
+# re-triggered 2026-06-03T00:30Z — post-k3s-restart verification (cluster recovered)
 
 # Read-only visibility into the omv k3s cluster from CI. Runs scripts/cluster-
 # doctor.sh over Tailscale + KUBECONFIG_B64 and posts the snapshot as a comment

--- a/.github/workflows/keycloak-full-verify.yml
+++ b/.github/workflows/keycloak-full-verify.yml
@@ -1,5 +1,6 @@
 name: Keycloak full verify (enable signup + provision + verify login)
 # re-triggered 2026-06-03 — post-deploy full-stack verification
+# re-triggered 2026-06-03T00:30Z — post-k3s-restart verification (cluster recovered)
 
 # Drives the live system to "100%": enables self-service registration on the
 # realm, provisions/verifies a test user, and posts the full result to issue


### PR DESCRIPTION
$(cat <<'EOF'
Re-trigger cluster-doctor, app-auth-doctor, and keycloak-full-verify now that the k3s control plane is back (SSH restart succeeded at 00:14Z, Keycloak autoheal redeployed via PRs #580/#582).

The previous runs (00:08Z) all failed due to `i/o timeout` on port 6443 — the Pi was offline. This run verifies the recovered cluster.

https://claude.ai/code/session_013sTDMVEYibee8tbXxrwjzo
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_013sTDMVEYibee8tbXxrwjzo)_