### PR TITLE
feat(skills): add workmail-outlook-setup skill + connectivity scripts

### DIFF
--- a/scripts/workmail-connectivity-test.sh
+++ b/scripts/workmail-connectivity-test.sh
@@ -1,0 +1,171 @@
+#!/usr/bin/env bash
+# workmail-connectivity-test.sh — diagnose WorkMail connectivity from any
+# workstation before blaming Outlook.
+#
+# Tests, in order:
+#   1. DNS resolution for imap / smtp / autodiscover / ews hosts
+#   2. TCP+TLS handshake to imap:993 and smtp:465 (raises STARTTLS=NO)
+#   3. HTTPS reachability of the Autodiscover XML endpoint
+#   4. (optional) Real IMAP LOGIN if --password is supplied
+#
+# Usage:
+#   workmail-connectivity-test.sh --region <us-east-1|us-west-2|eu-west-1> \
+#                                 --user <full-email> \
+#                                 [--password <pw>]
+#
+# Designed to run on Linux, macOS, and Git-Bash on Windows. Requires
+# `openssl` (for TLS probes) and `curl`. No AWS credentials needed —
+# this only exercises the public mail endpoints.
+
+set -euo pipefail
+
+REGION=""
+USER_EMAIL=""
+PASSWORD=""
+VERBOSE=0
+
+usage() {
+  sed -n '2,18p' "$0" | sed 's/^# \{0,1\}//'
+  exit "${1:-0}"
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --region)   REGION="$2"; shift 2 ;;
+    --user)     USER_EMAIL="$2"; shift 2 ;;
+    --password) PASSWORD="$2"; shift 2 ;;
+    -v|--verbose) VERBOSE=1; shift ;;
+    -h|--help)  usage 0 ;;
+    *) echo "Unknown arg: $1" >&2; usage 1 ;;
+  esac
+done
+
+[[ -z "$REGION"     ]] && { echo "ERR: --region required" >&2; exit 2; }
+[[ -z "$USER_EMAIL" ]] && { echo "ERR: --user required" >&2; exit 2; }
+
+case "$REGION" in
+  us-east-1|us-west-2|eu-west-1) ;;
+  *) echo "ERR: WorkMail is only available in us-east-1, us-west-2, eu-west-1" >&2; exit 2 ;;
+esac
+
+IMAP_HOST="imap.mail.${REGION}.awsapps.com"
+SMTP_HOST="smtp.mail.${REGION}.awsapps.com"
+AUTODISCOVER_HOST="autodiscover-service.mail.${REGION}.awsapps.com"
+EWS_HOST="ews.mail.${REGION}.awsapps.com"
+AUTODISCOVER_URL="https://${AUTODISCOVER_HOST}/autodiscover/autodiscover.xml"
+
+PASS=0; FAIL=0
+ok()   { printf "  \033[32m✓\033[0m %s\n" "$1"; PASS=$((PASS+1)); }
+bad()  { printf "  \033[31m✗\033[0m %s\n" "$1"; FAIL=$((FAIL+1)); }
+note() { printf "    %s\n" "$1"; }
+section() { printf "\n\033[1m%s\033[0m\n" "$1"; }
+
+require_bin() {
+  command -v "$1" >/dev/null 2>&1 || { echo "ERR: missing tool: $1" >&2; exit 3; }
+}
+require_bin openssl
+require_bin curl
+require_bin getent || command -v dig >/dev/null 2>&1 || \
+  echo "WARN: neither getent nor dig found — DNS step uses curl's resolver only" >&2
+
+resolve() {
+  local host=$1
+  if command -v getent >/dev/null 2>&1; then
+    getent ahosts "$host" 2>/dev/null | awk '{print $1}' | sort -u | head -5
+  elif command -v dig >/dev/null 2>&1; then
+    dig +short "$host" 2>/dev/null | head -5
+  else
+    # Fallback via curl --resolve probe — won't print IPs, only succeed/fail
+    curl -fsS --max-time 3 --connect-to "${host}:443:${host}:443" "https://${host}" -o /dev/null \
+      && echo "<resolved-by-curl>" || true
+  fi
+}
+
+probe_tls() {
+  # $1 host  $2 port  → return 0 on TLS handshake, fill $TLS_INFO
+  local host=$1 port=$2
+  local out
+  out=$(echo "" | openssl s_client -connect "${host}:${port}" -servername "$host" \
+    -showcerts -brief 2>&1 </dev/null || true)
+  TLS_INFO=$(printf '%s\n' "$out" | grep -E 'Protocol|Cipher|Verification|subject=' | head -4 | tr '\n' '; ')
+  printf '%s\n' "$out" | grep -q "Verification: OK\|Verification error"
+}
+
+section "WorkMail connectivity probe"
+note "Region:         $REGION"
+note "Email:          $USER_EMAIL"
+note "IMAP host:      ${IMAP_HOST}:993"
+note "SMTP host:      ${SMTP_HOST}:465"
+note "Autodiscover:   $AUTODISCOVER_URL"
+note "EWS:            https://${EWS_HOST}/EWS/Exchange.asmx"
+
+section "1. DNS resolution"
+for h in "$IMAP_HOST" "$SMTP_HOST" "$AUTODISCOVER_HOST" "$EWS_HOST"; do
+  ips=$(resolve "$h" || true)
+  if [[ -n "$ips" ]]; then
+    ok "$h → $(echo "$ips" | tr '\n' ' ')"
+  else
+    bad "$h → NO A RECORD"
+    note "DNS or split-horizon problem on this network. Check resolv.conf / VPN."
+  fi
+done
+
+section "2. TLS handshake"
+if probe_tls "$IMAP_HOST" 993; then
+  ok "IMAPS ${IMAP_HOST}:993 — ${TLS_INFO}"
+else
+  bad "IMAPS ${IMAP_HOST}:993 — handshake failed"
+  note "Likely outbound 993 blocked by firewall/VPN."
+fi
+
+if probe_tls "$SMTP_HOST" 465; then
+  ok "SMTPS ${SMTP_HOST}:465 — ${TLS_INFO}"
+else
+  bad "SMTPS ${SMTP_HOST}:465 — handshake failed"
+  note "Likely outbound 465 blocked. WorkMail does NOT support STARTTLS on 587."
+fi
+
+section "3. Autodiscover XML reachability"
+code=$(curl -s -o /dev/null -w "%{http_code}" -m 10 -X POST \
+  -H "Content-Type: text/xml; charset=utf-8" \
+  --data '<?xml version="1.0" encoding="utf-8"?><Autodiscover/>' \
+  "$AUTODISCOVER_URL" || echo "000")
+case "$code" in
+  401|403|600) ok "Autodiscover XML reachable (HTTP $code — auth challenge expected)"
+               note "401/403 is correct: clients prove identity with Basic auth on the next round-trip." ;;
+  200)         ok "Autodiscover XML reachable (HTTP 200 — unusual but valid)" ;;
+  000)         bad "Autodiscover XML unreachable (no TCP/TLS)"
+               note "Most common cause: outbound 443 blocked or DNS poisoning." ;;
+  *)           bad "Autodiscover XML HTTP $code"
+               note "Expected 401/403; got $code. Confirm region and that the URL begins with 'autodiscover-service.' not 'autodiscover.'." ;;
+esac
+
+section "4. IMAP LOGIN (optional)"
+if [[ -z "$PASSWORD" ]]; then
+  note "Skipped (pass --password '...' to test LOGIN). Use a one-shot env-var or stdin to avoid"
+  note "writing the password into shell history."
+else
+  # Use a tmpfile so the password never appears on the command line in ps.
+  TMP=$(mktemp)
+  trap 'rm -f "$TMP"' EXIT
+  cat >"$TMP" <<EOF
+A001 LOGIN $USER_EMAIL $PASSWORD
+A002 LOGOUT
+EOF
+  out=$(openssl s_client -connect "${IMAP_HOST}:993" -servername "$IMAP_HOST" \
+        -ign_eof -quiet 2>/dev/null <"$TMP" || true)
+  rm -f "$TMP"; trap - EXIT
+  if printf '%s' "$out" | grep -q "A001 OK"; then
+    ok "IMAP LOGIN succeeded for $USER_EMAIL"
+  elif printf '%s' "$out" | grep -q "A001 NO"; then
+    bad "IMAP LOGIN refused — credentials invalid OR IMAP disabled at org level"
+    note "WorkMail admin → Organizations → <org> → Access control rules. Confirm IMAP is allowed."
+  else
+    bad "IMAP LOGIN inconclusive — no protocol response"
+    [[ $VERBOSE -eq 1 ]] && printf '%s\n' "$out" | sed 's/^/      /'
+  fi
+fi
+
+section "Summary"
+printf "  Passed: %d\n  Failed: %d\n" "$PASS" "$FAIL"
+[[ $FAIL -gt 0 ]] && exit 1 || exit 0

--- a/scripts/workmail-outlook-autodiscover-fix.ps1
+++ b/scripts/workmail-outlook-autodiscover-fix.ps1
@@ -1,0 +1,197 @@
+<#
+.SYNOPSIS
+    Fix Outlook (classic) Autodiscover so it resolves WorkMail's
+    `autodiscover-service.mail.<region>.awsapps.com` endpoint instead of
+    hijacking to Microsoft 365.
+
+.DESCRIPTION
+    Classic Outlook walks several Autodiscover sources in order: SCP (AD),
+    HTTPS root domain, SRV record, then the email-suffix subdomain. On
+    networks that have ever been M365-joined, the SCP or SRV step routes
+    everything to outlook.office365.com — which has no idea about your
+    `@cloudless.gr` WorkMail mailbox and bounces back a sign-in prompt.
+
+    This script writes the documented registry overrides under
+    HKCU\Software\Microsoft\Office\<ver>\Outlook\AutoDiscover so Outlook
+    skips the hijack-prone sources and goes straight to the WorkMail
+    Autodiscover XML. Per-user (HKCU), no admin elevation required.
+
+    Source: AWS re:Post — "Preventing Outlook (Classic) Autodiscover Hijack
+    to Microsoft 365 (AWS WorkMail)".
+
+.PARAMETER Region
+    AWS region of the WorkMail org. WorkMail is available in
+    us-east-1 / us-west-2 / eu-west-1 only.
+
+.PARAMETER OfficeVersion
+    Outlook registry version (16.0 = Office 2016/2019/2021/365, 15.0 = 2013).
+    Default 16.0. Specify when you have multiple Outlook installs.
+
+.PARAMETER DryRun
+    Print every action without writing to the registry.
+
+.PARAMETER Revert
+    Remove the keys this script added. Useful if you later move back to
+    M365 / Exchange Online.
+
+.EXAMPLE
+    .\workmail-outlook-autodiscover-fix.ps1 -Region us-east-1
+
+.EXAMPLE
+    .\workmail-outlook-autodiscover-fix.ps1 -Region eu-west-1 -DryRun
+
+.EXAMPLE
+    .\workmail-outlook-autodiscover-fix.ps1 -Region us-east-1 -Revert
+#>
+
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory)]
+    [ValidateSet('us-east-1', 'us-west-2', 'eu-west-1')]
+    [string]$Region,
+
+    [ValidateSet('16.0', '15.0')]
+    [string]$OfficeVersion = '16.0',
+
+    [switch]$DryRun,
+
+    [switch]$Revert
+)
+
+$ErrorActionPreference = 'Stop'
+
+$AutoDiscoverKey = "HKCU:\Software\Microsoft\Office\$OfficeVersion\Outlook\AutoDiscover"
+$RedirectKey     = "HKCU:\Software\Microsoft\Office\$OfficeVersion\Outlook\AutoDiscover\RedirectServers"
+$WorkMailHost    = "autodiscover-service.mail.$Region.awsapps.com"
+
+# DWORD values that disable the hijack-prone Autodiscover sources.
+# 1 = skip this lookup method. Leaving HttpsAutoDiscoverDomain at 0 means
+# Outlook IS allowed to hit autodiscover.<your-domain>, which is what we want
+# because cloudless.gr (or whatever vanity domain) should CNAME there.
+$Values = @{
+    'ExcludeScpLookup'              = 1
+    'ExcludeHttpsRootDomain'        = 1
+    'ExcludeSrvRecord'              = 1
+    'ExcludeHttpsAutoDiscoverDomain' = 0
+    'ExcludeLastKnownGoodURL'       = 1
+    'ExcludeExplicitO365Endpoint'   = 1
+}
+
+function Write-Action {
+    param([string]$Message, [string]$Color = 'Cyan')
+    Write-Host "[workmail-fix] $Message" -ForegroundColor $Color
+}
+
+function Ensure-Key {
+    param([string]$Path)
+    if (-not (Test-Path $Path)) {
+        if ($DryRun) {
+            Write-Action "DRYRUN would create key: $Path"
+        }
+        else {
+            New-Item -Path $Path -Force | Out-Null
+            Write-Action "Created key: $Path"
+        }
+    }
+}
+
+function Set-DwordValue {
+    param([string]$Path, [string]$Name, [int]$Value)
+    $existing = $null
+    try { $existing = (Get-ItemProperty -Path $Path -Name $Name -ErrorAction Stop).$Name } catch {}
+
+    if ($null -ne $existing -and $existing -eq $Value) {
+        Write-Action "Unchanged: $Path\$Name = $Value"
+        return
+    }
+
+    if ($DryRun) {
+        Write-Action "DRYRUN would set: $Path\$Name = $Value (was: $existing)"
+    }
+    else {
+        New-ItemProperty -Path $Path -Name $Name -Value $Value -PropertyType DWord -Force | Out-Null
+        Write-Action "Set: $Path\$Name = $Value (was: $existing)"
+    }
+}
+
+function Set-StringValue {
+    param([string]$Path, [string]$Name, [string]$Value)
+    if ($DryRun) {
+        Write-Action "DRYRUN would set: $Path\$Name = '$Value'"
+    }
+    else {
+        New-ItemProperty -Path $Path -Name $Name -Value $Value -PropertyType String -Force | Out-Null
+        Write-Action "Set: $Path\$Name = '$Value'"
+    }
+}
+
+function Remove-NameIfPresent {
+    param([string]$Path, [string]$Name)
+    try {
+        Get-ItemProperty -Path $Path -Name $Name -ErrorAction Stop | Out-Null
+        if ($DryRun) {
+            Write-Action "DRYRUN would remove: $Path\$Name"
+        }
+        else {
+            Remove-ItemProperty -Path $Path -Name $Name -Force
+            Write-Action "Removed: $Path\$Name"
+        }
+    }
+    catch { }
+}
+
+if ($Revert) {
+    Write-Action "Reverting WorkMail Autodiscover overrides for Office $OfficeVersion" 'Yellow'
+
+    if (Test-Path $AutoDiscoverKey) {
+        foreach ($name in $Values.Keys) {
+            Remove-NameIfPresent -Path $AutoDiscoverKey -Name $name
+        }
+    }
+    else {
+        Write-Action "Key not present, nothing to revert: $AutoDiscoverKey" 'Yellow'
+    }
+
+    if (Test-Path $RedirectKey) {
+        if ($DryRun) {
+            Write-Action "DRYRUN would remove: $RedirectKey"
+        }
+        else {
+            Remove-Item -Path $RedirectKey -Recurse -Force
+            Write-Action "Removed: $RedirectKey"
+        }
+    }
+
+    Write-Action "Done. Restart Outlook for changes to take effect." 'Green'
+    exit 0
+}
+
+Write-Action "Applying WorkMail Autodiscover fix" 'Green'
+Write-Action "  Region:         $Region"
+Write-Action "  Autodiscover:   $WorkMailHost"
+Write-Action "  Office version: $OfficeVersion"
+Write-Action "  Registry key:   $AutoDiscoverKey"
+if ($DryRun) { Write-Action "  Mode:           DRY RUN — no changes written" 'Yellow' }
+
+Ensure-Key -Path $AutoDiscoverKey
+
+foreach ($entry in $Values.GetEnumerator()) {
+    Set-DwordValue -Path $AutoDiscoverKey -Name $entry.Key -Value $entry.Value
+}
+
+# Tell Outlook the redirect to autodiscover-service.mail.<region>.awsapps.com
+# is trusted, otherwise it prompts the user on every restart.
+Ensure-Key -Path $RedirectKey
+Set-DwordValue -Path $RedirectKey -Name $WorkMailHost -Value 1
+
+Write-Action ""
+Write-Action "Done." 'Green'
+Write-Action ""
+Write-Action "Next steps:"
+Write-Action "  1. Close Outlook completely (check the system tray)."
+Write-Action "  2. Reopen Outlook → File → Add Account → enter your email."
+Write-Action "  3. When prompted with 'Allow this website to configure...',"
+Write-Action "     tick 'Don't ask again' and click Allow."
+Write-Action ""
+Write-Action "If Outlook still routes to office365.com, verify the registry"
+Write-Action "writes with: reg query `"$AutoDiscoverKey`""

--- a/skills/workmail-outlook-setup/SKILL.md
+++ b/skills/workmail-outlook-setup/SKILL.md
@@ -1,0 +1,145 @@
+# workmail-outlook-setup
+
+Add an Amazon WorkMail mailbox to Microsoft Outlook (new or classic), or
+diagnose why one won't connect. Region-aware; covers EWS/Autodiscover and
+IMAP/SMTP fallbacks; includes a connectivity-doctor script.
+
+Use this skill whenever the user says any of:
+
+- "add my WorkMail to Outlook"
+- "WorkMail not working in Outlook"
+- "Outlook keeps asking for password" against a WorkMail address
+- "Autodiscover failed" for a `*.awsapps.com` mailbox
+- "set up IMAP for WorkMail"
+- "new Outlook can't find my Exchange server"
+
+## What it covers
+
+1. Pick the right Outlook client given the user's needs (calendar/contacts vs
+   mail-only).
+2. Resolve the AWS region of the WorkMail org from the webmail URL.
+3. Drive the right connection path: **Autodiscover/EWS** for classic Outlook,
+   **IMAP/SMTP** for new Outlook (the only path it supports against WorkMail).
+4. Apply the Autodiscover registry fix when classic Outlook tries to hijack the
+   lookup to Microsoft 365.
+5. Run `scripts/workmail-connectivity-test.sh` to confirm DNS, TLS, and
+   IMAP login work before blaming Outlook.
+
+## Client capability matrix
+
+| Capability        | Classic Outlook (EWS) | New Outlook (IMAP) |
+| ----------------- | --------------------- | ------------------ |
+| Mail              | ✓                     | ✓                  |
+| Calendar sync     | ✓                     | ✗ local only       |
+| Contacts sync     | ✓                     | ✗ local only       |
+| Server-side rules | ✓                     | ✗                  |
+| Shared mailbox    | ✓                     | ✗                  |
+| Setup steps       | email + password      | 7 manual fields    |
+
+**Recommend classic Outlook** unless the user explicitly wants the new UI and
+is OK with mail-only.
+
+## Authoritative endpoints
+
+The canonical table is at `reference/endpoints.md` (mirrored from the AWS
+General Reference so the skill stays usable offline). All hostnames follow
+the `*.mail.<region>.awsapps.com` pattern; the Autodiscover host is
+**`autodiscover-service.mail.<region>.awsapps.com`**, NOT
+`autodiscover.mail.<region>.awsapps.com` — newer WorkMail mailboxes ONLY
+resolve via the `-service` variant, which is the single most common cause of
+Autodiscover failures.
+
+## Workflow
+
+### 1. Region detection
+
+Ask the user for their webmail URL (the page they log into to read mail
+in a browser). The hostname format is `https://<org-alias>.awsapps.com/mail`
+and the region is encoded in the redirect. If unknown:
+
+```bash
+curl -s -o /dev/null -w "%{redirect_url}\n" "https://<org-alias>.awsapps.com/mail"
+# → contains us-east-1 / us-west-2 / eu-west-1
+```
+
+If the user can't find their URL, ask whether they originally created the org
+in Ireland, N. Virginia, or Oregon. Default Greek/EU customers to eu-west-1.
+
+### 2. Decide path
+
+```
+Does the user need calendar/contacts/rules?
+  ├─ Yes  → Classic Outlook + Autodiscover (Section 3)
+  └─ No   → New Outlook + IMAP/SMTP (Section 4)
+```
+
+### 3. Classic Outlook + Autodiscover
+
+1. If "New Outlook" toggle is on in the title bar, flip it off.
+2. `File → Add Account → <email>` → **Connect**.
+3. If Outlook resolves: enter the password, done.
+4. If Outlook redirects to a Microsoft 365 sign-in page or fails with
+   "Cannot connect to server", run
+   `scripts/workmail-outlook-autodiscover-fix.ps1 -Region <region>` from an
+   admin PowerShell, restart Outlook, retry. The script writes registry keys
+   that disable SCP/SRV/HttpsRootDomain lookups so Autodiscover goes straight
+   to the WorkMail endpoint.
+
+### 4. New Outlook + IMAP/SMTP
+
+1. Settings (gear) → **Accounts → Email accounts → Add account**.
+2. Enter the email → **Continue** → **Show advanced setup** → **IMAP**.
+3. Use settings from `reference/endpoints.md` for the user's region.
+4. **Both ports MUST be SSL/TLS**, not STARTTLS — WorkMail SMTP rejects
+   STARTTLS on 465. The new-Outlook wizard sometimes preselects STARTTLS;
+   flip it.
+
+### 5. Verify
+
+Always run the connectivity doctor before blaming Outlook:
+
+```bash
+scripts/workmail-connectivity-test.sh \
+  --region eu-west-1 \
+  --user tbaltzakis@cloudless.gr
+```
+
+The script tests DNS, TLS handshake on 993 + 465, the Autodiscover XML
+endpoint, and (with `--password`) a real IMAP LOGIN.
+
+## Common errors
+
+| Symptom                                                | Likely cause                                            | Fix                                                                                              |
+| ------------------------------------------------------ | ------------------------------------------------------- | ------------------------------------------------------------------------------------------------ |
+| Outlook redirects to M365 sign-in                      | Classic Outlook hit SCP/AD lookup or SRV record         | Run `scripts/workmail-outlook-autodiscover-fix.ps1 -Region <r>`                                  |
+| "Cannot connect to autodiscover"                       | Outlook tried `autodiscover.mail.<r>.awsapps.com`       | Fix script forces `autodiscover-service.mail.<r>.awsapps.com`                                    |
+| New Outlook offers Exchange but fails to detect server | New Outlook only supports M365 Exchange, not WorkMail   | Use IMAP path (Section 4)                                                                        |
+| IMAP login fails with "Authentication failed"          | Wrong username form, or IMAP disabled at org level      | Username must be the full address. Check WorkMail admin → Organizations → Access control rules. |
+| Outgoing mail bounces with TLS error                   | Wizard set STARTTLS on port 465                         | Switch to SSL/TLS on 465                                                                         |
+| TLS handshake times out                                | Outbound 993/465 blocked by firewall/VPN                | Run connectivity test from outside the network to confirm                                        |
+| Password "wrong" but is correct                        | Wizard re-encoded non-ASCII chars                       | Copy-paste rather than type                                                                      |
+
+## Security notes
+
+- Never accept a WorkMail password pasted into chat — direct the user to type
+  it into Outlook locally, or hand them the connectivity script to test on
+  their own machine. If a password has already been shared in chat, advise
+  rotating it in the WorkMail admin console.
+- WorkMail has no concept of "app-specific passwords" — the IMAP/EWS password
+  is the account password. For unattended integrations (forwarders,
+  sync agents), create a dedicated mailbox rather than reusing the human
+  user's credentials.
+
+## Files
+
+- `reference/endpoints.md` — mirror of AWS WorkMail endpoint table
+- `../../scripts/workmail-outlook-autodiscover-fix.ps1` — registry helper
+- `../../scripts/workmail-connectivity-test.sh` — DNS/TLS/IMAP doctor
+
+## Sources
+
+- [Amazon WorkMail endpoints and quotas — AWS General Reference](https://docs.aws.amazon.com/general/latest/gr/workmail.html)
+- [Setting up Microsoft Outlook clients for Amazon WorkMail](https://docs.aws.amazon.com/workmail/latest/userguide/outlook-client.html)
+- [Setting up IMAP for Amazon WorkMail](https://docs.aws.amazon.com/workmail/latest/userguide/using_IMAP.html)
+- [Preventing Outlook (Classic) Autodiscover Hijack to Microsoft 365 — AWS re:Post](https://repost.aws/questions/QUm3TxTl15TcGk7iPJflOJZw/preventing-outlook-classic-autodiscover-hijack-to-microsoft-365-aws-workmail)
+- [Outlook autodiscover fails for new WorkMail mailboxes (`autodiscover-service` vs `autodiscover`) — AWS re:Post](https://repost.aws/questions/QUQ4uJvhs6TySjirSsr4Hdjw/outlook-autodiscover-fails-for-new-work-mail-mailboxes-points-to-wrong-endpoint-autodiscover-mail-us-east-1-awsapps-com-instead-of-autodiscover-service-mail-us-east-1-awsapps-com)

--- a/skills/workmail-outlook-setup/reference/endpoints.md
+++ b/skills/workmail-outlook-setup/reference/endpoints.md
@@ -1,0 +1,65 @@
+# Amazon WorkMail endpoint reference
+
+Authoritative source: <https://docs.aws.amazon.com/general/latest/gr/workmail.html>
+Mirrored 2026-06-15. Re-check when adding a new region or after any AWS
+WorkMail announcement.
+
+WorkMail is available in **three** AWS regions only: `us-east-1`, `us-west-2`,
+`eu-west-1`. Picking the wrong region is the most common configuration error
+— the protocols silently 404 or time out instead of failing loudly.
+
+## Service endpoints (SDK / control plane)
+
+| Region    | Service             | Endpoint                                            |
+| --------- | ------------------- | --------------------------------------------------- |
+| us-east-1 | WorkMail SDK        | <https://workmail.us-east-1.amazonaws.com>          |
+| us-east-1 | Message Flow SDK    | <https://workmailmessageflow.us-east-1.amazonaws.com> |
+| us-west-2 | WorkMail SDK        | <https://workmail.us-west-2.amazonaws.com>          |
+| us-west-2 | Message Flow SDK    | <https://workmailmessageflow.us-west-2.amazonaws.com> |
+| eu-west-1 | WorkMail SDK        | <https://workmail.eu-west-1.amazonaws.com>          |
+| eu-west-1 | Message Flow SDK    | <https://workmailmessageflow.eu-west-1.amazonaws.com> |
+
+## Email-protocol endpoints (what Outlook/clients use)
+
+| Region    | Protocol      | Endpoint                                                                                |
+| --------- | ------------- | --------------------------------------------------------------------------------------- |
+| us-east-1 | Autodiscover  | `https://autodiscover-service.mail.us-east-1.awsapps.com/autodiscover/autodiscover.xml` |
+| us-east-1 | EWS           | `https://ews.mail.us-east-1.awsapps.com/EWS/Exchange.asmx`                              |
+| us-east-1 | ActiveSync    | `https://mobile.mail.us-east-1.awsapps.com/Microsoft-Server-ActiveSync`                 |
+| us-east-1 | IMAPS         | `imap.mail.us-east-1.awsapps.com:993`                                                   |
+| us-east-1 | SMTPS         | `smtp.mail.us-east-1.awsapps.com:465`                                                   |
+| us-west-2 | Autodiscover  | `https://autodiscover-service.mail.us-west-2.awsapps.com/autodiscover/autodiscover.xml` |
+| us-west-2 | EWS           | `https://ews.mail.us-west-2.awsapps.com/EWS/Exchange.asmx`                              |
+| us-west-2 | ActiveSync    | `https://mobile.mail.us-west-2.awsapps.com/Microsoft-Server-ActiveSync`                 |
+| us-west-2 | IMAPS         | `imap.mail.us-west-2.awsapps.com:993`                                                   |
+| us-west-2 | SMTPS         | `smtp.mail.us-west-2.awsapps.com:465`                                                   |
+| eu-west-1 | Autodiscover  | `https://autodiscover-service.mail.eu-west-1.awsapps.com/autodiscover/autodiscover.xml` |
+| eu-west-1 | EWS           | `https://ews.mail.eu-west-1.awsapps.com/EWS/Exchange.asmx`                              |
+| eu-west-1 | ActiveSync    | `https://mobile.mail.eu-west-1.awsapps.com/Microsoft-Server-ActiveSync`                 |
+| eu-west-1 | IMAPS         | `imap.mail.eu-west-1.awsapps.com:993`                                                   |
+| eu-west-1 | SMTPS         | `smtp.mail.eu-west-1.awsapps.com:465`                                                   |
+
+## Important gotchas
+
+- The Autodiscover hostname is **`autodiscover-service.mail.<region>.awsapps.com`**,
+  not `autodiscover.mail.<region>.awsapps.com`. Older mailboxes resolved the
+  shorter name; newer ones do not. Always use the `-service` form.
+- IMAP encryption: **SSL/TLS** on 993 (IMAPS). STARTTLS on 143 is not supported.
+- SMTP encryption: **SSL/TLS** on 465 (SMTPS). STARTTLS on 587 is **not**
+  supported by WorkMail — clients that default to STARTTLS will fail.
+- Authentication mechanism: **PLAIN** over the TLS-wrapped channel.
+- The username for IMAP/SMTP/EWS is always the **full email address**, never
+  the local part.
+- WorkMail has no separate "app password" — the human's account password is
+  the credential clients use.
+
+## Quotas worth remembering
+
+- Max attachment size: 25 MB per message (after MIME encoding overhead).
+- Max recipients per outbound message: 500.
+- Per-user mailbox: 50 GB.
+- Send rate: 14,400 messages / 24h / user (the spam-filter ceiling, not a
+  documented hard limit — burst above this gets throttled).
+
+See <https://docs.aws.amazon.com/workmail/latest/adminguide/workmail_limits.html>
+for the authoritative current numbers.


### PR DESCRIPTION
## Why

While wiring `tbaltzakis@cloudless.gr` (Amazon WorkMail) into Outlook this session, several non-obvious gotchas surfaced — most notably that the Autodiscover hostname is `autodiscover-service.mail.<region>.awsapps.com` (not `autodiscover.mail.<region>.awsapps.com`) and that **New Outlook for Windows cannot speak EWS** to anything outside Microsoft 365 / Outlook.com, so WorkMail there is IMAP-only. Capturing the playbook as a project-local skill following the `cluster-bash` / `terraform-doctor` pattern.

## What's added

- **`skills/workmail-outlook-setup/SKILL.md`** — trigger phrases, when-to-use, client capability matrix (classic EWS vs new IMAP), region-detection one-liner, error → fix table, security notes.
- **`skills/workmail-outlook-setup/reference/endpoints.md`** — authoritative WorkMail endpoint table mirrored from the AWS General Reference. All three regions (`us-east-1`, `us-west-2`, `eu-west-1`); Autodiscover / EWS / ActiveSync / IMAPS / SMTPS; the `-service` hostname gotcha called out.
- **`scripts/workmail-outlook-autodiscover-fix.ps1`** — per-user (HKCU) PowerShell helper that writes the documented Outlook AutoDiscover overrides: `ExcludeScpLookup`, `ExcludeHttpsRootDomain`, `ExcludeSrvRecord`, `ExcludeLastKnownGoodURL`, `ExcludeExplicitO365Endpoint`, plus a `RedirectServers` entry trusting the WorkMail host. Region-parameterized, supports `-DryRun` and `-Revert`. Source: AWS re:Post 'Preventing Outlook (Classic) Autodiscover Hijack to Microsoft 365 (AWS WorkMail)'.
- **`scripts/workmail-connectivity-test.sh`** — POSIX bash doctor. Probes DNS resolution for `imap`/`smtp`/`autodiscover-service`/`ews` hosts, TLS handshake on 993 + 465, the Autodiscover XML endpoint (expects 401/403 = auth challenge), and (with `--password`) a real `IMAP LOGIN`. Runs on Linux / macOS / Git-Bash. Region-validated to the 3 WorkMail regions.

## How to use after merge

```bash
# Diagnose from any workstation
bash scripts/workmail-connectivity-test.sh --region us-east-1 --user tbaltzakis@cloudless.gr

# Fix Classic Outlook Autodiscover hijack (run in PowerShell on the Windows box)
powershell -ExecutionPolicy Bypass -File scripts/workmail-outlook-autodiscover-fix.ps1 -Region us-east-1
```

## Risk

Docs + scripts only — no runtime code paths touched. Branch protection only requires `Build`, which still runs unchanged.

## Sources

- [Amazon WorkMail endpoints and quotas — AWS General Reference](https://docs.aws.amazon.com/general/latest/gr/workmail.html)
- [Preventing Outlook (Classic) Autodiscover Hijack to Microsoft 365 — AWS re:Post](https://repost.aws/questions/QUm3TxTl15TcGk7iPJflOJZw/preventing-outlook-classic-autodiscover-hijack-to-microsoft-365-aws-workmail)
- [Setting up Microsoft Outlook clients for Amazon WorkMail](https://docs.aws.amazon.com/workmail/latest/userguide/outlook-client.html)
- [Setting up IMAP for Amazon WorkMail](https://docs.aws.amazon.com/workmail/latest/userguide/using_IMAP.html)