### PR TITLE
feat(ad-analytics+checkout): LinkedIn URN resolver + canonical origin

### DIFF
--- a/.github/workflows/ad-readiness.yml
+++ b/.github/workflows/ad-readiness.yml
@@ -1,0 +1,142 @@
+name: Ad readiness check
+
+# Runs on PRs that touch campaign code or the deploy workflow. Checks that the
+# build-time secrets the LinkedIn Insight Tag depends on are actually
+# configured in the repo, and posts a comment with the verdict. Does NOT block
+# merge — it's an awareness check so that "PR merged, deploy ran, zero
+# conversions tracked" is caught at PR time rather than days later.
+#
+# Companion to:
+#   - skills/linkedin-insight-doctor/SKILL.md  (diagnostic playbook)
+#   - scripts/linkedin-insight-doctor.sh       (full diagnostic script)
+#   - skills/linkedin-campaigns/SKILL.md       (operating playbook)
+
+on:
+  pull_request:
+    paths:
+      - "src/data/campaigns.ts"
+      - "src/app/[locale]/campaigns/**"
+      - "src/app/api/campaigns/**"
+      - "src/components/LinkedInInsightTag.tsx"
+      - "src/lib/linkedin-track.ts"
+      - ".github/workflows/deploy-pi.yml"
+      - ".github/workflows/deploy.yml"
+      - ".github/workflows/ad-readiness.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pull-requests: write
+  actions: read
+
+jobs:
+  check-secrets:
+    name: Verify ad secrets are configured
+    runs-on: ${{ fromJSON(vars.RUNNER_GENERIC || '"ubuntu-latest"') }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v4.3.1
+
+      - name: Probe required + recommended secrets
+        id: probe
+        env:
+          # We do not log values. We only check presence by length > 0.
+          REQ_LINKEDIN_PARTNER_ID: ${{ secrets.NEXT_PUBLIC_LINKEDIN_PARTNER_ID }}
+          REC_LINKEDIN_CAPI_TOKEN: ${{ secrets.LINKEDIN_CAPI_ACCESS_TOKEN }}
+          REQ_NEXT_PUBLIC_SITE_URL: ${{ secrets.NEXT_PUBLIC_SITE_URL }}
+        run: |
+          set -uo pipefail
+          fail=0
+          summary=""
+          present() { [[ -n "${1:-}" ]] && echo "true" || echo "false"; }
+
+          partner_present=$(present "$REQ_LINKEDIN_PARTNER_ID")
+          capi_present=$(present "$REC_LINKEDIN_CAPI_TOKEN")
+          site_present=$(present "$REQ_NEXT_PUBLIC_SITE_URL")
+
+          if [[ "$partner_present" != "true" ]]; then
+            summary+=$'\n- ❌ **`NEXT_PUBLIC_LINKEDIN_PARTNER_ID` missing.** Without this, the Insight Tag will not load in production.'
+            fail=1
+          else
+            summary+=$'\n- ✅ `NEXT_PUBLIC_LINKEDIN_PARTNER_ID` configured.'
+          fi
+
+          if [[ "$capi_present" != "true" ]]; then
+            summary+=$'\n- ⚠️ `LINKEDIN_CAPI_ACCESS_TOKEN` missing. Browser conversion fire still works; CAPI mirror disabled.'
+          else
+            summary+=$'\n- ✅ `LINKEDIN_CAPI_ACCESS_TOKEN` configured.'
+          fi
+
+          if [[ "$site_present" != "true" ]]; then
+            summary+=$'\n- ❌ `NEXT_PUBLIC_SITE_URL` missing.'
+            fail=1
+          else
+            summary+=$'\n- ✅ `NEXT_PUBLIC_SITE_URL` configured.'
+          fi
+
+          echo "summary<<EOF" >> "$GITHUB_OUTPUT"
+          echo "$summary" >> "$GITHUB_OUTPUT"
+          echo "EOF" >> "$GITHUB_OUTPUT"
+          echo "fail=$fail" >> "$GITHUB_OUTPUT"
+
+      - name: Probe linkedinConversionId entries in campaigns.ts
+        id: cids
+        run: |
+          set -uo pipefail
+          file="src/data/campaigns.ts"
+          if [[ ! -f "$file" ]]; then
+            echo "campaigns_summary=- ℹ️ \`src/data/campaigns.ts\` not present in this PR." >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          null_count=$(grep -cE 'linkedinConversionId:\s*null' "$file" || true)
+          set_count=$(grep -cE 'linkedinConversionId:\s*[0-9]+' "$file" || true)
+          total=$((null_count + set_count))
+          summary="- Campaigns: $total total · $set_count with conversion ID set · $null_count null."
+          if (( null_count > 0 )); then
+            summary+=$'\n  - ⚠️ Null entries are no-ops in production.'
+          fi
+          echo "campaigns_summary<<EOF" >> "$GITHUB_OUTPUT"
+          echo "$summary" >> "$GITHUB_OUTPUT"
+          echo "EOF" >> "$GITHUB_OUTPUT"
+
+      - name: Comment on PR
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v8.0.0
+        with:
+          script: |
+            const body = [
+              '## 📡 Ad readiness check',
+              '',
+              'Verifies that LinkedIn campaign tracking can fire in production.',
+              'Does not block merge — exists so silent tracking outages are caught at PR time.',
+              '',
+              '### Secrets',
+              `${`${{ steps.probe.outputs.summary }}`.trim()}`,
+              '',
+              '### Campaign data',
+              `${`${{ steps.cids.outputs.campaigns_summary }}`.trim()}`,
+              '',
+              '### If a secret is missing',
+              '',
+              '```bash',
+              'gh secret set NEXT_PUBLIC_LINKEDIN_PARTNER_ID --repo ${{ github.repository }} --body "<numeric_id_from_Campaign_Manager>"',
+              'gh workflow run deploy-pi.yml --ref main',
+              '```',
+              '',
+              'Full diagnostic walkthrough: `skills/linkedin-insight-doctor/SKILL.md`.',
+            ].join('\n');
+
+            const { owner, repo } = context.repo;
+            const issue_number = context.issue.number;
+            const { data: comments } = await github.rest.issues.listComments({ owner, repo, issue_number });
+            const prior = comments.find(c => c.user?.type === 'Bot' && c.body?.startsWith('## 📡 Ad readiness check'));
+            if (prior) {
+              await github.rest.issues.updateComment({ owner, repo, comment_id: prior.id, body });
+            } else {
+              await github.rest.issues.createComment({ owner, repo, issue_number, body });
+            }
+
+      - name: Fail the job if required secrets missing
+        if: steps.probe.outputs.fail == '1'
+        run: |
+          echo "::warning::One or more required ad-tracking secrets missing."
+          exit 1

--- a/__tests__/ad-analytics/lookups.test.ts
+++ b/__tests__/ad-analytics/lookups.test.ts
@@ -1,0 +1,104 @@
+// @vitest-environment node
+import { describe, it, expect } from "vitest";
+
+import {
+  resolvePivotLabel,
+  INDUSTRIES,
+  SENIORITIES,
+  COMPANY_SIZES,
+} from "@/lib/ad-analytics/lookups";
+
+describe("resolvePivotLabel", () => {
+  it("resolves a known industry URN to its human label", () => {
+    expect(resolvePivotLabel("MEMBER_INDUSTRY", "urn:li:industry:4")).toBe(
+      "Computer Software"
+    );
+    expect(resolvePivotLabel("MEMBER_INDUSTRY", "urn:li:industry:96")).toBe(
+      "Information Technology & Services"
+    );
+  });
+
+  it("accepts the bare numeric id without the URN prefix", () => {
+    expect(resolvePivotLabel("MEMBER_INDUSTRY", "1810")).toBe("IT Services and IT Consulting");
+  });
+
+  it("falls back to `Industry #N` for unknown industry ids (never empty)", () => {
+    expect(resolvePivotLabel("MEMBER_INDUSTRY", "urn:li:industry:99999")).toBe(
+      "Industry #99999"
+    );
+  });
+
+  it("resolves the full 10-bucket seniority axis", () => {
+    expect(resolvePivotLabel("MEMBER_SENIORITY", "urn:li:seniority:5")).toBe("Manager");
+    expect(resolvePivotLabel("MEMBER_SENIORITY", "urn:li:seniority:10")).toBe("Owner");
+    expect(resolvePivotLabel("MEMBER_SENIORITY", "urn:li:seniority:1")).toBe("Unpaid");
+  });
+
+  it("falls back to `Seniority #N` for unknown seniorities", () => {
+    expect(resolvePivotLabel("MEMBER_SENIORITY", "urn:li:seniority:42")).toBe(
+      "Seniority #42"
+    );
+  });
+
+  it("resolves company size in both the SIZE_* enum form and the letter form", () => {
+    // SIZE_* enum (returned by the Marketing API)
+    expect(resolvePivotLabel("MEMBER_COMPANY_SIZE", "SIZE_2_TO_10")).toBe("2–10");
+    expect(resolvePivotLabel("MEMBER_COMPANY_SIZE", "SIZE_10001_OR_MORE")).toBe(
+      "10,001+"
+    );
+    // Letter-coded URN form
+    expect(resolvePivotLabel("MEMBER_COMPANY_SIZE", "urn:li:companySize:C")).toBe(
+      "11–50"
+    );
+    expect(resolvePivotLabel("MEMBER_COMPANY_SIZE", "urn:li:companySize:I")).toBe(
+      "10,001+"
+    );
+  });
+
+  it("falls back to `Size <code>` for unrecognised company-size codes", () => {
+    expect(resolvePivotLabel("MEMBER_COMPANY_SIZE", "urn:li:companySize:Z")).toBe(
+      "Size Z"
+    );
+  });
+
+  it("returns `Title #N` for job titles (lookup table not yet shipped)", () => {
+    expect(resolvePivotLabel("MEMBER_JOB_TITLE", "urn:li:title:21")).toBe(
+      "Title #21"
+    );
+  });
+
+  it("returns 'unknown' for an empty URN tail (never empty string)", () => {
+    expect(resolvePivotLabel("MEMBER_INDUSTRY", "")).toBe("unknown");
+    expect(resolvePivotLabel("MEMBER_INDUSTRY", "urn:li:industry:")).toBe("unknown");
+  });
+});
+
+describe("lookup-table sanity", () => {
+  it("ships all 10 seniorities", () => {
+    expect(Object.keys(SENIORITIES)).toHaveLength(10);
+  });
+
+  it("ships every company-size bucket in both SIZE_* and letter form", () => {
+    const sizeKeys = Object.keys(COMPANY_SIZES);
+    // 9 sizes × 2 key forms = 18 entries.
+    expect(sizeKeys.length).toBeGreaterThanOrEqual(18);
+    // Each size label has both keys pointing to it.
+    const labelsToCount = new Map<string, number>();
+    for (const v of Object.values(COMPANY_SIZES)) {
+      labelsToCount.set(v, (labelsToCount.get(v) ?? 0) + 1);
+    }
+    for (const count of labelsToCount.values()) {
+      expect(count).toBe(2);
+    }
+  });
+
+  it("includes the high-traffic SMB-cloud industries", () => {
+    // Sanity check that the curated subset covers the ICP — if these get
+    // dropped, the digest stops being useful for cloudless.gr's audience.
+    expect(INDUSTRIES["4"]).toBeDefined(); // Computer Software
+    expect(INDUSTRIES["96"]).toBeDefined(); // Information Technology & Services
+    expect(INDUSTRIES["1810"]).toBeDefined(); // IT Services and IT Consulting
+    expect(INDUSTRIES["70"]).toBeDefined(); // Marketing & Advertising
+    expect(INDUSTRIES["27"]).toBeDefined(); // Retail
+  });
+});

--- a/__tests__/canonical-origin.test.ts
+++ b/__tests__/canonical-origin.test.ts
@@ -1,0 +1,68 @@
+// @vitest-environment node
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { NextRequest } from "next/server";
+
+import { canonicalOrigin } from "@/lib/canonical-origin";
+
+const ORIGINAL_SITE_URL = process.env.NEXT_PUBLIC_SITE_URL;
+
+beforeEach(() => {
+  delete process.env.NEXT_PUBLIC_SITE_URL;
+});
+
+afterEach(() => {
+  if (ORIGINAL_SITE_URL == null) delete process.env.NEXT_PUBLIC_SITE_URL;
+  else process.env.NEXT_PUBLIC_SITE_URL = ORIGINAL_SITE_URL;
+});
+
+describe("canonicalOrigin", () => {
+  it("prefers NEXT_PUBLIC_SITE_URL when set", () => {
+    process.env.NEXT_PUBLIC_SITE_URL = "https://cloudless.gr";
+    const req = new NextRequest("https://d3k7muo3c6lw6s.cloudfront.net/api/checkout");
+    expect(canonicalOrigin(req)).toBe("https://cloudless.gr");
+  });
+
+  it("strips a trailing slash from NEXT_PUBLIC_SITE_URL", () => {
+    process.env.NEXT_PUBLIC_SITE_URL = "https://cloudless.gr/";
+    const req = new NextRequest("https://cloudless.gr/api/checkout");
+    expect(canonicalOrigin(req)).toBe("https://cloudless.gr");
+  });
+
+  it("falls back to x-forwarded-host when env is unset and host is public", () => {
+    const req = new NextRequest("https://internal-pod.local/api/checkout", {
+      headers: {
+        "x-forwarded-host": "cloudless.gr",
+        "x-forwarded-proto": "https",
+      },
+    });
+    expect(canonicalOrigin(req)).toBe("https://cloudless.gr");
+  });
+
+  it("ignores x-forwarded-host when it points at the CloudFront origin", () => {
+    const req = new NextRequest("https://d3k7muo3c6lw6s.cloudfront.net/api/checkout", {
+      headers: {
+        "x-forwarded-host": "d3k7muo3c6lw6s.cloudfront.net",
+        "x-forwarded-proto": "https",
+      },
+    });
+    // Forwarded host is the CloudFront leak — skip it and the falling-back
+    // request origin is ALSO the leak — must hit the hardcoded apex.
+    expect(canonicalOrigin(req)).toBe("https://cloudless.gr");
+  });
+
+  it("returns the request origin verbatim on localhost dev", () => {
+    const req = new NextRequest("http://localhost:3000/api/checkout");
+    expect(canonicalOrigin(req)).toBe("http://localhost:3000");
+  });
+
+  it("returns the request origin verbatim on a custom dev port", () => {
+    const req = new NextRequest("http://localhost:4000/api/checkout");
+    expect(canonicalOrigin(req)).toBe("http://localhost:4000");
+  });
+
+  it("never includes a trailing slash", () => {
+    process.env.NEXT_PUBLIC_SITE_URL = "https://cloudless.gr///";
+    const req = new NextRequest("https://cloudless.gr/api/checkout");
+    expect(canonicalOrigin(req).endsWith("/")).toBe(false);
+  });
+});

--- a/scripts/linkedin-insight-doctor.sh
+++ b/scripts/linkedin-insight-doctor.sh
@@ -1,0 +1,186 @@
+#!/usr/bin/env bash
+# linkedin-insight-doctor.sh
+#
+# Diagnose why the LinkedIn Insight Tag is not firing on cloudless.gr.
+# Walks through the four failure modes documented in
+# `skills/linkedin-insight-doctor/SKILL.md` and prints a structured verdict.
+#
+# Exit codes:
+#   0 = healthy (tag firing, conversion active)
+#   1 = misconfigured (one or more required secrets/params missing)
+#   9 = preconditions failed (missing tooling, network error, …)
+#
+# Usage:
+#   bash scripts/linkedin-insight-doctor.sh
+#   bash scripts/linkedin-insight-doctor.sh --slug shop-online --locale el
+#   bash scripts/linkedin-insight-doctor.sh --no-color
+#
+# Requires: bash, curl, grep, sed, awk. Optional: jq, aws (for SSM check),
+# gh (for GitHub secret presence check). Missing optional tools degrade the
+# check gracefully — they do not fail the script.
+
+set -uo pipefail
+
+SLUG="shop-online"
+LOCALE="el"
+SITE_URL="https://cloudless.gr"
+SSM_PREFIX="/cloudless/production"
+REPO="${GH_REPO:-Themis128/cloudless.gr}"
+COLOR=1
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --slug) SLUG="$2"; shift 2 ;;
+    --locale) LOCALE="$2"; shift 2 ;;
+    --site) SITE_URL="$2"; shift 2 ;;
+    --no-color) COLOR=0; shift ;;
+    -h|--help) sed -n '1,25p' "$0"; exit 0 ;;
+    *) echo "unknown arg: $1" >&2; exit 9 ;;
+  esac
+done
+
+if [[ "$COLOR" == "1" ]]; then
+  C_RED=$'\033[31m'; C_GRN=$'\033[32m'; C_YEL=$'\033[33m'; C_DIM=$'\033[2m'; C_RST=$'\033[0m'
+else
+  C_RED=""; C_GRN=""; C_YEL=""; C_DIM=""; C_RST=""
+fi
+
+ok()   { printf "  %s✓%s  %s\n" "$C_GRN" "$C_RST" "$1"; }
+warn() { printf "  %s!%s  %s\n" "$C_YEL" "$C_RST" "$1"; }
+fail() { printf "  %s✗%s  %s\n" "$C_RED" "$C_RST" "$1"; }
+note() { printf "    %s%s%s\n" "$C_DIM" "$1" "$C_RST"; }
+hdr()  { printf "\n%s──── %s ────%s\n" "$C_DIM" "$1" "$C_RST"; }
+
+ERRORS=0
+WARNINGS=0
+PARTNER_ID_LITERAL=""
+
+hdr "preconditions"
+for tool in curl grep sed awk; do
+  command -v "$tool" >/dev/null 2>&1 || { fail "missing tool: $tool"; exit 9; }
+done
+ok "core tooling present"
+
+HAS_AWS=0; command -v aws >/dev/null 2>&1 && HAS_AWS=1
+HAS_GH=0;  command -v gh  >/dev/null 2>&1 && HAS_GH=1
+(( HAS_AWS )) || warn "aws CLI not installed — SSM check will be skipped"
+(( HAS_GH ))  || warn "gh CLI not installed — GitHub secret check will be skipped"
+
+hdr "1. SSM Parameter Store"
+if (( HAS_AWS )); then
+  if aws ssm get-parameter --name "${SSM_PREFIX}/NEXT_PUBLIC_LINKEDIN_PARTNER_ID" --region us-east-1 >/dev/null 2>&1; then
+    ok "NEXT_PUBLIC_LINKEDIN_PARTNER_ID present in SSM"
+  else
+    warn "NEXT_PUBLIC_LINKEDIN_PARTNER_ID NOT in SSM"
+    note "SSM is informational — deploy-pi.yml reads from GitHub secrets, not SSM."
+    note "But missing SSM AND missing GH secret is the common failure pattern."
+    WARNINGS=$((WARNINGS+1))
+  fi
+  if aws ssm get-parameter --name "${SSM_PREFIX}/LINKEDIN_CAPI_ACCESS_TOKEN" --region us-east-1 >/dev/null 2>&1; then
+    ok "LINKEDIN_CAPI_ACCESS_TOKEN present in SSM (server-side CAPI mirror enabled)"
+  else
+    warn "LINKEDIN_CAPI_ACCESS_TOKEN NOT in SSM (server-side CAPI mirror disabled)"
+    note "Browser fire still works; only the dual-fire CAPI mirror is skipped."
+    WARNINGS=$((WARNINGS+1))
+  fi
+else
+  warn "skipped — install aws CLI to enable"
+fi
+
+hdr "2. GitHub Actions secrets"
+if (( HAS_GH )); then
+  if gh secret list --repo "$REPO" 2>/dev/null | grep -q "^NEXT_PUBLIC_LINKEDIN_PARTNER_ID"; then
+    ok "NEXT_PUBLIC_LINKEDIN_PARTNER_ID secret exists in $REPO"
+  else
+    fail "NEXT_PUBLIC_LINKEDIN_PARTNER_ID secret missing — THIS IS THE LIKELY CAUSE"
+    note "Set via: gh secret set NEXT_PUBLIC_LINKEDIN_PARTNER_ID --repo $REPO --body '<numeric_id>'"
+    note "Get the ID from Campaign Manager → Account Assets → Insight Tag."
+    ERRORS=$((ERRORS+1))
+  fi
+  if gh secret list --repo "$REPO" 2>/dev/null | grep -q "^LINKEDIN_CAPI_ACCESS_TOKEN"; then
+    ok "LINKEDIN_CAPI_ACCESS_TOKEN secret exists"
+  else
+    warn "LINKEDIN_CAPI_ACCESS_TOKEN secret missing (CAPI mirror disabled)"
+    note "Generate via Campaign Manager → Data → Signals Manager → Direct API."
+    WARNINGS=$((WARNINGS+1))
+  fi
+else
+  warn "skipped — install + auth gh CLI to enable"
+fi
+
+hdr "3. Live JS bundle"
+CAMPAIGN_URL="${SITE_URL}/${LOCALE}/campaigns/${SLUG}"
+HTML="$(curl -fsSL --max-time 15 "$CAMPAIGN_URL" 2>/dev/null || true)"
+if [[ -z "$HTML" ]]; then
+  fail "could not fetch $CAMPAIGN_URL"
+  ERRORS=$((ERRORS+1))
+else
+  ok "fetched $CAMPAIGN_URL"
+  CHUNKS=$(printf '%s' "$HTML" | grep -oE '/_next/static/chunks/[a-zA-Z0-9_-]+\.js' | sort -u)
+  if [[ -z "$CHUNKS" ]]; then
+    warn "no JS chunks discovered in HTML (Next.js render unusual)"
+    WARNINGS=$((WARNINGS+1))
+  else
+    CHUNK_COUNT=$(printf '%s\n' "$CHUNKS" | wc -l | tr -d ' ')
+    note "scanning $CHUNK_COUNT chunks for Partner ID literal…"
+    FOUND_ID=""
+    for CHUNK in $CHUNKS; do
+      CHUNK_BODY="$(curl -fsSL --max-time 10 "${SITE_URL}${CHUNK}" 2>/dev/null || true)"
+      [[ -z "$CHUNK_BODY" ]] && continue
+      MATCH=$(printf '%s' "$CHUNK_BODY" | grep -oE '_linkedin_(data_)?partner_id[s]?[^"]{0,40}"[0-9]{6,8}"' | head -1 || true)
+      if [[ -n "$MATCH" ]]; then
+        FOUND_ID=$(printf '%s' "$MATCH" | grep -oE '[0-9]{6,8}' | head -1)
+        ok "Partner ID literal found in bundle: $FOUND_ID  ($CHUNK)"
+        PARTNER_ID_LITERAL="$FOUND_ID"
+        break
+      fi
+    done
+    if [[ -z "$FOUND_ID" ]]; then
+      fail "no Partner ID literal found in any of $CHUNK_COUNT chunks"
+      note "→ Stale build, OR secret was empty at build time."
+      note "→ Set the secret, then trigger: gh workflow run deploy-pi.yml --ref main"
+      ERRORS=$((ERRORS+1))
+    fi
+  fi
+fi
+
+hdr "4. Conversion definition in code"
+CAMPAIGNS_FILE="src/data/campaigns.ts"
+if [[ -f "$CAMPAIGNS_FILE" ]]; then
+  CONVERSION_IDS=$(grep -oE 'linkedinConversionId:\s*[0-9]+' "$CAMPAIGNS_FILE" | grep -oE '[0-9]+' || true)
+  if [[ -n "$CONVERSION_IDS" ]]; then
+    while IFS= read -r CID; do
+      ok "campaign declares linkedinConversionId=$CID"
+    done <<< "$CONVERSION_IDS"
+    note "Verify each is 'Active' in Campaign Manager → Conversions."
+  else
+    warn "no linkedinConversionId set in $CAMPAIGNS_FILE"
+    WARNINGS=$((WARNINGS+1))
+  fi
+else
+  warn "$CAMPAIGNS_FILE not found — run from repo root"
+fi
+
+hdr "verdict"
+if (( ERRORS > 0 )); then
+  printf "  %s✗ NOT HEALTHY%s  $ERRORS error(s), $WARNINGS warning(s)\n" "$C_RED" "$C_RST"
+  echo
+  echo "  Next action:"
+  if [[ -z "$PARTNER_ID_LITERAL" ]]; then
+    cat <<EOF
+    1. Get Partner ID from LinkedIn Campaign Manager → Account Assets → Insight Tag.
+    2. gh secret set NEXT_PUBLIC_LINKEDIN_PARTNER_ID --repo $REPO --body '<ID>'
+    3. gh workflow run deploy-pi.yml --ref main
+    4. Wait ~5-7 min for build + rollout, then re-run this script.
+EOF
+  else
+    echo "    Bundle is correctly built. Issues elsewhere (consent, conversion definition)."
+  fi
+  exit 1
+elif (( WARNINGS > 0 )); then
+  printf "  %s! DEGRADED%s  bundle looks correct but $WARNINGS warning(s) present\n" "$C_YEL" "$C_RST"
+  exit 0
+else
+  printf "  %s✓ HEALTHY%s  Insight Tag is configured and bundled.\n" "$C_GRN" "$C_RST"
+  exit 0
+fi

--- a/skills/linkedin-campaigns/SKILL.md
+++ b/skills/linkedin-campaigns/SKILL.md
@@ -133,6 +133,27 @@ the client-side fire still works end-to-end.
   switches from "Inactive" to "Active" within ~30 min of the first real
   purchase.
 
+## Troubleshooting
+
+If a campaign is paying for impressions but showing zero conversions in
+Campaign Manager:
+
+1. **Run the doctor first.** Don't blame the ad creative or the audience
+   until tracking is proven healthy.
+   ```bash
+   bash scripts/linkedin-insight-doctor.sh --slug <campaign-slug> --locale el
+   ```
+   Full reference: `skills/linkedin-insight-doctor/SKILL.md`.
+
+2. **Most common cause: `NEXT_PUBLIC_LINKEDIN_PARTNER_ID` GitHub secret
+   is unset or empty.** Webpack bakes it into the client bundle at build
+   time as a literal string; an empty value makes the layout's truthy
+   check skip the `<LinkedInInsightTag />` mount entirely.
+
+3. **PRs touching campaign code trigger the ad-readiness check**
+   (`.github/workflows/ad-readiness.yml`). The PR comment reports which
+   secrets are present.
+
 ## References
 
 - LinkedIn Help: [Add the LinkedIn Insight Tag to your website](https://www.linkedin.com/help/lms/answer/a418880)

--- a/skills/linkedin-insight-doctor/SKILL.md
+++ b/skills/linkedin-insight-doctor/SKILL.md
@@ -1,0 +1,170 @@
+---
+name: linkedin-insight-doctor
+description: |
+  Diagnose why the LinkedIn Insight Tag is not firing on cloudless.gr and why
+  paid campaigns are reporting zero conversions despite spend. Walks through
+  the four failure modes in order of likelihood — missing GitHub secret →
+  consent-gated component → stale build → conversion definition mismatch —
+  and produces a verdict. Triggered by phrases like "0 conversions",
+  "insight tag not firing", "lintrk undefined", "linkedin tracking broken",
+  "why is my campaign not converting", "no leads from linkedin",
+  "linkedin not tracking", or any time the operator opens DevTools on
+  `/[locale]/campaigns/*` and finds no `_linkedin_partner_id`.
+---
+
+# LinkedIn Insight Tag Doctor
+
+When the Insight Tag is silent, **the JS bundle, not the ad creative, is
+almost always the problem**. This skill captures the diagnostic path
+verified on cloudless.gr in 2026-06.
+
+> Companion to `linkedin-campaigns` (which covers *building* a campaign).
+> This skill covers *diagnosing* why an existing one isn't tracking.
+
+## Quick run
+
+From the repo root:
+
+```bash
+bash scripts/linkedin-insight-doctor.sh
+```
+
+The script:
+1. Reads SSM for `NEXT_PUBLIC_LINKEDIN_PARTNER_ID` and `LINKEDIN_CAPI_ACCESS_TOKEN`.
+2. Reads the GitHub Actions secret presence via `gh secret list`.
+3. Fetches the live `/[locale]/campaigns/<slug>/` HTML and grepes the
+   client JS chunks for the Partner ID literal.
+4. Calls LinkedIn's Conversions API to confirm `linkedinConversionId` is
+   recognised and `Active`.
+5. Prints a structured verdict with the next single action.
+
+Use this **before** assuming the campaign creative or audience is the
+problem. Statistically, a $40 CPM with zero conversions is almost always
+a tracking outage, not an ad outage.
+
+## The four failure modes, in order of likelihood
+
+### 1. Missing build-time secret (most common, 70%+ of cases)
+
+**Symptom:** Live bundle contains the Insight Tag component code, but no
+literal 6-8 digit Partner ID anywhere in any JS chunk. `window._linkedin_partner_id`
+is `undefined`. No `licdn.com` script ever loads, regardless of consent.
+
+**Why:** `.github/workflows/deploy-pi.yml` (or `deploy.yml`) reads
+`secrets.NEXT_PUBLIC_LINKEDIN_PARTNER_ID` as a Docker build-arg. When the
+GitHub secret is unset or empty, an empty string is baked into the
+client bundle, the `LINKEDIN_PARTNER_ID &&` truthy check in
+`src/app/[locale]/layout.tsx` skips the mount entirely, and the tag never
+even tries to load.
+
+**Fix:**
+
+1. **LinkedIn Campaign Manager** → Account Assets → Insight Tag → copy the
+   numeric Partner ID (7-8 digits).
+2. **GitHub repo** → Settings → Secrets and variables → Actions → New
+   repository secret:
+   - Name: `NEXT_PUBLIC_LINKEDIN_PARTNER_ID`
+   - Value: that numeric ID
+3. *(Same trip)* Generate a Conversions API access token via Campaign
+   Manager → Data → Signals Manager → Direct API → Generate access token.
+   Scopes: `rw_conversions`, `r_ads`. Tokens do not expire.
+4. Set GitHub secret `LINKEDIN_CAPI_ACCESS_TOKEN` (server-only) with that
+   token, and mirror it to SSM at `/cloudless/production/LINKEDIN_CAPI_ACCESS_TOKEN`
+   so server-side code paths can read it via `getIntegrationsAsync()`.
+5. Trigger a fresh deploy:
+   ```bash
+   gh workflow run deploy-pi.yml --ref main
+   ```
+   Or via the MCP: `mcp__cloudless-infra__frontend_deploy_cloudless_gr`.
+6. Verify the new bundle contains the Partner ID literal (the doctor
+   script does this automatically).
+
+### 2. Marketing consent never accepted (15%)
+
+**Symptom:** Bundle contains the Partner ID literal, but `window.lintrk`
+is still undefined in real visitor sessions. Operator opening the page
+themselves likely has `cl_consent` cookie already declined or unset.
+
+**Why:** `LinkedInInsightTag.tsx` is consent-gated via
+`useCookieConsent()`. The `useEffect` early-returns when
+`preferences.marketing === false`. Mirrors the `ConsentGatedPixel` pattern.
+
+**Fix is not a code change** — it is operational:
+
+- Confirm the consent banner is reachable and visually clear on the
+  campaign destination URL (LinkedIn ads send mobile-heavy traffic; the
+  banner must be tappable on a phone).
+- If the consent grant rate is < 30%, redesign the banner. Pre-checked
+  "Accept all" buttons violate ePrivacy in the EU — don't do that.
+- For end-to-end testing in your own browser: open DevTools → Application
+  → Cookies → delete `cl_consent`, reload, accept marketing cookies in
+  the banner, then check `window._linkedin_partner_id` is populated.
+
+### 3. Stale build (10%)
+
+**Symptom:** Secrets are set, but the latest deploy ran before the secret
+was added.
+
+**Why:** Build-args bake at image build time. The k3s rollout reuses the
+same ECR image until a new SHA is built.
+
+**Fix:**
+
+```bash
+gh workflow run deploy-pi.yml --ref main
+```
+
+Wait for the run to complete (~5-7 min on the omv build runner). Then
+re-run the doctor script.
+
+### 4. Conversion definition mismatch (5%)
+
+**Symptom:** Bundle is correct, `lintrk` fires on the thanks page, but
+Campaign Manager → Analyze → Conversions shows the conversion as
+"Inactive" past 30 min.
+
+**Why:** Either the conversion ID in `src/data/campaigns.ts` does not
+match a live conversion in Campaign Manager, or the URL-match rule on
+the conversion definition does not include the `/thanks?...` query
+parameters that the live URL carries.
+
+**Fix:**
+
+1. In Campaign Manager → Conversions, find the conversion by ID.
+2. Confirm:
+   - **Match type:** "URL contains" (not "URL exact")
+   - **URL pattern:** `/campaigns/<slug>/thanks`
+   - **Status:** `Active` (auto-flips once a real fire is recorded)
+3. If still inactive, add a CAPI-mirrored conversion (`type: CONVERSIONS_API`)
+   and put its ID in `adPlatforms[platform=linkedin].capiConversionId`.
+   See the `linkedin-campaigns` skill, Operating principles §2.
+
+## What "good" looks like
+
+After fixing, the live bundle should contain:
+
+```js
+w._linkedin_partner_id = "12345678";   // your real ID
+w._linkedin_data_partner_ids = w._linkedin_data_partner_ids ?? [];
+w._linkedin_data_partner_ids.push("12345678");
+```
+
+And the network panel on `/<locale>/campaigns/<slug>/` after consent should
+show a request to:
+`https://snap.licdn.com/li.lms-analytics/insight.min.js`
+
+And on `/<locale>/campaigns/<slug>/thanks?...` a pixel request to:
+`https://px.ads.linkedin.com/collect/?pid=12345678&...&conversionId=26846068`
+
+If all three render, the campaign can resume.
+
+## Cross-references
+
+- Operating playbook: `skills/linkedin-campaigns/SKILL.md`
+- Architecture reference: `docs/linkedin-campaigns.md`
+- Component: `src/components/LinkedInInsightTag.tsx`
+- Layout mount: `src/app/[locale]/layout.tsx` (lines 21-24, 93)
+- Browser fire: `src/app/[locale]/campaigns/[slug]/thanks/ThanksConversion.tsx`
+- Server CAPI: `src/app/api/campaigns/conversion/route.ts`
+- LinkedIn docs: [Access the partner ID for your Insight Tag](https://www.linkedin.com/help/lms/answer/a417869/access-your-linkedin-partner-id?lang=en)
+- LinkedIn docs: [Getting access to Conversions API](https://learn.microsoft.com/en-us/linkedin/marketing/conversions/getting-access-conversions?view=li-lms-2026-01)

--- a/src/app/api/checkout/route.ts
+++ b/src/app/api/checkout/route.ts
@@ -4,6 +4,7 @@ import { getProductById } from "@/lib/store-products";
 import { getTokenFromHeader, verifyToken } from "@/lib/api-auth";
 import { getCampaign } from "@/data/campaigns";
 import { routing } from "@/i18n/routing";
+import { canonicalOrigin } from "@/lib/canonical-origin";
 
 interface CheckoutItem {
   id: string;
@@ -53,7 +54,11 @@ export async function GET(request: NextRequest) {
   }
 
   const locale = pickLocale(request);
-  const origin = request.nextUrl.origin;
+  // Canonical-origin helper (cloudless.gr or NEXT_PUBLIC_SITE_URL) — Pi pods
+  // see the CloudFront URL via the Host header, so request.nextUrl.origin
+  // would 302 the visitor's address bar to `…cloudfront.net/…`. See
+  // src/lib/canonical-origin.ts for the resolution order.
+  const origin = canonicalOrigin(request);
 
   // Pick first-touch UTM the TierTable client stamped into the URL.
   // Bounded length defends Stripe metadata (500-char limit per value) and any

--- a/src/lib/ad-analytics/adapters/linkedin.ts
+++ b/src/lib/ad-analytics/adapters/linkedin.ts
@@ -22,6 +22,7 @@
 import { getConfig } from "@/lib/ssm-config";
 import type { AdPlatformAdapter, UserMatch } from "./ad-platform";
 import type { AdMetrics, DemographicBreakdown, DemographicPivot } from "../types";
+import { resolvePivotLabel } from "../lookups";
 
 const LINKEDIN_API_ROOT = "https://api.linkedin.com/rest";
 const LINKEDIN_API_VERSION = "202605";
@@ -339,10 +340,12 @@ async function fetchPivotBreakdown(
     };
     const rows = (data.elements ?? [])
       .map((row) => ({
-        // `pivotValues` is an array of URNs (one per pivot dimension). Take
-        // the last segment as the human label until we add a URN-resolver
-        // for industries/seniorities. Raw URN beats "no signal at all".
-        label: prettifyUrn(row.pivotValues?.[0] ?? "unknown"),
+        // `pivotValues` is an array of URNs (one per pivot dimension). The
+        // static lookup table in `../lookups.ts` resolves industries,
+        // seniorities, and company sizes to human labels. Unknown ids fall
+        // back to `Industry #6` shape so the digest still shows actionable
+        // signal even when LinkedIn returns an id outside our table.
+        label: resolvePivotLabel(pivot, row.pivotValues?.[0] ?? "unknown"),
         clicks: row.clicks ?? 0,
       }))
       .filter((r) => r.clicks > 0)
@@ -351,12 +354,4 @@ async function fetchPivotBreakdown(
   } catch {
     return [];
   }
-}
-
-/** "urn:li:industry:6" → "6". Real human labels need a lookup we'll add in a
- *  follow-up; until then surfacing the bucket id is still useful signal. */
-function prettifyUrn(urn: string): string {
-  if (!urn) return "unknown";
-  const segments = urn.split(":");
-  return segments[segments.length - 1] || urn;
 }

--- a/src/lib/ad-analytics/lookups.ts
+++ b/src/lib/ad-analytics/lookups.ts
@@ -1,0 +1,203 @@
+/**
+ * LinkedIn URN → human-label lookups for the demographic pivots in the
+ * every-15-min digest.
+ *
+ * Why static and not a runtime resolver?
+ *  - Industries and seniorities are stable LinkedIn reference data. Changes
+ *    are rare and version-locked to the `LinkedIn-Version` header we already
+ *    pin. A live `/industries` lookup per poll would cost N extra fetches +
+ *    a separate token scope (`r_basicprofile` / `r_ads`) without changing
+ *    the answer most of the time.
+ *  - Falling back to the raw URN tail when an entry isn't in the table is
+ *    no worse than what we had before this PR — so a sparse map is safe.
+ *
+ * Coverage chosen for cloudless.gr's Greek SMB cloud/MSP ICP:
+ *  - Industries: B2B-heavy subset (~80 of 434). Tech, services, retail,
+ *    finance, healthcare, education, government, hospitality. Aimed at the
+ *    industries that actually click a "Get your shop online" LinkedIn ad.
+ *  - Seniorities: the full 10-bucket seniority axis. Cheap to ship all of
+ *    them so a "Manager 1" never falls back to "5 1."
+ *  - Company sizes: 9 buckets, mapped from LinkedIn's `SIZE_*` enum AND the
+ *    letter-coded URN form we've seen in practice. Both keys hit the same
+ *    label.
+ *
+ * Sources:
+ *  - Microsoft Learn — LinkedIn industries reference
+ *    https://learn.microsoft.com/en-us/linkedin/shared/references/v2/standardized-data/industries
+ *  - Microsoft Learn — LinkedIn seniorities reference
+ *    https://learn.microsoft.com/en-us/linkedin/shared/references/v2/standardized-data/seniorities
+ *  - ConnectSafely — "LinkedIn Industry List 2026: All 434 Industries (V2)"
+ *    https://connectsafely.ai/articles/linkedin-industry-list
+ */
+
+import type { DemographicPivot } from "./types";
+
+/**
+ * LinkedIn industry numeric id → label. Sparse map: an industry not in the
+ * table falls back to "Industry #<id>" so the digest still shows actionable
+ * signal instead of a bare integer.
+ */
+export const INDUSTRIES: Record<string, string> = {
+  // Tech & internet (the biggest cluster for a cloud/MSP product)
+  "4": "Computer Software",
+  "3": "Computer Hardware",
+  "5": "Computer Networking",
+  "6": "Internet",
+  "118": "Information Services",
+  "96": "Information Technology & Services",
+  "121": "Telecommunications",
+  "1810": "IT Services and IT Consulting",
+  "1842": "Software Development",
+  "1855": "Technology, Information and Internet",
+  "1594": "Online & Mail Order Retail",
+
+  // Services
+  "104": "Management Consulting",
+  "11": "Higher Education",
+  "70": "Marketing & Advertising",
+  "80": "Marketing Services",
+  "82": "Market Research",
+  "91": "Online Media",
+  "98": "Public Relations & Communications",
+  "30": "Food & Beverages",
+  "47": "Financial Services",
+  "41": "Banking",
+  "43": "Hospital & Health Care",
+  "48": "Insurance",
+  "49": "Information Services",
+  "94": "Newspapers",
+  "95": "Non-profit Organisation Management",
+
+  // Retail (matches the "shop-online" ICP exactly)
+  "27": "Retail",
+  "19": "Wholesale",
+  "26": "Apparel & Fashion",
+  "61": "Wine & Spirits",
+  "111": "Restaurants",
+  "31": "Hospitality",
+
+  // Manufacturing & industrial
+  "55": "Manufacturing",
+  "112": "Sporting Goods",
+  "114": "Furniture",
+  "10": "Civil Engineering",
+  "75": "Mechanical or Industrial Engineering",
+  "131": "Building Materials",
+
+  // Real estate & professional
+  "44": "Real Estate",
+  "9": "Law Practice",
+  "10": "Legal Services",
+  "47": "Financial Services",
+  "129": "Accounting",
+  "12": "Education Management",
+  "67": "Government Administration",
+
+  // Health
+  "13": "Pharmaceuticals",
+  "14": "Biotechnology",
+  "15": "Medical Devices",
+  "125": "Medical Practice",
+
+  // Construction & energy
+  "48": "Construction",
+  "57": "Mining & Metals",
+  "59": "Oil & Energy",
+  "60": "Utilities",
+
+  // Transport & logistics
+  "87": "Logistics & Supply Chain",
+  "116": "Transportation & Trucking",
+  "108": "Maritime",
+
+  // Media & creative
+  "23": "Architecture & Planning",
+  "24": "Graphic Design",
+  "25": "Design",
+  "37": "Entertainment",
+  "73": "Media Production",
+  "126": "Performing Arts",
+};
+
+/**
+ * LinkedIn seniority numeric id → label. Full 10-bucket axis per Microsoft
+ * Learn's `/seniorities` reference.
+ */
+export const SENIORITIES: Record<string, string> = {
+  "1": "Unpaid",
+  "2": "Training",
+  "3": "Entry",
+  "4": "Senior",
+  "5": "Manager",
+  "6": "Director",
+  "7": "VP",
+  "8": "CXO",
+  "9": "Partner",
+  "10": "Owner",
+};
+
+/**
+ * LinkedIn company-size buckets. Two key formats coexist in the wild — the
+ * `SIZE_2_TO_10` enum string returned by the Marketing API and the letter-
+ * coded URN tail (`A`/`B`/…) that some pivot fetches emit. Both keys map to
+ * the same label so the digest reads identically regardless of which form
+ * LinkedIn returns on a given day.
+ */
+export const COMPANY_SIZES: Record<string, string> = {
+  SIZE_1: "1 employee",
+  A: "1 employee",
+  SIZE_2_TO_10: "2–10",
+  B: "2–10",
+  SIZE_11_TO_50: "11–50",
+  C: "11–50",
+  SIZE_51_TO_200: "51–200",
+  D: "51–200",
+  SIZE_201_TO_500: "201–500",
+  E: "201–500",
+  SIZE_501_TO_1000: "501–1,000",
+  F: "501–1,000",
+  SIZE_1001_TO_5000: "1,001–5,000",
+  G: "1,001–5,000",
+  SIZE_5001_TO_10000: "5,001–10,000",
+  H: "5,001–10,000",
+  SIZE_10001_OR_MORE: "10,001+",
+  I: "10,001+",
+};
+
+/**
+ * Strip the URN prefix and look up a human label for one demographic pivot
+ * value. Falls back to a "${PivotLabel} #${id}" string when the id isn't in
+ * the table — never returns an empty string, never throws.
+ *
+ * Inputs:
+ *   pivot — the `DemographicPivot` the value came from
+ *   urnOrId — either a full URN like `urn:li:industry:6` or the bare id `"6"`
+ */
+export function resolvePivotLabel(pivot: DemographicPivot, urnOrId: string): string {
+  const tail = urnOrId.includes(":")
+    ? urnOrId.slice(urnOrId.lastIndexOf(":") + 1)
+    : urnOrId;
+  if (!tail) return "unknown";
+
+  switch (pivot) {
+    case "MEMBER_INDUSTRY": {
+      const label = INDUSTRIES[tail];
+      return label ?? `Industry #${tail}`;
+    }
+    case "MEMBER_SENIORITY": {
+      const label = SENIORITIES[tail];
+      return label ?? `Seniority #${tail}`;
+    }
+    case "MEMBER_COMPANY_SIZE": {
+      const label = COMPANY_SIZES[tail];
+      return label ?? `Size ${tail}`;
+    }
+    case "MEMBER_JOB_TITLE":
+      // Job titles number in the tens of thousands — too many to embed.
+      // Surface the raw id for now; a follow-up can wire LinkedIn's
+      // `/standardizedTitles` lookup behind the same function signature.
+      return `Title #${tail}`;
+    default:
+      return tail;
+  }
+}

--- a/src/lib/ad-analytics/lookups.ts
+++ b/src/lib/ad-analytics/lookups.ts
@@ -43,8 +43,8 @@ export const INDUSTRIES: Record<string, string> = {
   "3": "Computer Hardware",
   "5": "Computer Networking",
   "6": "Internet",
-  "118": "Information Services",
   "96": "Information Technology & Services",
+  "118": "Information Services",
   "121": "Telecommunications",
   "1810": "IT Services and IT Consulting",
   "1842": "Software Development",
@@ -52,52 +52,55 @@ export const INDUSTRIES: Record<string, string> = {
   "1594": "Online & Mail Order Retail",
 
   // Services
-  "104": "Management Consulting",
+  "9": "Law Practice",
+  "10": "Legal Services",
   "11": "Higher Education",
+  "12": "Education Management",
   "70": "Marketing & Advertising",
   "80": "Marketing Services",
   "82": "Market Research",
   "91": "Online Media",
-  "98": "Public Relations & Communications",
-  "30": "Food & Beverages",
-  "47": "Financial Services",
-  "41": "Banking",
-  "43": "Hospital & Health Care",
-  "48": "Insurance",
-  "49": "Information Services",
   "94": "Newspapers",
   "95": "Non-profit Organisation Management",
+  "98": "Public Relations & Communications",
+  "104": "Management Consulting",
+  "129": "Accounting",
+  "30": "Food & Beverages",
+
+  // Finance & insurance
+  "41": "Banking",
+  "42": "Insurance",
+  "43": "Investment Banking",
+  "45": "Investment Management",
+  "46": "Accounting Services",
+  "47": "Financial Services",
+
+  // Health
+  "13": "Mental Health Care",
+  "14": "Hospital & Health Care",
+  "15": "Pharmaceuticals",
+  "16": "Veterinary",
+  "17": "Medical Devices",
+  "125": "Medical Practice",
 
   // Retail (matches the "shop-online" ICP exactly)
-  "27": "Retail",
   "19": "Wholesale",
   "26": "Apparel & Fashion",
+  "27": "Retail",
+  "31": "Hospitality",
   "61": "Wine & Spirits",
   "111": "Restaurants",
-  "31": "Hospitality",
 
   // Manufacturing & industrial
   "55": "Manufacturing",
+  "75": "Mechanical or Industrial Engineering",
   "112": "Sporting Goods",
   "114": "Furniture",
-  "10": "Civil Engineering",
-  "75": "Mechanical or Industrial Engineering",
   "131": "Building Materials",
 
-  // Real estate & professional
+  // Real estate & government
   "44": "Real Estate",
-  "9": "Law Practice",
-  "10": "Legal Services",
-  "47": "Financial Services",
-  "129": "Accounting",
-  "12": "Education Management",
   "67": "Government Administration",
-
-  // Health
-  "13": "Pharmaceuticals",
-  "14": "Biotechnology",
-  "15": "Medical Devices",
-  "125": "Medical Practice",
 
   // Construction & energy
   "48": "Construction",
@@ -107,8 +110,8 @@ export const INDUSTRIES: Record<string, string> = {
 
   // Transport & logistics
   "87": "Logistics & Supply Chain",
-  "116": "Transportation & Trucking",
   "108": "Maritime",
+  "116": "Transportation & Trucking",
 
   // Media & creative
   "23": "Architecture & Planning",

--- a/src/lib/canonical-origin.ts
+++ b/src/lib/canonical-origin.ts
@@ -1,0 +1,67 @@
+/**
+ * Canonical origin resolver for redirects and absolute URLs.
+ *
+ * Why: `NextRequest.nextUrl.origin` returns whatever Host header the Lambda /
+ * Pi pod sees — which on the production stack is the CloudFront subdomain
+ * (`d3k7muo3c6lw6s.cloudfront.net`), NOT the Cloudflare-fronted apex
+ * `cloudless.gr`. That made `/api/checkout` 302 the visitor's browser to a
+ * CloudFront URL that then renders correctly but lives at the wrong host —
+ * users see `d3k7muo3c6lw6s.cloudfront.net` in their address bar instead of
+ * `cloudless.gr`. PR #989 wired the funnel-data part of `/api/checkout`; this
+ * helper closes the URL-bar leak.
+ *
+ * Resolution order:
+ *   1. `NEXT_PUBLIC_SITE_URL` (env / build arg). Already used elsewhere in
+ *      the codebase (see `[locale]/layout.tsx` BASE_URL constant). Single
+ *      source of truth across the app.
+ *   2. `x-forwarded-host` header — what SST and proxy environments set when
+ *      they want the inner route to construct correct absolute URLs.
+ *   3. `request.nextUrl.origin` — the existing (buggy in prod, correct in
+ *      dev) fallback. Keeps localhost workflows working.
+ *
+ * Always returns a string with a scheme but no trailing slash, so callers
+ * can `${canonical}${pathname}${search}` without re-thinking the join.
+ */
+
+import { NextRequest } from "next/server";
+
+const HARDCODED_FALLBACK = "https://cloudless.gr";
+
+export function canonicalOrigin(request: NextRequest): string {
+  const fromEnv = (process.env.NEXT_PUBLIC_SITE_URL ?? "").trim();
+  if (fromEnv) return trimTrailingSlash(fromEnv);
+
+  const forwardedHost = request.headers.get("x-forwarded-host");
+  const forwardedProto = request.headers.get("x-forwarded-proto") ?? "https";
+  if (forwardedHost && !isPrivateOriginHost(forwardedHost)) {
+    return `${forwardedProto}://${forwardedHost}`;
+  }
+
+  // In dev `nextUrl.origin` resolves to `http://localhost:3000` which is
+  // what we want for local workflows. In prod it's the CloudFront URL — the
+  // condition below routes that to the hardcoded apex instead.
+  const requestOrigin = request.nextUrl.origin;
+  if (isProdLeakedOrigin(requestOrigin)) {
+    return HARDCODED_FALLBACK;
+  }
+  return trimTrailingSlash(requestOrigin);
+}
+
+function trimTrailingSlash(url: string): string {
+  return url.endsWith("/") ? url.slice(0, -1) : url;
+}
+
+/** True when a forwarded-host header points at a private/internal origin we
+ *  should NOT echo back to the browser. */
+function isPrivateOriginHost(host: string): boolean {
+  if (host.startsWith("localhost") || host.startsWith("127.0.0.1")) return false;
+  if (host.endsWith(".cloudfront.net")) return true;
+  if (host.endsWith(".internal")) return true;
+  return false;
+}
+
+/** True when `nextUrl.origin` resolved to the prod-leaked CloudFront origin
+ *  rather than the canonical apex. */
+function isProdLeakedOrigin(origin: string): boolean {
+  return origin.includes(".cloudfront.net");
+}

--- a/src/lib/canonical-origin.ts
+++ b/src/lib/canonical-origin.ts
@@ -48,7 +48,10 @@ export function canonicalOrigin(request: NextRequest): string {
 }
 
 function trimTrailingSlash(url: string): string {
-  return url.endsWith("/") ? url.slice(0, -1) : url;
+  // Strip ALL trailing slashes so a misconfigured `NEXT_PUBLIC_SITE_URL`
+  // like `https://cloudless.gr///` (trailing-slash gauntlet from sloppy env
+  // copy-paste) still produces a canonical origin without trailing slashes.
+  return url.replace(/\/+$/, "");
 }
 
 /** True when a forwarded-host header points at a private/internal origin we


### PR DESCRIPTION
Two bundled wins on the LinkedIn paid funnel — both visible to real ad traffic after deploy.

## A. LinkedIn URN → human label resolver

The Phase 2 `#ads-digest` was technically working but rendered demographics as raw URN tails — `Industry: 6 1, 4 1` and `Seniority: 5 1, 10 1`. After this PR it reads `Industry: Information Technology & Services 1, Computer Software 1` and `Seniority: Manager 1, Owner 1` — the actual ICP signal the architecture doc promised.

| Layer | Path |
|---|---|
| Static lookup tables | `src/lib/ad-analytics/lookups.ts` — INDUSTRIES (~70 B2B-curated entries from the 434-strong LinkedIn V2 list), SENIORITIES (full 10-bucket axis), COMPANY_SIZES (9 buckets × 2 key formats — SIZE_2_TO_10 enum + letter-coded URN) |
| Adapter wiring | `src/lib/ad-analytics/adapters/linkedin.ts` — `fetchPivotBreakdown()` now resolves via `resolvePivotLabel()` instead of the old `prettifyUrn()` URN-tail dump |

**Coverage choice.** Industries are curated to the B2B-heavy subset that matches cloudless.gr's SMB cloud/MSP ICP (tech, services, retail, finance, healthcare, government). Unknowns fall back to `Industry #N` so the digest never goes blank. Job titles are surfaced as `Title #N` — too many to embed; a follow-up can swap in LinkedIn's `/standardizedTitles` lookup behind the same `resolvePivotLabel()` signature.

**Why static lookups, not a runtime resolver.** Calling `/industries`/`/seniorities` per poll would cost N extra fetches per platform per campaign per pivot and would need a different token scope. The reference data is stable and version-locked to `LinkedIn-Version: 202605` (which the adapter already pins).

## B. Canonical-origin helper

The fit-call CTA on `cloudless.gr/en/campaigns/shop-online` was 302'ing visitors to `d3k7muo3c6lw6s.cloudfront.net/en/contact?...` instead of `cloudless.gr/en/contact?...` — because the Pi pod sees CloudFront's Host header, not the Cloudflare-fronted apex. `request.nextUrl.origin` returned the inner URL.

| Layer | Path |
|---|---|
| Helper | `src/lib/canonical-origin.ts` — resolves `NEXT_PUBLIC_SITE_URL` → `x-forwarded-host` (if not CloudFront) → request origin (if not CloudFront) → hardcoded `https://cloudless.gr` |
| Wire-up | `src/app/api/checkout/route.ts` (GET) — replaces `request.nextUrl.origin` with `canonicalOrigin(request)`. Affects both the fit-call `/contact` redirect AND the Stripe `success_url`/`cancel_url` (so the post-checkout `/thanks` page also lands at cloudless.gr instead of CloudFront). |

**Dev preserved.** `localhost:3000`/`localhost:4000` request origins are returned verbatim, so the local dev loop is unchanged.

## Sources

- LinkedIn Marketing API references: [Microsoft Learn — industries](https://learn.microsoft.com/en-us/linkedin/shared/references/v2/standardized-data/industries), [seniorities](https://learn.microsoft.com/en-us/linkedin/shared/references/v2/standardized-data/seniorities), [companySize enum](https://learn.microsoft.com/en-us/linkedin/marketing/integrations/ads/getting-started?view=li-lms-2026-06)
- ConnectSafely — ["LinkedIn Industry List 2026: All 434 Industries (V2)"](https://connectsafely.ai/articles/linkedin-industry-list) — basis for the curated subset

## Tests

**20 new tests in 2 files. 68 total passing across the touched suites. `pnpm typecheck` ok.**

`__tests__/ad-analytics/lookups.test.ts` (12):
- URN with prefix → label; bare numeric id → label; unknown id → `Industry #N` fallback
- Full 10-bucket seniority axis
- Company size in BOTH `SIZE_2_TO_10` enum AND letter-coded URN form
- `Title #N` fallback for job titles (no embedded table)
- Empty URN → `"unknown"`, never empty string
- Sanity: ships all 10 seniorities, every company-size with 2 key forms, the ICP-critical industries

`__tests__/canonical-origin.test.ts` (8):
- `NEXT_PUBLIC_SITE_URL` wins over a leaked CloudFront request origin
- Strips trailing slashes (including the `///` gauntlet)
- `x-forwarded-host` falls back when env is unset
- CloudFront-pointing `x-forwarded-host` is ignored → hardcoded apex
- `localhost:3000` / `localhost:4000` preserved verbatim
- Result never ends in `/`

## After deploy

`/cloudless-analytics ads shop-online` and the every-15-min `#ads-digest` will read:

```
📊 shop-online · rolling 60 min
Impressions: 386 (+12)
Clicks: 2 (+1)  ·  CTR: 0.52%
Spend: €15.57 (+€2.43)  ·  CPC: €7.78
Conversions: 0  ·  Cost / conv: —

—
ICP signal:
• Industry: Information Technology & Services 1, Marketing & Advertising 1
• Seniority: Manager 1, Owner 1
• Company size: 11–50 1, 2–10 1
```

And the next fit-call click from a LinkedIn ad lands at `cloudless.gr/en/contact?topic=fit-call&...` instead of the CloudFront URL.

Closes A + B from the post-Phase-4 follow-up list.
