### PR TITLE
feat(auth): provider-aware AuthContext sign-in/sign-up/reset (Cognito)

### DIFF
--- a/__tests__/auth-context-provider.test.tsx
+++ b/__tests__/auth-context-provider.test.tsx
@@ -1,0 +1,110 @@
+/**
+ * AuthContext provider-handoff tests.
+ *
+ * AuthContext picks the next-auth provider at build time from
+ * NEXT_PUBLIC_AUTH_PROVIDER. These tests verify the sign-in / sign-up /
+ * forgot-password handlers hand off to the right provider:
+ *   - Cognito → nextAuthSignIn("cognito", ...) for all three flows
+ *   - default (Keycloak) → nextAuthSignIn("keycloak", ...) for sign-in
+ *
+ * (The Keycloak sign-up / reset paths navigate via window.location and are
+ * covered by the existing Keycloak-mode tests; jsdom can't follow navigation.)
+ */
+
+import { render, act, cleanup } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import React from "react";
+
+const { signInMock } = vi.hoisted(() => ({ signInMock: vi.fn() }));
+
+vi.mock("next-auth/react", () => ({
+  SessionProvider: ({ children }: { children: React.ReactNode }) => children,
+  getSession: vi.fn().mockResolvedValue(null),
+  signIn: signInMock,
+  signOut: vi.fn(),
+  useSession: () => ({ data: null, status: "unauthenticated" }),
+}));
+
+vi.mock("next-intl", () => ({ useTranslations: () => (k: string) => k }));
+
+beforeEach(() => {
+  signInMock.mockReset();
+  // Session check on mount → no user.
+  vi.stubGlobal("fetch", vi.fn().mockResolvedValue({ ok: true, json: async () => ({}) }));
+});
+
+afterEach(() => {
+  cleanup();
+  vi.unstubAllGlobals();
+  delete process.env.NEXT_PUBLIC_AUTH_PROVIDER;
+  vi.resetModules();
+});
+
+type AuthApi = {
+  signIn: (e: string, p: string) => Promise<unknown>;
+  signUp: (e: string, p: string, n?: string) => Promise<void>;
+  forgotPassword: (e: string) => Promise<void>;
+};
+
+async function mountWith(provider?: string): Promise<() => AuthApi> {
+  if (provider) process.env.NEXT_PUBLIC_AUTH_PROVIDER = provider;
+  else delete process.env.NEXT_PUBLIC_AUTH_PROVIDER;
+  vi.resetModules();
+  const mod = await import("@/context/AuthContext");
+  let api: AuthApi;
+  function Grab() {
+    api = mod.useAuth() as unknown as AuthApi;
+    return null;
+  }
+  await act(async () => {
+    render(
+      <mod.AuthProvider>
+        <Grab />
+      </mod.AuthProvider>
+    );
+  });
+  return () => api;
+}
+
+describe("AuthContext provider handoff", () => {
+  it("cognito: signIn hands off to the cognito provider", async () => {
+    const get = await mountWith("cognito");
+    await act(async () => {
+      await get().signIn("e@x.com", "pw");
+    });
+    expect(signInMock).toHaveBeenCalledWith("cognito", expect.objectContaining({ redirect: true }));
+  });
+
+  it("cognito: forgotPassword routes through the cognito hosted UI", async () => {
+    const get = await mountWith("cognito");
+    await act(async () => {
+      await get().forgotPassword("e@x.com");
+    });
+    expect(signInMock).toHaveBeenCalledWith(
+      "cognito",
+      expect.objectContaining({ callbackUrl: "/auth/post-login" })
+    );
+  });
+
+  it("cognito: signUp routes through the cognito hosted UI", async () => {
+    const get = await mountWith("cognito");
+    await act(async () => {
+      await get().signUp("e@x.com", "pw", "Name");
+    });
+    expect(signInMock).toHaveBeenCalledWith(
+      "cognito",
+      expect.objectContaining({ callbackUrl: "/auth/post-login" })
+    );
+  });
+
+  it("default (keycloak): signIn hands off to the keycloak provider", async () => {
+    const get = await mountWith(undefined);
+    await act(async () => {
+      await get().signIn("e@x.com", "pw");
+    });
+    expect(signInMock).toHaveBeenCalledWith(
+      "keycloak",
+      expect.objectContaining({ redirect: true })
+    );
+  });
+});

--- a/src/app/[locale]/auth/forgot-password/page.tsx
+++ b/src/app/[locale]/auth/forgot-password/page.tsx
@@ -19,7 +19,8 @@ export default function ForgotPasswordPage() {
     setError("");
     setSubmitting(true);
     try {
-      // Redirects to Keycloak's reset-credentials page; browser navigates away.
+      // Hands off to the active provider's hosted reset flow (Cognito Hosted UI
+      // or Keycloak reset-credentials); the browser navigates away.
       await forgotPassword(email);
     } catch (err: unknown) {
       setError(err instanceof Error ? err.message : "Request failed");

--- a/src/context/AuthContext.tsx
+++ b/src/context/AuthContext.tsx
@@ -19,8 +19,14 @@ const DEFAULT_PREFERENCES: UserPreferences = {
   emailMarketing: false,
 };
 
-/** Same-origin route that reads (GET) and writes (POST) Keycloak profile attributes. */
+/** Same-origin route that reads (GET) and writes (POST) user profile attributes. */
 const PROFILE_ENDPOINT = "/api/user/profile";
+
+// Active OIDC provider, chosen at build time. Cognito (always-up AWS) wins when
+// NEXT_PUBLIC_AUTH_PROVIDER === "cognito"; Keycloak is the fallback. This drives
+// which next-auth provider the sign-in / sign-up / reset flows hand off to.
+const USE_COGNITO = process.env.NEXT_PUBLIC_AUTH_PROVIDER === "cognito";
+const OIDC_PROVIDER = USE_COGNITO ? "cognito" : "keycloak";
 
 export interface AuthUser {
   username: string;
@@ -173,16 +179,24 @@ export function AuthProvider({ children }: AuthProviderProps) {
     checkAuth().catch(() => {}); // eslint-disable-line react-hooks/set-state-in-effect
   }, [checkAuth]);
 
-  // Sign-in delegates entirely to next-auth/Keycloak OIDC flow.
-  // The email/password arguments are ignored — Keycloak shows its own
-  // hosted login page. They're kept in the signature for interface compat
-  // with any callers that pass them (e.g. legacy login form).
+  // Sign-in delegates entirely to the active OIDC provider's hosted flow.
+  // The email/password arguments are ignored — the provider (Cognito Hosted UI
+  // or Keycloak) shows its own login page. They're kept in the signature for
+  // interface compat with any callers that pass them (e.g. legacy login form).
   const handleSignIn = async (_email: string, _password: string): Promise<SignInResult> => {
-    await nextAuthSignIn("keycloak", { redirect: true });
+    await nextAuthSignIn(OIDC_PROVIDER, { redirect: true });
     return {};
   };
 
   const handleSignUp = async (_email: string, _password: string, _name?: string) => {
+    if (USE_COGNITO) {
+      // Cognito Hosted UI handles registration. Route through next-auth so it
+      // manages the OAuth state/PKCE on the callback (a bare Hosted UI deep-link
+      // would fail next-auth's state check on return). The hosted login page
+      // carries the "Sign up" link.
+      await nextAuthSignIn("cognito", { callbackUrl: "/auth/post-login" });
+      return;
+    }
     const issuer = process.env.NEXT_PUBLIC_KEYCLOAK_ISSUER ?? "";
     const clientId = process.env.NEXT_PUBLIC_KEYCLOAK_CLIENT_ID ?? "cloudless-app";
     if (!issuer) return;
@@ -204,10 +218,16 @@ export function AuthProvider({ children }: AuthProviderProps) {
   };
 
   const handleConfirmSignUp = async (_email: string, _code: string) => {
-    // Keycloak handles email verification via its own hosted flow.
+    // The provider handles email verification via its own hosted flow.
   };
 
   const handleForgotPassword = async (email: string) => {
+    if (USE_COGNITO) {
+      // Cognito Hosted UI carries the "Forgot your password?" link. Route
+      // through next-auth so it manages OAuth state/PKCE on return.
+      await nextAuthSignIn("cognito", { callbackUrl: "/auth/post-login" });
+      return;
+    }
     const issuer = process.env.NEXT_PUBLIC_KEYCLOAK_ISSUER ?? "";
     const clientId = process.env.NEXT_PUBLIC_KEYCLOAK_CLIENT_ID ?? "cloudless-app";
     if (!issuer) return;


### PR DESCRIPTION
## Summary

Continues the Cognito migration with a **code-only** fix (no secrets/manual steps): makes the client-side auth flows provider-aware. The login page already branches on `NEXT_PUBLIC_AUTH_PROVIDER`, but **AuthContext's handlers were still hardcoded to Keycloak**:

- `handleSignIn` → `nextAuthSignIn("keycloak")` — under Cognito this hits a **non-existent provider id**.
- `handleSignUp` / `handleForgotPassword` → built Keycloak hosted-page URLs that **no-op** when `NEXT_PUBLIC_KEYCLOAK_ISSUER` is unset → on a Cognito build, the **forgot-password page did nothing**.

### Fix

Pick the provider at build time from `NEXT_PUBLIC_AUTH_PROVIDER` (same signal the login page uses). Under Cognito, all three flows route through `nextAuthSignIn("cognito")` so next-auth manages the OAuth **state/PKCE** on the callback — a bare Hosted UI deep-link would fail next-auth's state check on return. The Cognito hosted login page carries the "Sign up" and "Forgot your password?" links. Keycloak paths unchanged.

## Test plan

- [x] `auth-context-provider.test.tsx` (new, 4 tests): cognito handoff for signIn/signUp/forgotPassword + keycloak default for signIn
- [x] Existing `auth-context.test.tsx` / `auth-signup-page.test.tsx` still green (33 auth tests total)
- [x] `tsc --noEmit` + `eslint` clean

https://claude.ai/code/session_01SFLAFG395WWQcyj69toXbT

---
_Generated by [Claude Code](https://claude.ai/code/session_01SFLAFG395WWQcyj69toXbT)_