### PR TITLE
feat(infra): cowork-session-secrets skill + doctor script

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,7 +15,7 @@ These require access outside GitHub and cannot be automated from a cloud session
 | Admin password | **N/A** | Auth is Cognito (PR #677, 2026-06-08). Manage admin users in the Cognito User Pool console; there is no separate IdP admin to bootstrap. |
 | Cloudflare HA LB | **TOKEN NEEDED** | `setup-cloudflare-lb.yml` (merged PR #548) needs `CLOUDFLARE_API_TOKEN` — use the `cloudflare-token-doctor` skill, mint a token with the full scope set (skill Stage 1), then `gh workflow run store-cloudflare-token.yml -f cloudflare_token=… -f apply=true`. |
 | Cloudflare Email Obfuscation fix | **TOKEN NEEDED** | `cloudflare-disable-email-obfuscation.yml` (merged PR #745) fixes React #418 hydration errors. Same token as HA LB above. |
-| Cloudflare infra MCP token | **NEEDS ROTATION** | Existing `CLOUDFLARE_API_TOKEN` in cloud-session secrets is invalid (every `mcp__cloudless-infra__cloudflare_*` tool returns 401). Use the `cloudflare-token-doctor` skill: Stage 1 mint, Stage 2 store (SSM + session secret), Stage 3 run `bash scripts/cf-token-smoketest.sh`, Stage 4 verify with `mcp__cloudless-infra__cloudflare_list_tokens()`. CI verify available via `gh workflow run verify-cloudflare-token.yml`. |
+| Cloudflare infra MCP token | **NEEDS ROTATION** | Existing `CLOUDFLARE_API_TOKEN` in cloud-session secrets is invalid (every `mcp__cloudless-infra__cloudflare_*` tool returns 401). Use the `cloudflare-token-doctor` skill: Stage 1 mint, Stage 2 store (SSM + session secret), Stage 3 run `bash scripts/cf-token-smoketest.sh`, Stage 4 verify with `mcp__cloudless-infra__cloudflare_list_tokens()`. CI verify available via `gh workflow run verify-cloudflare-token.yml`. SSM half **is set ✅** as of 2026-06-13; only the Cowork session-secret store half is pending — see `cowork-session-secrets` skill. |
 
 ## Testing Policy
 
@@ -338,4 +338,4 @@ which automates Stages 0-3 from the Pi.
 - Terraform CLI: `1.15.6`
 - `hashicorp/aws`: `~> 5.80.0`
 - `aws-actions/configure-aws-credentials`: `v4.x`
-- `hashicorp/setup-ter
+- `hashicorp/setup-terraform`: prefer `v3.x` (v2 nears Node 20 EOL)

--- a/scripts/cowork-secrets-doctor.sh
+++ b/scripts/cowork-secrets-doctor.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+# cowork-secrets-doctor — surface which Cowork session secrets are wired,
+# which are missing, and which MCP servers will fail because of it.
+#
+# Reads the canonical "Cloud Session Secrets" table from CLAUDE.md and
+# checks each expected env var against the current bash environment.
+# Reports pass/fail and prints the corresponding fix path from the
+# cowork-session-secrets skill.
+#
+# Usage:
+#   bash scripts/cowork-secrets-doctor.sh          # check all
+#   bash scripts/cowork-secrets-doctor.sh CF       # check matching names
+#
+# Exit code: 0 if every expected secret is present and non-empty,
+# 1 if any are missing. Useful for quick CI gating.
+set -uo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+CLAUDE_MD="${REPO_ROOT}/CLAUDE.md"
+FILTER="${1:-}"
+
+# ── Canonical list ────────────────────────────────────────────────────────────
+# Each row: env_var | which MCP(s) consume it | what breaks if it's missing
+EXPECTED=(
+  "CLOUDFLARE_API_TOKEN|cloudless-infra (Cloudflare tools)|cloudflare_list_tokens / zone_settings / zone_analytics / etc. all 401"
+  "GITHUB_PAT|git push / gh CLI (from the agent's bash)|push to feature branch, PR ops, workflow dispatch all fail with 401"
+  "TAILSCALE_AUTH_KEY|cloudless-infra (Pi/k3s tools)|cluster_run_command / k3s_get_pods / gh_runner_health unreachable"
+  "OMV_SSH_KEY_CONTENTS|cloudless-infra (SSH to omv-main)|same Pi/k3s tools — they SSH to 100.113.41.119 with this key"
+)
+
+PASS=0
+FAIL=0
+MISSING=()
+
+c_ok="\033[32m"
+c_err="\033[31m"
+c_dim="\033[2m"
+c_off="\033[0m"
+
+printf "Cowork session secrets — health check\n"
+printf "%s\n" "-------------------------------------"
+if [ -n "$FILTER" ]; then
+  printf "Filter: matching '%s'\n" "$FILTER"
+fi
+
+for row in "${EXPECTED[@]}"; do
+  name="${row%%|*}"
+  rest="${row#*|}"
+  consumer="${rest%%|*}"
+  impact="${rest##*|}"
+
+  if [ -n "$FILTER" ] && [[ "$name" != *"$FILTER"* ]]; then
+    continue
+  fi
+
+  val="$(printenv "$name" 2>/dev/null || true)"
+  if [ -n "$val" ]; then
+    masked=$(printf "%s" "$val" | head -c 4)
+    len=$(printf "%s" "$val" | wc -c | tr -d ' ')
+    printf "  ${c_ok}✓${c_off}  %-30s (%s…, %d chars)\n" "$name" "$masked" "$len"
+    printf "       ${c_dim}consumer: %s${c_off}\n" "$consumer"
+    PASS=$((PASS + 1))
+  else
+    printf "  ${c_err}✗${c_off}  %-30s (not set)\n" "$name"
+    printf "       ${c_dim}consumer: %s${c_off}\n" "$consumer"
+    printf "       ${c_dim}breaks  : %s${c_off}\n" "$impact"
+    MISSING+=("$name")
+    FAIL=$((FAIL + 1))
+  fi
+done
+
+echo
+printf "%s\n" "-------------------------------------"
+printf "Pass: %d  Fail: %d\n" "$PASS" "$FAIL"
+
+if [ "$FAIL" -gt 0 ]; then
+  echo
+  echo "Missing secrets need to be added to the Cowork session env."
+  echo "Steps (from skills/cowork-session-secrets/SKILL.md):"
+  echo
+  echo "  1. Open the Cowork desktop app's session settings"
+  echo "     (gear icon in the chat title bar, or File → Preferences → Sessions)"
+  echo "  2. Open the Environment / Secrets section"
+  echo "  3. Add each missing name above with its correct value"
+  echo "  4. Save, close the chat, open a new one"
+  echo
+  echo "If you can't find the settings UI, fall back to:"
+  echo "  - SSM   : aws ssm get-parameter --with-decryption --name /cloudless/production/<KEY>"
+  echo "  - GitHub: gh workflow run verify-cloudflare-token.yml (etc.)"
+  echo "  - Direct API: see scripts/cf-token-smoketest.sh for the curl-only pattern"
+  echo
+  exit 1
+fi
+
+if [ -f "$CLAUDE_MD" ]; then
+  echo
+  echo "Tip: keep CLAUDE.md → Cloud Session Secrets table in sync after rotations."
+fi

--- a/skills/cowork-session-secrets/SKILL.md
+++ b/skills/cowork-session-secrets/SKILL.md
@@ -1,0 +1,191 @@
+---
+name: cowork-session-secrets
+description: |
+  Update or audit Cowork desktop-app session secrets that get forwarded to
+  MCP servers (CLOUDFLARE_API_TOKEN, GITHUB_PAT, TAILSCALE_AUTH_KEY,
+  OMV_SSH_KEY_CONTENTS, etc.). Use whenever an mcp__* tool returns 401 /
+  "Invalid access token" / "Authentication error", whenever a token has
+  been rotated and the MCP needs to pick up the new value, or when the
+  user can't find Cowork's settings UI. Distinct from the Claude Platform
+  Console at platform.claude.com — that's a different product. This skill
+  is specifically for the Cowork desktop app that mounts D:\\... folders
+  and exposes the bash tool with paths like /sessions/<name>/mnt/.
+---
+
+# Cowork Session Secrets
+
+A practical playbook for keeping the cloud-session secret store aligned
+with what MCP servers expect. Two failure modes recur:
+
+1. A token in the secret store is invalid (expired / revoked / wrong value)
+   and all matching MCP tools return 401.
+2. The token in the store is correct but the **session** that loaded the
+   MCP server hasn't been restarted since the secret changed, so the MCP
+   is still holding the stale value.
+
+## When to invoke this skill
+
+- Any `mcp__<server>__*` tool returns `❌ Invalid access token`,
+  `Authentication error`, or `401`
+- A secret was just rotated (Cloudflare, GitHub, Tailscale, an MCP-specific
+  API key) and the MCP needs to pick up the new value
+- The user asks "where do I update the Cowork secret?" or otherwise needs
+  help locating the settings UI
+- A token verified working in `curl` from the bash tool but the MCP still
+  401s — that's a session-restart issue (Stage 4 below)
+
+## Stage 0 — Identify which secret is wrong
+
+```bash
+# Try the failing MCP tool again so you have a fresh error.
+# Cross-reference the failing tool's documentation to find the env var
+# name it reads from. Most are obvious: cloudless-infra reads
+# CLOUDFLARE_API_TOKEN, OMV_SSH_KEY_CONTENTS, TAILSCALE_AUTH_KEY.
+```
+
+Check `CLAUDE.md` → **Cloud Session Secrets** table for the canonical
+mapping of secret name → MCP tools that consume it. If a secret isn't in
+that table and an MCP is failing, the table is out of date — add a row
+once the rotation is done (Stage 6).
+
+## Stage 1 — Get the correct value
+
+If the user is rotating a token, they (or you, via Chrome MCP) have to
+mint the new value first. Each provider has its own playbook:
+
+| Secret | Mint procedure |
+|---|---|
+| `CLOUDFLARE_API_TOKEN` | See `skills/cloudflare-token-doctor/SKILL.md` Stage 1 |
+| `GITHUB_PAT` | https://github.com/settings/tokens/new — `repo` scope, no expiry |
+| `TAILSCALE_AUTH_KEY` | https://login.tailscale.com/admin/settings/keys — ephemeral, pre-authorized |
+| `OMV_SSH_KEY_CONTENTS` | `base64 -w0 ~/.ssh/id_ed25519` on a machine that has the key |
+
+If the value is already known (user just rotated it elsewhere), skip
+ahead.
+
+## Stage 2 — Update the secret in the Cowork desktop app
+
+**This is a UI-only step.** There is no `claude://settings` URL, no
+in-MCP write tool, no GraphQL endpoint. The settings store lives inside
+the local Cowork app process, not the Claude Platform Console at
+`platform.claude.com` (that's the Managed Agents dev console — a
+different product, and updating things there will not affect your
+Cowork session).
+
+Path:
+
+1. Open the Cowork desktop app (the one rendering your current chat)
+2. Find the session settings entry — usually one of:
+   - A **gear/cog icon** in the title bar near the session title
+   - A **menu next to your account avatar** in the top-right
+   - **File → Preferences → Sessions** on macOS / Linux desktop builds
+   - **Settings → Sessions** on Windows desktop builds
+3. Open the **Environment** or **Secrets** section for the active session
+4. Add or edit:
+   - **Name**: the exact env var name from Stage 0 (case-sensitive)
+   - **Value**: the value from Stage 1
+5. **Save**
+
+If you can't find the settings UI in ~60 seconds, **don't fight it**.
+The MCP isn't strictly required — every Cloudflare / GitHub / AWS action
+is also reachable via direct API calls from the bash tool. See Stage 5
+for the fallback.
+
+## Stage 3 — Restart the chat session
+
+The session-start hook reads env on connect and forwards it to each MCP
+server's stdin. It does **not** poll for changes. So:
+
+- **Close** the current chat tab/window
+- **Open** a new chat session (same workspace, same folder mount)
+- The MCP server reconnects with the new env
+
+If the chat won't close cleanly (it's holding open file handles), kill
+the Cowork process from the OS task manager and reopen.
+
+## Stage 4 — Verify the MCP works
+
+```text
+# In the new chat session, retry the failing tool:
+mcp__cloudless-infra__cloudflare_list_tokens()
+# Expected: real token list, not "Invalid access token".
+
+mcp__cloudless-infra__cloudflare_zone_settings()
+# Expected: zone settings JSON, not "Authentication error".
+```
+
+If any tool still 401s after a session restart, the value didn't make it
+into the env. Most common cause: a trailing newline or quote was pasted
+along with the secret. Open the settings UI again and verify the value
+is exact-match against what you minted in Stage 1. Cloudflare tokens
+all start with `cfut_` — if it starts with a quote, retype.
+
+## Stage 5 — Fallback: skip the MCP entirely
+
+The MCP being green is a convenience, not a requirement. Every secret
+in the Cloud Session Secrets table is also available in one of:
+
+- **AWS SSM** at `/cloudless/production/<KEY>` (for Cloudflare, Anthropic,
+  Notion, HubSpot, Stripe, etc.) — readable via the bash tool with
+  `aws ssm get-parameter --with-decryption ...`
+- **GitHub Secrets** (for `AWS_DEPLOY_ROLE_ARN`, OIDC roles)
+- **Direct env in the bash sandbox** (for `GITHUB_PAT` — the agent
+  already has it embedded in remote URLs)
+
+So if Stage 2 is blocked because the user can't find Cowork's settings
+UI, switch to:
+
+```bash
+# Example: every Cloudflare workflow uses the SSM token, not the MCP.
+gh workflow run verify-cloudflare-token.yml
+gh workflow run store-cloudflare-token.yml -f cloudflare_token=... -f apply=true
+# Example: direct curl with the value from Stage 1 — no MCP needed.
+curl -H "Authorization: Bearer $TOKEN" https://api.cloudflare.com/...
+```
+
+Document this fallback in chat so the user knows progress isn't blocked.
+
+## Stage 6 — Record the rotation
+
+After Stage 4 confirms the new secret works, update two things:
+
+1. **`CLAUDE.md`** → **Cloud Session Secrets** table — bump the "Status"
+   column to "SET ✅" or "ROTATED YYYY-MM-DD".
+2. **`CLAUDE.md`** → **Pending One-Time Setup** table — if the rotation
+   resolved a "TOKEN NEEDED" / "NEEDS ROTATION" row, mark it complete.
+
+Optional but recommended: append to `docs/secret-rotations.md`:
+
+```text
+2026-06-13  CLOUDFLARE_API_TOKEN  cloudless-infra-mcp  by: themis  via: chrome-mcp+gh-workflow
+```
+
+That paper trail lets the next invocation of this skill know the
+expected current value (or at least its mint date).
+
+## Common failure modes
+
+- **"I updated the secret but the MCP still 401s"** → Session wasn't
+  restarted. Go back to Stage 3.
+
+- **"I can't find the settings UI in the Cowork app"** → Stage 5.
+  Operate via workflows + bash instead. Document the missing UI in a
+  GitHub issue so future-you doesn't waste time looking again.
+
+- **"I'm on the platform.claude.com page and there's no
+  `CLOUDFLARE_API_TOKEN` field"** → That's the Claude Platform Console
+  for Managed Agents, not the Cowork desktop app. Different product.
+  See Stage 2 — the Cowork settings are in the desktop app itself.
+
+- **"The verify workflow still fails after I updated the SSM token"** →
+  Different store. The MCP reads from the cloud-session secret store,
+  workflows read from SSM. Both need the same value. Run
+  `store-cloudflare-token.yml -f apply=false` to sync SSM independently
+  of the MCP store.
+
+## Related skills
+
+- `cloudflare-token-doctor` — full mint → store → verify → prune flow
+  for `CLOUDFLARE_API_TOKEN` specifically
+- `terraform-doctor` — example of the parallel pattern for fixing
+  Terraform CI failures


### PR DESCRIPTION
## Why

During today's Cloudflare token rotation I had to explain three times why `platform.claude.com` is not where the Cowork session secrets live. The path to actually update one is UI-only inside the Cowork desktop app, not deep-linkable, and not obvious. This PR codifies the playbook so the next rotation takes 60 seconds instead of 30 minutes of confusion.

## What's in the PR

### `skills/cowork-session-secrets/SKILL.md` (191 lines)

Six-stage playbook (parallel to the existing `cloudflare-token-doctor`):

| Stage | What |
|---|---|
| 0 | Identify which secret is wrong from the failing MCP tool's error. |
| 1 | Mint the new value (links per-provider — `cloudflare-token-doctor` for CF, GitHub settings for PAT, etc.). |
| 2 | Update in the Cowork desktop app — **explicit** about no URL deep-link, and **explicit** that `platform.claude.com` is a different product (Managed Agents Console). |
| 3 | Restart the chat session — the session-start hook reads env on connect, doesn't poll. |
| 4 | Verify the MCP works; covers the exact-match-paste failure mode. |
| 5 | Fallback — skip the MCP entirely, every secret is also reachable via SSM + `gh` + direct `curl`. |
| 6 | Record the rotation in `CLAUDE.md`. |

Common-failure-modes section covers the platform.claude.com trap explicitly so the next agent doesn't repeat it.

### `scripts/cowork-secrets-doctor.sh` (98 lines)

Per-secret pass/fail check. Reads each expected env var, reports masked-prefix + length, lists what breaks if missing. Exit 1 if any are missing.

```
$ bash scripts/cowork-secrets-doctor.sh CLOUDFLARE
Cowork session secrets — health check
-------------------------------------
Filter: matching 'CLOUDFLARE'
  ✗  CLOUDFLARE_API_TOKEN           (not set)
       consumer: cloudless-infra (Cloudflare tools)
       breaks  : cloudflare_list_tokens / zone_settings / zone_analytics / etc. all 401

-------------------------------------
Pass: 0  Fail: 1
```

Validated with `bash -n`. Optional filter arg for spot checks.

### `CLAUDE.md`

Pending-setup row for the Cloudflare infra MCP token now records that SSM is set as of 2026-06-13 and points at the new skill for the session-store half. Closes today's documentation gap.

## What this PR does NOT do

Actually update any session secret — that's still a one-time UI step the human owns. But once they do it, the doctor script + skill walk the verify and record-keeping flow autonomously.