### PR TITLE
fix(pi-rollout): wire imagePullSecrets onto cloudless Deployment

### DIFF
--- a/.github/workflows/rollout-pi-force.yml
+++ b/.github/workflows/rollout-pi-force.yml
@@ -235,6 +235,35 @@ jobs:
               fi
             " 2>/dev/null || echo "ECR pre-pull SSH step failed — continuing"
 
+      - name: Wire imagePullSecrets onto cloudless Deployment
+        env:
+          PI_HOST: "100.113.41.119"
+          PI_USER: "tbaltzakis"
+        run: |
+          # Permanently fix ErrImagePull: patch the Deployment so pods reference
+          # the k8s docker-registry Secret that ecr-heal keeps fresh, instead of
+          # relying on stale node-level containerd credentials.
+          ssh -i ~/.ssh/id_ed25519 \
+            -o StrictHostKeyChecking=no \
+            -o ConnectTimeout=15 \
+            -o ServerAliveInterval=15 \
+            -o ServerAliveCountMax=3 \
+            "$PI_USER@$PI_HOST" '
+              SECRET_NAME=$(sudo kubectl --kubeconfig=/etc/rancher/k3s/k3s.yaml \
+                get secret -n cloudless -o name 2>/dev/null \
+                | grep ecr | head -1 | sed "s|secret/||")
+              if [ -n "$SECRET_NAME" ]; then
+                echo "Patching imagePullSecrets → $SECRET_NAME"
+                sudo kubectl --kubeconfig=/etc/rancher/k3s/k3s.yaml \
+                  patch deployment/cloudless -n cloudless \
+                  -p "{\"spec\":{\"template\":{\"spec\":{\"imagePullSecrets\":[{\"name\":\"$SECRET_NAME\"}]}}}}" \
+                  && echo "imagePullSecrets patched successfully" \
+                  || echo "patch failed — continuing"
+              else
+                echo "No ECR secret found — skipping imagePullSecrets patch"
+              fi
+            ' 2>/dev/null || echo "imagePullSecrets patch SSH step failed — continuing"
+
       - name: Set image and roll out
         env:
           PI_HOST: "100.113.41.119"


### PR DESCRIPTION
## Summary

- The `cloudless` Deployment on k3s has no `imagePullSecrets` — pods use node-level containerd credentials which expire every 12h → `ErrImagePull` on every pod restart (OOMKill recovery, CrashLoop, etc.)
- The crictl pre-pull in PR #692 fixes rollouts but not pod restarts between rollouts
- This PR adds a step that patches `imagePullSecrets` onto the live Deployment using the ECR docker-registry Secret that `ecr-heal` already keeps fresh every 5 min

## What changed

New step "Wire imagePullSecrets onto cloudless Deployment" (between crictl pre-pull and set-image):
1. SSHes to Pi, finds the ECR Secret created by `ecr-heal` (grep for `ecr` in secret names)
2. `kubectl patch deployment/cloudless` to add `imagePullSecrets: [{name: <secret>}]`
3. From this point on, every pod the k8s scheduler starts uses the k8s Secret for ECR auth — no stale node-level creds

## Result

- Rollouts: crictl pre-pull (cached) + imagePullSecrets (for future restarts)
- Pod restarts between rollouts: imagePullSecrets points to ecr-heal Secret → always fresh

https://claude.ai/code/session_013sTDMVEYibee8tbXxrwjzo

---
_Generated by [Claude Code](https://claude.ai/code/session_013sTDMVEYibee8tbXxrwjzo)_