### PR TITLE
fix(pi-proxy): set FUNNEL_HOST env var, fix cert-check timeout

### DIFF
--- a/.github/workflows/deploy-pi-proxy.yml
+++ b/.github/workflows/deploy-pi-proxy.yml
@@ -47,6 +47,16 @@ jobs:
             --function-name cloudless-pi-proxy \
             --region us-east-1
 
+      - name: Set FUNNEL_HOST env var on Lambda
+        run: |
+          aws lambda update-function-configuration \
+            --function-name cloudless-pi-proxy \
+            --region us-east-1 \
+            --environment "Variables={FUNNEL_HOST=omv.tail8eb71.ts.net,FUNNEL_PORT=443}"
+          aws lambda wait function-updated \
+            --function-name cloudless-pi-proxy \
+            --region us-east-1
+
       - name: Verify deployment
         run: |
           aws lambda get-function-configuration \

--- a/.github/workflows/pi-tls-cert-check.yml
+++ b/.github/workflows/pi-tls-cert-check.yml
@@ -7,13 +7,13 @@ name: Pi TLS Cert Check
 #   4. /api/health returns 200 from behind the Lambda IPv6 proxy
 #   5. Legacy TLS 1.0/1.1 are rejected; TLS 1.2+ remains available
 #
-# Architecture (post PR #100, sst.config.ts:83-200):
+# Architecture (lambda/pi-proxy/index.py + deploy-pi-proxy.yml):
 #   Public client
-#     ↓ DNS: cloudless.gr → R53 alias to APIGW (when PRIMARY/CloudFront red)
+#     ↓ DNS: cloudless.gr → Cloudflare LB → APIGW alias (when PRIMARY/CloudFront red)
 #     ↓ TLS to APIGW custom domain (ACM cert, AWS-managed)
-#     ↓ Lambda 'cloudless-pi-proxy' (dual-stack VPC)
-#     ↓ HTTPS over IPv6:18443
-#   Pi (Starlink CGNAT — IPv4 unusable, IPv6 only)
+#     ↓ Lambda 'cloudless-pi-proxy' (FUNNEL_HOST=omv.tail8eb71.ts.net)
+#     ↓ HTTPS:443 → Tailscale Funnel → Pi Traefik → k3s cloudless service
+#   Pi (Starlink CGNAT — reachable only via Tailscale Funnel)
 #
 # Why probe APIGW directly instead of cloudless.gr: while CloudFront is
 # healthy, R53 returns CloudFront. Probing cloudless.gr would never
@@ -129,11 +129,12 @@ jobs:
           echo "→ GET /api/health via SECONDARY (Host: ${SNI}, target: ${APIGW_HOST})"
           # --resolve forces curl to TCP-connect to APIGW while presenting
           # SNI/Host = cloudless.gr. This is exactly how a failover client
-          # would resolve cloudless.gr when R53 returns the APIGW alias.
+          # would resolve cloudless.gr when Cloudflare routes to the APIGW alias.
           # --retry-all-errors retries on 5xx (e.g. transient 504 from Lambda
-          # cold start or Pi wake-up); 3 attempts × 20 s + 2 × 15 s backoff
-          # = ~90 s max, well within the 3-min job timeout.
-          response=$(timeout 20 curl -fsS \
+          # cold start or Pi wake-up); 3 attempts × --max-time 25s + 2 × 15s
+          # backoff = ~105s max. Outer timeout is 120s to cover this budget.
+          response=$(timeout 120 curl -fsS \
+            --max-time 25 \
             --retry 3 --retry-delay 15 --retry-all-errors \
             --resolve "${SNI}:443:$(getent ahosts "${APIGW_HOST}" | awk 'NR==1{print $1}')" \
             -H "User-Agent: pi-tls-cert-check (gh-actions)" \

--- a/lambda/pi-proxy/index.py
+++ b/lambda/pi-proxy/index.py
@@ -16,11 +16,16 @@ TTL = int(os.environ.get("BACKEND_TTL_SEC", "300"))
 TIMEOUT = float(os.environ.get("UPSTREAM_TIMEOUT_SEC", "10"))
 FUNNEL_PORT = int(os.environ.get("FUNNEL_PORT", "443"))
 
+# FUNNEL_HOST env var bypasses SSM lookup entirely — set by deploy-pi-proxy.yml.
+_STATIC_HOST = os.environ.get("FUNNEL_HOST", "")
+
 _ssm = boto3.client("ssm")
 _cache = {"host": None, "exp": 0.0}
 
 
 def _get_funnel_host():
+    if _STATIC_HOST:
+        return _STATIC_HOST
     now = time.time()
     if _cache["host"] and now < _cache["exp"]:
         return _cache["host"]


### PR DESCRIPTION
## Summary

- **Lambda pi-proxy**: Added `FUNNEL_HOST` env var support to bypass SSM lookup on every cold start. The SSM param `/cloudless/production/pi-standby/funnel-host` was never set by any workflow, causing the Lambda to return 503 on every cold start invocation.
- **deploy-pi-proxy.yml**: Added a step to set `FUNNEL_HOST=omv.tail8eb71.ts.net` on the Lambda after each deploy — no SSM needed for the common path.
- **pi-tls-cert-check.yml**: Fixed a timeout bug where `timeout 20` killed `curl` during the 15s retry delay between attempts, producing exit 124 (the third attempt never ran). Changed to `timeout 120` + `--max-time 25` per-request. Also updated the stale architecture comment (`sst.config.ts:83-200` no longer contains the proxy — Cloudflare owns failover now).

## Root cause

`pi-tls-cert-check.yml` was failing with the pattern: 503 → 502 → exit 124. The 503 was the Lambda reporting SSM lookup failure (parameter never set), the 502 was an upstream connection error, and exit 124 was the `timeout 20` outer wrapper killing curl during the 15s retry delay of the third attempt.

## Test plan

- [ ] `deploy-pi-proxy.yml` triggers on merge, sets `FUNNEL_HOST` env var on the Lambda
- [ ] Next `pi-tls-cert-check.yml` run (every 6h) should pass step 3 with the corrected Lambda

https://claude.ai/code/session_013sTDMVEYibee8tbXxrwjzo

---
_Generated by [Claude Code](https://claude.ai/code/session_013sTDMVEYibee8tbXxrwjzo)_