### PR TITLE
fix(terraform): bump aws provider 5.0.0 → ~> 5.80.0 (fixes expired GPG key)

### DIFF
--- a/.github/workflows/deploy-infrastructure.yml
+++ b/.github/workflows/deploy-infrastructure.yml
@@ -47,25 +47,25 @@ jobs:
 
       - name: Pre-download AWS provider (bypass GPG verification)
         run: |
-          PROVIDER_DIR="/home/runner/.terraform.d/plugins/registry.terraform.io/hashicorp/aws/5.0.0/linux_amd64"
+          PROVIDER_DIR="/home/runner/.terraform.d/plugins/registry.terraform.io/hashicorp/aws/5.80.0/linux_amd64"
           mkdir -p "$PROVIDER_DIR"
           cd "$PROVIDER_DIR"
 
           # Download AWS provider binary directly (no signature verification)
-          echo "Downloading AWS provider 5.0.0..."
-          curl -sLO https://releases.hashicorp.com/terraform-provider-aws/5.0.0/terraform-provider-aws_5.0.0_linux_amd64.zip
+          echo "Downloading AWS provider 5.80.0..."
+          curl -sLO https://releases.hashicorp.com/terraform-provider-aws/5.80.0/terraform-provider-aws_5.80.0_linux_amd64.zip
 
           echo "Extracting..."
-          unzip -q terraform-provider-aws_5.0.0_linux_amd64.zip
+          unzip -q terraform-provider-aws_5.80.0_linux_amd64.zip
 
           # Make binary executable
-          chmod +x terraform-provider-aws_v5.0.0_x5
+          chmod +x terraform-provider-aws_v5.80.0_x5
 
           # Clean up zip
-          rm terraform-provider-aws_5.0.0_linux_amd64.zip
+          rm terraform-provider-aws_5.80.0_linux_amd64.zip
 
           echo "✅ Provider ready at: $PROVIDER_DIR"
-          ls -lh "$PROVIDER_DIR"/terraform-provider-aws_v5.0.0_x5
+          ls -lh "$PROVIDER_DIR"/terraform-provider-aws_v5.80.0_x5
 
       - name: Configure Terraform to use local provider
         run: |
@@ -159,25 +159,25 @@ jobs:
 
       - name: Pre-download AWS provider (bypass GPG verification)
         run: |
-          PROVIDER_DIR="/home/runner/.terraform.d/plugins/registry.terraform.io/hashicorp/aws/5.0.0/linux_amd64"
+          PROVIDER_DIR="/home/runner/.terraform.d/plugins/registry.terraform.io/hashicorp/aws/5.80.0/linux_amd64"
           mkdir -p "$PROVIDER_DIR"
           cd "$PROVIDER_DIR"
 
           # Download AWS provider binary directly (no signature verification)
-          echo "Downloading AWS provider 5.0.0..."
-          curl -sLO https://releases.hashicorp.com/terraform-provider-aws/5.0.0/terraform-provider-aws_5.0.0_linux_amd64.zip
+          echo "Downloading AWS provider 5.80.0..."
+          curl -sLO https://releases.hashicorp.com/terraform-provider-aws/5.80.0/terraform-provider-aws_5.80.0_linux_amd64.zip
 
           echo "Extracting..."
-          unzip -q terraform-provider-aws_5.0.0_linux_amd64.zip
+          unzip -q terraform-provider-aws_5.80.0_linux_amd64.zip
 
           # Make binary executable
-          chmod +x terraform-provider-aws_v5.0.0_x5
+          chmod +x terraform-provider-aws_v5.80.0_x5
 
           # Clean up zip
-          rm terraform-provider-aws_5.0.0_linux_amd64.zip
+          rm terraform-provider-aws_5.80.0_linux_amd64.zip
 
           echo "✅ Provider ready at: $PROVIDER_DIR"
-          ls -lh "$PROVIDER_DIR"/terraform-provider-aws_v5.0.0_x5
+          ls -lh "$PROVIDER_DIR"/terraform-provider-aws_v5.80.0_x5
 
       - name: Configure Terraform to use local provider
         run: |

--- a/infrastructure/terraform/lambda-optimization.tf
+++ b/infrastructure/terraform/lambda-optimization.tf
@@ -5,7 +5,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "5.0.0"
+      version = "~> 5.80.0"
     }
   }
 }


### PR DESCRIPTION
**Closes the deploy-infrastructure.yml failure.**

### Root cause
Provider `hashicorp/aws@5.0.0` (May 2023) is signed with a PGP key that expired in 2026. `terraform init` fails with:
```
Error: Failed to install provider
Error while installing hashicorp/aws v5.0.0: error checking signature:
openpgp: key expired
```

The verification happens during provider metadata fetch **before** the local filesystem mirror is consulted, so all the existing workarounds (pre-download, .terraformrc mirror, TF_SKIP_PROVIDER_VERIFICATION) can't bypass it.

### Fix
Bump provider to `~> 5.80.0` (Nov 2024), which is signed with the rotated key. Workflow URLs + plugin paths updated to match.

No Terraform code changes needed — 5.80 is API-compatible with 5.0 for all resources in lambda-optimization.tf (CloudFront, Lambda, RDS Proxy, IAM).

### After merge
Trigger the workflow:
```bash
gh workflow run deploy-infrastructure.yml -f phase=cloudfront
```