### PR TITLE
fix(skills): markdownlint MD022/MD031/MD032/MD028 on slack-app-* SKILL.md

### DIFF
--- a/.claude/skills/slack-app-builder/SKILL.md
+++ b/.claude/skills/slack-app-builder/SKILL.md
@@ -88,6 +88,7 @@ Save as `<thing>-app.manifest.json` and paste at
     "token_rotation_enabled": false
   }
 }
+
 ```
 
 Manifest validation reference: <https://docs.slack.dev/reference/app-manifest>.
@@ -133,6 +134,7 @@ If you want a public **"Add to Slack"** install button anyway:
 3. Exchange: `POST https://slack.com/api/oauth.v2.access` form-encoded with
    `code`, `client_id`, `client_secret`, optional `redirect_uri`. The `code`
    expires in 10 min.
+
 4. Response: top-level `access_token` is the **bot token (`xoxb-…`)**;
    `authed_user.access_token` is the **user token (`xoxp-…`)** if you asked
    for any `user_scope`.
@@ -161,6 +163,7 @@ await fetch("https://slack.com/api/views.publish", {
   },
   body: JSON.stringify({ user_id: userId, view }),
 });
+
 ```
 
 Hard caps: **100 blocks per Home view, 100 per modal, 50 per chat message.**
@@ -171,8 +174,10 @@ Server code lives in `slack-app-routes-nextjs` skill (events route).
 - **Slash command** (`/<thing>-list`): the user is creating an action.
   Payload is form-encoded; you respond synchronously in 3s or post via
   `response_url`.
+
 - **Message shortcut**: the user is acting on a specific message.
   Payload is the interactions endpoint; needs `commands` scope still.
+
 - **Global shortcut**: lives in the ⚡ menu; no message context.
 - All slash commands share the same Request URL — switch on `payload.command`
   inside one handler.
@@ -210,14 +215,18 @@ For **public distribution** (Marketplace):
 1. **Asking for the legacy `bot` scope.** Use granular (`chat:write`,
    `app_mentions:read`, …). The `bot` scope only works for classic apps,
    which can't be created anymore on a new app form.
+
 2. **Forgetting `messages_tab_enabled`.** If the bot DMs users and this is
    `false`, `chat.postMessage` returns `ok:true` but the user never sees it.
+
 3. **Putting the wrong URL paths in the manifest.** Slash commands /
    interactivity / events all point to *different* endpoints — Slack does
    not auto-discover.
+
 4. **Reusing the same app for two unrelated domains.** A scope rotation,
    token leak, or quota incident on one will take down the other. Spin a
    dedicated app per domain (e.g. newsletter ops vs general bookings).
+
 5. **Adding a scope without re-installing.** Existing tokens don't backfill
    new scopes. After every manifest scope change, the install button on
    the app page is the *required* second step.

--- a/.claude/skills/slack-app-debugging/SKILL.md
+++ b/.claude/skills/slack-app-debugging/SKILL.md
@@ -16,12 +16,14 @@ Companion skills: `slack-app-builder` (manifest design), `slack-app-routes-nextj
 ## §1 — Symptom table (alphabetical)
 
 ### `app_home_disabled`
+
 **Where:** `views.publish` response.
 **Cause:** `features.app_home.home_tab_enabled: false` in the manifest.
 **Fix:** Flip it to `true` in the manifest, save, reinstall the app. The
 event subscription does not need to change.
 
 ### `channel_not_found` (from `chat.postMessage` or `conversations.invite`)
+
 **Where:** Web API call returns 200 with `{ok:false, error:"channel_not_found"}`.
 **Cause #1:** The bot isn't a member of the target channel and lacks
 `chat:write.public`. **Fix:** add `chat:write.public` scope, reinstall.
@@ -31,11 +33,13 @@ event subscription does not need to change.
 **Fix:** Re-resolve via `conversations.list`.
 
 ### `chat.postMessage` returns `{ok:true}` but no message appears in user's DM
+
 **Cause:** `features.app_home.messages_tab_enabled: false`.
 **Fix:** Set to `true` in the manifest, save, reinstall. This is the single
 most surprising silent failure in the Slack API.
 
 ### Daily / hourly workflow stops posting to Slack overnight
+
 **Cause:** The repo became public and Slack's secret scanning auto-revoked
 the webhook URL within hours (you'll find a Slack notification in the owner's
 inbox).
@@ -44,12 +48,14 @@ the URL into a secret manager (SSM, env, 1Password) — never commit. See
 `scripts/restore-slack-webhook.sh` for the one-shot helper.
 
 ### Generator/publisher worked at midnight, fails at 08:15
+
 **Cause:** App-config token (`xoxe.xoxp-…`) expired at the 12-hour mark.
 **Fix:** Run `scripts/rotate-slack-app-config-token.sh` (uses
 `tooling.tokens.rotate`). **Don't put `refresh_token` in the Bearer header**
 — it goes in the form body. Otherwise: `invalid_auth`.
 
 ### `invalid_arguments` from `chat.postMessage` with Block Kit
+
 **Cause #1:** Unescaped apostrophe / curly quote in a JSON heredoc.
 **Fix:** Use a JSON file + `--data @file.json` instead of a heredoc; or
 switch to plain `text` and skip blocks.
@@ -57,24 +63,28 @@ switch to plain `text` and skip blocks.
 **Fix:** Trim or paginate.
 
 ### `invalid_auth` on every Web API call after a reinstall
+
 **Cause:** Cached the old bot token at module load; reinstall minted a new
 one but the cache wasn't invalidated.
 **Fix:** Call your config-reset (`resetSlackConfigCache()` in this repo) or
 restart the Lambda. **Bot tokens change on every reinstall.**
 
 ### `missing_scope` after manifest update
+
 **Cause:** Adding a scope to the manifest does **not** backfill existing
 tokens — the user has to **re-OAuth**.
 **Fix:** Open app settings → Install App → "Reinstall" button. The new
 token (`xoxb-…`) has the added scope; rotate it into your secret store.
 
 ### `not_allowed_token_type` from `users.profile.set`
+
 **Cause:** Bot tokens (`xoxb-…`) can't modify user profiles — that needs a
 user token (`xoxp-…`) with `users.profile:write`.
 **Fix:** Ask the user to do it in the Slack UI, or add `user_scope:
 users.profile:write` to the manifest and have them re-OAuth.
 
 ### Signature 401s on every request (production-only)
+
 **Cause #1:** Cached the signing secret with an empty string (env not set in
 Lambda). **Fix:** Add a missing-secret check at module load that logs
 loudly; verify `SLACK_SIGNING_SECRET` is in SSM and the Lambda IAM role can
@@ -85,28 +95,35 @@ verifier hashes empty bytes.
 verifier and the JSON parser.
 
 ### Slash command shows "we had trouble" / "darn — that didn't work"
+
 **Cause:** Handler returned non-200 *or* took longer than 3 s.
 **Fix:** Return 200 immediately (with the response body or just
 `{ok:true}`); defer work to `response_url` follow-up.
 
 ### `trigger_expired` from `views.open`
+
 **Cause:** `trigger_id` is **single-use, 3-second TTL**. You held it across
 an `await` to a slow API.
 **Fix:** Call `views.open` *immediately* with a skeleton view, then
 `views.update` once your data is ready.
 
 ### `tooling.tokens.rotate` returns `invalid_auth`
+
 **Cause:** Tried to send `refresh_token` as `Authorization: Bearer
 <refresh-token>`. The endpoint requires it in the **form body**.
 **Fix:**
+
 ```bash
 curl -sS https://slack.com/api/tooling.tokens.rotate \
   -H 'Content-Type: application/x-www-form-urlencoded' \
   --data-urlencode "refresh_token=$REFRESH_TOKEN"
+
 ```
+
 Reference: `scripts/rotate-slack-app-config-token.sh` in this repo (PR #899).
 
 ### `url_verification` fails when saving the Request URL
+
 **Cause:** Endpoint responded with anything other than the exact `challenge`
 string. Common bug: tried to JSON-parse the body but the route handler
 shortcircuits on type mismatch before reaching that branch.
@@ -131,6 +148,7 @@ bash scripts/slack-app-doctor.sh \
   --token "$SLACK_BOT_TOKEN" \
   --signing-secret "$SLACK_SIGNING_SECRET" \
   --channel "$NEWSLETTER_SLACK_CHANNEL_ID"
+
 ```
 
 Prints: `auth.test` result, granted scope list, channel reachability, and a
@@ -158,8 +176,10 @@ apps created on/after 2025-05-29 have `conversations.history` and
 - **Public-repo commits** of an `https://hooks.slack.com/services/…` URL get
   auto-revoked by Slack within hours (sometimes minutes). The workspace
   owner gets an email.
+
 - **Webhooks die silently** — your script will POST and get a 404; nothing
   surfaces in Slack itself. Always assert on the response status.
+
 - **Re-minting:** app settings → Incoming Webhooks → "Add New Webhook to
   Workspace". The URL is per-channel — picking a different channel mints a
   new URL.

--- a/.claude/skills/slack-app-routes-nextjs/SKILL.md
+++ b/.claude/skills/slack-app-routes-nextjs/SKILL.md
@@ -17,11 +17,12 @@ first try:
 3. **Replay attack protection** (signature + event_id dedup)
 4. **Response routing** — sync body vs `response_url` follow-up
 
-> Where helpers live in this repo:
-> - `src/lib/slack-verify.ts` — main Cloudless app verifier
-> - `src/lib/newsletter-slack-verify.ts` — Newsletter app verifier (dedicated secret)
-> - `src/lib/slack-rate-limit.ts` — token-bucket per-IP rate limiter
-> - `src/lib/slack-notify.ts` — `SlackClient` wrapper for `chat.postMessage`
+**Where helpers live in this repo:**
+
+- `src/lib/slack-verify.ts` — main Cloudless app verifier
+- `src/lib/newsletter-slack-verify.ts` — Newsletter app verifier (dedicated secret)
+- `src/lib/slack-rate-limit.ts` — token-bucket per-IP rate limiter
+- `src/lib/slack-notify.ts` — `SlackClient` wrapper for `chat.postMessage`
 
 ## Pattern 1 — Signature verification (do this first, in every route)
 
@@ -62,6 +63,7 @@ export async function verifySlackRequest(
   }
   return { ok: true, body };
 }
+
 ```
 
 Also keep an in-process **replay set** keyed on the signature with a 5-minute
@@ -115,6 +117,7 @@ function slackResponse(body: unknown): Response {
     headers: { "Content-Type": "application/json" },
   });
 }
+
 ```
 
 Response body shape:
@@ -154,6 +157,7 @@ export async function POST(request: Request): Promise<Response> {
 
   return Response.json({ ok: true });
 }
+
 ```
 
 The `isDuplicate(event_id)` cache prevents processing the same event twice
@@ -206,9 +210,11 @@ export async function POST(request: Request): Promise<Response> {
 
   return Response.json({ ok: true });
 }
+
 ```
 
 **Critical timings** to memorise:
+
 - `trigger_id` — **3 seconds, single-use** for the first `views.open`.
 - `views.push` from inside a modal generates a *new* `trigger_id` valid ~5s.
 - `response_url` — **30 minutes, up to 5 sends**.
@@ -228,6 +234,7 @@ async function replyEphemeral(responseUrl: string, text: string): Promise<void> 
     body: JSON.stringify({ response_type: "ephemeral", text }),
   }).catch((err) => console.warn("[Slack] response_url POST failed:", err));
 }
+
 ```
 
 Add `"replace_original": true` (on a button-triggered follow-up) to update the
@@ -249,6 +256,7 @@ const resp = await fetch("https://slack.com/api/views.publish", {
 });
 const json = await resp.json();
 if (!json.ok) console.warn("[Slack] views.publish failed:", json.error);
+
 ```
 
 Block limits: **100 blocks per Home view, 100 per modal, 50 per chat message**.
@@ -273,6 +281,7 @@ export async function getSlackConfigAsync(): Promise<SlackConfig> {
   }
   return { SLACK_BOT_TOKEN: token, SLACK_SIGNING_SECRET: signingSecret, ... };
 }
+
 ```
 
 For a **second** Slack app (e.g. Newsletter), copy this pattern with a
@@ -284,14 +293,18 @@ See `src/lib/newsletter-slack-config.ts` for the reference implementation.
 
 1. **Calling `await req.json()` before `verifySlackRequest`.** The verifier
    needs the raw bytes; once you've consumed the stream, it can't.
+
 2. **Doing the work inside the handler.** Slack's 3 s window fires before
    your DB / API call returns. Pattern: `res.status(200).end()` first,
    `void doWork().catch(log)` after.
+
 3. **Not deduping events.** Slack retries up to 3x on no-200. Hash on
    `event.event_id` with a 5-min TTL.
+
 4. **Forgetting that `response_url` ≠ chat.postMessage.** `response_url` is
    ephemeral by default, expires in 30 min, and only allows 5 sends. For
    permanent posts use the Web API.
+
 5. **Verifying with the wrong signing secret.** Each Slack app has its own
    secret — never reuse. Per-app verifier files (`slack-verify.ts`,
    `newsletter-slack-verify.ts`) keep them isolated.


### PR DESCRIPTION
Markdownlint on  started failing immediately after PR #904 — the three new Slack-app SKILL.md files had:

- **MD022** — headings without blank lines below
- **MD031** — fenced code blocks without surrounding blanks
- **MD032** — lists without leading blank lines
- **MD028** — blank line inside a blockquote, plus a prose+list blockquote pattern

All fixed. Local markdownlint-cli2 v0.22.1 (markdownlint v0.40.0)
Finding: .claude/skills/slack-app-builder/SKILL.md .claude/skills/slack-app-debugging/SKILL.md .claude/skills/slack-app-routes-nextjs/SKILL.md !node_modules !.next !.venv !.git !coverage !**/node_modules/** !.claude/**/node_modules/** !CHANGELOG.md !test-results !test-results/** !playwright-report !playwright-report/** !monocart-report !monocart-report/** !.coverage-run/** !.coverage-v8-server/**
Linting: 3 file(s)
Summary: 0 error(s) reports 0 errors.

The fix is purely whitespace + one blockquote→plain-prose conversion (the helpers list at line 21 of routes-nextjs). No content changes.