### PR TITLE
chore: audit residuals — bump aws-iam dev, document audit closure

### DIFF
--- a/docs/AUDIT-2026-06-20.md
+++ b/docs/AUDIT-2026-06-20.md
@@ -208,6 +208,41 @@ slack-ops-users (new), ad-analytics, contact-campaign-pipeline. Repo also has
 
 ---
 
+## 3a. Resolved — what has shipped since the audit
+
+| Item | PR | Status |
+|---|---|---|
+| Lint warnings (3 → 0) | [#1009](https://github.com/Themis128/cloudless.gr/pull/1009) | ✅ done |
+| Patch-bump dep wave (Stripe, AWS SDK, Sentry, lucide) | [#1009](https://github.com/Themis128/cloudless.gr/pull/1009) | ✅ done |
+| `/sitemap.xml` 1.75 s → 0.54 s (avg of 5 warm hits) | [#1009](https://github.com/Themis128/cloudless.gr/pull/1009) | ✅ done |
+| `@react-email/components` pinned exact (no successor) | [#1009](https://github.com/Themis128/cloudless.gr/pull/1009) | ✅ done |
+| AWS X-Ray active tracing on Lambda | [#1010](https://github.com/Themis128/cloudless.gr/pull/1010) | ✅ done |
+| Lighthouse Win #4 — `DeferredRender` + `/services` wiring | [#1010](https://github.com/Themis128/cloudless.gr/pull/1010) | ✅ done |
+| `audit-routine` skill (P4 #15) | [#1010](https://github.com/Themis128/cloudless.gr/pull/1010) | ✅ done |
+| `@aws-sdk/client-iam` (dev) → 3.1073.0 | this PR | ✅ done |
+| Lighthouse Win #1 — extract services data | already in `src/lib/services-data.ts` | ✅ pre-existing |
+
+### Confirmed dead (verified, do not retry)
+
+| Item | Why |
+|---|---|
+| Lighthouse Win #2 — `next.config.ts` rewrites for `/services` + `/store` | `next.config.ts:110-117` documents that next-intl middleware intercepts before rewrites; verified live by author of next.config.ts. |
+
+### Deferred (need own scope or external action)
+
+| Item | Why deferred |
+|---|---|
+| Lighthouse Win #3 — compress ProductIcon SVGs | Needs `svgo` dev dep + asset extraction; warrants its own PR. |
+| Lighthouse Win #5 — WebP icon assets | Needs `cwebp`/ImageMagick binary not present in WSL. |
+| AWS WAF (P3 #10) | Needs AWS console + IaC. |
+| CSP report-only → enforced (P3 #12) | Needs a week of clean `/api/csp-report` data first. |
+| CloudFront edge caching (P3 #13) | Needs CloudFront cache-behavior config. |
+| `console.*` sweep into Sentry breadcrumbs (P2 #7) | 343 call sites; multi-file refactor warrants own PR. |
+| `any`-type + `eslint-disable` sweep (P2 #8) | 52 `any` + 93 disables; same. |
+| AWS cost cuts (P1 #6) | Needs AWS console (CloudTrail trail delete, Config recorder stop, KMS key rotation). |
+| Monday CI routine upgrade (P4 #14) | Anthropic Cloud routine prompt (`trig_01WQ7NdStiHu4Ab3DpBrRuiV`) — edit lives outside the repo. |
+| `eslint` 9 → 10 (major) + `@types/node` 25 → 26 (major) | Both safe majors but each warrants its own PR with type/rule audit. |
+
 ## 4. Suggested next action
 
 If I had to pick one thing to ship today, it's **P1 #5 (sitemap 1.75 s

--- a/package.json
+++ b/package.json
@@ -115,7 +115,7 @@
     "stripe": "^22.2.2"
   },
   "devDependencies": {
-    "@aws-sdk/client-iam": "3.1068.0",
+    "@aws-sdk/client-iam": "3.1073.0",
     "@axe-core/playwright": "^4.11.3",
     "@next/bundle-analyzer": "^16.2.9",
     "@parcel/watcher": "^2.5.6",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -88,8 +88,8 @@ importers:
         version: 22.2.2(@types/node@25.9.3)
     devDependencies:
       '@aws-sdk/client-iam':
-        specifier: 3.1068.0
-        version: 3.1068.0
+        specifier: 3.1073.0
+        version: 3.1073.0
       '@axe-core/playwright':
         specifier: ^4.11.3
         version: 4.11.3(playwright-core@1.61.0)
@@ -286,8 +286,8 @@ packages:
     resolution: {integrity: sha512-2GUPeI0drcms+LOoSC2DfVLCUWQxjjUm4jN08MrVh40XnIRQZ9PxCjFCqAj6yMRXPAzze925MMXEXBQC7IS6jw==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/client-iam@3.1068.0':
-    resolution: {integrity: sha512-92JNXFGkDl1Y1rdjqX5RKtjBeDl5q748rErAKzmxZPmqUH4pu2Jp9k+yH5GQoI5b8Pai223JYY/ZijZH8bcAow==}
+  '@aws-sdk/client-iam@3.1073.0':
+    resolution: {integrity: sha512-TEovDL6IPOiThcSWj0xVJe0Mffc06xFD1xEry+kAREra0d8ArxGFnYeCRBOxQkGpw0H3z0T8STWxw73ibkm/Mw==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/client-lambda@3.1057.0':
@@ -5667,7 +5667,7 @@ snapshots:
       '@aws-crypto/sha256-js': 5.2.0
       '@aws-crypto/supports-web-crypto': 5.2.0
       '@aws-crypto/util': 5.2.0
-      '@aws-sdk/types': 3.973.12
+      '@aws-sdk/types': 3.973.13
       '@aws-sdk/util-locate-window': 3.965.7
       '@smithy/util-utf8': 2.3.0
       tslib: 2.8.1
@@ -5675,7 +5675,7 @@ snapshots:
   '@aws-crypto/sha256-js@5.2.0':
     dependencies:
       '@aws-crypto/util': 5.2.0
-      '@aws-sdk/types': 3.973.12
+      '@aws-sdk/types': 3.973.13
       tslib: 2.8.1
 
   '@aws-crypto/supports-web-crypto@5.2.0':
@@ -5753,17 +5753,17 @@ snapshots:
       '@smithy/types': 4.14.4
       tslib: 2.8.1
 
-  '@aws-sdk/client-iam@3.1068.0':
+  '@aws-sdk/client-iam@3.1073.0':
     dependencies:
       '@aws-crypto/sha256-browser': 5.2.0
       '@aws-crypto/sha256-js': 5.2.0
-      '@aws-sdk/core': 3.974.20
-      '@aws-sdk/credential-provider-node': 3.972.55
-      '@aws-sdk/types': 3.973.12
-      '@smithy/core': 3.24.7
+      '@aws-sdk/core': 3.974.22
+      '@aws-sdk/credential-provider-node': 3.972.57
+      '@aws-sdk/types': 3.973.13
+      '@smithy/core': 3.25.1
       '@smithy/fetch-http-handler': 5.4.7
       '@smithy/node-http-handler': 4.7.8
-      '@smithy/types': 4.14.4
+      '@smithy/types': 4.15.0
       tslib: 2.8.1
 
   '@aws-sdk/client-lambda@3.1057.0':


### PR DESCRIPTION
Closes the open-ended items from docs/AUDIT-2026-06-20.md by capturing exactly what shipped, what is verified-dead, and what is intentionally deferred.

## 1. @aws-sdk/client-iam (dev) 3.1068.0 → 3.1073.0
Re-aligns with the rest of the AWS SDK wave shipped in PR #1009. Was the only AWS SDK package still pinned to the old patch level.

After: pnpm outdated drops from 4 to 3 entries, all documented:
- @react-email/components: intentionally pinned 1.0.12 (deprecated namespace, no successor)
- @types/node 25→26: major, deferred to its own PR
- eslint 9→10: major, deferred to its own PR

## 2. Audit doc closure addendum
Added §3a to docs/AUDIT-2026-06-20.md with three tables:
- **Resolved** — every shipped item mapped to its PR (#1008/#1009/#1010 + this one)
- **Confirmed dead** — Lighthouse Win #2 (next-intl intercepts before rewrites, verified)
- **Deferred** — each remaining item with the explicit reason it warrants its own scope

The next audit pass can diff against this addendum instead of re-walking the same surface.

## Verified
- pnpm typecheck: clean
- pnpm lint: 0 errors, 0 warnings  
- PR #1010 deploys (X-Ray + DeferredRender) currently in flight on 4e971dc1.