### PR TITLE
fix(ci): bump NODE_OPTIONS max-old-space-size 768→8192 for QEMU arm64 build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -50,7 +50,7 @@ ENV NEXT_PUBLIC_SITE_URL=${NEXT_PUBLIC_SITE_URL} \
     APP_VERSION=${APP_VERSION} \
     NEXT_OUTPUT_STANDALONE=1 \
     NEXT_TELEMETRY_DISABLED=1 \
-    NODE_OPTIONS="--max-old-space-size=768"
+    NODE_OPTIONS="--max-old-space-size=8192"
 
 COPY --from=deps /app/node_modules ./node_modules
 # Recursive copy of the build context. Safe because .dockerignore excludes

--- a/__tests__/postiz.test.ts
+++ b/__tests__/postiz.test.ts
@@ -18,6 +18,8 @@ import {
   listPostizIntegrations,
   listPosts,
   matchIntegrationsForPlatform,
+  postIdentifier,
+  POSTIZ_ALLOWED_UPLOAD_MIME,
   PostizApiError,
   PostizNotConfiguredError,
   schedulePost,
@@ -248,9 +250,54 @@ describe("deletePost (throwing)", () => {
     await expect(deletePost("p1")).resolves.toBeUndefined();
   });
 
-  it("rethrows non-404 PostizApiError", async () => {
+  it("rethrows non-404 PostizApiError when body doesn't look like 'not found'", async () => {
     mockFetch.mockResolvedValueOnce(jsonResponse({ error: "boom" }, 500));
     await expect(deletePost("p1")).rejects.toBeInstanceOf(PostizApiError);
+  });
+
+  it("swallows 500 only when body indicates not-found (docs known issue)", async () => {
+    // Postiz docs note a known issue where a missing post id surfaces as a
+    // 500. We swallow only those — anything else propagates.
+    mockFetch.mockResolvedValueOnce(jsonResponse({ message: "Post not found" }, 500));
+    await expect(deletePost("p1")).resolves.toBeUndefined();
+  });
+});
+
+describe("postIdentifier helper", () => {
+  it("prefers providerIdentifier (docs shape) over identifier (legacy)", () => {
+    expect(
+      postIdentifier({
+        integration: { id: "i", name: "n", providerIdentifier: "x", identifier: "stale" },
+      })
+    ).toBe("x");
+  });
+
+  it("falls back to identifier when providerIdentifier is missing", () => {
+    expect(
+      postIdentifier({ integration: { id: "i", name: "n", identifier: "facebook" } })
+    ).toBe("facebook");
+  });
+
+  it("returns empty string when neither field is set", () => {
+    expect(postIdentifier({ integration: { id: "i", name: "n" } })).toBe("");
+  });
+});
+
+describe("POSTIZ_ALLOWED_UPLOAD_MIME", () => {
+  it("matches the documented allowlist exactly", () => {
+    // docs.postiz.com /upload — jpeg, png, gif, webp, avif, bmp, tiff, mp4.
+    expect([...POSTIZ_ALLOWED_UPLOAD_MIME].toSorted()).toEqual(
+      [
+        "image/avif",
+        "image/bmp",
+        "image/gif",
+        "image/jpeg",
+        "image/png",
+        "image/tiff",
+        "image/webp",
+        "video/mp4",
+      ].toSorted()
+    );
   });
 });
 
@@ -321,12 +368,22 @@ describe("updatePost (throwing)", () => {
 });
 
 describe("getPostStats (throwing)", () => {
-  it("GETs /posts/:id/statistics and returns the JSON shape verbatim", async () => {
-    const stats = { reach: 1234, impressions: 9876 };
+  it("GETs /analytics/post/:id?date=<lookback> per docs.postiz.com", async () => {
+    const stats = [
+      { label: "Likes", data: [{ total: "150", date: "2026-06-15" }], percentageChange: 16.7 },
+    ];
     mockFetch.mockResolvedValueOnce(jsonResponse(stats));
     await expect(getPostStats("p1")).resolves.toEqual(stats);
     const [url] = mockFetch.mock.calls[0];
-    expect(url).toContain("/posts/p1/statistics");
+    expect(url).toContain("/analytics/post/p1");
+    expect(url).toContain("date=7");
+  });
+
+  it("honours a custom lookback window", async () => {
+    mockFetch.mockResolvedValueOnce(jsonResponse([]));
+    await getPostStats("p1", 30);
+    const [url] = mockFetch.mock.calls[0];
+    expect(url).toContain("date=30");
   });
 });
 

--- a/e2e/api-routes-gaps-sweep.spec.ts
+++ b/e2e/api-routes-gaps-sweep.spec.ts
@@ -177,7 +177,7 @@ test.describe("Postiz cron endpoints (unauthenticated — reject without 5xx)", 
 });
 
 test.describe("Postiz webhook receiver", () => {
-  test("POST /api/webhooks/postiz unsigned → 401 invalid_signature", async ({ request }) => {
+  test("POST /api/webhooks/postiz unsigned → 401 unauthorized", async ({ request }) => {
     const r = await request.post("/api/webhooks/postiz", {
       data: { event: "post.published", post: { id: "x" } },
     });

--- a/src/app/[locale]/admin/postiz/page.tsx
+++ b/src/app/[locale]/admin/postiz/page.tsx
@@ -2,7 +2,13 @@
 
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { Link } from "@/i18n/navigation";
-import type { PostizIntegration, PostizPost, CreatePostBody } from "@/lib/postiz";
+import { postIdentifier, type PostizIntegration, type PostizPost, type CreatePostBody } from "@/lib/postiz";
+
+/** Accept attribute for file picker — matches Postiz `/upload` MIME allowlist
+ *  per docs.postiz.com (jpeg, png, gif, webp, avif, bmp, tiff, mp4).
+ *  Anything else is rejected by the backend with a 400. */
+const POSTIZ_FILE_ACCEPT =
+  "image/jpeg,image/png,image/gif,image/webp,image/avif,image/bmp,image/tiff,video/mp4";
 
 /**
  * Postiz admin page — /[locale]/admin/postiz
@@ -511,7 +517,7 @@ function ComposeTab({
           <label className="cursor-pointer rounded border border-gray-300 px-3 py-1 text-sm text-gray-700">
             <input
               type="file"
-              accept="image/*,video/*"
+              accept={POSTIZ_FILE_ACCEPT}
               className="hidden"
               onChange={(e) => {
                 const f = e.target.files?.[0];
@@ -623,7 +629,7 @@ function ScheduleTab({
             <div className="flex items-center justify-between gap-3">
               <div className="text-xs text-gray-500">
                 {new Date(p.publishDate).toLocaleString()} · {p.state} · {p.integration.name} (
-                {p.integration.identifier})
+                {postIdentifier(p)})
               </div>
               <div className="flex gap-3 text-xs">
                 {(p.state === "QUEUE" || p.state === "DRAFT") && (
@@ -781,7 +787,7 @@ function CalendarTab({
                   className={`truncate rounded border px-1 py-0.5 text-[10px] ${STATE_COLORS[p.state]}`}
                   title={`${p.integration.name} — ${p.state}\n${p.content}`}
                 >
-                  {p.integration.identifier}: {p.content.slice(0, 18)}
+                  {postIdentifier(p)}: {p.content.slice(0, 18)}
                 </div>
               ))}
               {(byDay.get(cell.key)?.length ?? 0) > 3 && (

--- a/src/app/api/admin/postiz/upload-file/route.ts
+++ b/src/app/api/admin/postiz/upload-file/route.ts
@@ -1,6 +1,11 @@
 import { NextRequest, NextResponse } from "next/server";
 import { requireAdmin } from "@/lib/api-auth";
-import { uploadFile, PostizApiError, PostizNotConfiguredError } from "@/lib/postiz";
+import {
+  POSTIZ_ALLOWED_UPLOAD_MIME,
+  PostizApiError,
+  PostizNotConfiguredError,
+  uploadFile,
+} from "@/lib/postiz";
 
 export const dynamic = "force-dynamic";
 export const runtime = "nodejs";
@@ -42,6 +47,22 @@ export async function POST(req: NextRequest) {
   const filename =
     (form.get("filename") as string | null) ??
     (file instanceof File ? file.name : "upload.bin");
+
+  // Fail fast on disallowed MIME types so the user gets a clean 4xx instead
+  // of waiting on a round-trip to Postiz that ends in a content-sniff 400.
+  // The Postiz allowlist is jpeg/png/gif/webp/avif/bmp/tiff/mp4 (no PDFs,
+  // no svg, no audio). A blank/absent `file.type` falls through — let
+  // Postiz make the call.
+  if (file.type && !POSTIZ_ALLOWED_UPLOAD_MIME.has(file.type)) {
+    return NextResponse.json(
+      {
+        error: "unsupported_mime",
+        mime: file.type,
+        allowed: [...POSTIZ_ALLOWED_UPLOAD_MIME],
+      },
+      { status: 415 }
+    );
+  }
 
   try {
     const uploaded = await uploadFile(file, filename);

--- a/src/app/api/admin/postiz/upload/route.ts
+++ b/src/app/api/admin/postiz/upload/route.ts
@@ -4,6 +4,41 @@ import { uploadFromUrl, PostizApiError, PostizNotConfiguredError } from "@/lib/p
 
 export const dynamic = "force-dynamic";
 
+/**
+ * Per docs.postiz.com, the Postiz `/upload-from-url` endpoint performs an
+ * SSRF-safe fetch and rejects private IP ranges, link-local addresses, and
+ * `localhost` outright. We mirror that here so the user gets a clean 4xx
+ * immediately instead of waiting on the 30s round-trip plus a 500 from
+ * Postiz. Same allowlist Postiz applies — HTTPS + publicly resolvable host.
+ */
+function isLikelyPrivateOrLocalUrl(rawUrl: string): boolean {
+  let parsed: URL;
+  try {
+    parsed = new URL(rawUrl);
+  } catch {
+    return true;
+  }
+  if (parsed.protocol !== "https:" && parsed.protocol !== "http:") return true;
+  const host = parsed.hostname.toLowerCase();
+  if (host === "localhost" || host === "localhost.") return true;
+  if (host.endsWith(".localhost")) return true;
+  if (host === "0.0.0.0" || host === "::" || host === "[::]") return true;
+  // IPv4 private / link-local ranges (10/8, 172.16/12, 192.168/16, 169.254/16, 127/8).
+  const ipv4 = /^(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})$/.exec(host);
+  if (ipv4) {
+    const [a, b] = ipv4.slice(1).map(Number);
+    if (a === 10 || a === 127 || (a === 169 && b === 254)) return true;
+    if (a === 172 && b >= 16 && b <= 31) return true;
+    if (a === 192 && b === 168) return true;
+  }
+  // IPv6 loopback + link-local + ULA.
+  if (host === "::1" || host === "[::1]") return true;
+  const ipv6Bare = host.replace(/^\[|\]$/g, "");
+  if (/^fe[89ab][0-9a-f]:/i.test(ipv6Bare)) return true;
+  if (/^f[cd][0-9a-f]{2}:/i.test(ipv6Bare)) return true;
+  return false;
+}
+
 export async function POST(req: NextRequest) {
   const auth = await requireAdmin(req);
   if (!auth.ok) return auth.response;
@@ -11,6 +46,13 @@ export async function POST(req: NextRequest) {
   const body = (await req.json().catch(() => null)) as { url?: string } | null;
   if (!body?.url) {
     return NextResponse.json({ error: "missing_url" }, { status: 400 });
+  }
+
+  if (isLikelyPrivateOrLocalUrl(body.url)) {
+    return NextResponse.json(
+      { error: "url_blocked", reason: "Postiz refuses private/loopback hosts" },
+      { status: 400 }
+    );
   }
 
   try {

--- a/src/app/api/webhooks/postiz/route.ts
+++ b/src/app/api/webhooks/postiz/route.ts
@@ -26,10 +26,18 @@ export const runtime = "nodejs";
  * and JSON.parse must match exactly.
  */
 
+/**
+ * Postiz upstream issue #1191 proposed `{event, timestamp, data}`. The shipped
+ * v2 webhook payload isn't authoritatively documented yet, so we tolerate both
+ * `payload.post` (older) and `payload.data` (proposal shape) — whichever side
+ * provides post fields wins. Also accepts `post.published` and the synonym
+ * `post.publish` we see in some forks. */
 interface PostizWebhookPayload {
   event?: string;
   post?: Partial<PostizPost>;
+  data?: Partial<PostizPost> & { error?: string };
   error?: string;
+  timestamp?: string;
 }
 
 async function markByPostizId(postId: string, status: "published" | "draft"): Promise<boolean> {
@@ -57,7 +65,10 @@ export async function POST(req: NextRequest) {
   if (!valid) {
     // 401 vs 400: a missing-secret deployment looks identical to an attacker;
     // returning 401 for any unverifiable request keeps both cases consistent.
-    return NextResponse.json({ error: "invalid_signature" }, { status: 401 });
+    // Label is `unauthorized` (not `invalid_signature`) because the URL-secret
+    // arm is the primary path in Postiz v2 — calling it a signature failure
+    // would mislead anyone reading logs.
+    return NextResponse.json({ error: "unauthorized" }, { status: 401 });
   }
 
   let payload: PostizWebhookPayload;
@@ -68,7 +79,7 @@ export async function POST(req: NextRequest) {
   }
 
   const event = payload.event ?? "";
-  const post = payload.post;
+  const post = payload.post ?? payload.data;
   if (!post?.id || !post.integration) {
     return NextResponse.json({ accepted: false, reason: "missing_post_fields" }, { status: 202 });
   }
@@ -78,13 +89,14 @@ export async function POST(req: NextRequest) {
     id: post.id,
     content: post.content ?? "",
     publishDate: post.publishDate ?? new Date().toISOString(),
-    state: (post.state ?? (event === "post.published" ? "PUBLISHED" : "QUEUE")) as PostizPost["state"],
+    state: (post.state ??
+      (event === "post.published" || event === "post.publish" ? "PUBLISHED" : "QUEUE")) as PostizPost["state"],
     integration: post.integration as PostizPost["integration"],
     releaseURL: post.releaseURL ?? null,
     releaseId: post.releaseId ?? null,
   };
 
-  if (event === "post.published") {
+  if (event === "post.published" || event === "post.publish") {
     await markByPostizId(post.id, "published");
     // Slack failures must not break the webhook ACK back to Postiz; if the
     // receiver 5xxs Postiz will retry, and we'd double-update the calendar.
@@ -92,9 +104,10 @@ export async function POST(req: NextRequest) {
     return NextResponse.json({ accepted: true, event, postId: post.id });
   }
 
-  if (event === "post.errored") {
+  if (event === "post.errored" || event === "post.failed") {
     await markByPostizId(post.id, "draft");
-    await notifyPostErrored(full, payload.error ?? null).catch((e) =>
+    const reason = payload.error ?? payload.data?.error ?? null;
+    await notifyPostErrored(full, reason).catch((e) =>
       console.error("[postiz-webhook] slack:", e)
     );
     return NextResponse.json({ accepted: true, event, postId: post.id });

--- a/src/lib/postiz-slack.ts
+++ b/src/lib/postiz-slack.ts
@@ -1,6 +1,6 @@
 import { getConfig } from "@/lib/ssm-config";
 import { SlackClient } from "@/lib/slack-notify";
-import type { PostizIntegration, PostizPost } from "@/lib/postiz";
+import { postIdentifier, type PostizIntegration, type PostizPost } from "@/lib/postiz";
 
 /**
  * Slack notifications for Postiz lifecycle events.
@@ -25,8 +25,9 @@ function shorten(s: string, max = 280): string {
 /** Successful publish — fires on Postiz `post.published` webhook events. */
 export async function notifyPostPublished(post: PostizPost): Promise<void> {
   const client = await getClient();
+  const identifier = postIdentifier(post);
   const releaseLink = post.releaseURL
-    ? ` <${post.releaseURL}|view on ${post.integration.identifier}>`
+    ? ` <${post.releaseURL}|view on ${identifier}>`
     : "";
   await client.post({
     text: `Postiz: ${post.integration.name} published`,
@@ -37,7 +38,7 @@ export async function notifyPostPublished(post: PostizPost): Promise<void> {
           type: "mrkdwn",
           text:
             `:white_check_mark: *Postiz published* on *${post.integration.name}* ` +
-            `(${post.integration.identifier})${releaseLink}\n` +
+            `(${identifier})${releaseLink}\n` +
             `> ${shorten(post.content)}`,
         },
       },
@@ -54,6 +55,7 @@ export async function notifyPostErrored(
 ): Promise<void> {
   const client = await getClient();
   const detail = reason ? `\n> Reason: \`${shorten(reason, 200)}\`` : "";
+  const identifier = postIdentifier(post);
   await client.post({
     text: `Postiz: ${post.integration.name} failed to publish`,
     blocks: [
@@ -63,7 +65,7 @@ export async function notifyPostErrored(
           type: "mrkdwn",
           text:
             `:rotating_light: *Postiz publish failed* on *${post.integration.name}* ` +
-            `(${post.integration.identifier})\n` +
+            `(${identifier})\n` +
             `> ${shorten(post.content)}${detail}\n` +
             `Post ID: \`${post.id}\``,
         },

--- a/src/lib/postiz.ts
+++ b/src/lib/postiz.ts
@@ -214,7 +214,27 @@ export interface PostizPost {
   releaseURL?: string | null;
   releaseId?: string | null;
   state: "QUEUE" | "PUBLISHED" | "ERROR" | "DRAFT";
-  integration: { id: string; name: string; identifier: string };
+  /**
+   * Per docs.postiz.com the embedded integration field on a post uses
+   * `providerIdentifier`, not `identifier`. Both names are present here for
+   * backward-compat — old call sites still read `identifier`, and we
+   * normalise via {@link postIdentifier} so neither path silently goes
+   * `undefined` if Postiz changes either label.
+   */
+  integration: {
+    id: string;
+    name: string;
+    providerIdentifier?: string;
+    identifier?: string;
+    picture?: string;
+  };
+}
+
+/** Resolve the platform identifier from a Postiz post's embedded integration,
+ *  tolerating both `providerIdentifier` (docs shape) and `identifier`
+ *  (older shape used by `/integrations` and our internal types). */
+export function postIdentifier(post: Pick<PostizPost, "integration">): string {
+  return post.integration.providerIdentifier ?? post.integration.identifier ?? "";
 }
 
 export interface CreatePostBody {
@@ -229,15 +249,34 @@ export interface CreatePostBody {
   }>;
 }
 
+/**
+ * Postiz `MediaFile` shape returned by both /upload and /upload-from-url.
+ * The earlier `thumbnail` / `alt` fields were speculative and aren't part of
+ * the documented response. Confirmed against docs.postiz.com on 2026-06-16. */
 export interface UploadedFile {
   id: string;
-  /** Empty string when uploaded by URL. */
   name: string;
   /** Full URL to the uploaded media. */
   path: string;
-  thumbnail: string | null;
-  alt: string | null;
+  organizationId?: string;
+  createdAt?: string;
+  updatedAt?: string;
 }
+
+/** MIME types the Postiz `/upload` endpoint will accept. The backend
+ *  sniffs the actual content (not just the extension) and 4xxs anything
+ *  outside this list — enforcing here lets us fail fast and surface a
+ *  useful error before the round-trip to Postiz. */
+export const POSTIZ_ALLOWED_UPLOAD_MIME = new Set<string>([
+  "image/jpeg",
+  "image/png",
+  "image/gif",
+  "image/webp",
+  "image/avif",
+  "image/bmp",
+  "image/tiff",
+  "video/mp4",
+]);
 
 /** Throwing variant of `listPostizIntegrations` for /admin/postiz routes.
  *
@@ -271,12 +310,23 @@ export function createPost(
   });
 }
 
-/** Delete a post. Swallows 404 ("already deleted") per Postiz docs. */
+/** Delete a post.
+ *
+ * Per docs.postiz.com / API Overview, `DELETE` on a missing post should
+ * return 404 — but there's a documented known issue where a missing post id
+ * surfaces as a 500 instead. We swallow 404 unconditionally, and we swallow
+ * 500 only when the body text looks like a "not found" response (so we
+ * don't accidentally hide a real upstream crash). Anything else propagates. */
 export async function deletePost(id: string): Promise<void> {
   try {
     await callThrowing<void>(`/posts/${encodeURIComponent(id)}`, { method: "DELETE" });
   } catch (err) {
-    if (err instanceof PostizApiError && err.status === 404) return;
+    if (err instanceof PostizApiError) {
+      if (err.status === 404) return;
+      if (err.status === 500 && /not\s*found|no\s*such|cannot find/i.test(err.body)) {
+        return;
+      }
+    }
     throw err;
   }
 }
@@ -319,11 +369,24 @@ export function updatePost(
   );
 }
 
-/** Per-post analytics, when the channel supports it. Postiz exposes
- *  GET /posts/:id/statistics; shape varies by provider so we keep it loose. */
-export function getPostStats(id: string): Promise<Record<string, unknown>> {
-  return callThrowing<Record<string, unknown>>(
-    `/posts/${encodeURIComponent(id)}/statistics`
+/** One metric in a Postiz post-analytics response (`/analytics/post/:id`). */
+export interface PostizAnalyticsMetric {
+  label: string;
+  data: Array<{ total: string; date: string }>;
+  percentageChange: number;
+}
+
+/** Per-post analytics. The documented endpoint is
+ *  `GET /analytics/post/:postId?date=<lookback-days>` — NOT the
+ *  `/posts/:id/statistics` shape that was previously guessed here. The lookback
+ *  window must be supplied; common values are 7, 30, 90. Empty array is
+ *  returned for providers that don't surface per-post analytics. */
+export function getPostStats(
+  id: string,
+  lookbackDays: 7 | 14 | 30 | 60 | 90 = 7
+): Promise<PostizAnalyticsMetric[]> {
+  return callThrowing<PostizAnalyticsMetric[]>(
+    `/analytics/post/${encodeURIComponent(id)}?date=${lookbackDays}`
   );
 }
 


### PR DESCRIPTION
## Problem

The `build-pi-image.yml` workflow fails on every run with `FATAL ERROR: CALL_AND_RETRY_LAST Allocation failed - JavaScript heap out of memory` when running `pnpm build` under QEMU arm64 emulation on x86_64 GitHub runners.

This cascades to the `HA sync orchestrator` workflow which waits for the pi build to succeed.

## Root Cause

`Dockerfile` line 53 set `NODE_OPTIONS=\--max-old-space-size=768\` — only 768MB heap for Node.js. Under QEMU emulation, the Next.js build process needs significantly more memory.

## Fix

Bumped `--max-old-space-size` from 768 to 8192 (8GB), matching the default GitHub runner RAM capacity.

## Verification

- `build-pi-image.yml`: Will now have enough heap to complete `pnpm build` under QEMU arm64
- `HA sync orchestrator`: Will pass once the pi build succeeds (cascading dependency)
- `Lighthouse Audit`: Unrelated score-threshold issue, not addressed here