### PR TITLE
feat(slack): bot scope channels:join + enable DM tab

### DIFF
--- a/slack-app.manifest.json
+++ b/slack-app.manifest.json
@@ -8,7 +8,7 @@
   "features": {
     "app_home": {
       "home_tab_enabled": true,
-      "messages_tab_enabled": false,
+      "messages_tab_enabled": true,
       "messages_tab_read_only_enabled": false
     },
     "bot_user": {
@@ -85,6 +85,7 @@
     "scopes": {
       "bot": [
         "app_mentions:read",
+        "channels:join",
         "channels:manage",
         "channels:read",
         "channels:write.invites",


### PR DESCRIPTION
Adds channels:join to bot scopes so the bot can join arbitrary public channels (then archive them), and flips messages_tab_enabled=true so it can DM users for personal notifications. Together these address two limitations we hit during the live tidy-up flow this morning. slack-manifest-apply.yml will deploy on push to main.