### PR TITLE
fix(cloudflare): disable Email Obfuscation to stop React #418 on /en

### DIFF
--- a/.github/workflows/cloudflare-disable-email-obfuscation.yml
+++ b/.github/workflows/cloudflare-disable-email-obfuscation.yml
@@ -1,0 +1,95 @@
+name: Disable Cloudflare Email Obfuscation (fix React #418)
+
+# Cloudflare's "Email Obfuscation" (Scrape Shield) rewrites email addresses in
+# the HTML at the edge, AFTER Next.js SSR — injecting __cf_email__ placeholders
+# + a /cdn-cgi/.../email-decode.min.js script. React hydrates the plain-email
+# SSR markup against the edge-rewritten DOM → text mismatch → React error #418
+# on /en (caught by e2e/k3s/assets.spec.ts). The strict CSP also blocks the
+# injected decode script. This workflow turns the feature off zone-wide so the
+# edge HTML matches the SSR HTML again.
+#
+# HOW TO RUN: push any change to this file (or workflow_dispatch). Result is
+# posted to issue #382. Idempotent + reversible (set the value back to "on" in
+# the Cloudflare dashboard → Scrape Shield, or PATCH email_obfuscation:"on").
+#
+# Token: secrets.CLOUDFLARE_API_TOKEN, else SSM /cloudless/production/
+# CLOUDFLARE_API_TOKEN via the OIDC role. Needs Zone:Read + Zone Settings:Edit.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - ".github/workflows/cloudflare-disable-email-obfuscation.yml"
+      - "scripts/disable-cloudflare-email-obfuscation.sh"
+  workflow_dispatch:
+
+permissions:
+  id-token: write # OIDC fallback — reads token from SSM if repo secret is absent
+  contents: read
+  issues: write
+
+concurrency:
+  group: cloudflare-email-obfuscation
+  cancel-in-progress: false
+
+jobs:
+  disable:
+    runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ github.token }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v4.3.1
+
+      # Fallback: if CLOUDFLARE_API_TOKEN repo secret is absent, the OIDC role
+      # reads it from SSM /cloudless/production/CLOUDFLARE_API_TOKEN.
+      - name: Configure AWS credentials (OIDC)
+        continue-on-error: true
+        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4
+        with:
+          role-to-assume: ${{ secrets.AWS_DEPLOY_ROLE_ARN }}
+          aws-region: us-east-1
+
+      - name: Disable email obfuscation
+        id: disable
+        env:
+          AWS_REGION: us-east-1
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+        run: |
+          set -o pipefail
+          bash scripts/disable-cloudflare-email-obfuscation.sh 2>&1 | tee cf-email.log
+
+      # Verify the edge no longer injects the __cf_email__ rewrite. Cloudflare
+      # applies setting changes within seconds; retry briefly to avoid a race.
+      - name: Verify __cf_email__ is gone from /en
+        id: verify
+        run: |
+          set -o pipefail
+          ok=0
+          for i in $(seq 1 6); do
+            html="$(curl -fsS -m 20 https://cloudless.gr/en || true)"
+            if ! grep -q "__cf_email__\|data-cfemail\|email-decode" <<<"$html"; then
+              echo "✓ no email-obfuscation markers in /en HTML (attempt $i)"
+              ok=1; break
+            fi
+            echo "… markers still present (attempt $i), waiting…"
+            sleep 10
+          done
+          if [ "$ok" != "1" ]; then
+            echo "::warning::__cf_email__ still present after retries — propagation lag or Cloudflare cache; re-check shortly."
+          fi
+          echo "verified=$ok" >> "$GITHUB_OUTPUT"
+
+      - name: Post result to tracking issue
+        if: always()
+        run: |
+          {
+            echo "# Cloudflare Email Obfuscation — DISABLE — $(date -u '+%F %T')Z"
+            echo ""
+            echo "Fixes React #418 on /en (edge email rewrite vs SSR markup)."
+            echo "**Job:** ${{ job.status }}  •  **/en clean:** ${{ steps.verify.outputs.verified == '1' && 'yes' || 'not yet (propagation lag)' }}"
+            echo ""
+            echo '```'
+            cat cf-email.log 2>/dev/null || echo '(no log)'
+            echo '```'
+          } > c.md
+          gh issue comment 382 --repo "${{ github.repository }}" --body-file c.md

--- a/scripts/disable-cloudflare-email-obfuscation.sh
+++ b/scripts/disable-cloudflare-email-obfuscation.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+#
+# Disable Cloudflare "Email Obfuscation" (Scrape Shield) on the cloudless.gr
+# zone.
+#
+# WHY: Email Obfuscation rewrites email addresses in the HTML at the Cloudflare
+# edge — AFTER Next.js SSR — turning `contact@cloudless.gr` into an obfuscated
+# `<a class="__cf_email__" data-cfemail="...">` placeholder plus an injected
+# `/cdn-cgi/.../email-decode.min.js`. React then hydrates the SSR markup (plain
+# email) against the edge-rewritten DOM → text mismatch → React error #418 on
+# /en. The strict CSP also blocks the injected decode script. Turning the
+# feature off makes the edge HTML byte-identical to the SSR HTML again.
+#
+# Auth: CLOUDFLARE_API_TOKEN env, else SSM /cloudless/production/CLOUDFLARE_API_TOKEN.
+# The token needs Zone:Read + Zone Settings:Edit on zone cloudless.gr.
+#
+# Idempotent: if the setting is already "off" it reports success and changes
+# nothing. Safe to re-run.
+set -euo pipefail
+
+DOMAIN="${DOMAIN:-cloudless.gr}"
+API="https://api.cloudflare.com/client/v4"
+
+CF_TOKEN="${CLOUDFLARE_API_TOKEN:-}"
+if [ -z "$CF_TOKEN" ]; then
+  CF_TOKEN="$(aws ssm get-parameter --name /cloudless/production/CLOUDFLARE_API_TOKEN \
+    --with-decryption --query Parameter.Value --output text 2>/dev/null || true)"
+fi
+if [ -z "$CF_TOKEN" ]; then
+  echo "::error::no CLOUDFLARE_API_TOKEN — add a repo secret (or SSM /cloudless/production/CLOUDFLARE_API_TOKEN) with Zone:Read + Zone Settings:Edit on ${DOMAIN}."
+  exit 1
+fi
+
+cf() {
+  local method="$1" url="$2" body="${3:-}"
+  if [ -n "$body" ]; then
+    curl -fsS -X "$method" "$url" \
+      -H "Authorization: Bearer ${CF_TOKEN}" \
+      -H "Content-Type: application/json" \
+      --data "$body"
+  else
+    curl -fsS -X "$method" "$url" \
+      -H "Authorization: Bearer ${CF_TOKEN}" \
+      -H "Content-Type: application/json"
+  fi
+}
+
+ok() { echo "$1" | grep -q '"success":true'; }
+
+echo "==> resolving zone for ${DOMAIN}"
+ZRESP="$(cf GET "${API}/zones?name=${DOMAIN}")"
+ok "$ZRESP" || { echo "$ZRESP"; echo "::error::zone lookup failed (token missing Zone:Read?)"; exit 1; }
+ZONE_ID="$(echo "$ZRESP" | grep -o '"id":"[0-9a-f]\{32\}"' | head -1 | cut -d'"' -f4)"
+[ -n "$ZONE_ID" ] || { echo "::error::could not resolve zone id for ${DOMAIN}"; exit 1; }
+echo "    zone: ${ZONE_ID}"
+
+echo "==> current email_obfuscation setting"
+CUR="$(cf GET "${API}/zones/${ZONE_ID}/settings/email_obfuscation")" || true
+CUR_VAL="$(echo "$CUR" | grep -o '"value":"[a-z]*"' | head -1 | cut -d'"' -f4)"
+echo "    value: ${CUR_VAL:-unknown}"
+
+if [ "$CUR_VAL" = "off" ]; then
+  echo "==> already off — nothing to do"
+  exit 0
+fi
+
+echo "==> disabling email_obfuscation"
+RESP="$(cf PATCH "${API}/zones/${ZONE_ID}/settings/email_obfuscation" '{"value":"off"}')" || {
+  echo "$RESP"
+  echo "::error::PATCH failed — token likely missing 'Zone Settings: Edit' scope. Add it to the Cloudflare token (Zone → Zone Settings → Edit, zone ${DOMAIN})."
+  exit 1
+}
+ok "$RESP" || { echo "$RESP"; echo "::error::Cloudflare reported failure disabling email_obfuscation"; exit 1; }
+
+NEW_VAL="$(echo "$RESP" | grep -o '"value":"[a-z]*"' | head -1 | cut -d'"' -f4)"
+echo "==> email_obfuscation is now: ${NEW_VAL}"
+[ "$NEW_VAL" = "off" ] || { echo "::error::expected off, got ${NEW_VAL}"; exit 1; }
+echo "==> done. The __cf_email__ rewrite that caused React #418 on /en is disabled."


### PR DESCRIPTION
## Found by testing the prior #741 fix against production

The k3s standby E2E (`assets.spec.ts` "no fatal page errors on homepage load") still failed with React **#418** on `/en` even after the Footer year hardening shipped (#741). A browser capture against prod showed the real cause:

```
Loading 'https://.../cdn-cgi/scripts/.../email-decode.min.js' violates CSP ...
PAGEERROR: Minified React error #418
```

Cloudflare's **Email Obfuscation** (Scrape Shield) rewrites email addresses in the HTML **at the edge, after Next.js SSR**: `contact@cloudless.gr` → `<a class="__cf_email__" data-cfemail="...">` + an injected `/cdn-cgi/.../email-decode.min.js`. React hydrates the plain-email SSR markup against the edge-rewritten DOM → **text mismatch → #418**. The strict CSP also blocks the injected decode script.

Confirmed `__cf_email__` / `data-cfemail` / `email-decode` present on **all three hosts** (`apex`, `www`, `pi-origin`) — a zone-wide setting, not code.

> The Footer year fix in #741 was real hydration hardening (fixed a *local* #418, verified: zero hydration errors in dev) but it was not this production cause.

## Fix

A path-triggered workflow (mirrors `apply-cloudflare-lb.yml`'s token sourcing — repo secret + OIDC/SSM fallback) that `PATCH`es the zone's `email_obfuscation` setting to `off`, then verifies the markers are gone from `/en` and posts to issue #382. Idempotent + reversible.

**Token scope note:** the existing Cloudflare token may need **Zone Settings: Edit** added (it has Zone:Read + LB/DNS:Edit). The script reports clearly if the PATCH is denied for that reason.

## Validation
- `bash -n` + YAML lint pass; zone-id extraction verified against the CF response shape.
- Root cause reproduced via browser against `pi-origin.cloudless.gr` (the `__cf_email__` + CSP-blocked decode script).

🤖 Generated with [Claude Code](https://claude.com/claude-code)