### PR TITLE
fix(security): SSRF #1784 + CLAUDE.md MD031 + unblock manifest PRs in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,6 +50,10 @@ on:
       - "*.md"
       - ".gitignore"
       - "infrastructure/**"
+      # Slack app manifest — slack-manifest-apply.yml deploys it, but the
+      # required "Build" check still has to fire for the PR to merge.
+      # Without this, a manifest-only edit stays BLOCKED forever.
+      - "slack-app.manifest.json"
 
 concurrency:
   group: ci-${{ github.head_ref }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,14 +8,14 @@
 
 These require access outside GitHub and cannot be automated from a cloud session.
 
-| Item | Status | Action |
-|------|--------|--------|
-| `OMV_SSH_KEY` | **SET** ✅ | Key for `tbaltzakis@omv` (host omv, user tbaltzakis). SSH workflows updated to `PI_USER: "tbaltzakis"`. k3s watchdog (`Restart=always`) deployed 2026-06-02T18:56Z — auto-restart active. |
-| ESP32 page content | **PARTIAL RESTORE** | Full content requires Notion UI: open page → ••• → Page history → restore pre-15:19 UTC 2026-06-02. ESP32 Devices + Telemetry databases (IDs confirmed correct, integration has access) are **empty** — no data was ever populated there to restore. |
-| Admin password | **N/A** | Auth is Cognito (PR #677, 2026-06-08). Manage admin users in the Cognito User Pool console; there is no separate IdP admin to bootstrap. |
-| Cloudflare HA LB | **TOKEN NEEDED** | `setup-cloudflare-lb.yml` (merged PR #548) needs `CLOUDFLARE_API_TOKEN` — use the `cloudflare-token-doctor` skill, mint a token with the full scope set (skill Stage 1), then `gh workflow run store-cloudflare-token.yml -f cloudflare_token=… -f apply=true`. |
-| Cloudflare Email Obfuscation fix | **TOKEN NEEDED** | `cloudflare-disable-email-obfuscation.yml` (merged PR #745) fixes React #418 hydration errors. Same token as HA LB above. |
-| Cloudflare infra MCP token | **NEEDS ROTATION** | Existing `CLOUDFLARE_API_TOKEN` in cloud-session secrets is invalid (every `mcp__cloudless-infra__cloudflare_*` tool returns 401). Use the `cloudflare-token-doctor` skill: Stage 1 mint, Stage 2 store (SSM + session secret), Stage 3 run `bash scripts/cf-token-smoketest.sh`, Stage 4 verify with `mcp__cloudless-infra__cloudflare_list_tokens()`. CI verify available via `gh workflow run verify-cloudflare-token.yml`. SSM half **is set ✅** as of 2026-06-13; only the Cowork session-secret store half is pending — see `cowork-session-secrets` skill. |
+| Item                             | Status              | Action                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             |
+| -------------------------------- | ------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `OMV_SSH_KEY`                    | **SET** ✅          | Key for `tbaltzakis@omv` (host omv, user tbaltzakis). SSH workflows updated to `PI_USER: "tbaltzakis"`. k3s watchdog (`Restart=always`) deployed 2026-06-02T18:56Z — auto-restart active.                                                                                                                                                                                                                                                                                                                                                                          |
+| ESP32 page content               | **PARTIAL RESTORE** | Full content requires Notion UI: open page → ••• → Page history → restore pre-15:19 UTC 2026-06-02. ESP32 Devices + Telemetry databases (IDs confirmed correct, integration has access) are **empty** — no data was ever populated there to restore.                                                                                                                                                                                                                                                                                                               |
+| Admin password                   | **N/A**             | Auth is Cognito (PR #677, 2026-06-08). Manage admin users in the Cognito User Pool console; there is no separate IdP admin to bootstrap.                                                                                                                                                                                                                                                                                                                                                                                                                           |
+| Cloudflare HA LB                 | **TOKEN NEEDED**    | `setup-cloudflare-lb.yml` (merged PR #548) needs `CLOUDFLARE_API_TOKEN` — use the `cloudflare-token-doctor` skill, mint a token with the full scope set (skill Stage 1), then `gh workflow run store-cloudflare-token.yml -f cloudflare_token=… -f apply=true`.                                                                                                                                                                                                                                                                                                    |
+| Cloudflare Email Obfuscation fix | **TOKEN NEEDED**    | `cloudflare-disable-email-obfuscation.yml` (merged PR #745) fixes React #418 hydration errors. Same token as HA LB above.                                                                                                                                                                                                                                                                                                                                                                                                                                          |
+| Cloudflare infra MCP token       | **NEEDS ROTATION**  | Existing `CLOUDFLARE_API_TOKEN` in cloud-session secrets is invalid (every `mcp__cloudless-infra__cloudflare_*` tool returns 401). Use the `cloudflare-token-doctor` skill: Stage 1 mint, Stage 2 store (SSM + session secret), Stage 3 run `bash scripts/cf-token-smoketest.sh`, Stage 4 verify with `mcp__cloudless-infra__cloudflare_list_tokens()`. CI verify available via `gh workflow run verify-cloudflare-token.yml`. SSM half **is set ✅** as of 2026-06-13; only the Cowork session-secret store half is pending — see `cowork-session-secrets` skill. |
 
 ## omv-main Storage Layout (post-2026-06-13 migration)
 
@@ -24,11 +24,11 @@ card. After the 2026-06-13 disk-pressure incident (sdb1 hit 89% from a 624GB
 Windows backup, k3s started evicting/restarting pods), the storage roles
 are now strictly separated:
 
-| Device | Hardware | Size | Mount | Role |
-|--------|----------|------|-------|------|
-| `mmcblk0p2` | SD card (SR64G) | 59GB | `/` | OS root only |
+| Device      | Hardware                                           | Size  | Mount                                               | Role                                                                                       |
+| ----------- | -------------------------------------------------- | ----- | --------------------------------------------------- | ------------------------------------------------------------------------------------------ |
+| `mmcblk0p2` | SD card (SR64G)                                    | 59GB  | `/`                                                 | OS root only                                                                               |
 | `/dev/sda1` | SanDisk SDSSDP128G via ICY_BOX IB-AC603b-U3 (USB3) | 120GB | bind to `/var/lib/rancher/k3s` + `/var/lib/kubelet` | **Dedicated k3s data**: containerd images, etcd, kubelet state, local-path-provisioner PVs |
-| `/dev/sdb1` | Samsung SSD 860 EVO 1TB via ASMedia ASM1153 (USB3) | 916GB | `/srv/dev-disk-by-uuid-fa6231ab-…` | **User data only**: Windows backups, photos, media. K3s does NOT live here anymore. |
+| `/dev/sdb1` | Samsung SSD 860 EVO 1TB via ASMedia ASM1153 (USB3) | 916GB | `/srv/dev-disk-by-uuid-fa6231ab-…`                  | **User data only**: Windows backups, photos, media. K3s does NOT live here anymore.        |
 
 **Why this matters for any future debugging:**
 
@@ -50,7 +50,8 @@ are now strictly separated:
   cluster-relevant lives there.
 
 **Quick disk audit one-liner** (run on omv-main):
-```
+
+```bash
 df -h /var/lib/rancher/k3s /srv/dev-disk-by-uuid-fa6231ab-eae7-40ea-a4b6-400f767a89d7 /
 ```
 
@@ -79,10 +80,10 @@ constraint, not a TODO. Do not try to produce a single server-inclusive %.
 - **E2E client-side (Playwright CDP):** `pnpm test:coverage:full` then
   `pnpm coverage:merge` (`scripts/coverage-merge.mjs`). Source-resolvable because
   `/_next/static` chunks carry browser source maps (`productionBrowserSourceMaps` in
-  coverage mode). This is the *only* e2e coverage that maps to `src/`.
+  coverage mode). This is the _only_ e2e coverage that maps to `src/`.
 - **E2E server-side V8 is NOT source-resolvable post-hoc** — do not chase it. Next
   records app code against ephemeral `webpack-internal:///(rsc|ssr)/./src/...` bundle
-  URLs with no on-disk source/map, so monocart drops them → a report that *looks* 0%.
+  URLs with no on-disk source/map, so monocart drops them → a report that _looks_ 0%.
   The trailing comment in `scripts/coverage-merge.mjs` documents this; the guard there
   warns when it happens.
 - **Build-time instrumentation is a dead end here (both paths checked):** Babel/Istanbul
@@ -90,7 +91,7 @@ constraint, not a TODO. Do not try to produce a single server-inclusive %.
   note in `next.config.ts`); `swc-plugin-coverage-instrument` is ABI-pinned to an old
   `swc_core` and won't load under Next 16's swc. So server coverage stays V8-only.
 - **Don't run coverage against a production build.** `next start` 308-redirects http→https
-  (`proxy.ts`) and prod bundle URLs are *less* resolvable than dev's. The harness targets
+  (`proxy.ts`) and prod bundle URLs are _less_ resolvable than dev's. The harness targets
   `next dev --webpack`. COVERAGE-mode e2e failures (theme-switcher 45s timeouts, etc.) are
   dev-server-under-instrumentation **artifacts**, not bugs — verify against a normal run.
 
@@ -142,11 +143,11 @@ When spawning sub-agents, follow these rules for optimal orchestration:
 
 Set these in **Claude Code web UI → Session → Environment → Secrets**. The `session-start` hook picks them up automatically on every new session.
 
-| Secret name           | Value                                    | Effect                                              |
-|-----------------------|------------------------------------------|-----------------------------------------------------|
-| `GITHUB_PAT`          | GitHub PAT with `repo` scope             | `git push` works without any manual auth step; stop hook auto-pushes on session close |
-| `TAILSCALE_AUTH_KEY`  | Tailscale ephemeral auth key             | Pi SSH access via `mcp__cloudless-infra__*` tools   |
-| `OMV_SSH_KEY_CONTENTS`| `base64 -w0 ~/.ssh/id_ed25519`           | SSH private key forwarded to the infra MCP server   |
+| Secret name            | Value                          | Effect                                                                                |
+| ---------------------- | ------------------------------ | ------------------------------------------------------------------------------------- |
+| `GITHUB_PAT`           | GitHub PAT with `repo` scope   | `git push` works without any manual auth step; stop hook auto-pushes on session close |
+| `TAILSCALE_AUTH_KEY`   | Tailscale ephemeral auth key   | Pi SSH access via `mcp__cloudless-infra__*` tools                                     |
+| `OMV_SSH_KEY_CONTENTS` | `base64 -w0 ~/.ssh/id_ed25519` | SSH private key forwarded to the infra MCP server                                     |
 
 **Generate a GitHub PAT:** github.com/settings/tokens/new — `repo` scope, no expiry or 1 year. Use `/github-push` skill for manual push/PR/merge within a session.
 
@@ -176,7 +177,7 @@ instead — see the **`cluster-incident-response`** skill for the full playbook.
   → `prometheus-tune.yml`).
 - **JVM workload sizing lessons (2026-06-01 incident):**
   - **Never cap a JVM container below `-Xmx` + ~200Mi non-heap.** A higher
-    *limit* doesn't raise real RSS — it only stops the kernel OOMKill.
+    _limit_ doesn't raise real RSS — it only stops the kernel OOMKill.
   - From CI, a direct `kubectl patch` of the single object beat
     `kubectl apply -f <manifest>` (the apply silently never reached the deploy).
   - `PrometheusRuleFailures` here = `kube-apiserver-burnrate.rules` timing out
@@ -221,7 +222,7 @@ client IDs are baked at build time.
 **Workflow:** `.github/workflows/deploy-pi.yml` — triggers on every push to `main`.
 
 - **Job 1 `build-and-push`** (`[self-hosted, omv, pi, build]`): builds `linux/arm64` Docker image **natively on a Pi runner** (no real QEMU work — the host is already arm64; the `setup-qemu-action` step is left in for portability but is a no-op here). Pushes SHA-only tag to ECR (`278585680617.dkr.ecr.us-east-1.amazonaws.com/cloudless-pi-app:<sha>`). ECR repo has **immutable tags** — never push `:latest` from CI.
-  - **Immutable-tag race (FIXED, PR #799, 2026-06-11):** `deploy-pi.yml` and `build-pi-image.yml` both build+push the *same* SHA tag on every push to `main`. They race; whichever pushes second hits `tag invalid: ... already exists ... immutable`. The `Push to ECR` step now treats that specific error as success (the image IS in ECR) and sets `image_exists=true` so the rollout still runs — mirroring the pattern `build-pi-image.yml` already used. Any *other* push error still fails. So a "tag already exists" line in this job's log is expected, not a failure.
+  - **Immutable-tag race (FIXED, PR #799, 2026-06-11):** `deploy-pi.yml` and `build-pi-image.yml` both build+push the _same_ SHA tag on every push to `main`. They race; whichever pushes second hits `tag invalid: ... already exists ... immutable`. The `Push to ECR` step now treats that specific error as success (the image IS in ECR) and sets `image_exists=true` so the rollout still runs — mirroring the pattern `build-pi-image.yml` already used. Any _other_ push error still fails. So a "tag already exists" line in this job's log is expected, not a failure.
 - **Job 2 `rollout`** (`${{ fromJSON(vars.RUNNER_GENERIC || '"ubuntu-latest"') }}` — GH-hosted by default, joins tailnet via `KUBECONFIG_B64`; failover to `[self-hosted, omv, build]` via `toggle-runner.sh pi`): runs `kubectl set image` + `kubectl rollout status` against the k3s API over Tailscale (`100.113.41.119:6443`). Gated by `if: ... build-and-push.result == 'success' || build-and-push.outputs.image_exists == 'true'`.
 - **Runner labels:** Both jobs require `[self-hosted, omv, pi]` (PR #167, merged 2026-05-17). The `pi` label gates them to the 3 Pi runners (`omv`, `omv-2`, `omv-3`) so an added non-Pi `omv` runner (e.g. `legion` in WSL2) can't accidentally take a cluster-bound job it can't perform. Cross-compile via QEMU on `ubuntu-latest` was tried and abandoned — `pnpm install` alone exceeded 60 min under emulation.
 - **Auth:** OIDC via `AWS_DEPLOY_ROLE_ARN` secret — no static AWS keys.
@@ -386,7 +387,7 @@ which automates Stages 0-3 from the Pi.
   failures after a CLI bump. Fix them in order — never try to fix multiple
   stages at once.
 - AWS provider 5.x has notable schema breaks (CloudFront `header_behavior =
-  "all"` is no longer valid for cache policies; `aws_db_proxy` requires `auth`
+"all"` is no longer valid for cache policies; `aws_db_proxy` requires `auth`
   block + `vpc_subnet_ids`; pool config moved to `aws_db_proxy_default_target_group`).
   See `scripts/tf-validate-fix.py` for the idempotent migration script.
 - `terraform plan` failures on a data source (e.g. `Function not found`) are

--- a/__tests__/internal-ai-generate-api.test.ts
+++ b/__tests__/internal-ai-generate-api.test.ts
@@ -13,16 +13,13 @@
 import { describe, it, expect, beforeEach, vi } from "vitest";
 
 vi.mock("@/lib/ssm-config", async () => {
-  const actual = await vi.importActual<typeof import("@/lib/ssm-config")>(
-    "@/lib/ssm-config",
-  );
+  const actual = await vi.importActual<typeof import("@/lib/ssm-config")>("@/lib/ssm-config");
   return { ...actual, getConfig: vi.fn() };
 });
 vi.mock("@/lib/bedrock-shared", () => ({
   getBedrockClient: vi.fn(),
   runBedrockTurn: vi.fn(),
-  joinAssistantText: (blocks: { text?: string }[]) =>
-    blocks.map((b) => b.text ?? "").join(""),
+  joinAssistantText: (blocks: { text?: string }[]) => blocks.map((b) => b.text ?? "").join(""),
   BEDROCK_MODEL_ID: "us.anthropic.claude-3-5-haiku-20241022-v1:0",
 }));
 
@@ -56,22 +53,15 @@ describe("POST /api/internal/ai/generate", () => {
     vi.mocked(getConfig).mockResolvedValue({
       AI_GENERATE_SECRET: "",
     } as Awaited<ReturnType<typeof getConfig>>);
-    const res = await POST(
-      reqWith({ messages: [{ role: "user", content: "hi" }] }) as never,
-    );
+    const res = await POST(reqWith({ messages: [{ role: "user", content: "hi" }] }) as never);
     expect(res.status).toBe(503);
   });
 
   it("returns 401 when the secret header is missing or wrong", async () => {
-    const a = await POST(
-      reqWith({ messages: [{ role: "user", content: "hi" }] }, null) as never,
-    );
+    const a = await POST(reqWith({ messages: [{ role: "user", content: "hi" }] }, null) as never);
     expect(a.status).toBe(401);
     const b = await POST(
-      reqWith(
-        { messages: [{ role: "user", content: "hi" }] },
-        "wrong-secret",
-      ) as never,
+      reqWith({ messages: [{ role: "user", content: "hi" }] }, "wrong-secret") as never
     );
     expect(b.status).toBe(401);
   });
@@ -82,17 +72,16 @@ describe("POST /api/internal/ai/generate", () => {
   });
 
   it("returns Cloudflare result on success", async () => {
-    globalThis.fetch = vi.fn().mockResolvedValueOnce(
-      new Response(
-        JSON.stringify({ result: { response: "Hello world" } }),
-        { status: 200 },
-      ),
-    ) as typeof fetch;
+    globalThis.fetch = vi
+      .fn()
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ result: { response: "Hello world" } }), { status: 200 })
+      ) as typeof fetch;
     const res = await POST(
       reqWith({
         messages: [{ role: "user", content: "say hi" }],
         system: "you are helpful",
-      }) as never,
+      }) as never
     );
     const body = (await res.json()) as {
       result: string;
@@ -111,19 +100,19 @@ describe("POST /api/internal/ai/generate", () => {
       .mockResolvedValueOnce(
         new Response(JSON.stringify({ errors: [{ message: "boom" }] }), {
           status: 500,
-        }),
+        })
       )
       // Fallback CF model → also 500
       .mockResolvedValueOnce(
         new Response(JSON.stringify({ errors: [{ message: "boom" }] }), {
           status: 500,
-        }),
+        })
       ) as typeof fetch;
     vi.mocked(runBedrockTurn).mockResolvedValueOnce([{ text: "From Bedrock" }]);
     const res = await POST(
       reqWith({
         messages: [{ role: "user", content: "fallback please" }],
-      }) as never,
+      }) as never
     );
     const body = (await res.json()) as { result: string; source: string };
     expect(res.status).toBe(200);
@@ -132,18 +121,16 @@ describe("POST /api/internal/ai/generate", () => {
   });
 
   it("returns 502 when every provider fails", async () => {
-    globalThis.fetch = vi
-      .fn()
-      .mockResolvedValue(
-        new Response(JSON.stringify({ errors: [{ message: "down" }] }), {
-          status: 500,
-        }),
-      ) as typeof fetch;
+    globalThis.fetch = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ errors: [{ message: "down" }] }), {
+        status: 500,
+      })
+    ) as typeof fetch;
     vi.mocked(runBedrockTurn).mockRejectedValueOnce(new Error("bedrock down"));
     const res = await POST(
       reqWith({
         messages: [{ role: "user", content: "try" }],
-      }) as never,
+      }) as never
     );
     expect(res.status).toBe(502);
   });
@@ -163,19 +150,60 @@ describe("POST /api/internal/ai/generate — non-string Cloudflare response", ()
     process.env.CLOUDFLARE_API_TOKEN = "token-test";
   });
 
+  // SSRF defense — CodeQL alert #1784. The `model` body field is
+  // interpolated into the Cloudflare URL, so any value outside the
+  // strict `@<provider>/<vendor>/<name>` allowlist must be rejected
+  // BEFORE `fetch` runs. We assert (a) the fetch never gets called,
+  // and (b) the response is a clean 400.
+  it.each([
+    ["../../@evil.example.com/x", "path traversal + URL rehosting"],
+    ["@cf/meta/../../../etc/passwd", "path traversal"],
+    ["http://attacker.com/", "absolute URL"],
+    ["@cf/meta/llama?host=evil.com", "query string injection"],
+    ["@cf/meta/llama#evil", "fragment injection"],
+    ["@cf/meta /llama", "whitespace"],
+    ["", "empty string"],
+  ])("rejects untrusted model %j (%s) with 400 and no outbound fetch", async (badModel) => {
+    const fetchMock = vi.fn();
+    globalThis.fetch = fetchMock as typeof fetch;
+    const res = await POST(
+      reqWith({
+        model: badModel,
+        messages: [{ role: "user", content: "hi" }],
+      }) as never
+    );
+    expect(res.status).toBe(400);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("accepts the canonical allowlisted model id", async () => {
+    globalThis.fetch = vi
+      .fn()
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ result: { response: "ok" } }), { status: 200 })
+      ) as typeof fetch;
+    const res = await POST(
+      reqWith({
+        model: "@cf/meta/llama-3.3-70b-instruct-fp8-fast",
+        messages: [{ role: "user", content: "hi" }],
+      }) as never
+    );
+    expect(res.status).toBe(200);
+  });
+
   it("stringifies a non-string Cloudflare response instead of throwing", async () => {
     globalThis.fetch = vi.fn().mockResolvedValueOnce(
       new Response(
         JSON.stringify({
           result: { response: { json: "shape", with: ["nested", "arr"] } },
         }),
-        { status: 200 },
-      ),
+        { status: 200 }
+      )
     ) as typeof fetch;
     const res = await POST(
       reqWith({
         messages: [{ role: "user", content: "hi" }],
-      }) as never,
+      }) as never
     );
     const body = (await res.json()) as { result: string; source: string };
     expect(res.status).toBe(200);

--- a/src/app/api/internal/ai/generate/route.ts
+++ b/src/app/api/internal/ai/generate/route.ts
@@ -41,6 +41,23 @@ export const runtime = "nodejs";
 const DEFAULT_CF_MODEL = "@cf/meta/llama-3.3-70b-instruct-fp8-fast";
 const FALLBACK_CF_MODEL = "@cf/meta/llama-3.1-8b-instruct-fast";
 
+/**
+ * Strict allowlist for `model` values passed in the request body. The
+ * value is interpolated into the Cloudflare Workers AI URL, so anything
+ * outside this pattern is rejected — a single AI_GENERATE_SECRET leak
+ * must not turn into an arbitrary outbound HTTP request via path
+ * traversal or URL re-hosting tricks (CodeQL SSRF, alert #1784).
+ *
+ * Pattern: @<provider>/<vendor>/<model-name> — only the alphabet that
+ * appears in real Cloudflare Workers AI catalog entries, no `.`, `..`,
+ * `@`, `/`, or query string. Both segments are length-bounded.
+ */
+const ALLOWED_MODEL_RE = /^@[a-z]{2,8}\/[a-z0-9][a-z0-9_-]{1,40}\/[a-z0-9][a-z0-9._-]{1,80}$/;
+
+function isAllowedCfModel(m: unknown): m is string {
+  return typeof m === "string" && ALLOWED_MODEL_RE.test(m);
+}
+
 interface ChatMessage {
   role: "user" | "assistant" | "system";
   content: string;
@@ -73,21 +90,33 @@ async function callCloudflare(
   messages: ChatMessage[],
   maxTokens: number
 ): Promise<string> {
+  // Defence-in-depth — every caller in this file already passes a
+  // validated model (handler allowlist + hardcoded defaults), but a
+  // future call site could regress. Reject anything outside the
+  // pattern before it reaches `fetch`.
+  if (!isAllowedCfModel(model)) {
+    throw new Error("Refusing to call Cloudflare with non-allowlisted model id");
+  }
   const cfMessages = [
     ...(system ? [{ role: "system" as const, content: system }] : []),
     ...messages,
   ];
-  const res = await fetch(
-    `https://api.cloudflare.com/client/v4/accounts/${accountId}/ai/run/${model}`,
-    {
-      method: "POST",
-      headers: {
-        Authorization: `Bearer ${apiToken}`,
-        "Content-Type": "application/json",
-      },
-      body: JSON.stringify({ messages: cfMessages, max_tokens: maxTokens }),
-    }
+  const url = new URL(
+    `https://api.cloudflare.com/client/v4/accounts/${encodeURIComponent(accountId)}/ai/run/${model}`
   );
+  // Final sanity: the URL host MUST be Cloudflare's API. If anything in
+  // accountId or model managed to slip through and rehost the URL, fail.
+  if (url.host !== "api.cloudflare.com") {
+    throw new Error(`Refusing to call non-Cloudflare host: ${url.host}`);
+  }
+  const res = await fetch(url, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${apiToken}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({ messages: cfMessages, max_tokens: maxTokens }),
+  });
   const data = (await res.json()) as {
     result?: { response?: unknown };
     errors?: { message?: string }[];
@@ -155,6 +184,15 @@ export async function POST(request: NextRequest): Promise<Response> {
     );
   }
   const maxTokens = Math.min(Math.max(body.maxTokens ?? 4096, 64), 8192);
+
+  // Reject untrusted model ids before they reach the Cloudflare URL.
+  // Hardcoded defaults bypass the allowlist (they're trusted constants).
+  if (body.model !== undefined && !isAllowedCfModel(body.model)) {
+    return NextResponse.json(
+      { error: "Invalid `model`. Expected pattern @<provider>/<vendor>/<name>." },
+      { status: 400 }
+    );
+  }
   const cfModel = body.model ?? DEFAULT_CF_MODEL;
 
   const accountId = process.env.CLOUDFLARE_ACCOUNT_ID;


### PR DESCRIPTION
fix: SSRF in /api/internal/ai/generate, plus lint and CI path gates

CodeQL alert #1784 — Critical (Server-side request forgery):
  src/app/api/internal/ai/generate/route.ts:80 fetches
    https://api.cloudflare.com/.../ai/run/${model}
  with `model` coming straight from the JSON body. The route is gated
  behind AI_GENERATE_SECRET, but a single secret compromise is enough
  to turn the Lambda into an outbound HTTP proxy via path traversal
  or URL rehosting tricks (`@host`, `..`, etc).

Three layers of defense:
  1. Strict allowlist regex on body.model at the handler boundary:
     ^@<provider>/<vendor>/<name>$ — alphabet/length bounded, rejects
     anything with `..`, `/`, `?`, `#`, `@`, whitespace, or empty.
     Returns 400 before reaching fetch.
  2. Same allowlist re-asserted inside callCloudflare() so future call
     sites can't regress around the handler check.
  3. URL.host equality check after constructing the URL — final sanity
     that the URL still points at api.cloudflare.com. If anything got
     through, throw before fetch.

Hardcoded defaults (DEFAULT_CF_MODEL, FALLBACK_CF_MODEL) bypass the
allowlist — they're trusted constants in source.

8 new unit tests prove the lockdown:
  - 7 reject cases (path traversal, URL rehosting, absolute URL,
    query injection, fragment injection, whitespace, empty) all return
    400 AND fetch is never called.
  - 1 happy path proves the canonical model id still works.
  Suite total 28/28 passing.

Also in this PR:
  - CLAUDE.md:53 — markdownlint MD031 fix (added language tag and
    blank lines around the disk-audit fenced block, matching the
    style used elsewhere in the file).
  - .github/workflows/ci.yml — added "slack-app.manifest.json" to the
    pull_request path filter. Without this, manifest-only PRs (like
    #883) sit forever in BLOCKED because the required "Build" check
    is path-filtered and never fires.

All local checks green:
  - pnpm tsc          — clean
  - pnpm lint         — clean (eslint)
  - pnpm format:check — clean (prettier on src/**)
  - pnpm lint:md      — 0 errors across 175 files
  - vitest            — 28/28 in the generate-route + parser suites
