### PR TITLE
feat(campaigns): opt shop-online into the #ads-digest 15-min poll

### DIFF
--- a/__tests__/ad-analytics/poll.test.ts
+++ b/__tests__/ad-analytics/poll.test.ts
@@ -41,6 +41,50 @@ function fakeChannel(messageId: string): NotificationChannel {
 
 describe("runScheduledPoll", () => {
   it("returns noop when no campaign has a digest channel", async () => {
+    // Use a mocked campaigns module so this assertion stays meaningful even
+    // after the live `shop-online` config opts INTO #ads-digest.
+    vi.doMock("@/data/campaigns", async (importOriginal) => {
+      const actual = await importOriginal<typeof import("@/data/campaigns")>();
+      return {
+        ...actual,
+        campaigns: [
+          {
+            slug: "test-no-digest",
+            status: "live",
+            startsAt: "",
+            endsAt: "",
+            tagline: { el: "", en: "" },
+            headline: { el: "", en: "" },
+            headlineAccent: { el: "", en: "" },
+            subhead: { el: "", en: "" },
+            heroImage: "",
+            ogImage: "",
+            tiers: [],
+            faq: [],
+            utmCampaign: "",
+            linkedinConversionId: 26846068,
+            adPlatforms: [
+              {
+                platform: "linkedin",
+                accountId: "511588554",
+                campaignIds: ["692134846"],
+                insightTagConversionId: 26846068,
+                capiConversionId: null,
+              },
+            ],
+            // Only an event-level channel — no digest target. The poll must
+            // skip this campaign entirely instead of spamming a digest
+            // message to the realtime channel.
+            notifyChannels: [
+              { channel: "slack", target: "#ads-realtime", level: "event" },
+            ],
+          },
+        ],
+      };
+    });
+    vi.resetModules();
+    const fresh = await import("@/lib/ad-analytics/runtime");
+
     const adapter = fakeAdapter({
       platform: "linkedin",
       campaignId: "692134846",
@@ -52,18 +96,18 @@ describe("runScheduledPoll", () => {
       spendEur: 0,
     });
     const channel = fakeChannel("slack:#ads-realtime:1");
-    restoreRegistries = _setRegistries({
+    const restore = fresh._setRegistries({
       adapters: { linkedin: adapter },
       channels: { slack: channel },
     });
 
-    // shop-online ships with `notifyChannels: [{ level: "event", ... }]` only
-    // (no digest channel). The poll must return noop instead of spamming
-    // #ads-realtime with a digest block.
-    const outcome = await runScheduledPoll();
+    const outcome = await fresh.runScheduledPoll();
     expect(outcome.noop).toBe(true);
     expect(adapter.pullMetrics).not.toHaveBeenCalled();
     expect(channel.sendBlock).not.toHaveBeenCalled();
+
+    restore();
+    vi.doUnmock("@/data/campaigns");
   });
 
   it("posts a digest + advances bookmark when a digest channel is present", async () => {

--- a/src/data/campaigns.ts
+++ b/src/data/campaigns.ts
@@ -154,6 +154,11 @@ export const campaigns: Campaign[] = [
       // Real-time pings on every conversion (paid + fit-call). Operator's
       // phone lights up the moment a clicker becomes a known person.
       { channel: "slack", target: "#ads-realtime", level: "event" },
+      // Every-15-min digest of impressions / clicks / spend / CTR / CPC plus
+      // demographic pivots (industry, seniority, job title, company size).
+      // Driven by `/api/cron/ad-analytics-poll` via the
+      // `.github/workflows/linkedin-poll.yml` cron.
+      { channel: "slack", target: "#ads-digest", level: "digest" },
     ],
     tiers: [
       {


### PR DESCRIPTION
Adds the digest-level Slack channel to shop-online so the every-15-min LinkedIn poll (PR #992 / linkedin-poll.yml workflow) actually fires. Reworks one test to mock the campaigns module so it stays meaningful. 31/31 tests pass.

Pre-flight confirmed during this session:
- CRON_SECRET is in repo secrets (added 2026-06-10) ✓
- RUNNER_GENERIC routes the workflow to the Pi build cluster ✓

Operator still needs to create the #ads-digest Slack channel and invite the Cloudless bot. SLACK_WEBHOOK_URL fallback to #general works either way.