### PR TITLE
fix(analytics): HOTFIX restore unified/route.ts truncated tail

### DIFF
--- a/src/app/api/admin/analytics/unified/route.ts
+++ b/src/app/api/admin/analytics/unified/route.ts
@@ -63,4 +63,14 @@ export async function GET(request: NextRequest) {
               ) / 100,
           };
         })
-      : Promise.resolve
+      : Promise.resolve(null),
+  ]);
+
+  return NextResponse.json({
+    seo,
+    pipeline,
+    email,
+    stripe,
+    fetchedAt: new Date().toISOString(),
+  });
+}


### PR DESCRIPTION
Production build broken by PR #855 (C2). Turbopack:

```
./src/app/api/admin/analytics/unified/route.ts:66:24
Expected ',', got '<eof>'
  64 |           };
  65 |         })
> 66 |       : Promise.resolve
     |                        ^
```

Edit-tool truncated `unified/route.ts` mid-`Promise.resolve` at line 66 during the C2 wiring pass. Same defect that broke PR #843 (`sst.config.ts`) and that already hand-rewrote `seo/route.ts` during C2 once I noticed it there.

Restored via Python text write (no Edit tool). File is now 76 lines, ends cleanly, and the C2 cache wiring is preserved (read-through on the seo call, 1h TTL).

`__tests__/gsc-routes-cache-wiring.test.ts` still 9/9 green.

Production was on commit `408df64c` (PR C1) before the failed C2 deploy, so the previous version is still serving traffic — this hotfix just lets the next deploy succeed.