### PR TITLE
fix(postiz): image array required by live Postiz post validator

### DIFF
--- a/src/lib/postiz.ts
+++ b/src/lib/postiz.ts
@@ -133,7 +133,10 @@ export async function schedulePost(input: SchedulePostInput): Promise<SchedulePo
         tags: [],
         posts: input.integrationIds.map((id) => ({
           integration: { id },
-          value: [{ content: input.content }],
+          // `image` must always be present as an array — the live Postiz
+          // v2.11.2 validator rejects value items without it
+          // ("posts.0.value.0.image must be an array", verified 2026-06-12).
+          value: [{ content: input.content, image: [] }],
         })),
       }),
     });


### PR DESCRIPTION
Live Postiz v2.11.2 rejects POST /api/public/v1/posts when value items lack image ('posts.0.value.0.image must be an array' - verified against production instance 2026-06-12). Adds image: [] so calendar publish works.