### PR TITLE
fix(rollout-pi-force): increase SSH ConnectTimeout 15→30s + 20s settle delay (run #24)

### DIFF
--- a/.github/workflows/rollout-pi-force.yml
+++ b/.github/workflows/rollout-pi-force.yml
@@ -19,7 +19,7 @@ on:
 env:
   # SHA used when triggered by push (no workflow_dispatch input available).
   # Update this value to re-trigger a rollout to a different image.
-  # run-23-trigger: 2026-06-07
+  # run-24-trigger: 2026-06-07
   DEFAULT_ROLLOUT_SHA: '89b57243c994'
   ECR_REGISTRY: 278585680617.dkr.ecr.us-east-1.amazonaws.com
   ECR_REPOSITORY: cloudless-pi-app
@@ -245,6 +245,12 @@ jobs:
           echo "Rolling out image tag: ${SHA}"
           IMAGE="${{ env.ECR_REGISTRY }}/${{ env.ECR_REPOSITORY }}:${SHA}"
 
+          # Give Pi SSH daemon 20s to settle after step 8's kubectl patch.
+          # Step 8 triggers k3s reconciliation; the resulting memory pressure
+          # can push SSH connection time above ConnectTimeout=15s.
+          echo "Waiting 20s for Pi to settle after imagePullSecrets patch..."
+          sleep 20
+
           # Retry loop: etcd may still be settling after startup maintenance.
           # All kubectl calls go via SSH (local k3s.yaml on Pi) to avoid the
           # Tailscale DERP TCP hang that causes remote kubectl to stall ~90s per call.
@@ -253,8 +259,8 @@ jobs:
 
             if ssh -i ~/.ssh/id_ed25519 \
                  -o StrictHostKeyChecking=no \
-                 -o ConnectTimeout=15 \
-                 -o ServerAliveInterval=15 \
+                 -o ConnectTimeout=30 \
+                 -o ServerAliveInterval=30 \
                  -o ServerAliveCountMax=3 \
                  "$PI_USER@$PI_HOST" \
                  "sudo kubectl --kubeconfig=/etc/rancher/k3s/k3s.yaml \


### PR DESCRIPTION
## Summary

- Run #23 failed at step 9: every SSH attempt timed out at exactly 15s (= `ConnectTimeout=15`). Step 8's `kubectl patch` to add `imagePullSecrets` triggers k3s reconciliation; the resulting memory pressure on the Pi pushes SSH connection time above 15s.
- Add a 20s settle sleep before the step 9 retry loop to let the Pi recover.
- Increase `ConnectTimeout` from 15s to 30s in the patch+set-image SSH command.

## Root cause evidence

```
09:45:55Z === kubectl attempt 1/3 (SSH) ===
09:46:10Z kubectl via SSH failed     ← exactly 15s = timeout
09:47:10Z === kubectl attempt 2/3 (SSH) ===
09:47:25Z kubectl via SSH failed     ← exactly 15s = timeout
09:48:25Z === kubectl attempt 3/3 (SSH) ===
09:48:40Z ::error::kubectl failed after 3 attempts (SSH)
```

Steps 7 and 8 each took exactly 15s and succeeded — SSH is already borderline slow. Step 8's kubectl patch pushed it over.

https://claude.ai/code/session_013sTDMVEYibee8tbXxrwjzo

---
_Generated by [Claude Code](https://claude.ai/code/session_013sTDMVEYibee8tbXxrwjzo)_