### PR TITLE
fix(pi-rollout): use curl --max-time 8 for /readyz instead of kubectl

### DIFF
--- a/.github/workflows/rollout-pi-force.yml
+++ b/.github/workflows/rollout-pi-force.yml
@@ -147,41 +147,42 @@ jobs:
           PI_HOST: "100.113.41.119"
           PI_USER: "tbaltzakis"
         run: |
-          # Poll k3s /readyz via SSH to the Pi rather than from the runner via
-          # Tailscale. The Pi's local kubectl is always reliable; the Tailscale
-          # tunnel to port 6443 can be intermittent under memory pressure.
+          # Poll k3s /readyz via SSH to the Pi. Uses curl with --max-time 8 so
+          # each probe is strictly bounded. kubectl has no default request timeout
+          # and can hang for the entire SSH ServerAlive window (20s+) when the API
+          # is slow, preventing stable from ever reaching 3.
+          # /readyz does not require authentication in Kubernetes — curl -k is sufficient.
           wait_for_api() {
             local stable=0
             for i in $(seq 1 72); do
-              STATUS=$(ssh -i ~/.ssh/id_ed25519 \
+              CODE=$(ssh -i ~/.ssh/id_ed25519 \
                 -o StrictHostKeyChecking=no \
                 -o ConnectTimeout=10 \
-                -o ServerAliveInterval=10 \
-                -o ServerAliveCountMax=2 \
+                -o ServerAliveInterval=15 \
+                -o ServerAliveCountMax=3 \
                 "$PI_USER@$PI_HOST" \
-                "sudo kubectl --kubeconfig=/etc/rancher/k3s/k3s.yaml \
-                  get --raw /readyz 2>/dev/null" \
+                "curl -k -s -o /dev/null -w '%{http_code}' --max-time 8 https://127.0.0.1:6443/readyz 2>/dev/null" \
                 2>/dev/null || echo "")
-              if echo "$STATUS" | grep -q 'ok'; then
+              if [ "$CODE" = "200" ]; then
                 stable=$((stable + 1))
-                echo "  ${i}/72 — /readyz ok via SSH (stable ${stable}/3)"
+                echo "  ${i}/72 — /readyz HTTP 200 via SSH (stable ${stable}/3)"
                 if [ "$stable" -ge 3 ]; then
                   return 0
                 fi
               else
                 stable=0
-                echo "  ${i}/72 — /readyz not ready via SSH, waiting 5s..."
+                echo "  ${i}/72 — /readyz returned ${CODE:-timeout/err}, waiting 5s..."
               fi
               sleep 5
             done
             return 1
           }
 
-          echo "Waiting for k3s API to be stable (3x SSH /readyz ok)..."
+          echo "Waiting for k3s API to be stable (3x SSH /readyz HTTP 200)..."
           if wait_for_api; then
             echo "k3s API stable — proceeding to rollout"
           else
-            echo "::error::k3s /readyz never returned 3x ok in 6 min via SSH — aborting"
+            echo "::error::k3s /readyz never returned 3x HTTP 200 in time via SSH — aborting"
             exit 1
           fi
 


### PR DESCRIPTION
## Problem

Step 6 ("Wait for k3s /readyz") uses `kubectl get --raw /readyz` via SSH. `kubectl` has no default request timeout — under Pi memory pressure, the k3s API responds slowly and `kubectl` hangs until the SSH `ServerAlive` window expires (~20s). When SSH kills the connection, `stable` resets to 0, and 3× consecutive success is never reached. Step 6 can run for 20-30 minutes doing nothing useful.

## Fix

Replace `kubectl get --raw /readyz` with `curl -k --max-time 8 https://127.0.0.1:6443/readyz`. Advantages:
- Strictly bounded to 8s per probe (vs unlimited for kubectl)
- `/readyz` doesn't require auth in Kubernetes — `curl -k` is sufficient
- Checks HTTP status code 200 (more precise than `grep 'ok'` on kubectl output)
- Each iteration is max ~13s (8s probe + 5s sleep) instead of up to 25s

## Test plan

- Run #16 should show step 6 completing within 30-90s with 3× "HTTP 200" logged

---
_Generated by [Claude Code](https://claude.ai/code/session_013sTDMVEYibee8tbXxrwjzo)_