### PR TITLE
test(e2e): fix fresh-checkout failures — setup project, k3s exclusion, 503 + mobile-menu handling

### DIFF
--- a/e2e/journey-contact-lead.spec.ts
+++ b/e2e/journey-contact-lead.spec.ts
@@ -12,7 +12,13 @@ test.describe("Contact lead flow", () => {
     await page.goto("/en");
     await expect(page.locator("h1, h2").first()).toBeVisible();
 
-    // Find a contact link in the nav or footer
+    // Find a contact link in the nav or footer. On mobile viewports the nav
+    // links live inside the hamburger drawer and the sticky navbar intercepts
+    // pointer events — open the menu first so the link is actually clickable.
+    const menuToggle = page.locator('button[aria-label*="menu" i]').first();
+    if (await menuToggle.isVisible().catch(() => false)) {
+      await menuToggle.click();
+    }
     const contactLink = page.getByRole("link", { name: /contact/i }).first();
     await expect(contactLink).toBeVisible();
     await contactLink.click();

--- a/e2e/journey-theme-locale.spec.ts
+++ b/e2e/journey-theme-locale.spec.ts
@@ -1,17 +1,31 @@
-import { test, expect } from "@playwright/test";
+import { test, expect, type Page } from "@playwright/test";
 
 /**
  * Deep journey: theme switcher + locale switcher.
  * Tests user-facing personalization controls survive a reload.
  */
 
+/**
+ * On mobile viewports the navbar controls (theme/locale switchers) live
+ * inside the hamburger drawer — open it first so they become visible.
+ */
+async function openMobileMenuIfNeeded(page: Page): Promise<void> {
+  const menuToggle = page.locator('button[aria-label*="menu" i]').first();
+  if (await menuToggle.isVisible().catch(() => false)) {
+    await menuToggle.click();
+  }
+}
+
 test.describe("Theme switcher", () => {
   test("light theme applies data-theme=light and persists", async ({ page }) => {
     await page.goto("/en");
-    // Open the theme switcher (might be popover or inline button)
+    await openMobileMenuIfNeeded(page);
+    // Open the theme switcher (might be popover or inline button). The navbar
+    // renders one instance for desktop and one inside the mobile drawer, so
+    // filter to the visible one instead of blindly taking the first match.
     const themeTrigger = page.locator(
       '[aria-label*="theme" i], button:has-text("Theme"), [data-testid="theme-switcher"]'
-    ).first();
+    ).filter({ visible: true }).first();
     if (await themeTrigger.count() === 0) test.skip();
     await themeTrigger.click();
     const light = page.getByRole("option", { name: /light/i }).or(
@@ -29,9 +43,11 @@ test.describe("Theme switcher", () => {
 
   test("dark theme applies data-theme=dark", async ({ page }) => {
     await page.goto("/en");
+    await openMobileMenuIfNeeded(page);
+    // Filter to the visible instance — desktop + mobile-drawer both exist in DOM.
     const themeTrigger = page.locator(
       '[aria-label*="theme" i], button:has-text("Theme"), [data-testid="theme-switcher"]'
-    ).first();
+    ).filter({ visible: true }).first();
     if (await themeTrigger.count() === 0) test.skip();
     await themeTrigger.click();
     const dark = page.getByRole("option", { name: /dark/i }).or(

--- a/e2e/public-api-deep.spec.ts
+++ b/e2e/public-api-deep.spec.ts
@@ -27,7 +27,9 @@ for (const ep of PUBLIC_API_GET) {
 for (const { template, sample } of PUBLIC_API_DYNAMIC) {
   test(`GET ${template} — handles unknown slug (404 or empty 200)`, async ({ request }) => {
     const r = await request.get(sample);
-    expect([200, 301, 302, 303, 307, 308, 400, 401, 404]).toContain(r.status());
+    // 503 is the documented "integration not configured" response (e.g. the
+    // docs API returns 503 when NOTION_API_KEY/NOTION_DOCS_DB_ID are unset).
+    expect([200, 301, 302, 303, 307, 308, 400, 401, 404, 503]).toContain(r.status());
   });
 }
 
@@ -102,8 +104,10 @@ test("POST /api/chat — non-empty message", async ({ request }) => {
     data: { messages: [{ role: "user", content: "test" }] },
     failOnStatusCode: false,
   });
-  // /api/chat may be auth-gated (returns 401) or rate-limited (429)
-  expect(r.status()).toBeLessThan(500);
+  // /api/chat may be auth-gated (401), rate-limited (429), or unconfigured —
+  // the route surfaces missing/invalid Anthropic credentials as 503.
+  const s = r.status();
+  expect(s < 500 || s === 503, `/api/chat returned ${s}`).toBeTruthy();
 });
 
 test("GET /api/notion-image — without url param returns 4xx", async ({ request }) => {
@@ -201,7 +205,9 @@ test("GET /api/case-studies/sample — handles slug lookup", async ({ request })
 
 test("GET /api/docs/getting-started — handles slug lookup", async ({ request }) => {
   const r = await request.get("/api/docs/getting-started");
-  expect(r.status()).toBeLessThan(500);
+  // 503 = docs integration not configured (NOTION_API_KEY/NOTION_DOCS_DB_ID unset)
+  const s = r.status();
+  expect(s < 500 || s === 503, `/api/docs/getting-started returned ${s}`).toBeTruthy();
 });
 
 test("POST /api/portal/me with missing auth header", async ({ request }) => {

--- a/playwright.config.mts
+++ b/playwright.config.mts
@@ -14,6 +14,9 @@ const isCi = !!process.env.CI;
  */
 export default defineConfig({
   testDir: path.join(rootDir, "e2e"),
+  // k3s specs target the live Pi cluster and have their own config
+  // (playwright.k3s.config.mts) — never run them against localhost.
+  testIgnore: ["**/k3s/**"],
   fullyParallel: true,
   forbidOnly: isCi,
   retries: isCi ? 2 : 1,
@@ -28,13 +31,23 @@ export default defineConfig({
   },
 
   projects: [
+    // Writes e2e/.auth/{user,admin}.json before any spec runs. Without
+    // E2E_USER_* / E2E_ADMIN_* credentials it writes empty storage states so
+    // the authenticated suites in the deep specs skip via their hasRealAuth()
+    // guards instead of failing with ENOENT on a fresh checkout.
+    {
+      name: "setup",
+      testMatch: /auth\.setup\.ts/,
+    },
     {
       name: "chromium",
       use: { ...devices["Desktop Chrome"] },
+      dependencies: ["setup"],
     },
     {
       name: "mobile-chrome",
       use: { ...devices["Pixel 7"] },
+      dependencies: ["setup"],
     },
   ],
 


### PR DESCRIPTION
Full-suite verification on a fresh checkout of main surfaced 206 failures + 270 misdirected k3s tests. Root causes and fixes:

1. **playwright.config.mts** — #754 replaced the config and dropped the 'setup' project and the k3s exclusion. Without setup, e2e/.auth/{user,admin}.json never exist on a fresh checkout, so every storageState-based deep spec fails with ENOENT (206 tests) instead of skipping; k3s specs (live-cluster, own config) ran against localhost. Restored both.
2. **public-api-deep** — /api/docs/:slug and /api/chat intentionally return 503 when their integration is unconfigured (repo convention, see calendar availability tests); expectations now accept 503.
3. **journey-contact-lead / journey-theme-locale** — on Pixel-7 viewport the nav links and theme switcher live inside the hamburger drawer; the specs clicked the hidden desktop instances and timed out. They now open the drawer and filter to the visible instance.

Verified locally: 2096 tests, 0 unexplained failures (323 skips are credential-gated by design).