### PR TITLE
fix(ci): exclude not-yet-live postiz.cloudless.gr from links audit

### DIFF
--- a/.github/workflows/links-audit.yml
+++ b/.github/workflows/links-audit.yml
@@ -45,6 +45,7 @@ jobs:
             --exclude "^https://abc123\."
             --exclude "^http://localhost"
             --exclude "^https://cloudless\.online"
+            --exclude "^https://postiz\.cloudless\.gr"
             --exclude "\.\.\."
             --exclude "^https?://[^@]+@.*\.ingest\.sentry\.io"
             --exclude "^https?://.*\.api-us1\.com"


### PR DESCRIPTION
The **Broken Links Audit** went red on `https://postiz.cloudless.gr/` (referenced in `docs/POSTIZ.md`, added by #809's Postiz publishing bridge). That self-hosted subdomain isn't deployed yet, so the live link check fails with a connection error.

Excludes it from lychee the same way other planned/external hosts already are (`cloudless.online`, ngrok, localhost), until the Postiz instance is live. One-line, convention-following.

🤖 Generated with [Claude Code](https://claude.com/claude-code)