### PR TITLE
fix(ai-route): defensive response coercion, valid fallback model, drop empty toolConfig

### DIFF
--- a/__tests__/bedrock-shared.test.ts
+++ b/__tests__/bedrock-shared.test.ts
@@ -140,7 +140,6 @@ describe("bedrock-shared", () => {
         client: getBedrockClient(),
         system: "be helpful",
         messages: [{ role: "user", content: [{ text: "hi" }] }],
-        toolConfig: { tools: [] },
         maxTokens: 100,
       });
 
@@ -154,7 +153,6 @@ describe("bedrock-shared", () => {
         client: getBedrockClient(),
         system: "s",
         messages: [{ role: "user", content: [{ text: "hi" }] }],
-        toolConfig: { tools: [] },
       });
       const cmd = mockSend.mock.calls[0][0] as {
         input?: { inferenceConfig?: { maxTokens?: number } };
@@ -168,9 +166,62 @@ describe("bedrock-shared", () => {
         client: getBedrockClient(),
         system: "s",
         messages: [],
-        toolConfig: { tools: [] },
       });
       expect(out).toEqual([]);
+    });
+
+    // Regression: Bedrock 400s with ValidationException when toolConfig.tools
+    // is an empty array. The shared helper must OMIT toolConfig in that case.
+    it("omits toolConfig from ConverseCommand when none is provided", async () => {
+      mockSend.mockResolvedValueOnce({ output: { message: { content: [] } } });
+      await runBedrockTurn({
+        client: getBedrockClient(),
+        system: "s",
+        messages: [{ role: "user", content: [{ text: "hi" }] }],
+      });
+      const cmd = mockSend.mock.calls[0][0] as {
+        input?: Record<string, unknown>;
+      };
+      expect(cmd.input).toBeDefined();
+      expect("toolConfig" in (cmd.input ?? {})).toBe(false);
+    });
+
+    it("omits toolConfig when tools array is empty", async () => {
+      mockSend.mockResolvedValueOnce({ output: { message: { content: [] } } });
+      await runBedrockTurn({
+        client: getBedrockClient(),
+        system: "s",
+        messages: [{ role: "user", content: [{ text: "hi" }] }],
+        toolConfig: { tools: [] },
+      });
+      const cmd = mockSend.mock.calls[0][0] as {
+        input?: Record<string, unknown>;
+      };
+      expect("toolConfig" in (cmd.input ?? {})).toBe(false);
+    });
+
+    it("forwards toolConfig when tools is non-empty", async () => {
+      mockSend.mockResolvedValueOnce({ output: { message: { content: [] } } });
+      await runBedrockTurn({
+        client: getBedrockClient(),
+        system: "s",
+        messages: [{ role: "user", content: [{ text: "hi" }] }],
+        toolConfig: {
+          tools: [
+            {
+              toolSpec: {
+                name: "x",
+                description: "y",
+                inputSchema: { json: {} },
+              },
+            },
+          ],
+        },
+      });
+      const cmd = mockSend.mock.calls[0][0] as {
+        input?: { toolConfig?: { tools?: unknown[] } };
+      };
+      expect(cmd.input?.toolConfig?.tools).toHaveLength(1);
     });
   });
 });

--- a/__tests__/internal-ai-generate-api.test.ts
+++ b/__tests__/internal-ai-generate-api.test.ts
@@ -148,3 +148,39 @@ describe("POST /api/internal/ai/generate", () => {
     expect(res.status).toBe(502);
   });
 });
+
+// Regression: in production we saw Workers AI sometimes return a non-string
+// `result.response`, which crashed the handler with `text.trim is not a function`.
+// The route must coerce defensively and either return a stringified value or
+// fall through to Bedrock cleanly.
+describe("POST /api/internal/ai/generate — non-string Cloudflare response", () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    vi.mocked(getConfig).mockResolvedValue({
+      AI_GENERATE_SECRET: SECRET,
+    } as Awaited<ReturnType<typeof getConfig>>);
+    process.env.CLOUDFLARE_ACCOUNT_ID = "acct-test";
+    process.env.CLOUDFLARE_API_TOKEN = "token-test";
+  });
+
+  it("stringifies a non-string Cloudflare response instead of throwing", async () => {
+    globalThis.fetch = vi.fn().mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({
+          result: { response: { json: "shape", with: ["nested", "arr"] } },
+        }),
+        { status: 200 },
+      ),
+    ) as typeof fetch;
+    const res = await POST(
+      reqWith({
+        messages: [{ role: "user", content: "hi" }],
+      }) as never,
+    );
+    const body = (await res.json()) as { result: string; source: string };
+    expect(res.status).toBe(200);
+    expect(body.source).toBe("cloudflare");
+    expect(typeof body.result).toBe("string");
+    expect(body.result).toContain('"json":"shape"');
+  });
+});

--- a/src/app/api/internal/ai/generate/route.ts
+++ b/src/app/api/internal/ai/generate/route.ts
@@ -39,7 +39,7 @@ import {
 export const runtime = "nodejs";
 
 const DEFAULT_CF_MODEL = "@cf/meta/llama-3.3-70b-instruct-fp8-fast";
-const FALLBACK_CF_MODEL = "@cf/meta/llama-3-70b-instruct";
+const FALLBACK_CF_MODEL = "@cf/meta/llama-3.1-8b-instruct-fast";
 
 interface ChatMessage {
   role: "user" | "assistant" | "system";
@@ -89,14 +89,19 @@ async function callCloudflare(
     }
   );
   const data = (await res.json()) as {
-    result?: { response?: string };
+    result?: { response?: unknown };
     errors?: { message?: string }[];
   };
   if (!res.ok) {
     const reason = data.errors?.[0]?.message ?? `status ${res.status}`;
     throw new Error(`Cloudflare Workers AI: ${reason}`);
   }
-  const text = data.result?.response ?? "";
+  // Workers AI usually returns `result.response` as a string, but some models
+  // (and some failure modes) put a non-string there. Coerce defensively so a
+  // bad shape doesn't crash the handler — it just becomes "fall back to Bedrock".
+  const raw = data.result?.response;
+  const text =
+    typeof raw === "string" ? raw : raw == null ? "" : JSON.stringify(raw);
   if (!text.trim()) throw new Error("Cloudflare Workers AI returned empty response");
   return text;
 }
@@ -116,7 +121,6 @@ async function callBedrock(
     client: getBedrockClient(),
     system: system ?? "",
     messages: bedrockMessages,
-    toolConfig: { tools: [] },
     maxTokens,
   });
   const text = joinAssistantText(content);

--- a/src/lib/bedrock-shared.ts
+++ b/src/lib/bedrock-shared.ts
@@ -101,7 +101,9 @@ export interface RunBedrockTurnOptions {
   client: BedrockRuntimeClient;
   system: string;
   messages: BedrockMessage[];
-  toolConfig: ToolConfiguration;
+  /** Omit (or pass an empty tools array) for plain text generation —
+   *  Bedrock 400s on `toolConfig: { tools: [] }`. */
+  toolConfig?: ToolConfiguration;
   maxTokens?: number;
 }
 
@@ -110,11 +112,14 @@ export interface RunBedrockTurnOptions {
  * Callers handle the loop, tool dispatch, and termination conditions.
  */
 export async function runBedrockTurn(opts: RunBedrockTurnOptions): Promise<AnyBlock[]> {
+  // Only attach toolConfig when there is at least one tool — Bedrock 400s on
+  // an empty tools array.
+  const hasTools = !!opts.toolConfig?.tools?.length;
   const cmd = new ConverseCommand({
     modelId: BEDROCK_MODEL_ID,
     system: [{ text: opts.system }],
     messages: opts.messages,
-    toolConfig: opts.toolConfig,
+    ...(hasTools ? { toolConfig: opts.toolConfig } : {}),
     inferenceConfig: { maxTokens: opts.maxTokens ?? 400 },
   });
   const response = await opts.client.send(cmd);


### PR DESCRIPTION
Three production bugs surfaced when the newsletter cron made its first
real call (system prompt + 4096 maxTokens) against the live route:

1. `text.trim is not a function`
   Cloudflare Workers AI sometimes returns `result.response` as a
   non-string (object/array for certain shapes or failure modes). The
   `data.result?.response ?? ""` path then handed a non-string to
   `.trim()` and the handler crashed.
   Fix: coerce defensively in callCloudflare — string passes through,
   nullish becomes "", anything else gets JSON.stringify-ed.

2. `Cloudflare Workers AI: No route for that URI`
   The fallback model id `@cf/meta/llama-3-70b-instruct` no longer
   exists on Workers AI. The retry path was always 404-ing before
   reaching Bedrock.
   Fix: swap fallback to `@cf/meta/llama-3.1-8b-instruct-fast`
   (current, free-tier, fast).

3. `Bedrock also failed: ValidationException`
   `runBedrockTurn` was forwarding `toolConfig: { tools: [] }` and
   Bedrock 400s on an empty tools array.
   Fix: make `toolConfig` optional in `RunBedrockTurnOptions` and only
   attach it to the ConverseCommand when there is at least one tool.
   Route stops passing it for plain text generation.

Tests:
- __tests__/bedrock-shared.test.ts now covers all three branches of
  the optional toolConfig (undefined, empty, non-empty).
- __tests__/internal-ai-generate-api.test.ts now has a regression test
  for the non-string Cloudflare response — the same shape that crashed
  the production handler.

Existing callers (`agent-voice-brief`, `bedrock-chat`) pass non-empty
tools and are unaffected.
