### PR TITLE
chore: trigger cluster doctor — k3s crash check 2026-06-05

### DIFF
--- a/.github/workflows/cluster-doctor.yml
+++ b/.github/workflows/cluster-doctor.yml
@@ -4,6 +4,7 @@ name: Cluster doctor (read-only diagnostics)
 # re-triggered 2026-06-03T00:30Z — post-k3s-restart verification (cluster recovered)
 # re-triggered 2026-06-03T01:2xZ — pi unresponsive (SSH timeout × 3); checking if recovered
 # re-triggered 2026-06-03 — checking stuck Pi runners (deploy pending since 10:13Z)
+# re-triggered 2026-06-05 — k3s crash-looped on omv 2026-06-04; checking current state
 
 # Read-only visibility into the omv k3s cluster from CI. Runs scripts/cluster-
 # doctor.sh over Tailscale + KUBECONFIG_B64 and posts the snapshot as a comment


### PR DESCRIPTION
Triggers the cluster-doctor workflow to check k3s state after the crash-loop seen on omv on 2026-06-04.\n\nSee issue #382 for the last snapshot (k3s exiting status=1, port 6443 never came up)."

---
_Generated by [Claude Code](https://claude.ai/code/session_01LV4AdXEE9ESwFWFKXybHko)_