### PR TITLE
docs: update README and ARCHITECTURE for Keycloak + next-auth migration

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -96,7 +96,7 @@ src/
 │   │   │   ├── [id]/page.tsx     ← Product detail + JSON-LD
 │   │   │   └── success/          ← Order confirmation page
 │   │   ├── contact/              ← Contact form (SES + Slack + HubSpot + Notion)
-│   │   ├── auth/                 ← Login · Signup · Forgot Password (Cognito)
+│   │   ├── auth/                 ← Login · Signup · Forgot Password (Keycloak + next-auth)
 │   │   ├── dashboard/            ← Customer portal (auth-protected)
 │   │   │   ├── page.tsx          ← Personalized overview
 │   │   │   ├── profile/          ← Edit name, company, phone
@@ -112,7 +112,7 @@ src/
 │   │       ├── notion/           ← Notion DB explorer (blog, docs, tasks, projects)
 │   │       ├── notifications/    ← Slack test panel
 │   │       ├── settings/         ← App config viewer
-│   │       └── users/            ← Cognito user management
+│   │       └── users/            ← Keycloak user management
 │   └── api/                      ← API Routes (server-only)
 │       ├── contact/              ← POST: SES + Slack + HubSpot + Notion
 │       ├── checkout/             ← POST: Stripe checkout session
@@ -143,7 +143,7 @@ src/
 │           ├── notion/           ← Notion DB queries: blog, docs, tasks, projects, submissions
 │           ├── ops/errors/       ← Sentry issues
 │           ├── orders/           ← Stripe orders summary
-│           └── users/            ← Cognito user list
+│           └── users/            ← Keycloak user list
 │
 ├── components/                   ← Shared UI components
 │   ├── Navbar.tsx
@@ -164,7 +164,7 @@ src/
 │       └── AddToCartButton.tsx
 │
 ├── context/
-│   ├── AuthContext.tsx            ← Cognito auth state + useAuth() hook
+│   ├── AuthContext.tsx            ← Auth state (next-auth session) + useAuth() hook
 │   ├── CartContext.tsx            ← Shopping cart (useReducer, in-memory)
 │   └── CookieConsentContext.tsx
 │
@@ -221,8 +221,9 @@ src/
 | `SES_FROM_EMAIL` | String | All outbound emails |
 | `SES_TO_EMAIL` | String | Contact form recipient |
 | `AWS_SES_REGION` | String | SES client config |
-| `COGNITO_USER_POOL_ID` | String | API JWT verification |
-| `COGNITO_CLIENT_ID` | String | API JWT verification |
+| `KEYCLOAK_ISSUER` | String | Keycloak realm URL (JWKS source) |
+| `KEYCLOAK_CLIENT_ID` | String | Keycloak app client (JWT aud) |
+| `KEYCLOAK_CLIENT_SECRET` | SecureString | Keycloak app client secret |
 | `SLACK_BOT_TOKEN` | SecureString | Slack API calls |
 | `SLACK_SIGNING_SECRET` | SecureString | Inbound Slack verification |
 | `SLACK_WEBHOOK_URL` | SecureString | Outbound Slack notifications |
@@ -242,8 +243,7 @@ src/
 |---|---|
 | `NEXT_PUBLIC_SITE_URL` | `https://cloudless.gr` |
 | `NEXT_PUBLIC_STAGE` | `production` |
-| `NEXT_PUBLIC_COGNITO_USER_POOL_ID` | `us-east-1_JQWwFbO9a` |
-| `NEXT_PUBLIC_COGNITO_CLIENT_ID` | `2qq6i24oc48391cmuv4kfl1rm2` |
+| `NEXT_PUBLIC_KEYCLOAK_ISSUER` | `https://auth.cloudless.gr/realms/master` |
 | `NOTION_BLOG_DB_ID` | (Notion DB ID — non-secret) |
 | `NOTION_SUBMISSIONS_DB_ID` | (Notion DB ID — non-secret) |
 | `NOTION_DOCS_DB_ID` | (Notion DB ID — non-secret) |
@@ -256,37 +256,42 @@ src/
 ## 5. Authentication & Authorization
 
 ```
-Browser (Amplify v6)
+Browser
       │
-      │  signIn(email, password)
+      │  click "Sign in" → redirect to Keycloak hosted UI
       ▼
-AWS Cognito User Pool (us-east-1_JQWwFbO9a)
+Keycloak (auth.cloudless.gr)  —  Authorization Code + PKCE
       │
-      │  JWT tokens (ID + Access + Refresh)
+      │  code → /api/auth/callback/keycloak
+      ▼
+next-auth v5 (src/lib/auth.ts)
+      │  exchanges code → access_token + id_token + refresh_token
+      │  stores in signed+encrypted session cookie
       ▼
 AuthContext.tsx  ──► useAuth() hook everywhere
 
-User Groups:
+User Groups (groups claim in id_token):
   - (none)  → regular user → /dashboard
   - admin   → /admin + /dashboard
 
 Page Route Protection (src/proxy.ts middleware):
   - All requests to /dashboard/* and /admin/* without a valid
-    Cognito cookie are redirected to /auth/login server-side.
+    next-auth session cookie are redirected to /auth/login server-side.
   - Locale-prefixed paths (e.g. /en/dashboard, /fr/admin/orders) are
     normalized before auth checks, so localized routes follow the same
     protection rules.
-  - Admin paths with a valid cookie but no admin group are
+  - Admin paths with a valid session but no admin group are
     redirected to /dashboard (with locale preserved).
 
 API Route Protection (src/lib/api-auth.ts):
   requireAuth(req)   → 401 if missing/invalid JWT
   requireAdmin(req)  → 401/403 if not admin group
+  Provider: Keycloak by default; Cognito when COGNITO_ISSUER is set.
 
 JWT Verification (JWKS · RS256):
-  - Issuer:   https://cognito-idp.us-east-1.amazonaws.com/<pool>
-  - Audience: COGNITO_CLIENT_ID (rejects tokens for other apps)
-  - token_use: "id" required (access tokens explicitly rejected)
+  - Issuer:   KEYCLOAK_ISSUER or COGNITO_ISSUER
+  - Audience: KEYCLOAK_CLIENT_ID or COGNITO_CLIENT_ID
+  - Group membership: groups claim (Keycloak) or cognito:groups (Cognito)
   - Key rotation handled automatically (jose in-process JWKS cache)
 ```
 
@@ -315,7 +320,7 @@ graph TB
         UI["Next.js App<br/>React 19 + Tailwind 4"]
         SW["Service Worker<br/>PWA / Offline"]
         Cart["CartContext<br/>(in-memory)"]
-        Auth["AuthContext<br/>(Cognito Amplify v6)"]
+        Auth["AuthContext<br/>(next-auth v5 / Keycloak)"]
     end
 
     subgraph Routes["📡 API Routes (Lambda)"]
@@ -333,7 +338,7 @@ graph TB
     end
 
     subgraph AWS["☁️ AWS (us-east-1)"]
-        Cognito["Cognito<br/>User Pool"]
+        Keycloak["Keycloak<br/>(auth.cloudless.gr)"]
         SES["SES<br/>Transactional Email"]
         SSM["SSM Parameter Store<br/>/cloudless/production/*"]
         CF["CloudFront CDN"]
@@ -374,7 +379,7 @@ graph TB
 
     CF --> Lambda
     UI --> Routes
-    Auth --> Cognito
+    Auth --> Keycloak
     Routes --> SSM
 
     RC --> SES
@@ -493,7 +498,7 @@ graph TB
 | `GET /api/admin/notion/tasks` | Notion | Tasks DB |
 | `GET /api/admin/ops/errors` | Sentry | Unresolved issues |
 | `GET /api/admin/orders` | Stripe | Orders summary |
-| `GET /api/admin/users` | Cognito | User list |
+| `GET /api/admin/users` | Keycloak | User list |
 
 ---
 
@@ -502,7 +507,8 @@ graph TB
 ```
 Integration            Status         Auth Method                    Used In
 ────────────────────────────────────────────────────────────────────────────────────
-AWS Cognito            ✅ Live         JWKS / Amplify v6              Auth, all protected routes
+Keycloak               ✅ Live         OIDC / next-auth v5            Auth, all protected routes
+AWS Cognito            🔶 Optional     OIDC (when COGNITO_ISSUER set) Auth fallback (serverless path)
 AWS SES                ✅ Live         IAM (Lambda role)              Contact, subscribe, webhooks
 AWS SSM                ✅ Live         IAM (Lambda role)              All API routes (secrets)
 Stripe                 ✅ Live         Secret key (SSM)               Store, checkout, webhooks
@@ -543,10 +549,11 @@ All modules live in `src/lib/`. They are **server-side only** unless noted.
 
 | File | Purpose |
 |---|---|
-| `ssm-config.ts` | Loads all secrets from SSM (5-min TTL cache, singleton `SSMClient`, stale-cache fallback on error). Validates `STRIPE_SECRET_KEY`, `STRIPE_WEBHOOK_SECRET`, `COGNITO_USER_POOL_ID`, `COGNITO_CLIENT_ID` as required. `SSM_PREFIX` uses `||` so an empty string falls back to `/cloudless/production`. |
+| `ssm-config.ts` | Loads all secrets from SSM (5-min TTL cache, singleton `SSMClient`, stale-cache fallback on error). Validates `STRIPE_SECRET_KEY` and `STRIPE_WEBHOOK_SECRET` as required. `SSM_PREFIX` uses `||` so an empty string falls back to `/cloudless/production`. |
 | `integrations.ts` | Reads integration keys from env. Provides `isConfigured(...keys)` guard. |
-| `api-auth.ts` | `requireAuth()` / `requireAdmin()` — RS256 JWT verification against Cognito JWKS; enforces issuer, audience (client ID), and `token_use: "id"`. |
-| `amplify-config.ts` | Configures Amplify v6 Cognito client (singleton, client-side). |
+| `auth.ts` | next-auth v5 configuration — provider-agnostic (Keycloak default; Cognito when `COGNITO_ISSUER` is set). Handles token refresh and RP-Initiated Logout. |
+| `api-auth.ts` | `requireAuth()` / `requireAdmin()` — RS256 JWT verification against the active provider's JWKS; enforces issuer, audience (client ID), and group membership claims. |
+| `keycloak-auth.ts` | Keycloak auth adapter — implements the `AuthContext` interface using next-auth `signIn`/`signOut`/`getSession`. |
 
 ### Email
 
@@ -625,7 +632,7 @@ All modules live in `src/lib/`. They are **server-side only** unless noted.
 | `server-locale.ts` | `getServerLocale()` — reads `NEXT_LOCALE` cookie server-side. |
 | `use-locale.ts` | `useCurrentLocale()` hook for client components. |
 | `structured-data.ts` | JSON-LD schemas: Organization, BreadcrumbList, FAQPage, Product, BlogPosting. |
-| `fetch-with-auth.ts` | `fetchWithAuth()` — adds Cognito JWT to requests from client components. |
+| `fetch-with-auth.ts` | `fetchWithAuth()` — adds next-auth `idToken` as Bearer header to authenticated API requests from client components. |
 | `sound-effects.ts` | Browser audio effects (UI easter eggs). |
 
 ---
@@ -799,7 +806,7 @@ pnpm test:e2e      # Playwright E2E
 | `e2e/*.spec.ts` | Full browser flows via Playwright + axe-core accessibility |
 
 ### Key testing rules
-- AWS services (SES, SSM, Cognito) are mocked in unit tests
+- AWS services (SES, SSM) are mocked in unit tests
 - `resetSsmCache()` + `vi.stubEnv()` pattern for per-test config
 - `NODE_ENV=test` skips SSM entirely — reads from `process.env`
 
@@ -872,7 +879,7 @@ The analysis runs **in addition to** the following static-analysis workflows def
 ### ✅ Fully Live
 
 - Next.js app deployed on AWS Lambda via SST v4
-- Cognito auth (login, signup, forgot password, admin group)
+- Keycloak + next-auth v5 (login, signup, forgot password, admin group)
 - Stripe store, checkout, subscriptions, webhooks
 - AWS SES email (contact form, order confirmation, newsletter)
 - SES suppression list (unsubscribe)

--- a/README.md
+++ b/README.md
@@ -25,41 +25,34 @@ Translation dictionaries live in `src/locales/en.json` and `src/locales/el.json`
 sequenceDiagram
     participant U as User
     participant App as Next.js Client
-    participant Cognito as AWS Cognito
+    participant KC as Keycloak (auth.cloudless.gr)
 
-    U->>App: Enter email + password
-    App->>Cognito: signIn(email, password)
-    alt FORCE_CHANGE_PASSWORD
-        Cognito-->>App: Challenge
-        App->>U: Show new password form
-        U->>App: Submit new password
-        App->>Cognito: confirmSignIn(newPassword)
-    end
-    alt Unverified user
-        Cognito-->>App: UserNotConfirmedException
-        App->>U: Redirect to verify page
-    end
-    Cognito-->>App: JWT tokens
-    App->>App: Decode JWT, check cognito:groups
-    alt Admin group
+    U->>App: Click "Sign in"
+    App->>KC: Authorization Code + PKCE redirect
+    KC-->>U: Hosted login page
+    U->>KC: Enter credentials
+    KC-->>App: Authorization code → /api/auth/callback/keycloak
+    App->>KC: Exchange code for tokens
+    KC-->>App: access_token + id_token + refresh_token
+    App->>App: Decode id_token, check groups claim
+    alt admin group
         App->>U: Show admin panel
-    else Regular user
+    else regular user
         App->>U: Show dashboard
     end
 ```
 
-User authentication is powered by **AWS Cognito** via **Amplify v6**. The `AuthProvider` in `src/context/AuthContext.tsx` wraps the entire app and exposes sign-in, sign-up, sign-out, password reset, and admin detection through the `useAuth()` hook.
+User authentication is powered by **Keycloak** (self-hosted at `auth.cloudless.gr`) via **next-auth v5**. The `AuthProvider` in `src/context/AuthContext.tsx` wraps the entire app and exposes sign-in, sign-out, and admin detection through the `useAuth()` hook. The auth backend is provider-agnostic: Keycloak is the default; AWS Cognito is used when `COGNITO_ISSUER` is set (serverless path).
 
 Key features of the auth system:
 
-- Graceful configuration failure — if Cognito env vars are missing, the app sets a `configError` state instead of crashing.
-- Friendly error messages — raw Cognito exceptions (e.g. `NotAuthorizedException`, `CodeMismatchException`) are mapped to plain-language strings via `friendlyAuthError()`.
-- Sign-in edge case handling — `FORCE_CHANGE_PASSWORD` challenge, unverified users (`CONFIRM_SIGN_UP` → redirect to verify), and `UserAlreadyAuthenticatedException` (auto sign-out + retry) are all handled.
-- Password manager support — all auth forms include `autoComplete` attributes (`email`, `current-password`, `new-password`, `one-time-code`).
-- Admin detection — client-side via decoded JWT `cognito:groups` claim. Admin routes redirect non-admins to the dashboard.
+- **OIDC Authorization Code + PKCE** — login redirects to Keycloak's hosted UI; tokens are exchanged server-side and stored in an encrypted next-auth session cookie.
+- **Refresh-token rotation** — the server transparently refreshes expired access tokens before they reach API routes.
+- **RP-Initiated Logout** — sign-out calls Keycloak's end-session endpoint so the SSO session is fully terminated.
+- Admin detection — server-side via `groups` claim in the next-auth JWT (`["admin"]`). Admin routes are checked in `src/proxy.ts` middleware before rendering.
 - Route protection is **server-side** via `src/proxy.ts` middleware (all unauthenticated requests to `/dashboard` and `/admin` are redirected to login before the page renders) and additionally client-side via layout guards. Locale-prefixed routes (e.g. `/en/dashboard`, `/el/admin/orders`) are normalized before authorization checks.
 - Theme preference (`dark` / `light` / `system`) is exposed via a navbar `ThemeSwitcher` (popover on desktop, inline radios on mobile) and the dashboard settings form. Anonymous visitors persist to `localStorage["cloudless-theme-pref"]`; signed-in users also sync to `user.preferences.theme`. Selection priority: admin path (locked dark) → user preference → localStorage → route default. Cross-tab sync via the `storage` event. See `docs/design-system-v2.md` § "Theme switcher".
-- JWT hardening — `verifyToken` in `src/lib/api-auth.ts` enforces `issuer`, `audience` (Cognito client ID), and `token_use: "id"` claims so only ID tokens issued for this app are accepted.
+- JWT hardening — `api-auth.ts` validates Bearer JWTs against the active provider's JWKS endpoint, enforcing `issuer`, `audience`, and group membership claims.
 
 ## Architecture
 
@@ -84,7 +77,7 @@ graph TB
     end
 
     subgraph AWS["AWS"]
-        Cognito["Cognito Auth"]
+        Keycloak["Keycloak OIDC"]
         SES["SES Email"]
         SSM["SSM Parameter Store"]
     end
@@ -97,7 +90,7 @@ graph TB
     end
 
     UI --> Routes
-    UI --> Cognito
+    UI --> Keycloak
     Routes --> SSM
     Contact --> SES
     Contact --> Slack
@@ -125,10 +118,10 @@ src/
 │   ├── blog/               # Blog listing & [slug] detail pages
 │   ├── store/              # E-commerce store, [id] detail, success page
 │   ├── contact/page.tsx    # Contact form (AWS SES)
-│   ├── auth/               # Authentication pages (Cognito)
-│   │   ├── login/page.tsx       # Login with FORCE_CHANGE_PASSWORD support
-│   │   ├── signup/page.tsx      # Two-step: signup form → email verification
-│   │   └── forgot-password/page.tsx # Two-step: email → code + new password
+│   ├── auth/               # Authentication pages (Keycloak + next-auth)
+│   │   ├── login/page.tsx       # Login — redirects to Keycloak hosted UI
+│   │   ├── signup/page.tsx      # Sign-up — redirects to Keycloak registration
+│   │   └── forgot-password/page.tsx # Forgot password — Keycloak self-service flow
 │   ├── dashboard/          # Client dashboard (auth-protected)
 │   ├── admin/              # Admin panel (admin-group-only)
 │   ├── not-found.tsx       # Custom 404
@@ -148,9 +141,10 @@ src/
 │   └── store/              # Cart button, slide-over, grid, add-to-cart
 ├── context/
 │   ├── CartContext.tsx      # Shopping cart state (useReducer)
-│   └── AuthContext.tsx      # Cognito auth state with friendly error mapping
+│   └── AuthContext.tsx      # Auth state (next-auth session) with useAuth() hook
 └── lib/
-    ├── amplify-config.ts   # Amplify v6 Cognito configuration (singleton)
+    ├── keycloak-auth.ts    # Keycloak auth adapter (implements AuthContext interface)
+    ├── auth.ts             # next-auth v5 config (Keycloak + optional Cognito)
     ├── ssm-config.ts       # AWS SSM Parameter Store config loader
     ├── integrations.ts     # Third-party integration config (Slack tokens)
     ├── stripe.ts           # Stripe client initialization
@@ -251,8 +245,8 @@ This project uses **no `.env` files** in production. All secrets are stored in *
 |---|---|---|
 | `STRIPE_SECRET_KEY` | SecureString | Stripe API secret key |
 | `STRIPE_WEBHOOK_SECRET` | SecureString | Stripe webhook signature secret |
-| `COGNITO_USER_POOL_ID` | String | Cognito pool for JWT verification |
-| `COGNITO_CLIENT_ID` | String | Cognito app client for JWT `aud` check |
+| `KEYCLOAK_ISSUER` | String | Keycloak realm URL for JWKS verification |
+| `KEYCLOAK_CLIENT_ID` | String | Keycloak app client for JWT `aud` check |
 
 ### All SSM parameters
 
@@ -264,8 +258,9 @@ This project uses **no `.env` files** in production. All secrets are stored in *
 | `STRIPE_SECRET_KEY`      | SecureString | Stripe API secret key         |
 | `STRIPE_PUBLISHABLE_KEY` | SecureString | Stripe publishable key        |
 | `STRIPE_WEBHOOK_SECRET`  | SecureString | Stripe webhook signature       |
-| `COGNITO_USER_POOL_ID`   | String       | Cognito pool ID               |
-| `COGNITO_CLIENT_ID`      | String       | Cognito app client ID         |
+| `KEYCLOAK_ISSUER`        | String       | Keycloak realm URL            |
+| `KEYCLOAK_CLIENT_ID`     | String       | Keycloak app client ID        |
+| `KEYCLOAK_CLIENT_SECRET` | SecureString | Keycloak app client secret    |
 | `SLACK_BOT_TOKEN`        | SecureString | Slack bot OAuth token         |
 | `SLACK_SIGNING_SECRET`   | SecureString | Slack request signing secret  |
 | `SLACK_WEBHOOK_URL`      | SecureString | Slack incoming webhook URL    |
@@ -325,7 +320,7 @@ All Stripe operations use a lazy singleton from `src/lib/stripe.ts` (`getStripe(
 - Server-side price resolution only — client-submitted prices are ignored; all amounts come from the internal product catalog.
 - Quantity clamped to 1-99.
 - Origin validated against an allowlist to prevent open redirect on `success_url`/`cancel_url`.
-- If the user is authenticated (Bearer token in `Authorization` header), the checkout session is pre-filled with `customer_email` and `metadata.userId` to link the Stripe order to the Cognito account.
+- If the user is authenticated (Bearer token in `Authorization` header), the checkout session is pre-filled with `customer_email` and `metadata.userId` to link the Stripe order to the authenticated account.
 - Every session includes `metadata.source = "cloudless.gr"` for tracing.
 
 ### Webhook (`POST /api/webhooks/stripe`)
@@ -501,7 +496,7 @@ This avoids noisy `LF will be replaced by CRLF` warnings and keeps diffs stable 
 - React 19.2.4
 - TypeScript 5
 - Tailwind CSS 4
-- AWS Cognito + Amplify v6 (authentication)
+- Keycloak + next-auth v5 (authentication)
 - AWS SES v2 (transactional email — contact, orders, newsletter, portal approvals)
 - AWS SSM Parameter Store (secrets)
 - Stripe (checkout & payments)


### PR DESCRIPTION
## Summary

Both `README.md` and `ARCHITECTURE.md` still described AWS Cognito + Amplify v6 as the auth system. This PR updates them to match the current Keycloak + next-auth v5 stack.

**README.md:**
- Auth sequence diagram: Cognito → Keycloak OIDC (Authorization Code + PKCE)
- Auth section prose: rewritten for next-auth v5 + Keycloak
- Architecture mermaid: Cognito node → Keycloak
- File tree: update `auth/` comments; replace `amplify-config.ts` with `keycloak-auth.ts` + `auth.ts`
- SSM params table: `COGNITO_USER_POOL_ID` → `KEYCLOAK_ISSUER`/`CLIENT_ID`/`CLIENT_SECRET`
- Checkout note: "Cognito account" → "authenticated account"
- Tech stack: "Cognito + Amplify v6" → "Keycloak + next-auth v5"

**ARCHITECTURE.md:**
- Auth section (§5): full rewrite of the flow diagram and JWT verification block
- Data flow mermaid (§6): `AuthContext (Cognito Amplify v6)` → `next-auth v5 / Keycloak`; `Cognito User Pool` → `Keycloak`
- API endpoint table: `/api/admin/users` tag Cognito → Keycloak
- Integration map (§8): Keycloak live + Cognito optional row
- SSM params: replace Cognito with Keycloak params; public env vars updated
- Library module table: `api-auth.ts` and `fetch-with-auth.ts` descriptions updated; `amplify-config.ts` removed, `auth.ts` + `keycloak-auth.ts` added
- Testing notes: Cognito removed from mocked services list
- What's Working (§16): Cognito auth → Keycloak + next-auth v5

## Test plan
- [ ] Docs-only change — no functional impact

https://claude.ai/code/session_01PHsA9s3tK2thgSJVwEGuWq

---
_Generated by [Claude Code](https://claude.ai/code/session_01PHsA9s3tK2thgSJVwEGuWq)_