### PR TITLE
fix k3s-app-recover: awk $3 for STATUS column, guard kubectl get pods

### DIFF
--- a/.github/workflows/k3s-app-recover.yml
+++ b/.github/workflows/k3s-app-recover.yml
@@ -84,15 +84,15 @@ jobs:
 
           echo "--- force-deleting pods stuck in ContainerCreating ---"
           kubectl get pods -n cloudless --no-headers 2>/dev/null | \
-            awk '$4 ~ /ContainerCreating/ {print $1}' | \
+            awk '$3 ~ /ContainerCreating/ {print $1}' | \
             while read pod; do
               echo "  force-deleting stuck pod: $pod"
               kubectl delete pod -n cloudless "$pod" --force --grace-period=0 --ignore-not-found=true
             done
 
-          echo "--- force-deleting pods stuck in Unknown state ---"
+          echo "--- force-deleting pods stuck in Unknown/ContainerStatusUnknown state ---"
           kubectl get pods -n cloudless --no-headers 2>/dev/null | \
-            awk '$4 ~ /Unknown/ {print $1}' | \
+            awk '$3 ~ /Unknown/ {print $1}' | \
             while read pod; do
               echo "  force-deleting Unknown pod: $pod"
               kubectl delete pod -n cloudless "$pod" --force --grace-period=0 --ignore-not-found=true
@@ -106,7 +106,7 @@ jobs:
           echo "=== waiting for cloudless deployment to have ≥1 ready pod ==="
           kubectl rollout status deployment/cloudless -n cloudless --timeout=300s || true
           echo "=== final cloudless pod state ==="
-          kubectl get pods -n cloudless
+          kubectl get pods -n cloudless || true
 
       - name: Check pi-origin health
         run: |


### PR DESCRIPTION
## Summary

- **Root cause of first recovery run failure**: `awk '$4 ~ /Unknown/'` was checking the RESTARTS column ($4) instead of the STATUS column ($3). Pod status `ContainerStatusUnknown` lives in $3, so neither the `ContainerCreating` nor the `Unknown` filter ever matched — stuck pods were not deleted.
- **Secondary fix**: Added `|| true` to the final `kubectl get pods -n cloudless` in the rollout-wait step. Without it, a transient apiserver crash right at the end of the rollout window causes the entire step to exit non-zero, which skips the pi-origin health check (step 9 has default `if: success()` condition).

## First run outcome (run 26883354559)

- ✅ ecr-heal jobs/pods deleted
- ❌ ContainerStatusUnknown pods NOT deleted (awk $4 bug)
- ❌ Rollout timed out (old `ContainerStatusUnknown` replicas still blocking)
- ❌ k3s API crashed at 12:06:48Z → `kubectl get pods` failed → step 8 non-zero → pi-origin health check skipped

This PR fixes both issues and re-triggers the recovery on merge.

https://claude.ai/code/session_013sTDMVEYibee8tbXxrwjzo

---
_Generated by [Claude Code](https://claude.ai/code/session_013sTDMVEYibee8tbXxrwjzo)_