### PR TITLE
fix(terraform): bump CLI 1.6.0 → 1.15.6 (real fix for openpgp expired key)

### DIFF
--- a/.github/workflows/deploy-infrastructure.yml
+++ b/.github/workflows/deploy-infrastructure.yml
@@ -23,7 +23,7 @@ permissions:
 
 env:
   AWS_REGION: us-east-1
-  TF_VERSION: 1.6.0
+  TF_VERSION: 1.15.6
 
 jobs:
   plan:


### PR DESCRIPTION
PR #778 (bumping the aws provider) didn't fix it — the expired key is **Terraform CLI's embedded root key**, not the provider's signing key.

Terraform 1.6.0 (Oct 2023) ships with a GPG root that's now expired. 1.15.6 has the rotated root key.

This is a one-line change. After merge, trigger:
```bash
gh workflow run deploy-infrastructure.yml -f phase=cloudfront
```