### PR TITLE
fix(voice-brief): align SSM path + region with production, drop SSRF self-call

### DIFF
--- a/__tests__/admin-voice-brief-api.test.ts
+++ b/__tests__/admin-voice-brief-api.test.ts
@@ -5,10 +5,12 @@ const VOICE_BRIEF_URL = "http://localhost/api/admin/voice-brief";
 // ---------------------------------------------------------------------------
 // Hoist mocks
 // ---------------------------------------------------------------------------
-const { mockGetConfig, mockSSMSend, mockFetch } = vi.hoisted(() => ({
+const { mockGetConfig, mockSSMSend, mockFetch, mockRunAgent, mockPersist } = vi.hoisted(() => ({
   mockGetConfig: vi.fn(),
   mockSSMSend: vi.fn(),
   mockFetch: vi.fn(),
+  mockRunAgent: vi.fn(),
+  mockPersist: vi.fn(),
 }));
 
 vi.mock("jose", async () => {
@@ -27,6 +29,13 @@ vi.mock("jose", async () => {
 });
 
 vi.mock("@/lib/ssm-config", () => ({ getConfig: mockGetConfig }));
+vi.mock("@/lib/agent-voice-brief", () => ({
+  runVoiceBriefAgent: (...a: unknown[]) => mockRunAgent(...a),
+}));
+vi.mock("@/lib/voice-brief-store", () => ({
+  VOICE_BRIEF_SSM_NAME: "/cloudless/production/VOICE_BRIEF_LATEST",
+  persistVoiceBrief: (...a: unknown[]) => mockPersist(...a),
+}));
 vi.stubGlobal("fetch", mockFetch);
 
 vi.mock("@aws-sdk/client-ssm", async () => {
@@ -156,12 +165,12 @@ describe("GET /api/admin/voice-brief", () => {
 describe("POST /api/admin/voice-brief", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    mockGetConfig.mockResolvedValue({
-      ...BASE_CFG,
-      NEXTAUTH_URL: "http://localhost",
+    mockGetConfig.mockResolvedValue(BASE_CFG);
+    mockRunAgent.mockResolvedValue({
+      text: "AI-enhanced brief.",
+      sources: [],
     });
-    process.env.CRON_SECRET = "test-cron-secret";
-    process.env.NEXTAUTH_URL = "http://localhost";
+    mockPersist.mockResolvedValue(undefined);
   });
 
   it("returns 401 without token", async () => {
@@ -170,27 +179,43 @@ describe("POST /api/admin/voice-brief", () => {
       new NextRequest(VOICE_BRIEF_URL, { method: "POST" }),
     );
     expect(res.status).toBe(401);
+    expect(mockRunAgent).not.toHaveBeenCalled();
   });
 
-  it("returns brief when cron route succeeds", async () => {
-    mockFetch.mockResolvedValueOnce({
-      ok: true,
-      json: async () => ({
-        text: "AI-enhanced brief.",
-        generatedAt: new Date().toISOString(),
+  it("returns 403 for non-admin", async () => {
+    const { POST } = await import("@/app/api/admin/voice-brief/route");
+    const res = await POST(
+      new NextRequest(VOICE_BRIEF_URL, {
+        method: "POST",
+        headers: { Authorization: `Bearer ${makeUserToken()}` },
       }),
-    });
+    );
+    expect(res.status).toBe(403);
+  });
+
+  it("calls the agent directly and returns the generated brief", async () => {
     const { POST } = await import("@/app/api/admin/voice-brief/route");
     const res = await POST(adminReq(VOICE_BRIEF_URL, { method: "POST" }));
     expect(res.status).toBe(200);
     const data = await res.json();
-    expect(data.brief).toBeDefined();
     expect(data.brief.text).toBe("AI-enhanced brief.");
     expect(data.brief.week).toBe("on-demand");
+    expect(typeof data.brief.generatedAt).toBe("string");
+    expect(mockRunAgent).toHaveBeenCalledTimes(1);
+    expect(mockPersist).toHaveBeenCalledTimes(1);
   });
 
-  it("returns 500 when cron route fails", async () => {
-    mockFetch.mockResolvedValueOnce({ ok: false, status: 500 });
+  it("returns the brief even when persist fails (best-effort)", async () => {
+    mockPersist.mockRejectedValueOnce(new Error("ssm down"));
+    const { POST } = await import("@/app/api/admin/voice-brief/route");
+    const res = await POST(adminReq(VOICE_BRIEF_URL, { method: "POST" }));
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data.brief.text).toBe("AI-enhanced brief.");
+  });
+
+  it("returns 500 when the agent throws", async () => {
+    mockRunAgent.mockRejectedValueOnce(new Error("agent down"));
     const { POST } = await import("@/app/api/admin/voice-brief/route");
     const res = await POST(adminReq(VOICE_BRIEF_URL, { method: "POST" }));
     expect(res.status).toBe(500);
@@ -198,37 +223,10 @@ describe("POST /api/admin/voice-brief", () => {
     expect(data.error).toBeDefined();
   });
 
-  it("ignores an off-allowlist NEXTAUTH_URL and targets cloudless.gr (SSRF guard)", async () => {
-    process.env.NEXTAUTH_URL = "https://evil.example.com";
-    mockFetch.mockResolvedValueOnce({
-      ok: true,
-      json: async () => ({
-        text: "brief",
-        generatedAt: new Date().toISOString(),
-      }),
-    });
+  it("does NOT make any outbound HTTP call (no SSRF surface)", async () => {
+    mockFetch.mockClear();
     const { POST } = await import("@/app/api/admin/voice-brief/route");
     await POST(adminReq(VOICE_BRIEF_URL, { method: "POST" }));
-
-    expect(mockFetch).toHaveBeenCalledTimes(1);
-    const calledUrl = String(mockFetch.mock.calls[0][0]);
-    expect(calledUrl).toBe("https://cloudless.gr/api/cron/voice-brief");
-    expect(calledUrl).not.toContain("evil.example.com");
-  });
-
-  it("uses an allowlisted NEXTAUTH_URL when configured", async () => {
-    process.env.NEXTAUTH_URL = "https://cloudless.gr";
-    mockFetch.mockResolvedValueOnce({
-      ok: true,
-      json: async () => ({
-        text: "brief",
-        generatedAt: new Date().toISOString(),
-      }),
-    });
-    const { POST } = await import("@/app/api/admin/voice-brief/route");
-    await POST(adminReq(VOICE_BRIEF_URL, { method: "POST" }));
-
-    const calledUrl = String(mockFetch.mock.calls[0][0]);
-    expect(calledUrl).toBe("https://cloudless.gr/api/cron/voice-brief");
+    expect(mockFetch).not.toHaveBeenCalled();
   });
 });

--- a/__tests__/voice-brief-store.test.ts
+++ b/__tests__/voice-brief-store.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+const { mockSend } = vi.hoisted(() => ({ mockSend: vi.fn() }));
+const putCalls: Record<string, unknown>[] = [];
+
+vi.mock("@aws-sdk/client-ssm", () => ({
+  SSMClient: vi.fn().mockImplementation(function (config: unknown) {
+    return { __config: config, send: mockSend };
+  }),
+  PutParameterCommand: vi.fn().mockImplementation(function (input: Record<string, unknown>) {
+    putCalls.push(input);
+    return { __cmd: "Put", input };
+  }),
+}));
+
+describe("voice-brief-store", () => {
+  beforeEach(() => {
+    mockSend.mockReset();
+    putCalls.length = 0;
+  });
+  afterEach(() => {
+    delete process.env.AWS_REGION;
+  });
+
+  it("VOICE_BRIEF_SSM_NAME points at the production prefix", async () => {
+    const mod = await import("@/lib/voice-brief-store");
+    expect(mod.VOICE_BRIEF_SSM_NAME).toBe(
+      "/cloudless/production/VOICE_BRIEF_LATEST",
+    );
+  });
+
+  it("persistVoiceBrief writes JSON to SSM with Overwrite=true", async () => {
+    mockSend.mockResolvedValueOnce({});
+    const { persistVoiceBrief } = await import("@/lib/voice-brief-store");
+    await persistVoiceBrief({
+      text: "weekly highlights",
+      generatedAt: "2026-06-12T21:00:00Z",
+      week: "2026-W24",
+    });
+    expect(putCalls).toHaveLength(1);
+    const input = putCalls[0];
+    expect(input.Name).toBe("/cloudless/production/VOICE_BRIEF_LATEST");
+    expect(input.Overwrite).toBe(true);
+    expect(input.Type).toBe("String");
+    const payload = JSON.parse(input.Value as string) as { text: string };
+    expect(payload.text).toBe("weekly highlights");
+  });
+
+  it("defaults to us-east-1 when AWS_REGION is unset", async () => {
+    mockSend.mockResolvedValueOnce({});
+    const { SSMClient } = await import("@aws-sdk/client-ssm");
+    const { persistVoiceBrief } = await import("@/lib/voice-brief-store");
+    delete process.env.AWS_REGION;
+    await persistVoiceBrief({
+      text: "x",
+      generatedAt: "2026-06-12T21:00:00Z",
+      week: "2026-W24",
+    });
+    const ctorArgs = (SSMClient as unknown as { mock: { calls: unknown[][] } }).mock.calls;
+    const lastCallConfig = ctorArgs[ctorArgs.length - 1][0] as { region: string };
+    expect(lastCallConfig.region).toBe("us-east-1");
+  });
+
+  it("uses AWS_REGION env when set", async () => {
+    mockSend.mockResolvedValueOnce({});
+    const { SSMClient } = await import("@aws-sdk/client-ssm");
+    const { persistVoiceBrief } = await import("@/lib/voice-brief-store");
+    process.env.AWS_REGION = "eu-west-1";
+    await persistVoiceBrief({
+      text: "x",
+      generatedAt: "2026-06-12T21:00:00Z",
+      week: "2026-W24",
+    });
+    const ctorArgs = (SSMClient as unknown as { mock: { calls: unknown[][] } }).mock.calls;
+    const lastCallConfig = ctorArgs[ctorArgs.length - 1][0] as { region: string };
+    expect(lastCallConfig.region).toBe("eu-west-1");
+  });
+});

--- a/src/app/api/admin/voice-brief/route.ts
+++ b/src/app/api/admin/voice-brief/route.ts
@@ -1,7 +1,8 @@
 import { NextRequest, NextResponse } from "next/server";
 import { requireAdmin } from "@/lib/api-auth";
-import { getConfig } from "@/lib/ssm-config";
 import { SSMClient, GetParameterCommand } from "@aws-sdk/client-ssm";
+import { runVoiceBriefAgent } from "@/lib/agent-voice-brief";
+import { persistVoiceBrief, VOICE_BRIEF_SSM_NAME } from "@/lib/voice-brief-store";
 
 interface VoiceBrief {
   text: string;
@@ -13,12 +14,14 @@ export async function GET(request: NextRequest) {
   const auth = await requireAdmin(request);
   if (!auth.ok) return auth.response;
 
-  const region = process.env.AWS_REGION ?? "eu-central-1";
+  // Region defaults to us-east-1 (where all production SSM lives). Lambda's
+  // runtime auto-sets AWS_REGION; we read it but fall back to the prod region.
+  const region = process.env.AWS_REGION || "us-east-1";
 
   try {
     const client = new SSMClient({ region });
     const res = await client.send(
-      new GetParameterCommand({ Name: "/cloudless/VOICE_BRIEF_LATEST" }),
+      new GetParameterCommand({ Name: VOICE_BRIEF_SSM_NAME }),
     );
     const raw = res.Parameter?.Value;
     if (!raw) {
@@ -35,39 +38,29 @@ export async function POST(request: NextRequest) {
   const auth = await requireAdmin(request);
   if (!auth.ok) return auth.response;
 
-  // Trigger on-demand generation by calling the cron route internally.
-  // Pin the base URL to a known allowlist so a misconfigured or tampered env
-  // var cannot redirect this server-side fetch to an attacker host (SSRF guard).
-  const ALLOWED_BASE_URLS = [
-    "https://cloudless.gr",
-    "http://localhost:3000",
-  ];
-  const envBase =
-    process.env.NEXTAUTH_URL ?? process.env.NEXT_PUBLIC_APP_URL ?? "";
-  const baseUrl = ALLOWED_BASE_URLS.includes(envBase)
-    ? envBase
-    : "https://cloudless.gr";
-  // Read CRON_SECRET from SSM-backed config — process.env is not populated
-  // in Lambda runtime where secrets live only in SSM.
-  const cfg = await getConfig();
-  const cronSecret = cfg.CRON_SECRET ?? process.env.CRON_SECRET ?? "";
   try {
-    const res = await fetch(`${baseUrl}/api/cron/voice-brief`, {
-      headers: { authorization: `Bearer ${cronSecret}` },
-      signal: AbortSignal.timeout(60_000),
+    const agentResult = await runVoiceBriefAgent({
+      dateLabel: new Date().toLocaleDateString("en-IE", {
+        weekday: "long",
+        year: "numeric",
+        month: "long",
+        day: "numeric",
+      }),
     });
-    if (!res.ok) throw new Error(`Cron returned ${res.status}`);
-    const data = await res.json();
-    return NextResponse.json({
-      brief: {
-        text: data.text,
-        generatedAt: data.generatedAt,
-        week: "on-demand",
-      },
-    });
+    const brief: VoiceBrief = {
+      text: agentResult.text,
+      generatedAt: new Date().toISOString(),
+      week: "on-demand",
+    };
+    // Best-effort persist — failure should not fail the user-facing response.
+    await persistVoiceBrief(brief).catch((err) =>
+      console.warn(
+        "[admin/voice-brief] persist failed:",
+        err instanceof Error ? err.message : String(err),
+      ),
+    );
+    return NextResponse.json({ brief });
   } catch (e) {
-    // Log only the message — the raw error may carry the internal fetch's
-    // Authorization header (CRON_SECRET) in its request context.
     console.error(
       "[admin/voice-brief] generation failed:",
       e instanceof Error ? e.message : String(e),

--- a/src/app/api/cron/voice-brief/route.ts
+++ b/src/app/api/cron/voice-brief/route.ts
@@ -1,12 +1,9 @@
 import { NextRequest, NextResponse } from "next/server";
-import { SSMClient, PutParameterCommand } from "@aws-sdk/client-ssm";
-import { getConfig } from "@/lib/ssm-config";
 import { isCronAuthorized, cronUnauthorized } from "@/lib/cron-auth";
 import { mapIntegrationError } from "@/lib/api-errors";
 import { runVoiceBriefAgent } from "@/lib/agent-voice-brief";
 import { SlackClient } from "@/lib/slack-notify";
-
-const SSM_PARAM_NAME = "/cloudless/VOICE_BRIEF_LATEST";
+import { persistVoiceBrief } from "@/lib/voice-brief-store";
 
 function now() {
   return new Date();
@@ -35,25 +32,12 @@ async function safeCall<T>(fn: () => Promise<T>): Promise<T | null> {
 // Persistence + notification
 // ---------------------------------------------------------------------------
 
-async function persistBrief(
-  text: string,
-  cfg: Record<string, string | undefined>,
-): Promise<void> {
-  const region = cfg.AWS_REGION ?? "eu-central-1";
-  const client = new SSMClient({ region });
-  const brief = {
+async function persistBrief(text: string): Promise<void> {
+  await persistVoiceBrief({
     text,
     generatedAt: new Date().toISOString(),
     week: weekLabel(now()),
-  };
-  await client.send(
-    new PutParameterCommand({
-      Name: SSM_PARAM_NAME,
-      Value: JSON.stringify(brief),
-      Type: "String",
-      Overwrite: true,
-    }),
-  );
+  });
 }
 
 interface SlackSourceSummary {
@@ -109,11 +93,6 @@ export async function GET(request: NextRequest) {
     return cronUnauthorized();
   }
 
-  const cfg = (await getConfig()) as unknown as Record<
-    string,
-    string | undefined
-  >;
-
   let text: string;
   let sources: SlackSourceSummary[] = [];
 
@@ -134,7 +113,7 @@ export async function GET(request: NextRequest) {
     throw err;
   }
 
-  await safeCall(() => persistBrief(text, cfg));
+  await safeCall(() => persistBrief(text));
   await safeCall(() => notifySlack(text, sources));
 
   return NextResponse.json({

--- a/src/lib/voice-brief-store.ts
+++ b/src/lib/voice-brief-store.ts
@@ -1,0 +1,32 @@
+import { SSMClient, PutParameterCommand } from "@aws-sdk/client-ssm";
+
+/**
+ * Single source of truth for where the weekly voice brief is persisted.
+ *
+ * History: the original implementation used "/cloudless/VOICE_BRIEF_LATEST"
+ * with a default region of eu-central-1 — but production SSM lives in
+ * us-east-1 under the /cloudless/production/ prefix. Both writer (cron) and
+ * reader (admin route) silently disagreed with the environment, so the
+ * persisted parameter was never visible to the reader. The constants here
+ * keep them aligned forever.
+ */
+export const VOICE_BRIEF_SSM_NAME = "/cloudless/production/VOICE_BRIEF_LATEST";
+
+export interface VoiceBriefRecord {
+  text: string;
+  generatedAt: string;
+  week: string;
+}
+
+export async function persistVoiceBrief(brief: VoiceBriefRecord): Promise<void> {
+  const region = process.env.AWS_REGION || "us-east-1";
+  const client = new SSMClient({ region });
+  await client.send(
+    new PutParameterCommand({
+      Name: VOICE_BRIEF_SSM_NAME,
+      Value: JSON.stringify(brief),
+      Type: "String",
+      Overwrite: true,
+    }),
+  );
+}


### PR DESCRIPTION
## Cluster 2 audit finding

During the AI cluster audit, I confirmed the weekly Voice Brief has **never** been visible in the admin UI — and traced it to two silent disagreements between the writer and reader and the production environment:

| Component | Wrong default | Production reality |
|---|---|---|
| SSM path | `/cloudless/VOICE_BRIEF_LATEST` | All other prod keys live under `/cloudless/production/` |
| AWS region | `eu-central-1` (fallback when `AWS_REGION` unset) | All prod SSM is in `us-east-1` |

Verified with `aws_get_ssm_parameters` — no `VOICE_BRIEF_LATEST` parameter exists anywhere in our SSM tree. Even when the cron *did* successfully run the agent, the `PutParameterCommand` went to the wrong region — and the reader was looking at a different wrong region. Neither failed loudly; both silently returned `{ brief: null }`.

## Fix

- **NEW `src/lib/voice-brief-store.ts`** — single source of truth for the SSM name and a `persistVoiceBrief()` helper that pins the correct region default. Both reader and writer import from here.
- **`admin/voice-brief/route.ts` GET** — uses the shared constant + `'us-east-1'` default.
- **`admin/voice-brief/route.ts` POST** — replaced the SSRF-style internal self-call to `/api/cron/voice-brief` with a direct invocation of `runVoiceBriefAgent`. The previous design required threading `CRON_SECRET` through a server-to-server HTTPS hop just to invoke the same TypeScript that was already loaded in the same Lambda — slow, fragile, and an attack-surface the SSRF allow-list was forced to defend.
- **`cron/voice-brief/route.ts`** — `persistBrief()` now delegates to the shared store. The unused `SSMClient` / `PutParameterCommand` / `SSM_PARAM_NAME` / `getConfig` imports are gone.

## Tests

```
✓ __tests__/admin-voice-brief-api.test.ts  10/10 pass
✓ __tests__/cron-voice-brief.test.ts        5/5 pass
✓ __tests__/voice-brief-store.test.ts       4/4 pass  (new)
```

The new POST tests include an explicit `expect(mockFetch).not.toHaveBeenCalled()` assertion as a guard against SSRF regression — if anyone ever re-adds an outbound fetch from this admin route, that test will fail loudly.

The old SSRF-allowlist tests (which asserted the inner fetch URL was clamped to `https://cloudless.gr`) are dropped — there is no longer any inner fetch.

## Impact

After this deploys, the next scheduled cron run (or the first admin-triggered POST) will write the parameter to the correct path + region, and the admin Voice Brief page will finally display the brief instead of the empty state.