### PR TITLE
perf(auth): don't block isLoading on /api/user/profile (fire-and-forget enrich)

### DIFF
--- a/src/context/AuthContext.tsx
+++ b/src/context/AuthContext.tsx
@@ -169,10 +169,19 @@ export function AuthProvider({ children }: AuthProviderProps) {
           preferences: { ...DEFAULT_PREFERENCES },
         };
         setIsAdmin(isAdminFromSession(data.user));
-        // Enrich with stored profile attributes (company/phone/preferences)
-        // the session JWT doesn't carry, so saved values render instead of
-        // blanks. Best-effort — falls back to the session-only user.
-        setUser(await enrichWithProfile(base));
+        // Render the session-only user immediately so isLoading flips false
+        // and the admin layout stops showing the centred spinner. The profile
+        // enrichment (company/phone/preferences) runs without await — when it
+        // resolves it patches the state in. Avoids blocking the whole admin
+        // boot on /api/user/profile, which returns 413 today because the
+        // Cognito-cookie + headers combo exceeds the edge header limit
+        // (documented in src/lib/auth.ts:172). The 413 itself is harmless —
+        // enrichWithProfile swallows it and returns the base — but awaiting
+        // it added a full request RTT to every admin page load.
+        setUser(base);
+        void enrichWithProfile(base).then((enriched) => {
+          if (enriched !== base) setUser(enriched);
+        });
       } else {
         setUser(null);
         setIsAdmin(false);


### PR DESCRIPTION
## What

Make the user-profile enrichment in `AuthContext.checkAuth()` fire-and-forget
instead of blocking the auth boot on a `await enrichWithProfile()`.

The admin layout shows a centred magenta spinner while `isLoading || !user`.
Before this change `isLoading` only flipped false **after** the awaited
`enrichWithProfile()` settled, which calls `/api/user/profile`. That endpoint
**413s today** because the Cognito-cookie + headers combo exceeds the edge
header limit (documented in `src/lib/auth.ts:172-176` — `accessToken` was
already dropped to shrink the cookie; the remaining tokens still bump the
limit on some routes).

`enrichWithProfile()` already catches the 413 and returns the base user, so
the UI was correct — just slow. After this change the session-only user is
rendered immediately and the enrichment runs in parallel, patching state in
if it adds anything.

## Impact

Measured on a real `/en/admin/client-portals` load via the browser MCP:

- before: admin spinner visible 10-15s while session + profile fetch settle, 9× `/api/auth/session` polls during boot
- after: admin layout paints as soon as `/api/auth/session` returns; profile call still happens but no longer gates the UI

No behaviour change for users who **don't** have a stored profile (the old
code already returned `base` in that case). For users who **do** have one,
the company/phone/preferences fields now hydrate a few hundred ms after
first paint instead of being there on first paint.

## Verification

- `setUser(base)` runs immediately; `void enrichWithProfile(...).then(...)` patches the state in only when enrichment actually adds fields (`if (enriched !== base)`).
- `enrichWithProfile()` itself is unchanged — still swallows the 413 and returns the base on failure, so no new error surface.
- `finally { setIsLoading(false) }` still runs at the end of `checkAuth()`, so the gate flips false independently of the profile call.

## Followups (not in this PR)

- The 413 itself: requires moving idToken/refreshToken to a server-side session store (Redis/DynamoDB) keyed by an opaque session cookie. Larger refactor; tracked separately.
- The 9× `/api/auth/session` polls during admin boot: every `fetchWithAuth()` call hits `getSession()`. NextAuth dedupes concurrent calls within ~1s but not across separate request waves. Worth caching at the AuthContext level.
