### PR TITLE
Deploy Keycloak custom login theme; clean up Cognito env vars

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,11 +12,17 @@ AWS_SECRET_ACCESS_KEY=your-secret-access-key
 # SSM prefix for production secrets (set by SST deploy — do not set locally)
 SSM_PREFIX=/cloudless/production
 
-# ── Cognito ───────────────────────────────────────────────────────────────────
-COGNITO_USER_POOL_ID=us-east-1_xxxxxxxxx
-COGNITO_CLIENT_ID=your-cognito-client-id
-NEXT_PUBLIC_COGNITO_USER_POOL_ID=us-east-1_xxxxxxxxx
-NEXT_PUBLIC_COGNITO_CLIENT_ID=your-cognito-client-id
+# ── Keycloak (auth) ───────────────────────────────────────────────────────────
+# Server-side vars (not exposed to the browser)
+KEYCLOAK_ISSUER=https://auth.cloudless.gr/realms/master
+KEYCLOAK_CLIENT_ID=cloudless-app
+KEYCLOAK_CLIENT_SECRET=your-keycloak-client-secret
+# Build-time public var baked into the Next.js bundle (used by the login button)
+NEXT_PUBLIC_KEYCLOAK_ISSUER=https://auth.cloudless.gr/realms/master
+# next-auth session encryption secret — generate with: openssl rand -hex 32
+AUTH_SECRET=your-auth-secret-here
+AUTH_URL=http://localhost:4000
+AUTH_TRUST_HOST=true
 
 # ── SES (transactional email) ──────────────────────────────────────────────────
 SES_FROM_EMAIL=hello@cloudless.gr

--- a/.github/workflows/deploy-keycloak-theme.yml
+++ b/.github/workflows/deploy-keycloak-theme.yml
@@ -1,0 +1,57 @@
+name: Deploy Keycloak theme
+
+# Triggered by editing the workflow or any file under keycloak-theme/.
+# Copies the Cloudless login theme into the k3s Keycloak pod as a ConfigMap
+# + volumeMounts (survives pod restarts without rebuilding the image), then
+# activates it on the master realm via Admin REST API.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - ".github/workflows/deploy-keycloak-theme.yml"
+      - "keycloak-theme/**"
+      - "scripts/deploy-keycloak-theme.sh"
+
+permissions:
+  contents: read
+  issues: write
+
+concurrency:
+  group: deploy-keycloak-theme
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ github.token }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v4.3.1
+
+      - name: Connect to tailnet
+        uses: tailscale/github-action@0263d9e6d793eaefcf1de98ff7fde47abe6664d3 # v3.2.4
+        with:
+          authkey: ${{ secrets.TS_AUTHKEY }}
+
+      - name: Configure kubectl
+        run: |
+          mkdir -p ~/.kube
+          echo "${{ secrets.KUBECONFIG_B64 }}" | base64 -d > ~/.kube/config
+          chmod 600 ~/.kube/config
+
+      - name: Deploy theme
+        id: deploy
+        env:
+          KEYCLOAK_ADMIN_PASSWORD: ${{ secrets.ADMIN_BOOTSTRAP_PASSWORD }}
+        run: |
+          set -uo pipefail
+          bash scripts/deploy-keycloak-theme.sh 2>&1 | tee theme.log
+          echo "exit=${PIPESTATUS[0]}" >> "$GITHUB_OUTPUT"
+
+      - name: Report to tracking issue
+        if: always()
+        run: |
+          STATUS="${{ job.status }}"
+          { echo "# Keycloak theme deploy — $(date -u '+%F %T')Z — ${STATUS}"; echo; echo '```'; cat theme.log 2>/dev/null || echo '(no log)'; echo '```'; } > c.md
+          gh issue comment 382 --repo "${{ github.repository }}" --body-file c.md

--- a/scripts/deploy-keycloak-theme.sh
+++ b/scripts/deploy-keycloak-theme.sh
@@ -1,0 +1,123 @@
+#!/usr/bin/env bash
+# Deploy the Cloudless Keycloak login theme to the running k3s cluster.
+#
+# Strategy: ConfigMap (3 files) + volumeMounts with subPath → survives pod
+# restarts without rebuilding the Keycloak image.
+#
+# Steps:
+#   1. Create/update ConfigMap keycloak-theme-cloudless in ns keycloak
+#   2. Patch the Keycloak deployment to mount the 3 theme files via subPath
+#   3. Rollout restart + wait
+#   4. Activate theme on master realm via Admin REST API
+#   5. Smoke-check: verify loginTheme=cloudless in realm settings
+set -euo pipefail
+
+NAMESPACE=keycloak
+DEPLOY=keycloak
+KC_URL="${KC_URL:-https://auth.cloudless.gr}"
+THEME_DIR="${THEME_DIR:-keycloak-theme/cloudless}"
+LOG_PREFIX="[keycloak-theme]"
+
+echo "$LOG_PREFIX Starting theme deployment"
+
+# ── 1. ConfigMap ──────────────────────────────────────────────────────────────
+echo "$LOG_PREFIX Creating ConfigMap keycloak-theme-cloudless …"
+kubectl create configmap keycloak-theme-cloudless \
+  -n "$NAMESPACE" \
+  --from-file=theme.properties="${THEME_DIR}/login/theme.properties" \
+  --from-file=messages_en.properties="${THEME_DIR}/login/messages/messages_en.properties" \
+  --from-file=cloudless.css="${THEME_DIR}/login/resources/css/cloudless.css" \
+  --dry-run=client -o yaml | kubectl apply -f -
+echo "$LOG_PREFIX ConfigMap applied"
+
+# ── 2. Patch deployment volumes + volumeMounts ────────────────────────────────
+echo "$LOG_PREFIX Patching Keycloak deployment to mount theme files …"
+kubectl patch deployment "$DEPLOY" -n "$NAMESPACE" --type=strategic --patch '{
+  "spec": {
+    "template": {
+      "spec": {
+        "volumes": [
+          {
+            "name": "kc-theme-cloudless",
+            "configMap": { "name": "keycloak-theme-cloudless" }
+          }
+        ],
+        "containers": [
+          {
+            "name": "keycloak",
+            "volumeMounts": [
+              {
+                "name": "kc-theme-cloudless",
+                "mountPath": "/opt/keycloak/themes/cloudless/login/theme.properties",
+                "subPath": "theme.properties"
+              },
+              {
+                "name": "kc-theme-cloudless",
+                "mountPath": "/opt/keycloak/themes/cloudless/login/messages/messages_en.properties",
+                "subPath": "messages_en.properties"
+              },
+              {
+                "name": "kc-theme-cloudless",
+                "mountPath": "/opt/keycloak/themes/cloudless/login/resources/css/cloudless.css",
+                "subPath": "cloudless.css"
+              }
+            ]
+          }
+        ]
+      }
+    }
+  }
+}'
+echo "$LOG_PREFIX Deployment patched"
+
+# ── 3. Rollout restart ────────────────────────────────────────────────────────
+echo "$LOG_PREFIX Restarting Keycloak …"
+kubectl rollout restart deployment/"$DEPLOY" -n "$NAMESPACE"
+kubectl rollout status deployment/"$DEPLOY" -n "$NAMESPACE" --timeout=180s
+echo "$LOG_PREFIX Keycloak is running"
+
+# ── 4. Activate theme via Admin REST API ──────────────────────────────────────
+if [ -z "${KEYCLOAK_ADMIN_PASSWORD:-}" ]; then
+  echo "$LOG_PREFIX WARN: KEYCLOAK_ADMIN_PASSWORD not set — skipping theme activation"
+  echo "THEME_ACTIVATED=skipped"
+  exit 0
+fi
+
+KC_ADMIN="${KEYCLOAK_ADMIN:-admin}"
+
+echo "$LOG_PREFIX Authenticating with Keycloak Admin API …"
+TOKEN=$(curl -sS --fail-with-body \
+  -X POST "${KC_URL}/realms/master/protocol/openid-connect/token" \
+  -H "Content-Type: application/x-www-form-urlencoded" \
+  --data-urlencode "client_id=admin-cli" \
+  --data-urlencode "grant_type=password" \
+  --data-urlencode "username=${KC_ADMIN}" \
+  --data-urlencode "password=${KEYCLOAK_ADMIN_PASSWORD}" \
+  | python3 -c "import sys,json; print(json.load(sys.stdin)['access_token'])")
+
+echo "$LOG_PREFIX Activating cloudless login theme on master realm …"
+HTTP=$(curl -sS -o /dev/null -w "%{http_code}" \
+  -X PUT "${KC_URL}/admin/realms/master" \
+  -H "Authorization: Bearer ${TOKEN}" \
+  -H "Content-Type: application/json" \
+  -d '{"loginTheme": "cloudless"}')
+
+if [ "$HTTP" = "204" ]; then
+  echo "$LOG_PREFIX Theme activated (HTTP 204)"
+else
+  echo "$LOG_PREFIX WARN: PUT /admin/realms/master returned HTTP $HTTP"
+fi
+
+# ── 5. Verify ─────────────────────────────────────────────────────────────────
+echo "$LOG_PREFIX Verifying realm loginTheme …"
+CURRENT_THEME=$(curl -sS --fail-with-body \
+  -H "Authorization: Bearer ${TOKEN}" \
+  "${KC_URL}/admin/realms/master" \
+  | python3 -c "import sys,json; print(json.load(sys.stdin).get('loginTheme','(not set)'))") || CURRENT_THEME="(read failed)"
+
+if [ "$CURRENT_THEME" = "cloudless" ]; then
+  echo "THEME_ACTIVATED=ok THEME=${CURRENT_THEME}"
+else
+  echo "THEME_ACTIVATED=fail CURRENT=${CURRENT_THEME}"
+  exit 1
+fi


### PR DESCRIPTION
## Summary

- **`scripts/deploy-keycloak-theme.sh`** — Deploys `keycloak-theme/cloudless` as a Kubernetes ConfigMap with three `subPath` volume mounts into the Keycloak pod. This approach survives pod restarts without rebuilding the Keycloak image. After mounting, activates the theme on the `master` realm via Admin REST API and verifies `loginTheme=cloudless`.
- **`.github/workflows/deploy-keycloak-theme.yml`** — Path-triggered on push to `main` (any file under `keycloak-theme/**`, the script, or the workflow itself). Runs on `ubuntu-latest` + Tailscale, posts result to issue #382.
- **`.env.example`** — Replaces the stale Cognito section with the actual Keycloak vars (`KEYCLOAK_ISSUER`, `KEYCLOAK_CLIENT_ID/SECRET`, `AUTH_SECRET`, `AUTH_URL`, `AUTH_TRUST_HOST`, `NEXT_PUBLIC_KEYCLOAK_ISSUER`).

## How to trigger theme deployment

Merge this PR — the workflow fires automatically on the `keycloak-theme/**` path match.

## Test plan
- [ ] Workflow completes green and posts to issue #382
- [ ] Log shows `THEME_ACTIVATED=ok THEME=cloudless`
- [ ] Login at https://auth.cloudless.gr shows dark theme with neon-cyan accents

https://claude.ai/code/session_01PHsA9s3tK2thgSJVwEGuWq

---
_Generated by [Claude Code](https://claude.ai/code/session_01PHsA9s3tK2thgSJVwEGuWq)_