### PR TITLE
fix(api): align Cognito unknown-action to 400 (matches Keycloak)

### DIFF
--- a/__tests__/admin-users-cognito-api.test.ts
+++ b/__tests__/admin-users-cognito-api.test.ts
@@ -191,7 +191,7 @@ describe("/api/admin/users — Cognito path", () => {
     expect(sendMock).not.toHaveBeenCalled();
   });
 
-  it("POST unknown action surfaces an error without mutating", async () => {
+  it("POST unknown action returns 400 without mutating", async () => {
     sendMock.mockResolvedValue({});
     const { POST } = await import("@/app/api/admin/users/route");
     const res = await POST(
@@ -200,7 +200,7 @@ describe("/api/admin/users — Cognito path", () => {
         body: JSON.stringify({ action: "nuke", username: "u-1" }),
       })
     );
-    expect(res.status).toBeGreaterThanOrEqual(400);
+    expect(res.status).toBe(400);
     expect(sendMock).not.toHaveBeenCalled();
   });
 

--- a/src/app/api/admin/users/route.ts
+++ b/src/app/api/admin/users/route.ts
@@ -47,7 +47,11 @@ function cognitoAttr(attrs: Array<{ Name?: string; Value?: string }>, name: stri
   return attrs.find((a) => a.Name === name)?.Value ?? "";
 }
 
-async function listCognitoUsers(issuer: string, limit: number, filter?: string): Promise<AdminUser[]> {
+async function listCognitoUsers(
+  issuer: string,
+  limit: number,
+  filter?: string
+): Promise<AdminUser[]> {
   const client = cognitoClient(issuer);
   const userPoolId = getUserPoolId(issuer);
 
@@ -75,9 +79,10 @@ async function listCognitoUsers(issuer: string, limit: number, filter?: string):
       return {
         username: u.Username ?? "",
         email: cognitoAttr(attrs, "email"),
-        name: [cognitoAttr(attrs, "given_name"), cognitoAttr(attrs, "family_name")]
-          .filter(Boolean)
-          .join(" ") || cognitoAttr(attrs, "name"),
+        name:
+          [cognitoAttr(attrs, "given_name"), cognitoAttr(attrs, "family_name")]
+            .filter(Boolean)
+            .join(" ") || cognitoAttr(attrs, "name"),
         company: cognitoAttr(attrs, "custom:company"),
         phone: cognitoAttr(attrs, "phone_number"),
         emailVerified: cognitoAttr(attrs, "email_verified") === "true",
@@ -101,23 +106,34 @@ async function mutateCognitoUser(
 
   switch (action) {
     case "disable":
-      await client.send(new AdminDisableUserCommand({ UserPoolId: userPoolId, Username: username }));
+      await client.send(
+        new AdminDisableUserCommand({ UserPoolId: userPoolId, Username: username })
+      );
       return { success: true, message: "User disabled" };
     case "enable":
       await client.send(new AdminEnableUserCommand({ UserPoolId: userPoolId, Username: username }));
       return { success: true, message: "User enabled" };
     case "promote":
       await client.send(
-        new AdminAddUserToGroupCommand({ UserPoolId: userPoolId, Username: username, GroupName: "admin" })
+        new AdminAddUserToGroupCommand({
+          UserPoolId: userPoolId,
+          Username: username,
+          GroupName: "admin",
+        })
       );
       return { success: true, message: "User promoted to admin" };
     case "demote":
       await client.send(
-        new AdminRemoveUserFromGroupCommand({ UserPoolId: userPoolId, Username: username, GroupName: "admin" })
+        new AdminRemoveUserFromGroupCommand({
+          UserPoolId: userPoolId,
+          Username: username,
+          GroupName: "admin",
+        })
       );
       return { success: true, message: "User removed from admin group" };
     default:
-      throw new Error(`Unknown action: ${action}`);
+      // 400 (client error), consistent with the Keycloak path's unknown-action.
+      throw Object.assign(new Error(`Unknown action: ${action}`), { status: 400 });
   }
 }
 
@@ -140,8 +156,17 @@ async function getKeycloakAdminToken(): Promise<string> {
   const adminPass = cfg?.KEYCLOAK_ADMIN_PASSWORD || process.env.KEYCLOAK_ADMIN_PASSWORD || "";
 
   const body = clientSecret
-    ? new URLSearchParams({ grant_type: "client_credentials", client_id: clientId, client_secret: clientSecret })
-    : new URLSearchParams({ grant_type: "password", client_id: clientId, username: adminUser, password: adminPass });
+    ? new URLSearchParams({
+        grant_type: "client_credentials",
+        client_id: clientId,
+        client_secret: clientSecret,
+      })
+    : new URLSearchParams({
+        grant_type: "password",
+        client_id: clientId,
+        username: adminUser,
+        password: adminPass,
+      });
 
   const res = await globalThis.fetch(`${KC_BASE}/protocol/openid-connect/token`, {
     method: "POST",
@@ -173,8 +198,14 @@ async function listKeycloakUsers(limit: number, filter?: string): Promise<AdminU
   if (!res.ok) throw new Error(`Keycloak list users: ${res.status}`);
 
   interface KcUser {
-    id: string; username: string; email?: string; firstName?: string; lastName?: string;
-    emailVerified?: boolean; enabled?: boolean; createdTimestamp?: number;
+    id: string;
+    username: string;
+    email?: string;
+    firstName?: string;
+    lastName?: string;
+    emailVerified?: boolean;
+    enabled?: boolean;
+    createdTimestamp?: number;
     attributes?: Record<string, string[]>;
   }
   const kcUsers = (await res.json()) as KcUser[];
@@ -188,7 +219,9 @@ async function listKeycloakUsers(limit: number, filter?: string): Promise<AdminU
           const groups = (await gr.json()) as Array<{ name: string }>;
           isAdmin = groups.some((g) => g.name === "admin");
         }
-      } catch { /* default non-admin */ }
+      } catch {
+        /* default non-admin */
+      }
 
       const attrs = u.attributes ?? {};
       return {
@@ -217,11 +250,17 @@ async function mutateKeycloakUser(
   const token = await getKeycloakAdminToken();
 
   if (action === "disable") {
-    await kcFetch(`/users/${userId}`, token, { method: "PUT", body: JSON.stringify({ enabled: false }) });
+    await kcFetch(`/users/${userId}`, token, {
+      method: "PUT",
+      body: JSON.stringify({ enabled: false }),
+    });
     return { success: true, message: "User disabled" };
   }
   if (action === "enable") {
-    await kcFetch(`/users/${userId}`, token, { method: "PUT", body: JSON.stringify({ enabled: true }) });
+    await kcFetch(`/users/${userId}`, token, {
+      method: "PUT",
+      body: JSON.stringify({ enabled: true }),
+    });
     return { success: true, message: "User enabled" };
   }
   const grRes = await kcFetch(`/groups?search=admin`, token);
@@ -299,6 +338,9 @@ export async function POST(request: NextRequest) {
   } catch (err) {
     const status = (err as { status?: number }).status ?? 500;
     console.error("Failed to modify user:", err instanceof Error ? err.message : String(err));
-    return NextResponse.json({ error: err instanceof Error ? err.message : "Failed to modify user" }, { status });
+    return NextResponse.json(
+      { error: err instanceof Error ? err.message : "Failed to modify user" },
+      { status }
+    );
   }
 }


### PR DESCRIPTION
## Summary

Addresses the consistency nit flagged after #620: the Cognito branch of `/api/admin/users` threw a plain `Error` for an unknown POST action, which the handler mapped to **500**, while the Keycloak path returned **400**. Now both providers return **400** for an unknown action.

- `mutateCognitoUser` default case: `throw Object.assign(new Error(...), { status: 400 })` — same pattern as the Keycloak path, picked up by the POST catch's `err.status ?? 500`.
- Tightened `admin-users-cognito-api.test.ts` from `>= 400` to exactly `400`.

(Prettier also reflowed a few long lines in the route on save — no behavior change.)

## Test plan

- [x] `admin-users-cognito-api.test.ts` (8) + `cognito-implementation.test.ts` (7) + `admin-api.test.ts` (51) + `admin-users-orders-ops-api.test.ts` (16) — **82 pass** (full files)
- [x] `tsc --noEmit` + `eslint` clean

https://claude.ai/code/session_01SFLAFG395WWQcyj69toXbT

---
_Generated by [Claude Code](https://claude.ai/code/session_01SFLAFG395WWQcyj69toXbT)_