### PR TITLE
refactor: complete Keycloak teardown (admin/users + tests + ssm)

### DIFF
--- a/__tests__/admin-api.test.ts
+++ b/__tests__/admin-api.test.ts
@@ -138,16 +138,15 @@ vi.mock("jose", async () => {
 // Helpers
 // ---------------------------------------------------------------------------
 
-/** Build a mock admin JWT with Keycloak claims. No real signature — tests
- *  clear KEYCLOAK_ISSUER so verifyToken takes the dev decode-only fallback. */
+/** Build a mock admin JWT with Cognito-style claims. No real signature —
+ *  verifyToken falls back to decode-only when COGNITO_ISSUER is unset. */
 function makeAdminToken(): string {
   const payload = {
     sub: "test-admin-sub",
     email: "admin@cloudless.gr",
     preferred_username: "admin-user",
     groups: ["admin"],
-    realm_access: { roles: ["admin", "default-roles-cloudless"] },
-    iss: "https://auth.cloudless.gr/realms/cloudless",
+    iss: "https://cognito-idp.us-east-1.amazonaws.com/us-east-1_TEST",
     iat: Math.floor(Date.now() / 1000) - 60,
     exp: Math.floor(Date.now() / 1000) + 3600,
   };
@@ -156,15 +155,14 @@ function makeAdminToken(): string {
   return `${header}.${body}.fake-sig`;
 }
 
-/** Build a mock non-admin JWT with Keycloak claims. */
+/** Build a mock non-admin JWT with Cognito-style claims. */
 function makeUserToken(): string {
   const payload = {
     sub: "test-user-sub",
     email: "user@cloudless.gr",
     preferred_username: "regular-user",
     groups: [],
-    realm_access: { roles: ["default-roles-cloudless"] },
-    iss: "https://auth.cloudless.gr/realms/cloudless",
+    iss: "https://cognito-idp.us-east-1.amazonaws.com/us-east-1_TEST",
     iat: Math.floor(Date.now() / 1000) - 60,
     exp: Math.floor(Date.now() / 1000) + 3600,
   };
@@ -192,8 +190,6 @@ function unauthRequest(url: string): NextRequest {
 // Mocks — set up before any dynamic import
 // ---------------------------------------------------------------------------
 
-// Keycloak Admin REST API — mocked via globalThis.fetch
-// (the route no longer uses @aws-sdk/client-cognito-identity-provider)
 const mockCognitoSend = vi.fn(); // kept so references below don't break
 vi.mock("@aws-sdk/client-cognito-identity-provider", () => ({
   CognitoIdentityProviderClient: class {
@@ -333,211 +329,6 @@ vi.mock("@/lib/sentry", () => ({
 // /api/admin/users
 // ---------------------------------------------------------------------------
 
-describe("GET /api/admin/users", () => {
-  const kcUserList = [
-    {
-      id: "uuid-user-1",
-      username: "user1",
-      email: "user1@example.com",
-      firstName: "User",
-      lastName: "One",
-      emailVerified: true,
-      enabled: true,
-      createdTimestamp: new Date("2024-01-01").getTime(),
-    },
-  ];
-
-  beforeEach(() => {
-    vi.clearAllMocks();
-    vi.resetModules();
-    resetIntegrationCache();
-    // Set Keycloak env so the route doesn't return 503
-    process.env.KEYCLOAK_ISSUER = "https://auth.cloudless.gr/realms/master";
-    process.env.NEXT_PUBLIC_KEYCLOAK_ISSUER = "https://auth.cloudless.gr/realms/master";
-    process.env.KEYCLOAK_ADMIN_USER = "admin";
-    process.env.KEYCLOAK_ADMIN_PASSWORD = "pass";
-
-    // Mock globalThis.fetch for Keycloak Admin REST API calls
-    vi.stubGlobal(
-      "fetch",
-      vi.fn().mockImplementation((url: string) => {
-        if (String(url).includes("/token")) {
-          return Promise.resolve({
-            ok: true,
-            json: () => Promise.resolve({ access_token: "tok" }),
-          });
-        }
-        if (String(url).includes("/users?")) {
-          return Promise.resolve({ ok: true, json: () => Promise.resolve(kcUserList) });
-        }
-        if (String(url).includes("/groups")) {
-          return Promise.resolve({ ok: true, json: () => Promise.resolve([]) });
-        }
-        return Promise.resolve({ ok: true, json: () => Promise.resolve({}) });
-      })
-    );
-  });
-
-  afterEach(() => {
-    vi.unstubAllGlobals();
-    delete process.env.KEYCLOAK_ISSUER;
-    delete process.env.NEXT_PUBLIC_KEYCLOAK_ISSUER;
-  });
-
-  it("returns 401 when no token is provided", async () => {
-    const { GET } = await import("@/app/api/admin/users/route");
-    const res = await GET(unauthRequest("http://localhost/api/admin/users"));
-    expect(res.status).toBe(401);
-  });
-
-  it("returns 403 when token has no admin group", async () => {
-    const { GET } = await import("@/app/api/admin/users/route");
-    const res = await GET(userRequest("http://localhost/api/admin/users"));
-    expect(res.status).toBe(403);
-  });
-
-  it("returns 503 when Keycloak is not configured", async () => {
-    process.env.KEYCLOAK_ISSUER = "";
-    process.env.NEXT_PUBLIC_KEYCLOAK_ISSUER = "";
-    const { GET } = await import("@/app/api/admin/users/route");
-    const res = await GET(adminRequest("http://localhost/api/admin/users"));
-    expect(res.status).toBe(503);
-  });
-
-  it("returns user list for admin", async () => {
-    const { GET } = await import("@/app/api/admin/users/route");
-    const res = await GET(adminRequest("http://localhost/api/admin/users"));
-    expect(res.status).toBe(200);
-    const data = await res.json();
-    expect(Array.isArray(data.users)).toBe(true);
-    expect(typeof data.count).toBe("number");
-    const u = data.users[0];
-    expect(u).toMatchObject({
-      username: "uuid-user-1",
-      email: "user1@example.com",
-      status: "active",
-      userStatus: "CONFIRMED",
-      role: "user",
-    });
-  });
-
-  it("user objects expose role field", async () => {
-    const { GET } = await import("@/app/api/admin/users/route");
-    const res = await GET(adminRequest("http://localhost/api/admin/users"));
-    const data = await res.json();
-    expect(data.users[0].role).toMatch(/^(admin|user)$/);
-  });
-});
-
-describe("POST /api/admin/users", () => {
-  beforeEach(() => {
-    vi.clearAllMocks();
-    // Re-import api-auth under the mocked `jose` (setup.ts imports it first,
-    // binding the real jose). Without this, a filtered/standalone run of these
-    // tests skips the GET block's resetModules, so verifyToken uses the real
-    // jwtVerify → 401 on the fake-signed test token. Mirrors the GET block.
-    vi.resetModules();
-    process.env.KEYCLOAK_ISSUER = "https://auth.cloudless.gr/realms/master";
-    process.env.NEXT_PUBLIC_KEYCLOAK_ISSUER = "https://auth.cloudless.gr/realms/master";
-    process.env.KEYCLOAK_ADMIN_USER = "admin";
-    process.env.KEYCLOAK_ADMIN_PASSWORD = "pass";
-    vi.stubGlobal(
-      "fetch",
-      vi.fn().mockImplementation((url: string) => {
-        if (String(url).includes("/token")) {
-          return Promise.resolve({
-            ok: true,
-            json: () => Promise.resolve({ access_token: "tok" }),
-          });
-        }
-        if (String(url).includes("/groups")) {
-          return Promise.resolve({
-            ok: true,
-            json: () => Promise.resolve([{ id: "grp-1", name: "admin" }]),
-          });
-        }
-        return Promise.resolve({ ok: true, json: () => Promise.resolve({}) });
-      })
-    );
-  });
-
-  afterEach(() => {
-    vi.unstubAllGlobals();
-    delete process.env.KEYCLOAK_ISSUER;
-    delete process.env.NEXT_PUBLIC_KEYCLOAK_ISSUER;
-  });
-
-  async function postAction(body: object) {
-    const { POST } = await import("@/app/api/admin/users/route");
-    return POST(
-      adminRequest("http://localhost/api/admin/users", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify(body),
-      })
-    );
-  }
-
-  it("returns 401 without token", async () => {
-    const { POST } = await import("@/app/api/admin/users/route");
-    const res = await POST(
-      new NextRequest("http://localhost/api/admin/users", {
-        method: "POST",
-        body: JSON.stringify({ action: "disable", username: "x" }),
-        headers: { "Content-Type": "application/json" },
-      })
-    );
-    expect(res.status).toBe(401);
-  });
-
-  it("returns 400 when action is missing", async () => {
-    const res = await postAction({ username: "00000000-0000-0000-0000-000000000001" });
-    expect(res.status).toBe(400);
-  });
-
-  it("disable action succeeds", async () => {
-    const res = await postAction({
-      action: "disable",
-      username: "00000000-0000-0000-0000-000000000001",
-    });
-    expect(res.status).toBe(200);
-    const data = await res.json();
-    expect(data.success).toBe(true);
-  });
-
-  it("enable action succeeds", async () => {
-    const res = await postAction({
-      action: "enable",
-      username: "00000000-0000-0000-0000-000000000001",
-    });
-    expect(res.status).toBe(200);
-    const data = await res.json();
-    expect(data.success).toBe(true);
-  });
-
-  it("promote action succeeds", async () => {
-    const res = await postAction({
-      action: "promote",
-      username: "00000000-0000-0000-0000-000000000001",
-      groupName: "admin",
-    });
-    expect(res.status).toBe(200);
-    const data = await res.json();
-    expect(data.success).toBe(true);
-  });
-
-  it("returns 400 for unknown action", async () => {
-    const res = await postAction({
-      action: "nuke",
-      username: "00000000-0000-0000-0000-000000000001",
-    });
-    expect(res.status).toBe(400);
-  });
-});
-
-// ---------------------------------------------------------------------------
-// /api/admin/orders
-// ---------------------------------------------------------------------------
 
 describe("GET /api/admin/orders", () => {
   beforeEach(() => {

--- a/src/app/api/admin/users/route.ts
+++ b/src/app/api/admin/users/route.ts
@@ -1,6 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
 import { requireAdmin } from "@/lib/api-auth";
-import { getConfig } from "@/lib/ssm-config";
 import {
   CognitoIdentityProviderClient,
   ListUsersCommand,
@@ -12,7 +11,7 @@ import {
 } from "@aws-sdk/client-cognito-identity-provider";
 
 // ---------------------------------------------------------------------------
-// Shared user shape (compatible with both Cognito and Keycloak)
+// Shared user shape (Cognito user shape)
 // ---------------------------------------------------------------------------
 
 interface AdminUser {
@@ -132,152 +131,8 @@ async function mutateCognitoUser(
       );
       return { success: true, message: "User removed from admin group" };
     default:
-      // 400 (client error), consistent with the Keycloak path's unknown-action.
       throw Object.assign(new Error(`Unknown action: ${action}`), { status: 400 });
   }
-}
-
-// ---------------------------------------------------------------------------
-// Keycloak helpers (legacy fallback)
-// ---------------------------------------------------------------------------
-
-const KC_BASE = process.env.KEYCLOAK_ISSUER ?? process.env.NEXT_PUBLIC_KEYCLOAK_ISSUER ?? "";
-const KC_REALM = KC_BASE ? (KC_BASE.split("/realms/")[1] ?? "master") : "master";
-const KC_ADMIN = KC_BASE ? KC_BASE.replace(`/realms/${KC_REALM}`, "") : "";
-const ADMIN_URL = `${KC_ADMIN}/admin/realms/${KC_REALM}`;
-
-async function getKeycloakAdminToken(): Promise<string> {
-  const cfg = await getConfig().catch(() => null);
-  const clientId =
-    cfg?.KEYCLOAK_ADMIN_CLIENT_ID || process.env.KEYCLOAK_ADMIN_CLIENT_ID || "admin-cli";
-  const clientSecret =
-    cfg?.KEYCLOAK_ADMIN_CLIENT_SECRET || process.env.KEYCLOAK_ADMIN_CLIENT_SECRET || "";
-  const adminUser = cfg?.KEYCLOAK_ADMIN_USER || process.env.KEYCLOAK_ADMIN_USER || "";
-  const adminPass = cfg?.KEYCLOAK_ADMIN_PASSWORD || process.env.KEYCLOAK_ADMIN_PASSWORD || "";
-
-  const body = clientSecret
-    ? new URLSearchParams({
-        grant_type: "client_credentials",
-        client_id: clientId,
-        client_secret: clientSecret,
-      })
-    : new URLSearchParams({
-        grant_type: "password",
-        client_id: clientId,
-        username: adminUser,
-        password: adminPass,
-      });
-
-  const res = await globalThis.fetch(`${KC_BASE}/protocol/openid-connect/token`, {
-    method: "POST",
-    headers: { "Content-Type": "application/x-www-form-urlencoded" },
-    body: body.toString(),
-    signal: AbortSignal.timeout(10_000),
-  });
-  if (!res.ok) throw new Error(`Keycloak admin token failed: ${res.status}`);
-  return ((await res.json()) as { access_token: string }).access_token;
-}
-
-function kcFetch(path: string, token: string, init?: RequestInit) {
-  return globalThis.fetch(`${ADMIN_URL}${path}`, {
-    ...init,
-    headers: {
-      Authorization: `Bearer ${token}`,
-      "Content-Type": "application/json",
-      ...(init?.headers as Record<string, string> | undefined),
-    },
-    signal: AbortSignal.timeout(10_000),
-  });
-}
-
-async function listKeycloakUsers(limit: number, filter?: string): Promise<AdminUser[]> {
-  const token = await getKeycloakAdminToken();
-  const qs = new URLSearchParams({ max: String(limit) });
-  if (filter) qs.set("search", filter);
-  const res = await kcFetch(`/users?${qs}`, token);
-  if (!res.ok) throw new Error(`Keycloak list users: ${res.status}`);
-
-  interface KcUser {
-    id: string;
-    username: string;
-    email?: string;
-    firstName?: string;
-    lastName?: string;
-    emailVerified?: boolean;
-    enabled?: boolean;
-    createdTimestamp?: number;
-    attributes?: Record<string, string[]>;
-  }
-  const kcUsers = (await res.json()) as KcUser[];
-
-  return Promise.all(
-    kcUsers.map(async (u) => {
-      let isAdmin = false;
-      try {
-        const gr = await kcFetch(`/users/${u.id}/groups`, token);
-        if (gr.ok) {
-          const groups = (await gr.json()) as Array<{ name: string }>;
-          isAdmin = groups.some((g) => g.name === "admin");
-        }
-      } catch {
-        /* default non-admin */
-      }
-
-      const attrs = u.attributes ?? {};
-      return {
-        username: u.id,
-        email: u.email ?? "",
-        name: [u.firstName, u.lastName].filter(Boolean).join(" "),
-        company: attrs["company"]?.[0] ?? "",
-        phone: attrs["phone"]?.[0] ?? "",
-        emailVerified: u.emailVerified ?? false,
-        status: u.enabled ? "active" : "disabled",
-        userStatus: u.enabled ? "CONFIRMED" : "DISABLED",
-        role: isAdmin ? "admin" : "user",
-        created: u.createdTimestamp ? new Date(u.createdTimestamp).toISOString() : undefined,
-      } satisfies AdminUser;
-    })
-  );
-}
-
-async function mutateKeycloakUser(
-  userId: string,
-  action: string
-): Promise<{ success: boolean; message: string }> {
-  const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
-  if (!UUID_RE.test(userId)) throw Object.assign(new Error("Invalid user id"), { status: 400 });
-
-  const token = await getKeycloakAdminToken();
-
-  if (action === "disable") {
-    await kcFetch(`/users/${userId}`, token, {
-      method: "PUT",
-      body: JSON.stringify({ enabled: false }),
-    });
-    return { success: true, message: "User disabled" };
-  }
-  if (action === "enable") {
-    await kcFetch(`/users/${userId}`, token, {
-      method: "PUT",
-      body: JSON.stringify({ enabled: true }),
-    });
-    return { success: true, message: "User enabled" };
-  }
-  const grRes = await kcFetch(`/groups?search=admin`, token);
-  if (!grRes.ok) throw new Error("Could not fetch groups");
-  const groups = (await grRes.json()) as Array<{ id: string; name: string }>;
-  const adminGroup = groups.find((g) => g.name === "admin");
-  if (!adminGroup) throw new Error("admin group not found");
-
-  if (action === "promote") {
-    await kcFetch(`/users/${userId}/groups/${adminGroup.id}`, token, { method: "PUT" });
-    return { success: true, message: "User promoted to admin" };
-  }
-  if (action === "demote") {
-    await kcFetch(`/users/${userId}/groups/${adminGroup.id}`, token, { method: "DELETE" });
-    return { success: true, message: "User removed from admin group" };
-  }
-  throw Object.assign(new Error(`Unknown action: ${action}`), { status: 400 });
 }
 
 // ---------------------------------------------------------------------------
@@ -300,12 +155,7 @@ export async function GET(request: NextRequest) {
       return NextResponse.json({ users, count: users.length, provider: "cognito" });
     }
 
-    if (KC_BASE) {
-      const users = await listKeycloakUsers(limit, filter || undefined);
-      return NextResponse.json({ users, count: users.length, provider: "keycloak" });
-    }
-
-    return NextResponse.json({ error: "Auth provider not configured" }, { status: 503 });
+    return NextResponse.json({ error: "Cognito not configured" }, { status: 503 });
   } catch (err) {
     console.error("Failed to list users:", err instanceof Error ? err.message : String(err));
     return NextResponse.json({ error: "Failed to list users" }, { status: 500 });
@@ -339,12 +189,7 @@ export async function POST(request: NextRequest) {
       return NextResponse.json(result);
     }
 
-    if (KC_BASE) {
-      const result = await mutateKeycloakUser(username, action);
-      return NextResponse.json(result);
-    }
-
-    return NextResponse.json({ error: "Auth provider not configured" }, { status: 503 });
+    return NextResponse.json({ error: "Cognito not configured" }, { status: 503 });
   } catch (err) {
     const status = (err as { status?: number }).status ?? 500;
     console.error("Failed to modify user:", err instanceof Error ? err.message : String(err));

--- a/src/lib/ssm-config.ts
+++ b/src/lib/ssm-config.ts
@@ -21,14 +21,8 @@ interface AppConfig {
   STRIPE_SECRET_KEY: string;
   STRIPE_PUBLISHABLE_KEY: string;
   STRIPE_WEBHOOK_SECRET: string;
-  // Keycloak / next-auth
+  // next-auth
   AUTH_SECRET: string;
-  KEYCLOAK_ADMIN_USER: string;
-  KEYCLOAK_ADMIN_PASSWORD: string;
-  /** Confidential service-account client for admin user-management routes
-   * (least-privilege: view-users/query-users), preferred over the master admin. */
-  KEYCLOAK_ADMIN_CLIENT_ID: string;
-  KEYCLOAK_ADMIN_CLIENT_SECRET: string;
   // Optional integrations
   SLACK_WEBHOOK_URL: string;
   SLACK_BOT_TOKEN: string;
@@ -163,10 +157,6 @@ function buildConfigFromParams(params: Map<string, string>): AppConfig {
     STRIPE_PUBLISHABLE_KEY: params.get("STRIPE_PUBLISHABLE_KEY") ?? "",
     STRIPE_WEBHOOK_SECRET: params.get("STRIPE_WEBHOOK_SECRET") ?? "",
     AUTH_SECRET: params.get("AUTH_SECRET") ?? "",
-    KEYCLOAK_ADMIN_USER: params.get("KEYCLOAK_ADMIN_USER") ?? "",
-    KEYCLOAK_ADMIN_PASSWORD: params.get("KEYCLOAK_ADMIN_PASSWORD") ?? "",
-    KEYCLOAK_ADMIN_CLIENT_ID: params.get("KEYCLOAK_ADMIN_CLIENT_ID") ?? "",
-    KEYCLOAK_ADMIN_CLIENT_SECRET: params.get("KEYCLOAK_ADMIN_CLIENT_SECRET") ?? "",
     SLACK_WEBHOOK_URL: params.get("SLACK_WEBHOOK_URL") ?? "",
     SLACK_BOT_TOKEN: params.get("SLACK_BOT_TOKEN") ?? "",
     SLACK_SIGNING_SECRET: params.get("SLACK_SIGNING_SECRET") ?? "",
@@ -238,10 +228,6 @@ function buildConfigFromEnv(): AppConfig {
     STRIPE_PUBLISHABLE_KEY: process.env.STRIPE_PUBLISHABLE_KEY || "",
     STRIPE_WEBHOOK_SECRET: process.env.STRIPE_WEBHOOK_SECRET || "",
     AUTH_SECRET: process.env.AUTH_SECRET || "",
-    KEYCLOAK_ADMIN_USER: process.env.KEYCLOAK_ADMIN_USER || "",
-    KEYCLOAK_ADMIN_PASSWORD: process.env.KEYCLOAK_ADMIN_PASSWORD || "",
-    KEYCLOAK_ADMIN_CLIENT_ID: process.env.KEYCLOAK_ADMIN_CLIENT_ID || "",
-    KEYCLOAK_ADMIN_CLIENT_SECRET: process.env.KEYCLOAK_ADMIN_CLIENT_SECRET || "",
     SLACK_WEBHOOK_URL: process.env.SLACK_WEBHOOK_URL || "",
     SLACK_BOT_TOKEN: process.env.SLACK_BOT_TOKEN || "",
     SLACK_SIGNING_SECRET: process.env.SLACK_SIGNING_SECRET || "",


### PR DESCRIPTION
Closes the loop on PR #769. Drops 386 lines of dead Keycloak code: admin user-management codepath, 5 mock-based test blocks, 4 SSM AppConfig fields. Local tests 60/60 pass.