### PR TITLE
fix: resolve client-portals console errors (CSP pixel, 413 cookie, 500)

### DIFF
--- a/__tests__/auth-lib-callbacks.test.ts
+++ b/__tests__/auth-lib-callbacks.test.ts
@@ -227,14 +227,15 @@ describe("src/lib/auth.ts — real callback behaviour", () => {
       }),
     });
     const expired = {
-      accessToken: "old-atk",
       refreshToken: "rtk-old",
       expiresAt: Math.floor(Date.now() / 1000) - 60,
       groups: ["member"],
       roles: [],
     };
     const result = await jwt.jwt({ token: { ...expired } });
-    expect(result.accessToken).toBe(newAccessToken);
+    // accessToken is no longer persisted on the JWT (cookie-size slim); the
+    // refresh still rotates the refresh_token and clears the error flag.
+    expect(result.accessToken).toBeUndefined();
     expect(result.refreshToken).toBe("rtk-new");
     expect(result.error).toBeUndefined();
   });
@@ -256,7 +257,7 @@ describe("src/lib/auth.ts — real callback behaviour", () => {
 
   // ── session callback ───────────────────────────────────────────────────────
 
-  it("session callback surfaces accessToken, idToken, groups, roles, and user.id", async () => {
+  it("session callback surfaces idToken, groups, roles, and user.id", async () => {
     const { session: sessionCb } = capturedConfig.callbacks as {
       session: (a: SessionInput) => Promise<SessionInput["session"]>;
     };
@@ -264,14 +265,14 @@ describe("src/lib/auth.ts — real callback behaviour", () => {
       session: { user: { id: "" } },
       token: {
         sub: "u-1",
-        accessToken: "atk",
         idToken: "itk",
         groups: ["admin"],
         roles: [],
       },
     });
     expect(out.user.id).toBe("u-1");
-    expect(out.accessToken).toBe("atk");
+    // accessToken is no longer surfaced on the session (cookie-size slim).
+    expect(out.accessToken).toBeUndefined();
     expect(out.idToken).toBe("itk");
     expect((out as Record<string, unknown>).user).toMatchObject({
       groups: ["admin"],

--- a/__tests__/client-portals.test.ts
+++ b/__tests__/client-portals.test.ts
@@ -44,7 +44,36 @@ describe("client-portals", () => {
         Parameter: { Value: JSON.stringify([SAMPLE_PORTAL]) },
       });
       const r = await readPortals();
-      expect(r).toEqual([SAMPLE_PORTAL]);
+      // readPortals normalizes records, so the array fields are always present.
+      expect(r).toEqual([{ ...SAMPLE_PORTAL, deliverables: [], paymentLinks: [] }]);
+    });
+
+    it("normalizes legacy records missing array fields (regression: 500 on GET)", async () => {
+      // A pre-deliverables record with no steps array (and a step missing its
+      // comments) must be coerced to valid arrays so scoreClientHealth and the
+      // admin route can iterate without throwing an unhandled TypeError.
+      const legacy = {
+        token: "tok-legacy",
+        label: "Legacy",
+        clientEmail: "y@acme.example",
+        clientName: "Acme",
+        createdAt: "2026-01-01T00:00:00Z",
+        steps: [{ id: "s1", name: "Audit", status: "pending" }],
+      };
+      mockSSMSend.mockResolvedValueOnce({
+        Parameter: { Value: JSON.stringify([legacy]) },
+      });
+      const [p] = await readPortals();
+      expect(p.steps[0].comments).toEqual([]);
+      expect(p.deliverables).toEqual([]);
+      expect(p.paymentLinks).toEqual([]);
+    });
+
+    it("returns empty array when the stored value is not an array", async () => {
+      mockSSMSend.mockResolvedValueOnce({
+        Parameter: { Value: JSON.stringify({ not: "an array" }) },
+      });
+      await expect(readPortals()).resolves.toEqual([]);
     });
 
     it("returns empty array on SSM error", async () => {

--- a/e2e/security-headers.spec.ts
+++ b/e2e/security-headers.spec.ts
@@ -85,7 +85,8 @@ test.describe("security headers — cloud", () => {
       "frame-ancestors 'none'",
       "object-src 'none'",
       "base-uri 'self'",
-      "form-action 'self'",
+      // Meta Pixel form-post fallback hosts are appended to 'self'.
+      "form-action 'self' https://www.facebook.com https://connect.facebook.net",
       "report-uri /api/csp-report",
       "report-to csp-endpoint",
     ]) {

--- a/src/app/api/admin/client-portals/route.ts
+++ b/src/app/api/admin/client-portals/route.ts
@@ -39,10 +39,17 @@ export async function GET(request: NextRequest) {
   const auth = await requireAdmin(request);
   if (!auth.ok) return auth.response;
 
-  const portals = await readPortals();
-  // Computed, non-persisted health score per portal (Phase 4).
-  const withHealth = portals.map((p) => ({ ...p, health: scoreClientHealth(p) }));
-  return NextResponse.json({ portals: withHealth });
+  try {
+    const portals = await readPortals();
+    // Computed, non-persisted health score per portal (Phase 4). readPortals
+    // normalizes record shape, so scoring can't throw on legacy data — the
+    // try/catch is defense-in-depth, matching the sibling admin routes.
+    const withHealth = portals.map((p) => ({ ...p, health: scoreClientHealth(p) }));
+    return NextResponse.json({ portals: withHealth });
+  } catch (err) {
+    console.error("[client-portals] GET failed:", err);
+    return NextResponse.json({ error: "Failed to load client portals." }, { status: 500 });
+  }
 }
 
 export async function POST(request: NextRequest) {

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -18,7 +18,6 @@ type RefreshTokenError = typeof REFRESH_TOKEN_ERROR;
 
 declare module "next-auth" {
   interface Session {
-    accessToken?: string;
     idToken?: string;
     error?: RefreshTokenError;
     user: {
@@ -31,7 +30,6 @@ declare module "next-auth" {
 
 declare module "next-auth/jwt" {
   interface JWT {
-    accessToken?: string;
     idToken?: string;
     refreshToken?: string;
     expiresAt?: number;
@@ -170,7 +168,12 @@ function buildNextAuth(env: AuthEnv): NextAuthResult {
     callbacks: {
       async jwt({ token, account, profile }) {
         if (account) {
-          token.accessToken = account.access_token;
+          // accessToken is intentionally NOT persisted on the JWT. Nothing reads
+          // session.accessToken, and dropping it shrinks the encrypted session
+          // cookie — which chunks past the 4KB limit and can push the combined
+          // Cookie header over the CloudFront/Lambda edge limit (→ 413 on
+          // authenticated requests). idToken (used by fetch-with-auth) and
+          // refreshToken (used to refresh) are still needed, so they stay.
           token.idToken = account.id_token;
           token.refreshToken = account.refresh_token;
           token.expiresAt =
@@ -201,7 +204,8 @@ function buildNextAuth(env: AuthEnv): NextAuthResult {
 
         try {
           const refreshed = await refreshAccessToken(token.refreshToken, env);
-          token.accessToken = refreshed.access_token;
+          // accessToken not stored (see jwt account branch above); we still decode
+          // the fresh access_token below to refresh the groups claim.
           if (refreshed.refresh_token) token.refreshToken = refreshed.refresh_token;
           if (refreshed.id_token) token.idToken = refreshed.id_token;
           token.expiresAt = now + refreshed.expires_in;
@@ -215,7 +219,6 @@ function buildNextAuth(env: AuthEnv): NextAuthResult {
         }
       },
       async session({ session, token }) {
-        session.accessToken = token.accessToken;
         session.idToken = token.idToken;
         session.user.id = token.sub ?? "";
         session.user.groups = token.groups ?? [];

--- a/src/lib/client-portals.ts
+++ b/src/lib/client-portals.ts
@@ -85,10 +85,30 @@ export interface ClientPortal {
   lastReportAt?: string;
 }
 
+/**
+ * Coerce a stored record into a well-formed portal. Legacy/partial entries in
+ * SSM (written before deliverables/paymentLinks existed, or hand-edited) can be
+ * missing the array fields that scoreClientHealth and the admin route iterate
+ * over. A missing `steps` array threw an unhandled TypeError that surfaced as a
+ * 500 on GET /api/admin/client-portals. Normalizing on read is the single choke
+ * point that guarantees every consumer sees the arrays it assumes.
+ */
+function normalizePortal(raw: ClientPortal): ClientPortal {
+  const steps = Array.isArray(raw?.steps) ? raw.steps : [];
+  return {
+    ...raw,
+    steps: steps.map((s) => ({ ...s, comments: Array.isArray(s?.comments) ? s.comments : [] })),
+    deliverables: Array.isArray(raw?.deliverables) ? raw.deliverables : [],
+    paymentLinks: Array.isArray(raw?.paymentLinks) ? raw.paymentLinks : [],
+  };
+}
+
 export async function readPortals(): Promise<ClientPortal[]> {
   try {
     const res = await getClient().send(new GetParameterCommand({ Name: SSM_KEY }));
-    return JSON.parse(res.Parameter?.Value ?? "[]");
+    const parsed: unknown = JSON.parse(res.Parameter?.Value ?? "[]");
+    if (!Array.isArray(parsed)) return [];
+    return parsed.map((p) => normalizePortal(p as ClientPortal));
   } catch {
     return [];
   }

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -195,7 +195,12 @@ function buildCSP(nonce: string): string {
     "media-src 'self'",
     "object-src 'none'",
     "base-uri 'self'",
-    "form-action 'self'",
+    // Meta Pixel (fbevents.js) falls back to submitting a hidden <form> to
+    // https://www.facebook.com/tr/ when it can't use an image/beacon transport.
+    // connect.facebook.net is the documented companion host. Without these the
+    // browser blocks the post ("violates form-action 'self'") and conversions
+    // silently stop being reported. 'self' stays first so our own forms work.
+    "form-action 'self' https://www.facebook.com https://connect.facebook.net",
     "frame-ancestors 'none'",
     "report-uri /api/csp-report",
     "report-to csp-endpoint",


### PR DESCRIPTION
Resolves three distinct issues surfaced in the live `/admin/client-portals` browser console.

## 1. CSP blocked Meta Pixel conversions (`form-action 'self'`)
The Meta Pixel falls back to posting a hidden `<form>` to `https://www.facebook.com/tr/`; `form-action 'self'` blocked it, silently dropping conversion reporting. Added `https://www.facebook.com` + `https://connect.facebook.net` to `form-action` (both already allowlisted in `connect-src`/`script-src`). e2e CSP pin updated.

## 2. `500` on `GET /api/admin/client-portals`
The handler had no try/catch (unlike its sibling `roi`/`profile` routes); a legacy portal record in SSM missing its `steps` array made `scoreClientHealth` throw. `readPortals` now normalizes every record (arrays guaranteed) at the single read choke point, plus a defensive try/catch + log on the handler. Regression tests added.

## 3. `413` on authenticated GETs (`/api/user/profile`, `/api/admin/analytics/roi`)
The encrypted next-auth session cookie stored `accessToken` + `idToken` + `refreshToken`, exceeding the 4KB limit → chunked cookies → combined `Cookie` header trips the CloudFront/Lambda edge header limit. Dropped the **unused** Cognito `accessToken` from the JWT/session (verified no reader in `src/`; groups still derived transiently; `idToken`/`refreshToken` retained). First-step mitigation — durable fix if 413s persist is a server-side (DynamoDB-adapter) session store.

### Not in scope (no code change)
- The `logo.svg` manifest-icon error is **not in the current code** (`git grep` is empty; the manifest route serves PNG icons) — it's a stale deployed/cached manifest that clears on redeploy.
- The font "preloaded but not used" warnings are benign `next/font` hints.

## Verification
- `tsc --noEmit`: clean
- Affected unit suites: **76 passing** (client-portals, client-health, auth callbacks, auth, fetch-with-auth)

🤖 Generated with [Claude Code](https://claude.com/claude-code)