### PR TITLE
fix(postiz/webhook): accept ?secret= query param (Postiz v2 UI has no signing field)

### DIFF
--- a/__tests__/postiz.test.ts
+++ b/__tests__/postiz.test.ts
@@ -353,13 +353,14 @@ describe("uploadFile (multipart)", () => {
 });
 
 describe("verifyPostizWebhookSignature", () => {
-  it("returns false when the signature header is missing", async () => {
+  it("returns false when both signature header AND URL secret are missing", async () => {
     mockGetConfig.mockResolvedValue({
       POSTIZ_API_URL: "https://x",
       POSTIZ_API_KEY: "k",
       POSTIZ_WEBHOOK_SECRET: "secret",
     });
     await expect(verifyPostizWebhookSignature("body", null)).resolves.toBe(false);
+    await expect(verifyPostizWebhookSignature("body", null, null)).resolves.toBe(false);
   });
 
   it("returns false when no secret is configured", async () => {
@@ -369,6 +370,32 @@ describe("verifyPostizWebhookSignature", () => {
       POSTIZ_WEBHOOK_SECRET: "",
     });
     await expect(verifyPostizWebhookSignature("body", "abc")).resolves.toBe(false);
+    await expect(verifyPostizWebhookSignature("body", null, "abc")).resolves.toBe(false);
+  });
+
+  it("returns true on a matching URL-secret query param", async () => {
+    mockGetConfig.mockResolvedValue({
+      POSTIZ_API_URL: "https://x",
+      POSTIZ_API_KEY: "k",
+      POSTIZ_WEBHOOK_SECRET: "exact-secret-value",
+    });
+    await expect(
+      verifyPostizWebhookSignature("any-body", null, "exact-secret-value")
+    ).resolves.toBe(true);
+  });
+
+  it("returns false on a wrong URL-secret query param", async () => {
+    mockGetConfig.mockResolvedValue({
+      POSTIZ_API_URL: "https://x",
+      POSTIZ_API_KEY: "k",
+      POSTIZ_WEBHOOK_SECRET: "exact-secret-value",
+    });
+    // Same length, different bytes — exercises the constant-time arm.
+    await expect(
+      verifyPostizWebhookSignature("body", null, "wrong-secret-value")
+    ).resolves.toBe(false);
+    // Different length — exercises the length-prefilter.
+    await expect(verifyPostizWebhookSignature("body", null, "short")).resolves.toBe(false);
   });
 
   it("returns true on a matching HMAC-SHA256 hex digest of the raw body", async () => {
@@ -388,7 +415,7 @@ describe("verifyPostizWebhookSignature", () => {
     await expect(verifyPostizWebhookSignature(body, sig.toUpperCase())).resolves.toBe(true);
   });
 
-  it("returns false on tampered body", async () => {
+  it("returns false on tampered body (HMAC arm)", async () => {
     const { createHmac } = await import("node:crypto");
     const secret = "shhh";
     const sig = createHmac("sha256", secret).update("original").digest("hex");
@@ -398,6 +425,17 @@ describe("verifyPostizWebhookSignature", () => {
       POSTIZ_WEBHOOK_SECRET: secret,
     });
     await expect(verifyPostizWebhookSignature("tampered", sig)).resolves.toBe(false);
+  });
+
+  it("accepts either arm — URL-secret wins even if signature is wrong", async () => {
+    mockGetConfig.mockResolvedValue({
+      POSTIZ_API_URL: "https://x",
+      POSTIZ_API_KEY: "k",
+      POSTIZ_WEBHOOK_SECRET: "shared",
+    });
+    await expect(
+      verifyPostizWebhookSignature("body", "definitely-not-a-hash", "shared")
+    ).resolves.toBe(true);
   });
 });
 

--- a/src/app/api/webhooks/postiz/route.ts
+++ b/src/app/api/webhooks/postiz/route.ts
@@ -17,10 +17,13 @@ export const runtime = "nodejs";
  *                        event types over time; ignoring them keeps the
  *                        receiver forward-compatible.
  *
- * Signature: `X-Postiz-Signature` carries the HMAC-SHA256 hex digest of the
- * raw body using `POSTIZ_WEBHOOK_SECRET`. Verification is constant-time and
- * happens on the raw body BEFORE JSON.parse — never reorder these steps,
- * the bytes used for HMAC and JSON parse must match exactly.
+ * Authentication: see `verifyPostizWebhookSignature` — accepts either an
+ * `X-Postiz-Signature` HMAC over the raw body OR a `?secret=<hex>` query
+ * param matching `POSTIZ_WEBHOOK_SECRET`. Postiz v2's webhook UI has no
+ * signing-secret field, so the URL-secret path is the primary one in
+ * production. Verification is constant-time and happens on the raw body
+ * BEFORE JSON.parse — never reorder these steps; the bytes used for HMAC
+ * and JSON.parse must match exactly.
  */
 
 interface PostizWebhookPayload {
@@ -48,8 +51,9 @@ export async function POST(req: NextRequest) {
   // Raw body FIRST so we can HMAC the exact bytes Postiz signed.
   const rawBody = await req.text();
   const signatureHeader = req.headers.get("x-postiz-signature");
+  const urlSecret = new URL(req.url).searchParams.get("secret");
 
-  const valid = await verifyPostizWebhookSignature(rawBody, signatureHeader);
+  const valid = await verifyPostizWebhookSignature(rawBody, signatureHeader, urlSecret);
   if (!valid) {
     // 401 vs 400: a missing-secret deployment looks identical to an attacker;
     // returning 401 for any unverifiable request keeps both cases consistent.

--- a/src/lib/postiz.ts
+++ b/src/lib/postiz.ts
@@ -348,26 +348,57 @@ export async function uploadFile(file: Blob, filename: string): Promise<Uploaded
 }
 
 /**
- * Verify an inbound Postiz webhook signature.
+ * Verify an inbound Postiz webhook request.
  *
- * Postiz signs the raw JSON body with HMAC-SHA256 using
- * `POSTIZ_WEBHOOK_SECRET` and sends the hex digest in the
- * `X-Postiz-Signature` header (lowercase hex, no `sha256=` prefix).
+ * Postiz v2.11.2's webhook UI exposes only Name / URL / Integrations — there
+ * is no signing-secret field. So we authenticate inbound events two ways and
+ * accept EITHER:
  *
- * Returns `true` only when the secret is configured AND the digest matches.
- * Performs a constant-time comparison. */
+ *   1. **URL-secret** (primary in v2): the configured URL is
+ *      `https://cloudless.gr/api/webhooks/postiz?secret=<hex>`. The receiver
+ *      pulls `secret` from the query string and compares it constant-time
+ *      against `POSTIZ_WEBHOOK_SECRET`. The full URL itself is the
+ *      capability token; rotate the SSM param and the URL together.
+ *
+ *   2. **HMAC-SHA256 signature** (forward-compat): if Postiz starts shipping
+ *      `X-Postiz-Signature` (or the user runs a downstream fork that does),
+ *      we accept a hex digest of the raw body using the same SSM secret.
+ *      Lowercase hex, with or without a `sha256=` prefix.
+ *
+ * Returns `true` only when the secret is configured AND one of the two paths
+ * matches. Both comparisons are constant-time.
+ *
+ * Callers MUST pass the raw body (pre-JSON.parse) so the HMAC arm has the
+ * exact bytes Postiz signed if it does sign. */
 export async function verifyPostizWebhookSignature(
   rawBody: string,
-  signatureHeader: string | null
+  signatureHeader: string | null,
+  urlSecret?: string | null
 ): Promise<boolean> {
-  if (!signatureHeader) return false;
   const cfg = await getConfig();
   const secret = cfg.POSTIZ_WEBHOOK_SECRET;
   if (!secret) return false;
+
   const { createHmac, timingSafeEqual } = await import("node:crypto");
-  const expected = createHmac("sha256", secret).update(rawBody).digest("hex");
-  // Both arms must be the same length for timingSafeEqual.
-  const got = signatureHeader.toLowerCase().replace(/^sha256=/, "");
-  if (got.length !== expected.length) return false;
-  return timingSafeEqual(Buffer.from(got, "utf8"), Buffer.from(expected, "utf8"));
+
+  // Path 1 — URL secret. Equal-length check first so timingSafeEqual doesn't
+  // throw on a mismatch; constant-time compare otherwise.
+  if (urlSecret && urlSecret.length === secret.length) {
+    if (timingSafeEqual(Buffer.from(urlSecret, "utf8"), Buffer.from(secret, "utf8"))) {
+      return true;
+    }
+  }
+
+  // Path 2 — HMAC-SHA256 over the raw body.
+  if (signatureHeader) {
+    const expected = createHmac("sha256", secret).update(rawBody).digest("hex");
+    const got = signatureHeader.toLowerCase().replace(/^sha256=/, "");
+    if (got.length === expected.length) {
+      if (timingSafeEqual(Buffer.from(got, "utf8"), Buffer.from(expected, "utf8"))) {
+        return true;
+      }
+    }
+  }
+
+  return false;
 }


### PR DESCRIPTION
Discovered while wiring the actual Postiz UI: v2.11.2 exposes only Name / URL / Integrations on the webhook form. No HMAC-secret field is configurable. The HMAC arm shipped in #942 would never have authenticated a real event.

Fix:
- Extend verifyPostizWebhookSignature with a third arg urlSecret. Returns true on EITHER a constant-time match against POSTIZ_WEBHOOK_SECRET or a valid HMAC.
- Receiver pulls ?secret= from the request URL and passes it through.
- 5 new vitest cases cover the new arm (matching, wrong-same-length, short-length, either-arm-wins, missing-both). 40/40 in postiz.test.ts pass.

Configured webhook URL: . HMAC arm stays for forward-compat.