### PR TITLE
chore(deploy): trigger fresh deploy after OIDC trust policy repair

### DIFF
--- a/public/sw.js
+++ b/public/sw.js
@@ -1,4 +1,5 @@
 /* global Response, URL, caches, fetch, self */
+/* deploy-trigger: 2026-06-07 — post OIDC trust policy repair */
 
 // Bump CACHE_VERSION on each deploy to invalidate stale caches
 const CACHE_VERSION = "5";


### PR DESCRIPTION
The OIDC trust policy for `GitHubActionsOIDC` was repaired by `oidc-diagnostic.yml` v5 — set to `StringLike: repo:Themis128/cloudless.gr:*`. Both the hardcoded ARN and the `AWS_DEPLOY_ROLE_ARN` secret now assume the role successfully.

All previous deploy failures were caused by the OIDC race condition (the trust policy was only repaired after each deploy had already exhausted retries). This commit triggers a clean deploy run to bring the live Lambda up to date.

https://claude.ai/code/session_01VGeEB9n192BxzKv6hL6Kqq

---
_Generated by [Claude Code](https://claude.ai/code/session_01VGeEB9n192BxzKv6hL6Kqq)_