### PR TITLE
Fix TS type error: non-null assert DB IDs before createPage calls

### DIFF
--- a/src/lib/notion-case-studies.ts
+++ b/src/lib/notion-case-studies.ts
@@ -222,7 +222,7 @@ export async function createCaseStudy(input: CaseStudyInput): Promise<string | n
   const { NOTION_CASE_STUDIES_DB_ID } = await getIntegrationsAsync();
 
   const metrics = input.metrics ?? [];
-  const id = await createPage(NOTION_CASE_STUDIES_DB_ID, {
+  const id = await createPage(NOTION_CASE_STUDIES_DB_ID!, {
     Title: { title: [{ text: { content: input.title } }] },
     Slug: { rich_text: [{ text: { content: input.slug ?? "" } }] },
     Client: { rich_text: [{ text: { content: input.client ?? "" } }] },

--- a/src/lib/notion-faqs.ts
+++ b/src/lib/notion-faqs.ts
@@ -154,7 +154,7 @@ export async function createFaq(input: FaqInput): Promise<string | null> {
   await requireIntegrationAsync("NOTION_API_KEY", "NOTION_FAQS_DB_ID");
   const { NOTION_FAQS_DB_ID } = await getIntegrationsAsync();
 
-  const id = await createPage(NOTION_FAQS_DB_ID, {
+  const id = await createPage(NOTION_FAQS_DB_ID!, {
     Question: { title: [{ text: { content: input.question } }] },
     Answer: { rich_text: [{ text: { content: input.answer ?? "" } }] },
     ...(input.category ? { Category: { select: { name: input.category } } } : {}),

--- a/src/lib/notion-services.ts
+++ b/src/lib/notion-services.ts
@@ -205,7 +205,7 @@ export async function createService(input: ServiceInput): Promise<string | null>
   const { NOTION_SERVICES_DB_ID } = await getIntegrationsAsync();
 
   const featuresText = (input.features ?? []).join("\n");
-  const id = await createPage(NOTION_SERVICES_DB_ID, {
+  const id = await createPage(NOTION_SERVICES_DB_ID!, {
     Name: { title: [{ text: { content: input.name } }] },
     Slug: { rich_text: [{ text: { content: input.slug ?? "" } }] },
     Description: { rich_text: [{ text: { content: input.description ?? "" } }] },

--- a/src/lib/notion-testimonials.ts
+++ b/src/lib/notion-testimonials.ts
@@ -151,7 +151,7 @@ export async function createTestimonial(input: TestimonialInput): Promise<string
   await requireIntegrationAsync("NOTION_API_KEY", "NOTION_TESTIMONIALS_DB_ID");
   const { NOTION_TESTIMONIALS_DB_ID } = await getIntegrationsAsync();
 
-  const id = await createPage(NOTION_TESTIMONIALS_DB_ID, {
+  const id = await createPage(NOTION_TESTIMONIALS_DB_ID!, {
     Name: { title: [{ text: { content: input.name } }] },
     Company: { rich_text: [{ text: { content: input.company ?? "" } }] },
     Role: { rich_text: [{ text: { content: input.role ?? "" } }] },


### PR DESCRIPTION
Fixes the TypeScript build failure from PR #644.

`getIntegrationsAsync()` returns `string | undefined` for DB ID fields, but `createPage()` requires `string`. Since `requireIntegrationAsync()` is called immediately before each `createPage()` call and throws if the value is missing, the non-null assertion (`!`) is safe here.

Affected files: `notion-case-studies.ts`, `notion-testimonials.ts`, `notion-services.ts`, `notion-faqs.ts`

https://claude.ai/code/session_013sTDMVEYibee8tbXxrwjzo

---
_Generated by [Claude Code](https://claude.ai/code/session_013sTDMVEYibee8tbXxrwjzo)_