### PR TITLE
fix(ci): k3s recovery — add journal + disk diagnostics before restart

### DIFF
--- a/.github/workflows/k3s-restart.yml
+++ b/.github/workflows/k3s-restart.yml
@@ -43,8 +43,36 @@ jobs:
           echo "=== k3s status BEFORE restart ===" | tee k3s.log
           ssh -i ~/.ssh/id_ed25519 -o StrictHostKeyChecking=no -o ConnectTimeout=10 \
             "$PI_USER@$PI_HOST" \
-            "sudo systemctl status k3s --no-pager 2>&1 | head -15; \
+            "sudo systemctl status k3s --no-pager 2>&1 | head -20; \
              echo ''; ss -tlnp 2>/dev/null | grep 6443 || echo '(6443 not listening)'" \
+            2>&1 | tee -a k3s.log || true
+
+      - name: Get k3s crash logs
+        run: |
+          echo "" | tee -a k3s.log
+          echo "=== k3s journal (last 80 lines) ===" | tee -a k3s.log
+          ssh -i ~/.ssh/id_ed25519 -o StrictHostKeyChecking=no -o ConnectTimeout=10 \
+            "$PI_USER@$PI_HOST" \
+            "sudo journalctl -xeu k3s.service --no-pager --lines=80 2>&1" \
+            2>&1 | tee -a k3s.log || true
+
+      - name: Check data disk
+        run: |
+          echo "" | tee -a k3s.log
+          echo "=== data disk / mount check ===" | tee -a k3s.log
+          ssh -i ~/.ssh/id_ed25519 -o StrictHostKeyChecking=no -o ConnectTimeout=10 \
+            "$PI_USER@$PI_HOST" \
+            "df -h /srv 2>&1 || echo '(df failed)'; \
+             echo ''; \
+             ls -la /srv/ 2>&1 | head -10 || echo '(ls /srv failed)'; \
+             echo ''; \
+             DATA_DIR=\$(ls -d /srv/dev-disk-by-uuid-*/k3s 2>/dev/null | head -1); \
+             if [ -n \"\$DATA_DIR\" ]; then
+               echo \"data dir: \$DATA_DIR\";
+               ls \"\$DATA_DIR\" 2>&1 | head -10;
+             else
+               echo 'WARNING: k3s data dir not found under /srv/dev-disk-by-uuid-*/';
+             fi" \
             2>&1 | tee -a k3s.log || true
 
       - name: Restart k3s
@@ -73,7 +101,7 @@ jobs:
           echo "=== k3s status AFTER restart ===" | tee -a k3s.log
           ssh -i ~/.ssh/id_ed25519 -o StrictHostKeyChecking=no -o ConnectTimeout=10 \
             "$PI_USER@$PI_HOST" \
-            "sudo systemctl status k3s --no-pager 2>&1 | head -15; \
+            "sudo systemctl status k3s --no-pager 2>&1 | head -20; \
              echo ''; \
              sudo kubectl --kubeconfig /etc/rancher/k3s/k3s.yaml get nodes 2>&1 | head -10" \
             2>&1 | tee -a k3s.log || true
@@ -88,4 +116,4 @@ jobs:
             cat k3s.log 2>/dev/null || echo "(no log)"
             echo '```'
           } | gh issue comment 382 --repo "$GITHUB_REPOSITORY" --body-file -
-# re-triggered 2026-06-04
+# re-triggered 2026-06-05 — API server down since 2026-06-04; added journal + disk checks


### PR DESCRIPTION
k3s on `omv` has been crash-looping since 2026-06-04 (~14:43 EEST) with `status=1/FAILURE` in under 500ms. The previous restart attempt also failed. This is not OOM — it crashes too fast.\n\nThis PR adds two new SSH steps before the restart attempt:\n- **Journal logs** (`journalctl -xeu k3s --lines=80`) to see the actual crash reason\n- **Data disk check** (`df -h /srv`, `ls` of the k3s data dir under `/srv/dev-disk-by-uuid-*/k3s`) to detect unmounted/missing disk\n\nMerging this will immediately trigger the workflow and post results to #382.

---
_Generated by [Claude Code](https://claude.ai/code/session_01LV4AdXEE9ESwFWFKXybHko)_