### PR TITLE
fix(security): broaden log-injection sanitization to all control chars

### DIFF
--- a/src/app/api/checkout/route.ts
+++ b/src/app/api/checkout/route.ts
@@ -146,12 +146,9 @@ export async function POST(request: NextRequest) {
 
     return Response.json({ url: session.url });
   } catch (error) {
-    const rawMsg = ((error as Error)?.message ?? "unknown error");
-    // Sanitize: strip control chars, cap length. Re-encode through encodeURIComponent
-    // + decodeURIComponent to fully break CodeQL taint flow (js/log-injection).
-    const msg = decodeURIComponent(
-      encodeURIComponent(rawMsg).replace(/%(0A|0D|09)/gi, "%20")
-    ).slice(0, 200);
+    const msg = String((error as Error)?.message ?? "unknown error")
+      .replace(/[\x00-\x1f\x7f]/g, " ")
+      .slice(0, 200);
     console.error("Checkout error:", msg);
 
     // Client errors: malformed body or unknown product → 400. Return a fixed,

--- a/src/lib/notion.ts
+++ b/src/lib/notion.ts
@@ -23,7 +23,7 @@ function safeId(id: string): string {
 
 function safeMsg(msg: string): string {
   return String(msg)
-    .replace(/[\r\n\t]/g, " ")
+    .replace(/[\x00-\x1f\x7f]/g, " ")
     .slice(0, 200);
 }
 


### PR DESCRIPTION
## What

Two log-sanitization sites stripped only a narrow whitespace set before `console.error`. Widen both to strip the full C0 control range + DEL (`\x00-\x1f`, `\x7f`) — covers CR/LF/tab plus other control characters that can forge/corrupt log lines (CodeQL `js/log-injection`).

- **`src/lib/notion.ts`** `safeMsg()`: `/[\r\n\t]/` → `/[\x00-\x1f\x7f]/`.
- **`src/app/api/checkout/route.ts`**: replace the `encodeURIComponent`/`decodeURIComponent` taint-breaking workaround with the same direct control-char strip — simpler and equally taint-safe.

## Provenance
These edits were already present in the working tree (authored in a separate session); committed here unchanged at the user's request.

## Verification
`lint` / `format:check` / `typecheck` green; `checkout-api` + `notion-client` suites pass (78 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)