### PR TITLE
fix(scripts): setup-newsletter-slack-app.sh — rename PATH→SSM_PATH (silent aws failure)

### DIFF
--- a/scripts/setup-newsletter-slack-app.sh
+++ b/scripts/setup-newsletter-slack-app.sh
@@ -81,11 +81,11 @@ do
   REST="${pair#*:}"
   VALUE="${REST%:*}"
   TYPE="${REST##*:}"
-  PATH="/cloudless/production/$NAME"
+  SSM_PATH="/cloudless/production/$NAME"
   aws ssm put-parameter --region "$REGION" \
-    --name "$PATH" --type "$TYPE" --value "$VALUE" --overwrite \
+    --name "$SSM_PATH" --type "$TYPE" --value "$VALUE" --overwrite \
     >/dev/null
-  echo "  ✓ $PATH ($TYPE)"
+  echo "  ✓ $SSM_PATH ($TYPE)"
 done
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
See commit message for full root cause. Renames a 3-occurrence variable. No code-path or test changes. Verified: re-stored secrets correctly + restarted Pi pod + signed request now returns 200 OK against /api/newsletter-slack/events.