### PR TITLE
fix(sst): restore truncated tail of sst.config.ts

### DIFF
--- a/sst.config.ts
+++ b/sst.config.ts
@@ -403,4 +403,25 @@ export default {
     //   - PRIMARY:   this SST stack (CloudFront -> Lambda).
     //   - SECONDARY: the Pi/k3s cluster, reachable on the public Tailscale
     //                Funnel (omv.tail8eb71.ts.net:443), serving the SAME
-    //                Ne
+    //                Next.js image.
+    //
+    // Failover is owned by Cloudflare (where the domain DNS lives), NOT by
+    // Route 53. A Cloudflare Load Balancer health-checks /api/health and steers
+    // traffic AWS -> Pi automatically. Provision/update it with
+    // scripts/setup-cloudflare-lb.sh (CI: .github/workflows/cloudflare-lb.yml).
+    //
+    // HISTORY: a Route 53 PRIMARY/SECONDARY record set used to live here, but
+    // the domain has never actually been delegated to Route 53 (it resolves via
+    // Cloudflare), so those records served no real traffic. The hosted zone
+    // Z079608614L53CC4EAZM3 was then deleted out-of-band on 2026-06-02, which
+    // broke every sst deploy (pulumi could no longer refresh the imported
+    // records). The dead block was removed in favour of the Cloudflare LB.
+
+    return {
+      url: site.url,
+      cognitoUserPoolId: userPool.id,
+      cognitoClientId: userPoolClient.id,
+      cognitoHostedDomain,
+    };
+  },
+} satisfies sst.Config;


### PR DESCRIPTION
**HOTFIX** — PR #843 inadvertently truncated the last 22 lines of `sst.config.ts` during an Edit operation, leaving the file unterminated and breaking deploy with `Unexpected end of file at sst.config.ts:407:24`.

This commit reconstructs the missing trailing block (HA/failover comment + return statement + `satisfies sst.Config` closing) verbatim from `origin/main` pre-merge of #843. No other functional changes.

Verified: `wc -l sst.config.ts` is now 427 (was 405 broken / 404 original pre-A1). Diff vs pre-A1 main shows only the intended A1 additions (admin notifications table, env wiring, link). File ends with `} satisfies sst.Config;`.