### PR TITLE
fix(postiz): use NextRequest in /api/admin/postiz routes

### DIFF
--- a/src/app/api/admin/postiz/integrations/route.ts
+++ b/src/app/api/admin/postiz/integrations/route.ts
@@ -1,4 +1,4 @@
-import { NextResponse } from "next/server";
+import { NextRequest, NextResponse } from "next/server";
 import { requireAdmin } from "@/lib/api-auth";
 import {
   listIntegrations,
@@ -8,9 +8,9 @@ import {
 
 export const dynamic = "force-dynamic";
 
-export async function GET(req: Request) {
+export async function GET(req: NextRequest) {
   const auth = await requireAdmin(req);
-  if (auth instanceof NextResponse) return auth;
+  if (!auth.ok) return auth.response;
 
   try {
     const integrations = await listIntegrations();

--- a/src/app/api/admin/postiz/posts/[id]/route.ts
+++ b/src/app/api/admin/postiz/posts/[id]/route.ts
@@ -1,4 +1,4 @@
-import { NextResponse } from "next/server";
+import { NextRequest, NextResponse } from "next/server";
 import { requireAdmin } from "@/lib/api-auth";
 import {
   deletePost,
@@ -9,11 +9,11 @@ import {
 export const dynamic = "force-dynamic";
 
 export async function DELETE(
-  req: Request,
+  req: NextRequest,
   { params }: { params: Promise<{ id: string }> },
 ) {
   const auth = await requireAdmin(req);
-  if (auth instanceof NextResponse) return auth;
+  if (!auth.ok) return auth.response;
 
   const { id } = await params;
   if (!id) {

--- a/src/app/api/admin/postiz/posts/route.ts
+++ b/src/app/api/admin/postiz/posts/route.ts
@@ -1,4 +1,4 @@
-import { NextResponse } from "next/server";
+import { NextRequest, NextResponse } from "next/server";
 import { requireAdmin } from "@/lib/api-auth";
 import {
   createPost,
@@ -10,9 +10,9 @@ import {
 
 export const dynamic = "force-dynamic";
 
-export async function GET(req: Request) {
+export async function GET(req: NextRequest) {
   const auth = await requireAdmin(req);
-  if (auth instanceof NextResponse) return auth;
+  if (!auth.ok) return auth.response;
 
   const url = new URL(req.url);
   const startDate =
@@ -42,9 +42,9 @@ export async function GET(req: Request) {
   }
 }
 
-export async function POST(req: Request) {
+export async function POST(req: NextRequest) {
   const auth = await requireAdmin(req);
-  if (auth instanceof NextResponse) return auth;
+  if (!auth.ok) return auth.response;
 
   let body: CreatePostBody;
   try {

--- a/src/app/api/admin/postiz/slot/route.ts
+++ b/src/app/api/admin/postiz/slot/route.ts
@@ -1,4 +1,4 @@
-import { NextResponse } from "next/server";
+import { NextRequest, NextResponse } from "next/server";
 import { requireAdmin } from "@/lib/api-auth";
 import {
   findSlot,
@@ -8,9 +8,9 @@ import {
 
 export const dynamic = "force-dynamic";
 
-export async function GET(req: Request) {
+export async function GET(req: NextRequest) {
   const auth = await requireAdmin(req);
-  if (auth instanceof NextResponse) return auth;
+  if (!auth.ok) return auth.response;
 
   const id = new URL(req.url).searchParams.get("id");
   if (!id) {

--- a/src/app/api/admin/postiz/upload/route.ts
+++ b/src/app/api/admin/postiz/upload/route.ts
@@ -1,4 +1,4 @@
-import { NextResponse } from "next/server";
+import { NextRequest, NextResponse } from "next/server";
 import { requireAdmin } from "@/lib/api-auth";
 import {
   uploadFromUrl,
@@ -8,9 +8,9 @@ import {
 
 export const dynamic = "force-dynamic";
 
-export async function POST(req: Request) {
+export async function POST(req: NextRequest) {
   const auth = await requireAdmin(req);
-  if (auth instanceof NextResponse) return auth;
+  if (!auth.ok) return auth.response;
 
   const body = (await req.json().catch(() => null)) as { url?: string } | null;
   if (!body?.url) {


### PR DESCRIPTION
## What

Five new admin route handlers from PR #926/#927 typed their request param as
`Request` instead of `NextRequest`. `requireAdmin` in `@/lib/api-auth` is
typed `(request: NextRequest) => Promise<AuthResult>`, so the build fails on
type check:

> Type 'Request' is missing the following properties from type 'NextRequest':
> cookies, nextUrl, page, ua

Also fixes a related shape mismatch — `AuthResult` is a discriminated union
`{ok: true, user} | {ok: false, response}`, not a `NextResponse` subtype, so
`if (auth instanceof NextResponse) return auth` never narrowed and would have
broken at runtime too. Switched to the existing pattern used in
`src/app/api/admin/postiz/route.ts`:

```ts
if (!auth.ok) return auth.response;
```

## Files

- `src/app/api/admin/postiz/integrations/route.ts`
- `src/app/api/admin/postiz/posts/route.ts` (GET + POST)
- `src/app/api/admin/postiz/posts/[id]/route.ts` (DELETE)
- `src/app/api/admin/postiz/upload/route.ts`
- `src/app/api/admin/postiz/slot/route.ts`

## Verification

- All 5 files now import `NextRequest` from `next/server`.
- Every handler signature reads `req: NextRequest`.
- Every auth gate reads `if (!auth.ok) return auth.response`.
- Bundle Budget Audit on this branch should pass (the failing run was the
  same TS type error that this PR fixes).
