### PR TITLE
fix(deploy-pi): add self-healing k3s API wait before rollout

### DIFF
--- a/.github/workflows/deploy-pi.yml
+++ b/.github/workflows/deploy-pi.yml
@@ -190,10 +190,45 @@ jobs:
           mkdir -p ~/.kube
           echo "${{ secrets.KUBECONFIG_B64 }}" | base64 -d > ~/.kube/config
           chmod 600 ~/.kube/config
+      - name: Wait for k3s API server (restart via SSH if needed)
+        env:
+          PI_HOST: "100.113.41.119"
+          PI_USER: "tbaltzakis"
+        run: |
+          wait_for_api() {
+            for i in $(seq 1 18); do
+              if nc -zv -w3 "$PI_HOST" 6443 2>/dev/null; then
+                echo "k3s API ready (attempt ${i})"
+                return 0
+              fi
+              echo "  ${i}/18 — API not ready, waiting 5s..."
+              sleep 5
+            done
+            return 1
+          }
+
+          if wait_for_api; then
+            echo "k3s API is up — proceeding to rollout"
+            exit 0
+          fi
+
+          echo "k3s API not ready after 90s — attempting SSH restart"
+          mkdir -p ~/.ssh
+          printf '%s\n' "${{ secrets.OMV_SSH_KEY }}" > ~/.ssh/id_ed25519
+          chmod 600 ~/.ssh/id_ed25519
+          ssh-keyscan -H "$PI_HOST" >> ~/.ssh/known_hosts 2>/dev/null || true
+          ssh -i ~/.ssh/id_ed25519 -o StrictHostKeyChecking=no -o ConnectTimeout=10 \
+            "$PI_USER@$PI_HOST" "sudo systemctl restart k3s 2>&1; echo restart_exit=\$?"
+
+          echo "Waiting up to 3 more minutes for API server..."
+          if ! wait_for_api; then
+            echo "::error::k3s API still not reachable after restart — aborting rollout"
+            exit 1
+          fi
+          echo "k3s API is up after restart"
       - name: Set image and roll out
         run: |
           kubectl set image deployment/${{ env.K3S_DEPLOYMENT }} \
             ${{ env.K3S_DEPLOYMENT }}=${{ env.ECR_REGISTRY }}/${{ env.ECR_REPOSITORY }}:${{ needs.build-and-push.outputs.short_sha }} \
             -n ${{ env.K3S_NAMESPACE }}
-          kubectl rollout status deployment/${{ env.K3S_DEPLOYMENT }} -n ${{ env.K3S_NAMESPACE }} --timeout=180s
-# re-triggered 2026-06-04 after k3s apiserver recovery
+          kubectl rollout status deployment/${{ env.K3S_DEPLOYMENT }} -n ${{ env.K3S_NAMESPACE }} --timeout=300s


### PR DESCRIPTION
## Summary

- Adds a pre-rollout step that polls `100.113.41.119:6443` for up to 90s before attempting `kubectl set image`
- If the API is still down after 90s, SSH-restarts k3s (same `OMV_SSH_KEY` pattern as `k3s-restart.yml`), then waits up to 3 more minutes
- Bumps rollout timeout 180s → 300s to handle memory-pressured Pi pulling a new ECR image

**Root cause:** k3s apiserver crashed between the build job finishing (11:45Z) and the rollout job starting (11:59Z). Previous rollout had zero tolerance — fired `kubectl set image` immediately and failed in 3 seconds.

https://claude.ai/code/session_013sTDMVEYibee8tbXxrwjzo

---
_Generated by [Claude Code](https://claude.ai/code/session_013sTDMVEYibee8tbXxrwjzo)_