### PR TITLE
perf(lighthouse): /store — remove force-dynamic, enable ISR

### DIFF
--- a/src/app/[locale]/store/page.tsx
+++ b/src/app/[locale]/store/page.tsx
@@ -4,7 +4,11 @@ import JsonLd from "@/components/JsonLd";
 import { getFAQSchema } from "@/lib/structured-data";
 import ScrollReveal from "@/components/ScrollReveal";
 
-export const dynamic = "force-dynamic";
+
+// Lighthouse Win — let Next.js statically generate the shell + ISR-refresh
+// every hour. The product grid is client-side (StoreGrid uses defaultProducts),
+// so SSG works; this removes a Lambda cold-start from every visit.
+export const revalidate = 3600;
 
 export const metadata: Metadata = {
   title: "Store",


### PR DESCRIPTION
Issue #773 follow-up. The store page set `export const dynamic = 'force-dynamic'` but had no async data fetching — StoreGrid is a client component using `defaultProducts` as a static import. force-dynamic was forcing a Lambda cold-start on every visit.

Replaced with `export const revalidate = 3600` so Next.js statically generates the shell + ISR-refreshes hourly. Lambda is only invoked for revalidations.

Expected: ~200-400ms TTFB improvement, +2-3 LH pts on /store.