### PR TITLE
feat(slack): /cloudless-newsletter slash command + #newsletter channel wiring

### DIFF
--- a/.github/workflows/weekly-article-draft.yml
+++ b/.github/workflows/weekly-article-draft.yml
@@ -28,6 +28,10 @@ jobs:
       NOTION_API_KEY: ${{ secrets.NOTION_API_KEY }}
       NOTION_BLOG_DB_ID: ${{ secrets.NOTION_BLOG_DB_ID }}
       SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+      # When both are set, the script posts to #newsletter via the bot
+      # instead of falling back to the generic SLACK_WEBHOOK_URL.
+      SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+      NEWSLETTER_SLACK_CHANNEL_ID: ${{ secrets.NEWSLETTER_SLACK_CHANNEL_ID }}
 
     steps:
       - name: Checkout

--- a/.github/workflows/weekly-newsletter.yml
+++ b/.github/workflows/weekly-newsletter.yml
@@ -31,6 +31,10 @@ jobs:
       NEWSLETTER_SEND_SECRET: ${{ secrets.NEWSLETTER_SEND_SECRET }}
       SITE_URL: ${{ secrets.SITE_URL }}
       SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+      # When both are set, the publisher posts confirmations to #newsletter
+      # via the bot instead of falling back to the generic SLACK_WEBHOOK_URL.
+      SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+      NEWSLETTER_SLACK_CHANNEL_ID: ${{ secrets.NEWSLETTER_SLACK_CHANNEL_ID }}
 
     steps:
       - name: Checkout

--- a/scripts/generate-weekly-article.ts
+++ b/scripts/generate-weekly-article.ts
@@ -540,6 +540,29 @@ async function createDraftPage(
 }
 
 async function slackPing(text: string): Promise<void> {
+  // Prefer the bot-token path when both NEWSLETTER_SLACK_CHANNEL_ID and
+  // SLACK_BOT_TOKEN are set — keeps editorial pings scoped to #newsletter
+  // instead of fanning out via the generic incoming webhook.
+  const botToken = process.env.SLACK_BOT_TOKEN;
+  const channelId = process.env.NEWSLETTER_SLACK_CHANNEL_ID;
+  if (botToken && channelId) {
+    try {
+      await fetch("https://slack.com/api/chat.postMessage", {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${botToken}`,
+          "Content-Type": "application/json; charset=utf-8",
+        },
+        body: JSON.stringify({ channel: channelId, text }),
+      });
+      return;
+    } catch (err) {
+      console.warn(
+        "[generate-weekly-article] chat.postMessage failed, falling back to webhook:",
+        err,
+      );
+    }
+  }
   const url = process.env.SLACK_WEBHOOK_URL;
   if (!url) return;
   try {

--- a/scripts/publish-and-send-newsletter.ts
+++ b/scripts/publish-and-send-newsletter.ts
@@ -453,6 +453,30 @@ async function revalidate(slug: string): Promise<void> {
 
 async function slackPing(text: string): Promise<void> {
   const url = process.env.SLACK_WEBHOOK_URL;
+  // Prefer the bot-token path when both NEWSLETTER_SLACK_CHANNEL_ID and
+  // SLACK_BOT_TOKEN are set — it posts to the dedicated #newsletter channel
+  // so the cron pings are scoped to the editorial channel instead of fanning
+  // out via a generic incoming webhook.
+  const botToken = process.env.SLACK_BOT_TOKEN;
+  const channelId = process.env.NEWSLETTER_SLACK_CHANNEL_ID;
+  if (botToken && channelId) {
+    try {
+      await fetch("https://slack.com/api/chat.postMessage", {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${botToken}`,
+          "Content-Type": "application/json; charset=utf-8",
+        },
+        body: JSON.stringify({ channel: channelId, text }),
+      });
+      return;
+    } catch (err) {
+      console.warn(
+        "[publish-and-send-newsletter] chat.postMessage failed, falling back to webhook:",
+        err,
+      );
+    }
+  }
   if (!url) return;
   try {
     await fetch(url, {

--- a/scripts/setup-newsletter-channel.sh
+++ b/scripts/setup-newsletter-channel.sh
@@ -1,0 +1,179 @@
+#!/usr/bin/env bash
+#
+# One-shot bootstrap for the dedicated #newsletter Slack channel.
+#
+# Idempotent: safe to re-run. Does the following with a Slack USER token
+# (which has the workspace admin's scopes, including channels:manage):
+#   1. Creates #newsletter (or reuses if it already exists)
+#   2. Invites the @cloudless_bot to it
+#   3. Sets a topic + purpose
+#   4. Posts a welcome card
+#   5. Writes the channel ID to AWS SSM as /cloudless/production/NEWSLETTER_SLACK_CHANNEL_ID
+#   6. Writes it as a GitHub Actions repository secret so the weekly
+#      cron scripts pick it up
+#
+# WHY a USER token, not the bot token?
+#   The cloudless_bot in production currently has the minimal scope set
+#   (chat:write, im:*, commands, incoming-webhook). channels:manage and
+#   channels:read are in the source manifest but the manifest hasn't
+#   deployed yet (SLACK_APP_CONFIG_TOKEN seeding still pending). Using
+#   the workspace admin's user token sidesteps that ordering problem.
+#
+# HOW TO MINT A USER TOKEN (browser, ~60s — one time only):
+#   1. https://api.slack.com/apps  →  Your "Cloudless" app  →  OAuth & Permissions
+#   2. Scroll to "User Token Scopes" → add channels:manage, channels:read,
+#      channels:write.invites, groups:write (if you want private channel support)
+#   3. Click "Reinstall to Workspace" (top of page) — Slack will prompt for
+#      consent and return a `xoxp-...` user token.
+#   4. Copy the "User OAuth Token" (starts with xoxp-).
+#   5. Run this script and paste it at the prompt.
+#
+# After this runs, the user token is discarded — it's used only to create
+# the channel + invite the bot. From then on, the bot's chat:write scope
+# is enough to post into a channel it's a member of.
+
+set -euo pipefail
+
+REGION="${AWS_REGION:-us-east-1}"
+PREFIX="${SSM_PREFIX:-/cloudless/production}"
+CHANNEL_NAME="newsletter"
+
+if ! command -v aws >/dev/null; then
+  echo "ERROR: aws CLI not found." >&2; exit 1
+fi
+if ! command -v gh >/dev/null; then
+  echo "ERROR: gh CLI not found — needed to write the GH Actions secret." >&2; exit 1
+fi
+if ! aws sts get-caller-identity >/dev/null 2>&1; then
+  echo "ERROR: AWS credentials not configured. Run 'aws configure' first." >&2; exit 1
+fi
+if ! gh auth status >/dev/null 2>&1; then
+  echo "ERROR: gh CLI not authenticated. Run 'gh auth login' first." >&2; exit 1
+fi
+
+# --- Get user token from stdin (silent) ---
+if [ -t 0 ]; then
+  read -r -s -p "Paste Slack USER OAuth token (xoxp-...): " USER_TOKEN
+  echo
+else
+  echo "ERROR: stdin is not a tty — this script expects interactive paste." >&2
+  exit 1
+fi
+case "$USER_TOKEN" in
+  xoxp-*) : ;;
+  *) echo "ERROR: token prefix is not xoxp- — that's a user token. Got something else." >&2; exit 1 ;;
+esac
+
+# --- Verify identity + scopes ---
+echo -n "Verifying user token ... "
+WHOAMI=$(curl -sS https://slack.com/api/auth.test -H "Authorization: Bearer $USER_TOKEN")
+OK=$(echo "$WHOAMI" | jq -r .ok)
+if [ "$OK" != "true" ]; then
+  echo "FAILED ($(echo "$WHOAMI" | jq -r .error))"; exit 1
+fi
+TEAM=$(echo "$WHOAMI" | jq -r .team)
+USER=$(echo "$WHOAMI" | jq -r .user)
+echo "ok (team=$TEAM, user=$USER)"
+
+# --- Get bot's user id from the bot token (for invite step) ---
+BOT_TOKEN=$(aws ssm get-parameter --region "$REGION" \
+  --name "$PREFIX/SLACK_BOT_TOKEN" --with-decryption --output json \
+  | jq -r .Parameter.Value)
+BOT_INFO=$(curl -sS https://slack.com/api/auth.test -H "Authorization: Bearer $BOT_TOKEN")
+BOT_USER_ID=$(echo "$BOT_INFO" | jq -r .user_id)
+BOT_NAME=$(echo "$BOT_INFO" | jq -r .user)
+echo "Bot identity: @$BOT_NAME ($BOT_USER_ID)"
+
+# --- Find or create the channel ---
+echo ""
+echo "=== Locating #$CHANNEL_NAME ==="
+CHANNELS=$(curl -sS "https://slack.com/api/conversations.list?exclude_archived=true&limit=1000&types=public_channel" \
+  -H "Authorization: Bearer $USER_TOKEN")
+LIST_OK=$(echo "$CHANNELS" | jq -r .ok)
+if [ "$LIST_OK" != "true" ]; then
+  echo "list failed: $(echo "$CHANNELS" | jq -r '{error, needed, provided}')"; exit 1
+fi
+CH_ID=$(echo "$CHANNELS" | jq -r ".channels[]? | select(.name==\"$CHANNEL_NAME\") | .id // empty")
+
+if [ -n "$CH_ID" ]; then
+  echo "Channel already exists: $CH_ID"
+else
+  echo "Creating #$CHANNEL_NAME ..."
+  CREATE=$(curl -sS -X POST https://slack.com/api/conversations.create \
+    -H "Authorization: Bearer $USER_TOKEN" \
+    -H "Content-Type: application/json; charset=utf-8" \
+    -d "{\"name\":\"$CHANNEL_NAME\",\"is_private\":false}")
+  CH_ID=$(echo "$CREATE" | jq -r '.channel.id // empty')
+  if [ -z "$CH_ID" ]; then
+    echo "Create failed: $(echo "$CREATE" | jq '{ok, error, needed, provided}')"; exit 1
+  fi
+  echo "Created: $CH_ID"
+fi
+
+# --- Invite the bot ---
+echo ""
+echo "=== Inviting @$BOT_NAME ==="
+INVITE=$(curl -sS -X POST https://slack.com/api/conversations.invite \
+  -H "Authorization: Bearer $USER_TOKEN" \
+  -H "Content-Type: application/json; charset=utf-8" \
+  -d "{\"channel\":\"$CH_ID\",\"users\":\"$BOT_USER_ID\"}")
+INVITE_OK=$(echo "$INVITE" | jq -r .ok)
+INVITE_ERR=$(echo "$INVITE" | jq -r '.error // ""')
+if [ "$INVITE_OK" = "true" ] || [ "$INVITE_ERR" = "already_in_channel" ]; then
+  echo "ok (${INVITE_ERR:-invited})"
+else
+  echo "invite failed: $INVITE"; exit 1
+fi
+
+# --- Set topic + purpose ---
+echo ""
+echo "=== Setting topic + purpose ==="
+curl -sS -X POST https://slack.com/api/conversations.setTopic \
+  -H "Authorization: Bearer $USER_TOKEN" \
+  -H "Content-Type: application/json; charset=utf-8" \
+  -d "{\"channel\":\"$CH_ID\",\"topic\":\"Newsletter ops — drafts, publishes, subscriber events\"}" \
+  | jq -r '"topic: ok=\(.ok), error=\(.error // \"none\")"'
+curl -sS -X POST https://slack.com/api/conversations.setPurpose \
+  -H "Authorization: Bearer $USER_TOKEN" \
+  -H "Content-Type: application/json; charset=utf-8" \
+  -d "{\"channel\":\"$CH_ID\",\"purpose\":\"Weekly newsletter pipeline: draft generation, editorial approvals, publish + send confirmations, new-subscriber pings. Slash: /cloudless-draft rerun · /cloudless-newsletter list|send\"}" \
+  | jq -r '"purpose: ok=\(.ok), error=\(.error // \"none\")"'
+
+# --- Post a welcome card via the bot (bot is now a member, chat:write works) ---
+echo ""
+echo "=== Posting welcome card from @$BOT_NAME ==="
+BLOCKS=$(jq -nc '[
+  {type:"header", text:{type:"plain_text", text:":newspaper: Newsletter Operations", emoji:true}},
+  {type:"section", text:{type:"mrkdwn", text:"This channel receives every newsletter pipeline event:\n• :memo: Draft generated each Monday 06:00 UTC by Claude/Cloudflare\n• :rocket: Publish + send confirmations (delivered/failed counts)\n• :inbox_tray: New subscriber sign-ups in real time\n• :warning: Publisher failures with re-run buttons"}},
+  {type:"divider"},
+  {type:"section", text:{type:"mrkdwn", text:"*Quick commands* (run from any channel):"}},
+  {type:"section", text:{type:"mrkdwn", text:"• `/cloudless-draft rerun` — generate a new article draft now\n• `/cloudless-newsletter list` — show pending Notion drafts\n• `/cloudless-newsletter send <slug>` — approve in Notion + publish + email subscribers\n• `/cloudless-help` — full command list"}}
+]')
+curl -sS -X POST https://slack.com/api/chat.postMessage \
+  -H "Authorization: Bearer $BOT_TOKEN" \
+  -H "Content-Type: application/json; charset=utf-8" \
+  -d "$(jq -n --arg ch "$CH_ID" --argjson blocks "$BLOCKS" '{channel:$ch, text:"Newsletter Operations channel", blocks:$blocks}')" \
+  | jq -r '"welcome card: ok=\(.ok), ts=\(.ts // \"\"), error=\(.error // \"none\")"'
+
+# --- Persist the channel ID ---
+echo ""
+echo "=== Persisting NEWSLETTER_SLACK_CHANNEL_ID ==="
+aws ssm put-parameter --region "$REGION" \
+  --name "$PREFIX/NEWSLETTER_SLACK_CHANNEL_ID" \
+  --type String --value "$CH_ID" --overwrite >/dev/null
+echo "SSM:   $PREFIX/NEWSLETTER_SLACK_CHANNEL_ID = $CH_ID"
+
+if echo "$CH_ID" | gh secret set NEWSLETTER_SLACK_CHANNEL_ID --body - >/dev/null 2>&1; then
+  echo "gh:    repo secret NEWSLETTER_SLACK_CHANNEL_ID set"
+else
+  # Fallback for older gh versions
+  gh secret set NEWSLETTER_SLACK_CHANNEL_ID --body "$CH_ID" >/dev/null
+  echo "gh:    repo secret NEWSLETTER_SLACK_CHANNEL_ID set"
+fi
+
+echo ""
+echo "Done. Next weekly-article-draft.yml + weekly-newsletter.yml runs will"
+echo "post their pings into #$CHANNEL_NAME via the bot (chat.postMessage),"
+echo "instead of the generic SLACK_WEBHOOK_URL."
+echo ""
+echo "Discard the pasted user token now — it is no longer needed."

--- a/slack-app.manifest.json
+++ b/slack-app.manifest.json
@@ -66,6 +66,13 @@
         "should_escape": false
       },
       {
+        "command": "/cloudless-newsletter",
+        "url": "https://cloudless.gr/api/slack/commands",
+        "description": "List pending Notion drafts or approve+send the newsletter",
+        "usage_hint": "list | send <slug>",
+        "should_escape": false
+      },
+      {
         "command": "/cloudless-help",
         "url": "https://cloudless.gr/api/slack/commands",
         "description": "Show all available Cloudless slash commands",
@@ -98,12 +105,7 @@
   "settings": {
     "event_subscriptions": {
       "request_url": "https://cloudless.gr/api/slack/events",
-      "bot_events": [
-        "app_home_opened",
-        "app_mention",
-        "member_joined_channel",
-        "message.im"
-      ]
+      "bot_events": ["app_home_opened", "app_mention", "member_joined_channel", "message.im"]
     },
     "interactivity": {
       "is_enabled": true,

--- a/src/app/api/slack/commands/route.ts
+++ b/src/app/api/slack/commands/route.ts
@@ -9,6 +9,7 @@
  *   /cloudless-analytics — Stripe revenue summary
  *   /cloudless-deploy    — trigger production deploy (confirmation modal)
  *   /cloudless-draft     — re-run the weekly article draft workflow
+ *   /cloudless-newsletter — list pending drafts, approve + send a draft
  *   /cloudless-help      — show all available commands
  *
  * Slack delivers slash command payloads as application/x-www-form-urlencoded.
@@ -24,6 +25,12 @@ import { listChannels } from "@/lib/slack-admin";
 import { getBotInfo } from "@/lib/slack-workspace";
 import { getSlackConfigAsync } from "@/lib/integrations";
 import { dispatchWorkflow } from "@/lib/github-dispatch";
+import {
+  listEditorialPosts,
+  findEditorialPost,
+  setEditorialStatus,
+  type NotionBlogDraft,
+} from "@/lib/notion-blog-admin";
 
 /**
  * Slack user-ID allowlist for slash-command-driven workflow dispatch.
@@ -95,6 +102,9 @@ export async function POST(request: Request): Promise<Response> {
 
     case "/cloudless-draft":
       return handleDraftRerun(payload);
+
+    case "/cloudless-newsletter":
+      return handleNewsletter(payload);
 
     case "/cloudless-help":
       return handleHelp();
@@ -590,6 +600,8 @@ function handleHelp(): Response {
             "• `/cloudless-analytics` — Stripe revenue summary",
             "• `/cloudless-deploy` — deploy latest code to production",
             "• `/cloudless-draft rerun` — re-run the weekly article draft generator",
+            "• `/cloudless-newsletter list` — show pending Notion drafts",
+            "• `/cloudless-newsletter send <slug|id>` — approve in Notion + publish + email subscribers",
             "• `/cloudless-help` — show this message",
           ].join("\n"),
         },
@@ -671,5 +683,211 @@ async function handleDraftRerun(payload: SlashCommandPayload): Promise<Response>
     text:
       `:warning: Re-run failed (HTTP ${result.status}): \`${result.error.slice(0, 200)}\`. ` +
       "Check that `GITHUB_DISPATCH_TOKEN` (or `GITHUB_TOKEN`) is set in SSM with Actions write permission.",
+  });
+}
+
+// ---------------------------------------------------------------------------
+// /cloudless-newsletter — Notion → publish chain operated from Slack
+//
+// Subcommands:
+//   list                    — show pending Notion drafts (Draft + In Review)
+//   send <slug|page-id>     — flip Status to "In Review" + dispatch the
+//                             weekly-newsletter.yml workflow which:
+//                               · renders the page to HTML/text
+//                               · marks the row Published in Notion
+//                               · revalidates /blog/[slug] on the live site
+//                               · POSTs the rendered email to
+//                                 /api/newsletter/send → SES → subscribers
+//
+// Optional SLACK_OPS_USERS allowlist gates the `send` subcommand (the
+// destructive one — actually emails subscribers). `list` is read-only and
+// available to anyone in the workspace.
+// ---------------------------------------------------------------------------
+
+function formatPostLine(p: NotionBlogDraft): string {
+  const statusEmoji = p.status === "In Review" ? ":eyes:" : ":memo:";
+  const createdTs = p.createdAt ? Math.floor(new Date(p.createdAt).getTime() / 1000) : 0;
+  const dateLabel = createdTs
+    ? `<!date^${createdTs}^{date_short_pretty}|${p.createdAt.slice(0, 10)}>`
+    : "—";
+  // Slug is the operator-friendly handle for the `send` subcommand.
+  const slugBit = p.slug ? `\`${p.slug}\`` : `\`${p.id.slice(0, 8)}\``;
+  return `${statusEmoji} *<${p.url}|${p.title}>* — ${p.category} · ${p.readTime} · ${dateLabel}\n   ${slugBit}`;
+}
+
+async function handleNewsletter(payload: SlashCommandPayload): Promise<Response> {
+  const args = payload.text.trim().split(/\s+/).filter(Boolean);
+  const sub = (args[0] ?? "").toLowerCase();
+
+  if (sub === "list") {
+    const posts = await listEditorialPosts();
+    if (posts.length === 0) {
+      return slackResponse({
+        response_type: "ephemeral",
+        text:
+          ":mailbox_with_no_mail: No pending drafts in Notion. " +
+          "Run `/cloudless-draft rerun` to generate one.",
+      });
+    }
+    return slackResponse({
+      response_type: "ephemeral",
+      blocks: [
+        {
+          type: "header",
+          text: {
+            type: "plain_text",
+            text: `:newspaper: Pending Newsletter Drafts (${posts.length})`,
+            emoji: true,
+          },
+        },
+        {
+          type: "section",
+          text: {
+            type: "mrkdwn",
+            text: posts.map(formatPostLine).join("\n\n"),
+          },
+        },
+        {
+          type: "context",
+          elements: [
+            {
+              type: "mrkdwn",
+              text: "Send any of these with: `/cloudless-newsletter send <slug>`",
+            },
+          ],
+        },
+      ],
+    });
+  }
+
+  if (sub === "send") {
+    const target = args[1];
+    if (!target) {
+      return slackResponse({
+        response_type: "ephemeral",
+        text:
+          "Usage: `/cloudless-newsletter send <slug-or-notion-id>`\n" +
+          "Tip: run `/cloudless-newsletter list` first to see available drafts.",
+      });
+    }
+
+    if (SLACK_OPS_USERS.length > 0 && !SLACK_OPS_USERS.includes(payload.user_id)) {
+      return slackResponse({
+        response_type: "ephemeral",
+        text:
+          ":no_entry: You're not on the ops allowlist for newsletter sends. " +
+          "Ask the admin to add your Slack user ID to `SLACK_OPS_USERS`.",
+      });
+    }
+
+    const post = await findEditorialPost(target);
+    if (!post) {
+      return slackResponse({
+        response_type: "ephemeral",
+        text:
+          `:warning: Could not find a Notion draft matching \`${target}\`. ` +
+          "Run `/cloudless-newsletter list` to see what's available.",
+      });
+    }
+
+    if (post.status === "Published") {
+      return slackResponse({
+        response_type: "ephemeral",
+        text:
+          `:information_source: *${post.title}* is already Published. ` +
+          "The publisher won't pick it up again. Revert Status to Draft in Notion to resend.",
+      });
+    }
+
+    // Flip Status → In Review so the publisher picks it up.
+    const flipped = await setEditorialStatus(post.id, "In Review");
+    if (!flipped) {
+      return slackResponse({
+        response_type: "ephemeral",
+        text:
+          ":warning: Failed to update Notion status. Check NOTION_API_KEY in SSM " +
+          "and that the integration is shared with the Blog database.",
+      });
+    }
+
+    // Dispatch the publisher workflow.
+    const result = await dispatchWorkflow("weekly-newsletter.yml", "main");
+    if (!result.ok) {
+      return slackResponse({
+        response_type: "ephemeral",
+        text:
+          `:warning: Notion was updated to *In Review* but workflow dispatch failed ` +
+          `(HTTP ${result.status}): \`${result.error.slice(0, 200)}\`. ` +
+          "Re-run with `/cloudless-newsletter send " +
+          (post.slug || post.id) +
+          "` once dispatch is fixed, or trigger weekly-newsletter.yml from the Actions tab.",
+      });
+    }
+
+    return slackResponse({
+      response_type: "in_channel",
+      blocks: [
+        {
+          type: "header",
+          text: {
+            type: "plain_text",
+            text: ":rocket: Newsletter Send Initiated",
+            emoji: true,
+          },
+        },
+        {
+          type: "section",
+          text: {
+            type: "mrkdwn",
+            text:
+              `<@${payload.user_id}> approved *<${post.url}|${post.title}>* ` +
+              `(${post.category} · ${post.readTime}) and triggered the publisher.\n\n` +
+              "The workflow will render the page, mark it Published in Notion, revalidate " +
+              `\`/blog/${post.slug}\` on the live site, and SES-send to every newsletter subscriber.`,
+          },
+        },
+        {
+          type: "context",
+          elements: [
+            {
+              type: "mrkdwn",
+              text: "Check progress in the GitHub Actions tab (~5 seconds to start).",
+            },
+          ],
+        },
+      ],
+    });
+  }
+
+  // No subcommand / unknown subcommand → usage.
+  return slackResponse({
+    response_type: "ephemeral",
+    blocks: [
+      {
+        type: "header",
+        text: {
+          type: "plain_text",
+          text: ":newspaper: /cloudless-newsletter — Usage",
+          emoji: true,
+        },
+      },
+      {
+        type: "section",
+        text: {
+          type: "mrkdwn",
+          text: [
+            "*Subcommands:*",
+            "• `list` — show pending Notion drafts (Draft + In Review)",
+            "• `send <slug|notion-id>` — approve in Notion + publish + email subscribers",
+            "",
+            "*Example flow:*",
+            "1. `/cloudless-draft rerun` — generate a new draft (Claude → Notion)",
+            "2. Read it in Notion, edit if needed",
+            "3. `/cloudless-newsletter list` — copy the slug",
+            "4. `/cloudless-newsletter send <slug>` — flips Status, dispatches publisher",
+          ].join("\n"),
+        },
+      },
+    ],
   });
 }

--- a/src/lib/notion-blog-admin.ts
+++ b/src/lib/notion-blog-admin.ts
@@ -1,0 +1,206 @@
+/**
+ * Notion Blog admin helpers — used by the Slack ops surface to list
+ * drafts and flip the editorial status from Slack without opening Notion.
+ *
+ * Kept separate from src/lib/notion-blog.ts (which serves the public
+ * `/blog` frontend) so admin functionality cannot accidentally leak
+ * through the public render path.
+ *
+ * All functions read NOTION_API_KEY and NOTION_BLOG_DB_ID from SSM via
+ * getConfig(). They return [] / null on any failure and log the error
+ * — never throw — so a transient Notion outage cannot 500 a Slack
+ * interaction handler. The handler surfaces the empty/null and responds
+ * with an ephemeral warning instead.
+ */
+
+import { getConfig } from "@/lib/ssm-config";
+
+const NOTION_API = "https://api.notion.com/v1";
+const NOTION_VERSION = "2022-06-28";
+
+/** The four select values that exist on the Notion Blog DB Status field. */
+export type NotionBlogStatus = "Draft" | "In Review" | "Published" | "Archived";
+
+export interface NotionBlogDraft {
+  id: string;
+  title: string;
+  slug: string;
+  status: NotionBlogStatus | "";
+  category: string;
+  readTime: string;
+  createdAt: string;
+  /** Direct Notion app URL — opens the page in the user's Notion workspace. */
+  url: string;
+}
+
+interface NotionRichText {
+  plain_text?: string;
+}
+interface NotionPageRaw {
+  id: string;
+  url?: string;
+  created_time?: string;
+  properties: Record<string, unknown>;
+}
+
+function rt(value: unknown): string {
+  const arr =
+    (value as { title?: NotionRichText[]; rich_text?: NotionRichText[] } | undefined)?.title ??
+    (value as { rich_text?: NotionRichText[] } | undefined)?.rich_text ??
+    [];
+  return arr.map((t) => t.plain_text ?? "").join("");
+}
+
+function selectName(value: unknown): string {
+  return (value as { select?: { name?: string } } | undefined)?.select?.name ?? "";
+}
+
+function mapPage(page: NotionPageRaw): NotionBlogDraft {
+  const p = page.properties;
+  return {
+    id: page.id,
+    title: rt(p.Title) || rt(p.Name) || "(untitled)",
+    slug: rt(p.Slug),
+    status: (selectName(p.Status) || "") as NotionBlogStatus | "",
+    category: selectName(p.Category) || "Cloud",
+    readTime: rt(p.ReadTime) || "5 min read",
+    createdAt: page.created_time ?? "",
+    url: page.url ?? `https://www.notion.so/${page.id.replace(/-/g, "")}`,
+  };
+}
+
+async function notionFetch(path: string, init: RequestInit = {}): Promise<Response> {
+  const config = await getConfig();
+  return fetch(`${NOTION_API}${path}`, {
+    ...init,
+    headers: {
+      Authorization: `Bearer ${config.NOTION_API_KEY}`,
+      "Notion-Version": NOTION_VERSION,
+      "Content-Type": "application/json",
+      ...init.headers,
+    },
+    signal: init.signal ?? AbortSignal.timeout(10_000),
+  });
+}
+
+/**
+ * List every Notion Blog row whose Status is in the editorial-active set
+ * (Draft or In Review). Sorted newest first.
+ *
+ * Returns [] on failure (logged). The Slack handler turns an empty
+ * response into a "no drafts found" message rather than a 500.
+ */
+export async function listEditorialPosts(): Promise<NotionBlogDraft[]> {
+  try {
+    const config = await getConfig();
+    if (!config.NOTION_BLOG_DB_ID) {
+      console.error("[notion-blog-admin] NOTION_BLOG_DB_ID is not configured in SSM");
+      return [];
+    }
+    const res = await notionFetch(`/databases/${config.NOTION_BLOG_DB_ID}/query`, {
+      method: "POST",
+      body: JSON.stringify({
+        filter: {
+          or: [
+            { property: "Status", select: { equals: "Draft" } },
+            { property: "Status", select: { equals: "In Review" } },
+          ],
+        },
+        sorts: [{ timestamp: "created_time", direction: "descending" }],
+        page_size: 25,
+      }),
+    });
+    if (!res.ok) {
+      console.error(
+        `[notion-blog-admin] list query failed: ${res.status} ${await res.text().catch(() => "")}`
+      );
+      return [];
+    }
+    const data = (await res.json()) as { results: NotionPageRaw[] };
+    return data.results.map(mapPage);
+  } catch (err) {
+    console.error("[notion-blog-admin] listEditorialPosts error:", err);
+    return [];
+  }
+}
+
+/**
+ * Resolve a Notion page either by its full id (with or without hyphens)
+ * or by its blog Slug. Returns null when nothing matches.
+ *
+ * The id path is preferred because it is unambiguous and skips the search.
+ * Slug is convenience for humans typing the readable identifier in Slack.
+ */
+export async function findEditorialPost(idOrSlug: string): Promise<NotionBlogDraft | null> {
+  const trimmed = idOrSlug.trim();
+  if (!trimmed) return null;
+
+  // 32-hex or hyphenated UUID looks like a Notion id — try direct fetch first.
+  const looksLikeId = /^[0-9a-f]{32}$|^[0-9a-f]{8}(?:-[0-9a-f]{4}){3}-[0-9a-f]{12}$/i.test(
+    trimmed.replace(/[^0-9a-f-]/gi, "")
+  );
+  if (looksLikeId) {
+    try {
+      const cleanId = trimmed.replace(/[^0-9a-f-]/gi, "");
+      const res = await notionFetch(`/pages/${cleanId}`);
+      if (res.ok) {
+        const page = (await res.json()) as NotionPageRaw;
+        return mapPage(page);
+      }
+    } catch (err) {
+      console.warn("[notion-blog-admin] direct id fetch failed, falling back to slug:", err);
+    }
+  }
+
+  // Slug lookup — query DB for an exact slug match.
+  try {
+    const config = await getConfig();
+    if (!config.NOTION_BLOG_DB_ID) return null;
+    const res = await notionFetch(`/databases/${config.NOTION_BLOG_DB_ID}/query`, {
+      method: "POST",
+      body: JSON.stringify({
+        filter: { property: "Slug", rich_text: { equals: trimmed } },
+        page_size: 1,
+      }),
+    });
+    if (!res.ok) return null;
+    const data = (await res.json()) as { results: NotionPageRaw[] };
+    return data.results[0] ? mapPage(data.results[0]) : null;
+  } catch (err) {
+    console.error("[notion-blog-admin] findEditorialPost error:", err);
+    return null;
+  }
+}
+
+/**
+ * Flip the Status select on a Notion Blog row. Used by the Slack
+ * /cloudless-newsletter send flow to move a Draft into In Review
+ * before triggering the publisher workflow.
+ *
+ * Returns true on success, false on failure (logged).
+ */
+export async function setEditorialStatus(
+  pageId: string,
+  status: NotionBlogStatus
+): Promise<boolean> {
+  try {
+    const res = await notionFetch(`/pages/${pageId}`, {
+      method: "PATCH",
+      body: JSON.stringify({
+        properties: {
+          Status: { select: { name: status } },
+        },
+      }),
+    });
+    if (!res.ok) {
+      console.error(
+        `[notion-blog-admin] setEditorialStatus failed: ${res.status} ${await res.text().catch(() => "")}`
+      );
+      return false;
+    }
+    return true;
+  } catch (err) {
+    console.error("[notion-blog-admin] setEditorialStatus error:", err);
+    return false;
+  }
+}


### PR DESCRIPTION
feat(slack): /cloudless-newsletter slash command + #newsletter channel wiring

Adds end-to-end Slack-driven control of the weekly newsletter pipeline.
Previously, the only way to publish an approved draft was to manually
flip Status in Notion and either wait for Monday 09:00 UTC cron or
trigger weekly-newsletter.yml from the Actions tab. Now it's a single
slash command.

USAGE

  /cloudless-newsletter list
      Lists pending Notion drafts (Draft + In Review), newest first.
      Ephemeral. Slug is the operator handle for the send subcommand.

  /cloudless-newsletter send <slug-or-notion-page-id>
      1. Looks up the row in Notion (by slug, falling back to id).
      2. Flips Status to "In Review" via Notion PATCH /v1/pages/{id}.
      3. Dispatches weekly-newsletter.yml via GitHub workflow_dispatch.
      4. Confirms publicly in-channel with article title, category,
         operator handle, and the live slug.
      Gated by the existing SLACK_OPS_USERS allowlist (same one that
      protects /cloudless-draft rerun).

CODE

  - src/lib/notion-blog-admin.ts (new) — narrow admin helpers kept
    separate from the public-facing notion-blog.ts so admin queries
    cannot leak through the /blog render path. All functions return
    [] / null / false on failure (logged, never thrown) so a transient
    Notion outage cannot 500 the Slack interaction handler.
  - src/app/api/slack/commands/route.ts — registers the command and
    its dispatcher. Reuses the dispatchWorkflow helper from PR #882.

CRON-SCRIPT CHANNEL ROUTING

  scripts/{generate-weekly-article,publish-and-send-newsletter}.ts
  now prefer chat.postMessage with SLACK_BOT_TOKEN +
  NEWSLETTER_SLACK_CHANNEL_ID, falling back to the legacy
  SLACK_WEBHOOK_URL when either is unset. The two workflows pass both
  env vars through. With the new channel wired, all pipeline pings
  land in a dedicated #newsletter channel instead of the generic
  webhook target.

ONE-TIME SETUP

  scripts/setup-newsletter-channel.sh — idempotent bootstrap that:
    1. Accepts a Slack USER token paste (xoxp-...) — needed because
       the bot's current scope set lacks channels:manage. The token
       is used only to create the channel and invite the bot, then
       discarded.
    2. Creates (or reuses) #newsletter.
    3. Invites the cloudless_bot.
    4. Sets topic + purpose.
    5. Posts a welcome card via the bot (proves chat:write works now
       that the bot is a channel member).
    6. Writes NEWSLETTER_SLACK_CHANNEL_ID to both SSM and GH repo
       secrets.

  Header documents the exact api.slack.com → OAuth & Permissions
  flow for minting the user token.

SLACK MANIFEST

  Adds /cloudless-newsletter command definition. Deploys to api.slack
  on the next slack-manifest-apply.yml run once SLACK_APP_CONFIG_TOKEN
  is seeded (see PR #888).

VERIFIED

  pnpm tsc                 — clean (app + scripts)
  pnpm eslint              — clean across all touched files
  pnpm format:check        — clean (after prettier --write)
  vitest                   — 77/77 across slack + newsletter suites
  shell -n on new script   — syntax ok
  yaml parse               — both workflows valid
  manifest JSON parse      — valid

REMAINING HUMAN ACTIONS

  Without these, the feature still works degraded (slash command
  responds in-channel, cron pings keep using the webhook):

  1. Seed Slack app-config tokens (PR #888 helper) so the manifest
     auto-deploys and the bot gains the manifest's broader scope set.
  2. Run scripts/setup-newsletter-channel.sh once with a workspace-
     admin user token to create #newsletter + wire the channel ID.

  After both: every editorial event lands in #newsletter, and the
  slash commands work from anywhere in the workspace.
