### PR TITLE
feat(seo): surface the weekly GSC archive from Notion in admin

### DIFF
--- a/__tests__/admin-gsc-archive-api.test.ts
+++ b/__tests__/admin-gsc-archive-api.test.ts
@@ -1,0 +1,87 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { NextRequest } from "next/server";
+import { IntegrationNotConfiguredError } from "@/lib/integrations";
+
+const requireAdminMock = vi.fn();
+const getGscReportsMock = vi.fn();
+
+vi.mock("@/lib/api-auth", () => ({
+  requireAdmin: requireAdminMock,
+}));
+
+vi.mock("@/lib/notion-gsc-reports", () => ({
+  getGscReports: getGscReportsMock,
+}));
+
+function makeGet(path: string): NextRequest {
+  return new NextRequest(`http://localhost:4500${path}`, { method: "GET" });
+}
+
+const okAuth = { ok: true as const };
+const denyAuth = {
+  ok: false as const,
+  response: new Response("Unauthorized", { status: 401 }),
+};
+
+describe("GET /api/admin/analytics/gsc-archive", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    requireAdminMock.mockResolvedValue(okAuth);
+  });
+
+  it("returns 401 when unauthenticated (does not call the lib)", async () => {
+    requireAdminMock.mockResolvedValueOnce(denyAuth);
+
+    const { GET } = await import("@/app/api/admin/analytics/gsc-archive/route");
+    const res = await GET(makeGet("/api/admin/analytics/gsc-archive"));
+
+    expect(res.status).toBe(401);
+    expect(getGscReportsMock).not.toHaveBeenCalled();
+  });
+
+  it("returns the archive rows with source=notion", async () => {
+    getGscReportsMock.mockResolvedValueOnce([
+      { id: "p1", week: "Week of 2026-06-08", date: "2026-06-08", clicks: 100 },
+    ]);
+
+    const { GET } = await import("@/app/api/admin/analytics/gsc-archive/route");
+    const res = await GET(makeGet("/api/admin/analytics/gsc-archive"));
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.source).toBe("notion");
+    expect(body.count).toBe(1);
+    expect(body.reports[0].week).toBe("Week of 2026-06-08");
+  });
+
+  it("clamps the limit param to [1,100]", async () => {
+    getGscReportsMock.mockResolvedValueOnce([]);
+
+    const { GET } = await import("@/app/api/admin/analytics/gsc-archive/route");
+    await GET(makeGet("/api/admin/analytics/gsc-archive?limit=9999"));
+
+    expect(getGscReportsMock).toHaveBeenCalledWith(100);
+  });
+
+  it("returns 503 when the integration is not configured", async () => {
+    getGscReportsMock.mockRejectedValueOnce(
+      new IntegrationNotConfiguredError(["NOTION_GSC_REPORTS_DB_ID"])
+    );
+
+    const { GET } = await import("@/app/api/admin/analytics/gsc-archive/route");
+    const res = await GET(makeGet("/api/admin/analytics/gsc-archive"));
+    const body = await res.json();
+
+    expect(res.status).toBe(503);
+    expect(body.reports).toEqual([]);
+  });
+
+  it("returns 502 when the lib returns null (Notion read error)", async () => {
+    getGscReportsMock.mockResolvedValueOnce(null);
+
+    const { GET } = await import("@/app/api/admin/analytics/gsc-archive/route");
+    const res = await GET(makeGet("/api/admin/analytics/gsc-archive"));
+
+    expect(res.status).toBe(502);
+  });
+});

--- a/__tests__/notion-gsc-reports.test.ts
+++ b/__tests__/notion-gsc-reports.test.ts
@@ -1,0 +1,159 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import {
+  resetIntegrationCache,
+  resetIntegrationCacheAsync,
+  IntegrationNotConfiguredError,
+} from "@/lib/integrations";
+
+const mockNotionFetch = vi.fn();
+
+vi.mock("@/lib/notion", () => ({
+  notionFetch: (...args: unknown[]) => mockNotionFetch(...args),
+}));
+
+function makeGscPage(overrides: Record<string, unknown> = {}) {
+  return {
+    id: "notion-gsc-1",
+    properties: {
+      Week: { title: [{ plain_text: "Week of 2026-06-08" }] },
+      Date: { date: { start: "2026-06-08" } },
+      Clicks: { number: 1234 },
+      Impressions: { number: 56789 },
+      "CTR %": { number: 3.5 },
+      "Avg Position": { number: 12.4 },
+      Keywords: { number: 87 },
+      "Top Keywords": {
+        rich_text: [
+          {
+            plain_text: JSON.stringify([
+              { q: "cloud consulting", clicks: 40, ctr: 5.1 },
+              { q: "aws audit", clicks: 22, ctr: 3.0 },
+            ]),
+          },
+        ],
+      },
+      "Top Country": { rich_text: [{ plain_text: "GR" }] },
+      "Mobile %": { number: 61.2 },
+      "CTR Opportunities": { number: 9 },
+    },
+    ...overrides,
+  };
+}
+
+describe("notion-gsc-reports.ts", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    resetIntegrationCache();
+    resetIntegrationCacheAsync();
+    process.env.NOTION_GSC_REPORTS_DB_ID = "gsc-db-123";
+    process.env.NOTION_API_KEY = "secret_test_key_12345";
+  });
+
+  it("queries the GSC reports DB and maps a page to a report", async () => {
+    mockNotionFetch.mockResolvedValueOnce({ results: [makeGscPage()] });
+
+    const { getGscReports } = await import("@/lib/notion-gsc-reports");
+    const reports = await getGscReports();
+
+    expect(reports).toHaveLength(1);
+    const r = reports![0];
+    expect(r.id).toBe("notion-gsc-1");
+    expect(r.week).toBe("Week of 2026-06-08");
+    expect(r.date).toBe("2026-06-08");
+    expect(r.clicks).toBe(1234);
+    expect(r.impressions).toBe(56789);
+    expect(r.ctrPct).toBe(3.5);
+    expect(r.avgPosition).toBe(12.4);
+    expect(r.keywords).toBe(87);
+    expect(r.topCountry).toBe("GR");
+    expect(r.mobilePct).toBe(61.2);
+    expect(r.ctrOpportunities).toBe(9);
+    expect(r.topKeywords).toEqual([
+      { q: "cloud consulting", clicks: 40, ctr: 5.1 },
+      { q: "aws audit", clicks: 22, ctr: 3.0 },
+    ]);
+    expect(mockNotionFetch).toHaveBeenCalledWith(
+      `/databases/gsc-db-123/query`,
+      expect.objectContaining({ method: "POST" })
+    );
+  });
+
+  it("sorts by Date descending and clamps page_size", async () => {
+    mockNotionFetch.mockResolvedValueOnce({ results: [] });
+
+    const { getGscReports } = await import("@/lib/notion-gsc-reports");
+    await getGscReports(500);
+
+    const body = JSON.parse(mockNotionFetch.mock.calls[0][1].body);
+    expect(body.sorts).toEqual([{ property: "Date", direction: "descending" }]);
+    expect(body.page_size).toBe(100); // clamped from 500
+  });
+
+  it("defaults missing numbers to 0 and empty top-keywords to []", async () => {
+    mockNotionFetch.mockResolvedValueOnce({
+      results: [
+        makeGscPage({
+          properties: {
+            Week: { title: [{ plain_text: "Week of 2026-06-01" }] },
+            Date: { date: { start: "2026-06-01" } },
+            // all numeric + rich_text props omitted
+          },
+        }),
+      ],
+    });
+
+    const { getGscReports } = await import("@/lib/notion-gsc-reports");
+    const reports = await getGscReports();
+    const r = reports![0];
+    expect(r.clicks).toBe(0);
+    expect(r.impressions).toBe(0);
+    expect(r.ctrPct).toBe(0);
+    expect(r.topCountry).toBe("");
+    expect(r.topKeywords).toEqual([]);
+  });
+
+  it("tolerates malformed Top Keywords JSON", async () => {
+    mockNotionFetch.mockResolvedValueOnce({
+      results: [
+        makeGscPage({
+          properties: {
+            ...makeGscPage().properties,
+            "Top Keywords": { rich_text: [{ plain_text: "{not valid json" }] },
+          },
+        }),
+      ],
+    });
+
+    const { getGscReports } = await import("@/lib/notion-gsc-reports");
+    const reports = await getGscReports();
+    expect(reports![0].topKeywords).toEqual([]);
+  });
+
+  it("throws when NOTION_GSC_REPORTS_DB_ID not configured", async () => {
+    process.env.NOTION_GSC_REPORTS_DB_ID = "";
+    resetIntegrationCache();
+    resetIntegrationCacheAsync();
+
+    const { getGscReports } = await import("@/lib/notion-gsc-reports");
+    await expect(getGscReports()).rejects.toBeInstanceOf(IntegrationNotConfiguredError);
+    expect(mockNotionFetch).not.toHaveBeenCalled();
+  });
+
+  it("throws when NOTION_API_KEY not configured", async () => {
+    process.env.NOTION_API_KEY = "";
+    resetIntegrationCache();
+    resetIntegrationCacheAsync();
+
+    const { getGscReports } = await import("@/lib/notion-gsc-reports");
+    await expect(getGscReports()).rejects.toBeInstanceOf(IntegrationNotConfiguredError);
+    expect(mockNotionFetch).not.toHaveBeenCalled();
+  });
+
+  it("returns null on Notion API error", async () => {
+    mockNotionFetch.mockRejectedValueOnce(new Error("Notion API 502"));
+
+    const { getGscReports } = await import("@/lib/notion-gsc-reports");
+    const reports = await getGscReports();
+    expect(reports).toBeNull();
+  });
+});

--- a/src/app/[locale]/admin/analytics/seo/page.tsx
+++ b/src/app/[locale]/admin/analytics/seo/page.tsx
@@ -56,6 +56,22 @@ interface DeviceRow {
   avgPosition: number;
 }
 
+/** One persisted weekly snapshot from the Notion GSC archive. */
+interface ArchiveRow {
+  id: string;
+  week: string;
+  date: string;
+  clicks: number;
+  impressions: number;
+  /** whole percent */
+  ctrPct: number;
+  avgPosition: number;
+  keywords: number;
+  topCountry: string;
+  mobilePct: number;
+  ctrOpportunities: number;
+}
+
 export default function SeoAnalyticsPage() {
   const [snapshot, setSnapshot] = useState<SeoSnapshot | null>(null);
   const [keywords, setKeywords] = useState<KeywordRow[]>([]);
@@ -63,6 +79,7 @@ export default function SeoAnalyticsPage() {
   const [intent, setIntent] = useState<IntentBreakdown | null>(null);
   const [countries, setCountries] = useState<CountryRow[]>([]);
   const [devices, setDevices] = useState<DeviceRow[]>([]);
+  const [archive, setArchive] = useState<ArchiveRow[]>([]);
   const [loading, setLoading] = useState(true);
   const [notConfigured, setNotConfigured] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -71,12 +88,15 @@ export default function SeoAnalyticsPage() {
     setLoading(true);
     setError(null);
     try {
-      const [seoRes, qpRes, intentRes, countryRes, deviceRes] = await Promise.all([
+      const [seoRes, qpRes, intentRes, countryRes, deviceRes, archiveRes] = await Promise.all([
         fetchWithAuth("/api/admin/analytics/seo"),
         fetchWithAuth("/api/admin/analytics/query-pages?limit=50"),
         fetchWithAuth("/api/admin/analytics/search-intent"),
         fetchWithAuth("/api/admin/analytics/countries?limit=20"),
         fetchWithAuth("/api/admin/analytics/devices"),
+        // Notion-backed weekly archive — optional; absent when the DB isn't
+        // configured (503). Never block the live GSC view on it.
+        fetchWithAuth("/api/admin/analytics/gsc-archive?limit=26"),
       ]);
       if (seoRes.status === 503) {
         setNotConfigured(true);
@@ -90,6 +110,7 @@ export default function SeoAnalyticsPage() {
       if (intentRes.ok) setIntent((await intentRes.json()).intent ?? null);
       if (countryRes.ok) setCountries((await countryRes.json()).countries ?? []);
       if (deviceRes.ok) setDevices((await deviceRes.json()).devices ?? []);
+      if (archiveRes.ok) setArchive((await archiveRes.json()).reports ?? []);
     } catch (e) {
       setError(e instanceof Error ? e.message : "Failed to load");
     } finally {
@@ -232,6 +253,40 @@ export default function SeoAnalyticsPage() {
               />
             </section>
           </div>
+
+          {archive.length > 0 && (
+            <section>
+              <h2 className="mb-3 font-mono text-xs font-medium tracking-wider text-slate-400">
+                WEEKLY ARCHIVE{" "}
+                <span className="text-slate-600">— persisted snapshots (Notion)</span>
+              </h2>
+              <SeoTable
+                head={[
+                  "Week",
+                  "Clicks",
+                  "Impressions",
+                  "CTR",
+                  "Avg Pos",
+                  "Keywords",
+                  "Mobile",
+                  "Top Country",
+                  "CTR Opps",
+                ]}
+                empty="No archived snapshots yet."
+                rows={archive.map((a) => [
+                  a.week,
+                  a.clicks.toLocaleString(),
+                  a.impressions.toLocaleString(),
+                  `${a.ctrPct}%`,
+                  a.avgPosition.toFixed(1),
+                  a.keywords.toLocaleString(),
+                  `${a.mobilePct}%`,
+                  a.topCountry || "—",
+                  a.ctrOpportunities.toLocaleString(),
+                ])}
+              />
+            </section>
+          )}
         </div>
       )}
     </div>

--- a/src/app/api/admin/analytics/gsc-archive/route.ts
+++ b/src/app/api/admin/analytics/gsc-archive/route.ts
@@ -1,0 +1,46 @@
+import { NextRequest, NextResponse } from "next/server";
+import { requireAdmin } from "@/lib/api-auth";
+import { getGscReports } from "@/lib/notion-gsc-reports";
+import { IntegrationNotConfiguredError } from "@/lib/integrations";
+
+/**
+ * Persisted weekly GSC archive (written by scripts/weekly-gsc-sync.ts into the
+ * NOTION_GSC_REPORTS_DB_ID database). Distinct from /api/admin/analytics/history,
+ * which queries the GSC API live — this serves the durable Notion-backed record.
+ */
+export async function GET(request: NextRequest) {
+  const auth = await requireAdmin(request);
+  if (!auth.ok) return auth.response;
+
+  const DEFAULT_LIMIT = 26;
+  const MAX_LIMIT = 100;
+  const limit = Math.max(
+    1,
+    Math.min(Number(request.nextUrl.searchParams.get("limit") ?? String(DEFAULT_LIMIT)), MAX_LIMIT)
+  );
+
+  try {
+    const reports = await getGscReports(limit);
+    if (reports === null) {
+      return NextResponse.json(
+        { error: "Failed to read the GSC archive from Notion." },
+        { status: 502 }
+      );
+    }
+    return NextResponse.json({
+      reports,
+      count: reports.length,
+      fetchedAt: new Date().toISOString(),
+      source: "notion",
+    });
+  } catch (err) {
+    if (err instanceof IntegrationNotConfiguredError) {
+      return NextResponse.json(
+        { error: "GSC archive not configured (NOTION_GSC_REPORTS_DB_ID).", reports: [] },
+        { status: 503 }
+      );
+    }
+    console.error("[GSC archive] Error:", err);
+    return NextResponse.json({ error: "Failed to fetch GSC archive." }, { status: 500 });
+  }
+}

--- a/src/lib/notion-gsc-reports.ts
+++ b/src/lib/notion-gsc-reports.ts
@@ -1,0 +1,139 @@
+/**
+ * Notion read access for the weekly GSC archive.
+ *
+ * `scripts/weekly-gsc-sync.ts` writes one page per week into the
+ * NOTION_GSC_REPORTS_DB_ID database (cron: Mondays 07:00, see
+ * .github/workflows/weekly-gsc-sync.yml). This module is the *read* side —
+ * it surfaces that persisted archive in the admin UI. It is distinct from the
+ * live `/api/admin/analytics/history` route, which queries the GSC API fresh
+ * each request: the archive is durable (survives GSC quota/credential gaps)
+ * and carries the curated fields the sync computed (CTR-opportunity counts,
+ * top country, mobile share, top-keyword breakdown).
+ *
+ * Expected Notion database schema (NOTION_GSC_REPORTS_DB_ID):
+ * ┌────────────────────┬─────────────────────────────────────────────────────┐
+ * │ Week               │ Title       "Week of YYYY-MM-DD"                     │
+ * │ Date               │ Date        End date of the 28-day window            │
+ * │ Clicks             │ Number                                               │
+ * │ Impressions        │ Number                                               │
+ * │ CTR %              │ Number      Whole percent (e.g. 3.5)                 │
+ * │ Avg Position       │ Number                                               │
+ * │ Keywords           │ Number      Count of organic keywords w/ impressions │
+ * │ Top Keywords       │ Rich text   JSON [{ q, clicks, ctr }]                │
+ * │ Top Country        │ Rich text   ISO country with most clicks            │
+ * │ Mobile %           │ Number      Share of clicks from mobile             │
+ * │ CTR Opportunities  │ Number      Queries with impressions>=20 & ctr<2%   │
+ * └────────────────────┴─────────────────────────────────────────────────────┘
+ */
+
+import { notionFetch } from "@/lib/notion";
+import { IntegrationNotConfiguredError, requireIntegrationAsync } from "@/lib/integrations";
+
+export interface GscTopKeyword {
+  q: string;
+  clicks: number;
+  ctr: number;
+}
+
+export interface GscWeeklyReport {
+  /** Notion page id — stable key for the row. */
+  id: string;
+  /** Title, e.g. "Week of 2026-06-08". */
+  week: string;
+  /** End date of the 28-day window (ISO date). */
+  date: string;
+  clicks: number;
+  impressions: number;
+  ctrPct: number;
+  avgPosition: number;
+  keywords: number;
+  topKeywords: GscTopKeyword[];
+  topCountry: string;
+  mobilePct: number;
+  ctrOpportunities: number;
+}
+
+async function getDb(): Promise<{ apiKey: string; dbId: string }> {
+  // An explicitly-cleared env var means "disabled" — don't let SSM re-enable it.
+  if (process.env.NOTION_API_KEY === "" || process.env.NOTION_GSC_REPORTS_DB_ID === "") {
+    throw new IntegrationNotConfiguredError(["NOTION_API_KEY", "NOTION_GSC_REPORTS_DB_ID"]);
+  }
+  const cfg = await requireIntegrationAsync("NOTION_API_KEY", "NOTION_GSC_REPORTS_DB_ID");
+  return { apiKey: cfg.NOTION_API_KEY!, dbId: cfg.NOTION_GSC_REPORTS_DB_ID! };
+}
+
+function pageToReport(page: Record<string, unknown>): GscWeeklyReport | null {
+  try {
+    const p = (page as { properties: Record<string, unknown> }).properties ?? {};
+
+    function num(key: string): number {
+      const prop = p[key] as { number?: number | null } | undefined;
+      return prop?.number ?? 0;
+    }
+
+    function richText(key: string): string {
+      const prop = p[key] as { rich_text?: { plain_text?: string }[] } | undefined;
+      return prop?.rich_text?.map((r) => r.plain_text ?? "").join("") ?? "";
+    }
+
+    function title(key: string): string {
+      const prop = p[key] as { title?: { plain_text?: string }[] } | undefined;
+      return prop?.title?.map((r) => r.plain_text ?? "").join("") ?? "";
+    }
+
+    function dateField(key: string): string {
+      const prop = p[key] as { date?: { start?: string } } | undefined;
+      return prop?.date?.start ?? "";
+    }
+
+    let topKeywords: GscTopKeyword[] = [];
+    try {
+      const parsed = JSON.parse(richText("Top Keywords") || "[]");
+      if (Array.isArray(parsed)) topKeywords = parsed as GscTopKeyword[];
+    } catch {
+      /* malformed JSON → empty list */
+    }
+
+    return {
+      id: (page as { id: string }).id,
+      week: title("Week"),
+      date: dateField("Date"),
+      clicks: num("Clicks"),
+      impressions: num("Impressions"),
+      ctrPct: num("CTR %"),
+      avgPosition: num("Avg Position"),
+      keywords: num("Keywords"),
+      topKeywords,
+      topCountry: richText("Top Country"),
+      mobilePct: num("Mobile %"),
+      ctrOpportunities: num("CTR Opportunities"),
+    };
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Return the persisted weekly GSC snapshots, newest first.
+ * Throws IntegrationNotConfiguredError when Notion/the DB id is not configured;
+ * returns null on a Notion API error so callers can fall back gracefully.
+ */
+export async function getGscReports(limit = 26): Promise<GscWeeklyReport[] | null> {
+  const db = await getDb();
+
+  try {
+    const res = await notionFetch<{ results: unknown[] }>(`/databases/${db.dbId}/query`, {
+      method: "POST",
+      body: JSON.stringify({
+        sorts: [{ property: "Date", direction: "descending" }],
+        page_size: Math.max(1, Math.min(limit, 100)),
+      }),
+    });
+
+    return res.results
+      .map((p) => pageToReport(p as Record<string, unknown>))
+      .filter((r): r is GscWeeklyReport => r !== null);
+  } catch {
+    return null;
+  }
+}


### PR DESCRIPTION
## Why — closing a half-built loop

`scripts/weekly-gsc-sync.ts` writes one snapshot per week into the `NOTION_GSC_REPORTS_DB_ID` database (cron Mondays 07:00, `weekly-gsc-sync.yml`), but **nothing in the app ever read it** — the data has been accruing with no consumer. This was the cleanest "next integration" on the current Notion architecture: pure read-side, no external-account or Notion-UI dependency.

## What

- **`src/lib/notion-gsc-reports.ts`** — read side for the GSC archive, mirroring the `notion-reports.ts` pattern (`requireIntegrationAsync` gate, graceful `null` on Notion error, tolerant Top-Keywords JSON parse). Maps the exact schema the sync writes (Week, Date, Clicks, Impressions, CTR %, Avg Position, Keywords, Top Keywords, Top Country, Mobile %, CTR Opportunities).
- **`/api/admin/analytics/gsc-archive`** — admin route (`requireAdmin`) returning the archive newest-first. `503` when `NOTION_GSC_REPORTS_DB_ID` is unset, `502` on a Notion read error.
- **SEO Deep Dive page** — a "WEEKLY ARCHIVE" table fetched tolerantly, so it only renders when the DB is configured and **never blocks the live GSC view**.

## Why not duplicate `/api/admin/analytics/history`?
That route queries GSC **live** each request. The archive is **durable** (survives GSC quota/credential gaps) and carries the curated fields the sync computed (CTR-opportunity counts, top country, mobile share, top-keyword breakdown) — a different, complementary source.

## Tests
12 new unit tests (7 lib + 5 route), covering mapping, sort+clamp, missing-field defaults, malformed-JSON tolerance, not-configured (503), null/read-error (502), and auth (401). `lint` / `format:check` / `typecheck` green; full suite passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)