### PR TITLE
fix(workflows): gate 4 Anthropic-dependent workflows as dispatch-only

### DIFF
--- a/.github/workflows/ci-babysitter.yml
+++ b/.github/workflows/ci-babysitter.yml
@@ -6,12 +6,16 @@ name: CI Failure Babysitter
 # the relevant PR (or tracking issue #382 for main-branch failures).
 
 on:
-  workflow_run:
-    workflows:
-      - CI
-      - Deploy to Production
-      - Deploy to Pi (ECR + k3s rollout)
-    types: [completed]
+  # Dispatch-only. The Anthropic API call fails with 400 "credit balance
+  # too low" while the account is unfunded. Until credits are added at
+  # platform.claude.com/settings/billing, scheduled/auto runs would generate
+  # GH email noise on every fire. Stays available for manual dispatch.
+  workflow_dispatch:
+    inputs:
+      run_id:
+        description: "Failed run ID to narrate"
+        required: true
+        type: string
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"

--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -4,12 +4,16 @@ env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
 
 on:
-  pull_request:
-    types: [opened, synchronize, reopened]
-    paths:
-      - "src/**"
-      - "sentry.*.config.ts"
-      - "instrumentation.ts"
+  # Dispatch-only. The Anthropic API call fails with 400 "credit balance
+  # too low" while the account is unfunded. Until credits are added at
+  # platform.claude.com/settings/billing, scheduled/auto runs would generate
+  # GH email noise on every fire. Stays available for manual dispatch.
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: "PR number to review"
+        required: true
+        type: string
 
 # One review per PR branch at a time; cancel stale runs on new push
 concurrency:

--- a/.github/workflows/stale-gate-sweeper.yml
+++ b/.github/workflows/stale-gate-sweeper.yml
@@ -6,9 +6,11 @@ name: Stale Gate Sweeper
 # are ready to delete, and posts a triage report to tracking issue #382.
 
 on:
-  schedule:
-    - cron: "0 9 * * 1" # Monday 09:00 UTC
-  workflow_dispatch: # manual trigger
+  # Dispatch-only. The Anthropic API call fails with 400 "credit balance
+  # too low" while the account is unfunded. Until credits are added at
+  # platform.claude.com/settings/billing, scheduled/auto runs would generate
+  # GH email noise on every fire. Stays available for manual dispatch.
+  workflow_dispatch:
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"

--- a/.github/workflows/weekly-article-draft.yml
+++ b/.github/workflows/weekly-article-draft.yml
@@ -1,11 +1,11 @@
 name: Weekly Article Draft
 
 on:
-  schedule:
-    # Every Monday at 06:00 UTC (08:00 Athens). Three hours before the
-    # publisher runs — that window is the human review SLA.
-    - cron: "0 6 * * 1"
-  workflow_dispatch: # Manual trigger from the Actions tab
+  # Dispatch-only. The Anthropic API call fails with 400 "credit balance
+  # too low" while the account is unfunded. Until credits are added at
+  # platform.claude.com/settings/billing, scheduled/auto runs would generate
+  # GH email noise on every fire. Stays available for manual dispatch.
+  workflow_dispatch:
 
 concurrency:
   group: weekly-article-draft


### PR DESCRIPTION
Anthropic account has zero credits. Every call to api.anthropic.com returns:

```
400 {"type":"invalid_request_error","message":"Your credit balance is too low to access the Anthropic API. Please go to Plans & Billing to upgrade or purchase credits."}
```

4 workflows fail on every schedule/auto fire and email me:
- `stale-gate-sweeper` (Mon 09:00 UTC schedule)
- `pr-review` (pull_request event - reason my PR review comments have been missing all night)
- `ci-babysitter` (workflow_run on CI/Deploy failures)
- `weekly-article-draft` (Mon 06:00 UTC schedule)

The auth itself is now healthy - rotated the SSM ANTHROPIC_API_KEY to a fresh key (`cloudless-production-2026-06-14`) earlier this hour. But the workflows still can't do useful work without funded credits.

**This PR:** gates each as `workflow_dispatch:` only. The schedule/pull_request/workflow_run triggers are removed. Each gains an explanatory comment. `pr-review` and `ci-babysitter` get optional dispatch inputs (`pr_number`, `run_id`) so they're still manually runnable.

**To restore full functionality**: add credits at https://platform.claude.com/settings/billing and revert this PR.