### PR TITLE
chore(lint): exclude vendored .claude/skills from md + ruff lint

### DIFF
--- a/.amazonq/rules/memory-bank/guidelines.md
+++ b/.amazonq/rules/memory-bank/guidelines.md
@@ -3,6 +3,7 @@
 ## Code Quality Standards
 
 ### TypeScript
+
 - Strict mode everywhere (`strict: true`, `noEmit: true`)
 - `moduleResolution: "bundler"` — do not use `node16`/`nodenext`
 - Absolute imports via `@/` alias (maps to `src/`) — always prefer over relative paths for `src/` code
@@ -11,6 +12,7 @@
 - Export interface/type for all non-trivial shapes; inline only for one-off props
 
 ### Naming Conventions
+
 - Files: `kebab-case.ts`, `PascalCase.tsx` for components
 - Functions/variables: `camelCase`
 - Types/interfaces: `PascalCase`
@@ -19,6 +21,7 @@
 - Test constants at top of file: named constants instead of magic strings (e.g. `const PAGE_ID = "page-1"`)
 
 ### File-Level Structure
+
 1. JSDoc module comment (optional but used on complex files)
 2. Imports (external → internal `@/` → relative)
 3. Module-level constants (`SCREAMING_SNAKE_CASE`)
@@ -27,7 +30,9 @@
 6. Exported functions / default export
 
 ### Section Separators
+
 Use `// ── Section Name ──────────────────────────────────────────────────` (em-dash + trailing dashes) to visually separate major sections within a file. Seen in both TypeScript and Python files:
+
 ```ts
 // ── Types ────────────────────────────────────────────────────────────────────
 // ── Helper components ─────────────────────────────────────────────────────────
@@ -39,6 +44,7 @@ Use `// ── Section Name ─────────────────�
 ## API Route Patterns
 
 ### Route Handler Structure (`src/app/api/**/route.ts`)
+
 ```ts
 import { NextRequest } from "next/server";
 
@@ -73,6 +79,7 @@ export async function POST(request: NextRequest) {
 ```
 
 ### Key API Route Conventions
+
 - Always use `Response.json()` (not `NextResponse.json()`) for response creation
 - SSM config loaded via `await getConfig()` — never read secrets from `process.env` directly in production routes
 - Fire-and-forget side effects (Slack, HubSpot) call `.catch(() => {})` inline — they never fail the main response
@@ -86,11 +93,13 @@ export async function POST(request: NextRequest) {
 ## React Component Patterns
 
 ### Client Components (`"use client"`)
+
 - All admin dashboard pages are `"use client"` with data fetching via `fetchWithAuth`
 - State organized by concern: data state, loading state (per-tab/section), error state, UI state
 - Per-section loading/error state tracked with `Record<TabName, boolean>` and `Record<TabName, string | null>`
 
 ### Data Fetching in Client Components
+
 ```ts
 // Pattern: lazy load — only fetch when tab is first visited
 const [fetchedTabs, setFetchedTabs] = useState<Set<Tab>>(new Set());
@@ -112,19 +121,23 @@ useEffect(() => {
 ```
 
 ### useState Initialization
+
 - Use lazy initializer `useState(() => expensiveComputation())` to avoid SSR/mount issues
 - For localStorage reads: guard with `typeof window === "undefined"` before accessing
 
 ### useCallback/useMemo
+
 - Wrap fetch functions in `useCallback` with correct `[deps]` array
 - Use `useMemo` for derived values (e.g. `presetForDays(days)`)
 
 ### Component Props
+
 - Always use `readonly` for destructured props
 - Prefer small focused sub-components over monolithic render — extract tab components, card components, state components
 - Loading/error/empty states are dedicated components: `LoadingState`, `ErrorState`
 
 ### Promise.allSettled for Parallel Fetches
+
 ```ts
 const [seoRes, webRes] = await Promise.allSettled([
   fetchWithAuth("/api/admin/analytics/seo"),
@@ -138,6 +151,7 @@ const [seoRes, webRes] = await Promise.allSettled([
 ## Testing Patterns
 
 ### Test File Structure
+
 ```ts
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 
@@ -161,7 +175,9 @@ describe("module-name — Description", () => {
 ```
 
 ### Dynamic Imports in Tests
+
 Modules are imported **inside test bodies** to pick up mocked globals:
+
 ```ts
 it("sends correct headers", async () => {
   const { notionFetch } = await import("@/lib/notion");
@@ -169,9 +185,11 @@ it("sends correct headers", async () => {
   ...
 });
 ```
+
 This ensures `vi.stubGlobal("fetch", mockFetch)` is in effect when the module initializes.
 
 ### Mock Patterns
+
 - `vi.fn()` for function mocks
 - `vi.stubGlobal()` for globals (`fetch`, `setTimeout`)
 - `vi.spyOn(globalThis, "setTimeout")` to make timers synchronous in retry tests
@@ -179,6 +197,7 @@ This ensures `vi.stubGlobal("fetch", mockFetch)` is in effect when the module in
 - Never mock the module under test — mock its dependencies (external calls)
 
 ### Test Coverage Conventions
+
 - Test both happy path and error/edge cases for every exported function
 - Pagination tests: verify cursor is passed in subsequent calls
 - Error tests: HTTP 4xx/5xx, parse failures, retry exhaustion
@@ -189,13 +208,16 @@ This ensures `vi.stubGlobal("fetch", mockFetch)` is in effect when the module in
 ## Library Module Patterns (`src/lib/`)
 
 ### Self-Contained Modules
+
 Scripts that need portability (e.g. `scripts/article-quality-gates.ts`) are explicitly kept self-contained:
+
 ```ts
 // Self-contained: reads no src/lib/* (kept as a sibling script module so
 // the cron tooling stays portable).
 ```
 
 ### Constants as Single Source of Truth
+
 ```ts
 export const WORD_MIN = 700;    // exported so tests and consumers share the value
 export const WORD_MAX = 1400;
@@ -203,7 +225,9 @@ export const MIN_CRITIC_SCORE = 7.0;
 ```
 
 ### Discriminated Union Return Types
+
 Complex multi-outcome functions return discriminated unions:
+
 ```ts
 export type AutoPromoteVerdict =
   | { promote: true; gates: GateResult[]; critic: CriticResponse }
@@ -211,7 +235,9 @@ export type AutoPromoteVerdict =
 ```
 
 ### Robust JSON Parsing
+
 LLM/external JSON: try strict parse first, then extract largest `{...}` block as fallback:
+
 ```ts
 export function parseCriticJson(raw: string): CriticResponse {
   try { return JSON.parse(raw); } catch {
@@ -223,6 +249,7 @@ export function parseCriticJson(raw: string): CriticResponse {
 ```
 
 ### Error Propagation
+
 - Functions that do I/O: throw on unrecoverable errors, return `null`/`false`/`[]` on expected failures (missing config, 404s)
 - Callers decide whether to surface or swallow
 - Never silently swallow unexpected errors at lib level
@@ -232,12 +259,15 @@ export function parseCriticJson(raw: string): CriticResponse {
 ## Python / Infrastructure Patterns (FastAPI on Pi)
 
 ### Route Module Pattern
+
 ```python
 router = APIRouter()  # Router defined at module level, included in main.py
 ```
 
 ### Pydantic Input Models
+
 All route inputs use Pydantic `BaseModel`:
+
 ```python
 class CommandIn(BaseModel):
     action: str
@@ -245,28 +275,34 @@ class CommandIn(BaseModel):
 ```
 
 ### Async HTTP with httpx
+
 ```python
 async with httpx.AsyncClient(timeout=CMD_TIMEOUT) as client:
     r = await client.post(url, data=params)
 return r.status_code == 200
 ```
+
 Private helpers prefixed with `_`: `_esphome_post`, `_esphome_get`, `_dispatch_command`
 
 ### Error Handling in FastAPI
+
 ```python
 raise HTTPException(status_code=400, detail=f"Unknown command: {action!r}")
 raise HTTPException(status_code=502, detail="ESPHome did not acknowledge")
 ```
 
 ### Background Tasks for Long Operations
+
 ```python
 async def esp32_ota(body: OtaIn, background_tasks: BackgroundTasks):
     background_tasks.add_task(_do_ota)
     return {"ok": True, "message": "OTA triggered — device will reboot after flashing (~30 s)"}
 ```
+
 OTA endpoint returns immediately; actual HTTP call is in background task.
 
 ### Environment-Based Config
+
 ```python
 ESPHOME_BASE = os.getenv("ESPHOME_URL", "http://192.168.1.201:9101")
 ```
@@ -276,6 +312,7 @@ ESPHOME_BASE = os.getenv("ESPHOME_URL", "http://192.168.1.201:9101")
 ## Tailwind CSS / Design System Conventions
 
 ### Custom Design Tokens (from admin pages)
+
 - `font-mono` — monospace labels, table data, badges, metric values
 - `font-heading` — section headings
 - `font-body` — paragraph text
@@ -288,6 +325,7 @@ ESPHOME_BASE = os.getenv("ESPHOME_URL", "http://192.168.1.201:9101")
 - Loading spinner: `border-neon-magenta h-6 w-6 animate-spin rounded-full border-2 border-t-transparent`
 
 ### Accessibility
+
 - Interactive filter groups: `role="group" aria-label="..."` on container
 - Buttons: `aria-pressed` for toggle state, `aria-label` on icon-only buttons
 - Tables: proper `<thead>/<tbody>`, `<th>` elements with scope implied
@@ -297,6 +335,7 @@ ESPHOME_BASE = os.getenv("ESPHOME_URL", "http://192.168.1.201:9101")
 ## i18n Patterns
 
 ### Server Components
+
 ```ts
 import { getServerLocale } from "@/lib/server-locale";
 const locale = await getServerLocale();
@@ -304,12 +343,14 @@ const label = translate(locale, "section.key", "Fallback string");
 ```
 
 ### Client Components
+
 ```ts
 import { useCurrentLocale } from "@/lib/use-locale";
 const locale = useCurrentLocale();
 ```
 
 ### Translation Keys
+
 - Add to both `src/locales/en.json` and `src/locales/el.json` (and fr/de for full parity)
 - The `locales-parity.test.ts` test enforces all four locale files have matching keys — CI will fail if parity breaks
 
@@ -318,7 +359,9 @@ const locale = useCurrentLocale();
 ## Security Patterns
 
 ### Webhook Signature Verification
+
 Always verify before processing payload:
+
 ```ts
 // Stripe
 event = stripe.webhooks.constructEvent(body, signature, webhookSecret);
@@ -331,12 +374,15 @@ crypto.timingSafeEqual(Buffer.from(providedSecret), Buffer.from(expectedSecret))
 ```
 
 ### HTML Escaping
+
 Use `escapeHtml()` from `@/lib/escape-html` for all user-controlled data rendered in HTML email bodies.
 
 ### JWT Validation
+
 `src/lib/api-auth.ts` validates Bearer JWTs against the Cognito JWKS endpoint, enforcing `issuer`, `audience`, and group claims. All admin API routes call this before processing.
 
 ### Rate Limiting
+
 `src/lib/rate-limit.ts` provides IP-based rate limiting. Applied to public-facing endpoints like `/api/unsubscribe` (5 req/IP/min).
 
 ---

--- a/.amazonq/rules/memory-bank/product.md
+++ b/.amazonq/rules/memory-bank/product.md
@@ -9,6 +9,7 @@ Core value: One platform that serves as a marketing site, lead capture engine, c
 ## Key Features & Capabilities
 
 ### Public / Marketing
+
 - Multi-locale site (en, el, fr, de) with cookie-based locale switching
 - Blog via Notion CMS, services listing, contact form (SES + Slack + HubSpot)
 - Newsletter signup with SES welcome email + Slack notification
@@ -17,6 +18,7 @@ Core value: One platform that serves as a marketing site, lead capture engine, c
 - SEO: sitemap, robots.txt, structured data (JSON-LD), OpenGraph images
 
 ### Authentication & Users
+
 - AWS Cognito Hosted UI (OIDC + PKCE) via next-auth v5
 - Admin detection via Cognito `admin` group → JWT `groups` claim
 - RP-initiated logout (full SSO session termination)
@@ -24,12 +26,14 @@ Core value: One platform that serves as a marketing site, lead capture engine, c
 - Theme preference (dark/light/system) synced across tabs and to user profile
 
 ### Client Dashboard (`/dashboard`)
+
 - Authenticated client portal with settings, subscriptions, orders
 - User profile management
 - Consultation booking (Google Calendar integration)
 - Portal deliverables and client-specific workspace
 
 ### Admin Panel (`/admin`)
+
 - Full analytics: GSC (Google Search Console), Stripe, DuckDB
 - CRM: HubSpot contacts, pipelines, deals
 - Notion CMS management: blog, docs, forms, case studies, tasks
@@ -43,6 +47,7 @@ Core value: One platform that serves as a marketing site, lead capture engine, c
 - Calendar and content calendar management
 
 ### Integrations
+
 - Slack: full two-way (outbound notify + inbound slash commands, events, interactions)
 - Notion: blog, docs, forms, projects, analytics, calendar, reports
 - HubSpot: CRM contacts, deals, pipelines, webhooks
@@ -58,6 +63,7 @@ Core value: One platform that serves as a marketing site, lead capture engine, c
 - TikTok OAuth, LinkedIn, X Ads, Google Ads
 
 ### Infrastructure
+
 - k3s Kubernetes on Raspberry Pi for HA standby / self-hosted workloads
 - ESP32 watchdog hardware with MQTT alerts → Notion + Slack
 - Cloudflare tunnels for Pi exposure
@@ -65,6 +71,7 @@ Core value: One platform that serves as a marketing site, lead capture engine, c
 - GitHub Actions: 80+ workflows for CI, deploy, audits, cluster ops
 
 ## Target Users
+
 - **Clients**: Greek/EU startups and SMBs receiving cloud/marketing services
 - **Admin (owner)**: Single-tenant internal ops — analytics, CRM, content management
 - **Anonymous visitors**: Lead generation through contact form, newsletter, blog, store

--- a/.amazonq/rules/memory-bank/structure.md
+++ b/.amazonq/rules/memory-bank/structure.md
@@ -38,7 +38,9 @@ cloudless.gr/
 ## App Router Structure (`src/app/`)
 
 ### Locale-Prefixed Pages (`src/app/[locale]/`)
+
 All user-facing pages live under the `[locale]` segment (en/el/fr/de):
+
 - `/` — Homepage (hero, services, CTA, newsletter)
 - `/blog/`, `/blog/[slug]` — Notion-powered blog
 - `/case-studies/`, `/case-studies/[slug]` — Portfolio
@@ -51,7 +53,9 @@ All user-facing pages live under the `[locale]` segment (en/el/fr/de):
 - `/admin/` — Admin panel (40+ sub-pages: analytics, CRM, AI, CMS, etc.)
 
 ### API Routes (`src/app/api/`)
+
 Organized by domain:
+
 - `/api/admin/**` — Admin-only endpoints (analytics, CRM, AI, Notion, campaigns)
 - `/api/auth/[...nextauth]` — next-auth v5 handlers
 - `/api/webhooks/stripe|notion|hubspot|postiz` — Inbound webhooks
@@ -65,11 +69,13 @@ Organized by domain:
 - `/api/portal/**` — Client portal token endpoints
 
 ### Non-Locale Routes
+
 - `/portal/[token]` — Client portal (locale-neutral, token-driven)
 - `/services/page.tsx` — Redirect to locale-prefixed version
 - Root `layout.tsx` / `page.tsx` — Shell + locale redirect
 
 ## Source Library (`src/lib/`)
+
 Flat module directory — one file per concern:
 
 | Category | Files |
@@ -88,23 +94,28 @@ Flat module directory — one file per concern:
 | Utils | `api-errors.ts`, `validation.ts`, `escape-html.ts`, `format-price.ts`, `structured-data.ts`, `sha-drift.ts` |
 
 ## Components (`src/components/`)
+
 - Flat + two subdirectories: `admin/` and `store/`
 - Key: `Navbar.tsx`, `Footer.tsx`, `ThemeSwitcher.tsx`, `LocaleSwitcher.tsx`, `NewsletterForm.tsx`, `ChatWidget.tsx`, `CommandPalette.tsx`, `CookieConsent.tsx`
 
 ## Context Providers (`src/context/`)
+
 - `AuthContext.tsx` — `useAuth()` hook (session, isAdmin, signIn/Out)
 - `CartContext.tsx` — Shopping cart with useReducer
 - `CookieConsentContext.tsx` — GDPR consent state
 - `WorkspaceContext.tsx` — Multi-workspace switcher
 
 ## Middleware (`src/proxy.ts`)
+
 Single middleware file handling:
+
 1. next-intl locale routing (prefix-based)
 2. Auth protection: redirects unauthenticated users away from `/dashboard` and `/admin`
 3. Admin group check for `/admin` routes
 4. Locale normalization before auth checks
 
 ## Test Architecture
+
 - `__tests__/` — Vitest unit tests mirror `src/lib/` and `src/app/api/` structure
 - `__tests__/stubs/` — Module stubs for AWS SDKs, Next.js server/navigation
 - `__tests__/setup.ts` — Global test setup
@@ -112,6 +123,7 @@ Single middleware file handling:
 - `e2e/_internal/`, `e2e/fixtures/`, `e2e/helpers/` — Shared test utilities
 
 ## Infrastructure Components
+
 - `infrastructure/pi-alert-api/` — Python FastAPI service running on Pi: receives ESP32 MQTT alerts, forwards to Notion + Slack
 - `infrastructure/esp32-watchdog/` — ESP32 firmware (Arduino/ESPHome/PlatformIO)
 - `workers/esp32-proxy/` — Cloudflare Worker bridging ESP32 → Pi API
@@ -119,6 +131,7 @@ Single middleware file handling:
 - `k8s/` — k3s manifests: app deployment, cluster protection, Grafana dashboards
 
 ## Key Configuration Files
+
 | File | Purpose |
 |---|---|
 | `next.config.ts` | Next.js config: next-intl plugin, SST/Docker output, coverage mode, image optimization |

--- a/.amazonq/rules/memory-bank/tech.md
+++ b/.amazonq/rules/memory-bank/tech.md
@@ -21,6 +21,7 @@
 | TypeScript | ^6.0.3 | Strict mode, `@/` path alias → `./src/` |
 
 ## Package Management
+
 - **pnpm** 10.33.2 (enforced via `packageManager` field and `engines`)
 - Node.js >= 20 required
 - pnpm workspace: `pnpm-workspace.yaml` (monorepo root + `tools/` packages)
@@ -76,6 +77,7 @@ Coverage thresholds (CI enforced): lines 47%, functions 37%, branches 37%, state
 | k3s | Kubernetes on Raspberry Pi (HA standby) |
 
 ## Dev Port
+
 App runs on **port 4000** (not the default 3000): `next dev -p 4000` / `next start -p 4000`.
 
 ## Development Commands
@@ -112,6 +114,7 @@ pnpm cognito:setup          # Configure Cognito Hosted UI
 ```
 
 ## Infrastructure Languages
+
 - **Terraform** (`infrastructure/terraform/`): Lambda resource optimization
 - **Python FastAPI** (`infrastructure/pi-alert-api/`): ESP32 alert receiver on Pi
   - Typed with mypy, linted with ruff, pylint config in `.codacy/`
@@ -119,6 +122,7 @@ pnpm cognito:setup          # Configure Cognito Hosted UI
 - **Cloudflare Workers TypeScript** (`workers/esp32-proxy/`): Edge proxy
 
 ## TypeScript Configuration Highlights
+
 - `strict: true` — full strict mode
 - `moduleResolution: "bundler"` — Turbopack-compatible resolution
 - `paths: { "@/*": ["./src/*"] }` — absolute imports via `@/`
@@ -126,6 +130,7 @@ pnpm cognito:setup          # Configure Cognito Hosted UI
 - Test and script files excluded from main tsconfig (have their own)
 
 ## Code Quality Tools
+
 - ESLint flat config (`eslint.config.mjs`) with `eslint-config-next`
 - Prettier with `prettier-plugin-tailwindcss` (auto-sorts Tailwind classes)
 - Ruff for Python (lint + format)
@@ -136,6 +141,7 @@ pnpm cognito:setup          # Configure Cognito Hosted UI
 - `.gitattributes`: LF enforcement for all text files
 
 ## Secrets / Config Pattern
+
 - **No `.env` files in production** — all secrets from AWS SSM Parameter Store
 - Path prefix: `/cloudless/production/`
 - Local dev: `.env.local` (git-ignored)

--- a/.claude/skills/ab-test-setup/SKILL.md
+++ b/.claude/skills/ab-test-setup/SKILL.md
@@ -70,18 +70,23 @@ If duration exceeds 8 weeks: increase MDE, reduce variants, test a higher-traffi
 ## Step 5: Test Design by Element
 
 ### Headline Tests
+
 Test: value prop angle, specificity, social proof integration, question vs. statement, length. Measure: conversion rate, bounce rate, scroll depth.
 
 ### CTA Tests
+
 Test: button copy (action vs. benefit), color (contrast), size, placement, surrounding copy. Measure: click-through rate, conversion rate.
 
 ### Layout Tests
+
 Test: single vs. two column, long vs. short form, section order, video vs. static hero, with vs. without nav. Measure: conversion rate, scroll depth. Guardrail: page load time.
 
 ### Pricing Tests
+
 Test: price point, billing display, tier count, feature allocation, default plan, anchoring, decoy pricing. Measure: **revenue per visitor** (not just CR). Guardrail: support tickets, refund rate.
 
 ### Copy Tests
+
 Test: tone, length, format (paragraphs vs. bullets), emotional angle, proof type. Measure: conversion rate, read depth.
 
 ## Step 6: Running the Test

--- a/.claude/skills/affiliate-marketing/SKILL.md
+++ b/.claude/skills/affiliate-marketing/SKILL.md
@@ -75,6 +75,7 @@ Your affiliate program page should include:
 ### Terms of Service
 
 Key terms to include:
+
 - Commission rates and payment schedule
 - Cookie duration and attribution model
 - Prohibited promotion methods (spam, brand bidding, misleading claims)
@@ -184,6 +185,7 @@ Required disclosures:
 ### Prohibited Activities
 
 Define clearly in your terms:
+
 - Spam (email, social, forum)
 - Brand bidding (PPC ads on your brand name)
 - Cookie stuffing or forced clicks

--- a/.claude/skills/ahrefs-research/SKILL.md
+++ b/.claude/skills/ahrefs-research/SKILL.md
@@ -10,6 +10,7 @@ description: Manages Ahrefs API usage in Python using `ahrefs-python` library. U
 The Ahrefs API provides programmatic access to Ahrefs SEO data. The official Python SDK (`ahrefs-python`) provides typed request and response models for all endpoints, auto-generated from the OpenAPI spec.
 
 Key capabilities:
+
 - **Site Explorer** - Backlinks, organic keywords, domain rating, traffic, referring domains
 - **Keywords Explorer** - Keyword research, volumes, difficulty, related terms
 - **Rank Tracker** - SERP monitoring, competitor tracking

--- a/.claude/skills/ahrefs-research/references/api-methods.md
+++ b/.claude/skills/ahrefs-research/references/api-methods.md
@@ -2,8 +2,6 @@
 
 <!-- AUTO-GENERATED -- DO NOT EDIT -->
 
-
-
 <!-- mdformat-toc start --slug=github --no-anchors --maxlevel=6 --minlevel=1 -->
 
 - [API Reference](#api-reference)

--- a/.claude/skills/ahrefs-research/references/filter-syntax.md
+++ b/.claude/skills/ahrefs-research/references/filter-syntax.md
@@ -7,9 +7,7 @@ The following sections give some examples of filter usage and a full syntax refe
 
 ## Examples
 
-
 > For more real world examples, try applying some filters to a report on ahrefs.com using our visual interface, and then press the `API {}` button to view the `where` parameter of the generated API v3 query.
-
 
 Field "foo" equals 3:
 
@@ -59,7 +57,7 @@ Either the uppercased value of the string field "foo" equals "AHREFS", or all st
 
 ## Language reference
 
-The filter syntax is described by the following grammar, expressed in [BNF](https://en.wikipedia.org/wiki/Backus%E2%80%93Naur_form)-style notation. 
+The filter syntax is described by the following grammar, expressed in [BNF](https://en.wikipedia.org/wiki/Backus%E2%80%93Naur_form)-style notation.
 
 A term enclosed in angle brackets `<` and `>` denotes a symbol.  A symbol followed by a `+` denotes a non-empty array containing the symbol. A `?` preceding an object field indicates that the field is optional.
 
@@ -69,6 +67,7 @@ The two terminal symbols are defined as follows:
 - `<value>` A JSON value. It should match the type of the field (or of the field's modifier, if one is present).
 
 Permitted patterns in regex filter expressions differs by tool.
+
 - Keywords Explorer: Only `*` as a wildcard operator.
 - Site Explorer: [RE2](https://github.com/google/re2/wiki/Syntax) syntax.
 
@@ -108,5 +107,3 @@ Permitted patterns in regex filter expressions differs by tool.
 <list_condition> ::= { "any" : <condition_bool_filter> }
                  |   { "all" : <condition_bool_filter> }
 ```
-
-

--- a/.claude/skills/ai-image-gen/SKILL.md
+++ b/.claude/skills/ai-image-gen/SKILL.md
@@ -125,6 +125,7 @@ python ~/.agents/tools/generate-image.py \
 - `requests` (for API calls)
 
 Install if needed:
+
 ```bash
 pip install requests
 ```
@@ -132,6 +133,7 @@ pip install requests
 ## Output
 
 The script prints:
+
 - The provider and model used
 - The prompt (and revised prompt if applicable)
 - The saved file path

--- a/.claude/skills/apollo-outreach/SKILL.md
+++ b/.claude/skills/apollo-outreach/SKILL.md
@@ -44,6 +44,7 @@ curl -s -X POST "https://api.apollo.io/api/v1/mixed_people/search" \
 ```
 
 **Useful filters:**
+
 - `q_keywords` - Keyword search across name, title, company
 - `person_titles` - Array of job titles
 - `person_locations` - Array of locations
@@ -93,6 +94,7 @@ curl -s -X POST "https://api.apollo.io/api/v1/people/match" \
 ### Step 1: Define ICP (Ideal Customer Profile)
 
 Ask or infer:
+
 - **Target titles:** What roles are you selling to?
 - **Company size:** Employee count range
 - **Industry:** Specific verticals
@@ -103,6 +105,7 @@ Ask or infer:
 ### Step 2: Build Search Query
 
 Translate ICP into Apollo search filters. Run multiple searches with variations:
+
 - Different title variations (VP Marketing = VP of Marketing = Vice President, Marketing)
 - Adjacent roles (CMO, Director of Marketing, Head of Growth)
 - Company size tiers separately
@@ -110,6 +113,7 @@ Translate ICP into Apollo search filters. Run multiple searches with variations:
 ### Step 3: Enrich Results
 
 For each prospect found:
+
 1. Note their current title, company, and location
 2. Enrich their company domain for additional context
 3. Look for mutual connections or shared background

--- a/.claude/skills/backlink-audit/SKILL.md
+++ b/.claude/skills/backlink-audit/SKILL.md
@@ -25,31 +25,37 @@ Use `curl` via the Bash tool. Base URL: `https://api.semrush.com/analytics/v1/`
 ### Core Endpoints
 
 **1. Backlinks Overview**
+
 ```
 https://api.semrush.com/analytics/v1/?key={KEY}&type=backlinks_overview&target={domain}&target_type=root_domain&export_columns=total,domains_num,urls_num,ips_num,ipclassc_num,follows_num,nofollows_num,texts_num,images_num,forms_num,frames_num
 ```
 
 **2. Backlinks List (individual links)**
+
 ```
 https://api.semrush.com/analytics/v1/?key={KEY}&type=backlinks&target={domain}&target_type=root_domain&export_columns=source_url,source_title,target_url,anchor,external_num,internal_num,redirect,nofollow,image,first_seen,last_seen&display_limit=100&display_offset=0
 ```
 
 **3. Referring Domains**
+
 ```
 https://api.semrush.com/analytics/v1/?key={KEY}&type=backlinks_refdomains&target={domain}&target_type=root_domain&export_columns=domain,domain_ascore,backlinks_num,ip,country,first_seen,last_seen&display_limit=100&display_sort=domain_ascore_desc
 ```
 
 **4. Anchor Text Distribution**
+
 ```
 https://api.semrush.com/analytics/v1/?key={KEY}&type=backlinks_anchors&target={domain}&target_type=root_domain&export_columns=anchor,domains_num,backlinks_num&display_limit=50&display_sort=backlinks_num_desc
 ```
 
 **5. Indexed Pages (pages receiving links)**
+
 ```
 https://api.semrush.com/analytics/v1/?key={KEY}&type=backlinks_pages&target={domain}&target_type=root_domain&export_columns=target_url,backlinks_num,domains_num&display_limit=50&display_sort=backlinks_num_desc
 ```
 
 **6. Competitor Backlinks (for comparison)**
+
 ```
 # Reuse endpoints above with competitor domain as target
 ```
@@ -64,52 +70,65 @@ If `AHREFS_API_KEY` is available (and SemRush is not), use the Ahrefs API v3 end
 ### Ahrefs Core Endpoints
 
 **1. Backlinks Overview (Stats)**
+
 ```bash
 # Ahrefs backlinks overview
 curl -s "https://api.ahrefs.com/v3/site-explorer/backlinks-stats?target={domain}&output=json" \
   -H "Authorization: Bearer ${AHREFS_API_KEY}"
 ```
+
 Returns: `live_backlinks`, `all_time_backlinks`, `live_refdomains`, `all_time_refdomains`, `live_refpages`, `dofollow_backlinks`, `nofollow_backlinks`.
 
 **2. Referring Domains**
+
 ```bash
 # Ahrefs referring domains
 curl -s "https://api.ahrefs.com/v3/site-explorer/refdomains?target={domain}&output=json&limit=100" \
   -H "Authorization: Bearer ${AHREFS_API_KEY}"
 ```
+
 Returns: Array of referring domains with `domain`, `domain_rating`, `backlinks`, `first_seen`, `last_seen`, `dofollow`, `nofollow`. Sort by `domain_rating` to see highest-authority referrers first.
 
 **3. Backlinks List**
+
 ```bash
 curl -s "https://api.ahrefs.com/v3/site-explorer/backlinks?target={domain}&output=json&limit=100&mode=subdomains" \
   -H "Authorization: Bearer ${AHREFS_API_KEY}"
 ```
+
 Returns: Individual backlinks with `url_from`, `url_to`, `anchor`, `domain_rating`, `first_seen`, `last_seen`, `nofollow`, `redirect`, `edu`, `gov`.
 
 **4. Anchors**
+
 ```bash
 curl -s "https://api.ahrefs.com/v3/site-explorer/anchors?target={domain}&output=json&limit=50&mode=subdomains" \
   -H "Authorization: Bearer ${AHREFS_API_KEY}"
 ```
+
 Returns: Anchor text distribution with `anchor`, `backlinks`, `refdomains`.
 
 **5. Pages by Backlinks (Best by Links)**
+
 ```bash
 curl -s "https://api.ahrefs.com/v3/site-explorer/best-by-links?target={domain}&output=json&limit=50" \
   -H "Authorization: Bearer ${AHREFS_API_KEY}"
 ```
+
 Returns: Top linked pages with `url`, `backlinks`, `refdomains`, `dofollow`.
 
 **6. Domain Rating**
+
 ```bash
 curl -s "https://api.ahrefs.com/v3/site-explorer/domain-rating?target={domain}&output=json" \
   -H "Authorization: Bearer ${AHREFS_API_KEY}"
 ```
+
 Returns: `domain_rating` (0-100) and `ahrefs_rank`.
 
 ### Ahrefs vs. SemRush Field Mapping
 
 When using Ahrefs instead of SemRush, map the fields as follows:
+
 | SemRush Field | Ahrefs Equivalent | Notes |
 |---------------|-------------------|-------|
 | `domain_ascore` | `domain_rating` | Both are 0-100 authority scores |
@@ -159,12 +178,14 @@ Pull the top referring domains sorted by authority score. Evaluate:
 
 **Domain Quality Distribution:**
 Calculate the percentage of referring domains in each tier. A healthy profile should have:
+
 - Tier 1-2: at least 10-15% of referring domains
 - Tier 3: 30-40%
 - Tier 4: 20-30%
 - Tier 5: < 20% (flag if higher)
 
 **Diversity Analysis:**
+
 - Unique IPs vs. referring domains (ratio close to 1:1 is healthy)
 - Unique Class C subnets (should be close to IP count)
 - Country distribution (should match target market)
@@ -186,6 +207,7 @@ Pull anchor text data and classify each anchor:
 | Image (no alt) | < 5% | Images without alt text | [image] |
 
 **Red flags in anchor text:**
+
 - Exact match > 10% = Over-optimized (Penguin risk)
 - Single anchor > 15% of total = Unnatural concentration
 - Money keyword anchors from low-quality sites = Likely spam
@@ -212,6 +234,7 @@ Score each backlink for toxicity based on these signals:
 | Foreign language + irrelevant | +15 | From anchor text + domain TLD |
 
 **Toxicity Rating:**
+
 - 0-20: Clean - no action needed
 - 21-40: Monitor - watch for changes
 - 41-60: Suspicious - investigate further
@@ -228,6 +251,7 @@ Analyze the `first_seen` and `last_seen` dates to determine:
 - **Velocity spikes** (unnatural bursts of links)
 
 **Healthy velocity patterns:**
+
 - Steady, gradual growth = Natural
 - Correlated with content publishing = Natural
 - Sudden spike then flat = Likely campaign or mention (investigate)
@@ -252,6 +276,7 @@ Pull backlink overview for 2-3 competitors and compare:
 
 **Link Gap Analysis:**
 Find domains that link to competitors but not to the target:
+
 1. Pull top 100 referring domains for each competitor
 2. Filter out domains already linking to the target
 3. Sort by authority score
@@ -276,6 +301,7 @@ domain:{domain2}
 ```
 
 **Disavow rules:**
+
 - Only disavow domains where 80%+ of their links are toxic
 - For mixed domains, disavow individual URLs
 - Never disavow high-authority domains (AS > 60) without manual verification

--- a/.claude/skills/bluesky/SKILL.md
+++ b/.claude/skills/bluesky/SKILL.md
@@ -10,6 +10,7 @@ You are a Bluesky content and engagement specialist. Help create, schedule, and 
 ## Platform Overview
 
 Bluesky is a decentralized social network built on the AT Protocol. Key differences from Twitter/X:
+
 - **300 character limit** per post (vs. 280 on X)
 - **Algorithmic choice** — Users pick their own feed algorithms
 - **Custom feeds** — Anyone can create topic-based feeds
@@ -52,6 +53,7 @@ Bluesky is a decentralized social network built on the AT Protocol. Key differen
 ### Post Formulas
 
 **1. Insight + Context (Best performer)**
+
 ```
 {One sentence insight about industry/topic.}
 
@@ -59,6 +61,7 @@ Bluesky is a decentralized social network built on the AT Protocol. Key differen
 ```
 
 **2. Question + Take**
+
 ```
 {Provocative question?}
 
@@ -66,11 +69,13 @@ My take: {Your opinion in 1-2 sentences.}
 ```
 
 **3. Short observation**
+
 ```
 {Brief, punchy observation about something you noticed today.}
 ```
 
 **4. Thread opener (for multi-post threads)**
+
 ```
 {Topic I've been thinking about:}
 
@@ -90,6 +95,7 @@ Final post: {Summary + CTA (follow, repost, or reply)}
 ```
 
 **Thread rules:**
+
 - Each post should be independently valuable
 - 5-10 posts is the sweet spot
 - Number your posts if sequential (1/8, 2/8, etc.)
@@ -98,6 +104,7 @@ Final post: {Summary + CTA (follow, repost, or reply)}
 ### Hashtag Strategy
 
 Bluesky doesn't have traditional hashtags. Instead:
+
 - Use descriptive text that feeds can pick up
 - Mention relevant topics naturally
 - Custom feeds use keyword matching, so include relevant terms
@@ -115,6 +122,7 @@ Bluesky doesn't have traditional hashtags. Instead:
 For programmatic posting and engagement:
 
 **Authentication:**
+
 ```bash
 # Create session
 curl -s -X POST "https://bsky.social/xrpc/com.atproto.server.createSession" \
@@ -123,6 +131,7 @@ curl -s -X POST "https://bsky.social/xrpc/com.atproto.server.createSession" \
 ```
 
 **Create post:**
+
 ```bash
 curl -s -X POST "https://bsky.social/xrpc/com.atproto.repo.createRecord" \
   -H "Authorization: Bearer ${ACCESS_TOKEN}" \
@@ -139,12 +148,14 @@ curl -s -X POST "https://bsky.social/xrpc/com.atproto.repo.createRecord" \
 ```
 
 **Search posts:**
+
 ```bash
 curl -s "https://bsky.social/xrpc/app.bsky.feed.searchPosts?q={keyword}&limit=25" \
   -H "Authorization: Bearer ${ACCESS_TOKEN}"
 ```
 
 **Get profile:**
+
 ```bash
 curl -s "https://bsky.social/xrpc/app.bsky.actor.getProfile?actor={handle}" \
   -H "Authorization: Bearer ${ACCESS_TOKEN}"

--- a/.claude/skills/brand-monitor/SKILL.md
+++ b/.claude/skills/brand-monitor/SKILL.md
@@ -140,6 +140,7 @@ curl -s -H "Authorization: Bearer ${BRANDDEV_API_KEY}" \
 ```
 
 Use logo detection to find:
+
 - Unauthorized logo usage
 - Partner and sponsor visibility
 - Event coverage and media placements
@@ -276,6 +277,7 @@ Get sentiment trends. Flag any negative spikes and investigate root causes.
 ### Step 4: PR Opportunities
 
 From mention data, identify:
+
 - **High-authority sites** that mention competitors but not you
 - **Journalists** who cover your industry
 - **Trending topics** where your brand could contribute

--- a/.claude/skills/brand-research/SKILL.md
+++ b/.claude/skills/brand-research/SKILL.md
@@ -22,6 +22,7 @@ curl -s "https://api.brand.dev/v1/brand/retrieve?domain=${DOMAIN}" \
 ```
 
 Extract from the response:
+
 - **Brand name** (`.brand.title` or `.brand.name`)
 - **Description** (`.brand.description`)
 - **Logo URLs** (from `.brand.logos[]`) — prefer icon/square logos for card layouts, full logos for headers
@@ -34,23 +35,27 @@ ALWAYS download logos locally for serving. Never reference external `media.brand
 ### Where to save
 
 The save location depends on the project. Look for existing patterns:
+
 - **Next.js / static sites**: `public/logos/<context>/` (served as `/logos/<context>/`)
 - **Other web projects**: check for existing `static/`, `assets/`, `images/`, or `public/` directories
 - **If no convention exists**: create a `logos/` directory under the project's static asset root
 
 ### Naming Convention
+
 - `<brand-slug>.<ext>` where:
   - `<brand-slug>` is the lowercase brand name, spaces replaced by hyphens (e.g., `miss-a` not `miss_a`)
   - `<ext>` matches the original file extension (png, webp, jpg, svg)
 - Optionally group by context subdirectory (e.g., `partners/`, `customers/`) if the project has multiple logo collections
 
 ### Download Command
+
 ```bash
 mkdir -p <logo-dir>
 curl -sL "<logo-url>" -o "<logo-dir>/<brand-slug>.<ext>"
 ```
 
 ### Verify Download
+
 ```bash
 ls -la <logo-dir>/<brand-slug>.<ext>
 ```
@@ -58,6 +63,7 @@ ls -la <logo-dir>/<brand-slug>.<ext>
 ## Step 4: Return Results
 
 Provide the user with:
+
 - Brand name
 - Description
 - Industry

--- a/.claude/skills/competitor-analysis/SKILL.md
+++ b/.claude/skills/competitor-analysis/SKILL.md
@@ -18,60 +18,76 @@ The following API keys enable richer data collection. All are optional -- the fr
 ### SemRush API (if SEMRUSH_API_KEY available)
 
 **Domain Overview** - Get traffic, keywords, and authority for any competitor:
+
 ```bash
 # Domain overview (organic traffic, keywords, authority score)
 curl -s "https://api.semrush.com/?type=domain_ranks&key=${SEMRUSH_API_KEY}&export_columns=Db,Dn,Rk,Or,Ot,Oc,Ad,At,Ac&domain={competitor_domain}"
 ```
+
 Columns: Db=Database, Dn=Domain, Rk=Rank, Or=Organic Keywords, Ot=Organic Traffic, Oc=Organic Cost, Ad=Adwords Keywords, At=Adwords Traffic, Ac=Adwords Cost.
 
 **Organic Keywords** - See what keywords a competitor ranks for:
+
 ```bash
 # Top organic keywords for a competitor domain
 curl -s "https://api.semrush.com/?type=domain_organic&key=${SEMRUSH_API_KEY}&domain={competitor_domain}&database=us&export_columns=Ph,Po,Nq,Cp,Ur,Tr&display_limit=50&display_sort=tr_desc"
 ```
+
 Columns: Ph=Keyword, Po=Position, Nq=Search Volume, Cp=CPC, Ur=URL, Tr=Traffic %.
 
 **Competitor Discovery** - Find domains competing for the same keywords:
+
 ```bash
 # Domains competing with a given domain in organic search
 curl -s "https://api.semrush.com/?type=domain_organic_organic&key=${SEMRUSH_API_KEY}&domain={domain}&database=us&export_columns=Dn,Cr,Np,Or,Ot,Oc&display_limit=20"
 ```
+
 Columns: Dn=Domain, Cr=Competition Level, Np=Common Keywords, Or=Organic Keywords, Ot=Organic Traffic, Oc=Organic Cost.
 
 **Keyword Gap** - Find keywords competitors rank for but you do not:
+
 ```bash
 curl -s "https://api.semrush.com/?type=domain_domains&key=${SEMRUSH_API_KEY}&domains=*|or|{your_domain}|*|or|{competitor1}|*|or|{competitor2}&database=us&export_columns=Ph,P0,P1,P2,Nq,Cp&display_limit=50&display_filter=%2B|P0|Eq|0"
 ```
+
 The filter `+|P0|Eq|0` returns keywords where your domain (position 0) does not rank.
 
 ### SerpAPI (if SERPAPI_API_KEY available)
 
 **SERP Competitive Analysis** - See who ranks for key terms in real time:
+
 ```bash
 # Real-time SERP for competitive keywords
 curl -s "https://serpapi.com/search.json?q={keyword}&api_key=${SERPAPI_API_KEY}&num=20&gl=us&hl=en"
 ```
+
 Use this to:
+
 - Identify which competitors dominate organic results for target keywords (parse `organic_results`)
 - Extract competitor ad copy from `ads` and `shopping_results` fields
 - Discover related competitor keywords from `related_searches`
 - See competitor presence in SERP features: `knowledge_graph`, `local_results`, `featured_snippet`
 
 **Google Ads Competitor Analysis:**
+
 ```bash
 # Search a commercial keyword to see competitor ads
 curl -s "https://serpapi.com/search.json?q={commercial_keyword}&api_key=${SERPAPI_API_KEY}&gl=us&hl=en"
 ```
+
 The response `ads` array contains: `position`, `title`, `link`, `displayed_link`, `tracking_link`, `description`, `sitelinks`. This reveals competitor ad copy, landing pages, and messaging.
 
 ### ScrapingBee (if SCRAPINGBEE_API_KEY available)
 
 Use ScrapingBee to scrape competitor pages that block direct fetching via WebFetch (e.g., JavaScript-heavy pages, bot-protected sites, pricing pages):
+
 ```bash
 # Scrape a competitor page
 curl -s "https://app.scrapingbee.com/api/v1/?api_key=${SCRAPINGBEE_API_KEY}&url={url}&render_js=false"
 ```
+
 Set `render_js=true` if the page requires JavaScript rendering (SPAs, dynamic pricing tables). Useful for:
+
 - Extracting pricing page details when WebFetch returns incomplete content
 - Scraping competitor landing pages for messaging and positioning analysis
 - Capturing competitor feature comparison pages

--- a/.claude/skills/content-calendar/SKILL.md
+++ b/.claude/skills/content-calendar/SKILL.md
@@ -34,6 +34,7 @@ Content pillars are 3-5 core themes that every piece of content ties back to. Th
 variety while maintaining brand relevance.
 
 **Example for a SaaS marketing tool:**
+
 1. **SEO & Organic Growth** - Tips, case studies, algorithm updates.
 2. **Content Marketing** - Strategy, writing, distribution, repurposing.
 3. **Conversion Optimization** - Landing pages, CTAs, A/B testing, UX.
@@ -41,6 +42,7 @@ variety while maintaining brand relevance.
 5. **Industry Trends** - Marketing news, data, predictions.
 
 **Example for a personal brand (marketing consultant):**
+
 1. **Tactical Marketing Tips** - Actionable how-to content.
 2. **Client Stories & Case Studies** - Results and lessons learned.
 3. **Personal Journey** - Career insights, failures, learnings.
@@ -125,21 +127,25 @@ Assign recurring themes to days of the week for consistency and reduced planning
 ### Platform-Specific Optimal Posting Times
 
 **Twitter/X:**
+
 - Weekdays: 8-10am, 12-1pm, 5-6pm (audience timezone)
 - Weekends: 9-11am
 - Best day: Tuesday and Wednesday
 
 **LinkedIn:**
+
 - Weekdays: 7-8am, 12pm, 5-6pm
 - Best days: Tuesday, Wednesday, Thursday
 - Avoid weekends (60% lower engagement)
 
 **Instagram:**
+
 - Weekdays: 11am-1pm, 7-9pm
 - Weekends: 10am-12pm
 - Best days: Monday, Wednesday, Friday
 
 **TikTok:**
+
 - Every day: 7-9am, 12-3pm, 7-11pm
 - Best days: Tuesday, Thursday, Friday
 - Post when your Analytics tab shows your audience is most active
@@ -270,10 +276,13 @@ content types and test new formats or platforms.
 For every content calendar request, deliver:
 
 ### 1. Content Pillars and Mix
+
 Defined pillars with percentage allocations and the 80/20 breakdown.
 
 ### 2. Calendar
+
 Monthly or weekly view in table format with:
+
 - Date and day
 - Platform
 - Content type and format
@@ -282,16 +291,21 @@ Monthly or weekly view in table format with:
 - Status (idea, draft, designed, scheduled, published)
 
 ### 3. Theme Day Schedule
+
 Day-by-day theme assignments with rationale.
 
 ### 4. Batch Workflow
+
 Customized batch schedule based on team size and capacity.
 
 ### 5. Posting Times
+
 Platform-specific recommended posting times based on the user's audience.
 
 ### 6. Content Bank
+
 Starter list of 20-30 content ideas organized by pillar.
 
 ### 7. Metrics Dashboard
+
 Template for tracking weekly and monthly performance.

--- a/.claude/skills/content-gap-analysis/SKILL.md
+++ b/.claude/skills/content-gap-analysis/SKILL.md
@@ -18,6 +18,7 @@ Inventory the user's current content:
 3. **Map topics covered** — What keywords/topics does each page target?
 
 If the user has a codebase, check:
+
 - Blog post files/directories
 - MDX/markdown content files
 - CMS entries or database content
@@ -31,6 +32,7 @@ For 2-3 competitors, gather their content:
 3. **Categorize their content** by topic cluster
 
 If SemRush API is available:
+
 ```bash
 # Get competitor's top organic keywords
 curl -s "https://api.semrush.com/?type=domain_organic&key=${SEMRUSH_API_KEY}&domain={competitor}&database=us&export_columns=Ph,Po,Nq,Cp,Co,Tr,Tc&display_limit=100"
@@ -51,6 +53,7 @@ curl -s "https://api.semrush.com/?type=domain_organic&key=${SEMRUSH_API_KEY}&dom
 **Gap = Keywords competitors rank for that you don't.**
 
 Filter gaps by:
+
 - Search volume > 100/month
 - Keyword difficulty < 60 (achievable)
 - Relevant to your business

--- a/.claude/skills/content-repurposing/SKILL.md
+++ b/.claude/skills/content-repurposing/SKILL.md
@@ -35,12 +35,14 @@ You are a content repurposing expert. Take one piece of content and transform it
 ### Recipe 1: Blog Post → Twitter/X Thread
 
 **Process:**
+
 1. Extract the core thesis (this becomes the hook tweet)
 2. Pull 5-10 key points (each becomes a tweet)
 3. Add a personal take or story (for engagement)
 4. End with a CTA tweet
 
 **Format:**
+
 ```
 🧵 {Hook: Bold claim or surprising insight from the article}
 
@@ -54,6 +56,7 @@ You are a content repurposing expert. Take one piece of content and transform it
 ```
 
 **Rules:**
+
 - Each tweet must stand alone (people see individual tweets in feeds)
 - Use numbers or bullet points for scannability
 - Add 1-2 relevant images or data visualizations
@@ -62,12 +65,14 @@ You are a content repurposing expert. Take one piece of content and transform it
 ### Recipe 2: Blog Post → LinkedIn Carousel
 
 **Process:**
+
 1. Extract 7-10 actionable takeaways
 2. Write a hook slide (title + subtitle)
 3. One takeaway per slide with minimal text
 4. Add a CTA final slide
 
 **Format:**
+
 ```
 SLIDE 1 (Cover): {Compelling title}
 {Subtitle: "X lessons from..." or "How to..."}
@@ -82,6 +87,7 @@ SLIDE 10 (CTA): {Follow / Save / Visit link}
 ```
 
 **Rules:**
+
 - Large, readable text (imagine reading on a phone)
 - Max 3 lines of text per slide
 - Use contrasting colors for key words
@@ -90,12 +96,14 @@ SLIDE 10 (CTA): {Follow / Save / Visit link}
 ### Recipe 3: Blog Post → Newsletter Section
 
 **Process:**
+
 1. Write a 2-sentence personal intro connecting to the topic
 2. Summarize the 3 most actionable insights
 3. Add your unique take or commentary
 4. Link to the full post
 
 **Format:**
+
 ```markdown
 ## {Section title}
 
@@ -117,12 +125,14 @@ Here are the 3 biggest takeaways:
 ### Recipe 4: Blog Post → Video Script (60-90 seconds)
 
 **Process:**
+
 1. Open with the most surprising/useful point (hook: 5 seconds)
 2. Quick context on why it matters (10 seconds)
 3. 3 key points, rapid-fire (45 seconds)
 4. CTA (10 seconds)
 
 **Format:**
+
 ```
 HOOK (0-5s): "{Surprising statement or question from the article}"
 
@@ -140,6 +150,7 @@ CTA (60-70s): "Follow for more {topic} content. Link to the full breakdown in my
 ### Recipe 5: Podcast Episode → Blog Post
 
 **Process:**
+
 1. Extract the main topic and thesis
 2. Identify 5-8 distinct segments/talking points
 3. Pull specific quotes and stories
@@ -149,11 +160,13 @@ CTA (60-70s): "Follow for more {topic} content. Link to the full breakdown in my
 ### Recipe 6: Podcast Episode → Quote Cards
 
 **Process:**
+
 1. Find 5-10 quotable moments (surprising, insightful, or contrarian)
 2. Keep quotes under 30 words each
 3. Format with speaker attribution
 
 **Output per quote:**
+
 ```
 "{Quote text}" — {Speaker Name}
 
@@ -164,6 +177,7 @@ Best for: {Platform — Instagram, LinkedIn, Twitter}
 ### Recipe 7: Video → GIF Clips + Social Posts
 
 **Process:**
+
 1. Identify 3-5 key moments (reactions, demonstrations, key statements)
 2. Note timestamps for each clip (3-10 seconds each)
 3. Write a social caption for each clip
@@ -186,9 +200,11 @@ When repurposing, adjust for each platform:
 ## Repurposing Workflow
 
 ### Step 1: Identify Source Content
+
 Ask or infer: What is the pillar content? (URL, text, transcript, etc.)
 
 ### Step 2: Extract Core Elements
+
 - **Thesis:** The one big idea
 - **Key points:** 5-10 supporting arguments or insights
 - **Stories/examples:** Specific anecdotes that illustrate points
@@ -197,6 +213,7 @@ Ask or infer: What is the pillar content? (URL, text, transcript, etc.)
 - **Action items:** Concrete steps the reader can take
 
 ### Step 3: Map to Target Platforms
+
 Based on the user's channels, create a repurposing plan:
 
 ```markdown
@@ -217,10 +234,13 @@ Based on the user's channels, create a repurposing plan:
 ```
 
 ### Step 4: Create Each Piece
+
 Write each content piece following the platform-specific rules above.
 
 ### Step 5: Scheduling Recommendation
+
 Stagger content across days/weeks for maximum reach:
+
 - Day 1: Publish pillar content
 - Day 1-2: Twitter thread + LinkedIn post
 - Day 3-4: Carousel + newsletter mention

--- a/.claude/skills/content-strategy/SKILL.md
+++ b/.claude/skills/content-strategy/SKILL.md
@@ -41,6 +41,7 @@ each other. This structure signals topical authority to search engines.
 List 3-5 core topics that align with your product and audience needs.
 
 Example for a project management SaaS:
+
 - Project management methodologies
 - Team productivity
 - Remote work collaboration
@@ -119,6 +120,7 @@ Map every piece of content to a buyer journey stage.
 **Reader mindset:** "I have a problem but don't know the solution yet."
 
 **Content types:**
+
 - Blog posts answering "what is" and "why" questions
 - Educational guides and how-to articles
 - Industry reports and trend pieces
@@ -136,6 +138,7 @@ Map every piece of content to a buyer journey stage.
 **Reader mindset:** "I know the solution category. Which option is best for me?"
 
 **Content types:**
+
 - Comparison articles (X vs Y)
 - "Best [category] for [use case]" listicles
 - Case studies
@@ -154,6 +157,7 @@ Map every piece of content to a buyer journey stage.
 **Reader mindset:** "I'm ready to buy. Convince me this is the right choice."
 
 **Content types:**
+
 - Product landing pages
 - Pricing pages
 - Customer testimonials and success stories
@@ -172,6 +176,7 @@ Map every piece of content to a buyer journey stage.
 **Reader mindset:** "How do I get the most from this product?"
 
 **Content types:**
+
 - Onboarding guides and tutorials
 - Best practices and tips
 - Product update announcements
@@ -217,18 +222,21 @@ Follow this ratio for a balanced content strategy:
 For every piece of content, plan distribution across these channels:
 
 ### Owned Channels
+
 - **Blog** - Publish the full piece.
 - **Newsletter** - Summarize with a link to full article.
 - **Social media** - Create 3-5 social posts per article (see below).
 - **Podcast/video** - Repurpose written content into audio/video.
 
 ### Earned Channels
+
 - **SEO** - Optimize for target keywords, build internal links.
 - **Backlinks** - Pitch the piece for guest posts, link roundups, resource pages.
 - **PR** - If newsworthy, pitch to journalists and industry publications.
 - **Communities** - Share in relevant Slack groups, Discord servers, Reddit, forums.
 
 ### Paid Channels
+
 - **Social ads** - Boost top-performing organic posts.
 - **Retargeting** - Show content to website visitors who did not convert.
 - **Sponsored newsletters** - Place in niche industry newsletters.
@@ -254,26 +262,34 @@ Turn one blog post into 8+ pieces of content:
 When building a content strategy, deliver:
 
 ### 1. Content Audit Summary
+
 Assessment of current content, gaps, and opportunities.
 
 ### 2. Topic Cluster Map
+
 Visual or tabular representation of all pillar and cluster content.
 
 ### 3. Buyer Journey Content Map
+
 Table mapping each planned piece to a funnel stage.
 
 ### 4. 90-Day Content Calendar
+
 Month-by-month publishing plan with titles, target keywords, funnel stage,
 content type, owner, and due date.
 
 ### 5. Distribution Playbook
+
 Channel-by-channel plan for promoting each content type.
 
 ### 6. KPI Dashboard
+
 Metrics to track for each funnel stage with targets.
 
 ### 7. Content Briefs
+
 For the first month's content, provide detailed content briefs including:
+
 - Title and target keyword
 - Search intent
 - Outline (H2s and H3s)

--- a/.claude/skills/copy-editing/SKILL.md
+++ b/.claude/skills/copy-editing/SKILL.md
@@ -19,6 +19,7 @@ Follow this exact sequence for every editing job:
 ### Step 1: Read the Full Piece
 
 Read the entire piece before making any edits. Understand:
+
 - What is the goal of this copy? (Convert, inform, persuade, nurture)
 - Who is the audience?
 - What tone is intended?
@@ -27,6 +28,7 @@ Read the entire piece before making any edits. Understand:
 ### Step 2: Structural Review
 
 Before line edits, assess the overall structure:
+
 - Does the opening hook the reader immediately?
 - Is there a logical flow from problem to solution to CTA?
 - Are there sections that should be reordered, merged, or cut entirely?
@@ -126,6 +128,7 @@ audience. Know your reader.
 **Rule:** Marketing copy must make the reader feel something. Facts inform. Emotions convert.
 
 **Techniques:**
+
 - **Specificity creates emotion.** "Save time" is weak. "Get home for dinner instead of staying
   late to fix reports" is strong.
 - **Use sensory language.** "See your revenue dashboard light up green" beats "Track revenue."
@@ -194,6 +197,7 @@ Score every piece using Flesch-Kincaid Grade Level:
 | 12+ | Expert | Probably too complex. Simplify. |
 
 **How to estimate without tools:**
+
 - Count sentences in a 100-word sample.
 - Count words with 3+ syllables.
 - Fewer long words and more sentences = lower grade level.
@@ -205,12 +209,15 @@ Score every piece using Flesch-Kincaid Grade Level:
 For every editing job, deliver:
 
 ### 1. Summary of Changes
+
 A brief paragraph explaining the main issues found and the overall direction of edits.
 
 ### 2. Edited Copy
+
 The full edited piece with changes applied.
 
 ### 3. Change Log
+
 A table of significant changes:
 
 | Location | Original | Edited | Reason |
@@ -219,10 +226,13 @@ A table of significant changes:
 | Para 2, Sent 1 | "We have the ability to help you..." | "We help you..." | Conciseness |
 
 ### 4. Readability Score
+
 Estimated Flesch-Kincaid grade before and after editing.
 
 ### 5. Remaining Suggestions
+
 Things the user should consider that go beyond copy editing:
+
 - Structural changes
 - Missing sections (social proof, CTA, FAQ)
 - Opportunities to add data or proof points

--- a/.claude/skills/copywriting/SKILL.md
+++ b/.claude/skills/copywriting/SKILL.md
@@ -136,24 +136,28 @@ Use 1-2 power words per headline or CTA. Rotate to avoid repetition.
 ## Tone Guidelines
 
 ### Professional
+
 - Use complete sentences and proper grammar.
 - Avoid slang, contractions (selectively), and exclamation marks.
 - Lead with data, credentials, and specificity.
 - Suitable for: B2B, enterprise, finance, legal, healthcare.
 
 ### Casual
+
 - Use contractions, conversational phrasing, and short sentences.
 - Address the reader as "you". Write like you are talking to a friend.
 - Use analogies and everyday language.
 - Suitable for: DTC, consumer apps, lifestyle brands.
 
 ### Urgent
+
 - Short sentences. Fragments are fine.
 - Use time-bound language: "Today only", "Ends midnight", "Only 3 spots left".
 - Bold the most important phrases.
 - Suitable for: Sales, launches, limited offers, flash deals.
 
 ### Authoritative
+
 - Use declarative statements. Avoid hedging words (might, maybe, could).
 - Cite sources, data points, and results.
 - Position the brand as the definitive expert.

--- a/.claude/skills/demand-gen/SKILL.md
+++ b/.claude/skills/demand-gen/SKILL.md
@@ -37,24 +37,28 @@ POST-SALE                → Expansion & Advocacy
 ### Campaign Types
 
 **1. Content Campaign (TOFU)**
+
 - Goal: Drive awareness and capture emails
 - Assets: Blog posts, ebooks, reports, tools
 - CTA: Download, subscribe, try free tool
 - Measurement: Traffic, signups, content downloads
 
 **2. Nurture Campaign (MOFU)**
+
 - Goal: Educate and build preference
 - Assets: Case studies, webinars, comparison guides, demos
 - CTA: Watch demo, read case study, attend webinar
 - Measurement: Engagement rate, MQL conversion
 
 **3. Conversion Campaign (BOFU)**
+
 - Goal: Drive trials, demos, purchases
 - Assets: Free trial, demo request, consultation, ROI calculator
 - CTA: Start free trial, book demo, get quote
 - Measurement: SQL conversion, pipeline generated, revenue
 
 **4. ABM Campaign (Targeted)**
+
 - Goal: Engage specific high-value accounts
 - Assets: Personalized content, direct mail, executive dinners
 - CTA: Custom per account

--- a/.claude/skills/discord-bot/SKILL.md
+++ b/.claude/skills/discord-bot/SKILL.md
@@ -700,16 +700,20 @@ When the user asks to post to Discord:
 For every Discord posting request, deliver:
 
 ### 1. Message Preview
+
 - Full message content (plain text + embeds) formatted for readability.
 - Visual description of what the embed will look like.
 - Character counts for fields approaching limits.
 
 ### 2. API Payload
+
 - The complete curl command ready to execute.
 - All variables resolved (webhook URL, channel ID, etc.).
 
 ### 3. Post-Send Report
+
 After posting:
+
 - HTTP response status.
 - Message ID (for editing or deleting later).
 - Direct link to the message if possible (`https://discord.com/channels/GUILD_ID/CHANNEL_ID/MESSAGE_ID`).

--- a/.claude/skills/domain-research/SKILL.md
+++ b/.claude/skills/domain-research/SKILL.md
@@ -16,6 +16,7 @@ curl -s "https://mcp.domaindetails.com/lookup/{domain}" | jq
 ```
 
 Returns:
+
 - **Registrar:** Who the domain is registered through
 - **Created date:** When the domain was first registered
 - **Expiry date:** When it expires
@@ -31,6 +32,7 @@ curl -s "https://api.domaindetails.com/api/marketplace/search?domain={domain}" |
 ```
 
 Checks listings across:
+
 - **Sedo** — Largest domain marketplace
 - **Afternic** — GoDaddy's marketplace
 - **Atom** — Premium domains
@@ -97,6 +99,7 @@ curl -s "https://api.domaindetails.com/api/marketplace/search?domain={domain}" |
 ### Step 3: Check Domain History
 
 Use WebFetch to check:
+
 - `web.archive.org/web/*/{domain}` — Past versions of the site
 - Historical use, content type, any red flags
 
@@ -115,6 +118,7 @@ curl -s "https://api.semrush.com/?type=backlinks_overview&key=${SEMRUSH_API_KEY}
 If the desired domain is taken, suggest alternatives:
 
 **Patterns:**
+
 - `get{brand}.com` — getnotion.com
 - `{brand}hq.com` — slackhq.com
 - `try{brand}.com` — tryfigma.com

--- a/.claude/skills/email-sequence/SKILL.md
+++ b/.claude/skills/email-sequence/SKILL.md
@@ -32,6 +32,7 @@ Before creating any sequence, collect these inputs:
 ## Universal Email Principles
 
 ### Subject Line Rules
+
 - Keep between 30-50 characters (6-10 words).
 - Front-load the most important word.
 - Use lowercase for a casual feel, title case for professional.
@@ -40,12 +41,14 @@ Before creating any sequence, collect these inputs:
 - A/B test every subject line in your ESP.
 
 ### Preview Text Rules
+
 - Always write custom preview text (40-90 characters).
 - Do not repeat the subject line.
 - Complement the subject line by adding context or intrigue.
 - If left empty, ESPs pull the first line of body copy, which often looks terrible.
 
 ### Email Structure
+
 1. **Hook** (first 2 lines) - Must earn the scroll. Ask a question, state a bold claim,
    or reference something personal.
 2. **Body** (3-8 sentences) - One idea per email. Do not try to cover everything.
@@ -64,6 +67,7 @@ Before creating any sequence, collect these inputs:
 ### Segmentation Rules
 
 Segment sequences based on:
+
 - **Behavior** - Pages visited, features used, emails opened, links clicked.
 - **Demographics** - Industry, company size, role, location.
 - **Lifecycle stage** - New lead, trial user, paying customer, churned user.
@@ -162,6 +166,7 @@ Segment sequences based on:
 ### Spam Trigger Avoidance
 
 **Avoid these in subject lines and body:**
+
 - ALL CAPS words (e.g., "FREE", "BUY NOW", "CLICK HERE")
 - Excessive exclamation marks (!!!)
 - Spam trigger phrases: "Act now", "Limited time", "You've been selected", "Congratulations",
@@ -266,11 +271,14 @@ curl -X POST https://api.resend.com/emails/batch \
 For every email sequence, deliver:
 
 ### 1. Sequence Overview
+
 - Sequence name, goal, trigger, audience segment.
 - Visual flow diagram (text-based).
 
 ### 2. Individual Emails
+
 For each email in the sequence:
+
 - **Email number and name** (e.g., "Email 3: Social Proof")
 - **Timing** (delay from previous email or trigger)
 - **Subject line** (primary + 2 A/B variants)
@@ -282,10 +290,13 @@ For each email in the sequence:
 - **Branch logic** (if applicable: what happens if they open/click/don't)
 
 ### 3. Segmentation Rules
+
 Who enters this sequence, who exits, and any branch conditions.
 
 ### 4. Success Metrics
+
 Target open rates, click rates, and conversion rates for each email.
 
 ### 5. A/B Test Plan
+
 Recommended tests for the first 30 days (subject lines, send times, CTA copy).

--- a/.claude/skills/email-subject-lines/SKILL.md
+++ b/.claude/skills/email-subject-lines/SKILL.md
@@ -36,6 +36,7 @@ Before generating subject lines, collect these inputs:
 **Target: 30-50 characters (6-10 words).** This range is fully visible on mobile and desktop.
 
 **Mobile preview widths:**
+
 - iPhone: ~35-40 characters
 - Android: ~33-43 characters
 - Gmail app: ~40 characters
@@ -57,6 +58,7 @@ Create an information gap that can only be closed by opening the email.
 | "I was wrong about cold email" | Contrarian + personal admission |
 
 **Rules:**
+
 - Do not be vague to the point of irrelevance ("You won't believe this!").
 - The email body must deliver on the curiosity promise.
 - Use sparingly; overuse trains subscribers to distrust.
@@ -74,6 +76,7 @@ Create time pressure that motivates immediate action.
 | "Flash sale: 6 hours only" | Time-limited |
 
 **Rules:**
+
 - Urgency must be real. Fake urgency destroys trust permanently.
 - Do not use urgency in every email. Reserve for genuine time-sensitive offers.
 - Avoid all-caps urgency words (LAST CHANCE, HURRY).
@@ -92,6 +95,7 @@ Use subscriber data to make the subject feel individually crafted.
 | "[Name], you left items in your cart" | Name + behavior |
 
 **Rules:**
+
 - Personalization boosts open rates by 10-20% on average.
 - Do not overuse first names. If every email starts with "[Name]," it loses effect.
 - Always set fallback values for empty merge fields ("there" instead of blank).
@@ -110,6 +114,7 @@ Pose a question the reader wants answered.
 | "Can you write a landing page in 30 min?" | Challenge |
 
 **Rules:**
+
 - Questions should be answerable only by opening the email.
 - Avoid yes/no questions where the answer is obvious.
 - Rhetorical questions ("Want to make more money?") feel spammy.
@@ -128,6 +133,7 @@ Include a specific number for concreteness and scannability.
 | "11 subject line formulas (steal these)" | Odd numbers outperform even |
 
 **Rules:**
+
 - Odd numbers (3, 5, 7, 9, 11) tend to outperform even numbers.
 - Specific numbers (247%) outperform round numbers (250%).
 - Use digits, not words ("7" not "seven") for visual impact in the inbox.
@@ -145,6 +151,7 @@ Promise a practical, actionable skill or outcome.
 | "How top founders write investor updates" | How [authority] [does thing] |
 
 **Rules:**
+
 - "How to" subjects set a learning expectation. The email must teach.
 - Pair with a specific, measurable outcome when possible.
 - Avoid vague how-to's ("How to improve your marketing").
@@ -162,6 +169,7 @@ Challenge a widely held belief to provoke engagement.
 | "Forget about SEO for 6 months" | SEO is always important |
 
 **Rules:**
+
 - You must back up the contrarian claim in the email body.
 - Do not be contrarian for shock value alone. Have a genuine insight.
 - This formula generates high opens AND high unsubscribes. Use intentionally.
@@ -301,6 +309,7 @@ rates in your Resend dashboard.
 For every subject line request, deliver:
 
 ### 1. Subject Line Options (10-15)
+
 Organized by formula type with character count:
 
 ```
@@ -316,9 +325,11 @@ URGENCY
 ```
 
 ### 2. Top 3 Recommendations
+
 Ranked by predicted open rate with reasoning.
 
 ### 3. A/B Test Pairs
+
 3 recommended A/B pairs with hypothesis for each:
 
 ```
@@ -329,4 +340,5 @@ Test 1: Curiosity vs. Direct
 ```
 
 ### 4. Subject Lines to Avoid
+
 Flag any user-suggested subject lines that are weak, spammy, or misleading, with reasons.

--- a/.claude/skills/feishu-lark/SKILL.md
+++ b/.claude/skills/feishu-lark/SKILL.md
@@ -36,21 +36,25 @@ echo "FEISHU_APP_SECRET is ${FEISHU_APP_SECRET:+set}"
 If no credentials are set, instruct the user:
 
 > **Custom Bot Webhook (quickest setup):**
+>
 > 1. Open a Feishu/Lark group chat
 > 2. Click the group name at the top to open Group Settings
 > 3. Go to **Bots** > **Add Bot** > **Custom Bot**
 > 4. Name the bot and optionally set a Signature Verification secret
 > 5. Copy the webhook URL and add to `.env`:
+>
 >    ```
 >    FEISHU_WEBHOOK_URL=https://open.feishu.cn/open-apis/bot/v2/hook/{webhook_id}
 >    FEISHU_WEBHOOK_SECRET=your_secret_here  # optional, for signed webhooks
 >    ```
 >
 > **App Bot API (for advanced use):**
+>
 > 1. Go to [Feishu Open Platform](https://open.feishu.cn/app) or [Lark Developer Console](https://open.larksuite.com/app)
 > 2. Create a new app, enable the Bot capability
 > 3. Add required permissions: `im:message:send_as_bot`, `im:chat:readonly`
 > 4. Publish and approve the app, then add to `.env`:
+>
 >    ```
 >    FEISHU_APP_ID=cli_xxxxx
 >    FEISHU_APP_SECRET=xxxxx
@@ -202,6 +206,7 @@ curl -s -X POST "${FEISHU_WEBHOOK_URL}" \
 ```
 
 **Feishu signature algorithm details:**
+
 1. Concatenate `timestamp + "\n" + secret` as the string to sign
 2. Compute HMAC-SHA256 with an empty key over that string
 3. Base64-encode the result
@@ -853,16 +858,19 @@ curl -s -X POST "${FEISHU_WEBHOOK_URL}" \
 ### Common Troubleshooting
 
 **Message not delivered:**
+
 - Verify the webhook URL is correct and the bot is still in the group
 - Check that `msg_type` matches the content structure
 - For signed webhooks, ensure the timestamp is within 1 hour of current time
 
 **Card not rendering:**
+
 - Validate JSON structure: header and elements are both required
 - Button URLs must start with `http://` or `https://`
 - Markdown in cards supports a limited subset: bold, italic, links, lists, tables
 
 **API token errors:**
+
 - Tenant access tokens expire after 2 hours; re-fetch before sending
 - Ensure the app has been published and approved in the developer console
 - Verify `im:message:send_as_bot` permission is granted

--- a/.claude/skills/geo-query-finder/SKILL.md
+++ b/.claude/skills/geo-query-finder/SKILL.md
@@ -23,6 +23,7 @@ Use when the user asks to "find queries for [brand]", "check GEO visibility", "w
 ```
 
 **Examples:**
+
 - `/geo-query-finder "Acme Corp"` — auto-researches the brand and generates queries
 - `/geo-query-finder "Acme Corp" --industry "smart TV OS" --features "white-label,voice-control,OEM licensing"`
 - `/geo-query-finder "Acme Corp" --queries "best regulatory AI;eCTD validation tool;pharma compliance software"`
@@ -45,11 +46,13 @@ curl -s -X POST "https://api.dataforseo.com/v3/ai_optimization/llm_mentions/sear
 ```
 
 **Critical flags:**
+
 - `"include_subdomains": true` — without it, apex domains return 0 results (www.X treated as a different domain).
 - Omit `location_code` to get global results; add `"location_code": 2840` only to scope to US.
 - `platform` options: `"google"` (AI Overview), `"chat_gpt"`. Perplexity is NOT supported via this dataset.
 
 **Extract from each `items[]`:**
+
 - `question` — the real search query where the brand was cited
 - `ai_search_volume` — monthly AI search volume (use to prioritize)
 - `sources[]` — entries with `domain` matching the brand have the exact cited URL
@@ -57,18 +60,23 @@ curl -s -X POST "https://api.dataforseo.com/v3/ai_optimization/llm_mentions/sear
 - `answer` — the LLM answer text (for context)
 
 **Decision rule:**
+
 - If ≥20 queries returned → skip Steps 1–4 entirely; report these as ground-truth mentions and focus Step 5 on gap analysis (sort by volume, find URL-section winners like `/guides/` vs `/tools/`).
 - If <20 queries → use them as seed input for Step 2 (generate variations of the query themes DataForSEO already confirmed), then run Steps 3–4 only on the gaps.
 - If 0 queries → the domain has no AI citations; proceed with the original Steps 1–5 (speculative testing) as fallback.
 
 ### Step 1: Research the Brand
+
 If no `--industry` or `--features` provided, use web search to understand:
+
 - What the brand does / what industry it's in
 - Key differentiators vs competitors
 - Unique features that competitors DON'T have
 
 ### Step 2: Generate Long-Tail Queries
+
 Generate 15-20 long-tail queries across these categories:
+
 1. **Feature-specific** (unique capabilities only this brand has)
 2. **B2B/decision-maker** (queries from buyers, not consumers)
 3. **Problem-solving** ("how to X without Y")
@@ -114,6 +122,7 @@ answer = result["choices"][0]["message"]["content"]
 ### Step 4: Check Mentions
 
 For each query, check if the brand name (or known aliases) appears in ChatGPT's response:
+
 - Check case-insensitive match
 - Check variations (with/without spaces, dots, hyphens)
 - If mentioned, extract the surrounding context (200 chars around the mention)

--- a/.claude/skills/google-ads-report/SKILL.md
+++ b/.claude/skills/google-ads-report/SKILL.md
@@ -15,6 +15,7 @@ Pull campaign, keyword, and conversion data from the Google Ads API.
 ## Prerequisites
 
 Requires:
+
 - `GOOGLE_CLIENT_ID` and `GOOGLE_CLIENT_SECRET` (OAuth)
 - `GOOGLE_ADS_DEVELOPER_TOKEN` (apply at https://ads.google.com/home/tools/manager-accounts/)
 - `GOOGLE_ADS_CUSTOMER_ID` (the account ID, format: `XXX-XXX-XXXX`, passed without dashes)
@@ -50,6 +51,7 @@ POST https://googleads.googleapis.com/v17/customers/{CUSTOMER_ID}/googleAds:sear
 ```
 
 Headers:
+
 ```
 Authorization: Bearer {ACCESS_TOKEN}
 developer-token: {DEVELOPER_TOKEN}
@@ -128,6 +130,7 @@ curl -s -X POST \
 ```
 
 Quality Score Components:
+
 - **quality_score**: Overall score (1-10)
 - **creative_quality_score**: Ad relevance (BELOW_AVERAGE, AVERAGE, ABOVE_AVERAGE)
 - **post_click_quality_score**: Landing page experience
@@ -166,6 +169,7 @@ curl -s -X POST \
 ```
 
 Use this to:
+
 - Find new keyword opportunities (high-converting search terms)
 - Identify negative keyword candidates (irrelevant terms with spend)
 - Discover match type issues (broad match pulling in junk traffic)
@@ -224,6 +228,7 @@ curl -s -X POST \
 ## GAQL Date Ranges
 
 Use these built-in date ranges in GAQL:
+
 - `TODAY`, `YESTERDAY`
 - `LAST_7_DAYS`, `LAST_14_DAYS`, `LAST_30_DAYS`
 - `THIS_MONTH`, `LAST_MONTH`

--- a/.claude/skills/google-ads/SKILL.md
+++ b/.claude/skills/google-ads/SKILL.md
@@ -79,10 +79,12 @@ Display URL path 2 (max 15 characters): [Offer or category]
 ### Responsive Search Ads (RSA)
 
 Provide exactly:
+
 - **15 headlines** (max 30 chars each)
 - **4 descriptions** (max 90 chars each)
 
 Pin only when necessary:
+
 - Pin your brand name headline to Position 1 or 2
 - Pin your strongest CTA headline to Position 2 or 3
 - Leave remaining slots unpinned to let Google optimize
@@ -154,7 +156,9 @@ Performance Max requires a full asset package:
 Always recommend and write copy for these extensions:
 
 ### Sitelink Extensions
+
 Provide 4-8 sitelinks:
+
 ```
 Sitelink headline (max 25 chars): [Page name]
 Description line 1 (max 35 chars): [What they'll find]
@@ -163,24 +167,31 @@ Final URL: [Specific page URL]
 ```
 
 ### Callout Extensions
+
 Provide 4-6 callouts (max 25 chars each):
+
 - Highlight USPs: "Free Shipping Over $50"
 - Trust signals: "4.9 Star Rating"
 - Features: "24/7 Support"
 
 ### Structured Snippets
+
 Choose a header and provide 3+ values:
+
 - Types: Brands, Courses, Destinations, Featured Hotels, Insurance Coverage, Models, Neighborhoods, Service Catalog, Shows, Styles, Types
 
 ### Call Extensions
+
 - Include phone number if the business accepts calls
 - Set call reporting and call schedule
 
 ### Price Extensions
+
 - At least 3 items with price, description, and URL
 - Use the correct price qualifier (from, up to, average)
 
 ### Image Extensions
+
 - Square (1:1) and landscape (1.91:1) images
 - Must be relevant to the ad and landing page
 
@@ -189,18 +200,21 @@ Choose a header and provide 3+ values:
 Quality Score is determined by three factors. Optimize each:
 
 ### 1. Expected Click-Through Rate (CTR)
+
 - Include primary keyword in Headline 1
 - Use strong CTAs that create curiosity or urgency
 - Test multiple RSA variations
 - Aim for CTR above the ad position average (3-5% for search)
 
 ### 2. Ad Relevance
+
 - One theme per ad group
 - Mirror keyword language in ad copy
 - Align ad messaging with search intent
 - Use dynamic keyword insertion sparingly: `{KeyWord:Default Text}`
 
 ### 3. Landing Page Experience
+
 - Landing page headline must match the ad promise
 - Page must load in under 3 seconds
 - Mobile-responsive design is mandatory
@@ -219,6 +233,7 @@ Quality Score is determined by three factors. Optimize each:
 | Full automation | Maximize Conversions | Sufficient conversion data, flexible CPA |
 
 ### Bidding Best Practices
+
 - Start with Maximize Conversions (no target) for new campaigns
 - Switch to Target CPA after 50+ conversions in 30 days
 - Set Target CPA at 20% above your actual average CPA, then decrease gradually

--- a/.claude/skills/google-analytics/SKILL.md
+++ b/.claude/skills/google-analytics/SKILL.md
@@ -15,6 +15,7 @@ Pull reports and insights from GA4 using the Google Analytics Data API.
 ## Prerequisites
 
 Requires Google OAuth credentials:
+
 - `GOOGLE_CLIENT_ID`
 - `GOOGLE_CLIENT_SECRET`
 - A valid OAuth access token (refreshed as needed)

--- a/.claude/skills/google-reviews/SKILL.md
+++ b/.claude/skills/google-reviews/SKILL.md
@@ -33,6 +33,7 @@ cd ~/.agents/tools && node fetch-google-reviews.js "Business Name" "City,Provinc
 ```
 
 Example:
+
 ```bash
 cd ~/.agents/tools && node fetch-google-reviews.js "Trust Auto Sales" "Richmond,British Columbia,Canada"
 ```
@@ -46,6 +47,7 @@ cd ~/.agents/tools && node fetch-google-reviews.js --batch /path/to/businesses.j
 ```
 
 JSON file format:
+
 ```json
 [
   {"keyword": "Business One", "location": "Vancouver,British Columbia,Canada"},
@@ -88,6 +90,7 @@ Prints a markdown table followed by full JSON:
 Use the DataForSEO location format: `City,Province/State,Country`
 
 Examples:
+
 - `Richmond,British Columbia,Canada`
 - `Vancouver,British Columbia,Canada`
 - `Toronto,Ontario,Canada`

--- a/.claude/skills/growth-strategy/SKILL.md
+++ b/.claude/skills/growth-strategy/SKILL.md
@@ -12,6 +12,7 @@ You are a growth strategist. Build data-driven growth frameworks using pirate me
 Every growth strategy starts with identifying the one metric that best captures the core value delivered to customers.
 
 **How to find it:**
+
 1. What action indicates a user is getting value?
 2. Is it measurable and actionable?
 3. Does improving it directly improve revenue?
@@ -65,31 +66,39 @@ Growth loops > funnels. Funnels are linear; loops compound.
 ### Types of Growth Loops
 
 **1. Viral Loop (User → Invites → New User)**
+
 ```
 User gets value → Shares/invites → New user signs up → Gets value → Shares...
 ```
+
 - Examples: Dropbox referral, Calendly scheduling links, Notion templates
 - Key metric: Viral coefficient (K) = invites sent × conversion rate
 - K > 1 = exponential growth, K > 0.5 = meaningful viral lift
 
 **2. Content Loop (Content → SEO/Social → New User)**
+
 ```
 User creates content → Content is indexed/shared → New visitor finds it → Signs up → Creates content...
 ```
+
 - Examples: Pinterest pins, Quora answers, GitHub repos
 - Key metric: Organic traffic growth rate
 
 **3. Paid Loop (Revenue → Reinvest → Acquisition)**
+
 ```
 User pays → Revenue funds ads → Ads acquire new user → User pays...
 ```
+
 - Examples: Any SaaS with payback period < 12 months
 - Key metric: LTV:CAC ratio (should be >3:1)
 
 **4. Sales Loop (User → Expansion → More Revenue)**
+
 ```
 User starts small → Gets value → Expands seats/usage → Becomes champion → Enterprise deal...
 ```
+
 - Examples: Slack, Figma, Notion (bottoms-up SaaS)
 - Key metric: Net revenue retention
 
@@ -121,6 +130,7 @@ Bad retention: Curve approaches zero (everyone churns eventually)
 ```
 
 **Analysis approach:**
+
 1. Plot weekly/monthly retention cohorts
 2. Find where the curve flattens (that's your "retained" base)
 3. Focus on getting more users past the flattening point

--- a/.claude/skills/hubspot/SKILL.md
+++ b/.claude/skills/hubspot/SKILL.md
@@ -29,12 +29,14 @@ Rate limit: 100 requests per 10 seconds for private apps.
 ### Contacts
 
 **List contacts:**
+
 ```bash
 curl -s "https://api.hubapi.com/crm/v3/objects/contacts?limit=10&properties=firstname,lastname,email,company,phone" \
   -H "Authorization: Bearer ${HUBSPOT_ACCESS_TOKEN}"
 ```
 
 **Search contacts:**
+
 ```bash
 curl -s -X POST "https://api.hubapi.com/crm/v3/objects/contacts/search" \
   -H "Authorization: Bearer ${HUBSPOT_ACCESS_TOKEN}" \
@@ -53,6 +55,7 @@ curl -s -X POST "https://api.hubapi.com/crm/v3/objects/contacts/search" \
 ```
 
 **Create contact:**
+
 ```bash
 curl -s -X POST "https://api.hubapi.com/crm/v3/objects/contacts" \
   -H "Authorization: Bearer ${HUBSPOT_ACCESS_TOKEN}" \
@@ -69,6 +72,7 @@ curl -s -X POST "https://api.hubapi.com/crm/v3/objects/contacts" \
 ```
 
 **Get contact by email:**
+
 ```bash
 curl -s -X POST "https://api.hubapi.com/crm/v3/objects/contacts/search" \
   -H "Authorization: Bearer ${HUBSPOT_ACCESS_TOKEN}" \
@@ -88,12 +92,14 @@ curl -s -X POST "https://api.hubapi.com/crm/v3/objects/contacts/search" \
 ### Companies
 
 **List companies:**
+
 ```bash
 curl -s "https://api.hubapi.com/crm/v3/objects/companies?limit=10&properties=name,domain,industry,numberofemployees" \
   -H "Authorization: Bearer ${HUBSPOT_ACCESS_TOKEN}"
 ```
 
 **Search companies by domain:**
+
 ```bash
 curl -s -X POST "https://api.hubapi.com/crm/v3/objects/companies/search" \
   -H "Authorization: Bearer ${HUBSPOT_ACCESS_TOKEN}" \
@@ -113,6 +119,7 @@ curl -s -X POST "https://api.hubapi.com/crm/v3/objects/companies/search" \
 ### Deals
 
 **Create deal:**
+
 ```bash
 curl -s -X POST "https://api.hubapi.com/crm/v3/objects/deals" \
   -H "Authorization: Bearer ${HUBSPOT_ACCESS_TOKEN}" \
@@ -129,12 +136,14 @@ curl -s -X POST "https://api.hubapi.com/crm/v3/objects/deals" \
 ```
 
 **List deals:**
+
 ```bash
 curl -s "https://api.hubapi.com/crm/v3/objects/deals?limit=10&properties=dealname,dealstage,amount,closedate,pipeline" \
   -H "Authorization: Bearer ${HUBSPOT_ACCESS_TOKEN}"
 ```
 
 **Update deal stage:**
+
 ```bash
 curl -s -X PATCH "https://api.hubapi.com/crm/v3/objects/deals/{dealId}" \
   -H "Authorization: Bearer ${HUBSPOT_ACCESS_TOKEN}" \
@@ -145,6 +154,7 @@ curl -s -X PATCH "https://api.hubapi.com/crm/v3/objects/deals/{dealId}" \
 ### Owners
 
 **List owners (sales reps):**
+
 ```bash
 curl -s "https://api.hubapi.com/crm/v3/owners/" \
   -H "Authorization: Bearer ${HUBSPOT_ACCESS_TOKEN}"
@@ -169,6 +179,7 @@ curl -s -X PUT "https://api.hubapi.com/crm/v3/objects/contacts/{contactId}/assoc
 ```
 
 **Get associated contacts for a deal:**
+
 ```bash
 curl -s "https://api.hubapi.com/crm/v3/objects/deals/{dealId}/associations/contacts" \
   -H "Authorization: Bearer ${HUBSPOT_ACCESS_TOKEN}"
@@ -177,6 +188,7 @@ curl -s "https://api.hubapi.com/crm/v3/objects/deals/{dealId}/associations/conta
 ### Properties
 
 **List all contact properties:**
+
 ```bash
 curl -s "https://api.hubapi.com/crm/v3/properties/contacts" \
   -H "Authorization: Bearer ${HUBSPOT_ACCESS_TOKEN}"
@@ -185,12 +197,14 @@ curl -s "https://api.hubapi.com/crm/v3/properties/contacts" \
 ### CMS Pages
 
 **List site pages:**
+
 ```bash
 curl -s "https://api.hubapi.com/cms/v3/pages/site-pages?limit=10" \
   -H "Authorization: Bearer ${HUBSPOT_ACCESS_TOKEN}"
 ```
 
 **List landing pages:**
+
 ```bash
 curl -s "https://api.hubapi.com/cms/v3/pages/landing-pages?limit=10" \
   -H "Authorization: Bearer ${HUBSPOT_ACCESS_TOKEN}"
@@ -212,6 +226,7 @@ curl -s "https://api.hubapi.com/cms/v3/pages/landing-pages?limit=10" \
 ### Pagination
 
 All list endpoints support pagination via the `after` parameter:
+
 ```bash
 curl -s "https://api.hubapi.com/crm/v3/objects/contacts?limit=100&after={next_cursor}" \
   -H "Authorization: Bearer ${HUBSPOT_ACCESS_TOKEN}"
@@ -222,17 +237,20 @@ The `after` value comes from `paging.next.after` in the response.
 ## Common Workflows
 
 ### Pipeline Report
+
 1. List all deals with `dealstage`, `amount`, `closedate`
 2. Group by stage
 3. Sum amounts per stage
 4. Present as pipeline summary table
 
 ### Contact Enrichment
+
 1. Search contacts missing key properties (`NOT_HAS_PROPERTY`)
 2. For each, check if company domain exists
 3. Pull company data and update contact
 
 ### Deal Health Check
+
 1. List deals in active stages
 2. Flag deals with no activity in 14+ days
 3. Flag deals past expected close date

--- a/.claude/skills/i18n/SKILL.md
+++ b/.claude/skills/i18n/SKILL.md
@@ -27,6 +27,7 @@ npm install next-intl
 Create 4 files under `src/i18n/`:
 
 ### `src/i18n/config.ts`
+
 ```typescript
 export const locales = ['en', 'es', 'fr', 'de', 'pt', 'ja', 'ar', 'zh', 'zh-tw', 'id', 'vi', 'ms', 'ru', 'hi'] as const
 
@@ -54,6 +55,7 @@ export const rtlLocales: Locale[] = ['ar']
 ```
 
 ### `src/i18n/routing.ts`
+
 ```typescript
 import { defineRouting } from 'next-intl/routing'
 import { defaultLocale, locales } from './config'
@@ -66,6 +68,7 @@ export const routing = defineRouting({
 ```
 
 ### `src/i18n/navigation.ts`
+
 ```typescript
 import { createNavigation } from 'next-intl/navigation'
 import { routing } from './routing'
@@ -74,6 +77,7 @@ export const { Link, redirect, usePathname, useRouter } = createNavigation(routi
 ```
 
 ### `src/i18n/request.ts`
+
 ```typescript
 import { getRequestConfig } from 'next-intl/server'
 import { routing } from './routing'
@@ -93,6 +97,7 @@ export default getRequestConfig(async ({ requestLocale }) => {
 ## Step 4: Create Middleware
 
 Create `src/middleware.ts`:
+
 ```typescript
 import createMiddleware from 'next-intl/middleware'
 import { routing } from '@/i18n/routing'
@@ -138,6 +143,7 @@ Move all page content under `src/app/[locale]/`:
 ## Step 7: Extract Strings into Translation Files
 
 1. Create `src/messages/en.json` with all user-facing strings organized by section:
+
    ```json
    {
      "common": { "signIn": "Sign In", ... },
@@ -147,12 +153,14 @@ Move all page content under `src/app/[locale]/`:
    ```
 
 2. Replace all hardcoded strings in components with `useTranslations()`:
+
    ```typescript
    const t = useTranslations('common')
    return <button>{t('signIn')}</button>
    ```
 
 3. For server components, use `getTranslations()`:
+
    ```typescript
    const t = await getTranslations('common')
    ```

--- a/.claude/skills/icp-builder/SKILL.md
+++ b/.claude/skills/icp-builder/SKILL.md
@@ -194,6 +194,7 @@ QUOTE: "[Representative mindset quote]"
 ## Step 9: Validation
 
 ### Checklist
+
 - [ ] Based on data (interviews, surveys, analytics), not just assumptions
 - [ ] 10+ customers/prospects match the profile
 - [ ] ICP customers have higher LTV and lower churn
@@ -202,6 +203,7 @@ QUOTE: "[Representative mindset quote]"
 - [ ] Documented and shared with all customer-facing teams
 
 ### When to Update
+
 After every 50 new customers, after pricing changes, after major features, after new market entry, quarterly minimum.
 
 ## Output Format

--- a/.claude/skills/keyword-research/SKILL.md
+++ b/.claude/skills/keyword-research/SKILL.md
@@ -24,34 +24,43 @@ Use `curl` via the Bash tool for all API calls. The base URL is `https://api.sem
 ### Core Endpoints
 
 **1. Keyword Overview (phrase_all)**
+
 ```
 https://api.semrush.com/?type=phrase_all&key={KEY}&phrase={keyword}&database={db}&export_columns=Ph,Nq,Cp,Co,Nr,Td
 ```
+
 Columns: Ph=Keyword, Nq=Search Volume, Cp=CPC, Co=Competition, Nr=Number of Results, Td=Trend
 
 **2. Related Keywords (phrase_related)**
+
 ```
 https://api.semrush.com/?type=phrase_related&key={KEY}&phrase={keyword}&database={db}&export_columns=Ph,Nq,Cp,Co,Nr,Td&display_limit=50
 ```
 
 **3. Keyword Questions (phrase_questions)**
+
 ```
 https://api.semrush.com/?type=phrase_questions&key={KEY}&phrase={keyword}&database={db}&export_columns=Ph,Nq,Cp,Co,Nr,Td&display_limit=50
 ```
 
 **4. Domain Organic Keywords (domain_organic)**
+
 ```
 https://api.semrush.com/?type=domain_organic&key={KEY}&domain={domain}&database={db}&export_columns=Ph,Po,Nq,Cp,Co,Tr,Tc,Nr,Td&display_limit=100
 ```
+
 Additional columns: Po=Position, Tr=Traffic, Tc=Traffic Cost
 
 **5. Keyword Difficulty (phrase_kdi)**
+
 ```
 https://api.semrush.com/?type=phrase_kdi&key={KEY}&phrase={keyword}&database={db}&export_columns=Ph,Kd
 ```
+
 Columns: Kd=Keyword Difficulty (0-100)
 
 ### Database Codes
+
 - `us` (United States - default)
 - `uk` (United Kingdom)
 - `ca` (Canada)
@@ -65,6 +74,7 @@ Ask the user for target market if not specified. Default to `us`.
 ### Step 1: Understand the Brief
 
 Ask or infer:
+
 - **Niche/Topic:** What is the site about?
 - **Target audience:** Who are they trying to reach?
 - **Business model:** How do they monetize? (SaaS, ecommerce, ads, affiliate)
@@ -77,6 +87,7 @@ Ask or infer:
 Generate 10-20 seed keywords based on the brief. Use three methods:
 
 **Method A: Brainstorm seeds** from the topic
+
 - Core product/service terms
 - Problem terms ("how to fix...", "why is...")
 - Audience terms (job titles, demographics)
@@ -111,6 +122,7 @@ Categorize every keyword into one of four intents:
 | **Transactional** | buy, price, discount, coupon, free trial, sign up | "semrush pricing" | Landing page, product page |
 
 **Intent classification rules:**
+
 - "how to" / "what is" / "why" = Informational
 - "{brand} + {feature}" = Navigational
 - "best" / "top" / "vs" / "alternative" / "review" = Commercial Investigation
@@ -137,6 +149,7 @@ Pillar Page: [Broad topic keyword - high volume, high difficulty]
 ```
 
 **Clustering rules:**
+
 - Pillar: Volume > 5,000, KD 40-80, broad topic
 - Cluster head: Volume 1,000-5,000, KD 20-50, specific subtopic
 - Supporting: Volume 100-1,000, KD < 30, long-tail variations
@@ -157,6 +170,7 @@ Where:
 ```
 
 **Priority tiers:**
+
 - KOB > 50: High priority - target first
 - KOB 20-50: Medium priority - target in months 2-3
 - KOB 5-20: Low priority - target later
@@ -269,6 +283,7 @@ curl -s -X POST "https://api.dataforseo.com/v3/keywords_data/google_ads/search_v
 ```
 
 Key fields:
+
 - **`search_volume`** - Average monthly search volume
 - **`competition`** - Competition level: "LOW", "MEDIUM", or "HIGH"
 - **`competition_index`** - Numeric competition score (0-100)
@@ -276,6 +291,7 @@ Key fields:
 - **`monthly_searches`** - Array of 12 monthly volume data points (useful for identifying seasonal trends)
 
 **Common location codes:**
+
 - `2840` - United States
 - `2826` - United Kingdom
 - `2124` - Canada
@@ -294,6 +310,7 @@ curl -s -X POST "https://api.dataforseo.com/v3/keywords_data/google_ads/keywords
 ```
 
 **When to use DataForSEO vs SemRush:**
+
 - Use **SemRush** as the primary source for keyword difficulty, competitor analysis, and domain organic keywords
 - Use **DataForSEO** for bulk search volume lookups (supports up to 700 keywords per request, more cost-effective for large batches)
 - Use **DataForSEO** when you need Google Ads-aligned data (their data comes directly from Google Keyword Planner)
@@ -324,6 +341,7 @@ curl -s "https://serpapi.com/search.json?q={keyword}&api_key=${SERPAPI_API_KEY}&
 ```
 
 Key response sections:
+
 - **`related_questions`** - Array of "People Also Ask" questions with snippets and source URLs
 - **`related_searches`** - Array of related search queries that Google suggests
 - **`organic_results`** - Top 10 organic results (useful for SERP analysis)
@@ -345,6 +363,7 @@ curl -s "https://serpapi.com/search.json?q={keyword}&api_key=${SERPAPI_API_KEY}&
 5. **Cluster building:** Group PAA questions and related searches by subtopic to identify natural content clusters.
 
 **Additional SerpAPI parameters:**
+
 - `location=United+States` - Geo-target the search
 - `gl=us` - Country code for Google domain
 - `hl=en` - Interface language

--- a/.claude/skills/launch-strategy/SKILL.md
+++ b/.claude/skills/launch-strategy/SKILL.md
@@ -27,6 +27,7 @@ Establish: product (new/feature/update), target audience, launch type (soft/beta
 ### Week 8-6: Foundation
 
 **Positioning**: One-sentence value prop. Elevator pitch (30s/60s/2min). Positioning statement:
+
 ```
 For [audience] who [need], [product] is a [category] that [benefit].
 Unlike [alternative], we [differentiator].
@@ -55,6 +56,7 @@ Unlike [alternative], we [differentiator].
 ## Step 4: Launch Week
 
 ### Day Before
+
 - [ ] Final QA of product, page, links
 - [ ] Queue social posts, pre-schedule email
 - [ ] Brief team on roles

--- a/.claude/skills/lead-magnet/SKILL.md
+++ b/.claude/skills/lead-magnet/SKILL.md
@@ -23,6 +23,7 @@ Design and build lead magnets that convert visitors into email subscribers and q
 **Conversion rate:** High (30-50% on dedicated landing pages)
 
 Template structure:
+
 ```
 Title: The Complete [Topic] Checklist
 
@@ -42,6 +43,7 @@ Bonus: [Extra tip or resource link]
 ```
 
 Example titles:
+
 - "The 47-Point Website Launch Checklist"
 - "Pre-Publish Blog Post Checklist (Never Miss a Step)"
 - "The Complete SEO Audit Checklist for 2025"
@@ -53,6 +55,7 @@ Example titles:
 **Conversion rate:** Very high (35-60%)
 
 Types of templates:
+
 - Spreadsheet templates (Google Sheets, Excel)
 - Document templates (Google Docs, Notion)
 - Design templates (Canva, Figma)
@@ -60,6 +63,7 @@ Types of templates:
 - Email templates (copy-paste ready)
 
 Template packaging:
+
 ```
 [Template Name]
 
@@ -84,6 +88,7 @@ EXAMPLE (filled in)
 **Conversion rate:** Very high (40-60%)
 
 Calculator ideas:
+
 - ROI calculator for your product
 - Cost savings estimator
 - "How much are you losing?" audit tool
@@ -91,6 +96,7 @@ Calculator ideas:
 - Carbon footprint / impact calculator
 
 Implementation notes:
+
 - Can be built as a simple HTML/JS page
 - Gate the results (not the calculator itself) behind email
 - Show a preview of results, require email for full report
@@ -103,6 +109,7 @@ Implementation notes:
 **Conversion rate:** Medium-high (25-40%)
 
 Structure:
+
 ```
 Course: [Title] -- [X]-Day [Topic] Course
 
@@ -132,6 +139,7 @@ Day 5: [Summary + next steps + soft pitch]
 **Conversion rate:** Medium (15-30%)
 
 Structure:
+
 ```
 Title: [The State of / The Complete Guide to / X Trends in] [Topic]
 
@@ -167,6 +175,7 @@ About [Company]
 **Conversion rate:** High (30-50%)
 
 Swipe file types:
+
 - Email subject line swipe file (100+ proven subjects)
 - Ad copy swipe file (best-performing ads by industry)
 - Landing page swipe file (screenshots + analysis)
@@ -174,6 +183,7 @@ Swipe file types:
 - Social media post swipe file (viral post formulas)
 
 Structure:
+
 ```
 [Swipe File Title]: [X] Proven [Type] You Can Steal
 
@@ -338,22 +348,27 @@ P.S. If you found this helpful, you might also like [related resource].
 ### Post-Download Nurture Sequence
 
 **Email 2 (Day 2):** "Did you get a chance to use [Lead Magnet]?"
+
 - Quick tip or walkthrough
 - Ask if they have questions
 
 **Email 3 (Day 4):** "Here's how [Customer] used [Lead Magnet] to [Result]"
+
 - Case study or success story
 - Social proof
 
 **Email 4 (Day 7):** "[Related valuable content]"
+
 - Blog post, video, or additional resource
 - Build authority
 
 **Email 5 (Day 10):** "The next step after [Lead Magnet topic]"
+
 - Introduce your product/service as the logical next step
 - Soft pitch with value framing
 
 **Email 6 (Day 14):** "[Direct offer]"
+
 - Special offer for lead magnet downloaders
 - Clear CTA to product/service
 - Urgency element (limited time, limited spots)
@@ -395,6 +410,7 @@ A content upgrade is a lead magnet specific to an individual blog post.
 ```
 
 Place content upgrades:
+
 - After the introduction (for skimmers)
 - At the midpoint (for engaged readers)
 - At the end (for completionists)

--- a/.claude/skills/linkedin-ads/SKILL.md
+++ b/.claude/skills/linkedin-ads/SKILL.md
@@ -89,6 +89,7 @@ Audience: [Descriptive Name]
 ### ABM (Account-Based Marketing) Strategy
 
 For high-value target accounts:
+
 1. Upload target company list (100-1,000 companies)
 2. Layer job title + seniority targeting on top
 3. Run awareness ads to the full buying committee
@@ -111,6 +112,7 @@ CTA Button: [Sign Up | Download | Learn More | Subscribe | Register | Request De
 ```
 
 **Copy Rules for LinkedIn**:
+
 1. Lead with a stat, question, or bold claim in the first line
 2. Speak to the professional identity ("As a [job title], you know...")
 3. Focus on business outcomes, not features (revenue, efficiency, growth)
@@ -143,6 +145,7 @@ Video specs:
 ```
 
 **Video structure**:
+
 - 0-3s: Visual hook + text overlay with the key message
 - 3-15s: Problem/pain point
 - 15-25s: Solution introduction
@@ -163,6 +166,7 @@ CTA Button (max 20 chars): [Action phrase]
 ```
 
 **InMail Rules**:
+
 1. Keep under 500 characters for best conversion rates
 2. One CTA only — multiple CTAs reduce conversion by 20%+
 3. Use a real person as the sender (not a company page)
@@ -234,6 +238,7 @@ Campaign: [Product] - A/B Test - [Variable]
 | InMail cost per send | $0.50-1.00 |
 
 **Rules**:
+
 - Minimum $10/day per campaign, but $50/day recommended for meaningful data
 - Monthly minimum for reliable optimization: $1,500-3,000
 - Never increase budget more than 25% at a time (resets learning)

--- a/.claude/skills/linkedin-content/SKILL.md
+++ b/.claude/skills/linkedin-content/SKILL.md
@@ -10,6 +10,7 @@ You are a LinkedIn content strategist and copywriter. Create posts optimized for
 ## LinkedIn Algorithm Signals (2026)
 
 Posts are ranked by:
+
 1. **Dwell time** — How long people stop scrolling to read
 2. **Meaningful comments** (5+ words) — Most valuable signal
 3. **Saves/bookmarks** — High-value engagement
@@ -18,6 +19,7 @@ Posts are ranked by:
 6. **Profile authority** — Consistent posting history, complete profile
 
 **What kills reach:**
+
 - External links in post body (use comments instead)
 - Editing within first hour of posting
 - Posting more than once per day
@@ -42,6 +44,7 @@ Posts are ranked by:
 The first 2-3 lines determine if people click "see more." Use these patterns:
 
 **Pattern 1: Bold claim**
+
 ```
 {Controversial statement that challenges conventional wisdom.}
 
@@ -49,6 +52,7 @@ Here's why most people get this wrong:
 ```
 
 **Pattern 2: Unexpected story**
+
 ```
 {Unexpected event happened to me last week.}
 
@@ -56,6 +60,7 @@ It changed how I think about {topic}.
 ```
 
 **Pattern 3: List preview**
+
 ```
 {Number} lessons I learned from {specific experience}:
 
@@ -63,6 +68,7 @@ It changed how I think about {topic}.
 ```
 
 **Pattern 4: Before/After**
+
 ```
 {Time period} ago, I was {struggling state}.
 Today, I {success state}.
@@ -71,6 +77,7 @@ Here's exactly what changed:
 ```
 
 **Pattern 5: Question hook**
+
 ```
 Why do {group of people} keep making this mistake?
 
@@ -78,6 +85,7 @@ I've seen it {number} times this month alone.
 ```
 
 **Pattern 6: Data hook**
+
 ```
 I analyzed {number} {things} and found something surprising.
 
@@ -87,6 +95,7 @@ I analyzed {number} {things} and found something surprising.
 ## Writing Rules
 
 ### Structure
+
 - **Line breaks are critical.** One thought per line. White space = readability.
 - Max 3,000 characters (about 500 words). Sweet spot: 1,200-1,800 characters.
 - Short paragraphs: 1-2 sentences each.
@@ -94,6 +103,7 @@ I analyzed {number} {things} and found something surprising.
 - End with a clear CTA or question to drive comments.
 
 ### Voice & Tone
+
 - First person, conversational
 - Specific > vague ("I grew from 200 to 12,000 followers" not "I grew my audience")
 - Numbers and data points increase credibility
@@ -101,6 +111,7 @@ I analyzed {number} {things} and found something surprising.
 - No hashtags in the post body (add 3-5 in the first comment if desired)
 
 ### Formatting Tricks
+
 - Use → ↳ • ✓ ✗ for visual variety (sparingly)
 - Bold doesn't work in LinkedIn posts, but ALL CAPS for 1-2 words adds emphasis
 - Numbered lists for sequential content
@@ -123,6 +134,7 @@ Aim for: 40% Utility, 25% Authority, 20% Relatability, 10% Opinion, 5% Social pr
 ## Posting Schedule
 
 **Optimal posting times (general, adjust for audience timezone):**
+
 - Tuesday-Thursday: 7:30-8:30am, 12:00-1:00pm
 - Monday/Friday: 8:00-9:00am
 - Avoid weekends (50-70% less reach)
@@ -164,6 +176,7 @@ When creating a LinkedIn post, deliver:
 ## Carousel Posts
 
 For carousel (PDF) posts, provide:
+
 1. **Slide 1 (Cover):** Bold title + subtitle + author name. This is the hook.
 2. **Slides 2-8:** One key point per slide. Large text. Minimal words.
 3. **Final slide:** CTA (follow, save, share, visit link)

--- a/.claude/skills/marketing-ideas/SKILL.md
+++ b/.claude/skills/marketing-ideas/SKILL.md
@@ -345,21 +345,25 @@ A comprehensive collection of marketing tactics organized by category. Use this 
 ### By Company Stage
 
 **Pre-launch (0 customers):**
+
 - Focus: Ideas 57, 108, 109, 112 (launch tactics)
 - Build an audience before you build the product
 - Priority: Waitlist, community building, build in public
 
 **Early stage (0-100 customers):**
+
 - Focus: Ideas 1-5, 15, 29, 38, 68 (content + product-led)
 - Do things that do not scale: handwritten notes, 1:1 calls
 - Priority: SEO foundation, founder-led marketing, free tools
 
 **Growth stage (100-1,000 customers):**
+
 - Focus: Ideas 41-52, 69-78, 79-88 (paid + email + partnerships)
 - Start investing in channels with predictable ROI
 - Priority: Paid acquisition, email nurture, integrations
 
 **Scale stage (1,000+ customers):**
+
 - Focus: Ideas 89-96, 97-106, 115-126 (events + PR + product-led)
 - Systematize what works, experiment with new channels
 - Priority: PR, conferences, product virality
@@ -367,24 +371,28 @@ A comprehensive collection of marketing tactics organized by category. Use this 
 ### By Budget
 
 **$0/month (sweat equity only):**
+
 - Content & SEO (1-20)
 - Social & community (53-68)
 - Build in public (38)
 - Product Hunt launch (57, 107)
 
 **$500/month:**
+
 - Newsletter sponsorships (50)
 - Micro-influencer partnerships (51)
 - Basic retargeting (43)
 - Tool subscriptions (SemRush, email provider)
 
 **$2,000/month:**
+
 - Google Ads on high-intent keywords (42)
 - LinkedIn Ads (44)
 - Podcast sponsorships (49)
 - Freelance content writers
 
 **$10,000+/month:**
+
 - Multi-channel paid campaigns (41-52)
 - Agency partnerships (83)
 - Events and webinars (89-96)
@@ -393,6 +401,7 @@ A comprehensive collection of marketing tactics organized by category. Use this 
 ### By Timeline
 
 **This week (quick wins):**
+
 - Optimize email signatures (78)
 - Set up retargeting pixel (43)
 - Post on social media (54, 55)
@@ -400,6 +409,7 @@ A comprehensive collection of marketing tactics organized by category. Use this 
 - Comment on industry posts (67)
 
 **This month:**
+
 - Publish 4 blog posts (1-2)
 - Launch on Product Hunt (107)
 - Start email welcome sequence (69)
@@ -407,6 +417,7 @@ A comprehensive collection of marketing tactics organized by category. Use this 
 - Guest post on one publication (8)
 
 **This quarter:**
+
 - Build a free tool (29)
 - Launch referral program (see referral-program skill)
 - Start a podcast or webinar series (12, 89)
@@ -414,6 +425,7 @@ A comprehensive collection of marketing tactics organized by category. Use this 
 - Publish original research (3, 97)
 
 **This year:**
+
 - Build comprehensive content library (1-20)
 - Establish partner ecosystem (79-88)
 - Scale paid channels (41-52)

--- a/.claude/skills/newsletter/SKILL.md
+++ b/.claude/skills/newsletter/SKILL.md
@@ -24,6 +24,7 @@ You are a newsletter growth strategist. Help plan content, grow subscribers, imp
 | List/Roundup | "This week: 5 links worth your time" | Medium |
 
 **Rules:**
+
 - 30-50 characters optimal (mobile-friendly)
 - Preview text is equally important — extend the subject line, don't repeat it
 - Personalization tokens ({first_name}) lift open rates 5-10%

--- a/.claude/skills/onboarding-cro/SKILL.md
+++ b/.claude/skills/onboarding-cro/SKILL.md
@@ -22,12 +22,14 @@ Design and optimize user onboarding flows that drive activation and long-term re
 The best onboarding flows are organized around the user's job, not the product's features.
 
 **Process:**
+
 1. Identify the user's primary job-to-be-done
 2. Map the minimum steps to complete that job in your product
 3. Guide the user through those steps, removing all distractions
 4. Celebrate completion (aha moment)
 
 **Example (Notion):**
+
 - Job: "I need to organize my team's projects"
 - Steps: Create workspace > Invite team > Create first page > Use a template
 - The onboarding flow guides exactly this path, nothing more
@@ -39,12 +41,14 @@ The best onboarding flows are organized around the user's job, not the product's
 Reveal functionality gradually as users demonstrate readiness.
 
 **Levels:**
+
 1. **First session:** Only show core functionality needed for primary job
 2. **After first success:** Introduce secondary features that enhance the core workflow
 3. **After repeated use:** Surface power features, integrations, customization
 4. **After mastery:** Invite to advanced features, API, automation
 
 **Implementation:**
+
 - Use feature flags or user state to control what's visible
 - Track user actions to determine when to advance disclosure level
 - Never show everything at once
@@ -66,6 +70,7 @@ Define your activation metric before designing onboarding. The activation metric
 | HubSpot | Import contacts + send first email | First 14 days |
 
 **How to find your activation metric:**
+
 1. Cohort analysis: Compare retained vs churned users
 2. Identify actions that retained users took that churned users did not
 3. Find the action with strongest correlation to 30-day retention
@@ -76,16 +81,19 @@ Define your activation metric before designing onboarding. The activation metric
 The aha moment is when a user first experiences the core value of your product.
 
 **Framework for identifying it:**
+
 1. What do users say when they recommend your product? ("It's amazing because...")
 2. When during their journey do users typically say "wow" or "this is cool"?
 3. What single action separates users who stay from those who leave?
 
 **The aha moment is NOT:**
+
 - Signing up
 - Completing onboarding
 - Seeing a feature demo
 
 **The aha moment IS:**
+
 - Getting their first result
 - Experiencing time saved
 - Seeing their data visualized for the first time
@@ -100,6 +108,7 @@ The aha moment is when a user first experiences the core value of your product.
 The first screen after signup. Serves two purposes: make the user feel welcomed and collect information for personalization.
 
 **Best Practices:**
+
 - Use the user's name ("Welcome, Sarah!")
 - Keep it to 1-3 questions maximum
 - Use visual selectors (cards with icons) instead of dropdowns
@@ -107,6 +116,7 @@ The first screen after signup. Serves two purposes: make the user feel welcomed 
 - Always allow skipping
 
 **Template:**
+
 ```
 Welcome to [Product], [Name]!
 
@@ -122,6 +132,7 @@ What's your primary goal?
 ```
 
 **Example (Notion):**
+
 ```
 What will you use Notion for?
 [Personal] [Team] [School]
@@ -137,6 +148,7 @@ Guided multi-step flows that set up the product for use.
 **When to use:** When the product requires configuration before it can deliver value (CRM, analytics, marketing automation).
 
 **Best Practices:**
+
 - Maximum 3-5 steps
 - Show progress indicator
 - Pre-fill defaults where possible
@@ -145,6 +157,7 @@ Guided multi-step flows that set up the product for use.
 - End with a clear next action, not a blank screen
 
 **Template:**
+
 ```
 Step 1: Connect your [data source]
   [Connect Google] [Connect manually] [Use sample data]
@@ -164,12 +177,14 @@ You're all set!
 Interactive walkthroughs of the product interface.
 
 **Types:**
+
 1. **Tooltip tour:** Highlights UI elements with explanatory tooltips (Intercom, Appcues)
 2. **Video walkthrough:** Short video showing key workflows
 3. **Interactive tutorial:** User performs real actions with guidance
 4. **Sandbox mode:** Pre-populated environment for safe exploration
 
 **Best Practices:**
+
 - Keep tours under 5 steps (3 is ideal)
 - Focus on ONE workflow per tour
 - Let users exit at any point
@@ -178,12 +193,14 @@ Interactive walkthroughs of the product interface.
 - Never replay completed tours unless user requests it
 
 **Anti-patterns:**
+
 - 15-step tours that show every button
 - Forced tours that cannot be dismissed
 - Tours that explain obvious UI elements
 - Tours that trigger repeatedly
 
 **Template (per step):**
+
 ```
 Step [X] of [Y]:
 
@@ -199,12 +216,14 @@ Step [X] of [Y]:
 Persistent task lists that guide users through activation.
 
 **Why they work:**
+
 - Zeigarnik effect: People feel compelled to complete unfinished tasks
 - Clear progress visualization
 - Users self-pace through the list
 - Can be dismissed and revisited
 
 **Template:**
+
 ```
 Get started with [Product]  [3/5 complete]
 
@@ -218,6 +237,7 @@ Get started with [Product]  [3/5 complete]
 ```
 
 **Best Practices:**
+
 - 4-6 items maximum
 - Pre-check easy items (account creation) for momentum
 - Order by dependency and importance
@@ -227,6 +247,7 @@ Get started with [Product]  [3/5 complete]
 - Show percentage complete or progress bar
 
 **Example (Slack):**
+
 ```
 Getting started  [2/4]
 [x] Set your profile photo
@@ -236,6 +257,7 @@ Getting started  [2/4]
 ```
 
 **Example (Figma):**
+
 ```
 Welcome to Figma  [1/5]
 [x] Create your account
@@ -262,6 +284,7 @@ Drip emails that complement the in-app experience.
 | 14 | Upgrade prompt | If activated, pitch premium features |
 
 **Day 0 Welcome Email Template:**
+
 ```
 Subject: Welcome to [Product] -- here's your quick start
 
@@ -281,6 +304,7 @@ Need help? Reply to this email or check our [getting started guide].
 ```
 
 **Day 3 Social Proof Email Template:**
+
 ```
 Subject: How [Customer] uses [Product] to [Result]
 
@@ -304,6 +328,7 @@ You can do the same:
 ### Notion
 
 **What they do well:**
+
 - Welcome screen asks role + use case (2 questions)
 - Offers templates based on selection
 - Pre-populates workspace with starter content
@@ -316,6 +341,7 @@ You can do the same:
 ### Slack
 
 **What they do well:**
+
 - Workspace setup wizard is 3 steps (name, invite, channel)
 - Slackbot guides first interactions conversationally
 - Pre-created #general and #random channels with welcome messages
@@ -327,6 +353,7 @@ You can do the same:
 ### Figma
 
 **What they do well:**
+
 - Minimal signup (Google OAuth one-click)
 - Immediately drops user into a canvas with interactive tutorial
 - Tutorial teaches by doing (create shape, move it, style it)
@@ -338,6 +365,7 @@ You can do the same:
 ### Canva
 
 **What they do well:**
+
 - Asks "What will you design today?" with visual categories
 - Immediately shows templates relevant to selection
 - First design experience uses pre-made template (user edits, not creates from scratch)
@@ -346,6 +374,7 @@ You can do the same:
 ### Linear
 
 **What they do well:**
+
 - Import from existing tools (Jira, Asana) as first step
 - Pre-configured with sensible defaults (workflow states, labels)
 - Keyboard shortcuts taught in context
@@ -388,27 +417,32 @@ Track conversion rate between each step. The biggest drop-off is your biggest op
 ## 5. A/B Test Ideas for Onboarding
 
 ### Welcome Screen
+
 1. 1 question vs 3 questions on welcome screen
 2. Visual card selection vs dropdown
 3. Personalized template suggestions vs generic
 
 ### Setup Flow
+
 4. Guided setup vs "explore on your own"
 5. Pre-populated sample data vs empty state
 6. Setup wizard vs onboarding checklist
 
 ### Product Tour
+
 7. Tooltip tour vs video walkthrough
 8. 3-step tour vs 5-step tour
 9. Auto-triggered tour vs user-initiated
 
 ### Activation
+
 10. Email nudge on day 1 vs day 3 for inactive users
 11. In-app prompt for next action vs no prompt
 12. Celebrating milestones (confetti, badge) vs no celebration
 13. Showing progress ("You're 60% set up") vs not showing
 
 ### Engagement
+
 14. Daily tip emails vs weekly digest
 15. Push notifications for incomplete onboarding vs email only
 16. Peer comparison ("Teams like yours usually...") vs no comparison

--- a/.claude/skills/podcast-edit/SKILL.md
+++ b/.claude/skills/podcast-edit/SKILL.md
@@ -50,6 +50,7 @@ curl -s https://api.openai.com/v1/audio/transcriptions \
 ```
 
 Scan transcriptions for:
+
 - **Start markers**: "welcome", "hello everyone", "大家好", "欢迎", intro music, first substantive topic sentence
 - **End markers**: "see you next time", "bye", "下期见", "感谢收听", followed by post-show chat
 
@@ -90,6 +91,7 @@ python3 ./filler_removal.py \
 ```
 
 **Arguments:**
+
 - `--total-duration`: Duration of the trimmed input file in seconds (required)
 - `--end-at`: Cut everything after this timestamp (e.g., post-show chat start)
 - `--cut START:END`: Cut a specific range. Can be repeated.
@@ -132,11 +134,13 @@ loudnorm=I=-16:TP=-1.5:LRA=13                    # Podcast standard loudness
 **Why `dynaudnorm` is the star:** it normalizes in 200 ms rolling windows, so when the guest is speaking, that window gets lifted independently of the host's louder windows. Order matters — run `dynaudnorm` BEFORE `acompressor` so the compressor sees a balanced signal.
 
 **Never add these to the default chain:**
+
 - `agate` (noise gate) — cuts off any speaker quieter than the threshold; kills the guest.
 - Heavy compression (ratio >3:1, makeup >2 dB) — flattens dynamics and makes the guest sound pumped.
 - Narrow LRA (<12) in `loudnorm` — crushes natural speech dynamics.
 
 **Adjust lowpass based on source sample rate:**
+
 - 16kHz source → `lowpass=7500`
 - 44.1kHz+ source → `lowpass=12000` (or skip)
 

--- a/.claude/skills/podcast-marketing/SKILL.md
+++ b/.claude/skills/podcast-marketing/SKILL.md
@@ -10,6 +10,7 @@ You are a podcast production and marketing expert. Help plan, produce, and grow 
 ## Podcast as Marketing
 
 Podcasts work differently from other marketing channels:
+
 - **Long-form trust building** — 30-60 minutes of attention per episode
 - **Relationship engine** — Guests become advocates, partners, customers
 - **Content multiplier** — Each episode yields 10-20 content pieces (see content-repurposing skill)
@@ -51,6 +52,7 @@ Podcasts work differently from other marketing channels:
 | Post-production | Noise removal, leveling | Professional editing |
 
 **Rules:**
+
 - Record in WAV/AIFF, not MP3 (compress for delivery only)
 - Audio levels between -16 and -12 LUFS
 - Remove long pauses, filler words, and background noise
@@ -138,6 +140,7 @@ Every episode should have optimized show notes:
 ```
 
 **SEO tips:**
+
 - Include full or partial transcript for long-tail keyword coverage
 - Use the episode title as an H1 with the target keyword
 - Internal link to related episodes

--- a/.claude/skills/pricing-strategy/SKILL.md
+++ b/.claude/skills/pricing-strategy/SKILL.md
@@ -28,24 +28,31 @@ Establish: product/service, target market (B2B/B2C/SMB/enterprise), current pric
 ## Step 3: Pricing Psychology
 
 ### 1. Price Anchoring
+
 Show highest tier first, compare to alternatives ("vs. hiring at $80K/year"), compare to outcome value ("Generates $10K savings. Costs $99/month").
 
 ### 2. Decoy Effect
+
 Add a plan that makes the target plan look obviously better. Example: Basic $9 (5 users), Plus $25 (10 users, DECOY), Pro $29 (25 users, TARGET).
 
 ### 3. Charm Pricing
+
 $99 feels cheaper than $100. Use .99 for consumer/SMB, round numbers for enterprise/premium.
 
 ### 4. Center-Stage Effect
+
 People choose the middle of 3 options. Make your target plan the middle tier and highlight it.
 
 ### 5. Loss Aversion
+
 Frame around what they lose without your product. Use "downgrade" language. Show features they would lose.
 
 ### 6. Endowment Effect
+
 Full-featured trials, then keep. Show personalized data that makes leaving painful.
 
 ### 7. Price-Quality Signal
+
 Premium products should not underprice. Own higher prices: "We cost more because we deliver more."
 
 ## Step 4: Tier Design

--- a/.claude/skills/product-marketing/SKILL.md
+++ b/.claude/skills/product-marketing/SKILL.md
@@ -14,6 +14,7 @@ You are a product marketing strategist. Build positioning, messaging, competitiv
 What would customers use if your product didn't exist?
 
 List all alternatives:
+
 - Direct competitors (same category)
 - Indirect competitors (different approach, same problem)
 - Status quo (manual process, spreadsheets, doing nothing)
@@ -45,6 +46,7 @@ For each unique attribute, answer "So what? Why does the customer care?"
 Who cares the most about these specific values?
 
 Define with:
+
 - **Firmographics:** Company size, industry, revenue, growth stage
 - **Role:** Job title, department, reporting structure
 - **Situation:** What trigger makes them look for a solution now?
@@ -55,6 +57,7 @@ Define with:
 What category context makes your value obvious?
 
 Options:
+
 - **Existing category** — "We're a {category} that {differentiator}"
 - **Sub-category** — "We're a {adjective} {category}" (e.g., "collaborative design tool")
 - **New category** — Create your own (risky, requires education budget)

--- a/.claude/skills/programmatic-seo/SKILL.md
+++ b/.claude/skills/programmatic-seo/SKILL.md
@@ -10,12 +10,14 @@ You are an expert in programmatic SEO (pSEO) -- the strategy of creating large n
 ## What is Programmatic SEO?
 
 Programmatic SEO creates pages at scale by combining:
+
 - A **page template** (layout + structure)
 - A **data source** (database, API, CSV)
 - **Dynamic content** (unique per page, not just variable substitution)
 - **SEO optimization** (meta tags, internal links, schema)
 
 **Examples of successful pSEO:**
+
 - Zapier: "How to connect {App A} to {App B}" (150K+ pages)
 - Nomad List: "{City} for digital nomads" (1000+ city pages)
 - Wise: "{Currency A} to {Currency B} exchange rate" (10K+ pages)
@@ -44,6 +46,7 @@ Help the user find their pSEO opportunity. Look for patterns where:
 | Cost/Pricing | "How much does {service} cost" | "How much does a website cost" | Services count |
 
 **Qualification criteria for a good pSEO opportunity:**
+
 - [ ] Pattern has 100+ possible pages minimum
 - [ ] Each combination has measurable search volume (even 10-50/mo is fine at scale)
 - [ ] You can generate genuinely useful, unique content for each page
@@ -82,6 +85,7 @@ interface PageData {
 ```
 
 **Data sources to consider:**
+
 - Public APIs (government data, Wikipedia, industry databases)
 - Web scraping (with permission/robots.txt compliance)
 - User-generated content (reviews, contributions)
@@ -283,6 +287,7 @@ export default function robots(): MetadataRoute.Robots {
 Internal linking is critical for pSEO. Implement these patterns:
 
 **1. Hub-and-Spoke:**
+
 ```
 Hub: /services/plumber/
   |- /plumber/austin-tx
@@ -297,6 +302,7 @@ Each city page links to 5-10 nearby city pages for the same service.
 Each city page links to other services in the same city.
 
 **4. Breadcrumb Navigation:**
+
 ```
 Home > Services > Plumber > Austin, TX
 ```
@@ -305,6 +311,7 @@ Home > Services > Plumber > Austin, TX
 Popular pages and category indexes.
 
 **Implementation pattern:**
+
 ```typescript
 // Internal linking component
 function RelatedPages({ currentSlug, relatedPages }) {
@@ -332,6 +339,7 @@ function RelatedPages({ currentSlug, relatedPages }) {
 When deploying thousands of pages, manage indexation carefully:
 
 **Gradual rollout:**
+
 1. Deploy 50-100 pages first
 2. Monitor indexation in Google Search Console
 3. Check for "Discovered - currently not indexed" and "Crawled - currently not indexed"
@@ -339,12 +347,14 @@ When deploying thousands of pages, manage indexation carefully:
 5. If indexation rate < 50%, improve page quality before deploying more
 
 **Indexation signals:**
+
 - Submit sitemap to Google Search Console
 - Use IndexNow API (Bing, Yandex) for faster discovery
 - Internal link from high-authority existing pages
 - Share initial pages on social media for crawl signals
 
 **Quality thresholds:**
+
 - If Google indexes < 30% of pages, your template likely produces thin content
 - If pages get indexed then dropped, content quality is borderline
 - Monitor "Page experience" and "Core Web Vitals" in GSC for pSEO pages
@@ -354,6 +364,7 @@ When deploying thousands of pages, manage indexation carefully:
 Use these formulas for generating meta tags at scale:
 
 **Title tag formulas (50-60 chars):**
+
 ```
 "{Primary Keyword} in {Location} | {Brand}"
 "Best {Service} in {City}, {State} ({Year})"
@@ -363,6 +374,7 @@ Use these formulas for generating meta tags at scale:
 ```
 
 **Meta description formulas (150-160 chars):**
+
 ```
 "Find the best {service} in {city}. Compare {X} local providers, read {Y} reviews, and get free quotes. Average cost: ${Z}."
 "Detailed comparison of {A} vs {B}. See features, pricing, pros/cons, and which is better for {use case}."
@@ -370,6 +382,7 @@ Use these formulas for generating meta tags at scale:
 ```
 
 **H1 formulas:**
+
 ```
 "Best {Service} in {City}, {State}"
 "{Product A} vs {Product B}: Complete Comparison"

--- a/.claude/skills/reddit-marketing/SKILL.md
+++ b/.claude/skills/reddit-marketing/SKILL.md
@@ -14,6 +14,7 @@ You are a Reddit marketing strategist. Help build authentic presence, find targe
 **The 90/10 rule:** 90% of your activity should be valuable contributions (comments, helpful posts). 10% or less can mention your product/service.
 
 **What gets you banned:**
+
 - Posting links to your site without context or value
 - Creating posts that are thinly disguised ads
 - Using multiple accounts to upvote your own content
@@ -68,6 +69,7 @@ Title: "{How-to that solves a common pain point in the community}"
 ```
 
 **Format:**
+
 - Text post (not a link post — text posts get more engagement)
 - Share the full value in the post itself (don't make people click out)
 - If your product is relevant, mention it briefly at the bottom: "Full disclosure: I work on {product} which does this, but these tips work regardless of tools."
@@ -85,6 +87,7 @@ The highest ROI Reddit strategy:
 ### Strategy 3: AMA (Ask Me Anything)
 
 If you have genuine expertise:
+
 - Coordinate with subreddit moderators in advance
 - Prepare proof of credentials
 - Answer questions for 2+ hours
@@ -93,6 +96,7 @@ If you have genuine expertise:
 ### Strategy 4: Case Studies / Show & Tell
 
 Many subreddits have "Show" or "Share" threads:
+
 - Share genuine results with transparent methodology
 - Show failures alongside successes (authenticity)
 - Respond to every comment with additional detail
@@ -108,6 +112,7 @@ Reddit's ad platform for when organic isn't enough:
 | Takeover | Brand awareness | High budget, broad reach |
 
 **Reddit Ads tips:**
+
 - Target by subreddit (most effective) or interest
 - Creative should match Reddit's organic tone (no polished corporate ads)
 - Comments on promoted posts are open — be ready to engage

--- a/.claude/skills/referral-program/SKILL.md
+++ b/.claude/skills/referral-program/SKILL.md
@@ -21,15 +21,18 @@ Design effective referral programs and viral loops that drive sustainable growth
 Only the referrer gets rewarded.
 
 **Best for:**
+
 - Products with strong organic word-of-mouth
 - Low-friction signups where the referred user needs no extra motivation
 - Cost-sensitive businesses
 
 **Examples:**
+
 - Uber: "$10 credit for every friend you refer"
 - Amazon Associates: Commission on referred purchases
 
 **Template:**
+
 ```
 Refer a friend and get [reward].
 Share your unique link: [referral_url]
@@ -40,16 +43,19 @@ Share your unique link: [referral_url]
 Both referrer and referred user get rewarded.
 
 **Best for:**
+
 - Products requiring activation effort from new users
 - Competitive markets where new users need a nudge
 - Subscription businesses
 
 **Examples:**
+
 - Dropbox: Both get 500MB extra storage
 - Airbnb: Referrer gets $25 credit, friend gets $40 off first stay
 - PayPal: Both get $10 when friend makes first transaction
 
 **Template:**
+
 ```
 Give [friend_reward], get [referrer_reward].
 Share your link and you both win: [referral_url]
@@ -60,6 +66,7 @@ Share your link and you both win: [referral_url]
 Rewards increase with number of successful referrals.
 
 **Example tier structure:**
+
 | Referrals | Reward |
 |-----------|--------|
 | 1 | Free month |
@@ -69,6 +76,7 @@ Rewards increase with number of successful referrals.
 | 25 | Cash payout or swag box |
 
 **Best for:**
+
 - Creating power referrers / ambassadors
 - Products with passionate user bases
 - Building a referral leaderboard culture
@@ -134,6 +142,7 @@ A K of 0.5 with a 1-day cycle > K of 0.8 with a 30-day cycle
 **Cons:** Lower volume, requires email access
 
 Template:
+
 ```
 Subject: I thought you'd like [Product] -- here's [reward] to try it
 
@@ -155,12 +164,14 @@ I wanted to share my referral link so you can get [friend_reward]:
 Platform-specific templates:
 
 **Twitter/X:**
+
 ```
 I just [achievement/milestone] with @Product! If you want to try it,
 use my link and we both get [reward]: [referral_url]
 ```
 
 **LinkedIn:**
+
 ```
 I've been using [Product] to [professional benefit] and the results
 have been impressive: [specific metric].
@@ -170,6 +181,7 @@ If you're looking for [solution], here's my referral link
 ```
 
 **WhatsApp/SMS:**
+
 ```
 Hey! I've been using [Product] and really like it. They have a
 referral deal -- we both get [reward] if you sign up through my link:
@@ -182,6 +194,7 @@ referral deal -- we both get [reward] if you sign up through my link:
 **Cons:** Only reaches existing users
 
 Best practices:
+
 - Show referral prompt after a success moment (completed task, achievement, positive outcome)
 - Pre-populate sharing message
 - Show referral progress and rewards earned

--- a/.claude/skills/schema-markup/SKILL.md
+++ b/.claude/skills/schema-markup/SKILL.md
@@ -61,6 +61,7 @@ This skill supports the following schema types. When the user asks for schema, d
 ```
 
 **Google requirements:**
+
 - `headline` is required (max 110 characters)
 - `image` is required (provide 3 aspect ratios: 16:9, 4:3, 1:1; each > 696px wide)
 - `datePublished` is required (ISO 8601 format)
@@ -164,6 +165,7 @@ This skill supports the following schema types. When the user asks for schema, d
 ```
 
 **Google requirements:**
+
 - `name` is required
 - `offers`, `review`, or `aggregateRating` - at least one required
 - `offers.price` and `offers.priceCurrency` required if offers present
@@ -203,6 +205,7 @@ This skill supports the following schema types. When the user asks for schema, d
 ```
 
 **Google requirements:**
+
 - Each `Question` must have exactly one `acceptedAnswer`
 - Answer `text` can include HTML: `<h2>` through `<h6>`, `<br>`, `<ol>`, `<ul>`, `<li>`, `<a>`, `<p>`, `<b>`, `<strong>`, `<i>`, `<em>`
 - Must be visible on the page (not hidden behind tabs/accordions without proper implementation)
@@ -270,6 +273,7 @@ This skill supports the following schema types. When the user asks for schema, d
 ```
 
 **Google requirements:**
+
 - `name` is required
 - `step` array is required with at least one step
 - Each step needs either `text` or `itemListElement` with `HowToDirection`/`HowToTip`
@@ -393,6 +397,7 @@ This skill supports the following schema types. When the user asks for schema, d
 ```
 
 **Google requirements:**
+
 - `name`, `address` are required
 - Use specific subtypes when possible: `Restaurant`, `Dentist`, `LegalService`, `RealEstateAgent`, etc.
 - `geo` coordinates should be accurate to the business location
@@ -432,6 +437,7 @@ This skill supports the following schema types. When the user asks for schema, d
 ```
 
 **Google requirements:**
+
 - `position` must be sequential starting at 1
 - Last item should not have `item` (it's the current page)
 - Must match the visible breadcrumb on the page
@@ -473,6 +479,7 @@ This skill supports the following schema types. When the user asks for schema, d
 ```
 
 **Google requirements:**
+
 - `author` is required (must be a valid `Person` or `Organization`)
 - `itemReviewed` is required
 - `reviewRating` is recommended
@@ -541,6 +548,7 @@ When the user asks for schema markup:
 ## Implementation Instructions
 
 For **Next.js App Router**:
+
 ```tsx
 // In your page component or layout
 export default function Page() {
@@ -559,6 +567,7 @@ export default function Page() {
 ```
 
 For **Next.js with next/head (Pages Router)**:
+
 ```tsx
 import Head from 'next/head';
 
@@ -580,6 +589,7 @@ export default function Page() {
 ```
 
 For **plain HTML**:
+
 ```html
 <head>
   <script type="application/ld+json">
@@ -591,6 +601,7 @@ For **plain HTML**:
 ## Validation
 
 After generating the markup, remind the user to validate using:
+
 1. **Google Rich Results Test:** https://search.google.com/test/rich-results
 2. **Schema.org Validator:** https://validator.schema.org/
 

--- a/.claude/skills/search-console/SKILL.md
+++ b/.claude/skills/search-console/SKILL.md
@@ -16,6 +16,7 @@ Pull search performance data, index coverage, and Core Web Vitals from Google Se
 ## Prerequisites
 
 Requires Google OAuth credentials:
+
 - `GOOGLE_CLIENT_ID`
 - `GOOGLE_CLIENT_SECRET`
 - A valid OAuth access token with `https://www.googleapis.com/auth/webmasters.readonly` scope

--- a/.claude/skills/semrush-research/SKILL.md
+++ b/.claude/skills/semrush-research/SKILL.md
@@ -151,6 +151,7 @@ https://api.semrush.com/?type=phrase_kdi&key={KEY}&phrase={keyword}&database=us&
 | `Kd` | Keyword difficulty (0-100) |
 
 Interpretation:
+
 - 0-29: Easy - achievable with quality content
 - 30-49: Moderate - needs solid content + some backlinks
 - 50-69: Hard - needs strong domain authority + backlinks
@@ -271,6 +272,7 @@ Present results as a comparison table:
 ```
 
 Then highlight:
+
 - **Keyword gaps**: Keywords competitors rank for but target does not
 - **Quick wins**: Keywords where target ranks positions 5-20 (improvement opportunities)
 - **Content gaps**: Topics competitors cover but target does not
@@ -293,6 +295,7 @@ Then highlight:
 | Empty response | Usually means no data available for the query parameters |
 
 When you get "NOTHING FOUND", try:
+
 - Different database (e.g., `uk` instead of `us`)
 - Root domain instead of subdomain
 - Broader keyword phrase

--- a/.claude/skills/seo-audit/SKILL.md
+++ b/.claude/skills/seo-audit/SKILL.md
@@ -20,6 +20,7 @@ Use the available tools to collect information about the target site:
 5. **Check PageSpeed** via `https://www.googleapis.com/pagespeedonline/v5/runPagespeed?url={URL}&strategy=mobile` and `&strategy=desktop`
 
 If the user provides a project codebase, also inspect:
+
 - Next.js `next.config.js`, `app/layout.tsx`, `middleware.ts`
 - Meta tag generation in page components
 - `<head>` contents, Open Graph tags
@@ -50,6 +51,7 @@ Check these items:
 | Crawl depth | Important pages within 3 clicks of homepage | Medium |
 
 **Scoring formula:**
+
 - Start at 100
 - Critical issue: -25 each
 - High issue: -15 each
@@ -142,6 +144,7 @@ Overall = (Crawlability * 0.20) + (Technical * 0.25) + (On-Page * 0.25) + (Conte
 ```
 
 **Rating scale:**
+
 - 90-100: Excellent - minor optimizations only
 - 75-89: Good - some important fixes needed
 - 50-74: Needs Improvement - significant issues to address

--- a/.claude/skills/seo-content-brief/SKILL.md
+++ b/.claude/skills/seo-content-brief/SKILL.md
@@ -35,6 +35,7 @@ For the target keyword, analyze top 5-10 results:
 | #2 | ... | ... | ... | ... |
 
 **Extract from top results:**
+
 - Common H2/H3 topics (every result covers these → mandatory sections)
 - Unique sections (only 1-2 results cover → differentiation opportunity)
 - Questions answered (People Also Ask + in-content FAQs)
@@ -48,6 +49,7 @@ For the target keyword, analyze top 5-10 results:
 **LSI keywords:** Related terms that signal topical depth
 
 If SemRush API is available (`SEMRUSH_API_KEY`), pull:
+
 ```bash
 # Primary keyword data
 curl -s "https://api.semrush.com/?type=phrase_all&key=${SEMRUSH_API_KEY}&phrase={keyword}&database=us&export_columns=Ph,Nq,Cp,Co,Nr,Td"
@@ -76,6 +78,7 @@ H1: {Title with primary keyword}
 ```
 
 **Heading rules:**
+
 - H1: One per page, includes primary keyword
 - H2: Every 200-300 words, includes secondary keywords where natural
 - H3: Only when a section needs subdivision
@@ -138,7 +141,9 @@ What will make this article better than the current #1 result?
 ## Heading Structure
 
 ```
+
 {Full H1-H3 outline as designed in Step 4}
+
 ```
 
 ## Section-by-Section Guidance

--- a/.claude/skills/serp-analyzer/SKILL.md
+++ b/.claude/skills/serp-analyzer/SKILL.md
@@ -10,6 +10,7 @@ You are an expert SERP analyst. Given a target keyword, analyze what currently r
 ## Prerequisites
 
 Optional API keys for enriched data (the skill can work without any of them using web search):
+
 - `SEMRUSH_API_KEY` - for keyword and organic results data
 - `SERPAPI_API_KEY` - for real-time Google SERP data including SERP features
 - `DATAFORSEO_LOGIN` and `DATAFORSEO_PASSWORD` - for advanced SERP data
@@ -21,10 +22,12 @@ Optional API keys for enriched data (the skill can work without any of them usin
 Use multiple data sources to build a complete SERP picture:
 
 **Method A: SemRush API (if available)**
+
 ```
 # Get organic results for keyword
 https://api.semrush.com/?type=phrase_organic&key={KEY}&phrase={keyword}&database=us&export_columns=Dn,Ur,Fk,Fp&display_limit=20
 ```
+
 Columns: Dn=Domain, Ur=URL, Fk=SERP Features, Fp=Position
 
 **Method B: Web Search (always do this)**
@@ -36,12 +39,14 @@ Use WebFetch on the top 5-10 ranking URLs to analyze actual content.
 **Method D: SerpAPI (if SERPAPI_API_KEY available)**
 
 Real-time Google SERP data with structured SERP features:
+
 ```bash
 # Real-time Google SERP data via SerpAPI
 curl -s "https://serpapi.com/search.json?q={keyword}&api_key=${SERPAPI_API_KEY}&num=20&gl=us&hl=en"
 ```
 
 The JSON response includes:
+
 - `organic_results` - Array of organic listings with `position`, `title`, `link`, `snippet`, `displayed_link`
 - `related_questions` - People Also Ask questions with `question`, `snippet`, `title`, `link`
 - `knowledge_graph` - Knowledge panel data with `title`, `description`, `entity_type`, and attributes
@@ -52,6 +57,7 @@ The JSON response includes:
 - `related_searches` - Related search queries
 
 Parse example:
+
 ```bash
 # Extract organic results
 curl -s "https://serpapi.com/search.json?q={keyword}&api_key=${SERPAPI_API_KEY}&num=20&gl=us&hl=en" | \
@@ -71,6 +77,7 @@ SerpAPI is especially useful for mapping SERP features in Step 2, as it returns 
 **Method E: DataForSEO (if DATAFORSEO_LOGIN and DATAFORSEO_PASSWORD available)**
 
 Advanced SERP data with detailed item types and ranking metrics:
+
 ```bash
 # DataForSEO SERP API
 curl -s -X POST "https://api.dataforseo.com/v3/serp/google/organic/live/advanced" \
@@ -80,6 +87,7 @@ curl -s -X POST "https://api.dataforseo.com/v3/serp/google/organic/live/advanced
 ```
 
 The response provides:
+
 - `result[0].items` - Array of all SERP items, each with a `type` field:
   - `"organic"` - Standard organic results with `url`, `title`, `description`, `rank_group`, `rank_absolute`
   - `"featured_snippet"` - Featured snippet with `description`, `url`, `type` (paragraph/list/table)
@@ -115,6 +123,7 @@ Document every SERP feature present for this keyword:
 | Breadcrumbs | Yes/No | {domains} | - |
 
 **SERP Intent Signal Analysis:**
+
 - Mostly blog posts/guides = Informational intent
 - Mostly product/service pages = Transactional intent
 - Mix of reviews + product pages = Commercial investigation
@@ -207,6 +216,7 @@ Competitor 2 ({domain}): {Positioning summary}
 ```
 
 **Find your differentiation angle:**
+
 - Can you be more comprehensive? (10x content)
 - Can you be more actionable? (templates, tools, checklists)
 - Can you be more current? (latest data, 2025 updates)
@@ -291,6 +301,7 @@ Write 3 options following these patterns from top results:
 ## Output Format
 
 Always present:
+
 1. **SERP Overview** - Feature map and intent analysis
 2. **Top 10 Analysis Table** - Key metrics for each result
 3. **Pattern Summary** - What the SERP rewards

--- a/.claude/skills/signup-flow-cro/SKILL.md
+++ b/.claude/skills/signup-flow-cro/SKILL.md
@@ -30,6 +30,7 @@ When auditing a signup flow, evaluate each of these dimensions:
 **Rule of thumb:** Every additional step loses 10-20% of users.
 
 **Audit questions:**
+
 - Can any steps be combined?
 - Can any steps be deferred to post-signup?
 - Is every step necessary for the user to start getting value?
@@ -44,6 +45,7 @@ When auditing a signup flow, evaluate each of these dimensions:
 | 5+ fields | -30-50% vs email only |
 
 **Audit questions:**
+
 - Which fields are truly required at signup? (vs. collected later)
 - Can you use progressive profiling instead of upfront collection?
 - Are field labels clear and unambiguous?
@@ -61,6 +63,7 @@ When auditing a signup flow, evaluate each of these dimensions:
 | Facebook | +5-10% | B2C, social products (declining trust) |
 
 **Audit questions:**
+
 - Are social login buttons prominent or buried?
 - Do social logins request minimal permissions?
 - Is there a fallback if social auth fails?
@@ -70,6 +73,7 @@ When auditing a signup flow, evaluate each of these dimensions:
 For multi-step flows, progress indicators reduce abandonment.
 
 **Types:**
+
 - Step counter ("Step 2 of 3")
 - Progress bar (visual fill)
 - Checklist (shows completed and upcoming steps)
@@ -80,6 +84,7 @@ For multi-step flows, progress indicators reduce abandonment.
 ### Error Handling
 
 **Audit checklist:**
+
 - [ ] Inline validation (errors appear next to the field, not at top of form)
 - [ ] Real-time validation (check as user types, not on submit)
 - [ ] Clear error messages (say what's wrong AND how to fix it)
@@ -91,6 +96,7 @@ For multi-step flows, progress indicators reduce abandonment.
 ### Mobile Optimization
 
 **Audit checklist:**
+
 - [ ] Form fills the viewport without horizontal scroll
 - [ ] Input fields are at least 44px tap targets
 - [ ] Keyboard type matches input (email keyboard for email, number pad for phone)
@@ -134,66 +140,80 @@ For multi-step flows, progress indicators reduce abandonment.
 ### Pre-Signup (Landing Page to Signup Start)
 
 **Hypothesis 1: Reducing perceived effort increases signup starts**
+
 - Test: Replace "Create Account" button with "Get Started Free" or "Start in 30 seconds"
 - Expected lift: 5-15%
 
 **Hypothesis 2: Social proof near CTA increases conversion**
+
 - Test: Add "Join 10,000+ teams" or user count next to signup button
 - Expected lift: 5-12%
 
 **Hypothesis 3: Showing the product increases intent**
+
 - Test: Add screenshot or demo GIF above signup form
 - Expected lift: 10-20%
 
 **Hypothesis 4: Reducing options increases action**
+
 - Test: Remove pricing tiers from signup page; show one clear CTA
 - Expected lift: 8-15%
 
 ### Step 1: Account Creation
 
 **Hypothesis 5: Social login as primary option reduces friction**
+
 - Test: Show "Continue with Google" as the primary/largest button, email form secondary
 - Expected lift: 15-25%
 
 **Hypothesis 6: Fewer fields increase completion**
+
 - Test: Email-only signup (collect name later) vs email + name + password
 - Expected lift: 10-20%
 
 **Hypothesis 7: Magic link eliminates password friction**
+
 - Test: "Enter email, we'll send a login link" vs traditional password creation
 - Expected lift: 5-15% (higher for mobile)
 
 **Hypothesis 8: Password visibility toggle reduces errors**
+
 - Test: Add show/hide password toggle
 - Expected lift: 3-8%
 
 ### Step 2: Profile / Preferences
 
 **Hypothesis 9: Making profile completion optional increases flow-through**
+
 - Test: Add "Skip for now" option to profile step
 - Expected lift: 15-25%
 
 **Hypothesis 10: Explaining why increases willingness**
+
 - Test: Add micro-copy explaining why each field is needed ("We use this to personalize your dashboard")
 - Expected lift: 5-10%
 
 **Hypothesis 11: Visual selection beats text input**
+
 - Test: Use icon/image cards for preference selection vs dropdown/text
 - Expected lift: 8-15%
 
 ### Step 3: Verification
 
 **Hypothesis 12: Delayed email verification increases activation**
+
 - Test: Let users access the product immediately, verify email later
 - Expected lift: 20-40% on activation rate
 
 **Hypothesis 13: SMS verification is faster than email**
+
 - Test: Offer phone verification as alternative to email
 - Expected lift: 5-10% on verification completion
 
 ### Post-Signup
 
 **Hypothesis 14: Immediate value delivery reduces churn**
+
 - Test: Drop users into a pre-populated workspace vs empty state
 - Expected lift: 15-30% on day-1 retention
 

--- a/.claude/skills/similarweb-traffic/SKILL.md
+++ b/.claude/skills/similarweb-traffic/SKILL.md
@@ -26,6 +26,7 @@ node scripts/fetch-similarweb-traffic.js <domain>
 ```
 
 Examples:
+
 ```bash
 # Formatted markdown summary (default)
 node scripts/fetch-similarweb-traffic.js chatslide.ai

--- a/.claude/skills/slack-bot/SKILL.md
+++ b/.claude/skills/slack-bot/SKILL.md
@@ -523,7 +523,7 @@ several ways.
 | Formatting | Syntax | Example |
 |-----------|--------|---------|
 | Bold | `*text*` | *bold text* |
-| Italic | `_text_` | _italic text_ |
+| Italic | `_text_` | *italic text* |
 | Strikethrough | `~text~` | ~strikethrough~ |
 | Code (inline) | `` `text` `` | `inline code` |
 | Code block | ` ```text``` ` | Multi-line code block |
@@ -532,11 +532,12 @@ several ways.
 | User mention | `<@U0123456>` | @username |
 | Channel mention | `<#C0123456>` | #channel |
 | Emoji | `:emoji_name:` | :rocket: |
-| Bulleted list | Start line with `- ` or `* ` | Bullet point |
-| Numbered list | Start line with `1. ` | Numbered item |
+| Bulleted list | Start line with `-` or `*` | Bullet point |
+| Numbered list | Start line with `1.` | Numbered item |
 | Line break | `\n` in JSON string | New line |
 
 **Important differences from standard Markdown:**
+
 - Bold uses single asterisks `*bold*`, not double `**bold**`.
 - Italic uses underscores `_italic_`, not single asterisks.
 - Links use `<url|text>` format with a pipe, not `[text](url)`.

--- a/.claude/skills/social-content/SKILL.md
+++ b/.claude/skills/social-content/SKILL.md
@@ -46,6 +46,7 @@ Before creating social content, collect these inputs:
 | Link preview | Yes, but links reduce reach. Put links in replies. |
 
 **Twitter/X Content Rules:**
+
 - First line is everything. 90% of engagement is determined by the hook.
 - Short sentences. Line breaks between thoughts.
 - No hashtags in the main text body. Add 1-2 at the end or in a reply.
@@ -67,6 +68,7 @@ Before creating social content, collect these inputs:
 | Carousel | PDF upload (up to 300 pages), 1080x1080 or 1080x1350 per slide |
 
 **LinkedIn Content Rules:**
+
 - First 2-3 lines must hook before the "See more" fold. This is critical.
 - Use line breaks aggressively. One sentence per line for readability.
 - Personal stories outperform corporate announcements 10:1.
@@ -90,6 +92,7 @@ Before creating social content, collect these inputs:
 | Best posting times | 11am-1pm, 7-9pm Mon-Fri |
 
 **Instagram Content Rules:**
+
 - Visuals come first. The image/video stops the scroll; the caption sells the click.
 - First line of the caption is the hook. Make it bold and curiosity-driven.
 - Carousel posts get 3x more engagement than single images.
@@ -112,6 +115,7 @@ Before creating social content, collect these inputs:
 | Audio | Original or trending audio |
 
 **TikTok Content Rules:**
+
 - Hook in the first 1-3 seconds or viewers scroll away.
 - Native-feeling content outperforms polished/produced content.
 - Use trending audio when relevant (boosts discoverability).
@@ -168,6 +172,7 @@ Structure a carousel for maximum swipe-through:
 | 10 (CTA) | Action | Follow, save, share, visit link, comment. |
 
 **Carousel Design Rules:**
+
 - One idea per slide. Maximum 30-40 words per slide.
 - Use consistent branding (colors, fonts, logo placement).
 - Number the slides ("1/10", "2/10") to show progress and encourage swiping.
@@ -203,21 +208,25 @@ Transform one blog post into platform-specific content:
 ### From a 2000-Word Blog Post, Create:
 
 **Twitter/X:**
+
 - 1 single tweet (key takeaway + link in reply)
 - 1 thread (7-12 tweets covering the main points)
 - 3-5 standalone tweets (one insight per tweet, spread across the week)
 
 **LinkedIn:**
+
 - 1 long-form post (personal angle on the topic, 800-1200 chars)
 - 1 carousel (key points as slides, PDF format)
 - 1 poll (related question to the blog topic)
 
 **Instagram:**
+
 - 1 carousel (10 slides summarizing the post)
 - 1 reel (30-60s video covering the top 3 points)
 - 3 stories (teaser, key insight, swipe-up/link)
 
 **TikTok:**
+
 - 1 explainer video (60-90s covering the core idea)
 - 1 reaction/hot-take video (contrarian angle from the post)
 - 1 listicle video (quick tips from the post)
@@ -248,6 +257,7 @@ Transform one blog post into platform-specific content:
 - **TikTok:** 3-5 hashtags in caption. Include 1-2 trending tags.
 
 ### Hashtag Don'ts
+
 - Do not use banned or shadowbanned hashtags.
 - Do not use the same hashtag set on every post (looks like bot behavior).
 - Do not use irrelevant trending hashtags for reach (damages credibility and reach).
@@ -258,7 +268,9 @@ Transform one blog post into platform-specific content:
 For every social content request, deliver:
 
 ### 1. Platform-Specific Posts
+
 Full post copy formatted for each requested platform with:
+
 - Hook line
 - Body content
 - CTA
@@ -267,16 +279,19 @@ Full post copy formatted for each requested platform with:
 - Character count
 
 ### 2. Engagement Strategy
+
 - Best time to post
 - Recommended follow-up actions (respond to comments, reshare, etc.)
 - Cross-promotion plan across platforms
 
 ### 3. Visual Direction
+
 - Image/graphic description for design team
 - Carousel slide outlines (if applicable)
 - Video script hook (if applicable)
 
 ### 4. Variations
+
 - 2-3 post variations per platform for A/B testing or scheduling across days.
 
 ## API Integrations (Optional Enhancements)
@@ -313,12 +328,14 @@ curl -s "https://api.unsplash.com/search/photos?query={topic}&per_page=3" \
 ```
 
 Key fields for social media:
+
 - **`.urls.regular`** - 1080px wide, good for LinkedIn and Twitter posts
 - **`.urls.small`** - 400px wide, good for thumbnails and previews
 - **`.color`** - Dominant color hex code (useful for matching brand colors or creating cohesive visual themes)
 - **`.width` / `.height`** - Original dimensions (check aspect ratio fits the target platform)
 
 **Platform-specific image tips:**
+
 - For **Instagram** (1080x1080 or 1080x1350): Search with `orientation=squarish`
 - For **Twitter/LinkedIn** (1200x675): Search with `orientation=landscape`
 - For **TikTok/Reels/Stories** (1080x1920): Search with `orientation=portrait`
@@ -344,6 +361,7 @@ curl -s -X POST "https://www.reddit.com/api/v1/access_token" \
 ```
 
 The response contains:
+
 ```json
 {
   "access_token": "your_token_here",
@@ -354,6 +372,7 @@ The response contains:
 ```
 
 Extract the token:
+
 ```bash
 REDDIT_ACCESS_TOKEN=$(curl -s -X POST "https://www.reddit.com/api/v1/access_token" \
   -u "${REDDIT_CLIENT_ID}:${REDDIT_CLIENT_SECRET}" \
@@ -397,6 +416,7 @@ curl -s "https://oauth.reddit.com/search?q={topic}&sort=relevance&t=week&limit=2
 ```
 
 **How to use Reddit data for social content:**
+
 - **Trending topics:** Posts with high scores (500+) and comment counts indicate what the community cares about right now. Use these as content topics.
 - **Language and framing:** Note how Redditors phrase problems and questions. Mirror this language in your social hooks for authenticity.
 - **Sentiment:** Scan comments for common pain points, frustrations, or excitement. Address these directly in your posts.
@@ -404,6 +424,7 @@ curl -s "https://oauth.reddit.com/search?q={topic}&sort=relevance&t=week&limit=2
 - **Timing:** If a topic is trending on Reddit today, create social content about it within 24-48 hours for maximum relevance.
 
 **Useful subreddits by niche:**
+
 - Marketing: r/marketing, r/digital_marketing, r/SEO, r/socialmedia
 - Tech: r/technology, r/programming, r/webdev, r/SaaS
 - Business: r/entrepreneur, r/smallbusiness, r/startups
@@ -478,6 +499,7 @@ curl -s -X POST "https://oauth.reddit.com/api/comment" \
 The `thing_id` is the fullname of the post or comment to reply to (e.g., `t3_abc123` for a post, `t1_abc123` for a comment).
 
 **Reddit posting best practices:**
+
 - Check subreddit rules before posting (`/r/{subreddit}/about/rules`)
 - Many subreddits have minimum karma/age requirements
 - Avoid self-promotion in subreddits that prohibit it — focus on value

--- a/.claude/skills/stock-images/SKILL.md
+++ b/.claude/skills/stock-images/SKILL.md
@@ -77,6 +77,7 @@ python ~/.agents/tools/unsplash-search.py \
 ## Text Overlay
 
 When `--title` is provided, the script adds a text overlay to the bottom portion of the image with:
+
 - Semi-transparent dark background behind the text
 - White title text with shadow
 - Gray subtitle text (if provided)
@@ -90,6 +91,7 @@ When `--title` is provided, the script adds a text overlay to the bottom portion
 - `Pillow` (only needed if using text overlay with `--title`)
 
 Install if needed:
+
 ```bash
 pip install requests Pillow
 ```
@@ -97,6 +99,7 @@ pip install requests Pillow
 ## Output
 
 The script prints:
+
 - The download URL
 - Photographer attribution (required by Unsplash)
 - The saved file path

--- a/.claude/skills/stripe-dispute/SKILL.md
+++ b/.claude/skills/stripe-dispute/SKILL.md
@@ -30,6 +30,7 @@ EVIDENCE_DIR=~/disputes            # Where to save the per-customer evidence fol
 ## Inputs
 
 The user provides any of:
+
 - Stripe dispute ID (`du_xxxxx`) — preferred
 - Customer email — skill will look up the dispute
 - Charge ID (`ch_xxxxx` or `py_xxxxx`)
@@ -191,6 +192,7 @@ curl -s -u "$STRIPE_SECRET_KEY:" \
 ```
 
 Verify the response:
+
 - `status` should be `under_review`
 - `evidence_details.has_evidence` should be `true`
 - `evidence_details.submission_count` should be `1`
@@ -198,7 +200,9 @@ Verify the response:
 ## Evidence Strategy by Dispute Reason
 
 ### `fraudulent`
+
 Goal: prove the cardholder made the purchase.
+
 - Prior undisputed payments on the same card (strongest)
 - OAuth login (Google/Apple) = identity-verified signup
 - Consistent IP / country / device across sessions
@@ -207,19 +211,25 @@ Goal: prove the cardholder made the purchase.
 - Subscription still active and not cancelled
 
 ### `product_not_received`
+
 Goal: prove delivery + use.
+
 - Login activity log
 - Items created / actions taken inside the product
 - **The customer's own self-reported cancel reason**, if they cancelled — quoted verbatim against the dispute claim
 - Receipt and welcome email
 
 ### `product_unacceptable`
+
 Goal: show the product matched its description and the customer used it.
+
 - Same as `product_not_received` PLUS your terms-of-service language about quality / refund policy
 - Highlight that customer never opened a support ticket
 
 ### `subscription_canceled`
+
 Goal: prove the customer never cancelled (or cancelled after the renewal).
+
 - Subscription object showing `cancel_at_period_end=false` at the renewal date
 - All login/use activity from after the renewal date
 - Terms language stating annual renewals require explicit cancellation
@@ -227,12 +237,15 @@ Goal: prove the customer never cancelled (or cancelled after the renewal).
 ## Rebuttal Templates
 
 ### `uncategorized_text`
+>
 > [Customer name] created a [Product name] account on [date] via [auth method] and subscribed to [plan] ($[amount]/[interval]) using the same [card brand]. The first [N] payment(s) were never disputed. The customer actively used the service: [N] login sessions from [country] on [device], [N] items created ([list]), and [N] [units] consumed. The disputed charge is the [renewal/initial] payment on [date]. The subscription was [status] and remains [active/cancelled]. The customer never contacted support to cancel or request a refund. Our cancellation and refund policies are published at [TERMS_URL]. This is not a fraudulent transaction — it is a legitimate purchase from the cardholder who [made/has made] [N] other undisputed payments on this account.
 
 ### `cancellation_policy_disclosure`
+>
 > Our cancellation policy is disclosed at [TERMS_URL]. Subscribers may cancel at any time and retain access through the end of their billing cycle. This customer never cancelled.
 
 ### `refund_policy_disclosure`
+>
 > Our refund policy is disclosed at [TERMS_URL]. We offer a [N]-day money-back guarantee. The customer did not request a refund within that window, nor at any time.
 
 ## Important Notes

--- a/.claude/skills/telegram-bot/SKILL.md
+++ b/.claude/skills/telegram-bot/SKILL.md
@@ -234,6 +234,7 @@ curl -s -X POST "https://api.telegram.org/bot${TELEGRAM_BOT_TOKEN}/sendMessage" 
 **Keyboard layout:** Each inner array is a row of buttons. Keep rows to 1-3 buttons for readability on mobile. Maximum 100 buttons total per message.
 
 **Button types:**
+
 - `url` - Opens a URL in the browser
 - `callback_data` - Sends data back to the bot (requires a webhook to handle)
 - `switch_inline_query` - Prompts the user to select a chat and send an inline query

--- a/.claude/skills/thread-writer/SKILL.md
+++ b/.claude/skills/thread-writer/SKILL.md
@@ -34,6 +34,7 @@ Every great thread follows a consistent structure:
 ### 1. Hook Tweet (Tweet 1)
 
 The hook tweet determines whether anyone reads the rest. It must:
+
 - Stop the scroll in under 2 seconds.
 - Make a bold promise, surprising claim, or emotional statement.
 - Not include "Thread:" or "[1/N]" (these reduce engagement).
@@ -55,11 +56,13 @@ The hook tweet determines whether anyone reads the rest. It must:
 ### 2. Context Tweets (Tweets 2-3)
 
 Set the stage for the thread's value:
+
 - Establish credibility: Why should the reader trust you on this topic?
 - Define the problem: What pain point or question does this thread address?
 - Set expectations: What will the reader learn or gain?
 
 **Example:**
+
 ```
 Tweet 2: "I've spent 5 years building email lists. Tested 200+ lead magnets.
 Most advice out there is outdated. Here's what actually works in 2025:"
@@ -73,6 +76,7 @@ The strategies below get 5-12%. The difference is worth millions."
 The meat of the thread. Each tweet delivers one point, lesson, or step.
 
 **Value tweet rules:**
+
 - One idea per tweet. Never cram two points into one tweet.
 - Start each tweet with a bold statement or number.
 - Use concrete examples, not abstract advice.
@@ -117,6 +121,7 @@ The final tweet drives a specific action:
 | Engage | "Which tip was most surprising? I'll elaborate on the most popular one." |
 
 **CTA rules:**
+
 - Always include a CTA. Threads without CTAs waste distribution.
 - Pair a follow CTA with a retweet request for maximum growth.
 - Link CTAs should go in the last tweet or a reply, never the hook tweet.
@@ -266,15 +271,19 @@ Here's every change we made:"
 For every thread request, deliver:
 
 ### 1. Thread Outline
+
 A brief bullet-point plan showing the arc of the thread.
 
 ### 2. Full Thread
+
 Each tweet numbered, with character count. Formatted exactly as it would be posted.
 
 ### 3. Hook Variations
+
 3-5 alternative hook tweets for the user to choose from.
 
 ### 4. Posting Instructions
+
 - Suggested posting time.
 - Whether to post all at once or with delays.
 - Recommended first reply (often the link or bonus tip).

--- a/.claude/skills/video-ad-analysis/SKILL.md
+++ b/.claude/skills/video-ad-analysis/SKILL.md
@@ -66,6 +66,7 @@ Note: Not all ads follow this structure. Document what actually happens.
 ### Dimension 4: Target Audience
 
 Infer the target audience from:
+
 - **Demographics:** Age, gender, location signals in the creative
 - **Psychographics:** Values, lifestyle, interests shown
 - **Awareness level:** Unaware → Problem-aware → Solution-aware → Product-aware → Most-aware

--- a/.claude/skills/write-blog/SKILL.md
+++ b/.claude/skills/write-blog/SKILL.md
@@ -15,6 +15,7 @@ Before writing a single word, gather intelligence:
 
 **1A. Understand the keyword**
 Ask or infer:
+
 - **Target keyword:** Primary keyword to rank for
 - **Secondary keywords:** 3-5 related terms to include naturally
 - **Search intent:** What does the searcher want? (Answer, comparison, tutorial, list)
@@ -31,6 +32,7 @@ curl -s "https://api.semrush.com/?type=phrase_all&key=${SEMRUSH_API_KEY}&phrase=
 ```
 
 The response is semicolon-delimited with columns:
+
 - **Ph** - Keyword phrase
 - **Nq** - Monthly search volume (use this to gauge content depth: higher volume = more comprehensive article)
 - **Cp** - CPC in dollars (high CPC signals strong commercial intent - emphasize CTAs and product mentions)
@@ -38,12 +40,14 @@ The response is semicolon-delimited with columns:
 - **Nr** - Number of organic results (more results = more competitive SERP)
 
 Use these insights to:
+
 - **Calibrate word count:** Keywords with volume >5,000 typically need 2,500+ word articles
 - **Adjust commercial angle:** CPC > $5 means readers have buying intent - include product recommendations, comparisons, or pricing info
 - **Identify difficulty:** Competition > 0.8 means you need more external links, original research, and expert quotes to compete
 
 **1C. Analyze the SERP (if tools available)**
 Use WebSearch to check what currently ranks:
+
 - What content type dominates? (Listicle, how-to, guide, comparison)
 - What's the average word count of top 5?
 - What topics do all top results cover?
@@ -120,6 +124,7 @@ Choose the best pattern for the intent:
 | Question | "{Question}? {Promise}" | "Is SEO Dead? What the Data Actually Shows" |
 
 **Title rules:**
+
 - Primary keyword within first 30 characters
 - Add a power word: Ultimate, Complete, Proven, Essential, Definitive
 - Include year if the topic is time-sensitive
@@ -133,10 +138,12 @@ Choose the best pattern for the intent:
 ```
 
 Examples:
+
 - "Learn how to start a blog in 2025 with our step-by-step guide. Covers hosting, design, content, and monetization. Free checklist included."
 - "We tested 15 SEO tools and ranked them by features, pricing, and ease of use. See which tool is best for your budget and goals."
 
 **Meta description rules:**
+
 - Include primary keyword naturally
 - Include a CTA or curiosity element
 - Use active voice
@@ -146,6 +153,7 @@ Examples:
 #### Writing Style Rules
 
 **Readability:**
+
 - Paragraphs: 2-4 sentences max
 - Sentences: 15-20 words average
 - Use short sentences for emphasis. Like this.
@@ -154,6 +162,7 @@ Examples:
 - Active voice > passive voice (aim for 90%+ active)
 
 **Structure & Scannability:**
+
 - H2 every 200-300 words
 - H3 for subsections within H2s
 - Bullet points for lists of 3+ items
@@ -163,6 +172,7 @@ Examples:
 - Tables for comparisons (Google loves tables for featured snippets)
 
 **SEO Integration (natural, not forced):**
+
 - Primary keyword in: H1, first 100 words, 1-2 H2s, conclusion, alt text
 - Primary keyword density: 0.5-1.5% (roughly every 200 words in a 2000-word post)
 - Secondary keywords: each appears 2-3 times throughout
@@ -170,6 +180,7 @@ Examples:
 - Never keyword stuff - if it sounds unnatural, rewrite it
 
 **E-E-A-T Signals:**
+
 - **Experience:** Include first-hand observations, "In my experience...", "When I tested..."
 - **Expertise:** Reference specific methodologies, use precise terminology, show deep knowledge
 - **Authoritativeness:** Cite authoritative sources (studies, official docs, industry leaders)
@@ -191,6 +202,7 @@ Examples:
 Target featured snippets with these patterns:
 
 **Paragraph snippet (definition/what is):**
+
 ```markdown
 ## What Is {Topic}?
 
@@ -199,6 +211,7 @@ Target featured snippets with these patterns:
 ```
 
 **List snippet (how-to/best of):**
+
 ```markdown
 ## How to {Action}
 
@@ -209,6 +222,7 @@ Target featured snippets with these patterns:
 ```
 
 **Table snippet (comparison/data):**
+
 ```markdown
 ## {Comparison Topic}
 
@@ -221,12 +235,14 @@ Target featured snippets with these patterns:
 
 **Image suggestions:**
 For each major section, suggest an image:
+
 ```markdown
 [IMAGE: {Description of what the image should show}]
 Alt text: "{Descriptive alt text with keyword where natural}"
 ```
 
 **Image types to suggest:**
+
 - Hero image (featured image for social sharing)
 - Screenshots (for tutorials)
 - Comparison tables (as images for Pinterest)
@@ -265,6 +281,7 @@ curl -s "https://api.unsplash.com/search/photos?query={topic}&per_page=5&orienta
 ```
 
 Key fields from the response:
+
 - **`.urls.regular`** - Optimized image (1080px wide, good for blog featured images)
 - **`.urls.full`** - Full resolution image
 - **`.urls.small`** - Thumbnail (400px wide, good for social sharing previews)
@@ -281,6 +298,7 @@ Photo by [Photographer Name](https://unsplash.com/@username?utm_source=your_app&
 ```
 
 Place the attribution either:
+
 - In the image caption directly below the featured image
 - In an image credits section at the bottom of the post
 - In the alt text or title attribute of the image tag
@@ -288,12 +306,14 @@ Place the attribution either:
 **Tip:** Search with specific, descriptive queries rather than broad terms. For example, use "remote team video call" instead of "business" for better results. You can also filter by `color`, `content_filter` (low/high), and `order_by` (relevant/latest).
 
 **Internal link placement:**
+
 - Contextual links within body paragraphs (most valuable)
 - "Related reading" callout boxes between sections
 - "Further reading" section at the end
 - Anchor text should be descriptive, not "click here"
 
 **External link rules:**
+
 - Link to authoritative sources (studies, official docs, .edu, .gov)
 - Open external links in new tab
 - No-follow affiliate links and sponsored content
@@ -318,6 +338,7 @@ This format optimizes for both featured snippets and FAQ rich results.}
 ```
 
 **FAQ rules:**
+
 - 4-6 questions
 - Questions should use natural language (how, what, why, when, can, does)
 - Answer the question in the first sentence
@@ -329,6 +350,7 @@ This format optimizes for both featured snippets and FAQ rich results.}
 Before delivering the post, verify:
 
 **SEO Checklist:**
+
 - [ ] Title tag: 50-60 characters, keyword front-loaded
 - [ ] Meta description: 150-160 characters, includes keyword, has CTA
 - [ ] URL slug: Short, includes keyword, hyphenated
@@ -344,6 +366,7 @@ Before delivering the post, verify:
 - [ ] No duplicate content or thin sections
 
 **Readability Checklist:**
+
 - [ ] Average paragraph: 2-4 sentences
 - [ ] Average sentence: under 20 words
 - [ ] Grade level: 7-9
@@ -353,6 +376,7 @@ Before delivering the post, verify:
 - [ ] Bold text highlights key points
 
 **E-E-A-T Checklist:**
+
 - [ ] Author byline with credentials suggested
 - [ ] Sources cited and linked
 - [ ] First-hand experience or expertise demonstrated
@@ -380,6 +404,7 @@ author: "{Author name}"
 ```
 
 After the article, provide:
+
 1. **SEO metadata summary** (title, description, slug, word count)
 2. **Internal linking recommendations** (which pages to link to/from)
 3. **Schema markup** (Article or BlogPosting JSON-LD)

--- a/.claude/skills/write-landing/SKILL.md
+++ b/.claude/skills/write-landing/SKILL.md
@@ -31,7 +31,9 @@ If the user doesn't provide all of these, ask for the critical ones (product, au
 Select the right framework based on the product type and traffic temperature:
 
 #### Framework A: PAS (Problem-Agitation-Solution)
+
 **Best for:** Cold traffic, awareness stage, complex problems
+
 ```
 Hero (Problem statement)
   -> Agitate (Consequences of not solving)
@@ -42,7 +44,9 @@ Hero (Problem statement)
 ```
 
 #### Framework B: AIDA (Attention-Interest-Desire-Action)
+
 **Best for:** Warm traffic, known product category
+
 ```
 Hero (Attention-grabbing headline)
   -> Interest (Key features and hook)
@@ -51,7 +55,9 @@ Hero (Attention-grabbing headline)
 ```
 
 #### Framework C: Before-After-Bridge
+
 **Best for:** Transformation products (SaaS, courses, coaching)
+
 ```
 Hero (Before: current painful state)
   -> After (Vision of success)
@@ -62,7 +68,9 @@ Hero (Before: current painful state)
 ```
 
 #### Framework D: Feature-Benefit Grid
+
 **Best for:** Technical products, SaaS, feature-rich tools
+
 ```
 Hero (Bold promise)
   -> Feature-benefit grid
@@ -91,6 +99,7 @@ The hero section has 5 seconds to hook the visitor. Every word must earn its pla
 | `{Number} {people} use {product} to {outcome}` | When you have social proof scale | "50,000 marketers use Buffer to grow on social" |
 
 **Headline rules:**
+
 - Max 10 words (6-8 is ideal)
 - Specific > vague ("50% faster" > "blazing fast")
 - Benefit > feature ("Save 10 hours/week" > "AI-powered automation")
@@ -98,18 +107,22 @@ The hero section has 5 seconds to hook the visitor. Every word must earn its pla
 
 **Subheadline (H2):**
 Expand on the headline with specifics. Formula:
+
 ```
 {Product} helps {audience} {achieve outcome} by {mechanism/method}. {Proof point or time frame}.
 ```
+
 Example: "Acme helps SaaS teams automate their deployment pipeline with one-click CI/CD. Ship 10x faster from day one."
 
 **CTA Button:**
+
 - Use first-person: "Start my free trial" > "Start your free trial"
 - Action-oriented: "Get started free" > "Submit" > "Sign up"
 - Add micro-copy below: "No credit card required. Free for 14 days."
 - Button color should contrast with background (high contrast = more clicks)
 
 **Supporting element (choose one):**
+
 - Product screenshot or demo video
 - Key metric ("Trusted by 10,000+ companies")
 - Logo bar of notable customers
@@ -196,12 +209,14 @@ Make the reader feel understood. Describe their current situation precisely.
 ```
 
 **Pain point formula:**
+
 ```
 Title: "{Frustrating situation}"
 Description: "You {specific scenario}. But {consequence}. And {escalation}."
 ```
 
 Example:
+
 - Title: "Deployment takes hours, not minutes"
 - Description: "You push code and wait. Build fails. Fix it. Wait again. By the time it's live, the bug report queue has doubled. And your weekend is gone."
 
@@ -241,6 +256,7 @@ Transition from pain to solution. Show the product as the bridge.
 ```
 
 **Step formula:**
+
 ```
 Step 1: "{Simple first action}" - Lower the barrier to entry
 Step 2: "{Core value action}" - The product doing its thing
@@ -248,6 +264,7 @@ Step 3: "{Desired outcome}" - The result they care about
 ```
 
 Example:
+
 1. "Connect your repo" - Link your GitHub in one click
 2. "Push your code" - Our AI handles builds, tests, and deployment
 3. "Ship with confidence" - Go live in minutes with zero-downtime deploys
@@ -259,6 +276,7 @@ Example:
 Never list features alone. Always pair with the benefit (the "so what?").
 
 **Feature-Benefit formula:**
+
 ```
 Feature: {What it does}
 Benefit: So you can {outcome the user cares about}
@@ -287,6 +305,7 @@ Benefit: So you can {outcome the user cares about}
 ```
 
 **Arrange features by importance:**
+
 1. The feature that solves the #1 pain point (biggest, most prominent)
 2. The feature that differentiates from competitors
 3. Supporting features that round out the product
@@ -355,6 +374,7 @@ Social proof is the most persuasive element on the page. Layer multiple types:
 ```
 
 **Testimonial writing rules:**
+
 - Include specific outcomes ("40% more leads" > "more leads")
 - Include name, role, company, and photo (real > stock)
 - Match testimonials to the objection they overcome
@@ -404,6 +424,7 @@ Address the top 5-7 objections that prevent conversion:
 #### Section 7: Pricing (if applicable)
 
 Only include pricing on the landing page if:
+
 - The product has clear, fixed pricing
 - The user wants pricing on the page
 - The traffic is warm/hot (they already know what the product does)
@@ -448,6 +469,7 @@ Only include pricing on the landing page if:
 ```
 
 **Pricing copy rules:**
+
 - Anchor with the highest plan first (or highlight the middle plan)
 - Use specific numbers ("$49/mo" > "Starting at...")
 - Show value: "$49/mo - less than the cost of one lost lead"
@@ -484,6 +506,7 @@ The closing CTA should create urgency and restate the core value:
 ```
 
 **Final CTA formulas:**
+
 ```
 "Ready to {desired outcome}?"
 "Start {action}ing today"
@@ -497,10 +520,12 @@ The closing CTA should create urgency and restate the core value:
 Landing pages should rank too. Include:
 
 **Meta tags:**
+
 - Title: "{Product} - {Primary benefit} | {Brand}" (50-60 chars)
 - Description: "{Product} helps {audience} {outcome}. {Proof point}. {CTA}." (150-160 chars)
 
 **On-page SEO:**
+
 - H1 includes primary keyword
 - Primary keyword in first 100 words
 - Image alt text with keyword

--- a/.claude/skills/youtube-analytics/SKILL.md
+++ b/.claude/skills/youtube-analytics/SKILL.md
@@ -27,16 +27,19 @@ Base URL: `https://www.googleapis.com/youtube/v3`
 ### Channel Analysis
 
 **Get channel by username or handle:**
+
 ```bash
 curl -s "https://www.googleapis.com/youtube/v3/channels?part=snippet,statistics,contentDetails,brandingSettings&forHandle=@{handle}&key=${YOUTUBE_API_KEY}"
 ```
 
 **Get channel by ID:**
+
 ```bash
 curl -s "https://www.googleapis.com/youtube/v3/channels?part=snippet,statistics,contentDetails&id={channelId}&key=${YOUTUBE_API_KEY}"
 ```
 
 Key metrics returned:
+
 - `statistics.viewCount` — Total channel views
 - `statistics.subscriberCount` — Subscriber count
 - `statistics.videoCount` — Total videos published
@@ -45,6 +48,7 @@ Key metrics returned:
 ### List Channel Videos
 
 **Get uploads playlist:**
+
 ```bash
 curl -s "https://www.googleapis.com/youtube/v3/playlistItems?part=snippet,contentDetails&playlistId={uploadsPlaylistId}&maxResults=50&key=${YOUTUBE_API_KEY}"
 ```
@@ -52,11 +56,13 @@ curl -s "https://www.googleapis.com/youtube/v3/playlistItems?part=snippet,conten
 ### Video Performance
 
 **Get video statistics:**
+
 ```bash
 curl -s "https://www.googleapis.com/youtube/v3/videos?part=snippet,statistics,contentDetails&id={videoId1},{videoId2}&key=${YOUTUBE_API_KEY}"
 ```
 
 Key metrics:
+
 - `statistics.viewCount` — Views
 - `statistics.likeCount` — Likes
 - `statistics.commentCount` — Comments
@@ -67,11 +73,13 @@ Key metrics:
 ### Search
 
 **Search videos by keyword:**
+
 ```bash
 curl -s "https://www.googleapis.com/youtube/v3/search?part=snippet&q={keyword}&type=video&maxResults=10&order=relevance&key=${YOUTUBE_API_KEY}"
 ```
 
 **Search with filters:**
+
 - `order=viewCount` — Most viewed
 - `order=date` — Most recent
 - `order=rating` — Highest rated
@@ -95,12 +103,14 @@ Pull channel data and compute:
 ### Step 2: Top Performing Content
 
 List the last 50 videos and sort by:
+
 1. View count (absolute performance)
 2. Views per day since publish (velocity)
 3. Engagement rate (likes + comments / views)
 4. Like-to-view ratio
 
 Identify patterns in top performers:
+
 - Common topics or keywords
 - Video length sweet spot
 - Thumbnail style (from title patterns)
@@ -109,6 +119,7 @@ Identify patterns in top performers:
 ### Step 3: Content Gaps
 
 Search for the channel's core keywords and compare:
+
 - What top-ranking videos cover vs. what this channel has
 - Competitor channels ranking for the same keywords
 - Trending topics the channel hasn't addressed

--- a/.kiro/steering/serverless.md
+++ b/.kiro/steering/serverless.md
@@ -5,6 +5,7 @@ inclusion: always
 # Infrastructure Constraint: Serverless Only
 
 All implementations MUST be serverless. Never create, suggest, or reference:
+
 - EC2 instances
 - ECS on EC2 launch type
 - Self-managed VMs or servers

--- a/.markdownlint-cli2.jsonc
+++ b/.markdownlint-cli2.jsonc
@@ -58,6 +58,12 @@
     "coverage",
     "**/node_modules/**",
     ".claude/**/node_modules/**",
+    // .claude/skills/** are vendored OpenClaudia skill docs (~67 SKILL.md
+    // files) installed via the OpenClaudia tooling, not authored here. Linting
+    // them surfaces real authoring issues in external content we don't own
+    // (MD059 "[here]" link text, MD056 malformed tables) — file upstream
+    // rather than patching local copies.
+    ".claude/skills/**",
     "CHANGELOG.md",
     // Generated, gitignored artifacts — not authored docs. markdownlint-cli2
     // does not read .gitignore, so these must be listed explicitly.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -456,8 +456,6 @@ which automates Stages 0-3 from the Pi.
 - `aws-actions/configure-aws-credentials`: `v4.x`
 - `hashicorp/setup-terraform`: prefer `v3.x` (v2 nears Node 20 EOL)
 
-
-
 ## OpenClaudia Marketing Skills
 
 67 marketing skills from [OpenClaudia](https://github.com/OpenClaudia/openclaudia-skills) are installed at `.claude/skills/`. They provide slash-command marketing automation for cloudless.gr.
@@ -485,11 +483,13 @@ which automates Stages 0-3 from the Pi.
 ### API Keys (in `~/.claude/.env.global`)
 
 Currently configured:
+
 - `CLOUDFLARE_API_TOKEN` — DNS/CDN operations
 - `NOTION_API_KEY` — content management queries
 - `SITE_URL` — https://cloudless.gr
 
 Add these for richer skill output when available:
+
 - `SEMRUSH_API_KEY` — keyword/backlink data
 - `RESEND_API_KEY` — send emails directly
 - `UNSPLASH_CLIENT_ID` — stock images for blog posts

--- a/cloudless-campaigns-code/README.md
+++ b/cloudless-campaigns-code/README.md
@@ -34,11 +34,13 @@ public/campaigns/
 1. **Copy files** into your cloudless.gr Next.js repo, preserving paths (treat the project root as `cloudless-campaigns-code/`).
 2. **Set the env var:** `NEXT_PUBLIC_LINKEDIN_PARTNER_ID=<your partner id>` in `.env.local`. LinkedIn Campaign Manager gives you this number on the "Conversion tracking" step of the ad-set wizard.
 3. **Mount the tag** in `app/layout.tsx`:
+
    ```tsx
    import { LinkedInInsightTag } from "@/components/LinkedInInsightTag";
    // inside <body>, ideally at the top:
    <LinkedInInsightTag />
    ```
+
 4. **Copy the two PNGs** into `public/campaigns/`:
    - `shop-insights-monday-digest-mockup.png` → `shop-online-hero.png`
    - `linkedin-ad-variant-a-creative.png` → `shop-online-ad-a.png`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,11 @@ extend-exclude = [
   ".ruff_cache",
   "node_modules",
   ".next",
+  # Vendored OpenClaudia skill scripts (e.g. .claude/skills/podcast-edit/
+  # filler_removal.py) are installed by external tooling and not owned here.
+  # File ruff drift upstream rather than reformatting local copies.
+  ".claude",
+  ".kiro",
 ]
 
 [tool.ruff.lint]


### PR DESCRIPTION
Companion to #973. The Lint & Format CI step also runs pnpm lint:md and ruff format/check, both of which were red on PR branches.

Causes:

- markdownlint-cli2 flagged 4 errors in vendored OpenClaudia skill content under .claude/skills/ (MD059 [here] link text, MD056 malformed table column count) that we do not own and should not patch locally.
- ruff format --check . flagged .claude/skills/podcast-edit/filler_removal.py — same story.

Fix:

- .markdownlint-cli2.jsonc: add .claude/skills/** to ignores (kept .claude/**/node_modules/** as-is; only skill content excluded).
- pyproject.toml: add .claude + .kiro to ruff extend-exclude (matches the README intent of governing helper scripts under scripts/infrastructure/lambda/).
- 73 .md files auto-fixed (markdownlint-cli2 --fix): blank-line drift around lists/fences. Mostly vendored skill content (now ignored anyway, so this is one-time housekeeping); CLAUDE.md and cloudless-campaigns-code/README.md were authored here.

Verification:

- pnpm lint:md → 0 errors across 121 linted files
- ruff format --check . → 22 files already formatted
- ruff check . → All checks passed