### PR TITLE
feat(admin): make Postiz/HubSpot/AC integration failures actionable

### DIFF
--- a/docs/HUBSPOT.md
+++ b/docs/HUBSPOT.md
@@ -114,6 +114,18 @@ The private app token needs these scopes:
 | `crm.objects.contacts.read` | `listContacts()`, `searchContacts()` |
 | `crm.objects.contacts.write` | `upsertContact()` |
 | `crm.objects.tickets.write` | `createTicket()` |
+| `content` | `/api/admin/email/campaigns` (Marketing Emails list). Without it the route returns a structured 501 with `setupUrl`/`docsUrl`, and the `/admin/integrations` dashboard flags HubSpot as "degraded — content scope missing". |
+
+When you add or remove a scope, the private-app token is invalidated and a new one is issued. Update SSM in place; no redeploy needed:
+
+```bash
+aws ssm put-parameter \
+  --name /cloudless/production/HUBSPOT_API_KEY \
+  --type SecureString --overwrite \
+  --value <new-token>
+```
+
+The Lambda picks up the new value within the 5-minute SSM cache TTL.
 
 ---
 

--- a/src/app/[locale]/admin/email/campaigns/page.tsx
+++ b/src/app/[locale]/admin/email/campaigns/page.tsx
@@ -25,7 +25,11 @@ export default function EmailCampaignsPage() {
   const [automations, setAutomations] = useState<ACAutomation[]>([]);
   // /api/admin/email/campaigns deliberately returns 501 until the HubSpot
   // token gains the Marketing Emails "content" scope — surface that here.
-  const [campaignsNotice, setCampaignsNotice] = useState<string | null>(null);
+  const [campaignsNotice, setCampaignsNotice] = useState<{
+    text: string;
+    setupUrl?: string;
+    docsUrl?: string;
+  } | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
@@ -49,8 +53,18 @@ export default function EmailCampaignsPage() {
       }
       if (autoRes.ok) setAutomations((await autoRes.json()).automations ?? []);
       if (!campRes.ok) {
-        const body = (await campRes.json().catch(() => null)) as { error?: string } | null;
-        setCampaignsNotice(body?.error ?? `Campaigns unavailable (HTTP ${campRes.status})`);
+        const body = (await campRes.json().catch(() => null)) as {
+          error?: string;
+          instructions?: string;
+          setupUrl?: string;
+          docsUrl?: string;
+        } | null;
+        setCampaignsNotice({
+          text:
+            body?.instructions ?? body?.error ?? `Campaigns unavailable (HTTP ${campRes.status})`,
+          setupUrl: body?.setupUrl,
+          docsUrl: body?.docsUrl,
+        });
       }
     } catch (e) {
       setError(e instanceof Error ? e.message : "Failed to load");
@@ -97,8 +111,36 @@ export default function EmailCampaignsPage() {
           {campaignsNotice && (
             <div className="rounded-xl border border-yellow-900/30 bg-yellow-950/10 p-4">
               <p className="font-mono text-xs text-yellow-400">
-                <span className="font-bold">Campaign history unavailable:</span> {campaignsNotice}
+                <span className="font-bold">Campaign history unavailable:</span>{" "}
+                {campaignsNotice.text}
               </p>
+              {(campaignsNotice.setupUrl || campaignsNotice.docsUrl) && (
+                <p className="mt-2 font-mono text-xs text-yellow-300">
+                  {campaignsNotice.setupUrl && (
+                    <a
+                      href={campaignsNotice.setupUrl}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="underline hover:text-yellow-100"
+                    >
+                      Open HubSpot private-apps →
+                    </a>
+                  )}
+                  {campaignsNotice.setupUrl && campaignsNotice.docsUrl && (
+                    <span className="mx-2">·</span>
+                  )}
+                  {campaignsNotice.docsUrl && (
+                    <a
+                      href={campaignsNotice.docsUrl}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="underline hover:text-yellow-100"
+                    >
+                      Marketing Emails API docs →
+                    </a>
+                  )}
+                </p>
+              )}
             </div>
           )}
 

--- a/src/app/api/admin/email/campaigns/route.ts
+++ b/src/app/api/admin/email/campaigns/route.ts
@@ -1,14 +1,34 @@
 import { NextRequest, NextResponse } from "next/server";
 import { requireAdmin } from "@/lib/api-auth";
 
-// Marketing Emails API requires the 'content' scope which is not granted
-// on this private app token. Return a clear 501 so the UI can surface it.
+// Marketing Emails API requires the `content` scope, which is not granted
+// on the current HubSpot private-app token. We return a structured 501 so the
+// /admin/email/campaigns page can render an actionable "Add scope" link
+// instead of a bare status code.
+//
+// Fix path (operator action, ~3 minutes):
+//   1. https://app.hubspot.com/private-apps  → open the cloudless app
+//   2. Scopes tab → add `content` (under Marketing)
+//   3. Save → copy the regenerated token
+//   4. aws ssm put-parameter --name /cloudless/production/HUBSPOT_API_KEY \
+//        --type SecureString --overwrite --value <new-token>
+//   5. Wait <=5min for Lambda SSM cache TTL or recycle the function
+//
+// The integrations dashboard (/admin/integrations) will also flip HubSpot
+// from "degraded — content scope missing" to "configured" automatically.
 export async function GET(request: NextRequest) {
   const auth = await requireAdmin(request);
   if (!auth.ok) return auth.response;
 
   return NextResponse.json(
-    { error: "Marketing Emails API requires 'content' scope — not available on current HubSpot private app token." },
-    { status: 501 },
+    {
+      error: "Marketing Emails API requires the 'content' scope.",
+      missingScope: "content",
+      setupUrl: "https://app.hubspot.com/private-apps",
+      docsUrl: "https://developers.hubspot.com/docs/api/marketing/marketing-emails",
+      instructions:
+        "Open the HubSpot private-app, add the `content` scope under Marketing, save, then update HUBSPOT_API_KEY in SSM. The /admin/integrations dashboard pings this scope automatically.",
+    },
+    { status: 501 }
   );
 }

--- a/src/app/api/admin/integrations/status/route.ts
+++ b/src/app/api/admin/integrations/status/route.ts
@@ -19,6 +19,7 @@ type Cfg = Awaited<ReturnType<typeof getConfig>>;
 
 async function pingHubSpot(token: string): Promise<PingResult> {
   try {
+    // Core CRM probe: validates the token itself.
     const res = await fetch("https://api.hubapi.com/crm/v3/objects/contacts?limit=1", {
       headers: { Authorization: `Bearer ${token}` },
       signal: AbortSignal.timeout(5000),
@@ -26,6 +27,22 @@ async function pingHubSpot(token: string): Promise<PingResult> {
     if (res.status === 401 || res.status === 403)
       return { status: "degraded", message: `Token rejected (${res.status}).` };
     if (!res.ok) return { status: "error", message: `API returned ${res.status}` };
+
+    // Secondary probe: marketing-emails scope. The same token may be valid for
+    // CRM but missing the `content` scope, which causes /admin/email/campaigns
+    // to 501. Surface that here so the integrations page tells the operator
+    // exactly which scope to add instead of leaving them to dig.
+    const me = await fetch("https://api.hubapi.com/marketing/v3/emails?limit=1", {
+      headers: { Authorization: `Bearer ${token}` },
+      signal: AbortSignal.timeout(5000),
+    });
+    if (me.status === 403) {
+      return {
+        status: "degraded",
+        message:
+          "CRM scopes OK but `content` scope is missing — Marketing Emails API blocked. Re-issue the private-app token with `content` and update HUBSPOT_API_KEY in SSM.",
+      };
+    }
     return { status: "configured" };
   } catch {
     return { status: "error", message: "Connection failed." };
@@ -64,6 +81,30 @@ async function pingNotion(token: string): Promise<PingResult> {
     return { status: "configured" };
   } catch {
     return { status: "error", message: "Connection failed." };
+  }
+}
+
+async function pingPostiz(baseUrl: string, apiKey: string): Promise<PingResult> {
+  try {
+    const url = `${baseUrl.replace(/\/$/, "")}/api/public/v1/groups`;
+    const res = await fetch(url, {
+      headers: { Authorization: apiKey },
+      signal: AbortSignal.timeout(5000),
+    });
+    if (res.status === 401 || res.status === 403)
+      return { status: "degraded", message: `API key rejected (${res.status}).` };
+    if (res.status >= 500)
+      return {
+        status: "error",
+        message: `Upstream Postiz returned ${res.status} — pod/container may be down. Check the Postiz deployment.`,
+      };
+    if (!res.ok) return { status: "degraded", message: `API returned ${res.status}` };
+    return { status: "configured" };
+  } catch {
+    return {
+      status: "error",
+      message: "Connection failed — Postiz host unreachable from the app (DNS/network/pod down).",
+    };
   }
 }
 
@@ -237,13 +278,17 @@ function buildStaticReports(cfg: Cfg): IntegrationReport[] {
 }
 
 async function buildPingedReports(cfg: Cfg): Promise<IntegrationReport[]> {
-  const [stripeResult, hubspotResult, slackResult, notionResult, acResult] = await Promise.all([
-    cfg.STRIPE_SECRET_KEY ? pingStripe(cfg.STRIPE_SECRET_KEY) : Promise.resolve(NOT_CONFIGURED),
-    cfg.HUBSPOT_API_KEY ? pingHubSpot(cfg.HUBSPOT_API_KEY) : Promise.resolve(NOT_CONFIGURED),
-    cfg.SLACK_BOT_TOKEN ? pingSlack(cfg.SLACK_BOT_TOKEN) : Promise.resolve(NOT_CONFIGURED),
-    cfg.NOTION_API_KEY ? pingNotion(cfg.NOTION_API_KEY) : Promise.resolve(NOT_CONFIGURED),
-    verifyActiveCampaignToken(),
-  ]);
+  const [stripeResult, hubspotResult, slackResult, notionResult, acResult, postizResult] =
+    await Promise.all([
+      cfg.STRIPE_SECRET_KEY ? pingStripe(cfg.STRIPE_SECRET_KEY) : Promise.resolve(NOT_CONFIGURED),
+      cfg.HUBSPOT_API_KEY ? pingHubSpot(cfg.HUBSPOT_API_KEY) : Promise.resolve(NOT_CONFIGURED),
+      cfg.SLACK_BOT_TOKEN ? pingSlack(cfg.SLACK_BOT_TOKEN) : Promise.resolve(NOT_CONFIGURED),
+      cfg.NOTION_API_KEY ? pingNotion(cfg.NOTION_API_KEY) : Promise.resolve(NOT_CONFIGURED),
+      verifyActiveCampaignToken(),
+      cfg.POSTIZ_API_URL && cfg.POSTIZ_API_KEY
+        ? pingPostiz(cfg.POSTIZ_API_URL, cfg.POSTIZ_API_KEY)
+        : Promise.resolve(NOT_CONFIGURED),
+    ]);
 
   const acStatusMap: Record<string, IntegrationStatus> = {
     valid: "configured",
@@ -295,6 +340,13 @@ async function buildPingedReports(cfg: Cfg): Promise<IntegrationReport[]> {
       status: acStatusMap[acResult.status] ?? "error",
       message: acMessage,
       setupUrl: "https://www.activecampaign.com",
+    },
+    {
+      id: "postiz",
+      name: "Postiz (social publishing)",
+      category: "social_ads",
+      ...postizResult,
+      setupUrl: cfg.POSTIZ_API_URL || "https://postiz.cloudless.gr",
     },
   ];
 }

--- a/src/app/api/admin/postiz/groups/route.ts
+++ b/src/app/api/admin/postiz/groups/route.ts
@@ -17,8 +17,23 @@ export async function GET(req: NextRequest) {
       return NextResponse.json({ error: "postiz_not_configured" }, { status: 503 });
     }
     if (err instanceof PostizApiError) {
+      // Surface the upstream URL + a status-specific hint so the operator can
+      // act without leaving /admin/workspaces — the integrations dashboard
+      // ping for Postiz uses the same logic.
+      const hint =
+        err.status >= 500
+          ? "Postiz pod likely down or restarting. Check the k3s deployment in the postiz namespace."
+          : err.status === 401 || err.status === 403
+            ? "Postiz API key rejected. Regenerate from Postiz → Settings → Public API and update POSTIZ_API_KEY in SSM."
+            : "Postiz returned a non-2xx — see body above.";
       return NextResponse.json(
-        { error: "postiz_upstream", status: err.status, body: err.body },
+        {
+          error: "postiz_upstream",
+          status: err.status,
+          body: err.body,
+          troubleshootUrl: "https://postiz.cloudless.gr",
+          hint,
+        },
         { status: 502 }
       );
     }


### PR DESCRIPTION
Triage of 4 failing admin endpoints showed two are intentional 503-not-configured per CLAUDE.md, but the operator response was unclear from the UI. This PR makes each failure actionable.

### What changed

| Surface | Before | After |
|---|---|---|
| `/admin/integrations` dashboard | Did not ping Postiz; HubSpot ping only validated CRM scope | Now pings Postiz upstream (5xx -> error w/ message, 401 -> degraded), and HubSpot now also probes `/marketing/v3/emails` to surface `content` scope gap as `degraded` with the exact remediation in the message |
| `/api/admin/email/campaigns` 501 | `{error: string}` | `{error, missingScope: "content", setupUrl, docsUrl, instructions}` — UI renders deep links |
| `/admin/email/campaigns` page | One-line yellow notice | Notice + clickable "Open HubSpot private-apps ->" + "Marketing Emails API docs ->" |
| `/api/admin/postiz/groups` 502 | `{error, status, body}` | `+ troubleshootUrl, hint` (status-specific: 5xx says "pod down", 401/403 says "rotate API key") |
| `docs/HUBSPOT.md` | Required scopes table | Adds `content` row + SSM rotation snippet |

### What this does NOT touch (operator action still required)

- **Postiz pod health** — needs cluster access (no AWS/Tailscale creds in this session)
- **ActiveCampaign config** — needs `ACTIVECAMPAIGN_API_URL` + `_TOKEN` in SSM if AC is intended
- **HubSpot `content` scope** — operator has to add it in HubSpot UI + rotate the SSM key

But each of those is now visible + actionable from `/admin/integrations` instead of failing silently in a sub-page.

### Verification

- typecheck OK
- lint OK
- format:check OK
