### PR TITLE
Add in-app admin CRUD for Testimonials, Case Studies, Services, and FAQs

### DIFF
--- a/.github/workflows/cloudless-https-health-probe.yml
+++ b/.github/workflows/cloudless-https-health-probe.yml
@@ -22,6 +22,10 @@ name: cloudless.gr HTTPS health probe
 on:
   schedule:
     - cron: "0 */6 * * *"
+  push:
+    branches: [main]
+    paths:
+      - ".github/workflows/cloudless-https-health-probe.yml"
   workflow_dispatch:
     inputs:
       skip_tls_floor:

--- a/.github/workflows/cloudless-https-health-probe.yml
+++ b/.github/workflows/cloudless-https-health-probe.yml
@@ -1,0 +1,294 @@
+name: cloudless.gr HTTPS health probe
+
+# Probes the two live HTTPS serving paths end-to-end and asserts:
+#   PRIMARY  — cloudless.gr (Cloudflare LB → CloudFront)
+#   STANDBY  — pi-origin.cloudless.gr (Tailscale Funnel → Pi/k3s)
+#
+# Per probe:
+#   1. TLS handshake succeeds
+#   2. Cert SAN matches the expected hostname
+#   3. Cert does not expire within MIN_DAYS_REMAINING days
+#   4. TLS 1.0 and 1.1 are rejected; TLS 1.2 is accepted
+#   5. GET /api/health returns HTTP 200 with a valid JSON body
+#
+# This workflow complements pi-tls-cert-check.yml (which probes the legacy
+# APIGW secondary path) by covering the live Cloudflare-fronted paths that
+# serve real traffic.
+#
+# Schedule: every 6h at :00 (00:00, 06:00, 12:00, 18:00 UTC).
+# On failure the workflow run goes red — Slack / email notifications from
+# the existing CI-babysitter pick it up within the next scheduled cycle.
+
+on:
+  schedule:
+    - cron: "0 */6 * * *"
+  workflow_dispatch:
+    inputs:
+      skip_tls_floor:
+        description: "Skip TLS 1.0/1.1 floor check (set to 'true' to bypass)"
+        required: false
+        default: "false"
+
+permissions:
+  contents: read
+
+env:
+  MIN_DAYS_REMAINING: 14
+  SKIP_TLS_FLOOR: ${{ inputs.skip_tls_floor || 'false' }}
+
+jobs:
+  probe-primary:
+    name: Probe PRIMARY (cloudless.gr via Cloudflare → CloudFront)
+    runs-on: ${{ fromJSON(vars.RUNNER_GENERIC || '"ubuntu-latest"') }}
+    timeout-minutes: 5
+    env:
+      PROBE_HOST: "cloudless.gr"
+    steps:
+      - name: TLS handshake + cert validity
+        run: |
+          set -euo pipefail
+
+          echo "→ Pre-check: TCP/443 reachability of ${PROBE_HOST}"
+          if ! timeout 10 bash -c "exec 3<>/dev/tcp/${PROBE_HOST}/443" 2>/dev/null; then
+            echo "::error::${PROBE_HOST}:443 not reachable — Cloudflare edge or upstream offline."
+            exit 1
+          fi
+          echo "  ✓ TCP 443 open"
+
+          echo "→ TLS handshake (SNI=${PROBE_HOST})"
+          set +e
+          timeout 20 openssl s_client \
+            -connect "${PROBE_HOST}:443" \
+            -servername "${PROBE_HOST}" \
+            -showcerts -verify_return_error \
+            < /dev/null > /tmp/openssl.out 2>&1
+          rc=$?
+          set -e
+          if [ "$rc" -ne 0 ]; then
+            echo "::error::TLS handshake failed (exit=${rc})"
+            echo "::group::openssl output"
+            cat /tmp/openssl.out >&2
+            echo "::endgroup::"
+            exit 1
+          fi
+
+          echo "→ Verifying TLS version floor (reject 1.0/1.1, allow 1.2+)"
+          if [ "${SKIP_TLS_FLOOR}" != "true" ]; then
+            if timeout 10 openssl s_client -tls1 \
+                -connect "${PROBE_HOST}:443" -servername "${PROBE_HOST}" \
+                < /dev/null > /tmp/tls10.out 2>&1; then
+              echo "::error::TLS 1.0 handshake unexpectedly succeeded on ${PROBE_HOST}."
+              exit 1
+            fi
+            if timeout 10 openssl s_client -tls1_1 \
+                -connect "${PROBE_HOST}:443" -servername "${PROBE_HOST}" \
+                < /dev/null > /tmp/tls11.out 2>&1; then
+              echo "::error::TLS 1.1 handshake unexpectedly succeeded on ${PROBE_HOST}."
+              exit 1
+            fi
+            if ! timeout 10 openssl s_client -tls1_2 \
+                -connect "${PROBE_HOST}:443" -servername "${PROBE_HOST}" \
+                < /dev/null > /tmp/tls12.out 2>&1; then
+              echo "::error::TLS 1.2 handshake failed on ${PROBE_HOST}."
+              cat /tmp/tls12.out >&2
+              exit 1
+            fi
+            echo "  ✓ TLS 1.0/1.1 rejected, TLS 1.2 accepted"
+          fi
+
+          # Extract leaf cert from the handshake output
+          cert=$(cat /tmp/openssl.out)
+          leaf=$(echo "$cert" | awk '/-----BEGIN CERTIFICATE-----/,/-----END CERTIFICATE-----/' | awk '/-----BEGIN/{i++} i==1')
+
+          not_after=$(echo "$leaf" | openssl x509 -noout -enddate | cut -d= -f2)
+          not_after_epoch=$(date -d "$not_after" +%s)
+          days_left=$(( (not_after_epoch - $(date +%s)) / 86400 ))
+          echo "→ notAfter: ${not_after} (${days_left} days remaining)"
+
+          if [ "$days_left" -lt "${MIN_DAYS_REMAINING}" ]; then
+            echo "::error::Cert for ${PROBE_HOST} expires in ${days_left} days (< ${MIN_DAYS_REMAINING})."
+            exit 1
+          fi
+
+          san=$(echo "$leaf" | openssl x509 -noout -text | grep -A1 "Subject Alternative Name" | tail -1 | tr ',' '\n' | tr -d ' ')
+          if echo "$san" | grep -qE "DNS:${PROBE_HOST}(\b|$)"; then
+            echo "  ✓ Cert valid for ${PROBE_HOST}, ${days_left} days remaining"
+          else
+            echo "::error::Cert at ${PROBE_HOST} does not include ${PROBE_HOST} in SAN: ${san}"
+            exit 1
+          fi
+
+          echo "DAYS_LEFT=${days_left}" >> "$GITHUB_ENV"
+
+      - name: GET /api/health
+        run: |
+          set -euo pipefail
+          echo "→ GET https://${PROBE_HOST}/api/health"
+          response=$(curl -fsS \
+            --max-time 20 \
+            --retry 2 --retry-delay 10 --retry-all-errors \
+            -H "User-Agent: cloudless-https-health-probe (gh-actions)" \
+            "https://${PROBE_HOST}/api/health" -o /tmp/body -w "%{http_code}|%{time_total}s")
+          code="${response%%|*}"
+          elapsed="${response#*|}"
+          echo "  → HTTP ${code} in ${elapsed}"
+          body=$(cat /tmp/body)
+          echo "  → body: ${body}"
+
+          if [ "${code}" != "200" ]; then
+            echo "::error::${PROBE_HOST}/api/health returned ${code}."
+            exit 1
+          fi
+
+          status=$(echo "$body" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('status',''))" 2>/dev/null || echo "")
+          if [ "${status}" != "ok" ]; then
+            echo "::warning::${PROBE_HOST}/api/health returned 200 but status field is '${status}' (expected 'ok')"
+          fi
+          echo "HEALTH_STATUS=${status}" >> "$GITHUB_ENV"
+          echo "HEALTH_ELAPSED=${elapsed}" >> "$GITHUB_ENV"
+
+      - name: Step summary
+        if: success()
+        run: |
+          {
+            echo "## PRIMARY HTTPS Health — cloudless.gr"
+            echo ""
+            echo "| Field | Value |"
+            echo "|---|---|"
+            echo "| Host | \`${PROBE_HOST}\` |"
+            echo "| TLS policy | TLS 1.0/1.1 rejected; TLS 1.2 accepted |"
+            echo "| Cert days remaining | ${DAYS_LEFT} |"
+            echo "| /api/health | ✅ 200 (${HEALTH_ELAPSED}) |"
+            echo "| health.status | ${HEALTH_STATUS} |"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+  probe-standby:
+    name: Probe STANDBY (pi-origin.cloudless.gr via Tailscale Funnel → Pi/k3s)
+    runs-on: ${{ fromJSON(vars.RUNNER_GENERIC || '"ubuntu-latest"') }}
+    timeout-minutes: 5
+    env:
+      PROBE_HOST: "pi-origin.cloudless.gr"
+    steps:
+      - name: TLS handshake + cert validity
+        run: |
+          set -euo pipefail
+
+          echo "→ Pre-check: TCP/443 reachability of ${PROBE_HOST}"
+          if ! timeout 15 bash -c "exec 3<>/dev/tcp/${PROBE_HOST}/443" 2>/dev/null; then
+            echo "::error::${PROBE_HOST}:443 not reachable — Tailscale Funnel or Pi/k3s offline."
+            exit 1
+          fi
+          echo "  ✓ TCP 443 open"
+
+          echo "→ TLS handshake (SNI=${PROBE_HOST})"
+          set +e
+          timeout 20 openssl s_client \
+            -connect "${PROBE_HOST}:443" \
+            -servername "${PROBE_HOST}" \
+            -showcerts -verify_return_error \
+            < /dev/null > /tmp/openssl.out 2>&1
+          rc=$?
+          set -e
+          if [ "$rc" -ne 0 ]; then
+            echo "::error::TLS handshake failed for ${PROBE_HOST} (exit=${rc})"
+            echo "::group::openssl output"
+            cat /tmp/openssl.out >&2
+            echo "::endgroup::"
+            exit 1
+          fi
+
+          echo "→ Verifying TLS version floor"
+          if [ "${SKIP_TLS_FLOOR}" != "true" ]; then
+            if timeout 10 openssl s_client -tls1 \
+                -connect "${PROBE_HOST}:443" -servername "${PROBE_HOST}" \
+                < /dev/null > /tmp/tls10.out 2>&1; then
+              echo "::error::TLS 1.0 unexpectedly accepted by ${PROBE_HOST}."
+              exit 1
+            fi
+            if timeout 10 openssl s_client -tls1_1 \
+                -connect "${PROBE_HOST}:443" -servername "${PROBE_HOST}" \
+                < /dev/null > /tmp/tls11.out 2>&1; then
+              echo "::error::TLS 1.1 unexpectedly accepted by ${PROBE_HOST}."
+              exit 1
+            fi
+            if ! timeout 10 openssl s_client -tls1_2 \
+                -connect "${PROBE_HOST}:443" -servername "${PROBE_HOST}" \
+                < /dev/null > /tmp/tls12.out 2>&1; then
+              echo "::error::TLS 1.2 failed for ${PROBE_HOST}."
+              cat /tmp/tls12.out >&2
+              exit 1
+            fi
+            echo "  ✓ TLS 1.0/1.1 rejected, TLS 1.2 accepted"
+          fi
+
+          cert=$(cat /tmp/openssl.out)
+          leaf=$(echo "$cert" | awk '/-----BEGIN CERTIFICATE-----/,/-----END CERTIFICATE-----/' | awk '/-----BEGIN/{i++} i==1')
+
+          not_after=$(echo "$leaf" | openssl x509 -noout -enddate | cut -d= -f2)
+          not_after_epoch=$(date -d "$not_after" +%s)
+          days_left=$(( (not_after_epoch - $(date +%s)) / 86400 ))
+          echo "→ notAfter: ${not_after} (${days_left} days remaining)"
+
+          if [ "$days_left" -lt "${MIN_DAYS_REMAINING}" ]; then
+            echo "::error::Cert for ${PROBE_HOST} expires in ${days_left} days (< ${MIN_DAYS_REMAINING})."
+            exit 1
+          fi
+
+          san=$(echo "$leaf" | openssl x509 -noout -text | grep -A1 "Subject Alternative Name" | tail -1 | tr ',' '\n' | tr -d ' ')
+          # Cloudflare Universal SSL wildcard cert covers *.cloudless.gr
+          if echo "$san" | grep -qE "DNS:(${PROBE_HOST}|\*\.cloudless\.gr)(\b|$)"; then
+            echo "  ✓ Cert valid for ${PROBE_HOST}, ${days_left} days remaining"
+          else
+            echo "::error::Cert at ${PROBE_HOST} does not cover ${PROBE_HOST} in SAN: ${san}"
+            exit 1
+          fi
+
+          echo "DAYS_LEFT=${days_left}" >> "$GITHUB_ENV"
+
+      - name: GET /api/health
+        run: |
+          set -euo pipefail
+          echo "→ GET https://${PROBE_HOST}/api/health"
+          # Pi/k3s can be slower to respond (cold k3s pod, DERP relay hop).
+          # Generous timeouts: 30s per attempt, 3 retries, 15s backoff.
+          response=$(curl -fsS \
+            --max-time 30 \
+            --retry 3 --retry-delay 15 --retry-all-errors \
+            -H "User-Agent: cloudless-https-health-probe (gh-actions)" \
+            "https://${PROBE_HOST}/api/health" -o /tmp/body -w "%{http_code}|%{time_total}s")
+          code="${response%%|*}"
+          elapsed="${response#*|}"
+          echo "  → HTTP ${code} in ${elapsed}"
+          body=$(cat /tmp/body)
+          echo "  → body: ${body}"
+
+          if [ "${code}" != "200" ]; then
+            echo "::error::${PROBE_HOST}/api/health returned ${code} (Pi/k3s serving path broken)."
+            exit 1
+          fi
+
+          status=$(echo "$body" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('status',''))" 2>/dev/null || echo "")
+          version=$(echo "$body" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('version',''))" 2>/dev/null || echo "")
+          if [ "${status}" != "ok" ]; then
+            echo "::warning::${PROBE_HOST}/api/health returned 200 but status='${status}' (expected 'ok')"
+          fi
+          echo "HEALTH_STATUS=${status}" >> "$GITHUB_ENV"
+          echo "HEALTH_VERSION=${version}" >> "$GITHUB_ENV"
+          echo "HEALTH_ELAPSED=${elapsed}" >> "$GITHUB_ENV"
+
+      - name: Step summary
+        if: success()
+        run: |
+          {
+            echo "## STANDBY HTTPS Health — pi-origin.cloudless.gr"
+            echo ""
+            echo "| Field | Value |"
+            echo "|---|---|"
+            echo "| Host | \`${PROBE_HOST}\` |"
+            echo "| Serving path | Tailscale Funnel → Pi/k3s |"
+            echo "| TLS policy | TLS 1.0/1.1 rejected; TLS 1.2 accepted |"
+            echo "| Cert days remaining | ${DAYS_LEFT} |"
+            echo "| /api/health | ✅ 200 (${HEALTH_ELAPSED}) |"
+            echo "| health.status | ${HEALTH_STATUS} |"
+            echo "| app version | ${HEALTH_VERSION} |"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/notion-schema-check.yml
+++ b/.github/workflows/notion-schema-check.yml
@@ -8,6 +8,10 @@ on:
       - "src/lib/notion-forms.ts"
       - "src/lib/notion-docs.ts"
       - "src/lib/notion.ts"
+      - "src/lib/notion-testimonials.ts"
+      - "src/lib/notion-case-studies.ts"
+      - "src/lib/notion-services.ts"
+      - "src/lib/notion-faqs.ts"
   workflow_dispatch:
 
 env:
@@ -16,6 +20,10 @@ env:
   NOTION_BLOG_DB_ID: ${{ secrets.NOTION_BLOG_DB_ID }}
   NOTION_SUBMISSIONS_DB_ID: ${{ secrets.NOTION_SUBMISSIONS_DB_ID }}
   NOTION_DOCS_DB_ID: ${{ secrets.NOTION_DOCS_DB_ID }}
+  NOTION_TESTIMONIALS_DB_ID: ${{ secrets.NOTION_TESTIMONIALS_DB_ID }}
+  NOTION_CASE_STUDIES_DB_ID: ${{ secrets.NOTION_CASE_STUDIES_DB_ID }}
+  NOTION_SERVICES_DB_ID: ${{ secrets.NOTION_SERVICES_DB_ID }}
+  NOTION_FAQS_DB_ID: ${{ secrets.NOTION_FAQS_DB_ID }}
 
 jobs:
   validate:
@@ -120,6 +128,136 @@ jobs:
 
           # Check Category select options
           EXPECTED_CATS='["Getting Started","Integrations","API Reference","Guides","General"]'
+          ACTUAL_CATS=$(echo "$RESPONSE" | jq '[.properties.Category.select.options[]?.name]')
+          MISSING_CATS=$(echo "$EXPECTED_CATS" | jq -r --argjson actual "$ACTUAL_CATS" '[.[] | select(. as $k | $actual | index($k) | not)]')
+
+          if [ "$(echo "$MISSING_CATS" | jq 'length')" -gt 0 ]; then
+            echo "⚠️ Missing Category options: $(echo "$MISSING_CATS" | jq -r 'join(", ")')" >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "✅ Category select options valid" >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+      - name: Validate Testimonials DB schema
+        if: ${{ env.NOTION_TESTIMONIALS_DB_ID != '' }}
+        run: |
+          echo "### Testimonials Database" >> "$GITHUB_STEP_SUMMARY"
+          RESPONSE=$(curl -sS "https://api.notion.com/v1/databases/${NOTION_TESTIMONIALS_DB_ID}" \
+            -H "Authorization: Bearer ${NOTION_API_KEY}" \
+            -H "Notion-Version: 2022-06-28")
+
+          STATUS=$(echo "$RESPONSE" | jq -r '.object // "error"')
+          if [ "$STATUS" = "error" ]; then
+            echo "❌ Failed to reach Testimonials DB: $(echo "$RESPONSE" | jq -r '.message')" >> "$GITHUB_STEP_SUMMARY"
+            echo "::error::Testimonials DB unreachable"
+            exit 1
+          fi
+
+          REQUIRED='["Name","Company","Role","Quote","Featured","Published","Order"]'
+          ACTUAL=$(echo "$RESPONSE" | jq -r '[.properties | keys[]]')
+          MISSING=$(echo "$REQUIRED" | jq -r --argjson actual "$ACTUAL" '[.[] | select(. as $k | $actual | index($k) | not)]')
+          COUNT=$(echo "$MISSING" | jq 'length')
+
+          if [ "$COUNT" -gt 0 ]; then
+            echo "⚠️ Missing columns: $(echo "$MISSING" | jq -r 'join(", ")')" >> "$GITHUB_STEP_SUMMARY"
+            echo "::warning::Testimonials DB missing columns: $(echo "$MISSING" | jq -r 'join(", ")')"
+          else
+            echo "✅ All required columns present" >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+      - name: Validate Case Studies DB schema
+        if: ${{ env.NOTION_CASE_STUDIES_DB_ID != '' }}
+        run: |
+          echo "### Case Studies Database" >> "$GITHUB_STEP_SUMMARY"
+          RESPONSE=$(curl -sS "https://api.notion.com/v1/databases/${NOTION_CASE_STUDIES_DB_ID}" \
+            -H "Authorization: Bearer ${NOTION_API_KEY}" \
+            -H "Notion-Version: 2022-06-28")
+
+          STATUS=$(echo "$RESPONSE" | jq -r '.object // "error"')
+          if [ "$STATUS" = "error" ]; then
+            echo "❌ Failed to reach Case Studies DB: $(echo "$RESPONSE" | jq -r '.message')" >> "$GITHUB_STEP_SUMMARY"
+            echo "::error::Case Studies DB unreachable"
+            exit 1
+          fi
+
+          REQUIRED='["Title","Slug","Client","Summary","Challenge","Solution","Results","Published","Featured","Date"]'
+          ACTUAL=$(echo "$RESPONSE" | jq -r '[.properties | keys[]]')
+          MISSING=$(echo "$REQUIRED" | jq -r --argjson actual "$ACTUAL" '[.[] | select(. as $k | $actual | index($k) | not)]')
+          COUNT=$(echo "$MISSING" | jq 'length')
+
+          if [ "$COUNT" -gt 0 ]; then
+            echo "⚠️ Missing columns: $(echo "$MISSING" | jq -r 'join(", ")')" >> "$GITHUB_STEP_SUMMARY"
+            echo "::warning::Case Studies DB missing columns: $(echo "$MISSING" | jq -r 'join(", ")')"
+          else
+            echo "✅ All required columns present" >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+      - name: Validate Services DB schema
+        if: ${{ env.NOTION_SERVICES_DB_ID != '' }}
+        run: |
+          echo "### Services Database" >> "$GITHUB_STEP_SUMMARY"
+          RESPONSE=$(curl -sS "https://api.notion.com/v1/databases/${NOTION_SERVICES_DB_ID}" \
+            -H "Authorization: Bearer ${NOTION_API_KEY}" \
+            -H "Notion-Version: 2022-06-28")
+
+          STATUS=$(echo "$RESPONSE" | jq -r '.object // "error"')
+          if [ "$STATUS" = "error" ]; then
+            echo "❌ Failed to reach Services DB: $(echo "$RESPONSE" | jq -r '.message')" >> "$GITHUB_STEP_SUMMARY"
+            echo "::error::Services DB unreachable"
+            exit 1
+          fi
+
+          REQUIRED='["Name","Slug","Description","Price","Category","Features","CTA","Icon","Published","Order"]'
+          ACTUAL=$(echo "$RESPONSE" | jq -r '[.properties | keys[]]')
+          MISSING=$(echo "$REQUIRED" | jq -r --argjson actual "$ACTUAL" '[.[] | select(. as $k | $actual | index($k) | not)]')
+          COUNT=$(echo "$MISSING" | jq 'length')
+
+          if [ "$COUNT" -gt 0 ]; then
+            echo "⚠️ Missing columns: $(echo "$MISSING" | jq -r 'join(", ")')" >> "$GITHUB_STEP_SUMMARY"
+            echo "::warning::Services DB missing columns: $(echo "$MISSING" | jq -r 'join(", ")')"
+          else
+            echo "✅ All required columns present" >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+          # Check Category select options
+          EXPECTED_CATS='["audit","devops","consulting","training"]'
+          ACTUAL_CATS=$(echo "$RESPONSE" | jq '[.properties.Category.select.options[]?.name]')
+          MISSING_CATS=$(echo "$EXPECTED_CATS" | jq -r --argjson actual "$ACTUAL_CATS" '[.[] | select(. as $k | $actual | index($k) | not)]')
+
+          if [ "$(echo "$MISSING_CATS" | jq 'length')" -gt 0 ]; then
+            echo "⚠️ Missing Category options: $(echo "$MISSING_CATS" | jq -r 'join(", ")')" >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "✅ Category select options valid" >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+      - name: Validate FAQs DB schema
+        if: ${{ env.NOTION_FAQS_DB_ID != '' }}
+        run: |
+          echo "### FAQs Database" >> "$GITHUB_STEP_SUMMARY"
+          RESPONSE=$(curl -sS "https://api.notion.com/v1/databases/${NOTION_FAQS_DB_ID}" \
+            -H "Authorization: Bearer ${NOTION_API_KEY}" \
+            -H "Notion-Version: 2022-06-28")
+
+          STATUS=$(echo "$RESPONSE" | jq -r '.object // "error"')
+          if [ "$STATUS" = "error" ]; then
+            echo "❌ Failed to reach FAQs DB: $(echo "$RESPONSE" | jq -r '.message')" >> "$GITHUB_STEP_SUMMARY"
+            echo "::error::FAQs DB unreachable"
+            exit 1
+          fi
+
+          REQUIRED='["Question","Answer","Category","Published","Order"]'
+          ACTUAL=$(echo "$RESPONSE" | jq -r '[.properties | keys[]]')
+          MISSING=$(echo "$REQUIRED" | jq -r --argjson actual "$ACTUAL" '[.[] | select(. as $k | $actual | index($k) | not)]')
+          COUNT=$(echo "$MISSING" | jq 'length')
+
+          if [ "$COUNT" -gt 0 ]; then
+            echo "⚠️ Missing columns: $(echo "$MISSING" | jq -r 'join(", ")')" >> "$GITHUB_STEP_SUMMARY"
+            echo "::warning::FAQs DB missing columns: $(echo "$MISSING" | jq -r 'join(", ")')"
+          else
+            echo "✅ All required columns present" >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+          # Check Category select options
+          EXPECTED_CATS='["general","pricing","technical","process"]'
           ACTUAL_CATS=$(echo "$RESPONSE" | jq '[.properties.Category.select.options[]?.name]')
           MISSING_CATS=$(echo "$EXPECTED_CATS" | jq -r --argjson actual "$ACTUAL_CATS" '[.[] | select(. as $k | $actual | index($k) | not)]')
 

--- a/__tests__/notion-webhook-api.test.ts
+++ b/__tests__/notion-webhook-api.test.ts
@@ -55,7 +55,7 @@ describe("POST /api/webhooks/notion", () => {
   it("returns 401 when x-webhook-secret header is missing", async () => {
     const { POST } = await import("@/app/api/webhooks/notion/route");
     const response = await POST(
-      makeRequest({ type: "page.updated", database: "blog", page_id: "p1" }),
+      makeRequest({ type: "page.updated", database: "blog", page_id: "p1" })
     );
 
     expect(response.status).toBe(401);
@@ -66,10 +66,7 @@ describe("POST /api/webhooks/notion", () => {
   it("returns 401 when x-webhook-secret is wrong", async () => {
     const { POST } = await import("@/app/api/webhooks/notion/route");
     const response = await POST(
-      makeRequest(
-        { type: "page.updated", database: "blog", page_id: "p1" },
-        "wrong_secret",
-      ),
+      makeRequest({ type: "page.updated", database: "blog", page_id: "p1" }, "wrong_secret")
     );
 
     expect(response.status).toBe(401);
@@ -80,10 +77,7 @@ describe("POST /api/webhooks/notion", () => {
 
     const { POST } = await import("@/app/api/webhooks/notion/route");
     const response = await POST(
-      makeRequest(
-        { type: "page.updated", database: "blog", page_id: "p1" },
-        "test_notion_secret",
-      ),
+      makeRequest({ type: "page.updated", database: "blog", page_id: "p1" }, "test_notion_secret")
     );
 
     expect(response.status).toBe(401);
@@ -108,9 +102,7 @@ describe("POST /api/webhooks/notion", () => {
 
   it("returns 400 when required fields are missing", async () => {
     const { POST } = await import("@/app/api/webhooks/notion/route");
-    const response = await POST(
-      makeRequest({ type: "page.updated" }, "test_notion_secret"),
-    );
+    const response = await POST(makeRequest({ type: "page.updated" }, "test_notion_secret"));
 
     expect(response.status).toBe(400);
     const data = await response.json();
@@ -120,10 +112,7 @@ describe("POST /api/webhooks/notion", () => {
   it("returns 400 for unknown event type", async () => {
     const { POST } = await import("@/app/api/webhooks/notion/route");
     const response = await POST(
-      makeRequest(
-        { type: "unknown.event", database: "blog", page_id: "p1" },
-        "test_notion_secret",
-      ),
+      makeRequest({ type: "unknown.event", database: "blog", page_id: "p1" }, "test_notion_secret")
     );
 
     expect(response.status).toBe(400);
@@ -136,8 +125,8 @@ describe("POST /api/webhooks/notion", () => {
     const response = await POST(
       makeRequest(
         { type: "page.updated", database: "blog", page_id: "p1", slug: "my-post" },
-        "test_notion_secret",
-      ),
+        "test_notion_secret"
+      )
     );
 
     expect(response.status).toBe(200);
@@ -154,8 +143,8 @@ describe("POST /api/webhooks/notion", () => {
     const response = await POST(
       makeRequest(
         { type: "page.updated", database: "docs", page_id: "p2", slug: "my-doc" },
-        "test_notion_secret",
-      ),
+        "test_notion_secret"
+      )
     );
 
     expect(response.status).toBe(200);
@@ -167,10 +156,7 @@ describe("POST /api/webhooks/notion", () => {
   it("handles page.created for blog — revalidates blog and sitemap", async () => {
     const { POST } = await import("@/app/api/webhooks/notion/route");
     const response = await POST(
-      makeRequest(
-        { type: "page.created", database: "blog", page_id: "p3" },
-        "test_notion_secret",
-      ),
+      makeRequest({ type: "page.created", database: "blog", page_id: "p3" }, "test_notion_secret")
     );
 
     expect(response.status).toBe(200);
@@ -192,8 +178,8 @@ describe("POST /api/webhooks/notion", () => {
           slug: "new-doc",
           data: { title: "New Guide" },
         },
-        "test_notion_secret",
-      ),
+        "test_notion_secret"
+      )
     );
 
     expect(response.status).toBe(200);
@@ -211,8 +197,8 @@ describe("POST /api/webhooks/notion", () => {
           page_id: "p5",
           data: { email: "client@example.com", name: "Alice", status: "Done" },
         },
-        "test_notion_secret",
-      ),
+        "test_notion_secret"
+      )
     );
 
     expect(response.status).toBe(200);
@@ -235,8 +221,8 @@ describe("POST /api/webhooks/notion", () => {
           page_id: "p6",
           data: { email: "client@example.com", name: "Bob", status: "In Progress" },
         },
-        "test_notion_secret",
-      ),
+        "test_notion_secret"
+      )
     );
 
     expect(response.status).toBe(200);
@@ -255,8 +241,8 @@ describe("POST /api/webhooks/notion", () => {
           page_id: "p7",
           data: { name: "Cloud Migration", status: "Completed" },
         },
-        "test_notion_secret",
-      ),
+        "test_notion_secret"
+      )
     );
 
     expect(response.status).toBe(200);
@@ -275,8 +261,8 @@ describe("POST /api/webhooks/notion", () => {
           page_id: "p8",
           data: { name: "SEO Audit", status: "Blocked" },
         },
-        "test_notion_secret",
-      ),
+        "test_notion_secret"
+      )
     );
 
     expect(response.status).toBe(200);
@@ -294,8 +280,8 @@ describe("POST /api/webhooks/notion", () => {
           page_id: "p9",
           data: { task: "Write report", status: "Blocked", assignee: "Themis" },
         },
-        "test_notion_secret",
-      ),
+        "test_notion_secret"
+      )
     );
 
     expect(response.status).toBe(200);
@@ -314,8 +300,8 @@ describe("POST /api/webhooks/notion", () => {
           page_id: "p10",
           data: { type: "error", count: 15 },
         },
-        "test_notion_secret",
-      ),
+        "test_notion_secret"
+      )
     );
 
     expect(response.status).toBe(200);
@@ -333,12 +319,84 @@ describe("POST /api/webhooks/notion", () => {
           page_id: "p11",
           data: { type: "error", count: 5 },
         },
-        "test_notion_secret",
-      ),
+        "test_notion_secret"
+      )
     );
 
     expect(response.status).toBe(200);
     expect(slackContactNotifyMock).not.toHaveBeenCalled();
+  });
+
+  it("handles page.updated for testimonials — invalidates testimonials cache", async () => {
+    const { POST } = await import("@/app/api/webhooks/notion/route");
+    const response = await POST(
+      makeRequest(
+        { type: "page.updated", database: "testimonials", page_id: "t1" },
+        "test_notion_secret"
+      )
+    );
+
+    expect(response.status).toBe(200);
+    const data = await response.json();
+    expect(data.ok).toBe(true);
+    expect(data.revalidated).toBe(true);
+    expect(invalidateCacheMock).toHaveBeenCalledWith("testimonials");
+    expect(revalidatePathMock).toHaveBeenCalledWith("/api/testimonials");
+  });
+
+  it("handles page.updated for case-studies — invalidates cache and revalidates slug path", async () => {
+    const { POST } = await import("@/app/api/webhooks/notion/route");
+    const response = await POST(
+      makeRequest(
+        { type: "page.updated", database: "case-studies", page_id: "cs1", slug: "techflow" },
+        "test_notion_secret"
+      )
+    );
+
+    expect(response.status).toBe(200);
+    expect(invalidateCacheMock).toHaveBeenCalledWith("case-studies");
+    expect(revalidatePathMock).toHaveBeenCalledWith("/api/case-studies");
+    expect(revalidatePathMock).toHaveBeenCalledWith("/api/case-studies/techflow");
+  });
+
+  it("handles page.updated for services — invalidates services cache", async () => {
+    const { POST } = await import("@/app/api/webhooks/notion/route");
+    const response = await POST(
+      makeRequest(
+        { type: "page.updated", database: "services", page_id: "s1" },
+        "test_notion_secret"
+      )
+    );
+
+    expect(response.status).toBe(200);
+    expect(invalidateCacheMock).toHaveBeenCalledWith("services");
+    expect(revalidatePathMock).toHaveBeenCalledWith("/api/services");
+  });
+
+  it("handles page.updated for faqs — invalidates faqs cache", async () => {
+    const { POST } = await import("@/app/api/webhooks/notion/route");
+    const response = await POST(
+      makeRequest({ type: "page.updated", database: "faqs", page_id: "f1" }, "test_notion_secret")
+    );
+
+    expect(response.status).toBe(200);
+    expect(invalidateCacheMock).toHaveBeenCalledWith("faqs");
+    expect(revalidatePathMock).toHaveBeenCalledWith("/api/faqs");
+  });
+
+  it("handles page.created for case-studies — revalidates sitemap", async () => {
+    const { POST } = await import("@/app/api/webhooks/notion/route");
+    const response = await POST(
+      makeRequest(
+        { type: "page.created", database: "case-studies", page_id: "cs2", slug: "retail-plus" },
+        "test_notion_secret"
+      )
+    );
+
+    expect(response.status).toBe(200);
+    expect(invalidateCacheMock).toHaveBeenCalledWith("case-studies");
+    expect(revalidatePathMock).toHaveBeenCalledWith("/api/case-studies");
+    expect(revalidatePathMock).toHaveBeenCalledWith("/sitemap.xml");
   });
 
   it("returns 500 when a downstream handler throws", async () => {
@@ -350,8 +408,8 @@ describe("POST /api/webhooks/notion", () => {
     const response = await POST(
       makeRequest(
         { type: "page.updated", database: "blog", page_id: "p12", slug: "boom" },
-        "test_notion_secret",
-      ),
+        "test_notion_secret"
+      )
     );
 
     expect(response.status).toBe(500);

--- a/src/app/[locale]/admin/AdminLayoutClient.tsx
+++ b/src/app/[locale]/admin/AdminLayoutClient.tsx
@@ -37,6 +37,10 @@ import {
   Server,
   Cpu,
   ExternalLink,
+  Star,
+  Briefcase,
+  HelpCircle,
+  Package,
   type LucideIcon,
 } from "lucide-react";
 
@@ -80,6 +84,15 @@ const adminGroups: AdminGroup[] = [
       { href: "/admin/docs", label: "Docs", Icon: FileText },
       { href: "/admin/projects", label: "Projects", Icon: FolderKanban },
       { href: "/admin/notion", label: "Submissions", Icon: Inbox },
+    ],
+  },
+  {
+    label: "CMS",
+    links: [
+      { href: "/admin/cms/testimonials", label: "Testimonials", Icon: Star },
+      { href: "/admin/cms/case-studies", label: "Case Studies", Icon: Briefcase },
+      { href: "/admin/cms/services", label: "Services", Icon: Package },
+      { href: "/admin/cms/faqs", label: "FAQs", Icon: HelpCircle },
     ],
   },
   {

--- a/src/app/[locale]/admin/cms/case-studies/page.tsx
+++ b/src/app/[locale]/admin/cms/case-studies/page.tsx
@@ -1,0 +1,368 @@
+"use client";
+
+import { fetchWithAuth } from "@/lib/fetch-with-auth";
+import { useCallback, useEffect, useState } from "react";
+import type { CaseStudy, CaseStudyInput, CaseStudyMetric } from "@/lib/notion-case-studies";
+
+const EMPTY_FORM: CaseStudyInput & { metricsText?: string; tagsText?: string; servicesText?: string } = {
+  title: "",
+  slug: "",
+  client: "",
+  industry: "",
+  services: [],
+  servicesText: "",
+  summary: "",
+  challenge: "",
+  solution: "",
+  results: "",
+  metrics: [],
+  metricsText: "",
+  coverImage: "",
+  tags: [],
+  tagsText: "",
+  published: false,
+  featured: false,
+  date: new Date().toISOString().slice(0, 10),
+};
+
+type FormState = typeof EMPTY_FORM & { pageId?: string };
+
+function parseMetrics(text: string): CaseStudyMetric[] {
+  return text
+    .split("\n")
+    .map((line) => {
+      const parts = line.split("|").map((p) => p.trim());
+      return parts.length >= 2 ? { label: parts[0], value: parts[1] } : null;
+    })
+    .filter((m): m is CaseStudyMetric => m !== null && Boolean(m.label));
+}
+
+export default function AdminCaseStudiesPage() {
+  const [items, setItems] = useState<CaseStudy[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [saving, setSaving] = useState(false);
+  const [deleting, setDeleting] = useState<string | null>(null);
+  const [form, setForm] = useState<FormState | null>(null);
+  const [formError, setFormError] = useState<string | null>(null);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await fetchWithAuth("/api/admin/notion/case-studies");
+      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      const data = (await res.json()) as { caseStudies: CaseStudy[] };
+      setItems(data.caseStudies ?? []);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to load");
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  const openCreate = () => {
+    setForm({ ...EMPTY_FORM });
+    setFormError(null);
+  };
+
+  const openEdit = (cs: CaseStudy) => {
+    setForm({
+      pageId: cs.id,
+      title: cs.title,
+      slug: cs.slug,
+      client: cs.client,
+      industry: cs.industry,
+      services: cs.services,
+      servicesText: cs.services.join(", "),
+      summary: cs.summary,
+      challenge: cs.challenge,
+      solution: cs.solution,
+      results: cs.results,
+      metrics: cs.metrics,
+      metricsText: cs.metrics.map((m) => `${m.label} | ${m.value}`).join("\n"),
+      coverImage: cs.coverImage ?? "",
+      tags: cs.tags,
+      tagsText: cs.tags.join(", "),
+      published: cs.featured,
+      featured: cs.featured,
+      date: cs.date?.slice(0, 10) ?? "",
+    });
+    setFormError(null);
+  };
+
+  const submitForm = async () => {
+    if (!form) return;
+    if (!form.title.trim()) {
+      setFormError("Title is required.");
+      return;
+    }
+    setSaving(true);
+    setFormError(null);
+    try {
+      const { pageId, metricsText, tagsText, servicesText, ...input } = form;
+      input.metrics = parseMetrics(metricsText ?? "");
+      input.tags = (tagsText ?? "").split(",").map((t) => t.trim()).filter(Boolean);
+      input.services = (servicesText ?? "").split(",").map((s) => s.trim()).filter(Boolean);
+      const method = pageId ? "PATCH" : "POST";
+      const body = pageId ? { pageId, ...input } : input;
+      const res = await fetchWithAuth("/api/admin/notion/case-studies", {
+        method,
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(body),
+      });
+      if (!res.ok) {
+        const d = (await res.json()) as { error?: string };
+        throw new Error(d.error ?? `HTTP ${res.status}`);
+      }
+      setForm(null);
+      await load();
+    } catch (err) {
+      setFormError(err instanceof Error ? err.message : "Save failed");
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const deleteItem = async (pageId: string) => {
+    if (!confirm("Archive this case study?")) return;
+    setDeleting(pageId);
+    try {
+      const res = await fetchWithAuth(
+        `/api/admin/notion/case-studies?pageId=${encodeURIComponent(pageId)}`,
+        { method: "DELETE" }
+      );
+      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      setItems((prev) => prev.filter((cs) => cs.id !== pageId));
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Delete failed");
+    } finally {
+      setDeleting(null);
+    }
+  };
+
+  return (
+    <div>
+      <div className="mb-8 flex items-start justify-between">
+        <div>
+          <div className="bg-neon-magenta/10 border-neon-magenta/20 mb-4 inline-flex items-center gap-2 rounded-full border px-3 py-1.5">
+            <span className="bg-neon-magenta h-2 w-2 animate-pulse rounded-full" />
+            <span className="text-neon-magenta font-mono text-xs">CMS_CASE_STUDIES</span>
+          </div>
+          <h1 className="font-heading text-2xl font-bold text-white">Case Studies</h1>
+          <p className="font-body mt-1 text-slate-400">Manage client success stories and case studies.</p>
+        </div>
+        <div className="flex gap-2">
+          <button
+            onClick={load}
+            disabled={loading}
+            className="rounded-lg border border-slate-700 px-3 py-1.5 font-mono text-xs text-slate-400 hover:border-slate-500 disabled:opacity-50"
+          >
+            {loading ? "Loading…" : "↺ Refresh"}
+          </button>
+          <button
+            onClick={openCreate}
+            className="rounded-lg border border-neon-magenta/30 bg-neon-magenta/10 px-3 py-1.5 font-mono text-xs text-neon-magenta hover:bg-neon-magenta/20"
+          >
+            + New
+          </button>
+        </div>
+      </div>
+
+      {error && (
+        <div className="mb-4 rounded-xl border border-red-500/30 bg-red-500/10 p-4 font-mono text-sm text-red-400">
+          {error}
+        </div>
+      )}
+
+      {form && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/70 p-4">
+          <div className="max-h-[90vh] w-full max-w-2xl overflow-y-auto rounded-2xl border border-slate-700 bg-void-dark p-6 shadow-2xl">
+            <h2 className="font-heading mb-4 text-lg font-bold text-white">
+              {form.pageId ? "Edit Case Study" : "New Case Study"}
+            </h2>
+            <div className="grid grid-cols-2 gap-3">
+              {(["title", "slug", "client", "industry", "date"] as const).map((k) => (
+                <label key={k} className={`flex flex-col gap-1 ${k === "title" ? "col-span-2" : ""}`}>
+                  <span className="font-mono text-xs text-slate-400 capitalize">
+                    {k}{k === "title" ? " *" : ""}
+                  </span>
+                  <input
+                    type={k === "date" ? "date" : "text"}
+                    className="rounded border border-slate-700 bg-void px-3 py-1.5 font-body text-sm text-white focus:border-neon-magenta focus:outline-none"
+                    value={(form[k] as string) ?? ""}
+                    onChange={(e) => setForm((f) => f && { ...f, [k]: e.target.value })}
+                  />
+                </label>
+              ))}
+              <label className="col-span-2 flex flex-col gap-1">
+                <span className="font-mono text-xs text-slate-400">Services (comma-separated)</span>
+                <input
+                  type="text"
+                  className="rounded border border-slate-700 bg-void px-3 py-1.5 font-body text-sm text-white focus:border-neon-magenta focus:outline-none"
+                  value={form.servicesText ?? ""}
+                  onChange={(e) => setForm((f) => f && { ...f, servicesText: e.target.value })}
+                />
+              </label>
+              <label className="col-span-2 flex flex-col gap-1">
+                <span className="font-mono text-xs text-slate-400">Tags (comma-separated)</span>
+                <input
+                  type="text"
+                  className="rounded border border-slate-700 bg-void px-3 py-1.5 font-body text-sm text-white focus:border-neon-magenta focus:outline-none"
+                  value={form.tagsText ?? ""}
+                  onChange={(e) => setForm((f) => f && { ...f, tagsText: e.target.value })}
+                />
+              </label>
+              {(["summary", "challenge", "solution", "results"] as const).map((k) => (
+                <label key={k} className="col-span-2 flex flex-col gap-1">
+                  <span className="font-mono text-xs text-slate-400 capitalize">{k}</span>
+                  <textarea
+                    rows={3}
+                    className="rounded border border-slate-700 bg-void px-3 py-1.5 font-body text-sm text-white focus:border-neon-magenta focus:outline-none"
+                    value={(form[k] as string) ?? ""}
+                    onChange={(e) => setForm((f) => f && { ...f, [k]: e.target.value })}
+                  />
+                </label>
+              ))}
+              <label className="col-span-2 flex flex-col gap-1">
+                <span className="font-mono text-xs text-slate-400">
+                  Metrics (one per line: Label | Value)
+                </span>
+                <textarea
+                  rows={3}
+                  placeholder={"Cost reduction | 55%\nTime to results | 30 days"}
+                  className="rounded border border-slate-700 bg-void px-3 py-1.5 font-mono text-xs text-white placeholder-slate-700 focus:border-neon-magenta focus:outline-none"
+                  value={form.metricsText ?? ""}
+                  onChange={(e) => setForm((f) => f && { ...f, metricsText: e.target.value })}
+                />
+              </label>
+              <label className="col-span-2 flex flex-col gap-1">
+                <span className="font-mono text-xs text-slate-400">Cover Image URL</span>
+                <input
+                  type="text"
+                  className="rounded border border-slate-700 bg-void px-3 py-1.5 font-body text-sm text-white focus:border-neon-magenta focus:outline-none"
+                  value={form.coverImage ?? ""}
+                  onChange={(e) => setForm((f) => f && { ...f, coverImage: e.target.value })}
+                />
+              </label>
+              <div className="col-span-2 flex gap-4">
+                {(["published", "featured"] as const).map((k) => (
+                  <label key={k} className="flex items-center gap-2 font-mono text-xs text-slate-400">
+                    <input
+                      type="checkbox"
+                      checked={(form[k] as boolean) ?? false}
+                      onChange={(e) => setForm((f) => f && { ...f, [k]: e.target.checked })}
+                      className="accent-neon-magenta"
+                    />
+                    {k.charAt(0).toUpperCase() + k.slice(1)}
+                  </label>
+                ))}
+              </div>
+            </div>
+            {formError && <p className="mt-3 font-mono text-xs text-red-400">{formError}</p>}
+            <div className="mt-5 flex justify-end gap-2">
+              <button
+                onClick={() => setForm(null)}
+                className="rounded-lg border border-slate-700 px-4 py-1.5 font-mono text-xs text-slate-400 hover:border-slate-500"
+              >
+                Cancel
+              </button>
+              <button
+                onClick={submitForm}
+                disabled={saving}
+                className="rounded-lg border border-neon-magenta/40 bg-neon-magenta/20 px-4 py-1.5 font-mono text-xs text-neon-magenta hover:bg-neon-magenta/30 disabled:opacity-50"
+              >
+                {saving ? "Saving…" : form.pageId ? "Save Changes" : "Create"}
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {loading && (
+        <div className="space-y-3">
+          {[1, 2, 3].map((i) => (
+            <div key={i} className="h-24 animate-pulse rounded-xl border border-slate-800 bg-void-light/50" />
+          ))}
+        </div>
+      )}
+
+      {!loading && !error && items.length === 0 && (
+        <div className="rounded-xl border border-slate-800 bg-void-light/30 p-12 text-center">
+          <p className="font-mono text-slate-500">No case studies yet. Click + New to add one.</p>
+        </div>
+      )}
+
+      {!loading && items.length > 0 && (
+        <div className="space-y-3">
+          {items.map((cs) => (
+            <div key={cs.id} className="rounded-xl border border-slate-800 bg-void-light/50 p-4">
+              <div className="flex items-start justify-between gap-4">
+                <div className="flex-1 min-w-0">
+                  <div className="flex flex-wrap items-center gap-2">
+                    <span className="font-heading font-semibold text-white">{cs.title}</span>
+                    {cs.client && (
+                      <span className="font-mono text-xs text-slate-500">{cs.client}</span>
+                    )}
+                    {cs.industry && (
+                      <span className="rounded-full border border-slate-700 px-2 py-0.5 font-mono text-xs text-slate-400">
+                        {cs.industry}
+                      </span>
+                    )}
+                    {cs.featured && (
+                      <span className="rounded-full border border-yellow-500/30 bg-yellow-500/10 px-2 py-0.5 font-mono text-xs text-yellow-400">
+                        Featured
+                      </span>
+                    )}
+                    {cs.date && (
+                      <span className="font-mono text-xs text-slate-600">
+                        {cs.date.slice(0, 10)}
+                      </span>
+                    )}
+                  </div>
+                  {cs.summary && (
+                    <p className="mt-1 font-body text-sm text-slate-400 line-clamp-1">{cs.summary}</p>
+                  )}
+                  {cs.metrics.length > 0 && (
+                    <div className="mt-1 flex flex-wrap gap-3">
+                      {cs.metrics.map((m, i) => (
+                        <span key={i} className="font-mono text-xs text-neon-magenta">
+                          {m.label}: {m.value}
+                        </span>
+                      ))}
+                    </div>
+                  )}
+                </div>
+                <div className="flex shrink-0 gap-2">
+                  <button
+                    onClick={() => openEdit(cs)}
+                    className="rounded border border-slate-700 px-2 py-1 font-mono text-xs text-slate-400 hover:border-slate-500 hover:text-white"
+                  >
+                    Edit
+                  </button>
+                  <button
+                    onClick={() => deleteItem(cs.id)}
+                    disabled={deleting === cs.id}
+                    className="rounded border border-red-900/40 px-2 py-1 font-mono text-xs text-red-500 hover:border-red-700/50 hover:text-red-400 disabled:opacity-40"
+                  >
+                    {deleting === cs.id ? "…" : "Archive"}
+                  </button>
+                </div>
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+
+      {!loading && items.length > 0 && (
+        <p className="mt-4 text-right font-mono text-xs text-slate-600">
+          {items.length} case stud{items.length !== 1 ? "ies" : "y"}
+        </p>
+      )}
+    </div>
+  );
+}

--- a/src/app/[locale]/admin/cms/faqs/page.tsx
+++ b/src/app/[locale]/admin/cms/faqs/page.tsx
@@ -1,0 +1,290 @@
+"use client";
+
+import { fetchWithAuth } from "@/lib/fetch-with-auth";
+import { useCallback, useEffect, useState } from "react";
+import type { Faq, FaqInput, FaqCategory } from "@/lib/notion-faqs";
+
+const FAQ_CATEGORIES: FaqCategory[] = ["general", "pricing", "technical", "process"];
+
+const EMPTY_FORM: FaqInput = {
+  question: "",
+  answer: "",
+  category: "general",
+  locales: [],
+  published: false,
+  order: undefined,
+};
+
+type FormState = FaqInput & { pageId?: string };
+
+export default function AdminFaqsPage() {
+  const [items, setItems] = useState<Faq[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [saving, setSaving] = useState(false);
+  const [deleting, setDeleting] = useState<string | null>(null);
+  const [form, setForm] = useState<FormState | null>(null);
+  const [formError, setFormError] = useState<string | null>(null);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await fetchWithAuth("/api/admin/notion/faqs");
+      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      const data = (await res.json()) as { faqs: Faq[] };
+      setItems(data.faqs ?? []);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to load");
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  const openCreate = () => {
+    setForm({ ...EMPTY_FORM });
+    setFormError(null);
+  };
+
+  const openEdit = (f: Faq) => {
+    setForm({
+      pageId: f.id,
+      question: f.question,
+      answer: f.answer,
+      category: f.category,
+      locales: f.locales,
+      published: true,
+    });
+    setFormError(null);
+  };
+
+  const submitForm = async () => {
+    if (!form) return;
+    if (!form.question.trim()) {
+      setFormError("Question is required.");
+      return;
+    }
+    setSaving(true);
+    setFormError(null);
+    try {
+      const { pageId, ...input } = form;
+      const method = pageId ? "PATCH" : "POST";
+      const body = pageId ? { pageId, ...input } : input;
+      const res = await fetchWithAuth("/api/admin/notion/faqs", {
+        method,
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(body),
+      });
+      if (!res.ok) {
+        const d = (await res.json()) as { error?: string };
+        throw new Error(d.error ?? `HTTP ${res.status}`);
+      }
+      setForm(null);
+      await load();
+    } catch (err) {
+      setFormError(err instanceof Error ? err.message : "Save failed");
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const deleteItem = async (pageId: string) => {
+    if (!confirm("Archive this FAQ?")) return;
+    setDeleting(pageId);
+    try {
+      const res = await fetchWithAuth(
+        `/api/admin/notion/faqs?pageId=${encodeURIComponent(pageId)}`,
+        { method: "DELETE" }
+      );
+      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      setItems((prev) => prev.filter((f) => f.id !== pageId));
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Delete failed");
+    } finally {
+      setDeleting(null);
+    }
+  };
+
+  const CATEGORY_COLORS: Record<FaqCategory, string> = {
+    general: "border-slate-700 text-slate-400",
+    pricing: "border-neon-green/30 text-neon-green",
+    technical: "border-neon-cyan/30 text-neon-cyan",
+    process: "border-yellow-500/30 text-yellow-400",
+  };
+
+  return (
+    <div>
+      <div className="mb-8 flex items-start justify-between">
+        <div>
+          <div className="bg-yellow-500/10 border-yellow-500/20 mb-4 inline-flex items-center gap-2 rounded-full border px-3 py-1.5">
+            <span className="h-2 w-2 animate-pulse rounded-full bg-yellow-400" />
+            <span className="font-mono text-xs text-yellow-400">CMS_FAQS</span>
+          </div>
+          <h1 className="font-heading text-2xl font-bold text-white">FAQs</h1>
+          <p className="font-body mt-1 text-slate-400">Manage frequently asked questions.</p>
+        </div>
+        <div className="flex gap-2">
+          <button
+            onClick={load}
+            disabled={loading}
+            className="rounded-lg border border-slate-700 px-3 py-1.5 font-mono text-xs text-slate-400 hover:border-slate-500 disabled:opacity-50"
+          >
+            {loading ? "Loading…" : "↺ Refresh"}
+          </button>
+          <button
+            onClick={openCreate}
+            className="rounded-lg border border-yellow-500/30 bg-yellow-500/10 px-3 py-1.5 font-mono text-xs text-yellow-400 hover:bg-yellow-500/20"
+          >
+            + New
+          </button>
+        </div>
+      </div>
+
+      {error && (
+        <div className="mb-4 rounded-xl border border-red-500/30 bg-red-500/10 p-4 font-mono text-sm text-red-400">
+          {error}
+        </div>
+      )}
+
+      {/* Modal form */}
+      {form && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/70 p-4">
+          <div className="w-full max-w-lg rounded-2xl border border-slate-700 bg-void-dark p-6 shadow-2xl">
+            <h2 className="font-heading mb-4 text-lg font-bold text-white">
+              {form.pageId ? "Edit FAQ" : "New FAQ"}
+            </h2>
+            <div className="space-y-3">
+              <label className="flex flex-col gap-1">
+                <span className="font-mono text-xs text-slate-400">Question *</span>
+                <input
+                  type="text"
+                  className="rounded border border-slate-700 bg-void px-3 py-1.5 font-body text-sm text-white focus:border-yellow-500 focus:outline-none"
+                  value={form.question}
+                  onChange={(e) => setForm((f) => f && { ...f, question: e.target.value })}
+                />
+              </label>
+              <label className="flex flex-col gap-1">
+                <span className="font-mono text-xs text-slate-400">Answer</span>
+                <textarea
+                  rows={4}
+                  className="rounded border border-slate-700 bg-void px-3 py-1.5 font-body text-sm text-white focus:border-yellow-500 focus:outline-none"
+                  value={form.answer ?? ""}
+                  onChange={(e) => setForm((f) => f && { ...f, answer: e.target.value })}
+                />
+              </label>
+              <label className="flex flex-col gap-1">
+                <span className="font-mono text-xs text-slate-400">Category</span>
+                <select
+                  className="rounded border border-slate-700 bg-void px-3 py-1.5 font-mono text-xs text-white focus:outline-none"
+                  value={form.category ?? "general"}
+                  onChange={(e) =>
+                    setForm((f) => f && { ...f, category: e.target.value as FaqCategory })
+                  }
+                >
+                  {FAQ_CATEGORIES.map((c) => (
+                    <option key={c} value={c}>
+                      {c}
+                    </option>
+                  ))}
+                </select>
+              </label>
+              <label className="flex items-center gap-2 font-mono text-xs text-slate-400">
+                <input
+                  type="checkbox"
+                  checked={form.published ?? false}
+                  onChange={(e) => setForm((f) => f && { ...f, published: e.target.checked })}
+                  className="accent-yellow-400"
+                />
+                Published
+              </label>
+            </div>
+            {formError && <p className="mt-3 font-mono text-xs text-red-400">{formError}</p>}
+            <div className="mt-5 flex justify-end gap-2">
+              <button
+                onClick={() => setForm(null)}
+                className="rounded-lg border border-slate-700 px-4 py-1.5 font-mono text-xs text-slate-400 hover:border-slate-500"
+              >
+                Cancel
+              </button>
+              <button
+                onClick={submitForm}
+                disabled={saving}
+                className="rounded-lg border border-yellow-500/40 bg-yellow-500/20 px-4 py-1.5 font-mono text-xs text-yellow-400 hover:bg-yellow-500/30 disabled:opacity-50"
+              >
+                {saving ? "Saving…" : form.pageId ? "Save Changes" : "Create"}
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {loading && (
+        <div className="space-y-3">
+          {[1, 2, 3].map((i) => (
+            <div key={i} className="h-16 animate-pulse rounded-xl border border-slate-800 bg-void-light/50" />
+          ))}
+        </div>
+      )}
+
+      {!loading && !error && items.length === 0 && (
+        <div className="rounded-xl border border-slate-800 bg-void-light/30 p-12 text-center">
+          <p className="font-mono text-slate-500">No FAQs yet. Click + New to add one.</p>
+        </div>
+      )}
+
+      {!loading && items.length > 0 && (
+        <div className="space-y-3">
+          {items.map((f) => (
+            <div key={f.id} className="rounded-xl border border-slate-800 bg-void-light/50 p-4">
+              <div className="flex items-start justify-between gap-4">
+                <div className="flex-1 min-w-0">
+                  <div className="flex flex-wrap items-center gap-2">
+                    <span className="font-heading font-semibold text-white">{f.question}</span>
+                    <span
+                      className={`rounded-full border px-2 py-0.5 font-mono text-xs ${CATEGORY_COLORS[f.category]}`}
+                    >
+                      {f.category}
+                    </span>
+                    {f.locales.length > 0 && (
+                      <span className="font-mono text-xs text-slate-600">
+                        [{f.locales.join(", ")}]
+                      </span>
+                    )}
+                  </div>
+                  {f.answer && (
+                    <p className="mt-1 font-body text-sm text-slate-400 line-clamp-2">{f.answer}</p>
+                  )}
+                </div>
+                <div className="flex shrink-0 gap-2">
+                  <button
+                    onClick={() => openEdit(f)}
+                    className="rounded border border-slate-700 px-2 py-1 font-mono text-xs text-slate-400 hover:border-slate-500 hover:text-white"
+                  >
+                    Edit
+                  </button>
+                  <button
+                    onClick={() => deleteItem(f.id)}
+                    disabled={deleting === f.id}
+                    className="rounded border border-red-900/40 px-2 py-1 font-mono text-xs text-red-500 hover:border-red-700/50 hover:text-red-400 disabled:opacity-40"
+                  >
+                    {deleting === f.id ? "…" : "Archive"}
+                  </button>
+                </div>
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+
+      {!loading && items.length > 0 && (
+        <p className="mt-4 text-right font-mono text-xs text-slate-600">
+          {items.length} FAQ{items.length !== 1 ? "s" : ""}
+        </p>
+      )}
+    </div>
+  );
+}

--- a/src/app/[locale]/admin/cms/services/page.tsx
+++ b/src/app/[locale]/admin/cms/services/page.tsx
@@ -1,0 +1,331 @@
+"use client";
+
+import { fetchWithAuth } from "@/lib/fetch-with-auth";
+import { useCallback, useEffect, useState } from "react";
+import type { CloudlessService, ServiceInput, ServiceCategory } from "@/lib/notion-services";
+
+const SERVICE_CATEGORIES: ServiceCategory[] = ["audit", "devops", "consulting", "training"];
+
+const EMPTY_FORM: ServiceInput = {
+  name: "",
+  slug: "",
+  description: "",
+  price: "",
+  category: "consulting",
+  features: [],
+  cta: "Learn more",
+  icon: "☁️",
+  stripePriceId: "",
+  published: false,
+  order: undefined,
+};
+
+type FormState = ServiceInput & { pageId?: string; featuresText?: string };
+
+export default function AdminServicesPage() {
+  const [items, setItems] = useState<CloudlessService[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [saving, setSaving] = useState(false);
+  const [deleting, setDeleting] = useState<string | null>(null);
+  const [form, setForm] = useState<FormState | null>(null);
+  const [formError, setFormError] = useState<string | null>(null);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await fetchWithAuth("/api/admin/notion/services");
+      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      const data = (await res.json()) as { services: CloudlessService[] };
+      setItems(data.services ?? []);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to load");
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  const openCreate = () => {
+    setForm({ ...EMPTY_FORM, featuresText: "" });
+    setFormError(null);
+  };
+
+  const openEdit = (s: CloudlessService) => {
+    setForm({
+      pageId: s.id,
+      name: s.name,
+      slug: s.slug,
+      description: s.description,
+      price: s.price,
+      category: s.category,
+      features: s.features,
+      featuresText: s.features.join("\n"),
+      cta: s.cta,
+      icon: s.icon,
+      stripePriceId: s.stripePriceId ?? "",
+      published: true,
+    });
+    setFormError(null);
+  };
+
+  const submitForm = async () => {
+    if (!form) return;
+    if (!form.name.trim()) {
+      setFormError("Name is required.");
+      return;
+    }
+    setSaving(true);
+    setFormError(null);
+    try {
+      const { pageId, featuresText, ...input } = form;
+      input.features = (featuresText ?? "")
+        .split("\n")
+        .map((l) => l.trim())
+        .filter(Boolean);
+      const method = pageId ? "PATCH" : "POST";
+      const body = pageId ? { pageId, ...input } : input;
+      const res = await fetchWithAuth("/api/admin/notion/services", {
+        method,
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(body),
+      });
+      if (!res.ok) {
+        const d = (await res.json()) as { error?: string };
+        throw new Error(d.error ?? `HTTP ${res.status}`);
+      }
+      setForm(null);
+      await load();
+    } catch (err) {
+      setFormError(err instanceof Error ? err.message : "Save failed");
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const deleteItem = async (pageId: string) => {
+    if (!confirm("Archive this service?")) return;
+    setDeleting(pageId);
+    try {
+      const res = await fetchWithAuth(
+        `/api/admin/notion/services?pageId=${encodeURIComponent(pageId)}`,
+        { method: "DELETE" }
+      );
+      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      setItems((prev) => prev.filter((s) => s.id !== pageId));
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Delete failed");
+    } finally {
+      setDeleting(null);
+    }
+  };
+
+  const CATEGORY_COLORS: Record<ServiceCategory, string> = {
+    audit: "border-neon-magenta/30 text-neon-magenta",
+    devops: "border-neon-cyan/30 text-neon-cyan",
+    consulting: "border-neon-green/30 text-neon-green",
+    training: "border-yellow-500/30 text-yellow-400",
+  };
+
+  return (
+    <div>
+      <div className="mb-8 flex items-start justify-between">
+        <div>
+          <div className="bg-neon-green/10 border-neon-green/20 mb-4 inline-flex items-center gap-2 rounded-full border px-3 py-1.5">
+            <span className="bg-neon-green h-2 w-2 animate-pulse rounded-full" />
+            <span className="text-neon-green font-mono text-xs">CMS_SERVICES</span>
+          </div>
+          <h1 className="font-heading text-2xl font-bold text-white">Services</h1>
+          <p className="font-body mt-1 text-slate-400">Manage the service catalog shown on the services page.</p>
+        </div>
+        <div className="flex gap-2">
+          <button
+            onClick={load}
+            disabled={loading}
+            className="rounded-lg border border-slate-700 px-3 py-1.5 font-mono text-xs text-slate-400 hover:border-slate-500 disabled:opacity-50"
+          >
+            {loading ? "Loading…" : "↺ Refresh"}
+          </button>
+          <button
+            onClick={openCreate}
+            className="rounded-lg border border-neon-green/30 bg-neon-green/10 px-3 py-1.5 font-mono text-xs text-neon-green hover:bg-neon-green/20"
+          >
+            + New
+          </button>
+        </div>
+      </div>
+
+      {error && (
+        <div className="mb-4 rounded-xl border border-red-500/30 bg-red-500/10 p-4 font-mono text-sm text-red-400">
+          {error}
+        </div>
+      )}
+
+      {form && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/70 p-4">
+          <div className="max-h-[90vh] w-full max-w-lg overflow-y-auto rounded-2xl border border-slate-700 bg-void-dark p-6 shadow-2xl">
+            <h2 className="font-heading mb-4 text-lg font-bold text-white">
+              {form.pageId ? "Edit Service" : "New Service"}
+            </h2>
+            <div className="space-y-3">
+              {(["name", "slug", "price", "icon", "cta"] as const).map((k) => (
+                <label key={k} className="flex flex-col gap-1">
+                  <span className="font-mono text-xs text-slate-400 capitalize">
+                    {k}{k === "name" ? " *" : ""}
+                  </span>
+                  <input
+                    type="text"
+                    className="rounded border border-slate-700 bg-void px-3 py-1.5 font-body text-sm text-white focus:border-neon-green focus:outline-none"
+                    value={(form[k] as string) ?? ""}
+                    onChange={(e) => setForm((f) => f && { ...f, [k]: e.target.value })}
+                  />
+                </label>
+              ))}
+              <label className="flex flex-col gap-1">
+                <span className="font-mono text-xs text-slate-400">Description</span>
+                <textarea
+                  rows={3}
+                  className="rounded border border-slate-700 bg-void px-3 py-1.5 font-body text-sm text-white focus:border-neon-green focus:outline-none"
+                  value={form.description ?? ""}
+                  onChange={(e) => setForm((f) => f && { ...f, description: e.target.value })}
+                />
+              </label>
+              <label className="flex flex-col gap-1">
+                <span className="font-mono text-xs text-slate-400">Features (one per line)</span>
+                <textarea
+                  rows={4}
+                  className="rounded border border-slate-700 bg-void px-3 py-1.5 font-body text-sm text-white focus:border-neon-green focus:outline-none"
+                  value={form.featuresText ?? ""}
+                  onChange={(e) => setForm((f) => f && { ...f, featuresText: e.target.value })}
+                />
+              </label>
+              <label className="flex flex-col gap-1">
+                <span className="font-mono text-xs text-slate-400">Category</span>
+                <select
+                  className="rounded border border-slate-700 bg-void px-3 py-1.5 font-mono text-xs text-white focus:outline-none"
+                  value={form.category ?? "consulting"}
+                  onChange={(e) =>
+                    setForm((f) => f && { ...f, category: e.target.value as ServiceCategory })
+                  }
+                >
+                  {SERVICE_CATEGORIES.map((c) => (
+                    <option key={c} value={c}>
+                      {c}
+                    </option>
+                  ))}
+                </select>
+              </label>
+              <label className="flex flex-col gap-1">
+                <span className="font-mono text-xs text-slate-400">Stripe Price ID</span>
+                <input
+                  type="text"
+                  className="rounded border border-slate-700 bg-void px-3 py-1.5 font-body text-sm text-white focus:border-neon-green focus:outline-none"
+                  value={form.stripePriceId ?? ""}
+                  onChange={(e) => setForm((f) => f && { ...f, stripePriceId: e.target.value })}
+                />
+              </label>
+              <label className="flex items-center gap-2 font-mono text-xs text-slate-400">
+                <input
+                  type="checkbox"
+                  checked={form.published ?? false}
+                  onChange={(e) => setForm((f) => f && { ...f, published: e.target.checked })}
+                  className="accent-neon-green"
+                />
+                Published
+              </label>
+            </div>
+            {formError && <p className="mt-3 font-mono text-xs text-red-400">{formError}</p>}
+            <div className="mt-5 flex justify-end gap-2">
+              <button
+                onClick={() => setForm(null)}
+                className="rounded-lg border border-slate-700 px-4 py-1.5 font-mono text-xs text-slate-400 hover:border-slate-500"
+              >
+                Cancel
+              </button>
+              <button
+                onClick={submitForm}
+                disabled={saving}
+                className="rounded-lg border border-neon-green/40 bg-neon-green/20 px-4 py-1.5 font-mono text-xs text-neon-green hover:bg-neon-green/30 disabled:opacity-50"
+              >
+                {saving ? "Saving…" : form.pageId ? "Save Changes" : "Create"}
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {loading && (
+        <div className="space-y-3">
+          {[1, 2, 3].map((i) => (
+            <div key={i} className="h-20 animate-pulse rounded-xl border border-slate-800 bg-void-light/50" />
+          ))}
+        </div>
+      )}
+
+      {!loading && !error && items.length === 0 && (
+        <div className="rounded-xl border border-slate-800 bg-void-light/30 p-12 text-center">
+          <p className="font-mono text-slate-500">No services yet. Click + New to add one.</p>
+        </div>
+      )}
+
+      {!loading && items.length > 0 && (
+        <div className="space-y-3">
+          {items.map((s) => (
+            <div key={s.id} className="rounded-xl border border-slate-800 bg-void-light/50 p-4">
+              <div className="flex items-start justify-between gap-4">
+                <div className="flex-1 min-w-0">
+                  <div className="flex flex-wrap items-center gap-2">
+                    <span className="text-lg">{s.icon}</span>
+                    <span className="font-heading font-semibold text-white">{s.name}</span>
+                    <span
+                      className={`rounded-full border px-2 py-0.5 font-mono text-xs ${CATEGORY_COLORS[s.category]}`}
+                    >
+                      {s.category}
+                    </span>
+                    <span className="font-mono text-xs text-slate-500">{s.price}</span>
+                    {s.slug && (
+                      <span className="font-mono text-xs text-slate-600">/{s.slug}</span>
+                    )}
+                  </div>
+                  {s.description && (
+                    <p className="mt-1 font-body text-sm text-slate-400 line-clamp-1">{s.description}</p>
+                  )}
+                  {s.features.length > 0 && (
+                    <p className="mt-1 font-mono text-xs text-slate-600">
+                      {s.features.length} features
+                    </p>
+                  )}
+                </div>
+                <div className="flex shrink-0 gap-2">
+                  <button
+                    onClick={() => openEdit(s)}
+                    className="rounded border border-slate-700 px-2 py-1 font-mono text-xs text-slate-400 hover:border-slate-500 hover:text-white"
+                  >
+                    Edit
+                  </button>
+                  <button
+                    onClick={() => deleteItem(s.id)}
+                    disabled={deleting === s.id}
+                    className="rounded border border-red-900/40 px-2 py-1 font-mono text-xs text-red-500 hover:border-red-700/50 hover:text-red-400 disabled:opacity-40"
+                  >
+                    {deleting === s.id ? "…" : "Archive"}
+                  </button>
+                </div>
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+
+      {!loading && items.length > 0 && (
+        <p className="mt-4 text-right font-mono text-xs text-slate-600">
+          {items.length} service{items.length !== 1 ? "s" : ""}
+        </p>
+      )}
+    </div>
+  );
+}

--- a/src/app/[locale]/admin/cms/testimonials/page.tsx
+++ b/src/app/[locale]/admin/cms/testimonials/page.tsx
@@ -1,0 +1,308 @@
+"use client";
+
+import { fetchWithAuth } from "@/lib/fetch-with-auth";
+import { useCallback, useEffect, useState } from "react";
+import type { Testimonial, TestimonialInput } from "@/lib/notion-testimonials";
+
+const EMPTY_FORM: TestimonialInput = {
+  name: "",
+  company: "",
+  role: "",
+  quote: "",
+  avatar: "",
+  service: "",
+  rating: undefined,
+  featured: false,
+  published: false,
+  order: undefined,
+};
+
+type FormState = TestimonialInput & { pageId?: string };
+
+export default function AdminTestimonialsPage() {
+  const [items, setItems] = useState<Testimonial[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [saving, setSaving] = useState(false);
+  const [deleting, setDeleting] = useState<string | null>(null);
+  const [form, setForm] = useState<FormState | null>(null);
+  const [formError, setFormError] = useState<string | null>(null);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await fetchWithAuth("/api/admin/notion/testimonials");
+      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      const data = (await res.json()) as { testimonials: Testimonial[] };
+      setItems(data.testimonials ?? []);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to load");
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  const openCreate = () => {
+    setForm({ ...EMPTY_FORM });
+    setFormError(null);
+  };
+
+  const openEdit = (t: Testimonial) => {
+    setForm({
+      pageId: t.id,
+      name: t.name,
+      company: t.company,
+      role: t.role,
+      quote: t.quote,
+      avatar: t.avatar ?? "",
+      service: t.service ?? "",
+      rating: t.rating,
+      featured: t.featured,
+      published: true,
+    });
+    setFormError(null);
+  };
+
+  const submitForm = async () => {
+    if (!form) return;
+    if (!form.name.trim() || !form.quote.trim()) {
+      setFormError("Name and Quote are required.");
+      return;
+    }
+    setSaving(true);
+    setFormError(null);
+    try {
+      const { pageId, ...input } = form;
+      const method = pageId ? "PATCH" : "POST";
+      const body = pageId ? { pageId, ...input } : input;
+      const res = await fetchWithAuth("/api/admin/notion/testimonials", {
+        method,
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(body),
+      });
+      if (!res.ok) {
+        const d = (await res.json()) as { error?: string };
+        throw new Error(d.error ?? `HTTP ${res.status}`);
+      }
+      setForm(null);
+      await load();
+    } catch (err) {
+      setFormError(err instanceof Error ? err.message : "Save failed");
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const deleteItem = async (pageId: string) => {
+    if (!confirm("Archive this testimonial?")) return;
+    setDeleting(pageId);
+    try {
+      const res = await fetchWithAuth(
+        `/api/admin/notion/testimonials?pageId=${encodeURIComponent(pageId)}`,
+        { method: "DELETE" }
+      );
+      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      setItems((prev) => prev.filter((t) => t.id !== pageId));
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Delete failed");
+    } finally {
+      setDeleting(null);
+    }
+  };
+
+  const field = (key: keyof TestimonialInput, label: string, type: string = "text") => (
+    <label className="flex flex-col gap-1">
+      <span className="font-mono text-xs text-slate-400">{label}</span>
+      <input
+        type={type}
+        className="rounded border border-slate-700 bg-void px-3 py-1.5 font-body text-sm text-white focus:outline-none focus:border-neon-cyan"
+        value={(form?.[key] as string) ?? ""}
+        onChange={(e) => setForm((f) => f && { ...f, [key]: e.target.value })}
+      />
+    </label>
+  );
+
+  return (
+    <div>
+      <div className="mb-8 flex items-start justify-between">
+        <div>
+          <div className="bg-neon-cyan/10 border-neon-cyan/20 mb-4 inline-flex items-center gap-2 rounded-full border px-3 py-1.5">
+            <span className="bg-neon-cyan h-2 w-2 animate-pulse rounded-full" />
+            <span className="text-neon-cyan font-mono text-xs">CMS_TESTIMONIALS</span>
+          </div>
+          <h1 className="font-heading text-2xl font-bold text-white">Testimonials</h1>
+          <p className="font-body mt-1 text-slate-400">Manage customer testimonials shown on the site.</p>
+        </div>
+        <div className="flex gap-2">
+          <button
+            onClick={load}
+            disabled={loading}
+            className="rounded-lg border border-slate-700 px-3 py-1.5 font-mono text-xs text-slate-400 hover:border-slate-500 disabled:opacity-50"
+          >
+            {loading ? "Loading…" : "↺ Refresh"}
+          </button>
+          <button
+            onClick={openCreate}
+            className="rounded-lg bg-neon-cyan/10 border border-neon-cyan/30 px-3 py-1.5 font-mono text-xs text-neon-cyan hover:bg-neon-cyan/20"
+          >
+            + New
+          </button>
+        </div>
+      </div>
+
+      {error && (
+        <div className="mb-4 rounded-xl border border-red-500/30 bg-red-500/10 p-4 font-mono text-sm text-red-400">
+          {error}
+        </div>
+      )}
+
+      {/* Modal form */}
+      {form && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/70 p-4">
+          <div className="w-full max-w-lg rounded-2xl border border-slate-700 bg-void-dark p-6 shadow-2xl">
+            <h2 className="font-heading mb-4 text-lg font-bold text-white">
+              {form.pageId ? "Edit Testimonial" : "New Testimonial"}
+            </h2>
+            <div className="space-y-3">
+              {field("name", "Name *")}
+              {field("quote", "Quote *")}
+              {field("company", "Company")}
+              {field("role", "Role")}
+              {field("service", "Service")}
+              {field("avatar", "Avatar URL")}
+              {field("rating", "Rating (1–5)", "number")}
+              <div className="flex gap-4">
+                <label className="flex items-center gap-2 font-mono text-xs text-slate-400">
+                  <input
+                    type="checkbox"
+                    checked={form.featured ?? false}
+                    onChange={(e) => setForm((f) => f && { ...f, featured: e.target.checked })}
+                    className="accent-neon-cyan"
+                  />
+                  Featured
+                </label>
+                <label className="flex items-center gap-2 font-mono text-xs text-slate-400">
+                  <input
+                    type="checkbox"
+                    checked={form.published ?? false}
+                    onChange={(e) => setForm((f) => f && { ...f, published: e.target.checked })}
+                    className="accent-neon-cyan"
+                  />
+                  Published
+                </label>
+              </div>
+            </div>
+            {formError && (
+              <p className="mt-3 font-mono text-xs text-red-400">{formError}</p>
+            )}
+            <div className="mt-5 flex justify-end gap-2">
+              <button
+                onClick={() => setForm(null)}
+                className="rounded-lg border border-slate-700 px-4 py-1.5 font-mono text-xs text-slate-400 hover:border-slate-500"
+              >
+                Cancel
+              </button>
+              <button
+                onClick={submitForm}
+                disabled={saving}
+                className="rounded-lg bg-neon-cyan/20 border border-neon-cyan/40 px-4 py-1.5 font-mono text-xs text-neon-cyan hover:bg-neon-cyan/30 disabled:opacity-50"
+              >
+                {saving ? "Saving…" : form.pageId ? "Save Changes" : "Create"}
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* Loading skeleton */}
+      {loading && (
+        <div className="space-y-3">
+          {[1, 2, 3].map((i) => (
+            <div key={i} className="h-20 animate-pulse rounded-xl border border-slate-800 bg-void-light/50" />
+          ))}
+        </div>
+      )}
+
+      {/* Empty state */}
+      {!loading && !error && items.length === 0 && (
+        <div className="rounded-xl border border-slate-800 bg-void-light/30 p-12 text-center">
+          <p className="font-mono text-slate-500">No testimonials yet. Click + New to add one.</p>
+        </div>
+      )}
+
+      {/* List */}
+      {!loading && items.length > 0 && (
+        <div className="space-y-3">
+          {items.map((t) => (
+            <div key={t.id} className="rounded-xl border border-slate-800 bg-void-light/50 p-4">
+              <div className="flex items-start justify-between gap-4">
+                <div className="flex-1 min-w-0">
+                  <div className="flex flex-wrap items-center gap-2">
+                    <span className="font-heading font-semibold text-white">{t.name}</span>
+                    {t.company && (
+                      <span className="font-mono text-xs text-slate-500">{t.company}</span>
+                    )}
+                    {t.role && (
+                      <span className="font-mono text-xs text-slate-600">· {t.role}</span>
+                    )}
+                    {t.featured && (
+                      <span className="rounded-full border border-yellow-500/30 bg-yellow-500/10 px-2 py-0.5 font-mono text-xs text-yellow-400">
+                        Featured
+                      </span>
+                    )}
+                    <span
+                      className={`rounded-full border px-2 py-0.5 font-mono text-xs ${
+                        t.featured
+                          ? "border-neon-green/30 bg-neon-green/10 text-neon-green"
+                          : "border-slate-700 bg-slate-800/50 text-slate-500"
+                      }`}
+                    >
+                      {t.featured ? "Published" : "Draft"}
+                    </span>
+                    {t.rating != null && (
+                      <span className="font-mono text-xs text-yellow-400">{"★".repeat(t.rating)}</span>
+                    )}
+                  </div>
+                  <p className="mt-1 font-body text-sm text-slate-400 line-clamp-2">
+                    &ldquo;{t.quote}&rdquo;
+                  </p>
+                  {t.service && (
+                    <span className="mt-1 inline-block font-mono text-xs text-slate-600">
+                      {t.service}
+                    </span>
+                  )}
+                </div>
+                <div className="flex shrink-0 gap-2">
+                  <button
+                    onClick={() => openEdit(t)}
+                    className="rounded border border-slate-700 px-2 py-1 font-mono text-xs text-slate-400 hover:border-slate-500 hover:text-white"
+                  >
+                    Edit
+                  </button>
+                  <button
+                    onClick={() => deleteItem(t.id)}
+                    disabled={deleting === t.id}
+                    className="rounded border border-red-900/40 px-2 py-1 font-mono text-xs text-red-500 hover:border-red-700/50 hover:text-red-400 disabled:opacity-40"
+                  >
+                    {deleting === t.id ? "…" : "Archive"}
+                  </button>
+                </div>
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+
+      {!loading && items.length > 0 && (
+        <p className="mt-4 text-right font-mono text-xs text-slate-600">
+          {items.length} testimonial{items.length !== 1 ? "s" : ""}
+        </p>
+      )}
+    </div>
+  );
+}

--- a/src/app/api/admin/notion/case-studies/route.ts
+++ b/src/app/api/admin/notion/case-studies/route.ts
@@ -1,0 +1,101 @@
+import { NextRequest, NextResponse } from "next/server";
+import { requireAdmin } from "@/lib/api-auth";
+import { isConfiguredAsync } from "@/lib/integrations";
+import {
+  getAllCaseStudiesAdmin,
+  createCaseStudy,
+  updateCaseStudy,
+  deleteCaseStudy,
+  type CaseStudyInput,
+} from "@/lib/notion-case-studies";
+
+export async function GET(request: NextRequest) {
+  const auth = await requireAdmin(request);
+  if (!auth.ok) return auth.response;
+
+  if (!(await isConfiguredAsync("NOTION_API_KEY", "NOTION_CASE_STUDIES_DB_ID"))) {
+    return NextResponse.json({ error: "Notion Case Studies not configured" }, { status: 503 });
+  }
+
+  try {
+    const caseStudies = await getAllCaseStudiesAdmin();
+    return NextResponse.json({ caseStudies, count: caseStudies.length });
+  } catch (err) {
+    console.error("[Admin Case Studies] GET failed:", err instanceof Error ? err.message : err);
+    return NextResponse.json({ error: "Failed to list case studies" }, { status: 500 });
+  }
+}
+
+export async function POST(request: NextRequest) {
+  const auth = await requireAdmin(request);
+  if (!auth.ok) return auth.response;
+
+  if (!(await isConfiguredAsync("NOTION_API_KEY", "NOTION_CASE_STUDIES_DB_ID"))) {
+    return NextResponse.json({ error: "Notion Case Studies not configured" }, { status: 503 });
+  }
+
+  let body: CaseStudyInput;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON" }, { status: 400 });
+  }
+
+  if (!body.title?.trim()) {
+    return NextResponse.json({ error: "title is required" }, { status: 400 });
+  }
+
+  try {
+    const id = await createCaseStudy(body);
+    if (!id) return NextResponse.json({ error: "Failed to create case study" }, { status: 500 });
+    return NextResponse.json({ id }, { status: 201 });
+  } catch (err) {
+    console.error("[Admin Case Studies] POST failed:", err instanceof Error ? err.message : err);
+    return NextResponse.json({ error: "Failed to create case study" }, { status: 500 });
+  }
+}
+
+export async function PATCH(request: NextRequest) {
+  const auth = await requireAdmin(request);
+  if (!auth.ok) return auth.response;
+
+  let body: { pageId: string } & Partial<CaseStudyInput>;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON" }, { status: 400 });
+  }
+
+  if (!body.pageId) {
+    return NextResponse.json({ error: "pageId is required" }, { status: 400 });
+  }
+
+  try {
+    const { pageId, ...input } = body;
+    const ok = await updateCaseStudy(pageId, input);
+    if (!ok) return NextResponse.json({ error: "Failed to update case study" }, { status: 500 });
+    return NextResponse.json({ success: true });
+  } catch (err) {
+    console.error("[Admin Case Studies] PATCH failed:", err instanceof Error ? err.message : err);
+    return NextResponse.json({ error: "Failed to update case study" }, { status: 500 });
+  }
+}
+
+export async function DELETE(request: NextRequest) {
+  const auth = await requireAdmin(request);
+  if (!auth.ok) return auth.response;
+
+  const pageId = new URL(request.url).searchParams.get("pageId");
+  if (!pageId) {
+    return NextResponse.json({ error: "pageId query parameter is required" }, { status: 400 });
+  }
+
+  try {
+    const ok = await deleteCaseStudy(pageId);
+    if (!ok) return NextResponse.json({ error: "Failed to delete case study" }, { status: 500 });
+    return NextResponse.json({ success: true });
+  } catch (err) {
+    console.error("[Admin Case Studies] DELETE failed:", err instanceof Error ? err.message : err);
+    return NextResponse.json({ error: "Failed to delete case study" }, { status: 500 });
+  }
+}

--- a/src/app/api/admin/notion/faqs/route.ts
+++ b/src/app/api/admin/notion/faqs/route.ts
@@ -1,0 +1,95 @@
+import { NextRequest, NextResponse } from "next/server";
+import { requireAdmin } from "@/lib/api-auth";
+import { isConfiguredAsync } from "@/lib/integrations";
+import { getAllFaqsAdmin, createFaq, updateFaq, deleteFaq, type FaqInput } from "@/lib/notion-faqs";
+
+export async function GET(request: NextRequest) {
+  const auth = await requireAdmin(request);
+  if (!auth.ok) return auth.response;
+
+  if (!(await isConfiguredAsync("NOTION_API_KEY", "NOTION_FAQS_DB_ID"))) {
+    return NextResponse.json({ error: "Notion FAQs not configured" }, { status: 503 });
+  }
+
+  try {
+    const faqs = await getAllFaqsAdmin();
+    return NextResponse.json({ faqs, count: faqs.length });
+  } catch (err) {
+    console.error("[Admin FAQs] GET failed:", err instanceof Error ? err.message : err);
+    return NextResponse.json({ error: "Failed to list FAQs" }, { status: 500 });
+  }
+}
+
+export async function POST(request: NextRequest) {
+  const auth = await requireAdmin(request);
+  if (!auth.ok) return auth.response;
+
+  if (!(await isConfiguredAsync("NOTION_API_KEY", "NOTION_FAQS_DB_ID"))) {
+    return NextResponse.json({ error: "Notion FAQs not configured" }, { status: 503 });
+  }
+
+  let body: FaqInput;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON" }, { status: 400 });
+  }
+
+  if (!body.question?.trim()) {
+    return NextResponse.json({ error: "question is required" }, { status: 400 });
+  }
+
+  try {
+    const id = await createFaq(body);
+    if (!id) return NextResponse.json({ error: "Failed to create FAQ" }, { status: 500 });
+    return NextResponse.json({ id }, { status: 201 });
+  } catch (err) {
+    console.error("[Admin FAQs] POST failed:", err instanceof Error ? err.message : err);
+    return NextResponse.json({ error: "Failed to create FAQ" }, { status: 500 });
+  }
+}
+
+export async function PATCH(request: NextRequest) {
+  const auth = await requireAdmin(request);
+  if (!auth.ok) return auth.response;
+
+  let body: { pageId: string } & Partial<FaqInput>;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON" }, { status: 400 });
+  }
+
+  if (!body.pageId) {
+    return NextResponse.json({ error: "pageId is required" }, { status: 400 });
+  }
+
+  try {
+    const { pageId, ...input } = body;
+    const ok = await updateFaq(pageId, input);
+    if (!ok) return NextResponse.json({ error: "Failed to update FAQ" }, { status: 500 });
+    return NextResponse.json({ success: true });
+  } catch (err) {
+    console.error("[Admin FAQs] PATCH failed:", err instanceof Error ? err.message : err);
+    return NextResponse.json({ error: "Failed to update FAQ" }, { status: 500 });
+  }
+}
+
+export async function DELETE(request: NextRequest) {
+  const auth = await requireAdmin(request);
+  if (!auth.ok) return auth.response;
+
+  const pageId = new URL(request.url).searchParams.get("pageId");
+  if (!pageId) {
+    return NextResponse.json({ error: "pageId query parameter is required" }, { status: 400 });
+  }
+
+  try {
+    const ok = await deleteFaq(pageId);
+    if (!ok) return NextResponse.json({ error: "Failed to delete FAQ" }, { status: 500 });
+    return NextResponse.json({ success: true });
+  } catch (err) {
+    console.error("[Admin FAQs] DELETE failed:", err instanceof Error ? err.message : err);
+    return NextResponse.json({ error: "Failed to delete FAQ" }, { status: 500 });
+  }
+}

--- a/src/app/api/admin/notion/services/route.ts
+++ b/src/app/api/admin/notion/services/route.ts
@@ -1,0 +1,101 @@
+import { NextRequest, NextResponse } from "next/server";
+import { requireAdmin } from "@/lib/api-auth";
+import { isConfiguredAsync } from "@/lib/integrations";
+import {
+  getAllServicesAdmin,
+  createService,
+  updateService,
+  deleteService,
+  type ServiceInput,
+} from "@/lib/notion-services";
+
+export async function GET(request: NextRequest) {
+  const auth = await requireAdmin(request);
+  if (!auth.ok) return auth.response;
+
+  if (!(await isConfiguredAsync("NOTION_API_KEY", "NOTION_SERVICES_DB_ID"))) {
+    return NextResponse.json({ error: "Notion Services not configured" }, { status: 503 });
+  }
+
+  try {
+    const services = await getAllServicesAdmin();
+    return NextResponse.json({ services, count: services.length });
+  } catch (err) {
+    console.error("[Admin Services] GET failed:", err instanceof Error ? err.message : err);
+    return NextResponse.json({ error: "Failed to list services" }, { status: 500 });
+  }
+}
+
+export async function POST(request: NextRequest) {
+  const auth = await requireAdmin(request);
+  if (!auth.ok) return auth.response;
+
+  if (!(await isConfiguredAsync("NOTION_API_KEY", "NOTION_SERVICES_DB_ID"))) {
+    return NextResponse.json({ error: "Notion Services not configured" }, { status: 503 });
+  }
+
+  let body: ServiceInput;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON" }, { status: 400 });
+  }
+
+  if (!body.name?.trim()) {
+    return NextResponse.json({ error: "name is required" }, { status: 400 });
+  }
+
+  try {
+    const id = await createService(body);
+    if (!id) return NextResponse.json({ error: "Failed to create service" }, { status: 500 });
+    return NextResponse.json({ id }, { status: 201 });
+  } catch (err) {
+    console.error("[Admin Services] POST failed:", err instanceof Error ? err.message : err);
+    return NextResponse.json({ error: "Failed to create service" }, { status: 500 });
+  }
+}
+
+export async function PATCH(request: NextRequest) {
+  const auth = await requireAdmin(request);
+  if (!auth.ok) return auth.response;
+
+  let body: { pageId: string } & Partial<ServiceInput>;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON" }, { status: 400 });
+  }
+
+  if (!body.pageId) {
+    return NextResponse.json({ error: "pageId is required" }, { status: 400 });
+  }
+
+  try {
+    const { pageId, ...input } = body;
+    const ok = await updateService(pageId, input);
+    if (!ok) return NextResponse.json({ error: "Failed to update service" }, { status: 500 });
+    return NextResponse.json({ success: true });
+  } catch (err) {
+    console.error("[Admin Services] PATCH failed:", err instanceof Error ? err.message : err);
+    return NextResponse.json({ error: "Failed to update service" }, { status: 500 });
+  }
+}
+
+export async function DELETE(request: NextRequest) {
+  const auth = await requireAdmin(request);
+  if (!auth.ok) return auth.response;
+
+  const pageId = new URL(request.url).searchParams.get("pageId");
+  if (!pageId) {
+    return NextResponse.json({ error: "pageId query parameter is required" }, { status: 400 });
+  }
+
+  try {
+    const ok = await deleteService(pageId);
+    if (!ok) return NextResponse.json({ error: "Failed to delete service" }, { status: 500 });
+    return NextResponse.json({ success: true });
+  } catch (err) {
+    console.error("[Admin Services] DELETE failed:", err instanceof Error ? err.message : err);
+    return NextResponse.json({ error: "Failed to delete service" }, { status: 500 });
+  }
+}

--- a/src/app/api/admin/notion/testimonials/route.ts
+++ b/src/app/api/admin/notion/testimonials/route.ts
@@ -1,0 +1,101 @@
+import { NextRequest, NextResponse } from "next/server";
+import { requireAdmin } from "@/lib/api-auth";
+import { isConfiguredAsync } from "@/lib/integrations";
+import {
+  getAllTestimonialsAdmin,
+  createTestimonial,
+  updateTestimonial,
+  deleteTestimonial,
+  type TestimonialInput,
+} from "@/lib/notion-testimonials";
+
+export async function GET(request: NextRequest) {
+  const auth = await requireAdmin(request);
+  if (!auth.ok) return auth.response;
+
+  if (!(await isConfiguredAsync("NOTION_API_KEY", "NOTION_TESTIMONIALS_DB_ID"))) {
+    return NextResponse.json({ error: "Notion Testimonials not configured" }, { status: 503 });
+  }
+
+  try {
+    const testimonials = await getAllTestimonialsAdmin();
+    return NextResponse.json({ testimonials, count: testimonials.length });
+  } catch (err) {
+    console.error("[Admin Testimonials] GET failed:", err instanceof Error ? err.message : err);
+    return NextResponse.json({ error: "Failed to list testimonials" }, { status: 500 });
+  }
+}
+
+export async function POST(request: NextRequest) {
+  const auth = await requireAdmin(request);
+  if (!auth.ok) return auth.response;
+
+  if (!(await isConfiguredAsync("NOTION_API_KEY", "NOTION_TESTIMONIALS_DB_ID"))) {
+    return NextResponse.json({ error: "Notion Testimonials not configured" }, { status: 503 });
+  }
+
+  let body: TestimonialInput;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON" }, { status: 400 });
+  }
+
+  if (!body.name?.trim() || !body.quote?.trim()) {
+    return NextResponse.json({ error: "name and quote are required" }, { status: 400 });
+  }
+
+  try {
+    const id = await createTestimonial(body);
+    if (!id) return NextResponse.json({ error: "Failed to create testimonial" }, { status: 500 });
+    return NextResponse.json({ id }, { status: 201 });
+  } catch (err) {
+    console.error("[Admin Testimonials] POST failed:", err instanceof Error ? err.message : err);
+    return NextResponse.json({ error: "Failed to create testimonial" }, { status: 500 });
+  }
+}
+
+export async function PATCH(request: NextRequest) {
+  const auth = await requireAdmin(request);
+  if (!auth.ok) return auth.response;
+
+  let body: { pageId: string } & Partial<TestimonialInput>;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON" }, { status: 400 });
+  }
+
+  if (!body.pageId) {
+    return NextResponse.json({ error: "pageId is required" }, { status: 400 });
+  }
+
+  try {
+    const { pageId, ...input } = body;
+    const ok = await updateTestimonial(pageId, input);
+    if (!ok) return NextResponse.json({ error: "Failed to update testimonial" }, { status: 500 });
+    return NextResponse.json({ success: true });
+  } catch (err) {
+    console.error("[Admin Testimonials] PATCH failed:", err instanceof Error ? err.message : err);
+    return NextResponse.json({ error: "Failed to update testimonial" }, { status: 500 });
+  }
+}
+
+export async function DELETE(request: NextRequest) {
+  const auth = await requireAdmin(request);
+  if (!auth.ok) return auth.response;
+
+  const pageId = new URL(request.url).searchParams.get("pageId");
+  if (!pageId) {
+    return NextResponse.json({ error: "pageId query parameter is required" }, { status: 400 });
+  }
+
+  try {
+    const ok = await deleteTestimonial(pageId);
+    if (!ok) return NextResponse.json({ error: "Failed to delete testimonial" }, { status: 500 });
+    return NextResponse.json({ success: true });
+  } catch (err) {
+    console.error("[Admin Testimonials] DELETE failed:", err instanceof Error ? err.message : err);
+    return NextResponse.json({ error: "Failed to delete testimonial" }, { status: 500 });
+  }
+}

--- a/src/app/api/webhooks/notion/route.ts
+++ b/src/app/api/webhooks/notion/route.ts
@@ -41,7 +41,17 @@ interface WebhookPayload {
     | "project.updated"
     | "task.updated"
     | "analytics.event";
-  database: "blog" | "docs" | "submissions" | "projects" | "tasks" | "analytics";
+  database:
+    | "blog"
+    | "docs"
+    | "submissions"
+    | "projects"
+    | "tasks"
+    | "analytics"
+    | "testimonials"
+    | "case-studies"
+    | "services"
+    | "faqs";
   page_id: string;
   slug?: string;
   data?: Record<string, unknown>;
@@ -65,18 +75,40 @@ async function verifySecret(request: NextRequest): Promise<boolean> {
 async function handlePageUpdated(payload: WebhookPayload) {
   const { database, slug } = payload;
 
-  invalidateCache(database === "blog" ? "blog" : database === "docs" ? "docs" : undefined);
-
-  if (database === "blog") {
-    revalidatePath("/blog");
-    if (slug) revalidatePath(`/blog/${slug}`);
-    revalidatePath("/api/blog/posts");
-    if (slug) revalidatePath(`/api/blog/${slug}`);
-  } else if (database === "docs") {
-    revalidatePath("/docs");
-    if (slug) revalidatePath(`/docs/${slug}`);
-    revalidatePath("/api/docs");
-    if (slug) revalidatePath(`/api/docs/${slug}`);
+  switch (database) {
+    case "blog":
+      invalidateCache("blog");
+      revalidatePath("/blog");
+      if (slug) revalidatePath(`/blog/${slug}`);
+      revalidatePath("/api/blog/posts");
+      if (slug) revalidatePath(`/api/blog/${slug}`);
+      break;
+    case "docs":
+      invalidateCache("docs");
+      revalidatePath("/docs");
+      if (slug) revalidatePath(`/docs/${slug}`);
+      revalidatePath("/api/docs");
+      if (slug) revalidatePath(`/api/docs/${slug}`);
+      break;
+    case "testimonials":
+      invalidateCache("testimonials");
+      revalidatePath("/api/testimonials");
+      break;
+    case "case-studies":
+      invalidateCache("case-studies");
+      revalidatePath("/api/case-studies");
+      if (slug) revalidatePath(`/api/case-studies/${slug}`);
+      break;
+    case "services":
+      invalidateCache("services");
+      revalidatePath("/api/services");
+      break;
+    case "faqs":
+      invalidateCache("faqs");
+      revalidatePath("/api/faqs");
+      break;
+    default:
+      break;
   }
 
   revalidatePath(SITEMAP_PATH);
@@ -87,16 +119,38 @@ async function handlePageUpdated(payload: WebhookPayload) {
 async function handlePageCreated(payload: WebhookPayload) {
   const { database, slug, data } = payload;
 
-  invalidateCache(database === "blog" ? "blog" : database === "docs" ? "docs" : undefined);
-
-  if (database === "blog") {
-    revalidatePath("/blog");
-    revalidatePath("/api/blog/posts");
-    revalidatePath(SITEMAP_PATH);
-  } else if (database === "docs") {
-    revalidatePath("/docs");
-    revalidatePath("/api/docs");
-    revalidatePath(SITEMAP_PATH);
+  switch (database) {
+    case "blog":
+      invalidateCache("blog");
+      revalidatePath("/blog");
+      revalidatePath("/api/blog/posts");
+      revalidatePath(SITEMAP_PATH);
+      break;
+    case "docs":
+      invalidateCache("docs");
+      revalidatePath("/docs");
+      revalidatePath("/api/docs");
+      revalidatePath(SITEMAP_PATH);
+      break;
+    case "testimonials":
+      invalidateCache("testimonials");
+      revalidatePath("/api/testimonials");
+      break;
+    case "case-studies":
+      invalidateCache("case-studies");
+      revalidatePath("/api/case-studies");
+      revalidatePath(SITEMAP_PATH);
+      break;
+    case "services":
+      invalidateCache("services");
+      revalidatePath("/api/services");
+      break;
+    case "faqs":
+      invalidateCache("faqs");
+      revalidatePath("/api/faqs");
+      break;
+    default:
+      break;
   }
 
   if (database === "docs" && data?.title) {

--- a/src/lib/notion-case-studies.ts
+++ b/src/lib/notion-case-studies.ts
@@ -34,9 +34,16 @@ import {
   blocksToHtml,
   extractText,
   notionImageProxyUrl,
+  createPage,
+  updatePage,
+  archivePage,
 } from "@/lib/notion";
-import { getIntegrationsAsync, requireIntegrationAsync } from "@/lib/integrations";
-import { cached } from "@/lib/notion-cache";
+import {
+  getIntegrationsAsync,
+  requireIntegrationAsync,
+  isConfiguredAsync,
+} from "@/lib/integrations";
+import { cached, invalidateCache } from "@/lib/notion-cache";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -164,6 +171,150 @@ function mapPage(page: any): CaseStudy {
 
 // ---------------------------------------------------------------------------
 // Public API
+// ---------------------------------------------------------------------------
+
+// ---------------------------------------------------------------------------
+// Admin write API
+// ---------------------------------------------------------------------------
+
+export interface CaseStudyInput {
+  title: string;
+  slug?: string;
+  client?: string;
+  industry?: string;
+  services?: string[];
+  summary?: string;
+  challenge?: string;
+  solution?: string;
+  results?: string;
+  metrics?: CaseStudyMetric[];
+  coverImage?: string;
+  tags?: string[];
+  published?: boolean;
+  featured?: boolean;
+  date?: string;
+}
+
+/**
+ * List ALL case studies (published + unpublished) for the admin panel.
+ */
+export async function getAllCaseStudiesAdmin(): Promise<CaseStudy[]> {
+  const configured = await isConfiguredAsync("NOTION_API_KEY", "NOTION_CASE_STUDIES_DB_ID");
+  if (!configured) return staticCaseStudies;
+
+  const { NOTION_CASE_STUDIES_DB_ID } = await getIntegrationsAsync();
+  try {
+    const pages = await notionFetchAll(`/databases/${NOTION_CASE_STUDIES_DB_ID}/query`, {
+      sorts: [{ property: "Date", direction: "descending" }],
+    });
+    return pages.map(mapPage);
+  } catch (err) {
+    console.error("[Notion Case Studies] Admin list failed:", err);
+    return [];
+  }
+}
+
+/**
+ * Create a new case study page in Notion.
+ */
+export async function createCaseStudy(input: CaseStudyInput): Promise<string | null> {
+  await requireIntegrationAsync("NOTION_API_KEY", "NOTION_CASE_STUDIES_DB_ID");
+  const { NOTION_CASE_STUDIES_DB_ID } = await getIntegrationsAsync();
+
+  const metrics = input.metrics ?? [];
+  const id = await createPage(NOTION_CASE_STUDIES_DB_ID, {
+    Title: { title: [{ text: { content: input.title } }] },
+    Slug: { rich_text: [{ text: { content: input.slug ?? "" } }] },
+    Client: { rich_text: [{ text: { content: input.client ?? "" } }] },
+    ...(input.industry ? { Industry: { select: { name: input.industry } } } : {}),
+    ...(input.services?.length
+      ? { Services: { multi_select: input.services.map((s) => ({ name: s })) } }
+      : {}),
+    Summary: { rich_text: [{ text: { content: input.summary ?? "" } }] },
+    Challenge: { rich_text: [{ text: { content: input.challenge ?? "" } }] },
+    Solution: { rich_text: [{ text: { content: input.solution ?? "" } }] },
+    Results: { rich_text: [{ text: { content: input.results ?? "" } }] },
+    ...(metrics[0]
+      ? {
+          Metric1Label: { rich_text: [{ text: { content: metrics[0].label } }] },
+          Metric1Value: { rich_text: [{ text: { content: metrics[0].value } }] },
+        }
+      : {}),
+    ...(metrics[1]
+      ? {
+          Metric2Label: { rich_text: [{ text: { content: metrics[1].label } }] },
+          Metric2Value: { rich_text: [{ text: { content: metrics[1].value } }] },
+        }
+      : {}),
+    ...(metrics[2]
+      ? {
+          Metric3Label: { rich_text: [{ text: { content: metrics[2].label } }] },
+          Metric3Value: { rich_text: [{ text: { content: metrics[2].value } }] },
+        }
+      : {}),
+    ...(input.coverImage ? { CoverImage: { url: input.coverImage } } : {}),
+    ...(input.tags?.length ? { Tags: { multi_select: input.tags.map((t) => ({ name: t })) } } : {}),
+    Published: { checkbox: input.published ?? false },
+    Featured: { checkbox: input.featured ?? false },
+    ...(input.date ? { Date: { date: { start: input.date } } } : {}),
+  });
+
+  if (id) invalidateCache("case-studies");
+  return id;
+}
+
+/**
+ * Update an existing case study's properties.
+ */
+export async function updateCaseStudy(
+  pageId: string,
+  input: Partial<CaseStudyInput>
+): Promise<boolean> {
+  const props: Record<string, unknown> = {};
+  if (input.title != null) props.Title = { title: [{ text: { content: input.title } }] };
+  if (input.slug != null) props.Slug = { rich_text: [{ text: { content: input.slug } }] };
+  if (input.client != null) props.Client = { rich_text: [{ text: { content: input.client } }] };
+  if (input.industry != null) props.Industry = { select: { name: input.industry } };
+  if (input.services != null)
+    props.Services = { multi_select: input.services.map((s) => ({ name: s })) };
+  if (input.summary != null) props.Summary = { rich_text: [{ text: { content: input.summary } }] };
+  if (input.challenge != null)
+    props.Challenge = { rich_text: [{ text: { content: input.challenge } }] };
+  if (input.solution != null)
+    props.Solution = { rich_text: [{ text: { content: input.solution } }] };
+  if (input.results != null) props.Results = { rich_text: [{ text: { content: input.results } }] };
+  if (input.metrics != null) {
+    const m = input.metrics;
+    props.Metric1Label = { rich_text: [{ text: { content: m[0]?.label ?? "" } }] };
+    props.Metric1Value = { rich_text: [{ text: { content: m[0]?.value ?? "" } }] };
+    props.Metric2Label = { rich_text: [{ text: { content: m[1]?.label ?? "" } }] };
+    props.Metric2Value = { rich_text: [{ text: { content: m[1]?.value ?? "" } }] };
+    props.Metric3Label = { rich_text: [{ text: { content: m[2]?.label ?? "" } }] };
+    props.Metric3Value = { rich_text: [{ text: { content: m[2]?.value ?? "" } }] };
+  }
+  if (input.coverImage !== undefined)
+    props.CoverImage = input.coverImage ? { url: input.coverImage } : { url: null };
+  if (input.tags != null) props.Tags = { multi_select: input.tags.map((t) => ({ name: t })) };
+  if (input.published != null) props.Published = { checkbox: input.published };
+  if (input.featured != null) props.Featured = { checkbox: input.featured };
+  if (input.date != null) props.Date = { date: { start: input.date } };
+
+  const ok = await updatePage(pageId, props);
+  if (ok) invalidateCache("case-studies");
+  return ok;
+}
+
+/**
+ * Archive (soft-delete) a case study.
+ */
+export async function deleteCaseStudy(pageId: string): Promise<boolean> {
+  const ok = await archivePage(pageId);
+  if (ok) invalidateCache("case-studies");
+  return ok;
+}
+
+// ---------------------------------------------------------------------------
+// Public read API
 // ---------------------------------------------------------------------------
 
 /**

--- a/src/lib/notion-faqs.ts
+++ b/src/lib/notion-faqs.ts
@@ -17,9 +17,13 @@
  * └──────────┴──────────────────────────────────────────────────────┘
  */
 
-import { notionFetchAll, extractText } from "@/lib/notion";
-import { getIntegrationsAsync, isConfiguredAsync } from "@/lib/integrations";
-import { cached } from "@/lib/notion-cache";
+import { notionFetchAll, extractText, createPage, updatePage, archivePage } from "@/lib/notion";
+import {
+  getIntegrationsAsync,
+  isConfiguredAsync,
+  requireIntegrationAsync,
+} from "@/lib/integrations";
+import { cached, invalidateCache } from "@/lib/notion-cache";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -109,6 +113,91 @@ function mapPage(page: any): Faq {
 
 // ---------------------------------------------------------------------------
 // Public API
+// ---------------------------------------------------------------------------
+
+// ---------------------------------------------------------------------------
+// Admin write API
+// ---------------------------------------------------------------------------
+
+export interface FaqInput {
+  question: string;
+  answer?: string;
+  category?: FaqCategory;
+  locales?: string[];
+  published?: boolean;
+  order?: number;
+}
+
+/**
+ * List ALL FAQs (published + unpublished) for the admin panel.
+ */
+export async function getAllFaqsAdmin(): Promise<Faq[]> {
+  const configured = await isConfiguredAsync("NOTION_API_KEY", "NOTION_FAQS_DB_ID");
+  if (!configured) return staticFaqs;
+
+  const { NOTION_FAQS_DB_ID } = await getIntegrationsAsync();
+  try {
+    const pages = await notionFetchAll(`/databases/${NOTION_FAQS_DB_ID}/query`, {
+      sorts: [{ property: "Order", direction: "ascending" }],
+    });
+    return pages.map(mapPage);
+  } catch (err) {
+    console.error("[Notion FAQs] Admin list failed:", err);
+    return [];
+  }
+}
+
+/**
+ * Create a new FAQ page in Notion.
+ */
+export async function createFaq(input: FaqInput): Promise<string | null> {
+  await requireIntegrationAsync("NOTION_API_KEY", "NOTION_FAQS_DB_ID");
+  const { NOTION_FAQS_DB_ID } = await getIntegrationsAsync();
+
+  const id = await createPage(NOTION_FAQS_DB_ID, {
+    Question: { title: [{ text: { content: input.question } }] },
+    Answer: { rich_text: [{ text: { content: input.answer ?? "" } }] },
+    ...(input.category ? { Category: { select: { name: input.category } } } : {}),
+    ...(input.locales?.length
+      ? { Locale: { multi_select: input.locales.map((l) => ({ name: l })) } }
+      : {}),
+    Published: { checkbox: input.published ?? false },
+    ...(input.order != null ? { Order: { number: input.order } } : {}),
+  });
+
+  if (id) invalidateCache("faqs");
+  return id;
+}
+
+/**
+ * Update an existing FAQ's properties.
+ */
+export async function updateFaq(pageId: string, input: Partial<FaqInput>): Promise<boolean> {
+  const props: Record<string, unknown> = {};
+  if (input.question != null) props.Question = { title: [{ text: { content: input.question } }] };
+  if (input.answer != null) props.Answer = { rich_text: [{ text: { content: input.answer } }] };
+  if (input.category != null) props.Category = { select: { name: input.category } };
+  if (input.locales != null)
+    props.Locale = { multi_select: input.locales.map((l) => ({ name: l })) };
+  if (input.published != null) props.Published = { checkbox: input.published };
+  if (input.order != null) props.Order = { number: input.order };
+
+  const ok = await updatePage(pageId, props);
+  if (ok) invalidateCache("faqs");
+  return ok;
+}
+
+/**
+ * Archive (soft-delete) a FAQ.
+ */
+export async function deleteFaq(pageId: string): Promise<boolean> {
+  const ok = await archivePage(pageId);
+  if (ok) invalidateCache("faqs");
+  return ok;
+}
+
+// ---------------------------------------------------------------------------
+// Public read API
 // ---------------------------------------------------------------------------
 
 /**

--- a/src/lib/notion-services.ts
+++ b/src/lib/notion-services.ts
@@ -22,9 +22,13 @@
  * └──────────────┴───────────────────────────────────────────────────┘
  */
 
-import { notionFetchAll, extractText } from "@/lib/notion";
-import { getIntegrationsAsync, isConfiguredAsync } from "@/lib/integrations";
-import { cached } from "@/lib/notion-cache";
+import { notionFetchAll, extractText, createPage, updatePage, archivePage } from "@/lib/notion";
+import {
+  getIntegrationsAsync,
+  isConfiguredAsync,
+  requireIntegrationAsync,
+} from "@/lib/integrations";
+import { cached, invalidateCache } from "@/lib/notion-cache";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -154,6 +158,112 @@ function mapPage(page: any): CloudlessService {
 
 // ---------------------------------------------------------------------------
 // Public API
+// ---------------------------------------------------------------------------
+
+// ---------------------------------------------------------------------------
+// Admin write API
+// ---------------------------------------------------------------------------
+
+export interface ServiceInput {
+  name: string;
+  slug?: string;
+  description?: string;
+  price?: string;
+  category?: ServiceCategory;
+  features?: string[];
+  cta?: string;
+  icon?: string;
+  stripePriceId?: string;
+  published?: boolean;
+  order?: number;
+}
+
+/**
+ * List ALL services (published + unpublished) for the admin panel.
+ */
+export async function getAllServicesAdmin(): Promise<CloudlessService[]> {
+  const configured = await isConfiguredAsync("NOTION_API_KEY", "NOTION_SERVICES_DB_ID");
+  if (!configured) return staticServices;
+
+  const { NOTION_SERVICES_DB_ID } = await getIntegrationsAsync();
+  try {
+    const pages = await notionFetchAll(`/databases/${NOTION_SERVICES_DB_ID}/query`, {
+      sorts: [{ property: "Order", direction: "ascending" }],
+    });
+    return pages.map(mapPage);
+  } catch (err) {
+    console.error("[Notion Services] Admin list failed:", err);
+    return [];
+  }
+}
+
+/**
+ * Create a new service page in Notion.
+ */
+export async function createService(input: ServiceInput): Promise<string | null> {
+  await requireIntegrationAsync("NOTION_API_KEY", "NOTION_SERVICES_DB_ID");
+  const { NOTION_SERVICES_DB_ID } = await getIntegrationsAsync();
+
+  const featuresText = (input.features ?? []).join("\n");
+  const id = await createPage(NOTION_SERVICES_DB_ID, {
+    Name: { title: [{ text: { content: input.name } }] },
+    Slug: { rich_text: [{ text: { content: input.slug ?? "" } }] },
+    Description: { rich_text: [{ text: { content: input.description ?? "" } }] },
+    Price: { rich_text: [{ text: { content: input.price ?? "" } }] },
+    ...(input.category ? { Category: { select: { name: input.category } } } : {}),
+    Features: { rich_text: [{ text: { content: featuresText } }] },
+    CTA: { rich_text: [{ text: { content: input.cta ?? "Learn more" } }] },
+    Icon: { rich_text: [{ text: { content: input.icon ?? "☁️" } }] },
+    ...(input.stripePriceId
+      ? { StripePriceId: { rich_text: [{ text: { content: input.stripePriceId } }] } }
+      : {}),
+    Published: { checkbox: input.published ?? false },
+    ...(input.order != null ? { Order: { number: input.order } } : {}),
+  });
+
+  if (id) invalidateCache("services");
+  return id;
+}
+
+/**
+ * Update an existing service's properties.
+ */
+export async function updateService(
+  pageId: string,
+  input: Partial<ServiceInput>
+): Promise<boolean> {
+  const props: Record<string, unknown> = {};
+  if (input.name != null) props.Name = { title: [{ text: { content: input.name } }] };
+  if (input.slug != null) props.Slug = { rich_text: [{ text: { content: input.slug } }] };
+  if (input.description != null)
+    props.Description = { rich_text: [{ text: { content: input.description } }] };
+  if (input.price != null) props.Price = { rich_text: [{ text: { content: input.price } }] };
+  if (input.category != null) props.Category = { select: { name: input.category } };
+  if (input.features != null)
+    props.Features = { rich_text: [{ text: { content: input.features.join("\n") } }] };
+  if (input.cta != null) props.CTA = { rich_text: [{ text: { content: input.cta } }] };
+  if (input.icon != null) props.Icon = { rich_text: [{ text: { content: input.icon } }] };
+  if (input.stripePriceId !== undefined)
+    props.StripePriceId = { rich_text: [{ text: { content: input.stripePriceId ?? "" } }] };
+  if (input.published != null) props.Published = { checkbox: input.published };
+  if (input.order != null) props.Order = { number: input.order };
+
+  const ok = await updatePage(pageId, props);
+  if (ok) invalidateCache("services");
+  return ok;
+}
+
+/**
+ * Archive (soft-delete) a service.
+ */
+export async function deleteService(pageId: string): Promise<boolean> {
+  const ok = await archivePage(pageId);
+  if (ok) invalidateCache("services");
+  return ok;
+}
+
+// ---------------------------------------------------------------------------
+// Public read API
 // ---------------------------------------------------------------------------
 
 /**

--- a/src/lib/notion-testimonials.ts
+++ b/src/lib/notion-testimonials.ts
@@ -18,9 +18,13 @@
  * └──────────┴──────────────────────────────────────────────────────┘
  */
 
-import { notionFetchAll, extractText } from "@/lib/notion";
-import { getIntegrationsAsync, requireIntegrationAsync } from "@/lib/integrations";
-import { cached } from "@/lib/notion-cache";
+import { notionFetchAll, extractText, createPage, updatePage, archivePage } from "@/lib/notion";
+import {
+  getIntegrationsAsync,
+  requireIntegrationAsync,
+  isConfiguredAsync,
+} from "@/lib/integrations";
+import { cached, invalidateCache } from "@/lib/notion-cache";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -102,6 +106,105 @@ function mapPage(page: any): Testimonial {
 
 // ---------------------------------------------------------------------------
 // Public API
+// ---------------------------------------------------------------------------
+
+// ---------------------------------------------------------------------------
+// Admin write API
+// ---------------------------------------------------------------------------
+
+export interface TestimonialInput {
+  name: string;
+  company?: string;
+  role?: string;
+  quote: string;
+  avatar?: string;
+  service?: string;
+  rating?: number;
+  featured?: boolean;
+  published?: boolean;
+  order?: number;
+}
+
+/**
+ * List ALL testimonials (published + unpublished) for the admin panel.
+ */
+export async function getAllTestimonialsAdmin(): Promise<Testimonial[]> {
+  const configured = await isConfiguredAsync("NOTION_API_KEY", "NOTION_TESTIMONIALS_DB_ID");
+  if (!configured) return staticTestimonials;
+
+  const { NOTION_TESTIMONIALS_DB_ID } = await getIntegrationsAsync();
+  try {
+    const pages = await notionFetchAll(`/databases/${NOTION_TESTIMONIALS_DB_ID}/query`, {
+      sorts: [{ property: "Order", direction: "ascending" }],
+    });
+    return pages.map(mapPage);
+  } catch (err) {
+    console.error("[Notion Testimonials] Admin list failed:", err);
+    return [];
+  }
+}
+
+/**
+ * Create a new testimonial page in Notion.
+ */
+export async function createTestimonial(input: TestimonialInput): Promise<string | null> {
+  await requireIntegrationAsync("NOTION_API_KEY", "NOTION_TESTIMONIALS_DB_ID");
+  const { NOTION_TESTIMONIALS_DB_ID } = await getIntegrationsAsync();
+
+  const id = await createPage(NOTION_TESTIMONIALS_DB_ID, {
+    Name: { title: [{ text: { content: input.name } }] },
+    Company: { rich_text: [{ text: { content: input.company ?? "" } }] },
+    Role: { rich_text: [{ text: { content: input.role ?? "" } }] },
+    Quote: { rich_text: [{ text: { content: input.quote } }] },
+    ...(input.avatar ? { Avatar: { url: input.avatar } } : {}),
+    ...(input.service ? { Service: { select: { name: input.service } } } : {}),
+    ...(input.rating != null ? { Rating: { number: input.rating } } : {}),
+    Featured: { checkbox: input.featured ?? false },
+    Published: { checkbox: input.published ?? false },
+    ...(input.order != null ? { Order: { number: input.order } } : {}),
+  });
+
+  if (id) invalidateCache("testimonials");
+  return id;
+}
+
+/**
+ * Update an existing testimonial's properties.
+ */
+export async function updateTestimonial(
+  pageId: string,
+  input: Partial<TestimonialInput>
+): Promise<boolean> {
+  const props: Record<string, unknown> = {};
+  if (input.name != null) props.Name = { title: [{ text: { content: input.name } }] };
+  if (input.company != null) props.Company = { rich_text: [{ text: { content: input.company } }] };
+  if (input.role != null) props.Role = { rich_text: [{ text: { content: input.role } }] };
+  if (input.quote != null) props.Quote = { rich_text: [{ text: { content: input.quote } }] };
+  if (input.avatar !== undefined)
+    props.Avatar = input.avatar ? { url: input.avatar } : { url: null };
+  if (input.service !== undefined)
+    props.Service = input.service ? { select: { name: input.service } } : { select: null };
+  if (input.rating != null) props.Rating = { number: input.rating };
+  if (input.featured != null) props.Featured = { checkbox: input.featured };
+  if (input.published != null) props.Published = { checkbox: input.published };
+  if (input.order != null) props.Order = { number: input.order };
+
+  const ok = await updatePage(pageId, props);
+  if (ok) invalidateCache("testimonials");
+  return ok;
+}
+
+/**
+ * Archive (soft-delete) a testimonial.
+ */
+export async function deleteTestimonial(pageId: string): Promise<boolean> {
+  const ok = await archivePage(pageId);
+  if (ok) invalidateCache("testimonials");
+  return ok;
+}
+
+// ---------------------------------------------------------------------------
+// Public read API
 // ---------------------------------------------------------------------------
 
 /**

--- a/src/lib/notion.ts
+++ b/src/lib/notion.ts
@@ -341,6 +341,32 @@ export function notionImageProxyUrl(id: string, type: "block" | "cover" = "block
  * Update page properties via PATCH.
  * Accepts a plain object of property updates.
  */
+/**
+ * Create a new page in a Notion database.
+ * Returns the new page ID on success, null on failure.
+ */
+export async function createPage(
+  databaseId: string,
+  properties: Record<string, unknown>
+): Promise<string | null> {
+  try {
+    const page = await notionFetch<{ id: string }>("/pages", {
+      method: "POST",
+      body: JSON.stringify({
+        parent: { database_id: databaseId },
+        properties,
+      }),
+    });
+    return page.id;
+  } catch (err) {
+    console.error(
+      `[Notion] Failed to create page in ${databaseId}:`,
+      (err as Error)?.message ?? "unknown error"
+    );
+    return null;
+  }
+}
+
 export async function updatePage(
   pageId: string,
   properties: Record<string, unknown>


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- Add full CRUD admin UI for all 4 Notion CMS databases (Testimonials, Case Studies, Services, FAQs)
- Each database gets an admin API route (`/api/admin/notion/{resource}`) with `requireAdmin` auth, GET/POST/PATCH/DELETE handlers, and cache invalidation
- Each database gets an admin page (`/admin/cms/{resource}`) with list view, modal form (create/edit), skeleton loading, and archive action
- Add `createPage()` utility to `notion.ts` for Notion page creation
- Extend lib files with `Input` types and admin CRUD functions
- Wire CMS nav group into the admin sidebar

## Test plan

- [ ] Log in as admin and navigate to `/admin/cms/testimonials` — list loads, "+ New" opens modal, create/edit/archive work
- [ ] Repeat for `/admin/cms/case-studies`, `/admin/cms/services`, `/admin/cms/faqs`
- [ ] Confirm non-admin users cannot access the API routes (401)
- [ ] Confirm cache is invalidated after create/update/delete (public API reflects changes)

https://claude.ai/code/session_013sTDMVEYibee8tbXxrwjzo
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_013sTDMVEYibee8tbXxrwjzo)_