### PR TITLE
feat(newsletter): drop Anthropic.com dep, use Cloudflare Workers AI + Bedrock fallback

### DIFF
--- a/.github/workflows/weekly-article-draft.yml
+++ b/.github/workflows/weekly-article-draft.yml
@@ -21,7 +21,8 @@ jobs:
     timeout-minutes: 10
 
     env:
-      ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+      AI_GENERATE_SECRET: ${{ secrets.AI_GENERATE_SECRET }}
+      SITE_URL: ${{ secrets.SITE_URL }}
       NOTION_API_KEY: ${{ secrets.NOTION_API_KEY }}
       NOTION_BLOG_DB_ID: ${{ secrets.NOTION_BLOG_DB_ID }}
       SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/__tests__/internal-ai-generate-api.test.ts
+++ b/__tests__/internal-ai-generate-api.test.ts
@@ -1,0 +1,150 @@
+/**
+ * /api/internal/ai/generate — provider routing tests.
+ *
+ * Covers the contract that the weekly newsletter cron depends on:
+ *   - 401 without the shared secret
+ *   - 503 when the secret isn't configured
+ *   - 400 with no user message
+ *   - Cloudflare success path
+ *   - Cloudflare failure → Bedrock fallback
+ *   - Both providers failing → 502
+ */
+
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+vi.mock("@/lib/ssm-config", async () => {
+  const actual = await vi.importActual<typeof import("@/lib/ssm-config")>(
+    "@/lib/ssm-config",
+  );
+  return { ...actual, getConfig: vi.fn() };
+});
+vi.mock("@/lib/bedrock-shared", () => ({
+  getBedrockClient: vi.fn(),
+  runBedrockTurn: vi.fn(),
+  joinAssistantText: (blocks: { text?: string }[]) =>
+    blocks.map((b) => b.text ?? "").join(""),
+  BEDROCK_MODEL_ID: "us.anthropic.claude-3-5-haiku-20241022-v1:0",
+}));
+
+import { POST } from "../src/app/api/internal/ai/generate/route";
+import { getConfig } from "@/lib/ssm-config";
+import { runBedrockTurn } from "@/lib/bedrock-shared";
+
+const SECRET = "test-internal-secret";
+
+function reqWith(body: unknown, secret: string | null = SECRET): Request {
+  const headers: Record<string, string> = { "content-type": "application/json" };
+  if (secret !== null) headers["x-internal-secret"] = secret;
+  return new Request("http://localhost/api/internal/ai/generate", {
+    method: "POST",
+    headers,
+    body: JSON.stringify(body),
+  });
+}
+
+beforeEach(() => {
+  vi.resetAllMocks();
+  vi.mocked(getConfig).mockResolvedValue({
+    AI_GENERATE_SECRET: SECRET,
+  } as Awaited<ReturnType<typeof getConfig>>);
+  process.env.CLOUDFLARE_ACCOUNT_ID = "acct-test";
+  process.env.CLOUDFLARE_API_TOKEN = "token-test";
+});
+
+describe("POST /api/internal/ai/generate", () => {
+  it("returns 503 when AI_GENERATE_SECRET is not configured", async () => {
+    vi.mocked(getConfig).mockResolvedValue({
+      AI_GENERATE_SECRET: "",
+    } as Awaited<ReturnType<typeof getConfig>>);
+    const res = await POST(
+      reqWith({ messages: [{ role: "user", content: "hi" }] }) as never,
+    );
+    expect(res.status).toBe(503);
+  });
+
+  it("returns 401 when the secret header is missing or wrong", async () => {
+    const a = await POST(
+      reqWith({ messages: [{ role: "user", content: "hi" }] }, null) as never,
+    );
+    expect(a.status).toBe(401);
+    const b = await POST(
+      reqWith(
+        { messages: [{ role: "user", content: "hi" }] },
+        "wrong-secret",
+      ) as never,
+    );
+    expect(b.status).toBe(401);
+  });
+
+  it("returns 400 with no user message", async () => {
+    const res = await POST(reqWith({ messages: [] }) as never);
+    expect(res.status).toBe(400);
+  });
+
+  it("returns Cloudflare result on success", async () => {
+    globalThis.fetch = vi.fn().mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({ result: { response: "Hello world" } }),
+        { status: 200 },
+      ),
+    ) as typeof fetch;
+    const res = await POST(
+      reqWith({
+        messages: [{ role: "user", content: "say hi" }],
+        system: "you are helpful",
+      }) as never,
+    );
+    const body = (await res.json()) as {
+      result: string;
+      source: string;
+      model: string;
+    };
+    expect(res.status).toBe(200);
+    expect(body.source).toBe("cloudflare");
+    expect(body.result).toBe("Hello world");
+  });
+
+  it("falls back to Bedrock when Cloudflare returns 500", async () => {
+    globalThis.fetch = vi
+      .fn()
+      // First CF call (default model) → 500
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ errors: [{ message: "boom" }] }), {
+          status: 500,
+        }),
+      )
+      // Fallback CF model → also 500
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ errors: [{ message: "boom" }] }), {
+          status: 500,
+        }),
+      ) as typeof fetch;
+    vi.mocked(runBedrockTurn).mockResolvedValueOnce([{ text: "From Bedrock" }]);
+    const res = await POST(
+      reqWith({
+        messages: [{ role: "user", content: "fallback please" }],
+      }) as never,
+    );
+    const body = (await res.json()) as { result: string; source: string };
+    expect(res.status).toBe(200);
+    expect(body.source).toBe("bedrock");
+    expect(body.result).toBe("From Bedrock");
+  });
+
+  it("returns 502 when every provider fails", async () => {
+    globalThis.fetch = vi
+      .fn()
+      .mockResolvedValue(
+        new Response(JSON.stringify({ errors: [{ message: "down" }] }), {
+          status: 500,
+        }),
+      ) as typeof fetch;
+    vi.mocked(runBedrockTurn).mockRejectedValueOnce(new Error("bedrock down"));
+    const res = await POST(
+      reqWith({
+        messages: [{ role: "user", content: "try" }],
+      }) as never,
+    );
+    expect(res.status).toBe(502);
+  });
+});

--- a/scripts/generate-weekly-article.ts
+++ b/scripts/generate-weekly-article.ts
@@ -2,16 +2,21 @@
  * Weekly Article Generator
  *
  * Picks the least-recently-used Category from the Notion Blog database,
- * asks Claude to author a fresh article in that category (avoiding topic
- * repetition with recent posts), and inserts the result as a Draft for
- * human review. Slack-pings the editor with a link.
+ * asks our /api/internal/ai/generate endpoint to author a fresh article in
+ * that category (avoiding topic repetition with recent posts), and inserts
+ * the result as a Draft for human review. Slack-pings the editor with a link.
+ *
+ * The generation endpoint tries Cloudflare Workers AI first (free tier) and
+ * falls back to AWS Bedrock Claude — so this cron does NOT depend on an
+ * Anthropic.com account or its credit balance.
  *
  * Designed to run from .github/workflows/weekly-article-draft.yml on
  * Monday 06:00 UTC. Self-contained — reads env directly, talks to Notion
- * and Anthropic via raw fetch (no src/lib/* imports, no SSM, no @/ alias).
+ * via raw fetch and to its own /api/internal/ai/generate route over HTTPS.
  *
  * Required env:
- *   ANTHROPIC_API_KEY            Claude API key
+ *   AI_GENERATE_SECRET           Shared secret for /api/internal/ai/generate
+ *   SITE_URL                     Base URL of the Lambda hosting the route
  *   NOTION_API_KEY               Notion integration token
  *   NOTION_BLOG_DB_ID            Blog database id
  *   SLACK_WEBHOOK_URL            (optional) pings the team on success
@@ -23,9 +28,10 @@
 
 const NOTION_API = "https://api.notion.com/v1";
 const NOTION_VERSION = "2022-06-28";
-const ANTHROPIC_API = "https://api.anthropic.com/v1/messages";
-const ANTHROPIC_VERSION = "2023-06-01";
-const MODEL = "claude-sonnet-4-6";
+const SITE_URL_DEFAULT = "https://cloudless.gr";
+/** Cloudflare Workers AI model. Route will fall back to llama-3-70b and then
+ *  Bedrock Claude 3.5 Haiku if this model errors or is rate-limited. */
+const CF_MODEL = "@cf/meta/llama-3.3-70b-instruct-fp8-fast";
 
 export const CATEGORIES = [
   "Cloud",
@@ -164,7 +170,8 @@ async function generateArticle(
   category: Category,
   avoidTitles: string[],
 ): Promise<GeneratedArticle> {
-  const apiKey = requireEnv("ANTHROPIC_API_KEY");
+  const secret = requireEnv("AI_GENERATE_SECRET");
+  const siteUrl = (process.env.SITE_URL || SITE_URL_DEFAULT).replace(/\/$/, "");
 
   const userMessage = [
     `Write this week's blog post for the **${category}** category.`,
@@ -177,39 +184,34 @@ async function generateArticle(
     "Pick a fresh angle that hasn't been covered. Output the JSON object only.",
   ].join("\n");
 
-  const res = await fetch(ANTHROPIC_API, {
+  const res = await fetch(`${siteUrl}/api/internal/ai/generate`, {
     method: "POST",
     headers: {
-      "x-api-key": apiKey,
-      "anthropic-version": ANTHROPIC_VERSION,
       "content-type": "application/json",
+      "x-internal-secret": secret,
     },
     body: JSON.stringify({
-      model: MODEL,
-      max_tokens: 4096,
-      system: [
-        {
-          type: "text",
-          text: SYSTEM_PROMPT,
-          cache_control: { type: "ephemeral" },
-        },
-      ],
+      model: CF_MODEL,
+      maxTokens: 4096,
+      system: SYSTEM_PROMPT,
       messages: [{ role: "user", content: userMessage }],
     }),
   });
 
   if (!res.ok) {
     throw new Error(
-      `Anthropic API failed: ${res.status} ${await res.text().catch(() => "")}`,
+      `Internal AI generation failed: ${res.status} ${await res.text().catch(() => "")}`,
     );
   }
   const data = (await res.json()) as {
-    content: Array<{ type: string; text?: string }>;
+    result?: string;
+    source?: "cloudflare" | "bedrock";
+    model?: string;
   };
-  const text = data.content
-    .filter((b) => b.type === "text" && b.text)
-    .map((b) => b.text!)
-    .join("");
+  const text = data.result ?? "";
+  console.log(
+    `[generate-weekly-article] generated via ${data.source ?? "unknown"} (${data.model ?? "?"})`,
+  );
 
   // Strip ```json fences if the model adds them despite instructions.
   const cleaned = text

--- a/src/app/api/internal/ai/generate/route.ts
+++ b/src/app/api/internal/ai/generate/route.ts
@@ -1,0 +1,211 @@
+import { timingSafeEqual } from "node:crypto";
+import { NextResponse, type NextRequest } from "next/server";
+import { getConfig } from "@/lib/ssm-config";
+import {
+  getBedrockClient,
+  runBedrockTurn,
+  joinAssistantText,
+  BEDROCK_MODEL_ID,
+} from "@/lib/bedrock-shared";
+
+/**
+ * POST /api/internal/ai/generate — service-to-service text generation.
+ *
+ * Used by the weekly newsletter draft cron (and any future internal job)
+ * to generate text without needing an Anthropic.com API key. Tries
+ * Cloudflare Workers AI first (free tier covers our usage); falls back
+ * to AWS Bedrock Claude on any Cloudflare error so a CF outage or quota
+ * exhaustion doesn't kill the Monday draft.
+ *
+ * Auth: shared secret in `x-internal-secret`, compared in constant time
+ * with `AI_GENERATE_SECRET` from SSM. Returns 503 if the secret isn't
+ * configured (refuses to run open).
+ *
+ * Body:
+ *   {
+ *     system?: string,                       // optional system prompt
+ *     messages: { role, content: string }[], // required
+ *     maxTokens?: number,                    // default 4096
+ *     model?: string,                        // CF model id (ignored on Bedrock fallback)
+ *   }
+ *
+ * Response 200:
+ *   { result: string, source: "cloudflare" | "bedrock", model: string }
+ *
+ * NOT in /api/admin/* on purpose: this is machine-to-machine, the secret
+ * IS the auth, and we don't want the admin rate limit on cron traffic.
+ */
+
+export const runtime = "nodejs";
+
+const DEFAULT_CF_MODEL = "@cf/meta/llama-3.3-70b-instruct-fp8-fast";
+const FALLBACK_CF_MODEL = "@cf/meta/llama-3-70b-instruct";
+
+interface ChatMessage {
+  role: "user" | "assistant" | "system";
+  content: string;
+}
+
+interface GenerateBody {
+  system?: string;
+  messages?: ChatMessage[];
+  maxTokens?: number;
+  model?: string;
+}
+
+function secretsMatch(provided: string | null, expected: string): boolean {
+  if (!provided) return false;
+  const a = Buffer.from(provided);
+  const b = Buffer.from(expected);
+  if (a.length !== b.length) return false;
+  try {
+    return timingSafeEqual(a, b);
+  } catch {
+    return false;
+  }
+}
+
+async function callCloudflare(
+  accountId: string,
+  apiToken: string,
+  model: string,
+  system: string | undefined,
+  messages: ChatMessage[],
+  maxTokens: number,
+): Promise<string> {
+  const cfMessages = [
+    ...(system ? [{ role: "system" as const, content: system }] : []),
+    ...messages,
+  ];
+  const res = await fetch(
+    `https://api.cloudflare.com/client/v4/accounts/${accountId}/ai/run/${model}`,
+    {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${apiToken}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ messages: cfMessages, max_tokens: maxTokens }),
+    },
+  );
+  const data = (await res.json()) as {
+    result?: { response?: string };
+    errors?: { message?: string }[];
+  };
+  if (!res.ok) {
+    const reason = data.errors?.[0]?.message ?? `status ${res.status}`;
+    throw new Error(`Cloudflare Workers AI: ${reason}`);
+  }
+  const text = data.result?.response ?? "";
+  if (!text.trim()) throw new Error("Cloudflare Workers AI returned empty response");
+  return text;
+}
+
+async function callBedrock(
+  system: string | undefined,
+  messages: ChatMessage[],
+  maxTokens: number,
+): Promise<string> {
+  const bedrockMessages = messages
+    .filter((m) => m.role === "user" || m.role === "assistant")
+    .map((m) => ({
+      role: m.role as "user" | "assistant",
+      content: [{ text: m.content }],
+    }));
+  const content = await runBedrockTurn({
+    client: getBedrockClient(),
+    system: system ?? "",
+    messages: bedrockMessages,
+    toolConfig: { tools: [] },
+    maxTokens,
+  });
+  const text = joinAssistantText(content);
+  if (!text) throw new Error("Bedrock returned empty response");
+  return text;
+}
+
+export async function POST(request: NextRequest): Promise<Response> {
+  const config = await getConfig();
+  const secret = config.AI_GENERATE_SECRET;
+  if (!secret) {
+    return NextResponse.json(
+      { error: "Internal AI generation is not configured." },
+      { status: 503 },
+    );
+  }
+  if (!secretsMatch(request.headers.get("x-internal-secret"), secret)) {
+    return NextResponse.json({ error: "Unauthorized." }, { status: 401 });
+  }
+
+  let body: GenerateBody;
+  try {
+    body = (await request.json()) as GenerateBody;
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+
+  const messages = Array.isArray(body.messages) ? body.messages : [];
+  if (!messages.length || !messages.some((m) => m.role === "user" && m.content?.trim())) {
+    return NextResponse.json(
+      { error: "messages[] with at least one non-empty user turn is required." },
+      { status: 400 },
+    );
+  }
+  const maxTokens = Math.min(Math.max(body.maxTokens ?? 4096, 64), 8192);
+  const cfModel = body.model ?? DEFAULT_CF_MODEL;
+
+  const accountId = process.env.CLOUDFLARE_ACCOUNT_ID;
+  const apiToken = process.env.CLOUDFLARE_API_TOKEN;
+
+  // Primary: Cloudflare Workers AI (free tier).
+  if (accountId && apiToken) {
+    try {
+      const result = await callCloudflare(
+        accountId,
+        apiToken,
+        cfModel,
+        body.system,
+        messages,
+        maxTokens,
+      );
+      return NextResponse.json({ result, source: "cloudflare", model: cfModel });
+    } catch (err) {
+      console.warn("[internal/ai/generate] Cloudflare failed, trying Bedrock:", err);
+      // Try the fallback CF model once before going to Bedrock.
+      if (cfModel !== FALLBACK_CF_MODEL) {
+        try {
+          const result = await callCloudflare(
+            accountId,
+            apiToken,
+            FALLBACK_CF_MODEL,
+            body.system,
+            messages,
+            maxTokens,
+          );
+          return NextResponse.json({
+            result,
+            source: "cloudflare",
+            model: FALLBACK_CF_MODEL,
+          });
+        } catch (err2) {
+          console.warn("[internal/ai/generate] fallback CF model also failed:", err2);
+        }
+      }
+    }
+  }
+
+  // Fallback: Bedrock (uses Lambda IAM, no API key).
+  try {
+    const result = await callBedrock(body.system, messages, maxTokens);
+    return NextResponse.json({ result, source: "bedrock", model: BEDROCK_MODEL_ID });
+  } catch (err) {
+    console.error("[internal/ai/generate] Bedrock also failed:", err);
+    return NextResponse.json(
+      {
+        error: "All AI providers failed.",
+        detail: (err as Error)?.message ?? String(err),
+      },
+      { status: 502 },
+    );
+  }
+}

--- a/src/lib/ssm-config.ts
+++ b/src/lib/ssm-config.ts
@@ -18,6 +18,8 @@ interface AppConfig {
   AWS_SES_REGION: string;
   /** Shared secret authenticating the weekly newsletter send endpoint. */
   NEWSLETTER_SEND_SECRET: string;
+  /** Shared secret authenticating the internal AI text-generation endpoint. */
+  AI_GENERATE_SECRET: string;
   STRIPE_SECRET_KEY: string;
   STRIPE_PUBLISHABLE_KEY: string;
   STRIPE_WEBHOOK_SECRET: string;
@@ -160,6 +162,7 @@ function buildConfigFromParams(params: Map<string, string>): AppConfig {
     SES_TO_EMAIL: sesTo,
     AWS_SES_REGION: sesRegion,
     NEWSLETTER_SEND_SECRET: params.get("NEWSLETTER_SEND_SECRET") ?? "",
+    AI_GENERATE_SECRET: params.get("AI_GENERATE_SECRET") ?? "",
     STRIPE_SECRET_KEY: params.get("STRIPE_SECRET_KEY") ?? "",
     STRIPE_PUBLISHABLE_KEY: params.get("STRIPE_PUBLISHABLE_KEY") ?? "",
     STRIPE_WEBHOOK_SECRET: params.get("STRIPE_WEBHOOK_SECRET") ?? "",
@@ -235,6 +238,7 @@ function buildConfigFromEnv(): AppConfig {
     SES_TO_EMAIL: process.env.SES_TO_EMAIL || "tbaltzakis@cloudless.gr",
     AWS_SES_REGION: process.env.AWS_SES_REGION || "us-east-1",
     NEWSLETTER_SEND_SECRET: process.env.NEWSLETTER_SEND_SECRET || "",
+    AI_GENERATE_SECRET: process.env.AI_GENERATE_SECRET || "",
     STRIPE_SECRET_KEY: process.env.STRIPE_SECRET_KEY || "",
     STRIPE_PUBLISHABLE_KEY: process.env.STRIPE_PUBLISHABLE_KEY || "",
     STRIPE_WEBHOOK_SECRET: process.env.STRIPE_WEBHOOK_SECRET || "",


### PR DESCRIPTION
Anthropic.com credit balance is gone, so 'pnpm newsletter:draft' currently
400s with 'credit balance too low'. Newsletter pipeline was effectively
held hostage by a single vendor invoice.

Move the AI generation behind a new internal route:

  /api/internal/ai/generate
    1. Try Cloudflare Workers AI (free tier, 10k Neurons/day) with
       llama-3.3-70b-instruct-fp8-fast.
    2. On error, retry on llama-3-70b-instruct.
    3. On error again, fall back to AWS Bedrock Claude 3.5 Haiku via the
       same plumbing the chat widget already uses (no API key — Lambda
       IAM grants InvokeModel).

The cron script POSTs to this route with a shared 'x-internal-secret'
header (stored in SSM as AI_GENERATE_SECRET). The Anthropic.com SDK and
API key are no longer required anywhere in the pipeline.

Workflow secret swap:
  - REMOVED  ANTHROPIC_API_KEY
  - ADDED    AI_GENERATE_SECRET, SITE_URL

Tests added:

  __tests__/internal-ai-generate-api.test.ts
    - 401 / 503 / 400 contract
    - Cloudflare success path
    - Cloudflare → fallback CF model → Bedrock chain
    - 502 when everything fails

The existing /api/admin/ai/generate stays as-is for the admin UI.
