### PR TITLE
fix(infra): read Cloudflare token from SSM, not stale GH secret

### DIFF
--- a/.github/workflows/apply-cloudflare-lb.yml
+++ b/.github/workflows/apply-cloudflare-lb.yml
@@ -74,7 +74,7 @@ jobs:
           AWS_REGION: us-east-1
           MODE: apply
           CONFIRM: "1"
-          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          # GH secret is stale; script reads SSM. See cloudflare-token-rotate.yml.
         run: |
           set -o pipefail
           bash scripts/setup-cloudflare-lb.sh 2>&1 | tee cloudflare-lb.log

--- a/.github/workflows/cloudflare-disable-email-obfuscation.yml
+++ b/.github/workflows/cloudflare-disable-email-obfuscation.yml
@@ -53,7 +53,7 @@ jobs:
         id: disable
         env:
           AWS_REGION: us-east-1
-          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          # GH secret is stale; script reads SSM. See cloudflare-token-rotate.yml.
         run: |
           set -o pipefail
           bash scripts/disable-cloudflare-email-obfuscation.sh 2>&1 | tee cf-email.log

--- a/.github/workflows/cloudflare-lb.yml
+++ b/.github/workflows/cloudflare-lb.yml
@@ -63,7 +63,7 @@ jobs:
           # push trigger => always report-only; dispatch => honour the apply input.
           MODE: ${{ github.event.inputs.apply == 'true' && 'apply' || 'report' }}
           CONFIRM: ${{ github.event.inputs.apply == 'true' && '1' || '0' }}
-          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          # GH secret is stale; script reads SSM. See cloudflare-token-rotate.yml.
         run: |
           set -o pipefail
           bash scripts/setup-cloudflare-lb.sh 2>&1 | tee cloudflare-lb.log

--- a/.github/workflows/cloudflare-token-rotate.yml
+++ b/.github/workflows/cloudflare-token-rotate.yml
@@ -174,16 +174,20 @@ jobs:
           GH_PAT_SET: ${{ secrets.GH_PAT != '' }}
         continue-on-error: true
         run: |
-          set -e
+          # All consumer workflows now read CF token from SSM directly.
+          # GH secret is optional/legacy; failure here is not a real outage.
+          set +e
           if [ "$GH_PAT_SET" != "true" ]; then
-            echo "::warning::GH_PAT secret not set — using GITHUB_TOKEN (likely will 403)."
-            echo "::warning::If this step fails, sync the GH secret from SSM manually (see comment in step env)."
+            echo "::notice::GH_PAT not set - skipping GH secret update. SSM is source of truth."
+            exit 0
           fi
-          # gh secret set reads from stdin to avoid arg-list disclosure.
-          echo -n "$NEW_TOKEN" | gh secret set CLOUDFLARE_API_TOKEN \
-            --repo ${{ github.repository }} \
-            --body -
-          echo "✅ GitHub Actions secret updated"
+          if echo -n "$NEW_TOKEN" | gh secret set CLOUDFLARE_API_TOKEN \
+            --repo ${{ github.repository }} --body - 2>&1; then
+            echo "GitHub Actions secret updated"
+          else
+            echo "::warning::Failed to update GH Actions secret. Not blocking."
+            exit 0
+          fi
 
       - name: Apply summary
         if: ${{ inputs.apply == true }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -99,6 +99,20 @@ jobs:
       - name: Clear any stale SST lock
         run: pnpm sst unlock --stage production || true
 
+      - name: Resolve Cloudflare token from SSM
+        id: cftoken
+        run: |
+          set -e
+          TOKEN=$(aws ssm get-parameter \
+            --name /cloudless/production/CLOUDFLARE_API_TOKEN \
+            --with-decryption --region us-east-1 \
+            --query 'Parameter.Value' --output text 2>/dev/null || echo "")
+          if [ -z "$TOKEN" ] || [ "$TOKEN" = "None" ]; then
+            echo "::warning::SSM CLOUDFLARE_API_TOKEN empty - Workers AI not wired"
+          fi
+          echo "::add-mask::$TOKEN"
+          echo "token=$TOKEN" >> "$GITHUB_OUTPUT"
+
       - name: Deploy (SST)
         run: pnpm sst deploy --stage production
         env:
@@ -107,9 +121,9 @@ jobs:
           SENTRY_ORG: baltzakisthemiscom
           SENTRY_PROJECT: cloudless-gr
           NEXT_PUBLIC_SENTRY_DSN: ${{ secrets.NEXT_PUBLIC_SENTRY_DSN }}
-          # Cloudflare Workers AI — consumed by /api/admin/ai/generate at runtime
+          # Cloudflare Workers AI - reads SSM (source of truth, GH secret is stale).
           CLOUDFLARE_ACCOUNT_ID: fb7dc7b69b662480cd5961a4d1913c78
-          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_API_TOKEN: ${{ steps.cftoken.outputs.token }}
           NODE_OPTIONS: --max-old-space-size=3072
 
       - name: Publish cloud SHA to SSM (source of truth for sha-drift-detector)

--- a/.github/workflows/domain-decommission.yml
+++ b/.github/workflows/domain-decommission.yml
@@ -67,7 +67,7 @@ jobs:
           # Cloudflare token: prefer a repo secret (add it in the GitHub UI — no
           # AWS access needed); the script falls back to SSM
           # /cloudless/production/CLOUDFLARE_API_TOKEN if this is empty.
-          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          # GH secret is stale; script reads SSM. See cloudflare-token-rotate.yml.
         run: |
           set -o pipefail
           bash scripts/domain-decommission.sh 2>&1 | tee decommission.log

--- a/.github/workflows/ha-failover-watchdog.yml
+++ b/.github/workflows/ha-failover-watchdog.yml
@@ -71,18 +71,21 @@ jobs:
 
       - name: Resolve Cloudflare token
         id: token
+        env:
+          # SSM is source of truth - cloudflare-token-rotate.yml cant write GH secrets.
+          SECRET_FALLBACK: ${{ secrets.CLOUDFLARE_API_TOKEN }}
         run: |
           set -e
-          TOKEN="${{ secrets.CLOUDFLARE_API_TOKEN }}"
-          if [ -z "$TOKEN" ]; then
-            echo "Falling back to SSM…" >&2
-            TOKEN=$(aws ssm get-parameter \
-              --name /cloudless/production/CLOUDFLARE_API_TOKEN \
-              --with-decryption --region us-east-1 \
-              --query 'Parameter.Value' --output text)
+          TOKEN=$(aws ssm get-parameter \
+            --name /cloudless/production/CLOUDFLARE_API_TOKEN \
+            --with-decryption --region us-east-1 \
+            --query 'Parameter.Value' --output text 2>/dev/null || echo "")
+          if [ -z "$TOKEN" ] || [ "$TOKEN" = "None" ]; then
+            echo "SSM unreachable, falling back to GH secret" >&2
+            TOKEN="$SECRET_FALLBACK"
           fi
           if [ -z "$TOKEN" ] || [ "$TOKEN" = "None" ]; then
-            echo "::error::No Cloudflare token resolved"
+            echo "::error::No Cloudflare token resolved (SSM empty, GH secret empty)"
             exit 1
           fi
           echo "::add-mask::$TOKEN"

--- a/.github/workflows/workers-ai-verify.yml
+++ b/.github/workflows/workers-ai-verify.yml
@@ -36,10 +36,25 @@ jobs:
           role-to-assume: ${{ secrets.AWS_DEPLOY_ROLE_ARN }}
           aws-region: us-east-1
 
+      - name: Resolve Cloudflare token from SSM
+        id: cftoken
+        run: |
+          set -e
+          TOKEN=$(aws ssm get-parameter \
+            --name /cloudless/production/CLOUDFLARE_API_TOKEN \
+            --with-decryption --region us-east-1 \
+            --query 'Parameter.Value' --output text 2>/dev/null || echo "")
+          if [ -z "$TOKEN" ] || [ "$TOKEN" = "None" ]; then
+            echo "::warning::SSM CLOUDFLARE_API_TOKEN empty - skipping CF checks"
+          fi
+          echo "::add-mask::$TOKEN"
+          echo "token=$TOKEN" >> "$GITHUB_OUTPUT"
+
       - name: Run Workers AI doctor
         id: doctor
         env:
-          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          # GH secret is stale; SSM is the source of truth.
+          CLOUDFLARE_API_TOKEN: ${{ steps.cftoken.outputs.token }}
         run: |
           set +e
           OUT=$(bash scripts/workers-ai-doctor.sh 2>&1)


### PR DESCRIPTION
Fixes the cascading HA failover watchdog / HA sync orchestrator failures visible in baltzakis.themis inbox (8+ failure emails on 2026-06-14).

Root cause: cloudflare-token-rotate.yml updates SSM but cannot write the GH Actions secret CLOUDFLARE_API_TOKEN because GITHUB_TOKEN lacks scope and GH_PAT is unset. So the GH secret is permanently stale (revoked). 7 workflows referenced `${{ secrets.CLOUDFLARE_API_TOKEN }}` and crashed with TypeError when Cloudflare returned `{result: null}` for the revoked token.

Fix:
- 4 workflows just stop forwarding the env var so their script's existing SSM fallback fires.
- 3 workflows (ha-failover-watchdog, deploy, workers-ai-verify) gain an explicit SSM resolve step.
- cloudflare-token-rotate exits 0 on GH-secret-write failure (SSM is source of truth, not failure-worthy).

Verified locally: all 8 YAMLs syntax-clean, all 4 helper scripts already do SSM fallback when env is empty.