### PR TITLE
revert(footer): plain mailto now that CF Email Obfuscation is disabled

### DIFF
--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -108,21 +108,11 @@ export default function Footer() {
             </p>
             <ul className="space-y-2 font-mono text-sm">
               <li>
-                {/* Defeat Cloudflare's Email Address Obfuscation by emitting the
-                    email in pieces that don't form a contiguous "x@y.z" string
-                    in the rendered HTML. CF's edge regex only rewrites if it
-                    sees a recognisable email pattern. Splitting at "@" via
-                    separate text nodes (with HTML comments between) prevents
-                    detection — the visible result reads tbaltzakis@cloudless.gr
-                    just like before, no React #418, no [email protected]
-                    placeholder, no CSP-blocked decode script. */}
                 <a
-                  href={mounted ? `mailto:${"tbaltzakis"}@${"cloudless.gr"}` : "#"}
+                  href="mailto:tbaltzakis@cloudless.gr"
                   className="hover:text-neon-cyan active:text-neon-cyan text-xs text-slate-400 transition-colors"
                 >
-                  {"tbaltzakis"}
-                  <span aria-hidden="true">{"@"}</span>
-                  {"cloudless.gr"}
+                  tbaltzakis@cloudless.gr
                 </a>
               </li>
               <li className="text-xs text-slate-400">


### PR DESCRIPTION
CF Email Obfuscation is off → workaround no longer needed.