### PR TITLE
fix(rollout-pi-force): scale 0→1 instead of rollout-restart to avoid OOM

### DIFF
--- a/.github/workflows/rollout-pi-force.yml
+++ b/.github/workflows/rollout-pi-force.yml
@@ -166,8 +166,7 @@ jobs:
           SHA="${{ github.event.inputs.sha || env.DEFAULT_ROLLOUT_SHA }}"
           echo "Rolling out image tag: ${SHA}"
 
-          # Retry loop: etcd may still be settling after startup maintenance
-          # (compact / defrag / alarm-disarm). Retry up to 3× with 60s gaps.
+          # Retry loop: etcd may still be settling after startup maintenance.
           for attempt in 1 2 3; do
             echo "=== kubectl attempt ${attempt}/3 ==="
 
@@ -176,8 +175,6 @@ jobs:
               -p '{"spec":{"progressDeadlineSeconds":3600}}' \
             && kubectl set image deployment/${{ env.K3S_DEPLOYMENT }} \
                  ${{ env.K3S_DEPLOYMENT }}=${{ env.ECR_REGISTRY }}/${{ env.ECR_REPOSITORY }}:${SHA} \
-                 -n ${{ env.K3S_NAMESPACE }} \
-            && kubectl rollout restart deployment/${{ env.K3S_DEPLOYMENT }} \
                  -n ${{ env.K3S_NAMESPACE }} \
             && break
 
@@ -189,6 +186,21 @@ jobs:
               exit 1
             fi
           done
+
+          # Scale to 0 before image pull: stops the running Next.js pod (frees
+          # ~500 MB Pi RAM) so containerd can pull + start the new image without
+          # OOM-killing k3s. rollout-restart (old+new overlap) caused k3s to
+          # crash-loop for 30 min in run #4 (apiserver not ready, pod stuck
+          # Terminating). Sequential scale 0→1 avoids that entirely.
+          echo "Scaling down to 0 to free RAM before image pull..."
+          kubectl scale deployment/${{ env.K3S_DEPLOYMENT }} \
+            -n ${{ env.K3S_NAMESPACE }} --replicas=0
+          echo "Sleeping 60s for old pod to terminate and RAM to settle..."
+          sleep 60
+
+          echo "Scaling back up to 1 with new image..."
+          kubectl scale deployment/${{ env.K3S_DEPLOYMENT }} \
+            -n ${{ env.K3S_NAMESPACE }} --replicas=1
 
           kubectl rollout status deployment/${{ env.K3S_DEPLOYMENT }} \
             -n ${{ env.K3S_NAMESPACE }} --timeout=1800s


### PR DESCRIPTION
## Root cause (Run #4)

`rollout restart` runs old and new pods simultaneously during the transition window. On the Pi, pulling the large arm64 image while the old Next.js pod (~500 MB RSS) is still alive triggers OOM. k3s crash-loops (`apiserver not ready`), the old pod stays stuck in `Terminating` for 30 min, `rollout status` times out.

## Fix

Drop `rollout restart`. After `set image` succeeds:
1. `scale --replicas=0` → terminates old pod, frees ~500 MB RAM  
2. `sleep 60s` → lets containerd/cgroups clean up and RAM settle  
3. `scale --replicas=1` → fresh pod start with full RAM headroom for image pull + Next.js startup

Sequential 0→1 avoids the old/new pod memory overlap entirely.

https://claude.ai/code/session_013sTDMVEYibee8tbXxrwjzo

---
_Generated by [Claude Code](https://claude.ai/code/session_013sTDMVEYibee8tbXxrwjzo)_