### PR TITLE
fix(e2e): stop public-page audits racing Turbopack cold-compile

### DIFF
--- a/e2e/customer-behavior.spec.ts
+++ b/e2e/customer-behavior.spec.ts
@@ -63,15 +63,16 @@ test.describe("Homepage", () => {
 
   test("desktop: homepage → blog navigation works", async ({ page, isMobile }) => {
     test.skip(!!isMobile, "Navbar links hidden on mobile");
-    await page.goto("/");
-    await page.waitForLoadState("networkidle");
+    await page.goto("/", { waitUntil: "domcontentloaded" });
     const link = page.getByRole("navigation").first().getByRole("link", { name: /blog/i });
     await link.waitFor({ state: "visible" });
     await Promise.all([
-      page.waitForURL(/\/blog/, { timeout: 10000 }),
+      page.waitForURL(/\/blog/, { timeout: 15000 }),
       link.click(),
     ]);
-    await expect(page.getByRole("heading", { level: 1 })).toBeVisible();
+    // The URL flips before the cold blog route finishes streaming in dev mode;
+    // give the heading room to paint rather than asserting at the default deadline.
+    await expect(page.getByRole("heading", { level: 1 })).toBeVisible({ timeout: 15000 });
   });
 });
 

--- a/e2e/public-pages-audit.spec.ts
+++ b/e2e/public-pages-audit.spec.ts
@@ -111,22 +111,21 @@ for (const locale of LOCALES) {
 
       expect(status, `${route} → HTTP ${status}`).toBeLessThan(400);
 
-      // Check for actual content (h1 or main)
-      const hasH1 = await page
-        .locator("h1")
+      // Check for actual content (h1 or main). Actively wait for either to
+      // become visible — a fixed isVisible() timeout resolves false the instant
+      // the element isn't mounted yet, racing Turbopack's first-compile streaming
+      // of a cold route in dev mode (the cause of the /el/services flake).
+      const hasContent = await page
+        .locator("h1, main")
         .first()
-        .isVisible({ timeout: 10_000 })
-        .catch(() => false);
-      const hasMain = await page
-        .locator("main")
-        .first()
-        .isVisible({ timeout: 5_000 })
+        .waitFor({ state: "visible", timeout: 15_000 })
+        .then(() => true)
         .catch(() => false);
 
-      if (!hasH1 && !hasMain) {
+      if (!hasContent) {
         issues.push({ route, type: "missing", detail: "no <h1> or <main> element" });
       }
-      expect(hasH1 || hasMain, `${route}: no <h1> or <main> element`).toBeTruthy();
+      expect(hasContent, `${route}: no <h1> or <main> element`).toBeTruthy();
     });
   }
 }

--- a/e2e/public-pages-deep.spec.ts
+++ b/e2e/public-pages-deep.spec.ts
@@ -27,10 +27,16 @@ for (const route of PUBLIC_PAGES) {
     const status = resp?.status() ?? 0;
     expect(isAcceptableStatus(status), `got HTTP ${status} for ${route}`).toBeTruthy();
 
-    // Either an h1 or main content exists
-    const hasH1 = await page.locator("h1").first().isVisible({ timeout: 10_000 }).catch(() => false);
-    const hasMain = await page.locator("main").first().isVisible({ timeout: 5_000 }).catch(() => false);
-    expect(hasH1 || hasMain, `${route} has no h1 or main`).toBeTruthy();
+    // Either an h1 or main content exists. waitFor() actively waits for the
+    // element to appear rather than sampling visibility at a fixed deadline,
+    // which avoids racing Turbopack's first-compile streaming of a cold dev route.
+    const hasContent = await page
+      .locator("h1, main")
+      .first()
+      .waitFor({ state: "visible", timeout: 15_000 })
+      .then(() => true)
+      .catch(() => false);
+    expect(hasContent, `${route} has no h1 or main`).toBeTruthy();
 
     // Title present
     const title = await page.title();


### PR DESCRIPTION
## Problem

The full Playwright run surfaced one hard failure (`static /el/services — no <h1> or <main>`) plus 4 flaky entries (`/en/terms`, homepage→blog nav). All shared **one root cause**: the public-page audit/deep specs sampled element visibility at a *fixed deadline* via `isVisible({ timeout })`, which resolves `false` the instant the element isn't mounted yet — racing Turbopack's first-compile streaming of a cold dev route.

The pages themselves are fine: `/el/services` serves `HTTP 200` with exactly one `<h1>` and one `<main>` (verified by direct curl). The failure was purely a test-timing race, confirmed by the test passing on retry in isolation.

## Fix

- **`public-pages-audit.spec.ts` / `public-pages-deep.spec.ts`** — replace the fixed-deadline `isVisible()` sampling with an active `locator("h1, main").waitFor({ state: "visible" })`, so the assertion waits for content to paint instead of giving up early.
- **`customer-behavior.spec.ts`** (homepage→blog nav) — drop the discouraged `waitForLoadState("networkidle")` and give the post-navigation heading a cold-compile-tolerant timeout (the URL flips before the cold blog route finishes streaming).

## Verification

- `tsc --noEmit` clean on all three specs
- **15/15** passes on warm cache and **9/9** on a cold-rebuilt `.next`, both under `--retries=0 --repeat-each --workers>=3` — the exact parallel/no-retry condition that exposed the original flake

No production code changed; e2e specs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)