### PR TITLE
feat(ci): Phase 4b — CI failure babysitter with Claude diagnosis

### DIFF
--- a/.github/workflows/ci-babysitter.yml
+++ b/.github/workflows/ci-babysitter.yml
@@ -1,0 +1,80 @@
+name: CI Failure Babysitter
+
+# Phase 4b of docs/AGENTS_ROADMAP.md.
+# Triggers whenever one of the monitored workflows fails, fetches the failed
+# job logs, calls Claude for root-cause analysis, and posts a comment to
+# the relevant PR (or tracking issue #382 for main-branch failures).
+
+on:
+  workflow_run:
+    workflows:
+      - CI
+      - Deploy to Production
+      - Deploy to Pi (ECR + k3s rollout)
+    types: [completed]
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
+jobs:
+  diagnose:
+    name: Diagnose CI failure
+    runs-on: ubuntu-latest
+    if: github.event.workflow_run.conclusion == 'failure'
+
+    permissions:
+      contents: read
+      pull-requests: write   # post PR comment
+      issues: write          # post to tracking issue #382
+      actions: read          # fetch job logs
+      id-token: write        # OIDC → AWS SSM for ANTHROPIC_API_KEY
+
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v4.3.1
+
+      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
+        with:
+          dest: ~/setup-pnpm-${{ runner.name }}
+
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: Install Anthropic SDK
+        run: pnpm add -D @anthropic-ai/sdk --no-lockfile
+
+      - name: Configure AWS credentials (OIDC)
+        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4
+        with:
+          role-to-assume: ${{ secrets.AWS_DEPLOY_ROLE_ARN }}
+          aws-region: us-east-1
+
+      - name: Fetch ANTHROPIC_API_KEY from SSM
+        id: ssm
+        run: |
+          KEY=$(aws ssm get-parameter \
+            --name "/cloudless/production/ANTHROPIC_API_KEY" \
+            --with-decryption \
+            --query "Parameter.Value" \
+            --output text 2>/dev/null || echo "")
+          echo "::add-mask::$KEY"
+          echo "key=$KEY" >> "$GITHUB_OUTPUT"
+
+      - name: Diagnose and comment
+        if: steps.ssm.outputs.key != ''
+        env:
+          ANTHROPIC_API_KEY: ${{ steps.ssm.outputs.key }}
+          GITHUB_TOKEN: ${{ github.token }}
+          WORKFLOW_NAME: ${{ github.event.workflow_run.name }}
+          RUN_ID: ${{ github.event.workflow_run.id }}
+          REPO: ${{ github.repository }}
+          HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
+          HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+          PR_NUMBER: >-
+            ${{ github.event.workflow_run.pull_requests[0].number }}
+        run: node scripts/ci-babysitter.mjs
+
+      - name: Skip (API key absent)
+        if: steps.ssm.outputs.key == ''
+        run: echo "ANTHROPIC_API_KEY not in SSM — skipping diagnosis."

--- a/docs/AGENTS_ROADMAP.md
+++ b/docs/AGENTS_ROADMAP.md
@@ -99,9 +99,9 @@ On every PR open / push that touches `src/**` or root config files, a workflow d
 
 Implementation: `.github/workflows/pr-review.yml` + `scripts/pr-review.mjs`. Anthropic key fetched from SSM via the existing OIDC role — no new secrets needed. Skipped for `dependabot/*` and `revert/*` branches. Default model: `claude-haiku-4-5` (override with `REVIEW_MODEL` env var). Cost: ~$0.02–0.10 per PR. Use `pr-review-debug` agent to tune.
 
-### 4b — Failing-CI babysitter
+### 4b — Failing-CI babysitter — SHIPPED
 
-When a workflow fails, an agent investigates the logs and posts a comment summarizing the cause and a suggested fix. Replaces ~50% of "the CI is red, why?" Slack pings.
+On CI/Deploy failure a `workflow_run` triggers `ci-babysitter.yml` which fetches failed job logs (capped at 40k chars), calls Claude Haiku for root-cause analysis (root cause + fix + confidence), and posts a comment to the triggering PR or to tracking issue #382 if run on main. Implementation: `scripts/ci-babysitter.mjs` + `.github/workflows/ci-babysitter.yml`. Uses the same OIDC → ANTHROPIC_API_KEY SSM pattern as the PR review agent. Cost: ~$0.02–0.08 per failure.
 
 ### 4c — Auto-cleanup of stale gates
 

--- a/scripts/ci-babysitter.mjs
+++ b/scripts/ci-babysitter.mjs
@@ -1,0 +1,204 @@
+#!/usr/bin/env node
+/**
+ * CI Failure Babysitter — Phase 4b of AGENTS_ROADMAP.md
+ *
+ * Fetches failed job logs from a GitHub Actions workflow run, sends them to
+ * Claude for root-cause analysis, and posts a comment to the associated PR
+ * (or to tracking issue #382 if the run was on main with no open PR).
+ *
+ * Called from .github/workflows/ci-babysitter.yml on workflow_run failure.
+ *
+ * Cost: ~$0.02–0.08 per failure (Claude Haiku). Uses the same OIDC →
+ * ANTHROPIC_API_KEY SSM pattern as pr-review.yml.
+ */
+
+import Anthropic from "@anthropic-ai/sdk";
+
+// ---------------------------------------------------------------------------
+// Config
+// ---------------------------------------------------------------------------
+
+const MODEL = process.env.REVIEW_MODEL ?? "claude-haiku-4-5-20251001";
+const MAX_LOG_CHARS = 40_000;
+const TRACKING_ISSUE = 382;
+
+const WORKFLOW_NAME = process.env.WORKFLOW_NAME ?? "(unknown workflow)";
+const RUN_ID = process.env.RUN_ID ?? "";
+const REPO = process.env.REPO ?? ""; // "owner/repo"
+const HEAD_BRANCH = process.env.HEAD_BRANCH ?? "";
+const HEAD_SHA = process.env.HEAD_SHA ?? "";
+const PR_NUMBER = process.env.PR_NUMBER ?? ""; // empty when not from a PR
+const GITHUB_TOKEN = process.env.GITHUB_TOKEN ?? "";
+const ANTHROPIC_API_KEY = process.env.ANTHROPIC_API_KEY ?? "";
+
+if (!GITHUB_TOKEN) { console.error("GITHUB_TOKEN is required"); process.exit(1); }
+if (!ANTHROPIC_API_KEY) { console.error("ANTHROPIC_API_KEY is required"); process.exit(1); }
+if (!RUN_ID || !REPO) { console.error("RUN_ID and REPO are required"); process.exit(1); }
+
+const [owner, repo] = REPO.split("/");
+
+// ---------------------------------------------------------------------------
+// GitHub API helpers
+// ---------------------------------------------------------------------------
+
+async function ghFetch(path, opts = {}) {
+  const res = await fetch(`https://api.github.com${path}`, {
+    ...opts,
+    headers: {
+      Authorization: `Bearer ${GITHUB_TOKEN}`,
+      Accept: "application/vnd.github+json",
+      "X-GitHub-Api-Version": "2022-11-28",
+      ...opts.headers,
+    },
+    signal: AbortSignal.timeout(20_000),
+  });
+  if (!res.ok) {
+    const text = await res.text().catch(() => "");
+    throw new Error(`GitHub API ${path} → ${res.status}: ${text.slice(0, 200)}`);
+  }
+  return res;
+}
+
+async function getFailedJobs() {
+  const res = await ghFetch(`/repos/${owner}/${repo}/actions/runs/${RUN_ID}/jobs`);
+  const data = await res.json();
+  return (data.jobs ?? []).filter((j) => j.conclusion === "failure");
+}
+
+async function getJobLogs(jobId) {
+  try {
+    // GitHub returns a redirect to the log download URL
+    const res = await fetch(
+      `https://api.github.com/repos/${owner}/${repo}/actions/jobs/${jobId}/logs`,
+      {
+        headers: {
+          Authorization: `Bearer ${GITHUB_TOKEN}`,
+          Accept: "application/vnd.github+json",
+          "X-GitHub-Api-Version": "2022-11-28",
+        },
+        redirect: "follow",
+        signal: AbortSignal.timeout(20_000),
+      }
+    );
+    if (!res.ok) return `(log fetch failed: ${res.status})`;
+    return await res.text();
+  } catch (e) {
+    return `(log fetch error: ${e.message})`;
+  }
+}
+
+async function postPrComment(prNumber, body) {
+  await ghFetch(`/repos/${owner}/${repo}/issues/${prNumber}/comments`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ body }),
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Find PR number from branch (when workflow was triggered by a push to main
+// branch of a PR — workflow_run may not populate pull_requests for pushes)
+// ---------------------------------------------------------------------------
+
+async function findPrForBranch(branch) {
+  if (PR_NUMBER) return Number(PR_NUMBER);
+  if (!branch || branch === "main") return null;
+  try {
+    const res = await ghFetch(
+      `/repos/${owner}/${repo}/pulls?head=${owner}:${encodeURIComponent(branch)}&state=open&per_page=1`
+    );
+    const prs = await res.json();
+    return prs[0]?.number ?? null;
+  } catch {
+    return null;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Truncate logs to stay within model context
+// ---------------------------------------------------------------------------
+
+function truncateLogs(logs) {
+  if (logs.length <= MAX_LOG_CHARS) return logs;
+  const half = MAX_LOG_CHARS / 2;
+  return (
+    logs.slice(0, half) +
+    `\n\n[... ${logs.length - MAX_LOG_CHARS} chars truncated ...]\n\n` +
+    logs.slice(-half)
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Claude analysis
+// ---------------------------------------------------------------------------
+
+async function analyzeFailure(jobName, logs) {
+  const client = new Anthropic({ apiKey: ANTHROPIC_API_KEY });
+  const msg = await client.messages.create({
+    model: MODEL,
+    max_tokens: 600,
+    system: `You are a CI diagnosis assistant for a Next.js project (cloudless.gr).
+Analyze the GitHub Actions log excerpt and respond in this exact format:
+
+**Root cause:** One sentence describing the error.
+
+**Fix:** Concrete, actionable 1–3 step fix (code change, env var, config, etc.).
+
+**Confidence:** High / Medium / Low — with a brief reason.
+
+Be specific and concise. Do not explain what CI is. Focus on the actionable fix.`,
+    messages: [
+      {
+        role: "user",
+        content: `Workflow: ${WORKFLOW_NAME}\nJob: ${jobName}\nBranch: ${HEAD_BRANCH}\nSHA: ${HEAD_SHA}\n\nFailed log:\n\`\`\`\n${truncateLogs(logs)}\n\`\`\``,
+      },
+    ],
+  });
+  return msg.content[0]?.text ?? "(no analysis)";
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+const failedJobs = await getFailedJobs();
+if (failedJobs.length === 0) {
+  console.log("No failed jobs found — nothing to diagnose.");
+  process.exit(0);
+}
+
+const analyses = [];
+for (const job of failedJobs.slice(0, 3)) { // cap at 3 jobs
+  console.log(`Fetching logs for job: ${job.name} (${job.id})`);
+  const logs = await getJobLogs(job.id);
+  const analysis = await analyzeFailure(job.name, logs);
+  analyses.push({ name: job.name, url: job.html_url, analysis });
+}
+
+const prNumber = await findPrForBranch(HEAD_BRANCH);
+
+const runUrl = `https://github.com/${REPO}/actions/runs/${RUN_ID}`;
+const body = [
+  `## 🔍 CI Failure Diagnosis — ${WORKFLOW_NAME}`,
+  ``,
+  `**Run:** [${RUN_ID}](${runUrl}) | **Branch:** \`${HEAD_BRANCH}\` | **SHA:** \`${HEAD_SHA.slice(0, 7)}\``,
+  ``,
+  ...analyses.flatMap(({ name, url, analysis }) => [
+    `### Job: [${name}](${url})`,
+    ``,
+    analysis,
+    ``,
+  ]),
+  `---`,
+  `*Generated by CI babysitter (Phase 4b) — [AGENTS_ROADMAP.md](https://github.com/${REPO}/blob/main/docs/AGENTS_ROADMAP.md)*`,
+].join("\n");
+
+if (prNumber) {
+  console.log(`Posting diagnosis to PR #${prNumber}`);
+  await postPrComment(prNumber, body);
+} else {
+  console.log(`No PR found — posting to tracking issue #${TRACKING_ISSUE}`);
+  await postPrComment(TRACKING_ISSUE, body);
+}
+
+console.log("Done.");


### PR DESCRIPTION
## Summary

Implements **AGENTS_ROADMAP.md Phase 4b** — the CI failure babysitter.

- **`.github/workflows/ci-babysitter.yml`** — triggers on `workflow_run` failure for CI, Deploy to Production, Deploy to Pi; single `diagnose` job on `ubuntu-latest` with OIDC → SSM for `ANTHROPIC_API_KEY`
- **`scripts/ci-babysitter.mjs`** — fetches failed job logs via GitHub API (up to 40k chars), calls Claude Haiku for root-cause analysis (root cause + fix + confidence), posts a comment to the triggering PR or tracking issue #382 for main-branch failures
- **`docs/AGENTS_ROADMAP.md`** — marks Phase 4b as SHIPPED

**Behaviour:**
- Only runs when conclusion is `failure`
- Caps at 3 failed jobs per run (most CIs only have 1)
- Posts to PR if triggered by a PR branch, else to issue #382
- Gracefully skips if `ANTHROPIC_API_KEY` absent in SSM

## Test plan
- [ ] CI passes
- [ ] Force a CI failure on a test branch — babysitter should post a diagnosis comment to the PR within ~60s of the failure
- [ ] Main-branch failure → diagnosis posted to issue #382

https://claude.ai/code/session_01PHsA9s3tK2thgSJVwEGuWq

---
_Generated by [Claude Code](https://claude.ai/code/session_01PHsA9s3tK2thgSJVwEGuWq)_