### PR TITLE
feat(infra-mcp): add SSM write + GH secret + patch-to-PR tools

### DIFF
--- a/__tests__/infra-mcp-validators.test.ts
+++ b/__tests__/infra-mcp-validators.test.ts
@@ -1,0 +1,100 @@
+/**
+ * Input validators for the cloudless-infra MCP write tools.
+ *
+ * These guards run BEFORE any shell command is built, so a regression here
+ * could exfiltrate a value into ps, push to a protected branch, or accept
+ * a name GitHub would later reject. Lock the regexes here.
+ */
+import { describe, it, expect } from "vitest";
+import {
+  isValidSecretName,
+  isPlainBase64,
+  isClaudeBranch,
+  resolveSsmName,
+} from "../tools/ssh-mcp/src/validators";
+
+describe("isValidSecretName", () => {
+  it.each([
+    "ANTHROPIC_API_KEY",
+    "STRIPE_WEBHOOK_SECRET",
+    "X1",
+    "AI_GENERATE_SECRET",
+    "A_B_C_D",
+  ])("accepts %s", (name) => {
+    expect(isValidSecretName(name)).toBe(true);
+  });
+
+  it.each([
+    "",            // empty
+    "lowercase",   // not uppercase
+    "1LEADING",    // starts with digit
+    "WITH SPACE",  // space
+    "WITH-DASH",   // dash
+    "WITH.DOT",    // dot
+    "_LEADING",    // underscore lead
+    "Mixed",       // mixed case
+  ])("rejects %s", (name) => {
+    expect(isValidSecretName(name)).toBe(false);
+  });
+});
+
+describe("isPlainBase64", () => {
+  it("accepts a plain base64-encoded payload", () => {
+    const b64 = Buffer.from("hello world").toString("base64");
+    expect(isPlainBase64(b64)).toBe(true);
+  });
+
+  it("accepts padded base64", () => {
+    expect(isPlainBase64("YWJjZA==")).toBe(true);
+  });
+
+  it("rejects empty string", () => {
+    expect(isPlainBase64("")).toBe(false);
+  });
+
+  it.each([
+    "abc def",         // whitespace inside
+    "abc\ndef",        // newline (`base64` without -w0)
+    "abc-def_ghi=",    // URL-safe base64 (not what `base64 -d` expects)
+    "abc#def",         // bogus char
+  ])("rejects malformed value %j", (val) => {
+    expect(isPlainBase64(val)).toBe(false);
+  });
+});
+
+describe("isClaudeBranch", () => {
+  it.each([
+    "claude/fix-newsletter-pipeline",
+    "claude/infra-mcp-write-tools",
+    "claude/feature_v2",
+    "claude/x.y.z",
+  ])("accepts %s", (name) => {
+    expect(isClaudeBranch(name)).toBe(true);
+  });
+
+  it.each([
+    "main",                 // protected
+    "release/1.0",          // non-claude prefix
+    "claude",               // bare prefix
+    "claude/",              // empty topic
+    "claude/-leading-dash", // weird first char
+    "claude/with space",    // space in topic
+    "feature/x",            // wrong prefix
+  ])("rejects %s", (name) => {
+    expect(isClaudeBranch(name)).toBe(false);
+  });
+});
+
+describe("resolveSsmName", () => {
+  it("prefixes short names with /cloudless/production/", () => {
+    expect(resolveSsmName("AI_GENERATE_SECRET")).toBe(
+      "/cloudless/production/AI_GENERATE_SECRET",
+    );
+  });
+
+  it("leaves absolute paths untouched", () => {
+    expect(resolveSsmName("/cloudless/staging/X")).toBe(
+      "/cloudless/staging/X",
+    );
+  });
+});

--- a/src/app/api/internal/ai/generate/route.ts
+++ b/src/app/api/internal/ai/generate/route.ts
@@ -71,7 +71,7 @@ async function callCloudflare(
   model: string,
   system: string | undefined,
   messages: ChatMessage[],
-  maxTokens: number,
+  maxTokens: number
 ): Promise<string> {
   const cfMessages = [
     ...(system ? [{ role: "system" as const, content: system }] : []),
@@ -86,7 +86,7 @@ async function callCloudflare(
         "Content-Type": "application/json",
       },
       body: JSON.stringify({ messages: cfMessages, max_tokens: maxTokens }),
-    },
+    }
   );
   const data = (await res.json()) as {
     result?: { response?: string };
@@ -104,7 +104,7 @@ async function callCloudflare(
 async function callBedrock(
   system: string | undefined,
   messages: ChatMessage[],
-  maxTokens: number,
+  maxTokens: number
 ): Promise<string> {
   const bedrockMessages = messages
     .filter((m) => m.role === "user" || m.role === "assistant")
@@ -130,7 +130,7 @@ export async function POST(request: NextRequest): Promise<Response> {
   if (!secret) {
     return NextResponse.json(
       { error: "Internal AI generation is not configured." },
-      { status: 503 },
+      { status: 503 }
     );
   }
   if (!secretsMatch(request.headers.get("x-internal-secret"), secret)) {
@@ -148,7 +148,7 @@ export async function POST(request: NextRequest): Promise<Response> {
   if (!messages.length || !messages.some((m) => m.role === "user" && m.content?.trim())) {
     return NextResponse.json(
       { error: "messages[] with at least one non-empty user turn is required." },
-      { status: 400 },
+      { status: 400 }
     );
   }
   const maxTokens = Math.min(Math.max(body.maxTokens ?? 4096, 64), 8192);
@@ -166,7 +166,7 @@ export async function POST(request: NextRequest): Promise<Response> {
         cfModel,
         body.system,
         messages,
-        maxTokens,
+        maxTokens
       );
       return NextResponse.json({ result, source: "cloudflare", model: cfModel });
     } catch (err) {
@@ -180,7 +180,7 @@ export async function POST(request: NextRequest): Promise<Response> {
             FALLBACK_CF_MODEL,
             body.system,
             messages,
-            maxTokens,
+            maxTokens
           );
           return NextResponse.json({
             result,
@@ -205,7 +205,7 @@ export async function POST(request: NextRequest): Promise<Response> {
         error: "All AI providers failed.",
         detail: (err as Error)?.message ?? String(err),
       },
-      { status: 502 },
+      { status: 502 }
     );
   }
 }

--- a/tools/ssh-mcp/src/index.ts
+++ b/tools/ssh-mcp/src/index.ts
@@ -35,6 +35,7 @@ import { readFileSync, existsSync } from "fs";
 import { homedir } from "os";
 import { join } from "path";
 import { z } from "zod";
+import { isValidSecretName, isPlainBase64, isClaudeBranch, resolveSsmName } from "./validators.js";
 
 // ── Node definitions ───────────────────────────────────────────────────────
 
@@ -607,6 +608,95 @@ server.tool(
 );
 
 server.tool(
+  "gh_secret_set",
+  "Set a GitHub Actions secret for the repo. Value is base64-encoded over SSH so it never appears in `ps`.\nOverwrites if it already exists. Use repo-level Actions secrets only (no environment scoping).",
+  {
+    name: z.string().describe('Secret name (e.g. "AI_GENERATE_SECRET"). Must match GitHub naming rules.'),
+    value: z.string().describe("Plain-text value. Base64-encoded for transport, decoded on the Pi."),
+    repo: z.string().optional().describe("Repo name (default: cloudless.gr)"),
+  },
+  async ({ name, value, repo }) => {
+    if (!isValidSecretName(name)) {
+      return err(new Error(`Invalid secret name "${name}" — must match /^[A-Z][A-Z0-9_]*$/`));
+    }
+    const r = `Themis128/${repo ?? "cloudless.gr"}`;
+    const valueB64 = Buffer.from(value, "utf8").toString("base64");
+    const cmd = `printf %s '${valueB64}' | base64 -d | gh secret set ${name} --repo ${r} 2>&1`;
+    try { return ok(await sshMain(cmd, 15_000)); } catch (e) { return err(e); }
+  }
+);
+
+server.tool(
+  "gh_secret_delete",
+  "Delete a repo-level GitHub Actions secret.",
+  {
+    name: z.string().describe("Secret name to delete."),
+    repo: z.string().optional().describe("Repo name (default: cloudless.gr)"),
+  },
+  async ({ name, repo }) => {
+    if (!isValidSecretName(name)) {
+      return err(new Error(`Invalid secret name "${name}" — must match /^[A-Z][A-Z0-9_]*$/`));
+    }
+    const r = `Themis128/${repo ?? "cloudless.gr"}`;
+    const cmd = `gh secret delete ${name} --repo ${r} 2>&1 || echo "(secret already absent)"`;
+    try { return ok(await sshMain(cmd, 15_000)); } catch (e) { return err(e); }
+  }
+);
+
+server.tool(
+  "gh_secret_list",
+  "List repo-level GitHub Actions secrets (names + last-updated; values stay hidden).",
+  {
+    repo: z.string().optional().describe("Repo name (default: cloudless.gr)"),
+  },
+  async ({ repo }) => {
+    const r = `Themis128/${repo ?? "cloudless.gr"}`;
+    try { return ok(await sshMain(`gh secret list --repo ${r} 2>&1`, 15_000)); } catch (e) { return err(e); }
+  }
+);
+
+server.tool(
+  "gh_apply_patch_and_open_pr",
+  "Apply a git format-patch on the omv-main shared clone, push to a feature branch, and open an auto-merge PR.\nUseful for service-to-service code changes (e.g. agent-driven hotfixes). Returns the PR URL.\nThe patch must be a unified diff with author/subject headers — generate it with `git format-patch -1 HEAD --stdout`.",
+  {
+    branch: z.string().describe('Feature branch name (e.g. "claude/fix-x"). Must start with "claude/".'),
+    patch_base64: z.string().describe("Base64-encoded patch content (`base64 -w0 patch.patch`)."),
+    base_ref: z.string().optional().describe('Base ref to branch from (default: "main").'),
+    merge: z.enum(["auto", "admin", "skip"]).default("auto").describe('"auto" = wait for required checks; "admin" = override; "skip" = leave PR open.'),
+    repo: z.string().optional().describe("Repo name (default: cloudless.gr)"),
+  },
+  async ({ branch, patch_base64, base_ref, merge, repo }) => {
+    if (!isClaudeBranch(branch)) {
+      return err(new Error(`Refusing to push to "${branch}" — only claude/<topic> branches are accepted from this tool.`));
+    }
+    if (!isPlainBase64(patch_base64)) {
+      return err(new Error("patch_base64 must be plain base64 (single line, no whitespace)."));
+    }
+    const r = `Themis128/${repo ?? "cloudless.gr"}`;
+    const base = base_ref ?? "main";
+    // Use a per-invocation scratch dir; clone fresh to avoid stepping on whatever else the Pi is doing.
+    const cmd = [
+      `set -euo pipefail`,
+      `WORKDIR=$(mktemp -d)`,
+      `cd $WORKDIR`,
+      `git clone --quiet --depth 5 --branch ${base} https://x-access-token:$(gh auth token)@github.com/${r}.git repo`,
+      `cd repo`,
+      `git checkout -b ${branch}`,
+      `printf %s '${patch_base64}' | base64 -d > /tmp/in.patch`,
+      `git am /tmp/in.patch`,
+      `git push -u origin ${branch} 2>&1`,
+      `PR_URL=$(gh pr create --fill --repo ${r} 2>&1 | tail -1)`,
+      `echo "PR_URL=$PR_URL"`,
+      merge === "skip" ? `echo "(merge skipped per request)"` :
+        merge === "admin" ? `gh pr merge $PR_URL --squash --delete-branch --admin --repo ${r} 2>&1` :
+        `gh pr merge $PR_URL --squash --delete-branch --auto --repo ${r} 2>&1`,
+      `cd / && rm -rf $WORKDIR`,
+    ].join(" && ");
+    try { return ok(await sshMain(cmd, 90_000)); } catch (e) { return err(e); }
+  }
+);
+
+server.tool(
   "gh_pr_checks",
   "Show CI check statuses for a PR.",
   {
@@ -675,6 +765,41 @@ server.tool(
       cmd = `aws ssm get-parameters-by-path --path "${pfx}" --recursive --region us-east-1 --query 'Parameters[].{Name:Name,Type:Type,LastModifiedDate:LastModifiedDate}' --output table 2>&1`;
     }
     try { return ok(await sshMain(cmd, 20_000)); } catch (e) { return err(e); }
+  }
+);
+
+server.tool(
+  "aws_put_ssm_parameter",
+  "Write (create or overwrite) an SSM parameter under /cloudless/production.\nSecure by default — values are sent over SSH and stored as SecureString unless overridden.\nThe value is base64-encoded on the wire to avoid quoting issues and to keep it out of `ps`.",
+  {
+    parameter_name: z.string().describe('Short name (e.g. "AI_GENERATE_SECRET") or absolute path. Short names are placed under /cloudless/production/.'),
+    value: z.string().describe("Plain-text value. Will be base64-encoded for transport and decoded on the Pi before the AWS CLI sees it."),
+    type: z.enum(["SecureString", "String", "StringList"]).default("SecureString").describe('Parameter type (default: SecureString).'),
+    description: z.string().optional().describe("Human-readable description stored alongside the parameter."),
+  },
+  async ({ parameter_name, value, type, description }) => {
+    const name = resolveSsmName(parameter_name);
+    const valueB64 = Buffer.from(value, "utf8").toString("base64");
+    const descFlag = description
+      ? `--description ${JSON.stringify(description)}`
+      : "";
+    // shellcheck-safe: the only externally-supplied strings are name (validated path), valueB64
+    // (alphanumeric+/=), and the optional description (passed through JSON.stringify quoting).
+    const cmd = `VAL=$(printf %s '${valueB64}' | base64 -d) && aws ssm put-parameter --name '${name}' --type ${type} --value "$VAL" --overwrite ${descFlag} --region us-east-1 --output json 2>&1 && unset VAL`;
+    try { return ok(await sshMain(cmd, 20_000)); } catch (e) { return err(e); }
+  }
+);
+
+server.tool(
+  "aws_delete_ssm_parameter",
+  "Delete an SSM parameter under /cloudless/production. No-op if it doesn't exist.",
+  {
+    parameter_name: z.string().describe('Short name (e.g. "OLD_KEY") or absolute path.'),
+  },
+  async ({ parameter_name }) => {
+    const name = resolveSsmName(parameter_name);
+    const cmd = `aws ssm delete-parameter --name '${name}' --region us-east-1 2>&1 || echo "(parameter already absent)"`;
+    try { return ok(await sshMain(cmd, 15_000)); } catch (e) { return err(e); }
   }
 );
 

--- a/tools/ssh-mcp/src/validators.ts
+++ b/tools/ssh-mcp/src/validators.ts
@@ -1,0 +1,33 @@
+/**
+ * Pure input validators for the cloudless-infra MCP write tools.
+ *
+ * Extracted into their own module so the root vitest suite can cover them
+ * without importing index.ts (which starts an MCP stdio server on import).
+ */
+
+/** GitHub Actions secret names must be uppercase A-Z plus digits and underscores. */
+export function isValidSecretName(name: string): boolean {
+  return /^[A-Z][A-Z0-9_]*$/.test(name);
+}
+
+/** Plain base64 — no whitespace, no URL-safe variants. Matches `base64 -w0` output. */
+export function isPlainBase64(s: string): boolean {
+  if (s.length === 0) return false;
+  return /^[A-Za-z0-9+/=]+$/.test(s);
+}
+
+/**
+ * Refuse anything that doesn't look like an agent-authored topic branch.
+ * Keeps the patch-apply tool from ever pushing to a release/protected branch.
+ */
+export function isClaudeBranch(name: string): boolean {
+  return /^claude\/[a-z0-9][a-z0-9._-]*$/i.test(name);
+}
+
+/**
+ * Resolve a short SSM name to the full `/cloudless/production/X` path.
+ * Pass-through if the user already gave an absolute path.
+ */
+export function resolveSsmName(name: string): string {
+  return name.startsWith("/") ? name : `/cloudless/production/${name}`;
+}


### PR DESCRIPTION
Extends the cloudless-infra MCP server (tools/ssh-mcp) with six write
tools, routed through the existing SSH-to-omv-main plumbing so they
inherit the Pi's gh + aws CLI sessions:

  aws_put_ssm_parameter      Create or overwrite an SSM parameter.
                             Value is base64-encoded over the wire so
                             it never appears in argv or `ps`.
  aws_delete_ssm_parameter   Remove an SSM parameter (no-op if absent).
  gh_secret_set              Set a repo-level GitHub Actions secret.
  gh_secret_delete           Delete one.
  gh_secret_list             List names + ages.
  gh_apply_patch_and_open_pr Clone, apply a base64 git format-patch,
                             push a claude/* branch, open PR, auto-merge.

Hard guards live in tools/ssh-mcp/src/validators.ts (so the root vitest
suite covers them without importing the stdio MCP server):
  - isValidSecretName: /^[A-Z][A-Z0-9_]*$/
  - isPlainBase64: no whitespace, no URL-safe variants
  - isClaudeBranch: refuse anything not under claude/*
  - resolveSsmName: short name → /cloudless/production/<name>

Tests in __tests__/infra-mcp-validators.test.ts cover the accept/reject
matrix for each. The MCP tool handlers use the helpers directly so a
future maintainer can't silently weaken a guard without breaking a test.
