### PR TITLE
fix(deploy-pi): surface kubectl errors instead of silent 10-min loop

### DIFF
--- a/.github/workflows/deploy-pi.yml
+++ b/.github/workflows/deploy-pi.yml
@@ -196,24 +196,49 @@ jobs:
           mkdir -p ~/.kube
           echo "${{ secrets.KUBECONFIG_B64 }}" | base64 -d > ~/.kube/config
           chmod 600 ~/.kube/config
+      - name: Diagnose kubectl reachability
+        # FAIL-FAST: the old "Wait for k3s /readyz" step swallowed kubectl
+        # stderr with `2>/dev/null`, so any auth/TLS/network error looped
+        # silently for 10 minutes as "not ready". Surface the real error
+        # before polling so failures are diagnosable in seconds, not minutes.
+        run: |
+          set +e
+          echo "==> kubeconfig (minified)"
+          kubectl config view --minify || echo "(kubectl config view failed)"
+          echo
+          echo "==> First /readyz call WITH stderr"
+          kubectl get --raw /readyz --request-timeout=10s
+          rc=$?
+          echo "kubectl exit code: $rc"
+          if [ "$rc" -ne 0 ]; then
+            echo "::error::kubectl could not reach the k3s API. Likely causes:"
+            echo "::error::  - KUBECONFIG_B64 secret is stale or wrong cluster CA"
+            echo "::error::  - Tailscale tunnel didn't come up (see prior step)"
+            echo "::error::  - k3s server cert was rotated (refresh KUBECONFIG_B64)"
+            exit 1
+          fi
       - name: Wait for k3s /readyz (3x stable via kubectl)
         run: |
-          # Use kubectl (kubeconfig creds) — anonymous curl returns 401 when
-          # anonymous-auth is disabled; kubectl uses the client cert in KUBECONFIG.
           # k3s /readyz returns the string "ok" when all checks pass.
+          # We do NOT suppress stderr — if kubectl starts failing, we want
+          # to see why immediately, not after a silent loop.
           wait_for_api() {
             local stable=0
-            for i in $(seq 1 120); do
-              if kubectl get --raw /readyz --request-timeout=5s 2>/dev/null \
-                  | grep -q 'ok'; then
+            local last_err=""
+            for i in $(seq 1 60); do
+              # Capture stderr to a temp so we can surface it on failure
+              out=$(kubectl get --raw /readyz --request-timeout=5s 2>/tmp/k_err)
+              rc=$?
+              if [ "$rc" -eq 0 ] && echo "$out" | grep -q 'ok'; then
                 stable=$((stable + 1))
-                echo "  ${i}/120 — /readyz ok (stable ${stable}/3)"
+                echo "  ${i}/60 — /readyz ok (stable ${stable}/3)"
                 if [ "$stable" -ge 3 ]; then
                   return 0
                 fi
               else
                 stable=0
-                echo "  ${i}/120 — /readyz not ready, waiting 5s..."
+                last_err=$(cat /tmp/k_err 2>/dev/null | head -3)
+                echo "  ${i}/60 — /readyz not ready (rc=$rc): ${last_err}"
               fi
               sleep 5
             done
@@ -224,7 +249,7 @@ jobs:
           if wait_for_api; then
             echo "k3s API stable — proceeding to rollout"
           else
-            echo "::error::k3s /readyz never returned 3x ok in 10 min — aborting"
+            echo "::error::k3s /readyz never returned 3x ok in 5 min — aborting"
             exit 1
           fi
       - name: Set image and roll out

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,9 @@
 # Claude Code — Project Memory
 
+## Working Style
+
+- **Never use placeholders.** No `<paste-output-here>`, no `TODO`, no `# TODO`, no `# fill in`, no `# replace this`, no `your-value-here`, no `xxx`, no `???`. If a value isn't known, fetch it, ask one direct question, or stop — do not write code/configs/docs that contain placeholders the user has to find and replace.
+
 ## Pending One-Time Setup (human action required)
 
 These require access outside GitHub and cannot be automated from a cloud session.


### PR DESCRIPTION
## What

The `Wait for k3s /readyz` step suppressed kubectl stderr with `2>/dev/null`, so any auth/TLS/network failure looped silently for 10 minutes as `not ready, waiting 5s...`

The last 4 deploy-pi runs failed this way with zero diagnostic output (runs 27154426439, 27154123827, 27148977109, 27148179594).

## How

- Add `Diagnose kubectl reachability` step that runs ONE kubectl call with stderr visible and exits fast with a hint if the API is unreachable.
- Rewrite the polling loop to capture stderr to `/tmp/k_err` and print it on each failed iteration.
- Shorten poll loop from 10min to 5min (the diagnostic step already proved the API is reachable).

## Why

Without this, every deploy failure is a 10-minute wait with no information. With this, real errors surface in seconds.