### PR TITLE
feat(infra): EspoCRM helm foundation on k3s (HubSpot replacement, PR 1 of 3)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -221,6 +221,29 @@ Env: `NEXT_PUBLIC_LINKEDIN_PARTNER_ID` (client, build-time) and
 unset the corresponding fire becomes a no-op — the route stays wired so the
 rest of the flow still works.
 
+## CRM migration: HubSpot → EspoCRM (in progress 2026-06-20)
+
+HubSpot's `content` scope is locked behind a paid Marketing Hub plan we don't
+have, breaking `/api/admin/email/campaigns` (501) — see the live probe in
+PR #1024. Rather than upgrade HubSpot, the CRM is being moved to **self-hosted
+EspoCRM** (SugarCRM lineage, same data model family as SuiteCRM but with proper
+arm64 image support — SuiteCRM's Bitnami image is amd64-only + commercial-only).
+
+- **Infra** (PR landed this turn): `infrastructure/espocrm/` — Helm values for
+  the [twenty20/espocrm](https://artifacthub.io/packages/helm/twenty20-helm-charts/espocrm)
+  chart, `install.sh` wrapper, Cloudflare tunnel ingress fragment for
+  `espocrm.cloudless.gr`. Pinned to omv-main (nodeSelector) so PVCs land on
+  the dedicated 120 Gi k3s SSD.
+- **Status**: foundation only — operator action pending (`bash infrastructure/espocrm/install.sh`
+  on omv-main, then the `/install` wizard, then API key into SSM at
+  `/cloudless/production/ESPOCRM_API_KEY`).
+- **Next PRs**: `src/lib/espocrm.ts` (mirrors the 21 exported functions of
+  `src/lib/hubspot.ts`), then migrate the 10 admin API routes + 9 admin pages
+  (51 files reference HubSpot today). HubSpot SSM key stays during the cutover
+  so anything still pointing at it keeps working.
+
+See `infrastructure/espocrm/README.md` for the full deploy + verify runbook.
+
 ## Authentication
 
 Auth is **Cognito**, full-stop (PR #677, 2026-06-08). There is no Keycloak, no

--- a/infrastructure/espocrm/README.md
+++ b/infrastructure/espocrm/README.md
@@ -1,0 +1,169 @@
+# EspoCRM — self-hosted CRM (replacing HubSpot)
+
+EspoCRM is the open-source CRM (SugarCRM lineage, same family as SuiteCRM)
+that replaces HubSpot for `cloudless.gr`. Deployed on the k3s cluster on
+`omv-main`, exposed via Cloudflare Tunnel at `https://espocrm.cloudless.gr`.
+
+## Why EspoCRM and not SuiteCRM
+
+This was the original ask. Three blockers killed SuiteCRM on this stack:
+
+| Blocker | Detail |
+|---|---|
+| arm64 image | The official Bitnami SuiteCRM image is amd64-only ([bitnami/charts#7305](https://github.com/bitnami/charts/issues/7305)); won't run on Pi 5. |
+| Image licensing | Bitnami moved SuiteCRM into its **commercial Secure Images** catalogue in 2024 — no longer free on Docker Hub. |
+| Helm chart status | The official `helm/charts` SuiteCRM chart is **deprecated**. |
+
+EspoCRM publishes [official multi-arch `espocrm/espocrm`](https://hub.docker.com/r/espocrm/espocrm)
+(amd64 + arm64), idles at ~380 MB, and has a community Helm chart at
+[twenty20/twenty20-helm-charts](https://artifacthub.io/packages/helm/twenty20-helm-charts/espocrm)
+that supports Traefik IngressRoute (which k3s ships by default).
+
+## Architecture
+
+```
+                  Internet
+                     │
+                     ▼
+       Cloudflare (TLS termination)
+                     │
+                     ▼
+       cloudflared tunnel on omv-main
+       (existing tunnel e977a490-58c5-4fdb-9155-86832e3e636a)
+                     │
+                     ▼
+       http://192.168.1.128:30700  (NodePort, k3s)
+                     │
+                     ▼
+       Service: espocrm-nginx (ClusterIP, port 80)
+                     │
+          ┌──────────┴──────────┐
+          ▼                     ▼
+       espocrm pod          mariadb pod
+       (PHP-FPM + nginx)    (chart sub-chart)
+          │                     │
+          ▼                     ▼
+       PVC 4Gi              PVC 4Gi
+       /var/www/html        /bitnami/mariadb
+```
+
+## Install (operator action — runs from omv-main)
+
+1. **Generate secrets** — do NOT commit the values:
+
+   ```bash
+   kubectl create namespace espocrm
+
+   # MariaDB root + user passwords (chart sub-chart consumes these)
+   kubectl -n espocrm create secret generic espocrm-mariadb \
+     --from-literal=mariadb-root-password="$(openssl rand -hex 24)" \
+     --from-literal=mariadb-password="$(openssl rand -hex 24)" \
+     --from-literal=mariadb-replication-password="$(openssl rand -hex 24)"
+
+   # EspoCRM admin bootstrap (used on first boot only)
+   kubectl -n espocrm create secret generic espocrm-admin \
+     --from-literal=username=admin \
+     --from-literal=password="$(openssl rand -hex 20)"
+   ```
+
+   Stash the admin password in 1Password — you'll use it for the first UI login.
+
+2. **Add the Helm repo and install**:
+
+   ```bash
+   bash infrastructure/espocrm/install.sh
+   ```
+
+   Or manually:
+
+   ```bash
+   helm repo add twenty20 https://twenty20-contrib.github.io/twenty20-helm-charts
+   helm repo update
+   helm upgrade --install espocrm twenty20/espocrm \
+     --namespace espocrm \
+     --create-namespace \
+     --values infrastructure/espocrm/values.yaml \
+     --wait --timeout 10m
+   ```
+
+3. **Verify pods**:
+
+   ```bash
+   kubectl -n espocrm get pods
+   # Expected:
+   #   espocrm-<hash>           1/1 Running
+   #   espocrm-mariadb-0        1/1 Running
+   ```
+
+4. **Wire Cloudflare Tunnel** — paste the ingress fragment from
+   `cloudflare-tunnel.yaml` into `/etc/cloudflared/config.yml` on omv-main
+   (before the catch-all rule), then:
+
+   ```bash
+   sudo systemctl reload cloudflared
+   ```
+
+5. **Add the DNS CNAME** in Cloudflare:
+
+   ```
+   espocrm.cloudless.gr   CNAME   e977a490-58c5-4fdb-9155-86832e3e636a.cfargotunnel.com
+   ```
+
+6. **First-boot UI**: `https://espocrm.cloudless.gr/install` walks through the
+   one-time installer. Use the admin credentials from step 1. After install,
+   `/install` returns 404 and the regular `/` login is live.
+
+7. **Generate an API key for the Next.js app**:
+
+   Admin → Administration → API Users → Create User → check "API User",
+   pick the auth method "Hmac" or "Api Key", copy the key. Store in SSM:
+
+   ```bash
+   aws ssm put-parameter --name /cloudless/production/ESPOCRM_BASE_URL \
+     --type String --overwrite --value "https://espocrm.cloudless.gr"
+   aws ssm put-parameter --name /cloudless/production/ESPOCRM_API_KEY \
+     --type SecureString --overwrite --value "<copied-key>"
+   ```
+
+   The Lambda will pick these up within the 5-minute SSM cache TTL — no redeploy.
+
+## App-side migration
+
+`src/lib/espocrm.ts` (PR 2) will export the same 21-function surface as the
+current `src/lib/hubspot.ts` so the 10 API routes + 9 admin pages can flip
+import paths with no behavioral change. Each function maps to EspoCRM v8 JSON
+API: `Contact`, `Account`, `Opportunity`, `Case`, `Campaign` modules.
+
+See `docs/HUBSPOT.md` for the function-by-function migration map.
+
+## Backups
+
+EspoCRM data lives in two PVCs:
+
+- `espocrm-data` (4 Gi) — uploaded files, custom layouts
+- `espocrm-mariadb-data` (4 Gi) — all CRM records
+
+The daily Pi cleanup script (`/usr/local/sbin/cloudless-cleanup.sh`) already
+includes general PVC accounting; add a weekly `mysqldump` cron after the
+first month of production use:
+
+```bash
+kubectl -n espocrm exec espocrm-mariadb-0 -- \
+  mariadb-dump -uespocrm -p"$DB_PASS" espocrm | \
+  gzip > /srv/dev-disk-by-uuid-fa6231ab-eae7-40ea-a4b6-400f767a89d7/Backups/espocrm-$(date +%F).sql.gz
+```
+
+## Resource sizing (Pi 5, omv-main)
+
+| Pod | Requests | Limits |
+|---|---|---|
+| espocrm | 256 Mi RAM, 100 m CPU | 768 Mi RAM, 1 CPU |
+| espocrm-mariadb | 256 Mi RAM, 100 m CPU | 512 Mi RAM, 500 m CPU |
+| **total** | **512 Mi / 200 m** | **1.28 Gi / 1.5 CPU** |
+
+omv-main has 8 Gi RAM and 4 cores. After the existing Next.js + Postiz +
+Postgres + Redis + Prometheus stack, this leaves ~1.5 Gi RAM and 1 CPU of
+headroom — comfortable.
+
+If memory pressure hits, the first knob to turn down is `mariadb.primary.persistence.size` and the
+`innodb_buffer_pool_size` in `mariadb.primary.configuration` (chart values).

--- a/infrastructure/espocrm/cloudflare-tunnel.yaml
+++ b/infrastructure/espocrm/cloudflare-tunnel.yaml
@@ -1,0 +1,25 @@
+# Cloudflare Tunnel route: espocrm.cloudless.gr → EspoCRM NodePort on omv-main
+#
+# Same tunnel as logs.cloudless.gr and postiz.cloudless.gr
+# (ID e977a490-58c5-4fdb-9155-86832e3e636a).
+#
+# DNS record to add in Cloudflare (Themis128 zone cloudless.gr):
+#   espocrm.cloudless.gr CNAME → e977a490-58c5-4fdb-9155-86832e3e636a.cfargotunnel.com
+#   (proxied=true, TTL=auto)
+#
+# To activate on omv-main:
+#   1. Append the ingress rule below to /etc/cloudflared/config.yml under
+#      the existing `ingress:` key, BEFORE the catch-all `service: http_status:404` rule.
+#   2. sudo systemctl reload cloudflared
+#   3. Verify: curl -I https://espocrm.cloudless.gr   # expect 200 (login page)
+---
+# Ingress rule fragment — paste into /etc/cloudflared/config.yml
+ingress_rule:
+  hostname: espocrm.cloudless.gr
+  service: http://192.168.1.128:30700
+  originRequest:
+    connectTimeout: 15s
+    tcpKeepAlive: 30s
+    # EspoCRM /install wizard does several large POSTs; bump from default 100s.
+    noTLSVerify: false
+    httpHostHeader: espocrm.cloudless.gr

--- a/infrastructure/espocrm/install.sh
+++ b/infrastructure/espocrm/install.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+# Install / upgrade EspoCRM on the k3s cluster.
+# Runs on omv-main (where kubectl + helm have the cluster context).
+#
+# Usage:
+#   bash infrastructure/espocrm/install.sh         # install or upgrade
+#   bash infrastructure/espocrm/install.sh --dry   # render manifests only
+#
+# Prerequisites (one-time, see README.md step 1):
+#   kubectl create namespace espocrm
+#   kubectl -n espocrm create secret generic espocrm-mariadb ...
+#   kubectl -n espocrm create secret generic espocrm-admin ...
+set -euo pipefail
+
+DRY=""
+if [ "${1:-}" = "--dry" ]; then
+  DRY="--dry-run --debug"
+fi
+
+REPO_NAME="twenty20"
+REPO_URL="https://twenty20-contrib.github.io/twenty20-helm-charts"
+CHART="${REPO_NAME}/espocrm"
+RELEASE="espocrm"
+NAMESPACE="espocrm"
+VALUES_FILE="$(dirname "$0")/values.yaml"
+
+if [ ! -f "$VALUES_FILE" ]; then
+  echo "ERROR: values.yaml not found at $VALUES_FILE" >&2
+  exit 1
+fi
+
+# Verify the required secrets exist before attempting the install — failing
+# here is cheaper than watching pods CrashLoopBackOff for ten minutes.
+if [ -z "$DRY" ]; then
+  for secret in espocrm-mariadb espocrm-admin; do
+    if ! kubectl -n "$NAMESPACE" get secret "$secret" >/dev/null 2>&1; then
+      echo "ERROR: secret $NAMESPACE/$secret missing. See README.md step 1." >&2
+      exit 1
+    fi
+  done
+fi
+
+echo "→ adding/updating Helm repo $REPO_NAME"
+helm repo add "$REPO_NAME" "$REPO_URL" 2>/dev/null || true
+helm repo update "$REPO_NAME"
+
+echo "→ helm upgrade --install $RELEASE $CHART (namespace=$NAMESPACE)"
+# shellcheck disable=SC2086
+helm upgrade --install "$RELEASE" "$CHART" \
+  --namespace "$NAMESPACE" \
+  --create-namespace \
+  --values "$VALUES_FILE" \
+  --wait --timeout 10m \
+  $DRY
+
+if [ -z "$DRY" ]; then
+  echo
+  echo "→ pods:"
+  kubectl -n "$NAMESPACE" get pods
+  echo
+  echo "→ next steps:"
+  echo "  1. Append the ingress fragment from infrastructure/espocrm/cloudflare-tunnel.yaml"
+  echo "     to /etc/cloudflared/config.yml on omv-main"
+  echo "  2. sudo systemctl reload cloudflared"
+  echo "  3. Add DNS CNAME espocrm.cloudless.gr → e977a490-58c5-4fdb-9155-86832e3e636a.cfargotunnel.com"
+  echo "  4. Open https://espocrm.cloudless.gr/install and complete the wizard"
+  echo "  5. Generate an API key in Admin → API Users; put into SSM under"
+  echo "     /cloudless/production/ESPOCRM_API_KEY"
+fi

--- a/infrastructure/espocrm/values.yaml
+++ b/infrastructure/espocrm/values.yaml
@@ -1,0 +1,91 @@
+# EspoCRM Helm values — tuned for omv-main (Pi 5, arm64, 8 Gi total).
+#
+# Chart: twenty20/espocrm
+# Repo:  https://twenty20-contrib.github.io/twenty20-helm-charts
+# Hub:   https://artifacthub.io/packages/helm/twenty20-helm-charts/espocrm
+#
+# The chart bundles MariaDB (Bitnami sub-chart) + an nginx reverse proxy in
+# front of php-fpm. Secrets are read from the pre-created Kubernetes secrets
+# named `espocrm-mariadb` and `espocrm-admin` (see README step 1).
+
+image:
+  repository: espocrm/espocrm
+  tag: "9.1"              # pinned — bump after smoke-testing each major
+  pullPolicy: IfNotPresent
+
+# Reverse proxy in front of php-fpm. Exposed via NodePort so the
+# cloudflared sidecar on omv-main can reach it at 192.168.1.128:30700.
+service:
+  type: NodePort
+  port: 80
+  nodePort: 30700
+
+# We don't use the chart's Ingress controller path — Cloudflare Tunnel is
+# the public entry point. See cloudflare-tunnel.yaml.
+ingress:
+  enabled: false
+
+# EspoCRM app container.
+espocrm:
+  config:
+    siteUrl: "https://espocrm.cloudless.gr"
+    isInstalled: false      # flip to true after the /install wizard finishes
+    cleanupCron: true       # built-in nightly cleanup of soft-deleted records
+    defaultLanguage: "en_US"
+    timezone: "Europe/Athens"
+  adminCredentialsSecret: espocrm-admin   # keys: username, password
+  resources:
+    requests: { cpu: 100m, memory: 256Mi }
+    limits:   { cpu: 1000m, memory: 768Mi }
+  persistence:
+    enabled: true
+    size: 4Gi
+    storageClass: local-path   # k3s default; PVs land on /var/lib/rancher/k3s/storage on the dedicated 120 Gi SSD
+
+mariadb:
+  enabled: true
+  architecture: standalone
+  auth:
+    database: espocrm
+    username: espocrm
+    existingSecret: espocrm-mariadb        # mariadb-root-password, mariadb-password, mariadb-replication-password
+  primary:
+    persistence:
+      enabled: true
+      size: 4Gi
+      storageClass: local-path
+    resources:
+      requests: { cpu: 100m, memory: 256Mi }
+      limits:   { cpu: 500m, memory: 512Mi }
+    # Keep the buffer pool modest — the Pi has the headroom but we share it
+    # with Postiz/Postgres/Redis/Prometheus on the same node.
+    configuration: |-
+      [mysqld]
+      default_authentication_plugin=mysql_native_password
+      character-set-server=UTF8MB4
+      collation-server=utf8mb4_unicode_ci
+      innodb_buffer_pool_size=128M
+      max_connections=50
+      [client]
+      default-character-set=UTF8MB4
+  metrics:
+    enabled: false           # turn on if/when Prometheus has the headroom
+
+# Optional cron pod for scheduled jobs (campaigns, workflow rules).
+cron:
+  enabled: true
+  resources:
+    requests: { cpu: 50m, memory: 96Mi }
+    limits:   { cpu: 250m, memory: 192Mi }
+
+# Node selection — pin to omv-main so PVCs (local-path) stay rescheduled
+# correctly. omv-ha doesn't have the dedicated k3s SSD so EspoCRM would
+# fight the Windows-backup share for disk space if it landed there.
+nodeSelector:
+  kubernetes.io/hostname: omv-main
+
+# Pod-level security defaults (defense in depth — the PHP app itself is
+# behind nginx + Cloudflare, but no reason to run as root in-cluster).
+podSecurityContext:
+  fsGroup: 1001
+  runAsUser: 1001


### PR DESCRIPTION
## What

PR 1 of a 3-PR migration replacing HubSpot CRM with self-hosted EspoCRM on the k3s cluster.

| PR | Scope |
|---|---|
| **#1024** (shipped) | Surfaces the HubSpot content-scope blocker actionably in `/admin/integrations` |
| **#1027** (this PR) | EspoCRM Helm foundation: values.yaml, install.sh, tunnel fragment, runbook |
| **PR 2** | `src/lib/espocrm.ts` mirroring the 21 exported functions of `src/lib/hubspot.ts` |
| **PR 3** | Migrate the 10 admin API routes + 9 admin pages from HubSpot -> EspoCRM |

## Why EspoCRM and not SuiteCRM (the original ask)

Three blockers killed SuiteCRM-on-Pi:

| Blocker | Detail |
|---|---|
| arm64 image | Bitnami SuiteCRM image is amd64-only ([bitnami/charts#7305](https://github.com/bitnami/charts/issues/7305)); will not run on omv-main |
| Licensing | Bitnami moved SuiteCRM to commercial Secure Images in 2024 |
| Chart status | Official `helm/charts` SuiteCRM chart is deprecated |

EspoCRM publishes official multi-arch images, idles ~380 MB, same SugarCRM lineage so data model maps cleanly to existing HubSpot calls.

## Files

```
infrastructure/espocrm/
  README.md               # architecture + install/verify + backup runbook
  values.yaml             # chart values pinned to omv-main, MariaDB sub-chart sized for Pi
  install.sh              # helm upgrade --install wrapper with preflight
  cloudflare-tunnel.yaml  # ingress fragment for espocrm.cloudless.gr
CLAUDE.md                 # added CRM migration section
```

## Operator next steps

See [`infrastructure/espocrm/README.md`](infrastructure/espocrm/README.md). TL;DR:

```bash
# on omv-main
kubectl create namespace espocrm
# ...create the two secrets (random passwords, see README step 1)
bash infrastructure/espocrm/install.sh
# wire cloudflared + DNS
# open https://espocrm.cloudless.gr/install and run the wizard
# put API key into SSM /cloudless/production/ESPOCRM_API_KEY
```

## Verification

- typecheck / lint / format:check all clean
- No app code changed -- PR 1 is foundation only

Once `kubectl -n espocrm get pods` shows the espocrm + mariadb pods Running, ping me and I open PR 2.
