### PR TITLE
fix(services): hardening pass on link/plan/rewrite issues found by trace

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -102,29 +102,17 @@ const nextConfig: NextConfig = {
   },
 };
 
-// Bypass Turbopack dev-mode bug where [locale] catches special metadata routes
-// in the App Router before next/manifest.ts can handle them.
-// Lighthouse Win #2 — avoid the locale redirect round-trip for top
-// landing-page paths. The middleware would 302 /services → /en/services
-// (~300-500ms first-load penalty); rewriting server-side cuts that latency
-// without changing what the user sees in the address bar.
-const LOCALE_REWRITE_PATHS = [
-  "/services",
-  "/store",
-  "/contact",
-  "/blog",
-  "/docs",
-  "/case-studies",
-  "/work",
-];
+// next-intl middleware (localePrefix: "always") intercepts every unprefixed
+// route on its own and 307s to the appropriate locale BEFORE Next.js
+// rewrites() get a chance. An earlier attempt to pre-rewrite hot landing
+// paths (/services, /store, /contact, /blog, /docs, /case-studies, /work)
+// here to /en/* was dead code — verified live: both with and without the
+// NEXT_LOCALE cookie those URLs still produce a 307 from middleware. Per
+// next-intl docs, the middleware IS the locale layer; we keep
+// /manifest.webmanifest → /api/pwa-manifest as the only legitimate rewrite.
 nextConfig.rewrites = async () => ({
   beforeFiles: [
     { source: "/manifest.webmanifest", destination: "/api/pwa-manifest" },
-    ...LOCALE_REWRITE_PATHS.map((path) => ({
-      source: path,
-      destination: `/en${path}`,
-      missing: [{ type: "cookie" as const, key: "NEXT_LOCALE" }],
-    })),
   ],
   afterFiles: [],
   fallback: [],

--- a/src/app/[locale]/auth/signup/page.tsx
+++ b/src/app/[locale]/auth/signup/page.tsx
@@ -7,6 +7,7 @@ import { useSearchParams } from "next/navigation";
 import { useAuth } from "@/context/AuthContext";
 import { translate } from "@/lib/i18n";
 import { useCurrentLocale } from "@/lib/use-locale";
+import { isValidPlan } from "@/lib/plans";
 
 const AUTH_PROVIDER = process.env.NEXT_PUBLIC_AUTH_PROVIDER;
 const USE_COGNITO = AUTH_PROVIDER === "cognito";
@@ -18,7 +19,12 @@ function SignUpForm() {
   const router = useRouter();
   const searchParams = useSearchParams();
 
-  const planParam = searchParams.get("plan");
+  // Validate against the shared plan allowlist. An unknown ?plan= would
+  // forward into /portal/waiting and silently dead-end at the server
+  // enroll step (which validates the same allowlist) — drop it here so
+  // the user isn't shipped to a confusing waiting room with no enroll.
+  const rawPlan = searchParams.get("plan");
+  const planParam = isValidPlan(rawPlan) ? rawPlan : null;
   const postSignupDestination = planParam
     ? `/portal/waiting?plan=${encodeURIComponent(planParam)}`
     : null;

--- a/src/app/portal/waiting/WaitingRoomClient.tsx
+++ b/src/app/portal/waiting/WaitingRoomClient.tsx
@@ -6,6 +6,11 @@ import { useRouter, useSearchParams } from "next/navigation";
 import { useAuth } from "@/context/AuthContext";
 import { fetchWithAuth } from "@/lib/fetch-with-auth";
 import TerminalBlock from "@/components/TerminalBlock";
+// Single source of truth — also consumed by /api/portal/enroll +
+// src/lib/pending-clients.ts (server) and the signup gate (client).
+// Lives in a dependency-free module so the AWS SDK isn't pulled into the
+// browser bundle.
+import { PLAN_LABELS } from "@/lib/plans";
 
 interface PortalStatus {
   status: "none" | "waiting" | "approved";
@@ -17,16 +22,6 @@ interface PortalStatus {
   email?: string;
   name?: string;
 }
-
-const PLAN_LABELS: Record<string, string> = {
-  cloud: "Cloud Architecture & Migration",
-  serverless: "Serverless Development",
-  analytics: "Data Analytics & Dashboards",
-  marketing: "AI & Digital Marketing",
-  web: "Web Design & Development",
-  hosting: "Managed Hosting & Maintenance",
-  bundle: "Full-Stack Growth Engine (Bundle)",
-};
 
 const POLL_INTERVAL_MS = 30_000;
 

--- a/src/lib/pending-clients.ts
+++ b/src/lib/pending-clients.ts
@@ -33,15 +33,13 @@ export interface PendingClient {
   notes?: string;
 }
 
-export const PLAN_LABELS: Record<string, string> = {
-  cloud: "Cloud Architecture & Migration",
-  serverless: "Serverless Development",
-  analytics: "Data Analytics & Dashboards",
-  marketing: "AI & Digital Marketing",
-  web: "Web Design & Development",
-  hosting: "Managed Hosting & Maintenance",
-  bundle: "Full-Stack Growth Engine (Bundle)",
-};
+// PLAN_LABELS lives in the shared, dependency-free `./plans` module so
+// the client-side waiting room (which must not pull AWS SDK into the
+// browser bundle) and the server enroll route both consume the same map.
+// We import + re-export so callers of this file get the same name they
+// always did AND we can use it ourselves below.
+import { PLAN_LABELS } from "./plans";
+export { PLAN_LABELS };
 
 export async function readPendingClients(): Promise<PendingClient[]> {
   try {

--- a/src/lib/plans.ts
+++ b/src/lib/plans.ts
@@ -1,0 +1,27 @@
+/**
+ * Plan keys + labels — single source of truth shared across client and
+ * server code paths. Kept free of any runtime dependencies (no AWS SDK,
+ * no Node-only imports) so it can be imported into both server routes
+ * (`src/lib/pending-clients.ts`, `/api/portal/enroll`) and the client
+ * waiting-room UI (`src/app/portal/waiting/WaitingRoomClient.tsx`)
+ * without dragging server-only deps into the browser bundle.
+ */
+
+export const PLAN_LABELS: Record<string, string> = {
+  cloud: "Cloud Architecture & Migration",
+  serverless: "Serverless Development",
+  analytics: "Data Analytics & Dashboards",
+  marketing: "AI & Digital Marketing",
+  web: "Web Design & Development",
+  hosting: "Managed Hosting & Maintenance",
+  bundle: "Full-Stack Growth Engine (Bundle)",
+};
+
+export type PlanKey = keyof typeof PLAN_LABELS;
+
+export const PLAN_KEYS: ReadonlySet<string> = new Set(Object.keys(PLAN_LABELS));
+
+/** Returns true if `value` is a known plan key. */
+export function isValidPlan(value: unknown): value is PlanKey {
+  return typeof value === "string" && PLAN_KEYS.has(value);
+}


### PR DESCRIPTION
Three real bugs / footguns surfaced when tracing every link on /en/services: deleted dead LOCALE_REWRITE_PATHS, deduped PLAN_LABELS into a dependency-free module, validated the signup ?plan= param. typecheck + lint clean. No behavior change for users on the happy path.