### PR TITLE
fix(deploy-pi): replace nc with HTTP /readyz probe + SSH diagnostics

### DIFF
--- a/.github/workflows/deploy-pi.yml
+++ b/.github/workflows/deploy-pi.yml
@@ -190,42 +190,64 @@ jobs:
           mkdir -p ~/.kube
           echo "${{ secrets.KUBECONFIG_B64 }}" | base64 -d > ~/.kube/config
           chmod 600 ~/.kube/config
-      - name: Wait for k3s API server (restart via SSH if needed)
+      - name: Diagnose k3s on Pi
         env:
           PI_HOST: "100.113.41.119"
           PI_USER: "tbaltzakis"
         run: |
-          wait_for_api() {
-            for i in $(seq 1 18); do
-              if nc -zv -w3 "$PI_HOST" 6443 2>/dev/null; then
-                echo "k3s API ready (attempt ${i})"
-                return 0
+          mkdir -p ~/.ssh
+          printf '%s\n' "${{ secrets.OMV_SSH_KEY }}" > ~/.ssh/id_ed25519
+          chmod 600 ~/.ssh/id_ed25519
+          ssh-keyscan -H "$PI_HOST" >> ~/.ssh/known_hosts 2>/dev/null || true
+          ssh -i ~/.ssh/id_ed25519 -o StrictHostKeyChecking=no -o ConnectTimeout=15 \
+            "$PI_USER@$PI_HOST" '
+              echo "=== k3s service status ==="
+              systemctl is-active k3s || true
+              echo "=== last 30 k3s journal lines ==="
+              sudo journalctl -u k3s -n 30 --no-pager 2>/dev/null || true
+              echo "=== memory ==="
+              free -m
+              echo "=== disk ==="
+              df -h /
+              echo "=== restart k3s if not active ==="
+              if ! systemctl is-active --quiet k3s; then
+                sudo systemctl restart k3s
+                echo "k3s restart triggered"
+              else
+                echo "k3s is active — no restart needed"
               fi
-              echo "  ${i}/18 — API not ready, waiting 5s..."
+            '
+      - name: Wait for k3s HTTP /readyz (3x stable)
+        env:
+          PI_HOST: "100.113.41.119"
+        run: |
+          wait_for_api() {
+            local stable=0
+            for i in $(seq 1 36); do
+              code=$(curl -k -s -o /dev/null -w "%{http_code}" \
+                --max-time 3 "https://$PI_HOST:6443/readyz" 2>/dev/null)
+              if [ "$code" = "200" ]; then
+                stable=$((stable + 1))
+                echo "  ${i}/36 — /readyz HTTP 200 (stable ${stable}/3)"
+                if [ "$stable" -ge 3 ]; then
+                  return 0
+                fi
+              else
+                stable=0
+                echo "  ${i}/36 — /readyz returned ${code:-timeout}, waiting 5s..."
+              fi
               sleep 5
             done
             return 1
           }
 
+          echo "Waiting for k3s API to be stable (3x /readyz 200)..."
           if wait_for_api; then
-            echo "k3s API is up — proceeding to rollout"
-            exit 0
-          fi
-
-          echo "k3s API not ready after 90s — attempting SSH restart"
-          mkdir -p ~/.ssh
-          printf '%s\n' "${{ secrets.OMV_SSH_KEY }}" > ~/.ssh/id_ed25519
-          chmod 600 ~/.ssh/id_ed25519
-          ssh-keyscan -H "$PI_HOST" >> ~/.ssh/known_hosts 2>/dev/null || true
-          ssh -i ~/.ssh/id_ed25519 -o StrictHostKeyChecking=no -o ConnectTimeout=10 \
-            "$PI_USER@$PI_HOST" "sudo systemctl restart k3s 2>&1; echo restart_exit=\$?"
-
-          echo "Waiting up to 3 more minutes for API server..."
-          if ! wait_for_api; then
-            echo "::error::k3s API still not reachable after restart — aborting rollout"
+            echo "k3s API stable — proceeding to rollout"
+          else
+            echo "::error::k3s /readyz never returned 3x 200 in 3 min — aborting"
             exit 1
           fi
-          echo "k3s API is up after restart"
       - name: Set image and roll out
         run: |
           kubectl set image deployment/${{ env.K3S_DEPLOYMENT }} \


### PR DESCRIPTION
## Problem

`nc` gives a false positive during k3s's brief TCP-open window before the process crashes (OOM or startup failure). The sequence from run 26952714459:

```
k3s API ready (attempt 1)   ← nc passes at 13:00:46Z
k3s API is up — proceeding to rollout
connection refused           ← kubectl fails at 13:00:56Z
```

k3s opens port 6443 during init, then is OOM-killed before it can serve requests. systemd `Restart=always` restarts it in ~100ms → rapid crash loop. The nc check exits during the brief TCP window, triggering an immediate rollout that fails.

## Fix

**Step 1 — Diagnose k3s on Pi** (new, runs before wait loop)
- SSH in with `OMV_SSH_KEY`
- Dumps last 30 `journalctl -u k3s` lines (shows OOM/crash reason)
- `free -m` + `df -h /` (memory/disk pressure check)
- Restarts k3s if `systemctl is-active` returns inactive

**Step 2 — Wait for k3s HTTP /readyz (3× stable)** (replaces nc loop)
- Polls `https://100.113.41.119:6443/readyz` with `curl -k`
- Requires **3 consecutive HTTP 200 responses** (5s apart) before passing
- Up to 36 attempts (3 min) before aborting
- This endpoint only returns 200 when k3s is fully ready to serve API requests — no false positives from brief TCP-open window

## Test plan
- [ ] Rollout job logs show k3s journal lines
- [ ] "k3s API stable — proceeding to rollout" appears
- [ ] `deployment "cloudless" successfully rolled out`
- [ ] `pi-origin.cloudless.gr/api/health` returns HTTP 200

---
_Generated by [Claude Code](https://claude.ai/code/session_013sTDMVEYibee8tbXxrwjzo)_