### PR TITLE
fix(slack): audit cleanup — SlackClient, lazy ops-users, dispatchWorkflow

### DIFF
--- a/__tests__/slack-ops-users.test.ts
+++ b/__tests__/slack-ops-users.test.ts
@@ -1,0 +1,107 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+
+const { getConfigMock } = vi.hoisted(() => ({
+  getConfigMock: vi.fn(),
+}));
+
+vi.mock("@/lib/ssm-config", () => ({
+  getConfig: () => getConfigMock(),
+}));
+
+import {
+  getSlackOpsUsers,
+  getSlackOpsUsersSync,
+  isSlackOpsUser,
+  resetSlackOpsUsersCache,
+} from "@/lib/slack-ops-users";
+
+const ENV_KEY = "SLACK_OPS_USERS";
+
+describe("slack-ops-users", () => {
+  let origEnv: string | undefined;
+
+  beforeEach(() => {
+    origEnv = process.env[ENV_KEY];
+    delete process.env[ENV_KEY];
+    getConfigMock.mockReset();
+    resetSlackOpsUsersCache();
+  });
+
+  afterEach(() => {
+    if (origEnv === undefined) delete process.env[ENV_KEY];
+    else process.env[ENV_KEY] = origEnv;
+  });
+
+  describe("getSlackOpsUsersSync", () => {
+    it("returns [] when env var is unset", () => {
+      expect(getSlackOpsUsersSync()).toEqual([]);
+    });
+
+    it("parses comma-separated env var", () => {
+      process.env[ENV_KEY] = "U01ABC,U02DEF , U03GHI";
+      expect(getSlackOpsUsersSync()).toEqual(["U01ABC", "U02DEF", "U03GHI"]);
+    });
+
+    it("filters empty entries from a trailing comma", () => {
+      process.env[ENV_KEY] = "U01ABC,,U02DEF,";
+      expect(getSlackOpsUsersSync()).toEqual(["U01ABC", "U02DEF"]);
+    });
+  });
+
+  describe("getSlackOpsUsers (async)", () => {
+    it("prefers env over SSM when env is set", async () => {
+      process.env[ENV_KEY] = "U01ENV";
+      getConfigMock.mockResolvedValue({ SLACK_OPS_USERS: "U99SSM" });
+      const list = await getSlackOpsUsers();
+      expect(list).toEqual(["U01ENV"]);
+      // SSM not consulted because env was already populated
+      expect(getConfigMock).not.toHaveBeenCalled();
+    });
+
+    it("falls back to SSM when env is unset", async () => {
+      getConfigMock.mockResolvedValue({ SLACK_OPS_USERS: "U01SSM,U02SSM" });
+      const list = await getSlackOpsUsers();
+      expect(list).toEqual(["U01SSM", "U02SSM"]);
+      expect(getConfigMock).toHaveBeenCalledOnce();
+    });
+
+    it("returns [] when neither env nor SSM is set", async () => {
+      getConfigMock.mockResolvedValue({});
+      const list = await getSlackOpsUsers();
+      expect(list).toEqual([]);
+    });
+
+    it("returns [] and warns when SSM lookup throws", async () => {
+      const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+      getConfigMock.mockRejectedValue(new Error("ssm down"));
+      const list = await getSlackOpsUsers();
+      expect(list).toEqual([]);
+      expect(warn).toHaveBeenCalledOnce();
+      warn.mockRestore();
+    });
+
+    it("caches results across calls (env path)", async () => {
+      process.env[ENV_KEY] = "U01CACHED";
+      const a = await getSlackOpsUsers();
+      const b = await getSlackOpsUsers();
+      expect(a).toBe(b);
+    });
+  });
+
+  describe("isSlackOpsUser", () => {
+    it("returns true for everyone when list is empty (open semantics)", async () => {
+      getConfigMock.mockResolvedValue({});
+      expect(await isSlackOpsUser("U_RANDOM")).toBe(true);
+    });
+
+    it("returns true when user is in the list", async () => {
+      process.env[ENV_KEY] = "U01ABC,U02DEF";
+      expect(await isSlackOpsUser("U02DEF")).toBe(true);
+    });
+
+    it("returns false when user is not in the list", async () => {
+      process.env[ENV_KEY] = "U01ABC,U02DEF";
+      expect(await isSlackOpsUser("U99XYZ")).toBe(false);
+    });
+  });
+});

--- a/slack-app.manifest.json
+++ b/slack-app.manifest.json
@@ -47,8 +47,8 @@
       {
         "command": "/cloudless-analytics",
         "url": "https://cloudless.gr/api/slack/commands",
-        "description": "7-day and 30-day revenue & order summary",
-        "usage_hint": "(no arguments)",
+        "description": "Stripe revenue summary (default) or LinkedIn ad metrics (`ads <slug>`)",
+        "usage_hint": "[ads [<slug>|list|help]]",
         "should_escape": false
       },
       {

--- a/src/app/api/slack/commands/route.ts
+++ b/src/app/api/slack/commands/route.ts
@@ -50,16 +50,7 @@ import {
   buildCacheFlushBlocks,
 } from "@/lib/slack-commands-extra";
 
-/**
- * Slack user-ID allowlist for slash-command-driven workflow dispatch.
- * Mirrors SLACK_OPS_USERS in interactions/route.ts. Empty/unset = anyone
- * in the workspace can use /cloudless-draft. Set to a single user ID to
- * lock it down to one operator.
- */
-const SLACK_OPS_USERS: string[] = (process.env.SLACK_OPS_USERS ?? "")
-  .split(",")
-  .map((s) => s.trim())
-  .filter(Boolean);
+import { getSlackOpsUsers } from "@/lib/slack-ops-users";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -83,8 +74,9 @@ export async function POST(request: Request): Promise<Response> {
   const verified = await verifySlackRequest(request);
   if (!verified.ok) return unauthorizedSlack(verified.reason, request);
 
-  const rateLimitKey = request.headers.get("x-forwarded-for") ?? "unknown";
-  if (!checkSlackRateLimit(rateLimitKey)) {
+  // Pre-parse IP-based rate limit — coarse guard against scanner storms.
+  const ipKey = `ip:${request.headers.get("x-forwarded-for") ?? "unknown"}`;
+  if (!checkSlackRateLimit(ipKey)) {
     return Response.json({ error: "Too many requests" }, { status: 429 });
   }
 
@@ -98,6 +90,12 @@ export async function POST(request: Request): Promise<Response> {
     response_url: params.get("response_url") ?? "",
     trigger_id: params.get("trigger_id") ?? "",
   };
+
+  // Post-parse per-user rate limit — fairness on top of IP aggregation, since
+  // every Slack request hits us from the same egress pool.
+  if (!checkSlackRateLimit(`user:${payload.user_id || "anon"}`)) {
+    return Response.json({ error: "Too many requests" }, { status: 429 });
+  }
 
   switch (payload.command) {
     case "/cloudless-status":
@@ -1112,7 +1110,8 @@ async function handleDraftRerun(payload: SlashCommandPayload): Promise<Response>
     });
   }
 
-  if (SLACK_OPS_USERS.length > 0 && !SLACK_OPS_USERS.includes(payload.user_id)) {
+  const opsUsers = await getSlackOpsUsers();
+  if (opsUsers.length > 0 && !opsUsers.includes(payload.user_id)) {
     return slackResponse({
       response_type: "ephemeral",
       text:
@@ -1227,7 +1226,8 @@ async function handleNewsletter(payload: SlashCommandPayload): Promise<Response>
       });
     }
 
-    if (SLACK_OPS_USERS.length > 0 && !SLACK_OPS_USERS.includes(payload.user_id)) {
+    const unpubOpsUsers = await getSlackOpsUsers();
+    if (unpubOpsUsers.length > 0 && !unpubOpsUsers.includes(payload.user_id)) {
       return slackResponse({
         response_type: "ephemeral",
         text: ":no_entry: You're not on the ops allowlist. Ask the admin to add your user ID to `SLACK_OPS_USERS`.",
@@ -1283,7 +1283,8 @@ async function handleNewsletter(payload: SlashCommandPayload): Promise<Response>
       });
     }
 
-    if (SLACK_OPS_USERS.length > 0 && !SLACK_OPS_USERS.includes(payload.user_id)) {
+    const sendOpsUsers = await getSlackOpsUsers();
+    if (sendOpsUsers.length > 0 && !sendOpsUsers.includes(payload.user_id)) {
       return slackResponse({
         response_type: "ephemeral",
         text:

--- a/src/app/api/slack/events/route.ts
+++ b/src/app/api/slack/events/route.ts
@@ -87,9 +87,9 @@ export async function POST(request: Request): Promise<Response> {
   const verified = await verifySlackRequest(request);
   if (!verified.ok) return unauthorizedSlack(verified.reason, request);
 
-  // Rate-limit by team (extracted after parse) — pre-parse check uses IP placeholder
-  const rateLimitKey = request.headers.get("x-forwarded-for") ?? "unknown";
-  if (!checkSlackRateLimit(rateLimitKey)) {
+  // Pre-parse IP-based rate limit — coarse guard before we touch the body.
+  const ipKey = `ip:${request.headers.get("x-forwarded-for") ?? "unknown"}`;
+  if (!checkSlackRateLimit(ipKey)) {
     return Response.json({ error: "Too many requests" }, { status: 429 });
   }
 
@@ -106,6 +106,12 @@ export async function POST(request: Request): Promise<Response> {
   }
 
   if (payload.type === "event_callback") {
+    // Post-parse per-team rate limit — Slack egress IPs are workspace-shared,
+    // so the IP key alone over-aggregates. Keying by team_id keeps a noisy
+    // team from starving every other workspace using the same egress pool.
+    if (!checkSlackRateLimit(`team:${payload.team_id || "anon"}`)) {
+      return Response.json({ error: "Too many requests" }, { status: 429 });
+    }
     // Deduplicate — Slack may retry the same event up to 3 times.
     if (isDuplicate(payload.event_id)) {
       return Response.json({ ok: true });

--- a/src/app/api/slack/interactions/route.ts
+++ b/src/app/api/slack/interactions/route.ts
@@ -16,19 +16,9 @@
 import { verifySlackRequest, unauthorizedSlack } from "@/lib/slack-verify";
 import { checkSlackRateLimit } from "@/lib/slack-rate-limit";
 import { listRecentCheckoutSessions, formatPrice } from "@/lib/stripe";
-import { getSlackConfigAsync } from "@/lib/integrations";
+import { SlackClient } from "@/lib/slack-notify";
 import { dispatchWorkflow } from "@/lib/github-dispatch";
-
-/**
- * Comma-separated list of Slack user IDs allowed to trigger workflow
- * dispatch from interaction buttons. Empty/unset = anyone in the workspace
- * who can see the button. Set to a single user ID (e.g. "U01ABCDEF") to
- * lock workflow re-runs down to one operator.
- */
-const SLACK_OPS_USERS: string[] = (process.env.SLACK_OPS_USERS ?? "")
-  .split(",")
-  .map((s) => s.trim())
-  .filter(Boolean);
+import { getSlackOpsUsers } from "@/lib/slack-ops-users";
 
 /**
  * Action IDs registered in this route that map to a workflow_dispatch
@@ -79,8 +69,10 @@ export async function POST(request: Request): Promise<Response> {
   const verified = await verifySlackRequest(request);
   if (!verified.ok) return unauthorizedSlack(verified.reason, request);
 
-  const rateLimitKey = request.headers.get("x-forwarded-for") ?? "unknown";
-  if (!checkSlackRateLimit(rateLimitKey)) {
+  // Pre-parse IP-based rate limit — coarse guard against scanner storms
+  // before we spend cycles parsing the form body.
+  const ipKey = `ip:${request.headers.get("x-forwarded-for") ?? "unknown"}`;
+  if (!checkSlackRateLimit(ipKey)) {
     return Response.json({ error: "Too many requests" }, { status: 429 });
   }
 
@@ -96,6 +88,13 @@ export async function POST(request: Request): Promise<Response> {
     payload = JSON.parse(rawPayload) as SlackInteractionPayload;
   } catch {
     return Response.json({ error: "Invalid payload JSON" }, { status: 400 });
+  }
+
+  // Post-parse per-user rate limit — fairness vs. IP-aggregated traffic.
+  // Slack egress IPs are shared across the whole workspace; without this
+  // a single noisy user can exhaust the budget for everyone.
+  if (!checkSlackRateLimit(`user:${payload.user?.id ?? "anon"}`)) {
+    return Response.json({ error: "Too many requests" }, { status: 429 });
   }
 
   switch (payload.type) {
@@ -202,9 +201,6 @@ function priorityEmoji(priority: string): string {
 }
 
 async function postTicketAsync(payload: SlackInteractionPayload): Promise<void> {
-  const { SLACK_BOT_TOKEN: token } = await getSlackConfigAsync();
-  if (!token) return;
-
   const values = payload.view?.state.values ?? {};
   const email = slackEscape(values.ticket_email?.ticket_email_input?.value ?? "");
   const issueType =
@@ -215,55 +211,48 @@ async function postTicketAsync(payload: SlackInteractionPayload): Promise<void> 
   const emoji = priorityEmoji(priority);
   const userId = payload.user.id;
 
-  await fetch("https://slack.com/api/chat.postMessage", {
-    method: "POST",
-    headers: {
-      "Content-Type": "application/json",
-      Authorization: `Bearer ${token}`,
-    },
-    body: JSON.stringify({
-      channel: "#contacts",
-      blocks: [
-        {
-          type: "header",
-          text: {
-            type: "plain_text",
-            text: `${emoji} New Support Ticket`,
-            emoji: true,
+  // Use SlackClient so the post inherits retry/backoff, rate-limit honoring,
+  // webhook fallback, and unfurl suppression — the raw chat.postMessage call
+  // this replaces had none of those.
+  const client = new SlackClient({ channel: "#contacts" });
+  await client.post({
+    text: `New support ticket: ${email} (${priority})`,
+    blocks: [
+      {
+        type: "header",
+        text: {
+          type: "plain_text",
+          text: `${emoji} New Support Ticket`,
+          emoji: true,
+        },
+      },
+      {
+        type: "section",
+        fields: [
+          { type: "mrkdwn", text: `*Email*\n${email}` },
+          { type: "mrkdwn", text: `*Issue Type*\n${issueType}` },
+          { type: "mrkdwn", text: `*Priority*\n${emoji} ${priority}` },
+          { type: "mrkdwn", text: `*Submitted by*\n<@${userId}>` },
+        ],
+      },
+      {
+        type: "section",
+        text: { type: "mrkdwn", text: `*Description*\n${description}` },
+      },
+      {
+        type: "context",
+        elements: [
+          {
+            type: "mrkdwn",
+            text: `Ticket submitted by <@${userId}> via Slack`,
           },
-        },
-        {
-          type: "section",
-          fields: [
-            { type: "mrkdwn", text: `*Email*\n${email}` },
-            { type: "mrkdwn", text: `*Issue Type*\n${issueType}` },
-            { type: "mrkdwn", text: `*Priority*\n${emoji} ${priority}` },
-            { type: "mrkdwn", text: `*Submitted by*\n<@${userId}>` },
-          ],
-        },
-        {
-          type: "section",
-          text: { type: "mrkdwn", text: `*Description*\n${description}` },
-        },
-        {
-          type: "context",
-          elements: [
-            {
-              type: "mrkdwn",
-              text: `Ticket submitted by <@${userId}> via Slack`,
-            },
-          ],
-        },
-      ],
-    }),
-    signal: AbortSignal.timeout(5_000),
+        ],
+      },
+    ],
   });
 }
 
 async function postDeployAsync(payload: SlackInteractionPayload): Promise<void> {
-  const { SLACK_BOT_TOKEN: token } = await getSlackConfigAsync();
-  if (!token) return;
-
   const values = payload.view?.state.values ?? {};
   const releaseNotes = values.deploy_notes?.deploy_notes_input?.value ?? null;
 
@@ -278,94 +267,74 @@ async function postDeployAsync(payload: SlackInteractionPayload): Promise<void> 
   }
   const userId = meta.user_id ?? payload.user.id;
 
-  // 1. Post "Deploy Started" to #deployments
-  await fetch("https://slack.com/api/chat.postMessage", {
-    method: "POST",
-    headers: {
-      "Content-Type": "application/json",
-      Authorization: `Bearer ${token}`,
-    },
-    body: JSON.stringify({
-      channel: "#deployments",
-      blocks: [
-        {
-          type: "header",
-          text: {
-            type: "plain_text",
-            text: ":rocket: Deploy Started",
-            emoji: true,
-          },
-        },
-        ...(releaseNotes
-          ? [
-              {
-                type: "section",
-                text: {
-                  type: "mrkdwn",
-                  text: `*Release Notes*\n${slackEscape(releaseNotes)}`,
-                },
-              },
-            ]
-          : []),
-        {
-          type: "context",
-          elements: [
-            {
-              type: "mrkdwn",
-              text: `Triggered by <@${userId}>`,
-            },
-          ],
-        },
-      ],
-    }),
-    signal: AbortSignal.timeout(5_000),
-  });
-
-  // 2. Trigger GitHub Actions workflow dispatch
-  const githubToken = process.env.GITHUB_TOKEN;
-  if (!githubToken) {
-    await fetch("https://slack.com/api/chat.postMessage", {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-        Authorization: `Bearer ${token}`,
-      },
-      body: JSON.stringify({
-        channel: "#deployments",
-        text: ":warning: GITHUB_TOKEN is not configured — workflow dispatch skipped.",
-      }),
-      signal: AbortSignal.timeout(5_000),
-    });
+  // Optional ops allowlist gates this destructive button — same semantics as
+  // workflow re-runs and newsletter sends. Empty list = open to workspace.
+  const opsUsers = await getSlackOpsUsers();
+  if (opsUsers.length > 0 && !opsUsers.includes(userId)) {
+    if (payload.response_url) {
+      await fetch(payload.response_url, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          response_type: "ephemeral",
+          text:
+            ":no_entry: You're not on the ops allowlist for production deploys. " +
+            "Ask the admin to add your Slack user ID to `SLACK_OPS_USERS`.",
+        }),
+        signal: AbortSignal.timeout(5_000),
+      }).catch((err) => console.error("[Slack Interactions] deploy denial post failed:", err));
+    }
     return;
   }
 
-  const dispatchRes = await fetch(
-    "https://api.github.com/repos/Themis128/cloudless.gr/actions/workflows/build-pi-image.yml/dispatches",
-    {
-      method: "POST",
-      headers: {
-        Accept: "application/vnd.github+json",
-        Authorization: `Bearer ${githubToken}`,
-        "X-GitHub-Api-Version": "2022-11-28",
-        "Content-Type": "application/json",
-      },
-      body: JSON.stringify({ ref: "main" }),
-      signal: AbortSignal.timeout(10_000),
-    }
-  );
+  const deployments = new SlackClient({ channel: "#deployments" });
 
-  if (!dispatchRes.ok) {
-    await fetch("https://slack.com/api/chat.postMessage", {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-        Authorization: `Bearer ${token}`,
+  // 1. Post "Deploy Started" to #deployments
+  await deployments.post({
+    text: `Deploy started by <@${userId}>`,
+    blocks: [
+      {
+        type: "header",
+        text: {
+          type: "plain_text",
+          text: ":rocket: Deploy Started",
+          emoji: true,
+        },
       },
-      body: JSON.stringify({
-        channel: "#deployments",
-        text: `:x: Deploy workflow dispatch failed (${dispatchRes.status}). Check GitHub Actions.`,
-      }),
-      signal: AbortSignal.timeout(5_000),
+      ...(releaseNotes
+        ? [
+            {
+              type: "section",
+              text: {
+                type: "mrkdwn",
+                text: `*Release Notes*\n${slackEscape(releaseNotes)}`,
+              },
+            },
+          ]
+        : []),
+      {
+        type: "context",
+        elements: [
+          {
+            type: "mrkdwn",
+            text: `Triggered by <@${userId}>`,
+          },
+        ],
+      },
+    ],
+  });
+
+  // 2. Trigger GitHub Actions workflow dispatch via the shared helper that
+  //    resolves the token from SSM (process.env.GITHUB_TOKEN is unavailable
+  //    in the deployed Lambda). Workflow: deploy-pi.yml — the active main
+  //    deploy pipeline per CLAUDE.md. The previous build-pi-image.yml is
+  //    racy (immutable-tag collision) and is not what the operator wants
+  //    when they press "Deploy" in Slack.
+  const result = await dispatchWorkflow("deploy-pi.yml", "main");
+
+  if (!result.ok) {
+    await deployments.post({
+      text: `:x: Deploy workflow dispatch failed (HTTP ${result.status}). Check GitHub Actions.`,
     });
   }
 }
@@ -438,7 +407,11 @@ async function rerunWorkflowAsync(
   actionId: string
 ): Promise<void> {
   // Optional allowlist — when set, only listed Slack user IDs can dispatch.
-  if (SLACK_OPS_USERS.length > 0 && !SLACK_OPS_USERS.includes(userId)) {
+  // Lazy-loaded from env then SSM so a runtime change to SLACK_OPS_USERS in
+  // SSM takes effect without a redeploy (in Lambda, env vars are frozen at
+  // cold start).
+  const opsUsers = await getSlackOpsUsers();
+  if (opsUsers.length > 0 && !opsUsers.includes(userId)) {
     await fetch(responseUrl, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
@@ -448,7 +421,7 @@ async function rerunWorkflowAsync(
         text:
           ":no_entry: You're not on the ops allowlist for workflow dispatch. " +
           "Ask <@" +
-          (SLACK_OPS_USERS[0] ?? "the admin") +
+          (opsUsers[0] ?? "the admin") +
           "> to add your Slack user ID to `SLACK_OPS_USERS`.",
       }),
       signal: AbortSignal.timeout(5_000),

--- a/src/lib/slack-ops-users.ts
+++ b/src/lib/slack-ops-users.ts
@@ -1,0 +1,75 @@
+/**
+ * Slack ops-user allowlist resolver.
+ *
+ * The list of Slack user IDs allowed to trigger destructive actions
+ * (workflow re-runs, newsletter sends, deploys) is read at request time —
+ * not at module load. In Lambda, environment variables are baked at cold
+ * start, so a fresh value in SSM only takes effect through this resolver.
+ *
+ * Resolution order:
+ *   1. `process.env.SLACK_OPS_USERS` (when set + non-empty)
+ *   2. `SSM SLACK_OPS_USERS` parameter
+ *   3. Empty list → "anyone in the workspace" semantics
+ *
+ * Format: comma-separated Slack user IDs, e.g. "U01ABCDEF,U02GHIJKL".
+ *
+ * Cached for the lifetime of the Lambda container — the list rotates rarely
+ * (admin churn is annual at most), and an immediate refresh is unnecessary.
+ */
+
+let cached: { value: string[]; at: number } | null = null;
+const TTL_MS = 5 * 60 * 1_000; // 5 minutes — long enough to absorb a burst,
+// short enough to pick up an SSM update without a redeploy.
+
+function parse(raw: string | undefined): string[] {
+  if (!raw) return [];
+  return raw
+    .split(",")
+    .map((s) => s.trim())
+    .filter(Boolean);
+}
+
+export async function getSlackOpsUsers(): Promise<string[]> {
+  if (cached && Date.now() - cached.at < TTL_MS) return cached.value;
+
+  const envList = parse(process.env.SLACK_OPS_USERS);
+  if (envList.length > 0) {
+    cached = { value: envList, at: Date.now() };
+    return envList;
+  }
+
+  // SSM fallback — keeps the Lambda working when the operator forgot to set
+  // SLACK_OPS_USERS as an env var but added it to SSM the normal way.
+  try {
+    const { getConfig } = await import("@/lib/ssm-config");
+    const cfg = (await getConfig()) as unknown as Record<string, string>;
+    const ssmList = parse(cfg.SLACK_OPS_USERS);
+    cached = { value: ssmList, at: Date.now() };
+    return ssmList;
+  } catch (err) {
+    console.warn("[slack-ops-users] SSM lookup failed:", err);
+    cached = { value: [], at: Date.now() };
+    return [];
+  }
+}
+
+/**
+ * Sync version for code paths that can't await (e.g. synchronous Slack
+ * command handlers that already block on env vars). Returns env-only and
+ * does NOT consult SSM. Prefer the async variant when possible.
+ */
+export function getSlackOpsUsersSync(): string[] {
+  return parse(process.env.SLACK_OPS_USERS);
+}
+
+/** Test hook — reset the cache so the next call re-reads env + SSM. */
+export function resetSlackOpsUsersCache(): void {
+  cached = null;
+}
+
+/** Pure helper for handlers that already have a userId in hand. */
+export async function isSlackOpsUser(userId: string): Promise<boolean> {
+  const list = await getSlackOpsUsers();
+  if (list.length === 0) return true; // empty = open
+  return list.includes(userId);
+}


### PR DESCRIPTION
Audit-driven cleanup of the Slack integration.

## What changed

**interactions/route.ts**
- Replace raw chat.postMessage calls in postTicketAsync/postDeployAsync with SlackClient. Preserves retry/backoff, rate-limit honoring, webhook fallback, unfurl suppression.
- Replace process.env.GITHUB_TOKEN + direct fetch with dispatchWorkflow() so the token is SSM-resolved in Lambda.
- Switch the dispatched workflow from build-pi-image.yml (racy, immutable-tag collision) to deploy-pi.yml (the active main pipeline per CLAUDE.md).
- Add ops-allowlist gate on the deploy button.

**commands/route.ts**
- Replace module-load SLACK_OPS_USERS parse with getSlackOpsUsers() helper — env-first, SSM fallback, cached 5 min.

**events + commands + interactions**
- Two-stage rate limit: pre-parse IP key + post-parse team_id (events) / user_id (commands+interactions). Stops a single noisy actor from starving the budget for everyone sharing Slack egress IPs.

**slack-app.manifest.json**
- /cloudless-analytics description tightened to match the actual handler (Stripe revenue + LinkedIn ad metrics, not 7/30-day).

**New**
- src/lib/slack-ops-users.ts — env+SSM lazy resolver with 5-min cache.
- __tests__/slack-ops-users.test.ts — 11 tests.

## Verified
- pnpm typecheck: clean
- 81 unit tests across slack-notify, slack-ops-users, ad-analytics, contact-campaign-pipeline: all pass.