### PR TITLE
ci(oidc): re-trigger deploy after trust policy fix

### DIFF
--- a/.github/workflows/restore-oidc-trust.yml
+++ b/.github/workflows/restore-oidc-trust.yml
@@ -1,3 +1,4 @@
+# last-verified: 2026-06-07
 name: Restore AWS OIDC trust policy
 
 on:


### PR DESCRIPTION
Trust policy on `GitHubActionsOIDC` manually repaired via AWS CloudShell. This PR triggers `deploy.yml` to verify OIDC authentication is working again.

---
_Generated by [Claude Code](https://claude.ai/code/session_01VGeEB9n192BxzKv6hL6Kqq)_