### PR TITLE
fix(tests): cms-api-routes — mock isConfiguredAsync (unblock Pi deploy)

### DIFF
--- a/__tests__/cms-api-routes.test.ts
+++ b/__tests__/cms-api-routes.test.ts
@@ -305,6 +305,7 @@ describe("GET /api/docs/[slug]", () => {
 
   it("returns 503 when not configured", async () => {
     mockIsConfigured.mockReturnValue(false);
+    mockIsConfiguredAsync.mockResolvedValue(false);
     const { NextRequest } = await import("next/server");
     const { GET } = await import("@/app/api/docs/[slug]/route");
     const res = await GET(new NextRequest("http://localhost/api/docs/intro"), { params: Promise.resolve({ slug: "intro" }) });
@@ -313,6 +314,7 @@ describe("GET /api/docs/[slug]", () => {
 
   it("returns 404 when doc not found", async () => {
     mockIsConfigured.mockReturnValue(true);
+    mockIsConfiguredAsync.mockResolvedValue(true);
     mockGetDocBySlug.mockResolvedValue(null);
     const { NextRequest } = await import("next/server");
     const { GET } = await import("@/app/api/docs/[slug]/route");
@@ -322,6 +324,7 @@ describe("GET /api/docs/[slug]", () => {
 
   it("returns 500 when content fetch fails", async () => {
     mockIsConfigured.mockReturnValue(true);
+    mockIsConfiguredAsync.mockResolvedValue(true);
     mockGetDocBySlug.mockResolvedValue({ id: "d1", slug: "intro" });
     mockGetDocContent.mockResolvedValue(null);
     const { NextRequest } = await import("next/server");
@@ -332,6 +335,7 @@ describe("GET /api/docs/[slug]", () => {
 
   it("returns doc content when found", async () => {
     mockIsConfigured.mockReturnValue(true);
+    mockIsConfiguredAsync.mockResolvedValue(true);
     mockGetDocBySlug.mockResolvedValue({ id: "d1", slug: "intro", title: "Intro" });
     mockGetDocContent.mockResolvedValue({ id: "d1", slug: "intro", title: "Intro", html: "<p>content</p>" });
     const { NextRequest } = await import("next/server");


### PR DESCRIPTION
Single-line fix that unblocks deploy-pi.yml after PR #907. Adds mockIsConfiguredAsync.mockResolvedValue() to the 4 docs slug tests that still only mocked the sync version. 25/25 cms-api-routes tests now pass.