### PR TITLE
feat: audit-driven improvements — X-Ray, DeferredRender, audit-routine skill

### DIFF
--- a/skills/audit-routine/SKILL.md
+++ b/skills/audit-routine/SKILL.md
@@ -1,0 +1,114 @@
+---
+name: audit-routine
+description: |
+  Run the full cloudless.gr stack-health audit and publish a one-page
+  report. Use when the user asks for a stack audit, a "health check",
+  a weekly status, or wants to see what's drifted since the last
+  baseline. Pairs with the Monday CI health routine
+  (`docs/ci-health-routine.md`) — that routine runs `gh run` checks
+  only; this skill runs the full audit surface and is what you reach
+  for when you want code + infra + perf in one place.
+
+  Trigger phrases: "audit the stack", "health check", "weekly status",
+  "what's drifted", "is the stack healthy", "run the audit".
+---
+
+# cloudless.gr stack audit routine
+
+A single, repeatable pass over every audit surface in the repo. The
+output is a markdown table the operator can scan in 30 seconds.
+
+## What the audit covers
+
+| Surface | Tool | Failure mode |
+|---|---|---|
+| Type safety | `pnpm typecheck` | `tsc` errors → broken build |
+| Lint hygiene | `pnpm lint` | ESLint errors → CI fail; warnings → drift |
+| Dependency vulns | `pnpm audit` | known advisories from the npm DB |
+| Outdated deps | `pnpm outdated` | major+minor lag, deprecated packages |
+| Lambda env drift | `bash scripts/lambda-env-audit.sh` | required vars missing or stale |
+| Live `/` round-trip | `curl -w '%{time_total}'` | regression in TTFB |
+| Live `/api/health` | same + version field cross-check | deploy version vs current `main` |
+| Live `/sitemap.xml` | same + 1.75 s threshold | ISR cache not engaging |
+| Live `/robots.txt` | same | upstream CDN broken |
+| Security headers | `curl -sI \| grep` | missing HSTS / CSP / COOP etc. |
+| Cluster k3s state | `pnpm cluster:doctor` (from cowork/CI only — kubectl is not in WSL) | pod evictions, OOM, image churn |
+| Unit tests | `pnpm test:ci --reporter=dot` | regression in covered paths |
+
+## Running
+
+The pure-code surface (typecheck, lint, audit, outdated, tests, env
+audit, live curls, headers) runs from any environment with
+`pnpm install --frozen-lockfile` complete. Suggested ordering:
+
+```bash
+pnpm typecheck
+pnpm lint
+pnpm audit --audit-level=moderate
+pnpm outdated
+bash scripts/lambda-env-audit.sh
+
+# Live surface — measure in 5 sequential warm hits to filter cold-start
+for i in 1 2 3 4 5; do
+  curl -s -o /dev/null -w '%{url_effective} %{time_total}s\n' \
+    https://cloudless.gr/ \
+    https://cloudless.gr/api/health \
+    https://cloudless.gr/sitemap.xml \
+    https://cloudless.gr/robots.txt
+done
+
+# Security headers smoke
+curl -sI https://cloudless.gr/ | \
+  grep -iE 'hsts|content-security|x-content-type-options|x-frame-options|cross-origin|permissions-policy'
+```
+
+The k3s surface needs the cowork-infra MCP (`cluster_run_command`,
+`k3s_get_pods`) or GH Actions. From WSL `kubectl` is intentionally
+absent (per `CLAUDE.md`), so this step is silently skipped in a local
+audit run.
+
+## Reporting
+
+Produce a single markdown table with one row per surface and
+columns: **Check**, **Before** (last baseline), **Now**, **Status**.
+For pass/fail use `✅` / `⚠️` / `❌`. The latest baseline lives at
+`docs/AUDIT-2026-06-20.md` — extend it (don't replace) so trends are
+visible.
+
+When run weekly, save the report as
+`docs/audit-routine/YYYY-MM-DD.md` and link from the index. Operator
+should be able to skim in 30 seconds and spot anything that turned
+yellow or red.
+
+## When to use a deeper tool instead
+
+- A **cluster incident** (k3s pods CrashLoopBackOff, runner stuck) →
+  use `cluster-incident-response` skill.
+- An **integration is silently broken** (LinkedIn pixel, Postiz,
+  Cloudflare token) → use the corresponding `*-doctor` skill
+  (`linkedin-insight-doctor`, `postiz-doctor`,
+  `cloudflare-token-doctor`).
+- A **PR check is red** for SonarCloud → use `sonarcloud-triage`.
+- A **performance regression** specific to one route → use the
+  Lighthouse plan in `docs/lighthouse-optimization-plan.md`.
+
+This audit-routine skill is the **coarse** layer; the doctors are the
+**fine** layer.
+
+## What this skill won't do
+
+- It won't dispatch fixes. It surfaces drift; fixing is a separate
+  PR (the docs/AUDIT-2026-06-20.md report has the ranked improvement
+  list — that's the action queue).
+- It won't run e2e (Playwright) — too slow for a weekly cadence.
+  Reserve `pnpm test:e2e` for pre-deploy.
+- It won't touch AWS console state (cost analysis, IAM audit). For
+  those, see `docs/aws-cost-reduction.md` + `docs/iam.md` and run
+  the AWS-side checks manually.
+
+## Integration with the Monday CI routine
+
+`docs/ci-health-routine.md` already runs every Monday 09:00 Athens.
+That routine is gh-checks-only. To upgrade it: edit the Anthropic
+Cloud routine prompt (ID `trig_01WQ7NdStiHu4Ab3DpBrRuiV`) to add the
+commands above. Keep the agent **read-only** — triage is manual.

--- a/src/app/[locale]/services/page.tsx
+++ b/src/app/[locale]/services/page.tsx
@@ -7,6 +7,7 @@ import { getServiceSchema, getBreadcrumbSchema, getFAQSchema } from "@/lib/struc
 import { translate, getMessages, isSupportedLocale, type Locale } from "@/lib/i18n";
 import { getServerLocale } from "@/lib/server-locale";
 import StatCounter from "@/components/StatCounter";
+import DeferredRender from "@/components/DeferredRender";
 
 // All service content comes from the static `services-data` module — there is
 // no per-request data on this page. Removing `force-dynamic` and the explicit
@@ -382,29 +383,55 @@ export default async function ServicesPage() {
                     </div>
                   </div>
 
-                  {/* Visual column — terminal + stats grid */}
+                  {/* Visual column — terminal + stats grid.
+                      Both inner blocks are decorative below-the-fold widgets:
+                      TerminalBlock is an ASCII-line animation, StatCounter is
+                      an IntersectionObserver-driven count-up. Deferring their
+                      hydration past LCP is Lighthouse plan Win #4. The
+                      DeferredRender skeleton roughly matches the eventual
+                      height so CLS stays minimal. */}
                   <div className={`space-y-4 ${isReversed ? "lg:order-1" : ""}`}>
-                    <TerminalBlock
-                      lines={service.terminal}
-                      title={`cloudless-cli — ${service.tag.toLowerCase()}`}
-                    />
-
-                    <div className="grid grid-cols-2 gap-3">
-                      {service.stats.map((stat) => (
+                    <DeferredRender
+                      fallback={
                         <div
-                          key={stat.label}
-                          className={`rounded-lg border p-4 ${colors.stat} text-center`}
-                        >
-                          <StatCounter
-                            value={stat.value}
-                            label={stat.label}
-                            valueClassName={`font-mono text-xl font-bold ${colors.statValue}`}
-                            showLabel={false}
-                          />
-                          <div className="mt-1 font-mono text-xs text-slate-500">{stat.label}</div>
-                        </div>
-                      ))}
-                    </div>
+                          aria-hidden="true"
+                          className="bg-void-light/30 h-48 w-full rounded-lg"
+                          data-deferred="terminal"
+                        />
+                      }
+                    >
+                      <TerminalBlock
+                        lines={service.terminal}
+                        title={`cloudless-cli — ${service.tag.toLowerCase()}`}
+                      />
+                    </DeferredRender>
+
+                    <DeferredRender
+                      fallback={
+                        <div
+                          aria-hidden="true"
+                          className="bg-void-light/30 grid h-24 w-full grid-cols-2 gap-3 rounded"
+                          data-deferred="stats"
+                        />
+                      }
+                    >
+                      <div className="grid grid-cols-2 gap-3">
+                        {service.stats.map((stat) => (
+                          <div
+                            key={stat.label}
+                            className={`rounded-lg border p-4 ${colors.stat} text-center`}
+                          >
+                            <StatCounter
+                              value={stat.value}
+                              label={stat.label}
+                              valueClassName={`font-mono text-xl font-bold ${colors.statValue}`}
+                              showLabel={false}
+                            />
+                            <div className="mt-1 font-mono text-xs text-slate-500">{stat.label}</div>
+                          </div>
+                        ))}
+                      </div>
+                    </DeferredRender>
                   </div>
                 </div>
               </ScrollReveal>
@@ -634,9 +661,20 @@ export default async function ServicesPage() {
               </Link>
             </div>
 
-            {/* Desktop: terminal */}
+            {/* Desktop: terminal — deferred past LCP (decorative below-the-fold).
+                See DeferredRender note above and Lighthouse plan Win #4. */}
             <div className="hidden lg:block">
-              <TerminalBlock lines={bundleTerminal} title="cloudless-cli — bundle" />
+              <DeferredRender
+                fallback={
+                  <div
+                    aria-hidden="true"
+                    className="bg-void-light/30 h-64 w-full rounded-lg"
+                    data-deferred="bundle-terminal"
+                  />
+                }
+              >
+                <TerminalBlock lines={bundleTerminal} title="cloudless-cli — bundle" />
+              </DeferredRender>
             </div>
 
             {/* Mobile: 6-service badge grid */}

--- a/src/components/DeferredRender.tsx
+++ b/src/components/DeferredRender.tsx
@@ -1,0 +1,86 @@
+"use client";
+
+import { useState, useEffect, type ReactNode } from "react";
+
+/**
+ * Defer hydration of a below-the-fold or decorative subtree until the browser
+ * is idle. Used to pull heavy client components (terminal sims, animated stat
+ * counters, FAQ accordions) out of the LCP critical path.
+ *
+ * Mechanics:
+ *   1. SSR + first paint: renders the `fallback` (or a neutral skeleton box).
+ *   2. After hydration, schedules `setReady(true)` via `requestIdleCallback`
+ *      (or a 0-delay setTimeout fallback for Safari < 18.4).
+ *   3. On next render, swaps to `children`.
+ *
+ * The fallback is a thin div so layout shift stays minimal. If a specific
+ * call site has known dimensions, pass an explicit `fallback` matching the
+ * eventual children's bounding box to avoid a CLS bump.
+ *
+ * Targeted by Lighthouse Win #4 in `docs/lighthouse-optimization-plan.md`:
+ * deferring TerminalBlock + StatCounter on `/services` past LCP.
+ */
+export default function DeferredRender({
+  children,
+  fallback,
+  /**
+   * Wait this many ms past idle before swapping. Defaults to 0 — render
+   * immediately when idle fires. Bump to small values (e.g. 200) only if a
+   * particular call site benchmarks slower with eager idle-mount.
+   */
+  idleDelayMs = 0,
+}: Readonly<{
+  children: ReactNode;
+  fallback?: ReactNode;
+  idleDelayMs?: number;
+}>) {
+  const [ready, setReady] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    const fire = () => {
+      if (cancelled) return;
+      if (idleDelayMs > 0) {
+        const t = setTimeout(() => !cancelled && setReady(true), idleDelayMs);
+        return () => clearTimeout(t);
+      }
+      setReady(true);
+    };
+
+    // Prefer requestIdleCallback when available so we don't compete with
+    // post-hydration work that the user actually sees. Safari < 18.4 lacks
+    // it; for those we fall back to setTimeout(..., 0) which lands at the
+    // end of the current task queue — still after the critical render.
+    type IdleWindow = Window & {
+      requestIdleCallback?: (cb: () => void, opts?: { timeout: number }) => number;
+      cancelIdleCallback?: (id: number) => void;
+    };
+    const w = window as IdleWindow;
+    if (typeof w.requestIdleCallback === "function") {
+      const id = w.requestIdleCallback(fire, { timeout: 2_000 });
+      return () => {
+        cancelled = true;
+        w.cancelIdleCallback?.(id);
+      };
+    }
+    const t = setTimeout(fire, 0);
+    return () => {
+      cancelled = true;
+      clearTimeout(t);
+    };
+  }, [idleDelayMs]);
+
+  if (ready) return <>{children}</>;
+  // Neutral skeleton: low-contrast block, no animation (so it doesn't compete
+  // for paint time with the real LCP element).
+  return (
+    fallback ?? (
+      <div
+        aria-hidden="true"
+        className="bg-void-light/30 h-24 w-full rounded"
+        data-deferred="pending"
+      />
+    )
+  );
+}

--- a/sst.config.ts
+++ b/sst.config.ts
@@ -366,6 +366,14 @@ export default {
         architecture: "arm64",
         runtime: "nodejs22.x",
         timeout: "30 seconds",
+        // X-Ray active tracing — captures cold-start frequency + duration,
+        // p50/p95/p99 by route, and downstream call latency (Bedrock, DDB,
+        // SSM). Documented as Phase 2 in docs/SECURITY_ENHANCEMENTS_ROADMAP.md.
+        // The CloudWatch SERVERLESS-APP_MAIN-Errors alarm only counts errors;
+        // X-Ray segments are what actually explain them. AWS bills $5 / 1M
+        // traces — at our volume that's <$0.01/mo. Sampled 5% by default;
+        // bump if more detail is needed via aws xray put-sampling-rule.
+        tracing: "active",
       },
       transform: {
         // Force arm64 on SST-internal functions (warmer + revalidation).


### PR DESCRIPTION
Three independent low-risk wins from docs/AUDIT-2026-06-20.md.

## 1. AWS X-Ray active tracing on Lambda
sst.config.ts — single-line addition to server config. Captures cold-start frequency + duration, p50/p95/p99 by route, downstream call latency (Bedrock, DynamoDB, SSM). Phase 2 of docs/SECURITY_ENHANCEMENTS_ROADMAP.md.

## 2. DeferredRender + Lighthouse Win #4 wiring
New src/components/DeferredRender.tsx: requestIdleCallback-gated subtree, neutral-skeleton fallback (sized so CLS stays minimal). Wired into src/app/[locale]/services/page.tsx for the 6 per-service TerminalBlock + 24 StatCounter instances and the bundle terminal at the bottom. Expected: +250ms LCP / +4 Lighthouse points on /services.

## 3. New audit-routine skill
skills/audit-routine/SKILL.md — the coarse weekly audit pass: typecheck, lint, audit, outdated, lambda-env-audit, live-curl timing band, security headers. Designed to upgrade the Monday CI routine (docs/ci-health-routine.md, currently gh-checks-only). The doctor skills remain the fine layer.

## Skipped (need own scope)
- Lighthouse Win #2 — verified dead code by next.config.ts:110-117 (next-intl middleware intercepts before rewrites)
- AWS WAF, cost cuts, CSP enforce flip — need AWS console
- console.* sweep + any-type tightening — large refactors

## Verified
- pnpm typecheck: clean
- pnpm lint: 0 errors, 0 warnings
- 81/81 unit tests across slack-notify, slack-ops-users, ad-analytics, contact-campaign-pipeline pass