### PR TITLE
fix(k3s+pwa): kubectl readyz probe + etcd defrag + iOS PWA meta

### DIFF
--- a/.github/workflows/deploy-pi.yml
+++ b/.github/workflows/deploy-pi.yml
@@ -203,12 +203,19 @@ jobs:
             "$PI_USER@$PI_HOST" '
               echo "=== k3s service status ==="
               systemctl is-active k3s || true
-              echo "=== last 30 k3s journal lines ==="
-              sudo journalctl -u k3s -n 30 --no-pager 2>/dev/null || true
+              echo "=== last 20 k3s journal lines ==="
+              sudo journalctl -u k3s -n 20 --no-pager 2>/dev/null || true
               echo "=== memory ==="
               free -m
               echo "=== disk ==="
               df -h /
+              echo "=== etcd defrag (prevent slow raft consensus) ==="
+              sudo k3s etcdctl defrag \
+                --endpoints=https://127.0.0.1:2379 \
+                --cacert=/var/lib/rancher/k3s/server/tls/etcd/server-ca.crt \
+                --cert=/var/lib/rancher/k3s/server/tls/etcd/server-client.crt \
+                --key=/var/lib/rancher/k3s/server/tls/etcd/server-client.key \
+                2>/dev/null && echo "etcd defrag done" || echo "etcd defrag skipped (not embedded etcd or certs missing)"
               echo "=== restart k3s if not active ==="
               if ! systemctl is-active --quiet k3s; then
                 sudo systemctl restart k3s
@@ -217,35 +224,35 @@ jobs:
                 echo "k3s is active — no restart needed"
               fi
             '
-      - name: Wait for k3s HTTP /readyz (3x stable)
-        env:
-          PI_HOST: "100.113.41.119"
+      - name: Wait for k3s /readyz (3x stable via kubectl)
         run: |
+          # Use kubectl (kubeconfig creds) — anonymous curl returns 401 when
+          # anonymous-auth is disabled; kubectl uses the client cert in KUBECONFIG.
+          # k3s /readyz returns the string "ok" when all checks pass.
           wait_for_api() {
             local stable=0
-            for i in $(seq 1 36); do
-              code=$(curl -k -s -o /dev/null -w "%{http_code}" \
-                --max-time 3 "https://$PI_HOST:6443/readyz" 2>/dev/null)
-              if [ "$code" = "200" ]; then
+            for i in $(seq 1 60); do
+              if kubectl get --raw /readyz --request-timeout=5s 2>/dev/null \
+                  | grep -q 'ok'; then
                 stable=$((stable + 1))
-                echo "  ${i}/36 — /readyz HTTP 200 (stable ${stable}/3)"
+                echo "  ${i}/60 — /readyz ok (stable ${stable}/3)"
                 if [ "$stable" -ge 3 ]; then
                   return 0
                 fi
               else
                 stable=0
-                echo "  ${i}/36 — /readyz returned ${code:-timeout}, waiting 5s..."
+                echo "  ${i}/60 — /readyz not ready, waiting 5s..."
               fi
               sleep 5
             done
             return 1
           }
 
-          echo "Waiting for k3s API to be stable (3x /readyz 200)..."
+          echo "Waiting for k3s API to be stable (3x kubectl /readyz ok)..."
           if wait_for_api; then
             echo "k3s API stable — proceeding to rollout"
           else
-            echo "::error::k3s /readyz never returned 3x 200 in 3 min — aborting"
+            echo "::error::k3s /readyz never returned 3x ok in 5 min — aborting"
             exit 1
           fi
       - name: Set image and roll out

--- a/public/manifest.webmanifest
+++ b/public/manifest.webmanifest
@@ -5,7 +5,7 @@
   "description": "Cloud architecture, serverless development, data analytics, and AI-powered marketing for startups and SMBs.",
   "start_url": "/?source=pwa",
   "scope": "/",
-  "lang": "el",
+  "lang": "en",
   "dir": "ltr",
   "display": "standalone",
   "display_override": ["window-controls-overlay", "standalone", "minimal-ui"],
@@ -30,15 +30,15 @@
     {
       "name": "Our Services",
       "short_name": "Services",
-      "url": "/#services?source=pwa-shortcut",
-      "description": "Explore our cloud services",
+      "url": "/services",
+      "description": "Cloud, serverless, analytics & AI marketing",
       "icons": [{ "src": "/icons/icon-192.png", "sizes": "192x192" }]
     },
     {
       "name": "Read Blog",
       "short_name": "Blog",
-      "url": "/blog?source=pwa-shortcut",
-      "description": "Cloud computing insights and guides",
+      "url": "/blog",
+      "description": "Tech insights and guides",
       "icons": [{ "src": "/icons/icon-192.png", "sizes": "192x192" }]
     }
   ]

--- a/src/app/api/pwa-manifest/route.ts
+++ b/src/app/api/pwa-manifest/route.ts
@@ -8,7 +8,7 @@ const MANIFEST = {
     "Cloud architecture, serverless development, data analytics, and AI-powered marketing for startups and SMBs.",
   start_url: "/?source=pwa",
   scope: "/",
-  lang: "el",
+  lang: "en",
   dir: "ltr",
   display: "standalone",
   display_override: ["window-controls-overlay", "standalone", "minimal-ui"],

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -58,6 +58,15 @@ export const metadata: Metadata = {
   verification: {
     google: process.env.NEXT_PUBLIC_GOOGLE_SITE_VERIFICATION,
   },
+  // iOS PWA support — apple-touch-icon + status bar style
+  appleWebApp: {
+    capable: true,
+    title: "Cloudless",
+    statusBarStyle: "black-translucent",
+  },
+  icons: {
+    apple: [{ url: "/icons/icon-192.png", sizes: "192x192", type: "image/png" }],
+  },
   openGraph: {
     title: "Cloudless — Training & Portfolio Project",
     description:


### PR DESCRIPTION
## k3s rollout fix

**Root cause from diagnostic logs:** etcd revision 8490627, raft consensus taking 2–4s (expected <100ms) → API server reports 503 on /readyz → rollout never sees 200.

Secondary issue: `curl -k` on `/readyz` returns **401** (not 200) because k3s has anonymous-auth disabled — the probe was fundamentally broken.

**Changes:**
- Replace `curl /readyz` with `kubectl get --raw /readyz` — uses kubeconfig client cert, bypasses 401
- Add `etcdctl defrag` to SSH diagnostic step — compacts etcd history and restores I/O performance on SD card
- Increase poll limit 36 → 60 iterations (5 min) to accommodate post-defrag stabilization

## PWA improvements

- `layout.tsx`: add `appleWebApp` + apple icon meta for iOS PWA installability (iOS ignores manifest icons without `<meta name="apple-mobile-web-app-capable">`)
- Fix `lang: "el"` → `"en"` in both manifest files (name/short_name are English)
- Sync static manifest shortcut URLs with API route (`/services`, `/blog` — removes stale hash/query params)

---
_Generated by [Claude Code](https://claude.ai/code/session_013sTDMVEYibee8tbXxrwjzo)_