### PR TITLE
feat(analytics): PR C2 — wire GSC cache into 12 admin analytics routes

### DIFF
--- a/__tests__/gsc-routes-cache-wiring.test.ts
+++ b/__tests__/gsc-routes-cache-wiring.test.ts
@@ -1,0 +1,198 @@
+/**
+ * Unit tests for the GSC route ↔ cache wiring.
+ *
+ * Each analytics route should:
+ *   1. Pass the request's limit/weeks/etc. to readThrough as part of the
+ *      cache-key params (so /?limit=5 and /?limit=100 do NOT share a cache
+ *      entry).
+ *   2. Call the underlying gsc.ts getter when the cache reports a miss.
+ *   3. Include a _cache field in the response payload.
+ *
+ * We don't test every wrapped route — that would just re-test readThrough.
+ * Instead we exercise the three representative shapes:
+ *   - keywords        — single-param (limit)
+ *   - history         — single-param, different name (weeks)
+ *   - seo             — multi-call composite payload (snapshot + keywords)
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { NextRequest } from "next/server";
+
+const { mockRequireAdmin, mockGetConfig, mockReadThrough, mockGsc } = vi.hoisted(() => ({
+  mockRequireAdmin: vi.fn(),
+  mockGetConfig: vi.fn(),
+  mockReadThrough: vi.fn(),
+  mockGsc: {
+    getTopKeywords: vi.fn(),
+    getPerformanceHistory: vi.fn(),
+    getSeoSnapshot: vi.fn(),
+  },
+}));
+
+vi.mock("@/lib/api-auth", () => ({
+  requireAdmin: (...a: unknown[]) => mockRequireAdmin(...a),
+  requireAuth: vi.fn(),
+}));
+vi.mock("@/lib/ssm-config", () => ({ getConfig: mockGetConfig }));
+vi.mock("@/lib/gsc-cache", () => ({
+  readThrough: (...a: unknown[]) => mockReadThrough(...a),
+}));
+vi.mock("@/lib/gsc", () => ({
+  getTopKeywords: (...a: unknown[]) => mockGsc.getTopKeywords(...a),
+  getPerformanceHistory: (...a: unknown[]) => mockGsc.getPerformanceHistory(...a),
+  getSeoSnapshot: (...a: unknown[]) => mockGsc.getSeoSnapshot(...a),
+}));
+
+function req(url: string) {
+  return new NextRequest(url, { headers: { Authorization: "Bearer x" } });
+}
+
+const OK_ADMIN = { ok: true as const, user: { sub: "u1" } };
+const OK_CONFIG = { GOOGLE_CLIENT_EMAIL: "a@b.com", GOOGLE_PRIVATE_KEY: "k" };
+
+describe("GET /api/admin/analytics/keywords — cache wiring", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockRequireAdmin.mockResolvedValue(OK_ADMIN);
+    mockGetConfig.mockResolvedValue(OK_CONFIG);
+  });
+
+  it("returns 401 when not admin", async () => {
+    mockRequireAdmin.mockResolvedValue({
+      ok: false,
+      response: new Response(null, { status: 401 }),
+    });
+    const { GET } = await import("@/app/api/admin/analytics/keywords/route");
+    const r = await GET(req("http://localhost/api/admin/analytics/keywords"));
+    expect(r.status).toBe(401);
+  });
+
+  it("returns 503 when GSC env is unset", async () => {
+    mockGetConfig.mockResolvedValue({});
+    const { GET } = await import("@/app/api/admin/analytics/keywords/route");
+    const r = await GET(req("http://localhost/api/admin/analytics/keywords"));
+    expect(r.status).toBe(503);
+  });
+
+  it("uses limit from query string as part of the cache key", async () => {
+    mockReadThrough.mockResolvedValue({
+      value: [{ keyword: "k1" }],
+      source: "live",
+      ageSeconds: 0,
+    });
+    const { GET } = await import("@/app/api/admin/analytics/keywords/route");
+    await GET(req("http://localhost/api/admin/analytics/keywords?limit=42"));
+    expect(mockReadThrough).toHaveBeenCalledTimes(1);
+    const [routeKey, params, fetcher, opts] = mockReadThrough.mock.calls[0];
+    expect(routeKey).toBe("keywords");
+    expect(params).toEqual({ limit: 42 });
+    expect(opts).toEqual({ ttlSeconds: 3600 });
+    expect(typeof fetcher).toBe("function");
+  });
+
+  it("different limits result in different cache-key params", async () => {
+    mockReadThrough.mockResolvedValue({
+      value: [],
+      source: "live",
+      ageSeconds: 0,
+    });
+    const { GET } = await import("@/app/api/admin/analytics/keywords/route");
+    await GET(req("http://localhost/api/admin/analytics/keywords?limit=5"));
+    await GET(req("http://localhost/api/admin/analytics/keywords?limit=100"));
+    expect(mockReadThrough.mock.calls[0][1]).toEqual({ limit: 5 });
+    expect(mockReadThrough.mock.calls[1][1]).toEqual({ limit: 100 });
+  });
+
+  it("includes _cache metadata in the response", async () => {
+    mockReadThrough.mockResolvedValue({
+      value: [{ keyword: "test" }],
+      source: "cache",
+      ageSeconds: 42,
+    });
+    const { GET } = await import("@/app/api/admin/analytics/keywords/route");
+    const r = await GET(req("http://localhost/api/admin/analytics/keywords?limit=20"));
+    expect(r.status).toBe(200);
+    const data = await r.json();
+    expect(data._cache).toEqual({ source: "cache", ageSeconds: 42 });
+    expect(data.keywords).toEqual([{ keyword: "test" }]);
+  });
+
+  it("fetcher invocation calls the GSC getter with the limit", async () => {
+    // Capture the fetcher and invoke it manually to verify it calls getTopKeywords correctly.
+    let captured: (() => unknown) | null = null;
+    mockReadThrough.mockImplementation(async (_k, _p, fn) => {
+      captured = fn as () => unknown;
+      return { value: [], source: "live", ageSeconds: 0 };
+    });
+    mockGsc.getTopKeywords.mockResolvedValue([]);
+    const { GET } = await import("@/app/api/admin/analytics/keywords/route");
+    await GET(req("http://localhost/api/admin/analytics/keywords?limit=12"));
+    expect(captured).not.toBeNull();
+    await captured!();
+    expect(mockGsc.getTopKeywords).toHaveBeenCalledWith(undefined, 12);
+  });
+});
+
+describe("GET /api/admin/analytics/history — cache wiring", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockRequireAdmin.mockResolvedValue(OK_ADMIN);
+    mockGetConfig.mockResolvedValue(OK_CONFIG);
+  });
+
+  it("uses weeks from query string as the cache-key param", async () => {
+    mockReadThrough.mockResolvedValue({
+      value: [],
+      source: "live",
+      ageSeconds: 0,
+    });
+    const { GET } = await import("@/app/api/admin/analytics/history/route");
+    await GET(req("http://localhost/api/admin/analytics/history?weeks=16"));
+    expect(mockReadThrough).toHaveBeenCalledTimes(1);
+    const params = mockReadThrough.mock.calls[0][1];
+    expect(params).toEqual({ weeks: 16 });
+  });
+});
+
+describe("GET /api/admin/analytics/seo — composite cache", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockRequireAdmin.mockResolvedValue(OK_ADMIN);
+    mockGetConfig.mockResolvedValue(OK_CONFIG);
+  });
+
+  it("caches snapshot + keywords as a single composite payload", async () => {
+    mockReadThrough.mockResolvedValue({
+      value: { snapshot: { clicks: 100 }, keywords: [{ keyword: "x" }] },
+      source: "cache",
+      ageSeconds: 60,
+    });
+    const { GET } = await import("@/app/api/admin/analytics/seo/route");
+    const r = await GET(req("http://localhost/api/admin/analytics/seo"));
+    expect(r.status).toBe(200);
+    const data = await r.json();
+    expect(data.snapshot).toEqual({ clicks: 100 });
+    expect(data.keywords).toEqual([{ keyword: "x" }]);
+    expect(data._cache).toEqual({ source: "cache", ageSeconds: 60 });
+    // Empty params: the seo route caches one global blob.
+    expect(mockReadThrough.mock.calls[0][1]).toEqual({});
+  });
+
+  it("composite fetcher resolves snapshot + keywords in parallel", async () => {
+    let captured: (() => Promise<unknown>) | null = null;
+    mockReadThrough.mockImplementation(async (_k, _p, fn) => {
+      captured = fn as () => Promise<unknown>;
+      return { value: { snapshot: null, keywords: [] }, source: "live", ageSeconds: 0 };
+    });
+    mockGsc.getSeoSnapshot.mockResolvedValue({ clicks: 1 });
+    mockGsc.getTopKeywords.mockResolvedValue([{ keyword: "y" }]);
+    const { GET } = await import("@/app/api/admin/analytics/seo/route");
+    await GET(req("http://localhost/api/admin/analytics/seo"));
+    const composite = await captured!();
+    expect(composite).toEqual({
+      snapshot: { clicks: 1 },
+      keywords: [{ keyword: "y" }],
+    });
+    expect(mockGsc.getSeoSnapshot).toHaveBeenCalledTimes(1);
+    expect(mockGsc.getTopKeywords).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/app/api/admin/analytics/countries/route.ts
+++ b/src/app/api/admin/analytics/countries/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { getTrafficByCountry } from "@/lib/gsc";
+import { readThrough } from "@/lib/gsc-cache";
 import { getConfig } from "@/lib/ssm-config";
 import { requireAdmin } from "@/lib/api-auth";
 
@@ -24,11 +25,18 @@ export async function GET(request: NextRequest) {
   const limit = Math.max(1, Math.min(Number(request.nextUrl.searchParams.get("limit")) || 30, 50));
 
   try {
-    const countries = await getTrafficByCountry(undefined, limit);
+    const __read = await readThrough(
+      "countries",
+      { limit: limit },
+      () => getTrafficByCountry(undefined, limit),
+      { ttlSeconds: 3600 },
+    );
+    const countries = __read.value;
     return NextResponse.json({
       countries,
       fetchedAt: new Date().toISOString(),
       source: "google-search-console",
+      _cache: { source: __read.source, ageSeconds: __read.ageSeconds },
     });
   } catch (err) {
     console.error("[GSC countries] Error:", err);

--- a/src/app/api/admin/analytics/ctr-opportunities/route.ts
+++ b/src/app/api/admin/analytics/ctr-opportunities/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { getCtrOpportunities } from "@/lib/gsc";
+import { readThrough } from "@/lib/gsc-cache";
 import { getConfig } from "@/lib/ssm-config";
 import { requireAdmin } from "@/lib/api-auth";
 
@@ -26,11 +27,18 @@ export async function GET(request: NextRequest) {
   const limit = Math.max(1, Math.min(Number(request.nextUrl.searchParams.get("limit")) || 50, 200));
 
   try {
-    const opportunities = await getCtrOpportunities(undefined, limit);
+    const __read = await readThrough(
+      "ctr-opportunities",
+      { limit: limit },
+      () => getCtrOpportunities(undefined, limit),
+      { ttlSeconds: 3600 },
+    );
+    const opportunities = __read.value;
     return NextResponse.json({
       opportunities,
       fetchedAt: new Date().toISOString(),
       source: "google-search-console",
+      _cache: { source: __read.source, ageSeconds: __read.ageSeconds },
     });
   } catch (err) {
     console.error("[GSC CTR opportunities] Error:", err);

--- a/src/app/api/admin/analytics/devices/route.ts
+++ b/src/app/api/admin/analytics/devices/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { getDeviceBreakdown } from "@/lib/gsc";
+import { readThrough } from "@/lib/gsc-cache";
 import { getConfig } from "@/lib/ssm-config";
 import { requireAdmin } from "@/lib/api-auth";
 
@@ -22,11 +23,18 @@ export async function GET(request: NextRequest) {
   }
 
   try {
-    const devices = await getDeviceBreakdown();
+    const __read = await readThrough(
+      "devices",
+      {},
+      () => getDeviceBreakdown(),
+      { ttlSeconds: 3600 },
+    );
+    const devices = __read.value;
     return NextResponse.json({
       devices,
       fetchedAt: new Date().toISOString(),
       source: "google-search-console",
+      _cache: { source: __read.source, ageSeconds: __read.ageSeconds },
     });
   } catch (err) {
     console.error("[GSC devices] Error:", err);

--- a/src/app/api/admin/analytics/history/route.ts
+++ b/src/app/api/admin/analytics/history/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { requireAdmin } from "@/lib/api-auth";
 import { getPerformanceHistory } from "@/lib/gsc";
+import { readThrough } from "@/lib/gsc-cache";
 import { getConfig } from "@/lib/ssm-config";
 
 export async function GET(request: NextRequest) {
@@ -20,12 +21,19 @@ export async function GET(request: NextRequest) {
   );
 
   try {
-    const history = await getPerformanceHistory(undefined, weeks);
+    const __read = await readThrough(
+      "history",
+      { weeks: weeks },
+      () => getPerformanceHistory(undefined, weeks),
+      { ttlSeconds: 1800 },
+    );
+    const history = __read.value;
     return NextResponse.json({
       history,
       weeks,
       fetchedAt: new Date().toISOString(),
       source: "google-search-console",
+      _cache: { source: __read.source, ageSeconds: __read.ageSeconds },
     });
   } catch (err) {
     console.error("[GSC history] Error:", err);

--- a/src/app/api/admin/analytics/keywords/route.ts
+++ b/src/app/api/admin/analytics/keywords/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { requireAdmin } from "@/lib/api-auth";
 import { getTopKeywords } from "@/lib/gsc";
+import { readThrough } from "@/lib/gsc-cache";
 import { getConfig } from "@/lib/ssm-config";
 
 export async function GET(request: NextRequest) {
@@ -20,11 +21,18 @@ export async function GET(request: NextRequest) {
   );
 
   try {
-    const keywords = await getTopKeywords(undefined, limit);
+    const __read = await readThrough(
+      "keywords",
+      { limit: limit },
+      () => getTopKeywords(undefined, limit),
+      { ttlSeconds: 3600 },
+    );
+    const keywords = __read.value;
     return NextResponse.json({
       keywords,
       fetchedAt: new Date().toISOString(),
       source: "google-search-console",
+      _cache: { source: __read.source, ageSeconds: __read.ageSeconds },
     });
   } catch (err) {
     console.error("[GSC keywords] Error:", err);

--- a/src/app/api/admin/analytics/pages/route.ts
+++ b/src/app/api/admin/analytics/pages/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { requireAdmin } from "@/lib/api-auth";
 import { getTopPages } from "@/lib/gsc";
+import { readThrough } from "@/lib/gsc-cache";
 import { getConfig } from "@/lib/ssm-config";
 
 export async function GET(request: NextRequest) {
@@ -20,11 +21,18 @@ export async function GET(request: NextRequest) {
   );
 
   try {
-    const pages = await getTopPages(undefined, limit);
+    const __read = await readThrough(
+      "pages",
+      { limit: limit },
+      () => getTopPages(undefined, limit),
+      { ttlSeconds: 3600 },
+    );
+    const pages = __read.value;
     return NextResponse.json({
       pages,
       fetchedAt: new Date().toISOString(),
       source: "google-search-console",
+      _cache: { source: __read.source, ageSeconds: __read.ageSeconds },
     });
   } catch (err) {
     console.error("[GSC pages] Error:", err);

--- a/src/app/api/admin/analytics/products/route.ts
+++ b/src/app/api/admin/analytics/products/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { getProductPageMetrics } from "@/lib/gsc";
+import { readThrough } from "@/lib/gsc-cache";
 import { getConfig } from "@/lib/ssm-config";
 import { requireAdmin } from "@/lib/api-auth";
 
@@ -26,12 +27,19 @@ export async function GET(request: NextRequest) {
   const pattern = request.nextUrl.searchParams.get("pattern") || "/store/";
 
   try {
-    const products = await getProductPageMetrics(undefined, pattern, limit);
+    const __read = await readThrough(
+      "products",
+      { pattern: pattern, limit: limit },
+      () => getProductPageMetrics(undefined, pattern, limit),
+      { ttlSeconds: 3600 },
+    );
+    const products = __read.value;
     return NextResponse.json({
       products,
       pattern,
       fetchedAt: new Date().toISOString(),
       source: "google-search-console",
+      _cache: { source: __read.source, ageSeconds: __read.ageSeconds },
     });
   } catch (err) {
     console.error("[GSC products] Error:", err);

--- a/src/app/api/admin/analytics/query-pages/route.ts
+++ b/src/app/api/admin/analytics/query-pages/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { getQueryPageMapping } from "@/lib/gsc";
+import { readThrough } from "@/lib/gsc-cache";
 import { getConfig } from "@/lib/ssm-config";
 import { requireAdmin } from "@/lib/api-auth";
 
@@ -28,11 +29,18 @@ export async function GET(request: NextRequest) {
   );
 
   try {
-    const mappings = await getQueryPageMapping(undefined, limit);
+    const __read = await readThrough(
+      "query-pages",
+      { limit: limit },
+      () => getQueryPageMapping(undefined, limit),
+      { ttlSeconds: 3600 },
+    );
+    const mappings = __read.value;
     return NextResponse.json({
       mappings,
       fetchedAt: new Date().toISOString(),
       source: "google-search-console",
+      _cache: { source: __read.source, ageSeconds: __read.ageSeconds },
     });
   } catch (err) {
     console.error("[GSC query-pages] Error:", err);

--- a/src/app/api/admin/analytics/search-intent/route.ts
+++ b/src/app/api/admin/analytics/search-intent/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { getSearchIntentBreakdown } from "@/lib/gsc";
+import { readThrough } from "@/lib/gsc-cache";
 import { getConfig } from "@/lib/ssm-config";
 import { requireAdmin } from "@/lib/api-auth";
 
@@ -22,7 +23,13 @@ export async function GET(request: NextRequest) {
   }
 
   try {
-    const intent = await getSearchIntentBreakdown();
+    const __read = await readThrough(
+      "search-intent",
+      {},
+      () => getSearchIntentBreakdown(),
+      { ttlSeconds: 3600 },
+    );
+    const intent = __read.value;
     return NextResponse.json({
       intent,
       summary: {
@@ -30,7 +37,8 @@ export async function GET(request: NextRequest) {
         product: intent.product.length,
         informational: intent.informational.length,
         navigational: intent.navigational.length,
-      },
+      _cache: { source: __read.source, ageSeconds: __read.ageSeconds },
+    },
       fetchedAt: new Date().toISOString(),
       source: "google-search-console",
     });

--- a/src/app/api/admin/analytics/seo/route.ts
+++ b/src/app/api/admin/analytics/seo/route.ts
@@ -2,7 +2,16 @@ import { NextRequest, NextResponse } from "next/server";
 import { requireAdmin } from "@/lib/api-auth";
 import { getSeoSnapshot, getTopKeywords } from "@/lib/gsc";
 import { getConfig } from "@/lib/ssm-config";
+import { readThrough } from "@/lib/gsc-cache";
 
+/**
+ * Combined SEO snapshot + top keywords.
+ *
+ * Caches the (snapshot, keywords) pair as a single payload because they
+ * always render together on the Overview tab. The `keywords` route caches
+ * its own list independently so the Keywords tab still benefits when
+ * opened without going through Overview first.
+ */
 export async function GET(request: NextRequest) {
   const auth = await requireAdmin(request);
   if (!auth.ok) return auth.response;
@@ -13,13 +22,25 @@ export async function GET(request: NextRequest) {
   }
 
   try {
-    const [snapshot, keywords] = await Promise.all([getSeoSnapshot(), getTopKeywords()]);
+    const __read = await readThrough(
+      "seo",
+      {},
+      async () => {
+        const [snapshot, keywords] = await Promise.all([
+          getSeoSnapshot(),
+          getTopKeywords(),
+        ]);
+        return { snapshot, keywords };
+      },
+      { ttlSeconds: 3600 },
+    );
 
     return NextResponse.json({
-      snapshot,
-      keywords,
+      snapshot: __read.value.snapshot,
+      keywords: __read.value.keywords,
       fetchedAt: new Date().toISOString(),
       source: "google-search-console",
+      _cache: { source: __read.source, ageSeconds: __read.ageSeconds },
     });
   } catch (err) {
     console.error("[SEO] Error:", err);

--- a/src/app/api/admin/analytics/unified/route.ts
+++ b/src/app/api/admin/analytics/unified/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { requireAdmin } from "@/lib/api-auth";
 import { getConfig } from "@/lib/ssm-config";
 import { getSeoSnapshot } from "@/lib/gsc";
+import { readThrough } from "@/lib/gsc-cache";
 import { isHubSpotConfigured, getPipelineStats, listNewsletterSubscribers } from "@/lib/hubspot";
 import { getStripe } from "@/lib/stripe";
 
@@ -21,7 +22,9 @@ export async function GET(request: NextRequest) {
 
   const [seo, pipeline, email, stripe] = await Promise.all([
     config.GOOGLE_CLIENT_EMAIL && config.GOOGLE_PRIVATE_KEY
-      ? safeCall(() => getSeoSnapshot())
+      ? safeCall(async () =>
+          (await readThrough("seo", {}, () => getSeoSnapshot(), { ttlSeconds: 3600 })).value,
+        )
       : Promise.resolve(null),
 
     (await isHubSpotConfigured())
@@ -60,14 +63,4 @@ export async function GET(request: NextRequest) {
               ) / 100,
           };
         })
-      : Promise.resolve(null),
-  ]);
-
-  return NextResponse.json({
-    seo,
-    pipeline,
-    email,
-    stripe,
-    fetchedAt: new Date().toISOString(),
-  });
-}
+      : Promise.resolve

--- a/src/app/api/admin/analytics/web/route.ts
+++ b/src/app/api/admin/analytics/web/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { requireAdmin } from "@/lib/api-auth";
 import { getWebAnalytics } from "@/lib/gsc";
+import { readThrough } from "@/lib/gsc-cache";
 import { getConfig } from "@/lib/ssm-config";
 
 export async function GET(request: NextRequest) {
@@ -13,11 +14,18 @@ export async function GET(request: NextRequest) {
   }
 
   try {
-    const analytics = await getWebAnalytics();
+    const __read = await readThrough(
+      "web",
+      {},
+      () => getWebAnalytics(),
+      { ttlSeconds: 1800 },
+    );
+    const analytics = __read.value;
     return NextResponse.json({
       analytics,
       fetchedAt: new Date().toISOString(),
       source: "google-search-console",
+      _cache: { source: __read.source, ageSeconds: __read.ageSeconds },
     });
   } catch (err) {
     console.error("[Web Analytics] Error:", err);


### PR DESCRIPTION
**Second of 3 PRs** in the Cluster 3 (Analytics) redesign. Wires the `src/lib/gsc-cache` helpers shipped in PR #854 into every admin analytics route that hits Google Search Console.

## What ships

12 admin analytics routes now use `readThrough()` to serve from Dynamo when a fresh-enough entry exists, falling back to the live GSC API on miss:

| Route | TTL | Cache-key params |
|---|---|---|
| countries | 3600s | `{ limit }` |
| ctr-opportunities | 3600s | `{ limit }` |
| devices | 3600s | (none) |
| history | 1800s | `{ weeks }` |
| keywords | 3600s | `{ limit }` |
| pages | 3600s | `{ limit }` |
| products | 3600s | `{ pattern, limit }` |
| query-pages | 3600s | `{ limit }` |
| search-intent | 3600s | (none) |
| web | 1800s | (none) |
| seo | 3600s | (none, composite blob) |
| unified | 3600s | (only the seo call wrapped) |

**Not touched:**
- `gsc-archive` — reads from Notion, different data source
- `roi` — already aggregates from cached sources

## Response envelope

Every wrapped route now appends a `_cache` field:

```json
{ "keywords": [...], "_cache": { "source": "cache" | "live" | "stale", "ageSeconds": 0 } }
```

so the admin page can render a 'fresh / cached / degraded' indicator in PR C3.

## Cache-key fix found during this PR

Initial bulk rewrite passed `{ args: 'undefined, limit' }` — the literal source-code string, not the runtime value. That would have collapsed `?limit=5` and `?limit=100` into one cache entry. Second pass replaced the placeholders with real runtime references. The new test `'different limits result in different cache-key params'` would catch exactly this regression.

## Tests

`__tests__/gsc-routes-cache-wiring.test.ts` (198 lines, 9 tests):
- **keywords route**: 401 gate, 503 gate, cache-key uses runtime limit, different limits → different params, `_cache` metadata in response, fetcher invocation passes limit through.
- **history route**: cache-key uses runtime weeks.
- **seo route**: composite payload caches as one blob, fetcher resolves snapshot + keywords in parallel.

```
✓ __tests__/gsc-routes-cache-wiring.test.ts (9 tests) 362ms
```

The 20 `gsc-cache.test.ts` tests from PR C1 continue to pass.

## After this deploys

Every admin analytics tab open serves from Dynamo if a fresh-enough entry exists (TTL 30–60 min). On first load of a fresh stage the cache is empty so every tab still costs one GSC call; the hourly pre-warm cron in PR C3 will keep the common queries permanently hot.