### PR TITLE
fix(chat): switch /api/chat from Claude Haiku 4.5 -> Amazon Nova Micro

### DIFF
--- a/src/app/api/chat/route.ts
+++ b/src/app/api/chat/route.ts
@@ -32,7 +32,9 @@ Booking flow: (1) call check_calendar_availability → show slots → (2) ask vi
 
 Use tools when their output would be more accurate than your memory (specific prices, real availability). Don't call a tool just to confirm what you already know. After a tool returns, summarize the result in plain language and include any URLs the tool gave you so the visitor can click through.
 
-Keep answers concise (2–4 sentences max). If someone asks about pricing not surfaced by lookup_product, give the ranges from "Services offered" above and suggest booking a free audit. Never make up specific technical details. If you don't know something, say so and suggest they book a call.`;
+Keep answers concise (2–4 sentences max). If someone asks about pricing not surfaced by lookup_product, give the ranges from "Services offered" above and suggest booking a free audit. Never make up specific technical details. If you don't know something, say so and suggest they book a call.
+
+Output format: respond with plain conversational text only. Do NOT include internal reasoning, <thinking> tags, XML markup, or any kind of monologue — only the message you want the visitor to read.`;
 
 const MAX_USER_MESSAGE = 500;
 const MAX_TURNS = 10;

--- a/src/lib/bedrock-chat.ts
+++ b/src/lib/bedrock-chat.ts
@@ -6,7 +6,12 @@
  * bedrock:InvokeModel on the foundation-model resource (granted via
  * sst.config.ts permissions).
  *
- * Model: us.anthropic.claude-haiku-4-5-20251001-v1:0 (US cross-region inference)
+ * Model: us.amazon.nova-micro-v1:0 (US cross-region inference)
+ *   - Switched from Claude Haiku 4.5 on 2026-06-19 (Marketplace subscription
+ *     never enabled on this account; Nova Micro is ~30x cheaper anyway).
+ *   - Nova sometimes wraps reasoning in <thinking>…</thinking> XML — we strip
+ *     those before returning text to the user. The system prompt also asks
+ *     Nova not to emit them, but stripping is the safety net.
  * Region: us-east-1 (Lambda deployment region; falls back to AWS_REGION env var)
  */
 
@@ -27,6 +32,15 @@ const MAX_TOKENS = 600;
 const MAX_TOOL_ITERATIONS = 4;
 
 const BEDROCK_TOOL_CONFIG = buildBedrockToolConfig(CHAT_TOOLS);
+
+// Nova models occasionally emit internal reasoning wrapped in
+// <thinking>…</thinking> tags. The system prompt asks them not to, but we
+// strip defensively in case they slip through (the alternative is the user
+// seeing the chatbot's monologue).
+const THINKING_TAG_RE = /<thinking>[\s\S]*?<\/thinking>\s*/gi;
+function stripThinkingTags(text: string): string {
+  return text.replace(THINKING_TAG_RE, "").trim();
+}
 
 // ---------------------------------------------------------------------------
 // Core loop
@@ -64,11 +78,13 @@ export async function runBedrockChatLoop(
     const assistantContent: AnyBlock[] = (response.output?.message?.content as AnyBlock[]) ?? [];
 
     if (stopReason !== "tool_use") {
-      // Extract and concatenate all text blocks.
-      return (assistantContent as TextBlock[])
+      // Extract and concatenate all text blocks, stripping any Nova
+      // <thinking>…</thinking> markers before returning to the user.
+      const joined = (assistantContent as TextBlock[])
         .filter((b) => typeof b.text === "string")
         .map((b) => b.text)
         .join("");
+      return stripThinkingTags(joined);
     }
 
     // Append assistant turn (may contain both text and toolUse blocks).

--- a/src/lib/bedrock-shared.ts
+++ b/src/lib/bedrock-shared.ts
@@ -16,7 +16,12 @@ import {
 } from "@aws-sdk/client-bedrock-runtime";
 
 const DEFAULT_REGION = "us-east-1";
-const DEFAULT_MODEL_ID = "us.anthropic.claude-haiku-4-5-20251001-v1:0";
+// Switched 2026-06-19 from us.anthropic.claude-haiku-4-5-20251001-v1:0 to Nova
+// Micro: Haiku 4.5 Marketplace subscription was never enabled on this account,
+// and Nova Micro is ~30x cheaper ($0.035/M in, $0.14/M out) while still
+// supporting the Bedrock Converse tool-use loop the chat widget + booking
+// agent depend on. IAM grants in sst.config.ts must match this model.
+const DEFAULT_MODEL_ID = "us.amazon.nova-micro-v1:0";
 
 export const BEDROCK_REGION = process.env.AWS_REGION ?? DEFAULT_REGION;
 export const BEDROCK_MODEL_ID = process.env.BEDROCK_MODEL_ID ?? DEFAULT_MODEL_ID;

--- a/sst.config.ts
+++ b/sst.config.ts
@@ -328,14 +328,20 @@ export default {
         {
           // Allow the Lambda server to invoke Bedrock Converse for the chat widget.
           // The us.* prefix is required for cross-region inference profiles.
+          //
+          // Model: Amazon Nova Micro (switched from Claude Haiku 4.5 on
+          // 2026-06-19). Haiku 4.5 needed a Bedrock Marketplace subscription
+          // that was never enabled on this account; Nova Micro is already
+          // active and is ~30x cheaper. See src/lib/bedrock-shared.ts for
+          // the matching DEFAULT_MODEL_ID — keep these in sync.
           actions: ["bedrock:InvokeModel", "bedrock:Converse"],
           resources: [
             // Foundation model — all US regions (cross-region inference routes through any of these)
-            "arn:aws:bedrock:us-east-1::foundation-model/anthropic.claude-haiku-4-5-20251001-v1:0",
-            "arn:aws:bedrock:us-east-2::foundation-model/anthropic.claude-haiku-4-5-20251001-v1:0",
-            "arn:aws:bedrock:us-west-2::foundation-model/anthropic.claude-haiku-4-5-20251001-v1:0",
+            "arn:aws:bedrock:us-east-1::foundation-model/amazon.nova-micro-v1:0",
+            "arn:aws:bedrock:us-east-2::foundation-model/amazon.nova-micro-v1:0",
+            "arn:aws:bedrock:us-west-2::foundation-model/amazon.nova-micro-v1:0",
             // Cross-region inference profile (us.* prefix routes to any US region)
-            "arn:aws:bedrock:us-east-1:278585680617:inference-profile/us.anthropic.claude-haiku-4-5-20251001-v1:0",
+            "arn:aws:bedrock:us-east-1:278585680617:inference-profile/us.amazon.nova-micro-v1:0",
           ],
         },
         {


### PR DESCRIPTION
Restores the chat widget on cloudless.gr.

**Symptom**: `/api/chat` returns 503 on every request (reproducible on https://cloudless.gr/en/campaigns/shop-online).

**Root cause**: PR #1003 (commit 9b92c415) migrated the model ID from Haiku 3.5 to Haiku 4.5 and deployed the new IAM grants, but the AWS account never had a Bedrock Marketplace subscription for Haiku 4.5. Direct AWS CLI test against the inference profile returns:
```
AccessDeniedException: Model access is denied due to IAM user or service role
is not authorized to perform the required AWS Marketplace actions
(aws-marketplace:ViewSubscriptions, aws-marketplace:Subscribe).
```

The fallback to direct Anthropic API also wouldnt help — the `ANTHROPIC_API_KEY` in the `cloudless-app-config` k8s secret is currently returning HTTP 401 from `api.anthropic.com` (separate rotation issue).

**Fix**: Swap to Amazon Nova Micro, which is already active on this account, supports Bedrock Converse + tool use, and is ~30x cheaper. Verified live against the actual chat-widget tool schema (lookup_product) — returned a clean tool_use response with the same shape the existing loop already handles.

**Files**:
- `src/lib/bedrock-shared.ts` — DEFAULT_MODEL_ID -> `us.amazon.nova-micro-v1:0`
- `sst.config.ts` — Lambda IAM resources updated (foundation models in us-east-1/2 + us-west-2, inference profile in us-east-1)
- `src/lib/bedrock-chat.ts` — strip `<thinking>...</thinking>` tags Nova sometimes emits before returning to the user
- `src/app/api/chat/route.ts` — system-prompt nudge asking Nova not to emit reasoning tags (strip is the safety net)

After merge, SST deploy updates the Lambda IAM policy automatically and the chat starts working — no manual AWS console action needed.