### PR TITLE
feat(notifications): PR A1 — durable admin-notifications store on DynamoDB (infra + lib)

### DIFF
--- a/__tests__/admin-notifications.test.ts
+++ b/__tests__/admin-notifications.test.ts
@@ -1,0 +1,361 @@
+import { describe, it, expect, beforeEach, vi, afterEach } from "vitest";
+
+const { mockDynamoSend, putCalls, queryCalls, updateCalls, batchWriteCalls } = vi.hoisted(() => ({
+  mockDynamoSend: vi.fn(),
+  putCalls: [] as unknown[],
+  queryCalls: [] as unknown[],
+  updateCalls: [] as unknown[],
+  batchWriteCalls: [] as unknown[],
+}));
+
+vi.mock("@aws-sdk/client-dynamodb", () => ({
+  DynamoDBClient: vi.fn().mockImplementation(function () {
+    return { send: mockDynamoSend };
+  }),
+  PutItemCommand: vi.fn().mockImplementation(function (input: unknown) {
+    putCalls.push(input);
+    return { __cmd: "Put", input };
+  }),
+  QueryCommand: vi.fn().mockImplementation(function (input: unknown) {
+    queryCalls.push(input);
+    return { __cmd: "Query", input };
+  }),
+  UpdateItemCommand: vi.fn().mockImplementation(function (input: unknown) {
+    updateCalls.push(input);
+    return { __cmd: "Update", input };
+  }),
+  BatchWriteItemCommand: vi.fn().mockImplementation(function (input: unknown) {
+    batchWriteCalls.push(input);
+    return { __cmd: "BatchWrite", input };
+  }),
+}));
+
+vi.mock("@/lib/stripe-transactions", () => ({
+  resolveDynamoEndpoint: () => "http://localhost:8000",
+}));
+
+import {
+  recordNotification,
+  listNotifications,
+  markNotificationsRead,
+  notificationAnalytics,
+  purgeArchivedOlderThan,
+} from "@/lib/admin-notifications";
+
+describe("admin-notifications", () => {
+  const originalTable = process.env.ADMIN_NOTIFICATIONS_TABLE;
+
+  beforeEach(() => {
+    mockDynamoSend.mockReset();
+    putCalls.length = 0;
+    queryCalls.length = 0;
+    updateCalls.length = 0;
+    batchWriteCalls.length = 0;
+    process.env.ADMIN_NOTIFICATIONS_TABLE = "test-notifs";
+  });
+
+  afterEach(() => {
+    if (originalTable === undefined) delete process.env.ADMIN_NOTIFICATIONS_TABLE;
+    else process.env.ADMIN_NOTIFICATIONS_TABLE = originalTable;
+  });
+
+  describe("recordNotification", () => {
+    it("returns null when ADMIN_NOTIFICATIONS_TABLE is not set (safe no-op)", async () => {
+      delete process.env.ADMIN_NOTIFICATIONS_TABLE;
+      const r = await recordNotification({
+        category: "contact",
+        title: "T",
+        message: "M",
+      });
+      expect(r).toBeNull();
+      expect(mockDynamoSend).not.toHaveBeenCalled();
+    });
+
+    it("writes a row with the documented shape on success", async () => {
+      mockDynamoSend.mockResolvedValueOnce({});
+      const r = await recordNotification({
+        category: "contact",
+        title: "New contact",
+        message: "Themis says hi",
+        actor: "t@x",
+        route: "/api/contact",
+        metadata: { ua: "curl" },
+      });
+      expect(r).not.toBeNull();
+      expect(putCalls).toHaveLength(1);
+      const input = putCalls[0] as { TableName: string; Item: Record<string, { S?: string; BOOL?: boolean }> };
+      expect(input.TableName).toBe("test-notifs");
+      expect(input.Item.pk.S).toBe("NOTIF");
+      expect(input.Item.catPk.S).toBe("CAT#contact");
+      expect(input.Item.category.S).toBe("contact");
+      expect(input.Item.title.S).toBe("New contact");
+      expect(input.Item.message.S).toBe("Themis says hi");
+      expect(input.Item.actor.S).toBe("t@x");
+      expect(input.Item.route.S).toBe("/api/contact");
+      expect(input.Item.read.BOOL).toBe(false);
+      expect(JSON.parse(input.Item.metadata.S ?? "{}")).toEqual({ ua: "curl" });
+    });
+
+    it("defaults type to 'info' when not provided", async () => {
+      mockDynamoSend.mockResolvedValueOnce({});
+      await recordNotification({ category: "subscribe", title: "T", message: "M" });
+      const input = putCalls[0] as { Item: Record<string, { S?: string }> };
+      expect(input.Item.type.S).toBe("info");
+    });
+
+    it("omits optional fields when not provided", async () => {
+      mockDynamoSend.mockResolvedValueOnce({});
+      await recordNotification({ category: "order", title: "T", message: "M" });
+      const input = putCalls[0] as { Item: Record<string, unknown> };
+      expect(input.Item.actor).toBeUndefined();
+      expect(input.Item.route).toBeUndefined();
+      expect(input.Item.metadata).toBeUndefined();
+    });
+
+    it("returns null when Dynamo throws (producer paths must not crash)", async () => {
+      mockDynamoSend.mockRejectedValueOnce(new Error("ThrottlingException"));
+      const r = await recordNotification({ category: "error", title: "T", message: "M" });
+      expect(r).toBeNull();
+    });
+
+    it("generates unique ids across calls", async () => {
+      mockDynamoSend.mockResolvedValue({});
+      const a = await recordNotification({ category: "auth", title: "T", message: "M" });
+      const b = await recordNotification({ category: "auth", title: "T", message: "M" });
+      expect(a?.id).not.toBe(b?.id);
+    });
+
+    it("encodes the sort key as <createdAt>#<id>", async () => {
+      mockDynamoSend.mockResolvedValueOnce({});
+      await recordNotification({ category: "portal", title: "T", message: "M" });
+      const input = putCalls[0] as { Item: Record<string, { S?: string }> };
+      const sk = input.Item.sk.S ?? "";
+      const createdAt = input.Item.createdAt.S ?? "";
+      expect(sk.startsWith(createdAt + "#")).toBe(true);
+    });
+  });
+
+  describe("listNotifications", () => {
+    it("queries the main partition newest-first by default", async () => {
+      mockDynamoSend.mockResolvedValueOnce({ Items: [] });
+      await listNotifications();
+      const q = queryCalls[0] as {
+        IndexName?: string;
+        ScanIndexForward: boolean;
+        Limit: number;
+        ExpressionAttributeValues: Record<string, { S: string }>;
+      };
+      expect(q.IndexName).toBeUndefined();
+      expect(q.ScanIndexForward).toBe(false);
+      expect(q.Limit).toBe(50);
+      expect(q.ExpressionAttributeValues[":pk"].S).toBe("NOTIF");
+    });
+
+    it("uses the category GSI when category filter is set", async () => {
+      mockDynamoSend.mockResolvedValueOnce({ Items: [] });
+      await listNotifications({ category: "order" });
+      const q = queryCalls[0] as {
+        IndexName?: string;
+        ExpressionAttributeValues: Record<string, { S: string }>;
+      };
+      expect(q.IndexName).toBe("categoryIndex");
+      expect(q.ExpressionAttributeValues[":cpk"].S).toBe("CAT#order");
+    });
+
+    it("clamps limit to the 1–200 range", async () => {
+      mockDynamoSend.mockResolvedValueOnce({ Items: [] });
+      await listNotifications({ limit: 5000 });
+      expect((queryCalls[0] as { Limit: number }).Limit).toBe(200);
+
+      mockDynamoSend.mockResolvedValueOnce({ Items: [] });
+      await listNotifications({ limit: -10 });
+      expect((queryCalls[1] as { Limit: number }).Limit).toBe(1);
+    });
+
+    it("filters out archived rows by default", async () => {
+      mockDynamoSend.mockResolvedValueOnce({ Items: [] });
+      await listNotifications();
+      const q = queryCalls[0] as { FilterExpression?: string };
+      expect(q.FilterExpression).toContain("attribute_not_exists(#archivedAt)");
+    });
+
+    it("includes archived rows when includeArchived=true", async () => {
+      mockDynamoSend.mockResolvedValueOnce({ Items: [] });
+      await listNotifications({ includeArchived: true });
+      const q = queryCalls[0] as { FilterExpression?: string };
+      expect(q.FilterExpression).toBeUndefined();
+    });
+
+    it("maps Dynamo items back into AdminNotification shape", async () => {
+      mockDynamoSend.mockResolvedValueOnce({
+        Items: [
+          {
+            id: { S: "n_1" },
+            createdAt: { S: "2026-06-12T10:00:00Z" },
+            category: { S: "contact" },
+            type: { S: "info" },
+            title: { S: "T" },
+            message: { S: "M" },
+            actor: { S: "a@b" },
+            route: { S: "/r" },
+            metadata: { S: '{"x":1}' },
+            read: { BOOL: false },
+          },
+        ],
+      });
+      const r = await listNotifications();
+      expect(r).toHaveLength(1);
+      expect(r[0]).toMatchObject({
+        id: "n_1",
+        category: "contact",
+        title: "T",
+        actor: "a@b",
+        route: "/r",
+        metadata: { x: 1 },
+      });
+    });
+
+    it("drops malformed metadata JSON silently", async () => {
+      mockDynamoSend.mockResolvedValueOnce({
+        Items: [
+          {
+            id: { S: "n_1" },
+            createdAt: { S: "2026-06-12T10:00:00Z" },
+            category: { S: "contact" },
+            type: { S: "info" },
+            title: { S: "T" },
+            message: { S: "M" },
+            metadata: { S: "{not json" },
+            read: { BOOL: false },
+          },
+        ],
+      });
+      const r = await listNotifications();
+      expect(r[0].metadata).toBeUndefined();
+    });
+  });
+
+  describe("markNotificationsRead", () => {
+    it("is a no-op when ids array is empty", async () => {
+      await markNotificationsRead([]);
+      expect(mockDynamoSend).not.toHaveBeenCalled();
+    });
+
+    it("looks up each row then updates its read flag", async () => {
+      mockDynamoSend
+        .mockResolvedValueOnce({
+          Items: [{ pk: { S: "NOTIF" }, sk: { S: "2026#n_1" } }],
+        })
+        .mockResolvedValueOnce({}); // UpdateItem
+      await markNotificationsRead(["n_1"]);
+      expect(queryCalls).toHaveLength(1);
+      expect(updateCalls).toHaveLength(1);
+      const u = updateCalls[0] as {
+        UpdateExpression: string;
+        ExpressionAttributeValues: Record<string, { BOOL?: boolean }>;
+      };
+      expect(u.UpdateExpression).toContain("SET");
+      expect(u.ExpressionAttributeValues[":true"].BOOL).toBe(true);
+    });
+
+    it("skips ids that don't exist (Items empty)", async () => {
+      mockDynamoSend.mockResolvedValueOnce({ Items: [] });
+      await markNotificationsRead(["missing"]);
+      expect(updateCalls).toHaveLength(0);
+    });
+  });
+
+  describe("notificationAnalytics", () => {
+    it("returns zero counts when no rows", async () => {
+      mockDynamoSend.mockResolvedValueOnce({ Items: [] });
+      const r = await notificationAnalytics({ since: "2026-06-01" });
+      expect(r.total).toBe(0);
+      expect(r.byCategory.contact).toBe(0);
+      expect(r.byCategory.order).toBe(0);
+      expect(r.byDay).toEqual({});
+    });
+
+    it("counts by category and by day", async () => {
+      mockDynamoSend.mockResolvedValueOnce({
+        Items: [
+          {
+            id: { S: "1" },
+            createdAt: { S: "2026-06-12T10:00:00Z" },
+            category: { S: "contact" },
+            type: { S: "info" },
+            title: { S: "T" },
+            message: { S: "M" },
+            read: { BOOL: false },
+          },
+          {
+            id: { S: "2" },
+            createdAt: { S: "2026-06-12T11:00:00Z" },
+            category: { S: "order" },
+            type: { S: "success" },
+            title: { S: "T" },
+            message: { S: "M" },
+            read: { BOOL: false },
+          },
+          {
+            id: { S: "3" },
+            createdAt: { S: "2026-06-11T10:00:00Z" },
+            category: { S: "contact" },
+            type: { S: "info" },
+            title: { S: "T" },
+            message: { S: "M" },
+            read: { BOOL: false },
+          },
+        ],
+      });
+      const r = await notificationAnalytics({ since: "2026-06-01" });
+      expect(r.total).toBe(3);
+      expect(r.byCategory.contact).toBe(2);
+      expect(r.byCategory.order).toBe(1);
+      expect(r.byDay["2026-06-12"]).toBe(2);
+      expect(r.byDay["2026-06-11"]).toBe(1);
+    });
+  });
+
+  describe("purgeArchivedOlderThan", () => {
+    it("returns 0 when no archived rows match", async () => {
+      mockDynamoSend.mockResolvedValueOnce({ Items: [] });
+      const n = await purgeArchivedOlderThan("2026-01-01");
+      expect(n).toBe(0);
+      expect(batchWriteCalls).toHaveLength(0);
+    });
+
+    it("batches deletes for matched archived rows", async () => {
+      mockDynamoSend
+        .mockResolvedValueOnce({
+          Items: [
+            { pk: { S: "NOTIF" }, sk: { S: "2025#a" } },
+            { pk: { S: "NOTIF" }, sk: { S: "2025#b" } },
+          ],
+        })
+        .mockResolvedValueOnce({}); // BatchWrite
+      const n = await purgeArchivedOlderThan("2026-01-01");
+      expect(n).toBe(2);
+      expect(batchWriteCalls).toHaveLength(1);
+      const bw = batchWriteCalls[0] as {
+        RequestItems: Record<string, Array<{ DeleteRequest: { Key: unknown } }>>;
+      };
+      expect(bw.RequestItems["test-notifs"]).toHaveLength(2);
+    });
+
+    it("walks LastEvaluatedKey across multiple pages", async () => {
+      mockDynamoSend
+        .mockResolvedValueOnce({
+          Items: [{ pk: { S: "NOTIF" }, sk: { S: "2025#a" } }],
+          LastEvaluatedKey: { pk: { S: "NOTIF" }, sk: { S: "2025#a" } },
+        })
+        .mockResolvedValueOnce({}) // BatchWrite 1
+        .mockResolvedValueOnce({
+          Items: [{ pk: { S: "NOTIF" }, sk: { S: "2025#b" } }],
+        })
+        .mockResolvedValueOnce({}); // BatchWrite 2
+      const n = await purgeArchivedOlderThan("2026-01-01");
+      expect(n).toBe(2);
+      expect(batchWriteCalls).toHaveLength(2);
+    });
+  });
+});

--- a/src/lib/admin-notifications.ts
+++ b/src/lib/admin-notifications.ts
@@ -1,0 +1,373 @@
+import {
+  DynamoDBClient,
+  PutItemCommand,
+  QueryCommand,
+  UpdateItemCommand,
+  BatchWriteItemCommand,
+  type AttributeValue,
+} from "@aws-sdk/client-dynamodb";
+import { resolveDynamoEndpoint } from "@/lib/stripe-transactions";
+
+/**
+ * Durable admin notifications store on DynamoDB.
+ *
+ * Schema:
+ *   - pk = "NOTIF"  (single partition — small scale, simpler queries)
+ *   - sk = "<createdAt-ISO8601>#<id>"  (sortable, unique)
+ *   - GSI categoryIndex: pk = "CAT#<category>", sk = "<createdAt-ISO8601>#<id>"
+ *
+ * Categories:
+ *   contact   — contact form submission
+ *   subscribe — newsletter sign-up
+ *   booking   — calendar booking
+ *   order     — Stripe paid checkout
+ *   error     — application exception
+ *   auth      — sign-up / sign-in / password reset
+ *   portal    — client-portal action
+ *
+ * Retention policy: 90 days hot in Dynamo. After 90 days, the daily archive
+ * cron job sets `archivedAt` and exports the row to S3 (see PR B). Rows with
+ * `archivedAt` set are excluded from the admin UI by default.
+ */
+
+export type NotificationCategory =
+  | "contact"
+  | "subscribe"
+  | "booking"
+  | "order"
+  | "error"
+  | "auth"
+  | "portal";
+
+export type NotificationType = "info" | "warning" | "error" | "success";
+
+export interface AdminNotification {
+  id: string;
+  createdAt: string; // ISO 8601
+  category: NotificationCategory;
+  type: NotificationType;
+  title: string;
+  message: string;
+  /** Optional actor (email / user id / system). */
+  actor?: string;
+  /** Optional route that fired the notification. */
+  route?: string;
+  /** Free-form structured payload for analytics. */
+  metadata?: Record<string, unknown>;
+  read: boolean;
+  /** Set by the archive cron when the row is exported to S3. */
+  archivedAt?: string;
+}
+
+const REGION = process.env.AWS_REGION || "us-east-1";
+
+let dynamoClient: DynamoDBClient | null = null;
+function getDynamoClient(): DynamoDBClient {
+  dynamoClient ??= new DynamoDBClient({
+    region: REGION,
+    endpoint: resolveDynamoEndpoint(),
+  });
+  return dynamoClient;
+}
+
+function getTableName(): string {
+  const name = process.env.ADMIN_NOTIFICATIONS_TABLE?.trim();
+  if (!name) throw new Error("ADMIN_NOTIFICATIONS_TABLE is not configured");
+  return name;
+}
+
+const PK_ALL = "NOTIF";
+const CAT_INDEX = "categoryIndex";
+
+function randomId(): string {
+  return `n_${Date.now()}_${Math.random().toString(36).slice(2, 10)}`;
+}
+
+function buildSk(createdAt: string, id: string): string {
+  return `${createdAt}#${id}`;
+}
+
+function toItem(notif: AdminNotification): Record<string, AttributeValue> {
+  const item: Record<string, AttributeValue> = {
+    pk: { S: PK_ALL },
+    sk: { S: buildSk(notif.createdAt, notif.id) },
+    catPk: { S: `CAT#${notif.category}` },
+    catSk: { S: buildSk(notif.createdAt, notif.id) },
+    id: { S: notif.id },
+    createdAt: { S: notif.createdAt },
+    category: { S: notif.category },
+    type: { S: notif.type },
+    title: { S: notif.title },
+    message: { S: notif.message },
+    read: { BOOL: notif.read },
+  };
+  if (notif.actor) item.actor = { S: notif.actor };
+  if (notif.route) item.route = { S: notif.route };
+  if (notif.metadata)
+    item.metadata = { S: JSON.stringify(notif.metadata) };
+  if (notif.archivedAt) item.archivedAt = { S: notif.archivedAt };
+  return item;
+}
+
+function fromItem(item: Record<string, AttributeValue>): AdminNotification {
+  let metadata: Record<string, unknown> | undefined;
+  const rawMeta = item.metadata?.S;
+  if (rawMeta) {
+    try {
+      metadata = JSON.parse(rawMeta) as Record<string, unknown>;
+    } catch {
+      // Malformed JSON — drop silently to keep the list useful.
+    }
+  }
+  return {
+    id: item.id?.S ?? "",
+    createdAt: item.createdAt?.S ?? "",
+    category: (item.category?.S ?? "error") as NotificationCategory,
+    type: (item.type?.S ?? "info") as NotificationType,
+    title: item.title?.S ?? "",
+    message: item.message?.S ?? "",
+    actor: item.actor?.S,
+    route: item.route?.S,
+    metadata,
+    read: item.read?.BOOL ?? false,
+    archivedAt: item.archivedAt?.S,
+  };
+}
+
+/**
+ * Append a notification. Failures are returned (not thrown) so producer paths
+ * can keep serving the user-facing response. Callers should log but not abort.
+ */
+export async function recordNotification(input: {
+  category: NotificationCategory;
+  type?: NotificationType;
+  title: string;
+  message: string;
+  actor?: string;
+  route?: string;
+  metadata?: Record<string, unknown>;
+}): Promise<AdminNotification | null> {
+  if (!process.env.ADMIN_NOTIFICATIONS_TABLE) {
+    // Table not configured (local dev, partial deploys) — caller can ignore.
+    return null;
+  }
+  try {
+    const notif: AdminNotification = {
+      id: randomId(),
+      createdAt: new Date().toISOString(),
+      category: input.category,
+      type: input.type ?? "info",
+      title: input.title,
+      message: input.message,
+      actor: input.actor,
+      route: input.route,
+      metadata: input.metadata,
+      read: false,
+    };
+    await getDynamoClient().send(
+      new PutItemCommand({
+        TableName: getTableName(),
+        Item: toItem(notif),
+      }),
+    );
+    return notif;
+  } catch (err) {
+    console.warn(
+      "[admin-notifications] recordNotification failed:",
+      err instanceof Error ? err.message : err,
+    );
+    return null;
+  }
+}
+
+export interface ListFilters {
+  category?: NotificationCategory;
+  since?: string;
+  until?: string;
+  limit?: number;
+  includeArchived?: boolean;
+  includeRead?: boolean;
+}
+
+/**
+ * Read recent notifications, newest first. Defaults to 50 most recent
+ * un-archived entries.
+ */
+export async function listNotifications(
+  filters: ListFilters = {},
+): Promise<AdminNotification[]> {
+  const limit = Math.min(Math.max(filters.limit ?? 50, 1), 200);
+  const useCategoryIndex = Boolean(filters.category);
+
+  const keyConditionParts: string[] = [];
+  const exprNames: Record<string, string> = {};
+  const exprValues: Record<string, AttributeValue> = {};
+
+  if (useCategoryIndex) {
+    keyConditionParts.push("#cpk = :cpk");
+    exprNames["#cpk"] = "catPk";
+    exprValues[":cpk"] = { S: `CAT#${filters.category}` };
+  } else {
+    keyConditionParts.push("#pk = :pk");
+    exprNames["#pk"] = "pk";
+    exprValues[":pk"] = { S: PK_ALL };
+  }
+
+  // Range condition on the sort key (which encodes createdAt).
+  if (filters.since && filters.until) {
+    keyConditionParts.push("#sk BETWEEN :since AND :until");
+    exprNames["#sk"] = useCategoryIndex ? "catSk" : "sk";
+    exprValues[":since"] = { S: `${filters.since}#` };
+    // End-of-range trick: append "~" so we capture every id with the
+    // until timestamp prefix.
+    exprValues[":until"] = { S: `${filters.until}~` };
+  } else if (filters.since) {
+    keyConditionParts.push("#sk >= :since");
+    exprNames["#sk"] = useCategoryIndex ? "catSk" : "sk";
+    exprValues[":since"] = { S: `${filters.since}#` };
+  }
+
+  const filterExpressions: string[] = [];
+  if (!filters.includeArchived) {
+    filterExpressions.push("attribute_not_exists(#archivedAt)");
+    exprNames["#archivedAt"] = "archivedAt";
+  }
+  if (!filters.includeRead) {
+    // Keep this opt-in too — by default the UI shows everything.
+  }
+
+  const out = await getDynamoClient().send(
+    new QueryCommand({
+      TableName: getTableName(),
+      IndexName: useCategoryIndex ? CAT_INDEX : undefined,
+      KeyConditionExpression: keyConditionParts.join(" AND "),
+      ...(filterExpressions.length
+        ? { FilterExpression: filterExpressions.join(" AND ") }
+        : {}),
+      ExpressionAttributeNames: exprNames,
+      ExpressionAttributeValues: exprValues,
+      Limit: limit,
+      ScanIndexForward: false, // newest first
+    }),
+  );
+
+  return (out.Items ?? []).map(fromItem);
+}
+
+/**
+ * Mark a set of notifications as read.
+ */
+export async function markNotificationsRead(ids: string[]): Promise<void> {
+  if (!ids.length || !process.env.ADMIN_NOTIFICATIONS_TABLE) return;
+  // We can't UpdateItem without the full sort key, so fetch + update.
+  // For small batches this is fine. (Optimization: store an idIndex GSI.)
+  for (const id of ids) {
+    const matches = await getDynamoClient().send(
+      new QueryCommand({
+        TableName: getTableName(),
+        KeyConditionExpression: "#pk = :pk",
+        FilterExpression: "#id = :id",
+        ExpressionAttributeNames: { "#pk": "pk", "#id": "id" },
+        ExpressionAttributeValues: {
+          ":pk": { S: PK_ALL },
+          ":id": { S: id },
+        },
+        Limit: 1,
+      }),
+    );
+    const item = matches.Items?.[0];
+    if (!item) continue;
+    await getDynamoClient().send(
+      new UpdateItemCommand({
+        TableName: getTableName(),
+        Key: { pk: item.pk, sk: item.sk },
+        UpdateExpression: "SET #read = :true",
+        ExpressionAttributeNames: { "#read": "read" },
+        ExpressionAttributeValues: { ":true": { BOOL: true } },
+      }),
+    );
+  }
+}
+
+/**
+ * Per-category counts over a window. Used by the admin analytics endpoint.
+ * Returns { total, byCategory: { contact: N, ... }, byDay: { '2026-06-12': N, ... } }.
+ */
+export async function notificationAnalytics(opts: {
+  since: string;
+  until?: string;
+} = { since: "" }): Promise<{
+  total: number;
+  byCategory: Record<NotificationCategory, number>;
+  byDay: Record<string, number>;
+}> {
+  const byCategory: Record<NotificationCategory, number> = {
+    contact: 0,
+    subscribe: 0,
+    booking: 0,
+    order: 0,
+    error: 0,
+    auth: 0,
+    portal: 0,
+  };
+  const byDay: Record<string, number> = {};
+  let total = 0;
+  const items = await listNotifications({
+    since: opts.since,
+    until: opts.until,
+    limit: 200,
+    includeArchived: true,
+  });
+  for (const n of items) {
+    total++;
+    byCategory[n.category]++;
+    const day = n.createdAt.slice(0, 10);
+    byDay[day] = (byDay[day] ?? 0) + 1;
+  }
+  return { total, byCategory, byDay };
+}
+
+/**
+ * Hard-delete archived rows older than `olderThan` (ISO 8601 cutoff).
+ * Called by the archive cron AFTER successful S3 export + grace window.
+ * Returns the number of rows deleted.
+ */
+export async function purgeArchivedOlderThan(olderThan: string): Promise<number> {
+  let purged = 0;
+  // Walk in batches of 25 (BatchWriteItem max).
+  let lastKey: Record<string, AttributeValue> | undefined;
+  do {
+    const page: QueryCommand = new QueryCommand({
+      TableName: getTableName(),
+      KeyConditionExpression: "#pk = :pk AND #sk < :until",
+      FilterExpression: "attribute_exists(#archivedAt) AND #archivedAt < :until",
+      ExpressionAttributeNames: {
+        "#pk": "pk",
+        "#sk": "sk",
+        "#archivedAt": "archivedAt",
+      },
+      ExpressionAttributeValues: {
+        ":pk": { S: PK_ALL },
+        ":until": { S: `${olderThan}~` },
+      },
+      ExclusiveStartKey: lastKey,
+      Limit: 25,
+    });
+    const res = await getDynamoClient().send(page);
+    const items = res.Items ?? [];
+    if (items.length) {
+      await getDynamoClient().send(
+        new BatchWriteItemCommand({
+          RequestItems: {
+            [getTableName()]: items.map((it) => ({
+              DeleteRequest: { Key: { pk: it.pk, sk: it.sk } },
+            })),
+          },
+        }),
+      );
+      purged += items.length;
+    }
+    lastKey = res.LastEvaluatedKey;
+  } while (lastKey);
+  return purged;
+}

--- a/sst.config.ts
+++ b/sst.config.ts
@@ -15,6 +15,7 @@ function buildSiteEnvironment(
   isProd: boolean,
   stripeTransactionsTableName: $util.Output<string>,
   userProfileTableName: $util.Output<string>,
+  adminNotificationsTableName: $util.Output<string>,
   authSecret?: $util.Output<string>,
   cognito?: {
     issuer: $util.Output<string>;
@@ -41,6 +42,7 @@ function buildSiteEnvironment(
     APP_VERSION: process.env.GITHUB_SHA ?? "local",
     STRIPE_TRANSACTIONS_TABLE: stripeTransactionsTableName,
     USER_PROFILE_TABLE: userProfileTableName,
+    ADMIN_NOTIFICATIONS_TABLE: adminNotificationsTableName,
     // Cloudflare Workers AI — consumed by /api/admin/ai/generate. Passed from
     // the deploy workflow env; the route returns 503 when absent.
     ...(process.env.CLOUDFLARE_ACCOUNT_ID && process.env.CLOUDFLARE_API_TOKEN
@@ -153,6 +155,26 @@ export default {
       primaryIndex: { hashKey: "userId" },
     });
 
+    // Durable admin notifications store — audit + analytics for every
+    // client-facing interaction (contact, subscribe, booking, order, error,
+    // auth, portal). 90-day hot retention, then archived to S3 via the
+    // notifications-archive cron (see src/lib/admin-notifications.ts).
+    //
+    // pk = "NOTIF", sk = "<createdAt-ISO8601>#<id>"
+    // GSI categoryIndex: catPk = "CAT#<category>", catSk = "<createdAt-ISO8601>#<id>"
+    const adminNotificationsTable = new sst.aws.Dynamo("AdminNotifications", {
+      fields: {
+        pk: "string",
+        sk: "string",
+        catPk: "string",
+        catSk: "string",
+      },
+      primaryIndex: { hashKey: "pk", rangeKey: "sk" },
+      globalIndexes: {
+        categoryIndex: { hashKey: "catPk", rangeKey: "catSk" },
+      },
+    });
+
     // -------------------------------------------------------------------------
     // Cognito User Pool — always-up AWS auth
     //
@@ -258,6 +280,7 @@ export default {
         isProd,
         stripeTransactionsTable.name,
         userProfileTable.name,
+        adminNotificationsTable.name,
         authSecret,
         {
           issuer: cognitoIssuer,
@@ -266,7 +289,7 @@ export default {
           domain: cognitoHostedDomain,
         }
       ),
-      link: [stripeTransactionsTable, userProfileTable],
+      link: [stripeTransactionsTable, userProfileTable, adminNotificationsTable],
       permissions: [
         {
           // Allow the Lambda server to invoke Bedrock Converse for the chat widget.
@@ -380,25 +403,4 @@ export default {
     //   - PRIMARY:   this SST stack (CloudFront -> Lambda).
     //   - SECONDARY: the Pi/k3s cluster, reachable on the public Tailscale
     //                Funnel (omv.tail8eb71.ts.net:443), serving the SAME
-    //                Next.js image.
-    //
-    // Failover is owned by Cloudflare (where the domain DNS lives), NOT by
-    // Route 53. A Cloudflare Load Balancer health-checks /api/health and steers
-    // traffic AWS -> Pi automatically. Provision/update it with
-    // scripts/setup-cloudflare-lb.sh (CI: .github/workflows/cloudflare-lb.yml).
-    //
-    // HISTORY: a Route 53 PRIMARY/SECONDARY record set used to live here, but
-    // the domain has never actually been delegated to Route 53 (it resolves via
-    // Cloudflare), so those records served no real traffic. The hosted zone
-    // Z079608614L53CC4EAZM3 was then deleted out-of-band on 2026-06-02, which
-    // broke every sst deploy (pulumi could no longer refresh the imported
-    // records). The dead block was removed in favour of the Cloudflare LB.
-
-    return {
-      url: site.url,
-      cognitoUserPoolId: userPool.id,
-      cognitoClientId: userPoolClient.id,
-      cognitoHostedDomain,
-    };
-  },
-} satisfies sst.Config;
+    //                Ne


### PR DESCRIPTION
**First of 3 PRs** migrating `/api/admin/notifications` from an unused in-memory ring buffer to a durable Dynamo-backed audit log.

Context: Cluster 1 audit (#842) flagged this page as the only ops-baseline page that was structurally broken — `pushNotification()` was exported but **never called anywhere in the codebase**. The list was always empty. User asked for audit + analytics on every client-facing interaction (contact, subscribe, booking, order, error, auth, portal).

Full design: [📘 KB — Admin notifications: durable client-interaction audit log on DynamoDB + S3/Athena](https://www.notion.so/37d7d82c410a8111af53dc57b92ae7ea)

## This PR is INFRA-ONLY and dormant by design

- `recordNotification()` returns `null` when `ADMIN_NOTIFICATIONS_TABLE` env is unset, so producer paths can call it safely before deploy.
- No producer routes are wired yet (PR A2).
- The existing `GET /api/admin/notifications` still reads the empty in-memory ring buffer (PR A3 refactors it).

## What landed

### Infra (sst.config.ts)
- New `sst.aws.Dynamo("AdminNotifications")` table with pk/sk + `categoryIndex` GSI
- Linked + env-wired into the `CloudlessSite` Lambda
- `ADMIN_NOTIFICATIONS_TABLE` env carried via `buildSiteEnvironment`

### Library (src/lib/admin-notifications.ts, 373 LOC)
- `recordNotification(input)` — append, returns null on error
- `listNotifications(filters)` — newest first, category + date range, archived-row exclusion by default, limit clamp 1..200
- `markNotificationsRead(ids)` — find-by-id then UpdateItem
- `notificationAnalytics({since, until})` — count by category + by day
- `purgeArchivedOlderThan(olderThan)` — BatchWrite delete pages, used by the future archive cron

### Tests (__tests__/admin-notifications.test.ts, 22 tests)
- `recordNotification`: no-op when env unset, Dynamo error → null, documented item shape, type default, optional fields omission, unique ids, sk format
- `listNotifications`: main partition vs categoryIndex, limit clamp, archived filter default, item shape mapping, malformed metadata
- `markNotificationsRead`: empty no-op, find+update flow, missing id
- `notificationAnalytics`: zero counts, by-category + by-day rollup
- `purgeArchivedOlderThan`: empty no-op, batch delete, pagination

All 22 Vitest tests pass locally.

## Cost

At projected 100k events/year (10 KB each, 1 GB/year total):
- Dynamo on-demand: ~$0.10/month
- S3 archive (>90 days, PR B): < $0.01/month
- Athena queries: ~$0.02/month
- **Total: < $0.15/month**

## Rollout sequence

| PR | Scope | Risk |
|---|---|---|
| **A1 (this)** | Infra + lib + tests | None — lib is dormant until producers wire it |
| A2 | Wire `recordNotification` into 7 producer routes (contact, subscribe, booking, order, error, auth, portal) | Low — producers swallow Dynamo errors |
| A3 | Refactor `/api/admin/notifications` route + admin page UI (filter, date range, analytics panel) | Medium — user-visible change |
| B (later) | Nightly archive cron → S3 + Athena lifecycle | Low — read-side falls back gracefully |