### PR TITLE
fix(rollout-pi-force): stop cloudless pod before k3s restart + scale to 0

### DIFF
--- a/.github/workflows/rollout-pi-force.yml
+++ b/.github/workflows/rollout-pi-force.yml
@@ -166,8 +166,7 @@ jobs:
           SHA="${{ github.event.inputs.sha || env.DEFAULT_ROLLOUT_SHA }}"
           echo "Rolling out image tag: ${SHA}"
 
-          # Retry loop: etcd may still be settling after startup maintenance
-          # (compact / defrag / alarm-disarm). Retry up to 3× with 60s gaps.
+          # Retry loop: etcd may still be settling after startup maintenance.
           for attempt in 1 2 3; do
             echo "=== kubectl attempt ${attempt}/3 ==="
 
@@ -176,8 +175,6 @@ jobs:
               -p '{"spec":{"progressDeadlineSeconds":3600}}' \
             && kubectl set image deployment/${{ env.K3S_DEPLOYMENT }} \
                  ${{ env.K3S_DEPLOYMENT }}=${{ env.ECR_REGISTRY }}/${{ env.ECR_REPOSITORY }}:${SHA} \
-                 -n ${{ env.K3S_NAMESPACE }} \
-            && kubectl rollout restart deployment/${{ env.K3S_DEPLOYMENT }} \
                  -n ${{ env.K3S_NAMESPACE }} \
             && break
 
@@ -189,6 +186,21 @@ jobs:
               exit 1
             fi
           done
+
+          # Scale to 0 before image pull: stops the running Next.js pod (frees
+          # ~500 MB Pi RAM) so containerd can pull + start the new image without
+          # OOM-killing k3s. rollout-restart (old+new overlap) caused k3s to
+          # crash-loop for 30 min in run #4 (apiserver not ready, pod stuck
+          # Terminating). Sequential scale 0→1 avoids that entirely.
+          echo "Scaling down to 0 to free RAM before image pull..."
+          kubectl scale deployment/${{ env.K3S_DEPLOYMENT }} \
+            -n ${{ env.K3S_NAMESPACE }} --replicas=0
+          echo "Sleeping 60s for old pod to terminate and RAM to settle..."
+          sleep 60
+
+          echo "Scaling back up to 1 with new image..."
+          kubectl scale deployment/${{ env.K3S_DEPLOYMENT }} \
+            -n ${{ env.K3S_NAMESPACE }} --replicas=1
 
           kubectl rollout status deployment/${{ env.K3S_DEPLOYMENT }} \
             -n ${{ env.K3S_NAMESPACE }} --timeout=1800s

--- a/.github/workflows/rollout-pi-force.yml
+++ b/.github/workflows/rollout-pi-force.yml
@@ -95,6 +95,11 @@ jobs:
               else
                 echo "No leftover containerd-shim processes found"
               fi
+              echo "=== Stop cloudless app containers before restart (free RAM) ==="
+              sudo crictl ps 2>/dev/null | grep cloudless | awk '{print $1}' \
+                | xargs -r sudo crictl stop --timeout 10 2>/dev/null || true
+              sudo crictl ps -a 2>/dev/null | grep cloudless | awk '{print $1}' \
+                | xargs -r sudo crictl rm -f 2>/dev/null || true
               echo "=== Restart k3s after defrag + cleanup ==="
               sudo systemctl restart k3s
               echo "k3s restarted — waiting 30s for etcd to initialise..."
@@ -130,6 +135,12 @@ jobs:
               fi
               echo "Sleeping 15s after etcd maintenance..."
               sleep 15
+              echo "=== Scale cloudless to 0 replicas (free RAM for /readyz polling) ==="
+              sudo kubectl --kubeconfig=/etc/rancher/k3s/k3s.yaml \
+                scale deployment/cloudless -n cloudless --replicas=0 \
+                2>/dev/null && echo "scale to 0: done" || echo "scale to 0: skipped (k3s not ready)"
+              echo "Sleeping 20s for pod to terminate..."
+              sleep 20
             '
 
       - name: Wait for k3s /readyz (3x stable via kubectl)


### PR DESCRIPTION
## Root cause (Run #5)

k3s crash-loops during `/readyz` polling. After `systemctl restart k3s`, k3s reconciles the cloudless deployment (replicas=1) and immediately starts the ~500 MB Next.js pod. k3s + running pod = OOM kill → k3s restarts → repeat. `/readyz` gets 2/3 "ok" then drops — never reaches 3 consecutive.

## Two fixes (both in the SSH diagnostic step)

**1. `crictl stop/rm` cloudless containers before k3s restart**  
k3s starts with no running pods so it doesn't immediately hit OOM on first reconciliation.

**2. `kubectl scale --replicas=0` via Pi's local kubeconfig after etcd maintenance**  
Even if k3s re-created the pod during the restart window, this terminates it before the `/readyz` polling window begins, giving k3s free RAM to stay stable throughout step 6.

Step 7 (`scale --replicas=1`) was already fixed in PR #665 and remains in place.

https://claude.ai/code/session_013sTDMVEYibee8tbXxrwjzo

---
_Generated by [Claude Code](https://claude.ai/code/session_013sTDMVEYibee8tbXxrwjzo)_