### PR TITLE
fix(sha-drift): probe www.cloudless.gr for cloud surface, not apex

### DIFF
--- a/scripts/detect-sha-drift.mts
+++ b/scripts/detect-sha-drift.mts
@@ -103,7 +103,7 @@ function evaluateDrift(snapshot: DriftSnapshot, now: number = Date.now()): Drift
 // ───────────────────────────────────────────────────────────────────────
 
 const HEALTH_URLS = {
-  cloud: "https://cloudless.gr/api/health",
+  cloud: "https://www.cloudless.gr/api/health",
   pi: "https://pi-origin.cloudless.gr/api/health",
 } as const;
 const SSM_CLOUD = "/cloudless/production/cloud-sha";

--- a/src/lib/sha-drift.ts
+++ b/src/lib/sha-drift.ts
@@ -16,7 +16,7 @@ export interface DriftSnapshot {
   cloudExpected: string;
   /** deploy-pi.yml SHA — source of truth for the Pi surface. */
   piExpected: string;
-  /** cloudless.gr/api/health.version, or null if unreachable. */
+  /** www.cloudless.gr/api/health.version, or null if unreachable. */
   cloud: string | null;
   /** pi-origin.cloudless.gr/api/health.version, or null if unreachable. */
   pi: string | null;


### PR DESCRIPTION
# The bug

The SHA drift detector kept firing 'cloud differs from SSM source of truth' even after fresh Lambda deploys. Root cause: it was probing https://cloudless.gr/api/health for the 'cloud' surface, but the apex is served by the Pi origin via the HA failover system — NOT CloudFront.

```
$ curl https://cloudless.gr/api/health -D -
x-served-by: pi-origin          ← Pi, not Lambda
x-origin-latency: 52
{"version":"8983eb35…"}      ← old Pi image SHA
```

The cloud-surface probe was effectively reading the Pi's SHA. So whenever the Pi was behind on deploys (which is most of the time, because deploy-pi.yml has restrictive path filters), the detector failed.

# The fix

Change the cloud probe to https://www.cloudless.gr/api/health — that bypasses the HA layer and goes through CloudFront → Lambda directly:

```
$ curl https://www.cloudless.gr/api/health
x-cache: Miss from cloudfront    ← Lambda, properly
{"version":"cae52300…"}      ← Lambda's actual SHA
```

# Verified

Local run, before fix:
```
{ "drifted": true,  "cloud": { "actual": "8983eb35", "matches": false } }
```

Local run, after fix:
```
{ "drifted": false, "cloud": { "actual": "cae52300", "matches": true } }
```

Unit tests: 30/30 pass (sha-drift.test.ts + detect-sha-drift.test.ts).

# Why this is the right fix

The Pi surface still probes pi-origin.cloudless.gr (a dedicated subdomain that bypasses the apex/HA layer). And the apex correctly serves Pi for HA-failover purposes — that's by design, not a bug. The bug was only in what the detector thought it was measuring.

Follow-up (separate PR): Pi build path filters skip k8s/e2e/docs-only PRs, so the Pi image can drift behind main. Worth either widening the filter or letting the SHA detector flag Pi-only drift as warning (already done — see the workflow conditional that turns Pi-only drift into a warning when cloud is in sync).