### PR TITLE
fix(next-config): widen 'missing' type with 'as const' (unblock deploy-pi)

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -123,7 +123,7 @@ nextConfig.rewrites = async () => ({
     ...LOCALE_REWRITE_PATHS.map((path) => ({
       source: path,
       destination: `/en${path}`,
-      missing: [{ type: "cookie", key: "NEXT_LOCALE" }],
+      missing: [{ type: "cookie" as const, key: "NEXT_LOCALE" }],
     })),
   ],
   afterFiles: [],


### PR DESCRIPTION
PR #783 + #784 are correct semantically but failed the Pi Docker build because Next's `Rewrite` type requires `missing.type` to be a literal union (`'cookie' | 'header' | ...`), not `string`. Added `as const` to narrow it.

Production is still serving the previous good build (sha 62c56b00); this fix unblocks the deploy-pi for PRs #783, #784.