### PR TITLE
ci: alt wire-pi-cognito running on Pi self-hosted runner

### DIFF
--- a/.github/workflows/wire-pi-cognito-from-pi.yml
+++ b/.github/workflows/wire-pi-cognito-from-pi.yml
@@ -1,0 +1,49 @@
+name: Wire Pi → Cognito auth (from Pi runner)
+
+# Same as wire-pi-cognito.yml but runs ON the Pi where kubectl can reach
+# the local cluster directly (no Tailscale needed). Triggered via repo
+# workflow_dispatch.
+
+on:
+  workflow_dispatch:
+
+permissions:
+  id-token: write
+  contents: read
+  issues: write
+
+jobs:
+  wire:
+    runs-on: [self-hosted, omv, pi]
+    env:
+      GH_TOKEN: ${{ github.token }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v4.3.1
+
+      - name: Configure AWS credentials (OIDC)
+        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4
+        with:
+          role-to-assume: ${{ secrets.AWS_DEPLOY_ROLE_ARN }}
+          aws-region: us-east-1
+
+      - name: Wire Cognito auth onto Pi deployment
+        env:
+          KUBECONFIG: /etc/rancher/k3s/k3s.yaml
+        run: |
+          # The Pi runner has kubectl with system:admin via local k3s
+          sudo chmod 644 /etc/rancher/k3s/k3s.yaml || true
+          bash scripts/wire-pi-cognito.sh 2>&1 | tee wire.log
+
+      - name: Post result to tracking issue
+        if: always()
+        run: |
+          {
+            echo "# Wire Pi → Cognito (from Pi runner) — $(date -u '+%F %T')Z"
+            echo ""
+            echo "**Job:** ${{ job.status }}"
+            echo ""
+            echo '```'
+            cat wire.log 2>/dev/null || echo '(no log)'
+            echo '```'
+          } > c.md
+          gh issue comment 382 --repo "${{ github.repository }}" --body-file c.md


### PR DESCRIPTION
URGENT: live login broken. The original workflow hangs forever on 'Wait for cluster API' because Tailscale → k3s is blocked by network policy. Run from Pi runner instead.