### PR TITLE
fix(routing): remove src/middleware.ts (Next.js 16 conflict)

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,1 +1,0 @@
-export { proxy as default, config } from "@/proxy";


### PR DESCRIPTION
Commit #722 added `src/middleware.ts` (a 1-line re-export of proxy) alongside `src/proxy.ts`. Next.js 16 fails the build when both exist: `Both middleware file and proxy file are detected. Please use proxy.ts only.` This broke every deploy-pi run for ~1 day. `proxy.ts` is canonical and contains all logic; `middleware.ts` only re-exported it. Deleting it restores the build.