### PR TITLE
feat(ops): Workers AI doctor, verify workflow, and skill

### DIFF
--- a/.claude/skills/workers-ai/SKILL.md
+++ b/.claude/skills/workers-ai/SKILL.md
@@ -1,0 +1,61 @@
+---
+name: workers-ai
+description: Activate, verify, rotate, and troubleshoot the Cloudflare Workers AI integration (/api/admin/ai/generate + /admin/ai-generator). Use when the AI Generator shows "not configured", when rotating CLOUDFLARE_API_TOKEN, when a Workers AI call returns 401/403/502/503, or when the user asks to "enable the AI generator", "check Workers AI", or "rotate the Cloudflare token".
+argument-hint: "what's wrong, e.g. 'AI generator not configured', 'rotate token', 'verify workers ai'"
+---
+
+# Cloudflare Workers AI — activation, verification, rotation
+
+The admin AI Generator (`/admin/ai-generator`) calls
+`POST /api/admin/ai/generate`, which proxies Cloudflare Workers AI. The route
+needs two Lambda env vars, forwarded by `sst.config.ts` from the deploy
+workflow: `CLOUDFLARE_ACCOUNT_ID` (inline in `deploy.yml`,
+`fb7dc7b69b662480cd5961a4d1913c78`) and `CLOUDFLARE_API_TOKEN` (repo secret).
+
+## Tools
+
+| Tool | What it does |
+| --- | --- |
+| `scripts/workers-ai-doctor.sh` | Full chain check: token validity + Workers AI scope (real 1-token inference), Lambda env wiring, live auth gate. Each check skips gracefully without its credential. |
+| `.github/workflows/workers-ai-verify.yml` | Runs the doctor on a hosted runner **with the repo secret** (the only way to test a secret a session can't read) and posts the result to issue #382. Trigger via `gh workflow run workers-ai-verify.yml` or by editing the doctor script. |
+
+## Activate (one-time)
+
+1. Token: dash.cloudflare.com → Profile → API Tokens → Create Token → Custom →
+   permissions **Account → Workers AI → Read + Run** (an existing token can be
+   edited to add the scope instead).
+2. `gh secret set CLOUDFLARE_API_TOKEN` (paste when prompted).
+3. `gh workflow run deploy.yml` — the deploy injects it into the Lambda env.
+4. `gh workflow run workers-ai-verify.yml` — confirm ✅ on issue #382.
+
+## Rotate
+
+Same as activation steps 1–3 with a fresh token; revoke the old one in the
+dashboard afterwards. The route reads the env per-invocation, so rotation
+needs a redeploy (Lambda env is deploy-time).
+
+## Troubleshooting
+
+| Symptom | Meaning | Fix |
+| --- | --- | --- |
+| UI shows "not configured" / route 503 | Lambda env vars missing | Set secret → `gh workflow run deploy.yml` |
+| Route 401/403 | Caller isn't an admin | Sign in with a Cognito `admin`-group user |
+| Route 502 `Cloudflare API error` | Upstream rejected the call | Run `workers-ai-verify.yml`; if scope MISSING, edit the token to add Workers AI Read+Run |
+| Doctor: "token: INVALID" | Token revoked/expired | Create a new token, rotate |
+| Doctor: "route NOT deployed (404)" | deploy.yml hasn't shipped the route | Wait for/trigger deploy |
+| 429 | Shared `/api/admin/*` rate limit (90/min/IP, proxy.ts) | Back off |
+
+## Cost
+
+Workers AI free tier ≈ 10,000 neurons/day; Llama-3-8B costs fractions of a
+neuron per short generation. Pricing:
+https://developers.cloudflare.com/workers-ai/platform/pricing/
+
+## Known issue (infra)
+
+The cloudless-infra MCP's master Cloudflare credential is **invalid** —
+`cloudflare_create_token` / `cloudflare_list_permission_groups` fail with
+"Invalid access token", so tokens cannot be minted programmatically. To
+restore that, put a token with **User API Tokens: Edit** into the MCP server's
+`CLOUDFLARE_API_TOKEN` env. (The zone-scoped `CLOUDFLARE_GR_API_TOKEN` used by
+the DNS tools is fine and unrelated.)

--- a/.github/workflows/workers-ai-verify.yml
+++ b/.github/workflows/workers-ai-verify.yml
@@ -1,0 +1,69 @@
+name: Workers AI verify
+
+# Verifies the Workers AI chain end-to-end using the repo's
+# CLOUDFLARE_API_TOKEN secret (which a session can never read directly):
+# token validity + Workers AI scope (real 1-token inference), Lambda env
+# wiring, and the live auth gate. Posts the result to issue #382.
+#
+# Trigger: workflow_dispatch, or edit scripts/workers-ai-doctor.sh / this file
+# (path-trigger pattern — the GitHub MCP cannot workflow_dispatch).
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [main]
+    paths:
+      - "scripts/workers-ai-doctor.sh"
+      - ".github/workflows/workers-ai-verify.yml"
+
+permissions:
+  id-token: write
+  contents: read
+  issues: write
+
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Configure AWS credentials (OIDC)
+        continue-on-error: true
+        uses: aws-actions/configure-aws-credentials@e7f100cf4c008499ea8adda475de1042d6975c7b # v6.2.0
+        with:
+          role-to-assume: ${{ secrets.AWS_DEPLOY_ROLE_ARN }}
+          aws-region: us-east-1
+
+      - name: Run Workers AI doctor
+        id: doctor
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+        run: |
+          set +e
+          OUT=$(bash scripts/workers-ai-doctor.sh 2>&1)
+          CODE=$?
+          echo "$OUT"
+          {
+            echo "result<<EOF"
+            echo "$OUT"
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+          echo "code=$CODE" >> "$GITHUB_OUTPUT"
+          exit 0
+
+      - name: Post result to issue 382
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          STATUS=$([ "${{ steps.doctor.outputs.code }}" = "0" ] && echo "✅ PASS" || echo "❌ FAIL")
+          gh issue comment 382 --repo "${{ github.repository }}" --body "## Workers AI verify — ${STATUS}
+          \`\`\`
+          ${{ steps.doctor.outputs.result }}
+          \`\`\`
+          Run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+
+      - name: Fail job if doctor failed
+        if: steps.doctor.outputs.code != '0'
+        run: exit 1

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "cognito:setup": "bash scripts/cognito-setup.sh",
     "cognito:setup:dry": "bash scripts/cognito-setup.sh --dry-run",
     "cognito:setup:quick": "bash scripts/cognito-setup.sh --skip-verify",
+    "workers-ai:doctor": "bash scripts/workers-ai-doctor.sh",
     "e2e:cognito": "bash scripts/e2e-cognito-provision.sh",
     "e2e:cognito:dry": "bash scripts/e2e-cognito-provision.sh --dry-run",
     "mcp-security-scan": "cd tools/mcp-security-scanner && npm install && npm run scan -- --path \"../../src/**/*.{ts,tsx,js,jsx,py,md}\"",

--- a/scripts/workers-ai-doctor.sh
+++ b/scripts/workers-ai-doctor.sh
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+#
+# Workers AI doctor — verifies the full /api/admin/ai/generate chain.
+#
+# Checks (each skipped gracefully when its credential isn't available):
+#   1. Cloudflare token validity + Workers AI scope (needs CLOUDFLARE_API_TOKEN)
+#      — runs a real 1-token inference against llama-3-8b-instruct.
+#   2. Production Lambda env carries CLOUDFLARE_ACCOUNT_ID/CLOUDFLARE_API_TOKEN
+#      (needs AWS credentials with lambda:GetFunctionConfiguration).
+#   3. Live endpoint is deployed and auth-gated: unauthenticated POST
+#      https://cloudless.gr/api/admin/ai/generate must return 401.
+#
+# Usage:
+#   CLOUDFLARE_API_TOKEN=... bash scripts/workers-ai-doctor.sh
+#   bash scripts/workers-ai-doctor.sh            # env/Lambda/live checks only
+#
+# Exit code: 0 when every check that COULD run passed; 1 otherwise.
+
+set -uo pipefail
+
+ACCOUNT_ID="${CLOUDFLARE_ACCOUNT_ID:-fb7dc7b69b662480cd5961a4d1913c78}"
+LAMBDA_FN="${LAMBDA_FN:-cloudless-production-CloudlessSiteServerUseast1Function-ddkafukh}"
+SITE="${SITE:-https://cloudless.gr}"
+FAIL=0
+
+say() { printf '%s\n' "$*"; }
+
+# ── 1. Token validity + Workers AI scope ─────────────────────────────────────
+if [ -n "${CLOUDFLARE_API_TOKEN:-}" ]; then
+  say "== 1. Cloudflare token"
+  VERIFY=$(curl -s --max-time 15 \
+    -H "Authorization: Bearer ${CLOUDFLARE_API_TOKEN}" \
+    https://api.cloudflare.com/client/v4/user/tokens/verify)
+  if printf '%s' "$VERIFY" | grep -q '"status":"active"'; then
+    say "   token: active"
+  else
+    say "   token: INVALID — $VERIFY"
+    FAIL=1
+  fi
+
+  RUN_CODE=$(curl -s -o /tmp/wai-run.json -w '%{http_code}' --max-time 30 \
+    -X POST \
+    -H "Authorization: Bearer ${CLOUDFLARE_API_TOKEN}" \
+    -H "Content-Type: application/json" \
+    -d '{"messages":[{"role":"user","content":"ping"}],"max_tokens":1}' \
+    "https://api.cloudflare.com/client/v4/accounts/${ACCOUNT_ID}/ai/run/@cf/meta/llama-3-8b-instruct")
+  if [ "$RUN_CODE" = "200" ]; then
+    say "   Workers AI scope: OK (inference HTTP 200)"
+  else
+    say "   Workers AI scope: MISSING/BLOCKED (HTTP ${RUN_CODE})"
+    say "   body: $(head -c 300 /tmp/wai-run.json)"
+    say "   fix: dash.cloudflare.com → API Tokens → edit token → add Account → Workers AI → Read+Run"
+    FAIL=1
+  fi
+else
+  say "== 1. Cloudflare token — SKIPPED (CLOUDFLARE_API_TOKEN not set)"
+fi
+
+# ── 2. Lambda env wiring ─────────────────────────────────────────────────────
+if command -v aws >/dev/null 2>&1 && aws sts get-caller-identity >/dev/null 2>&1; then
+  say "== 2. Lambda env"
+  ENVV=$(aws lambda get-function-configuration --function-name "$LAMBDA_FN" \
+    --region us-east-1 \
+    --query "Environment.Variables.{ID:CLOUDFLARE_ACCOUNT_ID,TOK:CLOUDFLARE_API_TOKEN}" \
+    --output text 2>/dev/null)
+  ID_VAL=$(printf '%s' "$ENVV" | awk '{print $1}')
+  TOK_VAL=$(printf '%s' "$ENVV" | awk '{print $2}')
+  if [ "$ID_VAL" != "None" ] && [ -n "$ID_VAL" ]; then
+    say "   CLOUDFLARE_ACCOUNT_ID: present"
+  else
+    say "   CLOUDFLARE_ACCOUNT_ID: MISSING — redeploy after setting the repo secret"
+    FAIL=1
+  fi
+  if [ "$TOK_VAL" != "None" ] && [ -n "$TOK_VAL" ]; then
+    say "   CLOUDFLARE_API_TOKEN: present"
+  else
+    say "   CLOUDFLARE_API_TOKEN: MISSING — add repo secret CLOUDFLARE_API_TOKEN, then gh workflow run deploy.yml"
+    FAIL=1
+  fi
+else
+  say "== 2. Lambda env — SKIPPED (no AWS credentials)"
+fi
+
+# ── 3. Live endpoint deployed + auth-gated ───────────────────────────────────
+say "== 3. Live endpoint"
+LIVE_CODE=$(curl -s -o /dev/null -w '%{http_code}' --max-time 20 \
+  -X POST -H "Content-Type: application/json" -d '{"prompt":"ping"}' \
+  "${SITE}/api/admin/ai/generate")
+case "$LIVE_CODE" in
+  401|403) say "   unauth POST → ${LIVE_CODE} (auth gate OK, route deployed)" ;;
+  404)     say "   unauth POST → 404 — route NOT deployed yet (wait for deploy.yml)"; FAIL=1 ;;
+  *)       say "   unauth POST → ${LIVE_CODE} (unexpected)"; FAIL=1 ;;
+esac
+
+say ""
+if [ "$FAIL" = "0" ]; then
+  say "WORKERS AI DOCTOR: all runnable checks passed ✓"
+else
+  say "WORKERS AI DOCTOR: issues found ✗"
+fi
+exit "$FAIL"


### PR DESCRIPTION
Operational tooling for the Workers AI integration (follow-up to #795):

- **scripts/workers-ai-doctor.sh** (\pnpm workers-ai:doctor\) — full-chain check: Cloudflare token validity + Workers AI scope (real 1-token inference), Lambda env wiring, live auth gate. Credential-aware: skips checks it can't run.
- **workers-ai-verify.yml** — runs the doctor on a hosted runner *with the CLOUDFLARE_API_TOKEN repo secret* (the only way to empirically test a secret's scope) and posts the verdict to issue #382.
- **.claude/skills/workers-ai/SKILL.md** — activation/rotation/troubleshooting playbook; documents the invalid infra-MCP master Cloudflare credential.

Doctor already verified live: Lambda env carries both CLOUDFLARE_* vars (today's deploys), route deployed + 401 auth gate.