### PR TITLE
ops: trigger SES SMTP status check and Cloudflare LB report

### DIFF
--- a/.github/workflows/cloudflare-lb.yml
+++ b/.github/workflows/cloudflare-lb.yml
@@ -9,6 +9,7 @@ name: Cloudflare HA load balancer
 # the token + LB entitlement, prints the live account/zone/DNS/LB state and the
 # plan, writes nothing). To apply — including the apex/www DNS cutover — dispatch
 # with apply=true.
+# Last triggered: 2026-06-03 (status check — verifying token + LB state)
 #
 # Auth: Cloudflare token from the CLOUDFLARE_API_TOKEN repo secret (add in the
 # GitHub UI), falling back to SSM /cloudless/production/CLOUDFLARE_API_TOKEN via

--- a/.github/workflows/provision-ses-smtp.yml
+++ b/.github/workflows/provision-ses-smtp.yml
@@ -3,7 +3,7 @@ name: Provision SES SMTP credentials
 # One-shot provisioner for the SES SMTP credential Keycloak needs to send
 # registration verification emails. Uses the OIDC deploy role (no static keys,
 # no PAT). Idempotent: skips if the SSM params already exist.
-# Last triggered: 2026-06-02 (removed push-guard, now auto-provisions via IAM on push)
+# Last triggered: 2026-06-03 (status check — verifying SSM creds exist)
 #
 # After it succeeds, trigger keycloak-configure-email.yml to apply the creds to
 # the realm (or it runs automatically on its own next push).


### PR DESCRIPTION
Path-trigger both status-check workflows so they post their state to issue #382:\n- `provision-ses-smtp.yml` → checks whether SES SMTP creds already exist in SSM (auto-provisions via IAM if not)\n- `cloudflare-lb.yml` → report-only run, checks if `CLOUDFLARE_API_TOKEN` is available and prints current LB/DNS state\n\nhttps://claude.ai/code/session_013sTDMVEYibee8tbXxrwjzo

---
_Generated by [Claude Code](https://claude.ai/code/session_013sTDMVEYibee8tbXxrwjzo)_