### PR TITLE
fix(e2e): HOTFIX restore coverage-routes.ts truncated tail

### DIFF
--- a/e2e/helpers/coverage-routes.ts
+++ b/e2e/helpers/coverage-routes.ts
@@ -251,4 +251,8 @@ export const ADMIN_API_DYNAMIC = [
     template: "/api/admin/pipeline/deals/[id]/notes",
     sample: "/api/admin/pipeline/deals/sample-id/notes",
   },
-  { template: "/api/admin/reports/[id]", sample: "/api/admin
+  { template: "/api/admin/reports/[id]", sample: "/api/admin/reports/sample-id" },
+  { template: "/api/admin/reports/[id]/pdf", sample: "/api/admin/reports/sample-id/pdf" },
+] as const;
+
+export const AUTH_API = "/api/auth/session"; // NextAuth handler


### PR DESCRIPTION
Accessibility Audit workflow failed with:

```
SyntaxError: Unterminated string constant. (254:49)
  254 |   { template: "/api/admin/reports/[id]", sample: "/api/admin
                                                        ^
```

The file on `origin/main` ended mid-string at line 254 — same Edit-tool truncation defect that already hit `sst.config.ts` (PR #843), `unified/route.ts` (PR #856), and the seo route earlier today. The local working tree had the fix from earlier work in this session but it was never committed.

Restored the 4 missing lines (the two `reports/[id]` entries, the closing `] as const;`, and the `AUTH_API` export) via Python text write.

Not blocking production traffic — the Accessibility Audit is a PR-time check, not a deploy gate.