### PR TITLE
feat(ci): healthchecks.io cluster dead-man's-switch + post-recovery doctor

### DIFF
--- a/.github/workflows/cluster-doctor.yml
+++ b/.github/workflows/cluster-doctor.yml
@@ -5,6 +5,7 @@ name: Cluster doctor (read-only diagnostics)
 # re-triggered 2026-06-03T01:2xZ — pi unresponsive (SSH timeout × 3); checking if recovered
 # re-triggered 2026-06-03 — checking stuck Pi runners (deploy pending since 10:13Z)
 # re-triggered 2026-06-05 — k3s crash-looped on omv 2026-06-04; checking current state
+# re-triggered 2026-06-05T06:40Z — k3s recovered via restart workflow; full pod health check
 
 # Read-only visibility into the omv k3s cluster from CI. Runs scripts/cluster-
 # doctor.sh over Tailscale + KUBECONFIG_B64 and posts the snapshot as a comment

--- a/.github/workflows/cluster-healthcheck.yml
+++ b/.github/workflows/cluster-healthcheck.yml
@@ -1,0 +1,65 @@
+name: Cluster health ping (healthchecks.io)
+
+# Pings healthchecks.io every 10 minutes so a dead-man's alert fires if the
+# k3s API server on omv stops responding. The check URL is stored as the repo
+# secret HEALTHCHECKS_CLUSTER_URL (e.g. https://hc-ping.com/<uuid>).
+#
+# healthchecks.io check config:
+#   Period:  10 min
+#   Grace:   5 min  → alert fires after 15 min of silence
+#   Alert:   email / Slack (configure in healthchecks.io dashboard)
+#
+# To set up the secret: go to healthchecks.io, create a new check with
+# period=10min, copy the ping URL, and add it as repo secret
+# HEALTHCHECKS_CLUSTER_URL.
+
+on:
+  schedule:
+    - cron: "*/10 * * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  ping:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    env:
+      HC_URL: ${{ secrets.HEALTHCHECKS_CLUSTER_URL }}
+      PI_HOST: "100.113.41.119"
+    steps:
+      - name: Skip if secret not configured
+        if: ${{ env.HC_URL == '' }}
+        run: |
+          echo "HEALTHCHECKS_CLUSTER_URL is not set — skipping ping."
+          exit 0
+
+      - name: Connect to tailnet
+        if: ${{ env.HC_URL != '' }}
+        uses: tailscale/github-action@0263d9e6d793eaefcf1de98ff7fde47abe6664d3 # v3.2.4
+        with:
+          authkey: ${{ secrets.TS_AUTHKEY }}
+
+      - name: Ping /start
+        if: ${{ env.HC_URL != '' }}
+        run: curl -fsS --retry 3 --max-time 10 "${HC_URL}/start" > /dev/null || true
+
+      - name: Check cluster reachability (port 6443)
+        if: ${{ env.HC_URL != '' }}
+        id: check
+        run: |
+          if nc -zv -w5 "$PI_HOST" 6443 2>/dev/null; then
+            echo "exit_code=0" >> "$GITHUB_OUTPUT"
+          else
+            echo "exit_code=1" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Ping result (0=up, 1=down)
+        if: ${{ env.HC_URL != '' }}
+        run: |
+          EXIT="${{ steps.check.outputs.exit_code }}"
+          curl -fsS --retry 3 --max-time 10 "${HC_URL}/${EXIT}" > /dev/null || true
+          if [ "$EXIT" = "1" ]; then
+            echo "::warning::Cluster port 6443 is unreachable — failure ping sent to healthchecks.io"
+          fi

--- a/.github/workflows/k3s-restart.yml
+++ b/.github/workflows/k3s-restart.yml
@@ -43,8 +43,36 @@ jobs:
           echo "=== k3s status BEFORE restart ===" | tee k3s.log
           ssh -i ~/.ssh/id_ed25519 -o StrictHostKeyChecking=no -o ConnectTimeout=10 \
             "$PI_USER@$PI_HOST" \
-            "sudo systemctl status k3s --no-pager 2>&1 | head -15; \
+            "sudo systemctl status k3s --no-pager 2>&1 | head -20; \
              echo ''; ss -tlnp 2>/dev/null | grep 6443 || echo '(6443 not listening)'" \
+            2>&1 | tee -a k3s.log || true
+
+      - name: Get k3s crash logs
+        run: |
+          echo "" | tee -a k3s.log
+          echo "=== k3s journal (last 80 lines) ===" | tee -a k3s.log
+          ssh -i ~/.ssh/id_ed25519 -o StrictHostKeyChecking=no -o ConnectTimeout=10 \
+            "$PI_USER@$PI_HOST" \
+            "sudo journalctl -xeu k3s.service --no-pager --lines=80 2>&1" \
+            2>&1 | tee -a k3s.log || true
+
+      - name: Check data disk
+        run: |
+          echo "" | tee -a k3s.log
+          echo "=== data disk / mount check ===" | tee -a k3s.log
+          ssh -i ~/.ssh/id_ed25519 -o StrictHostKeyChecking=no -o ConnectTimeout=10 \
+            "$PI_USER@$PI_HOST" \
+            "df -h /srv 2>&1 || echo '(df failed)'; \
+             echo ''; \
+             ls -la /srv/ 2>&1 | head -10 || echo '(ls /srv failed)'; \
+             echo ''; \
+             DATA_DIR=\$(ls -d /srv/dev-disk-by-uuid-*/k3s 2>/dev/null | head -1); \
+             if [ -n \"\$DATA_DIR\" ]; then
+               echo \"data dir: \$DATA_DIR\";
+               ls \"\$DATA_DIR\" 2>&1 | head -10;
+             else
+               echo 'WARNING: k3s data dir not found under /srv/dev-disk-by-uuid-*/';
+             fi" \
             2>&1 | tee -a k3s.log || true
 
       - name: Restart k3s
@@ -73,7 +101,7 @@ jobs:
           echo "=== k3s status AFTER restart ===" | tee -a k3s.log
           ssh -i ~/.ssh/id_ed25519 -o StrictHostKeyChecking=no -o ConnectTimeout=10 \
             "$PI_USER@$PI_HOST" \
-            "sudo systemctl status k3s --no-pager 2>&1 | head -15; \
+            "sudo systemctl status k3s --no-pager 2>&1 | head -20; \
              echo ''; \
              sudo kubectl --kubeconfig /etc/rancher/k3s/k3s.yaml get nodes 2>&1 | head -10" \
             2>&1 | tee -a k3s.log || true
@@ -88,4 +116,4 @@ jobs:
             cat k3s.log 2>/dev/null || echo "(no log)"
             echo '```'
           } | gh issue comment 382 --repo "$GITHUB_REPOSITORY" --body-file -
-# re-triggered 2026-06-04
+# re-triggered 2026-06-05 — API server down since 2026-06-04; added journal + disk checks


### PR DESCRIPTION
## Summary

- **New**: `cluster-healthcheck.yml` — 10-min cron pings healthchecks.io with k3s port 6443 reachability. Sends `/start` then `/<exit_code>` (0=up, 1=down). Alert fires after 15 min silence (10 min period + 5 min grace). Skips gracefully if `HEALTHCHECKS_CLUSTER_URL` secret is not yet set.
- **Trigger**: `cluster-doctor.yml` updated to run a post-recovery pod health snapshot now that k3s is back up.

## k3s incident summary (2026-06-04 → 2026-06-05)

k3s was crash-looping: etcd reconciled OK but API server failed to bind on 6443 after an unclean prior stop left containerd-shim processes in the cgroup. `systemctl restart k3s` via the k3s-restart workflow cleared it at 06:36Z. Both nodes now Ready.

## Human action required

Add repo secret `HEALTHCHECKS_CLUSTER_URL` = `https://hc-ping.com/<uuid>` (create the check at healthchecks.io with period=10min, grace=5min, then copy the ping URL).

## Test plan
- [ ] Cluster-doctor run posts pod health snapshot to issue #382
- [ ] `cluster-healthcheck.yml` first cron fires within 10 min and pings healthchecks.io
- [ ] Human adds `HEALTHCHECKS_CLUSTER_URL` secret to activate monitoring

---
_Generated by [Claude Code](https://claude.ai/code/session_01LV4AdXEE9ESwFWFKXybHko)_