### PR TITLE
feat(postiz): complete Public API coverage per docs.postiz.com

### DIFF
--- a/__tests__/postiz.test.ts
+++ b/__tests__/postiz.test.ts
@@ -9,12 +9,22 @@ vi.mock("@/lib/ssm-config", () => ({ getConfig: mockGetConfig }));
 vi.stubGlobal("fetch", mockFetch);
 
 import {
+  changePostStatus,
   createPost,
+  deleteIntegration,
   deletePost,
+  deletePostsByGroup,
   findSlot,
+  getIntegrationAnalytics,
+  getIntegrationConnectUrl,
+  getIntegrationSettings,
+  getPostMissingContent,
   getPostStats,
+  isApiKeyValid,
   isPostizConfigured,
+  listGroups,
   listIntegrations,
+  listNotifications,
   listPostizIntegrations,
   listPosts,
   matchIntegrationsForPlatform,
@@ -23,7 +33,9 @@ import {
   PostizApiError,
   PostizNotConfiguredError,
   schedulePost,
+  triggerIntegrationTool,
   updatePost,
+  updatePostReleaseId,
   uploadFile,
   uploadFromUrl,
   verifyPostizWebhookSignature,
@@ -280,6 +292,140 @@ describe("postIdentifier helper", () => {
 
   it("returns empty string when neither field is set", () => {
     expect(postIdentifier({ integration: { id: "i", name: "n" } })).toBe("");
+  });
+});
+
+describe("deletePostsByGroup", () => {
+  it("DELETEs /posts/group/:group and URL-encodes the id", async () => {
+    mockFetch.mockResolvedValueOnce(jsonResponse({ id: "grp-1" }));
+    await expect(deletePostsByGroup("grp/1")).resolves.toEqual({ id: "grp-1" });
+    const [url, init] = mockFetch.mock.calls[0];
+    expect(url).toContain("/posts/group/grp%2F1");
+    expect(init.method).toBe("DELETE");
+  });
+});
+
+describe("changePostStatus", () => {
+  it("PUTs /posts/:id/status with the status body and returns {id,state}", async () => {
+    mockFetch.mockResolvedValueOnce(jsonResponse({ id: "p1", state: "QUEUE" }));
+    const result = await changePostStatus("p1", "schedule");
+    expect(result).toEqual({ id: "p1", state: "QUEUE" });
+    const [url, init] = mockFetch.mock.calls[0];
+    expect(url).toContain("/posts/p1/status");
+    expect(init.method).toBe("PUT");
+    expect(JSON.parse(init.body)).toEqual({ status: "schedule" });
+  });
+});
+
+describe("getPostMissingContent", () => {
+  it("GETs /posts/:id/missing-content", async () => {
+    const items = [{ id: "x1", url: "https://x.com/post/1" }];
+    mockFetch.mockResolvedValueOnce(jsonResponse(items));
+    await expect(getPostMissingContent("p1")).resolves.toEqual(items);
+    const [url] = mockFetch.mock.calls[0];
+    expect(url).toContain("/posts/p1/missing-content");
+  });
+});
+
+describe("updatePostReleaseId", () => {
+  it("PUTs /posts/:id/release-id with the new release id", async () => {
+    mockFetch.mockResolvedValueOnce(jsonResponse({ id: "p1", releaseId: "r1" }));
+    const r = await updatePostReleaseId("p1", "r1");
+    expect(r).toEqual({ id: "p1", releaseId: "r1" });
+    const [, init] = mockFetch.mock.calls[0];
+    expect(JSON.parse(init.body)).toEqual({ releaseId: "r1" });
+  });
+});
+
+describe("listGroups", () => {
+  it("GETs /groups and returns the array", async () => {
+    const groups = [{ id: "g1", name: "Acme" }];
+    mockFetch.mockResolvedValueOnce(jsonResponse(groups));
+    await expect(listGroups()).resolves.toEqual(groups);
+    const [url] = mockFetch.mock.calls[0];
+    expect(url).toMatch(/\/groups$/);
+  });
+});
+
+describe("isApiKeyValid", () => {
+  it("GETs /integrations/is-connected", async () => {
+    mockFetch.mockResolvedValueOnce(jsonResponse({ connected: true }));
+    await expect(isApiKeyValid()).resolves.toEqual({ connected: true });
+    const [url] = mockFetch.mock.calls[0];
+    expect(url).toContain("/integrations/is-connected");
+  });
+
+  it("propagates 401 as PostizApiError so the admin route can map it", async () => {
+    mockFetch.mockResolvedValueOnce(jsonResponse({ error: "no" }, 401));
+    await expect(isApiKeyValid()).rejects.toBeInstanceOf(PostizApiError);
+  });
+});
+
+describe("deleteIntegration", () => {
+  it("DELETEs /integrations/:id and URL-encodes", async () => {
+    mockFetch.mockResolvedValueOnce(new Response(null, { status: 204 }));
+    await expect(deleteIntegration("i/1")).resolves.toBeUndefined();
+    const [url, init] = mockFetch.mock.calls[0];
+    expect(url).toContain("/integrations/i%2F1");
+    expect(init.method).toBe("DELETE");
+  });
+});
+
+describe("getIntegrationConnectUrl", () => {
+  it("GETs /integrations/:provider/connect", async () => {
+    mockFetch.mockResolvedValueOnce(jsonResponse({ url: "https://oauth.example/start" }));
+    await expect(getIntegrationConnectUrl("facebook")).resolves.toEqual({
+      url: "https://oauth.example/start",
+    });
+    const [url] = mockFetch.mock.calls[0];
+    expect(url).toContain("/integrations/facebook/connect");
+  });
+});
+
+describe("getIntegrationSettings", () => {
+  it("GETs /integrations/:id/settings", async () => {
+    const settings = { maxLength: 280, tools: ["search"] };
+    mockFetch.mockResolvedValueOnce(jsonResponse(settings));
+    await expect(getIntegrationSettings("int-1")).resolves.toEqual(settings);
+    const [url] = mockFetch.mock.calls[0];
+    expect(url).toContain("/integrations/int-1/settings");
+  });
+});
+
+describe("triggerIntegrationTool", () => {
+  it("POSTs the tool body to /integrations/:id/trigger", async () => {
+    mockFetch.mockResolvedValueOnce(jsonResponse({ items: ["a", "b"] }));
+    await triggerIntegrationTool("int-1", { tool: "search-audio", data: { q: "lofi" } });
+    const [url, init] = mockFetch.mock.calls[0];
+    expect(url).toContain("/integrations/int-1/trigger");
+    expect(init.method).toBe("POST");
+    expect(JSON.parse(init.body)).toEqual({ tool: "search-audio", data: { q: "lofi" } });
+  });
+});
+
+describe("listNotifications", () => {
+  it("GETs /notifications with the page param", async () => {
+    mockFetch.mockResolvedValueOnce(jsonResponse([]));
+    await listNotifications(3);
+    const [url] = mockFetch.mock.calls[0];
+    expect(url).toContain("/notifications?page=3");
+  });
+
+  it("defaults page=1", async () => {
+    mockFetch.mockResolvedValueOnce(jsonResponse([]));
+    await listNotifications();
+    const [url] = mockFetch.mock.calls[0];
+    expect(url).toContain("/notifications?page=1");
+  });
+});
+
+describe("getIntegrationAnalytics", () => {
+  it("GETs /analytics/integration/:id with the date window", async () => {
+    mockFetch.mockResolvedValueOnce(jsonResponse([]));
+    await getIntegrationAnalytics("int-1", 30);
+    const [url] = mockFetch.mock.calls[0];
+    expect(url).toContain("/analytics/integration/int-1");
+    expect(url).toContain("date=30");
   });
 });
 

--- a/e2e/api-routes-gaps-sweep.spec.ts
+++ b/e2e/api-routes-gaps-sweep.spec.ts
@@ -105,6 +105,14 @@ test.describe("Admin API gap sweep (authenticated GETs)", () => {
     `/api/admin/postiz/slot?id=${SENTINEL_ID}`,
     "/api/admin/postiz/health",
     "/api/admin/postiz/health?format=prom",
+    "/api/admin/postiz/is-connected",
+    "/api/admin/postiz/groups",
+    "/api/admin/postiz/notifications",
+    `/api/admin/postiz/integrations/${SENTINEL_ID}/connect`,
+    `/api/admin/postiz/integrations/${SENTINEL_ID}/settings`,
+    `/api/admin/postiz/posts/${SENTINEL_ID}/missing-content`,
+    `/api/admin/postiz/analytics/post/${SENTINEL_ID}`,
+    `/api/admin/postiz/analytics/integration/${SENTINEL_ID}`,
     `/api/admin/reports/${SENTINEL_ID}`,
     `/api/admin/reports/${SENTINEL_ID}/pdf`,
   ] as const;
@@ -129,6 +137,7 @@ test.describe("Admin API gap sweep (authenticated POSTs)", () => {
     "/api/admin/postiz/posts",
     "/api/admin/postiz/upload",
     "/api/admin/postiz/upload-file",
+    `/api/admin/postiz/integrations/${SENTINEL_ID}/trigger`,
   ] as const;
 
   for (const url of ADMIN_POST_GAPS) {
@@ -164,6 +173,32 @@ test.describe("Admin API gap sweep (authenticated PUTs)", () => {
     expect([401, 403]).not.toContain(r.status());
     expect(r.status()).toBeGreaterThanOrEqual(200);
   });
+
+  for (const url of [
+    `/api/admin/postiz/posts/${SENTINEL_ID}/status`,
+    `/api/admin/postiz/posts/${SENTINEL_ID}/release-id`,
+  ] as const) {
+    test(`PUT ${url} (empty body)`, async ({ request }) => {
+      const a = await adminRequest(request);
+      const r = await a.put(url, { data: {} });
+      expect([401, 403]).not.toContain(r.status());
+      expect(r.status()).toBeGreaterThanOrEqual(200);
+    });
+  }
+});
+
+test.describe("Admin API gap sweep — extra DELETEs (Postiz)", () => {
+  for (const url of [
+    `/api/admin/postiz/posts/group/${SENTINEL_ID}`,
+    `/api/admin/postiz/integrations/${SENTINEL_ID}`,
+  ] as const) {
+    test(`DELETE ${url}`, async ({ request }) => {
+      const a = await adminRequest(request);
+      const r = await a.delete(url);
+      expect([401, 403]).not.toContain(r.status());
+      expect(r.status()).toBeGreaterThanOrEqual(200);
+    });
+  }
 });
 
 test.describe("Postiz cron endpoints (unauthenticated — reject without 5xx)", () => {

--- a/src/app/api/admin/postiz/analytics/integration/[id]/route.ts
+++ b/src/app/api/admin/postiz/analytics/integration/[id]/route.ts
@@ -1,0 +1,44 @@
+import { NextRequest, NextResponse } from "next/server";
+import { requireAdmin } from "@/lib/api-auth";
+import {
+  getIntegrationAnalytics,
+  PostizApiError,
+  PostizNotConfiguredError,
+} from "@/lib/postiz";
+
+export const dynamic = "force-dynamic";
+
+const ALLOWED_LOOKBACK = new Set([7, 14, 30, 60, 90]);
+
+function parseLookback(raw: string | null): 7 | 14 | 30 | 60 | 90 {
+  const n = Number.parseInt(raw ?? "7", 10);
+  return (ALLOWED_LOOKBACK.has(n) ? n : 7) as 7 | 14 | 30 | 60 | 90;
+}
+
+/** GET /api/admin/postiz/analytics/integration/:id?date=7 — per-channel
+ *  analytics (followers, impressions, etc., shape varies by provider). */
+export async function GET(req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+  const auth = await requireAdmin(req);
+  if (!auth.ok) return auth.response;
+
+  const { id } = await params;
+  if (!id) return NextResponse.json({ error: "missing_id" }, { status: 400 });
+
+  const lookback = parseLookback(new URL(req.url).searchParams.get("date"));
+
+  try {
+    const metrics = await getIntegrationAnalytics(id, lookback);
+    return NextResponse.json({ metrics, lookbackDays: lookback });
+  } catch (err) {
+    if (err instanceof PostizNotConfiguredError) {
+      return NextResponse.json({ error: "postiz_not_configured" }, { status: 503 });
+    }
+    if (err instanceof PostizApiError) {
+      return NextResponse.json(
+        { error: "postiz_upstream", status: err.status, body: err.body },
+        { status: 502 }
+      );
+    }
+    throw err;
+  }
+}

--- a/src/app/api/admin/postiz/analytics/post/[id]/route.ts
+++ b/src/app/api/admin/postiz/analytics/post/[id]/route.ts
@@ -1,0 +1,39 @@
+import { NextRequest, NextResponse } from "next/server";
+import { requireAdmin } from "@/lib/api-auth";
+import { getPostStats, PostizApiError, PostizNotConfiguredError } from "@/lib/postiz";
+
+export const dynamic = "force-dynamic";
+
+const ALLOWED_LOOKBACK = new Set([7, 14, 30, 60, 90]);
+
+function parseLookback(raw: string | null): 7 | 14 | 30 | 60 | 90 {
+  const n = Number.parseInt(raw ?? "7", 10);
+  return (ALLOWED_LOOKBACK.has(n) ? n : 7) as 7 | 14 | 30 | 60 | 90;
+}
+
+/** GET /api/admin/postiz/analytics/post/:id?date=7 — per-post analytics. */
+export async function GET(req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+  const auth = await requireAdmin(req);
+  if (!auth.ok) return auth.response;
+
+  const { id } = await params;
+  if (!id) return NextResponse.json({ error: "missing_id" }, { status: 400 });
+
+  const lookback = parseLookback(new URL(req.url).searchParams.get("date"));
+
+  try {
+    const metrics = await getPostStats(id, lookback);
+    return NextResponse.json({ metrics, lookbackDays: lookback });
+  } catch (err) {
+    if (err instanceof PostizNotConfiguredError) {
+      return NextResponse.json({ error: "postiz_not_configured" }, { status: 503 });
+    }
+    if (err instanceof PostizApiError) {
+      return NextResponse.json(
+        { error: "postiz_upstream", status: err.status, body: err.body },
+        { status: 502 }
+      );
+    }
+    throw err;
+  }
+}

--- a/src/app/api/admin/postiz/groups/route.ts
+++ b/src/app/api/admin/postiz/groups/route.ts
@@ -1,0 +1,27 @@
+import { NextRequest, NextResponse } from "next/server";
+import { requireAdmin } from "@/lib/api-auth";
+import { listGroups, PostizApiError, PostizNotConfiguredError } from "@/lib/postiz";
+
+export const dynamic = "force-dynamic";
+
+/** GET /api/admin/postiz/groups — list customer (group) tags from Postiz. */
+export async function GET(req: NextRequest) {
+  const auth = await requireAdmin(req);
+  if (!auth.ok) return auth.response;
+
+  try {
+    const groups = await listGroups();
+    return NextResponse.json({ groups });
+  } catch (err) {
+    if (err instanceof PostizNotConfiguredError) {
+      return NextResponse.json({ error: "postiz_not_configured" }, { status: 503 });
+    }
+    if (err instanceof PostizApiError) {
+      return NextResponse.json(
+        { error: "postiz_upstream", status: err.status, body: err.body },
+        { status: 502 }
+      );
+    }
+    throw err;
+  }
+}

--- a/src/app/api/admin/postiz/integrations/[id]/connect/route.ts
+++ b/src/app/api/admin/postiz/integrations/[id]/connect/route.ts
@@ -1,0 +1,37 @@
+import { NextRequest, NextResponse } from "next/server";
+import { requireAdmin } from "@/lib/api-auth";
+import {
+  getIntegrationConnectUrl,
+  PostizApiError,
+  PostizNotConfiguredError,
+} from "@/lib/postiz";
+
+export const dynamic = "force-dynamic";
+
+/** GET /api/admin/postiz/integrations/:id/connect — returns an OAuth URL the
+ *  user opens to connect a new channel of that provider. The `:id` here is
+ *  the *provider identifier* (`facebook`, `linkedin`, `tiktok`, ...) not an
+ *  existing integration. */
+export async function GET(req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+  const auth = await requireAdmin(req);
+  if (!auth.ok) return auth.response;
+
+  const { id } = await params;
+  if (!id) return NextResponse.json({ error: "missing_provider" }, { status: 400 });
+
+  try {
+    const result = await getIntegrationConnectUrl(id);
+    return NextResponse.json(result);
+  } catch (err) {
+    if (err instanceof PostizNotConfiguredError) {
+      return NextResponse.json({ error: "postiz_not_configured" }, { status: 503 });
+    }
+    if (err instanceof PostizApiError) {
+      return NextResponse.json(
+        { error: "postiz_upstream", status: err.status, body: err.body },
+        { status: 502 }
+      );
+    }
+    throw err;
+  }
+}

--- a/src/app/api/admin/postiz/integrations/[id]/route.ts
+++ b/src/app/api/admin/postiz/integrations/[id]/route.ts
@@ -1,0 +1,37 @@
+import { NextRequest, NextResponse } from "next/server";
+import { requireAdmin } from "@/lib/api-auth";
+import {
+  deleteIntegration,
+  PostizApiError,
+  PostizNotConfiguredError,
+} from "@/lib/postiz";
+
+export const dynamic = "force-dynamic";
+
+/** DELETE /api/admin/postiz/integrations/:id — disconnects a channel and
+ *  cascades to any scheduled posts on it. */
+export async function DELETE(req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+  const auth = await requireAdmin(req);
+  if (!auth.ok) return auth.response;
+
+  const { id } = await params;
+  if (!id) return NextResponse.json({ error: "missing_id" }, { status: 400 });
+
+  try {
+    await deleteIntegration(id);
+    return NextResponse.json({ deleted: true });
+  } catch (err) {
+    if (err instanceof PostizNotConfiguredError) {
+      return NextResponse.json({ error: "postiz_not_configured" }, { status: 503 });
+    }
+    if (err instanceof PostizApiError) {
+      // Idempotent for 404 — already gone.
+      if (err.status === 404) return NextResponse.json({ deleted: true });
+      return NextResponse.json(
+        { error: "postiz_upstream", status: err.status, body: err.body },
+        { status: 502 }
+      );
+    }
+    throw err;
+  }
+}

--- a/src/app/api/admin/postiz/integrations/[id]/settings/route.ts
+++ b/src/app/api/admin/postiz/integrations/[id]/settings/route.ts
@@ -1,0 +1,35 @@
+import { NextRequest, NextResponse } from "next/server";
+import { requireAdmin } from "@/lib/api-auth";
+import {
+  getIntegrationSettings,
+  PostizApiError,
+  PostizNotConfiguredError,
+} from "@/lib/postiz";
+
+export const dynamic = "force-dynamic";
+
+/** GET /api/admin/postiz/integrations/:id/settings — posting rules, content
+ *  max-length, settings JSON schema, available provider tools. */
+export async function GET(req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+  const auth = await requireAdmin(req);
+  if (!auth.ok) return auth.response;
+
+  const { id } = await params;
+  if (!id) return NextResponse.json({ error: "missing_id" }, { status: 400 });
+
+  try {
+    const settings = await getIntegrationSettings(id);
+    return NextResponse.json(settings);
+  } catch (err) {
+    if (err instanceof PostizNotConfiguredError) {
+      return NextResponse.json({ error: "postiz_not_configured" }, { status: 503 });
+    }
+    if (err instanceof PostizApiError) {
+      return NextResponse.json(
+        { error: "postiz_upstream", status: err.status, body: err.body },
+        { status: 502 }
+      );
+    }
+    throw err;
+  }
+}

--- a/src/app/api/admin/postiz/integrations/[id]/trigger/route.ts
+++ b/src/app/api/admin/postiz/integrations/[id]/trigger/route.ts
@@ -1,0 +1,48 @@
+import { NextRequest, NextResponse } from "next/server";
+import { requireAdmin } from "@/lib/api-auth";
+import {
+  triggerIntegrationTool,
+  PostizApiError,
+  PostizNotConfiguredError,
+} from "@/lib/postiz";
+
+export const dynamic = "force-dynamic";
+
+/** POST /api/admin/postiz/integrations/:id/trigger — execute a
+ *  provider-specific tool (e.g. listing Discord channels, fetching Reddit
+ *  flairs). Body: `{ tool: string, data?: object }`. */
+export async function POST(req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+  const auth = await requireAdmin(req);
+  if (!auth.ok) return auth.response;
+
+  const { id } = await params;
+  if (!id) return NextResponse.json({ error: "missing_id" }, { status: 400 });
+
+  let body: { tool?: unknown; data?: unknown };
+  try {
+    body = (await req.json()) as { tool?: unknown; data?: unknown };
+  } catch {
+    return NextResponse.json({ error: "invalid_json" }, { status: 400 });
+  }
+  if (typeof body.tool !== "string" || !body.tool) {
+    return NextResponse.json({ error: "missing_tool" }, { status: 400 });
+  }
+
+  try {
+    const data =
+      body.data && typeof body.data === "object" ? (body.data as Record<string, unknown>) : undefined;
+    const result = await triggerIntegrationTool(id, { tool: body.tool, data });
+    return NextResponse.json(result);
+  } catch (err) {
+    if (err instanceof PostizNotConfiguredError) {
+      return NextResponse.json({ error: "postiz_not_configured" }, { status: 503 });
+    }
+    if (err instanceof PostizApiError) {
+      return NextResponse.json(
+        { error: "postiz_upstream", status: err.status, body: err.body },
+        { status: 502 }
+      );
+    }
+    throw err;
+  }
+}

--- a/src/app/api/admin/postiz/is-connected/route.ts
+++ b/src/app/api/admin/postiz/is-connected/route.ts
@@ -1,0 +1,32 @@
+import { NextRequest, NextResponse } from "next/server";
+import { requireAdmin } from "@/lib/api-auth";
+import { isApiKeyValid, PostizApiError, PostizNotConfiguredError } from "@/lib/postiz";
+
+export const dynamic = "force-dynamic";
+
+/** GET /api/admin/postiz/is-connected — round-trip to Postiz to check the
+ *  configured API key actually authenticates upstream. Distinct from
+ *  /health which only checks reachability. */
+export async function GET(req: NextRequest) {
+  const auth = await requireAdmin(req);
+  if (!auth.ok) return auth.response;
+
+  try {
+    const result = await isApiKeyValid();
+    return NextResponse.json(result);
+  } catch (err) {
+    if (err instanceof PostizNotConfiguredError) {
+      return NextResponse.json({ connected: false, error: "postiz_not_configured" }, { status: 503 });
+    }
+    if (err instanceof PostizApiError) {
+      if (err.status === 401 || err.status === 403) {
+        return NextResponse.json({ connected: false, error: "invalid_api_key" }, { status: 401 });
+      }
+      return NextResponse.json(
+        { connected: false, error: "postiz_upstream", status: err.status, body: err.body },
+        { status: 502 }
+      );
+    }
+    throw err;
+  }
+}

--- a/src/app/api/admin/postiz/notifications/route.ts
+++ b/src/app/api/admin/postiz/notifications/route.ts
@@ -1,0 +1,30 @@
+import { NextRequest, NextResponse } from "next/server";
+import { requireAdmin } from "@/lib/api-auth";
+import { listNotifications, PostizApiError, PostizNotConfiguredError } from "@/lib/postiz";
+
+export const dynamic = "force-dynamic";
+
+/** GET /api/admin/postiz/notifications?page=N — newest 100 per page. */
+export async function GET(req: NextRequest) {
+  const auth = await requireAdmin(req);
+  if (!auth.ok) return auth.response;
+
+  const pageRaw = new URL(req.url).searchParams.get("page");
+  const page = Math.max(1, Number.parseInt(pageRaw ?? "1", 10) || 1);
+
+  try {
+    const items = await listNotifications(page);
+    return NextResponse.json({ items, page });
+  } catch (err) {
+    if (err instanceof PostizNotConfiguredError) {
+      return NextResponse.json({ error: "postiz_not_configured" }, { status: 503 });
+    }
+    if (err instanceof PostizApiError) {
+      return NextResponse.json(
+        { error: "postiz_upstream", status: err.status, body: err.body },
+        { status: 502 }
+      );
+    }
+    throw err;
+  }
+}

--- a/src/app/api/admin/postiz/posts/[id]/missing-content/route.ts
+++ b/src/app/api/admin/postiz/posts/[id]/missing-content/route.ts
@@ -1,0 +1,36 @@
+import { NextRequest, NextResponse } from "next/server";
+import { requireAdmin } from "@/lib/api-auth";
+import {
+  getPostMissingContent,
+  PostizApiError,
+  PostizNotConfiguredError,
+} from "@/lib/postiz";
+
+export const dynamic = "force-dynamic";
+
+/** GET /api/admin/postiz/posts/:id/missing-content — list recent content
+ *  from the provider so the user can match the right published post when
+ *  `releaseId === "missing"`. */
+export async function GET(req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+  const auth = await requireAdmin(req);
+  if (!auth.ok) return auth.response;
+
+  const { id } = await params;
+  if (!id) return NextResponse.json({ error: "missing_id" }, { status: 400 });
+
+  try {
+    const items = await getPostMissingContent(id);
+    return NextResponse.json({ items });
+  } catch (err) {
+    if (err instanceof PostizNotConfiguredError) {
+      return NextResponse.json({ error: "postiz_not_configured" }, { status: 503 });
+    }
+    if (err instanceof PostizApiError) {
+      return NextResponse.json(
+        { error: "postiz_upstream", status: err.status, body: err.body },
+        { status: 502 }
+      );
+    }
+    throw err;
+  }
+}

--- a/src/app/api/admin/postiz/posts/[id]/release-id/route.ts
+++ b/src/app/api/admin/postiz/posts/[id]/release-id/route.ts
@@ -1,0 +1,46 @@
+import { NextRequest, NextResponse } from "next/server";
+import { requireAdmin } from "@/lib/api-auth";
+import {
+  updatePostReleaseId,
+  PostizApiError,
+  PostizNotConfiguredError,
+} from "@/lib/postiz";
+
+export const dynamic = "force-dynamic";
+
+/** PUT /api/admin/postiz/posts/:id/release-id
+ *  Body: `{ releaseId: string }`. Connects a "missing" post to the real
+ *  platform post-id. */
+export async function PUT(req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+  const auth = await requireAdmin(req);
+  if (!auth.ok) return auth.response;
+
+  const { id } = await params;
+  if (!id) return NextResponse.json({ error: "missing_id" }, { status: 400 });
+
+  let body: { releaseId?: unknown };
+  try {
+    body = (await req.json()) as { releaseId?: unknown };
+  } catch {
+    return NextResponse.json({ error: "invalid_json" }, { status: 400 });
+  }
+  if (typeof body.releaseId !== "string" || !body.releaseId) {
+    return NextResponse.json({ error: "missing_release_id" }, { status: 400 });
+  }
+
+  try {
+    const result = await updatePostReleaseId(id, body.releaseId);
+    return NextResponse.json(result);
+  } catch (err) {
+    if (err instanceof PostizNotConfiguredError) {
+      return NextResponse.json({ error: "postiz_not_configured" }, { status: 503 });
+    }
+    if (err instanceof PostizApiError) {
+      return NextResponse.json(
+        { error: "postiz_upstream", status: err.status, body: err.body },
+        { status: 502 }
+      );
+    }
+    throw err;
+  }
+}

--- a/src/app/api/admin/postiz/posts/[id]/status/route.ts
+++ b/src/app/api/admin/postiz/posts/[id]/status/route.ts
@@ -1,0 +1,48 @@
+import { NextRequest, NextResponse } from "next/server";
+import { requireAdmin } from "@/lib/api-auth";
+import {
+  changePostStatus,
+  PostizApiError,
+  PostizNotConfiguredError,
+} from "@/lib/postiz";
+
+export const dynamic = "force-dynamic";
+
+/** PUT /api/admin/postiz/posts/:id/status
+ *  Body: `{ status: "draft" | "schedule" }`. */
+export async function PUT(req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+  const auth = await requireAdmin(req);
+  if (!auth.ok) return auth.response;
+
+  const { id } = await params;
+  if (!id) return NextResponse.json({ error: "missing_id" }, { status: 400 });
+
+  let body: { status?: unknown };
+  try {
+    body = (await req.json()) as { status?: unknown };
+  } catch {
+    return NextResponse.json({ error: "invalid_json" }, { status: 400 });
+  }
+  if (body.status !== "draft" && body.status !== "schedule") {
+    return NextResponse.json(
+      { error: "invalid_status", allowed: ["draft", "schedule"] },
+      { status: 400 }
+    );
+  }
+
+  try {
+    const result = await changePostStatus(id, body.status);
+    return NextResponse.json(result);
+  } catch (err) {
+    if (err instanceof PostizNotConfiguredError) {
+      return NextResponse.json({ error: "postiz_not_configured" }, { status: 503 });
+    }
+    if (err instanceof PostizApiError) {
+      return NextResponse.json(
+        { error: "postiz_upstream", status: err.status, body: err.body },
+        { status: err.status === 400 ? 400 : 502 }
+      );
+    }
+    throw err;
+  }
+}

--- a/src/app/api/admin/postiz/posts/group/[id]/route.ts
+++ b/src/app/api/admin/postiz/posts/group/[id]/route.ts
@@ -1,0 +1,36 @@
+import { NextRequest, NextResponse } from "next/server";
+import { requireAdmin } from "@/lib/api-auth";
+import {
+  deletePostsByGroup,
+  PostizApiError,
+  PostizNotConfiguredError,
+} from "@/lib/postiz";
+
+export const dynamic = "force-dynamic";
+
+/** DELETE /api/admin/postiz/posts/group/:id — deletes every post in the group. */
+export async function DELETE(req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+  const auth = await requireAdmin(req);
+  if (!auth.ok) return auth.response;
+
+  const { id } = await params;
+  if (!id) return NextResponse.json({ error: "missing_group_id" }, { status: 400 });
+
+  try {
+    const result = await deletePostsByGroup(id);
+    return NextResponse.json({ deleted: true, ...result });
+  } catch (err) {
+    if (err instanceof PostizNotConfiguredError) {
+      return NextResponse.json({ error: "postiz_not_configured" }, { status: 503 });
+    }
+    if (err instanceof PostizApiError) {
+      // 404 → "already deleted" semantics; treat as success per docs.
+      if (err.status === 404) return NextResponse.json({ deleted: true });
+      return NextResponse.json(
+        { error: "postiz_upstream", status: err.status, body: err.body },
+        { status: 502 }
+      );
+    }
+    throw err;
+  }
+}

--- a/src/lib/postiz.ts
+++ b/src/lib/postiz.ts
@@ -410,6 +410,131 @@ export async function uploadFile(file: Blob, filename: string): Promise<Uploaded
   return (await res.json()) as UploadedFile;
 }
 
+// --- Full Public-API coverage per docs.postiz.com ------------------------
+
+/** Delete every post in a group with a single call. */
+export function deletePostsByGroup(group: string): Promise<{ id: string }> {
+  return callThrowing<{ id: string }>(`/posts/group/${encodeURIComponent(group)}`, {
+    method: "DELETE",
+  });
+}
+
+/** Move a post between `draft` and `schedule` state. Date is preserved.
+ *  `schedule` → state QUEUE (workflow restarted), `draft` → state DRAFT
+ *  (workflow terminated). */
+export function changePostStatus(
+  id: string,
+  status: "draft" | "schedule"
+): Promise<{ id: string; state: "DRAFT" | "QUEUE" }> {
+  return callThrowing<{ id: string; state: "DRAFT" | "QUEUE" }>(
+    `/posts/${encodeURIComponent(id)}/status`,
+    {
+      method: "PUT",
+      body: JSON.stringify({ status }),
+    }
+  );
+}
+
+/** When Postiz publishes but can't get a real post-id back from the platform
+ *  (`releaseId === "missing"`), this lists recent content from the provider
+ *  so you can match and connect the right one. */
+export interface PostizMissingContentItem {
+  id: string;
+  url: string;
+}
+export function getPostMissingContent(id: string): Promise<PostizMissingContentItem[]> {
+  return callThrowing<PostizMissingContentItem[]>(
+    `/posts/${encodeURIComponent(id)}/missing-content`
+  );
+}
+
+/** Connect a missing post to the real platform post-id, restoring
+ *  analytics + statistics tracking. */
+export function updatePostReleaseId(
+  id: string,
+  releaseId: string
+): Promise<{ id: string; releaseId: string }> {
+  return callThrowing<{ id: string; releaseId: string }>(
+    `/posts/${encodeURIComponent(id)}/release-id`,
+    {
+      method: "PUT",
+      body: JSON.stringify({ releaseId }),
+    }
+  );
+}
+
+/** A customer group — the API counterpart of the multi-tenancy UI. */
+export interface PostizGroup {
+  id: string;
+  name: string;
+}
+export function listGroups(): Promise<PostizGroup[]> {
+  return callThrowing<PostizGroup[]>("/groups");
+}
+
+/** Probe whether the configured Postiz API key is currently valid. Returns
+ *  the upstream JSON (typically `{connected: true}`) on success and throws
+ *  PostizApiError on 401/403/etc. */
+export function isApiKeyValid(): Promise<{ connected: boolean }> {
+  return callThrowing<{ connected: boolean }>("/integrations/is-connected");
+}
+
+/** Delete a connected channel by integration id. Any scheduled posts on the
+ *  channel are also deleted (per docs). */
+export function deleteIntegration(id: string): Promise<void> {
+  return callThrowing<void>(`/integrations/${encodeURIComponent(id)}`, { method: "DELETE" });
+}
+
+/** Generate an OAuth authorization URL for a brand-new channel. Only OAuth
+ *  providers are supported (Mastodon and friends that need a URL return 4xx). */
+export function getIntegrationConnectUrl(integrationName: string): Promise<{ url: string }> {
+  return callThrowing<{ url: string }>(`/integrations/${encodeURIComponent(integrationName)}/connect`);
+}
+
+/** Provider posting rules + settings JSON schema + available tools.
+ *  Shape varies per provider so we keep it open. */
+export function getIntegrationSettings(id: string): Promise<Record<string, unknown>> {
+  return callThrowing<Record<string, unknown>>(
+    `/integrations/${encodeURIComponent(id)}/settings`
+  );
+}
+
+/** Execute a provider-specific tool (e.g. listing Discord channels, fetching
+ *  Reddit flairs). Tool names + body shape discovered via `getIntegrationSettings`. */
+export function triggerIntegrationTool(
+  id: string,
+  body: { tool: string; data?: Record<string, unknown> }
+): Promise<Record<string, unknown>> {
+  return callThrowing<Record<string, unknown>>(
+    `/integrations/${encodeURIComponent(id)}/trigger`,
+    {
+      method: "POST",
+      body: JSON.stringify(body),
+    }
+  );
+}
+
+/** Org notifications, newest first. 100 per page. */
+export interface PostizNotification {
+  id: string;
+  text: string;
+  createdAt: string;
+}
+export function listNotifications(page = 1): Promise<PostizNotification[]> {
+  return callThrowing<PostizNotification[]>(`/notifications?page=${page}`);
+}
+
+/** Per-integration analytics (followers, impressions, engagement, …). Same
+ *  AnalyticsData[] shape as the per-post variant. */
+export function getIntegrationAnalytics(
+  id: string,
+  lookbackDays: 7 | 14 | 30 | 60 | 90 = 7
+): Promise<PostizAnalyticsMetric[]> {
+  return callThrowing<PostizAnalyticsMetric[]>(
+    `/analytics/integration/${encodeURIComponent(id)}?date=${lookbackDays}`
+  );
+}
+
 /**
  * Verify an inbound Postiz webhook request.
  *


### PR DESCRIPTION
Closes the API-surface gap surfaced by mining docs.postiz.com — 12 new lib helpers + 12 new admin routes matching the documented OpenAPI shapes. 60/60 postiz vitest, typecheck + lint clean.