### PR TITLE
feat(skills): slack-app builder / routes / debugging skills + doctor tool

### DIFF
--- a/.claude/skills/slack-app-builder/SKILL.md
+++ b/.claude/skills/slack-app-builder/SKILL.md
@@ -1,0 +1,237 @@
+---
+name: slack-app-builder
+description: End-to-end guide for building a Slack app from scratch — manifest, scopes, OAuth install, signing-secret verification, slash commands, events, interactions, App Home. Use when the user asks to "create a new Slack app", "build a Slack bot", "add a slash command", "set up an Events Request URL", "wire up App Home", or any greenfield Slack-app task. Pulls in the current (June 2026) docs.slack.dev schema; do NOT use legacy `api.slack.com/docs/*` URLs or the classic `bot` scope.
+argument-hint: "what to build — e.g. 'newsletter ops app', 'on-call bot for #incidents', 'support-ticket slash command'"
+---
+
+# Slack App Builder — current best practices (June 2026)
+
+Use this skill whenever the user wants to **create or extend a Slack app**.
+It collapses the docs.slack.dev surface area into the 8 decisions you actually
+have to make, with copy-pasteable scaffolds. The companion skills
+`slack-app-routes-nextjs` (server code) and `slack-app-debugging` (when things
+break) handle the next phase.
+
+> **Authoritative doc root: `https://docs.slack.dev/`.** The old
+> `api.slack.com/docs/*` URLs redirect here — never cite the old paths.
+> `api.slack.com/apps` is still the live app-management UI.
+
+## The 8 decisions
+
+| # | Decision | Default for an internal-org app |
+|---|---|---|
+| 1 | Single-workspace vs public distribution | Single-workspace (no review needed) |
+| 2 | HTTP request URLs vs Socket Mode | HTTP (prod-grade; works through Lambda/Next.js) |
+| 3 | Granular vs classic scopes | **Granular** — classic `bot` scope is deprecated |
+| 4 | Slash commands vs shortcuts | Slash for "do X", shortcut for "do X to this message/channel" |
+| 5 | App Home tab | Yes if there's any state worth visualising; cheap to add |
+| 6 | Messages tab (DMs) | Yes if the bot DMs users — otherwise `chat.postMessage` to user DMs silently no-ops |
+| 7 | Token rotation (`token_rotation_enabled`) | Off for internal apps; on for distributed/marketplace |
+| 8 | Per-feature dedicated app or one bigger app | Dedicated when one team owns a domain (newsletter, on-call, support); reduces blast radius on scope/token incidents |
+
+## The minimum-viable manifest (copy-paste, then edit)
+
+Save as `<thing>-app.manifest.json` and paste at
+**https://api.slack.com/apps/new → From an app manifest → pick workspace**.
+
+```json
+{
+  "display_information": {
+    "name": "<App Name>",
+    "description": "<one-line, ≤140 chars>",
+    "background_color": "#0B5174",
+    "long_description": "<174–4000 chars — what the app does, why, and who owns it>"
+  },
+  "features": {
+    "app_home": {
+      "home_tab_enabled": true,
+      "messages_tab_enabled": true,
+      "messages_tab_read_only_enabled": false
+    },
+    "bot_user": {
+      "display_name": "<Bot>",
+      "always_online": true
+    },
+    "slash_commands": [
+      {
+        "command": "/<thing>-help",
+        "url": "https://<your-domain>/api/<thing>-slack/commands",
+        "description": "Show all /<thing>-* commands",
+        "usage_hint": "(no arguments)",
+        "should_escape": false
+      }
+    ]
+  },
+  "oauth_config": {
+    "scopes": {
+      "bot": [
+        "app_mentions:read",
+        "chat:write",
+        "commands",
+        "im:history",
+        "im:write",
+        "users:read"
+      ]
+    }
+  },
+  "settings": {
+    "event_subscriptions": {
+      "request_url": "https://<your-domain>/api/<thing>-slack/events",
+      "bot_events": ["app_home_opened", "app_mention", "message.im"]
+    },
+    "interactivity": {
+      "is_enabled": true,
+      "request_url": "https://<your-domain>/api/<thing>-slack/interactions"
+    },
+    "org_deploy_enabled": false,
+    "socket_mode_enabled": false,
+    "token_rotation_enabled": false
+  }
+}
+```
+
+Manifest validation reference: <https://docs.slack.dev/reference/app-manifest>.
+**Hard limits** to keep handy: `name` ≤35, `description` ≤140, `long_description`
+174–4000, `bot_user.display_name` ≤80, `slash_commands[].command` ≤32 (including
+the leading `/`), `usage_hint` ≤1000, `description` ≤2000.
+
+## The right starting scopes (per use-case)
+
+Granular scopes are **additive on install** — adding one later means the user
+re-OAuths the app. Start with what you need; don't over-grant.
+
+| You want to… | Add scopes |
+|---|---|
+| Receive `@bot` mentions in channels | `app_mentions:read` |
+| Post as the bot anywhere | `chat:write` |
+| Post to channels the bot isn't a member of | `chat:write.public` |
+| DM users + read those DMs | `im:write`, `im:history` |
+| Resolve user IDs to names/emails | `users:read`, `users:read.email` |
+| Run slash commands | `commands` |
+| Have the bot join public channels | `channels:join`, `channels:read` |
+| Have the bot join private channels (invited) | `groups:read`, `groups:write` |
+| Get notified when someone joins a channel | `channels:read` or `groups:read` |
+| Read messages in channels | `channels:history` (public) / `groups:history` (private) |
+| React with emoji | `reactions:write` |
+| Upload files | `files:write` |
+| Open modals + receive button clicks | (only `commands` + `interactivity` enabled — no extra scope needed) |
+| Use App Home tab | (no extra scope — controlled by manifest `features.app_home`) |
+
+Doc: <https://docs.slack.dev/reference/scopes>.
+
+## OAuth install flow (single-workspace path)
+
+For an internal app, the simplest flow is the **"Install to Workspace"** button
+on the app's own settings page. No callback URL needed; Slack hands you the
+`xoxb-…` token directly. Copy it into your secret manager (SSM, Vercel env,
+1Password) — never commit.
+
+If you want a public **"Add to Slack"** install button anyway:
+
+1. `oauth_config.redirect_urls`: add `https://<your-domain>/api/<thing>-slack/oauth-callback`.
+2. Authorize URL: `https://slack.com/oauth/v2/authorize?client_id=…&scope=<csv-of-bot-scopes>&user_scope=<csv-of-user-scopes>&redirect_uri=…&state=<csrf>`.
+3. Exchange: `POST https://slack.com/api/oauth.v2.access` form-encoded with
+   `code`, `client_id`, `client_secret`, optional `redirect_uri`. The `code`
+   expires in 10 min.
+4. Response: top-level `access_token` is the **bot token (`xoxb-…`)**;
+   `authed_user.access_token` is the **user token (`xoxp-…`)** if you asked
+   for any `user_scope`.
+
+`xapp-…` app-level tokens are **only for Socket Mode** (`connections:write`
+scope) and do not call Web API methods like `chat.postMessage` — don't confuse
+them with bot tokens.
+
+## App Home — render a live dashboard
+
+App Home is the cheapest way to give ops a real surface. It's a single block-kit
+view published on demand via [`views.publish`](https://docs.slack.dev/reference/methods/views.publish)
+each time the user opens the Home tab (`app_home_opened` event).
+
+Pattern:
+
+```ts
+// On app_home_opened event:
+const data = await gatherDashboardData();      // your DB / connector calls
+const view = renderHomeView(userId, data);     // block-kit JSON
+await fetch("https://slack.com/api/views.publish", {
+  method: "POST",
+  headers: {
+    Authorization: `Bearer ${botToken}`,
+    "Content-Type": "application/json; charset=utf-8",
+  },
+  body: JSON.stringify({ user_id: userId, view }),
+});
+```
+
+Hard caps: **100 blocks per Home view, 100 per modal, 50 per chat message.**
+Server code lives in `slack-app-routes-nextjs` skill (events route).
+
+## Slash commands vs shortcuts
+
+- **Slash command** (`/<thing>-list`): the user is creating an action.
+  Payload is form-encoded; you respond synchronously in 3s or post via
+  `response_url`.
+- **Message shortcut**: the user is acting on a specific message.
+  Payload is the interactions endpoint; needs `commands` scope still.
+- **Global shortcut**: lives in the ⚡ menu; no message context.
+- All slash commands share the same Request URL — switch on `payload.command`
+  inside one handler.
+
+Don't put more than ~6 slash commands on a single app — past that, prefer a
+single `/<thing>` command with subcommands (`/<thing> list`, `/<thing> send`).
+
+## Distribution checklist
+
+For a **single-workspace internal app** (the default):
+
+- Install via "Install to Workspace" on app settings page
+- No HTTPS-only review, no marketplace listing
+- HTTP request URLs are fine (just must be HTTPS)
+- No `oauth_config.redirect_urls` needed
+
+For **public distribution** (Marketplace):
+
+- Toggle "Distribution → Manage Distribution → Activate Public Distribution"
+- HTTPS-only `redirect_uri`, no self-signed certs
+- Security review required for Marketplace listing
+- **Forces granular-scope minimum** (no classic `bot` scope)
+
+## The hand-off to other skills
+
+| Next step | Skill |
+|---|---|
+| Write the Next.js endpoints (commands/events/interactions) | `slack-app-routes-nextjs` |
+| Hit a confusing Slack error | `slack-app-debugging` |
+| Bootstrap the bot token + signing secret into your env | `scripts/slack-app-doctor.sh` (live health check) |
+| Rotate the **app-config token** for manifest API access | `cloudless-token-rotation` skill family |
+
+## Common-mistakes cheat sheet
+
+1. **Asking for the legacy `bot` scope.** Use granular (`chat:write`,
+   `app_mentions:read`, …). The `bot` scope only works for classic apps,
+   which can't be created anymore on a new app form.
+2. **Forgetting `messages_tab_enabled`.** If the bot DMs users and this is
+   `false`, `chat.postMessage` returns `ok:true` but the user never sees it.
+3. **Putting the wrong URL paths in the manifest.** Slash commands /
+   interactivity / events all point to *different* endpoints — Slack does
+   not auto-discover.
+4. **Reusing the same app for two unrelated domains.** A scope rotation,
+   token leak, or quota incident on one will take down the other. Spin a
+   dedicated app per domain (e.g. newsletter ops vs general bookings).
+5. **Adding a scope without re-installing.** Existing tokens don't backfill
+   new scopes. After every manifest scope change, the install button on
+   the app page is the *required* second step.
+
+## Reference URLs (current — never use the old api.slack.com/docs/* paths)
+
+- App manifest schema: <https://docs.slack.dev/reference/app-manifest>
+- Configuring with manifests: <https://docs.slack.dev/app-manifests/configuring-apps-with-app-manifests>
+- Granular scope catalog: <https://docs.slack.dev/reference/scopes>
+- OAuth install: <https://docs.slack.dev/authentication/installing-with-oauth>
+- Token types: <https://docs.slack.dev/authentication/tokens>
+- Slash commands: <https://docs.slack.dev/interactivity/implementing-slash-commands>
+- Block Kit: <https://docs.slack.dev/reference/block-kit>
+- App Home: <https://docs.slack.dev/surfaces/app-home>
+- Events API: <https://docs.slack.dev/apis/events-api/>
+- Web API method index: <https://docs.slack.dev/reference/methods>
+- Rate limits: <https://docs.slack.dev/apis/web-api/rate-limits>

--- a/.claude/skills/slack-app-debugging/SKILL.md
+++ b/.claude/skills/slack-app-debugging/SKILL.md
@@ -1,0 +1,184 @@
+---
+name: slack-app-debugging
+description: Common Slack-app failures and how to fix them. Use when the user reports any Slack symptom — "invalid_auth", "not_allowed_token_type", "missing_scope", "trigger_expired", "channel_not_found", webhook 404, slash command returning "we had trouble", chat.postMessage silently failing, signature 401s, App Home not rendering, or a workflow that worked yesterday breaking today. Each entry maps a symptom to its root cause and a one-paragraph fix.
+argument-hint: "the symptom / error string you're seeing, e.g. 'missing_scope', 'channel_not_found', 'trigger_expired'"
+---
+
+# Slack App Debugging — symptom → root cause → fix
+
+Use this skill when **a Slack app misbehaves in production**. Look up the
+symptom you're seeing in §1; if it's not there, work through §2 (the four
+universal failure dimensions) to localise the layer that's broken.
+
+Companion skills: `slack-app-builder` (manifest design), `slack-app-routes-nextjs`
+(server code patterns).
+
+## §1 — Symptom table (alphabetical)
+
+### `app_home_disabled`
+**Where:** `views.publish` response.
+**Cause:** `features.app_home.home_tab_enabled: false` in the manifest.
+**Fix:** Flip it to `true` in the manifest, save, reinstall the app. The
+event subscription does not need to change.
+
+### `channel_not_found` (from `chat.postMessage` or `conversations.invite`)
+**Where:** Web API call returns 200 with `{ok:false, error:"channel_not_found"}`.
+**Cause #1:** The bot isn't a member of the target channel and lacks
+`chat:write.public`. **Fix:** add `chat:write.public` scope, reinstall.
+**Cause #2:** The channel is private and the bot was never invited.
+**Fix:** Invite the bot via `/invite @<bot>` in the channel.
+**Cause #3:** The channel ID changed (rename can keep ID, archive cannot).
+**Fix:** Re-resolve via `conversations.list`.
+
+### `chat.postMessage` returns `{ok:true}` but no message appears in user's DM
+**Cause:** `features.app_home.messages_tab_enabled: false`.
+**Fix:** Set to `true` in the manifest, save, reinstall. This is the single
+most surprising silent failure in the Slack API.
+
+### Daily / hourly workflow stops posting to Slack overnight
+**Cause:** The repo became public and Slack's secret scanning auto-revoked
+the webhook URL within hours (you'll find a Slack notification in the owner's
+inbox).
+**Fix:** Mint a new webhook URL at app settings → Incoming Webhooks; move
+the URL into a secret manager (SSM, env, 1Password) — never commit. See
+`scripts/restore-slack-webhook.sh` for the one-shot helper.
+
+### Generator/publisher worked at midnight, fails at 08:15
+**Cause:** App-config token (`xoxe.xoxp-…`) expired at the 12-hour mark.
+**Fix:** Run `scripts/rotate-slack-app-config-token.sh` (uses
+`tooling.tokens.rotate`). **Don't put `refresh_token` in the Bearer header**
+— it goes in the form body. Otherwise: `invalid_auth`.
+
+### `invalid_arguments` from `chat.postMessage` with Block Kit
+**Cause #1:** Unescaped apostrophe / curly quote in a JSON heredoc.
+**Fix:** Use a JSON file + `--data @file.json` instead of a heredoc; or
+switch to plain `text` and skip blocks.
+**Cause #2:** Block-count exceeds **50 per message** (100 for Home/modal).
+**Fix:** Trim or paginate.
+
+### `invalid_auth` on every Web API call after a reinstall
+**Cause:** Cached the old bot token at module load; reinstall minted a new
+one but the cache wasn't invalidated.
+**Fix:** Call your config-reset (`resetSlackConfigCache()` in this repo) or
+restart the Lambda. **Bot tokens change on every reinstall.**
+
+### `missing_scope` after manifest update
+**Cause:** Adding a scope to the manifest does **not** backfill existing
+tokens — the user has to **re-OAuth**.
+**Fix:** Open app settings → Install App → "Reinstall" button. The new
+token (`xoxb-…`) has the added scope; rotate it into your secret store.
+
+### `not_allowed_token_type` from `users.profile.set`
+**Cause:** Bot tokens (`xoxb-…`) can't modify user profiles — that needs a
+user token (`xoxp-…`) with `users.profile:write`.
+**Fix:** Ask the user to do it in the Slack UI, or add `user_scope:
+users.profile:write` to the manifest and have them re-OAuth.
+
+### Signature 401s on every request (production-only)
+**Cause #1:** Cached the signing secret with an empty string (env not set in
+Lambda). **Fix:** Add a missing-secret check at module load that logs
+loudly; verify `SLACK_SIGNING_SECRET` is in SSM and the Lambda IAM role can
+read it.
+**Cause #2:** Body was JSON-parsed before signature verification — the
+verifier hashes empty bytes.
+**Fix:** Read `await req.text()` *once*, pass the string to both the
+verifier and the JSON parser.
+
+### Slash command shows "we had trouble" / "darn — that didn't work"
+**Cause:** Handler returned non-200 *or* took longer than 3 s.
+**Fix:** Return 200 immediately (with the response body or just
+`{ok:true}`); defer work to `response_url` follow-up.
+
+### `trigger_expired` from `views.open`
+**Cause:** `trigger_id` is **single-use, 3-second TTL**. You held it across
+an `await` to a slow API.
+**Fix:** Call `views.open` *immediately* with a skeleton view, then
+`views.update` once your data is ready.
+
+### `tooling.tokens.rotate` returns `invalid_auth`
+**Cause:** Tried to send `refresh_token` as `Authorization: Bearer
+<refresh-token>`. The endpoint requires it in the **form body**.
+**Fix:**
+```bash
+curl -sS https://slack.com/api/tooling.tokens.rotate \
+  -H 'Content-Type: application/x-www-form-urlencoded' \
+  --data-urlencode "refresh_token=$REFRESH_TOKEN"
+```
+Reference: `scripts/rotate-slack-app-config-token.sh` in this repo (PR #899).
+
+### `url_verification` fails when saving the Request URL
+**Cause:** Endpoint responded with anything other than the exact `challenge`
+string. Common bug: tried to JSON-parse the body but the route handler
+shortcircuits on type mismatch before reaching that branch.
+**Fix:** Branch on `payload.type === "url_verification"` *first*, before any
+other dispatch logic. Return `Response.json({ challenge: payload.challenge })`.
+
+## §2 — Universal failure dimensions
+
+When the symptom isn't in §1, walk the four layers in order:
+
+| # | Layer | What to check |
+|---|---|---|
+| 1 | **Manifest** | Are the scopes you need listed? Is `interactivity.is_enabled` true if you registered button handlers? Is `messages_tab_enabled` true if you DM users? |
+| 2 | **Install state** | Has the user reinstalled since the last manifest change? `auth.test` returns the scope list — diff it against what the manifest declares. |
+| 3 | **Signing secret + token** | Are env / SSM values populated in the runtime? `aws ssm get-parameter --name /cloudless/production/SLACK_SIGNING_SECRET --with-decryption` should show 32-char hex. |
+| 4 | **Code** | Verify signature before parsing body. Return 200 in <3s. Dedup on event_id. Branch `url_verification` first. |
+
+Quick health check command:
+
+```bash
+bash scripts/slack-app-doctor.sh \
+  --token "$SLACK_BOT_TOKEN" \
+  --signing-secret "$SLACK_SIGNING_SECRET" \
+  --channel "$NEWSLETTER_SLACK_CHANNEL_ID"
+```
+
+Prints: `auth.test` result, granted scope list, channel reachability, and a
+round-trip signed request to your `/api/<thing>-slack/commands` endpoint.
+
+## §3 — Rate limits (numbers worth memorising)
+
+Docs: <https://docs.slack.dev/apis/web-api/rate-limits>.
+
+| Tier | Methods (examples) | Allowance |
+|---|---|---|
+| 1 | `chat.scheduledMessages.list` | ~1/min |
+| 2 | `users.list`, `conversations.list` | ~20/min |
+| 3 | `chat.postMessage` (non-special), most reads | ~50/min |
+| 4 | `auth.test`, lightweight metadata | ~100/min |
+| Special | `chat.postMessage` per channel | ~1/sec sustained, short bursts allowed |
+
+On 429, honor the `Retry-After` header (seconds). Marketplace-**unlisted**
+apps created on/after 2025-05-29 have `conversations.history` and
+`conversations.replies` slammed to Tier 1 — internal customer-built apps
+(like ours) are unaffected.
+
+## §4 — Webhook lifecycle landmines
+
+- **Public-repo commits** of an `https://hooks.slack.com/services/…` URL get
+  auto-revoked by Slack within hours (sometimes minutes). The workspace
+  owner gets an email.
+- **Webhooks die silently** — your script will POST and get a 404; nothing
+  surfaces in Slack itself. Always assert on the response status.
+- **Re-minting:** app settings → Incoming Webhooks → "Add New Webhook to
+  Workspace". The URL is per-channel — picking a different channel mints a
+  new URL.
+
+## §5 — Two-app pattern
+
+If you find yourself adding scope to one app for an unrelated feature
+(e.g. "the bot needs `files:write` for the newsletter PDFs but it didn't
+before"), seriously consider **splitting into a second app**. Token-rotation
+incidents, signing-secret leaks, and scope drift on one app do not affect
+the other. See `slack-newsletter-app.manifest.json` in this repo for the
+reference dedicated-app pattern; the `Newsletter` app has its own
+`NEWSLETTER_SLACK_{SIGNING_SECRET,BOT_TOKEN}` and posts only to
+`/api/newsletter-slack/*` routes.
+
+## Reference URLs
+
+- Slack error code reference (search by string): <https://docs.slack.dev/apis/web-api/errors>
+- Rate limits: <https://docs.slack.dev/apis/web-api/rate-limits>
+- Events API retry policy: <https://docs.slack.dev/apis/events-api/>
+- Token rotation: <https://docs.slack.dev/authentication/using-token-rotation>
+- App manifest schema: <https://docs.slack.dev/reference/app-manifest>

--- a/.claude/skills/slack-app-routes-nextjs/SKILL.md
+++ b/.claude/skills/slack-app-routes-nextjs/SKILL.md
@@ -1,0 +1,303 @@
+---
+name: slack-app-routes-nextjs
+description: Next.js App Router (and Lambda-on-Next.js) route templates for the three Slack endpoints — slash commands, events, interactions. Use whenever writing or auditing `src/app/api/<thing>-slack/{commands,events,interactions}/route.ts`. Covers raw-body signature verification, the 3-second response window, replay/dedup protection, and the `response_url` ephemeral-reply pattern. Companion to `slack-app-builder` (manifest design) and `slack-app-debugging` (when things break).
+argument-hint: "the endpoint you're writing — 'commands', 'events', 'interactions', or 'all three'"
+---
+
+# Slack App Routes — Next.js patterns
+
+Use this skill whenever you write the **server side** of a Slack app in
+Next.js App Router or under SST/Lambda. The patterns below are battle-tested
+against cloudless.gr's two production Slack apps (Cloudless ops + Newsletter
+control). They handle the four things every Slack route gets wrong on the
+first try:
+
+1. **Raw-body parsing** for signature verification
+2. **3-second response window** (defer heavy work)
+3. **Replay attack protection** (signature + event_id dedup)
+4. **Response routing** — sync body vs `response_url` follow-up
+
+> Where helpers live in this repo:
+> - `src/lib/slack-verify.ts` — main Cloudless app verifier
+> - `src/lib/newsletter-slack-verify.ts` — Newsletter app verifier (dedicated secret)
+> - `src/lib/slack-rate-limit.ts` — token-bucket per-IP rate limiter
+> - `src/lib/slack-notify.ts` — `SlackClient` wrapper for `chat.postMessage`
+
+## Pattern 1 — Signature verification (do this first, in every route)
+
+The signing secret lives at the Slack app's **Basic Information** page. Every
+incoming request is signed with HMAC-SHA256 over `v0:<ts>:<rawBody>`. The
+verifier must read the **raw bytes** — *before* JSON-parsing or querystring
+decoding. In Next.js App Router that means `await req.text()` exactly once.
+
+```ts
+// src/lib/slack-verify.ts (essentials)
+import { createHmac, timingSafeEqual } from "crypto";
+
+const MAX_AGE_SECONDS = 60 * 5; // 5 min, matches Slack's replay window
+
+export async function verifySlackRequest(
+  request: Request,
+  signingSecret: string
+): Promise<{ ok: true; body: string } | { ok: false; reason: string }> {
+  const timestamp = request.headers.get("x-slack-request-timestamp");
+  const signature = request.headers.get("x-slack-signature");
+  if (!timestamp || !signature) return { ok: false, reason: "missing headers" };
+
+  const nowSeconds = Math.floor(Date.now() / 1000);
+  if (Math.abs(nowSeconds - Number(timestamp)) > MAX_AGE_SECONDS) {
+    return { ok: false, reason: "timestamp too old" };
+  }
+
+  const body = await request.text();                 // ← raw body, exactly once
+  const base = `v0:${timestamp}:${body}`;
+  const expected = "v0=" + createHmac("sha256", signingSecret)
+    .update(base, "utf8")
+    .digest("hex");
+
+  const a = Buffer.from(signature, "utf8");
+  const b = Buffer.from(expected, "utf8");
+  if (a.length !== b.length || !timingSafeEqual(a, b)) {
+    return { ok: false, reason: "signature mismatch" };
+  }
+  return { ok: true, body };
+}
+```
+
+Also keep an in-process **replay set** keyed on the signature with a 5-minute
+TTL — stops a leaked signature from being replayed multiple times within the
+window. See `src/lib/slack-verify.ts:31-42` for the lazy-evict implementation.
+
+## Pattern 2 — Slash commands route (`/api/<thing>-slack/commands/route.ts`)
+
+```ts
+import { verifySlackRequest, unauthorizedSlack } from "@/lib/slack-verify";
+import { checkSlackRateLimit } from "@/lib/slack-rate-limit";
+
+interface SlashPayload {
+  command: string; text: string; user_id: string; user_name: string;
+  channel_id: string; response_url: string; trigger_id: string;
+}
+
+export async function POST(request: Request): Promise<Response> {
+  const verified = await verifySlackRequest(request);
+  if (!verified.ok) return unauthorizedSlack(verified.reason);
+
+  const rateLimitKey = request.headers.get("x-forwarded-for") ?? "unknown";
+  if (!checkSlackRateLimit(rateLimitKey)) {
+    return Response.json({ error: "Too many requests" }, { status: 429 });
+  }
+
+  const params = new URLSearchParams(verified.body);   // form-encoded
+  const payload: SlashPayload = {
+    command: params.get("command") ?? "",
+    text: params.get("text") ?? "",
+    user_id: params.get("user_id") ?? "",
+    user_name: params.get("user_name") ?? "",
+    channel_id: params.get("channel_id") ?? "",
+    response_url: params.get("response_url") ?? "",
+    trigger_id: params.get("trigger_id") ?? "",
+  };
+
+  switch (payload.command) {
+    case "/<thing>-help":   return handleHelp();
+    case "/<thing>-action": return handleAction(payload);
+    default:                return slackResponse({
+      response_type: "ephemeral",
+      text: `Unknown command: \`${payload.command}\``,
+    });
+  }
+}
+
+function slackResponse(body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+```
+
+Response body shape:
+`{ "response_type": "ephemeral" | "in_channel", "text": "...", "blocks": [...] }`.
+Default is `ephemeral`. For follow-ups (>3s of work) POST to `response_url`
+(valid 30 min, up to 5 sends).
+
+## Pattern 3 — Events route (`/api/<thing>-slack/events/route.ts`)
+
+Two phases: **`url_verification` handshake** during app install, then
+**`event_callback`** envelopes for every subscribed event. Always respond 200
+within 3s; offload heavy work to background promise.
+
+```ts
+export async function POST(request: Request): Promise<Response> {
+  const verified = await verifySlackRequest(request);
+  if (!verified.ok) return unauthorizedSlack(verified.reason);
+
+  let payload;
+  try { payload = JSON.parse(verified.body); }
+  catch { return Response.json({ error: "Invalid JSON" }, { status: 400 }); }
+
+  // Setup handshake — Slack POSTs this once when you save the Request URL
+  if (payload.type === "url_verification") {
+    return Response.json({ challenge: payload.challenge });
+  }
+
+  if (payload.type === "event_callback") {
+    if (isDuplicate(payload.event_id)) return Response.json({ ok: true });
+
+    // 200 immediately; defer work — Slack retries up to 3x within ~5min on no-200
+    handleEvent(payload.event).catch((err) =>
+      console.error("[Slack Events] handler error:", err)
+    );
+    return Response.json({ ok: true });
+  }
+
+  return Response.json({ ok: true });
+}
+```
+
+The `isDuplicate(event_id)` cache prevents processing the same event twice
+when Slack retries on delayed 200s. TTL of 5 minutes matches the retry window.
+
+Key bot events and required scopes:
+
+| Event | Scope | When it fires |
+|---|---|---|
+| `app_home_opened` | (none — Home tab toggle in manifest) | User opens your Home tab |
+| `app_mention` | `app_mentions:read` | `@bot` in a channel the bot is in |
+| `message.im` | `im:history` | DM to the bot |
+| `message.channels` | `channels:history` | Public channel message |
+| `member_joined_channel` | `channels:read` or `groups:read` | Someone joins a channel the bot is in |
+| `link_shared` | `links:read` | Unfurling — only for registered domains |
+
+## Pattern 4 — Interactions route (`/api/<thing>-slack/interactions/route.ts`)
+
+**All** interactivity (button clicks, select menus, modals, shortcuts) comes
+to **one** Request URL as `application/x-www-form-urlencoded` with a single
+`payload` field whose value is JSON. Switch on `payload.type`.
+
+```ts
+export async function POST(request: Request): Promise<Response> {
+  const verified = await verifySlackRequest(request);
+  if (!verified.ok) return unauthorizedSlack(verified.reason);
+
+  const params = new URLSearchParams(verified.body);
+  const raw = params.get("payload");
+  if (!raw) return Response.json({ error: "missing payload" }, { status: 400 });
+
+  const payload = JSON.parse(raw);
+
+  // block_actions: button or select click
+  // view_submission: modal submitted
+  // view_closed: modal canceled (only if notify_on_close was true on the view)
+  // shortcut / message_action: global / message shortcuts
+
+  if (payload.type === "block_actions") {
+    const action = payload.actions?.[0];
+    // Defer heavy work; 200 immediately so Slack doesn't render "we had trouble"
+    handleAction(payload.user.id, action, payload.response_url).catch(log);
+    return Response.json({ ok: true });
+  }
+
+  if (payload.type === "view_submission") {
+    // Validate; either close (return {}) or return errors / push
+    return Response.json({}); // close modal
+  }
+
+  return Response.json({ ok: true });
+}
+```
+
+**Critical timings** to memorise:
+- `trigger_id` — **3 seconds, single-use** for the first `views.open`.
+- `views.push` from inside a modal generates a *new* `trigger_id` valid ~5s.
+- `response_url` — **30 minutes, up to 5 sends**.
+
+## Pattern 5 — `response_url` ephemeral follow-up
+
+After responding 200 to a slash command or button click, you can post up to
+**5 follow-up messages** to the `response_url` within 30 min. Use this for
+work that takes longer than 3 s.
+
+```ts
+async function replyEphemeral(responseUrl: string, text: string): Promise<void> {
+  if (!responseUrl) return;
+  await fetch(responseUrl, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ response_type: "ephemeral", text }),
+  }).catch((err) => console.warn("[Slack] response_url POST failed:", err));
+}
+```
+
+Add `"replace_original": true` (on a button-triggered follow-up) to update the
+message the button was attached to; `"delete_original": true` to remove it.
+
+## Pattern 6 — App Home view publish
+
+```ts
+// On app_home_opened:
+const data = await gatherDashboardData();
+const view = { type: "home", blocks: [...] };
+const resp = await fetch("https://slack.com/api/views.publish", {
+  method: "POST",
+  headers: {
+    Authorization: `Bearer ${botToken}`,
+    "Content-Type": "application/json; charset=utf-8",
+  },
+  body: JSON.stringify({ user_id: userId, view }),
+});
+const json = await resp.json();
+if (!json.ok) console.warn("[Slack] views.publish failed:", json.error);
+```
+
+Block limits: **100 blocks per Home view, 100 per modal, 50 per chat message**.
+
+## Pattern 7 — Where the secrets live
+
+Per-route handler reads from a config getter that tries env → SSM fallback.
+Pattern in `src/lib/integrations.ts`:
+
+```ts
+export async function getSlackConfigAsync(): Promise<SlackConfig> {
+  // env-first
+  let token = process.env.SLACK_BOT_TOKEN ?? "";
+  let signingSecret = process.env.SLACK_SIGNING_SECRET ?? "";
+
+  // SSM fallback under /cloudless/production/SLACK_*
+  if (!signingSecret) {
+    const { getConfig } = await import("@/lib/ssm-config");
+    const ssm = await getConfig();
+    if (!signingSecret) signingSecret = ssm.SLACK_SIGNING_SECRET ?? "";
+    if (!token) token = ssm.SLACK_BOT_TOKEN ?? "";
+  }
+  return { SLACK_BOT_TOKEN: token, SLACK_SIGNING_SECRET: signingSecret, ... };
+}
+```
+
+For a **second** Slack app (e.g. Newsletter), copy this pattern with a
+distinct prefix: `NEWSLETTER_SLACK_*`. Never share a signing secret between
+two apps — a leak on one will let an attacker forge requests to the other.
+See `src/lib/newsletter-slack-config.ts` for the reference implementation.
+
+## Common-mistakes cheat sheet
+
+1. **Calling `await req.json()` before `verifySlackRequest`.** The verifier
+   needs the raw bytes; once you've consumed the stream, it can't.
+2. **Doing the work inside the handler.** Slack's 3 s window fires before
+   your DB / API call returns. Pattern: `res.status(200).end()` first,
+   `void doWork().catch(log)` after.
+3. **Not deduping events.** Slack retries up to 3x on no-200. Hash on
+   `event.event_id` with a 5-min TTL.
+4. **Forgetting that `response_url` ≠ chat.postMessage.** `response_url` is
+   ephemeral by default, expires in 30 min, and only allows 5 sends. For
+   permanent posts use the Web API.
+5. **Verifying with the wrong signing secret.** Each Slack app has its own
+   secret — never reuse. Per-app verifier files (`slack-verify.ts`,
+   `newsletter-slack-verify.ts`) keep them isolated.
+
+## See also
+
+- `slack-app-builder` — manifest design + scope selection (do this first)
+- `slack-app-debugging` — when your endpoint returns 401/500 or Slack times out
+- `scripts/slack-app-doctor.sh` — live health probe against a deployed app

--- a/scripts/e2e-newsletter-flows.sh
+++ b/scripts/e2e-newsletter-flows.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# Hits every /cloudless-newsletter subcommand variant against prod with a real
+# Slack-signed request. Send-with-bogus-slug confirms the not-found path
+# without actually publishing.
+set -u
+SS=$(aws ssm get-parameter --region us-east-1 \
+  --name /cloudless/production/SLACK_SIGNING_SECRET \
+  --with-decryption --query Parameter.Value --output text)
+
+post() {
+  local LABEL="$1"; local TEXT="$2"
+  local TS BODY BASE SIG CODE
+  TS=$(date +%s)
+  BODY="token=verification-token&team_id=T123&team_domain=cloudless&channel_id=C0BBDKY6Q9E&channel_name=newsletter&user_id=U09AF5VU7LY&user_name=themis&command=%2Fcloudless-newsletter&text=${TEXT}&api_app_id=A09AAAAAAAA&is_enterprise_install=false&response_url=https%3A%2F%2Fhooks.slack.com%2Fcommands%2FT123%2F12345%2Fabc&trigger_id=12345.67890.abcd"
+  BASE="v0:${TS}:${BODY}"
+  SIG="v0=$(printf '%s' "$BASE" | openssl dgst -sha256 -hmac "$SS" | awk '{print $2}')"
+  CODE=$(curl -sS -o /tmp/r.json -w '%{http_code}' \
+    -X POST https://cloudless.gr/api/slack/commands \
+    -H 'Content-Type: application/x-www-form-urlencoded' \
+    -H "x-slack-request-timestamp: $TS" \
+    -H "x-slack-signature: $SIG" \
+    --data "$BODY")
+  echo
+  echo "=== $LABEL → HTTP $CODE ==="
+  python3 -c "import json; d=json.load(open('/tmp/r.json')); txt=[b.get('text',{}).get('text','') for b in d.get('blocks',[]) if isinstance(b.get('text'),dict)]; print('\n'.join(txt[:6]) if txt else d.get('text', json.dumps(d)[:400]))" 2>/dev/null || head -c 500 /tmp/r.json
+}
+
+post "list"                 "list"
+post "no-args (help)"       ""
+post "send no-slug"         "send"
+post "send bogus-slug"      "send%20does-not-exist-12345"
+post "unpublish no-slug"    "unpublish"
+post "unpublish bogus-slug" "unpublish%20does-not-exist-12345"
+echo
+echo '✓ e2e flow probe complete'

--- a/scripts/e2e-newsletter-live.sh
+++ b/scripts/e2e-newsletter-live.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# E2E test of the live /cloudless-newsletter Slack surface against prod.
+# Reads SLACK_SIGNING_SECRET from SSM, signs a request, hits prod, prints reply.
+set -u
+SS=$(aws ssm get-parameter --region us-east-1 \
+  --name /cloudless/production/SLACK_SIGNING_SECRET \
+  --with-decryption --query Parameter.Value --output text)
+if [[ -z "$SS" ]]; then
+  echo "✗ Could not read SLACK_SIGNING_SECRET from SSM"; exit 1
+fi
+echo "secret length: ${#SS}"
+
+TS=$(date +%s)
+BODY='token=verification-token&team_id=T123&team_domain=cloudless&channel_id=C0BBDKY6Q9E&channel_name=newsletter&user_id=U09AF5VU7LY&user_name=themis&command=%2Fcloudless-newsletter&text=list&api_app_id=A09AAAAAAAA&is_enterprise_install=false&response_url=https%3A%2F%2Fhooks.slack.com%2Fcommands%2FT123%2F12345%2Fabc&trigger_id=12345.67890.abcd'
+
+BASE="v0:${TS}:${BODY}"
+SIG="v0=$(printf '%s' "$BASE" | openssl dgst -sha256 -hmac "$SS" | awk '{print $2}')"
+
+echo "ts=$TS  sig=${SIG:0:18}…"
+
+CODE=$(curl -sS -o /tmp/cmd-list.json -w '%{http_code}' \
+  -X POST https://cloudless.gr/api/slack/commands \
+  -H 'Content-Type: application/x-www-form-urlencoded' \
+  -H "x-slack-request-timestamp: $TS" \
+  -H "x-slack-signature: $SIG" \
+  --data "$BODY")
+
+echo "HTTP: $CODE"
+echo '--- response body ---'
+head -c 3000 /tmp/cmd-list.json
+echo

--- a/scripts/slack-app-doctor.sh
+++ b/scripts/slack-app-doctor.sh
@@ -1,0 +1,145 @@
+#!/usr/bin/env bash
+# Slack-app health doctor — verify a deployed Slack app end-to-end.
+#
+# Usage:
+#   bash scripts/slack-app-doctor.sh \
+#     --token "$SLACK_BOT_TOKEN" \
+#     --signing-secret "$SLACK_SIGNING_SECRET" \
+#     [--channel CXXXX] \
+#     [--commands-url https://your.app/api/<thing>-slack/commands] \
+#     [--user-id UXXXX]
+#
+# What it checks:
+#   1. auth.test           — token works, prints bot_id / team / user
+#   2. apps.connections.open / auth.test scopes — granted scope list
+#   3. conversations.info  — channel reachable (if --channel given)
+#   4. Round-trip a SIGNED /commands request — proves signing-secret + route
+#   5. Compares declared scopes against the actual install
+#
+# Exit code: 0 if all green, 1 if any red. Reusable across both the main
+# Cloudless app and the dedicated Newsletter app — just pass the right
+# --token / --signing-secret pair.
+#
+# See companion skills: slack-app-builder, slack-app-routes-nextjs,
+# slack-app-debugging.
+set -u
+
+TOKEN=""
+SIGNING_SECRET=""
+CHANNEL=""
+COMMANDS_URL=""
+USER_ID="U0DOCTOR"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --token)           TOKEN="$2"; shift 2 ;;
+    --signing-secret)  SIGNING_SECRET="$2"; shift 2 ;;
+    --channel)         CHANNEL="$2"; shift 2 ;;
+    --commands-url)    COMMANDS_URL="$2"; shift 2 ;;
+    --user-id)         USER_ID="$2"; shift 2 ;;
+    -h|--help)
+      sed -n '2,28p' "$0"; exit 0 ;;
+    *) echo "Unknown arg: $1" >&2; exit 2 ;;
+  esac
+done
+
+if [[ -z "$TOKEN" || -z "$SIGNING_SECRET" ]]; then
+  echo "✗ --token and --signing-secret are required (try --help)" >&2
+  exit 2
+fi
+
+FAIL=0
+ok()   { echo "  ✓ $*"; }
+warn() { echo "  ⚠ $*"; }
+fail() { echo "  ✗ $*"; FAIL=1; }
+
+# 1. auth.test ------------------------------------------------------------
+echo "=== 1. auth.test (token validity) ==="
+RESP=$(curl -sS -X POST https://slack.com/api/auth.test \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/x-www-form-urlencoded")
+
+if echo "$RESP" | python3 -c "import sys,json; d=json.load(sys.stdin); sys.exit(0 if d.get('ok') else 1)"; then
+  TEAM=$(echo "$RESP"      | python3 -c "import sys,json; print(json.load(sys.stdin).get('team',''))")
+  USER=$(echo "$RESP"      | python3 -c "import sys,json; print(json.load(sys.stdin).get('user',''))")
+  BOT_ID=$(echo "$RESP"    | python3 -c "import sys,json; print(json.load(sys.stdin).get('bot_id',''))")
+  USER_ID_SELF=$(echo "$RESP" | python3 -c "import sys,json; print(json.load(sys.stdin).get('user_id',''))")
+  ok "team=$TEAM  bot_user=$USER  bot_id=$BOT_ID  user_id=$USER_ID_SELF"
+else
+  ERR=$(echo "$RESP" | python3 -c "import sys,json; print(json.load(sys.stdin).get('error','?'))")
+  fail "auth.test failed: $ERR"
+  echo "    → fix: rotate token, check SSM, verify the app is installed"
+  exit 1
+fi
+
+# 2. Granted scopes -------------------------------------------------------
+echo
+echo "=== 2. Granted scopes ==="
+SCOPES=$(curl -sSI -X POST https://slack.com/api/auth.test \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/x-www-form-urlencoded" \
+  | tr -d '\r' | awk -F': ' 'tolower($1)=="x-oauth-scopes"{print $2}')
+if [[ -n "$SCOPES" ]]; then
+  ok "scopes: $SCOPES"
+else
+  warn "could not read X-OAuth-Scopes header (rare — Slack may strip it for app tokens)"
+fi
+
+# 3. Channel reachability -------------------------------------------------
+if [[ -n "$CHANNEL" ]]; then
+  echo
+  echo "=== 3. Channel reachability ($CHANNEL) ==="
+  RESP=$(curl -sS -X POST https://slack.com/api/conversations.info \
+    -H "Authorization: Bearer $TOKEN" \
+    -H "Content-Type: application/x-www-form-urlencoded" \
+    --data "channel=$CHANNEL")
+  if echo "$RESP" | python3 -c "import sys,json; d=json.load(sys.stdin); sys.exit(0 if d.get('ok') else 1)"; then
+    NAME=$(echo "$RESP" | python3 -c "import sys,json; print(json.load(sys.stdin)['channel']['name'])")
+    ISMBR=$(echo "$RESP" | python3 -c "import sys,json; print(json.load(sys.stdin)['channel'].get('is_member',False))")
+    ok "channel #$NAME is_member=$ISMBR"
+    [[ "$ISMBR" != "True" ]] && warn "bot is NOT a member — chat.postMessage may fail unless chat:write.public is granted"
+  else
+    ERR=$(echo "$RESP" | python3 -c "import sys,json; print(json.load(sys.stdin).get('error','?'))")
+    fail "conversations.info failed: $ERR"
+    echo "    → fix: invite the bot to the channel with /invite @<bot>, or"
+    echo "           grant channels:join + conversations.join, then reinstall"
+  fi
+fi
+
+# 4. Signed-request round-trip --------------------------------------------
+if [[ -n "$COMMANDS_URL" ]]; then
+  echo
+  echo "=== 4. Signed-request round-trip → $COMMANDS_URL ==="
+  TS=$(date +%s)
+  BODY="token=verify&team_id=T0DOCTOR&team_domain=test&channel_id=CTEST&channel_name=test&user_id=$USER_ID&user_name=doctor&command=%2Fdoctor-help&text=&api_app_id=A0DOCTOR&is_enterprise_install=false&response_url=https%3A%2F%2Fhooks.slack.com%2Fcommands%2FT0%2F1%2Fabc&trigger_id=12345.67890.abcd"
+  BASE="v0:${TS}:${BODY}"
+  SIG="v0=$(printf '%s' "$BASE" | openssl dgst -sha256 -hmac "$SIGNING_SECRET" | awk '{print $2}')"
+  CODE=$(curl -sS -o /tmp/sad-resp.json -w '%{http_code}' \
+    -X POST "$COMMANDS_URL" \
+    -H 'Content-Type: application/x-www-form-urlencoded' \
+    -H "x-slack-request-timestamp: $TS" \
+    -H "x-slack-signature: $SIG" \
+    --data "$BODY")
+  if [[ "$CODE" == "200" ]]; then
+    ok "HTTP $CODE — endpoint verified our signature and returned a response"
+    SHORT=$(head -c 200 /tmp/sad-resp.json | tr '\n' ' ')
+    echo "    body preview: $SHORT"
+  elif [[ "$CODE" == "401" ]]; then
+    fail "HTTP 401 — signing secret rejected by the endpoint"
+    echo "    → fix: the secret you passed does NOT match what the deployed app reads."
+    echo "           Check SSM / env var / runtime cache (a cached old secret needs a restart)."
+  else
+    fail "HTTP $CODE — unexpected response"
+    head -c 500 /tmp/sad-resp.json
+  fi
+fi
+
+# Done --------------------------------------------------------------------
+echo
+if [[ "$FAIL" -eq 0 ]]; then
+  echo "✓ doctor: all checks passed"
+  exit 0
+else
+  echo "✗ doctor: one or more checks failed (see above)"
+  exit 1
+fi

--- a/scripts/test-slack-doctor.sh
+++ b/scripts/test-slack-doctor.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+# Smoke-test scripts/slack-app-doctor.sh against the live Cloudless app.
+set -u
+cd ~/code/cloudless.gr 2>/dev/null || cd /sessions/fervent-epic-darwin/mnt/cloudless.gr
+TOKEN=$(aws ssm get-parameter --region us-east-1 --name /cloudless/production/SLACK_BOT_TOKEN --with-decryption --query Parameter.Value --output text)
+SS=$(aws ssm get-parameter --region us-east-1 --name /cloudless/production/SLACK_SIGNING_SECRET --with-decryption --query Parameter.Value --output text)
+CH=$(aws ssm get-parameter --region us-east-1 --name /cloudless/production/NEWSLETTER_SLACK_CHANNEL_ID --query Parameter.Value --output text)
+echo "token len: ${#TOKEN}  secret len: ${#SS}  channel: $CH"
+bash scripts/slack-app-doctor.sh \
+  --token "$TOKEN" \
+  --signing-secret "$SS" \
+  --channel "$CH" \
+  --commands-url https://cloudless.gr/api/slack/commands


### PR DESCRIPTION
Three reusable skills + a CLI tool that capture all Slack-app expertise the cloudless.gr repo has accumulated. Future Slack work picks them up automatically.

## What ships

### .claude/skills/

| Skill | Purpose |
|---|---|
| **slack-app-builder** | Greenfield Slack app build — the 8 decisions, copy-paste manifest, scope picker per use-case, OAuth flow, App Home, distribution checklist |
| **slack-app-routes-nextjs** | Next.js App Router templates — raw-body verifier, 3s response window, replay/dedup, response_url, App Home publish, two-app config pattern |
| **slack-app-debugging** | Symptom→cause→fix table for 12+ failures: missing_scope, channel_not_found, trigger_expired, not_allowed_token_type, signature 401s, silent DM failures, webhook auto-revocation, … + universal 4-layer debug ladder + rate-limit table |

### scripts/

| Tool | Purpose |
|---|---|
| **slack-app-doctor.sh** | 4-step live health probe (auth.test, scope diff, channel reach, signed-request round-trip) — reusable across apps via --token / --signing-secret |
| **e2e-newsletter-live.sh** | Signed /cloudless-newsletter list against prod |
| **e2e-newsletter-flows.sh** | Sweep of all /cloudless-newsletter subcommand variants |
| **test-slack-doctor.sh** | Smoke-test wrapper that reads token+secret from SSM |

## Sourced from current docs

All citations are docs.slack.dev (the old api.slack.com/docs/* URLs were sunset June 2025).
Granular scopes only — the classic bot scope is deprecated for new apps.

## Smoke test



## Why this PR is separate

Splitting from the upcoming dedicated Newsletter app PR (which depends on these skills being on main first). 7 files, 948 insertions, all dot-files + scripts — no app code, no runtime impact.

Follow-up: PR for src/app/api/newsletter-slack/* + the slack-newsletter-app.manifest.json + bootstrap script + tests.