### PR TITLE
test(vitest): add unit coverage for 4 more lib modules (batch 3)

### DIFF
--- a/__tests__/agent-book.test.ts
+++ b/__tests__/agent-book.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const { isConfiguredAsyncMock } = vi.hoisted(() => ({
+  isConfiguredAsyncMock: vi.fn(),
+}));
+
+vi.mock("@/lib/integrations", () => ({
+  isConfiguredAsync: (...keys: string[]) => isConfiguredAsyncMock(...keys),
+}));
+
+vi.mock("@/lib/google-calendar", () => ({
+  getAvailableSlots: vi.fn(),
+}));
+
+vi.mock("@/lib/bedrock-shared", () => ({
+  BEDROCK_MODEL_ID: "model",
+  buildBedrockToolConfig: vi.fn(),
+  getBedrockClient: vi.fn(),
+}));
+
+vi.mock("@aws-sdk/client-bedrock-runtime", () => ({
+  ConverseCommand: vi.fn(),
+}));
+
+import { isAgentBookConfigured } from "@/lib/agent-book";
+
+describe("agent-book.isAgentBookConfigured", () => {
+  beforeEach(() => {
+    isConfiguredAsyncMock.mockReset();
+  });
+
+  it("returns true when the required Google Calendar keys are configured", async () => {
+    isConfiguredAsyncMock.mockResolvedValueOnce(true);
+    await expect(isAgentBookConfigured()).resolves.toBe(true);
+    expect(isConfiguredAsyncMock).toHaveBeenCalledWith(
+      "GOOGLE_CLIENT_EMAIL",
+      "GOOGLE_PRIVATE_KEY",
+    );
+  });
+
+  it("returns false when integration keys are missing", async () => {
+    isConfiguredAsyncMock.mockResolvedValueOnce(false);
+    await expect(isAgentBookConfigured()).resolves.toBe(false);
+  });
+});

--- a/__tests__/bedrock-shared.test.ts
+++ b/__tests__/bedrock-shared.test.ts
@@ -1,0 +1,176 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+const { mockSend } = vi.hoisted(() => ({ mockSend: vi.fn() }));
+
+vi.mock("@aws-sdk/client-bedrock-runtime", () => ({
+  BedrockRuntimeClient: vi.fn().mockImplementation(function () {
+    return { send: mockSend };
+  }),
+  ConverseCommand: vi.fn().mockImplementation(function (input: unknown) {
+    return { __cmd: "Converse", input };
+  }),
+}));
+
+import {
+  BEDROCK_REGION,
+  BEDROCK_MODEL_ID,
+  buildBedrockToolConfig,
+  pickToolUseBlocks,
+  joinAssistantText,
+  runBedrockTurn,
+  getBedrockClient,
+  type AnyBlock,
+} from "@/lib/bedrock-shared";
+
+describe("bedrock-shared", () => {
+  beforeEach(() => {
+    mockSend.mockReset();
+  });
+
+  describe("env-driven constants", () => {
+    it("BEDROCK_REGION resolves to a non-empty string", () => {
+      expect(typeof BEDROCK_REGION).toBe("string");
+      expect(BEDROCK_REGION.length).toBeGreaterThan(0);
+    });
+
+    it("BEDROCK_MODEL_ID resolves to a non-empty string", () => {
+      expect(typeof BEDROCK_MODEL_ID).toBe("string");
+      expect(BEDROCK_MODEL_ID.length).toBeGreaterThan(0);
+    });
+  });
+
+  describe("getBedrockClient", () => {
+    it("returns the same singleton on subsequent calls", () => {
+      const a = getBedrockClient();
+      const b = getBedrockClient();
+      expect(a).toBe(b);
+    });
+  });
+
+  describe("buildBedrockToolConfig", () => {
+    it("maps Anthropic-shaped tools to a Bedrock ToolConfiguration", () => {
+      const cfg = buildBedrockToolConfig([
+        {
+          name: "book_slot",
+          description: "Book a 30-min consult slot",
+          input_schema: { type: "object", properties: { start: { type: "string" } } },
+        },
+        {
+          name: "search",
+          description: "Search docs",
+          input_schema: { type: "object" },
+        },
+      ]);
+      expect(cfg.tools).toHaveLength(2);
+      const first = cfg.tools?.[0] as { toolSpec: { name: string; description: string } };
+      expect(first.toolSpec.name).toBe("book_slot");
+      expect(first.toolSpec.description).toBe("Book a 30-min consult slot");
+    });
+
+    it("preserves arbitrary input_schema shape under inputSchema.json", () => {
+      const schema = { type: "object", required: ["x"], properties: { x: { type: "number" } } };
+      const cfg = buildBedrockToolConfig([
+        { name: "t", description: "d", input_schema: schema },
+      ]);
+      const first = cfg.tools?.[0] as { toolSpec: { inputSchema: { json: unknown } } };
+      expect(first.toolSpec.inputSchema.json).toBe(schema);
+    });
+
+    it("returns an empty tools list when given no tools", () => {
+      const cfg = buildBedrockToolConfig([]);
+      expect(cfg.tools).toEqual([]);
+    });
+  });
+
+  describe("pickToolUseBlocks", () => {
+    it("returns only blocks with a valid toolUse shape", () => {
+      const blocks: AnyBlock[] = [
+        { text: "hi" } as AnyBlock,
+        { toolUse: { toolUseId: "id-1", name: "x", input: {} } } as AnyBlock,
+        { toolUse: { toolUseId: "id-2", name: "y", input: { a: 1 } } } as AnyBlock,
+        { text: "trailing" } as AnyBlock,
+      ];
+      const out = pickToolUseBlocks(blocks);
+      expect(out).toHaveLength(2);
+      expect(out[0].toolUse.toolUseId).toBe("id-1");
+    });
+
+    it("returns [] when there are no tool-use blocks", () => {
+      expect(pickToolUseBlocks([{ text: "hi" } as AnyBlock])).toEqual([]);
+    });
+
+    it("ignores tool-use blocks without a string toolUseId", () => {
+      const blocks = [
+        // @ts-expect-error — intentionally malformed
+        { toolUse: { name: "n", input: {} } } as AnyBlock,
+      ];
+      expect(pickToolUseBlocks(blocks)).toEqual([]);
+    });
+  });
+
+  describe("joinAssistantText", () => {
+    it("joins and trims text fragments", () => {
+      const blocks: AnyBlock[] = [
+        { text: "  hello" } as AnyBlock,
+        { toolUse: { toolUseId: "id", name: "n", input: {} } } as AnyBlock,
+        { text: "world  " } as AnyBlock,
+      ];
+      expect(joinAssistantText(blocks)).toBe("hello world");
+    });
+
+    it("returns empty string when no text blocks present", () => {
+      expect(
+        joinAssistantText([
+          { toolUse: { toolUseId: "id", name: "n", input: {} } } as AnyBlock,
+        ]),
+      ).toBe("");
+    });
+  });
+
+  describe("runBedrockTurn", () => {
+    it("returns the content array from Converse output", async () => {
+      const blocks: AnyBlock[] = [
+        { text: "ok" } as AnyBlock,
+      ];
+      mockSend.mockResolvedValueOnce({
+        output: { message: { content: blocks } },
+      });
+
+      const out = await runBedrockTurn({
+        client: getBedrockClient(),
+        system: "be helpful",
+        messages: [{ role: "user", content: [{ text: "hi" }] }],
+        toolConfig: { tools: [] },
+        maxTokens: 100,
+      });
+
+      expect(out).toEqual(blocks);
+      expect(mockSend).toHaveBeenCalledTimes(1);
+    });
+
+    it("defaults maxTokens when not provided", async () => {
+      mockSend.mockResolvedValueOnce({});
+      await runBedrockTurn({
+        client: getBedrockClient(),
+        system: "s",
+        messages: [{ role: "user", content: [{ text: "hi" }] }],
+        toolConfig: { tools: [] },
+      });
+      const cmd = mockSend.mock.calls[0][0] as {
+        input?: { inferenceConfig?: { maxTokens?: number } };
+      };
+      expect(cmd.input?.inferenceConfig?.maxTokens).toBe(400);
+    });
+
+    it("returns [] when output.message.content is missing", async () => {
+      mockSend.mockResolvedValueOnce({ output: { message: {} } });
+      const out = await runBedrockTurn({
+        client: getBedrockClient(),
+        system: "s",
+        messages: [],
+        toolConfig: { tools: [] },
+      });
+      expect(out).toEqual([]);
+    });
+  });
+});

--- a/__tests__/slack-admin.test.ts
+++ b/__tests__/slack-admin.test.ts
@@ -1,0 +1,155 @@
+import { describe, it, expect, beforeEach, vi, afterEach } from "vitest";
+
+vi.mock("@/lib/integrations", () => ({
+  getSlackConfigAsync: vi.fn().mockResolvedValue({
+    SLACK_BOT_TOKEN: "xoxb-test",
+  }),
+}));
+
+import {
+  SLACK_CHANNELS,
+  listChannels,
+  createChannel,
+  setChannelTopic,
+  joinChannel,
+  archiveChannel,
+  type SlackChannelKey,
+} from "@/lib/slack-admin";
+
+describe("slack-admin", () => {
+  const fetchMock = vi.fn();
+  const originalFetch = globalThis.fetch;
+
+  beforeEach(() => {
+    fetchMock.mockReset();
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  describe("SLACK_CHANNELS registry", () => {
+    it("defines the canonical 6 channels", () => {
+      const keys = Object.keys(SLACK_CHANNELS) as SlackChannelKey[];
+      expect(keys).toEqual([
+        "bookings",
+        "orders",
+        "errors",
+        "deployments",
+        "contacts",
+        "subscribers",
+      ]);
+    });
+
+    it("every channel has name + topic", () => {
+      for (const def of Object.values(SLACK_CHANNELS)) {
+        expect(def.name).toBeTruthy();
+        expect(def.topic).toBeTruthy();
+        expect(def.topic.length).toBeGreaterThan(0);
+      }
+    });
+
+    it("channel names are unique", () => {
+      const names = Object.values(SLACK_CHANNELS).map(c => c.name);
+      expect(new Set(names).size).toBe(names.length);
+    });
+  });
+
+  describe("listChannels", () => {
+    it("returns channels from a paginated Slack response", async () => {
+      fetchMock.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          ok: true,
+          channels: [
+            { id: "C1", name: "bookings", is_private: false, is_member: true, is_archived: false },
+            { id: "C2", name: "orders", is_private: false, is_member: false, is_archived: false },
+          ],
+        }),
+      });
+      const out = await listChannels("xoxb-x");
+      expect(out).toHaveLength(2);
+      expect(out[0].id).toBe("C1");
+    });
+
+    it("throws on non-2xx HTTP", async () => {
+      fetchMock.mockResolvedValueOnce({ ok: false, status: 500, json: async () => ({}) });
+      await expect(listChannels("xoxb-x")).rejects.toThrow(/HTTP 500/);
+    });
+
+    it("throws on Slack-level ok:false", async () => {
+      fetchMock.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ ok: false, error: "invalid_auth" }),
+      });
+      await expect(listChannels("xoxb-x")).rejects.toThrow(/invalid_auth/);
+    });
+  });
+
+  describe("createChannel", () => {
+    it("posts to conversations.create with the name", async () => {
+      fetchMock.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          ok: true,
+          channel: { id: "C1", name: "test", is_private: false, is_member: true, is_archived: false },
+        }),
+      });
+      const ch = await createChannel("test", "xoxb-x");
+      expect(ch.id).toBe("C1");
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+      const [url, init] = fetchMock.mock.calls[0];
+      expect(url).toContain("conversations.create");
+      const body = JSON.parse((init as { body: string }).body);
+      expect(body.name).toBe("test");
+    });
+
+    it("surfaces Slack ok:false errors", async () => {
+      fetchMock.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ ok: false, error: "name_taken" }),
+      });
+      await expect(createChannel("test", "xoxb-x")).rejects.toThrow(/name_taken/);
+    });
+  });
+
+  describe("setChannelTopic", () => {
+    it("calls conversations.setTopic", async () => {
+      fetchMock.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ ok: true }),
+      });
+      await setChannelTopic("C1", "new topic", "xoxb-x");
+      const [url, init] = fetchMock.mock.calls[0];
+      expect(url).toContain("conversations.setTopic");
+      const body = JSON.parse((init as { body: string }).body);
+      expect(body.channel).toBe("C1");
+      expect(body.topic).toBe("new topic");
+    });
+  });
+
+  describe("joinChannel", () => {
+    it("calls conversations.join", async () => {
+      fetchMock.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ ok: true }),
+      });
+      await joinChannel("C1", "xoxb-x");
+      const [url] = fetchMock.mock.calls[0];
+      expect(url).toContain("conversations.join");
+    });
+  });
+
+  describe("archiveChannel", () => {
+    it("calls conversations.archive", async () => {
+      fetchMock.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ ok: true }),
+      });
+      await archiveChannel("C1", "xoxb-x");
+      const [url] = fetchMock.mock.calls[0];
+      expect(url).toContain("conversations.archive");
+    });
+  });
+});

--- a/__tests__/user-profile.test.ts
+++ b/__tests__/user-profile.test.ts
@@ -1,0 +1,160 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+
+const { mockDynamoSend, getCalls, updateCalls } = vi.hoisted(() => ({
+  mockDynamoSend: vi.fn(),
+  getCalls: [] as unknown[],
+  updateCalls: [] as unknown[],
+}));
+
+vi.mock("@aws-sdk/client-dynamodb", () => ({
+  DynamoDBClient: vi.fn().mockImplementation(function () {
+    return { send: mockDynamoSend };
+  }),
+  GetItemCommand: vi.fn().mockImplementation(function (input: unknown) {
+    getCalls.push(input);
+    return { __cmd: "Get", input };
+  }),
+  UpdateItemCommand: vi.fn().mockImplementation(function (input: unknown) {
+    updateCalls.push(input);
+    return { __cmd: "Update", input };
+  }),
+}));
+
+vi.mock("@/lib/stripe-transactions", () => ({
+  resolveDynamoEndpoint: () => "http://localhost:8000",
+}));
+
+import { getUserProfile, putUserProfile } from "@/lib/user-profile";
+
+describe("user-profile", () => {
+  const originalTable = process.env.USER_PROFILE_TABLE;
+
+  beforeEach(() => {
+    mockDynamoSend.mockReset();
+    getCalls.length = 0;
+    updateCalls.length = 0;
+    process.env.USER_PROFILE_TABLE = "test-user-profile-table";
+  });
+
+  afterEach(() => {
+    if (originalTable === undefined) delete process.env.USER_PROFILE_TABLE;
+    else process.env.USER_PROFILE_TABLE = originalTable;
+  });
+
+  describe("getUserProfile", () => {
+    it("returns {} when DynamoDB returns no item", async () => {
+      mockDynamoSend.mockResolvedValueOnce({});
+      const r = await getUserProfile("user-1");
+      expect(r).toEqual({});
+    });
+
+    it("maps stored String attributes back to fields", async () => {
+      mockDynamoSend.mockResolvedValueOnce({
+        Item: {
+          name: { S: "Themis" },
+          company: { S: "Cloudless" },
+          phone: { S: "+30..." },
+        },
+      });
+      const r = await getUserProfile("user-1");
+      expect(r.name).toBe("Themis");
+      expect(r.company).toBe("Cloudless");
+      expect(r.phone).toBe("+30...");
+    });
+
+    it("parses JSON preferences out of the stored String", async () => {
+      mockDynamoSend.mockResolvedValueOnce({
+        Item: {
+          preferences: { S: JSON.stringify({ theme: "dark", lang: "en" }) },
+        },
+      });
+      const r = await getUserProfile("user-1");
+      expect(r.preferences).toEqual({ theme: "dark", lang: "en" });
+    });
+
+    it("silently drops malformed JSON preferences (fallback to undefined)", async () => {
+      mockDynamoSend.mockResolvedValueOnce({
+        Item: { preferences: { S: "{not json" } },
+      });
+      const r = await getUserProfile("user-1");
+      expect(r.preferences).toBeUndefined();
+    });
+
+    it("throws when USER_PROFILE_TABLE is unset", async () => {
+      delete process.env.USER_PROFILE_TABLE;
+      await expect(getUserProfile("user-1")).rejects.toThrow(
+        /USER_PROFILE_TABLE/,
+      );
+    });
+
+    it("treats whitespace-only USER_PROFILE_TABLE as unset", async () => {
+      process.env.USER_PROFILE_TABLE = "   ";
+      await expect(getUserProfile("user-1")).rejects.toThrow(
+        /USER_PROFILE_TABLE/,
+      );
+    });
+  });
+
+  describe("putUserProfile", () => {
+    it("does not call DynamoDB when no fields are provided", async () => {
+      await putUserProfile("user-1", {});
+      expect(mockDynamoSend).not.toHaveBeenCalled();
+    });
+
+    it("builds a SET clause for provided string fields", async () => {
+      mockDynamoSend.mockResolvedValueOnce({});
+      await putUserProfile("user-1", { name: "Themis", company: "Cloudless" });
+      expect(updateCalls).toHaveLength(1);
+      const input = updateCalls[0] as {
+        UpdateExpression: string;
+        ExpressionAttributeNames: Record<string, string>;
+        ExpressionAttributeValues: Record<string, { S: string }>;
+      };
+      expect(input.UpdateExpression.startsWith("SET")).toBe(true);
+      expect(input.UpdateExpression).toContain("#name = :name");
+      expect(input.UpdateExpression).toContain("#company = :company");
+      expect(input.ExpressionAttributeNames["#name"]).toBe("name");
+      expect(input.ExpressionAttributeValues[":name"]).toEqual({ S: "Themis" });
+    });
+
+    it("converts empty-string fields to REMOVE clauses", async () => {
+      mockDynamoSend.mockResolvedValueOnce({});
+      await putUserProfile("user-1", { name: "", phone: "" });
+      const input = updateCalls[0] as { UpdateExpression: string };
+      expect(input.UpdateExpression).toContain("REMOVE");
+      expect(input.UpdateExpression).toContain("#name");
+      expect(input.UpdateExpression).toContain("#phone");
+    });
+
+    it("combines SET and REMOVE in a single update", async () => {
+      mockDynamoSend.mockResolvedValueOnce({});
+      await putUserProfile("user-1", { name: "Themis", phone: "" });
+      const input = updateCalls[0] as { UpdateExpression: string };
+      expect(input.UpdateExpression).toContain("SET");
+      expect(input.UpdateExpression).toContain("REMOVE");
+    });
+
+    it("serializes preferences as JSON in a String attribute", async () => {
+      mockDynamoSend.mockResolvedValueOnce({});
+      await putUserProfile("user-1", { preferences: { theme: "dark" } });
+      const input = updateCalls[0] as {
+        ExpressionAttributeValues: Record<string, { S: string }>;
+      };
+      expect(JSON.parse(input.ExpressionAttributeValues[":preferences"].S)).toEqual({
+        theme: "dark",
+      });
+    });
+
+    it("skips ExpressionAttributeValues when only REMOVE is needed", async () => {
+      mockDynamoSend.mockResolvedValueOnce({});
+      await putUserProfile("user-1", { name: "" });
+      const input = updateCalls[0] as {
+        UpdateExpression: string;
+        ExpressionAttributeValues?: Record<string, unknown>;
+      };
+      expect(input.UpdateExpression).toContain("REMOVE");
+      expect(input.UpdateExpression).not.toContain("SET");
+      expect(input.ExpressionAttributeValues).toBeUndefined();
+    });
+  });
+});


### PR DESCRIPTION
Batch 3 of the Vitest coverage climb (after #832, #833).

## What landed (39 new tests)

### bedrock-shared.ts (14 tests)
- BEDROCK_REGION / BEDROCK_MODEL_ID env-driven defaults
- getBedrockClient singleton behaviour
- buildBedrockToolConfig: anthropic-shape -> bedrock toolSpec mapping, arbitrary input_schema pass-through, empty input
- pickToolUseBlocks: filter, empty, malformed-id rejection
- joinAssistantText: trim+join, no-text fallback
- runBedrockTurn: content return, default maxTokens=400, missing output

### user-profile.ts (12 tests)
- getUserProfile: no item, string attributes, JSON preferences parse, malformed-JSON drop, unset/whitespace USER_PROFILE_TABLE throw
- putUserProfile: empty noop, SET clause, REMOVE for empty strings, combined SET+REMOVE, preferences JSON-serialize, no-values skip

### agent-book.ts (2 tests)
- isAgentBookConfigured passes the required Google Calendar keys through and returns the integrations layer answer

### slack-admin.ts (11 tests)
- SLACK_CHANNELS registry: 6 canonical channels, name+topic, unique
- listChannels: success, HTTP error, Slack-level ok:false
- createChannel: posts to conversations.create, surfaces errors
- setChannelTopic: posts to conversations.setTopic with channel+topic
- joinChannel + archiveChannel: hit the right Slack endpoints

## Cumulative climb (3 batches)

| PR | Modules | Tests |
|---|---|---|
| #832 | booking-slots, sha-drift, slack-rate-limit, slack-verify | 40 |
| #833 | amplify-config, client-portals, services-data, notion-esp32 | 43 |
| this | bedrock-shared, user-profile, agent-book, slack-admin | 39 |
| **Total** | **12 lib modules from 0% → covered** | **122 tests** |

All 39 tests verified locally with vitest run.