### PR TITLE
chore(ad-analytics): scaffold interfaces + skill (Phase 0)

### DIFF
--- a/scripts/nlp-lint-locales.py
+++ b/scripts/nlp-lint-locales.py
@@ -43,37 +43,136 @@ LANG_MAP = {
 # legitimately omit terminal punctuation, casing of "Cloudless" etc).
 SKIP_RULES_GLOBAL = {
     # Generic / formatting
-    "WHITESPACE_RULE",          # next-intl ICU placeholders break around args
-    "MORFOLOGIK_RULE_EN_US",    # we'll re-include this selectively below
+    "WHITESPACE_RULE",  # next-intl ICU placeholders break around args
+    "MORFOLOGIK_RULE_EN_US",  # we'll re-include this selectively below
 }
 
 # Per-language skip — brand names, technical terms etc that produce noise.
 SKIP_FOR_BRAND = {
-    "cloudless", "Cloudless", "Cloudless.gr", "AWS", "GCP", "Azure",
-    "GA4", "GDPR", "Stripe", "PayPal", "Viva", "WooCommerce", "Next.js",
-    "ELTA", "ACS", "Speedex", "Skroutz", "BestPrice", "Meta Pixel",
-    "Notion", "Lambda", "DynamoDB", "Insight Tag", "Hosted UI",
-    "Cognito", "Slack", "HubSpot", "Sentry", "OpenNext",
-    "Cloudflare", "Tailscale", "Athena", "AI", "MSP", "ETL", "SaaS",
-    "AWS Lambda", "S3", "EC2", "RDS", "Aurora",
-    "GraphQL", "REST", "API", "APIs", "URL", "URLs", "HTTPS", "TLS",
-    "TypeScript", "JavaScript", "Node.js", "React", "Vercel",
-    "Kubernetes", "Docker", "DevOps", "MLOps", "CI/CD",
+    "cloudless",
+    "Cloudless",
+    "Cloudless.gr",
+    "AWS",
+    "GCP",
+    "Azure",
+    "GA4",
+    "GDPR",
+    "Stripe",
+    "PayPal",
+    "Viva",
+    "WooCommerce",
+    "Next.js",
+    "ELTA",
+    "ACS",
+    "Speedex",
+    "Skroutz",
+    "BestPrice",
+    "Meta Pixel",
+    "Notion",
+    "Lambda",
+    "DynamoDB",
+    "Insight Tag",
+    "Hosted UI",
+    "Cognito",
+    "Slack",
+    "HubSpot",
+    "Sentry",
+    "OpenNext",
+    "Cloudflare",
+    "Tailscale",
+    "Athena",
+    "AI",
+    "MSP",
+    "ETL",
+    "SaaS",
+    "AWS Lambda",
+    "S3",
+    "EC2",
+    "RDS",
+    "Aurora",
+    "GraphQL",
+    "REST",
+    "API",
+    "APIs",
+    "URL",
+    "URLs",
+    "HTTPS",
+    "TLS",
+    "TypeScript",
+    "JavaScript",
+    "Node.js",
+    "React",
+    "Vercel",
+    "Kubernetes",
+    "Docker",
+    "DevOps",
+    "MLOps",
+    "CI/CD",
 }
 
 # English/technical loanwords commonly used in Greek/French/German UI copy
 # that LanguageTool flags as misspellings. These are intentional, so skip.
 LOANWORDS = {
-    "growth", "hacks", "spam", "cookies", "cookie", "dashboard",
-    "kickoff", "newsletter", "online", "email", "emails", "domain",
-    "hosting", "feed", "feeds", "logo", "blog", "blogs", "podcast",
-    "checkout", "marketing", "stack", "startup", "startups", "SaaS",
-    "premium", "Insights", "audit", "pipeline", "pipelines", "freemium",
-    "marketplace", "framework", "frameworks", "backup", "backups",
-    "router", "firewall", "POS", "CCTV", "B2B", "B2C", "KPIs",
-    "ETL", "MLOps", "DevOps", "frontend", "backend", "fullstack",
-    "cloud", "serverless", "tokens", "token", "session", "sessions",
-    "Pixel", "OS", "iOS", "Android", "Microsoft",
+    "growth",
+    "hacks",
+    "spam",
+    "cookies",
+    "cookie",
+    "dashboard",
+    "kickoff",
+    "newsletter",
+    "online",
+    "email",
+    "emails",
+    "domain",
+    "hosting",
+    "feed",
+    "feeds",
+    "logo",
+    "blog",
+    "blogs",
+    "podcast",
+    "checkout",
+    "marketing",
+    "stack",
+    "startup",
+    "startups",
+    "SaaS",
+    "premium",
+    "Insights",
+    "audit",
+    "pipeline",
+    "pipelines",
+    "freemium",
+    "marketplace",
+    "framework",
+    "frameworks",
+    "backup",
+    "backups",
+    "router",
+    "firewall",
+    "POS",
+    "CCTV",
+    "B2B",
+    "B2C",
+    "KPIs",
+    "ETL",
+    "MLOps",
+    "DevOps",
+    "frontend",
+    "backend",
+    "fullstack",
+    "cloud",
+    "serverless",
+    "tokens",
+    "token",
+    "session",
+    "sessions",
+    "Pixel",
+    "OS",
+    "iOS",
+    "Android",
+    "Microsoft",
 }
 
 # Interpolation tokens used by next-intl / ICU.
@@ -120,7 +219,11 @@ class Finding:
         # Morphological/spelling rule misfires: in non-English locales, ASCII
         # tokens flagged by MORFOLOGIK_RULE_* are almost always English
         # loanwords the team wrote on purpose (growth, hacks, dashboard…).
-        if self.locale != "en" and self.rule_id.startswith("MORFOLOGIK_RULE_") and ASCII_RE.match(m):
+        if (
+            self.locale != "en"
+            and self.rule_id.startswith("MORFOLOGIK_RULE_")
+            and ASCII_RE.match(m)
+        ):
             return True
         # "ETL pipelines", "Big Data", "AI marketing" etc — short ALL CAPS
         # acronyms are virtually never spelling errors.
@@ -149,7 +252,9 @@ class Finding:
         return True
 
 
-def lint_locale(locale: str, data, tools: dict[str, language_tool_python.LanguageTool]) -> list[Finding]:
+def lint_locale(
+    locale: str, data, tools: dict[str, language_tool_python.LanguageTool]
+) -> list[Finding]:
     lt = tools[locale]
     findings: list[Finding] = []
     for key, text in iter_leaf_strings(data):
@@ -209,10 +314,15 @@ def update_value(data, key_path: str, new_value: str) -> None:
 def main() -> int:
     ap = argparse.ArgumentParser()
     ap.add_argument("--fix", action="store_true", help="Apply unambiguous fixes in place.")
-    ap.add_argument("--json", action="store_true", help="Print JSON instead of human-readable text.")
+    ap.add_argument(
+        "--json", action="store_true", help="Print JSON instead of human-readable text."
+    )
     args = ap.parse_args()
 
-    print("=== bootstrapping LanguageTool engines (first run downloads ~250 MB jar) ===", file=sys.stderr)
+    print(
+        "=== bootstrapping LanguageTool engines (first run downloads ~250 MB jar) ===",
+        file=sys.stderr,
+    )
     tools = {locale: language_tool_python.LanguageTool(code) for locale, code in LANG_MAP.items()}
 
     all_findings: list[Finding] = []
@@ -257,32 +367,38 @@ def main() -> int:
                     needs_review.append(f)
 
     if args.json:
-        print(json.dumps(
-            {
-                "total": len(all_findings),
-                "applied": applied,
-                "needs_review": [
-                    {
-                        "locale": f.locale,
-                        "key": f.key,
-                        "text": f.text,
-                        "rule_id": f.rule_id,
-                        "message": f.message,
-                        "match": f.context_match,
-                        "replacements": f.replacements,
-                    }
-                    for f in needs_review
-                ],
-            },
-            ensure_ascii=False,
-            indent=2,
-        ))
+        print(
+            json.dumps(
+                {
+                    "total": len(all_findings),
+                    "applied": applied,
+                    "needs_review": [
+                        {
+                            "locale": f.locale,
+                            "key": f.key,
+                            "text": f.text,
+                            "rule_id": f.rule_id,
+                            "message": f.message,
+                            "match": f.context_match,
+                            "replacements": f.replacements,
+                        }
+                        for f in needs_review
+                    ],
+                },
+                ensure_ascii=False,
+                indent=2,
+            )
+        )
     else:
         if args.fix:
-            print(f"\n=== applied {applied} unambiguous fixes; {len(needs_review)} need human review ===")
+            print(
+                f"\n=== applied {applied} unambiguous fixes; {len(needs_review)} need human review ==="
+            )
         else:
             safe = sum(1 for f in all_findings if f.safe_to_apply)
-            print(f"\n=== {len(all_findings)} findings total; {safe} are auto-fixable, {len(needs_review)} need human review ===")
+            print(
+                f"\n=== {len(all_findings)} findings total; {safe} are auto-fixable, {len(needs_review)} need human review ==="
+            )
         print()
         for f in needs_review[:60]:
             print(f"[{f.locale}] {f.key}")

--- a/scripts/verify-linkedin-tag.py
+++ b/scripts/verify-linkedin-tag.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 """Quick sanity check: does the live cloudless.gr serve a JS chunk that
 carries the LinkedIn partner ID 9535068? Run after a deploy."""
+
 from __future__ import annotations
 
 import re

--- a/skills/ad-analytics/SKILL.md
+++ b/skills/ad-analytics/SKILL.md
@@ -1,0 +1,146 @@
+---
+name: ad-analytics
+description: |
+  Build, extend, or operate the reusable ad-analytics Slack module on
+  cloudless.gr. Use whenever the user mentions: LinkedIn / Meta / Google /
+  TikTok ad metrics, real-time conversion alerts, Slack digests of ad
+  performance, /cloudless analytics slash commands, ad-anomaly DMs, the
+  AdPlatformAdapter or NotificationChannel interfaces, /api/ad-analytics/*,
+  /api/cron/ad-analytics-poll, or any change under src/lib/ad-analytics/**.
+
+  The Notion canonicals are:
+    - 📊 Reusable Ad Analytics Slack App — Architecture
+      (3837d82c-410a-81bf-b560-d517d9140138)
+    - ✅ Ad Analytics Slack App — Build Tracker
+      (3837d82c-410a-81f9-ab17-f212493a4613)
+  under 📣 Campaign Management (35e7d82c-410a-8193-bc45-e05668806eda).
+---
+
+# Reusable ad-analytics Slack module
+
+cloudless.gr ships a configurable, multi-platform ad-analytics module that:
+
+- Captures **real-time conversion events** from any campaign (in-seconds via
+  the browser thanks-page fire) and posts to Slack.
+- Polls **per-platform ad metrics** every 15 min (LinkedIn AdAnalytics today,
+  Meta / Google Ads / TikTok as adapters land), diffs vs a DynamoDB bookmark,
+  posts a Block Kit digest to Slack.
+- Exposes `/cloudless analytics …` Slack slash commands for on-demand status.
+- DMs the operator when configured anomaly rules fire.
+
+**Reusability principle:** ONE configurable module — not one Slack app per
+platform. Adding a new ad platform = implementing `AdPlatformAdapter`. Adding
+a new notification target = implementing `NotificationChannel`. Adding a new
+campaign = appending one config entry in `src/data/campaigns.ts`. Never copy.
+
+## File map
+
+| Piece                          | Path                                                                            |
+| ------------------------------ | ------------------------------------------------------------------------------- |
+| Configuration                  | `src/data/campaigns.ts` (extended schema)                                       |
+| Public types                   | `src/lib/ad-analytics/types.ts`                                                 |
+| Platform adapter interface     | `src/lib/ad-analytics/adapters/ad-platform.ts`                                  |
+| Notification channel interface | `src/lib/ad-analytics/channels/notification.ts`                                 |
+| LinkedIn adapter (concrete)    | `src/lib/ad-analytics/adapters/linkedin.ts` (wraps `lib/campaigns/linkedin.ts`) |
+| Slack channel (concrete)       | `src/lib/ad-analytics/channels/slack.ts` (wraps `lib/slack-notify.ts`)          |
+| Orchestrator                   | `src/lib/ad-analytics/runtime.ts`                                               |
+| Bookmark state                 | `src/lib/ad-analytics/bookmarks.ts` (DynamoDB)                                  |
+| Digest renderer                | `src/lib/ad-analytics/digest.ts`                                                |
+| Anomaly evaluator              | `src/lib/ad-analytics/anomaly.ts`                                               |
+| Real-time conversion route     | `src/app/api/ad-analytics/conversion/route.ts`                                  |
+| Scheduled poll route           | `src/app/api/cron/ad-analytics-poll/route.ts`                                   |
+| Slash command extension        | `src/app/api/slack/commands/route.ts` (add subcommand)                          |
+| Scheduled workflow             | `.github/workflows/linkedin-poll.yml` (every 15 min)                            |
+| Architecture doc               | `docs/ad-analytics-architecture.md`                                             |
+
+## Operating principles
+
+1. **L1 reusable, L2-extractable.** Build inside `src/lib/ad-analytics/` with
+   module boundaries clean enough that a future `@cloudless/ad-analytics`
+   npm extract is mechanical. Don't pay the cross-repo tax until it pays back.
+2. **Two LinkedIn conversion IDs per event.** Per the Gilgamesh CAPI
+   source-bound finding, every event needs `insightTagConversionId` (browser)
+   AND `capiConversionId` (server). Same `eventId` (Stripe session ID) on both.
+   LinkedIn dedupes account-scoped. The CAPI-typed conversion must be created
+   in Campaign Manager UI BEFORE the server path is enabled.
+3. **`LinkedIn-Version: 202605`** — pin the API version explicitly. The
+   existing `src/lib/campaigns/linkedin.ts` pins `202401` which is 16 months
+   stale and missing the `appointmentsScheduled` metric.
+4. **No webhooks from LinkedIn.** Polling is the only ad-metrics path.
+   Practical floor is 15 min — LinkedIn's reporting pipeline lag makes
+   anything faster wasteful.
+5. **AdAnalytics has no pagination.** Partition queries by campaign ×
+   time-window (the Singer.io tap pattern).
+6. **Slack 3-second budget** for slash commands. Existing
+   `/api/slack/commands` handler already implements the lazy-listener
+   pattern (ack <3s, defer, `chat.update`). Reuse it.
+7. **Cron-secret gating** identical to `/api/cron/slack-digest` already in
+   the codebase — reuse `CRON_SECRET`.
+8. **Idempotent bookmarks.** Each `(campaign, platform, metric, window)`
+   tuple has its own DynamoDB item. Polling is idempotent — re-running a
+   poll over the same window produces the same result.
+
+## Adding a new ad platform (3 steps)
+
+1. Create `src/lib/ad-analytics/adapters/<platform>.ts` implementing
+   `AdPlatformAdapter`. Wrap the existing `src/lib/campaigns/<platform>.ts`
+   client if one exists.
+2. Register it in `src/lib/ad-analytics/runtime.ts` `ADAPTERS` map.
+3. Append a `{ platform: "<platform>", … }` entry to the campaign's
+   `adPlatforms[]` in `src/data/campaigns.ts`.
+
+No other code changes required. Notifications, digests, slash commands, and
+anomaly evaluation all flow automatically.
+
+## Adding a new notification channel (3 steps)
+
+1. Create `src/lib/ad-analytics/channels/<channel>.ts` implementing
+   `NotificationChannel`.
+2. Register it in `src/lib/ad-analytics/runtime.ts` `CHANNELS` map.
+3. Append a `{ channel: "<channel>", target: "…", level: "event" | "digest" }`
+   entry to the campaign's `notifyChannels[]`.
+
+## Required env
+
+| Variable                                | Where       | Purpose                                           |
+| --------------------------------------- | ----------- | ------------------------------------------------- |
+| `LINKEDIN_ACCESS_TOKEN`                 | SSM, server | LinkedIn Marketing API (already set)              |
+| `LINKEDIN_AD_ACCOUNT_ID`                | SSM, server | (already set)                                     |
+| `SLACK_BOT_TOKEN` / `SLACK_WEBHOOK_URL` | SSM         | Slack outbound (already set)                      |
+| `CRON_SECRET`                           | SSM, server | Gates `/api/cron/ad-analytics-poll` (already set) |
+| `AD_ANALYTICS_BOOKMARKS_TABLE`          | SSM, server | DynamoDB table for poll state (NEW, Phase 2)      |
+
+## Verification recipe
+
+After any change:
+
+```bash
+pnpm typecheck
+pnpm test:ci -- ad-analytics
+pnpm test:e2e -- --grep ad-analytics  # once e2e exists
+```
+
+Live verification of a real conversion via Chrome MCP:
+
+1. Hit `https://cloudless.gr/en/campaigns/shop-online/thanks?tier=full-bundle&order=cs_test_xyz`
+2. Within 5 s a Block Kit message should appear in `#ads-realtime`.
+3. `window.lintrk("track", { conversion_id: 26846068 })` still fires.
+
+## Phase order (do not skip steps)
+
+- **Phase 0** — Scaffold types + interfaces. Zero behavior change.
+- **Phase 1** — Real-time conversion → Slack.
+- **Phase 2** — Scheduled 15-min digest.
+- **Phase 3** — Slash command surface.
+- **Phase 4** — Anomaly DM alerts.
+
+Each phase ships as its own PR with typecheck + tests + a verification log.
+
+## References
+
+- Notion: [📊 Reusable Ad Analytics Slack App — Architecture](https://app.notion.com/p/3837d82c410a81bfb560d517d9140138)
+- Notion: [✅ Ad Analytics Slack App — Build Tracker](https://app.notion.com/p/3837d82c410a81f9ab17f212493a4613)
+- Gilgamesh: [LinkedIn CAPI Is Not Meta CAPI — the source-bound conversion trap](https://gilgamesh.in/blog/linkedin-capi-source-bound-conversions)
+- Singer.io: [tap-linkedin-ads](https://github.com/singer-io/tap-linkedin-ads) — bookmark pattern reference
+- Microsoft Learn: [LinkedIn Reporting API](https://learn.microsoft.com/en-us/linkedin/marketing/integrations/ads-reporting/ads-reporting?view=li-lms-2026-03)
+- Existing repo skill: [linkedin-campaigns](../linkedin-campaigns/SKILL.md)

--- a/src/lib/ad-analytics/adapters/ad-platform.ts
+++ b/src/lib/ad-analytics/adapters/ad-platform.ts
@@ -1,0 +1,65 @@
+/**
+ * AdPlatformAdapter — the per-platform contract for pulling metrics and
+ * pushing server-side conversion events.
+ *
+ * Adding a new ad platform (Meta, Google Ads, TikTok, X) = implementing
+ * this interface and registering it in `runtime.ts`. The orchestrator never
+ * imports a concrete adapter directly.
+ *
+ * The first concrete implementation is `./linkedin.ts` which wraps the
+ * existing `src/lib/campaigns/linkedin.ts` client (with `LinkedIn-Version`
+ * bumped to `202605`).
+ */
+
+import type { AdMetrics, AdPlatformId } from "../types";
+
+/** Minimal user identifiers a CAPI push can use to match the event.
+ *  LinkedIn supports hashed email, hashed phone, LiFatId, and a few others.
+ *  Adapters that don't need user matching can ignore this. */
+export interface UserMatch {
+  emailSha256?: string;
+  phoneSha256?: string;
+  /** LinkedIn first-party click identifier captured from the
+   *  `?li_fat_id=…` query param on the landing page. */
+  liFatId?: string;
+  ipAddress?: string;
+  userAgent?: string;
+}
+
+export interface AdPlatformAdapter {
+  readonly id: AdPlatformId;
+
+  /** Returns true when SSM/env credentials are present and recently valid.
+   *  Mirrors the existing `isConfigured()` 503 pattern documented under
+   *  📣 Campaign Management. */
+  isConfigured(): Promise<boolean>;
+
+  /**
+   * Pull per-campaign metrics for the requested window. Adapters that
+   * lack pagination (LinkedIn AdAnalytics) partition internally by
+   * campaign × time-window so callers never have to. Implementations MUST
+   * return one `AdMetrics` per `campaignIds[i]`, in the same order.
+   */
+  pullMetrics(opts: {
+    accountId: string;
+    campaignIds: string[];
+    since: Date;
+    until: Date;
+  }): Promise<AdMetrics[]>;
+
+  /**
+   * Server-side conversion push (CAPI). For LinkedIn this requires that
+   * the `conversionId` was created in Campaign Manager with
+   * `conversionMethod = CONVERSIONS_API` — see the Gilgamesh source-bound
+   * note in the skill. The adapter returns `{ accepted: false, status }`
+   * on 403 instead of throwing so the runtime can degrade cleanly.
+   */
+  pushConversion(opts: {
+    accountId: string;
+    conversionId: number;
+    eventId: string;
+    happenedAt: Date;
+    user?: UserMatch;
+    pageUrl?: string;
+  }): Promise<{ accepted: boolean; status: number; message?: string }>;
+}

--- a/src/lib/ad-analytics/channels/notification.ts
+++ b/src/lib/ad-analytics/channels/notification.ts
@@ -1,0 +1,45 @@
+/**
+ * NotificationChannel — the per-channel contract for outbound notifications.
+ *
+ * Adding a new channel (Discord, Teams, email, etc.) = implementing this
+ * interface and registering it in `runtime.ts`. The orchestrator never
+ * imports a concrete channel directly.
+ *
+ * The first concrete implementation is `./slack.ts` which wraps the
+ * existing `src/lib/slack-notify.ts` `SlackClient`.
+ */
+
+import type { NotificationChannelId } from "../types";
+
+/** Subset of Slack Block Kit / generic block descriptor used by the digest
+ *  + event renderers. Channels translate this into their wire format. The
+ *  shape mirrors Slack's Block Kit because that's the richest target — the
+ *  email channel will fall back to a markdown rendering, Discord to embeds. */
+export interface NotificationBlock {
+  type: "section" | "context" | "header" | "divider" | "actions";
+  text?: string;
+  fields?: Array<{ title: string; value: string }>;
+  /** Slack Block Kit raw JSON, when a section requires capabilities the
+   *  abstraction doesn't cover yet. Channels that can't render this fall
+   *  back to `text`. */
+  slackRaw?: unknown;
+}
+
+export interface NotificationChannel {
+  readonly id: NotificationChannelId;
+
+  /** Returns true when the channel is configured (SLACK_BOT_TOKEN present,
+   *  for instance). */
+  isConfigured(): Promise<boolean>;
+
+  /**
+   * Post a top-level notification. `target` is channel-specific (Slack
+   * channel name / DM user id / email address / Discord webhook URL).
+   * Returns a stable handle that can be used by `reply()` to thread.
+   */
+  sendBlock(opts: { target: string; blocks: NotificationBlock[] }): Promise<{ messageId: string }>;
+
+  /** Reply in-thread to a previously sent message. No-op for channels
+   *  (email, basic webhooks) that have no concept of threads. */
+  reply(opts: { threadKey: string; blocks: NotificationBlock[] }): Promise<void>;
+}

--- a/src/lib/ad-analytics/types.ts
+++ b/src/lib/ad-analytics/types.ts
@@ -1,0 +1,140 @@
+/**
+ * Shared types for the reusable ad-analytics module.
+ *
+ * All identifiers live here so adapter implementations, channel
+ * implementations, the runtime orchestrator, the conversion route, the
+ * scheduled poll, and the slash-command handler all import from one place.
+ *
+ * Adding a new ad platform = add to `AdPlatformId`, implement an
+ * `AdPlatformAdapter`, register in `runtime.ts`.
+ * Adding a new notification channel = add to `NotificationChannelId`,
+ * implement a `NotificationChannel`, register in `runtime.ts`.
+ *
+ * See `docs/ad-analytics-architecture.md` and `skills/ad-analytics/SKILL.md`.
+ */
+
+/** Per-platform identifiers used in `src/data/campaigns.ts` and
+ *  registered adapter lookups. */
+export type AdPlatformId = "linkedin" | "meta" | "google-ads" | "tiktok" | "x";
+
+/** Per-channel identifiers for outbound notifications. */
+export type NotificationChannelId = "slack" | "email" | "discord";
+
+/** What kind of notification this channel config wants to receive.
+ *  - `event` — one Slack message per real-time conversion event.
+ *  - `digest` — every-15-min metric digest with deltas.
+ *  - `anomaly` — DM operator when an anomaly rule fires. */
+export type NotificationLevel = "event" | "digest" | "anomaly";
+
+/** One ad platform's wiring on one campaign. Two conversion IDs per
+ *  Gilgamesh's source-bound finding: browser-only Insight Tag conversion +
+ *  server-only CAPI conversion. Same eventId on both so LinkedIn dedupes
+ *  account-scoped. */
+export interface CampaignPlatformConfig {
+  platform: AdPlatformId;
+  /** Platform-native account identifier (LinkedIn `urn:li:sponsoredAccount:N`
+   *  in short form, Meta ad-account ID, Google customer ID, etc.). */
+  accountId: string;
+  /** Platform-native campaign IDs to poll. */
+  campaignIds: string[];
+  /** Browser-fired conversion (Insight Tag / Pixel). null = browser-side
+   *  not wired yet. */
+  insightTagConversionId: number | null;
+  /** Server-fired CAPI conversion. null = CAPI not wired yet. */
+  capiConversionId: number | null;
+}
+
+/** One notification target on one campaign. */
+export interface NotifyChannelConfig {
+  channel: NotificationChannelId;
+  /** Channel-specific target — `#ads-realtime` for Slack channels, a user
+   *  ID like `U12345` for DMs, an email address for the email channel. */
+  target: string;
+  level: NotificationLevel;
+}
+
+/** Per-campaign tunable thresholds for anomaly DMs. All values are optional;
+ *  unset = no anomaly check for that dimension. */
+export interface AnomalyRules {
+  /** Today's spend pace > N × yesterday's spend pace at same hour → DM. */
+  spendPaceMultiplier?: number;
+  /** CPC above this absolute value → DM. */
+  maxCpcEur?: number;
+  /** No conversions in N hours while spend > 0 → DM. */
+  zeroConversionsHours?: number;
+  /** CTR below this fraction (e.g. 0.005 = 0.5%) → DM. */
+  minCtr?: number;
+}
+
+/**
+ * A real-time conversion event arriving at `/api/ad-analytics/conversion`
+ * from a browser thanks-page fire. Becomes a Slack ping per matching
+ * `notifyChannels[].level === "event"`.
+ */
+export interface AdConversionEvent {
+  campaign: string;
+  tier: string | null;
+  orderId: string | null;
+  /** Numeric LinkedIn conversion ID (the browser one, from
+   *  `CampaignPlatformConfig.insightTagConversionId`). */
+  conversionId: number | null;
+  /** Locale at the time of fire — useful in the Slack render. */
+  locale?: string;
+  /** Page URL the visitor was on. */
+  url?: string;
+  userAgent?: string;
+  /** Cloudflare-derived country code, if available. */
+  country?: string;
+  /** Captured first-touch UTM if `AttributionCapture` set them. */
+  utm?: {
+    source?: string;
+    medium?: string;
+    campaign?: string;
+    term?: string;
+    content?: string;
+  };
+}
+
+/** Snapshot of per-platform metrics for a campaign over a window. */
+export interface AdMetrics {
+  platform: AdPlatformId;
+  campaignId: string;
+  windowStart: string; // ISO
+  windowEnd: string; // ISO
+  impressions: number;
+  clicks: number;
+  conversions: number;
+  spendEur: number;
+  /** Derived where the platform doesn't already expose them. */
+  ctr?: number;
+  cpcEur?: number;
+  cpaEur?: number;
+}
+
+/** Delta of `current` vs the previous `bookmark` snapshot. */
+export interface AdMetricsDelta {
+  current: AdMetrics;
+  previous: AdMetrics | null;
+  delta: {
+    impressions: number;
+    clicks: number;
+    conversions: number;
+    spendEur: number;
+  };
+}
+
+/** DynamoDB-backed bookmark for one (campaign, platform, metric, window)
+ *  tuple. Holds the last snapshot we posted and the timestamp we posted
+ *  it. Re-posting a digest is idempotent over the same window. */
+export interface Bookmark {
+  key: string; // ad-analytics:<campaign>:<platform>:<metric>:<window>
+  lastPostedAt: string; // ISO
+  snapshot: AdMetrics;
+}
+
+/** Convenience: the matching `CampaignPlatformConfig` from
+ *  `src/data/campaigns.ts` for a given event/digest. */
+export interface ResolvedPlatform {
+  campaignSlug: string;
+  config: CampaignPlatformConfig;
+}


### PR DESCRIPTION
Lands the type + interface boundary for the reusable ad-analytics module, plus the agent-facing skill documenting the architecture, gotchas, and phase order. **Zero runtime change** — no route touched, no campaign data extended yet.

## Why now

User asked for a reusable Slack app that captures LinkedIn ad activity in real time and produces analytics for any campaign. Design + build tracker are in Notion under 📣 Campaign Management:

- [📊 Reusable Ad Analytics Slack App — Architecture](https://app.notion.com/p/3837d82c410a81bfb560d517d9140138)
- [✅ Ad Analytics Slack App — Build Tracker](https://app.notion.com/p/3837d82c410a81f9ab17f212493a4613)

## Architecture key points

- One configurable module, not one Slack app per platform.
- AdPlatformAdapter / NotificationChannel interfaces, registered in a central runtime map. Adding LinkedIn/Meta/Google/TikTok/X = implement + register + append to campaign config.
- L1 reusable (within cloudless.gr), L2-extractable later as @cloudless/ad-analytics once a second repo needs it.
- **Two LinkedIn conversion IDs per event** per the [Gilgamesh CAPI source-bound finding](https://gilgamesh.in/blog/linkedin-capi-source-bound-conversions): insightTagConversionId (browser, immutable) + capiConversionId (server, immutable). Same eventId on both.
- LinkedIn-Version 202605 (current 202401 is 16 months stale).
- No webhooks from LinkedIn for ad events; polling at 15-min floor.
- AdAnalytics has no pagination; partition by campaign × time-window.

## Files

- skills/ad-analytics/SKILL.md (agent-facing playbook)
- src/lib/ad-analytics/types.ts (shared types)
- src/lib/ad-analytics/adapters/ad-platform.ts (platform interface)
- src/lib/ad-analytics/channels/notification.ts (channel interface)

## Verification

pnpm typecheck ✔