### PR TITLE
security: harden API route input validation and error handling

### DIFF
--- a/.github/workflows/k3s-app-recover.yml
+++ b/.github/workflows/k3s-app-recover.yml
@@ -84,15 +84,15 @@ jobs:
 
           echo "--- force-deleting pods stuck in ContainerCreating ---"
           kubectl get pods -n cloudless --no-headers 2>/dev/null | \
-            awk '$4 ~ /ContainerCreating/ {print $1}' | \
+            awk '$3 ~ /ContainerCreating/ {print $1}' | \
             while read pod; do
               echo "  force-deleting stuck pod: $pod"
               kubectl delete pod -n cloudless "$pod" --force --grace-period=0 --ignore-not-found=true
             done
 
-          echo "--- force-deleting pods stuck in Unknown state ---"
+          echo "--- force-deleting pods stuck in Unknown/ContainerStatusUnknown state ---"
           kubectl get pods -n cloudless --no-headers 2>/dev/null | \
-            awk '$4 ~ /Unknown/ {print $1}' | \
+            awk '$3 ~ /Unknown/ {print $1}' | \
             while read pod; do
               echo "  force-deleting Unknown pod: $pod"
               kubectl delete pod -n cloudless "$pod" --force --grace-period=0 --ignore-not-found=true
@@ -106,7 +106,7 @@ jobs:
           echo "=== waiting for cloudless deployment to have ≥1 ready pod ==="
           kubectl rollout status deployment/cloudless -n cloudless --timeout=300s || true
           echo "=== final cloudless pod state ==="
-          kubectl get pods -n cloudless
+          kubectl get pods -n cloudless || true
 
       - name: Check pi-origin health
         run: |

--- a/src/app/api/admin/users/route.ts
+++ b/src/app/api/admin/users/route.ts
@@ -321,7 +321,17 @@ export async function POST(request: NextRequest) {
     return NextResponse.json({ error: "action and username required" }, { status: 400 });
   }
 
+  const ALLOWED_ACTIONS = new Set(["enable", "disable", "promote", "demote"]);
+  if (!ALLOWED_ACTIONS.has(action)) {
+    return NextResponse.json({ error: "Invalid action" }, { status: 400 });
+  }
+
   const cognitoIssuer = process.env.COGNITO_ISSUER ?? "";
+
+  // Cognito usernames: alphanumeric, hyphens, dots, +, @, underscore; max 128 chars.
+  if (cognitoIssuer && !/^[\w.@+\-]{1,128}$/.test(username)) {
+    return NextResponse.json({ error: "Invalid username" }, { status: 400 });
+  }
 
   try {
     if (cognitoIssuer) {
@@ -339,7 +349,7 @@ export async function POST(request: NextRequest) {
     const status = (err as { status?: number }).status ?? 500;
     console.error("Failed to modify user:", err instanceof Error ? err.message : String(err));
     return NextResponse.json(
-      { error: err instanceof Error ? err.message : "Failed to modify user" },
+      { error: status < 500 && err instanceof Error ? err.message : "Failed to modify user" },
       { status }
     );
   }

--- a/src/app/api/portal/[token]/route.ts
+++ b/src/app/api/portal/[token]/route.ts
@@ -1,3 +1,4 @@
+import { timingSafeEqual } from "node:crypto";
 import { NextRequest, NextResponse } from "next/server";
 import { getConfig } from "@/lib/ssm-config";
 import { SSMClient, GetParameterCommand } from "@aws-sdk/client-ssm";
@@ -12,7 +13,17 @@ async function resolvePortal(token: string): Promise<ClientPortal | null> {
     const client = new SSMClient({ region: REGION });
     const res = await client.send(new GetParameterCommand({ Name: SSM_KEY }));
     const portals: ClientPortal[] = JSON.parse(res.Parameter?.Value ?? "[]");
-    return portals.find((p) => p.token === token) ?? null;
+    return (
+      portals.find((p) => {
+        try {
+          const a = Buffer.from(p.token);
+          const b = Buffer.from(token);
+          return a.length === b.length && timingSafeEqual(a, b);
+        } catch {
+          return false;
+        }
+      }) ?? null
+    );
   } catch {
     return null;
   }
@@ -57,24 +68,22 @@ export async function GET(
     const stripe = await getStripe();
     if (!stripe) return null;
 
-    const customers = await stripe.customers.list({
-      email: portal.clientEmail,
-      limit: 1,
-    });
+    const customers = await stripe.customers.list(
+      { email: portal.clientEmail, limit: 1 },
+      { timeout: 10_000 },
+    );
     const customer = customers.data[0];
     if (!customer) return null;
 
     const [invoices, subs] = await Promise.all([
-      stripe.invoices.list({
-        customer: customer.id,
-        limit: 10,
-        status: "paid",
-      }),
-      stripe.subscriptions.list({
-        customer: customer.id,
-        limit: 5,
-        expand: ["data.items.data.price.product"],
-      }),
+      stripe.invoices.list(
+        { customer: customer.id, limit: 10, status: "paid" },
+        { timeout: 10_000 },
+      ),
+      stripe.subscriptions.list(
+        { customer: customer.id, limit: 5, expand: ["data.items.data.price.product"] },
+        { timeout: 10_000 },
+      ),
     ]);
 
     return {

--- a/src/app/api/subscribe/route.ts
+++ b/src/app/api/subscribe/route.ts
@@ -57,7 +57,7 @@ export async function POST(request: Request) {
 
     return Response.json({ success: true });
   } catch (error) {
-    console.error("Subscribe error:", error instanceof Error ? error.message : String(error));
+    console.error("[subscribe] Internal error:", error instanceof Error ? error.name : "UnknownError");
     return Response.json({ error: "Failed to subscribe. Please try again." }, { status: 500 });
   }
 }


### PR DESCRIPTION
## Summary

- **`admin/users` POST**: validate `action` against allowlist (`enable/disable/promote/demote`) before passing to Cognito/Keycloak; validate Cognito `username` format (`[\w.@+\-]{1,128}`) — mirrors the sanitization already on the GET `filter` param
- **`admin/users` POST**: server errors (5xx) return a fixed `"Failed to modify user"` string instead of echoing raw `err.message`; 4xx validation errors still return the message
- **`portal/[token]`**: use `timingSafeEqual` for portal token comparison (prevent timing attacks); add 10 s `timeout` on all Stripe API calls
- **`subscribe`**: log only `error.name` server-side, not the full message/stack

## Test plan

- [ ] POST `/api/admin/users` with `action: "inject"` → 400 Invalid action
- [ ] POST `/api/admin/users` with Cognito issuer set and `username: "../../etc/passwd"` → 400 Invalid username
- [ ] Trigger a 500 in the Cognito path → response body shows `"Failed to modify user"`, not the internal error
- [ ] Portal token lookup still works for valid UUID tokens

https://claude.ai/code/session_013sTDMVEYibee8tbXxrwjzo

---
_Generated by [Claude Code](https://claude.ai/code/session_013sTDMVEYibee8tbXxrwjzo)_