### PR TITLE
fix(postiz): defensive integrations unwrap, sticky-false configured, custom upload timeout

### DIFF
--- a/__tests__/postiz.test.ts
+++ b/__tests__/postiz.test.ts
@@ -9,10 +9,18 @@ vi.mock("@/lib/ssm-config", () => ({ getConfig: mockGetConfig }));
 vi.stubGlobal("fetch", mockFetch);
 
 import {
+  createPost,
+  deletePost,
+  findSlot,
   isPostizConfigured,
+  listIntegrations,
   listPostizIntegrations,
+  listPosts,
   matchIntegrationsForPlatform,
+  PostizApiError,
+  PostizNotConfiguredError,
   schedulePost,
+  uploadFromUrl,
   type PostizIntegration,
 } from "@/lib/postiz";
 
@@ -141,5 +149,143 @@ describe("schedulePost", () => {
     mockFetch.mockRejectedValue(new Error("down"));
     const result = await schedulePost({ content: "hi", integrationIds: ["fb"] });
     expect(result.ok).toBe(false);
+  });
+});
+
+// ------------------------------------------------------------------
+// Admin-console surface (throwing variants used by /api/admin/postiz/*)
+// ------------------------------------------------------------------
+
+describe("listIntegrations (throwing)", () => {
+  it("unwraps both bare-array and {integrations} shapes", async () => {
+    const channels: PostizIntegration[] = [{ id: "1", name: "FB", identifier: "facebook" }];
+
+    mockFetch.mockResolvedValueOnce(jsonResponse(channels));
+    await expect(listIntegrations()).resolves.toEqual(channels);
+
+    mockFetch.mockResolvedValueOnce(jsonResponse({ integrations: channels }));
+    await expect(listIntegrations()).resolves.toEqual(channels);
+  });
+
+  it("throws PostizNotConfiguredError when SSM is empty", async () => {
+    mockGetConfig.mockResolvedValue({ POSTIZ_API_URL: "", POSTIZ_API_KEY: "" });
+    await expect(listIntegrations()).rejects.toBeInstanceOf(PostizNotConfiguredError);
+  });
+
+  it("throws PostizApiError on a non-OK response", async () => {
+    mockFetch.mockResolvedValueOnce(jsonResponse({ error: "unauthorized" }, 401));
+    await expect(listIntegrations()).rejects.toBeInstanceOf(PostizApiError);
+  });
+});
+
+describe("listPosts (throwing)", () => {
+  it("unwraps {posts} envelope returned by Postiz", async () => {
+    const items = [
+      {
+        id: "p1",
+        content: "hi",
+        publishDate: "2026-06-16T10:00:00.000Z",
+        state: "QUEUE",
+        integration: { id: "fb", name: "FB", identifier: "facebook" },
+      },
+    ];
+    mockFetch.mockResolvedValueOnce(jsonResponse({ posts: items }));
+    await expect(listPosts("2026-06-01", "2026-06-30")).resolves.toEqual(items);
+  });
+
+  it("passes startDate and endDate as query params", async () => {
+    mockFetch.mockResolvedValueOnce(jsonResponse({ posts: [] }));
+    await listPosts("2026-06-01", "2026-06-30");
+    const [url] = mockFetch.mock.calls[0];
+    expect(url).toContain("startDate=2026-06-01");
+    expect(url).toContain("endDate=2026-06-30");
+  });
+
+  it("returns [] when Postiz returns an empty envelope", async () => {
+    mockFetch.mockResolvedValueOnce(jsonResponse({}));
+    await expect(listPosts("a", "b")).resolves.toEqual([]);
+  });
+});
+
+describe("createPost (throwing)", () => {
+  it("POSTs the body and returns the upstream array", async () => {
+    const upstream = [{ postId: "p1", integration: "fb" }];
+    mockFetch.mockResolvedValueOnce(jsonResponse(upstream));
+    const result = await createPost({
+      type: "now",
+      date: "2026-06-16T10:00:00.000Z",
+      shortLink: false,
+      tags: [],
+      posts: [
+        {
+          integration: { id: "fb" },
+          value: [{ content: "hi", image: [] }],
+          settings: { __type: "facebook" },
+        },
+      ],
+    });
+    expect(result).toEqual(upstream);
+    const [, init] = mockFetch.mock.calls[0];
+    expect(init.method).toBe("POST");
+  });
+});
+
+describe("deletePost (throwing)", () => {
+  it("issues DELETE on the post id with URL encoding", async () => {
+    mockFetch.mockResolvedValueOnce(new Response(null, { status: 204 }));
+    await deletePost("abc/123");
+    const [url, init] = mockFetch.mock.calls[0];
+    expect(url).toContain("/posts/abc%2F123");
+    expect(init.method).toBe("DELETE");
+  });
+
+  it("swallows 404 (idempotent)", async () => {
+    mockFetch.mockResolvedValueOnce(jsonResponse({ error: "not found" }, 404));
+    await expect(deletePost("p1")).resolves.toBeUndefined();
+  });
+
+  it("rethrows non-404 PostizApiError", async () => {
+    mockFetch.mockResolvedValueOnce(jsonResponse({ error: "boom" }, 500));
+    await expect(deletePost("p1")).rejects.toBeInstanceOf(PostizApiError);
+  });
+});
+
+describe("uploadFromUrl (throwing)", () => {
+  it("POSTs the source URL and returns the UploadedFile", async () => {
+    const uploaded = { id: "u1", name: "", path: "https://cdn/u1.png", thumbnail: null, alt: null };
+    mockFetch.mockResolvedValueOnce(jsonResponse(uploaded));
+    await expect(uploadFromUrl("https://x.example/i.png")).resolves.toEqual(uploaded);
+    const [, init] = mockFetch.mock.calls[0];
+    expect(init.method).toBe("POST");
+    expect(init.body).toBe(JSON.stringify({ url: "https://x.example/i.png" }));
+    // 30s timeout — see uploadFromUrl docstring; a 10s default trips on
+    // 5 MB+ source images.
+    expect(init.signal).toBeInstanceOf(AbortSignal);
+  });
+});
+
+describe("findSlot (throwing)", () => {
+  it("calls /find-slot/:id with the integration id URL-encoded", async () => {
+    mockFetch.mockResolvedValueOnce(jsonResponse({ date: "2026-06-17T09:00:00.000Z" }));
+    await findSlot("fb/page-1");
+    const [url] = mockFetch.mock.calls[0];
+    expect(url).toContain("/find-slot/fb%2Fpage-1");
+  });
+});
+
+describe("error class shapes", () => {
+  it("PostizApiError exposes status and a truncated body", () => {
+    const err = new PostizApiError(429, "rate limited and a long message ".repeat(20));
+    expect(err.status).toBe(429);
+    expect(err.body).toContain("rate limited");
+    // Truncated to 200 chars in the message; the body field keeps the original.
+    expect(err.message.length).toBeLessThan(250);
+    expect(err.name).toBe("PostizApiError");
+  });
+
+  it("PostizNotConfiguredError keeps its name for instanceof routing", () => {
+    const err = new PostizNotConfiguredError();
+    expect(err.name).toBe("PostizNotConfiguredError");
+    expect(err.message).toContain("not configured");
   });
 });

--- a/e2e/api-routes-gaps-sweep.spec.ts
+++ b/e2e/api-routes-gaps-sweep.spec.ts
@@ -34,6 +34,9 @@
  *     /api/admin/notion/testimonials
  *     /api/admin/ops/errors/[id]             (sample id)
  *     /api/admin/postiz
+ *     /api/admin/postiz/integrations
+ *     /api/admin/postiz/posts
+ *     /api/admin/postiz/slot                 (id=sample)
  *     /api/admin/reports/[id]                (sample id)
  *     /api/admin/reports/[id]/pdf            (sample id)
  *
@@ -88,6 +91,9 @@ test.describe("Admin API gap sweep (authenticated GETs)", () => {
     "/api/admin/notion/testimonials",
     `/api/admin/ops/errors/${SENTINEL_ID}`,
     "/api/admin/postiz",
+    "/api/admin/postiz/integrations",
+    "/api/admin/postiz/posts",
+    `/api/admin/postiz/slot?id=${SENTINEL_ID}`,
     `/api/admin/reports/${SENTINEL_ID}`,
     `/api/admin/reports/${SENTINEL_ID}/pdf`,
   ] as const;
@@ -109,6 +115,8 @@ test.describe("Admin API gap sweep (authenticated POSTs)", () => {
     `/api/admin/calendar/${SENTINEL_ID}/publish`,
     `/api/admin/pipeline/deals/${SENTINEL_ID}/move`,
     `/api/admin/pipeline/deals/${SENTINEL_ID}/notes`,
+    "/api/admin/postiz/posts",
+    "/api/admin/postiz/upload",
   ] as const;
 
   for (const url of ADMIN_POST_GAPS) {
@@ -121,6 +129,19 @@ test.describe("Admin API gap sweep (authenticated POSTs)", () => {
       expect(r.status()).toBeGreaterThanOrEqual(200);
     });
   }
+});
+
+test.describe("Admin API gap sweep (authenticated DELETEs)", () => {
+  // /api/admin/postiz/posts/[id] DELETE — the gap sweep didn't cover any
+  // DELETE-only admin routes before. Confirm the auth gate holds; the
+  // handler may 4xx (Postiz says "not found") or 5xx (no upstream creds in
+  // dev). We just care the route is wired and admin auth flowed through.
+  test(`DELETE /api/admin/postiz/posts/${SENTINEL_ID}`, async ({ request }) => {
+    const a = await adminRequest(request);
+    const r = await a.delete(`/api/admin/postiz/posts/${SENTINEL_ID}`);
+    expect([401, 403]).not.toContain(r.status());
+    expect(r.status()).toBeGreaterThanOrEqual(200);
+  });
 });
 
 test.describe("Admin OAuth entry point", () => {

--- a/src/app/[locale]/admin/postiz/page.tsx
+++ b/src/app/[locale]/admin/postiz/page.tsx
@@ -25,20 +25,29 @@ export default function PostizAdminPage() {
   const [configured, setConfigured] = useState<boolean | null>(null);
   const [error, setError] = useState<string | null>(null);
 
+  // Concurrent reloads race against `configured` — once a 503 is observed,
+  // Postiz is definitively unconfigured and the success path of the other
+  // request must NOT flip the flag back to `true`. Use the functional setter
+  // so `false` is sticky; `null` (initial) → `true` is the only upgrade.
+  const markConfigured = useCallback(() => {
+    setConfigured((cur) => (cur === false ? false : true));
+  }, []);
+
   const reloadIntegrations = useCallback(async () => {
     const res = await fetch("/api/admin/postiz/integrations");
     if (res.status === 503) {
       setConfigured(false);
       return;
     }
-    setConfigured(true);
+    markConfigured();
     if (!res.ok) {
       setError(`integrations: ${res.status}`);
       return;
     }
     const data = (await res.json()) as { integrations: PostizIntegration[] };
     setIntegrations(data.integrations ?? []);
-  }, []);
+    setError(null);
+  }, [markConfigured]);
 
   const reloadPosts = useCallback(async () => {
     const res = await fetch("/api/admin/postiz/posts");
@@ -46,14 +55,15 @@ export default function PostizAdminPage() {
       setConfigured(false);
       return;
     }
-    setConfigured(true);
+    markConfigured();
     if (!res.ok) {
       setError(`posts: ${res.status}`);
       return;
     }
     const data = (await res.json()) as { posts: PostizPost[] };
     setPosts(data.posts ?? []);
-  }, []);
+    setError(null);
+  }, [markConfigured]);
 
   useEffect(() => {
     // reloadIntegrations / reloadPosts are async; the setState calls inside
@@ -62,7 +72,6 @@ export default function PostizAdminPage() {
     // difference. Matches the existing pattern in AuthContext.tsx:199.
     // eslint-disable-next-line react-hooks/set-state-in-effect
     void reloadIntegrations();
-    // eslint-disable-next-line react-hooks/set-state-in-effect
     void reloadPosts();
   }, [reloadIntegrations, reloadPosts]);
 
@@ -382,7 +391,9 @@ function ScheduleTab({ posts, onReload }: { posts: PostizPost[] | null; onReload
   if (posts.length === 0) return <p className="text-gray-600">No posts in the current window.</p>;
 
   const onDelete = async (id: string) => {
-    if (!confirm("Delete this post?")) return;
+    // `globalThis.confirm` satisfies SonarCloud `prefer-global-this` (S7059);
+    // direct `confirm` would also lint as `no-alert`.
+    if (!globalThis.confirm("Delete this post?")) return;
     const res = await fetch(`/api/admin/postiz/posts/${id}`, {
       method: "DELETE",
     });

--- a/src/lib/postiz.ts
+++ b/src/lib/postiz.ts
@@ -37,16 +37,20 @@ async function getPostizConfig(): Promise<{ baseUrl: string; apiKey: string }> {
   };
 }
 
-async function postizFetch(path: string, options: RequestInit = {}): Promise<Response> {
+async function postizFetch(
+  path: string,
+  options: RequestInit & { timeoutMs?: number } = {}
+): Promise<Response> {
   const { baseUrl, apiKey } = await getPostizConfig();
+  const { timeoutMs, ...init } = options;
   return fetch(`${baseUrl}/api/public/v1${path}`, {
-    ...options,
+    ...init,
     headers: {
       "Content-Type": "application/json",
       Authorization: apiKey,
-      ...options.headers,
+      ...init.headers,
     },
-    signal: AbortSignal.timeout(10_000),
+    signal: AbortSignal.timeout(timeoutMs ?? 10_000),
   });
 }
 
@@ -69,7 +73,10 @@ export class PostizApiError extends Error {
   }
 }
 
-async function callThrowing<T>(path: string, init: RequestInit = {}): Promise<T> {
+async function callThrowing<T>(
+  path: string,
+  init: RequestInit & { timeoutMs?: number } = {}
+): Promise<T> {
   const res = await postizFetch(path, init);
   if (!res.ok) throw new PostizApiError(res.status, await res.text().catch(() => ""));
   if (res.status === 204) return undefined as T;
@@ -232,9 +239,16 @@ export interface UploadedFile {
   alt: string | null;
 }
 
-/** Throwing variant of `listPostizIntegrations` for /admin/postiz routes. */
-export function listIntegrations(): Promise<PostizIntegration[]> {
-  return callThrowing<PostizIntegration[]>("/integrations");
+/** Throwing variant of `listPostizIntegrations` for /admin/postiz routes.
+ *
+ * Postiz can return either a bare array or `{ integrations: PostizIntegration[] }`
+ * depending on version — we defensively unwrap the same way `listPostizIntegrations`
+ * and `listPosts` do. Verified against live API 2026-06-16. */
+export async function listIntegrations(): Promise<PostizIntegration[]> {
+  const data = await callThrowing<PostizIntegration[] | { integrations?: PostizIntegration[] }>(
+    "/integrations"
+  );
+  return Array.isArray(data) ? data : (data.integrations ?? []);
 }
 
 /** List posts in a window (ISO 8601 dates).
@@ -267,11 +281,17 @@ export async function deletePost(id: string): Promise<void> {
   }
 }
 
-/** Upload media to Postiz by URL — returns an `{id,path}` usable in posts. */
+/** Upload media to Postiz by URL — returns an `{id,path}` usable in posts.
+ *
+ * Postiz fetches the remote URL server-side, which can take longer than the
+ * default 10s when the source is a large image or a slow CDN. Bump the
+ * timeout to 30s so a 5 MB media URL doesn't trip an AbortError on the
+ * upstream fetch. */
 export function uploadFromUrl(url: string): Promise<UploadedFile> {
   return callThrowing<UploadedFile>("/upload-from-url", {
     method: "POST",
     body: JSON.stringify({ url }),
+    timeoutMs: 30_000,
   });
 }
 


### PR DESCRIPTION
Audit-and-fix pass over the Postiz implementation surfaced by the user.

## What

- **lib**: `listIntegrations` now defensively unwraps both bare-array and `{integrations}` response shapes — the same pattern `listPostizIntegrations` (calendar-side) and `listPosts` use. Closes the parallel gap that PR #938 only fixed for `listPosts`.
- **lib**: `postizFetch` accepts an optional `timeoutMs`; `uploadFromUrl` uses 30s. Postiz fetches the remote URL server-side, so 10s trips on 5 MB+ images / slow CDNs.
- **admin page**: `configured` state is sticky-false — concurrent `reloadIntegrations` + `reloadPosts` can no longer race a 503 back to true and render the wrong screen. `error` state clears on successful reload. `confirm()` → `globalThis.confirm()` to satisfy SonarCloud `prefer-global-this`.
- **tests**: 14 new vitest cases covering the throwing variants (`listIntegrations`, `listPosts`, `createPost`, `deletePost`, `uploadFromUrl`, `findSlot`) and the two error classes. **28/28 pass**; `calendar-api` and `publish-and-send-newsletter` both still green; typecheck + lint clean.
- **e2e**: gap sweep now covers `/api/admin/postiz/integrations`, `/posts` (GET + POST), `/upload`, `/slot`, and DELETE `/posts/[id]` — the four sub-routes shipped in PR #935 were absent from both `admin-api-sweep` and the gap sweep.

## Verification

```
pnpm vitest run __tests__/postiz.test.ts __tests__/calendar-api.test.ts __tests__/publish-and-send-newsletter.test.ts
 Test Files  3 passed (3)
      Tests  61 passed (61)
pnpm typecheck   # clean
pnpm lint        # clean (postiz files + tests)
```
