### PR TITLE
feat(bedrock): migrate Claude 3.5 Haiku → Haiku 4.5 (EOL 2026-06-19)

### DIFF
--- a/.claude/skills/bedrock-chat/SKILL.md
+++ b/.claude/skills/bedrock-chat/SKILL.md
@@ -9,7 +9,7 @@ allowed-tools: mcp__cloudless-infra__aws_get_ssm_parameters, mcp__cloudless-infr
 ## Overview
 
 `/api/chat` uses **AWS Bedrock Converse API** (IAM auth, no Anthropic credits needed).
-Model: `us.anthropic.claude-3-5-haiku-20241022-v1:0` (US cross-region inference profile).
+Model: `us.anthropic.claude-haiku-4-5-20251001-v1:0` (US cross-region inference profile).
 
 **Why Bedrock?** Anthropic direct API requires prepaid credits; Bedrock is pay-per-token billed to the AWS account.
 
@@ -96,8 +96,8 @@ permissions: [
   {
     actions: ["bedrock:InvokeModel", "bedrock:Converse"],
     resources: [
-      "arn:aws:bedrock:us-east-1::foundation-model/anthropic.claude-3-5-haiku-20241022-v1:0",
-      "arn:aws:bedrock:us-east-1:278585680617:inference-profile/us.anthropic.claude-3-5-haiku-20241022-v1:0",
+      "arn:aws:bedrock:us-east-1::foundation-model/anthropic.claude-haiku-4-5-20251001-v1:0",
+      "arn:aws:bedrock:us-east-1:278585680617:inference-profile/us.anthropic.claude-haiku-4-5-20251001-v1:0",
     ],
   },
 ],
@@ -119,8 +119,8 @@ aws iam put-user-policy \
       "Effect":"Allow",
       "Action":["bedrock:InvokeModel","bedrock:Converse"],
       "Resource":[
-        "arn:aws:bedrock:us-east-1::foundation-model/anthropic.claude-3-5-haiku-20241022-v1:0",
-        "arn:aws:bedrock:us-east-1:278585680617:inference-profile/us.anthropic.claude-3-5-haiku-20241022-v1:0"
+        "arn:aws:bedrock:us-east-1::foundation-model/anthropic.claude-haiku-4-5-20251001-v1:0",
+        "arn:aws:bedrock:us-east-1:278585680617:inference-profile/us.anthropic.claude-haiku-4-5-20251001-v1:0"
       ]
     }]
   }'
@@ -196,4 +196,4 @@ cluster_run_command(node: "omv-main",
 | `MAX_TOKENS` | 600 | Max tokens per Bedrock response |
 | `MAX_TURNS` | 10 | Max message history sent to Bedrock |
 | `MAX_USER_MESSAGE` | 500 | Max chars per user message (trimmed) |
-| `BEDROCK_MODEL_ID` | `us.anthropic.claude-3-5-haiku-20241022-v1:0` | Override via `BEDROCK_MODEL_ID` env var |
+| `BEDROCK_MODEL_ID` | `us.anthropic.claude-haiku-4-5-20251001-v1:0` | Override via `BEDROCK_MODEL_ID` env var |

--- a/.claude/skills/deploy-pipeline/SKILL.md
+++ b/.claude/skills/deploy-pipeline/SKILL.md
@@ -133,8 +133,8 @@ permissions: [
   {
     actions: ["bedrock:InvokeModel", "bedrock:Converse"],
     resources: [
-      "arn:aws:bedrock:us-east-1::foundation-model/anthropic.claude-3-5-haiku-20241022-v1:0",
-      "arn:aws:bedrock:us-east-1:278585680617:inference-profile/us.anthropic.claude-3-5-haiku-20241022-v1:0",
+      "arn:aws:bedrock:us-east-1::foundation-model/anthropic.claude-haiku-4-5-20251001-v1:0",
+      "arn:aws:bedrock:us-east-1:278585680617:inference-profile/us.anthropic.claude-haiku-4-5-20251001-v1:0",
     ],
   },
 ],
@@ -154,8 +154,8 @@ aws iam put-user-policy \
       "Effect":"Allow",
       "Action":["bedrock:InvokeModel","bedrock:Converse"],
       "Resource":[
-        "arn:aws:bedrock:us-east-1::foundation-model/anthropic.claude-3-5-haiku-20241022-v1:0",
-        "arn:aws:bedrock:us-east-1:278585680617:inference-profile/us.anthropic.claude-3-5-haiku-20241022-v1:0"
+        "arn:aws:bedrock:us-east-1::foundation-model/anthropic.claude-haiku-4-5-20251001-v1:0",
+        "arn:aws:bedrock:us-east-1:278585680617:inference-profile/us.anthropic.claude-haiku-4-5-20251001-v1:0"
       ]
     }]
   }'

--- a/.claude/skills/pi-image-rollout/SKILL.md
+++ b/.claude/skills/pi-image-rollout/SKILL.md
@@ -135,8 +135,8 @@ aws iam put-user-policy \
       "Effect":"Allow",
       "Action":["bedrock:InvokeModel","bedrock:Converse"],
       "Resource":[
-        "arn:aws:bedrock:us-east-1::foundation-model/anthropic.claude-3-5-haiku-20241022-v1:0",
-        "arn:aws:bedrock:us-east-1:278585680617:inference-profile/us.anthropic.claude-3-5-haiku-20241022-v1:0"
+        "arn:aws:bedrock:us-east-1::foundation-model/anthropic.claude-haiku-4-5-20251001-v1:0",
+        "arn:aws:bedrock:us-east-1:278585680617:inference-profile/us.anthropic.claude-haiku-4-5-20251001-v1:0"
       ]
     }]
   }'

--- a/.env.example
+++ b/.env.example
@@ -100,7 +100,7 @@ NEXT_PUBLIC_SENTRY_ORG=baltzakisthemiscom
 
 # ── Anthropic (AI Assistant) ───────────────────────────────────────────────────
 ANTHROPIC_API_KEY=sk-ant-...
-ANTHROPIC_CHAT_MODEL=claude-3-5-haiku-latest
+ANTHROPIC_CHAT_MODEL=claude-haiku-4-5
 
 # ── ActiveCampaign ────────────────────────────────────────────────────────────
 ACTIVECAMPAIGN_API_URL=https://youraccountname.api-us1.com

--- a/__tests__/anthropic.test.ts
+++ b/__tests__/anthropic.test.ts
@@ -17,7 +17,7 @@ import {
 
 const CONFIGURED_CONFIG = {
   ANTHROPIC_API_KEY: "sk-ant-test-key",
-  ANTHROPIC_CHAT_MODEL: "claude-3-5-haiku-latest",
+  ANTHROPIC_CHAT_MODEL: "claude-haiku-4-5",
 };
 const TEST_API_KEY = "sk-ant-key";
 const TEST_API_SECRET = "sk-ant-secret";

--- a/__tests__/bedrock-chat.test.ts
+++ b/__tests__/bedrock-chat.test.ts
@@ -12,7 +12,7 @@ vi.mock("@aws-sdk/client-bedrock-runtime", () => ({
 }));
 
 vi.mock("@/lib/bedrock-shared", () => ({
-  BEDROCK_MODEL_ID: "anthropic.claude-3-5-haiku",
+  BEDROCK_MODEL_ID: "anthropic.claude-haiku-4-5",
   buildBedrockToolConfig: vi.fn().mockReturnValue({ tools: [] }),
   getBedrockClient: vi.fn(() => ({ send: mockBedrockSend })),
 }));

--- a/__tests__/internal-ai-generate-api.test.ts
+++ b/__tests__/internal-ai-generate-api.test.ts
@@ -20,7 +20,7 @@ vi.mock("@/lib/bedrock-shared", () => ({
   getBedrockClient: vi.fn(),
   runBedrockTurn: vi.fn(),
   joinAssistantText: (blocks: { text?: string }[]) => blocks.map((b) => b.text ?? "").join(""),
-  BEDROCK_MODEL_ID: "us.anthropic.claude-3-5-haiku-20241022-v1:0",
+  BEDROCK_MODEL_ID: "us.anthropic.claude-haiku-4-5-20251001-v1:0",
 }));
 
 import { POST } from "../src/app/api/internal/ai/generate/route";

--- a/docs/ANTHROPIC.md
+++ b/docs/ANTHROPIC.md
@@ -41,7 +41,7 @@ graph TB
 
     Widget -->|POST messages| ChatRoute
     ChatRoute --> BedrockLoop
-    BedrockLoop -->|ConverseCommand IAM auth| Bedrock["AWS Bedrock\nus.anthropic.claude-3-5-haiku"]
+    BedrockLoop -->|ConverseCommand IAM auth| Bedrock["AWS Bedrock\nus.anthropic.claude-haiku-4-5"]
     BedrockLoop --> Tools
 
     Copy & Campaign & Audience & Insights -->|callClaude + getAnthropicApiKey| Call & Key
@@ -58,7 +58,7 @@ graph TB
 
 ```bash
 ANTHROPIC_API_KEY=sk-ant-api03-...
-ANTHROPIC_CHAT_MODEL=claude-3-5-haiku-latest
+ANTHROPIC_CHAT_MODEL=claude-haiku-4-5
 ```
 
 ### Production (AWS SSM Parameter Store)
@@ -93,7 +93,7 @@ const ChatWidget = dynamic(() => import("@/components/ChatWidget"));
 | Property | Value |
 |----------|-------|
 | Backend | AWS Bedrock Converse API — IAM auth via Lambda execution role (no API key) |
-| Model | `BEDROCK_MODEL_ID` env var or `us.anthropic.claude-3-5-haiku-20241022-v1:0` |
+| Model | `BEDROCK_MODEL_ID` env var or `us.anthropic.claude-haiku-4-5-20251001-v1:0` |
 | `maxTokens` | 600 |
 | Streaming | SSE (`text/event-stream`) — final assistant text chunk-encoded after tool loop |
 | Tools | `lookup_product`, `check_calendar_availability`, `book_slot` (see below) |
@@ -245,9 +245,9 @@ Throws on API errors — callers catch and return 500.
 
 | Surface | Model | Auth |
 |---------|-------|------|
-| Public chatbot (`/api/chat`) | `BEDROCK_MODEL_ID` env var or `us.anthropic.claude-3-5-haiku-20241022-v1:0` | IAM (Lambda execution role via `sst.config.ts` permissions) |
+| Public chatbot (`/api/chat`) | `BEDROCK_MODEL_ID` env var or `us.anthropic.claude-haiku-4-5-20251001-v1:0` | IAM (Lambda execution role via `sst.config.ts` permissions) |
 | Admin AI routes | `claude-sonnet-4-6` | Anthropic API key from SSM (`ANTHROPIC_API_KEY`) |
-| `verifyAnthropicKey()` ping | `ANTHROPIC_CHAT_MODEL` (or `claude-3-5-haiku-latest`) | Anthropic API key |
+| `verifyAnthropicKey()` ping | `ANTHROPIC_CHAT_MODEL` (or `claude-haiku-4-5`) | Anthropic API key |
 
 ---
 

--- a/src/lib/anthropic.ts
+++ b/src/lib/anthropic.ts
@@ -19,7 +19,7 @@ const ANTHROPIC_API = "https://api.anthropic.com/v1/messages";
 const ANTHROPIC_VERSION = "2023-06-01";
 const VERIFY_TIMEOUT_MS = 8_000;
 const DEFAULT_MAX_TOKENS = 1_000;
-const DEFAULT_CHAT_MODEL = "claude-3-5-haiku-latest";
+const DEFAULT_CHAT_MODEL = "claude-haiku-4-5";
 
 export type AnthropicTokenStatus = "valid" | "rejected" | "not_configured" | "error";
 

--- a/src/lib/bedrock-chat.ts
+++ b/src/lib/bedrock-chat.ts
@@ -6,7 +6,7 @@
  * bedrock:InvokeModel on the foundation-model resource (granted via
  * sst.config.ts permissions).
  *
- * Model: us.anthropic.claude-3-5-haiku-20241022-v1:0 (US cross-region inference)
+ * Model: us.anthropic.claude-haiku-4-5-20251001-v1:0 (US cross-region inference)
  * Region: us-east-1 (Lambda deployment region; falls back to AWS_REGION env var)
  */
 

--- a/src/lib/bedrock-shared.ts
+++ b/src/lib/bedrock-shared.ts
@@ -16,7 +16,7 @@ import {
 } from "@aws-sdk/client-bedrock-runtime";
 
 const DEFAULT_REGION = "us-east-1";
-const DEFAULT_MODEL_ID = "us.anthropic.claude-3-5-haiku-20241022-v1:0";
+const DEFAULT_MODEL_ID = "us.anthropic.claude-haiku-4-5-20251001-v1:0";
 
 export const BEDROCK_REGION = process.env.AWS_REGION ?? DEFAULT_REGION;
 export const BEDROCK_MODEL_ID = process.env.BEDROCK_MODEL_ID ?? DEFAULT_MODEL_ID;

--- a/sst.config.ts
+++ b/sst.config.ts
@@ -331,11 +331,11 @@ export default {
           actions: ["bedrock:InvokeModel", "bedrock:Converse"],
           resources: [
             // Foundation model — all US regions (cross-region inference routes through any of these)
-            "arn:aws:bedrock:us-east-1::foundation-model/anthropic.claude-3-5-haiku-20241022-v1:0",
-            "arn:aws:bedrock:us-east-2::foundation-model/anthropic.claude-3-5-haiku-20241022-v1:0",
-            "arn:aws:bedrock:us-west-2::foundation-model/anthropic.claude-3-5-haiku-20241022-v1:0",
+            "arn:aws:bedrock:us-east-1::foundation-model/anthropic.claude-haiku-4-5-20251001-v1:0",
+            "arn:aws:bedrock:us-east-2::foundation-model/anthropic.claude-haiku-4-5-20251001-v1:0",
+            "arn:aws:bedrock:us-west-2::foundation-model/anthropic.claude-haiku-4-5-20251001-v1:0",
             // Cross-region inference profile (us.* prefix routes to any US region)
-            "arn:aws:bedrock:us-east-1:278585680617:inference-profile/us.anthropic.claude-3-5-haiku-20241022-v1:0",
+            "arn:aws:bedrock:us-east-1:278585680617:inference-profile/us.anthropic.claude-haiku-4-5-20251001-v1:0",
           ],
         },
         {


### PR DESCRIPTION
AWS Health AWS_BEDROCK_PLANNED_LIFECYCLE_EVENT — Claude 3.5 Haiku reaches end-of-life on Bedrock today (2026-06-19 07:00 UTC) for account 278585680617. Migrates all 28 references in production code, SST IAM grants, tests, and docs to claude-haiku-4-5-20251001-v1:0 (and the us.* cross-region inference profile). Sed-driven, no logic changes.