### PR TITLE
fix(api): correct requireAdmin usage in AI assistant route

### DIFF
--- a/src/app/api/admin/ai/assistant/route.ts
+++ b/src/app/api/admin/ai/assistant/route.ts
@@ -43,8 +43,8 @@ interface AnthropicResponse {
 }
 
 export async function POST(req: NextRequest) {
-  const authError = await requireAdmin(req);
-  if (authError) return authError;
+  const auth = await requireAdmin(req);
+  if (!auth.ok) return auth.response;
 
   if (!(await isAnthropicConfigured())) {
     return NextResponse.json(


### PR DESCRIPTION
## Summary

- The AI assistant route at `src/app/api/admin/ai/assistant/route.ts` was introduced in PR #608 using the old `requireAdmin` pattern (`if (authError) return authError`)
- PR #604 changed `requireAdmin` to return `AuthResult` (`AuthSuccess | AuthError`) instead of `NextResponse | null`
- `AuthSuccess` is not a `Response`, so the Next.js build TypeScript check failed, blocking all deploys since #609

## Fix

Changed lines 46–47 from the old pattern to the standard one used by every other route:
```ts
// before
const authError = await requireAdmin(req);
if (authError) return authError;

// after
const auth = await requireAdmin(req);
if (!auth.ok) return auth.response;
```

## Test plan
- [ ] TypeScript build succeeds (`pnpm build`)
- [ ] Deploy to Production succeeds

https://claude.ai/code/session_013sTDMVEYibee8tbXxrwjzo

---
_Generated by [Claude Code](https://claude.ai/code/session_013sTDMVEYibee8tbXxrwjzo)_