### PR TITLE
fix(services): export colorMap + bundleTerminal from services-data

### DIFF
--- a/src/app/[locale]/services/page.tsx
+++ b/src/app/[locale]/services/page.tsx
@@ -59,7 +59,7 @@ function Arrow({ className = "" }: { className?: string }) {
 /* ── Service data ─────────────────────────────────────────────── */
 
 
-import { getServices, getServicesFaqs } from "@/lib/services-data";
+import { getServices, getServicesFaqs, colorMap, bundleTerminal } from "@/lib/services-data";
 
 export default async function ServicesPage() {
   const locale = await getServerLocale();

--- a/src/lib/services-data.ts
+++ b/src/lib/services-data.ts
@@ -318,7 +318,7 @@ export const getServicesFaqs = (t: (key: string, fallback: string) => string) =>
   },
 ];
 
-const bundleTerminal = [
+export const bundleTerminal = [
   "$ cloudless bundle --plan growth-engine",
   "  ✓ Cloud Architecture & Migration",
   "  ✓ Serverless Development",
@@ -334,7 +334,7 @@ const bundleTerminal = [
 
 /* ── Color maps ───────────────────────────────────────────────── */
 
-const colorMap = {
+export const colorMap = {
   cyan: {
     badge: "bg-neon-cyan/10 border-neon-cyan/20 text-neon-cyan",
     dot: "bg-neon-cyan",


### PR DESCRIPTION
PR #783's extraction missed exporting two symbols that services/page.tsx still references: `colorMap` (line 337 of the data module) and `bundleTerminal` (line 320).

Real `tsc --noEmit` now passes (9.3s, exit 0). Should unblock deploy-pi.