### PR TITLE
test(vitest): add unit coverage for 4 more lib modules

### DIFF
--- a/__tests__/amplify-config.test.ts
+++ b/__tests__/amplify-config.test.ts
@@ -1,0 +1,70 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+
+const ENV_KEY = "NEXT_PUBLIC_AUTH_PROVIDER";
+
+describe("amplify-config", () => {
+  const originalEnv = process.env[ENV_KEY];
+
+  beforeEach(() => {
+    delete process.env[ENV_KEY];
+    // Force a fresh module import each test so the module-scoped
+    // `configured` flag does not bleed across cases.
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    if (originalEnv === undefined) {
+      delete process.env[ENV_KEY];
+    } else {
+      process.env[ENV_KEY] = originalEnv;
+    }
+  });
+
+  it("configureAmplifyWith returns false when no provider env is set", async () => {
+    const mod = await import("@/lib/amplify-config");
+    expect(
+      mod.configureAmplifyWith({
+        userPoolId: "us-east-1_xxxxx",
+        userPoolClientId: "abc",
+      }),
+    ).toBe(false);
+    expect(mod.isAmplifyConfigured()).toBe(false);
+  });
+
+  it("configureAmplifyWith returns true once provider env is set", async () => {
+    process.env[ENV_KEY] = "cognito";
+    const mod = await import("@/lib/amplify-config");
+    expect(
+      mod.configureAmplifyWith({
+        userPoolId: "us-east-1_xxxxx",
+        userPoolClientId: "abc",
+      }),
+    ).toBe(true);
+    expect(mod.isAmplifyConfigured()).toBe(true);
+  });
+
+  it("subsequent calls short-circuit (cached configured flag)", async () => {
+    process.env[ENV_KEY] = "cognito";
+    const mod = await import("@/lib/amplify-config");
+    expect(
+      mod.configureAmplifyWith({
+        userPoolId: "us-east-1_a",
+        userPoolClientId: "client-a",
+      }),
+    ).toBe(true);
+
+    // Removing the env var after first configure should NOT flip the
+    // cached flag — that's the documented short-circuit behaviour.
+    delete process.env[ENV_KEY];
+    expect(
+      mod.configureAmplifyWith({
+        userPoolId: "us-east-1_b",
+        userPoolClientId: "client-b",
+      }),
+    ).toBe(true);
+    expect(mod.isAmplifyConfigured()).toBe(true);
+  });
+});

--- a/__tests__/client-portals.test.ts
+++ b/__tests__/client-portals.test.ts
@@ -1,0 +1,240 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+const { mockSSMSend, putCalls } = vi.hoisted(() => ({
+  mockSSMSend: vi.fn(),
+  putCalls: [] as unknown[],
+}));
+
+vi.mock("@aws-sdk/client-ssm", () => ({
+  SSMClient: vi.fn().mockImplementation(function () { return { send: mockSSMSend }; }),
+  GetParameterCommand: vi.fn().mockImplementation(function (input: unknown) { return { __cmd: "Get", input }; }),
+  PutParameterCommand: vi.fn().mockImplementation(function (input: unknown) { putCalls.push(input); return { __cmd: "Put", input }; }),
+}));
+
+import {
+  readPortals,
+  writePortals,
+  tokenMatches,
+  findPortalByToken,
+  newDeliverable,
+  newPaymentLink,
+  applyClientResponse,
+  clientVisibleDeliverables,
+  type ClientPortal,
+} from "@/lib/client-portals";
+
+const SAMPLE_PORTAL: ClientPortal = {
+  token: "tok-1",
+  label: "Acme",
+  clientEmail: "x@acme.example",
+  clientName: "Acme",
+  createdAt: "2026-01-01T00:00:00Z",
+  steps: [],
+};
+
+describe("client-portals", () => {
+  beforeEach(() => {
+    mockSSMSend.mockReset();
+    putCalls.length = 0;
+  });
+
+  describe("readPortals", () => {
+    it("returns parsed array on success", async () => {
+      mockSSMSend.mockResolvedValueOnce({
+        Parameter: { Value: JSON.stringify([SAMPLE_PORTAL]) },
+      });
+      const r = await readPortals();
+      expect(r).toEqual([SAMPLE_PORTAL]);
+    });
+
+    it("returns empty array on SSM error", async () => {
+      mockSSMSend.mockRejectedValueOnce(new Error("ParameterNotFound"));
+      await expect(readPortals()).resolves.toEqual([]);
+    });
+
+    it("returns empty array when parameter has no Value", async () => {
+      mockSSMSend.mockResolvedValueOnce({ Parameter: {} });
+      await expect(readPortals()).resolves.toEqual([]);
+    });
+  });
+
+  describe("writePortals", () => {
+    it("calls PutParameter with JSON payload and Overwrite=true", async () => {
+      mockSSMSend.mockResolvedValueOnce({});
+      await writePortals([SAMPLE_PORTAL]);
+      expect(putCalls).toHaveLength(1);
+      const input = putCalls[0] as { Value: string; Overwrite: boolean; Type: string };
+      expect(input.Overwrite).toBe(true);
+      expect(input.Type).toBe("String");
+      expect(JSON.parse(input.Value)).toHaveLength(1);
+    });
+  });
+
+  describe("tokenMatches", () => {
+    it("rejects different-length tokens", () => {
+      expect(tokenMatches("abc", "abcd")).toBe(false);
+      expect(tokenMatches("longer-token-12345", "short")).toBe(false);
+    });
+
+    it("accepts identical tokens", () => {
+      expect(tokenMatches("xyz-token", "xyz-token")).toBe(true);
+    });
+
+    it("rejects same-length but different tokens", () => {
+      expect(tokenMatches("abcdef", "abcdeg")).toBe(false);
+    });
+  });
+
+  describe("findPortalByToken", () => {
+    it("returns the matching portal", async () => {
+      const portals: ClientPortal[] = [
+        { ...SAMPLE_PORTAL, token: "AAA", label: "A" },
+        { ...SAMPLE_PORTAL, token: "BBB", label: "B" },
+      ];
+      mockSSMSend.mockResolvedValueOnce({
+        Parameter: { Value: JSON.stringify(portals) },
+      });
+      const found = await findPortalByToken("BBB");
+      expect(found?.label).toBe("B");
+    });
+
+    it("returns null when no portal matches", async () => {
+      mockSSMSend.mockResolvedValueOnce({ Parameter: { Value: "[]" } });
+      expect(await findPortalByToken("nope")).toBeNull();
+    });
+  });
+
+  describe("newDeliverable", () => {
+    it("creates a draft with id, timestamps, and truncated fields", () => {
+      const d = newDeliverable({
+        title: "x".repeat(200),
+        url: "https://example.com/" + "p".repeat(1000),
+        description: "y".repeat(2000),
+      });
+      expect(d.id).toBeTruthy();
+      expect(d.status).toBe("draft");
+      expect(d.createdAt).toBe(d.updatedAt);
+      expect(d.title.length).toBe(120);
+      expect(d.url?.length).toBe(500);
+      expect(d.description?.length).toBe(1000);
+    });
+
+    it("leaves optional fields undefined when not provided", () => {
+      const d = newDeliverable({ title: "T" });
+      expect(d.url).toBeUndefined();
+      expect(d.description).toBeUndefined();
+    });
+  });
+
+  describe("newPaymentLink", () => {
+    it("defaults currency to EUR and rounds amountCents", () => {
+      const link = newPaymentLink({
+        label: "Deposit",
+        url: "https://stripe/x",
+        amountCents: 12345.6,
+      });
+      expect(link.currency).toBe("EUR");
+      expect(link.amountCents).toBe(12346);
+      expect(link.status).toBe("open");
+    });
+
+    it("uppercases and clamps a non-default currency", () => {
+      const link = newPaymentLink({
+        label: "Deposit",
+        url: "https://stripe/x",
+        currency: "usd",
+      });
+      expect(link.currency).toBe("USD");
+    });
+
+    it("drops negative amountCents", () => {
+      const link = newPaymentLink({
+        label: "Deposit",
+        url: "https://stripe/x",
+        amountCents: -100,
+      });
+      expect(link.amountCents).toBeUndefined();
+    });
+  });
+
+  describe("applyClientResponse", () => {
+    function portalWith(status: "draft" | "in_review" | "approved"): ClientPortal {
+      return {
+        ...SAMPLE_PORTAL,
+        deliverables: [
+          {
+            id: "d-1",
+            title: "T",
+            status,
+            createdAt: "2026-01-01T00:00:00Z",
+            updatedAt: "2026-01-01T00:00:00Z",
+          },
+        ],
+      };
+    }
+
+    it("returns error string when deliverable not found", () => {
+      const r = applyClientResponse(portalWith("in_review"), "missing", "approve");
+      expect(typeof r).toBe("string");
+      expect(r as string).toMatch(/not found/i);
+    });
+
+    it("rejects responses on draft deliverables", () => {
+      const r = applyClientResponse(portalWith("draft"), "d-1", "approve");
+      expect(r as string).toMatch(/not awaiting review/i);
+    });
+
+    it("rejects responses on approved deliverables", () => {
+      const r = applyClientResponse(portalWith("approved"), "d-1", "request_changes");
+      expect(r as string).toMatch(/not awaiting review/i);
+    });
+
+    it("transitions in_review to approved on approve", () => {
+      const r = applyClientResponse(portalWith("in_review"), "d-1", "approve", "lgtm");
+      if (typeof r === "string") throw new Error(r);
+      expect(r.status).toBe("approved");
+      expect(r.clientComment).toBe("lgtm");
+      expect(r.respondedAt).toBeTruthy();
+    });
+
+    it("transitions in_review to changes_requested on request_changes", () => {
+      const r = applyClientResponse(
+        portalWith("in_review"),
+        "d-1",
+        "request_changes",
+        "needs work",
+      );
+      if (typeof r === "string") throw new Error(r);
+      expect(r.status).toBe("changes_requested");
+    });
+
+    it("truncates client comment to 2000 chars", () => {
+      const r = applyClientResponse(
+        portalWith("in_review"),
+        "d-1",
+        "approve",
+        "x".repeat(3000),
+      );
+      if (typeof r === "string") throw new Error(r);
+      expect(r.clientComment?.length).toBe(2000);
+    });
+  });
+
+  describe("clientVisibleDeliverables", () => {
+    it("filters out drafts", () => {
+      const visible = clientVisibleDeliverables({
+        ...SAMPLE_PORTAL,
+        deliverables: [
+          { id: "1", title: "d", status: "draft", createdAt: "x", updatedAt: "x" },
+          { id: "2", title: "r", status: "in_review", createdAt: "x", updatedAt: "x" },
+          { id: "3", title: "a", status: "approved", createdAt: "x", updatedAt: "x" },
+        ],
+      });
+      expect(visible.map(d => d.id)).toEqual(["2", "3"]);
+    });
+
+    it("returns empty array when deliverables is undefined", () => {
+      expect(clientVisibleDeliverables(SAMPLE_PORTAL)).toEqual([]);
+    });
+  });
+});

--- a/__tests__/notion-esp32.test.ts
+++ b/__tests__/notion-esp32.test.ts
@@ -1,0 +1,133 @@
+import { describe, it, expect, beforeEach, vi, afterEach } from "vitest";
+
+const notionFetchMock = vi.fn();
+const getIntegrationsAsyncMock = vi.fn();
+
+vi.mock("@/lib/notion", () => ({
+  notionFetch: (...args: unknown[]) => notionFetchMock(...args),
+}));
+
+vi.mock("@/lib/integrations", () => ({
+  getIntegrationsAsync: () => getIntegrationsAsyncMock(),
+}));
+
+describe("notion-esp32", () => {
+  const originalDevices = process.env.NOTION_ESP32_DEVICES_DB_ID;
+  const originalTelemetry = process.env.NOTION_ESP32_TELEMETRY_DB_ID;
+
+  beforeEach(() => {
+    notionFetchMock.mockReset();
+    getIntegrationsAsyncMock.mockReset();
+    delete process.env.NOTION_ESP32_DEVICES_DB_ID;
+    delete process.env.NOTION_ESP32_TELEMETRY_DB_ID;
+  });
+
+  afterEach(() => {
+    if (originalDevices === undefined) delete process.env.NOTION_ESP32_DEVICES_DB_ID;
+    else process.env.NOTION_ESP32_DEVICES_DB_ID = originalDevices;
+    if (originalTelemetry === undefined) delete process.env.NOTION_ESP32_TELEMETRY_DB_ID;
+    else process.env.NOTION_ESP32_TELEMETRY_DB_ID = originalTelemetry;
+  });
+
+  describe("getEsp32NotionConfig", () => {
+    it("reads from env vars first when present", async () => {
+      process.env.NOTION_ESP32_DEVICES_DB_ID = "env-devices";
+      process.env.NOTION_ESP32_TELEMETRY_DB_ID = "env-telemetry";
+      const { getEsp32NotionConfig } = await import("@/lib/notion-esp32");
+      const cfg = await getEsp32NotionConfig();
+      expect(cfg.devicesDbId).toBe("env-devices");
+      expect(cfg.telemetryDbId).toBe("env-telemetry");
+      // Did not touch the integrations module.
+      expect(getIntegrationsAsyncMock).not.toHaveBeenCalled();
+    });
+
+    it("falls through to integrations when env vars are not set", async () => {
+      getIntegrationsAsyncMock.mockResolvedValueOnce({
+        NOTION_ESP32_DEVICES_DB_ID: "integ-devices",
+        NOTION_ESP32_TELEMETRY_DB_ID: "integ-telemetry",
+      });
+      const { getEsp32NotionConfig } = await import("@/lib/notion-esp32");
+      const cfg = await getEsp32NotionConfig();
+      expect(cfg.devicesDbId).toBe("integ-devices");
+      expect(cfg.telemetryDbId).toBe("integ-telemetry");
+    });
+
+    it("returns {} when integrations throws and env is unset", async () => {
+      getIntegrationsAsyncMock.mockRejectedValueOnce(new Error("ssm down"));
+      const { getEsp32NotionConfig } = await import("@/lib/notion-esp32");
+      const cfg = await getEsp32NotionConfig();
+      expect(cfg).toEqual({});
+    });
+
+    it("returns env values even when only one of two is set", async () => {
+      process.env.NOTION_ESP32_DEVICES_DB_ID = "env-devices-only";
+      const { getEsp32NotionConfig } = await import("@/lib/notion-esp32");
+      const cfg = await getEsp32NotionConfig();
+      expect(cfg.devicesDbId).toBe("env-devices-only");
+      expect(cfg.telemetryDbId).toBeUndefined();
+      // Integrations was NOT consulted because env had at least one value.
+      expect(getIntegrationsAsyncMock).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("isEsp32NotionConfigured", () => {
+    it("is true only when devicesDbId is present", async () => {
+      const { isEsp32NotionConfigured } = await import("@/lib/notion-esp32");
+      expect(isEsp32NotionConfigured({})).toBe(false);
+      expect(isEsp32NotionConfigured({ telemetryDbId: "t" })).toBe(false);
+      expect(isEsp32NotionConfigured({ devicesDbId: "d" })).toBe(true);
+      expect(isEsp32NotionConfigured({ devicesDbId: "d", telemetryDbId: "t" })).toBe(true);
+    });
+
+    it("treats an empty string devicesDbId as unconfigured", async () => {
+      const { isEsp32NotionConfigured } = await import("@/lib/notion-esp32");
+      expect(isEsp32NotionConfigured({ devicesDbId: "" })).toBe(false);
+    });
+  });
+
+  describe("upsertEsp32DeviceInNotion (no-op when unconfigured)", () => {
+    it("returns null and does not call Notion when devicesDbId is missing", async () => {
+      const { upsertEsp32DeviceInNotion } = await import("@/lib/notion-esp32");
+      const result = await upsertEsp32DeviceInNotion({
+        ip: "10.0.0.1",
+        rssi: -55,
+        firmware_ver: "1.0",
+        uptime_s: 100,
+        free_ram_bytes: 100_000,
+        last_heartbeat: "2026-06-12T00:00:00Z",
+        device_id: "dev-1",
+        stale: false,
+      });
+      expect(result).toBeNull();
+      expect(notionFetchMock).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("appendEsp32TelemetryToNotion (no-op when unconfigured)", () => {
+    it("returns null when telemetryDbId is missing", async () => {
+      const { appendEsp32TelemetryToNotion } = await import(
+        "@/lib/notion-esp32"
+      );
+      const result = await appendEsp32TelemetryToNotion({
+        code: "ESP32_LOW_RAM",
+        host: "esp32-1",
+        severity: "high",
+        message: "RAM low",
+        status: "ACTIVE",
+        first_seen: "2026-06-12T00:00:00Z",
+        last_seen: "2026-06-12T00:00:00Z",
+      });
+      expect(result).toBeNull();
+      expect(notionFetchMock).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("readEsp32DevicesFromNotion (no-op when unconfigured)", () => {
+    it("returns [] when devicesDbId is missing", async () => {
+      const { readEsp32DevicesFromNotion } = await import("@/lib/notion-esp32");
+      const out = await readEsp32DevicesFromNotion();
+      expect(out).toEqual([]);
+      expect(notionFetchMock).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/__tests__/services-data.test.ts
+++ b/__tests__/services-data.test.ts
@@ -1,0 +1,128 @@
+import { describe, it, expect } from "vitest";
+import {
+  getServices,
+  getServicesFaqs,
+  bundleTerminal,
+  colorMap,
+} from "@/lib/services-data";
+
+// Pass-through translator — services-data takes a (key, fallback) function
+// so it can be locale-aware without importing next-intl.
+const tPass = (_key: string, fallback: string) => fallback;
+
+describe("services-data", () => {
+  describe("getServices", () => {
+    it("returns 6 services in stable order", () => {
+      const services = getServices(tPass);
+      expect(services).toHaveLength(6);
+      expect(services.map(s => s.num)).toEqual([
+        "01",
+        "02",
+        "03",
+        "04",
+        "05",
+        "06",
+      ]);
+    });
+
+    it("every service exposes the contract the page renders against", () => {
+      const services = getServices(tPass);
+      for (const s of services) {
+        expect(s).toMatchObject({
+          tag: expect.any(String),
+          num: expect.any(String),
+          title: expect.any(String),
+          price: expect.any(String),
+          unit: expect.any(String),
+          color: expect.any(String),
+          planKey: expect.any(String),
+          outcome: expect.any(String),
+          perfectFor: expect.any(String),
+          description: expect.any(String),
+        });
+        expect(Array.isArray(s.features)).toBe(true);
+        expect(s.features.length).toBeGreaterThan(0);
+        expect(Array.isArray(s.stats)).toBe(true);
+        expect(s.stats.length).toBeGreaterThan(0);
+        expect(Array.isArray(s.terminal)).toBe(true);
+        expect(s.terminal.length).toBeGreaterThan(0);
+      }
+    });
+
+    it("every service.color has a matching entry in colorMap", () => {
+      const services = getServices(tPass);
+      for (const s of services) {
+        expect(colorMap[s.color]).toBeDefined();
+        expect(typeof colorMap[s.color].badge).toBe("string");
+      }
+    });
+
+    it("planKeys are unique across services", () => {
+      const services = getServices(tPass);
+      const keys = services.map(s => s.planKey);
+      expect(new Set(keys).size).toBe(keys.length);
+    });
+
+    it("stats entries have value + label", () => {
+      const services = getServices(tPass);
+      for (const s of services) {
+        for (const stat of s.stats) {
+          expect(stat.value).toBeTruthy();
+          expect(stat.label).toBeTruthy();
+        }
+      }
+    });
+
+    it("passes the translator through — non-trivial t() output flows into title", () => {
+      const tag = (key: string) => `[T:${key}]`;
+      const services = getServices((key, _fallback) => tag(key));
+      // service1Title should now be tagged with its translation key.
+      expect(services[0].title).toBe("[T:servicesSection.service1Title]");
+    });
+  });
+
+  describe("getServicesFaqs", () => {
+    it("returns a non-empty list with question + answer shape", () => {
+      const faqs = getServicesFaqs(tPass);
+      expect(faqs.length).toBeGreaterThan(0);
+      for (const f of faqs) {
+        expect(f.question).toBeTruthy();
+        expect(f.answer).toBeTruthy();
+      }
+    });
+  });
+
+  describe("bundleTerminal", () => {
+    it("is a non-empty string array (the homepage's terminal animation source)", () => {
+      expect(Array.isArray(bundleTerminal)).toBe(true);
+      expect(bundleTerminal.length).toBeGreaterThan(0);
+      for (const line of bundleTerminal) {
+        expect(typeof line).toBe("string");
+      }
+    });
+  });
+
+  describe("colorMap", () => {
+    it("each color theme defines every Tailwind slot the renderer uses", () => {
+      const requiredSlots = [
+        "badge",
+        "dot",
+        "tag",
+        "stat",
+        "statValue",
+        "check",
+        "num",
+        "price",
+        "link",
+      ] as const;
+      for (const theme of Object.values(colorMap)) {
+        for (const slot of requiredSlots) {
+          expect(theme).toHaveProperty(slot);
+          expect(typeof (theme as Record<string, string>)[slot]).toBe(
+            "string",
+          );
+        }
+      }
+    });
+  });
+});


### PR DESCRIPTION
Batch 2 of the Vitest coverage climb (batch 1 was #832). Adds focused unit tests for four more `src/lib/` modules with zero existing coverage.

## What landed (43 new tests)

### amplify-config.ts (3 tests)
- `configureAmplifyWith` without provider env returns false
- `configureAmplifyWith` with provider env returns true
- Subsequent calls short-circuit the cached flag

### client-portals.ts (22 tests)
- `readPortals`: success, SSM error, empty Value
- `writePortals`: PutParameter shape (Value/Overwrite/Type)
- `tokenMatches`: length/identity/diff cases
- `findPortalByToken`: hit + miss
- `newDeliverable`: id, timestamps, title/url/description truncation
- `newPaymentLink`: EUR default, currency uppercasing, negative drop
- `applyClientResponse`: all 6 state-transition + guard branches
- `clientVisibleDeliverables`: draft filter + undefined fallback

### services-data.ts (9 tests)
- `getServices`: 6 items, contract shape, colorMap covers every color, planKey uniqueness, `t()` pass-through
- `getServicesFaqs`: shape
- `bundleTerminal`: string array
- `colorMap`: every theme has every required slot

### notion-esp32.ts (9 tests)
- `getEsp32NotionConfig`: env vars, fallback to integrations, integrations throw, partial env
- `isEsp32NotionConfigured`: missing/empty/present
- `upsert/append/read` no-op early returns when unconfigured

## Verification

All 43 tests verified locally with `vitest run` against each spec file.

## Cumulative climb (4 modules × 2 PRs = 8 modules)

| PR | Modules | Tests |
|---|---|---|
| #832 | booking-slots, sha-drift, slack-rate-limit, slack-verify | 40 |
| this | amplify-config, client-portals, services-data, notion-esp32 | 43 |
| **Total** | **8 lib modules from 0% → covered** | **83** |