### PR TITLE
fix(deploy): remove environment: production to restore OIDC trust

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -37,10 +37,6 @@ jobs:
     # docs/runners.md "Workflows that stay GitHub-hosted".
     runs-on: ubuntu-latest
     timeout-minutes: 40
-    environment:
-      name: production
-      url: https://cloudless.gr
-
     env:
       NEXT_PUBLIC_HUBSPOT_PORTAL_ID: ${{ secrets.NEXT_PUBLIC_HUBSPOT_PORTAL_ID }}
       SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}


### PR DESCRIPTION
## Root cause

The deploy job declared `environment: production` which changes the OIDC token `sub` claim from:
```
repo:Themis128/cloudless.gr:ref:refs/heads/main
```
to:
```
repo:Themis128/cloudless.gr:environment:production
```

The IAM trust policy on the deploy role expects `ref:refs/heads/main`, so every deploy since the environment block was added failed with:
```
Not authorized to perform sts:AssumeRoleWithWebIdentity
```

The SHA drift detector (no environment declaration) uses the same OIDC provider and succeeds — confirming the trust policy itself is valid.

## Fix

Remove the `environment: name: production / url: https://cloudless.gr` block from the deploy job. This restores the sub claim to `ref:refs/heads/main`, matching the IAM trust policy.

## Cascade resolved

Once this merges and deploy succeeds:
- SSM `/cloudless/production/cloud-sha` gets updated with the new SHA
- SHA drift detector stops failing

https://claude.ai/code/session_01VGeEB9n192BxzKv6hL6Kqq

---
_Generated by [Claude Code](https://claude.ai/code/session_01VGeEB9n192BxzKv6hL6Kqq)_