### PR TITLE
fix(security): validate Stripe ID format in subscriptions route

### DIFF
--- a/src/app/api/admin/subscriptions/route.ts
+++ b/src/app/api/admin/subscriptions/route.ts
@@ -87,6 +87,13 @@ export async function POST(request: NextRequest) {
     subscriptionId?: string;
   };
 
+  if (customerId && !/^cus_[a-zA-Z0-9]+$/.test(customerId)) {
+    return NextResponse.json({ error: "Invalid customerId format" }, { status: 400 });
+  }
+  if (subscriptionId && !/^sub_[a-zA-Z0-9]+$/.test(subscriptionId)) {
+    return NextResponse.json({ error: "Invalid subscriptionId format" }, { status: 400 });
+  }
+
   try {
     const stripe = await getStripe();
     if (!stripe) return NextResponse.json({ error: "Stripe not configured" }, { status: 503 });


### PR DESCRIPTION
## Summary

- Add `cus_*` prefix check for `customerId` before passing to `stripe.billingPortal.sessions.create`
- Add `sub_*` prefix check for `subscriptionId` before passing to `stripe.subscriptions.update`
- Invalid IDs now return a clean 400 instead of an opaque Stripe API error

Route is admin-gated so exploitability is low, but this prevents misleading internal errors and is consistent with input validation at system boundaries.

Found during full API security audit of all 120 routes in `src/app/api/`.

## Other audit findings (skipped — design decisions or already correct)
- `analytics-orchestration/_shared.ts` HIGH: confirmed safe — parser only throws hardcoded strings
- `portal/[token]` MEDIUM: no token expiry — requires Notion schema change + feature work
- `voice-brief` MEDIUM: internal CRON_SECRET via HTTP — requires architectural refactor
- `esp32/notion-sync` LOW: dual auth (cron OR admin) — intentional, uses timing-safe compare
- `subscribe/route.ts` LOW: already logs `error.message` only ✅

https://claude.ai/code/session_013sTDMVEYibee8tbXxrwjzo

---
_Generated by [Claude Code](https://claude.ai/code/session_013sTDMVEYibee8tbXxrwjzo)_