### PR TITLE
fix(ci): upgrade configure-aws-credentials to v6.2.0 in deploy.yml

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -75,7 +75,7 @@ jobs:
           grep "CACHE_VERSION" public/sw.js
 
       - name: Configure AWS credentials (OIDC)
-        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v6 v4
+        uses: aws-actions/configure-aws-credentials@e7f100cf4c008499ea8adda475de1042d6975c7b # v6.2.0
         with:
           role-to-assume: ${{ secrets.AWS_DEPLOY_ROLE_ARN }}
           aws-region: us-east-1


### PR DESCRIPTION
## Problem

`deploy.yml` uses `aws-actions/configure-aws-credentials@7474bc4690…` which is a much older version (labeled v4/v5 in comments). Every deploy fails at the OIDC step with "Not authorized to perform sts:AssumeRoleWithWebIdentity" even though:

- `oidc-diagnostic.yml` uses `@e7f100cf4c…` (v6.2.0) and **succeeds** assuming the exact same role via the exact same `AWS_DEPLOY_ROLE_ARN` secret
- The IAM trust policy has been repaired to `StringLike: repo:Themis128/cloudless.gr:*`

The older action version has different OIDC token exchange behavior that fails with the current trust policy.

## Fix

Align `deploy.yml` to use the same `configure-aws-credentials` version (v6.2.0) that the diagnostic already verified works.

## Expected outcome

Next deploy run passes the OIDC step and proceeds to SST deploy.

https://claude.ai/code/session_01VGeEB9n192BxzKv6hL6Kqq

---
_Generated by [Claude Code](https://claude.ai/code/session_01VGeEB9n192BxzKv6hL6Kqq)_