### PR TITLE
fix(auth-doctor): diagnose live Cognito /api/auth/* 500 on Pi

### DIFF
--- a/.github/workflows/app-auth-doctor.yml
+++ b/.github/workflows/app-auth-doctor.yml
@@ -46,9 +46,9 @@ jobs:
           [ -n "$AK" ] && echo "::add-mask::$AK"; [ -n "$SK" ] && echo "::add-mask::$SK"
           if [ -z "$AK" ] || [ -z "$SK" ]; then echo "## SSM: could not read pi-standby-aws-creds (keys may differ)"; kubectl -n cloudless get secret pi-standby-aws-creds -o jsonpath='{.data}' | grep -oE '"[^"]+":' | tr -d '":,' | sed 's/^/  key: /'; exit 0; fi
           export AWS_ACCESS_KEY_ID="$AK" AWS_SECRET_ACCESS_KEY="$SK" AWS_REGION=us-east-1
-          echo "## SSM /cloudless/production param NAMES matching AUTH|KEYCLOAK|NEXTAUTH:" | tee -a aad.log
+          echo "## SSM /cloudless/production param NAMES matching AUTH|COGNITO|KEYCLOAK|NEXTAUTH:" | tee -a aad.log
           aws ssm get-parameters-by-path --path /cloudless/production --recursive --query 'Parameters[].Name' --output text 2>&1 \
-            | tr '\t' '\n' | grep -iE 'AUTH_SECRET|KEYCLOAK|NEXTAUTH' | sed 's/^/  /' | tee -a aad.log || echo "  (none / aws error)" | tee -a aad.log
+            | tr '\t' '\n' | grep -iE 'AUTH_SECRET|COGNITO|KEYCLOAK|NEXTAUTH' | sed 's/^/  /' | tee -a aad.log || echo "  (none / aws error)" | tee -a aad.log
       - name: Post to tracking issue
         if: always()
         run: |

--- a/scripts/app-auth-doctor.sh
+++ b/scripts/app-auth-doctor.sh
@@ -26,7 +26,12 @@ kubectl -n "$NS" get deploy "$DEP" -o jsonpath='{range .spec.template.spec.conta
 echo
 echo "## auth-critical env present in the deployment?"
 ENVNAMES=$(kubectl -n "$NS" get deploy "$DEP" -o jsonpath='{.spec.template.spec.containers[0].env[*].name}' 2>/dev/null | tr ' ' '\n')
-for v in AUTH_SECRET KEYCLOAK_ISSUER KEYCLOAK_CLIENT_ID KEYCLOAK_CLIENT_SECRET NEXT_PUBLIC_KEYCLOAK_ISSUER; do
+# Cognito is the active provider (auth.ts gates next-auth on AUTH_SECRET +
+# COGNITO_ISSUER/CLIENT_ID at module load). Keycloak vars kept for fallback visibility.
+for v in AUTH_SECRET AUTH_TRUST_HOST AUTH_URL \
+         COGNITO_ISSUER COGNITO_CLIENT_ID COGNITO_CLIENT_SECRET COGNITO_DOMAIN \
+         NEXT_PUBLIC_AUTH_PROVIDER \
+         KEYCLOAK_ISSUER NEXT_PUBLIC_KEYCLOAK_ISSUER; do
   printf '  %-30s %s\n' "$v" "$(printf '%s\n' "$ENVNAMES" | grep -qx "$v" && echo PRESENT || echo MISSING)"
 done
 


### PR DESCRIPTION
## Why

Production `/api/auth/*` is broken:
- `pi-origin.cloudless.gr/api/auth/providers` → **HTTP 500** (but `/api/health` → 200)
- via CloudFront → **404** with `x-served-by: aws-fallback`, `x-cache: Error from cloudfront`

`src/lib/auth.ts` gates the entire next-auth instance on `AUTH_SECRET` + `COGNITO_ISSUER`/`COGNITO_CLIENT_ID` being present **at module load**. If any are missing from `process.env` when the route module loads (SSM-vs-instrumentation ordering on the Pi), every `/api/auth/*` route fails.

## What

Updates the **read-only** `app-auth-doctor` so it actually diagnoses the *Cognito* wiring:
- checks the env vars the app reads now (`AUTH_SECRET`, `AUTH_TRUST_HOST`, `AUTH_URL`, `COGNITO_ISSUER/CLIENT_ID/CLIENT_SECRET/DOMAIN`, `NEXT_PUBLIC_AUTH_PROVIDER`) instead of only `KEYCLOAK_*`
- widens the SSM param-name grep to include `COGNITO`

No values are ever printed. Merging fires the workflow (push path-filter) which posts the live wiring snapshot to issue #382.

## After merge
Read the #382 comment to confirm whether `COGNITO_ISSUER/CLIENT_ID/CLIENT_SECRET` + `AUTH_SECRET` are PRESENT on the deploy and exist in SSM. That pinpoints the exact missing var behind the 500.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
