### PR TITLE
fix(tests): 5 stale tests for PR C2 days arg + commit 8983eb3

### DIFF
--- a/__tests__/gsc-routes-cache-wiring.test.ts
+++ b/__tests__/gsc-routes-cache-wiring.test.ts
@@ -84,7 +84,7 @@ describe("GET /api/admin/analytics/keywords — cache wiring", () => {
     expect(mockReadThrough).toHaveBeenCalledTimes(1);
     const [routeKey, params, fetcher, opts] = mockReadThrough.mock.calls[0];
     expect(routeKey).toBe("keywords");
-    expect(params).toEqual({ limit: 42 });
+    expect(params).toEqual({ limit: 42, days: 28 });
     expect(opts).toEqual({ ttlSeconds: 3600 });
     expect(typeof fetcher).toBe("function");
   });
@@ -98,8 +98,8 @@ describe("GET /api/admin/analytics/keywords — cache wiring", () => {
     const { GET } = await import("@/app/api/admin/analytics/keywords/route");
     await GET(req("http://localhost/api/admin/analytics/keywords?limit=5"));
     await GET(req("http://localhost/api/admin/analytics/keywords?limit=100"));
-    expect(mockReadThrough.mock.calls[0][1]).toEqual({ limit: 5 });
-    expect(mockReadThrough.mock.calls[1][1]).toEqual({ limit: 100 });
+    expect(mockReadThrough.mock.calls[0][1]).toEqual({ limit: 5, days: 28 });
+    expect(mockReadThrough.mock.calls[1][1]).toEqual({ limit: 100, days: 28 });
   });
 
   it("includes _cache metadata in the response", async () => {
@@ -128,7 +128,7 @@ describe("GET /api/admin/analytics/keywords — cache wiring", () => {
     await GET(req("http://localhost/api/admin/analytics/keywords?limit=12"));
     expect(captured).not.toBeNull();
     await captured!();
-    expect(mockGsc.getTopKeywords).toHaveBeenCalledWith(undefined, 12);
+    expect(mockGsc.getTopKeywords).toHaveBeenCalledWith(undefined, 12, 28);
   });
 });
 
@@ -174,7 +174,7 @@ describe("GET /api/admin/analytics/seo — composite cache", () => {
     expect(data.keywords).toEqual([{ keyword: "x" }]);
     expect(data._cache).toEqual({ source: "cache", ageSeconds: 60 });
     // Empty params: the seo route caches one global blob.
-    expect(mockReadThrough.mock.calls[0][1]).toEqual({});
+    expect(mockReadThrough.mock.calls[0][1]).toEqual({ days: 28 });
   });
 
   it("composite fetcher resolves snapshot + keywords in parallel", async () => {

--- a/__tests__/notion-calendar.test.ts
+++ b/__tests__/notion-calendar.test.ts
@@ -246,20 +246,24 @@ describe("notion-calendar.ts", () => {
       expect(mockNotionFetch).not.toHaveBeenCalled();
     });
 
-    it("returns null on API error", async () => {
+    it("propagates API error (caller must handle, no silent data-loss)", async () => {
+      // notionCreateCalendarItem no longer swallows errors — see CLAUDE.md
+      // commit 8983eb3 ("calendar silent-data-loss fix"). Failures now bubble
+      // up and the /api/admin/calendar/create route returns 502 instead of a
+      // false 201 with item:null.
       mockNotionFetch.mockRejectedValueOnce(new Error("fail"));
 
       const { notionCreateCalendarItem } = await import("@/lib/notion-calendar");
-      const result = await notionCreateCalendarItem({
-        id: "cal_1",
-        title: "T",
-        type: "social_post",
-        platform: "x",
-        date: "2026-06-01",
-        status: "draft",
-      });
-
-      expect(result).toBeNull();
+      await expect(
+        notionCreateCalendarItem({
+          id: "cal_1",
+          title: "T",
+          type: "social_post",
+          platform: "x",
+          date: "2026-06-01",
+          status: "draft",
+        }),
+      ).rejects.toThrow("fail");
     });
   });
 


### PR DESCRIPTION
Fixes 5 stale unit tests caught by CI on PR #866 branch.

**4 in gsc-routes-cache-wiring.test.ts**: PR C2 added a days param to getTopKeywords/getTopPages and includes days in the cache-key params. Tests updated to expect {limit, days: 28} and (undefined, limit, 28).

**1 in notion-calendar.test.ts**: notionCreateCalendarItem no longer swallows errors after commit 8983eb3 (calendar silent-data-loss fix); test updated to assert rejection.