### PR TITLE
feat: WAF + audit doc closure — deferred items addressed or verified moot

### DIFF
--- a/docs/AUDIT-2026-06-20.md
+++ b/docs/AUDIT-2026-06-20.md
@@ -243,6 +243,45 @@ slack-ops-users (new), ad-analytics, contact-campaign-pipeline. Repo also has
 | Monday CI routine upgrade (P4 #14) | Anthropic Cloud routine prompt (`trig_01WQ7NdStiHu4Ab3DpBrRuiV`) — edit lives outside the repo. |
 | `eslint` 9 → 10 (major) + `@types/node` 25 → 26 (major) | Both safe majors but each warrants its own PR with type/rule audit. |
 
+## 3b. Deferred items revisited (2026-06-20, second pass with AWS creds)
+
+Verified live AWS state and refined the deferred list. Several items
+turned out to be already done, not actually applicable, or smaller in
+scope than the audit doc suggested.
+
+| Original deferred item | Verified state | Action this PR |
+|---|---|---|
+| AWS WAF (P3 #10) | No WebACL existed | **Created** `cloudless-waf` (COUNT mode, attached to `ELGQBR8109MTM`). See `docs/waf.md`. |
+| CSP report-only → enforced (P3 #12) | `src/proxy.ts:273` already sets `Content-Security-Policy` (not Report-Only) | **Already done** — no flip needed. |
+| AWS cost cuts (P1 #6) — CloudTrail extra trail | 1 trail, management-only, free tier | **Already at floor** — nothing to cut. |
+| AWS cost cuts — AWS Config recorder | Recorder is **OFF** | **Already at floor.** |
+| AWS cost cuts — KMS CMKs | All 7 keys are `alias/aws/*` (AWS-managed, free) | **No customer CMKs to delete.** |
+| AWS cost cuts — Secrets Manager | Empty in both us-east-1 + eu-central-1 | **Nothing to clean up.** |
+| Lighthouse Win #1 — extract services data | `src/lib/services-data.ts` exists, imported by `services/page.tsx:79` | **Already done.** |
+| Lighthouse Win #5 — WebP icons | PWA icons are 1.4 KB + 2.7 KB + 2.7 KB | **Negligible win** — skipped. |
+| Lighthouse Win #3 — compress ProductIcon SVGs | 9 inline SVGs, ~6 KB savings on `/store` only, requires JSX→`<img>` rewrite that breaks color animations | **Skipped** — risk > reward; warrants its own design pass. |
+| CloudFront edge caching (P3 #13) | Two distributions, both no caching policy | **Skipped** — production risk; needs route-by-route cache-behavior design. |
+| `console.*` sweep (P2 #7) | 343 call sites | **Skipped** — multi-PR refactor. |
+| `any`-type + `eslint-disable` sweep (P2 #8) | 52 + 93 | **Skipped** — multi-PR refactor. |
+| `eslint` 9 → 10 (major) | Major bump | **Separate PR** — needs ESLint config audit. |
+| `@types/node` 25 → 26 (major) | Major bump | **Separate PR.** |
+| Monday CI routine upgrade (P4 #14) | Anthropic Cloud routine, not in repo | **Cannot do from here** — edit `trig_01WQ7NdStiHu4Ab3DpBrRuiV` directly. |
+
+### Net change after this pass
+
+- WAF spend: **+~$7.50/mo** (security investment, reversible).
+- No reductions found: account was already optimised on the
+  CloudTrail / Config / KMS / Secrets Manager surfaces the audit
+  flagged. The original audit doc was based on an old monthly invoice
+  ($18/mo) whose costs had already been cut by the time this audit
+  ran (current net is much closer to the floor).
+- The audit's "5 items to defer" list shrinks from 11 to **6**: WAF
+  done, CSP already enforced, all 4 cost-cut categories already at
+  floor, Lighthouse #1 already done. Six genuine deferrals remain:
+  Lighthouse #3 (refactor risk), Lighthouse #5 (negligible win),
+  CloudFront cache (design pass), `console.*` + `any` sweeps (scope),
+  ESLint + `@types/node` majors (separate PRs).
+
 ## 4. Suggested next action
 
 If I had to pick one thing to ship today, it's **P1 #5 (sitemap 1.75 s

--- a/docs/waf.md
+++ b/docs/waf.md
@@ -1,0 +1,96 @@
+# AWS WAF — cloudless.gr
+
+A CLOUDFRONT-scoped WebACL fronts the cloudless.gr distribution. Both rules
+run in **COUNT mode** today — they inspect every request and emit CloudWatch
+metrics + sampled requests, but do not block. Promotion to BLOCK is a manual
+follow-up after a few days of monitoring so we can see false-positive rates
+before they hit real users.
+
+## Layout
+
+| Field | Value |
+|---|---|
+| WebACL name | `cloudless-waf` |
+| Scope | `CLOUDFRONT` (us-east-1 control plane, global edge) |
+| ARN | `arn:aws:wafv2:us-east-1:278585680617:global/webacl/cloudless-waf/d212efa8-0389-4daf-b97b-0ecd2df73939` |
+| Default action | `Allow` |
+| Attached to | CloudFront distribution `ELGQBR8109MTM` (`d3k7muo3c6lw6s.cloudfront.net`, i.e. cloudless.gr) |
+| Created | 2026-06-20 via `aws wafv2 create-web-acl` |
+
+## Rules
+
+| Priority | Name | Type | Action | Purpose |
+|---:|---|---|---|---|
+| 10 | `AWS-CommonRuleSet` | AWS-managed (`AWSManagedRulesCommonRuleSet`) | **Count** (overridden) | OWASP Top-10 baseline: SQLi, XSS, LFI, RFI, Log4Shell, request smuggling, oversize body/URL/headers, etc. |
+| 20 | `RateLimit-2000-per-5min` | Rate-based, key=IP | **Count** | One IP doing > 2 000 requests in any rolling 5-minute window. |
+
+CloudWatch metric namespace `AWS/WAFV2`, metric names
+`cloudless-waf-CommonRuleSet` and `cloudless-waf-RateLimit`. Sampled
+requests are visible in the WAF console.
+
+## Promotion to BLOCK (the operator action)
+
+After a few days of monitoring:
+
+```bash
+# 1. Inspect the sampled requests in the WAF console to see what's
+#    being matched. Anything obviously legitimate that's matching means
+#    that managed-rule sub-rule needs an exclusion (not a flip to BLOCK).
+# 2. Flip CommonRuleSet override from Count → None (so its sub-rule
+#    actions apply, which is mostly Block).
+aws wafv2 update-web-acl \
+  --scope CLOUDFRONT --region us-east-1 \
+  --name cloudless-waf \
+  --id d212efa8-0389-4daf-b97b-0ecd2df73939 \
+  --lock-token <fresh-token-from-list-web-acls> \
+  --default-action Allow={} \
+  --visibility-config 'SampledRequestsEnabled=true,CloudWatchMetricsEnabled=true,MetricName=cloudless-waf' \
+  --rules file://docs/waf-rules-block.json
+```
+
+A `docs/waf-rules-block.json` template can be created off the live spec
+via `aws wafv2 get-web-acl ... > docs/waf-rules-current.json` then a
+sed of `"Count": {}` → `"None": {}` on the CommonRuleSet override and
+`"Action": { "Count": {} }` → `"Action": { "Block": {} }` on the
+rate-based rule. Always keep one rule in COUNT during the flip so you
+can compare counts before/after.
+
+## Cost
+
+| Item | Monthly |
+|---|---|
+| 1 WebACL | $5.00 |
+| 1 AWS-managed rule group | $1.00 |
+| 1 rate-based rule | $1.00 |
+| Request inspection | $0.60 / 1 M |
+| Sampled-request storage | free (3 hrs sliding window) |
+
+Estimated total at current traffic: ~$7.50/mo. This is a **security
+investment**, not a cost cut — it adds spend to the bill from
+`docs/aws-cost-reduction.md`. Reversible by detaching from the
+CloudFront distribution (`WebACLId = ""`) and `delete-web-acl`.
+
+## Reversal
+
+```bash
+# Detach from CloudFront
+aws cloudfront get-distribution-config --id ELGQBR8109MTM > /tmp/cf.json
+# zero out WebACLId, save as /tmp/cf-new.json
+aws cloudfront update-distribution --id ELGQBR8109MTM \
+  --if-match <ETag-from-cf.json> \
+  --distribution-config file:///tmp/cf-new.json
+
+# Delete WebACL (must be detached first)
+aws wafv2 delete-web-acl \
+  --scope CLOUDFRONT --region us-east-1 \
+  --name cloudless-waf \
+  --id d212efa8-0389-4daf-b97b-0ecd2df73939 \
+  --lock-token <token>
+```
+
+## Why not the portfolio distribution
+
+The second CloudFront distribution (`E134SCTR0QGQKJ`,
+`d1947b4i8egesz.cloudfront.net`) serves `baltzakisthemis.com` (a static
+portfolio site). It has no Lambda origin, no API surface, and no
+attack surface worth WAF spend. Leave it un-WAFed.


### PR DESCRIPTION
Second-pass on docs/AUDIT-2026-06-20.md deferred items, with live AWS state verification.

## One real action: AWS WAF
- Created cloudless-waf WebACL (CLOUDFRONT scope)
- AWSManagedRulesCommonRuleSet (Count override) + 2000 req/5min/IP rate-based rule (Count)
- Attached to distribution ELGQBR8109MTM (cloudless.gr)
- Both rules in COUNT mode — log only, never block, operator promotes to BLOCK after monitoring
- Adds ~\.50/mo. Runbook + reversal in docs/waf.md

## Already done / moot (verified live)
- **CSP enforce**: proxy.ts:273 already sets Content-Security-Policy (not Report-Only)
- **AWS cost cuts**: CloudTrail at free tier (1 management trail), AWS Config recorder OFF, all KMS keys are aws-managed, Secrets Manager empty
- **Lighthouse Win #1**: src/lib/services-data.ts already exists, services/page.tsx already imports

## Skipped with rationale
- **Lighthouse #5** (WebP icons): PWA icons already 1.4 + 2.7 + 2.7 KB; negligible win
- **Lighthouse #3** (compress ProductIcon): JSX→<img> rewrite breaks color animations; ~6 KB on /store only; risk > reward
- **CloudFront cache, console.* sweep, any-type sweep**: per audit doc original deferrals
- **eslint 9→10, @types/node 25→26**: separate PRs (each needs config/type audit)
- **Monday CI routine**: lives in Anthropic Cloud, edit outside repo

## Audit doc updated
§3b documents the second-pass findings. Net deferred items: 11 → 6.

## Verified
- pnpm typecheck clean
- pnpm lint 0/0
- CloudFront ELGQBR8109MTM status InProgress after WAF attach (5 min propagation)