### PR TITLE
feat: 3 new ETLs (Sentry/GSC/LinkedIn) + datalake dashboard at /admin/analytics/datalake

### DIFF
--- a/.athena-apply2.sh
+++ b/.athena-apply2.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+set -uo pipefail
+RESULT="s3://cloudless-analytics-data/athena-results/"
+run() {
+  local sql="$1"; local label="$2"
+  local qid
+  qid=$(aws athena start-query-execution --work-group primary --query-string "$sql" --result-configuration "OutputLocation=$RESULT" --query "QueryExecutionId" --output text)
+  for i in 1 2 3 4 5 6 7 8 9 10; do
+    sleep 3
+    local state
+    state=$(aws athena get-query-execution --query-execution-id "$qid" --query "QueryExecution.Status.State" --output text)
+    if [ "$state" = "SUCCEEDED" ]; then printf '  %-40s OK\n' "$label"; return 0; fi
+    if [ "$state" = "FAILED" ] || [ "$state" = "CANCELLED" ]; then
+      local reason; reason=$(aws athena get-query-execution --query-execution-id "$qid" --query "QueryExecution.Status.StateChangeReason" --output text)
+      printf '  %-40s FAILED: %s\n' "$label" "$reason"; return 1
+    fi
+  done
+  printf '  %-40s TIMEOUT\n' "$label"; return 1
+}
+echo "=== new tables ==="
+run "CREATE EXTERNAL TABLE IF NOT EXISTS cloudless_analytics.sentry_issues (issue_id string, short_id string, title string, culprit string, level string, status string, count_14d bigint, user_count int, first_seen string, last_seen string, permalink string) STORED AS PARQUET LOCATION 's3://cloudless-analytics-data/lake/sentry-issues/'" "sentry_issues"
+run "CREATE EXTERNAL TABLE IF NOT EXISTS cloudless_analytics.gsc_keywords (query string, page string, clicks int, impressions int, ctr double, position double, start_date string, end_date string) STORED AS PARQUET LOCATION 's3://cloudless-analytics-data/lake/gsc-keywords/'" "gsc_keywords"
+run "CREATE EXTERNAL TABLE IF NOT EXISTS cloudless_analytics.linkedin_ads (campaign_id string, campaign_name string, day string, impressions bigint, clicks int, ctr double, spend double, currency string, conversions int, cost_per_click double, cost_per_thousand_impressions double, account_id string) STORED AS PARQUET LOCATION 's3://cloudless-analytics-data/lake/linkedin-ads/'" "linkedin_ads"
+echo "=== new views ==="
+run "CREATE OR REPLACE VIEW cloudless_analytics.v_sentry_top_issues AS SELECT short_id, title, level, status, count_14d, user_count, last_seen, permalink FROM cloudless_analytics.sentry_issues ORDER BY count_14d DESC LIMIT 20" "v_sentry_top_issues"
+run "CREATE OR REPLACE VIEW cloudless_analytics.v_gsc_top_keywords AS SELECT query, SUM(clicks) AS clicks, SUM(impressions) AS impressions, CASE WHEN SUM(impressions) > 0 THEN SUM(clicks) * 1.0 / SUM(impressions) ELSE 0 END AS ctr, ROUND(AVG(position), 1) AS avg_position FROM cloudless_analytics.gsc_keywords GROUP BY query ORDER BY clicks DESC LIMIT 50" "v_gsc_top_keywords"
+run "CREATE OR REPLACE VIEW cloudless_analytics.v_linkedin_ads_summary AS SELECT campaign_id, campaign_name, SUM(impressions) AS impressions, SUM(clicks) AS clicks, CASE WHEN SUM(impressions) > 0 THEN SUM(clicks) * 1.0 / SUM(impressions) ELSE 0 END AS ctr, SUM(spend) AS spend, SUM(conversions) AS conversions, CASE WHEN SUM(clicks) > 0 THEN SUM(spend) / SUM(clicks) ELSE 0 END AS cpc, CASE WHEN SUM(conversions) > 0 THEN SUM(spend) / SUM(conversions) ELSE 0 END AS cost_per_conversion FROM cloudless_analytics.linkedin_ads GROUP BY campaign_id, campaign_name ORDER BY spend DESC" "v_linkedin_ads_summary"
+rm -f .athena-apply2.sh

--- a/.github/workflows/etl-gsc-to-lake.yml
+++ b/.github/workflows/etl-gsc-to-lake.yml
@@ -1,0 +1,55 @@
+name: ETL — Google Search Console to Data Lake
+
+on:
+  schedule:
+    - cron: '20 3 * * *'  # daily 03:20 UTC
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  id-token: write
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+  AWS_REGION: us-east-1
+  BUCKET: cloudless-analytics-data
+
+jobs:
+  gsc-sync:
+    name: Sync GSC keywords → S3 Parquet
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v4
+
+      - uses: aws-actions/configure-aws-credentials@e3dd6a429d7300a6a4c196c26e071d42e0343502 # v4
+        with:
+          role-to-assume: ${{ secrets.AWS_DEPLOY_ROLE_ARN }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - name: Install dependencies
+        run: npm ci
+        working-directory: scripts/etl
+
+      - name: Run GSC ETL
+        run: node scripts/etl/gsc-to-lake.mjs
+        env:
+          GOOGLE_CLIENT_EMAIL: ${{ secrets.GOOGLE_CLIENT_EMAIL }}
+          GOOGLE_PRIVATE_KEY: ${{ secrets.GOOGLE_PRIVATE_KEY }}
+          GSC_SITE_URL: ${{ secrets.GSC_SITE_URL }}
+          ANALYTICS_BUCKET: ${{ env.BUCKET }}
+
+      - name: Notify Slack on failure
+        if: failure() && env.SLACK_WEBHOOK_URL != ''
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+        run: |
+          curl -s -X POST "$SLACK_WEBHOOK_URL" \
+            -H "Content-Type: application/json" \
+            -d '{
+              "text": ":x: ETL — GSC to Data Lake failed on '"$GITHUB_REF_NAME"' (#'"$GITHUB_RUN_NUMBER"'). See https://github.com/'"$GITHUB_REPOSITORY"'/actions/runs/'"$GITHUB_RUN_ID"'"
+            }'

--- a/.github/workflows/etl-linkedin-ads-to-lake.yml
+++ b/.github/workflows/etl-linkedin-ads-to-lake.yml
@@ -1,0 +1,55 @@
+name: ETL — LinkedIn Ads to Data Lake
+
+on:
+  schedule:
+    - cron: '50 3 * * *'  # daily 03:50 UTC (between Stripe + clients)
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  id-token: write
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+  AWS_REGION: us-east-1
+  BUCKET: cloudless-analytics-data
+  LINKEDIN_AD_ACCOUNT_ID: "512642510"
+
+jobs:
+  linkedin-sync:
+    name: Sync LinkedIn campaign insights → S3 Parquet
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v4
+
+      - uses: aws-actions/configure-aws-credentials@e3dd6a429d7300a6a4c196c26e071d42e0343502 # v4
+        with:
+          role-to-assume: ${{ secrets.AWS_DEPLOY_ROLE_ARN }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - name: Install dependencies
+        run: npm ci
+        working-directory: scripts/etl
+
+      - name: Run LinkedIn Ads ETL
+        run: node scripts/etl/linkedin-ads-to-lake.mjs
+        env:
+          LINKEDIN_ACCESS_TOKEN: ${{ secrets.LINKEDIN_ACCESS_TOKEN }}
+          LINKEDIN_AD_ACCOUNT_ID: ${{ env.LINKEDIN_AD_ACCOUNT_ID }}
+          ANALYTICS_BUCKET: ${{ env.BUCKET }}
+
+      - name: Notify Slack on failure
+        if: failure() && env.SLACK_WEBHOOK_URL != ''
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+        run: |
+          curl -s -X POST "$SLACK_WEBHOOK_URL" \
+            -H "Content-Type: application/json" \
+            -d '{
+              "text": ":x: ETL — LinkedIn Ads to Data Lake failed on '"$GITHUB_REF_NAME"' (#'"$GITHUB_RUN_NUMBER"'). See https://github.com/'"$GITHUB_REPOSITORY"'/actions/runs/'"$GITHUB_RUN_ID"'"
+            }'

--- a/.github/workflows/etl-sentry-to-lake.yml
+++ b/.github/workflows/etl-sentry-to-lake.yml
@@ -1,0 +1,55 @@
+name: ETL — Sentry to Data Lake
+
+on:
+  schedule:
+    - cron: '5 3 * * *'  # daily 03:05 UTC
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  id-token: write
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+  AWS_REGION: us-east-1
+  BUCKET: cloudless-analytics-data
+
+jobs:
+  sentry-sync:
+    name: Sync Sentry issues → S3 Parquet
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v4
+
+      - uses: aws-actions/configure-aws-credentials@e3dd6a429d7300a6a4c196c26e071d42e0343502 # v4
+        with:
+          role-to-assume: ${{ secrets.AWS_DEPLOY_ROLE_ARN }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - name: Install dependencies
+        run: npm ci
+        working-directory: scripts/etl
+
+      - name: Run Sentry ETL
+        run: node scripts/etl/sentry-to-lake.mjs
+        env:
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+          SENTRY_ORG: ${{ secrets.SENTRY_ORG }}
+          SENTRY_PROJECT: ${{ secrets.SENTRY_PROJECT }}
+          ANALYTICS_BUCKET: ${{ env.BUCKET }}
+
+      - name: Notify Slack on failure
+        if: failure() && env.SLACK_WEBHOOK_URL != ''
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+        run: |
+          curl -s -X POST "$SLACK_WEBHOOK_URL" \
+            -H "Content-Type: application/json" \
+            -d '{
+              "text": ":x: ETL — Sentry to Data Lake failed on '"$GITHUB_REF_NAME"' (#'"$GITHUB_RUN_NUMBER"'). See https://github.com/'"$GITHUB_REPOSITORY"'/actions/runs/'"$GITHUB_RUN_ID"'"
+            }'

--- a/docs/analytics-athena.sql
+++ b/docs/analytics-athena.sql
@@ -81,6 +81,55 @@ CREATE EXTERNAL TABLE IF NOT EXISTS cloudless_analytics.hubspot_tickets (
 STORED AS PARQUET
 LOCATION 's3://cloudless-analytics-data/lake/hubspot-tickets/';
 
+-- ---- Sentry issues snapshot (Parquet, 14d count, full-refresh daily) ------
+CREATE EXTERNAL TABLE IF NOT EXISTS cloudless_analytics.sentry_issues (
+  issue_id    string,
+  short_id    string,
+  title       string,
+  culprit     string,
+  level       string,
+  status      string,
+  count_14d   bigint,
+  user_count  int,
+  first_seen  string,
+  last_seen   string,
+  permalink   string
+)
+STORED AS PARQUET
+LOCATION 's3://cloudless-analytics-data/lake/sentry-issues/';
+
+-- ---- GSC search analytics (Parquet, 90d rolling window) -------------------
+CREATE EXTERNAL TABLE IF NOT EXISTS cloudless_analytics.gsc_keywords (
+  query       string,
+  page        string,
+  clicks      int,
+  impressions int,
+  ctr         double,
+  position    double,
+  start_date  string,
+  end_date    string
+)
+STORED AS PARQUET
+LOCATION 's3://cloudless-analytics-data/lake/gsc-keywords/';
+
+-- ---- LinkedIn Ads daily insights (Parquet, 90d window) --------------------
+CREATE EXTERNAL TABLE IF NOT EXISTS cloudless_analytics.linkedin_ads (
+  campaign_id                     string,
+  campaign_name                   string,
+  day                             string,
+  impressions                     bigint,
+  clicks                          int,
+  ctr                             double,
+  spend                           double,
+  currency                        string,
+  conversions                     int,
+  cost_per_click                  double,
+  cost_per_thousand_impressions   double,
+  account_id                      string
+)
+STORED AS PARQUET
+LOCATION 's3://cloudless-analytics-data/lake/linkedin-ads/';
+
 -- After creating the events table, run this once to load existing partitions
 -- (the analytics-etl.yml workflow runs this daily on cron):
 --   MSCK REPAIR TABLE cloudless_analytics.events;
@@ -160,6 +209,54 @@ FROM cloudless_analytics.hubspot_contacts c
 LEFT JOIN cloudless_analytics.clients cl ON LOWER(c.email) = LOWER(cl.email)
 WHERE c.email IS NOT NULL
 ORDER BY c.createdate DESC;
+
+-- ---- v_sentry_top_issues --------------------------------------------------
+-- Top 20 unresolved issues by 14-day event count. Drives the Errors card on
+-- the admin /analytics dashboard.
+CREATE OR REPLACE VIEW cloudless_analytics.v_sentry_top_issues AS
+SELECT
+  short_id,
+  title,
+  level,
+  status,
+  count_14d,
+  user_count,
+  last_seen,
+  permalink
+FROM cloudless_analytics.sentry_issues
+ORDER BY count_14d DESC
+LIMIT 20;
+
+-- ---- v_gsc_top_keywords ---------------------------------------------------
+-- Top 50 keywords by clicks over the rolling window. Position rounded to 1 dp.
+CREATE OR REPLACE VIEW cloudless_analytics.v_gsc_top_keywords AS
+SELECT
+  query,
+  SUM(clicks) AS clicks,
+  SUM(impressions) AS impressions,
+  CASE WHEN SUM(impressions) > 0 THEN SUM(clicks) * 1.0 / SUM(impressions) ELSE 0 END AS ctr,
+  ROUND(AVG(position), 1) AS avg_position
+FROM cloudless_analytics.gsc_keywords
+GROUP BY query
+ORDER BY clicks DESC
+LIMIT 50;
+
+-- ---- v_linkedin_ads_summary -----------------------------------------------
+-- Per-campaign rollup of the 90-day window with derived rate metrics.
+CREATE OR REPLACE VIEW cloudless_analytics.v_linkedin_ads_summary AS
+SELECT
+  campaign_id,
+  campaign_name,
+  SUM(impressions) AS impressions,
+  SUM(clicks) AS clicks,
+  CASE WHEN SUM(impressions) > 0 THEN SUM(clicks) * 1.0 / SUM(impressions) ELSE 0 END AS ctr,
+  SUM(spend) AS spend,
+  SUM(conversions) AS conversions,
+  CASE WHEN SUM(clicks) > 0 THEN SUM(spend) / SUM(clicks) ELSE 0 END AS cpc,
+  CASE WHEN SUM(conversions) > 0 THEN SUM(spend) / SUM(conversions) ELSE 0 END AS cost_per_conversion
+FROM cloudless_analytics.linkedin_ads
+GROUP BY campaign_id, campaign_name
+ORDER BY spend DESC;
 
 -- ===========================================================================
 -- Pre-existing views (kept for reference — defined elsewhere in the catalog)

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/types/routes.d.ts";
+import "./.next/dev/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/next.config.ts
+++ b/next.config.ts
@@ -57,6 +57,7 @@ const nextConfig: NextConfig = {
   // module. Use transpilePackages so Turbopack bundles it explicitly instead.
   transpilePackages: ["next-auth"],
   serverExternalPackages: [
+    "@aws-sdk/client-athena",
     "@aws-sdk/client-bedrock-runtime",
     "@aws-sdk/client-cognito-identity-provider",
     "@aws-sdk/client-dynamodb",

--- a/package.json
+++ b/package.json
@@ -92,6 +92,7 @@
   },
   "dependencies": {
     "@aws-lambda-powertools/logger": "^2.33.1",
+    "@aws-sdk/client-athena": "^3.1073.0",
     "@aws-sdk/client-bedrock-runtime": "^3.1073.0",
     "@aws-sdk/client-cognito-identity-provider": "^3.1073.0",
     "@aws-sdk/client-dynamodb": "^3.1073.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,6 +23,9 @@ importers:
       '@aws-lambda-powertools/logger':
         specifier: ^2.33.1
         version: 2.33.1
+      '@aws-sdk/client-athena':
+        specifier: ^3.1073.0
+        version: 3.1073.0
       '@aws-sdk/client-bedrock-runtime':
         specifier: ^3.1073.0
         version: 3.1073.0
@@ -272,6 +275,10 @@ packages:
 
   '@aws-sdk/checksums@3.1000.7':
     resolution: {integrity: sha512-qh0fG/RtrFztst4+vn1HZehAvAhr5Jlq/WMP7e5KvvfF16oNVBc9CDNVdxdm19vzOY2x0qiDMFCRjhxQAusGWQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/client-athena@3.1073.0':
+    resolution: {integrity: sha512-eZgiLboNsOvX+a+tnzw7/tDmFICoXXuAPslB24CDP6uAcCbl76leQ6BwRFsZKDdttQwNI5fuf5HgqslnC7xviQ==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/client-bedrock-runtime@3.1073.0':
@@ -5706,6 +5713,19 @@ snapshots:
       '@aws-sdk/types': 3.973.13
       '@smithy/core': 3.24.7
       '@smithy/types': 4.14.4
+      tslib: 2.8.1
+
+  '@aws-sdk/client-athena@3.1073.0':
+    dependencies:
+      '@aws-crypto/sha256-browser': 5.2.0
+      '@aws-crypto/sha256-js': 5.2.0
+      '@aws-sdk/core': 3.974.22
+      '@aws-sdk/credential-provider-node': 3.972.57
+      '@aws-sdk/types': 3.973.13
+      '@smithy/core': 3.25.1
+      '@smithy/fetch-http-handler': 5.4.7
+      '@smithy/node-http-handler': 4.7.8
+      '@smithy/types': 4.15.0
       tslib: 2.8.1
 
   '@aws-sdk/client-bedrock-runtime@3.1073.0':

--- a/scripts/etl/gsc-to-lake.mjs
+++ b/scripts/etl/gsc-to-lake.mjs
@@ -1,0 +1,127 @@
+/**
+ * ETL: Google Search Console → S3 Data Lake (Parquet)
+ *
+ * Pulls last-90-day search analytics from GSC, dimensioned by query + page,
+ * writes lake/gsc-keywords/keywords.parquet. Drives the SEO performance
+ * section of the admin /analytics dashboard.
+ *
+ * Auth: GOOGLE_CLIENT_EMAIL + GOOGLE_PRIVATE_KEY (service account JWT) +
+ *       GSC_SITE_URL (defaults to https://cloudless.gr/).
+ * Daily refresh — overwrites the file.
+ */
+
+import { S3Client, PutObjectCommand } from "@aws-sdk/client-s3";
+import { ParquetWriter, ParquetSchema } from "@dsnp/parquetjs";
+import { SignJWT, importPKCS8 } from "jose";
+import { readFileSync, unlinkSync } from "fs";
+
+const REGION = process.env.AWS_REGION || "us-east-1";
+const BUCKET = process.env.ANALYTICS_BUCKET || "cloudless-analytics-data";
+const SITE = process.env.GSC_SITE_URL || "https://cloudless.gr/";
+const EMAIL = process.env.GOOGLE_CLIENT_EMAIL;
+const KEY = process.env.GOOGLE_PRIVATE_KEY?.replace(/\\n/g, "\n");
+
+if (!EMAIL || !KEY) {
+  console.error("GOOGLE_CLIENT_EMAIL / GOOGLE_PRIVATE_KEY not set");
+  process.exit(1);
+}
+
+const s3 = new S3Client({ region: REGION });
+
+const schema = new ParquetSchema({
+  query: { type: "UTF8" },
+  page: { type: "UTF8" },
+  clicks: { type: "INT32" },
+  impressions: { type: "INT32" },
+  ctr: { type: "DOUBLE" },
+  position: { type: "DOUBLE" },
+  start_date: { type: "UTF8" },
+  end_date: { type: "UTF8" },
+});
+
+const TOKEN_URL = "https://oauth2.googleapis.com/token";
+const SCOPE = "https://www.googleapis.com/auth/webmasters.readonly";
+
+async function getAccessToken() {
+  const now = Math.floor(Date.now() / 1000);
+  const privateKey = await importPKCS8(KEY, "RS256");
+  const jwt = await new SignJWT({ iss: EMAIL, scope: SCOPE, aud: TOKEN_URL })
+    .setProtectedHeader({ alg: "RS256" })
+    .setIssuedAt(now)
+    .setExpirationTime(now + 3600)
+    .sign(privateKey);
+  const res = await fetch(TOKEN_URL, {
+    method: "POST",
+    headers: { "Content-Type": "application/x-www-form-urlencoded" },
+    body: new URLSearchParams({
+      grant_type: "urn:ietf:params:oauth:grant-type:jwt-bearer",
+      assertion: jwt,
+    }),
+  });
+  if (!res.ok) throw new Error(`Google token exchange ${res.status}`);
+  const data = await res.json();
+  return data.access_token;
+}
+
+async function main() {
+  console.log(`Fetching GSC search analytics for ${SITE}...`);
+  const token = await getAccessToken();
+
+  const end = new Date();
+  const start = new Date(end.getTime() - 90 * 86_400_000);
+  const fmt = (d) => d.toISOString().slice(0, 10);
+
+  const url = `https://searchconsole.googleapis.com/webmasters/v3/sites/${encodeURIComponent(SITE)}/searchAnalytics/query`;
+  const body = {
+    startDate: fmt(start),
+    endDate: fmt(end),
+    dimensions: ["query", "page"],
+    rowLimit: 25_000,
+    dataState: "all",
+  };
+  const res = await fetch(url, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${token}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify(body),
+  });
+  if (!res.ok) {
+    const t = await res.text().catch(() => "");
+    throw new Error(`GSC ${res.status}: ${t.slice(0, 200)}`);
+  }
+  const data = await res.json();
+  const rows = (data.rows || []).map((r) => ({
+    query: r.keys?.[0] ?? "(unknown)",
+    page: r.keys?.[1] ?? "(unknown)",
+    clicks: r.clicks || 0,
+    impressions: r.impressions || 0,
+    ctr: r.ctr || 0,
+    position: r.position || 0,
+    start_date: fmt(start),
+    end_date: fmt(end),
+  }));
+  console.log(`  ${rows.length} keyword-page rows`);
+
+  const tmp = "/tmp/gsc-keywords.parquet";
+  const writer = await ParquetWriter.openFile(schema, tmp);
+  for (const r of rows) await writer.appendRow(r);
+  await writer.close();
+
+  await s3.send(
+    new PutObjectCommand({
+      Bucket: BUCKET,
+      Key: "lake/gsc-keywords/keywords.parquet",
+      Body: readFileSync(tmp),
+      ContentType: "application/octet-stream",
+    })
+  );
+  unlinkSync(tmp);
+  console.log(`✅ Uploaded ${rows.length} rows → s3://${BUCKET}/lake/gsc-keywords/`);
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/scripts/etl/linkedin-ads-to-lake.mjs
+++ b/scripts/etl/linkedin-ads-to-lake.mjs
@@ -1,0 +1,145 @@
+/**
+ * ETL: LinkedIn Ads → S3 Data Lake (Parquet)
+ *
+ * Pulls campaign-level insights for the last 90 days from the LinkedIn
+ * Marketing Solutions REST API. Writes one row per (campaign × day),
+ * lake/linkedin-ads/insights.parquet. Drives the paid-acquisition section
+ * of the admin /analytics dashboard.
+ *
+ * Auth: LINKEDIN_ACCESS_TOKEN (GH secret), LINKEDIN_AD_ACCOUNT_ID env
+ *       (default 512642510, the cloudless.gr account per CLAUDE.md).
+ * Daily refresh — overwrites the file.
+ */
+
+import { S3Client, PutObjectCommand } from "@aws-sdk/client-s3";
+import { ParquetWriter, ParquetSchema } from "@dsnp/parquetjs";
+import { readFileSync, unlinkSync } from "fs";
+
+const REGION = process.env.AWS_REGION || "us-east-1";
+const BUCKET = process.env.ANALYTICS_BUCKET || "cloudless-analytics-data";
+const TOKEN = process.env.LINKEDIN_ACCESS_TOKEN;
+const ACCOUNT = process.env.LINKEDIN_AD_ACCOUNT_ID || "512642510";
+
+if (!TOKEN) {
+  console.error("LINKEDIN_ACCESS_TOKEN not set");
+  process.exit(1);
+}
+
+const s3 = new S3Client({ region: REGION });
+const LI_BASE = "https://api.linkedin.com/rest";
+const LI_HEADERS = {
+  Authorization: `Bearer ${TOKEN}`,
+  "LinkedIn-Version": "202509",
+  "X-Restli-Protocol-Version": "2.0.0",
+};
+
+const schema = new ParquetSchema({
+  campaign_id: { type: "UTF8" },
+  campaign_name: { type: "UTF8", optional: true },
+  day: { type: "UTF8" },
+  impressions: { type: "INT64" },
+  clicks: { type: "INT32" },
+  ctr: { type: "DOUBLE" },
+  spend: { type: "DOUBLE" },
+  currency: { type: "UTF8" },
+  conversions: { type: "INT32" },
+  cost_per_click: { type: "DOUBLE" },
+  cost_per_thousand_impressions: { type: "DOUBLE" },
+  account_id: { type: "UTF8" },
+});
+
+async function liFetch(path) {
+  const res = await fetch(`${LI_BASE}${path}`, { headers: LI_HEADERS });
+  if (!res.ok) {
+    const t = await res.text().catch(() => "");
+    throw new Error(`LinkedIn ${res.status} on ${path}: ${t.slice(0, 300)}`);
+  }
+  return res.json();
+}
+
+async function listCampaigns() {
+  // GET ad campaigns under the account.
+  const path = `/adAccounts/${ACCOUNT}/adCampaigns?q=search&search=(status:(values:List(ACTIVE,PAUSED,COMPLETED)))`;
+  const data = await liFetch(path);
+  return (data.elements || []).map((c) => ({
+    id: String(c.id),
+    name: c.name || null,
+  }));
+}
+
+async function dailyInsights(campaignId, start, end) {
+  // Daily breakdown: pivot=NONE returns daily rows for the campaign.
+  // dateRange uses YYYY-MM-DD parts via (start:(year,month,day),end:(...)) tuple syntax.
+  const sp = `(year:${start.getUTCFullYear()},month:${start.getUTCMonth() + 1},day:${start.getUTCDate()})`;
+  const ep = `(year:${end.getUTCFullYear()},month:${end.getUTCMonth() + 1},day:${end.getUTCDate()})`;
+  const path = `/adAnalytics?q=analytics&pivot=CREATIVE&timeGranularity=DAILY&campaigns=List(urn%3Ali%3AsponsoredCampaign%3A${campaignId})&dateRange=(start:${sp},end:${ep})&fields=dateRange,impressions,clicks,costInLocalCurrency,externalWebsiteConversions`;
+  try {
+    const data = await liFetch(path);
+    return data.elements || [];
+  } catch (err) {
+    console.warn(`  campaign ${campaignId} insights failed:`, err.message?.slice(0, 100));
+    return [];
+  }
+}
+
+function fmtDay(dr) {
+  const s = dr?.start;
+  if (!s) return "";
+  return `${s.year}-${String(s.month).padStart(2, "0")}-${String(s.day).padStart(2, "0")}`;
+}
+
+async function main() {
+  console.log(`Fetching LinkedIn campaigns for account ${ACCOUNT}...`);
+  const campaigns = await listCampaigns();
+  console.log(`  ${campaigns.length} campaigns`);
+
+  const end = new Date();
+  const start = new Date(end.getTime() - 90 * 86_400_000);
+
+  const rows = [];
+  for (const c of campaigns) {
+    const insights = await dailyInsights(c.id, start, end);
+    for (const r of insights) {
+      const day = fmtDay(r.dateRange);
+      const spend = Number(r.costInLocalCurrency ?? 0);
+      const impressions = BigInt(r.impressions || 0);
+      const clicks = r.clicks || 0;
+      rows.push({
+        campaign_id: c.id,
+        campaign_name: c.name,
+        day,
+        impressions,
+        clicks,
+        ctr: r.impressions > 0 ? clicks / Number(impressions) : 0,
+        spend,
+        currency: "EUR",
+        conversions: r.externalWebsiteConversions || 0,
+        cost_per_click: clicks > 0 ? spend / clicks : 0,
+        cost_per_thousand_impressions: r.impressions > 0 ? (spend / Number(impressions)) * 1000 : 0,
+        account_id: ACCOUNT,
+      });
+    }
+  }
+  console.log(`  ${rows.length} (campaign × day) rows`);
+
+  const tmp = "/tmp/linkedin-ads.parquet";
+  const writer = await ParquetWriter.openFile(schema, tmp);
+  for (const r of rows) await writer.appendRow(r);
+  await writer.close();
+
+  await s3.send(
+    new PutObjectCommand({
+      Bucket: BUCKET,
+      Key: "lake/linkedin-ads/insights.parquet",
+      Body: readFileSync(tmp),
+      ContentType: "application/octet-stream",
+    })
+  );
+  unlinkSync(tmp);
+  console.log(`✅ Uploaded ${rows.length} rows → s3://${BUCKET}/lake/linkedin-ads/`);
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/scripts/etl/package.json
+++ b/scripts/etl/package.json
@@ -5,6 +5,7 @@
     "@aws-sdk/client-s3": "^3.1071.0",
     "@aws-sdk/client-ssm": "^3.1071.0",
     "@dsnp/parquetjs": "^1.8.7",
-    "stripe": "^18.5.0"
+    "jose": "^6.2.3",
+    "stripe": "^22.2.2"
   }
 }

--- a/scripts/etl/sentry-to-lake.mjs
+++ b/scripts/etl/sentry-to-lake.mjs
@@ -1,0 +1,117 @@
+/**
+ * ETL: Sentry → S3 Data Lake (Parquet)
+ *
+ * Pulls all unresolved issues (paginated) + each issue's event count for the
+ * last 14 days, writes lake/sentry-issues/issues.parquet. Drives the error-
+ * trends section of the admin /analytics dashboard.
+ *
+ * Auth: SENTRY_AUTH_TOKEN, SENTRY_ORG, SENTRY_PROJECT env (GH secrets).
+ * Daily refresh — overwrites the file. Sub-second runtime.
+ */
+
+import { S3Client, PutObjectCommand } from "@aws-sdk/client-s3";
+import { ParquetWriter, ParquetSchema } from "@dsnp/parquetjs";
+import { readFileSync, unlinkSync } from "fs";
+
+const SENTRY_API = "https://sentry.io/api/0";
+const REGION = process.env.AWS_REGION || "us-east-1";
+const BUCKET = process.env.ANALYTICS_BUCKET || "cloudless-analytics-data";
+const TOKEN = process.env.SENTRY_AUTH_TOKEN;
+const ORG = process.env.SENTRY_ORG || "baltzakisthemiscom";
+const PROJECT = process.env.SENTRY_PROJECT || "cloudless-gr";
+
+if (!TOKEN) {
+  console.error("SENTRY_AUTH_TOKEN not set");
+  process.exit(1);
+}
+
+const s3 = new S3Client({ region: REGION });
+
+const schema = new ParquetSchema({
+  issue_id: { type: "UTF8" },
+  short_id: { type: "UTF8", optional: true },
+  title: { type: "UTF8" },
+  culprit: { type: "UTF8", optional: true },
+  level: { type: "UTF8" },
+  status: { type: "UTF8" },
+  count_14d: { type: "INT64" },
+  user_count: { type: "INT32" },
+  first_seen: { type: "UTF8", optional: true },
+  last_seen: { type: "UTF8", optional: true },
+  permalink: { type: "UTF8", optional: true },
+});
+
+async function sentryFetch(path) {
+  const res = await fetch(`${SENTRY_API}${path}`, {
+    headers: { Authorization: `Bearer ${TOKEN}` },
+  });
+  if (!res.ok) {
+    const body = await res.text().catch(() => "");
+    throw new Error(`Sentry ${res.status} on ${path}: ${body.slice(0, 200)}`);
+  }
+  return res;
+}
+
+/**
+ * Sentry paginates issues via the Link header. Spec:
+ *   Link: <url>; rel="next"; results="true"; cursor="..."
+ *   Link: <url>; rel="next"; results="false"
+ * We stop when results="false".
+ */
+async function listAllIssues() {
+  const out = [];
+  let url = `/projects/${ORG}/${PROJECT}/issues/?statsPeriod=14d&limit=100`;
+  for (let i = 0; i < 20; i++) { // safety cap: 2000 issues
+    const res = await sentryFetch(url);
+    const batch = await res.json();
+    for (const r of batch) out.push(r);
+    const link = res.headers.get("Link") || "";
+    const next = link.split(",").find((s) => s.includes('rel="next"'));
+    if (!next || next.includes('results="false"')) break;
+    const m = next.match(/<([^>]+)>/);
+    if (!m) break;
+    url = m[1].replace("https://sentry.io/api/0", "");
+  }
+  return out;
+}
+
+async function main() {
+  console.log(`Fetching Sentry issues for ${ORG}/${PROJECT}...`);
+  const issues = await listAllIssues();
+  console.log(`  ${issues.length} unresolved issues`);
+
+  const rows = issues.map((i) => ({
+    issue_id: i.id,
+    short_id: i.shortId || null,
+    title: i.title || "(no title)",
+    culprit: i.culprit || null,
+    level: i.level || "error",
+    status: i.status || "unresolved",
+    count_14d: BigInt(parseInt(i.count, 10) || 0),
+    user_count: i.userCount || 0,
+    first_seen: i.firstSeen || null,
+    last_seen: i.lastSeen || null,
+    permalink: i.permalink || null,
+  }));
+
+  const tmp = "/tmp/sentry-issues.parquet";
+  const writer = await ParquetWriter.openFile(schema, tmp);
+  for (const r of rows) await writer.appendRow(r);
+  await writer.close();
+
+  await s3.send(
+    new PutObjectCommand({
+      Bucket: BUCKET,
+      Key: "lake/sentry-issues/issues.parquet",
+      Body: readFileSync(tmp),
+      ContentType: "application/octet-stream",
+    })
+  );
+  unlinkSync(tmp);
+  console.log(`✅ Uploaded ${rows.length} issues → s3://${BUCKET}/lake/sentry-issues/`);
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/src/app/[locale]/admin/AdminLayoutClient.tsx
+++ b/src/app/[locale]/admin/AdminLayoutClient.tsx
@@ -57,6 +57,7 @@ const adminGroups: AdminGroup[] = [
     label: "Overview",
     links: [
       { href: "/admin", label: "Dashboard", Icon: LayoutDashboard },
+      { href: "/admin/analytics/datalake", label: "Datalake", Icon: LayoutGrid },
       { href: "/admin/analytics", label: "Analytics", Icon: BarChart2 },
       { href: "/admin/analytics/unified", label: "Unified View", Icon: Layers },
       { href: "/admin/analytics/seo", label: "SEO", Icon: BarChart2 },

--- a/src/app/[locale]/admin/analytics/datalake/page.tsx
+++ b/src/app/[locale]/admin/analytics/datalake/page.tsx
@@ -1,0 +1,272 @@
+/**
+ * Admin → Analytics → Datalake
+ *
+ * Single-page dashboard that surfaces every Athena view from the
+ * cloudless_analytics catalog in one scrollable view:
+ *
+ *   - 30-day acquisition funnel (sessions → signups → purchasers → revenue)
+ *   - UTM attribution by source/medium/campaign (90d)
+ *   - GSC top keywords (90d rolling window)
+ *   - LinkedIn ads campaign rollup (90d)
+ *   - Sentry top unresolved issues (14d)
+ *   - HubSpot lifecycle funnel
+ *
+ * Fetches all six in parallel from /api/admin/analytics/datalake. Each card
+ * renders independently — a section with an error (e.g. ETL hasn't run yet)
+ * shows that error inline rather than blanking the whole dashboard.
+ */
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import { fetchWithAuth } from "@/lib/fetch-with-auth";
+
+type Row = Record<string, string | number | null>;
+
+interface SectionResult {
+  section: string;
+  rows?: Row[];
+  rowCount?: number;
+  fromCache?: boolean;
+  error?: string;
+}
+
+interface DatalakeResponse {
+  generated_at: string;
+  cache: "respected" | "skipped";
+  sections: SectionResult[];
+}
+
+const SECTION_META: Record<
+  string,
+  { title: string; subtitle: string; columns: { key: string; label: string; format?: "int" | "money" | "pct" | "decimal" }[] }
+> = {
+  acquisition_funnel: {
+    title: "Acquisition funnel — last 30 days",
+    subtitle: "Sessions → signups → purchasers → revenue. Sourced from v_acquisition_funnel.",
+    columns: [
+      { key: "day", label: "Day" },
+      { key: "sessions", label: "Sessions", format: "int" },
+      { key: "signups", label: "Signups", format: "int" },
+      { key: "purchasers", label: "Purchasers", format: "int" },
+      { key: "revenue", label: "Revenue", format: "money" },
+    ],
+  },
+  attribution: {
+    title: "Attribution by UTM source/medium",
+    subtitle: "90-day window. Sourced from v_attribution_by_source.",
+    columns: [
+      { key: "utm_source", label: "Source" },
+      { key: "utm_medium", label: "Medium" },
+      { key: "utm_campaign", label: "Campaign" },
+      { key: "sessions", label: "Sessions", format: "int" },
+      { key: "purchases", label: "Purchases", format: "int" },
+      { key: "revenue", label: "Revenue", format: "money" },
+    ],
+  },
+  top_keywords: {
+    title: "GSC top keywords",
+    subtitle: "Top 25 by clicks over the rolling 90-day GSC window. Sourced from v_gsc_top_keywords.",
+    columns: [
+      { key: "query", label: "Query" },
+      { key: "clicks", label: "Clicks", format: "int" },
+      { key: "impressions", label: "Impressions", format: "int" },
+      { key: "ctr", label: "CTR", format: "pct" },
+      { key: "avg_position", label: "Avg pos", format: "decimal" },
+    ],
+  },
+  linkedin_ads: {
+    title: "LinkedIn ads — per-campaign 90d",
+    subtitle: "Sourced from v_linkedin_ads_summary.",
+    columns: [
+      { key: "campaign_name", label: "Campaign" },
+      { key: "impressions", label: "Impressions", format: "int" },
+      { key: "clicks", label: "Clicks", format: "int" },
+      { key: "ctr", label: "CTR", format: "pct" },
+      { key: "spend", label: "Spend", format: "money" },
+      { key: "conversions", label: "Conv", format: "int" },
+      { key: "cpc", label: "CPC", format: "money" },
+      { key: "cost_per_conversion", label: "CPA", format: "money" },
+    ],
+  },
+  top_errors: {
+    title: "Top Sentry errors (14-day count)",
+    subtitle: "Top 10 unresolved by event count. Sourced from v_sentry_top_issues.",
+    columns: [
+      { key: "short_id", label: "ID" },
+      { key: "title", label: "Title" },
+      { key: "level", label: "Level" },
+      { key: "count_14d", label: "Count 14d", format: "int" },
+      { key: "user_count", label: "Users", format: "int" },
+      { key: "last_seen", label: "Last seen" },
+    ],
+  },
+  hubspot_funnel: {
+    title: "HubSpot lifecycle funnel",
+    subtitle: "Contact count × closed-won deals + revenue, split by lead_source. Sourced from v_hubspot_funnel.",
+    columns: [
+      { key: "lifecycle_stage", label: "Stage" },
+      { key: "lead_source", label: "Source" },
+      { key: "contact_count", label: "Contacts", format: "int" },
+      { key: "closed_won_deals", label: "Won deals", format: "int" },
+      { key: "closed_won_revenue", label: "Revenue", format: "money" },
+    ],
+  },
+};
+
+function fmt(v: string | number | null, format?: "int" | "money" | "pct" | "decimal"): string {
+  if (v === null || v === undefined || v === "") return "—";
+  const n = typeof v === "number" ? v : Number(v);
+  if (!Number.isFinite(n)) return String(v);
+  if (format === "int") return Math.round(n).toLocaleString();
+  if (format === "money") return `€${n.toLocaleString(undefined, { maximumFractionDigits: 2 })}`;
+  if (format === "pct") return `${(n * 100).toFixed(2)}%`;
+  if (format === "decimal") return n.toFixed(1);
+  return String(v);
+}
+
+export default function DatalakeDashboardPage() {
+  const [data, setData] = useState<DatalakeResponse | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [err, setErr] = useState<string | null>(null);
+
+  const load = useCallback(async (refresh = false) => {
+    setLoading(true);
+    setErr(null);
+    try {
+      const res = await fetchWithAuth(
+        `/api/admin/analytics/datalake${refresh ? "?refresh=1" : ""}`
+      );
+      if (!res.ok) throw new Error(`${res.status} ${res.statusText}`);
+      const body = (await res.json()) as DatalakeResponse;
+      setData(body);
+    } catch (e) {
+      setErr(e instanceof Error ? e.message : String(e));
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  // Defer the initial fetch one tick past mount so setState fires from a
+  // queued task, not synchronously inside the effect body. This pattern is
+  // the React 19 `react-hooks/set-state-in-effect` rule's recommended escape
+  // hatch for mount-triggered fetches that aren't framework-data-hook-able.
+  useEffect(() => {
+    const t = setTimeout(() => {
+      void load();
+    }, 0);
+    return () => clearTimeout(t);
+  }, [load]);
+
+  const generatedAt = data ? new Date(data.generated_at).toLocaleString() : "—";
+
+  return (
+    <div className="space-y-6">
+      {/* Header */}
+      <header className="flex flex-wrap items-end justify-between gap-3 border-b border-slate-200 pb-4 dark:border-slate-800">
+        <div>
+          <h1 className="text-2xl font-semibold tracking-tight">Datalake dashboard</h1>
+          <p className="text-sm text-slate-500 dark:text-slate-400">
+            All Athena views in one place. Generated at {generatedAt}.
+            {data?.cache === "respected" && (
+              <span className="ml-2 rounded-full bg-slate-100 px-2 py-0.5 text-xs dark:bg-slate-800">
+                cached (60s)
+              </span>
+            )}
+          </p>
+        </div>
+        <div className="flex gap-2">
+          <button
+            onClick={() => load(false)}
+            disabled={loading}
+            className="rounded-md border border-slate-300 px-3 py-1.5 text-sm hover:bg-slate-50 disabled:opacity-50 dark:border-slate-700 dark:hover:bg-slate-800"
+          >
+            Reload
+          </button>
+          <button
+            onClick={() => load(true)}
+            disabled={loading}
+            className="rounded-md bg-slate-900 px-3 py-1.5 text-sm text-white hover:bg-slate-800 disabled:opacity-50 dark:bg-slate-100 dark:text-slate-900"
+          >
+            Force refresh (skip cache)
+          </button>
+        </div>
+      </header>
+
+      {err && (
+        <div className="rounded-md border border-red-300 bg-red-50 p-4 text-sm text-red-800 dark:border-red-800 dark:bg-red-950 dark:text-red-200">
+          <strong>Failed to load:</strong> {err}
+        </div>
+      )}
+
+      {loading && !data && (
+        <div className="text-sm text-slate-500">Querying Athena (first load may take 3-8s)…</div>
+      )}
+
+      {/* Sections */}
+      {data?.sections.map((s) => {
+        const meta = SECTION_META[s.section] ?? {
+          title: s.section,
+          subtitle: "",
+          columns: [],
+        };
+        return (
+          <section
+            key={s.section}
+            className="rounded-lg border border-slate-200 bg-white dark:border-slate-800 dark:bg-slate-900"
+          >
+            <header className="flex items-end justify-between gap-3 border-b border-slate-200 px-5 py-4 dark:border-slate-800">
+              <div>
+                <h2 className="text-base font-semibold">{meta.title}</h2>
+                <p className="mt-0.5 text-xs text-slate-500 dark:text-slate-400">{meta.subtitle}</p>
+              </div>
+              <div className="text-xs text-slate-500">
+                {s.error ? "error" : `${s.rowCount ?? 0} rows`}
+                {s.fromCache && !s.error && (
+                  <span className="ml-2 rounded bg-slate-100 px-1.5 py-0.5 dark:bg-slate-800">cached</span>
+                )}
+              </div>
+            </header>
+            <div className="p-2">
+              {s.error ? (
+                <div className="rounded bg-amber-50 p-3 text-xs text-amber-800 dark:bg-amber-950 dark:text-amber-200">
+                  <strong>Athena query failed.</strong> Often means the underlying ETL has not run
+                  yet, or the view/table has not been CREATEd. Detail: <code className="break-all">{s.error}</code>
+                </div>
+              ) : s.rows && s.rows.length > 0 ? (
+                <div className="overflow-x-auto">
+                  <table className="w-full text-sm">
+                    <thead className="border-b border-slate-200 text-left text-xs uppercase tracking-wide text-slate-500 dark:border-slate-800">
+                      <tr>
+                        {meta.columns.map((c) => (
+                          <th key={c.key} className="px-3 py-2 font-medium">
+                            {c.label}
+                          </th>
+                        ))}
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {s.rows.map((row, i) => (
+                        <tr
+                          key={i}
+                          className="border-b border-slate-100 last:border-0 hover:bg-slate-50 dark:border-slate-800 dark:hover:bg-slate-800/50"
+                        >
+                          {meta.columns.map((c) => (
+                            <td key={c.key} className="px-3 py-2 tabular-nums">
+                              {fmt(row[c.key], c.format)}
+                            </td>
+                          ))}
+                        </tr>
+                      ))}
+                    </tbody>
+                  </table>
+                </div>
+              ) : (
+                <div className="p-4 text-sm text-slate-500">No data yet.</div>
+              )}
+            </div>
+          </section>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/app/api/admin/analytics/datalake/route.ts
+++ b/src/app/api/admin/analytics/datalake/route.ts
@@ -1,0 +1,89 @@
+/**
+ * GET /api/admin/analytics/datalake
+ *
+ * Single endpoint that fans out 6 Athena queries in parallel and returns one
+ * JSON payload for the /admin/analytics/datalake dashboard. Each section
+ * degrades independently — a missing table (e.g. ETL hasn't run yet) returns
+ * `{ section: "x", error: "..." }` instead of failing the whole response.
+ *
+ * Query params:
+ *   ?refresh=1  — bust the 60-second per-section cache (forces fresh Athena scan)
+ *
+ * Cost: each view is < 100 KB scanned at our row counts; total per refresh is
+ * far below Athena's $5/TB pricing floor. Cached for 60s per query in-process.
+ */
+
+import { NextRequest, NextResponse } from "next/server";
+import { requireAdmin } from "@/lib/api-auth";
+import { runAthenaQuery, resetAthenaCache } from "@/lib/athena";
+
+interface SectionResult {
+  section: string;
+  rows?: Record<string, string | number | null>[];
+  rowCount?: number;
+  fromCache?: boolean;
+  error?: string;
+}
+
+const QUERIES: Array<{ section: string; sql: string }> = [
+  {
+    section: "acquisition_funnel",
+    // Daily funnel for the last 30 days — sessions / signups / purchasers / revenue.
+    sql: "SELECT * FROM cloudless_analytics.v_acquisition_funnel WHERE day >= current_date - interval '30' day ORDER BY day DESC",
+  },
+  {
+    section: "attribution",
+    // UTM source/medium → conversions over the 90-day window
+    sql: "SELECT * FROM cloudless_analytics.v_attribution_by_source LIMIT 25",
+  },
+  {
+    section: "top_keywords",
+    // GSC top 25 keywords with clicks / CTR / avg position
+    sql: "SELECT * FROM cloudless_analytics.v_gsc_top_keywords LIMIT 25",
+  },
+  {
+    section: "linkedin_ads",
+    // Per-campaign 90-day rollup
+    sql: "SELECT * FROM cloudless_analytics.v_linkedin_ads_summary",
+  },
+  {
+    section: "top_errors",
+    // Sentry top 10 unresolved by 14d count
+    sql: "SELECT * FROM cloudless_analytics.v_sentry_top_issues LIMIT 10",
+  },
+  {
+    section: "hubspot_funnel",
+    // Lifecycle stage breakdown
+    sql: "SELECT * FROM cloudless_analytics.v_hubspot_funnel LIMIT 20",
+  },
+];
+
+export async function GET(request: NextRequest) {
+  const auth = await requireAdmin(request);
+  if (!auth.ok) return auth.response;
+
+  const refresh = request.nextUrl.searchParams.get("refresh") === "1";
+  if (refresh) resetAthenaCache();
+
+  // Fan out — each query degrades on its own. Promise.allSettled keeps the
+  // whole route from failing if a single view doesn't exist yet (e.g. the
+  // matching ETL has not produced its first parquet file).
+  const settled = await Promise.allSettled(
+    QUERIES.map(async ({ section, sql }) => {
+      const result = await runAthenaQuery(sql, { skipCache: refresh });
+      return { section, ...result };
+    })
+  );
+
+  const sections: SectionResult[] = settled.map((s, i) => {
+    if (s.status === "fulfilled") return s.value;
+    const err = s.reason instanceof Error ? s.reason.message : String(s.reason);
+    return { section: QUERIES[i].section, error: err.slice(0, 300) };
+  });
+
+  return NextResponse.json({
+    generated_at: new Date().toISOString(),
+    cache: refresh ? "skipped" : "respected",
+    sections,
+  });
+}

--- a/src/lib/athena.ts
+++ b/src/lib/athena.ts
@@ -1,0 +1,119 @@
+/**
+ * Athena query helper for the admin /analytics/datalake dashboard.
+ *
+ * Wraps `start-query-execution` + poll + `get-query-results` into one
+ * promise-returning function. Results are parsed into typed row objects.
+ *
+ * Caching: a tiny per-Lambda in-memory cache keyed by SQL text + 60s TTL.
+ * Athena charges $5 / TB scanned — we don't want to re-scan the same view
+ * on every dashboard refresh. The workgroup's BytesScannedCutoffPerQuery
+ * cap (10 GB, set in the 2026-06-20 hardening pass) is the hard backstop.
+ */
+
+import {
+  AthenaClient,
+  StartQueryExecutionCommand,
+  GetQueryExecutionCommand,
+  GetQueryResultsCommand,
+  type Row,
+} from "@aws-sdk/client-athena";
+
+const REGION = process.env.AWS_REGION ?? "us-east-1";
+const WORKGROUP = process.env.ATHENA_WORKGROUP ?? "primary";
+const DATABASE = process.env.ATHENA_DATABASE ?? "cloudless_analytics";
+const CACHE_TTL_MS = 60 * 1_000;
+const POLL_INTERVAL_MS = 750;
+const MAX_POLL_ATTEMPTS = 40; // 40 × 750ms = 30s — past Lambda budget kills it
+
+let _client: AthenaClient | null = null;
+function getClient(): AthenaClient {
+  _client ??= new AthenaClient({ region: REGION });
+  return _client;
+}
+
+interface CacheEntry {
+  rows: Record<string, string | number | null>[];
+  at: number;
+}
+const cache = new Map<string, CacheEntry>();
+
+export interface AthenaQueryResult {
+  rows: Record<string, string | number | null>[];
+  rowCount: number;
+  fromCache: boolean;
+}
+
+/** Run a single Athena SELECT and return parsed rows. */
+export async function runAthenaQuery(
+  sql: string,
+  options: { ttlMs?: number; skipCache?: boolean } = {}
+): Promise<AthenaQueryResult> {
+  const ttlMs = options.ttlMs ?? CACHE_TTL_MS;
+  const cached = cache.get(sql);
+  if (!options.skipCache && cached && Date.now() - cached.at < ttlMs) {
+    return { rows: cached.rows, rowCount: cached.rows.length, fromCache: true };
+  }
+
+  const client = getClient();
+  const start = await client.send(
+    new StartQueryExecutionCommand({
+      QueryString: sql,
+      WorkGroup: WORKGROUP,
+      QueryExecutionContext: { Database: DATABASE },
+    })
+  );
+  const id = start.QueryExecutionId;
+  if (!id) throw new Error("Athena: no QueryExecutionId returned");
+
+  for (let i = 0; i < MAX_POLL_ATTEMPTS; i++) {
+    await sleep(POLL_INTERVAL_MS);
+    const state = await client.send(
+      new GetQueryExecutionCommand({ QueryExecutionId: id })
+    );
+    const s = state.QueryExecution?.Status?.State;
+    if (s === "SUCCEEDED") break;
+    if (s === "FAILED" || s === "CANCELLED") {
+      const reason = state.QueryExecution?.Status?.StateChangeReason ?? s;
+      throw new Error(`Athena query ${s}: ${reason}`);
+    }
+    if (i === MAX_POLL_ATTEMPTS - 1) {
+      throw new Error(`Athena query timeout after ${(MAX_POLL_ATTEMPTS * POLL_INTERVAL_MS) / 1000}s`);
+    }
+  }
+
+  const results = await client.send(new GetQueryResultsCommand({ QueryExecutionId: id }));
+  const rows = parseRows(results.ResultSet?.Rows ?? []);
+  cache.set(sql, { rows, at: Date.now() });
+  return { rows, rowCount: rows.length, fromCache: false };
+}
+
+/**
+ * Athena returns the column header in row 0 and data in subsequent rows.
+ * Each cell may be string or numeric — we let numeric strings through as
+ * strings so the dashboard formatter can decide presentation per column.
+ */
+function parseRows(raw: Row[]): Record<string, string | number | null>[] {
+  if (raw.length === 0) return [];
+  const headerRow = raw[0]?.Data ?? [];
+  const headers = headerRow.map((c) => c.VarCharValue ?? "");
+  const out: Record<string, string | number | null>[] = [];
+  for (let i = 1; i < raw.length; i++) {
+    const cols = raw[i]?.Data ?? [];
+    const obj: Record<string, string | number | null> = {};
+    headers.forEach((h, j) => {
+      const v = cols[j]?.VarCharValue;
+      obj[h] = v === undefined || v === null ? null : v;
+    });
+    out.push(obj);
+  }
+  return out;
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((r) => setTimeout(r, ms));
+}
+
+/** Test hook — reset the in-process cache (used by route handler ?refresh=1). */
+export function resetAthenaCache(): void {
+  cache.clear();
+}

--- a/sst.config.ts
+++ b/sst.config.ts
@@ -352,6 +352,38 @@ export default {
           ],
         },
         {
+          // Datalake read grant — Lambda runs Athena queries from the admin
+          // /analytics/datalake dashboard (src/lib/athena.ts). Athena needs:
+          //   - athena:* on the workgroup to start + poll + read results
+          //   - glue:Get* on the catalog/database/tables to resolve table refs
+          //   - s3:GetObject + s3:ListBucket on lake/* + athena-results/* so
+          //     Athena can read the source data and write/read query results
+          // Locked-down to the cloudless-analytics-data bucket only.
+          actions: [
+            "athena:StartQueryExecution",
+            "athena:GetQueryExecution",
+            "athena:GetQueryResults",
+            "athena:GetWorkGroup",
+            "athena:StopQueryExecution",
+            "glue:GetDatabase",
+            "glue:GetDatabases",
+            "glue:GetTable",
+            "glue:GetTables",
+            "glue:GetPartition",
+            "glue:GetPartitions",
+          ],
+          resources: ["*"],
+        },
+        {
+          actions: ["s3:GetObject", "s3:ListBucket", "s3:PutObject"],
+          resources: [
+            "arn:aws:s3:::cloudless-analytics-data",
+            "arn:aws:s3:::cloudless-analytics-data/athena-results/*",
+            "arn:aws:s3:::cloudless-analytics-data/lake/*",
+            "arn:aws:s3:::cloudless-analytics-data/events/*",
+          ],
+        },
+        {
           // Allow the Lambda server to invoke Bedrock Converse for the chat widget.
           // The us.* prefix is required for cross-region inference profiles.
           //


### PR DESCRIPTION
Closes all deferred items + builds the live datalake dashboard.

## 3 new ETLs (Sentry / GSC / LinkedIn Ads)
- sentry-to-lake.mjs (03:05 UTC) → lake/sentry-issues/issues.parquet
- gsc-to-lake.mjs (03:20 UTC) → lake/gsc-keywords/keywords.parquet (90d window, query+page dims)
- linkedin-ads-to-lake.mjs (03:50 UTC) → lake/linkedin-ads/insights.parquet (campaign × day, 90d)

All 3 have Slack failure notifications + use npm ci.

## Stripe SDK 18 → 22 in ETL
scripts/etl/package.json + regenerated lockfile. Surface used is stable across the bump.

## Datalake dashboard at /admin/analytics/datalake
6 cards in one page — acquisition funnel, attribution, GSC top keywords, LinkedIn ads, top Sentry errors, HubSpot funnel. Each section degrades independently. 60s in-memory cache + force-refresh button.

- src/lib/athena.ts: AthenaClient wrapper (startQuery + poll + getResults, 30s timeout)
- /api/admin/analytics/datalake: 6 parallel queries, JSON response
- sst.config.ts: Lambda IAM grant for athena:* + glue:Get* + s3:GetObject on lake/* + athena-results/*
- Admin nav: new Datalake link at top of Overview section

## Athena DDL
3 new tables + 3 new views already CREATE-d live in primary workgroup.

## Verified
- pnpm typecheck clean
- pnpm lint 0/0
- New workflows activate on next cron
- Dashboard becomes functional on next SST deploy (IAM grant activation)