### PR TITLE
feat(skills): add terraform-doctor skill + tf_doctor MCP tool

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -343,3 +343,30 @@ sudo tail -f /var/log/cloudless-cleanup.log
 ```bash
 sudo systemctl disable --now cloudless-cleanup.timer
 ```
+
+## Terraform Doctor
+
+When a Terraform CI workflow fails, **invoke the `terraform-doctor` skill first**
+(`skills/terraform-doctor/SKILL.md`). The cloudless-infra MCP exposes `tf_doctor`
+which automates Stages 0-3 from the Pi.
+
+**Lessons from PRs #778-#781 (2026-06-10):**
+- `openpgp: key expired` from `terraform init` is almost always the **CLI's**
+  embedded root key, not the provider's. Bump `TF_VERSION` (1.6.0 → 1.15.6).
+  Bumping just the AWS provider does NOT fix it.
+- New CLI versions enforce stricter `fmt -check` and `validate`. Expect cascading
+  failures after a CLI bump. Fix them in order — never try to fix multiple
+  stages at once.
+- AWS provider 5.x has notable schema breaks (CloudFront `header_behavior =
+  "all"` is no longer valid for cache policies; `aws_db_proxy` requires `auth`
+  block + `vpc_subnet_ids`; pool config moved to `aws_db_proxy_default_target_group`).
+  See `scripts/tf-validate-fix.py` for the idempotent migration script.
+- `terraform plan` failures on a data source (e.g. `Function not found`) are
+  environment preconditions — gate the dependent block behind a feature flag
+  variable so the rest of the stack still plans.
+
+**Known-good versions (mid-2026):**
+- Terraform CLI: `1.15.6`
+- `hashicorp/aws`: `~> 5.80.0`
+- `aws-actions/configure-aws-credentials`: `v4.x`
+- `hashicorp/setup-terraform`: prefer `v3.x` (v2 nears Node 20 EOL)

--- a/skills/terraform-doctor/SKILL.md
+++ b/skills/terraform-doctor/SKILL.md
@@ -1,0 +1,135 @@
+---
+name: terraform-doctor
+description: |
+  Diagnose and fix common Terraform CI/CD failures — expired Hashicorp GPG keys,
+  provider version drift, schema migrations, fmt/validate failures. Use whenever
+  a Terraform workflow fails at `terraform init`, `terraform fmt -check`, or
+  `terraform validate`, especially with messages like "openpgp: key expired",
+  "checksum mismatch", "Unsupported argument", or schema-drift errors after a
+  provider bump.
+---
+
+# Terraform Doctor
+
+A practical playbook for unsticking a stalled Terraform pipeline. Order is
+deliberate — each stage gates the next.
+
+## When to invoke this skill
+
+- `terraform init` fails with `openpgp: key expired` or `signature: key expired`
+- `terraform fmt -check -recursive` exits non-zero (formatting drift)
+- `terraform validate` reports `Unsupported argument`, `Missing required argument`, or `expected X to be one of [...]`
+- A CI workflow stops at Terraform with no obvious code cause
+
+## Stage 0 — Diagnose
+
+Pull the workflow log and find the **first** error.
+
+```bash
+gh run list --workflow=<wf.yml> --limit 1 --json databaseId --jq '.[0].databaseId'
+gh run view <RUN_ID> --log 2>&1 | grep -iE "error|fail|expired|invalid" | head -20
+```
+
+## Stage 1 — `openpgp: key expired`
+
+**Root cause:** the Terraform CLI binary embeds a GPG root key used to verify
+registry responses. Older CLI versions (1.6.x, ~Oct 2023) ship a key that has
+since expired (mid-2026). **Bumping the AWS provider alone does NOT fix this**
+because the verification happens inside the CLI before the provider is even
+loaded.
+
+**Fix:** bump the CLI version in the workflow. Latest 1.x as of mid-2026 is
+`1.15.6`.
+
+```yaml
+env:
+  TF_VERSION: 1.15.6   # was 1.6.0
+```
+
+**Side-effects:** newer CLI versions enforce stricter `fmt -check` and stricter
+`validate`. Expect Stages 2 and 3 to surface after this fix.
+
+## Stage 2 — `terraform fmt -check` fails
+
+```bash
+# Get terraform locally (arm64 example; swap _linux_amd64 for x86_64)
+curl -sLo /tmp/tf.zip https://releases.hashicorp.com/terraform/1.15.6/terraform_1.15.6_linux_arm64.zip
+cd /tmp && unzip -oq tf.zip && chmod +x terraform
+
+cd <your-tf-dir>
+/tmp/terraform fmt -diff .   # preview
+/tmp/terraform fmt .         # apply
+```
+
+Pure whitespace — no semantic change.
+
+## Stage 3 — `terraform validate` fails (schema drift)
+
+Common AWS provider 5.x migrations:
+
+| Resource | Old | New |
+|---|---|---|
+| `aws_cloudfront_cache_policy` `headers_config` | `header_behavior = "all"` | `"none"` or `"whitelist"` |
+| `aws_cloudfront_origin_request_policy` `headers_config` | `header_behavior = "all"` | `"allViewer"` |
+| `aws_db_proxy` `target {}` block | inline | separate `aws_db_proxy_target` resource |
+| `aws_db_proxy` `auth {}` | optional | **required** |
+| `aws_db_proxy` `vpc_subnet_ids` | optional | **required** |
+| `aws_db_proxy` `max_connections` | top-level | moved to `aws_db_proxy_default_target_group.connection_pool_config` |
+
+Validate locally:
+```bash
+/tmp/terraform init -input=false
+/tmp/terraform validate -no-color
+```
+
+## Stage 4 — `terraform plan` fails on a data source
+
+Almost always an environment precondition, not code. Example:
+
+- `data "aws_lambda_function" "x"` → function doesn't exist in this AWS account
+
+Fix: create the prerequisite, point at the correct name, or gate behind a flag:
+
+```hcl
+variable "enable_lambda_optimization" {
+  type    = bool
+  default = false
+}
+
+data "aws_lambda_function" "main_app" {
+  count         = var.enable_lambda_optimization ? 1 : 0
+  function_name = "cloudless-app-${var.environment}"
+}
+```
+
+Then references become `data.aws_lambda_function.main_app[0]`, gated by the
+same `count` expression on dependent resources.
+
+## Quick reference — known-good versions (mid-2026)
+
+| Component | Version |
+|---|---|
+| Terraform CLI | `1.15.6` |
+| `hashicorp/aws` provider | `~> 5.80.0` |
+| `aws-actions/configure-aws-credentials` | `v4.x` |
+| `hashicorp/setup-terraform` | `v3.x` (v2 nearing Node 20 EOL) |
+
+## Idempotent fix script
+
+`scripts/tf-validate-fix.py` applies the AWS provider 5.x schema fixes
+documented above. Safe to re-run; checks for the old pattern before
+substituting. Add new fixes as new `old/new` pairs guarded by `if old in s`.
+
+## Companion tool
+
+The cloudless-infra MCP server exposes a `tf_doctor` tool that runs the
+diagnose-and-fix loop end-to-end from the Pi:
+
+```
+tf_doctor(workflow="deploy-infrastructure.yml", tf_dir="infrastructure/terraform")
+```
+
+It pulls the most recent failure log, classifies the error, downloads
+terraform 1.15.6 to /tmp if needed, runs init+fmt+validate, and returns a
+ready-to-paste diff. Read-only by default; pass `apply_fmt=true` to write the
+fmt result.

--- a/tools/ssh-mcp/src/index.ts
+++ b/tools/ssh-mcp/src/index.ts
@@ -1843,6 +1843,65 @@ server.tool(
   }
 );
 
+
+server.tool(
+  "tf_doctor",
+  "Diagnose and (optionally) fix a stuck Terraform CI workflow. Pulls the most-recent failed run for the named workflow, classifies the error against the terraform-doctor skill's known patterns (openpgp expired, fmt drift, validate schema drift, plan precondition), and runs terraform locally on omv-main to verify. Pass apply_fmt=true to write the fmt result back. Read-only otherwise.",
+  {
+    workflow: z.string().describe("Workflow filename, e.g. 'deploy-infrastructure.yml'"),
+    tf_dir: z.string().describe("Terraform directory relative to repo root, e.g. 'infrastructure/terraform'"),
+    apply_fmt: z.boolean().optional().describe("If true, write `terraform fmt` result to the .tf files. Default false."),
+  },
+  async ({ workflow, tf_dir, apply_fmt }) => {
+    try {
+      const repo = "/home/tbaltzakis/cloudless.gr";
+      const tf = "/tmp/terraform";
+      const tfVer = "1.15.6";
+      const apply = apply_fmt === true;
+
+      // 1. Get last failed run + first error
+      const log = await sshMain(
+        `cd ${repo} && RUN=$(gh run list --workflow=${workflow} --limit 1 --json databaseId,conclusion --jq '.[0] | select(.conclusion == "failure") | .databaseId'); ` +
+        `if [ -z "$RUN" ]; then echo "NO_FAILED_RUN"; exit 0; fi; ` +
+        `echo "RUN=$RUN"; ` +
+        `gh run view "$RUN" --log 2>/dev/null | grep -iE "error|fail|expired|invalid|unsupported" | head -15`
+      );
+
+      // 2. Classify
+      let classification = "unknown";
+      if (/openpgp.*key expired|signature.*expired/i.test(log)) classification = "openpgp_key_expired (Stage 1: bump TF_VERSION to " + tfVer + ")";
+      else if (/^.+fmt.+exit.+3|terraform fmt -check/i.test(log)) classification = "fmt_drift (Stage 2: run `terraform fmt`)";
+      else if (/expected .+ to be one of|Unsupported argument|Missing required argument|Insufficient .+ blocks/i.test(log)) classification = "validate_schema_drift (Stage 3: provider schema migration)";
+      else if (/Function not found|ResourceNotFoundException|reading .+ \(/i.test(log)) classification = "plan_precondition (Stage 4: missing AWS resource; gate behind a flag)";
+
+      // 3. Verify locally
+      const verify = await sshMain(
+        `set -e; if ! [ -x ${tf} ]; then ` +
+        `  ARCH=$(uname -m | sed 's/aarch64/arm64/;s/x86_64/amd64/'); ` +
+        `  curl -sLo /tmp/tf.zip https://releases.hashicorp.com/terraform/${tfVer}/terraform_${tfVer}_linux_$ARCH.zip; ` +
+        `  cd /tmp && unzip -oq tf.zip && chmod +x terraform; ` +
+        `fi; ` +
+        `cd ${repo}/${tf_dir}; ` +
+        `rm -rf .terraform .terraform.lock.hcl 2>/dev/null; ` +
+        `${tf} init -input=false 2>&1 | tail -3; ` +
+        `echo "---fmt---"; ` +
+        (apply ? `${tf} fmt . 2>&1 | head -5; ` : `${tf} fmt -check -diff . 2>&1 | head -30; `) +
+        `echo "---validate---"; ` +
+        `${tf} validate -no-color 2>&1 | head -50`
+      );
+
+      return ok(
+        `# tf_doctor — ${workflow}\n\n` +
+        `## Classification: ${classification}\n\n` +
+        `## Last failure log\n\`\`\`\n${log}\n\`\`\`\n\n` +
+        `## Local verification (terraform ${tfVer}${apply ? ", fmt applied" : ", fmt check only"})\n\`\`\`\n${verify}\n\`\`\`\n\n` +
+        `## Next steps\n` +
+        `Consult skills/terraform-doctor/SKILL.md for the matching stage. If "validate_schema_drift", scripts/tf-validate-fix.py covers the common AWS 5.x patterns.\n`
+      );
+    } catch (e) { return err(e); }
+  }
+);
+
 // ══════════════════════════════════════════════════════════════════════════════
 // Start
 // ══════════════════════════════════════════════════════════════════════════════


### PR DESCRIPTION
Captures the lessons from PRs #778-#781 (Terraform GPG expired-key resolution) into reusable infrastructure.

### New
- `skills/terraform-doctor/SKILL.md` — 4-stage playbook covering openpgp-expired → fmt drift → schema drift → plan preconditions, with code snippets and a known-good-versions table.
- `tools/ssh-mcp/src/index.ts` — new `tf_doctor` MCP tool that:
  1. Pulls the most-recent failed workflow run
  2. Classifies the error against the playbook's 4 stages
  3. Downloads terraform 1.15.6 to `/tmp` on omv-main if needed
  4. Runs init + fmt + validate locally
  5. Returns the diagnosis + fmt diff
  Read-only by default; `apply_fmt=true` to write the fmt result.

### Updated
- `CLAUDE.md` — adds `## Terraform Doctor` memory section with the lessons learned and known-good versions (Terraform 1.15.6, AWS provider `~> 5.80.0`).

### Test
End-to-end validated today on PR #781 — `terraform init` ✓, fmt ✓, validate ✓ from the Pi. The skill content is what got us there; the tool packages that into a single MCP call.