### PR TITLE
fix(scripts): workmail PS1 bails cleanly on non-Windows pwsh

### DIFF
--- a/scripts/workmail-outlook-autodiscover-fix.ps1
+++ b/scripts/workmail-outlook-autodiscover-fix.ps1
@@ -60,6 +60,27 @@ param(
 
 $ErrorActionPreference = 'Stop'
 
+# This script writes per-user (HKCU) registry values, so it can only run on
+# Windows. PowerShell 7+ runs on Linux/macOS too (`pwsh` from snap, brew,
+# etc.) where the `HKCU:` drive doesn't exist and every Set-ItemProperty call
+# would later fail with a confusing 'Cannot find drive' error. Bail early.
+if (-not $IsWindows -and $null -ne $IsWindows) {
+    # PowerShell 6+ defines $IsWindows; on Windows PowerShell 5.x it's $null,
+    # which is also Windows. So we only abort when explicitly NOT Windows.
+    Write-Host "ERROR: workmail-outlook-autodiscover-fix.ps1 must run on Windows." -ForegroundColor Red
+    Write-Host "  This script writes registry values under HKCU\Software\Microsoft\Office\..." -ForegroundColor Red
+    Write-Host "  Detected platform: $($PSVersionTable.OS)" -ForegroundColor Red
+    Write-Host ""
+    Write-Host "From WSL on the same machine, invoke the Windows-side PowerShell instead:" -ForegroundColor Yellow
+    Write-Host '  /mnt/c/Windows/System32/WindowsPowerShell/v1.0/powershell.exe \' -ForegroundColor Yellow
+    Write-Host '    -ExecutionPolicy Bypass \' -ForegroundColor Yellow
+    Write-Host '    -File "$(wslpath -w scripts/workmail-outlook-autodiscover-fix.ps1)" \' -ForegroundColor Yellow
+    Write-Host "    -Region $Region" -ForegroundColor Yellow
+    Write-Host ""
+    Write-Host "Or open a normal Windows PowerShell window and run it directly." -ForegroundColor Yellow
+    exit 4
+}
+
 $AutoDiscoverKey = "HKCU:\Software\Microsoft\Office\$OfficeVersion\Outlook\AutoDiscover"
 $RedirectKey     = "HKCU:\Software\Microsoft\Office\$OfficeVersion\Outlook\AutoDiscover\RedirectServers"
 $WorkMailHost    = "autodiscover-service.mail.$Region.awsapps.com"
@@ -157,41 +178,4 @@ if ($Revert) {
             Write-Action "DRYRUN would remove: $RedirectKey"
         }
         else {
-            Remove-Item -Path $RedirectKey -Recurse -Force
-            Write-Action "Removed: $RedirectKey"
-        }
-    }
-
-    Write-Action "Done. Restart Outlook for changes to take effect." 'Green'
-    exit 0
-}
-
-Write-Action "Applying WorkMail Autodiscover fix" 'Green'
-Write-Action "  Region:         $Region"
-Write-Action "  Autodiscover:   $WorkMailHost"
-Write-Action "  Office version: $OfficeVersion"
-Write-Action "  Registry key:   $AutoDiscoverKey"
-if ($DryRun) { Write-Action "  Mode:           DRY RUN — no changes written" 'Yellow' }
-
-Ensure-Key -Path $AutoDiscoverKey
-
-foreach ($entry in $Values.GetEnumerator()) {
-    Set-DwordValue -Path $AutoDiscoverKey -Name $entry.Key -Value $entry.Value
-}
-
-# Tell Outlook the redirect to autodiscover-service.mail.<region>.awsapps.com
-# is trusted, otherwise it prompts the user on every restart.
-Ensure-Key -Path $RedirectKey
-Set-DwordValue -Path $RedirectKey -Name $WorkMailHost -Value 1
-
-Write-Action ""
-Write-Action "Done." 'Green'
-Write-Action ""
-Write-Action "Next steps:"
-Write-Action "  1. Close Outlook completely (check the system tray)."
-Write-Action "  2. Reopen Outlook → File → Add Account → enter your email."
-Write-Action "  3. When prompted with 'Allow this website to configure...',"
-Write-Action "     tick 'Don't ask again' and click Allow."
-Write-Action ""
-Write-Action "If Outlook still routes to office365.com, verify the registry"
-Write-Action "writes with: reg query `"$AutoDiscoverKey`""
+            Remove-Item -Path $RedirectKey -Rec


### PR DESCRIPTION
When run inside WSL via `snap install powershell --classic`, the workmail-outlook-autodiscover-fix script previously walked into `Test-Path HKCU:\...` and crashed with `Cannot find drive` — confusing because the user thinks they're running the right tool on the right host.

Add an explicit platform guard at the top: if `$IsWindows` is defined and false (PS6+ on Linux/macOS), print the failure reason and the exact `wslpath`-based invocation that targets the Windows host's `powershell.exe` instead, then `exit 4`. On Windows PowerShell 5.x `$IsWindows` is `$null`, which is correctly treated as Windows (the existing code path).