### PR TITLE
ops: retry k3s SSH restart (SSH handshake timeout on prior attempt)

### DIFF
--- a/.github/workflows/k3s-ssh-restart.yml
+++ b/.github/workflows/k3s-ssh-restart.yml
@@ -23,6 +23,9 @@ name: k3s-ssh-restart — recover k3s API server via SSH when cluster tools fail
 # cloudless.gr unaffected. SSH-restart k3s and wait for the apiserver.
 # Re-triggered 2026-06-03T01:10Z — cluster still unreachable (i/o timeout on 6443)
 # after 00:08Z outage; all diagnostic workflows timed out; SSH-restart again.
+# Re-triggered 2026-06-03T01:13Z — prior SSH restart failed: SSH handshake timeout
+# on port 22 despite TCP connection accepted; port 6443 never came back after 90s.
+# Pi may be under extreme load; retrying. If same failure, Pi needs power cycle.
 
 on:
   push:


### PR DESCRIPTION
Retry trigger for k3s-ssh-restart.yml. Previous run (01:07Z June 3) SSH timed out despite port 22 accepting TCP connections; port 6443 never came back after full 90s wait. Pi may be under extreme load — retrying. If this fails the same way, Pi needs a power cycle.

---
_Generated by [Claude Code](https://claude.ai/code/session_013sTDMVEYibee8tbXxrwjzo)_