### PR TITLE
docs: replace stale Cognito JWT annotations across integration docs

### DIFF
--- a/docs/ACTIVECAMPAIGN.md
+++ b/docs/ACTIVECAMPAIGN.md
@@ -11,7 +11,7 @@ Cloudless uses ActiveCampaign for email campaign management, contact lists, and 
 ```
 Admin Browser
     │
-    └── fetchWithAuth() ── Cognito JWT ──► /api/admin/email/**
+    └── fetchWithAuth() ── Bearer JWT ──► /api/admin/email/**
                                                 │
                                         src/lib/activecampaign.ts
                                                 │

--- a/docs/AGENCY-HUB.md
+++ b/docs/AGENCY-HUB.md
@@ -65,7 +65,7 @@ The admin panel gains a **"Marketing Hub"** — a set of new sections alongside 
 ```
 Admin Browser
     │
-    ├── fetchWithAuth() ── Cognito JWT ──► /api/admin/campaigns/**
+    ├── fetchWithAuth() ── Bearer JWT ──► /api/admin/campaigns/**
     │                                           │
     │                                    lib/campaigns/
     │                                    ├── meta.ts         → Meta Marketing API v19

--- a/docs/AGENTS_ROADMAP.md
+++ b/docs/AGENTS_ROADMAP.md
@@ -53,7 +53,7 @@ Detail: see [`docs/ANTHROPIC.md`](ANTHROPIC.md#tools-phase-2a-of-docsagents_road
 
 Guardrails:
 
-- Auth required (Cognito ID token via Bearer). Email is forced to the authenticated user's email — the model cannot override it.
+- Auth required (Bearer JWT — authenticated user session). Email is forced to the authenticated user's email — the model cannot override it.
 - Rate-limited 5 / 10 min per IP for both propose and confirm.
 - Re-checks availability at confirm time (409 if slot no longer free).
 

--- a/docs/ANTHROPIC.md
+++ b/docs/ANTHROPIC.md
@@ -166,7 +166,7 @@ fields @timestamp, @message
 
 ## Admin AI Routes
 
-All require a valid Cognito JWT with the `admin` group. Return 503 when the API key is not configured.
+All require a valid admin session or Bearer JWT with the `admin` group. Return 503 when the API key is not configured.
 
 ### `POST /api/admin/ai/copy`
 

--- a/docs/GSC.md
+++ b/docs/GSC.md
@@ -85,7 +85,7 @@ GSC_SITE_URL=sc-domain:cloudless.gr
 
 ## Admin API Endpoints
 
-All endpoints require a valid Cognito JWT with the `admin` group (Bearer token in `Authorization` header). Returns 401/403 if unauthenticated. Returns 503 if GSC credentials are not configured.
+All endpoints require a valid admin session or Bearer JWT with the `admin` group. Returns 401/403 if unauthenticated. Returns 503 if GSC credentials are not configured.
 
 All responses include `fetchedAt: ISO8601` and `source: "google-search-console"`.
 
@@ -194,7 +194,7 @@ sequenceDiagram
     participant GSC as GSC Search Analytics API
 
     Admin->>Route: GET with Bearer token
-    Route->>Auth: Verify Cognito JWT
+    Route->>Auth: Verify JWT (requireAdmin)
     Auth-->>Route: ok: true / 401/403
 
     Route->>Route: Check GOOGLE_CLIENT_EMAIL in config
@@ -231,7 +231,7 @@ Test coverage (29 + 33 tests):
 
 ## Security Notes
 
-- **Auth required:** All analytics endpoints are protected by `requireAdmin()` (Cognito JWT with `admin` group). No public GSC data is exposed.
+- **Auth required:** All analytics endpoints are protected by `requireAdmin()` (JWT with `admin` group). No public GSC data is exposed.
 - **Read-only scope:** Token scoped to `webmasters.readonly` — cannot write to GSC.
 - **Shared service account:** Same `GOOGLE_PRIVATE_KEY` as Calendar — store as SecureString in SSM.
 - **Graceful degradation:** All functions catch errors and return `null` / `[]` — a GSC API failure never crashes the admin dashboard.

--- a/docs/HUBSPOT.md
+++ b/docs/HUBSPOT.md
@@ -454,7 +454,7 @@ Deals with no `amount` contribute `0` to the value totals. Returns zeroed stats 
 
 ### Pipeline API Routes
 
-All pipeline routes require a valid Cognito admin JWT (checked by `requireAdmin`) and return `503` when HubSpot is not configured.
+All pipeline routes require a valid admin session or Bearer JWT (checked by `requireAdmin`) and return `503` when HubSpot is not configured.
 
 | Route | Method | Description |
 |---|---|---|

--- a/docs/README.md
+++ b/docs/README.md
@@ -37,7 +37,7 @@
 
 ### Admin panel quick reference
 
-`/admin` is gated by Cognito admin-group membership (server **and** client). Key surfaces:
+`/admin` is gated by `admin` group membership verified server-side and client-side. Key surfaces:
 
 | Section | Path | Notes |
 |---|---|---|

--- a/docs/SENTRY.md
+++ b/docs/SENTRY.md
@@ -142,7 +142,7 @@ No PII leaves the runtime in Sentry events.
 
 ## Admin API Endpoints
 
-Both endpoints require a valid Cognito JWT with the `admin` group. Return 503 when `SENTRY_AUTH_TOKEN` is not configured.
+Both endpoints require a valid admin session or Bearer JWT with the `admin` group. Return 503 when `SENTRY_AUTH_TOKEN` is not configured.
 
 ### `GET /api/admin/ops/errors`
 
@@ -227,7 +227,7 @@ sequenceDiagram
     participant API as Sentry REST API
 
     Admin->>Route: GET with Bearer token
-    Route->>Auth: Verify Cognito JWT
+    Route->>Auth: Verify JWT (requireAdmin)
     Auth-->>Route: ok / 401
 
     Route->>Lib: await isSentryConfigured()
@@ -267,7 +267,7 @@ Test coverage (15 tests):
 
 ## Security Notes
 
-- **Auth required:** Both admin endpoints protected by `requireAdmin()` (Cognito JWT + `admin` group).
+- **Auth required:** Both admin endpoints protected by `requireAdmin()` (JWT with `admin` group).
 - **Token scopes:** `SENTRY_AUTH_TOKEN` needs `project:read` (list/get issues) and `project:write` (update status). Use an Internal Integration token in Sentry settings, not a personal auth token.
 - **Token in SSM SecureString:** Never commit `SENTRY_AUTH_TOKEN` — store as SecureString.
 - **503 guard fixed:** `isSentryConfigured()` is `async` — both routes use `await` to ensure the 503 path fires correctly when unconfigured.

--- a/docs/security/SECURITY_FIXES.md
+++ b/docs/security/SECURITY_FIXES.md
@@ -37,7 +37,7 @@ Fixed critical security vulnerabilities in user and admin API endpoints by addin
 **Solution:**
 - Added `requireAdmin()` check to verify:
   1. User has valid JWT token
-  2. User is in `admin` group (via `cognito:groups` claim)
+  2. User is in `admin` group (via `groups` / `cognito:groups` claim)
 - Returns 401 if no token, 403 if not admin
 - Frontend updated to send JWT tokens
 
@@ -67,7 +67,7 @@ Server-side authentication helper with utilities:
 ### `src/lib/fetch-with-auth.ts`
 Client-side fetch helper:
 - `fetchWithAuth()` - Automatically adds JWT to requests
-- Retrieves token from Amplify session
+- Retrieves token from auth session
 - Falls back to unauthenticated request if needed
 
 ## Frontend Changes
@@ -108,7 +108,7 @@ The JWT token is automatically included in the Authorization header.
 
 1. **Server-side validation** - JWT verified on backend, not client
 2. **User ownership** - Can only access own data (email from JWT)
-3. **Admin verification** - Cognito groups checked for admin role
+3. **Admin verification** - `admin` group claim checked for admin role
 4. **Token expiry** - Expired tokens rejected
 5. **Consistent headers** - Authorization header pattern (Bearer scheme)
 6. **Fallback handling** - Graceful degradation if auth fails


### PR DESCRIPTION
## Summary

Removes the last remaining hard-coded Cognito auth references from 9 documentation files. All admin routes still use `requireAdmin()` — the actual implementation now supports Keycloak (default) + Cognito (optional); these docs were just stale.

**Files changed:**
- `docs/ANTHROPIC.md` — @auth note updated
- `docs/HUBSPOT.md` — @auth note updated
- `docs/SENTRY.md` — @auth note + sequence diagram + security notes updated
- `docs/GSC.md` — @auth note + sequence diagram + security notes updated
- `docs/AGENCY-HUB.md` — ASCII flow diagram updated (`Cognito JWT` → `Bearer JWT`)
- `docs/ACTIVECAMPAIGN.md` — ASCII flow diagram updated
- `docs/AGENTS_ROADMAP.md` — booking route auth description updated
- `docs/README.md` — admin panel gating description updated
- `docs/security/SECURITY_FIXES.md` — historical descriptions updated for dual-provider

## Test plan
- [ ] Docs-only change — no runtime impact
- [ ] `grep -r "Cognito JWT" docs/` returns no results after merge

https://claude.ai/code/session_01PHsA9s3tK2thgSJVwEGuWq

---
_Generated by [Claude Code](https://claude.ai/code/session_01PHsA9s3tK2thgSJVwEGuWq)_