### PR TITLE
test(vitest): add unit coverage for 2 more lib modules (batch 6)

### DIFF
--- a/__tests__/bedrock-chat.test.ts
+++ b/__tests__/bedrock-chat.test.ts
@@ -1,0 +1,159 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+const { mockBedrockSend, runToolMock } = vi.hoisted(() => ({
+  mockBedrockSend: vi.fn(),
+  runToolMock: vi.fn(),
+}));
+
+vi.mock("@aws-sdk/client-bedrock-runtime", () => ({
+  ConverseCommand: vi.fn().mockImplementation(function (input: unknown) {
+    return { __cmd: "Converse", input };
+  }),
+}));
+
+vi.mock("@/lib/bedrock-shared", () => ({
+  BEDROCK_MODEL_ID: "anthropic.claude-3-5-haiku",
+  buildBedrockToolConfig: vi.fn().mockReturnValue({ tools: [] }),
+  getBedrockClient: vi.fn(() => ({ send: mockBedrockSend })),
+}));
+
+vi.mock("@/lib/chat-tools", () => ({
+  CHAT_TOOLS: [
+    {
+      name: "book_slot",
+      description: "Book a 30min slot",
+      input_schema: { type: "object", properties: {} },
+    },
+  ],
+  runTool: (...args: unknown[]) => runToolMock(...args),
+}));
+
+import { runBedrockChatLoop } from "@/lib/bedrock-chat";
+
+describe("bedrock-chat.runBedrockChatLoop", () => {
+  beforeEach(() => {
+    mockBedrockSend.mockReset();
+    runToolMock.mockReset();
+  });
+
+  it("returns concatenated text when Bedrock stops without tool use", async () => {
+    mockBedrockSend.mockResolvedValueOnce({
+      stopReason: "end_turn",
+      output: {
+        message: {
+          content: [{ text: "Hello, " }, { text: "world." }],
+        },
+      },
+    });
+    const r = await runBedrockChatLoop("You are helpful.", [
+      { role: "user", content: "hi" },
+    ]);
+    expect(r).toBe("Hello, world.");
+  });
+
+  it("returns empty string when the assistant emits no content", async () => {
+    mockBedrockSend.mockResolvedValueOnce({
+      stopReason: "end_turn",
+      output: { message: { content: [] } },
+    });
+    const r = await runBedrockChatLoop("s", [{ role: "user", content: "x" }]);
+    expect(r).toBe("");
+  });
+
+  it("runs a tool when Bedrock requests it and continues the loop", async () => {
+    mockBedrockSend
+      .mockResolvedValueOnce({
+        stopReason: "tool_use",
+        output: {
+          message: {
+            content: [
+              { text: "Let me check..." },
+              {
+                toolUse: {
+                  toolUseId: "tu-1",
+                  name: "book_slot",
+                  input: { days_ahead: 7 },
+                },
+              },
+            ],
+          },
+        },
+      })
+      .mockResolvedValueOnce({
+        stopReason: "end_turn",
+        output: { message: { content: [{ text: "Booked!" }] } },
+      });
+    runToolMock.mockResolvedValueOnce("slot reserved");
+    const r = await runBedrockChatLoop("s", [{ role: "user", content: "book" }]);
+    expect(r).toBe("Booked!");
+    expect(runToolMock).toHaveBeenCalledWith("book_slot", { days_ahead: 7 });
+  });
+
+  it("forwards tool error-string results back to the next Bedrock turn", async () => {
+    // The real runTool catches its own errors and returns a string —
+    // the loop should pass that string through as a tool_result and
+    // keep iterating until end_turn.
+    mockBedrockSend
+      .mockResolvedValueOnce({
+        stopReason: "tool_use",
+        output: {
+          message: {
+            content: [
+              { toolUse: { toolUseId: "tu-2", name: "book_slot", input: {} } },
+            ],
+          },
+        },
+      })
+      .mockResolvedValueOnce({
+        stopReason: "end_turn",
+        output: { message: { content: [{ text: "Sorry, no slots." }] } },
+      });
+    runToolMock.mockResolvedValueOnce("Tool book_slot failed.");
+    const r = await runBedrockChatLoop("s", [{ role: "user", content: "book" }]);
+    expect(r).toBe("Sorry, no slots.");
+    expect(runToolMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("falls back to the contact-page nudge when MAX_TOOL_ITERATIONS is hit", async () => {
+    // Bedrock keeps requesting tools forever — the loop must bail out
+    // with a deterministic fallback string (not "" or a thrown error).
+    mockBedrockSend.mockResolvedValue({
+      stopReason: "tool_use",
+      output: {
+        message: {
+          content: [
+            { text: "still working..." },
+            { toolUse: { toolUseId: "tu-x", name: "book_slot", input: {} } },
+          ],
+        },
+      },
+    });
+    runToolMock.mockResolvedValue("more data");
+    const r = await runBedrockChatLoop("s", [{ role: "user", content: "go" }]);
+    expect(r).toMatch(/contact page/i);
+  });
+
+  it("filters non-text blocks out of the final response", async () => {
+    mockBedrockSend.mockResolvedValueOnce({
+      stopReason: "end_turn",
+      output: {
+        message: {
+          content: [
+            { text: "Real text." },
+            { toolUse: { toolUseId: "x", name: "n", input: {} } },
+            { text: 42 as unknown as string },
+          ],
+        },
+      },
+    });
+    const r = await runBedrockChatLoop("s", [{ role: "user", content: "x" }]);
+    expect(r).toBe("Real text.");
+  });
+
+  it("propagates Bedrock API errors to the caller", async () => {
+    mockBedrockSend.mockRejectedValueOnce(new Error("ThrottlingException"));
+    await expect(
+      runBedrockChatLoop("s", [{ role: "user", content: "x" }]),
+    ).rejects.toThrow(/ThrottlingException/);
+  });
+});

--- a/__tests__/stripe.test.ts
+++ b/__tests__/stripe.test.ts
@@ -1,0 +1,257 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+const { mockSessionsList, mockProductsList, mockGetConfig } = vi.hoisted(() => ({
+  mockSessionsList: vi.fn(),
+  mockProductsList: vi.fn(),
+  mockGetConfig: vi.fn(),
+}));
+
+vi.mock("stripe", () => ({
+  default: vi.fn().mockImplementation(function () {
+    return {
+      checkout: { sessions: { list: mockSessionsList } },
+      products: { list: mockProductsList },
+    };
+  }),
+}));
+
+vi.mock("@/lib/ssm-config", () => ({
+  getConfig: () => mockGetConfig(),
+}));
+
+describe("stripe", () => {
+  beforeEach(() => {
+    mockSessionsList.mockReset();
+    mockProductsList.mockReset();
+    mockGetConfig.mockReset();
+    vi.resetModules();
+  });
+
+  describe("getStripe", () => {
+    it("returns null when STRIPE_SECRET_KEY is not configured", async () => {
+      mockGetConfig.mockResolvedValueOnce({});
+      const { getStripe } = await import("@/lib/stripe");
+      expect(await getStripe()).toBeNull();
+    });
+
+    it("returns a Stripe instance when the key is configured", async () => {
+      mockGetConfig.mockResolvedValueOnce({ STRIPE_SECRET_KEY: "sk_test_x" });
+      const { getStripe } = await import("@/lib/stripe");
+      const s = await getStripe();
+      expect(s).not.toBeNull();
+    });
+
+    it("caches the instance across calls (singleton)", async () => {
+      mockGetConfig.mockResolvedValue({ STRIPE_SECRET_KEY: "sk_test_x" });
+      const { getStripe } = await import("@/lib/stripe");
+      const a = await getStripe();
+      const b = await getStripe();
+      expect(a).toBe(b);
+      // getConfig only consulted once because of the cache.
+      expect(mockGetConfig).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("listRecentCheckoutSessions", () => {
+    it("returns empty list + hasMore=false when Stripe is not configured", async () => {
+      mockGetConfig.mockResolvedValueOnce({});
+      const { listRecentCheckoutSessions } = await import("@/lib/stripe");
+      const r = await listRecentCheckoutSessions(5);
+      expect(r).toEqual({ orders: [], hasMore: false });
+    });
+
+    it("maps Stripe sessions to the RecentOrder shape", async () => {
+      mockGetConfig.mockResolvedValueOnce({ STRIPE_SECRET_KEY: "sk_x" });
+      mockSessionsList.mockResolvedValueOnce({
+        data: [
+          {
+            id: "cs_1",
+            customer_email: "alice@example.com",
+            customer_details: { email: "alice@example.com" },
+            amount_total: 12500,
+            currency: "eur",
+            status: "complete",
+            created: 1_700_000_000,
+            payment_status: "paid",
+            mode: "payment",
+          },
+        ],
+        has_more: false,
+      });
+      const { listRecentCheckoutSessions } = await import("@/lib/stripe");
+      const r = await listRecentCheckoutSessions(10);
+      expect(r.orders).toHaveLength(1);
+      expect(r.orders[0]).toMatchObject({
+        id: "cs_1",
+        email: "alice@example.com",
+        amount: 12500,
+        currency: "EUR",
+        status: "complete",
+        paymentStatus: "paid",
+        mode: "payment",
+      });
+    });
+
+    it("falls back to customer_details.email when customer_email is missing", async () => {
+      mockGetConfig.mockResolvedValueOnce({ STRIPE_SECRET_KEY: "sk_x" });
+      mockSessionsList.mockResolvedValueOnce({
+        data: [
+          {
+            id: "cs_2",
+            customer_email: null,
+            customer_details: { email: "bob@example.com" },
+            amount_total: 100,
+            currency: "usd",
+            status: "complete",
+            created: 1_700_000_000,
+            payment_status: "paid",
+            mode: "payment",
+          },
+        ],
+        has_more: false,
+      });
+      const { listRecentCheckoutSessions } = await import("@/lib/stripe");
+      const r = await listRecentCheckoutSessions(10);
+      expect(r.orders[0].email).toBe("bob@example.com");
+      expect(r.orders[0].currency).toBe("USD");
+    });
+
+    it("returns null email when neither field is present", async () => {
+      mockGetConfig.mockResolvedValueOnce({ STRIPE_SECRET_KEY: "sk_x" });
+      mockSessionsList.mockResolvedValueOnce({
+        data: [
+          {
+            id: "cs_3",
+            customer_email: null,
+            customer_details: {},
+            amount_total: 0,
+            currency: null,
+            status: null,
+            created: 0,
+            payment_status: "unpaid",
+            mode: null,
+          },
+        ],
+        has_more: true,
+      });
+      const { listRecentCheckoutSessions } = await import("@/lib/stripe");
+      const r = await listRecentCheckoutSessions(10);
+      expect(r.orders[0].email).toBeNull();
+      expect(r.orders[0].currency).toBe("EUR");
+      expect(r.orders[0].status).toBe("unknown");
+      expect(r.orders[0].mode).toBe("payment");
+      expect(r.hasMore).toBe(true);
+    });
+
+    it("passes through the requested limit", async () => {
+      mockGetConfig.mockResolvedValueOnce({ STRIPE_SECRET_KEY: "sk_x" });
+      mockSessionsList.mockResolvedValueOnce({ data: [], has_more: false });
+      const { listRecentCheckoutSessions } = await import("@/lib/stripe");
+      await listRecentCheckoutSessions(7);
+      expect(mockSessionsList).toHaveBeenCalledWith({
+        limit: 7,
+        expand: ["data.line_items"],
+      });
+    });
+  });
+
+  describe("listStripeProducts", () => {
+    it("returns null when Stripe is not configured", async () => {
+      mockGetConfig.mockResolvedValueOnce({});
+      const { listStripeProducts } = await import("@/lib/stripe");
+      expect(await listStripeProducts()).toBeNull();
+    });
+
+    it("maps products with default prices", async () => {
+      mockGetConfig.mockResolvedValueOnce({ STRIPE_SECRET_KEY: "sk_x" });
+      mockProductsList.mockResolvedValueOnce({
+        data: [
+          {
+            id: "prod_1",
+            name: "Course",
+            description: "Cloud course",
+            active: true,
+            images: ["https://x/img.png"],
+            metadata: { tier: "pro" },
+            default_price: {
+              id: "price_1",
+              unit_amount: 9900,
+              currency: "eur",
+              recurring: null,
+            },
+          },
+        ],
+      });
+      const { listStripeProducts } = await import("@/lib/stripe");
+      const r = await listStripeProducts();
+      expect(r).toHaveLength(1);
+      expect(r?.[0]).toMatchObject({
+        id: "prod_1",
+        name: "Course",
+        defaultPrice: { id: "price_1", unitAmount: 9900, currency: "EUR", recurring: null },
+      });
+    });
+
+    it("returns null when products API throws", async () => {
+      mockGetConfig.mockResolvedValueOnce({ STRIPE_SECRET_KEY: "sk_x" });
+      mockProductsList.mockRejectedValueOnce(new Error("Stripe down"));
+      const { listStripeProducts } = await import("@/lib/stripe");
+      expect(await listStripeProducts()).toBeNull();
+    });
+
+    it("handles missing default_price", async () => {
+      mockGetConfig.mockResolvedValueOnce({ STRIPE_SECRET_KEY: "sk_x" });
+      mockProductsList.mockResolvedValueOnce({
+        data: [
+          {
+            id: "prod_2",
+            name: "X",
+            description: null,
+            active: true,
+            images: [],
+            metadata: {},
+            default_price: null,
+          },
+        ],
+      });
+      const { listStripeProducts } = await import("@/lib/stripe");
+      const r = await listStripeProducts();
+      expect(r?.[0].defaultPrice).toBeNull();
+    });
+
+    it("includes recurring metadata when present", async () => {
+      mockGetConfig.mockResolvedValueOnce({ STRIPE_SECRET_KEY: "sk_x" });
+      mockProductsList.mockResolvedValueOnce({
+        data: [
+          {
+            id: "prod_sub",
+            name: "Subscription",
+            description: null,
+            active: true,
+            images: [],
+            metadata: {},
+            default_price: {
+              id: "price_sub",
+              unit_amount: 1000,
+              currency: "eur",
+              recurring: { interval: "month", interval_count: 1 },
+            },
+          },
+        ],
+      });
+      const { listStripeProducts } = await import("@/lib/stripe");
+      const r = await listStripeProducts();
+      expect(r?.[0].defaultPrice?.recurring).toEqual({
+        interval: "month",
+        intervalCount: 1,
+      });
+    });
+  });
+
+  describe("formatPrice re-export", () => {
+    it("is re-exported from @/lib/stripe", async () => {
+      const mod = await import("@/lib/stripe");
+      expect(typeof mod.formatPrice).toBe("function");
+    });
+  });
+});


### PR DESCRIPTION
Batch 6 of the Vitest coverage climb (after #832..#836).

## What landed (21 new tests)

### stripe.ts (14 tests)
- getStripe: null when STRIPE_SECRET_KEY missing, instance when set, singleton across calls (getConfig only consulted once)
- listRecentCheckoutSessions: empty fallback when unconfigured, RecentOrder shape mapping, customer_email → customer_details.email fallback, null email when both absent, defaults for currency/status/mode/hasMore, limit pass-through
- listStripeProducts: null when unconfigured, default-price mapping, products API error returns null, missing default_price, recurring interval metadata
- formatPrice re-export

### bedrock-chat.ts (7 tests)
- returns concatenated text when stopReason is end_turn
- returns empty string when no content blocks
- runs a tool when Bedrock requests it and continues
- forwards tool result string into the next turn (matches real runTool's catch-and-return-string contract)
- falls back to the contact-page nudge when MAX_TOOL_ITERATIONS
- filters non-text blocks from the final response
- propagates Bedrock API errors to the caller (no swallow)

## Cumulative climb (6 batches)

| PR | Modules | Tests |
|---|---|---|
| #832 | booking-slots, sha-drift, slack-rate-limit, slack-verify | 40 |
| #833 | amplify-config, client-portals, services-data, notion-esp32 | 43 |
| #834 | bedrock-shared, user-profile, agent-book, slack-admin | 39 |
| #835 | client-report-email, slack-users, slack-workspace, slack-manifest | 45 |
| #836 | admin-assistant-tools, analytics-report-pdf | 27 |
| this | stripe, bedrock-chat | 21 |
| **Total** | **20 lib modules from 0% → covered** | **215 tests** |

All 21 tests verified locally with `vitest run`.