### PR TITLE
Trigger k3s restart to recover Pi apiserver

### DIFF
--- a/.github/workflows/k3s-restart.yml
+++ b/.github/workflows/k3s-restart.yml
@@ -88,3 +88,4 @@ jobs:
             cat k3s.log 2>/dev/null || echo "(no log)"
             echo '```'
           } | gh issue comment 382 --repo "$GITHUB_REPOSITORY" --body-file -
+# re-triggered 2026-06-04


### PR DESCRIPTION
Triggers the `k3s-restart.yml` workflow (path-triggered) to recover the Pi k3s apiserver after it went `not ready` during the rollout of `e1d25008`.

After the restart succeeds, the `Deploy to Pi` workflow can be re-run against the same commit.

https://claude.ai/code/session_013sTDMVEYibee8tbXxrwjzo

---
_Generated by [Claude Code](https://claude.ai/code/session_013sTDMVEYibee8tbXxrwjzo)_