### PR TITLE
fix(seo): remove portfolio meta, add DE hreflang, install OpenClaudia skills

### DIFF
--- a/.claude/skills/ab-test-setup/SKILL.md
+++ b/.claude/skills/ab-test-setup/SKILL.md
@@ -1,0 +1,158 @@
+---
+name: ab-test-setup
+description: Design, plan, and analyze A/B tests with statistical rigor. Use when the user asks about A/B testing, split testing, experiment design, statistical significance, sample size calculation, test duration, multivariate testing, or conversion experiments. Trigger phrases include "A/B test", "split test", "experiment", "statistical significance", "sample size", "test duration", "which version wins", "conversion experiment", "hypothesis test", "variant testing".
+---
+
+# A/B Test Design and Analysis
+
+You are an expert in experimentation and A/B testing. When the user asks you to design a test, calculate sample sizes, analyze results, or plan an experimentation roadmap, follow this framework.
+
+## Step 1: Gather Test Context
+
+Establish: page/feature being tested, current conversion rate, monthly traffic, primary metric, secondary metrics, guardrail metrics, duration constraints, testing platform (Optimizely, VWO, custom).
+
+## Step 2: Hypothesis Framework
+
+### Hypothesis Template
+
+```
+OBSERVATION: [What we noticed in data/research/feedback]
+HYPOTHESIS: If we [specific change], then [metric] will [change] by [amount],
+            because [behavioral/psychological reasoning].
+CONTROL (A): [Current state]
+VARIANT (B): [Proposed change]
+PRIMARY METRIC: [Single metric that determines winner]
+GUARDRAILS: [Metrics that must not degrade]
+```
+
+### Hypothesis Categories
+
+- **Clarity**: "Users don't understand what we offer" -- test headline, value prop
+- **Motivation**: "Users aren't motivated to act" -- test social proof, urgency, benefits
+- **Friction**: "Process is too difficult" -- test form length, step count, layout
+- **Trust**: "Users don't trust us" -- test testimonials, guarantees, badges
+- **Relevance**: "Content doesn't match intent" -- test personalization, segmentation
+
+## Step 3: Sample Size and Duration
+
+### Sample Size Formula
+
+```
+n = (Z_alpha/2 + Z_beta)^2 * (p1*(1-p1) + p2*(1-p2)) / (p2 - p1)^2
+Where: Z_alpha/2 = 1.96 (95%), Z_beta = 0.84 (80% power), p2 = p1 * (1 + MDE)
+```
+
+### Quick Reference (per variant, 95% significance, 80% power)
+
+| Baseline CR | 10% MDE | 15% MDE | 20% MDE | 25% MDE |
+|---|---|---|---|---|
+| 2% | 385,040 | 173,470 | 98,740 | 63,850 |
+| 3% | 253,670 | 114,300 | 65,080 | 42,110 |
+| 5% | 148,640 | 67,040 | 38,200 | 24,730 |
+| 10% | 70,420 | 31,780 | 18,120 | 11,740 |
+| 15% | 44,310 | 20,010 | 11,420 | 7,400 |
+| 20% | 31,310 | 14,140 | 8,070 | 5,230 |
+
+**Duration** = (Sample size per variant x Number of variants) / Daily traffic. Minimum 7 days, maximum 8 weeks.
+
+If duration exceeds 8 weeks: increase MDE, reduce variants, test a higher-traffic page, use a micro-conversion metric, or accept lower power.
+
+## Step 4: Test Types
+
+| Type | What | When | Caution |
+|---|---|---|---|
+| A/B | Two versions, 50/50 split | One specific change, sufficient traffic | Minimum 7 days |
+| A/B/n | Control + 2-4 variants | Multiple approaches to same element | Needs proportionally more traffic |
+| MVT | Multiple element combinations | High traffic (100K+/month) | Combinations multiply fast |
+| Bandit | Dynamic traffic allocation | High opportunity cost | Harder to reach significance |
+| Pre/Post | Before vs. after (no split) | Cannot split traffic | Weakest causal evidence |
+
+## Step 5: Test Design by Element
+
+### Headline Tests
+Test: value prop angle, specificity, social proof integration, question vs. statement, length. Measure: conversion rate, bounce rate, scroll depth.
+
+### CTA Tests
+Test: button copy (action vs. benefit), color (contrast), size, placement, surrounding copy. Measure: click-through rate, conversion rate.
+
+### Layout Tests
+Test: single vs. two column, long vs. short form, section order, video vs. static hero, with vs. without nav. Measure: conversion rate, scroll depth. Guardrail: page load time.
+
+### Pricing Tests
+Test: price point, billing display, tier count, feature allocation, default plan, anchoring, decoy pricing. Measure: **revenue per visitor** (not just CR). Guardrail: support tickets, refund rate.
+
+### Copy Tests
+Test: tone, length, format (paragraphs vs. bullets), emotional angle, proof type. Measure: conversion rate, read depth.
+
+## Step 6: Running the Test
+
+### Pre-Launch Checklist
+
+- [ ] Hypothesis documented with primary metric defined
+- [ ] Sample size calculated, traffic sufficient
+- [ ] QA on both variants across devices and browsers
+- [ ] Tracking verified -- conversions fire correctly for both variants
+- [ ] No other tests on same page/funnel
+- [ ] Traffic allocation set (50/50)
+- [ ] Exclusion criteria defined (bots, internal IPs)
+- [ ] Stakeholders aligned on decision criteria before launch
+
+### During the Test
+
+- Do not peek for first 3-5 days (early results are misleading)
+- Do not stop early unless guardrail metrics violated
+- Monitor for technical issues and tracking accuracy
+- Watch for sample ratio mismatch (SRM): >1% deviation means setup problem
+- Do not add variants mid-test
+
+### Post-Test Analysis
+
+```
+TEST RESULTS
+============
+Test: [name] | Duration: [days] | Sample: [n] | Split: [%/%]
+SRM Check: [Pass/Fail]
+
+| Variant | Visitors | Conversions | CR | vs Control | p-value | Significant? |
+|---------|----------|-------------|-----|------------|---------|--------------|
+| Control | X,XXX | XXX | X.XX% | -- | -- | -- |
+| Var B | X,XXX | XXX | X.XX% | +X.X% | 0.XXX | Yes/No |
+
+DECISION: [Implement / Keep Control / Iterate]
+REASONING: [Data-based rationale]
+NEXT TEST: [What to test next]
+```
+
+## Step 7: Common Pitfalls
+
+1. **Peeking**: Checking daily inflates false positives to 25-30%. Commit to sample size upfront.
+2. **Underpowered tests**: "No result" often means "not enough data."
+3. **Too many variables**: Isolate one variable per test.
+4. **Ignoring segments**: Overall flat, but mobile wins / desktop loses. Always segment.
+5. **Novelty effect**: Run 2+ weeks to account for novelty wearing off.
+6. **Multiple comparisons**: One primary metric. Bonferroni correction for extras.
+7. **Practical significance**: A significant 0.1% lift may not be worth implementing.
+
+## Step 8: Test Prioritization (ICE Scoring)
+
+```
+Impact (1-10): How much will this move the metric?
+Confidence (1-10): How likely to produce a result?
+Ease (1-10): How easy to implement?
+ICE Score = (Impact + Confidence + Ease) / 3
+```
+
+### Roadmap Template
+
+```
+EXPERIMENTATION ROADMAP
+Quarter: [Q] | Page: [target] | Traffic: [volume] | Current CR: [X%]
+
+| Priority | Test | ICE | Duration | Status |
+|----------|------|-----|----------|--------|
+| 1 | ... | 8.3 | 14 days | Ready |
+| 2 | ... | 7.7 | 21 days | Ready |
+| 3 | ... | 7.0 | 14 days | Idea |
+```
+
+Run tests sequentially on the same page to avoid interaction effects. Provide a backlog ranked by ICE score.

--- a/.claude/skills/affiliate-marketing/SKILL.md
+++ b/.claude/skills/affiliate-marketing/SKILL.md
@@ -1,0 +1,247 @@
+---
+name: affiliate-marketing
+description: Build and manage an affiliate marketing program. Use when the user says "affiliate program", "affiliate marketing", "affiliate partners", "referral commissions", "affiliate network", "partner program", "affiliate tracking", or asks about creating, managing, or growing an affiliate or partner program.
+---
+
+# Affiliate Marketing Skill
+
+You are an affiliate marketing strategist. Help build, launch, and optimize affiliate programs that drive revenue through partner referrals.
+
+## Affiliate Program Design
+
+### Commission Models
+
+| Model | How It Works | Best For | Typical Rate |
+|-------|-------------|----------|-------------|
+| **Revenue share** | % of each sale | SaaS, subscriptions | 15-30% recurring |
+| **Flat fee per sale** | Fixed $ per conversion | E-commerce, one-time purchases | $5-$200 |
+| **Tiered commission** | Higher % at higher volumes | Motivating top affiliates | 15-40% scaling |
+| **CPA (Cost per Action)** | Fixed $ per lead/trial | Lead gen, freemium | $5-$100 |
+| **Hybrid** | Base + bonus | Complex products | Varies |
+
+### Commission Rate Benchmarks
+
+| Industry | Typical Rate | Top Programs |
+|----------|-------------|-------------|
+| SaaS (B2B) | 20-30% recurring | Some offer 40-50% first year |
+| SaaS (B2C) | 15-25% recurring | 30% for annual plans |
+| E-commerce | 5-15% per sale | Up to 20% for high-margin products |
+| Online courses | 30-50% per sale | Up to 75% for affiliates with large audiences |
+| Financial services | $50-$200 per lead | Higher for premium products |
+| Hosting/domains | $50-$200 per sale | Flat fee common |
+
+### Cookie Duration
+
+How long after clicking an affiliate link is the referral tracked?
+
+| Duration | Use Case |
+|----------|----------|
+| 24 hours | Amazon (low, but high volume) |
+| 30 days | Standard for most programs |
+| 60-90 days | B2B with longer sales cycles |
+| 365 days | High-value products, generous programs |
+| Lifetime | First-click attribution (rare, very attractive to affiliates) |
+
+**Recommendation:** 60-90 days for B2B SaaS, 30 days for B2C/e-commerce.
+
+## Program Setup
+
+### Platform Options
+
+| Platform | Best For | Pricing |
+|----------|----------|---------|
+| **PartnerStack** | B2B SaaS | $$$, enterprise |
+| **FirstPromoter** | SaaS startups | $49-$149/mo |
+| **Rewardful** | Stripe-based SaaS | $49-$299/mo |
+| **ShareASale** | E-commerce | Setup + transaction fees |
+| **Impact** | Enterprise | Custom pricing |
+| **Post Affiliate Pro** | Self-hosted | $129-$599/mo |
+| **Tapfiliate** | SaaS/e-commerce | $89-$149/mo |
+| **Custom built** | Full control | Dev time + maintenance |
+
+### Program Page Essentials
+
+Your affiliate program page should include:
+
+1. **Headline:** Clear value prop for affiliates
+2. **Commission structure:** Transparent rates and terms
+3. **Cookie duration:** How long referrals are tracked
+4. **Payment terms:** When and how affiliates get paid (Net 30/60)
+5. **Promotional assets:** What you provide (banners, copy, links)
+6. **Success stories:** Earnings examples from existing affiliates
+7. **FAQ:** Common questions answered
+8. **Application form:** Simple signup process
+
+### Terms of Service
+
+Key terms to include:
+- Commission rates and payment schedule
+- Cookie duration and attribution model
+- Prohibited promotion methods (spam, brand bidding, misleading claims)
+- Minimum payout threshold ($50-$100)
+- Program modification rights
+- Termination conditions
+- Trademark usage guidelines
+- FTC disclosure requirements
+
+## Recruiting Affiliates
+
+### Affiliate Tiers
+
+| Tier | Profile | Commission | Support Level |
+|------|---------|-----------|--------------|
+| **Content creators** | Bloggers, YouTubers, podcasters | Standard | Self-serve |
+| **Influencers** | Social media followings | Standard + bonus | Medium touch |
+| **Review sites** | Comparison and review platforms | Standard | Self-serve |
+| **Existing customers** | Happy users who refer | Standard | Self-serve |
+| **Super affiliates** | High-volume professional affiliates | Premium | High touch |
+| **Strategic partners** | Complementary businesses | Custom | Partnership model |
+
+### Recruitment Strategies
+
+1. **Competitor's affiliates** — Search for "{competitor} affiliate program" and reach out to people promoting them
+2. **Content creators in your niche** — Find bloggers/YouTubers who review similar products
+3. **Your own customers** — Invite happy customers to earn by referring
+4. **Affiliate networks** — List on ShareASale, Impact, PartnerStack marketplace
+5. **Outreach campaigns** — Direct email/DM to relevant creators
+
+### Outreach Template
+
+```
+Subject: Partner opportunity: Earn {X}% promoting {Product}
+
+Hi {Name},
+
+I noticed your {content piece/channel/blog} about {topic} — great work on {specific compliment}.
+
+We just launched our affiliate program for {Product}, which {one-sentence value prop}.
+I think it'd be a great fit for your audience because {specific reason}.
+
+Here's what we offer affiliates:
+- {X}% recurring commission
+- {Y}-day cookie window
+- Dedicated affiliate support
+- Custom landing pages and promo assets
+
+Our top affiliates earn ${X,XXX}/month. Want me to send you details?
+
+{Your name}
+```
+
+## Optimization
+
+### Key Metrics
+
+| Metric | Formula | Good | Action if Low |
+|--------|---------|------|--------------|
+| Activation rate | Active affiliates / Total affiliates | 20-30% | Improve onboarding, provide more assets |
+| Click-through rate | Clicks / Impressions | 1-5% | Better creative, more relevant placement |
+| Conversion rate | Sales / Clicks | 2-10% | Improve landing page, offer, or targeting |
+| Avg. order value | Revenue / Orders | Varies | Upsell/cross-sell offers for affiliates |
+| Revenue per affiliate | Total revenue / Active affiliates | Varies | Recruit higher-quality affiliates |
+| Payback period | Commission / Customer LTV | <6 months | Adjust rates or target higher-LTV segments |
+
+### Affiliate Activation
+
+Most affiliates sign up and do nothing. Activate them with:
+
+```
+Day 0: Welcome email + quick start guide
+Day 3: "Your first promotion" email with templates
+Day 7: Check-in email — "Need help getting started?"
+Day 14: Case study of successful affiliate
+Day 30: If no activity, "Is {Product} still a fit?" email
+```
+
+### Providing Promotional Assets
+
+| Asset | Purpose |
+|-------|---------|
+| Banner ads (multiple sizes) | Display advertising |
+| Email templates | Email marketing |
+| Social media posts | Ready-to-share content |
+| Product screenshots | Blog posts and reviews |
+| Comparison tables | Competitor comparison content |
+| Custom landing pages | Higher conversion rates |
+| Video clips / B-roll | YouTube and social video |
+| Discount codes | Exclusive offers for their audience |
+| Data sheets / one-pagers | B2B affiliate sales |
+
+## Compliance & Legal
+
+### FTC Disclosure Requirements
+
+All affiliates must disclose their financial relationship:
+
+```
+Required disclosures:
+- Blog: "This post contains affiliate links. I may earn a commission..."
+- Social: "#ad" or "#affiliate" clearly visible
+- Video: Verbal disclosure + on-screen text
+- Email: "This email contains affiliate links"
+```
+
+### Prohibited Activities
+
+Define clearly in your terms:
+- Spam (email, social, forum)
+- Brand bidding (PPC ads on your brand name)
+- Cookie stuffing or forced clicks
+- Misleading claims about the product
+- Trademark violations
+- Coupon/deal sites without permission
+
+## Output Format
+
+```markdown
+# Affiliate Program Strategy: {Product}
+
+## Program Design
+
+| Element | Details |
+|---------|---------|
+| Commission model | {model} |
+| Commission rate | {rate} |
+| Cookie duration | {days} |
+| Payment terms | {Net 30/60} |
+| Min. payout | ${amount} |
+| Platform | {platform} |
+
+## Target Affiliates
+
+| Tier | Profile | Recruitment Strategy | Est. Count |
+|------|---------|---------------------|-----------|
+
+## Launch Plan
+
+### Week 1-2: Setup
+{Tasks}
+
+### Week 3-4: Soft Launch
+{Tasks}
+
+### Month 2-3: Recruitment
+{Tasks}
+
+### Month 4+: Optimization
+{Tasks}
+
+## Promotional Assets Needed
+{List of assets to create}
+
+## Budget
+| Item | Monthly Cost |
+|------|-------------|
+
+## Success Metrics
+| Metric | Month 3 Target | Month 6 Target |
+```
+
+## Important Notes
+
+- Affiliate programs take 3-6 months to gain traction. Be patient.
+- 80% of affiliate revenue typically comes from 20% of affiliates. Invest in your top performers.
+- Always pay affiliates on time. Late payments destroy relationships and your program's reputation.
+- Monitor for fraud: unusual click patterns, abnormal conversion spikes, brand bidding violations.
+- Affiliates promote what converts. If your conversion rate is low, fix your product/landing page before scaling the program.
+- Recurring commissions (for SaaS) are more attractive to affiliates than one-time payments and incentivize them to promote long-term.

--- a/.claude/skills/ahrefs-research/SKILL.md
+++ b/.claude/skills/ahrefs-research/SKILL.md
@@ -1,0 +1,211 @@
+---
+name: ahrefs-python
+description: Manages Ahrefs API usage in Python using `ahrefs-python` library. Use when working with SEO / marketing related tasks or with data including backlinks, keywords, domain ratings, organic traffic, site audits, rank tracking, and brand monitoring. Covers `ahrefs-python` usage including AhrefsClient / AsyncAhrefsClient, typed request/response models, error handling, and all API sections.
+---
+
+# Ahrefs Python SDK Skill
+
+## Overview
+
+The Ahrefs API provides programmatic access to Ahrefs SEO data. The official Python SDK (`ahrefs-python`) provides typed request and response models for all endpoints, auto-generated from the OpenAPI spec.
+
+Key capabilities:
+- **Site Explorer** - Backlinks, organic keywords, domain rating, traffic, referring domains
+- **Keywords Explorer** - Keyword research, volumes, difficulty, related terms
+- **Rank Tracker** - SERP monitoring, competitor tracking
+- **Site Audit** - Technical SEO issues, page content, page explorer
+- **Brand Radar** - AI brand mentions, share of voice, impressions
+- **SERP Overview** - Search result analysis
+- **Batch Analysis** - Bulk domain/URL metrics via POST
+
+## Installation
+
+```sh
+pip3 install git+https://github.com/ahrefs/ahrefs-python.git
+```
+
+Requires Python 3.11+. Dependencies: `httpx`, `pydantic`.
+
+## API Method Discovery
+
+The SDK has 52 methods across 7 API sections. The built-in search tool is the fastest way to find the right method — it returns matching method signatures, parameters, and return types directly, so there's no need to scan through a large reference.
+
+**Python** (preferred when already in a Python context):
+
+```python
+from ahrefs.search import search_api_methods
+
+# Returns formatted text with method signatures, parameters, and return types
+print(search_api_methods("domain rating"))
+
+# Filter by API section and limit results
+print(search_api_methods("backlinks", section="site-explorer", limit=3))
+```
+
+**CLI** (preferred when exploring from the terminal):
+
+```sh
+# Ensure python3 points to the interpreter where ahrefs-python is installed:
+#   which python3
+#   python3 -c "import ahrefs"
+python3 -m ahrefs.api_search "domain rating"
+python3 -m ahrefs.api_search "backlinks" --section site-explorer --limit 3
+python3 -m ahrefs.api_search "batch" --json
+python3 -m ahrefs.api_search --sections  # list all API sections
+```
+
+## IMPORTANT RULES
+
+- ALWAYS use the `ahrefs-python` SDK. DO NOT make raw `httpx`/`requests` calls to the Ahrefs API.
+- ALWAYS pass dates as strings in `YYYY-MM-DD` format (e.g. `"2025-01-15"`).
+- ALWAYS use `select` on list endpoints to request only the columns you need. List endpoints return all columns by default, which wastes API units and increases response size.
+- USE context managers (`with` / `async with`) for client lifecycle management.
+- NEVER hardcode API keys in source code. Use the `AHREFS_API_KEY` environment variable or your preferred secrets mechanism.
+- The client handles retries (429, 5xx, connection errors) automatically. DO NOT implement your own retry logic on top of the SDK.
+
+## Quick Start
+
+```python
+import os
+from ahrefs import AhrefsClient
+
+with AhrefsClient(api_key=os.environ["AHREFS_API_KEY"]) as client:
+    data = client.site_explorer_domain_rating(target="ahrefs.com", date="2025-01-15")
+    print(data.domain_rating)  # 91.0
+    print(data.ahrefs_rank)    # 3
+```
+
+## SDK Patterns
+
+### Client Setup
+
+```python
+import os
+import ahrefs
+
+with ahrefs.AhrefsClient(
+    api_key=os.environ["AHREFS_API_KEY"],  # or any secrets source
+    base_url="...",          # override API base URL (default: https://api.ahrefs.com/v3)
+    timeout=30.0,            # request timeout in seconds (default: 60)
+    max_retries=3,           # retries on transient errors (default: 2)
+) as client:
+    ...
+```
+
+Async client:
+
+```python
+import os
+from ahrefs import AsyncAhrefsClient
+
+async with AsyncAhrefsClient(api_key=os.environ["AHREFS_API_KEY"]) as client:
+    data = await client.site_explorer_domain_rating(target="ahrefs.com", date="2025-01-15")
+```
+
+For parallel calls, use `asyncio.gather`:
+
+```python
+import asyncio
+
+async with AsyncAhrefsClient(api_key=os.environ["AHREFS_API_KEY"]) as client:
+    dr_ahrefs, dr_moz = await asyncio.gather(
+        client.site_explorer_domain_rating(target="ahrefs.com", date="2025-01-15"),
+        client.site_explorer_domain_rating(target="moz.com", date="2025-01-15"),
+    )
+```
+
+### Calling Methods
+
+Two calling styles -- both are equivalent:
+
+```python
+# Keyword arguments (recommended)
+data = client.site_explorer_domain_rating(target="ahrefs.com", date="2025-01-15")
+
+# Request objects (full type safety)
+from ahrefs.types import SiteExplorerDomainRatingRequest
+request = SiteExplorerDomainRatingRequest(target="ahrefs.com", date="2025-01-15")
+data = client.site_explorer_domain_rating(request)
+```
+
+Method names follow `{api_section}_{endpoint}`, e.g. `site_explorer_organic_keywords`, `keywords_explorer_overview`.
+
+### Responses
+
+Methods return typed Data objects directly.
+
+**Scalar endpoints** return a single data object (or `None`):
+
+```python
+data = client.site_explorer_domain_rating(target="ahrefs.com", date="2025-01-15")
+print(data.domain_rating)
+```
+
+**List endpoints** return a list of data objects. There is no pagination — set `limit` to the number of results you need. Use `select` to request only the columns you need:
+
+```python
+items = client.site_explorer_organic_keywords(
+    target="ahrefs.com",
+    date="2025-01-15",
+    select="keyword,volume,best_position",
+    order_by="volume:desc",
+    limit=10,
+)
+for item in items:
+    print(item.keyword, item.volume, item.best_position)
+```
+
+### Error Handling
+
+```python
+import ahrefs
+
+try:
+    data = client.site_explorer_domain_rating(target="example.com", date="2025-01-15")
+except ahrefs.AuthenticationError:    # 401
+    ...
+except ahrefs.RateLimitError as e:    # 429 -- e.retry_after has the delay
+    ...
+except ahrefs.NotFoundError:          # 404
+    ...
+except ahrefs.APIError as e:          # other 4xx/5xx -- e.status_code, e.response_body
+    ...
+except ahrefs.APIConnectionError:     # network / timeout
+    ...
+```
+
+All exceptions inherit from `ahrefs.AhrefsError`.
+
+### Common Parameters
+
+Most list endpoints share these parameters:
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `target` | `str` | Domain, URL, or path to analyze |
+| `date` | `str` | Date in YYYY-MM-DD format |
+| `date_from` / `date_to` | `str` | Date range for history endpoints |
+| `country` | `str` | Two-letter country code (ISO 3166-1 alpha-2) |
+| `select` | `str` | Comma-separated columns to return |
+| `where` | `str` | Filter expression |
+| `order_by` | `str` | Column and direction, e.g. `"volume:desc"` |
+| `limit` | `int` | Max results to return |
+
+Parameters typed as enums in the API reference (`CountryEnum`, `VolumeModeEnum`, etc.) accept plain strings — pass `country="us"` not `CountryEnum("us")`.
+
+The `where` parameter takes a JSON string. Use `json.dumps()` to build it:
+
+```python
+import json
+where = json.dumps({"field": "volume", "is": ["gte", 1000]})
+items = client.site_explorer_organic_keywords(
+    target="ahrefs.com", date="2025-01-15",
+    select="keyword,volume", where=where,
+)
+```
+
+For full filter syntax (boolean combinators, operators, nested fields), see `references/filter-syntax.md`.
+
+## API Methods
+
+Use `search_api_methods("query")` or `python3 -m ahrefs.api_search "query"` to find methods by keyword. Search covers all 52 methods across 7 API sections and returns complete signatures, parameters, and response fields.

--- a/.claude/skills/ahrefs-research/references/api-methods.md
+++ b/.claude/skills/ahrefs-research/references/api-methods.md
@@ -1,0 +1,4336 @@
+# API Reference
+
+<!-- AUTO-GENERATED -- DO NOT EDIT -->
+
+
+
+<!-- mdformat-toc start --slug=github --no-anchors --maxlevel=6 --minlevel=1 -->
+
+- [API Reference](#api-reference)
+  - [Batch Analysis](#batch-analysis)
+    - [`batch_analysis()`](#batch_analysis)
+  - [Brand Radar](#brand-radar)
+    - [`brand_radar_ai_responses()`](#brand_radar_ai_responses)
+    - [`brand_radar_cited_domains()`](#brand_radar_cited_domains)
+    - [`brand_radar_cited_pages()`](#brand_radar_cited_pages)
+    - [`brand_radar_impressions_history()`](#brand_radar_impressions_history)
+    - [`brand_radar_impressions_overview()`](#brand_radar_impressions_overview)
+    - [`brand_radar_mentions_history()`](#brand_radar_mentions_history)
+    - [`brand_radar_mentions_overview()`](#brand_radar_mentions_overview)
+    - [`brand_radar_sov_history()`](#brand_radar_sov_history)
+    - [`brand_radar_sov_overview()`](#brand_radar_sov_overview)
+  - [Keywords Explorer](#keywords-explorer)
+    - [`keywords_explorer_matching_terms()`](#keywords_explorer_matching_terms)
+    - [`keywords_explorer_overview()`](#keywords_explorer_overview)
+    - [`keywords_explorer_related_terms()`](#keywords_explorer_related_terms)
+    - [`keywords_explorer_search_suggestions()`](#keywords_explorer_search_suggestions)
+    - [`keywords_explorer_volume_by_country()`](#keywords_explorer_volume_by_country)
+    - [`keywords_explorer_volume_history()`](#keywords_explorer_volume_history)
+  - [Rank Tracker](#rank-tracker)
+    - [`rank_tracker_competitors_overview()`](#rank_tracker_competitors_overview)
+    - [`rank_tracker_competitors_pages()`](#rank_tracker_competitors_pages)
+    - [`rank_tracker_competitors_stats()`](#rank_tracker_competitors_stats)
+    - [`rank_tracker_overview()`](#rank_tracker_overview)
+    - [`rank_tracker_serp_overview()`](#rank_tracker_serp_overview)
+  - [Serp Overview](#serp-overview)
+    - [`serp_overview()`](#serp_overview)
+  - [Site Audit](#site-audit)
+    - [`site_audit_issues()`](#site_audit_issues)
+    - [`site_audit_page_content()`](#site_audit_page_content)
+    - [`site_audit_page_explorer()`](#site_audit_page_explorer)
+    - [`site_audit_projects()`](#site_audit_projects)
+  - [Site Explorer](#site-explorer)
+    - [`site_explorer_all_backlinks()`](#site_explorer_all_backlinks)
+    - [`site_explorer_anchors()`](#site_explorer_anchors)
+    - [`site_explorer_backlinks_stats()`](#site_explorer_backlinks_stats)
+    - [`site_explorer_best_by_external_links()`](#site_explorer_best_by_external_links)
+    - [`site_explorer_best_by_internal_links()`](#site_explorer_best_by_internal_links)
+    - [`site_explorer_broken_backlinks()`](#site_explorer_broken_backlinks)
+    - [`site_explorer_domain_rating()`](#site_explorer_domain_rating)
+    - [`site_explorer_domain_rating_history()`](#site_explorer_domain_rating_history)
+    - [`site_explorer_keywords_history()`](#site_explorer_keywords_history)
+    - [`site_explorer_linked_anchors_external()`](#site_explorer_linked_anchors_external)
+    - [`site_explorer_linked_anchors_internal()`](#site_explorer_linked_anchors_internal)
+    - [`site_explorer_linkeddomains()`](#site_explorer_linkeddomains)
+    - [`site_explorer_metrics()`](#site_explorer_metrics)
+    - [`site_explorer_metrics_by_country()`](#site_explorer_metrics_by_country)
+    - [`site_explorer_metrics_history()`](#site_explorer_metrics_history)
+    - [`site_explorer_organic_competitors()`](#site_explorer_organic_competitors)
+    - [`site_explorer_organic_keywords()`](#site_explorer_organic_keywords)
+    - [`site_explorer_outlinks_stats()`](#site_explorer_outlinks_stats)
+    - [`site_explorer_pages_by_traffic()`](#site_explorer_pages_by_traffic)
+    - [`site_explorer_pages_history()`](#site_explorer_pages_history)
+    - [`site_explorer_paid_pages()`](#site_explorer_paid_pages)
+    - [`site_explorer_refdomains()`](#site_explorer_refdomains)
+    - [`site_explorer_refdomains_history()`](#site_explorer_refdomains_history)
+    - [`site_explorer_top_pages()`](#site_explorer_top_pages)
+    - [`site_explorer_total_search_volume_history()`](#site_explorer_total_search_volume_history)
+    - [`site_explorer_url_rating_history()`](#site_explorer_url_rating_history)
+
+<!-- mdformat-toc end -->
+
+All methods below are available on both `AhrefsClient` (sync) and
+`AsyncAhrefsClient` (async). The async client uses the same method
+names — just `await` the call.
+
+For filter expression syntax (`where` parameter), see [Filter Syntax](filter-syntax.md).
+
+______________________________________________________________________
+
+## Batch Analysis
+
+### `batch_analysis()`
+
+Batch Analysis.
+
+**Parameters:**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `select` | `list[str]` | Yes | A list of columns to return. See response schema for valid column identifiers. |
+| `order_by` | `str` | No | |
+| `country` | `CountryEnum` | No | A two-letter country code (ISO 3166-1 alpha-2). |
+| `volume_mode` | `VolumeModeEnum` | No | The search volume calculation mode: monthly or average. It affects volume, traffic, and traffic value. |
+| `targets` | `list[BatchAnalysisTarget]` | Yes | A list of targets to do batch analysis. |
+
+**Returns:** `list[BatchAnalysisData]`
+
+<details>
+<summary>35 fields</summary>
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `ahrefs_rank` | `int \| None` | The strength of your target's backlink profile compared to the other websites in our database, with rank #1 being the strongest. |
+| `backlinks` | `int \| None` | The total number of links from other websites pointing to your target. |
+| `backlinks_dofollow` | `int \| None` | Links to your target that do not contain a “nofollow”, “ugc”, or “sponsored” value in their “rel” attribute. These links are also called “dofollow”. |
+| `backlinks_internal` | `int \| None` | The total number of internal links pointing to the target's pages. |
+| `backlinks_nofollow` | `int \| None` | Links to your target that contain a “nofollow”, “ugc”, or “sponsored” value in their “rel” attribute. |
+| `backlinks_redirect` | `int \| None` | Links pointing to your target via a redirect. |
+| `domain_rating` | `float \| None` | The strength of your target's backlink profile compared to the other websites in our database on a 100-point logarithmic scale. |
+| `index` | `int` | Target index number. |
+| `ip` | `str \| None` | The IP address of the target. |
+| `linked_domains` | `int \| None` | The number of unique domains linked from your target. |
+| `linked_domains_dofollow` | `int \| None` | The number of unique domains linked from your target with followed links. |
+| `mode` | `str` | The target mode used for the analysis. Depending on the selected mode (Exact URL, Path, Domain, Subdomains), different parts of the website will be analyzed. |
+| `org_cost` | `int \| None` | (10 units) The estimated value of your target’s monthly organic search traffic. |
+| `org_keywords` | `int \| None` | The total number of keywords that your target ranks for in the top 100 organic search results. When ranking for the same keyword across different locations in “All locations” mode, it's still counted as one keyword. |
+| `org_keywords_11_20` | `int \| None` | The total number of unique keywords for which your target's top organic ranking position is within the 11th to 20th results. When ranking for the same keyword across different locations in “All locations” mode, it's still counted as one keyword. |
+| `org_keywords_1_3` | `int \| None` | The total number of unique keywords for which your target's top organic ranking position is within the top 3 results. When ranking for the same keyword across different locations in “All locations” mode, it's still counted as one keyword. |
+| `org_keywords_21_50` | `int \| None` | The total number of unique keywords for which your target's top organic ranking position is within the 21st to 50th results. When ranking for the same keyword across different locations in “All locations” mode, it's still counted as one keyword. |
+| `org_keywords_4_10` | `int \| None` | The total number of unique keywords for which your target's top organic ranking position is within the 4th to 10th results. When ranking for the same keyword across different locations in “All locations” mode, it's still counted as one keyword. |
+| `org_keywords_51_plus` | `int \| None` | The total number of unique keywords for which your target's top organic ranking position is the 51st result or higher. When ranking for the same keyword across different locations in “All locations” mode, it's still counted as one keyword. |
+| `org_traffic` | `int \| None` | (10 units) The estimated number of monthly visits that your target gets from organic search. |
+| `org_traffic_top_by_country` | `list[list[Any] \| None]` | (10 units) Top countries by traffic with corresponding traffic values. (Currently only a single element is being returned with the country with the most traffic.) |
+| `outgoing_links` | `int \| None` | The total number of links from your target to other domains. |
+| `outgoing_links_dofollow` | `int \| None` | The total number of followed links from your target to other domains. |
+| `paid_ads` | `int \| None` | The total number of unique ads of a target website or URL in paid search results. |
+| `paid_cost` | `int \| None` | (10 units) The estimated cost of your target’s monthly paid search traffic. |
+| `paid_keywords` | `int \| None` | The total number of keywords that your target ranks for in paid search results. When ranking for the same keyword across different locations in “All locations” mode, it's still counted as one keyword. |
+| `paid_traffic` | `int \| None` | (10 units) The estimated number of monthly visits that your target gets from paid search. |
+| `protocol` | `str` | The protocol of the target. Possible values: `both`, `http`, `https`. |
+| `refdomains` | `int \| None` | (5 units) The total number of unique domains linking to your target. |
+| `refdomains_dofollow` | `int \| None` | (5 units) The number of unique domains with links to your target that do not contain a “nofollow”, “ugc”, or “sponsored” value in their “rel” attribute. These links are also called “dofollow”. |
+| `refdomains_nofollow` | `int \| None` | (5 units) The number of unique domains that only have links to your target containing a “nofollow”, “ugc”, or “sponsored” value in their “rel” attribute. |
+| `refips` | `int \| None` | The number of unique IP addresses with at least one domain pointing to your target. Several domains can share one IP address. |
+| `refips_subnets` | `int \| None` | The number of c-class IP networks (AAA.BBB.CCC.DDD) with at least one link to your target. Example: 151.80.39.61 is the website IP address where 151.80.39.XXX is the subnet. |
+| `url` | `str` | The URL of the analyzed target. |
+| `url_rating` | `float \| None` | URL Rating (UR) shows the strength of your target page's backlink profile on a 100-point logarithmic scale. If you analyze a domain, the homepage's UR is shown. |
+
+</details>
+
+______________________________________________________________________
+
+## Brand Radar
+
+### `brand_radar_ai_responses()`
+
+AI Responses.
+
+**Parameters:**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `timeout` | `int` | No | A manual timeout duration in seconds. |
+| `limit` | `int` | No | The number of results to return. |
+| `where` | `str` | No | Filter expression ([syntax](filter-syntax.md)). Filterable fields listed below. |
+| `select` | `SelectStr` | Yes | A comma-separated list of columns to return. See response schema for valid column identifiers. |
+| `date` | `DateStr` | No | The date to search for in YYYY-MM-DD format. |
+| `country` | `CountryEnum` | No | A two-letter country code (ISO 3166-1 alpha-2). |
+| `order_by` | `OrderByEnum` | No | A column to order the results by. |
+| `report_id` | `str` | No | The ID of the report to use. If one is given, other parameters are taken from the report (brand, competitors, market, country, filters). If country or filters are provided, they override the ones in the report. You can find it in the URL of your Brand Radar report in Ahrefs: `https://app.ahrefs.com/brand-radar/reports/#report_id#/...` |
+| `prompts` | `PromptsEnum` | No | The type of prompts to use. If not specified, both will be used. Custom prompts require a report_id to be provided. |
+| `data_source` | `DataSourceEnum` | Yes | The chatbot model to use. |
+| `market` | `str` | No | A comma-separated list of the niche markets of your brands. |
+| `competitors` | `str` | No | A comma-separated list of competitors of your brands. |
+| `brand` | `str` | No | A comma-separated list of brands to search for. At least one of brand, competitors, market or where should not be empty. |
+
+<details>
+<summary>Filterable fields (7 fields)</summary>
+
+- `cited_domain` (domain)
+- `cited_domain_subdomains` (string)
+- `cited_url_exact` (string)
+- `cited_url_prefix` (string)
+- `question` (string)
+- `response` (string)
+- `topic` (string)
+
+</details>
+
+**Returns:** `list[BrandRadarAiResponsesData]`
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `country` | `str` | The country of the question. |
+| `links` | `list[dict[str, Any] \| None]` | (10 units) The links used for the response. |
+| `question` | `str` | The question asked by the user. |
+| `response` | `str` | (10 units) The response from the model. |
+| `volume` | `int` | (10 units) Estimated monthly searches. This is based on our estimates for Google, combining the search volumes of related keywords where this question appears in People Also Ask section. |
+
+### `brand_radar_cited_domains()`
+
+Cited Domains.
+
+**Parameters:**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `where` | `str` | No | Filter expression ([syntax](filter-syntax.md)). Filterable fields listed below. |
+| `select` | `SelectStr` | Yes | A comma-separated list of columns to return. See response schema for valid column identifiers. |
+| `limit` | `int` | No | The number of results to return. |
+| `date` | `DateStr` | No | The date to search for in YYYY-MM-DD format. |
+| `country` | `CountryEnum` | No | A two-letter country code (ISO 3166-1 alpha-2). |
+| `report_id` | `str` | No | The ID of the report to use. If one is given, other parameters are taken from the report (brand, competitors, market, country, filters). If country or filters are provided, they override the ones in the report. You can find it in the URL of your Brand Radar report in Ahrefs: `https://app.ahrefs.com/brand-radar/reports/#report_id#/...` |
+| `prompts` | `PromptsEnum` | No | The type of prompts to use. If not specified, both will be used. Custom prompts require a report_id to be provided. |
+| `data_source` | `DataSourceEnum` | Yes | The chatbot model to use. |
+| `market` | `str` | No | A comma-separated list of the niche markets of your brands. |
+| `competitors` | `str` | No | A comma-separated list of competitors of your brands. |
+| `brand` | `str` | No | A comma-separated list of brands to search for. At least one of brand, competitors, market or where should not be empty. |
+
+<details>
+<summary>Filterable fields (7 fields)</summary>
+
+- `cited_domain` (domain)
+- `cited_domain_subdomains` (string)
+- `cited_url_exact` (string)
+- `cited_url_prefix` (string)
+- `question` (string)
+- `response` (string)
+- `topic` (string)
+
+</details>
+
+**Returns:** `list[BrandRadarCitedDomainsData]`
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `domain` | `str` | The cited domain name. |
+| `mentions` | `list[dict[str, Any] \| None]` | Deprecated on 2026-02-10. |
+| `pages` | `int` | The number of unique pages from the domain that were cited in the responses. |
+| `responses` | `int` | The number of responses that cited the domain. |
+| `volume` | `int` | (10 units) Estimated monthly searches that cited the domain. Based on the average monthly number of searches for the query on Google over the latest known 12 months of data. |
+
+### `brand_radar_cited_pages()`
+
+Cited Pages.
+
+**Parameters:**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `where` | `str` | No | Filter expression ([syntax](filter-syntax.md)). Filterable fields listed below. |
+| `select` | `SelectStr` | Yes | A comma-separated list of columns to return. See response schema for valid column identifiers. |
+| `limit` | `int` | No | The number of results to return. |
+| `date` | `DateStr` | No | The date to search for in YYYY-MM-DD format. |
+| `country` | `CountryEnum` | No | A two-letter country code (ISO 3166-1 alpha-2). |
+| `report_id` | `str` | No | The ID of the report to use. If one is given, other parameters are taken from the report (brand, competitors, market, country, filters). If country or filters are provided, they override the ones in the report. You can find it in the URL of your Brand Radar report in Ahrefs: `https://app.ahrefs.com/brand-radar/reports/#report_id#/...` |
+| `prompts` | `PromptsEnum` | No | The type of prompts to use. If not specified, both will be used. Custom prompts require a report_id to be provided. |
+| `data_source` | `DataSourceEnum` | Yes | The chatbot model to use. |
+| `market` | `str` | No | A comma-separated list of the niche markets of your brands. |
+| `competitors` | `str` | No | A comma-separated list of competitors of your brands. |
+| `brand` | `str` | No | A comma-separated list of brands to search for. At least one of brand, competitors, market or where should not be empty. |
+
+<details>
+<summary>Filterable fields (7 fields)</summary>
+
+- `cited_domain` (domain)
+- `cited_domain_subdomains` (string)
+- `cited_url_exact` (string)
+- `cited_url_prefix` (string)
+- `question` (string)
+- `response` (string)
+- `topic` (string)
+
+</details>
+
+**Returns:** `list[BrandRadarCitedPagesData]`
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `mentions` | `list[dict[str, Any] \| None]` | Deprecated on 2026-02-10. |
+| `responses` | `int` | The number of responses that cited the page. |
+| `url` | `str` | The URL of the cited page. |
+| `volume` | `int` | (10 units) Estimated monthly searches that cited the page. Based on the average monthly number of searches for the query on Google over the latest known 12 months of data. |
+
+### `brand_radar_impressions_history()`
+
+Overview history - Impressions.
+
+**Parameters:**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `where` | `str` | No | Filter expression ([syntax](filter-syntax.md)). Filterable fields listed below. |
+| `date_to` | `DateStr` | No | The end date of the historical period in YYYY-MM-DD format. |
+| `date_from` | `DateStr` | Yes | The start date of the historical period in YYYY-MM-DD format. |
+| `country` | `CountryEnum` | No | A two-letter country code (ISO 3166-1 alpha-2). |
+| `report_id` | `str` | No | The ID of the report to use. If one is given, other parameters are taken from the report (market, country, filters). If country or filters are provided, they override the ones in the report. You can find it in the URL of your Brand Radar report in Ahrefs: `https://app.ahrefs.com/brand-radar/reports/#report_id#/...` |
+| `prompts` | `PromptsEnum` | No | The type of prompts to use. If not specified, both will be used. Custom prompts require a report_id to be provided. |
+| `data_source` | `DataSourceEnum` | Yes | The chatbot model to use. |
+| `market` | `str` | No | A comma-separated list of the niche markets of your brands. |
+| `brand` | `str` | Yes | The brand to search for. |
+
+<details>
+<summary>Filterable fields (7 fields)</summary>
+
+- `cited_domain` (domain)
+- `cited_domain_subdomains` (string)
+- `cited_url_exact` (string)
+- `cited_url_prefix` (string)
+- `question` (string)
+- `response` (string)
+- `topic` (string)
+
+</details>
+
+**Returns:** `list[BrandRadarImpressionsHistoryData]`
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `date` | `str` | |
+| `impressions` | `int` | Estimated impressions from responses mentioning the brand. |
+
+### `brand_radar_impressions_overview()`
+
+Overview - Impressions.
+
+**Parameters:**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `where` | `str` | No | Filter expression ([syntax](filter-syntax.md)). Filterable fields listed below. |
+| `select` | `SelectStr` | Yes | A comma-separated list of columns to return. See response schema for valid column identifiers. |
+| `country` | `CountryEnum` | No | A two-letter country code (ISO 3166-1 alpha-2). |
+| `report_id` | `str` | No | The ID of the report to use. If one is given, other parameters are taken from the report (brand, competitors, market, country, filters). If country or filters are provided, they override the ones in the report. You can find it in the URL of your Brand Radar report in Ahrefs: `https://app.ahrefs.com/brand-radar/reports/#report_id#/...` |
+| `prompts` | `PromptsEnum` | No | The type of prompts to use. If not specified, both will be used. Custom prompts require a report_id to be provided. |
+| `data_source` | `DataSourceEnum` | Yes | The chatbot model to use. |
+| `market` | `str` | No | A comma-separated list of the niche markets of your brands. |
+| `competitors` | `str` | No | A comma-separated list of competitors of your brands. |
+| `brand` | `str` | No | A comma-separated list of brands to search for. At least one of brand, competitors, market or where should not be empty. |
+
+<details>
+<summary>Filterable fields (7 fields)</summary>
+
+- `cited_domain` (domain)
+- `cited_domain_subdomains` (string)
+- `cited_url_exact` (string)
+- `cited_url_prefix` (string)
+- `question` (string)
+- `response` (string)
+- `topic` (string)
+
+</details>
+
+**Returns:** `list[BrandRadarImpressionsOverviewData]`
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `brand` | `str` | Brand name (either your brand or a competitor provided in the request). |
+| `no_tracked_brands` | `int` | Estimated impressions from responses related to the specified market that do not mention any provided brands (value is zero when `market` is not specified). |
+| `only_competitors_brands` | `int` | Estimated impressions from responses mentioning only competitor brands. |
+| `only_target_brand` | `int` | Estimated impressions from responses mentioning only your brand. |
+| `target_and_competitors_brands` | `int` | Estimated impressions from responses mentioning both your and competitor brands. |
+| `total` | `int` | Total estimated impressions for your brand (includes both `only_target_brand` and `target_and_competitors_brands`). |
+
+### `brand_radar_mentions_history()`
+
+Overview history - Mentions.
+
+**Parameters:**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `where` | `str` | No | Filter expression ([syntax](filter-syntax.md)). Filterable fields listed below. |
+| `date_to` | `DateStr` | No | The end date of the historical period in YYYY-MM-DD format. |
+| `date_from` | `DateStr` | Yes | The start date of the historical period in YYYY-MM-DD format. |
+| `country` | `CountryEnum` | No | A two-letter country code (ISO 3166-1 alpha-2). |
+| `report_id` | `str` | No | The ID of the report to use. If one is given, other parameters are taken from the report (market, country, filters). If country or filters are provided, they override the ones in the report. You can find it in the URL of your Brand Radar report in Ahrefs: `https://app.ahrefs.com/brand-radar/reports/#report_id#/...` |
+| `prompts` | `PromptsEnum` | No | The type of prompts to use. If not specified, both will be used. Custom prompts require a report_id to be provided. |
+| `data_source` | `DataSourceEnum` | Yes | The chatbot model to use. |
+| `market` | `str` | No | A comma-separated list of the niche markets of your brands. |
+| `brand` | `str` | Yes | The brand to search for. |
+
+<details>
+<summary>Filterable fields (7 fields)</summary>
+
+- `cited_domain` (domain)
+- `cited_domain_subdomains` (string)
+- `cited_url_exact` (string)
+- `cited_url_prefix` (string)
+- `question` (string)
+- `response` (string)
+- `topic` (string)
+
+</details>
+
+**Returns:** `list[BrandRadarMentionsHistoryData]`
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `date` | `str` | |
+| `mentions` | `int` | Estimated mentions from responses mentioning the brand. |
+
+### `brand_radar_mentions_overview()`
+
+Overview - Mentions.
+
+**Parameters:**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `where` | `str` | No | Filter expression ([syntax](filter-syntax.md)). Filterable fields listed below. |
+| `select` | `SelectStr` | Yes | A comma-separated list of columns to return. See response schema for valid column identifiers. |
+| `country` | `CountryEnum` | No | A two-letter country code (ISO 3166-1 alpha-2). |
+| `report_id` | `str` | No | The ID of the report to use. If one is given, other parameters are taken from the report (brand, competitors, market, country, filters). If country or filters are provided, they override the ones in the report. You can find it in the URL of your Brand Radar report in Ahrefs: `https://app.ahrefs.com/brand-radar/reports/#report_id#/...` |
+| `prompts` | `PromptsEnum` | No | The type of prompts to use. If not specified, both will be used. Custom prompts require a report_id to be provided. |
+| `data_source` | `DataSourceEnum` | Yes | The chatbot model to use. |
+| `market` | `str` | No | A comma-separated list of the niche markets of your brands. |
+| `competitors` | `str` | No | A comma-separated list of competitors of your brands. |
+| `brand` | `str` | No | A comma-separated list of brands to search for. At least one of brand, competitors, market or where should not be empty. |
+
+<details>
+<summary>Filterable fields (7 fields)</summary>
+
+- `cited_domain` (domain)
+- `cited_domain_subdomains` (string)
+- `cited_url_exact` (string)
+- `cited_url_prefix` (string)
+- `question` (string)
+- `response` (string)
+- `topic` (string)
+
+</details>
+
+**Returns:** `list[BrandRadarMentionsOverviewData]`
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `brand` | `str` | Brand name (either your brand or a competitor provided in the request). |
+| `no_tracked_brands` | `int` | Estimated mentions from responses related to the specified market that do not mention any provided brands (value is zero when `market` is not specified). |
+| `only_competitors_brands` | `int` | Estimated mentions from responses mentioning only competitor brands. |
+| `only_target_brand` | `int` | Estimated mentions from responses mentioning only your brand. |
+| `target_and_competitors_brands` | `int` | Estimated mentions from responses mentioning both your and competitor brands. |
+| `total` | `int` | Total estimated mentions for your brand (includes both `only_target_brand` and `target_and_competitors_brands`). |
+
+### `brand_radar_sov_history()`
+
+Overview history - Share of Voice.
+
+**Parameters:**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `where` | `str` | No | Filter expression ([syntax](filter-syntax.md)). Filterable fields listed below. |
+| `date_to` | `DateStr` | No | The end date of the historical period in YYYY-MM-DD format. |
+| `date_from` | `DateStr` | Yes | The start date of the historical period in YYYY-MM-DD format. |
+| `country` | `CountryEnum` | No | A two-letter country code (ISO 3166-1 alpha-2). |
+| `report_id` | `str` | No | The ID of the report to use. If one is given, other parameters are taken from the report (brand, competitors, market, country, filters). If country or filters are provided, they override the ones in the report. You can find it in the URL of your Brand Radar report in Ahrefs: `https://app.ahrefs.com/brand-radar/reports/#report_id#/...` |
+| `prompts` | `PromptsEnum` | No | The type of prompts to use. If not specified, both will be used. Custom prompts require a report_id to be provided. |
+| `data_source` | `DataSourceEnum` | Yes | The chatbot model to use. |
+| `market` | `str` | No | A comma-separated list of the niche markets of your brands. |
+| `competitors` | `str` | No | A comma-separated list of competitors of your brands. |
+| `brand` | `str` | No | A comma-separated list of brands to search for. At least one of brand, competitors, market or where should not be empty. |
+
+<details>
+<summary>Filterable fields (7 fields)</summary>
+
+- `cited_domain` (domain)
+- `cited_domain_subdomains` (string)
+- `cited_url_exact` (string)
+- `cited_url_prefix` (string)
+- `question` (string)
+- `response` (string)
+- `topic` (string)
+
+</details>
+
+**Returns:** `list[BrandRadarSovHistoryData]`
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `date` | `str` | |
+| `share_of_voice` | `list[dict[str, Any] \| None]` | (1 unit per brand) Estimated share of voice for the brand. |
+
+### `brand_radar_sov_overview()`
+
+Overview - Share of Voice.
+
+**Parameters:**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `where` | `str` | No | Filter expression ([syntax](filter-syntax.md)). Filterable fields listed below. |
+| `country` | `CountryEnum` | No | A two-letter country code (ISO 3166-1 alpha-2). |
+| `report_id` | `str` | No | The ID of the report to use. If one is given, other parameters are taken from the report (brand, competitors, market, country, filters). If country or filters are provided, they override the ones in the report. You can find it in the URL of your Brand Radar report in Ahrefs: `https://app.ahrefs.com/brand-radar/reports/#report_id#/...` |
+| `prompts` | `PromptsEnum` | No | The type of prompts to use. If not specified, both will be used. Custom prompts require a report_id to be provided. |
+| `data_source` | `DataSourceEnum` | Yes | The chatbot model to use. |
+| `market` | `str` | No | A comma-separated list of the niche markets of your brands. |
+| `competitors` | `str` | No | A comma-separated list of competitors of your brands. |
+| `brand` | `str` | No | A comma-separated list of brands to search for. At least one of brand, competitors, market or where should not be empty. |
+
+<details>
+<summary>Filterable fields (7 fields)</summary>
+
+- `cited_domain` (domain)
+- `cited_domain_subdomains` (string)
+- `cited_url_exact` (string)
+- `cited_url_prefix` (string)
+- `question` (string)
+- `response` (string)
+- `topic` (string)
+
+</details>
+
+**Returns:** `list[BrandRadarSovOverviewData]`
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `brand` | `str` | Brand name (either your brand or a competitor provided in the request). |
+| `share_of_voice` | `float` | Estimated share of voice for your brand. |
+
+______________________________________________________________________
+
+## Keywords Explorer
+
+### `keywords_explorer_matching_terms()`
+
+Matching terms.
+
+**Parameters:**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `timeout` | `int` | No | A manual timeout duration in seconds. |
+| `limit` | `int` | No | The number of results to return. |
+| `order_by` | `str` | No | A column to order results by. See the response schema for valid column identifiers, except for `volume_monthly`, which is not supported in `order_by` for this endpoint. |
+| `where` | `str` | No | Filter expression ([syntax](filter-syntax.md)). Filterable fields listed below. |
+| `select` | `SelectStr` | Yes | A comma-separated list of columns to return. See response schema for valid column identifiers. |
+| `country` | `CountryEnum` | Yes | A two-letter country code (ISO 3166-1 alpha-2). |
+| `search_engine` | `SearchEngineEnum` | No | [Deprecated on 5 Aug 2024]. |
+| `keywords` | `str` | No | A comma-separated list of keywords to show metrics for. |
+| `keyword_list_id` | `int` | No | The id of an existing keyword list to show metrics for. |
+| `match_mode` | `MatchModeEnum` | No | Keyword ideas contain the words from your query in any order (terms mode) or in the exact order they are written (phrase mode). |
+| `terms` | `TermsEnum` | No | All keywords ideas or keywords ideas phrased as questions. |
+
+<details>
+<summary>Filterable fields (17 fields)</summary>
+
+- `cpc` (integer)
+- `cps` (float)
+- `difficulty` (integer)
+- `first_seen` (datetime)
+- `global_volume` (integer)
+- `intents` (object)
+- `keyword` (string)
+- `parent_topic` (string)
+- `serp_domain_rating_top10_min` (float)
+- `serp_domain_rating_top5_min` (float)
+- `serp_features` (array(string))
+- `serp_last_update` (datetime)
+- `traffic_potential` (integer)
+- `volume` (integer)
+- `volume_desktop_pct` (float)
+- `volume_mobile_pct` (float)
+- `word_count` (integer)
+
+</details>
+
+**Returns:** `list[KeywordsExplorerMatchingTermsData]`
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `cpc` | `int \| None` | Cost Per Click shows the average price that advertisers pay for each ad click in paid search results for a keyword, in USD cents. |
+| `cps` | `float \| None` | Clicks Per Search (or CPS) is the ratio of Clicks to Keyword Search volume. It shows how many different search results get clicked, on average, when people search for the target keyword in a given country. |
+| `difficulty` | `int \| None` | (10 units) An estimation of how hard it is to rank in the top 10 organic search results for a keyword on a 100-point scale. |
+| `first_seen` | `str \| None` | The date when we first checked search engine results for a keyword. |
+| `global_volume` | `int \| None` | (10 units) How many times per month, on average, people search for the target keyword across all countries in our database. |
+| `intents` | `dict[str, Any] \| None` | (10 units) Indicates the purpose behind the user's search query. Object fields: `informational`, `navigational`, `commercial`, `transactional`, `branded` or `local`. All the fields are of type `bool`, with posible values `true` or `false`. |
+| `keyword` | `str` | |
+| `parent_topic` | `str \| None` | Parent Topic determines if you can rank for your target keyword while targeting a more general topic on your page instead. To identify the Parent Topic, we take the #1 ranking page for your keyword and find the keyword responsible for sending the most traffic to that page. |
+| `serp_features` | `list[SerpFeaturesItemEnum \| None]` | The enriched results on a search engine results page (SERP) that are not traditional organic results. |
+| `serp_last_update` | `str \| None` | The date when we last checked search engine results for a keyword. |
+| `traffic_potential` | `int \| None` | (10 units) The sum of organic traffic that the #1 ranking page for your target keyword receives from all the keywords that it ranks for. |
+| `volume` | `int \| None` | (10 units) An estimation of the average monthly number of searches for a keyword over the latest known 12 months of data. |
+| `volume_desktop_pct` | `float \| None` | The percentage of searches for a keyword performed on desktop devices. |
+| `volume_mobile_pct` | `float \| None` | The percentage of searches for a keyword performed on mobile devices. |
+| `volume_monthly` | `int \| None` | (10 units) An estimation of the number of searches for a keyword over the latest month. This field may not be included in the `order_by` parameter |
+
+### `keywords_explorer_overview()`
+
+Overview.
+
+**Parameters:**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `timeout` | `int` | No | A manual timeout duration in seconds. |
+| `limit` | `int` | No | The number of results to return. |
+| `order_by` | `str` | No | A column to order results by. See the response schema for valid column identifiers, except for `volume_monthly`, which is not supported in `order_by` for this endpoint. |
+| `where` | `str` | No | Filter expression ([syntax](filter-syntax.md)). Filterable fields listed below. |
+| `select` | `SelectStr` | Yes | A comma-separated list of columns to return. See response schema for valid column identifiers. |
+| `volume_monthly_date_to` | `DateStr` | No | The end date in YYYY-MM-DD format for retrieving historical monthly search volumes in the `volume_monthly_history` field. Required only if `volume_monthly_history` is requested. |
+| `volume_monthly_date_from` | `DateStr` | No | The start date in YYYY-MM-DD format for retrieving historical monthly search volumes in the `volume_monthly_history` field. Required only if `volume_monthly_history` is requested. |
+| `target_mode` | `ModeEnum` | No | The scope of the target URL you specified. |
+| `target` | `str` | No | The target of the search: a domain or a URL. |
+| `target_position` | `TargetPositionEnum` | No | Filters keywords based on the ranking position of the specified `target`. |
+| `country` | `CountryEnum` | Yes | A two-letter country code (ISO 3166-1 alpha-2). |
+| `search_engine` | `SearchEngineEnum` | No | [Deprecated on 5 Aug 2024]. |
+| `keywords` | `str` | No | A comma-separated list of keywords to show metrics for. |
+| `keyword_list_id` | `int` | No | The id of an existing keyword list to show metrics for. |
+
+<details>
+<summary>Filterable fields (19 fields)</summary>
+
+- `clicks` (integer)
+- `cpc` (integer)
+- `cps` (float)
+- `difficulty` (integer)
+- `first_seen` (datetime)
+- `global_volume` (integer)
+- `intents` (object)
+- `keyword` (string)
+- `parent_topic` (string)
+- `parent_volume` (integer)
+- `serp_domain_rating_top10_min` (float)
+- `serp_domain_rating_top5_min` (float)
+- `serp_features` (array(string))
+- `serp_last_update` (datetime)
+- `traffic_potential` (integer)
+- `volume` (integer)
+- `volume_desktop_pct` (float)
+- `volume_mobile_pct` (float)
+- `word_count` (integer)
+
+</details>
+
+**Returns:** `list[KeywordsExplorerOverviewData]`
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `clicks` | `int \| None` | The average monthly number of clicks on the search results that people make while searching for the target keyword. |
+| `cpc` | `int \| None` | Cost Per Click shows the average price that advertisers pay for each ad click in paid search results for a keyword, in USD cents. |
+| `cps` | `float \| None` | Clicks Per Search (or CPS) is the ratio of Clicks to Keyword Search volume. It shows how many different search results get clicked, on average, when people search for the target keyword in a given country. |
+| `difficulty` | `int \| None` | (10 units) An estimation of how hard it is to rank in the top 10 organic search results for a keyword on a 100-point scale. |
+| `first_seen` | `str \| None` | The date when we first checked search engine results for a keyword. |
+| `global_volume` | `int \| None` | (10 units) How many times per month, on average, people search for the target keyword across all countries in our database. |
+| `intents` | `dict[str, Any] \| None` | (10 units) Indicates the purpose behind the user's search query. Object fields: `informational`, `navigational`, `commercial`, `transactional`, `branded` or `local`. All the fields are of type `bool`, with posible values `true` or `false`. |
+| `keyword` | `str` | |
+| `parent_topic` | `str \| None` | Parent Topic determines if you can rank for your target keyword while targeting a more general topic on your page instead. To identify the Parent Topic, we take the #1 ranking page for your keyword and find the keyword responsible for sending the most traffic to that page. |
+| `parent_volume` | `int \| None` | (10 units) The search volume of the parent topic. |
+| `searches_pct_clicks_organic_and_paid` | `float \| None` | The average monthly percentage of people who clicked on both organic and paid results while searching for the target keyword. |
+| `searches_pct_clicks_organic_only` | `float \| None` | The average monthly percentage of people who clicked only on organic results while searching for the target keyword. |
+| `searches_pct_clicks_paid_only` | `float \| None` | The average monthly percentage of people who clicked only on paid results while searching for the target keyword. |
+| `serp_features` | `list[SerpFeaturesItemEnum \| None]` | The enriched results on a search engine results page (SERP) that are not traditional organic results. |
+| `serp_last_update` | `str \| None` | The date when we last checked search engine results for a keyword. |
+| `traffic_potential` | `int \| None` | (10 units) The sum of organic traffic that the #1 ranking page for your target keyword receives from all the keywords that it ranks for. |
+| `volume` | `int \| None` | (10 units) An estimation of the average monthly number of searches for a keyword over the latest known 12 months of data. |
+| `volume_desktop_pct` | `float \| None` | The percentage of searches for a keyword performed on desktop devices. |
+| `volume_mobile_pct` | `float \| None` | The percentage of searches for a keyword performed on mobile devices. |
+| `volume_monthly` | `int \| None` | (10 units) An estimation of the number of searches for a keyword over the latest month. This field may not be included in the `order_by` parameter |
+| `volume_monthly_history` | `list[dict[str, Any] \| None]` | (2 units per historical month, with a minimum of 50 units) Historical monthly search volume estimates of a keyword for the period set by the `volume_monthly_date_from` and `volume_monthly_date_to` parameters. |
+
+### `keywords_explorer_related_terms()`
+
+Related terms.
+
+**Parameters:**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `timeout` | `int` | No | A manual timeout duration in seconds. |
+| `limit` | `int` | No | The number of results to return. |
+| `order_by` | `str` | No | A column to order results by. See the response schema for valid column identifiers, except for `volume_monthly`, which is not supported in `order_by` for this endpoint. |
+| `where` | `str` | No | Filter expression ([syntax](filter-syntax.md)). Filterable fields listed below. |
+| `select` | `SelectStr` | Yes | A comma-separated list of columns to return. See response schema for valid column identifiers. |
+| `country` | `CountryEnum` | Yes | A two-letter country code (ISO 3166-1 alpha-2). |
+| `keywords` | `str` | No | A comma-separated list of keywords to show metrics for. |
+| `keyword_list_id` | `int` | No | The id of an existing keyword list to show metrics for. |
+| `view_for` | `ViewForEnum` | No | View keywords for the top 10 or top 100 ranking pages. |
+| `terms` | `TermsEnum1` | No | Related keywords which top-ranking pages also rank for (`also_rank_for`), additional keywords frequently mentioned in top-ranking pages (`also_talk_about`), or combination of both (`all`). |
+
+<details>
+<summary>Filterable fields (17 fields)</summary>
+
+- `cpc` (integer)
+- `cps` (float)
+- `difficulty` (integer)
+- `first_seen` (datetime)
+- `global_volume` (integer)
+- `intents` (object)
+- `keyword` (string)
+- `parent_topic` (string)
+- `serp_domain_rating_top10_min` (float)
+- `serp_domain_rating_top5_min` (float)
+- `serp_features` (array(string))
+- `serp_last_update` (datetime)
+- `traffic_potential` (integer)
+- `volume` (integer)
+- `volume_desktop_pct` (float)
+- `volume_mobile_pct` (float)
+- `word_count` (integer)
+
+</details>
+
+**Returns:** `list[KeywordsExplorerRelatedTermsData]`
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `cpc` | `int \| None` | Cost Per Click shows the average price that advertisers pay for each ad click in paid search results for a keyword, in USD cents. |
+| `cps` | `float \| None` | Clicks Per Search (or CPS) is the ratio of Clicks to Keyword Search volume. It shows how many different search results get clicked, on average, when people search for the target keyword in a given country. |
+| `difficulty` | `int \| None` | (10 units) An estimation of how hard it is to rank in the top 10 organic search results for a keyword on a 100-point scale. |
+| `first_seen` | `str \| None` | The date when we first checked search engine results for a keyword. |
+| `global_volume` | `int \| None` | (10 units) How many times per month, on average, people search for the target keyword across all countries in our database. |
+| `intents` | `dict[str, Any] \| None` | (10 units) Indicates the purpose behind the user's search query. Object fields: `informational`, `navigational`, `commercial`, `transactional`, `branded` or `local`. All the fields are of type `bool`, with posible values `true` or `false`. |
+| `keyword` | `str` | |
+| `parent_topic` | `str \| None` | Parent Topic determines if you can rank for your target keyword while targeting a more general topic on your page instead. To identify the Parent Topic, we take the #1 ranking page for your keyword and find the keyword responsible for sending the most traffic to that page. |
+| `serp_features` | `list[SerpFeaturesItemEnum \| None]` | The enriched results on a search engine results page (SERP) that are not traditional organic results. |
+| `serp_last_update` | `str \| None` | The date when we last checked search engine results for a keyword. |
+| `traffic_potential` | `int \| None` | (10 units) The sum of organic traffic that the #1 ranking page for your target keyword receives from all the keywords that it ranks for. |
+| `volume` | `int \| None` | (10 units) An estimation of the average monthly number of searches for a keyword over the latest known 12 months of data. |
+| `volume_desktop_pct` | `float \| None` | The percentage of searches for a keyword performed on desktop devices. |
+| `volume_mobile_pct` | `float \| None` | The percentage of searches for a keyword performed on mobile devices. |
+| `volume_monthly` | `int \| None` | (10 units) An estimation of the number of searches for a keyword over the latest month. This field may not be included in the `order_by` parameter |
+
+### `keywords_explorer_search_suggestions()`
+
+Search suggestions.
+
+**Parameters:**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `timeout` | `int` | No | A manual timeout duration in seconds. |
+| `limit` | `int` | No | The number of results to return. |
+| `order_by` | `str` | No | A column to order results by. See the response schema for valid column identifiers, except for `volume_monthly`, which is not supported in `order_by` for this endpoint. |
+| `where` | `str` | No | Filter expression ([syntax](filter-syntax.md)). Filterable fields listed below. |
+| `select` | `SelectStr` | Yes | A comma-separated list of columns to return. See response schema for valid column identifiers. |
+| `country` | `CountryEnum` | Yes | A two-letter country code (ISO 3166-1 alpha-2). |
+| `search_engine` | `SearchEngineEnum` | No | [Deprecated on 5 Aug 2024]. |
+| `keywords` | `str` | No | A comma-separated list of keywords to show metrics for. |
+| `keyword_list_id` | `int` | No | The id of an existing keyword list to show metrics for. |
+
+<details>
+<summary>Filterable fields (17 fields)</summary>
+
+- `cpc` (integer)
+- `cps` (float)
+- `difficulty` (integer)
+- `first_seen` (datetime)
+- `global_volume` (integer)
+- `intents` (object)
+- `keyword` (string)
+- `parent_topic` (string)
+- `serp_domain_rating_top10_min` (float)
+- `serp_domain_rating_top5_min` (float)
+- `serp_features` (array(string))
+- `serp_last_update` (datetime)
+- `traffic_potential` (integer)
+- `volume` (integer)
+- `volume_desktop_pct` (float)
+- `volume_mobile_pct` (float)
+- `word_count` (integer)
+
+</details>
+
+**Returns:** `list[KeywordsExplorerSearchSuggestionsData]`
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `cpc` | `int \| None` | Cost Per Click shows the average price that advertisers pay for each ad click in paid search results for a keyword, in USD cents. |
+| `cps` | `float \| None` | Clicks Per Search (or CPS) is the ratio of Clicks to Keyword Search volume. It shows how many different search results get clicked, on average, when people search for the target keyword in a given country. |
+| `difficulty` | `int \| None` | (10 units) An estimation of how hard it is to rank in the top 10 organic search results for a keyword on a 100-point scale. |
+| `first_seen` | `str \| None` | The date when we first checked search engine results for a keyword. |
+| `global_volume` | `int \| None` | (10 units) How many times per month, on average, people search for the target keyword across all countries in our database. |
+| `intents` | `dict[str, Any] \| None` | (10 units) Indicates the purpose behind the user's search query. Object fields: `informational`, `navigational`, `commercial`, `transactional`, `branded` or `local`. All the fields are of type `bool`, with posible values `true` or `false`. |
+| `keyword` | `str` | |
+| `parent_topic` | `str \| None` | Parent Topic determines if you can rank for your target keyword while targeting a more general topic on your page instead. To identify the Parent Topic, we take the #1 ranking page for your keyword and find the keyword responsible for sending the most traffic to that page. |
+| `serp_features` | `list[SerpFeaturesItemEnum \| None]` | The enriched results on a search engine results page (SERP) that are not traditional organic results. |
+| `serp_last_update` | `str \| None` | The date when we last checked search engine results for a keyword. |
+| `traffic_potential` | `int \| None` | (10 units) The sum of organic traffic that the #1 ranking page for your target keyword receives from all the keywords that it ranks for. |
+| `volume` | `int \| None` | (10 units) An estimation of the average monthly number of searches for a keyword over the latest known 12 months of data. |
+| `volume_desktop_pct` | `float \| None` | The percentage of searches for a keyword performed on desktop devices. |
+| `volume_mobile_pct` | `float \| None` | The percentage of searches for a keyword performed on mobile devices. |
+| `volume_monthly` | `int \| None` | (10 units) An estimation of the number of searches for a keyword over the latest month. This field may not be included in the `order_by` parameter |
+
+### `keywords_explorer_volume_by_country()`
+
+Volume by country.
+
+**Parameters:**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `limit` | `int` | No | The number of results to return. |
+| `search_engine` | `SearchEngineEnum` | No | [Deprecated on 5 Aug 2024]. |
+| `keyword` | `str` | Yes | The keyword to show metrics for. |
+
+**Returns:** `list[KeywordsExplorerVolumeByCountryData]`
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `country` | `str` | |
+| `volume` | `int` | (10 units) An estimation of the average monthly number of searches for a keyword in a given country. |
+
+### `keywords_explorer_volume_history()`
+
+Volume history.
+
+**Parameters:**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `date_to` | `DateStr` | No | The end date of the historical period in YYYY-MM-DD format. |
+| `date_from` | `DateStr` | No | The start date of the historical period in YYYY-MM-DD format. |
+| `country` | `CountryEnum` | Yes | A two-letter country code (ISO 3166-1 alpha-2). |
+| `keyword` | `str` | Yes | The keyword to show metrics for. |
+
+**Returns:** `list[KeywordsExplorerVolumeHistoryData]`
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `date` | `str` | |
+| `volume` | `int` | An estimation of the number of searches for a keyword over a given month. |
+
+______________________________________________________________________
+
+## Rank Tracker
+
+### `rank_tracker_competitors_overview()`
+
+Competitors overview.
+
+**Parameters:**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `timeout` | `int` | No | A manual timeout duration in seconds. |
+| `limit` | `int` | No | The number of results to return. |
+| `order_by` | `str` | No | A column to order results by. See response schema for valid column identifiers. |
+| `where` | `str` | No | Filter expression ([syntax](filter-syntax.md)). Filterable fields listed below. |
+| `select` | `SelectStr` | Yes | A comma-separated list of columns to return. See response schema for valid column identifiers. |
+| `date_compared` | `DateStr` | No | A date to compare metrics with in YYYY-MM-DD format. |
+| `date` | `DateStr` | Yes | A date to report metrics on in YYYY-MM-DD format. |
+| `device` | `DeviceEnum` | Yes | Choose between mobile and desktop rankings. |
+| `project_id` | `int` | Yes | The unique identifier of the project. You can find it in the URL of your Rank Tracker project in Ahrefs: `https://app.ahrefs.com/rank-tracker/overview/#project_id#` |
+| `volume_mode` | `VolumeModeEnum` | No | The search volume calculation mode: monthly or average. It affects volume, traffic, and traffic value. |
+
+<details>
+<summary>Filterable fields (14 fields)</summary>
+
+- `country` (string)
+- `is_main_position` (boolean)
+- `is_main_position_prev` (boolean)
+- `keyword` (string)
+- `keyword_difficulty` (integer)
+- `keyword_has_data` (boolean)
+- `keyword_is_frozen` (boolean)
+- `language` (string)
+- `location` (string)
+- `serp_features` (array(string))
+- `serp_updated` (datetime)
+- `serp_updated_prev` (datetime)
+- `tags` (array(string))
+- `volume` (integer)
+
+</details>
+
+**Returns:** `list[RankTrackerCompetitorsOverviewData]`
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `competitors_list` | `list[dict[str, Any] \| None]` | Competitors information for a given keyword. The following fields are included: `url`, `url_prev`, `position`, `position_prev`, `best_position_kind`, `best_position_kind`, `traffic`, `traffic_prev`, `value`, `value_prev`. Fields ending in `prev` are included only in the compared view. |
+| `country` | `CountryEnum1` | The country that a given keyword is being tracked in. A two-letter country code (ISO 3166-1 alpha-2). |
+| `keyword` | `str` | The keyword your target ranks for. |
+| `keyword_difficulty` | `int \| None` | An estimation of how hard it is to rank in the top 10 organic search results for a keyword on a 100-point scale. |
+| `keyword_has_data` | `bool` | Will return `false` if the keyword is still processing and no SERP has been fetched yet. |
+| `keyword_is_frozen` | `bool` | Indicates whether a keyword has exceeded the tracked keywords limit on your plan. Such keywords are "frozen", meaning they do not have their rankings updated. |
+| `language` | `str` | The SERP language that a given keyword is being tracked for. |
+| `location` | `str` | The location (country, state/province, or city) that a given keyword is being tracked in. |
+| `serp_features` | `list[SerpFeaturesItemEnum1 \| None]` | The SERP features that appear in search results for a keyword. |
+| `serp_updated` | `str \| None` | The date when we last checked search engine results for a keyword. |
+| `serp_updated_prev` | `str \| None` | The date when we checked search engine results up to the comparison date. |
+| `tags` | `list[str \| None]` | A list of tags assigned to a given keyword. |
+| `volume` | `int \| None` | An estimation of the average monthly number of searches for a keyword over the latest month or over the latest known 12 months of data depending on the "volume_mode" parameter. |
+
+### `rank_tracker_competitors_pages()`
+
+Competitors pages.
+
+**Parameters:**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `timeout` | `int` | No | A manual timeout duration in seconds. |
+| `limit` | `int` | No | The number of results to return. |
+| `order_by` | `str` | No | A column to order results by. See response schema for valid column identifiers. |
+| `where` | `str` | No | Filter expression ([syntax](filter-syntax.md)). Filterable fields listed below. |
+| `select` | `SelectStr` | Yes | A comma-separated list of columns to return. See response schema for valid column identifiers. |
+| `target_and_tracked_competitors_only` | `bool` | No | Restrict pages to target and tracked competitors |
+| `date_compared` | `DateStr` | No | A date to compare metrics with in YYYY-MM-DD format. |
+| `date` | `DateStr` | Yes | A date to report metrics on in YYYY-MM-DD format. |
+| `device` | `DeviceEnum` | Yes | Choose between mobile and desktop rankings. |
+| `project_id` | `int` | Yes | The unique identifier of the project. You can find it in the URL of your Rank Tracker project in Ahrefs: `https://app.ahrefs.com/rank-tracker/overview/#project_id#` |
+| `volume_mode` | `VolumeModeEnum` | No | The search volume calculation mode: monthly or average. It affects volume, traffic, and traffic value. |
+
+<details>
+<summary>Filterable fields (10 fields)</summary>
+
+- `country` (string)
+- `country_prev` (string)
+- `domain` (string)
+- `language` (string)
+- `language_prev` (string)
+- `location` (string)
+- `location_prev` (string)
+- `tags` (array(string))
+- `tags_prev` (array(string))
+- `url` (string)
+
+</details>
+
+**Returns:** `list[RankTrackerCompetitorsPagesData]`
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `keywords` | `int` | The total number of keywords that your target ranks for in the top 100 organic search results. |
+| `share_of_traffic_value` | `float` | The share of your target's organic search traffic value compared to the total organic search traffic value for all tracked keywords. |
+| `share_of_traffic_value_prev` | `float` | The share of traffic value on the comparison date. |
+| `share_of_voice` | `float` | The share of your target's organic search traffic compared to the total organic search traffic for all tracked keywords. |
+| `share_of_voice_prev` | `float` | The share of voice on the comparison date. |
+| `status` | `StatusEnum` | The status of a page: the new page that just started to rank ("left"), the lost page that disappeared from search results ("right"), or no change ("both"). |
+| `title` | `str \| None` | The title displayed for the page in its top keyword's SERP. |
+| `title_prev` | `str \| None` | The title on the comparison date. |
+| `traffic` | `int` | An estimation of the number of monthly visits that a page gets from organic search. |
+| `traffic_prev` | `int` | The traffic on the comparison date. |
+| `traffic_value` | `int \| None` | The estimated value of a page’s monthly organic search traffic, in USD cents. |
+| `traffic_value_prev` | `int \| None` | The traffic value on the comparison date. |
+| `url` | `str` | The page URL. |
+
+### `rank_tracker_competitors_stats()`
+
+Competitors metrics.
+
+**Parameters:**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `select` | `SelectStr` | Yes | A comma-separated list of columns to return. See response schema for valid column identifiers. |
+| `date` | `DateStr` | Yes | A date to report metrics on in YYYY-MM-DD format. |
+| `device` | `DeviceEnum` | Yes | Choose between mobile and desktop rankings. |
+| `project_id` | `int` | Yes | The unique identifier of the project. You can find it in the URL of your Rank Tracker project in Ahrefs: `https://app.ahrefs.com/rank-tracker/overview/#project_id#` |
+| `volume_mode` | `VolumeModeEnum` | No | The search volume calculation mode: monthly or average. It affects volume, traffic, and traffic value. |
+
+**Returns:** `list[RankTrackerCompetitorsStatsData]`
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `ai_overview_count` | `int` | The total number of tracked keywords for which your target ranks in an AI Overview. |
+| `average_position` | `float \| None` | The average of your target's top organic positions across all tracked keywords. |
+| `competitor` | `str` | Competitor's URL. |
+| `discussions_count` | `int` | The total number of tracked keywords for which your target ranks in Discussions and forums. |
+| `featured_snippet_count` | `int` | The total number of tracked keywords for which your target ranks in a Featured snippet. |
+| `image_pack_count` | `int` | The total number of tracked keywords for which your target ranks in an Image pack. |
+| `knowledge_card_count` | `int` | The total number of tracked keywords for which your target ranks in a Knowledge card. |
+| `knowledge_panel_count` | `int` | The total number of tracked keywords for which your target ranks in a Knowledge panel. |
+| `pos_11_20` | `int` | The total number of tracked keywords for which your target's top organic position is within the 11th to 20th results. |
+| `pos_1_3` | `int` | The total number of tracked keywords for which your target's top organic position is within the top 3 results. |
+| `pos_21_50` | `int` | The total number of tracked keywords for which your target's top organic position is within the 21st to 50th results. |
+| `pos_4_10` | `int` | The total number of tracked keywords for which your target's top organic position is within the 4th to 10th results. |
+| `pos_51_plus` | `int` | The total number of tracked keywords for which your target's top organic position is the 51st or higher. |
+| `pos_no_rank` | `int` | The total number of tracked keywords where your target doesn't rank. |
+| `share_of_traffic_value` | `float` | The share of your target's organic search traffic value compared to the total organic search traffic value for all tracked keywords. |
+| `share_of_voice` | `float` | The share of your target's organic search traffic compared to the total organic search traffic for all tracked keywords. |
+| `sitelinks_count` | `int` | The total number of tracked keywords for which your target ranks in Sitelinks. |
+| `thumbnail_count` | `int` | The total number of tracked keywords for which your target ranks in a Thumbnail. |
+| `top_stories_count` | `int` | The total number of tracked keywords for which your target ranks in Top stories. |
+| `traffic` | `int \| None` | The estimated number of monthly visits that your target gets from organic search for all tracked keywords. |
+| `traffic_value` | `int \| None` | The estimated value of your target's monthly organic search traffic for all tracked keywords. |
+| `video_preview_count` | `int` | The total number of tracked keywords for which your target ranks in a Video preview. |
+| `videos_count` | `int` | The total number of tracked keywords for which your target ranks in Videos. |
+| `x_count` | `int` | The total number of tracked keywords for which your target ranks in an X (Twitter) widget. |
+
+### `rank_tracker_overview()`
+
+Overview.
+
+**Parameters:**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `timeout` | `int` | No | A manual timeout duration in seconds. |
+| `limit` | `int` | No | The number of results to return. |
+| `order_by` | `str` | No | A column to order results by. See response schema for valid column identifiers. |
+| `where` | `str` | No | Filter expression ([syntax](filter-syntax.md)). Filterable fields listed below. |
+| `select` | `SelectStr` | Yes | A comma-separated list of columns to return. See response schema for valid column identifiers. |
+| `date_compared` | `DateStr` | No | A date to compare metrics with in YYYY-MM-DD format. |
+| `date` | `DateStr` | Yes | A date to report metrics on in YYYY-MM-DD format. |
+| `device` | `DeviceEnum` | Yes | Choose between mobile and desktop rankings. |
+| `project_id` | `int` | Yes | The unique identifier of the project. You can find it in the URL of your Rank Tracker project in Ahrefs: `https://app.ahrefs.com/rank-tracker/overview/#project_id#` |
+| `volume_mode` | `VolumeModeEnum` | No | The search volume calculation mode: monthly or average. It affects volume, traffic, and traffic value. |
+
+<details>
+<summary>Filterable fields (54 fields)</summary>
+
+- `best_position_has_thumbnail` (boolean)
+- `best_position_has_thumbnail_previous` (boolean)
+- `best_position_has_video_preview` (boolean)
+- `best_position_has_video_preview_previous` (boolean)
+- `best_position_kind` (string)
+- `best_position_kind_previous` (string)
+- `clicks` (integer)
+- `clicks_per_search` (float)
+- `cost_per_click` (integer)
+- `country` (string)
+- `country_prev` (string)
+- `created_at` (datetime)
+- `is_branded` (boolean)
+- `is_commercial` (boolean)
+- `is_informational` (boolean)
+- `is_local` (boolean)
+- `is_main_position` (boolean)
+- `is_main_position_prev` (boolean)
+- `is_navigational` (boolean)
+- `is_transactional` (boolean)
+- `keyword` (string)
+- `keyword_difficulty` (integer)
+- `keyword_has_data` (boolean)
+- `keyword_is_frozen` (boolean)
+- `keyword_prev` (string)
+- `keyword_words` (integer)
+- `keyword_words_prev` (integer)
+- `language` (string)
+- `language_prev` (string)
+- `location` (string)
+- `location_prev` (string)
+- `parent_topic` (string)
+- `position` (integer)
+- `position_diff` (integer)
+- `position_prev` (integer)
+- `search_type_image` (float)
+- `search_type_news` (float)
+- `search_type_video` (float)
+- `search_type_web` (float)
+- `serp_features` (array(string))
+- `serp_features_prev` (array(string))
+- `serp_updated` (datetime)
+- `serp_updated_prev` (datetime)
+- `tags` (array(string))
+- `tags_prev` (array(string))
+- `target_positions_count` (integer)
+- `traffic` (integer)
+- `traffic_diff` (integer)
+- `traffic_prev` (integer)
+- `url` (string)
+- `url_prev` (string)
+- `volume` (integer)
+- `volume_desktop_pct` (float)
+- `volume_mobile_pct` (float)
+
+</details>
+
+**Returns:** `list[RankTrackerOverviewData]`
+
+<details>
+<summary>50 fields</summary>
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `best_position_has_thumbnail` | `bool \| None` | The top position (or target URL’s, if set) has a thumbnail. |
+| `best_position_has_thumbnail_previous` | `bool \| None` | The top position (or target URL’s, if set) has a thumbnail on the comparison date. |
+| `best_position_has_video_preview` | `bool \| None` | The top position (or target URL’s, if set) has a video preview. |
+| `best_position_has_video_preview_previous` | `bool \| None` | The top position (or target URL’s, if set) has a video preview on the comparison date. |
+| `best_position_kind` | `BestPositionKindEnum \| None` | The kind of top position (or target URL’s, if set): organic, paid, or a SERP feature. |
+| `best_position_kind_previous` | `BestPositionKindEnum \| None` | The kind of top position (or target URL’s, if set) on the comparison date. |
+| `clicks` | `int \| None` | Clicks metric refers to the average monthly number of clicks on the search results that people make while searching for the target keyword. Some searches generate clicks on multiple results, while others might not end in any clicks at all. |
+| `clicks_per_search` | `float \| None` | Clicks Per Search is the ratio of Clicks to Keyword Search volume. It shows how many different search results get clicked, on average, when people search for the target keyword in a given country. |
+| `cost_per_click` | `int \| None` | Cost Per Click shows the average price that advertisers pay for each ad click in paid search results for a keyword. |
+| `country` | `CountryEnum1` | The country that a given keyword is being tracked in. A two-letter country code (ISO 3166-1 alpha-2). |
+| `country_prev` | `CountryEnum1` | The country that a given keyword is being tracked in on the comparison date. A two-letter country code (ISO 3166-1 alpha-2). |
+| `created_at` | `str` | The date when a keyword was added to the project. |
+| `is_branded` | `bool` | User intent: branded. The user is searching for a specific brand or company name. |
+| `is_commercial` | `bool` | User intent: commercial. The user is comparing products or services before making a purchase decision. |
+| `is_informational` | `bool` | User intent: informational. The user is looking for information or an answer to a specific question. |
+| `is_local` | `bool` | User intent: local. The user is looking for information relevant to a specific location or nearby services. |
+| `is_navigational` | `bool` | User intent: navigational. The user is searching for a specific website or web page. |
+| `is_transactional` | `bool` | User intent: transactional. The user is ready to complete an action, often a purchase. |
+| `keyword` | `str` | The keyword your target ranks for. |
+| `keyword_difficulty` | `int \| None` | An estimation of how hard it is to rank in the top 10 organic search results for a keyword on a 100-point scale. |
+| `keyword_has_data` | `bool` | Will return `false` if the keyword is still processing and no SERP has been fetched yet. |
+| `keyword_is_frozen` | `bool` | Indicates whether a keyword has exceeded the tracked keywords limit on your plan. Such keywords are "frozen", meaning they do not have their rankings updated. |
+| `keyword_prev` | `str` | The keyword your target ranks for on the comparison date. |
+| `language` | `str` | The SERP language that a given keyword is being tracked for. |
+| `language_prev` | `str` | The SERP language on the comparison date. |
+| `location` | `str` | The location (country, state/province, or city) that a given keyword is being tracked in. |
+| `location_prev` | `str` | The location (country, state/province, or city) that a given keyword is being tracked in on the comparison date. |
+| `parent_topic` | `str \| None` | Parent Topic determines if you can rank for your target keyword while targeting a more general topic on your page instead. To identify the Parent Topic, we take the #1 ranking page for your keyword and find the keyword responsible for sending the most traffic to that page. |
+| `position` | `int \| None` | The top position (or target URL’s, if set) in organic search. |
+| `position_diff` | `int \| None` | The change in top position (or target URL’s, if set) between selected dates. |
+| `position_prev` | `int \| None` | The top position (or target URL’s, if set) on the comparison date. |
+| `search_type_image` | `float \| None` | Search type Image shows the percentage of searches for a keyword made for images, highlighting interest in visual content. |
+| `search_type_news` | `float \| None` | Search type News shows the percentage of searches for a keyword made for news articles. |
+| `search_type_video` | `float \| None` | Search type Video shows the percentage of searches for a keyword made for video, reflecting interest in video content. |
+| `search_type_web` | `float \| None` | Search type Web shows the percentage of searches for a keyword made for general web content, indicating interest in a wide range of information. |
+| `serp_features` | `list[SerpFeaturesItemEnum1 \| None]` | The SERP features that appear in search results for a keyword. |
+| `serp_features_prev` | `list[SerpFeaturesItemEnum1 \| None]` | The SERP features that appear in search results for a keyword on the comparison date. |
+| `serp_updated` | `str \| None` | The date when we last checked search engine results for a keyword. |
+| `serp_updated_prev` | `str \| None` | The date when we checked search engine results up to the comparison date. |
+| `tags` | `list[str \| None]` | A list of tags assigned to a given keyword. |
+| `tags_prev` | `list[str \| None]` | A list of tags assigned to a given keyword on the comparison date. |
+| `target_positions_count` | `int` | The number of target URLs ranking for a keyword. |
+| `traffic` | `int \| None` | An estimation of the number of monthly visits that a page gets from organic search over the latest month or over the latest known 12 months of data depending on the "volume_mode" parameter. |
+| `traffic_diff` | `int \| None` | The change in traffic between your selected dates. |
+| `traffic_prev` | `int \| None` | An estimation of the number of monthly visits that a page gets from organic search over the latest month or over the latest known 12 months of data depending on the "volume_mode" parameter. |
+| `url` | `str \| None` | The top-ranking URL (or target URL, if set) in organic search. |
+| `url_prev` | `str \| None` | The top-ranking URL (or target URL, if set) on the comparison date. |
+| `volume` | `int \| None` | An estimation of the average monthly number of searches for a keyword over the latest month or over the latest known 12 months of data depending on the "volume_mode" parameter. |
+| `volume_desktop_pct` | `float \| None` | The percentage of the total search volume that comes from desktop devices. |
+| `volume_mobile_pct` | `float \| None` | The percentage of the total search volume that comes from mobile devices. |
+
+</details>
+
+### `rank_tracker_serp_overview()`
+
+SERP Overview.
+
+**Parameters:**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `top_positions` | `int` | No | The number of top organic SERP positions to return. If not specified, all available positions will be returned. |
+| `device` | `DeviceEnum` | Yes | Choose between mobile and desktop rankings. |
+| `date` | `str` | No | A timestamp on which the last available SERP Overview is returned in YYYY-MM-DDThh:mm:ss format. If it is not specified, the most recent SERP Overview is returned. |
+| `location_id` | `int` | No | The location ID of a tracked keyword.You can use the `management/project-keywords` endpoint to get country codes, language codes and location IDs for your tracked keywords. |
+| `country` | `CountryEnum` | Yes | A two-letter country code (ISO 3166-1 alpha-2). |
+| `language_code` | `str` | No | The language code of a tracked keyword.You can use the `management/project-keywords` endpoint to get country codes, language codes and location IDs for your tracked keywords. |
+| `keyword` | `str` | Yes | The keyword to return SERP Overview for. |
+| `project_id` | `int` | Yes | The unique identifier of the project. You can find it in the URL of your Rank Tracker project in Ahrefs: `https://app.ahrefs.com/rank-tracker/overview/#project_id#` |
+
+**Returns:** `list[RankTrackerSerpOverviewData]`
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `position` | `int` | The position of the search result in SERP. |
+| `title` | `str \| None` | The title of a ranking page. |
+| `url` | `str \| None` | The URL of a ranking page. |
+| `type` | `list[str \| None]` | The kind of the position: organic, paid, or a SERP feature. Allowed values: `ai_overview`, `ai_overview_sitelink`, `discussion`, `image`, `image_th`, `knowledge_card`, `knowledge_panel`, `local_pack`, `organic`, `organic_shopping`, `paid_top`, `paid_bottom`, `paid_right`, `question`, `sitelink`, `snippet`, `top_story`, `tweet`, `video`, `video_th`. |
+| `update_date` | `str` | The date when we checked search engine results for a keyword. |
+| `nr_words` | `int \| None` | The total number of words present in the HTML of a web page. |
+| `domain_rating` | `float \| None` | The strength of a domain’s backlink profile compared to the others in our database on a 100-point scale. |
+| `url_rating` | `float \| None` | The strength of a page's backlink profile on a 100-point logarithmic scale. |
+| `ahrefs_rank` | `int \| None` | The strength of a domain's backlink profile compared to the other websites in our database, with rank #1 being the strongest. |
+| `backlinks` | `int \| None` | The total number of links from other websites pointing to a search result. |
+| `refdomains` | `int \| None` | The total number of unique domains linking to a search result. |
+| `traffic` | `int \| None` | An estimation of the monthly organic search traffic that a result gets from all the keywords that it ranks for. |
+| `value` | `int \| None` | The estimated value of a page’s monthly organic search traffic, in USD cents. |
+| `keywords` | `int \| None` | The total number of keywords that a search result ranks for in the top 100 organic positions. |
+| `top_keyword` | `str \| None` | The keyword that brings the most organic traffic to a search result. |
+| `top_keyword_volume` | `int \| None` | An estimation of the average monthly number of searches for the top keyword over the latest known 12 months of data. |
+| `page_type` | `str \| None` | Comma-separated list of AI-predicted hierarchical page type paths for the ranking page. Each value is a slash-prefixed path (e.g. /Article/How_to). |
+
+______________________________________________________________________
+
+## Serp Overview
+
+### `serp_overview()`
+
+SERP Overview.
+
+**Parameters:**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `select` | `SelectStr` | Yes | A comma-separated list of columns to return. See response schema for valid column identifiers. |
+| `top_positions` | `int` | No | The number of top organic SERP positions to return. If not specified, all available positions will be returned. |
+| `date` | `str` | No | A timestamp on which the last available SERP Overview is returned in YYYY-MM-DDThh:mm:ss format. If it is not specified, the most recent SERP Overview is returned. |
+| `country` | `CountryEnum` | Yes | A two-letter country code (ISO 3166-1 alpha-2). |
+| `keyword` | `str` | Yes | The keyword to return SERP Overview for. |
+
+**Returns:** `list[SerpOverviewData]`
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `ahrefs_rank` | `int \| None` | The strength of a domain's backlink profile compared to the other websites in our database, with rank #1 being the strongest. |
+| `backlinks` | `int \| None` | The total number of links from other websites pointing to a search result. |
+| `domain_rating` | `float \| None` | The strength of a domain’s backlink profile compared to the others in our database on a 100-point scale. |
+| `keywords` | `int \| None` | The total number of keywords that a search result ranks for in the top 100 organic positions. |
+| `page_type` | `str \| None` | Comma-separated list of AI-predicted hierarchical page type paths for the ranking page. Each value is a slash-prefixed path (e.g. /Article/How_to). |
+| `position` | `int` | The position of the search result in SERP. |
+| `refdomains` | `int \| None` | (5 units) The total number of unique domains linking to a search result. |
+| `title` | `str \| None` | The title of a ranking page. |
+| `top_keyword` | `str \| None` | The keyword that brings the most organic traffic to a search result. |
+| `top_keyword_volume` | `int \| None` | (10 units) An estimation of the average monthly number of searches for the top keyword over the latest known 12 months of data. |
+| `traffic` | `int \| None` | (10 units) An estimation of the monthly organic search traffic that a result gets from all the keywords that it ranks for. |
+| `type` | `list[SerpFeaturesItemEnum1 \| None]` | The kind of the position: organic, paid, or a SERP feature. |
+| `update_date` | `str` | The date when we checked search engine results for a keyword. |
+| `url` | `str \| None` | The URL of a ranking page. |
+| `url_rating` | `float \| None` | The strength of a page's backlink profile on a 100-point logarithmic scale. |
+| `value` | `int \| None` | (10 units) The estimated value of a page’s monthly organic search traffic, in USD cents. |
+
+______________________________________________________________________
+
+## Site Audit
+
+### `site_audit_issues()`
+
+Project Issues.
+
+**Parameters:**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `date_compared` | `str` | No | A timestamp in `YYYY-MM-DDThh:mm:ss` format specifying the crawl date to compare metrics with. Follows the same rules as the `date` field. |
+| `date` | `str` | No | A timestamp in `YYYY-MM-DDThh:mm:ss` format specifying the crawl date to retrieve metrics from. Defaults to the most recent available crawl if omitted. For scheduled crawls, we return data from the latest crawl finished before the specified timestamp. For Always-on audit crawls, we return data as of the provided date and time. If the time component is omitted, it defaults to `00:00:00`. The timestamp is interpreted in UTC. |
+| `project_id` | `int` | Yes | The unique identifier of the project. You can find it in the URL of your Site Audit project in Ahrefs: `https://app.ahrefs.com/site-audit/#project_id#` |
+
+**Returns:** `list[SiteAuditIssuesData]`
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `issue_id` | `str` | The unique identifier of the issue. |
+| `name` | `str` | The name of the issue. |
+| `importance` | `str` | The importance of the issue. Possible values: `Error`, `Warning`, `Notice`. |
+| `category` | `str` | The category of the issue. Possible values: `Internal pages`, `Indexability`, `Links`, `Redirects`, `Content`, `Social tags`, `Duplicates`, `Localization`, `Usability and performance`, `Images`, `JavaScript`, `CSS`, `Sitemaps`, `External pages`, `Other`. |
+| `is_indexable` | `bool \| None` | True if the issue applies only to indexable pages. |
+| `crawled` | `int` | Number of URLs currently affected by the issue. |
+| `change` | `int \| None` | Difference in the number of affected URLs between the specified dates. |
+| `added` | `int \| None` | Number of URLs that have the issue on the current date but did not have it on the previous date. |
+| `new` | `int \| None` | Number of newly discovered URLs that have the issue on the current date. |
+| `removed` | `int \| None` | Number of URLs that had the issue on the previous date but no longer have it on the current date. |
+| `missing` | `int \| None` | Number of URLs that had the issue on the previous date but cannot be found on the current date. |
+
+### `site_audit_page_content()`
+
+Page content.
+
+**Parameters:**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `select` | `SelectStr` | Yes | A comma-separated list of columns to return. See response schema for valid column identifiers. |
+| `date` | `str` | No | A timestamp in `YYYY-MM-DDThh:mm:ss` format specifying the crawl date to retrieve metrics from. Defaults to the most recent available crawl if omitted. For scheduled crawls, we return data from the latest crawl finished before the specified timestamp. For Always-on audit crawls, we return data as of the provided date and time. If the time component is omitted, it defaults to `00:00:00`. The timestamp is interpreted in UTC. |
+| `target_url` | `str` | Yes | The URL of the page to retrieve content for. |
+| `project_id` | `int` | Yes | The unique identifier of the project. Only projects with verified ownership are supported. You can find the project ID in the URL of your Site Audit project in Ahrefs: `https://app.ahrefs.com/site-audit/#project_id#` |
+
+**Returns:** `SiteAuditPageContentData | None`
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `crawl_datetime` | `str` | The timestamp when the page was crawled. |
+| `page_text` | `str \| None` | The text extracted from the page content. |
+| `raw_html` | `str \| None` | The raw HTML of the page. |
+| `rendered_html` | `str \| None` | The rendered HTML of the page. |
+
+### `site_audit_page_explorer()`
+
+Page explorer.
+
+**Parameters:**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `timeout` | `int` | No | A manual timeout duration in seconds. |
+| `limit` | `int` | No | The number of results to return. |
+| `order_by` | `str` | No | A column to order results by. See response schema for valid column identifiers. |
+| `where` | `str` | No | Filter expression ([syntax](filter-syntax.md)). Filterable fields listed below. |
+| `select` | `SelectStr` | No | A comma-separated list of columns to return. See response schema for valid column identifiers. |
+| `filter_mode` | `FilterModeEnum` | No | Indicates which pages to return compared to the previous crawl. If not specified, all URLs that match your filter conditions are returned. `added`: URLs that are a new match for your filter conditions. `new`: URLs that are newly crawled and match your filter conditions. `removed`: URLs that stopped matching your filter conditions. `missing`: URLs that weren't crawled, but previously matched your filter conditions. `no_change`: URLs that match your filter conditions in a crawl and the crawl before it. |
+| `issue_id` | `str` | No | The unique identifier of an issue. When specified, only URLs affected by this issue are returned. You can get issue IDs by querying the `site-audit/issues` endpoint. |
+| `date_compared` | `str` | No | A timestamp in `YYYY-MM-DDThh:mm:ss` format specifying the crawl date to compare metrics with. Follows the same rules as the `date` field. |
+| `date` | `str` | No | A timestamp in `YYYY-MM-DDThh:mm:ss` format specifying the crawl date to retrieve metrics from. Defaults to the most recent available crawl if omitted. For scheduled crawls, we return data from the latest crawl finished before the specified timestamp. For Always-on audit crawls, we return data as of the provided date and time. If the time component is omitted, it defaults to `00:00:00`. The timestamp is interpreted in UTC. |
+| `project_id` | `int` | Yes | The unique identifier of the project. Only projects with verified ownership are supported. You can find the project ID in the URL of your Site Audit project in Ahrefs: `https://app.ahrefs.com/site-audit/#project_id#` |
+
+<details>
+<summary>Filterable fields (605 fields)</summary>
+
+- `ai_content_level` (string)
+- `ai_content_status` (string)
+- `alternate` (integer)
+- `alternate_diff` (integer)
+- `alternate_prev` (integer)
+- `backlinks` (integer)
+- `backlinks_diff` (integer)
+- `backlinks_prev` (integer)
+- `canonical` (url)
+- `canonical_code` (integer)
+- `canonical_counts` (integer)
+- `canonical_counts_diff` (integer)
+- `canonical_counts_prev` (integer)
+- `canonical_group_hash` (integer)
+- `canonical_is_canonical` (boolean)
+- `canonical_is_canonical_prev` (boolean)
+- `canonical_no_crawl_reason` (string)
+- `canonical_no_crawl_reason_prev` (string)
+- `canonical_prev` (url)
+- `canonical_scheme` (string)
+- `canonical_scheme_prev` (string)
+- `compliant` (boolean)
+- `compliant_prev` (boolean)
+- `compression` (string)
+- `compression_prev` (string)
+- `content_encoding` (string)
+- `content_encoding_prev` (string)
+- `content_length` (integer)
+- `content_length_diff` (integer)
+- `content_length_prev` (integer)
+- `content_nr_word` (integer)
+- `content_nr_word_diff` (integer)
+- `content_nr_word_prev` (integer)
+- `content_type` (string)
+- `content_type_prev` (string)
+- `css_no_crawl_reason` (array(null))
+- `css_no_crawl_reason_prev` (array(null))
+- `curl_code` (integer)
+- `depth` (integer)
+- `depth_diff` (integer)
+- `depth_prev` (integer)
+- `dofollow` (integer)
+- `dofollow_prev` (integer)
+- `domain` (domain)
+- `duplicate_content` (integer)
+- `duplicate_content_canonical_hreflang` (integer)
+- `duplicate_content_canonical_hreflang_diff` (integer)
+- `duplicate_content_canonical_hreflang_prev` (integer)
+- `duplicate_content_diff` (integer)
+- `duplicate_content_prev` (integer)
+- `duplicate_description` (integer)
+- `duplicate_description_canonical_hreflang` (integer)
+- `duplicate_description_canonical_hreflang_diff` (integer)
+- `duplicate_description_canonical_hreflang_prev` (integer)
+- `duplicate_description_diff` (integer)
+- `duplicate_description_prev` (integer)
+- `duplicate_group_identifier` (integer)
+- `duplicate_h1` (integer)
+- `duplicate_h1_diff` (integer)
+- `duplicate_h1_prev` (integer)
+- `duplicate_h1canonical_hreflang` (integer)
+- `duplicate_h1canonical_hreflang_diff` (integer)
+- `duplicate_h1canonical_hreflang_prev` (integer)
+- `duplicate_title` (integer)
+- `duplicate_title_canonical_hreflang` (integer)
+- `duplicate_title_canonical_hreflang_diff` (integer)
+- `duplicate_title_canonical_hreflang_prev` (integer)
+- `duplicate_title_diff` (integer)
+- `duplicate_title_prev` (integer)
+- `edu` (integer)
+- `edu_diff` (integer)
+- `edu_prev` (integer)
+- `external_code` (array(null))
+- `external_link_anchor` (array(null))
+- `external_link_anchor_prev` (array(null))
+- `external_link_domain` (array(domain))
+- `external_link_domain_prev` (array(domain))
+- `external_links` (array(url))
+- `external_links_is_canonical` (array(null))
+- `external_links_is_canonical_prev` (array(null))
+- `external_links_prev` (array(url))
+- `external_no_crawl_reason` (array(null))
+- `external_no_crawl_reason_prev` (array(null))
+- `external_scheme` (array(string))
+- `external_scheme_prev` (array(string))
+- `final_redirect` (url)
+- `final_redirect_code` (integer)
+- `final_redirect_no_crawl_reason` (string)
+- `final_redirect_no_crawl_reason_prev` (string)
+- `final_redirect_prev` (url)
+- `found_in_sitemaps` (array(url))
+- `found_in_sitemaps_length` (integer)
+- `found_in_sitemaps_prev` (array(url))
+- `gov` (integer)
+- `gov_diff` (integer)
+- `gov_prev` (integer)
+- `h1` (array(string))
+- `h1_prev` (array(string))
+- `h1length` (array(integer))
+- `h1length_prev` (array(integer))
+- `h2` (array(string))
+- `h2_prev` (array(string))
+- `hash_content` (integer)
+- `hash_descriptions` (array(integer))
+- `hash_h1` (array(integer))
+- `hash_text` (integer)
+- `hash_titles` (array(integer))
+- `hreflang` (array(null))
+- `hreflang_code_is_valid` (array(null))
+- `hreflang_code_is_valid_prev` (array(null))
+- `hreflang_country` (array(null))
+- `hreflang_country_prev` (array(null))
+- `hreflang_group_hash` (integer)
+- `hreflang_inlink_urls` (array(url))
+- `hreflang_inlink_urls_prev` (array(url))
+- `hreflang_issues` (array(string))
+- `hreflang_issues_prev` (array(string))
+- `hreflang_language` (array(null))
+- `hreflang_language_prev` (array(null))
+- `hreflang_link` (array(url))
+- `hreflang_link_is_canonical` (array(null))
+- `hreflang_link_is_canonical_prev` (array(null))
+- `hreflang_link_prev` (array(url))
+- `hreflang_no_crawl_reason` (array(null))
+- `hreflang_no_crawl_reason_prev` (array(null))
+- `hreflang_pages_urls` (array(url))
+- `hreflang_pages_urls_count` (integer)
+- `hreflang_pages_urls_count_diff` (integer)
+- `hreflang_pages_urls_count_prev` (integer)
+- `hreflang_pages_urls_prev` (array(url))
+- `hreflang_prev` (array(null))
+- `html_lang` (string)
+- `html_lang_code_is_valid` (boolean)
+- `html_lang_code_is_valid_prev` (boolean)
+- `html_lang_country` (string)
+- `html_lang_country_prev` (string)
+- `html_lang_language` (string)
+- `html_lang_language_prev` (string)
+- `html_lang_prev` (string)
+- `http_code` (integer)
+- `http_header` (array(string))
+- `http_header_prev` (array(string))
+- `http_header_robots` (array(string))
+- `http_header_robots_prev` (array(string))
+- `http_headers_size` (integer)
+- `http_headers_size_diff` (integer)
+- `http_headers_size_prev` (integer)
+- `images_no_crawl_reason` (array(null))
+- `images_no_crawl_reason_prev` (array(null))
+- `incoming_all_links` (integer)
+- `incoming_all_links_diff` (integer)
+- `incoming_all_links_prev` (integer)
+- `incoming_canonical` (integer)
+- `incoming_canonical_diff` (integer)
+- `incoming_canonical_prev` (integer)
+- `incoming_css` (integer)
+- `incoming_css_diff` (integer)
+- `incoming_css_prev` (integer)
+- `incoming_follow` (integer)
+- `incoming_follow_diff` (integer)
+- `incoming_follow_prev` (integer)
+- `incoming_hreflang` (integer)
+- `incoming_hreflang_diff` (integer)
+- `incoming_hreflang_prev` (integer)
+- `incoming_image` (integer)
+- `incoming_image_diff` (integer)
+- `incoming_image_prev` (integer)
+- `incoming_js` (integer)
+- `incoming_js_diff` (integer)
+- `incoming_js_prev` (integer)
+- `incoming_links` (integer)
+- `incoming_links_diff` (integer)
+- `incoming_links_prev` (integer)
+- `incoming_nofollow` (integer)
+- `incoming_nofollow_diff` (integer)
+- `incoming_nofollow_prev` (integer)
+- `incoming_pagination` (integer)
+- `incoming_pagination_diff` (integer)
+- `incoming_pagination_prev` (integer)
+- `incoming_redirect` (integer)
+- `incoming_redirect_diff` (integer)
+- `incoming_redirect_prev` (integer)
+- `indexnow_error` (string)
+- `indexnow_error_prev` (string)
+- `indexnow_reason` (string)
+- `indexnow_reason_prev` (string)
+- `indexnow_status` (string)
+- `indexnow_status_prev` (string)
+- `indexnow_submitted_at` (date)
+- `indexnow_submitted_at_prev` (date)
+- `internal_code` (array(null))
+- `internal_inlink_urls` (array(url))
+- `internal_inlink_urls_prev` (array(url))
+- `internal_link_anchor` (array(null))
+- `internal_link_anchor_prev` (array(null))
+- `internal_link_domain` (array(domain))
+- `internal_link_domain_prev` (array(domain))
+- `internal_links` (array(url))
+- `internal_links_is_canonical` (array(null))
+- `internal_links_is_canonical_prev` (array(null))
+- `internal_links_prev` (array(url))
+- `internal_no_crawl_reason` (array(null))
+- `internal_no_crawl_reason_prev` (array(null))
+- `internal_scheme` (array(string))
+- `internal_scheme_prev` (array(string))
+- `is_html` (boolean)
+- `is_in_sitemap` (boolean)
+- `is_in_sitemap_prev` (boolean)
+- `is_page_title_used_in_serp` (boolean)
+- `is_redirect_loop` (boolean)
+- `is_redirect_loop_prev` (boolean)
+- `is_rendered` (boolean)
+- `is_rendered_prev` (boolean)
+- `is_valid_internal_html` (boolean)
+- `is_valid_internal_html_prev` (boolean)
+- `js_no_crawl_reason` (array(null))
+- `js_no_crawl_reason_prev` (array(null))
+- `jsonld_attributes` (array(string))
+- `jsonld_attributes_prev` (array(string))
+- `jsonld_schema_types` (array(string))
+- `jsonld_schema_types_prev` (array(string))
+- `jsonld_validation_kinds` (array(string))
+- `jsonld_validation_kinds_prev` (array(string))
+- `jsonld_values` (array(string))
+- `jsonld_values_prev` (array(string))
+- `keywords` (array(string))
+- `keywords_prev` (array(string))
+- `length` (integer)
+- `links_count_css` (integer)
+- `links_count_css_prev` (integer)
+- `links_count_external` (integer)
+- `links_count_external3xx` (integer)
+- `links_count_external3xx_diff` (integer)
+- `links_count_external3xx_prev` (integer)
+- `links_count_external4xx` (integer)
+- `links_count_external4xx_diff` (integer)
+- `links_count_external4xx_prev` (integer)
+- `links_count_external5xx` (integer)
+- `links_count_external5xx_diff` (integer)
+- `links_count_external5xx_prev` (integer)
+- `links_count_external_diff` (integer)
+- `links_count_external_follow` (integer)
+- `links_count_external_follow_diff` (integer)
+- `links_count_external_follow_prev` (integer)
+- `links_count_external_nofollow` (integer)
+- `links_count_external_nofollow_diff` (integer)
+- `links_count_external_nofollow_prev` (integer)
+- `links_count_external_non_canonical` (integer)
+- `links_count_external_non_canonical_diff` (integer)
+- `links_count_external_non_canonical_prev` (integer)
+- `links_count_external_prev` (integer)
+- `links_count_external_xxx` (integer)
+- `links_count_external_xxx_diff` (integer)
+- `links_count_external_xxx_prev` (integer)
+- `links_count_images` (integer)
+- `links_count_images_diff` (integer)
+- `links_count_images_prev` (integer)
+- `links_count_images_with_alt` (integer)
+- `links_count_images_with_alt_diff` (integer)
+- `links_count_images_with_alt_prev` (integer)
+- `links_count_images_without_alt` (integer)
+- `links_count_images_without_alt_diff` (integer)
+- `links_count_images_without_alt_prev` (integer)
+- `links_count_internal` (integer)
+- `links_count_internal3xx` (integer)
+- `links_count_internal3xx_diff` (integer)
+- `links_count_internal3xx_prev` (integer)
+- `links_count_internal4xx` (integer)
+- `links_count_internal4xx_diff` (integer)
+- `links_count_internal4xx_prev` (integer)
+- `links_count_internal5xx` (integer)
+- `links_count_internal5xx_diff` (integer)
+- `links_count_internal5xx_prev` (integer)
+- `links_count_internal_diff` (integer)
+- `links_count_internal_follow` (integer)
+- `links_count_internal_follow_diff` (integer)
+- `links_count_internal_follow_prev` (integer)
+- `links_count_internal_nofollow` (integer)
+- `links_count_internal_nofollow_diff` (integer)
+- `links_count_internal_nofollow_prev` (integer)
+- `links_count_internal_non_canonical` (integer)
+- `links_count_internal_non_canonical_diff` (integer)
+- `links_count_internal_non_canonical_prev` (integer)
+- `links_count_internal_prev` (integer)
+- `links_count_internal_xxx` (integer)
+- `links_count_internal_xxx_diff` (integer)
+- `links_count_internal_xxx_prev` (integer)
+- `links_count_js` (integer)
+- `links_count_js_diff` (integer)
+- `links_count_js_prev` (integer)
+- `links_css` (array(url))
+- `links_css_code` (array(null))
+- `links_css_domain` (array(domain))
+- `links_css_domain_prev` (array(domain))
+- `links_css_prev` (array(url))
+- `links_css_scheme` (array(string))
+- `links_css_scheme_prev` (array(string))
+- `links_external3xx` (array(url))
+- `links_external3xx_prev` (array(url))
+- `links_external4xx` (array(url))
+- `links_external4xx_prev` (array(url))
+- `links_external5xx` (array(url))
+- `links_external5xx_prev` (array(url))
+- `links_external_follow` (array(url))
+- `links_external_follow_prev` (array(url))
+- `links_external_nofollow` (array(url))
+- `links_external_nofollow_prev` (array(url))
+- `links_external_non_canonical` (array(url))
+- `links_external_non_canonical_prev` (array(url))
+- `links_external_xxx` (array(url))
+- `links_external_xxx_prev` (array(url))
+- `links_hreflang_code` (array(null))
+- `links_images` (array(url))
+- `links_images_alt` (array(null))
+- `links_images_alt_prev` (array(null))
+- `links_images_code` (array(null))
+- `links_images_domain` (array(domain))
+- `links_images_domain_prev` (array(domain))
+- `links_images_prev` (array(url))
+- `links_images_scheme` (array(string))
+- `links_images_scheme_prev` (array(string))
+- `links_images_with_alt` (array(url))
+- `links_images_with_alt_prev` (array(url))
+- `links_images_without_alt` (array(url))
+- `links_images_without_alt_prev` (array(url))
+- `links_internal3xx` (array(url))
+- `links_internal3xx_prev` (array(url))
+- `links_internal4xx` (array(url))
+- `links_internal4xx_prev` (array(url))
+- `links_internal5xx` (array(url))
+- `links_internal5xx_prev` (array(url))
+- `links_internal_follow` (array(url))
+- `links_internal_follow_prev` (array(url))
+- `links_internal_nofollow` (array(url))
+- `links_internal_nofollow_prev` (array(url))
+- `links_internal_non_canonical` (array(url))
+- `links_internal_non_canonical_prev` (array(url))
+- `links_internal_xxx` (array(url))
+- `links_internal_xxx_prev` (array(url))
+- `links_js` (array(url))
+- `links_js_code` (array(null))
+- `links_js_domain` (array(domain))
+- `links_js_domain_prev` (array(domain))
+- `links_js_prev` (array(url))
+- `links_js_scheme` (array(string))
+- `links_js_scheme_prev` (array(string))
+- `loading_time` (integer)
+- `loading_time_diff` (integer)
+- `loading_time_prev` (integer)
+- `meta_description` (array(string))
+- `meta_description_length` (array(integer))
+- `meta_description_length_prev` (array(integer))
+- `meta_description_prev` (array(string))
+- `meta_refresh` (array(string))
+- `meta_refresh_prev` (array(string))
+- `meta_robots` (array(string))
+- `meta_robots_prev` (array(string))
+- `meta_twitter_tags_app_google_play` (string)
+- `meta_twitter_tags_app_google_play_prev` (string)
+- `meta_twitter_tags_app_ipad` (string)
+- `meta_twitter_tags_app_ipad_prev` (string)
+- `meta_twitter_tags_app_iphone` (string)
+- `meta_twitter_tags_app_iphone_prev` (string)
+- `meta_twitter_tags_attributes` (array(string))
+- `meta_twitter_tags_attributes_prev` (array(string))
+- `meta_twitter_tags_card` (string)
+- `meta_twitter_tags_card_prev` (string)
+- `meta_twitter_tags_description` (string)
+- `meta_twitter_tags_description_prev` (string)
+- `meta_twitter_tags_image` (string)
+- `meta_twitter_tags_image_prev` (string)
+- `meta_twitter_tags_image_url_invalid` (boolean)
+- `meta_twitter_tags_image_url_invalid_prev` (boolean)
+- `meta_twitter_tags_player` (string)
+- `meta_twitter_tags_player_height` (integer)
+- `meta_twitter_tags_player_height_diff` (integer)
+- `meta_twitter_tags_player_height_prev` (integer)
+- `meta_twitter_tags_player_prev` (string)
+- `meta_twitter_tags_player_width` (integer)
+- `meta_twitter_tags_player_width_diff` (integer)
+- `meta_twitter_tags_player_width_prev` (integer)
+- `meta_twitter_tags_site` (string)
+- `meta_twitter_tags_site_prev` (string)
+- `meta_twitter_tags_title` (string)
+- `meta_twitter_tags_title_prev` (string)
+- `meta_twitter_tags_valid` (boolean)
+- `meta_twitter_tags_valid_prev` (boolean)
+- `meta_twitter_tags_values` (array(string))
+- `meta_twitter_tags_values_prev` (array(string))
+- `navigation_next` (url)
+- `navigation_next_code` (integer)
+- `navigation_next_no_crawl_reason` (string)
+- `navigation_next_no_crawl_reason_prev` (string)
+- `navigation_next_prev` (url)
+- `navigation_prev_code` (integer)
+- `navigation_prev_no_crawl_reason` (string)
+- `navigation_prev_no_crawl_reason_prev` (string)
+- `no_crawl_reason` (string)
+- `no_crawl_reason_prev` (string)
+- `nofollow` (integer)
+- `nofollow_diff` (integer)
+- `nofollow_prev` (integer)
+- `nr_h1` (integer)
+- `nr_h1_prev` (integer)
+- `nr_meta_description` (integer)
+- `nr_meta_description_diff` (integer)
+- `nr_meta_description_prev` (integer)
+- `nr_redirect_chain_urls` (integer)
+- `nr_redirect_chain_urls_diff` (integer)
+- `nr_redirect_chain_urls_prev` (integer)
+- `nr_titles` (integer)
+- `nr_titles_diff` (integer)
+- `nr_titles_prev` (integer)
+- `og_tags_attributes` (array(string))
+- `og_tags_attributes_prev` (array(string))
+- `og_tags_image` (string)
+- `og_tags_image_prev` (string)
+- `og_tags_image_url_invalid` (boolean)
+- `og_tags_image_url_invalid_prev` (boolean)
+- `og_tags_inconsistent_canonical` (boolean)
+- `og_tags_inconsistent_canonical_prev` (boolean)
+- `og_tags_title` (string)
+- `og_tags_title_prev` (string)
+- `og_tags_type` (string)
+- `og_tags_type_prev` (string)
+- `og_tags_url` (string)
+- `og_tags_url_prev` (string)
+- `og_tags_url_valid` (boolean)
+- `og_tags_url_valid_prev` (boolean)
+- `og_tags_valid` (boolean)
+- `og_tags_valid_prev` (boolean)
+- `og_tags_value` (array(string))
+- `og_tags_value_prev` (array(string))
+- `origin` (url)
+- `origin_prev` (url)
+- `page_is_nofollow` (boolean)
+- `page_is_nofollow_prev` (boolean)
+- `page_is_noindex` (boolean)
+- `page_is_noindex_prev` (boolean)
+- `page_rating` (integer)
+- `page_raw_ur` (integer)
+- `page_raw_ur_diff` (integer)
+- `page_raw_ur_prev` (integer)
+- `page_type` (array(string))
+- `page_type_prev` (array(string))
+- `pagination_group` (integer)
+- `pagination_group_prev` (integer)
+- `positions` (integer)
+- `positions_diff` (integer)
+- `positions_prev` (integer)
+- `positions_top10` (integer)
+- `positions_top10_diff` (integer)
+- `positions_top10_prev` (integer)
+- `positions_top3` (integer)
+- `positions_top3_diff` (integer)
+- `positions_top3_prev` (integer)
+- `psi_crux_cls_category` (string)
+- `psi_crux_cls_category_prev` (string)
+- `psi_crux_cls_distributions_proportion` (array(null))
+- `psi_crux_cls_distributions_proportion_prev` (array(null))
+- `psi_crux_cls_percentile` (float)
+- `psi_crux_cls_percentile_diff` (integer)
+- `psi_crux_cls_percentile_prev` (float)
+- `psi_crux_fid_category` (string)
+- `psi_crux_fid_category_prev` (string)
+- `psi_crux_fid_distributions_proportion` (array(null))
+- `psi_crux_fid_distributions_proportion_prev` (array(null))
+- `psi_crux_fid_percentile` (float)
+- `psi_crux_fid_percentile_diff` (integer)
+- `psi_crux_fid_percentile_prev` (float)
+- `psi_crux_inp_category` (string)
+- `psi_crux_inp_category_prev` (string)
+- `psi_crux_inp_distributions_proportion` (array(null))
+- `psi_crux_inp_distributions_proportion_prev` (array(null))
+- `psi_crux_inp_percentile` (float)
+- `psi_crux_inp_percentile_diff` (integer)
+- `psi_crux_inp_percentile_prev` (float)
+- `psi_crux_lcp_category` (string)
+- `psi_crux_lcp_category_prev` (string)
+- `psi_crux_lcp_distributions_proportion` (array(null))
+- `psi_crux_lcp_distributions_proportion_prev` (array(null))
+- `psi_crux_lcp_percentile` (float)
+- `psi_crux_lcp_percentile_diff` (integer)
+- `psi_crux_lcp_percentile_prev` (float)
+- `psi_lighthouse_cls_error_message` (string)
+- `psi_lighthouse_cls_error_message_prev` (string)
+- `psi_lighthouse_cls_value` (float)
+- `psi_lighthouse_cls_value_diff` (integer)
+- `psi_lighthouse_cls_value_prev` (float)
+- `psi_lighthouse_lcp_error_message` (string)
+- `psi_lighthouse_lcp_error_message_prev` (string)
+- `psi_lighthouse_lcp_value` (float)
+- `psi_lighthouse_lcp_value_diff` (integer)
+- `psi_lighthouse_lcp_value_prev` (float)
+- `psi_lighthouse_score` (integer)
+- `psi_lighthouse_score_diff` (integer)
+- `psi_lighthouse_score_prev` (integer)
+- `psi_lighthouse_tbt_error_message` (string)
+- `psi_lighthouse_tbt_error_message_prev` (string)
+- `psi_lighthouse_tbt_value` (float)
+- `psi_lighthouse_tbt_value_diff` (integer)
+- `psi_lighthouse_tbt_value_prev` (float)
+- `psi_mobile_issues` (array(string))
+- `psi_mobile_issues_explanations` (array(string))
+- `psi_mobile_issues_explanations_prev` (array(string))
+- `psi_mobile_issues_prev` (array(string))
+- `psi_request_error_message` (string)
+- `psi_request_error_message_prev` (string)
+- `psi_request_status` (string)
+- `psi_request_status_prev` (string)
+- `redirect` (url)
+- `redirect_chain_urls` (array(url))
+- `redirect_chain_urls_code` (array(null))
+- `redirect_chain_urls_no_crawl_reason` (array(null))
+- `redirect_chain_urls_no_crawl_reason_prev` (array(null))
+- `redirect_chain_urls_prev` (array(url))
+- `redirect_code` (integer)
+- `redirect_counts` (integer)
+- `redirect_counts_diff` (integer)
+- `redirect_counts_prev` (integer)
+- `redirect_is_canonical` (boolean)
+- `redirect_is_canonical_prev` (boolean)
+- `redirect_no_crawl_reason` (string)
+- `redirect_no_crawl_reason_prev` (string)
+- `redirect_prev` (url)
+- `redirect_scheme` (string)
+- `redirect_scheme_prev` (string)
+- `refclass_c` (integer)
+- `refclass_c_diff` (integer)
+- `refclass_c_prev` (integer)
+- `refhosts` (integer)
+- `refhosts_diff` (integer)
+- `refhosts_prev` (integer)
+- `refips` (integer)
+- `refips_prev` (integer)
+- `refpages` (integer)
+- `refpages_diff` (integer)
+- `refpages_prev` (integer)
+- `robots_allow_rules` (array(null))
+- `robots_allow_rules_prev` (array(null))
+- `robots_crawl_delay` (integer)
+- `robots_crawl_delay_prev` (integer)
+- `robots_disallow_rules` (array(null))
+- `robots_disallow_rules_prev` (array(null))
+- `robots_error` (string)
+- `robots_error_prev` (string)
+- `robots_error_text` (string)
+- `robots_error_text_prev` (string)
+- `robots_redirect_loop` (array(null))
+- `robots_redirect_loop_prev` (array(null))
+- `robots_sitemaps` (array(null))
+- `robots_sitemaps_prev` (array(null))
+- `rss` (integer)
+- `rss_diff` (integer)
+- `rss_prev` (integer)
+- `scheme` (string)
+- `self_canonical` (boolean)
+- `self_canonical_prev` (boolean)
+- `self_hreflang` (array(null))
+- `self_hreflang_code_is_valid` (array(null))
+- `self_hreflang_code_is_valid_prev` (array(null))
+- `self_hreflang_country` (array(null))
+- `self_hreflang_country_prev` (array(null))
+- `self_hreflang_language` (array(null))
+- `self_hreflang_language_prev` (array(null))
+- `self_hreflang_prev` (array(null))
+- `serp_title` (string)
+- `serp_title_prev` (string)
+- `sitemap_error` (string)
+- `sitemap_error_prev` (string)
+- `sitemap_error_text` (string)
+- `sitemap_error_text_prev` (string)
+- `sitemap_is_index` (boolean)
+- `sitemap_is_index_prev` (boolean)
+- `sitemap_nr_urls` (integer)
+- `sitemap_nr_urls_prev` (integer)
+- `sitemap_save_max_size` (integer)
+- `sitemap_save_max_size_diff` (integer)
+- `sitemap_save_max_size_prev` (integer)
+- `sitemap_unzipped_size` (integer)
+- `sitemap_unzipped_size_diff` (integer)
+- `sitemap_unzipped_size_prev` (integer)
+- `size` (integer)
+- `size_diff` (integer)
+- `size_prev` (integer)
+- `source` (array(string))
+- `source_prev` (array(string))
+- `stamp` (date)
+- `stamp_prev` (date)
+- `time_to_first_byte` (integer)
+- `time_to_first_byte_prev` (integer)
+- `title` (array(string))
+- `title_prev` (array(string))
+- `titles_length` (array(integer))
+- `titles_length_prev` (array(integer))
+- `top_keyword` (string)
+- `top_keyword_position` (integer)
+- `top_keyword_position_diff` (integer)
+- `top_keyword_position_prev` (integer)
+- `top_keyword_prev` (string)
+- `traffic` (float)
+- `traffic_diff` (float)
+- `traffic_prev` (float)
+- `url` (url)
+- `url_prev` (url)
+
+</details>
+
+**Returns:** `list[SiteAuditPageExplorerData]`
+
+<details>
+<summary>605 fields</summary>
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `ai_content_level` | `str \| None` | The estimated percentage of AI-generated text on the page. Possible values: `None`, `Low`, `Moderate`, `High`, `Very High` |
+| `ai_content_status` | `str \| None` | AI detection status for each page. Possible values: - `Success`: Content analyzed successfully - `Content_too_short`: Not enough text for reliable detection - `Not_eligible`: URL isn't an internal HTML page - `Failed`: Internal issue prevented detection - `Detection_off`: Disabled in Crawl settings |
+| `alternate` | `int \| None` | The number of incoming external links from rel="alternate" attributes on the pages (data from Ahrefs' Site Explorer database) |
+| `alternate_diff` | `int \| None` | The number of incoming external links from rel="alternate" attributes on the pages (data from Ahrefs' Site Explorer database) |
+| `alternate_prev` | `int \| None` | The number of incoming external links from rel="alternate" attributes on the pages (data from Ahrefs' Site Explorer database) |
+| `backlinks` | `int \| None` | The number of incoming external links (both dofollow and nofollow) pointing to the URL (data from Ahrefs' Site Explorer database). Not to be confused with the number of linking pages, as one page can contain multiple backlinks |
+| `backlinks_diff` | `int \| None` | The number of incoming external links (both dofollow and nofollow) pointing to the URL (data from Ahrefs' Site Explorer database). Not to be confused with the number of linking pages, as one page can contain multiple backlinks |
+| `backlinks_prev` | `int \| None` | The number of incoming external links (both dofollow and nofollow) pointing to the URL (data from Ahrefs' Site Explorer database). Not to be confused with the number of linking pages, as one page can contain multiple backlinks |
+| `canonical` | `str \| None` | The URL of the canonical version of the page |
+| `canonical_code` | `int \| None` | The HTTP status code of the canonical URL |
+| `canonical_counts` | `int \| None` | The number of incoming external links from canonical pages pointing to the URL. Not to be confused with the number of linking pages, as one page can contain multiple backlinks |
+| `canonical_counts_diff` | `int \| None` | The number of incoming external links from canonical pages pointing to the URL. Not to be confused with the number of linking pages, as one page can contain multiple backlinks |
+| `canonical_counts_prev` | `int \| None` | The number of incoming external links from canonical pages pointing to the URL. Not to be confused with the number of linking pages, as one page can contain multiple backlinks |
+| `canonical_group_hash` | `int \| None` | The ID of the group of pages that have the same canonical URL |
+| `canonical_is_canonical` | `bool \| None` | Indicates whether the target page tags itself as the canonical version to be shown in search results. A page is considered as canonical when it doesn't refer to any other pages as canonical |
+| `canonical_is_canonical_prev` | `bool \| None` | Indicates whether the target page tags itself as the canonical version to be shown in search results. A page is considered as canonical when it doesn't refer to any other pages as canonical |
+| `canonical_no_crawl_reason` | `str \| None` | The reason why the canonical version of the page was not crawled |
+| `canonical_no_crawl_reason_prev` | `str \| None` | The reason why the canonical version of the page was not crawled |
+| `canonical_prev` | `str \| None` | The URL of the canonical version of the page |
+| `canonical_scheme` | `str \| None` | The protocol of the canonical URL |
+| `canonical_scheme_prev` | `str \| None` | The protocol of the canonical URL |
+| `compliant` | `bool \| None` | Indicates that the page is indexable. An indexable page is an HTML page returning the 200 HTTP status code that has neither the "rel=canonical" tag pointing to a different URL nor the "noindex" directive |
+| `compliant_prev` | `bool \| None` | Indicates that the page is indexable. An indexable page is an HTML page returning the 200 HTTP status code that has neither the "rel=canonical" tag pointing to a different URL nor the "noindex" directive |
+| `compression` | `str \| None` | The data compression scheme |
+| `compression_prev` | `str \| None` | The data compression scheme |
+| `content_encoding` | `str \| None` | The Content-Encoding HTTP response header field |
+| `content_encoding_prev` | `str \| None` | The Content-Encoding HTTP response header field |
+| `content_length` | `int \| None` | The character length of content displayed on the page |
+| `content_length_diff` | `int \| None` | The character length of content displayed on the page |
+| `content_length_prev` | `int \| None` | The character length of content displayed on the page |
+| `content_nr_word` | `int \| None` | The word count of content displayed on the page |
+| `content_nr_word_diff` | `int \| None` | The word count of content displayed on the page |
+| `content_nr_word_prev` | `int \| None` | The word count of content displayed on the page |
+| `content_type` | `str \| None` | The Content-Type HTTP header of the page or resource. You can find the full list of content types [here](https://www.iana.org/assignments/media-types/media-types.xhtml) |
+| `content_type_prev` | `str \| None` | The Content-Type HTTP header of the page or resource. You can find the full list of content types [here](https://www.iana.org/assignments/media-types/media-types.xhtml) |
+| `css_no_crawl_reason` | `list[dict[str, Any] \| None]` | The reasons why CSS files linked from the page were not crawled |
+| `css_no_crawl_reason_prev` | `list[dict[str, Any] \| None]` | The reasons why CSS files linked from the page were not crawled |
+| `curl_code` | `int` | CURLcode return code. You can find the full list of CURL codes [here](https://curl.haxx.se/libcurl/c/libcurl-errors.html) |
+| `depth` | `int \| None` | The minimum number of clicks required for our crawler to reach the URL from the starting point of a crawl (seed page). Please note that redirects are also counted as a level |
+| `depth_diff` | `int \| None` | The minimum number of clicks required for our crawler to reach the URL from the starting point of a crawl (seed page). Please note that redirects are also counted as a level |
+| `depth_prev` | `int \| None` | The minimum number of clicks required for our crawler to reach the URL from the starting point of a crawl (seed page). Please note that redirects are also counted as a level |
+| `dofollow` | `int \| None` | The number of incoming external dofollow links pointing to the URL. Not to be confused with the number of linking pages, as one page can contain multiple backlinks |
+| `dofollow_prev` | `int \| None` | The number of incoming external dofollow links pointing to the URL. Not to be confused with the number of linking pages, as one page can contain multiple backlinks |
+| `domain` | `str` | The domain name part of the URL |
+| `duplicate_content` | `int \| None` | The number of pages with matching or appreciably similar content |
+| `duplicate_content_canonical_hreflang` | `int \| None` | The number of page groups with matching or appreciably similar content. A group includes pages united by a common canonical URL, hreflang or pagination tags |
+| `duplicate_content_canonical_hreflang_diff` | `int \| None` | The number of page groups with matching or appreciably similar content. A group includes pages united by a common canonical URL, hreflang or pagination tags |
+| `duplicate_content_canonical_hreflang_prev` | `int \| None` | The number of page groups with matching or appreciably similar content. A group includes pages united by a common canonical URL, hreflang or pagination tags |
+| `duplicate_content_diff` | `int \| None` | The number of pages with matching or appreciably similar content |
+| `duplicate_content_prev` | `int \| None` | The number of pages with matching or appreciably similar content |
+| `duplicate_description` | `int \| None` | The number of pages that have the same meta description. If the page has more than one meta description, each will be checked for duplicates |
+| `duplicate_description_canonical_hreflang` | `int \| None` | The number of page groups that have the same meta description. A group includes pages united by a common canonical URL, hreflang or pagination tags |
+| `duplicate_description_canonical_hreflang_diff` | `int \| None` | The number of page groups that have the same meta description. A group includes pages united by a common canonical URL, hreflang or pagination tags |
+| `duplicate_description_canonical_hreflang_prev` | `int \| None` | The number of page groups that have the same meta description. A group includes pages united by a common canonical URL, hreflang or pagination tags |
+| `duplicate_description_diff` | `int \| None` | The number of pages that have the same meta description. If the page has more than one meta description, each will be checked for duplicates |
+| `duplicate_description_prev` | `int \| None` | The number of pages that have the same meta description. If the page has more than one meta description, each will be checked for duplicates |
+| `duplicate_group_identifier` | `int \| None` | The ID of the group of pages that are interconnected via a common canonical URL, hreflang or pagination tags |
+| `duplicate_h1` | `int \| None` | The number of pages that have the same H1 subheader. If the page has more than one H1 subheader, each will be checked for duplicates |
+| `duplicate_h1_diff` | `int \| None` | The number of pages that have the same H1 subheader. If the page has more than one H1 subheader, each will be checked for duplicates |
+| `duplicate_h1_prev` | `int \| None` | The number of pages that have the same H1 subheader. If the page has more than one H1 subheader, each will be checked for duplicates |
+| `duplicate_h1canonical_hreflang` | `int \| None` | The number of page groups sharing the same H1 subheader. A group includes pages united by a common canonical URL, hreflang or pagination tags |
+| `duplicate_h1canonical_hreflang_diff` | `int \| None` | The number of page groups sharing the same H1 subheader. A group includes pages united by a common canonical URL, hreflang or pagination tags |
+| `duplicate_h1canonical_hreflang_prev` | `int \| None` | The number of page groups sharing the same H1 subheader. A group includes pages united by a common canonical URL, hreflang or pagination tags |
+| `duplicate_title` | `int \| None` | The number of pages that have the same title. If the page has more than one title, each will be checked for duplicates |
+| `duplicate_title_canonical_hreflang` | `int \| None` | The number of page groups that have the same title. A group includes pages united by a common canonical URL, hreflang or pagination tags |
+| `duplicate_title_canonical_hreflang_diff` | `int \| None` | The number of page groups that have the same title. A group includes pages united by a common canonical URL, hreflang or pagination tags |
+| `duplicate_title_canonical_hreflang_prev` | `int \| None` | The number of page groups that have the same title. A group includes pages united by a common canonical URL, hreflang or pagination tags |
+| `duplicate_title_diff` | `int \| None` | The number of pages that have the same title. If the page has more than one title, each will be checked for duplicates |
+| `duplicate_title_prev` | `int \| None` | The number of pages that have the same title. If the page has more than one title, each will be checked for duplicates |
+| `edu` | `int \| None` | The number of incoming external links from .edu domains pointing to the URL (data from Ahrefs' Site Explorer database). Not to be confused with the number of linking pages, as one page can contain multiple backlinks |
+| `edu_diff` | `int \| None` | The number of incoming external links from .edu domains pointing to the URL (data from Ahrefs' Site Explorer database). Not to be confused with the number of linking pages, as one page can contain multiple backlinks |
+| `edu_prev` | `int \| None` | The number of incoming external links from .edu domains pointing to the URL (data from Ahrefs' Site Explorer database). Not to be confused with the number of linking pages, as one page can contain multiple backlinks |
+| `external_code` | `list[dict[str, Any] \| None]` | The list of HTTP status codes returned by the external URLs linked from the page |
+| `external_link_anchor` | `list[dict[str, Any] \| None]` | The list of anchor texts used in external outgoing links on the page |
+| `external_link_anchor_prev` | `list[dict[str, Any] \| None]` | The list of anchor texts used in external outgoing links on the page |
+| `external_link_domain` | `list[str \| None]` | The list of external domains linked to from the page |
+| `external_link_domain_prev` | `list[str \| None]` | The list of external domains linked to from the page |
+| `external_links` | `list[str \| None]` | The list of external outgoing links on the page |
+| `external_links_is_canonical` | `list[dict[str, Any] \| None]` | Indicates whether the target page tags itself as the canonical version to be shown in search results. A page is considered as canonical when it doesn't refer to any other pages as canonical |
+| `external_links_is_canonical_prev` | `list[dict[str, Any] \| None]` | Indicates whether the target page tags itself as the canonical version to be shown in search results. A page is considered as canonical when it doesn't refer to any other pages as canonical |
+| `external_links_prev` | `list[str \| None]` | The list of external outgoing links on the page |
+| `external_no_crawl_reason` | `list[dict[str, Any] \| None]` | The reasons why the external URLs linked from the page were not crawled |
+| `external_no_crawl_reason_prev` | `list[dict[str, Any] \| None]` | The reasons why the external URLs linked from the page were not crawled |
+| `external_scheme` | `list[str \| None]` | The protocols of the external outgoing links on the page |
+| `external_scheme_prev` | `list[str \| None]` | The protocols of the external outgoing links on the page |
+| `final_redirect` | `str \| None` | The destination of the final redirecting URL |
+| `final_redirect_code` | `int \| None` | The HTTP status code of the destination of the final redirecting URL |
+| `final_redirect_no_crawl_reason` | `str \| None` | The reason why the destination of the final redirecting URL was not crawled |
+| `final_redirect_no_crawl_reason_prev` | `str \| None` | The reason why the destination of the final redirecting URL was not crawled |
+| `final_redirect_prev` | `str \| None` | The destination of the final redirecting URL |
+| `found_in_sitemaps` | `list[str \| None]` | The list of sitemaps that reference the URL |
+| `found_in_sitemaps_length` | `int` | The number of sitemaps that reference the URL |
+| `found_in_sitemaps_prev` | `list[str \| None]` | The list of sitemaps that reference the URL |
+| `gov` | `int \| None` | The total number of incoming external links from .gov domains pointing to the URL (data from Ahrefs' Site Explorer database). Not to be confused with the number of linking pages, as one page can contain multiple backlinks |
+| `gov_diff` | `int \| None` | The total number of incoming external links from .gov domains pointing to the URL (data from Ahrefs' Site Explorer database). Not to be confused with the number of linking pages, as one page can contain multiple backlinks |
+| `gov_prev` | `int \| None` | The total number of incoming external links from .gov domains pointing to the URL (data from Ahrefs' Site Explorer database). Not to be confused with the number of linking pages, as one page can contain multiple backlinks |
+| `h1` | `list[str \| None]` | The page H1 subheader |
+| `h1_prev` | `list[str \| None]` | The page H1 subheader |
+| `h1length` | `list[int \| None]` | The character length of the page H1 subheader |
+| `h1length_prev` | `list[int \| None]` | The character length of the page H1 subheader |
+| `h2` | `list[str \| None]` | The page H2 subheader |
+| `h2_prev` | `list[str \| None]` | The page H2 subheader |
+| `hash_content` | `int \| None` | The page content fingerprint. Pages with matching or appreciably similar content have the same content hash |
+| `hash_descriptions` | `list[int \| None]` | meta_descriptions.hash |
+| `hash_h1` | `list[int \| None]` | The page H1 subheader fingerprint. Pages with matching H1 tags have the same H1 hash |
+| `hash_text` | `int \| None` | The page text fingerprint. Pages with matching content have the same text hash |
+| `hash_titles` | `list[int \| None]` | The page title fingerprint. Pages with matching title tags have the same title hash |
+| `hreflang` | `list[dict[str, Any] \| None]` | Data from hreflang attributes |
+| `hreflang_code_is_valid` | `list[dict[str, Any] \| None]` | Indicates that hreflang data is specified properly in the hreflang tags on the page. The language must be specified in [ISO 639-1 format](https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes), and optionally the region in [ISO 3166-1 Alpha 2 format](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2) |
+| `hreflang_code_is_valid_prev` | `list[dict[str, Any] \| None]` | Indicates that hreflang data is specified properly in the hreflang tags on the page. The language must be specified in [ISO 639-1 format](https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes), and optionally the region in [ISO 3166-1 Alpha 2 format](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2) |
+| `hreflang_country` | `list[dict[str, Any] \| None]` | The list of regions specified in the hreflang tags on the page |
+| `hreflang_country_prev` | `list[dict[str, Any] \| None]` | The list of regions specified in the hreflang tags on the page |
+| `hreflang_group_hash` | `int \| None` | The ID of the group of pages that have the same set of hreflang attributes with the same set of URLs in them |
+| `hreflang_inlink_urls` | `list[str \| None]` | The list of incoming URLs with hreflang attribute |
+| `hreflang_inlink_urls_prev` | `list[str \| None]` | The list of incoming URLs with hreflang attribute |
+| `hreflang_issues` | `list[str \| None]` | The list of hreflang-related issues a page has |
+| `hreflang_issues_prev` | `list[str \| None]` | The list of hreflang-related issues a page has |
+| `hreflang_language` | `list[dict[str, Any] \| None]` | The list of languages specified in the hreflang tags on the page |
+| `hreflang_language_prev` | `list[dict[str, Any] \| None]` | The list of languages specified in the hreflang tags on the page |
+| `hreflang_link` | `list[str \| None]` | The list of URLs specified in the hreflang tags on the page |
+| `hreflang_link_is_canonical` | `list[dict[str, Any] \| None]` | Indicates whether the target page tags itself as the canonical version to be shown in search results. A page is considered as canonical when it doesn't refer to any other pages as canonical |
+| `hreflang_link_is_canonical_prev` | `list[dict[str, Any] \| None]` | Indicates whether the target page tags itself as the canonical version to be shown in search results. A page is considered as canonical when it doesn't refer to any other pages as canonical |
+| `hreflang_link_prev` | `list[str \| None]` | The list of URLs specified in the hreflang tags on the page |
+| `hreflang_no_crawl_reason` | `list[dict[str, Any] \| None]` | The reasons why URLs specified in the hreflang tags on the page were not crawled |
+| `hreflang_no_crawl_reason_prev` | `list[dict[str, Any] \| None]` | The reasons why URLs specified in the hreflang tags on the page were not crawled |
+| `hreflang_pages_urls` | `list[str \| None]` | List of hreflang-linked pages URLs the page belongs to |
+| `hreflang_pages_urls_count` | `int \| None` | Count of hreflang-linked pages URLs the page belongs to |
+| `hreflang_pages_urls_count_diff` | `int \| None` | Count of hreflang-linked pages URLs the page belongs to |
+| `hreflang_pages_urls_count_prev` | `int \| None` | Count of hreflang-linked pages URLs the page belongs to |
+| `hreflang_pages_urls_prev` | `list[str \| None]` | List of hreflang-linked pages URLs the page belongs to |
+| `hreflang_prev` | `list[dict[str, Any] \| None]` | Data from hreflang attributes |
+| `html_lang` | `str \| None` | Data from the page's HTML lang tag |
+| `html_lang_code_is_valid` | `bool \| None` | Indicates that the language (or language-region) code is specified properly in the HTML lang tag. The language must be specified in [ISO 639-1 format](https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes), and optionally the region in [ISO 3166-1 Alpha 2 format](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2) |
+| `html_lang_code_is_valid_prev` | `bool \| None` | Indicates that the language (or language-region) code is specified properly in the HTML lang tag. The language must be specified in [ISO 639-1 format](https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes), and optionally the region in [ISO 3166-1 Alpha 2 format](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2) |
+| `html_lang_country` | `str \| None` | The region code specified in the page's HTML lang tag |
+| `html_lang_country_prev` | `str \| None` | The region code specified in the page's HTML lang tag |
+| `html_lang_language` | `str \| None` | The language code specified in the page's HTML lang tag |
+| `html_lang_language_prev` | `str \| None` | The language code specified in the page's HTML lang tag |
+| `html_lang_prev` | `str \| None` | Data from the page's HTML lang tag |
+| `http_code` | `int` | The HTTP status code returned by the URL |
+| `http_header` | `list[str \| None]` | The HTTP headers that the web server returns |
+| `http_header_prev` | `list[str \| None]` | The HTTP headers that the web server returns |
+| `http_header_robots` | `list[str \| None]` | Instructions for web crawlers specified in HTTP headers |
+| `http_header_robots_prev` | `list[str \| None]` | Instructions for web crawlers specified in HTTP headers |
+| `http_headers_size` | `int` | The size of the HTTP headers that the web server returns, measured in bytes |
+| `http_headers_size_diff` | `int \| None` | The size of the HTTP headers that the web server returns, measured in bytes |
+| `http_headers_size_prev` | `int \| None` | The size of the HTTP headers that the web server returns, measured in bytes |
+| `images_no_crawl_reason` | `list[dict[str, Any] \| None]` | The reasons why images linked from the page were not crawled |
+| `images_no_crawl_reason_prev` | `list[dict[str, Any] \| None]` | The reasons why images linked from the page were not crawled |
+| `incoming_all_links` | `int \| None` | The number of incoming links to the URL of all types |
+| `incoming_all_links_diff` | `int \| None` | The number of incoming links to the URL of all types |
+| `incoming_all_links_prev` | `int \| None` | The number of incoming links to the URL of all types |
+| `incoming_canonical` | `int \| None` | Shows how many times the URL is linked to from a rel="canonical" element |
+| `incoming_canonical_diff` | `int \| None` | Shows how many times the URL is linked to from a rel="canonical" element |
+| `incoming_canonical_prev` | `int \| None` | Shows how many times the URL is linked to from a rel="canonical" element |
+| `incoming_css` | `int \| None` | The number of incoming links to the CSS file |
+| `incoming_css_diff` | `int \| None` | The number of incoming links to the CSS file |
+| `incoming_css_prev` | `int \| None` | The number of incoming links to the CSS file |
+| `incoming_follow` | `int \| None` | The number of incoming dofollow links to the URL from hyperlinks |
+| `incoming_follow_diff` | `int \| None` | The number of incoming dofollow links to the URL from hyperlinks |
+| `incoming_follow_prev` | `int \| None` | The number of incoming dofollow links to the URL from hyperlinks |
+| `incoming_hreflang` | `int \| None` | Shows how many times the URL is linked to from a rel="alternate" hreflang="x" attribute |
+| `incoming_hreflang_diff` | `int \| None` | Shows how many times the URL is linked to from a rel="alternate" hreflang="x" attribute |
+| `incoming_hreflang_prev` | `int \| None` | Shows how many times the URL is linked to from a rel="alternate" hreflang="x" attribute |
+| `incoming_image` | `int \| None` | The number of incoming links to the image file |
+| `incoming_image_diff` | `int \| None` | The number of incoming links to the image file |
+| `incoming_image_prev` | `int \| None` | The number of incoming links to the image file |
+| `incoming_js` | `int \| None` | The number of incoming links to the JS file |
+| `incoming_js_diff` | `int \| None` | The number of incoming links to the JS file |
+| `incoming_js_prev` | `int \| None` | The number of incoming links to the JS file |
+| `incoming_links` | `int \| None` | The number of incoming links to the URL from hyperlinks |
+| `incoming_links_diff` | `int \| None` | The number of incoming links to the URL from hyperlinks |
+| `incoming_links_prev` | `int \| None` | The number of incoming links to the URL from hyperlinks |
+| `incoming_nofollow` | `int \| None` | The number of incoming nofollow links to the URL from hyperlinks |
+| `incoming_nofollow_diff` | `int \| None` | The number of incoming nofollow links to the URL from hyperlinks |
+| `incoming_nofollow_prev` | `int \| None` | The number of incoming nofollow links to the URL from hyperlinks |
+| `incoming_pagination` | `int \| None` | Shows how many times the URL is linked to from rel="prev" or rel="next" elements on pages |
+| `incoming_pagination_diff` | `int \| None` | Shows how many times the URL is linked to from rel="prev" or rel="next" elements on pages |
+| `incoming_pagination_prev` | `int \| None` | Shows how many times the URL is linked to from rel="prev" or rel="next" elements on pages |
+| `incoming_redirect` | `int \| None` | The number of incoming redirecting links to the URL |
+| `incoming_redirect_diff` | `int \| None` | The number of incoming redirecting links to the URL |
+| `incoming_redirect_prev` | `int \| None` | The number of incoming redirecting links to the URL |
+| `indexnow_error` | `str \| None` | The error description for a failed auto-submission |
+| `indexnow_error_prev` | `str \| None` | The error description for a failed auto-submission |
+| `indexnow_reason` | `str \| None` | The reason the page was considered for auto-submission to IndexNow |
+| `indexnow_reason_prev` | `str \| None` | The reason the page was considered for auto-submission to IndexNow |
+| `indexnow_status` | `str \| None` | The status of IndexNow auto-submission. Possible values: - **Success:** The page was successfully submitted to IndexNow. - **No changes detected:** No changes were detected on the page; submission was not required. - **Not eligible:** The URL isn't eligible for submission, e.g., it's not an indexable HTML page. - **Invalid API key:** IndexNow submission failed due to an invalid API key. - **Failed:** Submission to IndexNow failed; see details for the reason. - **Auto-submission is off:** Automatic submission is disabled in Crawl settings |
+| `indexnow_status_prev` | `str \| None` | The status of IndexNow auto-submission. Possible values: - **Success:** The page was successfully submitted to IndexNow. - **No changes detected:** No changes were detected on the page; submission was not required. - **Not eligible:** The URL isn't eligible for submission, e.g., it's not an indexable HTML page. - **Invalid API key:** IndexNow submission failed due to an invalid API key. - **Failed:** Submission to IndexNow failed; see details for the reason. - **Auto-submission is off:** Automatic submission is disabled in Crawl settings |
+| `indexnow_submitted_at` | `str \| None` | The date and time when the URL was auto-submitted to IndexNow |
+| `indexnow_submitted_at_prev` | `str \| None` | The date and time when the URL was auto-submitted to IndexNow |
+| `internal_code` | `list[dict[str, Any] \| None]` | The list of HTTP status codes returned by the internal URLs linked to from the page |
+| `internal_inlink_urls` | `list[str \| None]` | The list of URLs for incoming internal links |
+| `internal_inlink_urls_prev` | `list[str \| None]` | The list of URLs for incoming internal links |
+| `internal_link_anchor` | `list[dict[str, Any] \| None]` | The list of anchor texts used in internal outgoing links on the page |
+| `internal_link_anchor_prev` | `list[dict[str, Any] \| None]` | The list of anchor texts used in internal outgoing links on the page |
+| `internal_link_domain` | `list[str \| None]` | The domain (or its subdomains, depending on the scope of the crawl) linked to from internal outgoing links on the page |
+| `internal_link_domain_prev` | `list[str \| None]` | The domain (or its subdomains, depending on the scope of the crawl) linked to from internal outgoing links on the page |
+| `internal_links` | `list[str \| None]` | The list of internal outgoing links on the page |
+| `internal_links_is_canonical` | `list[dict[str, Any] \| None]` | Indicates whether the target page tags itself as the canonical version to be shown in search results. A page is considered as canonical when it doesn't refer to any other pages as canonical |
+| `internal_links_is_canonical_prev` | `list[dict[str, Any] \| None]` | Indicates whether the target page tags itself as the canonical version to be shown in search results. A page is considered as canonical when it doesn't refer to any other pages as canonical |
+| `internal_links_prev` | `list[str \| None]` | The list of internal outgoing links on the page |
+| `internal_no_crawl_reason` | `list[dict[str, Any] \| None]` | The reasons why the internal URLs linked to from the page were not crawled |
+| `internal_no_crawl_reason_prev` | `list[dict[str, Any] \| None]` | The reasons why the internal URLs linked to from the page were not crawled |
+| `internal_scheme` | `list[str \| None]` | The protocols of the internal outgoing links on the page |
+| `internal_scheme_prev` | `list[str \| None]` | The protocols of the internal outgoing links on the page |
+| `is_html` | `bool` | Indicates that the content type of the web document is HTML |
+| `is_in_sitemap` | `bool \| None` | Indicates that the URL is included in the website's sitemap file |
+| `is_in_sitemap_prev` | `bool \| None` | Indicates that the URL is included in the website's sitemap file |
+| `is_page_title_used_in_serp` | `bool \| None` | Indicates that the page and SERP titles match |
+| `is_redirect_loop` | `bool \| None` | Checks if the URL has a redirect loop |
+| `is_redirect_loop_prev` | `bool \| None` | Checks if the URL has a redirect loop |
+| `is_rendered` | `bool \| None` | Indicates that the crawler had executed JavaScript on the page to generate content |
+| `is_rendered_prev` | `bool \| None` | Indicates that the crawler had executed JavaScript on the page to generate content |
+| `is_valid_internal_html` | `bool` | The HTML page on the crawled domain or its subdomain that returns a 200 HTTP status code |
+| `is_valid_internal_html_prev` | `bool \| None` | The HTML page on the crawled domain or its subdomain that returns a 200 HTTP status code |
+| `js_no_crawl_reason` | `list[dict[str, Any] \| None]` | The reasons why JavaScript files linked from the page were not crawled |
+| `js_no_crawl_reason_prev` | `list[dict[str, Any] \| None]` | The reasons why JavaScript files linked from the page were not crawled |
+| `jsonld_attributes` | `list[str \| None]` | Names of the schema properties found on the page (with indices) |
+| `jsonld_attributes_prev` | `list[str \| None]` | Names of the schema properties found on the page (with indices) |
+| `jsonld_schema_types` | `list[str \| None]` | Schema objects found on the page |
+| `jsonld_schema_types_prev` | `list[str \| None]` | Schema objects found on the page |
+| `jsonld_validation_kinds` | `list[str \| None]` | Issues with the structured data found on the page |
+| `jsonld_validation_kinds_prev` | `list[str \| None]` | Issues with the structured data found on the page |
+| `jsonld_values` | `list[str \| None]` | Values of the schema properties found on the page |
+| `jsonld_values_prev` | `list[str \| None]` | Values of the schema properties found on the page |
+| `keywords` | `list[str \| None]` | The page meta keywords |
+| `keywords_prev` | `list[str \| None]` | The page meta keywords |
+| `length` | `int` | The character length of the URL |
+| `links_count_css` | `int \| None` | The number of CSS files linked from the page |
+| `links_count_css_prev` | `int \| None` | The number of CSS files linked from the page |
+| `links_count_external` | `int \| None` | The number of external outgoing links on the page |
+| `links_count_external3xx` | `int \| None` | The number of external outgoing links on the page pointing to URLs that return one of the 3xx (redirection) HTTP status codes |
+| `links_count_external3xx_diff` | `int \| None` | The number of external outgoing links on the page pointing to URLs that return one of the 3xx (redirection) HTTP status codes |
+| `links_count_external3xx_prev` | `int \| None` | The number of external outgoing links on the page pointing to URLs that return one of the 3xx (redirection) HTTP status codes |
+| `links_count_external4xx` | `int \| None` | The number of external outgoing links on the page pointing to URLs that return one of the 4xx (client error) HTTP status codes |
+| `links_count_external4xx_diff` | `int \| None` | The number of external outgoing links on the page pointing to URLs that return one of the 4xx (client error) HTTP status codes |
+| `links_count_external4xx_prev` | `int \| None` | The number of external outgoing links on the page pointing to URLs that return one of the 4xx (client error) HTTP status codes |
+| `links_count_external5xx` | `int \| None` | The number of external outgoing links on the page pointing to URLs that return one of the 5xx (server error) HTTP status codes |
+| `links_count_external5xx_diff` | `int \| None` | The number of external outgoing links on the page pointing to URLs that return one of the 5xx (server error) HTTP status codes |
+| `links_count_external5xx_prev` | `int \| None` | The number of external outgoing links on the page pointing to URLs that return one of the 5xx (server error) HTTP status codes |
+| `links_count_external_diff` | `int \| None` | The number of external outgoing links on the page |
+| `links_count_external_follow` | `int \| None` | The number of external outgoing dofollow links on the page |
+| `links_count_external_follow_diff` | `int \| None` | The number of external outgoing dofollow links on the page |
+| `links_count_external_follow_prev` | `int \| None` | The number of external outgoing dofollow links on the page |
+| `links_count_external_nofollow` | `int \| None` | The number of external outgoing nofollow links on the page |
+| `links_count_external_nofollow_diff` | `int \| None` | The number of external outgoing nofollow links on the page |
+| `links_count_external_nofollow_prev` | `int \| None` | The number of external outgoing nofollow links on the page |
+| `links_count_external_non_canonical` | `int \| None` | The number of external outgoing links on the page that point to non-canonical pages |
+| `links_count_external_non_canonical_diff` | `int \| None` | The number of external outgoing links on the page that point to non-canonical pages |
+| `links_count_external_non_canonical_prev` | `int \| None` | The number of external outgoing links on the page that point to non-canonical pages |
+| `links_count_external_prev` | `int \| None` | The number of external outgoing links on the page |
+| `links_count_external_xxx` | `int \| None` | The number of external outgoing links on the page pointing to URLs that return HTTP status codes other than 2xx, 3xx, 4xx, 5xx or return no status code |
+| `links_count_external_xxx_diff` | `int \| None` | The number of external outgoing links on the page pointing to URLs that return HTTP status codes other than 2xx, 3xx, 4xx, 5xx or return no status code |
+| `links_count_external_xxx_prev` | `int \| None` | The number of external outgoing links on the page pointing to URLs that return HTTP status codes other than 2xx, 3xx, 4xx, 5xx or return no status code |
+| `links_count_images` | `int \| None` | The number of images linked from the page |
+| `links_count_images_diff` | `int \| None` | The number of images linked from the page |
+| `links_count_images_prev` | `int \| None` | The number of images linked from the page |
+| `links_count_images_with_alt` | `int \| None` | The number of images linked from the page that have an alt attribute (alternate text) |
+| `links_count_images_with_alt_diff` | `int \| None` | The number of images linked from the page that have an alt attribute (alternate text) |
+| `links_count_images_with_alt_prev` | `int \| None` | The number of images linked from the page that have an alt attribute (alternate text) |
+| `links_count_images_without_alt` | `int \| None` | The number of images linked from the page that have no alt attribute (alternate text) |
+| `links_count_images_without_alt_diff` | `int \| None` | The number of images linked from the page that have no alt attribute (alternate text) |
+| `links_count_images_without_alt_prev` | `int \| None` | The number of images linked from the page that have no alt attribute (alternate text) |
+| `links_count_internal` | `int \| None` | The number of internal outgoing links on the page |
+| `links_count_internal3xx` | `int \| None` | The number of internal outgoing links on the page pointing to URLs that return one of the 3xx (redirection) HTTP status codes |
+| `links_count_internal3xx_diff` | `int \| None` | The number of internal outgoing links on the page pointing to URLs that return one of the 3xx (redirection) HTTP status codes |
+| `links_count_internal3xx_prev` | `int \| None` | The number of internal outgoing links on the page pointing to URLs that return one of the 3xx (redirection) HTTP status codes |
+| `links_count_internal4xx` | `int \| None` | The number of internal outgoing links on the page pointing to URLs that return one of the 4xx (client error) HTTP status codes |
+| `links_count_internal4xx_diff` | `int \| None` | The number of internal outgoing links on the page pointing to URLs that return one of the 4xx (client error) HTTP status codes |
+| `links_count_internal4xx_prev` | `int \| None` | The number of internal outgoing links on the page pointing to URLs that return one of the 4xx (client error) HTTP status codes |
+| `links_count_internal5xx` | `int \| None` | The number of internal outgoing links on the page pointing to URLs that return one of the 5xx (server error) HTTP status codes |
+| `links_count_internal5xx_diff` | `int \| None` | The number of internal outgoing links on the page pointing to URLs that return one of the 5xx (server error) HTTP status codes |
+| `links_count_internal5xx_prev` | `int \| None` | The number of internal outgoing links on the page pointing to URLs that return one of the 5xx (server error) HTTP status codes |
+| `links_count_internal_diff` | `int \| None` | The number of internal outgoing links on the page |
+| `links_count_internal_follow` | `int \| None` | The number of internal outgoing dofollow links on the page |
+| `links_count_internal_follow_diff` | `int \| None` | The number of internal outgoing dofollow links on the page |
+| `links_count_internal_follow_prev` | `int \| None` | The number of internal outgoing dofollow links on the page |
+| `links_count_internal_nofollow` | `int \| None` | The number of internal outgoing nofollow links on the page |
+| `links_count_internal_nofollow_diff` | `int \| None` | The number of internal outgoing nofollow links on the page |
+| `links_count_internal_nofollow_prev` | `int \| None` | The number of internal outgoing nofollow links on the page |
+| `links_count_internal_non_canonical` | `int \| None` | The number of internal outgoing links on the page that point to non-canonical pages |
+| `links_count_internal_non_canonical_diff` | `int \| None` | The number of internal outgoing links on the page that point to non-canonical pages |
+| `links_count_internal_non_canonical_prev` | `int \| None` | The number of internal outgoing links on the page that point to non-canonical pages |
+| `links_count_internal_prev` | `int \| None` | The number of internal outgoing links on the page |
+| `links_count_internal_xxx` | `int \| None` | The number of internal outgoing links on the page pointing to URLs that return HTTP status codes other than 2xx, 3xx, 4xx, 5xx or return no status code |
+| `links_count_internal_xxx_diff` | `int \| None` | The number of internal outgoing links on the page pointing to URLs that return HTTP status codes other than 2xx, 3xx, 4xx, 5xx or return no status code |
+| `links_count_internal_xxx_prev` | `int \| None` | The number of internal outgoing links on the page pointing to URLs that return HTTP status codes other than 2xx, 3xx, 4xx, 5xx or return no status code |
+| `links_count_js` | `int \| None` | The number of JavaScript files linked from the page |
+| `links_count_js_diff` | `int \| None` | The number of JavaScript files linked from the page |
+| `links_count_js_prev` | `int \| None` | The number of JavaScript files linked from the page |
+| `links_css` | `list[str \| None]` | The list of CSS files linked from the page |
+| `links_css_code` | `list[dict[str, Any] \| None]` | The list of HTTP status codes returned by CSS files linked from the page |
+| `links_css_domain` | `list[str \| None]` | The list of domains that contain CSS files linked from the page |
+| `links_css_domain_prev` | `list[str \| None]` | The list of domains that contain CSS files linked from the page |
+| `links_css_prev` | `list[str \| None]` | The list of CSS files linked from the page |
+| `links_css_scheme` | `list[str \| None]` | The protocols of CSS files linked from the page |
+| `links_css_scheme_prev` | `list[str \| None]` | The protocols of CSS files linked from the page |
+| `links_external3xx` | `list[str \| None]` | The list of external outgoing links on the page pointing to URLs that return one of the 3xx (redirection) HTTP status codes |
+| `links_external3xx_prev` | `list[str \| None]` | The list of external outgoing links on the page pointing to URLs that return one of the 3xx (redirection) HTTP status codes |
+| `links_external4xx` | `list[str \| None]` | The list of external outgoing links on the page pointing to URLs that return one of the 4xx (client error) HTTP status codes |
+| `links_external4xx_prev` | `list[str \| None]` | The list of external outgoing links on the page pointing to URLs that return one of the 4xx (client error) HTTP status codes |
+| `links_external5xx` | `list[str \| None]` | The list of external outgoing links on the page pointing to URLs that return one of the 5xx (server error) HTTP status codes |
+| `links_external5xx_prev` | `list[str \| None]` | The list of external outgoing links on the page pointing to URLs that return one of the 5xx (server error) HTTP status codes |
+| `links_external_follow` | `list[str \| None]` | The list of external outgoing dofollow links on the page |
+| `links_external_follow_prev` | `list[str \| None]` | The list of external outgoing dofollow links on the page |
+| `links_external_nofollow` | `list[str \| None]` | The list of external outgoing nofollow links on the page |
+| `links_external_nofollow_prev` | `list[str \| None]` | The list of external outgoing nofollow links on the page |
+| `links_external_non_canonical` | `list[str \| None]` | The list of external outgoing links on the page that point to non-canonical pages |
+| `links_external_non_canonical_prev` | `list[str \| None]` | The list of external outgoing links on the page that point to non-canonical pages |
+| `links_external_xxx` | `list[str \| None]` | The number of external outgoing links on the page pointing to URLs that return HTTP status codes other than 2xx, 3xx, 4xx, 5xx or return no status code |
+| `links_external_xxx_prev` | `list[str \| None]` | The number of external outgoing links on the page pointing to URLs that return HTTP status codes other than 2xx, 3xx, 4xx, 5xx or return no status code |
+| `links_hreflang_code` | `list[dict[str, Any] \| None]` | The list of HTTP status codes returned by the URLs specified in hreflang tags on the page |
+| `links_images` | `list[str \| None]` | The list of images linked from the page |
+| `links_images_alt` | `list[dict[str, Any] \| None]` | The list of alternate texts of images linked from the page |
+| `links_images_alt_prev` | `list[dict[str, Any] \| None]` | The list of alternate texts of images linked from the page |
+| `links_images_code` | `list[dict[str, Any] \| None]` | The list of HTTP status codes returned by images linked from the page |
+| `links_images_domain` | `list[str \| None]` | The list of domains that contain images linked from the page |
+| `links_images_domain_prev` | `list[str \| None]` | The list of domains that contain images linked from the page |
+| `links_images_prev` | `list[str \| None]` | The list of images linked from the page |
+| `links_images_scheme` | `list[str \| None]` | The protocols of images linked from the page |
+| `links_images_scheme_prev` | `list[str \| None]` | The protocols of images linked from the page |
+| `links_images_with_alt` | `list[str \| None]` | The list of images linked from the page that have an alt attribute (alternate text) |
+| `links_images_with_alt_prev` | `list[str \| None]` | The list of images linked from the page that have an alt attribute (alternate text) |
+| `links_images_without_alt` | `list[str \| None]` | The list of images linked from the page that have no alt attribute (alternate text) |
+| `links_images_without_alt_prev` | `list[str \| None]` | The list of images linked from the page that have no alt attribute (alternate text) |
+| `links_internal3xx` | `list[str \| None]` | The list of internal outgoing links on the page pointing to URLs that return one of the 3xx (redirection) HTTP status codes |
+| `links_internal3xx_prev` | `list[str \| None]` | The list of internal outgoing links on the page pointing to URLs that return one of the 3xx (redirection) HTTP status codes |
+| `links_internal4xx` | `list[str \| None]` | The list of internal outgoing links on the page pointing to URLs that return one of the 4xx (client error) HTTP status codes |
+| `links_internal4xx_prev` | `list[str \| None]` | The list of internal outgoing links on the page pointing to URLs that return one of the 4xx (client error) HTTP status codes |
+| `links_internal5xx` | `list[str \| None]` | The list of internal outgoing links on the page pointing to URLs that return one of the 5xx (server error) HTTP status codes |
+| `links_internal5xx_prev` | `list[str \| None]` | The list of internal outgoing links on the page pointing to URLs that return one of the 5xx (server error) HTTP status codes |
+| `links_internal_follow` | `list[str \| None]` | The list of internal outgoing dofollow links on the page |
+| `links_internal_follow_prev` | `list[str \| None]` | The list of internal outgoing dofollow links on the page |
+| `links_internal_nofollow` | `list[str \| None]` | The list of internal outgoing nofollow links on the page |
+| `links_internal_nofollow_prev` | `list[str \| None]` | The list of internal outgoing nofollow links on the page |
+| `links_internal_non_canonical` | `list[str \| None]` | The list of internal outgoing links on the page that point to non-canonical pages |
+| `links_internal_non_canonical_prev` | `list[str \| None]` | The list of internal outgoing links on the page that point to non-canonical pages |
+| `links_internal_xxx` | `list[str \| None]` | The list of internal outgoing links on the page pointing to URLs that return HTTP status codes other than 2xx, 3xx, 4xx, 5xx or return no status code |
+| `links_internal_xxx_prev` | `list[str \| None]` | The list of internal outgoing links on the page pointing to URLs that return HTTP status codes other than 2xx, 3xx, 4xx, 5xx or return no status code |
+| `links_js` | `list[str \| None]` | The list of JavaScript files linked from the page |
+| `links_js_code` | `list[dict[str, Any] \| None]` | The list of HTTP status codes returned by JavaScript files linked from the page |
+| `links_js_domain` | `list[str \| None]` | The list of domains that contain JavaScript files linked from the page |
+| `links_js_domain_prev` | `list[str \| None]` | The list of domains that contain JavaScript files linked from the page |
+| `links_js_prev` | `list[str \| None]` | The list of JavaScript files linked from the page |
+| `links_js_scheme` | `list[str \| None]` | The protocols of JavaScript files linked from the page |
+| `links_js_scheme_prev` | `list[str \| None]` | The protocols of JavaScript files linked from the page |
+| `loading_time` | `int` | The time it takes for the crawler to load the full content of the document, measured in milliseconds |
+| `loading_time_diff` | `int \| None` | The time it takes for the crawler to load the full content of the document, measured in milliseconds |
+| `loading_time_prev` | `int \| None` | The time it takes for the crawler to load the full content of the document, measured in milliseconds |
+| `meta_description` | `list[str \| None]` | Meta description |
+| `meta_description_length` | `list[int \| None]` | Meta description length |
+| `meta_description_length_prev` | `list[int \| None]` | Meta description length |
+| `meta_description_prev` | `list[str \| None]` | Meta description |
+| `meta_refresh` | `list[str \| None]` | The time set in a meta refresh tag, in seconds |
+| `meta_refresh_prev` | `list[str \| None]` | The time set in a meta refresh tag, in seconds |
+| `meta_robots` | `list[str \| None]` | Instructions for web crawlers specified in HTML robots meta tags on the page |
+| `meta_robots_prev` | `list[str \| None]` | Instructions for web crawlers specified in HTML robots meta tags on the page |
+| `meta_twitter_tags_app_google_play` | `str \| None` | The app ID in the Google Play Store specified in the twitter:app:id:ipad meta property |
+| `meta_twitter_tags_app_google_play_prev` | `str \| None` | The app ID in the Google Play Store specified in the twitter:app:id:ipad meta property |
+| `meta_twitter_tags_app_ipad` | `str \| None` | The app ID in the iTunes App Store specified in the twitter:app:id:ipad meta property |
+| `meta_twitter_tags_app_ipad_prev` | `str \| None` | The app ID in the iTunes App Store specified in the twitter:app:id:ipad meta property |
+| `meta_twitter_tags_app_iphone` | `str \| None` | The app ID in the iTunes App Store specified in the twitter:app:id:iphone meta property |
+| `meta_twitter_tags_app_iphone_prev` | `str \| None` | The app ID in the iTunes App Store specified in the twitter:app:id:iphone meta property |
+| `meta_twitter_tags_attributes` | `list[str \| None]` | The list of X (Twitter) Card properties on the page |
+| `meta_twitter_tags_attributes_prev` | `list[str \| None]` | The list of X (Twitter) Card properties on the page |
+| `meta_twitter_tags_card` | `str \| None` | The X (Twitter) Card type can be "summary", "summary_large_image", "app", or "player" |
+| `meta_twitter_tags_card_prev` | `str \| None` | The X (Twitter) Card type can be "summary", "summary_large_image", "app", or "player" |
+| `meta_twitter_tags_description` | `str \| None` | meta_twitter_tags.description |
+| `meta_twitter_tags_description_prev` | `str \| None` | meta_twitter_tags.description |
+| `meta_twitter_tags_image` | `str \| None` | The image URL specified in the twitter:image meta property |
+| `meta_twitter_tags_image_prev` | `str \| None` | The image URL specified in the twitter:image meta property |
+| `meta_twitter_tags_image_url_invalid` | `bool \| None` | Indicates that the URL specified in the twitter:image meta property is a valid absolute URL |
+| `meta_twitter_tags_image_url_invalid_prev` | `bool \| None` | Indicates that the URL specified in the twitter:image meta property is a valid absolute URL |
+| `meta_twitter_tags_player` | `str \| None` | The HTTPS URL of player iframe specified in the twitter:player meta property |
+| `meta_twitter_tags_player_height` | `int \| None` | The height of iframe in pixels specified in the twitter:player:width meta property |
+| `meta_twitter_tags_player_height_diff` | `int \| None` | The height of iframe in pixels specified in the twitter:player:width meta property |
+| `meta_twitter_tags_player_height_prev` | `int \| None` | The height of iframe in pixels specified in the twitter:player:width meta property |
+| `meta_twitter_tags_player_prev` | `str \| None` | The HTTPS URL of player iframe specified in the twitter:player meta property |
+| `meta_twitter_tags_player_width` | `int \| None` | The width of iframe in pixels specified in the twitter:player:width meta property |
+| `meta_twitter_tags_player_width_diff` | `int \| None` | The width of iframe in pixels specified in the twitter:player:width meta property |
+| `meta_twitter_tags_player_width_prev` | `int \| None` | The width of iframe in pixels specified in the twitter:player:width meta property |
+| `meta_twitter_tags_site` | `str \| None` | The X (Twitter) handle specified in the twitter:site meta property |
+| `meta_twitter_tags_site_prev` | `str \| None` | The X (Twitter) handle specified in the twitter:site meta property |
+| `meta_twitter_tags_title` | `str \| None` | The title text specified in the twitter:title meta property |
+| `meta_twitter_tags_title_prev` | `str \| None` | The title text specified in the twitter:title meta property |
+| `meta_twitter_tags_valid` | `bool \| None` | Indicates that the page has all the necessary tags required in a X (Twitter) Card |
+| `meta_twitter_tags_valid_prev` | `bool \| None` | Indicates that the page has all the necessary tags required in a X (Twitter) Card |
+| `meta_twitter_tags_values` | `list[str \| None]` | Data from the X (Twitter) Card properties on the page |
+| `meta_twitter_tags_values_prev` | `list[str \| None]` | Data from the X (Twitter) Card properties on the page |
+| `navigation_next` | `str \| None` | The URL specified in the rel="next" element on the page |
+| `navigation_next_code` | `int \| None` | The HTTP status code returned by the URL specified in the rel="next" element on a page |
+| `navigation_next_no_crawl_reason` | `str \| None` | The reason why the URL specified in the rel="next" element on a page was not crawled |
+| `navigation_next_no_crawl_reason_prev` | `str \| None` | The reason why the URL specified in the rel="next" element on a page was not crawled |
+| `navigation_next_prev` | `str \| None` | The URL specified in the rel="next" element on the page |
+| `navigation_prev_code` | `int \| None` | The HTTP status code returned by the URL specified in the rel="prev" element on a page |
+| `navigation_prev_no_crawl_reason` | `str \| None` | The reason why the URL specified in the rel="prev" element on a page was not crawled |
+| `navigation_prev_no_crawl_reason_prev` | `str \| None` | The reason why the URL specified in the rel="prev" element on a page was not crawled |
+| `no_crawl_reason` | `str \| None` | The reason why the URL was not crawled |
+| `no_crawl_reason_prev` | `str \| None` | The reason why the URL was not crawled |
+| `nofollow` | `int \| None` | The number of incoming external nofollow links pointing to the URL. Not to be confused with the number of linking pages, as one page can contain multiple backlinks |
+| `nofollow_diff` | `int \| None` | The number of incoming external nofollow links pointing to the URL. Not to be confused with the number of linking pages, as one page can contain multiple backlinks |
+| `nofollow_prev` | `int \| None` | The number of incoming external nofollow links pointing to the URL. Not to be confused with the number of linking pages, as one page can contain multiple backlinks |
+| `nr_h1` | `int` | The number of H1 subheaders on the page |
+| `nr_h1_prev` | `int \| None` | The number of H1 subheaders on the page |
+| `nr_meta_description` | `int` | Number of Meta descriptions |
+| `nr_meta_description_diff` | `int \| None` | Number of Meta descriptions |
+| `nr_meta_description_prev` | `int \| None` | Number of Meta descriptions |
+| `nr_redirect_chain_urls` | `int \| None` | The number of redirect chain URLs |
+| `nr_redirect_chain_urls_diff` | `int \| None` | The number of redirect chain URLs |
+| `nr_redirect_chain_urls_prev` | `int \| None` | The number of redirect chain URLs |
+| `nr_titles` | `int` | The number of title tags on the page |
+| `nr_titles_diff` | `int \| None` | The number of title tags on the page |
+| `nr_titles_prev` | `int \| None` | The number of title tags on the page |
+| `og_tags_attributes` | `list[str \| None]` | The list of Open Graph properties on a page |
+| `og_tags_attributes_prev` | `list[str \| None]` | The list of Open Graph properties on a page |
+| `og_tags_image` | `str \| None` | The image URL specified in the og:image meta property |
+| `og_tags_image_prev` | `str \| None` | The image URL specified in the og:image meta property |
+| `og_tags_image_url_invalid` | `bool \| None` | Indicates that the URL specified in the og:image meta property is a valid absolute URL |
+| `og_tags_image_url_invalid_prev` | `bool \| None` | Indicates that the URL specified in the og:image meta property is a valid absolute URL |
+| `og_tags_inconsistent_canonical` | `bool \| None` | Indicates that the URL specified in the og:url meta property matches the URL specified as the canonical version of the page |
+| `og_tags_inconsistent_canonical_prev` | `bool \| None` | Indicates that the URL specified in the og:url meta property matches the URL specified as the canonical version of the page |
+| `og_tags_title` | `str \| None` | The title text specified in the og:title meta property |
+| `og_tags_title_prev` | `str \| None` | The title text specified in the og:title meta property |
+| `og_tags_type` | `str \| None` | The object type specified in the og:type meta property |
+| `og_tags_type_prev` | `str \| None` | The object type specified in the og:type meta property |
+| `og_tags_url` | `str \| None` | The URL specified in the og:url meta property |
+| `og_tags_url_prev` | `str \| None` | The URL specified in the og:url meta property |
+| `og_tags_url_valid` | `bool \| None` | Indicates that the URL specified in the og:url meta property is a valid absolute URL |
+| `og_tags_url_valid_prev` | `bool \| None` | Indicates that the URL specified in the og:url meta property is a valid absolute URL |
+| `og_tags_valid` | `bool \| None` | Indicates that the page has all four required Open Graph properties: og:title, og:type, og:image, and og:url |
+| `og_tags_valid_prev` | `bool \| None` | Indicates that the page has all four required Open Graph properties: og:title, og:type, og:image, and og:url |
+| `og_tags_value` | `list[str \| None]` | Data from Open Graph properties on a page |
+| `og_tags_value_prev` | `list[str \| None]` | Data from Open Graph properties on a page |
+| `origin` | `str \| None` | Shows where the URL was originally found during the crawl |
+| `origin_prev` | `str \| None` | Shows where the URL was originally found during the crawl |
+| `page_is_nofollow` | `bool \| None` | Check if the page is nofollow, based on http header and meta robots instructions |
+| `page_is_nofollow_prev` | `bool \| None` | Check if the page is nofollow, based on http header and meta robots instructions |
+| `page_is_noindex` | `bool \| None` | Check if the page is noindex, based on http header and meta robots instructions |
+| `page_is_noindex_prev` | `bool \| None` | Check if the page is noindex, based on http header and meta robots instructions |
+| `page_rating` | `int \| None` | Page Rating (PR) shows the URL's internal and external backlink profile strength relative to other URLs included in the crawl |
+| `page_raw_ur` | `int \| None` | URL Rating (UR) shows the strength of your target page's backlink profile on a 100-point logarithmic scale. [Learn more](https://help.ahrefs.com/en/articles/72658-what-is-url-rating-ur) |
+| `page_raw_ur_diff` | `int \| None` | URL Rating (UR) shows the strength of your target page's backlink profile on a 100-point logarithmic scale. [Learn more](https://help.ahrefs.com/en/articles/72658-what-is-url-rating-ur) |
+| `page_raw_ur_prev` | `int \| None` | URL Rating (UR) shows the strength of your target page's backlink profile on a 100-point logarithmic scale. [Learn more](https://help.ahrefs.com/en/articles/72658-what-is-url-rating-ur) |
+| `page_type` | `list[str \| None]` | Site Audit categorizes URLs as HTML Pages, Resource files (image, CSS or JavaScript), XML Sitemaps and Robots.txt. If a page doesn't return status code 200 or has a content type that isn't covered by the categories above, it's considered as "Other". Since we can't determine what these pages are, we further classify them based on how incoming links reference them: as resources (receive resource incoming links) or as pages (receive non-resource incoming links) |
+| `page_type_prev` | `list[str \| None]` | Site Audit categorizes URLs as HTML Pages, Resource files (image, CSS or JavaScript), XML Sitemaps and Robots.txt. If a page doesn't return status code 200 or has a content type that isn't covered by the categories above, it's considered as "Other". Since we can't determine what these pages are, we further classify them based on how incoming links reference them: as resources (receive resource incoming links) or as pages (receive non-resource incoming links) |
+| `pagination_group` | `int \| None` | The ID of the group of pages interconnected via their rel="next" and rel="prev" links |
+| `pagination_group_prev` | `int \| None` | The ID of the group of pages interconnected via their rel="next" and rel="prev" links |
+| `positions` | `int \| None` | The number of keywords the page is ranking for in top 100 organic search results worldwide (data from Ahrefs' Site Explorer) |
+| `positions_diff` | `int \| None` | The number of keywords the page is ranking for in top 100 organic search results worldwide (data from Ahrefs' Site Explorer) |
+| `positions_prev` | `int \| None` | The number of keywords the page is ranking for in top 100 organic search results worldwide (data from Ahrefs' Site Explorer) |
+| `positions_top10` | `int \| None` | The number of keywords the page is ranking for in top 10 organic search results worldwide (data from Ahrefs' Site Explorer) |
+| `positions_top10_diff` | `int \| None` | The number of keywords the page is ranking for in top 10 organic search results worldwide (data from Ahrefs' Site Explorer) |
+| `positions_top10_prev` | `int \| None` | The number of keywords the page is ranking for in top 10 organic search results worldwide (data from Ahrefs' Site Explorer) |
+| `positions_top3` | `int \| None` | The number of keywords the page is ranking for in top 3 organic search results worldwide (data from Ahrefs' Site Explorer) |
+| `positions_top3_diff` | `int \| None` | The number of keywords the page is ranking for in top 3 organic search results worldwide (data from Ahrefs' Site Explorer) |
+| `positions_top3_prev` | `int \| None` | The number of keywords the page is ranking for in top 3 organic search results worldwide (data from Ahrefs' Site Explorer) |
+| `psi_crux_cls_category` | `str \| None` | Your CLS category will be either Good (\<0.1), Needs Improvement (0.1 - 0.25), or Poor (>0.25). The category is based on the lowest threshold that includes 75% of page views. [Learn more](https://ahrefs.com/blog/core-web-vitals/) |
+| `psi_crux_cls_category_prev` | `str \| None` | Your CLS category will be either Good (\<0.1), Needs Improvement (0.1 - 0.25), or Poor (>0.25). The category is based on the lowest threshold that includes 75% of page views. [Learn more](https://ahrefs.com/blog/core-web-vitals/) |
+| `psi_crux_cls_distributions_proportion` | `list[dict[str, Any] \| None]` | What % of collected CLS metrics are in each associated threshold, which categorize performance as either "Good", "Needs Improvement", or "Poor". [Learn more](https://ahrefs.com/blog/core-web-vitals/) |
+| `psi_crux_cls_distributions_proportion_prev` | `list[dict[str, Any] \| None]` | What % of collected CLS metrics are in each associated threshold, which categorize performance as either "Good", "Needs Improvement", or "Poor". [Learn more](https://ahrefs.com/blog/core-web-vitals/) |
+| `psi_crux_cls_percentile` | `float \| None` | Cumulative Layout Shift measures visual stability. The range is 0-1, where 0 is stable and 1 means a lot of shifting. This score comes from the Chrome User Experience Report which looks at real user data. [Learn more](https://ahrefs.com/blog/core-web-vitals/) |
+| `psi_crux_cls_percentile_diff` | `int \| None` | Cumulative Layout Shift measures visual stability. The range is 0-1, where 0 is stable and 1 means a lot of shifting. This score comes from the Chrome User Experience Report which looks at real user data. [Learn more](https://ahrefs.com/blog/core-web-vitals/) |
+| `psi_crux_cls_percentile_prev` | `float \| None` | Cumulative Layout Shift measures visual stability. The range is 0-1, where 0 is stable and 1 means a lot of shifting. This score comes from the Chrome User Experience Report which looks at real user data. [Learn more](https://ahrefs.com/blog/core-web-vitals/) |
+| `psi_crux_fid_category` | `str \| None` | Your FID category will be either Good (\<100 ms), Needs Improvement (100 ms - 300 ms), or Poor (>300 ms). The category is based on the lowest threshold that includes 75% of page views. [Learn more](https://ahrefs.com/blog/core-web-vitals/) |
+| `psi_crux_fid_category_prev` | `str \| None` | Your FID category will be either Good (\<100 ms), Needs Improvement (100 ms - 300 ms), or Poor (>300 ms). The category is based on the lowest threshold that includes 75% of page views. [Learn more](https://ahrefs.com/blog/core-web-vitals/) |
+| `psi_crux_fid_distributions_proportion` | `list[dict[str, Any] \| None]` | What % of collected FID metrics are in each associated threshold, which categorize performance as either "Good", "Needs Improvement", or "Poor". [Learn more](https://ahrefs.com/blog/core-web-vitals/) |
+| `psi_crux_fid_distributions_proportion_prev` | `list[dict[str, Any] \| None]` | What % of collected FID metrics are in each associated threshold, which categorize performance as either "Good", "Needs Improvement", or "Poor". [Learn more](https://ahrefs.com/blog/core-web-vitals/) |
+| `psi_crux_fid_percentile` | `float \| None` | First Input Delay measures interactivity. This score comes from the Chrome User Experience Report which looks at real user data. [Learn more](https://ahrefs.com/blog/core-web-vitals/) |
+| `psi_crux_fid_percentile_diff` | `int \| None` | First Input Delay measures interactivity. This score comes from the Chrome User Experience Report which looks at real user data. [Learn more](https://ahrefs.com/blog/core-web-vitals/) |
+| `psi_crux_fid_percentile_prev` | `float \| None` | First Input Delay measures interactivity. This score comes from the Chrome User Experience Report which looks at real user data. [Learn more](https://ahrefs.com/blog/core-web-vitals/) |
+| `psi_crux_inp_category` | `str \| None` | Your INP category will be either Good (\<200 ms), Needs Improvement (200 ms - 500 ms), or Poor (>500 ms). The category is based on the lowest threshold that includes 75% of page views. [Learn more](https://web.dev/inp/) |
+| `psi_crux_inp_category_prev` | `str \| None` | Your INP category will be either Good (\<200 ms), Needs Improvement (200 ms - 500 ms), or Poor (>500 ms). The category is based on the lowest threshold that includes 75% of page views. [Learn more](https://web.dev/inp/) |
+| `psi_crux_inp_distributions_proportion` | `list[dict[str, Any] \| None]` | What % of collected INP metrics are in each associated threshold, which categorize performance as either "Good", "Needs Improvement", or "Poor". [Learn more](https://web.dev/inp/) |
+| `psi_crux_inp_distributions_proportion_prev` | `list[dict[str, Any] \| None]` | What % of collected INP metrics are in each associated threshold, which categorize performance as either "Good", "Needs Improvement", or "Poor". [Learn more](https://web.dev/inp/) |
+| `psi_crux_inp_percentile` | `float \| None` | Interaction to Next Paint measure overall responsiveness of a page to user interactions. This score comes from the Chrome User Experience Report which looks at real user data. [Learn more](https://web.dev/inp/) |
+| `psi_crux_inp_percentile_diff` | `int \| None` | Interaction to Next Paint measure overall responsiveness of a page to user interactions. This score comes from the Chrome User Experience Report which looks at real user data. [Learn more](https://web.dev/inp/) |
+| `psi_crux_inp_percentile_prev` | `float \| None` | Interaction to Next Paint measure overall responsiveness of a page to user interactions. This score comes from the Chrome User Experience Report which looks at real user data. [Learn more](https://web.dev/inp/) |
+| `psi_crux_lcp_category` | `str \| None` | Your LCP category will be either Good (\<2.5 sec), Needs Improvement (2.5 sec - 4.0 sec), or Poor (>4.0 sec). The category is based on the lowest threshold that includes 75% of page views. [Learn more](https://ahrefs.com/blog/core-web-vitals/) |
+| `psi_crux_lcp_category_prev` | `str \| None` | Your LCP category will be either Good (\<2.5 sec), Needs Improvement (2.5 sec - 4.0 sec), or Poor (>4.0 sec). The category is based on the lowest threshold that includes 75% of page views. [Learn more](https://ahrefs.com/blog/core-web-vitals/) |
+| `psi_crux_lcp_distributions_proportion` | `list[dict[str, Any] \| None]` | What % of collected LCP metrics are in each associated threshold, which categorize performance as either "Good", "Needs Improvement", or "Poor". [Learn more](https://ahrefs.com/blog/core-web-vitals/) |
+| `psi_crux_lcp_distributions_proportion_prev` | `list[dict[str, Any] \| None]` | What % of collected LCP metrics are in each associated threshold, which categorize performance as either "Good", "Needs Improvement", or "Poor". [Learn more](https://ahrefs.com/blog/core-web-vitals/) |
+| `psi_crux_lcp_percentile` | `float \| None` | Largest Contentful Paint measures visual loading performance. This score comes from the Chrome User Experience Report which looks at real user data. [Learn more](https://ahrefs.com/blog/core-web-vitals/) |
+| `psi_crux_lcp_percentile_diff` | `int \| None` | Largest Contentful Paint measures visual loading performance. This score comes from the Chrome User Experience Report which looks at real user data. [Learn more](https://ahrefs.com/blog/core-web-vitals/) |
+| `psi_crux_lcp_percentile_prev` | `float \| None` | Largest Contentful Paint measures visual loading performance. This score comes from the Chrome User Experience Report which looks at real user data. [Learn more](https://ahrefs.com/blog/core-web-vitals/) |
+| `psi_lighthouse_cls_error_message` | `str \| None` | The message returned by Lighthouse if there is an error when measuring CLS |
+| `psi_lighthouse_cls_error_message_prev` | `str \| None` | The message returned by Lighthouse if there is an error when measuring CLS |
+| `psi_lighthouse_cls_value` | `float \| None` | Cumulative Layout Shift measures visual stability. The range is 0-1, where 0 is stable and 1 means a lot of shifting. This score comes from Lighthouse in a simulated test environment. [Learn more](https://ahrefs.com/blog/core-web-vitals/) |
+| `psi_lighthouse_cls_value_diff` | `int \| None` | Cumulative Layout Shift measures visual stability. The range is 0-1, where 0 is stable and 1 means a lot of shifting. This score comes from Lighthouse in a simulated test environment. [Learn more](https://ahrefs.com/blog/core-web-vitals/) |
+| `psi_lighthouse_cls_value_prev` | `float \| None` | Cumulative Layout Shift measures visual stability. The range is 0-1, where 0 is stable and 1 means a lot of shifting. This score comes from Lighthouse in a simulated test environment. [Learn more](https://ahrefs.com/blog/core-web-vitals/) |
+| `psi_lighthouse_lcp_error_message` | `str \| None` | The message returned by Lighthouse if there is an error when measuring LCP |
+| `psi_lighthouse_lcp_error_message_prev` | `str \| None` | The message returned by Lighthouse if there is an error when measuring LCP |
+| `psi_lighthouse_lcp_value` | `float \| None` | Largest Contentful Paint measures visual loading performance. This score comes from Lighthouse in a simulated test environment. [Learn more](https://ahrefs.com/blog/core-web-vitals/) |
+| `psi_lighthouse_lcp_value_diff` | `int \| None` | Largest Contentful Paint measures visual loading performance. This score comes from Lighthouse in a simulated test environment. [Learn more](https://ahrefs.com/blog/core-web-vitals/) |
+| `psi_lighthouse_lcp_value_prev` | `float \| None` | Largest Contentful Paint measures visual loading performance. This score comes from Lighthouse in a simulated test environment. [Learn more](https://ahrefs.com/blog/core-web-vitals/) |
+| `psi_lighthouse_score` | `int \| None` | This score uses multiple Lighthouse speed metrics to create a summary of the page's performance and use of best practices. Scores will be considered Good (>90), Needs Improvement (50-90), or Poor (\<50). [Learn more](https://web.dev/performance-scoring/) |
+| `psi_lighthouse_score_diff` | `int \| None` | This score uses multiple Lighthouse speed metrics to create a summary of the page's performance and use of best practices. Scores will be considered Good (>90), Needs Improvement (50-90), or Poor (\<50). [Learn more](https://web.dev/performance-scoring/) |
+| `psi_lighthouse_score_prev` | `int \| None` | This score uses multiple Lighthouse speed metrics to create a summary of the page's performance and use of best practices. Scores will be considered Good (>90), Needs Improvement (50-90), or Poor (\<50). [Learn more](https://web.dev/performance-scoring/) |
+| `psi_lighthouse_tbt_error_message` | `str \| None` | The message returned by Lighthouse if there is an error when measuring TBT |
+| `psi_lighthouse_tbt_error_message_prev` | `str \| None` | The message returned by Lighthouse if there is an error when measuring TBT |
+| `psi_lighthouse_tbt_value` | `float \| None` | Total Blocking Time measures the total amount of time that a page is blocked from responding to user interactions. This score comes from Lighthouse in a simulated test environment. TBT is the recommended alternative to FID for lab tests. [Learn more](https://ahrefs.com/blog/core-web-vitals/) |
+| `psi_lighthouse_tbt_value_diff` | `int \| None` | Total Blocking Time measures the total amount of time that a page is blocked from responding to user interactions. This score comes from Lighthouse in a simulated test environment. TBT is the recommended alternative to FID for lab tests. [Learn more](https://ahrefs.com/blog/core-web-vitals/) |
+| `psi_lighthouse_tbt_value_prev` | `float \| None` | Total Blocking Time measures the total amount of time that a page is blocked from responding to user interactions. This score comes from Lighthouse in a simulated test environment. TBT is the recommended alternative to FID for lab tests. [Learn more](https://ahrefs.com/blog/core-web-vitals/) |
+| `psi_mobile_issues` | `list[str \| None]` | List of mobile-related issues on the page detected by Lighthouse |
+| `psi_mobile_issues_explanations` | `list[str \| None]` | Details about the mobile issues detected by Lighthouse |
+| `psi_mobile_issues_explanations_prev` | `list[str \| None]` | Details about the mobile issues detected by Lighthouse |
+| `psi_mobile_issues_prev` | `list[str \| None]` | List of mobile-related issues on the page detected by Lighthouse |
+| `psi_request_error_message` | `str \| None` | The message returned by PageSpeed Insights API if there is an error. [Learn more](https://help.ahrefs.com/en/articles/5369589-how-to-see-core-web-vitals-and-other-speed-metrics-in-site-audit-tool) |
+| `psi_request_error_message_prev` | `str \| None` | The message returned by PageSpeed Insights API if there is an error. [Learn more](https://help.ahrefs.com/en/articles/5369589-how-to-see-core-web-vitals-and-other-speed-metrics-in-site-audit-tool) |
+| `psi_request_status` | `str \| None` | The result of a request to PageSpeed Insights API. [Learn more](https://help.ahrefs.com/en/articles/5369589-how-to-see-core-web-vitals-and-other-speed-metrics-in-site-audit-tool) |
+| `psi_request_status_prev` | `str \| None` | The result of a request to PageSpeed Insights API. [Learn more](https://help.ahrefs.com/en/articles/5369589-how-to-see-core-web-vitals-and-other-speed-metrics-in-site-audit-tool) |
+| `redirect` | `str \| None` | The destination of the redirecting URL |
+| `redirect_chain_urls` | `list[str \| None]` | The list of redirect chain URLs |
+| `redirect_chain_urls_code` | `list[dict[str, Any] \| None]` | The list of HTTP status codes returned by the redirect chain URLs |
+| `redirect_chain_urls_no_crawl_reason` | `list[dict[str, Any] \| None]` | The reasons why the redirect chain URLs were not crawled |
+| `redirect_chain_urls_no_crawl_reason_prev` | `list[dict[str, Any] \| None]` | The reasons why the redirect chain URLs were not crawled |
+| `redirect_chain_urls_prev` | `list[str \| None]` | The list of redirect chain URLs |
+| `redirect_code` | `int \| None` | The HTTP status code of the destination of the redirecting URL |
+| `redirect_counts` | `int \| None` | The number of incoming external links pointing to the URL via a redirect. Not to be confused with the number of linking pages, as one page can contain multiple backlinks |
+| `redirect_counts_diff` | `int \| None` | The number of incoming external links pointing to the URL via a redirect. Not to be confused with the number of linking pages, as one page can contain multiple backlinks |
+| `redirect_counts_prev` | `int \| None` | The number of incoming external links pointing to the URL via a redirect. Not to be confused with the number of linking pages, as one page can contain multiple backlinks |
+| `redirect_is_canonical` | `bool \| None` | Indicates whether the target page tags itself as the canonical version to be shown in search results. A page is considered as canonical when it doesn't refer to any other pages as canonical |
+| `redirect_is_canonical_prev` | `bool \| None` | Indicates whether the target page tags itself as the canonical version to be shown in search results. A page is considered as canonical when it doesn't refer to any other pages as canonical |
+| `redirect_no_crawl_reason` | `str \| None` | The reason why the destination of the redirecting URL was not crawled |
+| `redirect_no_crawl_reason_prev` | `str \| None` | The reason why the destination of the redirecting URL was not crawled |
+| `redirect_prev` | `str \| None` | The destination of the redirecting URL |
+| `redirect_scheme` | `str \| None` | The protocol of the redirecting URL |
+| `redirect_scheme_prev` | `str \| None` | The protocol of the redirecting URL |
+| `refclass_c` | `int \| None` | The number of IP networks that have websites with at least 1 link pointing to the URL. An IP network consists of IP addresses sharing the first three numbers of their numerical label. Example: 151.80.39.61 is the website IP address where 151.80.39.XXX is the IP network |
+| `refclass_c_diff` | `int \| None` | The number of IP networks that have websites with at least 1 link pointing to the URL. An IP network consists of IP addresses sharing the first three numbers of their numerical label. Example: 151.80.39.61 is the website IP address where 151.80.39.XXX is the IP network |
+| `refclass_c_prev` | `int \| None` | The number of IP networks that have websites with at least 1 link pointing to the URL. An IP network consists of IP addresses sharing the first three numbers of their numerical label. Example: 151.80.39.61 is the website IP address where 151.80.39.XXX is the IP network |
+| `refhosts` | `int \| None` | The number of unique external domains that have at least 1 link pointing to the URL (data from Ahrefs' Site Explorer database) |
+| `refhosts_diff` | `int \| None` | The number of unique external domains that have at least 1 link pointing to the URL (data from Ahrefs' Site Explorer database) |
+| `refhosts_prev` | `int \| None` | The number of unique external domains that have at least 1 link pointing to the URL (data from Ahrefs' Site Explorer database) |
+| `refips` | `int \| None` | The number of unique external IP addresses that incorporate websites with at least 1 link pointing to the URL. Several domains can share one IP address |
+| `refips_prev` | `int \| None` | The number of unique external IP addresses that incorporate websites with at least 1 link pointing to the URL. Several domains can share one IP address |
+| `refpages` | `int \| None` | The number of unique external pages linking to the URL (data from Ahrefs' Site Explorer database) |
+| `refpages_diff` | `int \| None` | The number of unique external pages linking to the URL (data from Ahrefs' Site Explorer database) |
+| `refpages_prev` | `int \| None` | The number of unique external pages linking to the URL (data from Ahrefs' Site Explorer database) |
+| `robots_allow_rules` | `list[dict[str, Any] \| None]` | Allow: rules |
+| `robots_allow_rules_prev` | `list[dict[str, Any] \| None]` | Allow: rules |
+| `robots_crawl_delay` | `int \| None` | Crawl-delay: |
+| `robots_crawl_delay_prev` | `int \| None` | Crawl-delay: |
+| `robots_disallow_rules` | `list[dict[str, Any] \| None]` | Disallow: rules |
+| `robots_disallow_rules_prev` | `list[dict[str, Any] \| None]` | Disallow: rules |
+| `robots_error` | `str \| None` | The error occurred while crawling the robots.txt file |
+| `robots_error_prev` | `str \| None` | The error occurred while crawling the robots.txt file |
+| `robots_error_text` | `str \| None` | Robots.txt error text |
+| `robots_error_text_prev` | `str \| None` | Robots.txt error text |
+| `robots_redirect_loop` | `list[dict[str, Any] \| None]` | Robots.txt error redirect loop |
+| `robots_redirect_loop_prev` | `list[dict[str, Any] \| None]` | Robots.txt error redirect loop |
+| `robots_sitemaps` | `list[dict[str, Any] \| None]` | The list of sitemaps referenced in the robots.txt file |
+| `robots_sitemaps_prev` | `list[dict[str, Any] \| None]` | The list of sitemaps referenced in the robots.txt file |
+| `rss` | `int \| None` | The number of incoming external links from RSS feeds (data from Ahrefs' Site Explorer database) |
+| `rss_diff` | `int \| None` | The number of incoming external links from RSS feeds (data from Ahrefs' Site Explorer database) |
+| `rss_prev` | `int \| None` | The number of incoming external links from RSS feeds (data from Ahrefs' Site Explorer database) |
+| `scheme` | `str` | Hypertext Transfer Protocol of the URL (HTTP or HTTPS) |
+| `self_canonical` | `bool \| None` | Indicates that the page has a self-referential canonical URL |
+| `self_canonical_prev` | `bool \| None` | Indicates that the page has a self-referential canonical URL |
+| `self_hreflang` | `list[dict[str, Any] \| None]` | Data from hreflang tag with a self-referential URL |
+| `self_hreflang_code_is_valid` | `list[dict[str, Any] \| None]` | Indicates that hreflang data is specified properly in hreflang tag with a self-referential URL. The language must be specified in [ISO 639-1 format](https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes), and optionally the region in [ISO 3166-1 Alpha 2 format](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2) |
+| `self_hreflang_code_is_valid_prev` | `list[dict[str, Any] \| None]` | Indicates that hreflang data is specified properly in hreflang tag with a self-referential URL. The language must be specified in [ISO 639-1 format](https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes), and optionally the region in [ISO 3166-1 Alpha 2 format](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2) |
+| `self_hreflang_country` | `list[dict[str, Any] \| None]` | The region specified in the hreflang tag with a self-referential URL |
+| `self_hreflang_country_prev` | `list[dict[str, Any] \| None]` | The region specified in the hreflang tag with a self-referential URL |
+| `self_hreflang_language` | `list[dict[str, Any] \| None]` | The language specified in the hreflang tag with a self-referential URL |
+| `self_hreflang_language_prev` | `list[dict[str, Any] \| None]` | The language specified in the hreflang tag with a self-referential URL |
+| `self_hreflang_prev` | `list[dict[str, Any] \| None]` | Data from hreflang tag with a self-referential URL |
+| `serp_title` | `str \| None` | The title displayed for the page in its top keyword's SERP on desktop |
+| `serp_title_prev` | `str \| None` | The title displayed for the page in its top keyword's SERP on desktop |
+| `sitemap_error` | `str \| None` | The error occurred while crawling the sitemap |
+| `sitemap_error_prev` | `str \| None` | The error occurred while crawling the sitemap |
+| `sitemap_error_text` | `str \| None` | Sitemap error text |
+| `sitemap_error_text_prev` | `str \| None` | Sitemap error text |
+| `sitemap_is_index` | `bool \| None` | Indicates that the sitemap is a sitemap index file |
+| `sitemap_is_index_prev` | `bool \| None` | Indicates that the sitemap is a sitemap index file |
+| `sitemap_nr_urls` | `int \| None` | The number of URLs referenced in the sitemap |
+| `sitemap_nr_urls_prev` | `int \| None` | The number of URLs referenced in the sitemap |
+| `sitemap_save_max_size` | `int \| None` | Max size of sitemap allows content to be saved |
+| `sitemap_save_max_size_diff` | `int \| None` | Max size of sitemap allows content to be saved |
+| `sitemap_save_max_size_prev` | `int \| None` | Max size of sitemap allows content to be saved |
+| `sitemap_unzipped_size` | `int \| None` | Sitemap size (uncompressed) |
+| `sitemap_unzipped_size_diff` | `int \| None` | Sitemap size (uncompressed) |
+| `sitemap_unzipped_size_prev` | `int \| None` | Sitemap size (uncompressed) |
+| `size` | `int` | The size of the page or resource, measured in bytes |
+| `size_diff` | `int \| None` | The size of the page or resource, measured in bytes |
+| `size_prev` | `int \| None` | The size of the page or resource, measured in bytes |
+| `source` | `list[str \| None]` | Source from which the URL can be reached |
+| `source_prev` | `list[str \| None]` | Source from which the URL can be reached |
+| `stamp` | `str` | The time and date when the URL was crawled |
+| `stamp_prev` | `str \| None` | The time and date when the URL was crawled |
+| `time_to_first_byte` | `int` | The time it takes for the crawler to receive the first byte of the response from a web server, measured in milliseconds |
+| `time_to_first_byte_prev` | `int \| None` | The time it takes for the crawler to receive the first byte of the response from a web server, measured in milliseconds |
+| `title` | `list[str \| None]` | The page title |
+| `title_prev` | `list[str \| None]` | The page title |
+| `titles_length` | `list[int \| None]` | The character length of the page title |
+| `titles_length_prev` | `list[int \| None]` | The character length of the page title |
+| `top_keyword` | `str \| None` | The keyword that brings the page the most organic traffic across all countries |
+| `top_keyword_position` | `int \| None` | The position that the page holds for its top keyword |
+| `top_keyword_position_diff` | `int \| None` | The position that the page holds for its top keyword |
+| `top_keyword_position_prev` | `int \| None` | The position that the page holds for its top keyword |
+| `top_keyword_prev` | `str \| None` | The keyword that brings the page the most organic traffic across all countries |
+| `traffic` | `float \| None` | Our estimate of monthly organic search traffic coming to the URL (data from Ahrefs Site Explorer). Calculations are based on a mixture of clickstream data, the estimated monthly search volumes of keywords for which the page ranks, and the current ranking position for the URL in the search results. You can learn more [here](https://ahrefs.com/blog/ahrefs-seo-metrics/#organictraffic) |
+| `traffic_diff` | `float \| None` | Our estimate of monthly organic search traffic coming to the URL (data from Ahrefs Site Explorer). Calculations are based on a mixture of clickstream data, the estimated monthly search volumes of keywords for which the page ranks, and the current ranking position for the URL in the search results. You can learn more [here](https://ahrefs.com/blog/ahrefs-seo-metrics/#organictraffic) |
+| `traffic_prev` | `float \| None` | Our estimate of monthly organic search traffic coming to the URL (data from Ahrefs Site Explorer). Calculations are based on a mixture of clickstream data, the estimated monthly search volumes of keywords for which the page ranks, and the current ranking position for the URL in the search results. You can learn more [here](https://ahrefs.com/blog/ahrefs-seo-metrics/#organictraffic) |
+| `url` | `str` | The web address of the page or resource |
+| `url_prev` | `str \| None` | The web address of the page or resource |
+
+</details>
+
+### `site_audit_projects()`
+
+Project Health Scores.
+
+**Parameters:**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `date` | `str` | No | A timestamp in `YYYY-MM-DDThh:mm:ss` format specifying the crawl date to retrieve metrics from. Defaults to the most recent available crawl if omitted. For scheduled crawls, we return data from the latest crawl finished before the specified timestamp. For Always-on audit crawls, we return data as of the provided date and time. If the time component is omitted, it defaults to `00:00:00`. The timestamp is interpreted in UTC. |
+| `project_id` | `int` | No | The unique identifier of the project. You can find it in the URL of your Site Audit project in Ahrefs: `https://app.ahrefs.com/site-audit/#project_id#` |
+
+**Returns:** `list[SiteAuditProjectsData]`
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `project_id` | `str` | The unique identifier of the project. |
+| `project_name` | `str` | The project name. |
+| `target_protocol` | `str` | The protocol of the target. Possible values: `both`, `http`, `https`. |
+| `target_url` | `str` | The URL of the project's target. |
+| `target_mode` | `str` | The scope of the target. Possible values: `exact`, `prefix`, `domain`, `subdomains`. |
+| `date` | `str \| None` | The finish date and time of the last finished crawl, in GMT time zone. |
+| `status` | `str \| None` | The status of the most recent finished crawl. Possible values: `Completed`, `Stopped`, `Error`, `In_progress`. |
+| `health_score` | `int \| None` | Reflects the proportion of internal URLs on your site that do not have errors, based on the last finished crawl. Excludes crawls that are starting, in progress, finalizing, or were skipped. |
+| `urls_with_errors` | `int \| None` | Number of internal URLs with errors |
+| `urls_with_warnings` | `int \| None` | Number of internal URLs with warnings |
+| `urls_with_notices` | `int \| None` | Number of internal URLs with notices |
+| `total` | `int \| None` | Number of total crawled internal URLs |
+
+______________________________________________________________________
+
+## Site Explorer
+
+### `site_explorer_all_backlinks()`
+
+Backlinks.
+
+**Parameters:**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `timeout` | `int` | No | A manual timeout duration in seconds. |
+| `limit` | `int` | No | The number of results to return. |
+| `order_by` | `str` | No | A column to order results by. See the response schema for valid column identifiers, except for `link_group_count`, which is not supported in `order_by` for this endpoint. |
+| `where` | `str` | No | Filter expression ([syntax](filter-syntax.md)). Filterable fields listed below. |
+| `select` | `SelectStr` | Yes | A comma-separated list of columns to return. See response schema for valid column identifiers. |
+| `protocol` | `ProtocolEnum` | No | The protocol of your target. |
+| `target` | `str` | Yes | The target of the search: a domain or a URL. |
+| `mode` | `ModeEnum` | No | The scope of the search based on the target you entered. |
+| `aggregation` | `AggregationEnum` | No | The backlinks grouping mode. |
+| `history` | `str` | No | A time frame to add lost backlinks to the report. Choose between `live` (no history), `since:<date>` (history since a specified date), and `all_time` (full history). The date should be in YYYY-MM-DD format. |
+
+<details>
+<summary>Filterable fields (86 fields)</summary>
+
+- `ahrefs_rank_source` (integer)
+- `ahrefs_rank_target` (integer)
+- `alt` (string)
+- `anchor` (string)
+- `broken_redirect_new_target` (string)
+- `broken_redirect_reason` (string)
+- `broken_redirect_source` (string)
+- `class_c` (integer)
+- `discovered_status` (string)
+- `domain_rating_source` (float)
+- `domain_rating_target` (float)
+- `drop_reason` (string)
+- `encoding` (string)
+- `first_seen` (datetime)
+- `first_seen_link` (datetime)
+- `http_code` (integer)
+- `http_crawl` (boolean)
+- `ip_source` (string)
+- `is_alternate` (boolean)
+- `is_canonical` (boolean)
+- `is_content` (boolean)
+- `is_dofollow` (boolean)
+- `is_form` (boolean)
+- `is_frame` (boolean)
+- `is_homepage_link` (boolean)
+- `is_image` (boolean)
+- `is_lost` (boolean)
+- `is_new` (boolean)
+- `is_nofollow` (boolean)
+- `is_non_html` (boolean)
+- `is_redirect` (boolean)
+- `is_redirect_lost` (boolean)
+- `is_root_source` (boolean)
+- `is_root_target` (boolean)
+- `is_rss` (boolean)
+- `is_spam` (boolean)
+- `is_sponsored` (boolean)
+- `is_text` (boolean)
+- `is_ugc` (boolean)
+- `js_crawl` (boolean)
+- `languages` (array(string))
+- `last_seen` (datetime)
+- `last_visited` (datetime)
+- `len_url_redirect` (integer)
+- `link_group_count` (integer)
+- `link_type` (string)
+- `linked_domains_source_domain` (integer)
+- `linked_domains_source_page` (integer)
+- `linked_domains_target_domain` (integer)
+- `links_external` (integer)
+- `links_internal` (integer)
+- `lost_reason` (string)
+- `name_source` (string)
+- `name_target` (string)
+- `noindex` (boolean)
+- `page_category_source` (string)
+- `page_size` (integer)
+- `page_type_source` (string)
+- `port_source` (integer)
+- `port_target` (integer)
+- `positions` (integer)
+- `positions_source_domain` (integer)
+- `powered_by` (array(string))
+- `redirect_code` (integer)
+- `redirect_kind` (array(integer))
+- `refdomains_source` (integer)
+- `refdomains_source_domain` (integer)
+- `refdomains_target_domain` (integer)
+- `root_name_source` (string)
+- `root_name_target` (string)
+- `snippet_left` (string)
+- `snippet_right` (string)
+- `source_page_author` (string)
+- `source_page_publish_date` (date)
+- `title` (string)
+- `tld_class_source` (string)
+- `tld_class_target` (string)
+- `traffic` (integer)
+- `traffic_domain` (integer)
+- `url_from` (string)
+- `url_from_plain` (string)
+- `url_rating_source` (float)
+- `url_redirect` (array(url))
+- `url_redirect_with_target` (array(string))
+- `url_to` (string)
+- `url_to_plain` (string)
+
+</details>
+
+**Returns:** `list[SiteExplorerAllBacklinksData]`
+
+<details>
+<summary>82 fields</summary>
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `ahrefs_rank_source` | `int` | The strength of the referring domain's backlink profile compared to the other websites in our database, with rank #1 being the strongest. |
+| `ahrefs_rank_target` | `int` | The strength of the target domain's backlink profile compared to the other websites in our database, with rank #1 being the strongest. |
+| `alt` | `str \| None` | The alt attribute of the link. |
+| `anchor` | `str` | The clickable words in a link that point to a URL. |
+| `broken_redirect_new_target` | `str \| None` | The new destination of a modified redirect. |
+| `broken_redirect_reason` | `BrokenRedirectReasonEnum \| None` | The reason the redirect was considered broken during the last crawl. |
+| `broken_redirect_source` | `str \| None` | The redirecting URL that was modified, causing the redirect to become broken. |
+| `class_c` | `int` | (5 units) The number of unique class_c subnets linking to the referring page. |
+| `discovered_status` | `DiscoveredStatusEnum \| None` | The reason the link was discovered during the last crawl: the page was crawled for the first time, the link was added to the page, or the link re-appeared after being removed. |
+| `domain_rating_source` | `float` | The strength of the referring domain's backlink profile compared to the others in our database on a 100-point scale. |
+| `domain_rating_target` | `float` | The strength of the referring domain's backlink profile compared to the others in our database on a 100-point scale. |
+| `drop_reason` | `DropReasonEnum \| None` | The reason we removed the link from our index. |
+| `encoding` | `str` | The character set encoding of the referring page HTML. |
+| `first_seen` | `str` | The date the referring page URL was first discovered. |
+| `first_seen_link` | `str` | The date we first found a backlink to your target on a given referring page. |
+| `http_code` | `int` | The return code from HTTP protocol returned during the referring page crawl. |
+| `http_crawl` | `bool` | The link was discovered without executing javascript and rendering the page. |
+| `ip_source` | `str \| None` | The referring domain IP address. |
+| `is_alternate` | `bool` | The link with the rel=“alternate” attribute. |
+| `is_canonical` | `bool` | The link with the rel=“canonical” attribute. |
+| `is_content` | `bool` | The link was found in the biggest piece of content on the page. |
+| `is_dofollow` | `bool` | The link has no special nofollow attribute. |
+| `is_form` | `bool` | The link was found in a form HTML tag. |
+| `is_frame` | `bool` | The link was found in an iframe HTML tag. |
+| `is_image` | `bool` | The link is a regular link that has an image inside their href attribute. |
+| `is_lost` | `bool` | The link currently does not exist anymore. |
+| `is_new` | `bool` | The link was discovered on the last crawl. |
+| `is_nofollow` | `bool` | The link or the referring page has the nofollow attribute set. |
+| `is_redirect` | `bool` | The link pointing to your target via a redirect. |
+| `is_redirect_lost` | `bool` | The redirected link currently does not exist anymore. |
+| `is_root_source` | `bool` | The referring domain name is a root domain name. |
+| `is_root_target` | `bool` | The target domain name is a root domain name. |
+| `is_rss` | `bool` | The link was found in an RSS feed. |
+| `is_spam` | `bool` | Indicates whether the backlink comes from a known spammy domain. |
+| `is_sponsored` | `bool` | The link has the Sponsored attribute set in the referring page HTML. |
+| `is_text` | `bool` | The link is a standard href hyperlink. |
+| `is_ugc` | `bool` | The link has the User Generated Content attribute set in the referring page HTML. |
+| `js_crawl` | `bool` | The link was discovered after executing javascript and rendering the page. |
+| `languages` | `list[str \| None]` | The languages listed in the referring page metadata or detected by the crawler to appear in the HTML. |
+| `last_seen` | `str \| None` | The date we discovered that the link was lost. |
+| `last_visited` | `str` | The date we last verified a live link to your target page. |
+| `link_group_count` | `int` | The number of backlinks that were grouped together based on the aggregation parameter. This field cannot be used with aggregation 'all'. |
+| `link_type` | `LinkTypeEnum` | The kind of the backlink. |
+| `linked_domains_source_domain` | `int` | The number of unique root domains linked from the referring domain. |
+| `linked_domains_source_page` | `int` | The number of unique root domains linked from the referring page. |
+| `linked_domains_target_domain` | `int` | The number of unique root domains linked from the target domain. |
+| `links_external` | `int` | The number of external links from the referring page. |
+| `links_internal` | `int` | The number of internal links from the referring page. |
+| `lost_reason` | `LostReasonEnum \| None` | The reason the link was lost during the last crawl. |
+| `name_source` | `str` | The complete referring domain name, including subdomains. |
+| `name_target` | `str` | The complete target domain name, including subdomains. |
+| `noindex` | `bool` | The referring page has the noindex meta attribute. |
+| `page_category_source` | `str \| None` | Comma-separated list of AI-predicted hierarchical category paths for the referring page. Each value is a slash-prefixed path (e.g. /Business_and_Industrial/Advertising_and_Marketing/Marketing). |
+| `page_size` | `int` | The size in bytes of the referring page content. |
+| `page_type_source` | `str \| None` | Comma-separated list of AI-predicted hierarchical page type paths for the referring page. Each value is a slash-prefixed path (e.g. /Article/How_to). |
+| `port_source` | `int` | The network port of the referring page URL. |
+| `port_target` | `int` | The network port of the target page URL. |
+| `positions` | `int` | The number of keywords that the referring page ranks for in the top 100 positions. |
+| `powered_by` | `list[str \| None]` | Web technologies used to build and serve the referring page content. |
+| `redirect_code` | `int \| None` | The HTTP status code of a referring page pointing to your target via a redirect. |
+| `redirect_kind` | `list[int \| None]` | The HTTP status codes returned by the target redirecting URL or redirect chain. |
+| `refdomains_source` | `int` | (5 units) The number of unique referring domains linking to the referring page. |
+| `refdomains_source_domain` | `int` | (5 units) The number of unique referring domains linking to the referring domain. |
+| `refdomains_target_domain` | `int` | (5 units) The number of unique referring domains linking to the target domain. |
+| `root_name_source` | `str` | The root domain name of the referring domain, not including subdomains. |
+| `root_name_target` | `str` | The root domain name of the target domain, not including subdomains. |
+| `snippet_left` | `str` | The snippet of text appearing just before the link. |
+| `snippet_right` | `str` | The snippet of text appearing just after the link. |
+| `source_page_author` | `str \| None` | The author of the referring page. |
+| `source_page_publish_date` | `str \| None` | the date we identified the page was published |
+| `title` | `str` | The html title of the referring page. |
+| `tld_class_source` | `TldClassSourceEnum` | The top level domain class of the referring domain. |
+| `tld_class_target` | `TldClassSourceEnum` | The top level domain class of the target domain. |
+| `traffic` | `int` | (10 units) The referring page's estimated monthly organic traffic from search. |
+| `traffic_domain` | `int` | (10 units) The referring domain's estimated monthly organic traffic from search. |
+| `url_from` | `str` | The URL of the page containing a link to your target. |
+| `url_from_plain` | `str` | The referring page URL optimized for use as a filter. |
+| `url_rating_source` | `float` | The strength of the referring page's backlink profile compared to the others in our database on a 100-point scale. |
+| `url_redirect` | `list[str \| None]` | A redirect chain the target URL of the link points to. |
+| `url_redirect_with_target` | `list[str \| None]` | The target URL of the link with its redirect chain. |
+| `url_to` | `str` | The URL the backlink points to. |
+| `url_to_plain` | `str` | The target page URL optimized for use as a filter. |
+
+</details>
+
+### `site_explorer_anchors()`
+
+Anchors.
+
+**Parameters:**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `timeout` | `int` | No | A manual timeout duration in seconds. |
+| `limit` | `int` | No | The number of results to return. |
+| `order_by` | `str` | No | A column to order results by. See response schema for valid column identifiers. |
+| `where` | `str` | No | Filter expression ([syntax](filter-syntax.md)). Filterable fields listed below. |
+| `select` | `SelectStr` | Yes | A comma-separated list of columns to return. See response schema for valid column identifiers. |
+| `protocol` | `ProtocolEnum` | No | The protocol of your target. |
+| `target` | `str` | Yes | The target of the search: a domain or a URL. |
+| `mode` | `ModeEnum` | No | The scope of the search based on the target you entered. |
+| `history` | `str` | No | A time frame to add lost backlinks to the report. Choose between `live` (no history), `since:<date>` (history since a specified date), and `all_time` (full history). The date should be in YYYY-MM-DD format. |
+
+<details>
+<summary>Filterable fields (44 fields)</summary>
+
+- `anchor` (string)
+- `discovered_status` (string)
+- `dofollow_links` (integer)
+- `domain_rating` (float)
+- `drop_reason` (string)
+- `first_seen` (datetime)
+- `is_content` (boolean)
+- `is_dofollow` (boolean)
+- `is_homepage_link` (boolean)
+- `is_nofollow` (boolean)
+- `is_non_html` (boolean)
+- `is_root_domain` (boolean)
+- `is_spam` (boolean)
+- `is_sponsored` (boolean)
+- `is_ugc` (boolean)
+- `languages` (array(string))
+- `last_seen` (datetime)
+- `len_url_redirect` (integer)
+- `link_type` (string)
+- `linked_domains` (integer)
+- `links_external` (integer)
+- `links_to_target` (integer)
+- `lost_links` (integer)
+- `lost_reason` (string)
+- `new_links` (integer)
+- `noindex` (boolean)
+- `positions` (integer)
+- `positions_source_domain` (integer)
+- `powered_by` (array(string))
+- `refdomains` (integer)
+- `refdomains_source` (integer)
+- `refpages` (integer)
+- `root_domain_name` (string)
+- `snippet_left` (string)
+- `snippet_right` (string)
+- `source_page_author` (string)
+- `title` (string)
+- `top_domain_rating` (float)
+- `traffic_domain` (integer)
+- `traffic_page` (integer)
+- `url_from` (string)
+- `url_redirect` (array(url))
+- `url_redirect_with_target` (array(string))
+- `url_to` (string)
+
+</details>
+
+**Returns:** `list[SiteExplorerAnchorsData]`
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `anchor` | `str` | The clickable words in a link that point to a URL. |
+| `dofollow_links` | `int` | The number of links with a given anchor to your target that don’t have the “nofollow” attribute. |
+| `first_seen` | `str` | The date we first found a link with a given anchor to your target. |
+| `is_spam` | `bool` | Indicates whether the backlink comes from a known spammy domain. |
+| `last_seen` | `str \| None` | The date we discovered the last backlink with a given anchor was lost. |
+| `links_to_target` | `int` | The number of inbound backlinks your target has with a given anchor. |
+| `lost_links` | `int` | The number of backlinks with a given anchor lost during the selected time period. |
+| `new_links` | `int` | The number of new backlinks with a given anchor found during the selected time period. |
+| `refdomains` | `int` | (5 units) The number of unique domains linking to your target with a given anchor. |
+| `refpages` | `int` | The number of pages containing a link with a given anchor to your target. |
+| `top_domain_rating` | `float` | The highest Domain Rating (DR) counted out of all referring domains. DR shows the strength of a website’s backlink profile compared to the others in our database on a 100-point scale. |
+
+### `site_explorer_backlinks_stats()`
+
+Backlinks stats.
+
+**Parameters:**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `protocol` | `ProtocolEnum` | No | The protocol of your target. |
+| `target` | `str` | Yes | The target of the search: a domain or a URL. |
+| `mode` | `ModeEnum` | No | The scope of the search based on the target you entered. |
+| `date` | `DateStr` | Yes | A date to report metrics on in YYYY-MM-DD format. |
+
+**Returns:** `SiteExplorerBacklinksStatsData | None`
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `live` | `int` | The total number of links from other websites pointing to your target. |
+| `all_time` | `int` | The total number of links from other websites pointing to your target for all time. |
+| `live_refdomains` | `int` | (5 units) The total number of unique domains linking to your target. |
+| `all_time_refdomains` | `int` | (5 units) The total number of unique domains linking to your target for all time. |
+
+### `site_explorer_best_by_external_links()`
+
+Best by External Links.
+
+**Parameters:**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `timeout` | `int` | No | A manual timeout duration in seconds. |
+| `limit` | `int` | No | The number of results to return. |
+| `order_by` | `str` | No | A column to order results by. See the response schema for valid column identifiers, except for `http_code_target`, `languages_target`, `last_visited_target`, `powered_by_target`, `target_redirect`, `title_target`, `url_rating_target`, which are not supported in `order_by` for this endpoint. |
+| `where` | `str` | No | Filter expression ([syntax](filter-syntax.md)). Filterable fields listed below. |
+| `select` | `SelectStr` | Yes | A comma-separated list of columns to return. See response schema for valid column identifiers. |
+| `protocol` | `ProtocolEnum` | No | The protocol of your target. |
+| `target` | `str` | Yes | The target of the search: a domain or a URL. |
+| `mode` | `ModeEnum` | No | The scope of the search based on the target you entered. |
+| `history` | `str` | No | A time frame to add lost backlinks to the report. Choose between `live` (no history), `since:<date>` (history since a specified date), and `all_time` (full history). The date should be in YYYY-MM-DD format. |
+
+<details>
+<summary>Filterable fields (54 fields)</summary>
+
+- `anchor` (string)
+- `dofollow_to_target` (integer)
+- `domain_rating_source` (float)
+- `first_seen_link` (datetime)
+- `http_code_source` (integer)
+- `http_code_target` (integer)
+- `is_content` (boolean)
+- `is_dofollow` (boolean)
+- `is_homepage_link` (boolean)
+- `is_lost` (boolean)
+- `is_new` (boolean)
+- `is_nofollow` (boolean)
+- `is_non_html` (boolean)
+- `is_root_source` (boolean)
+- `is_spam` (boolean)
+- `is_sponsored` (boolean)
+- `is_ugc` (boolean)
+- `languages_source` (array(string))
+- `languages_target` (array(string))
+- `last_seen` (datetime)
+- `last_visited_source` (datetime)
+- `last_visited_target` (datetime)
+- `len_url_redirect` (integer)
+- `link_type` (string)
+- `linked_domains_source` (integer)
+- `links_external_source` (integer)
+- `links_to_target` (integer)
+- `lost_links_to_target` (integer)
+- `new_links_to_target` (integer)
+- `nofollow_to_target` (integer)
+- `positions_source` (integer)
+- `positions_source_domain` (integer)
+- `powered_by_source` (array(string))
+- `powered_by_target` (array(string))
+- `redirects_to_target` (integer)
+- `refdomains_source` (integer)
+- `refdomains_target` (integer)
+- `root_name_source` (string)
+- `snippet_left` (string)
+- `snippet_right` (string)
+- `source_page_author` (string)
+- `target_redirect` (string)
+- `title_source` (string)
+- `title_target` (string)
+- `top_domain_rating_source` (float)
+- `traffic_domain_source` (integer)
+- `traffic_source` (integer)
+- `url_from_plain` (string)
+- `url_rating_source` (float)
+- `url_rating_target` (float)
+- `url_redirect` (array(url))
+- `url_redirect_with_target` (array(string))
+- `url_to` (string)
+- `url_to_plain` (string)
+
+</details>
+
+**Returns:** `list[SiteExplorerBestByExternalLinksData]`
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `dofollow_to_target` | `int` | The number of links to your target page that don’t have the “nofollow” attribute. |
+| `first_seen_link` | `str` | The date we first found a link to your target. |
+| `http_code_target` | `int \| None` | The return code from HTTP protocol returned during the target page crawl. |
+| `is_spam` | `bool` | Indicates whether the backlink comes from a known spammy domain. |
+| `languages_target` | `list[str \| None]` | The languages listed in the target page metadata or detected by the crawler to appear in the HTML. |
+| `last_seen` | `str \| None` | The date your target page lost its last live link. |
+| `last_visited_source` | `str` | The date we last verified a live link to your target page. |
+| `last_visited_target` | `str \| None` | The date we last crawled your target page. |
+| `links_to_target` | `int` | The number of inbound backlinks the target page has. |
+| `lost_links_to_target` | `int` | The number of backlinks lost during the selected time period. |
+| `new_links_to_target` | `int` | The number of new backlinks found during the selected time period. |
+| `nofollow_to_target` | `int` | The number of links to your target page that have the “nofollow” attribute. |
+| `powered_by_target` | `list[str \| None]` | Web technologies used to build and serve the target page content. |
+| `redirects_to_target` | `int` | The number of inbound redirects to your target page. |
+| `refdomains_target` | `int` | (5 units) The number of unique referring domains linking to the target page. |
+| `target_redirect` | `str \| None` | The target's redirect if any. |
+| `title_target` | `str \| None` | The html title of the target page. |
+| `top_domain_rating_source` | `float` | The highest Domain Rating (DR) counted out of all referring domains. DR shows the strength of a website’s backlink profile compared to the others in our database on a 100-point scale. |
+| `url_rating_target` | `float \| None` | The strength of the target page's backlink profile compared to the others in our database on a 100-point scale. |
+| `url_to` | `str` | The URL the backlink points to. |
+| `url_to_plain` | `str` | The target page URL optimized for use as a filter. |
+
+### `site_explorer_best_by_internal_links()`
+
+Best by Internal Links.
+
+**Parameters:**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `timeout` | `int` | No | A manual timeout duration in seconds. |
+| `limit` | `int` | No | The number of results to return. |
+| `order_by` | `str` | No | A column to order results by. See the response schema for valid column identifiers, except for `http_code_target`, `languages_target`, `last_visited_target`, `powered_by_target`, `target_redirect`, `title_target`, `url_rating_target`, which are not supported in `order_by` for this endpoint. |
+| `where` | `str` | No | Filter expression ([syntax](filter-syntax.md)). Filterable fields listed below. |
+| `select` | `SelectStr` | Yes | A comma-separated list of columns to return. See response schema for valid column identifiers. |
+| `protocol` | `ProtocolEnum` | No | The protocol of your target. |
+| `target` | `str` | Yes | The target of the search: a domain or a URL. |
+| `mode` | `ModeEnum` | No | The scope of the search based on the target you entered. |
+
+<details>
+<summary>Filterable fields (48 fields)</summary>
+
+- `anchor` (string)
+- `canonical_to_target` (integer)
+- `dofollow_to_target` (integer)
+- `domain_rating_source` (float)
+- `first_seen_link` (datetime)
+- `http_code_source` (integer)
+- `http_code_target` (integer)
+- `is_content` (boolean)
+- `is_dofollow` (boolean)
+- `is_homepage_link` (boolean)
+- `is_nofollow` (boolean)
+- `is_non_html` (boolean)
+- `is_root_source` (boolean)
+- `is_sponsored` (boolean)
+- `is_ugc` (boolean)
+- `languages_source` (array(string))
+- `languages_target` (array(string))
+- `last_seen` (datetime)
+- `last_visited_source` (datetime)
+- `last_visited_target` (datetime)
+- `len_url_redirect` (integer)
+- `link_type` (string)
+- `linked_domains_source` (integer)
+- `links_external_source` (integer)
+- `links_to_target` (integer)
+- `nofollow_to_target` (integer)
+- `positions_source` (integer)
+- `positions_source_domain` (integer)
+- `powered_by_source` (array(string))
+- `powered_by_target` (array(string))
+- `redirects_to_target` (integer)
+- `refdomains_source` (integer)
+- `root_name_source` (string)
+- `snippet_left` (string)
+- `snippet_right` (string)
+- `source_page_author` (string)
+- `target_redirect` (string)
+- `title_source` (string)
+- `title_target` (string)
+- `traffic_domain_source` (integer)
+- `traffic_source` (integer)
+- `url_from_plain` (string)
+- `url_rating_source` (float)
+- `url_rating_target` (float)
+- `url_redirect` (array(url))
+- `url_redirect_with_target` (array(string))
+- `url_to` (string)
+- `url_to_plain` (string)
+
+</details>
+
+**Returns:** `list[SiteExplorerBestByInternalLinksData]`
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `canonical_to_target` | `int` | The number of inbound canonical links to your target page. |
+| `dofollow_to_target` | `int` | The number of links to your target page that don’t have the “nofollow” attribute. |
+| `first_seen_link` | `str` | The date we first found a link to your target. |
+| `http_code_target` | `int \| None` | The return code from HTTP protocol returned during the target page crawl. |
+| `languages_target` | `list[str \| None]` | The languages listed in the target page metadata or detected by the crawler to appear in the HTML. |
+| `last_seen` | `str \| None` | The date your target page lost its last live link. |
+| `last_visited_source` | `str` | The date we last verified a live link to your target page. |
+| `last_visited_target` | `str \| None` | The date we last crawled your target page. |
+| `links_to_target` | `int` | The number of inbound backlinks the target page has. |
+| `nofollow_to_target` | `int` | The number of links to your target page that have the “nofollow” attribute. |
+| `powered_by_target` | `list[str \| None]` | Web technologies used to build and serve the target page content. |
+| `redirects_to_target` | `int` | The number of inbound redirects to your target page. |
+| `target_redirect` | `str \| None` | The target's redirect if any. |
+| `title_target` | `str \| None` | The html title of the target page. |
+| `url_rating_target` | `float \| None` | The strength of the target page's backlink profile compared to the others in our database on a 100-point scale. |
+| `url_to` | `str` | The URL the backlink points to. |
+| `url_to_plain` | `str` | The target page URL optimized for use as a filter. |
+
+### `site_explorer_broken_backlinks()`
+
+Broken Backlinks.
+
+**Parameters:**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `timeout` | `int` | No | A manual timeout duration in seconds. |
+| `limit` | `int` | No | The number of results to return. |
+| `order_by` | `str` | No | A column to order results by. See the response schema for valid column identifiers, except for `http_code_target`, `last_visited_target`, `link_group_count`, which are not supported in `order_by` for this endpoint. |
+| `where` | `str` | No | Filter expression ([syntax](filter-syntax.md)). Filterable fields listed below. |
+| `select` | `SelectStr` | Yes | A comma-separated list of columns to return. See response schema for valid column identifiers. |
+| `protocol` | `ProtocolEnum` | No | The protocol of your target. |
+| `target` | `str` | Yes | The target of the search: a domain or a URL. |
+| `mode` | `ModeEnum` | No | The scope of the search based on the target you entered. |
+| `aggregation` | `AggregationEnum` | No | The backlinks grouping mode. |
+
+<details>
+<summary>Filterable fields (77 fields)</summary>
+
+- `ahrefs_rank_source` (integer)
+- `ahrefs_rank_target` (integer)
+- `alt` (string)
+- `anchor` (string)
+- `class_c` (integer)
+- `domain_rating_source` (float)
+- `domain_rating_target` (float)
+- `encoding` (string)
+- `first_seen` (datetime)
+- `first_seen_link` (datetime)
+- `http_code` (integer)
+- `http_code_target` (integer)
+- `http_crawl` (boolean)
+- `ip_source` (string)
+- `is_alternate` (boolean)
+- `is_canonical` (boolean)
+- `is_content` (boolean)
+- `is_dofollow` (boolean)
+- `is_form` (boolean)
+- `is_frame` (boolean)
+- `is_homepage_link` (boolean)
+- `is_image` (boolean)
+- `is_nofollow` (boolean)
+- `is_non_html` (boolean)
+- `is_redirect` (boolean)
+- `is_root_source` (boolean)
+- `is_root_target` (boolean)
+- `is_rss` (boolean)
+- `is_spam` (boolean)
+- `is_sponsored` (boolean)
+- `is_text` (boolean)
+- `is_ugc` (boolean)
+- `js_crawl` (boolean)
+- `languages` (array(string))
+- `last_seen` (datetime)
+- `last_visited` (datetime)
+- `last_visited_target` (datetime)
+- `len_url_redirect` (integer)
+- `link_group_count` (integer)
+- `link_type` (string)
+- `linked_domains_source_domain` (integer)
+- `linked_domains_source_page` (integer)
+- `linked_domains_target_domain` (integer)
+- `links_external` (integer)
+- `links_internal` (integer)
+- `name_source` (string)
+- `name_target` (string)
+- `page_category_source` (string)
+- `page_size` (integer)
+- `page_type_source` (string)
+- `port_source` (integer)
+- `port_target` (integer)
+- `positions` (integer)
+- `positions_source_domain` (integer)
+- `powered_by` (array(string))
+- `redirect_code` (integer)
+- `redirect_kind` (array(integer))
+- `refdomains_source` (integer)
+- `refdomains_source_domain` (integer)
+- `refdomains_target_domain` (integer)
+- `root_name_source` (string)
+- `root_name_target` (string)
+- `snippet_left` (string)
+- `snippet_right` (string)
+- `source_page_author` (string)
+- `title` (string)
+- `tld_class_source` (string)
+- `tld_class_target` (string)
+- `traffic` (integer)
+- `traffic_domain` (integer)
+- `url_from` (string)
+- `url_from_plain` (string)
+- `url_rating_source` (float)
+- `url_redirect` (array(url))
+- `url_redirect_with_target` (array(string))
+- `url_to` (string)
+- `url_to_plain` (string)
+
+</details>
+
+**Returns:** `list[SiteExplorerBrokenBacklinksData]`
+
+<details>
+<summary>73 fields</summary>
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `ahrefs_rank_source` | `int` | The strength of the referring domain's backlink profile compared to the other websites in our database, with rank #1 being the strongest. |
+| `ahrefs_rank_target` | `int` | The strength of the target domain's backlink profile compared to the other websites in our database, with rank #1 being the strongest. |
+| `alt` | `str \| None` | The alt attribute of the link. |
+| `anchor` | `str` | The clickable words in a link that point to a URL. |
+| `class_c` | `int` | (5 units) The number of unique class_c subnets linking to the referring page. |
+| `domain_rating_source` | `float` | The strength of the referring domain's backlink profile compared to the others in our database on a 100-point scale. |
+| `domain_rating_target` | `float` | The strength of the referring domain's backlink profile compared to the others in our database on a 100-point scale. |
+| `encoding` | `str` | The character set encoding of the referring page HTML. |
+| `first_seen` | `str` | The date the referring page URL was first discovered. |
+| `first_seen_link` | `str` | The date we first found a backlink to your target on a given referring page. |
+| `http_code` | `int` | The return code from HTTP protocol returned during the referring page crawl. |
+| `http_code_target` | `int \| None` | The return code from HTTP protocol returned during the target page crawl. |
+| `http_crawl` | `bool` | The link was discovered without executing javascript and rendering the page. |
+| `ip_source` | `str \| None` | The referring domain IP address. |
+| `is_alternate` | `bool` | The link with the rel=“alternate” attribute. |
+| `is_canonical` | `bool` | The link with the rel=“canonical” attribute. |
+| `is_content` | `bool` | The link was found in the biggest piece of content on the page. |
+| `is_dofollow` | `bool` | The link has no special nofollow attribute. |
+| `is_form` | `bool` | The link was found in a form HTML tag. |
+| `is_frame` | `bool` | The link was found in an iframe HTML tag. |
+| `is_image` | `bool` | The link is a regular link that has an image inside their href attribute. |
+| `is_nofollow` | `bool` | The link or the referring page has the nofollow attribute set. |
+| `is_redirect` | `bool` | The link pointing to your target via a redirect. |
+| `is_root_source` | `bool` | The referring domain name is a root domain name. |
+| `is_root_target` | `bool` | The target domain name is a root domain name. |
+| `is_rss` | `bool` | The link was found in an RSS feed. |
+| `is_spam` | `bool` | Indicates whether the backlink comes from a known spammy domain. |
+| `is_sponsored` | `bool` | The link has the Sponsored attribute set in the referring page HTML. |
+| `is_text` | `bool` | The link is a standard href hyperlink. |
+| `is_ugc` | `bool` | The link has the User Generated Content attribute set in the referring page HTML. |
+| `js_crawl` | `bool` | The link was discovered after executing javascript and rendering the page. |
+| `languages` | `list[str \| None]` | The languages listed in the referring page metadata or detected by the crawler to appear in the HTML. |
+| `last_seen` | `str \| None` | The date we discovered that the link was lost. |
+| `last_visited` | `str` | The date we last re-crawled the referring page to verify the backlink is alive. |
+| `last_visited_target` | `str \| None` | The date we last re-crawled the target page to verify that it is broken. |
+| `link_group_count` | `int` | The number of backlinks that were grouped together based on the aggregation parameter. This field cannot be used with aggregation 'all'. |
+| `link_type` | `LinkTypeEnum` | The kind of the backlink. |
+| `linked_domains_source_domain` | `int` | The number of unique root domains linked from the referring domain. |
+| `linked_domains_source_page` | `int` | The number of unique root domains linked from the referring page. |
+| `linked_domains_target_domain` | `int` | The number of unique root domains linked from the target domain. |
+| `links_external` | `int` | The number of external links from the referring page. |
+| `links_internal` | `int` | The number of internal links from the referring page. |
+| `name_source` | `str` | The complete referring domain name, including subdomains. |
+| `name_target` | `str` | The complete target domain name, including subdomains. |
+| `page_category_source` | `str \| None` | Comma-separated list of AI-predicted hierarchical category paths for the referring page. Each value is a slash-prefixed path (e.g. /Business_and_Industrial/Advertising_and_Marketing/Marketing). |
+| `page_size` | `int` | The size in bytes of the referring page content. |
+| `page_type_source` | `str \| None` | Comma-separated list of AI-predicted hierarchical page type paths for the referring page. Each value is a slash-prefixed path (e.g. /Article/How_to). |
+| `port_source` | `int` | The network port of the referring page URL. |
+| `port_target` | `int` | The network port of the target page URL. |
+| `positions` | `int` | The number of keywords that the referring page ranks for in the top 100 positions. |
+| `powered_by` | `list[str \| None]` | Web technologies used to build and serve the referring page content. |
+| `redirect_code` | `int \| None` | The HTTP status code of a referring page pointing to your target via a redirect. |
+| `redirect_kind` | `list[int \| None]` | The HTTP status codes returned by the target redirecting URL or redirect chain. |
+| `refdomains_source` | `int` | (5 units) The number of unique referring domains linking to the referring page. |
+| `refdomains_source_domain` | `int` | (5 units) The number of unique referring domains linking to the referring domain. |
+| `refdomains_target_domain` | `int` | (5 units) The number of unique referring domains linking to the target domain. |
+| `root_name_source` | `str` | The root domain name of the referring domain, not including subdomains. |
+| `root_name_target` | `str` | The root domain name of the target domain, not including subdomains. |
+| `snippet_left` | `str` | The snippet of text appearing just before the link. |
+| `snippet_right` | `str` | The snippet of text appearing just after the link. |
+| `source_page_author` | `str \| None` | The author of the referring page. |
+| `title` | `str` | The html title of the referring page. |
+| `tld_class_source` | `TldClassSourceEnum` | The top level domain class of the referring domain. |
+| `tld_class_target` | `TldClassSourceEnum` | The top level domain class of the target domain. |
+| `traffic` | `int` | (10 units) The referring page's estimated monthly organic traffic from search. |
+| `traffic_domain` | `int` | (10 units) The referring domain's estimated monthly organic traffic from search. |
+| `url_from` | `str` | The URL of the page containing a link to your target. |
+| `url_from_plain` | `str` | The referring page URL optimized for use as a filter. |
+| `url_rating_source` | `float` | The strength of the referring page's backlink profile compared to the others in our database on a 100-point scale. |
+| `url_redirect` | `list[str \| None]` | A redirect chain the target URL of the link points to. |
+| `url_redirect_with_target` | `list[str \| None]` | The target URL of the link with its redirect chain. |
+| `url_to` | `str` | The URL the backlink points to. |
+| `url_to_plain` | `str` | The target page URL optimized for use as a filter. |
+
+</details>
+
+### `site_explorer_domain_rating()`
+
+Domain rating.
+
+**Parameters:**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `protocol` | `ProtocolEnum` | No | The protocol of your target. |
+| `target` | `str` | Yes | The target of the search: a domain or a URL. |
+| `date` | `DateStr` | Yes | A date to report metrics on in YYYY-MM-DD format. |
+
+**Returns:** `SiteExplorerDomainRatingData | None`
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `domain_rating` | `float` | The strength of your target's backlink profile compared to the other websites in our database on a 100-point logarithmic scale. |
+| `ahrefs_rank` | `int \| None` | The strength of your target's backlink profile compared to the other websites in our database, with rank #1 being the strongest. |
+
+### `site_explorer_domain_rating_history()`
+
+Domain Rating history.
+
+**Parameters:**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `history_grouping` | `HistoryGroupingEnum` | No | The time interval used to group historical data. |
+| `date_to` | `DateStr` | No | The end date of the historical period in YYYY-MM-DD format. |
+| `date_from` | `DateStr` | Yes | The start date of the historical period in YYYY-MM-DD format. |
+| `target` | `str` | Yes | The target of the search: a domain or a URL. |
+
+**Returns:** `list[SiteExplorerDomainRatingHistoryData]`
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `date` | `str` | |
+| `domain_rating` | `float` | The strength of your target page's backlink profile compared to the other websites in our database on a 100-point logarithmic scale. |
+
+### `site_explorer_keywords_history()`
+
+Keywords history.
+
+**Parameters:**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `select` | `SelectStr` | No | A comma-separated list of columns to return. See response schema for valid column identifiers. |
+| `history_grouping` | `HistoryGroupingEnum` | No | The time interval used to group historical data. |
+| `date_to` | `DateStr` | No | The end date of the historical period in YYYY-MM-DD format. |
+| `date_from` | `DateStr` | Yes | The start date of the historical period in YYYY-MM-DD format. |
+| `country` | `CountryEnum` | No | A two-letter country code (ISO 3166-1 alpha-2). |
+| `protocol` | `ProtocolEnum` | No | The protocol of your target. |
+| `target` | `str` | Yes | The target of the search: a domain or a URL. |
+| `mode` | `ModeEnum` | No | The scope of the search based on the target you entered. |
+
+**Returns:** `list[SiteExplorerKeywordsHistoryData]`
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `date` | `str` | |
+| `top11_20` | `int` | The total number of keywords that your target ranks for in the top 11-20 organic search results. |
+| `top11_plus` | `int` | The total number of keywords that your target ranks for in the top 11+ organic search results. |
+| `top21_50` | `int` | The total number of keywords that your target ranks for in the top 21-50 organic search results. |
+| `top3` | `int` | The total number of keywords that your target ranks for in the top 3 organic search results. |
+| `top4_10` | `int` | The total number of keywords that your target ranks for in the top 4-10 organic search results. |
+| `top51_plus` | `int` | The total number of keywords that your target ranks for in the top 51+ organic search results. |
+
+### `site_explorer_linked_anchors_external()`
+
+Outgoing external anchors.
+
+**Parameters:**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `timeout` | `int` | No | A manual timeout duration in seconds. |
+| `limit` | `int` | No | The number of results to return. |
+| `order_by` | `str` | No | A column to order results by. See response schema for valid column identifiers. |
+| `where` | `str` | No | Filter expression ([syntax](filter-syntax.md)). Filterable fields listed below. |
+| `select` | `SelectStr` | Yes | A comma-separated list of columns to return. See response schema for valid column identifiers. |
+| `protocol` | `ProtocolEnum` | No | The protocol of your target. |
+| `target` | `str` | Yes | The target of the search: a domain or a URL. |
+| `mode` | `ModeEnum` | No | The scope of the search based on the target you entered. |
+
+<details>
+<summary>Filterable fields (32 fields)</summary>
+
+- `anchor` (string)
+- `dofollow_links` (integer)
+- `domain` (string)
+- `domain_rating` (float)
+- `first_seen` (datetime)
+- `is_content` (boolean)
+- `is_dofollow` (boolean)
+- `is_nofollow` (boolean)
+- `is_non_html` (boolean)
+- `is_sponsored` (boolean)
+- `is_ugc` (boolean)
+- `languages` (array(string))
+- `len_url_redirect` (integer)
+- `link_type` (string)
+- `linked_domains` (integer)
+- `linked_domains_source` (integer)
+- `linked_pages` (integer)
+- `links_external` (integer)
+- `links_from_target` (integer)
+- `port_source` (integer)
+- `port_target` (integer)
+- `positions` (integer)
+- `powered_by` (array(string))
+- `refdomains_source` (integer)
+- `snippet_left` (string)
+- `snippet_right` (string)
+- `title` (string)
+- `traffic_page` (integer)
+- `url_from` (string)
+- `url_redirect` (array(url))
+- `url_redirect_with_target` (array(string))
+- `url_to` (string)
+
+</details>
+
+**Returns:** `list[SiteExplorerLinkedAnchorsExternalData]`
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `anchor` | `str` | The clickable words in a link that point to a URL. |
+| `dofollow_links` | `int` | The number of outbound links with a given anchor from your target that don’t have the “nofollow” attribute. |
+| `first_seen` | `str` | The date we first found a link with a given anchor on your target. |
+| `linked_domains` | `int` | The number of unique domains linked from your target with a given anchor. |
+| `linked_pages` | `int` | The number of unique pages linked from your target with a given anchor. |
+| `links_from_target` | `int` | The number of outbound links your target has with a given anchor. |
+
+### `site_explorer_linked_anchors_internal()`
+
+Outgoing internal anchors.
+
+**Parameters:**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `timeout` | `int` | No | A manual timeout duration in seconds. |
+| `limit` | `int` | No | The number of results to return. |
+| `order_by` | `str` | No | A column to order results by. See response schema for valid column identifiers. |
+| `where` | `str` | No | Filter expression ([syntax](filter-syntax.md)). Filterable fields listed below. |
+| `select` | `SelectStr` | Yes | A comma-separated list of columns to return. See response schema for valid column identifiers. |
+| `protocol` | `ProtocolEnum` | No | The protocol of your target. |
+| `target` | `str` | Yes | The target of the search: a domain or a URL. |
+| `mode` | `ModeEnum` | No | The scope of the search based on the target you entered. |
+
+<details>
+<summary>Filterable fields (31 fields)</summary>
+
+- `anchor` (string)
+- `dofollow_links` (integer)
+- `domain` (string)
+- `domain_rating` (float)
+- `first_seen` (datetime)
+- `is_content` (boolean)
+- `is_dofollow` (boolean)
+- `is_nofollow` (boolean)
+- `is_non_html` (boolean)
+- `is_sponsored` (boolean)
+- `is_ugc` (boolean)
+- `languages` (array(string))
+- `len_url_redirect` (integer)
+- `link_type` (string)
+- `linked_domains_source` (integer)
+- `linked_pages` (integer)
+- `links_external` (integer)
+- `links_from_target` (integer)
+- `port_source` (integer)
+- `port_target` (integer)
+- `positions` (integer)
+- `powered_by` (array(string))
+- `refdomains_source` (integer)
+- `snippet_left` (string)
+- `snippet_right` (string)
+- `title` (string)
+- `traffic_page` (integer)
+- `url_from` (string)
+- `url_redirect` (array(url))
+- `url_redirect_with_target` (array(string))
+- `url_to` (string)
+
+</details>
+
+**Returns:** `list[SiteExplorerLinkedAnchorsInternalData]`
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `anchor` | `str` | The clickable words in a link that point to a URL. |
+| `dofollow_links` | `int` | The number of outbound links with a given anchor from your target that don’t have the “nofollow” attribute. |
+| `first_seen` | `str` | The date we first found a link with a given anchor on your target. |
+| `linked_pages` | `int` | The number of unique pages linked from your target with a given anchor. |
+| `links_from_target` | `int` | The number of outbound links your target has with a given anchor. |
+
+### `site_explorer_linkeddomains()`
+
+Linked Domains.
+
+**Parameters:**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `timeout` | `int` | No | A manual timeout duration in seconds. |
+| `limit` | `int` | No | The number of results to return. |
+| `order_by` | `str` | No | A column to order results by. See response schema for valid column identifiers. |
+| `where` | `str` | No | Filter expression ([syntax](filter-syntax.md)). Filterable fields listed below. |
+| `select` | `SelectStr` | Yes | A comma-separated list of columns to return. See response schema for valid column identifiers. |
+| `protocol` | `ProtocolEnum` | No | The protocol of your target. |
+| `target` | `str` | Yes | The target of the search: a domain or a URL. |
+| `mode` | `ModeEnum` | No | The scope of the search based on the target you entered. |
+
+<details>
+<summary>Filterable fields (36 fields)</summary>
+
+- `anchor` (string)
+- `dofollow_linked_domains` (integer)
+- `dofollow_links` (integer)
+- `dofollow_refdomains` (integer)
+- `domain` (string)
+- `domain_rating` (float)
+- `first_seen` (datetime)
+- `is_content` (boolean)
+- `is_dofollow` (boolean)
+- `is_nofollow` (boolean)
+- `is_non_html` (boolean)
+- `is_root_domain` (boolean)
+- `is_sponsored` (boolean)
+- `is_ugc` (boolean)
+- `languages` (array(string))
+- `len_url_redirect` (integer)
+- `link_type` (string)
+- `linked_domain_traffic` (integer)
+- `linked_domains` (integer)
+- `linked_pages` (integer)
+- `links_external` (integer)
+- `links_from_target` (integer)
+- `port_source` (integer)
+- `port_target` (integer)
+- `positions` (integer)
+- `powered_by` (array(string))
+- `refdomains` (integer)
+- `root_domain_name` (string)
+- `snippet_left` (string)
+- `snippet_right` (string)
+- `title` (string)
+- `traffic_page` (integer)
+- `url_from` (string)
+- `url_redirect` (array(url))
+- `url_redirect_with_target` (array(string))
+- `url_to` (string)
+
+</details>
+
+**Returns:** `list[SiteExplorerLinkeddomainsData]`
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `dofollow_linked_domains` | `int` | The number of unique root domains with dofollow links linked from the linked domain. |
+| `dofollow_links` | `int` | The number of links from your target to the linked domain that don’t have the “nofollow” attribute. |
+| `dofollow_refdomains` | `int` | (5 units) The number of unique domains with dofollow links to the linked domain. |
+| `domain` | `str` | A linked domain that has at least one link from your target. |
+| `domain_rating` | `float` | The strength of a domain's backlink profile compared to the others in our database on a 100-point scale. |
+| `first_seen` | `str` | The date we first found a link to the linked domain from your target. |
+| `is_root_domain` | `bool` | The domain name is a root domain name. |
+| `linked_domain_traffic` | `int` | (10 units) The linked domain’s estimated monthly organic traffic from search |
+| `linked_pages` | `int` | The number of the domain's pages linked from your target. |
+| `links_from_target` | `int` | The number of links to the linked domain from your target. |
+
+### `site_explorer_metrics()`
+
+Metrics.
+
+**Parameters:**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `volume_mode` | `VolumeModeEnum` | No | The search volume calculation mode: monthly or average. It affects volume, traffic, and traffic value. |
+| `country` | `CountryEnum` | No | A two-letter country code (ISO 3166-1 alpha-2). |
+| `protocol` | `ProtocolEnum` | No | The protocol of your target. |
+| `target` | `str` | Yes | The target of the search: a domain or a URL. |
+| `mode` | `ModeEnum` | No | The scope of the search based on the target you entered. |
+| `date` | `DateStr` | Yes | A date to report metrics on in YYYY-MM-DD format. |
+
+**Returns:** `SiteExplorerMetricsData | None`
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `org_keywords` | `int` | The total number of keywords that your target ranks for in the top 100 organic search results. |
+| `paid_keywords` | `int` | The total number of keywords that your target ranks for in paid search results. |
+| `org_keywords_1_3` | `int` | The total number of keywords that your target ranks for in the top 3 organic search results. |
+| `org_traffic` | `int` | (10 units) The estimated number of monthly visitors that your target gets from organic search. |
+| `org_cost` | `int \| None` | (10 units) The estimated value of your target's monthly organic search traffic, in USD cents. |
+| `paid_traffic` | `int` | (10 units) The estimated number of monthly visitors that your target gets from paid search. |
+| `paid_cost` | `int \| None` | (10 units) The estimated cost of your target's monthly paid search traffic, in USD cents. |
+| `paid_pages` | `int` | The total number of pages from a target ranking in paid search results. |
+
+### `site_explorer_metrics_by_country()`
+
+Metrics by country.
+
+**Parameters:**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `select` | `SelectStr` | No | A comma-separated list of columns to return. See response schema for valid column identifiers. |
+| `volume_mode` | `VolumeModeEnum` | No | The search volume calculation mode: monthly or average. It affects volume, traffic, and traffic value. |
+| `protocol` | `ProtocolEnum` | No | The protocol of your target. |
+| `target` | `str` | Yes | The target of the search: a domain or a URL. |
+| `mode` | `ModeEnum` | No | The scope of the search based on the target you entered. |
+| `date` | `DateStr` | Yes | A date to report metrics on in YYYY-MM-DD format. |
+
+**Returns:** `list[SiteExplorerMetricsByCountryData]`
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `country` | `CountryEnum1` | |
+| `org_cost` | `int \| None` | (10 units) The estimated value of your target's monthly organic search traffic, in USD cents. |
+| `org_keywords` | `int` | The total number of keywords that your target ranks for in the top 100 organic search results. |
+| `org_keywords_1_3` | `int` | The total number of keywords that your target ranks for in the top 3 organic search results. |
+| `org_traffic` | `int` | (10 units) The estimated number of monthly visitors that your target gets from organic search. |
+| `paid_cost` | `int \| None` | (10 units) The estimated cost of your target's monthly paid search traffic, in USD cents. |
+| `paid_keywords` | `int` | The total number of keywords that your target ranks for in paid search results. |
+| `paid_pages` | `int` | The total number of pages from a target ranking in the top 100 paid search results. |
+| `paid_traffic` | `int` | (10 units) The estimated number of monthly visitors that your target gets from paid search. |
+
+### `site_explorer_metrics_history()`
+
+Metrics history.
+
+**Parameters:**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `select` | `SelectStr` | No | A comma-separated list of columns to return. See response schema for valid column identifiers. |
+| `volume_mode` | `VolumeModeEnum` | No | The search volume calculation mode: monthly or average. It affects volume, traffic, and traffic value. |
+| `history_grouping` | `HistoryGroupingEnum` | No | The time interval used to group historical data. |
+| `date_to` | `DateStr` | No | The end date of the historical period in YYYY-MM-DD format. |
+| `date_from` | `DateStr` | Yes | The start date of the historical period in YYYY-MM-DD format. |
+| `country` | `CountryEnum` | No | A two-letter country code (ISO 3166-1 alpha-2). |
+| `protocol` | `ProtocolEnum` | No | The protocol of your target. |
+| `target` | `str` | Yes | The target of the search: a domain or a URL. |
+| `mode` | `ModeEnum` | No | The scope of the search based on the target you entered. |
+
+**Returns:** `list[SiteExplorerMetricsHistoryData]`
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `date` | `str` | |
+| `org_cost` | `int` | (10 units) The estimated cost of your target's monthly organic search traffic, in USD cents. |
+| `org_traffic` | `int` | (10 units) The estimated number of monthly visitors that your target gets from organic search. |
+| `paid_cost` | `int` | (10 units) The estimated cost of your target's monthly paid search traffic, in USD cents. |
+| `paid_traffic` | `int` | (10 units) The estimated number of monthly visitors that your target gets from paid search. |
+
+### `site_explorer_organic_competitors()`
+
+Organic competitors.
+
+**Parameters:**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `timeout` | `int` | No | A manual timeout duration in seconds. |
+| `limit` | `int` | No | The number of results to return. |
+| `order_by` | `str` | No | A column to order results by. See response schema for valid column identifiers. |
+| `where` | `str` | No | Filter expression ([syntax](filter-syntax.md)). Filterable fields listed below. |
+| `select` | `SelectStr` | Yes | A comma-separated list of columns to return. See response schema for valid column identifiers. |
+| `protocol` | `ProtocolEnum` | No | The protocol of your target. |
+| `target` | `str` | Yes | The target of the search: a domain or a URL. |
+| `mode` | `ModeEnum` | No | The scope of the search based on the target you entered. |
+| `country` | `CountryEnum` | Yes | A two-letter country code (ISO 3166-1 alpha-2). |
+| `date_compared` | `DateStr` | No | A date to compare metrics with in YYYY-MM-DD format. |
+| `date` | `DateStr` | Yes | A date to report metrics on in YYYY-MM-DD format. |
+| `volume_mode` | `VolumeModeEnum` | No | The search volume calculation mode: monthly or average. It affects volume, traffic, and traffic value. |
+
+<details>
+<summary>Filterable fields (28 fields)</summary>
+
+- `competitor_domain` (domain)
+- `competitor_url` (url)
+- `cpc_competitor` (integer)
+- `cpc_target` (integer)
+- `domain_rating` (float)
+- `group_mode` (string)
+- `keyword_difficulty_competitor` (integer)
+- `keyword_difficulty_target` (integer)
+- `keywords_common` (integer)
+- `keywords_competitor` (integer)
+- `keywords_target` (integer)
+- `pages` (integer)
+- `pages_diff` (integer)
+- `pages_merged` (integer)
+- `pages_prev` (integer)
+- `share` (float)
+- `traffic` (integer)
+- `traffic_diff` (integer)
+- `traffic_merged` (integer)
+- `traffic_prev` (integer)
+- `value` (integer)
+- `value_diff` (integer)
+- `value_merged` (integer)
+- `value_prev` (integer)
+- `volume_competitor` (integer)
+- `volume_target` (integer)
+- `words_competitor` (integer)
+- `words_target` (integer)
+
+</details>
+
+**Returns:** `list[SiteExplorerOrganicCompetitorsData]`
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `competitor_domain` | `str \| None` | A competitor's domain of your target in “domains" group mode. |
+| `competitor_url` | `str \| None` | A competitor's URL of your target in pages" group mode. |
+| `domain_rating` | `float` | The strength of a domain's backlink profile compared to the others in our database on a 100-point scale. |
+| `group_mode` | `GroupModeEnum` | To see competing pages instead, use the “exact URL” target mode or “path” target mode if your target doesn't have multiple pages. |
+| `keywords_common` | `int` | Organic keywords that both your target and a competitor are ranking for. |
+| `keywords_competitor` | `int` | Organic keywords that a competitor is ranking for, but your target isn't. |
+| `keywords_target` | `int` | Organic keywords that your target is ranking for, but a competitor isn't. |
+| `pages` | `int \| None` | The total number of pages from a target ranking in search results. |
+| `pages_diff` | `int` | The change in pages between your selected dates. |
+| `pages_merged` | `int` | The pages field optimized for sorting. |
+| `pages_prev` | `int \| None` | The total number of pages from a target ranking in search results on the comparison date. |
+| `share` | `float` | The percentage of common keywords out of the total number of keywords that your target and a competitor both rank for. |
+| `traffic` | `int \| None` | (10 units) An estimation of the number of monthly visits that a page gets from organic search over the latest month or over the latest known 12 months of data depending on the "volume_mode" parameter. |
+| `traffic_diff` | `int` | The change in traffic between your selected dates. |
+| `traffic_merged` | `int` | (10 units) The traffic field optimized for sorting. |
+| `traffic_prev` | `int \| None` | (10 units) An estimation of the number of monthly visits that a page gets from organic search over the latest month or over the latest known 12 months of data depending on the "volume_mode" parameter on the comparison date. |
+| `value` | `int \| None` | (10 units) The estimated value of a page's monthly organic search traffic, in USD cents. |
+| `value_diff` | `int` | The change in value between your selected dates. |
+| `value_merged` | `int \| None` | (10 units) The value field optimized for sorting. |
+| `value_prev` | `int \| None` | (10 units) The estimated value of a page's monthly organic search traffic, in USD cents on the comparison date. |
+
+### `site_explorer_organic_keywords()`
+
+Organic keywords.
+
+**Parameters:**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `timeout` | `int` | No | A manual timeout duration in seconds. |
+| `limit` | `int` | No | The number of results to return. |
+| `order_by` | `str` | No | A column to order results by. See response schema for valid column identifiers. |
+| `where` | `str` | No | Filter expression ([syntax](filter-syntax.md)). Filterable fields listed below. |
+| `select` | `SelectStr` | Yes | A comma-separated list of columns to return. See response schema for valid column identifiers. |
+| `protocol` | `ProtocolEnum` | No | The protocol of your target. |
+| `target` | `str` | Yes | The target of the search: a domain or a URL. |
+| `mode` | `ModeEnum` | No | The scope of the search based on the target you entered. |
+| `country` | `CountryEnum` | No | A two-letter country code (ISO 3166-1 alpha-2). |
+| `date_compared` | `DateStr` | No | A date to compare metrics with in YYYY-MM-DD format. |
+| `date` | `DateStr` | Yes | A date to report metrics on in YYYY-MM-DD format. |
+| `volume_mode` | `VolumeModeEnum` | No | The search volume calculation mode: monthly or average. It affects volume, traffic, and traffic value. |
+
+<details>
+<summary>Filterable fields (82 fields)</summary>
+
+- `best_position` (integer)
+- `best_position_diff` (integer)
+- `best_position_has_thumbnail` (boolean)
+- `best_position_has_thumbnail_prev` (boolean)
+- `best_position_has_video` (boolean)
+- `best_position_has_video_prev` (boolean)
+- `best_position_kind` (string)
+- `best_position_kind_merged` (string)
+- `best_position_kind_prev` (string)
+- `best_position_prev` (integer)
+- `best_position_set` (string)
+- `best_position_set_prev` (string)
+- `best_position_url` (string)
+- `best_position_url_prev` (string)
+- `best_position_url_raw` (string)
+- `best_position_url_raw_prev` (string)
+- `cpc` (integer)
+- `cpc_merged` (integer)
+- `cpc_prev` (integer)
+- `entities` (array(object))
+- `event_entities` (array(string))
+- `is_best_position_set_top_11_50` (boolean)
+- `is_best_position_set_top_11_50_prev` (boolean)
+- `is_best_position_set_top_3` (boolean)
+- `is_best_position_set_top_3_prev` (boolean)
+- `is_best_position_set_top_4_10` (boolean)
+- `is_best_position_set_top_4_10_prev` (boolean)
+- `is_branded` (boolean)
+- `is_commercial` (boolean)
+- `is_informational` (boolean)
+- `is_local` (boolean)
+- `is_main_position` (boolean)
+- `is_main_position_prev` (boolean)
+- `is_navigational` (boolean)
+- `is_transactional` (boolean)
+- `keyword` (string)
+- `keyword_country` (string)
+- `keyword_difficulty` (integer)
+- `keyword_difficulty_merged` (integer)
+- `keyword_difficulty_prev` (integer)
+- `keyword_language` (array(string))
+- `keyword_merged` (string)
+- `keyword_prev` (string)
+- `language` (string)
+- `language_prev` (string)
+- `last_update` (datetime)
+- `last_update_prev` (datetime)
+- `location_entities` (array(string))
+- `organisation_entities` (array(string))
+- `person_entities` (array(string))
+- `position_kind` (string)
+- `position_kind_prev` (string)
+- `positions_kinds` (array(string))
+- `positions_kinds_prev` (array(string))
+- `product_entities` (array(string))
+- `serp_features` (array(string))
+- `serp_features_count` (integer)
+- `serp_features_count_prev` (integer)
+- `serp_features_merged` (array(string))
+- `serp_features_prev` (array(string))
+- `serp_target_main_positions_count` (integer)
+- `serp_target_main_positions_count_prev` (integer)
+- `serp_target_positions_count` (integer)
+- `serp_target_positions_count_prev` (integer)
+- `status` (string)
+- `sum_paid_traffic` (integer)
+- `sum_paid_traffic_merged` (integer)
+- `sum_paid_traffic_prev` (integer)
+- `sum_traffic` (integer)
+- `sum_traffic_merged` (integer)
+- `sum_traffic_prev` (integer)
+- `title` (string)
+- `title_prev` (string)
+- `volume` (integer)
+- `volume_desktop_pct` (float)
+- `volume_merged` (integer)
+- `volume_mobile_pct` (float)
+- `volume_prev` (integer)
+- `words` (integer)
+- `words_merged` (integer)
+- `words_prev` (integer)
+- `work_entities` (array(string))
+
+</details>
+
+**Returns:** `list[SiteExplorerOrganicKeywordsData]`
+
+<details>
+<summary>68 fields</summary>
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `all_positions` | `list[dict[str, Any] \| None]` | (5 units) The list of all positions for a keyword. |
+| `all_positions_prev` | `list[dict[str, Any] \| None]` | (5 units) The list of all positions for a keyword on the comparison date. |
+| `best_position` | `int \| None` | The top position your target ranks for in the organic search results for a keyword. |
+| `best_position_diff` | `int \| None` | The change in position between your selected dates. |
+| `best_position_has_thumbnail` | `bool \| None` | The top position has a thumbnail. |
+| `best_position_has_thumbnail_prev` | `bool \| None` | The top position has a thumbnail on the comparison date. |
+| `best_position_has_video` | `bool \| None` | The top position has a video. |
+| `best_position_has_video_prev` | `bool \| None` | The top position has a video on the comparison date. |
+| `best_position_kind` | `BestPositionKindEnum \| None` | The kind of the top position: organic, paid, or a SERP feature. |
+| `best_position_kind_merged` | `BestPositionKindEnum` | The kind of the top position optimized for sorting. |
+| `best_position_kind_prev` | `BestPositionKindEnum \| None` | The kind of the top position on the comparison date. |
+| `best_position_prev` | `int \| None` | The top position on the comparison date. |
+| `best_position_set` | `BestPositionSetEnum` | The ranking group of the top position. |
+| `best_position_set_prev` | `BestPositionSetEnum \| None` | The ranking group of the top position on the comparison date. |
+| `best_position_url` | `str \| None` | The ranking URL in organic search results. |
+| `best_position_url_prev` | `str \| None` | The ranking URL on the comparison date. |
+| `cpc` | `int \| None` | Cost Per Click shows the average price that advertisers pay for each ad click in paid search results for a keyword, in USD cents. |
+| `cpc_merged` | `int \| None` | The CPC field optimized for sorting. |
+| `cpc_prev` | `int \| None` | The CPC metric on the comparison date. |
+| `entities` | `list[dict[str, Any] \| None]` | Organizations, products, persons, works, events, and locations found in a keyword. |
+| `is_best_position_set_top_11_50` | `bool` | The ranking group of the top position is 11-50. |
+| `is_best_position_set_top_11_50_prev` | `bool \| None` | The ranking group of the top position was 11-50 on the comparison date. |
+| `is_best_position_set_top_3` | `bool` | The ranking group of the top position is Top 3. |
+| `is_best_position_set_top_3_prev` | `bool \| None` | The ranking group of the top position was Top 3 on the comparison date. |
+| `is_best_position_set_top_4_10` | `bool` | The ranking group of the top position is 4-10. |
+| `is_best_position_set_top_4_10_prev` | `bool \| None` | The ranking group of the top position was 4-10 on the comparison date. |
+| `is_branded` | `bool` | User intent: branded. The user is searching for a specific brand or company name. |
+| `is_commercial` | `bool` | User intent: commercial. The user is comparing products or services before making a purchase decision. |
+| `is_informational` | `bool` | User intent: informational. The user is looking for information or an answer to a specific question. |
+| `is_local` | `bool` | User intent: local. The user is looking for information relevant to a specific location or nearby services. |
+| `is_navigational` | `bool` | User intent: navigational. The user is searching for a specific website or web page. |
+| `is_transactional` | `bool` | User intent: transactional. The user is ready to complete an action, often a purchase. |
+| `keyword` | `str \| None` | The keyword your target ranks for. |
+| `keyword_country` | `CountryEnum1` | The country of a keyword your target ranks for. |
+| `keyword_difficulty` | `int \| None` | (10 units) An estimation of how hard it is to rank in the top 10 organic search results for a keyword on a 100-point scale. |
+| `keyword_difficulty_merged` | `int \| None` | (10 units) The keyword difficulty field optimized for sorting. |
+| `keyword_difficulty_prev` | `int \| None` | (10 units) The keyword difficulty on the comparison date. |
+| `keyword_language` | `list[str \| None]` | The language of the search query |
+| `keyword_merged` | `str` | The keyword field optimized for sorting. |
+| `keyword_prev` | `str \| None` | The keyword your target ranks for on the comparison date. |
+| `language` | `str` | The SERP language. |
+| `language_prev` | `str \| None` | The SERP language on the comparison date. |
+| `last_update` | `str` | The date when we last checked search engine results for a keyword. |
+| `last_update_prev` | `str \| None` | The date when we checked search engine results up to the comparison date. |
+| `serp_features` | `list[SerpFeaturesItemEnum1 \| None]` | The SERP features that appear in search results for a keyword. |
+| `serp_features_count` | `int` | The number of SERP features that appear in search results for a keyword. |
+| `serp_features_count_prev` | `int \| None` | The number of SERP features on the comparison date. |
+| `serp_features_merged` | `list[SerpFeaturesItemEnum1 \| None]` | The SERP features field optimized for sorting. |
+| `serp_features_prev` | `list[SerpFeaturesItemEnum1 \| None]` | The SERP features that appear in search results for a keyword on the comparison date. |
+| `serp_target_main_positions_count` | `int` | The number of target URLs ranking for a keyword excluding positions in Sitelinks, Top stories, Image packs, and posts on X (Twitter). |
+| `serp_target_main_positions_count_prev` | `int \| None` | The number of target URLs ranking for a keyword excluding positions in Sitelinks, Top stories, Image packs, and posts on X (Twitter) on the comparison date. |
+| `serp_target_positions_count` | `int` | The number of target URLs ranking for a keyword. |
+| `serp_target_positions_count_prev` | `int \| None` | The number of target URLs ranking for a keyword on the comparison date. |
+| `status` | `StatusEnum` | The status of a page: the new page that just started to rank ("left"), the lost page that disappeared from search results ("right"), or no change ("both"). |
+| `sum_paid_traffic` | `int \| None` | (10 units) An estimation of the number of monthly visits that your target gets from paid search for a keyword. |
+| `sum_paid_traffic_merged` | `int` | (10 units) The paid traffic field optimized for sorting. |
+| `sum_paid_traffic_prev` | `int \| None` | (10 units) The paid traffic on the comparison date. |
+| `sum_traffic` | `int \| None` | (10 units) An estimation of the number of monthly visitors that your target gets from organic search for a keyword. |
+| `sum_traffic_merged` | `int` | (10 units) The traffic field optimized for sorting. |
+| `sum_traffic_prev` | `int \| None` | (10 units) The traffic on the comparison date. |
+| `volume` | `int \| None` | (10 units) An estimation of the number of searches for a keyword over the latest month. |
+| `volume_desktop_pct` | `float \| None` | The percentage of the total search volume that comes from desktop devices. |
+| `volume_merged` | `int \| None` | (10 units) The search volume field optimized for sorting. |
+| `volume_mobile_pct` | `float \| None` | The percentage of the total search volume that comes from mobile devices. |
+| `volume_prev` | `int \| None` | (10 units) The search volume on the comparison date. |
+| `words` | `int \| None` | The number of words in a keyword. |
+| `words_merged` | `int` | The number of words in a keyword optimized for sorting. |
+| `words_prev` | `int \| None` | The number of words in a keyword on the comparison date. |
+
+</details>
+
+### `site_explorer_outlinks_stats()`
+
+Outlinks stats.
+
+**Parameters:**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `protocol` | `ProtocolEnum` | No | The protocol of your target. |
+| `mode` | `ModeEnum` | No | The scope of the search based on the target you entered. |
+| `target` | `str` | Yes | The target of the search: a domain or a URL. |
+
+**Returns:** `SiteExplorerOutlinksStatsData | None`
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `outgoing_links` | `int` | The number of external links from the target. |
+| `outgoing_links_dofollow` | `int` | The number of external dofollow links from the target. |
+| `linked_domains` | `int` | The number of unique root domains linked from the target. |
+| `linked_domains_dofollow` | `int` | The number of unique root domains linked via dofollow links from the target. |
+
+### `site_explorer_pages_by_traffic()`
+
+Pages by traffic.
+
+**Parameters:**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `volume_mode` | `VolumeModeEnum` | No | The search volume calculation mode: monthly or average. It affects volume, traffic, and traffic value. |
+| `country` | `CountryEnum` | No | A two-letter country code (ISO 3166-1 alpha-2). |
+| `protocol` | `ProtocolEnum` | No | The protocol of your target. |
+| `target` | `str` | Yes | The target of the search: a domain or a URL. |
+| `mode` | `ModeEnum` | No | The scope of the search based on the target you entered. |
+
+**Returns:** `SiteExplorerPagesByTrafficData | None`
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `range0_pages` | `int` | The total number of pages with 0 traffic. |
+| `range100_traffic` | `int` | (10 units) The total traffic from pages with 1-100 traffic. |
+| `range100_pages` | `int` | The total number of pages with 1-100 traffic. |
+| `range1k_traffic` | `int` | (10 units) The total traffic from pages with 101-1K traffic. |
+| `range1k_pages` | `int` | The total number of pages with 101-1K traffic. |
+| `range5k_traffic` | `int` | (10 units) The total traffic from pages with 1K-5K traffic. |
+| `range5k_pages` | `int` | The total number of pages with 1K-5K traffic. |
+| `range10k_traffic` | `int` | (10 units) The total traffic from pages with 5K-10K traffic. |
+| `range10k_pages` | `int` | The total number of pages with 5K-10K traffic. |
+| `range10k_plus_traffic` | `int` | (10 units) The total traffic from pages with 10K+ traffic. |
+| `range10k_plus_pages` | `int` | The total number of pages with 10K+ traffic. |
+
+### `site_explorer_pages_history()`
+
+Pages history.
+
+**Parameters:**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `history_grouping` | `HistoryGroupingEnum` | No | The time interval used to group historical data. |
+| `date_to` | `DateStr` | No | The end date of the historical period in YYYY-MM-DD format. |
+| `date_from` | `DateStr` | Yes | The start date of the historical period in YYYY-MM-DD format. |
+| `country` | `CountryEnum` | No | A two-letter country code (ISO 3166-1 alpha-2). |
+| `protocol` | `ProtocolEnum` | No | The protocol of your target. |
+| `target` | `str` | Yes | The target of the search: a domain or a URL. |
+| `mode` | `ModeEnum` | No | The scope of the search based on the target you entered. |
+
+**Returns:** `list[SiteExplorerPagesHistoryData]`
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `date` | `str` | |
+| `pages` | `int` | The total number of pages from a target ranking in the top 100 organic search results. |
+
+### `site_explorer_paid_pages()`
+
+Paid pages.
+
+**Parameters:**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `timeout` | `int` | No | A manual timeout duration in seconds. |
+| `limit` | `int` | No | The number of results to return. |
+| `order_by` | `str` | No | A column to order results by. See response schema for valid column identifiers. |
+| `where` | `str` | No | Filter expression ([syntax](filter-syntax.md)). Filterable fields listed below. |
+| `select` | `SelectStr` | Yes | A comma-separated list of columns to return. See response schema for valid column identifiers. |
+| `protocol` | `ProtocolEnum` | No | The protocol of your target. |
+| `target` | `str` | Yes | The target of the search: a domain or a URL. |
+| `mode` | `ModeEnum` | No | The scope of the search based on the target you entered. |
+| `country` | `CountryEnum` | No | A two-letter country code (ISO 3166-1 alpha-2). |
+| `date_compared` | `DateStr` | No | A date to compare metrics with in YYYY-MM-DD format. |
+| `date` | `DateStr` | Yes | A date to report metrics on in YYYY-MM-DD format. |
+| `volume_mode` | `VolumeModeEnum` | No | The search volume calculation mode: monthly or average. It affects volume, traffic, and traffic value. |
+
+<details>
+<summary>Filterable fields (66 fields)</summary>
+
+- `ads_count` (integer)
+- `ads_count_diff` (integer)
+- `ads_count_prev` (integer)
+- `cpc` (integer)
+- `cpc_prev` (integer)
+- `description` (string)
+- `description_prev` (string)
+- `has_thumbnail` (boolean)
+- `has_thumbnail_prev` (boolean)
+- `has_video` (boolean)
+- `has_video_prev` (boolean)
+- `keyword` (string)
+- `keyword_difficulty` (integer)
+- `keyword_difficulty_prev` (integer)
+- `keyword_prev` (string)
+- `keywords` (integer)
+- `keywords_diff` (integer)
+- `keywords_diff_percent` (integer)
+- `keywords_merged` (integer)
+- `keywords_prev` (integer)
+- `position` (integer)
+- `position_kind` (string)
+- `position_kind_prev` (string)
+- `position_prev` (integer)
+- `raw_url` (string)
+- `raw_url_prev` (string)
+- `referring_domains` (integer)
+- `serp_features` (array(string))
+- `serp_features_prev` (array(string))
+- `status` (string)
+- `sum_traffic` (integer)
+- `sum_traffic_merged` (integer)
+- `sum_traffic_prev` (integer)
+- `title` (string)
+- `title_prev` (string)
+- `top_keyword` (string)
+- `top_keyword_best_position` (integer)
+- `top_keyword_best_position_diff` (integer)
+- `top_keyword_best_position_kind` (string)
+- `top_keyword_best_position_kind_prev` (string)
+- `top_keyword_best_position_prev` (integer)
+- `top_keyword_best_position_title` (string)
+- `top_keyword_best_position_title_prev` (string)
+- `top_keyword_country` (string)
+- `top_keyword_country_prev` (string)
+- `top_keyword_prev` (string)
+- `top_keyword_volume` (integer)
+- `top_keyword_volume_prev` (integer)
+- `traffic` (integer)
+- `traffic_diff` (integer)
+- `traffic_diff_percent` (integer)
+- `traffic_prev` (integer)
+- `ur` (float)
+- `url` (url)
+- `url_prev` (url)
+- `url_visual` (string)
+- `url_visual_prev` (string)
+- `value` (integer)
+- `value_diff` (integer)
+- `value_diff_percent` (integer)
+- `value_merged` (integer)
+- `value_prev` (integer)
+- `volume` (integer)
+- `volume_prev` (integer)
+- `words` (integer)
+- `words_prev` (integer)
+
+</details>
+
+**Returns:** `list[SiteExplorerPaidPagesData]`
+
+<details>
+<summary>38 fields</summary>
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `ads_count` | `int \| None` | The number of unique ads with a page. |
+| `ads_count_diff` | `int` | The change in ads between your selected dates. |
+| `ads_count_prev` | `int \| None` | The number of ads on the comparison date. |
+| `keywords` | `int \| None` | The total number of keywords that your target ranks for in paid search results. |
+| `keywords_diff` | `int` | The change in keywords between your selected dates. |
+| `keywords_diff_percent` | `int` | The change in keywords between your selected dates, in percents. |
+| `keywords_merged` | `int` | The total number of keywords optimized for sorting. |
+| `keywords_prev` | `int \| None` | The keyword your target ranks for on the comparison date. |
+| `raw_url` | `str` | The ranking page URL in encoded format. |
+| `raw_url_prev` | `str \| None` | The ranking page URL on the comparison date in encoded format. |
+| `referring_domains` | `int \| None` | (5 units) The number of unique domains linking to a page. |
+| `status` | `StatusEnum` | The status of a page: the new page that just started to rank in paid results ("left"), the lost page that disappeared from paid results ("right"), or no change ("both"). |
+| `sum_traffic` | `int \| None` | (10 units) An estimation of the monthly paid search traffic that a page gets from all the keywords that it ranks for. |
+| `sum_traffic_merged` | `int` | (10 units) The paid traffic field optimized for sorting. |
+| `sum_traffic_prev` | `int \| None` | (10 units) The paid traffic on the comparison date. |
+| `top_keyword` | `str \| None` | The keyword that brings the most paid traffic to a page. |
+| `top_keyword_best_position` | `int \| None` | The ranking position that a page holds for its top keyword. |
+| `top_keyword_best_position_diff` | `int \| None` | The change in the top position between your selected dates. |
+| `top_keyword_best_position_kind` | `BestPositionKindEnum \| None` | The kind of the top position: organic, paid or a SERP feature. |
+| `top_keyword_best_position_kind_prev` | `BestPositionKindEnum \| None` | The kind of the top position on the comparison date. |
+| `top_keyword_best_position_prev` | `int \| None` | The top position on the comparison date. |
+| `top_keyword_best_position_title` | `str \| None` | The title displayed for the page in its top keyword's SERP. |
+| `top_keyword_best_position_title_prev` | `str \| None` | The title displayed for the page in its top keyword's SERP on the comparison date. |
+| `top_keyword_country` | `CountryEnum1 \| None` | The country in which a page ranks for its top keyword. |
+| `top_keyword_country_prev` | `CountryEnum1 \| None` | The country in which a page ranks for its top keyword on the comparison date. |
+| `top_keyword_prev` | `str \| None` | The keyword that brings the most paid traffic to a page on the comparison date. |
+| `top_keyword_volume` | `int \| None` | (10 units) An estimation of the average monthly number of searches for the top keyword over the latest month or over the latest known 12 months of data depending on the "volume_mode" parameter. |
+| `top_keyword_volume_prev` | `int \| None` | (10 units) The search volume on the comparison date. |
+| `traffic_diff` | `int` | The change in traffic between your selected dates. |
+| `traffic_diff_percent` | `int` | The change in traffic between your selected dates, in percents. |
+| `ur` | `float \| None` | URL Rating (UR) shows the strength of your target page’s backlink profile on a 100-point logarithmic scale. |
+| `url` | `str \| None` | The ranking page URL. |
+| `url_prev` | `str \| None` | The ranking page URL on the comparison date. |
+| `value` | `int \| None` | (10 units) The estimated cost of a page's monthly paid search traffic, in USD cents. |
+| `value_diff` | `int` | The change in traffic value between your selected dates. |
+| `value_diff_percent` | `int` | The change in traffic value between your selected dates, in percents. |
+| `value_merged` | `int \| None` | (10 units) The traffic value field optimized for sorting. |
+| `value_prev` | `int \| None` | (10 units) The traffic value on the comparison date. |
+
+</details>
+
+### `site_explorer_refdomains()`
+
+Refdomains.
+
+**Parameters:**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `timeout` | `int` | No | A manual timeout duration in seconds. |
+| `limit` | `int` | No | The number of results to return. |
+| `order_by` | `str` | No | A column to order results by. See response schema for valid column identifiers. |
+| `where` | `str` | No | Filter expression ([syntax](filter-syntax.md)). Filterable fields listed below. |
+| `select` | `SelectStr` | Yes | A comma-separated list of columns to return. See response schema for valid column identifiers. |
+| `protocol` | `ProtocolEnum` | No | The protocol of your target. |
+| `target` | `str` | Yes | The target of the search: a domain or a URL. |
+| `mode` | `ModeEnum` | No | The scope of the search based on the target you entered. |
+| `history` | `str` | No | A time frame to add lost backlinks to the report. Choose between `live` (no history), `since:<date>` (history since a specified date), and `all_time` (full history). The date should be in YYYY-MM-DD format. |
+
+<details>
+<summary>Filterable fields (47 fields)</summary>
+
+- `anchor` (string)
+- `discovered_status` (string)
+- `dofollow_linked_domains` (integer)
+- `dofollow_links` (integer)
+- `dofollow_refdomains` (integer)
+- `domain` (string)
+- `domain_rating` (float)
+- `drop_reason` (string)
+- `first_seen` (datetime)
+- `ip_source` (string)
+- `is_content` (boolean)
+- `is_dofollow` (boolean)
+- `is_homepage_link` (boolean)
+- `is_nofollow` (boolean)
+- `is_non_html` (boolean)
+- `is_root_domain` (boolean)
+- `is_spam` (boolean)
+- `is_sponsored` (boolean)
+- `is_ugc` (boolean)
+- `languages` (array(string))
+- `last_seen` (datetime)
+- `len_url_redirect` (integer)
+- `link_type` (string)
+- `linked_domains` (integer)
+- `links_external` (integer)
+- `links_to_target` (integer)
+- `lost_links` (integer)
+- `lost_reason` (string)
+- `new_links` (integer)
+- `noindex` (boolean)
+- `port_source` (integer)
+- `port_target` (integer)
+- `positions` (integer)
+- `positions_source_domain` (integer)
+- `powered_by` (array(string))
+- `refdomains` (integer)
+- `root_domain_name` (string)
+- `snippet_left` (string)
+- `snippet_right` (string)
+- `source_page_author` (string)
+- `title` (string)
+- `traffic_domain` (integer)
+- `traffic_page` (integer)
+- `url_from` (string)
+- `url_redirect` (array(url))
+- `url_redirect_with_target` (array(string))
+- `url_to` (string)
+
+</details>
+
+**Returns:** `list[SiteExplorerRefdomainsData]`
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `dofollow_linked_domains` | `int` | The number of unique root domains with dofollow links linked from the referring domain. |
+| `dofollow_links` | `int` | The number of links from the referring domain to your target that don't have the “nofollow” attribute. |
+| `dofollow_refdomains` | `int` | (5 units) The number of unique domains with dofollow links to the referring domain. |
+| `domain` | `str` | A referring domain that has at least one link to your target. |
+| `domain_rating` | `float` | The strength of a domain's backlink profile compared to the others in our database on a 100-point scale. |
+| `first_seen` | `str` | The date we first found a backlink to your target from the referring domain. |
+| `ip_source` | `str \| None` | The referring domain IP address. |
+| `is_root_domain` | `bool` | The domain name is a root domain name. |
+| `is_spam` | `bool` | Indicates whether the backlink comes from a known spammy domain. |
+| `last_seen` | `str \| None` | The date your target lost its last live backlink for the referring domain. |
+| `links_to_target` | `int` | The number of backlinks from the referring domain to your target. |
+| `lost_links` | `int` | The number of backlinks lost from the referring domain for the selected time period. |
+| `new_links` | `int` | The number of new backlinks found from the referring domain for the selected time period. |
+| `positions_source_domain` | `int` | The number of keywords that the referring domain ranks for in the top 100 positions. |
+| `traffic_domain` | `int` | (10 units) The referring domain's estimated monthly organic traffic from search. |
+
+### `site_explorer_refdomains_history()`
+
+Refdomains history.
+
+**Parameters:**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `history_grouping` | `HistoryGroupingEnum` | No | The time interval used to group historical data. |
+| `date_to` | `DateStr` | No | The end date of the historical period in YYYY-MM-DD format. |
+| `date_from` | `DateStr` | Yes | The start date of the historical period in YYYY-MM-DD format. |
+| `protocol` | `ProtocolEnum` | No | The protocol of your target. |
+| `target` | `str` | Yes | The target of the search: a domain or a URL. |
+| `mode` | `ModeEnum` | No | The scope of the search based on the target you entered. |
+
+**Returns:** `list[SiteExplorerRefdomainsHistoryData]`
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `date` | `str` | |
+| `refdomains` | `int` | (5 units) The total number of unique domains linking to your target. |
+
+### `site_explorer_top_pages()`
+
+Top pages.
+
+**Parameters:**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `timeout` | `int` | No | A manual timeout duration in seconds. |
+| `limit` | `int` | No | The number of results to return. |
+| `order_by` | `str` | No | A column to order results by. See response schema for valid column identifiers. |
+| `where` | `str` | No | Filter expression ([syntax](filter-syntax.md)). Filterable fields listed below. |
+| `select` | `SelectStr` | Yes | A comma-separated list of columns to return. See response schema for valid column identifiers. |
+| `protocol` | `ProtocolEnum` | No | The protocol of your target. |
+| `target` | `str` | Yes | The target of the search: a domain or a URL. |
+| `mode` | `ModeEnum` | No | The scope of the search based on the target you entered. |
+| `country` | `CountryEnum` | No | A two-letter country code (ISO 3166-1 alpha-2). |
+| `date_compared` | `DateStr` | No | A date to compare metrics with in YYYY-MM-DD format. |
+| `date` | `DateStr` | Yes | A date to report metrics on in YYYY-MM-DD format. |
+| `volume_mode` | `VolumeModeEnum` | No | The search volume calculation mode: monthly or average. It affects volume, traffic, and traffic value. |
+
+<details>
+<summary>Filterable fields (58 fields)</summary>
+
+- `cpc` (integer)
+- `cpc_prev` (integer)
+- `has_thumbnail` (boolean)
+- `has_thumbnail_prev` (boolean)
+- `has_video` (boolean)
+- `has_video_prev` (boolean)
+- `keyword` (string)
+- `keyword_difficulty` (integer)
+- `keyword_difficulty_prev` (integer)
+- `keyword_prev` (string)
+- `keywords` (integer)
+- `keywords_diff` (integer)
+- `keywords_diff_percent` (integer)
+- `keywords_merged` (integer)
+- `keywords_prev` (integer)
+- `page_type` (string)
+- `position` (integer)
+- `position_kind` (string)
+- `position_kind_prev` (string)
+- `position_prev` (integer)
+- `raw_url` (string)
+- `raw_url_prev` (string)
+- `referring_domains` (integer)
+- `serp_features` (array(string))
+- `serp_features_prev` (array(string))
+- `status` (string)
+- `sum_traffic` (integer)
+- `sum_traffic_merged` (integer)
+- `sum_traffic_prev` (integer)
+- `top_keyword` (string)
+- `top_keyword_best_position` (integer)
+- `top_keyword_best_position_diff` (integer)
+- `top_keyword_best_position_kind` (string)
+- `top_keyword_best_position_kind_prev` (string)
+- `top_keyword_best_position_prev` (integer)
+- `top_keyword_best_position_title` (string)
+- `top_keyword_best_position_title_prev` (string)
+- `top_keyword_country` (string)
+- `top_keyword_country_prev` (string)
+- `top_keyword_prev` (string)
+- `top_keyword_volume` (integer)
+- `top_keyword_volume_prev` (integer)
+- `traffic` (integer)
+- `traffic_diff` (integer)
+- `traffic_diff_percent` (integer)
+- `traffic_prev` (integer)
+- `ur` (float)
+- `url` (url)
+- `url_prev` (url)
+- `value` (integer)
+- `value_diff` (integer)
+- `value_diff_percent` (integer)
+- `value_merged` (integer)
+- `value_prev` (integer)
+- `volume` (integer)
+- `volume_prev` (integer)
+- `words` (integer)
+- `words_prev` (integer)
+
+</details>
+
+**Returns:** `list[SiteExplorerTopPagesData]`
+
+<details>
+<summary>36 fields</summary>
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `keywords` | `int \| None` | The total number of keywords that your target ranks for in the top 100 organic search results. |
+| `keywords_diff` | `int` | The change in keywords between your selected dates. |
+| `keywords_diff_percent` | `int` | The change in keywords between your selected dates, in percents. |
+| `keywords_merged` | `int` | The total number of keywords optimized for sorting. |
+| `keywords_prev` | `int \| None` | The keyword your target ranks for on the comparison date. |
+| `page_type` | `str \| None` | Comma-separated list of AI-predicted hierarchical page type paths. Each value is a slash-prefixed path (e.g. /Article/How_to). |
+| `raw_url` | `str` | The ranking page URL in encoded format. |
+| `raw_url_prev` | `str \| None` | The ranking page URL on the comparison date in encoded format. |
+| `referring_domains` | `int \| None` | (5 units) The number of unique domains linking to a page. |
+| `status` | `StatusEnum` | The status of a page: the new page that just started to rank ("left"), the lost page that disappeared from search results ("right"), or no change ("both"). |
+| `sum_traffic` | `int \| None` | (10 units) An estimation of the monthly organic search traffic that a page gets from all the keywords that it ranks for. |
+| `sum_traffic_merged` | `int` | (10 units) The traffic field optimized for sorting. |
+| `sum_traffic_prev` | `int \| None` | (10 units) The traffic on the comparison date. |
+| `top_keyword` | `str \| None` | The keyword that brings the most organic traffic to a page. |
+| `top_keyword_best_position` | `int \| None` | The ranking position that a page holds for its top keyword. |
+| `top_keyword_best_position_diff` | `int \| None` | The change in the top position between your selected dates. |
+| `top_keyword_best_position_kind` | `BestPositionKindEnum \| None` | The kind of the top position: organic, paid or a SERP feature. |
+| `top_keyword_best_position_kind_prev` | `BestPositionKindEnum \| None` | The kind of the top position on the comparison date. |
+| `top_keyword_best_position_prev` | `int \| None` | The top position on the comparison date. |
+| `top_keyword_best_position_title` | `str \| None` | The title displayed for the page in its top keyword's SERP. |
+| `top_keyword_best_position_title_prev` | `str \| None` | The title displayed for the page in its top keyword's SERP on the comparison date. |
+| `top_keyword_country` | `CountryEnum1 \| None` | The country in which a page ranks for its top keyword. |
+| `top_keyword_country_prev` | `CountryEnum1 \| None` | The country in which a page ranks for its top keyword on the comparison date. |
+| `top_keyword_prev` | `str \| None` | The keyword that brings the most organic traffic to a page on the comparison date. |
+| `top_keyword_volume` | `int \| None` | (10 units) An estimation of the average monthly number of searches for the top keyword over the latest month or over the latest known 12 months of data depending on the "volume_mode" parameter. |
+| `top_keyword_volume_prev` | `int \| None` | (10 units) The search volume on the comparison date. |
+| `traffic_diff` | `int` | The change in traffic between your selected dates. |
+| `traffic_diff_percent` | `int` | The change in traffic between your selected dates, in percents. |
+| `ur` | `float \| None` | URL Rating (UR) shows the strength of your target page’s backlink profile on a 100-point logarithmic scale. |
+| `url` | `str \| None` | The ranking page URL. |
+| `url_prev` | `str \| None` | The ranking page URL on the comparison date. |
+| `value` | `int \| None` | (10 units) The estimated value of a page's monthly organic search traffic, in USD cents. |
+| `value_diff` | `int` | The change in traffic value between your selected dates. |
+| `value_diff_percent` | `int` | The change in traffic value between your selected dates, in percents. |
+| `value_merged` | `int \| None` | (10 units) The traffic value field optimized for sorting. |
+| `value_prev` | `int \| None` | (10 units) The traffic value on the comparison date. |
+
+</details>
+
+### `site_explorer_total_search_volume_history()`
+
+Total search volume history.
+
+**Parameters:**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `volume_mode` | `VolumeModeEnum` | No | The search volume calculation mode: monthly or average. It affects volume, traffic, and traffic value. |
+| `top_positions` | `ViewForEnum` | No | The number of top organic search positions to consider when calculating total search volume. |
+| `history_grouping` | `HistoryGroupingEnum` | No | The time interval used to group historical data. |
+| `date_to` | `DateStr` | No | The end date of the historical period in YYYY-MM-DD format. |
+| `date_from` | `DateStr` | Yes | The start date of the historical period in YYYY-MM-DD format. |
+| `country` | `CountryEnum` | No | A two-letter country code (ISO 3166-1 alpha-2). |
+| `protocol` | `ProtocolEnum` | No | The protocol of your target. |
+| `target` | `str` | Yes | The target of the search: a domain or a URL. |
+| `mode` | `ModeEnum` | No | The scope of the search based on the target you entered. |
+
+**Returns:** `list[SiteExplorerTotalSearchVolumeHistoryData]`
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `date` | `str` | |
+| `total_search_volume` | `int` | (10 units) The total search volume of keywords for which your target ranks within the specified `top_positions` in the search results. |
+
+### `site_explorer_url_rating_history()`
+
+URL Rating history.
+
+**Parameters:**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `history_grouping` | `HistoryGroupingEnum` | No | The time interval used to group historical data. |
+| `date_to` | `DateStr` | No | The end date of the historical period in YYYY-MM-DD format. |
+| `date_from` | `DateStr` | Yes | The start date of the historical period in YYYY-MM-DD format. |
+| `target` | `str` | Yes | The target of the search: a domain or a URL. |
+
+**Returns:** `list[SiteExplorerUrlRatingHistoryData]`
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `date` | `str` | |
+| `url_rating` | `float` | The strength of your target page's backlink profile compared to the other websites in our database on a 100-point logarithmic scale. |

--- a/.claude/skills/ahrefs-research/references/filter-syntax.md
+++ b/.claude/skills/ahrefs-research/references/filter-syntax.md
@@ -1,0 +1,112 @@
+
+# Filter syntax
+
+Some API endpoints accept a `where` parameter, which applies a filter to the result set.
+
+The following sections give some examples of filter usage and a full syntax reference.
+
+## Examples
+
+
+> For more real world examples, try applying some filters to a report on ahrefs.com using our visual interface, and then press the `API {}` button to view the `where` parameter of the generated API v3 query.
+
+
+Field "foo" equals 3:
+
+```json
+{ "field": "foo", "is": ["eq", 3] }
+```
+
+For fields of type object, use dot notation to refer to nested fields. Field "bar", nested under field "foo", equals 3:
+
+```json
+{ "field": "foo.bar", "is": ["eq", 3] }
+```
+
+The integer field "foo" equals 3 and the integer field "bar" is less than 10:
+
+```json
+{
+    "and": [
+        { "field": "foo", "is": ["eq", 3] },
+        { "field": "bar", "is": ["lt", 10] }
+    ]
+}
+```
+
+Either the uppercased value of the string field "foo" equals "AHREFS", or all string elements in the array field "bar" have the prefix "Ahrefs" and suffix "seo".
+
+```json
+{
+  "or": [
+    {
+      "field": "foo",
+      "modifier": "uppercase",
+      "is": ["eq", "AHREFS"]
+    },
+    {
+      "field": "bar",
+      "list_is": {
+        "and": [
+          ["prefix", "Ahrefs"],
+          ["suffix", "seo"],
+        ]
+      }
+    }
+  ]
+}
+```
+
+## Language reference
+
+The filter syntax is described by the following grammar, expressed in [BNF](https://en.wikipedia.org/wiki/Backus%E2%80%93Naur_form)-style notation. 
+
+A term enclosed in angle brackets `<` and `>` denotes a symbol.  A symbol followed by a `+` denotes a non-empty array containing the symbol. A `?` preceding an object field indicates that the field is optional.
+
+The two terminal symbols are defined as follows:
+
+- `<field_alias>` A filter field alias. See the particular endpoint's documentation for the list of valid aliases. Note that the `select` and `where` parameters may accept different aliases.
+- `<value>` A JSON value. It should match the type of the field (or of the field's modifier, if one is present).
+
+Permitted patterns in regex filter expressions differs by tool.
+- Keywords Explorer: Only `*` as a wildcard operator.
+- Site Explorer: [RE2](https://github.com/google/re2/wiki/Syntax) syntax.
+
+```json
+<bool_filter> ::= { "and" : <bool_filter>+ }
+              |   { "or" : <bool_filter>+ }
+              |   { "not" : <bool_filter> }
+              |   <expr>
+
+<expr> ::= {
+             "field" : <field_alias>,
+             ? "is": <condition>,
+             ? "list_is": <list_condition>
+           }
+
+<condition> ::= [ "eq", <value> ]
+            |   [ "neq", <value> ]
+            |   [ "gt", <value> ]
+            |   [ "gte", <value> ]
+            |   [ "lt", <value> ]
+            |   [ "lte", <value> ]
+            |   [ "substring", <value> ]
+            |   [ "isubstring", <value> ]
+            |   [ "phrase_match", <value> ]
+            |   [ "iphrase_match", <value> ]
+            |   [ "prefix", <value> ]
+            |   [ "suffix", <value> ]
+            |   [ "regex", <value> ]
+            |   "empty"
+            |   "is_null"
+
+<condition_bool_filter> ::= { "and" : <condition_bool_filter>+ }
+                        |   { "or" : <condition_bool_filter>+ }
+                        |   { "not" : <condition_bool_filter> }
+                        |   <condition>
+
+<list_condition> ::= { "any" : <condition_bool_filter> }
+                 |   { "all" : <condition_bool_filter> }
+```
+
+

--- a/.claude/skills/ai-image-gen/SKILL.md
+++ b/.claude/skills/ai-image-gen/SKILL.md
@@ -1,0 +1,137 @@
+---
+name: generate-image
+description: Generate images using AI (OpenAI GPT Image or Stability AI). Use when the user asks to generate an image, create an AI image, make an illustration, or produce artwork from a text prompt.
+argument-hint: [prompt description]
+allowed-tools: Bash(*), Read, Write
+---
+
+# AI Image Generation
+
+Generate images from text prompts using OpenAI GPT Image (gpt-image-2 / gpt-image-1 / variants) or Stability AI (SD 3.5 Large).
+
+## Tool Location
+
+- Script: `~/.agents/tools/generate-image.py`
+- Env file: `~/.agents/tools/.env` (contains `OPENAI_API_KEY` and `STABILITY_API_KEY`)
+
+## Available OpenAI image models (verified live via `/v1/models` 2026-05-15)
+
+| Model ID | Notes |
+|---|---|
+| `gpt-image-2` | **Flagship.** Released 2026-04-21. Best prompt adherence, best photorealism. Default when image quality matters. |
+| `gpt-image-2-2026-04-21` | Pinned dated variant of gpt-image-2 |
+| `gpt-image-1.5` | Intermediate release between 1 and 2 |
+| `gpt-image-1-mini` | Smaller/cheaper gpt-image-1 variant — use for batch/draft generation where cost matters |
+| `gpt-image-1` | Original gpt-image. Still works; superseded by gpt-image-2. |
+| `chatgpt-image-latest` | Always-current alias of the model ChatGPT.com uses (currently gpt-image-2-class). Use when you want "whatever ChatGPT uses today" |
+| `dall-e-3` | Legacy fallback. Different quality semantics (standard/hd, not low/medium/high). |
+
+Pass any of these to `--model`. The script branches on `gpt-image*` for the quality/format handling, so all gpt-image-* variants work out of the box.
+
+**Default in the script is now `gpt-image-2`** (the flagship) — pass `--model gpt-image-1-mini` for cheap batch/draft work.
+
+## Quick Usage
+
+### Generate with OpenAI gpt-image-2 (flagship)
+
+```bash
+python ~/.agents/tools/generate-image.py \
+  --prompt "a sunset over mountains, oil painting style" \
+  --output ./sunset.png \
+  --model gpt-image-2 \
+  --quality high
+```
+
+### Generate with default (gpt-image-2)
+
+```bash
+python ~/.agents/tools/generate-image.py \
+  --prompt "a sunset over mountains, oil painting style" \
+  --output ./sunset.png
+```
+
+### High quality
+
+```bash
+python ~/.agents/tools/generate-image.py \
+  --prompt "modern logo design for a tech company" \
+  --output ./logo.png \
+  --size 1024x1024 \
+  --quality high
+```
+
+### Wide format (good for blog covers, banners)
+
+```bash
+python ~/.agents/tools/generate-image.py \
+  --prompt "abstract digital art with blue tones" \
+  --output ./banner.png \
+  --size 1536x1024
+```
+
+### Tall format (good for mobile, stories)
+
+```bash
+python ~/.agents/tools/generate-image.py \
+  --prompt "portrait of a futuristic city" \
+  --output ./city.png \
+  --size 1024x1536
+```
+
+### Transparent background (icons, logos)
+
+```bash
+python ~/.agents/tools/generate-image.py \
+  --prompt "a minimalist cat icon, flat design" \
+  --output ./icon.png \
+  --background transparent
+```
+
+### Generate with Stability AI (SD 3.5 Large)
+
+```bash
+python ~/.agents/tools/generate-image.py \
+  --prompt "watercolor painting of a garden" \
+  --output ./garden.png \
+  --provider stability
+```
+
+## CLI Options
+
+| Option | Description |
+|--------|-------------|
+| `--prompt, -p` | **(Required)** Text prompt describing the desired image |
+| `--output, -o` | **(Required)** Output file path |
+| `--provider` | `openai` (default) or `stability` |
+| `--size` | Image size for OpenAI: `1024x1024` (default), `1536x1024` (wide), `1024x1536` (tall) |
+| `--quality` | OpenAI quality: `low`, `medium` (default), or `high` |
+| `--background` | OpenAI background: `auto` (default), `transparent`, or `opaque` |
+| `--model` | Override model (default: `gpt-image-2` for OpenAI, `sd3.5-large` for Stability) |
+
+## Provider Comparison
+
+| Feature | OpenAI gpt-image-2 | OpenAI gpt-image-1 | Stability AI SD 3.5 |
+|---------|--------------------|--------------------|---------------------|
+| Released | 2026-04-21 | 2025 | — |
+| Prompt adherence | Best | Excellent | Good |
+| Size options | 1024x1024, 1536x1024, 1024x1536 | 1024x1024, 1536x1024, 1024x1536 | 1024x1024 |
+| Quality options | low, medium, high | low, medium, high | N/A |
+| Transparent bg | Yes | Yes | No |
+| Style | Photorealistic + artistic | Photorealistic + artistic | Artistic + photorealistic |
+| Cost per image (high) | Higher than 1 | Baseline | N/A |
+
+## Dependencies
+
+- `requests` (for API calls)
+
+Install if needed:
+```bash
+pip install requests
+```
+
+## Output
+
+The script prints:
+- The provider and model used
+- The prompt (and revised prompt if applicable)
+- The saved file path

--- a/.claude/skills/apollo-outreach/SKILL.md
+++ b/.claude/skills/apollo-outreach/SKILL.md
@@ -1,0 +1,173 @@
+---
+name: apollo-outreach
+description: Research and enrich B2B leads using the Apollo.io API. Use when the user says "find leads", "prospect research", "company enrichment", "find decision makers", "B2B leads", "lead research", "enrich contacts", "find VP of marketing at", or asks about finding people at specific companies or in specific roles.
+---
+
+# Apollo.io B2B Lead Research Skill
+
+You are a B2B sales intelligence expert. Use the Apollo.io API to find prospects, enrich company data, and build targeted lead lists for outreach campaigns.
+
+## Prerequisites
+
+This skill requires `APOLLO_API_KEY`. Check for it in environment variables or `~/.claude/.env.global`. If not found, inform the user:
+
+```
+This skill requires an Apollo.io API key. Set it via:
+  export APOLLO_API_KEY=your_key_here
+Or add it to ~/.claude/.env.global
+
+Get your API key at: https://app.apollo.io/#/settings/integrations/api
+```
+
+## API Reference
+
+Base URL: `https://api.apollo.io`
+Auth: `X-Api-Key` header or `api_key` query parameter.
+Rate limit: ~600 requests/hour (varies by plan).
+
+### People Search
+
+Find prospects by role, company, location, and more:
+
+```bash
+curl -s -X POST "https://api.apollo.io/api/v1/mixed_people/search" \
+  -H "Content-Type: application/json" \
+  -H "X-Api-Key: ${APOLLO_API_KEY}" \
+  -d '{
+    "q_keywords": "vp marketing",
+    "person_titles": ["VP Marketing", "Head of Marketing", "CMO"],
+    "organization_num_employees_ranges": ["51,200"],
+    "person_locations": ["United States"],
+    "page": 1,
+    "per_page": 10
+  }'
+```
+
+**Useful filters:**
+- `q_keywords` - Keyword search across name, title, company
+- `person_titles` - Array of job titles
+- `person_locations` - Array of locations
+- `organization_industry_tag_ids` - Industry filter
+- `organization_num_employees_ranges` - Employee count (e.g., "1,10", "11,50", "51,200", "201,1000", "1001,5000")
+- `q_organization_domains` - Search within specific company domains
+
+### Organization Enrichment
+
+Get detailed company info from a domain:
+
+```bash
+curl -s -X POST "https://api.apollo.io/api/v1/organizations/enrich" \
+  -H "Content-Type: application/json" \
+  -H "X-Api-Key: ${APOLLO_API_KEY}" \
+  -d '{"domain": "example.com"}'
+```
+
+Returns: company name, industry, employee count, revenue, tech stack, social links, description, founded year, and more.
+
+### Bulk Organization Lookup
+
+```bash
+curl -s -X POST "https://api.apollo.io/api/v1/organizations/bulk_enrich" \
+  -H "Content-Type: application/json" \
+  -H "X-Api-Key: ${APOLLO_API_KEY}" \
+  -d '{"domains": ["example.com", "company2.com", "company3.com"]}'
+```
+
+### People Enrichment
+
+Enrich a contact by email:
+
+```bash
+curl -s -X POST "https://api.apollo.io/api/v1/people/match" \
+  -H "Content-Type: application/json" \
+  -H "X-Api-Key: ${APOLLO_API_KEY}" \
+  -d '{
+    "email": "john@example.com",
+    "reveal_personal_emails": false,
+    "reveal_phone_number": false
+  }'
+```
+
+## Lead Research Process
+
+### Step 1: Define ICP (Ideal Customer Profile)
+
+Ask or infer:
+- **Target titles:** What roles are you selling to?
+- **Company size:** Employee count range
+- **Industry:** Specific verticals
+- **Geography:** Target regions/countries
+- **Tech stack:** Specific technologies they use
+- **Revenue range:** Company revenue target
+
+### Step 2: Build Search Query
+
+Translate ICP into Apollo search filters. Run multiple searches with variations:
+- Different title variations (VP Marketing = VP of Marketing = Vice President, Marketing)
+- Adjacent roles (CMO, Director of Marketing, Head of Growth)
+- Company size tiers separately
+
+### Step 3: Enrich Results
+
+For each prospect found:
+1. Note their current title, company, and location
+2. Enrich their company domain for additional context
+3. Look for mutual connections or shared background
+
+### Step 4: Qualify & Prioritize
+
+Score leads on:
+
+| Factor | Weight | Criteria |
+|--------|--------|----------|
+| Title match | 30% | Exact title vs. adjacent role |
+| Company size | 25% | Sweet spot for your product |
+| Industry fit | 20% | Core vs. adjacent industry |
+| Recency | 15% | How recently they started the role |
+| Signals | 10% | Hiring, funding, tech stack changes |
+
+### Step 5: Output Lead List
+
+Format results as:
+
+```markdown
+# Lead Research Report: {ICP Description}
+**Date:** {date}
+**Prospects Found:** {count}
+**Companies Represented:** {count}
+
+## Top Prospects
+
+| # | Name | Title | Company | Employees | Industry | Score |
+|---|------|-------|---------|-----------|----------|-------|
+| 1 | {name} | {title} | {company} | {size} | {industry} | {score}/100 |
+
+## Company Insights
+
+### {Company Name}
+- **Domain:** {domain}
+- **Industry:** {industry}
+- **Employees:** {count}
+- **Revenue:** {range}
+- **Tech Stack:** {technologies}
+- **Key Contacts Found:** {count}
+
+## Outreach Recommendations
+
+### Personalization Angles
+1. {Specific angle based on company data}
+2. {Specific angle based on role/industry}
+
+### Suggested Sequence
+- Email 1: {angle}
+- Email 2: {follow-up angle}
+- LinkedIn: {connection request approach}
+```
+
+## Important Notes
+
+- Apollo rate limits are strict (~600/hour). Batch requests and cache results.
+- Some endpoints require a paid plan. Handle 403 responses gracefully.
+- Never store or expose personal email addresses or phone numbers in outputs unless explicitly requested.
+- Respect opt-out lists and GDPR/CAN-SPAM compliance.
+- Use enrichment data for personalization, not for unsolicited spam.

--- a/.claude/skills/backlink-audit/SKILL.md
+++ b/.claude/skills/backlink-audit/SKILL.md
@@ -1,0 +1,377 @@
+---
+name: backlink-audit
+description: Audit a domain's backlink profile using the SemRush API. Use when the user says "audit backlinks", "check my backlinks", "backlink analysis", "link profile", "toxic links", "disavow", "link building opportunities", "referring domains", "anchor text", or asks about a site's link authority.
+---
+
+# Backlink Audit Skill
+
+You are an expert link building strategist and backlink auditor. Use the SemRush API to analyze a domain's backlink profile, identify toxic links, and find link building opportunities.
+
+## Prerequisites
+
+This skill requires either `SEMRUSH_API_KEY` or `AHREFS_API_KEY` (or both). Check for them in environment variables or in `~/.claude/.env.global`. Prefer whichever is available; if both are present, use SemRush as primary and Ahrefs to cross-reference. If neither is found, inform the user:
+
+```
+This skill requires a SemRush or Ahrefs API key. Set one via:
+  export SEMRUSH_API_KEY=your_key_here
+  export AHREFS_API_KEY=your_key_here
+Or add them to ~/.claude/.env.global
+```
+
+## SemRush Backlink API Endpoints
+
+Use `curl` via the Bash tool. Base URL: `https://api.semrush.com/analytics/v1/`
+
+### Core Endpoints
+
+**1. Backlinks Overview**
+```
+https://api.semrush.com/analytics/v1/?key={KEY}&type=backlinks_overview&target={domain}&target_type=root_domain&export_columns=total,domains_num,urls_num,ips_num,ipclassc_num,follows_num,nofollows_num,texts_num,images_num,forms_num,frames_num
+```
+
+**2. Backlinks List (individual links)**
+```
+https://api.semrush.com/analytics/v1/?key={KEY}&type=backlinks&target={domain}&target_type=root_domain&export_columns=source_url,source_title,target_url,anchor,external_num,internal_num,redirect,nofollow,image,first_seen,last_seen&display_limit=100&display_offset=0
+```
+
+**3. Referring Domains**
+```
+https://api.semrush.com/analytics/v1/?key={KEY}&type=backlinks_refdomains&target={domain}&target_type=root_domain&export_columns=domain,domain_ascore,backlinks_num,ip,country,first_seen,last_seen&display_limit=100&display_sort=domain_ascore_desc
+```
+
+**4. Anchor Text Distribution**
+```
+https://api.semrush.com/analytics/v1/?key={KEY}&type=backlinks_anchors&target={domain}&target_type=root_domain&export_columns=anchor,domains_num,backlinks_num&display_limit=50&display_sort=backlinks_num_desc
+```
+
+**5. Indexed Pages (pages receiving links)**
+```
+https://api.semrush.com/analytics/v1/?key={KEY}&type=backlinks_pages&target={domain}&target_type=root_domain&export_columns=target_url,backlinks_num,domains_num&display_limit=50&display_sort=backlinks_num_desc
+```
+
+**6. Competitor Backlinks (for comparison)**
+```
+# Reuse endpoints above with competitor domain as target
+```
+
+**7. Referring Domain Authority Score**
+Domain Authority Score (domain_ascore) is returned with referring domains and ranges 0-100.
+
+## Alternative: Ahrefs API
+
+If `AHREFS_API_KEY` is available (and SemRush is not), use the Ahrefs API v3 endpoints below. All endpoints require the Bearer token header.
+
+### Ahrefs Core Endpoints
+
+**1. Backlinks Overview (Stats)**
+```bash
+# Ahrefs backlinks overview
+curl -s "https://api.ahrefs.com/v3/site-explorer/backlinks-stats?target={domain}&output=json" \
+  -H "Authorization: Bearer ${AHREFS_API_KEY}"
+```
+Returns: `live_backlinks`, `all_time_backlinks`, `live_refdomains`, `all_time_refdomains`, `live_refpages`, `dofollow_backlinks`, `nofollow_backlinks`.
+
+**2. Referring Domains**
+```bash
+# Ahrefs referring domains
+curl -s "https://api.ahrefs.com/v3/site-explorer/refdomains?target={domain}&output=json&limit=100" \
+  -H "Authorization: Bearer ${AHREFS_API_KEY}"
+```
+Returns: Array of referring domains with `domain`, `domain_rating`, `backlinks`, `first_seen`, `last_seen`, `dofollow`, `nofollow`. Sort by `domain_rating` to see highest-authority referrers first.
+
+**3. Backlinks List**
+```bash
+curl -s "https://api.ahrefs.com/v3/site-explorer/backlinks?target={domain}&output=json&limit=100&mode=subdomains" \
+  -H "Authorization: Bearer ${AHREFS_API_KEY}"
+```
+Returns: Individual backlinks with `url_from`, `url_to`, `anchor`, `domain_rating`, `first_seen`, `last_seen`, `nofollow`, `redirect`, `edu`, `gov`.
+
+**4. Anchors**
+```bash
+curl -s "https://api.ahrefs.com/v3/site-explorer/anchors?target={domain}&output=json&limit=50&mode=subdomains" \
+  -H "Authorization: Bearer ${AHREFS_API_KEY}"
+```
+Returns: Anchor text distribution with `anchor`, `backlinks`, `refdomains`.
+
+**5. Pages by Backlinks (Best by Links)**
+```bash
+curl -s "https://api.ahrefs.com/v3/site-explorer/best-by-links?target={domain}&output=json&limit=50" \
+  -H "Authorization: Bearer ${AHREFS_API_KEY}"
+```
+Returns: Top linked pages with `url`, `backlinks`, `refdomains`, `dofollow`.
+
+**6. Domain Rating**
+```bash
+curl -s "https://api.ahrefs.com/v3/site-explorer/domain-rating?target={domain}&output=json" \
+  -H "Authorization: Bearer ${AHREFS_API_KEY}"
+```
+Returns: `domain_rating` (0-100) and `ahrefs_rank`.
+
+### Ahrefs vs. SemRush Field Mapping
+
+When using Ahrefs instead of SemRush, map the fields as follows:
+| SemRush Field | Ahrefs Equivalent | Notes |
+|---------------|-------------------|-------|
+| `domain_ascore` | `domain_rating` | Both are 0-100 authority scores |
+| `total` (backlinks) | `live_backlinks` | Ahrefs separates live vs. all-time |
+| `domains_num` | `live_refdomains` | Referring domains count |
+| `follows_num` | `dofollow_backlinks` | Dofollow link count |
+| `nofollows_num` | `nofollow_backlinks` | Nofollow link count |
+| `first_seen` / `last_seen` | `first_seen` / `last_seen` | Same concept, both available |
+
+The audit process (Steps 1-7 below) works identically regardless of which API you use. Simply substitute the corresponding endpoints and field names.
+
+## Audit Process
+
+### Step 1: Pull Backlink Overview
+
+Fetch the backlink overview and summarize:
+
+```markdown
+## Backlink Profile Summary: {domain}
+
+| Metric | Value |
+|--------|-------|
+| Total Backlinks | {total} |
+| Referring Domains | {domains_num} |
+| Referring IPs | {ips_num} |
+| Referring Subnets (Class C) | {ipclassc_num} |
+| Follow Links | {follows_num} ({%}) |
+| Nofollow Links | {nofollows_num} ({%}) |
+| Text Links | {texts_num} ({%}) |
+| Image Links | {images_num} ({%}) |
+| Backlink-to-Domain Ratio | {total/domains_num} |
+```
+
+### Step 2: Analyze Referring Domains
+
+Pull the top referring domains sorted by authority score. Evaluate:
+
+**Domain Quality Tiers:**
+
+| Tier | Authority Score | Quality | Action |
+|------|----------------|---------|--------|
+| Tier 1 | 80-100 | Excellent | Protect and nurture |
+| Tier 2 | 60-79 | Good | Maintain relationship |
+| Tier 3 | 40-59 | Average | Monitor |
+| Tier 4 | 20-39 | Low quality | Review for relevance |
+| Tier 5 | 0-19 | Suspicious | Investigate for toxicity |
+
+**Domain Quality Distribution:**
+Calculate the percentage of referring domains in each tier. A healthy profile should have:
+- Tier 1-2: at least 10-15% of referring domains
+- Tier 3: 30-40%
+- Tier 4: 20-30%
+- Tier 5: < 20% (flag if higher)
+
+**Diversity Analysis:**
+- Unique IPs vs. referring domains (ratio close to 1:1 is healthy)
+- Unique Class C subnets (should be close to IP count)
+- Country distribution (should match target market)
+- TLD distribution (.com, .org, .edu, .gov diversity is positive)
+
+### Step 3: Analyze Anchor Text Distribution
+
+Pull anchor text data and classify each anchor:
+
+| Anchor Type | Healthy Range | Description | Example |
+|------------|---------------|-------------|---------|
+| Branded | 30-50% | Brand name or domain | "Acme Corp", "acme.com" |
+| Naked URL | 10-20% | Raw URL | "https://acme.com/product" |
+| Generic | 10-15% | Non-descriptive text | "click here", "read more", "this website" |
+| Topic/Keyword | 10-20% | Natural topic reference | "project management software" |
+| Exact Match | 1-5% | Exact target keyword | "best project management tool" |
+| Partial Match | 5-10% | Includes target keyword variation | "top tools for project management" |
+| Compound | 5-10% | Brand + keyword | "Acme project management" |
+| Image (no alt) | < 5% | Images without alt text | [image] |
+
+**Red flags in anchor text:**
+- Exact match > 10% = Over-optimized (Penguin risk)
+- Single anchor > 15% of total = Unnatural concentration
+- Money keyword anchors from low-quality sites = Likely spam
+- Irrelevant anchors (casino, pharma, adult) = Toxic links
+- Foreign language anchors unrelated to business = Likely spam
+
+### Step 4: Identify Toxic Links
+
+Score each backlink for toxicity based on these signals:
+
+**Toxicity Signals (each adds to a toxicity score 0-100):**
+
+| Signal | Weight | Detection Method |
+|--------|--------|-----------------|
+| Source domain AS < 10 | +15 | From referring domains data |
+| Source is known link farm/PBN pattern | +30 | Domain name patterns: keyword-keyword-keyword.com, random strings |
+| Anchor text is exact match keyword | +10 | From anchor text analysis |
+| Source page has 100+ external links | +20 | From external_num column |
+| Source is irrelevant niche | +15 | Compare source domain topic to target |
+| Source has no organic traffic | +15 | Check via domain_organic if budget allows |
+| Link from sitewide (footer/sidebar) | +10 | Same domain, many links to same target |
+| Link from non-indexed page | +20 | Page not in Google (manual check) |
+| Redirect chain to target | +10 | From redirect column |
+| Foreign language + irrelevant | +15 | From anchor text + domain TLD |
+
+**Toxicity Rating:**
+- 0-20: Clean - no action needed
+- 21-40: Monitor - watch for changes
+- 41-60: Suspicious - investigate further
+- 61-80: Likely toxic - consider disavow
+- 81-100: Toxic - add to disavow list
+
+### Step 5: Link Velocity Analysis
+
+Analyze the `first_seen` and `last_seen` dates to determine:
+
+- **Monthly new links** over the past 12 months
+- **Monthly lost links** (links where last_seen is in the past)
+- **Net link growth rate**
+- **Velocity spikes** (unnatural bursts of links)
+
+**Healthy velocity patterns:**
+- Steady, gradual growth = Natural
+- Correlated with content publishing = Natural
+- Sudden spike then flat = Likely campaign or mention (investigate)
+- Massive spike from low-quality domains = Negative SEO attack (flag immediately)
+- Declining trend = Losing links, need outreach
+
+### Step 6: Competitor Comparison
+
+Pull backlink overview for 2-3 competitors and compare:
+
+```markdown
+## Competitor Backlink Comparison
+
+| Metric | {Your Domain} | {Competitor 1} | {Competitor 2} | {Competitor 3} |
+|--------|--------------|----------------|----------------|----------------|
+| Total Backlinks | | | | |
+| Referring Domains | | | | |
+| Avg. Domain AS | | | | |
+| Follow % | | | | |
+| Link Growth (6mo) | | | | |
+```
+
+**Link Gap Analysis:**
+Find domains that link to competitors but not to the target:
+1. Pull top 100 referring domains for each competitor
+2. Filter out domains already linking to the target
+3. Sort by authority score
+4. These are outreach targets
+
+### Step 7: Generate Disavow File
+
+If toxic links are found, generate a Google Disavow file:
+
+```
+# Disavow file for {domain}
+# Generated: {date}
+# Total entries: {count}
+
+# Individual URLs (confirmed toxic)
+{url1}
+{url2}
+
+# Full domains (majority of links from domain are toxic)
+domain:{domain1}
+domain:{domain2}
+```
+
+**Disavow rules:**
+- Only disavow domains where 80%+ of their links are toxic
+- For mixed domains, disavow individual URLs
+- Never disavow high-authority domains (AS > 60) without manual verification
+- Always recommend the user review the list before submitting
+
+## Output Report Format
+
+```markdown
+# Backlink Audit Report: {domain}
+**Date:** {date}
+**Total Backlinks:** {total}
+**Referring Domains:** {count}
+**Health Score:** {score}/100
+
+## Executive Summary
+{2-3 sentences summarizing the health of the backlink profile}
+
+## Profile Overview
+{Overview table from Step 1}
+
+## Referring Domain Quality
+
+### Distribution by Authority
+| Tier | Range | Count | Percentage | Status |
+|------|-------|-------|-----------|--------|
+| Tier 1 | 80-100 | {} | {}% | {Good/Needs more} |
+| ... | ... | ... | ... | ... |
+
+### Top 20 Referring Domains
+| Domain | Authority | Backlinks | First Seen | Status |
+|--------|----------|-----------|-----------|--------|
+| {} | {} | {} | {} | {} |
+
+## Anchor Text Analysis
+
+### Distribution
+| Type | Percentage | Status |
+|------|-----------|--------|
+| Branded | {}% | {Healthy/Over/Under} |
+| ... | ... | ... |
+
+### Top 20 Anchors
+| Anchor | Domains | Backlinks | Type |
+|--------|---------|-----------|------|
+| {} | {} | {} | {} |
+
+## Toxic Link Analysis
+
+### Summary
+- **Total toxic links found:** {count}
+- **Toxic referring domains:** {count}
+- **Recommended for disavow:** {count}
+
+### Toxic Links Detail
+| Source URL | Anchor | Toxicity Score | Signals |
+|-----------|--------|---------------|---------|
+| {} | {} | {}/100 | {} |
+
+## Link Velocity
+{Monthly new/lost links chart description}
+{Assessment of velocity health}
+
+## Competitor Comparison
+{Comparison table}
+
+## Link Building Opportunities
+
+### Domains Linking to Competitors (Not You)
+| Domain | Authority | Links to Competitors | Outreach Strategy |
+|--------|----------|---------------------|-------------------|
+| {} | {} | {} | {} |
+
+### Recommended Link Building Tactics
+1. **{Tactic}** - {Description, estimated effort, expected results}
+2. ...
+
+## Action Items
+
+### Immediate (This Week)
+1. {Specific action}
+
+### Short Term (This Month)
+1. {Specific action}
+
+### Ongoing
+1. {Specific action}
+
+## Disavow File
+{If applicable, include the generated disavow file content}
+```
+
+## Notes
+
+- SemRush API has rate limits. Space out calls if making many requests.
+- Backlink data may be up to 30 days old. Note this in the report.
+- Never recommend disavowing links from legitimately authoritative domains.
+- For new sites (< 6 months), a small backlink profile is normal, not a problem.
+- Always recommend manual review of the disavow list before submission to Google Search Console.
+- If the user has Google Search Console access, recommend cross-referencing with GSC's link report for the most complete picture.

--- a/.claude/skills/bluesky/SKILL.md
+++ b/.claude/skills/bluesky/SKILL.md
@@ -1,0 +1,199 @@
+---
+name: bluesky
+description: Create and manage content for Bluesky social network. Use when the user says "Bluesky post", "post to Bluesky", "Bluesky content", "Bluesky strategy", "AT Protocol", or asks about creating content for or engaging on Bluesky.
+---
+
+# Bluesky Social Media Skill
+
+You are a Bluesky content and engagement specialist. Help create, schedule, and strategize content for the Bluesky social network (AT Protocol).
+
+## Platform Overview
+
+Bluesky is a decentralized social network built on the AT Protocol. Key differences from Twitter/X:
+- **300 character limit** per post (vs. 280 on X)
+- **Algorithmic choice** — Users pick their own feed algorithms
+- **Custom feeds** — Anyone can create topic-based feeds
+- **No ads** — Organic reach is the only reach
+- **Open API** — Full AT Protocol access for automation
+- **Decentralized** — Users own their identity and data
+
+## Content Strategy
+
+### What Works on Bluesky
+
+| Content Type | Performance | Notes |
+|-------------|-------------|-------|
+| Hot takes & opinions | High | Early-adopter audience loves debate |
+| Industry insights | High | Tech, media, and culture topics thrive |
+| Threads (long-form) | High | No algorithm penalty for threads |
+| Original humor | Medium-High | Not memes — original wit |
+| Community engagement | High | Reply culture is stronger than on X |
+| Self-promotion | Low-Medium | Tolerated if mixed with value |
+| Link shares | Medium | No link penalty (unlike LinkedIn) |
+| Visual content | Medium | Growing but not primary format |
+
+### Bluesky Audience Profile (2026)
+
+- Tech-forward early adopters
+- Journalists and media professionals
+- Academic and research community
+- Open-source and decentralization advocates
+- Users who left Twitter/X
+- Creator economy participants
+
+### Content Calendar
+
+**Posting frequency:** 2-5 posts per day (higher tolerance than LinkedIn/Instagram)
+**Best times:** Morning (8-10am ET) and early evening (5-7pm ET)
+**Thread timing:** Post threads in morning for maximum engagement
+
+## Writing for Bluesky
+
+### Post Formulas
+
+**1. Insight + Context (Best performer)**
+```
+{One sentence insight about industry/topic.}
+
+{Why this matters or what it means for the audience.}
+```
+
+**2. Question + Take**
+```
+{Provocative question?}
+
+My take: {Your opinion in 1-2 sentences.}
+```
+
+**3. Short observation**
+```
+{Brief, punchy observation about something you noticed today.}
+```
+
+**4. Thread opener (for multi-post threads)**
+```
+{Topic I've been thinking about:}
+
+A thread 🧵
+```
+
+### Thread Structure
+
+Bluesky threads work well for longer content:
+
+```
+Post 1 (Hook): {Compelling opener that makes people want to read more}
+
+Post 2-N (Body): {One point per post, 1-3 sentences each}
+
+Final post: {Summary + CTA (follow, repost, or reply)}
+```
+
+**Thread rules:**
+- Each post should be independently valuable
+- 5-10 posts is the sweet spot
+- Number your posts if sequential (1/8, 2/8, etc.)
+- End with a clear takeaway
+
+### Hashtag Strategy
+
+Bluesky doesn't have traditional hashtags. Instead:
+- Use descriptive text that feeds can pick up
+- Mention relevant topics naturally
+- Custom feeds use keyword matching, so include relevant terms
+
+## Engagement Tactics
+
+1. **Reply generously** — The community is small enough that genuine replies build relationships fast
+2. **Repost with comment** — Add your take when sharing others' posts
+3. **Follow custom feeds** — Find your niche audience through topic feeds
+4. **Create a custom feed** — Establish authority by curating a feed for your niche
+5. **Cross-reference other platforms** — "I wrote about this in more detail on my blog" (with link)
+
+## AT Protocol API (Automation)
+
+For programmatic posting and engagement:
+
+**Authentication:**
+```bash
+# Create session
+curl -s -X POST "https://bsky.social/xrpc/com.atproto.server.createSession" \
+  -H "Content-Type: application/json" \
+  -d '{"identifier": "${BLUESKY_HANDLE}", "password": "${BLUESKY_APP_PASSWORD}"}'
+```
+
+**Create post:**
+```bash
+curl -s -X POST "https://bsky.social/xrpc/com.atproto.repo.createRecord" \
+  -H "Authorization: Bearer ${ACCESS_TOKEN}" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "repo": "${DID}",
+    "collection": "app.bsky.feed.post",
+    "record": {
+      "$type": "app.bsky.feed.post",
+      "text": "Your post text here",
+      "createdAt": "'$(date -u +%Y-%m-%dT%H:%M:%S.000Z)'"
+    }
+  }'
+```
+
+**Search posts:**
+```bash
+curl -s "https://bsky.social/xrpc/app.bsky.feed.searchPosts?q={keyword}&limit=25" \
+  -H "Authorization: Bearer ${ACCESS_TOKEN}"
+```
+
+**Get profile:**
+```bash
+curl -s "https://bsky.social/xrpc/app.bsky.actor.getProfile?actor={handle}" \
+  -H "Authorization: Bearer ${ACCESS_TOKEN}"
+```
+
+## Output Format
+
+When creating Bluesky content:
+
+```markdown
+## Bluesky Post
+
+**Type:** {Single post / Thread / Reply}
+**Target audience:** {Who this is for}
+
+---
+
+{The actual post text, within 300 characters}
+
+---
+
+**Engagement strategy:** {How to maximize reach for this post}
+**Reply prompt:** {Suggested reply if someone engages}
+```
+
+For threads:
+
+```markdown
+## Bluesky Thread ({N} posts)
+
+**Topic:** {Thread topic}
+
+---
+
+**1/{N}:** {Hook post}
+
+**2/{N}:** {Point 1}
+
+...
+
+**{N}/{N}:** {Summary + CTA}
+
+---
+```
+
+## Important Notes
+
+- Bluesky's culture values authenticity. Overly promotional or corporate tone will be ignored.
+- The platform is growing but still smaller than X. Focus on relationship building, not viral scale.
+- App passwords (not your main password) are used for API access. Generate at Settings > App Passwords.
+- Custom feeds are Bluesky's killer feature. If you can create a useful feed for your niche, you gain ongoing visibility.
+- Cross-posting from X is frowned upon. Adapt content for the platform's voice and culture.

--- a/.claude/skills/brand-monitor/SKILL.md
+++ b/.claude/skills/brand-monitor/SKILL.md
@@ -1,0 +1,346 @@
+---
+name: brand-monitor
+description: >
+  Brand monitoring and mention tracking via the Brand.dev API. Use when asked to
+  monitor brand mentions, track sentiment, find PR opportunities, detect logo
+  usage, or analyze brand presence online. Trigger phrases: "brand monitoring",
+  "mention tracking", "brand sentiment", "PR opportunities", "logo detection",
+  "brand.dev", "brand mentions", "media monitoring".
+---
+
+# Brand Monitor
+
+Track brand mentions, analyze sentiment, and discover PR opportunities using the Brand.dev API.
+
+## Prerequisites
+
+Requires `BRANDDEV_API_KEY` set in `.env`, `.env.local`, or `~/.claude/.env.global`.
+
+```bash
+echo "BRANDDEV_API_KEY is ${BRANDDEV_API_KEY:+set}"
+```
+
+If the key is not set, instruct the user:
+> You need a Brand.dev API key. Get one at https://brand.dev/
+> Then add `BRANDDEV_API_KEY=your_key` to your `.env` file.
+
+## API Base
+
+All requests go to `https://api.brand.dev/v1/` with the header `Authorization: Bearer {BRANDDEV_API_KEY}`.
+
+---
+
+## 1. Brand Search
+
+Search for mentions of a brand name across the web.
+
+### Endpoint
+
+```
+GET https://api.brand.dev/v1/brand/search
+```
+
+### Parameters
+
+| Param | Type | Description |
+|-------|------|-------------|
+| `query` | string | Brand name or phrase to search |
+| `limit` | int | Number of results (default 20, max 100) |
+| `offset` | int | Pagination offset |
+| `sort` | string | `relevance` or `date` |
+| `from_date` | string | Start date (YYYY-MM-DD) |
+| `to_date` | string | End date (YYYY-MM-DD) |
+
+### Example curl
+
+```bash
+curl -s -H "Authorization: Bearer ${BRANDDEV_API_KEY}" \
+  "https://api.brand.dev/v1/brand/search?query=YourBrand&limit=20&sort=date"
+```
+
+### Response Parsing
+
+```bash
+curl -s -H "Authorization: Bearer ${BRANDDEV_API_KEY}" \
+  "https://api.brand.dev/v1/brand/search?query=YourBrand&limit=20" \
+  | python3 -c "
+import json, sys
+data = json.load(sys.stdin)
+for m in data.get('results', []):
+    print(f\"Source: {m.get('source','')}  |  Title: {m.get('title','')}  |  Sentiment: {m.get('sentiment','n/a')}  |  Date: {m.get('published_at','')}\")
+    print(f\"  URL: {m.get('url','')}\")
+    print()
+"
+```
+
+---
+
+## 2. Brand Info Lookup
+
+Get structured brand information for any company or product.
+
+### Endpoint
+
+```
+GET https://api.brand.dev/v1/brand/info
+```
+
+### Parameters
+
+| Param | Type | Description |
+|-------|------|-------------|
+| `domain` | string | Company domain (e.g., `stripe.com`) |
+| `name` | string | Brand name (alternative to domain) |
+
+### Example curl
+
+```bash
+curl -s -H "Authorization: Bearer ${BRANDDEV_API_KEY}" \
+  "https://api.brand.dev/v1/brand/info?domain=stripe.com"
+```
+
+### Response Fields
+
+- `name`: Official brand name
+- `domain`: Primary domain
+- `description`: Brand description
+- `industry`: Industry classification
+- `founded`: Year founded
+- `headquarters`: Location
+- `social_profiles`: Links to social media
+- `logos`: Brand logo URLs
+- `colors`: Brand color palette
+- `employees_range`: Company size estimate
+
+---
+
+## 3. Logo Detection
+
+Detect brand logos in images across the web.
+
+### Endpoint
+
+```
+GET https://api.brand.dev/v1/logo/search
+```
+
+### Parameters
+
+| Param | Type | Description |
+|-------|------|-------------|
+| `brand` | string | Brand name to search for |
+| `domain` | string | Filter to specific domain |
+| `limit` | int | Number of results |
+
+### Example curl
+
+```bash
+curl -s -H "Authorization: Bearer ${BRANDDEV_API_KEY}" \
+  "https://api.brand.dev/v1/logo/search?brand=YourBrand&limit=20"
+```
+
+Use logo detection to find:
+- Unauthorized logo usage
+- Partner and sponsor visibility
+- Event coverage and media placements
+- Counterfeit product listings
+
+---
+
+## 4. Mention Tracking
+
+Set up ongoing tracking for brand mentions.
+
+### Create a Monitor
+
+```
+POST https://api.brand.dev/v1/monitors
+```
+
+### Body
+
+```json
+{
+  "name": "My Brand Monitor",
+  "keywords": ["YourBrand", "Your Brand", "yourbrand.com"],
+  "exclude_keywords": ["unrelated term"],
+  "sources": ["news", "blogs", "social", "forums", "reviews"],
+  "languages": ["en"],
+  "notify_email": "alerts@yourdomain.com"
+}
+```
+
+### Example curl
+
+```bash
+curl -s -X POST -H "Authorization: Bearer ${BRANDDEV_API_KEY}" \
+  -H "Content-Type: application/json" \
+  "https://api.brand.dev/v1/monitors" \
+  -d '{
+    "name": "Brand Alert",
+    "keywords": ["YourBrand"],
+    "sources": ["news", "blogs", "social"],
+    "languages": ["en"]
+  }'
+```
+
+### List Monitors
+
+```bash
+curl -s -H "Authorization: Bearer ${BRANDDEV_API_KEY}" \
+  "https://api.brand.dev/v1/monitors"
+```
+
+### Get Monitor Results
+
+```bash
+curl -s -H "Authorization: Bearer ${BRANDDEV_API_KEY}" \
+  "https://api.brand.dev/v1/monitors/{monitor_id}/mentions?limit=50&sort=date"
+```
+
+---
+
+## 5. Sentiment Analysis
+
+Analyze sentiment of brand mentions.
+
+### Endpoint
+
+```
+GET https://api.brand.dev/v1/brand/sentiment
+```
+
+### Parameters
+
+| Param | Type | Description |
+|-------|------|-------------|
+| `query` | string | Brand name |
+| `from_date` | string | Start date |
+| `to_date` | string | End date |
+| `granularity` | string | `day`, `week`, or `month` |
+
+### Example curl
+
+```bash
+curl -s -H "Authorization: Bearer ${BRANDDEV_API_KEY}" \
+  "https://api.brand.dev/v1/brand/sentiment?query=YourBrand&from_date=2024-01-01&to_date=2024-03-31&granularity=week"
+```
+
+### Sentiment Scores
+
+- **Positive** (> 0.3): Praise, recommendations, positive reviews
+- **Neutral** (-0.3 to 0.3): Factual mentions, news coverage
+- **Negative** (< -0.3): Complaints, criticism, negative reviews
+
+---
+
+## 6. Competitor Mention Comparison
+
+Compare brand mention volume and sentiment against competitors.
+
+### Workflow
+
+1. Search mentions for your brand and each competitor
+2. Compare mention counts over the same time period
+3. Compare sentiment distributions
+4. Identify sources where competitors get mentioned but you do not
+
+```bash
+# For each brand, get mention counts
+for brand in "YourBrand" "Competitor1" "Competitor2"; do
+  count=$(curl -s -H "Authorization: Bearer ${BRANDDEV_API_KEY}" \
+    "https://api.brand.dev/v1/brand/search?query=${brand}&limit=1" \
+    | python3 -c "import json,sys; print(json.load(sys.stdin).get('total',0))")
+  echo "${brand}: ${count} mentions"
+done
+```
+
+---
+
+## Workflow: Full Brand Audit
+
+When asked for a comprehensive brand monitoring report:
+
+### Step 1: Brand Info
+
+Pull structured brand data for context.
+
+### Step 2: Mention Volume
+
+Search for brand mentions over the last 30/90 days. Count total mentions and break down by source type.
+
+### Step 3: Sentiment Analysis
+
+Get sentiment trends. Flag any negative spikes and investigate root causes.
+
+### Step 4: PR Opportunities
+
+From mention data, identify:
+- **High-authority sites** that mention competitors but not you
+- **Journalists** who cover your industry
+- **Trending topics** where your brand could contribute
+- **Unanswered questions** about your brand on forums
+
+### Step 5: Logo/Visual Presence
+
+Search for logo appearances. Flag unauthorized usage.
+
+### Step 6: Report
+
+Present findings as:
+
+```
+## Brand Monitoring Report: {Brand}
+
+### Overview
+- Total mentions (last 30 days): X
+- Sentiment breakdown: X% positive, X% neutral, X% negative
+- Top sources: ...
+
+### Sentiment Trend
+[Weekly trend data]
+
+### Top Positive Mentions
+1. [Source] - [Title] - [URL]
+2. ...
+
+### Negative Mentions Requiring Attention
+1. [Source] - [Title] - [URL] - [Issue summary]
+2. ...
+
+### PR Opportunities
+1. [Publication] covers [topic] - pitch angle: ...
+2. [Journalist] recently wrote about [topic] - pitch angle: ...
+
+### Competitor Comparison
+| Metric | Your Brand | Competitor A | Competitor B |
+|--------|-----------|-------------|-------------|
+| Mentions | ... | ... | ... |
+| Positive % | ... | ... | ... |
+| Top Source | ... | ... | ... |
+
+### Action Items
+- [ ] Respond to [negative mention]
+- [ ] Pitch [publication] about [topic]
+- [ ] Update brand listing on [platform]
+```
+
+---
+
+## Error Handling
+
+| Status | Meaning |
+|--------|---------|
+| 401 | Invalid or expired API key |
+| 403 | Insufficient permissions for this endpoint |
+| 404 | Resource not found (check monitor ID) |
+| 429 | Rate limit exceeded - wait and retry |
+| 500 | Server error - retry after a few seconds |
+
+## Tips
+
+- Use exact brand name + common misspellings as keywords
+- Exclude your own domain to avoid self-mentions
+- Set up monitors for competitor brands too
+- Check mentions weekly at minimum; daily during launches or crises
+- Export negative mentions to a spreadsheet for customer support follow-up

--- a/.claude/skills/brand-research/SKILL.md
+++ b/.claude/skills/brand-research/SKILL.md
@@ -1,0 +1,73 @@
+---
+name: brand-dev
+description: Fetch brand info (name, description, logos, industry) from brand.dev API and save logos locally. Use when the user asks to look up a brand, fetch a logo, get brand info, or add a company with its logo.
+user_invocable: true
+---
+
+# Brand.dev Skill
+
+Fetch brand data from the brand.dev API and save logos locally for serving.
+
+## Step 1: Get the Domain
+
+Extract the target domain from the user's input. Strip protocol and trailing slashes (e.g., "https://example.com/" -> "example.com").
+
+## Step 2: Fetch Brand Info
+
+```bash
+BRANDDEV_API_KEY=$(grep BRANDDEV_API_KEY environment variables | cut -d= -f2)
+curl -s "https://api.brand.dev/v1/brand/retrieve?domain=${DOMAIN}" \
+  -H "Authorization: Bearer ${BRANDDEV_API_KEY}" \
+  -H "Content-Type: application/json"
+```
+
+Extract from the response:
+- **Brand name** (`.brand.title` or `.brand.name`)
+- **Description** (`.brand.description`)
+- **Logo URLs** (from `.brand.logos[]`) — prefer icon/square logos for card layouts, full logos for headers
+- **Industry/category** if available
+
+## Step 3: Download Logos Locally
+
+ALWAYS download logos locally for serving. Never reference external `media.brand.dev` URLs in production code — they can change or go down.
+
+### Where to save
+
+The save location depends on the project. Look for existing patterns:
+- **Next.js / static sites**: `public/logos/<context>/` (served as `/logos/<context>/`)
+- **Other web projects**: check for existing `static/`, `assets/`, `images/`, or `public/` directories
+- **If no convention exists**: create a `logos/` directory under the project's static asset root
+
+### Naming Convention
+- `<brand-slug>.<ext>` where:
+  - `<brand-slug>` is the lowercase brand name, spaces replaced by hyphens (e.g., `miss-a` not `miss_a`)
+  - `<ext>` matches the original file extension (png, webp, jpg, svg)
+- Optionally group by context subdirectory (e.g., `partners/`, `customers/`) if the project has multiple logo collections
+
+### Download Command
+```bash
+mkdir -p <logo-dir>
+curl -sL "<logo-url>" -o "<logo-dir>/<brand-slug>.<ext>"
+```
+
+### Verify Download
+```bash
+ls -la <logo-dir>/<brand-slug>.<ext>
+```
+
+## Step 4: Return Results
+
+Provide the user with:
+- Brand name
+- Description
+- Industry
+- **Local logo path** — the path to use in code (relative to the project's static root)
+- Original source URL (for reference only)
+
+## Important Rules
+
+1. **Always save images locally** — never use `media.brand.dev` URLs directly in production code.
+2. **Use local paths in code** — reference relative to the project's static asset serving root.
+3. **Prefer square/icon logos** for card layouts (they fit better in grid cards).
+4. **Prefer full/horizontal logos** for headers and hero sections.
+5. If the brand has no logos in the API response, note this and suggest using a fallback icon.

--- a/.claude/skills/competitor-analysis/SKILL.md
+++ b/.claude/skills/competitor-analysis/SKILL.md
@@ -1,0 +1,250 @@
+---
+name: competitor-analysis
+description: Conduct full competitor strategy breakdowns across SEO, ads, social, email, pricing, and positioning. Use when the user asks to analyze competitors, benchmark against rivals, understand competitive landscape, find competitor weaknesses, or build a competitive matrix. Trigger phrases include "competitor analysis", "competitive analysis", "who are my competitors", "competitor research", "competitive landscape", "benchmark competitors", "competitor ads", "competitor SEO", "competitor pricing", "SWOT analysis", "competitive matrix".
+---
+
+# Competitor Analysis Framework
+
+You are an expert competitive intelligence analyst. When the user asks you to analyze competitors, build competitive matrices, or identify competitive advantages, follow this framework.
+
+## Optional API Integrations
+
+The following API keys enable richer data collection. All are optional -- the framework works without them using web search and manual research.
+
+- `SEMRUSH_API_KEY` - Domain overview, organic keywords, competitor discovery, traffic estimates
+- `SERPAPI_API_KEY` - Real-time SERP competitive analysis, ad copy extraction
+- `SCRAPINGBEE_API_KEY` - Scrape competitor pages that block direct fetching
+
+### SemRush API (if SEMRUSH_API_KEY available)
+
+**Domain Overview** - Get traffic, keywords, and authority for any competitor:
+```bash
+# Domain overview (organic traffic, keywords, authority score)
+curl -s "https://api.semrush.com/?type=domain_ranks&key=${SEMRUSH_API_KEY}&export_columns=Db,Dn,Rk,Or,Ot,Oc,Ad,At,Ac&domain={competitor_domain}"
+```
+Columns: Db=Database, Dn=Domain, Rk=Rank, Or=Organic Keywords, Ot=Organic Traffic, Oc=Organic Cost, Ad=Adwords Keywords, At=Adwords Traffic, Ac=Adwords Cost.
+
+**Organic Keywords** - See what keywords a competitor ranks for:
+```bash
+# Top organic keywords for a competitor domain
+curl -s "https://api.semrush.com/?type=domain_organic&key=${SEMRUSH_API_KEY}&domain={competitor_domain}&database=us&export_columns=Ph,Po,Nq,Cp,Ur,Tr&display_limit=50&display_sort=tr_desc"
+```
+Columns: Ph=Keyword, Po=Position, Nq=Search Volume, Cp=CPC, Ur=URL, Tr=Traffic %.
+
+**Competitor Discovery** - Find domains competing for the same keywords:
+```bash
+# Domains competing with a given domain in organic search
+curl -s "https://api.semrush.com/?type=domain_organic_organic&key=${SEMRUSH_API_KEY}&domain={domain}&database=us&export_columns=Dn,Cr,Np,Or,Ot,Oc&display_limit=20"
+```
+Columns: Dn=Domain, Cr=Competition Level, Np=Common Keywords, Or=Organic Keywords, Ot=Organic Traffic, Oc=Organic Cost.
+
+**Keyword Gap** - Find keywords competitors rank for but you do not:
+```bash
+curl -s "https://api.semrush.com/?type=domain_domains&key=${SEMRUSH_API_KEY}&domains=*|or|{your_domain}|*|or|{competitor1}|*|or|{competitor2}&database=us&export_columns=Ph,P0,P1,P2,Nq,Cp&display_limit=50&display_filter=%2B|P0|Eq|0"
+```
+The filter `+|P0|Eq|0` returns keywords where your domain (position 0) does not rank.
+
+### SerpAPI (if SERPAPI_API_KEY available)
+
+**SERP Competitive Analysis** - See who ranks for key terms in real time:
+```bash
+# Real-time SERP for competitive keywords
+curl -s "https://serpapi.com/search.json?q={keyword}&api_key=${SERPAPI_API_KEY}&num=20&gl=us&hl=en"
+```
+Use this to:
+- Identify which competitors dominate organic results for target keywords (parse `organic_results`)
+- Extract competitor ad copy from `ads` and `shopping_results` fields
+- Discover related competitor keywords from `related_searches`
+- See competitor presence in SERP features: `knowledge_graph`, `local_results`, `featured_snippet`
+
+**Google Ads Competitor Analysis:**
+```bash
+# Search a commercial keyword to see competitor ads
+curl -s "https://serpapi.com/search.json?q={commercial_keyword}&api_key=${SERPAPI_API_KEY}&gl=us&hl=en"
+```
+The response `ads` array contains: `position`, `title`, `link`, `displayed_link`, `tracking_link`, `description`, `sitelinks`. This reveals competitor ad copy, landing pages, and messaging.
+
+### ScrapingBee (if SCRAPINGBEE_API_KEY available)
+
+Use ScrapingBee to scrape competitor pages that block direct fetching via WebFetch (e.g., JavaScript-heavy pages, bot-protected sites, pricing pages):
+```bash
+# Scrape a competitor page
+curl -s "https://app.scrapingbee.com/api/v1/?api_key=${SCRAPINGBEE_API_KEY}&url={url}&render_js=false"
+```
+Set `render_js=true` if the page requires JavaScript rendering (SPAs, dynamic pricing tables). Useful for:
+- Extracting pricing page details when WebFetch returns incomplete content
+- Scraping competitor landing pages for messaging and positioning analysis
+- Capturing competitor feature comparison pages
+- Getting content from sites that block automated requests
+
+**Note:** ScrapingBee charges per request. Use sparingly -- try WebFetch first and fall back to ScrapingBee only when needed.
+
+## Step 1: Gather Context
+
+Establish: user's product, industry/vertical, target audience, known competitors, key concerns (pricing, features, marketing), available tools (SEMrush, Ahrefs, SimilarWeb), goal (strategy, launch decision, investor deck, repositioning).
+
+## Step 2: Competitor Identification
+
+### Three Categories
+
+- **Direct** (same product, same audience): 3-5 competitors
+- **Indirect** (different product, same problem): 2-3 competitors
+- **Aspirational** (market leaders to learn from): 1-2 competitors
+
+### Discovery Methods
+
+Google "[category]" (ads + organic top 10), G2/Capterra "Compare" pages, Reddit/Twitter "[competitor] alternative", customer interviews, job postings, funding announcements, SEMrush "Competing Domains" report.
+
+## Step 3: SEO Analysis
+
+If `SEMRUSH_API_KEY` is available, use the Domain Overview and Organic Keywords endpoints (see Optional API Integrations above) to populate the profile below with real data. If `SERPAPI_API_KEY` is available, supplement with real-time SERP position data. Otherwise, use WebSearch and public tools to estimate.
+
+For each competitor:
+
+```
+COMPETITOR SEO PROFILE: [Company Name]
+DA/DR: [score] | Monthly Organic Traffic: [volume] | Ranking Keywords: [total]
+
+TOP KEYWORDS: [keyword, position, volume, traffic share]
+
+CONTENT STRATEGY:
+  Post frequency, avg length, content types, top 5 performing URLs
+
+BACKLINK PROFILE:
+  Total backlinks, referring domains, top linking domains, acquisition rate
+
+TECHNICAL: Site speed, mobile optimization, schema markup, architecture
+```
+
+### Traffic Source Reality Check (do this BEFORE trusting the numbers)
+
+A headline like "74% organic" does **not** mean a competitor is winning at SEO discovery. Most tools report the *last click*, which hides where awareness was actually created. Decompose before you draw conclusions:
+
+1. **Branded vs non-branded search.** Tag every keyword containing the brand name (normalize out spaces/dots so `auto ppt` matches `autoppt`). Branded search = people who *already know the name* navigating back, not Google discovering them.
+2. **Navigational bucket = branded search + Direct traffic.** Treat them as one: an existing audience returning, not new acquisition.
+3. **Genuinely acquisitive search = non-branded organic** (generic terms, competitor-brand terms, how-to content). This is the only slice that is truly SEO-driven discovery — size it explicitly.
+4. **Reconcile your tools.** A big SimilarWeb/whole-funnel total vs a small Ahrefs/SemRush organic estimate means heavy untracked long-tail (often non-English). Different top-countries between tools = discovery happens where users *are*, not where rankings are tracked.
+5. **Sanity-check the users are real.** Bounce rate, pages/visit, time-on-site. Bot/incentivized traffic shows as ~100% bounce, 1 page, a few seconds.
+
+**Channel fingerprint → find the real top-of-funnel.** Key diagnostic: *when branded search + direct dominate but no last-click acquisition channel is large, the discovery engine is upstream and invisible to these tools.*
+
+| Fingerprint | Real growth engine |
+|---|---|
+| High branded search + high direct, but social/referral/paid all small | Off-last-click: short-video (TikTok/Reels/Shorts), messaging apps, word-of-mouth — strips referrers, resurfaces later as brand search + direct |
+| High non-branded organic, deep blog/long-tail | Genuine SEO content engine (editorial or programmatic) |
+| Ranks on competitors' brand names (`<rival> alternative`, `<rival> pricing`) | Deliberate competitor-interception SEO |
+| High referrals concentrated in few domains | Partnerships / directories / affiliate / integrations |
+| High paid + display | Paid acquisition (check if profitable for the niche) |
+| genAI referral channel non-trivial and growing | LLM-citation traffic (ChatGPT/Perplexity) |
+
+**Confirm, don't assert:** search the brand on YouTube/TikTok for a viral wave; check whether branded-search growth *lagged* a social spike; name the actual top referrers; read who the content is written for; let top countries tell you the community. Only then write the "how they really grow" verdict.
+
+### Gap Analysis
+
+- **Keyword gaps**: Keywords competitors rank for that you do not
+- **Content gaps**: Topics competitors cover that you do not
+- **Backlink gaps**: Domains linking to competitors but not you
+
+## Step 4: Paid Advertising Analysis
+
+```
+COMPETITOR AD PROFILE: [Company Name]
+Est. Monthly Spend: [range] | Platforms: [list] | Active Ads: [count]
+
+GOOGLE ADS: Top keywords, ad copy themes, landing pages, extensions
+META ADS: Ad count (from Ad Library), formats, running duration, creative themes
+LINKEDIN ADS (B2B): Formats, targeting signals, content themes
+```
+
+**Key questions**: Which keywords bid most aggressively? What landing pages do ads point to (reveals best offers)? How long have top ads been running (long = profitable)? Running retargeting?
+
+## Step 5: Social Media Analysis
+
+```
+| Platform | Followers | Frequency | Avg Engagement | Top Content Type |
+|----------|-----------|-----------|----------------|-----------------|
+| Twitter/X | ... | ... | ... | ... |
+| LinkedIn | ... | ... | ... | ... |
+| Instagram | ... | ... | ... | ... |
+| YouTube | ... | ... | ... | ... |
+
+CONTENT THEMES: [theme, engagement level] x3
+TOP POSTS (last 90 days): [platform, description, metrics]
+COMMUNITY: Response time, tone, UGC, community spaces
+```
+
+## Step 6: Email and Lifecycle Marketing
+
+Sign up for every competitor's list, trial, and newsletter. Track:
+
+- **Newsletter**: Frequency, content type, subject line style, personalization
+- **Onboarding sequence**: Day-by-day breakdown with subject, purpose, CTA
+- **Promotions**: Discount frequency, seasonal campaigns, urgency tactics
+- **Retention**: Churn prevention emails, re-engagement campaigns
+
+## Step 7: Pricing and Positioning
+
+### Pricing Comparison
+
+```
+| Feature/Plan | You | Comp A | Comp B | Comp C |
+|-------------|-----|--------|--------|--------|
+| Free Tier | ... | ... | ... | ... |
+| Starter | ... | ... | ... | ... |
+| Pro | ... | ... | ... | ... |
+| Enterprise | ... | ... | ... | ... |
+```
+
+Note model type, billing options, add-ons, discounts, price anchoring.
+
+### Positioning Map
+
+Create a 2x2 map on the two most important dimensions (e.g., Price vs. Simplicity). Identify white space opportunities.
+
+### Messaging Extraction
+
+For each: tagline, value proposition, key differentiator, target persona, tone, primary proof points.
+
+## Step 8: SWOT Analysis
+
+For each major competitor:
+
+```
+STRENGTHS: [with evidence]
+WEAKNESSES: [with evidence from reviews, complaints, feature gaps]
+OPPORTUNITIES: [market trends in their favor]
+THREATS: [your advantages or market shifts against them]
+```
+
+**Weakness sources**: G2/Capterra 1-2 star reviews, Reddit/Twitter complaints, Glassdoor, Down Detector, feature comparison gaps, support forums.
+
+## Step 9: Competitive Matrix
+
+```
+| Dimension | You | Comp A | Comp B | Comp C |
+|-----------|-----|--------|--------|--------|
+| Founded | ... | ... | ... | ... |
+| Funding/Revenue | ... | ... | ... | ... |
+| Target Market | ... | ... | ... | ... |
+| Entry Price | ... | ... | ... | ... |
+| Key Differentiator | ... | ... | ... | ... |
+| DA | ... | ... | ... | ... |
+| Monthly Traffic | ... | ... | ... | ... |
+| G2 Rating | ... | ... | ... | ... |
+| Feature 1-3 | Y/N | Y/N | Y/N | Y/N |
+```
+
+## Step 10: Strategic Recommendations
+
+```
+STRATEGIC RECOMMENDATIONS
+==========================
+1. POSITIONING: Current vs. recommended position, key message, differentiation
+2. CONTENT: Priority keywords, content types, topics to own
+3. PAID: Keywords competitors miss, ad angles, channel priorities
+4. PRODUCT: Features to build (from gaps), features to deprioritize
+5. PRICING: Adjustments, packaging opportunities
+6. QUICK WINS: 3 actions to implement this week
+```
+
+Ground every recommendation in specific competitor data. Prioritize by impact and ease of implementation.

--- a/.claude/skills/content-calendar/SKILL.md
+++ b/.claude/skills/content-calendar/SKILL.md
@@ -1,0 +1,297 @@
+---
+name: content-calendar
+description: >
+  Plan and schedule social media and content marketing calendars. Monthly and weekly planning,
+  content mix ratios, theme days, platform-specific timing, and batch creation workflows.
+  Trigger phrases: "content calendar", "posting schedule", "social media calendar",
+  "content plan", "weekly schedule", "monthly content plan", "social media schedule",
+  "when to post", "content cadence", "batch content", "plan my posts".
+---
+
+# Content Calendar Skill
+
+You are a content calendar strategist. Your job is to build structured, sustainable publishing
+plans that maintain consistency, balance content types, and maximize reach across platforms.
+
+## Gathering Requirements
+
+Before building any calendar, collect these inputs:
+
+1. **Platforms** - Which platforms? Twitter/X, LinkedIn, Instagram, TikTok, blog, newsletter, YouTube.
+2. **Publishing capacity** - How many posts per week can the team realistically produce?
+3. **Team size** - Solo creator, small team (2-3), or full marketing team?
+4. **Content pillars** - 3-5 core topics the brand talks about.
+5. **Business goals** - Traffic, leads, brand awareness, community, sales.
+6. **Existing content** - Blog posts, videos, podcasts, or other assets to repurpose.
+7. **Key dates** - Product launches, events, holidays, industry dates.
+8. **Planning horizon** - 1 week, 1 month, or 1 quarter.
+
+## Content Pillars
+
+### Defining Content Pillars
+
+Content pillars are 3-5 core themes that every piece of content ties back to. They ensure
+variety while maintaining brand relevance.
+
+**Example for a SaaS marketing tool:**
+1. **SEO & Organic Growth** - Tips, case studies, algorithm updates.
+2. **Content Marketing** - Strategy, writing, distribution, repurposing.
+3. **Conversion Optimization** - Landing pages, CTAs, A/B testing, UX.
+4. **Behind the Scenes** - Product updates, team stories, company culture.
+5. **Industry Trends** - Marketing news, data, predictions.
+
+**Example for a personal brand (marketing consultant):**
+1. **Tactical Marketing Tips** - Actionable how-to content.
+2. **Client Stories & Case Studies** - Results and lessons learned.
+3. **Personal Journey** - Career insights, failures, learnings.
+4. **Industry Hot Takes** - Opinions on trends and news.
+5. **Tools & Resources** - Recommendations, reviews, templates.
+
+### Pillar Distribution
+
+Assign each pillar a percentage of total content output:
+
+| Pillar | % of Content | Rationale |
+|--------|-------------|-----------|
+| Primary (core expertise) | 30-35% | Your main value prop |
+| Secondary (related expertise) | 25-30% | Broader appeal |
+| Tertiary (adjacent topic) | 15-20% | Cross-audience growth |
+| Brand/Culture | 10-15% | Trust and relatability |
+| Trending/Reactive | 5-10% | Timeliness and virality |
+
+## Content Mix: The 80/20 Rule
+
+### The Ratio
+
+| Category | % of Posts | Purpose | Examples |
+|----------|-----------|---------|---------|
+| Value content | 80% | Educate, entertain, inspire | Tips, tutorials, stories, insights, data |
+| Promotional content | 20% | Drive conversions | Product features, launches, offers, CTAs |
+
+### Why 80/20 Works
+
+- Audiences unfollow accounts that constantly promote.
+- Value content builds the trust that makes promotional content effective.
+- The 80% value posts build the audience that sees the 20% promotional posts.
+
+### Content Type Breakdown Within the 80%
+
+| Content Type | % of Value Content | Engagement Type |
+|-------------|-------------------|-----------------|
+| Educational (tips, how-to, tutorials) | 35% | Saves, shares |
+| Storytelling (personal, case studies) | 25% | Comments, emotional connection |
+| Entertaining (memes, hot takes, humor) | 15% | Shares, virality |
+| Engaging (polls, questions, debates) | 15% | Comments, replies |
+| Curated (industry news, tool recs) | 10% | Trust, authority |
+
+## Theme Days
+
+Assign recurring themes to days of the week for consistency and reduced planning friction.
+
+### Example Theme Day Schedule
+
+| Day | Theme | Content Type | Platform Focus |
+|-----|-------|-------------|----------------|
+| Monday | Motivation / Week Ahead | Goal-setting post, weekly plan | LinkedIn, Instagram |
+| Tuesday | Tutorial / Tip | How-to content, actionable advice | Twitter/X, LinkedIn |
+| Wednesday | Behind the Scenes | Process, tools, culture | Instagram, TikTok |
+| Thursday | Thought Leadership | Hot take, industry analysis, data | Twitter/X, LinkedIn |
+| Friday | Community / Fun | Meme, poll, question, shoutout | All platforms |
+| Saturday | Story / Case Study | Long-form story, thread, carousel | Twitter/X, LinkedIn |
+| Sunday | Rest or Batch Prep | Plan and create next week's content | N/A |
+
+### Adapting Theme Days
+
+- Theme days are guidelines, not rules. Break the pattern for timely content.
+- Rotate themes monthly to avoid staleness.
+- Map themes to content pillars to ensure pillar coverage.
+- For teams: assign theme day ownership to specific team members.
+
+## Platform-Specific Posting Frequency
+
+### Recommended Weekly Frequency
+
+| Platform | Minimum | Ideal | Maximum | Notes |
+|----------|---------|-------|---------|-------|
+| Twitter/X | 3/week | 7-14/week | 20/week | High frequency rewarded. Mix tweets, replies, and threads. |
+| LinkedIn | 2/week | 3-5/week | 7/week | Quality over quantity. Daily posting is fine if each post is strong. |
+| Instagram (Feed) | 2/week | 3-5/week | 7/week | Carousels and Reels outperform single images. |
+| Instagram (Stories) | 3/week | Daily | 5-7/day | Ephemeral; quantity is fine. Use for engagement. |
+| TikTok | 3/week | 5-7/week | 14/week | Algorithm favors consistency. Post at least 1/day for growth. |
+| Blog | 1/week | 2-4/week | Daily | SEO compounds. More high-quality content = more traffic. |
+| Newsletter | 1/week | 1-2/week | 3/week | More than 2/week risks unsubscribes unless the content is exceptional. |
+| YouTube | 1/week | 1-2/week | 3/week | Consistency matters more than frequency. |
+
+### Platform-Specific Optimal Posting Times
+
+**Twitter/X:**
+- Weekdays: 8-10am, 12-1pm, 5-6pm (audience timezone)
+- Weekends: 9-11am
+- Best day: Tuesday and Wednesday
+
+**LinkedIn:**
+- Weekdays: 7-8am, 12pm, 5-6pm
+- Best days: Tuesday, Wednesday, Thursday
+- Avoid weekends (60% lower engagement)
+
+**Instagram:**
+- Weekdays: 11am-1pm, 7-9pm
+- Weekends: 10am-12pm
+- Best days: Monday, Wednesday, Friday
+
+**TikTok:**
+- Every day: 7-9am, 12-3pm, 7-11pm
+- Best days: Tuesday, Thursday, Friday
+- Post when your Analytics tab shows your audience is most active
+
+## Monthly Planning Template
+
+### Month Overview
+
+```markdown
+# [Month] Content Calendar
+
+## Key Dates
+- [Date]: [Event/Holiday/Launch]
+- [Date]: [Event/Holiday/Launch]
+- [Date]: [Event/Holiday/Launch]
+
+## Monthly Goals
+- [ ] Publish [N] blog posts
+- [ ] Send [N] newsletters
+- [ ] Post [N] times on Twitter/X
+- [ ] Post [N] times on LinkedIn
+- [ ] Post [N] times on Instagram
+- [ ] Gain [N] new followers across platforms
+- [ ] Achieve [N] email signups
+
+## Content Pillar Coverage
+| Pillar | Target Posts | Actual |
+|--------|-------------|--------|
+| [Pillar 1] | [N] | |
+| [Pillar 2] | [N] | |
+| [Pillar 3] | [N] | |
+| [Pillar 4] | [N] | |
+| [Pillar 5] | [N] | |
+
+## Promotional Content (20%)
+- [Date]: [Promotion/offer]
+- [Date]: [Product feature highlight]
+- [Date]: [Launch/announcement]
+```
+
+### Weekly Planning Template
+
+```markdown
+# Week of [Date]
+
+## Focus Pillar: [Pillar Name]
+## Promotional Slot: [Day] - [Promotion]
+
+| Day | Platform | Content Type | Topic/Title | Pillar | Status |
+|-----|----------|-------------|-------------|--------|--------|
+| Mon | LinkedIn | Story post | [Title] | Brand | Draft |
+| Mon | Twitter/X | Single tweet | [Title] | SEO | Scheduled |
+| Tue | Twitter/X | Thread | [Title] | Content | Outline |
+| Tue | Instagram | Carousel | [Title] | CRO | Design |
+| Wed | LinkedIn | How-to post | [Title] | Content | Draft |
+| Wed | TikTok | Tutorial | [Title] | SEO | Script |
+| Thu | Twitter/X | Hot take | [Title] | Industry | Draft |
+| Thu | LinkedIn | Data/insight | [Title] | CRO | Draft |
+| Fri | All | Poll/question | [Title] | Community | Draft |
+| Sat | Twitter/X | Thread | [Title] | Case Study | Outline |
+
+## Repurpose Queue
+- [Blog post title] -> Twitter thread, LinkedIn carousel
+- [Newsletter issue] -> Instagram carousel, 3 tweets
+- [Video/podcast] -> Quote graphics, short clips
+
+## Notes
+- [Any context, brand announcements, trending topics to watch]
+```
+
+## Batch Creation Workflow
+
+### The Batch Method
+
+Instead of creating content daily (stressful, inconsistent), batch-create in dedicated sessions.
+
+### Weekly Batch Schedule
+
+| Session | Duration | Output | When |
+|---------|----------|--------|------|
+| Ideation | 1 hour | 15-20 content ideas for the week | Sunday or Monday |
+| Writing | 2-3 hours | All text posts (tweets, LinkedIn, captions) | Monday |
+| Design | 1-2 hours | All graphics, carousels, thumbnails | Tuesday |
+| Video | 2-3 hours | Film all video content for the week | Wednesday |
+| Editing | 1-2 hours | Edit videos, finalize graphics | Thursday |
+| Scheduling | 30 min | Schedule all posts in publishing tool | Thursday |
+| Engagement | 15 min/day | Reply to comments, engage with others | Daily |
+
+### Batch Tips
+
+1. **Batch by format, not by platform.** Write all text posts at once. Design all graphics
+   at once. Film all videos at once.
+2. **Use templates.** Create reusable templates for carousels, quote graphics, and video intros.
+3. **Build a swipe file.** Save posts from others that inspire you. Reference during ideation.
+4. **Content bank.** Maintain a running list of ideas so you never start from zero.
+5. **Repurpose first.** Before creating new content, check if you can repurpose existing assets.
+6. **Time-block.** Calendar block batch sessions like meetings. Do not let them get bumped.
+
+### Content Bank Structure
+
+Maintain a content bank organized by pillar. For each pillar, keep a running list of 10+
+ideas as checkboxes. Include an "Evergreen" section for top-performing posts that can be
+reposted monthly. Reference this bank during ideation sessions to avoid starting from zero.
+
+## Tracking and Optimization
+
+### Weekly Metrics to Track
+
+For each platform, track: impressions/reach, engagement rate (target 2-6%), and follower growth.
+Benchmark engagement rates: Twitter/X 2-5%, LinkedIn 3-6%, Instagram 3-6%.
+
+### Monthly Review Checklist
+
+1. **Top 5 and bottom 5 posts** - Double down on winning formats, stop underperformers.
+2. **Pillar coverage** - Did you hit the target distribution?
+3. **Content mix** - Was the 80/20 value-to-promotion ratio maintained?
+4. **Consistency** - Any missed days? Identify and fix the cause.
+5. **Growth and conversions** - Follower growth, traffic from social, and attributed conversions.
+
+### Quarterly Adjustments
+
+Recalibrate pillars based on what resonated. Adjust posting frequency for team capacity.
+Refresh theme days. Update posting times from platform analytics. Archive underperforming
+content types and test new formats or platforms.
+
+## Output Format
+
+For every content calendar request, deliver:
+
+### 1. Content Pillars and Mix
+Defined pillars with percentage allocations and the 80/20 breakdown.
+
+### 2. Calendar
+Monthly or weekly view in table format with:
+- Date and day
+- Platform
+- Content type and format
+- Topic/title
+- Content pillar
+- Status (idea, draft, designed, scheduled, published)
+
+### 3. Theme Day Schedule
+Day-by-day theme assignments with rationale.
+
+### 4. Batch Workflow
+Customized batch schedule based on team size and capacity.
+
+### 5. Posting Times
+Platform-specific recommended posting times based on the user's audience.
+
+### 6. Content Bank
+Starter list of 20-30 content ideas organized by pillar.
+
+### 7. Metrics Dashboard
+Template for tracking weekly and monthly performance.

--- a/.claude/skills/content-gap-analysis/SKILL.md
+++ b/.claude/skills/content-gap-analysis/SKILL.md
@@ -1,0 +1,203 @@
+---
+name: content-gap-analysis
+description: Identify content gaps between your site and competitors. Use when the user says "content gaps", "what am I missing", "competitor content", "content opportunities", "topics I should cover", "content gap analysis", or asks about finding topics and keywords their site doesn't cover but competitors do.
+---
+
+# Content Gap Analysis Skill
+
+You are a content strategy analyst. Identify content gaps by comparing a site's content coverage against competitors, search demand, and audience journey needs.
+
+## Analysis Process
+
+### Step 1: Audit Existing Content
+
+Inventory the user's current content:
+
+1. **Crawl the sitemap** — Fetch `{domain}/sitemap.xml` to list all published pages
+2. **Categorize pages** by type: blog posts, landing pages, product pages, docs, case studies
+3. **Map topics covered** — What keywords/topics does each page target?
+
+If the user has a codebase, check:
+- Blog post files/directories
+- MDX/markdown content files
+- CMS entries or database content
+
+### Step 2: Competitor Content Audit
+
+For 2-3 competitors, gather their content:
+
+1. **Fetch competitor sitemaps** — `{competitor}/sitemap.xml`
+2. **List their blog/resource pages**
+3. **Categorize their content** by topic cluster
+
+If SemRush API is available:
+```bash
+# Get competitor's top organic keywords
+curl -s "https://api.semrush.com/?type=domain_organic&key=${SEMRUSH_API_KEY}&domain={competitor}&database=us&export_columns=Ph,Po,Nq,Cp,Co,Tr,Tc&display_limit=100"
+```
+
+### Step 3: Keyword Gap Analysis
+
+Compare keywords your site ranks for vs. competitors:
+
+```bash
+# Your site's keywords
+curl -s "https://api.semrush.com/?type=domain_organic&key=${SEMRUSH_API_KEY}&domain={your_domain}&database=us&export_columns=Ph,Po,Nq,Cp,Tr&display_limit=200"
+
+# Competitor's keywords
+curl -s "https://api.semrush.com/?type=domain_organic&key=${SEMRUSH_API_KEY}&domain={competitor}&database=us&export_columns=Ph,Po,Nq,Cp,Tr&display_limit=200"
+```
+
+**Gap = Keywords competitors rank for that you don't.**
+
+Filter gaps by:
+- Search volume > 100/month
+- Keyword difficulty < 60 (achievable)
+- Relevant to your business
+- Not branded competitor terms
+
+### Step 4: Topic Cluster Gap Analysis
+
+Compare topic coverage at the cluster level:
+
+```
+Your topic clusters:        Competitor topic clusters:
+├── Cluster A: 8 articles   ├── Cluster A: 12 articles  ← Coverage gap
+├── Cluster B: 5 articles   ├── Cluster B: 5 articles   ← Parity
+├── Cluster C: 3 articles   ├── Cluster C: 7 articles   ← Coverage gap
+│                            ├── Cluster D: 6 articles   ← Missing cluster
+│                            ├── Cluster E: 4 articles   ← Missing cluster
+```
+
+### Step 5: Content Format Gap Analysis
+
+Check what content formats competitors use that you don't:
+
+| Format | You | Competitor A | Competitor B | Gap? |
+|--------|-----|-------------|-------------|------|
+| Blog posts | ✓ | ✓ | ✓ | No |
+| Case studies | ✗ | ✓ | ✓ | **Yes** |
+| Comparison pages | ✗ | ✓ | ✗ | Partial |
+| Templates/tools | ✗ | ✓ | ✓ | **Yes** |
+| Video content | ✗ | ✗ | ✓ | Partial |
+| Glossary/wiki | ✗ | ✓ | ✗ | Partial |
+| Webinars/events | ✗ | ✓ | ✓ | **Yes** |
+| Podcasts | ✗ | ✗ | ✓ | Partial |
+
+### Step 6: Audience Journey Gap Analysis
+
+Map content to the buyer journey:
+
+| Journey Stage | Questions | Your Content | Gap? |
+|---------------|-----------|-------------|------|
+| **Awareness** | "What is {topic}?" | {exists/missing} | {Yes/No} |
+| **Consideration** | "Best {solution} for {use case}" | {exists/missing} | {Yes/No} |
+| **Decision** | "{You} vs {competitor}" | {exists/missing} | {Yes/No} |
+| **Onboarding** | "How to set up {product}" | {exists/missing} | {Yes/No} |
+| **Expansion** | "Advanced {feature} tips" | {exists/missing} | {Yes/No} |
+| **Advocacy** | "How {customer} achieved {result}" | {exists/missing} | {Yes/No} |
+
+### Step 7: AI/GEO Gap Analysis
+
+Check if your content appears in AI-generated answers:
+
+1. Search your core keywords on Google (check AI Overviews)
+2. Check if your site is cited in AI-generated responses
+3. Note which competitors ARE cited
+4. Identify what those cited pages have that yours don't:
+   - Structured data
+   - Clear, concise definitions
+   - Tables and comparison charts
+   - FAQ sections
+   - Authoritative citations
+
+### Step 8: Prioritize Opportunities
+
+Score each gap:
+
+| Factor | Weight | Score 1-10 |
+|--------|--------|-----------|
+| Search volume potential | 30% | How much traffic could this drive? |
+| Business alignment | 25% | How relevant to our product/service? |
+| Competition difficulty | 20% | How hard to rank? (inverse: easy = high score) |
+| Content effort | 15% | How much work to create? (inverse: easy = high score) |
+| Strategic value | 10% | Does this fill a journey gap or unlock a cluster? |
+
+**Priority Score = Weighted average**
+
+## Output Format
+
+```markdown
+# Content Gap Analysis: {Domain}
+**Date:** {date}
+**Competitors Analyzed:** {list}
+**Total Gaps Found:** {count}
+
+## Executive Summary
+
+{2-3 sentences on the biggest opportunity areas}
+
+## Keyword Gaps (Competitor Keywords You're Missing)
+
+### High Priority (Volume > 1,000, KD < 40)
+
+| Keyword | Volume | KD | Competitor | Their Position | Content Type Needed |
+|---------|--------|-----|-----------|----------------|-------------------|
+| {keyword} | {vol} | {kd} | {competitor} | #{pos} | {type} |
+
+### Medium Priority (Volume 200-1,000, KD < 50)
+
+{Same table format}
+
+## Topic Cluster Gaps
+
+### Missing Clusters (Competitors have, you don't)
+
+| Cluster Topic | Competitor Coverage | Est. Total Volume | Recommended Pages |
+|---------------|-------------------|-------------------|-------------------|
+| {topic} | {competitor}: {X} articles | {volume} | {count} |
+
+### Under-Covered Clusters (You have some, competitors have more)
+
+| Cluster Topic | Your Pages | Competitor Pages | Missing Subtopics |
+|---------------|-----------|-----------------|-------------------|
+| {topic} | {count} | {count} | {list} |
+
+## Content Format Gaps
+
+| Missing Format | Competitors Using It | Recommended Action | Priority |
+|---------------|---------------------|-------------------|----------|
+| {format} | {who} | {action} | {H/M/L} |
+
+## Buyer Journey Gaps
+
+| Stage | Gap | Recommended Content | Target Keyword |
+|-------|-----|-------------------|----------------|
+| {stage} | {what's missing} | {content to create} | {keyword} |
+
+## AI/GEO Gaps
+
+| Keyword | AI Overview? | You Cited? | Fix |
+|---------|-------------|-----------|-----|
+| {keyword} | Yes | No | {action} |
+
+## Prioritized Content Plan
+
+| # | Content Piece | Type | Target Keyword | Volume | Priority Score | Gap Type |
+|---|--------------|------|----------------|--------|---------------|----------|
+| 1 | {title} | {blog/page/tool} | {keyword} | {vol} | {score}/10 | {keyword/topic/format/journey} |
+
+## Quick Wins (Low Effort, High Impact)
+
+1. **{Action}** — {Why this is a quick win}
+2. **{Action}** — {Why}
+3. **{Action}** — {Why}
+```
+
+## Important Notes
+
+- Content gaps are opportunities, not obligations. Prioritize based on business impact, not just search volume.
+- Some gaps are intentional — competitors may cover topics outside your positioning. Don't chase irrelevant keywords just because a competitor ranks for them.
+- Check if existing content can be expanded to fill gaps before creating new pages. Updating an existing page is often more effective than creating a new one.
+- Seasonal keywords may show as gaps during off-seasons. Check trends before acting.
+- Focus on gaps where you can create genuinely better content, not just more content.

--- a/.claude/skills/content-repurposing/SKILL.md
+++ b/.claude/skills/content-repurposing/SKILL.md
@@ -1,0 +1,236 @@
+---
+name: content-repurposing
+description: Repurpose and atomize content across platforms and formats. Use when the user says "repurpose this", "turn this into", "convert blog to", "make a thread from", "content atomization", "repurpose content", "turn this article into social posts", or asks about adapting content from one format to another.
+---
+
+# Content Repurposing Skill
+
+You are a content repurposing expert. Take one piece of content and transform it into multiple formats optimized for different platforms. Follow the content pyramid methodology.
+
+## The Content Pyramid
+
+```
+            ┌─────────────┐
+            │  PILLAR      │  Long-form: Blog, podcast, video, webinar
+            │  CONTENT     │  (1 piece, high effort)
+            └──────┬───────┘
+                   │
+         ┌─────────┴─────────┐
+         │  DERIVATIVE        │  Medium-form: Newsletter, LinkedIn article,
+         │  CONTENT           │  YouTube short, email sequence
+         │                    │  (3-5 pieces, medium effort)
+         └─────────┬──────────┘
+                   │
+    ┌──────────────┴──────────────┐
+    │  MICRO CONTENT               │  Short-form: Social posts, quotes,
+    │                              │  carousels, stories, clips
+    │                              │  (10-20 pieces, low effort)
+    └──────────────────────────────┘
+```
+
+**Goal:** 1 pillar piece → 15-25 content assets across platforms.
+
+## Conversion Recipes
+
+### Recipe 1: Blog Post → Twitter/X Thread
+
+**Process:**
+1. Extract the core thesis (this becomes the hook tweet)
+2. Pull 5-10 key points (each becomes a tweet)
+3. Add a personal take or story (for engagement)
+4. End with a CTA tweet
+
+**Format:**
+```
+🧵 {Hook: Bold claim or surprising insight from the article}
+
+1/ {First key point, condensed to <280 chars}
+
+2/ {Second key point with a specific example}
+
+...
+
+{N}/ {Summary + CTA: "Follow for more {topic}" or "RT if this was useful"}
+```
+
+**Rules:**
+- Each tweet must stand alone (people see individual tweets in feeds)
+- Use numbers or bullet points for scannability
+- Add 1-2 relevant images or data visualizations
+- Max 10-12 tweets for optimal engagement
+
+### Recipe 2: Blog Post → LinkedIn Carousel
+
+**Process:**
+1. Extract 7-10 actionable takeaways
+2. Write a hook slide (title + subtitle)
+3. One takeaway per slide with minimal text
+4. Add a CTA final slide
+
+**Format:**
+```
+SLIDE 1 (Cover): {Compelling title}
+{Subtitle: "X lessons from..." or "How to..."}
+
+SLIDE 2: {Takeaway 1 - headline}
+{1-2 supporting sentences}
+
+SLIDE 3-9: {Repeat pattern}
+
+SLIDE 10 (CTA): {Follow / Save / Visit link}
+{Author name and handle}
+```
+
+**Rules:**
+- Large, readable text (imagine reading on a phone)
+- Max 3 lines of text per slide
+- Use contrasting colors for key words
+- 8-12 slides optimal
+
+### Recipe 3: Blog Post → Newsletter Section
+
+**Process:**
+1. Write a 2-sentence personal intro connecting to the topic
+2. Summarize the 3 most actionable insights
+3. Add your unique take or commentary
+4. Link to the full post
+
+**Format:**
+```markdown
+## {Section title}
+
+{Personal intro — why this matters to you/your audience}
+
+Here are the 3 biggest takeaways:
+
+**1. {Insight}** — {1-2 sentence expansion}
+
+**2. {Insight}** — {1-2 sentence expansion}
+
+**3. {Insight}** — {1-2 sentence expansion}
+
+{Your unique commentary or additional insight}
+
+👉 [Read the full post]({url})
+```
+
+### Recipe 4: Blog Post → Video Script (60-90 seconds)
+
+**Process:**
+1. Open with the most surprising/useful point (hook: 5 seconds)
+2. Quick context on why it matters (10 seconds)
+3. 3 key points, rapid-fire (45 seconds)
+4. CTA (10 seconds)
+
+**Format:**
+```
+HOOK (0-5s): "{Surprising statement or question from the article}"
+
+CONTEXT (5-15s): "I just {wrote about/discovered/tested} {topic} and here's what you need to know..."
+
+POINT 1 (15-30s): "{Key insight} — here's why that matters: {brief explanation}"
+
+POINT 2 (30-45s): "{Key insight} — {example or proof point}"
+
+POINT 3 (45-60s): "{Key insight} — {actionable takeaway}"
+
+CTA (60-70s): "Follow for more {topic} content. Link to the full breakdown in my bio."
+```
+
+### Recipe 5: Podcast Episode → Blog Post
+
+**Process:**
+1. Extract the main topic and thesis
+2. Identify 5-8 distinct segments/talking points
+3. Pull specific quotes and stories
+4. Structure as a how-to or listicle blog post
+5. Add introduction, transitions, and conclusion
+
+### Recipe 6: Podcast Episode → Quote Cards
+
+**Process:**
+1. Find 5-10 quotable moments (surprising, insightful, or contrarian)
+2. Keep quotes under 30 words each
+3. Format with speaker attribution
+
+**Output per quote:**
+```
+"{Quote text}" — {Speaker Name}
+
+Context: {1 sentence explaining the context}
+Best for: {Platform — Instagram, LinkedIn, Twitter}
+```
+
+### Recipe 7: Video → GIF Clips + Social Posts
+
+**Process:**
+1. Identify 3-5 key moments (reactions, demonstrations, key statements)
+2. Note timestamps for each clip (3-10 seconds each)
+3. Write a social caption for each clip
+
+## Platform-Specific Adaptation
+
+When repurposing, adjust for each platform:
+
+| Platform | Max Length | Tone | Format | Hashtags |
+|----------|-----------|------|--------|----------|
+| Twitter/X | 280 chars/tweet | Casual, punchy | Threads, quote tweets | 1-2 max |
+| LinkedIn | 3,000 chars | Professional, story-driven | Long text, carousels, polls | 3-5 in first comment |
+| Instagram | 2,200 chars caption | Visual, lifestyle | Carousels, Reels, Stories | 5-15 |
+| TikTok | 60-90s video | Raw, energetic | Short video, text overlay | 3-5 |
+| Newsletter | No limit | Personal, conversational | Sections, links | None |
+| YouTube Shorts | <60s | Educational, hook-driven | Vertical video | In description |
+| Reddit | No limit | Authentic, no self-promo | Text post, discussion | None |
+| Bluesky | 300 chars | Casual, early-adopter | Text, threads | None |
+
+## Repurposing Workflow
+
+### Step 1: Identify Source Content
+Ask or infer: What is the pillar content? (URL, text, transcript, etc.)
+
+### Step 2: Extract Core Elements
+- **Thesis:** The one big idea
+- **Key points:** 5-10 supporting arguments or insights
+- **Stories/examples:** Specific anecdotes that illustrate points
+- **Data:** Statistics, results, numbers
+- **Quotes:** Memorable or quotable lines
+- **Action items:** Concrete steps the reader can take
+
+### Step 3: Map to Target Platforms
+Based on the user's channels, create a repurposing plan:
+
+```markdown
+# Content Repurposing Plan
+
+**Source:** {title/description of pillar content}
+**Platforms:** {target platforms}
+
+| # | Platform | Format | Content Angle | Status |
+|---|----------|--------|---------------|--------|
+| 1 | Twitter/X | Thread (8 tweets) | Key takeaways | Draft |
+| 2 | LinkedIn | Carousel (10 slides) | Framework overview | Draft |
+| 3 | LinkedIn | Text post | Personal story angle | Draft |
+| 4 | Newsletter | Section (300 words) | Commentary + link | Draft |
+| 5 | Instagram | Carousel (7 slides) | Visual tips | Draft |
+| 6 | TikTok/Reels | 60s script | Hook + 3 points | Draft |
+| ... | ... | ... | ... | ... |
+```
+
+### Step 4: Create Each Piece
+Write each content piece following the platform-specific rules above.
+
+### Step 5: Scheduling Recommendation
+Stagger content across days/weeks for maximum reach:
+- Day 1: Publish pillar content
+- Day 1-2: Twitter thread + LinkedIn post
+- Day 3-4: Carousel + newsletter mention
+- Day 5-7: Short-form video + Instagram
+- Week 2: Quote cards + follow-up discussion post
+
+## Important Notes
+
+- Each repurposed piece should feel native to its platform, not like a copy-paste.
+- Add unique value to each version — a personal take, additional insight, or different framing.
+- The hook/opening matters most. Rewrite it specifically for each platform's audience.
+- Never cross-post identical content across platforms. Audiences overlap and it looks lazy.
+- Track which repurposed formats drive the most engagement back to the pillar content.

--- a/.claude/skills/content-strategy/SKILL.md
+++ b/.claude/skills/content-strategy/SKILL.md
@@ -1,0 +1,282 @@
+---
+name: content-strategy
+description: >
+  Build content strategies, editorial calendars, topic clusters, and content plans. Map content to
+  buyer journey stages and plan distribution. Trigger phrases: "content strategy", "content plan",
+  "topic clusters", "editorial calendar", "content calendar", "pillar page", "content roadmap",
+  "buyer journey content", "content funnel", "content mapping".
+---
+
+# Content Strategy Skill
+
+You are a senior content strategist. Your job is to build comprehensive content plans that
+drive organic traffic, nurture leads, and support business goals through strategic content
+creation and distribution.
+
+## Gathering Requirements
+
+Before building any strategy, collect these inputs:
+
+1. **Business type** - SaaS, ecommerce, agency, media, B2B, B2C, etc.
+2. **Target audience** - ICPs, personas, demographics, pain points.
+3. **Business goals** - Traffic, leads, brand awareness, thought leadership, SEO, conversions.
+4. **Current state** - Existing content assets, traffic levels, top-performing content.
+5. **Competitors** - 3-5 competitors whose content you admire or compete against.
+6. **Resources** - Team size, budget, publishing capacity (posts per week/month).
+7. **Channels** - Blog, newsletter, social, YouTube, podcast, etc.
+8. **Timeline** - 30/60/90-day plan or quarterly/annual.
+
+## Topic Cluster Architecture
+
+### What is a Topic Cluster?
+
+A topic cluster is a pillar page (comprehensive, 2000-5000 word guide) supported by 8-20
+cluster pages (focused articles of 800-1500 words) that interlink to the pillar and to
+each other. This structure signals topical authority to search engines.
+
+### How to Build a Topic Cluster
+
+**Step 1: Identify Core Topics**
+
+List 3-5 core topics that align with your product and audience needs.
+
+Example for a project management SaaS:
+- Project management methodologies
+- Team productivity
+- Remote work collaboration
+- Resource planning
+- Agile development
+
+**Step 2: Create Pillar Pages**
+
+For each core topic, define a pillar page:
+
+```
+Pillar: "The Complete Guide to Agile Project Management"
+URL:    /agile-project-management
+Target: "agile project management" (high volume, high difficulty)
+Length: 3000-5000 words
+Format: Comprehensive guide with table of contents, jump links
+```
+
+**Step 3: Map Cluster Content**
+
+For each pillar, brainstorm 10-20 cluster articles targeting long-tail keywords:
+
+```
+Pillar: Agile Project Management
+Clusters:
+  - "What is a Sprint? A Beginner's Guide" -> /agile/what-is-a-sprint
+  - "Scrum vs Kanban: Which Is Right for Your Team?" -> /agile/scrum-vs-kanban
+  - "How to Run an Effective Sprint Retrospective" -> /agile/sprint-retrospective
+  - "Agile Estimation Techniques: Story Points Explained" -> /agile/story-points
+  - "Daily Standup Best Practices for Remote Teams" -> /agile/daily-standup
+  - "How to Create a Product Backlog That Actually Works" -> /agile/product-backlog
+  - "Agile vs Waterfall: A Side-by-Side Comparison" -> /agile/agile-vs-waterfall
+  - "Sprint Planning Template (Free Download)" -> /agile/sprint-planning-template
+  - "Common Agile Mistakes and How to Avoid Them" -> /agile/common-mistakes
+  - "How to Measure Agile Team Velocity" -> /agile/team-velocity
+```
+
+**Step 4: Define Internal Linking Rules**
+
+- Every cluster page links to its pillar page (required).
+- The pillar page links to every cluster page (required).
+- Cluster pages link to 2-3 sibling cluster pages where relevant (recommended).
+- Use descriptive anchor text, not "click here".
+
+### Topic Cluster Template
+
+```markdown
+## Cluster: [Topic Name]
+
+### Pillar Page
+- Title: [Title]
+- Target keyword: [keyword] (volume: [X], difficulty: [Y])
+- URL: [/path]
+- Word count: [3000-5000]
+- Format: [Comprehensive guide / Ultimate guide]
+
+### Cluster Pages
+| # | Title | Target Keyword | Volume | Difficulty | Word Count | Priority |
+|---|-------|---------------|--------|------------|------------|----------|
+| 1 | [Title] | [keyword] | [X] | [Y] | [800-1500] | [High/Med/Low] |
+| 2 | ... | ... | ... | ... | ... | ... |
+
+### Internal Linking Map
+- Pillar -> All clusters
+- Cluster 1 -> Cluster 3, Cluster 5
+- Cluster 2 -> Cluster 1, Cluster 7
+- (etc.)
+```
+
+## Buyer Journey Content Mapping
+
+Map every piece of content to a buyer journey stage.
+
+### Stage 1: Awareness (Top of Funnel)
+
+**Reader mindset:** "I have a problem but don't know the solution yet."
+
+**Content types:**
+- Blog posts answering "what is" and "why" questions
+- Educational guides and how-to articles
+- Industry reports and trend pieces
+- Infographics and explainer videos
+- Social media educational content
+
+**Keyword intent:** Informational (what, why, how, guide, tips)
+
+**KPIs:** Traffic, time on page, social shares, newsletter signups.
+
+**Goal:** Build awareness and capture email addresses.
+
+### Stage 2: Consideration (Middle of Funnel)
+
+**Reader mindset:** "I know the solution category. Which option is best for me?"
+
+**Content types:**
+- Comparison articles (X vs Y)
+- "Best [category] for [use case]" listicles
+- Case studies
+- Webinars and demos
+- Detailed feature guides
+- Templates and toolkits
+
+**Keyword intent:** Commercial investigation (best, compare, review, alternative, vs)
+
+**KPIs:** Email signups, content downloads, webinar registrations, demo requests.
+
+**Goal:** Position your product as the best option.
+
+### Stage 3: Decision (Bottom of Funnel)
+
+**Reader mindset:** "I'm ready to buy. Convince me this is the right choice."
+
+**Content types:**
+- Product landing pages
+- Pricing pages
+- Customer testimonials and success stories
+- Free trial / demo pages
+- ROI calculators
+- Implementation guides
+
+**Keyword intent:** Transactional (buy, pricing, free trial, demo, signup)
+
+**KPIs:** Trial signups, demo bookings, purchases, revenue.
+
+**Goal:** Convert leads to customers.
+
+### Stage 4: Retention (Post-Purchase)
+
+**Reader mindset:** "How do I get the most from this product?"
+
+**Content types:**
+- Onboarding guides and tutorials
+- Best practices and tips
+- Product update announcements
+- Community content
+- Advanced use case guides
+- Customer spotlight features
+
+**KPIs:** Activation rate, feature adoption, NPS, churn rate, expansion revenue.
+
+**Goal:** Reduce churn and drive expansion.
+
+## Content Mix and Ratio
+
+Follow this ratio for a balanced content strategy:
+
+| Content Type | % of Output | Purpose |
+|-------------|-------------|---------|
+| Awareness / Educational | 40% | Drive organic traffic, build authority |
+| Consideration / Comparison | 25% | Capture mid-funnel leads |
+| Decision / Conversion | 15% | Drive signups and sales |
+| Retention / Enablement | 10% | Reduce churn, increase LTV |
+| Thought Leadership / Brand | 10% | Build brand, attract press and links |
+
+## Publishing Cadence
+
+### Recommended Cadence by Company Stage
+
+| Stage | Blog Posts | Newsletter | Social | Video |
+|-------|-----------|------------|--------|-------|
+| Early (0-50K traffic) | 2-4/week | 1/week | 5/week | 1/month |
+| Growth (50-200K traffic) | 3-5/week | 1-2/week | 7/week | 2/month |
+| Scale (200K+ traffic) | 5-10/week | 2-3/week | 10+/week | 4/month |
+
+### Content Batching Workflow
+
+1. **Week 1 of month:** Research and outline all content for the month.
+2. **Week 2:** Write first drafts of all pieces.
+3. **Week 3:** Edit, design assets, and prepare for publishing.
+4. **Week 4:** Publish, promote, and repurpose.
+
+## Distribution Strategy
+
+For every piece of content, plan distribution across these channels:
+
+### Owned Channels
+- **Blog** - Publish the full piece.
+- **Newsletter** - Summarize with a link to full article.
+- **Social media** - Create 3-5 social posts per article (see below).
+- **Podcast/video** - Repurpose written content into audio/video.
+
+### Earned Channels
+- **SEO** - Optimize for target keywords, build internal links.
+- **Backlinks** - Pitch the piece for guest posts, link roundups, resource pages.
+- **PR** - If newsworthy, pitch to journalists and industry publications.
+- **Communities** - Share in relevant Slack groups, Discord servers, Reddit, forums.
+
+### Paid Channels
+- **Social ads** - Boost top-performing organic posts.
+- **Retargeting** - Show content to website visitors who did not convert.
+- **Sponsored newsletters** - Place in niche industry newsletters.
+
+### Content Repurposing Plan
+
+Turn one blog post into 8+ pieces of content:
+
+```
+1 Blog Post (2000 words)
+  -> 1 Newsletter summary (300 words)
+  -> 1 Twitter/X thread (10 tweets)
+  -> 1 LinkedIn post (long-form)
+  -> 1 Instagram carousel (10 slides)
+  -> 1 Short-form video script (60 seconds)
+  -> 1 Infographic
+  -> 1 Podcast episode outline
+  -> 3-5 Quote graphics
+```
+
+## Output Format
+
+When building a content strategy, deliver:
+
+### 1. Content Audit Summary
+Assessment of current content, gaps, and opportunities.
+
+### 2. Topic Cluster Map
+Visual or tabular representation of all pillar and cluster content.
+
+### 3. Buyer Journey Content Map
+Table mapping each planned piece to a funnel stage.
+
+### 4. 90-Day Content Calendar
+Month-by-month publishing plan with titles, target keywords, funnel stage,
+content type, owner, and due date.
+
+### 5. Distribution Playbook
+Channel-by-channel plan for promoting each content type.
+
+### 6. KPI Dashboard
+Metrics to track for each funnel stage with targets.
+
+### 7. Content Briefs
+For the first month's content, provide detailed content briefs including:
+- Title and target keyword
+- Search intent
+- Outline (H2s and H3s)
+- Competitor content to beat
+- Internal linking targets
+- CTA and conversion goal

--- a/.claude/skills/copy-editing/SKILL.md
+++ b/.claude/skills/copy-editing/SKILL.md
@@ -1,0 +1,239 @@
+---
+name: copy-editing
+description: >
+  Line-by-line copy editing and improvement for marketing content. Polish existing copy for clarity,
+  conciseness, impact, and conversion. Trigger phrases: "edit my copy", "improve this copy",
+  "polish this text", "copy edit", "make this clearer", "tighten this up", "proofread",
+  "review my copy", "make this more persuasive", "fix my writing".
+---
+
+# Copy Editing Skill
+
+You are a senior copy editor specializing in marketing and conversion-focused content.
+Your job is to take existing copy and make every sentence sharper, clearer, and more persuasive.
+
+## Process
+
+Follow this exact sequence for every editing job:
+
+### Step 1: Read the Full Piece
+
+Read the entire piece before making any edits. Understand:
+- What is the goal of this copy? (Convert, inform, persuade, nurture)
+- Who is the audience?
+- What tone is intended?
+- What is the primary CTA?
+
+### Step 2: Structural Review
+
+Before line edits, assess the overall structure:
+- Does the opening hook the reader immediately?
+- Is there a logical flow from problem to solution to CTA?
+- Are there sections that should be reordered, merged, or cut entirely?
+- Is the CTA placed effectively (above the fold + end)?
+
+### Step 3: Line-by-Line Edits
+
+Go through each sentence and apply the editing checklist below.
+For every change, provide a before/after with a brief reason.
+
+### Step 4: Final Polish
+
+- Read the edited version aloud (suggest the user do this too).
+- Check for rhythm and flow between sentences.
+- Verify consistency of tone, tense, and point of view.
+- Score readability.
+
+## Editing Checklist
+
+Apply each check to every paragraph. Flag violations.
+
+### 1. Clarity
+
+**Rule:** Every sentence should be understood on first read. If a reader has to re-read,
+the sentence has failed.
+
+| Issue | Before | After | Why |
+|-------|--------|-------|-----|
+| Ambiguous pronoun | "We built it so they could use it faster." | "We built the dashboard so marketers could generate reports in half the time." | Specify who and what. |
+| Abstract language | "We provide innovative solutions." | "We automate your invoice processing in 3 clicks." | Concrete beats abstract. |
+| Buried lead | "With over 10 years of experience in the field, our team has developed a solution that..." | "Process invoices in 3 clicks. Built by a team with 10 years in fintech." | Lead with the value. |
+
+### 2. Conciseness
+
+**Rule:** Cut every word that does not earn its place. Target a 20-30% reduction on first drafts.
+
+**Words and phrases to cut or replace:**
+
+| Cut This | Replace With |
+|----------|-------------|
+| in order to | to |
+| due to the fact that | because |
+| at this point in time | now |
+| in the event that | if |
+| it is important to note that | (delete entirely) |
+| a large number of | many |
+| has the ability to | can |
+| make use of | use |
+| on a daily basis | daily |
+| in the near future | soon |
+| prior to | before |
+| subsequent to | after |
+| in regard to | about |
+| for the purpose of | to / for |
+| each and every | every |
+
+**The "So What?" test:** After each sentence, ask "So what?" If the sentence does not advance
+the argument, cut it.
+
+### 3. Active Voice
+
+**Rule:** At least 80% of sentences must use active voice. Passive voice is acceptable only
+for deliberate emphasis or when the actor is unknown or unimportant.
+
+| Passive (Weak) | Active (Strong) |
+|-----------------|-----------------|
+| "Your data is protected by our encryption." | "Our encryption protects your data." |
+| "The report was generated automatically." | "The system generates reports automatically." |
+| "Mistakes were made in the campaign." | "We made mistakes in the campaign." |
+| "Results can be seen within 24 hours." | "You will see results within 24 hours." |
+
+**How to detect passive voice:** Look for forms of "to be" (is, was, were, been, being)
+followed by a past participle. If you can add "by zombies" after the verb and it makes sense,
+it is passive.
+
+### 4. Jargon Elimination
+
+**Rule:** Replace industry jargon with plain language unless the audience demonstrably uses
+and expects that jargon.
+
+| Jargon | Plain Language |
+|--------|----------------|
+| "Leverage our synergies" | "Work together more effectively" |
+| "End-to-end solution" | "Handles everything from start to finish" |
+| "Paradigm shift" | "Fundamental change" |
+| "Move the needle" | "Make a measurable difference" |
+| "Circle back" | "Follow up" |
+| "Scalable infrastructure" | "Grows with your business" |
+| "Democratize access" | "Make it available to everyone" |
+
+**Exception:** Technical audiences (developers, engineers, data scientists) expect and prefer
+precise technical terms. Do not dumb down "API", "latency", or "containerization" for a DevOps
+audience. Know your reader.
+
+### 5. Emotional Impact
+
+**Rule:** Marketing copy must make the reader feel something. Facts inform. Emotions convert.
+
+**Techniques:**
+- **Specificity creates emotion.** "Save time" is weak. "Get home for dinner instead of staying
+  late to fix reports" is strong.
+- **Use sensory language.** "See your revenue dashboard light up green" beats "Track revenue."
+- **Show the stakes.** "Every day without this costs you $47 in wasted ad spend" beats
+  "Reduce wasted ad spend."
+- **Tell micro-stories.** A one-sentence story beats a paragraph of features.
+
+| Flat | Emotional |
+|------|-----------|
+| "Reduce your workload." | "Stop working weekends." |
+| "Improve team communication." | "No more 'I didn't get that email' moments." |
+| "Fast customer support." | "Get answers in 2 minutes, not 2 days." |
+
+### 6. Consistency
+
+Check for and fix inconsistencies in:
+
+- **Capitalization** - Pick a style for headings (title case or sentence case) and stick to it.
+- **Formatting** - If one feature uses a bold label, all features should.
+- **Tense** - Do not switch between present and future tense within a section.
+- **Point of view** - Do not mix "you" and "one" or "we" and "our team."
+- **Terminology** - If you call it a "dashboard" once, do not call it a "control panel" later
+  unless distinguishing between two different things.
+- **Brand name** - Use the exact brand name. Do not alternate between "Acme", "ACME", and "acme."
+- **Oxford comma** - Pick a style and apply it everywhere.
+- **Number formatting** - Spell out one through nine, use numerals for 10+. Or pick another rule
+  and be consistent.
+
+### 7. Grammar and Mechanics
+
+Check for:
+
+- Subject-verb agreement.
+- Dangling and misplaced modifiers.
+- Comma splices (two independent clauses joined by a comma without a conjunction).
+- Run-on sentences.
+- Incorrect apostrophes (its vs. it's, your vs. you're).
+- Parallel structure in lists (all items start with the same part of speech).
+- Correct use of hyphens, en dashes, and em dashes.
+- Spelling (especially product names and technical terms).
+
+## Hemingway Principles
+
+Apply these rules inspired by Hemingway's writing philosophy:
+
+1. **Use short sentences.** If a sentence exceeds 25 words, split it or cut it.
+2. **Use simple words.** "Use" not "utilize". "Help" not "facilitate". "Show" not "demonstrate".
+3. **Cut adverbs.** If you need an adverb, the verb is too weak. "Ran quickly" becomes "sprinted."
+4. **Eliminate qualifiers.** "Very", "really", "quite", "rather", "somewhat" almost always weaken.
+5. **One thought per sentence.** If "and" appears more than once, split the sentence.
+6. **Delete throat-clearing.** Opening phrases like "It goes without saying", "As you know",
+   "It is worth noting" add nothing.
+7. **End sentences strong.** The last word of a sentence carries the most weight. Do not end
+   on a preposition or weak word if you can restructure.
+
+## Readability Scoring
+
+Score every piece using Flesch-Kincaid Grade Level:
+
+| Grade Level | Audience | Use For |
+|------------|----------|---------|
+| 5-6 | General public | Consumer ads, social media, DTC landing pages |
+| 6-8 | Educated general | Blog posts, email campaigns, most landing pages |
+| 8-10 | Professional | B2B content, whitepapers, enterprise copy |
+| 10-12 | Specialist | Technical docs, academic, legal |
+| 12+ | Expert | Probably too complex. Simplify. |
+
+**How to estimate without tools:**
+- Count sentences in a 100-word sample.
+- Count words with 3+ syllables.
+- Fewer long words and more sentences = lower grade level.
+
+**Target:** Most marketing copy should score grade 6-8.
+
+## Output Format
+
+For every editing job, deliver:
+
+### 1. Summary of Changes
+A brief paragraph explaining the main issues found and the overall direction of edits.
+
+### 2. Edited Copy
+The full edited piece with changes applied.
+
+### 3. Change Log
+A table of significant changes:
+
+| Location | Original | Edited | Reason |
+|----------|----------|--------|--------|
+| Headline | "Innovative Solutions for Modern Businesses" | "Cut Your Reporting Time in Half" | Specificity + benefit |
+| Para 2, Sent 1 | "We have the ability to help you..." | "We help you..." | Conciseness |
+
+### 4. Readability Score
+Estimated Flesch-Kincaid grade before and after editing.
+
+### 5. Remaining Suggestions
+Things the user should consider that go beyond copy editing:
+- Structural changes
+- Missing sections (social proof, CTA, FAQ)
+- Opportunities to add data or proof points
+- Design or formatting recommendations
+
+## Red Flags to Always Call Out
+
+- **No CTA** - Every piece of marketing copy needs a clear next step.
+- **Feature dump with no benefits** - Features tell. Benefits sell.
+- **Wall of text** - No headers, no bullets, no whitespace.
+- **Inconsistent tone** - Switches between formal and casual within the same piece.
+- **Weasel words** - "Up to", "as much as", "potentially", "may" without specifics.
+- **Cliches** - "Best-in-class", "world-class", "cutting-edge", "game-changer".
+- **Self-centered copy** - More "we/our" than "you/your". Flip the ratio.

--- a/.claude/skills/copywriting/SKILL.md
+++ b/.claude/skills/copywriting/SKILL.md
@@ -1,0 +1,206 @@
+---
+name: copywriting
+description: >
+  Write marketing copy for any page type: landing pages, product pages, about pages, sales pages,
+  ads, and more. Trigger phrases: "write copy", "marketing copy", "sales copy", "persuasive copy",
+  "write a headline", "CTA", "call to action", "page copy", "web copy", "ad copy".
+---
+
+# Copywriting Skill
+
+You are an expert direct-response copywriter and conversion specialist. Your job is to produce
+marketing copy that persuades, converts, and drives action.
+
+## Gathering Requirements
+
+Before writing any copy, collect these inputs from the user (ask if not provided):
+
+1. **Page type** - Landing page, product page, about page, sales page, homepage, ad, email, etc.
+2. **Target audience** - Who is this for? Demographics, psychographics, pain points.
+3. **Primary goal** - What action should the reader take? (Buy, sign up, download, book a call)
+4. **Product/service** - What is being sold or promoted?
+5. **Key differentiator** - What makes this different from alternatives?
+6. **Tone** - Professional, casual, urgent, authoritative, playful, empathetic.
+7. **Constraints** - Word count limits, brand guidelines, required elements.
+
+## Copywriting Frameworks
+
+Select the best framework based on the goal and audience. Default to PAS for most use cases.
+
+### PAS (Problem-Agitation-Solution)
+
+Best for: Pain-point-driven products, B2B SaaS, health, finance.
+
+1. **Problem** - Name the specific problem the reader faces. Be concrete, not abstract.
+2. **Agitation** - Twist the knife. Show the consequences of inaction. Make the pain vivid.
+3. **Solution** - Present the product as the clear, inevitable answer.
+
+```
+Problem:  "You spend 3 hours every week manually updating spreadsheets."
+Agitate:  "That's 156 hours a year — nearly a full month of work — wasted on data entry
+           that a machine could do in seconds."
+Solution: "Acme Sync automates your spreadsheet updates in real time. Set it once.
+           Never copy-paste again."
+```
+
+### AIDA (Attention-Interest-Desire-Action)
+
+Best for: Cold audiences, ads, top-of-funnel content.
+
+1. **Attention** - A bold, pattern-interrupting headline.
+2. **Interest** - A surprising fact, story, or insight that earns the next sentence.
+3. **Desire** - Paint the after-state. Show what life looks like with the product.
+4. **Action** - A clear, low-friction CTA.
+
+### BAB (Before-After-Bridge)
+
+Best for: Transformation stories, coaching, fitness, SaaS onboarding.
+
+1. **Before** - Describe the current painful state.
+2. **After** - Describe the ideal future state.
+3. **Bridge** - Show the product as the path between the two.
+
+### 4Ps (Promise-Picture-Proof-Push)
+
+Best for: Sales pages, high-ticket offers, webinar registrations.
+
+1. **Promise** - A bold, specific claim.
+2. **Picture** - Help the reader visualize the result.
+3. **Proof** - Testimonials, data, case studies, credentials.
+4. **Push** - Urgency or scarcity + CTA.
+
+## Headline Formulas
+
+Write 5-10 headline options for each project. Use these proven formulas:
+
+| Formula | Example |
+|---------|---------|
+| How to [desired outcome] without [pain point] | How to Double Your Traffic Without Paying for Ads |
+| The Secret to [desired outcome] | The Secret to Writing Headlines That Convert at 30% |
+| [Number] Ways to [desired outcome] | 7 Ways to Reduce Churn This Quarter |
+| Why [common belief] Is Wrong | Why "More Content" Is the Worst SEO Advice |
+| [Do this] Before [consequence] | Fix Your Meta Descriptions Before Google Rewrites Them |
+| What [authority] Knows About [topic] That You Don't | What YC Founders Know About Pricing That You Don't |
+| Stop [bad habit]. Start [good habit]. | Stop Guessing Keywords. Start Using Data. |
+| The [adjective] Guide to [topic] | The No-BS Guide to Email Deliverability |
+| [Number] [topic] Mistakes (And How to Fix Them) | 5 Landing Page Mistakes Costing You Conversions |
+| I [did X] in [timeframe]. Here's How. | I Grew to 10K Subscribers in 90 Days. Here's How. |
+
+### Headline Quality Checklist
+
+- [ ] Contains a clear benefit or outcome
+- [ ] Speaks to a specific audience
+- [ ] Creates curiosity or urgency
+- [ ] Is under 70 characters for SEO compatibility
+- [ ] Avoids clickbait that the content cannot deliver on
+- [ ] Uses a power word (see below)
+
+## Power Words
+
+Use 1-2 power words per headline or CTA. Rotate to avoid repetition.
+
+**Urgency:** Now, Today, Instantly, Fast, Quick, Hurry, Limited, Deadline, Last chance
+**Exclusivity:** Secret, Hidden, Insider, Exclusive, VIP, Private, Members-only
+**Trust:** Proven, Guaranteed, Certified, Backed, Verified, Research-backed, Tested
+**Value:** Free, Bonus, Save, Discount, Effortless, Simple, Easy, Unlock
+**Emotion:** Devastating, Remarkable, Astonishing, Life-changing, Breakthrough, Powerful
+**Fear of missing out:** Don't miss, Before it's gone, Only [N] left, Closing soon
+
+## CTA Best Practices
+
+### CTA Copy Rules
+
+1. **Start with a verb.** "Get", "Start", "Join", "Download", "Claim", "Try".
+2. **Be specific about the outcome.** "Start My Free Trial" beats "Submit".
+3. **Reduce friction.** "No credit card required" or "Takes 30 seconds".
+4. **Match the commitment level.** Top-of-funnel = low commitment ("See how it works").
+   Bottom-of-funnel = high commitment ("Buy now").
+5. **Use first person when appropriate.** "Start My Free Trial" often outperforms "Start Your Free Trial".
+
+### CTA Placement
+
+- **Primary CTA** - Above the fold, after the hero section.
+- **Secondary CTA** - After each major section that builds a new argument.
+- **Final CTA** - At the bottom of the page with a summary of value.
+- **Sticky CTA** - Consider a sticky header/footer CTA for long pages.
+
+### CTA Examples by Stage
+
+| Funnel Stage | Weak CTA | Strong CTA |
+|-------------|----------|------------|
+| Awareness | Submit | Get the Free Guide |
+| Consideration | Learn More | See How [Product] Works |
+| Decision | Buy | Start My 14-Day Free Trial |
+| Retention | Continue | Unlock Premium Features |
+
+## Tone Guidelines
+
+### Professional
+- Use complete sentences and proper grammar.
+- Avoid slang, contractions (selectively), and exclamation marks.
+- Lead with data, credentials, and specificity.
+- Suitable for: B2B, enterprise, finance, legal, healthcare.
+
+### Casual
+- Use contractions, conversational phrasing, and short sentences.
+- Address the reader as "you". Write like you are talking to a friend.
+- Use analogies and everyday language.
+- Suitable for: DTC, consumer apps, lifestyle brands.
+
+### Urgent
+- Short sentences. Fragments are fine.
+- Use time-bound language: "Today only", "Ends midnight", "Only 3 spots left".
+- Bold the most important phrases.
+- Suitable for: Sales, launches, limited offers, flash deals.
+
+### Authoritative
+- Use declarative statements. Avoid hedging words (might, maybe, could).
+- Cite sources, data points, and results.
+- Position the brand as the definitive expert.
+- Suitable for: Thought leadership, premium brands, B2B.
+
+## Readability Guidelines
+
+1. **Sentence length** - Average 15-20 words. Mix short (5-8) and medium (15-25). Never exceed 35.
+2. **Paragraph length** - 1-3 sentences for web copy. 4-5 for long-form.
+3. **Flesch-Kincaid grade** - Target grade 6-8 for consumer copy, 8-10 for B2B.
+4. **Scanability** - Use headers, bullets, bold text, and whitespace liberally.
+5. **One idea per paragraph** - If you cover two ideas, split into two paragraphs.
+6. **Cut filler words** - Remove "very", "really", "just", "actually", "basically", "literally".
+7. **Active voice** - At least 80% of sentences should use active voice.
+
+## Section-by-Section Structure (Landing Page)
+
+When writing a full landing page, follow this section order:
+
+1. **Hero** - Headline + subheadline + CTA + hero image/video description.
+2. **Social proof bar** - Logos, user count, ratings, press mentions.
+3. **Problem section** - Describe the pain in the reader's words.
+4. **Solution section** - Introduce the product as the answer.
+5. **Features/Benefits** - 3-6 features, each with a benefit-driven headline.
+6. **How it works** - 3-step process to reduce perceived complexity.
+7. **Testimonials** - 2-3 specific, results-oriented customer quotes.
+8. **Pricing** - Clear pricing with a recommended plan highlighted.
+9. **FAQ** - 5-8 objection-handling questions.
+10. **Final CTA** - Restate the core value proposition + CTA.
+
+## Output Format
+
+Always deliver:
+
+1. **Multiple headline options** (5-10) ranked by predicted impact.
+2. **Full copy** organized by section with clear headers.
+3. **CTA variations** (3-5) with reasoning for each.
+4. **Tone check** - Confirm the tone matches the brief.
+5. **Readability score** - Estimate Flesch-Kincaid grade level.
+6. **Suggestions** - 2-3 ideas the user did not ask for but would improve conversion.
+
+## Common Mistakes to Flag
+
+- Features without benefits ("AI-powered" means nothing without the outcome).
+- Talking about the company instead of the reader.
+- Weak, generic CTAs ("Learn More", "Submit", "Click Here").
+- No social proof anywhere on the page.
+- Burying the CTA below the fold with no early CTA.
+- Using jargon the target audience does not understand.
+- Making claims without proof (testimonials, data, case studies).

--- a/.claude/skills/demand-gen/SKILL.md
+++ b/.claude/skills/demand-gen/SKILL.md
@@ -1,0 +1,225 @@
+---
+name: demand-gen
+description: Build a demand generation strategy and multi-channel campaigns. Use when the user says "demand gen", "demand generation", "lead generation strategy", "pipeline generation", "multi-channel campaign", "funnel strategy", "MQL", "SQL", "attribution", or asks about generating qualified leads and building a sales pipeline through marketing.
+---
+
+# Demand Generation Skill
+
+You are a demand generation strategist for B2B SaaS and technology companies. Build multi-channel campaigns that generate qualified pipeline.
+
+## Demand Gen Framework
+
+### The Full Funnel
+
+```
+TOFU (Top of Funnel)     → Awareness & Education
+  ↓
+MOFU (Middle of Funnel)  → Consideration & Evaluation
+  ↓
+BOFU (Bottom of Funnel)  → Decision & Purchase
+  ↓
+POST-SALE                → Expansion & Advocacy
+```
+
+### Channel Mix by Funnel Stage
+
+| Channel | TOFU | MOFU | BOFU | Budget Allocation |
+|---------|------|------|------|-------------------|
+| SEO/Content | ★★★ | ★★ | ★ | 20-30% |
+| LinkedIn Ads | ★★ | ★★★ | ★★ | 15-25% |
+| Google Ads (Search) | ★ | ★★ | ★★★ | 15-25% |
+| Email nurture | ★ | ★★★ | ★★ | 5-10% |
+| Webinars/Events | ★★ | ★★★ | ★ | 10-15% |
+| Retargeting | ★ | ★★ | ★★★ | 5-10% |
+| Partnerships | ★★ | ★★ | ★★ | 5-10% |
+| Community | ★★★ | ★★ | ★ | 5-10% |
+
+### Campaign Types
+
+**1. Content Campaign (TOFU)**
+- Goal: Drive awareness and capture emails
+- Assets: Blog posts, ebooks, reports, tools
+- CTA: Download, subscribe, try free tool
+- Measurement: Traffic, signups, content downloads
+
+**2. Nurture Campaign (MOFU)**
+- Goal: Educate and build preference
+- Assets: Case studies, webinars, comparison guides, demos
+- CTA: Watch demo, read case study, attend webinar
+- Measurement: Engagement rate, MQL conversion
+
+**3. Conversion Campaign (BOFU)**
+- Goal: Drive trials, demos, purchases
+- Assets: Free trial, demo request, consultation, ROI calculator
+- CTA: Start free trial, book demo, get quote
+- Measurement: SQL conversion, pipeline generated, revenue
+
+**4. ABM Campaign (Targeted)**
+- Goal: Engage specific high-value accounts
+- Assets: Personalized content, direct mail, executive dinners
+- CTA: Custom per account
+- Measurement: Account engagement, meetings booked, deal velocity
+
+## Lead Scoring Model
+
+### Demographic Score (Fit)
+
+| Factor | Points |
+|--------|--------|
+| Job title matches ICP | +20 |
+| Company size matches ICP | +15 |
+| Industry matches ICP | +15 |
+| Geographic match | +10 |
+| Technology stack match | +10 |
+| Revenue range match | +10 |
+| Non-business email (gmail, etc.) | -20 |
+
+### Behavioral Score (Intent)
+
+| Action | Points |
+|--------|--------|
+| Visited pricing page | +15 |
+| Viewed demo/product page | +10 |
+| Downloaded BOFU content (case study, comparison) | +10 |
+| Attended webinar | +10 |
+| Opened 3+ emails in a week | +8 |
+| Downloaded TOFU content (ebook, report) | +5 |
+| Visited blog post | +3 |
+| Visited careers page | -10 |
+| No activity in 30 days | -15 |
+
+### Lead Stages
+
+| Stage | Definition | Score Range | Action |
+|-------|-----------|-------------|--------|
+| **Subscriber** | Email only | 0-20 | Nurture |
+| **Lead** | Some engagement | 20-40 | Nurture + educate |
+| **MQL** | Marketing Qualified | 40-60 | Route to SDR |
+| **SQL** | Sales Qualified | 60-80 | SDR qualification call |
+| **Opportunity** | In pipeline | 80+ | Sales owns |
+
+## Campaign Planning Template
+
+```markdown
+# Campaign: {Campaign Name}
+
+## Overview
+- **Objective:** {What are we trying to achieve?}
+- **Target audience:** {Who are we reaching?}
+- **Funnel stage:** {TOFU / MOFU / BOFU}
+- **Timeline:** {Start - End}
+- **Budget:** ${amount}
+
+## Key Metrics
+
+| Metric | Target |
+|--------|--------|
+| Impressions | {count} |
+| Clicks / CTR | {count / %} |
+| Leads generated | {count} |
+| MQLs | {count} |
+| SQLs | {count} |
+| Pipeline generated | ${amount} |
+| Cost per lead | ${amount} |
+| Cost per SQL | ${amount} |
+
+## Channel Plan
+
+| Channel | Budget | Targeting | Creative/Message |
+|---------|--------|-----------|-----------------|
+| {channel} | ${amount} | {audience targeting} | {message/offer} |
+
+## Content/Assets Needed
+
+| Asset | Owner | Due Date | Status |
+|-------|-------|----------|--------|
+| {asset} | {person} | {date} | {draft/review/done} |
+
+## Email Nurture Sequence
+
+| Email | Timing | Subject | CTA |
+|-------|--------|---------|-----|
+| 1 | Day 0 | {subject} | {CTA} |
+| 2 | Day 3 | {subject} | {CTA} |
+| 3 | Day 7 | {subject} | {CTA} |
+
+## A/B Tests Planned
+
+| Test | Variant A | Variant B | Metric |
+|------|-----------|-----------|--------|
+| {element} | {option A} | {option B} | {metric} |
+```
+
+## Attribution Models
+
+| Model | How It Works | Best For |
+|-------|-------------|----------|
+| **First touch** | 100% credit to first interaction | Understanding awareness channels |
+| **Last touch** | 100% credit to last interaction | Understanding conversion channels |
+| **Linear** | Equal credit to all touchpoints | General overview |
+| **U-shaped** | 40% first, 40% last, 20% middle | Balanced view |
+| **W-shaped** | 30% first, 30% lead creation, 30% opp creation, 10% rest | B2B with clear stages |
+| **Time decay** | More credit to recent touchpoints | Long sales cycles |
+
+**Recommendation:** Use W-shaped or U-shaped for B2B SaaS. Track both first-touch and last-touch as supplementary views.
+
+## B2B SaaS Benchmarks
+
+| Metric | Median | Top Quartile |
+|--------|--------|-------------|
+| Website → Lead conversion | 2-3% | 5%+ |
+| Lead → MQL conversion | 15-25% | 35%+ |
+| MQL → SQL conversion | 20-30% | 40%+ |
+| SQL → Opportunity | 40-60% | 70%+ |
+| Opportunity → Closed Won | 15-25% | 30%+ |
+| Overall Lead → Customer | 1-3% | 5%+ |
+| CAC payback period | 12-18 months | <12 months |
+| LTV:CAC ratio | 3:1 | 5:1+ |
+
+## Output Format
+
+```markdown
+# Demand Generation Strategy: {Company}
+
+## Goals & KPIs
+
+| KPI | Current | Target | Timeline |
+|-----|---------|--------|----------|
+
+## Target Audience
+{ICP definition}
+
+## Channel Strategy
+
+### Primary Channels (70% budget)
+{Top 2-3 channels with rationale}
+
+### Secondary Channels (30% budget)
+{Supporting channels}
+
+## Campaign Calendar
+
+| Month | Campaign | Stage | Channel | Budget | Target |
+|-------|----------|-------|---------|--------|--------|
+
+## Lead Scoring Model
+{Scoring rules}
+
+## Nurture Strategy
+{Email sequences and workflows}
+
+## Attribution & Reporting
+{Model and cadence}
+
+## Budget Allocation
+| Channel | Monthly | Quarterly | Expected CPL |
+```
+
+## Important Notes
+
+- Demand gen is a system, not a campaign. Think in terms of always-on programs, not one-off blasts.
+- Measure pipeline and revenue, not just leads. 100 MQLs that don't convert are worth less than 10 that do.
+- Sales and marketing alignment is critical. Agree on lead definitions, SLAs, and feedback loops before launching campaigns.
+- Start with one channel done well before adding more. Most teams spread budget too thin.
+- B2B sales cycles are long (60-180 days). Don't judge campaign performance in week 1.
+- Dark social (word of mouth, DMs, Slack groups) drives more B2B buying decisions than attributable channels. Create content people want to share privately.

--- a/.claude/skills/discord-bot/SKILL.md
+++ b/.claude/skills/discord-bot/SKILL.md
@@ -1,0 +1,715 @@
+---
+name: discord-bot
+description: >
+  Send messages, embeds, and marketing content to Discord channels via webhooks or bot API.
+  Manage community engagement, announcements, and automated posting. Trigger phrases:
+  "post to discord", "discord message", "discord webhook", "discord embed", "discord announcement",
+  "send to discord", "discord community", "discord marketing".
+allowed-tools:
+  - Bash
+  - WebFetch
+  - WebSearch
+---
+
+# Discord Bot Skill
+
+You are a Discord marketing and community engagement specialist. Your job is to help users send
+messages, rich embeds, and marketing content to Discord channels using webhooks or the Discord
+Bot API. You use `curl` for all API calls so no dependencies are needed.
+
+## Environment Setup
+
+Before doing anything, check for available credentials:
+
+```bash
+source ~/.claude/.env.global 2>/dev/null
+source .env 2>/dev/null
+source .env.local 2>/dev/null
+
+if [ -n "$DISCORD_WEBHOOK_URL" ]; then
+  echo "DISCORD_WEBHOOK_URL is configured. Webhook posting is available."
+elif [ -n "$DISCORD_BOT_TOKEN" ]; then
+  echo "DISCORD_BOT_TOKEN is configured. Bot API is available."
+else
+  echo "No Discord credentials found."
+  echo ""
+  echo "To enable Discord posting, set one of these in your .env or ~/.claude/.env.global:"
+  echo "  DISCORD_WEBHOOK_URL=https://discord.com/api/webhooks/YOUR_WEBHOOK_ID/YOUR_WEBHOOK_TOKEN"
+  echo "  DISCORD_BOT_TOKEN=your_bot_token_here"
+  echo ""
+  echo "See the 'Creating a Webhook' or 'Creating a Bot' sections below for setup instructions."
+fi
+```
+
+### Webhook vs. Bot API
+
+| Feature | Webhook | Bot API |
+|---------|---------|---------|
+| Setup difficulty | Easy (2 minutes) | Moderate (5 minutes) |
+| Send messages | Yes | Yes |
+| Send embeds | Yes | Yes |
+| Send to multiple channels | One webhook per channel | Any channel the bot can see |
+| Edit/delete own messages | Yes (with message ID) | Yes |
+| Read messages | No | Yes |
+| React to messages | No | Yes |
+| Manage roles/members | No | Yes |
+| Rate limits | 30 requests/minute per webhook | 50 requests/second globally |
+| Custom username/avatar per message | Yes | No (uses bot profile) |
+
+**Recommendation:** Use webhooks for simple posting (announcements, marketing content, automated
+updates). Use the Bot API when you need to interact with the server (read messages, manage
+community, react, assign roles).
+
+## Creating a Webhook
+
+To create a Discord webhook:
+
+1. Open Discord and go to the server where you want to post.
+2. Click the channel name, then **Edit Channel** (gear icon).
+3. Go to **Integrations** > **Webhooks**.
+4. Click **New Webhook**.
+5. Set a name (e.g., "OpenClaudia Marketing") and optionally upload an avatar.
+6. Click **Copy Webhook URL**.
+7. Save the URL to your environment:
+
+```bash
+# Add to your .env or ~/.claude/.env.global
+echo 'DISCORD_WEBHOOK_URL=https://discord.com/api/webhooks/YOUR_ID/YOUR_TOKEN' >> .env
+```
+
+The webhook URL format is: `https://discord.com/api/webhooks/{webhook_id}/{webhook_token}`
+
+## Creating a Bot
+
+To create a Discord bot for full API access:
+
+1. Go to https://discord.com/developers/applications
+2. Click **New Application**, give it a name, and click **Create**.
+3. Go to the **Bot** tab and click **Add Bot**.
+4. Under **Token**, click **Copy** to get your bot token.
+5. Under **Privileged Gateway Intents**, enable **Message Content Intent** if you need to read messages.
+6. Go to **OAuth2** > **URL Generator**.
+7. Select scopes: `bot`, `applications.commands`.
+8. Select permissions: `Send Messages`, `Embed Links`, `Attach Files`, `Read Message History`, `Add Reactions`, `Manage Messages` (adjust as needed).
+9. Copy the generated URL and open it in a browser to invite the bot to your server.
+10. Save the token:
+
+```bash
+echo 'DISCORD_BOT_TOKEN=your_bot_token_here' >> .env
+```
+
+## Gathering Requirements
+
+Before posting to Discord, collect these inputs:
+
+1. **Channel** - Which channel or webhook URL to post to?
+2. **Content type** - Plain message, embed, announcement, or scheduled post?
+3. **Message content** - What is the message about?
+4. **Goal** - Community engagement, product announcement, event promotion, content sharing?
+5. **Tone** - Professional, casual, hype, community-friendly?
+6. **Visuals** - Any images, thumbnails, or icons to include?
+7. **Call to action** - What should readers do after seeing the message?
+
+## Sending Messages via Webhook
+
+### Simple Text Message
+
+```bash
+source ~/.claude/.env.global 2>/dev/null
+source .env 2>/dev/null
+
+curl -s -X POST "$DISCORD_WEBHOOK_URL" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "content": "Your message text here"
+  }'
+```
+
+### Message with Custom Username and Avatar
+
+```bash
+curl -s -X POST "$DISCORD_WEBHOOK_URL" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "username": "OpenClaudia Updates",
+    "avatar_url": "https://example.com/your-avatar.png",
+    "content": "Your message text here"
+  }'
+```
+
+### Rich Embed Message
+
+```bash
+curl -s -X POST "$DISCORD_WEBHOOK_URL" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "username": "OpenClaudia",
+    "embeds": [{
+      "title": "Embed Title Here",
+      "description": "Embed description with **markdown** support.",
+      "url": "https://example.com",
+      "color": 16738122,
+      "fields": [
+        {
+          "name": "Field 1",
+          "value": "Field value here",
+          "inline": true
+        },
+        {
+          "name": "Field 2",
+          "value": "Another value",
+          "inline": true
+        }
+      ],
+      "thumbnail": {
+        "url": "https://example.com/thumbnail.png"
+      },
+      "image": {
+        "url": "https://example.com/image.png"
+      },
+      "footer": {
+        "text": "Footer text here",
+        "icon_url": "https://example.com/icon.png"
+      },
+      "timestamp": "'"$(date -u +%Y-%m-%dT%H:%M:%SZ)"'"
+    }]
+  }'
+```
+
+### Message with Content and Embed Combined
+
+```bash
+curl -s -X POST "$DISCORD_WEBHOOK_URL" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "content": "@everyone Check out our latest update!",
+    "username": "OpenClaudia",
+    "embeds": [{
+      "title": "Title",
+      "description": "Description",
+      "color": 16738122
+    }]
+  }'
+```
+
+## Sending Messages via Bot API
+
+### Send a Message to a Channel
+
+```bash
+source ~/.claude/.env.global 2>/dev/null
+source .env 2>/dev/null
+
+CHANNEL_ID="your_channel_id_here"
+
+curl -s -X POST "https://discord.com/api/v10/channels/${CHANNEL_ID}/messages" \
+  -H "Authorization: Bot ${DISCORD_BOT_TOKEN}" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "content": "Your message text here"
+  }'
+```
+
+### Send an Embed via Bot API
+
+```bash
+curl -s -X POST "https://discord.com/api/v10/channels/${CHANNEL_ID}/messages" \
+  -H "Authorization: Bot ${DISCORD_BOT_TOKEN}" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "embeds": [{
+      "title": "Embed Title",
+      "description": "Embed description here.",
+      "color": 16738122,
+      "fields": [
+        {"name": "Field 1", "value": "Value 1", "inline": true},
+        {"name": "Field 2", "value": "Value 2", "inline": true}
+      ],
+      "footer": {"text": "Posted via OpenClaudia"},
+      "timestamp": "'"$(date -u +%Y-%m-%dT%H:%M:%SZ)"'"
+    }]
+  }'
+```
+
+### List Channels in a Server
+
+To find the right channel ID:
+
+```bash
+GUILD_ID="your_server_id_here"
+
+curl -s "https://discord.com/api/v10/guilds/${GUILD_ID}/channels" \
+  -H "Authorization: Bot ${DISCORD_BOT_TOKEN}" | \
+  jq -r '.[] | select(.type == 0) | "\(.id) #\(.name)"'
+```
+
+Channel type `0` is a text channel. Type `2` is voice, type `4` is a category, type `5` is an announcement channel.
+
+### Edit a Message
+
+```bash
+MESSAGE_ID="the_message_id"
+
+curl -s -X PATCH "https://discord.com/api/v10/channels/${CHANNEL_ID}/messages/${MESSAGE_ID}" \
+  -H "Authorization: Bot ${DISCORD_BOT_TOKEN}" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "content": "Updated message content",
+    "embeds": [{
+      "title": "Updated Embed",
+      "description": "This embed has been updated.",
+      "color": 16738122
+    }]
+  }'
+```
+
+### Delete a Message
+
+```bash
+curl -s -X DELETE "https://discord.com/api/v10/channels/${CHANNEL_ID}/messages/${MESSAGE_ID}" \
+  -H "Authorization: Bot ${DISCORD_BOT_TOKEN}"
+```
+
+### Add a Reaction
+
+```bash
+# URL-encode the emoji. For Unicode emoji, use the emoji directly.
+# For custom emoji, use name:id format.
+EMOJI="🎉"
+ENCODED_EMOJI=$(python3 -c "import urllib.parse; print(urllib.parse.quote('${EMOJI}'))")
+
+curl -s -X PUT "https://discord.com/api/v10/channels/${CHANNEL_ID}/messages/${MESSAGE_ID}/reactions/${ENCODED_EMOJI}/@me" \
+  -H "Authorization: Bot ${DISCORD_BOT_TOKEN}" \
+  -H "Content-Length: 0"
+```
+
+## Discord Embed Reference
+
+### Embed Structure
+
+| Field | Type | Limit | Required | Description |
+|-------|------|-------|----------|-------------|
+| `title` | string | 256 chars | No | Embed title, supports markdown links |
+| `description` | string | 4096 chars | No | Main body text, supports full markdown |
+| `url` | string | - | No | Makes the title a clickable hyperlink |
+| `color` | integer | - | No | Decimal color code for the left border |
+| `fields` | array | 25 max | No | Key-value pairs displayed in the embed |
+| `fields[].name` | string | 256 chars | Yes | Field title |
+| `fields[].value` | string | 1024 chars | Yes | Field content |
+| `fields[].inline` | boolean | - | No | Display side-by-side (default: false) |
+| `thumbnail.url` | string | - | No | Small image in the top-right corner |
+| `image.url` | string | - | No | Large image below the description |
+| `footer.text` | string | 2048 chars | No | Small text at the bottom |
+| `footer.icon_url` | string | - | No | Small icon next to footer text |
+| `author.name` | string | 256 chars | No | Author name above the title |
+| `author.url` | string | - | No | Makes author name a link |
+| `author.icon_url` | string | - | No | Small icon next to author name |
+| `timestamp` | string | ISO 8601 | No | Timestamp shown in footer area |
+
+**Limits per message:** Up to 10 embeds. Total of all embed content must not exceed 6000 characters.
+
+### Color Reference
+
+| Color | Decimal | Hex | Use Case |
+|-------|---------|-----|----------|
+| OpenClaudia Accent | 16738122 | #ff6b4a | Brand default, announcements |
+| Success Green | 5763719 | #57F287 | Positive updates, milestones |
+| Warning Yellow | 16776960 | #FFFF00 | Notices, reminders |
+| Error Red | 15548997 | #ED4245 | Urgent, breaking changes |
+| Info Blue | 5793266 | #5865F2 | General info, tips |
+| Dark (Subtle) | 2303786 | #2326AB | Secondary announcements |
+
+## Marketing Content Templates
+
+### Announcement Post
+
+Use for product launches, feature releases, and major updates.
+
+```bash
+curl -s -X POST "$DISCORD_WEBHOOK_URL" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "content": "||@everyone||",
+    "username": "OpenClaudia",
+    "embeds": [{
+      "title": "Introducing [Feature Name]",
+      "description": "We are excited to announce **[Feature Name]** -- [one-sentence description of what it does and why it matters].\n\n[2-3 sentences expanding on the value, what problem it solves, or what is now possible.]",
+      "url": "https://example.com/announcement",
+      "color": 16738122,
+      "fields": [
+        {
+          "name": "What'\''s New",
+          "value": "- Feature highlight 1\n- Feature highlight 2\n- Feature highlight 3",
+          "inline": false
+        },
+        {
+          "name": "Get Started",
+          "value": "[Read the docs](https://example.com/docs) or try it now in your dashboard.",
+          "inline": false
+        }
+      ],
+      "image": {
+        "url": "https://example.com/announcement-banner.png"
+      },
+      "footer": {
+        "text": "Your Brand Name"
+      },
+      "timestamp": "'"$(date -u +%Y-%m-%dT%H:%M:%SZ)"'"
+    }]
+  }'
+```
+
+### Product Launch
+
+Use for new product releases with pricing and feature breakdown.
+
+```bash
+curl -s -X POST "$DISCORD_WEBHOOK_URL" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "username": "OpenClaudia",
+    "content": "**[Product Name] is here!** After [months/weeks] of development, we'\''re ready to share it with you.",
+    "embeds": [{
+      "title": "[Product Name] - [Tagline]",
+      "description": "[2-3 sentences about the product, what it does, and who it is for.]\n\n**Launch offer:** [special pricing, discount, or bonus for early adopters].",
+      "url": "https://example.com/product",
+      "color": 16738122,
+      "fields": [
+        {
+          "name": "Key Features",
+          "value": "- [Feature 1]: [brief benefit]\n- [Feature 2]: [brief benefit]\n- [Feature 3]: [brief benefit]",
+          "inline": false
+        },
+        {
+          "name": "Pricing",
+          "value": "**Free tier:** [what is included]\n**Pro:** $[X]/mo - [what is included]\n**Team:** $[X]/mo - [what is included]",
+          "inline": false
+        },
+        {
+          "name": "Links",
+          "value": "[Try it free](https://example.com/signup) | [Documentation](https://example.com/docs) | [Demo video](https://example.com/demo)",
+          "inline": false
+        }
+      ],
+      "thumbnail": {
+        "url": "https://example.com/product-logo.png"
+      },
+      "image": {
+        "url": "https://example.com/product-hero.png"
+      },
+      "footer": {
+        "text": "Launch day special - available for a limited time"
+      },
+      "timestamp": "'"$(date -u +%Y-%m-%dT%H:%M:%SZ)"'"
+    }]
+  }'
+```
+
+### Community Update
+
+Use for weekly/monthly community updates, metrics, and progress reports.
+
+```bash
+curl -s -X POST "$DISCORD_WEBHOOK_URL" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "username": "OpenClaudia",
+    "embeds": [{
+      "title": "Community Update - [Month/Week]",
+      "description": "Here'\''s what happened in our community this [week/month]:",
+      "color": 5793266,
+      "fields": [
+        {
+          "name": "By the Numbers",
+          "value": "- **[X]** new members joined\n- **[X]** messages sent\n- **[X]** issues resolved",
+          "inline": true
+        },
+        {
+          "name": "Top Contributors",
+          "value": "- <@user_id_1> - [contribution]\n- <@user_id_2> - [contribution]\n- <@user_id_3> - [contribution]",
+          "inline": true
+        },
+        {
+          "name": "What'\''s Coming Next",
+          "value": "- [Upcoming feature or event 1]\n- [Upcoming feature or event 2]\n- [Upcoming feature or event 3]",
+          "inline": false
+        },
+        {
+          "name": "How to Get Involved",
+          "value": "- Check out our [open issues](https://github.com/org/repo/issues)\n- Share feedback in #feedback\n- Invite a friend to the server!",
+          "inline": false
+        }
+      ],
+      "footer": {
+        "text": "Thank you for being part of this community"
+      },
+      "timestamp": "'"$(date -u +%Y-%m-%dT%H:%M:%SZ)"'"
+    }]
+  }'
+```
+
+### Event Promotion
+
+Use for webinars, AMAs, live streams, and community events.
+
+```bash
+curl -s -X POST "$DISCORD_WEBHOOK_URL" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "content": "@here Don'\''t miss this!",
+    "username": "OpenClaudia",
+    "embeds": [{
+      "title": "[Event Name]",
+      "description": "Join us for **[event description]**.\n\n[2-3 sentences about what attendees will learn, who is speaking, and why they should attend.]",
+      "color": 16738122,
+      "fields": [
+        {
+          "name": "Date & Time",
+          "value": "[Day, Month Date, Year]\n[Time] [Timezone]\n\nDiscord timestamp: <t:UNIX_TIMESTAMP:F>",
+          "inline": true
+        },
+        {
+          "name": "Where",
+          "value": "[#channel-name or external link]\n[Platform: Discord Stage / Zoom / YouTube Live]",
+          "inline": true
+        },
+        {
+          "name": "Speakers",
+          "value": "- **[Speaker 1]** - [Title/Role]\n- **[Speaker 2]** - [Title/Role]",
+          "inline": false
+        },
+        {
+          "name": "How to Join",
+          "value": "[Registration link or instructions]\nReact with a checkmark below to get a reminder!",
+          "inline": false
+        }
+      ],
+      "image": {
+        "url": "https://example.com/event-banner.png"
+      },
+      "footer": {
+        "text": "Limited spots available"
+      },
+      "timestamp": "'"$(date -u +%Y-%m-%dT%H:%M:%SZ)"'"
+    }]
+  }'
+```
+
+### Welcome Message
+
+Use for onboarding new members. Typically posted by a bot in a welcome channel or sent via DM.
+
+```bash
+curl -s -X POST "https://discord.com/api/v10/channels/${WELCOME_CHANNEL_ID}/messages" \
+  -H "Authorization: Bot ${DISCORD_BOT_TOKEN}" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "embeds": [{
+      "title": "Welcome to [Server Name]!",
+      "description": "Hey <@USER_ID>, glad to have you here! Here'\''s everything you need to get started.",
+      "color": 16738122,
+      "fields": [
+        {
+          "name": "Start Here",
+          "value": "1. Read the rules in #rules\n2. Introduce yourself in #introductions\n3. Pick your roles in #roles",
+          "inline": false
+        },
+        {
+          "name": "Key Channels",
+          "value": "- #general - Chat with the community\n- #announcements - Stay up to date\n- #help - Ask questions\n- #showcase - Share what you'\''re building",
+          "inline": false
+        },
+        {
+          "name": "Links",
+          "value": "[Website](https://example.com) | [Docs](https://example.com/docs) | [GitHub](https://github.com/org/repo)",
+          "inline": false
+        }
+      ],
+      "thumbnail": {
+        "url": "https://example.com/server-icon.png"
+      },
+      "footer": {
+        "text": "We'\''re happy you'\''re here!"
+      }
+    }]
+  }'
+```
+
+### Content Share / Blog Post Promotion
+
+Use for sharing blog posts, tutorials, videos, or other content with the community.
+
+```bash
+curl -s -X POST "$DISCORD_WEBHOOK_URL" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "username": "OpenClaudia",
+    "embeds": [{
+      "author": {
+        "name": "[Author Name]",
+        "icon_url": "https://example.com/author-avatar.png"
+      },
+      "title": "[Blog Post / Video Title]",
+      "description": "[2-3 sentence summary of the content. What will the reader learn? Why should they care?]\n\n[Read the full post ->](https://example.com/blog/post-slug)",
+      "url": "https://example.com/blog/post-slug",
+      "color": 16738122,
+      "fields": [
+        {
+          "name": "Key Takeaways",
+          "value": "- [Takeaway 1]\n- [Takeaway 2]\n- [Takeaway 3]",
+          "inline": false
+        }
+      ],
+      "image": {
+        "url": "https://example.com/blog/post-slug/og-image.png"
+      },
+      "footer": {
+        "text": "Read time: [X] min"
+      },
+      "timestamp": "'"$(date -u +%Y-%m-%dT%H:%M:%SZ)"'"
+    }]
+  }'
+```
+
+## Discord Markdown Reference
+
+Discord supports a subset of markdown in message content and embed descriptions/fields:
+
+| Syntax | Result |
+|--------|--------|
+| `*italic*` or `_italic_` | *italic* |
+| `**bold**` | **bold** |
+| `***bold italic***` | ***bold italic*** |
+| `~~strikethrough~~` | ~~strikethrough~~ |
+| `__underline__` | underlined text |
+| `` `inline code` `` | `inline code` |
+| ` ```code block``` ` | code block |
+| `> quote` | block quote (single line) |
+| `>>> quote` | block quote (multi-line, rest of message) |
+| `[text](url)` | hyperlink |
+| `- item` or `* item` | bulleted list |
+| `1. item` | numbered list |
+
+### Mentions and Timestamps
+
+| Syntax | Description |
+|--------|-------------|
+| `<@USER_ID>` | Mention a user |
+| `<@&ROLE_ID>` | Mention a role |
+| `<#CHANNEL_ID>` | Link to a channel |
+| `@everyone` | Notify all members |
+| `@here` | Notify online members |
+| `<t:UNIX_TIMESTAMP:F>` | Full date and time (localized) |
+| `<t:UNIX_TIMESTAMP:R>` | Relative time ("in 2 hours", "3 days ago") |
+| `<t:UNIX_TIMESTAMP:D>` | Date only |
+| `<t:UNIX_TIMESTAMP:t>` | Time only (short) |
+
+Generate Unix timestamps with: `date -d "2026-03-15 14:00:00 UTC" +%s` (Linux) or `date -j -f "%Y-%m-%d %H:%M:%S" "2026-03-15 14:00:00" +%s` (macOS).
+
+## Advanced: Webhook Management via Bot API
+
+### Create a Webhook Programmatically
+
+```bash
+curl -s -X POST "https://discord.com/api/v10/channels/${CHANNEL_ID}/webhooks" \
+  -H "Authorization: Bot ${DISCORD_BOT_TOKEN}" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "name": "OpenClaudia Marketing"
+  }' | jq '{id: .id, token: .token, url: ("https://discord.com/api/webhooks/" + .id + "/" + .token)}'
+```
+
+### List Webhooks for a Channel
+
+```bash
+curl -s "https://discord.com/api/v10/channels/${CHANNEL_ID}/webhooks" \
+  -H "Authorization: Bot ${DISCORD_BOT_TOKEN}" | \
+  jq -r '.[] | "\(.id) - \(.name) - https://discord.com/api/webhooks/\(.id)/\(.token)"'
+```
+
+### Delete a Webhook
+
+```bash
+WEBHOOK_ID="the_webhook_id"
+
+curl -s -X DELETE "https://discord.com/api/v10/webhooks/${WEBHOOK_ID}" \
+  -H "Authorization: Bot ${DISCORD_BOT_TOKEN}"
+```
+
+## Rate Limits and Best Practices
+
+### Rate Limits
+
+- **Webhooks:** 30 requests per 60 seconds per webhook.
+- **Bot API (global):** 50 requests per second.
+- **Bot API (per channel):** 5 messages per 5 seconds per channel.
+- **Bot API (per guild):** Varies by endpoint.
+
+If a request is rate-limited, Discord returns HTTP 429 with a `Retry-After` header (in seconds).
+Handle it like this:
+
+```bash
+RESPONSE=$(curl -s -w "\n%{http_code}" -X POST "$DISCORD_WEBHOOK_URL" \
+  -H "Content-Type: application/json" \
+  -d '{"content": "Test message"}')
+
+HTTP_CODE=$(echo "$RESPONSE" | tail -1)
+BODY=$(echo "$RESPONSE" | head -1)
+
+if [ "$HTTP_CODE" = "429" ]; then
+  RETRY_AFTER=$(echo "$BODY" | jq -r '.retry_after')
+  echo "Rate limited. Retrying after ${RETRY_AFTER} seconds..."
+  sleep "$RETRY_AFTER"
+  # Retry the request
+fi
+```
+
+### Best Practices
+
+- **Always preview before sending.** Show the user the full payload and ask for confirmation
+  before posting to any channel.
+- **Respect rate limits.** When sending multiple messages, add a 1-2 second delay between requests.
+- **Use embeds for marketing content.** Plain text is easy to miss in a busy channel. Embeds with
+  color, images, and structured fields stand out.
+- **Use `@everyone` and `@here` sparingly.** Overusing mentions burns community goodwill fast.
+  Reserve them for genuinely important announcements.
+- **Include timestamps.** Use Discord's `<t:TIMESTAMP:F>` format so times display in every
+  member's local timezone.
+- **Track message IDs.** Store returned message IDs so you can edit or delete posts later.
+- **Test with a private channel first.** Before posting to a public announcement channel, send
+  the message to a test channel to verify formatting.
+
+## Publishing Workflow
+
+When the user asks to post to Discord:
+
+1. **Generate** the message content using the appropriate template above.
+2. **Preview** -- show the user the full JSON payload, including:
+   - Target channel or webhook
+   - Message content
+   - Embed fields (title, description, color, fields, images)
+   - Any mentions (@everyone, @here, role mentions)
+3. **Confirm** -- ask the user to approve before posting.
+4. **Post** -- execute the curl command.
+5. **Report** -- show the response, including the message ID for future reference.
+
+**Never auto-post without explicit user confirmation.**
+
+## Output Format
+
+For every Discord posting request, deliver:
+
+### 1. Message Preview
+- Full message content (plain text + embeds) formatted for readability.
+- Visual description of what the embed will look like.
+- Character counts for fields approaching limits.
+
+### 2. API Payload
+- The complete curl command ready to execute.
+- All variables resolved (webhook URL, channel ID, etc.).
+
+### 3. Post-Send Report
+After posting:
+- HTTP response status.
+- Message ID (for editing or deleting later).
+- Direct link to the message if possible (`https://discord.com/channels/GUILD_ID/CHANNEL_ID/MESSAGE_ID`).

--- a/.claude/skills/domain-research/SKILL.md
+++ b/.claude/skills/domain-research/SKILL.md
@@ -1,0 +1,180 @@
+---
+name: domain-research
+description: Research domain WHOIS data and check marketplace listings. Use when the user says "domain lookup", "check domain", "WHOIS", "domain availability", "buy domain", "domain research", "who owns this domain", "domain marketplace", or asks about researching or acquiring a domain name.
+---
+
+# Domain Research Skill
+
+You are a domain research specialist. Look up WHOIS/RDAP data, check marketplace listings, and help evaluate domains for acquisition.
+
+## Domain Lookup (Free, No Auth Required)
+
+### WHOIS/RDAP Lookup
+
+```bash
+curl -s "https://mcp.domaindetails.com/lookup/{domain}" | jq
+```
+
+Returns:
+- **Registrar:** Who the domain is registered through
+- **Created date:** When the domain was first registered
+- **Expiry date:** When it expires
+- **Nameservers:** DNS configuration
+- **DNSSEC:** Whether DNSSEC is enabled
+- **Registrant contacts:** Owner info (often privacy-protected)
+- **Status codes:** Domain status (clientTransferProhibited, etc.)
+
+### Marketplace Listing Search
+
+```bash
+curl -s "https://api.domaindetails.com/api/marketplace/search?domain={domain}" | jq
+```
+
+Checks listings across:
+- **Sedo** — Largest domain marketplace
+- **Afternic** — GoDaddy's marketplace
+- **Atom** — Premium domains
+- **Dynadot** — Auction and marketplace
+- **Namecheap** — Marketplace listings
+- **NameSilo** — Budget marketplace
+- **Unstoppable Domains** — Web3 domains
+
+### Rate Limits
+
+100 requests/minute, no authentication needed.
+
+## Domain Evaluation
+
+### For Brand Domains
+
+| Factor | Weight | What to Check |
+|--------|--------|---------------|
+| **Length** | 25% | Shorter is better. <8 chars ideal, <12 acceptable |
+| **Memorability** | 20% | Easy to spell, say, and remember |
+| **Brandability** | 20% | Unique, ownable, not generic |
+| **Extension** | 15% | .com > .io > .ai > .co > others |
+| **History** | 10% | Check Wayback Machine for past use, spam, adult content |
+| **SEO value** | 10% | Existing backlinks, domain authority |
+
+### For SEO/Content Domains
+
+| Factor | Weight | What to Check |
+|--------|--------|---------------|
+| **Keyword match** | 25% | Contains target keyword |
+| **Domain authority** | 25% | Check via Moz, Ahrefs, or SemRush |
+| **Backlink profile** | 20% | Quality and quantity of existing backlinks |
+| **History** | 15% | Clean history, no penalties |
+| **Extension** | 15% | .com preferred for organic search |
+
+### Domain Valuation Factors
+
+| Factor | Low Value | High Value |
+|--------|-----------|------------|
+| Length | 15+ characters | 1-5 characters |
+| Extension | .xyz, .club | .com, .io, .ai |
+| Dictionary word | No | Yes (real English word) |
+| Keyword volume | <100/month | 10,000+/month |
+| Existing traffic | None | Organic traffic |
+| Backlinks | None | 100+ quality links |
+| Age | <1 year | 10+ years |
+| Comparable sales | None found | Multiple sales at $XX,XXX+ |
+
+## Research Workflow
+
+### Step 1: Check Availability
+
+```bash
+# Quick WHOIS check
+curl -s "https://mcp.domaindetails.com/lookup/{domain}" | jq '.available // .registrar'
+```
+
+### Step 2: Check Marketplace Listings
+
+```bash
+curl -s "https://api.domaindetails.com/api/marketplace/search?domain={domain}" | jq
+```
+
+### Step 3: Check Domain History
+
+Use WebFetch to check:
+- `web.archive.org/web/*/{domain}` — Past versions of the site
+- Historical use, content type, any red flags
+
+### Step 4: Check SEO Metrics (if SemRush available)
+
+```bash
+# Domain overview
+curl -s "https://api.semrush.com/?type=domain_rank&key=${SEMRUSH_API_KEY}&domain={domain}&database=us&export_columns=Dn,Rk,Or,Ot,Oc,Ad,At,Ac"
+
+# Backlinks overview
+curl -s "https://api.semrush.com/?type=backlinks_overview&key=${SEMRUSH_API_KEY}&target={domain}&export_columns=total,domains_num,urls_num,ips_num,follows_num,nofollows_num"
+```
+
+### Step 5: Generate Alternatives
+
+If the desired domain is taken, suggest alternatives:
+
+**Patterns:**
+- `get{brand}.com` — getnotion.com
+- `{brand}hq.com` — slackhq.com
+- `try{brand}.com` — tryfigma.com
+- `use{brand}.com` — usefathom.com
+- `{brand}app.com` — todoistapp.com
+- `{brand}.io` — linear.io
+- `{brand}.ai` — jasper.ai
+- `{brand}.co` — buffer.co
+- `hey{brand}.com` — heysummit.com
+
+## Output Format
+
+```markdown
+# Domain Research: {domain}
+
+## WHOIS Data
+
+| Field | Value |
+|-------|-------|
+| Registrar | {registrar} |
+| Created | {date} |
+| Expires | {date} |
+| Status | {status} |
+| Nameservers | {ns} |
+| Privacy | {Yes/No} |
+
+## Marketplace Listings
+
+| Marketplace | Listed? | Price | Link |
+|-------------|---------|-------|------|
+| Sedo | {Yes/No} | {price} | {link} |
+| Afternic | {Yes/No} | {price} | {link} |
+| ... | ... | ... | ... |
+
+## Domain Evaluation
+
+| Factor | Score | Notes |
+|--------|-------|-------|
+| Length | {}/10 | {X} characters |
+| Memorability | {}/10 | {assessment} |
+| Brandability | {}/10 | {assessment} |
+| Extension | {}/10 | {.com/.io/etc} |
+| History | {}/10 | {clean/flags} |
+| **Overall** | **{}/10** | |
+
+## SEO Metrics (if available)
+{Domain authority, backlinks, organic traffic}
+
+## Alternatives (if domain is taken)
+| Domain | Available? | Notes |
+|--------|-----------|-------|
+
+## Recommendation
+{Buy/Pass/Negotiate — with reasoning}
+```
+
+## Important Notes
+
+- WHOIS data is increasingly privacy-protected. Limited registrant info is normal.
+- Domain marketplace prices are often negotiable. Listed price is usually the starting point.
+- Always check domain history on the Wayback Machine before purchasing. Spam/adult history can carry Google penalties.
+- Expired domains with backlinks can be valuable for SEO, but verify the backlinks are from legitimate sites.
+- .com is still king for brand trust, but .io (tech), .ai (AI), and .co (startups) are increasingly accepted.

--- a/.claude/skills/email-sequence/SKILL.md
+++ b/.claude/skills/email-sequence/SKILL.md
@@ -1,0 +1,291 @@
+---
+name: email-sequence
+description: >
+  Create email drip campaigns, nurture sequences, and automated email flows. Includes templates
+  for welcome series, abandoned cart, re-engagement, product launch, and onboarding sequences.
+  Trigger phrases: "email sequence", "drip campaign", "nurture sequence", "email flow",
+  "welcome series", "abandoned cart emails", "onboarding emails", "email automation",
+  "product launch emails", "re-engagement campaign", "send email", "send sequence".
+allowed-tools:
+  - Bash
+---
+
+# Email Sequence Skill
+
+You are an expert email marketer specializing in automated sequences and drip campaigns.
+Your job is to create high-converting email sequences that nurture leads, drive sales,
+and retain customers.
+
+## Gathering Requirements
+
+Before creating any sequence, collect these inputs:
+
+1. **Sequence type** - Welcome, abandoned cart, re-engagement, launch, onboarding, or custom.
+2. **Product/service** - What is being sold or promoted?
+3. **Target audience** - Who receives this sequence? Segment details.
+4. **Primary goal** - Convert, activate, retain, re-engage, upsell?
+5. **Sender** - Who is the "from" name and email? (Founder, brand, team member)
+6. **Tone** - Friendly, professional, urgent, educational, witty.
+7. **ESP** - What email platform? (Affects merge tags and HTML capabilities.)
+8. **Existing data** - Open rates, click rates, conversion rates for benchmarking.
+
+## Universal Email Principles
+
+### Subject Line Rules
+- Keep between 30-50 characters (6-10 words).
+- Front-load the most important word.
+- Use lowercase for a casual feel, title case for professional.
+- Never use ALL CAPS for the full subject line.
+- Include personalization (first name) sparingly, not in every email.
+- A/B test every subject line in your ESP.
+
+### Preview Text Rules
+- Always write custom preview text (40-90 characters).
+- Do not repeat the subject line.
+- Complement the subject line by adding context or intrigue.
+- If left empty, ESPs pull the first line of body copy, which often looks terrible.
+
+### Email Structure
+1. **Hook** (first 2 lines) - Must earn the scroll. Ask a question, state a bold claim,
+   or reference something personal.
+2. **Body** (3-8 sentences) - One idea per email. Do not try to cover everything.
+3. **CTA** (1 primary) - One clear action. Link it 2-3 times in the body.
+4. **PS line** (optional) - Second-most-read part of an email. Use for urgency or bonus info.
+
+### Send Timing Guidelines
+
+| Audience | Best Days | Best Times | Why |
+|----------|-----------|------------|-----|
+| B2B / SaaS | Tue, Wed, Thu | 9-11am local | Workday focus, inbox reviewed early |
+| B2C / Ecommerce | Thu, Fri, Sat | 10am or 7-9pm local | Shopping mindset, evening browsing |
+| Newsletter | Tue or Thu | 7-9am local | Morning reading habit |
+| Urgent / Sales | Any day | Within 1 hour of trigger | Strike while interest is hot |
+
+### Segmentation Rules
+
+Segment sequences based on:
+- **Behavior** - Pages visited, features used, emails opened, links clicked.
+- **Demographics** - Industry, company size, role, location.
+- **Lifecycle stage** - New lead, trial user, paying customer, churned user.
+- **Engagement level** - Active (opened in 30 days), Inactive (no opens in 60+ days).
+- **Source** - How did they enter the sequence? Organic, paid, referral, event.
+
+## Sequence Templates
+
+### 1. Welcome Series (5 Emails)
+
+**Goal:** Introduce the brand, build trust, drive first conversion.
+**Trigger:** New email signup or account creation.
+
+| # | Timing | Subject Line Formula | Content Focus | CTA |
+|---|--------|---------------------|---------------|-----|
+| 1 | Immediate | "Welcome to [Brand] - here's what to expect" | Deliver promised lead magnet. Set expectations for email frequency. Quick brand story (2-3 sentences). | Access the resource / Explore the product |
+| 2 | Day 2 | "[Name], here's the #1 mistake [audience] make" | Educate on the core problem your product solves. Share a surprising insight. Build authority. | Read the full guide / Watch the video |
+| 3 | Day 4 | "How [Customer] achieved [specific result]" | Social proof through a customer story. Include specific numbers and timeline. | See the case study / Start free trial |
+| 4 | Day 7 | "The fastest way to [desired outcome]" | Product-focused: show how your product solves the problem from Email 2. Keep it benefit-driven, not feature-focused. | Start free trial / Book a demo |
+| 5 | Day 10 | "Quick question, [Name]" | Personal check-in from a real person. Ask what they are struggling with. Offer help. Soft sell. | Reply to this email / Book a call |
+
+### 2. Abandoned Cart Series (3 Emails)
+
+**Goal:** Recover abandoned purchases.
+**Trigger:** Cart created but checkout not completed within 1 hour.
+
+| # | Timing | Subject Line Formula | Content Focus | CTA |
+|---|--------|---------------------|---------------|-----|
+| 1 | 1 hour | "You left something behind" | Friendly reminder. Show the product image and name. No discount yet. Remove friction: "Need help? Reply to this email." | Complete your order |
+| 2 | 24 hours | "Still thinking about [Product]?" | Address objections: shipping, returns, quality. Add 1-2 reviews or testimonials for the specific product. | Return to your cart |
+| 3 | 48 hours | "[Name], your cart expires soon" | Create urgency. Optional: offer a small incentive (free shipping, 10% off). Last chance framing. | Claim your [discount] and checkout |
+
+### 3. Re-engagement Series (4 Emails)
+
+**Goal:** Win back inactive subscribers before removing them.
+**Trigger:** No email opens or clicks in 60-90 days.
+
+| # | Timing | Subject Line Formula | Content Focus | CTA |
+|---|--------|---------------------|---------------|-----|
+| 1 | Day 0 | "We miss you, [Name]" | Acknowledge the absence. Highlight what is new since they last engaged. No guilt. | See what's new |
+| 2 | Day 5 | "Here's what you've missed" | Curate 3-5 best pieces of content or product updates from the past 90 days. Pure value, no ask. | Read the top [3] updates |
+| 3 | Day 10 | "[Name], should we stop emailing you?" | Direct ask. Give them control: update preferences or unsubscribe. This honesty builds trust and often re-engages. | Update my preferences / Yes, unsubscribe me |
+| 4 | Day 15 | "Last email from us (unless you say otherwise)" | Final attempt. Summarize what they will miss. Clear unsubscribe link. If no action, remove from active list. | Keep me subscribed / Unsubscribe |
+
+### 4. Product Launch Series (6 Emails)
+
+**Goal:** Build anticipation and drive launch-day conversions.
+**Trigger:** Manual send based on launch timeline.
+
+| # | Timing | Subject Line Formula | Content Focus | CTA |
+|---|--------|---------------------|---------------|-----|
+| 1 | 2 weeks before | "Something big is coming..." | Tease the launch. Share the problem it solves without revealing the product. Build a waitlist. | Join the waitlist |
+| 2 | 1 week before | "The story behind [Product]" | Behind-the-scenes: why you built it, the journey, the vision. Personal and founder-led. | Get early access |
+| 3 | 3 days before | "Sneak peek: [Product] in action" | Show screenshots, a demo video, or early testimonials from beta users. | Watch the demo / Preview [Product] |
+| 4 | Launch day | "[Product] is LIVE" | The main announcement. Key features. Launch pricing or offer. Clear, prominent CTA. | Get [Product] now |
+| 5 | Day after launch | "[N] people already joined - here's why" | Social proof: signup numbers, early reviews, customer excitement. Address last-minute objections. | Join them / Get [Product] |
+| 6 | 3 days after | "Last chance: [Launch offer] ends tonight" | Urgency-driven close. Recap the offer, the price, and the deadline. FAQ section for objections. | Claim the launch price before midnight |
+
+### 5. Onboarding Series (7 Emails)
+
+**Goal:** Activate new users and drive them to their "aha moment."
+**Trigger:** New account creation or first purchase.
+
+| # | Timing | Subject Line Formula | Content Focus | CTA |
+|---|--------|---------------------|---------------|-----|
+| 1 | Immediate | "Welcome! Start here." | Quick-start guide. One action that delivers immediate value. Do not overwhelm with all features. | Complete step 1: [specific action] |
+| 2 | Day 1 | "Your first [result] in 5 minutes" | Walk through the core feature with a concrete example. Include a GIF or short video. | Try it now: [specific action] |
+| 3 | Day 3 | "Pro tip: [Feature] saves you [time/money]" | Introduce a second key feature. Show it as a natural next step after Email 2's action. | Set up [Feature] |
+| 4 | Day 5 | "How [Customer] uses [Product] for [use case]" | Use case story from a real customer. Relatable scenario that mirrors the new user's likely goals. | Try this workflow |
+| 5 | Day 7 | "[Name], how's it going so far?" | Check-in email. Ask for feedback. Offer help via support, docs, or a call. Link to help center. | Reply with your question / Book a walkthrough |
+| 6 | Day 10 | "3 features you haven't tried yet" | Highlight underused features based on behavioral data (or general for non-behavioral ESPs). | Explore [Feature 1] |
+| 7 | Day 14 | "You're all set - here's what's next" | Graduation email. Recap what they have learned. Point to advanced resources, community, or upgrade path. | Join the community / Upgrade to Pro |
+
+## Email Copywriting Rules
+
+### Hook Formulas for Email Openings
+
+| Formula | Example |
+|---------|---------|
+| Question | "What would you do with an extra 5 hours this week?" |
+| Bold claim | "90% of landing pages have this conversion-killing mistake." |
+| Story | "Last Tuesday, a customer sent me a message that stopped me in my tracks." |
+| Stat | "Companies that onboard in the first 24 hours see 3x higher retention." |
+| Direct address | "[Name], I noticed you signed up but haven't tried [Feature] yet." |
+| Contrarian | "Most email marketing advice is wrong. Here's why." |
+
+### Body Copy Rules
+
+1. **One idea per email.** Do not try to educate, sell, and announce in the same email.
+2. **Short paragraphs.** 1-3 sentences maximum. Emails are read on mobile.
+3. **Use "you" more than "we."** Flip the ratio: 3:1 "you" to "we."
+4. **Write at a 5th-8th grade level.** Short words, short sentences.
+5. **Link the CTA 2-3 times.** Once in the middle, once at the end, optionally in a PS.
+6. **Use a PS line.** 79% of readers scan the PS. Use it for urgency or a secondary point.
+
+### Spam Trigger Avoidance
+
+**Avoid these in subject lines and body:**
+- ALL CAPS words (e.g., "FREE", "BUY NOW", "CLICK HERE")
+- Excessive exclamation marks (!!!)
+- Spam trigger phrases: "Act now", "Limited time", "You've been selected", "Congratulations",
+  "No obligation", "100% free", "Click below", "Dear friend"
+- Too many images with too little text (maintain 60/40 text-to-image ratio)
+- Deceptive subject lines (Re:, Fwd: when not actually a reply/forward)
+- Purchased lists (always use opt-in subscribers only)
+
+## HTML Email Template Guidelines
+
+When the user requests HTML email templates:
+
+1. **Use tables for layout** - Email clients do not reliably support CSS grid or flexbox.
+2. **Inline all CSS** - Many email clients strip `<style>` blocks.
+3. **Max width: 600px** - Standard email width for cross-client compatibility.
+4. **Use web-safe fonts** - Arial, Helvetica, Georgia, Times New Roman.
+5. **Include alt text on all images** - Many readers have images disabled.
+6. **Test in multiple clients** - Gmail, Outlook, Apple Mail, Yahoo at minimum.
+7. **Mobile-first** - 60%+ of emails are opened on mobile. Stack columns on small screens.
+8. **Include a plain-text version** - Always provide a text fallback for deliverability.
+
+## Sending Emails via Resend API
+
+This skill can send emails directly using the [Resend](https://resend.com) API. This is optional:
+if the API key is not configured, the skill will still generate email content as usual without sending.
+
+### Prerequisites
+
+The `RESEND_API_KEY` environment variable must be set. Check for it by running:
+
+```bash
+source ~/.claude/.env.global 2>/dev/null
+if [ -z "$RESEND_API_KEY" ]; then
+  echo "RESEND_API_KEY is not set. Emails will be generated but not sent."
+  echo "To enable sending, add RESEND_API_KEY to ~/.claude/.env.global"
+else
+  echo "RESEND_API_KEY is configured. Ready to send emails."
+fi
+```
+
+### Sending a Single Email
+
+Use the Resend `/emails` endpoint to send an individual email from the sequence:
+
+```bash
+source ~/.claude/.env.global 2>/dev/null
+curl -X POST https://api.resend.com/emails \
+  -H "Authorization: Bearer ${RESEND_API_KEY}" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "from": "Your Name <you@yourdomain.com>",
+    "to": ["recipient@example.com"],
+    "subject": "Subject line here",
+    "html": "<p>Email body here</p>"
+  }'
+```
+
+The response returns a JSON object with an `id` field for tracking. Replace the `from`, `to`,
+`subject`, and `html` fields with the actual values from the generated sequence.
+
+### Sending a Batch (Full Sequence)
+
+To send multiple emails from a sequence at once, use the batch endpoint. This is useful for
+sending the same email to multiple recipients or sending several sequence emails simultaneously:
+
+```bash
+source ~/.claude/.env.global 2>/dev/null
+curl -X POST https://api.resend.com/emails/batch \
+  -H "Authorization: Bearer ${RESEND_API_KEY}" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "emails": [
+      {
+        "from": "Your Name <you@yourdomain.com>",
+        "to": ["recipient1@example.com"],
+        "subject": "Email 1: Welcome to [Brand]",
+        "html": "<p>Welcome email body</p>"
+      },
+      {
+        "from": "Your Name <you@yourdomain.com>",
+        "to": ["recipient2@example.com"],
+        "subject": "Email 1: Welcome to [Brand]",
+        "html": "<p>Welcome email body</p>"
+      }
+    ]
+  }'
+```
+
+### Important Notes
+
+- **Domain verification required:** The `from` address domain must be verified in your Resend
+  account. If you have not verified a domain, Resend provides a shared `onboarding@resend.dev`
+  address for testing.
+- **Rate limits:** Resend has rate limits depending on your plan. For large sequences, add a
+  short delay between batch calls.
+- **No RESEND_API_KEY?** The skill works without it. All email content (subject lines, body copy,
+  preview text, timing) is generated normally. The Resend integration simply adds the ability to
+  send the generated emails directly from the CLI.
+
+## Output Format
+
+For every email sequence, deliver:
+
+### 1. Sequence Overview
+- Sequence name, goal, trigger, audience segment.
+- Visual flow diagram (text-based).
+
+### 2. Individual Emails
+For each email in the sequence:
+- **Email number and name** (e.g., "Email 3: Social Proof")
+- **Timing** (delay from previous email or trigger)
+- **Subject line** (primary + 2 A/B variants)
+- **Preview text**
+- **From name and email**
+- **Body copy** (full draft, not an outline)
+- **CTA** (text and URL placeholder)
+- **PS line** (if applicable)
+- **Branch logic** (if applicable: what happens if they open/click/don't)
+
+### 3. Segmentation Rules
+Who enters this sequence, who exits, and any branch conditions.
+
+### 4. Success Metrics
+Target open rates, click rates, and conversion rates for each email.
+
+### 5. A/B Test Plan
+Recommended tests for the first 30 days (subject lines, send times, CTA copy).

--- a/.claude/skills/email-subject-lines/SKILL.md
+++ b/.claude/skills/email-subject-lines/SKILL.md
@@ -1,0 +1,332 @@
+---
+name: email-subject-lines
+description: >
+  Generate, evaluate, and A/B test email subject lines for maximum open rates. Includes formulas
+  for curiosity, urgency, personalization, and more. Trigger phrases: "email subject line",
+  "subject line ideas", "email subject", "write subject lines", "A/B test subject lines",
+  "improve open rates", "email open rate", "subject line formulas".
+---
+
+# Email Subject Lines Skill
+
+You are an email subject line specialist. Your job is to generate high-performing subject lines
+that maximize open rates while maintaining trust and deliverability.
+
+## Gathering Requirements
+
+Before generating subject lines, collect these inputs:
+
+1. **Email purpose** - Newsletter, promotional, transactional, nurture, announcement, etc.
+2. **Content summary** - What is the email about? (2-3 sentences)
+3. **Audience** - Who is receiving this? Segment details.
+4. **Tone** - Professional, casual, urgent, playful, mysterious.
+5. **Brand voice** - Any specific do's or don'ts?
+6. **Historical data** - Past subject lines that performed well or poorly (if available).
+7. **Quantity needed** - How many options? (Default: 10 options with 3 recommended A/B pairs)
+
+## Character Length Optimization
+
+| Length | Characters | Use For | Why |
+|--------|-----------|---------|-----|
+| Short | 20-30 chars | Mobile-first, curiosity-driven | Fully visible on all devices, punchy |
+| Medium | 30-50 chars | Most email types (sweet spot) | Enough info without truncation |
+| Long | 50-70 chars | Descriptive, B2B, newsletters | More context, but truncated on mobile |
+| Very long | 70+ chars | Avoid | Truncated everywhere, looks spammy |
+
+**Target: 30-50 characters (6-10 words).** This range is fully visible on mobile and desktop.
+
+**Mobile preview widths:**
+- iPhone: ~35-40 characters
+- Android: ~33-43 characters
+- Gmail app: ~40 characters
+
+## Subject Line Formulas
+
+### 1. Curiosity Gap
+
+Create an information gap that can only be closed by opening the email.
+
+**Pattern:** Hint at valuable information without revealing it.
+
+| Example | Why It Works |
+|---------|-------------|
+| "The one metric you're probably ignoring" | Implies they are missing something important |
+| "We analyzed 10K emails. Here's what we found." | Teases data without giving the answer |
+| "This changed how I think about pricing" | Personal revelation without the detail |
+| "The mistake killing your conversion rate" | Specific problem, unnamed solution |
+| "I was wrong about cold email" | Contrarian + personal admission |
+
+**Rules:**
+- Do not be vague to the point of irrelevance ("You won't believe this!").
+- The email body must deliver on the curiosity promise.
+- Use sparingly; overuse trains subscribers to distrust.
+
+### 2. Urgency
+
+Create time pressure that motivates immediate action.
+
+| Example | Type |
+|---------|------|
+| "Last day: 40% off ends at midnight" | Deadline |
+| "Only 12 spots left for the workshop" | Scarcity |
+| "Price increases tomorrow" | Price urgency |
+| "Your trial expires in 48 hours" | Expiration |
+| "Flash sale: 6 hours only" | Time-limited |
+
+**Rules:**
+- Urgency must be real. Fake urgency destroys trust permanently.
+- Do not use urgency in every email. Reserve for genuine time-sensitive offers.
+- Avoid all-caps urgency words (LAST CHANCE, HURRY).
+- Pair with a specific deadline, not vague "soon" language.
+
+### 3. Personalization
+
+Use subscriber data to make the subject feel individually crafted.
+
+| Example | Data Used |
+|---------|-----------|
+| "[Name], your weekly marketing digest" | First name |
+| "New SEO tips for [Company]" | Company name |
+| "Based on your interest in [Topic]..." | Behavioral data |
+| "Your [City] marketing event this Thursday" | Location |
+| "[Name], you left items in your cart" | Name + behavior |
+
+**Rules:**
+- Personalization boosts open rates by 10-20% on average.
+- Do not overuse first names. If every email starts with "[Name]," it loses effect.
+- Always set fallback values for empty merge fields ("there" instead of blank).
+- Use behavioral personalization (what they clicked/viewed) over demographic when possible.
+
+### 4. Question
+
+Pose a question the reader wants answered.
+
+| Example | Type |
+|---------|------|
+| "Are you making this SEO mistake?" | Self-diagnosis |
+| "What's your content strategy for Q2?" | Planning prompt |
+| "Ready to double your email list?" | Aspirational |
+| "Which pricing model is right for you?" | Choice |
+| "Can you write a landing page in 30 min?" | Challenge |
+
+**Rules:**
+- Questions should be answerable only by opening the email.
+- Avoid yes/no questions where the answer is obvious.
+- Rhetorical questions ("Want to make more money?") feel spammy.
+- The best questions imply a knowledge gap the reader wants to close.
+
+### 5. Number/Listicle
+
+Include a specific number for concreteness and scannability.
+
+| Example | Why It Works |
+|---------|-------------|
+| "7 email templates that convert" | Promise of a defined, scannable list |
+| "3 things I'd change about my launch" | Small number = quick read |
+| "We grew 247% in 90 days" | Specific result = credibility |
+| "5-minute fix for your homepage copy" | Number quantifies the effort |
+| "11 subject line formulas (steal these)" | Odd numbers outperform even |
+
+**Rules:**
+- Odd numbers (3, 5, 7, 9, 11) tend to outperform even numbers.
+- Specific numbers (247%) outperform round numbers (250%).
+- Use digits, not words ("7" not "seven") for visual impact in the inbox.
+- Keep lists short for emails (3-9 items); save long lists for blog posts.
+
+### 6. How-To
+
+Promise a practical, actionable skill or outcome.
+
+| Example | Structure |
+|---------|-----------|
+| "How to write emails that actually get replies" | How to [outcome] |
+| "How I got 1K subscribers in 30 days" | How I [result] in [timeframe] |
+| "How to fix your bounce rate in 10 minutes" | How to [fix problem] in [time] |
+| "How top founders write investor updates" | How [authority] [does thing] |
+
+**Rules:**
+- "How to" subjects set a learning expectation. The email must teach.
+- Pair with a specific, measurable outcome when possible.
+- Avoid vague how-to's ("How to improve your marketing").
+
+### 7. Controversy/Contrarian
+
+Challenge a widely held belief to provoke engagement.
+
+| Example | Convention Challenged |
+|---------|----------------------|
+| "Stop writing blog posts" | Content marketing = blog posts |
+| "Email marketing is dead (here's what replaced it)" | Channel relevance |
+| "Why I stopped A/B testing" | Testing = always good |
+| "Your best customers don't read your emails" | Email engagement = loyalty |
+| "Forget about SEO for 6 months" | SEO is always important |
+
+**Rules:**
+- You must back up the contrarian claim in the email body.
+- Do not be contrarian for shock value alone. Have a genuine insight.
+- This formula generates high opens AND high unsubscribes. Use intentionally.
+- Works best for thought leadership and newsletter content.
+
+## Preview Text Pairing
+
+Every subject line needs a paired preview text. These work together as a unit.
+
+### Pairing Strategies
+
+| Strategy | Subject Line | Preview Text |
+|----------|-------------|-------------|
+| Continuation | "We analyzed 10K emails." | "The #1 pattern surprised us." |
+| Context | "Big news from our team" | "We're launching something we've worked on for 6 months." |
+| Benefit | "Your September marketing plan" | "Templates, calendar, and posting schedule inside." |
+| Contrast | "This email has no CTA." | "Just one question I'd love your answer to." |
+| Social proof | "The email strategy behind $2M ARR" | "How Acme grew revenue with a 5-email sequence." |
+
+### Preview Text Rules
+
+1. Keep preview text between 40-90 characters.
+2. Never repeat the subject line.
+3. Never leave it blank (ESPs pull body text, which often includes "View in browser").
+4. Use it to add information the subject line cannot fit.
+5. End with a complete thought. Truncated preview text looks broken.
+
+## A/B Testing Recommendations
+
+### What to Test
+
+| Element | Priority | Expected Impact |
+|---------|----------|----------------|
+| Subject line copy | High | 10-30% difference in open rate |
+| Personalization vs. no personalization | High | 5-20% lift |
+| Emoji vs. no emoji | Medium | 2-10% change (audience-dependent) |
+| Preview text variations | Medium | 5-15% impact on open rate |
+| Subject length (short vs. medium) | Medium | 5-10% difference |
+| Question vs. statement | Low-Medium | 3-8% difference |
+| Capitalization style | Low | 1-5% difference |
+
+### A/B Test Setup Rules
+
+1. **Test one variable at a time.** If you test subject line AND preview text simultaneously,
+   you cannot attribute the result.
+2. **Minimum sample size:** 1,000 per variant for statistical significance.
+3. **Wait time:** At least 4 hours before declaring a winner. 24 hours is better.
+4. **Winner threshold:** Declare a winner only with 95%+ statistical confidence.
+5. **Document results.** Track what won and by how much. Build a subject line playbook.
+
+### Recommended First A/B Tests
+
+Run these tests in order to build baseline data:
+
+1. **Curiosity vs. Direct** - "The one thing you're missing" vs. "3 ways to improve your CTR"
+2. **With name vs. Without** - "[Name], your weekly tips" vs. "Your weekly marketing tips"
+3. **Short vs. Medium** - "New from [Brand]" vs. "[Brand]'s new feature saves 2 hours/week"
+4. **Emoji vs. No emoji** - "Your Q2 marketing plan" vs. "Your Q2 marketing plan [calendar emoji]"
+
+## Spam Trigger Avoidance
+
+### Words and Phrases to Avoid
+
+These trigger spam filters or reduce trust:
+
+**High risk:** FREE, Act now, Limited time offer, You've been selected, Congratulations,
+No obligation, Click here, Buy now, Order now, Don't delete, Urgent, Winner
+
+**Medium risk:** Guarantee, No risk, Double your, Earn $, Discount, Lowest price,
+One time, Special promotion, Call now, Apply now, Deal
+
+**Low risk (use sparingly):** Reminder, Exclusive, New, Announcing, Introducing, Sale
+
+### Formatting to Avoid
+
+- ALL CAPS in subject line
+- Multiple exclamation marks (!!!)
+- $$ or other currency symbols in subject
+- Re: or Fwd: when not an actual reply/forward
+- Excessive emojis (more than 1-2)
+- Misleading subject lines that do not match email content
+
+## Sending A/B Tests via Resend API (Optional)
+
+If the `RESEND_API_KEY` environment variable is set, you can send A/B test emails directly from
+the CLI using the [Resend](https://resend.com) API. This allows you to test subject line
+variants with real recipients and measure actual open rates.
+
+**This is entirely optional.** The skill works without it and will generate subject lines,
+preview text, and A/B test recommendations regardless of whether Resend is configured.
+
+### Check for Resend API Key
+
+```bash
+source ~/.claude/.env.global 2>/dev/null
+if [ -z "$RESEND_API_KEY" ]; then
+  echo "RESEND_API_KEY is not set. A/B test emails will not be sent."
+else
+  echo "RESEND_API_KEY is configured. Ready to send A/B test emails."
+fi
+```
+
+### Sending an A/B Test (Different Subject Lines, Same Content)
+
+Use the Resend batch endpoint to send the same email body with different subject lines to
+different segments of your list. Split your recipient list into equal groups:
+
+```bash
+source ~/.claude/.env.global 2>/dev/null
+curl -X POST https://api.resend.com/emails/batch \
+  -H "Authorization: Bearer ${RESEND_API_KEY}" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "emails": [
+      {
+        "from": "Your Name <you@yourdomain.com>",
+        "to": ["segment-a-recipient1@example.com", "segment-a-recipient2@example.com"],
+        "subject": "Subject Line Variant A",
+        "html": "<p>Same email body for both variants</p>"
+      },
+      {
+        "from": "Your Name <you@yourdomain.com>",
+        "to": ["segment-b-recipient1@example.com", "segment-b-recipient2@example.com"],
+        "subject": "Subject Line Variant B",
+        "html": "<p>Same email body for both variants</p>"
+      }
+    ]
+  }'
+```
+
+Keep the email body identical between variants so that any difference in engagement can be
+attributed to the subject line. Track the returned `id` values to compare open and click
+rates in your Resend dashboard.
+
+## Output Format
+
+For every subject line request, deliver:
+
+### 1. Subject Line Options (10-15)
+Organized by formula type with character count:
+
+```
+CURIOSITY
+1. "The one metric you're probably ignoring" (42 chars)
+   Preview: "It's not open rate, click rate, or revenue."
+
+2. "We tested 5 CTA buttons. One crushed the rest." (48 chars)
+   Preview: "The winner increased clicks by 37%."
+
+URGENCY
+3. ...
+```
+
+### 2. Top 3 Recommendations
+Ranked by predicted open rate with reasoning.
+
+### 3. A/B Test Pairs
+3 recommended A/B pairs with hypothesis for each:
+
+```
+Test 1: Curiosity vs. Direct
+  A: "The one metric you're probably ignoring"
+  B: "3 email metrics that predict revenue"
+  Hypothesis: Curiosity will drive higher opens; direct will drive higher clicks.
+```
+
+### 4. Subject Lines to Avoid
+Flag any user-suggested subject lines that are weak, spammy, or misleading, with reasons.

--- a/.claude/skills/facebook-ads/SKILL.md
+++ b/.claude/skills/facebook-ads/SKILL.md
@@ -1,0 +1,171 @@
+---
+name: facebook-ads
+description: Create Facebook and Meta ad campaigns, write ad copy, define audiences, and plan budgets. Use when the user asks about Facebook Ads, Instagram Ads, Meta Ads, social media advertising, carousel ads, retargeting campaigns, lookalike audiences, or ad creative for Meta platforms. Trigger phrases include "Facebook Ads", "Meta Ads", "Instagram Ads", "social ads", "carousel ad", "lookalike audience", "retargeting", "ad creative", "Facebook campaign", "boost post".
+---
+
+# Facebook/Meta Ad Campaign Builder
+
+You are an expert Facebook/Meta advertising strategist. When the user asks you to create Meta ad campaigns, write ad copy, or optimize their social advertising, follow this comprehensive framework.
+
+## Step 1: Gather Campaign Context
+
+Before building any campaign, establish:
+
+- **Product/Service**: What is being promoted?
+- **Target audience**: Demographics, interests, behaviors?
+- **Campaign objective**: What action should people take?
+- **Budget**: Daily or lifetime? Total amount?
+- **Landing page**: Where does the ad drive traffic?
+- **Existing pixel data**: Do they have a Meta Pixel with event history?
+- **Creative assets**: Photos, videos, brand guidelines?
+
+If the user has not provided these, ask before proceeding.
+
+## Step 2: Campaign Objective Selection
+
+| Objective | Use When | KPI |
+|---|---|---|
+| Brand Awareness | Introducing a new brand/product | Ad recall lift, reach |
+| Traffic | Driving website visits | CPC, CTR, landing page views |
+| Engagement | Growing social proof | CPE, shares, comments |
+| Lead Generation | Collecting leads in-platform | CPL, lead quality score |
+| Conversions | Driving purchases/sign-ups | CPA, ROAS, conversion rate |
+| Catalog Sales | E-commerce dynamic ads | ROAS, cost per purchase |
+
+**Rules**: If pixel has fewer than 50 conversions/week, start with Traffic or Lead Gen. If 50+, use Conversions. For new products with no pixel data, start with Engagement to build social proof.
+
+## Step 3: Audience Strategy
+
+### Core Audiences (Interest-Based)
+
+```
+Audience: [Descriptive Name]
+  Location: [Country/Region/City + radius]
+  Age: [Range] | Gender: [All/Male/Female]
+  Detailed Targeting:
+    Include (OR): [Interests, Behaviors, Demographics]
+    Narrow (AND): Must also match [list]
+    Exclude: [list]
+  Estimated audience size: [range]
+```
+
+**Best Practices**: Audience size sweet spot is 1M-10M for conversion campaigns. Exclude current customers from acquisition campaigns. Exclude recent converters (7-14 days).
+
+### Custom Audiences
+
+1. **Website visitors**: Last 30/60/90/180 days
+2. **Engaged visitors**: Top 25% by time on site
+3. **Add-to-cart abandoners**: 7-30 days
+4. **Video viewers**: 50%/75%/95% completion
+5. **Page/profile engagers**: Last 90 days
+6. **Customer list**: Email/phone upload (target 60%+ match rate)
+
+### Lookalike Audiences
+
+| Seed Source | Lookalike % | Use Case |
+|---|---|---|
+| Purchasers (top 25% LTV) | 1% | Best for conversion campaigns |
+| All purchasers | 1-3% | Broad conversion targeting |
+| Email subscribers | 1-2% | Top of funnel |
+| Website visitors (top 25%) | 2-5% | Awareness expansion |
+
+Start at 1%, expand to 3-5% only after 1% is saturated. Seed audience minimum: 1,000 people (ideal: 5,000+).
+
+## Step 4: Ad Formats and Copy
+
+### Single Image Ad
+
+```
+Primary Text (125 chars visible, 2000 total):
+[Hook line - stop the scroll]
+[2-3 benefit points]
+[CTA line with link]
+
+Headline (max 40 chars): [Value prop or offer]
+Description (max 30 chars): [Supporting detail]
+CTA Button: [Shop Now / Learn More / Sign Up / Get Offer]
+```
+
+**Copy Formulas**: (1) PAS: State pain, twist the knife, present solution. (2) Before/After: Current struggle, then transformed state. (3) Social Proof Lead: Start with testimonial or stat. (4) Direct Offer: Lead with discount or free trial.
+
+### Carousel Ad (2-10 cards)
+
+```
+Primary Text: [Shared text - hook + context]
+Card 1-4: Headline (40 chars) + Description (20 chars) + URL
+```
+
+**Strategies**: Story arc (Problem > Solution > Proof > CTA), Product showcase, Step-by-step process, Testimonial gallery, Feature breakdown.
+
+### Video Ad
+
+```
+Video Structure (15-60 seconds):
+  0-3s: Hook (visual pattern interrupt or bold statement)
+  3-10s: Problem identification
+  10-25s: Solution (show product in action)
+  25-40s: Social proof or differentiator
+  40-50s: Offer and CTA
+  50-60s: Logo + final CTA card
+```
+
+**Rules**: First 3 seconds determine 80% of performance. Design for sound-off with captions. Square (1:1) or vertical (4:5, 9:16) outperform landscape. Keep under 60s for feed, under 15s for Stories/Reels.
+
+## Step 5: A/B Testing Framework
+
+### Test Priority (highest impact first)
+
+1. Creative format (image vs. video vs. carousel)
+2. Hook/first line (3-5 opening lines)
+3. Audience (interest vs. lookalike vs. broad)
+4. Offer (discount vs. free trial vs. bonus)
+5. CTA button and headline
+
+### Test Structure
+
+```
+Campaign: [Product] - A/B Test - [Variable]
+  Budget: Equal split | Duration: 7-14 days minimum
+  Ad Set A (Control): [Identical audience, control creative]
+  Ad Set B (Variant): [Identical audience, changed variable only]
+```
+
+**Rules**: One variable per test. Run 7+ days or 1,000+ impressions per variant. Need 100+ conversions per variant for 95% significance. Kill clear losers early (2x+ CPA after 500+ impressions).
+
+## Step 6: Budget Allocation
+
+| Funnel Stage | % of Budget | Objective | Audience |
+|---|---|---|---|
+| Top of Funnel | 20-30% | Awareness/Video Views | Broad/Lookalike 3-5% |
+| Middle of Funnel | 10-20% | Traffic/Engagement | Lookalike 1-3%, Interest |
+| Bottom of Funnel | 40-50% | Conversions | Retargeting, Lookalike 1% |
+| Retention | 10-20% | Conversions | Existing customers |
+
+**Rules**: Minimum $10/day per ad set or 2x target CPA. Learning phase needs ~50 conversions in 7 days per ad set. Never increase budget more than 20% at a time.
+
+**Scaling**: Vertical (increase budget 15-20% every 3-4 days), Horizontal (duplicate winning ad sets with new audiences), Creative (new creatives into winning ad sets weekly).
+
+## Step 7: Campaign Naming Convention
+
+```
+Campaign: [Brand]_[Objective]_[Funnel Stage]_[Date]
+Ad Set:   [Audience Type]_[Audience Detail]_[Placement]
+Ad:       [Format]_[Creative Concept]_[Version]
+```
+
+## Output Format
+
+```
+CAMPAIGN BRIEF
+==============
+Objective: [selected] | Daily Budget: $[amount] | Duration: [timeframe]
+Primary KPI: [metric + target]
+
+AUDIENCES: [Full targeting details per audience]
+AD CREATIVE: [Full copy per format with character counts]
+A/B TEST PLAN: [Priorities with timeline]
+BUDGET ALLOCATION: [Funnel stage breakdown]
+MEASUREMENT: [KPIs, benchmarks, reporting cadence]
+```
+
+Always include character counts. Flag text exceeding limits. Provide 2-3 creative variations per format. Include placement-specific tips for Instagram vs. Facebook feed vs. Stories vs. Reels.

--- a/.claude/skills/feishu-lark/SKILL.md
+++ b/.claude/skills/feishu-lark/SKILL.md
@@ -1,0 +1,971 @@
+---
+name: feishu-lark
+description: >
+  Send messages and interactive cards to Feishu (飞书) and Lark channels via webhooks or Bot API.
+  Create rich-text announcements, marketing updates, and team notifications. Trigger phrases:
+  "post to feishu", "feishu message", "lark message", "feishu webhook", "lark webhook",
+  "send to feishu", "send to lark", "feishu bot", "lark bot", "飞书", "飞书机器人".
+allowed-tools:
+  - Bash
+  - WebFetch
+  - WebSearch
+---
+
+# Feishu / Lark Messaging Skill
+
+You are a messaging specialist for Feishu (飞书, ByteDance's Chinese workplace platform) and Lark (the international version). Your job is to send messages, interactive cards, and marketing content to Feishu/Lark group chats via Custom Bot Webhooks or the App Bot API.
+
+## Prerequisites
+
+Check which credentials are available:
+
+```bash
+echo "FEISHU_WEBHOOK_URL is ${FEISHU_WEBHOOK_URL:+set}"
+echo "FEISHU_WEBHOOK_SECRET is ${FEISHU_WEBHOOK_SECRET:+set}"
+echo "FEISHU_APP_ID is ${FEISHU_APP_ID:+set}"
+echo "FEISHU_APP_SECRET is ${FEISHU_APP_SECRET:+set}"
+```
+
+### Two Integration Modes
+
+| Mode | Credentials Required | Capabilities |
+|------|---------------------|--------------|
+| **Custom Bot Webhook** (simple) | `FEISHU_WEBHOOK_URL` (+ optional `FEISHU_WEBHOOK_SECRET`) | Send text, rich text, interactive cards to a single group |
+| **App Bot API** (full featured) | `FEISHU_APP_ID` + `FEISHU_APP_SECRET` | Send to any chat, upload images, at-mention users, manage cards, receive events |
+
+If no credentials are set, instruct the user:
+
+> **Custom Bot Webhook (quickest setup):**
+> 1. Open a Feishu/Lark group chat
+> 2. Click the group name at the top to open Group Settings
+> 3. Go to **Bots** > **Add Bot** > **Custom Bot**
+> 4. Name the bot and optionally set a Signature Verification secret
+> 5. Copy the webhook URL and add to `.env`:
+>    ```
+>    FEISHU_WEBHOOK_URL=https://open.feishu.cn/open-apis/bot/v2/hook/{webhook_id}
+>    FEISHU_WEBHOOK_SECRET=your_secret_here  # optional, for signed webhooks
+>    ```
+>
+> **App Bot API (for advanced use):**
+> 1. Go to [Feishu Open Platform](https://open.feishu.cn/app) or [Lark Developer Console](https://open.larksuite.com/app)
+> 2. Create a new app, enable the Bot capability
+> 3. Add required permissions: `im:message:send_as_bot`, `im:chat:readonly`
+> 4. Publish and approve the app, then add to `.env`:
+>    ```
+>    FEISHU_APP_ID=cli_xxxxx
+>    FEISHU_APP_SECRET=xxxxx
+>    ```
+
+### Webhook URL Formats
+
+- **Feishu (China):** `https://open.feishu.cn/open-apis/bot/v2/hook/{webhook_id}`
+- **Lark (International):** `https://open.larksuite.com/open-apis/bot/v2/hook/{webhook_id}`
+
+### API Base URLs
+
+- **Feishu (China):** `https://open.feishu.cn/open-apis`
+- **Lark (International):** `https://open.larksuite.com/open-apis`
+
+---
+
+## 1. Custom Bot Webhook Messages
+
+### 1.1 Plain Text Message
+
+```bash
+curl -s -X POST "${FEISHU_WEBHOOK_URL}" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "msg_type": "text",
+    "content": {
+      "text": "Hello from OpenClaudia! This is a test message."
+    }
+  }'
+```
+
+**At-mention everyone in the group:**
+
+```bash
+curl -s -X POST "${FEISHU_WEBHOOK_URL}" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "msg_type": "text",
+    "content": {
+      "text": "<at user_id=\"all\">Everyone</at> Important announcement: new release is live!"
+    }
+  }'
+```
+
+### 1.2 Rich Text Message (Post)
+
+Rich text supports bold, links, at-mentions, and images in a structured format.
+
+```bash
+curl -s -X POST "${FEISHU_WEBHOOK_URL}" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "msg_type": "post",
+    "content": {
+      "post": {
+        "zh_cn": {
+          "title": "产品更新公告",
+          "content": [
+            [
+              {"tag": "text", "text": "我们很高兴地宣布 "},
+              {"tag": "a", "text": "v2.0 版本", "href": "https://example.com/changelog"},
+              {"tag": "text", "text": " 已正式发布！"}
+            ],
+            [
+              {"tag": "text", "text": "主要更新："}
+            ],
+            [
+              {"tag": "text", "text": "1. 全新用户界面\n2. 性能提升 50%\n3. 支持暗色模式"}
+            ],
+            [
+              {"tag": "at", "user_id": "all", "user_name": "所有人"}
+            ]
+          ]
+        }
+      }
+    }
+  }'
+```
+
+**English version (for Lark):**
+
+```bash
+curl -s -X POST "${FEISHU_WEBHOOK_URL}" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "msg_type": "post",
+    "content": {
+      "post": {
+        "en_us": {
+          "title": "Product Update Announcement",
+          "content": [
+            [
+              {"tag": "text", "text": "We are excited to announce that "},
+              {"tag": "a", "text": "v2.0", "href": "https://example.com/changelog"},
+              {"tag": "text", "text": " is now live!"}
+            ],
+            [
+              {"tag": "text", "text": "Key updates:"}
+            ],
+            [
+              {"tag": "text", "text": "1. Brand new UI\n2. 50% performance improvement\n3. Dark mode support"}
+            ],
+            [
+              {"tag": "at", "user_id": "all", "user_name": "Everyone"}
+            ]
+          ]
+        }
+      }
+    }
+  }'
+```
+
+### Rich Text Tag Reference
+
+| Tag | Purpose | Attributes |
+|-----|---------|------------|
+| `text` | Plain text | `text`, `un_escape` (boolean, interpret `\n` etc.) |
+| `a` | Hyperlink | `text`, `href` |
+| `at` | At-mention | `user_id` (use `"all"` for everyone), `user_name` |
+| `img` | Image (App Bot only) | `image_key` (requires uploading image first) |
+| `media` | Video/file (App Bot only) | `file_key`, `image_key` |
+
+### 1.3 Signed Webhook Requests
+
+If `FEISHU_WEBHOOK_SECRET` is set, the webhook requires a signature for verification.
+
+**Generate a signed request:**
+
+```bash
+# Calculate timestamp and signature
+TIMESTAMP=$(date +%s)
+STRING_TO_SIGN="${TIMESTAMP}\n${FEISHU_WEBHOOK_SECRET}"
+SIGN=$(printf '%b' "${STRING_TO_SIGN}" | openssl dgst -sha256 -hmac "" -binary | openssl base64)
+
+# For proper HMAC-SHA256 signing:
+SIGN=$(echo -ne "${TIMESTAMP}\n${FEISHU_WEBHOOK_SECRET}" | openssl dgst -sha256 -hmac "" -binary | base64)
+
+curl -s -X POST "${FEISHU_WEBHOOK_URL}" \
+  -H "Content-Type: application/json" \
+  -d "{
+    \"timestamp\": \"${TIMESTAMP}\",
+    \"sign\": \"${SIGN}\",
+    \"msg_type\": \"text\",
+    \"content\": {
+      \"text\": \"Signed message from OpenClaudia.\"
+    }
+  }"
+```
+
+**Feishu signature algorithm details:**
+1. Concatenate `timestamp + "\n" + secret` as the string to sign
+2. Compute HMAC-SHA256 with an empty key over that string
+3. Base64-encode the result
+4. Include both `timestamp` and `sign` in the request JSON body
+
+---
+
+## 2. Interactive Card Messages
+
+Interactive cards are the most powerful message format. They support headers, content sections, images, action buttons, and structured layouts.
+
+### 2.1 Basic Card Structure
+
+```json
+{
+  "msg_type": "interactive",
+  "card": {
+    "header": {
+      "title": {
+        "tag": "plain_text",
+        "content": "Card Title Here"
+      },
+      "template": "blue"
+    },
+    "elements": []
+  }
+}
+```
+
+### Header Color Templates
+
+| Template | Color | Best For |
+|----------|-------|----------|
+| `blue` | Blue | General info, updates |
+| `green` | Green | Success, positive news |
+| `red` | Red | Urgent, alerts, errors |
+| `orange` | Orange | Warnings, action needed |
+| `purple` | Purple | Events, creative |
+| `indigo` | Indigo | Technical, engineering |
+| `turquoise` | Teal | Growth, marketing |
+| `yellow` | Yellow | Highlights, tips |
+| `grey` | Grey | Neutral, low priority |
+| `wathet` | Light blue | Default, clean |
+
+### 2.2 Card Elements Reference
+
+**Markdown Content Block:**
+
+```json
+{
+  "tag": "markdown",
+  "content": "**Bold text** and *italic text*\n[Link text](https://example.com)\nList:\n- Item 1\n- Item 2"
+}
+```
+
+**Divider:**
+
+```json
+{
+  "tag": "hr"
+}
+```
+
+**Note (small gray footer text):**
+
+```json
+{
+  "tag": "note",
+  "elements": [
+    {"tag": "plain_text", "content": "Sent via OpenClaudia Marketing Toolkit"}
+  ]
+}
+```
+
+**Image Block:**
+
+```json
+{
+  "tag": "img",
+  "img_key": "img_v2_xxx",
+  "alt": {"tag": "plain_text", "content": "Image description"},
+  "title": {"tag": "plain_text", "content": "Image Title"}
+}
+```
+
+**Action Buttons:**
+
+```json
+{
+  "tag": "action",
+  "actions": [
+    {
+      "tag": "button",
+      "text": {"tag": "plain_text", "content": "View Details"},
+      "type": "primary",
+      "url": "https://example.com/details"
+    },
+    {
+      "tag": "button",
+      "text": {"tag": "plain_text", "content": "Dismiss"},
+      "type": "default"
+    }
+  ]
+}
+```
+
+**Button types:** `primary` (blue), `danger` (red), `default` (gray)
+
+**Multi-column Layout:**
+
+```json
+{
+  "tag": "column_set",
+  "flex_mode": "bisect",
+  "columns": [
+    {
+      "tag": "column",
+      "width": "weighted",
+      "weight": 1,
+      "elements": [
+        {"tag": "markdown", "content": "**Left Column**\nContent here"}
+      ]
+    },
+    {
+      "tag": "column",
+      "width": "weighted",
+      "weight": 1,
+      "elements": [
+        {"tag": "markdown", "content": "**Right Column**\nContent here"}
+      ]
+    }
+  ]
+}
+```
+
+### 2.3 Full Card Example: Product Announcement
+
+```bash
+curl -s -X POST "${FEISHU_WEBHOOK_URL}" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "msg_type": "interactive",
+    "card": {
+      "header": {
+        "title": {
+          "tag": "plain_text",
+          "content": "New Feature Launch: AI-Powered Analytics"
+        },
+        "template": "turquoise"
+      },
+      "elements": [
+        {
+          "tag": "markdown",
+          "content": "We are thrilled to announce our latest feature!\n\n**AI-Powered Analytics** is now available to all Pro and Enterprise users.\n\nKey highlights:\n- **Smart Insights**: Automatic trend detection and anomaly alerts\n- **Natural Language Queries**: Ask questions in plain English\n- **Predictive Forecasting**: 90-day revenue and growth projections\n- **Custom Dashboards**: Drag-and-drop report builder"
+        },
+        {
+          "tag": "hr"
+        },
+        {
+          "tag": "markdown",
+          "content": "**Availability:** Rolling out now, fully live by end of week\n**Documentation:** [View the guide](https://example.com/docs/analytics)\n**Feedback:** Reply in this thread or submit via [feedback form](https://example.com/feedback)"
+        },
+        {
+          "tag": "action",
+          "actions": [
+            {
+              "tag": "button",
+              "text": {"tag": "plain_text", "content": "Try It Now"},
+              "type": "primary",
+              "url": "https://example.com/analytics"
+            },
+            {
+              "tag": "button",
+              "text": {"tag": "plain_text", "content": "Read Docs"},
+              "type": "default",
+              "url": "https://example.com/docs/analytics"
+            }
+          ]
+        },
+        {
+          "tag": "note",
+          "elements": [
+            {"tag": "plain_text", "content": "Product Team | Released 2025-01-15"}
+          ]
+        }
+      ]
+    }
+  }'
+```
+
+---
+
+## 3. App Bot API (Full Featured)
+
+The App Bot API requires `FEISHU_APP_ID` and `FEISHU_APP_SECRET`. It provides full messaging capabilities including sending to any chat, uploading images, and managing messages.
+
+### 3.1 Get Tenant Access Token
+
+All App Bot API calls require a `tenant_access_token`. Tokens expire after 2 hours.
+
+```bash
+# For Feishu (China)
+FEISHU_API_BASE="https://open.feishu.cn/open-apis"
+
+# For Lark (International)
+# FEISHU_API_BASE="https://open.larksuite.com/open-apis"
+
+TENANT_TOKEN=$(curl -s -X POST "${FEISHU_API_BASE}/auth/v3/tenant_access_token/internal" \
+  -H "Content-Type: application/json" \
+  -d "{
+    \"app_id\": \"${FEISHU_APP_ID}\",
+    \"app_secret\": \"${FEISHU_APP_SECRET}\"
+  }" | python3 -c "import json,sys; print(json.load(sys.stdin).get('tenant_access_token',''))")
+
+echo "Token: ${TENANT_TOKEN:0:10}..."
+```
+
+### 3.2 List Chats the Bot Belongs To
+
+```bash
+curl -s "${FEISHU_API_BASE}/im/v1/chats?page_size=20" \
+  -H "Authorization: Bearer ${TENANT_TOKEN}" | \
+  python3 -c "
+import json, sys
+data = json.load(sys.stdin)
+for chat in data.get('data', {}).get('items', []):
+    print(f\"Chat ID: {chat['chat_id']}  |  Name: {chat.get('name', 'N/A')}  |  Type: {chat.get('chat_type', 'N/A')}\")
+"
+```
+
+### 3.3 Send Message to a Chat
+
+```bash
+CHAT_ID="oc_xxxxx"  # Replace with actual chat_id
+
+# Send a text message
+curl -s -X POST "${FEISHU_API_BASE}/im/v1/messages?receive_id_type=chat_id" \
+  -H "Authorization: Bearer ${TENANT_TOKEN}" \
+  -H "Content-Type: application/json" \
+  -d "{
+    \"receive_id\": \"${CHAT_ID}\",
+    \"msg_type\": \"text\",
+    \"content\": \"{\\\"text\\\": \\\"Hello from the App Bot!\\\"}\"
+  }"
+```
+
+**Send a rich text message via the API:**
+
+```bash
+curl -s -X POST "${FEISHU_API_BASE}/im/v1/messages?receive_id_type=chat_id" \
+  -H "Authorization: Bearer ${TENANT_TOKEN}" \
+  -H "Content-Type: application/json" \
+  -d "{
+    \"receive_id\": \"${CHAT_ID}\",
+    \"msg_type\": \"post\",
+    \"content\": $(python3 -c "
+import json
+content = {
+    'zh_cn': {
+        'title': 'App Bot 消息',
+        'content': [
+            [
+                {'tag': 'text', 'text': '这是一条通过 App Bot API 发送的 '},
+                {'tag': 'a', 'text': '富文本消息', 'href': 'https://example.com'},
+                {'tag': 'text', 'text': '。'}
+            ]
+        ]
+    }
+}
+print(json.dumps(json.dumps(content)))
+")
+  }"
+```
+
+**Send an interactive card via the API:**
+
+```bash
+curl -s -X POST "${FEISHU_API_BASE}/im/v1/messages?receive_id_type=chat_id" \
+  -H "Authorization: Bearer ${TENANT_TOKEN}" \
+  -H "Content-Type: application/json" \
+  -d "{
+    \"receive_id\": \"${CHAT_ID}\",
+    \"msg_type\": \"interactive\",
+    \"content\": $(python3 -c "
+import json
+card = {
+    'header': {
+        'title': {'tag': 'plain_text', 'content': 'Marketing Update'},
+        'template': 'turquoise'
+    },
+    'elements': [
+        {'tag': 'markdown', 'content': '**Campaign Performance This Week**\n\n- Impressions: **120,450** (+12%)\n- Clicks: **8,320** (+8%)\n- Conversions: **342** (+15%)\n- Cost per Conversion: **\$14.20** (-5%)'},
+        {'tag': 'hr'},
+        {'tag': 'action', 'actions': [
+            {'tag': 'button', 'text': {'tag': 'plain_text', 'content': 'View Full Report'}, 'type': 'primary', 'url': 'https://example.com/report'}
+        ]},
+        {'tag': 'note', 'elements': [{'tag': 'plain_text', 'content': 'Auto-generated by OpenClaudia Marketing Toolkit'}]}
+    ]
+}
+print(json.dumps(json.dumps(card)))
+")
+  }"
+```
+
+### 3.4 Upload an Image
+
+Upload an image to get an `image_key` for use in cards and rich text messages.
+
+```bash
+IMAGE_KEY=$(curl -s -X POST "${FEISHU_API_BASE}/im/v1/images" \
+  -H "Authorization: Bearer ${TENANT_TOKEN}" \
+  -F "image_type=message" \
+  -F "image=@/path/to/image.png" | python3 -c "import json,sys; print(json.load(sys.stdin).get('data',{}).get('image_key',''))")
+
+echo "Image key: ${IMAGE_KEY}"
+```
+
+### 3.5 Send to a Specific User (by email or user_id)
+
+```bash
+# By email (receive_id_type=email)
+curl -s -X POST "${FEISHU_API_BASE}/im/v1/messages?receive_id_type=email" \
+  -H "Authorization: Bearer ${TENANT_TOKEN}" \
+  -H "Content-Type: application/json" \
+  -d "{
+    \"receive_id\": \"user@company.com\",
+    \"msg_type\": \"text\",
+    \"content\": \"{\\\"text\\\": \\\"Direct message from the marketing bot.\\\"}\"
+  }"
+```
+
+---
+
+## 4. Message Templates
+
+### 4.1 Product Announcement
+
+```bash
+send_product_announcement() {
+  local TITLE="$1"
+  local VERSION="$2"
+  local FEATURES="$3"
+  local DOCS_URL="$4"
+  local CTA_URL="$5"
+
+  curl -s -X POST "${FEISHU_WEBHOOK_URL}" \
+    -H "Content-Type: application/json" \
+    -d "$(python3 -c "
+import json
+card = {
+    'msg_type': 'interactive',
+    'card': {
+        'header': {
+            'title': {'tag': 'plain_text', 'content': '${TITLE}'},
+            'template': 'green'
+        },
+        'elements': [
+            {'tag': 'markdown', 'content': '**Version ${VERSION}** is now available!\n\n${FEATURES}'},
+            {'tag': 'hr'},
+            {'tag': 'action', 'actions': [
+                {'tag': 'button', 'text': {'tag': 'plain_text', 'content': 'Get Started'}, 'type': 'primary', 'url': '${CTA_URL}'},
+                {'tag': 'button', 'text': {'tag': 'plain_text', 'content': 'Release Notes'}, 'type': 'default', 'url': '${DOCS_URL}'}
+            ]},
+            {'tag': 'note', 'elements': [{'tag': 'plain_text', 'content': 'Product Team | $(date +%Y-%m-%d)'}]}
+        ]
+    }
+}
+print(json.dumps(card))
+")"
+}
+```
+
+### 4.2 Team Update / Weekly Report
+
+```bash
+curl -s -X POST "${FEISHU_WEBHOOK_URL}" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "msg_type": "interactive",
+    "card": {
+      "header": {
+        "title": {"tag": "plain_text", "content": "Weekly Marketing Report - W03 2025"},
+        "template": "blue"
+      },
+      "elements": [
+        {
+          "tag": "column_set",
+          "flex_mode": "bisect",
+          "columns": [
+            {
+              "tag": "column",
+              "width": "weighted",
+              "weight": 1,
+              "elements": [
+                {"tag": "markdown", "content": "**Traffic**\n\nSessions: **45,230**\nUnique Visitors: **32,100**\nBounce Rate: **42%**"}
+              ]
+            },
+            {
+              "tag": "column",
+              "width": "weighted",
+              "weight": 1,
+              "elements": [
+                {"tag": "markdown", "content": "**Conversions**\n\nSignups: **580**\nTrials: **120**\nPaid: **34**"}
+              ]
+            }
+          ]
+        },
+        {"tag": "hr"},
+        {
+          "tag": "markdown",
+          "content": "**Top Performing Content:**\n1. \"10 Tips for Better SEO\" - 8,200 views\n2. \"Product Comparison Guide\" - 5,100 views\n3. \"Customer Success Story: Acme Corp\" - 3,800 views\n\n**Action Items:**\n- [ ] Publish Q1 campaign landing page\n- [ ] Review ad spend allocation\n- [ ] Schedule social media posts for next week"
+        },
+        {
+          "tag": "action",
+          "actions": [
+            {
+              "tag": "button",
+              "text": {"tag": "plain_text", "content": "Full Dashboard"},
+              "type": "primary",
+              "url": "https://example.com/dashboard"
+            }
+          ]
+        },
+        {
+          "tag": "note",
+          "elements": [
+            {"tag": "plain_text", "content": "Marketing Team | Auto-generated weekly report"}
+          ]
+        }
+      ]
+    }
+  }'
+```
+
+### 4.3 Event Notification
+
+```bash
+curl -s -X POST "${FEISHU_WEBHOOK_URL}" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "msg_type": "interactive",
+    "card": {
+      "header": {
+        "title": {"tag": "plain_text", "content": "Upcoming Webinar: AI in Marketing"},
+        "template": "purple"
+      },
+      "elements": [
+        {
+          "tag": "markdown",
+          "content": "Join us for an exclusive webinar on leveraging AI for marketing success.\n\n**Date:** Thursday, January 30, 2025\n**Time:** 2:00 PM - 3:30 PM (PST)\n**Speaker:** Jane Smith, VP of Marketing\n**Format:** Live presentation + Q&A\n\n**What you will learn:**\n- How to use AI for content personalization\n- Automating campaign optimization\n- Measuring AI-driven marketing ROI"
+        },
+        {"tag": "hr"},
+        {
+          "tag": "action",
+          "actions": [
+            {
+              "tag": "button",
+              "text": {"tag": "plain_text", "content": "Register Now"},
+              "type": "primary",
+              "url": "https://example.com/webinar/register"
+            },
+            {
+              "tag": "button",
+              "text": {"tag": "plain_text", "content": "Add to Calendar"},
+              "type": "default",
+              "url": "https://example.com/webinar/calendar"
+            }
+          ]
+        },
+        {
+          "tag": "note",
+          "elements": [
+            {"tag": "plain_text", "content": "Limited to 200 seats | Free for all team members"}
+          ]
+        }
+      ]
+    }
+  }'
+```
+
+### 4.4 Marketing Campaign Alert
+
+```bash
+curl -s -X POST "${FEISHU_WEBHOOK_URL}" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "msg_type": "interactive",
+    "card": {
+      "header": {
+        "title": {"tag": "plain_text", "content": "Campaign Alert: Budget Threshold Reached"},
+        "template": "orange"
+      },
+      "elements": [
+        {
+          "tag": "markdown",
+          "content": "**Google Ads - Q1 Brand Campaign** has reached **80%** of its monthly budget.\n\n| Metric | Value |\n|--------|-------|\n| Budget | $10,000 |\n| Spent | $8,042 |\n| Remaining | $1,958 |\n| Days Left | 8 |\n| Projected Overspend | $2,100 |\n\n**Recommendation:** Reduce daily bid cap by 15% or pause low-performing ad groups."
+        },
+        {
+          "tag": "action",
+          "actions": [
+            {
+              "tag": "button",
+              "text": {"tag": "plain_text", "content": "Adjust Budget"},
+              "type": "danger",
+              "url": "https://ads.google.com/campaigns"
+            },
+            {
+              "tag": "button",
+              "text": {"tag": "plain_text", "content": "View Campaign"},
+              "type": "default",
+              "url": "https://example.com/campaigns/q1-brand"
+            }
+          ]
+        }
+      ]
+    }
+  }'
+```
+
+---
+
+## 5. Helper: Build and Send Cards Programmatically
+
+For complex or dynamic cards, use Python to construct the JSON payload:
+
+```bash
+python3 -c "
+import json, subprocess, os
+
+webhook_url = os.environ.get('FEISHU_WEBHOOK_URL', '')
+if not webhook_url:
+    print('Error: FEISHU_WEBHOOK_URL not set')
+    exit(1)
+
+# Build card dynamically
+card = {
+    'msg_type': 'interactive',
+    'card': {
+        'header': {
+            'title': {'tag': 'plain_text', 'content': 'Dynamic Card Title'},
+            'template': 'blue'
+        },
+        'elements': []
+    }
+}
+
+# Add content blocks
+card['card']['elements'].append({
+    'tag': 'markdown',
+    'content': 'This card was built programmatically.\n\n**Key metrics:**\n- Users: 10,000\n- Revenue: \$50,000'
+})
+
+# Add a divider
+card['card']['elements'].append({'tag': 'hr'})
+
+# Add buttons
+card['card']['elements'].append({
+    'tag': 'action',
+    'actions': [
+        {
+            'tag': 'button',
+            'text': {'tag': 'plain_text', 'content': 'Learn More'},
+            'type': 'primary',
+            'url': 'https://example.com'
+        }
+    ]
+})
+
+# Add footer
+card['card']['elements'].append({
+    'tag': 'note',
+    'elements': [{'tag': 'plain_text', 'content': 'Sent via OpenClaudia'}]
+})
+
+payload = json.dumps(card)
+result = subprocess.run(
+    ['curl', '-s', '-X', 'POST', webhook_url,
+     '-H', 'Content-Type: application/json',
+     '-d', payload],
+    capture_output=True, text=True
+)
+print(result.stdout)
+"
+```
+
+---
+
+## 6. Bilingual Support (Chinese + English)
+
+When sending messages that need both Chinese and English content, use the rich text `post` format which supports multiple locales. Feishu will display the locale matching the user's language setting.
+
+```bash
+curl -s -X POST "${FEISHU_WEBHOOK_URL}" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "msg_type": "post",
+    "content": {
+      "post": {
+        "zh_cn": {
+          "title": "重要通知：系统维护",
+          "content": [
+            [
+              {"tag": "text", "text": "我们将于 "},
+              {"tag": "text", "text": "1月25日 22:00-02:00 (北京时间)", "un_escape": true},
+              {"tag": "text", "text": " 进行系统维护。"}
+            ],
+            [
+              {"tag": "text", "text": "维护期间服务将暂时不可用。如有问题请联系 "},
+              {"tag": "a", "text": "技术支持", "href": "https://example.com/support"},
+              {"tag": "text", "text": "。"}
+            ]
+          ]
+        },
+        "en_us": {
+          "title": "Important: Scheduled Maintenance",
+          "content": [
+            [
+              {"tag": "text", "text": "We will perform scheduled maintenance on "},
+              {"tag": "text", "text": "January 25, 10:00 PM - 2:00 AM (CST)"},
+              {"tag": "text", "text": "."}
+            ],
+            [
+              {"tag": "text", "text": "Services will be temporarily unavailable. For questions, contact "},
+              {"tag": "a", "text": "Support", "href": "https://example.com/support"},
+              {"tag": "text", "text": "."}
+            ]
+          ]
+        }
+      }
+    }
+  }'
+```
+
+---
+
+## 7. Error Handling
+
+### Webhook Response Codes
+
+| Code | StatusMessage | Meaning |
+|------|---------------|---------|
+| 0 | `"success"` | Message sent successfully |
+| 9499 | `"Bad Request"` | Malformed JSON or missing required fields |
+| 19001 | `"param invalid"` | Invalid msg_type or content format |
+| 19002 | `"sign match fail"` | Signature verification failed (check timestamp and secret) |
+| 19021 | `"request too fast"` | Rate limit: max 100 messages per minute per webhook |
+| 19024 | `"bot not in chat"` | Bot has been removed from the group |
+
+### Common Troubleshooting
+
+**Message not delivered:**
+- Verify the webhook URL is correct and the bot is still in the group
+- Check that `msg_type` matches the content structure
+- For signed webhooks, ensure the timestamp is within 1 hour of current time
+
+**Card not rendering:**
+- Validate JSON structure: header and elements are both required
+- Button URLs must start with `http://` or `https://`
+- Markdown in cards supports a limited subset: bold, italic, links, lists, tables
+
+**API token errors:**
+- Tenant access tokens expire after 2 hours; re-fetch before sending
+- Ensure the app has been published and approved in the developer console
+- Verify `im:message:send_as_bot` permission is granted
+
+### Rate Limits
+
+| Integration | Limit |
+|-------------|-------|
+| Custom Bot Webhook | 100 messages/minute per webhook |
+| App Bot API (messages) | 50 messages/second per app |
+| App Bot API (token refresh) | 500 requests/hour |
+
+---
+
+## 8. Workflow: Post Marketing Content to Feishu/Lark
+
+When the user asks to send marketing content to Feishu or Lark, follow this workflow:
+
+### Step 1: Check Credentials
+
+Verify that `FEISHU_WEBHOOK_URL` or `FEISHU_APP_ID` + `FEISHU_APP_SECRET` are set. If not, guide the user through setup.
+
+### Step 2: Determine Message Type
+
+| User Intent | Recommended Format |
+|-------------|-------------------|
+| Quick text update | Plain text (`msg_type: text`) |
+| Formatted announcement | Rich text (`msg_type: post`) |
+| Marketing report with metrics | Interactive card with columns |
+| Product launch | Interactive card with buttons |
+| Event notification | Interactive card with CTA buttons |
+| Alert or warning | Interactive card with `red`/`orange` header |
+
+### Step 3: Compose the Message
+
+- Use the appropriate template from section 4
+- Adapt content to the user's requirements
+- For bilingual groups, provide both `zh_cn` and `en_us` content
+
+### Step 4: Preview and Confirm
+
+Show the user the full JSON payload before sending. Explain what the message will look like.
+
+**Never auto-send without explicit user confirmation.**
+
+### Step 5: Send
+
+Execute the curl command and report the response.
+
+### Step 6: Verify
+
+Check the response code. If `code: 0`, the message was delivered. If there is an error, troubleshoot using the error table above.
+
+---
+
+## 9. Advanced: Message Card JSON Schema Quick Reference
+
+```
+{
+  "msg_type": "interactive",
+  "card": {
+    "header": {                          // Required
+      "title": {
+        "tag": "plain_text",
+        "content": "string"
+      },
+      "template": "blue|green|red|..."   // Header color
+    },
+    "elements": [                        // Required, array of blocks
+      {"tag": "markdown", "content": "..."}, // Rich content
+      {"tag": "hr"},                         // Divider line
+      {"tag": "img", "img_key": "...", "alt": {...}}, // Image
+      {                                      // Multi-column layout
+        "tag": "column_set",
+        "flex_mode": "bisect|trisect|...",
+        "columns": [
+          {"tag": "column", "width": "weighted", "weight": 1, "elements": [...]}
+        ]
+      },
+      {                                      // Action buttons
+        "tag": "action",
+        "actions": [
+          {"tag": "button", "text": {...}, "type": "primary|danger|default", "url": "..."}
+        ]
+      },
+      {                                      // Footer note
+        "tag": "note",
+        "elements": [{"tag": "plain_text", "content": "..."}]
+      }
+    ]
+  }
+}
+```
+
+---
+
+## Tips
+
+- **Start with webhooks.** Custom Bot Webhooks require zero code infrastructure and can be set up in under a minute.
+- **Use interactive cards** for anything beyond simple text. They are more readable and actionable.
+- **Include action buttons** in every marketing card. Drive recipients to a landing page, dashboard, or sign-up form.
+- **Leverage bilingual support** if your team uses both Feishu and Lark, or has members in China and internationally.
+- **Respect rate limits.** For bulk messaging (e.g., sending to multiple groups), add a 1-second delay between requests.
+- **Test in a private group first** before sending to large team channels.
+- **Keep card content concise.** Cards have a maximum content size of approximately 30KB. For very long reports, link to an external page.
+- **Use the Feishu Message Card Builder** for visual card design: [https://open.feishu.cn/tool/cardbuilder](https://open.feishu.cn/tool/cardbuilder) (Feishu) or [https://open.larksuite.com/tool/cardbuilder](https://open.larksuite.com/tool/cardbuilder) (Lark).

--- a/.claude/skills/geo-query-finder/SKILL.md
+++ b/.claude/skills/geo-query-finder/SKILL.md
@@ -1,0 +1,156 @@
+---
+name: geo-query-finder
+description: >
+  Find which ChatGPT search queries mention a given brand. Tests long-tail
+  queries against ChatGPT's web-search-enabled model and reports which ones
+  surface the brand. Use when the user asks to "find queries for [brand]",
+  "check GEO visibility", "which queries mention [brand]", "geo query finder",
+  "find AI mentions", or "test ChatGPT queries for [brand]".
+---
+
+# GEO Query Finder
+
+Find which ChatGPT search queries mention a given brand. Tests long-tail queries against ChatGPT's web-search-enabled model and reports which ones surface the brand.
+
+## Trigger
+
+Use when the user asks to "find queries for [brand]", "check GEO visibility", "which queries mention [brand]", "geo query finder", "find AI mentions", or "test ChatGPT queries for [brand]".
+
+## Usage
+
+```
+/geo-query-finder <brand_name> [--industry <industry>] [--features <feature1,feature2,...>] [--queries <custom_query1;custom_query2;...>]
+```
+
+**Examples:**
+- `/geo-query-finder "Acme Corp"` — auto-researches the brand and generates queries
+- `/geo-query-finder "Acme Corp" --industry "smart TV OS" --features "white-label,voice-control,OEM licensing"`
+- `/geo-query-finder "Acme Corp" --queries "best regulatory AI;eCTD validation tool;pharma compliance software"`
+
+## How It Works
+
+### Step 0: Pull pre-indexed LLM mentions (DataForSEO) — do this FIRST
+
+Before generating speculative queries, check if DataForSEO already has indexed mentions for the brand's domain. If it does, you get ground-truth queries with search volume in one call instead of burning OpenAI dollars guessing.
+
+Auth via `DATAFORSEO_LOGIN` / `DATAFORSEO_PASSWORD` environment variables.
+
+```bash
+AUTH=$(printf '%s' "$DATAFORSEO_LOGIN:$DATAFORSEO_PASSWORD" | base64)
+# Google AI Overview citations
+curl -s -X POST "https://api.dataforseo.com/v3/ai_optimization/llm_mentions/search/live" \
+  -H "Authorization: Basic $AUTH" -H "Content-Type: application/json" \
+  -d '[{"target":[{"domain":"<DOMAIN>","search_filter":"include","include_subdomains":true}],"platform":"google","limit":700}]'
+# ChatGPT citations (substitute "platform":"chat_gpt")
+```
+
+**Critical flags:**
+- `"include_subdomains": true` — without it, apex domains return 0 results (www.X treated as a different domain).
+- Omit `location_code` to get global results; add `"location_code": 2840` only to scope to US.
+- `platform` options: `"google"` (AI Overview), `"chat_gpt"`. Perplexity is NOT supported via this dataset.
+
+**Extract from each `items[]`:**
+- `question` — the real search query where the brand was cited
+- `ai_search_volume` — monthly AI search volume (use to prioritize)
+- `sources[]` — entries with `domain` matching the brand have the exact cited URL
+- `location_code`, `language_code`, `model_name` — for geo/locale breakdown
+- `answer` — the LLM answer text (for context)
+
+**Decision rule:**
+- If ≥20 queries returned → skip Steps 1–4 entirely; report these as ground-truth mentions and focus Step 5 on gap analysis (sort by volume, find URL-section winners like `/guides/` vs `/tools/`).
+- If <20 queries → use them as seed input for Step 2 (generate variations of the query themes DataForSEO already confirmed), then run Steps 3–4 only on the gaps.
+- If 0 queries → the domain has no AI citations; proceed with the original Steps 1–5 (speculative testing) as fallback.
+
+### Step 1: Research the Brand
+If no `--industry` or `--features` provided, use web search to understand:
+- What the brand does / what industry it's in
+- Key differentiators vs competitors
+- Unique features that competitors DON'T have
+
+### Step 2: Generate Long-Tail Queries
+Generate 15-20 long-tail queries across these categories:
+1. **Feature-specific** (unique capabilities only this brand has)
+2. **B2B/decision-maker** (queries from buyers, not consumers)
+3. **Problem-solving** ("how to X without Y")
+4. **Comparison/alternative** ("alternative to [dominant player]")
+5. **Use-case specific** (niche scenarios where the brand excels)
+
+Avoid generic queries where dominant players will always win.
+
+### Step 3: Query ChatGPT via OpenAI Search API
+
+Use OpenAI's `gpt-4o-search-preview` model with web search enabled:
+
+```bash
+OPENAI_API_KEY from environment variable
+```
+
+```python
+import json, os, urllib.request, ssl
+
+OPENAI_API_KEY = os.environ["OPENAI_API_KEY"]
+
+data = json.dumps({
+    "model": "gpt-4o-search-preview",
+    "web_search_options": {"search_context_size": "medium"},
+    "messages": [{"role": "user", "content": "<query>"}],
+    "max_tokens": 1000
+}).encode()
+
+req = urllib.request.Request(
+    "https://api.openai.com/v1/chat/completions",
+    data=data,
+    headers={
+        "Authorization": f"Bearer {OPENAI_API_KEY}",
+        "Content-Type": "application/json"
+    }
+)
+
+resp = urllib.request.urlopen(req, context=ssl.create_default_context(), timeout=45)
+result = json.loads(resp.read())
+answer = result["choices"][0]["message"]["content"]
+```
+
+### Step 4: Check Mentions
+
+For each query, check if the brand name (or known aliases) appears in ChatGPT's response:
+- Check case-insensitive match
+- Check variations (with/without spaces, dots, hyphens)
+- If mentioned, extract the surrounding context (200 chars around the mention)
+- Note the position (is it #1 recommended? listed among many? mentioned in passing?)
+
+### Step 5: Report Results
+
+Output a summary table:
+
+```
+## GEO Query Finder Results: [Brand Name]
+
+### Mentioned (X/N queries)
+| Query | Position | Context |
+|-------|----------|---------|
+| ... | #1 | "Brand is the leading..." |
+
+### Not Mentioned (Y/N queries)
+| Query | What ChatGPT Recommended Instead |
+|-------|----------------------------------|
+| ... | Competitor A, Competitor B |
+
+### Recommendations
+- Queries where brand is ALREADY mentioned: create more authoritative content to maintain/improve position
+- Queries where brand is NOT mentioned but SHOULD be: these are content gaps — create targeted pages
+- Queries to AVOID: too generic, dominated by big players, not worth the effort
+```
+
+## Rate Limiting
+
+- Run queries sequentially with 1-2 second delays to avoid rate limits
+- Each query costs ~$0.01 via OpenAI API
+- Default: 15-20 queries per run (~$0.15-0.20 per run)
+
+## Notes
+
+- Results reflect ChatGPT with web search enabled (grounded in real-time web results)
+- Results may vary slightly between runs due to search freshness
+- This tests ChatGPT specifically — Gemini and Copilot may give different results
+- For ongoing monitoring, consider scheduling periodic runs to track visibility changes over time

--- a/.claude/skills/github-stars/SKILL.md
+++ b/.claude/skills/github-stars/SKILL.md
@@ -1,0 +1,71 @@
+---
+name: github-stars
+description: Show a GitHub repo's star growth as CLI charts — by day and by hour, in any timezone. Use when the user asks to "check GitHub stars", "stars by hour/day for <repo>", "star growth", "how many stars did <repo> get today", or shares a repo name and wants its starring activity over time.
+---
+
+# github-stars
+
+Fetch a repo's per-star timestamps from the GitHub API and render two ASCII charts in the terminal: **stars by day** and **stars by hour** (for the most recent day(s)). Useful for tracking a launch, a Show HN / Product Hunt spike, or DevRel growth.
+
+## Requirements
+
+- The [`gh` CLI](https://cli.github.com/) installed and authenticated (`gh auth status`). Unauthenticated calls hit a low rate limit and large repos fail mid-pagination.
+- Python 3.9+ (uses the stdlib `zoneinfo` for correct DST handling).
+
+## How it works
+
+The script calls `gh api` with the `application/vnd.github.star+json` Accept header, which adds a `starred_at` timestamp to each stargazer. It paginates through all stargazers, converts each timestamp to the target timezone, and buckets them by day and by hour.
+
+## Usage
+
+The script lives next to this file. From the skill directory:
+
+```bash
+bash github-stars.sh <owner/repo | search-term> [--tz <IANA tz>] [--days N] [--hours-days N]
+```
+
+- **`<owner/repo>`** — exact repo (e.g. `facebook/react`). Skips the search.
+- **`<search-term>`** — a bare word (no `/`) is resolved to the top repo by stars.
+- **`--tz`** — IANA timezone for all buckets. Default `America/Los_Angeles`. Use e.g. `UTC`, `America/New_York`, `Asia/Shanghai`, `Europe/Berlin`.
+- **`--days N`** — how many recent days to show in the daily chart (default 14).
+- **`--hours-days N`** — how many recent days to break out hourly (default 2).
+
+## Examples
+
+```bash
+# default: last 14 days daily + last 2 days hourly
+bash github-stars.sh vercel/next.js
+
+# resolve a search term, show UTC
+bash github-stars.sh next.js --tz UTC
+
+# zoom in: only today hourly, 7-day daily window
+bash github-stars.sh facebook/react --days 7 --hours-days 1
+```
+
+## Sample output
+
+```
+owner/repo — 284 stars (with timestamps)
+newest: 2026-06-15 02:03 PM PDT   |   now: 2026-06-15 02:11 PM PDT
+
+STARS BY DAY (PDT)
+  2026-06-13    16  █████████
+  2026-06-14    69  ████████████████████████████████████████  ← peak
+  2026-06-15    22  █████████████
+
+STARS BY HOUR — 2026-06-15 (PDT)   total 22
+  06:00     5  ██████████████████████████████
+  07:00     2  ████████████
+  14:00     2  ████████████
+```
+
+## Caveats — surface these to the user when relevant
+
+- **40,000-star cap:** GitHub only returns `starred_at` for the first 40k stargazers. Past that, the hourly/daily breakdown is incomplete (the script warns). The plain total stays accurate.
+- **Net, not gross:** the stargazer list reflects stars currently in place. Un-stars don't appear, so a flat total between two checks can hide +1/−1 churn. If the live `stargazers_count` disagrees with the timestamp count, an un-star happened.
+- **DST is handled** automatically via `zoneinfo` — don't hardcode UTC offsets.
+
+## Re-checking / live polling
+
+Just run the script again — it re-fetches live each time. To watch a launch, re-run on an interval and report the delta; don't poll faster than every ~15 minutes (rate limits + politeness).

--- a/.claude/skills/github-stars/github-stars.sh
+++ b/.claude/skills/github-stars/github-stars.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+# github-stars.sh — fetch a repo's stargazer timestamps and render
+# by-day + by-hour star charts in the CLI.
+#
+# Usage:
+#   github-stars.sh <owner/repo | search-term> [--tz <IANA tz>] [--days N] [--hours-days N]
+#
+# Examples:
+#   github-stars.sh melandlabs/openloomi
+#   github-stars.sh openloomi --tz America/Los_Angeles --days 14 --hours-days 2
+#
+# Notes:
+#   - Needs `gh` authenticated (gh auth status).
+#   - GitHub only returns starred_at for the first 40,000 stargazers (API cap).
+#   - Default timezone is America/Los_Angeles (PT). Pass --tz for another.
+set -euo pipefail
+
+REPO=""; TZ_ARG="America/Los_Angeles"; DAYS=14; HOURS_DAYS=2
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --tz) TZ_ARG="$2"; shift 2;;
+    --days) DAYS="$2"; shift 2;;
+    --hours-days) HOURS_DAYS="$2"; shift 2;;
+    *) REPO="$1"; shift;;
+  esac
+done
+
+if [[ -z "$REPO" ]]; then
+  echo "usage: github-stars.sh <owner/repo | search-term> [--tz TZ] [--days N] [--hours-days N]" >&2
+  exit 1
+fi
+
+# Resolve a search term to a full owner/repo (top result by stars).
+if [[ "$REPO" != */* ]]; then
+  echo "Searching GitHub for '$REPO'..." >&2
+  RESOLVED=$(gh api "search/repositories?q=$REPO&sort=stars&order=desc" \
+    --jq '.items[0].full_name' 2>/dev/null || true)
+  if [[ -z "$RESOLVED" || "$RESOLVED" == "null" ]]; then
+    echo "No repo found for '$REPO'." >&2; exit 1
+  fi
+  echo "Resolved to: $RESOLVED" >&2
+  REPO="$RESOLVED"
+fi
+
+CNT=$(gh api "repos/$REPO" --jq '.stargazers_count')
+echo "Repo: $REPO   total stars: $CNT" >&2
+PAGES=$(( (CNT + 99) / 100 ))
+if (( CNT > 40000 )); then
+  echo "WARNING: $CNT stars exceeds the 40,000 timestamp cap; only the earliest 40k have starred_at." >&2
+  PAGES=400
+fi
+
+TMP=$(mktemp)
+trap 'rm -f "$TMP"' EXIT
+echo "Fetching $PAGES page(s) of stargazer timestamps..." >&2
+for p in $(seq 1 "$PAGES"); do
+  gh api -H "Accept: application/vnd.github.star+json" \
+    "repos/$REPO/stargazers?per_page=100&page=$p" --jq '.[].starred_at'
+done > "$TMP"
+
+REPO="$REPO" TZ_NAME="$TZ_ARG" DAYS="$DAYS" HOURS_DAYS="$HOURS_DAYS" python3 - "$TMP" << 'PYEOF'
+import os, sys
+from datetime import datetime, timezone
+from collections import Counter
+from zoneinfo import ZoneInfo
+
+tz = ZoneInfo(os.environ["TZ_NAME"])
+days_n = int(os.environ["DAYS"]); hours_days = int(os.environ["HOURS_DAYS"])
+rows = [l.strip() for l in open(sys.argv[1]) if l.strip()]
+dts = sorted(datetime.strptime(r, "%Y-%m-%dT%H:%M:%SZ")
+             .replace(tzinfo=timezone.utc).astimezone(tz) for r in rows)
+if not dts:
+    print("No timestamped stars found."); sys.exit(0)
+
+tzabbr = dts[-1].strftime("%Z") or os.environ["TZ_NAME"]
+now = datetime.now(tz)
+print(f"\n{os.environ['REPO']} — {len(dts)} stars (with timestamps)")
+print(f"newest: {dts[-1]:%Y-%m-%d %I:%M %p} {tzabbr}   |   now: {now:%Y-%m-%d %I:%M %p} {tzabbr}\n")
+
+def bar(n, mx, w=40):
+    return "█" * round(n / mx * w) if mx else ""
+
+days = Counter(d.strftime("%Y-%m-%d") for d in dts)
+recent = sorted(days)[-days_n:]
+mx = max(days[d] for d in recent)
+peak = max(recent, key=lambda d: days[d])
+print(f"STARS BY DAY ({tzabbr})")
+for d in recent:
+    tag = "  ← peak" if d == peak else ""
+    print(f"  {d}  {days[d]:>4}  {bar(days[d], mx)}{tag}")
+
+for day in sorted({d.strftime('%Y-%m-%d') for d in dts})[-hours_days:]:
+    hrs = Counter(d.hour for d in dts if d.strftime('%Y-%m-%d') == day)
+    mx = max(hrs.values())
+    print(f"\nSTARS BY HOUR — {day} ({tzabbr})   total {sum(hrs.values())}")
+    for h in range(24):
+        if hrs[h]:
+            print(f"  {h:02d}:00  {hrs[h]:>3}  {bar(hrs[h], mx, 30)}")
+PYEOF

--- a/.claude/skills/google-ads-report/SKILL.md
+++ b/.claude/skills/google-ads-report/SKILL.md
@@ -1,0 +1,305 @@
+---
+name: google-ads-report
+description: >
+  Pull Google Ads performance data and generate reports. Use when asked about
+  ad campaign performance, keyword costs, quality scores, ROAS, conversion
+  tracking, or ad spend analysis. Trigger phrases: "google ads", "adwords",
+  "campaign performance", "ad spend", "quality score", "CPC report",
+  "ROAS", "ad conversion", "keyword performance", "google ads report".
+---
+
+# Google Ads Report
+
+Pull campaign, keyword, and conversion data from the Google Ads API.
+
+## Prerequisites
+
+Requires:
+- `GOOGLE_CLIENT_ID` and `GOOGLE_CLIENT_SECRET` (OAuth)
+- `GOOGLE_ADS_DEVELOPER_TOKEN` (apply at https://ads.google.com/home/tools/manager-accounts/)
+- `GOOGLE_ADS_CUSTOMER_ID` (the account ID, format: `XXX-XXX-XXXX`, passed without dashes)
+- `GOOGLE_ADS_LOGIN_CUSTOMER_ID` (if using a manager account, the manager account ID)
+
+Set in `.env`, `.env.local`, or `~/.claude/.env.global`.
+
+### Getting an Access Token
+
+```bash
+# Same OAuth flow as other Google APIs
+# Scope needed: https://www.googleapis.com/auth/adwords
+
+echo "https://accounts.google.com/o/oauth2/v2/auth?client_id=${GOOGLE_CLIENT_ID}&redirect_uri=urn:ietf:wg:oauth:2.0:oob&scope=https://www.googleapis.com/auth/adwords&response_type=code&access_type=offline"
+
+# Exchange code for tokens
+curl -s -X POST "https://oauth2.googleapis.com/token" \
+  -d "code={AUTH_CODE}" \
+  -d "client_id=${GOOGLE_CLIENT_ID}" \
+  -d "client_secret=${GOOGLE_CLIENT_SECRET}" \
+  -d "redirect_uri=urn:ietf:wg:oauth:2.0:oob" \
+  -d "grant_type=authorization_code"
+```
+
+---
+
+## API Base
+
+Google Ads API uses GAQL (Google Ads Query Language) via REST.
+
+```
+POST https://googleads.googleapis.com/v17/customers/{CUSTOMER_ID}/googleAds:searchStream
+```
+
+Headers:
+```
+Authorization: Bearer {ACCESS_TOKEN}
+developer-token: {DEVELOPER_TOKEN}
+login-customer-id: {LOGIN_CUSTOMER_ID}  # Only if using manager account
+Content-Type: application/json
+```
+
+---
+
+## 1. Campaign Performance Report
+
+Overview of all campaigns with key metrics.
+
+```bash
+curl -s -X POST \
+  "https://googleads.googleapis.com/v17/customers/${GOOGLE_ADS_CUSTOMER_ID}:searchStream" \
+  -H "Authorization: Bearer ${GADS_ACCESS_TOKEN}" \
+  -H "developer-token: ${GOOGLE_ADS_DEVELOPER_TOKEN}" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "query": "SELECT campaign.name, campaign.status, metrics.impressions, metrics.clicks, metrics.ctr, metrics.average_cpc, metrics.cost_micros, metrics.conversions, metrics.cost_per_conversion, metrics.conversions_value FROM campaign WHERE segments.date DURING LAST_30_DAYS AND campaign.status != REMOVED ORDER BY metrics.cost_micros DESC"
+  }'
+```
+
+### Parsing Campaign Data
+
+```bash
+curl -s -X POST "..." | python3 -c "
+import json, sys
+data = json.load(sys.stdin)
+print(f\"{'Campaign':<35} {'Status':<10} {'Impr':>8} {'Clicks':>7} {'CTR':>7} {'Avg CPC':>8} {'Cost':>10} {'Conv':>6} {'CPA':>8}\")
+print('-' * 110)
+for batch in data:
+    for row in batch.get('results', []):
+        c = row.get('campaign', {})
+        m = row.get('metrics', {})
+        cost = int(m.get('costMicros', 0)) / 1_000_000
+        cpc = int(m.get('averageCpc', 0)) / 1_000_000
+        cpa = float(m.get('costPerConversion', 0)) / 1_000_000 if m.get('costPerConversion') else 0
+        print(f\"{c.get('name',''):<35} {c.get('status',''):<10} {int(m.get('impressions',0)):>8} {int(m.get('clicks',0)):>7} {float(m.get('ctr',0))*100:>6.2f}% \${cpc:>7.2f} \${cost:>9.2f} {float(m.get('conversions',0)):>6.1f} \${cpa:>7.2f}\")
+"
+```
+
+### Important: Cost Micros
+
+All cost values in Google Ads API are in **micros** (1/1,000,000 of the currency unit). Divide by 1,000,000 to get the actual amount.
+
+---
+
+## 2. Keyword Performance Report
+
+See how individual keywords perform.
+
+```bash
+curl -s -X POST \
+  "https://googleads.googleapis.com/v17/customers/${GOOGLE_ADS_CUSTOMER_ID}:searchStream" \
+  -H "Authorization: Bearer ${GADS_ACCESS_TOKEN}" \
+  -H "developer-token: ${GOOGLE_ADS_DEVELOPER_TOKEN}" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "query": "SELECT ad_group_criterion.keyword.text, ad_group_criterion.keyword.match_type, ad_group_criterion.quality_info.quality_score, metrics.impressions, metrics.clicks, metrics.ctr, metrics.average_cpc, metrics.cost_micros, metrics.conversions, metrics.conversions_value FROM keyword_view WHERE segments.date DURING LAST_30_DAYS AND ad_group_criterion.status != REMOVED ORDER BY metrics.cost_micros DESC LIMIT 50"
+  }'
+```
+
+### Quality Score Breakdown
+
+```bash
+curl -s -X POST \
+  "https://googleads.googleapis.com/v17/customers/${GOOGLE_ADS_CUSTOMER_ID}:searchStream" \
+  -H "Authorization: Bearer ${GADS_ACCESS_TOKEN}" \
+  -H "developer-token: ${GOOGLE_ADS_DEVELOPER_TOKEN}" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "query": "SELECT ad_group_criterion.keyword.text, ad_group_criterion.quality_info.quality_score, ad_group_criterion.quality_info.creative_quality_score, ad_group_criterion.quality_info.post_click_quality_score, ad_group_criterion.quality_info.search_predicted_ctr, metrics.impressions, metrics.average_cpc FROM keyword_view WHERE ad_group_criterion.quality_info.quality_score IS NOT NULL AND segments.date DURING LAST_30_DAYS ORDER BY ad_group_criterion.quality_info.quality_score ASC LIMIT 50"
+  }'
+```
+
+Quality Score Components:
+- **quality_score**: Overall score (1-10)
+- **creative_quality_score**: Ad relevance (BELOW_AVERAGE, AVERAGE, ABOVE_AVERAGE)
+- **post_click_quality_score**: Landing page experience
+- **search_predicted_ctr**: Expected click-through rate
+
+---
+
+## 3. Ad Group Performance
+
+```bash
+curl -s -X POST \
+  "https://googleads.googleapis.com/v17/customers/${GOOGLE_ADS_CUSTOMER_ID}:searchStream" \
+  -H "Authorization: Bearer ${GADS_ACCESS_TOKEN}" \
+  -H "developer-token: ${GOOGLE_ADS_DEVELOPER_TOKEN}" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "query": "SELECT campaign.name, ad_group.name, ad_group.status, metrics.impressions, metrics.clicks, metrics.ctr, metrics.average_cpc, metrics.cost_micros, metrics.conversions FROM ad_group WHERE segments.date DURING LAST_30_DAYS AND ad_group.status != REMOVED ORDER BY metrics.cost_micros DESC LIMIT 50"
+  }'
+```
+
+---
+
+## 4. Search Terms Report
+
+See what users actually searched for (vs. your keywords).
+
+```bash
+curl -s -X POST \
+  "https://googleads.googleapis.com/v17/customers/${GOOGLE_ADS_CUSTOMER_ID}:searchStream" \
+  -H "Authorization: Bearer ${GADS_ACCESS_TOKEN}" \
+  -H "developer-token: ${GOOGLE_ADS_DEVELOPER_TOKEN}" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "query": "SELECT search_term_view.search_term, segments.keyword.info.text, segments.keyword.info.match_type, metrics.impressions, metrics.clicks, metrics.ctr, metrics.cost_micros, metrics.conversions FROM search_term_view WHERE segments.date DURING LAST_30_DAYS ORDER BY metrics.impressions DESC LIMIT 100"
+  }'
+```
+
+Use this to:
+- Find new keyword opportunities (high-converting search terms)
+- Identify negative keyword candidates (irrelevant terms with spend)
+- Discover match type issues (broad match pulling in junk traffic)
+
+---
+
+## 5. Conversion Tracking
+
+```bash
+curl -s -X POST \
+  "https://googleads.googleapis.com/v17/customers/${GOOGLE_ADS_CUSTOMER_ID}:searchStream" \
+  -H "Authorization: Bearer ${GADS_ACCESS_TOKEN}" \
+  -H "developer-token: ${GOOGLE_ADS_DEVELOPER_TOKEN}" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "query": "SELECT campaign.name, metrics.conversions, metrics.conversions_value, metrics.cost_micros, metrics.conversions_from_interactions_rate, metrics.value_per_conversion FROM campaign WHERE segments.date DURING LAST_30_DAYS AND campaign.status = ENABLED ORDER BY metrics.conversions DESC"
+  }'
+```
+
+### ROAS Calculation
+
+```bash
+# ROAS = conversions_value / (cost_micros / 1_000_000)
+curl -s -X POST "..." | python3 -c "
+import json, sys
+data = json.load(sys.stdin)
+print(f\"{'Campaign':<35} {'Cost':>10} {'Conv Value':>12} {'ROAS':>8}\")
+for batch in data:
+    for row in batch.get('results', []):
+        c = row['campaign']['name']
+        m = row['metrics']
+        cost = int(m.get('costMicros', 0)) / 1_000_000
+        value = float(m.get('conversionsValue', 0))
+        roas = value / cost if cost > 0 else 0
+        print(f\"{c:<35} \${cost:>9.2f} \${value:>11.2f} {roas:>7.2f}x\")
+"
+```
+
+---
+
+## 6. Daily Spend Trend
+
+```bash
+curl -s -X POST \
+  "https://googleads.googleapis.com/v17/customers/${GOOGLE_ADS_CUSTOMER_ID}:searchStream" \
+  -H "Authorization: Bearer ${GADS_ACCESS_TOKEN}" \
+  -H "developer-token: ${GOOGLE_ADS_DEVELOPER_TOKEN}" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "query": "SELECT segments.date, metrics.impressions, metrics.clicks, metrics.cost_micros, metrics.conversions FROM customer WHERE segments.date DURING LAST_30_DAYS ORDER BY segments.date DESC"
+  }'
+```
+
+---
+
+## GAQL Date Ranges
+
+Use these built-in date ranges in GAQL:
+- `TODAY`, `YESTERDAY`
+- `LAST_7_DAYS`, `LAST_14_DAYS`, `LAST_30_DAYS`
+- `THIS_MONTH`, `LAST_MONTH`
+- `THIS_QUARTER`, `LAST_QUARTER`
+- Custom: `segments.date BETWEEN '2024-01-01' AND '2024-03-31'`
+
+---
+
+## Workflow: Monthly Google Ads Report
+
+When asked for a full ads report:
+
+1. **Account Overview**: Total spend, impressions, clicks, conversions, ROAS
+2. **Campaign Performance**: All active campaigns ranked by spend
+3. **Top Keywords**: Top 20 keywords by spend with quality scores
+4. **Search Terms**: Top search terms and negative keyword candidates
+5. **Quality Score Distribution**: How many keywords at each QS level
+6. **Conversion Analysis**: Conversions and ROAS by campaign
+7. **Daily Trend**: Spend and conversion trend over the period
+
+### Report Format
+
+```
+## Google Ads Report: {Account Name}
+### Period: {date range}
+
+### Account Summary
+| Metric | Value | vs Previous |
+|--------|-------|-------------|
+| Total Spend | $X | +Y% |
+| Impressions | X | +Y% |
+| Clicks | X | +Y% |
+| CTR | X% | +Y pp |
+| Avg CPC | $X | +Y% |
+| Conversions | X | +Y% |
+| ROAS | Xx | +Y% |
+
+### Campaign Performance
+| Campaign | Spend | Clicks | Conv | CPA | ROAS |
+|----------|-------|--------|------|-----|------|
+| ...      | ...   | ...    | ...  | ... | ...  |
+
+### Top Keywords (by spend)
+| Keyword | Match | QS | Spend | Clicks | Conv | CPC |
+|---------|-------|-----|-------|--------|------|-----|
+| ...     | ...   | ... | ...   | ...    | ...  | ... |
+
+### Recommendations
+- **Pause**: Keywords with high spend and zero conversions
+- **Increase Bids**: Keywords with high conversion rate but limited budget
+- **Negative Keywords**: Search terms wasting budget
+- **Quality Score Fixes**: Keywords with QS < 5 and actions to improve
+- **Budget Reallocation**: Shift budget from low-ROAS to high-ROAS campaigns
+```
+
+---
+
+## Error Handling
+
+| Error | Cause |
+|-------|-------|
+| `AUTHENTICATION_ERROR` | Invalid or expired access token |
+| `AUTHORIZATION_ERROR` | Developer token issue or account access |
+| `REQUEST_ERROR` | GAQL syntax error |
+| `QUOTA_ERROR` | API quota exceeded |
+
+### Common GAQL Mistakes
+
+- Missing `WHERE segments.date DURING ...` (required for most metric queries)
+- Using `REMOVED` status filter incorrectly
+- Forgetting to handle `costMicros` division by 1,000,000
+- Requesting incompatible resource + segment combinations
+
+## Tips
+
+- Always filter out REMOVED campaigns/ad groups/keywords
+- Use `searchStream` instead of `search` for large result sets (no pagination needed)
+- Cache results when building multi-section reports
+- Quality Score of 0 means "not enough data" -- treat as null

--- a/.claude/skills/google-ads/SKILL.md
+++ b/.claude/skills/google-ads/SKILL.md
@@ -1,0 +1,257 @@
+---
+name: google-ads
+description: Write Google Ads copy and build campaign structures. Use when the user asks to create Google Ads, write ad copy for search or display, set up PPC campaigns, optimize Quality Score, choose bidding strategies, or generate responsive search ads. Trigger phrases include "Google Ads", "PPC", "search ads", "display ads", "Performance Max", "ad copy", "headlines and descriptions", "keyword match types", "ad extensions", "Quality Score".
+---
+
+# Google Ads Copy and Campaign Builder
+
+You are an expert Google Ads strategist and copywriter. When the user asks you to create Google Ads campaigns, write ad copy, or optimize existing ads, follow this comprehensive framework.
+
+## Step 1: Gather Campaign Context
+
+Before writing any ad copy, establish these fundamentals:
+
+- **Product/Service**: What is being advertised?
+- **Target audience**: Who are we reaching?
+- **Primary goal**: Leads, sales, sign-ups, calls, store visits?
+- **Landing page URL**: Where does the ad point?
+- **Budget range**: Daily or monthly spend?
+- **Competitors**: Who else is bidding on these terms?
+- **USPs**: What makes this offer unique?
+
+If the user has not provided these, ask before proceeding.
+
+## Step 2: Keyword Strategy
+
+### Match Types
+
+Structure keywords using all three match types:
+
+| Match Type | Syntax | Use Case |
+|---|---|---|
+| Broad match | `keyword` | Discovery, maximize reach, use with Smart Bidding |
+| Phrase match | `"keyword"` | Moderate control, captures intent variations |
+| Exact match | `[keyword]` | Tight control, highest relevance, best for proven terms |
+
+### Keyword Organization
+
+- Group keywords into tightly themed ad groups (5-15 keywords per group)
+- Each ad group should target a single intent cluster
+- Name ad groups descriptively: `[Product] - [Intent] - [Match Type]`
+
+### Negative Keywords
+
+Always include a negative keyword list. Common categories:
+
+- **Informational blockers**: free, how to, what is, tutorial, guide, DIY, reddit, youtube
+- **Job seekers**: jobs, careers, hiring, salary, internship
+- **Irrelevant modifiers**: cheap (if premium brand), used, broken, complaint
+- **Competitor brand names** (unless running a conquest campaign)
+
+Organize negatives at both campaign and ad group levels.
+
+## Step 3: Search Ad Copy
+
+### Standard Search Ad Format
+
+```
+Headline 1 (max 30 characters): [Primary keyword + value prop]
+Headline 2 (max 30 characters): [Benefit or differentiator]
+Headline 3 (max 30 characters): [CTA or trust signal]
+Description 1 (max 90 characters): [Expand on value prop, include keyword naturally]
+Description 2 (max 90 characters): [Social proof, urgency, or secondary benefit]
+Display URL path 1 (max 15 characters): [Relevant keyword slug]
+Display URL path 2 (max 15 characters): [Offer or category]
+```
+
+### Copy Rules
+
+1. **Include the primary keyword** in Headline 1 whenever possible (improves Quality Score)
+2. **Use numbers and specifics**: "Save 40%" beats "Save Money", "5-Min Setup" beats "Easy Setup"
+3. **Include a clear CTA**: "Get Quote", "Start Free Trial", "Book Demo", "Shop Now"
+4. **Add urgency when truthful**: "Limited Time", "Ends Sunday", "Only 3 Left"
+5. **Front-load value**: Put the most compelling word first in each headline
+6. **Never exceed character limits** -- count every character including spaces
+7. **Use title case** for headlines, sentence case for descriptions
+8. **Avoid exclamation marks in headlines** (Google may disapprove)
+9. **Do not repeat the same phrase** across headlines or descriptions
+
+### Responsive Search Ads (RSA)
+
+Provide exactly:
+- **15 headlines** (max 30 chars each)
+- **4 descriptions** (max 90 chars each)
+
+Pin only when necessary:
+- Pin your brand name headline to Position 1 or 2
+- Pin your strongest CTA headline to Position 2 or 3
+- Leave remaining slots unpinned to let Google optimize
+
+#### RSA Headline Categories (provide at least 2-3 from each):
+
+1. **Keyword headlines**: Include exact target keyword
+2. **Benefit headlines**: What the customer gains
+3. **Feature headlines**: What the product does
+4. **Trust headlines**: Awards, ratings, years in business
+5. **CTA headlines**: Direct action phrases
+6. **Urgency headlines**: Time-sensitive offers
+7. **Price/offer headlines**: Discounts, free trials, pricing
+
+#### RSA Quality Checklist
+
+- [ ] All 15 headlines make sense standalone and in any combination
+- [ ] No two headlines are semantically identical
+- [ ] At least 3 headlines include the primary keyword or close variant
+- [ ] Ad strength indicator target: "Excellent"
+- [ ] Each description is self-contained (not dependent on a specific headline)
+
+## Step 4: Display Ad Copy
+
+For Google Display Network campaigns:
+
+### Image Ad Copy
+
+- **Headline**: Max 30 characters. Bold, attention-grabbing.
+- **Long headline**: Max 90 characters. More descriptive.
+- **Description**: Max 90 characters. Support the headline with a benefit.
+- **Business name**: Max 25 characters.
+- **CTA button**: Choose from Google's options (Learn More, Shop Now, Sign Up, Get Quote, etc.)
+
+### Display Ad Best Practices
+
+- Use simple, direct language (users are not searching, they are browsing)
+- Lead with a pain point or aspiration, not a feature
+- Contrast your CTA button color with the ad background
+- Provide multiple image ratios: 1.91:1 (landscape), 1:1 (square), 4:5 (portrait)
+
+## Step 5: Performance Max Campaigns
+
+Performance Max requires a full asset package:
+
+### Asset Requirements
+
+| Asset | Count | Max Length |
+|---|---|---|
+| Headlines | 5-15 | 30 chars |
+| Long headlines | 1-5 | 90 chars |
+| Descriptions | 2-5 | 90 chars |
+| Images | 3+ | 1200x628, 1200x1200, 960x1200 |
+| Logos | 1+ | 1200x1200, 1200x300 |
+| Videos | 1+ | 10 sec minimum (YouTube) |
+| CTA | 1 | Select from list |
+| Business name | 1 | 25 chars |
+| Sitelinks | 4+ | 25 char headline, 35 char desc x2 |
+
+### Asset Group Strategy
+
+- Create separate asset groups for each product/service line
+- Each asset group should have its own audience signal
+- Use custom segments (keyword-based and URL-based) for targeting
+- Add your first-party data lists as audience signals
+
+## Step 6: Ad Extensions (Assets)
+
+Always recommend and write copy for these extensions:
+
+### Sitelink Extensions
+Provide 4-8 sitelinks:
+```
+Sitelink headline (max 25 chars): [Page name]
+Description line 1 (max 35 chars): [What they'll find]
+Description line 2 (max 35 chars): [Benefit of visiting]
+Final URL: [Specific page URL]
+```
+
+### Callout Extensions
+Provide 4-6 callouts (max 25 chars each):
+- Highlight USPs: "Free Shipping Over $50"
+- Trust signals: "4.9 Star Rating"
+- Features: "24/7 Support"
+
+### Structured Snippets
+Choose a header and provide 3+ values:
+- Types: Brands, Courses, Destinations, Featured Hotels, Insurance Coverage, Models, Neighborhoods, Service Catalog, Shows, Styles, Types
+
+### Call Extensions
+- Include phone number if the business accepts calls
+- Set call reporting and call schedule
+
+### Price Extensions
+- At least 3 items with price, description, and URL
+- Use the correct price qualifier (from, up to, average)
+
+### Image Extensions
+- Square (1:1) and landscape (1.91:1) images
+- Must be relevant to the ad and landing page
+
+## Step 7: Quality Score Optimization
+
+Quality Score is determined by three factors. Optimize each:
+
+### 1. Expected Click-Through Rate (CTR)
+- Include primary keyword in Headline 1
+- Use strong CTAs that create curiosity or urgency
+- Test multiple RSA variations
+- Aim for CTR above the ad position average (3-5% for search)
+
+### 2. Ad Relevance
+- One theme per ad group
+- Mirror keyword language in ad copy
+- Align ad messaging with search intent
+- Use dynamic keyword insertion sparingly: `{KeyWord:Default Text}`
+
+### 3. Landing Page Experience
+- Landing page headline must match the ad promise
+- Page must load in under 3 seconds
+- Mobile-responsive design is mandatory
+- Clear path to conversion (visible CTA above the fold)
+- Content must be relevant to the keyword and ad
+
+## Step 8: Bidding Strategy Recommendations
+
+| Goal | Recommended Strategy | When to Use |
+|---|---|---|
+| Maximize conversions | Target CPA | Mature campaigns with 30+ conversions/month |
+| Maximize revenue | Target ROAS | E-commerce with accurate conversion values |
+| Grow traffic | Maximize Clicks | New campaigns, brand awareness |
+| Top placement | Target Impression Share | Brand campaigns, competitive defense |
+| Manual control | Enhanced CPC | Low budget, learning phase |
+| Full automation | Maximize Conversions | Sufficient conversion data, flexible CPA |
+
+### Bidding Best Practices
+- Start with Maximize Conversions (no target) for new campaigns
+- Switch to Target CPA after 50+ conversions in 30 days
+- Set Target CPA at 20% above your actual average CPA, then decrease gradually
+- Never change bidding strategy and budget simultaneously
+- Allow 2 weeks of learning after any bidding change
+
+## Output Format
+
+When delivering ad copy, always present it in this structure:
+
+```
+Campaign: [Campaign Name]
+  Ad Group: [Ad Group Name]
+    Keywords: [list with match types]
+    Negative Keywords: [list]
+
+    RSA:
+      Headlines:
+        H1 (pinned to pos 1): "[text]" [XX chars]
+        H2: "[text]" [XX chars]
+        ...
+      Descriptions:
+        D1: "[text]" [XX chars]
+        D2: "[text]" [XX chars]
+        ...
+
+    Extensions:
+      Sitelinks: [list]
+      Callouts: [list]
+      Structured Snippets: [list]
+
+Bidding Recommendation: [strategy + rationale]
+Estimated Daily Budget: [range]
+```
+
+Always count and display character lengths. Flag any line that exceeds its limit. Provide at least 2 ad group variations per campaign. Include rationale for copy choices when the user is learning.

--- a/.claude/skills/google-analytics/SKILL.md
+++ b/.claude/skills/google-analytics/SKILL.md
@@ -1,0 +1,403 @@
+---
+name: google-analytics
+description: >
+  Pull GA4 reports, traffic data, and insights from the Google Analytics Data API.
+  Use when asked about website traffic, user behavior, acquisition channels,
+  conversions, or audience segments. Trigger phrases: "google analytics", "GA4",
+  "traffic report", "analytics data", "user acquisition", "engagement metrics",
+  "conversion tracking", "audience segments", "page views", "sessions".
+---
+
+# Google Analytics (GA4)
+
+Pull reports and insights from GA4 using the Google Analytics Data API.
+
+## Prerequisites
+
+Requires Google OAuth credentials:
+- `GOOGLE_CLIENT_ID`
+- `GOOGLE_CLIENT_SECRET`
+- A valid OAuth access token (refreshed as needed)
+
+Set credentials in `.env`, `.env.local`, or `~/.claude/.env.global`.
+
+### Getting an Access Token
+
+```bash
+# Step 1: Get authorization code (user must visit this URL in browser)
+echo "https://accounts.google.com/o/oauth2/v2/auth?client_id=${GOOGLE_CLIENT_ID}&redirect_uri=urn:ietf:wg:oauth:2.0:oob&scope=https://www.googleapis.com/auth/analytics.readonly&response_type=code&access_type=offline"
+
+# Step 2: Exchange code for tokens
+curl -s -X POST "https://oauth2.googleapis.com/token" \
+  -d "code={AUTH_CODE}" \
+  -d "client_id=${GOOGLE_CLIENT_ID}" \
+  -d "client_secret=${GOOGLE_CLIENT_SECRET}" \
+  -d "redirect_uri=urn:ietf:wg:oauth:2.0:oob" \
+  -d "grant_type=authorization_code"
+
+# Step 3: Refresh an expired token
+curl -s -X POST "https://oauth2.googleapis.com/token" \
+  -d "refresh_token={REFRESH_TOKEN}" \
+  -d "client_id=${GOOGLE_CLIENT_ID}" \
+  -d "client_secret=${GOOGLE_CLIENT_SECRET}" \
+  -d "grant_type=refresh_token"
+```
+
+Store the refresh token securely. The access token expires after 1 hour.
+
+### Finding Your GA4 Property ID
+
+```bash
+curl -s -H "Authorization: Bearer ${GA_ACCESS_TOKEN}" \
+  "https://analyticsadmin.googleapis.com/v1beta/accountSummaries" \
+  | python3 -c "
+import json, sys
+data = json.load(sys.stdin)
+for acct in data.get('accountSummaries', []):
+    for prop in acct.get('propertySummaries', []):
+        print(f\"{prop['property']}  |  {prop.get('displayName','')}  |  Account: {acct.get('displayName','')}\")
+"
+```
+
+The property ID format is `properties/XXXXXXXXX`.
+
+---
+
+## API Base
+
+```
+POST https://analyticsdata.googleapis.com/v1beta/{property_id}:runReport
+```
+
+All report requests use POST with a JSON body. Always include `Authorization: Bearer {ACCESS_TOKEN}`.
+
+---
+
+## 1. Traffic Overview Report
+
+Get sessions, users, page views, and engagement rate over a date range.
+
+### Example curl
+
+```bash
+curl -s -X POST \
+  "https://analyticsdata.googleapis.com/v1beta/properties/{PROPERTY_ID}:runReport" \
+  -H "Authorization: Bearer ${GA_ACCESS_TOKEN}" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "dateRanges": [{"startDate": "30daysAgo", "endDate": "today"}],
+    "metrics": [
+      {"name": "sessions"},
+      {"name": "totalUsers"},
+      {"name": "newUsers"},
+      {"name": "screenPageViews"},
+      {"name": "engagementRate"},
+      {"name": "averageSessionDuration"},
+      {"name": "bounceRate"}
+    ]
+  }'
+```
+
+### Date Range Shortcuts
+
+- `today`, `yesterday`
+- `7daysAgo`, `14daysAgo`, `28daysAgo`, `30daysAgo`, `90daysAgo`
+- Specific dates: `2024-01-01`
+- Compare periods by passing two dateRanges
+
+---
+
+## 2. User Acquisition Report
+
+See where users come from (channels, sources, campaigns).
+
+```bash
+curl -s -X POST \
+  "https://analyticsdata.googleapis.com/v1beta/properties/{PROPERTY_ID}:runReport" \
+  -H "Authorization: Bearer ${GA_ACCESS_TOKEN}" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "dateRanges": [{"startDate": "30daysAgo", "endDate": "today"}],
+    "dimensions": [
+      {"name": "sessionDefaultChannelGroup"}
+    ],
+    "metrics": [
+      {"name": "sessions"},
+      {"name": "totalUsers"},
+      {"name": "engagementRate"},
+      {"name": "conversions"}
+    ],
+    "orderBys": [{"metric": {"metricName": "sessions"}, "desc": true}],
+    "limit": 20
+  }'
+```
+
+### Useful Acquisition Dimensions
+
+| Dimension | Description |
+|-----------|-------------|
+| `sessionDefaultChannelGroup` | Channel grouping (Organic, Paid, Social, etc.) |
+| `sessionSource` | Traffic source (google, facebook, etc.) |
+| `sessionMedium` | Medium (organic, cpc, referral, etc.) |
+| `sessionCampaignName` | UTM campaign name |
+| `firstUserSource` | First-touch attribution source |
+
+---
+
+## 3. Top Pages Report
+
+Find the highest-traffic pages on the site.
+
+```bash
+curl -s -X POST \
+  "https://analyticsdata.googleapis.com/v1beta/properties/{PROPERTY_ID}:runReport" \
+  -H "Authorization: Bearer ${GA_ACCESS_TOKEN}" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "dateRanges": [{"startDate": "30daysAgo", "endDate": "today"}],
+    "dimensions": [
+      {"name": "pagePath"}
+    ],
+    "metrics": [
+      {"name": "screenPageViews"},
+      {"name": "totalUsers"},
+      {"name": "engagementRate"},
+      {"name": "averageSessionDuration"}
+    ],
+    "orderBys": [{"metric": {"metricName": "screenPageViews"}, "desc": true}],
+    "limit": 25
+  }'
+```
+
+---
+
+## 4. Engagement Metrics
+
+Understand how users interact with your content.
+
+```bash
+curl -s -X POST \
+  "https://analyticsdata.googleapis.com/v1beta/properties/{PROPERTY_ID}:runReport" \
+  -H "Authorization: Bearer ${GA_ACCESS_TOKEN}" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "dateRanges": [{"startDate": "30daysAgo", "endDate": "today"}],
+    "dimensions": [
+      {"name": "pagePath"}
+    ],
+    "metrics": [
+      {"name": "engagedSessions"},
+      {"name": "engagementRate"},
+      {"name": "averageSessionDuration"},
+      {"name": "screenPageViewsPerSession"},
+      {"name": "eventCount"}
+    ],
+    "orderBys": [{"metric": {"metricName": "engagedSessions"}, "desc": true}],
+    "limit": 20
+  }'
+```
+
+### Key Engagement Metrics
+
+| Metric | What It Measures |
+|--------|-----------------|
+| `engagementRate` | % of sessions that were engaged (>10s, 2+ pages, or conversion) |
+| `averageSessionDuration` | Mean session length in seconds |
+| `screenPageViewsPerSession` | Pages per session |
+| `bounceRate` | % of sessions with no engagement |
+| `eventCount` | Total events fired |
+
+---
+
+## 5. Conversion Tracking
+
+Report on conversion events (purchases, signups, etc.).
+
+```bash
+curl -s -X POST \
+  "https://analyticsdata.googleapis.com/v1beta/properties/{PROPERTY_ID}:runReport" \
+  -H "Authorization: Bearer ${GA_ACCESS_TOKEN}" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "dateRanges": [{"startDate": "30daysAgo", "endDate": "today"}],
+    "dimensions": [
+      {"name": "eventName"}
+    ],
+    "metrics": [
+      {"name": "eventCount"},
+      {"name": "totalUsers"},
+      {"name": "eventValue"}
+    ],
+    "dimensionFilter": {
+      "filter": {
+        "fieldName": "eventName",
+        "inListFilter": {
+          "values": ["purchase", "sign_up", "generate_lead", "begin_checkout"]
+        }
+      }
+    }
+  }'
+```
+
+### Conversion by Channel
+
+```bash
+curl -s -X POST \
+  "https://analyticsdata.googleapis.com/v1beta/properties/{PROPERTY_ID}:runReport" \
+  -H "Authorization: Bearer ${GA_ACCESS_TOKEN}" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "dateRanges": [{"startDate": "30daysAgo", "endDate": "today"}],
+    "dimensions": [
+      {"name": "sessionDefaultChannelGroup"}
+    ],
+    "metrics": [
+      {"name": "sessions"},
+      {"name": "conversions"},
+      {"name": "totalRevenue"}
+    ],
+    "orderBys": [{"metric": {"metricName": "conversions"}, "desc": true}]
+  }'
+```
+
+---
+
+## 6. Audience Segments
+
+Break down traffic by device, geography, and demographics.
+
+### By Device Category
+
+```bash
+curl -s -X POST \
+  "https://analyticsdata.googleapis.com/v1beta/properties/{PROPERTY_ID}:runReport" \
+  -H "Authorization: Bearer ${GA_ACCESS_TOKEN}" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "dateRanges": [{"startDate": "30daysAgo", "endDate": "today"}],
+    "dimensions": [{"name": "deviceCategory"}],
+    "metrics": [
+      {"name": "sessions"},
+      {"name": "totalUsers"},
+      {"name": "engagementRate"},
+      {"name": "conversions"}
+    ]
+  }'
+```
+
+### By Country
+
+Replace `deviceCategory` with `country` in the dimensions.
+
+### By Landing Page + Source
+
+```bash
+curl -s -X POST \
+  "https://analyticsdata.googleapis.com/v1beta/properties/{PROPERTY_ID}:runReport" \
+  -H "Authorization: Bearer ${GA_ACCESS_TOKEN}" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "dateRanges": [{"startDate": "30daysAgo", "endDate": "today"}],
+    "dimensions": [
+      {"name": "landingPage"},
+      {"name": "sessionSource"}
+    ],
+    "metrics": [
+      {"name": "sessions"},
+      {"name": "engagementRate"},
+      {"name": "conversions"}
+    ],
+    "orderBys": [{"metric": {"metricName": "sessions"}, "desc": true}],
+    "limit": 30
+  }'
+```
+
+---
+
+## 7. Period Comparison
+
+Compare two time periods to identify trends.
+
+```bash
+curl -s -X POST \
+  "https://analyticsdata.googleapis.com/v1beta/properties/{PROPERTY_ID}:runReport" \
+  -H "Authorization: Bearer ${GA_ACCESS_TOKEN}" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "dateRanges": [
+      {"startDate": "30daysAgo", "endDate": "today", "name": "current"},
+      {"startDate": "60daysAgo", "endDate": "31daysAgo", "name": "previous"}
+    ],
+    "metrics": [
+      {"name": "sessions"},
+      {"name": "totalUsers"},
+      {"name": "conversions"},
+      {"name": "engagementRate"}
+    ]
+  }'
+```
+
+---
+
+## Response Parsing
+
+GA4 API returns JSON. Parse with python3 or jq:
+
+```bash
+# Parse report into a table
+curl -s -X POST "..." | python3 -c "
+import json, sys
+data = json.load(sys.stdin)
+headers = [h['name'] for h in data.get('dimensionHeaders',[])] + [m['name'] for m in data.get('metricHeaders',[])]
+print(' | '.join(headers))
+print('-' * (len(headers) * 20))
+for row in data.get('rows', []):
+    dims = [d['value'] for d in row.get('dimensionValues',[])]
+    mets = [m['value'] for m in row.get('metricValues',[])]
+    print(' | '.join(dims + mets))
+"
+```
+
+---
+
+## Workflow: Monthly Analytics Report
+
+When asked for a monthly report:
+
+1. Pull traffic overview (sessions, users, page views) with period comparison
+2. Pull acquisition breakdown by channel
+3. Pull top 20 pages by page views
+4. Pull conversion summary by channel
+5. Pull device and country breakdown
+
+Present as a structured report with tables, trends (up/down arrows), and recommendations:
+
+```
+## Monthly Analytics Report: {Property Name}
+### Period: {date range} vs {previous period}
+
+### Traffic Summary
+| Metric | Current | Previous | Change |
+|--------|---------|----------|--------|
+| Sessions | X | Y | +Z% |
+| ...
+
+### Top Channels
+...
+
+### Top Pages
+...
+
+### Conversion Summary
+...
+
+### Recommendations
+- [Based on data patterns]
+```
+
+## Common Issues
+
+- **403 Forbidden**: User lacks access to the GA4 property
+- **Empty rows**: No data for the requested date range or filters
+- **Quota exceeded**: GA4 API has daily quotas; reduce date ranges or batch requests
+- **Property not found**: Verify the property ID format (`properties/XXXXXXXXX`)

--- a/.claude/skills/google-reviews/SKILL.md
+++ b/.claude/skills/google-reviews/SKILL.md
@@ -1,0 +1,107 @@
+---
+name: google-reviews
+description: Fetch Google review ratings and review counts for businesses via DataForSEO API. Use when the user asks to check Google reviews, get review counts, compare business ratings, audit Google Maps presence, or analyze competitor reviews.
+---
+
+# Google Reviews
+
+Fetch Google Maps ratings, review counts, and rating distributions for any business using the DataForSEO API.
+
+## When to Use This Skill
+
+Use this skill when the user:
+
+- Asks to check Google reviews for a business
+- Wants to compare ratings across multiple businesses
+- Needs Google review counts for a report or analysis
+- Asks about a business's Google Maps presence
+- Wants to audit competitor reviews
+
+## Tool Location
+
+Global tools directory: `~/.agents/tools/`
+
+- Script: `~/.agents/tools/fetch-google-reviews.js`
+- Credentials: `DATAFORSEO_LOGIN` and `DATAFORSEO_PASSWORD` in environment variables
+
+## Usage
+
+### Single Business
+
+```bash
+cd ~/.agents/tools && node fetch-google-reviews.js "Business Name" "City,Province,Country"
+```
+
+Example:
+```bash
+cd ~/.agents/tools && node fetch-google-reviews.js "Trust Auto Sales" "Richmond,British Columbia,Canada"
+```
+
+### Batch Mode
+
+Create a JSON file with an array of businesses, then run:
+
+```bash
+cd ~/.agents/tools && node fetch-google-reviews.js --batch /path/to/businesses.json
+```
+
+JSON file format:
+```json
+[
+  {"keyword": "Business One", "location": "Vancouver,British Columbia,Canada"},
+  {"keyword": "Business Two"}
+]
+```
+
+- `keyword` (required): Business name to search
+- `location` (optional): Defaults to "Richmond,British Columbia,Canada"
+
+## Output
+
+### Single Business (JSON)
+
+```json
+{
+  "keyword": "Trust Auto Sales",
+  "title": "Trust Auto Sales",
+  "rating": 4.2,
+  "reviews": 677,
+  "rating_distribution": {"1": 117, "2": 7, "3": 3, "4": 19, "5": 531},
+  "address": "3691 Number 3 Rd, Richmond, BC V6X 2B8",
+  "category": "Car dealer",
+  "url": "https://trustauto.ca/"
+}
+```
+
+### Batch Mode
+
+Prints a markdown table followed by full JSON:
+
+```
+| Business | Rating | Reviews | Address |
+|----------|--------|---------|---------|
+| Trust Auto Sales | 4.2 | 677 | 3691 Number 3 Rd, Richmond, BC V6X 2B8 |
+```
+
+## Location Format
+
+Use the DataForSEO location format: `City,Province/State,Country`
+
+Examples:
+- `Richmond,British Columbia,Canada`
+- `Vancouver,British Columbia,Canada`
+- `Toronto,Ontario,Canada`
+- `New York,New York,United States`
+
+## API Details
+
+- Uses DataForSEO `business_data/google/my_business_info/live` endpoint
+- Synchronous (returns results immediately)
+- Returns first matching business for the keyword + location
+- Batch mode adds 200ms delay between requests to avoid rate limits
+
+## Important Notes
+
+- If `npm install` hasn't been run yet: `cd ~/.agents/tools && npm install`
+- The script loads credentials from both local `.env` and environment variables
+- DataForSEO charges per API call -- be mindful with large batches

--- a/.claude/skills/growth-strategy/SKILL.md
+++ b/.claude/skills/growth-strategy/SKILL.md
@@ -1,0 +1,241 @@
+---
+name: growth-strategy
+description: Build a growth strategy with frameworks, metrics, and experimentation. Use when the user says "growth strategy", "growth plan", "AARRR", "growth loops", "North Star Metric", "growth model", "activation rate", "retention strategy", "churn reduction", "growth experiments", or asks about overall growth frameworks and metrics for their product.
+---
+
+# Growth Strategy Skill
+
+You are a growth strategist. Build data-driven growth frameworks using pirate metrics, growth loops, and experimentation methodologies.
+
+## North Star Metric
+
+Every growth strategy starts with identifying the one metric that best captures the core value delivered to customers.
+
+**How to find it:**
+1. What action indicates a user is getting value?
+2. Is it measurable and actionable?
+3. Does improving it directly improve revenue?
+
+| Business Type | Example NSM |
+|---------------|-------------|
+| SaaS (B2B) | Weekly active users completing core action |
+| Marketplace | Transactions per week |
+| Social | Daily active users |
+| Content/Media | Total reading time per month |
+| E-commerce | Purchase frequency |
+| Dev tools | API calls per month |
+
+## AARRR Pirate Metrics Framework
+
+```
+Acquisition → Activation → Retention → Revenue → Referral
+    │              │            │           │          │
+    ▼              ▼            ▼           ▼          ▼
+ How do users   Do they     Do they     Do they    Do they
+ find you?      get value   come back?  pay?       tell others?
+               quickly?
+```
+
+### Benchmarks
+
+| Stage | Metric | Good | Great |
+|-------|--------|------|-------|
+| **Acquisition** | Visitor → Signup | 2-5% | 8%+ |
+| **Activation** | Signup → "Aha moment" | 20-40% | 50%+ |
+| **Retention** | Week 1 retention | 25-40% | 50%+ |
+| **Retention** | Month 1 retention | 10-25% | 30%+ |
+| **Revenue** | Free → Paid conversion | 2-5% | 8%+ |
+| **Revenue** | Net revenue retention | 100-110% | 120%+ |
+| **Referral** | Users who refer | 5-10% | 20%+ |
+
+### Diagnosing the Funnel
+
+**Rule:** Fix from right to left. Retention before Acquisition.
+
+```
+If retention is broken → Fix the product before spending on acquisition
+If activation is low → Improve onboarding before optimizing landing pages
+If revenue is low → Fix pricing/packaging before adding features
+```
+
+## Growth Loops
+
+Growth loops > funnels. Funnels are linear; loops compound.
+
+### Types of Growth Loops
+
+**1. Viral Loop (User → Invites → New User)**
+```
+User gets value → Shares/invites → New user signs up → Gets value → Shares...
+```
+- Examples: Dropbox referral, Calendly scheduling links, Notion templates
+- Key metric: Viral coefficient (K) = invites sent × conversion rate
+- K > 1 = exponential growth, K > 0.5 = meaningful viral lift
+
+**2. Content Loop (Content → SEO/Social → New User)**
+```
+User creates content → Content is indexed/shared → New visitor finds it → Signs up → Creates content...
+```
+- Examples: Pinterest pins, Quora answers, GitHub repos
+- Key metric: Organic traffic growth rate
+
+**3. Paid Loop (Revenue → Reinvest → Acquisition)**
+```
+User pays → Revenue funds ads → Ads acquire new user → User pays...
+```
+- Examples: Any SaaS with payback period < 12 months
+- Key metric: LTV:CAC ratio (should be >3:1)
+
+**4. Sales Loop (User → Expansion → More Revenue)**
+```
+User starts small → Gets value → Expands seats/usage → Becomes champion → Enterprise deal...
+```
+- Examples: Slack, Figma, Notion (bottoms-up SaaS)
+- Key metric: Net revenue retention
+
+## Activation Checklist
+
+Getting users to the "aha moment" fast:
+
+1. **Identify the aha moment** — What action correlates with long-term retention?
+2. **Measure time-to-value** — How long from signup to aha moment?
+3. **Remove friction** — Every unnecessary step before aha moment kills conversion
+4. **Add motivation** — Progress bars, checklists, quick wins
+5. **Use empty states wisely** — Show value before the user does anything (sample data, templates)
+
+| Aha Moment Examples | Product |
+|--------------------|---------|
+| Send first message | Slack |
+| Create first design | Figma |
+| Deploy first site | Vercel |
+| First search query result | Algolia |
+| See first dashboard | Analytics tools |
+
+## Retention Framework
+
+### Retention Curves
+
+```
+Good retention: Curve flattens (plateau = retained cohort)
+Bad retention: Curve approaches zero (everyone churns eventually)
+```
+
+**Analysis approach:**
+1. Plot weekly/monthly retention cohorts
+2. Find where the curve flattens (that's your "retained" base)
+3. Focus on getting more users past the flattening point
+
+### Retention Tactics by Stage
+
+| Stage | Window | Focus |
+|-------|--------|-------|
+| **Onboarding** | Day 0-7 | Get to aha moment, set up habits |
+| **Activation** | Week 1-4 | Build workflow dependency, integrate with tools |
+| **Engagement** | Month 1-3 | Deepen usage, introduce advanced features |
+| **Loyalty** | Month 3+ | Community, identity, switching costs |
+
+### Reducing Churn
+
+1. **Identify churn signals** — Declining usage, support tickets, missed payments
+2. **Segment churned users** — Why did they leave? (Survey, interview, data)
+3. **Intervene early** — Automated nudges when churn signals appear
+4. **Win-back campaigns** — Email lapsed users with what's new
+5. **Fix the product** — Most churn is product churn, not marketing churn
+
+## Experimentation (ICE Framework)
+
+Prioritize growth experiments using ICE:
+
+| Factor | Score 1-10 | Definition |
+|--------|-----------|------------|
+| **Impact** | How much will this move the metric? | 1 = barely, 10 = 2x+ |
+| **Confidence** | How sure are we it will work? | 1 = wild guess, 10 = proven |
+| **Ease** | How easy to implement and measure? | 1 = months, 10 = hours |
+
+**ICE Score = (Impact + Confidence + Ease) / 3**
+
+### Experiment Template
+
+```markdown
+## Experiment: {Name}
+
+**Hypothesis:** If we {change}, then {metric} will {improve} because {reason}.
+
+**Metric:** {Primary metric to measure}
+**ICE Score:** Impact: {}/10, Confidence: {}/10, Ease: {}/10 = **{avg}**
+
+**Design:**
+- Control: {Current state}
+- Variant: {Proposed change}
+- Sample size needed: {estimate}
+- Duration: {days/weeks}
+
+**Results:**
+- {Metric}: Control {X} vs. Variant {Y} ({+/-Z%})
+- Statistical significance: {Yes/No, p-value}
+- Decision: {Ship / Iterate / Kill}
+
+**Learnings:** {What did we learn regardless of outcome?}
+```
+
+## Channel Selection Matrix
+
+| Channel | Time to Results | CAC Range | Best For |
+|---------|----------------|-----------|----------|
+| SEO/Content | 3-6 months | $50-200 | Sustained inbound, trust |
+| Paid Search | Immediate | $20-200 | High-intent buyers |
+| Social Ads | 1-2 weeks | $10-100 | Awareness, retargeting |
+| Email | 1-2 weeks | $1-10 | Nurture, retention |
+| Partnerships | 1-3 months | $10-50 | Co-marketing, trust transfer |
+| Community | 3-6 months | $5-20 | Loyalty, word-of-mouth |
+| Product-led | 1-3 months | $0-10 | Viral, bottoms-up |
+| Sales | Immediate | $200-2000 | Enterprise, high ACV |
+
+**Rule of thumb:** Master 1-2 channels before adding more. Most startups spread too thin.
+
+## Output Format
+
+```markdown
+# Growth Strategy: {Product/Company}
+
+## North Star Metric
+{Metric} — {Why this metric}
+
+## Current Funnel Analysis
+
+| Stage | Current | Target | Gap |
+|-------|---------|--------|-----|
+| Acquisition | {%} | {%} | {fix} |
+| Activation | {%} | {%} | {fix} |
+| Retention | {%} | {%} | {fix} |
+| Revenue | {%} | {%} | {fix} |
+| Referral | {%} | {%} | {fix} |
+
+## Primary Growth Loop
+{Description of the main loop to invest in}
+
+## Top 5 Growth Experiments (by ICE Score)
+
+| # | Experiment | Impact | Confidence | Ease | ICE | Stage |
+|---|-----------|--------|------------|------|-----|-------|
+| 1 | {name} | {}/10 | {}/10 | {}/10 | {avg} | {AARRR stage} |
+
+## 90-Day Roadmap
+
+### Month 1: {Theme}
+{Specific actions}
+
+### Month 2: {Theme}
+{Specific actions}
+
+### Month 3: {Theme}
+{Specific actions}
+```
+
+## Important Notes
+
+- Growth strategy without retention is a leaky bucket. Always fix retention first.
+- Metrics without context are meaningless. Always compare to your own trend line AND industry benchmarks.
+- Most growth comes from compounding small wins, not silver bullets.
+- The best growth channel is the one your competitors haven't saturated yet.
+- Talk to churned users. They'll tell you more than any dashboard.

--- a/.claude/skills/hubspot/SKILL.md
+++ b/.claude/skills/hubspot/SKILL.md
@@ -1,0 +1,246 @@
+---
+name: hubspot
+description: Manage HubSpot CRM contacts, companies, deals, and CMS content via API. Use when the user says "add contact to HubSpot", "create deal", "search CRM", "HubSpot contacts", "update deal stage", "CRM report", "HubSpot pages", or asks about managing their sales pipeline, CRM data, or HubSpot content.
+---
+
+# HubSpot CRM & CMS Skill
+
+You are a HubSpot CRM and CMS automation expert. Use the HubSpot API to manage contacts, companies, deals, owners, associations, properties, CMS pages, and files.
+
+## Prerequisites
+
+This skill requires `HUBSPOT_ACCESS_TOKEN` (Private App token). Check for it in environment variables or `~/.claude/.env.global`. If not found, inform the user:
+
+```
+This skill requires a HubSpot Private App access token. Set it via:
+  export HUBSPOT_ACCESS_TOKEN=your_token_here
+Or add it to ~/.claude/.env.global
+
+Create a Private App at: Settings > Integrations > Private Apps
+Required scopes: crm.objects.contacts, crm.objects.companies, crm.objects.deals, content
+```
+
+## API Reference
+
+Base URL: `https://api.hubapi.com`
+Auth header: `Authorization: Bearer ${HUBSPOT_ACCESS_TOKEN}`
+Rate limit: 100 requests per 10 seconds for private apps.
+
+### Contacts
+
+**List contacts:**
+```bash
+curl -s "https://api.hubapi.com/crm/v3/objects/contacts?limit=10&properties=firstname,lastname,email,company,phone" \
+  -H "Authorization: Bearer ${HUBSPOT_ACCESS_TOKEN}"
+```
+
+**Search contacts:**
+```bash
+curl -s -X POST "https://api.hubapi.com/crm/v3/objects/contacts/search" \
+  -H "Authorization: Bearer ${HUBSPOT_ACCESS_TOKEN}" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "filterGroups": [{
+      "filters": [{
+        "propertyName": "email",
+        "operator": "CONTAINS_TOKEN",
+        "value": "example.com"
+      }]
+    }],
+    "properties": ["firstname", "lastname", "email", "company"],
+    "limit": 10
+  }'
+```
+
+**Create contact:**
+```bash
+curl -s -X POST "https://api.hubapi.com/crm/v3/objects/contacts" \
+  -H "Authorization: Bearer ${HUBSPOT_ACCESS_TOKEN}" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "properties": {
+      "firstname": "John",
+      "lastname": "Doe",
+      "email": "john@example.com",
+      "company": "Acme Inc",
+      "phone": "+1234567890"
+    }
+  }'
+```
+
+**Get contact by email:**
+```bash
+curl -s -X POST "https://api.hubapi.com/crm/v3/objects/contacts/search" \
+  -H "Authorization: Bearer ${HUBSPOT_ACCESS_TOKEN}" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "filterGroups": [{
+      "filters": [{
+        "propertyName": "email",
+        "operator": "EQ",
+        "value": "john@example.com"
+      }]
+    }],
+    "properties": ["firstname", "lastname", "email", "company", "phone", "lifecyclestage"]
+  }'
+```
+
+### Companies
+
+**List companies:**
+```bash
+curl -s "https://api.hubapi.com/crm/v3/objects/companies?limit=10&properties=name,domain,industry,numberofemployees" \
+  -H "Authorization: Bearer ${HUBSPOT_ACCESS_TOKEN}"
+```
+
+**Search companies by domain:**
+```bash
+curl -s -X POST "https://api.hubapi.com/crm/v3/objects/companies/search" \
+  -H "Authorization: Bearer ${HUBSPOT_ACCESS_TOKEN}" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "filterGroups": [{
+      "filters": [{
+        "propertyName": "domain",
+        "operator": "EQ",
+        "value": "example.com"
+      }]
+    }],
+    "properties": ["name", "domain", "industry", "numberofemployees", "annualrevenue"]
+  }'
+```
+
+### Deals
+
+**Create deal:**
+```bash
+curl -s -X POST "https://api.hubapi.com/crm/v3/objects/deals" \
+  -H "Authorization: Bearer ${HUBSPOT_ACCESS_TOKEN}" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "properties": {
+      "dealname": "New Enterprise Deal",
+      "dealstage": "appointmentscheduled",
+      "pipeline": "default",
+      "amount": "50000",
+      "closedate": "2026-06-30"
+    }
+  }'
+```
+
+**List deals:**
+```bash
+curl -s "https://api.hubapi.com/crm/v3/objects/deals?limit=10&properties=dealname,dealstage,amount,closedate,pipeline" \
+  -H "Authorization: Bearer ${HUBSPOT_ACCESS_TOKEN}"
+```
+
+**Update deal stage:**
+```bash
+curl -s -X PATCH "https://api.hubapi.com/crm/v3/objects/deals/{dealId}" \
+  -H "Authorization: Bearer ${HUBSPOT_ACCESS_TOKEN}" \
+  -H "Content-Type: application/json" \
+  -d '{"properties": {"dealstage": "closedwon"}}'
+```
+
+### Owners
+
+**List owners (sales reps):**
+```bash
+curl -s "https://api.hubapi.com/crm/v3/owners/" \
+  -H "Authorization: Bearer ${HUBSPOT_ACCESS_TOKEN}"
+```
+
+### Associations
+
+Associate contacts with companies or deals:
+
+```bash
+# Associate deal with contact (type 3)
+curl -s -X PUT "https://api.hubapi.com/crm/v3/objects/deals/{dealId}/associations/contacts/{contactId}/3" \
+  -H "Authorization: Bearer ${HUBSPOT_ACCESS_TOKEN}"
+
+# Associate deal with company (type 5)
+curl -s -X PUT "https://api.hubapi.com/crm/v3/objects/deals/{dealId}/associations/companies/{companyId}/5" \
+  -H "Authorization: Bearer ${HUBSPOT_ACCESS_TOKEN}"
+
+# Associate contact with company (type 1)
+curl -s -X PUT "https://api.hubapi.com/crm/v3/objects/contacts/{contactId}/associations/companies/{companyId}/1" \
+  -H "Authorization: Bearer ${HUBSPOT_ACCESS_TOKEN}"
+```
+
+**Get associated contacts for a deal:**
+```bash
+curl -s "https://api.hubapi.com/crm/v3/objects/deals/{dealId}/associations/contacts" \
+  -H "Authorization: Bearer ${HUBSPOT_ACCESS_TOKEN}"
+```
+
+### Properties
+
+**List all contact properties:**
+```bash
+curl -s "https://api.hubapi.com/crm/v3/properties/contacts" \
+  -H "Authorization: Bearer ${HUBSPOT_ACCESS_TOKEN}"
+```
+
+### CMS Pages
+
+**List site pages:**
+```bash
+curl -s "https://api.hubapi.com/cms/v3/pages/site-pages?limit=10" \
+  -H "Authorization: Bearer ${HUBSPOT_ACCESS_TOKEN}"
+```
+
+**List landing pages:**
+```bash
+curl -s "https://api.hubapi.com/cms/v3/pages/landing-pages?limit=10" \
+  -H "Authorization: Bearer ${HUBSPOT_ACCESS_TOKEN}"
+```
+
+### Search Operators
+
+| Operator | Description |
+|----------|-------------|
+| `EQ` | Equal to |
+| `NEQ` | Not equal to |
+| `LT` / `LTE` | Less than / Less than or equal |
+| `GT` / `GTE` | Greater than / Greater than or equal |
+| `CONTAINS_TOKEN` | Contains word |
+| `NOT_CONTAINS_TOKEN` | Does not contain word |
+| `HAS_PROPERTY` | Property exists |
+| `NOT_HAS_PROPERTY` | Property does not exist |
+
+### Pagination
+
+All list endpoints support pagination via the `after` parameter:
+```bash
+curl -s "https://api.hubapi.com/crm/v3/objects/contacts?limit=100&after={next_cursor}" \
+  -H "Authorization: Bearer ${HUBSPOT_ACCESS_TOKEN}"
+```
+
+The `after` value comes from `paging.next.after` in the response.
+
+## Common Workflows
+
+### Pipeline Report
+1. List all deals with `dealstage`, `amount`, `closedate`
+2. Group by stage
+3. Sum amounts per stage
+4. Present as pipeline summary table
+
+### Contact Enrichment
+1. Search contacts missing key properties (`NOT_HAS_PROPERTY`)
+2. For each, check if company domain exists
+3. Pull company data and update contact
+
+### Deal Health Check
+1. List deals in active stages
+2. Flag deals with no activity in 14+ days
+3. Flag deals past expected close date
+4. Present prioritized action list
+
+## Important Notes
+
+- Always use pagination for large datasets. Default limit is 10, max is 100.
+- HubSpot property names are lowercase with no spaces (e.g., `firstname`, `dealstage`, `closedate`).
+- Deal stages vary by pipeline. List pipeline stages via the Pipelines API if needed.
+- Rate limit: 100 requests per 10 seconds. Batch operations when possible.

--- a/.claude/skills/i18n/SKILL.md
+++ b/.claude/skills/i18n/SKILL.md
@@ -1,0 +1,272 @@
+---
+name: i18n
+description: Add full internationalization (i18n) to a Next.js project using next-intl. Supports 14+ languages, SEO-friendly locale routing, hreflang sitemaps, and bulk translation. Use when the user asks to "internationalize", "add i18n", "add translations", "multi-language", "localize", "add language support", or "translate my site".
+user_invocable: true
+---
+
+# Internationalize a Next.js Project
+
+Add complete internationalization to a Next.js (App Router) project using **next-intl v4**. This skill handles routing, translation files, sitemap hreflang, and bulk translation across all locales.
+
+## Step 1: Assess the Project
+
+1. Check the Next.js version (`package.json`) — must be 13+ with App Router
+2. Check if i18n is already partially set up (look for `next-intl`, `next-i18next`, `[locale]` routes)
+3. Identify all pages/routes that need translation
+4. Identify all user-facing strings (hardcoded text in components)
+5. Ask the user which locales to support (default recommendation: en, es, fr, de, pt, ja, ar, zh, zh-tw, id, vi, ms, ru, hi)
+
+## Step 2: Install Dependencies
+
+```bash
+npm install next-intl
+```
+
+## Step 3: Create i18n Configuration Files
+
+Create 4 files under `src/i18n/`:
+
+### `src/i18n/config.ts`
+```typescript
+export const locales = ['en', 'es', 'fr', 'de', 'pt', 'ja', 'ar', 'zh', 'zh-tw', 'id', 'vi', 'ms', 'ru', 'hi'] as const
+
+export type Locale = (typeof locales)[number]
+export const defaultLocale: Locale = 'en'
+
+export const localeNames: Record<Locale, string> = {
+  en: 'English',
+  es: 'Espanol',
+  fr: 'Francais',
+  de: 'Deutsch',
+  pt: 'Portugues',
+  ja: '日本語',
+  ar: 'العربية',
+  zh: '简体中文',
+  'zh-tw': '繁體中文',
+  id: 'Bahasa Indonesia',
+  vi: 'Tieng Viet',
+  ms: 'Bahasa Melayu',
+  ru: 'Русский',
+  hi: 'हिन्दी',
+}
+
+export const rtlLocales: Locale[] = ['ar']
+```
+
+### `src/i18n/routing.ts`
+```typescript
+import { defineRouting } from 'next-intl/routing'
+import { defaultLocale, locales } from './config'
+
+export const routing = defineRouting({
+  locales,
+  defaultLocale,
+  localePrefix: 'as-needed', // English URLs stay clean, other locales get /es/, /fr/, etc.
+})
+```
+
+### `src/i18n/navigation.ts`
+```typescript
+import { createNavigation } from 'next-intl/navigation'
+import { routing } from './routing'
+
+export const { Link, redirect, usePathname, useRouter } = createNavigation(routing)
+```
+
+### `src/i18n/request.ts`
+```typescript
+import { getRequestConfig } from 'next-intl/server'
+import { routing } from './routing'
+
+export default getRequestConfig(async ({ requestLocale }) => {
+  let locale = await requestLocale
+  if (!locale || !routing.locales.includes(locale as any)) {
+    locale = routing.defaultLocale
+  }
+  return {
+    locale,
+    messages: (await import(`../messages/${locale}.json`)).default,
+  }
+})
+```
+
+## Step 4: Create Middleware
+
+Create `src/middleware.ts`:
+```typescript
+import createMiddleware from 'next-intl/middleware'
+import { routing } from '@/i18n/routing'
+
+export default createMiddleware({
+  ...routing,
+  localeDetection: false, // Don't auto-redirect based on Accept-Language
+})
+
+export const config = {
+  matcher: ['/((?!_next|api|images|fonts|favicon|sitemap|robots).*)'],
+}
+```
+
+**Key decision**: `localeDetection: false` prevents auto-redirecting users based on browser language. This keeps English URLs stable for SEO. Users can manually switch languages via a language selector.
+
+## Step 5: Update next.config
+
+Wrap the existing config with `createNextIntlPlugin`:
+
+```typescript
+import createNextIntlPlugin from 'next-intl/plugin'
+const withNextIntl = createNextIntlPlugin('./src/i18n/request.ts')
+
+// ... existing config ...
+export default withNextIntl(nextConfig)
+```
+
+## Step 6: Add `[locale]` Dynamic Route
+
+Move all page content under `src/app/[locale]/`:
+
+1. Create `src/app/[locale]/layout.tsx` with:
+   - `generateStaticParams()` returning all locales
+   - `setRequestLocale(locale)` call
+   - `<NextIntlClientProvider>` wrapping children
+   - `<html lang={locale} dir={rtlLocales.includes(locale) ? 'rtl' : 'ltr'}>`
+   - Hreflang `<link>` tags in `<head>` for all locales + `x-default`
+
+2. Move existing pages into `src/app/[locale]/`
+3. Each page should call `setRequestLocale(locale)` for static generation
+
+## Step 7: Extract Strings into Translation Files
+
+1. Create `src/messages/en.json` with all user-facing strings organized by section:
+   ```json
+   {
+     "common": { "signIn": "Sign In", ... },
+     "tools": { "tool-slug": { "title": "...", "description": "..." } },
+     "faq": { "tool-slug": [{ "question": "...", "answer": "..." }] }
+   }
+   ```
+
+2. Replace all hardcoded strings in components with `useTranslations()`:
+   ```typescript
+   const t = useTranslations('common')
+   return <button>{t('signIn')}</button>
+   ```
+
+3. For server components, use `getTranslations()`:
+   ```typescript
+   const t = await getTranslations('common')
+   ```
+
+## Step 8: Translate to All Locales
+
+For each non-English locale, create `src/messages/{locale}.json` with the same structure as `en.json`.
+
+### Translation Strategy
+
+Use **parallel Codex agents** via the `codex-tasks` skill to save Claude credits:
+
+1. Launch one Codex task per locale (up to 7 in parallel) using `/codex-tasks`
+2. Each task reads `en.json`, translates all strings, writes `{locale}.json`
+3. Codex prompt should include:
+   - The full `en.json` content (or path to read it)
+   - Target language name and locale code
+   - Instructions:
+     - Translate naturally, not literally
+     - Keep technical terms in English (PowerPoint, PDF, API, etc.)
+     - Preserve JSON structure exactly (same keys, same nesting)
+     - Preserve interpolation variables like `{count}`, `{name}` unchanged
+     - Write the result to `src/messages/{locale}.json`
+4. After Codex tasks complete, **verify the results** using the verification script below — Codex output quality varies and must be checked
+
+### Verification
+
+After translation, run a verification script to catch issues:
+
+```python
+import json
+
+locales = ['es', 'fr', 'de', 'pt', 'ja', 'ar', 'zh', 'zh-tw', 'id', 'vi', 'ms', 'ru', 'hi']
+english_words = ['the ', 'and ', 'you ', 'your ', 'our ', 'this ', 'that ', 'with ', 'from ', 'will ']
+
+with open('src/messages/en.json') as f:
+    en = json.load(f)
+
+for loc in locales:
+    with open(f'src/messages/{loc}.json') as f:
+        data = json.load(f)
+
+    # Check: missing sections
+    missing = [s for s in en if s not in data]
+
+    # Check: residual English content
+    eng_count = 0
+    def check(d):
+        nonlocal eng_count  # won't work in inline script; use list trick
+        if isinstance(d, dict):
+            for v in d.values(): check(v)
+        elif isinstance(d, str):
+            if sum(1 for w in english_words if w in d.lower()) >= 3:
+                eng_count += 1
+    check(data)
+
+    status = 'OK' if not missing and eng_count == 0 else 'ISSUES'
+    print(f'{loc}: {status} (missing={len(missing)}, english={eng_count})')
+```
+
+## Step 9: Update Sitemap with Hreflang
+
+Update `src/app/sitemap.ts` to include hreflang alternates:
+
+```typescript
+import { MetadataRoute } from 'next'
+import { locales } from '@/i18n/config'
+
+const baseUrl = 'https://www.example.com'
+
+function buildAlternates(path: string): Record<string, string> {
+  const alternates: Record<string, string> = {}
+  for (const locale of locales) {
+    const prefix = locale === 'en' ? '' : `/${locale}`
+    alternates[locale] = `${baseUrl}${prefix}${path}`
+  }
+  return alternates
+}
+
+export default function sitemap(): MetadataRoute.Sitemap {
+  return pages.map((path) => ({
+    url: `${baseUrl}${path}`,
+    lastModified: new Date(),
+    alternates: { languages: buildAlternates(path) },
+  }))
+}
+```
+
+**Important**: Generate one canonical URL per page with hreflang alternates, NOT one URL per locale. This prevents duplicate content in search results.
+
+## Step 10: Add Language Selector (Optional)
+
+Add a language switcher component that uses `useRouter` and `usePathname` from `@/i18n/navigation` to switch locales while preserving the current path.
+
+## Step 11: Verify
+
+1. Build the project: `npm run build` — check that all static pages generate correctly
+2. Test English URLs have no prefix: `https://example.com/tools`
+3. Test locale URLs have prefix: `https://example.com/es/tools`
+4. Verify sitemap has hreflang alternates
+5. Check RTL rendering for Arabic
+6. Run the translation verification script from Step 8
+
+## Common Pitfalls
+
+- **`public/sitemap.xml`** conflicts with dynamic `src/app/sitemap.ts` in dev mode — delete the static one or rename it
+- **Middleware matcher** must exclude `_next`, `api`, `sitemap`, `robots`, and static asset paths
+- **`localePrefix: 'as-needed'`** is critical — it keeps default locale URLs clean for SEO continuity
+- **`localeDetection: false`** prevents unwanted redirects that break SEO and confuse users
+- **Large translation files** (5000+ lines per locale) can make git pushes fail — use `git config http.postBuffer 524288000`
+- **Verify translations thoroughly** — automated translation often produces mixed-language output; always verify with the English word detection script after Codex tasks complete
+
+## Locale Count Reference
+
+- 14 locales x N pages = 14N static pages at build time
+- Each locale JSON file is typically 2-5x the size of en.json (CJK characters, verbose languages)
+- Build time increases linearly with locale count

--- a/.claude/skills/icp-builder/SKILL.md
+++ b/.claude/skills/icp-builder/SKILL.md
@@ -1,0 +1,222 @@
+---
+name: icp-builder
+description: Define ideal customer profiles and buyer personas with structured frameworks. Use when the user asks about ideal customer profile, ICP, buyer persona, target audience definition, customer segmentation, customer research, user interviews, or persona creation. Trigger phrases include "ideal customer profile", "ICP", "buyer persona", "who is my customer", "target audience", "customer profile", "persona", "customer segmentation", "user research", "customer interview", "who should I target".
+---
+
+# Ideal Customer Profile (ICP) Builder
+
+You are an expert in customer research and persona development. When the user asks you to define their ideal customer, build personas, or segment their audience, follow this framework.
+
+## Step 1: Gather Context
+
+Establish: product/service, problem solved, current customers (if any), market type (B2B/B2C), price point, sales motion (self-serve/sales-assisted/enterprise), stage (pre-launch/early/growth), existing data (analytics, CRM, surveys), geography.
+
+## Step 2: ICP Framework
+
+### B2B ICP (Company-Level)
+
+```
+FIRMOGRAPHICS
+  Industry: [specific verticals]
+  Size (employees): [range] | Size (revenue): [range]
+  Growth Stage: [startup/scaleup/enterprise/public]
+  Geography: [regions] | Business Model: [SaaS/e-comm/agency/etc.]
+
+TECHNOGRAPHICS
+  Tech Stack: [tools they use] | Current Solution: [for this problem]
+  Technical Maturity: [early adopter/mainstream/laggard]
+
+SITUATIONAL TRIGGERS (events creating buy urgency)
+  - [e.g., "Just raised funding", "Grew past 50 employees"]
+  - [e.g., "Current contract ending", "New VP hired"]
+
+QUALIFYING CRITERIA
+  Must-Have: [e.g., "Marketing team of 3+", "Spends $10K+/mo on ads"]
+  Nice-to-Have: [e.g., "Active on social media"]
+  Disqualifying: [e.g., "Pre-revenue", "Fewer than 10 employees"]
+```
+
+### B2C ICP (Individual-Level)
+
+```
+DEMOGRAPHICS
+  Age: [range] | Income: [bracket] | Location: [region]
+  Life Stage: [student/early career/parent/retiree]
+
+PSYCHOGRAPHICS
+  Values: [what they care about deeply]
+  Identity: [how they see themselves]
+  Aspirations: [what they're working toward]
+  Influences: [who shapes their decisions]
+
+BEHAVIORAL TRAITS
+  Platforms: [social, search, forums]
+  Content: [podcasts, newsletters, YouTube]
+  Purchase behavior: [impulse vs. research-heavy]
+  Brand loyalty: [switches easily vs. sticky]
+```
+
+## Step 3: Pain Points and Goals
+
+### Pain Point Structure
+
+```
+Pain Point: [Specific problem]
+  Severity: [1-10] | Frequency: [daily/weekly/monthly]
+  Current workaround: [how they handle it today]
+  Cost of inaction: [what happens if unsolved]
+  Emotional impact: [frustration/anxiety/embarrassment]
+  Quote: "[Representative customer quote]"
+```
+
+**Categories**: Functional (task is hard/slow), Financial (costs too much), Process (workflows broken), Social (look bad to boss/peers), Emotional (stress/overwhelm).
+
+### Goals
+
+```
+Primary Goal: [#1 outcome] | Metric: [how measured] | Timeframe: [expected]
+Secondary Goals: [2-3 additional outcomes]
+Dream Outcome: [if everything went perfectly]
+JTBD: "When I [situation], I want to [action], so I can [outcome]."
+```
+
+## Step 4: Objections and Barriers
+
+```
+PRICE: "We don't have budget" -> [Response framework + evidence needed]
+TIMING: "Not ready to switch" -> [Cost of waiting + easy migration]
+TRUST: "Never heard of you" -> [Social proof + guarantee]
+INERTIA: "Current solution works" -> [Hidden costs of status quo]
+AUTHORITY: "Need manager approval" -> [Business case template]
+TECHNICAL: "Will it integrate?" -> [Integration docs + support]
+```
+
+## Step 5: Channel Mapping
+
+```
+| Channel | Relevance (1-5) | Content Type | Cost |
+|---------|----------------|-------------|------|
+| Google Search | [score] | SEO/ads | free/paid |
+| LinkedIn | [score] | posts/ads | free/paid |
+| Twitter/X | [score] | threads | free |
+| Reddit | [score] | community | free |
+| Podcasts | [score] | guest/sponsor | free/paid |
+| YouTube | [score] | tutorials | free/paid |
+| Newsletters | [score] | sponsorships | paid |
+
+TOP 3 CHANNELS: [channel + why + tactic]
+CONTENT CONSUMED: Specific podcasts, newsletters, influencers, communities, events
+```
+
+## Step 6: Customer Interview Template
+
+Target 10-15 interviews. Mix: current customers (5-7), churned (2-3), prospects (3-5). 30-45 min calls.
+
+```
+CONTEXT (5 min)
+1. Tell me about your role and typical day.
+2. Biggest challenges in [relevant area]?
+3. How do you currently handle [problem]?
+
+PROBLEM (10 min)
+4. Walk me through the last time [problem occurred].
+5. Most frustrating part?
+6. How often does this come up?
+7. What happens if it doesn't get solved?
+8. What have you tried before?
+
+SOLUTION (10 min)
+9. What tools have you used?
+10. What do you like about your current solution?
+11. What would you change?
+12. Ideal solution looks like?
+
+BUYING (10 min)
+13. How did you find your current tool?
+14. Who else was involved in the decision?
+15. What would make you switch?
+16. What would hold you back?
+17. What would you pay for [key benefit]?
+
+CLOSE: Anything else? Know anyone similar who'd chat?
+```
+
+### Synthesis Template
+
+```
+COMMON THEMES: [theme, mentioned by X/n, key quotes]
+SURPRISING FINDINGS: [unexpected insights]
+VALIDATED ASSUMPTIONS: [confirmed]
+INVALIDATED ASSUMPTIONS: [disproven -- critical]
+ICP ADJUSTMENTS: [changes based on findings]
+```
+
+## Step 7: Survey Design
+
+10-15 questions, 5-7 minutes. Use after interviews for quantitative validation.
+
+**Screening** (2-3 Qs): Role, company size, do they [relevant activity]?
+**Problem** (3-4 Qs): Frequency, severity (1-10), current solution, satisfaction (1-10).
+**Solution** (3-4 Qs): Feature ranking, switch triggers, willingness to pay.
+**Demographics** (2-3 Qs): Industry, budget, open to follow-up?
+
+Minimum: 100 responses for quantitative, 30 for directional insights.
+
+## Step 8: Persona Card Template
+
+Create 2-4 personas:
+
+```
+PERSONA: [Name, e.g., "Marketing Mary"]
+Role: [title] | Company: [type] | Age: [range]
+
+BIO: [2-3 sentences: professional life, challenges, aspirations]
+
+GOALS                    FRUSTRATIONS
+- [Goal 1]               - [Frustration 1]
+- [Goal 2]               - [Frustration 2]
+- [Goal 3]               - [Frustration 3]
+
+TOOLS: [3-5 tools]       CHANNELS: [3-5 trusted channels]
+
+BUYING: Research style [self/peer/sales], Decision speed [fast/slow],
+        Budget authority [yes/needs approval]
+
+MESSAGING: Do say "[appeals to them]" | Don't say "[turns them off]"
+Key benefit: [#1 thing they care about]
+Proof needed: [evidence type that convinces them]
+
+OBJECTION: "[Biggest hesitation]" -> Response: "[How to address]"
+JTBD: "When I [situation], I want to [action], so I can [outcome]."
+QUOTE: "[Representative mindset quote]"
+```
+
+## Step 9: Validation
+
+### Checklist
+- [ ] Based on data (interviews, surveys, analytics), not just assumptions
+- [ ] 10+ customers/prospects match the profile
+- [ ] ICP customers have higher LTV and lower churn
+- [ ] ICP customers are reachable through identified channels
+- [ ] Specific enough to guide decisions, not so narrow market is too small
+- [ ] Documented and shared with all customer-facing teams
+
+### When to Update
+After every 50 new customers, after pricing changes, after major features, after new market entry, quarterly minimum.
+
+## Output Format
+
+```
+IDEAL CUSTOMER PROFILE: [Product]
+==================================
+EXECUTIVE SUMMARY: [2-3 sentences]
+COMPANY/CUSTOMER PROFILE: [Full details]
+PAIN POINTS AND GOALS: [Ranked with severity]
+BUYER PERSONAS: [2-4 persona cards]
+OBJECTION HANDLING: [Top objections + responses]
+CHANNEL STRATEGY: [Where to find them]
+RESEARCH TEMPLATES: [Interview + survey instruments]
+VALIDATION PLAN: [How to confirm and refine]
+```
+
+Ground in evidence. Label assumptions vs. validated insights. Make actionable for marketing copy, ad targeting, content strategy, and sales outreach.

--- a/.claude/skills/keyword-research/SKILL.md
+++ b/.claude/skills/keyword-research/SKILL.md
@@ -1,0 +1,353 @@
+---
+name: keyword-research
+description: Perform keyword research using the SemRush API. Use when the user says "find keywords", "keyword research", "what should I rank for", "keyword ideas", "search volume", "keyword difficulty", "topic clusters", "content gaps", or asks about SEO keywords for a topic or niche.
+---
+
+# Keyword Research Skill
+
+You are an expert SEO keyword researcher. Use the SemRush API to find, analyze, and organize keywords into actionable strategies.
+
+## Prerequisites
+
+This skill requires `SEMRUSH_API_KEY`. Check for it in environment variables or in `~/.claude/.env.global`. If not found, inform the user:
+
+```
+This skill requires a SemRush API key. Set it via:
+  export SEMRUSH_API_KEY=your_key_here
+Or add it to ~/.claude/.env.global
+```
+
+## SemRush API Endpoints
+
+Use `curl` via the Bash tool for all API calls. The base URL is `https://api.semrush.com/`.
+
+### Core Endpoints
+
+**1. Keyword Overview (phrase_all)**
+```
+https://api.semrush.com/?type=phrase_all&key={KEY}&phrase={keyword}&database={db}&export_columns=Ph,Nq,Cp,Co,Nr,Td
+```
+Columns: Ph=Keyword, Nq=Search Volume, Cp=CPC, Co=Competition, Nr=Number of Results, Td=Trend
+
+**2. Related Keywords (phrase_related)**
+```
+https://api.semrush.com/?type=phrase_related&key={KEY}&phrase={keyword}&database={db}&export_columns=Ph,Nq,Cp,Co,Nr,Td&display_limit=50
+```
+
+**3. Keyword Questions (phrase_questions)**
+```
+https://api.semrush.com/?type=phrase_questions&key={KEY}&phrase={keyword}&database={db}&export_columns=Ph,Nq,Cp,Co,Nr,Td&display_limit=50
+```
+
+**4. Domain Organic Keywords (domain_organic)**
+```
+https://api.semrush.com/?type=domain_organic&key={KEY}&domain={domain}&database={db}&export_columns=Ph,Po,Nq,Cp,Co,Tr,Tc,Nr,Td&display_limit=100
+```
+Additional columns: Po=Position, Tr=Traffic, Tc=Traffic Cost
+
+**5. Keyword Difficulty (phrase_kdi)**
+```
+https://api.semrush.com/?type=phrase_kdi&key={KEY}&phrase={keyword}&database={db}&export_columns=Ph,Kd
+```
+Columns: Kd=Keyword Difficulty (0-100)
+
+### Database Codes
+- `us` (United States - default)
+- `uk` (United Kingdom)
+- `ca` (Canada)
+- `au` (Australia)
+- `de`, `fr`, `es`, `it`, `br`, `in`, `jp`
+
+Ask the user for target market if not specified. Default to `us`.
+
+## Research Process
+
+### Step 1: Understand the Brief
+
+Ask or infer:
+- **Niche/Topic:** What is the site about?
+- **Target audience:** Who are they trying to reach?
+- **Business model:** How do they monetize? (SaaS, ecommerce, ads, affiliate)
+- **Current domain:** If they have one, pull existing rankings
+- **Target market:** Which country/language?
+- **Competitors:** Known competitors to analyze
+
+### Step 2: Seed Keyword Discovery
+
+Generate 10-20 seed keywords based on the brief. Use three methods:
+
+**Method A: Brainstorm seeds** from the topic
+- Core product/service terms
+- Problem terms ("how to fix...", "why is...")
+- Audience terms (job titles, demographics)
+- Alternative terms and synonyms
+
+**Method B: Pull competitor keywords** using `domain_organic` for 2-3 competitor domains
+
+**Method C: Expand seeds** using `phrase_related` and `phrase_questions` for each seed
+
+### Step 3: Analyze Each Keyword
+
+For every keyword candidate, collect via API:
+
+| Metric | Source | What it tells you |
+|--------|--------|-------------------|
+| Search Volume (Nq) | phrase_all | Monthly searches |
+| Keyword Difficulty (Kd) | phrase_kdi | How hard to rank (0-100) |
+| CPC (Cp) | phrase_all | Commercial value indicator |
+| Competition (Co) | phrase_all | PPC competition (0-1) |
+| Trend (Td) | phrase_all | 12-month trend data |
+| SERP Results (Nr) | phrase_all | Total competing pages |
+
+### Step 4: Classify by Search Intent
+
+Categorize every keyword into one of four intents:
+
+| Intent | Signals | Examples | Content Type |
+|--------|---------|----------|--------------|
+| **Informational** | how, what, why, guide, tutorial, tips | "how to start a blog" | Blog post, guide, video |
+| **Navigational** | brand names, specific product names, login | "semrush login" | Homepage, product page |
+| **Commercial** | best, review, comparison, vs, top, alternatives | "best SEO tools 2025" | Comparison, review, listicle |
+| **Transactional** | buy, price, discount, coupon, free trial, sign up | "semrush pricing" | Landing page, product page |
+
+**Intent classification rules:**
+- "how to" / "what is" / "why" = Informational
+- "{brand} + {feature}" = Navigational
+- "best" / "top" / "vs" / "alternative" / "review" = Commercial Investigation
+- "buy" / "price" / "discount" / "free" / "download" / "sign up" = Transactional
+- If ambiguous, check the SERP: majority blog posts = informational, majority product pages = transactional
+
+### Step 5: Build Topic Clusters
+
+Organize keywords into pillar-cluster structure:
+
+```
+Pillar Page: [Broad topic keyword - high volume, high difficulty]
+  |
+  +-- Cluster 1: [Subtopic keyword group]
+  |     +-- Supporting keyword 1
+  |     +-- Supporting keyword 2
+  |     +-- Question keyword 1
+  |
+  +-- Cluster 2: [Subtopic keyword group]
+  |     +-- Supporting keyword 1
+  |     +-- Supporting keyword 2
+  |
+  +-- Cluster 3: ...
+```
+
+**Clustering rules:**
+- Pillar: Volume > 5,000, KD 40-80, broad topic
+- Cluster head: Volume 1,000-5,000, KD 20-50, specific subtopic
+- Supporting: Volume 100-1,000, KD < 30, long-tail variations
+- Each cluster should have 3-8 supporting keywords
+- Every supporting page links back to the pillar page
+
+### Step 6: Prioritize with the KOB Score
+
+Calculate the Keyword Opposition to Benefit (KOB) score for prioritization:
+
+```
+KOB Score = (Search Volume * CTR Estimate * Business Value) / Keyword Difficulty
+
+Where:
+- CTR Estimate: Position 1 = 0.30, Pos 2 = 0.15, Pos 3 = 0.10 (use 0.15 as default)
+- Business Value: 3 = direct revenue keyword, 2 = consideration keyword, 1 = awareness keyword
+- Keyword Difficulty: 1-100 from SemRush (use max(KD, 1) to avoid division by zero)
+```
+
+**Priority tiers:**
+- KOB > 50: High priority - target first
+- KOB 20-50: Medium priority - target in months 2-3
+- KOB 5-20: Low priority - target later
+- KOB < 5: Deprioritize unless strategically important
+
+### Step 7: Find Content Gaps
+
+Compare the user's domain against competitors:
+
+1. Pull top 100 keywords for each competitor via `domain_organic`
+2. Identify keywords where competitors rank but user does not
+3. Filter for keywords with KOB > 20
+4. These are content gap opportunities
+
+## Output Format
+
+Present results in this structure:
+
+```markdown
+# Keyword Research Report: {Topic/Niche}
+**Date:** {date}
+**Target Market:** {country}
+**Total Keywords Found:** {count}
+**Total Monthly Search Volume:** {sum}
+
+## Top 20 Keywords by KOB Score
+
+| # | Keyword | Volume | KD | CPC | Intent | KOB Score |
+|---|---------|--------|-----|-----|--------|-----------|
+| 1 | {keyword} | {vol} | {kd} | ${cpc} | {intent} | {kob} |
+| ... | ... | ... | ... | ... | ... | ... |
+
+## Topic Clusters
+
+### Pillar: {Pillar keyword} (Volume: {vol}, KD: {kd})
+
+| Cluster | Head Keyword | Volume | KD | Supporting Keywords |
+|---------|-------------|--------|-----|---------------------|
+| {name} | {keyword} | {vol} | {kd} | kw1, kw2, kw3 |
+
+### Content Plan
+
+| Priority | Keyword | Intent | Content Type | Est. Monthly Traffic |
+|----------|---------|--------|-------------|---------------------|
+| 1 | {keyword} | {intent} | {type} | {vol * 0.15} |
+| ... | ... | ... | ... | ... |
+
+## Question Keywords (FAQ Opportunities)
+
+| Question | Volume | KD | Suggested Content |
+|----------|--------|-----|-------------------|
+| {question} | {vol} | {kd} | {content type} |
+
+## Content Gaps vs. Competitors
+
+| Keyword | Volume | KD | Competitor Ranking | Opportunity |
+|---------|--------|-----|--------------------|-------------|
+| {keyword} | {vol} | {kd} | {competitor}: #{pos} | {content type} |
+
+## Recommended Next Steps
+
+1. {Specific action item with keyword target}
+2. ...
+```
+
+## Tips for Better Results
+
+- **Batch API calls** to conserve API credits. Query related keywords in groups.
+- **Always check trends.** A keyword with declining volume may not be worth targeting.
+- **CPC indicates money intent.** High CPC keywords ($5+) usually have strong commercial intent even if not obvious.
+- **Low KD is not always easy.** If all top results are from DR 80+ sites, a KD of 20 may still be hard for a new site.
+- **Local vs. national.** For local businesses, append city/state to seed keywords.
+- **Seasonal keywords.** Note if trends show seasonality; plan content 2-3 months before peak.
+- If the API returns an error or no data, inform the user of the specific issue rather than guessing.
+
+## Supplementary API Integrations
+
+These APIs complement SemRush and can be used as alternatives or for additional data points. They are not required if SemRush is available.
+
+### DataForSEO (Alternative/Complement to SemRush)
+
+If `DATAFORSEO_LOGIN` and `DATAFORSEO_PASSWORD` are available, use DataForSEO for keyword search volume and related data. This is especially useful as a fallback when SemRush credits are limited or for cross-referencing data.
+
+**Search Volume Endpoint:**
+
+```bash
+# Get keyword search volume data from DataForSEO
+curl -s -X POST "https://api.dataforseo.com/v3/keywords_data/google_ads/search_volume/live" \
+  -H "Authorization: Basic $(echo -n "${DATAFORSEO_LOGIN}:${DATAFORSEO_PASSWORD}" | base64)" \
+  -H "Content-Type: application/json" \
+  -d '[{"keywords": ["keyword1", "keyword2", "keyword3"], "location_code": 2840, "language_code": "en"}]'
+```
+
+**Parsing the response:**
+
+```bash
+# Extract keyword metrics from DataForSEO response
+curl -s -X POST "https://api.dataforseo.com/v3/keywords_data/google_ads/search_volume/live" \
+  -H "Authorization: Basic $(echo -n "${DATAFORSEO_LOGIN}:${DATAFORSEO_PASSWORD}" | base64)" \
+  -H "Content-Type: application/json" \
+  -d '[{"keywords": ["keyword1", "keyword2"], "location_code": 2840, "language_code": "en"}]' | \
+  jq '.tasks[0].result[] | {
+    keyword: .keyword,
+    search_volume: .search_volume,
+    competition: .competition,
+    competition_index: .competition_index,
+    cpc: .cpc,
+    monthly_searches: .monthly_searches
+  }'
+```
+
+Key fields:
+- **`search_volume`** - Average monthly search volume
+- **`competition`** - Competition level: "LOW", "MEDIUM", or "HIGH"
+- **`competition_index`** - Numeric competition score (0-100)
+- **`cpc`** - Cost per click in USD
+- **`monthly_searches`** - Array of 12 monthly volume data points (useful for identifying seasonal trends)
+
+**Common location codes:**
+- `2840` - United States
+- `2826` - United Kingdom
+- `2124` - Canada
+- `2036` - Australia
+- `2250` - France
+- `2158` - Germany
+
+**Keyword Suggestions Endpoint:**
+
+```bash
+# Get keyword suggestions (similar to SemRush phrase_related)
+curl -s -X POST "https://api.dataforseo.com/v3/keywords_data/google_ads/keywords_for_keywords/live" \
+  -H "Authorization: Basic $(echo -n "${DATAFORSEO_LOGIN}:${DATAFORSEO_PASSWORD}" | base64)" \
+  -H "Content-Type: application/json" \
+  -d '[{"keywords": ["seed keyword"], "location_code": 2840, "language_code": "en", "sort_by": "search_volume"}]'
+```
+
+**When to use DataForSEO vs SemRush:**
+- Use **SemRush** as the primary source for keyword difficulty, competitor analysis, and domain organic keywords
+- Use **DataForSEO** for bulk search volume lookups (supports up to 700 keywords per request, more cost-effective for large batches)
+- Use **DataForSEO** when you need Google Ads-aligned data (their data comes directly from Google Keyword Planner)
+- Cross-reference both sources when search volume numbers differ significantly
+
+### SerpAPI (People Also Ask & Related Searches)
+
+If `SERPAPI_API_KEY` is available, use SerpAPI to extract "People Also Ask" questions and related searches directly from Google SERPs. This data is not available from SemRush and is valuable for FAQ sections and content ideation.
+
+**Search Endpoint:**
+
+```bash
+# Get SERP data including People Also Ask and related searches
+curl -s "https://serpapi.com/search.json?q={keyword}&api_key=${SERPAPI_API_KEY}&num=10"
+```
+
+**Parsing People Also Ask:**
+
+```bash
+# Extract People Also Ask questions
+curl -s "https://serpapi.com/search.json?q={keyword}&api_key=${SERPAPI_API_KEY}&num=10" | \
+  jq -r '.related_questions[] | {
+    question: .question,
+    snippet: .snippet,
+    link: .link,
+    title: .title
+  }'
+```
+
+Key response sections:
+- **`related_questions`** - Array of "People Also Ask" questions with snippets and source URLs
+- **`related_searches`** - Array of related search queries that Google suggests
+- **`organic_results`** - Top 10 organic results (useful for SERP analysis)
+
+**Parsing Related Searches:**
+
+```bash
+# Extract related searches for content ideation
+curl -s "https://serpapi.com/search.json?q={keyword}&api_key=${SERPAPI_API_KEY}&num=10" | \
+  jq -r '.related_searches[] | .query'
+```
+
+**How to use SerpAPI data in keyword research:**
+
+1. **FAQ content:** Use "People Also Ask" questions directly as H2/H3 headings in blog posts or as FAQ schema entries. These are questions Google already associates with the keyword.
+2. **Content gap discovery:** If a PAA question has a weak snippet answer (short, vague, or from a low-authority site), that is an opportunity to write a better answer and win the featured snippet.
+3. **Keyword expansion:** Related searches are Google's own suggestions for related topics. Add these to your keyword list and check their volume via SemRush or DataForSEO.
+4. **Search intent validation:** The organic results show what content types Google ranks for this keyword. If all top 10 are blog posts, write a blog post. If they are product pages, a blog post will not rank.
+5. **Cluster building:** Group PAA questions and related searches by subtopic to identify natural content clusters.
+
+**Additional SerpAPI parameters:**
+- `location=United+States` - Geo-target the search
+- `gl=us` - Country code for Google domain
+- `hl=en` - Interface language
+- `device=desktop` or `device=mobile` - Desktop vs mobile SERPs (mobile may show different PAA questions)
+
+**Note:** SerpAPI charges per search. Use it strategically for your highest-priority keywords rather than for bulk research. Pair it with SemRush for volume data and DataForSEO for bulk lookups.

--- a/.claude/skills/launch-strategy/SKILL.md
+++ b/.claude/skills/launch-strategy/SKILL.md
@@ -1,0 +1,142 @@
+---
+name: launch-strategy
+description: Plan and execute product launches with week-by-week timelines and channel-specific playbooks. Use when the user asks about launching a product, Product Hunt launch, go-to-market strategy, launch plan, beta program, pre-launch marketing, launch day execution, or post-launch growth. Trigger phrases include "product launch", "launch plan", "Product Hunt", "Hacker News launch", "go-to-market", "GTM strategy", "launch checklist", "pre-launch", "beta launch", "launch day", "launch sequence", "how to launch".
+---
+
+# Product Launch Strategy
+
+You are an expert product launch strategist. When the user asks you to plan a launch, prepare for Product Hunt, or build a go-to-market strategy, follow this framework.
+
+## Step 1: Gather Launch Context
+
+Establish: product (new/feature/update), target audience, launch type (soft/beta/public), timeline, budget, team size, existing audience (list size, following), relevant channels, competitive timing, success metrics.
+
+## Step 2: Launch Type Selection
+
+| Type | Timeline | Audience | Best For |
+|---|---|---|---|
+| Stealth/Alpha | Ongoing | 10-50 hand-picked | Validating concept |
+| Closed Beta | 2-4 weeks | 50-500 invited | Refining, testimonials |
+| Open Beta | 2-4 weeks | Anyone | Waitlist buzz, stress test |
+| Soft Launch | 1 week | Existing audience | Low-risk iteration |
+| Full Public | 1 day (4-8 week prep) | Everyone | Maximum impact, PR |
+| Rolling | 4-8 weeks | Phased access | Manage load, build FOMO |
+
+## Step 3: Pre-Launch (8-4 Weeks Before)
+
+### Week 8-6: Foundation
+
+**Positioning**: One-sentence value prop. Elevator pitch (30s/60s/2min). Positioning statement:
+```
+For [audience] who [need], [product] is a [category] that [benefit].
+Unlike [alternative], we [differentiator].
+```
+
+**Landing Page**: Clear headline, demo video, 3 benefits, email capture, social proof, FAQ. Set up analytics and email automation.
+
+**Content Prep**: 3-5 blog posts for launch week, product demo video (60-90s), screenshots, social calendar, press release draft, founder story narrative.
+
+### Week 6-4: Audience Building
+
+**Waitlist Growth**: Building-in-public updates, referral waitlist, content marketing, community engagement (Reddit/Discord/Slack), micro-influencer outreach (20-50 people), LinkedIn founder posts.
+
+**Waitlist Targets**: Solo founder: 500-5,000+. Small team: 1,000-10,000+. Funded: 5,000-50,000+.
+
+**Beta Setup**: Select 50-200 from waitlist. Private feedback channel. Feedback template: What did you try? Success (1-5)? What was frustrating? Would you recommend? Would you pay?
+
+### Week 4-2: Momentum
+
+**Social Proof**: Request testimonials ("[Result] since using [product]. Before [pain]. Now [benefit]."). Collect usage metrics. Video testimonials.
+
+**Amplification**: Newsletter authors, cross-promotion with complementary founders, advisors/investors briefed, "launch support" doc for network.
+
+**Technical**: Load test for 10x traffic. Monitoring/alerting. Scaling plan. War room channel. On-call assignments.
+
+## Step 4: Launch Week
+
+### Day Before
+- [ ] Final QA of product, page, links
+- [ ] Queue social posts, pre-schedule email
+- [ ] Brief team on roles
+- [ ] Verify tracking pixels
+- [ ] Test payment flows
+
+### Launch Day
+
+**Hour 0**: Publish everywhere. Send waitlist email. Post all social. Submit Product Hunt.
+**Hours 1-4**: Respond to every mention/comment. Share traction updates. Fix bugs immediately. DM supporters.
+**Hours 4-12**: Publish "why we built this" post. Share customer reactions. Behind-the-scenes content.
+**Hours 12-24**: Day 1 recap email. Wrap-up social post. Respond to all tickets. Plan Day 2.
+
+### Product Hunt Playbook
+
+**Prep**: Build maker profile 2+ weeks early. Prepare: tagline (60 chars), description (260 chars), 5+ gallery images, maker comment (200+ words), 60-90s video.
+
+**Launch Day**: Launch 12:01 AM PT. Post maker comment immediately. Share link by 6 AM PT. Respond to every comment within 30 min. Never ask for "upvotes" -- ask for "feedback." Target top 5.
+
+**Post-PH**: Thank community. Add PH badge. Reach out to commenters. Write retrospective.
+
+### Hacker News Playbook
+
+**Title**: "Show HN: [Name] - [What it does in plain English]"
+**Comment**: Technical architecture, why built, what's unique, honest limitations.
+**Rules**: Post 8-10 AM ET Tue-Thu. Be humble and transparent. No superlatives. Respond to criticism gracefully.
+
+### Social Media Blitz
+
+**Twitter Thread**: (1) Hook + announcement + link, (2) Problem, (3) Solution + screenshot, (4) Proof/metrics, (5) Story/motivation, (6) CTA + link.
+**LinkedIn**: Personal story, hook opening, lessons learned, CTA, tag supporters.
+**Reddit**: Follow sub rules, lead with value/story, engage extensively.
+
+## Step 5: Post-Launch (Weeks 2-8)
+
+**Week 2**: Recap email, first case study, retargeting ads, media outreach, NPS collection.
+**Week 3-4**: SEO content, comparison pages, onboarding optimization, outbound from leads.
+**Week 5-6**: Funnel analysis, landing page A/B tests, double down on best channels, referral program.
+**Week 7-8**: Scale paid ads, content partnerships, integrations, plan v2 launch.
+
+## Step 6: Metrics
+
+| Phase | Metric | Target |
+|---|---|---|
+| Pre-Launch | Waitlist sign-ups | [goal] |
+| Pre-Launch | Waitlist CR | 20-40% |
+| Pre-Launch | Beta activation | 60%+ |
+| Launch Day | Sign-ups | [goal] |
+| Launch Day | PH rank | Top 5 |
+| Post-Launch | Activation rate | 40%+ |
+| Post-Launch | D1/D7/D30 retention | 60%/30%/15%+ |
+| Post-Launch | Trial-to-paid | 10-25% |
+| Post-Launch | NPS | 40+ |
+
+Track channel attribution by quality (activation rate, retention, LTV), not just volume.
+
+## Step 7: Budget Allocation
+
+| Category | % | Activities |
+|---|---|---|
+| Content | 20-25% | Video, blog, graphics |
+| Paid Acquisition | 30-40% | Social ads, search ads, sponsorships |
+| PR/Outreach | 10-15% | Media, influencers |
+| Tools | 5-10% | Email, analytics, hosting |
+| Reserve | 10-15% | Double down on what works |
+
+**Zero-Budget**: Personal network, Product Hunt, Show HN, Reddit, Twitter thread, cold email journalists, cross-promotion, free email tools.
+
+## Output Format
+
+```
+LAUNCH PLAN: [Product]
+=======================
+TYPE: [type] | DATE: [date] | TARGET: [metric]
+
+TIMELINE: Week-by-week activities
+CHANNEL PLAYBOOKS: Detailed per-channel plans
+CONTENT CALENDAR: Pieces with publish dates
+LAUNCH DAY CHECKLIST: Hour-by-hour execution
+BUDGET: Category allocation
+METRICS: KPIs with targets
+RISK MITIGATION: Contingency plans
+```
+
+Tailor to the user's resources. A solo founder needs a different plan than a funded startup.

--- a/.claude/skills/lead-magnet/SKILL.md
+++ b/.claude/skills/lead-magnet/SKILL.md
@@ -1,0 +1,455 @@
+---
+name: lead-magnet
+description: >
+  Create lead magnets and gated content to capture email subscribers and leads.
+  Use when asked to design checklists, templates, calculators, mini-courses,
+  whitepapers, or other downloadable content offers. Trigger phrases: "lead magnet",
+  "gated content", "email capture", "content offer", "free download", "checklist",
+  "template", "whitepaper", "swipe file", "content upgrade", "opt-in offer".
+---
+
+# Lead Magnet Creation
+
+Design and build lead magnets that convert visitors into email subscribers and qualified leads.
+
+---
+
+## 1. Lead Magnet Types
+
+### Checklists
+
+**Best for:** Actionable topics, step-by-step processes
+**Effort to create:** Low (1-2 hours)
+**Conversion rate:** High (30-50% on dedicated landing pages)
+
+Template structure:
+```
+Title: The Complete [Topic] Checklist
+
+[ ] Step 1: [Action item]
+    Why: [Brief explanation]
+    Tool: [Recommended tool if applicable]
+
+[ ] Step 2: [Action item]
+    ...
+
+[ ] Step 3: [Action item]
+    ...
+
+[Continue for 10-25 items]
+
+Bonus: [Extra tip or resource link]
+```
+
+Example titles:
+- "The 47-Point Website Launch Checklist"
+- "Pre-Publish Blog Post Checklist (Never Miss a Step)"
+- "The Complete SEO Audit Checklist for 2025"
+
+### Templates
+
+**Best for:** Saving time, providing structure
+**Effort to create:** Medium (2-4 hours)
+**Conversion rate:** Very high (35-60%)
+
+Types of templates:
+- Spreadsheet templates (Google Sheets, Excel)
+- Document templates (Google Docs, Notion)
+- Design templates (Canva, Figma)
+- Code templates (GitHub repos, code snippets)
+- Email templates (copy-paste ready)
+
+Template packaging:
+```
+[Template Name]
+
+INSTRUCTIONS
+1. Make a copy of this template (File > Make a Copy)
+2. [Customization step 1]
+3. [Customization step 2]
+
+SECTIONS
+- Section 1: [Purpose]
+- Section 2: [Purpose]
+- Section 3: [Purpose]
+
+EXAMPLE (filled in)
+[Show one complete example so users understand how to use it]
+```
+
+### Calculators / Interactive Tools
+
+**Best for:** Quantifiable outcomes, ROI justification
+**Effort to create:** High (1-2 weeks with a developer)
+**Conversion rate:** Very high (40-60%)
+
+Calculator ideas:
+- ROI calculator for your product
+- Cost savings estimator
+- "How much are you losing?" audit tool
+- Salary/pricing benchmark calculator
+- Carbon footprint / impact calculator
+
+Implementation notes:
+- Can be built as a simple HTML/JS page
+- Gate the results (not the calculator itself) behind email
+- Show a preview of results, require email for full report
+- Save results as a PDF sent to their email
+
+### Mini-Courses (Email or Video)
+
+**Best for:** Complex topics, building authority, nurture sequences
+**Effort to create:** High (1-2 weeks)
+**Conversion rate:** Medium-high (25-40%)
+
+Structure:
+```
+Course: [Title] -- [X]-Day [Topic] Course
+
+Day 1: [Foundation topic]
+  - Email subject: "[Course Name] Day 1: [Topic]"
+  - Content: [500-800 words or 5-10 min video]
+  - Action item: [Homework]
+
+Day 2: [Building on Day 1]
+  ...
+
+Day 3: [Advanced topic]
+  ...
+
+Day 4: [Application / case study]
+  ...
+
+Day 5: [Summary + next steps + soft pitch]
+  - Recap key learnings
+  - "If you want to go further, [Product] can help with..."
+```
+
+### Whitepapers / Reports
+
+**Best for:** B2B, thought leadership, data-driven audiences
+**Effort to create:** High (1-3 weeks)
+**Conversion rate:** Medium (15-30%)
+
+Structure:
+```
+Title: [The State of / The Complete Guide to / X Trends in] [Topic]
+
+Executive Summary (1 page)
+- Key findings
+- Why this matters
+
+Section 1: [Current State]
+- Data point 1
+- Data point 2
+- Analysis
+
+Section 2: [Challenges]
+- Challenge 1 with data
+- Challenge 2 with data
+
+Section 3: [Solutions / Trends]
+- Trend 1 with examples
+- Trend 2 with examples
+
+Section 4: [Recommendations]
+- Actionable takeaways
+- Implementation roadmap
+
+Methodology (if original research)
+About [Company]
+```
+
+### Swipe Files
+
+**Best for:** Marketers, copywriters, designers
+**Effort to create:** Medium (curate over time)
+**Conversion rate:** High (30-50%)
+
+Swipe file types:
+- Email subject line swipe file (100+ proven subjects)
+- Ad copy swipe file (best-performing ads by industry)
+- Landing page swipe file (screenshots + analysis)
+- Cold email swipe file (templates for outreach)
+- Social media post swipe file (viral post formulas)
+
+Structure:
+```
+[Swipe File Title]: [X] Proven [Type] You Can Steal
+
+Category 1: [Theme]
+  Example 1:
+    Original: "[Exact copy]"
+    Source: [Brand/campaign]
+    Why it works: [Analysis]
+    Template: "[Fill-in-the-blank version]"
+
+  Example 2:
+    ...
+
+Category 2: [Theme]
+  ...
+```
+
+---
+
+## 2. Landing Page Structure
+
+Every lead magnet needs a dedicated landing page optimized for conversion.
+
+### Above the Fold
+
+```html
+<!-- Hero Section -->
+<section>
+  <h1>[Benefit-driven headline]</h1>
+  <p>[1-2 sentence description of what they'll get and why it matters]</p>
+
+  <!-- Lead Magnet Preview -->
+  <img src="[mockup of the lead magnet]" />
+
+  <!-- Opt-in Form -->
+  <form>
+    <input type="email" placeholder="Your email address" />
+    <button>Download Free [Type]</button>
+    <p class="privacy">No spam. Unsubscribe anytime.</p>
+  </form>
+</section>
+```
+
+### Below the Fold
+
+```html
+<!-- What's Inside -->
+<section>
+  <h2>Here's what you'll get:</h2>
+  <ul>
+    <li>[Specific deliverable 1]</li>
+    <li>[Specific deliverable 2]</li>
+    <li>[Specific deliverable 3]</li>
+  </ul>
+</section>
+
+<!-- Social Proof -->
+<section>
+  <p>"[Testimonial about the lead magnet]" -- [Name, Title]</p>
+  <p>[X] people have downloaded this [type]</p>
+</section>
+
+<!-- About the Author -->
+<section>
+  <h2>Created by [Name]</h2>
+  <p>[1-2 sentences of credibility]</p>
+</section>
+
+<!-- FAQ -->
+<section>
+  <h2>Questions?</h2>
+  <details>
+    <summary>Is this really free?</summary>
+    <p>Yes, 100% free. We just ask for your email so we can send it to you.</p>
+  </details>
+  <details>
+    <summary>What format is it in?</summary>
+    <p>[PDF / Google Sheet / Video / etc.]</p>
+  </details>
+</section>
+```
+
+### Headline Formulas
+
+1. "The [Adjective] [Type] to [Desired Outcome]"
+   - "The Ultimate Checklist to Launch Your Podcast"
+2. "[Number] [Things] Every [Audience] Needs to [Goal]"
+   - "7 Templates Every Startup Founder Needs to Raise Funding"
+3. "How to [Desired Outcome] (Free [Type])"
+   - "How to Double Your Email Open Rate (Free Swipe File)"
+4. "Get Our [Type] That [Social Proof]"
+   - "Get Our SEO Template That 10,000+ Marketers Use"
+5. "Stop [Pain Point]. Download Our Free [Type]."
+   - "Stop Guessing Your Pricing. Download Our Free Calculator."
+
+---
+
+## 3. Email Gate Setup
+
+### Simple Email Gate (HTML + API)
+
+```html
+<form id="lead-form" action="/api/subscribe" method="POST">
+  <input type="email" name="email" required placeholder="you@example.com" />
+  <input type="hidden" name="lead_magnet" value="seo-checklist" />
+  <button type="submit">Get Free Checklist</button>
+</form>
+```
+
+### Integration Options
+
+| Provider | Method |
+|----------|--------|
+| Mailchimp | Embed form or API (`POST /3.0/lists/{list_id}/members`) |
+| ConvertKit | API (`POST /v3/forms/{form_id}/subscribe`) |
+| Resend | API (`POST /emails` for delivery + webhook for list) |
+| SendGrid | API for delivery + contacts API for list management |
+| HubSpot | Forms API or embed form |
+
+### Double Opt-In Flow
+
+1. User submits email on landing page
+2. Show "Check your email" confirmation page
+3. Send confirmation email with "Confirm your email" button
+4. On confirmation, redirect to download page and deliver lead magnet
+5. Add to email nurture sequence
+
+### Single Opt-In Flow (Higher Conversion)
+
+1. User submits email on landing page
+2. Immediately redirect to download/thank-you page
+3. Simultaneously send email with download link (backup delivery)
+4. Add to email nurture sequence
+
+---
+
+## 4. Delivery Automation
+
+### Immediate Delivery Email
+
+```
+Subject: Your [Lead Magnet Name] is ready
+
+Hi [Name],
+
+Thanks for downloading [Lead Magnet Name]. Here's your copy:
+
+[Download Button/Link]
+
+A few tips to get the most out of it:
+1. [Quick tip 1]
+2. [Quick tip 2]
+3. [Quick tip 3]
+
+Questions? Just reply to this email.
+
+[Signature]
+
+P.S. If you found this helpful, you might also like [related resource].
+```
+
+### Post-Download Nurture Sequence
+
+**Email 2 (Day 2):** "Did you get a chance to use [Lead Magnet]?"
+- Quick tip or walkthrough
+- Ask if they have questions
+
+**Email 3 (Day 4):** "Here's how [Customer] used [Lead Magnet] to [Result]"
+- Case study or success story
+- Social proof
+
+**Email 4 (Day 7):** "[Related valuable content]"
+- Blog post, video, or additional resource
+- Build authority
+
+**Email 5 (Day 10):** "The next step after [Lead Magnet topic]"
+- Introduce your product/service as the logical next step
+- Soft pitch with value framing
+
+**Email 6 (Day 14):** "[Direct offer]"
+- Special offer for lead magnet downloaders
+- Clear CTA to product/service
+- Urgency element (limited time, limited spots)
+
+---
+
+## 5. Content Upgrade Strategy
+
+A content upgrade is a lead magnet specific to an individual blog post.
+
+### How It Works
+
+1. Write a high-traffic blog post
+2. Create a bonus resource that complements the post
+3. Embed an opt-in within the post to download the bonus
+
+### Content Upgrade Ideas by Post Type
+
+| Post Type | Content Upgrade |
+|-----------|----------------|
+| How-to guide | Printable checklist of all steps |
+| Listicle | Spreadsheet with all items + bonus items |
+| Case study | Template to replicate the results |
+| Data/research | Raw data spreadsheet or infographic |
+| Tutorial | Code snippets or starter template |
+| Comparison | Decision-making scorecard |
+
+### In-Post CTA Template
+
+```html
+<div class="content-upgrade">
+  <h3>Free Bonus: [Upgrade Name]</h3>
+  <p>[1 sentence description]. Download it free below.</p>
+  <form>
+    <input type="email" placeholder="Your email" />
+    <button>Send Me the [Type]</button>
+  </form>
+</div>
+```
+
+Place content upgrades:
+- After the introduction (for skimmers)
+- At the midpoint (for engaged readers)
+- At the end (for completionists)
+
+---
+
+## 6. Lead Magnet Selection Framework
+
+Choose the right lead magnet based on your goals:
+
+### By Funnel Stage
+
+| Stage | Best Lead Magnets | Goal |
+|-------|------------------|------|
+| Top of Funnel | Checklists, quizzes, cheat sheets | Maximum volume |
+| Middle of Funnel | Templates, calculators, webinars | Qualification |
+| Bottom of Funnel | Free trials, demos, consultations | Conversion |
+
+### By Audience Type
+
+| Audience | Best Formats |
+|----------|-------------|
+| Time-poor executives | 1-page cheat sheets, executive summaries |
+| Hands-on practitioners | Templates, tools, code snippets |
+| Data-driven analysts | Reports, benchmarks, calculators |
+| Visual learners | Infographics, video courses |
+| Beginners | Step-by-step guides, glossaries |
+
+### By Budget
+
+| Budget | Lead Magnet Options |
+|--------|-------------------|
+| $0 | Checklists, cheat sheets, email courses (text only) |
+| $100-500 | Designed PDFs, simple calculators, slide decks |
+| $500-2000 | Video courses, interactive tools, original research |
+| $2000+ | Software tools, comprehensive platforms, multi-format |
+
+---
+
+## 7. Conversion Benchmarks
+
+| Landing Page Type | Expected Conversion Rate |
+|-------------------|------------------------|
+| Dedicated lead magnet page | 30-50% |
+| Content upgrade (in-post) | 5-15% |
+| Sidebar widget | 1-3% |
+| Exit-intent popup | 3-8% |
+| Homepage email capture | 1-5% |
+| Webinar registration | 20-40% |
+
+### Optimization Levers
+
+1. **Headline**: Test benefit-driven vs curiosity-driven
+2. **Form fields**: Email-only vs email + name (fewer fields = higher conversion)
+3. **CTA button text**: "Download" vs "Get Instant Access" vs "Send Me the [Type]"
+4. **Social proof**: Add download count or testimonial
+5. **Preview**: Show a mockup/preview of the lead magnet
+6. **Urgency**: "Limited time" or "Updated for [current year]"

--- a/.claude/skills/linkedin-ads/SKILL.md
+++ b/.claude/skills/linkedin-ads/SKILL.md
@@ -1,0 +1,343 @@
+---
+name: linkedin-ads
+description: Create LinkedIn ad campaigns, write sponsored content, define professional audiences, and plan B2B advertising budgets. Use when the user asks about LinkedIn Ads, sponsored content, LinkedIn Campaign Manager, InMail ads, lead gen forms, B2B advertising, professional targeting, or LinkedIn retargeting. Trigger phrases include "LinkedIn Ads", "LinkedIn campaign", "sponsored content", "InMail ad", "LinkedIn lead gen", "B2B ads", "LinkedIn retargeting", "LinkedIn audience", "LinkedIn ad copy", "LinkedIn Campaign Manager".
+---
+
+# LinkedIn Ad Campaign Builder
+
+You are an expert LinkedIn advertising strategist specializing in B2B marketing. When the user asks you to create LinkedIn ad campaigns, write sponsored content, or optimize their LinkedIn advertising, follow this comprehensive framework.
+
+## Step 1: Gather Campaign Context
+
+Before building any campaign, establish:
+
+- **Product/Service**: What is being promoted?
+- **Target audience**: Job titles, industries, company sizes, seniority levels?
+- **Campaign objective**: Brand awareness, website visits, engagement, lead gen, conversions?
+- **Budget**: Daily or total? Amount? (LinkedIn minimum: $10/day)
+- **Landing page**: Where does the ad drive traffic?
+- **Lead gen forms**: Will you collect leads on LinkedIn or on your site?
+- **Creative assets**: Images, videos, brand guidelines, logos?
+- **Sales cycle**: How long and complex is the buying journey?
+
+If the user has not provided these, ask before proceeding.
+
+## Step 2: Campaign Objective Selection
+
+| Objective | Use When | KPI | Min Budget Recommendation |
+|---|---|---|---|
+| Brand Awareness | Launching in a new market or category | Impressions, brand lift | $50/day |
+| Website Visits | Driving traffic to content or landing pages | CPC, CTR | $30/day |
+| Engagement | Growing page followers, post interactions | CPE, engagement rate | $20/day |
+| Video Views | Promoting video content for awareness | CPV, view-through rate | $30/day |
+| Lead Generation | Collecting leads via LinkedIn forms | CPL, lead quality | $50/day |
+| Website Conversions | Driving sign-ups, demos, purchases | CPA, conversion rate | $50/day |
+| Job Applicants | Recruiting campaigns | Cost per applicant | $30/day |
+
+**Rules**: For B2B with deal sizes >$10K, Lead Generation or Website Conversions are typically most effective. For content marketing, use Website Visits. For product launches, start with Brand Awareness for 2-4 weeks, then retarget with Lead Gen.
+
+## Step 3: Audience Targeting
+
+### Professional Targeting (LinkedIn's Key Advantage)
+
+```
+Audience: [Descriptive Name]
+  Location: [Country/Region/Metro area]
+  Company:
+    Industry: [list]
+    Company size: [1-10, 11-50, 51-200, 201-500, 501-1000, 1001-5000, 5001-10000, 10000+]
+    Company name: [specific companies, if applicable]
+    Company growth rate: [optional]
+    Company revenue: [optional, select tiers]
+  Role:
+    Job title: [specific titles]
+    Job function: [department/function]
+    Seniority: [Individual Contributor, Manager, Director, VP, C-Suite, Owner/Partner]
+    Years of experience: [ranges]
+  Education:
+    Degrees: [optional]
+    Fields of study: [optional]
+    Schools: [optional]
+  Interests & Traits:
+    Member interests: [topics they engage with]
+    Member groups: [LinkedIn groups]
+    Member traits: [frequent travelers, job seekers, etc.]
+  Estimated audience size: [target range]
+```
+
+### Audience Size Guidelines
+
+| Campaign Type | Ideal Audience Size |
+|---|---|
+| Sponsored Content | 50,000 - 500,000 |
+| Message Ads (InMail) | 15,000 - 100,000 |
+| Text Ads | 60,000 - 600,000 |
+| Dynamic Ads | 50,000 - 300,000 |
+
+**Rules**: Audiences below 20,000 will have high CPMs and limited delivery. Audiences above 1M are usually too broad for B2B. Layer 2-3 targeting criteria but avoid over-narrowing. Exclude current customers from acquisition campaigns.
+
+### Matched Audiences (Retargeting)
+
+1. **Website retargeting**: Visitors in last 30/60/90/180/365 days (requires LinkedIn Insight Tag)
+2. **Contact targeting**: Upload email lists (minimum 300 matches, target 10,000+)
+3. **Company targeting**: Upload company lists by name or domain
+4. **Lookalike audiences**: Based on any matched audience source (select 1-15% similarity)
+5. **Event retargeting**: People who RSVPed to LinkedIn Events
+6. **Lead Gen Form retargeting**: People who opened but didn't submit a form
+7. **Video retargeting**: People who viewed 25%/50%/75%/97% of your video
+
+### ABM (Account-Based Marketing) Strategy
+
+For high-value target accounts:
+1. Upload target company list (100-1,000 companies)
+2. Layer job title + seniority targeting on top
+3. Run awareness ads to the full buying committee
+4. Retarget engaged users with lead gen or InMail
+5. Budget: $100-300/day for 500-company list
+
+## Step 4: Ad Formats and Copy
+
+### Sponsored Content (Single Image)
+
+```
+Introductory text (max 600 chars, ~150 visible before "see more"):
+[Hook - first line must stop the scroll]
+[2-3 lines of value/context]
+[CTA with link]
+
+Headline (max 200 chars, ~70 visible): [Clear value proposition]
+Description (max 300 chars): [Supporting detail - only shown in some placements]
+CTA Button: [Sign Up | Download | Learn More | Subscribe | Register | Request Demo | Get Quote | Apply Now]
+```
+
+**Copy Rules for LinkedIn**:
+1. Lead with a stat, question, or bold claim in the first line
+2. Speak to the professional identity ("As a [job title], you know...")
+3. Focus on business outcomes, not features (revenue, efficiency, growth)
+4. Use "you" language, not "we" language
+5. Include social proof: customer logos, metrics, awards
+6. Keep intro text under 150 characters for full visibility without truncation
+7. No clickbait — LinkedIn's professional audience responds to substance
+
+### Sponsored Content (Carousel)
+
+```
+Introductory text (max 255 chars): [Context-setting hook]
+Cards (2-10, recommended 4-6):
+  Card 1: Headline (max 45 chars) + Image (1080x1080)
+  Card 2-N: Headline (max 45 chars) + Image (1080x1080)
+  Final card: CTA headline + CTA button
+```
+
+**Carousel Strategies**: Framework breakdown (one step per card), Customer success stories, Before/after metrics, Product features tour, Industry statistics.
+
+### Sponsored Content (Video)
+
+```
+Introductory text (max 600 chars): [Hook + context]
+Video specs:
+  Duration: 15-90 seconds (30s sweet spot)
+  Aspect ratio: 16:9 (landscape), 1:1 (square), 9:16 (vertical for mobile)
+  Captions: Required (85% watch without sound)
+  File: MP4, max 200MB
+```
+
+**Video structure**:
+- 0-3s: Visual hook + text overlay with the key message
+- 3-15s: Problem/pain point
+- 15-25s: Solution introduction
+- 25-30s: CTA with clear next step
+
+### Message Ads (Sponsored InMail)
+
+```
+Sender: [Real person, not company page - VP/Director/Founder level]
+Subject line (max 60 chars): [Personal, curiosity-driven]
+Body (max 1,500 chars):
+  [Personal greeting - Hi {{FirstName}}]
+  [1 sentence relevance - why you're reaching out]
+  [2-3 sentences of value - what's in it for them]
+  [Clear single CTA]
+  [Signature with name, title, company]
+CTA Button (max 20 chars): [Action phrase]
+```
+
+**InMail Rules**:
+1. Keep under 500 characters for best conversion rates
+2. One CTA only — multiple CTAs reduce conversion by 20%+
+3. Use a real person as the sender (not a company page)
+4. Subject lines that work: questions, name-drops, personalization
+5. Send Tuesday-Thursday, 10am-2pm recipient's timezone
+6. LinkedIn limits to 1 InMail per member per 45 days — make it count
+7. Expected open rate: 50-60%. CTR: 3-5%.
+
+### Text Ads (Sidebar)
+
+```
+Headline (max 25 chars): [Direct, benefit-focused]
+Description (max 75 chars): [Supporting detail + CTA]
+Image: 100x100px (use a face, not a logo — faces get 20% higher CTR)
+```
+
+### Dynamic Ads (Personalized)
+
+```
+Type: Follower Ad | Spotlight Ad | Content Ad
+Headline (max 50 chars): [Personalized with %FIRSTNAME% or %COMPANYNAME%]
+Description (max 70 chars): [Value prop]
+CTA (max 18 chars): [Action phrase]
+Company logo: 100x100px
+```
+
+## Step 5: A/B Testing Framework
+
+### Test Priority (highest impact first)
+
+1. **Audience segments** (job title vs. seniority vs. skills targeting)
+2. **Ad format** (single image vs. carousel vs. video)
+3. **Introductory text** (hook variations)
+4. **CTA button** (Learn More vs. Download vs. Request Demo)
+5. **Creative** (image/video variations)
+6. **Offer** (whitepaper vs. webinar vs. demo vs. free trial)
+
+### Test Structure
+
+```
+Campaign: [Product] - A/B Test - [Variable]
+  Budget: Equal split | Duration: 14 days minimum
+  Ad A (Control): [baseline creative]
+  Ad B (Variant): [single changed variable]
+  Success metric: [primary KPI]
+  Statistical significance: Wait for 95% confidence or 100+ conversions per variant
+```
+
+**Rules**: One variable per test. LinkedIn needs 14+ days due to smaller daily impression volumes. Minimum 10,000 impressions per variant. Pause underperformers after 7 days if CTR difference is >50%.
+
+## Step 6: Budget and Bidding
+
+### Bidding Strategies
+
+| Strategy | Use When | Description |
+|---|---|---|
+| Maximum Delivery (automated) | Starting out, maximizing reach | LinkedIn optimizes for most results |
+| Cost Cap | Controlling CPA | Set max cost per result, LinkedIn stays under |
+| Manual Bidding | Full control | Set exact bid per click/impression |
+
+### Budget Benchmarks (B2B, varies by industry and audience)
+
+| Metric | Typical Range |
+|---|---|
+| CPC (Sponsored Content) | $5-12 |
+| CPM | $30-80 |
+| CPL (Lead Gen Forms) | $30-150 |
+| CPA (Website Conversions) | $50-300 |
+| InMail cost per send | $0.50-1.00 |
+
+**Rules**:
+- Minimum $10/day per campaign, but $50/day recommended for meaningful data
+- Monthly minimum for reliable optimization: $1,500-3,000
+- Never increase budget more than 25% at a time (resets learning)
+- Lead Gen Forms typically have 2-5x better conversion rate than landing pages (but lower intent)
+- Test budget: Allocate 20% of budget to testing new audiences and creatives
+
+### Funnel Budget Allocation
+
+| Funnel Stage | % of Budget | Format | Audience |
+|---|---|---|---|
+| Top of Funnel | 25-35% | Video, Sponsored Content | Broad professional targeting |
+| Middle of Funnel | 30-40% | Carousel, Content downloads | Engaged visitors, lookalikes |
+| Bottom of Funnel | 25-35% | Lead Gen, InMail, Retargeting | Website visitors, form abandoners |
+| Retention/Expansion | 5-10% | Sponsored Content | Current customers |
+
+## Step 7: LinkedIn Insight Tag and Conversion Tracking
+
+Always recommend installing:
+
+1. **LinkedIn Insight Tag**: JavaScript pixel for website retargeting and conversion tracking
+2. **Conversion actions**: Define what counts as a conversion (form submit, page visit, event-specific)
+3. **Revenue attribution**: Assign values to conversions for ROAS calculation
+
+```
+Conversion setup:
+  Name: [Descriptive name]
+  Type: [Lead | Purchase | Sign-up | Key page view | Add to cart | Download | Install | Other]
+  Attribution: [Last touch, 30-day click / 7-day view recommended]
+  Value: [Static amount or dynamic]
+```
+
+## Step 8: Campaign Naming Convention
+
+```
+Campaign: [Brand]_[Objective]_[Funnel]_[Quarter]_[Geo]
+Ad Set:   [Audience Type]_[Targeting Detail]_[Bid Strategy]
+Ad:       [Format]_[Creative Concept]_[Version]
+
+Examples:
+  Acme_LeadGen_BOFU_Q1-26_US
+  Decision-Makers_VP-CTO_SaaS-500+_CostCap
+  SingleImage_ROI-Calculator_v2
+```
+
+## Step 9: Reporting and Optimization
+
+### Key Metrics to Monitor
+
+| Metric | Benchmark | Action if Below |
+|---|---|---|
+| CTR (Sponsored Content) | 0.4-0.65% | Refresh creative, test new hooks |
+| CTR (InMail) | 3-5% | Rewrite subject line, change sender |
+| Lead Gen Form completion | 10-15% | Reduce form fields, improve offer |
+| Conversion rate (landing page) | 2-5% | Improve landing page alignment |
+| Frequency | <4 per month | Expand audience or pause |
+
+### Weekly Optimization Checklist
+
+1. Pause ads with CTR below 50% of campaign average
+2. Increase bids on high-performing audiences
+3. Refresh creatives every 4-6 weeks (creative fatigue)
+4. Review audience demographics report for insights
+5. Check frequency — over 4x/month = audience fatigue
+6. Monitor lead quality with sales team feedback
+
+## Output Format
+
+When delivering a LinkedIn ad campaign, always present:
+
+```
+LINKEDIN AD CAMPAIGN BRIEF
+===========================
+Objective: [selected] | Budget: $[amount]/day | Duration: [timeframe]
+Primary KPI: [metric + target]
+Insight Tag: [installed? / needs setup?]
+
+AUDIENCE
+--------
+[Full targeting details with estimated size]
+
+AD CREATIVE
+-----------
+Format: [Sponsored Content / Carousel / Video / InMail / Text Ad]
+[Full copy with character counts for each field]
+[Image/video specs and recommendations]
+
+VARIATIONS
+----------
+[2-3 creative variations]
+
+A/B TEST PLAN
+-------------
+[Testing priorities with timeline]
+
+BUDGET & BIDDING
+----------------
+[Funnel allocation breakdown]
+[Bidding strategy recommendation]
+
+MEASUREMENT
+-----------
+[Conversion tracking setup]
+[KPI targets and benchmarks]
+[Reporting cadence]
+```
+
+Always include character counts. Flag text exceeding limits. Provide 2-3 creative variations. Include LinkedIn-specific best practices for the chosen format.

--- a/.claude/skills/linkedin-content/SKILL.md
+++ b/.claude/skills/linkedin-content/SKILL.md
@@ -1,0 +1,193 @@
+---
+name: linkedin-content
+description: Create high-performing LinkedIn posts and content strategy. Use when the user says "LinkedIn post", "write for LinkedIn", "LinkedIn content", "LinkedIn strategy", "LinkedIn hook", "professional post", "thought leadership post", or asks about creating content specifically for LinkedIn.
+---
+
+# LinkedIn Content Skill
+
+You are a LinkedIn content strategist and copywriter. Create posts optimized for LinkedIn's algorithm and audience engagement patterns.
+
+## LinkedIn Algorithm Signals (2026)
+
+Posts are ranked by:
+1. **Dwell time** — How long people stop scrolling to read
+2. **Meaningful comments** (5+ words) — Most valuable signal
+3. **Saves/bookmarks** — High-value engagement
+4. **Shares** — Especially to feed (not DMs)
+5. **Reactions** — Least weighted but still matters
+6. **Profile authority** — Consistent posting history, complete profile
+
+**What kills reach:**
+- External links in post body (use comments instead)
+- Editing within first hour of posting
+- Posting more than once per day
+- Engagement bait ("Like if you agree")
+- Tagging people who don't engage back
+
+## Post Formats Ranked by Engagement
+
+| Format | Avg. Engagement | Best For |
+|--------|----------------|----------|
+| Carousel (PDF) | Highest | Frameworks, step-by-step, listicles |
+| Text + selfie photo | Very high | Personal stories, milestones |
+| Text-only (long) | High | Hot takes, stories, lessons |
+| Polls | High | Quick engagement, audience research |
+| Video (native, <90s) | Medium-High | Tutorials, behind-the-scenes |
+| Text + stock image | Medium | General posts |
+| Articles/newsletters | Low-Medium | Deep dives, SEO |
+| Posts with links | Lowest | Drive traffic (put link in comments) |
+
+## Hook Formulas
+
+The first 2-3 lines determine if people click "see more." Use these patterns:
+
+**Pattern 1: Bold claim**
+```
+{Controversial statement that challenges conventional wisdom.}
+
+Here's why most people get this wrong:
+```
+
+**Pattern 2: Unexpected story**
+```
+{Unexpected event happened to me last week.}
+
+It changed how I think about {topic}.
+```
+
+**Pattern 3: List preview**
+```
+{Number} lessons I learned from {specific experience}:
+
+(#{number} surprised me the most)
+```
+
+**Pattern 4: Before/After**
+```
+{Time period} ago, I was {struggling state}.
+Today, I {success state}.
+
+Here's exactly what changed:
+```
+
+**Pattern 5: Question hook**
+```
+Why do {group of people} keep making this mistake?
+
+I've seen it {number} times this month alone.
+```
+
+**Pattern 6: Data hook**
+```
+I analyzed {number} {things} and found something surprising.
+
+{One-line teaser of the finding.}
+```
+
+## Writing Rules
+
+### Structure
+- **Line breaks are critical.** One thought per line. White space = readability.
+- Max 3,000 characters (about 500 words). Sweet spot: 1,200-1,800 characters.
+- Short paragraphs: 1-2 sentences each.
+- Use line breaks between every paragraph.
+- End with a clear CTA or question to drive comments.
+
+### Voice & Tone
+- First person, conversational
+- Specific > vague ("I grew from 200 to 12,000 followers" not "I grew my audience")
+- Numbers and data points increase credibility
+- Avoid jargon unless your audience expects it
+- No hashtags in the post body (add 3-5 in the first comment if desired)
+
+### Formatting Tricks
+- Use → ↳ • ✓ ✗ for visual variety (sparingly)
+- Bold doesn't work in LinkedIn posts, but ALL CAPS for 1-2 words adds emphasis
+- Numbered lists for sequential content
+- Dashes and colons for structure
+
+## Content Pillars Framework
+
+Help the user build 3-5 content pillars:
+
+| Pillar Type | Purpose | Example |
+|-------------|---------|---------|
+| **Authority** | Establish expertise | Industry analysis, frameworks, case studies |
+| **Relatability** | Build connection | Failures, behind-the-scenes, day-in-the-life |
+| **Utility** | Provide value | How-tos, templates, checklists, tools |
+| **Opinion** | Spark discussion | Hot takes, predictions, industry commentary |
+| **Social proof** | Build trust | Results, testimonials, milestones |
+
+Aim for: 40% Utility, 25% Authority, 20% Relatability, 10% Opinion, 5% Social proof.
+
+## Posting Schedule
+
+**Optimal posting times (general, adjust for audience timezone):**
+- Tuesday-Thursday: 7:30-8:30am, 12:00-1:00pm
+- Monday/Friday: 8:00-9:00am
+- Avoid weekends (50-70% less reach)
+
+**Frequency:** 3-5 posts per week for growth. Minimum 2 for maintaining reach.
+
+## CTA Formulas
+
+End every post with one of:
+
+- **Question CTA:** "What's your experience with {topic}? I'd love to hear in the comments."
+- **Save CTA:** "Save this for next time you need to {action}."
+- **Share CTA:** "Repost this if your network needs to hear this ♻️"
+- **Follow CTA:** "Follow me for more {topic} content."
+- **DM CTA:** "DM me '{keyword}' and I'll send you {resource}."
+
+## Output Format
+
+When creating a LinkedIn post, deliver:
+
+```markdown
+## LinkedIn Post
+
+**Content pillar:** {pillar}
+**Format:** {text/carousel/poll/video}
+**Target audience:** {who this is for}
+
+---
+
+{The actual post content, formatted exactly as it should appear on LinkedIn}
+
+---
+
+**First comment:** {Hashtags, link, or additional context to post as first comment}
+**Best posting time:** {Recommended day/time}
+**Engagement tip:** {One specific tip for maximizing reach of this post}
+```
+
+## Carousel Posts
+
+For carousel (PDF) posts, provide:
+1. **Slide 1 (Cover):** Bold title + subtitle + author name. This is the hook.
+2. **Slides 2-8:** One key point per slide. Large text. Minimal words.
+3. **Final slide:** CTA (follow, save, share, visit link)
+
+Format carousel content as:
+
+```
+SLIDE 1: {Title}
+{Subtitle}
+by {Author}
+
+SLIDE 2: {Point 1 headline}
+{2-3 lines of supporting text}
+
+...
+
+SLIDE {N}: {CTA}
+{Follow for more | Save this | Visit link}
+```
+
+## Important Notes
+
+- Never include external links in the post body. Always suggest putting links in the first comment.
+- LinkedIn penalizes edited posts. Get it right before publishing.
+- Tag only people who will likely engage. Tagging without response hurts reach.
+- Comments from the author within the first hour boost reach significantly.
+- Reply to every comment within the first 2 hours.

--- a/.claude/skills/marketing-ideas/SKILL.md
+++ b/.claude/skills/marketing-ideas/SKILL.md
@@ -1,0 +1,421 @@
+---
+name: marketing-ideas
+description: >
+  139 proven marketing ideas organized by category with implementation guidance.
+  Use when asked for marketing ideas, growth strategies, campaign brainstorms,
+  or "what should I do to grow." Trigger phrases: "marketing ideas", "growth ideas",
+  "how to grow", "marketing strategies", "campaign ideas", "promote my product",
+  "marketing brainstorm", "growth tactics", "what should I try", "marketing playbook".
+---
+
+# 139 Proven Marketing Ideas
+
+A comprehensive collection of marketing tactics organized by category. Use this as a brainstorming tool and implementation reference.
+
+---
+
+## Category 1: Content & SEO (Ideas 1-20)
+
+1. **Start a blog targeting long-tail keywords** -- Write 2-4 posts/week answering questions your customers search for. Use tools like SemRush or Ahrefs to find low-difficulty keywords with decent volume.
+
+2. **Create pillar content + topic clusters** -- Build comprehensive guides (3,000+ words) on core topics, then write supporting articles that link back to the pillar page.
+
+3. **Publish original research or data studies** -- Survey your users or analyze your product data. Original data earns backlinks and media coverage naturally.
+
+4. **Build a glossary or knowledge base** -- Define every term in your industry. These pages rank well for informational queries and build authority.
+
+5. **Write comparison pages ("X vs Y")** -- Create honest comparisons between your product and competitors. These pages capture high-intent bottom-of-funnel traffic.
+
+6. **Create "best of" listicles** -- "Best [category] tools in 2025" pages attract searchers actively looking for solutions.
+
+7. **Repurpose content across formats** -- Turn blog posts into videos, podcasts, infographics, Twitter threads, LinkedIn carousels, and email newsletters.
+
+8. **Guest post on industry publications** -- Write for high-authority sites in your space to earn backlinks and reach new audiences.
+
+9. **Build interactive tools and calculators** -- ROI calculators, graders, quizzes. These earn backlinks and capture leads.
+
+10. **Optimize existing content** -- Update your top 20 pages with fresh data, better formatting, and additional sections. Often easier than creating new content.
+
+11. **Create templates and downloadable resources** -- Spreadsheets, checklists, Notion templates. High conversion rate as lead magnets.
+
+12. **Start a podcast or be a guest on podcasts** -- Builds personal brand, creates content, and reaches engaged audiences.
+
+13. **Create a free email course** -- 5-7 day email series teaching a skill. Builds your list and establishes expertise.
+
+14. **Build a resource directory** -- Curate and organize tools, blogs, communities in your niche. Becomes a go-to reference page.
+
+15. **Write case studies with real metrics** -- Document customer success stories with specific numbers. Powerful bottom-of-funnel content.
+
+16. **Create video tutorials and walkthroughs** -- YouTube is the second-largest search engine. Tutorial content has long shelf life.
+
+17. **Publish a "state of the industry" annual report** -- Position yourself as a thought leader. Gets press coverage and backlinks.
+
+18. **Optimize for featured snippets** -- Structure content with clear definitions, numbered lists, and tables that Google can pull into position zero.
+
+19. **Build programmatic SEO pages** -- Generate hundreds of pages from data (e.g., "[Tool] for [Industry]", "[City] + [Service]").
+
+20. **Add schema markup to all content** -- Structured data helps Google understand your content and can trigger rich results.
+
+---
+
+## Category 2: Competitor Intelligence (Ideas 21-28)
+
+21. **Analyze competitor content gaps** -- Use SemRush to find keywords competitors rank for that you do not. Create better content for those terms.
+
+22. **Monitor competitor pricing changes** -- Track competitor pricing pages and positioning. Adjust your value messaging accordingly.
+
+23. **Reverse-engineer competitor backlinks** -- Find sites linking to competitors and pitch those sites your superior content.
+
+24. **Track competitor social media** -- Monitor what content resonates for competitors. Identify patterns and adapt (do not copy).
+
+25. **Analyze competitor reviews** -- Read their 1-3 star reviews to find pain points you can address in your product and marketing.
+
+26. **Spy on competitor ads** -- Use Meta Ad Library and Google Ads Transparency Center to see competitor ad creative and messaging.
+
+27. **Monitor competitor job postings** -- Hiring patterns reveal strategic priorities (e.g., hiring SEOs = doubling down on organic).
+
+28. **Build a competitor comparison page** -- Honest comparison pages rank well and capture decision-stage traffic. Update quarterly.
+
+---
+
+## Category 3: Free Tools & Product-Led Growth (Ideas 29-40)
+
+29. **Build a free tool related to your product** -- HubSpot's Website Grader, Moz's Domain Authority Checker. Free tools drive massive organic traffic.
+
+30. **Offer a generous free tier** -- Let users experience core value without paying. The product becomes your best marketing.
+
+31. **Create a browser extension** -- Useful extensions get installed and keep your brand in front of users daily.
+
+32. **Build a Slack/Discord bot** -- Create a bot that solves a small problem and plugs into communities where your users live.
+
+33. **Open-source a component** -- Open-source a library, template, or tool. Builds goodwill and awareness in developer communities.
+
+34. **Create a free API** -- Offer a free tier of your API. Developers who integrate become long-term users and advocates.
+
+35. **Build a widget others can embed** -- Badges, calculators, or widgets that other sites embed (with backlink to you).
+
+36. **Create a Figma/Canva template library** -- Design templates get shared widely and bring users back to your brand.
+
+37. **Add viral mechanics to your product** -- "Made with [Product]" watermarks, shared workspaces, public profiles.
+
+38. **Build in public** -- Share your metrics, decisions, and progress publicly. Authenticity builds an audience.
+
+39. **Create a playground or sandbox** -- Let visitors try your product without signing up. Reduce friction to first experience.
+
+40. **Offer a free Chrome extension** -- Even if tangential to your main product, a useful extension is daily touchpoint.
+
+---
+
+## Category 4: Paid Advertising (Ideas 41-52)
+
+41. **Google Ads on branded competitor terms** -- Bid on competitor brand names. Legal in most jurisdictions. High intent traffic.
+
+42. **Google Ads on high-intent keywords** -- Target "best [category]", "[competitor] alternative", "how to [problem you solve]".
+
+43. **Retargeting ads** -- Show ads to people who visited your site but did not convert. 3-5x higher conversion than cold traffic.
+
+44. **LinkedIn Ads for B2B** -- Precise targeting by job title, company size, industry. Expensive but high quality leads.
+
+45. **Reddit Ads** -- Target specific subreddits where your audience hangs out. Authentic, non-salesy creative works best.
+
+46. **Twitter/X Ads** -- Promote tweets, accounts, or trends. Good for B2B thought leadership amplification.
+
+47. **YouTube pre-roll ads** -- Target competitors' channels and industry keywords. Skippable ads mean you only pay for engaged viewers.
+
+48. **Quora Ads** -- Answer questions in your space and amplify with ads. High intent, lower competition than Google.
+
+49. **Podcast sponsorships** -- Sponsor niche podcasts in your industry. Host-read ads convert better than programmatic.
+
+50. **Newsletter sponsorships** -- Sponsor email newsletters that your audience reads. Direct access to engaged subscribers.
+
+51. **Influencer partnerships** -- Pay micro-influencers (1K-50K followers) in your niche. Better ROI than mega-influencers.
+
+52. **Programmatic display on niche sites** -- Use platforms like BuySellAds to place ads on specific industry websites.
+
+---
+
+## Category 5: Social & Community (Ideas 53-68)
+
+53. **Build a community (Discord, Slack, Circle)** -- Owned communities create loyalty and reduce churn. Start small and curate.
+
+54. **Post consistently on LinkedIn** -- 3-5 posts/week with personal insights. LinkedIn organic reach is still strong for B2B.
+
+55. **Write Twitter/X threads** -- Weekly threads breaking down industry topics. Threads get 10x more reach than single tweets.
+
+56. **Create a subreddit or participate in existing ones** -- Answer questions, share value, build reputation over time. Never spam.
+
+57. **Launch on Product Hunt** -- Prepare a launch campaign. Top 5 products get significant traffic and backlinks.
+
+58. **Post on Hacker News** -- Show HN posts that demonstrate technical depth or novel approaches can drive massive traffic.
+
+59. **Join and contribute to Slack communities** -- Industry Slack groups are where professionals discuss tools and problems.
+
+60. **Create a Facebook Group** -- Niche Facebook Groups still have strong engagement, especially for B2C.
+
+61. **Instagram Reels and TikTok** -- Short-form video content for product demos, tips, and behind-the-scenes.
+
+62. **Go live regularly** -- LinkedIn Live, YouTube Live, Instagram Live. Live content gets algorithmic boosts.
+
+63. **Create a meme account** -- Industry-specific humor builds following and brand awareness among your audience.
+
+64. **Host Twitter/X Spaces** -- Weekly audio discussions on industry topics. Builds audience and thought leadership.
+
+65. **Share user-generated content** -- Repost customer content featuring your product. Social proof + community building.
+
+66. **Create shareable assets** -- Infographics, data visualizations, and quote cards that people want to repost.
+
+67. **Comment strategy** -- Thoughtfully comment on popular posts in your space. Be the first comment on influencer posts.
+
+68. **Build a personal brand for the founder** -- People follow people, not logos. Founder-led marketing is authentic and effective.
+
+---
+
+## Category 6: Email Marketing (Ideas 69-78)
+
+69. **Welcome email sequence** -- 5-7 emails over 14 days for new subscribers. Introduce your brand, deliver value, soft pitch.
+
+70. **Weekly newsletter with curated content** -- Become a trusted source of industry news and insights.
+
+71. **Behavioral email triggers** -- Abandoned cart, inactive user, feature unused. Triggered emails have 3-5x higher open rates.
+
+72. **Segment your email list** -- Different messages for different segments (industry, company size, behavior, funnel stage).
+
+73. **Re-engagement campaign** -- Target inactive subscribers with "We miss you" or "Is this goodbye?" campaigns.
+
+74. **Product update emails** -- Monthly changelog or feature announcement emails keep users engaged and informed.
+
+75. **Milestone celebration emails** -- "You've been with us for 1 year!" or "You've completed 100 tasks!" Drives loyalty.
+
+76. **Customer story emails** -- Share a customer success story in each newsletter. Aspirational and proof-driven.
+
+77. **Holiday and seasonal campaigns** -- Black Friday, New Year, back-to-school. Timely offers tied to calendar events.
+
+78. **Email signature marketing** -- Add a banner or CTA to every team member's email signature.
+
+---
+
+## Category 7: Partnerships & Integrations (Ideas 79-88)
+
+79. **Integration partnerships** -- Build integrations with complementary tools. Get listed in their marketplace/directory.
+
+80. **Co-marketing campaigns** -- Joint webinars, co-authored content, shared email blasts with non-competing partners.
+
+81. **Affiliate program** -- Pay partners commission for referred customers. Low risk (pay only for results).
+
+82. **Technology partner program** -- Formalize partnerships with tools in your ecosystem. Cross-promote.
+
+83. **Agency partner program** -- Agencies recommend tools to their clients. Give them training, certifications, commissions.
+
+84. **Guest on partner webinars** -- Present to their audience. You bring expertise; they bring the audience.
+
+85. **Cross-promote in email footers** -- "We integrate with [Partner]" in both companies' emails.
+
+86. **App store / marketplace presence** -- Get listed on Shopify App Store, HubSpot Marketplace, Salesforce AppExchange, etc.
+
+87. **Bundle deals** -- Partner with complementary products for a discounted bundle. AppSumo-style deals.
+
+88. **Sponsor partner events** -- Sponsor conferences, meetups, or webinars hosted by partners in your ecosystem.
+
+---
+
+## Category 8: Events & Webinars (Ideas 89-96)
+
+89. **Host monthly webinars** -- Educational webinars on topics your audience cares about. Record and repurpose.
+
+90. **Speak at industry conferences** -- Apply to speak at conferences where your customers attend.
+
+91. **Host a virtual summit** -- Multi-speaker online event over 1-3 days. Builds list and partnerships simultaneously.
+
+92. **Local meetups** -- Host small in-person meetups in major cities. Builds deep relationships.
+
+93. **Workshop series** -- Free or paid workshop teaching practical skills using your product.
+
+94. **Hackathons** -- Developer-focused events where participants build with your product or API.
+
+95. **Customer advisory board** -- Invite top customers to an exclusive group. They become advocates.
+
+96. **Founder dinners** -- Small, exclusive dinners with potential customers or partners. High-touch, high-conversion.
+
+---
+
+## Category 9: PR & Media (Ideas 97-106)
+
+97. **Publish original research** -- Newsworthy data gets picked up by journalists. Survey your users or analyze industry trends.
+
+98. **HARO / Connectively responses** -- Respond to journalist queries to get quoted in articles with backlinks.
+
+99. **Press release for launches** -- Use PRWeb or Newswire for major product launches. Supplements direct outreach.
+
+100. **Build journalist relationships** -- Identify 10-20 journalists covering your space. Follow, engage, and pitch thoughtfully.
+
+101. **Newsjacking** -- React quickly to industry news with expert commentary. Be the go-to source.
+
+102. **Founder story pitch** -- Journalists love origin stories. "Why I quit [big company] to build [startup]."
+
+103. **Award submissions** -- Apply for industry awards (G2, Capterra, local business awards). Wins provide social proof.
+
+104. **Contribute to industry publications** -- Write op-eds for Forbes, TechCrunch, etc. via contributor programs.
+
+105. **Publish a brand book or manifesto** -- A strong point of view attracts attention and media coverage.
+
+106. **Data-driven PR campaigns** -- Create shareable data visualizations and pitch them to media with an exclusive.
+
+---
+
+## Category 10: Launches & Announcements (Ideas 107-114)
+
+107. **Product Hunt launch** -- Plan a proper launch: build a following, prepare assets, coordinate upvotes, engage in comments.
+
+108. **Hacker News Show HN** -- Technical and novel products do well. Write a clear, honest description.
+
+109. **Beta launch with waitlist** -- Create scarcity and anticipation. Notify waitlist in waves.
+
+110. **Feature launch emails** -- Dedicated email for each major feature launch with use cases and examples.
+
+111. **Launch on multiple platforms simultaneously** -- Product Hunt + Hacker News + Reddit + Twitter thread on the same day.
+
+112. **Pre-launch content series** -- Build anticipation with a 5-part content series leading up to launch.
+
+113. **Launch party or live event** -- Virtual or in-person celebration for major releases.
+
+114. **Customer spotlight at launch** -- Feature a customer who tested the feature in beta as the launch story.
+
+---
+
+## Category 11: Product-Led Marketing (Ideas 115-126)
+
+115. **"Made with [Product]" watermarks** -- Canva, Loom, Notion do this. Every output is marketing.
+
+116. **Public sharing features** -- Enable users to share their work publicly (portfolios, dashboards, pages).
+
+117. **In-product referral prompts** -- Prompt at moments of delight: "Love this? Share with a friend."
+
+118. **Viral invite mechanics** -- Collaborative features that require inviting others (Google Docs, Figma, Slack).
+
+119. **Embeddable outputs** -- Let users embed product outputs on their websites (charts, forms, videos).
+
+120. **Free tier with branding** -- Free users become marketing channels. Paid removes branding.
+
+121. **API and developer ecosystem** -- Developers who build on your platform evangelize it.
+
+122. **Templates marketplace** -- User-created templates attract new users searching for those templates.
+
+123. **Public roadmap** -- A public roadmap builds transparency and attracts users who see planned features.
+
+124. **Changelog as content** -- Make your changelog engaging and shareable. Celebrate progress publicly.
+
+125. **Usage milestone sharing** -- "You've saved 100 hours with [Product]" prompts for social sharing.
+
+126. **Community templates and presets** -- Users sharing their setups brings in new users organically.
+
+---
+
+## Category 12: Unconventional & Creative (Ideas 127-139)
+
+127. **Billboards in target neighborhoods** -- A single billboard near a tech campus can generate massive buzz (Notion's SF billboards).
+
+128. **Swag that people actually want** -- High-quality, useful branded items: notebooks, water bottles, stickers.
+
+129. **Handwritten notes to customers** -- Does not scale, but creates unforgettable moments for early customers.
+
+130. **Easter eggs in your product** -- Hidden features or messages that users discover and share on social media.
+
+131. **Controversial takes** -- A strong, well-argued opinion generates more sharing than neutral content.
+
+132. **Challenge campaigns** -- "30-day [skill] challenge" using your product. Creates content and community.
+
+133. **Create a certification program** -- "[Product] Certified Professional" creates evangelists and adds resume value.
+
+134. **Buy a competing/expired domain** -- Redirect traffic from expired competitor domains to your site.
+
+135. **Direct mail to prospects** -- Physical mail stands out in the digital age. Send a memorable package.
+
+136. **Sponsor an open-source project** -- Builds goodwill in developer communities and gets logo placement.
+
+137. **Create a Spotify playlist** -- "Coding Focus" or "Startup Hustle" playlists with your brand attached.
+
+138. **Build a game** -- A simple, fun game related to your industry (Wordle-style) drives viral sharing.
+
+139. **Donate to charity per signup** -- "We'll plant a tree for every new account" creates feel-good sharing.
+
+---
+
+## Implementation Guide
+
+### By Company Stage
+
+**Pre-launch (0 customers):**
+- Focus: Ideas 57, 108, 109, 112 (launch tactics)
+- Build an audience before you build the product
+- Priority: Waitlist, community building, build in public
+
+**Early stage (0-100 customers):**
+- Focus: Ideas 1-5, 15, 29, 38, 68 (content + product-led)
+- Do things that do not scale: handwritten notes, 1:1 calls
+- Priority: SEO foundation, founder-led marketing, free tools
+
+**Growth stage (100-1,000 customers):**
+- Focus: Ideas 41-52, 69-78, 79-88 (paid + email + partnerships)
+- Start investing in channels with predictable ROI
+- Priority: Paid acquisition, email nurture, integrations
+
+**Scale stage (1,000+ customers):**
+- Focus: Ideas 89-96, 97-106, 115-126 (events + PR + product-led)
+- Systematize what works, experiment with new channels
+- Priority: PR, conferences, product virality
+
+### By Budget
+
+**$0/month (sweat equity only):**
+- Content & SEO (1-20)
+- Social & community (53-68)
+- Build in public (38)
+- Product Hunt launch (57, 107)
+
+**$500/month:**
+- Newsletter sponsorships (50)
+- Micro-influencer partnerships (51)
+- Basic retargeting (43)
+- Tool subscriptions (SemRush, email provider)
+
+**$2,000/month:**
+- Google Ads on high-intent keywords (42)
+- LinkedIn Ads (44)
+- Podcast sponsorships (49)
+- Freelance content writers
+
+**$10,000+/month:**
+- Multi-channel paid campaigns (41-52)
+- Agency partnerships (83)
+- Events and webinars (89-96)
+- PR campaigns (97-106)
+
+### By Timeline
+
+**This week (quick wins):**
+- Optimize email signatures (78)
+- Set up retargeting pixel (43)
+- Post on social media (54, 55)
+- Answer HARO queries (98)
+- Comment on industry posts (67)
+
+**This month:**
+- Publish 4 blog posts (1-2)
+- Launch on Product Hunt (107)
+- Start email welcome sequence (69)
+- Set up one integration (79)
+- Guest post on one publication (8)
+
+**This quarter:**
+- Build a free tool (29)
+- Launch referral program (see referral-program skill)
+- Start a podcast or webinar series (12, 89)
+- Run first paid campaign (42-44)
+- Publish original research (3, 97)
+
+**This year:**
+- Build comprehensive content library (1-20)
+- Establish partner ecosystem (79-88)
+- Scale paid channels (41-52)
+- Launch community (53)
+- Build product-led growth loops (115-126)

--- a/.claude/skills/newsletter/SKILL.md
+++ b/.claude/skills/newsletter/SKILL.md
@@ -1,0 +1,232 @@
+---
+name: newsletter
+description: Plan and grow an email newsletter. Use when the user says "newsletter strategy", "grow my newsletter", "newsletter content", "email newsletter", "subscriber growth", "newsletter monetization", "Substack strategy", "Beehiiv", or asks about building, growing, or monetizing a newsletter.
+---
+
+# Newsletter Growth Skill
+
+You are a newsletter growth strategist. Help plan content, grow subscribers, improve engagement, and monetize newsletters.
+
+## Newsletter Fundamentals
+
+### Subject Lines
+
+**Formulas that work:**
+
+| Formula | Example | Open Rate Impact |
+|---------|---------|-----------------|
+| Number + Benefit | "7 tools that saved me 10hrs/week" | High |
+| Question | "Are you making this SEO mistake?" | High |
+| How-to + Specific | "How I grew to 10K subs in 6 months" | High |
+| Curiosity gap | "The strategy nobody talks about" | Medium-High |
+| News/Urgency | "Breaking: Google just changed this" | Medium |
+| Personal/Story | "I almost quit last week" | Medium |
+| List/Roundup | "This week: 5 links worth your time" | Medium |
+
+**Rules:**
+- 30-50 characters optimal (mobile-friendly)
+- Preview text is equally important — extend the subject line, don't repeat it
+- Personalization tokens ({first_name}) lift open rates 5-10%
+- Avoid spam triggers: FREE, URGENT, ALL CAPS, excessive punctuation
+- A/B test subjects on every send
+
+### Content Structure
+
+**The 3 newsletter archetypes:**
+
+1. **Curated** — Links + commentary (e.g., TLDR, Morning Brew)
+   - 5-10 links with 2-3 sentence commentary each
+   - Fastest to produce, requires good sources
+   - Best for: News, industry updates, trends
+
+2. **Original** — Single essay/article (e.g., Lenny's Newsletter, Stratechery)
+   - 1,000-2,500 words of original analysis
+   - Highest authority building, most effort
+   - Best for: Thought leadership, premium/paid
+
+3. **Hybrid** — Original intro + curated links (most common)
+   - 200-500 word original section + 3-5 curated links
+   - Good balance of effort and value
+   - Best for: Most newsletters starting out
+
+### Frequency
+
+| Frequency | Pros | Cons | Best For |
+|-----------|------|------|----------|
+| Daily | Habit-forming, high touch | Burnout risk, high churn | News, curated |
+| 2-3x/week | Good balance | Moderate effort | Curated, hybrid |
+| Weekly | Most sustainable | Slower growth | Original, hybrid |
+| Biweekly | Low effort | Easy to forget | Premium, long-form |
+| Monthly | Minimal time | Low engagement | Company updates |
+
+**Recommendation:** Start weekly. Only increase frequency when you have a system (templates, curation tools, or a team).
+
+## Growth Strategies
+
+### Tier 1: Foundation (0 → 1,000 subscribers)
+
+1. **Lead magnet** — Offer a free resource in exchange for email
+   - Checklist, template, cheat sheet, toolkit, mini-course
+   - Must be instantly valuable (no "coming soon")
+   - Place on: landing page, blog sidebar, exit intent popup
+
+2. **Landing page optimization**
+   - Clear value proposition above the fold
+   - Social proof (subscriber count, testimonials, "as featured in")
+   - Show a sample issue
+   - Single CTA, no distractions
+
+3. **Content-driven signup**
+   - Add newsletter CTA to every blog post
+   - Create content upgrades (bonus content in exchange for email)
+   - Embed signup forms in content, not just sidebar
+
+4. **Personal network** — Email contacts, social media announcement, community posts
+
+### Tier 2: Growth (1,000 → 10,000)
+
+5. **Referral program**
+   - Reward subscribers who refer others
+   - Milestone rewards: 1 referral = bonus content, 5 = exclusive access, 10 = merchandise/call
+   - Tools: SparkLoop, ReferralHero, or built-in (Beehiiv, ConvertKit)
+
+6. **Cross-promotions**
+   - Partner with complementary newsletters (similar audience, not competing)
+   - Swap recommendations: "If you enjoy this, you'll also love {partner newsletter}"
+   - Paid cross-promotion: $1-5 per subscriber
+
+7. **Social media funnel**
+   - Post newsletter excerpts on Twitter/LinkedIn with "Subscribe for more"
+   - Carousel previews of newsletter content on Instagram
+   - Turn newsletter insights into Twitter threads
+
+8. **SEO-driven landing pages**
+   - Create keyword-targeted pages that lead to newsletter signup
+   - "Best {topic} newsletters" comparison pages
+   - Archive past issues as searchable blog posts
+
+### Tier 3: Scale (10,000+)
+
+9. **Paid acquisition** — Facebook/Instagram ads to landing page, $1-5 CPA target
+10. **Podcast/video guest appearances** — Mention newsletter as CTA
+11. **Giveaways** — Viral giveaway campaigns (use KingSumo, Gleam)
+12. **Acquisitions** — Buy smaller newsletters in your niche
+
+## Engagement & Retention
+
+### Key Metrics
+
+| Metric | Good | Great | Action if Below |
+|--------|------|-------|----------------|
+| Open rate | 35-45% | 50%+ | Improve subjects, clean list |
+| Click rate | 3-5% | 7%+ | Better CTAs, more relevant links |
+| Unsubscribe rate | <0.5% | <0.2% | Segment, reduce frequency |
+| Reply rate | 1-2% | 3%+ | Ask questions, be personal |
+| Growth rate | 5-10%/mo | 15%+/mo | Double down on top acquisition channel |
+
+### Re-engagement Campaign
+
+For subscribers who haven't opened in 60+ days:
+
+```
+Email 1 (Day 0): "Still interested in {topic}? Here's what you missed"
+  → Share 3 best recent issues
+
+Email 2 (Day 7): "Should I remove you?"
+  → Direct ask: click to stay, or we'll unsubscribe you
+
+Email 3 (Day 14): "Last chance — we're cleaning our list"
+  → Final warning, then remove non-openers
+```
+
+### Welcome Sequence
+
+```
+Email 1 (Immediate): Welcome + lead magnet delivery + "what to expect"
+Email 2 (Day 2): Your story + best issue ever (showcase value)
+Email 3 (Day 5): "Reply and tell me..." (build relationship)
+Email 4 (Day 7): Social proof + referral ask
+```
+
+## Monetization
+
+| Model | When to Start | Revenue Potential |
+|-------|--------------|-------------------|
+| Sponsorships | 1,000+ subscribers | $25-50 CPM |
+| Paid subscriptions | 5,000+ free subscribers | $5-20/month |
+| Affiliate links | Any size | 5-15% of clicks convert |
+| Digital products | 2,000+ subscribers | $10-500 per product |
+| Consulting/services | Any size | Varies |
+| Courses | 5,000+ subscribers | $50-500 per student |
+
+### Sponsorship Rate Card
+
+```
+CPM = (Sponsorship price / Subscribers) × 1,000
+
+Industry averages:
+- General/consumer: $15-25 CPM
+- Business/marketing: $25-50 CPM
+- Developer/technical: $30-60 CPM
+- Finance/investing: $40-80 CPM
+- Executive/C-suite: $50-100 CPM
+```
+
+## Deliverability
+
+### Must-Have Technical Setup
+
+| Check | Why |
+|-------|-----|
+| SPF record | Proves you're authorized to send from your domain |
+| DKIM signing | Cryptographic signature preventing spoofing |
+| DMARC policy | Tells receivers what to do with failed auth |
+| Custom sending domain | Avoid shared IP reputation issues |
+| Sunset inactive subscribers | Remove non-openers after 90 days |
+
+### Avoid Spam Filters
+
+- Maintain text-to-image ratio (80% text, 20% images)
+- Include unsubscribe link (required by law)
+- Use a real reply-to address
+- Don't use URL shorteners (bit.ly triggers spam filters)
+- Warm up new sending domains gradually
+
+## Output Format
+
+When creating a newsletter strategy, deliver:
+
+```markdown
+# Newsletter Strategy: {Newsletter Name}
+
+## Concept
+- **Niche:** {topic/audience}
+- **Format:** {curated/original/hybrid}
+- **Frequency:** {daily/weekly/biweekly}
+- **Value proposition:** {1-2 sentences — why subscribe?}
+
+## Growth Plan
+
+### Month 1: Foundation
+{Specific action items}
+
+### Month 2-3: Early Growth
+{Specific action items}
+
+### Month 4-6: Scale
+{Specific action items}
+
+## Content Template
+{Issue template/structure}
+
+## Monetization Roadmap
+{Timeline for monetization milestones}
+```
+
+## Important Notes
+
+- Consistency matters more than frequency. A reliable weekly newsletter beats an erratic daily one.
+- Always send from a real person's name, not a company name (higher open rates).
+- The reply is the most underrated metric. Ask questions. Read and respond to replies.
+- Clean your list quarterly. A 5,000-subscriber list with 50% open rate is worth more than 20,000 with 15%.
+- Always have a "Why am I getting this?" link for new subscribers who forgot they signed up.

--- a/.claude/skills/onboarding-cro/SKILL.md
+++ b/.claude/skills/onboarding-cro/SKILL.md
@@ -1,0 +1,486 @@
+---
+name: onboarding-cro
+description: >
+  Improve user onboarding flows to increase activation and retention. Use when
+  asked to design welcome screens, setup wizards, product tours, onboarding
+  checklists, or activation sequences. Trigger phrases: "onboarding flow",
+  "user activation", "welcome screen", "product tour", "onboarding checklist",
+  "first-run experience", "setup wizard", "aha moment", "time to value",
+  "user onboarding", "activation rate".
+---
+
+# Onboarding CRO
+
+Design and optimize user onboarding flows that drive activation and long-term retention.
+
+---
+
+## 1. Onboarding Frameworks
+
+### Jobs-To-Be-Done (JTBD) Onboarding
+
+The best onboarding flows are organized around the user's job, not the product's features.
+
+**Process:**
+1. Identify the user's primary job-to-be-done
+2. Map the minimum steps to complete that job in your product
+3. Guide the user through those steps, removing all distractions
+4. Celebrate completion (aha moment)
+
+**Example (Notion):**
+- Job: "I need to organize my team's projects"
+- Steps: Create workspace > Invite team > Create first page > Use a template
+- The onboarding flow guides exactly this path, nothing more
+
+**Anti-pattern:** Feature tours that show every feature. Users do not care about features during onboarding; they care about solving their problem.
+
+### Progressive Disclosure
+
+Reveal functionality gradually as users demonstrate readiness.
+
+**Levels:**
+1. **First session:** Only show core functionality needed for primary job
+2. **After first success:** Introduce secondary features that enhance the core workflow
+3. **After repeated use:** Surface power features, integrations, customization
+4. **After mastery:** Invite to advanced features, API, automation
+
+**Implementation:**
+- Use feature flags or user state to control what's visible
+- Track user actions to determine when to advance disclosure level
+- Never show everything at once
+
+### Activation Metrics
+
+Define your activation metric before designing onboarding. The activation metric is the action most correlated with long-term retention.
+
+**Examples:**
+
+| Product | Activation Metric | Timeframe |
+|---------|------------------|-----------|
+| Slack | Send 2,000 messages (team) | First 30 days |
+| Dropbox | Upload 1 file from 2 devices | First 7 days |
+| Facebook | Add 7 friends | First 10 days |
+| Zoom | Host first meeting | First 7 days |
+| Notion | Create 3 pages | First 7 days |
+| Figma | Create first design | First 3 days |
+| HubSpot | Import contacts + send first email | First 14 days |
+
+**How to find your activation metric:**
+1. Cohort analysis: Compare retained vs churned users
+2. Identify actions that retained users took that churned users did not
+3. Find the action with strongest correlation to 30-day retention
+4. Validate by testing whether guiding users to that action improves retention
+
+### Aha Moment Identification
+
+The aha moment is when a user first experiences the core value of your product.
+
+**Framework for identifying it:**
+1. What do users say when they recommend your product? ("It's amazing because...")
+2. When during their journey do users typically say "wow" or "this is cool"?
+3. What single action separates users who stay from those who leave?
+
+**The aha moment is NOT:**
+- Signing up
+- Completing onboarding
+- Seeing a feature demo
+
+**The aha moment IS:**
+- Getting their first result
+- Experiencing time saved
+- Seeing their data visualized for the first time
+- Completing their first task successfully
+
+---
+
+## 2. Onboarding Components
+
+### Welcome Screens
+
+The first screen after signup. Serves two purposes: make the user feel welcomed and collect information for personalization.
+
+**Best Practices:**
+- Use the user's name ("Welcome, Sarah!")
+- Keep it to 1-3 questions maximum
+- Use visual selectors (cards with icons) instead of dropdowns
+- Every question should directly affect their experience
+- Always allow skipping
+
+**Template:**
+```
+Welcome to [Product], [Name]!
+
+Let's personalize your experience.
+
+What's your primary goal?
+[ ] [Goal 1 -- with icon]
+[ ] [Goal 2 -- with icon]
+[ ] [Goal 3 -- with icon]
+[ ] Something else
+
+[Continue]  [Skip for now]
+```
+
+**Example (Notion):**
+```
+What will you use Notion for?
+[Personal] [Team] [School]
+
+How big is your team?
+[Just me] [2-10] [11-50] [50+]
+```
+
+### Setup Wizards
+
+Guided multi-step flows that set up the product for use.
+
+**When to use:** When the product requires configuration before it can deliver value (CRM, analytics, marketing automation).
+
+**Best Practices:**
+- Maximum 3-5 steps
+- Show progress indicator
+- Pre-fill defaults where possible
+- Allow skipping non-essential steps
+- Provide "try it with sample data" option
+- End with a clear next action, not a blank screen
+
+**Template:**
+```
+Step 1: Connect your [data source]
+  [Connect Google] [Connect manually] [Use sample data]
+
+Step 2: Configure your [workspace/project]
+  [Pre-filled sensible defaults with edit option]
+
+Step 3: Invite your team (optional)
+  [Email input] [Copy invite link] [Skip]
+
+You're all set!
+  [Go to your dashboard]
+```
+
+### Product Tours
+
+Interactive walkthroughs of the product interface.
+
+**Types:**
+1. **Tooltip tour:** Highlights UI elements with explanatory tooltips (Intercom, Appcues)
+2. **Video walkthrough:** Short video showing key workflows
+3. **Interactive tutorial:** User performs real actions with guidance
+4. **Sandbox mode:** Pre-populated environment for safe exploration
+
+**Best Practices:**
+- Keep tours under 5 steps (3 is ideal)
+- Focus on ONE workflow per tour
+- Let users exit at any point
+- Make the user DO something, not just read
+- Trigger contextually (first time visiting a feature), not globally
+- Never replay completed tours unless user requests it
+
+**Anti-patterns:**
+- 15-step tours that show every button
+- Forced tours that cannot be dismissed
+- Tours that explain obvious UI elements
+- Tours that trigger repeatedly
+
+**Template (per step):**
+```
+Step [X] of [Y]:
+
+[Pointer to UI element]
+
+"[Action verb] here to [achieve result]."
+
+[Try it now] / [Next] / [Skip tour]
+```
+
+### Onboarding Checklists
+
+Persistent task lists that guide users through activation.
+
+**Why they work:**
+- Zeigarnik effect: People feel compelled to complete unfinished tasks
+- Clear progress visualization
+- Users self-pace through the list
+- Can be dismissed and revisited
+
+**Template:**
+```
+Get started with [Product]  [3/5 complete]
+
+[x] Create your account
+[x] Set up your profile
+[x] [First key action]
+[ ] [Second key action] <-- "Do this next"
+[ ] [Third key action]
+
+[Dismiss checklist]
+```
+
+**Best Practices:**
+- 4-6 items maximum
+- Pre-check easy items (account creation) for momentum
+- Order by dependency and importance
+- Highlight the next recommended step
+- Celebrate completion (confetti, badge, reward)
+- Include at least one "aha moment" action
+- Show percentage complete or progress bar
+
+**Example (Slack):**
+```
+Getting started  [2/4]
+[x] Set your profile photo
+[x] Join a channel
+[ ] Send your first message
+[ ] Invite a teammate
+```
+
+**Example (Figma):**
+```
+Welcome to Figma  [1/5]
+[x] Create your account
+[ ] Create a design file
+[ ] Add a frame
+[ ] Use a component
+[ ] Share with your team
+```
+
+### Email Onboarding Sequences
+
+Drip emails that complement the in-app experience.
+
+**Sequence structure:**
+
+| Day | Email | Purpose |
+|-----|-------|---------|
+| 0 | Welcome + quick start | Immediate value, link to first action |
+| 1 | Tip: [Core feature] | Teach one key feature |
+| 3 | Social proof | Show what others achieve with the product |
+| 5 | "Need help?" | Address common obstacles, offer support |
+| 7 | Feature highlight | Introduce a secondary feature |
+| 10 | Activation reminder | If not activated, nudge toward key action |
+| 14 | Upgrade prompt | If activated, pitch premium features |
+
+**Day 0 Welcome Email Template:**
+```
+Subject: Welcome to [Product] -- here's your quick start
+
+Hi [Name],
+
+You're in! Here's how to get the most out of [Product] in the next 5 minutes:
+
+1. [First action] -- [link directly to it]
+2. [Second action] -- [link]
+3. [Third action] -- [link]
+
+[Primary CTA: "Go to your dashboard"]
+
+Need help? Reply to this email or check our [getting started guide].
+
+[Signature]
+```
+
+**Day 3 Social Proof Email Template:**
+```
+Subject: How [Customer] uses [Product] to [Result]
+
+Hi [Name],
+
+Did you know that [Customer/Company] uses [Product] to [specific result with metric]?
+
+Here's what they did:
+1. [Step they took]
+2. [Step they took]
+3. [Result they achieved]
+
+You can do the same:
+[CTA: "Try it now"]
+```
+
+---
+
+## 3. Onboarding Examples from Top Products
+
+### Notion
+
+**What they do well:**
+- Welcome screen asks role + use case (2 questions)
+- Offers templates based on selection
+- Pre-populates workspace with starter content
+- Progressive disclosure: basic blocks first, databases later
+- Checklist in sidebar tracks setup progress
+- Empty states have clear CTAs
+
+**Activation metric:** Create 3+ pages in first 7 days
+
+### Slack
+
+**What they do well:**
+- Workspace setup wizard is 3 steps (name, invite, channel)
+- Slackbot guides first interactions conversationally
+- Pre-created #general and #random channels with welcome messages
+- Teaches features by having users use them (send a message, react with emoji)
+- Onboarding checklist in sidebar
+
+**Activation metric:** Team sends 2,000 messages in first 30 days
+
+### Figma
+
+**What they do well:**
+- Minimal signup (Google OAuth one-click)
+- Immediately drops user into a canvas with interactive tutorial
+- Tutorial teaches by doing (create shape, move it, style it)
+- Sample files available to explore
+- Team collaboration demonstrated early (cursor presence)
+
+**Activation metric:** Create first design file in first 3 days
+
+### Canva
+
+**What they do well:**
+- Asks "What will you design today?" with visual categories
+- Immediately shows templates relevant to selection
+- First design experience uses pre-made template (user edits, not creates from scratch)
+- Celebrates first download with sharing prompt
+
+### Linear
+
+**What they do well:**
+- Import from existing tools (Jira, Asana) as first step
+- Pre-configured with sensible defaults (workflow states, labels)
+- Keyboard shortcuts taught in context
+- Empty states show exactly what to do next
+
+---
+
+## 4. Measuring Onboarding Success
+
+### Key Metrics
+
+| Metric | Formula | Target |
+|--------|---------|--------|
+| Onboarding completion rate | Users who complete onboarding / signups | 60-80% |
+| Time to first key action | Time from signup to first meaningful action | Under 5 min |
+| Activation rate | Users hitting activation metric / signups | 20-40% |
+| Day 1 retention | Users returning day after signup / signups | 40-60% |
+| Day 7 retention | Users returning 7 days after signup / signups | 20-35% |
+| Day 30 retention | Users active 30 days after signup / signups | 10-25% |
+| Onboarding step drop-off | Users completing step N / users starting step N | Track per step |
+| Time to value (TTV) | Median time from signup to aha moment | As low as possible |
+
+### Funnel Analysis
+
+Build an onboarding funnel in your analytics tool:
+
+```
+Signup completed
+  -> Welcome screen completed
+    -> First key action
+      -> Second key action (aha moment)
+        -> Activation metric reached
+          -> Day 7 return
+```
+
+Track conversion rate between each step. The biggest drop-off is your biggest opportunity.
+
+---
+
+## 5. A/B Test Ideas for Onboarding
+
+### Welcome Screen
+1. 1 question vs 3 questions on welcome screen
+2. Visual card selection vs dropdown
+3. Personalized template suggestions vs generic
+
+### Setup Flow
+4. Guided setup vs "explore on your own"
+5. Pre-populated sample data vs empty state
+6. Setup wizard vs onboarding checklist
+
+### Product Tour
+7. Tooltip tour vs video walkthrough
+8. 3-step tour vs 5-step tour
+9. Auto-triggered tour vs user-initiated
+
+### Activation
+10. Email nudge on day 1 vs day 3 for inactive users
+11. In-app prompt for next action vs no prompt
+12. Celebrating milestones (confetti, badge) vs no celebration
+13. Showing progress ("You're 60% set up") vs not showing
+
+### Engagement
+14. Daily tip emails vs weekly digest
+15. Push notifications for incomplete onboarding vs email only
+16. Peer comparison ("Teams like yours usually...") vs no comparison
+
+---
+
+## 6. Onboarding Audit Template
+
+When auditing an existing onboarding flow:
+
+```
+## Onboarding Audit: [Product Name]
+### Date: [Date]
+
+### Current Flow Map
+[Step-by-step flow with screenshots]
+
+### Time to Complete
+- Minimum path: [X] minutes
+- Average path: [X] minutes
+
+### Drop-off Analysis
+| Step | Users Entering | Completion Rate | Drop-off |
+|------|---------------|-----------------|----------|
+| Signup | 100% | X% | X% |
+| Welcome screen | X% | X% | X% |
+| Setup step 1 | X% | X% | X% |
+| Setup step 2 | X% | X% | X% |
+| First key action | X% | X% | X% |
+| Activation | X% | -- | -- |
+
+### Scores (1-10)
+| Dimension | Score | Notes |
+|-----------|-------|-------|
+| Time to value | X | |
+| Clarity of next step | X | |
+| Progressive disclosure | X | |
+| Error recovery | X | |
+| Mobile experience | X | |
+| Personalization | X | |
+| **Overall** | **X** | |
+
+### Issues Found
+1. **[Critical]** [Issue] -- Impact: [X]% activation loss
+2. **[High]** [Issue]
+3. **[Medium]** [Issue]
+
+### Recommendations (Priority Order)
+1. [Recommendation] -- Expected lift: X% on [metric]
+2. [Recommendation] -- Expected lift: X%
+3. [Recommendation] -- Expected lift: X%
+
+### Quick Wins
+- [ ] [Immediate fix]
+- [ ] [Immediate fix]
+
+### Long-term Improvements
+- [ ] [Bigger initiative]
+- [ ] [Bigger initiative]
+```
+
+---
+
+## 7. Common Onboarding Mistakes
+
+1. **Showing everything at once** -- Overwhelms users. Use progressive disclosure.
+2. **Explaining features, not outcomes** -- "This is our dashboard" vs "See your results here."
+3. **Forcing completion before value** -- Let users explore, then guide.
+4. **No empty state strategy** -- Blank screens kill activation. Use templates, samples, or guided prompts.
+5. **One-size-fits-all flow** -- Different user types need different onboarding paths.
+6. **Ignoring mobile** -- Mobile onboarding needs its own design (not a shrunk desktop flow).
+7. **No re-engagement for drop-offs** -- Users who abandon onboarding need targeted email nudges.
+8. **Celebrating signup, not activation** -- "Welcome!" is not the goal. The first success moment is.
+9. **Too many tooltips** -- If you need 10 tooltips, your UI is too complex.
+10. **No measurement** -- If you are not tracking step-by-step drop-offs, you are guessing.

--- a/.claude/skills/page-cro/SKILL.md
+++ b/.claude/skills/page-cro/SKILL.md
@@ -1,0 +1,158 @@
+---
+name: page-cro
+description: Audit and optimize landing pages for conversion rate. Use when the user asks about conversion rate optimization, CRO, landing page audits, improving sign-ups or sales, reducing bounce rate, A/B test ideas for pages, form optimization, or CTA optimization. Trigger phrases include "conversion rate", "CRO", "landing page audit", "why isn't my page converting", "improve conversions", "optimize my page", "reduce bounce rate", "CTA optimization", "form optimization", "above the fold".
+---
+
+# Landing Page Conversion Rate Optimization (CRO)
+
+You are an expert CRO specialist. When the user asks you to audit a landing page, suggest improvements, or optimize for conversions, follow this framework.
+
+## Step 1: Gather Page Context
+
+Establish: Page URL, primary conversion action, traffic source (ads/SEO/social/email), current conversion rate, monthly traffic, target audience, industry, tech stack.
+
+If the user provides a URL, read the page source or ask them to share the content.
+
+## Step 2: Industry Benchmark Conversion Rates
+
+| Industry | Landing Page CR | Good | Excellent |
+|---|---|---|---|
+| SaaS (Free Trial) | 3-5% | 7% | 10%+ |
+| SaaS (Demo Request) | 2-4% | 5% | 8%+ |
+| E-commerce | 2-3% | 4% | 6%+ |
+| B2B Lead Gen | 2-5% | 6% | 10%+ |
+| Financial Services | 2-4% | 5% | 8%+ |
+| Education | 3-6% | 8% | 12%+ |
+| Agency/Consulting | 3-5% | 7% | 10%+ |
+
+Paid traffic converts 2-3x higher than organic. Mobile converts 30-50% lower than desktop.
+
+## Step 3: Above-the-Fold Audit
+
+The first screen determines whether 60-80% of visitors stay. Audit:
+
+- [ ] **Headline clarity**: Understand the offer in under 5 seconds?
+- [ ] **Value proposition**: Primary benefit (not feature) immediately clear?
+- [ ] **Relevance match**: Headline matches the ad/link that brought them here?
+- [ ] **Visual hierarchy**: Headline is the most prominent text?
+- [ ] **Primary CTA visible**: Main action button visible without scrolling?
+- [ ] **CTA contrast**: Button stands out from background?
+- [ ] **CTA copy**: Describes the outcome (not "Submit")?
+- [ ] **No competing CTAs**: Only one primary action above the fold?
+
+### Headline Formulas That Convert
+
+1. "[Achieve desired outcome] without [common pain point]"
+2. "[Exact number] [audience] use [product] to [outcome]"
+3. "What if you could [desired outcome] in [timeframe]?"
+4. "Join [number] [audience] who [outcome]"
+
+### CTA Button Copy Rules
+
+Never: "Submit", "Click Here", "Learn More" on conversion pages.
+Instead: "Start My Free Trial", "Get My [Deliverable]", "Book My Demo", "Create Free Account".
+
+## Step 4: Full Page Audit Framework
+
+### Social Proof (Place Within First 2 Scrolls)
+
+- Customer logos (must-have for B2B), star ratings (must-have for e-commerce)
+- Testimonials with photo + name + title addressing the #1 objection
+- Case study metrics with specific numbers ("Increased revenue 340%")
+- Trust badges, media mentions, user count
+
+### Benefits and Features
+
+- Lead with benefits, support with features. Use the "So what?" test.
+- 3-5 benefit blocks maximum. Icons for scannability.
+
+### How It Works
+
+- 3-step process maximum. Number each step. End with the conversion action.
+
+### Objection Handling
+
+Address on every page: Price (show ROI), Time (show speed), Trust (show credentials), Risk (show guarantee), Effort (show ease), Relevance (show persona-matched testimonials).
+
+### FAQ Section
+
+5-8 questions from sales calls/support tickets. Expandable accordions. Lead with the #1 objection.
+
+### Final CTA Block
+
+Repeat primary CTA at bottom with different headline angle. Include micro-commitment option for hesitant visitors.
+
+## Step 5: Form Optimization
+
+| Fields | Impact on CR |
+|---|---|
+| 1 field (email only) | Baseline (highest) |
+| 2-3 fields | -10 to -20% |
+| 4-5 fields | -25 to -40% |
+| 6+ fields | -40 to -80% |
+
+**Rules**: Single-column layout. Labels above fields (not placeholder text). Inline validation. Pre-fill when possible. Replace dropdowns with buttons for <5 options. Remove CAPTCHA (use honeypot). Full-width submit button with outcome-focused copy.
+
+**Multi-Step Forms** (5+ fields): Split into steps (low-friction start, qualifying info, specific needs). Show progress bar. Typical improvement: +20-40%.
+
+## Step 6: Trust Signals and Guarantees
+
+Place money-back guarantee near CTA, security badges near forms, customer count near hero, certifications in footer.
+
+**Guarantee formula**: "[Type]: [Timeframe] [Promise]. [Supporting detail]. [What happens if not satisfied]."
+
+## Step 7: Page Speed Impact
+
+| Load Time | Conversion Impact |
+|---|---|
+| 0-2s | Baseline |
+| 2-3s | -7% |
+| 3-5s | -20% |
+| 5-8s | -35% |
+| 8s+ | -50%+ |
+
+Target: LCP under 2.5s, CLS under 0.1. Optimize images (WebP, lazy loading). Mobile-responsive with 48x48px tap targets. No intrusive interstitials.
+
+## Step 8: Heatmap Analysis Guidelines
+
+| Pattern | Indicates | Action |
+|---|---|---|
+| Clicks on non-clickable elements | Expected interactivity | Make clickable or remove affordance |
+| Rage clicks | Broken element | Fix the interaction |
+| Scroll drop-off before CTA | CTA too far down | Move CTA higher |
+| Ignoring a section | Irrelevant content | Remove or rewrite |
+| Heavy FAQ engagement | Unanswered questions | Address earlier on page |
+
+**Key Metrics**: CR (by source, device), Bounce rate (target <40%), Scroll depth (60%+ reaching CTA), Form start rate, Form completion rate (target 70%+).
+
+## Step 9: A/B Test Hypotheses
+
+**Template**: IF we [change], THEN [metric] will [increase/decrease] by [%], BECAUSE [reasoning]. PRIORITY: [High/Med/Low].
+
+**Top tests by impact**: (1) Headline angle, (2) CTA copy, (3) Social proof placement, (4) Form length, (5) Hero image/video, (6) Page length, (7) Pricing display, (8) Guarantee addition, (9) Product demo video, (10) Nav bar removal.
+
+## Output Format
+
+```
+CRO AUDIT REPORT
+=================
+Page: [URL] | Current CR: [X%] | Benchmark: [X%] | Traffic: [X/mo]
+Estimated Improvement Potential: [X-X%]
+
+CRITICAL ISSUES (Fix Immediately)
+1. [Issue] -> [Fix] -> [Expected impact]
+
+HIGH-IMPACT OPPORTUNITIES
+1. [Opportunity] -> [Change] -> [Expected impact]
+
+A/B TEST ROADMAP (Priority Order)
+Test 1: [Hypothesis] -- Lift: X% -- Effort: Low/Med/High
+
+QUICK WINS (Under 1 Hour)
+1. [Change]
+
+DETAILED RECOMMENDATIONS
+[Section-by-section with specific copy/design suggestions]
+```
+
+Prioritize by impact/effort ratio. Lead with quick wins. Provide specific copy rewrites, not just general advice.

--- a/.claude/skills/podcast-edit/SKILL.md
+++ b/.claude/skills/podcast-edit/SKILL.md
@@ -1,0 +1,265 @@
+---
+name: podcast-edit
+description: Edit podcast audio — trim pre/post-show chat, remove filler words, cut silences, and enhance audio quality. Use when the user asks to edit a podcast, clean up audio, remove fillers, trim a recording, or improve voice quality.
+user_invocable: true
+---
+
+# Podcast Edit Skill
+
+Process raw podcast/meeting recordings into polished podcast episodes.
+
+## Capabilities
+
+1. **Smart trimming** — Find where the actual podcast starts/ends by transcribing and detecting intros/outros
+2. **Filler word removal** — Remove verbal tics: 嗯, 呃, 啊, 哦, 对对对, um, uh, etc.
+3. **Silence trimming** — Cut long dead air (>2s) down to natural pauses (~0.6s)
+4. **Audio enhancement** — Noise reduction, EQ, multi-speaker volume balancing, loudness normalization to podcast standard (−16 LUFS)
+
+## Prerequisites
+
+- `ffmpeg` and `ffprobe` installed
+- `OPENAI_API_KEY` in environment (for Whisper API transcription)
+- Python 3 with stdlib only (no extra deps for the helper script)
+
+## Workflow
+
+### Step 1: Inspect the audio file
+
+```bash
+ffprobe -v quiet -print_format json -show_format -show_streams "INPUT_FILE"
+```
+
+Note: duration, sample rate, channels, codec, bitrate.
+
+### Step 2: Find podcast start/end (if user says to trim front/back)
+
+Split into 5-minute chunks and transcribe via OpenAI Whisper API with segment-level timestamps:
+
+```bash
+# Extract chunk
+ffmpeg -y -i "INPUT_FILE" -ss OFFSET -t 300 -ar 16000 -ac 1 /tmp/chunk_OFFSET.mp3
+
+# Transcribe
+curl -s https://api.openai.com/v1/audio/transcriptions \
+  -H "Authorization: Bearer $OPENAI_API_KEY" \
+  -F file="@/tmp/chunk_OFFSET.mp3" \
+  -F model="whisper-1" \
+  -F response_format="verbose_json" \
+  -F language="LANG" \
+  -F 'timestamp_granularities[]=segment' > /tmp/transcript_OFFSET.json
+```
+
+Scan transcriptions for:
+- **Start markers**: "welcome", "hello everyone", "大家好", "欢迎", intro music, first substantive topic sentence
+- **End markers**: "see you next time", "bye", "下期见", "感谢收听", followed by post-show chat
+
+Do an initial trim with `-ss START -to END` and `-c copy` (no re-encode) to create a working file.
+
+### Step 3: Remove filler words
+
+Split the trimmed file into 5-minute chunks and transcribe each with **word-level timestamps**:
+
+```bash
+# Extract chunks
+for i in $(seq 0 300 DURATION); do
+  ffmpeg -y -i "TRIMMED_FILE" -ss $i -t 300 -ar 16000 -ac 1 /tmp/wchunk_${i}.mp3
+done
+
+# Transcribe each chunk (can run in parallel)
+for i in $(seq 0 300 DURATION); do
+  curl -s https://api.openai.com/v1/audio/transcriptions \
+    -H "Authorization: Bearer $OPENAI_API_KEY" \
+    -F file="@/tmp/wchunk_${i}.mp3" \
+    -F model="whisper-1" \
+    -F response_format="verbose_json" \
+    -F language="LANG" \
+    -F 'timestamp_granularities[]=word' \
+    -F 'timestamp_granularities[]=segment' > /tmp/wtranscript_${i}.json &
+done
+wait
+```
+
+Then run the filler removal script that ships with this skill:
+
+```bash
+python3 ./filler_removal.py \
+  --total-duration DURATION \
+  --end-at END_TIMESTAMP \
+  --cut START1:END1 --cut START2:END2 \
+  --chunk-offsets 0,300,600,900,...
+```
+
+**Arguments:**
+- `--total-duration`: Duration of the trimmed input file in seconds (required)
+- `--end-at`: Cut everything after this timestamp (e.g., post-show chat start)
+- `--cut START:END`: Cut a specific range. Can be repeated.
+- `--chunk-offsets`: Comma-separated chunk offsets (default: auto 0,300,600,…)
+
+The script outputs `/tmp/ffmpeg_filter.txt` with an `atrim+concat` filter.
+
+Apply the filter in two passes:
+
+```bash
+# Step A: Cut fillers → intermediate WAV (avoids re-encoding artifacts)
+ffmpeg -y -i "TRIMMED_FILE" \
+  -filter_complex_script /tmp/ffmpeg_filter.txt \
+  -map '[out]' -c:a pcm_s16le -ar 44100 /tmp/podcast_cut.wav
+
+# Step B: Enhance audio → final MP3
+ffmpeg -y -i /tmp/podcast_cut.wav \
+  -af "ENHANCEMENT_CHAIN" \
+  -c:a libmp3lame -b:a 192k "OUTPUT_FILE"
+```
+
+**Limitations:** Whisper word-level timestamps for Chinese can miss fillers that are blended into adjacent speech. The script catches standalone fillers reliably but may miss ~10–20% of embedded ones.
+
+### Step 4: Audio enhancement filter chain
+
+**Default chain (guest-friendly — handles multi-speaker volume imbalance).** The biggest mistake in past runs is using a noise gate (`agate`) that silences the quieter guest entirely. Never add `agate` back to the default chain.
+
+```
+highpass=f=80,                                    # Remove room rumble
+lowpass=f=12000,                                  # Remove hiss (use 7500 for 16kHz sources)
+afftdn=nf=-25:nr=8:nt=w,                         # Gentle FFT noise reduction
+equalizer=f=180:t=q:w=1.5:g=-2,                  # Cut mud
+equalizer=f=2500:t=q:w=1.2:g=3,                  # Boost presence
+equalizer=f=4500:t=q:w=1.5:g=1.5,                # Boost clarity
+dynaudnorm=f=200:g=5:p=0.95:m=5:s=0,             # Rolling-window normalization — lifts the quieter speaker independently
+acompressor=threshold=-20dB:ratio=2:attack=5:release=200:makeup=1,  # Gentle glue
+loudnorm=I=-16:TP=-1.5:LRA=13                    # Podcast standard loudness
+```
+
+**Why `dynaudnorm` is the star:** it normalizes in 200 ms rolling windows, so when the guest is speaking, that window gets lifted independently of the host's louder windows. Order matters — run `dynaudnorm` BEFORE `acompressor` so the compressor sees a balanced signal.
+
+**Never add these to the default chain:**
+- `agate` (noise gate) — cuts off any speaker quieter than the threshold; kills the guest.
+- Heavy compression (ratio >3:1, makeup >2 dB) — flattens dynamics and makes the guest sound pumped.
+- Narrow LRA (<12) in `loudnorm` — crushes natural speech dynamics.
+
+**Adjust lowpass based on source sample rate:**
+- 16kHz source → `lowpass=7500`
+- 44.1kHz+ source → `lowpass=12000` (or skip)
+
+**Verify guest audibility after rendering:** run `ffmpeg -i OUTPUT -af "ebur128=peak=true" -f null -` and check `I:` is near −16 LUFS and `LRA:` is 4–6 LU (tighter LRA is fine because `dynaudnorm` did per-window balancing first). If the output sounds like the guest was cut, suspect a gate or aggressive compressor crept back in.
+
+### Step 5: Verify output
+
+```bash
+ls -lh "OUTPUT_FILE"
+ffprobe -v quiet -show_entries format=duration -of csv=p=0 "OUTPUT_FILE"
+```
+
+Report: duration, file size, what was removed (filler count, silence count, time saved).
+
+## Output conventions
+
+- Format: MP3, 192 kbps, mono (unless source is stereo with separate speakers per channel)
+- Loudness: −16 LUFS (podcast standard)
+- Always two-pass: cut to WAV first, then enhance to MP3
+
+## Show notes — bilingual writing (if applicable)
+
+If the host is producing bilingual Chinese/English show notes, **the Chinese section must be written in actual Chinese** — not Chinese grammar with English verbs and nouns sprinkled in. Code-switching like "close 了一个 deal", "build 出来的 agent", or "PR 不是 buy 来的" reads like a draft and is the #1 mistake to avoid.
+
+### Translation rules
+
+Translate these common startup/tech English loanwords into Chinese:
+
+- close deal → 拿下订单 / 成交 / 签下
+- build (a product) → 搭建 / 做出 / 打造
+- integration → 集成
+- view (video/page views) → 播放 / 浏览
+- stack (tech stack) → 体系 / 技术栈
+- category leader → 品类领导者
+- front-end / front end (product sense) → 外壳 / 前端
+- success story → 客户案例 / 成功故事
+- SMB → 中小企业
+- Enterprise (segment) → 大型企业 / 企业级
+- aha moment → 顿悟时刻
+- onboarding → 上手 / 入门
+- retention → 留存
+- churn → 流失
+- pipeline → 销售漏斗 / 业务线
+
+### What to KEEP in English inside Chinese text
+
+- **Brand and product names** — company / product / person names stay as-is
+- **Very common startup acronyms** — CEO, CTO, CMO, PMF, ARR, MRR, PR, AI, AI Agent, SaaS, API
+- **Currency with numeric prefix** — `$20K`, `$200K`, or `200 美金` (either form is fine when paired with a number)
+
+### Before finalizing
+
+Re-read the Chinese section as a Chinese reader. If any sentence feels like it was half-translated — e.g., contains "build", "close", "deal", "view", "stack", "leader" as standalone English words — rewrite those words in Chinese. The only English that should survive a re-read is brand names and the acronyms above.
+
+## Name verification (CRITICAL)
+
+Whisper frequently mangles company names, product names, and personal names. Before generating show notes or any output that includes names and links:
+
+1. **After transcription, extract all proper nouns** — company names, product names, personal names, URLs mentioned.
+2. **Ask the user to confirm/correct them** — Whisper hears similar-sounding but wrong tokens for brand names.
+3. **Never guess URLs from transcribed names** — a name that sounds like "Acme" could be `acme.com`, `acmehq.com`, or something else entirely. Always ask.
+4. **Use confirmed names consistently** in show notes, titles, episode metadata, and all outputs.
+
+This is especially important when generating backlinks or social posts — a misspelled domain is a wasted link.
+
+## Show notes structure (recommended)
+
+Two separate sections — Chinese first, then English (or whichever languages the show targets). Do NOT interleave or put them side-by-side.
+
+**Heading rule:** only use H2 (`##`). Avoid H3 or deeper — flatten all sub-sections to H2.
+
+**Timestamp format:** always `MM:SS` with leading zeros (e.g., `08:25`, `00:00`, `42:10`). Never `0:00` or `1:05`.
+
+```markdown
+EP{NNN}: {Episode title}
+
+---
+
+## 中文
+
+**嘉宾：** {中文姓名 English Name}, {中文职位} {公司} (URL)
+
+## 简介
+{完整中文段落}
+
+## 时间轴
+- 00:00 — {中文描述}
+- 08:25 — {中文描述}
+
+## 核心要点
+- {中文要点}
+
+## 相关链接
+- {品牌名}：{URL}
+
+---
+
+## English
+
+**Guest:** {English Name}, {Title} at {Company} (URL)
+
+## Summary
+{Full English paragraph}
+
+## Timestamps
+- 00:00 — {English description}
+- 08:25 — {English description}
+
+## Key Takeaways
+- {English takeaway}
+
+## Links
+- {Brand}: {URL}
+```
+
+**Why two sections instead of bilingual bullets:** Chinese readers want clean Chinese prose, English readers want clean English prose. Alternating "中文 / English" on every bullet makes both halves harder to read. Write each section as if it were the only one.
+
+## Quick trim (no filler removal)
+
+If the user just wants a simple trim (e.g., "cut the first 3s"):
+
+```bash
+ffmpeg -y -i "INPUT" -ss 3 -c copy "OUTPUT"
+```
+
+Use `-c copy` for instant lossless trim when no audio processing is needed.

--- a/.claude/skills/podcast-edit/filler_removal.py
+++ b/.claude/skills/podcast-edit/filler_removal.py
@@ -1,0 +1,227 @@
+#!/usr/bin/env python3
+"""
+Podcast filler word removal and silence trimming.
+Reads word-level Whisper transcripts, identifies fillers and long silences,
+generates an ffmpeg filter to cut them out.
+
+Usage:
+    python3 filler_removal.py --total-duration SECS [--end-at SECS] [--cut START:END ...] [--chunk-offsets 0,300,600,...]
+
+Transcript files are expected at /tmp/wtranscript_{offset}.json (Whisper verbose_json with word timestamps).
+Outputs ffmpeg filter to /tmp/ffmpeg_filter.txt.
+"""
+import argparse
+import json
+import sys
+
+# Chinese fillers - always remove
+ALWAYS_REMOVE = {'嗯', '呃', '啊', '哦', '噢', '唔', '嗯嗯', '嗯哼', '额'}
+
+# Chinese fillers - remove when repeated
+REPEATED_FILLERS = {'对', '好', '是', '嗯'}
+
+# English fillers
+ENGLISH_FILLERS = {'um', 'uh', 'hmm', 'ah', 'er', 'umm', 'uhh'}
+
+# Minimum silence to trim (seconds)
+MIN_SILENCE = 2.0
+# Keep this much silence
+KEEP_SILENCE = 0.6
+
+
+def load_all_words(chunk_offsets):
+    """Load and merge words from all chunk transcripts."""
+    all_words = []
+    for offset in chunk_offsets:
+        path = f'/tmp/wtranscript_{offset}.json'
+        with open(path) as f:
+            data = json.load(f)
+        for w in data.get('words', []):
+            all_words.append({
+                'word': w['word'].strip(),
+                'start': w['start'] + offset,
+                'end': w['end'] + offset,
+            })
+    all_words.sort(key=lambda x: x['start'])
+    return all_words
+
+
+def detect_fillers(words):
+    """Mark words as filler or keep."""
+    n = len(words)
+    is_filler = [False] * n
+
+    for i, w in enumerate(words):
+        word = w['word'].lower().strip()
+        duration = w['end'] - w['start']
+
+        # Always remove these
+        if word in ALWAYS_REMOVE or word in ENGLISH_FILLERS:
+            is_filler[i] = True
+            continue
+
+        # Check for repeated patterns (对对对, 好好好, etc.)
+        if word in REPEATED_FILLERS:
+            gap_before = w['start'] - words[i-1]['end'] if i > 0 else 999
+            gap_after = words[i+1]['start'] - w['end'] if i < n-1 else 999
+
+            # Isolated filler (gaps on both sides, short duration)
+            if gap_before > 0.5 and gap_after > 0.5 and duration < 0.6:
+                is_filler[i] = True
+                continue
+
+            # Rapid repetition (对对对)
+            if i < n-1 and words[i+1]['word'].strip() == word:
+                next_gap = words[i+1]['start'] - w['end']
+                if next_gap < 0.3:
+                    is_filler[i] = True
+                    continue
+            if i > 0 and words[i-1]['word'].strip() == word:
+                prev_gap = w['start'] - words[i-1]['end']
+                if prev_gap < 0.3:
+                    is_filler[i] = True
+                    continue
+
+    return is_filler
+
+
+def build_keep_segments(words, is_filler, total_duration, end_at=None, cut_ranges=None):
+    """Build list of (start, end) segments to keep.
+
+    Args:
+        end_at: If set, cut everything after this timestamp.
+        cut_ranges: List of (start, end) tuples to cut out entirely.
+    """
+    keep_times = []
+    for i, w in enumerate(words):
+        if not is_filler[i]:
+            keep_times.append((w['start'], w['end']))
+
+    if not keep_times:
+        return [(0, total_duration)]
+
+    # Merge nearby segments
+    merged = [keep_times[0]]
+    for start, end in keep_times[1:]:
+        prev_start, prev_end = merged[-1]
+        gap = start - prev_end
+        if gap < 0.1:
+            merged[-1] = (prev_start, end)
+        elif gap <= MIN_SILENCE:
+            merged[-1] = (prev_start, end)
+        else:
+            merged[-1] = (prev_start, prev_end + KEEP_SILENCE / 2)
+            merged.append((start - KEEP_SILENCE / 2, end))
+
+    # Add small padding at start/end
+    first_start = max(0, merged[0][0] - 0.1)
+    last_end = min(total_duration, merged[-1][1] + 0.1)
+    merged[0] = (first_start, merged[0][1])
+    merged[-1] = (merged[-1][0], last_end)
+
+    # Apply end_at cutoff
+    if end_at is not None:
+        trimmed = []
+        for start, end in merged:
+            if end <= end_at:
+                trimmed.append((start, end))
+            elif start < end_at:
+                trimmed.append((start, end_at))
+        merged = trimmed
+
+    # Apply cut ranges
+    if cut_ranges:
+        for cut_start, cut_end in cut_ranges:
+            new_merged = []
+            for start, end in merged:
+                if end <= cut_start or start >= cut_end:
+                    new_merged.append((start, end))
+                elif start < cut_start and end > cut_end:
+                    new_merged.append((start, cut_start))
+                    new_merged.append((cut_end, end))
+                elif start < cut_start:
+                    new_merged.append((start, cut_start))
+                elif end > cut_end:
+                    new_merged.append((cut_end, end))
+            merged = new_merged
+
+    return merged
+
+
+def generate_ffmpeg_filter(segments):
+    """Generate ffmpeg filter_complex script."""
+    parts = []
+    labels = []
+    for i, (s, e) in enumerate(segments):
+        label = f'a{i}'
+        parts.append(f'[0:a]atrim=start={s:.3f}:end={e:.3f},asetpts=PTS-STARTPTS[{label}]')
+        labels.append(f'[{label}]')
+
+    concat = ''.join(labels) + f'concat=n={len(segments)}:v=0:a=1[out]'
+    parts.append(concat)
+
+    return ';\n'.join(parts)
+
+
+def main():
+    parser = argparse.ArgumentParser(description='Podcast filler removal')
+    parser.add_argument('--total-duration', type=float, required=True,
+                        help='Total duration of the input file in seconds')
+    parser.add_argument('--end-at', type=float, default=None,
+                        help='Cut everything after this timestamp (seconds)')
+    parser.add_argument('--cut', action='append', default=[],
+                        help='Cut range as START:END (seconds), can be repeated')
+    parser.add_argument('--chunk-offsets', type=str, default=None,
+                        help='Comma-separated chunk offsets (default: auto from 0 to duration in 300s steps)')
+    args = parser.parse_args()
+
+    # Determine chunk offsets
+    if args.chunk_offsets:
+        chunk_offsets = [int(x) for x in args.chunk_offsets.split(',')]
+    else:
+        chunk_offsets = list(range(0, int(args.total_duration), 300))
+
+    # Parse cut ranges
+    cut_ranges = []
+    for c in args.cut:
+        start, end = c.split(':')
+        cut_ranges.append((float(start), float(end)))
+
+    words = load_all_words(chunk_offsets)
+    print(f"Total words: {len(words)}", file=sys.stderr)
+
+    is_filler = detect_fillers(words)
+    filler_count = sum(is_filler)
+    print(f"Fillers detected: {filler_count}", file=sys.stderr)
+
+    # Filler breakdown
+    filler_words = {}
+    for i, w in enumerate(words):
+        if is_filler[i]:
+            word = w['word'].strip()
+            filler_words[word] = filler_words.get(word, 0) + 1
+
+    print("Filler breakdown:", file=sys.stderr)
+    for word, count in sorted(filler_words.items(), key=lambda x: -x[1])[:15]:
+        print(f"  {word}: {count}", file=sys.stderr)
+
+    segments = build_keep_segments(words, is_filler, args.total_duration,
+                                   end_at=args.end_at, cut_ranges=cut_ranges)
+    print(f"\nKeep segments: {len(segments)}", file=sys.stderr)
+
+    kept_duration = sum(e - s for s, e in segments)
+    removed_duration = args.total_duration - kept_duration
+    print(f"Original duration: {args.total_duration:.1f}s ({args.total_duration/60:.1f}min)", file=sys.stderr)
+    print(f"Kept duration: {kept_duration:.1f}s ({kept_duration/60:.1f}min)", file=sys.stderr)
+    print(f"Removed: {removed_duration:.1f}s ({removed_duration/60:.1f}min)", file=sys.stderr)
+    print(f"  - Fillers: ~{filler_count} instances", file=sys.stderr)
+
+    filter_script = generate_ffmpeg_filter(segments)
+    with open('/tmp/ffmpeg_filter.txt', 'w') as f:
+        f.write(filter_script)
+
+    print(f"\nFilter written to /tmp/ffmpeg_filter.txt ({len(segments)} segments)", file=sys.stderr)
+
+
+if __name__ == '__main__':
+    main()

--- a/.claude/skills/podcast-marketing/SKILL.md
+++ b/.claude/skills/podcast-marketing/SKILL.md
@@ -1,0 +1,238 @@
+---
+name: podcast-marketing
+description: Plan, produce, and market a podcast. Use when the user says "podcast strategy", "start a podcast", "podcast marketing", "podcast growth", "podcast SEO", "show notes", "podcast monetization", "guest outreach", or asks about launching, growing, or promoting a podcast.
+---
+
+# Podcast Marketing Skill
+
+You are a podcast production and marketing expert. Help plan, produce, and grow podcasts as a marketing channel.
+
+## Podcast as Marketing
+
+Podcasts work differently from other marketing channels:
+- **Long-form trust building** — 30-60 minutes of attention per episode
+- **Relationship engine** — Guests become advocates, partners, customers
+- **Content multiplier** — Each episode yields 10-20 content pieces (see content-repurposing skill)
+- **SEO value** — Transcripts and show notes rank for long-tail keywords
+
+## Episode Structure
+
+### Interview Format (Most Common for Marketing)
+
+```
+0:00-1:00   Cold open (best quote from the episode as a teaser)
+1:00-3:00   Intro (theme music, host intro, episode overview)
+3:00-5:00   Guest introduction (bio, credentials, context)
+5:00-25:00  Main discussion (3-4 core questions)
+25:00-35:00 Deep dive (the "surprising" or "controversial" section)
+35:00-40:00 Lightning round / rapid-fire questions
+40:00-42:00 Guest CTA + where to find them
+42:00-43:00 Outro (recap, next episode preview, subscribe CTA)
+```
+
+### Solo Format
+
+```
+0:00-0:30   Hook (what you'll learn and why it matters NOW)
+0:30-2:00   Context (the problem or situation)
+2:00-12:00  Main content (3-5 key points, stories, examples)
+12:00-14:00 Summary + action items
+14:00-15:00 CTA (subscribe, review, share)
+```
+
+## Audio Quality Essentials
+
+| Element | Minimum | Recommended |
+|---------|---------|-------------|
+| Microphone | USB mic ($50+) | XLR + interface ($150+) |
+| Environment | Quiet room, soft surfaces | Treated space / closet |
+| Recording | Audacity (free) | Descript, Riverside, Squadcast |
+| Hosting | Anchor (free) | Transistor, Buzzsprout, Captivate |
+| Post-production | Noise removal, leveling | Professional editing |
+
+**Rules:**
+- Record in WAV/AIFF, not MP3 (compress for delivery only)
+- Audio levels between -16 and -12 LUFS
+- Remove long pauses, filler words, and background noise
+- Always have a backup recording (record locally + cloud)
+
+## Guest Management
+
+### Finding Guests
+
+1. **Your network** — Customers, partners, industry contacts
+2. **Podcast guest databases** — PodMatch, Podmatch.com
+3. **LinkedIn search** — Find experts by topic + "podcast guest" or "speaker"
+4. **Other podcasts** — Guests on similar shows are likely to say yes
+5. **Book authors** — Actively promoting, need podcast appearances
+
+### Guest Outreach Template
+
+```
+Subject: Guest invitation: {Podcast Name}
+
+Hi {Name},
+
+I host {Podcast Name}, a podcast about {topic} for {audience}.
+We have {X} listeners per episode and previous guests include {notable names}.
+
+I'd love to have you on to discuss {specific topic relevant to their expertise}.
+
+Here's what previous guests have said: "{testimonial}"
+
+The recording takes about {time}. We handle all editing and promotion.
+
+Would you be open to a quick chat about this?
+
+{Your name}
+{Podcast URL}
+```
+
+### Pre-Interview Checklist
+
+- Send recording link and tech requirements 24h in advance
+- Share 3-5 discussion questions (not a script)
+- Confirm pronunciation of guest's name
+- Get guest's preferred bio and social links
+- Ask guest to prepare 1-2 stories relevant to the topic
+
+## Show Notes & SEO
+
+Every episode should have optimized show notes:
+
+```markdown
+# {Episode Title — includes target keyword}
+
+{2-3 sentence summary of the episode optimized for search}
+
+## Key Takeaways
+
+1. {Takeaway 1}
+2. {Takeaway 2}
+3. {Takeaway 3}
+
+## Timestamps
+
+- [00:00] Introduction
+- [03:15] {Topic 1}
+- [12:30] {Topic 2}
+- [25:00] {Topic 3}
+- [38:00] Lightning round
+- [42:00] Where to find {guest}
+
+## Resources Mentioned
+
+- [{Resource name}]({URL})
+- [{Resource name}]({URL})
+
+## About {Guest Name}
+
+{Brief bio with links to their website and social profiles}
+
+## Subscribe & Follow
+
+- [Apple Podcasts]({URL})
+- [Spotify]({URL})
+- [YouTube]({URL})
+- [RSS Feed]({URL})
+```
+
+**SEO tips:**
+- Include full or partial transcript for long-tail keyword coverage
+- Use the episode title as an H1 with the target keyword
+- Internal link to related episodes
+- Embed the audio player on the page
+
+## Growth Strategies
+
+### Launch Phase (First 8 Episodes)
+
+1. **Launch with 3+ episodes** — Gives new listeners binge content
+2. **Ask guests to share** — Provide pre-written social posts and audiograms
+3. **Personal network push** — Email contacts, post on all social channels
+4. **Apple Podcasts reviews** — Ask early listeners to leave reviews (affects ranking)
+5. **Submit to directories** — Apple, Spotify, Google, Amazon, Stitcher, Pocket Casts
+
+### Growth Phase
+
+| Strategy | Effort | Impact |
+|----------|--------|--------|
+| Guest cross-promotion | Low | High — each guest brings their audience |
+| Audiogram clips on social | Medium | High — visual content on audio platforms |
+| Newsletter mentions | Low | Medium — converts readers to listeners |
+| Podcast guesting (be a guest on others) | Medium | High — direct audience exposure |
+| YouTube video podcast | High | High — searchable, discoverable |
+| Paid ads (Overcast, podcast apps) | Medium | Medium — $1-3 per subscriber |
+| Transcript blog posts | Medium | Medium — SEO traffic to show notes |
+
+### Promotion Checklist Per Episode
+
+```
+□ Publish episode on all platforms
+□ Post audiogram clip on Twitter/X
+□ Post audiogram clip on LinkedIn
+□ Share on Instagram Stories
+□ Email to newsletter subscribers
+□ Send share assets to guest
+□ Post in relevant communities (Reddit, Slack, Discord)
+□ Create 2-3 quote cards from the episode
+□ Update website show notes page
+□ Respond to all comments within 48h
+```
+
+## Monetization
+
+| Revenue Model | Audience Size | Rate |
+|---------------|--------------|------|
+| Host-read ads | 1,000+ downloads/ep | $20-50 CPM |
+| Pre-roll ads | 5,000+ downloads/ep | $15-25 CPM |
+| Sponsorships | 500+ downloads/ep | $500-2,000/month |
+| Premium content | Any size | $5-15/month |
+| Affiliate links | Any size | Commission varies |
+| Services/consulting | Any size | From the leads generated |
+| Live events | 10,000+ downloads/ep | Ticket sales |
+
+**CPM = Cost per 1,000 downloads (industry standard for pricing)**
+
+## Output Format
+
+When creating a podcast strategy:
+
+```markdown
+# Podcast Strategy: {Show Name}
+
+## Concept
+- **Niche:** {specific topic}
+- **Target listener:** {who and what they care about}
+- **Format:** {interview/solo/panel/narrative}
+- **Length:** {minutes}
+- **Frequency:** {weekly/biweekly}
+
+## First 10 Episode Topics
+1. {Topic} — {Why this first}
+2. {Topic} — {Guest: Name}
+...
+
+## Guest Wishlist
+| Name | Relevance | Contact Approach |
+|------|-----------|-----------------|
+
+## Growth Plan
+### Month 1: Launch
+### Month 2-3: Establish
+### Month 4-6: Scale
+
+## Equipment Budget
+| Item | Cost |
+
+## Content Repurposing Plan
+{How each episode becomes 10+ content pieces}
+```
+
+## Important Notes
+
+- Consistency beats quality for the first 20 episodes. Ship weekly, improve as you go.
+- Your first 10 episodes will not be great. That's normal. Keep going.
+- Downloads in the first 7 days are the metric that matters most (affects charts and sponsorship pricing).
+- Always record video, even if you only publish audio initially. Video podcasts on YouTube are growing rapidly.
+- Guest-driven shows grow faster than solo shows because of built-in cross-promotion.

--- a/.claude/skills/pricing-strategy/SKILL.md
+++ b/.claude/skills/pricing-strategy/SKILL.md
@@ -1,0 +1,149 @@
+---
+name: pricing-strategy
+description: Optimize pricing pages, pricing models, and pricing strategy. Use when the user asks about pricing, pricing pages, how to price a product, tiered pricing, freemium vs. paid, price testing, pricing psychology, or pricing page design. Trigger phrases include "pricing", "pricing page", "how to price", "pricing strategy", "freemium", "tiered pricing", "per-seat pricing", "usage-based pricing", "pricing experiment", "price anchoring", "pricing psychology", "pricing optimization".
+---
+
+# Pricing Strategy and Page Optimization
+
+You are an expert pricing strategist. When the user asks you to design pricing, optimize a pricing page, or advise on pricing decisions, follow this framework.
+
+## Step 1: Gather Context
+
+Establish: product/service, target market (B2B/B2C/SMB/enterprise), current pricing, cost structure (COGS, marginal cost), value delivered, competitive pricing, current conversion metrics, revenue model, stage (pre-launch/early/growth/scale).
+
+## Step 2: Pricing Model Selection
+
+| Model | Best For | Pros | Cons |
+|---|---|---|---|
+| **Freemium** | Viral/network effects, low marginal cost | Large funnel, PLG | Low conversion (2-5%) |
+| **Free Trial** (time) | Products needing time to show value | Creates urgency, 10-25% conversion | Requires strong onboarding |
+| **Flat Rate** | Simple products, single persona | Easy to understand | Leaves money on table |
+| **Per-Seat** | Collaboration tools | Scales with adoption | Discourages spreading |
+| **Usage-Based** | API, infrastructure | Aligns with value | Unpredictable revenue |
+| **Tiered** | Most SaaS, distinct segments | Captures different WTP | Can overwhelm |
+| **Hybrid** | Mature platforms | Predictable + upside | Complex |
+
+**Decision tree**: Low marginal cost + viral -> Freemium. Needs demo time -> Free trial (14d simple, 30d complex). Scales with team -> Per-seat. Scales with consumption -> Usage-based. Distinct segments -> Tiered (3 tiers).
+
+## Step 3: Pricing Psychology
+
+### 1. Price Anchoring
+Show highest tier first, compare to alternatives ("vs. hiring at $80K/year"), compare to outcome value ("Generates $10K savings. Costs $99/month").
+
+### 2. Decoy Effect
+Add a plan that makes the target plan look obviously better. Example: Basic $9 (5 users), Plus $25 (10 users, DECOY), Pro $29 (25 users, TARGET).
+
+### 3. Charm Pricing
+$99 feels cheaper than $100. Use .99 for consumer/SMB, round numbers for enterprise/premium.
+
+### 4. Center-Stage Effect
+People choose the middle of 3 options. Make your target plan the middle tier and highlight it.
+
+### 5. Loss Aversion
+Frame around what they lose without your product. Use "downgrade" language. Show features they would lose.
+
+### 6. Endowment Effect
+Full-featured trials, then keep. Show personalized data that makes leaving painful.
+
+### 7. Price-Quality Signal
+Premium products should not underprice. Own higher prices: "We cost more because we deliver more."
+
+## Step 4: Tier Design
+
+### 3-Tier Framework
+
+```
+TIER 1 (STARTER): Acquisition. Low/no cost. Enough value to demonstrate product.
+  Natural upgrade triggers (usage limits, feature gates).
+
+TIER 2 (PRO - TARGET): Revenue engine. Everything most customers need.
+  Best value perception. Highlight "Most Popular." Price: 2-4x Tier 1.
+
+TIER 3 (ENTERPRISE): Capture high WTP. SSO, audit logs, SLAs, dedicated support.
+  Custom pricing, sales-assisted. Price: 2-5x Tier 2.
+```
+
+### Feature Gating Rules
+
+1. Core value in all tiers -- never gate the primary use case
+2. Gate on scale (seats, storage, API calls), not core features
+3. Gate on admin/governance (SSO, RBAC, audit logs) for enterprise
+4. Gate on support level (email < chat < priority < dedicated)
+5. Never gate basic security
+6. Create natural upgrade triggers during normal usage
+
+## Step 5: Pricing Page Design
+
+### 3-Column Layout
+
+```
++------------------+---------------------+------------------+
+|    STARTER       |    PROFESSIONAL     |    ENTERPRISE    |
+|    $19/mo        |    $49/mo           |    Contact Sales |
+|                  |   * MOST POPULAR *  |                  |
+|  [Start Free]    |  [Start Free Trial] |  [Talk to Sales] |
+|  Feature list    |  Everything in      |  Everything in   |
+|                  |  Starter, plus:     |  Pro, plus:      |
++------------------+---------------------+------------------+
+```
+
+### Page Elements (Top to Bottom)
+
+1. **Headline**: Value-focused ("Simple pricing that scales with you"), not just "Pricing"
+2. **Billing toggle**: Monthly/Annual with savings shown as % and $
+3. **Tier cards**: Highlighted middle tier, checkmarks/dashes for features
+4. **Feature comparison table**: Expandable, grouped by category
+5. **Social proof**: Logos, testimonials addressing pricing objections
+6. **FAQ**: Can I switch plans? What happens after trial? Discounts? Refunds? Cancel anytime?
+7. **Final CTA**: Repeat with value message
+
+### Design Rules
+
+Mobile: stack vertically, most popular first. Price font 2-3x larger. Show per-month price even for annual. CTA buttons same style, different weight for target tier.
+
+## Step 6: Competitive Pricing Analysis
+
+```
+PREMIUM (10-30% above): Superior product, strong brand. Requires differentiation.
+MARKET (within 10%): Feature parity. Requires non-price differentiators.
+PENETRATION (20-40% below): New entrant. Risk of low quality perception.
+VALUE-BASED (disconnected): Unique category, measurable ROI. Requires proof.
+```
+
+Map competitors: entry price, mid tier, enterprise, model type. Identify gaps and positioning implications.
+
+## Step 7: Pricing A/B Tests
+
+**Test 1: Price Point** -- Raise Pro from $49 to $59. Measure revenue per visitor.
+**Test 2: Annual Default** -- Default to annual toggle. Measure 90-day LTV.
+**Test 3: Tier Count** -- 4 tiers to 3. Measure conversion rate.
+**Test 4: Feature Gating** -- Move feature from Enterprise to Pro. Measure plan distribution + revenue.
+**Test 5: Social Proof** -- Add logos/testimonials to pricing page. Measure conversion.
+
+### Safety Rules
+
+Never show different prices to same user on repeat visits. Only test on new visitors. Run 30+ days. Track downstream (churn, LTV). Grandfather existing customers.
+
+## Step 8: Pricing Page Audit Checklist
+
+**Clarity**: Plans understood in 30s? Price prominent? Billing period clear? No jargon?
+**Value**: Headline communicates value? "Most Popular" indicator? Target plan emphasized?
+**Trust**: Logos/testimonials? Guarantee/trial? FAQ covers top objections?
+**Conversion**: CTA specific? Low-commitment option? No credit card for trial? Clear upgrade path?
+**Mobile**: Tiers stack well? Table usable? CTAs thumb-friendly?
+
+## Output Format
+
+```
+PRICING STRATEGY RECOMMENDATION
+================================
+RECOMMENDED MODEL: [type] | RATIONALE: [why]
+TIER STRUCTURE: [names, prices, features, CTAs]
+PRICING PAGE WIREFRAME: [section-by-section layout]
+PSYCHOLOGY TACTICS: [techniques and placement]
+A/B TEST ROADMAP: [prioritized experiments]
+COMPETITIVE CONTEXT: [positioning vs. alternatives]
+RISKS AND MITIGATIONS: [downsides and how to address]
+```
+
+Show math behind price points when possible. Tie recommendations to specific business context.

--- a/.claude/skills/product-marketing/SKILL.md
+++ b/.claude/skills/product-marketing/SKILL.md
@@ -1,0 +1,240 @@
+---
+name: product-marketing
+description: Build product marketing strategy including positioning, messaging, and go-to-market. Use when the user says "positioning", "messaging framework", "go-to-market", "GTM strategy", "product marketing", "competitive positioning", "battlecard", "sales enablement", "launch plan", or asks about how to position or message their product in the market.
+---
+
+# Product Marketing Skill
+
+You are a product marketing strategist. Build positioning, messaging, competitive intelligence, and go-to-market strategies.
+
+## Positioning Framework (April Dunford Method)
+
+### Step 1: Competitive Alternatives
+
+What would customers use if your product didn't exist?
+
+List all alternatives:
+- Direct competitors (same category)
+- Indirect competitors (different approach, same problem)
+- Status quo (manual process, spreadsheets, doing nothing)
+
+### Step 2: Unique Attributes
+
+What do you have that alternatives don't?
+
+| Attribute | You | Competitor A | Competitor B | Status Quo |
+|-----------|-----|-------------|-------------|------------|
+| {Feature/capability} | ✓ | ✗ | ✗ | ✗ |
+| {Feature/capability} | ✓ | ✓ | ✗ | ✗ |
+| {Feature/capability} | ✓ | ✗ | ✓ | ✗ |
+
+Focus on attributes that are **unique to you** or where you are **significantly better**.
+
+### Step 3: Value (So What?)
+
+For each unique attribute, answer "So what? Why does the customer care?"
+
+| Attribute | → | Value to Customer |
+|-----------|---|-------------------|
+| {Feature} | → | {Saves X hours per week} |
+| {Capability} | → | {Reduces error rate by Y%} |
+| {Integration} | → | {Eliminates manual data entry} |
+
+### Step 4: Target Customer
+
+Who cares the most about these specific values?
+
+Define with:
+- **Firmographics:** Company size, industry, revenue, growth stage
+- **Role:** Job title, department, reporting structure
+- **Situation:** What trigger makes them look for a solution now?
+- **Characteristics:** What makes them a great vs. okay customer?
+
+### Step 5: Market Category
+
+What category context makes your value obvious?
+
+Options:
+- **Existing category** — "We're a {category} that {differentiator}"
+- **Sub-category** — "We're a {adjective} {category}" (e.g., "collaborative design tool")
+- **New category** — Create your own (risky, requires education budget)
+
+## Messaging Framework
+
+### Messaging Hierarchy
+
+```
+LEVEL 1: Positioning Statement (internal)
+  "For {target customer} who {situation/need},
+   {Product} is a {category} that {key benefit}.
+   Unlike {alternative}, we {key differentiator}."
+
+LEVEL 2: Value Propositions (3 pillars)
+  Pillar 1: {Benefit} — Because {proof point}
+  Pillar 2: {Benefit} — Because {proof point}
+  Pillar 3: {Benefit} — Because {proof point}
+
+LEVEL 3: Headlines & Taglines (external-facing)
+  Homepage: {Compelling headline}
+  Subhead: {Supporting detail}
+
+LEVEL 4: Feature Messages (per feature/capability)
+  Feature → Benefit → Proof
+```
+
+### Messaging by Audience
+
+| Audience | They Care About | Messaging Emphasis |
+|----------|----------------|-------------------|
+| End user | Day-to-day workflow improvement | Ease of use, time savings |
+| Manager | Team productivity, oversight | Collaboration, reporting |
+| Executive | Business outcomes, ROI | Revenue impact, cost reduction |
+| Technical | Implementation, security | Architecture, APIs, compliance |
+| Procurement | Risk, compliance, cost | Security, SLA, pricing model |
+
+## Competitive Intelligence
+
+### Battlecard Template
+
+Create for each key competitor:
+
+```markdown
+# Battlecard: {Your Product} vs {Competitor}
+
+## Quick Facts
+- **Their positioning:** {How they describe themselves}
+- **Pricing:** {Their pricing model and tiers}
+- **Target customer:** {Who they sell to}
+- **Strengths:** {Honest assessment}
+- **Weaknesses:** {Where they fall short}
+
+## Where We Win
+| Scenario | Why We Win | Talk Track |
+|----------|-----------|------------|
+| {Use case} | {Our advantage} | "{What to say to the prospect}" |
+
+## Where They Win
+| Scenario | Why They Win | Counter |
+|----------|-------------|---------|
+| {Use case} | {Their advantage} | "{How to reframe}" |
+
+## Common Objections
+| Objection | Response |
+|-----------|----------|
+| "They're cheaper" | "{Value-based response}" |
+| "They have {feature}" | "{Reframe or roadmap response}" |
+| "They're the market leader" | "{Category leadership angle}" |
+
+## Landmines (Questions to Ask Prospects)
+- "{Question that highlights competitor weakness}"
+- "{Question that highlights your strength}"
+
+## Win/Loss Insights
+- Win rate vs this competitor: {%}
+- Common deal sizes: {range}
+- Average sales cycle: {days}
+```
+
+### Win/Loss Analysis Template
+
+After each deal (won or lost), document:
+
+| Field | Details |
+|-------|---------|
+| Outcome | Won / Lost |
+| Competitor(s) | {Who you competed against} |
+| Deal size | {Amount} |
+| Decision maker | {Title/role} |
+| Why they chose us / them | {Top 3 reasons} |
+| What could have changed the outcome | {Specific actions} |
+| Sales cycle length | {Days} |
+
+## Go-to-Market (GTM) Strategy
+
+### Launch Tiers
+
+| Tier | When | Activities | Goal |
+|------|------|-----------|------|
+| **Tier 1: Major** | New product, pivot, rebrand | Press, event, campaign, all channels | Maximum awareness |
+| **Tier 2: Medium** | Major feature, integration | Blog, email, social, product in-app | Adoption + upgrades |
+| **Tier 3: Minor** | Feature update, improvement | Changelog, in-app notification, email | User awareness |
+
+### Launch Checklist (Tier 1)
+
+```
+PRE-LAUNCH (-4 weeks)
+□ Positioning and messaging finalized
+□ Landing page / product page created
+□ Demo video or walkthrough produced
+□ Press kit assembled (press release, images, founder bios)
+□ Sales enablement materials created (deck, battlecard, FAQ)
+□ Customer testimonials or beta feedback gathered
+
+LAUNCH WEEK
+□ Blog post published
+□ Email to existing customers/subscribers
+□ Social media campaign (all channels)
+□ Press outreach (if newsworthy)
+□ Product Hunt submission (if relevant)
+□ Community posts (Reddit, Hacker News, Twitter, LinkedIn)
+□ Partner/integration co-marketing
+
+POST-LAUNCH (+2 weeks)
+□ Follow-up content (case study, deep dive, tutorial)
+□ Retargeting ads to landing page visitors
+□ Win/loss tracking on new deals
+□ Performance metrics review
+□ Iterate messaging based on response
+```
+
+### Sales Enablement Package
+
+For each product or major feature, create:
+
+1. **One-pager** — Single page overview for prospects
+2. **Pitch deck** — 10-15 slide presentation
+3. **Demo script** — Guided walkthrough of key use cases
+4. **Battlecards** — Per-competitor comparison (see above)
+5. **ROI calculator** — Spreadsheet showing value vs. cost
+6. **Case studies** — Customer success stories with metrics
+7. **FAQ** — Common questions from prospects
+
+## Output Format
+
+```markdown
+# Product Marketing Strategy: {Product}
+
+## Positioning
+**For** {target customer} **who** {need/situation},
+**{Product}** is a {category} that {key benefit}.
+**Unlike** {alternative}, we {differentiator}.
+
+## Value Propositions
+1. **{Pillar 1}:** {Benefit + proof}
+2. **{Pillar 2}:** {Benefit + proof}
+3. **{Pillar 3}:** {Benefit + proof}
+
+## Messaging Matrix
+| Audience | Headline | Key Message | Proof Point |
+|----------|----------|------------|-------------|
+
+## Competitive Landscape
+{Positioning map or comparison table}
+
+## GTM Plan
+{Launch tier and timeline}
+
+## Sales Enablement
+{Materials needed and status}
+
+## Success Metrics
+| Metric | Baseline | Target | Timeline |
+```
+
+## Important Notes
+
+- Positioning is not tagline writing. It's a strategic decision about how to frame your product in the market.
+- Talk to customers before finalizing positioning. Internal assumptions are often wrong.
+- Refresh battlecards quarterly. Competitors change fast.
+- The best positioning makes the competition irrelevant rather than inferior.
+- Don't try to be everything to everyone. Strong positioning means saying no to some audiences.

--- a/.claude/skills/programmatic-seo/SKILL.md
+++ b/.claude/skills/programmatic-seo/SKILL.md
@@ -1,0 +1,400 @@
+---
+name: programmatic-seo
+description: Create SEO-optimized pages at scale using programmatic/template-based approaches. Use when the user says "programmatic SEO", "pSEO", "pages at scale", "template pages", "dynamic SEO pages", "auto-generate pages", "landing pages at scale", "city pages", "comparison pages", or wants to create many similar pages targeting different keywords.
+---
+
+# Programmatic SEO Skill
+
+You are an expert in programmatic SEO (pSEO) -- the strategy of creating large numbers of targeted pages using templates and data. Help users identify page patterns, build templates, and deploy at scale while avoiding thin content penalties.
+
+## What is Programmatic SEO?
+
+Programmatic SEO creates pages at scale by combining:
+- A **page template** (layout + structure)
+- A **data source** (database, API, CSV)
+- **Dynamic content** (unique per page, not just variable substitution)
+- **SEO optimization** (meta tags, internal links, schema)
+
+**Examples of successful pSEO:**
+- Zapier: "How to connect {App A} to {App B}" (150K+ pages)
+- Nomad List: "{City} for digital nomads" (1000+ city pages)
+- Wise: "{Currency A} to {Currency B} exchange rate" (10K+ pages)
+- G2: "{Software} reviews" (100K+ product pages)
+- Tripadvisor: "Best {type} in {city}" (millions of pages)
+
+## Process
+
+### Step 1: Identify the Page Pattern
+
+Help the user find their pSEO opportunity. Look for patterns where:
+
+**Pattern formula:** `{Modifier} + {Head Term} + {Qualifier}`
+
+| Pattern Type | Formula | Example | Volume Potential |
+|-------------|---------|---------|-----------------|
+| Location + Service | "{service} in {city}" | "plumber in Austin" | Cities x Services |
+| Comparison | "{product A} vs {product B}" | "Notion vs Asana" | nC2 combinations |
+| Integration | "{tool A} + {tool B} integration" | "Slack Salesforce integration" | Tools x Tools |
+| Template/Example | "{type} template" | "invoice template" | Types count |
+| Stats/Data | "{topic} statistics {year}" | "remote work statistics 2025" | Topics x Years |
+| Glossary | "What is {term}" | "What is APR" | Terms count |
+| Best/Top | "Best {product} for {use case}" | "Best CRM for startups" | Products x Uses |
+| Review | "{product} review" | "Airtable review" | Products count |
+| Alternative | "{product} alternatives" | "Slack alternatives" | Products count |
+| Cost/Pricing | "How much does {service} cost" | "How much does a website cost" | Services count |
+
+**Qualification criteria for a good pSEO opportunity:**
+- [ ] Pattern has 100+ possible pages minimum
+- [ ] Each combination has measurable search volume (even 10-50/mo is fine at scale)
+- [ ] You can generate genuinely useful, unique content for each page
+- [ ] The data is available (API, database, web scraping)
+- [ ] Competitors aren't already dominating with better data
+- [ ] Pages serve real user intent (not just keyword stuffing)
+
+### Step 2: Build the Data Source
+
+Define the data model that powers the pages:
+
+```typescript
+// Example: City + Service pages
+interface PageData {
+  // URL parameters
+  slug: string;           // "plumber-in-austin-tx"
+  city: string;           // "Austin"
+  state: string;          // "TX"
+  service: string;        // "plumber"
+
+  // SEO fields
+  title: string;          // "Best Plumber in Austin, TX | Top 10 for 2025"
+  metaDescription: string; // "Find the best plumber in Austin, TX..."
+  h1: string;             // "Best Plumber in Austin, TX"
+
+  // Dynamic content
+  providers: Provider[];  // Local providers data
+  avgCost: number;        // Average cost in this market
+  reviewCount: number;    // Total reviews aggregated
+  faqs: FAQ[];            // Location-specific FAQs
+
+  // Related pages (internal linking)
+  nearbyPages: string[];  // Nearby cities
+  relatedServices: string[]; // Related services
+}
+```
+
+**Data sources to consider:**
+- Public APIs (government data, Wikipedia, industry databases)
+- Web scraping (with permission/robots.txt compliance)
+- User-generated content (reviews, contributions)
+- AI-generated unique analysis per entity
+- Licensed data (paid data providers)
+- Internal product data (for SaaS/e-commerce)
+
+### Step 3: Create the Page Template
+
+Build a template that generates high-quality, unique pages. Critical principle: **each page must provide standalone value.**
+
+#### Template Structure
+
+```markdown
+## Page Template: {Pattern Name}
+
+### Above the Fold
+- H1: {dynamic title}
+- Key stat or hook: {dynamic data point}
+- Quick summary: 2-3 sentences with unique data
+- CTA (if commercial intent)
+
+### Main Content Section 1: Overview
+- {Entity}-specific introduction (NOT generic)
+- Unique data point 1: {dynamic}
+- Unique data point 2: {dynamic}
+- Contextual explanation
+
+### Main Content Section 2: Detailed Analysis
+- Comparison table or detailed breakdown
+- {Entity}-specific insights
+- Data visualizations if applicable
+
+### Main Content Section 3: Practical Information
+- How-to or action steps
+- Costs, timing, or specifications
+- Location-specific or entity-specific details
+
+### Related Content
+- Internal links to related pages (same cluster)
+- Links to parent/pillar page
+- Links to sibling pages
+
+### FAQ Section
+- 3-5 questions specific to this entity
+- Answers with unique data points
+
+### Schema Markup
+- Appropriate structured data for page type
+```
+
+#### Avoiding Thin Content
+
+**The #1 risk in pSEO is thin content.** Every page must pass this checklist:
+
+| Check | Requirement | How |
+|-------|------------|-----|
+| Unique content | > 60% of visible text is unique to this page | Dynamic data, unique analysis, UGC |
+| Sufficient depth | > 500 words of substantive content per page | Template sections + dynamic content |
+| Unique data | At least 2 data points unique to this entity | API data, calculations, aggregations |
+| Useful to visitor | Page answers the searcher's query fully | Match search intent |
+| Not auto-generated feel | Reads naturally, not like a template | Varied sentence structures, context |
+| Internal value | Links to and from other relevant pages | Related pages section, breadcrumbs |
+| Visual content | At least 1 unique or relevant image | Maps, charts, entity images |
+
+### Step 4: Next.js Implementation
+
+#### Dynamic Routes (App Router)
+
+```typescript
+// app/[service]/[city]/page.tsx
+
+import { Metadata } from 'next';
+import { notFound } from 'next/navigation';
+import { getPageData, getAllPages } from '@/lib/pseo-data';
+
+interface Props {
+  params: { service: string; city: string };
+}
+
+// Generate static paths at build time
+export async function generateStaticParams() {
+  const pages = await getAllPages();
+  return pages.map((page) => ({
+    service: page.serviceSlug,
+    city: page.citySlug,
+  }));
+}
+
+// Dynamic meta tags
+export async function generateMetadata({ params }: Props): Promise<Metadata> {
+  const data = await getPageData(params.service, params.city);
+  if (!data) return {};
+
+  return {
+    title: data.title,
+    description: data.metaDescription,
+    alternates: {
+      canonical: `https://example.com/${params.service}/${params.city}`,
+    },
+    openGraph: {
+      title: data.ogTitle,
+      description: data.ogDescription,
+      url: `https://example.com/${params.service}/${params.city}`,
+      type: 'website',
+    },
+  };
+}
+
+export default async function Page({ params }: Props) {
+  const data = await getPageData(params.service, params.city);
+  if (!data) notFound();
+
+  const jsonLd = {
+    '@context': 'https://schema.org',
+    '@type': 'WebPage',
+    name: data.title,
+    description: data.metaDescription,
+    // ... additional schema
+  };
+
+  return (
+    <>
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
+      />
+      {/* Page component tree */}
+    </>
+  );
+}
+```
+
+#### Sitemap Generation
+
+```typescript
+// app/sitemap.ts
+import { MetadataRoute } from 'next';
+import { getAllPages } from '@/lib/pseo-data';
+
+export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
+  const pages = await getAllPages();
+
+  return pages.map((page) => ({
+    url: `https://example.com/${page.serviceSlug}/${page.citySlug}`,
+    lastModified: page.updatedAt,
+    changeFrequency: 'monthly',
+    priority: 0.7,
+  }));
+}
+```
+
+For large sitemaps (50,000+ URLs), use sitemap index:
+
+```typescript
+// app/sitemap.xml/route.ts
+import { getAllPageCount } from '@/lib/pseo-data';
+
+export async function GET() {
+  const totalPages = await getAllPageCount();
+  const sitemapCount = Math.ceil(totalPages / 50000);
+
+  const sitemaps = Array.from({ length: sitemapCount }, (_, i) =>
+    `<sitemap><loc>https://example.com/sitemap-${i}.xml</loc></sitemap>`
+  ).join('');
+
+  return new Response(
+    `<?xml version="1.0" encoding="UTF-8"?>
+    <sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+      ${sitemaps}
+    </sitemapindex>`,
+    { headers: { 'Content-Type': 'application/xml' } }
+  );
+}
+```
+
+#### Robots.txt Management
+
+```typescript
+// app/robots.ts
+import { MetadataRoute } from 'next';
+
+export default function robots(): MetadataRoute.Robots {
+  return {
+    rules: [
+      {
+        userAgent: '*',
+        allow: '/',
+        disallow: ['/api/', '/admin/'],
+      },
+    ],
+    sitemap: 'https://example.com/sitemap.xml',
+  };
+}
+```
+
+### Step 5: Internal Linking Strategy
+
+Internal linking is critical for pSEO. Implement these patterns:
+
+**1. Hub-and-Spoke:**
+```
+Hub: /services/plumber/
+  |- /plumber/austin-tx
+  |- /plumber/dallas-tx
+  |- /plumber/houston-tx
+```
+
+**2. Sibling Links:**
+Each city page links to 5-10 nearby city pages for the same service.
+
+**3. Cross-Category Links:**
+Each city page links to other services in the same city.
+
+**4. Breadcrumb Navigation:**
+```
+Home > Services > Plumber > Austin, TX
+```
+
+**5. Footer/Sidebar Links:**
+Popular pages and category indexes.
+
+**Implementation pattern:**
+```typescript
+// Internal linking component
+function RelatedPages({ currentSlug, relatedPages }) {
+  return (
+    <section>
+      <h2>Related Pages</h2>
+      <div className="grid grid-cols-2 md:grid-cols-3 gap-4">
+        {relatedPages.map((page) => (
+          <Link
+            key={page.slug}
+            href={`/${page.slug}`}
+            className="text-blue-600 hover:underline"
+          >
+            {page.title}
+          </Link>
+        ))}
+      </div>
+    </section>
+  );
+}
+```
+
+### Step 6: Indexation Management
+
+When deploying thousands of pages, manage indexation carefully:
+
+**Gradual rollout:**
+1. Deploy 50-100 pages first
+2. Monitor indexation in Google Search Console
+3. Check for "Discovered - currently not indexed" and "Crawled - currently not indexed"
+4. If indexation rate > 80%, continue deploying in batches of 500-1000
+5. If indexation rate < 50%, improve page quality before deploying more
+
+**Indexation signals:**
+- Submit sitemap to Google Search Console
+- Use IndexNow API (Bing, Yandex) for faster discovery
+- Internal link from high-authority existing pages
+- Share initial pages on social media for crawl signals
+
+**Quality thresholds:**
+- If Google indexes < 30% of pages, your template likely produces thin content
+- If pages get indexed then dropped, content quality is borderline
+- Monitor "Page experience" and "Core Web Vitals" in GSC for pSEO pages
+
+### Step 7: Meta Tag Formulas
+
+Use these formulas for generating meta tags at scale:
+
+**Title tag formulas (50-60 chars):**
+```
+"{Primary Keyword} in {Location} | {Brand}"
+"Best {Service} in {City}, {State} ({Year})"
+"{Product A} vs {Product B}: {Differentiator}"
+"{Number} Best {Category} for {Use Case} ({Year})"
+"How Much Does {Service} Cost in {City}? ({Year} Pricing)"
+```
+
+**Meta description formulas (150-160 chars):**
+```
+"Find the best {service} in {city}. Compare {X} local providers, read {Y} reviews, and get free quotes. Average cost: ${Z}."
+"Detailed comparison of {A} vs {B}. See features, pricing, pros/cons, and which is better for {use case}."
+"{X} best {category} for {audience}. We analyzed {Y} options based on {criteria}. Updated for {year}."
+```
+
+**H1 formulas:**
+```
+"Best {Service} in {City}, {State}"
+"{Product A} vs {Product B}: Complete Comparison"
+"{Number} Best {Category} for {Use Case}"
+```
+
+## Output
+
+When helping a user with programmatic SEO, deliver:
+
+1. **Opportunity Analysis** - The pattern, estimated page count, volume potential
+2. **Data Model** - TypeScript interface for the page data
+3. **Page Template** - Complete template with all sections
+4. **Sample Pages** - 2-3 fully rendered example pages
+5. **Implementation Plan** - Next.js code for routes, sitemap, robots.txt
+6. **Internal Linking Strategy** - How pages connect
+7. **Indexation Plan** - Rollout schedule and monitoring metrics
+8. **Quality Checklist** - Per-page quality criteria
+
+## Common Pitfalls
+
+- **Template stuffing:** Just swapping city names in identical text = thin content penalty
+- **No unique data:** Pages without entity-specific data points add no value
+- **Over-generation:** Creating pages for combinations with zero search volume wastes crawl budget
+- **Ignoring cannibalization:** Overlapping pages compete with each other. Map one keyword per page.
+- **No internal links:** Orphan pages won't get crawled or ranked
+- **All at once:** Deploying 100K pages overnight looks unnatural. Batch them.
+- **Ignoring noindex:** Some pages may not deserve indexing. Use `noindex` for low-quality or duplicate combinations.

--- a/.claude/skills/reddit-marketing/SKILL.md
+++ b/.claude/skills/reddit-marketing/SKILL.md
@@ -1,0 +1,192 @@
+---
+name: reddit-marketing
+description: Market and engage on Reddit authentically. Use when the user says "Reddit marketing", "Reddit strategy", "promote on Reddit", "Reddit post", "subreddit strategy", "Reddit outreach", "Reddit ads", or asks about marketing or building presence on Reddit.
+---
+
+# Reddit Marketing Skill
+
+You are a Reddit marketing strategist. Help build authentic presence, find target communities, and drive traffic from Reddit without getting banned.
+
+## Reddit Marketing Rules
+
+**The #1 rule:** Reddit hates marketers. Self-promotion gets downvoted, reported, and banned. The only way to succeed is to provide genuine value first.
+
+**The 90/10 rule:** 90% of your activity should be valuable contributions (comments, helpful posts). 10% or less can mention your product/service.
+
+**What gets you banned:**
+- Posting links to your site without context or value
+- Creating posts that are thinly disguised ads
+- Using multiple accounts to upvote your own content
+- Dropping links in comments without relevance
+- Ignoring subreddit rules
+
+## Finding Target Subreddits
+
+### Step 1: Identify Relevant Communities
+
+Search for subreddits where your target audience hangs out:
+
+```
+Methods:
+1. Reddit search: reddit.com/search?q={topic}&type=sr
+2. Google: site:reddit.com {topic}
+3. Related subreddits (listed in each subreddit's sidebar)
+4. Subreddit analytics tools
+```
+
+### Step 2: Evaluate Subreddit Quality
+
+| Factor | What to Check | Good Sign |
+|--------|--------------|-----------|
+| Subscriber count | Sidebar | 10K-500K (sweet spot) |
+| Daily active posts | Sort by New | 5-20 posts/day |
+| Comment engagement | Top posts | 20+ comments regularly |
+| Self-promo rules | Sidebar/wiki | Some allowed, clear rules |
+| Moderator activity | Mod list | Active mods = quality community |
+| Audience match | Top posts | Content matches your ICP |
+
+### Step 3: Prioritize Subreddits
+
+| Tier | Criteria | Strategy |
+|------|----------|----------|
+| **Tier 1** | Perfect audience match, 50K+ members | Heavy investment: daily comments, weekly posts |
+| **Tier 2** | Adjacent audience, 10K-50K | Regular presence: 2-3 comments/week |
+| **Tier 3** | Loosely related, any size | Occasional engagement when relevant |
+
+## Content Strategies
+
+### Strategy 1: Value-First Posts
+
+Create genuinely useful content that happens to relate to your expertise:
+
+```
+Title: "I analyzed 500 {things} and here's what I found"
+or
+Title: "After 3 years of {activity}, here are the biggest lessons"
+or
+Title: "{How-to that solves a common pain point in the community}"
+```
+
+**Format:**
+- Text post (not a link post — text posts get more engagement)
+- Share the full value in the post itself (don't make people click out)
+- If your product is relevant, mention it briefly at the bottom: "Full disclosure: I work on {product} which does this, but these tips work regardless of tools."
+
+### Strategy 2: Helpful Comments
+
+The highest ROI Reddit strategy:
+
+1. Monitor subreddits for questions you can answer
+2. Write thoughtful, detailed responses (3-5 paragraphs)
+3. Include specific examples, data, or personal experience
+4. Only mention your product if directly relevant and helpful
+5. Build karma and reputation over weeks/months
+
+### Strategy 3: AMA (Ask Me Anything)
+
+If you have genuine expertise:
+- Coordinate with subreddit moderators in advance
+- Prepare proof of credentials
+- Answer questions for 2+ hours
+- Follow up on unanswered questions later
+
+### Strategy 4: Case Studies / Show & Tell
+
+Many subreddits have "Show" or "Share" threads:
+- Share genuine results with transparent methodology
+- Show failures alongside successes (authenticity)
+- Respond to every comment with additional detail
+
+### Strategy 5: Reddit Ads (Paid)
+
+Reddit's ad platform for when organic isn't enough:
+
+| Ad Type | Best For | Tips |
+|---------|----------|------|
+| Promoted posts | Awareness, traffic | Make them look like organic posts |
+| Conversation placement | Contextual targeting | Appear in relevant threads |
+| Takeover | Brand awareness | High budget, broad reach |
+
+**Reddit Ads tips:**
+- Target by subreddit (most effective) or interest
+- Creative should match Reddit's organic tone (no polished corporate ads)
+- Comments on promoted posts are open — be ready to engage
+- CPC is typically $0.50-$3.00 (cheaper than LinkedIn, pricier than Facebook)
+
+## Monitoring & Research
+
+### Social Listening on Reddit
+
+Use Reddit to understand your market:
+
+1. **Track brand mentions** — Search `{brand name}` regularly
+2. **Monitor competitor mentions** — See what people say about competitors
+3. **Identify pain points** — Search for complaints and frustrations in your niche
+4. **Find feature requests** — "I wish {product category} could do {X}"
+5. **Discover content ideas** — Top questions = content opportunities
+
+### Using Reddit for Market Research
+
+```
+Search queries to try:
+- "{product category} recommendation"
+- "best {product category} for {use case}"
+- "{competitor name} alternative"
+- "{competitor name} problems"
+- "how do you {task your product solves}"
+- "{industry} tools"
+```
+
+## Output Format
+
+```markdown
+# Reddit Marketing Strategy: {Brand/Product}
+
+## Target Subreddits
+
+### Tier 1 (Primary)
+| Subreddit | Members | Relevance | Self-Promo Rules | Strategy |
+|-----------|---------|-----------|-----------------|----------|
+| r/{sub} | {count} | {High} | {rules} | {approach} |
+
+### Tier 2 (Secondary)
+{Same table}
+
+## Content Plan
+
+### Weekly Rhythm
+- **Mon/Wed/Fri:** Comment on 3-5 posts in Tier 1 subreddits
+- **Tuesday:** Post value-first content in 1 subreddit
+- **Thursday:** Monitor and respond to brand/competitor mentions
+- **Ongoing:** Save interesting threads for content ideas
+
+### Post Ideas
+1. {Post idea + target subreddit}
+2. {Post idea + target subreddit}
+3. {Post idea + target subreddit}
+
+## Messaging Do's and Don'ts
+
+### Do
+- {Specific thing that works in these communities}
+
+### Don't
+- {Specific thing to avoid}
+
+## Success Metrics
+| Metric | Target |
+|--------|--------|
+| Karma growth | {X}/month |
+| Referral traffic | {X} visits/month |
+| Brand mentions | {X}/month |
+| Post engagement | {X} avg upvotes |
+```
+
+## Important Notes
+
+- Building Reddit presence takes months, not days. This is a long-term play.
+- Reddit users will check your post history. If it's all self-promotion, they'll call you out.
+- Each subreddit is its own culture. Lurk for at least a week before posting.
+- Screenshot and save positive comments about your product — great for testimonials and social proof.
+- Reddit threads rank well in Google. A helpful comment today can drive traffic for years.
+- Never buy upvotes or use vote manipulation. Reddit detects this and bans accounts permanently.

--- a/.claude/skills/referral-program/SKILL.md
+++ b/.claude/skills/referral-program/SKILL.md
@@ -1,0 +1,383 @@
+---
+name: referral-program
+description: >
+  Design referral programs and viral growth loops. Use when asked to create
+  referral systems, viral mechanics, word-of-mouth campaigns, or growth loops.
+  Trigger phrases: "referral program", "viral loop", "refer a friend",
+  "word of mouth", "viral coefficient", "referral incentive", "growth loop",
+  "invite system", "ambassador program".
+---
+
+# Referral Program Design
+
+Design effective referral programs and viral loops that drive sustainable growth.
+
+---
+
+## 1. Referral Program Frameworks
+
+### One-Sided Incentives
+
+Only the referrer gets rewarded.
+
+**Best for:**
+- Products with strong organic word-of-mouth
+- Low-friction signups where the referred user needs no extra motivation
+- Cost-sensitive businesses
+
+**Examples:**
+- Uber: "$10 credit for every friend you refer"
+- Amazon Associates: Commission on referred purchases
+
+**Template:**
+```
+Refer a friend and get [reward].
+Share your unique link: [referral_url]
+```
+
+### Two-Sided Incentives
+
+Both referrer and referred user get rewarded.
+
+**Best for:**
+- Products requiring activation effort from new users
+- Competitive markets where new users need a nudge
+- Subscription businesses
+
+**Examples:**
+- Dropbox: Both get 500MB extra storage
+- Airbnb: Referrer gets $25 credit, friend gets $40 off first stay
+- PayPal: Both get $10 when friend makes first transaction
+
+**Template:**
+```
+Give [friend_reward], get [referrer_reward].
+Share your link and you both win: [referral_url]
+```
+
+### Tiered Incentives
+
+Rewards increase with number of successful referrals.
+
+**Example tier structure:**
+| Referrals | Reward |
+|-----------|--------|
+| 1 | Free month |
+| 3 | Exclusive feature unlock |
+| 5 | Premium plan for 3 months |
+| 10 | Lifetime premium access |
+| 25 | Cash payout or swag box |
+
+**Best for:**
+- Creating power referrers / ambassadors
+- Products with passionate user bases
+- Building a referral leaderboard culture
+
+---
+
+## 2. Viral Coefficient Calculation
+
+The viral coefficient (K-factor) determines whether your referral loop is self-sustaining.
+
+### Formula
+
+```
+K = i * c
+
+Where:
+  i = number of invites sent per user
+  c = conversion rate of each invite
+
+If K > 1: viral growth (each user brings more than one new user)
+If K < 1: referrals supplement but don't replace other acquisition
+```
+
+### Example Calculation
+
+```
+Users send an average of 5 invites (i = 5)
+15% of invites convert to signups (c = 0.15)
+K = 5 * 0.15 = 0.75
+
+With 1,000 initial users:
+- Cycle 1: 1,000 * 0.75 = 750 new users
+- Cycle 2: 750 * 0.75 = 563 new users
+- Cycle 3: 563 * 0.75 = 422 new users
+- Total after 10 cycles: ~3,570 additional users from referrals
+```
+
+### Viral Cycle Time
+
+The speed of the viral loop matters as much as K:
+
+```
+Effective growth = K / cycle_time
+
+A K of 0.5 with a 1-day cycle > K of 0.8 with a 30-day cycle
+```
+
+### How to Improve K
+
+| Lever | Action |
+|-------|--------|
+| Increase invites (i) | Make sharing frictionless, prompt at key moments |
+| Increase conversion (c) | Better landing page, stronger incentive, social proof |
+| Reduce cycle time | Instant reward delivery, real-time notifications |
+
+---
+
+## 3. Referral Channels
+
+### Email Referral
+
+**Pros:** High conversion, personal, trackable
+**Cons:** Lower volume, requires email access
+
+Template:
+```
+Subject: I thought you'd like [Product] -- here's [reward] to try it
+
+Hey [Name],
+
+I've been using [Product] for [time] and it's been great for [specific benefit].
+
+I wanted to share my referral link so you can get [friend_reward]:
+[referral_url]
+
+[Your name]
+```
+
+### Social Media Sharing
+
+**Pros:** High reach, low effort, viral potential
+**Cons:** Lower conversion rate, less personal
+
+Platform-specific templates:
+
+**Twitter/X:**
+```
+I just [achievement/milestone] with @Product! If you want to try it,
+use my link and we both get [reward]: [referral_url]
+```
+
+**LinkedIn:**
+```
+I've been using [Product] to [professional benefit] and the results
+have been impressive: [specific metric].
+
+If you're looking for [solution], here's my referral link
+(we both get [reward]): [referral_url]
+```
+
+**WhatsApp/SMS:**
+```
+Hey! I've been using [Product] and really like it. They have a
+referral deal -- we both get [reward] if you sign up through my link:
+[referral_url]
+```
+
+### In-App Referral
+
+**Pros:** Highest intent, contextual, frictionless
+**Cons:** Only reaches existing users
+
+Best practices:
+- Show referral prompt after a success moment (completed task, achievement, positive outcome)
+- Pre-populate sharing message
+- Show referral progress and rewards earned
+- Add referral widget to account/settings page
+
+### Unique Link vs. Referral Code
+
+| Method | Pros | Cons |
+|--------|------|------|
+| Unique link | Frictionless, works in any channel | Harder to share verbally |
+| Referral code | Easy to remember, shareable verbally | Extra step at signup |
+| Both | Maximum flexibility | More complex to implement |
+
+---
+
+## 4. Referral Landing Page Template
+
+The page a referred user sees when they click the referral link.
+
+### Structure
+
+```
+[Hero Section]
+- Headline: "[Referrer's name] invited you to [Product]"
+- Subheadline: "Sign up now and get [friend_reward]"
+- CTA button: "Claim your [reward]"
+
+[Social Proof]
+- "[Referrer's name] and X others use [Product]"
+- Logos of known customers
+- Key metric: "Trusted by X users"
+
+[Value Proposition]
+- 3 key benefits with icons
+- Brief product description
+
+[How It Works]
+- Step 1: Sign up (takes 30 seconds)
+- Step 2: [Key activation action]
+- Step 3: Enjoy [reward] + the product
+
+[CTA Repeat]
+- "Join [Referrer's name] on [Product]"
+- Urgency: "This offer expires in [X days]"
+
+[FAQ]
+- When do I get my reward?
+- What does [Product] do?
+- Is there a catch?
+```
+
+---
+
+## 5. Case Studies
+
+### Dropbox (2008-2010)
+
+- **Mechanic:** Two-sided -- both get 500MB extra storage
+- **Result:** 3,900% growth in 15 months (100K to 4M users)
+- **Key insight:** The reward (storage) was the product itself, making it self-reinforcing
+- **Viral coefficient:** Estimated ~0.6-0.7 (supplemental, not purely viral)
+
+### Airbnb (2014)
+
+- **Mechanic:** Two-sided -- $25 travel credit for referrer, $40 off first booking for friend
+- **Result:** 300% increase in bookings from referral program 2.0
+- **Key insight:** Redesigned referral page to feel like a gift, not spam. Personalized with referrer's photo and travel history
+- **Viral coefficient:** Low K but high LTV per referred user
+
+### PayPal (1999-2000)
+
+- **Mechanic:** Two-sided -- $20 per referral (later reduced to $10, then $5)
+- **Result:** 7-10% daily growth, reaching 1M users in first year
+- **Key insight:** Cash incentive drove massive initial growth, then reduced as network effects kicked in
+- **Cost:** $60-70M in referral bonuses, but each user was worth much more in LTV
+
+### Robinhood (2014-2015)
+
+- **Mechanic:** Wait-list with move-up-the-line incentive + free stock for referrals
+- **Result:** 1M waitlist signups before launch
+- **Key insight:** Scarcity (waitlist) + social proof (your position) + tangible reward (free stock)
+
+---
+
+## 6. Implementation Checklist
+
+### Technical Setup
+
+- [ ] Generate unique referral links/codes per user
+- [ ] Build referral tracking (link clicks, signups, activations, rewards)
+- [ ] Set up attribution window (how long after click does signup count?)
+- [ ] Implement fraud detection (self-referral, fake accounts, VPN abuse)
+- [ ] Build reward fulfillment (automatic credit, manual approval, or hybrid)
+- [ ] Create referral dashboard for users (invites sent, pending, completed, rewards earned)
+
+### Fraud Prevention
+
+- [ ] Block self-referrals (same IP, same device, same email domain)
+- [ ] Require activation action before reward (not just signup)
+- [ ] Set daily/weekly referral limits per user
+- [ ] Flag suspicious patterns (bulk signups from same IP range)
+- [ ] Implement clawback for fraudulent referrals
+
+### Program Design Decisions
+
+| Decision | Options |
+|----------|---------|
+| Reward type | Cash, credit, product features, swag, charity donation |
+| Reward timing | On signup, on activation, on first purchase |
+| Reward amount | Test multiple amounts; higher is not always better |
+| Expiration | Referral links expire after X days? Rewards expire? |
+| Limit | Max referrals per user per month? |
+| Eligibility | All users or only paid/active users? |
+
+---
+
+## 7. Referral Email Sequences
+
+### Invite Reminder (to existing users)
+
+```
+Subject: You have [X] invites waiting
+
+Hey [Name],
+
+Did you know you can give your friends [reward] and get [reward] for yourself?
+
+You've invited [0/N] friends so far. Share your link:
+[referral_url]
+
+Here's what [Product] users are saying:
+"[Testimonial]" -- [Customer name]
+```
+
+### Referred User Welcome
+
+```
+Subject: [Referrer] sent you a gift -- [reward] inside
+
+Hey there!
+
+[Referrer's name] thinks you'd love [Product], so they're giving you [reward] to try it.
+
+[CTA: Claim your reward]
+
+What is [Product]?
+[1-sentence description]
+
+What you'll get:
+- [Benefit 1]
+- [Benefit 2]
+- [Benefit 3]
+- Plus [friend_reward] from [Referrer's name]
+
+This offer expires in [X] days.
+```
+
+### Referral Success Notification
+
+```
+Subject: [Friend's name] just signed up -- you earned [reward]!
+
+Great news, [Name]!
+
+[Friend's name] accepted your invitation and signed up for [Product].
+Your [reward] has been added to your account.
+
+Keep sharing: you've referred [X] friends so far.
+[referral_url]
+
+[Show progress toward next tier if using tiered rewards]
+```
+
+---
+
+## 8. Measuring Success
+
+### Key Metrics
+
+| Metric | Formula | Good Benchmark |
+|--------|---------|----------------|
+| Participation rate | Users who share / total users | 15-25% |
+| Shares per user | Total shares / participating users | 3-5 |
+| Click-through rate | Link clicks / shares | 20-40% |
+| Conversion rate | Signups / link clicks | 10-25% |
+| Viral coefficient (K) | Invites * conversion rate | 0.3-0.7 typical |
+| Viral cycle time | Avg days from invite to new user's first invite | 1-7 days |
+| Referral revenue | Revenue from referred users | Track separately |
+| CAC via referral | Reward cost / acquired users | Compare to paid CAC |
+
+### A/B Tests to Run
+
+1. Reward amount ($10 vs $20 vs $50)
+2. Reward type (credit vs cash vs feature unlock)
+3. One-sided vs two-sided incentive
+4. Referral prompt timing (after signup vs after first success)
+5. Landing page copy (gift framing vs deal framing)
+6. Email subject lines for referral invites
+7. Social sharing copy variations

--- a/.claude/skills/schema-markup/SKILL.md
+++ b/.claude/skills/schema-markup/SKILL.md
@@ -1,0 +1,608 @@
+---
+name: schema-markup
+description: Generate Schema.org structured data (JSON-LD) for any page type. Use when the user says "schema markup", "structured data", "JSON-LD", "rich snippets", "rich results", "FAQ schema", "product schema", "article schema", "breadcrumb schema", "organization schema", "how-to schema", "review schema", or asks about structured data for SEO.
+---
+
+# Schema Markup Generator Skill
+
+You are an expert in Schema.org structured data and Google's rich results requirements. Generate valid, complete JSON-LD markup that maximizes eligibility for Google rich results.
+
+## Supported Schema Types
+
+This skill supports the following schema types. When the user asks for schema, determine which type(s) are appropriate based on the page content.
+
+### 1. Article / BlogPosting / NewsArticle
+
+**Use for:** Blog posts, news articles, editorial content
+**Rich result:** Article carousel, headline in search
+
+```json
+{
+  "@context": "https://schema.org",
+  "@type": "Article",
+  "headline": "Your Article Title (max 110 characters)",
+  "description": "Brief description of the article (max 160 characters)",
+  "image": [
+    "https://example.com/image-16x9.jpg",
+    "https://example.com/image-4x3.jpg",
+    "https://example.com/image-1x1.jpg"
+  ],
+  "datePublished": "2025-01-15T08:00:00+00:00",
+  "dateModified": "2025-01-20T10:30:00+00:00",
+  "author": [{
+    "@type": "Person",
+    "name": "Author Name",
+    "url": "https://example.com/author/name",
+    "jobTitle": "Senior Editor",
+    "sameAs": [
+      "https://twitter.com/authorhandle",
+      "https://linkedin.com/in/authorname"
+    ]
+  }],
+  "publisher": {
+    "@type": "Organization",
+    "name": "Publisher Name",
+    "logo": {
+      "@type": "ImageObject",
+      "url": "https://example.com/logo.png",
+      "width": 600,
+      "height": 60
+    }
+  },
+  "mainEntityOfPage": {
+    "@type": "WebPage",
+    "@id": "https://example.com/article-url"
+  },
+  "wordCount": 2500,
+  "articleSection": "Technology",
+  "keywords": ["keyword1", "keyword2", "keyword3"],
+  "isAccessibleForFree": true
+}
+```
+
+**Google requirements:**
+- `headline` is required (max 110 characters)
+- `image` is required (provide 3 aspect ratios: 16:9, 4:3, 1:1; each > 696px wide)
+- `datePublished` is required (ISO 8601 format)
+- `author.name` is required
+- For `NewsArticle`, also add `dateline` if applicable
+- For `BlogPosting`, `@type` changes to `"BlogPosting"`
+
+---
+
+### 2. Product
+
+**Use for:** Product pages, e-commerce listings
+**Rich result:** Product snippet with price, availability, reviews
+
+```json
+{
+  "@context": "https://schema.org",
+  "@type": "Product",
+  "name": "Product Name",
+  "description": "Product description",
+  "image": [
+    "https://example.com/product-1.jpg",
+    "https://example.com/product-2.jpg"
+  ],
+  "sku": "SKU-12345",
+  "mpn": "MPN-67890",
+  "gtin13": "0123456789012",
+  "brand": {
+    "@type": "Brand",
+    "name": "Brand Name"
+  },
+  "offers": {
+    "@type": "Offer",
+    "url": "https://example.com/product",
+    "priceCurrency": "USD",
+    "price": "99.99",
+    "priceValidUntil": "2025-12-31",
+    "availability": "https://schema.org/InStock",
+    "itemCondition": "https://schema.org/NewCondition",
+    "seller": {
+      "@type": "Organization",
+      "name": "Seller Name"
+    },
+    "shippingDetails": {
+      "@type": "OfferShippingDetails",
+      "shippingRate": {
+        "@type": "MonetaryAmount",
+        "value": "0",
+        "currency": "USD"
+      },
+      "deliveryTime": {
+        "@type": "ShippingDeliveryTime",
+        "handlingTime": {
+          "@type": "QuantitativeValue",
+          "minValue": 0,
+          "maxValue": 1,
+          "unitCode": "DAY"
+        },
+        "transitTime": {
+          "@type": "QuantitativeValue",
+          "minValue": 1,
+          "maxValue": 5,
+          "unitCode": "DAY"
+        }
+      },
+      "shippingDestination": {
+        "@type": "DefinedRegion",
+        "addressCountry": "US"
+      }
+    },
+    "hasMerchantReturnPolicy": {
+      "@type": "MerchantReturnPolicy",
+      "applicableCountry": "US",
+      "returnPolicyCategory": "https://schema.org/MerchantReturnFiniteReturnWindow",
+      "merchantReturnDays": 30,
+      "returnMethod": "https://schema.org/ReturnByMail",
+      "returnFees": "https://schema.org/FreeReturn"
+    }
+  },
+  "aggregateRating": {
+    "@type": "AggregateRating",
+    "ratingValue": "4.5",
+    "bestRating": "5",
+    "ratingCount": "142"
+  },
+  "review": [{
+    "@type": "Review",
+    "author": {
+      "@type": "Person",
+      "name": "Reviewer Name"
+    },
+    "datePublished": "2025-01-10",
+    "reviewBody": "Review text here",
+    "reviewRating": {
+      "@type": "Rating",
+      "ratingValue": "5",
+      "bestRating": "5"
+    }
+  }]
+}
+```
+
+**Google requirements:**
+- `name` is required
+- `offers`, `review`, or `aggregateRating` - at least one required
+- `offers.price` and `offers.priceCurrency` required if offers present
+- `offers.availability` must use Schema.org enum values
+- As of 2024, `shippingDetails` and `hasMerchantReturnPolicy` are recommended for merchant listings
+
+---
+
+### 3. FAQPage
+
+**Use for:** FAQ sections, Q&A pages
+**Rich result:** Expandable FAQ in search results
+
+```json
+{
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  "mainEntity": [
+    {
+      "@type": "Question",
+      "name": "What is the first question?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "<p>The answer with <strong>HTML formatting</strong> allowed. You can include <a href=\"https://example.com\">links</a>.</p>"
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "What is the second question?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Plain text answers also work."
+      }
+    }
+  ]
+}
+```
+
+**Google requirements:**
+- Each `Question` must have exactly one `acceptedAnswer`
+- Answer `text` can include HTML: `<h2>` through `<h6>`, `<br>`, `<ol>`, `<ul>`, `<li>`, `<a>`, `<p>`, `<b>`, `<strong>`, `<i>`, `<em>`
+- Must be visible on the page (not hidden behind tabs/accordions without proper implementation)
+- Google may show up to 3 FAQ rich results per page
+- Do not use for advertising purposes
+
+---
+
+### 4. HowTo
+
+**Use for:** Tutorial pages, step-by-step guides, DIY instructions
+**Rich result:** Step-by-step display in search results
+
+```json
+{
+  "@context": "https://schema.org",
+  "@type": "HowTo",
+  "name": "How to Do Something",
+  "description": "Brief description of the task",
+  "image": {
+    "@type": "ImageObject",
+    "url": "https://example.com/howto-main.jpg",
+    "height": "406",
+    "width": "305"
+  },
+  "totalTime": "PT30M",
+  "estimatedCost": {
+    "@type": "MonetaryAmount",
+    "currency": "USD",
+    "value": "20"
+  },
+  "supply": [
+    {
+      "@type": "HowToSupply",
+      "name": "Supply item 1"
+    },
+    {
+      "@type": "HowToSupply",
+      "name": "Supply item 2"
+    }
+  ],
+  "tool": [
+    {
+      "@type": "HowToTool",
+      "name": "Tool 1"
+    }
+  ],
+  "step": [
+    {
+      "@type": "HowToStep",
+      "name": "Step 1 Title",
+      "text": "Detailed instructions for step 1.",
+      "url": "https://example.com/howto#step1",
+      "image": "https://example.com/step1.jpg"
+    },
+    {
+      "@type": "HowToStep",
+      "name": "Step 2 Title",
+      "text": "Detailed instructions for step 2.",
+      "url": "https://example.com/howto#step2",
+      "image": "https://example.com/step2.jpg"
+    }
+  ]
+}
+```
+
+**Google requirements:**
+- `name` is required
+- `step` array is required with at least one step
+- Each step needs either `text` or `itemListElement` with `HowToDirection`/`HowToTip`
+- `totalTime` uses ISO 8601 duration format (PT1H30M = 1 hour 30 minutes)
+- Do not use HowTo for recipes (use Recipe schema instead)
+
+---
+
+### 5. Organization
+
+**Use for:** Homepage, about page, company information
+**Rich result:** Knowledge panel, logo in search
+
+```json
+{
+  "@context": "https://schema.org",
+  "@type": "Organization",
+  "name": "Company Name",
+  "alternateName": "Company Abbreviation",
+  "url": "https://example.com",
+  "logo": {
+    "@type": "ImageObject",
+    "url": "https://example.com/logo.png",
+    "width": 512,
+    "height": 512
+  },
+  "description": "Company description",
+  "foundingDate": "2020-01-01",
+  "founder": {
+    "@type": "Person",
+    "name": "Founder Name"
+  },
+  "address": {
+    "@type": "PostalAddress",
+    "streetAddress": "123 Main St",
+    "addressLocality": "San Francisco",
+    "addressRegion": "CA",
+    "postalCode": "94102",
+    "addressCountry": "US"
+  },
+  "contactPoint": [{
+    "@type": "ContactPoint",
+    "telephone": "+1-555-555-5555",
+    "contactType": "customer service",
+    "areaServed": "US",
+    "availableLanguage": "English"
+  }],
+  "sameAs": [
+    "https://twitter.com/company",
+    "https://linkedin.com/company/company",
+    "https://facebook.com/company",
+    "https://github.com/company"
+  ],
+  "numberOfEmployees": {
+    "@type": "QuantitativeValue",
+    "minValue": 10,
+    "maxValue": 50
+  }
+}
+```
+
+---
+
+### 6. LocalBusiness
+
+**Use for:** Local business pages, Google Business Profile support
+**Rich result:** Local business panel, map results
+
+```json
+{
+  "@context": "https://schema.org",
+  "@type": "LocalBusiness",
+  "@id": "https://example.com/#business",
+  "name": "Business Name",
+  "description": "Business description",
+  "url": "https://example.com",
+  "telephone": "+1-555-555-5555",
+  "email": "info@example.com",
+  "image": "https://example.com/storefront.jpg",
+  "logo": "https://example.com/logo.png",
+  "priceRange": "$$",
+  "address": {
+    "@type": "PostalAddress",
+    "streetAddress": "123 Main St",
+    "addressLocality": "San Francisco",
+    "addressRegion": "CA",
+    "postalCode": "94102",
+    "addressCountry": "US"
+  },
+  "geo": {
+    "@type": "GeoCoordinates",
+    "latitude": "37.7749",
+    "longitude": "-122.4194"
+  },
+  "openingHoursSpecification": [
+    {
+      "@type": "OpeningHoursSpecification",
+      "dayOfWeek": ["Monday", "Tuesday", "Wednesday", "Thursday", "Friday"],
+      "opens": "09:00",
+      "closes": "17:00"
+    },
+    {
+      "@type": "OpeningHoursSpecification",
+      "dayOfWeek": "Saturday",
+      "opens": "10:00",
+      "closes": "14:00"
+    }
+  ],
+  "aggregateRating": {
+    "@type": "AggregateRating",
+    "ratingValue": "4.7",
+    "bestRating": "5",
+    "ratingCount": "312"
+  },
+  "areaServed": {
+    "@type": "City",
+    "name": "San Francisco"
+  },
+  "hasMap": "https://maps.google.com/?cid=123456789"
+}
+```
+
+**Google requirements:**
+- `name`, `address` are required
+- Use specific subtypes when possible: `Restaurant`, `Dentist`, `LegalService`, `RealEstateAgent`, etc.
+- `geo` coordinates should be accurate to the business location
+- `openingHoursSpecification` must reflect actual business hours
+
+---
+
+### 7. BreadcrumbList
+
+**Use for:** Any page with breadcrumb navigation
+**Rich result:** Breadcrumb trail in search results
+
+```json
+{
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  "itemListElement": [
+    {
+      "@type": "ListItem",
+      "position": 1,
+      "name": "Home",
+      "item": "https://example.com"
+    },
+    {
+      "@type": "ListItem",
+      "position": 2,
+      "name": "Category",
+      "item": "https://example.com/category"
+    },
+    {
+      "@type": "ListItem",
+      "position": 3,
+      "name": "Current Page Title"
+    }
+  ]
+}
+```
+
+**Google requirements:**
+- `position` must be sequential starting at 1
+- Last item should not have `item` (it's the current page)
+- Must match the visible breadcrumb on the page
+
+---
+
+### 8. Review / AggregateRating
+
+**Use for:** Review pages, product reviews, service reviews
+**Rich result:** Star rating in search results
+
+```json
+{
+  "@context": "https://schema.org",
+  "@type": "Review",
+  "name": "Review Title",
+  "reviewBody": "Full review text...",
+  "datePublished": "2025-01-15",
+  "author": {
+    "@type": "Person",
+    "name": "Reviewer Name"
+  },
+  "itemReviewed": {
+    "@type": "Product",
+    "name": "Product Being Reviewed",
+    "image": "https://example.com/product.jpg"
+  },
+  "reviewRating": {
+    "@type": "Rating",
+    "ratingValue": "4",
+    "bestRating": "5",
+    "worstRating": "1"
+  },
+  "publisher": {
+    "@type": "Organization",
+    "name": "Review Site Name"
+  }
+}
+```
+
+**Google requirements:**
+- `author` is required (must be a valid `Person` or `Organization`)
+- `itemReviewed` is required
+- `reviewRating` is recommended
+- Self-serving reviews (reviewing your own product) are against guidelines
+
+## Multi-Schema Pages
+
+Most pages need multiple schema types. Combine them using `@graph`:
+
+```json
+{
+  "@context": "https://schema.org",
+  "@graph": [
+    {
+      "@type": "Organization",
+      "@id": "https://example.com/#organization",
+      "name": "Company Name",
+      "url": "https://example.com",
+      "logo": "https://example.com/logo.png"
+    },
+    {
+      "@type": "WebSite",
+      "@id": "https://example.com/#website",
+      "url": "https://example.com",
+      "name": "Site Name",
+      "publisher": { "@id": "https://example.com/#organization" }
+    },
+    {
+      "@type": "WebPage",
+      "@id": "https://example.com/page/#webpage",
+      "url": "https://example.com/page/",
+      "name": "Page Title",
+      "isPartOf": { "@id": "https://example.com/#website" }
+    },
+    {
+      "@type": "Article",
+      "mainEntityOfPage": { "@id": "https://example.com/page/#webpage" },
+      "headline": "Article Title",
+      "author": { "@type": "Person", "name": "Author" },
+      "publisher": { "@id": "https://example.com/#organization" },
+      "datePublished": "2025-01-15"
+    },
+    {
+      "@type": "BreadcrumbList",
+      "itemListElement": [
+        { "@type": "ListItem", "position": 1, "name": "Home", "item": "https://example.com" },
+        { "@type": "ListItem", "position": 2, "name": "Blog", "item": "https://example.com/blog" },
+        { "@type": "ListItem", "position": 3, "name": "Article Title" }
+      ]
+    }
+  ]
+}
+```
+
+## Generation Process
+
+When the user asks for schema markup:
+
+1. **Determine page type** - Ask what kind of page this is for (or infer from context)
+2. **Gather information** - Ask for or collect the required fields. If the user provides a URL, fetch it to extract data.
+3. **Select schema types** - Choose all applicable schemas (most pages need 2-4 types)
+4. **Generate JSON-LD** - Create complete, valid markup
+5. **Validate** - Check against Google's requirements for each type
+6. **Provide implementation instructions** - Tell the user exactly where to place it
+
+## Implementation Instructions
+
+For **Next.js App Router**:
+```tsx
+// In your page component or layout
+export default function Page() {
+  const jsonLd = {/* generated schema */};
+
+  return (
+    <>
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
+      />
+      {/* page content */}
+    </>
+  );
+}
+```
+
+For **Next.js with next/head (Pages Router)**:
+```tsx
+import Head from 'next/head';
+
+export default function Page() {
+  const jsonLd = {/* generated schema */};
+
+  return (
+    <>
+      <Head>
+        <script
+          type="application/ld+json"
+          dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
+        />
+      </Head>
+      {/* page content */}
+    </>
+  );
+}
+```
+
+For **plain HTML**:
+```html
+<head>
+  <script type="application/ld+json">
+  {/* generated schema */}
+  </script>
+</head>
+```
+
+## Validation
+
+After generating the markup, remind the user to validate using:
+1. **Google Rich Results Test:** https://search.google.com/test/rich-results
+2. **Schema.org Validator:** https://validator.schema.org/
+
+## Common Mistakes to Avoid
+
+- Do not add schema for content that is not visible on the page
+- Do not use `Review` schema for self-serving reviews of your own business
+- Do not markup content behind a paywall as `isAccessibleForFree: true`
+- Do not use fake or placeholder data in production schema
+- Do not add `AggregateRating` without actual user reviews
+- Always use absolute URLs, never relative
+- Always use ISO 8601 date format
+- `priceValidUntil` must be a future date
+- `availability` must use full Schema.org URL (e.g., `https://schema.org/InStock`)
+- Image URLs must be crawlable and indexable

--- a/.claude/skills/search-console/SKILL.md
+++ b/.claude/skills/search-console/SKILL.md
@@ -1,0 +1,403 @@
+---
+name: search-console
+description: >
+  Pull Google Search Console data and perform search performance analysis.
+  Use when asked about search rankings, clicks, impressions, CTR, index coverage,
+  Core Web Vitals, or sitemap status. Trigger phrases: "search console", "GSC",
+  "search performance", "clicks and impressions", "CTR analysis", "index coverage",
+  "core web vitals", "URL inspection", "sitemap status", "ranking data",
+  "search queries", "keyword positions".
+---
+
+# Google Search Console
+
+Pull search performance data, index coverage, and Core Web Vitals from Google Search Console API.
+
+## Prerequisites
+
+Requires Google OAuth credentials:
+- `GOOGLE_CLIENT_ID`
+- `GOOGLE_CLIENT_SECRET`
+- A valid OAuth access token with `https://www.googleapis.com/auth/webmasters.readonly` scope
+
+Set credentials in `.env`, `.env.local`, or `~/.claude/.env.global`.
+
+### Getting an Access Token
+
+```bash
+# Step 1: Authorization URL (user visits in browser)
+echo "https://accounts.google.com/o/oauth2/v2/auth?client_id=${GOOGLE_CLIENT_ID}&redirect_uri=urn:ietf:wg:oauth:2.0:oob&scope=https://www.googleapis.com/auth/webmasters.readonly&response_type=code&access_type=offline"
+
+# Step 2: Exchange code for tokens
+curl -s -X POST "https://oauth2.googleapis.com/token" \
+  -d "code={AUTH_CODE}" \
+  -d "client_id=${GOOGLE_CLIENT_ID}" \
+  -d "client_secret=${GOOGLE_CLIENT_SECRET}" \
+  -d "redirect_uri=urn:ietf:wg:oauth:2.0:oob" \
+  -d "grant_type=authorization_code"
+
+# Step 3: Refresh expired token
+curl -s -X POST "https://oauth2.googleapis.com/token" \
+  -d "refresh_token={REFRESH_TOKEN}" \
+  -d "client_id=${GOOGLE_CLIENT_ID}" \
+  -d "client_secret=${GOOGLE_CLIENT_SECRET}" \
+  -d "grant_type=refresh_token"
+```
+
+### Listing Available Sites
+
+```bash
+curl -s -H "Authorization: Bearer ${GSC_ACCESS_TOKEN}" \
+  "https://www.googleapis.com/webmasters/v3/sites" \
+  | python3 -c "
+import json, sys
+data = json.load(sys.stdin)
+for site in data.get('siteEntry', []):
+    print(f\"{site['siteUrl']}  |  Permission: {site['permissionLevel']}\")
+"
+```
+
+The site URL format is either `https://example.com/` (URL prefix) or `sc-domain:example.com` (domain property).
+
+---
+
+## 1. Search Performance Report
+
+The core report: queries, pages, clicks, impressions, CTR, and average position.
+
+### API Endpoint
+
+```
+POST https://www.googleapis.com/webmasters/v3/sites/{siteUrl}/searchAnalytics/query
+```
+
+Note: The `{siteUrl}` must be URL-encoded (e.g., `https%3A%2F%2Fexample.com%2F` or `sc-domain%3Aexample.com`).
+
+### Top Queries
+
+```bash
+curl -s -X POST \
+  "https://www.googleapis.com/webmasters/v3/sites/sc-domain%3Aexample.com/searchAnalytics/query" \
+  -H "Authorization: Bearer ${GSC_ACCESS_TOKEN}" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "startDate": "2024-01-01",
+    "endDate": "2024-03-31",
+    "dimensions": ["query"],
+    "rowLimit": 50,
+    "startRow": 0
+  }'
+```
+
+### Top Pages
+
+```bash
+curl -s -X POST \
+  "https://www.googleapis.com/webmasters/v3/sites/sc-domain%3Aexample.com/searchAnalytics/query" \
+  -H "Authorization: Bearer ${GSC_ACCESS_TOKEN}" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "startDate": "2024-01-01",
+    "endDate": "2024-03-31",
+    "dimensions": ["page"],
+    "rowLimit": 50
+  }'
+```
+
+### Query + Page Combination
+
+```bash
+curl -s -X POST \
+  "https://www.googleapis.com/webmasters/v3/sites/sc-domain%3Aexample.com/searchAnalytics/query" \
+  -H "Authorization: Bearer ${GSC_ACCESS_TOKEN}" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "startDate": "2024-01-01",
+    "endDate": "2024-03-31",
+    "dimensions": ["query", "page"],
+    "rowLimit": 100,
+    "dimensionFilterGroups": [{
+      "filters": [{
+        "dimension": "page",
+        "operator": "contains",
+        "expression": "/blog/"
+      }]
+    }]
+  }'
+```
+
+### Available Dimensions
+
+| Dimension | Description |
+|-----------|-------------|
+| `query` | Search query |
+| `page` | URL |
+| `country` | Country code (ISO 3166-1 alpha-3) |
+| `device` | `DESKTOP`, `MOBILE`, `TABLET` |
+| `date` | Individual date |
+| `searchAppearance` | Rich result type |
+
+### Response Parsing
+
+```bash
+curl -s -X POST "..." | python3 -c "
+import json, sys
+data = json.load(sys.stdin)
+print(f\"{'Query':<50} {'Clicks':>8} {'Impr':>8} {'CTR':>8} {'Pos':>6}\")
+print('-' * 82)
+for row in data.get('rows', []):
+    keys = ' + '.join(row.get('keys', []))
+    print(f\"{keys:<50} {row['clicks']:>8} {row['impressions']:>8} {row['ctr']*100:>7.1f}% {row['position']:>6.1f}\")
+"
+```
+
+---
+
+## 2. Search Performance by Date
+
+Track daily trends for queries and pages.
+
+```bash
+curl -s -X POST \
+  "https://www.googleapis.com/webmasters/v3/sites/sc-domain%3Aexample.com/searchAnalytics/query" \
+  -H "Authorization: Bearer ${GSC_ACCESS_TOKEN}" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "startDate": "2024-01-01",
+    "endDate": "2024-03-31",
+    "dimensions": ["date"],
+    "rowLimit": 1000
+  }'
+```
+
+To track a specific query over time:
+
+```bash
+curl -s -X POST \
+  "https://www.googleapis.com/webmasters/v3/sites/sc-domain%3Aexample.com/searchAnalytics/query" \
+  -H "Authorization: Bearer ${GSC_ACCESS_TOKEN}" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "startDate": "2024-01-01",
+    "endDate": "2024-03-31",
+    "dimensions": ["date"],
+    "dimensionFilterGroups": [{
+      "filters": [{
+        "dimension": "query",
+        "operator": "equals",
+        "expression": "your target keyword"
+      }]
+    }]
+  }'
+```
+
+---
+
+## 3. Index Coverage (URL Inspection API)
+
+Check if a specific URL is indexed.
+
+### Endpoint
+
+```
+POST https://searchconsole.googleapis.com/v1/urlInspection/index:inspect
+```
+
+### Example curl
+
+```bash
+curl -s -X POST \
+  "https://searchconsole.googleapis.com/v1/urlInspection/index:inspect" \
+  -H "Authorization: Bearer ${GSC_ACCESS_TOKEN}" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "inspectionUrl": "https://example.com/page-to-check",
+    "siteUrl": "sc-domain:example.com"
+  }'
+```
+
+### Response Fields
+
+| Field | Description |
+|-------|-------------|
+| `inspectionResult.indexStatusResult.coverageState` | `Submitted and indexed`, `Crawled - currently not indexed`, etc. |
+| `inspectionResult.indexStatusResult.robotsTxtState` | `ALLOWED` or `DISALLOWED` |
+| `inspectionResult.indexStatusResult.indexingState` | `INDEXING_ALLOWED` or `INDEXING_NOT_ALLOWED` |
+| `inspectionResult.indexStatusResult.lastCrawlTime` | When Googlebot last crawled |
+| `inspectionResult.indexStatusResult.crawledAs` | `DESKTOP` or `MOBILE` |
+| `inspectionResult.mobileUsabilityResult.verdict` | `PASS`, `FAIL`, or `VERDICT_UNSPECIFIED` |
+
+---
+
+## 4. Sitemaps
+
+List and check sitemap status.
+
+### List Sitemaps
+
+```bash
+curl -s -H "Authorization: Bearer ${GSC_ACCESS_TOKEN}" \
+  "https://www.googleapis.com/webmasters/v3/sites/sc-domain%3Aexample.com/sitemaps" \
+  | python3 -c "
+import json, sys
+data = json.load(sys.stdin)
+for sm in data.get('sitemap', []):
+    print(f\"URL: {sm['path']}\")
+    print(f\"  Type: {sm.get('type','')}  |  Submitted: {sm.get('lastSubmitted','')}\")
+    print(f\"  URLs discovered: {sm.get('contents',[{}])[0].get('submitted','?')}  |  Indexed: {sm.get('contents',[{}])[0].get('indexed','?')}\")
+    print()
+"
+```
+
+### Submit a Sitemap
+
+```bash
+curl -s -X PUT -H "Authorization: Bearer ${GSC_ACCESS_TOKEN}" \
+  "https://www.googleapis.com/webmasters/v3/sites/sc-domain%3Aexample.com/sitemaps/https%3A%2F%2Fexample.com%2Fsitemap.xml"
+```
+
+---
+
+## 5. Opportunity Identification
+
+Use Search Console data to find SEO opportunities.
+
+### Low-Hanging Fruit: High Impressions, Low CTR
+
+Queries with many impressions but low CTR suggest the title/description needs optimization.
+
+```bash
+# Pull queries, then filter for: impressions > 100 AND ctr < 0.03 AND position < 20
+curl -s -X POST \
+  "https://www.googleapis.com/webmasters/v3/sites/sc-domain%3Aexample.com/searchAnalytics/query" \
+  -H "Authorization: Bearer ${GSC_ACCESS_TOKEN}" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "startDate": "2024-01-01",
+    "endDate": "2024-03-31",
+    "dimensions": ["query", "page"],
+    "rowLimit": 1000
+  }' | python3 -c "
+import json, sys
+data = json.load(sys.stdin)
+print('== Low CTR Opportunities (High impressions, low CTR, good position) ==')
+print(f\"{'Query':<40} {'Page':<40} {'Impr':>6} {'CTR':>7} {'Pos':>5}\")
+for row in data.get('rows', []):
+    if row['impressions'] > 100 and row['ctr'] < 0.03 and row['position'] < 20:
+        print(f\"{row['keys'][0]:<40} {row['keys'][1][-40:]:<40} {row['impressions']:>6} {row['ctr']*100:>6.1f}% {row['position']:>5.1f}\")
+"
+```
+
+### Striking Distance: Position 5-20
+
+Queries ranking on page 1-2 that could be pushed to top 5 with content optimization.
+
+```bash
+# Filter for position between 5 and 20 with decent impressions
+curl -s -X POST "..." | python3 -c "
+import json, sys
+data = json.load(sys.stdin)
+print('== Striking Distance Keywords (Position 5-20) ==')
+opps = [r for r in data.get('rows',[]) if 5 <= r['position'] <= 20 and r['impressions'] > 50]
+opps.sort(key=lambda x: x['impressions'], reverse=True)
+for row in opps[:30]:
+    print(f\"{row['keys'][0]:<50} Pos: {row['position']:>5.1f}  Impr: {row['impressions']:>6}  Clicks: {row['clicks']:>4}\")
+"
+```
+
+### Cannibalization Detection
+
+Find queries where multiple pages compete for the same keyword.
+
+```bash
+# Pull query+page data, then group by query to find duplicates
+curl -s -X POST "..." | python3 -c "
+import json, sys
+from collections import defaultdict
+data = json.load(sys.stdin)
+query_pages = defaultdict(list)
+for row in data.get('rows', []):
+    query_pages[row['keys'][0]].append({
+        'page': row['keys'][1],
+        'clicks': row['clicks'],
+        'impressions': row['impressions'],
+        'position': row['position']
+    })
+print('== Keyword Cannibalization (multiple pages for same query) ==')
+for query, pages in sorted(query_pages.items(), key=lambda x: -sum(p['impressions'] for p in x[1])):
+    if len(pages) > 1:
+        total_impr = sum(p['impressions'] for p in pages)
+        if total_impr > 100:
+            print(f\"\nQuery: {query} ({total_impr} total impressions)\")
+            for p in sorted(pages, key=lambda x: -x['impressions']):
+                print(f\"  {p['page'][-60:]}  Pos: {p['position']:.1f}  Impr: {p['impressions']}  Clicks: {p['clicks']}\")
+"
+```
+
+---
+
+## Workflow: Full Search Performance Audit
+
+When asked for a complete GSC audit:
+
+1. **Overall Metrics**: Total clicks, impressions, avg CTR, avg position for last 90 days vs previous 90 days
+2. **Top 30 Queries**: By clicks, with CTR and position
+3. **Top 20 Pages**: By clicks, with CTR and position
+4. **Device Breakdown**: Desktop vs mobile performance
+5. **Low-Hanging Fruit**: High impressions + low CTR opportunities
+6. **Striking Distance**: Position 5-20 keywords with optimization potential
+7. **Cannibalization**: Queries with multiple competing pages
+8. **Index Coverage**: Spot-check important URLs
+9. **Sitemap Health**: Verify sitemaps are submitted and indexed
+
+### Report Format
+
+```
+## Search Console Audit: {domain}
+### Period: {date range}
+
+### Summary
+| Metric | Current | Previous | Change |
+|--------|---------|----------|--------|
+| Clicks | X | Y | +Z% |
+| Impressions | X | Y | +Z% |
+| Avg CTR | X% | Y% | +Z pp |
+| Avg Position | X | Y | +Z |
+
+### Top Queries
+| Query | Clicks | Impressions | CTR | Position |
+|-------|--------|-------------|-----|----------|
+| ...   | ...    | ...         | ... | ...      |
+
+### Optimization Opportunities
+
+#### Title/Description Optimization (High Impressions, Low CTR)
+1. "{query}" - {impressions} impressions, {ctr}% CTR, position {pos}
+   - Page: {url}
+   - Recommendation: ...
+
+#### Content Optimization (Striking Distance)
+1. "{query}" - position {pos}, {impressions} impressions
+   - Action: Add {query} to H2, expand section on {topic}
+
+#### Cannibalization Fixes
+1. "{query}" appears on {n} pages
+   - Consolidate to: {best_url}
+   - Redirect/noindex: {other_urls}
+```
+
+---
+
+## Rate Limits
+
+- Search Analytics API: 1,200 queries per minute
+- URL Inspection API: 2,000 inspections per day per property
+- Data freshness: Search data is typically 2-3 days behind
+
+## Common Errors
+
+| Error | Cause | Fix |
+|-------|-------|-----|
+| 403 | No access to this property | Verify ownership in GSC |
+| 400 | Invalid date range | Dates must be within last 16 months |
+| Empty rows | No data matching filters | Broaden date range or remove filters |

--- a/.claude/skills/semrush-research/SKILL.md
+++ b/.claude/skills/semrush-research/SKILL.md
@@ -1,0 +1,298 @@
+---
+name: semrush-research
+description: >
+  SEO and competitive intelligence via the SemRush API. Use when asked to
+  research competitors, analyze domains, find keyword opportunities, check
+  backlinks, or estimate traffic. Trigger phrases: "competitor analysis",
+  "domain overview", "keyword research", "backlink check", "traffic estimate",
+  "SEO intelligence", "semrush", "competitive research".
+---
+
+# SemRush Research
+
+Pull live SEO and competitive intelligence data from the SemRush API.
+
+## Prerequisites
+
+Requires `SEMRUSH_API_KEY` set in `.env`, `.env.local`, or `~/.claude/.env.global`.
+
+```bash
+# Verify the key is available
+echo "SEMRUSH_API_KEY is ${SEMRUSH_API_KEY:+set}"
+```
+
+If the key is not set, instruct the user:
+> You need a SemRush API key. Get one at https://www.semrush.com/api/
+> Then add `SEMRUSH_API_KEY=your_key` to your `.env` file.
+
+## API Base
+
+All requests go to `https://api.semrush.com/` with the API key passed as `&key={SEMRUSH_API_KEY}`.
+
+Responses are semicolon-delimited CSV. The first line is the header row. Parse accordingly.
+
+---
+
+## 1. Domain Overview
+
+Get a high-level snapshot of any domain's organic and paid search performance.
+
+### Endpoint
+
+```
+https://api.semrush.com/?type=domain_ranks&key={KEY}&export_columns=Dn,Rk,Or,Ot,Oc,Ad,At,Ac&domain={domain}
+```
+
+### Export Columns
+
+| Column | Meaning |
+|--------|---------|
+| `Dn` | Domain |
+| `Rk` | SemRush Rank |
+| `Or` | Organic keywords count |
+| `Ot` | Organic traffic estimate |
+| `Oc` | Organic traffic cost ($) |
+| `Ad` | Paid keywords count |
+| `At` | Paid traffic estimate |
+| `Ac` | Paid traffic cost ($) |
+
+### Example curl
+
+```bash
+curl -s "https://api.semrush.com/?type=domain_ranks&key=${SEMRUSH_API_KEY}&export_columns=Dn,Rk,Or,Ot,Oc,Ad,At,Ac&domain=example.com"
+```
+
+### Parsing the Response
+
+```bash
+# Response format (semicolon-delimited):
+# Dn;Rk;Or;Ot;Oc;Ad;At;Ac
+# example.com;12345;8234;145000;234500;120;3400;5600
+
+# Parse with awk
+curl -s "..." | awk -F';' 'NR==2 {
+  printf "Domain: %s\nSemRush Rank: %s\nOrganic Keywords: %s\nOrganic Traffic: %s\nOrganic Traffic Cost: $%s\nPaid Keywords: %s\nPaid Traffic: %s\nPaid Traffic Cost: $%s\n",
+  $1,$2,$3,$4,$5,$6,$7,$8
+}'
+```
+
+---
+
+## 2. Keyword Overview
+
+Get search volume, CPC, competition, and SERP features for a keyword.
+
+### Endpoint
+
+```
+https://api.semrush.com/?type=phrase_all&key={KEY}&phrase={keyword}&database=us&export_columns=Ph,Nq,Cp,Co,Nr,Td
+```
+
+### Export Columns
+
+| Column | Meaning |
+|--------|---------|
+| `Ph` | Keyword phrase |
+| `Nq` | Search volume (monthly) |
+| `Cp` | CPC (USD) |
+| `Co` | Competition (0-1) |
+| `Nr` | Number of results |
+| `Td` | Trend (12 months, comma-separated) |
+
+### Example curl
+
+```bash
+curl -s "https://api.semrush.com/?type=phrase_all&key=${SEMRUSH_API_KEY}&phrase=content+marketing&database=us&export_columns=Ph,Nq,Cp,Co,Nr,Td"
+```
+
+### Supported Databases
+
+Use `&database=XX` where XX is: `us`, `uk`, `ca`, `au`, `de`, `fr`, `es`, `it`, `br`, `in`, `jp`.
+
+---
+
+## 3. Related Keywords
+
+Find semantically related keywords for content planning and gap analysis.
+
+### Endpoint
+
+```
+https://api.semrush.com/?type=phrase_related&key={KEY}&phrase={keyword}&database=us&export_columns=Ph,Nq,Cp,Co,Nr,Td&display_limit=20
+```
+
+### Example curl
+
+```bash
+curl -s "https://api.semrush.com/?type=phrase_related&key=${SEMRUSH_API_KEY}&phrase=project+management&database=us&export_columns=Ph,Nq,Cp,Co,Nr,Td&display_limit=20"
+```
+
+### Parsing Multiple Rows
+
+```bash
+curl -s "..." | awk -F';' 'NR>1 { printf "%-40s Vol: %-8s CPC: $%-6s Comp: %s\n", $1, $2, $3, $4 }'
+```
+
+---
+
+## 4. Keyword Difficulty
+
+Estimate how hard it is to rank for a keyword.
+
+### Endpoint
+
+```
+https://api.semrush.com/?type=phrase_kdi&key={KEY}&phrase={keyword}&database=us&export_columns=Ph,Kd
+```
+
+| Column | Meaning |
+|--------|---------|
+| `Ph` | Keyword |
+| `Kd` | Keyword difficulty (0-100) |
+
+Interpretation:
+- 0-29: Easy - achievable with quality content
+- 30-49: Moderate - needs solid content + some backlinks
+- 50-69: Hard - needs strong domain authority + backlinks
+- 70-84: Very hard - requires established authority
+- 85-100: Extremely hard - dominated by top-tier domains
+
+---
+
+## 5. Domain Organic Keywords
+
+See which keywords a domain ranks for organically.
+
+### Endpoint
+
+```
+https://api.semrush.com/?type=domain_organic&key={KEY}&domain={domain}&database=us&export_columns=Ph,Po,Nq,Cp,Url,Tr,Tc&display_limit=50&display_sort=tr_desc
+```
+
+| Column | Meaning |
+|--------|---------|
+| `Ph` | Keyword |
+| `Po` | Position |
+| `Nq` | Search volume |
+| `Cp` | CPC |
+| `Url` | Ranking URL |
+| `Tr` | Traffic (%) |
+| `Tc` | Traffic cost |
+
+### Example curl
+
+```bash
+curl -s "https://api.semrush.com/?type=domain_organic&key=${SEMRUSH_API_KEY}&domain=hubspot.com&database=us&export_columns=Ph,Po,Nq,Cp,Url,Tr,Tc&display_limit=20&display_sort=tr_desc"
+```
+
+---
+
+## 6. Backlink Overview
+
+Get a summary of a domain's backlink profile.
+
+### Endpoint
+
+```
+https://api.semrush.com/analytics/v1/?key={KEY}&type=backlinks_overview&target={domain}&target_type=root_domain&export_columns=total,domains_num,urls_num,ips_num,follows_num,nofollows_num,texts_num,images_num
+```
+
+### Example curl
+
+```bash
+curl -s "https://api.semrush.com/analytics/v1/?key=${SEMRUSH_API_KEY}&type=backlinks_overview&target=example.com&target_type=root_domain&export_columns=total,domains_num,urls_num,ips_num,follows_num,nofollows_num,texts_num,images_num"
+```
+
+---
+
+## 7. Competitor Discovery
+
+Find domains competing for the same organic keywords.
+
+### Endpoint
+
+```
+https://api.semrush.com/?type=domain_organic_organic&key={KEY}&domain={domain}&database=us&export_columns=Dn,Cr,Np,Or,Ot,Oc,Ad&display_limit=10
+```
+
+| Column | Meaning |
+|--------|---------|
+| `Dn` | Competitor domain |
+| `Cr` | Competition level |
+| `Np` | Common keywords |
+| `Or` | Organic keywords |
+| `Ot` | Organic traffic |
+| `Oc` | Organic traffic cost |
+| `Ad` | Paid keywords |
+
+### Example curl
+
+```bash
+curl -s "https://api.semrush.com/?type=domain_organic_organic&key=${SEMRUSH_API_KEY}&domain=notion.so&database=us&export_columns=Dn,Cr,Np,Or,Ot,Oc,Ad&display_limit=10"
+```
+
+---
+
+## 8. Traffic Analytics (Estimates)
+
+Estimate a domain's overall traffic sources and engagement.
+
+### Endpoint
+
+```
+https://api.semrush.com/analytics/ta/api/v3/summary?key={KEY}&targets={domain}&display_date=2024-01-01&country=us&export_columns=target,visits,users,bounce_rate,pages_per_visit,avg_visit_duration
+```
+
+---
+
+## Workflow: Full Competitive Analysis
+
+When the user asks for a full competitive analysis, run these steps in order:
+
+1. **Domain Overview** - Get the target domain's metrics
+2. **Competitor Discovery** - Find top 5-10 competitors
+3. **Domain Overview** for each competitor - Compare metrics
+4. **Top Keywords** for each domain - Find keyword gaps
+5. **Backlink Overview** for each domain - Compare link profiles
+
+### Output Format
+
+Present results as a comparison table:
+
+```
+| Metric              | target.com | competitor1.com | competitor2.com |
+|---------------------|-----------|-----------------|-----------------|
+| SemRush Rank        | ...       | ...             | ...             |
+| Organic Keywords    | ...       | ...             | ...             |
+| Organic Traffic     | ...       | ...             | ...             |
+| Traffic Cost        | ...       | ...             | ...             |
+| Backlinks           | ...       | ...             | ...             |
+| Referring Domains   | ...       | ...             | ...             |
+```
+
+Then highlight:
+- **Keyword gaps**: Keywords competitors rank for but target does not
+- **Quick wins**: Keywords where target ranks positions 5-20 (improvement opportunities)
+- **Content gaps**: Topics competitors cover but target does not
+- **Backlink opportunities**: Sites linking to competitors but not target
+
+## Rate Limits and Costs
+
+- Each API call costs API units (check your plan)
+- Use `&display_limit=` to control result count (default varies by endpoint)
+- Cache results locally when doing multi-step analysis to avoid redundant calls
+- Domain overview calls are cheapest; backlink and traffic analytics cost more
+
+## Error Handling
+
+| Error | Meaning |
+|-------|---------|
+| `ERROR 50 :: NOTHING FOUND` | No data for this query |
+| `ERROR 120 :: WRONG KEY` | Invalid API key |
+| `ERROR 130 :: LIMIT EXCEEDED` | API unit limit reached |
+| Empty response | Usually means no data available for the query parameters |
+
+When you get "NOTHING FOUND", try:
+- Different database (e.g., `uk` instead of `us`)
+- Root domain instead of subdomain
+- Broader keyword phrase

--- a/.claude/skills/seo-audit/SKILL.md
+++ b/.claude/skills/seo-audit/SKILL.md
@@ -1,0 +1,234 @@
+---
+name: seo-audit
+description: Run a full technical and on-page SEO audit on any website or page. Use when the user says "audit my site", "SEO check", "technical SEO review", "site health", "check my SEO", "what's wrong with my site", or provides a URL and asks for SEO feedback.
+---
+
+# SEO Audit Skill
+
+You are an expert SEO auditor. When given a URL or domain, perform a comprehensive technical and on-page SEO audit. Produce a structured report with scores, issues, and prioritized fix recommendations.
+
+## Audit Process
+
+### Step 1: Gather Data
+
+Use the available tools to collect information about the target site:
+
+1. **Fetch the page** using WebFetch to get the HTML content
+2. **Check robots.txt** at `{domain}/robots.txt`
+3. **Check sitemap** at `{domain}/sitemap.xml` (also check robots.txt for sitemap location)
+4. **Fetch key pages** - homepage, a few inner pages, blog post if available
+5. **Check PageSpeed** via `https://www.googleapis.com/pagespeedonline/v5/runPagespeed?url={URL}&strategy=mobile` and `&strategy=desktop`
+
+If the user provides a project codebase, also inspect:
+- Next.js `next.config.js`, `app/layout.tsx`, `middleware.ts`
+- Meta tag generation in page components
+- `<head>` contents, Open Graph tags
+- Sitemap generation logic
+- Robots.txt file
+
+### Step 2: Audit Categories
+
+Evaluate each category below. Score each 0-100 and list specific issues found.
+
+---
+
+#### Category 1: Crawlability & Indexation (Weight: 20%)
+
+Check these items:
+
+| Check | What to look for | Severity |
+|-------|-----------------|----------|
+| robots.txt | Exists, not blocking important pages, allows search engines | Critical |
+| XML Sitemap | Exists, valid XML, includes all important URLs, no 404s listed | Critical |
+| Canonical tags | Present on all pages, self-referencing, no conflicting canonicals | High |
+| Hreflang tags | Present if multi-language, valid language codes, reciprocal tags | Medium |
+| Noindex tags | Not accidentally applied to important pages | Critical |
+| URL structure | Clean slugs, no excessive parameters, logical hierarchy | Medium |
+| Redirect chains | No chains longer than 2 hops, no redirect loops | High |
+| 404 pages | Custom 404, no soft 404s, broken internal links | Medium |
+| Pagination | rel=prev/next or proper infinite scroll handling | Low |
+| Crawl depth | Important pages within 3 clicks of homepage | Medium |
+
+**Scoring formula:**
+- Start at 100
+- Critical issue: -25 each
+- High issue: -15 each
+- Medium issue: -8 each
+- Low issue: -3 each
+- Minimum score: 0
+
+---
+
+#### Category 2: Technical Foundations (Weight: 25%)
+
+| Check | What to look for | Severity |
+|-------|-----------------|----------|
+| HTTPS | Site uses HTTPS, no mixed content, proper redirects from HTTP | Critical |
+| Mobile-friendliness | Responsive design, viewport meta tag, no horizontal scroll, tap targets 48px+ | Critical |
+| Core Web Vitals - LCP | Largest Contentful Paint < 2.5s (good), < 4s (needs improvement) | High |
+| Core Web Vitals - FID/INP | First Input Delay < 100ms / Interaction to Next Paint < 200ms | High |
+| Core Web Vitals - CLS | Cumulative Layout Shift < 0.1 (good), < 0.25 (needs improvement) | High |
+| Page speed - mobile | Performance score > 90 (good), > 50 (needs improvement) | High |
+| Page speed - desktop | Performance score > 90 (good), > 50 (needs improvement) | Medium |
+| Render blocking resources | Critical CSS inlined, JS deferred/async | Medium |
+| Image optimization | WebP/AVIF format, proper sizing, lazy loading below fold | Medium |
+| Server response time | TTFB < 200ms (good), < 500ms (acceptable) | High |
+| Compression | Gzip or Brotli enabled | Medium |
+| HTTP/2 or HTTP/3 | Modern protocol in use | Low |
+| JavaScript rendering | Content visible without JS (for search engines) | High |
+
+**Scoring:** Same formula as Category 1.
+
+---
+
+#### Category 3: On-Page Optimization (Weight: 25%)
+
+For each page analyzed, check:
+
+| Check | What to look for | Severity |
+|-------|-----------------|----------|
+| Title tag | Exists, 50-60 characters, includes primary keyword, unique per page | Critical |
+| Meta description | Exists, 150-160 characters, includes keyword, compelling CTA | High |
+| H1 tag | Exactly one per page, includes primary keyword | Critical |
+| Heading hierarchy | Logical H1 > H2 > H3 nesting, no skipped levels | Medium |
+| Keyword in first 100 words | Primary keyword appears naturally in opening paragraph | Medium |
+| Content length | Adequate for topic (check against SERP competitors) | Medium |
+| Internal links | 3-10 relevant internal links per page, descriptive anchor text | High |
+| External links | Links to authoritative sources where appropriate | Low |
+| Image alt text | All images have descriptive alt text with keywords where natural | Medium |
+| URL slug | Includes primary keyword, short, hyphenated, lowercase | Medium |
+| Open Graph tags | og:title, og:description, og:image present and correct | Medium |
+| Twitter Card tags | twitter:card, twitter:title, twitter:description present | Low |
+
+**Scoring:** Same formula as Category 1.
+
+---
+
+#### Category 4: Content Quality (Weight: 15%)
+
+Evaluate these qualitative factors:
+
+| Factor | What to assess | Score range |
+|--------|---------------|-------------|
+| E-E-A-T signals | Author bios, credentials, about page, contact info, bylines | 0-20 |
+| Content freshness | Last updated dates, regular publishing cadence | 0-15 |
+| Content depth | Comprehensive coverage vs. thin content, word count vs. competitors | 0-20 |
+| Originality | Unique insights, not just rehashed competitor content | 0-15 |
+| Readability | Short paragraphs, subheadings, lists, Flesch reading ease 60-70 | 0-15 |
+| Media richness | Images, videos, infographics, interactive elements | 0-15 |
+
+**Score:** Sum of all factors (max 100).
+
+---
+
+#### Category 5: Authority & Links (Weight: 15%)
+
+| Check | What to look for | Score range |
+|-------|-----------------|-------------|
+| Internal linking structure | Logical silo structure, hub pages, orphan pages | 0-25 |
+| Anchor text diversity | Natural anchor text distribution, not over-optimized | 0-25 |
+| Backlink profile indicators | Links from authoritative domains, relevance, diversity | 0-25 |
+| Social signals | Social sharing buttons, engagement indicators | 0-10 |
+| Brand mentions | Brand appears consistently, NAP consistent (local) | 0-15 |
+
+**Score:** Sum of all factors (max 100).
+
+---
+
+### Step 3: Calculate Overall Score
+
+```
+Overall = (Crawlability * 0.20) + (Technical * 0.25) + (On-Page * 0.25) + (Content * 0.15) + (Authority * 0.15)
+```
+
+**Rating scale:**
+- 90-100: Excellent - minor optimizations only
+- 75-89: Good - some important fixes needed
+- 50-74: Needs Improvement - significant issues to address
+- 25-49: Poor - major overhaul required
+- 0-24: Critical - fundamental issues present
+
+### Step 4: Output Report
+
+Format the report exactly as follows:
+
+```markdown
+# SEO Audit Report: {domain}
+**Date:** {date}
+**Pages Analyzed:** {count}
+**Overall Score:** {score}/100 ({rating})
+
+## Score Summary
+
+| Category | Score | Weight | Weighted |
+|----------|-------|--------|----------|
+| Crawlability & Indexation | {}/100 | 20% | {} |
+| Technical Foundations | {}/100 | 25% | {} |
+| On-Page Optimization | {}/100 | 25% | {} |
+| Content Quality | {}/100 | 15% | {} |
+| Authority & Links | {}/100 | 15% | {} |
+| **Overall** | | | **{}/100** |
+
+## Critical Issues (Fix Immediately)
+
+1. **{Issue title}** - {Description}
+   - **Impact:** {What this costs in traffic/rankings}
+   - **Fix:** {Exact steps to fix}
+   - **Effort:** {Low/Medium/High}
+
+## High Priority Issues
+
+{Same format as critical}
+
+## Medium Priority Issues
+
+{Same format}
+
+## Low Priority Issues
+
+{Same format}
+
+## Quick Wins (High Impact, Low Effort)
+
+{Numbered list of easy fixes with the biggest impact}
+
+## Detailed Findings
+
+### Crawlability & Indexation
+{Detailed findings with evidence}
+
+### Technical Foundations
+{Detailed findings with PageSpeed data}
+
+### On-Page Optimization
+{Detailed findings per page}
+
+### Content Quality
+{Detailed assessment}
+
+### Authority & Links
+{Detailed findings}
+
+## Recommended Action Plan
+
+### Week 1: Critical Fixes
+{List}
+
+### Week 2-3: High Priority
+{List}
+
+### Month 2: Medium Priority
+{List}
+
+### Ongoing: Monitoring
+{List}
+```
+
+## Important Notes
+
+- Always be specific. Instead of "improve page speed", say "compress hero image from 2.4MB to ~200KB using WebP format".
+- Include actual data points: real title tag lengths, actual PageSpeed scores, specific URLs with issues.
+- If you cannot access a resource (blocked by robots.txt, auth required), note it explicitly.
+- Compare findings against the site's top 3 competitors when possible.
+- For Next.js sites, provide code-level fix suggestions (e.g., specific component changes, next.config.js updates).
+- Never fabricate metrics. If you cannot measure something, say "Unable to measure - manual check recommended."

--- a/.claude/skills/seo-content-brief/SKILL.md
+++ b/.claude/skills/seo-content-brief/SKILL.md
@@ -1,0 +1,205 @@
+---
+name: seo-content-brief
+description: Create an SEO content brief for writers. Use when the user says "content brief", "SEO brief", "writing brief", "brief for", "writer brief", "outline for SEO", or asks about creating a structured brief to hand to a writer for producing search-optimized content.
+---
+
+# SEO Content Brief Skill
+
+You are an SEO content strategist. Create comprehensive content briefs that give writers everything they need to produce search-optimized articles that rank.
+
+## Brief Creation Process
+
+### Step 1: Search Intent Analysis
+
+Before writing a brief, determine what Google thinks this query means:
+
+1. **Search the keyword** using WebSearch
+2. **Classify intent:**
+   - Informational (how, what, why, guide) → Blog post, guide
+   - Commercial (best, review, vs, top) → Comparison, listicle
+   - Transactional (buy, price, free, download) → Landing page, product page
+   - Navigational (brand + feature) → Product/feature page
+
+3. **Identify content type from SERP:**
+   - What format dominates top 5? (Listicle, how-to, guide, comparison)
+   - What content length are top results? (Estimate from structure)
+   - Are there featured snippets? What format? (Paragraph, list, table)
+
+### Step 2: SERP Analysis
+
+For the target keyword, analyze top 5-10 results:
+
+| Result | Title | Format | Est. Length | Unique Angle |
+|--------|-------|--------|-------------|-------------|
+| #1 | {title} | {format} | {words} | {what makes it different} |
+| #2 | ... | ... | ... | ... |
+
+**Extract from top results:**
+- Common H2/H3 topics (every result covers these → mandatory sections)
+- Unique sections (only 1-2 results cover → differentiation opportunity)
+- Questions answered (People Also Ask + in-content FAQs)
+- Types of media used (images, videos, tables, infographics)
+
+### Step 3: Keyword Research
+
+**Primary keyword:** The main target
+**Secondary keywords:** 5-10 related terms to include naturally
+**Question keywords:** 4-6 questions from "People Also Ask"
+**LSI keywords:** Related terms that signal topical depth
+
+If SemRush API is available (`SEMRUSH_API_KEY`), pull:
+```bash
+# Primary keyword data
+curl -s "https://api.semrush.com/?type=phrase_all&key=${SEMRUSH_API_KEY}&phrase={keyword}&database=us&export_columns=Ph,Nq,Cp,Co,Nr,Td"
+
+# Related keywords
+curl -s "https://api.semrush.com/?type=phrase_related&key=${SEMRUSH_API_KEY}&phrase={keyword}&database=us&export_columns=Ph,Nq,Cp,Co&display_limit=20"
+
+# Question keywords
+curl -s "https://api.semrush.com/?type=phrase_questions&key=${SEMRUSH_API_KEY}&phrase={keyword}&database=us&export_columns=Ph,Nq,Cp,Co&display_limit=10"
+```
+
+### Step 4: Build the Heading Structure
+
+Map out the exact heading structure:
+
+```
+H1: {Title with primary keyword}
+  H2: {Section 1 — with secondary keyword}
+    H3: {Subsection if needed}
+  H2: {Section 2}
+    H3: {Subsection}
+  H2: {Section 3}
+  H2: {FAQ — with question keywords}
+    H3: {Question 1?}
+    H3: {Question 2?}
+```
+
+**Heading rules:**
+- H1: One per page, includes primary keyword
+- H2: Every 200-300 words, includes secondary keywords where natural
+- H3: Only when a section needs subdivision
+- No skipped levels (H1 → H3 without H2)
+
+### Step 5: Content Differentiation
+
+What will make this article better than the current #1 result?
+
+| Angle | How to Execute |
+|-------|---------------|
+| **More comprehensive** | Cover subtopics others miss |
+| **More current** | Include 2026 data, trends, updates |
+| **More actionable** | Add templates, checklists, tools |
+| **More authoritative** | Include expert quotes, original data, case studies |
+| **Better structured** | Tables, comparison charts, visual aids |
+| **Unique perspective** | First-hand experience, original research |
+
+## Brief Output Format
+
+```markdown
+# Content Brief: {Primary Keyword}
+
+**Date:** {date}
+**Author:** {assigned writer or TBD}
+**Due date:** {if applicable}
+
+---
+
+## Target Keyword Data
+
+| Keyword | Volume | KD | CPC | Intent |
+|---------|--------|-----|-----|--------|
+| **{Primary}** | {vol} | {kd} | ${cpc} | {intent} |
+| {Secondary 1} | {vol} | {kd} | ${cpc} | {intent} |
+| {Secondary 2} | {vol} | {kd} | ${cpc} | {intent} |
+| {Secondary 3} | {vol} | {kd} | ${cpc} | {intent} |
+
+## Content Specifications
+
+| Spec | Value |
+|------|-------|
+| **Content type** | {Blog post / Guide / Listicle / Comparison} |
+| **Target word count** | {X - Y words} |
+| **Target audience** | {Who is reading this?} |
+| **Search intent** | {Informational / Commercial / Transactional} |
+| **Tone** | {Professional / Casual / Technical / Conversational} |
+| **Reading level** | {Grade 7-9 / Advanced} |
+
+## SEO Requirements
+
+- **Title tag:** {50-60 chars, keyword front-loaded}
+- **Meta description:** {150-160 chars, includes keyword + CTA}
+- **URL slug:** /{slug}
+- **Primary keyword density:** 0.5-1.5%
+- **Secondary keywords:** Include each 2-3 times naturally
+- **Internal links:** {3-5 specific pages to link to}
+- **External links:** {3-5 authoritative sources to cite}
+
+## Heading Structure
+
+```
+{Full H1-H3 outline as designed in Step 4}
+```
+
+## Section-by-Section Guidance
+
+### {H2: Section Title}
+**Word count:** {X words}
+**Keywords to include:** {keyword1, keyword2}
+**Points to cover:**
+- {Specific point 1}
+- {Specific point 2}
+- {Specific point 3}
+**Content notes:** {Any specific guidance — data to include, examples, tone}
+
+{Repeat for each H2 section}
+
+## FAQ Section (Target Featured Snippets)
+
+| Question | Answer Guidance | Target Keyword |
+|----------|----------------|----------------|
+| {Question 1?} | {What the answer should cover in 2-4 sentences} | {keyword} |
+| {Question 2?} | {Answer guidance} | {keyword} |
+| {Question 3?} | {Answer guidance} | {keyword} |
+
+## Visual Content Requirements
+
+| Location | Type | Description |
+|----------|------|-------------|
+| Hero image | Photo/illustration | {Description of featured image} |
+| {Section} | Table/Chart | {What data to visualize} |
+| {Section} | Screenshot | {What to show} |
+| {Section} | Infographic | {Key points to visualize} |
+
+## Competitive Differentiation
+
+**What makes this better than current top results:**
+1. {Specific advantage 1}
+2. {Specific advantage 2}
+3. {Specific advantage 3}
+
+## Reference Links
+
+- {URL 1}: {What to reference from this}
+- {URL 2}: {What to reference from this}
+
+## Checklist for Writer
+
+- [ ] Title includes primary keyword in first 60 characters
+- [ ] Primary keyword in first 100 words
+- [ ] All H2/H3 headings match the outline
+- [ ] Internal links included (3-5 minimum)
+- [ ] External authoritative sources cited
+- [ ] FAQ section with 4-6 questions
+- [ ] Images have descriptive alt text
+- [ ] Paragraphs are 2-4 sentences max
+- [ ] Reading level is grade 7-9
+- [ ] No factual claims without sources
+```
+
+## Important Notes
+
+- A brief should save the writer time, not constrain them. Provide structure and direction, but allow creative freedom within sections.
+- Always verify keyword data is current. Search volumes and difficulty change over time.
+- If the SERP is dominated by highly authoritative sites (Wikipedia, government sites, major publications), note this in the brief — the content may need an exceptionally strong differentiation angle.
+- The heading structure should feel natural to read, not forced for SEO. If a keyword doesn't fit naturally in a heading, use it in the body instead.

--- a/.claude/skills/serp-analyzer/SKILL.md
+++ b/.claude/skills/serp-analyzer/SKILL.md
@@ -1,0 +1,306 @@
+---
+name: serp-analyzer
+description: Analyze Google search results (SERP) for any keyword. Use when the user says "analyze the SERP", "what ranks for", "SERP analysis", "competitive analysis for keyword", "content brief", "what's ranking", "search results for", "who ranks for", or asks about ranking content patterns for a keyword.
+---
+
+# SERP Analyzer Skill
+
+You are an expert SERP analyst. Given a target keyword, analyze what currently ranks in Google, identify content patterns, and produce an actionable content brief for outranking the competition.
+
+## Prerequisites
+
+Optional API keys for enriched data (the skill can work without any of them using web search):
+- `SEMRUSH_API_KEY` - for keyword and organic results data
+- `SERPAPI_API_KEY` - for real-time Google SERP data including SERP features
+- `DATAFORSEO_LOGIN` and `DATAFORSEO_PASSWORD` - for advanced SERP data
+
+## Analysis Process
+
+### Step 1: Collect SERP Data
+
+Use multiple data sources to build a complete SERP picture:
+
+**Method A: SemRush API (if available)**
+```
+# Get organic results for keyword
+https://api.semrush.com/?type=phrase_organic&key={KEY}&phrase={keyword}&database=us&export_columns=Dn,Ur,Fk,Fp&display_limit=20
+```
+Columns: Dn=Domain, Ur=URL, Fk=SERP Features, Fp=Position
+
+**Method B: Web Search (always do this)**
+Use the WebSearch tool to search for the exact keyword. This gives you real-time SERP data.
+
+**Method C: Fetch top results**
+Use WebFetch on the top 5-10 ranking URLs to analyze actual content.
+
+**Method D: SerpAPI (if SERPAPI_API_KEY available)**
+
+Real-time Google SERP data with structured SERP features:
+```bash
+# Real-time Google SERP data via SerpAPI
+curl -s "https://serpapi.com/search.json?q={keyword}&api_key=${SERPAPI_API_KEY}&num=20&gl=us&hl=en"
+```
+
+The JSON response includes:
+- `organic_results` - Array of organic listings with `position`, `title`, `link`, `snippet`, `displayed_link`
+- `related_questions` - People Also Ask questions with `question`, `snippet`, `title`, `link`
+- `knowledge_graph` - Knowledge panel data with `title`, `description`, `entity_type`, and attributes
+- `shopping_results` - Product listings (if present) with `title`, `price`, `link`, `source`
+- `local_results` - Local Pack listings (if present) with `title`, `address`, `rating`, `reviews`
+- `inline_images` - Image pack results
+- `answer_box` - Featured snippet content with `type` (paragraph, list, table), `snippet`, `title`
+- `related_searches` - Related search queries
+
+Parse example:
+```bash
+# Extract organic results
+curl -s "https://serpapi.com/search.json?q={keyword}&api_key=${SERPAPI_API_KEY}&num=20&gl=us&hl=en" | \
+  jq '.organic_results[] | {position, title, link, snippet}'
+
+# Extract People Also Ask questions
+curl -s "https://serpapi.com/search.json?q={keyword}&api_key=${SERPAPI_API_KEY}&num=20&gl=us&hl=en" | \
+  jq '.related_questions[] | {question, snippet}'
+
+# Check for knowledge graph
+curl -s "https://serpapi.com/search.json?q={keyword}&api_key=${SERPAPI_API_KEY}&num=20&gl=us&hl=en" | \
+  jq '.knowledge_graph | {title, description, entity_type}'
+```
+
+SerpAPI is especially useful for mapping SERP features in Step 2, as it returns structured data for every feature type.
+
+**Method E: DataForSEO (if DATAFORSEO_LOGIN and DATAFORSEO_PASSWORD available)**
+
+Advanced SERP data with detailed item types and ranking metrics:
+```bash
+# DataForSEO SERP API
+curl -s -X POST "https://api.dataforseo.com/v3/serp/google/organic/live/advanced" \
+  -H "Authorization: Basic $(echo -n '${DATAFORSEO_LOGIN}:${DATAFORSEO_PASSWORD}' | base64)" \
+  -H "Content-Type: application/json" \
+  -d '[{"keyword": "{keyword}", "location_code": 2840, "language_code": "en"}]'
+```
+
+The response provides:
+- `result[0].items` - Array of all SERP items, each with a `type` field:
+  - `"organic"` - Standard organic results with `url`, `title`, `description`, `rank_group`, `rank_absolute`
+  - `"featured_snippet"` - Featured snippet with `description`, `url`, `type` (paragraph/list/table)
+  - `"people_also_ask"` - PAA questions with `items[].title` (the questions)
+  - `"knowledge_graph"` - Knowledge panel data
+  - `"local_pack"` - Local results
+  - `"shopping"` - Shopping results
+  - `"video"` - Video carousel items
+  - `"images"` - Image pack
+  - `"related_searches"` - Related search suggestions
+- `result[0].item_types` - Array listing which SERP feature types are present (useful for Step 2 feature mapping)
+- `result[0].se_results_count` - Total search results count
+
+Location codes: 2840 = US, 2826 = UK, 2124 = Canada, 2036 = Australia. Change `location_code` for geo-targeted analysis.
+
+### Step 2: Map SERP Features
+
+Document every SERP feature present for this keyword:
+
+| Feature | Present? | Who owns it? | Can you win it? |
+|---------|----------|-------------|-----------------|
+| Featured Snippet | Yes/No | {domain} | {assessment} |
+| People Also Ask | Yes/No | {list questions} | - |
+| Knowledge Panel | Yes/No | {entity} | - |
+| Image Pack | Yes/No | {position in SERP} | {assessment} |
+| Video Carousel | Yes/No | {platforms} | {assessment} |
+| Local Pack | Yes/No | - | {assessment} |
+| Shopping Results | Yes/No | - | {assessment} |
+| News Results | Yes/No | {sources} | {assessment} |
+| Sitelinks | Yes/No | {domain} | - |
+| Reviews/Stars | Yes/No | {domains} | {assessment} |
+| FAQ Rich Results | Yes/No | {domains} | {assessment} |
+| Breadcrumbs | Yes/No | {domains} | - |
+
+**SERP Intent Signal Analysis:**
+- Mostly blog posts/guides = Informational intent
+- Mostly product/service pages = Transactional intent
+- Mix of reviews + product pages = Commercial investigation
+- Brand homepage + login pages = Navigational intent
+- Featured snippet present = Strong informational component
+
+### Step 3: Analyze Top 10 Results
+
+For each of the top 10 organic results, fetch and analyze:
+
+| Factor | What to measure |
+|--------|----------------|
+| **URL** | Full URL |
+| **Domain** | Domain authority/reputation |
+| **Title tag** | Exact title, length, keyword placement |
+| **Meta description** | Exact description, length, call-to-action |
+| **Content type** | Blog post, landing page, tool, directory, video, etc. |
+| **Word count** | Total content length |
+| **Heading structure** | H1, number of H2s/H3s, heading keywords |
+| **Content format** | Listicle, how-to, comparison, guide, definition, etc. |
+| **Visuals** | Number of images, videos, infographics, tables |
+| **Date** | Published date, last updated date |
+| **Author** | Named author, credentials shown |
+| **Unique angle** | What differentiates this from others |
+| **Internal links** | Number of internal links |
+| **External links** | Number of outbound links, sources cited |
+| **Schema markup** | Types of structured data used |
+| **Reading level** | Approximate Flesch-Kincaid grade level |
+
+### Step 4: Identify Patterns
+
+After analyzing all top 10 results, find commonalities:
+
+**Content Pattern Analysis:**
+
+```markdown
+## Content Patterns for "{keyword}"
+
+### Dominant Content Type: {type}
+{X} of 10 results are {blog posts/landing pages/tools/etc.}
+
+### Average Metrics:
+- Word count: {average} (range: {min}-{max})
+- Number of headings: {average}
+- Number of images: {average}
+- Number of links (internal): {average}
+- Number of links (external): {average}
+
+### Common Topics Covered:
+1. {topic} - covered by {X}/10 results
+2. {topic} - covered by {X}/10 results
+3. {topic} - covered by {X}/10 results
+...
+
+### Common H2 Headings:
+1. "{heading}" or similar - used by {X}/10
+2. "{heading}" or similar - used by {X}/10
+...
+
+### Featured Snippet Format:
+Type: {paragraph/list/table/video}
+Content: {what the snippet shows}
+How to win it: {specific advice}
+```
+
+### Step 5: Find Content Gaps
+
+Identify what the top results are MISSING:
+
+- Topics mentioned by only 1-2 results (opportunity to be comprehensive)
+- Outdated information (opportunity for freshness)
+- Missing media types (no videos, no infographics, no interactive tools)
+- Missing perspectives (no expert quotes, no data, no case studies)
+- Unanswered "People Also Ask" questions
+- Missing schema markup types
+- Poor user experience (slow, no mobile optimization, intrusive ads)
+
+### Step 6: Analyze Competitive Positioning
+
+For each top 5 competitor, create a positioning map:
+
+```
+Competitor 1 ({domain}): {Positioning summary - e.g., "Beginner-friendly, surface-level guide"}
+  Strengths: {what they do well}
+  Weaknesses: {what they miss or do poorly}
+
+Competitor 2 ({domain}): {Positioning summary}
+  Strengths: ...
+  Weaknesses: ...
+```
+
+**Find your differentiation angle:**
+- Can you be more comprehensive? (10x content)
+- Can you be more actionable? (templates, tools, checklists)
+- Can you be more current? (latest data, 2025 updates)
+- Can you be more authoritative? (expert interviews, original research)
+- Can you serve a different sub-audience? (beginners vs. advanced)
+- Can you provide a unique format? (interactive tool vs. blog post)
+
+### Step 7: Generate Content Brief
+
+Produce a complete content brief based on the analysis:
+
+```markdown
+# Content Brief: {Target Keyword}
+
+## Target Keyword
+- **Primary:** {keyword} (Volume: {vol}, KD: {kd})
+- **Secondary:** {keyword2}, {keyword3}, {keyword4}
+- **Long-tail:** {keyword5}, {keyword6}
+
+## Search Intent
+**Primary intent:** {Informational/Commercial/Transactional}
+**User goal:** {What the searcher wants to accomplish}
+**Stage in funnel:** {Awareness/Consideration/Decision}
+
+## Content Specifications
+
+| Spec | Recommendation | Reasoning |
+|------|---------------|-----------|
+| Content type | {blog/landing/tool} | {X}/10 results are this type |
+| Word count | {target} words | Top 3 average {avg}, aim for {target} |
+| Format | {listicle/how-to/guide} | Dominant format in SERP |
+| Reading level | Grade {X} | Match audience expectation |
+| Visuals | {X} images, {X} custom graphics | Top results average {Y} |
+| Videos | {Yes/No - embed or create} | {Reasoning} |
+
+## Title Tag Recommendations
+Write 3 options following these patterns from top results:
+1. "{Title option 1}" ({length} chars)
+2. "{Title option 2}" ({length} chars)
+3. "{Title option 3}" ({length} chars)
+
+## Meta Description Recommendations
+1. "{Meta option 1}" ({length} chars)
+2. "{Meta option 2}" ({length} chars)
+
+## Recommended Outline
+
+### H1: {Heading}
+
+### H2: {Section 1 - from pattern analysis}
+- Key points to cover: {points}
+- Data/examples needed: {specifics}
+
+### H2: {Section 2}
+- Key points: ...
+
+### H2: {Section 3}
+...
+
+### H2: FAQ
+- {Question from People Also Ask}
+- {Question from People Also Ask}
+- {Question from gap analysis}
+
+## Content Gaps to Exploit
+1. **{Gap}** - Only {X}/10 competitors cover this. Include {specific content}.
+2. **{Gap}** - No competitors have {data/tool/visual}. Create {specific asset}.
+3. **{Gap}** - Top results are outdated on {topic}. Include {current data}.
+
+## Schema Markup to Include
+- {Type}: {Brief description of properties}
+- {Type}: {Brief description}
+
+## Internal Linking Targets
+- Link TO this page from: {related pages on your site}
+- Link FROM this page to: {related pages on your site}
+
+## Differentiation Strategy
+{2-3 sentences on how this content will stand out from current SERP}
+```
+
+## Output Format
+
+Always present:
+1. **SERP Overview** - Feature map and intent analysis
+2. **Top 10 Analysis Table** - Key metrics for each result
+3. **Pattern Summary** - What the SERP rewards
+4. **Content Gaps** - Opportunities to differentiate
+5. **Content Brief** - Complete brief ready for a writer
+
+## Notes
+
+- If you cannot fetch a URL (paywall, auth, blocking), note it and work with available data.
+- Always note the date of analysis. SERPs change; this is a snapshot.
+- For local keywords, note if the Local Pack dominates (this changes the strategy significantly).
+- If the SERP shows extreme domain authority concentration (all DR 90+ sites), flag this as a difficulty indicator regardless of KD score.
+- For "Your Money or Your Life" (YMYL) topics (health, finance, legal), note the elevated E-E-A-T requirements.

--- a/.claude/skills/signup-flow-cro/SKILL.md
+++ b/.claude/skills/signup-flow-cro/SKILL.md
@@ -1,0 +1,358 @@
+---
+name: signup-flow-cro
+description: >
+  Optimize signup and registration conversion funnels. Use when asked to improve
+  signup rates, reduce form abandonment, audit registration flows, or optimize
+  conversion funnels. Trigger phrases: "signup optimization", "registration flow",
+  "form conversion", "signup CRO", "reduce abandonment", "signup funnel",
+  "form optimization", "conversion rate optimization", "registration page".
+---
+
+# Signup Flow CRO
+
+Audit and optimize signup conversion funnels to maximize registration completions.
+
+---
+
+## 1. Signup Flow Audit Framework
+
+When auditing a signup flow, evaluate each of these dimensions:
+
+### Number of Steps
+
+| Steps | Benchmark Completion Rate | Notes |
+|-------|--------------------------|-------|
+| 1 (single page) | 65-80% | Best for simple products |
+| 2 | 50-65% | Good balance of data collection and UX |
+| 3 | 35-50% | Acceptable for complex products |
+| 4+ | 20-35% | Only if justified by product complexity |
+
+**Rule of thumb:** Every additional step loses 10-20% of users.
+
+**Audit questions:**
+- Can any steps be combined?
+- Can any steps be deferred to post-signup?
+- Is every step necessary for the user to start getting value?
+
+### Form Fields
+
+| Fields | Impact on Conversion |
+|--------|---------------------|
+| Email only | Highest conversion (baseline) |
+| Email + password | -10-15% vs email only |
+| Email + password + name | -15-25% vs email only |
+| 5+ fields | -30-50% vs email only |
+
+**Audit questions:**
+- Which fields are truly required at signup? (vs. collected later)
+- Can you use progressive profiling instead of upfront collection?
+- Are field labels clear and unambiguous?
+- Do fields use appropriate input types (email, tel, etc.)?
+- Are there unnecessary fields (phone, company size, "how did you hear about us")?
+
+### Social Login Options
+
+| Provider | Typical Lift | Best For |
+|----------|-------------|----------|
+| Google | +15-25% | B2B, SaaS, productivity tools |
+| Apple | +5-15% | iOS-first products, privacy-conscious users |
+| GitHub | +10-20% | Developer tools |
+| Microsoft | +5-15% | Enterprise, Office-adjacent tools |
+| Facebook | +5-10% | B2C, social products (declining trust) |
+
+**Audit questions:**
+- Are social login buttons prominent or buried?
+- Do social logins request minimal permissions?
+- Is there a fallback if social auth fails?
+
+### Progress Indicators
+
+For multi-step flows, progress indicators reduce abandonment.
+
+**Types:**
+- Step counter ("Step 2 of 3")
+- Progress bar (visual fill)
+- Checklist (shows completed and upcoming steps)
+- Breadcrumb ("Account > Profile > Preferences")
+
+**Best practice:** Show remaining steps, not total steps. "Just 1 more step" is more motivating than "Step 3 of 4."
+
+### Error Handling
+
+**Audit checklist:**
+- [ ] Inline validation (errors appear next to the field, not at top of form)
+- [ ] Real-time validation (check as user types, not on submit)
+- [ ] Clear error messages (say what's wrong AND how to fix it)
+- [ ] Password requirements shown upfront (not after failed attempt)
+- [ ] Email format validation with helpful suggestion ("Did you mean gmail.com?")
+- [ ] Preserve entered data on error (never clear the form)
+- [ ] Specific duplicate account messaging ("An account with this email exists. Log in?")
+
+### Mobile Optimization
+
+**Audit checklist:**
+- [ ] Form fills the viewport without horizontal scroll
+- [ ] Input fields are at least 44px tap targets
+- [ ] Keyboard type matches input (email keyboard for email, number pad for phone)
+- [ ] Auto-focus on first field
+- [ ] Sticky CTA button visible without scrolling
+- [ ] No CAPTCHA that's hard to solve on mobile (use invisible reCAPTCHA)
+- [ ] Social login buttons work smoothly on mobile
+
+---
+
+## 2. Benchmark Conversion Rates by Industry
+
+### Visitor-to-Signup Rates
+
+| Industry | Free Signup | Free Trial | Paid Signup |
+|----------|-----------|-----------|-------------|
+| SaaS (B2B) | 2-5% | 3-8% | 1-3% |
+| SaaS (B2C) | 5-15% | 5-10% | 2-5% |
+| E-commerce | 2-4% | N/A | 2-4% |
+| Media/Content | 5-10% | N/A | 1-2% |
+| FinTech | 1-3% | N/A | 0.5-2% |
+| EdTech | 3-8% | 5-12% | 1-3% |
+| Health/Fitness | 5-10% | 8-15% | 2-5% |
+| Developer Tools | 8-15% | 10-20% | 2-5% |
+| Marketplace | 3-8% | N/A | N/A |
+
+### Signup-to-Activation Rates
+
+| Product Type | Benchmark |
+|-------------|-----------|
+| Self-serve SaaS | 20-40% |
+| Free trial (no CC) | 15-25% |
+| Free trial (CC required) | 40-60% |
+| Freemium | 10-20% |
+| Mobile app | 15-30% |
+
+---
+
+## 3. A/B Test Hypotheses by Step
+
+### Pre-Signup (Landing Page to Signup Start)
+
+**Hypothesis 1: Reducing perceived effort increases signup starts**
+- Test: Replace "Create Account" button with "Get Started Free" or "Start in 30 seconds"
+- Expected lift: 5-15%
+
+**Hypothesis 2: Social proof near CTA increases conversion**
+- Test: Add "Join 10,000+ teams" or user count next to signup button
+- Expected lift: 5-12%
+
+**Hypothesis 3: Showing the product increases intent**
+- Test: Add screenshot or demo GIF above signup form
+- Expected lift: 10-20%
+
+**Hypothesis 4: Reducing options increases action**
+- Test: Remove pricing tiers from signup page; show one clear CTA
+- Expected lift: 8-15%
+
+### Step 1: Account Creation
+
+**Hypothesis 5: Social login as primary option reduces friction**
+- Test: Show "Continue with Google" as the primary/largest button, email form secondary
+- Expected lift: 15-25%
+
+**Hypothesis 6: Fewer fields increase completion**
+- Test: Email-only signup (collect name later) vs email + name + password
+- Expected lift: 10-20%
+
+**Hypothesis 7: Magic link eliminates password friction**
+- Test: "Enter email, we'll send a login link" vs traditional password creation
+- Expected lift: 5-15% (higher for mobile)
+
+**Hypothesis 8: Password visibility toggle reduces errors**
+- Test: Add show/hide password toggle
+- Expected lift: 3-8%
+
+### Step 2: Profile / Preferences
+
+**Hypothesis 9: Making profile completion optional increases flow-through**
+- Test: Add "Skip for now" option to profile step
+- Expected lift: 15-25%
+
+**Hypothesis 10: Explaining why increases willingness**
+- Test: Add micro-copy explaining why each field is needed ("We use this to personalize your dashboard")
+- Expected lift: 5-10%
+
+**Hypothesis 11: Visual selection beats text input**
+- Test: Use icon/image cards for preference selection vs dropdown/text
+- Expected lift: 8-15%
+
+### Step 3: Verification
+
+**Hypothesis 12: Delayed email verification increases activation**
+- Test: Let users access the product immediately, verify email later
+- Expected lift: 20-40% on activation rate
+
+**Hypothesis 13: SMS verification is faster than email**
+- Test: Offer phone verification as alternative to email
+- Expected lift: 5-10% on verification completion
+
+### Post-Signup
+
+**Hypothesis 14: Immediate value delivery reduces churn**
+- Test: Drop users into a pre-populated workspace vs empty state
+- Expected lift: 15-30% on day-1 retention
+
+---
+
+## 4. Signup Page Templates
+
+### Minimal (Email-Only)
+
+```
+[Logo]
+
+Get started with [Product]
+
+[Email input field]
+[Continue button: "Start Free"]
+
+or continue with [Google] [Apple]
+
+Already have an account? Log in
+
+[Privacy note: "No credit card required. Free forever for individuals."]
+```
+
+### Standard (Email + Password)
+
+```
+[Logo]
+
+Create your [Product] account
+
+[Continue with Google]
+[Continue with Apple]
+
+---- or ----
+
+[Email input]
+[Password input] [show/hide toggle]
+[Continue button]
+
+By signing up, you agree to our Terms and Privacy Policy.
+
+Already have an account? Log in
+```
+
+### Multi-Step
+
+```
+Step 1: Account
+[Logo]
+"Let's set up your account"
+[Email] [Password] [Continue]
+
+Step 2: About You (optional)
+"Help us personalize your experience"
+[Role dropdown] [Company size] [Use case cards]
+[Continue] [Skip for now]
+
+Step 3: Workspace
+"Name your workspace"
+[Workspace name input]
+[Invite teammates (optional): email1, email2]
+[Get Started]
+```
+
+---
+
+## 5. Friction Reducers
+
+### Micro-Copy That Converts
+
+| Location | Copy | Purpose |
+|----------|------|---------|
+| Below CTA | "Free forever. No credit card." | Remove risk |
+| Below CTA | "Setup takes 30 seconds" | Set expectation |
+| By email field | "We'll never spam you" | Build trust |
+| By password field | "8+ characters" | Prevent errors |
+| By social login | "We only access your name and email" | Privacy assurance |
+| After form | "Join 50,000+ users" | Social proof |
+
+### Trust Signals
+
+- Security badges (SSL, SOC2, GDPR)
+- Customer logos (if B2B)
+- Review scores (G2, Capterra, Trustpilot)
+- "As featured in" media logos
+- Number of users or companies
+- Data privacy statement
+
+---
+
+## 6. Signup Flow Audit Output Template
+
+When auditing a signup flow, produce this report:
+
+```
+## Signup Flow Audit: [Product Name]
+### Audit Date: [Date]
+
+### Current Flow
+- Steps: [X]
+- Fields: [List all fields]
+- Social login: [Yes/No, which providers]
+- Mobile optimized: [Yes/Partial/No]
+- Time to complete: ~[X] seconds
+
+### Scores (1-10)
+| Dimension | Score | Notes |
+|-----------|-------|-------|
+| Simplicity | X | [Why] |
+| Mobile UX | X | [Why] |
+| Error handling | X | [Why] |
+| Trust signals | X | [Why] |
+| Speed/friction | X | [Why] |
+| **Overall** | **X** | |
+
+### Issues Found
+1. **[Critical]** [Issue description]
+   - Impact: [Estimated conversion loss]
+   - Fix: [Specific recommendation]
+
+2. **[High]** [Issue description]
+   - Impact: [Estimated conversion loss]
+   - Fix: [Specific recommendation]
+
+3. **[Medium]** [Issue description]
+   ...
+
+### Recommended A/B Tests (Priority Order)
+1. [Test description] - Expected lift: X%
+2. [Test description] - Expected lift: X%
+3. [Test description] - Expected lift: X%
+
+### Quick Wins (No A/B Test Needed)
+- [ ] [Fix description] - implement immediately
+- [ ] [Fix description] - implement immediately
+```
+
+---
+
+## 7. Tools for Signup CRO
+
+| Tool | Use Case | Price |
+|------|----------|-------|
+| Hotjar / Microsoft Clarity | Heatmaps, session recordings, form analytics | Free tier available |
+| Google Optimize (sunset) / VWO | A/B testing | $0-$199/mo |
+| Amplitude / Mixpanel | Funnel analysis, drop-off tracking | Free tier available |
+| Crazy Egg | Click maps, scroll maps | $29/mo+ |
+| FullStory | Session replay, frustration detection | Free tier available |
+| Formisimo | Form field analytics | Custom pricing |
+
+### Key Metrics to Track
+
+| Metric | How to Measure |
+|--------|---------------|
+| Signup page visit rate | GA4: page views on signup URL |
+| Signup start rate | % who interact with first field or click social login |
+| Field-level drop-off | Form analytics tool (which field causes abandonment) |
+| Signup completion rate | Completed signups / signup page visits |
+| Time to complete | Session recording analysis |
+| Error rate | % of submissions with validation errors |
+| Social vs email split | % using each method |

--- a/.claude/skills/similarweb-traffic/SKILL.md
+++ b/.claude/skills/similarweb-traffic/SKILL.md
@@ -1,0 +1,80 @@
+---
+name: similarweb-traffic
+description: Fetch website traffic estimates (monthly visits, traffic sources, top countries, keywords, engagement, ranks) for any domain from SimilarWeb. Use when the user asks about a domain's traffic, monthly visits, traffic sources, audience countries, or wants to compare/benchmark sites against competitors.
+---
+
+# SimilarWeb Traffic
+
+Fetch traffic-overview estimates for any domain — monthly visits, traffic-source breakdown, top countries, top keywords, engagement metrics, and global/category ranks.
+
+## When to Use This Skill
+
+Use this skill when the user:
+
+- Asks how much traffic a domain gets ("what's the traffic for X")
+- Wants monthly visit trends for a site
+- Needs a traffic-source breakdown (organic vs direct vs paid vs GenAI, etc.)
+- Wants to know a site's audience countries
+- Wants to compare/benchmark several domains against each other or competitors
+
+## Usage
+
+No API key required. Self-contained Node script (uses built-in `fetch`, no `npm install`).
+
+```bash
+node scripts/fetch-similarweb-traffic.js <domain>
+```
+
+Examples:
+```bash
+# Formatted markdown summary (default)
+node scripts/fetch-similarweb-traffic.js chatslide.ai
+
+# Raw normalized JSON (for further processing / comparisons)
+node scripts/fetch-similarweb-traffic.js stripe.com --json
+```
+
+The domain can be passed bare (`example.com`) or as a URL (`https://www.example.com/pricing`) — it gets normalized (strips scheme, `www.`, and path).
+
+### Comparing multiple domains
+
+Run the script once per domain with `--json` and combine the results into a table. Add a short delay between calls to be polite to the endpoint.
+
+## Output
+
+Default mode prints a markdown summary: a metrics table (monthly visits, ranks, bounce, pages/visit, time on site), a monthly-visits trend line, traffic-source breakdown, top countries, and top keywords.
+
+`--json` mode prints a normalized object:
+
+```json
+{
+  "domain": "stripe.com",
+  "globalRank": 327,
+  "categoryRank": 21,
+  "category": "Finance",
+  "snapshotMonth": "2026-05",
+  "visits": 122394040,
+  "bounceRate": 0.55,
+  "pagesPerVisit": 3.26,
+  "timeOnSite": 165.9,
+  "estimatedMonthlyVisits": [{ "date": "2026-03-01", "visits": 118067753 }],
+  "trafficSources": { "searchOrganic": 0.48, "direct": 0.23, "...": 0 },
+  "topCountries": [{ "countryCode": "US", "value": 0.087 }],
+  "topKeywords": ["..."]
+}
+```
+
+`visits` is the most recent complete month. Rates (`bounceRate`, all `trafficSources`, `topCountries[].value`) are 0–1 fractions.
+
+## API Details
+
+- Endpoint: `https://data.similarweb.com/api/v1/data?domain=<domain>` — SimilarWeb's **undocumented public data endpoint** (the one their browser extension uses). No auth, no key, free.
+- Requires a browser `user-agent` header (the script sends one) — default `curl`/bot agents are blocked.
+- Synchronous, returns immediately.
+
+## Important Notes
+
+- **Estimates, not ground truth.** SimilarWeb models traffic; numbers can be off, especially for mid/low-traffic sites. For a domain you own, your own Google Analytics / Search Console data is authoritative — prefer those when available.
+- **Unknown domains return zeros, not an error.** SimilarWeb responds HTTP 200 with all-zero/synthetic data when it has no data for a domain. If every visit count is 0, treat it as "no SimilarWeb data."
+- **Unofficial endpoint.** It can be rate-limited, change shape, or require auth without notice; this is a gray-area use of SimilarWeb's data outside their paid API.
+- Exit codes: `2` network error, `3` non-200 HTTP response.

--- a/.claude/skills/similarweb-traffic/scripts/fetch-similarweb-traffic.js
+++ b/.claude/skills/similarweb-traffic/scripts/fetch-similarweb-traffic.js
@@ -1,0 +1,167 @@
+#!/usr/bin/env node
+// Fetch traffic overview for a domain from SimilarWeb's public data endpoint.
+// No dependencies, no API key. Same endpoint PageGun's fetchSimilarwebTraffic() uses.
+//
+// Usage:
+//   node fetch-similarweb-traffic.js <domain> [--json]
+//   node fetch-similarweb-traffic.js chatslide.ai
+//   node fetch-similarweb-traffic.js chatslide.ai --json   # raw normalized JSON only
+
+const DATA_URL = 'https://data.similarweb.com/api/v1/data'
+const USER_AGENT =
+  'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36'
+
+function normalizeDomain(domain) {
+  return String(domain || '')
+    .trim()
+    .replace(/^https?:\/\//i, '')
+    .replace(/^www\./i, '')
+    .replace(/\/.*$/, '')
+    .toLowerCase()
+}
+
+function num(v) {
+  if (v === null || v === undefined || v === '') return null
+  const n = Number(v)
+  return Number.isFinite(n) ? n : null
+}
+
+function fmt(n) {
+  return n === null ? 'n/a' : n.toLocaleString('en-US')
+}
+
+function pct(v) {
+  const n = num(v)
+  return n === null ? 'n/a' : `${(n * 100).toFixed(1)}%`
+}
+
+async function main() {
+  const args = process.argv.slice(2)
+  const jsonOnly = args.includes('--json')
+  const domain = normalizeDomain(args.find((a) => !a.startsWith('--')))
+
+  if (!domain) {
+    console.error('Usage: node fetch-similarweb-traffic.js <domain> [--json]')
+    process.exit(1)
+  }
+
+  const url = new URL(DATA_URL)
+  url.searchParams.set('domain', domain)
+
+  let res
+  try {
+    res = await fetch(url, {
+      headers: {
+        accept: 'application/json,text/plain,*/*',
+        'accept-language': 'en-US,en;q=0.9',
+        'user-agent': USER_AGENT,
+      },
+    })
+  } catch (err) {
+    console.error(`Network error fetching ${domain}: ${err.message}`)
+    process.exit(2)
+  }
+
+  if (!res.ok) {
+    console.error(`SimilarWeb request failed for ${domain}: HTTP ${res.status}`)
+    if (res.status === 404) console.error('(404 usually means SimilarWeb has no data for this domain.)')
+    process.exit(3)
+  }
+
+  const d = await res.json()
+  const e = d.Engagments || {}
+  const ts = d.TrafficSources || {}
+
+  const overview = {
+    domain,
+    siteName: d.SiteName ?? null,
+    title: d.Title ?? null,
+    description: d.Description ?? null,
+    globalRank: num(d.GlobalRank && d.GlobalRank.Rank),
+    categoryRank: num(d.CategoryRank && d.CategoryRank.Rank),
+    category: (d.CategoryRank && d.CategoryRank.Category) ?? null,
+    snapshotMonth:
+      e.Year && e.Month ? `${e.Year}-${String(e.Month).padStart(2, '0')}` : null,
+    visits: num(e.Visits),
+    bounceRate: num(e.BounceRate),
+    pagesPerVisit: num(e.PagePerVisit),
+    timeOnSite: num(e.TimeOnSite),
+    estimatedMonthlyVisits: Object.entries(d.EstimatedMonthlyVisits || {})
+      .map(([date, v]) => ({ date, visits: num(v) }))
+      .sort((a, b) => a.date.localeCompare(b.date)),
+    trafficSources: {
+      searchOrganic: num(ts.SearchOrganic),
+      searchPaid: num(ts.SearchPaid),
+      direct: num(ts.Direct),
+      referrals: num(ts.Referrals),
+      socialOrganic: num(ts.SocialOrganic),
+      socialPaid: num(ts.SocialPaid),
+      mail: num(ts.Mail),
+      displayAds: num(ts['Display Ads'] ?? ts.DisplayAds),
+      genAi: num(ts.GenAi),
+      affiliate: num(ts.Affiliate),
+    },
+    topCountries: (d.TopCountryShares || []).map((c) => ({
+      countryCode: c.CountryCode ?? null,
+      value: num(c.Value),
+    })),
+    topKeywords: (d.TopKeywords || []).map((k) => k.Name).filter(Boolean),
+  }
+
+  if (jsonOnly) {
+    console.log(JSON.stringify(overview, null, 2))
+    return
+  }
+
+  const lines = []
+  lines.push(`# SimilarWeb traffic — ${domain}`)
+  if (overview.snapshotMonth) lines.push(`Snapshot month: ${overview.snapshotMonth}`)
+  lines.push('')
+  lines.push('| Metric | Value |')
+  lines.push('|---|---|')
+  lines.push(`| Monthly visits | ${fmt(overview.visits)} |`)
+  lines.push(`| Global rank | ${overview.globalRank ? '#' + fmt(overview.globalRank) : 'n/a'} |`)
+  lines.push(`| Category rank | ${overview.categoryRank ? '#' + fmt(overview.categoryRank) : 'n/a'} |`)
+  lines.push(`| Category | ${overview.category ?? 'n/a'} |`)
+  lines.push(`| Bounce rate | ${pct(overview.bounceRate)} |`)
+  lines.push(`| Pages / visit | ${overview.pagesPerVisit === null ? 'n/a' : overview.pagesPerVisit.toFixed(2)} |`)
+  lines.push(`| Avg. time on site | ${overview.timeOnSite === null ? 'n/a' : Math.round(overview.timeOnSite) + 's'} |`)
+
+  if (overview.estimatedMonthlyVisits.length) {
+    lines.push('')
+    lines.push('**Monthly visits trend:**')
+    lines.push(
+      overview.estimatedMonthlyVisits
+        .map((p) => `${p.date.slice(0, 7)}: ${fmt(p.visits)}`)
+        .join('  →  '),
+    )
+  }
+
+  const srcEntries = Object.entries(overview.trafficSources)
+    .filter(([, v]) => v !== null && v > 0)
+    .sort((a, b) => b[1] - a[1])
+  if (srcEntries.length) {
+    lines.push('')
+    lines.push('**Traffic sources:**')
+    for (const [k, v] of srcEntries) lines.push(`- ${k}: ${pct(v)}`)
+  }
+
+  if (overview.topCountries.length) {
+    lines.push('')
+    lines.push('**Top countries:** ' + overview.topCountries
+      .map((c) => `${c.countryCode} ${pct(c.value)}`)
+      .join(', '))
+  }
+
+  if (overview.topKeywords.length) {
+    lines.push('')
+    lines.push('**Top keywords:** ' + overview.topKeywords.slice(0, 8).join(', '))
+  }
+
+  console.log(lines.join('\n'))
+}
+
+main().catch((err) => {
+  console.error(err.message)
+  process.exit(1)
+})

--- a/.claude/skills/slack-bot/SKILL.md
+++ b/.claude/skills/slack-bot/SKILL.md
@@ -1,0 +1,1246 @@
+---
+name: slack-bot
+description: >
+  Send messages and rich content to Slack channels via webhooks or Bot API. Use Block Kit for
+  formatted announcements, marketing reports, and community updates. Trigger phrases:
+  "post to slack", "slack message", "slack webhook", "slack notification", "slack announcement",
+  "send to slack", "slack marketing", "slack update", "slack channel".
+allowed-tools:
+  - Bash
+  - WebFetch
+  - WebSearch
+---
+
+# Slack Bot
+
+Send messages and rich content to Slack channels using Incoming Webhooks or the Slack Web API.
+Build formatted announcements, marketing reports, metrics dashboards, and community updates
+with Block Kit.
+
+## Prerequisites
+
+Requires either `SLACK_WEBHOOK_URL` or `SLACK_BOT_TOKEN` set in `.env`, `.env.local`, or
+`~/.claude/.env.global`.
+
+```bash
+source ~/.claude/.env.global 2>/dev/null
+source .env 2>/dev/null
+source .env.local 2>/dev/null
+
+if [ -n "$SLACK_WEBHOOK_URL" ]; then
+  echo "SLACK_WEBHOOK_URL is set. Webhook mode available."
+elif [ -n "$SLACK_BOT_TOKEN" ]; then
+  echo "SLACK_BOT_TOKEN is set. Web API mode available."
+else
+  echo "Neither SLACK_WEBHOOK_URL nor SLACK_BOT_TOKEN is set."
+  echo "See the Setup Guide below to configure Slack credentials."
+fi
+```
+
+If neither variable is set, instruct the user to follow the Setup Guide section below.
+
+---
+
+## Setup Guide
+
+### Option A: Incoming Webhook (Simple)
+
+Incoming Webhooks are the fastest way to post messages. They require no OAuth scopes and are
+scoped to a single channel.
+
+1. Go to https://api.slack.com/apps and click **Create New App** > **From scratch**.
+2. Name the app (e.g., "Marketing Bot") and select your workspace.
+3. In the left sidebar, click **Incoming Webhooks** and toggle it **On**.
+4. Click **Add New Webhook to Workspace** at the bottom.
+5. Select the channel to post to and click **Allow**.
+6. Copy the Webhook URL (starts with `https://hooks.slack.com/services/...`).
+7. Add it to your environment:
+
+```bash
+echo 'SLACK_WEBHOOK_URL=https://hooks.slack.com/services/T.../B.../xxxx' >> .env
+```
+
+**Limitations:** One webhook per channel. Cannot read messages, list channels, or reply to
+threads programmatically (you must know the `thread_ts` from a prior API response).
+
+### Option B: Bot Token (Full Featured)
+
+Bot tokens give access to the full Slack Web API: post to any channel the bot is in, reply to
+threads, list channels, upload files, and more.
+
+1. Go to https://api.slack.com/apps and click **Create New App** > **From scratch**.
+2. Name the app and select your workspace.
+3. In the left sidebar, click **OAuth & Permissions**.
+4. Under **Bot Token Scopes**, add these scopes:
+   - `chat:write` - Post messages
+   - `chat:write.public` - Post to channels without joining
+   - `channels:read` - List public channels
+   - `files:write` - Upload files (optional, for images/reports)
+   - `reactions:write` - Add emoji reactions (optional)
+5. Click **Install to Workspace** at the top and authorize.
+6. Copy the **Bot User OAuth Token** (starts with `xoxb-`).
+7. Add it to your environment:
+
+```bash
+echo 'SLACK_BOT_TOKEN=xoxb-your-token-here' >> .env
+```
+
+8. Invite the bot to the channels it should post in: type `/invite @YourBotName` in each channel.
+
+**Optional:** Set a default channel for convenience:
+
+```bash
+echo 'SLACK_DEFAULT_CHANNEL=#marketing' >> .env
+```
+
+---
+
+## Method 1: Incoming Webhooks
+
+### Send a Simple Text Message
+
+```bash
+curl -s -X POST "$SLACK_WEBHOOK_URL" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "text": "Hello from the marketing bot!"
+  }'
+```
+
+### Send a Message with Username and Icon Override
+
+```bash
+curl -s -X POST "$SLACK_WEBHOOK_URL" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "text": "New blog post published!",
+    "username": "Marketing Bot",
+    "icon_emoji": ":mega:"
+  }'
+```
+
+### Send a Message with Block Kit (Webhook)
+
+```bash
+curl -s -X POST "$SLACK_WEBHOOK_URL" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "blocks": [
+      {
+        "type": "header",
+        "text": {
+          "type": "plain_text",
+          "text": "New Product Launch"
+        }
+      },
+      {
+        "type": "section",
+        "text": {
+          "type": "mrkdwn",
+          "text": "*Product X* is now live! Check out the announcement."
+        }
+      },
+      {
+        "type": "divider"
+      },
+      {
+        "type": "section",
+        "text": {
+          "type": "mrkdwn",
+          "text": "Read the full announcement on our blog."
+        },
+        "accessory": {
+          "type": "button",
+          "text": {
+            "type": "plain_text",
+            "text": "Read More"
+          },
+          "url": "https://example.com/blog/launch"
+        }
+      }
+    ]
+  }'
+```
+
+---
+
+## Method 2: Slack Web API (Bot Token)
+
+The Web API provides full control over message delivery, threading, channel management, and more.
+
+### API Base
+
+All requests go to `https://slack.com/api/` with the header `Authorization: Bearer {SLACK_BOT_TOKEN}`.
+
+### Post a Message to a Channel
+
+```bash
+curl -s -X POST "https://slack.com/api/chat.postMessage" \
+  -H "Authorization: Bearer ${SLACK_BOT_TOKEN}" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "channel": "#marketing",
+    "text": "Weekly metrics report is ready!",
+    "blocks": [
+      {
+        "type": "header",
+        "text": {
+          "type": "plain_text",
+          "text": "Weekly Marketing Metrics"
+        }
+      },
+      {
+        "type": "section",
+        "text": {
+          "type": "mrkdwn",
+          "text": "Here are the numbers for this week."
+        }
+      }
+    ]
+  }'
+```
+
+The response includes a `ts` (timestamp) field which identifies the message. Save this value
+for threading replies:
+
+```bash
+# Post and capture the message timestamp for threading
+RESPONSE=$(curl -s -X POST "https://slack.com/api/chat.postMessage" \
+  -H "Authorization: Bearer ${SLACK_BOT_TOKEN}" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "channel": "#marketing",
+    "text": "Thread parent message"
+  }')
+
+MESSAGE_TS=$(echo "$RESPONSE" | python3 -c "import json,sys; print(json.load(sys.stdin).get('ts',''))")
+echo "Message timestamp: $MESSAGE_TS"
+```
+
+### Reply to a Thread
+
+Use the `thread_ts` parameter to reply inside an existing thread:
+
+```bash
+curl -s -X POST "https://slack.com/api/chat.postMessage" \
+  -H "Authorization: Bearer ${SLACK_BOT_TOKEN}" \
+  -H "Content-Type: application/json" \
+  -d "{
+    \"channel\": \"#marketing\",
+    \"thread_ts\": \"${MESSAGE_TS}\",
+    \"text\": \"This is a threaded reply with additional details.\"
+  }"
+```
+
+To also broadcast the reply to the channel (so it appears in the main conversation as well),
+add `"reply_broadcast": true`.
+
+### Update an Existing Message
+
+```bash
+curl -s -X POST "https://slack.com/api/chat.update" \
+  -H "Authorization: Bearer ${SLACK_BOT_TOKEN}" \
+  -H "Content-Type: application/json" \
+  -d "{
+    \"channel\": \"#marketing\",
+    \"ts\": \"${MESSAGE_TS}\",
+    \"text\": \"Updated message content.\",
+    \"blocks\": []
+  }"
+```
+
+### Delete a Message
+
+```bash
+curl -s -X POST "https://slack.com/api/chat.delete" \
+  -H "Authorization: Bearer ${SLACK_BOT_TOKEN}" \
+  -H "Content-Type: application/json" \
+  -d "{
+    \"channel\": \"#marketing\",
+    \"ts\": \"${MESSAGE_TS}\"
+  }"
+```
+
+### List Public Channels
+
+Useful for discovering which channel to post to:
+
+```bash
+curl -s "https://slack.com/api/conversations.list?types=public_channel&limit=100" \
+  -H "Authorization: Bearer ${SLACK_BOT_TOKEN}" | \
+  python3 -c "
+import json, sys
+data = json.load(sys.stdin)
+for ch in data.get('channels', []):
+    members = ch.get('num_members', 0)
+    print(f\"#{ch['name']}  |  Members: {members}  |  ID: {ch['id']}\")
+"
+```
+
+### Upload a File to a Channel
+
+```bash
+curl -s -X POST "https://slack.com/api/files.uploadV2" \
+  -H "Authorization: Bearer ${SLACK_BOT_TOKEN}" \
+  -F "file=@report.pdf" \
+  -F "filename=weekly-report.pdf" \
+  -F "channel_id=C0123456789" \
+  -F "initial_comment=Here is this week's marketing report."
+```
+
+### Add an Emoji Reaction
+
+```bash
+curl -s -X POST "https://slack.com/api/reactions.add" \
+  -H "Authorization: Bearer ${SLACK_BOT_TOKEN}" \
+  -H "Content-Type: application/json" \
+  -d "{
+    \"channel\": \"C0123456789\",
+    \"timestamp\": \"${MESSAGE_TS}\",
+    \"name\": \"white_check_mark\"
+  }"
+```
+
+---
+
+## Slack Block Kit Reference
+
+Block Kit is Slack's UI framework for building rich, interactive messages. Messages are composed
+of an array of blocks, each with a specific type and structure.
+
+### Block Types
+
+| Block Type | Purpose | Supports mrkdwn |
+|------------|---------|-----------------|
+| `header` | Large bold title text | No (plain_text only) |
+| `section` | Primary content block with text and optional accessory | Yes |
+| `divider` | Horizontal line separator | N/A |
+| `image` | Full-width image with alt text | N/A |
+| `context` | Small, muted text and images (for metadata, timestamps) | Yes |
+| `actions` | Row of interactive elements (buttons, selects, date pickers) | N/A |
+| `rich_text` | Advanced formatted text (lists, quotes, code blocks) | N/A |
+
+### Header Block
+
+```json
+{
+  "type": "header",
+  "text": {
+    "type": "plain_text",
+    "text": "Weekly Marketing Report",
+    "emoji": true
+  }
+}
+```
+
+### Section Block
+
+Plain text section:
+
+```json
+{
+  "type": "section",
+  "text": {
+    "type": "mrkdwn",
+    "text": "*Traffic is up 23%* this week compared to last week.\nOrganic search drove most of the growth."
+  }
+}
+```
+
+Section with fields (two-column layout):
+
+```json
+{
+  "type": "section",
+  "fields": [
+    {
+      "type": "mrkdwn",
+      "text": "*Visitors*\n12,450"
+    },
+    {
+      "type": "mrkdwn",
+      "text": "*Signups*\n342"
+    },
+    {
+      "type": "mrkdwn",
+      "text": "*MRR*\n$28,500"
+    },
+    {
+      "type": "mrkdwn",
+      "text": "*Churn*\n1.2%"
+    }
+  ]
+}
+```
+
+Section with a button accessory:
+
+```json
+{
+  "type": "section",
+  "text": {
+    "type": "mrkdwn",
+    "text": "New blog post: *How We Grew 10x in 6 Months*"
+  },
+  "accessory": {
+    "type": "button",
+    "text": {
+      "type": "plain_text",
+      "text": "Read Post"
+    },
+    "url": "https://example.com/blog/growth-story",
+    "action_id": "read_blog_post"
+  }
+}
+```
+
+Section with an image accessory:
+
+```json
+{
+  "type": "section",
+  "text": {
+    "type": "mrkdwn",
+    "text": "*New Feature: Dark Mode*\nOur most requested feature is finally here."
+  },
+  "accessory": {
+    "type": "image",
+    "image_url": "https://example.com/images/dark-mode-preview.png",
+    "alt_text": "Dark mode preview"
+  }
+}
+```
+
+### Divider Block
+
+```json
+{
+  "type": "divider"
+}
+```
+
+### Image Block
+
+```json
+{
+  "type": "image",
+  "image_url": "https://example.com/images/chart.png",
+  "alt_text": "Weekly traffic chart",
+  "title": {
+    "type": "plain_text",
+    "text": "Traffic Overview"
+  }
+}
+```
+
+### Context Block
+
+```json
+{
+  "type": "context",
+  "elements": [
+    {
+      "type": "mrkdwn",
+      "text": "Posted by *Marketing Team* | Feb 10, 2026"
+    },
+    {
+      "type": "image",
+      "image_url": "https://example.com/logo-small.png",
+      "alt_text": "Company logo"
+    }
+  ]
+}
+```
+
+### Actions Block (Buttons)
+
+```json
+{
+  "type": "actions",
+  "elements": [
+    {
+      "type": "button",
+      "text": {
+        "type": "plain_text",
+        "text": "Approve"
+      },
+      "style": "primary",
+      "action_id": "approve_action",
+      "value": "approved"
+    },
+    {
+      "type": "button",
+      "text": {
+        "type": "plain_text",
+        "text": "Reject"
+      },
+      "style": "danger",
+      "action_id": "reject_action",
+      "value": "rejected"
+    },
+    {
+      "type": "button",
+      "text": {
+        "type": "plain_text",
+        "text": "View Details"
+      },
+      "url": "https://example.com/details",
+      "action_id": "view_details"
+    }
+  ]
+}
+```
+
+Button styles: `"primary"` (green), `"danger"` (red), or omit for default (gray).
+
+**Note on interactivity:** Buttons with `action_id` (no `url`) require a Request URL configured
+in your Slack App settings under **Interactivity & Shortcuts** to receive the button click
+payload. Buttons with a `url` field open the link directly and do not require a backend.
+
+### Block Kit Limits
+
+| Limit | Value |
+|-------|-------|
+| Blocks per message | 50 |
+| Characters per text block | 3,000 |
+| Characters per header | 150 |
+| Fields per section | 10 |
+| Elements per actions block | 25 |
+| Elements per context block | 10 |
+
+### Block Kit Builder
+
+Use the visual builder to design and preview messages before coding them:
+https://app.slack.com/block-kit-builder
+
+---
+
+## Slack mrkdwn Formatting Guide
+
+Slack uses its own markdown variant called mrkdwn. It differs from standard Markdown in
+several ways.
+
+| Formatting | Syntax | Example |
+|-----------|--------|---------|
+| Bold | `*text*` | *bold text* |
+| Italic | `_text_` | _italic text_ |
+| Strikethrough | `~text~` | ~strikethrough~ |
+| Code (inline) | `` `text` `` | `inline code` |
+| Code block | ` ```text``` ` | Multi-line code block |
+| Blockquote | `>text` | Quoted text |
+| Link | `<https://url\|display text>` | Clickable link |
+| User mention | `<@U0123456>` | @username |
+| Channel mention | `<#C0123456>` | #channel |
+| Emoji | `:emoji_name:` | :rocket: |
+| Bulleted list | Start line with `- ` or `* ` | Bullet point |
+| Numbered list | Start line with `1. ` | Numbered item |
+| Line break | `\n` in JSON string | New line |
+
+**Important differences from standard Markdown:**
+- Bold uses single asterisks `*bold*`, not double `**bold**`.
+- Italic uses underscores `_italic_`, not single asterisks.
+- Links use `<url|text>` format with a pipe, not `[text](url)`.
+- Headers do not exist in mrkdwn. Use the `header` block type instead.
+- Images cannot be inlined in mrkdwn. Use the `image` block or `accessory` instead.
+
+---
+
+## Message Templates
+
+### Template 1: Product Announcement
+
+```bash
+curl -s -X POST "$SLACK_WEBHOOK_URL" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "blocks": [
+      {
+        "type": "header",
+        "text": {
+          "type": "plain_text",
+          "text": ":rocket: New Feature: [Feature Name]",
+          "emoji": true
+        }
+      },
+      {
+        "type": "section",
+        "text": {
+          "type": "mrkdwn",
+          "text": "We just shipped *[Feature Name]* — here is what it does and why it matters.\n\n:point_right: *What it does:* [One-sentence description]\n:point_right: *Why it matters:* [Key benefit for users]\n:point_right: *How to try it:* [Quick instructions or link]"
+        }
+      },
+      {
+        "type": "image",
+        "image_url": "https://example.com/feature-screenshot.png",
+        "alt_text": "Feature screenshot"
+      },
+      {
+        "type": "divider"
+      },
+      {
+        "type": "actions",
+        "elements": [
+          {
+            "type": "button",
+            "text": {
+              "type": "plain_text",
+              "text": ":newspaper: Read Announcement",
+              "emoji": true
+            },
+            "url": "https://example.com/blog/feature-launch",
+            "action_id": "read_announcement"
+          },
+          {
+            "type": "button",
+            "text": {
+              "type": "plain_text",
+              "text": ":play_or_pause_button: Watch Demo",
+              "emoji": true
+            },
+            "url": "https://example.com/demo",
+            "action_id": "watch_demo"
+          }
+        ]
+      },
+      {
+        "type": "context",
+        "elements": [
+          {
+            "type": "mrkdwn",
+            "text": "Posted by *Product Team* | :speech_balloon: Reply in thread with questions"
+          }
+        ]
+      }
+    ]
+  }'
+```
+
+### Template 2: Weekly Metrics Report
+
+```bash
+curl -s -X POST "$SLACK_WEBHOOK_URL" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "blocks": [
+      {
+        "type": "header",
+        "text": {
+          "type": "plain_text",
+          "text": ":bar_chart: Weekly Marketing Metrics — Feb 3-9, 2026",
+          "emoji": true
+        }
+      },
+      {
+        "type": "section",
+        "text": {
+          "type": "mrkdwn",
+          "text": "Here is this week'\''s performance snapshot."
+        }
+      },
+      {
+        "type": "divider"
+      },
+      {
+        "type": "section",
+        "text": {
+          "type": "mrkdwn",
+          "text": ":globe_with_meridians: *Website Traffic*"
+        },
+        "fields": [
+          {
+            "type": "mrkdwn",
+            "text": "*Sessions*\n45,230 (:arrow_up: 12%)"
+          },
+          {
+            "type": "mrkdwn",
+            "text": "*Unique Visitors*\n31,870 (:arrow_up: 8%)"
+          },
+          {
+            "type": "mrkdwn",
+            "text": "*Bounce Rate*\n42.3% (:arrow_down: 2.1%)"
+          },
+          {
+            "type": "mrkdwn",
+            "text": "*Avg. Session Duration*\n3m 42s (:arrow_up: 15s)"
+          }
+        ]
+      },
+      {
+        "type": "section",
+        "text": {
+          "type": "mrkdwn",
+          "text": ":money_with_wings: *Conversion Metrics*"
+        },
+        "fields": [
+          {
+            "type": "mrkdwn",
+            "text": "*Signups*\n487 (:arrow_up: 18%)"
+          },
+          {
+            "type": "mrkdwn",
+            "text": "*Trial-to-Paid*\n12.4% (:arrow_up: 1.2%)"
+          },
+          {
+            "type": "mrkdwn",
+            "text": "*MRR*\n$52,300 (:arrow_up: $3,200)"
+          },
+          {
+            "type": "mrkdwn",
+            "text": "*Churn*\n1.8% (:arrow_down: 0.3%)"
+          }
+        ]
+      },
+      {
+        "type": "section",
+        "text": {
+          "type": "mrkdwn",
+          "text": ":email: *Email Performance*"
+        },
+        "fields": [
+          {
+            "type": "mrkdwn",
+            "text": "*Emails Sent*\n12,400"
+          },
+          {
+            "type": "mrkdwn",
+            "text": "*Open Rate*\n34.2%"
+          },
+          {
+            "type": "mrkdwn",
+            "text": "*Click Rate*\n4.8%"
+          },
+          {
+            "type": "mrkdwn",
+            "text": "*Unsubscribes*\n23"
+          }
+        ]
+      },
+      {
+        "type": "divider"
+      },
+      {
+        "type": "section",
+        "text": {
+          "type": "mrkdwn",
+          "text": "*:bulb: Key Takeaways*\n- Organic traffic up 15% after publishing 3 new blog posts\n- Email welcome sequence A/B test: Variant B outperformed by 22%\n- Trial signup spike on Thursday correlated with Product Hunt feature"
+        }
+      },
+      {
+        "type": "actions",
+        "elements": [
+          {
+            "type": "button",
+            "text": {
+              "type": "plain_text",
+              "text": "Full Dashboard",
+              "emoji": true
+            },
+            "url": "https://analytics.example.com/dashboard",
+            "action_id": "view_dashboard"
+          }
+        ]
+      },
+      {
+        "type": "context",
+        "elements": [
+          {
+            "type": "mrkdwn",
+            "text": "Auto-generated by Marketing Bot | Data from Google Analytics + Stripe"
+          }
+        ]
+      }
+    ]
+  }'
+```
+
+### Template 3: Blog Post Share
+
+```bash
+curl -s -X POST "$SLACK_WEBHOOK_URL" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "blocks": [
+      {
+        "type": "header",
+        "text": {
+          "type": "plain_text",
+          "text": ":pencil: New Blog Post Published",
+          "emoji": true
+        }
+      },
+      {
+        "type": "section",
+        "text": {
+          "type": "mrkdwn",
+          "text": "*<https://example.com/blog/post-slug|Blog Post Title Here>*\n\nA brief summary of what the post covers — keep it to 2-3 sentences that capture the key value and make people want to click through."
+        },
+        "accessory": {
+          "type": "image",
+          "image_url": "https://example.com/blog/post-og-image.png",
+          "alt_text": "Blog post cover image"
+        }
+      },
+      {
+        "type": "context",
+        "elements": [
+          {
+            "type": "mrkdwn",
+            "text": ":bust_in_silhouette: Author: *Jane Smith* | :clock1: 6 min read | :label: SEO, Growth"
+          }
+        ]
+      },
+      {
+        "type": "divider"
+      },
+      {
+        "type": "section",
+        "text": {
+          "type": "mrkdwn",
+          "text": ":mega: *Help us amplify!* Share this post on your socials. Here are ready-to-use snippets:\n\n*Twitter/X:* _Just published: [title]. [Key insight from the post]. Link in reply._\n\n*LinkedIn:* _We just published a deep dive on [topic]. Here is the #1 takeaway: [insight]._"
+        }
+      },
+      {
+        "type": "actions",
+        "elements": [
+          {
+            "type": "button",
+            "text": {
+              "type": "plain_text",
+              "text": "Read the Post",
+              "emoji": true
+            },
+            "style": "primary",
+            "url": "https://example.com/blog/post-slug",
+            "action_id": "read_post"
+          },
+          {
+            "type": "button",
+            "text": {
+              "type": "plain_text",
+              "text": "Share on Twitter",
+              "emoji": true
+            },
+            "url": "https://twitter.com/intent/tweet?text=Check%20out%20this%20post&url=https://example.com/blog/post-slug",
+            "action_id": "share_twitter"
+          },
+          {
+            "type": "button",
+            "text": {
+              "type": "plain_text",
+              "text": "Share on LinkedIn",
+              "emoji": true
+            },
+            "url": "https://www.linkedin.com/sharing/share-offsite/?url=https://example.com/blog/post-slug",
+            "action_id": "share_linkedin"
+          }
+        ]
+      }
+    ]
+  }'
+```
+
+### Template 4: Team Update / Standup
+
+```bash
+curl -s -X POST "$SLACK_WEBHOOK_URL" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "blocks": [
+      {
+        "type": "header",
+        "text": {
+          "type": "plain_text",
+          "text": ":clipboard: Marketing Team Update — Monday, Feb 10",
+          "emoji": true
+        }
+      },
+      {
+        "type": "section",
+        "text": {
+          "type": "mrkdwn",
+          "text": "*:white_check_mark: Completed Last Week*\n- Launched email welcome sequence v2\n- Published 3 blog posts (SEO, product, case study)\n- Set up Google Ads remarketing campaign\n- Shipped landing page A/B test (Variant B live)"
+        }
+      },
+      {
+        "type": "section",
+        "text": {
+          "type": "mrkdwn",
+          "text": "*:construction: In Progress*\n- Content calendar for March (70% done)\n- Competitor analysis report (due Wednesday)\n- Social media campaign for Product Hunt launch"
+        }
+      },
+      {
+        "type": "section",
+        "text": {
+          "type": "mrkdwn",
+          "text": "*:dart: This Week'\''s Priorities*\n1. Finalize Product Hunt launch assets\n2. Send weekly newsletter (Thursday 9am)\n3. Review and approve Q1 ad spend budget\n4. Onboard new content writer"
+        }
+      },
+      {
+        "type": "section",
+        "text": {
+          "type": "mrkdwn",
+          "text": "*:warning: Blockers*\n- Waiting on design team for Product Hunt gallery images\n- Need legal review on new case study before publishing"
+        }
+      },
+      {
+        "type": "divider"
+      },
+      {
+        "type": "context",
+        "elements": [
+          {
+            "type": "mrkdwn",
+            "text": ":speech_balloon: Reply in thread with your own updates or questions"
+          }
+        ]
+      }
+    ]
+  }'
+```
+
+### Template 5: Incident / Urgent Notification
+
+```bash
+curl -s -X POST "$SLACK_WEBHOOK_URL" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "blocks": [
+      {
+        "type": "header",
+        "text": {
+          "type": "plain_text",
+          "text": ":rotating_light: Marketing Alert",
+          "emoji": true
+        }
+      },
+      {
+        "type": "section",
+        "text": {
+          "type": "mrkdwn",
+          "text": "*Issue:* [Brief description of the problem]\n*Impact:* [Who/what is affected]\n*Status:* :red_circle: Active\n*Owner:* <@U0123456>"
+        }
+      },
+      {
+        "type": "section",
+        "text": {
+          "type": "mrkdwn",
+          "text": "*Details:*\n[Longer explanation. What happened, when it started, what we know so far.]"
+        }
+      },
+      {
+        "type": "section",
+        "text": {
+          "type": "mrkdwn",
+          "text": "*Next Steps:*\n1. [Action item 1]\n2. [Action item 2]\n3. [Action item 3]"
+        }
+      },
+      {
+        "type": "actions",
+        "elements": [
+          {
+            "type": "button",
+            "text": {
+              "type": "plain_text",
+              "text": "Status Page"
+            },
+            "url": "https://status.example.com",
+            "action_id": "status_page"
+          }
+        ]
+      }
+    ]
+  }'
+```
+
+---
+
+## Workflows
+
+### Workflow 1: Post a Marketing Announcement
+
+When the user asks to post an announcement, product update, or news to Slack:
+
+1. **Gather details** - Ask for the announcement title, body, link, image URL, and target channel.
+2. **Choose a template** - Select from the templates above or build a custom Block Kit payload.
+3. **Build the payload** - Construct the JSON with proper mrkdwn formatting.
+4. **Preview** - Show the user the full JSON payload and describe how it will render.
+5. **Confirm** - Ask the user to approve before sending.
+6. **Send** - Execute the curl command.
+7. **Report** - Show the API response. For Web API, capture the `ts` for threading.
+
+### Workflow 2: Post Weekly Metrics
+
+When the user asks to send a metrics report or dashboard to Slack:
+
+1. **Collect metrics** - Ask for the numbers or help pull them from analytics tools.
+2. **Format with fields** - Use section blocks with `fields` for the two-column metric layout.
+3. **Add context** - Include week-over-week comparisons with arrow emoji.
+4. **Add takeaways** - Summarize 2-3 key insights in a section block.
+5. **Include a dashboard link** - Add a button to the full analytics dashboard.
+6. **Send and thread** - Post the main report, then thread detailed breakdowns as replies.
+
+### Workflow 3: Share a Blog Post
+
+When a new blog post needs to be distributed to the team:
+
+1. **Get the URL** - Ask for the blog post URL, or fetch the latest from the blog.
+2. **Extract metadata** - Use WebFetch to pull the title, description, author, and OG image.
+3. **Build the share message** - Use Template 3 with social amplification snippets.
+4. **Add share buttons** - Include Twitter and LinkedIn intent URLs pre-populated with the post.
+5. **Post to the channel** - Send to the team marketing channel.
+
+### Workflow 4: Community Engagement
+
+For managing Slack community channels (public communities, customer channels):
+
+1. **Welcome messages** - Post a welcome message with rules and resources when new members join.
+2. **Scheduled updates** - Post weekly roundups of popular discussions or new resources.
+3. **Event announcements** - Share upcoming webinars, AMAs, or meetups with RSVP buttons.
+4. **Polls and feedback** - Use actions blocks with buttons to collect quick feedback.
+5. **Thread management** - Reply to existing threads with updates or answers.
+
+---
+
+## Sending Messages with Dynamic Content
+
+### Build Payloads with Shell Variables
+
+```bash
+TITLE="Product X v2.0 Released"
+DESCRIPTION="Version 2.0 includes dark mode, API improvements, and 3x faster performance."
+LINK="https://example.com/changelog/v2"
+IMAGE_URL="https://example.com/images/v2-banner.png"
+CHANNEL="#announcements"
+
+curl -s -X POST "https://slack.com/api/chat.postMessage" \
+  -H "Authorization: Bearer ${SLACK_BOT_TOKEN}" \
+  -H "Content-Type: application/json" \
+  -d "$(python3 -c "
+import json
+payload = {
+    'channel': '${CHANNEL}',
+    'text': '${TITLE}',
+    'blocks': [
+        {
+            'type': 'header',
+            'text': {'type': 'plain_text', 'text': '${TITLE}', 'emoji': True}
+        },
+        {
+            'type': 'section',
+            'text': {'type': 'mrkdwn', 'text': '${DESCRIPTION}'}
+        },
+        {
+            'type': 'image',
+            'image_url': '${IMAGE_URL}',
+            'alt_text': '${TITLE}'
+        },
+        {
+            'type': 'actions',
+            'elements': [{
+                'type': 'button',
+                'text': {'type': 'plain_text', 'text': 'Learn More'},
+                'url': '${LINK}',
+                'style': 'primary',
+                'action_id': 'learn_more'
+            }]
+        }
+    ]
+}
+print(json.dumps(payload))
+")"
+```
+
+### Build Payloads from a JSON File
+
+For complex messages, write the payload to a file first:
+
+```bash
+# Write the payload
+cat > /tmp/slack-message.json << 'PAYLOAD'
+{
+  "channel": "#marketing",
+  "text": "Fallback text for notifications",
+  "blocks": [
+    {
+      "type": "header",
+      "text": {
+        "type": "plain_text",
+        "text": "Message Title"
+      }
+    },
+    {
+      "type": "section",
+      "text": {
+        "type": "mrkdwn",
+        "text": "Message body with *bold* and _italic_ formatting."
+      }
+    }
+  ]
+}
+PAYLOAD
+
+# Send it
+curl -s -X POST "https://slack.com/api/chat.postMessage" \
+  -H "Authorization: Bearer ${SLACK_BOT_TOKEN}" \
+  -H "Content-Type: application/json" \
+  -d @/tmp/slack-message.json
+```
+
+---
+
+## Scheduled Messages
+
+Post a message at a specific future time using `chat.scheduleMessage`:
+
+```bash
+# Schedule a message for a specific Unix timestamp
+# Use: date -d "2026-02-12 09:00:00" +%s (Linux) or date -j -f "%Y-%m-%d %H:%M:%S" "2026-02-12 09:00:00" +%s (macOS)
+SEND_AT=$(date -j -f "%Y-%m-%d %H:%M:%S" "2026-02-12 09:00:00" +%s 2>/dev/null || date -d "2026-02-12 09:00:00" +%s)
+
+curl -s -X POST "https://slack.com/api/chat.scheduleMessage" \
+  -H "Authorization: Bearer ${SLACK_BOT_TOKEN}" \
+  -H "Content-Type: application/json" \
+  -d "{
+    \"channel\": \"#marketing\",
+    \"post_at\": ${SEND_AT},
+    \"text\": \"Good morning team! Here is today's marketing agenda.\",
+    \"blocks\": []
+  }"
+```
+
+List scheduled messages:
+
+```bash
+curl -s "https://slack.com/api/chat.scheduledMessages.list" \
+  -H "Authorization: Bearer ${SLACK_BOT_TOKEN}" | \
+  python3 -c "
+import json, sys, datetime
+data = json.load(sys.stdin)
+for msg in data.get('scheduled_messages', []):
+    ts = datetime.datetime.fromtimestamp(msg['post_at']).strftime('%Y-%m-%d %H:%M')
+    print(f\"ID: {msg['id']}  |  Channel: {msg['channel_id']}  |  Scheduled: {ts}\")
+"
+```
+
+Delete a scheduled message:
+
+```bash
+curl -s -X POST "https://slack.com/api/chat.deleteScheduledMessage" \
+  -H "Authorization: Bearer ${SLACK_BOT_TOKEN}" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "channel": "C0123456789",
+    "scheduled_message_id": "Q0123456789"
+  }'
+```
+
+---
+
+## Multi-Channel Posting
+
+Post the same message to multiple channels:
+
+```bash
+CHANNELS=("#marketing" "#general" "#product")
+MESSAGE='{"text":"Big announcement coming tomorrow!","blocks":[{"type":"section","text":{"type":"mrkdwn","text":":mega: *Big announcement coming tomorrow!* Stay tuned."}}]}'
+
+for CHANNEL in "${CHANNELS[@]}"; do
+  echo "Posting to ${CHANNEL}..."
+  echo "$MESSAGE" | python3 -c "
+import json, sys
+msg = json.load(sys.stdin)
+msg['channel'] = '${CHANNEL}'
+print(json.dumps(msg))
+" | curl -s -X POST "https://slack.com/api/chat.postMessage" \
+    -H "Authorization: Bearer ${SLACK_BOT_TOKEN}" \
+    -H "Content-Type: application/json" \
+    -d @- | python3 -c "
+import json, sys
+r = json.load(sys.stdin)
+if r.get('ok'):
+    print(f'  Sent. ts={r[\"ts\"]}')
+else:
+    print(f'  Error: {r.get(\"error\", \"unknown\")}')
+"
+done
+```
+
+---
+
+## Error Handling
+
+### Common API Errors
+
+| Error | Cause | Fix |
+|-------|-------|-----|
+| `invalid_auth` | Bad or expired token | Regenerate the bot token in Slack App settings |
+| `channel_not_found` | Bot not in channel or wrong channel name | Invite bot with `/invite @BotName` or use channel ID |
+| `not_in_channel` | Bot needs to join the channel first | Invite the bot or use `chat:write.public` scope |
+| `too_many_attachments` | Over 50 blocks | Split the message into multiple posts or thread replies |
+| `msg_too_long` | Text exceeds 40,000 characters | Shorten the message or split into parts |
+| `rate_limited` | Too many requests | Wait the number of seconds in the `Retry-After` header |
+| `missing_scope` | Token lacks required permission | Add the scope in OAuth & Permissions and reinstall the app |
+
+### Validate a Response
+
+```bash
+RESPONSE=$(curl -s -X POST "https://slack.com/api/chat.postMessage" \
+  -H "Authorization: Bearer ${SLACK_BOT_TOKEN}" \
+  -H "Content-Type: application/json" \
+  -d '{"channel":"#marketing","text":"Test message"}')
+
+python3 -c "
+import json, sys
+r = json.loads('${RESPONSE}'.replace(\"'\", \"\"))
+if r.get('ok'):
+    print(f'Message sent successfully. ts={r[\"ts\"]} channel={r[\"channel\"]}')
+else:
+    print(f'Error: {r.get(\"error\", \"unknown\")}')
+    if r.get('response_metadata', {}).get('messages'):
+        for m in r['response_metadata']['messages']:
+            print(f'  Detail: {m}')
+" 2>/dev/null || echo "$RESPONSE"
+```
+
+A more robust approach using a temp file:
+
+```bash
+RESPONSE_FILE=$(mktemp)
+curl -s -X POST "https://slack.com/api/chat.postMessage" \
+  -H "Authorization: Bearer ${SLACK_BOT_TOKEN}" \
+  -H "Content-Type: application/json" \
+  -d '{"channel":"#marketing","text":"Test message"}' \
+  -o "$RESPONSE_FILE"
+
+python3 -c "
+import json
+with open('${RESPONSE_FILE}') as f:
+    r = json.load(f)
+if r.get('ok'):
+    print(f'Sent. ts={r[\"ts\"]}')
+else:
+    print(f'Error: {r.get(\"error\")}')
+"
+rm -f "$RESPONSE_FILE"
+```
+
+---
+
+## Tips
+
+- Always include a `text` field alongside `blocks` — it serves as the fallback for
+  notifications, accessibility readers, and clients that do not support Block Kit.
+- Use the Block Kit Builder at https://app.slack.com/block-kit-builder to visually design
+  and preview messages before building the curl commands.
+- For production workflows, use `chat.postMessage` (Web API) over webhooks. It returns a
+  message `ts` you can use for threading, updating, and deleting.
+- Thread long reports. Post a summary as the parent message and details as threaded replies
+  to keep channels clean.
+- Use `:emoji:` codes in `plain_text` fields with `"emoji": true` to render emoji in headers
+  and button labels.
+- Escape special characters in mrkdwn: `&` becomes `&amp;`, `<` becomes `&lt;`, `>` becomes `&gt;`.
+- Rate limits: Slack allows roughly 1 message per second per channel. For bulk posting, add a
+  1-second delay between requests.
+- When posting metrics, use section `fields` for the two-column layout rather than trying to
+  format tables in mrkdwn (Slack does not support tables).
+- **Always show the user the full message payload and ask for confirmation before posting.**

--- a/.claude/skills/social-content/SKILL.md
+++ b/.claude/skills/social-content/SKILL.md
@@ -1,0 +1,512 @@
+---
+name: social-content
+description: >
+  Create and publish social media posts for Reddit, Twitter/X, LinkedIn, Instagram, Facebook,
+  and TikTok. Platform-specific formats, character limits, hashtag strategies, hooks, and
+  content repurposing. Can post directly to Reddit and other platforms via API. Trigger phrases:
+  "social media post", "tweet", "LinkedIn post", "Instagram caption", "TikTok script",
+  "social content", "social media copy", "carousel", "thread", "social media strategy",
+  "repurpose content", "hashtag strategy", "post to reddit", "publish on social",
+  "post on reddit", "share on social media".
+allowed-tools:
+  - Bash
+  - WebFetch
+  - WebSearch
+---
+
+# Social Content Skill
+
+You are a social media content specialist. Your job is to create platform-native content that
+drives engagement, grows audiences, and supports business goals.
+
+## Gathering Requirements
+
+Before creating social content, collect these inputs:
+
+1. **Platform(s)** - Twitter/X, LinkedIn, Instagram, TikTok, or multi-platform.
+2. **Content type** - Post, thread, carousel, video script, story, reel, poll.
+3. **Topic** - What is the post about?
+4. **Goal** - Engagement, traffic, brand awareness, leads, community building.
+5. **Audience** - Who follows this account? Industry, interests, level.
+6. **Tone** - Professional, casual, witty, provocative, educational, inspirational.
+7. **Source material** - Blog post, data, experience, or original thought?
+8. **Visual assets** - Any images, videos, or graphics available?
+
+## Platform Specifications
+
+### Twitter/X
+
+| Element | Specification |
+|---------|--------------|
+| Character limit | 280 characters (free), 25,000 (Premium) |
+| Image sizes | 1200x675 (landscape), 1080x1080 (square) |
+| Video max | 2:20 (free), 60 min (Premium) |
+| Best posting times | 8-10am, 12-1pm, 5-6pm (audience timezone) |
+| Hashtags | 1-2 maximum. More reduces engagement. |
+| Link preview | Yes, but links reduce reach. Put links in replies. |
+
+**Twitter/X Content Rules:**
+- First line is everything. 90% of engagement is determined by the hook.
+- Short sentences. Line breaks between thoughts.
+- No hashtags in the main text body. Add 1-2 at the end or in a reply.
+- Use numbers, data, and specifics over vague claims.
+- Ask questions to drive replies (replies boost algorithmic reach).
+- Links reduce reach. Share the link in the first reply, not the main tweet.
+- Quote tweets with commentary outperform plain retweets.
+
+### LinkedIn
+
+| Element | Specification |
+|---------|--------------|
+| Character limit | 3,000 characters (posts), 100,000 (articles) |
+| "See more" cutoff | ~210 characters before the fold |
+| Image sizes | 1200x1200 (square, best), 1200x627 (landscape) |
+| Video max | 10 minutes |
+| Best posting times | 7-8am, 12pm, 5-6pm Tue-Thu |
+| Hashtags | 3-5 relevant hashtags at the end |
+| Carousel | PDF upload (up to 300 pages), 1080x1080 or 1080x1350 per slide |
+
+**LinkedIn Content Rules:**
+- First 2-3 lines must hook before the "See more" fold. This is critical.
+- Use line breaks aggressively. One sentence per line for readability.
+- Personal stories outperform corporate announcements 10:1.
+- Hot takes and contrarian opinions drive the most engagement.
+- Engagement in the first 60-90 minutes determines total reach.
+- Reply to every comment within the first 2 hours.
+- Avoid external links in the post body (reduces reach by 40-50%). Put links in comments.
+- Tag relevant people (max 3-5) only when genuinely relevant.
+- Use document/PDF carousels for maximum reach (they outperform images and text).
+
+### Instagram
+
+| Element | Specification |
+|---------|--------------|
+| Caption limit | 2,200 characters |
+| Visible caption | ~125 characters before "more" |
+| Image sizes | 1080x1080 (feed), 1080x1350 (portrait, best for feed), 1080x1920 (stories/reels) |
+| Carousel | Up to 20 slides |
+| Reels | 15s, 30s, 60s, 90s |
+| Hashtags | 5-15 relevant hashtags (hide in first comment or after line breaks) |
+| Best posting times | 11am-1pm, 7-9pm Mon-Fri |
+
+**Instagram Content Rules:**
+- Visuals come first. The image/video stops the scroll; the caption sells the click.
+- First line of the caption is the hook. Make it bold and curiosity-driven.
+- Carousel posts get 3x more engagement than single images.
+- Reels get 2x more reach than static posts.
+- Use a mix of hashtag sizes: 5 large (100K+ posts), 5 medium (10K-100K), 5 niche (1K-10K).
+- Include a CTA in every caption ("Save this for later", "Tag someone who needs this",
+  "Comment [word] for the link").
+- Stories: Use polls, questions, and sliders for engagement.
+- Alt text improves accessibility and gives SEO signals.
+
+### TikTok
+
+| Element | Specification |
+|---------|--------------|
+| Caption limit | 2,200 characters |
+| Video length | 15s to 10 minutes (60s-90s optimal) |
+| Video size | 1080x1920 (9:16 vertical) |
+| Hashtags | 3-5 relevant + 1-2 trending |
+| Best posting times | 7-9am, 12-3pm, 7-11pm |
+| Audio | Original or trending audio |
+
+**TikTok Content Rules:**
+- Hook in the first 1-3 seconds or viewers scroll away.
+- Native-feeling content outperforms polished/produced content.
+- Use trending audio when relevant (boosts discoverability).
+- Text overlay on video is essential (many watch without sound).
+- Pattern interrupts every 3-5 seconds hold attention.
+- End with a CTA: "Follow for more", "Comment your answer", "Watch to the end".
+- Batch-create content: film 5-10 videos in one session.
+
+## Hook Formulas (Universal)
+
+The first line of any social post determines 90% of its performance. Use these formulas:
+
+### Attention Hooks
+
+| Formula | Example |
+|---------|---------|
+| Bold statement | "Most marketing advice is wrong." |
+| Counter-intuitive | "I stopped posting daily. My engagement tripled." |
+| Specific result | "I grew from 0 to 10K followers in 90 days." |
+| Question | "What's the biggest waste of money in your marketing budget?" |
+| "This [thing]" | "This one change doubled our conversion rate." |
+| "Stop doing X" | "Stop writing long LinkedIn posts. Here's why." |
+| Personal story | "I got fired 3 years ago. It was the best thing that happened to me." |
+| Surprising stat | "73% of landing pages have no CTA above the fold." |
+| Listicle opener | "7 tools I use every day that cost $0:" |
+| Confession | "I spent $50K on ads before I learned this lesson." |
+
+### Engagement Prompts
+
+Add one of these to drive comments and shares:
+
+| Type | Example |
+|------|---------|
+| Question | "What's your biggest challenge with [topic]?" |
+| Poll-style | "Which one are you? A) [option] B) [option]" |
+| Fill in the blank | "The best marketing tool I've ever used is ___" |
+| Hot take invitation | "Unpopular opinion: [statement]. Agree or disagree?" |
+| Tag prompt | "Tag someone who needs to hear this." |
+| Save prompt | "Save this for when you need it." |
+| Share prompt | "Repost this if you agree." |
+
+## Content Formats
+
+### Carousel Outlines (LinkedIn + Instagram)
+
+Structure a carousel for maximum swipe-through:
+
+| Slide | Purpose | Content |
+|-------|---------|---------|
+| 1 (Cover) | Hook | Bold headline, minimal text, eye-catching design. Must earn the swipe. |
+| 2 | Context | Why this matters. State the problem or opportunity. |
+| 3-8 | Value | One point per slide. Short text. Visual hierarchy. |
+| 9 | Summary | Recap the key takeaways in a list. |
+| 10 (CTA) | Action | Follow, save, share, visit link, comment. |
+
+**Carousel Design Rules:**
+- One idea per slide. Maximum 30-40 words per slide.
+- Use consistent branding (colors, fonts, logo placement).
+- Number the slides ("1/10", "2/10") to show progress and encourage swiping.
+- Use arrows or "Swipe" indicators on the first slide.
+- Make the cover slide work as a standalone post in the feed.
+
+### Video Script Hooks (TikTok + Reels)
+
+| Hook Type | Script Opening |
+|-----------|---------------|
+| Challenge | "I bet you can't name 3 marketing metrics that actually matter." |
+| Storytime | "So this client came to me with $0 marketing budget..." |
+| Tutorial | "Here's how to write a landing page in 15 minutes." |
+| React | "I just saw a landing page that breaks every rule, and it's genius." |
+| List | "3 free tools that replaced my $500/month marketing stack:" |
+| Myth-bust | "Everyone says you need 10K followers to make money. That's a lie." |
+
+### Thread Structure (Twitter/X)
+
+See the dedicated `thread-writer` skill for full thread templates. Quick format:
+
+```
+Tweet 1: Hook (strongest line, earns the click to read more)
+Tweet 2-3: Context (why this matters, the story)
+Tweet 4-N: Value (one point per tweet, numbered)
+Final tweet: CTA (follow, retweet, reply)
+```
+
+## Content Repurposing: Blog to Social
+
+Transform one blog post into platform-specific content:
+
+### From a 2000-Word Blog Post, Create:
+
+**Twitter/X:**
+- 1 single tweet (key takeaway + link in reply)
+- 1 thread (7-12 tweets covering the main points)
+- 3-5 standalone tweets (one insight per tweet, spread across the week)
+
+**LinkedIn:**
+- 1 long-form post (personal angle on the topic, 800-1200 chars)
+- 1 carousel (key points as slides, PDF format)
+- 1 poll (related question to the blog topic)
+
+**Instagram:**
+- 1 carousel (10 slides summarizing the post)
+- 1 reel (30-60s video covering the top 3 points)
+- 3 stories (teaser, key insight, swipe-up/link)
+
+**TikTok:**
+- 1 explainer video (60-90s covering the core idea)
+- 1 reaction/hot-take video (contrarian angle from the post)
+- 1 listicle video (quick tips from the post)
+
+### Repurposing Process
+
+1. **Extract** - Pull out the 5-7 key insights from the blog post.
+2. **Reframe** - Adapt each insight for the platform's native format and audience expectations.
+3. **Rewrite** - Do not copy-paste. Write natively for each platform.
+4. **Schedule** - Spread repurposed content across 1-2 weeks to maximize exposure.
+
+## Hashtag Strategy
+
+### Hashtag Research Framework
+
+| Tier | Posts Using Tag | Purpose | # to Use |
+|------|----------------|---------|----------|
+| Large | 500K+ posts | Broad discovery | 2-3 |
+| Medium | 50K-500K posts | Targeted reach | 3-5 |
+| Niche | 5K-50K posts | Community, high relevance | 3-5 |
+| Branded | Any | Brand building, tracking | 1 |
+
+### Hashtag Rules by Platform
+
+- **Twitter/X:** 1-2 hashtags max. Integrate into text or add at end.
+- **LinkedIn:** 3-5 hashtags at the end of the post.
+- **Instagram:** 10-15 hashtags. Put in first comment or after 5 line breaks.
+- **TikTok:** 3-5 hashtags in caption. Include 1-2 trending tags.
+
+### Hashtag Don'ts
+- Do not use banned or shadowbanned hashtags.
+- Do not use the same hashtag set on every post (looks like bot behavior).
+- Do not use irrelevant trending hashtags for reach (damages credibility and reach).
+- Do not put hashtags in the middle of sentences.
+
+## Output Format
+
+For every social content request, deliver:
+
+### 1. Platform-Specific Posts
+Full post copy formatted for each requested platform with:
+- Hook line
+- Body content
+- CTA
+- Hashtags (where applicable)
+- Image/video direction (if relevant)
+- Character count
+
+### 2. Engagement Strategy
+- Best time to post
+- Recommended follow-up actions (respond to comments, reshare, etc.)
+- Cross-promotion plan across platforms
+
+### 3. Visual Direction
+- Image/graphic description for design team
+- Carousel slide outlines (if applicable)
+- Video script hook (if applicable)
+
+### 4. Variations
+- 2-3 post variations per platform for A/B testing or scheduling across days.
+
+## API Integrations (Optional Enhancements)
+
+The following integrations enhance the social content workflow but are not required. The skill works fully without them.
+
+### Unsplash Image Sourcing
+
+If `UNSPLASH_CLIENT_ID` is available, source high-quality, royalty-free images for social posts:
+
+```bash
+# Search Unsplash for social media images
+curl -s "https://api.unsplash.com/search/photos?query={topic}&per_page=3" \
+  -H "Authorization: Client-ID ${UNSPLASH_CLIENT_ID}"
+```
+
+**Parsing the response for social media use:**
+
+```bash
+# Extract image URLs and attribution info
+curl -s "https://api.unsplash.com/search/photos?query={topic}&per_page=3" \
+  -H "Authorization: Client-ID ${UNSPLASH_CLIENT_ID}" | \
+  jq -r '.results[] | {
+    image_regular: .urls.regular,
+    image_small: .urls.small,
+    image_thumb: .urls.thumb,
+    photographer: .user.name,
+    photographer_url: .user.links.html,
+    download: .links.download,
+    color: .color,
+    width: .width,
+    height: .height
+  }'
+```
+
+Key fields for social media:
+- **`.urls.regular`** - 1080px wide, good for LinkedIn and Twitter posts
+- **`.urls.small`** - 400px wide, good for thumbnails and previews
+- **`.color`** - Dominant color hex code (useful for matching brand colors or creating cohesive visual themes)
+- **`.width` / `.height`** - Original dimensions (check aspect ratio fits the target platform)
+
+**Platform-specific image tips:**
+- For **Instagram** (1080x1080 or 1080x1350): Search with `orientation=squarish`
+- For **Twitter/LinkedIn** (1200x675): Search with `orientation=landscape`
+- For **TikTok/Reels/Stories** (1080x1920): Search with `orientation=portrait`
+
+**Attribution:** Unsplash requires attribution. Include "Photo by [Name] on Unsplash" in the post caption, image overlay, or as a text comment. Example:
+
+```
+Photo by [Photographer Name](photographer_url) on [Unsplash](https://unsplash.com)
+```
+
+### Reddit Trending Topics & Community Sentiment
+
+If `REDDIT_CLIENT_ID` and `REDDIT_CLIENT_SECRET` are available, monitor Reddit for trending topics, popular discussions, and community sentiment to inform social content:
+
+**Step 1: Get an access token**
+
+```bash
+# Get Reddit access token (OAuth2 client credentials flow)
+curl -s -X POST "https://www.reddit.com/api/v1/access_token" \
+  -u "${REDDIT_CLIENT_ID}:${REDDIT_CLIENT_SECRET}" \
+  -d "grant_type=client_credentials" \
+  -A "${REDDIT_USER_AGENT:-openclaudia-skills:v1.0}"
+```
+
+The response contains:
+```json
+{
+  "access_token": "your_token_here",
+  "token_type": "bearer",
+  "expires_in": 86400,
+  "scope": "*"
+}
+```
+
+Extract the token:
+```bash
+REDDIT_ACCESS_TOKEN=$(curl -s -X POST "https://www.reddit.com/api/v1/access_token" \
+  -u "${REDDIT_CLIENT_ID}:${REDDIT_CLIENT_SECRET}" \
+  -d "grant_type=client_credentials" \
+  -A "${REDDIT_USER_AGENT:-openclaudia-skills:v1.0}" | jq -r '.access_token')
+```
+
+**Step 2: Search for trending topics in a subreddit**
+
+```bash
+# Get hot posts from a relevant subreddit
+curl -s "https://oauth.reddit.com/r/{subreddit}/hot?limit=25" \
+  -H "Authorization: Bearer ${REDDIT_ACCESS_TOKEN}" \
+  -A "${REDDIT_USER_AGENT:-openclaudia-skills:v1.0}"
+```
+
+**Step 3: Parse trending posts for content ideas**
+
+```bash
+# Extract post titles, scores, and comment counts for content inspiration
+curl -s "https://oauth.reddit.com/r/{subreddit}/hot?limit=25" \
+  -H "Authorization: Bearer ${REDDIT_ACCESS_TOKEN}" \
+  -A "${REDDIT_USER_AGENT:-openclaudia-skills:v1.0}" | \
+  jq -r '.data.children[] | .data | {
+    title: .title,
+    score: .score,
+    num_comments: .num_comments,
+    url: .url,
+    created_utc: .created_utc,
+    selftext: (.selftext | if length > 200 then .[:200] + "..." else . end)
+  }'
+```
+
+**Step 4: Search across Reddit for a specific topic**
+
+```bash
+# Search Reddit-wide for discussions about a topic
+curl -s "https://oauth.reddit.com/search?q={topic}&sort=relevance&t=week&limit=25" \
+  -H "Authorization: Bearer ${REDDIT_ACCESS_TOKEN}" \
+  -A "${REDDIT_USER_AGENT:-openclaudia-skills:v1.0}"
+```
+
+**How to use Reddit data for social content:**
+- **Trending topics:** Posts with high scores (500+) and comment counts indicate what the community cares about right now. Use these as content topics.
+- **Language and framing:** Note how Redditors phrase problems and questions. Mirror this language in your social hooks for authenticity.
+- **Sentiment:** Scan comments for common pain points, frustrations, or excitement. Address these directly in your posts.
+- **Content gaps:** If a Reddit thread has lots of questions but no clear answers, that is a content opportunity.
+- **Timing:** If a topic is trending on Reddit today, create social content about it within 24-48 hours for maximum relevance.
+
+**Useful subreddits by niche:**
+- Marketing: r/marketing, r/digital_marketing, r/SEO, r/socialmedia
+- Tech: r/technology, r/programming, r/webdev, r/SaaS
+- Business: r/entrepreneur, r/smallbusiness, r/startups
+- Design: r/design, r/graphic_design, r/UI_Design
+
+**Note:** Reddit API rate limits are 100 requests per minute. The access token expires after 24 hours. Always include a descriptive `User-Agent` string as Reddit blocks requests with generic user agents.
+
+---
+
+## Publishing Content via API
+
+These integrations let you post directly to social platforms from the terminal. **Always show the user what will be posted and ask for confirmation before publishing.**
+
+### Posting to Reddit
+
+Requires `REDDIT_CLIENT_ID`, `REDDIT_CLIENT_SECRET`, and a Reddit user account OAuth token.
+
+**Step 1: Get a user-authenticated token**
+
+Reddit posting requires the `authorization_code` OAuth flow (not `client_credentials`). The user must authorize once:
+
+```bash
+# Generate the authorization URL (user visits in browser)
+echo "https://www.reddit.com/api/v1/authorize?client_id=${REDDIT_CLIENT_ID}&response_type=code&state=openclaudia&redirect_uri=http://localhost:8080&duration=permanent&scope=submit,read,identity"
+```
+
+After the user authorizes and gets the `code` from the redirect:
+
+```bash
+# Exchange code for access + refresh token
+curl -s -X POST "https://www.reddit.com/api/v1/access_token" \
+  -u "${REDDIT_CLIENT_ID}:${REDDIT_CLIENT_SECRET}" \
+  -d "grant_type=authorization_code&code={CODE}&redirect_uri=http://localhost:8080" \
+  -A "${REDDIT_USER_AGENT:-openclaudia-skills:v1.0}"
+```
+
+Save the `refresh_token` for future sessions:
+
+```bash
+# Refresh an expired token
+curl -s -X POST "https://www.reddit.com/api/v1/access_token" \
+  -u "${REDDIT_CLIENT_ID}:${REDDIT_CLIENT_SECRET}" \
+  -d "grant_type=refresh_token&refresh_token={REFRESH_TOKEN}" \
+  -A "${REDDIT_USER_AGENT:-openclaudia-skills:v1.0}"
+```
+
+**Step 2: Post to a subreddit**
+
+```bash
+# Text post (self post)
+curl -s -X POST "https://oauth.reddit.com/api/submit" \
+  -H "Authorization: Bearer ${REDDIT_ACCESS_TOKEN}" \
+  -A "${REDDIT_USER_AGENT:-openclaudia-skills:v1.0}" \
+  -d "sr={subreddit}&kind=self&title={post_title}&text={post_body}&api_type=json"
+
+# Link post
+curl -s -X POST "https://oauth.reddit.com/api/submit" \
+  -H "Authorization: Bearer ${REDDIT_ACCESS_TOKEN}" \
+  -A "${REDDIT_USER_AGENT:-openclaudia-skills:v1.0}" \
+  -d "sr={subreddit}&kind=link&title={post_title}&url={url}&api_type=json"
+```
+
+**Step 3: Post a comment (for engagement)**
+
+```bash
+curl -s -X POST "https://oauth.reddit.com/api/comment" \
+  -H "Authorization: Bearer ${REDDIT_ACCESS_TOKEN}" \
+  -A "${REDDIT_USER_AGENT:-openclaudia-skills:v1.0}" \
+  -d "thing_id={parent_fullname}&text={comment_body}&api_type=json"
+```
+
+The `thing_id` is the fullname of the post or comment to reply to (e.g., `t3_abc123` for a post, `t1_abc123` for a comment).
+
+**Reddit posting best practices:**
+- Check subreddit rules before posting (`/r/{subreddit}/about/rules`)
+- Many subreddits have minimum karma/age requirements
+- Avoid self-promotion in subreddits that prohibit it — focus on value
+- Post during peak hours (9-11 AM EST for US subreddits)
+- Use the subreddit's preferred flair if required
+- Space out posts — no more than a few per day across all subreddits
+
+### Multi-Platform Posting via EngageMate
+
+If `ENGAGEMATE_API_KEY` is set, you can use EngageMate to post across Reddit, X/Twitter, Instagram, Facebook, and TikTok from a single API.
+
+```bash
+echo "ENGAGEMATE_API_KEY is ${ENGAGEMATE_API_KEY:+set}"
+```
+
+EngageMate is an AI-powered social engagement platform. Refer to their documentation at https://engagemate.app for current API endpoints. The product ID is stored as `ENGAGEMATE_PRODUCT_ID`.
+
+### Publishing Workflow
+
+When the user asks to post or publish content:
+
+1. **Generate** the content using the platform-specific rules above
+2. **Preview** — show the user exactly what will be posted, including:
+   - Platform and target (subreddit, account, etc.)
+   - Title (if applicable)
+   - Full post body
+   - Hashtags, links, media
+3. **Confirm** — ask the user to approve before posting
+4. **Post** — execute the API call
+5. **Report** — show the post URL and any response data
+
+**Never auto-post without explicit user confirmation.**

--- a/.claude/skills/stock-images/SKILL.md
+++ b/.claude/skills/stock-images/SKILL.md
@@ -1,0 +1,109 @@
+---
+name: unsplash-image
+description: Search for images on Unsplash and download them. Optionally add text overlay (title/subtitle) to the image. Use when the user asks to find a stock photo, search for an image, get an Unsplash image, or download a photo with text.
+argument-hint: [search query]
+allowed-tools: Bash(*), Read, Write
+---
+
+# Unsplash Image Search & Download
+
+Search Unsplash for images, download them, and optionally add text overlay.
+
+## Tool Location
+
+- Script: `~/.agents/tools/unsplash-search.py`
+- Env file: `~/.agents/tools/.env` (contains `UNSPLASH_CLIENT_ID`)
+
+## Quick Usage
+
+### Search and download a random matching image
+
+```bash
+python ~/.agents/tools/unsplash-search.py \
+  --query "nature landscape" \
+  --output ./image.jpg
+```
+
+### With orientation filter
+
+```bash
+python ~/.agents/tools/unsplash-search.py \
+  --query "coffee shop" \
+  --orientation landscape \
+  --output ./coffee.jpg
+```
+
+### With text overlay (title and subtitle)
+
+```bash
+python ~/.agents/tools/unsplash-search.py \
+  --query "technology abstract" \
+  --output ./cover.png \
+  --title "My Blog Post Title" \
+  --subtitle "A short description"
+```
+
+### List results without downloading
+
+```bash
+python ~/.agents/tools/unsplash-search.py \
+  --query "sunset" \
+  --list
+```
+
+### Pick the first result instead of random
+
+```bash
+python ~/.agents/tools/unsplash-search.py \
+  --query "mountains" \
+  --pick first \
+  --output ./mountains.jpg
+```
+
+## CLI Options
+
+| Option | Description |
+|--------|-------------|
+| `--query, -q` | **(Required)** Search query string |
+| `--output, -o` | **(Required unless --list)** Output file path |
+| `--orientation` | Filter: `landscape`, `portrait`, or `squarish` |
+| `--color` | Color filter (e.g., `blue`, `green`, `red`, `black_and_white`) |
+| `--pick` | How to select from results: `random` (default) or `first` |
+| `--title` | Title text to overlay on the image |
+| `--subtitle` | Subtitle text to overlay (only used with --title) |
+| `--list` | List search results instead of downloading |
+| `--count` | Number of results to fetch, max 30 (default: 30) |
+
+## Text Overlay
+
+When `--title` is provided, the script adds a text overlay to the bottom portion of the image with:
+- Semi-transparent dark background behind the text
+- White title text with shadow
+- Gray subtitle text (if provided)
+- Automatic word wrapping and font sizing
+
+**Requires Pillow**: `pip install Pillow`
+
+## Dependencies
+
+- `requests` (for API calls and image download)
+- `Pillow` (only needed if using text overlay with `--title`)
+
+Install if needed:
+```bash
+pip install requests Pillow
+```
+
+## Output
+
+The script prints:
+- The download URL
+- Photographer attribution (required by Unsplash)
+- The saved file path
+- Confirmation of text overlay if applied
+
+## Notes
+
+- Unsplash API guidelines require attribution. The script prints photographer info.
+- The script triggers Unsplash's download tracking endpoint as required by their API terms.
+- Images are downloaded at "regular" quality (1080px width). For higher resolution, modify the script to use `urls.full` or `urls.raw`.

--- a/.claude/skills/stripe-dispute/SKILL.md
+++ b/.claude/skills/stripe-dispute/SKILL.md
@@ -1,0 +1,255 @@
+---
+name: stripe-dispute
+description: Fight Stripe disputes and chargebacks by gathering evidence (Stripe API + your app database + terms page), generating an activity-log PDF, and submitting a counter-dispute. Use when the user says "fight dispute", "stripe dispute", "chargeback", "counter dispute", "dispute evidence", or shares a Stripe dispute ID.
+---
+
+# Stripe Dispute Fighter
+
+Build evidence packages and submit counter-disputes to Stripe. Works for any SaaS that uses Stripe + a user database with login/usage logs.
+
+## When to Use This Skill
+
+Use this skill when the user:
+
+- Receives a Stripe chargeback notification and wants to fight it
+- Provides a dispute ID (`du_*`) and asks to "counter" / "rebut" / "fight" it
+- Asks how to gather evidence for a dispute marked `fraudulent`, `product_not_received`, `product_unacceptable`, or `subscription_canceled`
+- Wants an activity-log PDF showing a customer used their product
+
+## Required Environment Variables
+
+```bash
+STRIPE_SECRET_KEY=sk_live_...      # Stripe restricted/secret key with disputes:write scope
+DATABASE_URL=postgres://...        # READ-ONLY connection to your app's user database (optional but recommended)
+TERMS_URL=https://yoursite.com/terms   # URL to your published cancellation/refund policy
+EVIDENCE_DIR=~/disputes            # Where to save the per-customer evidence folders
+```
+
+**Database safety:** all queries are SELECT-only. Never let this skill issue UPDATE/DELETE/INSERT.
+
+## Inputs
+
+The user provides any of:
+- Stripe dispute ID (`du_xxxxx`) — preferred
+- Customer email — skill will look up the dispute
+- Charge ID (`ch_xxxxx` or `py_xxxxx`)
+
+## Steps
+
+### 1. Pull the dispute from Stripe
+
+```bash
+curl -s -u "$STRIPE_SECRET_KEY:" \
+  "https://api.stripe.com/v1/disputes/$DISPUTE_ID" | python3 -m json.tool
+```
+
+Extract: `amount`, `reason`, `charge`, `evidence_details.due_by`, `evidence_details.submission_count`, `status`.
+
+If `submission_count > 0` the dispute has already been countered — STOP and warn the user.
+
+### 2. Pull the surrounding context
+
+```bash
+# Charge → tells you the payment method, risk score, billing details, customer ID
+curl -s -u "$STRIPE_SECRET_KEY:" "https://api.stripe.com/v1/charges/$CHARGE_ID"
+
+# Customer → name, email, default payment source
+curl -s -u "$STRIPE_SECRET_KEY:" "https://api.stripe.com/v1/customers/$CUSTOMER_ID"
+
+# All invoices for the customer → look for previously-undisputed payments
+curl -s -u "$STRIPE_SECRET_KEY:" \
+  "https://api.stripe.com/v1/invoices?customer=$CUSTOMER_ID&limit=100"
+
+# Subscription (if recurring)
+curl -s -u "$STRIPE_SECRET_KEY:" "https://api.stripe.com/v1/subscriptions/$SUB_ID"
+```
+
+**Prior undisputed payments on the same card are the strongest single piece of evidence** for `fraudulent` claims. Always count them.
+
+### 3. Look up the customer in your app database
+
+Adapt these queries to your schema. The shape that wins disputes:
+
+```sql
+-- User profile and self-reported cancel reason
+SELECT id, email, created_at, plan_tier, stripe_customer_id,
+       cancel_reason, cancelled_at, delete_reason
+FROM users WHERE email ILIKE :email;
+
+-- Login activity (timestamps + country + device)
+SELECT created_at, country_code, device
+FROM user_activity WHERE user_id = :uid ORDER BY created_at;
+
+-- Things the customer created/used in your product
+SELECT name, type, created_at, updated_at
+FROM projects WHERE user_id = :uid AND deleted = false ORDER BY created_at;
+
+-- Checkout / payment-related actions (proves intent)
+SELECT timestamp, endpoint, payload FROM action_logs
+WHERE user_id = :uid
+  AND endpoint ~* '(subscribe|checkout|stripe|upgrade|pay)'
+ORDER BY timestamp DESC;
+```
+
+**Critical for `product_not_received` claims:** check the user's self-reported `cancel_reason`. If they cancelled citing "Poor user experience" or anything that admits they used the product, that single field contradicts the dispute claim and tends to win the case on its own. Quote it verbatim in the rebuttal.
+
+### 4. Download supporting documents
+
+```bash
+FOLDER="$EVIDENCE_DIR/$(echo $CUSTOMER_NAME | tr '[:upper:] ' '[:lower:]-')-$(date +%Y-%m)"
+mkdir -p "$FOLDER"
+
+# Invoice PDFs (URLs come from the Stripe invoice objects)
+curl -sL "$INVOICE_PDF_URL" -o "$FOLDER/invoice.pdf"
+```
+
+### 5. Capture your terms / cancellation policy as a PDF
+
+Using Playwright (Node):
+
+```bash
+node -e "
+const { chromium } = require('playwright');
+(async () => {
+  const browser = await chromium.launch();
+  const page = await browser.newPage({ viewport: { width: 1280, height: 900 } });
+  await page.goto(process.env.TERMS_URL, { waitUntil: 'networkidle' });
+  await page.pdf({ path: process.argv[1], format: 'A4', printBackground: true });
+  await browser.close();
+})();
+" "$FOLDER/cancellation_policy.pdf"
+```
+
+### 6. Generate the activity-log PDF
+
+This is the document Stripe's reviewers actually read. Build an HTML file, then convert to PDF with WeasyPrint:
+
+```python
+from weasyprint import HTML
+HTML('activity_log.html').write_pdf('activity_log.pdf')
+```
+
+**HTML must include `<meta charset="UTF-8">`** to avoid mangled characters in customer names/addresses.
+
+The layout that has been shown to win:
+
+1. **Summary grid** — Customer / Email / Internal user ID / Stripe customer ID / Account created / Plan / Subscription start / Cancellation timestamp (with delta from signup) / Self-reported cancel reason / Credits or units consumed / Purchase IP / Billing address / Payment method (last4, brand) / Stripe risk assessment / Referral source / Payment trigger
+2. **Payment History table** — every invoice with date, amount, status. **Highlight the disputed row** in red. Add a column "Disputed?" with explicit Yes/No.
+3. **Checkout Attempts table** — proves deliberate purchase intent (defeats `fraudulent` by extension)
+4. **Items Created / Used table** — names, types, timestamps. Concrete usage > adjectives.
+5. **Login Activity Log** — every session: timestamp, country, device. Consistency = same cardholder.
+6. **Timeline Summary** — single chronological narrative ending with "and then on $DATE the dispute was filed."
+7. **Conclusion paragraph** — quote the user's own `cancel_reason` against the stated dispute reason, if they contradict.
+
+Concrete numbers beat adjectives every time. "29 login sessions, 3 named projects, 29,960 credits consumed, 1h 27m active, 2 deliberate checkout attempts" is undeniable. "Used extensively" is not.
+
+### 7. Show everything to the user before submitting
+
+```bash
+open "$FOLDER"
+```
+
+Display the rebuttal text, the evidence files, and your win-probability assessment. **Wait for explicit user approval.**
+
+### 8. Upload evidence files to Stripe
+
+**Files go to `files.stripe.com`, NOT `api.stripe.com`** — different host:
+
+```bash
+curl -s -u "$STRIPE_SECRET_KEY:" \
+  -F "purpose=dispute_evidence" \
+  -F "file=@$FOLDER/activity_log.pdf" \
+  https://files.stripe.com/v1/files
+```
+
+Returns `{"id": "file_xxx", ...}`. Capture the `id` — that's what you reference in evidence fields.
+
+**One file_id per dispute.** Stripe rejects with `400 "That file is already attached to something else"` if you try to reuse a `file_id` across disputes (especially for `service_documentation`). When fighting N disputes for the same customer, upload N copies of every shared PDF — same content, fresh `file_id` each time.
+
+### 9. Submit evidence (one shot — `submit=true` is final)
+
+```bash
+curl -s -u "$STRIPE_SECRET_KEY:" \
+  -X POST "https://api.stripe.com/v1/disputes/$DISPUTE_ID" \
+  -d "evidence[uncategorized_text]=$REBUTTAL_TEXT" \
+  -d "evidence[uncategorized_file]=$ACTIVITY_LOG_FILE_ID" \
+  -d "evidence[receipt]=$INVOICE_FILE_ID" \
+  -d "evidence[cancellation_policy]=$TERMS_FILE_ID" \
+  -d "evidence[cancellation_policy_disclosure]=$CANCEL_DISCLOSURE_TEXT" \
+  -d "evidence[refund_policy]=$TERMS_FILE_ID" \
+  -d "evidence[refund_policy_disclosure]=$REFUND_DISCLOSURE_TEXT" \
+  -d "evidence[cancellation_rebuttal]=$CANCEL_REBUTTAL_TEXT" \
+  -d "evidence[access_activity_log]=$ACCESS_LOG_SUMMARY" \
+  -d "evidence[service_date]=$SERVICE_START_DATE" \
+  -d "evidence[product_description]=$PRODUCT_DESCRIPTION" \
+  -d "evidence[customer_email_address]=$CUSTOMER_EMAIL" \
+  -d "evidence[customer_name]=$CUSTOMER_NAME" \
+  -d "evidence[customer_purchase_ip]=$PURCHASE_IP" \
+  -d "evidence[billing_address]=$BILLING_ADDRESS" \
+  -d "submit=true" \
+  "https://api.stripe.com/v1/disputes/$DISPUTE_ID"
+```
+
+Verify the response:
+- `status` should be `under_review`
+- `evidence_details.has_evidence` should be `true`
+- `evidence_details.submission_count` should be `1`
+
+## Evidence Strategy by Dispute Reason
+
+### `fraudulent`
+Goal: prove the cardholder made the purchase.
+- Prior undisputed payments on the same card (strongest)
+- OAuth login (Google/Apple) = identity-verified signup
+- Consistent IP / country / device across sessions
+- Multiple checkout attempts before purchase = real person deliberating
+- Stripe's own risk assessment was `normal`
+- Subscription still active and not cancelled
+
+### `product_not_received`
+Goal: prove delivery + use.
+- Login activity log
+- Items created / actions taken inside the product
+- **The customer's own self-reported cancel reason**, if they cancelled — quoted verbatim against the dispute claim
+- Receipt and welcome email
+
+### `product_unacceptable`
+Goal: show the product matched its description and the customer used it.
+- Same as `product_not_received` PLUS your terms-of-service language about quality / refund policy
+- Highlight that customer never opened a support ticket
+
+### `subscription_canceled`
+Goal: prove the customer never cancelled (or cancelled after the renewal).
+- Subscription object showing `cancel_at_period_end=false` at the renewal date
+- All login/use activity from after the renewal date
+- Terms language stating annual renewals require explicit cancellation
+
+## Rebuttal Templates
+
+### `uncategorized_text`
+> [Customer name] created a [Product name] account on [date] via [auth method] and subscribed to [plan] ($[amount]/[interval]) using the same [card brand]. The first [N] payment(s) were never disputed. The customer actively used the service: [N] login sessions from [country] on [device], [N] items created ([list]), and [N] [units] consumed. The disputed charge is the [renewal/initial] payment on [date]. The subscription was [status] and remains [active/cancelled]. The customer never contacted support to cancel or request a refund. Our cancellation and refund policies are published at [TERMS_URL]. This is not a fraudulent transaction — it is a legitimate purchase from the cardholder who [made/has made] [N] other undisputed payments on this account.
+
+### `cancellation_policy_disclosure`
+> Our cancellation policy is disclosed at [TERMS_URL]. Subscribers may cancel at any time and retain access through the end of their billing cycle. This customer never cancelled.
+
+### `refund_policy_disclosure`
+> Our refund policy is disclosed at [TERMS_URL]. We offer a [N]-day money-back guarantee. The customer did not request a refund within that window, nor at any time.
+
+## Important Notes
+
+- File uploads go to `files.stripe.com`, NOT `api.stripe.com`
+- One submission per dispute. `submit=true` is final
+- Evidence deadline is `evidence_details.due_by` (unix timestamp). After that you can no longer submit
+- Database queries must be READ-ONLY — restrict the connection's role if possible
+- Never include other customers' data in the activity log PDF
+- Save every evidence package to disk in case you need to reference it for future disputes from the same customer
+
+## Pattern That Wins
+
+The single most reliable winning pattern observed across same-day-cancellation disputes:
+
+> Customer signs up, uses product briefly, cancels within hours citing "Poor user experience" in your in-app cancel form, then files a chargeback days later claiming "product not received."
+
+The cancel form's reason — recorded in your own database — directly contradicts the chargeback claim. Quote it word-for-word in the rebuttal. This evidence pattern has won within ~30 days of submission with full amount + dispute fee returned.
+
+Always check `users.cancel_reason` (or your equivalent) FIRST when the dispute reason is `product_not_received` or `product_unacceptable`.

--- a/.claude/skills/telegram-bot/SKILL.md
+++ b/.claude/skills/telegram-bot/SKILL.md
@@ -1,0 +1,675 @@
+---
+name: telegram-bot
+description: >
+  Send messages, images, and marketing content to Telegram channels and groups via Bot API.
+  Create formatted posts, polls, and media content for Telegram communities. Trigger phrases:
+  "post to telegram", "telegram message", "telegram channel", "telegram bot", "telegram marketing",
+  "send to telegram", "telegram announcement", "telegram broadcast".
+allowed-tools:
+  - Bash
+  - WebFetch
+  - WebSearch
+---
+
+# Telegram Bot Skill
+
+You are a Telegram marketing specialist. Your job is to help users send messages, media, polls,
+and marketing content to Telegram channels and groups using the Telegram Bot API. You handle
+formatting, inline keyboards, and content templates for effective channel management.
+
+## Prerequisites
+
+### Environment Variables
+
+Check for required credentials before any API call:
+
+```bash
+source ~/.claude/.env.global 2>/dev/null
+source .env 2>/dev/null
+source .env.local 2>/dev/null
+
+if [ -z "$TELEGRAM_BOT_TOKEN" ]; then
+  echo "TELEGRAM_BOT_TOKEN is not set."
+  echo "To create a bot and get a token:"
+  echo "  1. Open Telegram and search for @BotFather"
+  echo "  2. Send /newbot and follow the prompts"
+  echo "  3. Copy the token and add it to your .env or ~/.claude/.env.global:"
+  echo "     TELEGRAM_BOT_TOKEN=123456:ABC-DEF1234ghIkl-zyx57W2v1u123ew11"
+  exit 1
+else
+  echo "TELEGRAM_BOT_TOKEN is configured."
+fi
+
+if [ -z "$TELEGRAM_CHAT_ID" ]; then
+  echo "TELEGRAM_CHAT_ID is not set."
+  echo "To find your channel/group chat ID:"
+  echo "  1. Add your bot to the channel/group as an admin"
+  echo "  2. Send a message in the channel/group"
+  echo "  3. Run: curl -s https://api.telegram.org/bot\${TELEGRAM_BOT_TOKEN}/getUpdates | jq '.result[-1].message.chat.id'"
+  echo "  4. For public channels, use the @channel_username format (e.g., @mychannel)"
+  echo "  5. Add it to your .env or ~/.claude/.env.global:"
+  echo "     TELEGRAM_CHAT_ID=-1001234567890"
+else
+  echo "TELEGRAM_CHAT_ID is configured: ${TELEGRAM_CHAT_ID}"
+fi
+```
+
+### Creating a Bot via @BotFather
+
+If the user does not have a bot yet, walk them through this process:
+
+1. Open Telegram and search for **@BotFather** (the official bot creation tool).
+2. Send `/newbot` to BotFather.
+3. Choose a **display name** for the bot (e.g., "My Marketing Bot").
+4. Choose a **username** ending in `bot` (e.g., `my_marketing_bot`).
+5. BotFather replies with an **API token** like `123456:ABC-DEF1234ghIkl-zyx57W2v1u123ew11`.
+6. Store the token as `TELEGRAM_BOT_TOKEN` in `.env` or `~/.claude/.env.global`.
+7. **Add the bot as an admin** to the target channel or group.
+8. Optionally, customize the bot with BotFather commands:
+   - `/setdescription` - Set the bot's description
+   - `/setabouttext` - Set the "About" section
+   - `/setuserpic` - Upload a profile photo for the bot
+
+### Finding the Chat ID
+
+For **public channels**, use `@channel_username` as the chat ID.
+
+For **private channels and groups**, retrieve the numeric chat ID:
+
+```bash
+source ~/.claude/.env.global 2>/dev/null
+# Send a message in the channel/group first, then run:
+curl -s "https://api.telegram.org/bot${TELEGRAM_BOT_TOKEN}/getUpdates" | \
+  jq -r '.result[] | "\(.message.chat.id // .channel_post.chat.id) - \(.message.chat.title // .channel_post.chat.title)"' | \
+  sort -u
+```
+
+Private channel and group IDs are negative numbers (e.g., `-1001234567890`).
+
+## API Reference
+
+All Telegram Bot API calls use this base URL:
+
+```
+https://api.telegram.org/bot{TELEGRAM_BOT_TOKEN}/{method}
+```
+
+Always source environment variables before making API calls:
+
+```bash
+source ~/.claude/.env.global 2>/dev/null
+source .env 2>/dev/null
+source .env.local 2>/dev/null
+```
+
+### sendMessage - Text Messages
+
+Send a text message to a channel or group:
+
+```bash
+curl -s -X POST "https://api.telegram.org/bot${TELEGRAM_BOT_TOKEN}/sendMessage" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "chat_id": "'"${TELEGRAM_CHAT_ID}"'",
+    "text": "Your message text here",
+    "parse_mode": "HTML"
+  }'
+```
+
+**Response:** Returns a JSON object with `ok: true` and the sent `message` object on success. Check `ok` to confirm delivery. The `message.message_id` can be saved for later editing or deletion.
+
+### sendPhoto - Images
+
+Send a photo by URL or file ID:
+
+```bash
+# Send photo by URL
+curl -s -X POST "https://api.telegram.org/bot${TELEGRAM_BOT_TOKEN}/sendPhoto" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "chat_id": "'"${TELEGRAM_CHAT_ID}"'",
+    "photo": "https://example.com/image.jpg",
+    "caption": "Image caption with <b>HTML</b> formatting",
+    "parse_mode": "HTML"
+  }'
+```
+
+```bash
+# Send photo from local file
+curl -s -X POST "https://api.telegram.org/bot${TELEGRAM_BOT_TOKEN}/sendPhoto" \
+  -F "chat_id=${TELEGRAM_CHAT_ID}" \
+  -F "photo=@/path/to/image.jpg" \
+  -F "caption=Image caption here" \
+  -F "parse_mode=HTML"
+```
+
+**Photo limits:** Maximum file size 10 MB. The photo will be compressed. For uncompressed images up to 50 MB, use `sendDocument` instead.
+
+### sendDocument - Files and Documents
+
+Send any file (PDF, ZIP, uncompressed images, etc.):
+
+```bash
+# Send document by URL
+curl -s -X POST "https://api.telegram.org/bot${TELEGRAM_BOT_TOKEN}/sendDocument" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "chat_id": "'"${TELEGRAM_CHAT_ID}"'",
+    "document": "https://example.com/report.pdf",
+    "caption": "Download our latest report",
+    "parse_mode": "HTML"
+  }'
+```
+
+```bash
+# Send document from local file
+curl -s -X POST "https://api.telegram.org/bot${TELEGRAM_BOT_TOKEN}/sendDocument" \
+  -F "chat_id=${TELEGRAM_CHAT_ID}" \
+  -F "document=@/path/to/file.pdf" \
+  -F "caption=Here is the document" \
+  -F "parse_mode=HTML"
+```
+
+**Document limits:** Maximum file size 50 MB.
+
+### sendPoll - Polls and Quizzes
+
+Create interactive polls for engagement:
+
+```bash
+# Regular poll (multiple choice)
+curl -s -X POST "https://api.telegram.org/bot${TELEGRAM_BOT_TOKEN}/sendPoll" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "chat_id": "'"${TELEGRAM_CHAT_ID}"'",
+    "question": "What feature should we build next?",
+    "options": ["Dark mode", "Mobile app", "API access", "Integrations"],
+    "is_anonymous": false,
+    "allows_multiple_answers": false
+  }'
+```
+
+```bash
+# Quiz mode (one correct answer)
+curl -s -X POST "https://api.telegram.org/bot${TELEGRAM_BOT_TOKEN}/sendPoll" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "chat_id": "'"${TELEGRAM_CHAT_ID}"'",
+    "question": "Which programming language was created first?",
+    "options": ["Python", "JavaScript", "C", "Java"],
+    "type": "quiz",
+    "correct_option_id": 2,
+    "explanation": "C was created by Dennis Ritchie in 1972, well before the others.",
+    "explanation_parse_mode": "HTML"
+  }'
+```
+
+**Poll limits:** Question text 1-300 characters. 2-10 options, each 1-100 characters. Explanation up to 200 characters.
+
+### Inline Keyboard Buttons (CTAs)
+
+Add clickable buttons below any message for calls-to-action:
+
+```bash
+curl -s -X POST "https://api.telegram.org/bot${TELEGRAM_BOT_TOKEN}/sendMessage" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "chat_id": "'"${TELEGRAM_CHAT_ID}"'",
+    "text": "Check out our latest product!",
+    "parse_mode": "HTML",
+    "reply_markup": {
+      "inline_keyboard": [
+        [
+          {"text": "Visit Website", "url": "https://example.com"},
+          {"text": "View Demo", "url": "https://example.com/demo"}
+        ],
+        [
+          {"text": "Read Blog Post", "url": "https://example.com/blog"}
+        ]
+      ]
+    }
+  }'
+```
+
+**Keyboard layout:** Each inner array is a row of buttons. Keep rows to 1-3 buttons for readability on mobile. Maximum 100 buttons total per message.
+
+**Button types:**
+- `url` - Opens a URL in the browser
+- `callback_data` - Sends data back to the bot (requires a webhook to handle)
+- `switch_inline_query` - Prompts the user to select a chat and send an inline query
+
+### editMessageText - Edit Existing Messages
+
+Update a previously sent message:
+
+```bash
+curl -s -X POST "https://api.telegram.org/bot${TELEGRAM_BOT_TOKEN}/editMessageText" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "chat_id": "'"${TELEGRAM_CHAT_ID}"'",
+    "message_id": MESSAGE_ID_HERE,
+    "text": "Updated message text",
+    "parse_mode": "HTML"
+  }'
+```
+
+### deleteMessage - Delete a Message
+
+Remove a message from the channel:
+
+```bash
+curl -s -X POST "https://api.telegram.org/bot${TELEGRAM_BOT_TOKEN}/deleteMessage" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "chat_id": "'"${TELEGRAM_CHAT_ID}"'",
+    "message_id": MESSAGE_ID_HERE
+  }'
+```
+
+### pinChatMessage - Pin Important Messages
+
+Pin a message to the top of the channel or group:
+
+```bash
+curl -s -X POST "https://api.telegram.org/bot${TELEGRAM_BOT_TOKEN}/pinChatMessage" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "chat_id": "'"${TELEGRAM_CHAT_ID}"'",
+    "message_id": MESSAGE_ID_HERE,
+    "disable_notification": true
+  }'
+```
+
+## Message Formatting
+
+### HTML Mode (Recommended)
+
+Set `"parse_mode": "HTML"` and use these tags:
+
+| Tag | Result | Example |
+|-----|--------|---------|
+| `<b>text</b>` | **Bold** | `<b>Important</b>` |
+| `<i>text</i>` | *Italic* | `<i>Note:</i>` |
+| `<u>text</u>` | Underline | `<u>highlight</u>` |
+| `<s>text</s>` | ~~Strikethrough~~ | `<s>old price</s>` |
+| `<code>text</code>` | `Monospace` | `<code>variable</code>` |
+| `<pre>text</pre>` | Code block | `<pre>code block</pre>` |
+| `<a href="url">text</a>` | Link | `<a href="https://example.com">Click here</a>` |
+| `<tg-emoji emoji-id="ID">emoji</tg-emoji>` | Custom emoji | Premium feature |
+| `<blockquote>text</blockquote>` | Block quote | `<blockquote>Quote</blockquote>` |
+| `<tg-spoiler>text</tg-spoiler>` | Spoiler | `<tg-spoiler>Hidden</tg-spoiler>` |
+
+**HTML escaping rules:** Replace `&` with `&amp;`, `<` with `&lt;`, `>` with `&gt;` in all text that is not part of an HTML tag. Unrecognized tags are stripped. Tags must be properly closed.
+
+### MarkdownV2 Mode
+
+Set `"parse_mode": "MarkdownV2"` and use this syntax:
+
+| Syntax | Result |
+|--------|--------|
+| `*bold*` | **Bold** |
+| `_italic_` | *Italic* |
+| `__underline__` | Underline |
+| `~strikethrough~` | ~~Strikethrough~~ |
+| `` `code` `` | `Monospace` |
+| ` ```code block``` ` | Code block |
+| `[text](url)` | Link |
+| `||spoiler||` | Spoiler |
+| `>blockquote` | Block quote (start of line) |
+
+**MarkdownV2 escaping rules:** These characters MUST be escaped with a preceding backslash outside of code blocks: `_ * [ ] ( ) ~ > # + - = | { } . !`. This makes MarkdownV2 error-prone. **HTML mode is recommended** for most use cases to avoid escaping issues.
+
+### Formatting Tips
+
+- Use blank lines (`\n\n`) to separate sections visually.
+- Emoji work natively in message text. No special handling needed.
+- Combine formatting: `<b><i>bold italic</i></b>` works in HTML mode.
+- Links can be hidden behind text: `<a href="https://example.com">Click here</a>`.
+- For silent messages (no notification), add `"disable_notification": true` to the request body.
+
+## Marketing Content Templates
+
+### Template 1: Product Announcement
+
+```bash
+curl -s -X POST "https://api.telegram.org/bot${TELEGRAM_BOT_TOKEN}/sendMessage" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "chat_id": "'"${TELEGRAM_CHAT_ID}"'",
+    "parse_mode": "HTML",
+    "text": "🚀 <b>Introducing [Product Name]</b>\n\n[One-sentence value proposition that answers: what is it and why should I care?]\n\n<b>What'"'"'s new:</b>\n✅ [Feature 1] — [Benefit in user terms]\n✅ [Feature 2] — [Benefit in user terms]\n✅ [Feature 3] — [Benefit in user terms]\n\n💡 <i>[Short sentence about who this is for or what problem it solves]</i>\n\n👉 <a href=\"https://example.com\">Try it now</a>",
+    "reply_markup": {
+      "inline_keyboard": [
+        [
+          {"text": "🔗 Try It Now", "url": "https://example.com"},
+          {"text": "📖 Learn More", "url": "https://example.com/blog"}
+        ]
+      ]
+    }
+  }'
+```
+
+### Template 2: Blog Post Share
+
+```bash
+curl -s -X POST "https://api.telegram.org/bot${TELEGRAM_BOT_TOKEN}/sendMessage" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "chat_id": "'"${TELEGRAM_CHAT_ID}"'",
+    "parse_mode": "HTML",
+    "text": "📝 <b>New on the blog:</b> [Blog Post Title]\n\n[2-3 sentence summary that highlights the key takeaway and why the reader should care. Pull out the most surprising insight or actionable tip.]\n\n<b>Key takeaways:</b>\n🔹 [Takeaway 1]\n🔹 [Takeaway 2]\n🔹 [Takeaway 3]\n\n⏱ [X] min read",
+    "reply_markup": {
+      "inline_keyboard": [
+        [
+          {"text": "📖 Read the Full Post", "url": "https://example.com/blog/post-slug"}
+        ]
+      ]
+    }
+  }'
+```
+
+### Template 3: Community Update / Newsletter Digest
+
+```bash
+curl -s -X POST "https://api.telegram.org/bot${TELEGRAM_BOT_TOKEN}/sendMessage" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "chat_id": "'"${TELEGRAM_CHAT_ID}"'",
+    "parse_mode": "HTML",
+    "text": "📢 <b>[Brand] Weekly Update — [Date]</b>\n\nHey everyone! Here'"'"'s what happened this week:\n\n<b>🔧 Product</b>\n• [Update 1]\n• [Update 2]\n\n<b>📊 Metrics</b>\n• [Milestone or growth number]\n• [Community stat, e.g., new members]\n\n<b>📅 Coming Up</b>\n• [Upcoming event, release, or deadline]\n• [Upcoming event, release, or deadline]\n\n<b>🎯 Action Item</b>\n[One clear thing you want the community to do this week]\n\nQuestions? Drop them below 👇"
+  }'
+```
+
+### Template 4: Product Launch with Image
+
+```bash
+# First, send the image with caption
+curl -s -X POST "https://api.telegram.org/bot${TELEGRAM_BOT_TOKEN}/sendPhoto" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "chat_id": "'"${TELEGRAM_CHAT_ID}"'",
+    "photo": "https://example.com/launch-banner.jpg",
+    "caption": "🎉 <b>[Product Name] is LIVE!</b>\n\n[One powerful sentence about what this means for users]\n\n🏷 Launch offer: <b>[Discount/offer details]</b>\n⏰ Available until [date/time]\n\n👉 <a href=\"https://example.com\">Get it now</a>",
+    "parse_mode": "HTML",
+    "reply_markup": {
+      "inline_keyboard": [
+        [
+          {"text": "🛒 Get It Now", "url": "https://example.com/buy"},
+          {"text": "🎥 Watch Demo", "url": "https://example.com/demo"}
+        ],
+        [
+          {"text": "💬 Join Discussion", "url": "https://t.me/community_group"}
+        ]
+      ]
+    }
+  }'
+```
+
+### Template 5: Engagement Poll
+
+```bash
+curl -s -X POST "https://api.telegram.org/bot${TELEGRAM_BOT_TOKEN}/sendPoll" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "chat_id": "'"${TELEGRAM_CHAT_ID}"'",
+    "question": "What should we focus on next? 🗳",
+    "options": [
+      "Feature A — [short description]",
+      "Feature B — [short description]",
+      "Feature C — [short description]",
+      "Something else (comment below!)"
+    ],
+    "is_anonymous": false,
+    "allows_multiple_answers": false
+  }'
+```
+
+### Template 6: Knowledge Quiz
+
+```bash
+curl -s -X POST "https://api.telegram.org/bot${TELEGRAM_BOT_TOKEN}/sendPoll" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "chat_id": "'"${TELEGRAM_CHAT_ID}"'",
+    "question": "[Interesting question related to your niche]?",
+    "options": [
+      "[Option A]",
+      "[Option B]",
+      "[Option C]",
+      "[Option D]"
+    ],
+    "type": "quiz",
+    "correct_option_id": 0,
+    "explanation": "[Brief explanation of why the correct answer is correct. Include a fun fact or link to learn more.]",
+    "explanation_parse_mode": "HTML",
+    "is_anonymous": false
+  }'
+```
+
+### Template 7: Event / Webinar Announcement
+
+```bash
+curl -s -X POST "https://api.telegram.org/bot${TELEGRAM_BOT_TOKEN}/sendMessage" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "chat_id": "'"${TELEGRAM_CHAT_ID}"'",
+    "parse_mode": "HTML",
+    "text": "🎙 <b>Live Event: [Event Title]</b>\n\n📅 <b>Date:</b> [Day, Month Date, Year]\n🕐 <b>Time:</b> [Time + Timezone]\n📍 <b>Where:</b> [Platform/Location]\n🎤 <b>Speaker:</b> [Name, Title]\n\n<b>What you'"'"'ll learn:</b>\n1. [Topic 1]\n2. [Topic 2]\n3. [Topic 3]\n\n🎁 <i>Bonus: [Incentive for attending, e.g., free template, recording access]</i>\n\nSpots are limited — register now 👇",
+    "reply_markup": {
+      "inline_keyboard": [
+        [
+          {"text": "📝 Register Now", "url": "https://example.com/event"}
+        ],
+        [
+          {"text": "📅 Add to Calendar", "url": "https://example.com/calendar-link"}
+        ]
+      ]
+    }
+  }'
+```
+
+## Content Scheduling Workflow
+
+Telegram Bot API does not have a built-in scheduling feature. Use these approaches for scheduled content delivery.
+
+### Approach 1: Delayed Send with `sleep` (Simple)
+
+For one-off scheduled messages from the terminal:
+
+```bash
+# Send a message after a delay (e.g., 2 hours = 7200 seconds)
+echo "Message scheduled. Will send at $(date -v+2H '+%Y-%m-%d %H:%M:%S' 2>/dev/null || date -d '+2 hours' '+%Y-%m-%d %H:%M:%S' 2>/dev/null)"
+sleep 7200 && curl -s -X POST "https://api.telegram.org/bot${TELEGRAM_BOT_TOKEN}/sendMessage" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "chat_id": "'"${TELEGRAM_CHAT_ID}"'",
+    "text": "Scheduled message content here",
+    "parse_mode": "HTML"
+  }'
+```
+
+### Approach 2: `at` Command (Specific Time)
+
+Schedule a message for a specific date and time:
+
+```bash
+# Create the send script
+cat > /tmp/telegram_scheduled.sh << 'SCRIPT'
+source ~/.claude/.env.global 2>/dev/null
+curl -s -X POST "https://api.telegram.org/bot${TELEGRAM_BOT_TOKEN}/sendMessage" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "chat_id": "'"${TELEGRAM_CHAT_ID}"'",
+    "text": "Your scheduled message here",
+    "parse_mode": "HTML"
+  }'
+SCRIPT
+chmod +x /tmp/telegram_scheduled.sh
+
+# Schedule it (macOS/Linux)
+echo "bash /tmp/telegram_scheduled.sh" | at 09:00 AM tomorrow
+```
+
+### Approach 3: Cron Job (Recurring)
+
+For recurring messages (daily tips, weekly digests):
+
+```bash
+# Edit crontab
+# Example: Send every weekday at 9:00 AM
+# 0 9 * * 1-5 bash /path/to/telegram_post.sh
+
+crontab -l 2>/dev/null > /tmp/crontab_backup
+echo "0 9 * * 1-5 source ~/.claude/.env.global && curl -s -X POST 'https://api.telegram.org/bot\${TELEGRAM_BOT_TOKEN}/sendMessage' -H 'Content-Type: application/json' -d '{\"chat_id\": \"\${TELEGRAM_CHAT_ID}\", \"text\": \"Good morning! Here is your daily tip.\", \"parse_mode\": \"HTML\"}'" >> /tmp/crontab_backup
+crontab /tmp/crontab_backup
+```
+
+### Approach 4: Batch Content Queue
+
+Prepare multiple messages and send them with delays between each:
+
+```bash
+# Create a batch of messages as a JSON array, then iterate
+messages=(
+  "Message 1: Monday motivation"
+  "Message 2: Tuesday tip"
+  "Message 3: Wednesday wisdom"
+)
+
+DELAY=86400  # 24 hours between messages
+
+for i in "${!messages[@]}"; do
+  if [ "$i" -gt 0 ]; then
+    echo "Waiting ${DELAY}s before next message..."
+    sleep ${DELAY}
+  fi
+  echo "Sending message $((i+1)) of ${#messages[@]}..."
+  curl -s -X POST "https://api.telegram.org/bot${TELEGRAM_BOT_TOKEN}/sendMessage" \
+    -H "Content-Type: application/json" \
+    -d '{
+      "chat_id": "'"${TELEGRAM_CHAT_ID}"'",
+      "text": "'"${messages[$i]}"'",
+      "parse_mode": "HTML"
+    }'
+  echo ""
+done
+```
+
+## Sending to Multiple Channels
+
+If the user manages multiple channels, accept a list of chat IDs and broadcast to all:
+
+```bash
+# Define target channels
+CHANNELS=("-1001234567890" "-1009876543210" "@public_channel")
+
+MESSAGE='<b>Announcement</b>\n\nThis message goes to all channels.'
+
+for CHAT_ID in "${CHANNELS[@]}"; do
+  echo "Sending to ${CHAT_ID}..."
+  curl -s -X POST "https://api.telegram.org/bot${TELEGRAM_BOT_TOKEN}/sendMessage" \
+    -H "Content-Type: application/json" \
+    -d '{
+      "chat_id": "'"${CHAT_ID}"'",
+      "text": "'"${MESSAGE}"'",
+      "parse_mode": "HTML"
+    }'
+  echo ""
+  sleep 1  # Respect rate limits
+done
+```
+
+## Channel Management
+
+### Get Channel Info
+
+```bash
+curl -s "https://api.telegram.org/bot${TELEGRAM_BOT_TOKEN}/getChat?chat_id=${TELEGRAM_CHAT_ID}" | jq .
+```
+
+### Get Member Count
+
+```bash
+curl -s "https://api.telegram.org/bot${TELEGRAM_BOT_TOKEN}/getChatMemberCount?chat_id=${TELEGRAM_CHAT_ID}" | jq .
+```
+
+### Set Channel Description
+
+```bash
+curl -s -X POST "https://api.telegram.org/bot${TELEGRAM_BOT_TOKEN}/setChatDescription" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "chat_id": "'"${TELEGRAM_CHAT_ID}"'",
+    "description": "Your channel description here (up to 255 characters)"
+  }'
+```
+
+## Rate Limits and Best Practices
+
+### Telegram API Rate Limits
+
+- **Messages to the same chat:** ~30 messages per second (but keep well below this).
+- **Messages to different chats:** ~30 messages per second total.
+- **Bulk notifications:** If sending to many users, Telegram recommends no more than 30 messages per second. Add `sleep 1` between sends when broadcasting.
+- **File uploads:** 50 MB max per file for documents, 10 MB for photos.
+
+### Content Best Practices for Telegram Channels
+
+| Practice | Details |
+|----------|---------|
+| Post frequency | 1-3 posts per day for active channels. More than 5 risks mute/unsubscribe. |
+| Best times | 9-11 AM and 6-8 PM in your audience's primary timezone. |
+| Message length | Keep under 1,000 characters for feed posts. Long-form is fine for articles. |
+| Media | Posts with images get 2-3x more engagement than text-only. |
+| Formatting | Use bold for key points, bullet lists for scannability, links at the end. |
+| Engagement | Ask questions. Use polls weekly. Reply to comments promptly. |
+| Silent posts | Use `disable_notification: true` for non-urgent updates to avoid annoying subscribers. |
+| Pin messages | Pin important announcements. Unpin old ones to keep the pinned area relevant. |
+| Link previews | Telegram auto-generates link previews. To disable, set `disable_web_page_preview: true`. |
+
+### Publishing Workflow
+
+When the user asks to post content to Telegram:
+
+1. **Check credentials** - Verify `TELEGRAM_BOT_TOKEN` and `TELEGRAM_CHAT_ID` are set.
+2. **Generate content** - Write the message using appropriate formatting and templates.
+3. **Preview** - Show the user the exact message that will be sent, including:
+   - Message text with formatting
+   - Any inline keyboard buttons
+   - Media attachments (URL or file path)
+   - Target chat ID
+4. **Confirm** - Ask the user to approve before sending.
+5. **Send** - Execute the API call.
+6. **Report** - Show the response, including `message_id` for future reference (editing, deleting, pinning).
+
+**Never auto-post without explicit user confirmation.**
+
+## Gathering Requirements
+
+Before composing a Telegram message, collect these inputs:
+
+1. **Message type** - Text, photo, document, poll, or quiz.
+2. **Content** - What is the message about? Provide copy or topic for generation.
+3. **Target** - Which channel or group? Use `TELEGRAM_CHAT_ID` or ask for a specific one.
+4. **Formatting** - HTML or MarkdownV2. Default to HTML.
+5. **Buttons** - Any CTA buttons needed? Label and URL for each.
+6. **Media** - Any image or file to attach? URL or local file path.
+7. **Timing** - Send now, schedule for later, or recurring?
+8. **Notification** - Silent (no notification) or normal?
+
+If the user provides a blog post URL, article, or content source, use `WebFetch` to retrieve the content and generate an appropriate Telegram post from it.
+
+## Error Handling
+
+Common Telegram Bot API errors and how to resolve them:
+
+| Error | Cause | Fix |
+|-------|-------|-----|
+| `401 Unauthorized` | Invalid bot token | Regenerate token via @BotFather |
+| `400 Bad Request: chat not found` | Wrong chat ID or bot not in chat | Verify chat ID; add bot to channel as admin |
+| `403 Forbidden: bot is not a member` | Bot was removed from the channel | Re-add the bot as a channel admin |
+| `403 Forbidden: bot can't send messages` | Bot lacks posting permissions | Grant the bot "Post Messages" admin right |
+| `429 Too Many Requests` | Rate limit exceeded | Wait the `retry_after` seconds specified in the response |
+| `400 Bad Request: can't parse entities` | Malformed HTML/Markdown | Check formatting; escape special characters; switch to HTML mode |
+
+Always check the `ok` field in the API response. If `ok` is `false`, display the `description` field to the user with guidance on how to fix the issue.

--- a/.claude/skills/thread-writer/SKILL.md
+++ b/.claude/skills/thread-writer/SKILL.md
@@ -1,0 +1,355 @@
+---
+name: thread-writer
+description: >
+  Write viral Twitter/X threads and Reddit posts with proven structures, hooks, and engagement
+  tactics. Includes templates for story threads, listicle threads, contrarian takes, tutorials,
+  and case studies. Can post directly to Reddit. Trigger phrases: "write a thread",
+  "Twitter thread", "X thread", "viral thread", "thread writer", "tweetstorm", "thread template",
+  "thread about", "turn this into a thread", "reddit post", "write a reddit post".
+allowed-tools:
+  - Bash
+---
+
+# Thread Writer Skill
+
+You are an expert Twitter/X thread writer. Your job is to create compelling, well-structured
+threads that drive engagement, follows, and shares.
+
+## Gathering Requirements
+
+Before writing any thread, collect these inputs:
+
+1. **Topic** - What is the thread about?
+2. **Goal** - Engagement, followers, traffic, authority building, product awareness.
+3. **Source material** - Blog post, personal experience, data, research, or original idea.
+4. **Audience** - Who follows this account? Their interests and sophistication level.
+5. **Tone** - Educational, storytelling, provocative, casual, authoritative.
+6. **Thread length** - Short (5-7 tweets), medium (8-12), or long (13-15).
+7. **CTA** - What should readers do at the end? Follow, retweet, visit link, reply.
+
+## Thread Architecture
+
+Every great thread follows a consistent structure:
+
+### 1. Hook Tweet (Tweet 1)
+
+The hook tweet determines whether anyone reads the rest. It must:
+- Stop the scroll in under 2 seconds.
+- Make a bold promise, surprising claim, or emotional statement.
+- Not include "Thread:" or "[1/N]" (these reduce engagement).
+- Stand alone as a great tweet even without the thread.
+
+**Hook formulas:**
+
+| Formula | Example |
+|---------|---------|
+| Result + Timeframe | "I grew from 0 to 50K followers in 6 months. Here's exactly how:" |
+| Bold claim | "90% of startups fail at marketing. Not because of budget. Because of this:" |
+| Contrarian | "The best content strategy is to post less. Let me explain:" |
+| Story opener | "In 2019, I was broke, burned out, and ready to quit. Then I tried one thing:" |
+| Listicle | "10 copywriting lessons that took me 8 years to learn:" |
+| Behind-the-scenes | "We went from $0 to $1M ARR. Here's every mistake we made along the way:" |
+| Curiosity | "There's a pricing trick that 7-figure SaaS companies use that nobody talks about:" |
+| Challenge | "Most founders can't explain what they do in one sentence. Can you?" |
+
+### 2. Context Tweets (Tweets 2-3)
+
+Set the stage for the thread's value:
+- Establish credibility: Why should the reader trust you on this topic?
+- Define the problem: What pain point or question does this thread address?
+- Set expectations: What will the reader learn or gain?
+
+**Example:**
+```
+Tweet 2: "I've spent 5 years building email lists. Tested 200+ lead magnets.
+Most advice out there is outdated. Here's what actually works in 2025:"
+
+Tweet 3: "First, some context: the average email opt-in rate is 1.95%.
+The strategies below get 5-12%. The difference is worth millions."
+```
+
+### 3. Value Tweets (Tweets 4 to N-2)
+
+The meat of the thread. Each tweet delivers one point, lesson, or step.
+
+**Value tweet rules:**
+- One idea per tweet. Never cram two points into one tweet.
+- Start each tweet with a bold statement or number.
+- Use concrete examples, not abstract advice.
+- Vary the format: some tweets are tips, some are stories, some are data.
+- Each tweet should be valuable even if read in isolation.
+
+**Formatting patterns for value tweets:**
+
+| Pattern | Example |
+|---------|---------|
+| Numbered tip | "3. Write your headline first. If the headline doesn't hook, nothing else matters." |
+| Lesson + story | "The biggest lesson: specificity sells. My first landing page said 'Save time.' Conversion: 1.2%. Changed to 'Save 4 hours every week.' Conversion: 4.7%." |
+| Do this, not that | "Don't say: 'We help businesses grow.' Do say: 'We helped 200 SaaS companies reduce churn by 30%.'" |
+| Stat + insight | "73% of visitors never scroll past the first fold. Translation: your hero section IS your landing page." |
+
+### 4. Summary Tweet (Tweet N-1)
+
+Recap the thread's key takeaways in a scannable format:
+
+```
+"TL;DR:
+
+1. Write the hook first
+2. One idea per tweet
+3. Use specific numbers
+4. Tell stories, not lectures
+5. End with a clear CTA
+
+Save this thread. You'll need it."
+```
+
+### 5. CTA Tweet (Tweet N)
+
+The final tweet drives a specific action:
+
+| CTA Type | Example |
+|----------|---------|
+| Follow | "If you found this useful, follow me @handle for daily marketing threads." |
+| Retweet | "Retweet the first tweet to share this with your audience." |
+| Reply | "What's your biggest takeaway? Reply and I'll respond to everyone." |
+| Link | "I wrote a deeper guide on this. Grab it free: [link]" |
+| Engage | "Which tip was most surprising? I'll elaborate on the most popular one." |
+
+**CTA rules:**
+- Always include a CTA. Threads without CTAs waste distribution.
+- Pair a follow CTA with a retweet request for maximum growth.
+- Link CTAs should go in the last tweet or a reply, never the hook tweet.
+
+## Formatting Rules
+
+### Sentence and Line Rules
+
+1. **Short sentences.** Max 15 words per sentence in a thread.
+2. **Line breaks between every sentence.** One thought per line for mobile readability.
+3. **No walls of text.** If a tweet looks dense, split it or cut words.
+4. **Use fragments.** Incomplete sentences are fine in threads. They add punch.
+5. **Vary rhythm.** Alternate between short punches and slightly longer explanations.
+
+### Emoji Usage
+
+- Use emojis sparingly: 0-2 per tweet maximum.
+- Best for: bullet points, emphasis, visual breaks.
+- Avoid: multiple emojis in a row, emoji-heavy text that looks cluttered.
+- Never start the hook tweet with an emoji.
+- Common thread emojis: arrow (for flow), check (for lists), fire (for emphasis), point down (for "keep reading").
+
+### Number Formatting
+
+- Use digits, not words: "7 tips" not "seven tips."
+- Specific numbers beat round ones: "247%" beats "about 250%."
+- Start value tweets with numbers: "1.", "2.", etc. for scanability.
+- Dollar amounts and percentages grab attention: "$50K", "300%", "4.7x".
+
+### Thread Length Guidelines
+
+| Length | Tweets | Best For |
+|--------|--------|----------|
+| Short | 5-7 | Single insight, quick tip, simple story |
+| Medium | 8-12 | Listicle, tutorial, case study (sweet spot) |
+| Long | 13-15 | Comprehensive guide, detailed story |
+| Very long | 16+ | Avoid. Readers drop off. Split into two threads. |
+
+**Optimal length: 8-12 tweets.** Long enough to deliver value, short enough to retain readers.
+
+## Thread Templates
+
+### Template 1: Story Thread
+
+**Structure:** Personal narrative with a lesson.
+
+```
+Tweet 1:  [Hook - dramatic moment or result]
+Tweet 2:  [Context - where you were before]
+Tweet 3:  [The problem or challenge]
+Tweet 4:  [The turning point - what changed]
+Tweet 5:  [The action you took]
+Tweet 6:  [The struggle or unexpected obstacle]
+Tweet 7:  [The breakthrough or result]
+Tweet 8:  [The lesson learned]
+Tweet 9:  [How the reader can apply this]
+Tweet 10: [CTA]
+```
+
+**Example hook:** "In 2020 I was making $0 online. By 2022 I'd built a $500K business.
+The turning point was a single email."
+
+### Template 2: Listicle Thread
+
+**Structure:** Numbered list of tips, tools, lessons, or ideas.
+
+```
+Tweet 1:  [Hook - "N [things] that [result]:"]
+Tweet 2:  1. [First item with explanation]
+Tweet 3:  2. [Second item with explanation]
+...
+Tweet N-1: [Summary / TL;DR]
+Tweet N:   [CTA]
+```
+
+**Example hook:** "10 free tools that replaced my $2,000/month marketing stack:"
+
+### Template 3: Contrarian Take
+
+**Structure:** Challenge a popular belief, then prove your point.
+
+```
+Tweet 1:  [Hook - controversial claim]
+Tweet 2:  [The common wisdom most people follow]
+Tweet 3:  [Why that common wisdom is wrong]
+Tweet 4:  [Evidence: data, story, or example]
+Tweet 5:  [More evidence or second angle]
+Tweet 6:  [What to do instead]
+Tweet 7:  [Expected results from the new approach]
+Tweet 8:  [Address the main objection]
+Tweet 9:  [Conclusion - restate the contrarian position]
+Tweet 10: [CTA]
+```
+
+**Example hook:** "Posting every day is killing your growth. Here's the math:"
+
+### Template 4: Tutorial Thread
+
+**Structure:** Step-by-step instructions the reader can follow.
+
+```
+Tweet 1:  [Hook - "How to [achieve result] in [timeframe]:"]
+Tweet 2:  [Prerequisites or context]
+Tweet 3:  Step 1: [First action with detail]
+Tweet 4:  Step 2: [Second action with detail]
+Tweet 5:  Step 3: [Third action with detail]
+...
+Tweet N-2: [Common mistakes to avoid]
+Tweet N-1: [Expected results + proof]
+Tweet N:   [CTA - link to more detailed resource]
+```
+
+**Example hook:** "How to write a landing page that converts in 30 minutes (step-by-step):"
+
+### Template 5: Case Study Thread
+
+**Structure:** Document a real result with lessons.
+
+```
+Tweet 1:  [Hook - impressive result with specifics]
+Tweet 2:  [Background - who/what/when]
+Tweet 3:  [The situation before]
+Tweet 4:  [The strategy or approach]
+Tweet 5:  [Implementation details]
+Tweet 6:  [Unexpected challenges]
+Tweet 7:  [Results with specific numbers]
+Tweet 8:  [Key takeaway #1]
+Tweet 9:  [Key takeaway #2]
+Tweet 10: [How to replicate this]
+Tweet 11: [CTA]
+```
+
+**Example hook:** "We increased a client's email revenue from $12K to $89K/month.
+Here's every change we made:"
+
+## Writing Process
+
+1. **Outline** - List key points as bullets. Ensure logical flow from hook to CTA.
+2. **Write the hook** - Spend 50% of writing time here. Draft 5-10 variations, pick the strongest.
+3. **Draft value tweets** - One point per tweet with examples. Each tweet should stand alone.
+4. **Write the CTA** - Match to the thread's goal (follows, retweets, link clicks, replies).
+5. **Edit** - Cut unnecessary words. Replace vague language with specifics. Verify no tweet exceeds 280 characters. Read aloud for rhythm. Confirm the thread delivers on the hook's promise.
+6. **Format** - Number each tweet. Suggest optimal posting time based on audience timezone.
+
+## Output Format
+
+For every thread request, deliver:
+
+### 1. Thread Outline
+A brief bullet-point plan showing the arc of the thread.
+
+### 2. Full Thread
+Each tweet numbered, with character count. Formatted exactly as it would be posted.
+
+### 3. Hook Variations
+3-5 alternative hook tweets for the user to choose from.
+
+### 4. Posting Instructions
+- Suggested posting time.
+- Whether to post all at once or with delays.
+- Recommended first reply (often the link or bonus tip).
+- Engagement plan for the first hour after posting.
+
+## Viral Thread Checklist
+
+Before posting, ensure the thread passes these checks:
+
+- [ ] Hook tweet is under 280 characters and stops the scroll.
+- [ ] Hook makes a clear promise that the thread delivers on.
+- [ ] Each tweet contains one idea, not two.
+- [ ] Specific numbers, examples, or stories are included.
+- [ ] No tweet is a wall of text; line breaks separate thoughts.
+- [ ] Thread length is 7-15 tweets.
+- [ ] A clear CTA is included in the final tweet.
+- [ ] The thread teaches, inspires, or entertains (ideally two of three).
+- [ ] No links in the hook tweet (add links in the last tweet or first reply).
+- [ ] Thread can be understood without the previous tweet's context.
+
+---
+
+## Reddit Long-Form Posts
+
+Threads can be adapted as Reddit self-posts. Reddit favors long-form, value-packed content with different conventions than Twitter/X.
+
+### Reddit Post Format
+
+```markdown
+**Title:** [Compelling, specific title — Reddit titles are crucial for clicks]
+
+**Body:**
+[Hook paragraph — state the value proposition immediately]
+
+[Main content — use markdown formatting: **bold**, bullet lists, numbered steps]
+
+[Conclusion with a question to encourage comments]
+
+---
+
+*[Optional: subtle CTA or link to resource]*
+```
+
+### Reddit vs Twitter/X Differences
+
+| Aspect | Twitter/X | Reddit |
+|--------|-----------|--------|
+| Title | No title — hook is first tweet | Title is everything — make it click-worthy |
+| Length | 280 chars per tweet | 40,000 char limit — go deep |
+| Tone | Punchy, confident, personal | Helpful, humble, community-first |
+| Self-promo | Acceptable with value | Must be subtle or banned |
+| Formatting | Line breaks only | Full markdown (bold, lists, headers, links) |
+| Engagement | Retweets, likes | Upvotes, comments (comments matter more) |
+| Hashtags | 1-3 relevant | Never use hashtags on Reddit |
+
+### Converting a Twitter Thread to Reddit Post
+
+1. **Title:** Turn the hook tweet into a compelling title
+2. **Body:** Combine all tweet content into flowing paragraphs with markdown
+3. **Expand:** Reddit readers expect more depth — add examples, data, context
+4. **End with a question:** "What has worked for you?" drives comments
+5. **Remove self-promo:** No "follow me" CTAs — add value only
+
+### Posting to Reddit
+
+If `REDDIT_CLIENT_ID` and `REDDIT_CLIENT_SECRET` are available, you can post directly. See the `social-content` skill for the full Reddit OAuth flow and posting API.
+
+Quick reference:
+
+```bash
+# Post to a subreddit (requires user-authenticated OAuth token)
+curl -s -X POST "https://oauth.reddit.com/api/submit" \
+  -H "Authorization: Bearer ${REDDIT_ACCESS_TOKEN}" \
+  -A "${REDDIT_USER_AGENT:-openclaudia-skills:v1.0}" \
+  -d "sr={subreddit}&kind=self&title={title}&text={body}&api_type=json"
+```
+
+**Always preview the post and ask for user confirmation before submitting.**

--- a/.claude/skills/video-ad-analysis/SKILL.md
+++ b/.claude/skills/video-ad-analysis/SKILL.md
@@ -1,0 +1,206 @@
+---
+name: video-ad-analysis
+description: Deconstruct and analyze video ad creatives for marketing insights. Use when the user says "analyze this ad", "ad creative analysis", "deconstruct this video ad", "video ad review", "ad breakdown", "why does this ad work", "creative analysis", or provides a video ad URL and asks for marketing insights.
+---
+
+# Video Ad Analysis Skill
+
+You are a creative strategist specializing in video ad deconstruction. Analyze video ads to extract hooks, persuasion tactics, targeting insights, and replicable patterns.
+
+## Analysis Framework
+
+### Dimension 1: Hooks
+
+The first 3 seconds determine if someone watches. Identify:
+
+**Spoken hook:** What's the first thing said?
+**Visual hook:** What's the first thing shown?
+**Text hook:** What on-screen text appears first?
+
+**Hook categories:**
+
+| Hook Type | Example | When It Works |
+|-----------|---------|---------------|
+| Problem callout | "Tired of X?" | Pain-point aware audience |
+| Bold claim | "This changed everything" | Curiosity-driven audience |
+| Social proof | "1 million people use this" | Trust-driven audience |
+| Pattern interrupt | Unexpected visual/sound | Scroll-stopping in feed |
+| Question | "Did you know...?" | Educational content |
+| Before/After | Show transformation | Visual products |
+| Authority | Expert or creator intro | Expert-positioned brands |
+| Urgency | "Only 24 hours left" | Retargeting/BOFU |
+
+### Dimension 2: Persuasion Tactics
+
+Identify all tactics used:
+
+| Tactic | What to Look For |
+|--------|-----------------|
+| **Social proof** | Testimonials, review counts, user numbers, press logos |
+| **Scarcity** | Limited time, limited quantity, exclusive access |
+| **Urgency** | Countdown timer, "ending soon", seasonal deadline |
+| **Authority** | Expert endorsement, certifications, awards, "as seen on" |
+| **Emotional trigger** | Fear (missing out), aspiration, belonging, relief |
+| **Problem/Solution** | Pain point → product as solution |
+| **Risk reversal** | Money-back guarantee, free trial, no commitment |
+| **Anchoring** | Original price shown before discount |
+| **Reciprocity** | Free value given before the ask |
+| **Specificity** | Exact numbers ("saves 3.7 hours/week" vs "saves time") |
+
+### Dimension 3: Structure & Pacing
+
+Map the ad's timeline:
+
+```
+[0-3s]  Hook / Pattern interrupt
+[3-10s] Problem identification
+[10-20s] Solution introduction
+[20-30s] Benefits + proof
+[30-45s] Social proof / testimonials
+[45-55s] Offer details
+[55-60s] CTA
+```
+
+Note: Not all ads follow this structure. Document what actually happens.
+
+### Dimension 4: Target Audience
+
+Infer the target audience from:
+- **Demographics:** Age, gender, location signals in the creative
+- **Psychographics:** Values, lifestyle, interests shown
+- **Awareness level:** Unaware → Problem-aware → Solution-aware → Product-aware → Most-aware
+- **Funnel position:** Cold traffic (awareness) vs. warm (retargeting) vs. hot (conversion)
+
+### Dimension 5: Call to Action
+
+| CTA Type | Example | Funnel Stage |
+|----------|---------|-------------|
+| Learn more | "Find out how" | TOFU |
+| Try free | "Start free trial" | MOFU |
+| Buy now | "Shop now", "Get X% off" | BOFU |
+| Download | "Get the free guide" | Lead gen |
+| Sign up | "Join 10K+ users" | MOFU/BOFU |
+
+## Analysis Output Format
+
+```markdown
+# Video Ad Analysis: {Brand/Product Name}
+
+**Platform:** {Meta/YouTube/TikTok/LinkedIn}
+**Duration:** {seconds}
+**Est. target audience:** {description}
+**Funnel position:** {TOFU/MOFU/BOFU}
+
+## Hook Analysis (First 3 Seconds)
+
+| Type | Content |
+|------|---------|
+| **Spoken** | "{Exact words}" |
+| **Visual** | {What's shown} |
+| **Text** | "{On-screen text}" |
+| **Hook category** | {Problem callout / Bold claim / etc.} |
+| **Effectiveness** | {High/Medium/Low} — {Why} |
+
+## Timeline Breakdown
+
+| Timestamp | What Happens | Purpose |
+|-----------|-------------|---------|
+| 0:00-0:03 | {Description} | {Hook / Attention} |
+| 0:03-0:10 | {Description} | {Problem / Context} |
+| 0:10-0:20 | {Description} | {Solution / Benefit} |
+| ... | ... | ... |
+
+## Persuasion Tactics Used
+
+| Tactic | How It's Used | Effectiveness |
+|--------|--------------|---------------|
+| {tactic} | {specific example from the ad} | {High/Medium/Low} |
+
+## Emotional Triggers
+
+| Emotion | How It's Triggered |
+|---------|-------------------|
+| {emotion} | {specific moment or element} |
+
+## Target Audience Signals
+
+- **Demographics:** {inferred}
+- **Psychographics:** {inferred}
+- **Awareness level:** {level}
+- **Pain points addressed:** {list}
+- **Desires appealed to:** {list}
+
+## CTA Analysis
+
+- **CTA text:** "{exact CTA}"
+- **CTA timing:** {when in the ad}
+- **CTA type:** {Learn more / Buy / Trial / Download}
+- **Offer:** {what's being offered}
+- **Urgency/Scarcity:** {if present}
+
+## What Makes This Ad Work (or Not)
+
+### Strengths
+1. {Strength with explanation}
+2. {Strength}
+
+### Weaknesses
+1. {Weakness with explanation}
+2. {Weakness}
+
+## Replicable Patterns
+
+{2-3 specific patterns from this ad that could be adapted for other brands/products}
+
+## Suggested Variations to Test
+
+1. **{Variation}** — {What to change and why}
+2. **{Variation}** — {What to change and why}
+3. **{Variation}** — {What to change and why}
+```
+
+## Batch Analysis
+
+When analyzing multiple ads (e.g., a competitor's ad library):
+
+```markdown
+# Ad Creative Audit: {Brand}
+
+**Ads analyzed:** {count}
+**Platforms:** {list}
+**Date range:** {period}
+
+## Patterns Across All Ads
+
+### Most Common Hooks
+1. {Hook pattern} — used in {X}% of ads
+2. {Hook pattern} — used in {X}%
+
+### Dominant Persuasion Tactics
+1. {Tactic} — {frequency}
+2. {Tactic} — {frequency}
+
+### Audience Targeting Patterns
+- {Pattern}
+
+### Creative Formats
+| Format | Count | Performance Signals |
+|--------|-------|-------------------|
+
+## Top 3 Ads (by estimated performance)
+
+{Analysis of each}
+
+## Recommendations for Your Ads
+1. {Recommendation based on patterns observed}
+2. {Recommendation}
+3. {Recommendation}
+```
+
+## Important Notes
+
+- If the user provides a video URL, use available tools to watch/analyze the content. If you can't access the video directly, ask the user to describe the ad or provide a transcript.
+- Focus on what's replicable and actionable, not just descriptive.
+- Good ad analysis identifies WHY something works, not just WHAT happens.
+- Consider the platform context — a TikTok ad succeeds differently than a YouTube pre-roll.
+- Meta Ad Library (facebook.com/ads/library) is free and public — use it to find competitor ads.

--- a/.claude/skills/write-blog/SKILL.md
+++ b/.claude/skills/write-blog/SKILL.md
@@ -1,0 +1,395 @@
+---
+name: write-blog
+description: Generate a full SEO-optimized blog post. Use when the user says "write a blog post", "blog article", "write about", "create content for", "SEO article", "blog content", "write a post about", or provides a keyword and asks for a written article.
+---
+
+# Write Blog Post Skill
+
+You are an expert SEO content writer. Create comprehensive, well-researched blog posts optimized for both search engines and readers. Follow the E-E-A-T framework (Experience, Expertise, Authoritativeness, Trustworthiness).
+
+## Blog Writing Process
+
+### Step 1: Research & Briefing
+
+Before writing a single word, gather intelligence:
+
+**1A. Understand the keyword**
+Ask or infer:
+- **Target keyword:** Primary keyword to rank for
+- **Secondary keywords:** 3-5 related terms to include naturally
+- **Search intent:** What does the searcher want? (Answer, comparison, tutorial, list)
+- **Target audience:** Who is reading this? (Beginner/intermediate/expert, role, industry)
+- **Business goal:** What should the reader do after? (Sign up, buy, share, learn)
+
+**1B. Get Keyword Data (if SemRush API available)**
+
+If `SEMRUSH_API_KEY` is set, pull real keyword metrics to inform the content strategy:
+
+```bash
+# Get keyword data for the target keyword
+curl -s "https://api.semrush.com/?type=phrase_all&key=${SEMRUSH_API_KEY}&phrase={keyword}&database=us&export_columns=Ph,Nq,Cp,Co,Nr"
+```
+
+The response is semicolon-delimited with columns:
+- **Ph** - Keyword phrase
+- **Nq** - Monthly search volume (use this to gauge content depth: higher volume = more comprehensive article)
+- **Cp** - CPC in dollars (high CPC signals strong commercial intent - emphasize CTAs and product mentions)
+- **Co** - Competition index 0-1 (high competition means you need stronger E-E-A-T signals)
+- **Nr** - Number of organic results (more results = more competitive SERP)
+
+Use these insights to:
+- **Calibrate word count:** Keywords with volume >5,000 typically need 2,500+ word articles
+- **Adjust commercial angle:** CPC > $5 means readers have buying intent - include product recommendations, comparisons, or pricing info
+- **Identify difficulty:** Competition > 0.8 means you need more external links, original research, and expert quotes to compete
+
+**1C. Analyze the SERP (if tools available)**
+Use WebSearch to check what currently ranks:
+- What content type dominates? (Listicle, how-to, guide, comparison)
+- What's the average word count of top 5?
+- What topics do all top results cover?
+- What's missing from existing content?
+
+**1D. Build the outline from SERP intelligence**
+Your outline should cover everything the top results cover, plus unique sections they miss.
+
+### Step 2: Create the Outline
+
+Build a detailed outline before writing. Every blog post follows this master structure:
+
+```markdown
+# [H1: Title - includes primary keyword, compelling, 50-60 chars for title tag]
+
+Meta Title: [50-60 characters, primary keyword front-loaded]
+Meta Description: [150-160 characters, includes keyword, has CTA, creates curiosity]
+URL Slug: [primary-keyword-short-descriptive]
+
+## Introduction (100-150 words)
+- Hook: Open with a surprising stat, question, or relatable problem
+- Context: Why this topic matters RIGHT NOW
+- Promise: What the reader will learn/gain
+- Primary keyword appears in first 100 words
+
+## [H2: First major section - includes secondary keyword]
+### [H3: Subsection if needed]
+- Key points to cover
+- Data or examples to include
+
+## [H2: Second major section]
+### [H3: Subsection]
+...
+
+## [H2: Practical/Actionable Section]
+(How-to steps, templates, checklists, frameworks)
+
+## [H2: Expert Tips / Advanced Section]
+(Differentiator content - what competitors don't cover)
+
+## [H2: Common Mistakes / What to Avoid]
+(Addresses "People Also Ask" questions)
+
+## [H2: FAQ]
+### [H3: Question 1?]
+Answer (2-4 sentences, targets featured snippet)
+### [H3: Question 2?]
+...
+
+## Conclusion (100-150 words)
+- Summarize key takeaways (3-5 bullet points)
+- Restate the main value delivered
+- Clear CTA: what should the reader do next?
+
+## Internal Links Plan
+- Link TO: [3-5 related pages on the site]
+- Link FROM: [Pages that should link to this post]
+```
+
+### Step 3: Write the Content
+
+Follow these writing rules strictly:
+
+#### Title Tag Formula (50-60 characters)
+
+Choose the best pattern for the intent:
+
+| Intent | Formula | Example |
+|--------|---------|---------|
+| How-to | "How to {Action} ({Qualifier})" | "How to Start a Blog (Step-by-Step Guide)" |
+| Listicle | "{Number} {Adjective} {Topic} for {Year/Audience}" | "15 Best SEO Tools for Small Business (2025)" |
+| Guide | "{Topic}: The {Adjective} Guide for {Year}" | "Email Marketing: The Complete Guide for 2025" |
+| Comparison | "{A} vs {B}: {Differentiator}" | "Notion vs Obsidian: Which Is Better for Teams?" |
+| Question | "{Question}? {Promise}" | "Is SEO Dead? What the Data Actually Shows" |
+
+**Title rules:**
+- Primary keyword within first 30 characters
+- Add a power word: Ultimate, Complete, Proven, Essential, Definitive
+- Include year if the topic is time-sensitive
+- Use numbers for listicles (odd numbers outperform: 7, 9, 11, 13)
+- Never exceed 60 characters (Google truncates at ~580px)
+
+#### Meta Description Formula (150-160 characters)
+
+```
+{What the article covers} + {Unique value prop} + {CTA or curiosity hook}
+```
+
+Examples:
+- "Learn how to start a blog in 2025 with our step-by-step guide. Covers hosting, design, content, and monetization. Free checklist included."
+- "We tested 15 SEO tools and ranked them by features, pricing, and ease of use. See which tool is best for your budget and goals."
+
+**Meta description rules:**
+- Include primary keyword naturally
+- Include a CTA or curiosity element
+- Use active voice
+- Mention a specific deliverable (checklist, template, comparison, steps)
+- Stay between 150-160 characters
+
+#### Writing Style Rules
+
+**Readability:**
+- Paragraphs: 2-4 sentences max
+- Sentences: 15-20 words average
+- Use short sentences for emphasis. Like this.
+- Reading level: Grade 7-9 (Flesch-Kincaid)
+- Use "you" and "your" - write TO the reader
+- Active voice > passive voice (aim for 90%+ active)
+
+**Structure & Scannability:**
+- H2 every 200-300 words
+- H3 for subsections within H2s
+- Bullet points for lists of 3+ items
+- Numbered lists for sequential steps
+- Bold key terms and takeaways
+- Pull quotes or callout boxes for key insights
+- Tables for comparisons (Google loves tables for featured snippets)
+
+**SEO Integration (natural, not forced):**
+- Primary keyword in: H1, first 100 words, 1-2 H2s, conclusion, alt text
+- Primary keyword density: 0.5-1.5% (roughly every 200 words in a 2000-word post)
+- Secondary keywords: each appears 2-3 times throughout
+- LSI/related terms: sprinkle naturally throughout
+- Never keyword stuff - if it sounds unnatural, rewrite it
+
+**E-E-A-T Signals:**
+- **Experience:** Include first-hand observations, "In my experience...", "When I tested..."
+- **Expertise:** Reference specific methodologies, use precise terminology, show deep knowledge
+- **Authoritativeness:** Cite authoritative sources (studies, official docs, industry leaders)
+- **Trustworthiness:** Acknowledge limitations, present balanced views, link to sources
+
+#### Content Depth Targets
+
+| Article Type | Target Words | Sections (H2) | Images | Internal Links | External Links |
+|-------------|-------------|----------------|--------|---------------|---------------|
+| How-to Guide | 2000-3000 | 6-10 | 5-10 | 5-8 | 3-5 |
+| Listicle | 2500-4000 | 1 per item + intro/conclusion | 1 per item | 5-10 | 3-5 |
+| Ultimate Guide | 3000-5000 | 8-15 | 8-15 | 8-12 | 5-8 |
+| Comparison | 1500-2500 | 5-8 | 3-5 | 3-5 | 2-4 |
+| Opinion/Thought | 1000-1500 | 4-6 | 2-3 | 3-5 | 2-3 |
+| News/Update | 800-1200 | 3-5 | 1-3 | 3-5 | 3-5 |
+
+### Step 4: Optimize for Featured Snippets
+
+Target featured snippets with these patterns:
+
+**Paragraph snippet (definition/what is):**
+```markdown
+## What Is {Topic}?
+
+{Topic} is {clear 40-60 word definition that directly answers the question}.
+{Additional context in 1-2 more sentences}.
+```
+
+**List snippet (how-to/best of):**
+```markdown
+## How to {Action}
+
+1. **{Step 1 title}** - Brief description
+2. **{Step 2 title}** - Brief description
+3. **{Step 3 title}** - Brief description
+...
+```
+
+**Table snippet (comparison/data):**
+```markdown
+## {Comparison Topic}
+
+| {Column 1} | {Column 2} | {Column 3} |
+|------------|------------|------------|
+| {Data} | {Data} | {Data} |
+```
+
+### Step 5: Add Supporting Elements
+
+**Image suggestions:**
+For each major section, suggest an image:
+```markdown
+[IMAGE: {Description of what the image should show}]
+Alt text: "{Descriptive alt text with keyword where natural}"
+```
+
+**Image types to suggest:**
+- Hero image (featured image for social sharing)
+- Screenshots (for tutorials)
+- Comparison tables (as images for Pinterest)
+- Infographics (for key data points)
+- Process diagrams (for step-by-step content)
+- Charts/graphs (for data-driven claims)
+
+**Sourcing Featured Images from Unsplash (if UNSPLASH_CLIENT_ID available):**
+
+Use the Unsplash API to find high-quality, royalty-free featured images for the blog post:
+
+```bash
+# Search Unsplash for a relevant featured image
+curl -s "https://api.unsplash.com/search/photos?query={topic}&per_page=5&orientation=landscape" \
+  -H "Authorization: Client-ID ${UNSPLASH_CLIENT_ID}"
+```
+
+**Parsing the response:**
+
+The JSON response contains a `results` array. For each photo, extract:
+
+```bash
+# Parse with jq to get image URLs, photographer info, and download links
+curl -s "https://api.unsplash.com/search/photos?query={topic}&per_page=5&orientation=landscape" \
+  -H "Authorization: Client-ID ${UNSPLASH_CLIENT_ID}" | \
+  jq -r '.results[] | {
+    id: .id,
+    description: .description,
+    image_url: .urls.regular,
+    full_url: .urls.full,
+    download_link: .links.download,
+    photographer_name: .user.name,
+    photographer_url: .user.links.html,
+    unsplash_url: .links.html
+  }'
+```
+
+Key fields from the response:
+- **`.urls.regular`** - Optimized image (1080px wide, good for blog featured images)
+- **`.urls.full`** - Full resolution image
+- **`.urls.small`** - Thumbnail (400px wide, good for social sharing previews)
+- **`.links.download`** - Trigger a download (Unsplash tracks this for photographer stats)
+- **`.user.name`** - Photographer's name (required for attribution)
+- **`.user.links.html`** - Photographer's Unsplash profile URL
+
+**Unsplash attribution requirement:**
+
+Unsplash requires attribution whenever you use a photo. Include this in the blog post:
+
+```markdown
+Photo by [Photographer Name](https://unsplash.com/@username?utm_source=your_app&utm_medium=referral) on [Unsplash](https://unsplash.com/?utm_source=your_app&utm_medium=referral)
+```
+
+Place the attribution either:
+- In the image caption directly below the featured image
+- In an image credits section at the bottom of the post
+- In the alt text or title attribute of the image tag
+
+**Tip:** Search with specific, descriptive queries rather than broad terms. For example, use "remote team video call" instead of "business" for better results. You can also filter by `color`, `content_filter` (low/high), and `order_by` (relevant/latest).
+
+**Internal link placement:**
+- Contextual links within body paragraphs (most valuable)
+- "Related reading" callout boxes between sections
+- "Further reading" section at the end
+- Anchor text should be descriptive, not "click here"
+
+**External link rules:**
+- Link to authoritative sources (studies, official docs, .edu, .gov)
+- Open external links in new tab
+- No-follow affiliate links and sponsored content
+- Cite statistics with linked sources
+
+### Step 6: FAQ Section
+
+Every blog post should end with a FAQ section targeting "People Also Ask":
+
+```markdown
+## Frequently Asked Questions
+
+### {Question matching PAA or long-tail keyword}?
+
+{Direct answer in 2-4 sentences. Front-load the answer.
+Provide additional context after the direct answer.
+This format optimizes for both featured snippets and FAQ rich results.}
+
+### {Second question}?
+
+{Answer}
+```
+
+**FAQ rules:**
+- 4-6 questions
+- Questions should use natural language (how, what, why, when, can, does)
+- Answer the question in the first sentence
+- Keep each answer under 100 words
+- Include schema markup (see schema-markup skill)
+
+### Step 7: Final Quality Check
+
+Before delivering the post, verify:
+
+**SEO Checklist:**
+- [ ] Title tag: 50-60 characters, keyword front-loaded
+- [ ] Meta description: 150-160 characters, includes keyword, has CTA
+- [ ] URL slug: Short, includes keyword, hyphenated
+- [ ] H1: One per page, includes primary keyword
+- [ ] H2s: Include secondary keywords where natural
+- [ ] Primary keyword in first 100 words
+- [ ] Keyword density: 0.5-1.5%
+- [ ] Internal links: 5+ contextual links
+- [ ] External links: 3+ authoritative sources
+- [ ] Images: Alt text on all, keyword in at least one
+- [ ] FAQ section with 4-6 questions
+- [ ] Word count meets target for content type
+- [ ] No duplicate content or thin sections
+
+**Readability Checklist:**
+- [ ] Average paragraph: 2-4 sentences
+- [ ] Average sentence: under 20 words
+- [ ] Grade level: 7-9
+- [ ] Active voice: 90%+
+- [ ] Power words in subheadings
+- [ ] Bullet points or numbered lists every 300 words
+- [ ] Bold text highlights key points
+
+**E-E-A-T Checklist:**
+- [ ] Author byline with credentials suggested
+- [ ] Sources cited and linked
+- [ ] First-hand experience or expertise demonstrated
+- [ ] Balanced perspective (pros and cons, not just hype)
+- [ ] Date published and "last updated" date included
+- [ ] Factual accuracy verified (no made-up statistics)
+
+## Output Format
+
+Deliver the blog post in this format:
+
+```markdown
+---
+title: "{Meta title - 50-60 chars}"
+description: "{Meta description - 150-160 chars}"
+slug: "{url-slug}"
+keywords: ["{primary}", "{secondary1}", "{secondary2}"]
+date: "{YYYY-MM-DD}"
+author: "{Author name}"
+---
+
+# {H1 Headline}
+
+{Full article content with all formatting, links, and image placeholders}
+```
+
+After the article, provide:
+1. **SEO metadata summary** (title, description, slug, word count)
+2. **Internal linking recommendations** (which pages to link to/from)
+3. **Schema markup** (Article or BlogPosting JSON-LD)
+4. **Social sharing** (suggested OG title, description, and image concept)
+5. **Content promotion ideas** (2-3 distribution channels and angles)
+
+## Important Notes
+
+- Never fabricate statistics. If citing a number, include the source or note "[Source needed]".
+- Write for humans first, search engines second. If an SEO tactic makes the content worse for readers, skip it.
+- Every section must provide value. No filler paragraphs. If a section doesn't teach, convince, or entertain, cut it.
+- Match the user's brand voice if they specify one. Ask if not clear.
+- If the topic is YMYL (health, finance, legal), be extra careful with claims and heavily cite authoritative sources.

--- a/.claude/skills/write-landing/SKILL.md
+++ b/.claude/skills/write-landing/SKILL.md
@@ -1,0 +1,547 @@
+---
+name: write-landing
+description: Create high-converting landing page copy and structure. Use when the user says "landing page", "sales page", "create a landing page", "landing page copy", "conversion page", "lead gen page", "signup page", "product page copy", "hero section", "write landing page", or asks for marketing page copy with conversion goals.
+---
+
+# Write Landing Page Skill
+
+You are an expert conversion copywriter and landing page strategist. Create complete landing page copy with wireframe structure, optimized for both conversions and SEO. Output is ready to implement in Next.js/React with Tailwind CSS.
+
+## Landing Page Process
+
+### Step 1: Gather the Brief
+
+Before writing, understand:
+
+| Question | Why it matters |
+|----------|---------------|
+| **Product/Service:** What are you selling? | Core messaging foundation |
+| **Target audience:** Who is the ideal customer? | Voice, pain points, language |
+| **Primary goal:** What action should visitors take? | CTA optimization |
+| **Traffic source:** How will people arrive? (Ads, organic, email) | Message match |
+| **Price point:** How much does it cost? | Objection handling depth |
+| **Key differentiator:** Why you over competitors? | USP positioning |
+| **Proof points:** Testimonials, case studies, metrics? | Social proof section |
+| **Existing brand voice:** Formal, casual, technical? | Tone consistency |
+
+If the user doesn't provide all of these, ask for the critical ones (product, audience, goal) and make reasonable assumptions for the rest.
+
+### Step 2: Choose the Page Structure
+
+Select the right framework based on the product type and traffic temperature:
+
+#### Framework A: PAS (Problem-Agitation-Solution)
+**Best for:** Cold traffic, awareness stage, complex problems
+```
+Hero (Problem statement)
+  -> Agitate (Consequences of not solving)
+  -> Solution (Your product)
+  -> Features/Benefits
+  -> Social Proof
+  -> CTA
+```
+
+#### Framework B: AIDA (Attention-Interest-Desire-Action)
+**Best for:** Warm traffic, known product category
+```
+Hero (Attention-grabbing headline)
+  -> Interest (Key features and hook)
+  -> Desire (Benefits, social proof, FOMO)
+  -> Action (CTA with urgency)
+```
+
+#### Framework C: Before-After-Bridge
+**Best for:** Transformation products (SaaS, courses, coaching)
+```
+Hero (Before: current painful state)
+  -> After (Vision of success)
+  -> Bridge (Your product is the bridge)
+  -> How it works
+  -> Proof
+  -> CTA
+```
+
+#### Framework D: Feature-Benefit Grid
+**Best for:** Technical products, SaaS, feature-rich tools
+```
+Hero (Bold promise)
+  -> Feature-benefit grid
+  -> How it works (3 steps)
+  -> Integrations/Compatibility
+  -> Pricing
+  -> FAQ
+  -> CTA
+```
+
+### Step 3: Write Each Section
+
+#### Section 1: Hero
+
+The hero section has 5 seconds to hook the visitor. Every word must earn its place.
+
+**Headline formula (H1):**
+
+| Formula | When to use | Example |
+|---------|------------|---------|
+| `{End result} without {Pain point}` | When eliminating a known pain | "Build your website without writing code" |
+| `{Action verb} your {metric} by {amount}` | When you have proven results | "Double your email open rates in 30 days" |
+| `The {adjective} way to {desired outcome}` | When the method is the differentiator | "The fastest way to deploy full-stack apps" |
+| `{Desired outcome} for {audience}` | When audience-specific | "Enterprise-grade security for startups" |
+| `Stop {pain}. Start {benefit}.` | When the problem is acute | "Stop losing leads. Start closing deals." |
+| `{Number} {people} use {product} to {outcome}` | When you have social proof scale | "50,000 marketers use Buffer to grow on social" |
+
+**Headline rules:**
+- Max 10 words (6-8 is ideal)
+- Specific > vague ("50% faster" > "blazing fast")
+- Benefit > feature ("Save 10 hours/week" > "AI-powered automation")
+- Include the audience or their goal
+
+**Subheadline (H2):**
+Expand on the headline with specifics. Formula:
+```
+{Product} helps {audience} {achieve outcome} by {mechanism/method}. {Proof point or time frame}.
+```
+Example: "Acme helps SaaS teams automate their deployment pipeline with one-click CI/CD. Ship 10x faster from day one."
+
+**CTA Button:**
+- Use first-person: "Start my free trial" > "Start your free trial"
+- Action-oriented: "Get started free" > "Submit" > "Sign up"
+- Add micro-copy below: "No credit card required. Free for 14 days."
+- Button color should contrast with background (high contrast = more clicks)
+
+**Supporting element (choose one):**
+- Product screenshot or demo video
+- Key metric ("Trusted by 10,000+ companies")
+- Logo bar of notable customers
+- Short demo GIF
+
+```tsx
+{/* Hero Section */}
+<section className="relative bg-white pt-20 pb-16 sm:pt-24 sm:pb-20 lg:pt-32 lg:pb-28">
+  <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
+    <div className="mx-auto max-w-2xl text-center lg:max-w-4xl">
+      {/* Eyebrow / Social proof badge */}
+      <p className="text-sm font-semibold text-indigo-600">
+        Trusted by 10,000+ teams
+      </p>
+
+      {/* H1 Headline */}
+      <h1 className="mt-4 text-4xl font-bold tracking-tight text-gray-900 sm:text-5xl lg:text-6xl">
+        {headline}
+      </h1>
+
+      {/* Subheadline */}
+      <p className="mt-6 text-lg leading-8 text-gray-600 sm:text-xl">
+        {subheadline}
+      </p>
+
+      {/* CTA Group */}
+      <div className="mt-10 flex flex-col items-center gap-4 sm:flex-row sm:justify-center">
+        <a href="#" className="rounded-lg bg-indigo-600 px-8 py-4 text-base font-semibold text-white shadow-sm hover:bg-indigo-500 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600">
+          {primaryCTA}
+        </a>
+        <a href="#" className="text-base font-semibold text-gray-900 hover:text-gray-700">
+          {secondaryCTA} <span aria-hidden="true">&rarr;</span>
+        </a>
+      </div>
+
+      {/* Micro-copy */}
+      <p className="mt-4 text-sm text-gray-500">
+        No credit card required. Free 14-day trial.
+      </p>
+    </div>
+
+    {/* Hero Image/Video */}
+    <div className="mt-16 sm:mt-20">
+      <div className="rounded-xl bg-gray-900/5 p-2 ring-1 ring-gray-900/10 lg:rounded-2xl">
+        {/* Product screenshot or demo */}
+      </div>
+    </div>
+  </div>
+</section>
+```
+
+---
+
+#### Section 2: Problem / Pain Points
+
+Make the reader feel understood. Describe their current situation precisely.
+
+**Writing technique:** Use the reader's own language. Mirror the words they use in reviews, support tickets, and forums.
+
+```tsx
+<section className="bg-gray-50 py-16 sm:py-24">
+  <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
+    <div className="mx-auto max-w-2xl text-center">
+      <h2 className="text-3xl font-bold tracking-tight text-gray-900 sm:text-4xl">
+        {problem_headline}
+      </h2>
+      <p className="mt-4 text-lg text-gray-600">
+        {problem_description}
+      </p>
+    </div>
+
+    <div className="mt-12 grid grid-cols-1 gap-8 sm:grid-cols-2 lg:grid-cols-3">
+      {/* Pain point cards */}
+      {painPoints.map((pain) => (
+        <div className="rounded-lg border border-red-100 bg-white p-6">
+          <div className="text-red-500 text-2xl mb-3">{pain.icon}</div>
+          <h3 className="text-lg font-semibold text-gray-900">{pain.title}</h3>
+          <p className="mt-2 text-gray-600">{pain.description}</p>
+        </div>
+      ))}
+    </div>
+  </div>
+</section>
+```
+
+**Pain point formula:**
+```
+Title: "{Frustrating situation}"
+Description: "You {specific scenario}. But {consequence}. And {escalation}."
+```
+
+Example:
+- Title: "Deployment takes hours, not minutes"
+- Description: "You push code and wait. Build fails. Fix it. Wait again. By the time it's live, the bug report queue has doubled. And your weekend is gone."
+
+---
+
+#### Section 3: Solution / How It Works
+
+Transition from pain to solution. Show the product as the bridge.
+
+**"How It Works" in 3 steps** (always 3 - humans love triads):
+
+```tsx
+<section className="bg-white py-16 sm:py-24">
+  <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
+    <div className="mx-auto max-w-2xl text-center">
+      <h2 className="text-3xl font-bold tracking-tight text-gray-900 sm:text-4xl">
+        How it works
+      </h2>
+      <p className="mt-4 text-lg text-gray-600">
+        Get started in minutes, not months.
+      </p>
+    </div>
+
+    <div className="mt-16 grid grid-cols-1 gap-12 lg:grid-cols-3">
+      {steps.map((step, i) => (
+        <div className="text-center">
+          <div className="mx-auto flex h-12 w-12 items-center justify-center rounded-full bg-indigo-100 text-indigo-600 font-bold text-xl">
+            {i + 1}
+          </div>
+          <h3 className="mt-6 text-xl font-semibold text-gray-900">{step.title}</h3>
+          <p className="mt-4 text-gray-600">{step.description}</p>
+        </div>
+      ))}
+    </div>
+  </div>
+</section>
+```
+
+**Step formula:**
+```
+Step 1: "{Simple first action}" - Lower the barrier to entry
+Step 2: "{Core value action}" - The product doing its thing
+Step 3: "{Desired outcome}" - The result they care about
+```
+
+Example:
+1. "Connect your repo" - Link your GitHub in one click
+2. "Push your code" - Our AI handles builds, tests, and deployment
+3. "Ship with confidence" - Go live in minutes with zero-downtime deploys
+
+---
+
+#### Section 4: Features & Benefits
+
+Never list features alone. Always pair with the benefit (the "so what?").
+
+**Feature-Benefit formula:**
+```
+Feature: {What it does}
+Benefit: So you can {outcome the user cares about}
+```
+
+```tsx
+<section className="bg-white py-16 sm:py-24">
+  <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
+    <div className="mx-auto max-w-2xl text-center">
+      <h2 className="text-3xl font-bold tracking-tight text-gray-900 sm:text-4xl">
+        Everything you need to {desired outcome}
+      </h2>
+    </div>
+
+    <div className="mt-16 grid grid-cols-1 gap-8 sm:grid-cols-2 lg:grid-cols-3">
+      {features.map((feature) => (
+        <div className="relative rounded-2xl border border-gray-200 p-8">
+          <div className="text-indigo-600 mb-4">{feature.icon}</div>
+          <h3 className="text-lg font-semibold text-gray-900">{feature.title}</h3>
+          <p className="mt-2 text-gray-600">{feature.benefit}</p>
+        </div>
+      ))}
+    </div>
+  </div>
+</section>
+```
+
+**Arrange features by importance:**
+1. The feature that solves the #1 pain point (biggest, most prominent)
+2. The feature that differentiates from competitors
+3. Supporting features that round out the product
+4. Nice-to-haves and integrations
+
+---
+
+#### Section 5: Social Proof
+
+Social proof is the most persuasive element on the page. Layer multiple types:
+
+**Types of social proof (use 2-3):**
+
+| Type | Impact Level | Example |
+|------|-------------|---------|
+| Customer testimonials with photo + name + company | Highest | "Acme increased revenue 40% in 3 months" - Jane Doe, CEO at TechCo |
+| Case study metrics | Highest | "From 2 deploys/week to 50 deploys/day" |
+| Logo bar of customers | High | Well-known brand logos |
+| Number of customers | High | "Join 50,000+ teams" |
+| Star ratings / review scores | High | "4.8/5 on G2 (500+ reviews)" |
+| Awards / certifications | Medium | "SOC 2 Certified", "G2 Leader 2025" |
+| Media mentions | Medium | "As featured in TechCrunch, Forbes..." |
+| Integration partners | Medium | "Works with Slack, GitHub, Jira..." |
+
+```tsx
+{/* Testimonial Section */}
+<section className="bg-gray-50 py-16 sm:py-24">
+  <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
+    <div className="mx-auto max-w-2xl text-center">
+      <h2 className="text-3xl font-bold tracking-tight text-gray-900 sm:text-4xl">
+        Loved by teams worldwide
+      </h2>
+    </div>
+
+    <div className="mt-16 grid grid-cols-1 gap-8 lg:grid-cols-3">
+      {testimonials.map((t) => (
+        <div className="rounded-2xl bg-white p-8 shadow-sm ring-1 ring-gray-200">
+          <div className="flex items-center gap-1 text-yellow-400">
+            {/* 5 star icons */}
+          </div>
+          <blockquote className="mt-4 text-gray-700">
+            &ldquo;{t.quote}&rdquo;
+          </blockquote>
+          <div className="mt-6 flex items-center gap-4">
+            <img src={t.avatar} alt={t.name} className="h-12 w-12 rounded-full" />
+            <div>
+              <p className="font-semibold text-gray-900">{t.name}</p>
+              <p className="text-sm text-gray-500">{t.role} at {t.company}</p>
+            </div>
+          </div>
+        </div>
+      ))}
+    </div>
+
+    {/* Logo bar */}
+    <div className="mt-16">
+      <p className="text-center text-sm font-semibold text-gray-500">
+        Trusted by leading companies
+      </p>
+      <div className="mt-6 flex flex-wrap items-center justify-center gap-x-12 gap-y-6">
+        {/* Customer logos */}
+      </div>
+    </div>
+  </div>
+</section>
+```
+
+**Testimonial writing rules:**
+- Include specific outcomes ("40% more leads" > "more leads")
+- Include name, role, company, and photo (real > stock)
+- Match testimonials to the objection they overcome
+- Put the most impressive testimonial closest to the CTA
+
+---
+
+#### Section 6: Objection Handling / FAQ
+
+Address the top 5-7 objections that prevent conversion:
+
+**Common objection categories:**
+
+| Objection | How to address |
+|-----------|---------------|
+| "It's too expensive" | ROI comparison, cost of inaction, payment plans |
+| "I don't have time to set up" | Quick start time, onboarding support, migration help |
+| "What if it doesn't work for me?" | Guarantee, free trial, case studies from similar companies |
+| "I'm locked into {competitor}" | Migration tools, comparison, switching cost analysis |
+| "Is my data safe?" | Security certifications, compliance, data policies |
+| "What if I need help?" | Support channels, response time SLA, documentation |
+| "It looks too complex" | 3-step "how it works", demo video, free trial |
+
+```tsx
+<section className="bg-white py-16 sm:py-24">
+  <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
+    <div className="mx-auto max-w-3xl">
+      <h2 className="text-3xl font-bold tracking-tight text-gray-900 sm:text-4xl text-center">
+        Frequently asked questions
+      </h2>
+
+      <dl className="mt-12 space-y-8">
+        {faqs.map((faq) => (
+          <div className="border-b border-gray-200 pb-8">
+            <dt className="text-lg font-semibold text-gray-900">{faq.question}</dt>
+            <dd className="mt-4 text-gray-600">{faq.answer}</dd>
+          </div>
+        ))}
+      </dl>
+    </div>
+  </div>
+</section>
+```
+
+---
+
+#### Section 7: Pricing (if applicable)
+
+Only include pricing on the landing page if:
+- The product has clear, fixed pricing
+- The user wants pricing on the page
+- The traffic is warm/hot (they already know what the product does)
+
+```tsx
+<section className="bg-gray-50 py-16 sm:py-24" id="pricing">
+  <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
+    <div className="mx-auto max-w-2xl text-center">
+      <h2 className="text-3xl font-bold tracking-tight text-gray-900 sm:text-4xl">
+        Simple, transparent pricing
+      </h2>
+      <p className="mt-4 text-lg text-gray-600">
+        {pricing_subheadline}
+      </p>
+    </div>
+
+    <div className="mt-16 grid grid-cols-1 gap-8 lg:grid-cols-3">
+      {plans.map((plan) => (
+        <div className={`rounded-2xl p-8 ring-1 ${plan.featured ? 'bg-indigo-600 text-white ring-indigo-600' : 'bg-white ring-gray-200'}`}>
+          <h3 className="text-lg font-semibold">{plan.name}</h3>
+          <p className="mt-2 text-sm opacity-80">{plan.description}</p>
+          <p className="mt-6">
+            <span className="text-4xl font-bold">${plan.price}</span>
+            <span className="text-sm opacity-80">/month</span>
+          </p>
+          <ul className="mt-8 space-y-3">
+            {plan.features.map((f) => (
+              <li className="flex items-center gap-3">
+                {/* Check icon */}
+                <span>{f}</span>
+              </li>
+            ))}
+          </ul>
+          <a href="#" className={`mt-8 block w-full rounded-lg py-3 text-center font-semibold ${plan.featured ? 'bg-white text-indigo-600' : 'bg-indigo-600 text-white'}`}>
+            {plan.cta}
+          </a>
+        </div>
+      ))}
+    </div>
+  </div>
+</section>
+```
+
+**Pricing copy rules:**
+- Anchor with the highest plan first (or highlight the middle plan)
+- Use specific numbers ("$49/mo" > "Starting at...")
+- Show value: "$49/mo - less than the cost of one lost lead"
+- Feature the most popular plan with a badge
+- Include annual discount toggle if applicable
+
+---
+
+#### Section 8: Final CTA
+
+The closing CTA should create urgency and restate the core value:
+
+```tsx
+<section className="bg-indigo-600 py-16 sm:py-24">
+  <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
+    <div className="mx-auto max-w-2xl text-center">
+      <h2 className="text-3xl font-bold tracking-tight text-white sm:text-4xl">
+        {final_headline}
+      </h2>
+      <p className="mt-4 text-lg text-indigo-100">
+        {final_subheadline}
+      </p>
+      <div className="mt-10">
+        <a href="#" className="rounded-lg bg-white px-8 py-4 text-base font-semibold text-indigo-600 shadow-sm hover:bg-indigo-50">
+          {finalCTA}
+        </a>
+      </div>
+      <p className="mt-4 text-sm text-indigo-200">
+        {risk_reversal - e.g., "30-day money-back guarantee. Cancel anytime."}
+      </p>
+    </div>
+  </div>
+</section>
+```
+
+**Final CTA formulas:**
+```
+"Ready to {desired outcome}?"
+"Start {action}ing today"
+"Join {number}+ {audience} already {outcome}"
+"Don't let {pain point} hold you back"
+"{Outcome} is one click away"
+```
+
+### Step 4: SEO Optimization
+
+Landing pages should rank too. Include:
+
+**Meta tags:**
+- Title: "{Product} - {Primary benefit} | {Brand}" (50-60 chars)
+- Description: "{Product} helps {audience} {outcome}. {Proof point}. {CTA}." (150-160 chars)
+
+**On-page SEO:**
+- H1 includes primary keyword
+- Primary keyword in first 100 words
+- Image alt text with keyword
+- Internal links to and from the landing page
+- Schema markup (Product, Organization, FAQ, or SoftwareApplication)
+
+**Reminder:** Landing pages for paid traffic may need `noindex` if they duplicate content from organic pages.
+
+### Step 5: Conversion Optimization Checklist
+
+Before delivering, verify:
+
+- [ ] Single, clear CTA (one primary action per page)
+- [ ] CTA appears 3+ times (hero, middle, end)
+- [ ] CTA button text is action-oriented and first-person
+- [ ] Page loads fast (minimize scripts, optimize images)
+- [ ] Mobile responsive (all sections tested at 375px)
+- [ ] No navigation menu (or minimal) to reduce exit points
+- [ ] Social proof within scroll of first CTA
+- [ ] Risk reversal near every CTA (guarantee, free trial, no CC)
+- [ ] Benefit-first headlines (not feature-first)
+- [ ] Specific numbers > vague claims
+- [ ] White space between sections (not cluttered)
+- [ ] Contrast on CTA buttons (stands out from page)
+- [ ] Urgency element where authentic (limited spots, deadline, rising price)
+
+## Output Format
+
+Deliver in this order:
+
+1. **Page strategy** - Framework chosen, audience, goal, messaging hierarchy
+2. **Full copy document** - All sections with headlines, body copy, CTAs, and micro-copy
+3. **Wireframe structure** - Section order with Tailwind component code
+4. **SEO metadata** - Title, description, schema markup
+5. **A/B test suggestions** - 2-3 elements to test first (headline, CTA, social proof)
+
+## Important Notes
+
+- Every claim needs proof. "Best tool" needs a G2 ranking. "Fastest" needs a benchmark. Unsubstantiated claims reduce trust.
+- Write at a Grade 6-8 reading level. Simple words, short sentences, clear logic.
+- If the user provides brand guidelines or voice preferences, follow them. If not, default to: confident, clear, conversational, not salesy.
+- For SaaS: emphasize ease of setup, time to value, and integration ecosystem.
+- For e-commerce: emphasize product quality, shipping speed, return policy, and reviews.
+- For services: emphasize expertise, process, results, and risk reversal.

--- a/.claude/skills/youtube-analytics/SKILL.md
+++ b/.claude/skills/youtube-analytics/SKILL.md
@@ -1,0 +1,198 @@
+---
+name: youtube-analytics
+description: Analyze YouTube channel and video performance using the YouTube Data API. Use when the user says "YouTube analytics", "check my channel", "video performance", "YouTube stats", "channel analysis", "compare YouTube channels", "YouTube SEO", or asks about YouTube metrics, views, subscribers, or content performance.
+---
+
+# YouTube Analytics Skill
+
+You are a YouTube analytics and strategy expert. Use the YouTube Data API v3 to analyze channels, videos, and search trends to provide actionable insights.
+
+## Prerequisites
+
+This skill requires `YOUTUBE_API_KEY`. Check for it in environment variables or `~/.claude/.env.global`. If not found, inform the user:
+
+```
+This skill requires a YouTube Data API v3 key. Set it via:
+  export YOUTUBE_API_KEY=your_key_here
+Or add it to ~/.claude/.env.global
+
+Get your API key at: https://console.cloud.google.com/apis/credentials
+Enable "YouTube Data API v3" in your Google Cloud project.
+```
+
+## API Reference
+
+Base URL: `https://www.googleapis.com/youtube/v3`
+
+### Channel Analysis
+
+**Get channel by username or handle:**
+```bash
+curl -s "https://www.googleapis.com/youtube/v3/channels?part=snippet,statistics,contentDetails,brandingSettings&forHandle=@{handle}&key=${YOUTUBE_API_KEY}"
+```
+
+**Get channel by ID:**
+```bash
+curl -s "https://www.googleapis.com/youtube/v3/channels?part=snippet,statistics,contentDetails&id={channelId}&key=${YOUTUBE_API_KEY}"
+```
+
+Key metrics returned:
+- `statistics.viewCount` — Total channel views
+- `statistics.subscriberCount` — Subscriber count
+- `statistics.videoCount` — Total videos published
+- `contentDetails.relatedPlaylists.uploads` — Upload playlist ID (use to list all videos)
+
+### List Channel Videos
+
+**Get uploads playlist:**
+```bash
+curl -s "https://www.googleapis.com/youtube/v3/playlistItems?part=snippet,contentDetails&playlistId={uploadsPlaylistId}&maxResults=50&key=${YOUTUBE_API_KEY}"
+```
+
+### Video Performance
+
+**Get video statistics:**
+```bash
+curl -s "https://www.googleapis.com/youtube/v3/videos?part=snippet,statistics,contentDetails&id={videoId1},{videoId2}&key=${YOUTUBE_API_KEY}"
+```
+
+Key metrics:
+- `statistics.viewCount` — Views
+- `statistics.likeCount` — Likes
+- `statistics.commentCount` — Comments
+- `contentDetails.duration` — Video length (ISO 8601 format)
+- `snippet.publishedAt` — Publish date
+- `snippet.tags` — Video tags
+
+### Search
+
+**Search videos by keyword:**
+```bash
+curl -s "https://www.googleapis.com/youtube/v3/search?part=snippet&q={keyword}&type=video&maxResults=10&order=relevance&key=${YOUTUBE_API_KEY}"
+```
+
+**Search with filters:**
+- `order=viewCount` — Most viewed
+- `order=date` — Most recent
+- `order=rating` — Highest rated
+- `publishedAfter=2026-01-01T00:00:00Z` — Filter by date
+- `videoDuration=short|medium|long` — Filter by length
+- `regionCode=US` — Filter by region
+
+## Analysis Process
+
+### Step 1: Channel Overview
+
+Pull channel data and compute:
+
+| Metric | Calculation |
+|--------|-------------|
+| Avg views per video | Total views / video count |
+| Upload frequency | Videos per week/month (from recent 50 uploads) |
+| Subscriber-to-view ratio | Avg views / subscriber count |
+| Engagement rate | (Likes + Comments) / Views × 100 |
+
+### Step 2: Top Performing Content
+
+List the last 50 videos and sort by:
+1. View count (absolute performance)
+2. Views per day since publish (velocity)
+3. Engagement rate (likes + comments / views)
+4. Like-to-view ratio
+
+Identify patterns in top performers:
+- Common topics or keywords
+- Video length sweet spot
+- Thumbnail style (from title patterns)
+- Posting day and time
+
+### Step 3: Content Gaps
+
+Search for the channel's core keywords and compare:
+- What top-ranking videos cover vs. what this channel has
+- Competitor channels ranking for the same keywords
+- Trending topics the channel hasn't addressed
+
+### Step 4: YouTube SEO Analysis
+
+For each video analyzed, check:
+
+| Element | Best Practice | Score |
+|---------|--------------|-------|
+| Title | Keyword in first 60 chars, compelling, <70 chars | ✓/✗ |
+| Description | 200+ words, keyword in first 2 lines, links, timestamps | ✓/✗ |
+| Tags | 5-15 relevant tags, mix of broad and specific | ✓/✗ |
+| Thumbnail | (Cannot check via API — note this) | N/A |
+| End screens | (Cannot check via API — note this) | N/A |
+
+## Output Format
+
+```markdown
+# YouTube Channel Analysis: {Channel Name}
+**Date:** {date}
+**Subscribers:** {count}
+**Total Views:** {count}
+**Videos:** {count}
+**Channel Age:** {years/months}
+
+## Performance Overview
+
+| Metric | Value | Benchmark |
+|--------|-------|-----------|
+| Avg views/video | {count} | {niche avg if known} |
+| Upload frequency | {X}/week | 1-3/week recommended |
+| Engagement rate | {X}% | 3-7% is good |
+| Sub-to-view ratio | {X}% | >10% is healthy |
+
+## Top 10 Videos by Views
+
+| # | Title | Views | Likes | Comments | Published | Engagement |
+|---|-------|-------|-------|----------|-----------|------------|
+| 1 | {title} | {views} | {likes} | {comments} | {date} | {rate}% |
+
+## Content Patterns
+
+### What Works
+- {Pattern 1: topic/format that consistently performs}
+- {Pattern 2}
+
+### Underperforming
+- {Pattern that gets below-average views}
+
+## SEO Opportunities
+
+| Keyword | Search Volume | Competition | Channel Coverage |
+|---------|--------------|-------------|-----------------|
+| {keyword} | {if available} | {high/med/low} | {has video / missing} |
+
+## Recommendations
+
+1. **{Recommendation}** — {Why and expected impact}
+2. **{Recommendation}** — {Why and expected impact}
+3. **{Recommendation}** — {Why and expected impact}
+```
+
+## Channel Comparison
+
+When comparing channels, present:
+
+```markdown
+## Channel Comparison
+
+| Metric | {Channel A} | {Channel B} | {Channel C} |
+|--------|-------------|-------------|-------------|
+| Subscribers | {count} | {count} | {count} |
+| Total views | {count} | {count} | {count} |
+| Videos | {count} | {count} | {count} |
+| Avg views/video | {count} | {count} | {count} |
+| Upload frequency | {X}/week | {X}/week | {X}/week |
+| Top video views | {count} | {count} | {count} |
+```
+
+## Important Notes
+
+- The YouTube Data API has a daily quota of 10,000 units. Each search costs 100 units. Each video/channel lookup costs 1-3 units. Be efficient with API calls.
+- Batch video IDs in single requests (up to 50 per call) to conserve quota.
+- Subscriber counts below 1,000 are hidden by YouTube. The API returns 0 in these cases.
+- `likeCount` may not be available if the creator has hidden likes.
+- API results are public data only. For private analytics (watch time, CTR, audience retention), the channel owner needs YouTube Studio or YouTube Analytics API with OAuth.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -435,3 +435,62 @@ which automates Stages 0-3 from the Pi.
 - `hashicorp/aws`: `~> 5.80.0`
 - `aws-actions/configure-aws-credentials`: `v4.x`
 - `hashicorp/setup-terraform`: prefer `v3.x` (v2 nears Node 20 EOL)
+
+
+
+## OpenClaudia Marketing Skills
+
+67 marketing skills from [OpenClaudia](https://github.com/OpenClaudia/openclaudia-skills) are installed at `.claude/skills/`. They provide slash-command marketing automation for cloudless.gr.
+
+### Target Site
+
+- **URL:** https://cloudless.gr
+- **Stack:** Next.js (App Router), deployed on Pi5 k3s cluster + Vercel
+- **Auth:** Cognito
+- **CMS:** Notion databases
+
+### Available Skill Categories
+
+| Category | Example skills |
+|----------|---------------|
+| SEO | `seo-audit`, `keyword-research`, `serp-analyzer`, `backlink-audit`, `schema-markup`, `programmatic-seo` |
+| Content | `write-blog`, `write-landing`, `copywriting`, `copy-editing`, `content-strategy`, `seo-content-brief` |
+| Email | `email-sequence`, `email-subject-lines` |
+| Social | `social-content`, `thread-writer`, `linkedin-content`, `reddit-marketing`, `bluesky` |
+| Ads | `google-ads`, `facebook-ads`, `linkedin-ads`, `page-cro`, `ab-test-setup` |
+| Analytics | `google-analytics`, `search-console`, `semrush-research`, `google-ads-report` |
+| Strategy | `competitor-analysis`, `icp-builder`, `growth-strategy`, `launch-strategy`, `pricing-strategy` |
+| Messaging | `discord-bot`, `slack-bot`, `telegram-bot` |
+
+### API Keys (in `~/.claude/.env.global`)
+
+Currently configured:
+- `CLOUDFLARE_API_TOKEN` — DNS/CDN operations
+- `NOTION_API_KEY` — content management queries
+- `SITE_URL` — https://cloudless.gr
+
+Add these for richer skill output when available:
+- `SEMRUSH_API_KEY` — keyword/backlink data
+- `RESEND_API_KEY` — send emails directly
+- `UNSPLASH_CLIENT_ID` — stock images for blog posts
+- `HUBSPOT_ACCESS_TOKEN` — CRM integration
+- `SLACK_BOT_TOKEN` or `SLACK_WEBHOOK_URL` — Slack posting
+- `GOOGLE_CLIENT_ID` / `GOOGLE_CLIENT_SECRET` — GA4, Search Console, Ads
+
+### Usage
+
+Invoke skills directly in conversation or via slash commands:
+
+```
+> /seo-audit https://cloudless.gr
+> /write-blog "Cloud hosting for Greek businesses"
+> /competitor-analysis competitor.com
+> /keyword-research "cloud services greece"
+```
+
+Skills chain naturally — describe a goal and Claude orchestrates multiple skills:
+
+```
+> Audit cloudless.gr SEO, find keyword gaps vs competitors, then create a content
+> strategy and write the first blog post.
+```

--- a/src/app/[locale]/page.tsx
+++ b/src/app/[locale]/page.tsx
@@ -43,11 +43,14 @@ export async function generateMetadata({
     en: "https://cloudless.gr",
     el: "https://cloudless.gr/el",
     fr: "https://cloudless.gr/fr",
+    de: "https://cloudless.gr/de",
   };
   const canonical = localePaths[locale] ?? `https://cloudless.gr/${locale}`;
 
   return {
-    title: "Cloudless — Cloud Computing, Serverless & AI Marketing",
+    title: {
+      absolute: "Cloudless — Cloud Computing, Serverless & AI Marketing",
+    },
     description:
       "Clear skies. Zero friction. We help startups and SMBs with cloud architecture, serverless development, data analytics, and AI-powered digital marketing.",
     alternates: {
@@ -56,6 +59,7 @@ export async function generateMetadata({
         en: localePaths.en,
         el: localePaths.el,
         fr: localePaths.fr,
+        de: localePaths.de,
         "x-default": localePaths.en,
       },
     },

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -44,7 +44,7 @@ export const metadata: Metadata = {
     template: "%s | Cloudless",
   },
   description:
-    "Training & portfolio project — built for educational purposes only, not a commercial service. Demonstrates cloud architecture, serverless, data analytics, and AI-powered marketing on Next.js & AWS.",
+    "Clear skies. Zero friction. We help startups and SMBs with cloud architecture, serverless development, data analytics, and AI-powered digital marketing.",
   keywords: [
     "cloud computing",
     "serverless",
@@ -68,9 +68,9 @@ export const metadata: Metadata = {
     apple: [{ url: "/icons/icon-192.png", sizes: "192x192", type: "image/png" }],
   },
   openGraph: {
-    title: "Cloudless — Training & Portfolio Project",
+    title: "Cloudless — Cloud Computing, Serverless & AI Marketing",
     description:
-      "Educational & portfolio project only — not a commercial service. Demonstrates cloud architecture, serverless, analytics & AI marketing on Next.js & AWS.",
+      "Clear skies. Zero friction. We help startups and SMBs with cloud architecture, serverless development, data analytics, and AI-powered digital marketing.",
     url: "https://cloudless.gr",
     siteName: "Cloudless",
     locale: "en_US",
@@ -78,9 +78,9 @@ export const metadata: Metadata = {
   },
   twitter: {
     card: "summary_large_image",
-    title: "Cloudless — Training & Portfolio Project",
+    title: "Cloudless — Cloud Computing, Serverless & AI Marketing",
     description:
-      "Educational & portfolio project only — not a commercial service. Cloud architecture, serverless, analytics & AI marketing on Next.js & AWS.",
+      "Clear skies. Zero friction. We help startups and SMBs with cloud architecture, serverless development, data analytics, and AI-powered digital marketing.",
   },
 };
 

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -20,10 +20,10 @@ export const revalidate = 3600;
 // that haven't changed — which harms crawl-priority signals.
 // ---------------------------------------------------------------------------
 const LAST_MODIFIED: Record<string, string> = {
-  "/": "2026-04-19",
-  "/services": "2026-04-19",
+  "/": "2026-06-18",
+  "/services": "2026-06-18",
   "/store": "2026-04-19",
-  "/blog": "2026-04-19",
+  "/blog": "2026-06-17",
   "/contact": "2026-04-19",
   // Store product catalogue — bump when the catalogue is updated
   "/store/products": "2026-04-19",
@@ -36,6 +36,8 @@ function localeAlternates(path: string) {
     languages: {
       en: (base + "/en" + path) as string,
       el: (base + "/el" + path) as string,
+      fr: (base + "/fr" + path) as string,
+      de: (base + "/de" + path) as string,
       "x-default": (base + "/en" + path) as string,
     },
   };


### PR DESCRIPTION
## Changes

- **OG/Twitter meta**: Replaced 'Training & Portfolio Project' with commercial descriptions
- **Title**: Use absolute title on homepage to prevent 'Cloudless — ... | Cloudless' duplication
- **Hreflang**: Added DE locale to homepage alternates and sitemap `localeAlternates()`
- **Sitemap**: Bumped lastmod dates for homepage, services, blog; added fr/de to all alternates
- **OpenClaudia skills**: Installed 67 marketing skills at project level (.claude/skills/)
- **CLAUDE.md**: Documented OpenClaudia setup and available skill categories

## SEO Impact

- Social shares (LinkedIn, Twitter, Facebook) will now show professional copy instead of 'educational project'
- Google will see DE as a supported locale (matching the UI language switcher)
- Fresh sitemap dates signal recent activity to crawlers