### PR TITLE
feat(e2e): Cognito test-user provisioning (replaces deleted Keycloak script)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,7 +1,9 @@
 <!-- BEGIN:nextjs-agent-rules -->
+
 # This is NOT the Next.js you know
 
 This version has breaking changes — APIs, conventions, and file structure may all differ from your training data. Read the relevant guide in `node_modules/next/dist/docs/` before writing any code. Heed deprecation notices.
+
 <!-- END:nextjs-agent-rules -->
 
 # Cloudless.gr — Project Architecture
@@ -13,7 +15,7 @@ This version has breaking changes — APIs, conventions, and file structure may 
 - **3D:** @react-three/fiber + @react-three/drei + three.js
 - **Animation:** GSAP (ScrollTrigger) + Lenis smooth scroll
 - **Command palette:** cmdk
-- **Auth:** Keycloak + next-auth v5 (default); AWS Cognito optional (when `COGNITO_ISSUER` is set)
+- **Auth:** AWS Cognito + next-auth v5 (production default, when `COGNITO_ISSUER` is set); Keycloak fallback
 - **Payments:** Stripe (webhooks, checkout)
 - **Email:** AWS SES
 - **Secrets:** AWS SSM Parameter Store (no .env files in prod)
@@ -41,7 +43,7 @@ This version has breaking changes — APIs, conventions, and file structure may 
 - **CTA gradients:** `bg-gradient-to-r from-neon-cyan/10 via-neon-blue/10 to-neon-magenta/10`
 - **FAQ details:** `bg-void border border-slate-800 rounded-xl open:border-neon-cyan/30`
 - **Section borders:** `border-y border-slate-800` (was `border-neon-cyan/10`)
-- **IMPORTANT:** Never use dynamic Tailwind class names (e.g., `` bg-${var}/10 ``). Tailwind 4 JIT cannot detect them. Use a static class mapping object instead.
+- **IMPORTANT:** Never use dynamic Tailwind class names (e.g., `bg-${var}/10`). Tailwind 4 JIT cannot detect them. Use a static class mapping object instead.
 
 ## Project Structure
 
@@ -131,8 +133,7 @@ src/
 │   ├── ssm-config.ts            # SSM secrets loader (5-min TTL, fails fast on required keys)
 │   ├── integrations.ts          # isConfigured() guards for all optional integrations
 │   ├── api-auth.ts              # requireAuth() / requireAdmin() — OIDC JWKS verification (Keycloak or Cognito)
-│   ├── auth.ts                  # next-auth v5 config — Keycloak default; Cognito when COGNITO_ISSUER set
-│   ├── keycloak-auth.ts         # Keycloak auth adapter (implements AuthContext interface)
+│   ├── auth.ts                  # next-auth v5 config — Cognito when COGNITO_ISSUER set, Keycloak fallback
 │   ├── email.ts                 # SES: sendEmail, sendOrderConfirmation, notifyTeam
 │   ├── ses-suppression.ts       # SES suppression list management
 │   ├── stripe.ts                # Stripe client, product/session helpers
@@ -217,10 +218,10 @@ sequenceDiagram
     end
 ```
 
-- **Provider:** Keycloak (`auth.cloudless.gr`, realm `master`); AWS Cognito is an optional fallback when `COGNITO_ISSUER` is set
-- **Env vars required:** `KEYCLOAK_ISSUER` + `KEYCLOAK_CLIENT_ID` + `KEYCLOAK_CLIENT_SECRET` + `AUTH_SECRET` (see `.env.example`)
-- **Admin group:** `admin` — checked via JWT `groups` claim (Keycloak) or `cognito:groups` (Cognito)
-- **AuthProvider:** Wraps entire app in `layout.tsx`; exposes `signIn`/`signOut`/`useAuth()` via `src/context/AuthContext.tsx` + `src/lib/keycloak-auth.ts`
+- **Provider:** AWS Cognito (Hosted UI) when `COGNITO_ISSUER` is set — the production default since the 2026-06 migration; Keycloak (`auth.cloudless.gr`, realm `master`) is the fallback when Cognito is not configured
+- **Env vars required:** `COGNITO_ISSUER` + `COGNITO_CLIENT_ID` + `COGNITO_CLIENT_SECRET` + `COGNITO_DOMAIN` + `AUTH_SECRET` (Cognito); or `KEYCLOAK_ISSUER` + `KEYCLOAK_CLIENT_ID` + `KEYCLOAK_CLIENT_SECRET` + `AUTH_SECRET` (Keycloak fallback). See `.env.example`
+- **Admin group:** `admin` — checked via JWT `cognito:groups` claim (Cognito) or `groups` (Keycloak)
+- **AuthProvider:** Wraps entire app in `layout.tsx`; exposes `signIn`/`signOut`/`useAuth()` via `src/context/AuthContext.tsx` (delegates to next-auth `signIn`/`signOut`)
 - **Route protection:** Server-side via `src/proxy.ts` middleware (before the page renders) + client-side layout guards
   - `/dashboard/*` → redirects to `/auth/login` if not authenticated
   - `/admin/*` → redirects to `/dashboard` if not in admin group, `/auth/login` if not authenticated
@@ -348,15 +349,16 @@ All integrations are optional and degrade gracefully. Config is centralized in `
 
 **Required env vars per integration:**
 
-| Integration        | Env vars                                                     | Lib file            |
-| ------------------ | ------------------------------------------------------------ | ------------------- |
-| Slack              | `SLACK_WEBHOOK_URL`                                          | `slack-notify.ts`   |
-| HubSpot CRM        | `HUBSPOT_API_KEY`                                            | `hubspot.ts`        |
-| Notion CMS         | `NOTION_API_KEY`, `NOTION_BLOG_DB`                           | `notion-blog.ts`    |
-| Google Calendar    | `GOOGLE_SERVICE_ACCOUNT_EMAIL`, `GOOGLE_PRIVATE_KEY`, `GOOGLE_CALENDAR_ID` | `google-calendar.ts` |
-| Sentry             | `SENTRY_AUTH_TOKEN`, `SENTRY_ORG`, `SENTRY_PROJECT`          | (inline in route)   |
+| Integration     | Env vars                                                                   | Lib file             |
+| --------------- | -------------------------------------------------------------------------- | -------------------- |
+| Slack           | `SLACK_WEBHOOK_URL`                                                        | `slack-notify.ts`    |
+| HubSpot CRM     | `HUBSPOT_API_KEY`                                                          | `hubspot.ts`         |
+| Notion CMS      | `NOTION_API_KEY`, `NOTION_BLOG_DB`                                         | `notion-blog.ts`     |
+| Google Calendar | `GOOGLE_SERVICE_ACCOUNT_EMAIL`, `GOOGLE_PRIVATE_KEY`, `GOOGLE_CALENDAR_ID` | `google-calendar.ts` |
+| Sentry          | `SENTRY_AUTH_TOKEN`, `SENTRY_ORG`, `SENTRY_PROJECT`                        | (inline in route)    |
 
 **Integration patterns:**
+
 - **Fire-and-forget:** Contact route uses `Promise.allSettled([slackContactNotify, hubspotUpsert]).catch(() => {})` so the main email flow isn't blocked
 - **Fallback:** Blog API returns static `lib/blog.ts` data when Notion isn't configured
 - **Cache:** Calendar availability is cached 5 minutes; Google OAuth tokens cached until expiry
@@ -399,6 +401,7 @@ The Stripe webhook handler (`api/webhooks/stripe/route.ts`) processes these even
 - **`invoice.payment_succeeded`**: Logs payment (no email)
 
 Email sending is handled by `src/lib/email.ts` which provides:
+
 - `sendEmail()`: Low-level SES wrapper with cached client
 - `sendOrderConfirmation()`: Customer order receipt with cyberpunk-styled HTML
 - `sendPaymentFailureNotice()`: Payment failure alert with support CTA

--- a/docs/test-accounts.md
+++ b/docs/test-accounts.md
@@ -7,38 +7,40 @@ guards), which is the source of truth.
 
 ## Identity provider
 
-- **Keycloak**, realm **`master`**, at `https://auth.cloudless.gr`
-  (issuer `https://auth.cloudless.gr/realms/master`, client `cloudless`).
+- **AWS Cognito** Hosted UI (production default since the 2026-06 migration),
+  pool **`cloudless-auth`**, app client **`cloudless-app`**. Keycloak
+  (realm `master`, `https://auth.cloudless.gr`) remains the fallback when
+  `COGNITO_ISSUER` is not set.
 - The session is a **next-auth (Auth.js) v5** JWT carried in the
   `authjs.session-token` cookie (`__Secure-` prefix in production).
 - The login form is served at `/{locale}/auth/login` (e.g. `/en/auth/login`).
-  When `NEXT_PUBLIC_KEYCLOAK_ISSUER` is set, the form renders a single
-  "Continue with Keycloak" button that hands off to Keycloak's hosted login
-  (`src/app/[locale]/auth/login/page.tsx:155-166`).
+  When `NEXT_PUBLIC_AUTH_PROVIDER=cognito`, the form renders a single
+  "Continue with AWS" button that hands off to the Cognito Hosted UI
+  (`src/app/[locale]/auth/login/page.tsx`).
 
-## How "admin" is decided (group membership, not a realm role)
+## How "admin" is decided (group membership, not a role)
 
-Admin status is **Keycloak `admin` group membership**, surfaced into the
-next-auth token as a `groups` claim:
+Admin status is **`admin` group membership**, surfaced into the next-auth
+token as a groups claim (`cognito:groups` on Cognito, `groups` on Keycloak):
 
-- **Page routes** — `src/proxy.ts:42-48` reads the next-auth JWT and treats
-  a user as admin if `groups` includes `"admin"` (it also accepts a
-  `roles` containing `admin`/`realm:admin` as a fallback).
-- **API routes** — `src/lib/api-auth.ts` (`isAdmin`) checks the
-  decoded token's `groups` for `"admin"`; `requireAdmin`
-  returns **403** when that group is absent.
+- **Page routes** — `src/proxy.ts` reads the next-auth JWT and treats a user
+  as admin if the groups claim includes `"admin"`.
+- **API routes** — `src/lib/api-auth.ts` (`isAdmin`) checks both `groups`
+  and `cognito:groups` for `"admin"`; `requireAdmin` returns **403** when
+  that group is absent.
 
-> The `groups` claim only appears in the token if the Keycloak `cloudless`
-> client has the **Group Membership** protocol mapper. The provisioning
-> script below installs that mapper automatically.
+> On Cognito the `cognito:groups` claim is emitted automatically for any
+> user added to the `admin` group — no protocol mapper needed (unlike
+> Keycloak). The provisioning script below adds the admin test user to that
+> group.
 
 ## Access tiers
 
-| Tier | Routes | Requirement | Enforced by |
-| --- | --- | --- | --- |
-| **Public** | everything else | none | `src/proxy.ts` passes through to next-intl |
-| **Authenticated user** | `/dashboard/**` | any valid next-auth session | `src/proxy.ts:328-338` |
-| **Admin** | `/admin/**`, `/api/admin/**` | session **+** `admin` group | `src/proxy.ts:331-333` (pages), `requireAdmin` (API) |
+| Tier                   | Routes                       | Requirement                 | Enforced by                                          |
+| ---------------------- | ---------------------------- | --------------------------- | ---------------------------------------------------- |
+| **Public**             | everything else              | none                        | `src/proxy.ts` passes through to next-intl           |
+| **Authenticated user** | `/dashboard/**`              | any valid next-auth session | `src/proxy.ts:328-338`                               |
+| **Admin**              | `/admin/**`, `/api/admin/**` | session **+** `admin` group | `src/proxy.ts:331-333` (pages), `requireAdmin` (API) |
 
 Behavior details:
 
@@ -49,40 +51,39 @@ Behavior details:
   `/{locale}/dashboard` (`src/proxy.ts:331-333`). API routes return **403**.
 - `/portal/**` is excluded from the middleware matcher
   (`src/proxy.ts:381`) — portal access uses its own magic-link token, not
-  the Keycloak session.
+  the next-auth session.
 
 ## The two test accounts
 
-These are exactly what `scripts/e2e-keycloak-provision.sh` creates:
+These are exactly what `scripts/e2e-cognito-provision.sh` creates:
 
-| Account | Email | Group | Can reach |
-| --- | --- | --- | --- |
-| **Test user** | `e2e-user@cloudless.gr` | none | `/dashboard/**`; **blocked** from `/admin` (redirected to `/dashboard`) |
-| **Test admin** | `e2e-admin@cloudless.gr` | `admin` | `/admin/**`, `/api/admin/**`, plus `/dashboard/**` |
+| Account        | Email                    | Group   | Can reach                                                               |
+| -------------- | ------------------------ | ------- | ----------------------------------------------------------------------- |
+| **Test user**  | `e2e-user@cloudless.gr`  | none    | `/dashboard/**`; **blocked** from `/admin` (redirected to `/dashboard`) |
+| **Test admin** | `e2e-admin@cloudless.gr` | `admin` | `/admin/**`, `/api/admin/**`, plus `/dashboard/**`                      |
 
 The plain user deliberately has **no** group — that is what proves the
 `/admin` gate works: it should be bounced to `/dashboard`.
 
 ## Creating the accounts (existing tooling)
 
-There is already a provisioning script. It is idempotent (re-running only
-resets the password + group membership), ensures the `admin` group exists,
-and installs the `groups` protocol mapper on the `cloudless` client. It
-needs a Keycloak admin password — pulled from SSM
-(`/cloudless/production/KEYCLOAK_ADMIN_PASSWORD`) when AWS creds + `aws`
-CLI are present, otherwise prompted / read from `KEYCLOAK_ADMIN_PASSWORD`.
+`scripts/e2e-cognito-provision.sh` provisions both users in the Cognito
+`cloudless-auth` pool. It is idempotent (re-running only resets the password
+and group membership), ensures the `admin` group exists, and gives each user
+a **permanent** password so Playwright can drive the Hosted UI login directly
+(no FORCE_CHANGE_PASSWORD step). It needs AWS creds with `cognito-idp` admin
+permissions; the pool/client are discovered by name (no hard-coded IDs).
 
 ```bash
-pnpm e2e:keycloak:dry     # preview — no writes
-pnpm e2e:keycloak         # create / update both users, write .env.e2e
+pnpm e2e:cognito:dry      # preview — no writes
+pnpm e2e:cognito          # create / update both users, write .env.e2e
 ```
 
 On success it writes `E2E_USER_EMAIL/PASSWORD` and
 `E2E_ADMIN_EMAIL/PASSWORD` into a gitignored `.env.e2e`.
 
-> In a cloud session without the `aws` CLI or Keycloak admin password,
-> export `KEYCLOAK_ADMIN_PASSWORD` first (ideally as a session secret), or
-> run this step where those creds exist.
+> In a cloud session without the `aws` CLI or AWS creds, run this step where
+> those creds exist (or via the e2e CI job that assumes the deploy role).
 
 ## Testing the login
 
@@ -94,7 +95,7 @@ It **skips** unless the matching `E2E_*` env vars are set.
 ```bash
 # Local suite (reads .env.e2e via scripts/e2e-with-env.sh):
 pnpm e2e:setup            # bootstrap .env.e2e (CRON_SECRET + creds)
-pnpm e2e:keycloak         # provision the two test users
+pnpm e2e:cognito          # provision the two test users
 pnpm e2e:run:admin        # admin-scoped specs
 pnpm e2e:run:user         # user-scoped specs
 

--- a/package.json
+++ b/package.json
@@ -48,6 +48,8 @@
     "newsletter:report": "tsx --tsconfig scripts/tsconfig.json scripts/weekly-subscriber-report.ts",
     "cognito:migrate": "bash scripts/migrate-keycloak-to-cognito.sh",
     "cognito:migrate:dry": "DRY_RUN=1 bash scripts/migrate-keycloak-to-cognito.sh",
+    "e2e:cognito": "bash scripts/e2e-cognito-provision.sh",
+    "e2e:cognito:dry": "bash scripts/e2e-cognito-provision.sh --dry-run",
     "keycloak:ensure": "bash scripts/keycloak-ensure.sh",
     "mcp-security-scan": "cd tools/mcp-security-scanner && npm install && npm run scan -- --path \"../../src/**/*.{ts,tsx,js,jsx,py,md}\"",
     "mcp-security-scan:server": "cd tools/mcp-security-scanner && npm install && npm run scan -- --path \"../../src/{app/api,lib}/**/*.{ts,tsx,js,jsx,py,md}\"",

--- a/scripts/e2e-cognito-provision.sh
+++ b/scripts/e2e-cognito-provision.sh
@@ -1,0 +1,145 @@
+#!/usr/bin/env bash
+#
+# e2e-cognito-provision.sh — provision the two E2E test users in AWS Cognito.
+#
+#   e2e-user@cloudless.gr   — regular user (no group)
+#   e2e-admin@cloudless.gr  — member of the "admin" group → isAdmin() returns true
+#
+# Cognito replacement for the retired e2e-keycloak-provision.sh. Both users get
+# a PERMANENT password (admin-set-user-password --permanent) so Playwright can
+# drive the Cognito Hosted UI login directly — no FORCE_CHANGE_PASSWORD step.
+#
+# Idempotent: an existing user is reused; only the password and group membership
+# are (re)applied. Writes the resulting creds into .env.e2e for Playwright.
+#
+# Usage:
+#   bash scripts/e2e-cognito-provision.sh            # provision + write .env.e2e
+#   bash scripts/e2e-cognito-provision.sh --dry-run  # show what would happen
+#
+# Requires: aws CLI + AWS creds with cognito-idp admin permissions.
+# Pool/client are discovered by name (POOL_NAME=cloudless-auth) — no hard IDs.
+
+set -uo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+ENV_FILE="$REPO_ROOT/.env.e2e"
+POOL_NAME="${POOL_NAME:-cloudless-auth}"
+ADMIN_GROUP="${ADMIN_GROUP:-admin}"
+export AWS_REGION="${AWS_REGION:-us-east-1}"
+
+DRY_RUN=0
+for arg in "$@"; do
+  case "$arg" in
+    --dry-run) DRY_RUN=1 ;;
+    -h|--help) sed -n '1,20p' "$0"; exit 0 ;;
+  esac
+done
+
+log()  { printf "\033[1;36m[cognito]\033[0m %s\n" "$*"; }
+warn() { printf "\033[1;33m[cognito]\033[0m %s\n" "$*"; }
+err()  { printf "\033[1;31m[cognito]\033[0m %s\n" "$*" >&2; }
+
+command -v aws >/dev/null 2>&1 || { err "aws CLI not found"; exit 1; }
+
+# ─── resolve pool by name ────────────────────────────────────
+log "Resolving Cognito pool '$POOL_NAME' in $AWS_REGION"
+POOL_ID=$(aws cognito-idp list-user-pools --max-results 60 \
+  --query "UserPools[?Name=='$POOL_NAME'].Id" --output text 2>/dev/null)
+if [ -z "$POOL_ID" ] || [ "$POOL_ID" = "None" ]; then
+  err "pool '$POOL_NAME' not found — is the SST deploy complete?"; exit 1
+fi
+log "  pool: $POOL_ID"
+
+# ─── ensure the admin group exists ───────────────────────────
+if ! aws cognito-idp get-group --user-pool-id "$POOL_ID" --group-name "$ADMIN_GROUP" \
+       >/dev/null 2>&1; then
+  if [ "$DRY_RUN" = "1" ]; then
+    log "  (dry-run) would create group '$ADMIN_GROUP'"
+  else
+    aws cognito-idp create-group --user-pool-id "$POOL_ID" --group-name "$ADMIN_GROUP" \
+      >/dev/null 2>&1 && log "  + created group '$ADMIN_GROUP'" \
+      || warn "  ! could not create group '$ADMIN_GROUP' (may already exist)"
+  fi
+else
+  log "  = group '$ADMIN_GROUP' exists"
+fi
+
+# ─── provision a single user ─────────────────────────────────
+provision_user() {
+  local email="$1" password="$2" add_to_admin="$3"
+  log "Provisioning $email"
+
+  if [ "$DRY_RUN" = "1" ]; then
+    log "  (dry-run) would admin-create-user + set permanent password" \
+        "${add_to_admin:++ add to $ADMIN_GROUP}"
+    return
+  fi
+
+  # Create (idempotent — ignore UsernameExistsException)
+  local create_err
+  create_err=$(aws cognito-idp admin-create-user \
+    --user-pool-id "$POOL_ID" --username "$email" \
+    --user-attributes "Name=email,Value=$email" "Name=email_verified,Value=true" \
+    --message-action SUPPRESS --output text 2>&1 >/dev/null) || true
+  if echo "$create_err" | grep -q "UsernameExistsException"; then
+    log "  = user exists"
+  elif [ -n "$create_err" ]; then
+    err "  create failed: $create_err"; return 1
+  else
+    log "  + created user"
+  fi
+
+  # Permanent password → direct Hosted UI login works for Playwright
+  aws cognito-idp admin-set-user-password \
+    --user-pool-id "$POOL_ID" --username "$email" \
+    --password "$password" --permanent >/dev/null \
+    && log "  ✓ permanent password set"
+
+  if [ "$add_to_admin" = "1" ]; then
+    aws cognito-idp admin-add-user-to-group \
+      --user-pool-id "$POOL_ID" --username "$email" --group-name "$ADMIN_GROUP" \
+      >/dev/null 2>&1 && log "  ✓ added to $ADMIN_GROUP group" \
+      || warn "  ! could not add to $ADMIN_GROUP"
+  fi
+}
+
+# Strong random passwords (Cognito default policy: ≥8 chars; complexity tail added)
+USER_PASS="$(head -c 18 /dev/urandom | base64 | tr -d '/+=' | head -c 24)Aa1!"
+ADMIN_PASS="$(head -c 18 /dev/urandom | base64 | tr -d '/+=' | head -c 24)Aa1!"
+echo "::add-mask::$USER_PASS"; echo "::add-mask::$ADMIN_PASS"
+
+provision_user "e2e-user@cloudless.gr"  "$USER_PASS"  0
+provision_user "e2e-admin@cloudless.gr" "$ADMIN_PASS" 1
+
+if [ "$DRY_RUN" = "1" ]; then
+  log ""
+  log "Dry-run complete — no changes written."
+  exit 0
+fi
+
+# ─── write to .env.e2e ───────────────────────────────────────
+upsert() {
+  local key="$1" value="$2"
+  touch "$ENV_FILE"
+  if grep -qE "^${key}=" "$ENV_FILE"; then
+    sed -i.bak -E "s|^${key}=.*$|${key}=${value//|/\\|}|" "$ENV_FILE" 2>/dev/null \
+      || sed -i '' -E "s|^${key}=.*$|${key}=${value//|/\\|}|" "$ENV_FILE"
+    rm -f "${ENV_FILE}.bak" 2>/dev/null || true
+  else
+    printf "%s=%s\n" "$key" "$value" >> "$ENV_FILE"
+  fi
+}
+
+upsert "E2E_USER_EMAIL"     "e2e-user@cloudless.gr"
+upsert "E2E_USER_PASSWORD"  "$USER_PASS"
+upsert "E2E_ADMIN_EMAIL"    "e2e-admin@cloudless.gr"
+upsert "E2E_ADMIN_PASSWORD" "$ADMIN_PASS"
+chmod 600 "$ENV_FILE"
+
+log ""
+log "✓ Wrote credentials to $ENV_FILE"
+log "  e2e-user@cloudless.gr   (regular user)"
+log "  e2e-admin@cloudless.gr  ($ADMIN_GROUP group)"
+log ""
+log "Next: pnpm e2e:setup:ssm   # pull CRON_SECRET"
+log "      pnpm test:e2e         # run full suite"


### PR DESCRIPTION
## Summary

Closes a gap opened by the Phase 6 Keycloak decommission (#604): it removed `scripts/e2e-keycloak-provision.sh` with no Cognito replacement, but production auth is now Cognito — so the Playwright e2e suite had no way to provision test accounts.

- **`scripts/e2e-cognito-provision.sh`** — provisions `e2e-user@cloudless.gr` (no group) and `e2e-admin@cloudless.gr` (admin group) in the `cloudless-auth` pool. Uses **permanent** passwords (`admin-set-user-password --permanent`) so Playwright can drive the Cognito Hosted UI login directly. Idempotent; pool/client discovered by name; supports `--dry-run`. Writes the same `.env.e2e` keys as the old script (`E2E_USER/ADMIN_EMAIL/PASSWORD`).
- **`package.json`** — `e2e:cognito` / `e2e:cognito:dry`.
- **`docs/test-accounts.md`** — rewritten for the Cognito Hosted UI flow and the new script; documents that `cognito:groups` is emitted automatically (no protocol mapper needed, unlike Keycloak).
- **`AGENTS.md`** — Cognito-as-default auth description; removed the file-tree entry for the deleted `keycloak-auth.ts`.

## Test plan

- [ ] `pnpm e2e:cognito:dry` — verify it resolves the pool and reports the two users without writing
- [ ] `pnpm e2e:cognito` — verify both users created, admin in `admin` group, `.env.e2e` written
- [ ] `pnpm e2e:run:admin` / `pnpm e2e:run:user` — green against the Cognito Hosted UI

https://claude.ai/code/session_01SFLAFG395WWQcyj69toXbT

---
_Generated by [Claude Code](https://claude.ai/code/session_01SFLAFG395WWQcyj69toXbT)_