### PR TITLE
feat(portals): token extend/rotate + cron client-reports workspace filter

### DIFF
--- a/src/app/[locale]/admin/client-portals/page.tsx
+++ b/src/app/[locale]/admin/client-portals/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { fetchWithAuth } from "@/lib/fetch-with-auth";
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import type { ClientPortal, PortalStep } from "@/app/api/admin/client-portals/route";
 import type { PendingClient } from "@/lib/pending-clients";
 
@@ -621,6 +621,138 @@ function ReportsToggle({
   );
 }
 
+/** Token lifecycle controls — show expiry + Extend/Rotate buttons.
+ *  Backed by the PATCH `extend-token` / `rotate-token` actions on
+ *  /api/admin/client-portals (90-day default TTL, configurable per call). */
+function TokenLifecycle({
+  portal,
+  onUpdate,
+}: Readonly<{ portal: ClientPortal; onUpdate: () => void }>) {
+  const [busy, setBusy] = useState<"" | "extend" | "rotate">("");
+  const [newTokenHint, setNewTokenHint] = useState<string | null>(null);
+
+  // `Date.now()` is impure for React's purity rule, so pin it in state at
+  // mount and bump it every minute via an interval. The displayed
+  // "expires in Xd" updates passively without a render-time impure call.
+  const [nowMs, setNowMs] = useState<number>(() => Date.now());
+  useEffect(() => {
+    const id = globalThis.setInterval(() => setNowMs(Date.now()), 60_000);
+    return () => globalThis.clearInterval(id);
+  }, []);
+
+  const expiryView = useMemo(() => {
+    const expiresAtMs = portal.expiresAt ? Date.parse(portal.expiresAt) : Number.NaN;
+    const hasExpiry = Number.isFinite(expiresAtMs);
+    const expired = hasExpiry && expiresAtMs < nowMs;
+    const daysLeft = hasExpiry ? Math.ceil((expiresAtMs - nowMs) / 86_400_000) : null;
+    const soon = !expired && daysLeft !== null && daysLeft <= 14;
+    return { expiresAtMs, hasExpiry, expired, daysLeft, soon };
+  }, [portal.expiresAt, nowMs]);
+  const { expiresAtMs, hasExpiry, expired, daysLeft, soon } = expiryView;
+
+  let badgeClass = "border-slate-700 text-slate-500";
+  let badgeLabel = "no expiry";
+  if (expired) {
+    badgeClass = "border-red-900/50 bg-red-950/30 text-red-300";
+    badgeLabel = "EXPIRED";
+  } else if (soon) {
+    badgeClass = "border-amber-900/50 bg-amber-950/30 text-amber-300";
+    badgeLabel = `expires in ${daysLeft}d`;
+  } else if (hasExpiry) {
+    badgeClass = "border-emerald-900/40 bg-emerald-950/20 text-emerald-300";
+    badgeLabel = `expires in ${daysLeft}d`;
+  }
+
+  async function extend() {
+    setBusy("extend");
+    setNewTokenHint(null);
+    try {
+      await patchPortal({ token: portal.token, action: "extend-token" });
+      onUpdate();
+    } finally {
+      setBusy("");
+    }
+  }
+
+  async function rotate() {
+    // `globalThis.confirm` per repo SonarCloud `prefer-global-this`.
+    if (
+      !globalThis.confirm(
+        "Rotate this portal token? The current URL stops working immediately — " +
+          "make sure you have a way to send the new link to the client."
+      )
+    ) {
+      return;
+    }
+    setBusy("rotate");
+    setNewTokenHint(null);
+    try {
+      const res = await fetchWithAuth("/api/admin/client-portals", {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ token: portal.token, action: "rotate-token" }),
+      });
+      if (res.ok) {
+        const data = await res.json().catch(() => ({}));
+        if (data?.portal?.token) {
+          setNewTokenHint(data.portal.token);
+        }
+        onUpdate();
+      }
+    } finally {
+      setBusy("");
+    }
+  }
+
+  const created = new Date(portal.createdAt).toLocaleDateString("en-IE");
+  const expiresAt = hasExpiry ? new Date(expiresAtMs).toLocaleDateString("en-IE") : null;
+
+  return (
+    <div className="mt-6 rounded-lg border border-slate-800 p-3">
+      <div className="flex flex-wrap items-center justify-between gap-2">
+        <div className="font-mono text-xs text-slate-500">
+          <span className="text-slate-400">token</span> · created {created}
+          {expiresAt && (
+            <>
+              {" · "}
+              <span className="text-slate-400">expires</span> {expiresAt}
+            </>
+          )}
+        </div>
+        <span className={`rounded-full border px-2 py-0.5 font-mono text-[10px] ${badgeClass}`}>
+          {badgeLabel}
+        </span>
+      </div>
+      <div className="mt-3 flex gap-2">
+        <button
+          type="button"
+          onClick={extend}
+          disabled={busy !== ""}
+          className="border-neon-cyan/30 text-neon-cyan hover:border-neon-cyan/60 rounded-lg border px-3 py-1.5 font-mono text-xs transition disabled:opacity-50"
+        >
+          {busy === "extend" ? "Extending…" : "Extend +90d"}
+        </button>
+        <button
+          type="button"
+          onClick={rotate}
+          disabled={busy !== ""}
+          className="rounded-lg border border-amber-900/40 px-3 py-1.5 font-mono text-xs text-amber-300 transition hover:border-amber-700 disabled:opacity-50"
+        >
+          {busy === "rotate" ? "Rotating…" : "Rotate token"}
+        </button>
+      </div>
+      {newTokenHint && (
+        <p className="font-body mt-2 text-xs text-amber-300">
+          Token rotated. Send the client the new portal URL:&nbsp;
+          <code className="bg-void rounded px-1.5 py-0.5 font-mono text-[10px] text-amber-200">
+            /portal/{newTokenHint}
+          </code>
+        </p>
+      )}
+    </div>
+  );
+}
+
 function PendingClients({ onApproved }: Readonly<{ onApproved: () => void }>) {
   const [clients, setClients] = useState<PendingClient[]>([]);
   const [loading, setLoading] = useState(true);
@@ -1075,6 +1207,7 @@ export default function ClientPortalsPage() {
                       Payment Links
                     </p>
                     <PaymentLinkManager portal={portal} onUpdate={load} />
+                    <TokenLifecycle portal={portal} onUpdate={load} />
                     <ReportsToggle portal={portal} onUpdate={load} />
                   </div>
                 )}

--- a/src/app/api/admin/client-portals/route.ts
+++ b/src/app/api/admin/client-portals/route.ts
@@ -182,7 +182,15 @@ type PatchAction =
       status: PaymentLinkStatus;
     }
   | { token: string; action: "delete-payment-link"; paymentLinkId: string }
-  | { token: string; action: "set-reports-enabled"; enabled: boolean };
+  | { token: string; action: "set-reports-enabled"; enabled: boolean }
+  /** Push expiresAt out by `ttlDays` (default 90). Token stays the same —
+   *  any URL already shared with the client keeps working. */
+  | { token: string; action: "extend-token"; ttlDays?: number }
+  /** Mint a brand-new token AND reset expiresAt. The old URL is invalidated
+   *  immediately. Use for security incidents (URL forwarded by mistake,
+   *  client device compromised, etc.). Body includes the new token in the
+   *  response so the admin can copy it to a fresh email. */
+  | { token: string; action: "rotate-token"; ttlDays?: number };
 
 function stepNotFound() {
   return NextResponse.json({ error: "Step not found" }, { status: 404 });
@@ -323,6 +331,25 @@ function applyUpdatePaymentLink(
   return null;
 }
 
+function applyExtendToken(
+  portal: ClientPortal,
+  body: Extract<PatchAction, { action: "extend-token" }>
+): NextResponse | null {
+  const ttl = typeof body.ttlDays === "number" && body.ttlDays > 0 ? body.ttlDays : undefined;
+  portal.expiresAt = computePortalExpiry(ttl);
+  return null;
+}
+
+function applyRotateToken(
+  portal: ClientPortal,
+  body: Extract<PatchAction, { action: "rotate-token" }>
+): NextResponse | null {
+  const ttl = typeof body.ttlDays === "number" && body.ttlDays > 0 ? body.ttlDays : undefined;
+  portal.token = randomUUID();
+  portal.expiresAt = computePortalExpiry(ttl);
+  return null;
+}
+
 function dispatchPatch(portal: ClientPortal, body: PatchAction): NextResponse | null {
   switch (body.action) {
     case "update-step":
@@ -355,6 +382,10 @@ function dispatchPatch(portal: ClientPortal, body: PatchAction): NextResponse | 
     case "set-reports-enabled":
       portal.reportsEnabled = Boolean(body.enabled);
       return null;
+    case "extend-token":
+      return applyExtendToken(portal, body);
+    case "rotate-token":
+      return applyRotateToken(portal, body);
     default:
       return NextResponse.json({ error: "Unknown action" }, { status: 400 });
   }

--- a/src/app/api/cron/client-reports/route.ts
+++ b/src/app/api/cron/client-reports/route.ts
@@ -16,7 +16,10 @@ import { sendEmail } from "@/lib/email";
  * the other /api/cron routes). Schedule it monthly from your scheduler of
  * choice (GitHub Actions cron, EventBridge, or the Pi's systemd timers).
  * Idempotent within the 25-day window — safe to run more often.
- */
+ *
+ * Workspace filter: pass `?workspace=<id>` to mail only that tenant's
+ * clients. Org-wide portals (no workspaceId) are included only when the
+ * query param is omitted — passing a workspace id is a strict scope. */
 
 const MIN_DAYS_BETWEEN_REPORTS = 25;
 const BASE_URL = "https://cloudless.gr";
@@ -35,11 +38,17 @@ export async function GET(request: NextRequest) {
   }
 
   const now = new Date();
-  const portals = await readPortals();
-  const due = portals.filter((p) => isDue(p, now));
+  const workspaceFilter = new URL(request.url).searchParams.get("workspace");
+  const all = await readPortals();
+  const scoped = workspaceFilter ? all.filter((p) => p.workspaceId === workspaceFilter) : all;
+  const due = scoped.filter((p) => isDue(p, now));
 
   if (due.length === 0) {
-    return NextResponse.json({ sent: 0, message: "No client reports due." });
+    return NextResponse.json({
+      sent: 0,
+      message: "No client reports due.",
+      ...(workspaceFilter ? { workspace: workspaceFilter } : {}),
+    });
   }
 
   const sent: string[] = [];
@@ -63,10 +72,17 @@ export async function GET(request: NextRequest) {
   }
 
   if (sent.length > 0) {
-    await writePortals(portals);
+    // Re-read + merge: we only mutated the `scoped` slice, so write the
+    // original `all` (which shares object refs with `scoped`) back to SSM.
+    await writePortals(all);
   }
 
-  return NextResponse.json({ sent: sent.length, failed: failed.length, recipients: sent });
+  return NextResponse.json({
+    sent: sent.length,
+    failed: failed.length,
+    recipients: sent,
+    ...(workspaceFilter ? { workspace: workspaceFilter } : {}),
+  });
 }
 
 export const runtime = "nodejs";


### PR DESCRIPTION
Two follow-ups from #951. PATCH extend-token (TTL bump) + rotate-token (new UUID + reset). Admin UI gets a TokenLifecycle widget per portal with expiry badge + Extend/Rotate buttons. Cron client-reports accepts ?workspace=<id> for single-tenant runs. 61/61 portal vitest; typecheck + lint clean.