### PR TITLE
chore: remove stale Amplify/Cognito references from comments

### DIFF
--- a/src/lib/keycloak-auth.ts
+++ b/src/lib/keycloak-auth.ts
@@ -2,7 +2,7 @@
 
 /**
  * Keycloak auth module — implements the same interface that AuthContext
- * previously called on aws-amplify/auth, so AuthContext needs no changes.
+ * previously defined by the Amplify adapter, so AuthContext needs no changes.
  *
  * Sign-in / sign-out delegate to next-auth's signIn() / signOut() which
  * redirect through Keycloak's Authorization Code + PKCE flow.
@@ -18,7 +18,7 @@
 
 import { signIn as nextAuthSignIn, signOut as nextAuthSignOut, getSession } from "next-auth/react";
 
-// ── Types matching the aws-amplify/auth surface ───────────────────────────
+// ── Auth module types ─────────────────────────────────────────────────────
 
 interface SignInInput {
   username: string;

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -166,7 +166,7 @@ function generateNonce(): string {
  *   - Stripe (checkout + redirect)
  *   - Sentry (browser SDK + ingest)
  *   - Meta Pixel (connect.facebook.net)
- *   - Cognito (Amplify auth flows)
+ *   - Keycloak (auth.cloudless.gr OIDC)
  *   - HubSpot (forms + tracking)
  *   - Google Analytics / GTM
  */


### PR DESCRIPTION
$(cat <<'EOF'
## Summary
- `src/proxy.ts`: CSP allowlist comment updated (Cognito → Keycloak OIDC)
- `src/lib/keycloak-auth.ts`: removed `aws-amplify/auth` references from jsdoc and type section header

## Test plan
- [ ] No functional changes — comment-only cleanup
- [ ] Passes existing unit tests

https://claude.ai/code/session_01PHsA9s3tK2thgSJVwEGuWq
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01PHsA9s3tK2thgSJVwEGuWq)_