### PR TITLE
fix(ci): align build-pi-image auth build args with deploy-pi

### DIFF
--- a/.github/workflows/build-pi-image.yml
+++ b/.github/workflows/build-pi-image.yml
@@ -231,8 +231,7 @@ jobs:
             APP_VERSION=${{ steps.sha.outputs.full }}
             NEXT_PUBLIC_SITE_URL=https://cloudless.gr
             NEXT_PUBLIC_STAGE=production
-            NEXT_PUBLIC_KEYCLOAK_ISSUER=${{ secrets.NEXT_PUBLIC_KEYCLOAK_ISSUER }}
-            NEXT_PUBLIC_KEYCLOAK_CLIENT_ID=${{ secrets.NEXT_PUBLIC_KEYCLOAK_CLIENT_ID }}
+            NEXT_PUBLIC_AUTH_PROVIDER=cognito
             NEXT_PUBLIC_HUBSPOT_PORTAL_ID=${{ secrets.NEXT_PUBLIC_HUBSPOT_PORTAL_ID }}
             NEXT_PUBLIC_SENTRY_DSN=${{ secrets.NEXT_PUBLIC_SENTRY_DSN }}
             NEXT_PUBLIC_META_PIXEL_ID=${{ secrets.NEXT_PUBLIC_META_PIXEL_ID }}


### PR DESCRIPTION
## Summary

`build-pi-image.yml` was still passing `NEXT_PUBLIC_KEYCLOAK_ISSUER` and `NEXT_PUBLIC_KEYCLOAK_CLIENT_ID` as Docker build args after the Cognito migration. `deploy-pi.yml` was correctly updated to `NEXT_PUBLIC_AUTH_PROVIDER=cognito`, but `build-pi-image.yml` (used by the HA sync orchestrator) was not.

This meant Pi standby images built via the orchestrator had Keycloak auth baked in, while direct deploys had Cognito — a silent auth divergence.

**Fix:** Replace the two stale Keycloak args with `NEXT_PUBLIC_AUTH_PROVIDER=cognito` to match `deploy-pi.yml`.

## Test plan
- [ ] Merge triggers `build-pi-image.yml` — new image has `NEXT_PUBLIC_AUTH_PROVIDER=cognito` instead of Keycloak vars
- [ ] `deploy-pi.yml` and `build-pi-image.yml` are now in sync on auth config

https://claude.ai/code/session_013sTDMVEYibee8tbXxrwjzo

---
_Generated by [Claude Code](https://claude.ai/code/session_013sTDMVEYibee8tbXxrwjzo)_