### PR TITLE
feat(admin): surface Postiz in sidebar + dashboard

### DIFF
--- a/src/app/[locale]/admin/AdminLayoutClient.tsx
+++ b/src/app/[locale]/admin/AdminLayoutClient.tsx
@@ -105,6 +105,7 @@ const adminGroups: AdminGroup[] = [
       { href: "/admin/email/campaigns", label: "Email Campaigns", Icon: Mail },
       { href: "/admin/pipeline", label: "Pipeline", Icon: GitMerge },
       { href: "/admin/calendar", label: "Calendar", Icon: CalendarDays },
+      { href: "/admin/postiz", label: "Postiz", Icon: Megaphone },
       { href: "/admin/reports", label: "Reports", Icon: ClipboardList },
       { href: "/admin/ai-assistant", label: "AI Assistant", Icon: Bot },
       { href: "/admin/ai-generator", label: "AI Generator", Icon: Bot },

--- a/src/app/[locale]/admin/page.tsx
+++ b/src/app/[locale]/admin/page.tsx
@@ -109,6 +109,12 @@ const NAV_GROUPS: NavGroup[] = [
       ),
       card("Content Calendar", "Plan and publish social posts via Postiz", "🗓", "/admin/calendar"),
       card(
+        "Postiz",
+        "Compose, schedule and review posts on connected social channels",
+        "📨",
+        "/admin/postiz"
+      ),
+      card(
         "Email Campaigns",
         "ActiveCampaign sends and automations",
         "📧",


### PR DESCRIPTION
## What

Wire `/admin/postiz` (shipped in #926) into the two places admins actually look:

1. **Sidebar** (`AdminLayoutClient.tsx`, Marketing Hub group, after Calendar): `Postiz` link with the `Megaphone` icon (icon already imported, matches `Campaigns`).
2. **Dashboard quick-action card** (`page.tsx`, Growth — leads to revenue group, after Content Calendar): `Postiz · Compose, schedule and review posts on connected social channels · 📨 · /admin/postiz`.

## Why

The page exists and is fully functional (Compose / Schedule / Channels tabs) but neither the sidebar nor the dashboard linked to it. The "Content Calendar" card mentioned Postiz in its description but pointed at `/admin/calendar`, so anyone landing on the dashboard would not discover the direct console.

## Verification

- Sidebar: Postiz now appears between Calendar and Reports in Marketing Hub.
- Dashboard: Postiz card now sits between Content Calendar and Email Campaigns in the Growth group.
- No JS changes — pure config-array additions, so type-check and lint stay clean.
