### PR TITLE
feat(ad-analytics): Phase 4 — anomaly DM alerts (research-backed thresholds)

### DIFF
--- a/__tests__/ad-analytics/anomaly.test.ts
+++ b/__tests__/ad-analytics/anomaly.test.ts
@@ -1,0 +1,160 @@
+// @vitest-environment node
+import { describe, it, expect } from "vitest";
+
+import {
+  evaluateAnomalies,
+  findingDedupKey,
+  DEFAULTS,
+} from "@/lib/ad-analytics/anomaly";
+import type { AdMetrics } from "@/lib/ad-analytics/types";
+
+function m(over: Partial<AdMetrics> = {}): AdMetrics {
+  return {
+    platform: "linkedin",
+    campaignId: "692134846",
+    windowStart: "2026-06-19T08:00:00.000Z",
+    windowEnd: "2026-06-19T09:00:00.000Z",
+    impressions: 1000,
+    clicks: 10,
+    conversions: 1,
+    spendEur: 10,
+    ctr: 0.01,
+    cpcEur: 1.0,
+    cpaEur: 10.0,
+    ...over,
+  };
+}
+
+describe("evaluateAnomalies — DEFAULTS", () => {
+  it("exports conservative industry-aligned thresholds", () => {
+    // These numbers are the contract — if you change them you also need to
+    // update skills/ad-analytics/SKILL.md and the Notion architecture doc.
+    expect(DEFAULTS.spendPaceMultiplier).toBe(1.5);
+    expect(DEFAULTS.cpcSpikeMultiplier).toBe(1.4);
+    expect(DEFAULTS.zeroConversionsHours).toBe(24);
+    expect(DEFAULTS.minCtr).toBe(0.003);
+  });
+});
+
+describe("evaluateAnomalies — rules", () => {
+  it("returns no findings on a healthy snapshot", () => {
+    const findings = evaluateAnomalies({
+      current: m(),
+      previous: m(),
+      windowHours: 1,
+    });
+    expect(findings).toEqual([]);
+  });
+
+  it("fires cpc_spike when current CPC ≥ 1.4× previous CPC", () => {
+    const findings = evaluateAnomalies({
+      current: m({ cpcEur: 2.0, spendEur: 20 }),
+      previous: m({ cpcEur: 1.0, spendEur: 10 }),
+    });
+    const cpcSpike = findings.find((f) => f.rule === "cpc_spike");
+    expect(cpcSpike).toBeDefined();
+    expect(cpcSpike?.severity).toBe("warning");
+    expect(cpcSpike?.detail.baseline).toBe(1.0);
+  });
+
+  it("does NOT fire cpc_spike on a cold start (no previous)", () => {
+    const findings = evaluateAnomalies({
+      current: m({ cpcEur: 10.0 }),
+      previous: null,
+    });
+    expect(findings.find((f) => f.rule === "cpc_spike")).toBeUndefined();
+  });
+
+  it("fires cpc_ceiling (critical) when CPC > maxCpcEur", () => {
+    const findings = evaluateAnomalies({
+      current: m({ cpcEur: 12 }),
+      previous: m({ cpcEur: 10 }),
+      rules: { maxCpcEur: 10 },
+    });
+    const ceiling = findings.find((f) => f.rule === "cpc_ceiling");
+    expect(ceiling).toBeDefined();
+    expect(ceiling?.severity).toBe("critical");
+    expect(ceiling?.detail.threshold).toBe(10);
+  });
+
+  it("fires ctr_floor only when impressions ≥ 200 (avoids small-sample false alarms)", () => {
+    // Below the impressions floor — must NOT fire even with a terrible CTR.
+    const smallSample = evaluateAnomalies({
+      current: m({ impressions: 50, clicks: 0, ctr: 0 }),
+    });
+    expect(smallSample.find((f) => f.rule === "ctr_floor")).toBeUndefined();
+
+    // Above the impressions floor with CTR below DEFAULTS.minCtr (0.3%).
+    const real = evaluateAnomalies({
+      current: m({ impressions: 1000, clicks: 1, ctr: 0.001 }),
+    });
+    const floor = real.find((f) => f.rule === "ctr_floor");
+    expect(floor).toBeDefined();
+    expect(floor?.detail.threshold).toBe(DEFAULTS.minCtr);
+  });
+
+  it("fires zero_conversions ONLY when windowHours ≥ zeroConversionsHours", () => {
+    // 15-min window — too short to claim "no conversions in 24h"; must NOT fire.
+    const short = evaluateAnomalies({
+      current: m({ conversions: 0, spendEur: 50 }),
+      windowHours: 1,
+    });
+    expect(short.find((f) => f.rule === "zero_conversions")).toBeUndefined();
+
+    // 24h+ window — fires.
+    const long = evaluateAnomalies({
+      current: m({ conversions: 0, spendEur: 50 }),
+      windowHours: 24,
+    });
+    const zero = long.find((f) => f.rule === "zero_conversions");
+    expect(zero).toBeDefined();
+    expect(zero?.severity).toBe("critical");
+  });
+
+  it("fires spend_pace when current spend ≥ 1.5× previous", () => {
+    const findings = evaluateAnomalies({
+      current: m({ spendEur: 20 }),
+      previous: m({ spendEur: 10 }),
+    });
+    const pace = findings.find((f) => f.rule === "spend_pace");
+    expect(pace).toBeDefined();
+    expect(pace?.detail.baseline).toBe(10);
+  });
+
+  it("respects per-campaign overrides over DEFAULTS", () => {
+    const findings = evaluateAnomalies({
+      current: m({ cpcEur: 5 }),
+      previous: m({ cpcEur: 4 }), // 1.25× — under the default 1.4× but over 1.2×
+      rules: { cpcSpikeMultiplier: 1.2 },
+    });
+    expect(findings.find((f) => f.rule === "cpc_spike")).toBeDefined();
+  });
+});
+
+describe("findingDedupKey", () => {
+  it("composes a stable per-day key so repeats inside the same day collapse", () => {
+    const k1 = findingDedupKey({
+      campaignSlug: "shop-online",
+      platform: "linkedin",
+      rule: "cpc_spike",
+      windowEnd: "2026-06-19T09:14:59.999Z",
+    });
+    const k2 = findingDedupKey({
+      campaignSlug: "shop-online",
+      platform: "linkedin",
+      rule: "cpc_spike",
+      windowEnd: "2026-06-19T23:45:00.000Z",
+    });
+    // Same day → same key (don't re-alert in the next 15-min tick).
+    expect(k1).toBe(k2);
+
+    const tomorrow = findingDedupKey({
+      campaignSlug: "shop-online",
+      platform: "linkedin",
+      rule: "cpc_spike",
+      windowEnd: "2026-06-20T08:00:00.000Z",
+    });
+    // Different day → different key (re-alert tomorrow if it persists).
+    expect(tomorrow).not.toBe(k1);
+  });
+});

--- a/skills/ad-analytics/SKILL.md
+++ b/skills/ad-analytics/SKILL.md
@@ -136,6 +136,26 @@ Live verification of a real conversion via Chrome MCP:
 
 Each phase ships as its own PR with typecheck + tests + a verification log.
 
+## Anomaly thresholds (Phase 4)
+
+`src/lib/ad-analytics/anomaly.ts` `DEFAULTS` are tuned from the 2026 industry
+consensus. Change them only with a cited reason — the test
+`__tests__/ad-analytics/anomaly.test.ts > evaluateAnomalies > DEFAULTS pins
+the contract` is the regression guard.
+
+| Rule                  | Default        | Source                                                        | Notes                                                 |
+| --------------------- | -------------- | ------------------------------------------------------------- | ----------------------------------------------------- |
+| `cpcSpikeMultiplier`  | 1.4 (40% over) | Improvado — "if CPC jumps by 40%, alert"                      | Skipped on cold start (no previous bookmark)          |
+| `spendPaceMultiplier` | 1.5 (50% over) | Go-Insights pacing methodology                                | Skipped on cold start                                 |
+| `zeroConversionsHours`| 24             | Ryze — "give the funnel one full day"                         | Skipped when poll window < this                       |
+| `minCtr`              | 0.003 (0.3%)   | LinkedIn effective floor + Improvado CTR-drop                 | Skipped below 200 impressions (small-sample guard)    |
+| `maxCpcEur`           | unset          | Operator hard ceiling                                         | Fires `critical` when set and exceeded                |
+
+Per-campaign overrides live in `Campaign.anomalyRules` in
+`src/data/campaigns.ts`. Findings are de-duped via the bookmark store on
+`findingDedupKey({ campaign, platform, rule, day })` — the same anomaly
+re-firing in the next 15-min tick stays silent until the next calendar day.
+
 ## References
 
 - Notion: [📊 Reusable Ad Analytics Slack App — Architecture](https://app.notion.com/p/3837d82c410a81bfb560d517d9140138)
@@ -143,4 +163,8 @@ Each phase ships as its own PR with typecheck + tests + a verification log.
 - Gilgamesh: [LinkedIn CAPI Is Not Meta CAPI — the source-bound conversion trap](https://gilgamesh.in/blog/linkedin-capi-source-bound-conversions)
 - Singer.io: [tap-linkedin-ads](https://github.com/singer-io/tap-linkedin-ads) — bookmark pattern reference
 - Microsoft Learn: [LinkedIn Reporting API](https://learn.microsoft.com/en-us/linkedin/marketing/integrations/ads-reporting/ads-reporting?view=li-lms-2026-03)
+- Improvado: [Marketing Anomaly Detection & Automated Alerts: 2026 Guide](https://improvado.io/blog/marketing-anomaly-detection-automated-alerts) — Phase 4 threshold source
+- Go-Insights: [How monitoring works](https://www.go-insights.com/anomaly-detection) — pacing methodology
+- Ryze AI: [How to Stop Wasting Ad Spend Automatically (2026)](https://www.get-ryze.ai/answers/how-to-stop-wasting-ad-spend-automatically) — alert cadence + conservative-threshold guidance
+- Tinybird: [Z-score anomaly detection](https://github.com/tinybirdco/use-case-real-time-anomaly-detection/blob/main/content/z-score.md) — statistical layer reference for the planned ≥7-snapshot upgrade
 - Existing repo skill: [linkedin-campaigns](../linkedin-campaigns/SKILL.md)

--- a/src/data/campaigns.ts
+++ b/src/data/campaigns.ts
@@ -159,6 +159,15 @@ export const campaigns: Campaign[] = [
       // Driven by `/api/cron/ad-analytics-poll` via the
       // `.github/workflows/linkedin-poll.yml` cron.
       { channel: "slack", target: "#ads-digest", level: "digest" },
+      // Phase 4 anomaly alerts (CPC spike, CTR collapse, spend pace,
+      // zero-conversions-with-spend, hard CPC ceiling). Fires on the same
+      // 15-min poll. De-duped per (campaign × platform × rule × day) so the
+      // same alert in the next tick doesn't spam. Target is the same digest
+      // channel for now — switch to a DM (user id `U…`) once anomalies start
+      // firing in real life. Industry default thresholds apply because
+      // `anomalyRules` is unset; tighten with `maxCpcEur` etc. once a
+      // baseline emerges.
+      { channel: "slack", target: "#ads-digest", level: "anomaly" },
     ],
     tiers: [
       {

--- a/src/lib/ad-analytics/anomaly.ts
+++ b/src/lib/ad-analytics/anomaly.ts
@@ -1,0 +1,208 @@
+/**
+ * Anomaly evaluator for the ad-analytics module — Phase 4.
+ *
+ * Inputs:
+ *  - `current`: the just-pulled snapshot (`AdMetrics` for one campaign × platform).
+ *  - `previous`: the last bookmarked snapshot, if any. Used as the rolling
+ *    baseline for the CPC-spike and spend-pace rules.
+ *  - `rules`: per-campaign overrides for the thresholds. Anything left
+ *    undefined falls back to the industry defaults captured in `DEFAULTS`
+ *    below.
+ *
+ * Output: a list of triggered `AnomalyFinding` rows — one per fired rule —
+ * which the runtime renders as a Block Kit DM via the configured notify
+ * channel (`level: "anomaly"`).
+ *
+ * Thresholds and rationale come from:
+ *  - Improvado 2026 ad anomaly playbook
+ *    https://improvado.io/blog/marketing-anomaly-detection-automated-alerts
+ *  - Go-Insights monitoring methodology
+ *    https://www.go-insights.com/anomaly-detection
+ *  - Ryze AI's "stop wasting ad spend automatically"
+ *    https://www.get-ryze.ai/answers/how-to-stop-wasting-ad-spend-automatically
+ *  - GitHub / Tinybird Z-score reference for the statistical layer
+ *    (CPC spike multiplier is the simpler ratio-of-means version; full Z-score
+ *    waits until we have ≥7 bookmarked snapshots to compute stddev over).
+ *
+ * Operating principles:
+ *  - Conservative by default. Industry guidance: a 20% CPA increase over 3
+ *    days is more reliable than a 10% increase over 1 day.
+ *  - "No previous snapshot" suppresses rules that require a baseline (spend
+ *    pace, CPC spike). Absolute-threshold rules (`maxCpcEur`, `minCtr`,
+ *    `zeroConversionsHours`) still fire — they don't need a baseline.
+ *  - Never throws. The runtime calls this in a hot path; a logic error must
+ *    never break the poll.
+ *
+ * See `skills/ad-analytics/SKILL.md` operating principles + the architecture
+ * doc §10 (added in this PR) for the wire-up and operator-facing notes.
+ */
+
+import type { AdMetrics, AnomalyRules } from "./types";
+
+/**
+ * Industry-default thresholds. Applied when the campaign opts into anomaly
+ * DMs (has a `level: "anomaly"` notify channel) but leaves the corresponding
+ * `AnomalyRules` field undefined. Source: see file header.
+ */
+export const DEFAULTS: Required<Pick<
+  AnomalyRules,
+  "spendPaceMultiplier" | "cpcSpikeMultiplier" | "zeroConversionsHours" | "minCtr"
+>> = {
+  spendPaceMultiplier: 1.5,
+  cpcSpikeMultiplier: 1.4,
+  zeroConversionsHours: 24,
+  minCtr: 0.003,
+};
+
+export type AnomalyRuleId =
+  | "cpc_spike"
+  | "cpc_ceiling"
+  | "ctr_floor"
+  | "zero_conversions"
+  | "spend_pace";
+
+export interface AnomalyFinding {
+  /** Stable id for the rule that fired — used for de-dup keying. */
+  rule: AnomalyRuleId;
+  /** "warning" | "critical" — drives the emoji + DM thread color. */
+  severity: "warning" | "critical";
+  /** Human-readable one-liner shown to the operator. */
+  message: string;
+  /** Structured detail the renderer can format. */
+  detail: {
+    metric: string;
+    observed: number;
+    threshold: number;
+    /** Rolling baseline value, if applicable. */
+    baseline?: number;
+  };
+}
+
+export interface EvaluateAnomaliesOpts {
+  current: AdMetrics;
+  previous?: AdMetrics | null;
+  rules?: AnomalyRules;
+  /** Length of the current window in hours — used by `zero_conversions`. */
+  windowHours?: number;
+}
+
+/**
+ * Evaluate every rule against the current snapshot and return all findings.
+ * Empty array = no anomalies — the runtime should NOT post a DM.
+ */
+export function evaluateAnomalies(opts: EvaluateAnomaliesOpts): AnomalyFinding[] {
+  const { current, previous, rules = {}, windowHours = 1 } = opts;
+  const findings: AnomalyFinding[] = [];
+
+  // ---- CPC spike (vs rolling baseline) -------------------------------------
+  const cpcMult = rules.cpcSpikeMultiplier ?? DEFAULTS.cpcSpikeMultiplier;
+  if (previous?.cpcEur && current.cpcEur && previous.cpcEur > 0) {
+    if (current.cpcEur >= previous.cpcEur * cpcMult) {
+      findings.push({
+        rule: "cpc_spike",
+        severity: "warning",
+        message: `CPC is ${(current.cpcEur / previous.cpcEur).toFixed(2)}× the prior window's CPC (€${current.cpcEur.toFixed(2)} vs €${previous.cpcEur.toFixed(2)}).`,
+        detail: {
+          metric: "cpcEur",
+          observed: current.cpcEur,
+          threshold: previous.cpcEur * cpcMult,
+          baseline: previous.cpcEur,
+        },
+      });
+    }
+  }
+
+  // ---- CPC ceiling (absolute) ---------------------------------------------
+  if (rules.maxCpcEur && current.cpcEur && current.cpcEur > rules.maxCpcEur) {
+    findings.push({
+      rule: "cpc_ceiling",
+      severity: "critical",
+      message: `CPC €${current.cpcEur.toFixed(2)} exceeds the configured ceiling of €${rules.maxCpcEur.toFixed(2)}.`,
+      detail: {
+        metric: "cpcEur",
+        observed: current.cpcEur,
+        threshold: rules.maxCpcEur,
+      },
+    });
+  }
+
+  // ---- CTR floor (absolute) ------------------------------------------------
+  // Only meaningful when there are enough impressions to make a CTR
+  // measurement statistically real. Skip when impressions < 200 so a 1-click
+  // window doesn't fire a false alarm.
+  const minCtr = rules.minCtr ?? DEFAULTS.minCtr;
+  if (
+    current.impressions >= 200 &&
+    typeof current.ctr === "number" &&
+    current.ctr < minCtr
+  ) {
+    findings.push({
+      rule: "ctr_floor",
+      severity: "warning",
+      message: `CTR ${(current.ctr * 100).toFixed(2)}% is below the floor of ${(minCtr * 100).toFixed(2)}%.`,
+      detail: {
+        metric: "ctr",
+        observed: current.ctr,
+        threshold: minCtr,
+      },
+    });
+  }
+
+  // ---- Zero conversions while spending ------------------------------------
+  const zeroHours = rules.zeroConversionsHours ?? DEFAULTS.zeroConversionsHours;
+  // Only fire when the configured window covers at least `zeroHours`. The
+  // 15-min poll window can't tell whether conversions are missing for "24h"
+  // — that's a derived fact the runtime feeds via `windowHours`.
+  if (
+    windowHours >= zeroHours &&
+    current.spendEur > 0 &&
+    current.conversions === 0
+  ) {
+    findings.push({
+      rule: "zero_conversions",
+      severity: "critical",
+      message: `€${current.spendEur.toFixed(2)} spent over ~${zeroHours}h with zero conversions.`,
+      detail: {
+        metric: "conversions",
+        observed: 0,
+        threshold: zeroHours,
+      },
+    });
+  }
+
+  // ---- Spend pace (vs rolling baseline) -----------------------------------
+  const paceMult = rules.spendPaceMultiplier ?? DEFAULTS.spendPaceMultiplier;
+  if (previous && previous.spendEur > 0 && current.spendEur > 0) {
+    if (current.spendEur >= previous.spendEur * paceMult) {
+      findings.push({
+        rule: "spend_pace",
+        severity: "warning",
+        message: `Spend is ${(current.spendEur / previous.spendEur).toFixed(2)}× the prior window (€${current.spendEur.toFixed(2)} vs €${previous.spendEur.toFixed(2)}).`,
+        detail: {
+          metric: "spendEur",
+          observed: current.spendEur,
+          threshold: previous.spendEur * paceMult,
+          baseline: previous.spendEur,
+        },
+      });
+    }
+  }
+
+  return findings;
+}
+
+/**
+ * Stable key per-finding so the runtime can de-dup re-sent alerts. Combines
+ * campaign + platform + rule + window-day so the SAME alert in the next 15-min
+ * tick doesn't spam the DM channel — but a fresh occurrence the next morning
+ * does.
+ */
+export function findingDedupKey(opts: {
+  campaignSlug: string;
+  platform: string;
+  rule: AnomalyRuleId;
+  windowEnd: string; // ISO
+}): string {
+  const day = opts.windowEnd.slice(0, 10); // YYYY-MM-DD
+  return `ad-analytics:anomaly:${opts.campaignSlug}:${opts.platform}:${opts.rule}:${day}`;
+}

--- a/src/lib/ad-analytics/digest.ts
+++ b/src/lib/ad-analytics/digest.ts
@@ -182,3 +182,66 @@ function formatRatio(value?: number): string {
   if (typeof value !== "number" || !Number.isFinite(value)) return "—";
   return `${(value * 100).toFixed(2)}%`;
 }
+
+// ---------------------------------------------------------------------------
+// Phase 4 — anomaly DM renderer
+// ---------------------------------------------------------------------------
+
+import type { AnomalyFinding } from "./anomaly";
+
+/**
+ * Render a Block Kit anomaly alert. Designed to read well as a DM (no header
+ * channel emoji — Slack already labels DMs in the sidebar) but works in a
+ * channel target too.
+ *
+ * One section per finding so an operator can scroll through multiple alerts
+ * without losing context. Severity gets a colored circle so a glance from a
+ * phone notification conveys priority.
+ */
+export function renderAnomalyBlocks(opts: {
+  campaignSlug: string;
+  platform: string;
+  findings: AnomalyFinding[];
+}): NotificationBlock[] {
+  const { campaignSlug, platform, findings } = opts;
+  if (findings.length === 0) return [];
+
+  const headerCount = findings.length === 1 ? "1 anomaly" : `${findings.length} anomalies`;
+  const blocks: NotificationBlock[] = [
+    {
+      type: "header",
+      text: `🚨 ${headerCount} on ${campaignSlug} (${platform})`,
+    },
+  ];
+
+  for (const f of findings) {
+    const dot = f.severity === "critical" ? "🔴" : "🟡";
+    const baselineLine =
+      typeof f.detail.baseline === "number"
+        ? ` · baseline ${formatDetailValue(f.detail.metric, f.detail.baseline)}`
+        : "";
+    blocks.push({
+      type: "section",
+      text:
+        `${dot} *${f.rule.replace(/_/g, " ")}* — ${escapeMrkdwn(f.message)}\n` +
+        `_observed ${formatDetailValue(f.detail.metric, f.detail.observed)}` +
+        ` · threshold ${formatDetailValue(f.detail.metric, f.detail.threshold)}` +
+        `${baselineLine}_`,
+    });
+  }
+
+  blocks.push({
+    type: "context",
+    text: `cloudless.gr ad-analytics · ${new Date().toISOString()}`,
+  });
+
+  return blocks;
+}
+
+function formatDetailValue(metric: string, value: number): string {
+  if (metric === "ctr") return `${(value * 100).toFixed(2)}%`;
+  if (metric === "spendEur" || metric === "cpcEur" || metric === "cpaEur") {
+    return `€${value.toFixed(2)}`;
+  }
+  return String(value);
+}

--- a/src/lib/ad-analytics/runtime.ts
+++ b/src/lib/ad-analytics/runtime.ts
@@ -33,8 +33,9 @@ import type { AdPlatformAdapter } from "./adapters/ad-platform";
 import type { NotificationChannel } from "./channels/notification";
 import { linkedinAdapter } from "./adapters/linkedin";
 import { slackChannel } from "./channels/slack";
-import { renderConversionBlocks, renderDigest } from "./digest";
+import { renderConversionBlocks, renderDigest, renderAnomalyBlocks } from "./digest";
 import { bookmarkKeyOf, getBookmarkStore } from "./bookmarks";
+import { evaluateAnomalies, findingDedupKey, type AnomalyFinding } from "./anomaly";
 
 /**
  * Registry of concrete adapters. Keep this map literal — `as const` enforces
@@ -283,6 +284,8 @@ export async function runScheduledPoll(opts?: {
       }
 
       const posted: Array<{ channel: string; target: string; ok: boolean }> = [];
+      const anomalyChannels = channelsForLevel(campaign.notifyChannels, "anomaly");
+      const windowHours = Math.max(1, Math.round(windowMs / 3_600_000));
       for (const current of metrics) {
         const key = bookmarkKeyOf({
           campaignSlug: campaign.slug,
@@ -316,8 +319,64 @@ export async function runScheduledPoll(opts?: {
             posted.push({ channel: config.channel, target: config.target, ok: false });
           }
         }
-        // Only advance the bookmark when at least one channel accepted the
-        // post — otherwise a Slack outage would silently drop a window.
+
+        // ---- Anomaly evaluation + DM fan-out ------------------------------
+        // Runs on every digest tick so the operator sees an alert within the
+        // same 15-min window the digest reports it in. De-dup keys live in
+        // the bookmark store under their own keys so the SAME anomaly in the
+        // next tick doesn't spam.
+        if (anomalyChannels.length > 0) {
+          const findings = evaluateAnomalies({
+            current,
+            previous: bookmark?.snapshot ?? null,
+            rules: campaign.anomalyRules,
+            windowHours,
+          });
+          const unsent = await filterAlreadySent(store, findings, {
+            campaignSlug: campaign.slug,
+            platform: platformConfig.platform,
+            windowEnd: current.windowEnd,
+          });
+          if (unsent.length > 0) {
+            const anomalyBlocks = renderAnomalyBlocks({
+              campaignSlug: campaign.slug,
+              platform: platformConfig.platform,
+              findings: unsent,
+            });
+            for (const { config, channel } of anomalyChannels) {
+              try {
+                const { messageId } = await channel.sendBlock({
+                  target: config.target,
+                  blocks: anomalyBlocks,
+                });
+                const ok = !messageId.endsWith(":not-sent");
+                posted.push({
+                  channel: config.channel,
+                  target: config.target,
+                  ok,
+                });
+                if (ok) {
+                  await markFindingsSent(store, unsent, {
+                    campaignSlug: campaign.slug,
+                    platform: platformConfig.platform,
+                    windowEnd: current.windowEnd,
+                    snapshot: current,
+                  });
+                }
+              } catch (err) {
+                console.error(
+                  `[ad-analytics/runtime] anomaly notification failed:`,
+                  err
+                );
+                posted.push({ channel: config.channel, target: config.target, ok: false });
+              }
+            }
+          }
+        }
+
+        // Only advance the bookmark when at least one digest/anomaly channel
+        // accepted the post — otherwise a Slack outage would silently drop a
+        // window.
         if (posted.some((p) => p.ok)) {
           await store.putBookmark(key, current);
         }
@@ -334,6 +393,51 @@ export async function runScheduledPoll(opts?: {
   }
 
   return { digests, noop: digests.length === 0 };
+}
+
+/**
+ * Drop findings that already fired and were DM'd in this dedup window (a
+ * day, currently). The bookmark store doubles as a de-dup ledger here so we
+ * don't need a second AWS resource — the same `pk` schema works.
+ */
+async function filterAlreadySent(
+  store: ReturnType<typeof getBookmarkStore>,
+  findings: AnomalyFinding[],
+  ctx: { campaignSlug: string; platform: string; windowEnd: string }
+): Promise<AnomalyFinding[]> {
+  const out: AnomalyFinding[] = [];
+  for (const f of findings) {
+    const key = findingDedupKey({
+      campaignSlug: ctx.campaignSlug,
+      platform: ctx.platform,
+      rule: f.rule,
+      windowEnd: ctx.windowEnd,
+    });
+    const existing = await store.getBookmark(key);
+    if (!existing) out.push(f);
+  }
+  return out;
+}
+
+async function markFindingsSent(
+  store: ReturnType<typeof getBookmarkStore>,
+  findings: AnomalyFinding[],
+  ctx: {
+    campaignSlug: string;
+    platform: string;
+    windowEnd: string;
+    snapshot: AdMetrics;
+  }
+): Promise<void> {
+  for (const f of findings) {
+    const key = findingDedupKey({
+      campaignSlug: ctx.campaignSlug,
+      platform: ctx.platform,
+      rule: f.rule,
+      windowEnd: ctx.windowEnd,
+    });
+    await store.putBookmark(key, ctx.snapshot);
+  }
 }
 
 // ---------------------------------------------------------------------------

--- a/src/lib/ad-analytics/types.ts
+++ b/src/lib/ad-analytics/types.ts
@@ -54,15 +54,36 @@ export interface NotifyChannelConfig {
 }
 
 /** Per-campaign tunable thresholds for anomaly DMs. All values are optional;
- *  unset = no anomaly check for that dimension. */
+ *  unset = no anomaly check for that dimension. Defaults (when the campaign
+ *  enables anomaly DMs but doesn't override) are documented in
+ *  `skills/ad-analytics/SKILL.md` and inline at evaluator level.
+ *
+ *  Source thresholds for the defaults — distilled from Improvado's 2026 ad
+ *  anomaly playbook, Go-Insights' monitoring rules, and Ryze's "stop wasting
+ *  ad spend" guide:
+ *    - CPM ≥25% vs 7-day average        → alert
+ *    - CTR drops ≥40% with stable freq  → alert
+ *    - CPA increase ≥25% sustained 48h+ → alert
+ *    - CPC spike ≥40%                   → alert
+ *    - Daily budget > 110% of target    → alert
+ *    - Conversion rate drop ≥30% DoD    → alert
+ *  "Start conservative" — a 20% CPA increase over 3 days is more reliable
+ *  than a 10% increase over 1 day. */
 export interface AnomalyRules {
-  /** Today's spend pace > N × yesterday's spend pace at same hour → DM. */
+  /** Today's spend pace > N × yesterday's spend pace at the same hour → fire.
+   *  Industry default 1.5 (50% over). */
   spendPaceMultiplier?: number;
-  /** CPC above this absolute value → DM. */
+  /** Current-window CPC > N × the rolling baseline CPC → fire. Industry
+   *  default 1.4 (40% spike per the Improvado threshold). */
+  cpcSpikeMultiplier?: number;
+  /** CPC above this absolute value (€) → fire. Useful as a hard ceiling
+   *  independent of the rolling baseline. */
   maxCpcEur?: number;
-  /** No conversions in N hours while spend > 0 → DM. */
+  /** No conversions in N hours while spend > 0 → fire. Industry default 24h —
+   *  give the funnel one full day before complaining. */
   zeroConversionsHours?: number;
-  /** CTR below this fraction (e.g. 0.005 = 0.5%) → DM. */
+  /** CTR below this fraction (e.g. 0.003 = 0.3%, LinkedIn's effective floor)
+   *  → fire. Industry default 0.003. */
   minCtr?: number;
 }
 


### PR DESCRIPTION
Phase 4 of the reusable ad-analytics module — anomaly DM alerts.

Thresholds are not invented — they're distilled from the 2026 industry consensus on ad-campaign anomaly detection so the cloudless.gr operator doesn't have to figure out "what counts as a CPC spike" from scratch.

## Research basis

Threshold defaults sourced from:

- [Improvado — Marketing Anomaly Detection & Automated Alerts: 2026 Guide](https://improvado.io/blog/marketing-anomaly-detection-automated-alerts) — "if CPC jumps by 40%, alert immediately"; "CTR declines ≥40%"; "CPA increase ≥25% sustained for 48+ hours"
- [Go-Insights — How monitoring works](https://www.go-insights.com/anomaly-detection) — baseline-aware pacing methodology
- [Ryze AI — How to Stop Wasting Ad Spend Automatically (2026)](https://www.get-ryze.ai/answers/how-to-stop-wasting-ad-spend-automatically) — "start conservative — 20% over 3 days is more reliable than 10% over 1 day"; "alert within 15 minutes, not 15 hours"
- [Tinybird Z-score reference](https://github.com/tinybirdco/use-case-real-time-anomaly-detection/blob/main/content/z-score.md) — statistical layer for the future ≥7-snapshot upgrade

## What ships

| Piece | Path |
|---|---|
| Anomaly evaluator | `src/lib/ad-analytics/anomaly.ts` — `evaluateAnomalies()`, `DEFAULTS`, `findingDedupKey()`. Five rules: `cpc_spike`, `cpc_ceiling`, `ctr_floor`, `zero_conversions`, `spend_pace`. |
| Anomaly DM renderer | `src/lib/ad-analytics/digest.ts` — new `renderAnomalyBlocks()` (severity dots, baseline context, structured detail line). |
| Runtime fan-out | `src/lib/ad-analytics/runtime.ts` — `runScheduledPoll()` now also evaluates anomalies on every poll, fires Block Kit messages to every `notifyChannels[].level === "anomaly"` target, and de-dupes via the bookmark store. |
| Schema | `src/lib/ad-analytics/types.ts` — `AnomalyRules` extended with `cpcSpikeMultiplier`. JSDoc captures the threshold sources inline. |
| Config | `src/data/campaigns.ts` — `shop-online` opts in with `{ channel: "slack", target: "#ads-digest", level: "anomaly" }`. Industry defaults apply because `anomalyRules` is unset. |
| Skill update | `skills/ad-analytics/SKILL.md` — new "Anomaly thresholds" section with the full default table + source citations. |

## Threshold defaults (the contract)

| Rule | Default | Why |
|---|---|---|
| `cpcSpikeMultiplier` | 1.4 (40% over baseline) | Improvado |
| `spendPaceMultiplier` | 1.5 (50% over baseline) | Go-Insights |
| `zeroConversionsHours` | 24 | Ryze — "give the funnel one full day" |
| `minCtr` | 0.003 (0.3%) | LinkedIn effective floor |
| `maxCpcEur` | unset | Operator opts in with a hard ceiling |

Plus two important guardrails:

- **CTR floor skips below 200 impressions** so a 1-click window doesn't fire a false alarm.
- **Spend pace and CPC spike are skipped on cold start** (no previous bookmark) so a freshly-deployed Lambda doesn't fire "+everything."

## De-dup ledger

Findings are de-duped via the existing bookmark store under `findingDedupKey({ campaign, platform, rule, day })`. Same rule re-firing in the next 15-min tick stays silent; the next calendar day re-opens it. No new AWS resource — same `pk` schema as the headline bookmarks.

## Tests

10 new tests in `__tests__/ad-analytics/anomaly.test.ts`, **33 total ad-analytics tests passing** (typecheck ok):

- `DEFAULTS` contract pinned — if you change them you must also update the skill.
- Healthy snapshot → no findings.
- CPC spike fires when current ≥ 1.4× previous; does NOT fire on cold start.
- CPC ceiling fires `critical` when CPC > `maxCpcEur`.
- CTR floor fires only when impressions ≥ 200 (small-sample guard).
- Zero conversions fires ONLY when `windowHours ≥ zeroConversionsHours`.
- Spend pace fires when current ≥ 1.5× previous.
- Per-campaign overrides beat `DEFAULTS`.
- `findingDedupKey()` collapses repeats inside a calendar day but re-opens next day.

## After deploy

Next time the every-15-min `linkedin-poll.yml` workflow runs `/api/cron/ad-analytics-poll`, anomalies (if any fire) land in `#ads-digest` alongside the regular digest. Format:

```
🚨 1 anomaly on shop-online (linkedin)
🟡 cpc spike — CPC is 1.62× the prior window's CPC (€12.60 vs €7.78).
   observed €12.60 · threshold €10.89 · baseline €7.78
cloudless.gr ad-analytics · 2026-06-19T09:00:00Z
```

## Operator levers

- Override `anomalyRules` per campaign (e.g. `{ maxCpcEur: 10 }`) when reality drifts from the industry defaults.
- Switch the anomaly channel target from `#ads-digest` to a Slack user-id DM (e.g. `target: "U12345"`) once anomalies start firing in real life — the runtime already routes by `target`.
- The `cpc_spike` and `spend_pace` rules currently use the simple ratio-of-means against the last bookmark. Once we have ≥7 bookmarked snapshots a future PR will swap them for proper Z-score against a rolling 7-day baseline (per the Tinybird reference in the skill).

Closes task #32.
