### PR TITLE
fix(infra): cf-token-smoketest Analytics window is 1h, not all-time

### DIFF
--- a/scripts/cf-token-smoketest.sh
+++ b/scripts/cf-token-smoketest.sh
@@ -116,10 +116,15 @@ if [ -n "$ZONE_ID" ]; then
 fi
 
 # ── 4. Analytics:Read (GraphQL) ──────────────────────────────────────────────
+# Cloudflare's httpRequests1hGroups dataset caps queries to a 3-day window.
+# Use the most recent hour so the test stays well under the limit and works
+# on a freshly minted token (no rolling cutover at midnight UTC).
 if [ -n "$ZONE_ID" ]; then
-  GQ_BODY="$(jq -nc --arg z "$ZONE_ID" '{
-    query: "query($z: String!) { viewer { zones(filter: {zoneTag: $z}) { httpRequests1hGroups(limit: 1, filter: {datetime_gt: \"2026-01-01T00:00:00Z\"}) { sum { requests } } } } }",
-    variables: { z: $z }
+  SINCE="$(date -u -d '1 hour ago' '+%Y-%m-%dT%H:00:00Z' 2>/dev/null || \
+           date -u -v-1H '+%Y-%m-%dT%H:00:00Z')"
+  GQ_BODY="$(jq -nc --arg z "$ZONE_ID" --arg s "$SINCE" '{
+    query: "query($z: String!, $s: Time!) { viewer { zones(filter: {zoneTag: $z}) { httpRequests1hGroups(limit: 1, filter: {datetime_geq: $s}) { sum { requests } } } } }",
+    variables: { z: $z, s: $s }
   }')"
   GQ="$(curl -sS -X POST -H "Authorization: Bearer $CF" \
     -H "Content-Type: application/json" \


### PR DESCRIPTION
Caught by `verify-cloudflare-token.yml` run [#27456129216](https://github.com/Themis128/cloudless.gr/actions/runs/27456129216). The freshly minted `cloudless-infra-mcp` token has `Analytics:Read` and was happy when probed directly — but the CI smoketest reported a false-negative:

```
✗  Analytics:Read — zone "…" cannot request a time range wider than 3d, but your query time range spans 23w2d4h9m53s948ms320us13ns
```

The smoketest's GraphQL query used `datetime_gt: "2026-01-01T00:00:00Z"` — i.e. all of 2026. Cloudflare's `httpRequests1hGroups` dataset caps queries to a 3-day window, so the query fails outright; the token's permissions never actually get checked.

## Fix

Use a 1-hour window (`datetime_geq: <one hour ago>`), computed via `date -u -d '1 hour ago'` with a BSD `date -u -v-1H` fallback. Adds a comment explaining the 3-day cap so the next person to read this doesn't widen it again.

## Verification

With this patch, the smoketest reports **7/7 pass** against the new token. Without it, 6/7. The token itself is unchanged.