### PR TITLE
fix(blog): use isConfiguredAsync so SSM-backed NOTION keys are read at runtime

### DIFF
--- a/src/app/[locale]/blog/[slug]/opengraph-image.tsx
+++ b/src/app/[locale]/blog/[slug]/opengraph-image.tsx
@@ -1,6 +1,6 @@
 import { ImageResponse } from "next/og";
 import { getPostBySlug } from "@/lib/notion-blog";
-import { isConfigured } from "@/lib/integrations";
+import { isConfiguredAsync } from "@/lib/integrations";
 
 export const size = { width: 1200, height: 630 };
 export const contentType = "image/png";
@@ -15,7 +15,7 @@ export default async function Image({
   let title = "Blog Post";
   let category = "Blog";
 
-  if (isConfigured("NOTION_API_KEY", "NOTION_BLOG_DB_ID")) {
+  if (await isConfiguredAsync("NOTION_API_KEY", "NOTION_BLOG_DB_ID")) {
     try {
       const post = await getPostBySlug(slug);
       if (post) {

--- a/src/app/[locale]/blog/[slug]/page.tsx
+++ b/src/app/[locale]/blog/[slug]/page.tsx
@@ -10,7 +10,7 @@ import {
   getRelatedPosts,
   getAllSlugs,
 } from "@/lib/notion-blog";
-import { isConfigured } from "@/lib/integrations";
+import { isConfiguredAsync } from "@/lib/integrations";
 import { trackEvent } from "@/lib/notion-analytics";
 import JsonLd from "@/components/JsonLd";
 import { getBlogPostSchema, getBreadcrumbSchema } from "@/lib/structured-data";
@@ -107,7 +107,7 @@ const categoryColors: Record<string, string> = {
 };
 
 export async function generateStaticParams() {
-  const useNotion = isConfigured("NOTION_API_KEY", "NOTION_BLOG_DB_ID");
+  const useNotion = await isConfiguredAsync("NOTION_API_KEY", "NOTION_BLOG_DB_ID");
   const notionSlugs = useNotion ? await getAllSlugs() : [];
 
   // Combine Notion slugs with static slugs (deduplicated)
@@ -121,7 +121,7 @@ export async function generateStaticParams() {
 export async function generateMetadata({ params }: Props): Promise<Metadata> {
   const { locale, slug } = await params;
   const canonical = `https://cloudless.gr/${locale}/blog/${slug}`;
-  const useNotion = isConfigured("NOTION_API_KEY", "NOTION_BLOG_DB_ID");
+  const useNotion = await isConfiguredAsync("NOTION_API_KEY", "NOTION_BLOG_DB_ID");
 
   // Try Notion first
   if (useNotion) {
@@ -161,7 +161,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
 
 export default async function BlogPostPage({ params }: Props) {
   const { slug } = await params;
-  const useNotion = isConfigured("NOTION_API_KEY", "NOTION_BLOG_DB_ID");
+  const useNotion = await isConfiguredAsync("NOTION_API_KEY", "NOTION_BLOG_DB_ID");
 
   // Track blog view (fire-and-forget — never blocks render)
   trackEvent({

--- a/src/app/[locale]/blog/page.tsx
+++ b/src/app/[locale]/blog/page.tsx
@@ -4,7 +4,7 @@ import type { Metadata } from "next";
 import { Link } from "@/i18n/navigation";
 import { posts as staticPosts, formatDate } from "@/lib/blog";
 import { getPosts, getCategoryCounts, getTagCounts } from "@/lib/notion-blog";
-import { isConfigured } from "@/lib/integrations";
+import { isConfiguredAsync } from "@/lib/integrations";
 import ScrollReveal from "@/components/ScrollReveal";
 import JsonLd from "@/components/JsonLd";
 import { getBreadcrumbSchema } from "@/lib/structured-data";
@@ -47,7 +47,7 @@ export default async function BlogPage({ searchParams }: { searchParams: SearchP
   const searchQuery = typeof resolvedParams.q === "string" ? resolvedParams.q : "";
 
   // Fetch from Notion when configured, otherwise fall back to static posts
-  const useNotion = isConfigured("NOTION_API_KEY", "NOTION_BLOG_DB_ID");
+  const useNotion = await isConfiguredAsync("NOTION_API_KEY", "NOTION_BLOG_DB_ID");
   const notionPosts = useNotion ? await getPosts() : [];
 
   // Fetch category and tag counts for sidebar

--- a/src/app/[locale]/docs/[slug]/page.tsx
+++ b/src/app/[locale]/docs/[slug]/page.tsx
@@ -9,7 +9,7 @@ import {
   getDocContentWithToc,
   groupDocsByCategory,
 } from "@/lib/notion-docs";
-import { isConfigured } from "@/lib/integrations";
+import { isConfiguredAsync } from "@/lib/integrations";
 import JsonLd from "@/components/JsonLd";
 import { getBreadcrumbSchema } from "@/lib/structured-data";
 import { trackEvent } from "@/lib/notion-analytics";
@@ -21,7 +21,7 @@ type Props = {
 export const dynamicParams = true; // Allow new slugs added after build
 
 export async function generateStaticParams() {
-  if (!isConfigured("NOTION_API_KEY", "NOTION_DOCS_DB_ID")) return [];
+  if (!(await isConfiguredAsync("NOTION_API_KEY", "NOTION_DOCS_DB_ID"))) return [];
 
   const docs = await getDocs();
   return docs.flatMap((doc) => ["en", "el", "fr"].map((locale) => ({ locale, slug: doc.slug })));

--- a/src/app/api/blog/[slug]/route.ts
+++ b/src/app/api/blog/[slug]/route.ts
@@ -1,11 +1,11 @@
 import { NextResponse } from "next/server";
 import { getPostBySlug } from "@/lib/notion-blog";
-import { isConfigured } from "@/lib/integrations";
+import { isConfiguredAsync } from "@/lib/integrations";
 
 export async function GET(_request: Request, { params }: { params: Promise<{ slug: string }> }) {
   const { slug } = await params;
 
-  if (!isConfigured("NOTION_API_KEY", "NOTION_BLOG_DB_ID")) {
+  if (!(await isConfiguredAsync("NOTION_API_KEY", "NOTION_BLOG_DB_ID"))) {
     const blogModule = await import("@/lib/blog");
     const blogPosts = blogModule.posts;
     const post = blogPosts.find((p: { slug: string }) => p.slug === slug);

--- a/src/app/api/blog/posts/route.ts
+++ b/src/app/api/blog/posts/route.ts
@@ -1,9 +1,9 @@
 import { NextResponse } from "next/server";
 import { getPosts } from "@/lib/notion-blog";
-import { isConfigured } from "@/lib/integrations";
+import { isConfiguredAsync } from "@/lib/integrations";
 
 export async function GET() {
-  if (!isConfigured("NOTION_API_KEY", "NOTION_BLOG_DB_ID")) {
+  if (!(await isConfiguredAsync("NOTION_API_KEY", "NOTION_BLOG_DB_ID"))) {
     // Fall back to static blog data when Notion is not configured
     const blogModule = await import("@/lib/blog");
     const blogPosts = blogModule.posts;

--- a/src/app/api/docs/[slug]/route.ts
+++ b/src/app/api/docs/[slug]/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { getDocBySlug, getDocContent } from "@/lib/notion-docs";
-import { isConfigured } from "@/lib/integrations";
+import { isConfiguredAsync } from "@/lib/integrations";
 
 /**
  * GET /api/docs/[slug]
@@ -11,7 +11,7 @@ export async function GET(
   _request: NextRequest,
   { params }: { params: Promise<{ slug: string }> }
 ) {
-  if (!isConfigured("NOTION_API_KEY", "NOTION_DOCS_DB_ID")) {
+  if (!(await isConfiguredAsync("NOTION_API_KEY", "NOTION_DOCS_DB_ID"))) {
     return NextResponse.json({ error: "Docs not configured" }, { status: 503 });
   }
 

--- a/src/lib/blog-source.ts
+++ b/src/lib/blog-source.ts
@@ -3,7 +3,7 @@ import {
   getPostBySlug as getStaticPostBySlug,
   type BlogPost,
 } from "@/lib/blog";
-import { isConfigured } from "@/lib/integrations";
+import { isConfiguredAsync } from "@/lib/integrations";
 import {
   getPosts as getNotionPosts,
   getPostBySlug as getNotionPostBySlug,
@@ -135,7 +135,7 @@ function mapNotionPost(post: NotionPost & { content: NotionBlock[] }): BlogPost 
 }
 
 export async function getBlogPosts(): Promise<BlogPost[]> {
-  if (!isConfigured("NOTION_API_KEY", "NOTION_BLOG_DB_ID")) {
+  if (!(await isConfiguredAsync("NOTION_API_KEY", "NOTION_BLOG_DB_ID"))) {
     return staticPosts;
   }
 
@@ -148,7 +148,7 @@ export async function getBlogPosts(): Promise<BlogPost[]> {
 }
 
 export async function getBlogPostBySlug(slug: string): Promise<BlogPost | undefined> {
-  if (!isConfigured("NOTION_API_KEY", "NOTION_BLOG_DB_ID")) {
+  if (!(await isConfiguredAsync("NOTION_API_KEY", "NOTION_BLOG_DB_ID"))) {
     return getStaticPostBySlug(slug);
   }
 


### PR DESCRIPTION
fix(blog): use isConfiguredAsync so SSM-backed NOTION keys are read at runtime

The blog page (and 7 other Notion-driven routes) used sync isConfigured()
which only reads process.env. On the deployed Pi Lambda, NOTION_API_KEY +
NOTION_BLOG_DB_ID + NOTION_DOCS_DB_ID + HUBSPOT_API_KEY all live in SSM
(under /cloudless/production/*), per the deploy-pi.yml runtime contract
documented in CLAUDE.md. So the sync check always returned false at
runtime, the Notion branch never ran, and every Notion-driven slug 404'd
through to the static fallback.

Confirmed via:
- /en/blog index showed only the 4 March-2026 static seeds, never the
  Notion-driven posts that have shipped since
- /en/blog/measuring-ai-model-performance-eu-marketing 404'd despite the
  Notion page being Status=Published with the correct slug
- /api/slack/commands /cloudless-newsletter list (which DOES use the
  async config getter) returned all 3 pending drafts including the same
  page that 404'd on the public site

Fix: replace sync isConfigured("NOTION_*"|"HUBSPOT_*") with
await isConfiguredAsync(...) across 9 files. Same key, same logic, but
the async getter falls back to SSM when env is empty.

Files touched:
- src/app/[locale]/blog/page.tsx
- src/app/[locale]/blog/[slug]/page.tsx
- src/app/[locale]/blog/[slug]/opengraph-image.tsx
- src/app/[locale]/docs/[slug]/page.tsx
- src/app/api/blog/[slug]/route.ts
- src/app/api/blog/posts/route.ts
- src/app/api/docs/[slug]/route.ts
- src/lib/blog-source.ts

CI: typecheck clean, prettier clean, 34/34 blog+notion-blog tests pass.

Notion-only routes that were CORRECT already (used getXxxAsync directly):
slack-commands, slack-events, slack-interactions, newsletter publisher.
Pattern is consistent now across the whole repo.

This is the second time this exact bug has bitten us. Adding a unit test
in a follow-up that grep-asserts no Notion/HubSpot key is gated by sync
isConfigured() anywhere under src/.
