### PR TITLE
fix(ci): k3s-restart — reset-failed + fuser 6443 + 30s stability check

### DIFF
--- a/.github/workflows/k3s-restart.yml
+++ b/.github/workflows/k3s-restart.yml
@@ -81,7 +81,9 @@ jobs:
           echo "=== restarting k3s ===" | tee -a k3s.log
           ssh -i ~/.ssh/id_ed25519 -o StrictHostKeyChecking=no -o ConnectTimeout=10 \
             "$PI_USER@$PI_HOST" \
-            "sudo systemctl restart k3s 2>&1; echo restart_exit=\$?" \
+            "sudo systemctl reset-failed k3s 2>/dev/null || true; \
+             sudo fuser -k 6443/tcp 2>/dev/null || true; \
+             sudo systemctl restart k3s 2>&1; echo restart_exit=\$?" \
             2>&1 | tee -a k3s.log
 
       - name: Wait for API server to become healthy
@@ -106,6 +108,21 @@ jobs:
              sudo kubectl --kubeconfig /etc/rancher/k3s/k3s.yaml get nodes 2>&1 | head -10" \
             2>&1 | tee -a k3s.log || true
 
+      - name: Stability check (30s post-restart)
+        run: |
+          sleep 30
+          echo "" | tee -a k3s.log
+          echo "=== stability check (30s after restart) ===" | tee -a k3s.log
+          if nc -zv -w3 "$PI_HOST" 6443 2>/dev/null; then
+            echo "STABLE: port 6443 still up after 30s" | tee -a k3s.log
+          else
+            echo "UNSTABLE: port 6443 down again — journal follows:" | tee -a k3s.log
+            ssh -i ~/.ssh/id_ed25519 -o StrictHostKeyChecking=no -o ConnectTimeout=10 \
+              "$PI_USER@$PI_HOST" \
+              "sudo journalctl -xeu k3s.service --no-pager --lines=40 2>&1" \
+              2>&1 | tee -a k3s.log || true
+          fi
+
       - name: Post result to tracking issue
         if: always()
         run: |
@@ -117,3 +134,4 @@ jobs:
             echo '```'
           } | gh issue comment 382 --repo "$GITHUB_REPOSITORY" --body-file -
 # re-triggered 2026-06-05 — API server down since 2026-06-04; added journal + disk checks
+# re-triggered 2026-06-05T07:00Z — k3s crash-looped again 16min after restart; adding fuser+reset-failed+30s stability check


### PR DESCRIPTION
## Summary

k3s crashed again 16 minutes after the 06:36Z restart. The `Restart=always` watchdog stopped firing (likely hit systemd's start-limit burst). This adds three pre/post steps to the restart workflow:

- `systemctl reset-failed k3s` — clears any start-limit state so systemd will restart the service again
- `fuser -k 6443/tcp` — evicts anything that might be holding the port after the previous instance exits (causing the next start to fail with "connection refused to self")
- 30-second stability check — if 6443 drops again within 30s of the restart, capture the crash journal immediately to diagnose what kills the API server during operation

## Root cause theory

The k3s API server exits cleanly (code 0) rather than crashing hard. This means `Restart=always` should pick it up — but if restarts happen fast enough to hit the default start-limit (e.g. 10 restarts in 5 min), systemd marks the unit failed and stops retrying. `reset-failed` clears that state before each manual restart so the cycle can begin fresh.

## Test plan
- [ ] Workflow triggers from this merge, restarts k3s
- [ ] 30-second stability check reports STABLE or captures crash journal
- [ ] Issue #382 gets the post-restart snapshot

---
_Generated by [Claude Code](https://claude.ai/code/session_01LV4AdXEE9ESwFWFKXybHko)_