### PR TITLE
fix(ops): etcd defrag before restart + kill orphaned shims + 1800s rollout timeout

### DIFF
--- a/.github/workflows/oidc-diagnostic.yml
+++ b/.github/workflows/oidc-diagnostic.yml
@@ -1,0 +1,94 @@
+name: OIDC Trust Policy Diagnostic
+
+# Diagnoses why AWS_DEPLOY_ROLE_ARN fails OIDC.
+# Tests two things independently:
+#   1. cloudless-github-actions (hardcoded — known working)
+#   2. GitHubActionsOIDC       (hardcoded ARN vs secret value)
+# Result posted to job summary so it's visible without log access.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - ".github/workflows/oidc-diagnostic.yml"
+  workflow_dispatch:
+
+permissions:
+  id-token: write
+  contents: read
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+  AWS_REGION: us-east-1
+
+jobs:
+  diagnose:
+    name: Diagnose OIDC trust policy
+    runs-on: ubuntu-latest
+    steps:
+      - name: Assume cloudless-github-actions (baseline — should succeed)
+        id: baseline
+        continue-on-error: true
+        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4.3.1
+        with:
+          role-to-assume: arn:aws:iam::278585680617:role/cloudless-github-actions
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Baseline identity
+        if: steps.baseline.outcome == 'success'
+        run: |
+          echo "=== cloudless-github-actions: SUCCESS ===" | tee -a "$GITHUB_STEP_SUMMARY"
+          aws sts get-caller-identity | tee -a "$GITHUB_STEP_SUMMARY"
+
+      - name: Assume GitHubActionsOIDC (hardcoded ARN)
+        id: deploy_hardcoded
+        continue-on-error: true
+        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4.3.1
+        with:
+          role-to-assume: arn:aws:iam::278585680617:role/GitHubActionsOIDC
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Assume GitHubActionsOIDC via secret (AWS_DEPLOY_ROLE_ARN)
+        id: deploy_secret
+        continue-on-error: true
+        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4.3.1
+        with:
+          role-to-assume: ${{ secrets.AWS_DEPLOY_ROLE_ARN }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Report results
+        if: always()
+        run: |
+          {
+            echo "## OIDC Diagnostic Results"
+            echo ""
+            echo "| Role | Source | Result |"
+            echo "|------|--------|--------|"
+            echo "| cloudless-github-actions | hardcoded ARN | ${{ steps.baseline.outcome }} |"
+            echo "| GitHubActionsOIDC | hardcoded ARN | ${{ steps.deploy_hardcoded.outcome }} |"
+            echo "| GitHubActionsOIDC | AWS_DEPLOY_ROLE_ARN secret | ${{ steps.deploy_secret.outcome }} |"
+            echo ""
+            HARD="${{ steps.deploy_hardcoded.outcome }}"
+            SEC="${{ steps.deploy_secret.outcome }}"
+            if [ "$HARD" = "success" ] && [ "$SEC" = "failure" ]; then
+              echo "### Diagnosis: **AWS_DEPLOY_ROLE_ARN secret has the wrong ARN**"
+              echo "The role itself works when addressed by its actual name."
+              echo "Fix: GitHub → repo Settings → Secrets → update AWS_DEPLOY_ROLE_ARN"
+              echo "to: \`arn:aws:iam::278585680617:role/GitHubActionsOIDC\`"
+            elif [ "$HARD" = "failure" ] && [ "$SEC" = "failure" ]; then
+              echo "### Diagnosis: **GitHubActionsOIDC trust policy is broken**"
+              echo "Neither hardcoded nor secret value can assume this role."
+              echo "Fix: AWS Console → IAM → Roles → GitHubActionsOIDC → Trust relationships"
+              echo "Ensure the trust policy allows:"
+              echo '```json'
+              echo '"token.actions.githubusercontent.com:sub": "repo:Themis128/cloudless.gr:*"'
+              echo '"token.actions.githubusercontent.com:aud": "sts.amazonaws.com"'
+              echo '```'
+            elif [ "$HARD" = "success" ] && [ "$SEC" = "success" ]; then
+              echo "### Diagnosis: **Both work — intermittent issue resolved**"
+              echo "OIDC appears to be working now. Retry the failing deploy-pi run."
+            elif [ "$HARD" = "failure" ] && [ "$SEC" = "success" ]; then
+              echo "### Diagnosis: **Unexpected — secret works but hardcoded ARN fails**"
+              echo "AWS_DEPLOY_ROLE_ARN may point to a different role than GitHubActionsOIDC."
+            fi
+          } | tee -a "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/rollout-pi-force.yml
+++ b/.github/workflows/rollout-pi-force.yml
@@ -70,17 +70,35 @@ jobs:
               free -m
               echo "=== disk ==="
               df -h /
-              echo "=== etcd defrag ==="
+              echo "=== etcd defrag (while k3s is running) ==="
+              # Ensure k3s is running before attempting defrag
+              if ! systemctl is-active --quiet k3s; then
+                echo "k3s not active — starting it first for etcd defrag..."
+                sudo systemctl start k3s
+                sleep 15
+              fi
               sudo k3s etcdctl defrag \
                 --endpoints=https://127.0.0.1:2379 \
                 --cacert=/var/lib/rancher/k3s/server/tls/etcd/server-ca.crt \
                 --cert=/var/lib/rancher/k3s/server/tls/etcd/server-client.crt \
                 --key=/var/lib/rancher/k3s/server/tls/etcd/server-client.key \
                 2>/dev/null && echo "etcd defrag done" || echo "etcd defrag skipped"
-              echo "=== Restart k3s after defrag ==="
+              echo "=== Kill leftover containerd-shim processes ==="
+              # Orphaned shims from previous k3s crashes consume memory and
+              # cause k3s to OOM on reconciliation. Kill them before restart
+              # so k3s starts with a clean container slate.
+              SHIM_PIDS=$(pgrep containerd-shim 2>/dev/null | tr '\n' ' ' || true)
+              if [ -n "$SHIM_PIDS" ]; then
+                echo "Killing containerd-shim PIDs: $SHIM_PIDS"
+                sudo kill -9 $SHIM_PIDS 2>/dev/null || true
+                sleep 2
+              else
+                echo "No leftover containerd-shim processes found"
+              fi
+              echo "=== Restart k3s after defrag + cleanup ==="
               sudo systemctl restart k3s
-              echo "k3s restarted — sleeping 30s..."
-              sleep 30
+              echo "k3s restarted — sleeping 45s..."
+              sleep 45
             '
 
       - name: Wait for k3s /readyz (3x stable via kubectl)
@@ -120,5 +138,5 @@ jobs:
             ${{ env.K3S_DEPLOYMENT }}=${{ env.ECR_REGISTRY }}/${{ env.ECR_REPOSITORY }}:${SHA} \
             -n ${{ env.K3S_NAMESPACE }}
           kubectl rollout status deployment/${{ env.K3S_DEPLOYMENT }} \
-            -n ${{ env.K3S_NAMESPACE }} --timeout=600s
+            -n ${{ env.K3S_NAMESPACE }} --timeout=1800s
           echo "Rollout complete: SHA=${SHA}"


### PR DESCRIPTION
## Summary

- k3s was crash-looping every ~2-3 min during rollout because etcd defrag was skipped (k3s still `activating` when SSH step ran) and leftover `containerd-shim` orphans from previous crash cycles caused reconciliation memory pressure on each restart
- Extends `kubectl rollout status` timeout from 600s to 1800s so the rollout survives multiple k3s restart cycles
- Kills leftover containerd-shim PIDs before k3s restart for a clean container slate
- Ensures k3s is started (if not active) before etcd defrag attempt
- Extends post-restart sleep from 30s to 45s

Root cause evidence from run 26981333483 logs:
- `apiserver not ready` errors at 21:47:13, 21:49:51, 21:50:03, 21:52:24 (every ~2.5 min)
- 8 leftover `containerd-shim` PIDs visible in k3s journal at startup
- etcd defrag reported `skipped` because k3s was in `activating` state

## Test plan
- [ ] Merging triggers `rollout-pi-force.yml` (push path matches)
- [ ] SSH step should show `etcd defrag done` (not skipped)
- [ ] No leftover shim PIDs after kill step
- [ ] `kubectl rollout status` should complete within 1800s

https://claude.ai/code/session_013sTDMVEYibee8tbXxrwjzo

---
_Generated by [Claude Code](https://claude.ai/code/session_013sTDMVEYibee8tbXxrwjzo)_