### PR TITLE
fix(build-pi-image): tolerate immutable-tag race on concurrent SHA push

### DIFF
--- a/.github/workflows/build-pi-image.yml
+++ b/.github/workflows/build-pi-image.yml
@@ -251,7 +251,24 @@ jobs:
           IFS=',' read -ra TAGS <<< "${{ steps.tags.outputs.tags }}"
           for tag in "${TAGS[@]}"; do
             echo "==> docker push ${tag}"
-            docker push "${tag}"
+            # The repo has immutable tags. A *concurrent* build for the SAME
+            # commit (e.g. push + orchestrator dispatch both firing) can push
+            # this exact SHA tag while our long arm64 build is still running —
+            # the existence check at step start missed it. The losing push then
+            # fails "tag ... already exists ... immutable". Because the tag is
+            # content-addressed by commit SHA, the image is byte-identical, so
+            # that specific conflict is a no-op success, not a failure. Any
+            # OTHER push error still fails the step.
+            if ! out="$(docker push "${tag}" 2>&1)"; then
+              echo "${out}"
+              if echo "${out}" | grep -qiE "already exists.*immutable|tag.*immutable"; then
+                echo "==> ${tag} already present (immutable, identical SHA) — treating as success"
+                continue
+              fi
+              echo "::error::docker push ${tag} failed" >&2
+              exit 1
+            fi
+            echo "${out}"
           done
 
       # Record the pushed image digest in SSM so the Pi's image-sync CronJob


### PR DESCRIPTION
## What
Restores the immutable-tag push guard in `build-pi-image.yml`. When a `push` to `main` and the HA sync orchestrator's `workflow_dispatch` fire for the **same commit SHA**, both can build concurrently and race into ECR. The losing push fails `tag … already exists … immutable` even though the image is byte-identical.

## Why
The start-of-run existence check misses a competing push that lands *during* the long arm64 build, and the ref-keyed concurrency group only serializes when the dispatch ref equals `main` (not guaranteed). This guard handles the conflict at the push, where the real resolved SHA is known.

## Behavior
- Normal push → success.
- Same-SHA immutable conflict → treated as success (no-op), step continues.
- Any **other** push error → still fails the step.

Unit-tested locally against a mocked `docker push` (3 cases, all pass).

🤖 Generated with [Claude Code](https://claude.com/claude-code)