### PR TITLE
feat(admin): Phase 2c — multi-tool AI assistant with Notion/Orders/Email

### DIFF
--- a/__tests__/admin-assistant-api.test.ts
+++ b/__tests__/admin-assistant-api.test.ts
@@ -1,0 +1,117 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+// Mock admin auth
+vi.mock("@/lib/api-auth", () => ({
+  requireAdmin: vi.fn(),
+}));
+
+// Mock Anthropic lib
+vi.mock("@/lib/anthropic", () => ({
+  isAnthropicConfigured: vi.fn(),
+  getAnthropicApiKey: vi.fn(),
+}));
+
+// Mock tool implementations (keeps tests fast and network-free)
+vi.mock("@/lib/admin-assistant-tools", () => ({
+  ASSISTANT_TOOLS: [{ name: "search_notion", description: "search", input_schema: { type: "object", properties: { query: { type: "string" } }, required: ["query"] } }],
+  runAssistantTool: vi.fn(),
+}));
+
+import { POST } from "@/app/api/admin/ai/assistant/route";
+import { requireAdmin } from "@/lib/api-auth";
+import { isAnthropicConfigured, getAnthropicApiKey } from "@/lib/anthropic";
+import { runAssistantTool } from "@/lib/admin-assistant-tools";
+
+function makeReq(body: unknown) {
+  return new NextRequest("http://localhost/api/admin/ai/assistant", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+describe("POST /api/admin/ai/assistant", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(requireAdmin).mockResolvedValue(null as never);
+    vi.mocked(isAnthropicConfigured).mockResolvedValue(true);
+    vi.mocked(getAnthropicApiKey).mockResolvedValue("sk-ant-test");
+  });
+
+  it("returns 401 when not admin", async () => {
+    const { NextResponse } = await import("next/server");
+    vi.mocked(requireAdmin).mockResolvedValue(
+      NextResponse.json({ error: "Unauthorized" }, { status: 401 })
+    );
+    const res = await POST(makeReq({ messages: [{ role: "user", content: "hi" }] }));
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 503 when Anthropic not configured", async () => {
+    vi.mocked(isAnthropicConfigured).mockResolvedValue(false);
+    const res = await POST(makeReq({ messages: [{ role: "user", content: "hi" }] }));
+    expect(res.status).toBe(503);
+  });
+
+  it("returns 400 when messages missing", async () => {
+    const res = await POST(makeReq({}));
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 when messages is empty array", async () => {
+    const res = await POST(makeReq({ messages: [] }));
+    expect(res.status).toBe(400);
+  });
+
+  it("returns direct text response on end_turn", async () => {
+    globalThis.fetch = vi.fn().mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        stop_reason: "end_turn",
+        content: [{ type: "text", text: "Hello admin!" }],
+      }),
+    });
+
+    const res = await POST(makeReq({ messages: [{ role: "user", content: "hi" }] }));
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data.response).toBe("Hello admin!");
+    expect(data.toolsUsed).toEqual([]);
+  });
+
+  it("runs tool and returns final response", async () => {
+    vi.mocked(runAssistantTool).mockResolvedValue("• Page A (notion.so/a)");
+
+    globalThis.fetch = vi
+      .fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          stop_reason: "tool_use",
+          content: [
+            { type: "tool_use", id: "tu_1", name: "search_notion", input: { query: "projects" } },
+          ],
+        }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          stop_reason: "end_turn",
+          content: [{ type: "text", text: "Found: Page A" }],
+        }),
+      });
+
+    const res = await POST(makeReq({ messages: [{ role: "user", content: "find projects" }] }));
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data.response).toBe("Found: Page A");
+    expect(data.toolsUsed).toContain("search_notion");
+  });
+
+  it("returns 502 on Anthropic API error", async () => {
+    globalThis.fetch = vi.fn().mockResolvedValueOnce({ ok: false, status: 500, text: async () => "error" });
+    const res = await POST(makeReq({ messages: [{ role: "user", content: "hi" }] }));
+    expect(res.status).toBe(502);
+  });
+});

--- a/src/app/[locale]/admin/ai-assistant/page.tsx
+++ b/src/app/[locale]/admin/ai-assistant/page.tsx
@@ -1,9 +1,15 @@
 "use client";
 
 import { fetchWithAuth } from "@/lib/fetch-with-auth";
-import { useState } from "react";
+import { useRef, useState } from "react";
 
-type Mode = "strategy" | "copy";
+type Mode = "chat" | "strategy" | "copy";
+
+interface ChatMessage {
+  role: "user" | "assistant";
+  content: string;
+  toolsUsed?: string[];
+}
 
 interface CopyVariant {
   headline: string;
@@ -13,7 +19,12 @@ interface CopyVariant {
 }
 
 export default function AIAssistantPage() {
-  const [mode, setMode] = useState<Mode>("strategy");
+  const [mode, setMode] = useState<Mode>("chat");
+
+  // Chat state
+  const [chatMessages, setChatMessages] = useState<ChatMessage[]>([]);
+  const [chatInput, setChatInput] = useState("");
+  const chatEndRef = useRef<HTMLDivElement>(null);
 
   // Strategy
   const [brief, setBrief] = useState("");
@@ -30,6 +41,41 @@ export default function AIAssistantPage() {
 
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+
+  async function sendChatMessage(e: React.FormEvent) {
+    e.preventDefault();
+    const text = chatInput.trim();
+    if (!text || loading) return;
+    const nextMessages: ChatMessage[] = [...chatMessages, { role: "user", content: text }];
+    setChatMessages(nextMessages);
+    setChatInput("");
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await fetchWithAuth("/api/admin/ai/assistant", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          messages: nextMessages.map((m) => ({ role: m.role, content: m.content })),
+        }),
+      });
+      if (res.status === 503) {
+        setError("ANTHROPIC_API_KEY is not configured in AWS SSM.");
+        return;
+      }
+      if (!res.ok) throw new Error("Assistant request failed");
+      const data = (await res.json()) as { response: string; toolsUsed: string[] };
+      setChatMessages((prev) => [
+        ...prev,
+        { role: "assistant", content: data.response, toolsUsed: data.toolsUsed },
+      ]);
+      setTimeout(() => chatEndRef.current?.scrollIntoView({ behavior: "smooth" }), 50);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Request failed");
+    } finally {
+      setLoading(false);
+    }
+  }
 
   async function generateStrategy(e: React.FormEvent) {
     e.preventDefault();
@@ -95,7 +141,7 @@ export default function AIAssistantPage() {
       </div>
 
       <div className="mb-6 flex gap-1 rounded-lg border border-slate-800 bg-slate-900/50 p-1">
-        {(["strategy", "copy"] as Mode[]).map((m) => (
+        {(["chat", "strategy", "copy"] as Mode[]).map((m) => (
           <button
             key={m}
             type="button"
@@ -109,7 +155,7 @@ export default function AIAssistantPage() {
                 : "text-slate-500 hover:text-slate-300"
             }`}
           >
-            {m === "strategy" ? "Campaign Strategy" : "Ad Copy Generator"}
+            {m === "chat" ? "AI Chat" : m === "strategy" ? "Campaign Strategy" : "Ad Copy"}
           </button>
         ))}
       </div>
@@ -117,6 +163,67 @@ export default function AIAssistantPage() {
       {error && (
         <div className="mb-6 rounded-lg border border-red-900/30 bg-red-950/10 px-4 py-3 font-mono text-sm text-red-400">
           {error}
+        </div>
+      )}
+
+      {mode === "chat" && (
+        <div className="bg-void-light/50 flex h-[520px] flex-col rounded-xl border border-slate-800">
+          <div className="flex-1 space-y-4 overflow-y-auto p-4">
+            {chatMessages.length === 0 && (
+              <p className="font-mono text-xs text-slate-500">
+                Ask me anything — I can search Notion, look up recent orders, or draft a team
+                email.
+              </p>
+            )}
+            {chatMessages.map((msg, i) => (
+              <div
+                key={i}
+                className={`flex ${msg.role === "user" ? "justify-end" : "justify-start"}`}
+              >
+                <div
+                  className={`max-w-[80%] rounded-lg px-3 py-2 font-mono text-xs ${
+                    msg.role === "user"
+                      ? "bg-neon-magenta/10 text-neon-magenta border border-neon-magenta/20"
+                      : "bg-slate-800 text-slate-300 border border-slate-700"
+                  }`}
+                >
+                  <p className="whitespace-pre-wrap">{msg.content}</p>
+                  {msg.toolsUsed && msg.toolsUsed.length > 0 && (
+                    <p className="mt-1 text-slate-500">
+                      Used: {msg.toolsUsed.join(", ")}
+                    </p>
+                  )}
+                </div>
+              </div>
+            ))}
+            {loading && mode === "chat" && (
+              <div className="flex justify-start">
+                <div className="rounded-lg border border-slate-700 bg-slate-800 px-3 py-2">
+                  <span className="font-mono text-xs text-slate-500">Thinking…</span>
+                </div>
+              </div>
+            )}
+            <div ref={chatEndRef} />
+          </div>
+          <form
+            onSubmit={sendChatMessage}
+            className="flex gap-2 border-t border-slate-800 p-3"
+          >
+            <input
+              value={chatInput}
+              onChange={(e) => setChatInput(e.target.value)}
+              placeholder="Search Notion, check orders, draft an email…"
+              disabled={loading}
+              className="flex-1 rounded-lg border border-slate-700 bg-slate-900 px-3 py-2 font-mono text-xs text-white placeholder-slate-600 focus:border-slate-500 focus:outline-none disabled:opacity-50"
+            />
+            <button
+              type="submit"
+              disabled={loading || !chatInput.trim()}
+              className="border-neon-magenta/30 bg-neon-magenta/10 text-neon-magenta hover:bg-neon-magenta/20 rounded-lg border px-4 py-2 font-mono text-xs transition-all disabled:opacity-50"
+            >
+              Send
+            </button>
+          </form>
         </div>
       )}
 

--- a/src/app/api/admin/ai/assistant/route.ts
+++ b/src/app/api/admin/ai/assistant/route.ts
@@ -1,0 +1,127 @@
+import { NextRequest, NextResponse } from "next/server";
+import { requireAdmin } from "@/lib/api-auth";
+import { getAnthropicApiKey, isAnthropicConfigured } from "@/lib/anthropic";
+import { ASSISTANT_TOOLS, runAssistantTool } from "@/lib/admin-assistant-tools";
+
+const MAX_ITERATIONS = 4;
+
+const SYSTEM_PROMPT = `You are a helpful admin assistant for cloudless.gr, a digital marketing agency in Greece. You have access to three tools:
+- search_notion: find pages, projects, tasks, and docs in the Notion workspace
+- get_recent_orders: look up recent Stripe orders
+- draft_email: compose or send a team email
+
+Use tools when the request needs live data. For general questions, answer directly. Be concise and actionable.`;
+
+interface TextBlock {
+  type: "text";
+  text: string;
+}
+
+interface ToolUseBlock {
+  type: "tool_use";
+  id: string;
+  name: string;
+  input: Record<string, unknown>;
+}
+
+interface ToolResultBlock {
+  type: "tool_result";
+  tool_use_id: string;
+  content: string;
+}
+
+type ContentBlock = TextBlock | ToolUseBlock | ToolResultBlock;
+
+interface AssistantMessage {
+  role: "user" | "assistant";
+  content: string | ContentBlock[];
+}
+
+interface AnthropicResponse {
+  stop_reason: "end_turn" | "tool_use" | "max_tokens" | string;
+  content: ContentBlock[];
+}
+
+export async function POST(req: NextRequest) {
+  const authError = await requireAdmin(req);
+  if (authError) return authError;
+
+  if (!(await isAnthropicConfigured())) {
+    return NextResponse.json(
+      { error: "ANTHROPIC_API_KEY is not configured in AWS SSM." },
+      { status: 503 }
+    );
+  }
+
+  let messages: AssistantMessage[];
+  try {
+    const body = (await req.json()) as { messages: AssistantMessage[] };
+    messages = body.messages;
+    if (!Array.isArray(messages) || messages.length === 0) {
+      return NextResponse.json({ error: "messages array is required" }, { status: 400 });
+    }
+  } catch {
+    return NextResponse.json({ error: "Invalid request body" }, { status: 400 });
+  }
+
+  const apiKey = await getAnthropicApiKey();
+  if (!apiKey) {
+    return NextResponse.json({ error: "API key unavailable" }, { status: 503 });
+  }
+
+  const toolsUsed: string[] = [];
+  const currentMessages = [...messages];
+
+  for (let i = 0; i < MAX_ITERATIONS; i++) {
+    const res = await globalThis.fetch("https://api.anthropic.com/v1/messages", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "x-api-key": apiKey,
+        "anthropic-version": "2023-06-01",
+      },
+      body: JSON.stringify({
+        model: "claude-sonnet-4-6",
+        max_tokens: 2000,
+        system: SYSTEM_PROMPT,
+        tools: ASSISTANT_TOOLS,
+        messages: currentMessages,
+      }),
+      signal: AbortSignal.timeout(30_000),
+    });
+
+    if (!res.ok) {
+      const err = await res.text().catch(() => "");
+      console.error("[assistant] Anthropic error", res.status, err);
+      return NextResponse.json({ error: "AI service error" }, { status: 502 });
+    }
+
+    const data = (await res.json()) as AnthropicResponse;
+
+    if (data.stop_reason === "end_turn") {
+      const text =
+        (data.content.find((b) => b.type === "text") as TextBlock | undefined)?.text ?? "";
+      return NextResponse.json({ response: text, toolsUsed });
+    }
+
+    if (data.stop_reason === "tool_use") {
+      currentMessages.push({ role: "assistant", content: data.content });
+
+      const toolResults: ToolResultBlock[] = [];
+      for (const block of data.content) {
+        if (block.type !== "tool_use") continue;
+        const { id, name, input } = block as ToolUseBlock;
+        if (!toolsUsed.includes(name)) toolsUsed.push(name);
+        const result = await runAssistantTool(name, input);
+        toolResults.push({ type: "tool_result", tool_use_id: id, content: result });
+      }
+      currentMessages.push({ role: "user", content: toolResults });
+    }
+  }
+
+  return NextResponse.json({
+    response:
+      "I hit the tool-use limit without a final answer. Please try rephrasing your request.",
+    toolsUsed,
+  });
+}

--- a/src/lib/admin-assistant-tools.ts
+++ b/src/lib/admin-assistant-tools.ts
@@ -1,0 +1,111 @@
+import { searchPages } from "@/lib/notion-search";
+import { listRecentCheckoutSessions } from "@/lib/stripe";
+import { notifyTeam } from "@/lib/email";
+
+export interface AnthropicTool {
+  name: string;
+  description: string;
+  input_schema: {
+    type: "object";
+    properties: Record<string, unknown>;
+    required?: string[];
+  };
+}
+
+export const ASSISTANT_TOOLS: AnthropicTool[] = [
+  {
+    name: "search_notion",
+    description:
+      "Search Notion workspace pages and databases. Returns page titles, URLs, and last-edited dates. Use this to find projects, tasks, documentation, or any Notion content.",
+    input_schema: {
+      type: "object",
+      properties: {
+        query: { type: "string", description: "Search query string" },
+        limit: {
+          type: "number",
+          description: "Max results (default 8, max 20)",
+        },
+      },
+      required: ["query"],
+    },
+  },
+  {
+    name: "get_recent_orders",
+    description:
+      "Fetch recent Stripe checkout sessions. Returns customer email, order amount, currency, and payment status.",
+    input_schema: {
+      type: "object",
+      properties: {
+        limit: {
+          type: "number",
+          description: "Number of orders to return (default 5, max 20)",
+        },
+      },
+    },
+  },
+  {
+    name: "draft_email",
+    description:
+      "Compose and optionally send an email to the admin team. Set send=true to deliver it immediately; omit or false for a preview draft only.",
+    input_schema: {
+      type: "object",
+      properties: {
+        subject: { type: "string", description: "Email subject line" },
+        body: { type: "string", description: "Email body text" },
+        send: {
+          type: "boolean",
+          description: "Whether to actually send the email (default false — preview only)",
+        },
+      },
+      required: ["subject", "body"],
+    },
+  },
+];
+
+export async function runAssistantTool(
+  name: string,
+  input: Record<string, unknown>
+): Promise<string> {
+  try {
+    if (name === "search_notion") {
+      const query = String(input.query ?? "");
+      const limit = Math.min(Number(input.limit ?? 8), 20);
+      const { results } = await searchPages(query, { limit });
+      if (!results.length) return "No Notion pages found for that query.";
+      return results
+        .map(
+          (r) =>
+            `• [${r.title || "(untitled)"}](${r.url}) — ${r.type}, last edited ${new Date(r.lastEditedTime).toLocaleDateString("en-GB")}`
+        )
+        .join("\n");
+    }
+
+    if (name === "get_recent_orders") {
+      const limit = Math.min(Number(input.limit ?? 5), 20);
+      const { orders } = await listRecentCheckoutSessions(limit);
+      if (!orders.length) return "No recent orders found (Stripe may not be configured).";
+      return orders
+        .map((o) => {
+          const amount = `${o.currency} ${(o.amount / 100).toFixed(2)}`;
+          const date = new Date(o.created * 1000).toLocaleDateString("en-GB");
+          return `• ${o.email ?? "unknown"} — ${amount} — ${o.paymentStatus} — ${date}`;
+        })
+        .join("\n");
+    }
+
+    if (name === "draft_email") {
+      const subject = String(input.subject ?? "");
+      const body = String(input.body ?? "");
+      const send = Boolean(input.send);
+      if (send) {
+        await notifyTeam(subject, body);
+        return `Email sent to team: "${subject}"`;
+      }
+      return `Draft ready (not sent yet):\n\nSubject: ${subject}\n\n${body}`;
+    }
+
+    return `Unknown tool: ${name}`;
+  } catch (err) {
+    return `Tool ${name} error: ${err instanceof Error ? err.message : String(err)}`;
+  }
+}


### PR DESCRIPTION
## Summary

Implements **AGENTS_ROADMAP.md Phase 2c** — the admin AI assistant becomes a multi-tool conversational agent.

- **`src/lib/admin-assistant-tools.ts`** — three tool definitions + executors:
  - `search_notion(query, limit?)` → `searchPages()` (Notion workspace search)
  - `get_recent_orders(limit?)` → `listRecentCheckoutSessions()` (Stripe orders)
  - `draft_email(subject, body, send?)` → `notifyTeam()` (team email, preview or send)
- **`src/app/api/admin/ai/assistant/route.ts`** — Anthropic Messages API tool-use loop (≤4 iterations); `requireAdmin()` guard; 503 when key absent
- **`src/app/[locale]/admin/ai-assistant/page.tsx`** — adds **"AI Chat"** as the default tab with a conversational UI (message history + tool-use labels); existing Campaign Strategy and Ad Copy tabs preserved
- **`__tests__/admin-assistant-api.test.ts`** — 7 tests: 401, 503, 400 (missing/empty messages), end_turn text, tool-use round-trip, 502 on API error

## Test plan
- [ ] CI passes (all 7 new tests + existing suite green)
- [ ] `/admin/ai-assistant` shows "AI Chat" tab by default
- [ ] Chat: "find my latest orders" → agent calls `get_recent_orders`, shows results
- [ ] Chat: "search Notion for blog posts" → agent calls `search_notion`
- [ ] Chat: "draft an email to the team about the new product launch" → returns draft with send=false
- [ ] 503 shown when `ANTHROPIC_API_KEY` absent in SSM

https://claude.ai/code/session_01PHsA9s3tK2thgSJVwEGuWq

---
_Generated by [Claude Code](https://claude.ai/code/session_01PHsA9s3tK2thgSJVwEGuWq)_