### PR TITLE
docs: fix last stale Cognito admin JWT ref in ACTIVECAMPAIGN.md

### DIFF
--- a/docs/ACTIVECAMPAIGN.md
+++ b/docs/ACTIVECAMPAIGN.md
@@ -156,7 +156,7 @@ Returns zeroed stats on API error.
 
 ## Admin API Routes
 
-All routes require a valid Cognito admin JWT. They all return `503` when ActiveCampaign is not configured.
+All routes require a valid admin session or Bearer JWT with the `admin` group. They all return `503` when ActiveCampaign is not configured.
 
 | Route | Method | Description |
 |---|---|---|


### PR DESCRIPTION
Missed in PR #601 — one more `Cognito admin JWT` line in the Admin API Routes section of `docs/ACTIVECAMPAIGN.md`.

After this merge, `grep -rn "Cognito JWT" docs/` returns zero results (excluding the cost doc which correctly lists Cognito as an AWS service).

https://claude.ai/code/session_01PHsA9s3tK2thgSJVwEGuWq

---
_Generated by [Claude Code](https://claude.ai/code/session_01PHsA9s3tK2thgSJVwEGuWq)_