### PR TITLE
feat(ci): add cloudless.gr HTTPS health probe workflow

### DIFF
--- a/.github/workflows/cloudless-https-health-probe.yml
+++ b/.github/workflows/cloudless-https-health-probe.yml
@@ -1,0 +1,294 @@
+name: cloudless.gr HTTPS health probe
+
+# Probes the two live HTTPS serving paths end-to-end and asserts:
+#   PRIMARY  — cloudless.gr (Cloudflare LB → CloudFront)
+#   STANDBY  — pi-origin.cloudless.gr (Tailscale Funnel → Pi/k3s)
+#
+# Per probe:
+#   1. TLS handshake succeeds
+#   2. Cert SAN matches the expected hostname
+#   3. Cert does not expire within MIN_DAYS_REMAINING days
+#   4. TLS 1.0 and 1.1 are rejected; TLS 1.2 is accepted
+#   5. GET /api/health returns HTTP 200 with a valid JSON body
+#
+# This workflow complements pi-tls-cert-check.yml (which probes the legacy
+# APIGW secondary path) by covering the live Cloudflare-fronted paths that
+# serve real traffic.
+#
+# Schedule: every 6h at :00 (00:00, 06:00, 12:00, 18:00 UTC).
+# On failure the workflow run goes red — Slack / email notifications from
+# the existing CI-babysitter pick it up within the next scheduled cycle.
+
+on:
+  schedule:
+    - cron: "0 */6 * * *"
+  workflow_dispatch:
+    inputs:
+      skip_tls_floor:
+        description: "Skip TLS 1.0/1.1 floor check (set to 'true' to bypass)"
+        required: false
+        default: "false"
+
+permissions:
+  contents: read
+
+env:
+  MIN_DAYS_REMAINING: 14
+  SKIP_TLS_FLOOR: ${{ inputs.skip_tls_floor || 'false' }}
+
+jobs:
+  probe-primary:
+    name: Probe PRIMARY (cloudless.gr via Cloudflare → CloudFront)
+    runs-on: ${{ fromJSON(vars.RUNNER_GENERIC || '"ubuntu-latest"') }}
+    timeout-minutes: 5
+    env:
+      PROBE_HOST: "cloudless.gr"
+    steps:
+      - name: TLS handshake + cert validity
+        run: |
+          set -euo pipefail
+
+          echo "→ Pre-check: TCP/443 reachability of ${PROBE_HOST}"
+          if ! timeout 10 bash -c "exec 3<>/dev/tcp/${PROBE_HOST}/443" 2>/dev/null; then
+            echo "::error::${PROBE_HOST}:443 not reachable — Cloudflare edge or upstream offline."
+            exit 1
+          fi
+          echo "  ✓ TCP 443 open"
+
+          echo "→ TLS handshake (SNI=${PROBE_HOST})"
+          set +e
+          timeout 20 openssl s_client \
+            -connect "${PROBE_HOST}:443" \
+            -servername "${PROBE_HOST}" \
+            -showcerts -verify_return_error \
+            < /dev/null > /tmp/openssl.out 2>&1
+          rc=$?
+          set -e
+          if [ "$rc" -ne 0 ]; then
+            echo "::error::TLS handshake failed (exit=${rc})"
+            echo "::group::openssl output"
+            cat /tmp/openssl.out >&2
+            echo "::endgroup::"
+            exit 1
+          fi
+
+          echo "→ Verifying TLS version floor (reject 1.0/1.1, allow 1.2+)"
+          if [ "${SKIP_TLS_FLOOR}" != "true" ]; then
+            if timeout 10 openssl s_client -tls1 \
+                -connect "${PROBE_HOST}:443" -servername "${PROBE_HOST}" \
+                < /dev/null > /tmp/tls10.out 2>&1; then
+              echo "::error::TLS 1.0 handshake unexpectedly succeeded on ${PROBE_HOST}."
+              exit 1
+            fi
+            if timeout 10 openssl s_client -tls1_1 \
+                -connect "${PROBE_HOST}:443" -servername "${PROBE_HOST}" \
+                < /dev/null > /tmp/tls11.out 2>&1; then
+              echo "::error::TLS 1.1 handshake unexpectedly succeeded on ${PROBE_HOST}."
+              exit 1
+            fi
+            if ! timeout 10 openssl s_client -tls1_2 \
+                -connect "${PROBE_HOST}:443" -servername "${PROBE_HOST}" \
+                < /dev/null > /tmp/tls12.out 2>&1; then
+              echo "::error::TLS 1.2 handshake failed on ${PROBE_HOST}."
+              cat /tmp/tls12.out >&2
+              exit 1
+            fi
+            echo "  ✓ TLS 1.0/1.1 rejected, TLS 1.2 accepted"
+          fi
+
+          # Extract leaf cert from the handshake output
+          cert=$(cat /tmp/openssl.out)
+          leaf=$(echo "$cert" | awk '/-----BEGIN CERTIFICATE-----/,/-----END CERTIFICATE-----/' | awk '/-----BEGIN/{i++} i==1')
+
+          not_after=$(echo "$leaf" | openssl x509 -noout -enddate | cut -d= -f2)
+          not_after_epoch=$(date -d "$not_after" +%s)
+          days_left=$(( (not_after_epoch - $(date +%s)) / 86400 ))
+          echo "→ notAfter: ${not_after} (${days_left} days remaining)"
+
+          if [ "$days_left" -lt "${MIN_DAYS_REMAINING}" ]; then
+            echo "::error::Cert for ${PROBE_HOST} expires in ${days_left} days (< ${MIN_DAYS_REMAINING})."
+            exit 1
+          fi
+
+          san=$(echo "$leaf" | openssl x509 -noout -text | grep -A1 "Subject Alternative Name" | tail -1 | tr ',' '\n' | tr -d ' ')
+          if echo "$san" | grep -qE "DNS:${PROBE_HOST}(\b|$)"; then
+            echo "  ✓ Cert valid for ${PROBE_HOST}, ${days_left} days remaining"
+          else
+            echo "::error::Cert at ${PROBE_HOST} does not include ${PROBE_HOST} in SAN: ${san}"
+            exit 1
+          fi
+
+          echo "DAYS_LEFT=${days_left}" >> "$GITHUB_ENV"
+
+      - name: GET /api/health
+        run: |
+          set -euo pipefail
+          echo "→ GET https://${PROBE_HOST}/api/health"
+          response=$(curl -fsS \
+            --max-time 20 \
+            --retry 2 --retry-delay 10 --retry-all-errors \
+            -H "User-Agent: cloudless-https-health-probe (gh-actions)" \
+            "https://${PROBE_HOST}/api/health" -o /tmp/body -w "%{http_code}|%{time_total}s")
+          code="${response%%|*}"
+          elapsed="${response#*|}"
+          echo "  → HTTP ${code} in ${elapsed}"
+          body=$(cat /tmp/body)
+          echo "  → body: ${body}"
+
+          if [ "${code}" != "200" ]; then
+            echo "::error::${PROBE_HOST}/api/health returned ${code}."
+            exit 1
+          fi
+
+          status=$(echo "$body" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('status',''))" 2>/dev/null || echo "")
+          if [ "${status}" != "ok" ]; then
+            echo "::warning::${PROBE_HOST}/api/health returned 200 but status field is '${status}' (expected 'ok')"
+          fi
+          echo "HEALTH_STATUS=${status}" >> "$GITHUB_ENV"
+          echo "HEALTH_ELAPSED=${elapsed}" >> "$GITHUB_ENV"
+
+      - name: Step summary
+        if: success()
+        run: |
+          {
+            echo "## PRIMARY HTTPS Health — cloudless.gr"
+            echo ""
+            echo "| Field | Value |"
+            echo "|---|---|"
+            echo "| Host | \`${PROBE_HOST}\` |"
+            echo "| TLS policy | TLS 1.0/1.1 rejected; TLS 1.2 accepted |"
+            echo "| Cert days remaining | ${DAYS_LEFT} |"
+            echo "| /api/health | ✅ 200 (${HEALTH_ELAPSED}) |"
+            echo "| health.status | ${HEALTH_STATUS} |"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+  probe-standby:
+    name: Probe STANDBY (pi-origin.cloudless.gr via Tailscale Funnel → Pi/k3s)
+    runs-on: ${{ fromJSON(vars.RUNNER_GENERIC || '"ubuntu-latest"') }}
+    timeout-minutes: 5
+    env:
+      PROBE_HOST: "pi-origin.cloudless.gr"
+    steps:
+      - name: TLS handshake + cert validity
+        run: |
+          set -euo pipefail
+
+          echo "→ Pre-check: TCP/443 reachability of ${PROBE_HOST}"
+          if ! timeout 15 bash -c "exec 3<>/dev/tcp/${PROBE_HOST}/443" 2>/dev/null; then
+            echo "::error::${PROBE_HOST}:443 not reachable — Tailscale Funnel or Pi/k3s offline."
+            exit 1
+          fi
+          echo "  ✓ TCP 443 open"
+
+          echo "→ TLS handshake (SNI=${PROBE_HOST})"
+          set +e
+          timeout 20 openssl s_client \
+            -connect "${PROBE_HOST}:443" \
+            -servername "${PROBE_HOST}" \
+            -showcerts -verify_return_error \
+            < /dev/null > /tmp/openssl.out 2>&1
+          rc=$?
+          set -e
+          if [ "$rc" -ne 0 ]; then
+            echo "::error::TLS handshake failed for ${PROBE_HOST} (exit=${rc})"
+            echo "::group::openssl output"
+            cat /tmp/openssl.out >&2
+            echo "::endgroup::"
+            exit 1
+          fi
+
+          echo "→ Verifying TLS version floor"
+          if [ "${SKIP_TLS_FLOOR}" != "true" ]; then
+            if timeout 10 openssl s_client -tls1 \
+                -connect "${PROBE_HOST}:443" -servername "${PROBE_HOST}" \
+                < /dev/null > /tmp/tls10.out 2>&1; then
+              echo "::error::TLS 1.0 unexpectedly accepted by ${PROBE_HOST}."
+              exit 1
+            fi
+            if timeout 10 openssl s_client -tls1_1 \
+                -connect "${PROBE_HOST}:443" -servername "${PROBE_HOST}" \
+                < /dev/null > /tmp/tls11.out 2>&1; then
+              echo "::error::TLS 1.1 unexpectedly accepted by ${PROBE_HOST}."
+              exit 1
+            fi
+            if ! timeout 10 openssl s_client -tls1_2 \
+                -connect "${PROBE_HOST}:443" -servername "${PROBE_HOST}" \
+                < /dev/null > /tmp/tls12.out 2>&1; then
+              echo "::error::TLS 1.2 failed for ${PROBE_HOST}."
+              cat /tmp/tls12.out >&2
+              exit 1
+            fi
+            echo "  ✓ TLS 1.0/1.1 rejected, TLS 1.2 accepted"
+          fi
+
+          cert=$(cat /tmp/openssl.out)
+          leaf=$(echo "$cert" | awk '/-----BEGIN CERTIFICATE-----/,/-----END CERTIFICATE-----/' | awk '/-----BEGIN/{i++} i==1')
+
+          not_after=$(echo "$leaf" | openssl x509 -noout -enddate | cut -d= -f2)
+          not_after_epoch=$(date -d "$not_after" +%s)
+          days_left=$(( (not_after_epoch - $(date +%s)) / 86400 ))
+          echo "→ notAfter: ${not_after} (${days_left} days remaining)"
+
+          if [ "$days_left" -lt "${MIN_DAYS_REMAINING}" ]; then
+            echo "::error::Cert for ${PROBE_HOST} expires in ${days_left} days (< ${MIN_DAYS_REMAINING})."
+            exit 1
+          fi
+
+          san=$(echo "$leaf" | openssl x509 -noout -text | grep -A1 "Subject Alternative Name" | tail -1 | tr ',' '\n' | tr -d ' ')
+          # Cloudflare Universal SSL wildcard cert covers *.cloudless.gr
+          if echo "$san" | grep -qE "DNS:(${PROBE_HOST}|\*\.cloudless\.gr)(\b|$)"; then
+            echo "  ✓ Cert valid for ${PROBE_HOST}, ${days_left} days remaining"
+          else
+            echo "::error::Cert at ${PROBE_HOST} does not cover ${PROBE_HOST} in SAN: ${san}"
+            exit 1
+          fi
+
+          echo "DAYS_LEFT=${days_left}" >> "$GITHUB_ENV"
+
+      - name: GET /api/health
+        run: |
+          set -euo pipefail
+          echo "→ GET https://${PROBE_HOST}/api/health"
+          # Pi/k3s can be slower to respond (cold k3s pod, DERP relay hop).
+          # Generous timeouts: 30s per attempt, 3 retries, 15s backoff.
+          response=$(curl -fsS \
+            --max-time 30 \
+            --retry 3 --retry-delay 15 --retry-all-errors \
+            -H "User-Agent: cloudless-https-health-probe (gh-actions)" \
+            "https://${PROBE_HOST}/api/health" -o /tmp/body -w "%{http_code}|%{time_total}s")
+          code="${response%%|*}"
+          elapsed="${response#*|}"
+          echo "  → HTTP ${code} in ${elapsed}"
+          body=$(cat /tmp/body)
+          echo "  → body: ${body}"
+
+          if [ "${code}" != "200" ]; then
+            echo "::error::${PROBE_HOST}/api/health returned ${code} (Pi/k3s serving path broken)."
+            exit 1
+          fi
+
+          status=$(echo "$body" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('status',''))" 2>/dev/null || echo "")
+          version=$(echo "$body" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('version',''))" 2>/dev/null || echo "")
+          if [ "${status}" != "ok" ]; then
+            echo "::warning::${PROBE_HOST}/api/health returned 200 but status='${status}' (expected 'ok')"
+          fi
+          echo "HEALTH_STATUS=${status}" >> "$GITHUB_ENV"
+          echo "HEALTH_VERSION=${version}" >> "$GITHUB_ENV"
+          echo "HEALTH_ELAPSED=${elapsed}" >> "$GITHUB_ENV"
+
+      - name: Step summary
+        if: success()
+        run: |
+          {
+            echo "## STANDBY HTTPS Health — pi-origin.cloudless.gr"
+            echo ""
+            echo "| Field | Value |"
+            echo "|---|---|"
+            echo "| Host | \`${PROBE_HOST}\` |"
+            echo "| Serving path | Tailscale Funnel → Pi/k3s |"
+            echo "| TLS policy | TLS 1.0/1.1 rejected; TLS 1.2 accepted |"
+            echo "| Cert days remaining | ${DAYS_LEFT} |"
+            echo "| /api/health | ✅ 200 (${HEALTH_ELAPSED}) |"
+            echo "| health.status | ${HEALTH_STATUS} |"
+            echo "| app version | ${HEALTH_VERSION} |"
+          } >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## Summary

Adds `.github/workflows/cloudless-https-health-probe.yml` — a scheduled workflow that probes the two live HTTPS serving paths for `cloudless.gr`:

| Path | Host | Route |
|------|------|-------|
| PRIMARY | `cloudless.gr` | Cloudflare LB → CloudFront → Lambda |
| STANDBY | `pi-origin.cloudless.gr` | Tailscale Funnel → Pi/k3s |

**Per probe (every 6h):**
- TCP/443 reachability check
- TLS handshake with SNI verification
- Cert SAN match + expiry guard (fails if < 14 days remaining)
- TLS version floor: TLS 1.0/1.1 rejected, TLS 1.2 accepted
- `GET /api/health → 200` with `status: "ok"` body check
- Step summary with cert days, response time, app version

**Why this is needed:**

The existing `pi-tls-cert-check.yml` probes the legacy APIGW secondary path (`d-uy6dmk95il.execute-api.us-east-1.amazonaws.com` → Lambda proxy → Pi). Since Cloudflare LB now manages DNS, the actual live serving paths are `cloudless.gr` and `pi-origin.cloudless.gr`. These were previously unmonitored from CI.

## Test plan
- [ ] Merge → first run fires at next 6h cron boundary (`0 */6 * * *`)
- [ ] `workflow_dispatch` to verify both probes pass immediately
- [ ] Simulate failure: `skip_tls_floor: true` input bypasses version check for testing

https://claude.ai/code/session_013sTDMVEYibee8tbXxrwjzo

---
_Generated by [Claude Code](https://claude.ai/code/session_013sTDMVEYibee8tbXxrwjzo)_