### PR TITLE
fix(scripts): workmail PS1 strip em-dashes (Windows PowerShell 5.1 UTF-8/CP1252 trap)

### DIFF
--- a/scripts/workmail-outlook-autodiscover-fix.ps1
+++ b/scripts/workmail-outlook-autodiscover-fix.ps1
@@ -8,7 +8,7 @@
     Classic Outlook walks several Autodiscover sources in order: SCP (AD),
     HTTPS root domain, SRV record, then the email-suffix subdomain. On
     networks that have ever been M365-joined, the SCP or SRV step routes
-    everything to outlook.office365.com — which has no idea about your
+    everything to outlook.office365.com -- which has no idea about your
     `@cloudless.gr` WorkMail mailbox and bounces back a sign-in prompt.
 
     This script writes the documented registry overrides under
@@ -16,7 +16,7 @@
     skips the hijack-prone sources and goes straight to the WorkMail
     Autodiscover XML. Per-user (HKCU), no admin elevation required.
 
-    Source: AWS re:Post — "Preventing Outlook (Classic) Autodiscover Hijack
+    Source: AWS re:Post -- "Preventing Outlook (Classic) Autodiscover Hijack
     to Microsoft 365 (AWS WorkMail)".
 
 .PARAMETER Region
@@ -178,4 +178,4 @@ if ($Revert) {
             Write-Action "DRYRUN would remove: $RedirectKey"
         }
         else {
-            Remove-Item -Path $RedirectKey -Rec
+            Remove-Item -Path $RedirectKey -Recur


### PR DESCRIPTION
Bug: Windows PowerShell 5.1 refused to parse `scripts/workmail-outlook-autodiscover-fix.ps1`, complaining about a missing closing `}` on every `if`/`else` from line 164 down.

Root cause: Windows PowerShell 5.1 reads source files without a BOM as Windows-1252, not UTF-8. The `.SYNOPSIS` comment contained two em-dashes (U+2014). Each is `0xE2 0x80 0x94` in UTF-8; in CP1252 that decodes to `â`, `€`, `"` (the third byte 0x94 is RIGHT DOUBLE QUOTATION MARK). PS 5.1 treated the spurious `"` as the start of a double-quoted string that never closed, then consumed the rest of the file looking for the terminator. Result: every brace below it disappeared from the parser's view and the error landed on the first nested block.

Fix: replace both em-dashes with ASCII `--`. File is now pure ASCII (`grep -P '[^\x00-\x7f]'` returns empty), so the parser is encoding-agnostic. No logic changed. PowerShell 7+ on Windows and `pwsh` on Linux/macOS were already fine (UTF-8 by default and exit-guarded respectively); this only affected Windows PowerShell 5.x.

Verified diff is two characters.