### PR TITLE
fix(client-portals): stop 500 on POST/PATCH/DELETE write path

### DIFF
--- a/__tests__/admin-client-portals-api.test.ts
+++ b/__tests__/admin-client-portals-api.test.ts
@@ -29,7 +29,9 @@ vi.mock("@aws-sdk/client-ssm", async () => {
   const actual = await vi.importActual<typeof import("@aws-sdk/client-ssm")>("@aws-sdk/client-ssm");
   return {
     ...actual,
-    SSMClient: vi.fn().mockImplementation(function() { return { send: mockSSMSend }; }),
+    SSMClient: vi.fn().mockImplementation(function () {
+      return { send: mockSSMSend };
+    }),
   };
 });
 
@@ -39,7 +41,7 @@ vi.mock("@aws-sdk/client-ssm", async () => {
 function makeAdminToken(): string {
   const payload = {
     sub: "admin-sub",
-    "groups": ["admin"],
+    groups: ["admin"],
     aud: "client",
     iss: "https://cognito-idp.us-east-1.amazonaws.com/pool",
     iat: Math.floor(Date.now() / 1000) - 10,
@@ -71,7 +73,12 @@ const MOCK_PORTAL: ClientPortal = {
       name: "Free Audit",
       status: "pending",
       comments: [
-        { id: COMMENT_ID, author: "Cloudless Team", text: "Audit scheduled.", createdAt: new Date().toISOString() },
+        {
+          id: COMMENT_ID,
+          author: "Cloudless Team",
+          text: "Audit scheduled.",
+          createdAt: new Date().toISOString(),
+        },
       ],
     },
     { id: "step-2", name: "Implementation", status: "pending", comments: [] },
@@ -129,19 +136,23 @@ describe("POST /api/admin/client-portals", () => {
 
   it("returns 400 when clientEmail is missing", async () => {
     const { POST } = await import("@/app/api/admin/client-portals/route");
-    const res = await POST(adminReq(CLIENT_PORTALS_URL, {
-      method: "POST",
-      body: JSON.stringify({ label: "Test" }),
-    }));
+    const res = await POST(
+      adminReq(CLIENT_PORTALS_URL, {
+        method: "POST",
+        body: JSON.stringify({ label: "Test" }),
+      })
+    );
     expect(res.status).toBe(400);
   });
 
   it("returns 400 when label is missing", async () => {
     const { POST } = await import("@/app/api/admin/client-portals/route");
-    const res = await POST(adminReq(CLIENT_PORTALS_URL, {
-      method: "POST",
-      body: JSON.stringify({ clientEmail: "test@example.com" }),
-    }));
+    const res = await POST(
+      adminReq(CLIENT_PORTALS_URL, {
+        method: "POST",
+        body: JSON.stringify({ clientEmail: "test@example.com" }),
+      })
+    );
     expect(res.status).toBe(400);
   });
 
@@ -150,14 +161,16 @@ describe("POST /api/admin/client-portals", () => {
       .mockResolvedValueOnce({ Parameter: { Value: JSON.stringify([]) } })
       .mockResolvedValue({});
     const { POST } = await import("@/app/api/admin/client-portals/route");
-    const res = await POST(adminReq(CLIENT_PORTALS_URL, {
-      method: "POST",
-      body: JSON.stringify({
-        label: "Beta Corp",
-        clientEmail: "beta@example.com",
-        clientName: "John Beta",
-      }),
-    }));
+    const res = await POST(
+      adminReq(CLIENT_PORTALS_URL, {
+        method: "POST",
+        body: JSON.stringify({
+          label: "Beta Corp",
+          clientEmail: "beta@example.com",
+          clientName: "John Beta",
+        }),
+      })
+    );
     expect(res.status).toBe(201);
     const data = await res.json();
     expect(data.portal).toMatchObject({
@@ -167,6 +180,23 @@ describe("POST /api/admin/client-portals", () => {
     });
     expect(typeof data.portal.token).toBe("string");
     expect(data.portal.token.length).toBeGreaterThan(10);
+  });
+
+  it("returns 502 (not an opaque 500) when the SSM write fails", async () => {
+    // Regression: writePortals had no error handling, so an SSM PutParameter
+    // failure (e.g. value over the size cap) surfaced as an unhandled 500.
+    mockSSMSend.mockReset();
+    mockSSMSend
+      .mockResolvedValueOnce({ Parameter: { Value: JSON.stringify([]) } }) // readPortals
+      .mockRejectedValueOnce(new Error("ParameterMaxValueExceeded")); // writePortals
+    const { POST } = await import("@/app/api/admin/client-portals/route");
+    const res = await POST(
+      adminReq(CLIENT_PORTALS_URL, {
+        method: "POST",
+        body: JSON.stringify({ label: "Big Corp", clientEmail: "big@example.com" }),
+      })
+    );
+    expect(res.status).toBe(502);
   });
 });
 
@@ -178,10 +208,12 @@ it("created portal includes default steps", async () => {
     .mockResolvedValueOnce({ Parameter: { Value: JSON.stringify([]) } })
     .mockResolvedValue({});
   const { POST } = await import("@/app/api/admin/client-portals/route");
-  const res = await POST(adminReq(CLIENT_PORTALS_URL, {
-    method: "POST",
-    body: JSON.stringify({ label: "Steps Corp", clientEmail: "steps@example.com" }),
-  }));
+  const res = await POST(
+    adminReq(CLIENT_PORTALS_URL, {
+      method: "POST",
+      body: JSON.stringify({ label: "Steps Corp", clientEmail: "steps@example.com" }),
+    })
+  );
   expect(res.status).toBe(201);
   const data = await res.json();
   expect(Array.isArray(data.portal.steps)).toBe(true);
@@ -202,24 +234,28 @@ describe("PATCH /api/admin/client-portals", () => {
 
   it("returns 400 when token is missing", async () => {
     const { PATCH } = await import("@/app/api/admin/client-portals/route");
-    const res = await PATCH(adminReq(CLIENT_PORTALS_URL, {
-      method: "PATCH",
-      body: JSON.stringify({ action: ACTION_UPDATE_STEP, stepId: STEP_ID, status: "completed" }),
-    }));
+    const res = await PATCH(
+      adminReq(CLIENT_PORTALS_URL, {
+        method: "PATCH",
+        body: JSON.stringify({ action: ACTION_UPDATE_STEP, stepId: STEP_ID, status: "completed" }),
+      })
+    );
     expect(res.status).toBe(400);
   });
 
   it("updates step status to completed", async () => {
     const { PATCH } = await import("@/app/api/admin/client-portals/route");
-    const res = await PATCH(adminReq(CLIENT_PORTALS_URL, {
-      method: "PATCH",
-      body: JSON.stringify({
-        token: MOCK_PORTAL.token,
-        action: ACTION_UPDATE_STEP,
-        stepId: STEP_ID,
-        status: "completed",
-      }),
-    }));
+    const res = await PATCH(
+      adminReq(CLIENT_PORTALS_URL, {
+        method: "PATCH",
+        body: JSON.stringify({
+          token: MOCK_PORTAL.token,
+          action: ACTION_UPDATE_STEP,
+          stepId: STEP_ID,
+          status: "completed",
+        }),
+      })
+    );
     expect(res.status).toBe(200);
     const data = await res.json();
     const step = data.portal.steps.find((s: { id: string }) => s.id === STEP_ID);
@@ -229,49 +265,58 @@ describe("PATCH /api/admin/client-portals", () => {
 
   it("adds a comment to a step", async () => {
     const { PATCH } = await import("@/app/api/admin/client-portals/route");
-    const res = await PATCH(adminReq(CLIENT_PORTALS_URL, {
-      method: "PATCH",
-      body: JSON.stringify({
-        token: MOCK_PORTAL.token,
-        action: "add-comment",
-        stepId: STEP_ID,
-        author: TEST_NAME,
-        text: "Work started on this step.",
-      }),
-    }));
+    const res = await PATCH(
+      adminReq(CLIENT_PORTALS_URL, {
+        method: "PATCH",
+        body: JSON.stringify({
+          token: MOCK_PORTAL.token,
+          action: "add-comment",
+          stepId: STEP_ID,
+          author: TEST_NAME,
+          text: "Work started on this step.",
+        }),
+      })
+    );
     expect(res.status).toBe(200);
     const data = await res.json();
     const step = data.portal.steps.find((s: { id: string }) => s.id === STEP_ID);
     expect(step.comments).toHaveLength(2);
-    expect(step.comments[1]).toMatchObject({ author: TEST_NAME, text: "Work started on this step." });
+    expect(step.comments[1]).toMatchObject({
+      author: TEST_NAME,
+      text: "Work started on this step.",
+    });
   });
 
   it("returns 400 for add-comment with empty text", async () => {
     const { PATCH } = await import("@/app/api/admin/client-portals/route");
-    const res = await PATCH(adminReq(CLIENT_PORTALS_URL, {
-      method: "PATCH",
-      body: JSON.stringify({
-        token: MOCK_PORTAL.token,
-        action: "add-comment",
-        stepId: STEP_ID,
-        author: TEST_NAME,
-        text: "  ",
-      }),
-    }));
+    const res = await PATCH(
+      adminReq(CLIENT_PORTALS_URL, {
+        method: "PATCH",
+        body: JSON.stringify({
+          token: MOCK_PORTAL.token,
+          action: "add-comment",
+          stepId: STEP_ID,
+          author: TEST_NAME,
+          text: "  ",
+        }),
+      })
+    );
     expect(res.status).toBe(400);
   });
 
   it("deletes a comment from a step", async () => {
     const { PATCH } = await import("@/app/api/admin/client-portals/route");
-    const res = await PATCH(adminReq(CLIENT_PORTALS_URL, {
-      method: "PATCH",
-      body: JSON.stringify({
-        token: MOCK_PORTAL.token,
-        action: "delete-comment",
-        stepId: STEP_ID,
-        commentId: COMMENT_ID,
-      }),
-    }));
+    const res = await PATCH(
+      adminReq(CLIENT_PORTALS_URL, {
+        method: "PATCH",
+        body: JSON.stringify({
+          token: MOCK_PORTAL.token,
+          action: "delete-comment",
+          stepId: STEP_ID,
+          commentId: COMMENT_ID,
+        }),
+      })
+    );
     expect(res.status).toBe(200);
     const data = await res.json();
     const step = data.portal.steps.find((s: { id: string }) => s.id === STEP_ID);
@@ -280,14 +325,16 @@ describe("PATCH /api/admin/client-portals", () => {
 
   it("adds a new custom step", async () => {
     const { PATCH } = await import("@/app/api/admin/client-portals/route");
-    const res = await PATCH(adminReq(CLIENT_PORTALS_URL, {
-      method: "PATCH",
-      body: JSON.stringify({
-        token: MOCK_PORTAL.token,
-        action: "add-step",
-        name: "Custom Review",
-      }),
-    }));
+    const res = await PATCH(
+      adminReq(CLIENT_PORTALS_URL, {
+        method: "PATCH",
+        body: JSON.stringify({
+          token: MOCK_PORTAL.token,
+          action: "add-step",
+          name: "Custom Review",
+        }),
+      })
+    );
     expect(res.status).toBe(200);
     const data = await res.json();
     expect(data.portal.steps).toHaveLength(3);
@@ -296,14 +343,16 @@ describe("PATCH /api/admin/client-portals", () => {
 
   it("deletes a step", async () => {
     const { PATCH } = await import("@/app/api/admin/client-portals/route");
-    const res = await PATCH(adminReq(CLIENT_PORTALS_URL, {
-      method: "PATCH",
-      body: JSON.stringify({
-        token: MOCK_PORTAL.token,
-        action: "delete-step",
-        stepId: STEP_ID,
-      }),
-    }));
+    const res = await PATCH(
+      adminReq(CLIENT_PORTALS_URL, {
+        method: "PATCH",
+        body: JSON.stringify({
+          token: MOCK_PORTAL.token,
+          action: "delete-step",
+          stepId: STEP_ID,
+        }),
+      })
+    );
     expect(res.status).toBe(200);
     const data = await res.json();
     expect(data.portal.steps).toHaveLength(1);
@@ -312,15 +361,17 @@ describe("PATCH /api/admin/client-portals", () => {
 
   it("returns 404 for unknown portal token", async () => {
     const { PATCH } = await import("@/app/api/admin/client-portals/route");
-    const res = await PATCH(adminReq(CLIENT_PORTALS_URL, {
-      method: "PATCH",
-      body: JSON.stringify({
-        token: "nonexistent-token-that-does-not-exist",
-        action: ACTION_UPDATE_STEP,
-        stepId: STEP_ID,
-        status: "completed",
-      }),
-    }));
+    const res = await PATCH(
+      adminReq(CLIENT_PORTALS_URL, {
+        method: "PATCH",
+        body: JSON.stringify({
+          token: "nonexistent-token-that-does-not-exist",
+          action: ACTION_UPDATE_STEP,
+          stepId: STEP_ID,
+          status: "completed",
+        }),
+      })
+    );
     expect(res.status).toBe(404);
   });
 });
@@ -338,10 +389,12 @@ describe("DELETE /api/admin/client-portals", () => {
 
   it("returns 400 when token is missing", async () => {
     const { DELETE } = await import("@/app/api/admin/client-portals/route");
-    const res = await DELETE(adminReq(CLIENT_PORTALS_URL, {
-      method: "DELETE",
-      body: JSON.stringify({}),
-    }));
+    const res = await DELETE(
+      adminReq(CLIENT_PORTALS_URL, {
+        method: "DELETE",
+        body: JSON.stringify({}),
+      })
+    );
     expect(res.status).toBe(400);
   });
 
@@ -350,10 +403,12 @@ describe("DELETE /api/admin/client-portals", () => {
       .mockResolvedValueOnce({ Parameter: { Value: JSON.stringify([MOCK_PORTAL]) } })
       .mockResolvedValue({});
     const { DELETE } = await import("@/app/api/admin/client-portals/route");
-    const res = await DELETE(adminReq(CLIENT_PORTALS_URL, {
-      method: "DELETE",
-      body: JSON.stringify({ token: MOCK_PORTAL.token }),
-    }));
+    const res = await DELETE(
+      adminReq(CLIENT_PORTALS_URL, {
+        method: "DELETE",
+        body: JSON.stringify({ token: MOCK_PORTAL.token }),
+      })
+    );
     expect(res.status).toBe(200);
     const data = await res.json();
     expect(data.ok).toBe(true);

--- a/__tests__/auth-lib-callbacks.test.ts
+++ b/__tests__/auth-lib-callbacks.test.ts
@@ -322,8 +322,6 @@ describe("src/lib/auth.ts — real callback behaviour", () => {
     const { signOut: signOutEvent } = capturedConfig.events as {
       signOut: (msg: { token?: { idToken?: string } }) => Promise<void>;
     };
-    await expect(
-      signOutEvent({ token: { idToken: "tok" } })
-    ).resolves.toBeUndefined();
+    await expect(signOutEvent({ token: { idToken: "tok" } })).resolves.toBeUndefined();
   });
 });

--- a/__tests__/client-portals.test.ts
+++ b/__tests__/client-portals.test.ts
@@ -6,9 +6,16 @@ const { mockSSMSend, putCalls } = vi.hoisted(() => ({
 }));
 
 vi.mock("@aws-sdk/client-ssm", () => ({
-  SSMClient: vi.fn().mockImplementation(function () { return { send: mockSSMSend }; }),
-  GetParameterCommand: vi.fn().mockImplementation(function (input: unknown) { return { __cmd: "Get", input }; }),
-  PutParameterCommand: vi.fn().mockImplementation(function (input: unknown) { putCalls.push(input); return { __cmd: "Put", input }; }),
+  SSMClient: vi.fn().mockImplementation(function () {
+    return { send: mockSSMSend };
+  }),
+  GetParameterCommand: vi.fn().mockImplementation(function (input: unknown) {
+    return { __cmd: "Get", input };
+  }),
+  PutParameterCommand: vi.fn().mockImplementation(function (input: unknown) {
+    putCalls.push(input);
+    return { __cmd: "Put", input };
+  }),
 }));
 
 import {
@@ -92,9 +99,17 @@ describe("client-portals", () => {
       mockSSMSend.mockResolvedValueOnce({});
       await writePortals([SAMPLE_PORTAL]);
       expect(putCalls).toHaveLength(1);
-      const input = putCalls[0] as { Value: string; Overwrite: boolean; Type: string };
+      const input = putCalls[0] as {
+        Value: string;
+        Overwrite: boolean;
+        Type: string;
+        Tier: string;
+      };
       expect(input.Overwrite).toBe(true);
       expect(input.Type).toBe("String");
+      // Intelligent-Tiering auto-upgrades past the 4KB Standard cap as the
+      // portals JSON grows, instead of throwing (which surfaced as a 500).
+      expect(input.Tier).toBe("Intelligent-Tiering");
       expect(JSON.parse(input.Value)).toHaveLength(1);
     });
   });
@@ -231,19 +246,14 @@ describe("client-portals", () => {
         portalWith("in_review"),
         "d-1",
         "request_changes",
-        "needs work",
+        "needs work"
       );
       if (typeof r === "string") throw new Error(r);
       expect(r.status).toBe("changes_requested");
     });
 
     it("truncates client comment to 2000 chars", () => {
-      const r = applyClientResponse(
-        portalWith("in_review"),
-        "d-1",
-        "approve",
-        "x".repeat(3000),
-      );
+      const r = applyClientResponse(portalWith("in_review"), "d-1", "approve", "x".repeat(3000));
       if (typeof r === "string") throw new Error(r);
       expect(r.clientComment?.length).toBe(2000);
     });
@@ -259,7 +269,7 @@ describe("client-portals", () => {
           { id: "3", title: "a", status: "approved", createdAt: "x", updatedAt: "x" },
         ],
       });
-      expect(visible.map(d => d.id)).toEqual(["2", "3"]);
+      expect(visible.map((d) => d.id)).toEqual(["2", "3"]);
     });
 
     it("returns empty array when deliverables is undefined", () => {

--- a/e2e/security-headers.spec.ts
+++ b/e2e/security-headers.spec.ts
@@ -45,9 +45,7 @@ test.describe("security headers — cloud", () => {
     expect(r.headers()["x-powered-by"]).toBeUndefined();
   });
 
-  test("Permissions-Policy hard-blocks 24 features (post-audit hardening)", async ({
-    request,
-  }) => {
+  test("Permissions-Policy hard-blocks 24 features (post-audit hardening)", async ({ request }) => {
     const r = await request.get(PROBE);
     const pp = r.headers()["permissions-policy"] ?? "";
     // Sample a representative subset of the locked-down directives.
@@ -73,9 +71,7 @@ test.describe("security headers — cloud", () => {
     expect(pp).toContain("fullscreen=(self)");
   });
 
-  test("CSP header is set with all expected directives", async ({
-    request,
-  }) => {
+  test("CSP header is set with all expected directives", async ({ request }) => {
     const r = await request.get(PROBE);
     const csp = r.headers()["content-security-policy"] ?? "";
     expect(csp.length, "expected CSP header").toBeGreaterThan(0);
@@ -129,9 +125,7 @@ test.describe("security headers — cloud", () => {
     expect(r.status()).toBe(204);
   });
 
-  test("CSP report endpoint accepts modern Reporting-API payload (204)", async ({
-    request,
-  }) => {
+  test("CSP report endpoint accepts modern Reporting-API payload (204)", async ({ request }) => {
     const r = await request.post("/api/csp-report", {
       headers: { "content-type": "application/reports+json" },
       data: [

--- a/src/app/api/admin/client-portals/route.ts
+++ b/src/app/api/admin/client-portals/route.ts
@@ -35,6 +35,21 @@ function makeDefaultSteps(): PortalStep[] {
   }));
 }
 
+/**
+ * Persist portals, converting an SSM write failure into a clean, logged 502
+ * instead of an unhandled exception (which surfaced as an opaque 500 on
+ * POST/PATCH/DELETE). Returns the error response, or null on success.
+ */
+async function persistPortals(portals: ClientPortal[]): Promise<NextResponse | null> {
+  try {
+    await writePortals(portals);
+    return null;
+  } catch (err) {
+    console.error("[client-portals] write failed:", err);
+    return NextResponse.json({ error: "Failed to save client portals." }, { status: 502 });
+  }
+}
+
 export async function GET(request: NextRequest) {
   const auth = await requireAdmin(request);
   if (!auth.ok) return auth.response;
@@ -87,7 +102,8 @@ export async function POST(request: NextRequest) {
   };
 
   portals.push(portal);
-  await writePortals(portals);
+  const writeErr = await persistPortals(portals);
+  if (writeErr) return writeErr;
 
   return NextResponse.json({ portal }, { status: 201 });
 }
@@ -345,7 +361,8 @@ export async function PATCH(request: NextRequest) {
   if (errorResponse) return errorResponse;
 
   portals[idx] = portal;
-  await writePortals(portals);
+  const writeErr = await persistPortals(portals);
+  if (writeErr) return writeErr;
   return NextResponse.json({ portal });
 }
 
@@ -358,7 +375,8 @@ export async function DELETE(request: NextRequest) {
 
   const portals = await readPortals();
   const updated = portals.filter((p) => p.token !== token);
-  await writePortals(updated);
+  const writeErr = await persistPortals(updated);
+  if (writeErr) return writeErr;
 
   return NextResponse.json({ ok: true });
 }

--- a/src/lib/client-portals.ts
+++ b/src/lib/client-portals.ts
@@ -121,6 +121,12 @@ export async function writePortals(portals: ClientPortal[]): Promise<void> {
       Value: JSON.stringify(portals),
       Type: "String",
       Overwrite: true,
+      // Standard String parameters cap at 4KB; as portals accumulate (steps,
+      // comments, deliverables) the JSON crosses that and PutParameter throws,
+      // surfacing as a 500 on POST/PATCH/DELETE. Intelligent-Tiering stays
+      // Standard (free) until the value exceeds 4KB, then auto-upgrades to the
+      // 8KB Advanced tier — no crash, no cost for the common small case.
+      Tier: "Intelligent-Tiering",
     })
   );
 }


### PR DESCRIPTION
Follow-up to #924, which fixed the GET-side 500 (and the CSP/413 issues) but merged before this write-path fix could be added. The live console showed the client-portals 500 also occurs on **POST** (create).

## Root causes (both fixed)
1. **SSM 4 KB size cap.** `writePortals` used a Standard `String` SSM parameter (4 KB limit, [AWS docs](https://docs.aws.amazon.com/systems-manager/latest/userguide/parameter-store-advanced-parameters.html)). As portals accumulate, `JSON.stringify(portals)` crosses 4 KB and `PutParameter` throws → unhandled 500 on POST/PATCH/DELETE. Switched to `Tier: "Intelligent-Tiering"` — stays Standard (free) until the value exceeds 4 KB, then auto-upgrades to the 8 KB Advanced tier.
2. **No error handling on the write path.** Added `persistPortals()` which catches an SSM write failure and returns a clean, logged **502** instead of an opaque 500, wired into POST/PATCH/DELETE.

Adds a `Tier` assertion and a 502-on-write-failure regression test. Also includes prettier formatting of the test/e2e files from #924.

## Verification
- `tsc --noEmit`: clean · prettier: clean · client-portals unit suites: **42 passing**

🤖 Generated with [Claude Code](https://claude.com/claude-code)