### PR TITLE
feat(workspaces): UI for postizGroupId/notionTag + analytics dashboard page

### DIFF
--- a/src/app/[locale]/admin/AdminLayoutClient.tsx
+++ b/src/app/[locale]/admin/AdminLayoutClient.tsx
@@ -77,6 +77,11 @@ const adminGroups: AdminGroup[] = [
     links: [
       { href: "/admin/client-portals", label: "Client Portals", Icon: Link2 },
       { href: "/admin/workspaces", label: "Workspaces", Icon: Building2 },
+      {
+        href: "/admin/analytics/workspaces",
+        label: "Workspace Analytics",
+        Icon: Activity,
+      },
     ],
   },
   {

--- a/src/app/[locale]/admin/analytics/workspaces/page.tsx
+++ b/src/app/[locale]/admin/analytics/workspaces/page.tsx
@@ -1,0 +1,295 @@
+"use client";
+
+import { fetchWithAuth } from "@/lib/fetch-with-auth";
+import { useEffect, useMemo, useState } from "react";
+import { Link } from "@/i18n/navigation";
+
+interface WorkspaceAnalytics {
+  workspaceId: string | null;
+  workspace: { id: string; name: string; slug: string } | null;
+  portals: {
+    total: number;
+    active: number;
+    expiringSoon: number;
+    averageHealth: number;
+    expired: number;
+  };
+  deliverables: {
+    total: number;
+    inReview: number;
+    approved: number;
+    changesRequested: number;
+    draft: number;
+  };
+  revenue: {
+    openCount: number;
+    paidCount: number;
+    voidCount: number;
+    openAmountCents: number;
+    paidAmountCents: number;
+    currency: string;
+  };
+  calendar: {
+    total: number;
+    draft: number;
+    scheduled: number;
+    published: number;
+    cancelled: number;
+    nextScheduledAt: string | null;
+  };
+}
+
+interface Response {
+  workspaces: WorkspaceAnalytics[];
+  orgWide: WorkspaceAnalytics;
+}
+
+function formatAmount(cents: number, currency: string): string {
+  const value = cents / 100;
+  try {
+    return new Intl.NumberFormat("en-IE", {
+      style: "currency",
+      currency,
+      maximumFractionDigits: 0,
+    }).format(value);
+  } catch {
+    return `${value.toFixed(0)} ${currency}`;
+  }
+}
+
+export default function WorkspaceAnalyticsPage() {
+  const [data, setData] = useState<Response | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  async function load() {
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await fetchWithAuth("/api/admin/analytics/workspaces");
+      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      setData(await res.json());
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Failed to load analytics");
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  useEffect(() => {
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    load();
+  }, []);
+
+  const totals = useMemo(() => {
+    if (!data) return null;
+    let portals = 0;
+    let deliverables = 0;
+    let paidCents = 0;
+    let openCents = 0;
+    let currency = "EUR";
+    let calendarTotal = 0;
+    for (const w of [...data.workspaces, data.orgWide]) {
+      portals += w.portals.total;
+      deliverables += w.deliverables.total;
+      paidCents += w.revenue.paidAmountCents;
+      openCents += w.revenue.openAmountCents;
+      calendarTotal += w.calendar.total;
+      if (w.revenue.currency && w.revenue.currency !== "EUR" && currency === "EUR") {
+        currency = w.revenue.currency;
+      }
+    }
+    return { portals, deliverables, paidCents, openCents, currency, calendarTotal };
+  }, [data]);
+
+  return (
+    <div>
+      <div className="mb-8">
+        <div className="border-neon-cyan/20 bg-neon-cyan/10 mb-4 inline-flex items-center gap-2 rounded-full border px-3 py-1.5">
+          <span className="bg-neon-cyan h-2 w-2 animate-pulse rounded-full" />
+          <span className="text-neon-cyan font-mono text-xs">CROSS-STORE ANALYTICS</span>
+        </div>
+        <h1 className="font-heading text-2xl font-bold text-white">Workspaces analytics</h1>
+        <p className="font-body mt-1 text-slate-400">
+          Per-workspace summary joining workspaces, client portals, and Notion calendar — read off
+          a single API call (
+          <code className="bg-void rounded px-1.5 py-0.5 font-mono text-xs text-slate-300">
+            GET /api/admin/analytics/workspaces
+          </code>
+          ).
+        </p>
+      </div>
+
+      {error && (
+        <div className="mb-6 rounded-lg border border-red-900/30 bg-red-950/10 px-4 py-3 font-mono text-xs text-red-400">
+          {error}
+        </div>
+      )}
+
+      {loading && (
+        <div className="space-y-3">
+          {["s1", "s2", "s3"].map((k) => (
+            <div
+              key={k}
+              className="bg-void-light/30 h-32 animate-pulse rounded-xl border border-slate-800"
+            />
+          ))}
+        </div>
+      )}
+
+      {!loading && data && totals && (
+        <>
+          {/* Top-line totals */}
+          <div className="mb-6 grid grid-cols-2 gap-3 sm:grid-cols-4">
+            <Kpi label="Total portals" value={String(totals.portals)} />
+            <Kpi label="Deliverables" value={String(totals.deliverables)} />
+            <Kpi label="Calendar items" value={String(totals.calendarTotal)} />
+            <Kpi
+              label="Paid revenue (all-time)"
+              value={formatAmount(totals.paidCents, totals.currency)}
+              subtle={`${formatAmount(totals.openCents, totals.currency)} open`}
+            />
+          </div>
+
+          <div className="space-y-3">
+            {data.workspaces.length === 0 && (
+              <div className="bg-void-light/30 rounded-xl border border-slate-800 px-6 py-12 text-center">
+                <p className="font-heading text-sm text-slate-400">
+                  No workspaces yet — create one on{" "}
+                  <Link href="/admin/workspaces" className="text-neon-cyan underline">
+                    /admin/workspaces
+                  </Link>
+                  .
+                </p>
+              </div>
+            )}
+            {data.workspaces.map((w) => (
+              <WorkspaceCard key={w.workspaceId ?? "n/a"} a={w} />
+            ))}
+
+            {data.orgWide && data.orgWide.portals.total + data.orgWide.calendar.total > 0 && (
+              <div>
+                <h2 className="font-heading mt-8 mb-2 font-mono text-xs tracking-wider text-slate-500 uppercase">
+                  Org-wide (no workspaceId)
+                </h2>
+                <WorkspaceCard a={data.orgWide} />
+              </div>
+            )}
+          </div>
+        </>
+      )}
+    </div>
+  );
+}
+
+function Kpi({
+  label,
+  value,
+  subtle,
+}: Readonly<{ label: string; value: string; subtle?: string }>) {
+  return (
+    <div className="bg-void-light/30 rounded-xl border border-slate-800 p-4">
+      <p className="font-mono text-[10px] tracking-wider text-slate-500 uppercase">{label}</p>
+      <p className="font-heading mt-1 text-2xl font-bold text-white">{value}</p>
+      {subtle && <p className="font-mono text-[10px] text-slate-600">{subtle}</p>}
+    </div>
+  );
+}
+
+function WorkspaceCard({ a }: Readonly<{ a: WorkspaceAnalytics }>) {
+  const title = a.workspace?.name ?? "Org-wide";
+  const slug = a.workspace?.slug;
+  const nextScheduled = a.calendar.nextScheduledAt
+    ? new Date(a.calendar.nextScheduledAt).toLocaleString("en-IE")
+    : "—";
+  return (
+    <div className="bg-void-light/30 rounded-xl border border-slate-800 p-5">
+      <div className="mb-4 flex flex-wrap items-baseline justify-between gap-2">
+        <div>
+          <h3 className="font-heading text-lg font-semibold text-white">{title}</h3>
+          {slug && (
+            <p className="font-mono text-[10px] text-slate-600">
+              slug: <span className="text-slate-400">{slug}</span>
+            </p>
+          )}
+        </div>
+        <div className="flex gap-2">
+          <Badge label={`${a.portals.total} portals`} tint="cyan" />
+          <Badge label={`${a.deliverables.total} deliverables`} tint="violet" />
+          <Badge label={`${a.calendar.total} calendar`} tint="emerald" />
+        </div>
+      </div>
+
+      <div className="grid grid-cols-1 gap-3 sm:grid-cols-4">
+        <Stat
+          group="Portals"
+          rows={[
+            ["Active", a.portals.active],
+            ["Expiring ≤14d", a.portals.expiringSoon],
+            ["Expired", a.portals.expired],
+            ["Avg health", a.portals.averageHealth],
+          ]}
+        />
+        <Stat
+          group="Deliverables"
+          rows={[
+            ["In review", a.deliverables.inReview],
+            ["Approved", a.deliverables.approved],
+            ["Changes requested", a.deliverables.changesRequested],
+            ["Draft", a.deliverables.draft],
+          ]}
+        />
+        <Stat
+          group="Revenue"
+          rows={[
+            ["Paid", formatAmount(a.revenue.paidAmountCents, a.revenue.currency)],
+            ["Open", formatAmount(a.revenue.openAmountCents, a.revenue.currency)],
+            ["Paid count", a.revenue.paidCount],
+            ["Void count", a.revenue.voidCount],
+          ]}
+        />
+        <Stat
+          group="Calendar"
+          rows={[
+            ["Draft", a.calendar.draft],
+            ["Scheduled", a.calendar.scheduled],
+            ["Published", a.calendar.published],
+            ["Next at", nextScheduled],
+          ]}
+        />
+      </div>
+    </div>
+  );
+}
+
+function Badge({ label, tint }: Readonly<{ label: string; tint: "cyan" | "violet" | "emerald" }>) {
+  const colors: Record<typeof tint, string> = {
+    cyan: "border-cyan-900/40 bg-cyan-950/30 text-cyan-300",
+    violet: "border-violet-900/40 bg-violet-950/30 text-violet-300",
+    emerald: "border-emerald-900/40 bg-emerald-950/30 text-emerald-300",
+  };
+  return (
+    <span className={`rounded-full border px-2 py-0.5 font-mono text-[10px] ${colors[tint]}`}>
+      {label}
+    </span>
+  );
+}
+
+function Stat({
+  group,
+  rows,
+}: Readonly<{ group: string; rows: ReadonlyArray<readonly [string, string | number]> }>) {
+  return (
+    <div className="rounded-lg border border-slate-800 p-3">
+      <p className="mb-2 font-mono text-[10px] tracking-wider text-slate-500 uppercase">{group}</p>
+      <dl className="space-y-1">
+        {rows.map(([k, v]) => (
+          <div key={k} className="flex items-baseline justify-between gap-2 font-mono text-xs">
+            <dt className="text-slate-500">{k}</dt>
+            <dd className="truncate text-slate-200">{v}</dd>
+          </div>
+        ))}
+      </dl>
+    </div>
+  );
+}

--- a/src/app/[locale]/admin/workspaces/page.tsx
+++ b/src/app/[locale]/admin/workspaces/page.tsx
@@ -5,23 +5,26 @@ import { useEffect, useState } from "react";
 import type { Workspace } from "@/app/api/admin/workspaces/route";
 import { useWorkspace } from "@/context/WorkspaceContext";
 
+interface PostizGroupOption {
+  id: string;
+  name: string;
+}
+
+const EMPTY_FORM = { name: "", description: "", adminEmails: "", postizGroupId: "", notionTag: "" };
+
 export default function WorkspacesPage() {
   const [workspaces, setWorkspaces] = useState<Workspace[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [creating, setCreating] = useState(false);
-  const [form, setForm] = useState({
-    name: "",
-    description: "",
-    adminEmails: "",
-  });
+  const [form, setForm] = useState(EMPTY_FORM);
   const [formError, setFormError] = useState<string | null>(null);
   const [editingId, setEditingId] = useState<string | null>(null);
-  const [editForm, setEditForm] = useState({
-    name: "",
-    description: "",
-    adminEmails: "",
-  });
+  const [editForm, setEditForm] = useState(EMPTY_FORM);
+  /** Postiz groups for the dropdown. `null` = not loaded yet, `[]` = either
+   *  Postiz isn't configured (503) or the org has no groups — both cases
+   *  fall back to a free-text input. */
+  const [postizGroups, setPostizGroups] = useState<PostizGroupOption[] | null>(null);
   const { setWorkspaces: setCtxWorkspaces, current } = useWorkspace();
 
   async function load() {
@@ -59,11 +62,13 @@ export default function WorkspacesPage() {
             .split(",")
             .map((e) => e.trim())
             .filter(Boolean),
+          postizGroupId: form.postizGroupId.trim() || undefined,
+          notionTag: form.notionTag.trim() || undefined,
         }),
       });
       const data = await res.json();
       if (!res.ok) throw new Error(data.error ?? `HTTP ${res.status}`);
-      setForm({ name: "", description: "", adminEmails: "" });
+      setForm(EMPTY_FORM);
       load();
     } catch (e) {
       setFormError(e instanceof Error ? e.message : "Failed to create workspace");
@@ -85,6 +90,10 @@ export default function WorkspacesPage() {
             .split(",")
             .map((e) => e.trim())
             .filter(Boolean),
+          // Pass through whether set or cleared — backend treats "" as a
+          // clear instruction, undefined as "leave unchanged".
+          postizGroupId: editForm.postizGroupId.trim(),
+          notionTag: editForm.notionTag.trim(),
         }),
       });
       if (!res.ok) {
@@ -118,6 +127,8 @@ export default function WorkspacesPage() {
       name: ws.name,
       description: ws.description,
       adminEmails: ws.adminEmails.join(", "),
+      postizGroupId: ws.postizGroupId ?? "",
+      notionTag: ws.notionTag ?? "",
     });
   }
 
@@ -125,6 +136,23 @@ export default function WorkspacesPage() {
     // eslint-disable-next-line react-hooks/set-state-in-effect
     load();
     // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  // Optimistically fetch Postiz groups once on mount. 503 (not configured)
+  // and other errors leave `postizGroups` at `null` so the inputs degrade
+  // to free text. The `groups` route on the server reads from SSM, so this
+  // is a single round-trip per page visit.
+  useEffect(() => {
+    fetchWithAuth("/api/admin/postiz/groups")
+      .then((r) => (r.ok ? r.json() : null))
+      .then((data) => {
+        if (Array.isArray(data?.groups)) {
+          setPostizGroups(data.groups as PostizGroupOption[]);
+        }
+      })
+      .catch(() => {
+        /* silent — UI just falls back to free-text */
+      });
   }, []);
 
   return (
@@ -256,6 +284,19 @@ export default function WorkspacesPage() {
               className="bg-void focus:border-neon-blue/50 w-full rounded-lg border border-slate-700 px-3 py-2 font-mono text-sm text-white placeholder-slate-600 focus:outline-none"
             />
           </div>
+          <div className="grid gap-3 sm:grid-cols-2">
+            <PostizGroupField
+              id="ws-postiz"
+              value={form.postizGroupId}
+              onChange={(v) => setForm((f) => ({ ...f, postizGroupId: v }))}
+              groups={postizGroups}
+            />
+            <NotionTagField
+              id="ws-notion"
+              value={form.notionTag}
+              onChange={(v) => setForm((f) => ({ ...f, notionTag: v }))}
+            />
+          </div>
           {formError && <p className="font-mono text-xs text-red-400">{formError}</p>}
           <button
             type="submit"
@@ -338,6 +379,23 @@ export default function WorkspacesPage() {
                     }
                     className="bg-void focus:border-neon-blue/50 w-full rounded-lg border border-slate-700 px-3 py-2 font-mono text-sm text-white focus:outline-none"
                   />
+                  <div className="grid gap-3 sm:grid-cols-2">
+                    <PostizGroupField
+                      id={`ws-postiz-${ws.id}`}
+                      value={editForm.postizGroupId}
+                      onChange={(v) =>
+                        setEditForm((f) => ({ ...f, postizGroupId: v }))
+                      }
+                      groups={postizGroups}
+                    />
+                    <NotionTagField
+                      id={`ws-notion-${ws.id}`}
+                      value={editForm.notionTag}
+                      onChange={(v) =>
+                        setEditForm((f) => ({ ...f, notionTag: v }))
+                      }
+                    />
+                  </div>
                   <div className="flex gap-2">
                     <button
                       type="button"
@@ -377,6 +435,24 @@ export default function WorkspacesPage() {
                         admins: {ws.adminEmails.join(", ")}
                       </p>
                     )}
+                    {(ws.postizGroupId || ws.notionTag) && (
+                      <p className="mt-1 flex flex-wrap items-center gap-2 font-mono text-[10px] text-slate-600">
+                        {ws.postizGroupId && (
+                          <span className="rounded border border-slate-800 px-1.5 py-0.5">
+                            postiz:{" "}
+                            <span className="text-slate-400">
+                              {postizGroups?.find((g) => g.id === ws.postizGroupId)?.name ??
+                                ws.postizGroupId}
+                            </span>
+                          </span>
+                        )}
+                        {ws.notionTag && (
+                          <span className="rounded border border-slate-800 px-1.5 py-0.5">
+                            notion: <span className="text-slate-400">{ws.notionTag}</span>
+                          </span>
+                        )}
+                      </p>
+                    )}
                     <p className="mt-1 font-mono text-xs text-slate-700">
                       created {new Date(ws.createdAt).toLocaleDateString("en-IE")}
                     </p>
@@ -403,6 +479,84 @@ export default function WorkspacesPage() {
           ))}
         </div>
       )}
+    </div>
+  );
+}
+
+/** Postiz group picker — dropdown of `/api/admin/postiz/groups` when the
+ *  upstream is reachable, free-text fallback when it isn't (Postiz not
+ *  configured, network error, etc.). The Workspace.postizGroupId stores the
+ *  group id; the dropdown shows the friendly name. */
+function PostizGroupField({
+  id,
+  value,
+  onChange,
+  groups,
+}: Readonly<{
+  id: string;
+  value: string;
+  onChange: (next: string) => void;
+  groups: PostizGroupOption[] | null;
+}>) {
+  const helper = "Filter this workspace's Postiz channels + posts to one Postiz group (customer).";
+  return (
+    <div>
+      <label htmlFor={id} className="mb-1 block font-mono text-xs text-slate-500">
+        Postiz group (optional)
+      </label>
+      {groups && groups.length > 0 ? (
+        <select
+          id={id}
+          value={value}
+          onChange={(e) => onChange(e.target.value)}
+          className="bg-void focus:border-neon-blue/50 w-full rounded-lg border border-slate-700 px-3 py-2 font-mono text-sm text-white focus:outline-none"
+        >
+          <option value="">— None (all groups) —</option>
+          {groups.map((g) => (
+            <option key={g.id} value={g.id}>
+              {g.name} ({g.id.slice(0, 8)}…)
+            </option>
+          ))}
+        </select>
+      ) : (
+        <input
+          id={id}
+          type="text"
+          value={value}
+          onChange={(e) => onChange(e.target.value)}
+          placeholder="paste the Postiz group id"
+          className="bg-void focus:border-neon-blue/50 w-full rounded-lg border border-slate-700 px-3 py-2 font-mono text-sm text-white placeholder-slate-600 focus:outline-none"
+        />
+      )}
+      <p className="mt-1 font-mono text-[10px] text-slate-600">{helper}</p>
+    </div>
+  );
+}
+
+/** Notion workspace tag — written into the WorkspaceID rich-text column on
+ *  calendar items so the calendar GET can filter by it. Free text — usually
+ *  matches the workspace slug. */
+function NotionTagField({
+  id,
+  value,
+  onChange,
+}: Readonly<{ id: string; value: string; onChange: (next: string) => void }>) {
+  return (
+    <div>
+      <label htmlFor={id} className="mb-1 block font-mono text-xs text-slate-500">
+        Notion tag (optional)
+      </label>
+      <input
+        id={id}
+        type="text"
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        placeholder="acme-corp"
+        className="bg-void focus:border-neon-blue/50 w-full rounded-lg border border-slate-700 px-3 py-2 font-mono text-sm text-white placeholder-slate-600 focus:outline-none"
+      />
+      <p className="mt-1 font-mono text-[10px] text-slate-600">
+        Tag written to the Notion calendar WorkspaceID column for filtering.
+      </p>
     </div>
   );
 }


### PR DESCRIPTION
Surfaces the workspace plumbing from #951 in the UI. /admin/workspaces gets editable Postiz group + Notion tag fields; /admin/analytics/workspaces renders the cross-store summary the API already exposes. typecheck + lint clean.