### PR TITLE
chore: enable typescript-lsp, sonarqube, semgrep Claude Code plugins

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,4 +1,9 @@
 {
+  "enabledPlugins": {
+    "typescript-lsp@claude-plugins-official": true,
+    "sonarqube@claude-plugins-official": true,
+    "semgrep@claude-plugins-official": true
+  },
   "hooks": {
     "SessionStart": [
       {


### PR DESCRIPTION
## What
Enables three Claude Code plugins (from the `claude-plugins-official` marketplace) in the shared `.claude/settings.json`:

- **typescript-lsp** — semantic code intelligence across the TS/Next.js codebase
- **sonarqube** — enforces SonarCloud-style rules in the coding loop (repo targets 0 new issues)
- **semgrep** — real-time SAST, complements the API security audit agent

Personal authoring tools (plugin-dev, skill-creator, claude-md-management) live in the gitignored `settings.local.json` and are intentionally not part of this PR.

Plugins load on each contributor's next session start.

🤖 Generated with [Claude Code](https://claude.com/claude-code)