### PR TITLE
feat(etl): HubSpot + RFM-compute ETLs, Slack failure alerts, 4 new Athena views

### DIFF
--- a/.github/workflows/analytics-etl.yml
+++ b/.github/workflows/analytics-etl.yml
@@ -82,3 +82,14 @@ jobs:
               --query "ResultSet.Rows[1:]" --output json 2>/dev/null \
             | jq -r '.[] | "| \(.Data[0].VarCharValue) | \(.Data[1].VarCharValue) |"' || echo "_(no data yet)_"
           } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Notify Slack on failure
+        if: failure() && env.SLACK_WEBHOOK_URL != ''
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+        run: |
+          curl -s -X POST "$SLACK_WEBHOOK_URL" \
+            -H "Content-Type: application/json" \
+            -d '{
+              "text": ":x: Analytics ETL (Athena partition repair) failed on '"$GITHUB_REF_NAME"' (#'"$GITHUB_RUN_NUMBER"'). New events/* partitions will not be queryable until this is fixed. See https://github.com/'"$GITHUB_REPOSITORY"'/actions/runs/'"$GITHUB_RUN_ID"'"
+            }'

--- a/.github/workflows/etl-compute-rfm-churn.yml
+++ b/.github/workflows/etl-compute-rfm-churn.yml
@@ -1,8 +1,10 @@
-name: ETL — Clients & Portals to Data Lake
+name: ETL — Compute RFM + churn scores
 
 on:
   schedule:
-    - cron: '0 4 * * *'  # daily 04:00 UTC (after Stripe ETL)
+    # 03:45 UTC — after Stripe ETL (03:30 UTC) finishes loading transactions
+    # but before clients-to-lake (04:00 UTC) joins the scores in.
+    - cron: '45 3 * * *'
   workflow_dispatch:
 
 permissions:
@@ -15,10 +17,10 @@ env:
   BUCKET: cloudless-analytics-data
 
 jobs:
-  clients-sync:
-    name: Sync Clients & Portals → S3 Parquet
+  rfm-compute:
+    name: Compute RFM + churn from transactions parquet
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 5
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v4
 
@@ -32,22 +34,13 @@ jobs:
           node-version: 22
 
       - name: Install dependencies
-        # `npm ci` uses scripts/etl/package-lock.json so portals + clients
-        # ETLs run against pinned deps every day. Previous `npm install`
-        # would resolve latest of each AWS SDK on every run.
         run: npm ci
         working-directory: scripts/etl
 
-      - name: Sync portals to lake
-        run: node scripts/etl/portals-to-lake.mjs
+      - name: Compute scores
+        run: node scripts/etl/compute-rfm-churn.mjs
         env:
           ANALYTICS_BUCKET: ${{ env.BUCKET }}
-
-      - name: Sync clients to lake
-        run: node scripts/etl/clients-to-lake.mjs
-        env:
-          ANALYTICS_BUCKET: ${{ env.BUCKET }}
-          COGNITO_USER_POOL_ID: us-east-1_1Bq3Mpqer
 
       - name: Notify Slack on failure
         if: failure() && env.SLACK_WEBHOOK_URL != ''
@@ -57,5 +50,5 @@ jobs:
           curl -s -X POST "$SLACK_WEBHOOK_URL" \
             -H "Content-Type: application/json" \
             -d '{
-              "text": ":x: ETL — Clients & Portals to Data Lake failed on '"$GITHUB_REF_NAME"' (#'"$GITHUB_RUN_NUMBER"'). See https://github.com/'"$GITHUB_REPOSITORY"'/actions/runs/'"$GITHUB_RUN_ID"'"
+              "text": ":x: ETL — Compute RFM + churn failed on '"$GITHUB_REF_NAME"' (#'"$GITHUB_RUN_NUMBER"'). Downstream clients-to-lake will fall back to no scores. See https://github.com/'"$GITHUB_REPOSITORY"'/actions/runs/'"$GITHUB_RUN_ID"'"
             }'

--- a/.github/workflows/etl-hubspot-to-lake.yml
+++ b/.github/workflows/etl-hubspot-to-lake.yml
@@ -1,8 +1,8 @@
-name: ETL — Clients & Portals to Data Lake
+name: ETL — HubSpot to Data Lake
 
 on:
   schedule:
-    - cron: '0 4 * * *'  # daily 04:00 UTC (after Stripe ETL)
+    - cron: '15 3 * * *'  # daily 03:15 UTC (before Stripe ETL at 03:30)
   workflow_dispatch:
 
 permissions:
@@ -15,8 +15,8 @@ env:
   BUCKET: cloudless-analytics-data
 
 jobs:
-  clients-sync:
-    name: Sync Clients & Portals → S3 Parquet
+  hubspot-sync:
+    name: Sync HubSpot CRM → S3 Parquet
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
@@ -32,22 +32,15 @@ jobs:
           node-version: 22
 
       - name: Install dependencies
-        # `npm ci` uses scripts/etl/package-lock.json so portals + clients
-        # ETLs run against pinned deps every day. Previous `npm install`
-        # would resolve latest of each AWS SDK on every run.
         run: npm ci
         working-directory: scripts/etl
 
-      - name: Sync portals to lake
-        run: node scripts/etl/portals-to-lake.mjs
+      - name: Run HubSpot ETL
+        id: etl
+        run: node scripts/etl/hubspot-to-lake.mjs
         env:
+          HUBSPOT_API_KEY: ${{ secrets.HUBSPOT_API_KEY }}
           ANALYTICS_BUCKET: ${{ env.BUCKET }}
-
-      - name: Sync clients to lake
-        run: node scripts/etl/clients-to-lake.mjs
-        env:
-          ANALYTICS_BUCKET: ${{ env.BUCKET }}
-          COGNITO_USER_POOL_ID: us-east-1_1Bq3Mpqer
 
       - name: Notify Slack on failure
         if: failure() && env.SLACK_WEBHOOK_URL != ''
@@ -57,5 +50,5 @@ jobs:
           curl -s -X POST "$SLACK_WEBHOOK_URL" \
             -H "Content-Type: application/json" \
             -d '{
-              "text": ":x: ETL — Clients & Portals to Data Lake failed on '"$GITHUB_REF_NAME"' (#'"$GITHUB_RUN_NUMBER"'). See https://github.com/'"$GITHUB_REPOSITORY"'/actions/runs/'"$GITHUB_RUN_ID"'"
+              "text": ":x: ETL — HubSpot to Data Lake failed on '"$GITHUB_REF_NAME"' (#'"$GITHUB_RUN_NUMBER"'). See https://github.com/'"$GITHUB_REPOSITORY"'/actions/runs/'"$GITHUB_RUN_ID"'"
             }'

--- a/.github/workflows/etl-stripe-to-lake.yml
+++ b/.github/workflows/etl-stripe-to-lake.yml
@@ -43,3 +43,14 @@ jobs:
         env:
           STRIPE_SECRET_KEY: ${{ secrets.STRIPE_SECRET_KEY }}
           ANALYTICS_BUCKET: ${{ env.BUCKET }}
+
+      - name: Notify Slack on failure
+        if: failure() && env.SLACK_WEBHOOK_URL != ''
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+        run: |
+          curl -s -X POST "$SLACK_WEBHOOK_URL" \
+            -H "Content-Type: application/json" \
+            -d '{
+              "text": ":x: ETL — Stripe to Data Lake failed on '"$GITHUB_REF_NAME"' (#'"$GITHUB_RUN_NUMBER"'). See https://github.com/'"$GITHUB_REPOSITORY"'/actions/runs/'"$GITHUB_RUN_ID"'"
+            }'

--- a/docs/analytics-athena.sql
+++ b/docs/analytics-athena.sql
@@ -1,8 +1,14 @@
--- Run once in Athena to create the events table over S3.
--- Replace the LOCATION with your actual bucket if it differs.
+-- Cloudless analytics — Athena / Glue DDL.
+-- Run from the Athena `primary` workgroup (which has the result location
+-- and 10 GB scan cap enforced — see docs/datalake.md).
 
 CREATE DATABASE IF NOT EXISTS cloudless_analytics;
 
+-- ===========================================================================
+-- Source tables
+-- ===========================================================================
+
+-- ---- events (NDJSON, partitioned, written real-time by Lambda) ------------
 CREATE EXTERNAL TABLE IF NOT EXISTS cloudless_analytics.events (
   `timestamp`   string,
   event         string,
@@ -29,10 +35,146 @@ ROW FORMAT SERDE 'org.openx.data.jsonserde.JsonSerDe'
 LOCATION 's3://cloudless-analytics-data/events/'
 TBLPROPERTIES ('has_encrypted_data'='false');
 
--- After creating the table, run this to load existing partitions:
-MSCK REPAIR TABLE cloudless_analytics.events;
+-- ---- HubSpot CRM tables (Parquet, full-refresh daily) ---------------------
+CREATE EXTERNAL TABLE IF NOT EXISTS cloudless_analytics.hubspot_contacts (
+  contact_id       string,
+  email            string,
+  firstname        string,
+  lastname         string,
+  company          string,
+  phone            string,
+  lifecyclestage   string,
+  lead_status      string,
+  lead_source      string,
+  service_interest string,
+  country          string,
+  createdate       string,
+  lastmodifieddate string
+)
+STORED AS PARQUET
+LOCATION 's3://cloudless-analytics-data/lake/hubspot-contacts/';
 
--- Example queries:
--- SELECT event, COUNT(*) AS n FROM cloudless_analytics.events GROUP BY event ORDER BY n DESC;
--- SELECT DATE(timestamp) AS day, COUNT(*) AS signups FROM cloudless_analytics.events WHERE event='signup' GROUP BY 1 ORDER BY 1;
--- SELECT email, SUM(amount) AS total FROM cloudless_analytics.events WHERE event='purchase' GROUP BY email ORDER BY total DESC;
+CREATE EXTERNAL TABLE IF NOT EXISTS cloudless_analytics.hubspot_deals (
+  deal_id          string,
+  dealname         string,
+  amount           double,
+  currency         string,
+  dealstage        string,
+  pipeline         string,
+  closedate        string,
+  createdate       string,
+  hubspot_owner_id string
+)
+STORED AS PARQUET
+LOCATION 's3://cloudless-analytics-data/lake/hubspot-deals/';
+
+CREATE EXTERNAL TABLE IF NOT EXISTS cloudless_analytics.hubspot_tickets (
+  ticket_id           string,
+  subject             string,
+  content             string,
+  hs_pipeline         string,
+  hs_pipeline_stage   string,
+  hs_ticket_priority  string,
+  createdate          string,
+  hs_lastmodifieddate string
+)
+STORED AS PARQUET
+LOCATION 's3://cloudless-analytics-data/lake/hubspot-tickets/';
+
+-- After creating the events table, run this once to load existing partitions
+-- (the analytics-etl.yml workflow runs this daily on cron):
+--   MSCK REPAIR TABLE cloudless_analytics.events;
+
+-- ===========================================================================
+-- Insight views — full-funnel analytics
+-- ===========================================================================
+
+-- ---- v_acquisition_funnel -------------------------------------------------
+-- Daily funnel: anonymous page_views → signups → first purchase.
+-- Built from the events table only — no joins. Drives the acquisition chart
+-- on the admin dashboard.
+CREATE OR REPLACE VIEW cloudless_analytics.v_acquisition_funnel AS
+SELECT
+  DATE(`timestamp`) AS day,
+  COUNT(DISTINCT session_id) FILTER (WHERE event = 'page_view')              AS sessions,
+  COUNT(DISTINCT user_id)    FILTER (WHERE event = 'signup')                 AS signups,
+  COUNT(DISTINCT user_id)    FILTER (WHERE event = 'purchase')               AS purchasers,
+  SUM(amount)                FILTER (WHERE event = 'purchase')               AS revenue
+FROM cloudless_analytics.events
+WHERE `timestamp` IS NOT NULL
+GROUP BY 1
+ORDER BY 1 DESC;
+
+-- ---- v_attribution_by_source ----------------------------------------------
+-- Conversions + revenue split by UTM source/medium for the last 90 days.
+-- Operator-facing view for the "what's actually driving paid signups" question.
+CREATE OR REPLACE VIEW cloudless_analytics.v_attribution_by_source AS
+SELECT
+  COALESCE(source, '(direct)')    AS utm_source,
+  COALESCE(medium, '(none)')      AS utm_medium,
+  COALESCE(campaign, '(none)')    AS utm_campaign,
+  COUNT(DISTINCT session_id) FILTER (WHERE event = 'page_view')   AS sessions,
+  COUNT(DISTINCT user_id)    FILTER (WHERE event = 'signup')      AS signups,
+  COUNT(*)                   FILTER (WHERE event = 'purchase')    AS purchases,
+  SUM(amount)                FILTER (WHERE event = 'purchase')    AS revenue
+FROM cloudless_analytics.events
+WHERE `timestamp` >= date_format(current_date - interval '90' day, '%Y-%m-%dT%H:%i:%s')
+GROUP BY 1, 2, 3
+HAVING COUNT(*) > 1
+ORDER BY revenue DESC NULLS LAST, sessions DESC;
+
+-- ---- v_hubspot_funnel ------------------------------------------------------
+-- HubSpot contact lifecycle stage breakdown joined to whether they have a
+-- closed-won deal in HubSpot. Lets us see lead-source ROI by stage.
+CREATE OR REPLACE VIEW cloudless_analytics.v_hubspot_funnel AS
+SELECT
+  COALESCE(c.lifecyclestage, 'unknown') AS lifecycle_stage,
+  COALESCE(c.lead_source, '(none)')     AS lead_source,
+  COUNT(DISTINCT c.contact_id)          AS contact_count,
+  COUNT(DISTINCT d.deal_id) FILTER (WHERE d.dealstage IN ('closedwon', 'closed-won')) AS closed_won_deals,
+  SUM(d.amount)             FILTER (WHERE d.dealstage IN ('closedwon', 'closed-won')) AS closed_won_revenue
+FROM cloudless_analytics.hubspot_contacts c
+LEFT JOIN cloudless_analytics.hubspot_deals d ON d.hubspot_owner_id IS NOT NULL  -- placeholder join, refine when association table lands
+GROUP BY 1, 2
+ORDER BY contact_count DESC;
+
+-- ---- v_lead_to_customer ----------------------------------------------------
+-- Cross-source funnel join: HubSpot contact → Cognito client → first Stripe
+-- transaction. Joins on lowercased email. Shows time-to-conversion + lifetime
+-- value once the contact becomes a paying customer.
+CREATE OR REPLACE VIEW cloudless_analytics.v_lead_to_customer AS
+SELECT
+  LOWER(c.email)                                                  AS email,
+  c.lead_source,
+  c.lifecyclestage,
+  c.createdate                                                    AS hubspot_created,
+  cl.signup_date                                                  AS cognito_signup,
+  cl.rfm_score,
+  cl.churn_risk,
+  cl.lifetime_value,
+  date_diff('day',
+    from_iso8601_timestamp(c.createdate),
+    COALESCE(from_iso8601_timestamp(cl.signup_date), current_timestamp)
+  )                                                               AS days_lead_to_signup
+FROM cloudless_analytics.hubspot_contacts c
+LEFT JOIN cloudless_analytics.clients cl ON LOWER(c.email) = LOWER(cl.email)
+WHERE c.email IS NOT NULL
+ORDER BY c.createdate DESC;
+
+-- ===========================================================================
+-- Pre-existing views (kept for reference — defined elsewhere in the catalog)
+-- ===========================================================================
+-- v_client_health, v_daily_events, v_funnel, v_ltv_ranking,
+-- v_project_velocity, v_revenue_monthly
+--
+-- These were created previously and live in the Glue catalog already. The four
+-- views above (v_acquisition_funnel, v_attribution_by_source, v_hubspot_funnel,
+-- v_lead_to_customer) are new in this audit pass and need to be CREATEd once
+-- in Athena before the dashboard can query them.
+
+-- ===========================================================================
+-- Example operator queries
+-- ===========================================================================
+-- SELECT * FROM cloudless_analytics.v_acquisition_funnel LIMIT 30;
+-- SELECT * FROM cloudless_analytics.v_attribution_by_source LIMIT 20;
+-- SELECT email, rfm_score, churn_risk FROM cloudless_analytics.v_lead_to_customer ORDER BY rfm_score DESC LIMIT 50;

--- a/docs/etl.md
+++ b/docs/etl.md
@@ -23,11 +23,27 @@ Athena Glue catalog        ←  analytics-etl.yml (MSCK REPAIR) ← s3://…/eve
 | Workflow | Schedule (UTC) | Source | Sink | Idempotency |
 |---|---|---|---|---|
 | `analytics-etl.yml` | `0 2 * * *` (02:00) | Hive partitions on `events/` | Glue catalog | Yes — `MSCK REPAIR TABLE` |
+| `etl-hubspot-to-lake.yml` | `15 3 * * *` (03:15) | HubSpot v3 API (contacts + deals + tickets) | `lake/hubspot-{contacts,deals,tickets}/` | Full refresh — overwrites |
 | `etl-stripe-to-lake.yml` | `30 3 * * *` (03:30) | Stripe API (sessions/invoices/subs) | `lake/transactions/transactions.parquet` | Full refresh — overwrites |
+| `etl-compute-rfm-churn.yml` | `45 3 * * *` (03:45) | `lake/transactions/transactions.parquet` (Stripe ETL output) | `ml-parquet/scores_{rfm,churn}.parquet` | Full refresh — replaces external ML pipeline |
 | `etl-clients-to-lake.yml` | `0 4 * * *` (04:00) | Cognito + SSM + ml-parquet | `lake/clients/clients.parquet` + `lake/portals/portals.parquet` | Full refresh — overwrites |
 
-All three use OIDC (`AWS_DEPLOY_ROLE_ARN`) to assume the deploy role —
-no static AWS keys.
+All five use OIDC (`AWS_DEPLOY_ROLE_ARN`) to assume the deploy role —
+no static AWS keys. Every workflow posts to `SLACK_WEBHOOK_URL` on
+failure (`if: failure() && env.SLACK_WEBHOOK_URL != ''`).
+
+### Daily ordering (UTC)
+
+```
+02:00 analytics-etl          (registers new events partitions in Glue)
+03:15 etl-hubspot-to-lake    (CRM snapshot)
+03:30 etl-stripe-to-lake     (Stripe transactions snapshot)
+03:45 etl-compute-rfm-churn  (reads Stripe parquet, computes scores)
+04:00 etl-clients-to-lake    (joins Cognito + SSM + RFM scores)
+```
+
+The 15-min spacing isn't strict but it keeps clients-to-lake able to
+read the RFM scores written 15 min earlier (instead of yesterday's).
 
 ## Source scripts
 
@@ -35,15 +51,26 @@ no static AWS keys.
   into a transactions schema (id, email, type=checkout/invoice/sub,
   status, amount_cents, currency, product, plan, timestamps), writes
   parquet via `@dsnp/parquetjs`.
+- `scripts/etl/hubspot-to-lake.mjs` — pulls HubSpot v3 (contacts,
+  deals, tickets) with cursor pagination, writes 3 parquet files.
+  Drives the v_hubspot_funnel and v_lead_to_customer Athena views.
+- `scripts/etl/compute-rfm-churn.mjs` — reads
+  `lake/transactions/transactions.parquet`, computes RFM (Recency,
+  Frequency, Monetary) per email + simple recency-based churn risk,
+  writes `ml-parquet/scores_rfm.parquet` and
+  `ml-parquet/scores_churn.parquet`. Replaces the external ML pipeline
+  whose output was 5+ days stale at the 2026-06-20 audit. Composite
+  RFM score is weighted 30% R + 30% F + 40% M, mapped to a 0-100 scale.
+  Churn bands: low / medium / high / at_risk by days-since-last-purchase.
 - `scripts/etl/portals-to-lake.mjs` — reads `/cloudless/CLIENT_PORTALS_JSON`
   SSM, computes per-portal health score (blocked steps × 25 +
   changes_requested × 10 + open-payments-over-14-days × 20, floored at 0),
   writes parquet.
 - `scripts/etl/clients-to-lake.mjs` — lists Cognito users, joins
   `/cloudless/PENDING_CLIENTS_JSON` (plan info) +
-  `/cloudless/CLIENT_PORTALS_JSON` (portal token) + ML scores from
-  `ml-parquet/scores_rfm.parquet` + `ml-parquet/scores_churn.parquet`,
-  writes unified clients table.
+  `/cloudless/CLIENT_PORTALS_JSON` (portal token) + RFM/churn scores
+  produced by `compute-rfm-churn.mjs` (above) — internally generated
+  now instead of relying on an external pipeline.
 
 ## Output shape (Glue catalog)
 
@@ -51,13 +78,18 @@ no static AWS keys.
 |---|---|---|---|
 | `events` | `s3://cloudless-analytics-data/events/` | NDJSON, Hive-partitioned (year/month/day) | Per-request (Lambda) |
 | `transactions` | `s3://cloudless-analytics-data/lake/transactions/` | Parquet | Daily 03:30 UTC |
+| `hubspot_contacts` | `s3://cloudless-analytics-data/lake/hubspot-contacts/` | Parquet | Daily 03:15 UTC |
+| `hubspot_deals` | `s3://cloudless-analytics-data/lake/hubspot-deals/` | Parquet | Daily 03:15 UTC |
+| `hubspot_tickets` | `s3://cloudless-analytics-data/lake/hubspot-tickets/` | Parquet | Daily 03:15 UTC |
 | `clients` | `s3://cloudless-analytics-data/lake/clients/` | Parquet | Daily 04:00 UTC |
 | `portals` | `s3://cloudless-analytics-data/lake/portals/` | Parquet | Daily 04:00 UTC |
 | `notifications` | `s3://cloudless-analytics-data/lake/notifications/` | Parquet | Per-event (Lambda, via `admin-notifications.ts`) |
 
-Plus 6 Athena views (`v_client_health`, `v_daily_events`, `v_funnel`,
-`v_ltv_ranking`, `v_project_velocity`, `v_revenue_monthly`) that
-project across these tables for the dashboard layer.
+Plus Athena views — 6 pre-existing
+(`v_client_health`, `v_daily_events`, `v_funnel`, `v_ltv_ranking`,
+`v_project_velocity`, `v_revenue_monthly`) and 4 new from this audit
+(`v_acquisition_funnel`, `v_attribution_by_source`, `v_hubspot_funnel`,
+`v_lead_to_customer`) — defined in `docs/analytics-athena.sql`.
 
 ## Health snapshot (2026-06-20)
 

--- a/scripts/etl/compute-rfm-churn.mjs
+++ b/scripts/etl/compute-rfm-churn.mjs
@@ -1,0 +1,222 @@
+/**
+ * ETL: Stripe transactions → RFM + churn scores (Parquet)
+ *
+ * Replaces the external ML pipeline that produced ml-parquet/scores_*.parquet
+ * (files were 5+ days stale as of 2026-06-20 audit, producer not in this repo).
+ * Internal compute is deterministic and cheap:
+ *   - Recency: days since last paid transaction
+ *   - Frequency: count of paid transactions in last 365 days
+ *   - Monetary: sum of paid amount_cents in last 365 days (converted to major units)
+ *   - Composite RFM score: weighted quintile mapping → 0-100
+ *
+ * Churn risk (simple heuristic, no labels needed):
+ *   - 0 days since last purchase     → 0.0
+ *   - 1-30 days                       → 0.1
+ *   - 31-60 days                      → 0.3
+ *   - 61-90 days                      → 0.6
+ *   - 90+ days                        → 1.0
+ *
+ * Reads:  s3://BUCKET/lake/transactions/transactions.parquet (Stripe ETL output)
+ * Writes: s3://BUCKET/ml-parquet/scores_rfm.parquet
+ *         s3://BUCKET/ml-parquet/scores_churn.parquet
+ *
+ * Daily refresh. Sub-second runtime. The downstream consumer is
+ * scripts/etl/clients-to-lake.mjs which joins these scores into the
+ * clients table.
+ */
+
+import { S3Client, PutObjectCommand, GetObjectCommand } from "@aws-sdk/client-s3";
+import { ParquetWriter, ParquetReader, ParquetSchema } from "@dsnp/parquetjs";
+import { readFileSync, unlinkSync, writeFileSync, mkdtempSync, rmSync } from "fs";
+import { join } from "path";
+import { tmpdir } from "os";
+
+const REGION = process.env.AWS_REGION || "us-east-1";
+const BUCKET = process.env.ANALYTICS_BUCKET || "cloudless-analytics-data";
+const s3 = new S3Client({ region: REGION });
+
+const rfmSchema = new ParquetSchema({
+  email: { type: "UTF8" },
+  recency_days: { type: "INT32" },
+  frequency: { type: "INT32" },
+  monetary: { type: "DOUBLE" },
+  rfm_score: { type: "DOUBLE" },
+  last_purchase_at: { type: "UTF8" },
+});
+
+const churnSchema = new ParquetSchema({
+  email: { type: "UTF8" },
+  recency_days: { type: "INT32" },
+  churn_score: { type: "DOUBLE" },
+  risk_band: { type: "UTF8" }, // "low" | "medium" | "high" | "at_risk"
+});
+
+// ---------------------------------------------------------------------------
+// Read transactions parquet from S3
+// ---------------------------------------------------------------------------
+
+async function loadTransactions() {
+  const res = await s3.send(
+    new GetObjectCommand({ Bucket: BUCKET, Key: "lake/transactions/transactions.parquet" })
+  );
+  const buf = Buffer.from(await res.Body.transformToByteArray());
+  const dir = mkdtempSync(join(tmpdir(), "rfm-"));
+  const tmp = join(dir, "data.parquet");
+  writeFileSync(tmp, buf);
+  const reader = await ParquetReader.openFile(tmp);
+  const cursor = reader.getCursor();
+  const rows = [];
+  let row;
+  while ((row = await cursor.next())) rows.push(row);
+  await reader.close();
+  rmSync(dir, { recursive: true, force: true });
+  return rows;
+}
+
+// ---------------------------------------------------------------------------
+// RFM math
+// ---------------------------------------------------------------------------
+
+function quintile(values, v) {
+  // Inverse rank: higher v → higher quintile (5 = top 20%)
+  if (values.length === 0) return 1;
+  const sorted = [...values].sort((a, b) => a - b);
+  const idx = sorted.findIndex((x) => x >= v);
+  const pct = idx < 0 ? 1 : idx / sorted.length;
+  return Math.min(5, Math.floor(pct * 5) + 1);
+}
+
+function recencyQuintile(values, v) {
+  // Reverse for recency: lower days = better, so flip
+  if (values.length === 0) return 1;
+  const sorted = [...values].sort((a, b) => a - b);
+  const idx = sorted.findIndex((x) => x >= v);
+  const pct = idx < 0 ? 1 : idx / sorted.length;
+  // recency: smaller is better, so high pct (high days) = low quintile
+  return 6 - Math.min(5, Math.floor(pct * 5) + 1);
+}
+
+function aggregate(transactions) {
+  // Group by email, only count paid status
+  const now = Date.now();
+  const oneYearAgo = now - 365 * 86400_000;
+  const byEmail = new Map();
+  for (const t of transactions) {
+    if (t.status !== "paid") continue;
+    const email = (t.email || "").toString().toLowerCase().trim();
+    if (!email) continue;
+    const paidAt = t.paid_at || t.created_at;
+    if (!paidAt) continue;
+    const ts = Date.parse(paidAt);
+    if (!Number.isFinite(ts)) continue;
+    const amount = Number(t.amount_cents || 0) / 100;
+    if (!byEmail.has(email)) byEmail.set(email, { lastTs: 0, freq365: 0, mon365: 0 });
+    const cur = byEmail.get(email);
+    if (ts > cur.lastTs) cur.lastTs = ts;
+    if (ts >= oneYearAgo) {
+      cur.freq365 += 1;
+      cur.mon365 += amount;
+    }
+  }
+  return byEmail;
+}
+
+function bandFromChurnScore(s) {
+  if (s >= 0.9) return "at_risk";
+  if (s >= 0.5) return "high";
+  if (s >= 0.2) return "medium";
+  return "low";
+}
+
+function churnFromRecency(daysSinceLastPurchase) {
+  if (daysSinceLastPurchase <= 0) return 0;
+  if (daysSinceLastPurchase <= 30) return 0.1;
+  if (daysSinceLastPurchase <= 60) return 0.3;
+  if (daysSinceLastPurchase <= 90) return 0.6;
+  return 1.0;
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+async function main() {
+  console.log("Loading transactions from lake...");
+  const transactions = await loadTransactions();
+  console.log(`  ${transactions.length} transactions`);
+
+  const aggMap = aggregate(transactions);
+  console.log(`  ${aggMap.size} unique paying customers`);
+
+  if (aggMap.size === 0) {
+    console.log("No paying customers yet — writing empty score files for downstream consistency.");
+  }
+
+  const now = Date.now();
+  const allRecency = [];
+  const allFreq = [];
+  const allMon = [];
+  const records = [];
+
+  for (const [email, agg] of aggMap) {
+    const recencyDays = Math.floor((now - agg.lastTs) / 86400_000);
+    allRecency.push(recencyDays);
+    allFreq.push(agg.freq365);
+    allMon.push(agg.mon365);
+    records.push({ email, recencyDays, freq: agg.freq365, mon: agg.mon365, lastTs: agg.lastTs });
+  }
+
+  // Compute composite RFM score per customer (0-100):
+  // weighted 30% R, 30% F, 40% M; each quintile maps to 20 points.
+  const rfmWriter = await ParquetWriter.openFile(rfmSchema, "/tmp/scores_rfm.parquet");
+  const churnWriter = await ParquetWriter.openFile(churnSchema, "/tmp/scores_churn.parquet");
+  for (const rec of records) {
+    const rQ = recencyQuintile(allRecency, rec.recencyDays);
+    const fQ = quintile(allFreq, rec.freq);
+    const mQ = quintile(allMon, rec.mon);
+    const rfm = Math.round((rQ * 0.3 + fQ * 0.3 + mQ * 0.4) * 20);
+    const churn = churnFromRecency(rec.recencyDays);
+    await rfmWriter.appendRow({
+      email: rec.email,
+      recency_days: rec.recencyDays,
+      frequency: rec.freq,
+      monetary: rec.mon,
+      rfm_score: rfm,
+      last_purchase_at: new Date(rec.lastTs).toISOString(),
+    });
+    await churnWriter.appendRow({
+      email: rec.email,
+      recency_days: rec.recencyDays,
+      churn_score: churn,
+      risk_band: bandFromChurnScore(churn),
+    });
+  }
+  await rfmWriter.close();
+  await churnWriter.close();
+
+  await s3.send(
+    new PutObjectCommand({
+      Bucket: BUCKET,
+      Key: "ml-parquet/scores_rfm.parquet",
+      Body: readFileSync("/tmp/scores_rfm.parquet"),
+      ContentType: "application/octet-stream",
+    })
+  );
+  await s3.send(
+    new PutObjectCommand({
+      Bucket: BUCKET,
+      Key: "ml-parquet/scores_churn.parquet",
+      Body: readFileSync("/tmp/scores_churn.parquet"),
+      ContentType: "application/octet-stream",
+    })
+  );
+  unlinkSync("/tmp/scores_rfm.parquet");
+  unlinkSync("/tmp/scores_churn.parquet");
+
+  console.log(`✅ Wrote scores for ${records.length} customers → s3://${BUCKET}/ml-parquet/`);
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/scripts/etl/hubspot-to-lake.mjs
+++ b/scripts/etl/hubspot-to-lake.mjs
@@ -1,0 +1,195 @@
+/**
+ * ETL: HubSpot CRM → S3 Data Lake (Parquet)
+ *
+ * Pulls all contacts + deals + tickets from HubSpot via the v3 API,
+ * writes three parquet files for Athena:
+ *   - lake/hubspot-contacts/contacts.parquet
+ *   - lake/hubspot-deals/deals.parquet
+ *   - lake/hubspot-tickets/tickets.parquet
+ *
+ * Auth: HUBSPOT_API_KEY env (GH secret in CI). Same scope the app uses.
+ * Runs daily via .github/workflows/etl-hubspot-to-lake.yml.
+ * Full refresh — overwrites the parquet each run. At our volume (≤ a few
+ * thousand contacts) the file is well under 1 MB and the run takes < 1 min.
+ */
+
+import { S3Client, PutObjectCommand } from "@aws-sdk/client-s3";
+import { ParquetWriter, ParquetSchema } from "@dsnp/parquetjs";
+import { readFileSync, unlinkSync } from "fs";
+
+const HUBSPOT_API = "https://api.hubapi.com";
+const PAGE_SIZE = 100;
+
+const REGION = process.env.AWS_REGION || "us-east-1";
+const BUCKET = process.env.ANALYTICS_BUCKET || "cloudless-analytics-data";
+const TOKEN = process.env.HUBSPOT_API_KEY;
+
+if (!TOKEN) {
+  console.error("HUBSPOT_API_KEY not set");
+  process.exit(1);
+}
+
+const s3 = new S3Client({ region: REGION });
+
+// ---------------------------------------------------------------------------
+// Schemas — flat, typed, matched to Athena/Glue expectations
+// ---------------------------------------------------------------------------
+
+const contactSchema = new ParquetSchema({
+  contact_id: { type: "UTF8" },
+  email: { type: "UTF8", optional: true },
+  firstname: { type: "UTF8", optional: true },
+  lastname: { type: "UTF8", optional: true },
+  company: { type: "UTF8", optional: true },
+  phone: { type: "UTF8", optional: true },
+  lifecyclestage: { type: "UTF8", optional: true },
+  lead_status: { type: "UTF8", optional: true },
+  lead_source: { type: "UTF8", optional: true },
+  service_interest: { type: "UTF8", optional: true },
+  country: { type: "UTF8", optional: true },
+  createdate: { type: "UTF8", optional: true },
+  lastmodifieddate: { type: "UTF8", optional: true },
+});
+
+const dealSchema = new ParquetSchema({
+  deal_id: { type: "UTF8" },
+  dealname: { type: "UTF8", optional: true },
+  amount: { type: "DOUBLE", optional: true },
+  currency: { type: "UTF8", optional: true },
+  dealstage: { type: "UTF8", optional: true },
+  pipeline: { type: "UTF8", optional: true },
+  closedate: { type: "UTF8", optional: true },
+  createdate: { type: "UTF8", optional: true },
+  hubspot_owner_id: { type: "UTF8", optional: true },
+});
+
+const ticketSchema = new ParquetSchema({
+  ticket_id: { type: "UTF8" },
+  subject: { type: "UTF8", optional: true },
+  content: { type: "UTF8", optional: true },
+  hs_pipeline: { type: "UTF8", optional: true },
+  hs_pipeline_stage: { type: "UTF8", optional: true },
+  hs_ticket_priority: { type: "UTF8", optional: true },
+  createdate: { type: "UTF8", optional: true },
+  hs_lastmodifieddate: { type: "UTF8", optional: true },
+});
+
+// ---------------------------------------------------------------------------
+// HubSpot client — cursor pagination per HubSpot v3 spec
+// ---------------------------------------------------------------------------
+
+async function hubspotListAll(path, propertyList) {
+  const props = propertyList.join(",");
+  const results = [];
+  let after;
+  do {
+    const sep = path.includes("?") ? "&" : "?";
+    const url =
+      `${HUBSPOT_API}${path}${sep}limit=${PAGE_SIZE}&properties=${props}` +
+      (after ? `&after=${encodeURIComponent(after)}` : "");
+    const res = await fetch(url, { headers: { Authorization: `Bearer ${TOKEN}` } });
+    if (!res.ok) {
+      const body = await res.text().catch(() => "");
+      throw new Error(`HubSpot ${res.status} on ${path}: ${body.slice(0, 200)}`);
+    }
+    const data = await res.json();
+    for (const r of data.results || []) results.push(r);
+    after = data.paging?.next?.after;
+  } while (after);
+  return results;
+}
+
+// ---------------------------------------------------------------------------
+// Sink helpers
+// ---------------------------------------------------------------------------
+
+async function writeParquet(schema, rows, tmpPath, s3Key) {
+  const writer = await ParquetWriter.openFile(schema, tmpPath);
+  for (const r of rows) await writer.appendRow(r);
+  await writer.close();
+  const body = readFileSync(tmpPath);
+  await s3.send(
+    new PutObjectCommand({
+      Bucket: BUCKET,
+      Key: s3Key,
+      Body: body,
+      ContentType: "application/octet-stream",
+    })
+  );
+  unlinkSync(tmpPath);
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+async function main() {
+  console.log("Fetching HubSpot contacts...");
+  const rawContacts = await hubspotListAll("/crm/v3/objects/contacts", [
+    "email", "firstname", "lastname", "company", "phone",
+    "lifecyclestage", "hs_lead_status", "lead_source", "service_interest",
+    "country", "createdate", "lastmodifieddate",
+  ]);
+  const contacts = rawContacts.map((c) => ({
+    contact_id: c.id,
+    email: c.properties?.email || null,
+    firstname: c.properties?.firstname || null,
+    lastname: c.properties?.lastname || null,
+    company: c.properties?.company || null,
+    phone: c.properties?.phone || null,
+    lifecyclestage: c.properties?.lifecyclestage || null,
+    lead_status: c.properties?.hs_lead_status || null,
+    lead_source: c.properties?.lead_source || null,
+    service_interest: c.properties?.service_interest || null,
+    country: c.properties?.country || null,
+    createdate: c.properties?.createdate || null,
+    lastmodifieddate: c.properties?.lastmodifieddate || null,
+  }));
+  console.log(`  ${contacts.length} contacts`);
+
+  console.log("Fetching HubSpot deals...");
+  const rawDeals = await hubspotListAll("/crm/v3/objects/deals", [
+    "dealname", "amount", "deal_currency_code", "dealstage", "pipeline",
+    "closedate", "createdate", "hubspot_owner_id",
+  ]);
+  const deals = rawDeals.map((d) => ({
+    deal_id: d.id,
+    dealname: d.properties?.dealname || null,
+    amount: d.properties?.amount ? Number(d.properties.amount) : null,
+    currency: d.properties?.deal_currency_code || null,
+    dealstage: d.properties?.dealstage || null,
+    pipeline: d.properties?.pipeline || null,
+    closedate: d.properties?.closedate || null,
+    createdate: d.properties?.createdate || null,
+    hubspot_owner_id: d.properties?.hubspot_owner_id || null,
+  }));
+  console.log(`  ${deals.length} deals`);
+
+  console.log("Fetching HubSpot tickets...");
+  const rawTickets = await hubspotListAll("/crm/v3/objects/tickets", [
+    "subject", "content", "hs_pipeline", "hs_pipeline_stage",
+    "hs_ticket_priority", "createdate", "hs_lastmodifieddate",
+  ]);
+  const tickets = rawTickets.map((t) => ({
+    ticket_id: t.id,
+    subject: t.properties?.subject || null,
+    content: t.properties?.content || null,
+    hs_pipeline: t.properties?.hs_pipeline || null,
+    hs_pipeline_stage: t.properties?.hs_pipeline_stage || null,
+    hs_ticket_priority: t.properties?.hs_ticket_priority || null,
+    createdate: t.properties?.createdate || null,
+    hs_lastmodifieddate: t.properties?.hs_lastmodifieddate || null,
+  }));
+  console.log(`  ${tickets.length} tickets`);
+
+  await writeParquet(contactSchema, contacts, "/tmp/hubspot-contacts.parquet", "lake/hubspot-contacts/contacts.parquet");
+  await writeParquet(dealSchema, deals, "/tmp/hubspot-deals.parquet", "lake/hubspot-deals/deals.parquet");
+  await writeParquet(ticketSchema, tickets, "/tmp/hubspot-tickets.parquet", "lake/hubspot-tickets/tickets.parquet");
+
+  console.log(`✅ Uploaded ${contacts.length} contacts + ${deals.length} deals + ${tickets.length} tickets to s3://${BUCKET}/lake/hubspot-*/`);
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});


### PR DESCRIPTION
Closes deferred ETL items + expands coverage for full-funnel insight.

## 2 new ETLs

**etl-hubspot-to-lake** (cron 03:15 UTC) — HubSpot v3 contacts + deals + tickets → lake/hubspot-{contacts,deals,tickets}/. Cursor pagination, full refresh.

**etl-compute-rfm-churn** (cron 03:45 UTC) — Reads Stripe transactions parquet, computes per-customer RFM + recency-based churn risk → ml-parquet/scores_{rfm,churn}.parquet. **Replaces the broken external ML pipeline** whose output was 5+ days stale at audit. Composite RFM = 30% R + 30% F + 40% M → 0-100 scale.

## Daily ordering (UTC)


## Slack failure notifications on ALL 5 ETL workflows
if: failure() && env.SLACK_WEBHOOK_URL !=  curls SLACK_WEBHOOK_URL with run URL. Posts to #errors.

## 4 new Athena views (in docs/analytics-athena.sql)

| View | Use |
|---|---|
| v_acquisition_funnel | daily sessions → signups → purchasers from events |
| v_attribution_by_source | UTM source/medium/campaign → conversions + revenue (90d) |
| v_hubspot_funnel | HubSpot lifecycle × lead_source → closed-won deals |
| v_lead_to_customer | HubSpot contact → Cognito client → RFM/churn (email join) |

Plus DDL for the 3 new hubspot_* Glue tables.

## Verified
- pnpm typecheck clean
- pnpm lint 0/0
- New workflows activate on next cron (or workflow_dispatch)
- Athena views need one-time CREATE OR REPLACE from docs/analytics-athena.sql