### PR TITLE
feat(newsletter): full-auto 3-layer quality gates + unpublish command

### DIFF
--- a/.github/workflows/weekly-article-draft.yml
+++ b/.github/workflows/weekly-article-draft.yml
@@ -32,6 +32,10 @@ jobs:
       # instead of falling back to the generic SLACK_WEBHOOK_URL.
       SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
       NEWSLETTER_SLACK_CHANNEL_ID: ${{ secrets.NEWSLETTER_SLACK_CHANNEL_ID }}
+      # Operator Slack user id — when set together with SLACK_BOT_TOKEN
+      # the generator DMs the full gate verdict + critic feedback to the
+      # operator, keeping #newsletter tidy.
+      SLACK_OPS_USER_ID: ${{ secrets.SLACK_OPS_USER_ID }}
 
     steps:
       - name: Checkout

--- a/__tests__/article-quality-gates.test.ts
+++ b/__tests__/article-quality-gates.test.ts
@@ -1,0 +1,171 @@
+/**
+ * Unit tests for scripts/article-quality-gates.ts
+ * Focuses on Layer 1 (deterministic) — Layer 2 (LLM critic) is integration-tested
+ * via the existing publish-and-send-newsletter e2e flow.
+ */
+
+import { describe, it, expect } from "vitest";
+import {
+  countWords,
+  runDeterministicGates,
+  parseCriticJson,
+  WORD_MAX,
+  MIN_H2_COUNT,
+  type DraftInput,
+} from "../scripts/article-quality-gates";
+
+const baseDraft: DraftInput = {
+  title: "How to size your Lambda memory without burning AWS budget",
+  slug: "lambda-memory-sizing-without-burning-budget",
+  excerpt: "A practical guide to right-sizing Lambda memory for cost and latency.",
+  readTime: "9 min read",
+  content:
+    [
+      "## Why memory sizing matters",
+      "Lambda bills you for memory × duration. Picking the right setting is one of the highest-leverage cost levers in serverless.",
+      "## How to measure",
+      "Use Lambda Power Tuning to sweep configurations. Hit each one with realistic traffic, capture P95 latency and cost per 1M invocations.",
+      "## When to choose more memory",
+      "Memory-bound workloads (image processing, in-memory caches) saturate before CPU. The plot of cost vs memory looks U-shaped: sweet spot is the trough.",
+      "## When to choose less",
+      "Glue functions that mostly wait on network calls. Adding memory just adds bill without improving latency.",
+      "## Putting it into practice this week",
+      "Pick your top 3 most-invoked functions. Run Power Tuning. Apply the cheapest setting that holds your P95 SLO. Save the report. Done.",
+    ].join("\n\n") +
+    "\n\n" +
+    "x ".repeat(750),
+};
+
+describe("countWords", () => {
+  it("counts plain words ignoring markdown markers", () => {
+    expect(countWords("# Hello\n\nworld how are you")).toBe(5);
+  });
+  it("strips code blocks", () => {
+    expect(countWords("hello\n```\ncode here\n```\nworld")).toBe(2);
+  });
+  it("strips link target text but keeps anchor", () => {
+    expect(countWords("read [the docs](https://x.com/y) carefully")).toBe(4);
+  });
+});
+
+describe("runDeterministicGates", () => {
+  it("passes a well-formed draft", () => {
+    const r = runDeterministicGates(baseDraft, ["Unrelated old title"], ["other-slug"]);
+    const failed = r.filter((g) => !g.pass);
+    expect(failed).toEqual([]);
+  });
+
+  it("fails word_count when too short", () => {
+    const short = { ...baseDraft, content: "## Tiny\n\nNot enough." };
+    const r = runDeterministicGates(short, [], []);
+    expect(r.find((g) => g.name === "word_count")?.pass).toBe(false);
+  });
+
+  it("fails word_count when too long", () => {
+    const longContent = "## H\n\n" + "word ".repeat(WORD_MAX + 200);
+    const r = runDeterministicGates({ ...baseDraft, content: longContent }, [], []);
+    expect(r.find((g) => g.name === "word_count")?.pass).toBe(false);
+  });
+
+  it("fails structure_h2 when too few H2 sections", () => {
+    const lowStructure = {
+      ...baseDraft,
+      content: "## one\n\n" + "x ".repeat(900),
+    };
+    const r = runDeterministicGates(lowStructure, [], []);
+    const gate = r.find((g) => g.name === "structure_h2");
+    expect(gate?.pass).toBe(false);
+    expect(gate?.detail).toContain(`need ≥ ${MIN_H2_COUNT}`);
+  });
+
+  it("fails slug_unique when slug already in published list", () => {
+    const r = runDeterministicGates(baseDraft, [], [baseDraft.slug]);
+    expect(r.find((g) => g.name === "slug_unique")?.pass).toBe(false);
+  });
+
+  it("catches LLM tells in the body (banned_phrases)", () => {
+    const tell = {
+      ...baseDraft,
+      content: baseDraft.content + "\n\n## conclusion\n\nAs an AI, I cannot give legal advice.",
+    };
+    const r = runDeterministicGates(tell, [], []);
+    const gate = r.find((g) => g.name === "banned_phrases");
+    expect(gate?.pass).toBe(false);
+    expect(gate?.detail).toMatch(/as an ai/);
+  });
+
+  it("catches placeholders in the body", () => {
+    const ph = {
+      ...baseDraft,
+      content: baseDraft.content + "\n\n[insert pricing details here]",
+    };
+    const r = runDeterministicGates(ph, [], []);
+    expect(r.find((g) => g.name === "banned_phrases")?.pass).toBe(false);
+  });
+
+  it("fails title_novelty when title overlaps a recent title heavily", () => {
+    // baseDraft significant tokens (>3 chars): how, size, your, lambda,
+    // memory, without, burning, budget — 8 distinct. The duplicate below
+    // shares 7 of them: size, your, lambda, memory, without, burning,
+    // budget → overlap = 7/8 = 87.5%, above the 75% threshold.
+    const dup = "Size your Lambda memory without burning your budget guide";
+    const r = runDeterministicGates(baseDraft, [dup], []);
+    expect(r.find((g) => g.name === "title_novelty")?.pass).toBe(false);
+  });
+
+  it("passes title_novelty for genuinely different titles", () => {
+    const r = runDeterministicGates(baseDraft, ["A different topic about VPC peering"], []);
+    expect(r.find((g) => g.name === "title_novelty")?.pass).toBe(true);
+  });
+
+  it("fails forbidden_topics for off-brand subjects", () => {
+    const crypto = { ...baseDraft, title: "Why bitcoin will hit 200k" };
+    const r = runDeterministicGates(crypto, [], []);
+    expect(r.find((g) => g.name === "forbidden_topics")?.pass).toBe(false);
+  });
+});
+
+describe("parseCriticJson", () => {
+  it("parses strict JSON", () => {
+    const raw = JSON.stringify({
+      scores: {
+        factual_credibility: 8,
+        brand_voice: 7,
+        structure: 8,
+        originality: 7,
+        technical_accuracy: 9,
+      },
+      overall: 7.8,
+      verdict: "pass",
+      issues: [],
+    });
+    const r = parseCriticJson(raw);
+    expect(r.verdict).toBe("pass");
+    expect(r.overall).toBe(7.8);
+  });
+
+  it("recovers JSON wrapped in prose", () => {
+    const raw =
+      "Sure! Here is my review:\n\n```json\n" +
+      JSON.stringify({
+        scores: {
+          factual_credibility: 5,
+          brand_voice: 6,
+          structure: 7,
+          originality: 5,
+          technical_accuracy: 6,
+        },
+        overall: 5.8,
+        verdict: "revise",
+        issues: ["claim about S3 pricing is wrong", "intro buries the lede"],
+      }) +
+      "\n```\n\nLet me know if you need anything else.";
+    const r = parseCriticJson(raw);
+    expect(r.verdict).toBe("revise");
+    expect(r.issues.length).toBe(2);
+  });
+
+  it("throws cleanly on total garbage", () => {
+    expect(() => parseCriticJson("just some prose, no braces here at all")).toThrow();
+  });
+});

--- a/scripts/article-quality-gates.ts
+++ b/scripts/article-quality-gates.ts
@@ -1,0 +1,419 @@
+/**
+ * Quality gates for AI-generated newsletter drafts.
+ *
+ * Layer 1 — Deterministic gates (cheap, fast, hard-fail):
+ *   • Word count within configured bounds
+ *   • Structural minimums (≥1 H1, ≥4 H2s)
+ *   • Slug uniqueness vs recent posts
+ *   • Banned phrases (LLM tells, placeholders, low-quality patterns)
+ *   • Title novelty (word-overlap vs last N titles)
+ *
+ * Layer 2 — LLM critic (a second model judges the article):
+ *   • Cloudflare Workers AI llama-3.1-8b returns JSON scores
+ *   • Pass threshold: verdict=pass AND overall ≥ MIN_CRITIC_SCORE
+ *   • Hallucination guard: critic explicitly checks factual plausibility
+ *
+ * Combined output drives the auto-promote decision in
+ * scripts/generate-weekly-article.ts:
+ *   verdict=auto-promote → Notion Status flips to "In Review" automatically;
+ *                          Monday 09:00 UTC cron sends without human input
+ *   verdict=needs-review → Notion Status stays "Draft"; operator gets DM
+ *                          with all reasons and the critic's issue list
+ *
+ * Self-contained: reads no src/lib/* (kept as a sibling script module so
+ * the cron tooling stays portable).
+ *
+ * References:
+ *   https://docs.slack.dev (just for token wiring patterns, not used here)
+ *   https://developers.cloudflare.com/workers-ai/configuration/json-mode/
+ *   https://pdpspectra.com/blog/llm-safety-guardrails-2026/
+ */
+
+// ── Thresholds (single source of truth) ─────────────────────────────────────
+
+export const WORD_MIN = 700; // brand-voice prompt asks 800–1200; allow some slack
+export const WORD_MAX = 1400;
+export const MIN_H2_COUNT = 3; // brand-voice prompt asks 4–6
+export const MAX_TITLE_OVERLAP = 0.75; // 75% word overlap with a recent title = too similar
+export const MIN_CRITIC_SCORE = 7.0; // overall avg out of 10 to auto-promote
+
+// Phrases that signal the model leaked metadata, refused, or shipped a template.
+// Kept short and high-signal — false positives here block legitimate articles.
+const BANNED_PHRASES: ReadonlyArray<string> = [
+  "as an ai",
+  "as a language model",
+  "i cannot",
+  "i can't help",
+  "i'm sorry, but",
+  "i don't have access",
+  "<placeholder",
+  "[insert ",
+  "lorem ipsum",
+  "todo:",
+  "fixme",
+  "click here", // weak CTA per brand-voice guide
+  "in conclusion,",
+  "in this blog post",
+  "in today's fast-paced",
+];
+
+// Topic terms we want a human to look at before publishing.
+// Designed for cloudless.gr's audience — adjust if you ever broaden scope.
+const FORBIDDEN_TOPIC_PATTERNS: ReadonlyArray<RegExp> = [
+  /\b(trump|biden|harris|election|war in (ukraine|gaza|israel))\b/i,
+  /\b(crypto|bitcoin|ethereum|nft)\b/i, // off-brand
+  /\bcompetitor\b/i, // catches LLM accidentally naming competitors
+];
+
+// ── Layer 1: deterministic gates ────────────────────────────────────────────
+
+export interface DraftInput {
+  title: string;
+  slug: string;
+  excerpt: string;
+  readTime: string;
+  content: string;
+}
+
+export interface GateResult {
+  name: string;
+  pass: boolean;
+  detail?: string;
+}
+
+/** Strip markdown to get plain words for counting + scanning. */
+function stripMarkdown(md: string): string {
+  return md
+    .replace(/```[\s\S]*?```/g, " ") // code blocks
+    .replace(/`[^`]*`/g, " ") // inline code
+    .replace(/\[([^\]]+)\]\([^)]+\)/g, "$1") // [text](url) → text
+    .replace(/[#*_>~-]/g, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+export function countWords(md: string): number {
+  const plain = stripMarkdown(md);
+  if (!plain) return 0;
+  return plain.split(/\s+/).filter(Boolean).length;
+}
+
+/** Levenshtein-adjacent overlap: fraction of normalised tokens in `a` also in `b`. */
+function tokenOverlap(a: string, b: string): number {
+  const norm = (s: string) =>
+    new Set(
+      s
+        .toLowerCase()
+        .replace(/[^a-z0-9\s]/g, " ")
+        .split(/\s+/)
+        .filter((w) => w.length > 3)
+    );
+  const A = norm(a);
+  const B = norm(b);
+  if (A.size === 0 || B.size === 0) return 0;
+  let overlap = 0;
+  for (const w of A) if (B.has(w)) overlap++;
+  return overlap / Math.max(A.size, B.size);
+}
+
+/** Find banned phrases anywhere in the lowercased article body. */
+function scanBannedPhrases(text: string): string[] {
+  const lower = text.toLowerCase();
+  return BANNED_PHRASES.filter((p) => lower.includes(p));
+}
+
+function scanForbiddenTopics(text: string): string[] {
+  const matches: string[] = [];
+  for (const re of FORBIDDEN_TOPIC_PATTERNS) {
+    const m = re.exec(text);
+    if (m) matches.push(m[0]);
+  }
+  return matches;
+}
+
+/**
+ * Run all Layer 1 gates synchronously. Returns one GateResult per gate so
+ * the Slack notification can show the exact reason a draft was held back.
+ */
+export function runDeterministicGates(
+  draft: DraftInput,
+  recentTitles: ReadonlyArray<string>,
+  existingSlugs: ReadonlyArray<string>
+): GateResult[] {
+  const results: GateResult[] = [];
+
+  // Word count
+  const words = countWords(draft.content);
+  results.push({
+    name: "word_count",
+    pass: words >= WORD_MIN && words <= WORD_MAX,
+    detail: `${words} words (need ${WORD_MIN}–${WORD_MAX})`,
+  });
+
+  // Structure: count H2s. The brand prompt embeds "## " sections.
+  const h2Count = (draft.content.match(/^##\s+\S/gm) ?? []).length;
+  results.push({
+    name: "structure_h2",
+    pass: h2Count >= MIN_H2_COUNT,
+    detail: `${h2Count} H2 sections (need ≥ ${MIN_H2_COUNT})`,
+  });
+
+  // Slug uniqueness
+  const slugTaken = existingSlugs.includes(draft.slug);
+  results.push({
+    name: "slug_unique",
+    pass: !slugTaken,
+    detail: slugTaken ? `slug "${draft.slug}" already published` : draft.slug,
+  });
+
+  // Banned phrases (scans title + excerpt + content)
+  const haystack = `${draft.title}\n${draft.excerpt}\n${draft.content}`;
+  const banned = scanBannedPhrases(haystack);
+  results.push({
+    name: "banned_phrases",
+    pass: banned.length === 0,
+    detail: banned.length > 0 ? `found: ${banned.join(", ")}` : "none",
+  });
+
+  // Title novelty (word-overlap, fast Levenshtein substitute)
+  const overlaps = recentTitles
+    .map((t) => ({ t, score: tokenOverlap(draft.title, t) }))
+    .filter((x) => x.score >= MAX_TITLE_OVERLAP);
+  results.push({
+    name: "title_novelty",
+    pass: overlaps.length === 0,
+    detail:
+      overlaps.length > 0
+        ? `${(overlaps[0].score * 100).toFixed(0)}% overlap with "${overlaps[0].t}"`
+        : "fresh angle",
+  });
+
+  // Forbidden topics
+  const forbidden = scanForbiddenTopics(haystack);
+  results.push({
+    name: "forbidden_topics",
+    pass: forbidden.length === 0,
+    detail: forbidden.length > 0 ? `matched: ${forbidden.join(", ")}` : "none",
+  });
+
+  return results;
+}
+
+// ── Layer 2: LLM critic ─────────────────────────────────────────────────────
+
+const CRITIC_MODEL = "@cf/meta/llama-3.1-8b-instruct-fast";
+
+export interface CriticResponse {
+  scores: {
+    factual_credibility: number;
+    brand_voice: number;
+    structure: number;
+    originality: number;
+    technical_accuracy: number;
+  };
+  overall: number;
+  verdict: "pass" | "revise";
+  issues: string[];
+}
+
+const CRITIC_SYSTEM_PROMPT = `You are a senior editor at Cloudless, a cloud consulting and AI marketing firm in Greece serving startups and SMBs across the EU. You judge AI-drafted articles before they go to a paid newsletter and to a public /blog page.
+
+Score each draft 1–10 across five dimensions:
+- factual_credibility: facts, numbers, named services — plausible and verifiable, NO obvious hallucinations?
+- brand_voice: direct, practical, no buzzword soup, no hedging, no hype, EU sensibility?
+- structure: hooks the problem first; ≥4 H2 sections; ends with one concrete actionable next step?
+- originality: not a generic listicle, not a rehash of obvious points, a specific angle?
+- technical_accuracy: AWS/serverless/AI claims technically accurate to a competent engineer reading it?
+
+Be strict. A score of 7 means "good enough to publish if nothing else is wrong". 8+ is meaningfully better.
+
+OUTPUT STRICT JSON only, no prose:
+{
+  "scores": {"factual_credibility": N, "brand_voice": N, "structure": N, "originality": N, "technical_accuracy": N},
+  "overall": <unweighted mean of the five scores, one decimal>,
+  "verdict": "pass" or "revise",
+  "issues": ["short, specific feedback", ...]
+}
+
+verdict=pass only if every score is ≥ 6 AND overall is ≥ 7.0. Otherwise verdict=revise.`;
+
+interface CfResponse {
+  result?: { response?: unknown };
+  errors?: { message?: string }[];
+  success?: boolean;
+}
+
+function articleSchema() {
+  return {
+    type: "object",
+    properties: {
+      scores: {
+        type: "object",
+        properties: {
+          factual_credibility: { type: "number" },
+          brand_voice: { type: "number" },
+          structure: { type: "number" },
+          originality: { type: "number" },
+          technical_accuracy: { type: "number" },
+        },
+        required: [
+          "factual_credibility",
+          "brand_voice",
+          "structure",
+          "originality",
+          "technical_accuracy",
+        ],
+        additionalProperties: false,
+      },
+      overall: { type: "number" },
+      verdict: { type: "string", enum: ["pass", "revise"] },
+      issues: { type: "array", items: { type: "string" } },
+    },
+    required: ["scores", "overall", "verdict", "issues"],
+    additionalProperties: false,
+  } as const;
+}
+
+/**
+ * Robust JSON parser tolerant of prose-wrapped model output.
+ * Tries strict parse first, then extracts the largest `{...}` block.
+ */
+export function parseCriticJson(raw: string): CriticResponse {
+  const attempt = (s: string): CriticResponse => JSON.parse(s) as CriticResponse;
+  try {
+    return attempt(raw);
+  } catch {
+    const start = raw.indexOf("{");
+    const end = raw.lastIndexOf("}");
+    if (start !== -1 && end > start) {
+      try {
+        return attempt(raw.slice(start, end + 1));
+      } catch (err2) {
+        throw new Error(`Critic output not parseable. Raw: ${raw.slice(0, 300)}`, { cause: err2 });
+      }
+    }
+    throw new Error(`Critic output had no JSON. Raw: ${raw.slice(0, 300)}`);
+  }
+}
+
+/**
+ * Calls Cloudflare Workers AI with the critic prompt + the draft body.
+ * Returns the parsed critic response. Throws on any HTTP / parse failure
+ * — caller decides whether to gate-fail or auto-promote on uncertainty.
+ */
+export async function runLLMCritic(
+  accountId: string,
+  apiToken: string,
+  draft: DraftInput
+): Promise<CriticResponse> {
+  const userMessage = [
+    `TITLE: ${draft.title}`,
+    `EXCERPT: ${draft.excerpt}`,
+    `READ TIME: ${draft.readTime}`,
+    "",
+    "CONTENT:",
+    draft.content,
+  ].join("\n");
+
+  const res = await fetch(
+    `https://api.cloudflare.com/client/v4/accounts/${accountId}/ai/run/${CRITIC_MODEL}`,
+    {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${apiToken}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        messages: [
+          { role: "system", content: CRITIC_SYSTEM_PROMPT },
+          { role: "user", content: userMessage },
+        ],
+        max_tokens: 1024,
+        response_format: {
+          type: "json_schema",
+          json_schema: { name: "critic", schema: articleSchema(), strict: true },
+        },
+      }),
+      signal: AbortSignal.timeout(30_000),
+    }
+  );
+
+  if (!res.ok) {
+    throw new Error(
+      `Critic Cloudflare call failed: ${res.status} ${await res.text().catch(() => "")}`
+    );
+  }
+
+  const data = (await res.json()) as CfResponse;
+  if (!data.success) {
+    throw new Error(
+      `Cloudflare Workers AI rejected critic: ${data.errors?.[0]?.message ?? "unknown"}`
+    );
+  }
+  const raw = data.result?.response;
+  const text = typeof raw === "string" ? raw : raw == null ? "" : JSON.stringify(raw);
+  return parseCriticJson(text);
+}
+
+// ── Combined verdict ─────────────────────────────────────────────────────────
+
+export type AutoPromoteVerdict =
+  | { promote: true; gates: GateResult[]; critic: CriticResponse }
+  | {
+      promote: false;
+      reason: "deterministic" | "critic" | "critic_unavailable";
+      gates: GateResult[];
+      critic?: CriticResponse;
+      criticError?: string;
+    };
+
+export interface RunGatesInput {
+  draft: DraftInput;
+  recentTitles: ReadonlyArray<string>;
+  existingSlugs: ReadonlyArray<string>;
+  cloudflareAccountId: string | undefined;
+  cloudflareApiToken: string | undefined;
+}
+
+/**
+ * Run all gates and produce a single verdict.
+ *
+ * Decision tree:
+ *   1. If ANY deterministic gate fails → promote=false, reason="deterministic"
+ *   2. Else if critic credentials are missing → promote=false, reason="critic_unavailable"
+ *      (we refuse to auto-promote without a second opinion)
+ *   3. Else run critic:
+ *      - critic throws → promote=false, reason="critic_unavailable", criticError
+ *      - critic verdict=revise OR overall<MIN_CRITIC_SCORE → promote=false, reason="critic"
+ *      - otherwise → promote=true
+ */
+export async function runGates(input: RunGatesInput): Promise<AutoPromoteVerdict> {
+  const gates = runDeterministicGates(input.draft, input.recentTitles, input.existingSlugs);
+
+  const failedGates = gates.filter((g) => !g.pass);
+  if (failedGates.length > 0) {
+    return { promote: false, reason: "deterministic", gates };
+  }
+
+  if (!input.cloudflareAccountId || !input.cloudflareApiToken) {
+    return { promote: false, reason: "critic_unavailable", gates };
+  }
+
+  let critic: CriticResponse;
+  try {
+    critic = await runLLMCritic(input.cloudflareAccountId, input.cloudflareApiToken, input.draft);
+  } catch (err) {
+    return {
+      promote: false,
+      reason: "critic_unavailable",
+      gates,
+      criticError: (err as Error)?.message ?? String(err),
+    };
+  }
+
+  if (critic.verdict !== "pass" || critic.overall < MIN_CRITIC_SCORE) {
+    return { promote: false, reason: "critic", gates, critic };
+  }
+
+  return { promote: true, gates, critic };
+}

--- a/scripts/generate-weekly-article.ts
+++ b/scripts/generate-weekly-article.ts
@@ -41,7 +41,19 @@
  * Exit codes:
  *   0  draft created (or Slack-pinged failure that we want to surface)
  *   1  hard failure (config error, Anthropic/Notion API down, bad JSON)
+ *
+ * Quality gates (Layer 1 + Layer 2 — see scripts/article-quality-gates.ts):
+ *   After generation we run deterministic gates (word count, structure,
+ *   slug uniqueness, banned phrases, title novelty, forbidden topics) and
+ *   an LLM critic (Cloudflare llama-3.1-8b). If ALL gates pass AND the
+ *   critic verdict is "pass" with overall ≥ 7.0, the draft is inserted as
+ *   Status="In Review" — this is the auto-promote path; the Monday 09:00
+ *   UTC publisher cron sends it without any human touch. Otherwise the
+ *   draft is inserted as Status="Draft" and the operator is DM'd with the
+ *   exact reasons + critic feedback.
  */
+
+import { runGates, type AutoPromoteVerdict } from "./article-quality-gates";
 
 const NOTION_API = "https://api.notion.com/v1";
 const NOTION_VERSION = "2022-06-28";
@@ -67,6 +79,7 @@ export interface RecentPost {
   category: Category;
   /** ISO date the publisher set, falls back to created_time */
   date: string;
+  slug: string;
 }
 
 async function notionFetch(path: string, init: RequestInit = {}): Promise<Response> {
@@ -107,7 +120,8 @@ async function fetchRecentPosts(): Promise<RecentPost[]> {
     const title = (p.Title?.title ?? p.Name?.title ?? []).map((t) => t.plain_text ?? "").join("");
     const cat = (p.Category?.select?.name ?? "Cloud") as Category;
     const date = p.PublishedAt?.date?.start ?? p.Date?.date?.start ?? page.created_time ?? "";
-    return { title, category: cat, date };
+    const slug = (p.Slug?.rich_text ?? []).map((t) => t.plain_text ?? "").join("");
+    return { title, category: cat, date, slug };
   });
 }
 
@@ -456,7 +470,8 @@ function numberedBlock(text: string): NotionBlock {
 
 async function createDraftPage(
   article: GeneratedArticle,
-  category: Category
+  category: Category,
+  initialStatus: "Draft" | "In Review" = "Draft"
 ): Promise<{ id: string; url: string }> {
   const dbId = requireEnv("NOTION_BLOG_DB_ID");
   const blocks = markdownToNotionBlocks(article.content);
@@ -474,7 +489,7 @@ async function createDraftPage(
         Slug: { rich_text: [{ text: { content: article.slug } }] },
         Excerpt: { rich_text: [{ text: { content: article.excerpt } }] },
         Category: { select: { name: category } },
-        Status: { select: { name: "Draft" } },
+        Status: { select: { name: initialStatus } },
         // Notion DB schema notes (verified 2026-06-14):
         //   - "Read Time" has a space; the script previously wrote `ReadTime`.
         //   - "Author" is a People property — cannot be set to a string from
@@ -508,6 +523,65 @@ async function createDraftPage(
     }
   }
   return created;
+}
+
+/**
+ * Direct-message the operator (bot DM). Best path for "needs your eyes"
+ * notifications — bypasses #newsletter noise. Requires SLACK_BOT_TOKEN and
+ * SLACK_OPS_USER_ID; both must be set in the cron secrets. Falls back to a
+ * regular slackPing if either is missing.
+ */
+async function slackDM(text: string): Promise<void> {
+  const botToken = process.env.SLACK_BOT_TOKEN;
+  const userId = process.env.SLACK_OPS_USER_ID;
+  if (!botToken || !userId) {
+    await slackPing(text);
+    return;
+  }
+  try {
+    // conversations.open is idempotent — returns the existing DM channel id.
+    const open = await fetch("https://slack.com/api/conversations.open", {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${botToken}`,
+        "Content-Type": "application/json; charset=utf-8",
+      },
+      body: JSON.stringify({ users: userId }),
+    });
+    const openData = (await open.json().catch(() => ({}))) as {
+      ok?: boolean;
+      channel?: { id?: string };
+      error?: string;
+    };
+    const dmCh = openData.channel?.id;
+    if (!openData.ok || !dmCh) {
+      console.warn(
+        `[generate-weekly-article] conversations.open failed (${openData.error}), falling back to channel ping`
+      );
+      await slackPing(text);
+      return;
+    }
+    const r = await fetch("https://slack.com/api/chat.postMessage", {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${botToken}`,
+        "Content-Type": "application/json; charset=utf-8",
+      },
+      body: JSON.stringify({ channel: dmCh, text }),
+    });
+    const data = (await r.json().catch(() => ({}))) as { ok?: boolean; error?: string };
+    if (data.ok) {
+      console.log("[generate-weekly-article] DM sent to operator");
+      return;
+    }
+    console.warn(
+      `[generate-weekly-article] DM rejected (${data.error}), falling back to channel ping`
+    );
+    await slackPing(text);
+  } catch (err) {
+    console.warn("[generate-weekly-article] DM failed, falling back to channel ping:", err);
+    await slackPing(text);
+  }
 }
 
 async function slackPing(text: string): Promise<void> {
@@ -563,11 +637,44 @@ async function slackPing(text: string): Promise<void> {
   }
 }
 
+function formatVerdict(verdict: AutoPromoteVerdict): string {
+  const lines: string[] = [];
+  lines.push("*Layer 1 — deterministic gates*");
+  for (const g of verdict.gates) {
+    const tick = g.pass ? ":white_check_mark:" : ":x:";
+    lines.push(`  ${tick} \`${g.name}\` — ${g.detail ?? ""}`);
+  }
+  if ("critic" in verdict && verdict.critic) {
+    const c = verdict.critic;
+    lines.push("");
+    lines.push("*Layer 2 — LLM critic*");
+    lines.push(`  overall: *${c.overall.toFixed(1)}/10* · verdict: \`${c.verdict}\``);
+    lines.push(
+      `  scores: factual=${c.scores.factual_credibility}, voice=${c.scores.brand_voice}, structure=${c.scores.structure}, originality=${c.scores.originality}, tech=${c.scores.technical_accuracy}`
+    );
+    if (c.issues.length > 0) {
+      lines.push(
+        `  issues: ${c.issues
+          .slice(0, 5)
+          .map((i) => `_${i}_`)
+          .join("; ")}`
+      );
+    }
+  }
+  if (!verdict.promote && verdict.reason === "critic_unavailable") {
+    lines.push("");
+    lines.push("*Layer 2 — LLM critic*");
+    lines.push(`  :warning: skipped (${verdict.criticError ?? "credentials missing"})`);
+  }
+  return lines.join("\n");
+}
+
 async function main(): Promise<void> {
   console.log("[generate-weekly-article] starting");
   const recent = await fetchRecentPosts();
   const category = pickLruCategory(recent);
   const avoidTitles = recent.slice(0, 8).map((p) => p.title);
+  const existingSlugs = recent.map((p) => p.slug).filter(Boolean);
   console.log(
     `[generate-weekly-article] picked category=${category}; avoiding ${avoidTitles.length} recent titles`
   );
@@ -575,12 +682,58 @@ async function main(): Promise<void> {
   const article = await generateArticle(category, avoidTitles);
   console.log(`[generate-weekly-article] generated: "${article.title}" (${article.slug})`);
 
-  const page = await createDraftPage(article, category);
-  console.log(`[generate-weekly-article] draft created: ${page.url}`);
+  // Run quality gates BEFORE creating the Notion page so we know which
+  // Status to insert with. This avoids needing a second PATCH after-create.
+  console.log("[generate-weekly-article] running quality gates...");
+  const verdict = await runGates({
+    draft: {
+      title: article.title,
+      slug: article.slug,
+      excerpt: article.excerpt,
+      readTime: article.readTime,
+      content: article.content,
+    },
+    recentTitles: avoidTitles,
+    existingSlugs,
+    cloudflareAccountId: process.env.CLOUDFLARE_ACCOUNT_ID,
+    cloudflareApiToken: process.env.CLOUDFLARE_API_TOKEN,
+  });
 
-  await slackPing(
-    `:newspaper: Weekly draft ready for review (${category}): *${article.title}*\n${page.url}\n\nApprove in Notion before Mon 09:00 UTC to publish + send newsletter.`
+  const initialStatus = verdict.promote ? "In Review" : "Draft";
+  console.log(
+    `[generate-weekly-article] gates verdict: ${verdict.promote ? "AUTO-PROMOTE" : `HOLD (${verdict.reason})`} — Notion Status will be "${initialStatus}"`
   );
+
+  const page = await createDraftPage(article, category, initialStatus);
+  console.log(`[generate-weekly-article] page created: ${page.url}`);
+
+  // Channel ping (visible to everyone in #newsletter)
+  const headline = verdict.promote
+    ? `:rocket: *AUTO-PROMOTED* — Weekly draft passed all gates, will publish + send Mon 09:00 UTC.`
+    : `:eyes: *NEEDS REVIEW* — Weekly draft created but did NOT auto-pass quality gates.`;
+  const channelMsg = `${headline}\n\n*${article.title}* — ${category} · ${article.readTime}\n${page.url}`;
+  await slackPing(channelMsg);
+
+  // Direct DM the operator the full verdict so the channel stays tidy.
+  const dmBody = [
+    headline,
+    "",
+    `*${article.title}*`,
+    `_${article.excerpt}_`,
+    `${category} · ${article.readTime} · slug \`${article.slug}\``,
+    page.url,
+    "",
+    formatVerdict(verdict),
+    "",
+    verdict.promote
+      ? ":information_source: No action needed. To cancel, flip Notion Status to `Archived` before Mon 09:00 UTC, or run `/cloudless-newsletter unpublish " +
+        article.slug +
+        "` after send."
+      : ":pencil2: To approve manually: open the Notion page, edit if needed, flip Status to `In Review`. The publisher will pick it up on Mon 09:00 UTC OR you can run `/cloudless-newsletter send " +
+        article.slug +
+        "` to send immediately.",
+  ].join("\n");
+  await slackDM(dmBody);
 }
 
 // Only auto-run when invoked directly (skip during vitest imports).

--- a/slack-app.manifest.json
+++ b/slack-app.manifest.json
@@ -68,8 +68,8 @@
       {
         "command": "/cloudless-newsletter",
         "url": "https://cloudless.gr/api/slack/commands",
-        "description": "List pending Notion drafts or approve+send the newsletter",
-        "usage_hint": "list | send <slug>",
+        "description": "List drafts, approve+send a newsletter, or emergency-unpublish",
+        "usage_hint": "list | send <slug> | unpublish <slug>",
         "should_escape": false
       },
       {

--- a/src/app/api/slack/commands/route.ts
+++ b/src/app/api/slack/commands/route.ts
@@ -602,6 +602,7 @@ function handleHelp(): Response {
             "• `/cloudless-draft rerun` — re-run the weekly article draft generator",
             "• `/cloudless-newsletter list` — show pending Notion drafts",
             "• `/cloudless-newsletter send <slug|id>` — approve in Notion + publish + email subscribers",
+            "• `/cloudless-newsletter unpublish <slug|id>` — emergency rollback: flip Status=Archived",
             "• `/cloudless-help` — show this message",
           ].join("\n"),
         },
@@ -760,6 +761,64 @@ async function handleNewsletter(payload: SlashCommandPayload): Promise<Response>
     });
   }
 
+  if (sub === "unpublish") {
+    const target = args[1];
+    if (!target) {
+      return slackResponse({
+        response_type: "ephemeral",
+        text:
+          "Usage: `/cloudless-newsletter unpublish <slug-or-notion-id>`\n" +
+          "Flips Notion Status to `Archived`. The post stops being indexed on the public blog. " +
+          "Use this for emergency rollback of a misfired auto-promoted article. " +
+          "Allowlist applies (only `SLACK_OPS_USERS` can run this).",
+      });
+    }
+
+    if (SLACK_OPS_USERS.length > 0 && !SLACK_OPS_USERS.includes(payload.user_id)) {
+      return slackResponse({
+        response_type: "ephemeral",
+        text: ":no_entry: You're not on the ops allowlist. Ask the admin to add your user ID to `SLACK_OPS_USERS`.",
+      });
+    }
+
+    const post = await findEditorialPost(target);
+    if (!post) {
+      return slackResponse({
+        response_type: "ephemeral",
+        text: `:warning: Could not find a Notion post matching \`${target}\`.`,
+      });
+    }
+
+    const flipped = await setEditorialStatus(post.id, "Archived");
+    if (!flipped) {
+      return slackResponse({
+        response_type: "ephemeral",
+        text: ":warning: Failed to update Notion. Check NOTION_API_KEY in SSM.",
+      });
+    }
+
+    return slackResponse({
+      response_type: "in_channel",
+      blocks: [
+        {
+          type: "header",
+          text: { type: "plain_text", text: ":wastebasket: Newsletter Unpublished", emoji: true },
+        },
+        {
+          type: "section",
+          text: {
+            type: "mrkdwn",
+            text:
+              `<@${payload.user_id}> flipped *<${post.url}|${post.title}>* to Notion Status=\`Archived\`.\n\n` +
+              `\`/blog/${post.slug}\` will start returning 404 within the next ISR cycle (5 min). ` +
+              `The email is already in subscriber inboxes — nothing the API can do about that. ` +
+              `If correction is needed, send a corrigendum via \`/cloudless-newsletter send\` for a fresh draft.`,
+          },
+        },
+      ],
+    });
+  }
+
   if (sub === "send") {
     const target = args[1];
     if (!target) {
@@ -879,12 +938,14 @@ async function handleNewsletter(payload: SlashCommandPayload): Promise<Response>
             "*Subcommands:*",
             "• `list` — show pending Notion drafts (Draft + In Review)",
             "• `send <slug|notion-id>` — approve in Notion + publish + email subscribers",
+            "• `unpublish <slug|notion-id>` — emergency rollback (flip Status=Archived)",
             "",
             "*Example flow:*",
             "1. `/cloudless-draft rerun` — generate a new draft (Claude → Notion)",
-            "2. Read it in Notion, edit if needed",
-            "3. `/cloudless-newsletter list` — copy the slug",
-            "4. `/cloudless-newsletter send <slug>` — flips Status, dispatches publisher",
+            "2. Quality gates auto-promote to `In Review` if they pass",
+            "3. `/cloudless-newsletter list` — see pending drafts",
+            "4. `/cloudless-newsletter send <slug>` — manual publish + send",
+            "5. `/cloudless-newsletter unpublish <slug>` — kill a misfired post",
           ].join("\n"),
         },
       },


### PR DESCRIPTION
Implements the 3-layer auto-publish pipeline researched earlier. Layer 1: deterministic gates (length, structure, slug, banned phrases, novelty, forbidden topics). Layer 2: Cloudflare llama-3.1-8b critic with json_schema strict mode. Layer 3 minimal: /cloudless-newsletter unpublish emergency rollback. When both layers pass the draft is inserted as Notion Status=In Review and the Mon 09:00 UTC publisher sends without human input — otherwise the operator gets a Slack DM with the full verdict. 70/70 tests passing.