### PR TITLE
test: fix env isolation in admin users POST blocks

### DIFF
--- a/__tests__/admin-api.test.ts
+++ b/__tests__/admin-api.test.ts
@@ -271,29 +271,25 @@ vi.mock("@/lib/gsc", () => ({
     { device: "DESKTOP", clicks: 300, impressions: 6000, ctr: 5, avgPosition: 9 },
     { device: "MOBILE", clicks: 200, impressions: 5000, ctr: 4, avgPosition: 12 },
   ]),
-  getProductPageMetrics: vi
-    .fn()
-    .mockResolvedValue([
-      {
-        page: "https://cloudless.gr/store/pro-plan",
-        clicks: 40,
-        impressions: 900,
-        ctr: 4.44,
-        position: 8,
-      },
-    ]),
-  getQueryPageMapping: vi
-    .fn()
-    .mockResolvedValue([
-      {
-        query: "cloudless hosting",
-        page: "https://cloudless.gr/",
-        clicks: 60,
-        impressions: 1500,
-        ctr: 4,
-        position: 6,
-      },
-    ]),
+  getProductPageMetrics: vi.fn().mockResolvedValue([
+    {
+      page: "https://cloudless.gr/store/pro-plan",
+      clicks: 40,
+      impressions: 900,
+      ctr: 4.44,
+      position: 8,
+    },
+  ]),
+  getQueryPageMapping: vi.fn().mockResolvedValue([
+    {
+      query: "cloudless hosting",
+      page: "https://cloudless.gr/",
+      clicks: 60,
+      impressions: 1500,
+      ctr: 4,
+      position: 6,
+    },
+  ]),
   getSearchIntentBreakdown: vi.fn().mockResolvedValue({
     brand: [{ keyword: "cloudless gr", clicks: 100, impressions: 2000, ctr: 5, position: 3 }],
     product: [],
@@ -436,6 +432,11 @@ describe("GET /api/admin/users", () => {
 describe("POST /api/admin/users", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    // Re-import api-auth under the mocked `jose` (setup.ts imports it first,
+    // binding the real jose). Without this, a filtered/standalone run of these
+    // tests skips the GET block's resetModules, so verifyToken uses the real
+    // jwtVerify → 401 on the fake-signed test token. Mirrors the GET block.
+    vi.resetModules();
     process.env.KEYCLOAK_ISSUER = "https://auth.cloudless.gr/realms/master";
     process.env.NEXT_PUBLIC_KEYCLOAK_ISSUER = "https://auth.cloudless.gr/realms/master";
     process.env.KEYCLOAK_ADMIN_USER = "admin";
@@ -495,14 +496,20 @@ describe("POST /api/admin/users", () => {
   });
 
   it("disable action succeeds", async () => {
-    const res = await postAction({ action: "disable", username: "00000000-0000-0000-0000-000000000001" });
+    const res = await postAction({
+      action: "disable",
+      username: "00000000-0000-0000-0000-000000000001",
+    });
     expect(res.status).toBe(200);
     const data = await res.json();
     expect(data.success).toBe(true);
   });
 
   it("enable action succeeds", async () => {
-    const res = await postAction({ action: "enable", username: "00000000-0000-0000-0000-000000000001" });
+    const res = await postAction({
+      action: "enable",
+      username: "00000000-0000-0000-0000-000000000001",
+    });
     expect(res.status).toBe(200);
     const data = await res.json();
     expect(data.success).toBe(true);
@@ -520,7 +527,10 @@ describe("POST /api/admin/users", () => {
   });
 
   it("returns 400 for unknown action", async () => {
-    const res = await postAction({ action: "nuke", username: "00000000-0000-0000-0000-000000000001" });
+    const res = await postAction({
+      action: "nuke",
+      username: "00000000-0000-0000-0000-000000000001",
+    });
     expect(res.status).toBe(400);
   });
 });

--- a/__tests__/admin-users-orders-ops-api.test.ts
+++ b/__tests__/admin-users-orders-ops-api.test.ts
@@ -34,14 +34,28 @@ vi.mock("jose", async () => {
 
 vi.mock("@aws-sdk/client-cognito-identity-provider", () => ({
   CognitoIdentityProviderClient: class {
-    send(cmd: unknown) { return cognitoSendMock(cmd); }
+    send(cmd: unknown) {
+      return cognitoSendMock(cmd);
+    }
   },
-  ListUsersCommand: class { constructor(public input: unknown) {} },
-  AdminDisableUserCommand: class { constructor(public input: unknown) {} },
-  AdminEnableUserCommand: class { constructor(public input: unknown) {} },
-  AdminAddUserToGroupCommand: class { constructor(public input: unknown) {} },
-  AdminRemoveUserFromGroupCommand: class { constructor(public input: unknown) {} },
-  AdminListGroupsForUserCommand: class { constructor(public input: unknown) {} },
+  ListUsersCommand: class {
+    constructor(public input: unknown) {}
+  },
+  AdminDisableUserCommand: class {
+    constructor(public input: unknown) {}
+  },
+  AdminEnableUserCommand: class {
+    constructor(public input: unknown) {}
+  },
+  AdminAddUserToGroupCommand: class {
+    constructor(public input: unknown) {}
+  },
+  AdminRemoveUserFromGroupCommand: class {
+    constructor(public input: unknown) {}
+  },
+  AdminListGroupsForUserCommand: class {
+    constructor(public input: unknown) {}
+  },
 }));
 
 vi.mock("@/lib/stripe", () => ({
@@ -61,7 +75,7 @@ function makeAdminToken(): string {
   const payload = {
     sub: "test-admin-sub",
     email: "admin@cloudless.gr",
-    "groups": ["admin"],
+    groups: ["admin"],
     aud: "test-client-id",
     iss: "https://auth.cloudless.gr/realms/cloudless",
     iat: Math.floor(Date.now() / 1000) - 60,
@@ -89,29 +103,52 @@ function unauthReq(url: string): NextRequest {
 // ---------------------------------------------------------------------------
 describe("GET /api/admin/users", () => {
   const kcUsers = [
-    { id: "uuid-1", username: "u1", email: "user@test.com",
-      firstName: "Test", lastName: "User", emailVerified: true,
-      enabled: true, createdTimestamp: Date.now() },
-    { id: "uuid-admin", username: "adm", email: "admin@cloudless.gr",
-      emailVerified: true, enabled: true, createdTimestamp: Date.now() },
+    {
+      id: "uuid-1",
+      username: "u1",
+      email: "user@test.com",
+      firstName: "Test",
+      lastName: "User",
+      emailVerified: true,
+      enabled: true,
+      createdTimestamp: Date.now(),
+    },
+    {
+      id: "uuid-admin",
+      username: "adm",
+      email: "admin@cloudless.gr",
+      emailVerified: true,
+      enabled: true,
+      createdTimestamp: Date.now(),
+    },
   ];
 
   function mockFetch(adminGroups: string[] = []) {
-    vi.stubGlobal("fetch", vi.fn().mockImplementation((url: string) => {
-      if (String(url).includes("/token")) {
-        return Promise.resolve({ ok: true, json: () => Promise.resolve({ access_token: "tok" }) });
-      }
-      if (/\/users\?/.exec(String(url))) {
-        return Promise.resolve({ ok: true, json: () => Promise.resolve(kcUsers) });
-      }
-      if (String(url).includes("/groups")) {
-        const isAdmin = String(url).includes("uuid-admin");
-        return Promise.resolve({ ok: true, json: () => Promise.resolve(
-          isAdmin && adminGroups.length ? [{ id: "g1", name: adminGroups[0] }] : []
-        )});
-      }
-      return Promise.resolve({ ok: true, json: () => Promise.resolve({}) });
-    }));
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockImplementation((url: string) => {
+        if (String(url).includes("/token")) {
+          return Promise.resolve({
+            ok: true,
+            json: () => Promise.resolve({ access_token: "tok" }),
+          });
+        }
+        if (/\/users\?/.exec(String(url))) {
+          return Promise.resolve({ ok: true, json: () => Promise.resolve(kcUsers) });
+        }
+        if (String(url).includes("/groups")) {
+          const isAdmin = String(url).includes("uuid-admin");
+          return Promise.resolve({
+            ok: true,
+            json: () =>
+              Promise.resolve(
+                isAdmin && adminGroups.length ? [{ id: "g1", name: adminGroups[0] }] : []
+              ),
+          });
+        }
+        return Promise.resolve({ ok: true, json: () => Promise.resolve({}) });
+      })
+    );
   }
 
   beforeEach(() => {
@@ -173,19 +210,33 @@ describe("GET /api/admin/users", () => {
 describe("POST /api/admin/users", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    // Re-import api-auth under the mocked `jose` (setup.ts imports it first,
+    // binding the real jose). Without this, a filtered/standalone run skips the
+    // GET block's resetModules, so verifyToken uses the real jwtVerify → 401 on
+    // the fake-signed test token. Mirrors the GET block.
+    vi.resetModules();
     process.env.KEYCLOAK_ISSUER = "https://auth.cloudless.gr/realms/master";
     process.env.NEXT_PUBLIC_KEYCLOAK_ISSUER = "https://auth.cloudless.gr/realms/master";
     process.env.KEYCLOAK_ADMIN_USER = "admin";
     process.env.KEYCLOAK_ADMIN_PASSWORD = "pass";
-    vi.stubGlobal("fetch", vi.fn().mockImplementation((url: string) => {
-      if (String(url).includes("/token")) {
-        return Promise.resolve({ ok: true, json: () => Promise.resolve({ access_token: "tok" }) });
-      }
-      if (String(url).includes("/groups")) {
-        return Promise.resolve({ ok: true, json: () => Promise.resolve([{ id: "grp-1", name: "admin" }]) });
-      }
-      return Promise.resolve({ ok: true, json: () => Promise.resolve({}) });
-    }));
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockImplementation((url: string) => {
+        if (String(url).includes("/token")) {
+          return Promise.resolve({
+            ok: true,
+            json: () => Promise.resolve({ access_token: "tok" }),
+          });
+        }
+        if (String(url).includes("/groups")) {
+          return Promise.resolve({
+            ok: true,
+            json: () => Promise.resolve([{ id: "grp-1", name: "admin" }]),
+          });
+        }
+        return Promise.resolve({ ok: true, json: () => Promise.resolve({}) });
+      })
+    );
   });
 
   afterEach(() => {
@@ -202,7 +253,9 @@ describe("POST /api/admin/users", () => {
 
   it("returns 400 when action or username missing", async () => {
     const { POST } = await import("@/app/api/admin/users/route");
-    const res = await POST(adminReq("http://localhost/api/admin/users", { method: "POST", body: { action: "disable" } }));
+    const res = await POST(
+      adminReq("http://localhost/api/admin/users", { method: "POST", body: { action: "disable" } })
+    );
     const data = await res.json();
     expect(res.status).toBe(400);
     expect(data.error).toMatch(/required/i);
@@ -210,10 +263,12 @@ describe("POST /api/admin/users", () => {
 
   it("disables a user", async () => {
     const { POST } = await import("@/app/api/admin/users/route");
-    const res = await POST(adminReq("http://localhost/api/admin/users", {
-      method: "POST",
-      body: { action: "disable", username: "00000000-0000-0000-0000-000000000001" },
-    }));
+    const res = await POST(
+      adminReq("http://localhost/api/admin/users", {
+        method: "POST",
+        body: { action: "disable", username: "00000000-0000-0000-0000-000000000001" },
+      })
+    );
     const data = await res.json();
     expect(res.status).toBe(200);
     expect(data.success).toBe(true);
@@ -221,10 +276,12 @@ describe("POST /api/admin/users", () => {
 
   it("promotes user to admin", async () => {
     const { POST } = await import("@/app/api/admin/users/route");
-    const res = await POST(adminReq("http://localhost/api/admin/users", {
-      method: "POST",
-      body: { action: "promote", username: "00000000-0000-0000-0000-000000000001" },
-    }));
+    const res = await POST(
+      adminReq("http://localhost/api/admin/users", {
+        method: "POST",
+        body: { action: "promote", username: "00000000-0000-0000-0000-000000000001" },
+      })
+    );
     const data = await res.json();
     expect(res.status).toBe(200);
     expect(data.message).toMatch(/admin/i);
@@ -232,10 +289,12 @@ describe("POST /api/admin/users", () => {
 
   it("returns 400 for unknown action", async () => {
     const { POST } = await import("@/app/api/admin/users/route");
-    const res = await POST(adminReq("http://localhost/api/admin/users", {
-      method: "POST",
-      body: { action: "nuke", username: "00000000-0000-0000-0000-000000000001" },
-    }));
+    const res = await POST(
+      adminReq("http://localhost/api/admin/users", {
+        method: "POST",
+        body: { action: "nuke", username: "00000000-0000-0000-0000-000000000001" },
+      })
+    );
     const data = await res.json();
     expect(res.status).toBe(400);
     expect(data.error).toMatch(/unknown action/i);
@@ -260,17 +319,21 @@ describe("GET /api/admin/orders", () => {
       checkout: {
         sessions: {
           list: vi.fn().mockResolvedValue({
-            data: [{
-              id: "cs_test_1",
-              customer_email: "buyer@test.com",
-              customer_details: { email: "buyer@test.com" },
-              amount_total: 9900,
-              currency: "eur",
-              payment_status: "paid",
-              mode: "payment",
-              line_items: { data: [{ description: "AI Package", quantity: 1, amount_total: 9900 }] },
-              created: Math.floor(Date.now() / 1000),
-            }],
+            data: [
+              {
+                id: "cs_test_1",
+                customer_email: "buyer@test.com",
+                customer_details: { email: "buyer@test.com" },
+                amount_total: 9900,
+                currency: "eur",
+                payment_status: "paid",
+                mode: "payment",
+                line_items: {
+                  data: [{ description: "AI Package", quantity: 1, amount_total: 9900 }],
+                },
+                created: Math.floor(Date.now() / 1000),
+              },
+            ],
           }),
         },
       },


### PR DESCRIPTION
## Summary

Fixes the test-isolation quirk flagged after #622: running the admin "POST /api/admin/users" tests standalone (e.g. `vitest -t "unknown action"`) **401'd**, even though the full file passed.

### Root cause

`setup.ts` imports `@/lib/api-auth` at setup time, which binds api-auth's `import { jwtVerify } from "jose"` to the **real** jose. The per-file `vi.mock("jose")` (decode-only) only takes effect for api-auth once `vi.resetModules()` forces it to re-import. The **GET** `/api/admin/users` blocks call `resetModules()` in `beforeEach`; the **POST** blocks did not. So:

- **Full run:** the GET block runs first, resets modules → api-auth rebinds to the mocked jose → POST tests reuse it → ✅
- **Filtered/standalone run:** GET block is skipped → api-auth keeps the real jose → `verifyToken` runs the real `jwtVerify` against the fake-signed token → throws → `401`.

Confirmed empirically: the jose mock was hit **14×** in the full run but **0×** when filtered.

### Fix

Add `vi.resetModules()` to the `POST /api/admin/users` `beforeEach` in both files (mirroring their GET blocks): `admin-api.test.ts` and `admin-users-orders-ops-api.test.ts`. Tests now pass regardless of run order or `-t` filter.

## Verification

- `admin-api.test.ts` + `admin-users-orders-ops-api.test.ts`: **67 pass** both full **and** filtered to `"unknown action"` (previously 2 failed when filtered).

## ⚠️ Separate pre-existing failure (not in scope)

`admin-subscriptions-api.test.ts` (2 tests) fails on **clean main**, in isolation — a regression from #623's new Stripe-ID validation, which rejects the test's `cus_test_…` fixture (400 instead of 200). Different route/session; flagging it. The fix is likely just updating the fixtures to valid-format Stripe IDs — happy to do it in a follow-up if you want.

https://claude.ai/code/session_01SFLAFG395WWQcyj69toXbT

---
_Generated by [Claude Code](https://claude.ai/code/session_01SFLAFG395WWQcyj69toXbT)_