### PR TITLE
chore: mark Phase 2c SHIPPED, remove flushEventQueue no-op call

### DIFF
--- a/docs/AGENTS_ROADMAP.md
+++ b/docs/AGENTS_ROADMAP.md
@@ -59,9 +59,11 @@ Guardrails:
 
 Implementation: `src/lib/agent-book.ts` + `src/app/api/agent/book/route.ts`. Tests in `__tests__/agent-book-api.test.ts`.
 
-### Phase 2c — admin assistant
+### Phase 2c — admin assistant — SHIPPED
 
-`/admin/assistant` page (already partially scaffolded) becomes a multi-tool agent: `search_notion`, `summarize_recent_orders`, `draft_email`. Admin-only, lower stakes than the public chat.
+`/admin/assistant` page hosts a multi-tool agent: `search_notion`, `get_recent_orders`, `draft_email`. Admin-only, lower stakes than the public chat.
+
+Implementation: `src/lib/admin-assistant-tools.ts` (tool definitions + executors) + `src/app/api/admin/ai/assistant/route.ts` (Anthropic Messages API tool-use loop, max 4 iterations, `requireAdmin` guard) + chat UI on `src/app/[locale]/admin/ai-assistant/page.tsx`. Tests (7 specs) in `__tests__/admin-assistant-api.test.ts`.
 
 **Cost model**: bursty — only used by admins. Probably under $5/month even at heavy use.
 

--- a/docs/ANTHROPIC.md
+++ b/docs/ANTHROPIC.md
@@ -4,6 +4,7 @@ cloudless.gr uses Claude on two distinct surfaces with different backends:
 
 1. **Public chatbot agent** — `ChatWidget` on every page; calls `/api/chat`. Backed by **AWS Bedrock Converse API** (IAM auth, no API key) with a tool-use loop and three tools (`lookup_product`, `check_calendar_availability`, `book_slot`). The final response is delivered as SSE so the widget keeps its existing event handling.
 2. **Admin AI tools** — copy generation, campaign strategy, audience targeting, and report insights under `/api/admin/ai/*`. Uses the **Anthropic Messages API** directly via `src/lib/anthropic.ts`.
+3. **Admin assistant** — multi-tool chat agent on `/admin/assistant`; calls `/api/admin/ai/assistant`. Tool-use loop (max 4 iterations) with `search_notion`, `get_recent_orders`, `draft_email` tools. See [Phase 2c in AGENTS_ROADMAP.md](AGENTS_ROADMAP.md).
 
 > **Status:** `/api/chat` returns 503 when `AccessDeniedException` is thrown by Bedrock (IAM misconfiguration) or 502 on transient failures. Admin AI routes return 503 when `ANTHROPIC_API_KEY` is absent. The rest of the site is unaffected.
 >

--- a/src/app/api/cron/analytics-rollup/route.ts
+++ b/src/app/api/cron/analytics-rollup/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
-import { createWeeklyRollup, archiveOldEvents, flushEventQueue } from "@/lib/notion-analytics";
+import { createWeeklyRollup, archiveOldEvents } from "@/lib/notion-analytics";
 import { SlackClient } from "@/lib/slack-notify";
 import { isCronAuthorized, cronUnauthorized } from "@/lib/cron-auth";
 
@@ -7,9 +7,6 @@ export async function GET(request: NextRequest) {
   if (!(await isCronAuthorized(request))) {
     return cronUnauthorized();
   }
-
-  // Flush any queued events before creating the rollup so counts are accurate
-  await flushEventQueue();
 
   const [rollupId, archiveResult] = await Promise.all([createWeeklyRollup(), archiveOldEvents(30)]);
 


### PR DESCRIPTION
## Summary

- `docs/AGENTS_ROADMAP.md` — Phase 2c admin assistant marked SHIPPED (implementation was merged in PR #608 but roadmap wasn't updated)
- `docs/ANTHROPIC.md` — admin assistant added as a third AI surface in the architecture overview
- `src/app/api/cron/analytics-rollup/route.ts` — remove `flushEventQueue` import and call; it's been a no-op since the queue was removed from `notion-analytics.ts`, and no other callers exist

## Test plan

- [x] `pnpm vitest run __tests__/cron-analytics-rollup.test.ts` — 9 tests pass

https://claude.ai/code/session_01PHsA9s3tK2thgSJVwEGuWq

---
_Generated by [Claude Code](https://claude.ai/code/session_01PHsA9s3tK2thgSJVwEGuWq)_