### PR TITLE
feat(slack): self-healing app-config token rotation via SSM + tooling.tokens.rotate

### DIFF
--- a/.github/workflows/slack-manifest-apply.yml
+++ b/.github/workflows/slack-manifest-apply.yml
@@ -3,9 +3,22 @@ name: Apply Slack App Manifest
 # Pushes slack-app.manifest.json to the Slack API whenever the file changes
 # on main, or on manual dispatch.
 #
+# Token flow (self-healing — no expiring GH secret):
+#   1. OIDC → AWS_DEPLOY_ROLE_ARN
+#   2. scripts/rotate-slack-app-config-token.sh reads
+#      /cloudless/production/SLACK_APP_CONFIG_REFRESH_TOKEN from SSM,
+#      hits Slack tooling.tokens.rotate, writes new access + refresh
+#      back to SSM. Access tokens are valid ~12h, refresh tokens are
+#      long-lived.
+#   3. Manifest validate + apply use the fresh access token.
+#
+# One-time bootstrap (only when there is no refresh token in SSM):
+#   bash scripts/seed-slack-app-config-tokens.sh
+#
 # Prerequisites:
-#   SLACK_APP_CONFIG_TOKEN — app configuration token from api.slack.com/apps
-#   SLACK_APP_ID           — app ID (Basic Information page)
+#   SLACK_APP_ID secret    — app ID (Basic Information page)
+#   AWS_DEPLOY_ROLE_ARN secret — already configured for OIDC
+#   SSM /cloudless/production/SLACK_APP_CONFIG_REFRESH_TOKEN (seed once)
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
@@ -22,6 +35,10 @@ on:
         required: false
         default: "false"
 
+permissions:
+  id-token: write # OIDC → AWS_DEPLOY_ROLE_ARN for ssm:Get/PutParameter
+  contents: read
+
 jobs:
   apply-manifest:
     name: Apply Slack Manifest
@@ -35,48 +52,95 @@ jobs:
           python3 -m json.tool slack-app.manifest.json > /dev/null
           echo "✓ JSON is valid"
 
+      - name: Configure AWS credentials (OIDC)
+        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4
+        with:
+          role-to-assume: ${{ secrets.AWS_DEPLOY_ROLE_ARN }}
+          aws-region: us-east-1
+
+      - name: Rotate Slack app-config token (Slack tooling.tokens.rotate)
+        id: rotate
+        env:
+          AWS_DEFAULT_REGION: us-east-1
+        run: bash scripts/rotate-slack-app-config-token.sh
+
+      - name: Read fresh access token from SSM
+        id: read-token
+        env:
+          AWS_DEFAULT_REGION: us-east-1
+        run: |
+          set -uo pipefail
+          TOKEN=$(aws ssm get-parameter \
+            --name /cloudless/production/SLACK_APP_CONFIG_TOKEN \
+            --with-decryption \
+            --query Parameter.Value \
+            --output text 2>/dev/null || true)
+          if [ -z "$TOKEN" ] || [ "$TOKEN" = "None" ]; then
+            echo "::warning::No SLACK_APP_CONFIG_TOKEN in SSM. Run scripts/seed-slack-app-config-tokens.sh first."
+            {
+              echo "## Slack manifest skipped — no token in SSM"
+              echo ""
+              echo "Bootstrap the access + refresh token pair once via:"
+              echo ""
+              echo '```'
+              echo "bash scripts/seed-slack-app-config-tokens.sh"
+              echo '```'
+              echo ""
+              echo "From then on this workflow auto-rotates via Slack \`tooling.tokens.rotate\`."
+            } >> "$GITHUB_STEP_SUMMARY"
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          echo "::add-mask::$TOKEN"
+          echo "token=$TOKEN" >> "$GITHUB_OUTPUT"
+          echo "skip=false" >> "$GITHUB_OUTPUT"
+
       - name: Validate manifest with Slack API
         id: validate
+        if: ${{ steps.read-token.outputs.skip != 'true' }}
+        env:
+          SLACK_TOKEN: ${{ steps.read-token.outputs.token }}
         run: |
           MANIFEST=$(cat slack-app.manifest.json)
           BODY=$(python3 -c "import json,sys; m=json.loads(sys.argv[1]); print(json.dumps({'manifest':m}))" "$MANIFEST")
           RESULT=$(curl -s -X POST https://slack.com/api/apps.manifest.validate \
-            -H "Authorization: Bearer ${{ secrets.SLACK_APP_CONFIG_TOKEN }}" \
+            -H "Authorization: Bearer $SLACK_TOKEN" \
             -H "Content-Type: application/json; charset=utf-8" \
             -d "$BODY")
           echo "$RESULT"
           OK=$(echo "$RESULT" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('ok','false'))")
           ERROR=$(echo "$RESULT" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('error',''))")
-          # Slack app-config tokens expire every 12h. When the token is dead
-          # we surface a warning + actionable summary rather than failing the
-          # workflow — manifest changes are infrequent enough that an admin
-          # rotating the token before the next manifest edit is the right flow.
+          # If we still see auth errors here despite a fresh rotation, the
+          # refresh token itself has been revoked or rotated out of band.
+          # Fail loudly so the operator reseeds via the seed script.
           if [ "$ERROR" = "invalid_auth" ] || [ "$ERROR" = "token_expired" ] || [ "$ERROR" = "not_authed" ]; then
-            echo "::warning::SLACK_APP_CONFIG_TOKEN is invalid or expired ($ERROR)."
+            echo "::error::Slack rejected the freshly-rotated token ($ERROR)."
             {
-              echo "## Slack manifest skipped — token rotation required"
+              echo "## Slack manifest failed — refresh token revoked"
               echo ""
-              echo "The \`SLACK_APP_CONFIG_TOKEN\` secret is **$ERROR**. Slack app config tokens expire every 12 hours."
+              echo "The access token was just rotated but Slack still returned **$ERROR**. The refresh token in SSM has been revoked or rotated outside this workflow. Reseed:"
               echo ""
-              echo "Rotate at <https://api.slack.com/apps> → your app → **Basic Information** → **App-Level Tokens / App configuration tokens**, then update the \`SLACK_APP_CONFIG_TOKEN\` secret."
+              echo '```'
+              echo "bash scripts/seed-slack-app-config-tokens.sh"
+              echo '```'
             } >> "$GITHUB_STEP_SUMMARY"
-            echo "skip=true" >> "$GITHUB_OUTPUT"
-            exit 0
+            exit 1
           fi
           if [ "$OK" != "True" ]; then
             echo "::error::Manifest validation failed"
             exit 1
           fi
           echo "✓ Manifest is valid"
-          echo "skip=false" >> "$GITHUB_OUTPUT"
 
       - name: Apply manifest to Slack app
-        if: ${{ github.event.inputs.dry_run != 'true' && steps.validate.outputs.skip != 'true' }}
+        if: ${{ github.event.inputs.dry_run != 'true' && steps.read-token.outputs.skip != 'true' }}
+        env:
+          SLACK_TOKEN: ${{ steps.read-token.outputs.token }}
         run: |
           MANIFEST=$(cat slack-app.manifest.json)
           BODY=$(python3 -c "import json,sys; m=json.loads(sys.argv[1]); print(json.dumps({'app_id':'${{ secrets.SLACK_APP_ID }}','manifest':m}))" "$MANIFEST")
           RESULT=$(curl -s -X POST https://slack.com/api/apps.manifest.update \
-            -H "Authorization: Bearer ${{ secrets.SLACK_APP_CONFIG_TOKEN }}" \
+            -H "Authorization: Bearer $SLACK_TOKEN" \
             -H "Content-Type: application/json; charset=utf-8" \
             -d "$BODY")
           echo "$RESULT"

--- a/scripts/rotate-slack-app-config-token.sh
+++ b/scripts/rotate-slack-app-config-token.sh
@@ -1,0 +1,112 @@
+#!/usr/bin/env bash
+#
+# Rotate the Slack app-configuration token using the long-lived refresh
+# token. Designed to be called from inside slack-manifest-apply.yml as a
+# pre-step so the manifest API call always has a fresh ~12h access token.
+#
+# Reads:
+#   SSM /cloudless/production/SLACK_APP_CONFIG_REFRESH_TOKEN  (SecureString)
+#
+# Writes (atomic — on Slack API success):
+#   SSM /cloudless/production/SLACK_APP_CONFIG_TOKEN          (SecureString)
+#   SSM /cloudless/production/SLACK_APP_CONFIG_REFRESH_TOKEN  (SecureString)
+#
+# Outputs to GITHUB_OUTPUT (when run in a workflow):
+#   token=<new_access_token>      — masked, available to subsequent steps
+#   rotated=true|false            — false on graceful no-op
+#
+# Exit codes:
+#   0 — success, or graceful skip (no refresh token present yet)
+#   1 — Slack API rejected the refresh token (refresh token has been
+#       revoked or rotated elsewhere); a human must reseed via
+#       scripts/seed-slack-app-config-tokens.sh
+#
+# Slack endpoint: POST https://slack.com/api/tooling.tokens.rotate
+# Docs: https://api.slack.com/methods/tooling.tokens.rotate
+
+set -uo pipefail
+
+REGION="${AWS_REGION:-${AWS_DEFAULT_REGION:-us-east-1}}"
+PREFIX="${SSM_PREFIX:-/cloudless/production}"
+
+REFRESH_PARAM="$PREFIX/SLACK_APP_CONFIG_REFRESH_TOKEN"
+ACCESS_PARAM="$PREFIX/SLACK_APP_CONFIG_TOKEN"
+
+emit_output() {
+  local key="$1" value="$2"
+  if [ -n "${GITHUB_OUTPUT:-}" ]; then
+    echo "${key}=${value}" >>"$GITHUB_OUTPUT"
+  fi
+}
+
+mask() {
+  # ::add-mask:: hides the value from GH Actions logs. No-op outside CI.
+  if [ -n "${GITHUB_ACTIONS:-}" ] && [ -n "$1" ]; then
+    echo "::add-mask::$1"
+  fi
+}
+
+# --- Fetch refresh token ---
+REFRESH=$(aws ssm get-parameter \
+  --region "$REGION" \
+  --name "$REFRESH_PARAM" \
+  --with-decryption \
+  --query Parameter.Value \
+  --output text 2>/dev/null || true)
+
+if [ -z "$REFRESH" ] || [ "$REFRESH" = "None" ]; then
+  echo "::warning::No refresh token in $REFRESH_PARAM — skipping rotation."
+  echo "  Bootstrap with: bash scripts/seed-slack-app-config-tokens.sh"
+  emit_output "rotated" "false"
+  exit 0
+fi
+mask "$REFRESH"
+
+# --- Call Slack API ---
+RESP=$(curl -sS -X POST "https://slack.com/api/tooling.tokens.rotate" \
+  -H "Authorization: Bearer $REFRESH" \
+  -H "Content-Type: application/x-www-form-urlencoded; charset=utf-8")
+
+OK=$(echo "$RESP" | jq -r '.ok // false')
+if [ "$OK" != "true" ]; then
+  ERR=$(echo "$RESP" | jq -r '.error // "unknown"')
+  echo "::error::Slack tooling.tokens.rotate failed: $ERR"
+  if [ "$ERR" = "invalid_refresh_token" ] || [ "$ERR" = "token_expired" ]; then
+    echo "::error::The refresh token has been revoked or rotated outside this workflow."
+    echo "::error::Reseed both tokens at https://api.slack.com/apps → Your App → Basic Information"
+    echo "::error::then run: bash scripts/seed-slack-app-config-tokens.sh"
+  fi
+  exit 1
+fi
+
+NEW_ACCESS=$(echo "$RESP" | jq -r '.token')
+NEW_REFRESH=$(echo "$RESP" | jq -r '.refresh_token')
+
+if [ -z "$NEW_ACCESS" ] || [ "$NEW_ACCESS" = "null" ]; then
+  echo "::error::Slack response missing .token field"
+  exit 1
+fi
+mask "$NEW_ACCESS"
+mask "$NEW_REFRESH"
+
+# --- Persist back to SSM (write refresh FIRST — if the workflow dies
+# between the two writes, the next run can still recover, because the
+# refresh token in SSM matches what Slack now expects).
+aws ssm put-parameter \
+  --region "$REGION" \
+  --name "$REFRESH_PARAM" \
+  --type SecureString \
+  --value "$NEW_REFRESH" \
+  --overwrite >/dev/null
+
+aws ssm put-parameter \
+  --region "$REGION" \
+  --name "$ACCESS_PARAM" \
+  --type SecureString \
+  --value "$NEW_ACCESS" \
+  --overwrite >/dev/null
+
+echo "✓ Slack app-config token rotated. New access token good for ~12h."
+
+emit_output "token" "$NEW_ACCESS"
+emit_output "rotated" "true"

--- a/scripts/seed-slack-app-config-tokens.sh
+++ b/scripts/seed-slack-app-config-tokens.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+#
+# One-time bootstrap for the Slack app-config token pair.
+#
+# Slack app-configuration tokens expire every 12 hours, but they come
+# with a long-lived refresh token. After this seed runs once, the
+# rotate-slack-app-config-token.sh script (called from
+# slack-manifest-apply.yml) keeps the access token fresh automatically.
+#
+# HOW TO MINT THE TOKEN PAIR (browser, ~30s):
+#
+#   1. https://api.slack.com/apps  →  Your Apps page (NOT inside a specific app)
+#   2. Click "Refresh Tokens" or "Generate Tokens" in the top-right.
+#   3. Select workspace "cloudless.gr" (or your dev workspace).
+#   4. Copy the two values that appear:
+#        - "Access Token"   (xoxe.xoxp-...)  — short-lived, ~12h
+#        - "Refresh Token"  (xoxe-...)       — long-lived
+#   5. Run this script. It will prompt for both (input hidden).
+#
+# Both values are written as SecureString to:
+#   /cloudless/production/SLACK_APP_CONFIG_TOKEN
+#   /cloudless/production/SLACK_APP_CONFIG_REFRESH_TOKEN
+
+set -euo pipefail
+
+REGION="${AWS_REGION:-us-east-1}"
+PREFIX="${SSM_PREFIX:-/cloudless/production}"
+
+if ! command -v aws >/dev/null; then
+  echo "ERROR: aws CLI not found." >&2; exit 1
+fi
+if ! aws sts get-caller-identity >/dev/null 2>&1; then
+  echo "ERROR: AWS credentials not configured. Run 'aws configure' first." >&2; exit 1
+fi
+
+if [ -t 0 ]; then
+  read -r -s -p "Paste Slack ACCESS token (xoxe.xoxp-...): " ACCESS
+  echo
+  read -r -s -p "Paste Slack REFRESH token (xoxe-...): " REFRESH
+  echo
+else
+  echo "ERROR: stdin is not a tty — this script expects interactive paste." >&2
+  exit 1
+fi
+
+if [ -z "$ACCESS" ] || [ -z "$REFRESH" ]; then
+  echo "ERROR: both tokens are required." >&2; exit 1
+fi
+
+case "$ACCESS" in xoxe.xoxp-*) : ;; *) echo "WARN: access token prefix is not xoxe.xoxp- — continuing anyway." >&2 ;; esac
+case "$REFRESH" in xoxe-*) : ;; *) echo "WARN: refresh token prefix is not xoxe- — continuing anyway." >&2 ;; esac
+
+# --- Verify the access token works ---
+echo -n "Verifying access token against Slack apps.manifest.validate ... "
+HTTP=$(curl -s -o /tmp/.slack-probe.json -w "%{http_code}" \
+  -X POST https://slack.com/api/auth.test \
+  -H "Authorization: Bearer $ACCESS")
+if [ "$HTTP" != "200" ]; then
+  echo "FAILED (HTTP $HTTP)"; cat /tmp/.slack-probe.json >&2; rm -f /tmp/.slack-probe.json; exit 1
+fi
+OK=$(jq -r .ok /tmp/.slack-probe.json)
+TEAM=$(jq -r '.team // ""' /tmp/.slack-probe.json)
+rm -f /tmp/.slack-probe.json
+if [ "$OK" != "true" ]; then echo "FAILED (Slack: $(jq -r .error 2>/dev/null))"; exit 1; fi
+echo "ok (team: $TEAM)"
+
+# --- Write both to SSM ---
+echo -n "Writing $PREFIX/SLACK_APP_CONFIG_REFRESH_TOKEN ... "
+aws ssm put-parameter --region "$REGION" \
+  --name "$PREFIX/SLACK_APP_CONFIG_REFRESH_TOKEN" \
+  --type SecureString --value "$REFRESH" --overwrite >/dev/null
+echo "ok"
+
+echo -n "Writing $PREFIX/SLACK_APP_CONFIG_TOKEN ... "
+aws ssm put-parameter --region "$REGION" \
+  --name "$PREFIX/SLACK_APP_CONFIG_TOKEN" \
+  --type SecureString --value "$ACCESS" --overwrite >/dev/null
+echo "ok"
+
+echo
+echo "Done. Next run of slack-manifest-apply.yml will auto-rotate the access"
+echo "token via tooling.tokens.rotate — no further manual steps needed."


### PR DESCRIPTION
Replaces the expired-since-2026-05-15 SLACK_APP_CONFIG_TOKEN GH secret with an SSM-backed rotation flow. One-time seed of access + refresh token pair into SSM, then slack-manifest-apply.yml auto-rotates via Slack tooling.tokens.rotate on every run. Graceful skip when SSM is unseeded. Full reasoning in the commit message.