### PR TITLE
ops: restore cancel-in-progress=false on build-pi-image concurrency

### DIFF
--- a/.github/workflows/build-pi-image.yml
+++ b/.github/workflows/build-pi-image.yml
@@ -46,7 +46,7 @@ permissions:
 
 concurrency:
   group: pi-image-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 jobs:
   build-and-push:


### PR DESCRIPTION
Follow-up to #638. Restores `cancel-in-progress: false` now that the stuck runs are cleared. This prevents a slow 45-min arm64 build from being cancelled mid-flight by an unrelated push.

https://claude.ai/code/session_013sTDMVEYibee8tbXxrwjzo

---
_Generated by [Claude Code](https://claude.ai/code/session_013sTDMVEYibee8tbXxrwjzo)_