### PR TITLE
ops: trigger cluster-doctor — diagnose Pi 502 / runner offline

### DIFF
--- a/scripts/cluster-doctor.sh
+++ b/scripts/cluster-doctor.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# triggered: 2026-06-03 session saJbZ — diagnose Pi 502 / runner offline cascade
 #
 # cluster-doctor.sh — comprehensive read-only diagnostics for the omv k3s cluster.
 #


### PR DESCRIPTION
Triggers `cluster-doctor.yml` via its path filter to get a current snapshot of the Pi k3s cluster state.

**Context:** All 4 CI failures today cascade from the Pi being unreachable:
- `build pi image` cancelled (Pi runner offline)
- `HA sync orchestrator` timed out (waiting on the cancelled build)
- `Pi TLS Cert Check` → APIGW cert fine, but `/api/health` via SECONDARY returns **502** (Lambda proxy → Pi IPv6 path broken — possible stale Starlink IPv6)
- `SHA drift detector` → Pi SHA drifted (no successful Pi build)

Doctor result will post to issue #382.

https://claude.ai/code/session_01PHsA9s3tK2thgSJVwEGuWq

---
_Generated by [Claude Code](https://claude.ai/code/session_01PHsA9s3tK2thgSJVwEGuWq)_