### PR TITLE
fix(k3s): force restart k3s after etcd defrag, widen readyz window to 20 min

### DIFF
--- a/.github/workflows/deploy-pi.yml
+++ b/.github/workflows/deploy-pi.yml
@@ -216,13 +216,10 @@ jobs:
                 --cert=/var/lib/rancher/k3s/server/tls/etcd/server-client.crt \
                 --key=/var/lib/rancher/k3s/server/tls/etcd/server-client.key \
                 2>/dev/null && echo "etcd defrag done" || echo "etcd defrag skipped (not embedded etcd or certs missing)"
-              echo "=== restart k3s if not active ==="
-              if ! systemctl is-active --quiet k3s; then
-                sudo systemctl restart k3s
-                echo "k3s restart triggered"
-              else
-                echo "k3s is active — no restart needed"
-              fi
+              echo "=== Restart k3s after defrag for clean etcd state ==="
+              sudo systemctl restart k3s
+              echo "k3s restarted — sleeping 30s for process to die and come back..."
+              sleep 30
             '
       - name: Wait for k3s /readyz (3x stable via kubectl)
         run: |
@@ -231,17 +228,17 @@ jobs:
           # k3s /readyz returns the string "ok" when all checks pass.
           wait_for_api() {
             local stable=0
-            for i in $(seq 1 60); do
+            for i in $(seq 1 120); do
               if kubectl get --raw /readyz --request-timeout=5s 2>/dev/null \
                   | grep -q 'ok'; then
                 stable=$((stable + 1))
-                echo "  ${i}/60 — /readyz ok (stable ${stable}/3)"
+                echo "  ${i}/120 — /readyz ok (stable ${stable}/3)"
                 if [ "$stable" -ge 3 ]; then
                   return 0
                 fi
               else
                 stable=0
-                echo "  ${i}/60 — /readyz not ready, waiting 5s..."
+                echo "  ${i}/120 — /readyz not ready, waiting 5s..."
               fi
               sleep 5
             done
@@ -252,7 +249,7 @@ jobs:
           if wait_for_api; then
             echo "k3s API stable — proceeding to rollout"
           else
-            echo "::error::k3s /readyz never returned 3x ok in 5 min — aborting"
+            echo "::error::k3s /readyz never returned 3x ok in 10 min — aborting"
             exit 1
           fi
       - name: Set image and roll out


### PR DESCRIPTION
## Summary

- Unconditionally restart k3s after etcd defrag (+ 30s sleep) so the API server starts clean before polling begins
- Widen the `/readyz` stability window from 60 → 120 iterations (5 min → 20 min max)

## Root cause

Run #317 failed: the 60-iteration poll ran for 5m56s without ever getting 3 consecutive `ok`. etcd was oscillating healthy/unhealthy every ~6s after defrag — SD card I/O bottleneck. Defrag without a restart leaves the in-memory etcd state unchanged; a restart after defrag lets it load from the compacted snapshot.

https://claude.ai/code/session_013sTDMVEYibee8tbXxrwjzo

---
_Generated by [Claude Code](https://claude.ai/code/session_013sTDMVEYibee8tbXxrwjzo)_