### PR TITLE
fix(rollout-pi-force): type-based ECR Secret detection + python3 auth parsing (run #21)

### DIFF
--- a/.github/workflows/rollout-pi-force.yml
+++ b/.github/workflows/rollout-pi-force.yml
@@ -174,8 +174,8 @@ jobs:
                 -n cloudless 2>/dev/null \
                 && echo 'ecr-heal job created' \
                 || echo 'ecr-heal cronjob not found — skipping'
-              for i in \\\$(seq 1 24); do
-                STATUS=\\\$(sudo kubectl --kubeconfig=/etc/rancher/k3s/k3s.yaml \
+              for i in \$(seq 1 24); do
+                STATUS=\$(sudo kubectl --kubeconfig=/etc/rancher/k3s/k3s.yaml \
                   get job \"\$JOB\" -n cloudless \
                   -o jsonpath='{.status.conditions[?(@.type==\"Complete\")].status}' \
                   2>/dev/null || echo '')
@@ -185,18 +185,18 @@ jobs:
               done
               sudo kubectl --kubeconfig=/etc/rancher/k3s/k3s.yaml \
                 delete job \"\$JOB\" -n cloudless --ignore-not-found 2>/dev/null || true
-              SECRET_NAME=\\\$(sudo kubectl --kubeconfig=/etc/rancher/k3s/k3s.yaml \
+              SECRET_NAME=\$(sudo kubectl --kubeconfig=/etc/rancher/k3s/k3s.yaml \
                 get secret -n cloudless -o name 2>/dev/null \
                 | grep ecr | head -1 | sed 's|secret/||')
               if [ -n \"\$SECRET_NAME\" ]; then
-                DOCKER_JSON=\\\$(sudo kubectl --kubeconfig=/etc/rancher/k3s/k3s.yaml \
+                DOCKER_JSON=\$(sudo kubectl --kubeconfig=/etc/rancher/k3s/k3s.yaml \
                   get secret \"\$SECRET_NAME\" -n cloudless \
                   -o jsonpath='{.data.\.dockerconfigjson}' 2>/dev/null | base64 -d)
-                AUTH_B64=\\\$(echo \"\$DOCKER_JSON\" | grep -o '\"auth\":\"[^\"]*\"' | cut -d'\"' -f4)
+                AUTH_B64=\$(echo \"\$DOCKER_JSON\" | grep -o '\"auth\":\"[^\"]*\"' | cut -d'\"' -f4)
                 if [ -n \"\$AUTH_B64\" ]; then
-                  CREDS=\\\$(echo \"\$AUTH_B64\" | base64 -d)
-                  ECR_USER=\\\$(echo \"\$CREDS\" | cut -d: -f1)
-                  ECR_PASS=\\\$(echo \"\$CREDS\" | cut -d: -f2-)
+                  CREDS=\$(echo \"\$AUTH_B64\" | base64 -d)
+                  ECR_USER=\$(echo \"\$CREDS\" | cut -d: -f1)
+                  ECR_PASS=\$(echo \"\$CREDS\" | cut -d: -f2-)
                   echo 'Pre-pulling image via crictl...'
                   sudo crictl pull --creds \"\$ECR_USER:\$ECR_PASS\" '${IMAGE}' \
                     && echo 'crictl pull succeeded — image cached locally' \
@@ -278,7 +278,7 @@ jobs:
 
           # Poll /readyz instead of blind sleep: k3s can crash after the
           # scale-to-0 write (etcd + reconciliation pressure). Wait up to
-          # 3 min for 3x stable /readyz before issuing scale-to-1.
+          # 3 min for 3× stable /readyz before issuing scale-to-1.
           echo "Waiting for k3s to stay stable after scale-to-0 (up to 3 min)..."
           stable=0
           for i in $(seq 1 36); do

--- a/.github/workflows/rollout-pi-force.yml
+++ b/.github/workflows/rollout-pi-force.yml
@@ -19,7 +19,7 @@ on:
 env:
   # SHA used when triggered by push (no workflow_dispatch input available).
   # Update this value to re-trigger a rollout to a different image.
-  # run-20-trigger: 2026-06-07
+  # run-21-trigger: 2026-06-07
   DEFAULT_ROLLOUT_SHA: '89b57243c994'
   ECR_REGISTRY: 278585680617.dkr.ecr.us-east-1.amazonaws.com
   ECR_REPOSITORY: cloudless-pi-app
@@ -166,33 +166,20 @@ jobs:
             -o ServerAliveInterval=15 \
             -o ServerAliveCountMax=3 \
             "$PI_USER@$PI_HOST" "
-              JOB=ecr-refresh-pre-rollout
-              sudo kubectl --kubeconfig=/etc/rancher/k3s/k3s.yaml \
-                delete job \"\$JOB\" -n cloudless --ignore-not-found 2>/dev/null || true
-              sudo kubectl --kubeconfig=/etc/rancher/k3s/k3s.yaml \
-                create job \"\$JOB\" --from=cronjob/ecr-heal \
-                -n cloudless 2>/dev/null \
-                && echo 'ecr-heal job created' \
-                || echo 'ecr-heal cronjob not found — skipping'
-              for i in \$(seq 1 24); do
-                STATUS=\$(sudo kubectl --kubeconfig=/etc/rancher/k3s/k3s.yaml \
-                  get job \"\$JOB\" -n cloudless \
-                  -o jsonpath='{.status.conditions[?(@.type==\"Complete\")].status}' \
-                  2>/dev/null || echo '')
-                [ \"\$STATUS\" = 'True' ] && { echo \"ECR job done (attempt \${i})\"; break; }
-                echo \"  \${i}/24 — waiting for ecr-heal job...\"
-                sleep 5
-              done
-              sudo kubectl --kubeconfig=/etc/rancher/k3s/k3s.yaml \
-                delete job \"\$JOB\" -n cloudless --ignore-not-found 2>/dev/null || true
               SECRET_NAME=\$(sudo kubectl --kubeconfig=/etc/rancher/k3s/k3s.yaml \
-                get secret -n cloudless -o name 2>/dev/null \
-                | grep ecr | head -1 | sed 's|secret/||')
+                get secret -n cloudless -o json 2>/dev/null | python3 -c \
+                \"import json,sys; d=json.load(sys.stdin); \
+                 items=[i['metadata']['name'] for i in d.get('items',[]) \
+                   if i.get('type')=='kubernetes.io/dockerconfigjson']; \
+                 print(items[0] if items else '')\" 2>/dev/null || echo '')
               if [ -n \"\$SECRET_NAME\" ]; then
                 DOCKER_JSON=\$(sudo kubectl --kubeconfig=/etc/rancher/k3s/k3s.yaml \
                   get secret \"\$SECRET_NAME\" -n cloudless \
                   -o jsonpath='{.data.\.dockerconfigjson}' 2>/dev/null | base64 -d)
-                AUTH_B64=\$(echo \"\$DOCKER_JSON\" | grep -o '\"auth\":\"[^\"]*\"' | cut -d'\"' -f4)
+                AUTH_B64=\$(echo \"\$DOCKER_JSON\" | python3 -c \
+                  \"import json,sys; d=json.load(sys.stdin); \
+                   auths=d.get('auths',{}); k=list(auths.keys())[0] if auths else ''; \
+                   print(auths[k].get('auth','') if k else '')\" 2>/dev/null || echo '')
                 if [ -n \"\$AUTH_B64\" ]; then
                   CREDS=\$(echo \"\$AUTH_B64\" | base64 -d)
                   ECR_USER=\$(echo \"\$CREDS\" | cut -d: -f1)
@@ -205,7 +192,7 @@ jobs:
                   echo 'Could not extract ECR auth token — skipping crictl pre-pull'
                 fi
               else
-                echo 'No ECR secret found — skipping crictl pre-pull'
+                echo 'No docker-registry Secret found — skipping crictl pre-pull'
               fi
             " 2>/dev/null || echo "ECR pre-pull SSH step failed — continuing"
 
@@ -224,8 +211,8 @@ jobs:
             -o ServerAliveCountMax=3 \
             "$PI_USER@$PI_HOST" '
               SECRET_NAME=$(sudo kubectl --kubeconfig=/etc/rancher/k3s/k3s.yaml \
-                get secret -n cloudless -o name 2>/dev/null \
-                | grep ecr | head -1 | sed "s|secret/||")
+                get secret -n cloudless -o json 2>/dev/null | python3 -c \
+                "import json,sys; d=json.load(sys.stdin); items=[i[\"metadata\"][\"name\"] for i in d.get(\"items\",[]) if i.get(\"type\")==\"kubernetes.io/dockerconfigjson\"]; print(items[0] if items else \"\")" 2>/dev/null || echo "")
               if [ -n "$SECRET_NAME" ]; then
                 echo "Patching imagePullSecrets → $SECRET_NAME"
                 sudo kubectl --kubeconfig=/etc/rancher/k3s/k3s.yaml \
@@ -234,7 +221,7 @@ jobs:
                   && echo "imagePullSecrets patched successfully" \
                   || echo "patch failed — continuing"
               else
-                echo "No ECR secret found — skipping imagePullSecrets patch"
+                echo "No docker-registry Secret found — skipping imagePullSecrets patch"
               fi
             ' 2>/dev/null || echo "imagePullSecrets patch SSH step failed — continuing"
 

--- a/.github/workflows/rollout-pi-force.yml
+++ b/.github/workflows/rollout-pi-force.yml
@@ -19,6 +19,7 @@ on:
 env:
   # SHA used when triggered by push (no workflow_dispatch input available).
   # Update this value to re-trigger a rollout to a different image.
+  # run-20-trigger: 2026-06-07
   DEFAULT_ROLLOUT_SHA: '89b57243c994'
   ECR_REGISTRY: 278585680617.dkr.ecr.us-east-1.amazonaws.com
   ECR_REPOSITORY: cloudless-pi-app
@@ -173,8 +174,8 @@ jobs:
                 -n cloudless 2>/dev/null \
                 && echo 'ecr-heal job created' \
                 || echo 'ecr-heal cronjob not found — skipping'
-              for i in \$(seq 1 24); do
-                STATUS=\$(sudo kubectl --kubeconfig=/etc/rancher/k3s/k3s.yaml \
+              for i in \\\$(seq 1 24); do
+                STATUS=\\\$(sudo kubectl --kubeconfig=/etc/rancher/k3s/k3s.yaml \
                   get job \"\$JOB\" -n cloudless \
                   -o jsonpath='{.status.conditions[?(@.type==\"Complete\")].status}' \
                   2>/dev/null || echo '')
@@ -184,18 +185,18 @@ jobs:
               done
               sudo kubectl --kubeconfig=/etc/rancher/k3s/k3s.yaml \
                 delete job \"\$JOB\" -n cloudless --ignore-not-found 2>/dev/null || true
-              SECRET_NAME=\$(sudo kubectl --kubeconfig=/etc/rancher/k3s/k3s.yaml \
+              SECRET_NAME=\\\$(sudo kubectl --kubeconfig=/etc/rancher/k3s/k3s.yaml \
                 get secret -n cloudless -o name 2>/dev/null \
                 | grep ecr | head -1 | sed 's|secret/||')
               if [ -n \"\$SECRET_NAME\" ]; then
-                DOCKER_JSON=\$(sudo kubectl --kubeconfig=/etc/rancher/k3s/k3s.yaml \
+                DOCKER_JSON=\\\$(sudo kubectl --kubeconfig=/etc/rancher/k3s/k3s.yaml \
                   get secret \"\$SECRET_NAME\" -n cloudless \
                   -o jsonpath='{.data.\.dockerconfigjson}' 2>/dev/null | base64 -d)
-                AUTH_B64=\$(echo \"\$DOCKER_JSON\" | grep -o '\"auth\":\"[^\"]*\"' | cut -d'\"' -f4)
+                AUTH_B64=\\\$(echo \"\$DOCKER_JSON\" | grep -o '\"auth\":\"[^\"]*\"' | cut -d'\"' -f4)
                 if [ -n \"\$AUTH_B64\" ]; then
-                  CREDS=\$(echo \"\$AUTH_B64\" | base64 -d)
-                  ECR_USER=\$(echo \"\$CREDS\" | cut -d: -f1)
-                  ECR_PASS=\$(echo \"\$CREDS\" | cut -d: -f2-)
+                  CREDS=\\\$(echo \"\$AUTH_B64\" | base64 -d)
+                  ECR_USER=\\\$(echo \"\$CREDS\" | cut -d: -f1)
+                  ECR_PASS=\\\$(echo \"\$CREDS\" | cut -d: -f2-)
                   echo 'Pre-pulling image via crictl...'
                   sudo crictl pull --creds \"\$ECR_USER:\$ECR_PASS\" '${IMAGE}' \
                     && echo 'crictl pull succeeded — image cached locally' \
@@ -277,7 +278,7 @@ jobs:
 
           # Poll /readyz instead of blind sleep: k3s can crash after the
           # scale-to-0 write (etcd + reconciliation pressure). Wait up to
-          # 3 min for 3× stable /readyz before issuing scale-to-1.
+          # 3 min for 3x stable /readyz before issuing scale-to-1.
           echo "Waiting for k3s to stay stable after scale-to-0 (up to 3 min)..."
           stable=0
           for i in $(seq 1 36); do


### PR DESCRIPTION
## Run #20 failure analysis

Steps 1-8 all passed for the first time. Step 9 failed with 30 min `ImagePullBackOff`.

**Root causes:**

1. **Dead ecr-heal trigger** — `kubectl create job --from=cronjob/ecr-heal` always fails because the ecr-heal Jobs are managed externally (not by a k8s CronJob resource). The 24-iteration wait loop waited 2 minutes for a job that was never created. Removed.

2. **Broken auth extraction** — `grep -o '"auth":"[^"]*"'` fails when dockerconfigjson uses `"auth": "..."` (space after colon, which is valid JSON). This caused `AUTH_B64` to be empty → crictl pre-pull silently skipped.

3. **Wrong imagePullSecrets Secret** — `grep ecr` on secret names matched `cloudless-app-auth` (an Opaque Secret with Keycloak creds, not an ECR docker-registry Secret). Pods had no valid ECR credentials → immediate `ErrImagePull`.

## Fix

Both steps 7 and 8 now detect the docker-registry Secret by **type**, not by name:
```bash
kubectl get secret -n cloudless -o json | python3 -c \
  "import json,sys; d=json.load(sys.stdin); \
   items=[i['metadata']['name'] for i in d.get('items',[]) \
     if i.get('type')=='kubernetes.io/dockerconfigjson']; \
   print(items[0] if items else '')"
```

Step 7 auth extraction now uses python3 (handles `"auth": "..."` with spaces):
```python
auths=d.get('auths',{}); k=list(auths.keys())[0] if auths else '';
print(auths[k].get('auth','') if k else '')
```

---
_Generated by [Claude Code](https://claude.ai/code/session_013sTDMVEYibee8tbXxrwjzo)_