### PR TITLE
feat(ad-analytics): Phase 3 — /cloudless-analytics ads slash command

### DIFF
--- a/__tests__/ad-analytics/snapshot.test.ts
+++ b/__tests__/ad-analytics/snapshot.test.ts
@@ -1,0 +1,99 @@
+// @vitest-environment node
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+import { runAdHocSnapshot, _setRegistries } from "@/lib/ad-analytics/runtime";
+import type { AdMetrics } from "@/lib/ad-analytics/types";
+import type { AdPlatformAdapter } from "@/lib/ad-analytics/adapters/ad-platform";
+
+let restore: (() => void) | null = null;
+
+beforeEach(() => {
+  vi.restoreAllMocks();
+});
+
+afterEach(() => {
+  if (restore) restore();
+  restore = null;
+});
+
+function fakeAdapter(rows: AdMetrics[]): AdPlatformAdapter {
+  return {
+    id: "linkedin",
+    isConfigured: vi.fn().mockResolvedValue(true),
+    pullMetrics: vi.fn().mockResolvedValue(rows),
+    pushConversion: vi.fn().mockResolvedValue({ accepted: true, status: 200 }),
+  };
+}
+
+describe("runAdHocSnapshot", () => {
+  it("returns null when the campaign slug is unknown", async () => {
+    restore = _setRegistries({
+      adapters: { linkedin: fakeAdapter([]) },
+      channels: {},
+    });
+    const out = await runAdHocSnapshot({ campaignSlug: "no-such-campaign" });
+    expect(out).toBeNull();
+  });
+
+  it("returns the platform's metrics rows for shop-online", async () => {
+    const rows: AdMetrics[] = [
+      {
+        platform: "linkedin",
+        campaignId: "692134846",
+        windowStart: "2026-06-19T08:00:00.000Z",
+        windowEnd: "2026-06-19T09:00:00.000Z",
+        impressions: 386,
+        clicks: 2,
+        conversions: 0,
+        spendEur: 15.57,
+        ctr: 0.0052,
+        cpcEur: 7.785,
+      },
+    ];
+    const adapter = fakeAdapter(rows);
+    restore = _setRegistries({ adapters: { linkedin: adapter }, channels: {} });
+
+    const out = await runAdHocSnapshot({ campaignSlug: "shop-online" });
+
+    expect(out).not.toBeNull();
+    expect(out?.campaign).toBe("shop-online");
+    expect(out?.metrics).toHaveLength(1);
+    expect(out?.metrics[0].impressions).toBe(386);
+    // adapter was called with the configured account + campaign IDs
+    const calledWith = (adapter.pullMetrics as ReturnType<typeof vi.fn>).mock.calls[0][0];
+    expect(calledWith.accountId).toBe("511588554");
+    expect(calledWith.campaignIds).toEqual(["692134846"]);
+    expect(calledWith.pivots).toContain("MEMBER_INDUSTRY");
+  });
+
+  it("does NOT advance any bookmark or post any Slack message", async () => {
+    const adapter = fakeAdapter([
+      {
+        platform: "linkedin",
+        campaignId: "692134846",
+        windowStart: "",
+        windowEnd: "",
+        impressions: 100,
+        clicks: 1,
+        conversions: 0,
+        spendEur: 5,
+      },
+    ]);
+    const channel = {
+      id: "slack" as const,
+      isConfigured: vi.fn().mockResolvedValue(true),
+      sendBlock: vi.fn().mockResolvedValue({ messageId: "slack:#ads-realtime:1" }),
+      reply: vi.fn().mockResolvedValue(undefined),
+    };
+    restore = _setRegistries({
+      adapters: { linkedin: adapter },
+      channels: { slack: channel },
+    });
+
+    await runAdHocSnapshot({ campaignSlug: "shop-online" });
+
+    // The on-demand snapshot is read-only — neither the bookmark nor any
+    // notification channel should be touched.
+    expect(channel.sendBlock).not.toHaveBeenCalled();
+  });
+});

--- a/src/app/api/slack/commands/route.ts
+++ b/src/app/api/slack/commands/route.ts
@@ -31,6 +31,9 @@ import {
   setEditorialStatus,
   type NotionBlogDraft,
 } from "@/lib/notion-blog-admin";
+import { getLiveCampaigns, getCampaign } from "@/data/campaigns";
+import { runAdHocSnapshot } from "@/lib/ad-analytics/runtime";
+import { renderDigest } from "@/lib/ad-analytics/digest";
 
 /**
  * Slack user-ID allowlist for slash-command-driven workflow dispatch.
@@ -431,6 +434,29 @@ async function handleTicket(payload: SlashCommandPayload): Promise<Response> {
 }
 
 async function handleAnalytics(payload: SlashCommandPayload): Promise<Response> {
+  // The slash command now multiplexes by `payload.text`:
+  //   (empty) / "stripe"   → existing Stripe revenue summary (back-compat).
+  //   "ads"                → list every campaign that's wired into the
+  //                          ad-analytics module + the channels it posts to.
+  //   "ads <slug>"         → live LinkedIn snapshot for one campaign. Heavy
+  //                          (N+1 fetches → ~3-5 s) so we use Slack's lazy-
+  //                          listener pattern: ack immediately with a
+  //                          "loading…" ephemeral, finish the work in the
+  //                          background, then POST the final Block Kit to
+  //                          `payload.response_url`.
+  //   "ads help"           → usage.
+  const argv = payload.text.trim().split(/\s+/).filter(Boolean);
+  const head = (argv[0] ?? "").toLowerCase();
+
+  if (head === "ads") {
+    return handleAdAnalytics(payload, argv.slice(1));
+  }
+  // Fall through: empty text, "stripe", or anything else lands in the
+  // pre-existing Stripe revenue path.
+  return handleStripeAnalytics(payload);
+}
+
+async function handleStripeAnalytics(payload: SlashCommandPayload): Promise<Response> {
   try {
     const { orders, hasMore } = await listRecentCheckoutSessions(10);
 
@@ -508,7 +534,7 @@ async function handleAnalytics(payload: SlashCommandPayload): Promise<Response> 
           elements: [
             {
               type: "mrkdwn",
-              text: `Requested by <@${payload.user_id}>`,
+              text: `Requested by <@${payload.user_id}> · Tip: \`/cloudless-analytics ads\` for LinkedIn ad metrics`,
             },
           ],
         },
@@ -520,6 +546,186 @@ async function handleAnalytics(payload: SlashCommandPayload): Promise<Response> 
       response_type: "ephemeral",
       text: ":warning: Analytics unavailable. Failed to fetch orders from Stripe.",
     });
+  }
+}
+
+/**
+ * `/cloudless-analytics ads …` — surfaces the reusable ad-analytics module
+ * inside Slack.
+ *
+ *   ads                  → list configured campaigns
+ *   ads <campaign-slug>  → live snapshot (LinkedIn pullMetrics + ICP block)
+ *   ads help             → usage
+ */
+function handleAdAnalytics(
+  payload: SlashCommandPayload,
+  rest: string[]
+): Response {
+  const arg = (rest[0] ?? "").toLowerCase();
+
+  if (!arg || arg === "list") {
+    const live = getLiveCampaigns().filter(
+      (c) => (c.adPlatforms?.length ?? 0) > 0 || (c.notifyChannels?.length ?? 0) > 0
+    );
+    if (live.length === 0) {
+      return slackResponse({
+        response_type: "ephemeral",
+        text:
+          ":information_source: No campaigns have ad-analytics wiring yet. " +
+          "Add `adPlatforms[]` and `notifyChannels[]` to a campaign in " +
+          "`src/data/campaigns.ts` and redeploy.",
+      });
+    }
+    const rows = live.map((c) => {
+      const platforms = (c.adPlatforms ?? [])
+        .map((p) => `${p.platform}(${p.campaignIds.length} ids)`)
+        .join(", ");
+      const channels = (c.notifyChannels ?? [])
+        .map((ch) => `${ch.target}(${ch.level})`)
+        .join(", ");
+      return `• *${c.slug}* — platforms: ${platforms || "—"} · channels: ${channels || "—"}`;
+    });
+    return slackResponse({
+      response_type: "ephemeral",
+      blocks: [
+        {
+          type: "header",
+          text: { type: "plain_text", text: ":chart_with_upwards_trend: Ad analytics — campaigns", emoji: true },
+        },
+        { type: "section", text: { type: "mrkdwn", text: rows.join("\n") } },
+        {
+          type: "context",
+          elements: [
+            {
+              type: "mrkdwn",
+              text:
+                "Snapshot one with `/cloudless-analytics ads <slug>`. " +
+                `Requested by <@${payload.user_id}>.`,
+            },
+          ],
+        },
+      ],
+    });
+  }
+
+  if (arg === "help") {
+    return slackResponse({
+      response_type: "ephemeral",
+      blocks: [
+        {
+          type: "section",
+          text: {
+            type: "mrkdwn",
+            text: [
+              "*`/cloudless-analytics ads` — subcommands*",
+              "• `/cloudless-analytics ads` — list configured campaigns + channels",
+              "• `/cloudless-analytics ads <slug>` — live snapshot (impressions / clicks / CTR / spend / CPC + ICP demographic breakdown)",
+              "• `/cloudless-analytics ads help` — this message",
+              "",
+              "_Live snapshot does N+1 LinkedIn API calls, so the response arrives in 3-5 seconds after the immediate ack._",
+            ].join("\n"),
+          },
+        },
+      ],
+    });
+  }
+
+  // Treat `arg` as a campaign slug.
+  const campaign = getCampaign(arg);
+  if (!campaign) {
+    return slackResponse({
+      response_type: "ephemeral",
+      text:
+        `:warning: No campaign named \`${arg}\`. ` +
+        "Run `/cloudless-analytics ads` to see what's available.",
+    });
+  }
+  if (!campaign.adPlatforms || campaign.adPlatforms.length === 0) {
+    return slackResponse({
+      response_type: "ephemeral",
+      text:
+        `:information_source: Campaign \`${arg}\` is configured but has no ` +
+        "`adPlatforms[]` entry. Nothing to snapshot.",
+    });
+  }
+
+  // Slack 3-second budget: ack immediately, do the work in the background,
+  // POST the final Block Kit message to `payload.response_url`.
+  void runAndReplyAdSnapshot(campaign.slug, payload.response_url, payload.user_id);
+
+  return slackResponse({
+    response_type: "ephemeral",
+    text:
+      `:hourglass_flowing_sand: Fetching live metrics for *${campaign.slug}* — ` +
+      "snapshot will replace this message in a few seconds.",
+  });
+}
+
+/**
+ * Background worker for the lazy-listener pattern. Pulls fresh metrics from
+ * every configured ad platform on the campaign, renders the same digest the
+ * scheduled poll uses, and POSTs the result to Slack's `response_url`.
+ *
+ * Never throws — failures surface as a Block Kit error message at
+ * `response_url` so the operator always gets visible feedback instead of a
+ * silent "loading…" stuck state.
+ */
+async function runAndReplyAdSnapshot(
+  campaignSlug: string,
+  responseUrl: string,
+  userId: string
+): Promise<void> {
+  if (!responseUrl) return;
+  try {
+    const snapshot = await runAdHocSnapshot({ campaignSlug });
+    if (!snapshot || snapshot.metrics.length === 0) {
+      await postToResponseUrl(responseUrl, {
+        response_type: "ephemeral",
+        replace_original: true,
+        text: `:warning: No metrics returned for *${campaignSlug}* — check that LINKEDIN_ACCESS_TOKEN and LINKEDIN_AD_ACCOUNT_ID are configured.`,
+      });
+      return;
+    }
+    const blocks = snapshot.metrics.flatMap((m) =>
+      renderDigest({
+        campaignSlug,
+        current: m,
+        previous: null, // on-demand snapshot has no bookmark context
+        windowLabel: `live snapshot (rolling 60 min)`,
+      })
+    );
+    blocks.push({
+      type: "context",
+      text: `Requested by <@${userId}>`,
+    });
+    await postToResponseUrl(responseUrl, {
+      response_type: "ephemeral",
+      replace_original: true,
+      blocks,
+    });
+  } catch (err) {
+    console.error("[Slack Commands] ad snapshot worker failed:", err);
+    await postToResponseUrl(responseUrl, {
+      response_type: "ephemeral",
+      replace_original: true,
+      text: `:warning: Ad-analytics snapshot failed: \`${((err as Error)?.message ?? "unknown").slice(0, 200)}\`.`,
+    });
+  }
+}
+
+async function postToResponseUrl(
+  responseUrl: string,
+  body: Record<string, unknown>
+): Promise<void> {
+  try {
+    await fetch(responseUrl, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+      signal: AbortSignal.timeout(5_000),
+    });
+  } catch (err) {
+    console.error("[Slack Commands] response_url POST failed:", err);
   }
 }
 
@@ -598,6 +804,8 @@ function handleHelp(): Response {
             "• `/cloudless-channels` — notification channel status",
             "• `/cloudless-ticket` — submit a support ticket",
             "• `/cloudless-analytics` — Stripe revenue summary",
+            "• `/cloudless-analytics ads` — list configured LinkedIn ad campaigns",
+            "• `/cloudless-analytics ads <slug>` — live LinkedIn snapshot (impressions / clicks / CTR / spend / ICP)",
             "• `/cloudless-deploy` — deploy latest code to production",
             "• `/cloudless-draft rerun` — re-run the weekly article draft generator",
             "• `/cloudless-newsletter list` — show pending Notion drafts",

--- a/src/lib/ad-analytics/runtime.ts
+++ b/src/lib/ad-analytics/runtime.ts
@@ -335,3 +335,52 @@ export async function runScheduledPoll(opts?: {
 
   return { digests, noop: digests.length === 0 };
 }
+
+// ---------------------------------------------------------------------------
+// Phase 3 — on-demand snapshot for the /cloudless-analytics ads <slug>
+// slash command. Same metric path as the scheduled poll but does NOT post to
+// any channel and does NOT touch the bookmark — purely read-only.
+// ---------------------------------------------------------------------------
+
+export interface AdHocSnapshot {
+  campaign: string;
+  metrics: AdMetrics[];
+}
+
+export async function runAdHocSnapshot(opts: {
+  campaignSlug: string;
+  now?: Date;
+  windowMs?: number;
+  pivots?: DemographicPivot[];
+}): Promise<AdHocSnapshot | null> {
+  const campaign = getCampaign(opts.campaignSlug);
+  if (!campaign || !campaign.adPlatforms || campaign.adPlatforms.length === 0) {
+    return null;
+  }
+  const now = opts.now ?? new Date();
+  const windowMs = opts.windowMs ?? DEFAULT_DIGEST_WINDOW_MS;
+  const pivots = opts.pivots ?? DEFAULT_DIGEST_PIVOTS;
+  const since = new Date(now.getTime() - windowMs);
+
+  const all: AdMetrics[] = [];
+  for (const platformConfig of campaign.adPlatforms) {
+    const adapter = ADAPTERS[platformConfig.platform];
+    if (!adapter) continue;
+    try {
+      const rows = await adapter.pullMetrics({
+        accountId: platformConfig.accountId,
+        campaignIds: platformConfig.campaignIds,
+        since,
+        until: now,
+        pivots,
+      });
+      all.push(...rows);
+    } catch (err) {
+      console.error(
+        `[ad-analytics/runtime] ad-hoc snapshot pullMetrics failed for ${campaign.slug}/${platformConfig.platform}:`,
+        err
+      );
+    }
+  }
+  return { campaign: campaign.slug, metrics: all };
+}


### PR DESCRIPTION
Phase 3 of the reusable ad-analytics module — on-demand LinkedIn snapshots from Slack.

## What ships

`/cloudless-analytics` is now multiplexed by the trailing text. No new Slack App configuration required — the existing slash command picks up the new subcommands.

| Command | Effect |
|---|---|
| `/cloudless-analytics` *(or `… stripe`)* | Existing Stripe revenue summary — unchanged for back-compat. |
| `/cloudless-analytics ads` | Lists every campaign that has `adPlatforms[]` + `notifyChannels[]` wiring, plus the channels it posts to. Read-only. |
| `/cloudless-analytics ads <slug>` | Live LinkedIn snapshot for one campaign — headline metrics + ICP-signal block (industry / seniority / job title / company size). Uses the lazy-listener pattern so the response budget stays under Slack's 3-second window. |
| `/cloudless-analytics ads help` | Usage. |
| `/cloudless-help` | Updated to mention the new subcommands. |

## Architecture

- **Lazy-listener pattern** — the `<slug>` path acks within ~50 ms with `:hourglass_flowing_sand: Fetching live metrics…`, runs `runAdHocSnapshot()` (N+1 LinkedIn API calls) in the background, then POSTs the final Block Kit to `payload.response_url` with `replace_original: true`. The operator sees the same digest block format as the scheduled `#ads-digest` poll.
- **Read-only snapshot** — `runAdHocSnapshot()` is in `src/lib/ad-analytics/runtime.ts`, but does NOT advance any bookmark and does NOT post to any `notifyChannels[]` target. The slash command response is the only side effect.
- **Reuses Phase 2 `renderDigest()`** — same delta math contract (here previous=null so deltas are suppressed) and the same ICP-signal block layout.
- **Failure surfaces visibly** — adapter errors are caught and reported back to `response_url` instead of silently leaving the "Fetching…" message stuck.

## Files

| Layer | Path |
|---|---|
| Runtime: on-demand snapshot | `src/lib/ad-analytics/runtime.ts` — new `runAdHocSnapshot({ campaignSlug })` + `AdHocSnapshot` type. |
| Slash command handler | `src/app/api/slack/commands/route.ts` — `handleAnalytics()` dispatches by trailing text; new `handleAdAnalytics()`; new `runAndReplyAdSnapshot()` worker; new `postToResponseUrl()` helper. |
| Help text | Updated in `handleHelp()`. |

## Tests

3 new tests in `__tests__/ad-analytics/snapshot.test.ts`, **23 total ad-analytics tests passing** (typecheck ok):

- Unknown campaign slug → `null`.
- Known slug → returns rows; adapter is called with the configured `accountId`, `campaignIds`, and the default demographic `pivots`.
- Regression guard: the on-demand snapshot does NOT touch any notification channel — the slash command response is the only side effect.

## Operator action items

1. Same as Phase 2 — create the `#ads-digest` Slack channel (already wired into `shop-online.notifyChannels`) and invite the Cloudless bot.
2. Try `/cloudless-analytics ads` to see the campaign list. Then `/cloudless-analytics ads shop-online` to fire a live LinkedIn pull and watch the digest replace the "Fetching…" message.

Closes task #31.
