### PR TITLE
chore: reflect optional Cognito status in next.config.ts and check-services.js

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -98,13 +98,6 @@ const nextConfig: NextConfig = {
   },
   experimental: {
     // Tree-shake heavy barrel packages — reduces client bundle for GSAP, cmdk, etc.
-    // NOTE: aws-amplify is intentionally NOT in this list. Turbopack's
-    // optimizePackageImports rewrites `import { Amplify } from "aws-amplify"`
-    // and `import { signIn } from "aws-amplify/auth"` to different submodule
-    // paths whose Amplify singletons can end up *separate*, so the
-    // configure() that ran via the first path is invisible to the auth
-    // helpers loaded via the second — surfacing "Auth UserPool not configured"
-    // at signIn time even when configure provably ran.
     optimizePackageImports: ["gsap", "cmdk", "lenis", "lucide-react", "three", "@react-three/drei"],
   },
 };

--- a/scripts/check-services.js
+++ b/scripts/check-services.js
@@ -1,5 +1,6 @@
 // Service connectivity check script for Cloudless.gr
-// Checks actual connectivity for AWS SSM, Cognito, SES, Stripe, Notion, HubSpot, Google Calendar, Slack, Sentry
+// Checks actual connectivity for AWS SSM, SES, Stripe, Notion, HubSpot, Google Calendar, Slack, Sentry,
+// Keycloak OIDC (when KEYCLOAK_ISSUER is set), and Cognito (when COGNITO_ISSUER is set).
 
 const fs = require('fs');
 const path = require('path');
@@ -85,6 +86,10 @@ async function checkGoogleCalendar() {
 }
 
 async function checkCognito() {
+  if (!process.env.COGNITO_ISSUER) {
+    console.log('  (Cognito: skipped — COGNITO_ISSUER not set; Keycloak is the active provider)');
+    return;
+  }
   const {
     CognitoIdentityProviderClient,
     ListUserPoolsCommand,
@@ -92,6 +97,16 @@ async function checkCognito() {
   const region = process.env.AWS_REGION || 'us-east-1';
   const client = new CognitoIdentityProviderClient({ region });
   await client.send(new ListUserPoolsCommand({ MaxResults: 1 }));
+}
+
+async function checkKeycloak() {
+  const issuer = process.env.KEYCLOAK_ISSUER;
+  if (!issuer) {
+    console.log('  (Keycloak: skipped — KEYCLOAK_ISSUER not set)');
+    return;
+  }
+  const res = await fetch(`${issuer}/.well-known/openid-configuration`, { signal: AbortSignal.timeout(5000) });
+  if (!res.ok) throw new Error(`OIDC discovery returned HTTP ${res.status}`);
 }
 
 async function checkSES() {
@@ -142,7 +157,8 @@ async function main() {
     [checkHubSpot, 'HubSpot', false],
     [checkNotion, 'Notion', false],
     [checkGoogleCalendar, 'Google Calendar', false],
-    [checkCognito, 'Cognito', true],
+    [checkKeycloak, 'Keycloak', false],
+    [checkCognito, 'Cognito', false],
     [checkSES, 'SES', true],
     [checkSSM, 'SSM', true],
     [checkSentry, 'Sentry', false],


### PR DESCRIPTION
## Summary
- `next.config.ts`: removed stale 7-line comment explaining why `aws-amplify` isn't in `optimizePackageImports` — the package is no longer in the project at all
- `scripts/check-services.js`: 
  - `checkCognito` now skips gracefully when `COGNITO_ISSUER` is not set (Keycloak is the active provider in that case); downgraded from `required: true` → `required: false` since Cognito is optional
  - Added `checkKeycloak` that validates OIDC discovery endpoint when `KEYCLOAK_ISSUER` is set; also `required: false`
  - Updated top-of-file comment to list Keycloak and conditional Cognito

## Test plan
- [ ] No functional impact on production app
- [ ] `scripts/check-services.js` logic: when neither `COGNITO_ISSUER` nor `KEYCLOAK_ISSUER` is set, both auth checks print a skip message and pass

https://claude.ai/code/session_01PHsA9s3tK2thgSJVwEGuWq

---
_Generated by [Claude Code](https://claude.ai/code/session_01PHsA9s3tK2thgSJVwEGuWq)_