### PR TITLE
fix(ci): pin configure-aws-credentials SHA in wire-pi-cognito

### DIFF
--- a/.github/workflows/wire-pi-cognito.yml
+++ b/.github/workflows/wire-pi-cognito.yml
@@ -46,7 +46,7 @@ jobs:
           done
 
       - name: Configure AWS credentials (OIDC)
-        uses: aws-actions/configure-aws-credentials@ececc3a90d58a371f81a37fcedcc63e9e0e1e78e # v4.1.0
+        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4
         with:
           role-to-assume: ${{ secrets.AWS_DEPLOY_ROLE_ARN }}
           aws-region: us-east-1


### PR DESCRIPTION
URGENT: live login broken. User hit cognito hosted UI with client_id=REPLACE_WITH_APP_CLIENT_ID.

Root cause: k8s Secret cloudless-app-auth still has KEYCLOAK_* env vars, not COGNITO_*. The Cognito migration (PR #677) updated source but never ran wire-pi-cognito.yml.

When I tried to run it now, the action SHA was stale. This PR fixes the SHA to one used by 14 other workflows. Once merged + re-run, the Cognito secrets get wired and login works.