### PR TITLE
ops: trigger restart-pi-runners via push.paths self-trigger

### DIFF
--- a/.github/workflows/restart-pi-runners.yml
+++ b/.github/workflows/restart-pi-runners.yml
@@ -9,6 +9,10 @@ name: Restart Pi self-hosted runners
 
 on:
   workflow_dispatch:
+  push:
+    branches: [main]
+    paths:
+      - ".github/workflows/restart-pi-runners.yml"
 
 permissions:
   contents: read


### PR DESCRIPTION
Adds `push.paths` self-trigger to `restart-pi-runners.yml` so merging this PR immediately fires the runner restart — workaround for `workflow_dispatch` requiring the `workflow` token scope which the cloud session MCP doesn't have.

https://claude.ai/code/session_013sTDMVEYibee8tbXxrwjzo

---
_Generated by [Claude Code](https://claude.ai/code/session_013sTDMVEYibee8tbXxrwjzo)_