### PR TITLE
feat(postiz/infra): RESTRICT_UPLOAD_DOMAINS allowlist for upload-from-url

### DIFF
--- a/infrastructure/postiz/helm/postiz/templates/postiz.yaml
+++ b/infrastructure/postiz/helm/postiz/templates/postiz.yaml
@@ -71,6 +71,10 @@ spec:
               value: {{ .Values.postiz.uploadDirectory | quote }}
             - name: NEXT_PUBLIC_UPLOAD_DIRECTORY
               value: {{ .Values.postiz.uploadDirectory | quote }}
+            {{- with .Values.postiz.restrictUploadDomains }}
+            - name: RESTRICT_UPLOAD_DOMAINS
+              value: {{ . | quote }}
+            {{- end }}
           volumeMounts:
             - name: uploads
               mountPath: /uploads

--- a/infrastructure/postiz/helm/postiz/values.yaml
+++ b/infrastructure/postiz/helm/postiz/values.yaml
@@ -35,6 +35,13 @@ postiz:
   disableRegistration: "true"
   storageProvider: "local"
   uploadDirectory: "/uploads"
+  # Server-side allowlist for POST /public/v1/upload-from-url
+  # (docs.postiz.com → Configuration Reference → RESTRICT_UPLOAD_DOMAINS).
+  # Comma-separated list of hostnames Postiz will fetch from. Defense in
+  # depth on top of the route's own SSRF prefilter in
+  # src/app/api/admin/postiz/upload/route.ts — leave commented to allow any
+  # public URL; set when you want to restrict to your own CDNs.
+  restrictUploadDomains: "cloudless.gr,uploads.postiz.cloudless.gr"
   resources:
     requests:
       cpu: "200m"

--- a/infrastructure/postiz/k8s/postiz.yaml
+++ b/infrastructure/postiz/k8s/postiz.yaml
@@ -256,6 +256,13 @@ spec:
               value: "/uploads"
             - name: NEXT_PUBLIC_UPLOAD_DIRECTORY
               value: "/uploads"
+            # Server-side allowlist for POST /public/v1/upload-from-url, per
+            # docs.postiz.com → Configuration Reference. Defense in depth on
+            # top of the route-level SSRF prefilter in src/app/api/admin/
+            # postiz/upload/route.ts. Only hostnames in this comma-separated
+            # list will be fetched by Postiz; everything else is rejected.
+            - name: RESTRICT_UPLOAD_DOMAINS
+              value: "cloudless.gr,uploads.postiz.cloudless.gr"
           volumeMounts:
             - name: uploads
               mountPath: /uploads


### PR DESCRIPTION
Documented Postiz knob we werent setting. Allowlist hostnames Postiz will fetch from in /upload-from-url. Both files updated (k8s manifest + helm chart).