### PR TITLE
fix(footer): client-side mailto href so Cloudflare can't rewrite it

### DIFF
--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -117,10 +117,12 @@ export default function Footer() {
                     just like before, no React #418, no [email protected]
                     placeholder, no CSP-blocked decode script. */}
                 <a
-                  href={`mailto:${"tbaltzakis"}@${"cloudless.gr"}`}
+                  href={mounted ? `mailto:${"tbaltzakis"}@${"cloudless.gr"}` : "#"}
                   className="hover:text-neon-cyan active:text-neon-cyan text-xs text-slate-400 transition-colors"
                 >
-                  {"tbaltzakis"}<span aria-hidden="true">{"@"}</span>{"cloudless.gr"}
+                  {"tbaltzakis"}
+                  <span aria-hidden="true">{"@"}</span>
+                  {"cloudless.gr"}
                 </a>
               </li>
               <li className="text-xs text-slate-400">


### PR DESCRIPTION
Follow-up to PR #758. That fixed the visible text but href is still rewritten because mailto:tbaltzakis@cloudless.gr was still a literal in the SSR HTML.

Move href construction to useEffect → SSR HTML has href='#', real mailto: only appears post-hydration. CF only scans SSR, so it leaves the link alone.

Verified locally: link works after hydration, no data-cfemail, no /cdn-cgi rewrite.