### PR TITLE
style: prettier sweep + datalake dashboard onto v2 tokens

### DIFF
--- a/src/app/[locale]/admin/analytics/datalake/page.tsx
+++ b/src/app/[locale]/admin/analytics/datalake/page.tsx
@@ -38,7 +38,11 @@ interface DatalakeResponse {
 
 const SECTION_META: Record<
   string,
-  { title: string; subtitle: string; columns: { key: string; label: string; format?: "int" | "money" | "pct" | "decimal" }[] }
+  {
+    title: string;
+    subtitle: string;
+    columns: { key: string; label: string; format?: "int" | "money" | "pct" | "decimal" }[];
+  }
 > = {
   acquisition_funnel: {
     title: "Acquisition funnel — last 30 days",
@@ -65,7 +69,8 @@ const SECTION_META: Record<
   },
   top_keywords: {
     title: "GSC top keywords",
-    subtitle: "Top 25 by clicks over the rolling 90-day GSC window. Sourced from v_gsc_top_keywords.",
+    subtitle:
+      "Top 25 by clicks over the rolling 90-day GSC window. Sourced from v_gsc_top_keywords.",
     columns: [
       { key: "query", label: "Query" },
       { key: "clicks", label: "Clicks", format: "int" },
@@ -102,7 +107,8 @@ const SECTION_META: Record<
   },
   hubspot_funnel: {
     title: "HubSpot lifecycle funnel",
-    subtitle: "Contact count × closed-won deals + revenue, split by lead_source. Sourced from v_hubspot_funnel.",
+    subtitle:
+      "Contact count × closed-won deals + revenue, split by lead_source. Sourced from v_hubspot_funnel.",
     columns: [
       { key: "lifecycle_stage", label: "Stage" },
       { key: "lead_source", label: "Source" },
@@ -159,16 +165,32 @@ export default function DatalakeDashboardPage() {
 
   const generatedAt = data ? new Date(data.generated_at).toLocaleString() : "—";
 
+  // All chrome below uses design-system v2 CSS variables
+  // (--surface-raised, --border-subtle, --ink-primary, --ink-muted, --accent,
+  // --danger, --warning, --shadow-sm) defined in src/app/theme-v2.css. /admin
+  // always renders with data-theme="dark" via ThemeProvider; the same tokens
+  // flip cleanly when /admin ever moves to a light variant.
   return (
-    <div className="space-y-6">
+    <div
+      className="space-y-6"
+      style={{
+        color: "var(--ink-primary)",
+      }}
+    >
       {/* Header */}
-      <header className="flex flex-wrap items-end justify-between gap-3 border-b border-slate-200 pb-4 dark:border-slate-800">
+      <header
+        className="flex flex-wrap items-end justify-between gap-3 pb-4"
+        style={{ borderBottom: "1px solid var(--border-subtle)" }}
+      >
         <div>
           <h1 className="text-2xl font-semibold tracking-tight">Datalake dashboard</h1>
-          <p className="text-sm text-slate-500 dark:text-slate-400">
+          <p className="text-sm" style={{ color: "var(--ink-muted)" }}>
             All Athena views in one place. Generated at {generatedAt}.
             {data?.cache === "respected" && (
-              <span className="ml-2 rounded-full bg-slate-100 px-2 py-0.5 text-xs dark:bg-slate-800">
+              <span
+                className="ml-2 rounded-full px-2 py-0.5 text-xs"
+                style={{ background: "var(--surface-subtle)" }}
+              >
                 cached (60s)
               </span>
             )}
@@ -178,14 +200,23 @@ export default function DatalakeDashboardPage() {
           <button
             onClick={() => load(false)}
             disabled={loading}
-            className="rounded-md border border-slate-300 px-3 py-1.5 text-sm hover:bg-slate-50 disabled:opacity-50 dark:border-slate-700 dark:hover:bg-slate-800"
+            className="rounded-md px-3 py-1.5 text-sm disabled:opacity-50"
+            style={{
+              border: "1px solid var(--border-strong)",
+              background: "var(--surface-raised)",
+              color: "var(--ink-primary)",
+            }}
           >
             Reload
           </button>
           <button
             onClick={() => load(true)}
             disabled={loading}
-            className="rounded-md bg-slate-900 px-3 py-1.5 text-sm text-white hover:bg-slate-800 disabled:opacity-50 dark:bg-slate-100 dark:text-slate-900"
+            className="rounded-md px-3 py-1.5 text-sm disabled:opacity-50"
+            style={{
+              background: "var(--accent)",
+              color: "var(--accent-on)",
+            }}
           >
             Force refresh (skip cache)
           </button>
@@ -193,13 +224,22 @@ export default function DatalakeDashboardPage() {
       </header>
 
       {err && (
-        <div className="rounded-md border border-red-300 bg-red-50 p-4 text-sm text-red-800 dark:border-red-800 dark:bg-red-950 dark:text-red-200">
+        <div
+          className="rounded-md p-4 text-sm"
+          style={{
+            border: "1px solid var(--danger)",
+            background: "rgb(192 57 43 / 0.08)",
+            color: "var(--danger)",
+          }}
+        >
           <strong>Failed to load:</strong> {err}
         </div>
       )}
 
       {loading && !data && (
-        <div className="text-sm text-slate-500">Querying Athena (first load may take 3-8s)…</div>
+        <div className="text-sm" style={{ color: "var(--ink-muted)" }}>
+          Querying Athena (first load may take 3-8s)…
+        </div>
       )}
 
       {/* Sections */}
@@ -212,30 +252,58 @@ export default function DatalakeDashboardPage() {
         return (
           <section
             key={s.section}
-            className="rounded-lg border border-slate-200 bg-white dark:border-slate-800 dark:bg-slate-900"
+            className="rounded-lg"
+            style={{
+              border: "1px solid var(--border-subtle)",
+              background: "var(--surface-raised)",
+              boxShadow: "var(--shadow-sm)",
+            }}
           >
-            <header className="flex items-end justify-between gap-3 border-b border-slate-200 px-5 py-4 dark:border-slate-800">
+            <header
+              className="flex items-end justify-between gap-3 px-5 py-4"
+              style={{ borderBottom: "1px solid var(--border-subtle)" }}
+            >
               <div>
                 <h2 className="text-base font-semibold">{meta.title}</h2>
-                <p className="mt-0.5 text-xs text-slate-500 dark:text-slate-400">{meta.subtitle}</p>
+                <p className="mt-0.5 text-xs" style={{ color: "var(--ink-muted)" }}>
+                  {meta.subtitle}
+                </p>
               </div>
-              <div className="text-xs text-slate-500">
+              <div className="text-xs" style={{ color: "var(--ink-muted)" }}>
                 {s.error ? "error" : `${s.rowCount ?? 0} rows`}
                 {s.fromCache && !s.error && (
-                  <span className="ml-2 rounded bg-slate-100 px-1.5 py-0.5 dark:bg-slate-800">cached</span>
+                  <span
+                    className="ml-2 rounded px-1.5 py-0.5"
+                    style={{ background: "var(--surface-subtle)" }}
+                  >
+                    cached
+                  </span>
                 )}
               </div>
             </header>
             <div className="p-2">
               {s.error ? (
-                <div className="rounded bg-amber-50 p-3 text-xs text-amber-800 dark:bg-amber-950 dark:text-amber-200">
+                <div
+                  className="rounded p-3 text-xs"
+                  style={{
+                    background: "rgb(181 110 0 / 0.08)",
+                    color: "var(--warning)",
+                  }}
+                >
                   <strong>Athena query failed.</strong> Often means the underlying ETL has not run
-                  yet, or the view/table has not been CREATEd. Detail: <code className="break-all">{s.error}</code>
+                  yet, or the view/table has not been CREATEd. Detail:{" "}
+                  <code className="break-all">{s.error}</code>
                 </div>
               ) : s.rows && s.rows.length > 0 ? (
                 <div className="overflow-x-auto">
                   <table className="w-full text-sm">
-                    <thead className="border-b border-slate-200 text-left text-xs uppercase tracking-wide text-slate-500 dark:border-slate-800">
+                    <thead
+                      className="text-left text-xs tracking-wide uppercase"
+                      style={{
+                        borderBottom: "1px solid var(--border-subtle)",
+                        color: "var(--ink-muted)",
+                      }}
+                    >
                       <tr>
                         {meta.columns.map((c) => (
                           <th key={c.key} className="px-3 py-2 font-medium">
@@ -248,7 +316,8 @@ export default function DatalakeDashboardPage() {
                       {s.rows.map((row, i) => (
                         <tr
                           key={i}
-                          className="border-b border-slate-100 last:border-0 hover:bg-slate-50 dark:border-slate-800 dark:hover:bg-slate-800/50"
+                          className="last:border-0"
+                          style={{ borderBottom: "1px solid var(--border-subtle)" }}
                         >
                           {meta.columns.map((c) => (
                             <td key={c.key} className="px-3 py-2 tabular-nums">
@@ -261,7 +330,9 @@ export default function DatalakeDashboardPage() {
                   </table>
                 </div>
               ) : (
-                <div className="p-4 text-sm text-slate-500">No data yet.</div>
+                <div className="p-4 text-sm" style={{ color: "var(--ink-muted)" }}>
+                  No data yet.
+                </div>
               )}
             </div>
           </section>

--- a/src/app/[locale]/blog/page.tsx
+++ b/src/app/[locale]/blog/page.tsx
@@ -21,10 +21,14 @@ export async function generateMetadata({
   const { locale } = await params;
   const safeLocale: Locale = isSupportedLocale(locale) ? locale : "en";
   const messages = getMessages(safeLocale);
-  const meta = (messages as Record<string, unknown>).meta as Record<string, Record<string, string>> | undefined;
+  const meta = (messages as Record<string, unknown>).meta as
+    | Record<string, Record<string, string>>
+    | undefined;
   return {
     title: meta?.blog?.title ?? "Blog",
-    description: meta?.blog?.description ?? "Insights on cloud computing, serverless architecture, data analytics, and AI marketing for startups and SMBs.",
+    description:
+      meta?.blog?.description ??
+      "Insights on cloud computing, serverless architecture, data analytics, and AI marketing for startups and SMBs.",
     alternates: {
       canonical: "https://cloudless.gr/blog",
     },

--- a/src/app/[locale]/contact/page.tsx
+++ b/src/app/[locale]/contact/page.tsx
@@ -15,7 +15,9 @@ export async function generateMetadata({
   const { locale } = await params;
   const safeLocale: Locale = isSupportedLocale(locale) ? locale : "en";
   const messages = getMessages(safeLocale);
-  const meta = (messages as Record<string, unknown>).meta as Record<string, Record<string, string>> | undefined;
+  const meta = (messages as Record<string, unknown>).meta as
+    | Record<string, Record<string, string>>
+    | undefined;
   return {
     title: meta?.contact?.title ?? "Contact Us",
     description: meta?.contact?.description,

--- a/src/app/[locale]/page.tsx
+++ b/src/app/[locale]/page.tsx
@@ -50,7 +50,9 @@ export async function generateMetadata({
 
   const safeLocale: Locale = isSupportedLocale(locale) ? locale : "en";
   const messages = getMessages(safeLocale);
-  const meta = (messages as Record<string, unknown>).meta as Record<string, Record<string, string>> | undefined;
+  const meta = (messages as Record<string, unknown>).meta as
+    | Record<string, Record<string, string>>
+    | undefined;
 
   return {
     title: {

--- a/src/app/[locale]/services/page.tsx
+++ b/src/app/[locale]/services/page.tsx
@@ -28,9 +28,13 @@ export async function generateMetadata({
   const { locale } = await params;
   const safeLocale: Locale = isSupportedLocale(locale) ? locale : "en";
   const messages = getMessages(safeLocale);
-  const meta = (messages as Record<string, unknown>).meta as Record<string, Record<string, string>> | undefined;
+  const meta = (messages as Record<string, unknown>).meta as
+    | Record<string, Record<string, string>>
+    | undefined;
   const title = meta?.services?.title ?? "Cloud Consulting & Serverless Services in Greece";
-  const description = meta?.services?.description ?? "Cloud consulting, serverless development, data analytics, and AI-powered digital marketing for startups and SMBs in Greece. No lock-in. Results in 14 days.";
+  const description =
+    meta?.services?.description ??
+    "Cloud consulting, serverless development, data analytics, and AI-powered digital marketing for startups and SMBs in Greece. No lock-in. Results in 14 days.";
 
   return {
     title,
@@ -427,7 +431,9 @@ export default async function ServicesPage() {
                               valueClassName={`font-mono text-xl font-bold ${colors.statValue}`}
                               showLabel={false}
                             />
-                            <div className="mt-1 font-mono text-xs text-slate-500">{stat.label}</div>
+                            <div className="mt-1 font-mono text-xs text-slate-500">
+                              {stat.label}
+                            </div>
                           </div>
                         ))}
                       </div>

--- a/src/app/[locale]/store/page.tsx
+++ b/src/app/[locale]/store/page.tsx
@@ -18,10 +18,14 @@ export async function generateMetadata({
   const { locale } = await params;
   const safeLocale: Locale = isSupportedLocale(locale) ? locale : "en";
   const messages = getMessages(safeLocale);
-  const meta = (messages as Record<string, unknown>).meta as Record<string, Record<string, string>> | undefined;
+  const meta = (messages as Record<string, unknown>).meta as
+    | Record<string, Record<string, string>>
+    | undefined;
   return {
     title: meta?.store?.title ?? "Store",
-    description: meta?.store?.description ?? "Cloud migration playbooks, serverless courses, analytics templates, dev merch, and expert service packages from Cloudless.",
+    description:
+      meta?.store?.description ??
+      "Cloud migration playbooks, serverless courses, analytics templates, dev merch, and expert service packages from Cloudless.",
   };
 }
 

--- a/src/app/api/campaigns/conversion/route.ts
+++ b/src/app/api/campaigns/conversion/route.ts
@@ -82,7 +82,10 @@ export async function POST(request: NextRequest) {
     url: body.url ?? undefined,
     userAgent: body.userAgent ?? undefined,
     country: request.headers.get("cf-ipcountry") ?? undefined,
-    ipAddress: request.headers.get("cf-connecting-ip") ?? request.headers.get("x-forwarded-for")?.split(",")[0]?.trim() ?? undefined,
+    ipAddress:
+      request.headers.get("cf-connecting-ip") ??
+      request.headers.get("x-forwarded-for")?.split(",")[0]?.trim() ??
+      undefined,
     utm: body.utm ?? undefined,
     customer,
   });

--- a/src/app/api/slack/commands/route.ts
+++ b/src/app/api/slack/commands/route.ts
@@ -130,27 +130,47 @@ export async function POST(request: Request): Promise<Response> {
 
     case "/cloudless-seo":
       void runAsyncCommand(payload, buildSeoBlocks);
-      return slackResponse({ response_type: "ephemeral", text: ":hourglass_flowing_sand: Fetching SEO data..." });
+      return slackResponse({
+        response_type: "ephemeral",
+        text: ":hourglass_flowing_sand: Fetching SEO data...",
+      });
 
     case "/cloudless-leads":
       void runAsyncCommand(payload, buildLeadsBlocks);
-      return slackResponse({ response_type: "ephemeral", text: ":hourglass_flowing_sand: Fetching leads..." });
+      return slackResponse({
+        response_type: "ephemeral",
+        text: ":hourglass_flowing_sand: Fetching leads...",
+      });
 
     case "/cloudless-errors":
       void runAsyncCommand(payload, buildErrorsBlocks);
-      return slackResponse({ response_type: "ephemeral", text: ":hourglass_flowing_sand: Fetching errors..." });
+      return slackResponse({
+        response_type: "ephemeral",
+        text: ":hourglass_flowing_sand: Fetching errors...",
+      });
 
     case "/cloudless-uptime":
       void runAsyncCommand(payload, buildUptimeBlocks);
-      return slackResponse({ response_type: "ephemeral", text: ":hourglass_flowing_sand: Pinging endpoints..." });
+      return slackResponse({
+        response_type: "ephemeral",
+        text: ":hourglass_flowing_sand: Pinging endpoints...",
+      });
 
     case "/cloudless-subscribers":
       void runAsyncCommand(payload, buildSubscribersBlocks);
-      return slackResponse({ response_type: "ephemeral", text: ":hourglass_flowing_sand: Fetching subscribers..." });
+      return slackResponse({
+        response_type: "ephemeral",
+        text: ":hourglass_flowing_sand: Fetching subscribers...",
+      });
 
     case "/cloudless-cache":
-      void runAsyncCommand(payload, (userId) => buildCacheFlushBlocks(userId, payload.text.trim() || undefined));
-      return slackResponse({ response_type: "ephemeral", text: ":hourglass_flowing_sand: Flushing cache..." });
+      void runAsyncCommand(payload, (userId) =>
+        buildCacheFlushBlocks(userId, payload.text.trim() || undefined)
+      );
+      return slackResponse({
+        response_type: "ephemeral",
+        text: ":hourglass_flowing_sand: Flushing cache...",
+      });
 
     default:
       return slackResponse({
@@ -923,7 +943,9 @@ function handleAds(payload: SlashCommandPayload): Response {
   const sub = (argv[0] ?? "help").toLowerCase();
 
   // Use the campaign ID from the wired campaign data
-  const campaign = getLiveCampaigns().find((c) => c.adPlatforms?.some((p) => p.platform === "linkedin"));
+  const campaign = getLiveCampaigns().find((c) =>
+    c.adPlatforms?.some((p) => p.platform === "linkedin")
+  );
   const campaignId = campaign?.adPlatforms?.find((p) => p.platform === "linkedin")?.campaignIds[0];
 
   if (!campaignId && sub !== "help") {
@@ -936,23 +958,38 @@ function handleAds(payload: SlashCommandPayload): Response {
   switch (sub) {
     case "status":
       void runAdsStatus(campaignId!, payload.response_url, payload.user_id);
-      return slackResponse({ response_type: "ephemeral", text: ":hourglass_flowing_sand: Fetching campaign status..." });
+      return slackResponse({
+        response_type: "ephemeral",
+        text: ":hourglass_flowing_sand: Fetching campaign status...",
+      });
 
     case "pause":
       void runAdsPause(campaignId!, payload.response_url, payload.user_id);
-      return slackResponse({ response_type: "ephemeral", text: ":hourglass_flowing_sand: Pausing campaign..." });
+      return slackResponse({
+        response_type: "ephemeral",
+        text: ":hourglass_flowing_sand: Pausing campaign...",
+      });
 
     case "resume":
       void runAdsResume(campaignId!, payload.response_url, payload.user_id);
-      return slackResponse({ response_type: "ephemeral", text: ":hourglass_flowing_sand: Resuming campaign..." });
+      return slackResponse({
+        response_type: "ephemeral",
+        text: ":hourglass_flowing_sand: Resuming campaign...",
+      });
 
     case "budget": {
       const amount = parseFloat(argv[1] ?? "");
       if (!amount || amount <= 0) {
-        return slackResponse({ response_type: "ephemeral", text: ":warning: Usage: `/cloudless-ads budget 20` (daily EUR amount)" });
+        return slackResponse({
+          response_type: "ephemeral",
+          text: ":warning: Usage: `/cloudless-ads budget 20` (daily EUR amount)",
+        });
       }
       void runAdsBudget(campaignId!, amount, payload.response_url, payload.user_id);
-      return slackResponse({ response_type: "ephemeral", text: `:hourglass_flowing_sand: Setting daily budget to €${amount}...` });
+      return slackResponse({
+        response_type: "ephemeral",
+        text: `:hourglass_flowing_sand: Setting daily budget to €${amount}...`,
+      });
     }
 
     default:
@@ -979,9 +1016,15 @@ function handleAds(payload: SlashCommandPayload): Response {
   }
 }
 
-async function runAdsStatus(campaignId: string, responseUrl: string, userId: string): Promise<void> {
+async function runAdsStatus(
+  campaignId: string,
+  responseUrl: string,
+  userId: string
+): Promise<void> {
   try {
-    const campaign = getLiveCampaigns().find((c) => c.adPlatforms?.some((p) => p.campaignIds.includes(campaignId)));
+    const campaign = getLiveCampaigns().find((c) =>
+      c.adPlatforms?.some((p) => p.campaignIds.includes(campaignId))
+    );
     const today = new Date().toISOString().split("T")[0];
     const startDate = campaign?.startsAt ?? today;
 
@@ -991,18 +1034,43 @@ async function runAdsStatus(campaignId: string, responseUrl: string, userId: str
       getLinkedInInsights(startDate, today),
     ]);
     if (!info.ok) {
-      await postToResponseUrl(responseUrl, { response_type: "ephemeral", replace_original: true, text: `:warning: ${info.error}` });
+      await postToResponseUrl(responseUrl, {
+        response_type: "ephemeral",
+        replace_original: true,
+        text: `:warning: ${info.error}`,
+      });
       return;
     }
-    const statusIcon = info.status === "ACTIVE" ? ":large_green_circle:" : info.status === "PAUSED" ? ":double_vertical_bar:" : ":white_circle:";
-    const todayCtr = todayInsights.impressions > 0 ? ((todayInsights.clicks / todayInsights.impressions) * 100).toFixed(2) + "%" : "—";
-    const lifetimeCtr = lifetimeInsights.impressions > 0 ? ((lifetimeInsights.clicks / lifetimeInsights.impressions) * 100).toFixed(2) + "%" : "—";
-    const lifetimeCpc = lifetimeInsights.clicks > 0 ? `€${(Number(lifetimeInsights.costInLocalCurrency) / lifetimeInsights.clicks).toFixed(2)}` : "—";
+    const statusIcon =
+      info.status === "ACTIVE"
+        ? ":large_green_circle:"
+        : info.status === "PAUSED"
+          ? ":double_vertical_bar:"
+          : ":white_circle:";
+    const todayCtr =
+      todayInsights.impressions > 0
+        ? ((todayInsights.clicks / todayInsights.impressions) * 100).toFixed(2) + "%"
+        : "—";
+    const lifetimeCtr =
+      lifetimeInsights.impressions > 0
+        ? ((lifetimeInsights.clicks / lifetimeInsights.impressions) * 100).toFixed(2) + "%"
+        : "—";
+    const lifetimeCpc =
+      lifetimeInsights.clicks > 0
+        ? `€${(Number(lifetimeInsights.costInLocalCurrency) / lifetimeInsights.clicks).toFixed(2)}`
+        : "—";
     await postToResponseUrl(responseUrl, {
       response_type: "ephemeral",
       replace_original: true,
       blocks: [
-        { type: "header", text: { type: "plain_text", text: ":chart_with_upwards_trend: LinkedIn Campaign Status", emoji: true } },
+        {
+          type: "header",
+          text: {
+            type: "plain_text",
+            text: ":chart_with_upwards_trend: LinkedIn Campaign Status",
+            emoji: true,
+          },
+        },
         {
           type: "section",
           fields: [
@@ -1017,20 +1085,32 @@ async function runAdsStatus(campaignId: string, responseUrl: string, userId: str
           type: "section",
           text: { type: "mrkdwn", text: "*Today*" },
           fields: [
-            { type: "mrkdwn", text: `*Impressions*\n${todayInsights.impressions.toLocaleString()}` },
+            {
+              type: "mrkdwn",
+              text: `*Impressions*\n${todayInsights.impressions.toLocaleString()}`,
+            },
             { type: "mrkdwn", text: `*Clicks*\n${todayInsights.clicks}` },
             { type: "mrkdwn", text: `*CTR*\n${todayCtr}` },
-            { type: "mrkdwn", text: `*Spend*\n€${Number(todayInsights.costInLocalCurrency).toFixed(2)}` },
+            {
+              type: "mrkdwn",
+              text: `*Spend*\n€${Number(todayInsights.costInLocalCurrency).toFixed(2)}`,
+            },
           ],
         },
         {
           type: "section",
           text: { type: "mrkdwn", text: `*Lifetime* (since ${startDate})` },
           fields: [
-            { type: "mrkdwn", text: `*Impressions*\n${lifetimeInsights.impressions.toLocaleString()}` },
+            {
+              type: "mrkdwn",
+              text: `*Impressions*\n${lifetimeInsights.impressions.toLocaleString()}`,
+            },
             { type: "mrkdwn", text: `*Clicks*\n${lifetimeInsights.clicks}` },
             { type: "mrkdwn", text: `*CTR*\n${lifetimeCtr}` },
-            { type: "mrkdwn", text: `*Spend*\n€${Number(lifetimeInsights.costInLocalCurrency).toFixed(2)}` },
+            {
+              type: "mrkdwn",
+              text: `*Spend*\n€${Number(lifetimeInsights.costInLocalCurrency).toFixed(2)}`,
+            },
           ],
         },
         {
@@ -1044,7 +1124,11 @@ async function runAdsStatus(campaignId: string, responseUrl: string, userId: str
       ],
     });
   } catch (err) {
-    await postToResponseUrl(responseUrl, { response_type: "ephemeral", replace_original: true, text: `:warning: ${(err as Error).message}` });
+    await postToResponseUrl(responseUrl, {
+      response_type: "ephemeral",
+      replace_original: true,
+      text: `:warning: ${(err as Error).message}`,
+    });
   }
 }
 
@@ -1059,7 +1143,11 @@ async function runAdsPause(campaignId: string, responseUrl: string, userId: stri
   });
 }
 
-async function runAdsResume(campaignId: string, responseUrl: string, userId: string): Promise<void> {
+async function runAdsResume(
+  campaignId: string,
+  responseUrl: string,
+  userId: string
+): Promise<void> {
   const result = await resumeLinkedInCampaign(campaignId);
   await postToResponseUrl(responseUrl, {
     response_type: "in_channel",
@@ -1070,7 +1158,12 @@ async function runAdsResume(campaignId: string, responseUrl: string, userId: str
   });
 }
 
-async function runAdsBudget(campaignId: string, amount: number, responseUrl: string, userId: string): Promise<void> {
+async function runAdsBudget(
+  campaignId: string,
+  amount: number,
+  responseUrl: string,
+  userId: string
+): Promise<void> {
   const result = await setLinkedInCampaignBudget(campaignId, amount);
   await postToResponseUrl(responseUrl, {
     response_type: "in_channel",

--- a/src/emails/BaseLayout.tsx
+++ b/src/emails/BaseLayout.tsx
@@ -1,12 +1,4 @@
-import {
-  Body,
-  Container,
-  Head,
-  Hr,
-  Html,
-  Preview,
-  Text,
-} from "@react-email/components";
+import { Body, Container, Head, Hr, Html, Preview, Text } from "@react-email/components";
 import * as React from "react";
 
 interface BaseLayoutProps {

--- a/src/lib/ad-analytics/digest.ts
+++ b/src/lib/ad-analytics/digest.ts
@@ -35,7 +35,7 @@ const FLAG_BY_COUNTRY: Record<string, string> = {
  */
 export function renderConversionBlocks(
   event: AdConversionEvent,
-  capiResults?: Array<{ platform: string; accepted: boolean; status: number; message?: string }>,
+  capiResults?: Array<{ platform: string; accepted: boolean; status: number; message?: string }>
 ): NotificationBlock[] {
   const tier = event.tier ?? "—";
   const order = event.orderId ? truncate(event.orderId, 30) : "—";
@@ -83,13 +83,15 @@ function formatCustomer(customer?: { name?: string; email?: string; phone?: stri
 }
 
 function formatCapiStatus(
-  results?: Array<{ platform: string; accepted: boolean; status: number; message?: string }>,
+  results?: Array<{ platform: string; accepted: boolean; status: number; message?: string }>
 ): string {
   if (!results || results.length === 0) return "*CAPI:* ⏭️ skipped (no platform wired)";
   return results
     .map((r) => {
       const icon = r.accepted ? "✅" : "❌";
-      const detail = r.accepted ? `${r.status}` : `${r.status}${r.message ? ` — ${truncate(r.message, 60)}` : ""}`;
+      const detail = r.accepted
+        ? `${r.status}`
+        : `${r.status}${r.message ? ` — ${truncate(r.message, 60)}` : ""}`;
       return `*CAPI ${r.platform}:* ${icon} ${detail}`;
     })
     .join("\n");

--- a/src/lib/ad-analytics/runtime.ts
+++ b/src/lib/ad-analytics/runtime.ts
@@ -146,7 +146,9 @@ export async function dispatchConversion(event: AdConversionEvent): Promise<Disp
         user: {
           userAgent: event.userAgent,
           ipAddress: event.ipAddress,
-          emailSha256: event.customer?.email ? await sha256(event.customer.email.toLowerCase().trim()) : undefined,
+          emailSha256: event.customer?.email
+            ? await sha256(event.customer.email.toLowerCase().trim())
+            : undefined,
         },
         pageUrl: event.url,
       });
@@ -484,7 +486,6 @@ export async function runAdHocSnapshot(opts: {
   }
   return { campaign: campaign.slug, metrics: all };
 }
-
 
 async function sha256(input: string): Promise<string> {
   const { createHash } = await import("crypto");

--- a/src/lib/athena.ts
+++ b/src/lib/athena.ts
@@ -67,9 +67,7 @@ export async function runAthenaQuery(
 
   for (let i = 0; i < MAX_POLL_ATTEMPTS; i++) {
     await sleep(POLL_INTERVAL_MS);
-    const state = await client.send(
-      new GetQueryExecutionCommand({ QueryExecutionId: id })
-    );
+    const state = await client.send(new GetQueryExecutionCommand({ QueryExecutionId: id }));
     const s = state.QueryExecution?.Status?.State;
     if (s === "SUCCEEDED") break;
     if (s === "FAILED" || s === "CANCELLED") {
@@ -77,7 +75,9 @@ export async function runAthenaQuery(
       throw new Error(`Athena query ${s}: ${reason}`);
     }
     if (i === MAX_POLL_ATTEMPTS - 1) {
-      throw new Error(`Athena query timeout after ${(MAX_POLL_ATTEMPTS * POLL_INTERVAL_MS) / 1000}s`);
+      throw new Error(
+        `Athena query timeout after ${(MAX_POLL_ATTEMPTS * POLL_INTERVAL_MS) / 1000}s`
+      );
     }
   }
 

--- a/src/lib/campaigns/linkedin.ts
+++ b/src/lib/campaigns/linkedin.ts
@@ -120,12 +120,13 @@ export async function getLinkedInInsights(
   }
 }
 
-
 // ---------------------------------------------------------------------------
 // Campaign control (pause / resume / budget)
 // ---------------------------------------------------------------------------
 
-export async function pauseLinkedInCampaign(campaignId: string): Promise<{ ok: boolean; error?: string }> {
+export async function pauseLinkedInCampaign(
+  campaignId: string
+): Promise<{ ok: boolean; error?: string }> {
   try {
     const { adAccountId } = await getLinkedInConfig();
     const res = await liiFetch(`/adAccounts/${adAccountId}/adCampaigns/${campaignId}`, {
@@ -141,7 +142,9 @@ export async function pauseLinkedInCampaign(campaignId: string): Promise<{ ok: b
   }
 }
 
-export async function resumeLinkedInCampaign(campaignId: string): Promise<{ ok: boolean; error?: string }> {
+export async function resumeLinkedInCampaign(
+  campaignId: string
+): Promise<{ ok: boolean; error?: string }> {
   try {
     const { adAccountId } = await getLinkedInConfig();
     const res = await liiFetch(`/adAccounts/${adAccountId}/adCampaigns/${campaignId}`, {

--- a/src/lib/slack-commands-extra.ts
+++ b/src/lib/slack-commands-extra.ts
@@ -24,15 +24,26 @@ export async function buildSeoBlocks(userId: string): Promise<unknown[]> {
     ]);
 
     if (!snapshot) {
-      return [{ type: "section", text: { type: "mrkdwn", text: ":warning: GSC not configured or no data available." } }];
+      return [
+        {
+          type: "section",
+          text: { type: "mrkdwn", text: ":warning: GSC not configured or no data available." },
+        },
+      ];
     }
 
     const keywordRows = keywords
-      .map((k, i) => `${i + 1}. \`${k.keyword}\` — pos *${k.position.toFixed(1)}* · ${k.clicks} clicks · ${k.impressions} impr`)
+      .map(
+        (k, i) =>
+          `${i + 1}. \`${k.keyword}\` — pos *${k.position.toFixed(1)}* · ${k.clicks} clicks · ${k.impressions} impr`
+      )
       .join("\n");
 
     return [
-      { type: "header", text: { type: "plain_text", text: ":mag: SEO — Google Search Console", emoji: true } },
+      {
+        type: "header",
+        text: { type: "plain_text", text: ":mag: SEO — Google Search Console", emoji: true },
+      },
       {
         type: "section",
         fields: [
@@ -47,7 +58,15 @@ export async function buildSeoBlocks(userId: string): Promise<unknown[]> {
       { type: "context", elements: [{ type: "mrkdwn", text: `Requested by <@${userId}>` }] },
     ];
   } catch (err) {
-    return [{ type: "section", text: { type: "mrkdwn", text: `:warning: SEO data unavailable: \`${(err as Error).message?.slice(0, 100)}\`` } }];
+    return [
+      {
+        type: "section",
+        text: {
+          type: "mrkdwn",
+          text: `:warning: SEO data unavailable: \`${(err as Error).message?.slice(0, 100)}\``,
+        },
+      },
+    ];
   }
 }
 
@@ -58,13 +77,24 @@ export async function buildSeoBlocks(userId: string): Promise<unknown[]> {
 export async function buildLeadsBlocks(userId: string): Promise<unknown[]> {
   try {
     if (!(await isHubSpotConfigured())) {
-      return [{ type: "section", text: { type: "mrkdwn", text: ":warning: HubSpot not configured (HUBSPOT_API_KEY missing)." } }];
+      return [
+        {
+          type: "section",
+          text: {
+            type: "mrkdwn",
+            text: ":warning: HubSpot not configured (HUBSPOT_API_KEY missing).",
+          },
+        },
+      ];
     }
     const contacts = await listContacts(10);
-    const results = (contacts as Array<{ properties?: Record<string, string> }>);
+    const results = contacts as Array<{ properties?: Record<string, string> }>;
     if (!results.length) {
       return [
-        { type: "header", text: { type: "plain_text", text: ":busts_in_silhouette: Leads", emoji: true } },
+        {
+          type: "header",
+          text: { type: "plain_text", text: ":busts_in_silhouette: Leads", emoji: true },
+        },
         { type: "section", text: { type: "mrkdwn", text: "No contacts found in HubSpot." } },
       ];
     }
@@ -72,16 +102,36 @@ export async function buildLeadsBlocks(userId: string): Promise<unknown[]> {
       const p = c.properties ?? {};
       const name = [p.firstname, p.lastname].filter(Boolean).join(" ") || "—";
       const email = p.email || "—";
-      const created = p.createdate ? `<!date^${Math.floor(new Date(p.createdate).getTime() / 1000)}^{date_short}|${p.createdate}>` : "";
+      const created = p.createdate
+        ? `<!date^${Math.floor(new Date(p.createdate).getTime() / 1000)}^{date_short}|${p.createdate}>`
+        : "";
       return `• *${name}* — ${email} ${created}`;
     });
     return [
-      { type: "header", text: { type: "plain_text", text: ":busts_in_silhouette: Recent Leads (HubSpot)", emoji: true } },
-      { type: "section", text: { type: "mrkdwn", text: `*${results.length}* contacts\n\n${rows.join("\n")}` } },
+      {
+        type: "header",
+        text: {
+          type: "plain_text",
+          text: ":busts_in_silhouette: Recent Leads (HubSpot)",
+          emoji: true,
+        },
+      },
+      {
+        type: "section",
+        text: { type: "mrkdwn", text: `*${results.length}* contacts\n\n${rows.join("\n")}` },
+      },
       { type: "context", elements: [{ type: "mrkdwn", text: `Requested by <@${userId}>` }] },
     ];
   } catch (err) {
-    return [{ type: "section", text: { type: "mrkdwn", text: `:warning: Leads unavailable: \`${(err as Error).message?.slice(0, 100)}\`` } }];
+    return [
+      {
+        type: "section",
+        text: {
+          type: "mrkdwn",
+          text: `:warning: Leads unavailable: \`${(err as Error).message?.slice(0, 100)}\``,
+        },
+      },
+    ];
   }
 }
 
@@ -92,36 +142,72 @@ export async function buildLeadsBlocks(userId: string): Promise<unknown[]> {
 export async function buildErrorsBlocks(userId: string): Promise<unknown[]> {
   try {
     if (!(await isSentryConfigured())) {
-      return [{ type: "section", text: { type: "mrkdwn", text: ":warning: Sentry not configured (SENTRY_AUTH_TOKEN missing)." } }];
+      return [
+        {
+          type: "section",
+          text: {
+            type: "mrkdwn",
+            text: ":warning: Sentry not configured (SENTRY_AUTH_TOKEN missing).",
+          },
+        },
+      ];
     }
     const issues = await getTopErrors(5);
     if (!issues.length) {
       return [
-        { type: "header", text: { type: "plain_text", text: ":white_check_mark: No Unresolved Errors", emoji: true } },
-        { type: "section", text: { type: "mrkdwn", text: "All clear! No unresolved Sentry issues." } },
+        {
+          type: "header",
+          text: {
+            type: "plain_text",
+            text: ":white_check_mark: No Unresolved Errors",
+            emoji: true,
+          },
+        },
+        {
+          type: "section",
+          text: { type: "mrkdwn", text: "All clear! No unresolved Sentry issues." },
+        },
       ];
     }
     const rows = issues.map((issue, i) => {
-      const level = issue.level === "error" ? ":red_circle:" : issue.level === "warning" ? ":large_orange_circle:" : ":white_circle:";
+      const level =
+        issue.level === "error"
+          ? ":red_circle:"
+          : issue.level === "warning"
+            ? ":large_orange_circle:"
+            : ":white_circle:";
       return `${i + 1}. ${level} *${issue.title?.slice(0, 60)}*\n    ${issue.count ?? "?"} events · last seen ${issue.lastSeen ? `<!date^${Math.floor(new Date(issue.lastSeen).getTime() / 1000)}^{date_short_pretty} {time}|${issue.lastSeen}>` : "?"}`;
     });
     return [
-      { type: "header", text: { type: "plain_text", text: ":rotating_light: Top Unresolved Errors", emoji: true } },
+      {
+        type: "header",
+        text: { type: "plain_text", text: ":rotating_light: Top Unresolved Errors", emoji: true },
+      },
       { type: "section", text: { type: "mrkdwn", text: rows.join("\n\n") } },
       {
         type: "actions",
-        elements: [{
-          type: "button",
-          text: { type: "plain_text", text: "Open Sentry", emoji: true },
-          url: "https://sentry.io/issues/",
-          action_id: "open_sentry",
-          style: "primary",
-        }],
+        elements: [
+          {
+            type: "button",
+            text: { type: "plain_text", text: "Open Sentry", emoji: true },
+            url: "https://sentry.io/issues/",
+            action_id: "open_sentry",
+            style: "primary",
+          },
+        ],
       },
       { type: "context", elements: [{ type: "mrkdwn", text: `Requested by <@${userId}>` }] },
     ];
   } catch (err) {
-    return [{ type: "section", text: { type: "mrkdwn", text: `:warning: Errors unavailable: \`${(err as Error).message?.slice(0, 100)}\`` } }];
+    return [
+      {
+        type: "section",
+        text: {
+          type: "mrkdwn",
+          text: `:warning: Errors unavailable: \`${(err as Error).message?.slice(0, 100)}\``,
+        },
+      },
+    ];
   }
 }
 
@@ -172,7 +258,9 @@ export async function buildUptimeBlocks(userId: string): Promise<unknown[]> {
 export async function buildSubscribersBlocks(userId: string): Promise<unknown[]> {
   try {
     if (!(await isHubSpotConfigured())) {
-      return [{ type: "section", text: { type: "mrkdwn", text: ":warning: HubSpot not configured." } }];
+      return [
+        { type: "section", text: { type: "mrkdwn", text: ":warning: HubSpot not configured." } },
+      ];
     }
     const subs = await listNewsletterSubscribers();
     const total = subs.length;
@@ -180,17 +268,37 @@ export async function buildSubscribersBlocks(userId: string): Promise<unknown[]>
     const rows = recent.map((s) => {
       const p = (s as { properties?: Record<string, string> }).properties ?? {};
       const email = p.email || "—";
-      const date = p.createdate ? `<!date^${Math.floor(new Date(p.createdate).getTime() / 1000)}^{date_short}|>` : "";
+      const date = p.createdate
+        ? `<!date^${Math.floor(new Date(p.createdate).getTime() / 1000)}^{date_short}|>`
+        : "";
       return `• ${email} ${date}`;
     });
     return [
-      { type: "header", text: { type: "plain_text", text: ":envelope: Newsletter Subscribers", emoji: true } },
+      {
+        type: "header",
+        text: { type: "plain_text", text: ":envelope: Newsletter Subscribers", emoji: true },
+      },
       { type: "section", text: { type: "mrkdwn", text: `*Total subscribers:* ${total}` } },
-      ...(rows.length ? [{ type: "section", text: { type: "mrkdwn", text: `*Recent signups:*\n${rows.join("\n")}` } }] : []),
+      ...(rows.length
+        ? [
+            {
+              type: "section",
+              text: { type: "mrkdwn", text: `*Recent signups:*\n${rows.join("\n")}` },
+            },
+          ]
+        : []),
       { type: "context", elements: [{ type: "mrkdwn", text: `Requested by <@${userId}>` }] },
     ];
   } catch (err) {
-    return [{ type: "section", text: { type: "mrkdwn", text: `:warning: Subscribers unavailable: \`${(err as Error).message?.slice(0, 100)}\`` } }];
+    return [
+      {
+        type: "section",
+        text: {
+          type: "mrkdwn",
+          text: `:warning: Subscribers unavailable: \`${(err as Error).message?.slice(0, 100)}\``,
+        },
+      },
+    ];
   }
 }
 
@@ -202,7 +310,13 @@ export async function buildCacheFlushBlocks(userId: string, prefix?: string): Pr
   const cleared = invalidateCache(prefix || undefined);
   return [
     { type: "header", text: { type: "plain_text", text: ":broom: Cache Flushed", emoji: true } },
-    { type: "section", text: { type: "mrkdwn", text: `Cleared *${cleared}* cached entries${prefix ? ` matching \`${prefix}\`` : ""}.` } },
+    {
+      type: "section",
+      text: {
+        type: "mrkdwn",
+        text: `Cleared *${cleared}* cached entries${prefix ? ` matching \`${prefix}\`` : ""}.`,
+      },
+    },
     { type: "context", elements: [{ type: "mrkdwn", text: `Flushed by <@${userId}>` }] },
   ];
 }

--- a/src/lib/slack-notify.ts
+++ b/src/lib/slack-notify.ts
@@ -506,7 +506,7 @@ export async function slackOrderNotify(data: {
     `*Session:* \`${data.sessionId.slice(0, ORDER_SESSION_DISPLAY_LENGTH)}...\``,
   ];
   if (data.campaign || data.tier) {
-    const parts = [data.campaign, data.tier].filter(Boolean).map(s => slackEscape(s!));
+    const parts = [data.campaign, data.tier].filter(Boolean).map((s) => slackEscape(s!));
     lines.push(`*Campaign:* ${parts.join(" · ")}`);
   }
   if (data.attribution) {
@@ -540,7 +540,6 @@ function slackEscape(text: string): string {
   return text.replaceAll("&", "&amp;").replaceAll("<", "&lt;").replaceAll(">", "&gt;");
 }
 
-
 // ---------------------------------------------------------------------------
 // Customer Interaction Notifications (Phase: full coverage)
 // ---------------------------------------------------------------------------
@@ -548,10 +547,7 @@ function slackEscape(text: string): string {
 const interactionsClient = new SlackClient({ channel: "#notifications" });
 
 /** Notify when a user starts a chat conversation with the AI assistant. */
-export async function slackChatNotify(data: {
-  message: string;
-  ip?: string;
-}): Promise<boolean> {
+export async function slackChatNotify(data: { message: string; ip?: string }): Promise<boolean> {
   const preview = data.message.length > 100 ? data.message.slice(0, 100) + "…" : data.message;
   return interactionsClient.post({
     text: `New chat: "${preview}"`,
@@ -571,10 +567,7 @@ export async function slackTicketNotify(data: {
   email?: string;
   priority: string;
 }): Promise<boolean> {
-  const lines = [
-    `*Subject:* ${slackEscape(data.subject)}`,
-    `*Priority:* ${data.priority}`,
-  ];
+  const lines = [`*Subject:* ${slackEscape(data.subject)}`, `*Priority:* ${data.priority}`];
   if (data.email) lines.push(`*Email:* ${slackEscape(data.email)}`);
   return interactionsClient.post({
     text: `New ticket: ${data.subject}`,

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -38,12 +38,7 @@
   "hero": {
     "badge": "v2.0 — Now Accepting Clients",
     "titleStatic": "Clear skies.",
-    "typingTexts": [
-      "Zero friction.",
-      "Full control.",
-      "Pure speed.",
-      "Real results."
-    ],
+    "typingTexts": ["Zero friction.", "Full control.", "Pure speed.", "Real results."],
     "subtitle": "Enterprise cloud? You can't afford it. DIY infrastructure? You shouldn't. We're the third way — serverless, data-driven growth, and scaling that actually fits a 2–20-person team.",
     "subtitleHighlight": "Finally.",
     "ctaPrimary": "Get a Free Audit",

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -38,12 +38,7 @@
   "hero": {
     "badge": "v2.0 — Nouveaux clients acceptés",
     "titleStatic": "Ciel dégagé.",
-    "typingTexts": [
-      "Zéro friction.",
-      "Contrôle total.",
-      "Vitesse pure.",
-      "Résultats concrets."
-    ],
+    "typingTexts": ["Zéro friction.", "Contrôle total.", "Vitesse pure.", "Résultats concrets."],
     "subtitle": "Le cloud enterprise ? Trop cher. L'infrastructure DIY ? Trop risqué. Nous sommes la troisième voie — serverless, croissance data-driven, et mise à l'échelle adaptée aux équipes de 2 à 20 personnes.",
     "subtitleHighlight": "Enfin.",
     "ctaPrimary": "Audit Gratuit",


### PR DESCRIPTION
Two bounded style fixes surfaced by an audit pass over the .md docs + actual styling:

1. **Prettier sweep across 17 files** — `pnpm format:check` was failing on slack commands route, services/store/blog/contact/home pages, ad-analytics modules, athena, slack-notify, locale json. All now clean.

2. **`/admin/analytics/datalake` page refactored off raw `slate-*`** onto design-system v2 CSS variables (`--surface-raised`, `--border-subtle`, `--ink-primary`, `--ink-muted`, `--accent`, `--accent-on`, `--danger`, `--warning`, `--shadow-sm`). Same tokens flip cleanly when `/admin` ever moves to a light variant.

### Out of scope (intentional)

The wider drift — 1700+ raw slate/gray/zinc utilities across older admin pages — is the right scope for a dedicated multi-PR v1->v2 token migration per docs/design-system-v2.md Phase 3 plan, not this PR.

### Verification

- typecheck OK
- lint OK
- format:check OK
