### PR TITLE
feat(profile): provider-agnostic user profile on DynamoDB (Cognito-ready)

### DIFF
--- a/__tests__/user-profile-api.test.ts
+++ b/__tests__/user-profile-api.test.ts
@@ -1,9 +1,10 @@
 /**
- * /api/user/profile — updates the signed-in user's Keycloak profile through a
- * same-origin server route (the browser cannot call Keycloak's Account API
- * directly due to CORS → "Failed to fetch"). These tests verify the auth gate
- * and that name → firstName/lastName + company/phone attributes are sent to
- * Keycloak's Account API, merging existing attributes rather than clobbering.
+ * /api/user/profile — provider-agnostic profile store on DynamoDB.
+ *
+ * The route reads/writes name/company/phone/preferences keyed by the OIDC
+ * `sub`, decoupled from the IdP (works for Cognito and Keycloak). These tests
+ * mock @/lib/user-profile so no AWS call is made, and verify the auth gate,
+ * the session fallback for name/email, and the upsert payload.
  *
  * @vitest-environment node
  */
@@ -11,6 +12,15 @@ import { describe, it, expect, beforeEach, vi } from "vitest";
 
 const authMock = vi.fn();
 vi.mock("@/lib/auth", () => ({ auth: authMock }));
+
+const { getUserProfileMock, putUserProfileMock } = vi.hoisted(() => ({
+  getUserProfileMock: vi.fn(),
+  putUserProfileMock: vi.fn(),
+}));
+vi.mock("@/lib/user-profile", () => ({
+  getUserProfile: getUserProfileMock,
+  putUserProfile: putUserProfileMock,
+}));
 
 function makeReq(body: unknown): Request {
   return new Request("http://localhost/api/user/profile", {
@@ -22,38 +32,41 @@ function makeReq(body: unknown): Request {
 
 beforeEach(() => {
   authMock.mockReset();
-  vi.restoreAllMocks();
-  // setup.ts deletes KEYCLOAK_ISSUER in its beforeEach; restore it here.
-  vi.stubEnv("KEYCLOAK_ISSUER", "https://auth.test/realms/master");
+  getUserProfileMock.mockReset();
+  putUserProfileMock.mockReset();
 });
 
 describe("POST /api/user/profile", () => {
-  it("401 when there is no session/accessToken", async () => {
+  it("401 when there is no session", async () => {
     authMock.mockResolvedValue(null);
+    const { POST } = await import("@/app/api/user/profile/route");
+    const res = await POST(makeReq({ name: "A B" }));
+    expect(res.status).toBe(401);
+    expect(putUserProfileMock).not.toHaveBeenCalled();
+  });
+
+  it("401 when the session has no user id (sub)", async () => {
+    authMock.mockResolvedValue({ user: { email: "u@x.gr" } });
     const { POST } = await import("@/app/api/user/profile/route");
     const res = await POST(makeReq({ name: "A B" }));
     expect(res.status).toBe(401);
   });
 
-  it("updates name + attributes and merges existing attributes", async () => {
-    authMock.mockResolvedValue({ user: { id: "u1" }, accessToken: "tok-abc" });
+  it("400 on invalid JSON body", async () => {
+    authMock.mockResolvedValue({ user: { id: "u1" } });
+    const { POST } = await import("@/app/api/user/profile/route");
+    const bad = new Request("http://localhost/api/user/profile", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: "{not json",
+    });
+    const res = await POST(bad);
+    expect(res.status).toBe(400);
+  });
 
-    const fetchMock = vi
-      .spyOn(globalThis, "fetch")
-      // 1) GET current account (existing attributes to merge)
-      .mockResolvedValueOnce(
-        new Response(
-          JSON.stringify({
-            firstName: "Old",
-            lastName: "Name",
-            email: "u@x.gr",
-            attributes: { locale: ["en"] },
-          }),
-          { status: 200 }
-        )
-      )
-      // 2) POST update
-      .mockResolvedValueOnce(new Response(null, { status: 204 }));
+  it("upserts the provided fields keyed by sub", async () => {
+    authMock.mockResolvedValue({ user: { id: "sub-123" } });
+    putUserProfileMock.mockResolvedValue(undefined);
 
     const { POST } = await import("@/app/api/user/profile/route");
     const res = await POST(
@@ -62,64 +75,44 @@ describe("POST /api/user/profile", () => {
 
     expect(res.status).toBe(200);
     expect(await res.json()).toEqual({ ok: true });
-
-    // Inspect the POST call (2nd fetch).
-    const [url, init] = fetchMock.mock.calls[1];
-    expect(url).toBe("https://auth.test/realms/master/account");
-    expect((init as RequestInit).method).toBe("POST");
-    const sent = JSON.parse((init as RequestInit).body as string);
-    expect(sent.firstName).toBe("Baltzakis");
-    expect(sent.lastName).toBe("Themistoklis");
-    expect(sent.attributes).toMatchObject({
-      locale: ["en"], // merged, not clobbered
-      company: ["cloudless.gr"],
-      phone: ["+30123"],
+    expect(putUserProfileMock).toHaveBeenCalledWith("sub-123", {
+      name: "Baltzakis Themistoklis",
+      company: "cloudless.gr",
+      phone: "+30123",
+      preferences: undefined,
     });
   });
 
-  it("surfaces Keycloak validation errors instead of an opaque failure", async () => {
-    authMock.mockResolvedValue({ user: { id: "u1" }, accessToken: "tok-abc" });
-    vi.spyOn(globalThis, "fetch")
-      .mockResolvedValueOnce(new Response(JSON.stringify({ attributes: {} }), { status: 200 }))
-      .mockResolvedValueOnce(new Response("attribute not supported", { status: 400 }));
-
+  it("502 when the store write fails", async () => {
+    authMock.mockResolvedValue({ user: { id: "u1" } });
+    putUserProfileMock.mockRejectedValue(new Error("dynamo down"));
     const { POST } = await import("@/app/api/user/profile/route");
     const res = await POST(makeReq({ company: "x" }));
-    expect(res.status).toBe(400);
-    expect((await res.json()).error).toMatch(/Failed to update profile/);
+    expect(res.status).toBe(502);
   });
 });
 
 describe("GET /api/user/profile", () => {
-  it("401 when there is no session/accessToken", async () => {
+  it("401 when there is no session", async () => {
     authMock.mockResolvedValue(null);
     const { GET } = await import("@/app/api/user/profile/route");
     const res = await GET();
     expect(res.status).toBe(401);
   });
 
-  it("reads name + company/phone/preferences back from Keycloak", async () => {
-    authMock.mockResolvedValue({ user: { id: "u1", email: "u@x.gr" }, accessToken: "tok" });
-    vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
-      new Response(
-        JSON.stringify({
-          firstName: "Baltzakis",
-          lastName: "Themistoklis",
-          email: "u@x.gr",
-          attributes: {
-            company: ["cloudless.gr"],
-            phone: ["+30123"],
-            preferences: [JSON.stringify({ theme: "light", language: "el" })],
-          },
-        }),
-        { status: 200 }
-      )
-    );
+  it("returns the stored profile merged with session name/email", async () => {
+    authMock.mockResolvedValue({ user: { id: "sub-1", email: "u@x.gr", name: "Session Name" } });
+    getUserProfileMock.mockResolvedValue({
+      name: "Stored Name",
+      company: "cloudless.gr",
+      phone: "+30123",
+      preferences: { theme: "light", language: "el" },
+    });
     const { GET } = await import("@/app/api/user/profile/route");
     const res = await GET();
     expect(res.status).toBe(200);
     expect(await res.json()).toEqual({
-      name: "Baltzakis Themistoklis",
+      name: "Stored Name",
       email: "u@x.gr",
       company: "cloudless.gr",
       phone: "+30123",
@@ -127,25 +120,21 @@ describe("GET /api/user/profile", () => {
     });
   });
 
-  it("ignores malformed stored preferences and still returns the profile", async () => {
-    authMock.mockResolvedValue({ user: { id: "u1" }, accessToken: "tok" });
-    vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
-      new Response(
-        JSON.stringify({ firstName: "A", attributes: { preferences: ["{not-json"] } }),
-        { status: 200 }
-      )
-    );
+  it("falls back to the session name/email when no record exists", async () => {
+    authMock.mockResolvedValue({ user: { id: "sub-1", email: "u@x.gr", name: "Session Name" } });
+    getUserProfileMock.mockResolvedValue({});
     const { GET } = await import("@/app/api/user/profile/route");
     const res = await GET();
     expect(res.status).toBe(200);
     const body = await res.json();
-    expect(body.name).toBe("A");
-    expect(body.preferences).toBeUndefined();
+    expect(body.name).toBe("Session Name");
+    expect(body.email).toBe("u@x.gr");
+    expect(body.company).toBeUndefined();
   });
 
-  it("502 when the account cannot be read", async () => {
-    authMock.mockResolvedValue({ user: { id: "u1" }, accessToken: "tok" });
-    vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(new Response(null, { status: 500 }));
+  it("502 when the store read fails", async () => {
+    authMock.mockResolvedValue({ user: { id: "u1" } });
+    getUserProfileMock.mockRejectedValue(new Error("dynamo down"));
     const { GET } = await import("@/app/api/user/profile/route");
     const res = await GET();
     expect(res.status).toBe(502);

--- a/__tests__/user-profile-lib.test.ts
+++ b/__tests__/user-profile-lib.test.ts
@@ -1,0 +1,127 @@
+/**
+ * src/lib/user-profile.ts — DynamoDB-backed profile store.
+ *
+ * Mocks the DynamoDB client `send` and asserts the command shapes:
+ *   - getUserProfile maps the item back, parsing preferences JSON
+ *   - putUserProfile builds a partial SET/REMOVE UpdateItem (name is a reserved
+ *     word → expression attribute names), and is a no-op when nothing changes
+ *
+ * @vitest-environment node
+ */
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+const sendMock = vi.fn();
+vi.mock("@aws-sdk/client-dynamodb", () => {
+  class Cmd {
+    input: Record<string, unknown>;
+    _t = "Base";
+    constructor(input: Record<string, unknown>) {
+      this.input = input;
+    }
+  }
+  const mk = (t: string) =>
+    class extends Cmd {
+      _t = t;
+    };
+  return {
+    DynamoDBClient: class {
+      send = sendMock;
+    },
+    GetItemCommand: mk("GetItem"),
+    UpdateItemCommand: mk("UpdateItem"),
+  };
+});
+
+// resolveDynamoEndpoint is imported from stripe-transactions; stub it cheaply.
+vi.mock("@/lib/stripe-transactions", () => ({ resolveDynamoEndpoint: () => undefined }));
+
+beforeEach(() => {
+  sendMock.mockReset();
+  process.env.USER_PROFILE_TABLE = "cloudless-user-profile";
+});
+
+describe("getUserProfile", () => {
+  it("maps a stored item and parses preferences JSON", async () => {
+    sendMock.mockResolvedValue({
+      Item: {
+        userId: { S: "sub-1" },
+        name: { S: "Stored Name" },
+        company: { S: "cloudless.gr" },
+        phone: { S: "+30123" },
+        preferences: { S: JSON.stringify({ theme: "light" }) },
+      },
+    });
+    const { getUserProfile } = await import("@/lib/user-profile");
+    const p = await getUserProfile("sub-1");
+    expect(p).toEqual({
+      name: "Stored Name",
+      company: "cloudless.gr",
+      phone: "+30123",
+      preferences: { theme: "light" },
+    });
+    const call = sendMock.mock.calls[0][0];
+    expect(call._t).toBe("GetItem");
+    expect(call.input.Key).toEqual({ userId: { S: "sub-1" } });
+  });
+
+  it("returns {} when no record exists", async () => {
+    sendMock.mockResolvedValue({});
+    const { getUserProfile } = await import("@/lib/user-profile");
+    expect(await getUserProfile("sub-x")).toEqual({});
+  });
+
+  it("ignores malformed stored preferences", async () => {
+    sendMock.mockResolvedValue({ Item: { name: { S: "A" }, preferences: { S: "{not-json" } } });
+    const { getUserProfile } = await import("@/lib/user-profile");
+    const p = await getUserProfile("sub-1");
+    expect(p.name).toBe("A");
+    expect(p.preferences).toBeUndefined();
+  });
+});
+
+describe("putUserProfile", () => {
+  it("builds a SET UpdateItem with expression attribute names", async () => {
+    sendMock.mockResolvedValue({});
+    const { putUserProfile } = await import("@/lib/user-profile");
+    await putUserProfile("sub-1", { name: "N", company: "C", phone: "+30" });
+
+    const call = sendMock.mock.calls[0][0];
+    expect(call._t).toBe("UpdateItem");
+    expect(call.input.Key).toEqual({ userId: { S: "sub-1" } });
+    expect(call.input.UpdateExpression).toContain("SET");
+    expect(call.input.ExpressionAttributeNames).toMatchObject({
+      "#name": "name",
+      "#company": "company",
+      "#phone": "phone",
+    });
+    expect(call.input.ExpressionAttributeValues).toMatchObject({
+      ":name": { S: "N" },
+      ":company": { S: "C" },
+      ":phone": { S: "+30" },
+    });
+  });
+
+  it("serializes preferences to a JSON string", async () => {
+    sendMock.mockResolvedValue({});
+    const { putUserProfile } = await import("@/lib/user-profile");
+    await putUserProfile("sub-1", { preferences: { theme: "dark", language: "en" } });
+    const call = sendMock.mock.calls[0][0];
+    expect(call.input.ExpressionAttributeValues[":preferences"].S).toBe(
+      JSON.stringify({ theme: "dark", language: "en" })
+    );
+  });
+
+  it("REMOVEs a field cleared with an empty string", async () => {
+    sendMock.mockResolvedValue({});
+    const { putUserProfile } = await import("@/lib/user-profile");
+    await putUserProfile("sub-1", { phone: "" });
+    const call = sendMock.mock.calls[0][0];
+    expect(call.input.UpdateExpression).toContain("REMOVE #phone");
+  });
+
+  it("is a no-op when no fields are provided (no Dynamo call)", async () => {
+    const { putUserProfile } = await import("@/lib/user-profile");
+    await putUserProfile("sub-1", {});
+    expect(sendMock).not.toHaveBeenCalled();
+  });
+});

--- a/src/app/api/user/profile/route.ts
+++ b/src/app/api/user/profile/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from "next/server";
 import { auth } from "@/lib/auth";
+import { getUserProfile, putUserProfile } from "@/lib/user-profile";
 
 export const dynamic = "force-dynamic";
 
@@ -10,102 +11,47 @@ interface ProfileBody {
   preferences?: unknown;
 }
 
-type KcAttributes = Record<string, string[]>;
-interface KcAccount {
-  firstName?: string;
-  lastName?: string;
-  email?: string;
-  attributes?: KcAttributes;
-}
-
-const JSON_MIME = "application/json";
-
-function splitName(name: string): { firstName: string; lastName?: string } {
-  const [first, ...rest] = name.trim().split(/\s+/);
-  return { firstName: first ?? "", lastName: rest.length ? rest.join(" ") : undefined };
-}
-
 /**
  * GET /api/user/profile
  *
- * Reads the signed-in user's Keycloak profile (name + company/phone/preferences
- * attributes) so the dashboard can display previously-saved values. Without
- * this, the session only carries name/email and the Profile/Settings forms
- * render blank on every load — making saves look like they never stuck.
- *
- * Like POST, this must run server-side: a browser → Keycloak Account API call
- * is cross-origin and CORS-blocked.
+ * Reads the signed-in user's stored profile (name + company/phone/preferences)
+ * from DynamoDB so the dashboard Profile/Settings forms render previously-saved
+ * values. Provider-agnostic: keyed by the OIDC `sub`, so it works identically
+ * for Cognito and Keycloak. `name`/`email` fall back to the session when no
+ * stored record exists yet.
  */
 export async function GET() {
   const session = await auth();
-  const accessToken = session?.accessToken;
-  if (!session?.user || !accessToken) {
+  const userId = session?.user?.id;
+  if (!userId) {
     return NextResponse.json({ error: "Not authenticated" }, { status: 401 });
   }
 
-  const KC_ISSUER = process.env.KEYCLOAK_ISSUER ?? process.env.NEXT_PUBLIC_KEYCLOAK_ISSUER ?? "";
-  if (!KC_ISSUER) {
-    return NextResponse.json({ error: "Auth not configured" }, { status: 500 });
-  }
-
   try {
-    const res = await globalThis.fetch(`${KC_ISSUER}/account`, {
-      headers: { Authorization: `Bearer ${accessToken}`, Accept: JSON_MIME },
-      signal: AbortSignal.timeout(10_000),
-    });
-    if (!res.ok) {
-      return NextResponse.json(
-        { error: "Could not read profile", status: res.status },
-        { status: 502 }
-      );
-    }
-    const acct = (await res.json()) as KcAccount;
-    const attrs = acct.attributes ?? {};
-    const name = [acct.firstName, acct.lastName].filter(Boolean).join(" ").trim();
-
-    let preferences: unknown;
-    const rawPrefs = attrs.preferences?.[0];
-    if (rawPrefs) {
-      try {
-        preferences = JSON.parse(rawPrefs);
-      } catch {
-        // Ignore malformed stored preferences — fall back to client defaults.
-      }
-    }
-
+    const profile = await getUserProfile(userId);
     return NextResponse.json({
-      name: name || undefined,
-      email: acct.email ?? session.user.email ?? undefined,
-      company: attrs.company?.[0],
-      phone: attrs.phone?.[0],
-      preferences,
+      name: profile.name ?? session.user.name ?? undefined,
+      email: session.user.email ?? undefined,
+      company: profile.company,
+      phone: profile.phone,
+      preferences: profile.preferences,
     });
   } catch {
-    return NextResponse.json({ error: "Could not reach auth server" }, { status: 502 });
+    return NextResponse.json({ error: "Could not read profile" }, { status: 502 });
   }
 }
 
 /**
  * POST /api/user/profile
  *
- * Updates the signed-in user's Keycloak profile (name + company/phone
- * attributes, and optional preferences). This MUST run server-side: the
- * browser cannot call Keycloak's Account REST API directly because that is a
- * cross-origin request (cloudless.gr → auth.cloudless.gr) which Keycloak does
- * not send CORS headers for — the browser blocks it and the client sees the
- * opaque "Failed to fetch". Server→Keycloak has no CORS constraint, and the
- * user's access_token (aud: account) is accepted by the Account API.
+ * Upserts the signed-in user's profile fields in DynamoDB. Partial update:
+ * only the keys present in the body are written (empty string clears a field).
  */
 export async function POST(req: Request) {
   const session = await auth();
-  const accessToken = session?.accessToken;
-  if (!session?.user || !accessToken) {
+  const userId = session?.user?.id;
+  if (!userId) {
     return NextResponse.json({ error: "Not authenticated" }, { status: 401 });
-  }
-
-  const KC_ISSUER = process.env.KEYCLOAK_ISSUER ?? process.env.NEXT_PUBLIC_KEYCLOAK_ISSUER ?? "";
-  if (!KC_ISSUER) {
-    return NextResponse.json({ error: "Auth not configured" }, { status: 500 });
   }
 
   let body: ProfileBody;
@@ -115,71 +61,15 @@ export async function POST(req: Request) {
     return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
   }
 
-  const accountUrl = `${KC_ISSUER}/account`;
-  const authHeader = { Authorization: `Bearer ${accessToken}` };
-
-  // Read the current account FIRST so we merge (not clobber) existing fields.
-  // The Account API POST is a full update — omitting email/attributes can blank
-  // them — so if we can't read the current state we must NOT write.
-  let current: KcAccount;
   try {
-    const res = await globalThis.fetch(accountUrl, {
-      headers: { ...authHeader, Accept: JSON_MIME },
-      signal: AbortSignal.timeout(10_000),
+    await putUserProfile(userId, {
+      name: body.name,
+      company: body.company,
+      phone: body.phone,
+      preferences: body.preferences,
     });
-    if (!res.ok) {
-      return NextResponse.json(
-        { error: "Could not read current profile", status: res.status },
-        { status: 502 }
-      );
-    }
-    current = (await res.json()) as KcAccount;
+    return NextResponse.json({ ok: true });
   } catch {
-    return NextResponse.json({ error: "Could not reach auth server" }, { status: 502 });
-  }
-
-  // Never blank the email: it is read-only in the UI, so always preserve it
-  // (fall back to the session's email if the account representation omits it).
-  const preservedEmail = current.email ?? session.user.email ?? undefined;
-
-  const attributes: KcAttributes = { ...(current.attributes ?? {}) };
-  if (body.company !== undefined) attributes.company = [body.company];
-  if (body.phone !== undefined && body.phone !== "") attributes.phone = [body.phone];
-  else if (body.phone === "") delete attributes.phone;
-  if (body.preferences !== undefined) {
-    attributes.preferences = [JSON.stringify(body.preferences)];
-  }
-
-  const payload: KcAccount = {
-    firstName: current.firstName,
-    lastName: current.lastName,
-    email: preservedEmail,
-    attributes,
-  };
-  if (body.name) {
-    const { firstName, lastName } = splitName(body.name);
-    payload.firstName = firstName;
-    payload.lastName = lastName;
-  }
-
-  try {
-    const res = await globalThis.fetch(accountUrl, {
-      method: "POST",
-      headers: { ...authHeader, "Content-Type": JSON_MIME },
-      body: JSON.stringify(payload),
-      signal: AbortSignal.timeout(10_000),
-    });
-    if (res.ok) {
-      return NextResponse.json({ ok: true });
-    }
-    // Surface Keycloak's validation message (e.g. an attribute not allowed by
-    // the realm user profile) instead of an opaque failure.
-    const detail = await res.text().catch(() => "");
-    return NextResponse.json(
-      { error: "Failed to update profile", status: res.status, detail: detail.slice(0, 500) },
-      { status: res.status === 400 ? 400 : 502 }
-    );
-  } catch {
-    return NextResponse.json({ error: "Failed to reach auth server" }, { status: 502 });
+    return NextResponse.json({ error: "Failed to update profile" }, { status: 502 });
   }
 }

--- a/src/context/AuthContext.tsx
+++ b/src/context/AuthContext.tsx
@@ -87,10 +87,11 @@ function isAdminFromSession(user: { groups?: string[]; roles?: string[] }): bool
 }
 
 /**
- * Pull the user's Keycloak profile attributes (company/phone/preferences) that
- * the session token does not carry, merging them onto the base user. Returns
- * the base unchanged on any failure so auth state never depends on it. Without
- * this, the Profile/Settings forms render blank on every load even after a save.
+ * Pull the user's stored profile attributes (company/phone/preferences) that
+ * the session token does not carry, merging them onto the base user. Served by
+ * the provider-agnostic /api/user/profile route (DynamoDB, keyed by sub).
+ * Returns the base unchanged on any failure so auth state never depends on it.
+ * Without this, the Profile/Settings forms render blank on every load.
  */
 async function enrichWithProfile(base: AuthUser): Promise<AuthUser> {
   try {
@@ -159,7 +160,7 @@ export function AuthProvider({ children }: AuthProviderProps) {
           preferences: { ...DEFAULT_PREFERENCES },
         };
         setIsAdmin(isAdminFromSession(data.user));
-        // Enrich with Keycloak profile attributes (company/phone/preferences)
+        // Enrich with stored profile attributes (company/phone/preferences)
         // the session JWT doesn't carry, so saved values render instead of
         // blanks. Best-effort — falls back to the session-only user.
         setUser(await enrichWithProfile(base));
@@ -254,10 +255,8 @@ export function AuthProvider({ children }: AuthProviderProps) {
     company?: string;
     phone?: string;
   }) => {
-    // Go through our own same-origin API route. A direct browser fetch to
-    // Keycloak's Account API (auth.cloudless.gr) is cross-origin and is blocked
-    // by CORS → the opaque "Failed to fetch". The server route uses the user's
-    // access token to update Keycloak with no CORS constraint.
+    // Go through our own same-origin API route, which persists the profile in
+    // DynamoDB keyed by the user's sub (provider-agnostic — Cognito or Keycloak).
     const res = await globalThis.fetch(PROFILE_ENDPOINT, {
       method: "POST",
       headers: { "Content-Type": "application/json" },

--- a/src/lib/user-profile.ts
+++ b/src/lib/user-profile.ts
@@ -1,0 +1,122 @@
+import {
+  DynamoDBClient,
+  GetItemCommand,
+  UpdateItemCommand,
+  type AttributeValue,
+} from "@aws-sdk/client-dynamodb";
+import { resolveDynamoEndpoint } from "@/lib/stripe-transactions";
+
+/**
+ * Provider-agnostic user-profile store on DynamoDB.
+ *
+ * The dashboard Profile/Settings form needs to persist name / company / phone /
+ * preferences. These used to live in the Keycloak Account API, which ties the
+ * profile to a specific IdP and is unavailable under Cognito (its custom
+ * attributes can't be added to an existing pool without replacing it). Storing
+ * the profile in DynamoDB keyed by the user's `sub` decouples it from the IdP,
+ * so it works identically for Cognito and Keycloak.
+ *
+ * Table (sst.config.ts → "UserProfile"): hashKey `userId` = the OIDC `sub`.
+ * Access is granted to the site Lambda via SST resource linking.
+ */
+
+const REGION = process.env.AWS_REGION || "us-east-1";
+
+let dynamoClient: DynamoDBClient | null = null;
+function getDynamoClient(): DynamoDBClient {
+  dynamoClient ??= new DynamoDBClient({ region: REGION, endpoint: resolveDynamoEndpoint() });
+  return dynamoClient;
+}
+
+function getTableName(): string {
+  const name = process.env.USER_PROFILE_TABLE?.trim();
+  if (!name) throw new Error("USER_PROFILE_TABLE is not configured");
+  return name;
+}
+
+export interface UserProfile {
+  name?: string;
+  company?: string;
+  phone?: string;
+  preferences?: unknown;
+}
+
+/** Read a user's stored profile. Returns {} when no record exists yet. */
+export async function getUserProfile(userId: string): Promise<UserProfile> {
+  const res = await getDynamoClient().send(
+    new GetItemCommand({
+      TableName: getTableName(),
+      Key: { userId: { S: userId } },
+    })
+  );
+  const item = res.Item;
+  if (!item) return {};
+
+  let preferences: unknown;
+  const rawPrefs = item.preferences?.S;
+  if (rawPrefs) {
+    try {
+      preferences = JSON.parse(rawPrefs);
+    } catch {
+      // Ignore malformed stored preferences — fall back to client defaults.
+    }
+  }
+
+  return {
+    name: item.name?.S,
+    company: item.company?.S,
+    phone: item.phone?.S,
+    preferences,
+  };
+}
+
+/**
+ * Upsert the provided profile fields, keyed by userId.
+ *
+ * Partial update: only the keys present in `fields` are written. A string set
+ * to "" clears (REMOVEs) that attribute; `undefined` leaves it untouched.
+ * `name` is a DynamoDB reserved word, so all attributes go through expression
+ * attribute names.
+ */
+export async function putUserProfile(userId: string, fields: UserProfile): Promise<void> {
+  const setParts: string[] = [];
+  const removeParts: string[] = [];
+  const names: Record<string, string> = {};
+  const values: Record<string, AttributeValue> = {};
+
+  const handleString = (attr: string, value: string | undefined): void => {
+    if (value === undefined) return;
+    names[`#${attr}`] = attr;
+    if (value === "") {
+      removeParts.push(`#${attr}`);
+      return;
+    }
+    setParts.push(`#${attr} = :${attr}`);
+    values[`:${attr}`] = { S: value };
+  };
+
+  handleString("name", fields.name);
+  handleString("company", fields.company);
+  handleString("phone", fields.phone);
+  if (fields.preferences !== undefined) {
+    names["#preferences"] = "preferences";
+    setParts.push("#preferences = :preferences");
+    values[":preferences"] = { S: JSON.stringify(fields.preferences) };
+  }
+
+  if (setParts.length === 0 && removeParts.length === 0) return; // nothing to write
+
+  const clauses: string[] = [];
+  if (setParts.length) clauses.push(`SET ${setParts.join(", ")}`);
+  if (removeParts.length) clauses.push(`REMOVE ${removeParts.join(", ")}`);
+
+  await getDynamoClient().send(
+    new UpdateItemCommand({
+      TableName: getTableName(),
+      Key: { userId: { S: userId } },
+      UpdateExpression: clauses.join(" "),
+      ExpressionAttributeNames: names,
+      ...(Object.keys(values).length ? { ExpressionAttributeValues: values } : {}),
+    })
+  );
+}

--- a/sst.config.ts
+++ b/sst.config.ts
@@ -15,6 +15,7 @@ function buildSiteEnvironment(
   stage: string,
   isProd: boolean,
   stripeTransactionsTableName: $util.Output<string>,
+  userProfileTableName: $util.Output<string>,
   authSecret?: $util.Output<string>,
   cognito?: {
     issuer: $util.Output<string>;
@@ -40,6 +41,7 @@ function buildSiteEnvironment(
     // what's actually deployed.
     APP_VERSION: process.env.GITHUB_SHA ?? "local",
     STRIPE_TRANSACTIONS_TABLE: stripeTransactionsTableName,
+    USER_PROFILE_TABLE: userProfileTableName,
     // Active auth provider — Cognito (always-up AWS) when configured, else Keycloak.
     // NEXT_PUBLIC_AUTH_PROVIDER drives the login/signup page button label.
     ...(cognito
@@ -145,6 +147,14 @@ export default {
       },
     });
 
+    // Provider-agnostic user-profile store (name/company/phone/preferences),
+    // keyed by the OIDC `sub`. Decouples the dashboard profile from the IdP so
+    // it works identically for Cognito and Keycloak (see src/lib/user-profile.ts).
+    const userProfileTable = new sst.aws.Dynamo("UserProfile", {
+      fields: { userId: "string" },
+      primaryIndex: { hashKey: "userId" },
+    });
+
     // -------------------------------------------------------------------------
     // Cognito User Pool — always-up AWS auth (migration target from Keycloak)
     //
@@ -246,13 +256,20 @@ export default {
         dns: false,
         cert: "arn:aws:acm:us-east-1:278585680617:certificate/f505905a-97b4-46b0-a2b0-fb1900f425b2",
       },
-      environment: buildSiteEnvironment(stage, isProd, stripeTransactionsTable.name, authSecret, {
-        issuer: cognitoIssuer,
-        clientId: userPoolClient.id,
-        clientSecret: userPoolClient.clientSecret.apply((s) => s ?? ""),
-        domain: cognitoHostedDomain,
-      }),
-      link: [stripeTransactionsTable],
+      environment: buildSiteEnvironment(
+        stage,
+        isProd,
+        stripeTransactionsTable.name,
+        userProfileTable.name,
+        authSecret,
+        {
+          issuer: cognitoIssuer,
+          clientId: userPoolClient.id,
+          clientSecret: userPoolClient.clientSecret.apply((s) => s ?? ""),
+          domain: cognitoHostedDomain,
+        }
+      ),
+      link: [stripeTransactionsTable, userProfileTable],
       permissions: [
         {
           // Allow the Lambda server to invoke Bedrock Converse for the chat widget.


### PR DESCRIPTION
## Summary

Fixes the dashboard Profile/Settings form, which **500'd under Cognito** because `/api/user/profile` read/wrote the **Keycloak Account API**. Cognito can't store `company`/`preferences` without custom attributes — and adding those to the existing pool forces a **pool replacement that destroys all users**. Per the chosen approach, the profile now lives in a **provider-agnostic DynamoDB table** keyed by the OIDC `sub`, so it works identically for Cognito and Keycloak.

- **`src/lib/user-profile.ts`** — `getUserProfile` / `putUserProfile` over DynamoDB. Partial `UpdateItem` (SET/REMOVE) using expression attribute names (`name` is a DynamoDB reserved word); `preferences` stored as JSON.
- **`sst.config.ts`** — new `UserProfile` Dynamo table (`hashKey: userId`), `USER_PROFILE_TABLE` env, and resource `link` so the site Lambda gets CRUD access. **Auto-provisioned on deploy — no manual config.**
- **`route.ts`** — rewritten provider-agnostic. Auth gate now needs only a session `sub` (no IdP access token); GET falls back to session `name`/`email` when no record exists yet.
- **`AuthContext`** — refreshed stale "Keycloak profile" comments (no logic change).
- **Tests** — rewrote `user-profile-api.test.ts` for the DDB route; added `user-profile-lib.test.ts` for the command shapes (16 tests).

## Test plan

- [x] Full suite: **177 files / 2096 tests pass**
- [x] `tsc --noEmit` + `eslint` clean
- [ ] After deploy: dashboard Profile form saves + reloads name/company/phone/preferences under Cognito

## Note (follow-up, not blocking)

The Pi HA standby gets config from SSM, not SST — so to serve this route on the Pi it'll need `USER_PROFILE_TABLE` + DynamoDB access on `pi-standby-aws-creds`. The primary (Lambda) path is fully wired here; the Pi standby is a separate runtime-config item.

https://claude.ai/code/session_01SFLAFG395WWQcyj69toXbT

---
_Generated by [Claude Code](https://claude.ai/code/session_01SFLAFG395WWQcyj69toXbT)_