### PR TITLE
fix: k3s standby E2E — Cloudflare edge topology + Footer #418 hydration

### DIFF
--- a/e2e/k3s/ha-failover.spec.ts
+++ b/e2e/k3s/ha-failover.spec.ts
@@ -1,8 +1,11 @@
 /**
- * HA failover path validation — verifies the dual-origin architecture
- * (CloudFront → Lambda primary, APIGW → Lambda → Pi standby).
+ * HA failover path validation — verifies the dual-origin architecture behind
+ * the Cloudflare edge (Cloudflare → CloudFront → Lambda primary; Cloudflare →
+ * Pi k3s standby). Cloudflare fronts both paths, so the client sees cf-ray on
+ * each; the primary-vs-standby backend split is asserted by the APIGW
+ * request-id check in standby-path.spec.ts, not by edge headers here.
  *
- * Catches: standby drift (different SHA), CloudFront origin misconfiguration,
+ * Catches: standby drift (different SHA), edge/DNS misconfiguration,
  * APIGW timeout, Lambda Funnel routing failure, Pi k3s pod crash.
  */
 import { test, expect } from "../coverage";
@@ -33,24 +36,33 @@ test.describe("HA failover readiness", () => {
     expect(typeof sBody.timestamp).toBe("string");
   });
 
-  test("primary path goes through CloudFront (x-cache header)", async ({ request }) => {
+  test("primary path goes through the Cloudflare edge (cf-ray header)", async ({ request }) => {
+    // The apex front door is Cloudflare, which proxies CloudFront → Lambda.
+    // Cloudflare terminates the client connection and strips the upstream
+    // x-amz-cf-* / x-cache headers, so the client only ever sees cf-ray here
+    // (same edge contract asserted in cloudflare-tunnel.spec.ts and
+    // tls-certificates.spec.ts). A missing cf-ray means the apex isn't behind
+    // Cloudflare — a real routing/DNS regression.
     const r = await request.get(`https://${PRIMARY_HOST}/api/health`, {
       failOnStatusCode: false,
     });
-    const headers = r.headers();
-    const isCloudFront =
-      !!headers["x-cache"] ||
-      !!headers["x-amz-cf-id"] ||
-      !!headers["x-amz-cf-pop"];
-    expect(isCloudFront, "primary path should route through CloudFront").toBe(true);
+    const cfRay = r.headers()["cf-ray"] ?? "";
+    expect(cfRay.length, "primary path should route through the Cloudflare edge").toBeGreaterThan(
+      0
+    );
   });
 
-  test("standby path does NOT go through CloudFront", async ({ request }) => {
+  test("standby path also routes through the Cloudflare edge", async ({ request }) => {
+    // The Pi standby is fronted by Cloudflare too (cf-ray present); it is NOT a
+    // raw origin exposed to the internet. The primary/standby distinction is the
+    // backend (CloudFront→Lambda vs Pi k3s), verified in standby-path.spec.ts.
     const r = await request.get(`https://${STANDBY_HOST}/api/health`, {
       failOnStatusCode: false,
     });
-    const server = (r.headers()["server"] ?? "").toLowerCase();
-    expect(server).not.toContain("cloudfront");
+    const cfRay = r.headers()["cf-ray"] ?? "";
+    expect(cfRay.length, "standby path should route through the Cloudflare edge").toBeGreaterThan(
+      0
+    );
   });
 
   test("Pi origin direct path is alive", async ({ request }) => {
@@ -75,7 +87,7 @@ test.describe("HA failover readiness", () => {
     const delta = Math.abs(standbyMs - primaryMs);
     expect(
       delta,
-      `latency delta ${delta}ms — primary ${primaryMs}ms, standby ${standbyMs}ms`,
+      `latency delta ${delta}ms — primary ${primaryMs}ms, standby ${standbyMs}ms`
     ).toBeLessThan(5_000);
   });
 });

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useEffect, useState } from "react";
 import { Link } from "@/i18n/navigation";
 import NewsletterForm from "@/components/NewsletterForm";
 import Logo from "@/components/Logo";
@@ -11,6 +12,22 @@ import { useCookieConsent } from "@/context/CookieConsentContext";
 export default function Footer() {
   const [locale] = useCurrentLocale();
   const { openSettings } = useCookieConsent();
+  // The page is ISR-cached (revalidate = 3600 + generateStaticParams), so the
+  // server HTML carries the year from the last build/revalidation. Reading
+  // `new Date().getFullYear()` during render — on the server OR in the initial
+  // client render — risks a different year than the cached HTML across a
+  // revalidation/year boundary → React #418 (hydration text mismatch). Mirror
+  // the useStoredPref() idiom: both sides render no year on the first pass,
+  // then a post-mount flip swaps in the live year (client-only). See
+  // src/lib/theme-pref.ts and e2e/k3s/assets.spec.ts.
+  const [mounted, setMounted] = useState(false);
+  useEffect(() => {
+    // Intentional post-hydration flip to swap from the SSR-matching empty
+    // snapshot to the real year. See React error #418 context above.
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    setMounted(true);
+  }, []);
+  const year = mounted ? new Date().getFullYear() : null;
 
   return (
     <footer
@@ -174,8 +191,8 @@ export default function Footer() {
         </div>
 
         <div className="border-neon-cyan/10 mt-4 flex flex-col items-center justify-between gap-4 border-t pt-5 font-mono text-xs sm:flex-row">
-          <p className="text-slate-400" suppressHydrationWarning>
-            &copy; {new Date().getFullYear()} Cloudless.{" "}
+          <p className="text-slate-400">
+            &copy; {year ?? ""} Cloudless.{" "}
             {translate(locale, "footer.rightsReserved", "All rights reserved.")}
           </p>
           <p className="text-slate-400">


### PR DESCRIPTION
The k3s standby E2E was failing on two issues **separate from** the auth fix (#738, now deployed — the `autherror`/500 cascade is gone). This fixes both.

## 1. `ha-failover.spec.ts` — assert the Cloudflare edge, not CloudFront

The apex is fronted by **Cloudflare** (the HA LB), which proxies CloudFront→Lambda and terminates client TLS — stripping the upstream `x-amz-cf-*`/`x-cache` headers. So `expect(isCloudFront).toBe(true)` failed against the real topology even though routing is healthy (apex returns `cf-ray`, no `x-amz-cf-*`).

The rest of the suite already encodes this — `cloudflare-tunnel.spec.ts` and `tls-certificates.spec.ts` assert `cf-ray`. Updated the primary/standby checks to match; the backend split stays covered by the APIGW request-id check in `standby-path.spec.ts`.

**Verified:** all 6 ha-failover tests pass against production.

## 2. `Footer.tsx` — hydration-safe copyright year (React #418)

The homepage is ISR-cached (`revalidate=3600` + `generateStaticParams`), so its HTML carries the year from the last revalidation. Footer (a client component) rendered `new Date().getFullYear()` inline → across a revalidation/year boundary the client year ≠ cached HTML year → **React #418** (text hydration mismatch), caught by `assets.spec.ts` on `/en`.

Mirrors the existing `useStoredPref()` idiom: no year on server + first client render (byte-identical), post-mount flip fills the live year. Drops the `suppressHydrationWarning` that was papering over it.

**Verified:** against prod, `assets.spec.ts` now reports *only* the #418 (auth errors gone), confirming this is the sole remaining cause; full unit suite (2039) + tsc pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)