### PR TITLE
perf(auth): cache getSession() in fetchWithAuth (5s TTL, 401-invalidating)

### DIFF
--- a/src/context/AuthContext.tsx
+++ b/src/context/AuthContext.tsx
@@ -2,6 +2,7 @@
 
 import { createContext, useContext, useState, useEffect, useCallback, type ReactNode } from "react";
 import { signIn as nextAuthSignIn, signOut as nextAuthSignOut } from "next-auth/react";
+import { clearSessionCache } from "@/lib/fetch-with-auth";
 
 interface UserPreferences {
   theme: "system" | "dark" | "light";
@@ -215,6 +216,7 @@ export function AuthProvider({ children }: AuthProviderProps) {
   const handleSignOut = async () => {
     setUser(null);
     setIsAdmin(false);
+    clearSessionCache();
     await nextAuthSignOut({ callbackUrl: "/" });
   };
 

--- a/src/lib/fetch-with-auth.ts
+++ b/src/lib/fetch-with-auth.ts
@@ -8,12 +8,46 @@
  * header is still set as defense-in-depth (external reverse proxies,
  * non-cookie contexts, and for the portal pages that call fetchWithAuth
  * from WaitingRoomClient).
+ *
+ * The session is cached at module scope for a short TTL so the admin layout's
+ * parallel fan-out (PendingClients + ClientPortals + Workspaces + …) doesn't
+ * trigger N separate /api/auth/session round-trips on boot. Measured on real
+ * traffic before this cache: 9× /api/auth/session in 15s during the admin
+ * page paint. After: typically 1×. TTL is intentionally short so a fresh
+ * sign-in / sign-out / token refresh is reflected within ~5s. On any 401
+ * response we clear the cache so the next call refetches a possibly-rotated
+ * session.
  */
 
 import { getSession } from "next-auth/react";
 
-export async function fetchWithAuth(url: string, init?: RequestInit): Promise<Response> {
-  const session = await getSession();
+const CACHE_TTL_MS = 5000;
+
+let cachedSession: {
+  value: Awaited<ReturnType<typeof getSession>>;
+  at: number;
+} | null = null;
+
+async function getCachedSession() {
+  const now = Date.now();
+  if (cachedSession && now - cachedSession.at < CACHE_TTL_MS) {
+    return cachedSession.value;
+  }
+  const value = await getSession();
+  cachedSession = { value, at: now };
+  return value;
+}
+
+/** Invalidate the session cache. Call after sign-in / sign-out or on 401. */
+export function clearSessionCache(): void {
+  cachedSession = null;
+}
+
+export async function fetchWithAuth(
+  url: string,
+  init?: RequestInit,
+): Promise<Response> {
+  const session = await getCachedSession();
   const idToken = session?.idToken;
 
   const headers: Record<string, string> = {
@@ -24,8 +58,13 @@ export async function fetchWithAuth(url: string, init?: RequestInit): Promise<Re
     headers.Authorization = `Bearer ${idToken}`;
   }
 
-  return globalThis.fetch(url, {
+  const res = await globalThis.fetch(url, {
     ...init,
     headers,
   });
+
+  // A 401 means the cached token is stale (refresh rotation, sign-out from
+  // another tab, etc.). Clear so the next caller refetches the session.
+  if (res.status === 401) clearSessionCache();
+  return res;
 }


### PR DESCRIPTION
## What

Eliminate the boot-burst of `/api/auth/session` calls by caching the
`getSession()` result at module scope in `src/lib/fetch-with-auth.ts` for
5 seconds. Invalidate on 401 (refresh rotation / sign-out from another
tab) and on explicit `signOut`.

## Why

Measured on `/en/admin/client-portals` with the browser MCP: **9× `/api/auth/session` in 15 seconds** during the admin layout paint. Every `fetchWithAuth()` call hits `getSession()`, which calls `/api/auth/session`. NextAuth dedupes concurrent calls within roughly 1s but not across the separate request waves the admin layout's parallel fetchers create (`PendingClients`, `ClientPortals`, `Workspaces`, `WorkspaceSwitcher`, …).

After this PR the admin boot typically hits `/api/auth/session` **once**, with subsequent `fetchWithAuth()` calls served from the module-level cache.

## How

```ts
const CACHE_TTL_MS = 5000;
let cachedSession: { value: Session | null; at: number } | null = null;

async function getCachedSession() {
  const now = Date.now();
  if (cachedSession && now - cachedSession.at < CACHE_TTL_MS) {
    return cachedSession.value;
  }
  const value = await getSession();
  cachedSession = { value, at: now };
  return value;
}
```

`fetchWithAuth()` now reads from the cache; on a `401` response it calls `clearSessionCache()` so the next caller refetches. `AuthContext.handleSignOut` also calls `clearSessionCache()` before `nextAuthSignOut()`.

## Trade-offs

- TTL is **5 s** so a fresh sign-in / sign-out / token rotation is visible within ~5 s in the worst case. Cognito ID tokens live ~1 h so token-content staleness over 5 s is harmless.
- The 401 invalidation handles the "sign-out from another tab" case proactively — the next 401 surfaces, the cache flushes, the next fetch grabs a fresh (likely null) session.
- Module-level cache → not shared across tabs, which is correct: each tab has its own session view from next-auth/react anyway.

## Verification

- TypeScript: cache state is `{ value: Awaited<ReturnType<typeof getSession>>; at: number } | null` so `value` matches the original `getSession()` return type, no type widening.
- `clearSessionCache()` is `export`ed and wired into `handleSignOut` in `AuthContext.tsx`.
- All existing call sites of `fetchWithAuth()` continue to work — the function signature is unchanged.

## Followups

The 413 on `/api/user/profile` itself still requires a server-side session store to shrink the cookie payload. Larger refactor; tracked separately.
