### PR TITLE
feat(scripts): generalize watch-deploy.sh into a reusable helper

### DIFF
--- a/scripts/watch-deploy.sh
+++ b/scripts/watch-deploy.sh
@@ -1,34 +1,115 @@
 #!/usr/bin/env bash
-# Watch for deploy completion: poll workflow + SSM + live bundle every 90s.
-# Exits 0 when bundle contains the Partner ID literal.
+# watch-deploy.sh
+#
+# Watch a Pi deploy to completion: poll the workflow run, the deployed SHA in
+# SSM, and the live Insight Tag in the production bundle. Exits 0 once the
+# Partner ID literal appears in the bundle (the truest signal that the new
+# code is live and serving traffic). Companion to
+# `scripts/linkedin-insight-doctor.sh`.
+#
+# Defaults (override with flags or env vars):
+#   --run-id <id>      latest deploy-pi.yml run for current repo
+#   --target-sha <sha> current HEAD short SHA (12 chars)
+#   --interval <sec>   90
+#   --max-tries <n>    20 (so up to 30 min by default)
+#   --slug <slug>      shop-online
+#   --locale <locale>  el
+#   --no-color
+#
+# Exit codes:
+#   0 = bundle now contains Partner ID literal (deploy effective)
+#   1 = polling exhausted; deploy did not become effective in time
+#   2 = preconditions failed (missing tooling, network error, …)
+#
+# Requires: bash, curl, grep, gh, aws.
+
 set -uo pipefail
-RUN_ID=27816302967
-TARGET_SHA="4291d493e943"
+cd "$(dirname "$0")/.."
 
-for i in $(seq 1 20); do
-  echo "=== try $i @ $(date -u +%H:%M:%SZ) ==="
+REPO="${GH_REPO:-Themis128/cloudless.gr}"
+RUN_ID=""
+TARGET_SHA=""
+INTERVAL=90
+MAX_TRIES=20
+SLUG="shop-online"
+LOCALE="el"
+COLOR_FLAG=""
 
-  status=$(gh run view "$RUN_ID" --repo Themis128/cloudless.gr --json status --jq '.status' 2>/dev/null || echo "?")
-  concl=$(gh run view "$RUN_ID" --repo Themis128/cloudless.gr --json conclusion --jq '.conclusion' 2>/dev/null || echo "?")
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --run-id) RUN_ID="$2"; shift 2 ;;
+    --target-sha) TARGET_SHA="$2"; shift 2 ;;
+    --interval) INTERVAL="$2"; shift 2 ;;
+    --max-tries) MAX_TRIES="$2"; shift 2 ;;
+    --slug) SLUG="$2"; shift 2 ;;
+    --locale) LOCALE="$2"; shift 2 ;;
+    --no-color) COLOR_FLAG="--no-color"; shift ;;
+    -h|--help) sed -n '1,28p' "$0"; exit 0 ;;
+    *) echo "unknown arg: $1" >&2; exit 2 ;;
+  esac
+done
+
+for tool in gh aws curl; do
+  command -v "$tool" >/dev/null 2>&1 || { echo "missing tool: $tool" >&2; exit 2; }
+done
+
+# Default RUN_ID = latest deploy-pi.yml run.
+if [[ -z "$RUN_ID" ]]; then
+  RUN_ID=$(gh run list \
+    --repo "$REPO" \
+    --workflow deploy-pi.yml \
+    --limit 1 \
+    --json databaseId \
+    --jq '.[0].databaseId' 2>/dev/null || true)
+  if [[ -z "$RUN_ID" || "$RUN_ID" == "null" ]]; then
+    echo "could not resolve latest deploy-pi.yml run; pass --run-id explicitly" >&2
+    exit 2
+  fi
+fi
+
+# Default TARGET_SHA = HEAD short SHA (12 chars — matches deploy-pi.yml's SHORT_SHA).
+if [[ -z "$TARGET_SHA" ]]; then
+  TARGET_SHA=$(git rev-parse HEAD 2>/dev/null | cut -c1-12 || true)
+  if [[ -z "$TARGET_SHA" ]]; then
+    echo "could not resolve HEAD SHA; pass --target-sha explicitly" >&2
+    exit 2
+  fi
+fi
+
+echo "watching run=$RUN_ID, target-sha=$TARGET_SHA, slug=$SLUG, locale=$LOCALE"
+echo "interval=${INTERVAL}s, max-tries=$MAX_TRIES (~$((INTERVAL * MAX_TRIES / 60)) min ceiling)"
+echo
+
+for i in $(seq 1 "$MAX_TRIES"); do
+  printf "=== try %d @ %s ===\n" "$i" "$(date -u +%H:%M:%SZ)"
+
+  status=$(gh run view "$RUN_ID" --repo "$REPO" --json status --jq '.status' 2>/dev/null || echo "?")
+  concl=$(gh run view "$RUN_ID" --repo "$REPO" --json conclusion --jq '.conclusion' 2>/dev/null || echo "?")
   echo "workflow: status=$status conclusion=$concl"
 
-  pi_sha=$(aws ssm get-parameter --name /cloudless/production/pi-sha --region us-east-1 --query 'Parameter.Value' --output text 2>/dev/null || echo "?")
+  pi_sha=$(aws ssm get-parameter \
+    --name /cloudless/production/pi-sha \
+    --region us-east-1 \
+    --query 'Parameter.Value' \
+    --output text 2>/dev/null || echo "?")
   echo "pi-sha SSM: $pi_sha"
 
-  # Probe live bundle for Partner ID literal
-  out=$(bash scripts/linkedin-insight-doctor.sh --slug shop-online --locale el --no-color 2>&1)
+  out=$(bash scripts/linkedin-insight-doctor.sh --slug "$SLUG" --locale "$LOCALE" $COLOR_FLAG 2>&1)
   echo "$out" | grep -E 'Partner ID literal|HEALTHY|NOT HEALTHY' | head -3
 
   if echo "$out" | grep -q 'Partner ID literal found in bundle'; then
-    echo "=== ✓ Partner ID is in the live bundle. STOPPING ==="
+    echo "=== ✓ Partner ID is in the live bundle. Deploy is effective. ==="
     exit 0
   fi
 
-  if [ "$pi_sha" = "$TARGET_SHA" ] && [ "$status" = "completed" ]; then
-    echo "=== Deploy finished but live bundle still missing Partner ID — investigate ==="
+  if [[ "$pi_sha" == "$TARGET_SHA" && "$status" == "completed" && -z "$(echo "$out" | grep 'Partner ID literal found')" ]]; then
+    echo "=== ! Deploy finished but live bundle still missing Partner ID. ==="
+    echo "    Likely cause: Docker build cache reused stale chunks despite secret"
+    echo "    being set. Bust /opt/docker-cache on the build runner and re-deploy."
   fi
 
-  sleep 90
+  sleep "$INTERVAL"
 done
-echo "=== exhausted polls (30 min) — escalate ==="
+
+echo "=== exhausted polls (~$((INTERVAL * MAX_TRIES / 60)) min). Deploy is taking longer than expected. ==="
 exit 1


### PR DESCRIPTION
## Why

The previous deploy-watching script was a one-shot helper with hardcoded `RUN_ID=27816302967` and `TARGET_SHA=4291d493e943` for the 2026-06-19 LinkedIn Insight Tag deploy investigation. Useful that day, dead weight every other day.

## What

Generalizes `scripts/watch-deploy.sh` into a reusable polling helper that pairs with `scripts/linkedin-insight-doctor.sh`:

- **Default RUN_ID** = latest `deploy-pi.yml` run for the repo (`gh run list --workflow deploy-pi.yml --limit 1`).
- **Default TARGET_SHA** = current HEAD short SHA (12 chars, matches deploy-pi.yml's `SHORT_SHA`).
- **Flags:** `--run-id`, `--target-sha`, `--interval`, `--max-tries`, `--slug`, `--locale`, `--no-color`, `--help`.
- **Exit codes:** `0` = bundle now contains Partner ID literal (deploy effective); `1` = polling exhausted; `2` = preconditions failed.
- **Hint added** when the workflow completes but the bundle remains stale — the Docker layer cache reuse failure mode encountered during the 2026-06-19 investigation. Points at busting `/opt/docker-cache`.

## Usage

Common case:

```bash
bash scripts/watch-deploy.sh
```

Watch a specific run:

```bash
bash scripts/watch-deploy.sh --run-id 27816302967 --target-sha 4291d493e943
```

Faster polling for fast deploys:

```bash
bash scripts/watch-deploy.sh --interval 30 --max-tries 10
```

## Companion

- `scripts/linkedin-insight-doctor.sh` — the per-poll healthcheck.
- `skills/linkedin-insight-doctor/SKILL.md` — operational playbook.
- `skills/linkedin-campaigns/SKILL.md` — campaign authoring.
