### PR TITLE
fix(ci): deploy-pi tolerates ECR immutable-tag race so k3s rollout still runs

### DIFF
--- a/.github/workflows/deploy-pi.yml
+++ b/.github/workflows/deploy-pi.yml
@@ -42,7 +42,10 @@ jobs:
     runs-on: [self-hosted, omv, pi, build]
     outputs:
       short_sha: ${{ steps.check_ecr.outputs.short_sha }}
-      image_exists: ${{ steps.check_ecr.outputs.exists }}
+      # Image is in ECR if the pre-build check found it OR our push step
+      # observed it already present (concurrent build-pi-image.yml won the
+      # race to the immutable tag). Either way the rollout can proceed.
+      image_exists: ${{ steps.check_ecr.outputs.exists == 'true' && 'true' || steps.push_ecr.outputs.pushed_or_exists }}
 
     steps:
       - name: Checkout
@@ -137,15 +140,35 @@ jobs:
       # `aws ecr get-login-password | docker login --password-stdin` writes
       # directly to config.json, bypassing any credential helper.
       - name: Push to ECR
+        id: push_ecr
         if: steps.check_ecr.outputs.exists != 'true'
         run: |
-          set -euo pipefail
+          set -uo pipefail
           TAG="${{ env.ECR_REGISTRY }}/${{ env.ECR_REPOSITORY }}:${{ steps.check_ecr.outputs.short_sha }}"
           echo "==> docker login via get-login-password"
           aws ecr get-login-password --region ${{ env.AWS_REGION }} \
             | docker login --username AWS --password-stdin ${{ env.ECR_REGISTRY }}
           echo "==> docker push ${TAG}"
-          docker push "${TAG}"
+          # Capture output so we can distinguish the immutable-tag race (the
+          # concurrent build-pi-image.yml already pushed this exact SHA) from a
+          # genuine push failure. ECR repos use immutable tags, so a same-SHA
+          # re-push returns: "tag invalid: ... already exists ... cannot be
+          # overwritten because the tag is immutable." That means the image IS
+          # in ECR — success for our purposes, so the rollout must still run.
+          push_log=$(docker push "${TAG}" 2>&1)
+          rc=$?
+          echo "${push_log}"
+          if [ "${rc}" -eq 0 ]; then
+            echo "pushed_or_exists=true" >> "$GITHUB_OUTPUT"
+            echo "Pushed ${TAG}."
+          elif echo "${push_log}" | grep -qiE 'already exists.*immutable|tag.*immutable'; then
+            echo "pushed_or_exists=true" >> "$GITHUB_OUTPUT"
+            echo "::notice::Tag already present (immutable) — concurrent build won the race; image is in ECR, proceeding to rollout."
+          else
+            echo "pushed_or_exists=false" >> "$GITHUB_OUTPUT"
+            echo "::error::docker push failed for a reason other than the immutable-tag race."
+            exit 1
+          fi
 
       - name: Update SSM Pi image tracking
         run: |


### PR DESCRIPTION
## Problem

The post-merge deploy for #798 (`3710bfd`) **failed the Pi rollout**:

- **Deploy to Pi** → `Build arm64 image and push to ECR` **failed** at `Push to ECR`:
  ```
  tag invalid: The image tag '3710bfdf49b0' already exists in the
  'cloudless-pi-app' repository and cannot be overwritten because the tag is immutable.
  ```
- `Rollout restart on k3s` → **skipped** (build job failed and `image_exists` was stale-`false`)
- **HA sync orchestrator** → failed at `wait for k3s rollout`

### Root cause — a race, not a flake
`deploy-pi.yml` and `build-pi-image.yml` both build + push the **same SHA tag** on every push to main. `deploy-pi`'s pre-build "does the tag exist?" check sees it absent, builds (~minutes), and by push time `build-pi-image` has already pushed the identical **immutable** tag. The losing push hard-fails. Because that failure made `image_exists=false`, the rollout `if` (line 171) evaluated false and the k3s rollout never ran. The image **is** in ECR — the conflict is a no-op success, not a failure.

## Fix
Make `deploy-pi.yml`'s push step tolerate the immutable-tag-exists error — the exact pattern **already used in `build-pi-image.yml`**:

- Capture `docker push` output. `rc==0` → pushed. `already exists…immutable` / `tag…immutable` → treat as success, set `pushed_or_exists=true`. Any **other** error → `exit 1` (real failures still fail).
- Job output `image_exists` now reflects "in ECR" from either the pre-check **or** the push step, so the rollout fires on the race path.

## Recovery
Merging this edits a file in `deploy-pi.yml`'s own `paths`, so it **re-triggers the deploy** and recovers the `3710bfd` rollout that the failed run skipped. The image is already in ECR, so the re-run will hit the tolerated path and proceed straight to the k3s rollout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)