### PR TITLE
chore: update stale @auth jsdoc in analytics routes and agent/book

### DIFF
--- a/src/app/api/admin/analytics/countries/route.ts
+++ b/src/app/api/admin/analytics/countries/route.ts
@@ -9,7 +9,7 @@ import { requireAdmin } from "@/lib/api-auth";
  * Returns organic traffic breakdown by country from Google Search Console.
  * `limit` is clamped to 1–50 (default 30). Non-numeric values fall back to 30.
  *
- * @auth Requires Cognito JWT with `admin` group (401 / 403).
+ * @auth Requires admin session or Bearer JWT with `admin` group (401 / 403).
  * @returns 503 if GSC credentials are not configured in SSM.
  */
 export async function GET(request: NextRequest) {

--- a/src/app/api/admin/analytics/ctr-opportunities/route.ts
+++ b/src/app/api/admin/analytics/ctr-opportunities/route.ts
@@ -11,7 +11,7 @@ import { requireAdmin } from "@/lib/api-auth";
  * could increase organic traffic.
  * `limit` is clamped to 1–200 (default 50). Non-numeric values fall back to 50.
  *
- * @auth Requires Cognito JWT with `admin` group (401 / 403).
+ * @auth Requires admin session or Bearer JWT with `admin` group (401 / 403).
  * @returns 503 if GSC credentials are not configured in SSM.
  */
 export async function GET(request: NextRequest) {

--- a/src/app/api/admin/analytics/devices/route.ts
+++ b/src/app/api/admin/analytics/devices/route.ts
@@ -9,7 +9,7 @@ import { requireAdmin } from "@/lib/api-auth";
  * Returns organic traffic breakdown by device type (DESKTOP, MOBILE, TABLET)
  * from Google Search Console.
  *
- * @auth Requires Cognito JWT with `admin` group (401 / 403).
+ * @auth Requires admin session or Bearer JWT with `admin` group (401 / 403).
  * @returns 503 if GSC credentials are not configured in SSM.
  */
 export async function GET(request: NextRequest) {

--- a/src/app/api/admin/analytics/products/route.ts
+++ b/src/app/api/admin/analytics/products/route.ts
@@ -10,7 +10,7 @@ import { requireAdmin } from "@/lib/api-auth";
  * Filters pages by URL pattern (default: "/store/").
  * `limit` is clamped to 1–100 (default 50). Non-numeric values fall back to 50.
  *
- * @auth Requires Cognito JWT with `admin` group (401 / 403).
+ * @auth Requires admin session or Bearer JWT with `admin` group (401 / 403).
  * @returns 503 if GSC credentials are not configured in SSM.
  */
 export async function GET(request: NextRequest) {

--- a/src/app/api/admin/analytics/query-pages/route.ts
+++ b/src/app/api/admin/analytics/query-pages/route.ts
@@ -10,7 +10,7 @@ import { requireAdmin } from "@/lib/api-auth";
  * Useful for detecting keyword cannibalization and mismatched landing pages.
  * `limit` is clamped to 1–500 (default 100). Non-numeric values fall back to 100.
  *
- * @auth Requires Cognito JWT with `admin` group (401 / 403).
+ * @auth Requires admin session or Bearer JWT with `admin` group (401 / 403).
  * @returns 503 if GSC credentials are not configured in SSM.
  */
 export async function GET(request: NextRequest) {

--- a/src/app/api/admin/analytics/search-intent/route.ts
+++ b/src/app/api/admin/analytics/search-intent/route.ts
@@ -9,7 +9,7 @@ import { requireAdmin } from "@/lib/api-auth";
  * Returns keywords grouped by search intent: brand, product, informational, navigational.
  * Helps understand whether organic traffic is purchase-intent or browsing.
  *
- * @auth Requires Cognito JWT with `admin` group (401 / 403).
+ * @auth Requires admin session or Bearer JWT with `admin` group (401 / 403).
  * @returns 503 if GSC credentials are not configured in SSM.
  */
 export async function GET(request: NextRequest) {

--- a/src/app/api/agent/book/route.ts
+++ b/src/app/api/agent/book/route.ts
@@ -8,7 +8,7 @@
  *   2. Confirm: POST { confirm: true, start, end, notes? }
  *      → 200 { status: "confirmed", eventId, meetingLink, slot }
  *
- * Auth: requires a valid Cognito ID token via Bearer header. The booking is
+ * Auth: requires a valid ID token via Bearer header. The booking is
  * always made on behalf of the authenticated email — the model cannot
  * override it.
  */


### PR DESCRIPTION
## Summary
- 5 analytics routes + `agent/book/route.ts`: replaced `@auth Requires Cognito JWT` with `Requires admin session or Bearer JWT with admin group` — matches what `requireAdmin()` / `requireAuth()` in `api-auth.ts` actually enforce (provider-agnostic: Cognito OR Keycloak).

## Test plan
- [ ] Comment-only change — no functional impact
- [ ] Passes existing unit tests

https://claude.ai/code/session_01PHsA9s3tK2thgSJVwEGuWq

---
_Generated by [Claude Code](https://claude.ai/code/session_01PHsA9s3tK2thgSJVwEGuWq)_