### PR TITLE
docs: fix 10 markdownlint errors in skills/CLAUDE docs

### DIFF
--- a/.claude/skills/calendar-notion-reshare/SKILL.md
+++ b/.claude/skills/calendar-notion-reshare/SKILL.md
@@ -17,6 +17,7 @@ This is **UI-only**. Notion's public API has no `add_connection`, `share`, or `g
 ## Affected databases (verify which are broken)
 
 From CLAUDE.md ("E2E (Playwright) Conventions" section):
+
 - Case studies
 - Testimonials
 - Services

--- a/.claude/skills/cloudflare-token-rotation/SKILL.md
+++ b/.claude/skills/cloudflare-token-rotation/SKILL.md
@@ -30,6 +30,7 @@ gh run watch --repo Themis128/cloudless.gr
 ```
 
 The step summary will print:
+
 - The current token id
 - Verify-call success
 - A plan of what `apply=true` will do
@@ -44,6 +45,7 @@ gh run watch --repo Themis128/cloudless.gr
 ```
 
 What happens:
+
 1. Workflow calls `PUT /user/tokens/{id}/value` — Cloudflare returns a new secret. **Old secret is invalidated immediately on this call.**
 2. New value is verified against `/user/tokens/verify`.
 3. AWS SSM is updated via `aws ssm put-parameter --overwrite`.

--- a/.claude/skills/esp32-notion-restore/SKILL.md
+++ b/.claude/skills/esp32-notion-restore/SKILL.md
@@ -45,6 +45,7 @@ If you don't know the URL, search Notion workspace for "ESP32" and pick the pare
 Scroll the list until you see a revision dated **before 2026-06-02 15:19 UTC**. The first viable candidate is likely the last revision *that morning* or the last one from 2026-06-01. Notion timestamps are in local time; the right column shows "X days ago" — for the 2026-06-02 incident at ~12 days ago, look for revisions dated 13+ days ago.
 
 Each revision shows:
+
 - Author
 - Timestamp
 - A preview of what the page looked like at that point
@@ -52,6 +53,7 @@ Each revision shows:
 ### 4. Verify it's the right revision
 
 Click the revision to preview it in the main canvas. Confirm:
+
 - The expected sections are present (device list, telemetry views, runbook links)
 - It is NOT one of the stub-content revisions from after the incident
 
@@ -60,6 +62,7 @@ If the preview is empty, that revision was already post-incident; pick an older 
 ### 5. Restore
 
 Click the **Restore** button in the history sidebar header. Notion will:
+
 - Snapshot the current (post-restore) state as a new revision
 - Replace the live page content with the chosen revision
 - Keep ALL nested databases untouched

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,6 +50,7 @@ are now strictly separated:
   cluster-relevant lives there.
 
 **Quick disk audit one-liner** (run on omv-main):
+
 ```
 df -h /var/lib/rancher/k3s /srv/dev-disk-by-uuid-fa6231ab-eae7-40ea-a4b6-400f767a89d7 /
 ```

--- a/skills/cloudflare-token-doctor/SKILL.md
+++ b/skills/cloudflare-token-doctor/SKILL.md
@@ -112,6 +112,7 @@ Use Path B for read-only consumers (Grafana, dashboards) so the wide
 Two stores keep them in sync:
 
 ### 2a — SSM (consumed by the infra MCP, deploy workflows, the Next.js
+
 runtime, and the Pi cluster)
 
 ```bash
@@ -208,11 +209,13 @@ mcp__cloudless-infra__cloudflare_delete_token(token_id: "<id>")
 ```
 
 Keep:
+
 - The currently active infra token
 - Anything used by a CI workflow (look for `gh secret list | grep -i cloudflare`)
 - Any tokens with a documented purpose in `docs/`
 
 Revoke:
+
 - "Edit Cloudflare Workers" default-named tokens you don't remember creating
 - Tokens with expiry > 1 year in the past
 - Duplicates from prior rotations


### PR DESCRIPTION
Pure docs formatting fix. Runs markdownlint-cli2 --fix on the 5 files (3 skill files + CLAUDE.md + cloudflare-token-doctor SKILL.md) that have MD031/MD032/MD022 violations.

Unblocks future PRs from failing CI on Lint & Format / Run pnpm lint:md step. No content changes — only blank lines around lists, code fences, and headings.