### PR TITLE
chore(format): prettier --write on 22 src files

### DIFF
--- a/src/app/[locale]/accessibility/page.tsx
+++ b/src/app/[locale]/accessibility/page.tsx
@@ -6,10 +6,19 @@ import { getBreadcrumbSchema } from "@/lib/structured-data";
 
 export const metadata: Metadata = {
   title: "Accessibility Statement",
-  description: "Cloudless.gr accessibility statement — WCAG 2.1 AA compliance and contact for assistance.",
+  description:
+    "Cloudless.gr accessibility statement — WCAG 2.1 AA compliance and contact for assistance.",
 };
 
-function Section({ id, title, children }: { id: string; title: string; children: React.ReactNode }) {
+function Section({
+  id,
+  title,
+  children,
+}: {
+  id: string;
+  title: string;
+  children: React.ReactNode;
+}) {
   return (
     <section id={id} className="scroll-mt-24">
       <h2 className="font-heading mb-4 text-xl font-bold text-white">{title}</h2>
@@ -21,19 +30,26 @@ function Section({ id, title, children }: { id: string; title: string; children:
 export default function AccessibilityPage() {
   return (
     <>
-      <JsonLd data={getBreadcrumbSchema([
-        { name: "Home", url: "https://cloudless.gr" },
-        { name: "Accessibility Statement", url: "https://cloudless.gr/accessibility" },
-      ])} />
+      <JsonLd
+        data={getBreadcrumbSchema([
+          { name: "Home", url: "https://cloudless.gr" },
+          { name: "Accessibility Statement", url: "https://cloudless.gr/accessibility" },
+        ])}
+      />
       <div className="bg-void min-h-screen">
         <div className="mx-auto max-w-3xl px-6 py-20 lg:py-28">
           <ScrollReveal>
-            <p className="text-neon-cyan/70 mb-4 font-mono text-xs tracking-widest">LEGAL DOCUMENT</p>
-            <h1 className="font-heading mb-4 text-3xl font-bold text-white lg:text-4xl">Accessibility Statement</h1>
+            <p className="text-neon-cyan/70 mb-4 font-mono text-xs tracking-widest">
+              LEGAL DOCUMENT
+            </p>
+            <h1 className="font-heading mb-4 text-3xl font-bold text-white lg:text-4xl">
+              Accessibility Statement
+            </h1>
             <p className="mb-2 font-mono text-xs text-slate-500">Last updated: June 2026</p>
             <p className="mb-12 text-sm leading-relaxed text-slate-400">
               Cloudless is committed to ensuring digital accessibility for people with disabilities.
-              We continually improve the user experience for everyone and apply relevant accessibility standards.
+              We continually improve the user experience for everyone and apply relevant
+              accessibility standards.
             </p>
           </ScrollReveal>
 
@@ -41,11 +57,16 @@ export default function AccessibilityPage() {
             <ScrollReveal>
               <Section id="conformance" title="Conformance Status">
                 <p>
-                  Cloudless.gr aims to conform to the <strong className="text-white">Web Content Accessibility Guidelines (WCAG) 2.1 Level AA</strong> as
-                  required by the EU Web Accessibility Directive (Directive 2016/2102) and the European Accessibility Act (Directive 2019/882).
+                  Cloudless.gr aims to conform to the{" "}
+                  <strong className="text-white">
+                    Web Content Accessibility Guidelines (WCAG) 2.1 Level AA
+                  </strong>{" "}
+                  as required by the EU Web Accessibility Directive (Directive 2016/2102) and the
+                  European Accessibility Act (Directive 2019/882).
                 </p>
                 <p>
-                  We are partially conformant — most content meets WCAG 2.1 AA. Known limitations are listed below.
+                  We are partially conformant — most content meets WCAG 2.1 AA. Known limitations
+                  are listed below.
                 </p>
               </Section>
             </ScrollReveal>
@@ -61,9 +82,18 @@ export default function AccessibilityPage() {
                   <li>Minimum 44×44px touch targets for all interactive elements</li>
                   <li>Skip-to-content link on every page</li>
                   <li>Focus trap and Escape-key handling in all modal dialogs</li>
-                  <li>Reduced-motion support via <code className="font-mono text-xs">prefers-reduced-motion</code></li>
-                  <li>All images have descriptive <code className="font-mono text-xs">alt</code> attributes</li>
-                  <li>Forms include visible labels and <code className="font-mono text-xs">autocomplete</code> attributes</li>
+                  <li>
+                    Reduced-motion support via{" "}
+                    <code className="font-mono text-xs">prefers-reduced-motion</code>
+                  </li>
+                  <li>
+                    All images have descriptive <code className="font-mono text-xs">alt</code>{" "}
+                    attributes
+                  </li>
+                  <li>
+                    Forms include visible labels and{" "}
+                    <code className="font-mono text-xs">autocomplete</code> attributes
+                  </li>
                 </ul>
               </Section>
             </ScrollReveal>
@@ -72,8 +102,14 @@ export default function AccessibilityPage() {
               <Section id="limitations" title="Known Limitations">
                 <p>The following known issues are being addressed:</p>
                 <ul className="list-disc space-y-1 pl-5">
-                  <li>Some third-party embedded content (e.g. HubSpot forms) may not fully meet WCAG 2.1 AA — we are working with vendors on remediation</li>
-                  <li>3D particle effects are decorative and hidden from assistive technologies; they respect <code className="font-mono text-xs">prefers-reduced-motion</code></li>
+                  <li>
+                    Some third-party embedded content (e.g. HubSpot forms) may not fully meet WCAG
+                    2.1 AA — we are working with vendors on remediation
+                  </li>
+                  <li>
+                    3D particle effects are decorative and hidden from assistive technologies; they
+                    respect <code className="font-mono text-xs">prefers-reduced-motion</code>
+                  </li>
                 </ul>
               </Section>
             </ScrollReveal>
@@ -84,9 +120,18 @@ export default function AccessibilityPage() {
                   If you experience any accessibility barrier on cloudless.gr, please contact us:
                 </p>
                 <p className="font-mono text-xs">
-                  Email: <a href="mailto:tbaltzakis@cloudless.gr" className="text-neon-cyan hover:underline">tbaltzakis@cloudless.gr</a>
+                  Email:{" "}
+                  <a
+                    href="mailto:tbaltzakis@cloudless.gr"
+                    className="text-neon-cyan hover:underline"
+                  >
+                    tbaltzakis@cloudless.gr
+                  </a>
                 </p>
-                <p>We aim to respond to accessibility feedback within <strong className="text-white">5 business days</strong>.</p>
+                <p>
+                  We aim to respond to accessibility feedback within{" "}
+                  <strong className="text-white">5 business days</strong>.
+                </p>
               </Section>
             </ScrollReveal>
 
@@ -94,24 +139,36 @@ export default function AccessibilityPage() {
               <Section id="enforcement" title="Enforcement">
                 <p>
                   If you are not satisfied with our response, you may contact the{" "}
-                  <a href="https://www.dpa.gr" className="text-neon-cyan hover:underline" target="_blank" rel="noopener noreferrer">
+                  <a
+                    href="https://www.dpa.gr"
+                    className="text-neon-cyan hover:underline"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                  >
                     Hellenic Data Protection Authority (HDPA)
                   </a>{" "}
                   or your national supervisory body.
                 </p>
                 <p>
-                  US users may contact us directly or file a complaint under Section 508 of the Rehabilitation Act where applicable.
+                  US users may contact us directly or file a complaint under Section 508 of the
+                  Rehabilitation Act where applicable.
                 </p>
               </Section>
             </ScrollReveal>
 
             <ScrollReveal>
               <div className="text-sm text-slate-500">
-                <Link href="/privacy" className="text-neon-cyan hover:underline">Privacy Policy</Link>
+                <Link href="/privacy" className="text-neon-cyan hover:underline">
+                  Privacy Policy
+                </Link>
                 {" · "}
-                <Link href="/terms" className="text-neon-cyan hover:underline">Terms of Service</Link>
+                <Link href="/terms" className="text-neon-cyan hover:underline">
+                  Terms of Service
+                </Link>
                 {" · "}
-                <Link href="/cookies" className="text-neon-cyan hover:underline">Cookie Policy</Link>
+                <Link href="/cookies" className="text-neon-cyan hover:underline">
+                  Cookie Policy
+                </Link>
               </div>
             </ScrollReveal>
           </div>

--- a/src/app/[locale]/admin/client-portals/page.tsx
+++ b/src/app/[locale]/admin/client-portals/page.tsx
@@ -1165,7 +1165,7 @@ export default function ClientPortalsPage() {
                       target="_blank"
                       rel="noopener noreferrer"
                       onClick={(e) => e.stopPropagation()}
-                      className="rounded-lg border border-neon-cyan/30 px-3 py-1.5 font-mono text-xs text-neon-cyan transition hover:border-neon-cyan/60 hover:bg-neon-cyan/10"
+                      className="border-neon-cyan/30 text-neon-cyan hover:border-neon-cyan/60 hover:bg-neon-cyan/10 rounded-lg border px-3 py-1.5 font-mono text-xs transition"
                     >
                       Open Portal
                     </a>

--- a/src/app/[locale]/auth/signup/page.tsx
+++ b/src/app/[locale]/auth/signup/page.tsx
@@ -162,7 +162,7 @@ function SignUpForm() {
       });
     }, 1000);
     return () => clearInterval(id);
-  // eslint-disable-next-line react-hooks/exhaustive-deps
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [step, secondsLeft > 0]);
 
   return (
@@ -232,7 +232,10 @@ function SignUpForm() {
                 <span className="text-white">{email}</span>
               </p>
               <div>
-                <label htmlFor="confirm-code" className="mb-2 block font-mono text-sm text-slate-400">
+                <label
+                  htmlFor="confirm-code"
+                  className="mb-2 block font-mono text-sm text-slate-400"
+                >
                   {t("auth.verificationCode", "Verification Code")}
                 </label>
                 <input
@@ -243,7 +246,7 @@ function SignUpForm() {
                   onChange={(e) => setCode(e.target.value)}
                   required
                   autoComplete="one-time-code"
-                  className="bg-void focus:border-neon-cyan/50 w-full rounded-lg border border-slate-700 px-4 py-3 font-mono text-sm text-white tracking-widest transition-all focus:shadow-[0_0_10px_rgba(0,255,245,0.1)] focus:outline-none"
+                  className="bg-void focus:border-neon-cyan/50 w-full rounded-lg border border-slate-700 px-4 py-3 font-mono text-sm tracking-widest text-white transition-all focus:shadow-[0_0_10px_rgba(0,255,245,0.1)] focus:outline-none"
                   placeholder="123456"
                 />
               </div>
@@ -280,8 +283,19 @@ function SignUpForm() {
           ) : step === "done" ? (
             <div className="space-y-5 text-center">
               <div className="bg-neon-green/10 border-neon-green/20 mx-auto flex h-16 w-16 items-center justify-center rounded-full border">
-                <svg className="text-neon-green h-8 w-8" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
-                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M5 13l4 4L19 7" />
+                <svg
+                  className="text-neon-green h-8 w-8"
+                  fill="none"
+                  stroke="currentColor"
+                  viewBox="0 0 24 24"
+                  aria-hidden="true"
+                >
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    strokeWidth={1.5}
+                    d="M5 13l4 4L19 7"
+                  />
                 </svg>
               </div>
               <p className="font-mono text-sm text-slate-300">
@@ -290,7 +304,10 @@ function SignUpForm() {
               <p className="font-mono text-xs text-slate-500">
                 {t("auth.canSignInNow", "You can now sign in with your email and password.")}
               </p>
-              <Link href="/auth/login" className="text-neon-cyan block font-mono text-sm hover:underline">
+              <Link
+                href="/auth/login"
+                className="text-neon-cyan block font-mono text-sm hover:underline"
+              >
                 {t("auth.goToSignIn", "Go to Sign In →")}
               </Link>
             </div>

--- a/src/app/[locale]/campaigns/[slug]/page.tsx
+++ b/src/app/[locale]/campaigns/[slug]/page.tsx
@@ -17,7 +17,7 @@ type PageProps = {
 
 export async function generateStaticParams() {
   return campaigns.flatMap((c) =>
-    (["el", "en"] as const).map((locale) => ({ locale, slug: c.slug })),
+    (["el", "en"] as const).map((locale) => ({ locale, slug: c.slug }))
   );
 }
 

--- a/src/app/[locale]/campaigns/[slug]/thanks/page.tsx
+++ b/src/app/[locale]/campaigns/[slug]/thanks/page.tsx
@@ -58,8 +58,7 @@ const COPY = {
     orderLabel: "Order ID:",
     fitcallH1: "Your fit-call request is in.",
     fitcallSub:
-      "We'll email you 2-3 time slots within the next 4 working hours. " +
-      "No pressure, no pitch.",
+      "We'll email you 2-3 time slots within the next 4 working hours. " + "No pressure, no pitch.",
   },
 } as const satisfies Record<Locale, unknown>;
 

--- a/src/app/[locale]/campaigns/page.tsx
+++ b/src/app/[locale]/campaigns/page.tsx
@@ -16,8 +16,7 @@ type PageProps = {
 
 export const metadata: Metadata = {
   title: "Campaigns — Cloudless",
-  description:
-    "Active offers and time-bound campaigns from Cloudless. Greek SMB focus.",
+  description: "Active offers and time-bound campaigns from Cloudless. Greek SMB focus.",
   robots: { index: false, follow: true },
 };
 
@@ -64,13 +63,9 @@ export default async function CampaignsIndex({ params }: PageProps) {
           {campaigns.map((c) => (
             <li key={c.slug} className="cl-cam-card">
               <div className="cl-cam-card__meta">
-                <time dateTime={c.startsAt}>
-                  {new Date(c.startsAt).toLocaleDateString(locale)}
-                </time>
+                <time dateTime={c.startsAt}>{new Date(c.startsAt).toLocaleDateString(locale)}</time>
                 <span aria-hidden> — </span>
-                <time dateTime={c.endsAt}>
-                  {new Date(c.endsAt).toLocaleDateString(locale)}
-                </time>
+                <time dateTime={c.endsAt}>{new Date(c.endsAt).toLocaleDateString(locale)}</time>
               </div>
               <h2>{c.headline[locale]}</h2>
               <p>{c.subhead[locale]}</p>

--- a/src/app/[locale]/dashboard/services/page.tsx
+++ b/src/app/[locale]/dashboard/services/page.tsx
@@ -98,7 +98,12 @@ export default function ServicesPage() {
         </div>
         {portalStatus?.submittedAt && (
           <p className="mt-3 font-mono text-xs text-slate-500">
-            Enrolled: {new Date(portalStatus.submittedAt).toLocaleDateString("en-IE", { day: "numeric", month: "short", year: "numeric" })}
+            Enrolled:{" "}
+            {new Date(portalStatus.submittedAt).toLocaleDateString("en-IE", {
+              day: "numeric",
+              month: "short",
+              year: "numeric",
+            })}
           </p>
         )}
       </div>
@@ -127,7 +132,7 @@ export default function ServicesPage() {
           </p>
           <Link
             href="/portal/waiting"
-            className="mt-4 inline-block font-mono text-xs text-neon-cyan underline underline-offset-4"
+            className="text-neon-cyan mt-4 inline-block font-mono text-xs underline underline-offset-4"
           >
             View waiting room →
           </Link>
@@ -142,7 +147,7 @@ export default function ServicesPage() {
               <h2 className="font-heading font-semibold text-white">{portalData.label}</h2>
               <a
                 href={`/portal/${portalStatus!.portalToken}`}
-                className="font-mono text-xs text-neon-cyan hover:underline"
+                className="text-neon-cyan font-mono text-xs hover:underline"
               >
                 Open Portal →
               </a>
@@ -152,9 +157,13 @@ export default function ServicesPage() {
             <div className="space-y-2">
               {portalData.steps.map((step) => (
                 <div key={step.id} className="flex items-center gap-3">
-                  <span className={`h-2 w-2 rounded-full ${STEP_STATUS_DOT[step.status] ?? "bg-slate-600"}`} />
+                  <span
+                    className={`h-2 w-2 rounded-full ${STEP_STATUS_DOT[step.status] ?? "bg-slate-600"}`}
+                  />
                   <span className="flex-1 font-mono text-sm text-slate-300">{step.name}</span>
-                  <span className="font-mono text-[10px] text-slate-500 capitalize">{step.status}</span>
+                  <span className="font-mono text-[10px] text-slate-500 capitalize">
+                    {step.status}
+                  </span>
                 </div>
               ))}
             </div>
@@ -165,11 +174,14 @@ export default function ServicesPage() {
                 <div className="h-1.5 overflow-hidden rounded-full bg-slate-800">
                   <div
                     className="from-neon-cyan to-neon-green h-full rounded-full bg-gradient-to-r transition-all"
-                    style={{ width: `${Math.round((portalData.steps.filter(s => s.status === "completed").length / portalData.steps.length) * 100)}%` }}
+                    style={{
+                      width: `${Math.round((portalData.steps.filter((s) => s.status === "completed").length / portalData.steps.length) * 100)}%`,
+                    }}
                   />
                 </div>
                 <p className="mt-1 font-mono text-[10px] text-slate-500">
-                  {portalData.steps.filter(s => s.status === "completed").length}/{portalData.steps.length} steps completed
+                  {portalData.steps.filter((s) => s.status === "completed").length}/
+                  {portalData.steps.length} steps completed
                 </p>
               </div>
             )}
@@ -181,9 +193,14 @@ export default function ServicesPage() {
               <h2 className="font-heading mb-3 font-semibold text-white">Deliverables</h2>
               <div className="space-y-2">
                 {portalData.deliverables.map((d) => (
-                  <div key={d.id} className="flex items-center justify-between rounded-lg border border-slate-800 px-4 py-2">
+                  <div
+                    key={d.id}
+                    className="flex items-center justify-between rounded-lg border border-slate-800 px-4 py-2"
+                  >
                     <span className="font-mono text-sm text-slate-300">{d.title}</span>
-                    <span className="font-mono text-[10px] text-slate-500 capitalize">{d.status.replace("_", " ")}</span>
+                    <span className="font-mono text-[10px] text-slate-500 capitalize">
+                      {d.status.replace("_", " ")}
+                    </span>
                   </div>
                 ))}
               </div>

--- a/src/app/api/analytics/track/route.ts
+++ b/src/app/api/analytics/track/route.ts
@@ -23,7 +23,9 @@ export async function POST(req: NextRequest) {
     try {
       const raw = cookieHeader.match(/cookieConsent=([^;]+)/)?.[1];
       return raw ? JSON.parse(decodeURIComponent(raw)).analytics === true : false;
-    } catch { return false; }
+    } catch {
+      return false;
+    }
   })();
   if (!analyticsConsented) return NextResponse.json({ ok: true }); // silent no-op
 
@@ -41,9 +43,10 @@ export async function POST(req: NextRequest) {
     medium: typeof body.medium === "string" ? body.medium : undefined,
     ip: getClientIp(req),
     user_agent: req.headers.get("user-agent") ?? undefined,
-    properties: typeof body.properties === "object" && body.properties !== null
-      ? body.properties as Record<string, unknown>
-      : undefined,
+    properties:
+      typeof body.properties === "object" && body.properties !== null
+        ? (body.properties as Record<string, unknown>)
+        : undefined,
   });
 
   return NextResponse.json({ ok: true });

--- a/src/app/api/auth/activate/route.ts
+++ b/src/app/api/auth/activate/route.ts
@@ -36,10 +36,7 @@ function verifyOtp(email: string, otp: string, token: string): boolean {
   const secret = process.env.AUTH_SECRET ?? process.env.NEXTAUTH_SECRET ?? "";
   const expected = (
     parseInt(
-      createHmac("sha256", secret)
-        .update(`otp:${email}:${exp}:${nonce}`)
-        .digest("hex")
-        .slice(0, 8),
+      createHmac("sha256", secret).update(`otp:${email}:${exp}:${nonce}`).digest("hex").slice(0, 8),
       16
     ) % 1_000_000
   )
@@ -82,12 +79,10 @@ export async function GET(req: NextRequest) {
     return NextResponse.redirect(`${origin}/en/auth/signup?activated=invalid`);
 
   const userPoolId = process.env.COGNITO_USER_POOL_ID;
-  if (!userPoolId)
-    return NextResponse.redirect(`${origin}/en/auth/signup?activated=error`);
+  if (!userPoolId) return NextResponse.redirect(`${origin}/en/auth/signup?activated=error`);
 
   const ok = await confirmUser(userPoolId, email);
-  if (!ok)
-    return NextResponse.redirect(`${origin}/en/auth/signup?activated=error`);
+  if (!ok) return NextResponse.redirect(`${origin}/en/auth/signup?activated=error`);
 
   return NextResponse.redirect(`${origin}/en/auth/login?activated=1`);
 }
@@ -116,12 +111,10 @@ export async function POST(req: NextRequest) {
     return NextResponse.json({ error: "Invalid or expired code" }, { status: 400 });
 
   const userPoolId = process.env.COGNITO_USER_POOL_ID;
-  if (!userPoolId)
-    return NextResponse.json({ error: "Auth not configured" }, { status: 503 });
+  if (!userPoolId) return NextResponse.json({ error: "Auth not configured" }, { status: 503 });
 
   const ok = await confirmUser(userPoolId, email);
-  if (!ok)
-    return NextResponse.json({ error: "Activation failed" }, { status: 500 });
+  if (!ok) return NextResponse.json({ error: "Activation failed" }, { status: 500 });
 
   return NextResponse.json({ ok: true });
 }

--- a/src/app/api/auth/confirm/route.ts
+++ b/src/app/api/auth/confirm/route.ts
@@ -16,7 +16,9 @@ function secretHash(username: string): string | undefined {
   const secret = process.env.COGNITO_CLIENT_SECRET;
   const clientId = process.env.COGNITO_CLIENT_ID ?? "";
   if (!secret) return undefined;
-  return createHmac("sha256", secret).update(username + clientId).digest("base64");
+  return createHmac("sha256", secret)
+    .update(username + clientId)
+    .digest("base64");
 }
 
 export async function POST(req: NextRequest) {
@@ -53,7 +55,10 @@ export async function POST(req: NextRequest) {
     const name = (err as { name?: string }).name;
     if (name === "CodeMismatchException" || name === "ExpiredCodeException")
       return NextResponse.json(
-        { error: name === "ExpiredCodeException" ? "Code expired — request a new one" : "Invalid code" },
+        {
+          error:
+            name === "ExpiredCodeException" ? "Code expired — request a new one" : "Invalid code",
+        },
         { status: 400 }
       );
     if (name === "NotAuthorizedException")

--- a/src/app/api/auth/register/route.ts
+++ b/src/app/api/auth/register/route.ts
@@ -79,9 +79,16 @@ export async function POST(req: NextRequest) {
     // Derive a 6-digit OTP from the same material — mobile users who can't
     // tap the link can type this code on the signup page instead.
     const otp = (
-      parseInt(createHmac("sha256", secret).update(`otp:${email}:${exp}:${nonce}`).digest("hex").slice(0, 8), 16) %
-      1_000_000
-    ).toString().padStart(6, "0");
+      parseInt(
+        createHmac("sha256", secret)
+          .update(`otp:${email}:${exp}:${nonce}`)
+          .digest("hex")
+          .slice(0, 8),
+        16
+      ) % 1_000_000
+    )
+      .toString()
+      .padStart(6, "0");
     // Fire-and-forget — don't fail the signup if SES is down
     sendActivationEmail(email, token, otp, fullName).catch((e) =>
       console.error("[auth/register] activation email failed:", e)

--- a/src/app/api/campaigns/conversion/route.ts
+++ b/src/app/api/campaigns/conversion/route.ts
@@ -82,14 +82,16 @@ export async function POST(request: NextRequest) {
       // Don't leak the raw upstream body to the caller — it can include the
       // CAPI access token in error messages.
       console.error(
-        "LinkedIn CAPI error " + res.status + ": " + text.slice(0, 200).replace(/[\x00-\x1f\x7f]/g, " ")
+        "LinkedIn CAPI error " +
+          res.status +
+          ": " +
+          text.slice(0, 200).replace(/[\x00-\x1f\x7f]/g, " ")
       );
       return NextResponse.json({ ok: false }, { status: 502 });
     }
   } catch (err) {
     console.error(
-      "LinkedIn CAPI fetch failed: " +
-        ((err as Error).message ?? "unknown").slice(0, 200)
+      "LinkedIn CAPI fetch failed: " + ((err as Error).message ?? "unknown").slice(0, 200)
     );
     return NextResponse.json({ ok: false }, { status: 502 });
   }

--- a/src/app/api/contact/route.ts
+++ b/src/app/api/contact/route.ts
@@ -200,7 +200,9 @@ export async function POST(request: Request) {
       try {
         const raw = cookieHeader.match(/cookieConsent=([^;]+)/)?.[1];
         return raw ? JSON.parse(decodeURIComponent(raw)).marketing === true : false;
-      } catch { return false; }
+      } catch {
+        return false;
+      }
     })();
     const fbp = marketingConsented ? cookieHeader.match(/_fbp=([^;]+)/)?.[1] : undefined;
     const fbc = marketingConsented ? cookieHeader.match(/_fbc=([^;]+)/)?.[1] : undefined;

--- a/src/app/api/user/delete/route.ts
+++ b/src/app/api/user/delete/route.ts
@@ -4,7 +4,10 @@
  * Deletes the authenticated user from Cognito and their DynamoDB profile.
  */
 import { NextRequest, NextResponse } from "next/server";
-import { CognitoIdentityProviderClient, AdminDeleteUserCommand } from "@aws-sdk/client-cognito-identity-provider";
+import {
+  CognitoIdentityProviderClient,
+  AdminDeleteUserCommand,
+} from "@aws-sdk/client-cognito-identity-provider";
 import { DynamoDBClient, DeleteItemCommand } from "@aws-sdk/client-dynamodb";
 import { requireAuth } from "@/lib/api-auth";
 
@@ -48,7 +51,10 @@ export async function POST(req: NextRequest) {
   }
 
   if (errors.length) {
-    return NextResponse.json({ error: `Partial deletion failure: ${errors.join(", ")}` }, { status: 500 });
+    return NextResponse.json(
+      { error: `Partial deletion failure: ${errors.join(", ")}` },
+      { status: 500 }
+    );
   }
 
   return NextResponse.json({ ok: true });

--- a/src/app/portal/[token]/page.tsx
+++ b/src/app/portal/[token]/page.tsx
@@ -197,7 +197,11 @@ function CommentCard({ comment }: Readonly<{ comment: PortalComment }>) {
   );
 }
 
-function ReplyForm({ token, stepId, onSent }: Readonly<{ token: string; stepId: string; onSent: (c: PortalComment) => void }>) {
+function ReplyForm({
+  token,
+  stepId,
+  onSent,
+}: Readonly<{ token: string; stepId: string; onSent: (c: PortalComment) => void }>) {
   const [text, setText] = useState("");
   const [sending, setSending] = useState(false);
 
@@ -228,7 +232,7 @@ function ReplyForm({ token, stepId, onSent }: Readonly<{ token: string; stepId: 
         value={text}
         onChange={(e) => setText(e.target.value)}
         placeholder="Write a reply..."
-        className="bg-void flex-1 rounded-lg border border-slate-700 px-3 py-2 font-mono text-sm text-white placeholder:text-slate-600 focus:border-neon-cyan/50 focus:outline-none"
+        className="bg-void focus:border-neon-cyan/50 flex-1 rounded-lg border border-slate-700 px-3 py-2 font-mono text-sm text-white placeholder:text-slate-600 focus:outline-none"
       />
       <button
         type="submit"
@@ -415,10 +419,14 @@ function ProjectTimeline({ steps, token }: Readonly<{ steps: PortalStep[]; token
                       ))}
                     </div>
                   )}
-                  <ReplyForm token={token} stepId={step.id} onSent={(c) => {
-                    step.comments.push(c);
-                    setExpanded(step.id);
-                  }} />
+                  <ReplyForm
+                    token={token}
+                    stepId={step.id}
+                    onSent={(c) => {
+                      step.comments.push(c);
+                      setExpanded(step.id);
+                    }}
+                  />
                 </div>
               )}
             </div>

--- a/src/components/CampaignHero.tsx
+++ b/src/components/CampaignHero.tsx
@@ -49,9 +49,7 @@ export default function CampaignHero({ campaign, locale }: Props) {
           <Image
             src={campaign.heroImage}
             alt={
-              locale === "el"
-                ? "Εβδομαδιαία αναφορά Shop Insights"
-                : "Weekly Shop Insights digest"
+              locale === "el" ? "Εβδομαδιαία αναφορά Shop Insights" : "Weekly Shop Insights digest"
             }
             width={760}
             height={1380}

--- a/src/components/TierTable.tsx
+++ b/src/components/TierTable.tsx
@@ -12,10 +12,7 @@ export default function TierTable({ campaign, locale }: Props) {
     <section className="cl-tiers" aria-label={locale === "el" ? "Πακέτα" : "Tiers"}>
       <div className="cl-tiers__grid">
         {campaign.tiers.map((t) => (
-          <article
-            key={t.id}
-            className={`cl-tier ${t.featured ? "cl-tier--featured" : ""}`}
-          >
+          <article key={t.id} className={`cl-tier ${t.featured ? "cl-tier--featured" : ""}`}>
             {t.badge && <span className="cl-tier__badge">{t.badge}</span>}
             <h3 className="cl-tier__name">{t.name[locale]}</h3>
             <div className="cl-tier__prices">

--- a/src/context/AuthContext.tsx
+++ b/src/context/AuthContext.tsx
@@ -257,7 +257,10 @@ export function AuthProvider({ children }: AuthProviderProps) {
       });
 
     let res = await doFetch();
-    if ((res.status === 502 || res.status === 503) && res.headers.get("x-served-by") !== "aws-fallback") {
+    if (
+      (res.status === 502 || res.status === 503) &&
+      res.headers.get("x-served-by") !== "aws-fallback"
+    ) {
       // Retry once — the Worker may route to AWS on the second attempt
       res = await doFetch();
     }

--- a/src/lib/admin-notifications.ts
+++ b/src/lib/admin-notifications.ts
@@ -374,7 +374,6 @@ export async function purgeArchivedOlderThan(olderThan: string): Promise<number>
   return purged;
 }
 
-
 // ---------------------------------------------------------------------------
 // Data Lake sink — writes notifications to S3 as NDJSON for Athena queries.
 // Partitioned by year/month for the notifications table schema.
@@ -406,6 +405,11 @@ async function sinkToLake(notif: AdminNotification): Promise<void> {
   });
 
   await getS3().send(
-    new PutObjectCommand({ Bucket: LAKE_BUCKET, Key: key, Body: record, ContentType: "application/json" })
+    new PutObjectCommand({
+      Bucket: LAKE_BUCKET,
+      Key: key,
+      Body: record,
+      ContentType: "application/json",
+    })
   );
 }

--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -16,8 +16,8 @@ function getS3(): S3Client {
 }
 
 export interface AnalyticsEvent {
-  event: string;           // e.g. "signup", "purchase", "page_view"
-  user_id?: string;        // Cognito sub
+  event: string; // e.g. "signup", "purchase", "page_view"
+  user_id?: string; // Cognito sub
   email?: string;
   session_id?: string;
   page?: string;
@@ -58,6 +58,13 @@ export function trackS3Event(evt: AnalyticsEvent): void {
   });
 
   getS3()
-    .send(new PutObjectCommand({ Bucket: BUCKET, Key: key, Body: record, ContentType: "application/x-ndjson" }))
+    .send(
+      new PutObjectCommand({
+        Bucket: BUCKET,
+        Key: key,
+        Body: record,
+        ContentType: "application/x-ndjson",
+      })
+    )
     .catch((e) => console.error("[analytics] S3 write failed:", e));
 }

--- a/src/lib/linkedin-track.ts
+++ b/src/lib/linkedin-track.ts
@@ -15,8 +15,9 @@
 export function trackLinkedInConversion(conversionId: number | string): void {
   if (typeof window === "undefined") return;
 
-  const lintrk = (window as { lintrk?: (action: string, payload?: Record<string, unknown>) => void })
-    .lintrk;
+  const lintrk = (
+    window as { lintrk?: (action: string, payload?: Record<string, unknown>) => void }
+  ).lintrk;
   if (!lintrk) return;
 
   lintrk("track", { conversion_id: conversionId });

--- a/src/lib/stripe-transactions.ts
+++ b/src/lib/stripe-transactions.ts
@@ -195,7 +195,6 @@ export async function markStripeEventFailed(eventId: string, errorMessage: strin
   );
 }
 
-
 // ---------------------------------------------------------------------------
 // Data Lake sink — writes Stripe events to S3 for Athena analytics.
 // ---------------------------------------------------------------------------
@@ -222,8 +221,10 @@ async function sinkStripeEventToLake(event: Stripe.Event): Promise<void> {
     timestamp: d.toISOString(),
     event: event.type,
     user_id: (obj.customer as string) ?? undefined,
-    email: (obj.customer_email as string) ??
-           ((obj.customer_details as Record<string, unknown>)?.email as string) ?? undefined,
+    email:
+      (obj.customer_email as string) ??
+      ((obj.customer_details as Record<string, unknown>)?.email as string) ??
+      undefined,
     amount: (obj.amount_total as number) ?? undefined,
     currency: (obj.currency as string) ?? undefined,
     product_id: event.type,
@@ -232,6 +233,11 @@ async function sinkStripeEventToLake(event: Stripe.Event): Promise<void> {
   });
 
   await getLakeS3().send(
-    new PutObjectCommand({ Bucket: LAKE_BUCKET, Key: key, Body: record, ContentType: "application/x-ndjson" })
+    new PutObjectCommand({
+      Bucket: LAKE_BUCKET,
+      Key: key,
+      Body: record,
+      ContentType: "application/x-ndjson",
+    })
   );
 }


### PR DESCRIPTION
Closes the Prettier drift on main that was failing the CI **Lint & Format** step on every new PR (visible on #972 CI run 27764867748).

The bulk of the drift arrived via #970 (campaigns) and #972 (blog post) where I shipped without running [EACCES] EACCES: permission denied, open /mnt/c/WINDOWS/system32/_tmp_164348_8517f7ffc8f20d824f9fdd269b900eb9



[ERROR] Command failed with exit code 243: /home/tbaltzakis/.nvm/versions/node/v24.14.1/bin/node /home/tbaltzakis/.cache/node/corepack/v1/pnpm/11.5.0/bin/pnpm.mjs install

pnpm: Command failed with exit code 243: /home/tbaltzakis/.nvm/versions/node/v24.14.1/bin/node /home/tbaltzakis/.cache/node/corepack/v1/pnpm/11.5.0/bin/pnpm.mjs install
    at getFinalError (file:///home/tbaltzakis/.cache/node/corepack/v1/pnpm/11.5.0/dist/pnpm.mjs:3761:14)
    at makeError (file:///home/tbaltzakis/.cache/node/corepack/v1/pnpm/11.5.0/dist/pnpm.mjs:6068:21)
    at getSyncResult (file:///home/tbaltzakis/.cache/node/corepack/v1/pnpm/11.5.0/dist/pnpm.mjs:7912:10)
    at spawnSubprocessSync (file:///home/tbaltzakis/.cache/node/corepack/v1/pnpm/11.5.0/dist/pnpm.mjs:7872:14)
    at execaCoreSync (file:///home/tbaltzakis/.cache/node/corepack/v1/pnpm/11.5.0/dist/pnpm.mjs:7802:23)
    at callBoundExeca (file:///home/tbaltzakis/.cache/node/corepack/v1/pnpm/11.5.0/dist/pnpm.mjs:10330:23)
    at boundExeca (file:///home/tbaltzakis/.cache/node/corepack/v1/pnpm/11.5.0/dist/pnpm.mjs:10307:49)
    at sync (file:///home/tbaltzakis/.cache/node/corepack/v1/pnpm/11.5.0/dist/pnpm.mjs:10466:10)
    at runPnpmCli (file:///home/tbaltzakis/.cache/node/corepack/v1/pnpm/11.5.0/dist/pnpm.mjs:217979:5)
    at runDepsStatusCheck (file:///home/tbaltzakis/.cache/node/corepack/v1/pnpm/11.5.0/dist/pnpm.mjs:219711:7) first.

Pure formatting — no behavior change. Typecheck green, 2797/2797 unit tests still passing.