### PR TITLE
fix(funnel): forward UTM into Stripe metadata + route fit-call to /contact

### DIFF
--- a/__tests__/checkout-api.test.ts
+++ b/__tests__/checkout-api.test.ts
@@ -19,6 +19,94 @@ vi.mock("@/lib/api-auth", () => ({
   verifyToken: vi.fn(() => Promise.resolve(null)),
 }));
 
+// ---------------------------------------------------------------------------
+// GET /api/checkout — campaign tier flow (paid + fit-call)
+// ---------------------------------------------------------------------------
+
+describe("GET /api/checkout (campaign tier)", () => {
+  let GET: (request: NextRequest) => Promise<Response>;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    mockCreate.mockResolvedValue({ url: "https://checkout.stripe.com/campaign-session" });
+    const mod = await import("@/app/api/checkout/route");
+    GET = mod.GET;
+  });
+
+  it("redirects fit-call to /contact with topic + campaign + UTM forwarded", async () => {
+    const url =
+      "http://localhost/api/checkout?campaign=shop-online&tier=fit-call" +
+      "&utm_source=linkedin&utm_medium=cpc&utm_campaign=shop_online_founding&utm_content=A_EN";
+    const request = new NextRequest(url, {
+      method: "GET",
+      headers: { "x-pathname": "/en/campaigns/shop-online" },
+    });
+
+    const response = await GET(request);
+    expect(response.status).toBe(302);
+    const location = response.headers.get("location") ?? "";
+    expect(location).toContain("/en/contact");
+    expect(location).toContain("topic=fit-call");
+    expect(location).toContain("campaign=shop-online");
+    expect(location).toContain("utm_source=linkedin");
+    expect(location).toContain("utm_content=A_EN");
+    // Stripe is not involved on the fit-call path.
+    expect(mockCreate).not.toHaveBeenCalled();
+  });
+
+  it("stamps UTM into Stripe metadata when present on a paid tier", async () => {
+    const url =
+      "http://localhost/api/checkout?campaign=shop-online&tier=starter" +
+      "&utm_source=linkedin&utm_medium=cpc&utm_campaign=shop_online_founding&utm_content=A_EN";
+    const request = new NextRequest(url, {
+      method: "GET",
+      headers: { "x-pathname": "/en/campaigns/shop-online" },
+    });
+
+    const response = await GET(request);
+    expect(response.status).toBe(303);
+    const createCall = mockCreate.mock.calls[0][0];
+    expect(createCall.metadata).toMatchObject({
+      source: "cloudless.gr",
+      campaign: "shop-online",
+      tier: "starter",
+      utm_source: "linkedin",
+      utm_medium: "cpc",
+      utm_campaign: "shop_online_founding",
+      utm_content: "A_EN",
+    });
+  });
+
+  it("omits UTM keys from metadata when not present (no empty values)", async () => {
+    const request = new NextRequest(
+      "http://localhost/api/checkout?campaign=shop-online&tier=starter",
+      { method: "GET", headers: { "x-pathname": "/en/campaigns/shop-online" } }
+    );
+
+    const response = await GET(request);
+    expect(response.status).toBe(303);
+    const md = mockCreate.mock.calls[0][0].metadata as Record<string, string>;
+    expect(md.source).toBe("cloudless.gr");
+    expect(md.campaign).toBe("shop-online");
+    expect(md.tier).toBe("starter");
+    // Empty UTM values do not waste Stripe's 50-key metadata budget.
+    expect(md.utm_source).toBeUndefined();
+    expect(md.utm_content).toBeUndefined();
+  });
+
+  it("returns 400 when campaign or tier query param is missing", async () => {
+    const noCampaign = new NextRequest("http://localhost/api/checkout?tier=starter", {
+      method: "GET",
+    });
+    expect((await GET(noCampaign)).status).toBe(400);
+
+    const noTier = new NextRequest("http://localhost/api/checkout?campaign=shop-online", {
+      method: "GET",
+    });
+    expect((await GET(noTier)).status).toBe(400);
+  });
+});
+
 
 describe("POST /api/checkout", () => {
   let POST: (request: NextRequest) => Promise<Response>;

--- a/__tests__/slack-notify.test.ts
+++ b/__tests__/slack-notify.test.ts
@@ -331,5 +331,28 @@ describe("slack-notify", () => {
       expect(rendered).toContain("EUR 99.00");
       expect(rendered).toContain("buyer@x");
     });
+
+    it("includes attribution line when carrying UTM from Stripe metadata", async () => {
+      getSlackConfigAsyncMock.mockResolvedValueOnce({
+        SLACK_BOT_TOKEN: "xoxb-x",
+      });
+      fetchMock.mockResolvedValueOnce(jsonResp({ ok: true }));
+      await slackOrderNotify({
+        sessionId: "cs_test_with_utm",
+        amount: "EUR 890.00",
+        email: "founder@example.com",
+        attribution:
+          "utm_source=linkedin | utm_medium=cpc | utm_campaign=shop_online_founding | utm_content=A_EN | campaign_slug=shop-online | tier=starter",
+      });
+      const body = JSON.parse(
+        (fetchMock.mock.calls[0][1] as { body: string }).body,
+      );
+      const rendered = JSON.stringify(body);
+      // The attribution line surfaces the creative variant so the operator
+      // sees ad-creative-level attribution without round-tripping to Stripe.
+      expect(rendered).toContain("Attribution:");
+      expect(rendered).toContain("utm_content=A_EN");
+      expect(rendered).toContain("tier=starter");
+    });
   });
 });

--- a/src/app/api/checkout/route.ts
+++ b/src/app/api/checkout/route.ts
@@ -55,12 +55,29 @@ export async function GET(request: NextRequest) {
   const locale = pickLocale(request);
   const origin = request.nextUrl.origin;
 
-  // fit-call is the lead-form path — redirect to contact, not checkout.
+  // Pick first-touch UTM the TierTable client stamped into the URL.
+  // Bounded length defends Stripe metadata (500-char limit per value) and any
+  // downstream string-formatted log line.
+  const utm = {
+    utm_source: request.nextUrl.searchParams.get("utm_source")?.slice(0, 100) ?? "",
+    utm_medium: request.nextUrl.searchParams.get("utm_medium")?.slice(0, 100) ?? "",
+    utm_campaign: request.nextUrl.searchParams.get("utm_campaign")?.slice(0, 100) ?? "",
+    utm_term: request.nextUrl.searchParams.get("utm_term")?.slice(0, 100) ?? "",
+    utm_content: request.nextUrl.searchParams.get("utm_content")?.slice(0, 100) ?? "",
+  };
+
+  // fit-call is the lead-form path — redirect to the real contact form so we
+  // actually capture an email. Previously we 302'd straight to /thanks which
+  // promised "we'll email you" but never asked for the email. Forward UTM so
+  // the contact handler can stamp HubSpot + Slack with the originating creative.
   if (tier === "fit-call") {
-    return NextResponse.redirect(
-      new URL(`/${locale}/campaigns/${campaign.slug}/thanks?tier=fit-call`, origin),
-      302
-    );
+    const contactUrl = new URL(`/${locale}/contact`, origin);
+    contactUrl.searchParams.set("topic", "fit-call");
+    contactUrl.searchParams.set("campaign", campaign.slug);
+    for (const [k, v] of Object.entries(utm)) {
+      if (v) contactUrl.searchParams.set(k, v);
+    }
+    return NextResponse.redirect(contactUrl, 302);
   }
 
   const tierData = campaign.tiers.find((t) => t.id === tier)!;
@@ -75,6 +92,18 @@ export async function GET(request: NextRequest) {
   const stripe = await getStripe();
   if (!stripe) {
     return NextResponse.json({ error: "Stripe not configured" }, { status: 503 });
+  }
+
+  // Build Stripe metadata: source/campaign/tier plus first-touch UTM. Stripe
+  // caps each key at 40 chars and each value at 500 chars; we only ship keys
+  // when the value is non-empty so we don't waste the 50-key budget.
+  const metadata: Record<string, string> = {
+    source: "cloudless.gr",
+    campaign: campaign.slug,
+    tier: tier,
+  };
+  for (const [k, v] of Object.entries(utm)) {
+    if (v) metadata[k] = v;
   }
 
   const session = await stripe.checkout.sessions.create({
@@ -95,11 +124,7 @@ export async function GET(request: NextRequest) {
     success_url: `${origin}/${locale}/campaigns/${campaign.slug}/thanks?tier=${encodeURIComponent(tier)}&order={CHECKOUT_SESSION_ID}`,
     cancel_url: `${origin}/${locale}/campaigns/${campaign.slug}`,
     billing_address_collection: "required",
-    metadata: {
-      source: "cloudless.gr",
-      campaign: campaign.slug,
-      tier: tier,
-    },
+    metadata,
   });
 
   return NextResponse.redirect(session.url!, { status: 303 });

--- a/src/app/api/webhooks/stripe/route.ts
+++ b/src/app/api/webhooks/stripe/route.ts
@@ -14,23 +14,54 @@ import {
   markStripeEventFailed,
 } from "@/lib/stripe-transactions";
 
+/**
+ * Pull UTM fields out of the Stripe Checkout Session's `metadata` (the
+ * checkout route stamps `utm_source / utm_medium / utm_campaign / utm_content
+ * / utm_term` there when present), and return a human-readable one-liner
+ * plus a `[k, v]` list. Empty if no UTM was carried through the click.
+ */
+function extractUtmFromSession(session: Stripe.Checkout.Session): {
+  summary: string;
+  entries: Array<[string, string]>;
+} {
+  const md = session.metadata ?? {};
+  const keys = ["utm_source", "utm_medium", "utm_campaign", "utm_content", "utm_term"] as const;
+  const entries: Array<[string, string]> = [];
+  for (const k of keys) {
+    const v = md[k];
+    if (typeof v === "string" && v.length > 0) entries.push([k, v]);
+  }
+  // Campaign slug + tier travel in the same metadata bag — surface those too
+  // so the email/Slack note shows "which paid offer was purchased."
+  if (typeof md.campaign === "string" && md.campaign) entries.push(["campaign_slug", md.campaign]);
+  if (typeof md.tier === "string" && md.tier) entries.push(["tier", md.tier]);
+  return {
+    summary: entries.map(([k, v]) => `${k}=${v}`).join(" | "),
+    entries,
+  };
+}
+
 async function syncHubSpotDeal(session: Stripe.Checkout.Session): Promise<void> {
   try {
     const amountEur = (session.amount_total ?? 0) / 100;
     const currency = (session.currency ?? "eur").toUpperCase();
+    const { summary: utmSummary } = extractUtmFromSession(session);
     const contactId = await upsertContact({
       email: session.customer_email ?? "",
       firstname: session.customer_details?.name?.split(" ")[0] ?? "",
       lastname: session.customer_details?.name?.split(" ").slice(1).join(" ") ?? "",
       lead_source: "stripe_checkout",
     });
+    const dealDescription = utmSummary
+      ? `Stripe checkout session ${session.id}\nAttribution: ${utmSummary}`
+      : `Stripe checkout session ${session.id}`;
     const dealId = await createDeal({
       dealname: `Purchase – ${session.id}`,
       amount: amountEur,
       currency,
       dealstage: "closedwon",
       lead_source: "stripe_checkout",
-      description: `Stripe checkout session ${session.id}`,
+      description: dealDescription,
     });
     if (dealId && contactId) {
       await associateDealWithContact(dealId, contactId);
@@ -55,18 +86,25 @@ async function handleCheckoutCompleted(
     );
   }
 
+  const { summary: utmSummary, entries: utmEntries } = extractUtmFromSession(session);
+  const utmHtml = utmSummary
+    ? `<p><strong>Attribution:</strong> ${escapeHtml(utmSummary)}</p>`
+    : "";
+
   await notifyTeam(
     `[Order] New purchase: ${session.id}`,
     `<h3>New order received</h3>
     <p><strong>Customer:</strong> ${escapeHtml(session.customer_email ?? "N/A")}</p>
     <p><strong>Amount:</strong> ${((session.amount_total ?? 0) / 100).toFixed(2)} ${escapeHtml((session.currency ?? "EUR").toUpperCase())}</p>
-    <p><strong>Session:</strong> ${escapeHtml(session.id)}</p>`
+    <p><strong>Session:</strong> ${escapeHtml(session.id)}</p>
+    ${utmHtml}`
   );
 
   slackOrderNotify({
     sessionId: session.id,
     email: session.customer_email ?? "N/A",
     amount: String((session.amount_total ?? 0) / 100),
+    attribution: utmSummary || undefined,
   }).catch(() => {});
 
   recordNotification({
@@ -82,6 +120,9 @@ async function handleCheckoutCompleted(
       currency: (session.currency ?? "eur").toUpperCase(),
       paymentStatus: session.payment_status,
       mode: session.mode,
+      // First-touch attribution so the admin dashboard can filter conversions
+      // by ad creative without having to round-trip back to Stripe.
+      ...Object.fromEntries(utmEntries),
     },
   });
 

--- a/src/components/TierTable.tsx
+++ b/src/components/TierTable.tsx
@@ -1,13 +1,56 @@
 "use client";
 
+import type { MouseEvent } from "react";
 import type { Campaign, Locale } from "@/data/campaigns";
+import { getStoredAttribution } from "@/lib/lead-attribution";
 
 type Props = {
   campaign: Campaign;
   locale: Locale;
 };
 
+/**
+ * Read first-touch attribution from sessionStorage and append it to the
+ * outbound `/api/checkout?…` URL so the server can stamp UTM into Stripe
+ * metadata (or carry it to /contact for the fit-call path). Without this
+ * the visitor's creative variant (utm_content=A_EN / B_EN / …) is lost
+ * the moment they leave the landing page.
+ */
+function appendAttributionToHref(href: string): string {
+  if (typeof window === "undefined") return href;
+  const a = getStoredAttribution();
+  if (!a) return href;
+  let url: URL;
+  try {
+    url = new URL(href, window.location.origin);
+  } catch {
+    return href;
+  }
+  if (a.utmSource) url.searchParams.set("utm_source", a.utmSource);
+  if (a.utmMedium) url.searchParams.set("utm_medium", a.utmMedium);
+  if (a.utmCampaign) url.searchParams.set("utm_campaign", a.utmCampaign);
+  if (a.utmTerm) url.searchParams.set("utm_term", a.utmTerm);
+  if (a.utmContent) url.searchParams.set("utm_content", a.utmContent);
+  // Same-origin — drop the origin prefix so the navigation stays a same-origin
+  // redirect (matters for the GET-302 → Stripe Checkout handoff).
+  return url.pathname + url.search;
+}
+
 export default function TierTable({ campaign, locale }: Props) {
+  function handleCtaClick(e: MouseEvent<HTMLAnchorElement>) {
+    // Plain (no modifier) left clicks get the attribution-stamped URL. Cmd /
+    // Ctrl / middle-click / right-click stay default so "open in new tab"
+    // keeps working — those visitors still send the bare URL but session-
+    // storage attribution is preserved for any subsequent paid hit.
+    if (e.metaKey || e.ctrlKey || e.shiftKey || e.altKey || e.button !== 0) return;
+    const anchor = e.currentTarget;
+    const stamped = appendAttributionToHref(anchor.getAttribute("href") ?? "");
+    if (stamped && stamped !== anchor.getAttribute("href")) {
+      e.preventDefault();
+      window.location.href = stamped;
+    }
+  }
+
   return (
     <section className="cl-tiers" aria-label={locale === "el" ? "Πακέτα" : "Tiers"}>
       <div className="cl-tiers__grid">
@@ -27,9 +70,12 @@ export default function TierTable({ campaign, locale }: Props) {
             </ul>
             {/* `checkoutHref` is an API path (not a Next.js route) — must be a
                 plain <a>. `@/i18n/navigation`'s Link rewrites to add the locale
-                prefix, which would break the /api/checkout call. */}
+                prefix, which would break the /api/checkout call. The onClick
+                stamps first-touch UTM into the URL so the creative variant
+                survives the Stripe handoff. */}
             <a
               href={t.checkoutHref}
+              onClick={handleCtaClick}
               className="cl-tier__cta"
               data-tier={t.id}
               data-campaign={campaign.slug}

--- a/src/lib/slack-notify.ts
+++ b/src/lib/slack-notify.ts
@@ -487,19 +487,26 @@ export async function slackOrderNotify(data: {
   email: string;
   amount: string;
   sessionId: string;
+  /** Optional attribution summary (UTM source/medium/campaign/content/term plus
+   *  campaign_slug and tier) extracted from the Stripe Session metadata. When
+   *  present, surfaced as an extra line so the operator can see immediately
+   *  which ad creative drove the conversion. */
+  attribution?: string;
 }): Promise<boolean> {
   const safeEmail = slackEscape(data.email);
+  const lines = [
+    `*Customer:* ${safeEmail}`,
+    `*Amount:* ${data.amount}`,
+    `*Session:* \`${data.sessionId.slice(0, ORDER_SESSION_DISPLAY_LENGTH)}...\``,
+  ];
+  if (data.attribution) {
+    lines.push(`*Attribution:* ${slackEscape(data.attribution)}`);
+  }
   return ordersClient.post({
     text: `New order: ${data.amount} from ${safeEmail}`,
     blocks: [
       headerBlock("\ud83d\udcb0 New Order"),
-      sectionBlock(
-        [
-          `*Customer:* ${safeEmail}`,
-          `*Amount:* ${data.amount}`,
-          `*Session:* \`${data.sessionId.slice(0, ORDER_SESSION_DISPLAY_LENGTH)}...\``,
-        ].join("\n")
-      ),
+      sectionBlock(lines.join("\n")),
       contextBlock(slackTimestamp(), "cloudless.gr stripe checkout"),
     ],
     icon_url: BOT_ICON_URL,


### PR DESCRIPTION
Plug two data-loss gaps on the live LinkedIn paid funnel that the operator surfaced after the first click.

## What was leaking

**1. `tier=fit-call` was a black hole.** The CTA 302'd straight to `/thanks?tier=fit-call`. The page told the visitor "we'll email you 2-3 time slots" — but never asked for an email. Zero capture.

**2. UTM was dropped on the floor for paid tiers.** A €890 click from `utm_content=A_EN` landed in Stripe with `metadata { source, campaign, tier }` only. The originating ad creative was stored in `sessionStorage` by `AttributionCapture` and then never read on click-out. The operator could not see which creative drove a Stripe sale without separately joining LinkedIn Campaign Manager.

## What this PR does

**Client (`src/components/TierTable.tsx`)**: client-side `onClick` reads `getStoredAttribution()` and stamps `utm_*` into the `/api/checkout?...` URL before navigation. Modifier-click stays default so "open in new tab" keeps working.

**Server (`src/app/api/checkout/route.ts` GET)**:
- `fit-call` → 302 to `/[locale]/contact?topic=fit-call&campaign=<slug>&utm_*=...` (real form, already feeds HubSpot + Slack + Meta CAPI).
- Paid tier → stamps `utm_*` into `stripe.checkout.sessions.create({ metadata })`. Empty values skipped so the 50-key budget stays clean.

**Webhook (`src/app/api/webhooks/stripe/route.ts`)**: new `extractUtmFromSession()` builds a one-line attribution summary. Surfaced in:
- `notifyTeam()` HTML email body (new "Attribution" line)
- `slackOrderNotify()` Slack message (new "Attribution" field)
- `recordNotification()` admin-dashboard metadata
- HubSpot deal description (Stripe → HubSpot sync)

**Slack helper (`src/lib/slack-notify.ts`)**: `slackOrderNotify` gains an optional `attribution` field — backwards-compatible.

## Tests

- `__tests__/checkout-api.test.ts` — new GET suite (4 tests): fit-call redirect carries topic + campaign + UTM; paid tier metadata includes utm_*; empty UTM values are omitted; missing tier/campaign → 400.
- `__tests__/slack-notify.test.ts` — `slackOrderNotify` with `attribution` renders the line + utm_content + tier.

`pnpm typecheck` ok, 61/61 tests pass across 3 files.

## After deploy

A paid LinkedIn click shows up in:

- Stripe Dashboard → Customer metadata (utm_source/medium/campaign/content)
- #orders Slack → `Attribution: utm_source=linkedin | ... | utm_content=A_EN | campaign_slug=shop-online | tier=starter`
- HubSpot deal description → same one-liner
- Admin notification panel → metadata blob

A free-fit-call click shows up where the existing contact form already lands data — Slack #contact, HubSpot contact, Meta CAPI Lead event, sessionStorage UTM included.
