### PR TITLE
fix(newsletter-slack): add NEWSLETTER_SLACK_* to ssm-config fetch list

### DIFF
--- a/src/lib/ssm-config.ts
+++ b/src/lib/ssm-config.ts
@@ -31,6 +31,10 @@ interface AppConfig {
   SLACK_SIGNING_SECRET: string;
   /** Default channel (ID or #name) for bot posts without an explicit channel. */
   SLACK_DEFAULT_CHANNEL: string;
+  // Dedicated Newsletter Slack app (separate from main Cloudless app)
+  NEWSLETTER_SLACK_BOT_TOKEN: string;
+  NEWSLETTER_SLACK_SIGNING_SECRET: string;
+  NEWSLETTER_SLACK_CHANNEL_ID: string;
   HUBSPOT_API_KEY: string;
   HUBSPOT_CLIENT_SECRET: string;
   NOTION_API_KEY: string;
@@ -178,6 +182,9 @@ function buildConfigFromParams(params: Map<string, string>): AppConfig {
     SLACK_BOT_TOKEN: params.get("SLACK_BOT_TOKEN") ?? "",
     SLACK_SIGNING_SECRET: params.get("SLACK_SIGNING_SECRET") ?? "",
     SLACK_DEFAULT_CHANNEL: params.get("SLACK_DEFAULT_CHANNEL") ?? "",
+    NEWSLETTER_SLACK_BOT_TOKEN: params.get("NEWSLETTER_SLACK_BOT_TOKEN") ?? "",
+    NEWSLETTER_SLACK_SIGNING_SECRET: params.get("NEWSLETTER_SLACK_SIGNING_SECRET") ?? "",
+    NEWSLETTER_SLACK_CHANNEL_ID: params.get("NEWSLETTER_SLACK_CHANNEL_ID") ?? "",
     HUBSPOT_API_KEY: params.get("HUBSPOT_API_KEY") ?? "",
     HUBSPOT_CLIENT_SECRET: params.get("HUBSPOT_CLIENT_SECRET") ?? "",
     NOTION_API_KEY: params.get("NOTION_API_KEY") ?? "",
@@ -255,6 +262,9 @@ function buildConfigFromEnv(): AppConfig {
     SLACK_BOT_TOKEN: process.env.SLACK_BOT_TOKEN || "",
     SLACK_SIGNING_SECRET: process.env.SLACK_SIGNING_SECRET || "",
     SLACK_DEFAULT_CHANNEL: process.env.SLACK_DEFAULT_CHANNEL || "",
+    NEWSLETTER_SLACK_BOT_TOKEN: process.env.NEWSLETTER_SLACK_BOT_TOKEN || "",
+    NEWSLETTER_SLACK_SIGNING_SECRET: process.env.NEWSLETTER_SLACK_SIGNING_SECRET || "",
+    NEWSLETTER_SLACK_CHANNEL_ID: process.env.NEWSLETTER_SLACK_CHANNEL_ID || "",
     HUBSPOT_API_KEY: process.env.HUBSPOT_API_KEY || process.env.HUBSPOT_PRIVATE_APP_TOKEN || "",
     HUBSPOT_CLIENT_SECRET: process.env.HUBSPOT_CLIENT_SECRET || "",
     NOTION_API_KEY: process.env.NOTION_API_KEY || "",


### PR DESCRIPTION
newsletter-slack-config.ts reads the 3 NEWSLETTER_SLACK_* keys via getConfig() from ssm-config, but ssm-config never declared those keys, so getConfig() returned undefined for them and the verifier saw an empty signing secret → every signed request to /api/newsletter-slack/* returned 401 on the deployed Lambda.

This unblocks the App Home dashboard auto-render and all /newsletter-* slash commands.

Adds the keys in 3 places: IntegrationConfig type, SSM GetParametersByPath fetch, and process.env fallback. 29/29 tests pass.