### PR TITLE
fix(build-pi-image): tolerate immutable-tag race on concurrent SHA push

### DIFF
--- a/.github/workflows/build-pi-image.yml
+++ b/.github/workflows/build-pi-image.yml
@@ -251,7 +251,24 @@ jobs:
           IFS=',' read -ra TAGS <<< "${{ steps.tags.outputs.tags }}"
           for tag in "${TAGS[@]}"; do
             echo "==> docker push ${tag}"
-            docker push "${tag}"
+            # The repo has immutable tags. A *concurrent* build for the SAME
+            # commit (e.g. push + orchestrator dispatch both firing) can push
+            # this exact SHA tag while our long arm64 build is still running —
+            # the existence check at step start missed it. The losing push then
+            # fails "tag ... already exists ... immutable". Because the tag is
+            # content-addressed by commit SHA, the image is byte-identical, so
+            # that specific conflict is a no-op success, not a failure. Any
+            # OTHER push error still fails the step.
+            if ! out="$(docker push "${tag}" 2>&1)"; then
+              echo "${out}"
+              if echo "${out}" | grep -qiE "already exists.*immutable|tag.*immutable"; then
+                echo "==> ${tag} already present (immutable, identical SHA) — treating as success"
+                continue
+              fi
+              echo "::error::docker push ${tag} failed" >&2
+              exit 1
+            fi
+            echo "${out}"
           done
 
       # Record the pushed image digest in SSM so the Pi's image-sync CronJob


### PR DESCRIPTION
## Problem

The HA sync orchestrator false-failed on the #738 deploy. Root cause: a push to main **and** the orchestrator's own dispatch both triggered a `build pi image` run for the same commit (`ee8d3af`). The two runs race:

1. Both pass the step-start "does the SHA tag already exist?" check (it doesn't yet).
2. The faster build pushes the SHA tag + rolls out (Pi healthy, serving the fix ✅).
3. The slower arm64 build (~15 min) then loses the push:
   ```
   tag invalid: The image tag 'ee8d3af827fb' already exists in the 'cloudless-pi-app'
   repository and cannot be overwritten because the tag is immutable.
   ```
   → the whole job fails → the **HA sync orchestrator** false-fails off it, even though the deploy already succeeded.

## Fix

The SHA tag is content-addressed by commit, so a concurrent push of the same tag is **byte-identical** — that specific immutable conflict is a no-op success. The `push to ECR` step now captures the push output and treats an "already exists / immutable" error on the SHA tag as success; **any other push error still fails the step.**

Verified the grep matches the exact ECR error string from the failing run (27188719593).

Relates to the `ecr-immutable-tags-ci` pattern. (A concurrency-group on the workflow would prevent the duplicate entirely; this idempotent-push fix is the minimal, race-safe change.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)