### PR TITLE
style: pnpm prettier --write across 32 drifted files

### DIFF
--- a/src/app/[locale]/admin/analytics/page.tsx
+++ b/src/app/[locale]/admin/analytics/page.tsx
@@ -553,9 +553,7 @@ export default function AdminAnalyticsPage() {
         role="group"
         aria-label="Date range filter"
       >
-        <span className="font-mono text-[10px] uppercase tracking-wide text-slate-500">
-          Range
-        </span>
+        <span className="font-mono text-[10px] tracking-wide text-slate-500 uppercase">Range</span>
         {RANGE_PRESETS.map((p) => {
           const active = p.days === days;
           return (
@@ -577,11 +575,8 @@ export default function AdminAnalyticsPage() {
       </div>
 
       {isFiltered && (
-        <div
-          className="mb-4 flex flex-wrap items-center gap-2"
-          aria-label="Active filters"
-        >
-          <span className="font-mono text-[10px] uppercase tracking-wide text-slate-500">
+        <div className="mb-4 flex flex-wrap items-center gap-2" aria-label="Active filters">
+          <span className="font-mono text-[10px] tracking-wide text-slate-500 uppercase">
             Active
           </span>
           <span className="bg-neon-magenta/10 text-neon-magenta border-neon-magenta/20 inline-flex items-center gap-1.5 rounded-full border px-3 py-1 font-mono text-xs">
@@ -598,7 +593,7 @@ export default function AdminAnalyticsPage() {
           <button
             type="button"
             onClick={resetFilters}
-            className="font-mono text-[10px] uppercase tracking-wide text-slate-500 underline-offset-2 hover:text-slate-300 hover:underline"
+            className="font-mono text-[10px] tracking-wide text-slate-500 uppercase underline-offset-2 hover:text-slate-300 hover:underline"
           >
             Reset to default
           </button>

--- a/src/app/[locale]/admin/audits/page.tsx
+++ b/src/app/[locale]/admin/audits/page.tsx
@@ -19,8 +19,10 @@ interface Dashboard {
 }
 
 function statusBadge(ok: boolean | null): { icon: string; color: string; label: string } {
-  if (ok === true) return { icon: "✅", color: "text-green-600 dark:text-green-400", label: "passing" };
-  if (ok === false) return { icon: "❌", color: "text-red-600 dark:text-red-400", label: "failing" };
+  if (ok === true)
+    return { icon: "✅", color: "text-green-600 dark:text-green-400", label: "passing" };
+  if (ok === false)
+    return { icon: "❌", color: "text-red-600 dark:text-red-400", label: "failing" };
   return { icon: "⚪", color: "text-gray-500 dark:text-gray-400", label: "unknown" };
 }
 
@@ -70,10 +72,10 @@ export default function AuditsPage() {
   }, [load]);
 
   return (
-    <div className="container mx-auto px-4 py-8 max-w-6xl">
-      <header className="flex items-center justify-between mb-6">
+    <div className="container mx-auto max-w-6xl px-4 py-8">
+      <header className="mb-6 flex items-center justify-between">
         <div>
-          <h1 className="text-3xl font-bold mb-1">Audits</h1>
+          <h1 className="mb-1 text-3xl font-bold">Audits</h1>
           <p className="text-sm text-gray-600 dark:text-gray-400">
             Rolling dashboard of every audit workflow. Updated nightly at 06:00 UTC.
           </p>
@@ -81,7 +83,7 @@ export default function AuditsPage() {
         <button
           type="button"
           onClick={() => void load()}
-          className="px-4 py-2 rounded bg-blue-600 text-white text-sm hover:bg-blue-700 disabled:opacity-50"
+          className="rounded bg-blue-600 px-4 py-2 text-sm text-white hover:bg-blue-700 disabled:opacity-50"
           disabled={loading}
         >
           {loading ? "Loading…" : "Refresh"}
@@ -89,14 +91,14 @@ export default function AuditsPage() {
       </header>
 
       {error && (
-        <div className="rounded border border-red-300 bg-red-50 dark:bg-red-950/30 dark:border-red-800 p-4 mb-6">
+        <div className="mb-6 rounded border border-red-300 bg-red-50 p-4 dark:border-red-800 dark:bg-red-950/30">
           <p className="text-red-700 dark:text-red-300">Failed to load audit dashboard: {error}</p>
         </div>
       )}
 
       {data && (
         <>
-          <p className="text-xs text-gray-500 dark:text-gray-400 mb-4">
+          <p className="mb-4 text-xs text-gray-500 dark:text-gray-400">
             Generated {new Date(data.generatedAt).toLocaleString()} · {data.repo}
           </p>
 
@@ -106,9 +108,9 @@ export default function AuditsPage() {
               return (
                 <article
                   key={key}
-                  className="rounded-lg border border-gray-200 dark:border-gray-800 bg-white dark:bg-gray-900 p-5 shadow-sm"
+                  className="rounded-lg border border-gray-200 bg-white p-5 shadow-sm dark:border-gray-800 dark:bg-gray-900"
                 >
-                  <header className="flex items-start justify-between mb-3">
+                  <header className="mb-3 flex items-start justify-between">
                     <h2 className="font-semibold">
                       {entry.lastRun?.url ? (
                         <a
@@ -123,11 +125,15 @@ export default function AuditsPage() {
                         entry.name
                       )}
                     </h2>
-                    <span className={`text-2xl ${badge.color}`} title={badge.label} aria-label={badge.label}>
+                    <span
+                      className={`text-2xl ${badge.color}`}
+                      title={badge.label}
+                      aria-label={badge.label}
+                    >
                       {badge.icon}
                     </span>
                   </header>
-                  <dl className="text-sm text-gray-600 dark:text-gray-400 space-y-1">
+                  <dl className="space-y-1 text-sm text-gray-600 dark:text-gray-400">
                     <div className="flex justify-between">
                       <dt>Workflow</dt>
                       <dd className="font-mono text-xs">{entry.workflow}</dd>
@@ -143,7 +149,9 @@ export default function AuditsPage() {
                       </div>
                     )}
                     {entry.note && (
-                      <div className="pt-2 text-xs italic text-gray-500 dark:text-gray-500">{entry.note}</div>
+                      <div className="pt-2 text-xs text-gray-500 italic dark:text-gray-500">
+                        {entry.note}
+                      </div>
                     )}
                   </dl>
                 </article>

--- a/src/app/[locale]/admin/crm/page.tsx
+++ b/src/app/[locale]/admin/crm/page.tsx
@@ -34,20 +34,20 @@ export default function AdminCRMPage() {
   const [search, setSearch] = useState("");
 
   const fetchContacts = useCallback(async () => {
-      try {
-        const res = await fetchWithAuth("/api/admin/crm/contacts?limit=50");
-        if (!res.ok) {
-          if (res.status === 503) throw new Error("HubSpot not configured");
-          throw new Error(`HTTP ${res.status}`);
-        }
-        const data = await res.json();
-        setContacts(data.contacts ?? []);
-      } catch (err) {
-        setError(err instanceof Error ? err.message : "Failed to load contacts");
-      } finally {
-        setLoading(false);
+    try {
+      const res = await fetchWithAuth("/api/admin/crm/contacts?limit=50");
+      if (!res.ok) {
+        if (res.status === 503) throw new Error("HubSpot not configured");
+        throw new Error(`HTTP ${res.status}`);
       }
-    }, []);
+      const data = await res.json();
+      setContacts(data.contacts ?? []);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to load contacts");
+    } finally {
+      setLoading(false);
+    }
+  }, []);
 
   // Visibility-gated polling — pauses while the tab is hidden to avoid
   // amplifying Cloudflare Worker / API request volume.

--- a/src/app/[locale]/admin/notifications/page.tsx
+++ b/src/app/[locale]/admin/notifications/page.tsx
@@ -197,7 +197,7 @@ export default function NotificationsPage() {
         <div className="mb-6 rounded-xl border border-slate-800 bg-slate-900/30 p-4">
           <div className="mb-3 flex items-baseline justify-between">
             <div>
-              <div className="font-mono text-[10px] uppercase tracking-wider text-slate-500">
+              <div className="font-mono text-[10px] tracking-wider text-slate-500 uppercase">
                 Last {windowDays}d
               </div>
               <div className="font-heading text-2xl font-bold text-white">
@@ -256,7 +256,7 @@ export default function NotificationsPage() {
               <div className="mb-1 flex items-center justify-between gap-3">
                 <div className="flex items-center gap-2">
                   {!n.read && <span className="bg-neon-magenta h-2 w-2 rounded-full" />}
-                  <span className="rounded border border-slate-700 px-1.5 py-0.5 font-mono text-[9px] uppercase text-slate-400">
+                  <span className="rounded border border-slate-700 px-1.5 py-0.5 font-mono text-[9px] text-slate-400 uppercase">
                     {n.category}
                   </span>
                   <span className="font-mono text-sm font-semibold text-white">{n.title}</span>

--- a/src/app/[locale]/cookies/page.tsx
+++ b/src/app/[locale]/cookies/page.tsx
@@ -1,2 +1,1 @@
-
 export { default } from "./CookiePolicyPageClient";

--- a/src/app/[locale]/not-found.tsx
+++ b/src/app/[locale]/not-found.tsx
@@ -1,4 +1,3 @@
-
 import { headers } from "next/headers";
 import { getLocale } from "next-intl/server";
 import { Link } from "@/i18n/navigation";

--- a/src/app/[locale]/privacy/page.tsx
+++ b/src/app/[locale]/privacy/page.tsx
@@ -1,4 +1,3 @@
-
 import type { Metadata } from "next";
 import { Link } from "@/i18n/navigation";
 import ScrollReveal from "@/components/ScrollReveal";

--- a/src/app/[locale]/refund/page.tsx
+++ b/src/app/[locale]/refund/page.tsx
@@ -1,4 +1,3 @@
-
 import type { Metadata } from "next";
 import { Link } from "@/i18n/navigation";
 import ScrollReveal from "@/components/ScrollReveal";

--- a/src/app/[locale]/terms/page.tsx
+++ b/src/app/[locale]/terms/page.tsx
@@ -1,4 +1,3 @@
-
 import type { Metadata } from "next";
 import { Link } from "@/i18n/navigation";
 import ScrollReveal from "@/components/ScrollReveal";

--- a/src/app/api/admin/analytics/countries/route.ts
+++ b/src/app/api/admin/analytics/countries/route.ts
@@ -29,7 +29,7 @@ export async function GET(request: NextRequest) {
       "countries",
       { limit: limit },
       () => getTrafficByCountry(undefined, limit),
-      { ttlSeconds: 3600 },
+      { ttlSeconds: 3600 }
     );
     const countries = __read.value;
     return NextResponse.json({

--- a/src/app/api/admin/analytics/ctr-opportunities/route.ts
+++ b/src/app/api/admin/analytics/ctr-opportunities/route.ts
@@ -31,7 +31,7 @@ export async function GET(request: NextRequest) {
       "ctr-opportunities",
       { limit: limit },
       () => getCtrOpportunities(undefined, limit),
-      { ttlSeconds: 3600 },
+      { ttlSeconds: 3600 }
     );
     const opportunities = __read.value;
     return NextResponse.json({

--- a/src/app/api/admin/analytics/devices/route.ts
+++ b/src/app/api/admin/analytics/devices/route.ts
@@ -23,12 +23,9 @@ export async function GET(request: NextRequest) {
   }
 
   try {
-    const __read = await readThrough(
-      "devices",
-      {},
-      () => getDeviceBreakdown(),
-      { ttlSeconds: 3600 },
-    );
+    const __read = await readThrough("devices", {}, () => getDeviceBreakdown(), {
+      ttlSeconds: 3600,
+    });
     const devices = __read.value;
     return NextResponse.json({
       devices,

--- a/src/app/api/admin/analytics/history/route.ts
+++ b/src/app/api/admin/analytics/history/route.ts
@@ -25,7 +25,7 @@ export async function GET(request: NextRequest) {
       "history",
       { weeks: weeks },
       () => getPerformanceHistory(undefined, weeks),
-      { ttlSeconds: 1800 },
+      { ttlSeconds: 1800 }
     );
     const history = __read.value;
     return NextResponse.json({

--- a/src/app/api/admin/analytics/keywords/route.ts
+++ b/src/app/api/admin/analytics/keywords/route.ts
@@ -29,7 +29,7 @@ export async function GET(request: NextRequest) {
       "keywords",
       { limit, days },
       () => getTopKeywords(undefined, limit, days),
-      { ttlSeconds: 3600 },
+      { ttlSeconds: 3600 }
     );
     const keywords = __read.value;
     return NextResponse.json({

--- a/src/app/api/admin/analytics/pages/route.ts
+++ b/src/app/api/admin/analytics/pages/route.ts
@@ -29,7 +29,7 @@ export async function GET(request: NextRequest) {
       "pages",
       { limit, days },
       () => getTopPages(undefined, limit, days),
-      { ttlSeconds: 3600 },
+      { ttlSeconds: 3600 }
     );
     const pages = __read.value;
     return NextResponse.json({

--- a/src/app/api/admin/analytics/products/route.ts
+++ b/src/app/api/admin/analytics/products/route.ts
@@ -31,7 +31,7 @@ export async function GET(request: NextRequest) {
       "products",
       { pattern: pattern, limit: limit },
       () => getProductPageMetrics(undefined, pattern, limit),
-      { ttlSeconds: 3600 },
+      { ttlSeconds: 3600 }
     );
     const products = __read.value;
     return NextResponse.json({

--- a/src/app/api/admin/analytics/query-pages/route.ts
+++ b/src/app/api/admin/analytics/query-pages/route.ts
@@ -33,7 +33,7 @@ export async function GET(request: NextRequest) {
       "query-pages",
       { limit: limit },
       () => getQueryPageMapping(undefined, limit),
-      { ttlSeconds: 3600 },
+      { ttlSeconds: 3600 }
     );
     const mappings = __read.value;
     return NextResponse.json({

--- a/src/app/api/admin/analytics/search-intent/route.ts
+++ b/src/app/api/admin/analytics/search-intent/route.ts
@@ -23,12 +23,9 @@ export async function GET(request: NextRequest) {
   }
 
   try {
-    const __read = await readThrough(
-      "search-intent",
-      {},
-      () => getSearchIntentBreakdown(),
-      { ttlSeconds: 3600 },
-    );
+    const __read = await readThrough("search-intent", {}, () => getSearchIntentBreakdown(), {
+      ttlSeconds: 3600,
+    });
     const intent = __read.value;
     return NextResponse.json({
       intent,
@@ -37,8 +34,8 @@ export async function GET(request: NextRequest) {
         product: intent.product.length,
         informational: intent.informational.length,
         navigational: intent.navigational.length,
-      _cache: { source: __read.source, ageSeconds: __read.ageSeconds },
-    },
+        _cache: { source: __read.source, ageSeconds: __read.ageSeconds },
+      },
       fetchedAt: new Date().toISOString(),
       source: "google-search-console",
     });

--- a/src/app/api/admin/analytics/seo/route.ts
+++ b/src/app/api/admin/analytics/seo/route.ts
@@ -23,7 +23,7 @@ export async function GET(request: NextRequest) {
 
   const days = Math.max(
     1,
-    Math.min(Number(request.nextUrl.searchParams.get("days") ?? "28"), 365 * 2),
+    Math.min(Number(request.nextUrl.searchParams.get("days") ?? "28"), 365 * 2)
   );
 
   try {
@@ -37,7 +37,7 @@ export async function GET(request: NextRequest) {
         ]);
         return { snapshot, keywords };
       },
-      { ttlSeconds: 3600 },
+      { ttlSeconds: 3600 }
     );
 
     return NextResponse.json({

--- a/src/app/api/admin/analytics/web/route.ts
+++ b/src/app/api/admin/analytics/web/route.ts
@@ -14,12 +14,7 @@ export async function GET(request: NextRequest) {
   }
 
   try {
-    const __read = await readThrough(
-      "web",
-      {},
-      () => getWebAnalytics(),
-      { ttlSeconds: 1800 },
-    );
+    const __read = await readThrough("web", {}, () => getWebAnalytics(), { ttlSeconds: 1800 });
     const analytics = __read.value;
     return NextResponse.json({
       analytics,

--- a/src/app/api/admin/audits/latest/route.ts
+++ b/src/app/api/admin/audits/latest/route.ts
@@ -33,7 +33,13 @@ async function gh<T>(path: string, token: string): Promise<T> {
 }
 
 interface RunsResponse {
-  workflow_runs: Array<{ id: number; head_sha: string; html_url: string; updated_at: string; conclusion: string }>;
+  workflow_runs: Array<{
+    id: number;
+    head_sha: string;
+    html_url: string;
+    updated_at: string;
+    conclusion: string;
+  }>;
 }
 
 interface ArtifactsResponse {
@@ -49,14 +55,14 @@ export async function GET(request: NextRequest) {
   if (!token) {
     return NextResponse.json(
       { error: "Audits API not configured — set GH_AUDITS_TOKEN" },
-      { status: 503 },
+      { status: 503 }
     );
   }
 
   try {
     const runs = await gh<RunsResponse>(
       `/repos/${REPO}/actions/workflows/${encodeURIComponent(WORKFLOW)}/runs?per_page=5&status=success`,
-      token,
+      token
     );
     const run = runs.workflow_runs[0];
     if (!run) {
@@ -65,7 +71,7 @@ export async function GET(request: NextRequest) {
 
     const arts = await gh<ArtifactsResponse>(
       `/repos/${REPO}/actions/runs/${run.id}/artifacts`,
-      token,
+      token
     );
     const dash = arts.artifacts.find((a) => a.name.startsWith("audits-dashboard-"));
     if (!dash) {
@@ -83,7 +89,7 @@ export async function GET(request: NextRequest) {
     if (!zipRes.ok) {
       return NextResponse.json(
         { error: `Artifact download failed: ${zipRes.status}` },
-        { status: 502 },
+        { status: 502 }
       );
     }
     const zipBuf = Buffer.from(await zipRes.arrayBuffer());

--- a/src/app/api/admin/notifications/analytics/route.ts
+++ b/src/app/api/admin/notifications/analytics/route.ts
@@ -22,10 +22,7 @@ export async function GET(request: NextRequest) {
   if (!auth.ok) return auth.response;
 
   if (!process.env.ADMIN_NOTIFICATIONS_TABLE) {
-    return NextResponse.json(
-      { error: "Notifications store not configured" },
-      { status: 503 },
-    );
+    return NextResponse.json({ error: "Notifications store not configured" }, { status: 503 });
   }
 
   const url = new URL(request.url);
@@ -34,18 +31,14 @@ export async function GET(request: NextRequest) {
 
   const until = untilParam ?? new Date().toISOString();
   const since =
-    sinceParam ??
-    new Date(Date.now() - DEFAULT_WINDOW_DAYS * 24 * 60 * 60 * 1000).toISOString();
+    sinceParam ?? new Date(Date.now() - DEFAULT_WINDOW_DAYS * 24 * 60 * 60 * 1000).toISOString();
 
   try {
     const stats = await notificationAnalytics({ since, until });
     return NextResponse.json({ window: { since, until }, ...stats });
   } catch (err) {
     console.error("[admin-notifications] analytics failed:", err);
-    return NextResponse.json(
-      { error: "Failed to compute analytics" },
-      { status: 500 },
-    );
+    return NextResponse.json({ error: "Failed to compute analytics" }, { status: 500 });
   }
 }
 

--- a/src/app/api/admin/notifications/route.ts
+++ b/src/app/api/admin/notifications/route.ts
@@ -54,10 +54,7 @@ export async function GET(request: NextRequest) {
   if (!auth.ok) return auth.response;
 
   if (!process.env.ADMIN_NOTIFICATIONS_TABLE) {
-    return NextResponse.json(
-      { error: "Notifications store not configured" },
-      { status: 503 },
-    );
+    return NextResponse.json({ error: "Notifications store not configured" }, { status: 503 });
   }
 
   const url = new URL(request.url);
@@ -74,10 +71,7 @@ export async function GET(request: NextRequest) {
     return NextResponse.json({ notifications });
   } catch (err) {
     console.error("[admin-notifications] GET failed:", err);
-    return NextResponse.json(
-      { error: "Failed to load notifications" },
-      { status: 500 },
-    );
+    return NextResponse.json({ error: "Failed to load notifications" }, { status: 500 });
   }
 }
 
@@ -90,10 +84,7 @@ export async function PATCH(request: NextRequest) {
   if (!auth.ok) return auth.response;
 
   if (!process.env.ADMIN_NOTIFICATIONS_TABLE) {
-    return NextResponse.json(
-      { error: "Notifications store not configured" },
-      { status: 503 },
-    );
+    return NextResponse.json({ error: "Notifications store not configured" }, { status: 503 });
   }
 
   let body: { id?: string; ids?: string[]; markAllRead?: boolean };
@@ -120,20 +111,14 @@ export async function PATCH(request: NextRequest) {
     }
 
     if (!ids.length) {
-      return NextResponse.json(
-        { error: "Provide id, ids, or markAllRead" },
-        { status: 400 },
-      );
+      return NextResponse.json({ error: "Provide id, ids, or markAllRead" }, { status: 400 });
     }
 
     await markNotificationsRead(ids);
     return NextResponse.json({ success: true, updated: ids.length });
   } catch (err) {
     console.error("[admin-notifications] PATCH failed:", err);
-    return NextResponse.json(
-      { error: "Failed to update notifications" },
-      { status: 500 },
-    );
+    return NextResponse.json({ error: "Failed to update notifications" }, { status: 500 });
   }
 }
 

--- a/src/app/api/cron/gsc-cache-refresh/route.ts
+++ b/src/app/api/cron/gsc-cache-refresh/route.ts
@@ -1,12 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { getConfig } from "@/lib/ssm-config";
 import { readThrough } from "@/lib/gsc-cache";
-import {
-  getSeoSnapshot,
-  getTopKeywords,
-  getTopPages,
-  getWebAnalytics,
-} from "@/lib/gsc";
+import { getSeoSnapshot, getTopKeywords, getTopPages, getWebAnalytics } from "@/lib/gsc";
 
 /**
  * GSC cache warmer.
@@ -41,30 +36,24 @@ async function warmRange(days: number): Promise<WarmResult> {
   // Run each warm in parallel; collect their failures but don't let one
   // route's flake fail the whole hourly job.
   const results = await Promise.allSettled([
-    readThrough(
-      "seo",
-      { days },
-      () => getSeoSnapshot(undefined, days),
-      { ttlSeconds: TTL_SECONDS },
-    ),
+    readThrough("seo", { days }, () => getSeoSnapshot(undefined, days), {
+      ttlSeconds: TTL_SECONDS,
+    }),
     readThrough(
       "keywords",
       { limit: KEYWORDS_LIMIT, days },
       () => getTopKeywords(undefined, KEYWORDS_LIMIT, days),
-      { ttlSeconds: TTL_SECONDS },
+      { ttlSeconds: TTL_SECONDS }
     ),
     readThrough(
       "pages",
       { limit: PAGES_LIMIT, days },
       () => getTopPages(undefined, PAGES_LIMIT, days),
-      { ttlSeconds: TTL_SECONDS },
+      { ttlSeconds: TTL_SECONDS }
     ),
-    readThrough(
-      "web",
-      { days },
-      () => getWebAnalytics(undefined, days),
-      { ttlSeconds: TTL_SECONDS },
-    ),
+    readThrough("web", { days }, () => getWebAnalytics(undefined, days), {
+      ttlSeconds: TTL_SECONDS,
+    }),
   ]);
 
   for (const r of results) {
@@ -94,10 +83,7 @@ export async function GET(request: NextRequest) {
   // GSC must actually be configured; otherwise return 503 (caller's cron
   // dashboard surfaces this distinctly from auth failures).
   if (!config.GOOGLE_CLIENT_EMAIL || !config.GOOGLE_PRIVATE_KEY) {
-    return NextResponse.json(
-      { error: "Google Search Console not configured." },
-      { status: 503 },
-    );
+    return NextResponse.json({ error: "Google Search Console not configured." }, { status: 503 });
   }
 
   const t0 = performance.now();

--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -1,4 +1,3 @@
-
 import Link from "next/link";
 import { headers } from "next/headers";
 import { translate, type Locale, isSupportedLocale, defaultLocale } from "@/lib/i18n";

--- a/src/components/NewsletterForm.tsx
+++ b/src/components/NewsletterForm.tsx
@@ -91,7 +91,7 @@ export default function NewsletterForm() {
           dark background and failed WCAG AA. Solid neon-cyan (#22d3e6)
           measures > 7:1 on the dark surface.
         */}
-        <Link href="/privacy" className="text-neon-cyan hover:text-white underline">
+        <Link href="/privacy" className="text-neon-cyan underline hover:text-white">
           {translate(locale, "legal.privacyTitle", "Privacy Policy")}
         </Link>
         {". "}

--- a/src/components/TrainingBanner.tsx
+++ b/src/components/TrainingBanner.tsx
@@ -60,7 +60,7 @@ export default function TrainingBanner({ locale }: Readonly<TrainingBannerProps>
               Δεν αποτελεί εμπορική υπηρεσία, δεν παρέχει πραγματικές υπηρεσίες και δεν δέχεται
               πελάτες.
               <span className="mx-2 text-amber-200">·</span>
-              <span className="italic text-amber-200">υπό κατασκευή</span>
+              <span className="text-amber-200 italic">υπό κατασκευή</span>
             </>
           ) : (
             <>
@@ -69,11 +69,11 @@ export default function TrainingBanner({ locale }: Readonly<TrainingBannerProps>
               This website is built for educational and portfolio purposes only. It is not a
               commercial service, does not provide real services, and does not accept clients.
               <span className="mx-2 text-amber-200">·</span>
-              <span className="italic text-amber-200">under construction</span>
+              <span className="text-amber-200 italic">under construction</span>
             </>
           )}
           <span className="mx-2 text-amber-200">|</span>
-          <span className="italic text-amber-200">&ldquo;{isEl ? QUOTE_EL : QUOTE_EN}&rdquo;</span>
+          <span className="text-amber-200 italic">&ldquo;{isEl ? QUOTE_EL : QUOTE_EN}&rdquo;</span>
         </p>
         <button
           type="button"

--- a/src/lib/admin-notifications.ts
+++ b/src/lib/admin-notifications.ts
@@ -103,8 +103,7 @@ function toItem(notif: AdminNotification): Record<string, AttributeValue> {
   };
   if (notif.actor) item.actor = { S: notif.actor };
   if (notif.route) item.route = { S: notif.route };
-  if (notif.metadata)
-    item.metadata = { S: JSON.stringify(notif.metadata) };
+  if (notif.metadata) item.metadata = { S: JSON.stringify(notif.metadata) };
   if (notif.archivedAt) item.archivedAt = { S: notif.archivedAt };
   return item;
 }
@@ -168,13 +167,13 @@ export async function recordNotification(input: {
       new PutItemCommand({
         TableName: getTableName(),
         Item: toItem(notif),
-      }),
+      })
     );
     return notif;
   } catch (err) {
     console.warn(
       "[admin-notifications] recordNotification failed:",
-      err instanceof Error ? err.message : err,
+      err instanceof Error ? err.message : err
     );
     return null;
   }
@@ -193,9 +192,7 @@ export interface ListFilters {
  * Read recent notifications, newest first. Defaults to 50 most recent
  * un-archived entries.
  */
-export async function listNotifications(
-  filters: ListFilters = {},
-): Promise<AdminNotification[]> {
+export async function listNotifications(filters: ListFilters = {}): Promise<AdminNotification[]> {
   const limit = Math.min(Math.max(filters.limit ?? 50, 1), 200);
   const useCategoryIndex = Boolean(filters.category);
 
@@ -241,14 +238,12 @@ export async function listNotifications(
       TableName: getTableName(),
       IndexName: useCategoryIndex ? CAT_INDEX : undefined,
       KeyConditionExpression: keyConditionParts.join(" AND "),
-      ...(filterExpressions.length
-        ? { FilterExpression: filterExpressions.join(" AND ") }
-        : {}),
+      ...(filterExpressions.length ? { FilterExpression: filterExpressions.join(" AND ") } : {}),
       ExpressionAttributeNames: exprNames,
       ExpressionAttributeValues: exprValues,
       Limit: limit,
       ScanIndexForward: false, // newest first
-    }),
+    })
   );
 
   return (out.Items ?? []).map(fromItem);
@@ -273,7 +268,7 @@ export async function markNotificationsRead(ids: string[]): Promise<void> {
           ":id": { S: id },
         },
         Limit: 1,
-      }),
+      })
     );
     const item = matches.Items?.[0];
     if (!item) continue;
@@ -284,7 +279,7 @@ export async function markNotificationsRead(ids: string[]): Promise<void> {
         UpdateExpression: "SET #read = :true",
         ExpressionAttributeNames: { "#read": "read" },
         ExpressionAttributeValues: { ":true": { BOOL: true } },
-      }),
+      })
     );
   }
 }
@@ -293,10 +288,12 @@ export async function markNotificationsRead(ids: string[]): Promise<void> {
  * Per-category counts over a window. Used by the admin analytics endpoint.
  * Returns { total, byCategory: { contact: N, ... }, byDay: { '2026-06-12': N, ... } }.
  */
-export async function notificationAnalytics(opts: {
-  since: string;
-  until?: string;
-} = { since: "" }): Promise<{
+export async function notificationAnalytics(
+  opts: {
+    since: string;
+    until?: string;
+  } = { since: "" }
+): Promise<{
   total: number;
   byCategory: Record<NotificationCategory, number>;
   byDay: Record<string, number>;
@@ -363,7 +360,7 @@ export async function purgeArchivedOlderThan(olderThan: string): Promise<number>
               DeleteRequest: { Key: { pk: it.pk, sk: it.sk } },
             })),
           },
-        }),
+        })
       );
       purged += items.length;
     }

--- a/src/lib/gsc-cache.ts
+++ b/src/lib/gsc-cache.ts
@@ -68,7 +68,7 @@ function toItem<T>(
   route: string,
   hash: string,
   payload: T,
-  ttlSeconds: number,
+  ttlSeconds: number
 ): Record<string, AttributeValue> {
   return {
     pk: { S: route },
@@ -81,7 +81,7 @@ function toItem<T>(
 
 function fromItem<T>(
   item: Record<string, AttributeValue>,
-  ttlSeconds: number,
+  ttlSeconds: number
 ): CacheEntry<T> | null {
   const storedAt = item.storedAt?.S;
   const raw = item.payload?.S;
@@ -113,7 +113,7 @@ function fromItem<T>(
 export async function getCached<T = unknown>(
   route: string,
   params: Record<string, unknown> = {},
-  ttlSeconds = 3600,
+  ttlSeconds = 3600
 ): Promise<CacheEntry<T> | null> {
   const table = getTableName();
   if (!table) return null;
@@ -123,15 +123,12 @@ export async function getCached<T = unknown>(
       new GetItemCommand({
         TableName: table,
         Key: { pk: { S: route }, sk: { S: hash } },
-      }),
+      })
     );
     if (!out.Item) return null;
     return fromItem<T>(out.Item, ttlSeconds);
   } catch (err) {
-    console.warn(
-      "[gsc-cache] getCached failed:",
-      err instanceof Error ? err.message : err,
-    );
+    console.warn("[gsc-cache] getCached failed:", err instanceof Error ? err.message : err);
     return null;
   }
 }
@@ -144,7 +141,7 @@ export async function setCached<T = unknown>(
   route: string,
   params: Record<string, unknown> = {},
   payload: T,
-  ttlSeconds = 3600,
+  ttlSeconds = 3600
 ): Promise<void> {
   const table = getTableName();
   if (!table) return;
@@ -154,13 +151,10 @@ export async function setCached<T = unknown>(
       new PutItemCommand({
         TableName: table,
         Item: toItem(route, hash, payload, ttlSeconds),
-      }),
+      })
     );
   } catch (err) {
-    console.warn(
-      "[gsc-cache] setCached failed:",
-      err instanceof Error ? err.message : err,
-    );
+    console.warn("[gsc-cache] setCached failed:", err instanceof Error ? err.message : err);
   }
 }
 
@@ -175,7 +169,7 @@ export async function readThrough<T>(
   route: string,
   params: Record<string, unknown>,
   fetcher: () => Promise<T>,
-  opts: { ttlSeconds?: number; acceptStaleSeconds?: number } = {},
+  opts: { ttlSeconds?: number; acceptStaleSeconds?: number } = {}
 ): Promise<{ value: T; source: "cache" | "live" | "stale"; ageSeconds: number }> {
   const ttlSeconds = opts.ttlSeconds ?? 3600;
   const acceptStaleSeconds = opts.acceptStaleSeconds ?? 24 * 3600;
@@ -193,7 +187,7 @@ export async function readThrough<T>(
     if (cached && cached.ageSeconds <= acceptStaleSeconds) {
       console.warn(
         `[gsc-cache] live fetch failed for ${route}, serving stale (age=${cached.ageSeconds}s):`,
-        err instanceof Error ? err.message : err,
+        err instanceof Error ? err.message : err
       );
       return { value: cached.payload, source: "stale", ageSeconds: cached.ageSeconds };
     }

--- a/src/lib/gsc.ts
+++ b/src/lib/gsc.ts
@@ -117,7 +117,7 @@ export interface WebAnalyticsData {
  */
 export async function getSeoSnapshot(
   siteUrl = DEFAULT_SITE,
-  days = 28,
+  days = 28
 ): Promise<SeoSnapshot | null> {
   try {
     const range = dateRange(days);
@@ -165,7 +165,7 @@ export async function getSeoSnapshot(
 export async function getTopKeywords(
   siteUrl = DEFAULT_SITE,
   limit = 20,
-  days = 28,
+  days = 28
 ): Promise<KeywordData[]> {
   try {
     const res = await gscQuery(siteUrl, {
@@ -250,7 +250,7 @@ export async function getPerformanceHistory(
 export async function getTopPages(
   siteUrl = DEFAULT_SITE,
   limit = 25,
-  days = 28,
+  days = 28
 ): Promise<PageData[]> {
   try {
     const res = await gscQuery(siteUrl, {
@@ -282,7 +282,7 @@ export async function getTopPages(
  */
 export async function getWebAnalytics(
   siteUrl = DEFAULT_SITE,
-  days = 28,
+  days = 28
 ): Promise<WebAnalyticsData | null> {
   try {
     const range = dateRange(days);

--- a/src/lib/notion.ts
+++ b/src/lib/notion.ts
@@ -382,7 +382,7 @@ export async function createPage(
       "[Notion] Failed to create page in " +
         JSON.stringify(safeId(databaseId)) +
         ": " +
-        JSON.stringify(safeMsg((err as Error)?.message ?? "unknown error")),
+        JSON.stringify(safeMsg((err as Error)?.message ?? "unknown error"))
     );
     return null;
   }
@@ -405,7 +405,7 @@ export async function updatePage(
       "[Notion] Failed to update page " +
         JSON.stringify(safeId(pageId)) +
         ": " +
-        JSON.stringify(safeMsg((err as Error)?.message ?? "unknown error")),
+        JSON.stringify(safeMsg((err as Error)?.message ?? "unknown error"))
     );
     return false;
   }
@@ -428,7 +428,7 @@ export async function archivePage(pageId: string): Promise<boolean> {
       "[Notion] Failed to archive page " +
         JSON.stringify(safeId(pageId)) +
         ": " +
-        JSON.stringify(safeMsg((err as Error)?.message ?? "unknown error")),
+        JSON.stringify(safeMsg((err as Error)?.message ?? "unknown error"))
     );
     return false;
   }
@@ -451,7 +451,7 @@ export async function restorePage(pageId: string): Promise<boolean> {
       "[Notion] Failed to restore page " +
         JSON.stringify(safeId(pageId)) +
         ": " +
-        JSON.stringify(safeMsg((err as Error)?.message ?? "unknown error")),
+        JSON.stringify(safeMsg((err as Error)?.message ?? "unknown error"))
     );
     return false;
   }
@@ -481,7 +481,7 @@ export async function appendBlocks(parentId: string, children: any[]): Promise<b
       "[Notion] Failed to append blocks to " +
         JSON.stringify(safeId(parentId)) +
         ": " +
-        JSON.stringify(safeMsg((err as Error)?.message ?? "unknown error")),
+        JSON.stringify(safeMsg((err as Error)?.message ?? "unknown error"))
     );
     return false;
   }
@@ -501,7 +501,7 @@ export async function deleteBlock(blockId: string): Promise<boolean> {
       "[Notion] Failed to delete block " +
         JSON.stringify(safeId(blockId)) +
         ": " +
-        JSON.stringify(safeMsg((err as Error)?.message ?? "unknown error")),
+        JSON.stringify(safeMsg((err as Error)?.message ?? "unknown error"))
     );
     return false;
   }

--- a/src/lib/voice-brief-store.ts
+++ b/src/lib/voice-brief-store.ts
@@ -27,6 +27,6 @@ export async function persistVoiceBrief(brief: VoiceBriefRecord): Promise<void> 
       Value: JSON.stringify(brief),
       Type: "String",
       Overwrite: true,
-    }),
+    })
   );
 }


### PR DESCRIPTION
Pure formatting fix. Runs prettier --write on the 32 files flagged by CI's pnpm format:check step in run #27491485340. No semantic changes — whitespace, line wrapping, and Tailwind class ordering only.

Unblocks future PRs from failing CI on Lint & Format / Run pnpm format:check.