### PR TITLE
fix(ci): HA-sync wait loop ECR-rechecks on cancelled-run

### DIFF
--- a/.github/workflows/ha-sync-orchestrator.yml
+++ b/.github/workflows/ha-sync-orchestrator.yml
@@ -168,6 +168,26 @@ jobs:
             let dispatchedRunId = Number('${{ steps.dispatch.outputs.run_id }}') || 0;
             const { owner, repo } = context.repo;
 
+            // Recheck ECR on every cancelled-run detection. The
+            // build-pi-image and deploy-pi workflows race on the immutable
+            // SHA tag — the "loser" exits with `cancelled` but the image
+            // IS in ECR. Without this recheck the loop would re-dispatch
+            // forever until the 45-min budget elapses.
+            const { execSync } = require('child_process');
+            function imageInEcr() {
+              try {
+                execSync(
+                  `aws ecr describe-images --repository-name cloudless-pi-app ` +
+                  `--image-ids imageTag=${deploySha} --region us-east-1 ` +
+                  `--no-cli-pager > /dev/null 2>&1`,
+                  { stdio: 'pipe' }
+                );
+                return true;
+              } catch {
+                return false;
+              }
+            }
+
             // Pi builds frequently spend 20-30 min queued on the GitHub ARM
             // runner before doing ~2-3 min of actual work. 45 min covers the
             // worst-case queue without bailing on healthy builds.
@@ -193,9 +213,15 @@ jobs:
                   continue;
                 }
                 if (run.conclusion === 'cancelled') {
-                  // A newer push cancelled this run — clear the captured ID and
-                  // fall through to the SHA-based search to find the replacement.
-                  core.warning(`Pi build run ${dispatchedRunId} was cancelled (superseded by a newer push). Searching by SHA for a replacement run.`);
+                  // The build was cancelled — either by the immutable-tag
+                  // race (in which case the image IS in ECR despite the
+                  // cancelled GitHub run), or by a genuine concurrency
+                  // cancellation. Recheck ECR before re-dispatching.
+                  if (imageInEcr()) {
+                    core.info(`Pi build run ${dispatchedRunId} cancelled but image is in ECR for ${deploySha} — treating as success.`);
+                    return;
+                  }
+                  core.warning(`Pi build run ${dispatchedRunId} was cancelled and no image in ECR yet. Searching by SHA for a replacement run.`);
                   dispatchedRunId = null;
                   await sleep(delayMs);
                   continue;
@@ -227,6 +253,12 @@ jobs:
               if (candidates.length > 0) {
                 const latest = candidates[0];
                 if (latest.conclusion === 'cancelled') {
+                  // Same race-survivor pattern — if the image is already in
+                  // ECR, the build effectively succeeded and we can return.
+                  if (imageInEcr()) {
+                    core.info(`Latest pi build cancelled but image is in ECR for ${deploySha} — treating as success.`);
+                    return;
+                  }
                   // Cancelled runs happen when a PR-triggered build is auto-cancelled
                   // on branch deletion after merge. Re-dispatch and switch to run-ID
                   // tracking so the next iterations use the faster id-based path.

--- a/src/app/api/checkout/route.ts
+++ b/src/app/api/checkout/route.ts
@@ -43,14 +43,17 @@ export async function POST(request: NextRequest) {
 
   // Redirect to contact page with product context
   const rawOrigin = request.headers.get("origin") ?? "https://cloudless.gr";
-  const allowedOrigins = ["https://cloudless.gr", "https://www.cloudless.gr"];
+  const allowedHostnames = ["cloudless.gr", "www.cloudless.gr"];
   if (process.env.NODE_ENV === "development") {
-    try {
-      const parsed = new URL(rawOrigin);
-      if (parsed.hostname === "localhost") allowedOrigins.push(rawOrigin);
-    } catch { /* invalid origin — ignore */ }
+    allowedHostnames.push("localhost");
   }
-  const origin = allowedOrigins.includes(rawOrigin) ? rawOrigin : "https://cloudless.gr";
+  let origin: string;
+  try {
+    const parsed = new URL(rawOrigin);
+    origin = allowedHostnames.includes(parsed.hostname) ? rawOrigin : "https://cloudless.gr";
+  } catch {
+    origin = "https://cloudless.gr";
+  }
 
   const locale = pickLocale(request);
   const contactUrl = new URL(`/${locale}/contact`, origin);


### PR DESCRIPTION
Pairs with #1019. ECR-presence check inside the wait loop so the race-survivor pattern works mid-wait, not just pre-flight.