### PR TITLE
docs: update security/sync/design docs for Keycloak dual-provider auth

### DIFF
--- a/docs/design-system-v2.md
+++ b/docs/design-system-v2.md
@@ -125,7 +125,7 @@ The route-driven default in `themeForRoute()` is what an unfamiliar visitor sees
 ```
 admin path (locked dark)
   ↓
-user.preferences.theme   (authenticated; lives in Cognito + AuthContext)
+user.preferences.theme   (authenticated; lives in next-auth session + AuthContext)
   ↓
 localStorage["cloudless-theme-pref"]   (anonymous override)
   ↓

--- a/docs/pi-cloud-sync.md
+++ b/docs/pi-cloud-sync.md
@@ -30,7 +30,7 @@ This doc is the contract for what's kept in sync, how, and what to monitor.
 | **Public env** | `NEXT_PUBLIC_*` baked into the image at build time (see [Dockerfile](../Dockerfile)). | Identical because identical image. |
 | **Runtime secrets** | Both read from SSM at `/cloudless/production/*` (see [sst.config.ts:31-32](../sst.config.ts)). | Pi must have `ssm:GetParametersByPath` on that prefix via `cloudless-pi-standby`. |
 | **Notion content** | Both fetch live from Notion API; ISR per-process. | Pi cache lags by up to its ISR TTL after Notion edits. |
-| **Cognito sessions** | Same User Pool; JWT verification fetches JWKS from Cognito. | None — federation is shared. |
+| **Auth sessions** | Both verify JWTs against the same provider JWKS (Keycloak or Cognito depending on env). | Pi must have `KEYCLOAK_ISSUER`/`KEYCLOAK_CLIENT_*` in SSM (or Cognito vars if using Cognito path). |
 | **Webhooks (Stripe/Notion/HubSpot)** | Hit `cloudless.gr` and route to whichever is live. | Pi must hold the same webhook secrets in SSM. |
 | **TLS cert** | Cloud uses ACM; Pi uses its own (Let's Encrypt / cert-manager). | Independent expiry. **Highest silent-failure risk.** |
 | **Outbound IP / source reputation** | Differs (CloudFront IP vs WAN `150.228.63.192`). | Anything with IP allowlists — outbound APIs, SES — must allowlist both. |

--- a/docs/security.md
+++ b/docs/security.md
@@ -10,7 +10,7 @@ same image, so all controls below apply identically to both).
 |---|---|---|
 | Transport | HTTPS at every public edge (ACM certs on CloudFront + APIGW), HSTS preload | `src/proxy.ts`, AWS infra |
 | Transport | Production HTTP→HTTPS 308 redirect | `src/proxy.ts` |
-| Auth (user) | Cognito JWT, RS256-verified against pool JWKS, ID-token-only via `token_use` claim | `src/lib/api-auth.ts` |
+| Auth (user) | OIDC JWT (Keycloak or Cognito), RS256-verified against provider JWKS | `src/lib/api-auth.ts` |
 | Auth (admin) | All 71 `/api/admin/*` routes gated by `requireAdmin`/`requireAuth` | `src/app/api/admin/**` |
 | Auth (cron) | `Bearer ${CRON_SECRET}`, constant-time compare | `src/lib/cron-auth.ts` |
 | Auth (webhook) | Stripe `constructEvent`, HubSpot v3 timing-safe HMAC, Notion HMAC, Pi-sync HMAC-SHA256 | `src/app/api/webhooks/**`, `.github/workflows/build-pi-image.yml` |
@@ -33,12 +33,13 @@ same image, so all controls below apply identically to both).
 
 ### Authentication
 
-- **User auth** uses Cognito User Pool `us-east-1_JQWwFbO9a`. ID tokens (not
-  access tokens) are required — checked via the `token_use` claim. Signature
-  is verified against the pool's published JWKS (`createRemoteJWKSet`), with
+- **User auth** uses Keycloak (default, `auth.cloudless.gr` realm `master`) or
+  AWS Cognito (when `COGNITO_ISSUER` is set — serverless path). Tokens are
+  verified against the active provider's JWKS (`createRemoteJWKSet`), with
   issuer + audience asserted.
 - **Admin gate** — `requireAdmin()` decodes the verified token and asserts
-  the user is in the admin Cognito group. Used by every route under
+  the user is in the admin group (`groups` claim for Keycloak,
+  `cognito:groups` for Cognito). Used by every route under
   `src/app/api/admin/*` (verified by audit script in this repo).
 - **Admin UI guard** — `AdminLayoutClient` checks `isAdmin` from
   `AuthContext` client-side and immediately redirects to `/dashboard` for


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- `docs/security.md`: auth snapshot row updated from Cognito-only JWT to dual-provider OIDC; authentication section rewrites user auth bullet (Keycloak default + Cognito optional) and admin gate bullet (`groups` vs `cognito:groups` claim)
- `docs/pi-cloud-sync.md`: sync surface table auth row rewritten from `Cognito sessions` to `Auth sessions` with explicit Pi SSM requirements for both Keycloak and Cognito paths
- `docs/design-system-v2.md`: theme priority chain now references `next-auth session + AuthContext` instead of `Cognito + AuthContext`

## Test plan
- [ ] Docs-only change — no runtime behaviour affected
- [ ] Verify no stale "Cognito JWT" / "pool JWKS" / "token_use" references remain in the three files

https://claude.ai/code/session_01PHsA9s3tK2thgSJVwEGuWq
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01PHsA9s3tK2thgSJVwEGuWq)_