### PR TITLE
fix(deploy-pi): make cache dir step robust against dangling symlink

### DIFF
--- a/.github/workflows/deploy-pi.yml
+++ b/.github/workflows/deploy-pi.yml
@@ -88,8 +88,12 @@ jobs:
       - name: ensure local cache dirs exist
         if: steps.check_ecr.outputs.exists != 'true'
         run: |
-          sudo mkdir -p /opt/docker-cache
-          sudo chmod 777 /opt/docker-cache
+          # /opt/docker-cache is a symlink to a USB-SSD-backed dir on the Pi.
+          # If the target dir is pruned, mkdir -p on the dangling symlink
+          # fails. Resolve and create the actual target.
+          TARGET=$(readlink -f /opt/docker-cache || echo /opt/docker-cache)
+          sudo mkdir -p "$TARGET"
+          sudo chmod 777 "$TARGET"
 
       - name: warm base image into Docker daemon cache
         if: steps.check_ecr.outputs.exists != 'true'


### PR DESCRIPTION
`/opt/docker-cache` on the Pi build runner is a symlink to USB-SSD. When the target gets pruned, the symlink dangles and `mkdir -p /opt/docker-cache` fails with `File exists`.

Run #27154123827 failed exactly here. Already restored the target dir manually; this patch resolves the symlink in the workflow so the next prune does not break deploys.