### PR TITLE
fix(ops): pod diagnostics in rollout poll + force-delete keycloak finalizers

### DIFF
--- a/.github/workflows/delete-keycloak-ns.yml
+++ b/.github/workflows/delete-keycloak-ns.yml
@@ -47,16 +47,41 @@ jobs:
 
       - name: Delete Keycloak namespace
         run: |
-          set -euo pipefail
           {
-            echo "=== Deleting keycloak namespace ==="
-            kubectl delete namespace keycloak --ignore-not-found --timeout=120s \
-              && echo "keycloak namespace deleted" \
-              || echo "keycloak namespace already gone or timed out"
+            echo "=== Checking keycloak namespace state ==="
+            NS_PHASE=$(kubectl get namespace keycloak \
+              -o jsonpath='{.status.phase}' 2>/dev/null || echo "NotFound")
+            echo "keycloak ns phase: $NS_PHASE"
+
+            if [ "$NS_PHASE" = "NotFound" ]; then
+              echo "keycloak namespace does not exist — nothing to do"
+            else
+              # Patch finalizers off all resources that block deletion
+              echo "=== Patching finalizers off stuck resources ==="
+              for resource in persistentvolumeclaims services pods deployments; do
+                kubectl get "$resource" -n keycloak \
+                  -o jsonpath='{.items[*].metadata.name}' 2>/dev/null \
+                  | tr ' ' '\n' | while read -r name; do
+                    [ -z "$name" ] && continue
+                    kubectl patch "$resource/$name" -n keycloak \
+                      -p '{"metadata":{"finalizers":[]}}' --type=merge \
+                      2>/dev/null && echo "patched $resource/$name" || true
+                  done
+              done
+              # Patch the namespace itself
+              kubectl patch namespace keycloak \
+                -p '{"metadata":{"finalizers":[]}}' --type=merge \
+                2>/dev/null && echo "patched namespace/keycloak finalizers" || true
+
+              echo "=== Deleting keycloak namespace ==="
+              kubectl delete namespace keycloak --ignore-not-found --timeout=60s \
+                && echo "keycloak namespace deleted" \
+                || echo "namespace not fully gone within 60s — finalizers patched, GC will complete"
+            fi
 
             echo ""
             echo "=== Remaining namespaces ==="
-            kubectl get namespaces
+            kubectl get namespaces 2>/dev/null || echo "(API unavailable)"
           } | tee delete.log
 
       - name: Post result to tracking issue

--- a/.github/workflows/rollout-pi-force.yml
+++ b/.github/workflows/rollout-pi-force.yml
@@ -235,13 +235,13 @@ jobs:
             -n ${{ env.K3S_NAMESPACE }} --replicas=1
 
           # Run rollout readiness check via SSH on the Pi itself (local kubeconfig,
-          # 127.0.0.1:6443). Run #7 timed out because kubectl rollout status run
-          # from the Actions runner over the Tailscale relay sees disconnections
-          # whenever k3s restarts during image pull + container startup. Each SSH
-          # poll is a fresh short-lived connection — k3s crashes between polls are
-          # handled transparently; the next poll just sees readyReplicas=0.
-          echo "Waiting for rollout via SSH on Pi (local kubeconfig, up to 20 min)..."
-          for i in $(seq 1 120); do
+          # 127.0.0.1:6443). Each SSH poll is a fresh short-lived connection —
+          # k3s crashes between polls are handled transparently.
+          # Every 6 iterations (~1 min) print pod status so we can see what's
+          # blocking readiness (ContainerCreating, CrashLoopBackOff, etc.).
+          echo "Waiting for rollout via SSH on Pi (local kubeconfig, up to 30 min)..."
+          ROLLOUT_DONE=0
+          for i in $(seq 1 180); do
             READY=$(ssh -i ~/.ssh/id_ed25519 \
               -o StrictHostKeyChecking=no \
               -o ConnectTimeout=10 \
@@ -255,13 +255,38 @@ jobs:
               2>/dev/null || echo "0")
             if [ "${READY:-0}" = "1" ]; then
               echo "Rollout complete — 1/1 replicas ready (attempt ${i})"
+              ROLLOUT_DONE=1
               break
             fi
-            if [ "$i" -eq 120 ]; then
-              echo "::error::Rollout timed out — pod not ready after 20 min"
-              exit 1
+            echo "  ${i}/180 — readyReplicas=${READY:-0}, waiting 10s..."
+            # Every 6 polls (~1 min) show pod status to surface the blocking condition
+            if [ $((i % 6)) -eq 0 ]; then
+              echo "--- pod status (attempt ${i}) ---"
+              ssh -i ~/.ssh/id_ed25519 \
+                -o StrictHostKeyChecking=no -o ConnectTimeout=10 \
+                "$PI_USER@$PI_HOST" \
+                "sudo kubectl --kubeconfig=/etc/rancher/k3s/k3s.yaml \
+                  get pod -n ${{ env.K3S_NAMESPACE }} -o wide 2>/dev/null || true" \
+                2>/dev/null || true
             fi
-            echo "  ${i}/120 — readyReplicas=${READY:-0}, waiting 10s..."
             sleep 10
           done
+
+          if [ "$ROLLOUT_DONE" -ne 1 ]; then
+            echo "::error::Rollout timed out after 30 min — dumping pod details"
+            ssh -i ~/.ssh/id_ed25519 \
+              -o StrictHostKeyChecking=no -o ConnectTimeout=10 \
+              "$PI_USER@$PI_HOST" \
+              "sudo kubectl --kubeconfig=/etc/rancher/k3s/k3s.yaml \
+                get pod -n ${{ env.K3S_NAMESPACE }} -o wide 2>/dev/null || true; \
+               echo '---'; \
+               sudo kubectl --kubeconfig=/etc/rancher/k3s/k3s.yaml \
+                describe pod -n ${{ env.K3S_NAMESPACE }} 2>/dev/null | tail -60 || true; \
+               echo '---'; \
+               sudo kubectl --kubeconfig=/etc/rancher/k3s/k3s.yaml \
+                logs -n ${{ env.K3S_NAMESPACE }} -l app=${{ env.K3S_DEPLOYMENT }} \
+                --tail=30 --previous 2>/dev/null || true" \
+              2>/dev/null || true
+            exit 1
+          fi
           echo "Rollout complete: SHA=${SHA}"


### PR DESCRIPTION
## Summary

**rollout-pi-force.yml** — run #8 failed: pod never reached `readyReplicas=1` after 20 min. Root cause unknown (could be ContainerCreating, CrashLoopBackOff, failing readiness probe). Can't diagnose without seeing the pod's status/events during the wait.
- Add `kubectl get pod -o wide` print every ~1 min (every 6 polls) during SSH polling
- Add full `kubectl describe pod` + `kubectl logs --previous` dump on timeout
- Extend timeout 20→30 min (120→180 SSH polls)

**delete-keycloak-ns.yml** — run #1 failed: `kubectl delete namespace keycloak --timeout=120s` timed out (namespace stuck in `Terminating` due to resource finalizers).
- Remove `set -euo pipefail` (was masking `||` error guards)
- Patch finalizers off all resources (pvcs, pods, services, deployments) before deleting
- Patch namespace finalizers directly
- Reduce kubectl timeout to 60s (finalizer removal makes deletion instant)

## Test plan
- [ ] Merge triggers run #9 of `rollout-pi-force.yml` — pod status lines appear every ~1 min in step 7 logs
- [ ] If run #9 times out, the describe dump shows the exact blocking event
- [ ] Merge also triggers run #2 of `delete-keycloak-ns.yml` — keycloak namespace is deleted

https://claude.ai/code/session_013sTDMVEYibee8tbXxrwjzo

---
_Generated by [Claude Code](https://claude.ai/code/session_013sTDMVEYibee8tbXxrwjzo)_