### PR TITLE
fix(pi-rollout): remove etcd compact from step 5 — causes 15min API outage (#701)

### DIFF
--- a/.github/workflows/rollout-pi-force.yml
+++ b/.github/workflows/rollout-pi-force.yml
@@ -89,25 +89,10 @@ jobs:
                   --endpoints="$ETCD_EP" --cacert="$ETCD_CA" \
                   --cert="$ETCD_CRT" --key="$ETCD_KEY" \
                   2>/dev/null && echo "etcd defrag done" || echo "etcd defrag skipped"
-                REV=$(sudo k3s etcdctl endpoint status \
+                sudo k3s etcdctl alarm disarm \
                   --endpoints="$ETCD_EP" --cacert="$ETCD_CA" \
                   --cert="$ETCD_CRT" --key="$ETCD_KEY" \
-                  --write-out=json 2>/dev/null \
-                  | grep -o '"revision":[0-9]*' | head -1 | cut -d: -f2 || echo "")
-                if [ -n "$REV" ] && [ "$REV" -gt 0 ] 2>/dev/null; then
-                  sudo k3s etcdctl compact "$REV" \
-                    --endpoints="$ETCD_EP" --cacert="$ETCD_CA" \
-                    --cert="$ETCD_CRT" --key="$ETCD_KEY" \
-                    2>/dev/null && echo "compact to rev $REV done" || echo "compact skipped"
-                  sudo k3s etcdctl defrag \
-                    --endpoints="$ETCD_EP" --cacert="$ETCD_CA" \
-                    --cert="$ETCD_CRT" --key="$ETCD_KEY" \
-                    2>/dev/null && echo "post-compact defrag done" || echo "defrag skipped"
-                  sudo k3s etcdctl alarm disarm \
-                    --endpoints="$ETCD_EP" --cacert="$ETCD_CA" \
-                    --cert="$ETCD_CRT" --key="$ETCD_KEY" \
-                    2>/dev/null && echo "alarm disarm done" || echo "alarm disarm skipped"
-                fi
+                  2>/dev/null && echo "alarm disarm done" || echo "alarm disarm skipped"
               else
                 echo "k3s not active — skipping etcd maintenance"
               fi

--- a/.github/workflows/rollout-pi-force.yml
+++ b/.github/workflows/rollout-pi-force.yml
@@ -143,37 +143,21 @@ jobs:
             '
 
       - name: Wait for k3s API to accept kubectl
-        env:
-          PI_HOST: "100.113.41.119"
-          PI_USER: "tbaltzakis"
         run: |
-          # One successful kubectl get nodes is enough — step 5 already confirmed
-          # k3s is running via kubectl scale. Give k3s 20s to reconnect to etcd
-          # after step 5's defrag/compact before polling.
-          # curl /readyz is avoided: k3s may require auth even for health endpoints,
-          # and curl --max-time 8 fires before the API responds under memory pressure.
-          # kubectl --request-timeout=20s is bounded and uses the correct credentials.
-          echo "Waiting 20s for k3s to stabilise after etcd maintenance..."
-          sleep 20
+          # Use runner-side kubectl (kubeconfig from step 4 KUBECONFIG_B64) to probe
+          # the Pi k3s API directly over Tailscale — eliminates SSH overhead (~3s per
+          # iteration) that made the effective 20s kubectl window too small. One
+          # success is sufficient; step 5 already confirmed k3s is running.
           for i in $(seq 1 36); do
-            RESP=$(ssh -i ~/.ssh/id_ed25519 \
-              -o StrictHostKeyChecking=no \
-              -o ConnectTimeout=10 \
-              -o ServerAliveInterval=25 \
-              -o ServerAliveCountMax=2 \
-              "$PI_USER@$PI_HOST" \
-              "sudo kubectl --kubeconfig=/etc/rancher/k3s/k3s.yaml \
-                get nodes --request-timeout=20s 2>/dev/null && echo KUBECTL_OK" \
-              2>/dev/null || echo "")
-            if echo "$RESP" | grep -q "KUBECTL_OK"; then
-              echo "  ${i}/36 — kubectl get nodes succeeded"
+            if kubectl get nodes --request-timeout=30s 2>/dev/null | grep -q "Ready"; then
+              echo "  ${i}/36 — k3s node Ready"
               echo "k3s API ready — proceeding to rollout"
               exit 0
             fi
-            echo "  ${i}/36 — kubectl not ready (${RESP:0:40}...), waiting 5s..."
-            sleep 5
+            echo "  ${i}/36 — k3s not ready, waiting 10s..."
+            sleep 10
           done
-          echo "::error::k3s API never responded to kubectl in 15 min — aborting"
+          echo "::error::k3s API never responded in ~24 min — aborting"
           exit 1
 
       - name: Pre-pull ECR image on Pi via crictl


### PR DESCRIPTION
etcdctl compact invalidates all watch positions in etcd, forcing k3s to restart every informer. Under Pi memory pressure this causes 15+ min of kubectl fast-errors (confirmed in run #17 logs: each iteration ~10s, not 20s timeout). Defrag + alarm-disarm are safe and sufficient.

---
_Generated by [Claude Code](https://claude.ai/code/session_013sTDMVEYibee8tbXxrwjzo)_