### PR TITLE
feat(analytics): PR C1 — GSC cache lib + AnalyticsCache Dynamo table

### DIFF
--- a/__tests__/gsc-cache.test.ts
+++ b/__tests__/gsc-cache.test.ts
@@ -1,0 +1,251 @@
+/**
+ * Unit tests for src/lib/gsc-cache.ts — the read-through cache for Google
+ * Search Console responses.
+ *
+ * AWS SDK Dynamo client is mocked with the regular-function constructor
+ * pattern used by every other Dynamo-backed lib in this repo
+ * (admin-notifications.test.ts, client-portals.test.ts).
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+const { mockSend, getCalls, putCalls } = vi.hoisted(() => ({
+  mockSend: vi.fn(),
+  getCalls: [] as Record<string, unknown>[],
+  putCalls: [] as Record<string, unknown>[],
+}));
+
+vi.mock("@aws-sdk/client-dynamodb", () => ({
+  DynamoDBClient: vi.fn().mockImplementation(function () {
+    return { send: mockSend };
+  }),
+  GetItemCommand: vi.fn().mockImplementation(function (input: Record<string, unknown>) {
+    getCalls.push(input);
+    return { __cmd: "Get", input };
+  }),
+  PutItemCommand: vi.fn().mockImplementation(function (input: Record<string, unknown>) {
+    putCalls.push(input);
+    return { __cmd: "Put", input };
+  }),
+}));
+
+vi.mock("@/lib/stripe-transactions", () => ({
+  resolveDynamoEndpoint: () => undefined,
+}));
+
+describe("gsc-cache", () => {
+  beforeEach(() => {
+    mockSend.mockReset();
+    getCalls.length = 0;
+    putCalls.length = 0;
+    process.env.ANALYTICS_CACHE_TABLE = "TestCache";
+  });
+  afterEach(() => {
+    delete process.env.ANALYTICS_CACHE_TABLE;
+  });
+
+  describe("paramsHash", () => {
+    it("returns 'default' for empty params", async () => {
+      const { paramsHash } = await import("@/lib/gsc-cache");
+      expect(paramsHash()).toBe("default");
+      expect(paramsHash({})).toBe("default");
+    });
+
+    it("is property-order invariant", async () => {
+      const { paramsHash } = await import("@/lib/gsc-cache");
+      expect(paramsHash({ a: 1, b: 2 })).toBe(paramsHash({ b: 2, a: 1 }));
+    });
+
+    it("ignores undefined and null values", async () => {
+      const { paramsHash } = await import("@/lib/gsc-cache");
+      expect(paramsHash({ a: 1, b: undefined, c: null })).toBe(paramsHash({ a: 1 }));
+    });
+
+    it("changes when values change", async () => {
+      const { paramsHash } = await import("@/lib/gsc-cache");
+      expect(paramsHash({ days: 7 })).not.toBe(paramsHash({ days: 28 }));
+    });
+
+    it("returns a 16-char hex string for non-empty params", async () => {
+      const { paramsHash } = await import("@/lib/gsc-cache");
+      const h = paramsHash({ days: 7, limit: 20 });
+      expect(h).toMatch(/^[0-9a-f]{16}$/);
+    });
+  });
+
+  describe("getCached", () => {
+    it("returns null when ANALYTICS_CACHE_TABLE is unset", async () => {
+      delete process.env.ANALYTICS_CACHE_TABLE;
+      const { getCached } = await import("@/lib/gsc-cache");
+      const r = await getCached("seo", {});
+      expect(r).toBeNull();
+      expect(mockSend).not.toHaveBeenCalled();
+    });
+
+    it("returns null when no item exists", async () => {
+      mockSend.mockResolvedValueOnce({});
+      const { getCached } = await import("@/lib/gsc-cache");
+      const r = await getCached("seo", {});
+      expect(r).toBeNull();
+    });
+
+    it("returns parsed payload with ageSeconds when present + fresh", async () => {
+      const storedAt = new Date(Date.now() - 60_000).toISOString();
+      mockSend.mockResolvedValueOnce({
+        Item: {
+          storedAt: { S: storedAt },
+          payload: { S: JSON.stringify({ clicks: 42 }) },
+        },
+      });
+      const { getCached } = await import("@/lib/gsc-cache");
+      const r = await getCached<{ clicks: number }>("seo", { days: 28 }, 3600);
+      expect(r).not.toBeNull();
+      expect(r!.payload.clicks).toBe(42);
+      expect(r!.ageSeconds).toBeGreaterThanOrEqual(60);
+      expect(r!.ageSeconds).toBeLessThan(120);
+      expect(r!.stale).toBe(false);
+    });
+
+    it("marks entry stale when older than ttlSeconds", async () => {
+      const storedAt = new Date(Date.now() - 7200_000).toISOString();
+      mockSend.mockResolvedValueOnce({
+        Item: {
+          storedAt: { S: storedAt },
+          payload: { S: JSON.stringify({ x: 1 }) },
+        },
+      });
+      const { getCached } = await import("@/lib/gsc-cache");
+      const r = await getCached("seo", {}, 3600);
+      expect(r!.stale).toBe(true);
+    });
+
+    it("returns null on malformed JSON payload", async () => {
+      mockSend.mockResolvedValueOnce({
+        Item: {
+          storedAt: { S: new Date().toISOString() },
+          payload: { S: "{not-json" },
+        },
+      });
+      const { getCached } = await import("@/lib/gsc-cache");
+      const r = await getCached("seo", {});
+      expect(r).toBeNull();
+    });
+
+    it("returns null and swallows error on Dynamo failure", async () => {
+      mockSend.mockRejectedValueOnce(new Error("dynamo down"));
+      const { getCached } = await import("@/lib/gsc-cache");
+      const r = await getCached("seo", {});
+      expect(r).toBeNull();
+    });
+  });
+
+  describe("setCached", () => {
+    it("is a no-op when table is unset", async () => {
+      delete process.env.ANALYTICS_CACHE_TABLE;
+      const { setCached } = await import("@/lib/gsc-cache");
+      await setCached("seo", {}, { clicks: 1 });
+      expect(mockSend).not.toHaveBeenCalled();
+    });
+
+    it("writes serialized payload with storedAt + ttlSeconds", async () => {
+      mockSend.mockResolvedValueOnce({});
+      const { setCached } = await import("@/lib/gsc-cache");
+      await setCached("seo", { days: 7 }, { clicks: 123 }, 1800);
+      expect(putCalls).toHaveLength(1);
+      const item = (putCalls[0] as { Item: Record<string, { S?: string; N?: string }> }).Item;
+      expect(item.pk.S).toBe("seo");
+      expect(item.sk.S).toMatch(/^[0-9a-f]{16}$/);
+      expect(JSON.parse(item.payload.S!).clicks).toBe(123);
+      expect(typeof item.storedAt.S).toBe("string");
+      expect(item.ttlSeconds.N).toBe("1800");
+    });
+
+    it("swallows Dynamo errors silently (best-effort)", async () => {
+      mockSend.mockRejectedValueOnce(new Error("boom"));
+      const { setCached } = await import("@/lib/gsc-cache");
+      await expect(setCached("seo", {}, { x: 1 })).resolves.toBeUndefined();
+    });
+  });
+
+  describe("readThrough", () => {
+    it("serves from cache when fresh, never calls fetcher", async () => {
+      mockSend.mockResolvedValueOnce({
+        Item: {
+          storedAt: { S: new Date(Date.now() - 60_000).toISOString() },
+          payload: { S: JSON.stringify({ clicks: 9 }) },
+        },
+      });
+      const { readThrough } = await import("@/lib/gsc-cache");
+      const fetcher = vi.fn().mockResolvedValue({ clicks: 999 });
+      const r = await readThrough("seo", {}, fetcher, { ttlSeconds: 3600 });
+      expect(r.source).toBe("cache");
+      expect((r.value as { clicks: number }).clicks).toBe(9);
+      expect(fetcher).not.toHaveBeenCalled();
+    });
+
+    it("calls fetcher and writes back when no cache entry exists", async () => {
+      mockSend.mockResolvedValueOnce({}); // empty get
+      mockSend.mockResolvedValueOnce({}); // put
+      const { readThrough } = await import("@/lib/gsc-cache");
+      const fetcher = vi.fn().mockResolvedValue({ clicks: 50 });
+      const r = await readThrough("seo", {}, fetcher);
+      expect(r.source).toBe("live");
+      expect((r.value as { clicks: number }).clicks).toBe(50);
+      expect(fetcher).toHaveBeenCalledTimes(1);
+      // The put should have been issued via send (2 calls total).
+      expect(mockSend).toHaveBeenCalledTimes(2);
+    });
+
+    it("calls fetcher when entry is stale", async () => {
+      mockSend.mockResolvedValueOnce({
+        Item: {
+          storedAt: { S: new Date(Date.now() - 7200_000).toISOString() },
+          payload: { S: JSON.stringify({ clicks: 1 }) },
+        },
+      });
+      mockSend.mockResolvedValueOnce({}); // put
+      const { readThrough } = await import("@/lib/gsc-cache");
+      const fetcher = vi.fn().mockResolvedValue({ clicks: 2 });
+      const r = await readThrough("seo", {}, fetcher, { ttlSeconds: 3600 });
+      expect(r.source).toBe("live");
+      expect((r.value as { clicks: number }).clicks).toBe(2);
+    });
+
+    it("falls back to stale cache when fetcher throws and stale is within window", async () => {
+      mockSend.mockResolvedValueOnce({
+        Item: {
+          storedAt: { S: new Date(Date.now() - 7200_000).toISOString() },
+          payload: { S: JSON.stringify({ clicks: 5 }) },
+        },
+      });
+      const { readThrough } = await import("@/lib/gsc-cache");
+      const fetcher = vi.fn().mockRejectedValue(new Error("quota"));
+      const r = await readThrough("seo", {}, fetcher, {
+        ttlSeconds: 3600,
+        acceptStaleSeconds: 24 * 3600,
+      });
+      expect(r.source).toBe("stale");
+      expect((r.value as { clicks: number }).clicks).toBe(5);
+    });
+
+    it("re-throws when fetcher fails and no acceptable stale cache exists", async () => {
+      mockSend.mockResolvedValueOnce({}); // empty get
+      const { readThrough } = await import("@/lib/gsc-cache");
+      const fetcher = vi.fn().mockRejectedValue(new Error("quota"));
+      await expect(readThrough("seo", {}, fetcher)).rejects.toThrow("quota");
+    });
+
+    it("re-throws when stale cache is past acceptStaleSeconds", async () => {
+      mockSend.mockResolvedValueOnce({
+        Item: {
+          storedAt: { S: new Date(Date.now() - 7 * 24 * 3600_000).toISOString() },
+          payload: { S: JSON.stringify({ clicks: 5 }) },
+        },
+      });
+      const { readThrough } = await import("@/lib/gsc-cache");
+      const fetcher = vi.fn().mockRejectedValue(new Error("quota"));
+      await expect(
+        readThrough("seo", {}, fetcher, { ttlSeconds: 3600, acceptStaleSeconds: 24 * 3600 }),
+      ).rejects.toThrow("quota");
+    });
+  });
+});

--- a/src/lib/gsc-cache.ts
+++ b/src/lib/gsc-cache.ts
@@ -1,0 +1,202 @@
+import {
+  DynamoDBClient,
+  GetItemCommand,
+  PutItemCommand,
+  type AttributeValue,
+} from "@aws-sdk/client-dynamodb";
+import { resolveDynamoEndpoint } from "@/lib/stripe-transactions";
+import { createHash } from "crypto";
+
+/**
+ * Read-through cache for slow third-party data (Google Search Console).
+ *
+ * GSC has per-minute, per-day, and 50k-row-per-day quotas. Every admin tab
+ * open used to hit the API fresh. This cache lets each route serve from
+ * Dynamo if a fresh-enough entry exists, falling back to the live API when
+ * not. The hourly /api/cron/gsc-cache-refresh job pre-warms the common
+ * queries so admin users see instant responses.
+ *
+ * Schema:
+ *   pk = "<route>"                e.g. "seo", "keywords", "ctr-opportunities"
+ *   sk = "<params-hash>"          deterministic for a given query-string
+ *   payload (S, JSON)             the cached response body
+ *   storedAt (S, ISO 8601)        when we wrote it
+ *   ttlSeconds (N)                requested TTL at write time
+ *
+ * Failure model: safe. If the table is not configured (no env var), or any
+ * Dynamo operation throws, helpers return null / undefined and callers fall
+ * back to the live API path. The cache is never on the critical path.
+ */
+
+const REGION = process.env.AWS_REGION || "us-east-1";
+
+let dynamoClient: DynamoDBClient | null = null;
+function getDynamoClient(): DynamoDBClient {
+  dynamoClient ??= new DynamoDBClient({
+    region: REGION,
+    endpoint: resolveDynamoEndpoint(),
+  });
+  return dynamoClient;
+}
+
+function getTableName(): string | null {
+  return process.env.ANALYTICS_CACHE_TABLE?.trim() || null;
+}
+
+/**
+ * Hash an arbitrary params object into a short deterministic key suffix.
+ * Same input → same hash, regardless of property order, on every Lambda.
+ */
+export function paramsHash(params: Record<string, unknown> = {}): string {
+  // Sort keys so {a:1, b:2} and {b:2, a:1} hash to the same value.
+  const entries = Object.entries(params)
+    .filter(([, v]) => v !== undefined && v !== null)
+    .sort(([a], [b]) => a.localeCompare(b));
+  if (entries.length === 0) return "default";
+  const canonical = JSON.stringify(entries);
+  return createHash("sha256").update(canonical).digest("hex").slice(0, 16);
+}
+
+export interface CacheEntry<T> {
+  payload: T;
+  storedAt: string;
+  ageSeconds: number;
+  stale: boolean;
+}
+
+function toItem<T>(
+  route: string,
+  hash: string,
+  payload: T,
+  ttlSeconds: number,
+): Record<string, AttributeValue> {
+  return {
+    pk: { S: route },
+    sk: { S: hash },
+    payload: { S: JSON.stringify(payload) },
+    storedAt: { S: new Date().toISOString() },
+    ttlSeconds: { N: String(ttlSeconds) },
+  };
+}
+
+function fromItem<T>(
+  item: Record<string, AttributeValue>,
+  ttlSeconds: number,
+): CacheEntry<T> | null {
+  const storedAt = item.storedAt?.S;
+  const raw = item.payload?.S;
+  if (!storedAt || !raw) return null;
+  let payload: T;
+  try {
+    payload = JSON.parse(raw) as T;
+  } catch {
+    return null;
+  }
+  const storedAtMs = Date.parse(storedAt);
+  const ageSeconds = Math.max(0, Math.floor((Date.now() - storedAtMs) / 1000));
+  return {
+    payload,
+    storedAt,
+    ageSeconds,
+    stale: ageSeconds > ttlSeconds,
+  };
+}
+
+/**
+ * Read a cached entry. Returns null if:
+ *   - the table is not configured (local dev / partial deploy)
+ *   - no entry exists for (route, hash)
+ *   - the entry is malformed
+ * The caller decides whether a stale entry is acceptable; both fresh and
+ * stale entries are returned with their `ageSeconds` filled in.
+ */
+export async function getCached<T = unknown>(
+  route: string,
+  params: Record<string, unknown> = {},
+  ttlSeconds = 3600,
+): Promise<CacheEntry<T> | null> {
+  const table = getTableName();
+  if (!table) return null;
+  const hash = paramsHash(params);
+  try {
+    const out = await getDynamoClient().send(
+      new GetItemCommand({
+        TableName: table,
+        Key: { pk: { S: route }, sk: { S: hash } },
+      }),
+    );
+    if (!out.Item) return null;
+    return fromItem<T>(out.Item, ttlSeconds);
+  } catch (err) {
+    console.warn(
+      "[gsc-cache] getCached failed:",
+      err instanceof Error ? err.message : err,
+    );
+    return null;
+  }
+}
+
+/**
+ * Write a payload to the cache. Best-effort — failures are logged and
+ * swallowed because cache writes must never break the user-facing path.
+ */
+export async function setCached<T = unknown>(
+  route: string,
+  params: Record<string, unknown> = {},
+  payload: T,
+  ttlSeconds = 3600,
+): Promise<void> {
+  const table = getTableName();
+  if (!table) return;
+  const hash = paramsHash(params);
+  try {
+    await getDynamoClient().send(
+      new PutItemCommand({
+        TableName: table,
+        Item: toItem(route, hash, payload, ttlSeconds),
+      }),
+    );
+  } catch (err) {
+    console.warn(
+      "[gsc-cache] setCached failed:",
+      err instanceof Error ? err.message : err,
+    );
+  }
+}
+
+/**
+ * Read-through helper: serve from cache if fresh; otherwise call `fetcher`,
+ * write the result back, return it. Always returns the live (or freshly
+ * fetched) value. Pass `acceptStaleSeconds` to keep serving slightly-stale
+ * data when the live API fails (degraded-mode pattern from the GSC quota
+ * best practices).
+ */
+export async function readThrough<T>(
+  route: string,
+  params: Record<string, unknown>,
+  fetcher: () => Promise<T>,
+  opts: { ttlSeconds?: number; acceptStaleSeconds?: number } = {},
+): Promise<{ value: T; source: "cache" | "live" | "stale"; ageSeconds: number }> {
+  const ttlSeconds = opts.ttlSeconds ?? 3600;
+  const acceptStaleSeconds = opts.acceptStaleSeconds ?? 24 * 3600;
+
+  const cached = await getCached<T>(route, params, ttlSeconds);
+  if (cached && !cached.stale) {
+    return { value: cached.payload, source: "cache", ageSeconds: cached.ageSeconds };
+  }
+
+  try {
+    const live = await fetcher();
+    void setCached(route, params, live, ttlSeconds);
+    return { value: live, source: "live", ageSeconds: 0 };
+  } catch (err) {
+    if (cached && cached.ageSeconds <= acceptStaleSeconds) {
+      console.warn(
+        `[gsc-cache] live fetch failed for ${route}, serving stale (age=${cached.ageSeconds}s):`,
+        err instanceof Error ? err.message : err,
+      );
+      return { value: cached.payload, source: "stale", ageSeconds: cached.ageSeconds };
+    }
+    throw err;
+  }
+}

--- a/sst.config.ts
+++ b/sst.config.ts
@@ -16,6 +16,7 @@ function buildSiteEnvironment(
   stripeTransactionsTableName: $util.Output<string>,
   userProfileTableName: $util.Output<string>,
   adminNotificationsTableName: $util.Output<string>,
+  analyticsCacheTableName: $util.Output<string>,
   authSecret?: $util.Output<string>,
   cognito?: {
     issuer: $util.Output<string>;
@@ -43,6 +44,7 @@ function buildSiteEnvironment(
     STRIPE_TRANSACTIONS_TABLE: stripeTransactionsTableName,
     USER_PROFILE_TABLE: userProfileTableName,
     ADMIN_NOTIFICATIONS_TABLE: adminNotificationsTableName,
+    ANALYTICS_CACHE_TABLE: analyticsCacheTableName,
     // Cloudflare Workers AI — consumed by /api/admin/ai/generate. Passed from
     // the deploy workflow env; the route returns 503 when absent.
     ...(process.env.CLOUDFLARE_ACCOUNT_ID && process.env.CLOUDFLARE_API_TOKEN
@@ -175,6 +177,25 @@ export default {
       },
     });
 
+    // Read-through cache for Google Search Console responses.
+    //
+    // GSC has per-minute / per-day / 50k-rows-per-day quotas, and every
+    // admin tab open today calls 1-2 endpoints directly. This table caches
+    // each (route, params) combination keyed by a deterministic hash, with
+    // TTL enforced application-side. See src/lib/gsc-cache.ts.
+    //
+    // pk = "<route>"  e.g. "seo", "keywords", "ctr-opportunities"
+    // sk = "<params-hash>"  deterministic for a given query-string
+    //
+    // Refreshed hourly by /api/cron/gsc-cache-refresh (PR C3).
+    const analyticsCacheTable = new sst.aws.Dynamo("AnalyticsCache", {
+      fields: {
+        pk: "string",
+        sk: "string",
+      },
+      primaryIndex: { hashKey: "pk", rangeKey: "sk" },
+    });
+
     // -------------------------------------------------------------------------
     // Cognito User Pool — always-up AWS auth
     //
@@ -281,6 +302,7 @@ export default {
         stripeTransactionsTable.name,
         userProfileTable.name,
         adminNotificationsTable.name,
+        analyticsCacheTable.name,
         authSecret,
         {
           issuer: cognitoIssuer,
@@ -289,7 +311,7 @@ export default {
           domain: cognitoHostedDomain,
         }
       ),
-      link: [stripeTransactionsTable, userProfileTable, adminNotificationsTable],
+      link: [stripeTransactionsTable, userProfileTable, adminNotificationsTable, analyticsCacheTable],
       permissions: [
         {
           // Allow the Lambda server to invoke Bedrock Converse for the chat widget.


### PR DESCRIPTION
**First of 3 PRs** in the Cluster 3 (Analytics) redesign. Adds the storage infrastructure and library functions that PR C2 will wire into the 14 analytics API routes and PR C3 will pre-warm via a cron job.

## Why

Google Search Console has per-minute, per-day, and 50k-rows-per-day quotas. Today every admin tab open hits the API fresh — the page even calls `/api/admin/analytics/seo` (which fetches keywords internally) **AND** `/api/admin/analytics/keywords` as a separate tab, double-billing the quota. At admin-session scale this is fine but the SaaS best-practices research (GSC quota docs + Incremys blog + Improvado guide) is unanimous: cache aggressively, refresh on a schedule, never bombard the live API from user-driven UIs.

## What ships

### `sst.config.ts`
- New `AnalyticsCache` Dynamo table. `pk = '<route>'`, `sk = '<params-hash>'` (deterministic SHA-256).
- `ANALYTICS_CACHE_TABLE` wired into the Lambda env via `buildSiteEnvironment`, same pattern as `ADMIN_NOTIFICATIONS_TABLE`.
- Added to the linked-resources array.

### `src/lib/gsc-cache.ts` (202 lines)
- `paramsHash(params)` — property-order-invariant, ignores `null`/`undefined`, returns 16-char hex (or `'default'` for empty)
- `getCached<T>(route, params, ttlSeconds)` → `CacheEntry<T> | null` with `ageSeconds` + `stale` flag
- `setCached<T>(route, params, payload, ttlSeconds)` → `void`. Best-effort, swallows errors.
- `readThrough<T>(route, params, fetcher, opts)` — serves from fresh cache, otherwise calls fetcher + writes back, otherwise returns stale (within `acceptStaleSeconds`) when the fetcher throws — the 'degraded mode' pattern called out explicitly in the GSC quota best-practices research. Returns `{ value, source: 'cache'|'live'|'stale', ageSeconds }`.

## Safety properties

- Returns `null` when `ANALYTICS_CACHE_TABLE` env is unset (local dev / partial deploys). **Safe to deploy before the table exists in any stage** — every caller sees `null` and falls through to the live path.
- All set/write paths catch + log + swallow errors.
- `getCached` on malformed JSON payload returns `null` (cache miss).

## Tests

`__tests__/gsc-cache.test.ts` (251 lines, 20 tests, same hoisted-mock pattern as `admin-notifications.test.ts`):

- `paramsHash`: empty, order-invariance, null-handling, hex length, value differentiation (5)
- `getCached`: env-unset, no-item, fresh hit, stale hit, malformed JSON, Dynamo error (6)
- `setCached`: env-unset no-op, write-shape, error swallow (3)
- `readThrough`: fresh-cache hit, miss + writeback, stale + refetch, fetcher-throws-fallback-to-stale, fetcher-throws-no-stale rethrow, stale-past-acceptStaleSeconds rethrow (6)

```
✓ __tests__/gsc-cache.test.ts (20 tests) 187ms
  Test Files  1 passed (1)
       Tests  20 passed (20)
```

Mirrors the PR A1 shape: ship infra + lib + tests first, let the table materialize, then PR C2 wires the routes and PR C3 adds the UI date-range filter + cache-warm cron. Same playbook caught the A1→A2 `sst.config.ts` truncation issue and let us hotfix it in one commit — keeping this PR small minimizes the same risk.

PR C2 will follow once this deploys and the `AnalyticsCache` table materializes in production.