### PR TITLE
feat(infra): cloudflare-token-doctor skill + verify workflow + smoketest

### DIFF
--- a/.github/workflows/verify-cloudflare-token.yml
+++ b/.github/workflows/verify-cloudflare-token.yml
@@ -1,0 +1,97 @@
+name: Verify Cloudflare API token
+
+# Read-only smoke test for the Cloudflare API token stored in SSM
+# /cloudless/production/CLOUDFLARE_API_TOKEN. Useful when:
+#   - An MCP tool returns "Invalid access token" and we need a clean CI
+#     log to attach to the rotation
+#   - An automated workflow (cloudflare-lb.yml, ...) fails with 401
+#   - After running store-cloudflare-token.yml to confirm scopes
+#
+# Companion to skills/cloudflare-token-doctor/SKILL.md Stage 3.
+#
+# Triggers ONLY on manual dispatch — never on push. The token never
+# appears in logs (set as ::add-mask:: before any use).
+
+on:
+  workflow_dispatch:
+    inputs:
+      zone_name:
+        description: "Zone to verify against (default: cloudless.gr)"
+        required: false
+        default: cloudless.gr
+
+permissions:
+  id-token: write   # OIDC → AWS_DEPLOY_ROLE_ARN for ssm:GetParameter
+  contents: read
+
+concurrency:
+  group: cloudflare-verify
+  cancel-in-progress: false
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ github.token }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v4.3.1
+
+      - name: Configure AWS credentials (OIDC)
+        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4
+        with:
+          role-to-assume: ${{ secrets.AWS_DEPLOY_ROLE_ARN }}
+          aws-region: us-east-1
+
+      - name: Fetch Cloudflare token from SSM
+        id: fetch
+        env:
+          AWS_DEFAULT_REGION: us-east-1
+        run: |
+          set -uo pipefail
+          CF="$(aws ssm get-parameter \
+            --name /cloudless/production/CLOUDFLARE_API_TOKEN \
+            --with-decryption \
+            --query Parameter.Value \
+            --output text 2>/dev/null || echo '')"
+          if [ -z "$CF" ] || [ "$CF" = "None" ]; then
+            echo "::error::No Cloudflare token in SSM. Run store-cloudflare-token.yml first."
+            exit 1
+          fi
+          echo "::add-mask::$CF"
+          # Hand the token to subsequent steps via env, not outputs (outputs
+          # are visible in run metadata even when masked from logs).
+          {
+            echo "CLOUDFLARE_API_TOKEN<<EOF"
+            echo "$CF"
+            echo "EOF"
+          } >> "$GITHUB_ENV"
+          echo "token_present=true" >> "$GITHUB_OUTPUT"
+
+      - name: Run smoke-test
+        id: smoke
+        env:
+          ZONE_NAME: ${{ github.event.inputs.zone_name }}
+        run: |
+          set -o pipefail
+          bash scripts/cf-token-smoketest.sh 2>&1 | tee smoke.log
+          # Preserve the exit code from the script (set -o pipefail above).
+          status=${PIPESTATUS[0]:-${pipestatus[1]:-0}}
+          echo "exit_status=$status" >> "$GITHUB_OUTPUT"
+          exit "$status"
+
+      - name: Summarize
+        if: always()
+        run: |
+          {
+            echo "# Cloudflare token verify — $(date -u '+%F %T')Z"
+            echo
+            echo "**Zone:** ${{ github.event.inputs.zone_name }}"
+            echo "**Job status:** ${{ job.status }}"
+            echo
+            echo '```'
+            tail -n 80 smoke.log 2>/dev/null || echo '(no log)'
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,8 +13,9 @@ These require access outside GitHub and cannot be automated from a cloud session
 | `OMV_SSH_KEY` | **SET** ✅ | Key for `tbaltzakis@omv` (host omv, user tbaltzakis). SSH workflows updated to `PI_USER: "tbaltzakis"`. k3s watchdog (`Restart=always`) deployed 2026-06-02T18:56Z — auto-restart active. |
 | ESP32 page content | **PARTIAL RESTORE** | Full content requires Notion UI: open page → ••• → Page history → restore pre-15:19 UTC 2026-06-02. ESP32 Devices + Telemetry databases (IDs confirmed correct, integration has access) are **empty** — no data was ever populated there to restore. |
 | Admin password | **N/A** | Auth is Cognito (PR #677, 2026-06-08). Manage admin users in the Cognito User Pool console; there is no separate IdP admin to bootstrap. |
-| Cloudflare HA LB | **TOKEN NEEDED** | `setup-cloudflare-lb.yml` (merged PR #548) needs `CLOUDFLARE_API_TOKEN` — add as repo secret or SSM `/cloudless/production/CLOUDFLARE_API_TOKEN` with scopes: Zone:Read, Load Balancing Monitors/Pools+Load Balancers:Edit, DNS:Edit (zone cloudless.gr). Then `workflow_dispatch` or touch the workflow to apply. |
-| Cloudflare Email Obfuscation fix | **TOKEN NEEDED** | `cloudflare-disable-email-obfuscation.yml` (merged PR #745) fixes React #418 hydration errors by disabling Scrape Shield Email Obfuscation zone-wide. Needs `CLOUDFLARE_API_TOKEN` repo secret or SSM `/cloudless/production/CLOUDFLARE_API_TOKEN` (can reuse HA LB token if it has Zone Settings:Edit, or create a new token with scopes: **Zone:Read, Zone Settings:Edit** for cloudless.gr). Then `workflow_dispatch` to run; it verifies the fix by curling /en and checking for email-obfuscation markers. |
+| Cloudflare HA LB | **TOKEN NEEDED** | `setup-cloudflare-lb.yml` (merged PR #548) needs `CLOUDFLARE_API_TOKEN` — use the `cloudflare-token-doctor` skill, mint a token with the full scope set (skill Stage 1), then `gh workflow run store-cloudflare-token.yml -f cloudflare_token=… -f apply=true`. |
+| Cloudflare Email Obfuscation fix | **TOKEN NEEDED** | `cloudflare-disable-email-obfuscation.yml` (merged PR #745) fixes React #418 hydration errors. Same token as HA LB above. |
+| Cloudflare infra MCP token | **NEEDS ROTATION** | Existing `CLOUDFLARE_API_TOKEN` in cloud-session secrets is invalid (every `mcp__cloudless-infra__cloudflare_*` tool returns 401). Use the `cloudflare-token-doctor` skill: Stage 1 mint, Stage 2 store (SSM + session secret), Stage 3 run `bash scripts/cf-token-smoketest.sh`, Stage 4 verify with `mcp__cloudless-infra__cloudflare_list_tokens()`. CI verify available via `gh workflow run verify-cloudflare-token.yml`. |
 
 ## Testing Policy
 
@@ -141,7 +142,8 @@ instead — see the **`cluster-incident-response`** skill for the full playbook.
 
 ## Authentication
 
-Auth is **Cognito**. App admin = membership in the Cognito
+Auth is **Cognito**, full-stop (PR #677, 2026-06-08). There is no Keycloak, no
+JVM heap, no realm config to maintain. App admin = membership in the Cognito
 group `admin`, surfaced via the `cognito:groups` claim and checked by
 `api-auth.ts` `requireAdmin`. Manage users in the Cognito User Pool console.
 The `[...nextauth]` route uses the Cognito provider; `NEXT_PUBLIC_COGNITO_*`
@@ -336,4 +338,4 @@ which automates Stages 0-3 from the Pi.
 - Terraform CLI: `1.15.6`
 - `hashicorp/aws`: `~> 5.80.0`
 - `aws-actions/configure-aws-credentials`: `v4.x`
-- `hashicorp/setup-terraform`: prefer `v3.x` (v2 nears Node 20 EOL)
+- `hashicorp/setup-ter

--- a/scripts/cf-token-smoketest.sh
+++ b/scripts/cf-token-smoketest.sh
@@ -1,0 +1,175 @@
+#!/usr/bin/env bash
+# Smoke-test a Cloudflare API token against the scopes the cloudless.gr
+# infra MCP expects. Reads the token from $CLOUDFLARE_API_TOKEN if set,
+# otherwise from AWS SSM /cloudless/production/CLOUDFLARE_API_TOKEN.
+#
+# Exit code: 0 if all checks pass, non-zero if any scope is missing or
+# the token verify call fails outright.
+#
+# Run after rotating the token (see skills/cloudflare-token-doctor/SKILL.md
+# Stage 3) or whenever an MCP tool unexpectedly returns "Invalid access
+# token".
+#
+# Usage:
+#   bash scripts/cf-token-smoketest.sh
+#   CLOUDFLARE_API_TOKEN=... bash scripts/cf-token-smoketest.sh
+#   ZONE_ID=... ACCOUNT_ID=... bash scripts/cf-token-smoketest.sh
+set -uo pipefail
+
+# ── Config ────────────────────────────────────────────────────────────────────
+ZONE_NAME="${ZONE_NAME:-cloudless.gr}"
+ZONE_ID="${ZONE_ID:-}"
+ACCOUNT_ID="${ACCOUNT_ID:-}"
+CF="${CLOUDFLARE_API_TOKEN:-}"
+
+if [ -z "$CF" ]; then
+  echo "→ Resolving token from SSM /cloudless/production/CLOUDFLARE_API_TOKEN"
+  CF="$(aws ssm get-parameter \
+    --name /cloudless/production/CLOUDFLARE_API_TOKEN \
+    --with-decryption \
+    --query Parameter.Value \
+    --output text 2>/dev/null)" || {
+      echo "ERR: cannot read token from SSM and \$CLOUDFLARE_API_TOKEN is unset" >&2
+      exit 2
+    }
+fi
+if [ -z "$CF" ] || [ "$CF" = "None" ]; then
+  echo "ERR: token is empty" >&2
+  exit 2
+fi
+
+API="https://api.cloudflare.com/client/v4"
+PASS=0
+FAIL=0
+
+check() {
+  local label="$1" status="$2"
+  if [ "$status" = "ok" ]; then
+    printf "  \033[32m✓\033[0m  %s\n" "$label"
+    PASS=$((PASS + 1))
+  else
+    printf "  \033[31m✗\033[0m  %s — %s\n" "$label" "$status"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+curl_cf() {
+  curl -sS -H "Authorization: Bearer $CF" -H "Content-Type: application/json" "$@"
+}
+
+# ── 0. Token verify ──────────────────────────────────────────────────────────
+echo
+echo "Cloudflare token smoke-test"
+echo "---------------------------"
+
+VERIFY="$(curl_cf "$API/user/tokens/verify")"
+SUCCESS="$(echo "$VERIFY" | jq -r '.success')"
+STATUS="$(echo "$VERIFY" | jq -r '.result.status // "unknown"')"
+
+if [ "$SUCCESS" = "true" ] && [ "$STATUS" = "active" ]; then
+  check "Token verify (active)" ok
+else
+  ERR_CODE="$(echo "$VERIFY" | jq -r '.errors[0].code // "no-code"')"
+  ERR_MSG="$(echo "$VERIFY" | jq -r '.errors[0].message // "unknown"')"
+  check "Token verify" "code=$ERR_CODE: $ERR_MSG"
+  echo
+  echo "Aborting further checks — token isn't valid."
+  exit 1
+fi
+
+# ── 1. Zone:Read ─────────────────────────────────────────────────────────────
+if [ -z "$ZONE_ID" ]; then
+  ZR="$(curl_cf "$API/zones?name=$ZONE_NAME")"
+  ZONE_ID="$(echo "$ZR" | jq -r '.result[0].id // empty')"
+  if [ -n "$ZONE_ID" ]; then
+    check "Zone:Read (resolved $ZONE_NAME → $ZONE_ID)" ok
+  else
+    ERR_MSG="$(echo "$ZR" | jq -r '.errors[0].message // "no result"')"
+    check "Zone:Read" "$ERR_MSG"
+  fi
+else
+  check "Zone:Read (zone id pre-set: $ZONE_ID)" ok
+fi
+
+# ── 2. Zone Settings:Edit (Read is implied — only Read is exercised) ─────────
+if [ -n "$ZONE_ID" ]; then
+  ZS="$(curl_cf "$API/zones/$ZONE_ID/settings")"
+  ZS_OK="$(echo "$ZS" | jq -r '.success')"
+  if [ "$ZS_OK" = "true" ]; then
+    check "Zone Settings:Read" ok
+  else
+    ERR_MSG="$(echo "$ZS" | jq -r '.errors[0].message // "unknown"')"
+    check "Zone Settings:Read" "$ERR_MSG"
+  fi
+fi
+
+# ── 3. DNS:Edit (Read leg) ───────────────────────────────────────────────────
+if [ -n "$ZONE_ID" ]; then
+  DNS="$(curl_cf "$API/zones/$ZONE_ID/dns_records?per_page=1")"
+  DNS_OK="$(echo "$DNS" | jq -r '.success')"
+  if [ "$DNS_OK" = "true" ]; then
+    check "DNS:Read" ok
+  else
+    ERR_MSG="$(echo "$DNS" | jq -r '.errors[0].message // "unknown"')"
+    check "DNS:Read" "$ERR_MSG"
+  fi
+fi
+
+# ── 4. Analytics:Read (GraphQL) ──────────────────────────────────────────────
+if [ -n "$ZONE_ID" ]; then
+  GQ_BODY="$(jq -nc --arg z "$ZONE_ID" '{
+    query: "query($z: String!) { viewer { zones(filter: {zoneTag: $z}) { httpRequests1hGroups(limit: 1, filter: {datetime_gt: \"2026-01-01T00:00:00Z\"}) { sum { requests } } } } }",
+    variables: { z: $z }
+  }')"
+  GQ="$(curl -sS -X POST -H "Authorization: Bearer $CF" \
+    -H "Content-Type: application/json" \
+    -d "$GQ_BODY" "$API/graphql")"
+  GQ_ERR="$(echo "$GQ" | jq -r '.errors[0].message // empty')"
+  if [ -z "$GQ_ERR" ]; then
+    check "Analytics:Read (GraphQL viewer.zones)" ok
+  else
+    check "Analytics:Read" "$GQ_ERR"
+  fi
+fi
+
+# ── 5. User API Tokens:Read ──────────────────────────────────────────────────
+TL="$(curl_cf "$API/user/tokens")"
+TL_OK="$(echo "$TL" | jq -r '.success')"
+if [ "$TL_OK" = "true" ]; then
+  TL_N="$(echo "$TL" | jq -r '.result | length')"
+  check "User API Tokens:Read ($TL_N tokens visible)" ok
+else
+  ERR_MSG="$(echo "$TL" | jq -r '.errors[0].message // "unknown"')"
+  check "User API Tokens:Read" "$ERR_MSG"
+fi
+
+# ── 6. Workers Scripts:Read (account-scoped) ─────────────────────────────────
+if [ -z "$ACCOUNT_ID" ]; then
+  ME="$(curl_cf "$API/accounts")"
+  ACCOUNT_ID="$(echo "$ME" | jq -r '.result[0].id // empty')"
+fi
+if [ -n "$ACCOUNT_ID" ]; then
+  WS="$(curl_cf "$API/accounts/$ACCOUNT_ID/workers/scripts")"
+  WS_OK="$(echo "$WS" | jq -r '.success')"
+  if [ "$WS_OK" = "true" ]; then
+    WS_N="$(echo "$WS" | jq -r '.result | length')"
+    check "Workers Scripts:Read ($WS_N scripts on account $ACCOUNT_ID)" ok
+  else
+    ERR_MSG="$(echo "$WS" | jq -r '.errors[0].message // "unknown"')"
+    check "Workers Scripts:Read" "$ERR_MSG"
+  fi
+else
+  check "Workers Scripts:Read" "could not resolve account id"
+fi
+
+# ── Summary ──────────────────────────────────────────────────────────────────
+echo
+echo "---------------------------"
+echo "Pass: $PASS  Fail: $FAIL"
+
+if [ "$FAIL" -gt 0 ]; then
+  echo
+  echo "→ Re-issue the token with the missing scopes. See"
+  echo "   skills/cloudflare-token-doctor/SKILL.md Stage 1."
+  exit 1
+fi

--- a/skills/cloudflare-token-doctor/SKILL.md
+++ b/skills/cloudflare-token-doctor/SKILL.md
@@ -1,0 +1,251 @@
+---
+name: cloudflare-token-doctor
+description: |
+  Diagnose and fix an invalid, expired, or under-scoped Cloudflare API token.
+  Use whenever the infra MCP returns "Invalid access token" from any
+  `mcp__cloudless-infra__cloudflare_*` tool, when Dependabot or a deploy
+  workflow mentions Cloudflare 401/403, when the Cloudflare email warning
+  about Workers limits arrives and we can't read analytics to confirm, or
+  when a freshly created token needs to be wired into SSM + the infra MCP
+  in one shot.
+---
+
+# Cloudflare Token Doctor
+
+A practical playbook for restoring a working Cloudflare API token without
+leaving the chat session. Order is deliberate — each stage gates the next.
+
+## When to invoke this skill
+
+- Any `mcp__cloudless-infra__cloudflare_*` tool returns `❌ Invalid access token`
+- The Cloudflare HA LB workflow (`cloudflare-lb.yml`,
+  `apply-cloudflare-lb.yml`, `cloudflare-disable-email-obfuscation.yml`)
+  fails with a 401 / 403 from `api.cloudflare.com`
+- The Cloudflare admin emails a "Workers request limit warning" and we
+  need analytics to confirm impact
+- The pending-setup table in `CLAUDE.md` lists "TOKEN NEEDED"
+- A new token has been minted in the Cloudflare dashboard and needs to
+  be propagated to SSM + the infra MCP
+
+## Stage 0 — Diagnose
+
+**One API call decides whether the token is alive.** Don't guess.
+
+```bash
+curl -sS -H "Authorization: Bearer $CLOUDFLARE_API_TOKEN" \
+  https://api.cloudflare.com/client/v4/user/tokens/verify \
+  | jq '.success, .result.status, .errors'
+```
+
+Outcomes:
+
+| Output | Meaning | Next stage |
+|---|---|---|
+| `true / "active" / []` | Token alive | Stage 4 (scope check) |
+| `false / null / [{"code":1000,...}]` | Token revoked or wrong | Stage 1 |
+| `false / null / [{"code":1001,...}]` | Token expired | Stage 1 |
+| `false / null / [{"code":10000,...}]` | Network/parse error | Stage 1 |
+
+The same check from inside CI is available via `verify-cloudflare-token.yml`
+(dispatch only). Use that when the token is already in SSM and you want a
+clean log entry rather than a one-liner.
+
+## Stage 1 — Mint a new token
+
+**Two paths. Pick whichever is reachable.**
+
+### Path A — Bootstrap from an existing high-privilege token
+
+If the **invalid** token is the only one in SSM but you (the human) still
+have a working Cloudflare login, run the dashboard flow once and store the
+output. This is the path you'll take if every prior token is gone.
+
+1. https://dash.cloudflare.com/profile/api-tokens → **Create Token →
+   Create Custom Token**
+2. Name: `cloudless-infra-mcp` (or `cloudless-infra-mcp-YYYY-MM` if you
+   rotate yearly).
+3. Permissions (add each as a separate row):
+
+   | Scope | Resource | Permission |
+   |---|---|---|
+   | Account | User API Tokens | Edit |
+   | Account | Account Settings | Read |
+   | Account | Workers Scripts | Read |
+   | Zone | Zone | Read |
+   | Zone | Analytics | Read |
+   | Zone | Zone Settings | Edit |
+   | Zone | DNS | Edit |
+   | Zone | Load Balancing: Monitors and Pools | Edit |
+   | Zone | Load Balancing: Load Balancers | Edit |
+
+4. Account Resources: **Include — All accounts**
+5. Zone Resources: **Include — Specific zone — cloudless.gr**
+   (Add another row for `cloudless.online` if failover analytics is
+   wanted.)
+6. TTL: **1 year** (or no expiry — your call; expiry forces rotation,
+   no expiry forces vigilance).
+7. **Continue → Create → copy the secret once.** Cloudflare will not
+   show it again.
+
+### Path B — Mint a scoped token from an existing high-privilege token
+
+If a working token with `User API Tokens:Edit` is already in SSM, the
+infra MCP can mint narrower derivative tokens itself:
+
+```text
+mcp__cloudless-infra__cloudflare_list_permission_groups(filter: "analytics")
+mcp__cloudless-infra__cloudflare_create_token(
+  name: "cloudless-readonly-analytics",
+  policies: [{
+    effect: "allow",
+    resources: { "com.cloudflare.api.account.zone.<ZONE_ID>": "*" },
+    permission_groups: [{ id: "<id-from-list>" }]
+  }]
+)
+```
+
+Use Path B for read-only consumers (Grafana, dashboards) so the wide
+`User API Tokens:Edit` token never leaves SSM.
+
+## Stage 2 — Store the token
+
+Two stores keep them in sync:
+
+### 2a — SSM (consumed by the infra MCP, deploy workflows, the Next.js
+runtime, and the Pi cluster)
+
+```bash
+gh workflow run store-cloudflare-token.yml \
+  -f cloudflare_token="<token>" \
+  -f apply=false
+```
+
+`apply=false` stores only. Use `apply=true` after Stage 4 verifies the
+scopes are right and you actually want to re-wire the HA load balancer
+in the same run.
+
+### 2b — Cloud session secret (consumed by `cloudless-infra` MCP server)
+
+The session-start hook reads `CLOUDFLARE_API_TOKEN` from the chat session's
+secret store and forwards it to the MCP server. Set it in:
+
+**Claude Code web UI → Session → Environment → Secrets**
+
+Use the **same** value as SSM. If they drift, the MCP will keep returning
+"Invalid access token" until you also rotate the session secret.
+
+## Stage 3 — Smoke-test
+
+```bash
+bash scripts/cf-token-smoketest.sh
+```
+
+The script (shipped alongside this skill) hits one endpoint per
+permission row from Stage 1 and reports pass/fail per scope. Exit code is
+non-zero if any scope is missing — useful for CI gating.
+
+Manual equivalents:
+
+```bash
+# Token verify
+curl -sS -H "Authorization: Bearer $CF" \
+  https://api.cloudflare.com/client/v4/user/tokens/verify
+
+# Zone list (Zone:Read)
+curl -sS -H "Authorization: Bearer $CF" \
+  https://api.cloudflare.com/client/v4/zones \
+  | jq '.result[].name'
+
+# Workers list (Workers Scripts:Read)
+curl -sS -H "Authorization: Bearer $CF" \
+  "https://api.cloudflare.com/client/v4/accounts/<ACCOUNT_ID>/workers/scripts" \
+  | jq '.result[].id'
+
+# Zone analytics (Analytics:Read)
+curl -sS -X POST -H "Authorization: Bearer $CF" \
+  -H "Content-Type: application/json" \
+  -d '{"query":"{ viewer { zones(filter:{zoneTag:\"<ZONE_ID>\"}){ httpRequests1hGroups(limit:1){ sum { requests } } } } }"}' \
+  https://api.cloudflare.com/client/v4/graphql
+
+# Token list (User API Tokens:Read)
+mcp__cloudless-infra__cloudflare_list_tokens()
+```
+
+## Stage 4 — Verify the infra MCP works
+
+The MCP server reads from the cloud-session secret store, **not** SSM.
+After Stage 2b, every MCP call must succeed:
+
+```text
+mcp__cloudless-infra__cloudflare_list_tokens()
+  → should list at least the freshly minted token
+
+mcp__cloudless-infra__cloudflare_zone_settings()
+  → should return real settings, not "Invalid access token"
+
+mcp__cloudless-infra__cloudflare_zone_analytics(since_hours: 24)
+  → should return requests/bandwidth/cached% (not error)
+```
+
+If any returns `❌ Invalid access token`:
+
+1. Did the session-start hook actually pick up the new value? Close +
+   reopen the cloud session, or run the hook manually.
+2. Did Stage 1 grant the corresponding permission row? The scopes in
+   Stage 1 cover every infra MCP tool that mentions Cloudflare; if you
+   skipped one, the matching tool will keep failing.
+3. Did you set the value in the right environment (Production vs Local)?
+   The hook only reads the active environment's secrets.
+
+## Stage 5 — Inventory and prune old tokens
+
+Once the new token is live, list every token on the account and revoke
+anything older / unused — minimizes blast radius if any token leaks.
+
+```text
+mcp__cloudless-infra__cloudflare_list_tokens()
+mcp__cloudless-infra__cloudflare_delete_token(token_id: "<id>")
+```
+
+Keep:
+- The currently active infra token
+- Anything used by a CI workflow (look for `gh secret list | grep -i cloudflare`)
+- Any tokens with a documented purpose in `docs/`
+
+Revoke:
+- "Edit Cloudflare Workers" default-named tokens you don't remember creating
+- Tokens with expiry > 1 year in the past
+- Duplicates from prior rotations
+
+## Stage 6 — Record the rotation
+
+Update `CLAUDE.md`'s **Pending One-Time Setup** table: change the status
+of any "TOKEN NEEDED" rows that the new token covers to "SET ✅".
+
+Optionally append a one-line entry to `docs/cloudflare-tokens.md`
+(create it if it doesn't exist):
+
+```text
+2026-06-13  cloudless-infra-mcp  expires 2027-06-13  scopes: …  by: themis
+```
+
+This is the audit trail that lets the *next* invocation of this skill
+know which token to expect.
+
+## Common failure modes
+
+- **"Invalid access token" only on a single MCP tool, but `verify` passes**
+  → The token is alive but the missing scope is what that tool needs.
+  Go back to Stage 1 and add the row from the failing tool's
+  documentation.
+
+- **HA LB workflows still fail after a fresh token**
+  → They read from SSM, not the cloud-session secret. Did Stage 2a run?
+  Re-run `store-cloudflare-token.yml -f apply=true`.
+
+- **"AUTH_INVALID_TOKEN_HEADER" from the GraphQL endpoint**
+  → The token format is correct but the header was typed `X-Auth-Key`
+  instead of `Authorization: Bearer`. GraphQL only accepts the latter.
+
+- **Token verify works in `curl` but the MCP still 401s**
+  → The cloud-session hook wasn't reloaded. Close + reopen the session.


### PR DESCRIPTION
## Why

The Cloudflare API token currently in the cloud-session secret store is **invalid** — every `mcp__cloudless-infra__cloudflare_*` tool returns `❌ Invalid access token`. That blocks:

- Workers-limit triage (couldn't read analytics to confirm PR #849's impact)
- The HA LB workflow (sitting in the pending-setup table)
- The Email-Obfuscation fix workflow (same table)
- The next time a warning email arrives and we want to look at the dashboard from chat

Manual rotation + dashboard prodding is the recurring pattern. This PR makes the next rotation a 60-second flow.

## What's in the PR

### `skills/cloudflare-token-doctor/SKILL.md` (251 lines)

Six-stage playbook mirroring the existing `terraform-doctor`:

| Stage | What |
|---|---|
| 0 | Diagnose via `/user/tokens/verify` — one curl, decision-tree per error code (1000 / 1001 / 10000). |
| 1 | Mint: dashboard Custom-Token flow with the full scope matrix (Path A) + mint-from-MCP recipe for narrower derivatives (Path B). |
| 2 | Store in SSM via `store-cloudflare-token.yml` *and* the cloud-session secret store — calls out the chicken-and-egg between them. |
| 3 | Smoke-test via the new script. |
| 4 | Verify the infra MCP works — concrete tools to retry and 4 common-failure-mode diagnostics. |
| 5 | Inventory and prune old tokens via the MCP. |
| 6 | Record the rotation in CLAUDE.md + optional `docs/cloudflare-tokens.md`. |

### `scripts/cf-token-smoketest.sh` (175 lines)

Self-contained smoke test. Reads token from `$CLOUDFLARE_API_TOKEN` or pulls from SSM. Exercises 7 scopes:

- Token verify (`/user/tokens/verify`)
- Zone:Read (`zones?name=…`)
- Zone Settings (`zones/<id>/settings`)
- DNS:Read (`zones/<id>/dns_records`)
- Analytics:Read (GraphQL viewer.zones)
- User API Tokens (`/user/tokens`)
- Workers Scripts (`accounts/<id>/workers/scripts`)

Per-scope pass/fail with colored output. Exit 1 if any scope is missing — safe to drop into CI gating. Validated with `bash -n`; ready to run.

### `.github/workflows/verify-cloudflare-token.yml` (97 lines)

`workflow_dispatch` only. Pulls the token from SSM (OIDC into AWS), `::add-mask::`s it before any use, runs the smoketest, surfaces output in the GitHub Step Summary. No leak surface — the value is passed via env (not outputs) between steps.

### `CLAUDE.md`

Pending-setup table updated. The two existing 'TOKEN NEEDED' entries now point at the doctor skill, and a third row tracks the current invalid-token state so a future agent (or future me) hits the skill instead of re-deriving the flow.

## What this PR does NOT do

Fix the actual token. That's a one-time dashboard step the human still owns (the chicken-and-egg: you need a token to make a token). Once you paste a new token, the doctor walks the rest of the flow autonomously.

## Testing

- `bash -n scripts/cf-token-smoketest.sh` → syntax OK
- The workflow uses the same OIDC + `aws ssm` + `::add-mask::` pattern as the already-merged `store-cloudflare-token.yml`
- Skill is documentation; renders fine in the file viewer