### PR TITLE
docs: add optional Cognito env vars to .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,17 +12,27 @@ AWS_SECRET_ACCESS_KEY=your-secret-access-key
 # SSM prefix for production secrets (set by SST deploy — do not set locally)
 SSM_PREFIX=/cloudless/production
 
-# ── Keycloak (auth) ───────────────────────────────────────────────────────────
+# ── Auth (next-auth v5 — Keycloak or Cognito) ────────────────────────────────
+# next-auth session encryption secret — generate with: openssl rand -hex 32
+AUTH_SECRET=your-auth-secret-here
+AUTH_URL=http://localhost:4000
+AUTH_TRUST_HOST=true
+
+# ── Keycloak (default OIDC provider) ─────────────────────────────────────────
 # Server-side vars (not exposed to the browser)
 KEYCLOAK_ISSUER=https://auth.cloudless.gr/realms/master
 KEYCLOAK_CLIENT_ID=cloudless-app
 KEYCLOAK_CLIENT_SECRET=your-keycloak-client-secret
 # Build-time public var baked into the Next.js bundle (used by the login button)
 NEXT_PUBLIC_KEYCLOAK_ISSUER=https://auth.cloudless.gr/realms/master
-# next-auth session encryption secret — generate with: openssl rand -hex 32
-AUTH_SECRET=your-auth-secret-here
-AUTH_URL=http://localhost:4000
-AUTH_TRUST_HOST=true
+
+# ── Cognito (optional — overrides Keycloak when COGNITO_ISSUER is set) ───────
+# Set these to switch auth to AWS Cognito (the always-up serverless path).
+# Leave unset to use the Keycloak provider above.
+# COGNITO_ISSUER=https://cognito-idp.us-east-1.amazonaws.com/us-east-1_XXXXXXXXX
+# COGNITO_CLIENT_ID=your-cognito-app-client-id
+# COGNITO_CLIENT_SECRET=your-cognito-app-client-secret
+# COGNITO_DOMAIN=https://your-pool.auth.us-east-1.amazoncognito.com
 
 # ── SES (transactional email) ──────────────────────────────────────────────────
 SES_FROM_EMAIL=hello@cloudless.gr


### PR DESCRIPTION
## Summary
- `auth.ts` now supports dual-provider (Cognito wins when `COGNITO_ISSUER` is set, else Keycloak), but the four Cognito env vars were missing from `.env.example`.
- Added `COGNITO_ISSUER`, `COGNITO_CLIENT_ID`, `COGNITO_CLIENT_SECRET`, `COGNITO_DOMAIN` as commented-out optional entries.
- Reorganised the auth block so shared `AUTH_SECRET`/`AUTH_URL`/`AUTH_TRUST_HOST` vars come first, followed by the Keycloak section, then the optional Cognito section.

## Test plan
- [ ] Docs-only change — no functional impact

https://claude.ai/code/session_01PHsA9s3tK2thgSJVwEGuWq

---
_Generated by [Claude Code](https://claude.ai/code/session_01PHsA9s3tK2thgSJVwEGuWq)_