### PR TITLE
re-trigger k3s-ssh-restart — cluster apiserver still down (01:10Z)

### DIFF
--- a/.github/workflows/k3s-ssh-restart.yml
+++ b/.github/workflows/k3s-ssh-restart.yml
@@ -21,6 +21,8 @@ name: k3s-ssh-restart — recover k3s API server via SSH when cluster tools fail
 # unreachable (autoheal deploy stuck on "wait for cluster API"), and Cloudflare
 # returns 530 for auth/pi-origin/grafana (all omv-fronted services). Lambda
 # cloudless.gr unaffected. SSH-restart k3s and wait for the apiserver.
+# Re-triggered 2026-06-03T01:10Z — cluster still unreachable (i/o timeout on 6443)
+# after 00:08Z outage; all diagnostic workflows timed out; SSH-restart again.
 
 on:
   push:


### PR DESCRIPTION
Adds a comment to k3s-ssh-restart.yml to re-trigger the path-filter push, recovering the k3s apiserver that has been unreachable since 00:08Z (i/o timeout on 100.113.41.119:6443). All diagnostic workflows (cluster-doctor, app-auth-doctor, keycloak-full-verify) timed out against the offline apiserver.

---
_Generated by [Claude Code](https://claude.ai/code/session_013sTDMVEYibee8tbXxrwjzo)_