### PR TITLE
fix(deploy-pi): route rollout via vars.RUNNER_GENERIC for Pi failover

### DIFF
--- a/.github/workflows/deploy-pi.yml
+++ b/.github/workflows/deploy-pi.yml
@@ -160,13 +160,13 @@ jobs:
     name: Rollout restart on k3s
     # GH-hosted runner joins tailnet, uses KUBECONFIG_B64 to call k3s API
     # directly over Tailscale — no SSH hop required.
-    # Failover-capable: when GH-hosted billing is broken, flip
-    #   .github/scripts/toggle-runner.sh pi
-    # to route this onto the self-hosted Pi build runners. The Pi runners are
-    # already inside the local network and can reach the k3s API directly
-    # (192.168.1.128:6443) without Tailscale, so the tailnet step becomes a
-    # no-op on them.
-    runs-on: ubuntu-latest
+    # Failover-capable: when the GH-hosted runner's Tailscale path to the
+    # k3s API breaks (DERP relay failures, packet drops, billing issues),
+    # flip vars.RUNNER_GENERIC to ["self-hosted","omv","build"] via
+    # `.github/scripts/toggle-runner.sh pi`. The Pi runners can reach the
+    # k3s API over the LAN; the Tailscale step is a no-op on them.
+    # Default stays ubuntu-latest for cost (Pi runner busy with build job).
+    runs-on: ${{ fromJSON(vars.RUNNER_GENERIC || '"ubuntu-latest"') }}
     needs: build-and-push
     if: always() && needs.build-and-push.result != 'cancelled' && (needs.build-and-push.result == 'success' || needs.build-and-push.outputs.image_exists == 'true')
 


### PR DESCRIPTION
Run 27160204761 diagnostic step proved the GH-hosted runner cannot reach k3s API at 100.113.41.119:6443 over Tailscale (context deadline exceeded). Route via RUNNER_GENERIC variable so the toggle script can shift between hosted and Pi without further code edits. RUNNER_GENERIC already set to [self-hosted,omv,build] so the next run uses the Pi.