### PR TITLE
ci(dependabot): pin eslint to v9 until eslint-plugin-react ships v10 support

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -33,6 +33,13 @@ updates:
         update-types: ['version-update:semver-major']
       - dependency-name: next
         update-types: ['version-update:semver-major']
+      # eslint v10 cannot land while `eslint-plugin-react` is in the lint
+      # config — its peer range still caps at eslint ^9.7 and no v10-compatible
+      # release exists (latest stable 7.37.5, no 8.x/9.x/10.x lines, the `next`
+      # tag is an older 7.8.0-rc.0). Re-enable when the plugin ships v10
+      # support (or after migrating to @eslint-react/eslint-plugin).
+      - dependency-name: eslint
+        update-types: ['version-update:semver-major']
 
   - package-ecosystem: github-actions
     directory: /


### PR DESCRIPTION
Closes #895.

## Why

Dependabot PR #895 bumps `eslint` 9.39.4 → 10.5.0, but the upgrade is blocked upstream — `eslint-plugin-react` (which the project's lint config uses) still pins its eslint peer range to `^3 || ^4 || ^5 || ^6 || ^7 || ^8 || ^9.7`. Merging the major bump immediately breaks `pnpm lint` with:

```
TypeError: Error while loading rule 'react/display-name': contextOrFilename.getFilename is not a function
  at resolveBasedir (node_modules/eslint-plugin-react/lib/util/version.js:31:100)
  at detectReactVersion (.../version.js:85:19)
  at getReactVersionFromContext (.../version.js:116:25)
  ...
Occurred while linting src/app/[locale]/admin/AdminLayoutClient.tsx
```

ESLint v10 dropped the legacy `context.getFilename()` shim; `eslint-plugin-react` v7.x still calls it for React-version detection. There is no v10-compatible release: `latest` is 7.37.5 (Apr 2025), there are no 8.x/9.x/10.x lines, and the `next` tag is an older `7.8.0-rc.0`.

## What this does

Adds `eslint` (major) to the dependabot `ignore` list with a comment explaining when to lift the pin (when `eslint-plugin-react` ships v10 support, or after migrating to `@eslint-react/eslint-plugin`). All minor/patch bumps for `eslint` continue to flow.

## Net effect

- #895 can be closed cleanly without dependabot re-spawning it on the next cycle.
- Future eslint minor/patch bumps still arrive normally.
- The major bump returns automatically once the comment criterion is met and we remove this entry.