### PR TITLE
docs(sonarcloud-triage): correct project key and org

### DIFF
--- a/.claude/skills/sonarcloud-triage/SKILL.md
+++ b/.claude/skills/sonarcloud-triage/SKILL.md
@@ -108,11 +108,17 @@ globalThis.fetch(...)
 
 ## SonarCloud project identifiers
 
-- **Organization:** `baltzakisthemiscom`
-- **Project key:** `cloudless-gr`
-- **Dashboard:** `sonarcloud.io/project/overview?id=cloudless-gr`
+- **Organization:** `Themis128` (NOT `baltzakisthemiscom` — that is the Sentry org)
+- **Project key:** `Themis128_cloudless.gr`
+- **Dashboard:** `sonarcloud.io/dashboard?id=Themis128_cloudless.gr`
 
-Hotspot acknowledgement URL pattern:
-`sonarcloud.io/project/security_hotspots?id=cloudless-gr&hotspots=<hotspot-key>`
+Analysis runs via SonarCloud's **automatic analysis** (the GitHub App) — there is no
+`sonar-project.properties` or Sonar step in the workflows, so the project key is only
+discoverable from the bot comment's dashboard URL (`?id=...`). SonarCloud keys follow the
+`{org}_{repo}` convention, hence org `Themis128`.
 
-The hotspot key is in the SonarCloud API response — the UI is the simplest path.
+Hotspot review URL for a PR:
+`sonarcloud.io/project/security_hotspots?id=Themis128_cloudless.gr&pullRequest=<PR#>&issueStatuses=OPEN,CONFIRMED&sinceLeakPeriod=true`
+
+The hotspot key is in the SonarCloud API response — but the API requires a `SONAR_TOKEN`
+(not present in cloud sessions), so the **UI is the only path** to enumerate and acknowledge.


### PR DESCRIPTION
## What
The `sonarcloud-triage` skill listed the wrong SonarCloud identifiers:
- Organization: `baltzakisthemiscom` → **`Themis128`** (the old value is the *Sentry* org, per `ci.yml`/`deploy.yml`)
- Project key: `cloudless-gr` → **`Themis128_cloudless.gr`**
- Dashboard URL corrected accordingly

Source of truth: the SonarCloud bot comment's own dashboard link (`?id=Themis128_cloudless.gr`). Keys follow the `{org}_{repo}` convention.

## Also clarified
- Analysis runs via SonarCloud automatic analysis (the GitHub App) — there's no `sonar-project.properties` or Sonar workflow step, so the key is only discoverable from the bot comment.
- The hotspots API needs a `SONAR_TOKEN` (absent in cloud sessions), so the UI is the only path to enumerate/acknowledge hotspots.

Docs-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)