### PR TITLE
feat(auth): Cognito IAM permissions + auth-path test coverage

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -33,6 +33,8 @@ NEXT_PUBLIC_KEYCLOAK_ISSUER=https://auth.cloudless.gr/realms/master
 # COGNITO_CLIENT_ID=your-cognito-app-client-id
 # COGNITO_CLIENT_SECRET=your-cognito-app-client-secret
 # COGNITO_DOMAIN=https://your-pool.auth.us-east-1.amazoncognito.com
+# Build-time public var: "cognito" or "keycloak" — drives the login button label.
+# NEXT_PUBLIC_AUTH_PROVIDER=cognito
 
 # ── SES (transactional email) ──────────────────────────────────────────────────
 SES_FROM_EMAIL=hello@cloudless.gr

--- a/__tests__/admin-users-cognito-api.test.ts
+++ b/__tests__/admin-users-cognito-api.test.ts
@@ -1,0 +1,214 @@
+// @vitest-environment node
+/**
+ * /api/admin/users — Cognito provider path.
+ *
+ * The Keycloak path is covered in admin-api.test.ts. This sets COGNITO_ISSUER
+ * so the route dispatches to the AWS-SDK Cognito branch, and asserts:
+ *   - GET lists Cognito users mapped to the shared shape, admin role from the
+ *     admin group, and provider:"cognito"; pool id + region derive from issuer
+ *   - POST disable/enable/promote/demote issue the right Cognito admin commands
+ *   - unknown action surfaces as an error (no mutation command sent)
+ *   - 503 when no provider is configured
+ *
+ * requireAdmin is mocked (the Bearer/JWKS path is exercised in api-auth.test.ts),
+ * and the Cognito SDK client is mocked so no AWS call is made.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { NextRequest } from "next/server";
+
+vi.mock("@/lib/api-auth", () => ({
+  requireAdmin: vi.fn(async () => ({ ok: true, user: { sub: "admin", groups: ["admin"] } })),
+}));
+
+vi.mock("@/lib/ssm-config", () => ({
+  getConfig: vi.fn(async () => ({})),
+  resetSsmCache: vi.fn(),
+}));
+
+const sendMock = vi.fn();
+vi.mock("@aws-sdk/client-cognito-identity-provider", () => {
+  class Cmd {
+    input: Record<string, unknown>;
+    _t = "Base";
+    constructor(input: Record<string, unknown>) {
+      this.input = input;
+    }
+  }
+  const mk = (t: string) =>
+    class extends Cmd {
+      _t = t;
+    };
+  return {
+    CognitoIdentityProviderClient: class {
+      send = sendMock;
+    },
+    ListUsersCommand: mk("ListUsers"),
+    AdminListGroupsForUserCommand: mk("AdminListGroupsForUser"),
+    AdminEnableUserCommand: mk("AdminEnableUser"),
+    AdminDisableUserCommand: mk("AdminDisableUser"),
+    AdminAddUserToGroupCommand: mk("AdminAddUserToGroup"),
+    AdminRemoveUserFromGroupCommand: mk("AdminRemoveUserFromGroup"),
+  };
+});
+
+const ISSUER = "https://cognito-idp.us-east-1.amazonaws.com/us-east-1_TESTPOOL";
+
+function adminReq(url: string, init?: RequestInit): NextRequest {
+  return new NextRequest(url, { method: init?.method, body: init?.body });
+}
+
+describe("/api/admin/users — Cognito path", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    sendMock.mockReset();
+    process.env.COGNITO_ISSUER = ISSUER;
+    delete process.env.KEYCLOAK_ISSUER;
+    delete process.env.NEXT_PUBLIC_KEYCLOAK_ISSUER;
+  });
+
+  afterEach(() => {
+    delete process.env.COGNITO_ISSUER;
+  });
+
+  it("GET lists Cognito users with admin role + provider, deriving the pool id", async () => {
+    sendMock.mockImplementation(async (cmd: { _t: string }) => {
+      if (cmd._t === "ListUsers") {
+        return {
+          Users: [
+            {
+              Username: "11111111-1111-1111-1111-111111111111",
+              Enabled: true,
+              UserStatus: "CONFIRMED",
+              UserCreateDate: new Date("2026-01-02T00:00:00Z"),
+              Attributes: [
+                { Name: "email", Value: "alice@cloudless.gr" },
+                { Name: "email_verified", Value: "true" },
+                { Name: "name", Value: "Alice A" },
+              ],
+            },
+          ],
+        };
+      }
+      if (cmd._t === "AdminListGroupsForUser") return { Groups: [{ GroupName: "admin" }] };
+      return {};
+    });
+
+    const { GET } = await import("@/app/api/admin/users/route");
+    const res = await GET(adminReq("http://localhost/api/admin/users?limit=60"));
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data.provider).toBe("cognito");
+    expect(data.count).toBe(1);
+    expect(data.users[0]).toMatchObject({
+      username: "11111111-1111-1111-1111-111111111111",
+      email: "alice@cloudless.gr",
+      name: "Alice A",
+      emailVerified: true,
+      status: "active",
+      userStatus: "CONFIRMED",
+      role: "admin",
+    });
+    const listCall = sendMock.mock.calls.find((c) => c[0]._t === "ListUsers");
+    expect(listCall?.[0].input.UserPoolId).toBe("us-east-1_TESTPOOL");
+  });
+
+  it("GET marks a user without the admin group as role=user, status=disabled", async () => {
+    sendMock.mockImplementation(async (cmd: { _t: string }) => {
+      if (cmd._t === "ListUsers") {
+        return {
+          Users: [
+            {
+              Username: "u-2",
+              Enabled: false,
+              UserStatus: "CONFIRMED",
+              Attributes: [{ Name: "email", Value: "bob@cloudless.gr" }],
+            },
+          ],
+        };
+      }
+      if (cmd._t === "AdminListGroupsForUser") return { Groups: [{ GroupName: "users" }] };
+      return {};
+    });
+
+    const { GET } = await import("@/app/api/admin/users/route");
+    const res = await GET(adminReq("http://localhost/api/admin/users"));
+    const data = await res.json();
+    expect(data.users[0]).toMatchObject({ role: "user", status: "disabled" });
+  });
+
+  it("POST promote adds the user to the admin group", async () => {
+    sendMock.mockResolvedValue({});
+    const { POST } = await import("@/app/api/admin/users/route");
+    const res = await POST(
+      adminReq("http://localhost/api/admin/users", {
+        method: "POST",
+        body: JSON.stringify({ action: "promote", username: "u-1" }),
+      })
+    );
+    expect(res.status).toBe(200);
+    expect((await res.json()).message).toBe("User promoted to admin");
+    const call = sendMock.mock.calls.find((c) => c[0]._t === "AdminAddUserToGroup");
+    expect(call?.[0].input).toMatchObject({ Username: "u-1", GroupName: "admin" });
+  });
+
+  it("POST disable issues AdminDisableUser", async () => {
+    sendMock.mockResolvedValue({});
+    const { POST } = await import("@/app/api/admin/users/route");
+    const res = await POST(
+      adminReq("http://localhost/api/admin/users", {
+        method: "POST",
+        body: JSON.stringify({ action: "disable", username: "u-1" }),
+      })
+    );
+    expect(res.status).toBe(200);
+    expect(sendMock.mock.calls.some((c) => c[0]._t === "AdminDisableUser")).toBe(true);
+  });
+
+  it("POST demote removes the user from the admin group", async () => {
+    sendMock.mockResolvedValue({});
+    const { POST } = await import("@/app/api/admin/users/route");
+    const res = await POST(
+      adminReq("http://localhost/api/admin/users", {
+        method: "POST",
+        body: JSON.stringify({ action: "demote", username: "u-1" }),
+      })
+    );
+    expect(res.status).toBe(200);
+    expect(sendMock.mock.calls.some((c) => c[0]._t === "AdminRemoveUserFromGroup")).toBe(true);
+  });
+
+  it("POST missing action/username returns 400", async () => {
+    sendMock.mockResolvedValue({});
+    const { POST } = await import("@/app/api/admin/users/route");
+    const res = await POST(
+      adminReq("http://localhost/api/admin/users", {
+        method: "POST",
+        body: JSON.stringify({ action: "disable" }),
+      })
+    );
+    expect(res.status).toBe(400);
+    expect(sendMock).not.toHaveBeenCalled();
+  });
+
+  it("POST unknown action surfaces an error without mutating", async () => {
+    sendMock.mockResolvedValue({});
+    const { POST } = await import("@/app/api/admin/users/route");
+    const res = await POST(
+      adminReq("http://localhost/api/admin/users", {
+        method: "POST",
+        body: JSON.stringify({ action: "nuke", username: "u-1" }),
+      })
+    );
+    expect(res.status).toBeGreaterThanOrEqual(400);
+    expect(sendMock).not.toHaveBeenCalled();
+  });
+
+  it("GET returns 503 when no auth provider is configured", async () => {
+    delete process.env.COGNITO_ISSUER;
+    vi.resetModules();
+    const { GET } = await import("@/app/api/admin/users/route");
+    const res = await GET(adminReq("http://localhost/api/admin/users"));
+    expect(res.status).toBe(503);
+  });
+});

--- a/__tests__/cognito-implementation.test.ts
+++ b/__tests__/cognito-implementation.test.ts
@@ -1,0 +1,252 @@
+// @vitest-environment node
+/**
+ * Cognito implementation tests — the REAL src/lib/auth.ts in Cognito mode.
+ *
+ * auth-lib-callbacks.test.ts exercises the same callbacks in *Keycloak* mode.
+ * This file flips the env so COGNITO_ISSUER is set and asserts the
+ * Cognito-specific behaviour that the Keycloak path never touches:
+ *
+ *   1. Provider selection — authProvider === "cognito" when COGNITO_ISSUER set
+ *   2. cognito:groups claim extraction (id_token preferred over access_token)
+ *   3. Refresh hits {COGNITO_DOMAIN}/oauth2/token with HTTP Basic auth
+ *      (client_id:client_secret) — NOT client_secret in the body
+ *   4. Cognito does not rotate refresh tokens — the existing one is kept
+ *      when the refresh response omits refresh_token
+ *   5. RP-initiated logout hits {COGNITO_DOMAIN}/logout?client_id&logout_uri
+ *      (Cognito's non-standard endpoint, not an OIDC end_session_endpoint)
+ *
+ * Sources:
+ *   - https://docs.aws.amazon.com/cognito/latest/developerguide/token-endpoint.html
+ *   - https://docs.aws.amazon.com/cognito/latest/developerguide/logout-endpoint.html
+ *   - https://authjs.dev/getting-started/providers/cognito
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+// ── Capture the config NextAuth() is called with ──────────────────────────────
+
+let capturedConfig: Record<string, unknown> = {};
+
+vi.mock("next-auth", () => ({
+  default: (config: Record<string, unknown>) => {
+    capturedConfig = config;
+    return {
+      handlers: { GET: vi.fn(), POST: vi.fn() },
+      signIn: vi.fn(),
+      signOut: vi.fn(),
+      auth: vi.fn(),
+    };
+  },
+}));
+
+vi.mock("next-auth/providers/cognito", () => ({
+  default: (opts: Record<string, unknown>) => ({ ...opts, id: "cognito", name: "cognito" }),
+}));
+
+vi.mock("next-auth/providers/keycloak", () => ({
+  default: (opts: Record<string, unknown>) => ({ ...opts, id: "keycloak", name: "keycloak" }),
+}));
+
+// ── JWT helper: base64url payload (unsigned — decodeJwtPayload only reads it) ──
+
+function buildToken(payload: Record<string, unknown>): string {
+  const enc = (o: unknown) =>
+    btoa(JSON.stringify(o)).replaceAll("+", "-").replaceAll("/", "_").replaceAll("=", "");
+  return `${enc({ alg: "RS256" })}.${enc(payload)}.sig`;
+}
+
+type JwtInput = {
+  token: Record<string, unknown>;
+  account?: Record<string, unknown> | null;
+  profile?: Record<string, unknown> | null;
+};
+
+const COGNITO_ISSUER = "https://cognito-idp.us-east-1.amazonaws.com/us-east-1_TEST";
+const COGNITO_DOMAIN = "https://cloudless-auth.auth.us-east-1.amazoncognito.com";
+const CLIENT_ID = "cognito-client-id";
+const CLIENT_SECRET = "cognito-client-secret";
+const AUTH_URL = "https://cloudless.gr";
+
+describe("src/lib/auth.ts — Cognito mode", () => {
+  const origFetch = globalThis.fetch;
+
+  beforeEach(() => {
+    vi.resetModules();
+    capturedConfig = {};
+    // Cognito wins: COGNITO_ISSUER set, Keycloak vars absent.
+    process.env.AUTH_SECRET = "test-auth-secret-32-chars-padded!!";
+    process.env.COGNITO_ISSUER = COGNITO_ISSUER;
+    process.env.COGNITO_CLIENT_ID = CLIENT_ID;
+    process.env.COGNITO_CLIENT_SECRET = CLIENT_SECRET;
+    process.env.COGNITO_DOMAIN = COGNITO_DOMAIN;
+    process.env.AUTH_URL = AUTH_URL;
+    delete process.env.KEYCLOAK_ISSUER;
+    delete process.env.KEYCLOAK_CLIENT_ID;
+    delete process.env.KEYCLOAK_CLIENT_SECRET;
+  });
+
+  afterEach(() => {
+    globalThis.fetch = origFetch;
+    delete process.env.COGNITO_ISSUER;
+    delete process.env.COGNITO_CLIENT_ID;
+    delete process.env.COGNITO_CLIENT_SECRET;
+    delete process.env.COGNITO_DOMAIN;
+    delete process.env.AUTH_URL;
+  });
+
+  // ── 1. provider selection ──────────────────────────────────────────────────
+
+  it("selects Cognito as the active provider when COGNITO_ISSUER is set", async () => {
+    const mod = await import("@/lib/auth");
+    expect(mod.authProvider).toBe("cognito");
+    const providers = capturedConfig.providers as Array<{ id?: string }>;
+    expect(providers[0]?.id).toBe("cognito");
+  });
+
+  // ── 2. cognito:groups extraction ───────────────────────────────────────────
+
+  it("extracts groups from the cognito:groups claim in the id_token", async () => {
+    await import("@/lib/auth");
+    const jwt = capturedConfig.callbacks as Record<
+      string,
+      (a: JwtInput) => Promise<Record<string, unknown>>
+    >;
+    const idToken = buildToken({ "cognito:groups": ["admin", "users"] });
+    const accessToken = buildToken({ "cognito:groups": ["other"] });
+    const result = await jwt.jwt({
+      token: {},
+      account: {
+        access_token: accessToken,
+        id_token: idToken,
+        expires_at: Math.floor(Date.now() / 1000) + 3600,
+        expires_in: 3600,
+      },
+    });
+    expect(result.groups).toEqual(["admin", "users"]);
+  });
+
+  it("ignores the Keycloak `groups` claim name when in Cognito mode", async () => {
+    await import("@/lib/auth");
+    const jwt = capturedConfig.callbacks as Record<
+      string,
+      (a: JwtInput) => Promise<Record<string, unknown>>
+    >;
+    // A token carrying only the Keycloak-style `groups` (not cognito:groups)
+    // must NOT populate groups when Cognito is the active provider.
+    const idToken = buildToken({ groups: ["admin"] });
+    const result = await jwt.jwt({
+      token: {},
+      account: {
+        access_token: buildToken({}),
+        id_token: idToken,
+        expires_at: Math.floor(Date.now() / 1000) + 3600,
+        expires_in: 3600,
+      },
+    });
+    expect(result.groups).toEqual([]);
+  });
+
+  // ── 3. refresh hits the Cognito token endpoint with HTTP Basic auth ─────────
+
+  it("refreshes at {domain}/oauth2/token using HTTP Basic auth (not body secret)", async () => {
+    await import("@/lib/auth");
+    const jwt = capturedConfig.callbacks as Record<
+      string,
+      (a: JwtInput) => Promise<Record<string, unknown>>
+    >;
+    const fetchMock = vi.fn().mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: async () => ({
+        access_token: buildToken({ "cognito:groups": ["admin"] }),
+        expires_in: 3600,
+      }),
+    });
+    globalThis.fetch = fetchMock;
+
+    const expired = {
+      accessToken: "old",
+      refreshToken: "rtk-cognito",
+      expiresAt: Math.floor(Date.now() / 1000) - 60,
+    };
+    await jwt.jwt({ token: { ...expired } });
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe(`${COGNITO_DOMAIN}/oauth2/token`);
+
+    const headers = init.headers as Record<string, string>;
+    expect(headers.Authorization).toBe(`Basic ${btoa(`${CLIENT_ID}:${CLIENT_SECRET}`)}`);
+
+    // The secret must travel in the Basic header, never in the body.
+    const body = String(init.body);
+    expect(body).toContain("grant_type=refresh_token");
+    expect(body).toContain("refresh_token=rtk-cognito");
+    expect(body).not.toContain("client_secret");
+  });
+
+  // ── 4. Cognito does not rotate refresh tokens ───────────────────────────────
+
+  it("keeps the existing refresh_token when the response omits one", async () => {
+    await import("@/lib/auth");
+    const jwt = capturedConfig.callbacks as Record<
+      string,
+      (a: JwtInput) => Promise<Record<string, unknown>>
+    >;
+    globalThis.fetch = vi.fn().mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: async () => ({
+        access_token: buildToken({ "cognito:groups": ["admin"] }),
+        // No refresh_token — Cognito reuses the existing one.
+        expires_in: 3600,
+      }),
+    });
+    const result = await jwt.jwt({
+      token: {
+        accessToken: "old",
+        refreshToken: "rtk-keep-me",
+        expiresAt: Math.floor(Date.now() / 1000) - 60,
+      },
+    });
+    expect(result.refreshToken).toBe("rtk-keep-me");
+    expect(result.groups).toEqual(["admin"]);
+    expect(result.error).toBeUndefined();
+  });
+
+  // ── 5. RP-initiated logout via Cognito's non-standard /logout ───────────────
+
+  it("signOut event calls {domain}/logout with client_id and logout_uri", async () => {
+    await import("@/lib/auth");
+    const fetchMock = vi.fn().mockResolvedValueOnce({ ok: true });
+    globalThis.fetch = fetchMock;
+
+    const { signOut: signOutEvent } = capturedConfig.events as {
+      signOut: (msg: { token?: { idToken?: string } }) => Promise<void>;
+    };
+    await signOutEvent({ token: { idToken: "id-tok" } });
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const url = fetchMock.mock.calls[0][0] as string;
+    expect(url).toContain(`${COGNITO_DOMAIN}/logout`);
+    expect(url).toContain(`client_id=${CLIENT_ID}`);
+    expect(url).toContain(`logout_uri=${encodeURIComponent(`${AUTH_URL}/`)}`);
+    // Cognito logout must NOT use the OIDC end_session endpoint.
+    expect(url).not.toContain("openid-connect/logout");
+  });
+
+  it("signOut event is a no-op when COGNITO_DOMAIN is unset", async () => {
+    delete process.env.COGNITO_DOMAIN;
+    vi.resetModules();
+    capturedConfig = {};
+    await import("@/lib/auth");
+    const fetchMock = vi.fn();
+    globalThis.fetch = fetchMock;
+
+    const { signOut: signOutEvent } = capturedConfig.events as {
+      signOut: (msg: { token?: { idToken?: string } }) => Promise<void>;
+    };
+    await signOutEvent({ token: { idToken: "id-tok" } });
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+});

--- a/sst.config.ts
+++ b/sst.config.ts
@@ -267,6 +267,21 @@ export default {
             "arn:aws:bedrock:us-east-1:278585680617:inference-profile/us.anthropic.claude-3-5-haiku-20241022-v1:0",
           ],
         },
+        {
+          // Admin Users page (/api/admin/users) manages Cognito accounts via the
+          // AWS SDK: list users, read group membership, enable/disable, and
+          // promote/demote (admin group). Scoped to this pool only. Without
+          // these the route 500s with AccessDenied in Cognito production.
+          actions: [
+            "cognito-idp:ListUsers",
+            "cognito-idp:AdminListGroupsForUser",
+            "cognito-idp:AdminEnableUser",
+            "cognito-idp:AdminDisableUser",
+            "cognito-idp:AdminAddUserToGroup",
+            "cognito-idp:AdminRemoveUserFromGroup",
+          ],
+          resources: [userPool.arn],
+        },
       ],
       warm: isProd ? 5 : 0,
       server: {


### PR DESCRIPTION
## Summary

A parallel session landed the provider-agnostic `/api/admin/users` route while this was in flight, so this PR was rebased to drop the now-duplicated route/page changes and keep only what's **genuinely still missing**:

- **`sst.config.ts` — Cognito IAM permissions (the critical gap).** The merged route calls `cognito-idp:ListUsers` / `AdminListGroupsForUser` / `AdminEnable·DisableUser` / `AdminAdd·RemoveUserToGroup`, but the site Lambda had **no** `cognito-idp` permissions — so the admin Users page would **500 with AccessDenied** in production. Granted those actions scoped to the user-pool ARN.
- **Test coverage for the Cognito code paths (none existed on main):**
  - `cognito-implementation.test.ts` — the real `src/lib/auth.ts` in Cognito mode: provider selection, `cognito:groups` extraction, `{domain}/oauth2/token` refresh with **HTTP Basic auth** (secret not in body), refresh-token retention, `{domain}/logout` RP-initiated logout.
  - `admin-users-cognito-api.test.ts` — the Cognito branch of `/api/admin/users`: list + admin-group→role mapping + `provider` field, enable/disable/promote/demote, 400/503 paths.
- **`.env.example`** — documented `NEXT_PUBLIC_AUTH_PROVIDER`.

## Test plan

- [x] `cognito-implementation.test.ts` + `admin-users-cognito-api.test.ts` — **15 pass** against main's route/auth
- [x] `tsc --noEmit` clean
- [ ] After deploy: open `/admin/users` in production (Cognito) — list loads, promote/demote works (verifies the IAM grant)

https://claude.ai/code/session_01SFLAFG395WWQcyj69toXbT