### PR TITLE
fix(postiz): pin image to v2.11.2 (last Temporal-free release)

### DIFF
--- a/infrastructure/postiz/k8s/postiz.yaml
+++ b/infrastructure/postiz/k8s/postiz.yaml
@@ -199,8 +199,12 @@ spec:
       automountServiceAccountToken: false
       containers:
         - name: postiz
-          # arm64-compatible multi-arch image; pin a release tag after first deploy
-          image: ghcr.io/gitroomhq/postiz-app:latest
+          # Pinned to v2.11.2 — the last release before Postiz made the Temporal
+          # workflow server mandatory (v2.12.0+ needs temporal + its own DB +
+          # optional Elasticsearch, too heavy for the Pi cluster). Upgrading past
+          # this tag requires deploying Temporal alongside; see
+          # https://docs.postiz.com/installation/migration
+          image: ghcr.io/gitroomhq/postiz-app:v2.11.2
           ports:
             - containerPort: 5000
           env:


### PR DESCRIPTION
postiz-app:latest (v2.12+) requires a Temporal workflow server — the backend crash-looped with ECONNREFUSED :7233 on the cluster. v2.11.2 is the last Temporal-free release per Postiz's own migration guide; the full Temporal stack (server + dedicated postgres + optional Elasticsearch) doesn't fit the Pi's budget. Cluster was already patched live with kubectl set image; this syncs the manifest. Upgrade path documented inline.