### PR TITLE
feat(postiz): 12 implementations — edit/multi-image/multipart/AI/slot/calendar/provider-settings/webhook/2 crons/Slack/Prometheus

### DIFF
--- a/__tests__/postiz-slack.test.ts
+++ b/__tests__/postiz-slack.test.ts
@@ -1,0 +1,94 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { mockGetConfig, mockGetSlackConfig } = vi.hoisted(() => ({
+  mockGetConfig: vi.fn(),
+  mockGetSlackConfig: vi.fn(),
+}));
+
+vi.mock("@/lib/ssm-config", () => ({ getConfig: mockGetConfig }));
+
+// SlackClient resolves its token via getSlackConfigAsync; stub that so we can
+// drive "no token → silent no-op" vs "token → would post" branches.
+vi.mock("@/lib/integrations", async () => {
+  const actual = await vi.importActual<typeof import("@/lib/integrations")>("@/lib/integrations");
+  return { ...actual, getSlackConfigAsync: mockGetSlackConfig };
+});
+
+import { notifyPostErrored, notifyPostPublished, notifyOauthExpiry } from "@/lib/postiz-slack";
+import type { PostizPost, PostizIntegration } from "@/lib/postiz";
+
+const POST: PostizPost = {
+  id: "p1",
+  content: "Hello world",
+  publishDate: "2026-06-16T10:00:00.000Z",
+  state: "PUBLISHED",
+  integration: { id: "fb", name: "FB Page", identifier: "facebook" },
+  releaseURL: "https://facebook.com/post/1",
+  releaseId: "1",
+};
+
+const INTEGRATION: PostizIntegration = {
+  id: "li",
+  name: "LinkedIn Page",
+  identifier: "linkedin-page",
+  disabled: true,
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("postiz-slack notifiers (no Slack token)", () => {
+  beforeEach(() => {
+    mockGetConfig.mockResolvedValue({ POSTIZ_SLACK_CHANNEL: "" });
+    mockGetSlackConfig.mockResolvedValue({
+      SLACK_BOT_TOKEN: "",
+      SLACK_WEBHOOK_URL: "",
+      SLACK_DEFAULT_CHANNEL: "",
+    });
+  });
+
+  it("notifyPostPublished resolves silently when Slack isn't configured", async () => {
+    await expect(notifyPostPublished(POST)).resolves.toBeUndefined();
+  });
+
+  it("notifyPostErrored resolves silently when Slack isn't configured", async () => {
+    await expect(notifyPostErrored(POST, "rate limited")).resolves.toBeUndefined();
+  });
+
+  it("notifyOauthExpiry resolves silently when Slack isn't configured", async () => {
+    await expect(notifyOauthExpiry(INTEGRATION)).resolves.toBeUndefined();
+  });
+});
+
+describe("postiz-slack notifiers (with token)", () => {
+  beforeEach(() => {
+    mockGetConfig.mockResolvedValue({ POSTIZ_SLACK_CHANNEL: "#postiz" });
+    mockGetSlackConfig.mockResolvedValue({
+      SLACK_BOT_TOKEN: "xoxb-test",
+      SLACK_WEBHOOK_URL: "",
+      SLACK_DEFAULT_CHANNEL: "#general",
+    });
+  });
+
+  it("notifyPostPublished issues a chat.postMessage with the channel override", async () => {
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(JSON.stringify({ ok: true }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      })
+    );
+    await notifyPostPublished(POST);
+    const call = fetchSpy.mock.calls.find(([url]) =>
+      String(url).includes("chat.postMessage")
+    );
+    expect(call).toBeDefined();
+    if (!call) return;
+    const [, init] = call;
+    expect(init?.method).toBe("POST");
+    const body = JSON.parse(String(init?.body));
+    expect(body.channel).toBe("#postiz");
+    expect(body.username).toBe("Postiz");
+    fetchSpy.mockRestore();
+  });
+});

--- a/__tests__/postiz.test.ts
+++ b/__tests__/postiz.test.ts
@@ -12,6 +12,7 @@ import {
   createPost,
   deletePost,
   findSlot,
+  getPostStats,
   isPostizConfigured,
   listIntegrations,
   listPostizIntegrations,
@@ -20,7 +21,10 @@ import {
   PostizApiError,
   PostizNotConfiguredError,
   schedulePost,
+  updatePost,
+  uploadFile,
   uploadFromUrl,
+  verifyPostizWebhookSignature,
   type PostizIntegration,
 } from "@/lib/postiz";
 
@@ -270,6 +274,130 @@ describe("findSlot (throwing)", () => {
     await findSlot("fb/page-1");
     const [url] = mockFetch.mock.calls[0];
     expect(url).toContain("/find-slot/fb%2Fpage-1");
+  });
+});
+
+describe("updatePost (throwing)", () => {
+  it("PUTs the body to /posts/:id and returns the upstream array", async () => {
+    const upstream = [{ postId: "p1", integration: "fb" }];
+    mockFetch.mockResolvedValueOnce(jsonResponse(upstream));
+    const result = await updatePost("p1", {
+      type: "schedule",
+      date: "2026-06-20T10:00:00.000Z",
+      shortLink: false,
+      tags: [],
+      posts: [
+        {
+          integration: { id: "fb" },
+          value: [{ content: "edited", image: [] }],
+          settings: { __type: "facebook" },
+        },
+      ],
+    });
+    expect(result).toEqual(upstream);
+    const [url, init] = mockFetch.mock.calls[0];
+    expect(url).toContain("/posts/p1");
+    expect(init.method).toBe("PUT");
+  });
+
+  it("URL-encodes the id", async () => {
+    mockFetch.mockResolvedValueOnce(jsonResponse([]));
+    await updatePost("abc/123", {
+      type: "draft",
+      date: new Date().toISOString(),
+      shortLink: false,
+      tags: [],
+      posts: [
+        {
+          integration: { id: "fb" },
+          value: [{ content: "x", image: [] }],
+          settings: { __type: "facebook" },
+        },
+      ],
+    });
+    const [url] = mockFetch.mock.calls[0];
+    expect(url).toContain("/posts/abc%2F123");
+  });
+});
+
+describe("getPostStats (throwing)", () => {
+  it("GETs /posts/:id/statistics and returns the JSON shape verbatim", async () => {
+    const stats = { reach: 1234, impressions: 9876 };
+    mockFetch.mockResolvedValueOnce(jsonResponse(stats));
+    await expect(getPostStats("p1")).resolves.toEqual(stats);
+    const [url] = mockFetch.mock.calls[0];
+    expect(url).toContain("/posts/p1/statistics");
+  });
+});
+
+describe("uploadFile (multipart)", () => {
+  it("POSTs multipart/form-data with a `file` field and the API key header", async () => {
+    const uploaded = { id: "u1", name: "x.png", path: "https://cdn/u1.png", thumbnail: null, alt: null };
+    mockFetch.mockResolvedValueOnce(jsonResponse(uploaded));
+    const blob = new Blob([new Uint8Array([1, 2, 3, 4])], { type: "image/png" });
+    await expect(uploadFile(blob, "x.png")).resolves.toEqual(uploaded);
+    const [url, init] = mockFetch.mock.calls[0];
+    expect(url).toContain("/api/public/v1/upload");
+    expect(init.method).toBe("POST");
+    // No JSON Content-Type — fetch sets the multipart boundary automatically.
+    expect(init.headers["Content-Type"]).toBeUndefined();
+    expect(init.headers.Authorization).toBe("pk_test_123");
+    expect(init.body).toBeInstanceOf(FormData);
+  });
+
+  it("throws PostizApiError on an upstream non-OK", async () => {
+    mockFetch.mockResolvedValueOnce(jsonResponse({ error: "too big" }, 413));
+    const blob = new Blob(["x"], { type: "image/png" });
+    await expect(uploadFile(blob, "x.png")).rejects.toBeInstanceOf(PostizApiError);
+  });
+});
+
+describe("verifyPostizWebhookSignature", () => {
+  it("returns false when the signature header is missing", async () => {
+    mockGetConfig.mockResolvedValue({
+      POSTIZ_API_URL: "https://x",
+      POSTIZ_API_KEY: "k",
+      POSTIZ_WEBHOOK_SECRET: "secret",
+    });
+    await expect(verifyPostizWebhookSignature("body", null)).resolves.toBe(false);
+  });
+
+  it("returns false when no secret is configured", async () => {
+    mockGetConfig.mockResolvedValue({
+      POSTIZ_API_URL: "https://x",
+      POSTIZ_API_KEY: "k",
+      POSTIZ_WEBHOOK_SECRET: "",
+    });
+    await expect(verifyPostizWebhookSignature("body", "abc")).resolves.toBe(false);
+  });
+
+  it("returns true on a matching HMAC-SHA256 hex digest of the raw body", async () => {
+    const { createHmac } = await import("node:crypto");
+    const secret = "shhh";
+    const body = '{"event":"post.published","post":{"id":"p1"}}';
+    const sig = createHmac("sha256", secret).update(body).digest("hex");
+    mockGetConfig.mockResolvedValue({
+      POSTIZ_API_URL: "https://x",
+      POSTIZ_API_KEY: "k",
+      POSTIZ_WEBHOOK_SECRET: secret,
+    });
+    await expect(verifyPostizWebhookSignature(body, sig)).resolves.toBe(true);
+    // Also accepts the `sha256=` prefix variant.
+    await expect(verifyPostizWebhookSignature(body, `sha256=${sig}`)).resolves.toBe(true);
+    // And tolerates uppercase hex.
+    await expect(verifyPostizWebhookSignature(body, sig.toUpperCase())).resolves.toBe(true);
+  });
+
+  it("returns false on tampered body", async () => {
+    const { createHmac } = await import("node:crypto");
+    const secret = "shhh";
+    const sig = createHmac("sha256", secret).update("original").digest("hex");
+    mockGetConfig.mockResolvedValue({
+      POSTIZ_API_URL: "https://x",
+      POSTIZ_API_KEY: "k",
+      POSTIZ_WEBHOOK_SECRET: secret,
+    });
+    await expect(verifyPostizWebhookSignature("tampered", sig)).resolves.toBe(false);
   });
 });
 

--- a/e2e/api-routes-gaps-sweep.spec.ts
+++ b/e2e/api-routes-gaps-sweep.spec.ts
@@ -37,8 +37,17 @@
  *     /api/admin/postiz/integrations
  *     /api/admin/postiz/posts
  *     /api/admin/postiz/slot                 (id=sample)
+ *     /api/admin/postiz/health
+ *     /api/admin/postiz/health?format=prom
  *     /api/admin/reports/[id]                (sample id)
  *     /api/admin/reports/[id]/pdf            (sample id)
+ *
+ *   Cron (unauthenticated — must reject without 5xx):
+ *     /api/cron/postiz-sync
+ *     /api/cron/postiz-oauth-check
+ *
+ *   Webhook (unsigned — must reject 401, never 5xx):
+ *     /api/webhooks/postiz
  *
  *   Admin POST:
  *     /api/admin/calendar/[id]/publish       (sample id)
@@ -94,6 +103,8 @@ test.describe("Admin API gap sweep (authenticated GETs)", () => {
     "/api/admin/postiz/integrations",
     "/api/admin/postiz/posts",
     `/api/admin/postiz/slot?id=${SENTINEL_ID}`,
+    "/api/admin/postiz/health",
+    "/api/admin/postiz/health?format=prom",
     `/api/admin/reports/${SENTINEL_ID}`,
     `/api/admin/reports/${SENTINEL_ID}/pdf`,
   ] as const;
@@ -117,6 +128,7 @@ test.describe("Admin API gap sweep (authenticated POSTs)", () => {
     `/api/admin/pipeline/deals/${SENTINEL_ID}/notes`,
     "/api/admin/postiz/posts",
     "/api/admin/postiz/upload",
+    "/api/admin/postiz/upload-file",
   ] as const;
 
   for (const url of ADMIN_POST_GAPS) {
@@ -141,6 +153,38 @@ test.describe("Admin API gap sweep (authenticated DELETEs)", () => {
     const r = await a.delete(`/api/admin/postiz/posts/${SENTINEL_ID}`);
     expect([401, 403]).not.toContain(r.status());
     expect(r.status()).toBeGreaterThanOrEqual(200);
+  });
+});
+
+test.describe("Admin API gap sweep (authenticated PUTs)", () => {
+  // PUT /api/admin/postiz/posts/[id] — added 2026-06-16 for edit-post.
+  test(`PUT /api/admin/postiz/posts/${SENTINEL_ID} (empty body)`, async ({ request }) => {
+    const a = await adminRequest(request);
+    const r = await a.put(`/api/admin/postiz/posts/${SENTINEL_ID}`, { data: {} });
+    expect([401, 403]).not.toContain(r.status());
+    expect(r.status()).toBeGreaterThanOrEqual(200);
+  });
+});
+
+test.describe("Postiz cron endpoints (unauthenticated — reject without 5xx)", () => {
+  for (const url of ["/api/cron/postiz-sync", "/api/cron/postiz-oauth-check"] as const) {
+    test(`GET ${url} unauthenticated`, async ({ request }) => {
+      const r = await request.get(url);
+      // Cron auth uses Bearer CRON_SECRET → 401 expected without it.
+      expect(r.status()).toBeGreaterThanOrEqual(200);
+    });
+  }
+});
+
+test.describe("Postiz webhook receiver", () => {
+  test("POST /api/webhooks/postiz unsigned → 401 invalid_signature", async ({ request }) => {
+    const r = await request.post("/api/webhooks/postiz", {
+      data: { event: "post.published", post: { id: "x" } },
+    });
+    // The verifier returns false on missing signature header AND on missing
+    // POSTIZ_WEBHOOK_SECRET, so 401 covers both dev (no secret) and prod
+    // (signed-only) cases. A 5xx would mean the verifier itself threw.
+    expect(r.status()).toBe(401);
   });
 });
 

--- a/src/app/[locale]/admin/postiz/page.tsx
+++ b/src/app/[locale]/admin/postiz/page.tsx
@@ -14,16 +14,48 @@ import type { PostizIntegration, PostizPost, CreatePostBody } from "@/lib/postiz
  *   GET    /api/admin/postiz/integrations  → connected channels
  *   GET    /api/admin/postiz/posts         → scheduled + published window
  *   POST   /api/admin/postiz/posts         → create / schedule a post
+ *   PUT    /api/admin/postiz/posts/:id     → edit a scheduled / draft post
  *   DELETE /api/admin/postiz/posts/:id     → delete a post
  *   POST   /api/admin/postiz/upload        → upload media by URL
+ *   POST   /api/admin/postiz/upload-file   → multipart file upload
  *   GET    /api/admin/postiz/slot?id=...   → next free time slot
+ *   POST   /api/admin/ai/generate          → AI-draft a post
  */
+
+type Tab = "compose" | "schedule" | "calendar" | "channels";
+
+interface ImageRef {
+  id: string;
+  path: string;
+}
+
+/** A draft being edited in the Compose tab. `id` set ⇒ PUT; unset ⇒ POST. */
+interface ComposeDraft {
+  id: string | null;
+  content: string;
+  selectedIds: string[];
+  scheduleAt: string;
+  images: ImageRef[];
+  /** Per-channel settings overrides keyed by integration id. */
+  settingsOverrides: Record<string, Record<string, unknown>>;
+}
+
+const EMPTY_DRAFT: ComposeDraft = {
+  id: null,
+  content: "",
+  selectedIds: [],
+  scheduleAt: "",
+  images: [],
+  settingsOverrides: {},
+};
+
 export default function PostizAdminPage() {
-  const [tab, setTab] = useState<"channels" | "compose" | "schedule">("compose");
+  const [tab, setTab] = useState<Tab>("compose");
   const [integrations, setIntegrations] = useState<PostizIntegration[] | null>(null);
   const [posts, setPosts] = useState<PostizPost[] | null>(null);
   const [configured, setConfigured] = useState<boolean | null>(null);
   const [error, setError] = useState<string | null>(null);
+  const [draft, setDraft] = useState<ComposeDraft>(EMPTY_DRAFT);
 
   // Concurrent reloads race against `configured` — once a 503 is observed,
   // Postiz is definitively unconfigured and the success path of the other
@@ -75,6 +107,20 @@ export default function PostizAdminPage() {
     void reloadPosts();
   }, [reloadIntegrations, reloadPosts]);
 
+  /** Switch to Compose tab populated from an existing scheduled / draft post. */
+  const editPost = useCallback((post: PostizPost) => {
+    setDraft({
+      id: post.id,
+      content: post.content,
+      selectedIds: [post.integration.id],
+      // datetime-local needs `YYYY-MM-DDTHH:mm` (no seconds, no Z).
+      scheduleAt: post.publishDate.slice(0, 16),
+      images: [],
+      settingsOverrides: {},
+    });
+    setTab("compose");
+  }, []);
+
   if (configured === false) {
     return <NotConfigured />;
   }
@@ -100,7 +146,7 @@ export default function PostizAdminPage() {
       )}
 
       <nav className="flex gap-2 border-b">
-        {(["compose", "schedule", "channels"] as const).map((t) => (
+        {(["compose", "schedule", "calendar", "channels"] as const).map((t) => (
           <button
             type="button"
             key={t}
@@ -110,6 +156,7 @@ export default function PostizAdminPage() {
             }`}
           >
             {t}
+            {t === "compose" && draft.id ? " (edit)" : ""}
           </button>
         ))}
       </nav>
@@ -120,13 +167,20 @@ export default function PostizAdminPage() {
       {tab === "compose" && (
         <ComposeTab
           integrations={integrations ?? []}
+          draft={draft}
+          onDraftChange={setDraft}
+          onCancel={() => setDraft(EMPTY_DRAFT)}
           onPosted={() => {
             void reloadPosts();
+            setDraft(EMPTY_DRAFT);
             setTab("schedule");
           }}
         />
       )}
-      {tab === "schedule" && <ScheduleTab posts={posts} onReload={reloadPosts} />}
+      {tab === "schedule" && (
+        <ScheduleTab posts={posts} onReload={reloadPosts} onEdit={editPost} />
+      )}
+      {tab === "calendar" && <CalendarTab posts={posts} onReload={reloadPosts} />}
     </div>
   );
 }
@@ -210,75 +264,147 @@ function ChannelsTab({
 
 function ComposeTab({
   integrations,
+  draft,
+  onDraftChange,
+  onCancel,
   onPosted,
 }: {
   integrations: PostizIntegration[];
+  draft: ComposeDraft;
+  onDraftChange: (next: ComposeDraft) => void;
+  onCancel: () => void;
   onPosted: () => void;
 }) {
-  const [content, setContent] = useState("");
-  const [selectedIds, setSelectedIds] = useState<string[]>([]);
-  const [scheduleAt, setScheduleAt] = useState("");
-  const [imageUrl, setImageUrl] = useState("");
+  const [imageUrlInput, setImageUrlInput] = useState("");
   const [submitting, setSubmitting] = useState(false);
   const [feedback, setFeedback] = useState<string | null>(null);
+  const [aiBusy, setAiBusy] = useState(false);
 
   const selectedIntegrations = useMemo(
-    () => integrations.filter((i) => selectedIds.includes(i.id)),
-    [integrations, selectedIds]
+    () => integrations.filter((i) => draft.selectedIds.includes(i.id)),
+    [integrations, draft.selectedIds]
   );
 
+  const setDraft = (patch: Partial<ComposeDraft>) => onDraftChange({ ...draft, ...patch });
+
   const toggleId = (id: string) =>
-    setSelectedIds((cur) => (cur.includes(id) ? cur.filter((x) => x !== id) : [...cur, id]));
+    setDraft({
+      selectedIds: draft.selectedIds.includes(id)
+        ? draft.selectedIds.filter((x) => x !== id)
+        : [...draft.selectedIds, id],
+    });
+
+  const addImageByUrl = async () => {
+    const url = imageUrlInput.trim();
+    if (!url) return;
+    const up = await fetch("/api/admin/postiz/upload", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ url }),
+    });
+    if (!up.ok) {
+      setFeedback(`Upload failed: ${up.status}`);
+      return;
+    }
+    const uploaded = (await up.json()) as ImageRef;
+    setDraft({ images: [...draft.images, { id: uploaded.id, path: uploaded.path }] });
+    setImageUrlInput("");
+  };
+
+  const addImageByFile = async (file: File) => {
+    const form = new FormData();
+    form.append("file", file, file.name);
+    const up = await fetch("/api/admin/postiz/upload-file", { method: "POST", body: form });
+    if (!up.ok) {
+      setFeedback(`File upload failed: ${up.status}`);
+      return;
+    }
+    const uploaded = (await up.json()) as ImageRef;
+    setDraft({ images: [...draft.images, { id: uploaded.id, path: uploaded.path }] });
+  };
+
+  const removeImage = (id: string) =>
+    setDraft({ images: draft.images.filter((i) => i.id !== id) });
+
+  const findNextSlot = async () => {
+    if (draft.selectedIds.length === 0) {
+      setFeedback("Select a channel first to find its next free slot.");
+      return;
+    }
+    const channelId = draft.selectedIds[0];
+    const res = await fetch(`/api/admin/postiz/slot?id=${encodeURIComponent(channelId)}`);
+    if (!res.ok) {
+      setFeedback(`Slot lookup failed: ${res.status}`);
+      return;
+    }
+    const { date } = (await res.json()) as { date: string };
+    // datetime-local input wants local time, no seconds/zone.
+    setDraft({ scheduleAt: new Date(date).toISOString().slice(0, 16) });
+    setFeedback(`Next free slot: ${new Date(date).toLocaleString()}`);
+  };
+
+  const aiDraft = async () => {
+    setAiBusy(true);
+    setFeedback(null);
+    try {
+      const channels = selectedIntegrations.map((i) => i.identifier).join(", ") || "social media";
+      const seed = draft.content.trim() || `cloudless.gr post for ${channels}`;
+      const prompt =
+        `Write one concise social media post for ${channels}. ` +
+        `Tone: practical, direct. No hashtag spam (max 3). Topic: ${seed}.\n` +
+        `Output the post text only — no preamble, no quotes, no explanation.`;
+      const res = await fetch("/api/admin/ai/generate", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ prompt }),
+      });
+      if (!res.ok) {
+        setFeedback(`AI draft failed: ${res.status}`);
+        return;
+      }
+      const data = (await res.json()) as { result?: string };
+      if (data.result) setDraft({ content: data.result.trim() });
+    } finally {
+      setAiBusy(false);
+    }
+  };
 
   const onSubmit = async (mode: "now" | "schedule" | "draft") => {
     setSubmitting(true);
     setFeedback(null);
     try {
-      let image: Array<{ id: string; path: string }> = [];
-      if (imageUrl.trim()) {
-        const up = await fetch("/api/admin/postiz/upload", {
-          method: "POST",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ url: imageUrl.trim() }),
-        });
-        if (!up.ok) {
-          setFeedback(`Upload failed: ${up.status}`);
-          setSubmitting(false);
-          return;
-        }
-        const uploaded = (await up.json()) as { id: string; path: string };
-        image = [uploaded];
-      }
-
       const body: CreatePostBody = {
         type: mode,
         date:
-          mode === "schedule" && scheduleAt
-            ? new Date(scheduleAt).toISOString()
+          mode === "schedule" && draft.scheduleAt
+            ? new Date(draft.scheduleAt).toISOString()
             : new Date().toISOString(),
         shortLink: false,
         tags: [],
         posts: selectedIntegrations.map((i) => ({
           integration: { id: i.id },
-          value: [{ content, image }],
-          settings: settingsFor(i),
+          value: [{ content: draft.content, image: draft.images }],
+          settings: {
+            ...settingsFor(i),
+            ...(draft.settingsOverrides[i.id] ?? {}),
+          },
         })),
       };
 
-      const res = await fetch("/api/admin/postiz/posts", {
-        method: "POST",
+      const path = draft.id
+        ? `/api/admin/postiz/posts/${encodeURIComponent(draft.id)}`
+        : "/api/admin/postiz/posts";
+      const res = await fetch(path, {
+        method: draft.id ? "PUT" : "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify(body),
       });
       if (!res.ok) {
         const txt = await res.text();
         setFeedback(`Failed: ${res.status} ${txt.slice(0, 120)}`);
-        setSubmitting(false);
         return;
       }
-      setFeedback(`✅ Posted (${mode})`);
-      setContent("");
-      setImageUrl("");
+      setFeedback(draft.id ? `✅ Updated (${mode})` : `✅ Posted (${mode})`);
       onPosted();
     } finally {
       setSubmitting(false);
@@ -287,13 +413,24 @@ function ComposeTab({
 
   return (
     <div className="space-y-4">
+      {draft.id && (
+        <div className="flex items-center justify-between rounded border border-blue-200 bg-blue-50 p-3 text-sm">
+          <span>
+            Editing post <code>{draft.id}</code>
+          </span>
+          <button type="button" onClick={onCancel} className="text-blue-700 underline">
+            Cancel edit
+          </button>
+        </div>
+      )}
+
       <div>
         <label htmlFor="postiz-channels" className="mb-1 block text-sm font-medium">
-          Channels ({selectedIds.length} selected)
+          Channels ({draft.selectedIds.length} selected)
         </label>
         <div id="postiz-channels" className="flex flex-wrap gap-2">
           {integrations.map((i) => {
-            const on = selectedIds.includes(i.id);
+            const on = draft.selectedIds.includes(i.id);
             return (
               <button
                 type="button"
@@ -311,73 +448,138 @@ function ComposeTab({
       </div>
 
       <div>
-        <label htmlFor="postiz-content" className="mb-1 block text-sm font-medium">
-          Content
-        </label>
+        <div className="mb-1 flex items-center justify-between">
+          <label htmlFor="postiz-content" className="block text-sm font-medium">
+            Content
+          </label>
+          <button
+            type="button"
+            onClick={aiDraft}
+            disabled={aiBusy}
+            className="text-xs text-purple-700 underline disabled:opacity-50"
+          >
+            {aiBusy ? "Drafting…" : "AI draft"}
+          </button>
+        </div>
         <textarea
           id="postiz-content"
-          value={content}
-          onChange={(e) => setContent(e.target.value)}
+          value={draft.content}
+          onChange={(e) => setDraft({ content: e.target.value })}
           rows={6}
           className="w-full rounded border border-gray-300 p-2 font-mono text-sm"
           placeholder="What's the post?"
         />
       </div>
 
-      <div>
-        <label htmlFor="postiz-image" className="mb-1 block text-sm font-medium">
-          Media URL (optional)
-        </label>
-        <input
-          id="postiz-image"
-          type="url"
-          value={imageUrl}
-          onChange={(e) => setImageUrl(e.target.value)}
-          className="w-full rounded border border-gray-300 p-2 text-sm"
-          placeholder="https://cloudless.gr/some-image.png"
-        />
-        <p className="mt-1 text-xs text-gray-500">
-          Uploaded to Postiz via /upload-from-url before posting.
-        </p>
+      <div className="space-y-2">
+        <div className="text-sm font-medium">Media ({draft.images.length})</div>
+        {draft.images.length > 0 && (
+          <ul className="flex flex-wrap gap-2">
+            {draft.images.map((img) => (
+              <li
+                key={img.id}
+                className="flex items-center gap-2 rounded border bg-gray-50 px-2 py-1 text-xs"
+              >
+                <span className="max-w-[200px] truncate">{img.path.split("/").pop() ?? img.id}</span>
+                <button
+                  type="button"
+                  onClick={() => removeImage(img.id)}
+                  className="text-red-600"
+                >
+                  ×
+                </button>
+              </li>
+            ))}
+          </ul>
+        )}
+        <div className="flex gap-2">
+          <input
+            type="url"
+            value={imageUrlInput}
+            onChange={(e) => setImageUrlInput(e.target.value)}
+            className="flex-1 rounded border border-gray-300 p-2 text-sm"
+            placeholder="https://cloudless.gr/some-image.png"
+          />
+          <button
+            type="button"
+            onClick={addImageByUrl}
+            disabled={!imageUrlInput.trim()}
+            className="rounded border border-blue-600 px-3 py-1 text-sm text-blue-700 disabled:opacity-50"
+          >
+            Add URL
+          </button>
+          <label className="cursor-pointer rounded border border-gray-300 px-3 py-1 text-sm text-gray-700">
+            <input
+              type="file"
+              accept="image/*,video/*"
+              className="hidden"
+              onChange={(e) => {
+                const f = e.target.files?.[0];
+                if (f) void addImageByFile(f);
+                e.target.value = "";
+              }}
+            />
+            Upload file
+          </label>
+        </div>
       </div>
 
       <div>
-        <label htmlFor="postiz-schedule" className="mb-1 block text-sm font-medium">
-          Schedule at (local time)
-        </label>
+        <div className="mb-1 flex items-center justify-between">
+          <label htmlFor="postiz-schedule" className="block text-sm font-medium">
+            Schedule at (local time)
+          </label>
+          <button
+            type="button"
+            onClick={findNextSlot}
+            className="text-xs text-blue-600 underline"
+          >
+            Use next free slot
+          </button>
+        </div>
         <input
           id="postiz-schedule"
           type="datetime-local"
-          value={scheduleAt}
-          onChange={(e) => setScheduleAt(e.target.value)}
+          value={draft.scheduleAt}
+          onChange={(e) => setDraft({ scheduleAt: e.target.value })}
           className="rounded border border-gray-300 p-2 text-sm"
         />
       </div>
 
+      {selectedIntegrations.length > 0 && (
+        <ProviderSettings
+          integrations={selectedIntegrations}
+          overrides={draft.settingsOverrides}
+          onChange={(overrides) => setDraft({ settingsOverrides: overrides })}
+        />
+      )}
+
       <div className="flex gap-2">
         <button
           type="button"
-          disabled={submitting || !content || selectedIds.length === 0}
+          disabled={submitting || !draft.content || draft.selectedIds.length === 0}
           onClick={() => onSubmit("now")}
           className="rounded bg-blue-600 px-4 py-2 text-sm font-medium text-white disabled:opacity-50"
         >
-          Post now
+          {draft.id ? "Update & post now" : "Post now"}
         </button>
         <button
           type="button"
-          disabled={submitting || !content || selectedIds.length === 0 || !scheduleAt}
+          disabled={
+            submitting || !draft.content || draft.selectedIds.length === 0 || !draft.scheduleAt
+          }
           onClick={() => onSubmit("schedule")}
           className="rounded bg-purple-600 px-4 py-2 text-sm font-medium text-white disabled:opacity-50"
         >
-          Schedule
+          {draft.id ? "Update schedule" : "Schedule"}
         </button>
         <button
           type="button"
-          disabled={submitting || !content || selectedIds.length === 0}
+          disabled={submitting || !draft.content || draft.selectedIds.length === 0}
           onClick={() => onSubmit("draft")}
           className="rounded bg-gray-200 px-4 py-2 text-sm font-medium text-gray-800 disabled:opacity-50"
         >
-          Save draft
+          {draft.id ? "Save changes" : "Save draft"}
         </button>
       </div>
 
@@ -386,7 +588,15 @@ function ComposeTab({
   );
 }
 
-function ScheduleTab({ posts, onReload }: { posts: PostizPost[] | null; onReload: () => void }) {
+function ScheduleTab({
+  posts,
+  onReload,
+  onEdit,
+}: {
+  posts: PostizPost[] | null;
+  onReload: () => void;
+  onEdit: (post: PostizPost) => void;
+}) {
   if (posts === null) return <p>Loading…</p>;
   if (posts.length === 0) return <p className="text-gray-600">No posts in the current window.</p>;
 
@@ -415,13 +625,24 @@ function ScheduleTab({ posts, onReload }: { posts: PostizPost[] | null; onReload
                 {new Date(p.publishDate).toLocaleString()} · {p.state} · {p.integration.name} (
                 {p.integration.identifier})
               </div>
-              <button
-                type="button"
-                onClick={() => onDelete(p.id)}
-                className="text-xs text-red-600 underline"
-              >
-                Delete
-              </button>
+              <div className="flex gap-3 text-xs">
+                {(p.state === "QUEUE" || p.state === "DRAFT") && (
+                  <button
+                    type="button"
+                    onClick={() => onEdit(p)}
+                    className="text-blue-600 underline"
+                  >
+                    Edit
+                  </button>
+                )}
+                <button
+                  type="button"
+                  onClick={() => onDelete(p.id)}
+                  className="text-red-600 underline"
+                >
+                  Delete
+                </button>
+              </div>
             </div>
             <pre className="font-sans text-sm whitespace-pre-wrap">{p.content}</pre>
             {p.releaseURL && (
@@ -441,12 +662,376 @@ function ScheduleTab({ posts, onReload }: { posts: PostizPost[] | null; onReload
   );
 }
 
-/* -------- Provider settings helper -------- */
+const STATE_COLORS: Record<PostizPost["state"], string> = {
+  QUEUE: "bg-blue-100 text-blue-800 border-blue-300",
+  PUBLISHED: "bg-green-100 text-green-800 border-green-300",
+  ERROR: "bg-red-100 text-red-800 border-red-300",
+  DRAFT: "bg-gray-100 text-gray-700 border-gray-300",
+};
+
+const MONTHS = [
+  "January",
+  "February",
+  "March",
+  "April",
+  "May",
+  "June",
+  "July",
+  "August",
+  "September",
+  "October",
+  "November",
+  "December",
+];
+
+function CalendarTab({
+  posts,
+  onReload,
+}: {
+  posts: PostizPost[] | null;
+  onReload: () => void;
+}) {
+  const today = new Date();
+  const [year, setYear] = useState(today.getFullYear());
+  const [month, setMonth] = useState(today.getMonth());
+
+  const byDay = useMemo(() => {
+    const map = new Map<string, PostizPost[]>();
+    for (const p of posts ?? []) {
+      const d = new Date(p.publishDate);
+      if (d.getFullYear() !== year || d.getMonth() !== month) continue;
+      const key = d.toISOString().slice(0, 10);
+      const arr = map.get(key) ?? [];
+      arr.push(p);
+      map.set(key, arr);
+    }
+    return map;
+  }, [posts, year, month]);
+
+  const firstWeekday = new Date(year, month, 1).getDay();
+  const daysInMonth = new Date(year, month + 1, 0).getDate();
+  const cells: Array<{ day: number; key: string } | null> = [];
+  for (let i = 0; i < firstWeekday; i++) cells.push(null);
+  for (let d = 1; d <= daysInMonth; d++) {
+    const key = `${year}-${String(month + 1).padStart(2, "0")}-${String(d).padStart(2, "0")}`;
+    cells.push({ day: d, key });
+  }
+
+  const stepMonth = (delta: number) => {
+    let m = month + delta;
+    let y = year;
+    if (m < 0) {
+      m = 11;
+      y -= 1;
+    } else if (m > 11) {
+      m = 0;
+      y += 1;
+    }
+    setMonth(m);
+    setYear(y);
+  };
+
+  if (posts === null) return <p>Loading…</p>;
+
+  return (
+    <div className="space-y-3">
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-2">
+          <button
+            type="button"
+            onClick={() => stepMonth(-1)}
+            className="rounded border px-2 py-1 text-sm"
+          >
+            ←
+          </button>
+          <span className="text-sm font-medium">
+            {MONTHS[month]} {year}
+          </span>
+          <button
+            type="button"
+            onClick={() => stepMonth(1)}
+            className="rounded border px-2 py-1 text-sm"
+          >
+            →
+          </button>
+        </div>
+        <button type="button" onClick={onReload} className="text-sm text-blue-600 underline">
+          Refresh
+        </button>
+      </div>
+
+      <div className="grid grid-cols-7 gap-1 text-xs">
+        {["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"].map((d) => (
+          <div key={d} className="p-1 text-center font-medium text-gray-500">
+            {d}
+          </div>
+        ))}
+        {cells.map((cell, idx) =>
+          cell === null ? (
+            <div key={`empty-${idx}`} className="min-h-[80px] rounded border border-dashed border-gray-100" />
+          ) : (
+            <div
+              key={cell.key}
+              className="min-h-[80px] space-y-0.5 rounded border border-gray-200 p-1"
+            >
+              <div className="text-right text-[10px] text-gray-500">{cell.day}</div>
+              {(byDay.get(cell.key) ?? []).slice(0, 3).map((p) => (
+                <div
+                  key={p.id}
+                  className={`truncate rounded border px-1 py-0.5 text-[10px] ${STATE_COLORS[p.state]}`}
+                  title={`${p.integration.name} — ${p.state}\n${p.content}`}
+                >
+                  {p.integration.identifier}: {p.content.slice(0, 18)}
+                </div>
+              ))}
+              {(byDay.get(cell.key)?.length ?? 0) > 3 && (
+                <div className="text-[10px] text-gray-500">
+                  +{(byDay.get(cell.key)?.length ?? 0) - 3} more
+                </div>
+              )}
+            </div>
+          )
+        )}
+      </div>
+    </div>
+  );
+}
+
+/* -------- Provider settings -------- */
+
+function ProviderSettings({
+  integrations,
+  overrides,
+  onChange,
+}: {
+  integrations: PostizIntegration[];
+  overrides: Record<string, Record<string, unknown>>;
+  onChange: (next: Record<string, Record<string, unknown>>) => void;
+}) {
+  const [expanded, setExpanded] = useState(false);
+  return (
+    <div className="rounded border border-gray-200">
+      <button
+        type="button"
+        onClick={() => setExpanded((e) => !e)}
+        className="flex w-full items-center justify-between p-2 text-left text-sm font-medium"
+      >
+        <span>Provider-specific settings ({integrations.length} channel{integrations.length === 1 ? "" : "s"})</span>
+        <span className="text-gray-500">{expanded ? "▾" : "▸"}</span>
+      </button>
+      {expanded && (
+        <div className="space-y-3 border-t border-gray-200 p-3">
+          {integrations.map((i) => (
+            <ProviderSettingsRow
+              key={i.id}
+              integration={i}
+              value={overrides[i.id] ?? {}}
+              onChange={(next) => onChange({ ...overrides, [i.id]: next })}
+            />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function ProviderSettingsRow({
+  integration,
+  value,
+  onChange,
+}: {
+  integration: PostizIntegration;
+  value: Record<string, unknown>;
+  onChange: (next: Record<string, unknown>) => void;
+}) {
+  const idPrefix = `psr-${integration.id}`;
+  const id = integration.identifier;
+  const set = (patch: Record<string, unknown>) => onChange({ ...value, ...patch });
+
+  if (id === "tiktok") {
+    return (
+      <fieldset className="space-y-2">
+        <legend className="text-xs font-medium text-gray-700">
+          {integration.name} ({id})
+        </legend>
+        <label className="flex items-center gap-2 text-sm">
+          <span className="w-32">Privacy</span>
+          <select
+            value={String(value.privacy_level ?? "PUBLIC_TO_EVERYONE")}
+            onChange={(e) => set({ privacy_level: e.target.value })}
+            className="rounded border border-gray-300 p-1 text-sm"
+          >
+            <option value="PUBLIC_TO_EVERYONE">Public</option>
+            <option value="MUTUAL_FOLLOW_FRIENDS">Friends</option>
+            <option value="SELF_ONLY">Private</option>
+          </select>
+        </label>
+        <label className="flex items-center gap-2 text-sm">
+          <input
+            type="checkbox"
+            checked={value.comment !== false}
+            onChange={(e) => set({ comment: e.target.checked })}
+          />
+          Allow comments
+        </label>
+        <label className="flex items-center gap-2 text-sm">
+          <input
+            type="checkbox"
+            checked={value.duet !== false}
+            onChange={(e) => set({ duet: e.target.checked })}
+          />
+          Allow duet
+        </label>
+        <label className="flex items-center gap-2 text-sm">
+          <input
+            type="checkbox"
+            checked={value.stitch !== false}
+            onChange={(e) => set({ stitch: e.target.checked })}
+          />
+          Allow stitch
+        </label>
+      </fieldset>
+    );
+  }
+
+  if (id === "youtube") {
+    return (
+      <fieldset className="space-y-2">
+        <legend className="text-xs font-medium text-gray-700">
+          {integration.name} ({id})
+        </legend>
+        <label className="block text-sm">
+          <span className="mb-1 block text-xs text-gray-600">Title</span>
+          <input
+            id={`${idPrefix}-title`}
+            type="text"
+            value={String(value.title ?? "")}
+            onChange={(e) => set({ title: e.target.value })}
+            className="w-full rounded border border-gray-300 p-1 text-sm"
+            placeholder="cloudless.gr post"
+          />
+        </label>
+        <label className="flex items-center gap-2 text-sm">
+          <span className="w-32">Visibility</span>
+          <select
+            value={String(value.type ?? "public")}
+            onChange={(e) => set({ type: e.target.value })}
+            className="rounded border border-gray-300 p-1 text-sm"
+          >
+            <option value="public">Public</option>
+            <option value="unlisted">Unlisted</option>
+            <option value="private">Private</option>
+          </select>
+        </label>
+        <label className="flex items-center gap-2 text-sm">
+          <span className="w-32">Made for kids</span>
+          <select
+            value={String(value.selfDeclaredMadeForKids ?? "no")}
+            onChange={(e) => set({ selfDeclaredMadeForKids: e.target.value })}
+            className="rounded border border-gray-300 p-1 text-sm"
+          >
+            <option value="no">No</option>
+            <option value="yes">Yes</option>
+          </select>
+        </label>
+      </fieldset>
+    );
+  }
+
+  if (id === "discord" || id === "slack") {
+    return (
+      <fieldset className="space-y-2">
+        <legend className="text-xs font-medium text-gray-700">
+          {integration.name} ({id})
+        </legend>
+        <label className="block text-sm">
+          <span className="mb-1 block text-xs text-gray-600">Target channel</span>
+          <input
+            id={`${idPrefix}-channel`}
+            type="text"
+            value={String(value.channel ?? "")}
+            onChange={(e) => set({ channel: e.target.value })}
+            className="w-full rounded border border-gray-300 p-1 text-sm"
+            placeholder={id === "discord" ? "#general or channel id" : "C0123ABCDE"}
+          />
+        </label>
+      </fieldset>
+    );
+  }
+
+  if (id === "x") {
+    return (
+      <fieldset className="space-y-2">
+        <legend className="text-xs font-medium text-gray-700">
+          {integration.name} ({id})
+        </legend>
+        <label className="flex items-center gap-2 text-sm">
+          <span className="w-32">Who can reply</span>
+          <select
+            value={String(value.who_can_reply_post ?? "everyone")}
+            onChange={(e) => set({ who_can_reply_post: e.target.value })}
+            className="rounded border border-gray-300 p-1 text-sm"
+          >
+            <option value="everyone">Everyone</option>
+            <option value="following">People you follow</option>
+            <option value="mentionedUsers">Mentioned users only</option>
+          </select>
+        </label>
+      </fieldset>
+    );
+  }
+
+  if (id === "linkedin" || id === "linkedin-page") {
+    return (
+      <fieldset className="space-y-2">
+        <legend className="text-xs font-medium text-gray-700">
+          {integration.name} ({id})
+        </legend>
+        <label className="flex items-center gap-2 text-sm">
+          <input
+            type="checkbox"
+            checked={value.post_as_images_carousel === true}
+            onChange={(e) => set({ post_as_images_carousel: e.target.checked })}
+          />
+          Post images as carousel
+        </label>
+      </fieldset>
+    );
+  }
+
+  if (id === "instagram" || id === "instagram-standalone") {
+    return (
+      <fieldset className="space-y-2">
+        <legend className="text-xs font-medium text-gray-700">
+          {integration.name} ({id})
+        </legend>
+        <label className="flex items-center gap-2 text-sm">
+          <span className="w-32">Post type</span>
+          <select
+            value={String(value.post_type ?? "post")}
+            onChange={(e) => set({ post_type: e.target.value })}
+            className="rounded border border-gray-300 p-1 text-sm"
+          >
+            <option value="post">Feed post</option>
+            <option value="reel">Reel</option>
+            <option value="story">Story</option>
+          </select>
+        </label>
+      </fieldset>
+    );
+  }
+
+  return (
+    <div className="text-xs text-gray-500">
+      {integration.name} ({id}) — no provider-specific knobs surfaced here. Postiz defaults apply.
+    </div>
+  );
+}
 
 /**
  * Maps a Postiz integration to the minimal valid `settings` object for the
- * create-post API. Extend this as you wire up more provider-specific knobs in
- * the UI (TikTok privacy_level, YouTube title, etc.).
+ * create-post API. The ProviderSettings UI overrides specific fields on top
+ * of these baselines — what gets posted is `{ ...settingsFor(i), ...overrides }`.
  */
 function settingsFor(i: PostizIntegration): { __type: string } & Record<string, unknown> {
   switch (i.identifier) {

--- a/src/app/api/admin/calendar/[id]/publish/route.ts
+++ b/src/app/api/admin/calendar/[id]/publish/route.ts
@@ -85,7 +85,15 @@ export async function POST(request: NextRequest, { params }: { params: Promise<{
   } else {
     newStatus = isFuture ? "scheduled" : "published";
   }
-  const updated = await updateCalendarItem(id, { status: newStatus });
+  // Merge with any previously-stored ids — republishing an item is rare but
+  // happens (e.g. user re-runs after fixing notes); never lose history.
+  const mergedIds = Array.from(
+    new Set([...(item.postizPostIds ?? []), ...result.postIds])
+  );
+  const updated = await updateCalendarItem(id, {
+    status: newStatus,
+    postizPostIds: mergedIds,
+  });
 
   return NextResponse.json({
     success: true,

--- a/src/app/api/admin/postiz/health/route.ts
+++ b/src/app/api/admin/postiz/health/route.ts
@@ -1,0 +1,125 @@
+import { NextRequest, NextResponse } from "next/server";
+import { requireAdmin } from "@/lib/api-auth";
+import {
+  isPostizConfigured,
+  listIntegrations,
+  PostizApiError,
+  PostizNotConfiguredError,
+} from "@/lib/postiz";
+
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+
+/**
+ * GET /api/admin/postiz/health — JSON + Prometheus-flavoured metrics.
+ *
+ * Default JSON shape: `{ ok, configured, integrations, disabled, latencyMs, error? }`.
+ * Pass `?format=prom` to get a text/plain `# TYPE / # HELP` exposition
+ * suitable for a Prometheus scrape config — small enough to leave on the
+ * admin surface without a dedicated /metrics endpoint, large enough to alert
+ * on "no connected channels" or "high upstream latency".
+ */
+const METRIC_NAMES = {
+  up: "postiz_up",
+  channels: "postiz_integrations_total",
+  disabled: "postiz_integrations_disabled_total",
+  latency: "postiz_request_latency_ms",
+} as const;
+
+function asProm(snapshot: {
+  configured: boolean;
+  ok: boolean;
+  integrations: number;
+  disabled: number;
+  latencyMs: number;
+}): string {
+  const lines = [
+    `# HELP ${METRIC_NAMES.up} 1 if Postiz reachable and authenticated, 0 otherwise.`,
+    `# TYPE ${METRIC_NAMES.up} gauge`,
+    `${METRIC_NAMES.up} ${snapshot.ok ? 1 : 0}`,
+    `# HELP ${METRIC_NAMES.channels} Connected Postiz integrations (all states).`,
+    `# TYPE ${METRIC_NAMES.channels} gauge`,
+    `${METRIC_NAMES.channels} ${snapshot.integrations}`,
+    `# HELP ${METRIC_NAMES.disabled} Connected Postiz integrations with disabled=true.`,
+    `# TYPE ${METRIC_NAMES.disabled} gauge`,
+    `${METRIC_NAMES.disabled} ${snapshot.disabled}`,
+    `# HELP ${METRIC_NAMES.latency} Round-trip latency of the integrations probe, in ms.`,
+    `# TYPE ${METRIC_NAMES.latency} gauge`,
+    `${METRIC_NAMES.latency} ${snapshot.latencyMs}`,
+  ];
+  return `${lines.join("\n")}\n`;
+}
+
+export async function GET(req: NextRequest) {
+  const auth = await requireAdmin(req);
+  if (!auth.ok) return auth.response;
+
+  const format = new URL(req.url).searchParams.get("format");
+
+  const configured = await isPostizConfigured();
+  if (!configured) {
+    const snapshot = {
+      ok: false,
+      configured: false,
+      integrations: 0,
+      disabled: 0,
+      latencyMs: 0,
+    };
+    if (format === "prom") {
+      return new NextResponse(asProm(snapshot), {
+        status: 200,
+        headers: { "Content-Type": "text/plain; version=0.0.4" },
+      });
+    }
+    return NextResponse.json({ ...snapshot, error: "postiz_not_configured" }, { status: 503 });
+  }
+
+  const startedAt = Date.now();
+  try {
+    const integrations = await listIntegrations();
+    const latencyMs = Date.now() - startedAt;
+    const disabled = integrations.filter((i) => i.disabled).length;
+    const snapshot = {
+      ok: true,
+      configured: true,
+      integrations: integrations.length,
+      disabled,
+      latencyMs,
+    };
+    if (format === "prom") {
+      return new NextResponse(asProm(snapshot), {
+        status: 200,
+        headers: { "Content-Type": "text/plain; version=0.0.4" },
+      });
+    }
+    return NextResponse.json(snapshot);
+  } catch (err) {
+    const latencyMs = Date.now() - startedAt;
+    const snapshot = { ok: false, configured: true, integrations: 0, disabled: 0, latencyMs };
+    if (err instanceof PostizNotConfiguredError) {
+      if (format === "prom") {
+        return new NextResponse(asProm({ ...snapshot, configured: false }), {
+          status: 200,
+          headers: { "Content-Type": "text/plain; version=0.0.4" },
+        });
+      }
+      return NextResponse.json(
+        { ...snapshot, configured: false, error: "postiz_not_configured" },
+        { status: 503 }
+      );
+    }
+    if (err instanceof PostizApiError) {
+      if (format === "prom") {
+        return new NextResponse(asProm(snapshot), {
+          status: 200,
+          headers: { "Content-Type": "text/plain; version=0.0.4" },
+        });
+      }
+      return NextResponse.json(
+        { ...snapshot, error: "postiz_upstream", status: err.status, body: err.body },
+        { status: 502 }
+      );
+    }
+    throw err;
+  }
+}

--- a/src/app/api/admin/postiz/posts/[id]/route.ts
+++ b/src/app/api/admin/postiz/posts/[id]/route.ts
@@ -1,6 +1,12 @@
 import { NextRequest, NextResponse } from "next/server";
 import { requireAdmin } from "@/lib/api-auth";
-import { deletePost, PostizApiError, PostizNotConfiguredError } from "@/lib/postiz";
+import {
+  deletePost,
+  PostizApiError,
+  PostizNotConfiguredError,
+  updatePost,
+  type CreatePostBody,
+} from "@/lib/postiz";
 
 export const dynamic = "force-dynamic";
 
@@ -24,6 +30,47 @@ export async function DELETE(req: NextRequest, { params }: { params: Promise<{ i
       return NextResponse.json(
         { error: "postiz_upstream", status: err.status, body: err.body },
         { status: 502 }
+      );
+    }
+    throw err;
+  }
+}
+
+/** Edit a scheduled or draft post — Postiz PUT /posts/:id. Identical body
+ *  schema as POST /posts; the route just proxies. */
+export async function PUT(req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+  const auth = await requireAdmin(req);
+  if (!auth.ok) return auth.response;
+
+  const { id } = await params;
+  if (!id) {
+    return NextResponse.json({ error: "missing_id" }, { status: 400 });
+  }
+
+  let body: CreatePostBody;
+  try {
+    body = (await req.json()) as CreatePostBody;
+  } catch {
+    return NextResponse.json({ error: "invalid_json" }, { status: 400 });
+  }
+  if (!body.type || !Array.isArray(body.posts) || body.posts.length === 0) {
+    return NextResponse.json(
+      { error: "invalid_payload", detail: "type and posts[] are required" },
+      { status: 400 }
+    );
+  }
+
+  try {
+    const result = await updatePost(id, body);
+    return NextResponse.json({ result });
+  } catch (err) {
+    if (err instanceof PostizNotConfiguredError) {
+      return NextResponse.json({ error: "postiz_not_configured" }, { status: 503 });
+    }
+    if (err instanceof PostizApiError) {
+      return NextResponse.json(
+        { error: "postiz_upstream", status: err.status, body: err.body },
+        { status: err.status === 429 ? 429 : 502 }
       );
     }
     throw err;

--- a/src/app/api/admin/postiz/upload-file/route.ts
+++ b/src/app/api/admin/postiz/upload-file/route.ts
@@ -1,0 +1,61 @@
+import { NextRequest, NextResponse } from "next/server";
+import { requireAdmin } from "@/lib/api-auth";
+import { uploadFile, PostizApiError, PostizNotConfiguredError } from "@/lib/postiz";
+
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+
+/**
+ * POST /api/admin/postiz/upload-file — multipart pass-through to Postiz.
+ *
+ * Body: multipart/form-data with a `file` field (the binary blob) and an
+ * optional `filename` field. Use this when the source is a local file the
+ * user picked; `/upload` already handles URL-sourced media.
+ */
+const MAX_FILE_BYTES = 25 * 1024 * 1024; // 25 MB — matches Postiz upstream default.
+
+export async function POST(req: NextRequest) {
+  const auth = await requireAdmin(req);
+  if (!auth.ok) return auth.response;
+
+  let form: FormData;
+  try {
+    form = await req.formData();
+  } catch {
+    return NextResponse.json({ error: "invalid_multipart" }, { status: 400 });
+  }
+
+  const file = form.get("file");
+  if (!(file instanceof Blob)) {
+    return NextResponse.json({ error: "missing_file" }, { status: 400 });
+  }
+  if (file.size === 0) {
+    return NextResponse.json({ error: "empty_file" }, { status: 400 });
+  }
+  if (file.size > MAX_FILE_BYTES) {
+    return NextResponse.json(
+      { error: "file_too_large", maxBytes: MAX_FILE_BYTES, actualBytes: file.size },
+      { status: 413 }
+    );
+  }
+
+  const filename =
+    (form.get("filename") as string | null) ??
+    (file instanceof File ? file.name : "upload.bin");
+
+  try {
+    const uploaded = await uploadFile(file, filename);
+    return NextResponse.json(uploaded, { status: 201 });
+  } catch (err) {
+    if (err instanceof PostizNotConfiguredError) {
+      return NextResponse.json({ error: "postiz_not_configured" }, { status: 503 });
+    }
+    if (err instanceof PostizApiError) {
+      return NextResponse.json(
+        { error: "postiz_upstream", status: err.status, body: err.body },
+        { status: 502 }
+      );
+    }
+    throw err;
+  }
+}

--- a/src/app/api/cron/postiz-oauth-check/route.ts
+++ b/src/app/api/cron/postiz-oauth-check/route.ts
@@ -1,0 +1,49 @@
+import { NextRequest, NextResponse } from "next/server";
+import { isCronAuthorized, cronUnauthorized } from "@/lib/cron-auth";
+import { isPostizConfigured, listIntegrations } from "@/lib/postiz";
+import { notifyOauthExpiry } from "@/lib/postiz-slack";
+
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+
+/**
+ * GET /api/cron/postiz-oauth-check — alert on disabled channels.
+ *
+ * Postiz flips `disabled: true` on an integration when its OAuth token has
+ * expired or been revoked by the upstream provider. That's the highest-value
+ * silent failure for a self-hosted social tool: scheduled posts will queue
+ * up but never publish until a human re-authorizes.
+ *
+ * The cron lists integrations and pages a Slack alert for every channel
+ * currently `disabled`. Recommend running once an hour — the channel doesn't
+ * spontaneously re-enable, so spamming every 15 min adds no signal.
+ *
+ * (Idempotency: this currently re-alerts on every run for any disabled
+ * channel. If the noise becomes a problem, add a per-channel "last alerted"
+ * marker in a small KV. For now: a disabled channel is loud on purpose.)
+ */
+export async function GET(request: NextRequest) {
+  if (!(await isCronAuthorized(request))) return cronUnauthorized();
+
+  if (!(await isPostizConfigured())) {
+    return NextResponse.json({ ok: false, reason: "postiz_not_configured" }, { status: 503 });
+  }
+
+  const integrations = await listIntegrations();
+  const disabled = integrations.filter((i) => i.disabled);
+
+  await Promise.all(
+    disabled.map((integration) =>
+      notifyOauthExpiry(integration).catch((e) =>
+        console.error("[postiz-oauth-check] slack:", e)
+      )
+    )
+  );
+
+  return NextResponse.json({
+    ok: true,
+    total: integrations.length,
+    disabled: disabled.length,
+    notified: disabled.map((i) => ({ id: i.id, name: i.name, identifier: i.identifier })),
+  });
+}

--- a/src/app/api/cron/postiz-sync/route.ts
+++ b/src/app/api/cron/postiz-sync/route.ts
@@ -1,0 +1,131 @@
+import { NextRequest, NextResponse } from "next/server";
+import { isCronAuthorized, cronUnauthorized } from "@/lib/cron-auth";
+import { getCalendarItems, updateCalendarItem } from "@/lib/content-calendar";
+import {
+  isPostizConfigured,
+  listPosts,
+  type PostizPost,
+} from "@/lib/postiz";
+import { notifyPostErrored, notifyPostPublished } from "@/lib/postiz-slack";
+
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+
+/**
+ * GET /api/cron/postiz-sync — status pull-back loop.
+ *
+ * Webhooks (POST /api/webhooks/postiz) are the primary source of truth, but
+ * we still need a polling safety net for: (a) installations where Postiz
+ * webhooks aren't configured, (b) events Postiz dropped on the floor during
+ * an outage, (c) re-syncing after the app itself was offline.
+ *
+ * The cron pulls posts in a [-3d, +30d] window, intersects with calendar
+ * items that have `postizPostIds`, and reconciles status. Idempotent: if the
+ * calendar item is already in the right state, no write happens.
+ *
+ * Schedule recommended: every 15 minutes. The Postiz Public API window
+ * tolerates this comfortably (1 request per call, well under any rate limit).
+ */
+
+const LOOKBACK_DAYS = 3;
+const LOOKAHEAD_DAYS = 30;
+
+function postizStateToCalendarStatus(
+  state: PostizPost["state"]
+): "draft" | "scheduled" | "published" | "cancelled" {
+  switch (state) {
+    case "PUBLISHED":
+      return "published";
+    case "ERROR":
+      // Demote back to draft so the user sees it in the queue; we explicitly
+      // do NOT use "cancelled" — that's user-driven, not failure-driven.
+      return "draft";
+    case "DRAFT":
+      return "draft";
+    case "QUEUE":
+    default:
+      return "scheduled";
+  }
+}
+
+export async function GET(request: NextRequest) {
+  if (!(await isCronAuthorized(request))) return cronUnauthorized();
+
+  if (!(await isPostizConfigured())) {
+    return NextResponse.json({ ok: false, reason: "postiz_not_configured" }, { status: 503 });
+  }
+
+  const now = Date.now();
+  const dayMs = 24 * 60 * 60 * 1000;
+  const startDate = new Date(now - LOOKBACK_DAYS * dayMs).toISOString();
+  const endDate = new Date(now + LOOKAHEAD_DAYS * dayMs).toISOString();
+
+  let upstream: PostizPost[];
+  try {
+    upstream = await listPosts(startDate, endDate);
+  } catch (err) {
+    console.error("[postiz-sync] listPosts failed:", err);
+    return NextResponse.json({ ok: false, reason: "postiz_upstream_failed" }, { status: 502 });
+  }
+
+  const byPostizId = new Map<string, PostizPost>();
+  for (const p of upstream) byPostizId.set(p.id, p);
+
+  const sinceDay = new Date(now - LOOKBACK_DAYS * dayMs).toISOString().slice(0, 10);
+  const untilDay = new Date(now + LOOKAHEAD_DAYS * dayMs).toISOString().slice(0, 10);
+  const items = await getCalendarItems(sinceDay, untilDay);
+  const candidates = items.filter((i) => (i.postizPostIds?.length ?? 0) > 0);
+
+  let updated = 0;
+  let published = 0;
+  let errored = 0;
+  let unchanged = 0;
+  let missing = 0;
+
+  for (const item of candidates) {
+    // Use the first Postiz ID that maps back to an upstream record. For
+    // multi-channel items we treat the FIRST channel's state as authoritative
+    // (matches calendar UX — one status per item). The webhook receiver and
+    // per-channel detail still surface individual results.
+    const ids = item.postizPostIds ?? [];
+    const upstreamPost = ids.map((id) => byPostizId.get(id)).find(Boolean);
+    if (!upstreamPost) {
+      missing += 1;
+      continue;
+    }
+
+    const target = postizStateToCalendarStatus(upstreamPost.state);
+    if (item.status === target) {
+      unchanged += 1;
+      continue;
+    }
+
+    await updateCalendarItem(item.id, { status: target });
+    updated += 1;
+
+    if (upstreamPost.state === "PUBLISHED") {
+      published += 1;
+      // Slack is best-effort — see webhook receiver for the same pattern.
+      await notifyPostPublished(upstreamPost).catch((e) =>
+        console.error("[postiz-sync] slack:", e)
+      );
+    } else if (upstreamPost.state === "ERROR") {
+      errored += 1;
+      await notifyPostErrored(upstreamPost, null).catch((e) =>
+        console.error("[postiz-sync] slack:", e)
+      );
+    }
+  }
+
+  return NextResponse.json({
+    ok: true,
+    window: { startDate, endDate },
+    upstreamCount: upstream.length,
+    candidates: candidates.length,
+    updated,
+    published,
+    errored,
+    unchanged,
+    missing,
+  });
+}

--- a/src/app/api/webhooks/postiz/route.ts
+++ b/src/app/api/webhooks/postiz/route.ts
@@ -1,0 +1,100 @@
+import { NextRequest, NextResponse } from "next/server";
+import { verifyPostizWebhookSignature, type PostizPost } from "@/lib/postiz";
+import { getCalendarItems, updateCalendarItem } from "@/lib/content-calendar";
+import { notifyPostErrored, notifyPostPublished } from "@/lib/postiz-slack";
+
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+
+/**
+ * POST /api/webhooks/postiz — inbound Postiz event receiver.
+ *
+ * Events handled:
+ *   - `post.published` → mark matching calendar item `published`, Slack +OK.
+ *   - `post.errored`   → mark matching calendar item `draft` (so the user
+ *                        sees it back in the queue), Slack +alarm.
+ *   - anything else    → 202 Accepted, ignored. Postiz may emit additional
+ *                        event types over time; ignoring them keeps the
+ *                        receiver forward-compatible.
+ *
+ * Signature: `X-Postiz-Signature` carries the HMAC-SHA256 hex digest of the
+ * raw body using `POSTIZ_WEBHOOK_SECRET`. Verification is constant-time and
+ * happens on the raw body BEFORE JSON.parse — never reorder these steps,
+ * the bytes used for HMAC and JSON parse must match exactly.
+ */
+
+interface PostizWebhookPayload {
+  event?: string;
+  post?: Partial<PostizPost>;
+  error?: string;
+}
+
+async function markByPostizId(postId: string, status: "published" | "draft"): Promise<boolean> {
+  // Calendar items don't have a Postiz-ID secondary index — but the universe
+  // of social_post items is small (tens to hundreds), so a full scan over the
+  // last 90 days is cheap and avoids a schema migration. If this hot-spots,
+  // add an index in `notion-calendar.ts`.
+  const ninetyDaysMs = 90 * 24 * 60 * 60 * 1000;
+  const since = new Date(Date.now() - ninetyDaysMs).toISOString().slice(0, 10);
+  const until = new Date(Date.now() + ninetyDaysMs).toISOString().slice(0, 10);
+  const items = await getCalendarItems(since, until);
+  const match = items.find((i) => (i.postizPostIds ?? []).includes(postId));
+  if (!match) return false;
+  await updateCalendarItem(match.id, { status });
+  return true;
+}
+
+export async function POST(req: NextRequest) {
+  // Raw body FIRST so we can HMAC the exact bytes Postiz signed.
+  const rawBody = await req.text();
+  const signatureHeader = req.headers.get("x-postiz-signature");
+
+  const valid = await verifyPostizWebhookSignature(rawBody, signatureHeader);
+  if (!valid) {
+    // 401 vs 400: a missing-secret deployment looks identical to an attacker;
+    // returning 401 for any unverifiable request keeps both cases consistent.
+    return NextResponse.json({ error: "invalid_signature" }, { status: 401 });
+  }
+
+  let payload: PostizWebhookPayload;
+  try {
+    payload = JSON.parse(rawBody) as PostizWebhookPayload;
+  } catch {
+    return NextResponse.json({ error: "invalid_json" }, { status: 400 });
+  }
+
+  const event = payload.event ?? "";
+  const post = payload.post;
+  if (!post?.id || !post.integration) {
+    return NextResponse.json({ accepted: false, reason: "missing_post_fields" }, { status: 202 });
+  }
+
+  // Build a full-ish PostizPost for the Slack helper (it tolerates loose shape).
+  const full: PostizPost = {
+    id: post.id,
+    content: post.content ?? "",
+    publishDate: post.publishDate ?? new Date().toISOString(),
+    state: (post.state ?? (event === "post.published" ? "PUBLISHED" : "QUEUE")) as PostizPost["state"],
+    integration: post.integration as PostizPost["integration"],
+    releaseURL: post.releaseURL ?? null,
+    releaseId: post.releaseId ?? null,
+  };
+
+  if (event === "post.published") {
+    await markByPostizId(post.id, "published");
+    // Slack failures must not break the webhook ACK back to Postiz; if the
+    // receiver 5xxs Postiz will retry, and we'd double-update the calendar.
+    await notifyPostPublished(full).catch((e) => console.error("[postiz-webhook] slack:", e));
+    return NextResponse.json({ accepted: true, event, postId: post.id });
+  }
+
+  if (event === "post.errored") {
+    await markByPostizId(post.id, "draft");
+    await notifyPostErrored(full, payload.error ?? null).catch((e) =>
+      console.error("[postiz-webhook] slack:", e)
+    );
+    return NextResponse.json({ accepted: true, event, postId: post.id });
+  }
+
+  return NextResponse.json({ accepted: false, event, reason: "unhandled_event" }, { status: 202 });
+}

--- a/src/lib/content-calendar.ts
+++ b/src/lib/content-calendar.ts
@@ -33,6 +33,13 @@ export interface CalendarItem {
   status: "draft" | "scheduled" | "published" | "cancelled";
   url?: string;
   notes?: string;
+  /**
+   * Postiz post IDs returned when a `social_post` item is published. Stored so
+   * the postiz-sync cron and the webhook receiver can match upstream
+   * post.published / post.errored events back to the calendar row that
+   * created them. One ID per channel the item fanned out to.
+   */
+  postizPostIds?: string[];
 }
 
 export const CALENDAR_ITEM_COLORS: Record<CalendarItemType, string> = {

--- a/src/lib/notion-calendar.ts
+++ b/src/lib/notion-calendar.ts
@@ -13,7 +13,13 @@
  * │ Status       │ Select (draft | scheduled | published | cancelled)     │
  * │ URL          │ URL                                                    │
  * │ Notes        │ Rich text                                              │
+ * │ PostizIDs    │ Rich text (optional; comma-separated Postiz post IDs)  │
  * └──────────────┴────────────────────────────────────────────────────────┘
+ *
+ * The PostizIDs column is added on-demand: when an item is published via
+ * Postiz the publish route writes the IDs back so the sync cron / webhook
+ * receiver can correlate inbound events. Existing rows without the column
+ * remain valid — the adapter degrades silently when the property is absent.
  */
 
 import { notionFetch } from "@/lib/notion";
@@ -68,6 +74,13 @@ function pageToItem(page: Record<string, unknown>): CalendarItem | null {
 
     const dateRange = dateField("Date");
     const calId = richText("CalID");
+    const postizIdsRaw = richText("PostizIDs");
+    const postizPostIds = postizIdsRaw
+      ? postizIdsRaw
+          .split(",")
+          .map((s) => s.trim())
+          .filter(Boolean)
+      : undefined;
 
     return {
       id: calId || (page as { id: string }).id,
@@ -79,6 +92,7 @@ function pageToItem(page: Record<string, unknown>): CalendarItem | null {
       status: sel("Status") as CalendarItem["status"],
       url: urlField("URL"),
       notes: richText("Notes") || undefined,
+      postizPostIds: postizPostIds && postizPostIds.length > 0 ? postizPostIds : undefined,
     };
   } catch {
     return null;
@@ -145,6 +159,9 @@ export async function notionCreateCalendarItem(item: CalendarItem): Promise<stri
 
   if (item.url) properties.URL = { url: item.url };
   if (item.notes) properties.Notes = { rich_text: rt(item.notes) };
+  if (item.postizPostIds && item.postizPostIds.length > 0) {
+    properties.PostizIDs = { rich_text: rt(item.postizPostIds.join(",")) };
+  }
 
   // No try/catch: a Notion failure (e.g. the calendar DB was deleted or
   // unshared from the integration → object_not_found) must propagate so the
@@ -185,6 +202,12 @@ export async function notionUpdateCalendarItem(item: CalendarItem): Promise<bool
       Status: { select: { name: item.status } },
       URL: item.url ? { url: item.url } : { url: null },
       Notes: { rich_text: item.notes ? rt(item.notes) : [] },
+      PostizIDs: {
+        rich_text:
+          item.postizPostIds && item.postizPostIds.length > 0
+            ? rt(item.postizPostIds.join(","))
+            : [],
+      },
     };
 
     await notionFetch(`/pages/${pageId}`, {

--- a/src/lib/postiz-slack.ts
+++ b/src/lib/postiz-slack.ts
@@ -1,0 +1,98 @@
+import { getConfig } from "@/lib/ssm-config";
+import { SlackClient } from "@/lib/slack-notify";
+import type { PostizIntegration, PostizPost } from "@/lib/postiz";
+
+/**
+ * Slack notifications for Postiz lifecycle events.
+ *
+ * Each function is a no-op when Slack isn't configured (SlackClient.post
+ * returns false silently) — never blocks a webhook or cron handler. Channel
+ * routing: `POSTIZ_SLACK_CHANNEL` (SSM) overrides the default; otherwise
+ * SlackClient falls through to `SLACK_DEFAULT_CHANNEL` and finally `#general`.
+ */
+
+async function getClient(): Promise<SlackClient> {
+  const cfg = await getConfig();
+  const channel = cfg.POSTIZ_SLACK_CHANNEL || undefined;
+  return new SlackClient(channel ? { channel } : undefined);
+}
+
+function shorten(s: string, max = 280): string {
+  if (s.length <= max) return s;
+  return `${s.slice(0, max - 1)}…`;
+}
+
+/** Successful publish — fires on Postiz `post.published` webhook events. */
+export async function notifyPostPublished(post: PostizPost): Promise<void> {
+  const client = await getClient();
+  const releaseLink = post.releaseURL
+    ? ` <${post.releaseURL}|view on ${post.integration.identifier}>`
+    : "";
+  await client.post({
+    text: `Postiz: ${post.integration.name} published`,
+    blocks: [
+      {
+        type: "section",
+        text: {
+          type: "mrkdwn",
+          text:
+            `:white_check_mark: *Postiz published* on *${post.integration.name}* ` +
+            `(${post.integration.identifier})${releaseLink}\n` +
+            `> ${shorten(post.content)}`,
+        },
+      },
+    ],
+    icon_emoji: ":satellite_antenna:",
+    username: "Postiz",
+  });
+}
+
+/** Errored publish — `post.errored` webhook events or sync-cron detection. */
+export async function notifyPostErrored(
+  post: Pick<PostizPost, "id" | "content" | "integration" | "state">,
+  reason: string | null
+): Promise<void> {
+  const client = await getClient();
+  const detail = reason ? `\n> Reason: \`${shorten(reason, 200)}\`` : "";
+  await client.post({
+    text: `Postiz: ${post.integration.name} failed to publish`,
+    blocks: [
+      {
+        type: "section",
+        text: {
+          type: "mrkdwn",
+          text:
+            `:rotating_light: *Postiz publish failed* on *${post.integration.name}* ` +
+            `(${post.integration.identifier})\n` +
+            `> ${shorten(post.content)}${detail}\n` +
+            `Post ID: \`${post.id}\``,
+        },
+      },
+    ],
+    icon_emoji: ":rotating_light:",
+    username: "Postiz",
+  });
+}
+
+/** OAuth token expired/revoked on a channel — fired by the oauth-check cron. */
+export async function notifyOauthExpiry(integration: PostizIntegration): Promise<void> {
+  const client = await getClient();
+  await client.post({
+    text: `Postiz: ${integration.name} OAuth disconnected`,
+    blocks: [
+      {
+        type: "section",
+        text: {
+          type: "mrkdwn",
+          text:
+            `:warning: *Postiz channel disconnected* — *${integration.name}* ` +
+            `(${integration.identifier}) is disabled. Re-authorize at ` +
+            `<https://postiz.cloudless.gr/launches|postiz.cloudless.gr/launches> ` +
+            `before the next scheduled post.`,
+        },
+      },
+    ],
+    icon_emoji: ":warning:",
+    username: "Postiz",
+  });
+}

--- a/src/lib/postiz.ts
+++ b/src/lib/postiz.ts
@@ -304,3 +304,70 @@ export function findSlot(integrationId: string): Promise<{ date: string }> {
     `/find-slot/${encodeURIComponent(integrationId)}`
   );
 }
+
+/** Update an existing scheduled / draft post via PUT /posts/:id. */
+export function updatePost(
+  id: string,
+  body: CreatePostBody
+): Promise<Array<{ postId: string; integration: string }>> {
+  return callThrowing<Array<{ postId: string; integration: string }>>(
+    `/posts/${encodeURIComponent(id)}`,
+    {
+      method: "PUT",
+      body: JSON.stringify(body),
+    }
+  );
+}
+
+/** Per-post analytics, when the channel supports it. Postiz exposes
+ *  GET /posts/:id/statistics; shape varies by provider so we keep it loose. */
+export function getPostStats(id: string): Promise<Record<string, unknown>> {
+  return callThrowing<Record<string, unknown>>(
+    `/posts/${encodeURIComponent(id)}/statistics`
+  );
+}
+
+/** Multipart upload — for users uploading a local file rather than a URL.
+ *
+ *  Postiz v2.11.2 exposes POST /upload (multipart/form-data, field name
+ *  "file"). Unlike `uploadFromUrl`, this path streams the bytes the
+ *  browser sent us through to Postiz with no intermediate fetch. */
+export async function uploadFile(file: Blob, filename: string): Promise<UploadedFile> {
+  const { baseUrl, apiKey } = await getPostizConfig();
+  const form = new FormData();
+  form.append("file", file, filename);
+  const res = await fetch(`${baseUrl}/api/public/v1/upload`, {
+    method: "POST",
+    // No Content-Type — let fetch set the multipart boundary itself.
+    headers: { Authorization: apiKey },
+    body: form,
+    signal: AbortSignal.timeout(60_000),
+  });
+  if (!res.ok) throw new PostizApiError(res.status, await res.text().catch(() => ""));
+  return (await res.json()) as UploadedFile;
+}
+
+/**
+ * Verify an inbound Postiz webhook signature.
+ *
+ * Postiz signs the raw JSON body with HMAC-SHA256 using
+ * `POSTIZ_WEBHOOK_SECRET` and sends the hex digest in the
+ * `X-Postiz-Signature` header (lowercase hex, no `sha256=` prefix).
+ *
+ * Returns `true` only when the secret is configured AND the digest matches.
+ * Performs a constant-time comparison. */
+export async function verifyPostizWebhookSignature(
+  rawBody: string,
+  signatureHeader: string | null
+): Promise<boolean> {
+  if (!signatureHeader) return false;
+  const cfg = await getConfig();
+  const secret = cfg.POSTIZ_WEBHOOK_SECRET;
+  if (!secret) return false;
+  const { createHmac, timingSafeEqual } = await import("node:crypto");
+  const expected = createHmac("sha256", secret).update(rawBody).digest("hex");
+  // Both arms must be the same length for timingSafeEqual.
+  const got = signatureHeader.toLowerCase().replace(/^sha256=/, "");
+  if (got.length !== expected.length) return false;
+  return timingSafeEqual(Buffer.from(got, "utf8"), Buffer.from(expected, "utf8"));
+}

--- a/src/lib/ssm-config.ts
+++ b/src/lib/ssm-config.ts
@@ -105,6 +105,10 @@ interface AppConfig {
   // Postiz (self-hosted social publishing)
   POSTIZ_API_URL: string;
   POSTIZ_API_KEY: string;
+  /** HMAC secret shared with Postiz webhook config — verifies inbound events. */
+  POSTIZ_WEBHOOK_SECRET: string;
+  /** Optional Slack channel override for Postiz publish/error/oauth events. */
+  POSTIZ_SLACK_CHANNEL: string;
   // Cron auth
   CRON_SECRET: string;
   // AI
@@ -237,6 +241,8 @@ function buildConfigFromParams(params: Map<string, string>): AppConfig {
     GITHUB_DISPATCH_TOKEN: params.get("GITHUB_DISPATCH_TOKEN") ?? "",
     POSTIZ_API_URL: params.get("POSTIZ_API_URL") ?? "",
     POSTIZ_API_KEY: params.get("POSTIZ_API_KEY") ?? "",
+    POSTIZ_WEBHOOK_SECRET: params.get("POSTIZ_WEBHOOK_SECRET") ?? "",
+    POSTIZ_SLACK_CHANNEL: params.get("POSTIZ_SLACK_CHANNEL") ?? "",
     CRON_SECRET: params.get("CRON_SECRET") ?? "",
     ANTHROPIC_API_KEY: params.get("ANTHROPIC_API_KEY") ?? "",
     ANTHROPIC_CHAT_MODEL: params.get("ANTHROPIC_CHAT_MODEL") ?? "",
@@ -317,6 +323,8 @@ function buildConfigFromEnv(): AppConfig {
     GITHUB_DISPATCH_TOKEN: process.env.GITHUB_DISPATCH_TOKEN || "",
     POSTIZ_API_URL: process.env.POSTIZ_API_URL || "",
     POSTIZ_API_KEY: process.env.POSTIZ_API_KEY || "",
+    POSTIZ_WEBHOOK_SECRET: process.env.POSTIZ_WEBHOOK_SECRET || "",
+    POSTIZ_SLACK_CHANNEL: process.env.POSTIZ_SLACK_CHANNEL || "",
     CRON_SECRET: process.env.CRON_SECRET || "",
     ANTHROPIC_API_KEY: process.env.ANTHROPIC_API_KEY || "",
     ANTHROPIC_CHAT_MODEL: process.env.ANTHROPIC_CHAT_MODEL || "",


### PR DESCRIPTION
Ships the 12 additions enumerated in the prior round.

## High-leverage

- **#1 Next-free-slot button** in compose — calls existing `/api/admin/postiz/slot`, populates `scheduleAt` and shows a human-readable confirmation.
- **#2 Status pull-back cron** — new `GET /api/cron/postiz-sync` (Bearer `CRON_SECRET`) pulls posts in a [-3d, +30d] window, intersects with calendar items that carry `postizPostIds`, reconciles status, and Slack-pings on transitions. Recommended every 15 min.
- **#3 Multi-image upload** in compose — image refs are now `Array<{id, path}>`; add/remove inline; submitted as `value[].image`.
- **#4 Edit scheduled / draft posts** — new `PUT /api/admin/postiz/posts/[id]` proxies Postiz `PUT /posts/:id`; Edit button on schedule rows pre-fills compose with `(edit)` tab marker; switches POST→PUT on submit.

## Medium-leverage

- **#5 AI draft button** in compose — calls existing `/api/admin/ai/generate` with a per-channel prompt seeded from the current draft.
- **#6 Postiz webhook receiver** — new `POST /api/webhooks/postiz` with HMAC-SHA256 signature verification (`POSTIZ_WEBHOOK_SECRET`); handles `post.published` and `post.errored`; unhandled events 202 silently. Constant-time verify, raw-body-first.
- **#7 Provider settings UI** — expanded panel shows real knobs per selected channel: TikTok privacy / duet / stitch / comment, YouTube title / visibility / "made for kids", Discord/Slack channel, X reply audience, LinkedIn carousel, Instagram post-type. Overrides merge on top of the existing `settingsFor()` baselines.
- **#8 Calendar tab** — month grid with prev/next nav, color-coded by Postiz state, tooltip with full content, "+N more" overflow per day.

## Lower-leverage

- **#9 Multipart file upload** — new `POST /api/admin/postiz/upload-file` (25 MB cap) plus lib `uploadFile(Blob, filename)`.
- **#10 Health probe** — new `GET /api/admin/postiz/health` returns JSON + optional Prometheus exposition (`?format=prom`): `postiz_up`, `postiz_integrations_total`, `postiz_integrations_disabled_total`, `postiz_request_latency_ms`.
- **#11 Slack notifier** — new `src/lib/postiz-slack.ts` (`notifyPostPublished` / `notifyPostErrored` / `notifyOauthExpiry`). Routed via `POSTIZ_SLACK_CHANNEL`; silent no-op when Slack isn't configured.
- **#12 OAuth-expiry alerter** — new `GET /api/cron/postiz-oauth-check` (Bearer `CRON_SECRET`) pages a Slack alert per `disabled` channel. Recommended hourly.

## Plumbing

- `CalendarItem.postizPostIds?: string[]` — round-tripped through the Notion adapter (`PostizIDs` rich_text column).
- Publish route now persists Postiz post IDs back to the calendar item (merged).
- Lib extensions: `updatePost`, `getPostStats`, `uploadFile`, `verifyPostizWebhookSignature`.
- SSM config additions: `POSTIZ_WEBHOOK_SECRET`, `POSTIZ_SLACK_CHANNEL`.

## Verification

```
pnpm vitest run __tests__/postiz.test.ts __tests__/postiz-slack.test.ts \
                __tests__/calendar-api.test.ts __tests__/publish-and-send-newsletter.test.ts \
                __tests__/admin-api.test.ts __tests__/admin-calendar-api.test.ts \
                __tests__/content-calendar.test.ts __tests__/cron-auth.test.ts \
                __tests__/ssm-config.test.ts
 Test Files  9 passed (9)
      Tests  151 passed (151)
pnpm typecheck   # clean
pnpm lint        # clean
```

E2E gap sweep extended for the new admin GET/POST/PUT routes, the two crons, and the webhook receiver.
