### PR TITLE
fix(ci): stop Keycloak OOM loop, run etcd defrag, guard k3s-restart fuser

### DIFF
--- a/.github/workflows/etcd-defrag-now.yml
+++ b/.github/workflows/etcd-defrag-now.yml
@@ -1,0 +1,93 @@
+name: etcd defrag (one-shot)
+
+# Runs etcd defrag + compact on the omv control-plane node via Tailscale + SSH.
+# Use when etcd operations are slow (>100ms latency in k3s journal) or after a
+# k3s crash to reduce db fragmentation on the Pi SD card.
+# Posts before/after endpoint status to tracking issue #382.
+#
+# TLS paths for k3s embedded etcd (same as rollout-pi-force.yml):
+#   /var/lib/rancher/k3s/server/tls/etcd/server-ca.crt
+#   /var/lib/rancher/k3s/server/tls/etcd/server-client.crt
+#   /var/lib/rancher/k3s/server/tls/etcd/server-client.key
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - ".github/workflows/etcd-defrag-now.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  defrag:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    env:
+      GH_TOKEN: ${{ github.token }}
+      PI_HOST: "100.113.41.119"
+      PI_USER: "tbaltzakis"
+    steps:
+      - name: Connect to tailnet
+        uses: tailscale/github-action@0263d9e6d793eaefcf1de98ff7fde47abe6664d3 # v3.2.4
+        with:
+          authkey: ${{ secrets.TS_AUTHKEY }}
+
+      - name: Install SSH key
+        run: |
+          mkdir -p ~/.ssh
+          printf '%s\n' "${{ secrets.OMV_SSH_KEY }}" > ~/.ssh/id_ed25519
+          chmod 600 ~/.ssh/id_ed25519
+          ssh-keyscan -H "$PI_HOST" >> ~/.ssh/known_hosts 2>/dev/null || true
+
+      - name: Run etcd defrag
+        run: |
+          ssh -i ~/.ssh/id_ed25519 -o StrictHostKeyChecking=no -o ConnectTimeout=15 \
+            "$PI_USER@$PI_HOST" bash <<'REMOTE'
+          set -e
+          ETCD_EP="https://127.0.0.1:2379"
+          ETCD_CA="/var/lib/rancher/k3s/server/tls/etcd/server-ca.crt"
+          ETCD_CRT="/var/lib/rancher/k3s/server/tls/etcd/server-client.crt"
+          ETCD_KEY="/var/lib/rancher/k3s/server/tls/etcd/server-client.key"
+          ETCDCTL="sudo k3s etcdctl --endpoints=$ETCD_EP --cacert=$ETCD_CA --cert=$ETCD_CRT --key=$ETCD_KEY"
+
+          echo "=== endpoint status BEFORE ==="
+          $ETCDCTL endpoint status -w table 2>&1 || echo "(status failed)"
+
+          echo ""
+          echo "=== compact to current revision ==="
+          REV=$($ETCDCTL endpoint status --write-out=json 2>/dev/null \
+            | grep -o '"revision":[0-9]*' | head -1 | cut -d: -f2 || echo "")
+          if [ -n "$REV" ] && [ "$REV" -gt 0 ] 2>/dev/null; then
+            echo "compacting to revision $REV"
+            $ETCDCTL compact "$REV" 2>&1 && echo "compact done" || echo "compact skipped"
+          else
+            echo "could not determine revision — skipping compact"
+          fi
+
+          echo ""
+          echo "=== defrag ==="
+          $ETCDCTL defrag 2>&1 && echo "defrag done" || echo "defrag failed"
+
+          echo ""
+          echo "=== disarm NOSPACE alarm (if any) ==="
+          $ETCDCTL alarm disarm 2>&1 || echo "(no alarm to disarm)"
+
+          echo ""
+          echo "=== endpoint status AFTER ==="
+          $ETCDCTL endpoint status -w table 2>&1 || echo "(status failed)"
+          REMOTE
+          2>&1 | tee defrag.log
+
+      - name: Post result to tracking issue
+        if: always()
+        run: |
+          {
+            echo "# etcd defrag — $(date -u '+%Y-%m-%d %H:%M:%SZ')"
+            echo ""
+            echo '```'
+            cat defrag.log 2>/dev/null || echo "(no log)"
+            echo '```'
+          } | gh issue comment 382 --repo "$GITHUB_REPOSITORY" --body-file -

--- a/.github/workflows/k3s-restart.yml
+++ b/.github/workflows/k3s-restart.yml
@@ -79,10 +79,17 @@ jobs:
         run: |
           echo "" | tee -a k3s.log
           echo "=== restarting k3s ===" | tee -a k3s.log
+          # Only evict stale port holder when 6443 is actually down — never kill a running k3s.
+          if nc -zv -w3 "$PI_HOST" 6443 2>/dev/null; then
+            echo "(port 6443 is already up — skipping fuser, doing clean restart)" | tee -a k3s.log
+            FUSER_CMD="echo '(fuser skipped)'"
+          else
+            FUSER_CMD="sudo fuser -k 6443/tcp 2>/dev/null || true"
+          fi
           ssh -i ~/.ssh/id_ed25519 -o StrictHostKeyChecking=no -o ConnectTimeout=10 \
             "$PI_USER@$PI_HOST" \
             "sudo systemctl reset-failed k3s 2>/dev/null || true; \
-             sudo fuser -k 6443/tcp 2>/dev/null || true; \
+             $FUSER_CMD; \
              sudo systemctl restart k3s 2>&1; echo restart_exit=\$?" \
             2>&1 | tee -a k3s.log
 

--- a/.github/workflows/keycloak-scale-down.yml
+++ b/.github/workflows/keycloak-scale-down.yml
@@ -1,0 +1,70 @@
+name: Keycloak scale-down (stop OOM loop)
+
+# Scales Keycloak and postgres to 0 replicas and deletes the in-cluster
+# autoheal CronJob that would otherwise fight a manual scale-down.
+# Triggered by pushing a change to this file.
+#
+# This is REVERSIBLE — it does not delete the namespace or any data.
+# To fully decommission Keycloak (irreversible), use decommission-keycloak.yml
+# via workflow_dispatch with confirmation="decommission".
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - ".github/workflows/keycloak-scale-down.yml"
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  scale-down:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    env:
+      GH_TOKEN: ${{ github.token }}
+      PI_HOST: "100.113.41.119"
+      PI_USER: "tbaltzakis"
+      KC: "sudo kubectl --kubeconfig /etc/rancher/k3s/k3s.yaml"
+    steps:
+      - name: Connect to tailnet
+        uses: tailscale/github-action@0263d9e6d793eaefcf1de98ff7fde47abe6664d3 # v3.2.4
+        with:
+          authkey: ${{ secrets.TS_AUTHKEY }}
+
+      - name: Install SSH key
+        run: |
+          mkdir -p ~/.ssh
+          printf '%s\n' "${{ secrets.OMV_SSH_KEY }}" > ~/.ssh/id_ed25519
+          chmod 600 ~/.ssh/id_ed25519
+          ssh-keyscan -H "$PI_HOST" >> ~/.ssh/known_hosts 2>/dev/null || true
+
+      - name: Delete autoheal CronJob (so it can't fight back)
+        run: |
+          ssh -i ~/.ssh/id_ed25519 -o StrictHostKeyChecking=no -o ConnectTimeout=10 \
+            "$PI_USER@$PI_HOST" \
+            "$KC delete cronjob keycloak-autoheal -n cluster-protection 2>/dev/null || echo '(autoheal not found in cluster-protection)'; \
+             $KC delete cronjob keycloak-autoheal -n keycloak 2>/dev/null || echo '(autoheal not found in keycloak ns)'" \
+            2>&1 | tee scale.log
+
+      - name: Scale Keycloak and postgres to 0
+        run: |
+          ssh -i ~/.ssh/id_ed25519 -o StrictHostKeyChecking=no -o ConnectTimeout=10 \
+            "$PI_USER@$PI_HOST" \
+            "$KC -n keycloak scale deploy keycloak --replicas=0 2>&1; \
+             $KC -n keycloak scale deploy postgres --replicas=0 2>&1; \
+             echo ''; \
+             $KC -n keycloak get pods 2>&1 | head -10" \
+            2>&1 | tee -a scale.log
+
+      - name: Post result to tracking issue
+        if: always()
+        run: |
+          {
+            echo "# Keycloak scale-down — $(date -u '+%Y-%m-%d %H:%M:%SZ')"
+            echo ""
+            echo '```'
+            cat scale.log 2>/dev/null || echo "(no log)"
+            echo '```'
+          } | gh issue comment 382 --repo "$GITHUB_REPOSITORY" --body-file -


### PR DESCRIPTION
## Summary

Three fixes that address the two ⚠️ warnings from the cluster status report:

### 1. `keycloak-scale-down.yml` (new)
Stops the Keycloak OOM loop permanently. The in-cluster `keycloak-autoheal` CronJob (every 5 min) was fighting any manual scale-down, so this workflow deletes it first, then scales `deploy/keycloak` and `deploy/postgres` to 0. **Reversible** — data preserved, namespace intact. Full decommission available via existing `decommission-keycloak.yml` when ready.

### 2. `etcd-defrag-now.yml` (new)
Addresses the root cause of periodic k3s crashes: etcd fragmentation on the Pi SD card causing 100–450ms op latency (threshold: 100ms). Runs compact → defrag → alarm disarm → endpoint status before/after via SSH. Also `workflow_dispatch` so it can be re-triggered any time.

### 3. `k3s-restart.yml` (fix)
The `fuser -k 6443/tcp` step was killing whatever process was on port 6443 — including a *running healthy k3s instance* (it killed PID 38689 in the last run). Now it only runs when port 6443 is actually down from the runner's perspective.

## Workflows triggered by this merge
- `keycloak-scale-down.yml` → scales Keycloak to 0, posts to #382
- `etcd-defrag-now.yml` → defrags etcd, posts to #382
- `k3s-restart.yml` → restarts k3s (with fixed fuser logic), posts to #382

## OMV repo failures (action needed)
3 workflows in `Themis128/OMV` failed at 11:03–11:04 EEST (`store-aws-credentials.yml`, `store-cloudflare-token.yml`, `apply-github-secrets-from-ssm.yml`) — likely due to Pi runners being offline during the k3s crash. Please **re-run them manually** from the GitHub Actions UI now that k3s is stable.

---
_Generated by [Claude Code](https://claude.ai/code/session_01LV4AdXEE9ESwFWFKXybHko)_