### PR TITLE
chore: re-trigger Pi deploy (QEMU build stuck)

### DIFF
--- a/.github/workflows/deploy-pi.yml
+++ b/.github/workflows/deploy-pi.yml
@@ -232,3 +232,4 @@ jobs:
             ${{ env.K3S_DEPLOYMENT }}=${{ env.ECR_REGISTRY }}/${{ env.ECR_REPOSITORY }}:${{ needs.build-and-push.outputs.short_sha }} \
             -n ${{ env.K3S_NAMESPACE }}
           kubectl rollout status deployment/${{ env.K3S_DEPLOYMENT }} -n ${{ env.K3S_NAMESPACE }} --timeout=300s
+# re-triggered 2026-06-04T12:45Z — previous QEMU build stuck at 35min


### PR DESCRIPTION
Run 26950826662 got a stuck GH Actions runner — QEMU step 10 ran for 35+ minutes (normal: 11 min). Merging this to cancel it via the `concurrency: deploy-pi, cancel-in-progress: true` setting and start a fresh run on a new runner.

---
_Generated by [Claude Code](https://claude.ai/code/session_013sTDMVEYibee8tbXxrwjzo)_