### PR TITLE
fix(notion): align cron property names with actual Blog DB schema

### DIFF
--- a/scripts/generate-weekly-article.ts
+++ b/scripts/generate-weekly-article.ts
@@ -437,9 +437,12 @@ async function createDraftPage(
         Excerpt: { rich_text: [{ text: { content: article.excerpt } }] },
         Category: { select: { name: category } },
         Status: { select: { name: "Draft" } },
-        GeneratedBy: { select: { name: "AI" } },
-        ReadTime: { rich_text: [{ text: { content: article.readTime } }] },
-        Author: { rich_text: [{ text: { content: "Cloudless Team" } }] },
+        // Notion DB schema notes (verified 2026-06-14):
+        //   - "Read Time" has a space; the script previously wrote `ReadTime`.
+        //   - "Author" is a People property — cannot be set to a string from
+        //     an integration token, so leave it empty for the human reviewer.
+        //   - There is no `GeneratedBy` property in the DB.
+        "Read Time": { rich_text: [{ text: { content: article.readTime } }] },
         Published: { checkbox: false },
       },
       children: initialChildren,

--- a/scripts/publish-and-send-newsletter.ts
+++ b/scripts/publish-and-send-newsletter.ts
@@ -17,7 +17,7 @@
  *
  * Flow per approved post:
  *   1. Fetch full block tree, render to HTML + plaintext.
- *   2. Atomically set Status=Published, Published=true, Date + PublishedAt.
+ *   2. Atomically set Status=Published, Published=true, Date.
  *   3. POST /api/webhooks/notion (page.updated, blog) to revalidate.
  *   4. POST /api/newsletter/send with the rendered email.
  *   5. Slack-ping with subject, slug, and delivered/failed counts.
@@ -100,7 +100,7 @@ async function fetchApprovedPosts(): Promise<ApprovedPost[]> {
       slug: get(p.Slug?.rich_text),
       excerpt: get(p.Excerpt?.rich_text),
       category: p.Category?.select?.name ?? "Cloud",
-      readTime: get(p.ReadTime?.rich_text) || "5 min read",
+      readTime: get(p["Read Time"]?.rich_text) || "5 min read",
     };
   });
 }
@@ -140,7 +140,6 @@ async function markPublished(pageId: string, today: string): Promise<void> {
         Status: { select: { name: "Published" } },
         Published: { checkbox: true },
         Date: { date: { start: today } },
-        PublishedAt: { date: { start: today } },
       },
     }),
   });

--- a/src/app/api/internal/ai/generate/route.ts
+++ b/src/app/api/internal/ai/generate/route.ts
@@ -100,8 +100,7 @@ async function callCloudflare(
   // (and some failure modes) put a non-string there. Coerce defensively so a
   // bad shape doesn't crash the handler — it just becomes "fall back to Bedrock".
   const raw = data.result?.response;
-  const text =
-    typeof raw === "string" ? raw : raw == null ? "" : JSON.stringify(raw);
+  const text = typeof raw === "string" ? raw : raw == null ? "" : JSON.stringify(raw);
   if (!text.trim()) throw new Error("Cloudflare Workers AI returned empty response");
   return text;
 }


### PR DESCRIPTION
The cron run that finally got past the Cloudflare 10s Worker limit
(direct Workers AI call, 18s generation) was rejected by Notion:

  validation_error: GeneratedBy is not a property that exists.
                    ReadTime is not a property that exists.
                    Author is expected to be people.

Verified the live schema via the integration's own query:

  Slug, Excerpt, Category, Status, Title, Date, Updated At,
  Cover Image, Locale, Tags, Featured, Published, "Read Time",
  Author (people), SEO Title, SEO Description

Three fixes in scripts/generate-weekly-article.ts createDraftPage:
  - Drop the `GeneratedBy` write — no such property in the DB.
  - Rename `ReadTime` → "Read Time" (the live key has a space).
  - Drop the `Author` write — it is a People property and cannot
    be set from an integration token; leave it for the human reviewer.

Mirror in scripts/publish-and-send-newsletter.ts:
  - Read from p["Read Time"] not p.ReadTime in fetchApprovedPosts.
  - Drop the `PublishedAt` write in markPublished — no such property.
    `Date` already serves as the publish date.

No tests cover these property names directly (the Notion shapes here
are tested as opaque pass-throughs), so this is a content-only fix.
