### PR TITLE
ci(postiz): schedule postiz-sync (15 min) and postiz-oauth-check (hourly)

### DIFF
--- a/.github/workflows/postiz-crons.yml
+++ b/.github/workflows/postiz-crons.yml
@@ -1,0 +1,111 @@
+name: Postiz crons
+
+# Wakes the app's two Postiz cron endpoints on a schedule:
+#
+#   /api/cron/postiz-sync         — every 15 min (with GHA jitter, in practice
+#                                   every 20-45 min). Safety net for the
+#                                   webhook receiver: reconciles calendar
+#                                   item status against Postiz state.
+#   /api/cron/postiz-oauth-check  — hourly. Pages a Slack alert per disabled
+#                                   channel (expired OAuth tokens).
+#
+# Auth: CRON_SECRET is read from SSM /cloudless/production/CRON_SECRET via
+# the existing AWS OIDC deploy role, same pattern as platform-crons.yml.
+#
+# Manual run: workflow_dispatch with a target picker (defaults to both).
+
+on:
+  schedule:
+    - cron: "*/15 * * * *" # postiz-sync — every 15 min
+    - cron: "5 * * * *" # postiz-oauth-check — 5 min past the hour
+  workflow_dispatch:
+    inputs:
+      target:
+        description: "Which cron endpoint(s) to trigger"
+        type: choice
+        default: both
+        options:
+          - both
+          - postiz-sync
+          - postiz-oauth-check
+
+permissions:
+  id-token: write
+  contents: read
+
+env:
+  AWS_REGION: us-east-1
+  BASE_URL: https://cloudless.gr
+
+jobs:
+  trigger:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Configure AWS credentials (OIDC)
+        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4
+        with:
+          role-to-assume: ${{ secrets.AWS_DEPLOY_ROLE_ARN }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Read CRON_SECRET from SSM
+        id: secret
+        run: |
+          SECRET=$(aws ssm get-parameter \
+            --name "/cloudless/production/CRON_SECRET" \
+            --with-decryption \
+            --query "Parameter.Value" --output text 2>/dev/null || echo "")
+          if [ -z "$SECRET" ] || [ "$SECRET" = "None" ]; then
+            echo "::error::/cloudless/production/CRON_SECRET is not set in SSM — Postiz crons cannot authenticate."
+            exit 1
+          fi
+          echo "::add-mask::$SECRET"
+          echo "value=$SECRET" >> "$GITHUB_OUTPUT"
+
+      - name: Decide targets
+        id: targets
+        run: |
+          EVENT="${{ github.event_name }}"
+          SCHEDULE="${{ github.event.schedule }}"
+          INPUT="${{ github.event.inputs.target }}"
+          RUN_SYNC="false"
+          RUN_OAUTH="false"
+          if [ "$EVENT" = "workflow_dispatch" ]; then
+            case "$INPUT" in
+              both)               RUN_SYNC="true"; RUN_OAUTH="true" ;;
+              postiz-sync)        RUN_SYNC="true" ;;
+              postiz-oauth-check) RUN_OAUTH="true" ;;
+            esac
+          elif [ "$SCHEDULE" = "*/15 * * * *" ]; then
+            RUN_SYNC="true"
+          elif [ "$SCHEDULE" = "5 * * * *" ]; then
+            RUN_OAUTH="true"
+          fi
+          echo "sync=$RUN_SYNC" >> "$GITHUB_OUTPUT"
+          echo "oauth=$RUN_OAUTH" >> "$GITHUB_OUTPUT"
+
+      - name: Trigger postiz-sync
+        if: steps.targets.outputs.sync == 'true'
+        run: |
+          echo "Calling $BASE_URL/api/cron/postiz-sync"
+          RESPONSE=$(curl -fsS --retry 3 --retry-delay 5 --max-time 60 \
+            -H "Authorization: Bearer ${{ steps.secret.outputs.value }}" \
+            "$BASE_URL/api/cron/postiz-sync")
+          echo "Response: $RESPONSE"
+          echo "## Postiz sync" >> "$GITHUB_STEP_SUMMARY"
+          echo '```json' >> "$GITHUB_STEP_SUMMARY"
+          echo "$RESPONSE" >> "$GITHUB_STEP_SUMMARY"
+          echo '```' >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Trigger postiz-oauth-check
+        if: steps.targets.outputs.oauth == 'true'
+        run: |
+          echo "Calling $BASE_URL/api/cron/postiz-oauth-check"
+          RESPONSE=$(curl -fsS --retry 3 --retry-delay 5 --max-time 30 \
+            -H "Authorization: Bearer ${{ steps.secret.outputs.value }}" \
+            "$BASE_URL/api/cron/postiz-oauth-check")
+          echo "Response: $RESPONSE"
+          echo "## Postiz OAuth check" >> "$GITHUB_STEP_SUMMARY"
+          echo '```json' >> "$GITHUB_STEP_SUMMARY"
+          echo "$RESPONSE" >> "$GITHUB_STEP_SUMMARY"
+          echo '```' >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
Wires the two new cron routes shipped in #942 to the same OIDC-backed scheduler that runs the existing platform-crons workflow.

- postiz-sync — */15 * * * *
- postiz-oauth-check — 5 * * * *

CRON_SECRET is read from SSM each run, no extra repo secrets needed. workflow_dispatch with a target picker for manual runs.