### PR TITLE
fix(ci): Lighthouse store-route budget never matched /en/store

### DIFF
--- a/.github/lighthouse-budget.json
+++ b/.github/lighthouse-budget.json
@@ -1,6 +1,6 @@
 [
   {
-    "path": "/store",
+    "path": "/*store*",
     "timings": [
       {
         "metric": "interactive",


### PR DESCRIPTION
See commit body. One-line glob fix — the /store budget rule now also catches /<locale>/store. No threshold relaxation; just routing the existing per-route budget to the URL it was always meant for.