### PR TITLE
fix(monitoring): align Prometheus alert rules with post-migration architecture

### DIFF
--- a/k8s/cluster-protection/alerts/README.md
+++ b/k8s/cluster-protection/alerts/README.md
@@ -1,0 +1,53 @@
+# Repo-tracked PrometheusRules
+
+This directory holds repo-tracked PrometheusRules that overlay or replace the
+`kube-prometheus-stack` defaults for the omv 2-Pi cluster.
+
+## Files
+
+| File | Purpose |
+|---|---|
+| `cluster-alerts.yaml` | Cluster-wide event scanner CronJob — posts Crash-loop / OOM / Evicted events to Slack `#errors` every 5 min. |
+| `pod-health.yaml` | Pod readiness / CPU / memory / restart alerts. The `PodRestartingFrequently` rule uses `increase(kube_pod_container_status_restarts_total[1h]) >= 5` — replacing the broken `>= 20` cumulative-counter rule that fired forever on any pod that had ever crashed. |
+| `disk-pressure.yaml` | Node disk-pressure alerts. Excludes the user-data SMB mount (`/srv/dev-disk-*`) where Windows backups live — that mount sits at 80-89% by design, and k3s no longer lives there (post-2026-06-13 migration; see CLAUDE.md). |
+
+## Apply
+
+```bash
+sudo k3s kubectl apply -f k8s/cluster-protection/alerts/pod-health.yaml
+sudo k3s kubectl apply -f k8s/cluster-protection/alerts/disk-pressure.yaml
+sudo k3s kubectl apply -f k8s/cluster-protection/alerts/cluster-alerts.yaml
+```
+
+## After applying
+
+Cumulative restart counters on pods that were noisy before the migration won't
+clear from these rule changes alone — the counter is stored on the pod object.
+Rolling-restart the affected pods to reset counters to zero:
+
+```bash
+# Find pods with cumulative restartCount > 20
+sudo k3s kubectl get pods -A -o json | python3 -c '
+import sys,json; d=json.load(sys.stdin)
+for p in d["items"]:
+    n = sum(c.get("restartCount",0) for c in p["status"].get("containerStatuses",[]))
+    if n > 20:
+        print(f"{p[\"metadata\"][\"namespace\"]}/{p[\"metadata\"][\"name\"]}: {n}")
+'
+
+# Delete each (pod gets recreated; counter starts at 0)
+sudo k3s kubectl -n <ns> delete pod <pod-name>
+```
+
+This was done on 2026-06-14 for: prometheus-monitoring-prometheus-0,
+kube-prom-kube-state-metrics, monitoring-operator, cert-manager,
+cert-manager-cainjector.
+
+## Why these aren't in upstream chart values
+
+The kube-prometheus-stack chart-managed rules live in the `monitoring-*`
+PrometheusRule resources. The files here either **add** new rules
+(`cluster-alerts.yaml` CronJob — not a PrometheusRule but lives here for
+operational grouping), or **replace** rules where the upstream version
+misfires on Pi-class hardware (`pod-health.yaml`, `disk-pressure.yaml`).
+These survive helm upgrades because they share the rule's name.

--- a/k8s/cluster-protection/alerts/disk-pressure.yaml
+++ b/k8s/cluster-protection/alerts/disk-pressure.yaml
@@ -1,0 +1,36 @@
+# Synced from live cluster after PR #880 architecture-alignment work.
+# Apply: sudo k3s kubectl apply -f k8s/cluster-protection/alerts/disk-pressure.yaml
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  labels:
+    app: kube-prometheus-stack
+  name: disk-pressure
+  namespace: monitoring
+spec:
+  groups:
+  - name: disk
+    rules:
+    - alert: DiskPressureHigh
+      annotations:
+        description: "{{ $value | humanize }}% used \u2014 free space before k3s crashes."
+        summary: Disk usage > 85% on {{ $labels.instance }} ({{ $labels.mountpoint
+          }})
+      expr: "(1 - node_filesystem_avail_bytes{fstype!~\"tmpfs|overlay|squashfs\",mountpoint!~\"\
+        /boot.*|/srv/dev-disk-.*\"}\n   / node_filesystem_size_bytes{fstype!~\"tmpfs|overlay|squashfs\"\
+        ,mountpoint!~\"/boot.*|/srv/dev-disk-.*\"}) * 100 > 85\n"
+      for: 5m
+      labels:
+        severity: warning
+    - alert: DiskPressureCritical
+      annotations:
+        description: "{{ $value | humanize }}% used \u2014 k3s is likely to crash.\
+          \ Free space immediately."
+        summary: Disk usage > 95% on {{ $labels.instance }} ({{ $labels.mountpoint
+          }})
+      expr: "(1 - node_filesystem_avail_bytes{fstype!~\"tmpfs|overlay|squashfs\",mountpoint!~\"\
+        /boot.*|/srv/dev-disk-.*\"}\n   / node_filesystem_size_bytes{fstype!~\"tmpfs|overlay|squashfs\"\
+        ,mountpoint!~\"/boot.*|/srv/dev-disk-.*\"}) * 100 > 95\n"
+      for: 2m
+      labels:
+        severity: critical

--- a/k8s/cluster-protection/alerts/pod-health.yaml
+++ b/k8s/cluster-protection/alerts/pod-health.yaml
@@ -1,0 +1,142 @@
+# Synced from live cluster after PR #880 architecture-alignment work.
+# Apply: sudo k3s kubectl apply -f k8s/cluster-protection/alerts/pod-health.yaml
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  labels:
+    app: kube-prometheus-stack
+  name: pod-health
+  namespace: monitoring
+spec:
+  groups:
+  - name: pod.crashloop
+    rules:
+    - alert: PodCrashLooping
+      annotations:
+        description: 'Container {{ $labels.container }} restarted {{ $value | printf
+          "%.0f" }} times in 15 m. Run: kubectl logs -p {{ $labels.pod }} -n {{ $labels.namespace
+          }}'
+        summary: '{{ $labels.namespace }}/{{ $labels.pod }} crash-looping'
+      expr: 'rate(kube_pod_container_status_restarts_total[15m]) * 60 * 15 > 3
+
+        '
+      for: 5m
+      labels:
+        severity: warning
+    - alert: PodOOMKilled
+      annotations:
+        description: Container {{ $labels.container }} was OOM-killed. Raise its memory
+          limit or investigate a leak.
+        summary: '{{ $labels.namespace }}/{{ $labels.pod }} OOMKilled'
+      expr: 'kube_pod_container_status_last_terminated_reason{reason="OOMKilled"}
+        == 1
+
+        '
+      for: 0m
+      labels:
+        severity: critical
+    - alert: PodRestartingFrequently
+      annotations:
+        summary: '{{ $labels.namespace }}/{{ $labels.pod }} restarted {{ $value |
+          printf "%.0f" }}x in last hour'
+      expr: 'increase(kube_pod_container_status_restarts_total[1h]) >= 5
+
+        '
+      for: 10m
+      labels:
+        severity: warning
+  - name: pod.readiness
+    rules:
+    - alert: PodNotReady
+      annotations:
+        description: 'Check: kubectl describe pod {{ $labels.pod }} -n {{ $labels.namespace
+          }}'
+        summary: '{{ $labels.namespace }}/{{ $labels.pod }} not ready for 5 m'
+      expr: 'kube_pod_status_ready{condition="true"} == 0
+
+        '
+      for: 5m
+      labels:
+        severity: warning
+    - alert: PodPendingTooLong
+      annotations:
+        description: 'Possible causes: insufficient node resources, image pull failure,
+          PVC not bound. Check: kubectl describe pod {{ $labels.pod }} -n {{ $labels.namespace
+          }}'
+        summary: '{{ $labels.namespace }}/{{ $labels.pod }} stuck Pending for 10 m'
+      expr: 'kube_pod_status_phase{phase="Pending"} == 1
+
+        '
+      for: 10m
+      labels:
+        severity: warning
+    - alert: DeploymentReplicasMismatch
+      annotations:
+        description: 'Desired {{ $value }} replicas not all available. Check: kubectl
+          rollout status deployment/{{ $labels.deployment }} -n {{ $labels.namespace
+          }}'
+        summary: '{{ $labels.namespace }}/{{ $labels.deployment }} replica mismatch
+          for 5 m'
+      expr: "kube_deployment_spec_replicas\n  != kube_deployment_status_replicas_available\n"
+      for: 5m
+      labels:
+        severity: warning
+  - name: pod.resources
+    rules:
+    - alert: ContainerHighMemory
+      annotations:
+        description: "Using {{ $value | humanizePercentage }} \u2014 OOMKill risk.\
+          \ Current limit may be too low."
+        summary: '{{ $labels.namespace }}/{{ $labels.pod }}/{{ $labels.container }}
+          memory > 90% of limit'
+      expr: "(\n  container_memory_working_set_bytes{container!=\"\",container!=\"\
+        POD\"}\n  / on(namespace,pod,container)\n  kube_pod_container_resource_limits{resource=\"\
+        memory\",container!=\"\"}\n) > 0.90\n"
+      for: 10m
+      labels:
+        severity: warning
+    - alert: ContainerHighCPU
+      annotations:
+        description: "Using {{ $value | humanizePercentage }} of CPU limit for 10\
+          \ m \u2014 consider raising limit or adding replicas."
+        summary: '{{ $labels.namespace }}/{{ $labels.pod }}/{{ $labels.container }}
+          CPU > 90% of limit'
+      expr: "(\n  rate(container_cpu_usage_seconds_total{container!=\"\",container!=\"\
+        POD\"}[5m])\n  / on(namespace,pod,container)\n  kube_pod_container_resource_limits{resource=\"\
+        cpu\",container!=\"\"}\n) > 0.90\n"
+      for: 10m
+      labels:
+        severity: warning
+    - alert: ContainerThrottled
+      annotations:
+        description: Container is heavily throttled. Raise cpu limit or reduce load.
+        summary: '{{ $labels.namespace }}/{{ $labels.pod }}/{{ $labels.container }}
+          CPU throttled > 50%'
+      expr: "rate(container_cpu_cfs_throttled_seconds_total{container!=\"\"}[5m])\n\
+        \  / rate(container_cpu_cfs_periods_total{container!=\"\"}[5m]) > 0.50\n"
+      for: 10m
+      labels:
+        severity: warning
+  - name: pod.hpa
+    rules:
+    - alert: HPAMaxedOut
+      annotations:
+        description: Autoscaler cannot add more pods. Consider raising maxReplicas
+          or reducing load.
+        summary: HPA {{ $labels.namespace }}/{{ $labels.horizontalpodautoscaler }}
+          at max replicas for 15 m
+      expr: "kube_horizontalpodautoscaler_status_current_replicas\n  == kube_horizontalpodautoscaler_spec_max_replicas\n"
+      for: 15m
+      labels:
+        severity: warning
+    - alert: HPAScalingFailure
+      annotations:
+        description: metrics-server may be unavailable or resource requests missing
+          on the target deployment.
+        summary: HPA {{ $labels.namespace }}/{{ $labels.horizontalpodautoscaler }}
+          scaling is inactive
+      expr: "kube_horizontalpodautoscaler_status_condition{\n  condition=\"ScalingActive\"\
+        , status=\"false\"\n} == 1\n"
+      for: 5m
+      labels:
+        severity: warning


### PR DESCRIPTION
# What

Two repo-tracked PrometheusRule fixes plus README documenting the post-2026-06-13 disk-migration architecture.

## pod-health.yaml — replaces broken PodRestartingFrequently

```diff
- expr: kube_pod_container_status_restarts_total > 20
+ expr: increase(kube_pod_container_status_restarts_total[1h]) >= 5
+ for:  10m
```

The cumulative counter rule fired forever on any pod that had ever crashed >20 times. After the disk migration, 7 pods (prometheus, kube-state-metrics, monitoring-operator, cert-manager x2, coredns, traefik svclb) kept firing the alert every 5 min in #platform despite being healthy. The rate-based replacement only fires when restarts are happening now.

## disk-pressure.yaml — excludes user-data SMB mount

```diff
- mountpoint!~"/boot.*"
+ mountpoint!~"/boot.*|/srv/dev-disk-.*"
```

Per CLAUDE.md storage layout:
- sda1 → /var/lib/rancher/k3s (k3s data, monitored)
- sdb1 → /srv/dev-disk-*/  (user backups, **excluded** — k3s no longer lives there)

sdb1 sits at 80-89% by design (Windows backup steward writes there). The previous rule paged every 5 min on sdb1 at 88%.

# Already done on the live cluster

- Live-patched the in-cluster rules — changes in effect immediately, not waiting on deploy
- Rolling-restarted the 7 noisy pods (prom, ksm, monitoring-op, cert-manager x2) to reset cumulative restart counters from 100s back to 0

# How tested

```
$ sudo k3s kubectl apply --dry-run=server -f k8s/cluster-protection/alerts/
prometheusrule.monitoring.coreos.com/pod-health configured (server dry run)
prometheusrule.monitoring.coreos.com/disk-pressure configured (server dry run)
```

# Why

This came out of a 2-week Slack-noise audit on 2026-06-14. #platform was firing ~10 false-positive alerts per hour for weeks.