### PR TITLE
fix(deploy-pi): route build job onto self-hosted Pi runner

### DIFF
--- a/.github/workflows/deploy-pi.yml
+++ b/.github/workflows/deploy-pi.yml
@@ -36,8 +36,10 @@ env:
 jobs:
   build-and-push:
     name: Build arm64 image and push to ECR
-    # GH-hosted runner with QEMU for arm64 cross-compilation.
-    runs-on: ubuntu-latest
+    # Self-hosted arm64 runner (omv-build on omv-main). Native arm64 build —
+    # no QEMU emulation needed. GH-hosted QEMU build hangs past 60 min on
+    # pnpm install; the Pi runner finishes in 3-5 min.
+    runs-on: [self-hosted, omv, pi, build]
     outputs:
       short_sha: ${{ steps.check_ecr.outputs.short_sha }}
       image_exists: ${{ steps.check_ecr.outputs.exists }}


### PR DESCRIPTION
GH-hosted ubuntu-latest with QEMU arm64 emulation hangs for 40+ min on pnpm install. Run #27152127943 was cancelled at 38 min.

`omv-build` is a self-hosted arm64 Pi runner (USB-SSD-backed _work) that completes the same build in 3-5 min natively.

Switching the build job to `[self-hosted, omv, pi, build]`. The rollout job stays on ubuntu-latest since it just calls kubectl over Tailscale.