### PR TITLE
feat(newsletter-slack): dedicated Slack app for 3-layer newsletter control

### DIFF
--- a/__tests__/newsletter-slack/newsletter-slack-commands.test.ts
+++ b/__tests__/newsletter-slack/newsletter-slack-commands.test.ts
@@ -1,0 +1,145 @@
+/**
+ * Unit tests for the dedicated Newsletter Slack slash command router.
+ *
+ * Probes the dispatch surface — each /newsletter-* subcommand should
+ * either return a help/usage block or short-circuit with ops-allowlist
+ * gating. We don't hit Notion/HubSpot/GitHub here; those are covered by
+ * their own lib tests. The point is to lock the COMMAND ROUTING surface.
+ */
+
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { createHmac } from "crypto";
+import { POST } from "@/app/api/newsletter-slack/commands/route";
+import { resetNewsletterSlackConfigCache } from "@/lib/newsletter-slack-config";
+
+const SECRET = "test-newsletter-signing-secret-32chr";
+
+function sign(body: string, ts: number, secret = SECRET): string {
+  return "v0=" + createHmac("sha256", secret).update(`v0:${ts}:${body}`, "utf8").digest("hex");
+}
+
+function buildRequest(opts: {
+  command: string;
+  text?: string;
+  userId?: string;
+  secret?: string;
+}): Request {
+  const ts = Math.floor(Date.now() / 1000);
+  const params = new URLSearchParams({
+    token: "verify",
+    team_id: "T1",
+    team_domain: "test",
+    channel_id: "C1",
+    channel_name: "test",
+    user_id: opts.userId ?? "UTESTUSER",
+    user_name: "tester",
+    command: opts.command,
+    text: opts.text ?? "",
+    response_url: "https://hooks.slack.com/commands/T1/1/abc",
+    trigger_id: "1.1.abc",
+    api_app_id: "A1",
+    is_enterprise_install: "false",
+  });
+  const body = params.toString();
+  return new Request("http://localhost/api/newsletter-slack/commands", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/x-www-form-urlencoded",
+      "x-slack-request-timestamp": String(ts),
+      "x-slack-signature": sign(body, ts, opts.secret ?? SECRET),
+    },
+    body,
+  });
+}
+
+beforeEach(() => {
+  resetNewsletterSlackConfigCache();
+  process.env.NEWSLETTER_SLACK_SIGNING_SECRET = SECRET;
+  process.env.NEWSLETTER_SLACK_BOT_TOKEN = "xoxb-test";
+  // No allowlist gate by default — empty SLACK_OPS_USERS means "anyone"
+  // We DON'T override it because the route module reads it at import time.
+  // Tests that need a populated allowlist must run in a separate file or
+  // re-import the module.
+});
+
+describe("/newsletter-slack/commands router", () => {
+  it("rejects an unsigned request with 401", async () => {
+    const req = new Request("http://localhost/api/newsletter-slack/commands", {
+      method: "POST",
+      headers: { "Content-Type": "application/x-www-form-urlencoded" },
+      body: "command=%2Fnewsletter-list",
+    });
+    const res = await POST(req);
+    expect(res.status).toBe(401);
+  });
+
+  it("rejects a wrongly-signed request with 401", async () => {
+    const req = buildRequest({ command: "/newsletter-list", secret: "wrong" });
+    const res = await POST(req);
+    expect(res.status).toBe(401);
+  });
+
+  it("/newsletter-help returns the usage card", async () => {
+    const res = await POST(buildRequest({ command: "/newsletter-help" }));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.response_type).toBe("ephemeral");
+    const flat = JSON.stringify(body.blocks);
+    expect(flat).toMatch(/Newsletter — Commands/);
+    expect(flat).toMatch(/\/newsletter-list/);
+    expect(flat).toMatch(/\/newsletter-send/);
+    expect(flat).toMatch(/\/newsletter-unpublish/);
+  });
+
+  it("/newsletter-gates returns the 3-layer thresholds card", async () => {
+    const res = await POST(buildRequest({ command: "/newsletter-gates" }));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    const flat = JSON.stringify(body.blocks);
+    expect(flat).toMatch(/3-Layer Quality Gates/);
+    expect(flat).toMatch(/Layer 1 — Deterministic/);
+    expect(flat).toMatch(/Layer 2 — LLM Critic/);
+    expect(flat).toMatch(/Layer 3 — Human Ops Override/);
+  });
+
+  it("/newsletter-send with no text returns usage hint", async () => {
+    const res = await POST(buildRequest({ command: "/newsletter-send", text: "" }));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.text).toMatch(/Usage: `\/newsletter-send/);
+  });
+
+  it("/newsletter-unpublish with no text returns usage hint", async () => {
+    const res = await POST(buildRequest({ command: "/newsletter-unpublish", text: "" }));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.text).toMatch(/Usage: `\/newsletter-unpublish/);
+  });
+
+  it("unknown command returns the unknown-command response", async () => {
+    const res = await POST(buildRequest({ command: "/newsletter-bogus" }));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.text).toMatch(/Unknown command/);
+    expect(body.text).toMatch(/\/newsletter-help/);
+  });
+});
+
+describe("ops allowlist gating", () => {
+  // The router reads SLACK_OPS_USERS at module import time, so we can't
+  // re-test the populated-allowlist path here without dynamic re-imports.
+  // The empty-allowlist path (covered above) means anyone passes — which is
+  // the documented default behavior when SLACK_OPS_USERS is unset.
+  it("documents the gating contract via the unpublish help text", async () => {
+    // Use a unique text suffix so the signature differs from previous tests
+    // (replay-protection cache would otherwise reject this as a duplicate).
+    const res = await POST(
+      buildRequest({ command: "/newsletter-unpublish", text: " " + Date.now() })
+    );
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    // The "no slug" guard fires on an effectively-empty text; the helper hint
+    // explains the contract.
+    expect(body.text ?? "").toMatch(/Flips Notion Status to `Archived`|warning|No Notion post/);
+  });
+});

--- a/__tests__/newsletter-slack/newsletter-slack-config.test.ts
+++ b/__tests__/newsletter-slack/newsletter-slack-config.test.ts
@@ -1,0 +1,68 @@
+/**
+ * Unit tests for the dedicated Newsletter Slack config loader.
+ *
+ * Verifies env-first then SSM-fallback resolution, and that the cache
+ * is properly invalidated by resetNewsletterSlackConfigCache().
+ */
+
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import {
+  getNewsletterSlackConfigAsync,
+  resetNewsletterSlackConfigCache,
+} from "@/lib/newsletter-slack-config";
+
+beforeEach(() => {
+  resetNewsletterSlackConfigCache();
+  delete process.env.NEWSLETTER_SLACK_BOT_TOKEN;
+  delete process.env.NEWSLETTER_SLACK_SIGNING_SECRET;
+  delete process.env.NEWSLETTER_SLACK_CHANNEL_ID;
+  vi.restoreAllMocks();
+});
+
+describe("getNewsletterSlackConfigAsync", () => {
+  it("returns env values when all three are set", async () => {
+    process.env.NEWSLETTER_SLACK_BOT_TOKEN = "xoxb-from-env";
+    process.env.NEWSLETTER_SLACK_SIGNING_SECRET = "signing-from-env";
+    process.env.NEWSLETTER_SLACK_CHANNEL_ID = "C-from-env";
+    const cfg = await getNewsletterSlackConfigAsync();
+    expect(cfg).toEqual({
+      NEWSLETTER_SLACK_BOT_TOKEN: "xoxb-from-env",
+      NEWSLETTER_SLACK_SIGNING_SECRET: "signing-from-env",
+      NEWSLETTER_SLACK_CHANNEL_ID: "C-from-env",
+    });
+  });
+
+  it("returns empty strings when nothing is set anywhere", async () => {
+    // SSM import will fail with no mock — that's the expected SSM-unavailable
+    // fallback path; we should still get a config object with empty strings.
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const cfg = await getNewsletterSlackConfigAsync();
+    expect(cfg.NEWSLETTER_SLACK_BOT_TOKEN).toBe("");
+    expect(cfg.NEWSLETTER_SLACK_SIGNING_SECRET).toBe("");
+    expect(cfg.NEWSLETTER_SLACK_CHANNEL_ID).toBe("");
+    // Should have warned about the missing signing secret
+    expect(warn).toHaveBeenCalled();
+  });
+
+  it("caches results — second call does not re-read env", async () => {
+    process.env.NEWSLETTER_SLACK_BOT_TOKEN = "xoxb-first";
+    process.env.NEWSLETTER_SLACK_SIGNING_SECRET = "secret-first";
+    const a = await getNewsletterSlackConfigAsync();
+    process.env.NEWSLETTER_SLACK_BOT_TOKEN = "xoxb-second";
+    const b = await getNewsletterSlackConfigAsync();
+    expect(b).toBe(a); // same object reference — cache hit
+    expect(b.NEWSLETTER_SLACK_BOT_TOKEN).toBe("xoxb-first");
+  });
+
+  it("resetNewsletterSlackConfigCache() invalidates the cache", async () => {
+    process.env.NEWSLETTER_SLACK_BOT_TOKEN = "xoxb-v1";
+    process.env.NEWSLETTER_SLACK_SIGNING_SECRET = "v1";
+    const a = await getNewsletterSlackConfigAsync();
+    expect(a.NEWSLETTER_SLACK_BOT_TOKEN).toBe("xoxb-v1");
+
+    process.env.NEWSLETTER_SLACK_BOT_TOKEN = "xoxb-v2";
+    resetNewsletterSlackConfigCache();
+    const b = await getNewsletterSlackConfigAsync();
+    expect(b.NEWSLETTER_SLACK_BOT_TOKEN).toBe("xoxb-v2");
+  });
+});

--- a/__tests__/newsletter-slack/newsletter-slack-verify.test.ts
+++ b/__tests__/newsletter-slack/newsletter-slack-verify.test.ts
@@ -1,0 +1,135 @@
+/**
+ * Unit tests for the dedicated Newsletter Slack signature verifier.
+ *
+ * Covers the same surface as __tests__/slack/slack-verify.test.ts but for
+ * the second app's verifier (NEWSLETTER_SLACK_SIGNING_SECRET). Keeps the
+ * two verifiers' behaviour locked together so a regression on one is
+ * caught on both.
+ */
+
+import { describe, it, expect, beforeEach } from "vitest";
+import { createHmac } from "crypto";
+import {
+  verifyNewsletterSlackRequest,
+  unauthorizedNewsletterSlack,
+} from "@/lib/newsletter-slack-verify";
+import { resetNewsletterSlackConfigCache } from "@/lib/newsletter-slack-config";
+
+const SECRET = "test-newsletter-signing-secret-32chr";
+
+function signRequest(body: string, timestamp: number, secret = SECRET): string {
+  const base = `v0:${timestamp}:${body}`;
+  return "v0=" + createHmac("sha256", secret).update(base, "utf8").digest("hex");
+}
+
+function makeRequest(
+  body: string,
+  timestamp: number,
+  options: { signature?: string; missingHeaders?: boolean } = {}
+): Request {
+  const headers: Record<string, string> = {};
+  if (!options.missingHeaders) {
+    headers["x-slack-request-timestamp"] = String(timestamp);
+    headers["x-slack-signature"] = options.signature ?? signRequest(body, timestamp);
+  }
+  return new Request("http://localhost/api/newsletter-slack/commands", {
+    method: "POST",
+    headers,
+    body,
+  });
+}
+
+beforeEach(() => {
+  resetNewsletterSlackConfigCache();
+  process.env.NEWSLETTER_SLACK_SIGNING_SECRET = SECRET;
+});
+
+describe("verifyNewsletterSlackRequest", () => {
+  it("accepts a freshly-signed request", async () => {
+    const body = "command=%2Fnewsletter-list&text=";
+    const ts = Math.floor(Date.now() / 1000);
+    const req = makeRequest(body, ts);
+    const result = await verifyNewsletterSlackRequest(req);
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.body).toBe(body);
+  });
+
+  it("rejects when signing secret is unset", async () => {
+    process.env.NEWSLETTER_SLACK_SIGNING_SECRET = "";
+    resetNewsletterSlackConfigCache();
+    const ts = Math.floor(Date.now() / 1000);
+    const req = makeRequest("x=1", ts);
+    const result = await verifyNewsletterSlackRequest(req);
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.reason).toMatch(/not configured/);
+  });
+
+  it("rejects requests missing the Slack headers", async () => {
+    const ts = Math.floor(Date.now() / 1000);
+    const req = makeRequest("x=1", ts, { missingHeaders: true });
+    const result = await verifyNewsletterSlackRequest(req);
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.reason).toMatch(/Missing/);
+  });
+
+  it("rejects requests older than 5 minutes (replay window)", async () => {
+    const ts = Math.floor(Date.now() / 1000) - 6 * 60;
+    const req = makeRequest("x=1", ts);
+    const result = await verifyNewsletterSlackRequest(req);
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.reason).toMatch(/timestamp is too old/);
+  });
+
+  it("rejects requests signed with the wrong secret", async () => {
+    const ts = Math.floor(Date.now() / 1000);
+    const body = "x=1";
+    const wrongSig = signRequest(body, ts, "different-secret-entirely");
+    const req = makeRequest(body, ts, { signature: wrongSig });
+    const result = await verifyNewsletterSlackRequest(req);
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.reason).toMatch(/[Ss]ignature mismatch/);
+  });
+
+  it("rejects malformed signatures (length mismatch)", async () => {
+    const ts = Math.floor(Date.now() / 1000);
+    const req = makeRequest("x=1", ts, { signature: "v0=too-short" });
+    const result = await verifyNewsletterSlackRequest(req);
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.reason).toMatch(/[Ss]ignature mismatch/);
+  });
+
+  it("rejects the SAME signature seen twice (replay protection)", async () => {
+    const body = "command=%2Fnewsletter-list&text=&_replay=" + Date.now();
+    const ts = Math.floor(Date.now() / 1000);
+    const sig = signRequest(body, ts);
+
+    const first = await verifyNewsletterSlackRequest(makeRequest(body, ts, { signature: sig }));
+    expect(first.ok).toBe(true);
+
+    const second = await verifyNewsletterSlackRequest(makeRequest(body, ts, { signature: sig }));
+    expect(second.ok).toBe(false);
+    if (!second.ok) expect(second.reason).toMatch(/[Dd]uplicate|replay/);
+  });
+
+  it("does NOT cross-validate against the main Slack app's secret", async () => {
+    // A request signed for the MAIN app must not pass the NEWSLETTER verifier
+    // even if SLACK_SIGNING_SECRET is set in the env at the same time.
+    process.env.SLACK_SIGNING_SECRET = "main-cloudless-app-secret";
+    const ts = Math.floor(Date.now() / 1000);
+    const body = "x=1";
+    const sigForMainApp = signRequest(body, ts, "main-cloudless-app-secret");
+    const req = makeRequest(body, ts, { signature: sigForMainApp });
+    const result = await verifyNewsletterSlackRequest(req);
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.reason).toMatch(/[Ss]ignature mismatch/);
+  });
+});
+
+describe("unauthorizedNewsletterSlack", () => {
+  it("returns a 401 JSON Response", async () => {
+    const res = unauthorizedNewsletterSlack("test reason");
+    expect(res.status).toBe(401);
+    const body = await res.json();
+    expect(body).toEqual({ error: "Unauthorized" });
+  });
+});

--- a/scripts/setup-newsletter-slack-app.sh
+++ b/scripts/setup-newsletter-slack-app.sh
@@ -1,0 +1,161 @@
+#!/usr/bin/env bash
+# Bootstrap the DEDICATED Newsletter Slack app secrets into SSM + GH.
+#
+# Run AFTER installing the app at https://api.slack.com/apps from
+# slack-newsletter-app.manifest.json. Copy the bot token + signing secret
+# from the app's settings pages, then run:
+#
+#   bash scripts/setup-newsletter-slack-app.sh \
+#     --bot-token       "xoxb-..." \
+#     --signing-secret  "32-char-hex" \
+#     --channel         "C0BBDKY6Q9E"    # the #newsletter channel ID
+#
+# What it does:
+#   1. Stores NEWSLETTER_SLACK_BOT_TOKEN, NEWSLETTER_SLACK_SIGNING_SECRET,
+#      and NEWSLETTER_SLACK_CHANNEL_ID into AWS SSM at
+#      /cloudless/production/NEWSLETTER_SLACK_*
+#   2. Calls auth.test to verify the bot token + prints granted scopes
+#   3. Smoke-tests the signing secret by signing a request and posting it
+#      to the live /api/newsletter-slack/commands endpoint
+#   4. Posts a Block Kit "hello" to the #newsletter channel so you can see
+#      the new bot's avatar appear
+#
+# This script is idempotent — re-running it after a token rotation will
+# overwrite the SSM values cleanly.
+#
+# See companion: scripts/slack-app-doctor.sh (re-checkable health probe).
+set -u
+
+BOT_TOKEN=""
+SIGNING_SECRET=""
+CHANNEL=""
+ENDPOINT="https://cloudless.gr/api/newsletter-slack/commands"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --bot-token)       BOT_TOKEN="$2"; shift 2 ;;
+    --signing-secret)  SIGNING_SECRET="$2"; shift 2 ;;
+    --channel)         CHANNEL="$2"; shift 2 ;;
+    --endpoint)        ENDPOINT="$2"; shift 2 ;;
+    -h|--help)         sed -n '2,28p' "$0"; exit 0 ;;
+    *) echo "Unknown arg: $1" >&2; exit 2 ;;
+  esac
+done
+
+if [[ -z "$BOT_TOKEN" || -z "$SIGNING_SECRET" || -z "$CHANNEL" ]]; then
+  echo "✗ --bot-token, --signing-secret, and --channel are all required" >&2
+  echo "  Try --help for the full usage." >&2
+  exit 2
+fi
+
+REGION="${AWS_REGION:-us-east-1}"
+
+# ---------------------------------------------------------------------------
+# 1. Verify the bot token works (auth.test)
+# ---------------------------------------------------------------------------
+echo "=== 1. auth.test (verify bot token before we store it) ==="
+RESP=$(curl -sS -X POST https://slack.com/api/auth.test \
+  -H "Authorization: Bearer $BOT_TOKEN" \
+  -H "Content-Type: application/x-www-form-urlencoded")
+OK=$(echo "$RESP" | python3 -c "import sys,json; print(json.load(sys.stdin).get('ok',False))")
+if [[ "$OK" != "True" ]]; then
+  ERR=$(echo "$RESP" | python3 -c "import sys,json; print(json.load(sys.stdin).get('error','?'))")
+  echo "  ✗ auth.test failed: $ERR — refusing to store an invalid token" >&2
+  exit 1
+fi
+TEAM=$(echo "$RESP"    | python3 -c "import sys,json; print(json.load(sys.stdin).get('team',''))")
+BOT_USER=$(echo "$RESP" | python3 -c "import sys,json; print(json.load(sys.stdin).get('user',''))")
+echo "  ✓ team=$TEAM  bot_user=$BOT_USER"
+
+# ---------------------------------------------------------------------------
+# 2. Store secrets in SSM
+# ---------------------------------------------------------------------------
+echo
+echo "=== 2. Storing secrets in SSM (region $REGION) ==="
+for pair in \
+  "NEWSLETTER_SLACK_BOT_TOKEN:$BOT_TOKEN:SecureString" \
+  "NEWSLETTER_SLACK_SIGNING_SECRET:$SIGNING_SECRET:SecureString" \
+  "NEWSLETTER_SLACK_CHANNEL_ID:$CHANNEL:String"
+do
+  NAME="${pair%%:*}"
+  REST="${pair#*:}"
+  VALUE="${REST%:*}"
+  TYPE="${REST##*:}"
+  PATH="/cloudless/production/$NAME"
+  aws ssm put-parameter --region "$REGION" \
+    --name "$PATH" --type "$TYPE" --value "$VALUE" --overwrite \
+    >/dev/null
+  echo "  ✓ $PATH ($TYPE)"
+done
+
+# ---------------------------------------------------------------------------
+# 3. Smoke-test the signed-request round-trip against the deployed endpoint
+# ---------------------------------------------------------------------------
+echo
+echo "=== 3. Signed-request smoke test → $ENDPOINT ==="
+TS=$(date +%s)
+BODY="token=verify&team_id=T0BOOT&team_domain=test&channel_id=$CHANNEL&channel_name=newsletter&user_id=U0BOOT&user_name=bootstrap&command=%2Fnewsletter-help&text=&api_app_id=A0BOOT&is_enterprise_install=false&response_url=https%3A%2F%2Fhooks.slack.com%2Fcommands%2FT0%2F1%2Fabc&trigger_id=12345.67890.abcd"
+BASE="v0:${TS}:${BODY}"
+SIG="v0=$(printf '%s' "$BASE" | openssl dgst -sha256 -hmac "$SIGNING_SECRET" | awk '{print $2}')"
+CODE=$(curl -sS -o /tmp/setup-newsletter-resp.json -w '%{http_code}' \
+  -X POST "$ENDPOINT" \
+  -H 'Content-Type: application/x-www-form-urlencoded' \
+  -H "x-slack-request-timestamp: $TS" \
+  -H "x-slack-signature: $SIG" \
+  --data "$BODY")
+if [[ "$CODE" == "200" ]]; then
+  echo "  ✓ HTTP 200 — endpoint verified signature using the SSM-stored secret"
+elif [[ "$CODE" == "401" ]]; then
+  echo "  ⚠ HTTP 401 — endpoint rejected signature."
+  echo "    Reason: the Lambda may be reading a cached old secret. Wait ~5 min"
+  echo "    for the SSM cache to expire OR redeploy the app to force a re-read."
+else
+  echo "  ⚠ HTTP $CODE — unexpected"
+  head -c 400 /tmp/setup-newsletter-resp.json
+fi
+
+# ---------------------------------------------------------------------------
+# 4. Post a "hello" message to #newsletter so the bot avatar appears
+# ---------------------------------------------------------------------------
+echo
+echo "=== 4. chat.postMessage to $CHANNEL (hello) ==="
+RESP=$(curl -sS -X POST https://slack.com/api/chat.postMessage \
+  -H "Authorization: Bearer $BOT_TOKEN" \
+  -H "Content-Type: application/json; charset=utf-8" \
+  -d "{
+    \"channel\": \"$CHANNEL\",
+    \"text\": \":newspaper: Newsletter app installed — try \`/newsletter-help\` or open the App Home (:house: tab).\",
+    \"blocks\": [
+      {
+        \"type\": \"header\",
+        \"text\": { \"type\": \"plain_text\", \"text\": \":newspaper: Newsletter app installed\", \"emoji\": true }
+      },
+      {
+        \"type\": \"section\",
+        \"text\": {
+          \"type\": \"mrkdwn\",
+          \"text\": \"This is the dedicated Newsletter Slack app — separate from the main Cloudless app, with its own signing secret and bot token.\\n\\nTry:\\n• \`/newsletter-help\` — list all commands\\n• \`/newsletter-list\` — pending drafts + gate verdicts\\n• \`/newsletter-stats\` — subscribers + drafts + cadence\\n• Open the :house: Home tab — live 3-layer dashboard\"
+        }
+      }
+    ]
+  }")
+HELLO_OK=$(echo "$RESP" | python3 -c "import sys,json; print(json.load(sys.stdin).get('ok',False))")
+if [[ "$HELLO_OK" == "True" ]]; then
+  echo "  ✓ hello posted to $CHANNEL"
+else
+  ERR=$(echo "$RESP" | python3 -c "import sys,json; print(json.load(sys.stdin).get('error','?'))")
+  echo "  ⚠ chat.postMessage failed: $ERR"
+  echo "    Common fixes:"
+  echo "    • Invite the bot to the channel via '/invite @<bot>'"
+  echo "    • Add chat:write.public scope + reinstall"
+fi
+
+echo
+echo "✓ bootstrap complete. Next steps:"
+echo "  • Open Slack → Apps → Newsletter → Home tab — should show the 3-layer dashboard"
+echo "  • Re-run the doctor anytime:"
+echo "      bash scripts/slack-app-doctor.sh \\"
+echo "        --token \"$BOT_TOKEN\" \\"
+echo "        --signing-secret \"$SIGNING_SECRET\" \\"
+echo "        --channel \"$CHANNEL\" \\"
+echo "        --commands-url $ENDPOINT"

--- a/slack-newsletter-app.manifest.json
+++ b/slack-newsletter-app.manifest.json
@@ -1,0 +1,103 @@
+{
+  "display_information": {
+    "name": "Newsletter",
+    "description": "3-layer newsletter pipeline: management, control, check for the cloudless.gr weekly draft + publish chain",
+    "background_color": "#0B5174",
+    "long_description": "Dedicated Slack app for the cloudless.gr newsletter. Surfaces the 3-layer quality-gate state of every weekly draft (deterministic gates, LLM critic, and human ops review), lets approved users send + unpublish from chat, and exposes a live App Home dashboard showing the current draft, recent publishes, subscriber count, and rolling ops actions. Separate from the main Cloudless app so newsletter incidents (token rotation, scope changes, signing-secret leaks) never disrupt the rest of the Cloudless workspace integrations."
+  },
+  "features": {
+    "app_home": {
+      "home_tab_enabled": true,
+      "messages_tab_enabled": true,
+      "messages_tab_read_only_enabled": false
+    },
+    "bot_user": {
+      "display_name": "Newsletter",
+      "always_online": true
+    },
+    "slash_commands": [
+      {
+        "command": "/newsletter-list",
+        "url": "https://cloudless.gr/api/newsletter-slack/commands",
+        "description": "List pending Notion drafts (Draft + In Review) with 3-layer gate verdicts",
+        "usage_hint": "(no arguments)",
+        "should_escape": false
+      },
+      {
+        "command": "/newsletter-send",
+        "url": "https://cloudless.gr/api/newsletter-slack/commands",
+        "description": "Approve a draft + publish + email subscribers (ops allowlist)",
+        "usage_hint": "<slug-or-notion-id>",
+        "should_escape": false
+      },
+      {
+        "command": "/newsletter-unpublish",
+        "url": "https://cloudless.gr/api/newsletter-slack/commands",
+        "description": "Emergency rollback — flip a Published post to Archived (ops allowlist)",
+        "usage_hint": "<slug-or-notion-id>",
+        "should_escape": false
+      },
+      {
+        "command": "/newsletter-rerun-draft",
+        "url": "https://cloudless.gr/api/newsletter-slack/commands",
+        "description": "Re-trigger the weekly-article-draft.yml workflow (generates a fresh draft)",
+        "usage_hint": "(no arguments)",
+        "should_escape": false
+      },
+      {
+        "command": "/newsletter-gates",
+        "url": "https://cloudless.gr/api/newsletter-slack/commands",
+        "description": "Show 3-layer quality-gate thresholds + last verdict",
+        "usage_hint": "(no arguments)",
+        "should_escape": false
+      },
+      {
+        "command": "/newsletter-stats",
+        "url": "https://cloudless.gr/api/newsletter-slack/commands",
+        "description": "Subscriber count, last send time, this-week status",
+        "usage_hint": "(no arguments)",
+        "should_escape": false
+      },
+      {
+        "command": "/newsletter-help",
+        "url": "https://cloudless.gr/api/newsletter-slack/commands",
+        "description": "Show all /newsletter-* commands and the 3-layer flow",
+        "usage_hint": "(no arguments)",
+        "should_escape": false
+      }
+    ]
+  },
+  "oauth_config": {
+    "scopes": {
+      "bot": [
+        "app_mentions:read",
+        "channels:join",
+        "channels:read",
+        "chat:write",
+        "chat:write.customize",
+        "commands",
+        "im:history",
+        "im:write",
+        "team:read",
+        "users:read"
+      ]
+    }
+  },
+  "settings": {
+    "event_subscriptions": {
+      "request_url": "https://cloudless.gr/api/newsletter-slack/events",
+      "bot_events": [
+        "app_home_opened",
+        "app_mention",
+        "message.im"
+      ]
+    },
+    "interactivity": {
+      "is_enabled": true,
+      "request_url": "https://cloudless.gr/api/newsletter-slack/interactions"
+    },
+    "org_deploy_enabled": false,
+    "socket_mode_enabled": false,
+    "token_rotation_enabled": false
+  }
+}

--- a/src/app/api/newsletter-slack/commands/route.ts
+++ b/src/app/api/newsletter-slack/commands/route.ts
@@ -1,0 +1,444 @@
+/**
+ * Slash command endpoint for the DEDICATED Newsletter Slack app.
+ *
+ *   /newsletter-list         — pending Notion drafts + 3-layer gate verdict
+ *   /newsletter-send         — approve + publish + email subscribers (ops)
+ *   /newsletter-unpublish    — flip Status to Archived (ops)
+ *   /newsletter-rerun-draft  — re-trigger weekly-article-draft.yml
+ *   /newsletter-gates        — show 3-layer thresholds + last verdict summary
+ *   /newsletter-stats        — subscriber count + last send time
+ *   /newsletter-help         — usage cheat-sheet
+ *
+ * This app has its own bot token + signing secret. See
+ * src/lib/newsletter-slack-{verify,config}.ts.
+ */
+
+import {
+  verifyNewsletterSlackRequest,
+  unauthorizedNewsletterSlack,
+} from "@/lib/newsletter-slack-verify";
+import { checkSlackRateLimit } from "@/lib/slack-rate-limit";
+import {
+  listEditorialPosts,
+  findEditorialPost,
+  setEditorialStatus,
+  type NotionBlogDraft,
+} from "@/lib/notion-blog-admin";
+import { dispatchWorkflow } from "@/lib/github-dispatch";
+import { listNewsletterSubscribers as listSubscribers } from "@/lib/hubspot";
+import { getNewsletterSlackConfigAsync } from "@/lib/newsletter-slack-config";
+
+interface SlashPayload {
+  command: string;
+  text: string;
+  user_id: string;
+  user_name: string;
+  channel_id: string;
+  response_url: string;
+  trigger_id: string;
+}
+
+const SLACK_OPS_USERS = (process.env.SLACK_OPS_USERS ?? "")
+  .split(",")
+  .map((s) => s.trim())
+  .filter(Boolean);
+
+export async function POST(request: Request): Promise<Response> {
+  const verified = await verifyNewsletterSlackRequest(request);
+  if (!verified.ok) return unauthorizedNewsletterSlack(verified.reason);
+
+  const rateLimitKey = request.headers.get("x-forwarded-for") ?? "unknown";
+  if (!checkSlackRateLimit(rateLimitKey)) {
+    return Response.json({ error: "Too many requests" }, { status: 429 });
+  }
+
+  const params = new URLSearchParams(verified.body);
+  const payload: SlashPayload = {
+    command: params.get("command") ?? "",
+    text: params.get("text") ?? "",
+    user_id: params.get("user_id") ?? "",
+    user_name: params.get("user_name") ?? "",
+    channel_id: params.get("channel_id") ?? "",
+    response_url: params.get("response_url") ?? "",
+    trigger_id: params.get("trigger_id") ?? "",
+  };
+
+  switch (payload.command) {
+    case "/newsletter-list":
+      return handleList();
+    case "/newsletter-send":
+      return handleSend(payload);
+    case "/newsletter-unpublish":
+      return handleUnpublish(payload);
+    case "/newsletter-rerun-draft":
+      return handleRerunDraft(payload);
+    case "/newsletter-gates":
+      return handleGates();
+    case "/newsletter-stats":
+      return handleStats();
+    case "/newsletter-help":
+      return handleHelp();
+    default:
+      return slackResponse({
+        response_type: "ephemeral",
+        text: `Unknown command: \`${payload.command}\`. Try \`/newsletter-help\`.`,
+      });
+  }
+}
+
+// ---------------------------------------------------------------------------
+// /newsletter-list
+// ---------------------------------------------------------------------------
+
+function formatPostLine(p: NotionBlogDraft): string {
+  const statusEmoji = p.status === "In Review" ? ":eyes:" : ":memo:";
+  const createdTs = p.createdAt ? Math.floor(new Date(p.createdAt).getTime() / 1000) : 0;
+  const dateLabel = createdTs
+    ? `<!date^${createdTs}^{date_short_pretty}|${p.createdAt.slice(0, 10)}>`
+    : "—";
+  const slugBit = p.slug ? `\`${p.slug}\`` : `\`${p.id.slice(0, 8)}\``;
+  return `${statusEmoji} *<${p.url}|${p.title}>* — ${p.category} · ${p.readTime} · ${dateLabel}\n   ${slugBit}`;
+}
+
+async function handleList(): Promise<Response> {
+  const posts = await listEditorialPosts();
+  if (posts.length === 0) {
+    return slackResponse({
+      response_type: "ephemeral",
+      text:
+        ":mailbox_with_no_mail: No pending drafts in Notion. " +
+        "Try `/newsletter-rerun-draft` to generate one.",
+    });
+  }
+  return slackResponse({
+    response_type: "ephemeral",
+    blocks: [
+      {
+        type: "header",
+        text: {
+          type: "plain_text",
+          text: `:newspaper: Pending Drafts (${posts.length})`,
+          emoji: true,
+        },
+      },
+      {
+        type: "section",
+        text: { type: "mrkdwn", text: posts.map(formatPostLine).join("\n\n") },
+      },
+      {
+        type: "context",
+        elements: [
+          {
+            type: "mrkdwn",
+            text: ":memo: = Draft (gates blocked) · :eyes: = In Review (gates passed) — `/newsletter-send <slug>` to ship",
+          },
+        ],
+      },
+    ],
+  });
+}
+
+// ---------------------------------------------------------------------------
+// /newsletter-send
+// ---------------------------------------------------------------------------
+
+async function handleSend(payload: SlashPayload): Promise<Response> {
+  const target = payload.text.trim();
+  if (!target) {
+    return slackResponse({
+      response_type: "ephemeral",
+      text:
+        "Usage: `/newsletter-send <slug-or-notion-id>`\n" +
+        "Tip: run `/newsletter-list` first to see available drafts.",
+    });
+  }
+
+  if (SLACK_OPS_USERS.length > 0 && !SLACK_OPS_USERS.includes(payload.user_id)) {
+    return slackResponse({
+      response_type: "ephemeral",
+      text:
+        ":no_entry: You are not on the ops allowlist for newsletter sends. " +
+        "Ask the admin to add your Slack user ID to `SLACK_OPS_USERS`.",
+    });
+  }
+
+  const post = await findEditorialPost(target);
+  if (!post) {
+    return slackResponse({
+      response_type: "ephemeral",
+      text:
+        `:warning: No Notion draft matching \`${target}\`. ` +
+        "Run `/newsletter-list` to see what is available.",
+    });
+  }
+  if (post.status === "Published") {
+    return slackResponse({
+      response_type: "ephemeral",
+      text: `:information_source: *${post.title}* is already Published.`,
+    });
+  }
+
+  const flipped = await setEditorialStatus(post.id, "In Review");
+  if (!flipped) {
+    return slackResponse({
+      response_type: "ephemeral",
+      text: ":warning: Failed to update Notion. Check NOTION_API_KEY in SSM.",
+    });
+  }
+
+  const result = await dispatchWorkflow("weekly-newsletter.yml", "main");
+  if (!result.ok) {
+    return slackResponse({
+      response_type: "ephemeral",
+      text:
+        `:warning: Notion updated to *In Review* but workflow dispatch failed ` +
+        `(HTTP ${result.status}): \`${result.error.slice(0, 200)}\`.`,
+    });
+  }
+
+  return slackResponse({
+    response_type: "in_channel",
+    blocks: [
+      {
+        type: "header",
+        text: { type: "plain_text", text: ":rocket: Send Initiated", emoji: true },
+      },
+      {
+        type: "section",
+        text: {
+          type: "mrkdwn",
+          text:
+            `<@${payload.user_id}> approved *<${post.url}|${post.title}>* ` +
+            `(${post.category} · ${post.readTime}) and triggered the publisher.\n\n` +
+            `Workflow will render → mark Published in Notion → revalidate ` +
+            `\`/blog/${post.slug}\` → SES-send to every subscriber.`,
+        },
+      },
+    ],
+  });
+}
+
+// ---------------------------------------------------------------------------
+// /newsletter-unpublish
+// ---------------------------------------------------------------------------
+
+async function handleUnpublish(payload: SlashPayload): Promise<Response> {
+  const target = payload.text.trim();
+  if (!target) {
+    return slackResponse({
+      response_type: "ephemeral",
+      text:
+        "Usage: `/newsletter-unpublish <slug-or-notion-id>`\n" +
+        "Flips Notion Status to `Archived`. `/blog/<slug>` will 404 within the next ISR cycle.",
+    });
+  }
+  if (SLACK_OPS_USERS.length > 0 && !SLACK_OPS_USERS.includes(payload.user_id)) {
+    return slackResponse({
+      response_type: "ephemeral",
+      text: ":no_entry: Not on ops allowlist (`SLACK_OPS_USERS`).",
+    });
+  }
+
+  const post = await findEditorialPost(target);
+  if (!post) {
+    return slackResponse({
+      response_type: "ephemeral",
+      text: `:warning: No Notion post matching \`${target}\`.`,
+    });
+  }
+  const flipped = await setEditorialStatus(post.id, "Archived");
+  if (!flipped) {
+    return slackResponse({
+      response_type: "ephemeral",
+      text: ":warning: Failed to update Notion. Check NOTION_API_KEY in SSM.",
+    });
+  }
+  return slackResponse({
+    response_type: "in_channel",
+    blocks: [
+      {
+        type: "header",
+        text: { type: "plain_text", text: ":wastebasket: Unpublished", emoji: true },
+      },
+      {
+        type: "section",
+        text: {
+          type: "mrkdwn",
+          text:
+            `<@${payload.user_id}> archived *<${post.url}|${post.title}>*.\n` +
+            "Emails already in inboxes are not recallable.",
+        },
+      },
+    ],
+  });
+}
+
+// ---------------------------------------------------------------------------
+// /newsletter-rerun-draft
+// ---------------------------------------------------------------------------
+
+async function handleRerunDraft(payload: SlashPayload): Promise<Response> {
+  if (SLACK_OPS_USERS.length > 0 && !SLACK_OPS_USERS.includes(payload.user_id)) {
+    return slackResponse({
+      response_type: "ephemeral",
+      text: ":no_entry: Not on ops allowlist for draft re-runs.",
+    });
+  }
+  const result = await dispatchWorkflow("weekly-article-draft.yml", "main");
+  if (!result.ok) {
+    return slackResponse({
+      response_type: "ephemeral",
+      text:
+        `:warning: Re-run failed (HTTP ${result.status}): ` + `\`${result.error.slice(0, 200)}\``,
+    });
+  }
+  return slackResponse({
+    response_type: "ephemeral",
+    text:
+      ":arrows_counterclockwise: Re-triggered `weekly-article-draft.yml`. " +
+      "New draft will appear in Notion within ~2 minutes. " +
+      "Run `/newsletter-list` to see it and the gate verdict.",
+  });
+}
+
+// ---------------------------------------------------------------------------
+// /newsletter-gates
+// ---------------------------------------------------------------------------
+
+function handleGates(): Response {
+  return slackResponse({
+    response_type: "ephemeral",
+    blocks: [
+      {
+        type: "header",
+        text: { type: "plain_text", text: ":shield: 3-Layer Quality Gates", emoji: true },
+      },
+      {
+        type: "section",
+        text: {
+          type: "mrkdwn",
+          text: [
+            "*Layer 1 — Deterministic (always runs):*",
+            "• Word count: 700–1400",
+            "• ≥3 H2 sections",
+            "• No banned phrases (AI disclaimers, lorem ipsum, click-bait)",
+            "• No forbidden topics (politics, crypto, competitors)",
+            "• Title novelty ≤75% overlap vs last 5 posts",
+            "• No placeholder tokens (TODO, <insert>, ???)",
+            "",
+            "*Layer 2 — LLM Critic (`@cf/meta/llama-3.1-8b-instruct-fast`):*",
+            "• Min score: 7.0/10",
+            "• Schema-validated JSON verdict (factuality, novelty, tone, action)",
+            "• Unavailable critic → conservative HOLD (stays Draft)",
+            "",
+            "*Layer 3 — Human Ops Override (this app):*",
+            "• `/newsletter-send <slug>` — manual override of a HOLD",
+            "• `/newsletter-unpublish <slug>` — emergency rollback",
+            "• Both gated on `SLACK_OPS_USERS` allowlist",
+          ].join("\n"),
+        },
+      },
+      {
+        type: "context",
+        elements: [
+          {
+            type: "mrkdwn",
+            text: "Code: `scripts/article-quality-gates.ts` · Auto-promotion: `In Review` on PASS, `Draft` on HOLD",
+          },
+        ],
+      },
+    ],
+  });
+}
+
+// ---------------------------------------------------------------------------
+// /newsletter-stats
+// ---------------------------------------------------------------------------
+
+async function handleStats(): Promise<Response> {
+  let subscriberCount = 0;
+  try {
+    const subs = await listSubscribers();
+    subscriberCount = subs.length;
+  } catch (err) {
+    console.warn("[NewsletterSlack] stats: subscriber count failed:", err);
+  }
+
+  const posts = await listEditorialPosts().catch(() => []);
+  const draftCount = posts.filter((p) => p.status === "Draft").length;
+  const inReviewCount = posts.filter((p) => p.status === "In Review").length;
+
+  return slackResponse({
+    response_type: "ephemeral",
+    blocks: [
+      {
+        type: "header",
+        text: { type: "plain_text", text: ":bar_chart: Newsletter Stats", emoji: true },
+      },
+      {
+        type: "section",
+        fields: [
+          { type: "mrkdwn", text: `*Subscribers*\n${subscriberCount}` },
+          { type: "mrkdwn", text: `*Pending drafts*\n${draftCount} (gates blocked)` },
+          { type: "mrkdwn", text: `*In Review*\n${inReviewCount} (ready to send)` },
+          { type: "mrkdwn", text: `*Cadence*\nMon 08:15 UTC draft · 11:15 publish` },
+        ],
+      },
+    ],
+  });
+}
+
+// ---------------------------------------------------------------------------
+// /newsletter-help
+// ---------------------------------------------------------------------------
+
+function handleHelp(): Response {
+  return slackResponse({
+    response_type: "ephemeral",
+    blocks: [
+      {
+        type: "header",
+        text: { type: "plain_text", text: ":newspaper: Newsletter — Commands", emoji: true },
+      },
+      {
+        type: "section",
+        text: {
+          type: "mrkdwn",
+          text: [
+            "• `/newsletter-list` — pending drafts + gate verdicts",
+            "• `/newsletter-send <slug>` — approve + publish + email subscribers",
+            "• `/newsletter-unpublish <slug>` — emergency rollback",
+            "• `/newsletter-rerun-draft` — re-generate this week's draft",
+            "• `/newsletter-gates` — show 3-layer thresholds",
+            "• `/newsletter-stats` — subscribers, drafts, cadence",
+            "• `/newsletter-help` — this card",
+          ].join("\n"),
+        },
+      },
+      {
+        type: "context",
+        elements: [
+          {
+            type: "mrkdwn",
+            text: "App Home (the :house: tab) shows the live 3-layer status dashboard.",
+          },
+        ],
+      },
+    ],
+  });
+}
+
+// ---------------------------------------------------------------------------
+// helpers
+// ---------------------------------------------------------------------------
+
+function slackResponse(body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+// Touch the async config getter once at module load so any missing-secret
+// warning surfaces in Lambda logs before the first real request.
+void getNewsletterSlackConfigAsync().catch(() => {});

--- a/src/app/api/newsletter-slack/events/route.ts
+++ b/src/app/api/newsletter-slack/events/route.ts
@@ -1,0 +1,421 @@
+/**
+ * Events API endpoint for the DEDICATED Newsletter Slack app.
+ *
+ * Handles:
+ *   - url_verification         (one-time during app setup)
+ *   - app_home_opened          → publishes the 3-layer status dashboard view
+ *   - app_mention              → bot was @mentioned in a channel
+ *   - message.im               → DM to the bot
+ *
+ * Uses a separate signing secret + bot token from the main Cloudless app.
+ * See src/lib/newsletter-slack-{verify,config}.ts.
+ */
+
+import {
+  verifyNewsletterSlackRequest,
+  unauthorizedNewsletterSlack,
+} from "@/lib/newsletter-slack-verify";
+import { checkSlackRateLimit } from "@/lib/slack-rate-limit";
+import { getNewsletterSlackConfigAsync } from "@/lib/newsletter-slack-config";
+import { listEditorialPosts, type NotionBlogDraft } from "@/lib/notion-blog-admin";
+import { listNewsletterSubscribers as listSubscribers } from "@/lib/hubspot";
+
+// ---------------------------------------------------------------------------
+// Event deduplication (Slack retries up to 3x within ~5min on no-200)
+// ---------------------------------------------------------------------------
+
+const DEDUP_TTL_MS = 5 * 60 * 1000;
+const seenEventIds = new Map<string, number>();
+
+function isDuplicate(eventId: string): boolean {
+  const now = Date.now();
+  for (const [id, ts] of seenEventIds) {
+    if (now - ts > DEDUP_TTL_MS) seenEventIds.delete(id);
+  }
+  if (seenEventIds.has(eventId)) return true;
+  seenEventIds.set(eventId, now);
+  return false;
+}
+
+// ---------------------------------------------------------------------------
+// Payload types (subset of Slack Events API)
+// ---------------------------------------------------------------------------
+
+interface SlackUrlVerification {
+  type: "url_verification";
+  challenge: string;
+  token: string;
+}
+
+interface SlackEventCallback {
+  type: "event_callback";
+  team_id: string;
+  event: SlackEvent;
+  event_id: string;
+  event_time: number;
+}
+
+interface SlackEvent {
+  type: string;
+  user?: string;
+  text?: string;
+  channel?: string;
+  channel_type?: string;
+  ts?: string;
+  bot_id?: string;
+  tab?: string;
+}
+
+type SlackPayload = SlackUrlVerification | SlackEventCallback;
+
+// ---------------------------------------------------------------------------
+// Route handler
+// ---------------------------------------------------------------------------
+
+export async function POST(request: Request): Promise<Response> {
+  const verified = await verifyNewsletterSlackRequest(request);
+  if (!verified.ok) return unauthorizedNewsletterSlack(verified.reason);
+
+  const rateLimitKey = request.headers.get("x-forwarded-for") ?? "unknown";
+  if (!checkSlackRateLimit(rateLimitKey)) {
+    return Response.json({ error: "Too many requests" }, { status: 429 });
+  }
+
+  let payload: SlackPayload;
+  try {
+    payload = JSON.parse(verified.body) as SlackPayload;
+  } catch {
+    return Response.json({ error: "Invalid JSON" }, { status: 400 });
+  }
+
+  if (payload.type === "url_verification") {
+    return Response.json({ challenge: payload.challenge });
+  }
+
+  if (payload.type === "event_callback") {
+    if (isDuplicate(payload.event_id)) {
+      return Response.json({ ok: true });
+    }
+    // Respond 200 immediately; offload heavy work to background promise.
+    handleEvent(payload.event).catch((err: unknown) => {
+      console.error("[NewsletterSlack Events] handler error:", err);
+    });
+    return Response.json({ ok: true });
+  }
+
+  return Response.json({ ok: true });
+}
+
+// ---------------------------------------------------------------------------
+// Event dispatch
+// ---------------------------------------------------------------------------
+
+async function handleEvent(event: SlackEvent): Promise<void> {
+  if (event.bot_id) return; // ignore loopbacks
+
+  switch (event.type) {
+    case "app_home_opened":
+      if (!event.tab || event.tab === "home") {
+        await publishAppHome(event);
+      }
+      break;
+    case "app_mention":
+      await handleAppMention(event);
+      break;
+    case "message":
+      if (event.channel?.startsWith("D")) {
+        await handleDirectMessage(event);
+      }
+      break;
+    default:
+      console.warn(`[NewsletterSlack Events] Unhandled event type: ${event.type}`);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// App Home — the 3-layer status dashboard
+// ---------------------------------------------------------------------------
+
+interface DashboardData {
+  drafts: NotionBlogDraft[];
+  subscriberCount: number;
+  subscribersOk: boolean;
+}
+
+async function gatherDashboardData(): Promise<DashboardData> {
+  const [drafts, subs] = await Promise.all([
+    listEditorialPosts().catch((err: unknown) => {
+      console.warn("[NewsletterSlack Home] listEditorialPosts failed:", err);
+      return [] as NotionBlogDraft[];
+    }),
+    listSubscribers()
+      .then((arr: string[]) => ({ ok: true, count: arr.length }))
+      .catch((err: unknown) => {
+        console.warn("[NewsletterSlack Home] listSubscribers failed:", err);
+        return { ok: false, count: 0 };
+      }),
+  ]);
+  return { drafts, subscriberCount: subs.count, subscribersOk: subs.ok };
+}
+
+function renderHomeView(userId: string, data: DashboardData): unknown {
+  const draftCount = data.drafts.filter((p) => p.status === "Draft").length;
+  const inReviewCount = data.drafts.filter((p) => p.status === "In Review").length;
+  const ts = Math.floor(Date.now() / 1_000);
+  const dateLabel = `<!date^${ts}^{date_short_pretty} at {time}|${new Date().toISOString()}>`;
+  const subscriberCell = data.subscribersOk
+    ? `*Subscribers*\n${data.subscriberCount}`
+    : `*Subscribers*\n— (HubSpot error)`;
+
+  // Current week's top draft (most recent by createdAt)
+  const sorted = [...data.drafts].sort((a, b) =>
+    (b.createdAt || "").localeCompare(a.createdAt || "")
+  );
+  const top = sorted[0];
+
+  const currentBlocks: unknown[] = top
+    ? [
+        {
+          type: "section",
+          text: {
+            type: "mrkdwn",
+            text:
+              `*This week's draft:* <${top.url}|${top.title}>\n` +
+              `Category: \`${top.category}\` · ${top.readTime} · Status: \`${top.status || "—"}\`\n` +
+              `Slug: \`${top.slug}\``,
+          },
+        },
+      ]
+    : [
+        {
+          type: "section",
+          text: {
+            type: "mrkdwn",
+            text:
+              ":mailbox_with_no_mail: *No draft yet this week.* " +
+              "Use `/newsletter-rerun-draft` to generate one.",
+          },
+        },
+      ];
+
+  const recentList = sorted
+    .slice(0, 5)
+    .map((p) => {
+      const icon =
+        p.status === "In Review"
+          ? ":eyes:"
+          : p.status === "Published"
+            ? ":white_check_mark:"
+            : ":memo:";
+      return `${icon} <${p.url}|${p.title}> — \`${p.status || "—"}\``;
+    })
+    .join("\n");
+
+  return {
+    type: "home",
+    blocks: [
+      {
+        type: "header",
+        text: { type: "plain_text", text: ":newspaper: Newsletter — 3-Layer Control", emoji: true },
+      },
+      {
+        type: "section",
+        text: {
+          type: "mrkdwn",
+          text:
+            `Hi <@${userId}>! This is the dedicated dashboard for the cloudless.gr ` +
+            "newsletter pipeline. The 3 layers (deterministic gates → LLM critic → " +
+            "human ops override) are surfaced live below.",
+        },
+      },
+      { type: "divider" },
+      {
+        type: "section",
+        fields: [
+          {
+            type: "mrkdwn",
+            text: `*:hourglass_flowing_sand: Pending drafts*\n${draftCount} (gates HOLD)`,
+          },
+          { type: "mrkdwn", text: `*:eyes: In Review*\n${inReviewCount} (ready to send)` },
+          { type: "mrkdwn", text: subscriberCell },
+          { type: "mrkdwn", text: `*:clock1: Updated*\n${dateLabel}` },
+        ],
+      },
+      { type: "divider" },
+      { type: "header", text: { type: "plain_text", text: ":calendar: This Week", emoji: true } },
+      ...currentBlocks,
+      ...(top
+        ? [
+            {
+              type: "actions",
+              elements: [
+                {
+                  type: "button",
+                  text: { type: "plain_text", text: "Open in Notion", emoji: true },
+                  url: top.url,
+                  action_id: "home_open_notion",
+                },
+                {
+                  type: "button",
+                  style: "primary",
+                  text: { type: "plain_text", text: "Send Now", emoji: true },
+                  action_id: "home_send",
+                  value: top.slug || top.id,
+                  confirm: {
+                    title: { type: "plain_text", text: "Send Newsletter?" },
+                    text: {
+                      type: "plain_text",
+                      text: `This will email "${top.title}" to all ${data.subscriberCount} subscribers via SES. This action cannot be undone.`,
+                    },
+                    confirm: { type: "plain_text", text: "Send" },
+                    deny: { type: "plain_text", text: "Cancel" },
+                  },
+                },
+                {
+                  type: "button",
+                  style: "danger",
+                  text: { type: "plain_text", text: "Unpublish", emoji: true },
+                  action_id: "home_unpublish",
+                  value: top.slug || top.id,
+                  confirm: {
+                    title: { type: "plain_text", text: "Archive post?" },
+                    text: {
+                      type: "plain_text",
+                      text: `Flips "${top.title}" Notion Status to Archived. /blog/${top.slug} will 404 within ~5min. Already-sent emails cannot be recalled.`,
+                    },
+                    confirm: { type: "plain_text", text: "Archive" },
+                    deny: { type: "plain_text", text: "Cancel" },
+                  },
+                },
+              ],
+            },
+          ]
+        : []),
+      { type: "divider" },
+      {
+        type: "header",
+        text: { type: "plain_text", text: ":scroll: Recent Drafts", emoji: true },
+      },
+      {
+        type: "section",
+        text: {
+          type: "mrkdwn",
+          text: recentList || "_(none yet)_",
+        },
+      },
+      { type: "divider" },
+      {
+        type: "header",
+        text: { type: "plain_text", text: ":shield: 3-Layer Gates", emoji: true },
+      },
+      {
+        type: "section",
+        text: {
+          type: "mrkdwn",
+          text:
+            "*Layer 1 — Deterministic*: word count, H2 count, banned phrases, forbidden topics, title novelty, placeholder check.\n" +
+            "*Layer 2 — LLM Critic*: `@cf/meta/llama-3.1-8b-instruct-fast` scores ≥7/10 with schema-validated JSON.\n" +
+            "*Layer 3 — Human Ops*: this app's `/newsletter-send` & `/newsletter-unpublish` (allowlist gated).",
+        },
+      },
+      { type: "divider" },
+      {
+        type: "actions",
+        elements: [
+          {
+            type: "button",
+            text: { type: "plain_text", text: "Re-run Draft Now", emoji: true },
+            action_id: "home_rerun_draft",
+          },
+          {
+            type: "button",
+            text: { type: "plain_text", text: "Open Notion DB", emoji: true },
+            url: "https://app.notion.com",
+            action_id: "home_open_notion_db",
+          },
+          {
+            type: "button",
+            text: { type: "plain_text", text: "View Live Blog", emoji: true },
+            url: "https://cloudless.gr/blog",
+            action_id: "home_open_blog",
+          },
+        ],
+      },
+      {
+        type: "context",
+        elements: [
+          {
+            type: "mrkdwn",
+            text: "Cadence: Mon 08:15 UTC draft → 11:15 UTC publish · Code: `scripts/article-quality-gates.ts`",
+          },
+        ],
+      },
+    ],
+  };
+}
+
+async function publishAppHome(event: SlackEvent): Promise<void> {
+  const userId = event.user;
+  if (!userId) return;
+
+  const cfg = await getNewsletterSlackConfigAsync();
+  const token = cfg.NEWSLETTER_SLACK_BOT_TOKEN;
+  if (!token) {
+    console.warn("[NewsletterSlack Home] no bot token — skipping views.publish");
+    return;
+  }
+
+  const data = await gatherDashboardData();
+  const view = renderHomeView(userId, data);
+
+  const resp = await fetch("https://slack.com/api/views.publish", {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${token}`,
+      "Content-Type": "application/json; charset=utf-8",
+    },
+    body: JSON.stringify({ user_id: userId, view }),
+  });
+  const json = (await resp.json()) as { ok: boolean; error?: string };
+  if (!json.ok) {
+    console.warn(`[NewsletterSlack Home] views.publish failed: ${json.error}`);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// App mentions + DMs — funnel users to App Home
+// ---------------------------------------------------------------------------
+
+async function postSimpleMessage(channel: string, text: string): Promise<void> {
+  const cfg = await getNewsletterSlackConfigAsync();
+  const token = cfg.NEWSLETTER_SLACK_BOT_TOKEN;
+  if (!token) return;
+  await fetch("https://slack.com/api/chat.postMessage", {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${token}`,
+      "Content-Type": "application/json; charset=utf-8",
+    },
+    body: JSON.stringify({ channel, text }),
+  }).catch((err: unknown) => console.warn("[NewsletterSlack] chat.postMessage failed:", err));
+}
+
+const HELP_TEXT =
+  "Hi! I am the Newsletter bot. Use these slash commands:\n" +
+  "• `/newsletter-list` — pending drafts + gate verdicts\n" +
+  "• `/newsletter-send <slug>` — approve + publish + email subscribers\n" +
+  "• `/newsletter-unpublish <slug>` — emergency rollback\n" +
+  "• `/newsletter-rerun-draft` — re-generate this week's draft\n" +
+  "• `/newsletter-gates` — show 3-layer thresholds\n" +
+  "• `/newsletter-stats` — subscribers, drafts, cadence\n" +
+  "Or open the :house: Home tab for the live dashboard.";
+
+async function handleAppMention(event: SlackEvent): Promise<void> {
+  if (!event.channel) return;
+  await postSimpleMessage(event.channel, HELP_TEXT);
+}
+
+async function handleDirectMessage(event: SlackEvent): Promise<void> {
+  if (!event.channel) return;
+  await postSimpleMessage(event.channel, HELP_TEXT);
+}

--- a/src/app/api/newsletter-slack/interactions/route.ts
+++ b/src/app/api/newsletter-slack/interactions/route.ts
@@ -1,0 +1,198 @@
+/**
+ * Interactions endpoint for the DEDICATED Newsletter Slack app.
+ *
+ * Handles Block Kit button payloads posted in App Home and in pings
+ * the bot publishes elsewhere. The action_ids correspond to buttons
+ * the events route renders into the App Home view.
+ *
+ *   home_send             — confirm modal already accepted → flip status + dispatch publisher
+ *   home_unpublish        — confirm modal already accepted → flip status to Archived
+ *   home_rerun_draft      — re-trigger weekly-article-draft.yml
+ *   home_open_*           — link-only buttons, no server side effect (Slack opens URL)
+ *
+ * All destructive actions check SLACK_OPS_USERS like the slash commands do.
+ */
+
+import {
+  verifyNewsletterSlackRequest,
+  unauthorizedNewsletterSlack,
+} from "@/lib/newsletter-slack-verify";
+import { checkSlackRateLimit } from "@/lib/slack-rate-limit";
+import { findEditorialPost, setEditorialStatus } from "@/lib/notion-blog-admin";
+import { dispatchWorkflow } from "@/lib/github-dispatch";
+
+interface ButtonAction {
+  action_id: string;
+  value?: string;
+  type?: string;
+}
+
+interface BlockActionsPayload {
+  type: "block_actions";
+  user: { id: string; username?: string };
+  actions: ButtonAction[];
+  response_url?: string;
+}
+
+const SLACK_OPS_USERS = (process.env.SLACK_OPS_USERS ?? "")
+  .split(",")
+  .map((s) => s.trim())
+  .filter(Boolean);
+
+export async function POST(request: Request): Promise<Response> {
+  const verified = await verifyNewsletterSlackRequest(request);
+  if (!verified.ok) return unauthorizedNewsletterSlack(verified.reason);
+
+  const rateLimitKey = request.headers.get("x-forwarded-for") ?? "unknown";
+  if (!checkSlackRateLimit(rateLimitKey)) {
+    return Response.json({ error: "Too many requests" }, { status: 429 });
+  }
+
+  const params = new URLSearchParams(verified.body);
+  const raw = params.get("payload");
+  if (!raw) return Response.json({ error: "Missing payload" }, { status: 400 });
+
+  let payload: BlockActionsPayload;
+  try {
+    payload = JSON.parse(raw) as BlockActionsPayload;
+  } catch {
+    return Response.json({ error: "Invalid JSON payload" }, { status: 400 });
+  }
+
+  if (payload.type !== "block_actions") {
+    return Response.json({ ok: true });
+  }
+
+  const action = payload.actions?.[0];
+  if (!action) return Response.json({ ok: true });
+
+  const userId = payload.user?.id ?? "";
+  const responseUrl = payload.response_url ?? "";
+
+  // Link-only buttons — Slack already opens the URL client-side.
+  if (action.action_id.startsWith("home_open_")) {
+    return Response.json({ ok: true });
+  }
+
+  // Destructive actions defer to background; respond 200 immediately so
+  // Slack does not retry. The response_url posts the result asynchronously.
+  switch (action.action_id) {
+    case "home_send":
+      handleSend(userId, action.value ?? "", responseUrl).catch((err) =>
+        console.error("[NewsletterSlack interactions] home_send error:", err)
+      );
+      return Response.json({ ok: true });
+    case "home_unpublish":
+      handleUnpublish(userId, action.value ?? "", responseUrl).catch((err) =>
+        console.error("[NewsletterSlack interactions] home_unpublish error:", err)
+      );
+      return Response.json({ ok: true });
+    case "home_rerun_draft":
+      handleRerunDraft(userId, responseUrl).catch((err) =>
+        console.error("[NewsletterSlack interactions] home_rerun_draft error:", err)
+      );
+      return Response.json({ ok: true });
+    default:
+      console.warn(`[NewsletterSlack interactions] Unknown action: ${action.action_id}`);
+      return Response.json({ ok: true });
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Handlers (run in background; reply via response_url)
+// ---------------------------------------------------------------------------
+
+function isAllowed(userId: string): boolean {
+  return SLACK_OPS_USERS.length === 0 || SLACK_OPS_USERS.includes(userId);
+}
+
+async function replyEphemeral(responseUrl: string, text: string): Promise<void> {
+  if (!responseUrl) return;
+  await fetch(responseUrl, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ response_type: "ephemeral", text }),
+  }).catch((err) => console.warn("[NewsletterSlack] response_url POST failed:", err));
+}
+
+async function handleSend(userId: string, target: string, responseUrl: string): Promise<void> {
+  if (!isAllowed(userId)) {
+    await replyEphemeral(responseUrl, ":no_entry: You are not on the ops allowlist.");
+    return;
+  }
+  if (!target) {
+    await replyEphemeral(responseUrl, ":warning: No target slug.");
+    return;
+  }
+
+  const post = await findEditorialPost(target);
+  if (!post) {
+    await replyEphemeral(responseUrl, `:warning: No Notion draft matching \`${target}\`.`);
+    return;
+  }
+  if (post.status === "Published") {
+    await replyEphemeral(responseUrl, `:information_source: *${post.title}* is already Published.`);
+    return;
+  }
+  const flipped = await setEditorialStatus(post.id, "In Review");
+  if (!flipped) {
+    await replyEphemeral(responseUrl, ":warning: Failed to update Notion status.");
+    return;
+  }
+  const result = await dispatchWorkflow("weekly-newsletter.yml", "main");
+  if (!result.ok) {
+    await replyEphemeral(
+      responseUrl,
+      `:warning: Notion updated but workflow dispatch failed (HTTP ${result.status}).`
+    );
+    return;
+  }
+  await replyEphemeral(
+    responseUrl,
+    `:rocket: <@${userId}> queued *${post.title}* for send. Publisher will render + email subscribers.`
+  );
+}
+
+async function handleUnpublish(userId: string, target: string, responseUrl: string): Promise<void> {
+  if (!isAllowed(userId)) {
+    await replyEphemeral(responseUrl, ":no_entry: You are not on the ops allowlist.");
+    return;
+  }
+  if (!target) {
+    await replyEphemeral(responseUrl, ":warning: No target slug.");
+    return;
+  }
+  const post = await findEditorialPost(target);
+  if (!post) {
+    await replyEphemeral(responseUrl, `:warning: No Notion post matching \`${target}\`.`);
+    return;
+  }
+  const flipped = await setEditorialStatus(post.id, "Archived");
+  if (!flipped) {
+    await replyEphemeral(responseUrl, ":warning: Failed to update Notion status.");
+    return;
+  }
+  await replyEphemeral(
+    responseUrl,
+    `:wastebasket: <@${userId}> archived *${post.title}*. /blog/${post.slug} will 404 within the next ISR cycle.`
+  );
+}
+
+async function handleRerunDraft(userId: string, responseUrl: string): Promise<void> {
+  if (!isAllowed(userId)) {
+    await replyEphemeral(responseUrl, ":no_entry: You are not on the ops allowlist.");
+    return;
+  }
+  const result = await dispatchWorkflow("weekly-article-draft.yml", "main");
+  if (!result.ok) {
+    await replyEphemeral(
+      responseUrl,
+      `:warning: Re-run failed (HTTP ${result.status}): \`${result.error.slice(0, 200)}\``
+    );
+    return;
+  }
+  await replyEphemeral(
+    responseUrl,
+    ":arrows_counterclockwise: Re-triggered `weekly-article-draft.yml`. New draft in Notion within ~2 minutes."
+  );
+}

--- a/src/lib/newsletter-slack-config.ts
+++ b/src/lib/newsletter-slack-config.ts
@@ -1,0 +1,59 @@
+/**
+ * Dedicated config loader for the Newsletter Slack app.
+ *
+ * The Newsletter app is a SEPARATE Slack app from the main Cloudless one
+ * (see slack-newsletter-app.manifest.json). It has its own bot token and
+ * signing secret so a leak/rotation/scope change on one cannot disrupt the
+ * other.
+ *
+ * Reads NEWSLETTER_SLACK_SIGNING_SECRET / NEWSLETTER_SLACK_BOT_TOKEN from
+ * env first, falls back to SSM (/cloudless/production/NEWSLETTER_SLACK_*).
+ * Cached after first read; tests can call resetNewsletterSlackConfigCache().
+ */
+
+export interface NewsletterSlackConfig {
+  NEWSLETTER_SLACK_BOT_TOKEN: string;
+  NEWSLETTER_SLACK_SIGNING_SECRET: string;
+  /** Channel ID the bot posts management/audit pings to. */
+  NEWSLETTER_SLACK_CHANNEL_ID: string;
+}
+
+let cached: NewsletterSlackConfig | null = null;
+
+export async function getNewsletterSlackConfigAsync(): Promise<NewsletterSlackConfig> {
+  if (cached) return cached;
+
+  let token = process.env.NEWSLETTER_SLACK_BOT_TOKEN ?? "";
+  let signingSecret = process.env.NEWSLETTER_SLACK_SIGNING_SECRET ?? "";
+  let channel = process.env.NEWSLETTER_SLACK_CHANNEL_ID ?? "";
+
+  if (!token || !signingSecret || !channel) {
+    try {
+      const { getConfig } = await import("@/lib/ssm-config");
+      const ssm = (await getConfig()) as unknown as Record<string, string>;
+      if (!token) token = ssm.NEWSLETTER_SLACK_BOT_TOKEN ?? "";
+      if (!signingSecret) signingSecret = ssm.NEWSLETTER_SLACK_SIGNING_SECRET ?? "";
+      if (!channel) channel = ssm.NEWSLETTER_SLACK_CHANNEL_ID ?? "";
+    } catch (err) {
+      console.warn("[NewsletterSlack] SSM fallback failed:", err);
+    }
+  }
+
+  if (!signingSecret) {
+    console.warn(
+      "[NewsletterSlack] NEWSLETTER_SLACK_SIGNING_SECRET not set — " +
+        "every request will be rejected as unauthorized."
+    );
+  }
+
+  cached = {
+    NEWSLETTER_SLACK_BOT_TOKEN: token,
+    NEWSLETTER_SLACK_SIGNING_SECRET: signingSecret,
+    NEWSLETTER_SLACK_CHANNEL_ID: channel,
+  };
+  return cached;
+}
+
+export function resetNewsletterSlackConfigCache(): void {
+  cached = null;
+}

--- a/src/lib/newsletter-slack-verify.ts
+++ b/src/lib/newsletter-slack-verify.ts
@@ -1,0 +1,85 @@
+/**
+ * Signature verification for the dedicated Newsletter Slack app.
+ *
+ * Mirrors src/lib/slack-verify.ts but reads NEWSLETTER_SLACK_SIGNING_SECRET
+ * (the secret of the SEPARATE Slack app at api.slack.com whose request URLs
+ * point to /api/newsletter-slack/*). Keeping verification logic per-app means
+ * a leaked or rotated secret on one cannot let the other in.
+ *
+ * Reference: https://docs.slack.dev/authentication/verifying-requests-from-slack
+ */
+
+import { createHmac, timingSafeEqual } from "crypto";
+import { getNewsletterSlackConfigAsync } from "@/lib/newsletter-slack-config";
+
+const MAX_AGE_SECONDS = 60 * 5;
+const SEEN_TTL_MS = MAX_AGE_SECONDS * 1000;
+
+const seenSignatures = new Map<string, number>();
+
+function isReplay(signature: string): boolean {
+  const now = Date.now();
+  for (const [sig, ts] of seenSignatures) {
+    if (now - ts > SEEN_TTL_MS) seenSignatures.delete(sig);
+  }
+  if (seenSignatures.has(signature)) return true;
+  seenSignatures.set(signature, now);
+  return false;
+}
+
+export async function verifyNewsletterSlackRequest(
+  request: Request
+): Promise<{ ok: true; body: string } | { ok: false; reason: string }> {
+  const envSecret = process.env.NEWSLETTER_SLACK_SIGNING_SECRET;
+  if (envSecret !== undefined && !envSecret) {
+    return { ok: false, reason: "NEWSLETTER_SLACK_SIGNING_SECRET is not configured" };
+  }
+
+  const cfg = await getNewsletterSlackConfigAsync();
+  if (!cfg.NEWSLETTER_SLACK_SIGNING_SECRET) {
+    return { ok: false, reason: "NEWSLETTER_SLACK_SIGNING_SECRET is not configured" };
+  }
+
+  const timestamp = request.headers.get("x-slack-request-timestamp");
+  const signature = request.headers.get("x-slack-signature");
+  if (!timestamp || !signature) {
+    return { ok: false, reason: "Missing x-slack-request-timestamp or x-slack-signature header" };
+  }
+
+  const nowSeconds = Math.floor(Date.now() / 1000);
+  const requestAge = Math.abs(nowSeconds - Number(timestamp));
+  if (requestAge > MAX_AGE_SECONDS) {
+    return { ok: false, reason: `Request timestamp is too old (${requestAge}s)` };
+  }
+
+  const body = await request.text();
+  const sigBaseString = `v0:${timestamp}:${body}`;
+  const expectedHex = createHmac("sha256", cfg.NEWSLETTER_SLACK_SIGNING_SECRET)
+    .update(sigBaseString, "utf8")
+    .digest("hex");
+  const expected = `v0=${expectedHex}`;
+
+  try {
+    const sigBuffer = Buffer.from(signature, "utf8");
+    const expectedBuffer = Buffer.from(expected, "utf8");
+    if (sigBuffer.length !== expectedBuffer.length) {
+      return { ok: false, reason: "Signature mismatch" };
+    }
+    if (!timingSafeEqual(sigBuffer, expectedBuffer)) {
+      return { ok: false, reason: "Signature mismatch" };
+    }
+  } catch {
+    return { ok: false, reason: "Signature comparison failed" };
+  }
+
+  if (isReplay(signature)) {
+    return { ok: false, reason: "Duplicate request (replay detected)" };
+  }
+
+  return { ok: true, body };
+}
+
+export function unauthorizedNewsletterSlack(reason: string): Response {
+  console.warn(`[NewsletterSlack] Signature verification failed: ${reason}`);
+  return Response.json({ error: "Unauthorized" }, { status: 401 });
+}


### PR DESCRIPTION
Adds a **second, focused Slack app** at the www.cloudless.gr workspace dedicated to the newsletter pipeline. Separate signing secret + bot token means token rotation, scope drift, or signing-secret leaks on the main Cloudless app cannot disrupt newsletter ops (and vice versa).

## Files

- `slack-newsletter-app.manifest.json` — Slack app manifest (7 `/newsletter-*` slash commands, App Home enabled, dedicated `/api/newsletter-slack/*` request URLs, 10 granular bot scopes)
- `src/lib/newsletter-slack-config.ts` — env+SSM resolver for `NEWSLETTER_SLACK_{BOT_TOKEN,SIGNING_SECRET,CHANNEL_ID}`
- `src/lib/newsletter-slack-verify.ts` — dedicated signature verifier
- `src/app/api/newsletter-slack/commands/route.ts` — 7 slash commands
- `src/app/api/newsletter-slack/events/route.ts` — App Home dashboard (3-layer live status + Send/Unpublish/Re-run buttons)
- `src/app/api/newsletter-slack/interactions/route.ts` — button handlers
- `scripts/setup-newsletter-slack-app.sh` — one-shot bootstrap (verify token, store SSM, smoke-test, post hello)
- `__tests__/newsletter-slack/*.test.ts` — 21 tests covering verifier, config, command router

## CI / quality

- **TypeScript:** clean (0 errors)
- **Prettier:** clean
- **ESLint:** 0 warnings
- **Unit tests:** **21/21 new pass** · **251/251 across slack + newsletter + gates**
- **Cross-app contamination test:** signed-for-main-app requests rejected by newsletter verifier ✓

## How to install (the manual half)

1. Open https://api.slack.com/apps/new → **From an app manifest**
2. Pick the **www.cloudless.gr** workspace
3. Paste `slack-newsletter-app.manifest.json` from this PR, click **Create**
4. **Settings → Basic Information** → copy the **Signing Secret**
5. **OAuth & Permissions → Install to Workspace** → copy the **Bot User OAuth Token** (`xoxb-…`)
6. From the WSL clone:
   ```
   bash scripts/setup-newsletter-slack-app.sh \
     --bot-token       xoxb-... \
     --signing-secret  <32-char-hex> \
     --channel         C0BBDKY6Q9E
   ```
7. In Slack: **Apps → Newsletter → :house: Home tab** — the live 3-layer dashboard should appear

The bootstrap script verifies the token via `auth.test` BEFORE storing, runs a signed-request smoke test against the deployed endpoint, and posts a "hello" Block Kit message to `#newsletter` so the new bot avatar appears immediately.

## Design notes

- Built on the conventions captured in **PR #904 / #905** (`.claude/skills/slack-app-builder` / `slack-app-routes-nextjs` / `slack-app-debugging`)
- Uses the "dedicated app per domain" pattern from `slack-app-debugging` §5
- All destructive subcommands (`send`, `unpublish`, `rerun-draft`) gate on `SLACK_OPS_USERS`
- App Home view is computed live from `listEditorialPosts()` + `listNewsletterSubscribers()` — no caching, no drift
- Re-runnable health probe: `bash scripts/slack-app-doctor.sh --token … --signing-secret … --channel C0BBDKY6Q9E --commands-url https://cloudless.gr/api/newsletter-slack/commands`

Closes the *separate app per domain* track of the 3-layer design from PR #903.
