### PR TITLE
style: run prettier on slack rerun files

### DIFF
--- a/src/app/api/slack/commands/route.ts
+++ b/src/app/api/slack/commands/route.ts
@@ -623,7 +623,6 @@ function slackResponse(body: SlackCommandResponse): Response {
   });
 }
 
-
 // ---------------------------------------------------------------------------
 // /cloudless-draft — re-run the weekly article draft workflow
 //

--- a/src/app/api/slack/interactions/route.ts
+++ b/src/app/api/slack/interactions/route.ts
@@ -146,10 +146,7 @@ async function handleBlockActions(payload: SlackInteractionPayload): Promise<Res
               payload.user.id,
               action.action_id
             ).catch((err) =>
-              console.error(
-                `[Slack Interactions] ${action.action_id} failed:`,
-                err
-              )
+              console.error(`[Slack Interactions] ${action.action_id} failed:`, err)
             );
           }
         } else {
@@ -425,7 +422,6 @@ async function refreshOrdersAsync(responseUrl: string): Promise<void> {
   }
 }
 
-
 // ---------------------------------------------------------------------------
 // Workflow re-run responder
 //
@@ -456,9 +452,7 @@ async function rerunWorkflowAsync(
           "> to add your Slack user ID to `SLACK_OPS_USERS`.",
       }),
       signal: AbortSignal.timeout(5_000),
-    }).catch((err) =>
-      console.error("[Slack Interactions] denial post failed:", err)
-    );
+    }).catch((err) => console.error("[Slack Interactions] denial post failed:", err));
     return;
   }
 
@@ -478,9 +472,6 @@ async function rerunWorkflowAsync(
     }),
     signal: AbortSignal.timeout(5_000),
   }).catch((err) =>
-    console.error(
-      `[Slack Interactions] follow-up post failed for ${actionId}:`,
-      err
-    )
+    console.error(`[Slack Interactions] follow-up post failed for ${actionId}:`, err)
   );
 }

--- a/src/lib/github-dispatch.ts
+++ b/src/lib/github-dispatch.ts
@@ -22,9 +22,7 @@ import { getConfig } from "@/lib/ssm-config";
  */
 const REPO = process.env.GITHUB_DISPATCH_REPO || "Themis128/cloudless.gr";
 
-export type DispatchResult =
-  | { ok: true }
-  | { ok: false; status: number; error: string };
+export type DispatchResult = { ok: true } | { ok: false; status: number; error: string };
 
 /**
  * Trigger a workflow_dispatch event on the given workflow file.


### PR DESCRIPTION
Fixes the Lint & Format failure on PR #884 (and every future PR) caused by PR #882 leaving three files unformatted. Pure prettier reformat — 4 inserts, 16 deletes, all whitespace + trailing commas. ESLint clean, vitest slack suite 44/44 still passing.