### PR TITLE
test(coverage): raise unit-test floor and lock it with thresholds

### DIFF
--- a/__tests__/lib-coverage-gaps.test.ts
+++ b/__tests__/lib-coverage-gaps.test.ts
@@ -167,6 +167,142 @@ describe("ssm-config.ts", () => {
   });
 });
 
+// ── ssm-config.ts — real SSM fetch path ───────────────────────────────────────
+// getConfig() short-circuits to env when NODE_ENV === "test", so to exercise
+// fetchSsmParams/buildConfigFromParams/validateRequiredKeys we temporarily flip
+// NODE_ENV to "production" and stub the @aws-sdk/client-ssm boundary (a network
+// dependency — not production code) to return canned parameters.
+
+describe("ssm-config.ts — SSM fetch path", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    // Restore NODE_ENV (and any other stubbed env) so other suites keep their
+    // env short-circuit. setup.ts also calls unstubAllEnvs() globally.
+    vi.unstubAllEnvs();
+  });
+
+  function stubSsm(pages: Array<{ Parameters?: Array<{ Name: string; Value: string }>; NextToken?: string }>) {
+    let call = 0;
+    const send = vi.fn(async () => pages[Math.min(call++, pages.length - 1)]);
+    vi.doMock("@aws-sdk/client-ssm", () => ({
+      SSMClient: class {
+        send = send;
+      },
+      GetParametersByPathCommand: class {
+        input: unknown;
+        constructor(input: unknown) {
+          this.input = input;
+        }
+      },
+    }));
+    return send;
+  }
+
+  it("builds config from SSM parameters and strips the prefix", async () => {
+    vi.stubEnv("NODE_ENV", "production");
+    stubSsm([
+      {
+        Parameters: [
+          { Name: "/cloudless/production/STRIPE_SECRET_KEY", Value: "sk_live_x" },
+          { Name: "/cloudless/production/STRIPE_WEBHOOK_SECRET", Value: "whsec_y" },
+          { Name: "/cloudless/production/NOTION_API_KEY", Value: "ntn_from_ssm" },
+        ],
+      },
+    ]);
+    const { getConfig, resetSsmCache } = await import("@/lib/ssm-config");
+    resetSsmCache();
+    const cfg = await getConfig();
+    expect(cfg.STRIPE_SECRET_KEY).toBe("sk_live_x");
+    expect(cfg.STRIPE_WEBHOOK_SECRET).toBe("whsec_y");
+    expect(cfg.NOTION_API_KEY).toBe("ntn_from_ssm");
+  });
+
+  it("follows NextToken pagination across multiple pages", async () => {
+    vi.stubEnv("NODE_ENV", "production");
+    const send = stubSsm([
+      {
+        Parameters: [{ Name: "/cloudless/production/STRIPE_SECRET_KEY", Value: "sk_p1" }],
+        NextToken: "page2",
+      },
+      {
+        Parameters: [{ Name: "/cloudless/production/STRIPE_WEBHOOK_SECRET", Value: "whsec_p2" }],
+      },
+    ]);
+    const { getConfig, resetSsmCache } = await import("@/lib/ssm-config");
+    resetSsmCache();
+    const cfg = await getConfig();
+    expect(send).toHaveBeenCalledTimes(2);
+    expect(cfg.STRIPE_SECRET_KEY).toBe("sk_p1");
+    expect(cfg.STRIPE_WEBHOOK_SECRET).toBe("whsec_p2");
+  });
+
+  it("normalizes escaped newlines in GOOGLE_PRIVATE_KEY from SSM", async () => {
+    vi.stubEnv("NODE_ENV", "production");
+    stubSsm([
+      {
+        Parameters: [
+          { Name: "/cloudless/production/STRIPE_SECRET_KEY", Value: "sk" },
+          { Name: "/cloudless/production/STRIPE_WEBHOOK_SECRET", Value: "wh" },
+          { Name: "/cloudless/production/GOOGLE_PRIVATE_KEY", Value: String.raw`-----BEGIN-----\nLINE2\n-----END-----` },
+        ],
+      },
+    ]);
+    const { getConfig, resetSsmCache } = await import("@/lib/ssm-config");
+    resetSsmCache();
+    const cfg = await getConfig();
+    expect(cfg.GOOGLE_PRIVATE_KEY).not.toContain(String.raw`\n`);
+    expect(cfg.GOOGLE_PRIVATE_KEY).toContain("\nLINE2\n");
+  });
+
+  it("warns when required Stripe keys are missing but still returns config", async () => {
+    vi.stubEnv("NODE_ENV", "production");
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    stubSsm([{ Parameters: [{ Name: "/cloudless/production/NOTION_API_KEY", Value: "n" }] }]);
+    const { getConfig, resetSsmCache } = await import("@/lib/ssm-config");
+    resetSsmCache();
+    const cfg = await getConfig();
+    expect(cfg.NOTION_API_KEY).toBe("n");
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining("Missing required parameters"));
+    warn.mockRestore();
+  });
+
+  it("serves stale cache when a later SSM fetch fails", async () => {
+    vi.stubEnv("NODE_ENV", "production");
+    let call = 0;
+    const send = vi.fn(async () => {
+      call += 1;
+      if (call === 1) {
+        return { Parameters: [
+          { Name: "/cloudless/production/STRIPE_SECRET_KEY", Value: "sk_cached" },
+          { Name: "/cloudless/production/STRIPE_WEBHOOK_SECRET", Value: "wh_cached" },
+        ] };
+      }
+      throw new Error("transient SSM outage");
+    });
+    vi.doMock("@aws-sdk/client-ssm", () => ({
+      SSMClient: class { send = send; },
+      GetParametersByPathCommand: class { constructor(public input: unknown) {} },
+    }));
+    const { getConfig, resetSsmCache } = await import("@/lib/ssm-config");
+    resetSsmCache();
+    const first = await getConfig();
+    expect(first.STRIPE_SECRET_KEY).toBe("sk_cached");
+    // Force the 5-min TTL to expire so the next call re-fetches (and fails)
+    vi.useFakeTimers();
+    vi.setSystemTime(Date.now() + 6 * 60 * 1000);
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const second = await getConfig();
+    expect(second.STRIPE_SECRET_KEY).toBe("sk_cached"); // stale cache served
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining("serving stale config"), expect.anything());
+    warn.mockRestore();
+    vi.useRealTimers();
+  });
+});
+
 // ── auth.ts ───────────────────────────────────────────────────────────────────
 // auth.ts uses next-auth which requires Node environment (not jsdom).
 // We verify it imports correctly in our test env by mocking next-auth.

--- a/__tests__/notion-testimonials.test.ts
+++ b/__tests__/notion-testimonials.test.ts
@@ -7,11 +7,17 @@ vi.mock("@/lib/notion-cache", () => ({
 }));
 
 const mockNotionFetchAll = vi.fn();
+const mockCreatePage = vi.fn();
+const mockUpdatePage = vi.fn();
+const mockArchivePage = vi.fn();
 
 vi.mock("@/lib/notion", () => ({
   notionFetchAll: (...args: unknown[]) => mockNotionFetchAll(...args),
   extractText: (rt: { plain_text: string }[] | undefined) =>
     (rt ?? []).map((t) => t.plain_text).join(""),
+  createPage: (...args: unknown[]) => mockCreatePage(...args),
+  updatePage: (...args: unknown[]) => mockUpdatePage(...args),
+  archivePage: (...args: unknown[]) => mockArchivePage(...args),
 }));
 
 function makeTestimonialPage(overrides: Record<string, unknown> = {}) {
@@ -176,6 +182,125 @@ describe("notion-testimonials.ts", () => {
         quote: expect.any(String),
         featured: expect.any(Boolean),
       });
+    });
+  });
+
+  describe("getAllTestimonialsAdmin", () => {
+    it("returns static fallback when not configured", async () => {
+      process.env.NOTION_API_KEY = "";
+      resetIntegrationCache();
+      const { getAllTestimonialsAdmin, staticTestimonials } = await import("@/lib/notion-testimonials");
+      const result = await getAllTestimonialsAdmin();
+      expect(result).toEqual(staticTestimonials);
+      expect(mockNotionFetchAll).not.toHaveBeenCalled();
+    });
+
+    it("lists every page sorted by Order (no Published filter)", async () => {
+      mockNotionFetchAll.mockResolvedValueOnce([
+        makeTestimonialPage(),
+        makeTestimonialPage({ id: "t-2", properties: { ...makeTestimonialPage().properties, Published: { checkbox: false } } }),
+      ]);
+      const { getAllTestimonialsAdmin } = await import("@/lib/notion-testimonials");
+      const result = await getAllTestimonialsAdmin();
+      expect(result).toHaveLength(2);
+      const [, body] = mockNotionFetchAll.mock.calls[0];
+      expect(body.filter).toBeUndefined();
+      expect(body.sorts).toEqual([{ property: "Order", direction: "ascending" }]);
+    });
+
+    it("returns empty array on fetch error", async () => {
+      mockNotionFetchAll.mockRejectedValueOnce(new Error("boom"));
+      const { getAllTestimonialsAdmin } = await import("@/lib/notion-testimonials");
+      expect(await getAllTestimonialsAdmin()).toEqual([]);
+    });
+  });
+
+  describe("createTestimonial", () => {
+    it("maps input to Notion props and invalidates cache on success", async () => {
+      mockCreatePage.mockResolvedValueOnce("new-page-id");
+      const { createTestimonial } = await import("@/lib/notion-testimonials");
+      const { invalidateCache } = await import("@/lib/notion-cache");
+      const id = await createTestimonial({
+        name: "Maria K.", company: "Acme", role: "CEO", quote: "Great work",
+        avatar: "https://x/a.png", service: "Audit", rating: 4, featured: true, published: true, order: 2,
+      });
+      expect(id).toBe("new-page-id");
+      const [dbId, props] = mockCreatePage.mock.calls[0];
+      expect(dbId).toBe("test-testimonials-db");
+      expect(props.Name).toEqual({ title: [{ text: { content: "Maria K." } }] });
+      expect(props.Rating).toEqual({ number: 4 });
+      expect(props.Avatar).toEqual({ url: "https://x/a.png" });
+      expect(props.Featured).toEqual({ checkbox: true });
+      expect(invalidateCache).toHaveBeenCalledWith("testimonials");
+    });
+
+    it("omits optional props when absent and does not invalidate on null id", async () => {
+      mockCreatePage.mockResolvedValueOnce(null);
+      const { createTestimonial } = await import("@/lib/notion-testimonials");
+      const { invalidateCache } = await import("@/lib/notion-cache");
+      const id = await createTestimonial({ name: "No Extras", quote: "ok" });
+      expect(id).toBeNull();
+      const [, props] = mockCreatePage.mock.calls[0];
+      expect(props.Avatar).toBeUndefined();
+      expect(props.Service).toBeUndefined();
+      expect(props.Rating).toBeUndefined();
+      expect(props.Featured).toEqual({ checkbox: false });
+      expect(invalidateCache).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("updateTestimonial", () => {
+    it("builds a partial prop set and invalidates cache when update succeeds", async () => {
+      mockUpdatePage.mockResolvedValueOnce(true);
+      const { updateTestimonial } = await import("@/lib/notion-testimonials");
+      const { invalidateCache } = await import("@/lib/notion-cache");
+      const ok = await updateTestimonial("page-7", { quote: "Updated", rating: 5 });
+      expect(ok).toBe(true);
+      const [pageId, props] = mockUpdatePage.mock.calls[0];
+      expect(pageId).toBe("page-7");
+      expect(props.Quote).toEqual({ rich_text: [{ text: { content: "Updated" } }] });
+      expect(props.Rating).toEqual({ number: 5 });
+      expect(props.Name).toBeUndefined();
+      expect(invalidateCache).toHaveBeenCalledWith("testimonials");
+    });
+
+    it("clears avatar/service via null when explicitly set empty", async () => {
+      mockUpdatePage.mockResolvedValueOnce(true);
+      const { updateTestimonial } = await import("@/lib/notion-testimonials");
+      await updateTestimonial("page-8", { avatar: "", service: "" });
+      const [, props] = mockUpdatePage.mock.calls[0];
+      expect(props.Avatar).toEqual({ url: null });
+      expect(props.Service).toEqual({ select: null });
+    });
+
+    it("does not invalidate cache when update fails", async () => {
+      mockUpdatePage.mockResolvedValueOnce(false);
+      const { updateTestimonial } = await import("@/lib/notion-testimonials");
+      const { invalidateCache } = await import("@/lib/notion-cache");
+      const ok = await updateTestimonial("page-9", { name: "X" });
+      expect(ok).toBe(false);
+      expect(invalidateCache).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("deleteTestimonial", () => {
+    it("archives the page and invalidates cache on success", async () => {
+      mockArchivePage.mockResolvedValueOnce(true);
+      const { deleteTestimonial } = await import("@/lib/notion-testimonials");
+      const { invalidateCache } = await import("@/lib/notion-cache");
+      const ok = await deleteTestimonial("page-del");
+      expect(ok).toBe(true);
+      expect(mockArchivePage).toHaveBeenCalledWith("page-del");
+      expect(invalidateCache).toHaveBeenCalledWith("testimonials");
+    });
+
+    it("returns false and skips cache invalidation when archive fails", async () => {
+      mockArchivePage.mockResolvedValueOnce(false);
+      const { deleteTestimonial } = await import("@/lib/notion-testimonials");
+      const { invalidateCache } = await import("@/lib/notion-cache");
+      const ok = await deleteTestimonial("page-x");
+      expect(ok).toBe(false);
+      expect(invalidateCache).not.toHaveBeenCalled();
     });
   });
 });

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -100,11 +100,15 @@ export default defineConfig({
         "src/**/types.ts",
         "src/**/index.ts",
       ],
+      // Ratchet thresholds: set a few points below the current measured
+      // coverage so CI fails on a regression but tolerates normal variance.
+      // Measured 2026-06-09: lines 49.98 / stmts 48.51 / funcs 39.01 / branches 39.27.
+      // Raise these as coverage improves; never lower them.
       thresholds: {
-        lines: 0,
-        functions: 0,
-        branches: 0,
-        statements: 0,
+        lines: 47,
+        functions: 37,
+        branches: 37,
+        statements: 46,
       },
     },
   },


### PR DESCRIPTION
## What

Raises unit-test coverage on the two lowest-coverage high-value lib files and locks the gains with non-zero CI thresholds (previously all `0`).

| File | Before (lines) | After (lines) | Funcs |
|------|---------------:|--------------:|------:|
| `src/lib/ssm-config.ts` | 25% | **85%** | 100% |
| `src/lib/notion-testimonials.ts` | 25% | **100%** | 100% |

Aggregate moved up: lines **49.43 → 49.98**, branches **37.47 → 39.27**, statements **47.95 → 48.51**, functions **38.74 → 39.01**.

## How

- **ssm-config** — the SSM *fetch* path was never run because `getConfig()` short-circuits to env when `NODE_ENV === "test"`. New tests flip `NODE_ENV` via `vi.stubEnv` and stub the `@aws-sdk/client-ssm` boundary (a network dependency — matching the repo's existing SSM mocks, **not** mocking production code) to cover pagination (`NextToken`), `buildConfigFromParams`, key normalization, the missing-required-key warning, and stale-cache-on-failure.
- **notion-testimonials** — added the admin CRUD surface (`getAllTestimonialsAdmin`, `create/update/deleteTestimonial`): prop mapping, optional-field omission, null/empty clearing, and cache-invalidation gating.
- **vitest.config.mts** — ratchet thresholds set a few points below the measured aggregate (lines 47 / statements 46 / functions 37 / branches 37) so CI fails on regression but tolerates variance. Comment notes the measured baseline and "raise, never lower."

## Verification

- Full unit suite green
- `vitest run --coverage` exits **0** against the new thresholds (verified locally)

No production code changed — tests + coverage config only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)