### PR TITLE
ops: re-trigger cluster-doctor — check Pi recovery after SSH timeout × 3

### DIFF
--- a/.github/workflows/cluster-doctor.yml
+++ b/.github/workflows/cluster-doctor.yml
@@ -2,6 +2,7 @@ name: Cluster doctor (read-only diagnostics)
 # triggered 2026-06-02T22:5X — auth.cloudless.gr 503 live; confirm Keycloak OOM/limit state
 # re-triggered 2026-06-03 — post-deploy full-stack verification
 # re-triggered 2026-06-03T00:30Z — post-k3s-restart verification (cluster recovered)
+# re-triggered 2026-06-03T01:2xZ — pi unresponsive (SSH timeout × 3); checking if recovered
 
 # Read-only visibility into the omv k3s cluster from CI. Runs scripts/cluster-
 # doctor.sh over Tailscale + KUBECONFIG_B64 and posts the snapshot as a comment

--- a/.github/workflows/k3s-ssh-restart.yml
+++ b/.github/workflows/k3s-ssh-restart.yml
@@ -23,6 +23,9 @@ name: k3s-ssh-restart — recover k3s API server via SSH when cluster tools fail
 # cloudless.gr unaffected. SSH-restart k3s and wait for the apiserver.
 # Re-triggered 2026-06-03T01:10Z — cluster still unreachable (i/o timeout on 6443)
 # after 00:08Z outage; all diagnostic workflows timed out; SSH-restart again.
+# Re-triggered 2026-06-03T01:13Z — prior SSH restart failed: SSH handshake timeout
+# on port 22 despite TCP connection accepted; port 6443 never came back after 90s.
+# Pi may be under extreme load; retrying. If same failure, Pi needs power cycle.
 
 on:
   push:


### PR DESCRIPTION
Probing current cluster state after three failed k3s SSH restarts (00:18Z, 01:11Z, 01:19Z). All three showed SSH handshake timeout despite port 22 accepting TCP SYNs — Pi needs physical power cycle if still unresponsive.

https://claude.ai/code/session_013sTDMVEYibee8tbXxrwjzo

---
_Generated by [Claude Code](https://claude.ai/code/session_013sTDMVEYibee8tbXxrwjzo)_