### PR TITLE
Postiz: provider OAuth env wiring (postiz-providers secret)

### DIFF
--- a/docs/POSTIZ.md
+++ b/docs/POSTIZ.md
@@ -54,6 +54,14 @@ calendar item status → scheduled / published
      cover the per-provider setup; the repo skills
      `.claude/skills/meta-business-help` and `instagram-graph-api` cover the
      Meta side.
+   - Provider OAuth credentials live in the k8s secret `postiz-providers`
+     (loaded via `envFrom` in `postiz.yaml`, created 2026-06-12 from the SSM
+     values): `FACEBOOK_APP_ID/SECRET`, `LINKEDIN_CLIENT_ID/SECRET`,
+     `X_API_KEY/SECRET`, `TIKTOK_CLIENT_ID/SECRET`. Each provider app console
+     must whitelist the redirect URI
+     `https://postiz.cloudless.gr/integrations/social/{provider}`
+     (provider = `facebook`, `instagram`, `linkedin`, `x`, `tiktok`) or the
+     channel OAuth flow fails with `redirect_uri_mismatch`.
    - Create an API key: Settings → Public API.
 
 5. **Wire the app** — set SSM params (then the 5-min config cache picks them up):

--- a/infrastructure/postiz/k8s/postiz.yaml
+++ b/infrastructure/postiz/k8s/postiz.yaml
@@ -207,6 +207,17 @@ spec:
           image: ghcr.io/gitroomhq/postiz-app:v2.11.2
           ports:
             - containerPort: 5000
+          # Social-provider OAuth app credentials (FACEBOOK_APP_ID/SECRET,
+          # LINKEDIN_CLIENT_ID/SECRET, X_API_KEY/SECRET, TIKTOK_CLIENT_ID/SECRET).
+          # Created out-of-band from SSM /cloudless/production values:
+          #   kubectl -n postiz create secret generic postiz-providers \
+          #     --from-literal=FACEBOOK_APP_ID=... (etc.)
+          # Marked optional so the manifest still applies on a fresh cluster
+          # before the secret exists — channel buttons just stay disabled.
+          envFrom:
+            - secretRef:
+                name: postiz-providers
+                optional: true
           env:
             - name: MAIN_URL
               value: "https://postiz.cloudless.gr"


### PR DESCRIPTION
Syncs the live kubectl change (secret postiz-providers + env injection, 2026-06-12) into infrastructure/postiz/k8s/postiz.yaml via optional envFrom, and documents the redirect-URI whitelist requirement in docs/POSTIZ.md.