### PR TITLE
chore: re-trigger Pi deploy after k3s apiserver recovery

### DIFF
--- a/.github/workflows/deploy-pi.yml
+++ b/.github/workflows/deploy-pi.yml
@@ -196,3 +196,4 @@ jobs:
             ${{ env.K3S_DEPLOYMENT }}=${{ env.ECR_REGISTRY }}/${{ env.ECR_REPOSITORY }}:${{ needs.build-and-push.outputs.short_sha }} \
             -n ${{ env.K3S_NAMESPACE }}
           kubectl rollout status deployment/${{ env.K3S_DEPLOYMENT }} -n ${{ env.K3S_NAMESPACE }} --timeout=180s
+# re-triggered 2026-06-04 after k3s apiserver recovery


### PR DESCRIPTION
k3s was restarted successfully (run 26949606790, concluded success at 11:45Z). This touches `deploy-pi.yml` to trigger a fresh rollout of the latest image (`e1d25008d52c`) to the Pi k3s cluster now that the apiserver is healthy again.

---
_Generated by [Claude Code](https://claude.ai/code/session_013sTDMVEYibee8tbXxrwjzo)_