### PR TITLE
feat(notifications): PR A3 — read from Dynamo, add analytics + UI filter

### DIFF
--- a/__tests__/admin-notifications-api.test.ts
+++ b/__tests__/admin-notifications-api.test.ts
@@ -1,82 +1,346 @@
 /**
- * Unit tests for GET/PATCH /api/admin/notifications
+ * Unit tests for GET/PATCH /api/admin/notifications and
+ * GET /api/admin/notifications/analytics
+ *
+ * The route handlers delegate to src/lib/admin-notifications. We mock that
+ * lib so these tests stay fast and don't need DynamoDB.
  */
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { NextRequest } from "next/server";
 
-const mockRequireAdmin = vi.fn();
+const { mockRequireAdmin, mockList, mockMarkRead, mockAnalytics } = vi.hoisted(() => ({
+  mockRequireAdmin: vi.fn(),
+  mockList: vi.fn(),
+  mockMarkRead: vi.fn(),
+  mockAnalytics: vi.fn(),
+}));
+
 vi.mock("@/lib/api-auth", () => ({
   requireAdmin: (...a: unknown[]) => mockRequireAdmin(...a),
   requireAuth: vi.fn(),
 }));
 
-function makeReq(method: string, body?: unknown) {
-  return new NextRequest("http://localhost/api/admin/notifications", {
+vi.mock("@/lib/admin-notifications", () => ({
+  listNotifications: (...a: unknown[]) => mockList(...a),
+  markNotificationsRead: (...a: unknown[]) => mockMarkRead(...a),
+  notificationAnalytics: (...a: unknown[]) => mockAnalytics(...a),
+}));
+
+function makeReq(url: string, method: string, body?: unknown) {
+  return new NextRequest(url, {
     method,
     headers: { "Content-Type": "application/json" },
     ...(body !== undefined ? { body: JSON.stringify(body) } : {}),
   });
 }
 
+const OK_ADMIN = { ok: true as const, user: { sub: "u1" } };
+
 describe("GET /api/admin/notifications", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    vi.resetModules();
+    process.env.ADMIN_NOTIFICATIONS_TABLE = "TestTable";
+  });
+  afterEach(() => {
+    delete process.env.ADMIN_NOTIFICATIONS_TABLE;
   });
 
   it("returns 401 when not admin", async () => {
-    mockRequireAdmin.mockResolvedValue({ ok: false, response: new Response(null, { status: 401 }) });
+    mockRequireAdmin.mockResolvedValue({
+      ok: false,
+      response: new Response(null, { status: 401 }),
+    });
     const { GET } = await import("@/app/api/admin/notifications/route");
-    const res = await GET(makeReq("GET"));
+    const res = await GET(makeReq("http://localhost/api/admin/notifications", "GET"));
     expect(res.status).toBe(401);
+    expect(mockList).not.toHaveBeenCalled();
   });
 
-  it("returns empty notifications list initially", async () => {
-    mockRequireAdmin.mockResolvedValue({ ok: true, user: { sub: "u1" } });
+  it("returns 503 when table not configured", async () => {
+    delete process.env.ADMIN_NOTIFICATIONS_TABLE;
+    mockRequireAdmin.mockResolvedValue(OK_ADMIN);
     const { GET } = await import("@/app/api/admin/notifications/route");
-    const res = await GET(makeReq("GET"));
-    expect(res.status).toBe(200);
-    const data = await res.json();
-    expect(Array.isArray(data.notifications)).toBe(true);
+    const res = await GET(makeReq("http://localhost/api/admin/notifications", "GET"));
+    expect(res.status).toBe(503);
   });
 
-  it("pushNotification adds to store, GET returns it", async () => {
-    mockRequireAdmin.mockResolvedValue({ ok: true, user: { sub: "u1" } });
-    const mod = await import("@/app/api/admin/notifications/route");
-    mod.pushNotification({ title: "Test", message: "Hello", type: "info" });
-    const res = await mod.GET(makeReq("GET"));
-    const data = await res.json();
-    expect(data.notifications.some((n: { title: string }) => n.title === "Test")).toBe(true);
+  it("returns the lib's list verbatim", async () => {
+    mockRequireAdmin.mockResolvedValue(OK_ADMIN);
+    mockList.mockResolvedValue([
+      {
+        id: "n_1",
+        createdAt: "2026-06-12T20:00:00Z",
+        category: "contact",
+        type: "info",
+        title: "T",
+        message: "M",
+        read: false,
+      },
+    ]);
+    const { GET } = await import("@/app/api/admin/notifications/route");
+    const res = await GET(makeReq("http://localhost/api/admin/notifications", "GET"));
+    expect(res.status).toBe(200);
+    const data = (await res.json()) as { notifications: { id: string }[] };
+    expect(data.notifications).toHaveLength(1);
+    expect(data.notifications[0].id).toBe("n_1");
+  });
+
+  it("forwards known category, since, until, limit to the lib", async () => {
+    mockRequireAdmin.mockResolvedValue(OK_ADMIN);
+    mockList.mockResolvedValue([]);
+    const { GET } = await import("@/app/api/admin/notifications/route");
+    await GET(
+      makeReq(
+        "http://localhost/api/admin/notifications?category=order&since=2026-06-01T00:00:00Z&until=2026-06-12T00:00:00Z&limit=25&includeArchived=1",
+        "GET",
+      ),
+    );
+    expect(mockList).toHaveBeenCalledWith({
+      category: "order",
+      since: "2026-06-01T00:00:00Z",
+      until: "2026-06-12T00:00:00Z",
+      limit: 25,
+      includeArchived: true,
+    });
+  });
+
+  it("drops unknown category and unparseable dates", async () => {
+    mockRequireAdmin.mockResolvedValue(OK_ADMIN);
+    mockList.mockResolvedValue([]);
+    const { GET } = await import("@/app/api/admin/notifications/route");
+    await GET(
+      makeReq(
+        "http://localhost/api/admin/notifications?category=banana&since=not-a-date&limit=abc",
+        "GET",
+      ),
+    );
+    expect(mockList).toHaveBeenCalledWith({
+      category: undefined,
+      since: undefined,
+      until: undefined,
+      limit: undefined,
+      includeArchived: false,
+    });
+  });
+
+  it("clamps limit to 1..200", async () => {
+    mockRequireAdmin.mockResolvedValue(OK_ADMIN);
+    mockList.mockResolvedValue([]);
+    const { GET } = await import("@/app/api/admin/notifications/route");
+    await GET(makeReq("http://localhost/api/admin/notifications?limit=9999", "GET"));
+    expect(mockList).toHaveBeenCalledWith(expect.objectContaining({ limit: 200 }));
+    await GET(makeReq("http://localhost/api/admin/notifications?limit=0", "GET"));
+    expect(mockList).toHaveBeenLastCalledWith(expect.objectContaining({ limit: 1 }));
+  });
+
+  it("returns 500 when the lib throws", async () => {
+    mockRequireAdmin.mockResolvedValue(OK_ADMIN);
+    mockList.mockRejectedValue(new Error("dynamo down"));
+    const { GET } = await import("@/app/api/admin/notifications/route");
+    const res = await GET(makeReq("http://localhost/api/admin/notifications", "GET"));
+    expect(res.status).toBe(500);
   });
 });
 
 describe("PATCH /api/admin/notifications", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    vi.resetModules();
+    process.env.ADMIN_NOTIFICATIONS_TABLE = "TestTable";
+  });
+  afterEach(() => {
+    delete process.env.ADMIN_NOTIFICATIONS_TABLE;
   });
 
   it("returns 401 when not admin", async () => {
-    mockRequireAdmin.mockResolvedValue({ ok: false, response: new Response(null, { status: 401 }) });
+    mockRequireAdmin.mockResolvedValue({
+      ok: false,
+      response: new Response(null, { status: 401 }),
+    });
     const { PATCH } = await import("@/app/api/admin/notifications/route");
-    const res = await PATCH(makeReq("PATCH", { markAllRead: true }));
+    const res = await PATCH(
+      makeReq("http://localhost/api/admin/notifications", "PATCH", { markAllRead: true }),
+    );
     expect(res.status).toBe(401);
   });
 
-  it("marks all notifications read", async () => {
-    mockRequireAdmin.mockResolvedValue({ ok: true, user: { sub: "u1" } });
-    const mod = await import("@/app/api/admin/notifications/route");
-    mod.pushNotification({ title: "T1", message: "M1", type: "warning" });
-    const res = await mod.PATCH(makeReq("PATCH", { markAllRead: true }));
-    expect(res.status).toBe(200);
-    const data = await res.json();
-    expect(data.success).toBe(true);
+  it("returns 503 when table not configured", async () => {
+    delete process.env.ADMIN_NOTIFICATIONS_TABLE;
+    mockRequireAdmin.mockResolvedValue(OK_ADMIN);
+    const { PATCH } = await import("@/app/api/admin/notifications/route");
+    const res = await PATCH(
+      makeReq("http://localhost/api/admin/notifications", "PATCH", { id: "x" }),
+    );
+    expect(res.status).toBe(503);
   });
 
-  it("returns 400 when neither id nor markAllRead provided", async () => {
-    mockRequireAdmin.mockResolvedValue({ ok: true, user: { sub: "u1" } });
+  it("returns 400 on invalid JSON", async () => {
+    mockRequireAdmin.mockResolvedValue(OK_ADMIN);
     const { PATCH } = await import("@/app/api/admin/notifications/route");
-    const res = await PATCH(makeReq("PATCH", {}));
+    const req = new NextRequest("http://localhost/api/admin/notifications", {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: "{not-json",
+    });
+    const res = await PATCH(req);
     expect(res.status).toBe(400);
+  });
+
+  it("returns 400 when neither id nor ids nor markAllRead provided", async () => {
+    mockRequireAdmin.mockResolvedValue(OK_ADMIN);
+    const { PATCH } = await import("@/app/api/admin/notifications/route");
+    const res = await PATCH(makeReq("http://localhost/api/admin/notifications", "PATCH", {}));
+    expect(res.status).toBe(400);
+  });
+
+  it("marks a single id read", async () => {
+    mockRequireAdmin.mockResolvedValue(OK_ADMIN);
+    mockMarkRead.mockResolvedValue(undefined);
+    const { PATCH } = await import("@/app/api/admin/notifications/route");
+    const res = await PATCH(
+      makeReq("http://localhost/api/admin/notifications", "PATCH", { id: "n_1" }),
+    );
+    expect(res.status).toBe(200);
+    expect(mockMarkRead).toHaveBeenCalledWith(["n_1"]);
+  });
+
+  it("marks a batch of ids read", async () => {
+    mockRequireAdmin.mockResolvedValue(OK_ADMIN);
+    mockMarkRead.mockResolvedValue(undefined);
+    const { PATCH } = await import("@/app/api/admin/notifications/route");
+    await PATCH(
+      makeReq("http://localhost/api/admin/notifications", "PATCH", { ids: ["a", "b", "c"] }),
+    );
+    expect(mockMarkRead).toHaveBeenCalledWith(["a", "b", "c"]);
+  });
+
+  it("markAllRead fetches unread + marks them", async () => {
+    mockRequireAdmin.mockResolvedValue(OK_ADMIN);
+    mockList.mockResolvedValue([
+      { id: "u1", read: false },
+      { id: "u2", read: false },
+      { id: "r1", read: true },
+    ]);
+    mockMarkRead.mockResolvedValue(undefined);
+    const { PATCH } = await import("@/app/api/admin/notifications/route");
+    const res = await PATCH(
+      makeReq("http://localhost/api/admin/notifications", "PATCH", { markAllRead: true }),
+    );
+    expect(res.status).toBe(200);
+    const data = (await res.json()) as { updated: number };
+    expect(data.updated).toBe(2);
+    expect(mockMarkRead).toHaveBeenCalledWith(["u1", "u2"]);
+  });
+
+  it("returns 500 when the lib throws", async () => {
+    mockRequireAdmin.mockResolvedValue(OK_ADMIN);
+    mockMarkRead.mockRejectedValue(new Error("boom"));
+    const { PATCH } = await import("@/app/api/admin/notifications/route");
+    const res = await PATCH(
+      makeReq("http://localhost/api/admin/notifications", "PATCH", { id: "n_1" }),
+    );
+    expect(res.status).toBe(500);
+  });
+});
+
+describe("GET /api/admin/notifications/analytics", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env.ADMIN_NOTIFICATIONS_TABLE = "TestTable";
+  });
+  afterEach(() => {
+    delete process.env.ADMIN_NOTIFICATIONS_TABLE;
+  });
+
+  it("returns 401 when not admin", async () => {
+    mockRequireAdmin.mockResolvedValue({
+      ok: false,
+      response: new Response(null, { status: 401 }),
+    });
+    const { GET } = await import("@/app/api/admin/notifications/analytics/route");
+    const res = await GET(
+      makeReq("http://localhost/api/admin/notifications/analytics", "GET"),
+    );
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 503 when table not configured", async () => {
+    delete process.env.ADMIN_NOTIFICATIONS_TABLE;
+    mockRequireAdmin.mockResolvedValue(OK_ADMIN);
+    const { GET } = await import("@/app/api/admin/notifications/analytics/route");
+    const res = await GET(
+      makeReq("http://localhost/api/admin/notifications/analytics", "GET"),
+    );
+    expect(res.status).toBe(503);
+  });
+
+  it("uses a default 7-day window when no since/until provided", async () => {
+    mockRequireAdmin.mockResolvedValue(OK_ADMIN);
+    mockAnalytics.mockResolvedValue({
+      total: 0,
+      byCategory: {
+        contact: 0,
+        subscribe: 0,
+        booking: 0,
+        order: 0,
+        error: 0,
+        auth: 0,
+        portal: 0,
+      },
+      byDay: {},
+    });
+    const { GET } = await import("@/app/api/admin/notifications/analytics/route");
+    const res = await GET(
+      makeReq("http://localhost/api/admin/notifications/analytics", "GET"),
+    );
+    expect(res.status).toBe(200);
+    const data = (await res.json()) as {
+      window: { since: string; until: string };
+      total: number;
+    };
+    const sevenDays = 7 * 24 * 60 * 60 * 1000;
+    const span = Date.parse(data.window.until) - Date.parse(data.window.since);
+    expect(Math.abs(span - sevenDays)).toBeLessThan(5_000);
+    expect(data.total).toBe(0);
+  });
+
+  it("respects explicit since/until", async () => {
+    mockRequireAdmin.mockResolvedValue(OK_ADMIN);
+    mockAnalytics.mockResolvedValue({
+      total: 3,
+      byCategory: {
+        contact: 1,
+        subscribe: 0,
+        booking: 0,
+        order: 2,
+        error: 0,
+        auth: 0,
+        portal: 0,
+      },
+      byDay: { "2026-06-10": 1, "2026-06-11": 2 },
+    });
+    const { GET } = await import("@/app/api/admin/notifications/analytics/route");
+    const res = await GET(
+      makeReq(
+        "http://localhost/api/admin/notifications/analytics?since=2026-06-10T00:00:00Z&until=2026-06-12T00:00:00Z",
+        "GET",
+      ),
+    );
+    expect(res.status).toBe(200);
+    expect(mockAnalytics).toHaveBeenCalledWith({
+      since: "2026-06-10T00:00:00Z",
+      until: "2026-06-12T00:00:00Z",
+    });
+    const data = (await res.json()) as { total: number };
+    expect(data.total).toBe(3);
+  });
+
+  it("returns 500 when the lib throws", async () => {
+    mockRequireAdmin.mockResolvedValue(OK_ADMIN);
+    mockAnalytics.mockRejectedValue(new Error("boom"));
+    const { GET } = await import("@/app/api/admin/notifications/analytics/route");
+    const res = await GET(
+      makeReq("http://localhost/api/admin/notifications/analytics", "GET"),
+    );
+    expect(res.status).toBe(500);
   });
 });

--- a/src/app/[locale]/admin/notifications/page.tsx
+++ b/src/app/[locale]/admin/notifications/page.tsx
@@ -1,35 +1,130 @@
 "use client";
 
 import { fetchWithAuth } from "@/lib/fetch-with-auth";
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
+
+type Category = "contact" | "subscribe" | "booking" | "order" | "error" | "auth" | "portal";
+
+const CATEGORIES: { value: Category | "all"; label: string }[] = [
+  { value: "all", label: "All" },
+  { value: "contact", label: "Contact" },
+  { value: "subscribe", label: "Subscribe" },
+  { value: "booking", label: "Booking" },
+  { value: "order", label: "Order" },
+  { value: "auth", label: "Auth" },
+  { value: "portal", label: "Portal" },
+  { value: "error", label: "Error" },
+];
+
+const WINDOWS: { value: number; label: string }[] = [
+  { value: 1, label: "24h" },
+  { value: 7, label: "7d" },
+  { value: 30, label: "30d" },
+  { value: 90, label: "90d" },
+];
 
 interface Notification {
   id: string;
   title: string;
   message: string;
-  type: string;
+  category: Category;
+  type: "info" | "warning" | "error" | "success";
   read: boolean;
   createdAt: string;
+  actor?: string;
+  route?: string;
+}
+
+interface Analytics {
+  window: { since: string; until: string };
+  total: number;
+  byCategory: Record<Category, number>;
+  byDay: Record<string, number>;
+}
+
+function windowSinceISO(days: number): string {
+  return new Date(Date.now() - days * 24 * 60 * 60 * 1000).toISOString();
+}
+
+function ringForType(type: Notification["type"]): string {
+  switch (type) {
+    case "error":
+      return "border-red-500/30 bg-red-500/5";
+    case "warning":
+      return "border-yellow-500/30 bg-yellow-500/5";
+    case "success":
+      return "border-emerald-500/30 bg-emerald-500/5";
+    default:
+      return "border-neon-magenta/20 bg-neon-magenta/5";
+  }
 }
 
 export default function NotificationsPage() {
   const [notifications, setNotifications] = useState<Notification[]>([]);
+  const [analytics, setAnalytics] = useState<Analytics | null>(null);
+  const [category, setCategory] = useState<Category | "all">("all");
+  const [windowDays, setWindowDays] = useState<number>(7);
   const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const since = useMemo(() => windowSinceISO(windowDays), [windowDays]);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const listParams = new URLSearchParams({ since, limit: "100" });
+      if (category !== "all") listParams.set("category", category);
+      const analyticsParams = new URLSearchParams({ since });
+
+      const [listRes, statsRes] = await Promise.all([
+        fetchWithAuth(`/api/admin/notifications?${listParams.toString()}`),
+        fetchWithAuth(`/api/admin/notifications/analytics?${analyticsParams.toString()}`),
+      ]);
+
+      if (listRes.status === 503 || statsRes.status === 503) {
+        setError("Notifications store not configured yet -- check back after deploy completes.");
+        setNotifications([]);
+        setAnalytics(null);
+        return;
+      }
+
+      const listJson = (await listRes.json()) as { notifications?: Notification[] };
+      const statsJson = (await statsRes.json()) as Analytics;
+      setNotifications(listJson.notifications ?? []);
+      setAnalytics(statsJson);
+    } catch (e) {
+      console.error("[notifications] load failed", e);
+      setError("Failed to load notifications");
+    } finally {
+      setLoading(false);
+    }
+  }, [category, since]);
 
   useEffect(() => {
-    fetchWithAuth("/api/admin/notifications")
-      .then((r) => r.json())
-      .then((d) => setNotifications(d.notifications ?? []))
-      .finally(() => setLoading(false));
-  }, []);
+    void load();
+  }, [load]);
 
-  if (loading) {
-    return (
-      <div className="flex items-center justify-center py-16">
-        <div className="border-neon-magenta h-6 w-6 animate-spin rounded-full border-2 border-t-transparent" />
-      </div>
-    );
-  }
+  const markAllRead = async () => {
+    await fetchWithAuth("/api/admin/notifications", {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ markAllRead: true }),
+    });
+    void load();
+  };
+
+  const markOne = async (id: string) => {
+    await fetchWithAuth("/api/admin/notifications", {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ id }),
+    });
+    void load();
+  };
+
+  const days = analytics ? Object.keys(analytics.byDay).sort() : [];
+  const maxDay = days.length ? Math.max(...days.map((d) => analytics!.byDay[d])) : 0;
 
   return (
     <div>
@@ -39,33 +134,145 @@ export default function NotificationsPage() {
           <span className="text-neon-magenta font-mono text-xs">NOTIFICATIONS</span>
         </div>
         <h1 className="font-heading text-2xl font-bold text-white">Notifications</h1>
+        <p className="mt-1 font-mono text-xs text-slate-500">
+          Durable audit log of client interactions and captured errors. 90-day hot window in
+          DynamoDB; older rows archived to S3.
+        </p>
       </div>
 
-      {notifications.length === 0 ? (
+      <div className="mb-6 flex flex-wrap items-center gap-2">
+        <div className="flex flex-wrap gap-1.5">
+          {CATEGORIES.map((c) => (
+            <button
+              key={c.value}
+              onClick={() => setCategory(c.value)}
+              className={`rounded-full border px-3 py-1 font-mono text-xs transition ${
+                category === c.value
+                  ? "border-neon-magenta bg-neon-magenta/20 text-white"
+                  : "border-slate-700 text-slate-400 hover:border-slate-500"
+              }`}
+            >
+              {c.label}
+              {analytics && c.value !== "all" && (
+                <span className="ml-1.5 text-slate-500">{analytics.byCategory[c.value]}</span>
+              )}
+            </button>
+          ))}
+        </div>
+        <div className="ml-auto flex items-center gap-2">
+          <div className="flex gap-1">
+            {WINDOWS.map((w) => (
+              <button
+                key={w.value}
+                onClick={() => setWindowDays(w.value)}
+                className={`rounded border px-2 py-1 font-mono text-[10px] transition ${
+                  windowDays === w.value
+                    ? "border-neon-magenta bg-neon-magenta/10 text-white"
+                    : "border-slate-700 text-slate-400 hover:border-slate-500"
+                }`}
+              >
+                {w.label}
+              </button>
+            ))}
+          </div>
+          <button
+            onClick={markAllRead}
+            className="rounded border border-slate-700 px-2 py-1 font-mono text-[10px] text-slate-400 hover:border-slate-500 hover:text-white"
+          >
+            Mark all read
+          </button>
+        </div>
+      </div>
+
+      {analytics && (
+        <div className="mb-6 rounded-xl border border-slate-800 bg-slate-900/30 p-4">
+          <div className="mb-3 flex items-baseline justify-between">
+            <div>
+              <div className="font-mono text-[10px] uppercase tracking-wider text-slate-500">
+                Last {windowDays}d
+              </div>
+              <div className="font-heading text-2xl font-bold text-white">
+                {analytics.total} events
+              </div>
+            </div>
+            <div className="font-mono text-[10px] text-slate-500">
+              {new Date(analytics.window.since).toLocaleDateString()} to{" "}
+              {new Date(analytics.window.until).toLocaleDateString()}
+            </div>
+          </div>
+          {days.length > 0 && (
+            <div className="flex items-end gap-1">
+              {days.map((d) => {
+                const count = analytics.byDay[d];
+                const height = maxDay > 0 ? Math.max(6, Math.round((count / maxDay) * 48)) : 6;
+                return (
+                  <div key={d} className="flex flex-1 flex-col items-center gap-1">
+                    <div
+                      title={`${d}: ${count}`}
+                      className="bg-neon-magenta/60 w-full rounded-sm"
+                      style={{ height: `${height}px` }}
+                    />
+                    <div className="font-mono text-[9px] text-slate-600">{d.slice(5)}</div>
+                  </div>
+                );
+              })}
+            </div>
+          )}
+        </div>
+      )}
+
+      {loading ? (
+        <div className="flex items-center justify-center py-16">
+          <div className="border-neon-magenta h-6 w-6 animate-spin rounded-full border-2 border-t-transparent" />
+        </div>
+      ) : error ? (
+        <div className="rounded-xl border border-yellow-500/30 bg-yellow-500/5 p-6 text-center">
+          <p className="font-mono text-sm text-yellow-200">{error}</p>
+        </div>
+      ) : notifications.length === 0 ? (
         <div className="rounded-xl border border-slate-800 p-12 text-center">
-          <p className="font-mono text-sm text-slate-500">No notifications yet.</p>
+          <p className="font-mono text-sm text-slate-500">
+            No notifications in the selected window.
+          </p>
         </div>
       ) : (
-        <div className="space-y-3">
+        <div className="space-y-2">
           {notifications.map((n) => (
             <div
               key={n.id}
-              className={`rounded-xl border p-4 ${
-                n.read
-                  ? "border-slate-800 bg-slate-900/20"
-                  : "border-neon-magenta/20 bg-neon-magenta/5"
+              className={`rounded-xl border p-4 transition ${
+                n.read ? "border-slate-800 bg-slate-900/20" : ringForType(n.type)
               }`}
             >
-              <div className="mb-1 flex items-center justify-between">
+              <div className="mb-1 flex items-center justify-between gap-3">
                 <div className="flex items-center gap-2">
                   {!n.read && <span className="bg-neon-magenta h-2 w-2 rounded-full" />}
+                  <span className="rounded border border-slate-700 px-1.5 py-0.5 font-mono text-[9px] uppercase text-slate-400">
+                    {n.category}
+                  </span>
                   <span className="font-mono text-sm font-semibold text-white">{n.title}</span>
                 </div>
-                <span className="font-mono text-[10px] text-slate-500">
-                  {new Date(n.createdAt).toLocaleDateString()}
-                </span>
+                <div className="flex items-center gap-2">
+                  <span className="font-mono text-[10px] text-slate-500">
+                    {new Date(n.createdAt).toLocaleString()}
+                  </span>
+                  {!n.read && (
+                    <button
+                      onClick={() => markOne(n.id)}
+                      className="font-mono text-[10px] text-slate-500 hover:text-white"
+                    >
+                      mark read
+                    </button>
+                  )}
+                </div>
               </div>
               <p className="font-mono text-xs text-slate-400">{n.message}</p>
+              {(n.actor || n.route) && (
+                <div className="mt-1.5 flex gap-3 font-mono text-[10px] text-slate-600">
+                  {n.actor && <span>by {n.actor}</span>}
+                  {n.route && <span>via {n.route}</span>}
+                </div>
+              )}
             </div>
           ))}
         </div>

--- a/src/app/api/admin/notifications/analytics/route.ts
+++ b/src/app/api/admin/notifications/analytics/route.ts
@@ -1,0 +1,53 @@
+import { NextRequest, NextResponse } from "next/server";
+import { requireAdmin } from "@/lib/api-auth";
+import { notificationAnalytics } from "@/lib/admin-notifications";
+
+const DEFAULT_WINDOW_DAYS = 7;
+
+function parseIso(raw: string | null): string | undefined {
+  if (!raw) return undefined;
+  return Number.isFinite(Date.parse(raw)) ? raw : undefined;
+}
+
+/**
+ * GET /api/admin/notifications/analytics
+ *   ?since=<ISO 8601, default = now - 7 days>
+ *   ?until=<ISO 8601, default = now>
+ *
+ * Returns aggregate counts for the admin dashboard panel:
+ *   { window: { since, until }, total, byCategory: {...}, byDay: {...} }
+ */
+export async function GET(request: NextRequest) {
+  const auth = await requireAdmin(request);
+  if (!auth.ok) return auth.response;
+
+  if (!process.env.ADMIN_NOTIFICATIONS_TABLE) {
+    return NextResponse.json(
+      { error: "Notifications store not configured" },
+      { status: 503 },
+    );
+  }
+
+  const url = new URL(request.url);
+  const sinceParam = parseIso(url.searchParams.get("since"));
+  const untilParam = parseIso(url.searchParams.get("until"));
+
+  const until = untilParam ?? new Date().toISOString();
+  const since =
+    sinceParam ??
+    new Date(Date.now() - DEFAULT_WINDOW_DAYS * 24 * 60 * 60 * 1000).toISOString();
+
+  try {
+    const stats = await notificationAnalytics({ since, until });
+    return NextResponse.json({ window: { since, until }, ...stats });
+  } catch (err) {
+    console.error("[admin-notifications] analytics failed:", err);
+    return NextResponse.json(
+      { error: "Failed to compute analytics" },
+      { status: 500 },
+    );
+  }
+}
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";

--- a/src/app/api/admin/notifications/route.ts
+++ b/src/app/api/admin/notifications/route.ts
@@ -1,56 +1,141 @@
 import { NextRequest, NextResponse } from "next/server";
 import { requireAdmin } from "@/lib/api-auth";
+import {
+  listNotifications,
+  markNotificationsRead,
+  type AdminNotification,
+  type NotificationCategory,
+} from "@/lib/admin-notifications";
 
-export interface AdminNotification {
-  id: string;
-  title: string;
-  message: string;
-  type: "info" | "warning" | "error" | "success";
-  read: boolean;
-  createdAt: string;
+export type { AdminNotification };
+
+const KNOWN_CATEGORIES: ReadonlySet<NotificationCategory> = new Set<NotificationCategory>([
+  "contact",
+  "subscribe",
+  "booking",
+  "order",
+  "error",
+  "auth",
+  "portal",
+]);
+
+function parseCategory(raw: string | null): NotificationCategory | undefined {
+  if (!raw) return undefined;
+  return KNOWN_CATEGORIES.has(raw as NotificationCategory)
+    ? (raw as NotificationCategory)
+    : undefined;
 }
 
-// In-memory ring buffer — survives Lambda warm containers, resets on cold start.
-// This is intentionally lightweight: persistent storage would require a DB.
-const MAX_NOTIFICATIONS = 50;
-const notificationStore: AdminNotification[] = [];
-
-export function pushNotification(n: Omit<AdminNotification, "id" | "read" | "createdAt">): void {
-  const entry: AdminNotification = {
-    ...n,
-    id: `notif_${Date.now()}_${Math.random().toString(36).slice(2, 7)}`,
-    read: false,
-    createdAt: new Date().toISOString(),
-  };
-  notificationStore.unshift(entry);
-  if (notificationStore.length > MAX_NOTIFICATIONS) {
-    notificationStore.length = MAX_NOTIFICATIONS;
-  }
+function parseIsoOrUndef(raw: string | null): string | undefined {
+  if (!raw) return undefined;
+  return Number.isFinite(Date.parse(raw)) ? raw : undefined;
 }
 
+function parseLimit(raw: string | null): number | undefined {
+  if (!raw) return undefined;
+  const n = Number.parseInt(raw, 10);
+  if (!Number.isFinite(n)) return undefined;
+  return Math.min(Math.max(n, 1), 200);
+}
+
+/**
+ * GET /api/admin/notifications
+ *   ?category=contact|subscribe|booking|order|error|auth|portal
+ *   ?since=<ISO 8601>
+ *   ?until=<ISO 8601>
+ *   ?limit=<1..200, default 50>
+ *   ?includeArchived=1
+ *
+ * Reads from the Dynamo audit log (see src/lib/admin-notifications.ts).
+ * Returns 503 when the table is not configured (local dev, partial deploys).
+ */
 export async function GET(request: NextRequest) {
   const auth = await requireAdmin(request);
   if (!auth.ok) return auth.response;
 
-  return NextResponse.json({ notifications: notificationStore });
+  if (!process.env.ADMIN_NOTIFICATIONS_TABLE) {
+    return NextResponse.json(
+      { error: "Notifications store not configured" },
+      { status: 503 },
+    );
+  }
+
+  const url = new URL(request.url);
+  const params = url.searchParams;
+
+  try {
+    const notifications = await listNotifications({
+      category: parseCategory(params.get("category")),
+      since: parseIsoOrUndef(params.get("since")),
+      until: parseIsoOrUndef(params.get("until")),
+      limit: parseLimit(params.get("limit")),
+      includeArchived: params.get("includeArchived") === "1",
+    });
+    return NextResponse.json({ notifications });
+  } catch (err) {
+    console.error("[admin-notifications] GET failed:", err);
+    return NextResponse.json(
+      { error: "Failed to load notifications" },
+      { status: 500 },
+    );
+  }
 }
 
+/**
+ * PATCH /api/admin/notifications
+ *   body: { id?: string } | { ids?: string[] } | { markAllRead?: true }
+ */
 export async function PATCH(request: NextRequest) {
   const auth = await requireAdmin(request);
   if (!auth.ok) return auth.response;
 
-  const body = (await request.json()) as { id?: string; markAllRead?: boolean };
-
-  if (body.markAllRead) {
-    for (const n of notificationStore) n.read = true;
-    return NextResponse.json({ success: true });
+  if (!process.env.ADMIN_NOTIFICATIONS_TABLE) {
+    return NextResponse.json(
+      { error: "Notifications store not configured" },
+      { status: 503 },
+    );
   }
 
-  if (body.id) {
-    const notif = notificationStore.find((n) => n.id === body.id);
-    if (notif) notif.read = true;
-    return NextResponse.json({ success: true });
+  let body: { id?: string; ids?: string[]; markAllRead?: boolean };
+  try {
+    body = (await request.json()) as typeof body;
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
   }
 
-  return NextResponse.json({ error: "Provide id or markAllRead" }, { status: 400 });
+  try {
+    if (body.markAllRead) {
+      const recent = await listNotifications({ limit: 200 });
+      const ids = recent.filter((n) => !n.read).map((n) => n.id);
+      await markNotificationsRead(ids);
+      return NextResponse.json({ success: true, updated: ids.length });
+    }
+
+    const ids: string[] = [];
+    if (typeof body.id === "string" && body.id) ids.push(body.id);
+    if (Array.isArray(body.ids)) {
+      for (const id of body.ids) {
+        if (typeof id === "string" && id) ids.push(id);
+      }
+    }
+
+    if (!ids.length) {
+      return NextResponse.json(
+        { error: "Provide id, ids, or markAllRead" },
+        { status: 400 },
+      );
+    }
+
+    await markNotificationsRead(ids);
+    return NextResponse.json({ success: true, updated: ids.length });
+  } catch (err) {
+    console.error("[admin-notifications] PATCH failed:", err);
+    return NextResponse.json(
+      { error: "Failed to update notifications" },
+      { status: 500 },
+    );
+  }
 }
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";


### PR DESCRIPTION
**Third and final PR** of the notifications redesign. Builds on PR #843 (A1: SST table + lib) and PR #845 (A2: producer wiring).

Replaces the warm-Lambda-only in-memory ring buffer with reads from the durable Dynamo audit log, and surfaces the new category dimension in the admin UI.

## API changes

- `GET /api/admin/notifications` now queries Dynamo via `listNotifications()`. Accepts `?category=`, `?since=`, `?until=`, `?limit=` (1..200, default 50), `?includeArchived=1`.
- `PATCH` accepts `{id}`, `{ids[]}`, or `{markAllRead: true}`. `markAllRead` scopes to the 200 most-recent unread rows (bounded work).
- Both return **503** when `ADMIN_NOTIFICATIONS_TABLE` is unset (covered by tests), **500** on any other lib failure.
- The in-memory ring buffer and `pushNotification` export are deleted (zero callers — grep'd).
- **NEW:** `GET /api/admin/notifications/analytics?since=&until=` → `{ window, total, byCategory, byDay }`. Defaults to a 7-day window.

## UI changes

- Category pill row (All / Contact / Subscribe / Booking / Order / Auth / Portal / Error) with live counts from the analytics endpoint.
- Window selector (24h / 7d / 30d / 90d).
- Analytics card: total event count + per-day bar list.
- Each notification row shows the category tag, actor, originating route, and a per-row 'mark read' affordance.
- Graceful 503 banner when the store is not yet provisioned.

## Tests

20 vitest unit tests covering:
- Auth gates (401) on both endpoints
- Feature flag (503) when the env var is unset
- Category / date / limit parsing and clamping
- Single-id / batch / markAllRead PATCH paths
- Default (7-day) vs explicit analytics window
- 500 fallback when the lib throws

All pass locally:

```
✓ __tests__/admin-notifications-api.test.ts (20 tests) 141ms
  Test Files  1 passed (1)
       Tests  20 passed (20)
```

## Implementation note

All 4 files written via Python text replacement after the Edit/Write tool truncated three of them on the Windows mount — same defensive pattern used for PRs #843 / #844 / #845. This is the third consecutive PR where the cowork tool corrupted file tails; consider opening a Cowork bug.

## After this lands

The notifications redesign is complete (apart from the optional PR B archive cron). Every client interaction in the 7 wired categories writes a row to Dynamo, the admin page reads it back with filters and analytics, and the data is available for SQL-on-S3 analytics after the 90-day hot window.