### PR TITLE
docs: decommission Pi cron orchestrator + clean cloudless.online ref

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -356,6 +356,37 @@ sudo tail -f /var/log/cloudless-cleanup.log
 sudo systemctl disable --now cloudless-cleanup.timer
 ```
 
+## Scheduled Tasks (cron architecture)
+
+**All scheduled tasks run on GitHub Actions, not on the Pi.** A legacy
+`/etc/cron.d/cloudless-tasks` orchestrator existed on `omv-main` and was
+decommissioned on 2026-06-14 — it had been silently failing every week with
+`Unable to locate credentials` because root cron has no AWS context. None
+of its 7 routines (cloudless-agency-hub-status, daily-leads-digest,
+notion-stale-submissions, weekly-sentry-digest, weekly-seo-snapshot,
+weekly-gsc-notion-sync, windsor-configuration-check) ran successfully for
+the prior ~5 weeks.
+
+Current scheduled-task setup:
+
+- **`platform-crons.yml`** — calls `/api/cron/owner-digest` weekly (Mon 06:00
+  UTC) and `/api/cron/client-reports` monthly (1st 08:00 UTC). owner-digest
+  consolidates k3s pod health, Lambda deploy state, Sentry unresolved-issue
+  summary, Stripe activity, and GSC stats into a single Slack post —
+  replacing 5 of the 7 legacy Pi routines.
+- **`weekly-gsc-sync.yml`** — weekly GSC → Notion sync (Mon 07:00 UTC),
+  direct replacement for the legacy weekly-gsc-notion-sync.
+- **`notion-integration-health.yml`** — hourly Notion DB reachability probe.
+- **`ha-failover-watchdog.yml`** — 1-min HA failover for cloudless.gr.
+- **`sha-drift-detector.yml`** + **`sha-drift-watchdog.yml`** — deployed-SHA
+  vs main-HEAD drift detection.
+- App-side stale-submissions surfacing happens via the admin notifications
+  Dynamo table (PR A1/A2/A3, 2026-06-08) — no need for a cron probe.
+
+Do **not** add new tasks to Pi cron. New scheduled work goes in
+`.github/workflows/<name>.yml` with `schedule:` and reads SSM via the AWS
+OIDC deploy role.
+
 ## Terraform Doctor
 
 When a Terraform CI workflow fails, **invoke the `terraform-doctor` skill first**

--- a/skills/cloudflare-token-doctor/SKILL.md
+++ b/skills/cloudflare-token-doctor/SKILL.md
@@ -80,8 +80,7 @@ output. This is the path you'll take if every prior token is gone.
 
 4. Account Resources: **Include — All accounts**
 5. Zone Resources: **Include — Specific zone — cloudless.gr**
-   (Add another row for `cloudless.online` if failover analytics is
-   wanted.)
+   (cloudless.online has been decommissioned — do not add it.)
 6. TTL: **1 year** (or no expiry — your call; expiry forces rotation,
    no expiry forces vigilance).
 7. **Continue → Create → copy the secret once.** Cloudflare will not


### PR DESCRIPTION
**Decommissioned the Pi cron orchestrator on omv-main** that had been failing silently every week since AWS creds rotated. None of its 7 routines (cloudless-agency-hub-status, daily-leads-digest, notion-stale-submissions, weekly-sentry-digest, weekly-seo-snapshot, weekly-gsc-notion-sync, windsor-configuration-check) had produced output in ~5 weeks — root cron has no AWS context so orchestrator.py couldn't SSM-fetch creds.

Removed from omv-main:
- `/etc/cron.d/cloudless-tasks`
- `/usr/local/lib/cloudless-tasks/` (orchestrator + scripts + task specs)
- `/etc/cloudless-tasks/`
- `/var/log/cloudless-tasks/`
- Stale backup `/etc/cron.d/cloudless-warmer.bak.20260614`

Backup of orchestrator.py at `/tmp/orchestrator.py.legacy-backup-*` on omv-main if reference needed.

**No business logic was lost** because every routine had already been re-implemented in the GH Actions architecture:
| Old Pi routine | Current replacement |
|---|---|
| cloudless-agency-hub-status | platform-crons.yml → /api/cron/owner-digest |
| daily-leads-digest | platform-crons.yml + admin notifications |
| notion-stale-submissions | admin notifications Dynamo table (PR A1-A3) |
| weekly-sentry-digest | platform-crons.yml → /api/cron/owner-digest |
| weekly-seo-snapshot | platform-crons.yml → /api/cron/owner-digest |
| weekly-gsc-notion-sync | weekly-gsc-sync.yml |
| windsor-configuration-check | Windsor connector deprecated |

Also documents the canonical scheduled-task architecture in CLAUDE.md so future agents know GH Actions is the only path.

Also: removed stale `cloudless.online` reference from skills/cloudflare-token-doctor/SKILL.md (domain decommissioned tonight).