### PR TITLE
chore(deploy-pi): re-trigger after OIDC transient failure (run #319)

### DIFF
--- a/.github/workflows/deploy-pi.yml
+++ b/.github/workflows/deploy-pi.yml
@@ -258,4 +258,4 @@ jobs:
             ${{ env.K3S_DEPLOYMENT }}=${{ env.ECR_REGISTRY }}/${{ env.ECR_REPOSITORY }}:${{ needs.build-and-push.outputs.short_sha }} \
             -n ${{ env.K3S_NAMESPACE }}
           kubectl rollout status deployment/${{ env.K3S_DEPLOYMENT }} -n ${{ env.K3S_NAMESPACE }} --timeout=600s
-# re-triggered 2026-06-04T12:45Z — previous QEMU build stuck at 35min
+# re-triggered 2026-06-04T20:50Z — run #319 OIDC auth transient failure


### PR DESCRIPTION
Re-triggers deploy-pi.yml after run #319 failed at AWS OIDC step (transient failure, unrelated to k3s fixes).

This deploy carries the 600s rollout timeout fix from PR #657.

https://claude.ai/code/session_013sTDMVEYibee8tbXxrwjzo

---
_Generated by [Claude Code](https://claude.ai/code/session_013sTDMVEYibee8tbXxrwjzo)_