### PR TITLE
fix(rollout-pi-force): poll /readyz after scale-to-0 instead of blind sleep

### DIFF
--- a/.github/workflows/rollout-pi-force.yml
+++ b/.github/workflows/rollout-pi-force.yml
@@ -206,8 +206,26 @@ jobs:
           echo "Scaling down to 0 to free RAM before image pull..."
           kubectl scale deployment/${{ env.K3S_DEPLOYMENT }} \
             -n ${{ env.K3S_NAMESPACE }} --replicas=0
-          echo "Sleeping 60s for old pod to terminate and RAM to settle..."
-          sleep 60
+
+          # Poll /readyz instead of blind sleep: k3s can crash after the
+          # scale-to-0 write (etcd + reconciliation pressure). Wait up to
+          # 3 min for 3× stable /readyz before issuing scale-to-1.
+          echo "Waiting for k3s to stay stable after scale-to-0 (up to 3 min)..."
+          stable=0
+          for i in $(seq 1 36); do
+            if kubectl get --raw /readyz --request-timeout=5s 2>/dev/null \
+                | grep -q 'ok'; then
+              stable=$((stable + 1))
+              echo "  ${i}/36 — /readyz ok (stable ${stable}/3)"
+              if [ "$stable" -ge 3 ]; then
+                break
+              fi
+            else
+              stable=0
+              echo "  ${i}/36 — k3s not ready, waiting 5s..."
+            fi
+            sleep 5
+          done
 
           echo "Scaling back up to 1 with new image..."
           kubectl scale deployment/${{ env.K3S_DEPLOYMENT }} \


### PR DESCRIPTION
## Root cause (Run #6)

`kubectl scale --replicas=0` succeeded, but k3s crashed during the 60s blind sleep (etcd/reconciliation pressure after the write). `kubectl scale --replicas=1` at the end of the sleep got `connection refused`.

## Fix

Replace `sleep 60` with an active `/readyz` poll loop (up to 3 min, requires 3× consecutive "ok") before issuing `scale --replicas=1`. This is the same pattern already used in step 6. Ensures k3s is genuinely stable before we ask it to schedule the new pod.

https://claude.ai/code/session_013sTDMVEYibee8tbXxrwjzo

---
_Generated by [Claude Code](https://claude.ai/code/session_013sTDMVEYibee8tbXxrwjzo)_