### PR TITLE
fix(admin): Google campaigns page called nonexistent /api/google/campaigns

### DIFF
--- a/src/app/[locale]/admin/campaigns/google/page.tsx
+++ b/src/app/[locale]/admin/campaigns/google/page.tsx
@@ -1,116 +1,191 @@
 "use client";
 
+import { fetchWithAuth } from "@/lib/fetch-with-auth";
 import { useEffect, useState } from "react";
+import { Link } from "@/i18n/navigation";
 
-interface Campaign {
+/**
+ * Matches GoogleCampaign returned by GET /api/admin/campaigns/google
+ * (src/lib/campaigns/google-ads.ts). Budget is in micros (1e6 = 1 unit).
+ */
+interface GoogleCampaign {
   id: string;
   name: string;
   status: string;
+  advertisingChannelType: string;
+  budgetAmountMicros: string;
+  startDate: string;
+  endDate: string;
+}
+
+/** Matches GoogleMetrics returned by GET /api/admin/campaigns/google/insights. */
+interface GoogleMetrics {
   impressions: number;
   clicks: number;
-  cost: number;
+  costMicros: number;
+  conversions: number;
+  /** Fraction (0.05 = 5%), as reported by the Google Ads API. */
+  ctr: number;
+}
+
+function microsToUnits(micros: string | number): string {
+  const n = typeof micros === "string" ? Number.parseInt(micros, 10) : micros;
+  return (Number.isFinite(n) ? n / 1_000_000 : 0).toFixed(2);
 }
 
 export default function GoogleCampaignsPage() {
-  const [campaigns, setCampaigns] = useState<Campaign[]>([]);
+  const [campaigns, setCampaigns] = useState<GoogleCampaign[]>([]);
+  const [metrics, setMetrics] = useState<GoogleMetrics | null>(null);
   const [loading, setLoading] = useState(true);
+  const [notConfigured, setNotConfigured] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  async function load() {
+    setLoading(true);
+    setError(null);
+    try {
+      const [camRes, insRes] = await Promise.all([
+        fetchWithAuth("/api/admin/campaigns/google"),
+        fetchWithAuth("/api/admin/campaigns/google/insights"),
+      ]);
+      if (camRes.status === 503) {
+        setNotConfigured(true);
+        return;
+      }
+      if (!camRes.ok) throw new Error("Failed to load campaigns");
+      setCampaigns((await camRes.json()).campaigns ?? []);
+      if (insRes.ok) setMetrics((await insRes.json()).metrics ?? null);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Failed to load");
+    } finally {
+      setLoading(false);
+    }
+  }
 
   useEffect(() => {
-    fetch("/api/google/campaigns")
-      .then((r) => r.json())
-      .then((d) => setCampaigns(d.campaigns ?? []))
-      .finally(() => setLoading(false));
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    load();
   }, []);
 
-  if (loading) {
+  if (notConfigured) {
     return (
-      <div className="flex items-center justify-center py-16">
-        <div className="border-neon-magenta h-6 w-6 animate-spin rounded-full border-2 border-t-transparent" />
+      <div>
+        <BackLink />
+        <div className="rounded-xl border border-yellow-900/30 bg-yellow-950/10 p-6">
+          <p className="font-mono text-sm text-yellow-400">
+            Google Ads is not configured. Add{" "}
+            <code className="text-yellow-300">GOOGLE_ADS_DEVELOPER_TOKEN</code> and{" "}
+            <code className="text-yellow-300">GOOGLE_ADS_CUSTOMER_ID</code> to AWS SSM.
+          </p>
+        </div>
       </div>
     );
   }
 
-  const totalImpressions = campaigns.reduce((s, c) => s + (c.impressions ?? 0), 0);
-  const totalClicks = campaigns.reduce((s, c) => s + (c.clicks ?? 0), 0);
-  const totalCost = campaigns.reduce((s, c) => s + Number.parseFloat(String(c.cost ?? 0)), 0);
-  const avgCtr =
-    totalImpressions > 0 ? ((totalClicks / totalImpressions) * 100).toFixed(2) : "0.00";
-
   return (
-    <div className="space-y-6">
-      <div className="grid grid-cols-3 gap-4">
-        <MetricCard label="Impressions" value={totalImpressions.toLocaleString()} />
-        <MetricCard label="Clicks" value={totalClicks.toLocaleString()} />
-        <MetricCard label="CTR" value={`${avgCtr}%`} />
-        <MetricCard label="Spend" value={`$${totalCost.toFixed(2)}`} />
+    <div>
+      <BackLink />
+      <div className="mb-8">
+        <div className="mb-4 inline-flex items-center gap-2 rounded-full border border-red-500/20 bg-red-500/10 px-3 py-1.5">
+          <span className="h-2 w-2 animate-pulse rounded-full bg-red-400" />
+          <span className="font-mono text-xs text-red-400">GOOGLE ADS</span>
+        </div>
+        <h1 className="font-heading text-2xl font-bold text-white">Google Ads Campaigns</h1>
       </div>
 
-      <div className="bg-void-light/50 overflow-hidden rounded-xl border border-slate-800">
-        <div className="border-b border-slate-800 px-6 py-3">
-          <h3 className="font-mono text-xs font-medium text-slate-400">Google Ads Campaigns</h3>
+      {metrics && (
+        <div className="mb-8 grid grid-cols-5 gap-4">
+          <MetricCard label="Impressions" value={metrics.impressions.toLocaleString()} />
+          <MetricCard label="Clicks" value={metrics.clicks.toLocaleString()} />
+          <MetricCard label="CTR" value={`${(metrics.ctr * 100).toFixed(2)}%`} />
+          <MetricCard label="Spend" value={`$${microsToUnits(metrics.costMicros)}`} />
+          <MetricCard label="Conversions" value={metrics.conversions.toLocaleString()} />
         </div>
-        <div className="overflow-x-auto">
-          <table className="w-full text-sm">
+      )}
+
+      {loading && <Spinner color="border-red-400" />}
+      {error && <ErrorMsg msg={error} />}
+      {!loading && !error && (
+        <div className="overflow-hidden rounded-xl border border-slate-800">
+          <table className="w-full">
             <thead>
-              <tr className="border-b border-slate-800">
-                <th className="px-6 py-3 text-left font-mono text-xs font-medium text-slate-500">
-                  Campaign
-                </th>
-                <th className="px-6 py-3 text-right font-mono text-xs font-medium text-slate-500">
-                  Status
-                </th>
-                <th className="px-6 py-3 text-right font-mono text-xs font-medium text-slate-500">
-                  Impressions
-                </th>
-                <th className="px-6 py-3 text-right font-mono text-xs font-medium text-slate-500">
-                  Clicks
-                </th>
-                <th className="px-6 py-3 text-right font-mono text-xs font-medium text-slate-500">
-                  Cost
-                </th>
+              <tr className="border-b border-slate-800 bg-slate-900/50">
+                <th className="px-4 py-3 text-left font-mono text-xs text-slate-500">Campaign</th>
+                <th className="px-4 py-3 text-left font-mono text-xs text-slate-500">Status</th>
+                <th className="px-4 py-3 text-left font-mono text-xs text-slate-500">Channel</th>
+                <th className="px-4 py-3 text-right font-mono text-xs text-slate-500">Budget</th>
+                <th className="px-4 py-3 text-right font-mono text-xs text-slate-500">Schedule</th>
               </tr>
             </thead>
-            <tbody>
-              {campaigns.map((c) => (
-                <tr
-                  key={c.id}
-                  className="hover:bg-void-lighter/30 border-b border-slate-800/50 transition-colors"
-                >
-                  <td className="px-6 py-3 text-white">{c.name}</td>
-                  <td className="px-6 py-3 text-right font-mono text-xs">
-                    <StatusBadge status={c.status} />
-                  </td>
-                  <td className="px-6 py-3 text-right font-mono text-sm text-white">
-                    {(c.impressions ?? 0).toLocaleString()}
-                  </td>
-                  <td className="px-6 py-3 text-right font-mono text-sm text-white">
-                    {(c.clicks ?? 0).toLocaleString()}
-                  </td>
-                  <td className="px-6 py-3 text-right font-mono text-sm text-white">
-                    ${Number.parseFloat(String(c.cost ?? 0)).toFixed(2)}
-                  </td>
-                </tr>
-              ))}
+            <tbody className="divide-y divide-slate-800">
               {campaigns.length === 0 && (
                 <tr>
-                  <td colSpan={5} className="px-6 py-12 text-center font-mono text-slate-600">
-                    No Google Ads campaigns found.
+                  <td colSpan={5} className="py-8 text-center font-mono text-sm text-slate-600">
+                    No campaigns found.
                   </td>
                 </tr>
               )}
+              {campaigns.map((c) => (
+                <tr key={c.id} className="transition-colors hover:bg-slate-800/30">
+                  <td className="px-4 py-3 font-mono text-sm text-white">{c.name}</td>
+                  <td className="px-4 py-3">
+                    <StatusBadge status={c.status} />
+                  </td>
+                  <td className="px-4 py-3 font-mono text-xs text-slate-400">
+                    {c.advertisingChannelType}
+                  </td>
+                  <td className="px-4 py-3 text-right font-mono text-sm text-slate-300">
+                    ${microsToUnits(c.budgetAmountMicros)}
+                  </td>
+                  <td className="px-4 py-3 text-right font-mono text-xs text-slate-400">
+                    {c.startDate}
+                    {c.endDate ? ` → ${c.endDate}` : ""}
+                  </td>
+                </tr>
+              ))}
             </tbody>
           </table>
         </div>
-      </div>
+      )}
     </div>
   );
 }
 
-function MetricCard({ label, value }: { readonly label: string; readonly value: string | number }) {
+function BackLink() {
   return (
-    <div className="bg-void-light/50 rounded-xl border border-slate-800 p-4">
-      <p className="font-mono text-xs text-slate-500">{label}</p>
-      <p className="mt-1 font-mono text-xl font-semibold text-white">{value}</p>
+    <div className="mb-6">
+      <Link
+        href="/admin/campaigns"
+        className="font-mono text-xs text-slate-500 hover:text-slate-300"
+      >
+        ← Campaigns
+      </Link>
+    </div>
+  );
+}
+
+function MetricCard({ label, value }: { readonly label: string; readonly value: string }) {
+  return (
+    <div className="bg-void-light/50 rounded-xl border border-slate-800 p-3">
+      <p className="font-mono text-[10px] text-slate-500">{label}</p>
+      <p className="mt-1 font-mono text-sm font-bold text-white">{value}</p>
+    </div>
+  );
+}
+
+function Spinner({ color = "border-neon-cyan" }: { readonly color?: string }) {
+  return (
+    <div className="flex items-center gap-3 text-slate-400">
+      <div className={`h-4 w-4 animate-spin rounded-full border-2 ${color} border-t-transparent`} />
+      <span className="font-mono text-sm">Loading...</span>
+    </div>
+  );
+}
+
+function ErrorMsg({ msg }: { readonly msg: string }) {
+  return (
+    <div className="rounded-lg border border-red-900/30 bg-red-950/10 px-4 py-3 font-mono text-sm text-red-400">
+      {msg}
     </div>
   );
 }


### PR DESCRIPTION
Found during a frontend/backend API contract audit (125 routes vs ~90 call sites).

The Google Ads admin page was the only campaigns page broken: it fetched **/api/google/campaigns** — a route that does not exist (the real one is /api/admin/campaigns/google) — using a plain unauthenticated fetch, so the page 404'd on every load and always rendered an empty table. Its Campaign interface also expected per-campaign impressions/clicks/cost, which the backend never returns (GoogleCampaign carries status/channel/budget-micros/schedule; metrics are account-level via /insights).

Rewritten to mirror the LinkedIn/TikTok/X sibling pages: fetchWithAuth on both endpoints, 503 → 'not configured' callout (GOOGLE_ADS_DEVELOPER_TOKEN / GOOGLE_ADS_CUSTOMER_ID), metric cards from GoogleMetrics (CTR fraction ×100, costMicros/1e6), real campaign table columns.

Everything else in the audit checked out: all other frontend /api/* calls (incl. dynamic templates) resolve to existing routes with matching methods; /api/esp32/*, /api/alerts, /api/status literals are upstream-service paths inside the ops/monitor proxy route, not browser calls. tsc clean for this file.