### PR TITLE
fix(routing): add missing middleware.ts to wire proxy into Next.js

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,0 +1,1 @@
+export { proxy as default, config } from "@/proxy";


### PR DESCRIPTION
## Summary

- `src/proxy.ts` had the full middleware implementation (next-intl locale routing, auth guards, CSP, rate limiting) but `src/middleware.ts` was missing — so Next.js never ran it
- Without middleware: locale routing didn't work, `/services`/`/work`/`/store` weren't redirected to locale-prefixed paths, admin auth guards were bypassed, CSP headers were missing
- Also forces a real Lambda code update (previous deploy was a no-op due to stale GitHub Actions build cache)

## What this fixes

- `/services` → redirects to `/en/services` ✅
- `/work`, `/store` → same ✅
- `/en/*` locale routes resolve correctly ✅
- `/api/auth/session` routed through proper API handler ✅
- Admin/dashboard auth guards active ✅
- CSP + security headers applied on all responses ✅

---
_Generated by [Claude Code](https://claude.ai/code/session_01VGeEB9n192BxzKv6hL6Kqq)_