### PR TITLE
perf(services,store): fix LCP (hero animation) + ScrollReveal TBT to clear Lighthouse

### DIFF
--- a/src/app/[locale]/services/page.tsx
+++ b/src/app/[locale]/services/page.tsx
@@ -92,20 +92,23 @@ export default async function ServicesPage() {
         <div className="cyber-grid absolute inset-0 opacity-20" />
         <div className="bg-neon-cyan/5 animate-float absolute top-0 right-0 h-[400px] w-[400px] translate-x-1/3 -translate-y-1/2 rounded-full blur-3xl" />
         <div className="relative z-10 mx-auto max-w-6xl px-6">
-          <div className="bg-neon-cyan/10 border-neon-cyan/20 text-neon-cyan animate-fade-in-up mb-6 inline-flex items-center gap-2 rounded-full border px-3 py-1.5 font-mono text-sm font-medium">
+          {/* Above-the-fold hero text renders at full opacity on first paint
+              (no entrance animation) — the h1 is the LCP element and a
+              fade-in delays LCP past the Lighthouse measurement point. */}
+          <div className="bg-neon-cyan/10 border-neon-cyan/20 text-neon-cyan mb-6 inline-flex items-center gap-2 rounded-full border px-3 py-1.5 font-mono text-sm font-medium">
             <span className="relative flex h-2 w-2">
               <span className="bg-neon-green animate-ping-slow absolute inline-flex h-full w-full rounded-full opacity-75" />
               <span className="bg-neon-green relative inline-flex h-2 w-2 rounded-full" />
             </span>
             {t("servicesPage.badge", "Transparent Pricing")}
           </div>
-          <h1 className="animate-fade-in-up font-heading text-3xl leading-tight font-bold delay-100 md:text-5xl">
+          <h1 className="font-heading text-3xl leading-tight font-bold md:text-5xl">
             {t("servicesPage.title", "No hidden fees.")}{" "}
             <span className="from-neon-cyan to-neon-magenta bg-gradient-to-r bg-clip-text text-transparent">
               {t("servicesPage.titleHighlight", "Real results.")}
             </span>
           </h1>
-          <p className="animate-fade-in-up mt-4 max-w-xl text-lg text-slate-400 delay-200">
+          <p className="mt-4 max-w-xl text-lg text-slate-400">
             {t(
               "servicesPage.subtitle",
               "Pick what you need or bundle everything for 30% savings. No lock-in contracts — your code is always yours."

--- a/src/app/[locale]/store/page.tsx
+++ b/src/app/[locale]/store/page.tsx
@@ -85,13 +85,15 @@ export default function StorePage() {
           <p className="animate-shimmer-text mb-3 font-mono text-xs font-medium tracking-[0.3em]">
             [ STORE ]
           </p>
-          <h1 className="animate-fade-in-up font-heading text-3xl leading-tight font-bold delay-100 md:text-5xl">
+          {/* LCP element renders at full opacity on first paint — no entrance
+              animation, which would delay LCP past Lighthouse's measurement. */}
+          <h1 className="font-heading text-3xl leading-tight font-bold md:text-5xl">
             Tools, templates &amp;{" "}
             <span className="from-neon-cyan to-neon-magenta bg-gradient-to-r bg-clip-text text-transparent">
               expert services.
             </span>
           </h1>
-          <p className="animate-fade-in-up mt-4 max-w-xl text-lg text-slate-400 delay-200">
+          <p className="mt-4 max-w-xl text-lg text-slate-400">
             Everything you need to build, scale, and market your cloud-powered business. From
             self-serve digital products to done-for-you services.
           </p>

--- a/src/components/ScrollReveal.tsx
+++ b/src/components/ScrollReveal.tsx
@@ -8,31 +8,62 @@ interface ScrollRevealProps {
   delay?: number;
 }
 
-export default function ScrollReveal({ children, className = "", delay = 0 }: ScrollRevealProps) {
+// A single shared IntersectionObserver for every ScrollReveal on the page.
+// Pages like /services mount 29 of these; one observer per instance spikes
+// Total Blocking Time. One observer watching all elements is far cheaper on
+// the main thread and behaves identically (each element reveals once, then is
+// unobserved). Per-element reveal delay is carried on a data attribute.
+let sharedObserver: IntersectionObserver | null = null;
+
+function getObserver(): IntersectionObserver | null {
+  if (typeof IntersectionObserver === "undefined") return null;
+  if (sharedObserver) return sharedObserver;
+
+  sharedObserver = new IntersectionObserver(
+    (entries, observer) => {
+      for (const entry of entries) {
+        if (!entry.isIntersecting) continue;
+        const el = entry.target as HTMLElement;
+        const delay = Number(el.dataset.revealDelay) || 0;
+        if (delay > 0) {
+          setTimeout(() => el.classList.add("reveal-visible"), delay);
+        } else {
+          el.classList.add("reveal-visible");
+        }
+        observer.unobserve(el);
+      }
+    },
+    { threshold: 0.15, rootMargin: "0px 0px -40px 0px" }
+  );
+
+  return sharedObserver;
+}
+
+export default function ScrollReveal({
+  children,
+  className = "",
+  delay = 0,
+}: Readonly<ScrollRevealProps>) {
   const ref = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
     const el = ref.current;
     if (!el) return;
 
-    const observer = new IntersectionObserver(
-      ([entry]) => {
-        if (entry.isIntersecting) {
-          setTimeout(() => {
-            el.classList.add("reveal-visible");
-          }, delay);
-          observer.unobserve(el);
-        }
-      },
-      { threshold: 0.15, rootMargin: "0px 0px -40px 0px" }
-    );
+    const observer = getObserver();
+    // No IntersectionObserver support (old browsers / SSR edge) — reveal
+    // immediately so content is never stuck invisible.
+    if (!observer) {
+      el.classList.add("reveal-visible");
+      return;
+    }
 
     observer.observe(el);
-    return () => observer.disconnect();
+    return () => observer.unobserve(el);
   }, [delay]);
 
   return (
-    <div ref={ref} className={`reveal ${className}`}>
+    <div ref={ref} className={`reveal ${className}`} data-reveal-delay={delay || undefined}>
       {children}
     </div>
   );


### PR DESCRIPTION
## Why

The post-merge **Lighthouse Audit** and **Core Web Vitals Route Audit** failed (median-of-3, Performance ≥ 65):

| Route | Perf (median) | |
|-------|---------------|--|
| `/` | 72 | ✅ |
| `/contact` | 73 | ✅ |
| `/en` | 71 | ✅ |
| **`/services`** | **64** | ❌ |
| `/store` | 65 | ⚠️ on the line |

`/services` runs clustered at 64/64/66 — a real borderline, not pure variance. Fixing the perf gap rather than lowering the threshold.

## Fixes

**1. Hero entrance animation delayed LCP (biggest win)**
The hero `<h1>` (the LCP element) on `/services` and `/store` used `animate-fade-in-up` (0.7s, `animation-fill-mode: both`), so it started at `opacity:0` and faded in. Lighthouse records LCP only when the element reaches its final painted state → the animation pushed LCP past the measurement point. Above-the-fold hero text now paints at full opacity on first paint. Below-the-fold `ScrollReveal` animations are untouched.

**2. ScrollReveal: one shared IntersectionObserver instead of 29**
`ScrollReveal` created a fresh `IntersectionObserver` per instance — 29 on `/services`, spiking Total Blocking Time. Refactored to a single module-level observer watching all instances. Behavior is identical: each element reveals once (per-element delay carried on a `data-reveal-delay` attribute) and is unobserved after; falls back to immediate reveal when `IntersectionObserver` is unavailable.

## Notes
- These audits are **informational** (they don't gate deploy/PRs); the production + Pi deploys for the current main SHA already succeeded.
- Local `lint`, `format:check`, `typecheck` all green. SonarCloud S6759 (Readonly props) addressed in the rewritten component.

🤖 Generated with [Claude Code](https://claude.com/claude-code)