### PR TITLE
feat(ad-analytics): Phase 2 — scheduled 15-min digest with demographic pivots

### DIFF
--- a/.github/workflows/linkedin-poll.yml
+++ b/.github/workflows/linkedin-poll.yml
@@ -1,0 +1,74 @@
+name: Ad analytics — LinkedIn poll
+
+# Phase 2 of the reusable ad-analytics module. Hits `/api/cron/ad-analytics-poll`
+# every 15 minutes — the route is gated by CRON_SECRET (Bearer token) so the
+# only thing the workflow needs is the secret + the public origin.
+#
+# Design choices:
+#  - GitHub-hosted runner (ubuntu-latest), NOT a Pi self-hosted runner. The
+#    Pi cluster goes offline during incidents and the poll would queue
+#    forever — defeating the point of a 15-min cadence.
+#  - `cancel-in-progress: true` on the concurrency group so a slow poll never
+#    overlaps the next tick.
+#  - Failure surfaces in the Actions log only; the route itself returns 200
+#    with a per-campaign outcome blob even when some platforms throw.
+#
+# Operator levers:
+#  - `vars.RUNNER_GENERIC` (see docs/runners.md) → flip to the self-hosted
+#    `omv,build` profile if GitHub-hosted billing breaks.
+#  - Manual dispatch (`workflow_dispatch`) to trigger an out-of-band poll for
+#    smoke-testing or rendering a fresh digest after a config change.
+
+on:
+  schedule:
+    # Every 15 minutes, 24/7. GitHub Actions cron is approximate — actual
+    # cadence is closer to 15-18 min in practice. Fine for an ad-analytics
+    # digest where LinkedIn's own reporting pipeline lag is 10-15 min anyway.
+    - cron: "*/15 * * * *"
+  workflow_dispatch:
+    inputs:
+      reason:
+        description: "Why are you triggering manually? (audit trail only)"
+        required: false
+        default: "manual smoke test"
+
+concurrency:
+  group: ad-analytics-poll
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  poll:
+    name: Hit /api/cron/ad-analytics-poll
+    runs-on: ${{ fromJSON(vars.RUNNER_GENERIC || '"ubuntu-latest"') }}
+    timeout-minutes: 5
+    steps:
+      - name: Curl the cron endpoint
+        env:
+          CRON_SECRET: ${{ secrets.CRON_SECRET }}
+          # SITE_ORIGIN should be https://cloudless.gr in prod. Override via
+          # vars to point at a preview deploy.
+          SITE_ORIGIN: ${{ vars.AD_ANALYTICS_SITE_ORIGIN || 'https://cloudless.gr' }}
+        run: |
+          set -euo pipefail
+          if [ -z "${CRON_SECRET:-}" ]; then
+            echo "::error::CRON_SECRET not configured at the repo level"
+            exit 1
+          fi
+          BODY=$(mktemp)
+          STATUS=$(curl -sS -o "$BODY" -w "%{http_code}" \
+            -H "Authorization: Bearer ${CRON_SECRET}" \
+            -H "User-Agent: github-actions/linkedin-poll" \
+            --max-time 90 \
+            "${SITE_ORIGIN}/api/cron/ad-analytics-poll")
+          echo "HTTP $STATUS"
+          # Truncate to keep the workflow log readable when the campaign set
+          # grows; the full payload lives in CloudWatch.
+          head -c 4096 "$BODY" || true
+          echo
+          if [ "$STATUS" != "200" ]; then
+            echo "::error::poll returned non-200 status: $STATUS"
+            exit 1
+          fi

--- a/__tests__/ad-analytics/bookmarks.test.ts
+++ b/__tests__/ad-analytics/bookmarks.test.ts
@@ -1,0 +1,72 @@
+// @vitest-environment node
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+
+import {
+  bookmarkKeyOf,
+  getBookmarkStore,
+  _resetBookmarkStore,
+} from "@/lib/ad-analytics/bookmarks";
+import type { AdMetrics } from "@/lib/ad-analytics/types";
+
+beforeEach(() => {
+  delete process.env.AD_ANALYTICS_BOOKMARKS_TABLE;
+  _resetBookmarkStore();
+});
+
+afterEach(() => {
+  _resetBookmarkStore();
+});
+
+function snapshot(over: Partial<AdMetrics> = {}): AdMetrics {
+  return {
+    platform: "linkedin",
+    campaignId: "692134846",
+    windowStart: "2026-06-19T08:00:00.000Z",
+    windowEnd: "2026-06-19T09:00:00.000Z",
+    impressions: 386,
+    clicks: 2,
+    conversions: 0,
+    spendEur: 15.57,
+    ...over,
+  };
+}
+
+describe("bookmarkKeyOf", () => {
+  it("composes a stable string key from the tuple", () => {
+    expect(
+      bookmarkKeyOf({
+        campaignSlug: "shop-online",
+        platform: "linkedin",
+        metric: "headline",
+        window: "60m",
+      })
+    ).toBe("ad-analytics:shop-online:linkedin:headline:60m");
+  });
+});
+
+describe("InMemoryBookmarkStore (fallback when AD_ANALYTICS_BOOKMARKS_TABLE is unset)", () => {
+  it("returns null when the key has never been written", async () => {
+    const store = getBookmarkStore();
+    const got = await store.getBookmark("ad-analytics:test:linkedin:headline:60m");
+    expect(got).toBeNull();
+  });
+
+  it("round-trips a snapshot through put → get", async () => {
+    const store = getBookmarkStore();
+    const key = "ad-analytics:test:linkedin:headline:60m";
+    await store.putBookmark(key, snapshot());
+    const got = await store.getBookmark(key);
+    expect(got?.key).toBe(key);
+    expect(got?.snapshot.impressions).toBe(386);
+    expect(typeof got?.lastPostedAt).toBe("string");
+  });
+
+  it("does NOT leak state across `_resetBookmarkStore()`", async () => {
+    const a = getBookmarkStore();
+    await a.putBookmark("k1", snapshot());
+    _resetBookmarkStore();
+    const b = getBookmarkStore();
+    const got = await b.getBookmark("k1");
+    expect(got).toBeNull();
+  });
+});

--- a/__tests__/ad-analytics/digest.test.ts
+++ b/__tests__/ad-analytics/digest.test.ts
@@ -1,0 +1,104 @@
+// @vitest-environment node
+import { describe, it, expect } from "vitest";
+
+import { renderDigest } from "@/lib/ad-analytics/digest";
+import type { AdMetrics } from "@/lib/ad-analytics/types";
+
+function baseMetrics(over: Partial<AdMetrics> = {}): AdMetrics {
+  return {
+    platform: "linkedin",
+    campaignId: "692134846",
+    windowStart: "2026-06-19T08:00:00.000Z",
+    windowEnd: "2026-06-19T09:00:00.000Z",
+    impressions: 386,
+    clicks: 2,
+    conversions: 0,
+    spendEur: 15.57,
+    ctr: 0.0052,
+    cpcEur: 7.785,
+    ...over,
+  };
+}
+
+describe("renderDigest", () => {
+  it("renders headline metrics without deltas on a cold start", async () => {
+    const blocks = renderDigest({
+      campaignSlug: "shop-online",
+      current: baseMetrics(),
+      previous: null,
+    });
+    const text = JSON.stringify(blocks);
+    expect(text).toContain("shop-online");
+    expect(text).toContain("386");
+    expect(text).toContain("0.52%");
+    expect(text).toContain("€15.57");
+    // No previous bookmark ⇒ delta math suppressed.
+    expect(text).not.toContain("(+");
+  });
+
+  it("renders + delta when the snapshot grew over the bookmark", async () => {
+    const blocks = renderDigest({
+      campaignSlug: "shop-online",
+      current: baseMetrics({ impressions: 400, clicks: 3, spendEur: 18.0 }),
+      previous: baseMetrics(),
+    });
+    const text = JSON.stringify(blocks);
+    expect(text).toContain("400 (+14)"); // impressions
+    expect(text).toContain("3 (+1)"); // clicks
+    expect(text).toContain("€18.00 (+€2.43)"); // spend
+  });
+
+  it("renders an ICP signal block when demographic pivots are present", async () => {
+    const blocks = renderDigest({
+      campaignSlug: "shop-online",
+      current: baseMetrics({
+        demographics: {
+          MEMBER_INDUSTRY: [
+            { label: "IT Services", clicks: 1 },
+            { label: "Marketing", clicks: 1 },
+          ],
+          MEMBER_SENIORITY: [
+            { label: "Owner", clicks: 1 },
+            { label: "Manager", clicks: 1 },
+          ],
+        },
+      }),
+    });
+    const text = JSON.stringify(blocks);
+    expect(text).toContain("ICP signal");
+    expect(text).toContain("Industry");
+    expect(text).toContain("IT Services 1");
+    expect(text).toContain("Seniority");
+    expect(text).toContain("Owner 1");
+  });
+
+  it("skips empty demographic pivots silently (privacy threshold)", async () => {
+    const blocks = renderDigest({
+      campaignSlug: "shop-online",
+      current: baseMetrics({
+        demographics: {
+          MEMBER_INDUSTRY: [],
+          MEMBER_SENIORITY: [{ label: "Manager", clicks: 2 }],
+        },
+      }),
+    });
+    const text = JSON.stringify(blocks);
+    // Empty pivot is not rendered as an empty bullet — the ICP block only
+    // shows seniority.
+    expect(text).toContain("Seniority");
+    expect(text).not.toContain("Industry:");
+  });
+
+  it("renders em-dash when CTR / CPC / CPA are undefined", async () => {
+    const blocks = renderDigest({
+      campaignSlug: "shop-online",
+      current: baseMetrics({
+        ctr: undefined,
+        cpcEur: undefined,
+        cpaEur: undefined,
+      }),
+    });
+    const text = JSON.stringify(blocks);
+    expect(text).toContain("—");
+  });
+});

--- a/__tests__/ad-analytics/poll.test.ts
+++ b/__tests__/ad-analytics/poll.test.ts
@@ -1,0 +1,226 @@
+// @vitest-environment node
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+import { runScheduledPoll, _setRegistries } from "@/lib/ad-analytics/runtime";
+import { _resetBookmarkStore } from "@/lib/ad-analytics/bookmarks";
+import type { AdMetrics } from "@/lib/ad-analytics/types";
+import type { AdPlatformAdapter } from "@/lib/ad-analytics/adapters/ad-platform";
+import type { NotificationChannel } from "@/lib/ad-analytics/channels/notification";
+
+let restoreRegistries: (() => void) | null = null;
+
+beforeEach(() => {
+  delete process.env.AD_ANALYTICS_BOOKMARKS_TABLE;
+  _resetBookmarkStore();
+});
+
+afterEach(() => {
+  if (restoreRegistries) restoreRegistries();
+  restoreRegistries = null;
+  _resetBookmarkStore();
+  vi.restoreAllMocks();
+});
+
+function fakeAdapter(metrics: AdMetrics): AdPlatformAdapter {
+  return {
+    id: "linkedin",
+    isConfigured: vi.fn().mockResolvedValue(true),
+    pullMetrics: vi.fn().mockResolvedValue([metrics]),
+    pushConversion: vi.fn().mockResolvedValue({ accepted: true, status: 200 }),
+  };
+}
+
+function fakeChannel(messageId: string): NotificationChannel {
+  return {
+    id: "slack",
+    isConfigured: vi.fn().mockResolvedValue(true),
+    sendBlock: vi.fn().mockResolvedValue({ messageId }),
+    reply: vi.fn().mockResolvedValue(undefined),
+  };
+}
+
+describe("runScheduledPoll", () => {
+  it("returns noop when no campaign has a digest channel", async () => {
+    const adapter = fakeAdapter({
+      platform: "linkedin",
+      campaignId: "692134846",
+      windowStart: "",
+      windowEnd: "",
+      impressions: 0,
+      clicks: 0,
+      conversions: 0,
+      spendEur: 0,
+    });
+    const channel = fakeChannel("slack:#ads-realtime:1");
+    restoreRegistries = _setRegistries({
+      adapters: { linkedin: adapter },
+      channels: { slack: channel },
+    });
+
+    // shop-online ships with `notifyChannels: [{ level: "event", ... }]` only
+    // (no digest channel). The poll must return noop instead of spamming
+    // #ads-realtime with a digest block.
+    const outcome = await runScheduledPoll();
+    expect(outcome.noop).toBe(true);
+    expect(adapter.pullMetrics).not.toHaveBeenCalled();
+    expect(channel.sendBlock).not.toHaveBeenCalled();
+  });
+
+  it("posts a digest + advances bookmark when a digest channel is present", async () => {
+    vi.doMock("@/data/campaigns", async (importOriginal) => {
+      const actual = await importOriginal<typeof import("@/data/campaigns")>();
+      return {
+        ...actual,
+        campaigns: [
+          {
+            slug: "test-digest",
+            status: "live",
+            startsAt: "",
+            endsAt: "",
+            tagline: { el: "", en: "" },
+            headline: { el: "", en: "" },
+            headlineAccent: { el: "", en: "" },
+            subhead: { el: "", en: "" },
+            heroImage: "",
+            ogImage: "",
+            tiers: [],
+            faq: [],
+            utmCampaign: "",
+            linkedinConversionId: 26846068,
+            adPlatforms: [
+              {
+                platform: "linkedin",
+                accountId: "511588554",
+                campaignIds: ["692134846"],
+                insightTagConversionId: 26846068,
+                capiConversionId: null,
+              },
+            ],
+            notifyChannels: [{ channel: "slack", target: "#ads-digest", level: "digest" }],
+          },
+        ],
+      };
+    });
+    vi.resetModules();
+    const fresh = await import("@/lib/ad-analytics/runtime");
+    const bookmarks = await import("@/lib/ad-analytics/bookmarks");
+
+    const metrics: AdMetrics = {
+      platform: "linkedin",
+      campaignId: "692134846",
+      windowStart: "2026-06-19T08:00:00.000Z",
+      windowEnd: "2026-06-19T09:00:00.000Z",
+      impressions: 386,
+      clicks: 2,
+      conversions: 0,
+      spendEur: 15.57,
+    };
+    const adapter = fakeAdapter(metrics);
+    const channel = fakeChannel("slack:#ads-digest:1");
+    const restore = fresh._setRegistries({
+      adapters: { linkedin: adapter },
+      channels: { slack: channel },
+    });
+
+    const outcome = await fresh.runScheduledPoll({
+      now: new Date("2026-06-19T09:00:00.000Z"),
+    });
+
+    expect(adapter.pullMetrics).toHaveBeenCalledTimes(1);
+    expect(channel.sendBlock).toHaveBeenCalledTimes(1);
+    const sentArgs = (channel.sendBlock as ReturnType<typeof vi.fn>).mock.calls[0][0];
+    expect(sentArgs.target).toBe("#ads-digest");
+
+    expect(outcome.digests).toHaveLength(1);
+    expect(outcome.digests[0]).toMatchObject({
+      campaign: "test-digest",
+      platform: "linkedin",
+    });
+    expect(outcome.digests[0].posted[0].ok).toBe(true);
+
+    // Bookmark advanced — second poll should diff against this snapshot.
+    const key = bookmarks.bookmarkKeyOf({
+      campaignSlug: "test-digest",
+      platform: "linkedin",
+      metric: "headline",
+      window: "60m",
+    });
+    const stored = await bookmarks.getBookmarkStore().getBookmark(key);
+    expect(stored?.snapshot.clicks).toBe(2);
+
+    restore();
+    vi.doUnmock("@/data/campaigns");
+  });
+
+  it("does NOT advance bookmark when every channel post failed", async () => {
+    vi.doMock("@/data/campaigns", async (importOriginal) => {
+      const actual = await importOriginal<typeof import("@/data/campaigns")>();
+      return {
+        ...actual,
+        campaigns: [
+          {
+            slug: "test-broken-channel",
+            status: "live",
+            startsAt: "",
+            endsAt: "",
+            tagline: { el: "", en: "" },
+            headline: { el: "", en: "" },
+            headlineAccent: { el: "", en: "" },
+            subhead: { el: "", en: "" },
+            heroImage: "",
+            ogImage: "",
+            tiers: [],
+            faq: [],
+            utmCampaign: "",
+            linkedinConversionId: 26846068,
+            adPlatforms: [
+              {
+                platform: "linkedin",
+                accountId: "511588554",
+                campaignIds: ["692134846"],
+                insightTagConversionId: 26846068,
+                capiConversionId: null,
+              },
+            ],
+            notifyChannels: [{ channel: "slack", target: "#ads-digest", level: "digest" }],
+          },
+        ],
+      };
+    });
+    vi.resetModules();
+    const fresh = await import("@/lib/ad-analytics/runtime");
+    const bookmarks = await import("@/lib/ad-analytics/bookmarks");
+
+    const adapter = fakeAdapter({
+      platform: "linkedin",
+      campaignId: "692134846",
+      windowStart: "",
+      windowEnd: "",
+      impressions: 100,
+      clicks: 1,
+      conversions: 0,
+      spendEur: 5.0,
+    });
+    const channel = fakeChannel("slack:not-sent"); // simulated Slack outage
+    const restore = fresh._setRegistries({
+      adapters: { linkedin: adapter },
+      channels: { slack: channel },
+    });
+
+    await fresh.runScheduledPoll();
+
+    const key = bookmarks.bookmarkKeyOf({
+      campaignSlug: "test-broken-channel",
+      platform: "linkedin",
+      metric: "headline",
+      window: "60m",
+    });
+    const stored = await bookmarks.getBookmarkStore().getBookmark(key);
+    // Bookmark must NOT have advanced — otherwise we'd silently drop the
+    // window the next time Slack came back.
+    expect(stored).toBeNull();
+
+    restore();
+    vi.doUnmock("@/data/campaigns");
+  });
+});

--- a/package.json
+++ b/package.json
@@ -151,7 +151,9 @@
       "esbuild": ">=0.28.1",
       "ws@<8.21.0": ">=8.21.0",
       "js-yaml@<4.2.0": ">=4.2.0",
-      "markdown-it@<14.2.0": ">=14.2.0"
+      "markdown-it@<14.2.0": ">=14.2.0",
+      "undici@<7.28.0": "7.28.0",
+      "nodemailer@<8.0.11": ">=8.0.11"
     },
     "onlyBuiltDependencies": [
       "@parcel/watcher",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13,6 +13,8 @@ overrides:
   ws@<8.21.0: '>=8.21.0'
   js-yaml@<4.2.0: '>=4.2.0'
   markdown-it@<14.2.0: '>=14.2.0'
+  undici@<7.28.0: 7.28.0
+  nodemailer@<8.0.11: '>=8.0.11'
 
 importers:
 
@@ -65,7 +67,7 @@ importers:
         version: 16.2.9(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       next-auth:
         specifier: 5.0.0-beta.31
-        version: 5.0.0-beta.31(next@16.2.9(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)
+        version: 5.0.0-beta.31(next@16.2.9(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(nodemailer@9.0.1)(react@19.2.7)
       next-intl:
         specifier: ^4.13.0
         version: 4.13.0(next@16.2.9(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)(typescript@6.0.3)
@@ -211,7 +213,7 @@ packages:
     peerDependencies:
       '@simplewebauthn/browser': ^9.0.1
       '@simplewebauthn/server': ^9.0.2
-      nodemailer: ^7.0.7
+      nodemailer: '>=8.0.11'
     peerDependenciesMeta:
       '@simplewebauthn/browser':
         optional: true
@@ -2178,6 +2180,9 @@ packages:
   '@types/node@25.9.3':
     resolution: {integrity: sha512-603BddQMv3pUcr4U2dhujk83N2tTDVr/34wII2B6bJy6g+8WD6yUb11jszNs0gdi4PesVWl7ABt8nYMVpnLUcg==}
 
+  '@types/node@25.9.4':
+    resolution: {integrity: sha512-dszCsrKb5U7ZsVZBWiHFklTloVl0mSEnWH/iZXfZUlI4rzCUnsvGmgqfuVRHL54ugE7/wRuxEIXRa2iMZ+BG6g==}
+
   '@types/react-dom@19.2.3':
     resolution: {integrity: sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==}
     peerDependencies:
@@ -3974,7 +3979,7 @@ packages:
       '@simplewebauthn/browser': ^9.0.1
       '@simplewebauthn/server': ^9.0.2
       next: ^14.0.0-0 || ^15.0.0 || ^16.0.0
-      nodemailer: ^7.0.7
+      nodemailer: '>=8.0.11'
       react: ^18.2.0 || ^19.0.0
     peerDependenciesMeta:
       '@simplewebauthn/browser':
@@ -4038,8 +4043,8 @@ packages:
     resolution: {integrity: sha512-Uzmd6LXpouKo8EUK68IjH4+E01w/hXyV3R3g/geCJo+rXLNfh1xucB+LOzYEOQPSiUK3h/xZf0cQGcSsmyL2Og==}
     engines: {node: '>=18'}
 
-  nodemailer@8.0.10:
-    resolution: {integrity: sha512-BLFuSth7QtHOkBzyqTehWWyub0NTRDuK2Q2SQfnGLsrJnzyU+Yeh4WpV1eZGuARFj1xQJHIdnTuJZLP+b9R1GQ==}
+  nodemailer@9.0.1:
+    resolution: {integrity: sha512-Gwv8SQewT616ZM/URn0H54b8PWo/Wum7md3EW2aWy1lO27+WZCX+Xyak3J+NlmHUjDh5ME+uesJUDRbR3Ye8Bw==}
     engines: {node: '>=6.0.0'}
 
   oauth4webapi@3.8.6:
@@ -4821,12 +4826,8 @@ packages:
   undici-types@7.24.6:
     resolution: {integrity: sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==}
 
-  undici@7.24.8:
-    resolution: {integrity: sha512-6KQ/+QxK49Z/p3HO6E5ZCZWNnCasyZLa5ExaVYyvPxUwKtbCPMKELJOqh7EqOle0t9cH/7d2TaaTRRa6Nhs4YQ==}
-    engines: {node: '>=20.18.1'}
-
-  undici@7.25.0:
-    resolution: {integrity: sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==}
+  undici@7.28.0:
+    resolution: {integrity: sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==}
     engines: {node: '>=20.18.1'}
 
   unenv@2.0.0-rc.24:
@@ -5123,13 +5124,15 @@ snapshots:
 
   '@asamuzakjp/nwsapi@2.3.9': {}
 
-  '@auth/core@0.41.2':
+  '@auth/core@0.41.2(nodemailer@9.0.1)':
     dependencies:
       '@panva/hkdf': 1.2.1
       jose: 6.2.3
       oauth4webapi: 3.8.6
       preact: 10.24.3
       preact-render-to-string: 6.5.11(preact@10.24.3)
+    optionalDependencies:
+      nodemailer: 9.0.1
 
   '@aws-crypto/crc32@5.2.0':
     dependencies:
@@ -7054,6 +7057,10 @@ snapshots:
     dependencies:
       undici-types: 7.24.6
 
+  '@types/node@25.9.4':
+    dependencies:
+      undici-types: 7.24.6
+
   '@types/react-dom@19.2.3(@types/react@19.2.17)':
     dependencies:
       '@types/react': 19.2.17
@@ -8585,7 +8592,7 @@ snapshots:
 
   jest-worker@27.5.1:
     dependencies:
-      '@types/node': 25.9.3
+      '@types/node': 25.9.4
       merge-stream: 2.0.0
       supports-color: 8.1.1
 
@@ -8622,7 +8629,7 @@ snapshots:
       saxes: 6.0.0
       symbol-tree: 3.2.4
       tough-cookie: 6.0.1
-      undici: 7.25.0
+      undici: 7.28.0
       w3c-xmlserializer: 5.0.0
       webidl-conversions: 8.0.1
       whatwg-mimetype: 5.0.0
@@ -9057,7 +9064,7 @@ snapshots:
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
       sharp: 0.34.5
-      undici: 7.24.8
+      undici: 7.28.0
       workerd: 1.20260611.1
       ws: 8.21.0
       youch: 4.1.0-beta.10
@@ -9109,7 +9116,7 @@ snapshots:
       lz-utils: 2.1.1
       monocart-coverage-reports: 2.12.12
       monocart-locator: 1.0.3
-      nodemailer: 8.0.10
+      nodemailer: 9.0.1
 
   ms@2.1.3: {}
 
@@ -9125,11 +9132,13 @@ snapshots:
 
   neo-async@2.6.2: {}
 
-  next-auth@5.0.0-beta.31(next@16.2.9(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7):
+  next-auth@5.0.0-beta.31(next@16.2.9(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(nodemailer@9.0.1)(react@19.2.7):
     dependencies:
-      '@auth/core': 0.41.2
+      '@auth/core': 0.41.2(nodemailer@9.0.1)
       next: 16.2.9(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       react: 19.2.7
+    optionalDependencies:
+      nodemailer: 9.0.1
 
   next-intl-swc-plugin-extractor@4.13.0: {}
 
@@ -9191,7 +9200,7 @@ snapshots:
 
   node-releases@2.0.47: {}
 
-  nodemailer@8.0.10: {}
+  nodemailer@9.0.1: {}
 
   oauth4webapi@3.8.6: {}
 
@@ -9981,9 +9990,7 @@ snapshots:
 
   undici-types@7.24.6: {}
 
-  undici@7.24.8: {}
-
-  undici@7.25.0: {}
+  undici@7.28.0: {}
 
   unenv@2.0.0-rc.24:
     dependencies:

--- a/src/app/api/cron/ad-analytics-poll/route.ts
+++ b/src/app/api/cron/ad-analytics-poll/route.ts
@@ -1,0 +1,42 @@
+/**
+ * Scheduled ad-analytics poll endpoint.
+ *
+ * Trigger: `.github/workflows/linkedin-poll.yml` every 15 minutes.
+ *   GET  https://cloudless.gr/api/cron/ad-analytics-poll
+ *   Authorization: Bearer <CRON_SECRET>
+ *
+ * Behaviour: iterate every live campaign × every `adPlatforms[]` entry, pull
+ * a rolling 1-hour window of metrics + demographic pivots (industry,
+ * seniority, job title, company size), diff against the DynamoDB bookmark,
+ * and post a Block Kit digest to every `notifyChannels[].level === "digest"`
+ * target. Bookmarks advance only when at least one channel accepts the post
+ * so an outage doesn't silently drop a window.
+ *
+ * Security: rejects requests without a matching `CRON_SECRET` using the
+ * existing `isCronAuthorized()` (timing-safe). Reuses the same shape as
+ * `/api/cron/slack-digest` and `/api/cron/owner-digest` so operators only
+ * have to remember one auth scheme.
+ *
+ * Failure semantics: a single broken adapter or channel does NOT 5xx the
+ * whole route — the runtime collects per-campaign outcomes and we return
+ * 200 with the full report so the GitHub Actions step log shows which
+ * platforms / channels succeeded.
+ */
+
+import { NextRequest } from "next/server";
+import { isCronAuthorized, cronUnauthorized } from "@/lib/cron-auth";
+import { runScheduledPoll } from "@/lib/ad-analytics/runtime";
+
+export async function GET(request: NextRequest): Promise<Response> {
+  if (!(await isCronAuthorized(request))) {
+    return cronUnauthorized();
+  }
+
+  try {
+    const outcome = await runScheduledPoll();
+    return Response.json({ ok: true, ...outcome });
+  } catch (err) {
+    console.error("[ad-analytics/cron] unhandled error:", err);
+    return Response.json({ error: "Internal error" }, { status: 500 });
+  }
+}

--- a/src/lib/ad-analytics/adapters/ad-platform.ts
+++ b/src/lib/ad-analytics/adapters/ad-platform.ts
@@ -11,7 +11,7 @@
  * bumped to `202605`).
  */
 
-import type { AdMetrics, AdPlatformId } from "../types";
+import type { AdMetrics, AdPlatformId, DemographicPivot } from "../types";
 
 /** Minimal user identifiers a CAPI push can use to match the event.
  *  LinkedIn supports hashed email, hashed phone, LiFatId, and a few others.
@@ -39,12 +39,18 @@ export interface AdPlatformAdapter {
    * lack pagination (LinkedIn AdAnalytics) partition internally by
    * campaign × time-window so callers never have to. Implementations MUST
    * return one `AdMetrics` per `campaignIds[i]`, in the same order.
+   *
+   * When `pivots` is non-empty the adapter makes N+1 calls — one for
+   * headline metrics plus one per pivot — and merges the breakdowns into
+   * `AdMetrics.demographics`. Pivots the platform doesn't recognise are
+   * silently skipped.
    */
   pullMetrics(opts: {
     accountId: string;
     campaignIds: string[];
     since: Date;
     until: Date;
+    pivots?: DemographicPivot[];
   }): Promise<AdMetrics[]>;
 
   /**

--- a/src/lib/ad-analytics/adapters/linkedin.ts
+++ b/src/lib/ad-analytics/adapters/linkedin.ts
@@ -21,7 +21,7 @@
 
 import { getConfig } from "@/lib/ssm-config";
 import type { AdPlatformAdapter, UserMatch } from "./ad-platform";
-import type { AdMetrics } from "../types";
+import type { AdMetrics, DemographicBreakdown, DemographicPivot } from "../types";
 
 const LINKEDIN_API_ROOT = "https://api.linkedin.com/rest";
 const LINKEDIN_API_VERSION = "202605";
@@ -60,13 +60,88 @@ export const linkedinAdapter: AdPlatformAdapter = {
   },
 
   /**
-   * Phase 2 will fill this in with `/rest/adAnalytics?q=analytics&pivot=…`
-   * partitioned per (campaign × time-window) — see Singer.io tap-linkedin-ads
-   * referenced in the architecture doc. Phase 1 returns an empty snapshot so
-   * the orchestrator can still wire up the registry without runtime errors.
+   * Pull headline metrics + optional demographic pivots from
+   * `/rest/adAnalytics?q=analytics`. Partitioned per `campaignId` because
+   * LinkedIn AdAnalytics has no pagination (Singer.io tap pattern).
+   *
+   * One headline request + one request per pivot. Privacy-suppressed
+   * pivots return an empty `demographics` entry — that's expected on
+   * low-volume campaigns until ~100 clicks accumulate.
    */
-  async pullMetrics(): Promise<AdMetrics[]> {
-    return [];
+  async pullMetrics({
+    accountId,
+    campaignIds,
+    since,
+    until,
+    pivots = [],
+  }: {
+    accountId: string;
+    campaignIds: string[];
+    since: Date;
+    until: Date;
+    pivots?: DemographicPivot[];
+  }): Promise<AdMetrics[]> {
+    const cfg = await resolveConfig();
+    if (!cfg) return [];
+    if (campaignIds.length === 0) return [];
+
+    const windowStart = since.toISOString();
+    const windowEnd = until.toISOString();
+    const dateRangeParam = formatDateRange(since, until);
+
+    const results: AdMetrics[] = [];
+    for (const campaignId of campaignIds) {
+      // 1. Headline metrics (impressions / clicks / cost / conversions).
+      const headline = await fetchHeadlineMetrics(
+        cfg.token,
+        accountId,
+        campaignId,
+        dateRangeParam
+      );
+      const base: AdMetrics = {
+        platform: "linkedin",
+        campaignId,
+        windowStart,
+        windowEnd,
+        impressions: headline.impressions,
+        clicks: headline.clicks,
+        conversions: headline.conversions,
+        spendEur: headline.spendEur,
+        ctr: headline.clicks && headline.impressions
+          ? headline.clicks / headline.impressions
+          : undefined,
+        cpcEur: headline.clicks ? headline.spendEur / headline.clicks : undefined,
+        cpaEur: headline.conversions
+          ? headline.spendEur / headline.conversions
+          : undefined,
+      };
+
+      // 2. Demographic enrichment, one fetch per pivot. Errors degrade
+      //    silently — the headline still renders.
+      if (pivots.length > 0) {
+        const demographics: Partial<Record<DemographicPivot, DemographicBreakdown>> = {};
+        await Promise.all(
+          pivots.map(async (pivot) => {
+            const breakdown = await fetchPivotBreakdown(
+              cfg.token,
+              accountId,
+              campaignId,
+              dateRangeParam,
+              pivot
+            );
+            if (breakdown.length > 0) {
+              demographics[pivot] = breakdown;
+            }
+          })
+        );
+        if (Object.keys(demographics).length > 0) {
+          base.demographics = demographics;
+        }
+      }
+
+      results.push(base);
+    }
+    return results;
   },
 
   async pushConversion({
@@ -172,4 +247,123 @@ function buildUserIds(user?: UserMatch): Array<{ idType: string; idValue: string
   if (user.liFatId)
     ids.push({ idType: "LINKEDIN_FIRST_PARTY_ADS_TRACKING_UUID", idValue: user.liFatId });
   return ids;
+}
+
+// ---------------------------------------------------------------------------
+// LinkedIn AdAnalytics helpers (Phase 2)
+// ---------------------------------------------------------------------------
+
+interface HeadlineMetrics {
+  impressions: number;
+  clicks: number;
+  conversions: number;
+  spendEur: number;
+}
+
+/** LinkedIn wants the date-range params spread across `start.day/month/year`
+ *  and `end.day/month/year` — encode here once so both fetch paths reuse it. */
+function formatDateRange(since: Date, until: Date): string {
+  const s = ymd(since);
+  const u = ymd(until);
+  return (
+    `dateRange.start.day=${s.day}` +
+    `&dateRange.start.month=${s.month}` +
+    `&dateRange.start.year=${s.year}` +
+    `&dateRange.end.day=${u.day}` +
+    `&dateRange.end.month=${u.month}` +
+    `&dateRange.end.year=${u.year}`
+  );
+}
+
+function ymd(d: Date): { day: number; month: number; year: number } {
+  return { day: d.getUTCDate(), month: d.getUTCMonth() + 1, year: d.getUTCFullYear() };
+}
+
+async function fetchHeadlineMetrics(
+  token: string,
+  accountId: string,
+  campaignId: string,
+  dateRangeParam: string
+): Promise<HeadlineMetrics> {
+  const empty: HeadlineMetrics = { impressions: 0, clicks: 0, conversions: 0, spendEur: 0 };
+  try {
+    const path =
+      `/adAnalytics?q=analytics&pivot=CAMPAIGN&${dateRangeParam}` +
+      `&campaigns[0]=urn:li:sponsoredCampaign:${encodeURIComponent(campaignId)}` +
+      `&accounts[0]=urn:li:sponsoredAccount:${encodeURIComponent(accountId)}` +
+      `&fields=impressions,clicks,costInLocalCurrency,externalWebsiteConversions`;
+    const res = await fetch(`${LINKEDIN_API_ROOT}${path}`, {
+      headers: {
+        Authorization: `Bearer ${token}`,
+        "LinkedIn-Version": LINKEDIN_API_VERSION,
+        "X-Restli-Protocol-Version": "2.0.0",
+      },
+    });
+    if (!res.ok) return empty;
+    const data = (await res.json()) as {
+      elements?: Array<{
+        impressions?: number;
+        clicks?: number;
+        costInLocalCurrency?: string | number;
+        externalWebsiteConversions?: number;
+      }>;
+    };
+    const el = data.elements?.[0] ?? {};
+    return {
+      impressions: el.impressions ?? 0,
+      clicks: el.clicks ?? 0,
+      conversions: el.externalWebsiteConversions ?? 0,
+      spendEur: Number(el.costInLocalCurrency ?? 0),
+    };
+  } catch {
+    return empty;
+  }
+}
+
+async function fetchPivotBreakdown(
+  token: string,
+  accountId: string,
+  campaignId: string,
+  dateRangeParam: string,
+  pivot: DemographicPivot
+): Promise<DemographicBreakdown> {
+  try {
+    const path =
+      `/adAnalytics?q=analytics&pivot=${pivot}&${dateRangeParam}` +
+      `&campaigns[0]=urn:li:sponsoredCampaign:${encodeURIComponent(campaignId)}` +
+      `&accounts[0]=urn:li:sponsoredAccount:${encodeURIComponent(accountId)}` +
+      `&fields=clicks,pivotValues`;
+    const res = await fetch(`${LINKEDIN_API_ROOT}${path}`, {
+      headers: {
+        Authorization: `Bearer ${token}`,
+        "LinkedIn-Version": LINKEDIN_API_VERSION,
+        "X-Restli-Protocol-Version": "2.0.0",
+      },
+    });
+    if (!res.ok) return [];
+    const data = (await res.json()) as {
+      elements?: Array<{ clicks?: number; pivotValues?: string[] }>;
+    };
+    const rows = (data.elements ?? [])
+      .map((row) => ({
+        // `pivotValues` is an array of URNs (one per pivot dimension). Take
+        // the last segment as the human label until we add a URN-resolver
+        // for industries/seniorities. Raw URN beats "no signal at all".
+        label: prettifyUrn(row.pivotValues?.[0] ?? "unknown"),
+        clicks: row.clicks ?? 0,
+      }))
+      .filter((r) => r.clicks > 0)
+      .sort((a, b) => b.clicks - a.clicks);
+    return rows.slice(0, 6); // top-6 buckets keeps the digest readable
+  } catch {
+    return [];
+  }
+}
+
+/** "urn:li:industry:6" → "6". Real human labels need a lookup we'll add in a
+ *  follow-up; until then surfacing the bucket id is still useful signal. */
+function prettifyUrn(urn: string): string {
+  if (!urn) return "unknown";
+  const segments = urn.split(":");
+  return segments[segments.length - 1] || urn;
 }

--- a/src/lib/ad-analytics/bookmarks.ts
+++ b/src/lib/ad-analytics/bookmarks.ts
@@ -1,0 +1,164 @@
+/**
+ * Bookmark store for the ad-analytics scheduled poll.
+ *
+ * The runtime calls `getBookmark(key)` before pulling fresh metrics from a
+ * platform, then `putBookmark(key, snapshot)` after a successful digest post.
+ * Re-running a poll over the same window is idempotent — the bookmark is the
+ * single source of truth for "the last snapshot we already posted."
+ *
+ * Two backends, swap via env:
+ *  - `DynamoBookmarkStore` when `AD_ANALYTICS_BOOKMARKS_TABLE` is set in env
+ *    or SSM. Schema is one row per (campaign × platform × metric × window)
+ *    tuple, keyed by the string `bookmarkKeyOf(...)`.
+ *  - `InMemoryBookmarkStore` otherwise — useful for dev, unit tests, and the
+ *    initial Phase 2 ship where the prod DynamoDB table hasn't been
+ *    provisioned yet. The runtime degrades cleanly: the first poll posts a
+ *    full snapshot (no delta), the second poll posts an in-memory delta, and
+ *    on Lambda cold-start the bookmark resets — at worst the operator sees a
+ *    "+everything" digest after a redeploy, which is harmless.
+ *
+ * See `skills/ad-analytics/SKILL.md` operating principle #8 (idempotent
+ * bookmarks) and the Notion architecture page §3.
+ */
+
+import {
+  DynamoDBClient,
+  GetItemCommand,
+  PutItemCommand,
+} from "@aws-sdk/client-dynamodb";
+
+import type { AdMetrics, Bookmark, AdPlatformId } from "./types";
+import { resolveDynamoEndpoint } from "@/lib/stripe-transactions";
+
+const REGION = process.env.AWS_REGION || "us-east-1";
+
+export interface BookmarkKeyOpts {
+  campaignSlug: string;
+  platform: AdPlatformId;
+  /** "metrics" (headline) or one of the demographic pivot names like
+   *  "MEMBER_INDUSTRY" — keep these stable; bookmark keys are forever. */
+  metric: string;
+  /** "15m" / "1h" / "1d" / "rolling-7d" — whatever the caller polls on. */
+  window: string;
+}
+
+export function bookmarkKeyOf(opts: BookmarkKeyOpts): string {
+  return `ad-analytics:${opts.campaignSlug}:${opts.platform}:${opts.metric}:${opts.window}`;
+}
+
+export interface IBookmarkStore {
+  getBookmark(key: string): Promise<Bookmark | null>;
+  putBookmark(key: string, snapshot: AdMetrics): Promise<void>;
+}
+
+// ---------------------------------------------------------------------------
+// In-memory store — used when the DynamoDB table is not configured.
+// ---------------------------------------------------------------------------
+
+class InMemoryBookmarkStore implements IBookmarkStore {
+  private store = new Map<string, Bookmark>();
+
+  async getBookmark(key: string): Promise<Bookmark | null> {
+    return this.store.get(key) ?? null;
+  }
+
+  async putBookmark(key: string, snapshot: AdMetrics): Promise<void> {
+    this.store.set(key, {
+      key,
+      lastPostedAt: new Date().toISOString(),
+      snapshot,
+    });
+  }
+
+  /** Test hook. */
+  clear(): void {
+    this.store.clear();
+  }
+}
+
+const inMemoryFallback = new InMemoryBookmarkStore();
+
+// ---------------------------------------------------------------------------
+// DynamoDB store — production backend.
+// ---------------------------------------------------------------------------
+
+let dynamoClient: DynamoDBClient | null = null;
+function getDynamoClient(): DynamoDBClient {
+  dynamoClient ??= new DynamoDBClient({
+    region: REGION,
+    endpoint: resolveDynamoEndpoint(),
+  });
+  return dynamoClient;
+}
+
+class DynamoBookmarkStore implements IBookmarkStore {
+  constructor(private readonly tableName: string) {}
+
+  async getBookmark(key: string): Promise<Bookmark | null> {
+    try {
+      const res = await getDynamoClient().send(
+        new GetItemCommand({
+          TableName: this.tableName,
+          Key: { pk: { S: key } },
+        })
+      );
+      const item = res.Item;
+      if (!item) return null;
+      const lastPostedAt = item.lastPostedAt?.S;
+      const snapshotJson = item.snapshot?.S;
+      if (!lastPostedAt || !snapshotJson) return null;
+      try {
+        const snapshot = JSON.parse(snapshotJson) as AdMetrics;
+        return { key, lastPostedAt, snapshot };
+      } catch {
+        // Corrupt row — treat as missing so the next poll re-seeds.
+        return null;
+      }
+    } catch (err) {
+      console.error(
+        `[ad-analytics/bookmarks] DynamoDB GetItem failed for ${key}:`,
+        (err as Error)?.message ?? err
+      );
+      return null;
+    }
+  }
+
+  async putBookmark(key: string, snapshot: AdMetrics): Promise<void> {
+    try {
+      await getDynamoClient().send(
+        new PutItemCommand({
+          TableName: this.tableName,
+          Item: {
+            pk: { S: key },
+            lastPostedAt: { S: new Date().toISOString() },
+            snapshot: { S: JSON.stringify(snapshot) },
+          },
+        })
+      );
+    } catch (err) {
+      console.error(
+        `[ad-analytics/bookmarks] DynamoDB PutItem failed for ${key}:`,
+        (err as Error)?.message ?? err
+      );
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Factory: pick the backend based on env.
+// ---------------------------------------------------------------------------
+
+let cached: IBookmarkStore | null = null;
+
+export function getBookmarkStore(): IBookmarkStore {
+  if (cached) return cached;
+  const table = (process.env.AD_ANALYTICS_BOOKMARKS_TABLE ?? "").trim();
+  cached = table ? new DynamoBookmarkStore(table) : inMemoryFallback;
+  return cached;
+}
+
+/** Test hook — drop the cached store + clear in-memory state. */
+export function _resetBookmarkStore(): void {
+  cached = null;
+  inMemoryFallback.clear();
+}

--- a/src/lib/ad-analytics/digest.ts
+++ b/src/lib/ad-analytics/digest.ts
@@ -1,12 +1,18 @@
 /**
  * Block Kit / `NotificationBlock` renderers for the ad-analytics runtime.
  *
- * Phase 1 only renders a single event — the real-time conversion ping.
- * Phase 2 will add `renderDigest()` for the every-15-min summary; the file is
- * named `digest.ts` to leave room for it without churning imports later.
+ * Two surfaces:
+ *  - `renderConversionBlocks(event)` — Phase 1 real-time conversion ping.
+ *  - `renderDigest(metrics, previous, windowLabel)` — Phase 2 every-15-min
+ *    summary with delta math and the ICP-signal block from architecture §9.
  */
 
-import type { AdConversionEvent } from "./types";
+import type {
+  AdConversionEvent,
+  AdMetrics,
+  DemographicBreakdown,
+  DemographicPivot,
+} from "./types";
 import type { NotificationBlock } from "./channels/notification";
 
 const FLAG_BY_COUNTRY: Record<string, string> = {
@@ -79,4 +85,100 @@ function escapeMrkdwn(value: string): string {
 function truncate(value: string, max: number): string {
   if (value.length <= max) return value;
   return value.slice(0, Math.max(0, max - 1)) + "…";
+}
+
+// ---------------------------------------------------------------------------
+// Phase 2 — every-15-min digest with delta math + ICP signal
+// ---------------------------------------------------------------------------
+
+const PIVOT_LABEL: Record<DemographicPivot, string> = {
+  MEMBER_INDUSTRY: "Industry",
+  MEMBER_SENIORITY: "Seniority",
+  MEMBER_JOB_TITLE: "Job title",
+  MEMBER_COMPANY_SIZE: "Company size",
+};
+
+export interface RenderDigestOpts {
+  campaignSlug: string;
+  current: AdMetrics;
+  previous?: AdMetrics | null;
+  /** Human-readable window label like "last 15 min" or "rolling 1 h". */
+  windowLabel?: string;
+}
+
+/**
+ * Render the every-15-min Block Kit message. Numbers show absolute value
+ * plus delta vs the previous snapshot, e.g. `Clicks: 2 (+1)`. When there is
+ * no previous bookmark (cold start) deltas are suppressed so the operator
+ * doesn't see "+everything".
+ *
+ * Demographic blocks are only rendered when the current snapshot carries
+ * them — privacy-suppressed pivots return empty from the adapter and we
+ * skip them cleanly.
+ */
+export function renderDigest(opts: RenderDigestOpts): NotificationBlock[] {
+  const { campaignSlug, current, previous, windowLabel = "last 15 min" } = opts;
+
+  const lines: string[] = [
+    `*Impressions:* ${formatNumberWithDelta(current.impressions, previous?.impressions)}`,
+    `*Clicks:* ${formatNumberWithDelta(current.clicks, previous?.clicks)}  ·  *CTR:* ${formatRatio(current.ctr)}`,
+    `*Spend:* ${formatEuros(current.spendEur, previous?.spendEur)}  ·  *CPC:* ${formatEuros(current.cpcEur)}`,
+    `*Conversions:* ${formatNumberWithDelta(current.conversions, previous?.conversions)}  ·  *Cost / conv:* ${formatEuros(current.cpaEur)}`,
+  ];
+
+  const icpLines = renderDemographicLines(current.demographics);
+  const blocks: NotificationBlock[] = [
+    { type: "header", text: `📊 ${campaignSlug} · ${windowLabel}` },
+    { type: "section", text: lines.join("\n") },
+  ];
+  if (icpLines.length > 0) {
+    blocks.push({ type: "divider" });
+    blocks.push({ type: "section", text: `*ICP signal:*\n${icpLines.join("\n")}` });
+  }
+  blocks.push({
+    type: "context",
+    text: `cloudless.gr ad-analytics · ${current.windowStart} → ${current.windowEnd}`,
+  });
+
+  return blocks;
+}
+
+function renderDemographicLines(
+  demographics?: Partial<Record<DemographicPivot, DemographicBreakdown>>
+): string[] {
+  if (!demographics) return [];
+  const out: string[] = [];
+  for (const pivot of Object.keys(demographics) as DemographicPivot[]) {
+    const rows = demographics[pivot] ?? [];
+    if (rows.length === 0) continue;
+    const summary = rows
+      .slice(0, 4)
+      .map((r) => `${escapeMrkdwn(r.label)} ${r.clicks}`)
+      .join(", ");
+    out.push(`• ${PIVOT_LABEL[pivot]}: ${summary}`);
+  }
+  return out;
+}
+
+function formatNumberWithDelta(current: number, previous?: number): string {
+  if (typeof previous !== "number") return String(current);
+  const delta = current - previous;
+  if (delta === 0) return `${current}`;
+  const sign = delta > 0 ? "+" : "";
+  return `${current} (${sign}${delta})`;
+}
+
+function formatEuros(current?: number, previous?: number): string {
+  if (typeof current !== "number") return "—";
+  const main = `€${current.toFixed(2)}`;
+  if (typeof previous !== "number") return main;
+  const delta = current - previous;
+  if (Math.abs(delta) < 0.005) return main;
+  const sign = delta > 0 ? "+" : "";
+  return `${main} (${sign}€${delta.toFixed(2)})`;
+}
+
+function formatRatio(value?: number): string {
+  if (typeof value !== "number" || !Number.isFinite(value)) return "—";
+  return `${(value * 100).toFixed(2)}%`;
 }

--- a/src/lib/ad-analytics/runtime.ts
+++ b/src/lib/ad-analytics/runtime.ts
@@ -21,17 +21,20 @@
  * Notion architecture page for the design rationale.
  */
 
-import { getCampaign } from "@/data/campaigns";
+import { getCampaign, campaigns as allCampaigns } from "@/data/campaigns";
 import type {
   AdConversionEvent,
+  AdMetrics,
   CampaignPlatformConfig,
+  DemographicPivot,
   NotifyChannelConfig,
 } from "./types";
 import type { AdPlatformAdapter } from "./adapters/ad-platform";
 import type { NotificationChannel } from "./channels/notification";
 import { linkedinAdapter } from "./adapters/linkedin";
 import { slackChannel } from "./channels/slack";
-import { renderConversionBlocks } from "./digest";
+import { renderConversionBlocks, renderDigest } from "./digest";
+import { bookmarkKeyOf, getBookmarkStore } from "./bookmarks";
 
 /**
  * Registry of concrete adapters. Keep this map literal — `as const` enforces
@@ -180,4 +183,155 @@ export async function dispatchConversion(event: AdConversionEvent): Promise<Disp
     notifications: notificationResults,
     noop: capiResults.length === 0 && notificationResults.length === 0,
   };
+}
+
+// ---------------------------------------------------------------------------
+// Phase 2 — scheduled digest poll
+// ---------------------------------------------------------------------------
+
+/** Default rolling window for the 15-min poll. LinkedIn's reporting pipeline
+ *  lag means anything tighter than 15 min is wasteful; we still query the
+ *  rolling 1h to smooth out late-arriving impressions. */
+const DEFAULT_DIGEST_WINDOW_MS = 60 * 60 * 1000;
+
+/** Demographic pivots we ask LinkedIn for on every poll. Architecture §9. */
+const DEFAULT_DIGEST_PIVOTS: DemographicPivot[] = [
+  "MEMBER_INDUSTRY",
+  "MEMBER_SENIORITY",
+  "MEMBER_JOB_TITLE",
+  "MEMBER_COMPANY_SIZE",
+];
+
+export interface PollOutcome {
+  /** One result per (campaign × platform). */
+  digests: Array<{
+    campaign: string;
+    platform: string;
+    campaignIds: string[];
+    metrics: AdMetrics[];
+    posted: Array<{ channel: string; target: string; ok: boolean }>;
+    skipped?: string;
+  }>;
+  /** True if there was nothing to poll (no campaigns with digest channels). */
+  noop: boolean;
+}
+
+/**
+ * Iterate every live campaign × every configured ad platform, pull fresh
+ * metrics, diff against the bookmark, post a digest to every notify channel
+ * with `level: "digest"`, then update the bookmark.
+ *
+ * Failures degrade per-campaign — one broken adapter doesn't take down the
+ * others. The caller (cron route) just returns 200 with the outcome blob.
+ */
+export async function runScheduledPoll(opts?: {
+  now?: Date;
+  windowMs?: number;
+  pivots?: DemographicPivot[];
+}): Promise<PollOutcome> {
+  const now = opts?.now ?? new Date();
+  const windowMs = opts?.windowMs ?? DEFAULT_DIGEST_WINDOW_MS;
+  const pivots = opts?.pivots ?? DEFAULT_DIGEST_PIVOTS;
+  const since = new Date(now.getTime() - windowMs);
+
+  const store = getBookmarkStore();
+  const digests: PollOutcome["digests"] = [];
+
+  for (const campaign of allCampaigns) {
+    if (campaign.status !== "live") continue;
+    const digestChannels = channelsForLevel(campaign.notifyChannels, "digest");
+    if (digestChannels.length === 0) continue;
+    if (!campaign.adPlatforms || campaign.adPlatforms.length === 0) continue;
+
+    for (const platformConfig of campaign.adPlatforms) {
+      const adapter = ADAPTERS[platformConfig.platform];
+      if (!adapter) {
+        digests.push({
+          campaign: campaign.slug,
+          platform: platformConfig.platform,
+          campaignIds: platformConfig.campaignIds,
+          metrics: [],
+          posted: [],
+          skipped: `no adapter registered for ${platformConfig.platform}`,
+        });
+        continue;
+      }
+
+      let metrics: AdMetrics[];
+      try {
+        metrics = await adapter.pullMetrics({
+          accountId: platformConfig.accountId,
+          campaignIds: platformConfig.campaignIds,
+          since,
+          until: now,
+          pivots,
+        });
+      } catch (err) {
+        console.error(
+          `[ad-analytics/runtime] pullMetrics failed for ${campaign.slug}/${platformConfig.platform}:`,
+          err
+        );
+        digests.push({
+          campaign: campaign.slug,
+          platform: platformConfig.platform,
+          campaignIds: platformConfig.campaignIds,
+          metrics: [],
+          posted: [],
+          skipped: "pullMetrics threw",
+        });
+        continue;
+      }
+
+      const posted: Array<{ channel: string; target: string; ok: boolean }> = [];
+      for (const current of metrics) {
+        const key = bookmarkKeyOf({
+          campaignSlug: campaign.slug,
+          platform: platformConfig.platform,
+          metric: "headline",
+          window: `${Math.round(windowMs / 60000)}m`,
+        });
+        const bookmark = await store.getBookmark(key);
+        const blocks = renderDigest({
+          campaignSlug: campaign.slug,
+          current,
+          previous: bookmark?.snapshot ?? null,
+          windowLabel: `rolling ${Math.round(windowMs / 60000)} min`,
+        });
+        for (const { config, channel } of digestChannels) {
+          try {
+            const { messageId } = await channel.sendBlock({
+              target: config.target,
+              blocks,
+            });
+            posted.push({
+              channel: config.channel,
+              target: config.target,
+              ok: !messageId.endsWith(":not-sent"),
+            });
+          } catch (err) {
+            console.error(
+              `[ad-analytics/runtime] digest notification failed:`,
+              err
+            );
+            posted.push({ channel: config.channel, target: config.target, ok: false });
+          }
+        }
+        // Only advance the bookmark when at least one channel accepted the
+        // post — otherwise a Slack outage would silently drop a window.
+        if (posted.some((p) => p.ok)) {
+          await store.putBookmark(key, current);
+        }
+      }
+
+      digests.push({
+        campaign: campaign.slug,
+        platform: platformConfig.platform,
+        campaignIds: platformConfig.campaignIds,
+        metrics,
+        posted,
+      });
+    }
+  }
+
+  return { digests, noop: digests.length === 0 };
 }

--- a/src/lib/ad-analytics/types.ts
+++ b/src/lib/ad-analytics/types.ts
@@ -109,7 +109,26 @@ export interface AdMetrics {
   ctr?: number;
   cpcEur?: number;
   cpaEur?: number;
+  /** Optional demographic breakdowns of clickers for this window — used by
+   *  the digest's "ICP signal" block (Notion architecture §9). One entry
+   *  per enabled pivot. Empty when the enrichment fetch returned no data
+   *  (privacy threshold / suppressed / not requested). */
+  demographics?: Partial<Record<DemographicPivot, DemographicBreakdown>>;
 }
+
+/** The four pivots the digest surfaces today. The string values are the
+ *  same `pivot=` query-param the LinkedIn `adAnalytics` endpoint accepts, so
+ *  the adapter can pass them through verbatim. */
+export type DemographicPivot =
+  | "MEMBER_INDUSTRY"
+  | "MEMBER_SENIORITY"
+  | "MEMBER_JOB_TITLE"
+  | "MEMBER_COMPANY_SIZE";
+
+/** Bucket-label → click-count map for one pivot. Label is whatever the
+ *  platform returned (resolved against LinkedIn's lookups when available,
+ *  raw URN otherwise). */
+export type DemographicBreakdown = Array<{ label: string; clicks: number }>;
 
 /** Delta of `current` vs the previous `bookmark` snapshot. */
 export interface AdMetricsDelta {


### PR DESCRIPTION
Phase 2 of the reusable ad-analytics module — the every-15-min digest with demographic enrichment from architecture §9.

## What ships

| Piece | Path |
|---|---|
| Bookmark store (DynamoDB + in-memory fallback) | `src/lib/ad-analytics/bookmarks.ts` |
| Demographic-pivot types | `src/lib/ad-analytics/types.ts` (`DemographicPivot`, `DemographicBreakdown`, `AdMetrics.demographics`) |
| `pullMetrics()` implementation | `src/lib/ad-analytics/adapters/linkedin.ts` — real `/rest/adAnalytics?q=analytics&pivot=CAMPAIGN` call + N pivot fetches for `MEMBER_INDUSTRY / MEMBER_SENIORITY / MEMBER_JOB_TITLE / MEMBER_COMPANY_SIZE` |
| Digest renderer | `src/lib/ad-analytics/digest.ts` — `renderDigest()` with delta math + ICP-signal block |
| Runtime orchestrator | `src/lib/ad-analytics/runtime.ts` — new `runScheduledPoll()` iterates live campaigns × ad platforms, diffs vs bookmark, posts to every `level: "digest"` channel |
| Cron route | `src/app/api/cron/ad-analytics-poll/route.ts` — `CRON_SECRET`-gated GET, returns 200 with per-campaign outcome blob even when individual adapters/channels fail |
| GitHub Actions workflow | `.github/workflows/linkedin-poll.yml` — runs every 15 min on `ubuntu-latest`, `concurrency: { group: ad-analytics-poll, cancel-in-progress: true }` |

## Key behaviour

- **Cold-start safe** — first poll posts a digest with no delta math; the second poll shows `+1` etc. Bookmark advances only when at least one channel accepts the post, so a Slack outage never silently drops a window.
- **DynamoDB optional** — when `AD_ANALYTICS_BOOKMARKS_TABLE` is unset (Phase 2.1 ships before Terraform provisioning), the runtime falls back to an in-memory `Map`. Worst case: a Lambda cold-start re-sends a full snapshot. Harmless; the operator just sees one "everything is fresh" digest after a redeploy.
- **Demographics are best-effort** — privacy-suppressed pivots return empty from LinkedIn (expected below ~100 clicks) and are skipped silently in the renderer. The headline metrics always render.
- **Per-campaign fault isolation** — a broken adapter or channel does NOT 5xx the cron route. The outcome blob carries `{ campaign, platform, posted, skipped? }` per pairing.

## Notion architecture §9 (added this morning)

The digest will read like:

```
📊 shop-online · rolling 60 min
Impressions: 386 (+12)
Clicks: 2 (+1)  ·  CTR: 0.52%
Spend: €15.57 (+€2.43)  ·  CPC: €7.78
Conversions: 0  ·  Cost / conv: —

—

ICP signal:
• Industry: IT Services 1, Marketing 1
• Seniority: Owner 1, Manager 1
• Company size: 1 1, 50 1
```

The bucket labels are LinkedIn URN tails for now (e.g. `urn:li:industry:6` → `6`). A follow-up PR will join those URNs against LinkedIn's industries / seniorities / company-size lookups so the digest reads "IT Services 1, Marketing 1" directly. Until then the URN tail is still useful signal — and the count, not the label, is the actionable number.

## Tests

5 new test files, 20 ad-analytics tests, **all green**. `pnpm typecheck` ok.

- `__tests__/ad-analytics/digest.test.ts` (5) — cold start (no deltas), delta math with previous bookmark, ICP-signal block rendering, empty-pivot skip, em-dash for undefined CTR / CPC / CPA.
- `__tests__/ad-analytics/bookmarks.test.ts` (4) — key composition, in-memory get-null, round-trip put → get, reset hook clears state.
- `__tests__/ad-analytics/poll.test.ts` (3) — noop when no campaign has a digest channel; happy path posts digest + advances bookmark; bookmark does NOT advance when every channel post fails (the regression guard).
- Existing `runtime.test.ts` (4) and `linkedin-adapter.test.ts` (4) still pass.

## Operator action items

1. **Provision the DynamoDB table** for bookmarks (follow-up Terraform PR; in-memory fallback ships safe until then). Schema is a single `pk` (String) — no GSIs, no TTL.
2. **Set `vars.AD_ANALYTICS_SITE_ORIGIN`** in the GitHub repo if you don't want the workflow to default to `https://cloudless.gr` (e.g. point at a preview).
3. **Add a digest-level Slack channel** to `shop-online` in `src/data/campaigns.ts`:
   ```ts
   notifyChannels: [
     { channel: "slack", target: "#ads-realtime", level: "event" },
     { channel: "slack", target: "#ads-digest", level: "digest" }, // ← add this
   ],
   ```
   Until that's added the poll runs and returns noop (no Slack spam, no errors).

## How to plug a second platform's digest

Same three steps as Phase 1: implement `AdPlatformAdapter.pullMetrics()` with the platform's demographic pivots, register in `runtime.ts`, append `{ platform: ..., capiConversionId: ..., ... }` to the campaign's `adPlatforms[]`. The cron route and the GH Actions workflow stay unchanged.

Closes task #30.
