### PR TITLE
test(vitest): add unit coverage for 4 more lib modules (batch 4)

### DIFF
--- a/__tests__/client-report-email.test.ts
+++ b/__tests__/client-report-email.test.ts
@@ -1,0 +1,147 @@
+import { describe, it, expect } from "vitest";
+import { buildReportHtml } from "@/lib/client-report-email";
+import type { ClientPortal } from "@/lib/client-portals";
+
+const SAMPLE: ClientPortal = {
+  token: "tok-1",
+  label: "Acme Migration",
+  clientEmail: "ops@acme.example",
+  clientName: "Acme",
+  createdAt: "2026-01-01T00:00:00Z",
+  steps: [
+    { id: "s1", name: "Discovery", status: "completed", comments: [] },
+    { id: "s2", name: "Build", status: "in-progress", comments: [] },
+    { id: "s3", name: "Launch", status: "pending", comments: [] },
+  ],
+  deliverables: [
+    {
+      id: "d1",
+      title: "Architecture diagram",
+      url: "https://example.com/diagram",
+      status: "approved",
+      createdAt: "2026-01-01T00:00:00Z",
+      updatedAt: "2026-01-01T00:00:00Z",
+    },
+    {
+      id: "d2",
+      title: "Cost model",
+      status: "in_review",
+      createdAt: "2026-01-01T00:00:00Z",
+      updatedAt: "2026-01-01T00:00:00Z",
+    },
+    {
+      id: "d3",
+      title: "Internal draft",
+      status: "draft",
+      createdAt: "2026-01-01T00:00:00Z",
+      updatedAt: "2026-01-01T00:00:00Z",
+    },
+  ],
+  paymentLinks: [
+    {
+      id: "p1",
+      label: "Deposit",
+      url: "https://stripe/deposit",
+      amountCents: 50000,
+      currency: "EUR",
+      status: "open",
+      createdAt: "2026-01-01T00:00:00Z",
+    },
+    {
+      id: "p2",
+      label: "Paid invoice",
+      url: "https://stripe/paid",
+      status: "paid",
+      createdAt: "2026-01-01T00:00:00Z",
+    },
+  ],
+};
+
+describe("client-report-email.buildReportHtml", () => {
+  it("includes the portal label and a personalized greeting", () => {
+    const html = buildReportHtml(SAMPLE);
+    expect(html).toContain("Acme Migration");
+    expect(html).toContain("Hi Acme");
+  });
+
+  it("renders every timeline step with its emoji", () => {
+    const html = buildReportHtml(SAMPLE);
+    expect(html).toContain("Discovery");
+    expect(html).toContain("Build");
+    expect(html).toContain("Launch");
+    // Status-specific emojis
+    expect(html).toContain("✅");  // completed
+    expect(html).toContain("🔧");  // in-progress
+    expect(html).toContain("⬜");  // pending
+  });
+
+  it("filters out draft deliverables", () => {
+    const html = buildReportHtml(SAMPLE);
+    expect(html).toContain("Architecture diagram");
+    expect(html).toContain("Cost model");
+    expect(html).not.toContain("Internal draft");
+  });
+
+  it("links titled deliverables that have a URL", () => {
+    const html = buildReportHtml(SAMPLE);
+    expect(html).toContain('href="https://example.com/diagram"');
+    expect(html).toContain(">Architecture diagram<");
+  });
+
+  it("renders the 'in_review' status as a space-separated label", () => {
+    const html = buildReportHtml(SAMPLE);
+    expect(html).toContain("in review");
+    expect(html).not.toContain(">in_review<");
+  });
+
+  it("flags how many deliverables are waiting for review", () => {
+    const html = buildReportHtml(SAMPLE);
+    expect(html).toMatch(/1 deliverable.* are waiting for your review/);
+  });
+
+  it("omits the review-waiting line when no deliverables are in_review", () => {
+    const html = buildReportHtml({
+      ...SAMPLE,
+      deliverables: SAMPLE.deliverables?.filter(d => d.status !== "in_review"),
+    });
+    expect(html).not.toMatch(/waiting for your review/);
+  });
+
+  it("lists only open payment links with formatted amount", () => {
+    const html = buildReportHtml(SAMPLE);
+    expect(html).toContain("Deposit");
+    expect(html).toContain("500.00 EUR");
+    expect(html).not.toContain("Paid invoice");
+  });
+
+  it("omits the payment section entirely when none are open", () => {
+    const html = buildReportHtml({ ...SAMPLE, paymentLinks: [] });
+    expect(html).not.toContain("Open payments");
+  });
+
+  it("renders a 'No deliverables shared yet' message when there are none visible", () => {
+    const html = buildReportHtml({ ...SAMPLE, deliverables: [] });
+    expect(html).toContain("No deliverables shared yet");
+  });
+
+  it("falls back to 'there' when clientName is empty", () => {
+    const html = buildReportHtml({ ...SAMPLE, clientName: "" });
+    expect(html).toContain("Hi there");
+  });
+
+  it("includes a link to the portal at /portal/<token>", () => {
+    const html = buildReportHtml(SAMPLE);
+    expect(html).toContain("/portal/tok-1");
+  });
+
+  it("escapes HTML in user-controlled fields", () => {
+    const html = buildReportHtml({
+      ...SAMPLE,
+      label: "<script>alert(1)</script>",
+      clientName: "<img onerror=x>",
+    });
+    expect(html).not.toContain("<script>alert(1)</script>");
+    expect(html).not.toContain("<img onerror=x>");
+    expect(html).toContain("&lt;script&gt;");
+  });
+});

--- a/__tests__/slack-manifest.test.ts
+++ b/__tests__/slack-manifest.test.ts
@@ -1,0 +1,148 @@
+import { describe, it, expect, beforeEach, vi, afterEach } from "vitest";
+
+const { readFileSyncMock } = vi.hoisted(() => ({
+  readFileSyncMock: vi.fn(),
+}));
+
+vi.mock("fs", async () => {
+  const actual = await vi.importActual<typeof import("fs")>("fs");
+  return {
+    ...actual,
+    readFileSync: (...args: unknown[]) => readFileSyncMock(...args),
+  };
+});
+
+import {
+  validateManifest,
+  applyManifest,
+  readLocalManifest,
+} from "@/lib/slack-manifest";
+
+const fetchMock = vi.fn();
+const originalFetch = globalThis.fetch;
+
+describe("slack-manifest", () => {
+  beforeEach(() => {
+    fetchMock.mockReset();
+    readFileSyncMock.mockReset();
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  describe("readLocalManifest", () => {
+    it("strips _comment / _docs / _apply meta fields", () => {
+      // The fs mock can't override readFileSync from this layer (slack-manifest
+      // imports it before vi.mock takes effect for an external dep). Verify
+      // the contract against the real file: meta fields are stripped, real
+      // schema keys survive.
+      const m = readLocalManifest();
+      expect(m._comment).toBeUndefined();
+      expect(m._docs).toBeUndefined();
+      expect(m._apply).toBeUndefined();
+      expect(m.display_information).toBeDefined();
+      expect(m.oauth_config).toBeDefined();
+    });
+  });
+
+  describe("validateManifest", () => {
+    it("returns valid=true when Slack ok:true", async () => {
+      readFileSyncMock.mockReturnValueOnce(
+        JSON.stringify({ display_information: { name: "x" } }),
+      );
+      fetchMock.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ ok: true }),
+      });
+      const r = await validateManifest("xapp-x");
+      expect(r.valid).toBe(true);
+      expect(r.errors).toEqual([]);
+    });
+
+    it("maps Slack validation errors to <pointer>: <message>", async () => {
+      readFileSyncMock.mockReturnValueOnce(
+        JSON.stringify({ display_information: { name: "x" } }),
+      );
+      fetchMock.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          ok: false,
+          errors: [
+            { pointer: "/oauth_config/scopes/bot/0", message: "Invalid scope" },
+            { pointer: "/display_information/name", message: "Required" },
+          ],
+        }),
+      });
+      const r = await validateManifest("xapp-x");
+      expect(r.valid).toBe(false);
+      expect(r.errors).toContain("/oauth_config/scopes/bot/0: Invalid scope");
+      expect(r.errors).toContain("/display_information/name: Required");
+    });
+
+    it("falls back to res.error when errors[] is absent", async () => {
+      readFileSyncMock.mockReturnValueOnce("{}");
+      fetchMock.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ ok: false, error: "invalid_auth" }),
+      });
+      const r = await validateManifest("xapp-x");
+      expect(r.valid).toBe(false);
+      expect(r.errors).toEqual(["invalid_auth"]);
+    });
+
+    it("throws on HTTP error", async () => {
+      readFileSyncMock.mockReturnValueOnce("{}");
+      fetchMock.mockResolvedValueOnce({ ok: false, status: 502, json: async () => ({}) });
+      await expect(validateManifest("xapp-x")).rejects.toThrow(/HTTP 502/);
+    });
+  });
+
+  describe("applyManifest", () => {
+    it("returns ok+appId on success", async () => {
+      readFileSyncMock.mockReturnValueOnce("{}");
+      fetchMock.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ ok: true, app_id: "A123" }),
+      });
+      const r = await applyManifest("A123", "xoxp-x");
+      expect(r).toEqual({ ok: true, appId: "A123" });
+    });
+
+    it("preserves the requested appId when Slack omits it from the response", async () => {
+      readFileSyncMock.mockReturnValueOnce("{}");
+      fetchMock.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ ok: true }),
+      });
+      const r = await applyManifest("A999", "xoxp-x");
+      expect(r.appId).toBe("A999");
+    });
+
+    it("throws on Slack ok:false", async () => {
+      readFileSyncMock.mockReturnValueOnce("{}");
+      fetchMock.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ ok: false, error: "not_allowed_token_type" }),
+      });
+      await expect(applyManifest("A1", "xoxb-bot")).rejects.toThrow(
+        /not_allowed_token_type/,
+      );
+    });
+
+    it("sends app_id and manifest in the request body", async () => {
+      fetchMock.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ ok: true, app_id: "A1" }),
+      });
+      await applyManifest("A1", "xoxp-x");
+      const [, init] = fetchMock.mock.calls[0];
+      const body = JSON.parse((init as { body: string }).body);
+      expect(body.app_id).toBe("A1");
+      expect(typeof body.manifest).toBe("string");
+      const m = JSON.parse(body.manifest);
+      expect(m.display_information).toBeDefined();
+    });
+  });
+});

--- a/__tests__/slack-users.test.ts
+++ b/__tests__/slack-users.test.ts
@@ -1,0 +1,177 @@
+import { describe, it, expect, beforeEach, vi, afterEach } from "vitest";
+import {
+  lookupUserByEmail,
+  getUserInfo,
+  listUsers,
+  resolveEmailToUserId,
+  type SlackUser,
+} from "@/lib/slack-users";
+
+const fetchMock = vi.fn();
+const originalFetch = globalThis.fetch;
+
+function userFixture(id: string, email?: string, deleted = false): SlackUser {
+  return {
+    id,
+    name: id.toLowerCase(),
+    real_name: id,
+    is_bot: false,
+    is_app_user: false,
+    deleted,
+    profile: {
+      display_name: id,
+      real_name: id,
+      ...(email ? { email } : {}),
+    },
+  };
+}
+
+describe("slack-users", () => {
+  beforeEach(() => {
+    fetchMock.mockReset();
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  describe("lookupUserByEmail", () => {
+    it("returns the user on success", async () => {
+      const user = userFixture("U1", "x@y");
+      fetchMock.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ ok: true, user }),
+      });
+      const r = await lookupUserByEmail("x@y", "xoxb-x");
+      expect(r?.id).toBe("U1");
+    });
+
+    it("returns null on users_not_found", async () => {
+      fetchMock.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ ok: false, error: "users_not_found" }),
+      });
+      expect(await lookupUserByEmail("nobody@x", "xoxb-x")).toBeNull();
+    });
+
+    it("throws on other Slack errors", async () => {
+      fetchMock.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ ok: false, error: "missing_scope" }),
+      });
+      await expect(lookupUserByEmail("x@y", "xoxb-x")).rejects.toThrow(
+        /missing_scope/,
+      );
+    });
+
+    it("throws on HTTP error", async () => {
+      fetchMock.mockResolvedValueOnce({ ok: false, status: 503, json: async () => ({}) });
+      await expect(lookupUserByEmail("x@y", "xoxb-x")).rejects.toThrow(/HTTP 503/);
+    });
+
+    it("uses form-encoded POST", async () => {
+      const user = userFixture("U1", "x@y");
+      fetchMock.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ ok: true, user }),
+      });
+      await lookupUserByEmail("x@y", "xoxb-x");
+      const [, init] = fetchMock.mock.calls[0];
+      expect((init as { method: string }).method).toBe("POST");
+      expect((init as { headers: Record<string, string> }).headers["Content-Type"]).toBe(
+        "application/x-www-form-urlencoded",
+      );
+    });
+  });
+
+  describe("getUserInfo", () => {
+    it("returns the user on success", async () => {
+      fetchMock.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ ok: true, user: userFixture("U2") }),
+      });
+      const r = await getUserInfo("U2", "xoxb-x");
+      expect(r.id).toBe("U2");
+    });
+
+    it("throws when the user is missing in the response", async () => {
+      fetchMock.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ ok: true }),
+      });
+      await expect(getUserInfo("U2", "xoxb-x")).rejects.toThrow();
+    });
+
+    it("throws on Slack-level error", async () => {
+      fetchMock.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ ok: false, error: "user_not_found" }),
+      });
+      await expect(getUserInfo("U2", "xoxb-x")).rejects.toThrow(/user_not_found/);
+    });
+  });
+
+  describe("listUsers", () => {
+    it("filters out deleted members", async () => {
+      fetchMock.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          ok: true,
+          members: [userFixture("U1"), userFixture("U2", undefined, true)],
+        }),
+      });
+      const r = await listUsers("xoxb-x");
+      expect(r).toHaveLength(1);
+      expect(r[0].id).toBe("U1");
+    });
+
+    it("walks the response_metadata.next_cursor pagination", async () => {
+      fetchMock
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({
+            ok: true,
+            members: [userFixture("U1")],
+            response_metadata: { next_cursor: "cur-2" },
+          }),
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({
+            ok: true,
+            members: [userFixture("U2")],
+          }),
+        });
+      const r = await listUsers("xoxb-x");
+      expect(r.map(u => u.id)).toEqual(["U1", "U2"]);
+      expect(fetchMock).toHaveBeenCalledTimes(2);
+    });
+
+    it("throws on Slack-level error", async () => {
+      fetchMock.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ ok: false, error: "ratelimited" }),
+      });
+      await expect(listUsers("xoxb-x")).rejects.toThrow(/ratelimited/);
+    });
+  });
+
+  describe("resolveEmailToUserId", () => {
+    it("returns the id when the user exists", async () => {
+      fetchMock.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ ok: true, user: userFixture("U99", "x@y") }),
+      });
+      expect(await resolveEmailToUserId("x@y", "xoxb-x")).toBe("U99");
+    });
+
+    it("returns null when the user does not exist", async () => {
+      fetchMock.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ ok: false, error: "users_not_found" }),
+      });
+      expect(await resolveEmailToUserId("nope@y", "xoxb-x")).toBeNull();
+    });
+  });
+});

--- a/__tests__/slack-workspace.test.ts
+++ b/__tests__/slack-workspace.test.ts
@@ -1,0 +1,193 @@
+import { describe, it, expect, beforeEach, vi, afterEach } from "vitest";
+
+const { getSlackConfigAsyncMock } = vi.hoisted(() => ({
+  getSlackConfigAsyncMock: vi.fn(),
+}));
+
+vi.mock("@/lib/integrations", () => ({
+  getSlackConfigAsync: () => getSlackConfigAsyncMock(),
+}));
+
+import {
+  getBotInfo,
+  getWorkspaceInfo,
+  getSlackBrandingAudit,
+} from "@/lib/slack-workspace";
+
+const fetchMock = vi.fn();
+const originalFetch = globalThis.fetch;
+
+describe("slack-workspace", () => {
+  beforeEach(() => {
+    fetchMock.mockReset();
+    getSlackConfigAsyncMock.mockReset();
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  describe("getBotInfo", () => {
+    it("returns the bot identity from auth.test", async () => {
+      fetchMock.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          ok: true,
+          user_id: "U_BOT",
+          user: "cloudless-bot",
+          team: "cloudless",
+          team_id: "T_TEAM",
+          url: "https://cloudless.slack.com/",
+        }),
+      });
+      const r = await getBotInfo("xoxb-x");
+      expect(r.userId).toBe("U_BOT");
+      expect(r.botName).toBe("cloudless-bot");
+      expect(r.team).toBe("cloudless");
+      expect(r.teamId).toBe("T_TEAM");
+    });
+
+    it("uses token from integrations when not provided", async () => {
+      getSlackConfigAsyncMock.mockResolvedValueOnce({ SLACK_BOT_TOKEN: "xoxb-from-integ" });
+      fetchMock.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ ok: true, user_id: "U1" }),
+      });
+      await getBotInfo();
+      const [, init] = fetchMock.mock.calls[0];
+      expect((init as { headers: Record<string, string> }).headers.Authorization).toBe(
+        "Bearer xoxb-from-integ",
+      );
+    });
+
+    it("throws when no token is available", async () => {
+      getSlackConfigAsyncMock.mockResolvedValueOnce({ SLACK_BOT_TOKEN: "" });
+      await expect(getBotInfo()).rejects.toThrow(/SLACK_BOT_TOKEN/);
+    });
+
+    it("throws on Slack-level ok:false", async () => {
+      fetchMock.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ ok: false, error: "invalid_auth" }),
+      });
+      await expect(getBotInfo("xoxb-x")).rejects.toThrow(/invalid_auth/);
+    });
+
+    it("returns empty strings when optional fields are absent", async () => {
+      fetchMock.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ ok: true }),
+      });
+      const r = await getBotInfo("xoxb-x");
+      expect(r.userId).toBe("");
+      expect(r.botName).toBe("");
+      expect(r.team).toBe("");
+    });
+  });
+
+  describe("getWorkspaceInfo", () => {
+    it("returns workspace metadata with the highest-res icon", async () => {
+      fetchMock.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          ok: true,
+          team: {
+            id: "T1",
+            name: "Cloudless",
+            domain: "cloudless",
+            email_domain: "cloudless.gr",
+            icon: {
+              image_88: "https://x/88.png",
+              image_132: "https://x/132.png",
+              image_230: "https://x/230.png",
+            },
+          },
+        }),
+      });
+      const r = await getWorkspaceInfo("xoxb-x");
+      expect(r.id).toBe("T1");
+      expect(r.name).toBe("Cloudless");
+      expect(r.iconUrl).toBe("https://x/230.png");
+    });
+
+    it("falls back to lower-res icon when 230 is missing", async () => {
+      fetchMock.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          ok: true,
+          team: {
+            id: "T1",
+            name: "n",
+            domain: "d",
+            email_domain: "e",
+            icon: { image_88: "https://x/88.png" },
+          },
+        }),
+      });
+      const r = await getWorkspaceInfo("xoxb-x");
+      expect(r.iconUrl).toBe("https://x/88.png");
+    });
+
+    it("returns null icon when image_default is true", async () => {
+      fetchMock.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          ok: true,
+          team: {
+            id: "T1",
+            name: "n",
+            domain: "d",
+            email_domain: "e",
+            icon: { image_default: true, image_230: "https://x/230.png" },
+          },
+        }),
+      });
+      const r = await getWorkspaceInfo("xoxb-x");
+      expect(r.iconUrl).toBeNull();
+    });
+
+    it("throws when ok:false", async () => {
+      fetchMock.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ ok: false, error: "missing_scope" }),
+      });
+      await expect(getWorkspaceInfo("xoxb-x")).rejects.toThrow(/missing_scope/);
+    });
+  });
+
+  describe("getSlackBrandingAudit", () => {
+    it("combines bot + workspace and pins the per-message branding", async () => {
+      fetchMock
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({
+            ok: true,
+            user_id: "U1",
+            user: "bot",
+            team: "cloudless",
+            team_id: "T1",
+          }),
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({
+            ok: true,
+            team: {
+              id: "T1",
+              name: "Cloudless",
+              domain: "cloudless",
+              email_domain: "cloudless.gr",
+              icon: { image_230: "https://x/230.png" },
+            },
+          }),
+        });
+      const r = await getSlackBrandingAudit("xoxb-x");
+      expect(r.bot.userId).toBe("U1");
+      expect(r.workspace.name).toBe("Cloudless");
+      expect(r.perMessageBranding.username).toBe("Cloudless");
+      expect(r.perMessageBranding.iconUrl).toMatch(/icon-512\.png$/);
+      expect(r.appLevelBrandingUrl).toBe("https://api.slack.com/apps");
+    });
+  });
+});


### PR DESCRIPTION
Batch 4 of the Vitest coverage climb (after #832, #833, #834).

## What landed (45 new tests)

### client-report-email.ts (13 tests)
- Label + personalized greeting
- Timeline steps with status emoji
- Draft deliverable filtering
- URL-linked deliverable titles
- in_review label spacing
- Review-waiting counter (present + absent)
- Open-payment filtering + amount formatting
- Empty-state messages
- Anonymous-client fallback
- Portal URL
- HTML escaping (XSS guard)

### slack-users.ts (13 tests)
- lookupUserByEmail: success, `users_not_found` null, other errors, HTTP error, form-encoded POST
- getUserInfo: success, missing user, `ok:false`
- listUsers: deleted filter, cursor pagination, error
- resolveEmailToUserId: hit + miss

### slack-workspace.ts (10 tests)
- getBotInfo: identity mapping, token from integrations fallback, missing token throw, `ok:false` throw, empty-field defaults
- getWorkspaceInfo: highest-res icon, lower-res fallback, `image_default → null`, `ok:false` throw
- getSlackBrandingAudit: combined output + pinned per-message branding

### slack-manifest.ts (9 tests)
- readLocalManifest: meta-field stripping
- validateManifest: valid path, Slack-shaped errors mapped to `pointer:message`, error fallback, HTTP error
- applyManifest: success, appId preservation, `ok:false` throw, request body shape

## Cumulative climb (4 batches)

| PR | Modules | Tests |
|---|---|---|
| #832 | booking-slots, sha-drift, slack-rate-limit, slack-verify | 40 |
| #833 | amplify-config, client-portals, services-data, notion-esp32 | 43 |
| #834 | bedrock-shared, user-profile, agent-book, slack-admin | 39 |
| this | client-report-email, slack-users, slack-workspace, slack-manifest | 45 |
| **Total** | **16 lib modules from 0% → covered** | **167 tests** |

All 45 tests verified locally with `vitest run`.