### PR TITLE
fix(keycloak-autoheal): run as nobody (UID 65534) to satisfy runAsNonRoot

### DIFF
--- a/k8s/cluster-protection/keycloak-autoheal.yaml
+++ b/k8s/cluster-protection/keycloak-autoheal.yaml
@@ -178,6 +178,7 @@ spec:
                   cpu: 200m
                   memory: 64Mi
               securityContext:
+                runAsUser: 65534
                 allowPrivilegeEscalation: false
                 readOnlyRootFilesystem: true
                 capabilities:


### PR DESCRIPTION
## Summary

- `alpine/k8s:1.35.5` runs as root by default, but the pod-level `securityContext.runAsNonRoot: true` blocked every CronJob invocation with `CreateContainerConfigError`
- Fix: add `runAsUser: 65534` (nobody) to the `heal` container's `securityContext` — kubectl and bash work fine as any UID; emptyDir at `/tmp` is world-writable

## Test plan
- [ ] Merge triggers `keycloak-autoheal-deploy.yml` (path filter on `k8s/cluster-protection/keycloak-autoheal.yaml`)
- [ ] Workflow applies the fixed CronJob and kicks one immediate job
- [ ] Job pod shows `Running` → `Completed` (no more `CreateContainerConfigError`)
- [ ] Logs in issue #382 confirm reconcile ran

https://claude.ai/code/session_01PHsA9s3tK2thgSJVwEGuWq

---
_Generated by [Claude Code](https://claude.ai/code/session_01PHsA9s3tK2thgSJVwEGuWq)_