### PR TITLE
chore(deps): pin ws/js-yaml/markdown-it via pnpm.overrides

### DIFF
--- a/package.json
+++ b/package.json
@@ -90,56 +90,56 @@
     "test:unit:coverage:ci": "mkdir -p coverage/vitest/.tmp && vitest run --coverage --pool=forks --maxWorkers=1 --reporter=default"
   },
   "dependencies": {
-    "@aws-sdk/client-bedrock-runtime": "^3.1068.0",
-    "@aws-sdk/client-cognito-identity-provider": "^3.1068.0",
-    "@aws-sdk/client-dynamodb": "^3.1068.0",
-    "@aws-sdk/client-ses": "^3.1068.0",
-    "@aws-sdk/client-sesv2": "^3.1068.0",
-    "@aws-sdk/client-ssm": "^3.1068.0",
-    "@sentry/nextjs": "^10.58.0",
+    "@aws-sdk/client-bedrock-runtime": "^3.1064.0",
+    "@aws-sdk/client-cognito-identity-provider": "^3.1064.0",
+    "@aws-sdk/client-dynamodb": "^3.1064.0",
+    "@aws-sdk/client-ses": "^3.1064.0",
+    "@aws-sdk/client-sesv2": "^3.1064.0",
+    "@aws-sdk/client-ssm": "^3.1064.0",
+    "@sentry/nextjs": "^10.56.0",
     "cmdk": "^1.1.1",
     "countup.js": "^2.10.0",
     "es-abstract": "^1.24.2",
     "jose": "^6.2.3",
     "lenis": "^1.3.23",
-    "lucide-react": "^1.18.0",
-    "next": "16.2.9",
+    "lucide-react": "^1.17.0",
+    "next": "16.2.7",
     "next-auth": "5.0.0-beta.31",
     "next-intl": "^4.13.0",
     "pdf-lib": "^1.17.1",
     "react": "19.2.7",
     "react-dom": "19.2.7",
-    "stripe": "^22.2.1"
+    "stripe": "^22.2.0"
   },
   "devDependencies": {
-    "@aws-sdk/client-iam": "3.1068.0",
+    "@aws-sdk/client-iam": "3.1064.0",
     "@axe-core/playwright": "^4.11.3",
     "@parcel/watcher": "^2.5.6",
-    "@playwright/test": "^1.61.0",
-    "@tailwindcss/postcss": "^4.3.1",
+    "@playwright/test": "^1.60.0",
+    "@tailwindcss/postcss": "^4.3.0",
     "@testing-library/dom": "^10.4.1",
     "@testing-library/react": "^16.3.2",
-    "@types/node": "^25.9.3",
+    "@types/node": "^25.9.2",
     "@types/react": "^19.2.17",
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^6.0.2",
-    "@vitest/coverage-v8": "^4.1.9",
+    "@vitest/coverage-v8": "^4.1.8",
     "eslint": "^9.39.4",
-    "eslint-config-next": "16.2.9",
+    "eslint-config-next": "16.2.7",
     "jiti": "^2.7.0",
     "jsdom": "^29.1.1",
     "markdownlint-cli2": "^0.22.1",
     "monocart-coverage-reports": "^2.12.12",
     "monocart-reporter": "^2.11.2",
-    "prettier": "^3.8.4",
+    "prettier": "^3.8.1",
     "prettier-plugin-tailwindcss": "^0.8.0",
     "sst": "^4.15.2",
-    "tailwindcss": "^4.3.1",
+    "tailwindcss": "^4.3.0",
     "tsx": "^4.22.4",
     "typescript": "^6.0.3",
     "vite": "^8.0.16",
     "vite-tsconfig-paths": "^6.1.1",
-    "vitest": "^4.1.9"
+    "vitest": "^4.1.8"
   },
   "pnpm": {
     "overrides": {
@@ -147,13 +147,9 @@
       "brace-expansion@>=5.0.0 <5.0.6": ">=5.0.6",
       "js-cookie@<3.0.7": ">=3.0.7",
       "postcss@<8.5.10": ">=8.5.10",
-      "esbuild": ">=0.28.1"
+      "esbuild": ">=0.28.1",
+      "ws@<8.21.0": ">=8.21.0",
+      "js-yaml@<4.2.0": ">=4.2.0",
+      "markdown-it@<14.2.0": ">=14.2.0"
     },
-    "onlyBuiltDependencies": [
-      "@parcel/watcher",
-      "@sentry/cli",
-      "@swc/core",
-      "esbuild"
-    ]
-  }
-}
+    "onlyBuiltDe

--- a/package.json
+++ b/package.json
@@ -90,56 +90,56 @@
     "test:unit:coverage:ci": "mkdir -p coverage/vitest/.tmp && vitest run --coverage --pool=forks --maxWorkers=1 --reporter=default"
   },
   "dependencies": {
-    "@aws-sdk/client-bedrock-runtime": "^3.1064.0",
-    "@aws-sdk/client-cognito-identity-provider": "^3.1064.0",
-    "@aws-sdk/client-dynamodb": "^3.1064.0",
-    "@aws-sdk/client-ses": "^3.1064.0",
-    "@aws-sdk/client-sesv2": "^3.1064.0",
-    "@aws-sdk/client-ssm": "^3.1064.0",
-    "@sentry/nextjs": "^10.56.0",
+    "@aws-sdk/client-bedrock-runtime": "^3.1068.0",
+    "@aws-sdk/client-cognito-identity-provider": "^3.1068.0",
+    "@aws-sdk/client-dynamodb": "^3.1068.0",
+    "@aws-sdk/client-ses": "^3.1068.0",
+    "@aws-sdk/client-sesv2": "^3.1068.0",
+    "@aws-sdk/client-ssm": "^3.1068.0",
+    "@sentry/nextjs": "^10.58.0",
     "cmdk": "^1.1.1",
     "countup.js": "^2.10.0",
     "es-abstract": "^1.24.2",
     "jose": "^6.2.3",
     "lenis": "^1.3.23",
-    "lucide-react": "^1.17.0",
-    "next": "16.2.7",
+    "lucide-react": "^1.18.0",
+    "next": "16.2.9",
     "next-auth": "5.0.0-beta.31",
     "next-intl": "^4.13.0",
     "pdf-lib": "^1.17.1",
     "react": "19.2.7",
     "react-dom": "19.2.7",
-    "stripe": "^22.2.0"
+    "stripe": "^22.2.1"
   },
   "devDependencies": {
-    "@aws-sdk/client-iam": "3.1064.0",
+    "@aws-sdk/client-iam": "3.1068.0",
     "@axe-core/playwright": "^4.11.3",
     "@parcel/watcher": "^2.5.6",
-    "@playwright/test": "^1.60.0",
-    "@tailwindcss/postcss": "^4.3.0",
+    "@playwright/test": "^1.61.0",
+    "@tailwindcss/postcss": "^4.3.1",
     "@testing-library/dom": "^10.4.1",
     "@testing-library/react": "^16.3.2",
-    "@types/node": "^25.9.2",
+    "@types/node": "^25.9.3",
     "@types/react": "^19.2.17",
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^6.0.2",
-    "@vitest/coverage-v8": "^4.1.8",
+    "@vitest/coverage-v8": "^4.1.9",
     "eslint": "^9.39.4",
-    "eslint-config-next": "16.2.7",
+    "eslint-config-next": "16.2.9",
     "jiti": "^2.7.0",
     "jsdom": "^29.1.1",
     "markdownlint-cli2": "^0.22.1",
     "monocart-coverage-reports": "^2.12.12",
     "monocart-reporter": "^2.11.2",
-    "prettier": "^3.8.1",
+    "prettier": "^3.8.4",
     "prettier-plugin-tailwindcss": "^0.8.0",
     "sst": "^4.15.2",
-    "tailwindcss": "^4.3.0",
+    "tailwindcss": "^4.3.1",
     "tsx": "^4.22.4",
     "typescript": "^6.0.3",
     "vite": "^8.0.16",
     "vite-tsconfig-paths": "^6.1.1",
-    "vitest": "^4.1.8"
+    "vitest": "^4.1.9"
   },
   "pnpm": {
     "overrides": {
@@ -152,4 +152,11 @@
       "js-yaml@<4.2.0": ">=4.2.0",
       "markdown-it@<14.2.0": ">=14.2.0"
     },
-    "onlyBuiltDe
+    "onlyBuiltDependencies": [
+      "@parcel/watcher",
+      "@sentry/cli",
+      "@swc/core",
+      "esbuild"
+    ]
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,6 +10,9 @@ overrides:
   js-cookie@<3.0.7: '>=3.0.7'
   postcss@<8.5.10: '>=8.5.10'
   esbuild: '>=0.28.1'
+  ws@<8.21.0: '>=8.21.0'
+  js-yaml@<4.2.0: '>=4.2.0'
+  markdown-it@<14.2.0: '>=14.2.0'
 
 importers:
 
@@ -3449,10 +3452,6 @@ packages:
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
-  js-yaml@4.1.1:
-    resolution: {integrity: sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==}
-    hasBin: true
-
   js-yaml@4.2.0:
     resolution: {integrity: sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==}
     hasBin: true
@@ -3682,8 +3681,8 @@ packages:
     resolution: {integrity: sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==}
     engines: {node: '>=10'}
 
-  markdown-it@14.1.1:
-    resolution: {integrity: sha512-BuU2qnTti9YKgK5N+IeMubp14ZUKUUw7yeJbkjtosvHiP0AZ5c8IAgEMk79D0eC8F23r4Ac/q8cAIFdm2FtyoA==}
+  markdown-it@14.2.0:
+    resolution: {integrity: sha512-1TGiQiJVRQ3NPmZH6sx5Cfnmg6GQm9jvC1ch4TK511NjSJvjzKLzn5pPfZRNZkRPZP0HqCioSndqH8v2nRaWVQ==}
     hasBin: true
 
   markdownlint-cli2-formatter-default@0.0.6:
@@ -4962,8 +4961,8 @@ packages:
       '@cloudflare/workers-types':
         optional: true
 
-  ws@8.20.1:
-    resolution: {integrity: sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==}
+  ws@8.21.0:
+    resolution: {integrity: sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==}
     engines: {node: '>=10.0.0'}
     peerDependencies:
       bufferutil: ^4.0.1
@@ -8320,10 +8319,6 @@ snapshots:
 
   js-tokens@4.0.0: {}
 
-  js-yaml@4.1.1:
-    dependencies:
-      argparse: 2.0.1
-
   js-yaml@4.2.0:
     dependencies:
       argparse: 2.0.1
@@ -8534,7 +8529,7 @@ snapshots:
     dependencies:
       semver: 7.8.4
 
-  markdown-it@14.1.1:
+  markdown-it@14.2.0:
     dependencies:
       argparse: 2.0.1
       entities: 4.5.0
@@ -8550,10 +8545,10 @@ snapshots:
   markdownlint-cli2@0.22.1:
     dependencies:
       globby: 16.2.0
-      js-yaml: 4.1.1
+      js-yaml: 4.2.0
       jsonc-parser: 3.3.1
       jsonpointer: 5.0.1
-      markdown-it: 14.1.1
+      markdown-it: 14.2.0
       markdownlint: 0.40.0
       markdownlint-cli2-formatter-default: 0.0.6(markdownlint-cli2@0.22.1)
       micromatch: 4.0.8
@@ -8782,7 +8777,7 @@ snapshots:
       sharp: 0.34.5
       undici: 7.24.8
       workerd: 1.20260611.1
-      ws: 8.20.1
+      ws: 8.21.0
       youch: 4.1.0-beta.10
     transitivePeerDependencies:
       - bufferutil
@@ -9977,7 +9972,7 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
-  ws@8.20.1: {}
+  ws@8.21.0: {}
 
   xml-name-validator@5.0.0: {}
 


### PR DESCRIPTION
Clears 3 Dependabot alerts (1 high + 2 medium). All transitive DoS bugs — see commit message.