### PR TITLE
feat(ci): Phase 4c — stale gate sweeper

### DIFF
--- a/.github/workflows/stale-gate-sweeper.yml
+++ b/.github/workflows/stale-gate-sweeper.yml
@@ -1,0 +1,68 @@
+name: Stale Gate Sweeper
+
+# Phase 4c of docs/AGENTS_ROADMAP.md.
+# Scans the codebase weekly for stale cleanup markers (// remove once X,
+# @deprecated, backward-compat shims, etc.), uses Claude to evaluate which
+# are ready to delete, and posts a triage report to tracking issue #382.
+
+on:
+  schedule:
+    - cron: "0 9 * * 1" # Monday 09:00 UTC
+  workflow_dispatch: # manual trigger
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
+jobs:
+  sweep:
+    name: Scan for stale gates
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      issues: write     # post to tracking issue #382
+      id-token: write   # OIDC → AWS SSM for ANTHROPIC_API_KEY
+
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v4.3.1
+
+      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
+        with:
+          dest: ~/setup-pnpm-${{ runner.name }}
+
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: Install Anthropic SDK
+        run: pnpm add -D @anthropic-ai/sdk --no-lockfile
+
+      - name: Configure AWS credentials (OIDC)
+        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4
+        with:
+          role-to-assume: ${{ secrets.AWS_DEPLOY_ROLE_ARN }}
+          aws-region: us-east-1
+
+      - name: Fetch ANTHROPIC_API_KEY from SSM
+        id: ssm
+        run: |
+          KEY=$(aws ssm get-parameter \
+            --name "/cloudless/production/ANTHROPIC_API_KEY" \
+            --with-decryption \
+            --query "Parameter.Value" \
+            --output text 2>/dev/null || echo "")
+          echo "::add-mask::$KEY"
+          echo "key=$KEY" >> "$GITHUB_OUTPUT"
+
+      - name: Scan and report
+        if: steps.ssm.outputs.key != ''
+        env:
+          ANTHROPIC_API_KEY: ${{ steps.ssm.outputs.key }}
+          GITHUB_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+        run: node scripts/stale-gate-sweeper.mjs
+
+      - name: Skip (API key absent)
+        if: steps.ssm.outputs.key == ''
+        run: echo "ANTHROPIC_API_KEY not in SSM — skipping sweep."

--- a/docs/AGENTS_ROADMAP.md
+++ b/docs/AGENTS_ROADMAP.md
@@ -103,9 +103,9 @@ Implementation: `.github/workflows/pr-review.yml` + `scripts/pr-review.mjs`. Ant
 
 On CI/Deploy failure a `workflow_run` triggers `ci-babysitter.yml` which fetches failed job logs (capped at 40k chars), calls Claude Haiku for root-cause analysis (root cause + fix + confidence), and posts a comment to the triggering PR or to tracking issue #382 if run on main. Implementation: `scripts/ci-babysitter.mjs` + `.github/workflows/ci-babysitter.yml`. Uses the same OIDC → ANTHROPIC_API_KEY SSM pattern as the PR review agent. Cost: ~$0.02–0.08 per failure.
 
-### 4c — Auto-cleanup of stale gates
+### 4c — Auto-cleanup of stale gates — SHIPPED
 
-You already use `/schedule` for one-off cleanup of feature flags / experiments. A repeating agent could sweep the codebase weekly for `// remove once X` TODOs whose `X` condition is met (e.g. flag flipped on for 30 days, no reverts). Posts a "ready to clean up" comment to a single triage issue.
+Runs weekly (Monday 09:00 UTC) via `.github/workflows/stale-gate-sweeper.yml` + `scripts/stale-gate-sweeper.mjs`. Scans `src/`, `scripts/`, and `sst.config.ts` for `remove once`, `TODO: remove`, `@deprecated`, `backward-compat`, and similar markers using `git grep`. Gets 4 lines of context per match and recent commits (last 30 days), calls Claude Haiku to evaluate which conditions are met, and posts a two-section triage report (Ready to remove / Not yet) to tracking issue #382. Cap: 40 matches, 30k prompt chars. Override model with `REVIEW_MODEL` env var. Cost: ~$0.01–0.04/run.
 
 ---
 

--- a/scripts/stale-gate-sweeper.mjs
+++ b/scripts/stale-gate-sweeper.mjs
@@ -1,0 +1,222 @@
+#!/usr/bin/env node
+/**
+ * Stale Gate Sweeper — Phase 4c of AGENTS_ROADMAP.md
+ *
+ * Scans the codebase for cleanup markers (// remove once X, // TODO: remove,
+ * // legacy, backward-compat shims, deprecated flags) and uses Claude to
+ * evaluate which ones are ready to delete. Posts a triage report to
+ * tracking issue #382.
+ *
+ * Run weekly via .github/workflows/stale-gate-sweeper.yml or manually with:
+ *   GITHUB_TOKEN=... ANTHROPIC_API_KEY=... node scripts/stale-gate-sweeper.mjs
+ */
+
+import { execSync } from "child_process";
+import Anthropic from "@anthropic-ai/sdk";
+
+// ---------------------------------------------------------------------------
+// Config
+// ---------------------------------------------------------------------------
+
+const MODEL = process.env.REVIEW_MODEL ?? "claude-haiku-4-5-20251001";
+const REPO = process.env.REPO ?? ""; // "owner/repo"
+const GITHUB_TOKEN = process.env.GITHUB_TOKEN ?? "";
+const ANTHROPIC_API_KEY = process.env.ANTHROPIC_API_KEY ?? "";
+const TRACKING_ISSUE = 382;
+const MAX_MATCHES = 40; // cap — avoid giant prompts
+const MAX_CONTEXT_CHARS = 30_000;
+
+if (!GITHUB_TOKEN) { console.error("GITHUB_TOKEN is required"); process.exit(1); }
+if (!ANTHROPIC_API_KEY) { console.error("ANTHROPIC_API_KEY is required"); process.exit(1); }
+
+// ---------------------------------------------------------------------------
+// Pattern search — grep for stale-gate markers in source files
+// ---------------------------------------------------------------------------
+
+const PATTERNS = [
+  "remove once",
+  "remove when",
+  "TODO.*remove",
+  "FIXME.*remove",
+  "remove after",
+  "cleanup.*after",
+  "backward.compat",
+  "backwards.compat",
+  "legacy shim",
+  "@deprecated",
+];
+
+// Directories to scan
+const SCAN_DIRS = "src scripts sst.config.ts";
+// File extensions to include
+const INCLUDE_EXTS = "--include=*.ts --include=*.tsx --include=*.mjs --include=*.js";
+
+function grepPatterns() {
+  const matches = new Map(); // "file:line" → { file, line, lineNum, context }
+
+  for (const pattern of PATTERNS) {
+    try {
+      const out = execSync(
+        `git grep -n -i -E "${pattern}" -- ${SCAN_DIRS} ${INCLUDE_EXTS} 2>/dev/null || true`,
+        { encoding: "utf8", maxBuffer: 2 * 1024 * 1024 }
+      );
+      for (const line of out.split("\n").filter(Boolean)) {
+        const colon = line.indexOf(":");
+        const colon2 = line.indexOf(":", colon + 1);
+        if (colon < 0 || colon2 < 0) continue;
+        const file = line.slice(0, colon);
+        const lineNum = line.slice(colon + 1, colon2);
+        const content = line.slice(colon2 + 1).trim();
+        const key = `${file}:${lineNum}`;
+        if (!matches.has(key)) {
+          matches.set(key, { file, lineNum: Number(lineNum), content });
+        }
+      }
+    } catch {
+      // git grep exits 1 on no matches — that's fine
+    }
+  }
+
+  return [...matches.values()].slice(0, MAX_MATCHES);
+}
+
+// Get a few lines of context around a match
+function getContext(file, lineNum, contextLines = 4) {
+  try {
+    const out = execSync(
+      `sed -n "${Math.max(1, lineNum - contextLines)},${lineNum + contextLines}p" "${file}" 2>/dev/null`,
+      { encoding: "utf8" }
+    );
+    return out.trim();
+  } catch {
+    return "(could not read file)";
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Get recent git log for context (commits in last 30 days)
+// ---------------------------------------------------------------------------
+
+function getRecentCommits() {
+  try {
+    return execSync(
+      'git log --oneline --since="30 days ago" --no-merges --format="%h %s" 2>/dev/null | head -30',
+      { encoding: "utf8" }
+    ).trim();
+  } catch {
+    return "";
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Claude analysis
+// ---------------------------------------------------------------------------
+
+async function analyzeStaleGates(matches, recentCommits) {
+  if (matches.length === 0) return null;
+
+  const matchList = matches
+    .map(({ file, lineNum, content }) => {
+      const ctx = getContext(file, lineNum);
+      return `### ${file}:${lineNum}\n\`\`\`\n${ctx}\n\`\`\``;
+    })
+    .join("\n\n");
+
+  const prompt = `You are reviewing a codebase for stale cleanup markers — comments that say "remove once X" or similar.
+
+Recent commits (last 30 days):
+\`\`\`
+${recentCommits || "(none)"}
+\`\`\`
+
+Cleanup markers found:
+
+${matchList.slice(0, MAX_CONTEXT_CHARS)}
+
+For each marker, assess:
+1. Is the condition likely already met? (based on the code context and recent commits)
+2. Is it safe to remove the guarded code now?
+
+Respond as a markdown list grouped into two sections:
+## Ready to remove (condition met)
+## Not yet (condition still active or unclear)
+
+For each item: file:line — one sentence on why it's ready/not ready. Be concise.
+If no markers are clearly ready, say so explicitly.`;
+
+  const client = new Anthropic({ apiKey: ANTHROPIC_API_KEY });
+  const msg = await client.messages.create({
+    model: MODEL,
+    max_tokens: 800,
+    messages: [{ role: "user", content: prompt }],
+  });
+  return msg.content[0]?.text ?? "(no analysis)";
+}
+
+// ---------------------------------------------------------------------------
+// Post to GitHub issue
+// ---------------------------------------------------------------------------
+
+async function postIssueComment(body) {
+  const [owner, repo] = REPO.split("/");
+  const res = await fetch(
+    `https://api.github.com/repos/${owner}/${repo}/issues/${TRACKING_ISSUE}/comments`,
+    {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${GITHUB_TOKEN}`,
+        Accept: "application/vnd.github+json",
+        "X-GitHub-Api-Version": "2022-11-28",
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ body }),
+      signal: AbortSignal.timeout(15_000),
+    }
+  );
+  if (!res.ok) {
+    const txt = await res.text().catch(() => "");
+    throw new Error(`GitHub API issue comment → ${res.status}: ${txt.slice(0, 200)}`);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+console.log("Scanning codebase for stale-gate markers…");
+const matches = grepPatterns();
+console.log(`Found ${matches.length} marker(s).`);
+
+if (matches.length === 0) {
+  console.log("No stale-gate markers found — nothing to report.");
+  process.exit(0);
+}
+
+const recentCommits = getRecentCommits();
+console.log("Asking Claude to evaluate…");
+const analysis = await analyzeStaleGates(matches, recentCommits);
+
+if (!analysis) {
+  console.log("No analysis produced — skipping.");
+  process.exit(0);
+}
+
+const now = new Date().toISOString().slice(0, 10);
+const body = [
+  `## 🧹 Stale Gate Sweeper — ${now}`,
+  ``,
+  `Scanned \`src/\`, \`scripts/\`, and \`sst.config.ts\` for \`remove once\`, \`TODO: remove\`, \`@deprecated\`, and similar markers. Found **${matches.length}** marker(s).`,
+  ``,
+  analysis,
+  ``,
+  `---`,
+  `*Generated by stale-gate sweeper (Phase 4c) — [AGENTS_ROADMAP.md](https://github.com/${REPO}/blob/main/docs/AGENTS_ROADMAP.md)*`,
+].join("\n");
+
+console.log("Posting report to tracking issue…");
+if (REPO) {
+  await postIssueComment(body);
+  console.log(`Posted to issue #${TRACKING_ISSUE}.`);
+} else {
+  console.log("REPO not set — printing report:\n", body);
+}


### PR DESCRIPTION
## Summary

- `scripts/stale-gate-sweeper.mjs` — scans `src/`, `scripts/`, `sst.config.ts` with `git grep` using 10 stale-marker patterns; fetches code context (4 lines per match) + recent commits; calls Claude Haiku to evaluate which cleanup conditions are met; posts a two-section triage report (Ready to remove / Not yet) to issue #382
- `.github/workflows/stale-gate-sweeper.yml` — weekly cron (Monday 09:00 UTC) + `workflow_dispatch`; OIDC → AWS SSM for `ANTHROPIC_API_KEY`; same pattern as `ci-babysitter.yml`
- `docs/AGENTS_ROADMAP.md` — Phase 4c marked SHIPPED

## Test plan

- [ ] `GITHUB_TOKEN=... ANTHROPIC_API_KEY=... REPO=Themis128/cloudless.gr node scripts/stale-gate-sweeper.mjs` runs locally
- [ ] Workflow appears in Actions tab → can be triggered manually via `workflow_dispatch`
- [ ] Weekly schedule fires Monday 09:00 UTC and posts to issue #382

https://claude.ai/code/session_01PHsA9s3tK2thgSJVwEGuWq

---
_Generated by [Claude Code](https://claude.ai/code/session_01PHsA9s3tK2thgSJVwEGuWq)_