### PR TITLE
ops: drop stale `pi` label from Pi build runner selector

### DIFF
--- a/.github/workflows/build-pi-image.yml
+++ b/.github/workflows/build-pi-image.yml
@@ -51,17 +51,15 @@ concurrency:
 jobs:
   build-and-push:
     name: build arm64 + push to ECR
-    # Self-hosted arm64 runner. The label set `[omv, pi, build]` is unique
-    # to the `omv-build` runner on omv-main — `omv-2-build` advertises
-    # `[omv, build]` but lacks `pi`, and `omv` is disabled. This pins Pi
-    # image builds to the runner that has docker installed and now uses
-    # the USB SSD for its `_work` dir (no SD-card thrash). The original
-    # `omv` runner (also on omv-main) stays disabled.
+    # Self-hosted arm64 runner on omv-main. `omv-build` carries
+    # `[self-hosted, omv, build]`; the `pi` label was dropped after a
+    # runner re-registration. Targeting `[omv, build]` picks up omv-main's
+    # Docker+USB-SSD runner correctly.
     #
     # Why not ubuntu-latest + QEMU: pnpm install alone exceeds 60min under
     # QEMU emulation. GH-hosted native arm64 runners require the paid
     # larger-runners plan.
-    runs-on: [self-hosted, omv, pi, build]
+    runs-on: [self-hosted, omv, build]
     timeout-minutes: 45
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v4.3.1

--- a/.github/workflows/deploy-pi.yml
+++ b/.github/workflows/deploy-pi.yml
@@ -36,10 +36,11 @@ env:
 jobs:
   build-and-push:
     name: Build arm64 image and push to ECR
-    # Self-hosted arm64 runner. Label set `[omv, pi, build]` is unique to
-    # `omv-build` on omv-main (which has docker + USB-SSD-backed _work).
-    # The `omv` runner stays disabled to relieve SD-card contention.
-    runs-on: [self-hosted, omv, pi, build]
+    # Self-hosted arm64 runner on omv-main. `omv-build` carries labels
+    # `[self-hosted, omv, build]`; the `pi` label was dropped after a
+    # runner re-registration. `[omv, build]` correctly targets the
+    # Docker+USB-SSD-backed runner on omv-main.
+    runs-on: [self-hosted, omv, build]
     outputs:
       short_sha: ${{ steps.check_ecr.outputs.short_sha }}
       image_exists: ${{ steps.check_ecr.outputs.exists }}


### PR DESCRIPTION
## Summary

- `omv-build` was re-registered without the `pi` label — its actual label set is `[self-hosted, omv, build]`
- Both `build-pi-image.yml` and `deploy-pi.yml` had `runs-on: [self-hosted, omv, pi, build]`, so no runner matched and Pi builds queued indefinitely
- Change both jobs to `runs-on: [self-hosted, omv, build]` — `omv-build` picks them up immediately

## Test plan
- [ ] Merge triggers `build-pi-image.yml` — job should be picked up by `omv-build` within seconds (not stay queued)
- [ ] `deploy-pi.yml` `build-and-push` job likewise routed to `omv-build`
- [ ] `rollout` job in `deploy-pi.yml` is unchanged (already on `ubuntu-latest` via `RUNNER_GENERIC`)

https://claude.ai/code/session_013sTDMVEYibee8tbXxrwjzo

---
_Generated by [Claude Code](https://claude.ai/code/session_013sTDMVEYibee8tbXxrwjzo)_