### PR TITLE
fix(deploy): restore environment: production to fix OIDC sub claim

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -30,6 +30,7 @@ permissions:
 jobs:
   deploy:
     name: Deploy
+    environment: production
     # Pinned to ubuntu-latest. SST + CDK synth + Sentry sourcemap upload
     # do not fit on an ARM Pi runner under cold-deploy conditions — the
     # Deploy (SST) step hung past the 40 min timeout when we tried the

--- a/.github/workflows/oidc-diagnostic.yml
+++ b/.github/workflows/oidc-diagnostic.yml
@@ -408,21 +408,12 @@ jobs:
               fi
               if [ "$REPAIRED" != "true" ]; then
                 echo ""
-                echo "**Manual fix required** — AWS Console → IAM → Roles → \`$ROLE_DEPLOY\` → Trust relationships:"
-                echo '```json'
-                echo '{
-  "Version": "2012-10-17",
-  "Statement": [{
-    "Effect": "Allow",
-    "Principal": {"Federated": "arn:aws:iam::'"${ACCOUNT_ID}"':oidc-provider/token.actions.githubusercontent.com"},
-    "Action": "sts:AssumeRoleWithWebIdentity",
-    "Condition": {
-      "StringEquals": {"token.actions.githubusercontent.com:aud": "sts.amazonaws.com"},
-      "StringLike": {"token.actions.githubusercontent.com:sub": "repo:Themis128/cloudless.gr:*"}
-    }
-  }]
-}'
-                echo '```'
+                echo "**Manual fix required** — AWS Console → IAM → Roles → \`$ROLE_DEPLOY\` → Trust relationships"
+                echo ""
+                echo "- Principal Federated: \`arn:aws:iam::${ACCOUNT_ID}:oidc-provider/token.actions.githubusercontent.com\`"
+                echo "- Action: \`sts:AssumeRoleWithWebIdentity\`"
+                echo "- StringEquals aud: \`sts.amazonaws.com\`"
+                echo "- StringLike sub: \`repo:Themis128/cloudless.gr:*\`"
               fi
             elif [ "$HARD" = "success" ] && [ "$SEC" = "failure" ]; then
               echo "### ❌ \`AWS_DEPLOY_ROLE_ARN\` secret has wrong ARN — update it to:"


### PR DESCRIPTION
## Summary

The `GitHubActionsOIDC` trust policy was created when `deploy.yml` had `environment: production`. That block produces OIDC sub claim:

```
repo:Themis128/cloudless.gr:environment:production
```

Removing that block changed the sub to:

```
repo:Themis128/cloudless.gr:ref:refs/heads/main
```

which no longer matches the trust policy condition — hence the `Not authorized to perform sts:AssumeRoleWithWebIdentity` failures on every deploy since.

All automated repair attempts were exhausted (diagnostic runs 27090160397, 27090918852): `cloudless-github-actions` lacks `iam:UpdateAssumeRolePolicy` on `GitHubActionsOIDC`, and `GitHubActionsOIDC` does not allow `sts:AssumeRole` from `cloudless-github-actions`. No IAM change possible from CI.

Restoring `environment: production` reinstates the original sub claim without any AWS Console change.

## Test plan

- [ ] PR merges → Deploy to Production triggers on `main`
- [ ] "Configure AWS credentials (OIDC)" step succeeds (no retries)
- [ ] `pnpm sst deploy --stage production` completes
- [ ] SHA drift detector clears

https://claude.ai/code/session_01VGeEB9n192BxzKv6hL6Kqq

---
_Generated by [Claude Code](https://claude.ai/code/session_01VGeEB9n192BxzKv6hL6Kqq)_