### PR TITLE
fix(newsletter): use 'In Review' instead of 'Approved' as the publish trigger

### DIFF
--- a/.github/workflows/weekly-newsletter.yml
+++ b/.github/workflows/weekly-newsletter.yml
@@ -6,7 +6,7 @@ env:
 on:
   schedule:
     # Every Monday at 09:00 UTC (11:00 Athens). Three hours after the draft
-    # generator — that window is the human review SLA. If nothing is approved
+    # generator — that window is the human review SLA. If nothing is in review
     # by now, the publisher exits 0 and no newsletter is sent.
     - cron: "0 9 * * 1"
   workflow_dispatch:
@@ -67,7 +67,7 @@ jobs:
                   "type": "section",
                   "text": {
                     "type": "mrkdwn",
-                    "text": "The Monday publisher failed. Approved posts may not have been promoted, and the newsletter may not have sent.\n<${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View logs>"
+                    "text": "The Monday publisher failed. Posts in review may not have been promoted, and the newsletter may not have sent.\n<${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View logs>"
                   }
                 }
               ]

--- a/__tests__/publish-and-send-newsletter.test.ts
+++ b/__tests__/publish-and-send-newsletter.test.ts
@@ -222,3 +222,27 @@ describe("renderPlaintext", () => {
     expect(out).toContain("%UNSUBSCRIBELINK%");
   });
 });
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Regression guard for the Notion status-name mismatch that broke 3 weeks of
+// Monday newsletter sends (2026-05-25, 06-01, 06-08).
+//
+// The Notion Blog DB's Status property exposes options
+// "Draft" | "In Review" | "Published" | "Archived". The script must filter on
+// "In Review" — "Approved" is a 400 from Notion and breaks the cron. Lock the
+// literal in source so a future rename has to update this test too.
+// ─────────────────────────────────────────────────────────────────────────────
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+describe("Notion publisher status filter", () => {
+  const source = readFileSync(
+    resolve(__dirname, "../scripts/publish-and-send-newsletter.ts"),
+    "utf8",
+  );
+
+  it("filters on the 'In Review' Status option (not 'Approved')", () => {
+    expect(source).toContain('equals: "In Review"');
+    expect(source).not.toContain('equals: "Approved"');
+  });
+});

--- a/scripts/publish-and-send-newsletter.ts
+++ b/scripts/publish-and-send-newsletter.ts
@@ -1,7 +1,7 @@
 /**
  * Publisher + Newsletter Sender
  *
- * Finds Notion Blog rows with Status=Approved, promotes them to Published,
+ * Finds Notion Blog rows with Status="In Review", promotes them to Published,
  * triggers ISR revalidation on the public blog, then asks the site's
  * newsletter send endpoint to email each post to every HubSpot subscriber.
  *
@@ -78,13 +78,13 @@ async function fetchApprovedPosts(): Promise<ApprovedPost[]> {
   const res = await notionFetch(`/databases/${dbId}/query`, {
     method: "POST",
     body: JSON.stringify({
-      filter: { property: "Status", select: { equals: "Approved" } },
+      filter: { property: "Status", select: { equals: "In Review" } },
       sorts: [{ timestamp: "created_time", direction: "ascending" }],
     }),
   });
   if (!res.ok) {
     throw new Error(
-      `Notion query (Approved) failed: ${res.status} ${await res
+      `Notion query (In Review) failed: ${res.status} ${await res
         .text()
         .catch(() => "")}`,
     );


### PR DESCRIPTION
The weekly publisher (Monday 09:00 UTC) queries Notion Blog rows with
Status='Approved' and 400s every run because that select option does not
exist in the database. Available options: Draft, In Review, Published,
Archived.

This is why no Monday issue has been sent since the welcome flow shipped
on 2026-05-20 — three consecutive Mondays (05-25, 06-01, 06-08) all
failed with the same error.

Realign to use 'In Review' as the human-approval signal: AI drafts land
as Draft, a human flips to In Review during the 3h review window, the
publisher promotes to Published and sends.

Also add a regression test that pins the literal in source so this
specific revert can't sneak through silently again.

Separate from this PR: the weekly-article-draft.yml workflow needs
ANTHROPIC_API_KEY in repo secrets (currently empty in the env block of
every recent failed run). Without it the draft generator exits 1 before
ever calling Claude, and there is nothing for the human to flip from
Draft to In Review. Set it via Settings -> Secrets -> Actions.
