### PR TITLE
feat(admin/users): Cognito as primary auth provider, Keycloak fallback

### DIFF
--- a/src/app/[locale]/admin/users/page.tsx
+++ b/src/app/[locale]/admin/users/page.tsx
@@ -3,7 +3,7 @@
 import { fetchWithAuth } from "@/lib/fetch-with-auth";
 import { useEffect, useState, useCallback } from "react";
 
-interface KeycloakUser {
+interface AdminUser {
   username: string;
   email: string;
   name: string;
@@ -37,7 +37,8 @@ const userStatusClasses: Record<string, string> = {
 };
 
 export default function AdminUsersPage() {
-  const [users, setUsers] = useState<KeycloakUser[]>([]);
+  const [users, setUsers] = useState<AdminUser[]>([]);
+  const [provider, setProvider] = useState<string>("cognito");
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [search, setSearch] = useState("");
@@ -52,6 +53,7 @@ export default function AdminUsersPage() {
       if (!res.ok) throw new Error(`HTTP ${res.status}`);
       const data = await res.json();
       setUsers(data.users ?? []);
+      if (data.provider) setProvider(data.provider);
     } catch (err) {
       setError(err instanceof Error ? err.message : "Failed to load users");
     } finally {
@@ -117,7 +119,7 @@ export default function AdminUsersPage() {
         </div>
         <h1 className="font-heading text-2xl font-bold text-white">User Management</h1>
         <p className="font-body mt-1 text-slate-400">
-          Keycloak user directory — manage accounts, roles, and access.
+          User directory — manage accounts, roles, and access.
         </p>
       </div>
 
@@ -182,8 +184,7 @@ export default function AdminUsersPage() {
         <div className="bg-void-light/50 rounded-xl border border-red-900/30 p-6 text-center">
           <p className="font-mono text-sm text-red-400">{error}</p>
           <p className="mt-2 text-xs text-slate-500">
-            Check that KEYCLOAK_ADMIN_USER and KEYCLOAK_ADMIN_PASSWORD are set in SSM and that the
-            Keycloak admin REST API is reachable.
+            Check that the auth provider (Cognito or Keycloak) is configured correctly in SSM.
           </p>
         </div>
       ) : (
@@ -326,7 +327,7 @@ export default function AdminUsersPage() {
       <p className="mt-4 font-mono text-xs text-slate-600">
         Powered by{" "}
         <span className="text-slate-500">
-          Keycloak · {process.env.NEXT_PUBLIC_KEYCLOAK_ISSUER ?? "not configured"}
+          {provider === "cognito" ? "AWS Cognito" : provider === "keycloak" ? "Keycloak" : "—"}
         </span>
       </p>
     </div>

--- a/src/app/api/admin/users/route.ts
+++ b/src/app/api/admin/users/route.ts
@@ -1,20 +1,136 @@
 import { NextRequest, NextResponse } from "next/server";
 import { requireAdmin } from "@/lib/api-auth";
 import { getConfig } from "@/lib/ssm-config";
+import {
+  CognitoIdentityProviderClient,
+  ListUsersCommand,
+  AdminListGroupsForUserCommand,
+  AdminEnableUserCommand,
+  AdminDisableUserCommand,
+  AdminAddUserToGroupCommand,
+  AdminRemoveUserFromGroupCommand,
+} from "@aws-sdk/client-cognito-identity-provider";
+
+// ---------------------------------------------------------------------------
+// Shared user shape (compatible with both Cognito and Keycloak)
+// ---------------------------------------------------------------------------
+
+interface AdminUser {
+  username: string;
+  email: string;
+  name: string;
+  company: string;
+  phone: string;
+  status: "active" | "disabled";
+  emailVerified: boolean;
+  userStatus: string;
+  role: "admin" | "user";
+  created?: string;
+  lastModified?: string;
+}
+
+// ---------------------------------------------------------------------------
+// Cognito helpers
+// ---------------------------------------------------------------------------
+
+function getUserPoolId(issuer: string): string {
+  // issuer format: https://cognito-idp.{region}.amazonaws.com/{userPoolId}
+  return issuer.split("/").at(-1) ?? "";
+}
+
+function cognitoClient(issuer: string): CognitoIdentityProviderClient {
+  const region = issuer.match(/cognito-idp\.([^.]+)\.amazonaws\.com/)?.[1] ?? "us-east-1";
+  return new CognitoIdentityProviderClient({ region });
+}
+
+function cognitoAttr(attrs: Array<{ Name?: string; Value?: string }>, name: string): string {
+  return attrs.find((a) => a.Name === name)?.Value ?? "";
+}
+
+async function listCognitoUsers(issuer: string, limit: number, filter?: string): Promise<AdminUser[]> {
+  const client = cognitoClient(issuer);
+  const userPoolId = getUserPoolId(issuer);
+
+  const cmd = new ListUsersCommand({
+    UserPoolId: userPoolId,
+    Limit: limit,
+    ...(filter ? { Filter: `email ^= "${filter}"` } : {}),
+  });
+  const res = await client.send(cmd);
+  const rawUsers = res.Users ?? [];
+
+  return Promise.all(
+    rawUsers.map(async (u) => {
+      const attrs = u.Attributes ?? [];
+      let isAdmin = false;
+      try {
+        const grRes = await client.send(
+          new AdminListGroupsForUserCommand({ UserPoolId: userPoolId, Username: u.Username ?? "" })
+        );
+        isAdmin = (grRes.Groups ?? []).some((g) => g.GroupName === "admin");
+      } catch {
+        /* default non-admin */
+      }
+
+      return {
+        username: u.Username ?? "",
+        email: cognitoAttr(attrs, "email"),
+        name: [cognitoAttr(attrs, "given_name"), cognitoAttr(attrs, "family_name")]
+          .filter(Boolean)
+          .join(" ") || cognitoAttr(attrs, "name"),
+        company: cognitoAttr(attrs, "custom:company"),
+        phone: cognitoAttr(attrs, "phone_number"),
+        emailVerified: cognitoAttr(attrs, "email_verified") === "true",
+        status: u.Enabled ? "active" : "disabled",
+        userStatus: u.UserStatus ?? "UNKNOWN",
+        role: isAdmin ? "admin" : "user",
+        created: u.UserCreateDate?.toISOString(),
+        lastModified: u.UserLastModifiedDate?.toISOString(),
+      } satisfies AdminUser;
+    })
+  );
+}
+
+async function mutateCognitoUser(
+  issuer: string,
+  username: string,
+  action: string
+): Promise<{ success: boolean; message: string }> {
+  const client = cognitoClient(issuer);
+  const userPoolId = getUserPoolId(issuer);
+
+  switch (action) {
+    case "disable":
+      await client.send(new AdminDisableUserCommand({ UserPoolId: userPoolId, Username: username }));
+      return { success: true, message: "User disabled" };
+    case "enable":
+      await client.send(new AdminEnableUserCommand({ UserPoolId: userPoolId, Username: username }));
+      return { success: true, message: "User enabled" };
+    case "promote":
+      await client.send(
+        new AdminAddUserToGroupCommand({ UserPoolId: userPoolId, Username: username, GroupName: "admin" })
+      );
+      return { success: true, message: "User promoted to admin" };
+    case "demote":
+      await client.send(
+        new AdminRemoveUserFromGroupCommand({ UserPoolId: userPoolId, Username: username, GroupName: "admin" })
+      );
+      return { success: true, message: "User removed from admin group" };
+    default:
+      throw new Error(`Unknown action: ${action}`);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Keycloak helpers (legacy fallback)
+// ---------------------------------------------------------------------------
 
 const KC_BASE = process.env.KEYCLOAK_ISSUER ?? process.env.NEXT_PUBLIC_KEYCLOAK_ISSUER ?? "";
 const KC_REALM = KC_BASE ? (KC_BASE.split("/realms/")[1] ?? "master") : "master";
 const KC_ADMIN = KC_BASE ? KC_BASE.replace(`/realms/${KC_REALM}`, "") : "";
 const ADMIN_URL = `${KC_ADMIN}/admin/realms/${KC_REALM}`;
 
-/**
- * Obtain a short-lived Keycloak admin token. Prefers a confidential
- * service-account client (client_credentials) whose creds live in SSM — on
- * Lambda/Pi they are NOT in process.env, which is why the env-only path 500'd.
- * Falls back to the resource-owner password grant only if no client secret is
- * configured (e.g. local dev with env vars).
- */
-async function getAdminToken(): Promise<string> {
+async function getKeycloakAdminToken(): Promise<string> {
   const cfg = await getConfig().catch(() => null);
   const clientId =
     cfg?.KEYCLOAK_ADMIN_CLIENT_ID || process.env.KEYCLOAK_ADMIN_CLIENT_ID || "admin-cli";
@@ -23,19 +139,9 @@ async function getAdminToken(): Promise<string> {
   const adminUser = cfg?.KEYCLOAK_ADMIN_USER || process.env.KEYCLOAK_ADMIN_USER || "";
   const adminPass = cfg?.KEYCLOAK_ADMIN_PASSWORD || process.env.KEYCLOAK_ADMIN_PASSWORD || "";
 
-  // Prefer client-credentials, fall back to resource-owner password for admin-cli
   const body = clientSecret
-    ? new URLSearchParams({
-        grant_type: "client_credentials",
-        client_id: clientId,
-        client_secret: clientSecret,
-      })
-    : new URLSearchParams({
-        grant_type: "password",
-        client_id: clientId,
-        username: adminUser,
-        password: adminPass,
-      });
+    ? new URLSearchParams({ grant_type: "client_credentials", client_id: clientId, client_secret: clientSecret })
+    : new URLSearchParams({ grant_type: "password", client_id: clientId, username: adminUser, password: adminPass });
 
   const res = await globalThis.fetch(`${KC_BASE}/protocol/openid-connect/token`, {
     method: "POST",
@@ -44,8 +150,7 @@ async function getAdminToken(): Promise<string> {
     signal: AbortSignal.timeout(10_000),
   });
   if (!res.ok) throw new Error(`Keycloak admin token failed: ${res.status}`);
-  const data = (await res.json()) as { access_token: string };
-  return data.access_token;
+  return ((await res.json()) as { access_token: string }).access_token;
 }
 
 function kcFetch(path: string, token: string, init?: RequestInit) {
@@ -60,74 +165,110 @@ function kcFetch(path: string, token: string, init?: RequestInit) {
   });
 }
 
+async function listKeycloakUsers(limit: number, filter?: string): Promise<AdminUser[]> {
+  const token = await getKeycloakAdminToken();
+  const qs = new URLSearchParams({ max: String(limit) });
+  if (filter) qs.set("search", filter);
+  const res = await kcFetch(`/users?${qs}`, token);
+  if (!res.ok) throw new Error(`Keycloak list users: ${res.status}`);
+
+  interface KcUser {
+    id: string; username: string; email?: string; firstName?: string; lastName?: string;
+    emailVerified?: boolean; enabled?: boolean; createdTimestamp?: number;
+    attributes?: Record<string, string[]>;
+  }
+  const kcUsers = (await res.json()) as KcUser[];
+
+  return Promise.all(
+    kcUsers.map(async (u) => {
+      let isAdmin = false;
+      try {
+        const gr = await kcFetch(`/users/${u.id}/groups`, token);
+        if (gr.ok) {
+          const groups = (await gr.json()) as Array<{ name: string }>;
+          isAdmin = groups.some((g) => g.name === "admin");
+        }
+      } catch { /* default non-admin */ }
+
+      const attrs = u.attributes ?? {};
+      return {
+        username: u.id,
+        email: u.email ?? "",
+        name: [u.firstName, u.lastName].filter(Boolean).join(" "),
+        company: attrs["company"]?.[0] ?? "",
+        phone: attrs["phone"]?.[0] ?? "",
+        emailVerified: u.emailVerified ?? false,
+        status: u.enabled ? "active" : "disabled",
+        userStatus: u.enabled ? "CONFIRMED" : "DISABLED",
+        role: isAdmin ? "admin" : "user",
+        created: u.createdTimestamp ? new Date(u.createdTimestamp).toISOString() : undefined,
+      } satisfies AdminUser;
+    })
+  );
+}
+
+async function mutateKeycloakUser(
+  userId: string,
+  action: string
+): Promise<{ success: boolean; message: string }> {
+  const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+  if (!UUID_RE.test(userId)) throw Object.assign(new Error("Invalid user id"), { status: 400 });
+
+  const token = await getKeycloakAdminToken();
+
+  if (action === "disable") {
+    await kcFetch(`/users/${userId}`, token, { method: "PUT", body: JSON.stringify({ enabled: false }) });
+    return { success: true, message: "User disabled" };
+  }
+  if (action === "enable") {
+    await kcFetch(`/users/${userId}`, token, { method: "PUT", body: JSON.stringify({ enabled: true }) });
+    return { success: true, message: "User enabled" };
+  }
+  const grRes = await kcFetch(`/groups?search=admin`, token);
+  if (!grRes.ok) throw new Error("Could not fetch groups");
+  const groups = (await grRes.json()) as Array<{ id: string; name: string }>;
+  const adminGroup = groups.find((g) => g.name === "admin");
+  if (!adminGroup) throw new Error("admin group not found");
+
+  if (action === "promote") {
+    await kcFetch(`/users/${userId}/groups/${adminGroup.id}`, token, { method: "PUT" });
+    return { success: true, message: "User promoted to admin" };
+  }
+  if (action === "demote") {
+    await kcFetch(`/users/${userId}/groups/${adminGroup.id}`, token, { method: "DELETE" });
+    return { success: true, message: "User removed from admin group" };
+  }
+  throw Object.assign(new Error(`Unknown action: ${action}`), { status: 400 });
+}
+
+// ---------------------------------------------------------------------------
+// Route handlers
+// ---------------------------------------------------------------------------
+
 export async function GET(request: NextRequest) {
   const auth = await requireAdmin(request);
   if (!auth.ok) return auth.response;
 
-  if (!KC_BASE) {
-    return NextResponse.json({ error: "Keycloak not configured" }, { status: 503 });
-  }
+  const { searchParams } = new URL(request.url);
+  const limit = Math.min(Number(searchParams.get("limit") ?? 20), 60);
+  const filter = (searchParams.get("filter") ?? "").replace(/[^\w.@+-]/g, "").slice(0, 128);
+
+  const cognitoIssuer = process.env.COGNITO_ISSUER ?? "";
 
   try {
-    const token = await getAdminToken();
-    const { searchParams } = new URL(request.url);
-    const limit = Math.min(Number(searchParams.get("limit") ?? 20), 60);
-    const filter = (searchParams.get("filter") ?? "").replace(/[^\w.@+-]/g, "").slice(0, 128);
-
-    const qs = new URLSearchParams({ max: String(limit) });
-    if (filter) qs.set("search", filter);
-
-    const res = await kcFetch(`/users?${qs}`, token);
-    if (!res.ok) throw new Error(`Keycloak list users: ${res.status}`);
-
-    interface KcUser {
-      id: string;
-      username: string;
-      email?: string;
-      firstName?: string;
-      lastName?: string;
-      emailVerified?: boolean;
-      enabled?: boolean;
-      createdTimestamp?: number;
-      attributes?: Record<string, string[]>;
+    if (cognitoIssuer) {
+      const users = await listCognitoUsers(cognitoIssuer, limit, filter || undefined);
+      return NextResponse.json({ users, count: users.length, provider: "cognito" });
     }
-    const kcUsers = (await res.json()) as KcUser[];
 
-    const users = await Promise.all(
-      kcUsers.map(async (u) => {
-        let isAdmin = false;
-        try {
-          const gr = await kcFetch(`/users/${u.id}/groups`, token);
-          if (gr.ok) {
-            const groups = (await gr.json()) as Array<{ name: string }>;
-            isAdmin = groups.some((g) => g.name === "admin");
-          }
-        } catch {
-          /* default non-admin */
-        }
+    if (KC_BASE) {
+      const users = await listKeycloakUsers(limit, filter || undefined);
+      return NextResponse.json({ users, count: users.length, provider: "keycloak" });
+    }
 
-        const attrs = u.attributes ?? {};
-        return {
-          username: u.id,
-          email: u.email ?? "",
-          name: [u.firstName, u.lastName].filter(Boolean).join(" "),
-          company: attrs["company"]?.[0] ?? "",
-          phone: attrs["phone"]?.[0] ?? "",
-          emailVerified: u.emailVerified ?? false,
-          status: u.enabled ? "active" : "disabled",
-          userStatus: u.enabled ? "CONFIRMED" : "DISABLED",
-          role: isAdmin ? "admin" : "user",
-          created: u.createdTimestamp ? new Date(u.createdTimestamp).toISOString() : undefined,
-        };
-      })
-    );
-
-    return NextResponse.json({ users, count: users.length });
+    return NextResponse.json({ error: "Auth provider not configured" }, { status: 503 });
   } catch (err) {
-    console.error(
-      "Failed to list Keycloak users:",
-      err instanceof Error ? err.message : String(err)
-    );
+    console.error("Failed to list users:", err instanceof Error ? err.message : String(err));
     return NextResponse.json({ error: "Failed to list users" }, { status: 500 });
   }
 }
@@ -136,66 +277,28 @@ export async function POST(request: NextRequest) {
   const auth = await requireAdmin(request);
   if (!auth.ok) return auth.response;
 
-  if (!KC_BASE) {
-    return NextResponse.json({ error: "Keycloak not configured" }, { status: 503 });
+  const { action, username } = (await request.json()) as { action: string; username: string };
+  if (!action || !username) {
+    return NextResponse.json({ error: "action and username required" }, { status: 400 });
   }
 
+  const cognitoIssuer = process.env.COGNITO_ISSUER ?? "";
+
   try {
-    const token = await getAdminToken();
-    const { action, username: userId } = (await request.json()) as {
-      action: string;
-      username: string;
-    };
-
-    if (!action || !userId) {
-      return NextResponse.json({ error: "action and username required" }, { status: 400 });
+    if (cognitoIssuer) {
+      const result = await mutateCognitoUser(cognitoIssuer, username, action);
+      return NextResponse.json(result);
     }
 
-    // Validate userId is a Keycloak UUID before interpolating into API paths
-    const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
-    if (!UUID_RE.test(userId)) {
-      return NextResponse.json({ error: "Invalid user id" }, { status: 400 });
+    if (KC_BASE) {
+      const result = await mutateKeycloakUser(username, action);
+      return NextResponse.json(result);
     }
 
-    if (action === "disable") {
-      await kcFetch(`/users/${userId}`, token, {
-        method: "PUT",
-        body: JSON.stringify({ enabled: false }),
-      });
-      return NextResponse.json({ success: true, message: "User disabled" });
-    }
-
-    if (action === "enable") {
-      await kcFetch(`/users/${userId}`, token, {
-        method: "PUT",
-        body: JSON.stringify({ enabled: true }),
-      });
-      return NextResponse.json({ success: true, message: "User enabled" });
-    }
-
-    // Get admin group id
-    const grRes = await kcFetch(`/groups?search=admin`, token);
-    if (!grRes.ok) throw new Error("Could not fetch groups");
-    const groups = (await grRes.json()) as Array<{ id: string; name: string }>;
-    const adminGroup = groups.find((g) => g.name === "admin");
-    if (!adminGroup) throw new Error("admin group not found");
-
-    if (action === "promote") {
-      await kcFetch(`/users/${userId}/groups/${adminGroup.id}`, token, { method: "PUT" });
-      return NextResponse.json({ success: true, message: "User promoted to admin" });
-    }
-
-    if (action === "demote") {
-      await kcFetch(`/users/${userId}/groups/${adminGroup.id}`, token, { method: "DELETE" });
-      return NextResponse.json({ success: true, message: "User removed from admin group" });
-    }
-
-    return NextResponse.json({ error: "Unknown action" }, { status: 400 });
+    return NextResponse.json({ error: "Auth provider not configured" }, { status: 503 });
   } catch (err) {
-    console.error(
-      "Failed to modify Keycloak user:",
-      err instanceof Error ? err.message : String(err)
-    );
-    return NextResponse.json({ error: "Failed to modify user" }, { status: 500 });
+    const status = (err as { status?: number }).status ?? 500;
+    console.error("Failed to modify user:", err instanceof Error ? err.message : String(err));
+    return NextResponse.json({ error: err instanceof Error ? err.message : "Failed to modify user" }, { status });
   }
 }


### PR DESCRIPTION
## Summary

- `/api/admin/users` GET and POST now resolve the auth provider at request time: Cognito when `COGNITO_ISSUER` is set, Keycloak when `KC_BASE` is set, 503 otherwise
- Response includes `provider` field (`"cognito"` or `"keycloak"`) so the UI can label correctly
- Cognito operations use `@aws-sdk/client-cognito-identity-provider` (already in package.json): list users, per-user admin group check, enable/disable, promote/demote
- Admin users page updated to be provider-agnostic: generic header, dynamic footer label, `provider` state

## Test plan

- [ ] All 16 tests in `__tests__/admin-users-orders-ops-api.test.ts` pass
- [ ] Keycloak path still works unchanged (Keycloak tests set `KEYCLOAK_ISSUER` without `COGNITO_ISSUER`)
- [ ] 503 path reached when neither provider is configured

https://claude.ai/code/session_01PHsA9s3tK2thgSJVwEGuWq

---
_Generated by [Claude Code](https://claude.ai/code/session_01PHsA9s3tK2thgSJVwEGuWq)_