### PR TITLE
fix(pi-rollout): etcd maintenance before restart, no unconditional k3s restart (#696)

### DIFF
--- a/.github/workflows/rollout-pi-force.yml
+++ b/.github/workflows/rollout-pi-force.yml
@@ -75,23 +75,43 @@ jobs:
               free -m
               echo "=== disk ==="
               df -h /
-              echo "=== etcd defrag (while k3s is running) ==="
-              # Ensure k3s is running before attempting defrag
-              if ! systemctl is-active --quiet k3s; then
-                echo "k3s not active — starting it first for etcd defrag..."
-                sudo systemctl start k3s
-                sleep 15
+              echo "=== Full etcd maintenance BEFORE any restart ==="
+              # Doing maintenance while k3s is already running avoids the
+              # network disruption caused by systemctl restart k3s (k3s
+              # manages the CNI/network interfaces and briefly takes them
+              # down during restart, which drops the SSH session).
+              ETCD_EP="https://127.0.0.1:2379"
+              ETCD_CA="/var/lib/rancher/k3s/server/tls/etcd/server-ca.crt"
+              ETCD_CRT="/var/lib/rancher/k3s/server/tls/etcd/server-client.crt"
+              ETCD_KEY="/var/lib/rancher/k3s/server/tls/etcd/server-client.key"
+              if systemctl is-active --quiet k3s; then
+                sudo k3s etcdctl defrag \
+                  --endpoints="$ETCD_EP" --cacert="$ETCD_CA" \
+                  --cert="$ETCD_CRT" --key="$ETCD_KEY" \
+                  2>/dev/null && echo "etcd defrag done" || echo "etcd defrag skipped"
+                REV=$(sudo k3s etcdctl endpoint status \
+                  --endpoints="$ETCD_EP" --cacert="$ETCD_CA" \
+                  --cert="$ETCD_CRT" --key="$ETCD_KEY" \
+                  --write-out=json 2>/dev/null \
+                  | grep -o '"revision":[0-9]*' | head -1 | cut -d: -f2 || echo "")
+                if [ -n "$REV" ] && [ "$REV" -gt 0 ] 2>/dev/null; then
+                  sudo k3s etcdctl compact "$REV" \
+                    --endpoints="$ETCD_EP" --cacert="$ETCD_CA" \
+                    --cert="$ETCD_CRT" --key="$ETCD_KEY" \
+                    2>/dev/null && echo "compact to rev $REV done" || echo "compact skipped"
+                  sudo k3s etcdctl defrag \
+                    --endpoints="$ETCD_EP" --cacert="$ETCD_CA" \
+                    --cert="$ETCD_CRT" --key="$ETCD_KEY" \
+                    2>/dev/null && echo "post-compact defrag done" || echo "defrag skipped"
+                  sudo k3s etcdctl alarm disarm \
+                    --endpoints="$ETCD_EP" --cacert="$ETCD_CA" \
+                    --cert="$ETCD_CRT" --key="$ETCD_KEY" \
+                    2>/dev/null && echo "alarm disarm done" || echo "alarm disarm skipped"
+                fi
+              else
+                echo "k3s not active — skipping etcd maintenance"
               fi
-              sudo k3s etcdctl defrag \
-                --endpoints=https://127.0.0.1:2379 \
-                --cacert=/var/lib/rancher/k3s/server/tls/etcd/server-ca.crt \
-                --cert=/var/lib/rancher/k3s/server/tls/etcd/server-client.crt \
-                --key=/var/lib/rancher/k3s/server/tls/etcd/server-client.key \
-                2>/dev/null && echo "etcd defrag done" || echo "etcd defrag skipped"
               echo "=== Kill leftover containerd-shim processes ==="
-              # Orphaned shims from previous k3s crashes consume memory and
-              # cause k3s to OOM on reconciliation. Kill them before restart
-              # so k3s starts with a clean container slate.
               SHIM_PIDS=$(pgrep containerd-shim 2>/dev/null | tr '\n' ' ' || true)
               if [ -n "$SHIM_PIDS" ]; then
                 echo "Killing containerd-shim PIDs: $SHIM_PIDS"
@@ -100,52 +120,26 @@ jobs:
               else
                 echo "No leftover containerd-shim processes found"
               fi
-              echo "=== Stop cloudless app containers before restart (free RAM) ==="
+              echo "=== Stop cloudless containers to free RAM ==="
               sudo crictl ps 2>/dev/null | grep cloudless | awk '{print $1}' \
                 | xargs -r sudo crictl stop --timeout 10 2>/dev/null || true
               sudo crictl ps -a 2>/dev/null | grep cloudless | awk '{print $1}' \
                 | xargs -r sudo crictl rm -f 2>/dev/null || true
-              echo "=== Restart k3s after defrag + cleanup ==="
-              sudo systemctl restart k3s
-              echo "k3s restarted — waiting 30s for etcd to initialise..."
-              sleep 30
-              echo "=== Compact + defrag etcd to clear NOSPACE condition ==="
-              ETCD_EP="https://127.0.0.1:2379"
-              ETCD_CA="/var/lib/rancher/k3s/server/tls/etcd/server-ca.crt"
-              ETCD_CRT="/var/lib/rancher/k3s/server/tls/etcd/server-client.crt"
-              ETCD_KEY="/var/lib/rancher/k3s/server/tls/etcd/server-client.key"
-              REV=$(sudo k3s etcdctl endpoint status \
-                --endpoints="$ETCD_EP" --cacert="$ETCD_CA" \
-                --cert="$ETCD_CRT" --key="$ETCD_KEY" \
-                --write-out=json 2>/dev/null \
-                | grep -o '"revision":[0-9]*' | head -1 | cut -d: -f2 || echo "")
-              if [ -n "$REV" ] && [ "$REV" -gt 0 ] 2>/dev/null; then
-                echo "Compacting to revision $REV..."
-                sudo k3s etcdctl compact "$REV" \
-                  --endpoints="$ETCD_EP" --cacert="$ETCD_CA" \
-                  --cert="$ETCD_CRT" --key="$ETCD_KEY" \
-                  2>/dev/null && echo "compact done" || echo "compact skipped"
-                echo "Defragmenting after compact..."
-                sudo k3s etcdctl defrag \
-                  --endpoints="$ETCD_EP" --cacert="$ETCD_CA" \
-                  --cert="$ETCD_CRT" --key="$ETCD_KEY" \
-                  2>/dev/null && echo "defrag done" || echo "defrag skipped"
-                echo "Disarming NOSPACE alarm if set..."
-                sudo k3s etcdctl alarm disarm \
-                  --endpoints="$ETCD_EP" --cacert="$ETCD_CA" \
-                  --cert="$ETCD_CRT" --key="$ETCD_KEY" \
-                  2>/dev/null && echo "alarm disarm done" || echo "alarm disarm skipped"
+              echo "=== Start k3s only if not active (no restart — avoids network disruption) ==="
+              if ! systemctl is-active --quiet k3s; then
+                echo "k3s not active — starting it..."
+                sudo systemctl start k3s
+                echo "k3s started — waiting 45s to initialise..."
+                sleep 45
               else
-                echo "etcd not ready for compact (rev=$REV) — skipping"
+                echo "k3s already active — no restart needed"
               fi
-              echo "Sleeping 15s after etcd maintenance..."
-              sleep 15
-              echo "=== Scale cloudless to 0 replicas (free RAM for /readyz polling) ==="
+              echo "=== Scale cloudless to 0 replicas (free RAM) ==="
               sudo kubectl --kubeconfig=/etc/rancher/k3s/k3s.yaml \
                 scale deployment/cloudless -n cloudless --replicas=0 \
                 2>/dev/null && echo "scale to 0: done" || echo "scale to 0: skipped (k3s not ready)"
-              echo "Sleeping 20s for pod to terminate..."
-              sleep 20
+              echo "Sleeping 10s for pod to terminate..."
+              sleep 10
             '
 
       - name: Wait for k3s /readyz (3x stable via SSH)

--- a/.github/workflows/rollout-pi-force.yml
+++ b/.github/workflows/rollout-pi-force.yml
@@ -61,7 +61,11 @@ jobs:
           printf '%s\n' "${{ secrets.OMV_SSH_KEY }}" > ~/.ssh/id_ed25519
           chmod 600 ~/.ssh/id_ed25519
           ssh-keyscan -H "$PI_HOST" >> ~/.ssh/known_hosts 2>/dev/null || true
-          ssh -i ~/.ssh/id_ed25519 -o StrictHostKeyChecking=no -o ConnectTimeout=15 \
+          ssh -i ~/.ssh/id_ed25519 \
+            -o StrictHostKeyChecking=no \
+            -o ConnectTimeout=30 \
+            -o ServerAliveInterval=30 \
+            -o ServerAliveCountMax=5 \
             "$PI_USER@$PI_HOST" '
               echo "=== k3s service status ==="
               systemctl is-active k3s || true
@@ -144,32 +148,46 @@ jobs:
               sleep 20
             '
 
-      - name: Wait for k3s /readyz (3x stable via kubectl)
+      - name: Wait for k3s /readyz (3x stable via SSH)
+        env:
+          PI_HOST: "100.113.41.119"
+          PI_USER: "tbaltzakis"
         run: |
+          # Poll k3s /readyz via SSH to the Pi rather than from the runner via
+          # Tailscale. The Pi's local kubectl is always reliable; the Tailscale
+          # tunnel to port 6443 can be intermittent under memory pressure.
           wait_for_api() {
             local stable=0
-            for i in $(seq 1 120); do
-              if kubectl get --raw /readyz --request-timeout=5s 2>/dev/null \
-                  | grep -q 'ok'; then
+            for i in $(seq 1 72); do
+              STATUS=$(ssh -i ~/.ssh/id_ed25519 \
+                -o StrictHostKeyChecking=no \
+                -o ConnectTimeout=10 \
+                -o ServerAliveInterval=10 \
+                -o ServerAliveCountMax=2 \
+                "$PI_USER@$PI_HOST" \
+                "sudo kubectl --kubeconfig=/etc/rancher/k3s/k3s.yaml \
+                  get --raw /readyz 2>/dev/null" \
+                2>/dev/null || echo "")
+              if echo "$STATUS" | grep -q 'ok'; then
                 stable=$((stable + 1))
-                echo "  ${i}/120 — /readyz ok (stable ${stable}/3)"
+                echo "  ${i}/72 — /readyz ok via SSH (stable ${stable}/3)"
                 if [ "$stable" -ge 3 ]; then
                   return 0
                 fi
               else
                 stable=0
-                echo "  ${i}/120 — /readyz not ready, waiting 5s..."
+                echo "  ${i}/72 — /readyz not ready via SSH, waiting 5s..."
               fi
               sleep 5
             done
             return 1
           }
 
-          echo "Waiting for k3s API to be stable (3x kubectl /readyz ok)..."
+          echo "Waiting for k3s API to be stable (3x SSH /readyz ok)..."
           if wait_for_api; then
             echo "k3s API stable — proceeding to rollout"
           else
-            echo "::error::k3s /readyz never returned 3x ok in 10 min — aborting"
+            echo "::error::k3s /readyz never returned 3x ok in 6 min via SSH — aborting"
             exit 1
           fi
 


### PR DESCRIPTION
## Summary

- `systemctl restart k3s` in step 5 causes a brief CNI network disruption that drops the SSH session — the post-restart etcd compact/alarm-disarm code (after `sleep 30`) was never reached
- NOSPACE etcd alarm stayed set → k3s can't write to etcd after restart → `/readyz` never returns ok → step 6 stuck for 20+ min (runs #13, #14)

## Fix

- Run ALL etcd maintenance (defrag, compact, alarm-disarm) **while k3s is already active**, before any restart — SSH stays alive throughout
- Never restart k3s unconditionally — only `systemctl start k3s` if it is not running
- Keep the RAM-freeing cleanup (kill orphaned containerd-shims, stop cloudless containers, scale deployment to 0)

After step 5, k3s is still running with a freshly maintained etcd and freed RAM. Step 6 SSH readyz should see 3× consecutive ok within seconds.

## Test plan

- [ ] Run #15 triggers from this merge
- [ ] Step 5 SSH stays connected through the full cleanup (~50s, no restart disruption)
- [ ] etcd compact + alarm disarm log lines appear in step 5 output
- [ ] Step 6 gets 3× SSH /readyz ok within 30s (k3s already running, no post-restart wait)
- [ ] Pod reaches `readyReplicas=1`

https://claude.ai/code/session_013sTDMVEYibee8tbXxrwjzo

---
_Generated by [Claude Code](https://claude.ai/code/session_013sTDMVEYibee8tbXxrwjzo)_