### PR TITLE
test: valid-format Stripe IDs in subscriptions fixtures (fixes main)

### DIFF
--- a/__tests__/admin-subscriptions-api.test.ts
+++ b/__tests__/admin-subscriptions-api.test.ts
@@ -1,7 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { NextRequest } from "next/server";
 const SUBSCRIPTIONS_URL = "http://localhost/api/admin/subscriptions";
-const TEST_SUB_ID = "sub_test_1";
+const TEST_SUB_ID = "sub_Test1";
 
 // ---------------------------------------------------------------------------
 // Hoist mocks
@@ -75,7 +75,7 @@ function userReq(url: string): NextRequest {
 
 const MOCK_SUB = {
   id: TEST_SUB_ID,
-  customer: { id: "cus_test_1", email: "customer@test.com", name: "Test Customer" },
+  customer: { id: "cus_Test1", email: "customer@test.com", name: "Test Customer" },
   status: "active",
   items: {
     data: [{
@@ -173,7 +173,7 @@ describe("POST /api/admin/subscriptions", () => {
     const { POST } = await import("@/app/api/admin/subscriptions/route");
     const res = await POST(adminReq(SUBSCRIPTIONS_URL, {
       method: "POST",
-      body: JSON.stringify({ action: "portal", customerId: "cus_test_1" }),
+      body: JSON.stringify({ action: "portal", customerId: "cus_Test1" }),
     }));
     expect(res.status).toBe(200);
     const data = await res.json();


### PR DESCRIPTION
## Summary

Fixes the 2 pre-existing failures in `admin-subscriptions-api.test.ts` (flagged after #624), restoring a fully green suite.

**Root cause:** #623 added Stripe-ID validation to the subscriptions route — `/^cus_[a-zA-Z0-9]+$/` and `/^sub_[a-zA-Z0-9]+$/`. The test fixtures used `cus_test_1` / `sub_test_1`, which have an **underscore after the prefix** — not a valid Stripe ID format — so the route correctly returned **400** and the `portal` / `cancel` tests (expecting 200) failed.

**Fix:** the validation is correct (real Stripe IDs are the prefix + alphanumerics only, e.g. `cus_NffrFeUfNV2Hib`), so I updated the fixtures to `cus_Test1` / `sub_Test1`. No production code changed.

## Verification

- `admin-subscriptions-api.test.ts`: **9 pass** (was 2 failing).
- Full suite: **175 files / 2083 tests pass** — main is fully green again.

https://claude.ai/code/session_01SFLAFG395WWQcyj69toXbT

---
_Generated by [Claude Code](https://claude.ai/code/session_01SFLAFG395WWQcyj69toXbT)_