### PR TITLE
feat(crm): EspoCRM app client + Slack webhook sync (PR 3 of 5)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -244,10 +244,24 @@ arm64 image support — SuiteCRM's Bitnami image is amd64-only + commercial-only
 - **Status**: pods 1/1 Running, HTTP 200 from inside the cluster. Pending:
   Cloudflare tunnel append + DNS CNAME + first UI login + API key into SSM
   (`/cloudless/production/ESPOCRM_BASE_URL` + `ESPOCRM_API_KEY`).
-- **Next PRs**: `src/lib/espocrm.ts` (mirrors the 21 exported functions of
-  `src/lib/hubspot.ts`), then migrate the 10 admin API routes + 9 admin pages
-  (51 files reference HubSpot today). HubSpot SSM key stays during the cutover
-  so anything still pointing at it keeps working.
+- **Live now**: API user `cloudless-app` (role `Cloudless App Full Access`,
+  ID `6a36ef141808ed737`); `Export Import` extension v2.9.0 installed via
+  `php command.php extension --file=...`. SSM keys live at
+  `/cloudless/production/ESPOCRM_BASE_URL`, `ESPOCRM_API_KEY`,
+  `ESPOCRM_WEBHOOK_SECRET`.
+- **`src/lib/espocrm.ts` SHIPPED** — drop-in mirror of the 21 hubspot.ts
+  exports (`upsertContact`, `createTicket`, `listDeals`, `createDeal`,
+  `getDealsByStage`, `getPipelineStats`, etc). Module mapping: Contact↔contact,
+  Account↔company, Opportunity↔deal, Case↔ticket. Auth via `X-Api-Key`.
+- **Slack sync LIVE** — `/api/webhooks/espocrm` route forwards Contact/Lead
+  create, Opportunity create + stage-change, and Case create + status-change
+  to Slack via `SlackClient` (per `feedback_slack_use_slackclient`). Six
+  Webhook entities registered in EspoCRM (one per event), all `isActive=true`.
+- **Next PRs**: PR 4 flips imports in the 10 admin API routes + 9 admin
+  pages from `@/lib/hubspot` → `@/lib/espocrm` (51 files reference HubSpot
+  today). PR 5: `scripts/etl/espocrm-to-lake.mjs` + Athena views.
+  HubSpot SSM key stays in place during cutover so anything still pointing
+  at it keeps working.
 
 See `infrastructure/espocrm/README.md` for the full deploy + verify runbook.
 

--- a/src/app/api/webhooks/espocrm/route.ts
+++ b/src/app/api/webhooks/espocrm/route.ts
@@ -1,0 +1,106 @@
+import { NextRequest, NextResponse } from "next/server";
+import {
+  type EspoEntityRecord,
+  type EspoWebhookEnvelope,
+  parseEspoEvent,
+  verifyEspoWebhookSecret,
+} from "@/lib/espocrm-webhook";
+import {
+  notifyCaseCreated,
+  notifyCaseStatusChanged,
+  notifyContactCreated,
+  notifyLeadCreated,
+  notifyOpportunityCreated,
+  notifyOpportunityStageChanged,
+} from "@/lib/espocrm-slack";
+
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+
+/**
+ * POST /api/webhooks/espocrm — inbound EspoCRM event receiver.
+ *
+ * Events forwarded to Slack:
+ *   Contact.create       → #leads
+ *   Lead.create          → #leads
+ *   Opportunity.create   → #orders
+ *   Opportunity.update   → #orders  (only when `stage` is in the changed
+ *                          attributes; otherwise 202 ignored)
+ *   Case.create          → #notifications
+ *   Case.update          → #notifications (only when `status` changed)
+ *   anything else        → 202 Accepted, ignored
+ *
+ * Auth: EspoCRM Webhook entity doesn't sign payloads — it POSTs raw JSON. We
+ * authenticate via a URL-secret query param (`?secret=<hex>`) checked
+ * constant-time against ESPOCRM_WEBHOOK_SECRET in SSM. Unset secret = always
+ * 401 (never auth-bypass for unconfigured deployments).
+ *
+ * Smoke-testing: include `{"verification": true}` in the payload to ACK 200
+ * without firing any Slack notification.
+ */
+export async function POST(req: NextRequest) {
+  const urlSecret = new URL(req.url).searchParams.get("secret");
+  const ok = await verifyEspoWebhookSecret(urlSecret);
+  if (!ok) {
+    return NextResponse.json({ error: "unauthorized" }, { status: 401 });
+  }
+
+  const rawBody = await req.text();
+  let payload: EspoWebhookEnvelope;
+  try {
+    payload = JSON.parse(rawBody) as EspoWebhookEnvelope;
+  } catch {
+    return NextResponse.json({ error: "invalid_json" }, { status: 400 });
+  }
+
+  if (payload.verification === true || payload.data?.verification === true) {
+    return NextResponse.json({ ok: true, verification: true });
+  }
+
+  const records = payload.list ?? (payload.data ? [payload.data] : []);
+  if (records.length === 0) {
+    return NextResponse.json({ ok: true, skipped: "no_records" }, { status: 202 });
+  }
+
+  const [entity, action] = parseEspoEvent(payload.event);
+  if (!entity || !action) {
+    // EspoCRM may POST the entity record itself without the wrapper; we infer
+    // the event from the URL path segment if the operator used the convention
+    // `?event=Contact.create`. Otherwise, no-op-ack so the receiver stays
+    // forward-compatible with payload shapes we don't recognise yet.
+    const inferred = new URL(req.url).searchParams.get("event");
+    const [e2, a2] = parseEspoEvent(inferred ?? undefined);
+    if (!e2 || !a2) {
+      return NextResponse.json({ ok: true, skipped: "no_event" }, { status: 202 });
+    }
+    await dispatch(e2, a2, records);
+    return NextResponse.json({ ok: true, dispatched: records.length });
+  }
+
+  await dispatch(entity, action, records);
+  return NextResponse.json({ ok: true, dispatched: records.length });
+}
+
+async function dispatch(
+  entity: string,
+  action: string,
+  records: EspoEntityRecord[]
+): Promise<void> {
+  // Slack sends in parallel; Promise.allSettled so one failure doesn't drop
+  // others. Errors are logged inside SlackClient.
+  const tasks: Promise<void>[] = [];
+  for (const rec of records ?? []) {
+    if (entity === "Contact" && action === "create") tasks.push(notifyContactCreated(rec));
+    else if (entity === "Lead" && action === "create") tasks.push(notifyLeadCreated(rec));
+    else if (entity === "Opportunity" && action === "create")
+      tasks.push(notifyOpportunityCreated(rec));
+    else if (entity === "Opportunity" && action === "update" && rec.stage)
+      tasks.push(notifyOpportunityStageChanged(rec));
+    else if (entity === "Case" && action === "create") tasks.push(notifyCaseCreated(rec));
+    else if (entity === "Case" && action === "update" && rec.status)
+      tasks.push(notifyCaseStatusChanged(rec));
+    // unknown <Entity.action> combos are silently ignored — keep the receiver
+    // forward-compatible with EspoCRM versions that add new event types.
+  }
+  await Promise.allSettled(tasks);
+}

--- a/src/lib/espocrm-slack.ts
+++ b/src/lib/espocrm-slack.ts
@@ -1,0 +1,178 @@
+/**
+ * EspoCRM event → Slack message formatters.
+ *
+ * Routes each event type to a SlackClient pinned to a specific channel. The
+ * client itself handles retry/backoff/webhook-fallback (per the
+ * `feedback_slack_use_slackclient` memory) — we never call `chat.postMessage`
+ * directly.
+ *
+ * Channel choices match the existing convention in src/lib/slack-notify.ts:
+ *   #leads          new Contact / Lead
+ *   #orders         new Opportunity, stage change, won/lost
+ *   #notifications  new Case (support ticket), status change
+ *   #notifications  catch-all for everything else
+ */
+import { SlackClient } from "@/lib/slack-notify";
+import type { EspoEntityRecord } from "@/lib/espocrm-webhook";
+
+const leadsClient = new SlackClient({ channel: "#leads" });
+const ordersClient = new SlackClient({ channel: "#orders" });
+const notificationsClient = new SlackClient({ channel: "#notifications" });
+
+function deepLinkFor(entity: string, id: string, baseUrl?: string): string {
+  const root = (baseUrl ?? "https://espocrm.cloudless.gr").replace(/\/$/, "");
+  return `${root}/#${entity}/view/${id}`;
+}
+
+function fmtMoney(amount?: number, currency?: string): string {
+  if (amount === undefined || amount === null) return "";
+  return new Intl.NumberFormat("en-US", {
+    style: "currency",
+    currency: currency ?? "EUR",
+    maximumFractionDigits: 0,
+  }).format(amount);
+}
+
+/* ─── Per-entity event handlers ──────────────────────────────────────────── */
+
+export async function notifyContactCreated(rec: EspoEntityRecord, baseUrl?: string): Promise<void> {
+  const url = deepLinkFor("Contact", rec.id, baseUrl);
+  const name = rec.name ?? rec.emailAddress ?? rec.id;
+  await leadsClient.post({
+    text: `:wave: New contact in CRM — ${name}`,
+    blocks: [
+      { type: "header", text: { type: "plain_text", text: ":wave: New contact", emoji: true } },
+      {
+        type: "section",
+        fields: [
+          { type: "mrkdwn", text: `*Name*\n<${url}|${name}>` },
+          rec.emailAddress ? { type: "mrkdwn", text: `*Email*\n${rec.emailAddress}` } : null,
+          rec.phoneNumber ? { type: "mrkdwn", text: `*Phone*\n${rec.phoneNumber}` } : null,
+          rec.assignedUserName
+            ? { type: "mrkdwn", text: `*Owner*\n${rec.assignedUserName}` }
+            : null,
+        ].filter(Boolean) as Array<{ type: string; text: string }>,
+      },
+      {
+        type: "actions",
+        elements: [{ type: "button", text: { type: "plain_text", text: "Open in EspoCRM" }, url }],
+      },
+    ],
+  });
+}
+
+export async function notifyLeadCreated(rec: EspoEntityRecord, baseUrl?: string): Promise<void> {
+  await leadsClient.post({
+    text: `:dart: New lead — ${rec.name ?? rec.id}`,
+    blocks: [
+      { type: "header", text: { type: "plain_text", text: ":dart: New lead", emoji: true } },
+      {
+        type: "section",
+        fields: [
+          {
+            type: "mrkdwn",
+            text: `*Name*\n<${deepLinkFor("Lead", rec.id, baseUrl)}|${rec.name ?? rec.id}>`,
+          },
+          rec.emailAddress ? { type: "mrkdwn", text: `*Email*\n${rec.emailAddress}` } : null,
+        ].filter(Boolean) as Array<{ type: string; text: string }>,
+      },
+    ],
+  });
+}
+
+export async function notifyOpportunityCreated(
+  rec: EspoEntityRecord,
+  baseUrl?: string
+): Promise<void> {
+  await ordersClient.post({
+    text: `:moneybag: New opportunity — ${rec.name ?? rec.id}`,
+    blocks: [
+      {
+        type: "header",
+        text: { type: "plain_text", text: ":moneybag: New opportunity", emoji: true },
+      },
+      {
+        type: "section",
+        fields: [
+          {
+            type: "mrkdwn",
+            text: `*Name*\n<${deepLinkFor("Opportunity", rec.id, baseUrl)}|${rec.name ?? rec.id}>`,
+          },
+          rec.amount
+            ? { type: "mrkdwn", text: `*Amount*\n${fmtMoney(rec.amount, rec.amountCurrency)}` }
+            : null,
+          rec.stage ? { type: "mrkdwn", text: `*Stage*\n${rec.stage}` } : null,
+        ].filter(Boolean) as Array<{ type: string; text: string }>,
+      },
+    ],
+  });
+}
+
+export async function notifyOpportunityStageChanged(
+  rec: EspoEntityRecord,
+  baseUrl?: string
+): Promise<void> {
+  const emoji =
+    rec.stage === "Closed Won" ? ":tada:" : rec.stage === "Closed Lost" ? ":x:" : ":arrow_right:";
+  await ordersClient.post({
+    text: `${emoji} ${rec.name ?? rec.id} → ${rec.stage ?? "?"}`,
+    blocks: [
+      {
+        type: "section",
+        text: {
+          type: "mrkdwn",
+          text:
+            `${emoji} *<${deepLinkFor("Opportunity", rec.id, baseUrl)}|${rec.name ?? rec.id}>*\n` +
+            `Stage → *${rec.stage ?? "?"}*` +
+            (rec.amount ? ` · ${fmtMoney(rec.amount, rec.amountCurrency)}` : ""),
+        },
+      },
+    ],
+  });
+}
+
+export async function notifyCaseCreated(rec: EspoEntityRecord, baseUrl?: string): Promise<void> {
+  await notificationsClient.post({
+    text: `:ticket: New case — ${rec.name ?? rec.id}`,
+    blocks: [
+      {
+        type: "header",
+        text: { type: "plain_text", text: ":ticket: New support case", emoji: true },
+      },
+      {
+        type: "section",
+        fields: [
+          {
+            type: "mrkdwn",
+            text: `*Subject*\n<${deepLinkFor("Case", rec.id, baseUrl)}|${rec.name ?? rec.id}>`,
+          },
+          rec.status ? { type: "mrkdwn", text: `*Status*\n${rec.status}` } : null,
+          rec.assignedUserName
+            ? { type: "mrkdwn", text: `*Assigned*\n${rec.assignedUserName}` }
+            : null,
+        ].filter(Boolean) as Array<{ type: string; text: string }>,
+      },
+    ],
+  });
+}
+
+export async function notifyCaseStatusChanged(
+  rec: EspoEntityRecord,
+  baseUrl?: string
+): Promise<void> {
+  const emoji = rec.status === "Closed" ? ":white_check_mark:" : ":arrows_counterclockwise:";
+  await notificationsClient.post({
+    text: `${emoji} Case ${rec.name ?? rec.id} → ${rec.status ?? "?"}`,
+    blocks: [
+      {
+        type: "section",
+        text: {
+          type: "mrkdwn",
+          text:
+            `${emoji} *<${deepLinkFor("Case", rec.id, baseUrl)}|${rec.name ?? rec.id}>*\n` +
+            `Status → *${rec.status ?? "?"}*`,
+        },
+      },
+    ],
+  });
+}

--- a/src/lib/espocrm-webhook.ts
+++ b/src/lib/espocrm-webhook.ts
@@ -1,0 +1,84 @@
+/**
+ * EspoCRM webhook payload shapes + URL-secret verification.
+ *
+ * EspoCRM's free Webhook entity does NOT sign the payload — it POSTs JSON to
+ * the configured URL. The only auth available is a shared secret carried in
+ * the URL itself (`?secret=<hex>`). We compare it constant-time against
+ * `ESPOCRM_WEBHOOK_SECRET` from SSM (see Postiz for the same pattern).
+ *
+ * Event naming convention: `<Entity>.<event>` — `Contact.create`,
+ * `Opportunity.update`, `Case.delete`. The Webhook entity in EspoCRM lets
+ * you subscribe to per-entity events; one Webhook can target multiple events.
+ */
+import { getIntegrationsAsync } from "@/lib/integrations";
+import { timingSafeEqual } from "node:crypto";
+
+export interface EspoWebhookEnvelope {
+  /**
+   * Some EspoCRM versions wrap payloads in `{event, data}`; others POST the
+   * raw entity record. We tolerate both — `event` may be undefined when
+   * EspoCRM POSTs raw.
+   */
+  event?: string;
+  /** Single-entity payload (older format / `Entity.create`). */
+  data?: EspoEntityRecord;
+  /** Multi-entity payload (newer format). EspoCRM may batch updates. */
+  list?: EspoEntityRecord[];
+  /** Smoke-test bypass — when present at any level the handler ACKs but
+   *  skips Slack notification and any side-effects. */
+  verification?: boolean;
+}
+
+export interface EspoEntityRecord {
+  id: string;
+  /** Display name (already concat'd by EspoCRM for Contact = first + last). */
+  name?: string;
+  emailAddress?: string;
+  phoneNumber?: string;
+  stage?: string;
+  status?: string;
+  amount?: number;
+  amountCurrency?: string;
+  /** Activity-stream fields when the webhook fires on Note. */
+  post?: string;
+  parentType?: string;
+  parentId?: string;
+  parentName?: string;
+  createdAt?: string;
+  modifiedAt?: string;
+  assignedUserName?: string;
+  /** Catch-all — EspoCRM custom fields land here untyped. */
+  [key: string]: unknown;
+}
+
+/**
+ * Verify the inbound webhook against the SSM-stored shared secret.
+ * Returns true only when the URL `?secret=` matches the configured value
+ * AND the configured value is non-empty (an unset secret is never a
+ * valid match — never auth-bypass for unconfigured deployments).
+ */
+export async function verifyEspoWebhookSecret(urlSecret: string | null): Promise<boolean> {
+  if (!urlSecret) return false;
+  const cfg = await getIntegrationsAsync();
+  const expected = cfg.ESPOCRM_WEBHOOK_SECRET;
+  if (!expected) return false;
+  const a = Buffer.from(urlSecret);
+  const b = Buffer.from(expected);
+  if (a.length !== b.length) return false;
+  return timingSafeEqual(a, b);
+}
+
+/**
+ * Parse the Espo-event name `<Entity>.<event>` into a tuple. Returns
+ * `[null, null]` when the event field is absent or malformed — callers should
+ * treat this as "ignored event" rather than an error (Espo may add new event
+ * shapes; ignoring keeps the receiver forward-compatible).
+ */
+export function parseEspoEvent(
+  event: string | undefined
+): [entity: string | null, action: string | null] {
+  if (!event) return [null, null];
+  const i = event.indexOf(".");
+  if (i <= 0 || i === event.length - 1) return [null, null];
+  return [event.slice(0, i), event.slice(i + 1)];
+}

--- a/src/lib/espocrm.ts
+++ b/src/lib/espocrm.ts
@@ -1,0 +1,606 @@
+/**
+ * EspoCRM client — drop-in replacement for src/lib/hubspot.ts.
+ *
+ * Every function exported here mirrors a function in lib/hubspot.ts so callers
+ * can flip imports without changing call sites:
+ *
+ *   - import { upsertContact, createTicket, listDeals } from "@/lib/hubspot";
+ *   + import { upsertContact, createTicket, listDeals } from "@/lib/espocrm";
+ *
+ * EspoCRM module mapping vs HubSpot:
+ *   HubSpot           EspoCRM
+ *   -------           -------
+ *   contact           Contact
+ *   company           Account
+ *   deal              Opportunity
+ *   ticket            Case
+ *   note              Note (parent on Contact / Opportunity)
+ *   owner             User (type=regular)
+ *   pipeline          Opportunity.stage enum (single pipeline in OSS)
+ *
+ * Auth: `Espo-Authorization: <base64 user:pwd>` or `X-Api-Key: <hex>`.
+ * We use API-key auth (the `cloudless-app` API user, role
+ * `Cloudless App Full Access`).
+ *
+ * Config: ESPOCRM_BASE_URL + ESPOCRM_API_KEY, both in SSM under
+ * `/cloudless/production/`; getIntegrationsAsync() reads them.
+ */
+import { getIntegrationsAsync } from "@/lib/integrations";
+
+const PAGE_SIZE = 100;
+const MAX_LIMIT = 100;
+
+interface EspoContact {
+  email: string;
+  firstname?: string;
+  lastname?: string;
+  company?: string;
+  phone?: string;
+  service_interest?: string;
+  message?: string;
+  lead_source?: string;
+}
+
+/** Resolve EspoCRM base URL + API key from env or SSM. Throws if unset. */
+async function getEspoConfig(): Promise<{ baseUrl: string; apiKey: string }> {
+  const cfg = await getIntegrationsAsync();
+  const baseUrl = cfg.ESPOCRM_BASE_URL;
+  const apiKey = cfg.ESPOCRM_API_KEY;
+  if (!baseUrl || !apiKey) {
+    throw new Error("EspoCRM not configured (ESPOCRM_BASE_URL/API_KEY missing in env+SSM)");
+  }
+  return { baseUrl: baseUrl.replace(/\/$/, ""), apiKey };
+}
+
+async function espoFetch(path: string, init: RequestInit = {}): Promise<Response> {
+  const { baseUrl, apiKey } = await getEspoConfig();
+  return fetch(`${baseUrl}/api/v1${path}`, {
+    ...init,
+    headers: {
+      "Content-Type": "application/json",
+      "X-Api-Key": apiKey,
+      ...init.headers,
+    },
+  });
+}
+
+/**
+ * Walk a paginated EspoCRM list endpoint. EspoCRM uses `offset`+`maxSize` not
+ * cursor pagination, so we stride by PAGE_SIZE until the page returns fewer
+ * than that many results.
+ */
+async function espoListAll<T = unknown>(
+  entity: string,
+  baseParams: Record<string, string> = {}
+): Promise<T[]> {
+  const all: T[] = [];
+  let offset = 0;
+  do {
+    const params = new URLSearchParams({
+      offset: String(offset),
+      maxSize: String(PAGE_SIZE),
+      ...baseParams,
+    });
+    const res = await espoFetch(`/${entity}?${params.toString()}`);
+    if (!res.ok) break;
+    const data = (await res.json()) as { list: T[]; total: number };
+    all.push(...data.list);
+    if (data.list.length < PAGE_SIZE) break;
+    offset += PAGE_SIZE;
+  } while (true);
+  return all;
+}
+
+/**
+ * Map a HubSpot-shaped contact onto EspoCRM Contact fields. EspoCRM stores
+ * `accountId` not `company` name — we leave company as a free-text custom
+ * field (cAccountName) on initial create; an admin can wire it to a real
+ * Account record later via Workflow.
+ */
+function toEspoContactPayload(c: EspoContact): Record<string, unknown> {
+  return {
+    emailAddress: c.email,
+    firstName: c.firstname ?? "",
+    lastName: c.lastname ?? c.email.split("@")[0],
+    accountName: c.company ?? undefined,
+    phoneNumber: c.phone ?? undefined,
+    description: [c.message, c.service_interest && `Service: ${c.service_interest}`]
+      .filter(Boolean)
+      .join("\n\n"),
+    leadSource: mapLeadSource(c.lead_source),
+  };
+}
+
+function mapLeadSource(s?: string): string | undefined {
+  if (!s) return undefined;
+  switch (s) {
+    case "website_contact_form":
+    case "contact_form":
+      return "Web Site";
+    case "newsletter_signup":
+      return "Email";
+    case "newsletter_unsubscribed":
+      return "Email";
+    default:
+      return s; // EspoCRM treats unknown values as Other
+  }
+}
+
+/** Create or update a contact (uniqueness by email). */
+export async function upsertContact(contact: EspoContact): Promise<string | null> {
+  try {
+    // EspoCRM has no upsert primitive — search first, then POST or PATCH.
+    const search = await espoFetch(
+      `/Contact?` +
+        new URLSearchParams({
+          "where[0][type]": "equals",
+          "where[0][attribute]": "emailAddress",
+          "where[0][value]": contact.email,
+          maxSize: "1",
+        }).toString()
+    );
+    if (search.ok) {
+      const data = (await search.json()) as { list: { id: string }[]; total: number };
+      const existing = data.list[0];
+      if (existing) {
+        await espoFetch(`/Contact/${existing.id}`, {
+          method: "PUT",
+          body: JSON.stringify(toEspoContactPayload(contact)),
+        });
+        return existing.id;
+      }
+    }
+    const create = await espoFetch("/Contact", {
+      method: "POST",
+      body: JSON.stringify(toEspoContactPayload(contact)),
+    });
+    if (!create.ok) {
+      console.error("[EspoCRM] upsertContact create failed:", create.status);
+      return null;
+    }
+    const created = (await create.json()) as { id: string };
+    return created.id;
+  } catch (err) {
+    console.error("[EspoCRM] upsertContact error:", err);
+    return null;
+  }
+}
+
+/** Fetch every newsletter subscriber email. We treat leadSource=Email as
+ *  the subscribed state. Mirrors the HubSpot newsletter_signup convention. */
+export async function listNewsletterSubscribers(): Promise<string[]> {
+  try {
+    const all = await espoListAll<{ emailAddress?: string }>("Contact", {
+      "where[0][type]": "equals",
+      "where[0][attribute]": "leadSource",
+      "where[0][value]": "Email",
+      select: "emailAddress",
+    });
+    return [...new Set(all.map((c) => c.emailAddress).filter((e): e is string => Boolean(e)))];
+  } catch (err) {
+    console.error("[EspoCRM] listNewsletterSubscribers error:", err);
+    return [];
+  }
+}
+
+/** Flip a contact's newsletter state. Maps to leadSource = Email / Other. */
+export async function setNewsletterStatus(
+  email: string,
+  status: "newsletter_signup" | "newsletter_unsubscribed"
+): Promise<boolean> {
+  try {
+    const search = await espoFetch(
+      `/Contact?` +
+        new URLSearchParams({
+          "where[0][type]": "equals",
+          "where[0][attribute]": "emailAddress",
+          "where[0][value]": email,
+          maxSize: "1",
+        }).toString()
+    );
+    if (search.ok) {
+      const data = (await search.json()) as { list: { id: string }[] };
+      const existing = data.list[0];
+      if (existing) {
+        const upd = await espoFetch(`/Contact/${existing.id}`, {
+          method: "PUT",
+          body: JSON.stringify({
+            leadSource: status === "newsletter_signup" ? "Email" : "Other",
+          }),
+        });
+        return upd.ok;
+      }
+    }
+    if (status === "newsletter_unsubscribed") return true; // unknown email + unsub = no-op
+    const create = await espoFetch("/Contact", {
+      method: "POST",
+      body: JSON.stringify({
+        emailAddress: email,
+        lastName: email.split("@")[0],
+        leadSource: "Email",
+      }),
+    });
+    return create.ok;
+  } catch {
+    return false;
+  }
+}
+
+function clampLimit(limit: number, fallback = 20): number {
+  return Number.isFinite(limit) ? Math.min(Math.max(Math.trunc(limit), 1), MAX_LIMIT) : fallback;
+}
+
+export async function listContacts(limit = 10): Promise<unknown[]> {
+  try {
+    const res = await espoFetch(`/Contact?maxSize=${clampLimit(limit, 10)}`);
+    if (!res.ok) return [];
+    return (((await res.json()) as { list: unknown[] }).list ?? []) as unknown[];
+  } catch {
+    return [];
+  }
+}
+
+export async function listTickets(limit = 20): Promise<unknown[]> {
+  try {
+    const res = await espoFetch(`/Case?maxSize=${clampLimit(limit)}`);
+    if (!res.ok) return [];
+    return (((await res.json()) as { list: unknown[] }).list ?? []) as unknown[];
+  } catch {
+    return [];
+  }
+}
+
+interface TicketData {
+  subject: string;
+  content: string;
+  hs_pipeline?: string;
+  hs_pipeline_stage?: string;
+  hs_ticket_priority?: string;
+}
+
+/**
+ * Create a Case. Maps HubSpot ticket-priority strings (LOW/MEDIUM/HIGH/URGENT)
+ * to EspoCRM Case.priority (Low/Normal/High/Urgent).
+ */
+export async function createTicket(
+  data: TicketData,
+  contactId?: string
+): Promise<{ id: string } | null> {
+  const priorityMap: Record<string, string> = {
+    LOW: "Low",
+    MEDIUM: "Normal",
+    HIGH: "High",
+    URGENT: "Urgent",
+  };
+  const body: Record<string, unknown> = {
+    name: data.subject,
+    description: data.content,
+    status: data.hs_pipeline_stage || "New",
+    priority: priorityMap[data.hs_ticket_priority ?? "MEDIUM"] ?? "Normal",
+    contactId: contactId ?? undefined,
+  };
+  const res = await espoFetch("/Case", { method: "POST", body: JSON.stringify(body) });
+  if (!res.ok) {
+    const err = await res.text().catch(() => "");
+    throw new Error(`EspoCRM Case create failed ${res.status}: ${err.slice(0, 200)}`);
+  }
+  const created = (await res.json()) as { id: string };
+  return { id: created.id };
+}
+
+/**
+ * Return a single-pipeline shape compatible with HubSpot's getPipelines() so
+ * the admin pipeline UI doesn't have to branch on backend. The OSS EspoCRM
+ * Opportunity module has one pipeline backed by the `stage` enum.
+ */
+export async function getPipelines(_objectType = "deals"): Promise<unknown[]> {
+  void _objectType;
+  return [
+    {
+      id: "default",
+      label: "Sales Pipeline",
+      stages: [
+        { id: "Prospecting", label: "Prospecting", probability: 10 },
+        { id: "Qualification", label: "Qualification", probability: 20 },
+        { id: "Proposal", label: "Proposal/Price Quote", probability: 50 },
+        { id: "Negotiation", label: "Negotiation/Review", probability: 75 },
+        { id: "Closed Won", label: "Closed Won", probability: 100 },
+        { id: "Closed Lost", label: "Closed Lost", probability: 0 },
+      ],
+    },
+  ];
+}
+
+export async function listCompanies(limit = 20): Promise<unknown[]> {
+  try {
+    const res = await espoFetch(`/Account?maxSize=${clampLimit(limit)}`);
+    if (!res.ok) return [];
+    return (((await res.json()) as { list: unknown[] }).list ?? []) as unknown[];
+  } catch {
+    return [];
+  }
+}
+
+export async function listDeals(limit = 20): Promise<unknown[]> {
+  try {
+    const res = await espoFetch(`/Opportunity?maxSize=${clampLimit(limit)}`);
+    if (!res.ok) return [];
+    return (((await res.json()) as { list: unknown[] }).list ?? []) as unknown[];
+  } catch {
+    return [];
+  }
+}
+
+export async function listOwners(): Promise<unknown[]> {
+  try {
+    const res = await espoFetch(
+      `/User?` +
+        new URLSearchParams({
+          "where[0][type]": "equals",
+          "where[0][attribute]": "type",
+          "where[0][value]": "regular",
+          maxSize: "100",
+        }).toString()
+    );
+    if (!res.ok) return [];
+    return (((await res.json()) as { list: unknown[] }).list ?? []) as unknown[];
+  } catch {
+    return [];
+  }
+}
+
+/** Search Contacts by an attribute (e.g. emailAddress). Property names map:
+ *  HubSpot `email` -> EspoCRM `emailAddress`; firstname/lastname unchanged. */
+export async function searchContacts(
+  propertyName: string,
+  value: string
+): Promise<{
+  total: number;
+  results: Array<{ id: string; properties: Record<string, string> }>;
+}> {
+  const espoAttr =
+    propertyName === "email"
+      ? "emailAddress"
+      : propertyName === "firstname"
+        ? "firstName"
+        : propertyName === "lastname"
+          ? "lastName"
+          : propertyName;
+  const res = await espoFetch(
+    `/Contact?` +
+      new URLSearchParams({
+        "where[0][type]": "equals",
+        "where[0][attribute]": espoAttr,
+        "where[0][value]": value,
+        maxSize: "100",
+      }).toString()
+  );
+  if (!res.ok) {
+    throw new Error(`EspoCRM search failed ${res.status}`);
+  }
+  const data = (await res.json()) as {
+    list: Array<Record<string, unknown> & { id: string }>;
+    total: number;
+  };
+  return {
+    total: data.total,
+    results: data.list.map((c) => ({
+      id: c.id,
+      properties: Object.fromEntries(
+        Object.entries(c).map(([k, v]) => [k, v == null ? "" : String(v)])
+      ),
+    })),
+  };
+}
+
+export async function isHubSpotConfigured(): Promise<boolean> {
+  // Kept name so `lib/hubspot` callers don't break on import-flip. Prefer the
+  // new name `isEspoCRMConfigured` in new code.
+  return isEspoCRMConfigured();
+}
+
+export async function isEspoCRMConfigured(): Promise<boolean> {
+  try {
+    await getEspoConfig();
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/* ─── Opportunity automation (HubSpot "deal" equivalents) ────────────────── */
+
+export type DealSource = "stripe_checkout" | "calendar_booking" | "contact_form";
+
+interface DealData {
+  dealname: string;
+  amount?: number;
+  currency?: string;
+  dealstage?: string;
+  pipeline?: string;
+  closedate?: string;
+  lead_source?: DealSource;
+  description?: string;
+  service_interest?: string;
+}
+
+function toEspoOpportunityPayload(data: DealData): Record<string, unknown> {
+  return {
+    name: data.dealname,
+    amount: data.amount ?? undefined,
+    amountCurrency: (data.currency ?? "EUR").toUpperCase(),
+    stage: data.dealstage ?? (data.amount !== undefined ? "Closed Won" : "Prospecting"),
+    closeDate: (data.closedate ?? new Date().toISOString()).slice(0, 10),
+    leadSource: mapLeadSource(data.lead_source),
+    description: [data.description, data.service_interest && `Service: ${data.service_interest}`]
+      .filter(Boolean)
+      .join("\n\n"),
+  };
+}
+
+export async function createDeal(data: DealData): Promise<string | null> {
+  try {
+    const res = await espoFetch("/Opportunity", {
+      method: "POST",
+      body: JSON.stringify(toEspoOpportunityPayload(data)),
+    });
+    if (!res.ok) {
+      console.error("[EspoCRM] createDeal failed:", res.status);
+      return null;
+    }
+    const created = (await res.json()) as { id: string };
+    return created.id;
+  } catch (err) {
+    console.error("[EspoCRM] createDeal error:", err);
+    return null;
+  }
+}
+
+export async function updateDeal(
+  id: string,
+  data: Partial<Record<string, string>>
+): Promise<{ id: string } | null> {
+  try {
+    // HubSpot uses snake_case property names; EspoCRM uses camelCase. Map the
+    // common ones; pass anything else through (custom fields use whatever name
+    // the operator created them with).
+    const mapped: Record<string, unknown> = {};
+    for (const [k, v] of Object.entries(data)) {
+      if (k === "dealname") mapped.name = v;
+      else if (k === "dealstage") mapped.stage = v;
+      else if (k === "amount") mapped.amount = v;
+      else if (k === "closedate") mapped.closeDate = String(v).slice(0, 10);
+      else mapped[k] = v;
+    }
+    const res = await espoFetch(`/Opportunity/${id}`, {
+      method: "PUT",
+      body: JSON.stringify(mapped),
+    });
+    if (!res.ok) return null;
+    const j = (await res.json()) as { id: string };
+    return { id: j.id };
+  } catch {
+    return null;
+  }
+}
+
+export async function moveDealStage(id: string, stageId: string): Promise<{ id: string } | null> {
+  return updateDeal(id, { dealstage: stageId });
+}
+
+export async function getDealsByStage(): Promise<Record<string, unknown[]>> {
+  try {
+    const all = await espoListAll<{ stage: string }>("Opportunity", {
+      select: "name,amount,stage,closeDate,createdAt,probability",
+    });
+    const grouped: Record<string, unknown[]> = {};
+    for (const d of all) {
+      const stage = d.stage ?? "Unknown";
+      if (!grouped[stage]) grouped[stage] = [];
+      grouped[stage].push(d);
+    }
+    return grouped;
+  } catch {
+    return {};
+  }
+}
+
+/* ─── Notes ───────────────────────────────────────────────────────────────── */
+
+/** Create a Note (Stream post) on an Opportunity. */
+export async function createNote(dealId: string, body: string): Promise<{ id: string } | null> {
+  try {
+    const res = await espoFetch("/Note", {
+      method: "POST",
+      body: JSON.stringify({
+        type: "Post",
+        post: body,
+        parentType: "Opportunity",
+        parentId: dealId,
+      }),
+    });
+    if (!res.ok) return null;
+    const j = (await res.json()) as { id: string };
+    return { id: j.id };
+  } catch {
+    return null;
+  }
+}
+
+/** Create a Note on a Contact's stream. */
+export async function createContactNote(
+  contactId: string,
+  body: string
+): Promise<{ id: string } | null> {
+  try {
+    const res = await espoFetch("/Note", {
+      method: "POST",
+      body: JSON.stringify({
+        type: "Post",
+        post: body,
+        parentType: "Contact",
+        parentId: contactId,
+      }),
+    });
+    if (!res.ok) return null;
+    const j = (await res.json()) as { id: string };
+    return { id: j.id };
+  } catch {
+    return null;
+  }
+}
+
+/** List notes for an Opportunity. */
+export async function listNotes(dealId: string): Promise<unknown[]> {
+  try {
+    const res = await espoFetch(
+      `/Opportunity/${dealId}/notes?` +
+        new URLSearchParams({ maxSize: "100", select: "post,createdAt,type" }).toString()
+    );
+    if (!res.ok) return [];
+    return (((await res.json()) as { list: unknown[] }).list ?? []) as unknown[];
+  } catch {
+    return [];
+  }
+}
+
+/** Pipeline stats: count + total value per stage. */
+export async function getPipelineStats(): Promise<{
+  totalDeals: number;
+  totalValue: number;
+  byStage: Record<string, { count: number; value: number }>;
+}> {
+  try {
+    const all = await espoListAll<{ stage: string; amount: number | null }>("Opportunity", {
+      select: "stage,amount",
+    });
+    const byStage: Record<string, { count: number; value: number }> = {};
+    let totalValue = 0;
+    for (const d of all) {
+      const stage = d.stage ?? "Unknown";
+      const val = Number(d.amount ?? 0) || 0;
+      if (!byStage[stage]) byStage[stage] = { count: 0, value: 0 };
+      byStage[stage].count++;
+      byStage[stage].value += val;
+      totalValue += val;
+    }
+    return { totalDeals: all.length, totalValue, byStage };
+  } catch {
+    return { totalDeals: 0, totalValue: 0, byStage: {} };
+  }
+}
+
+/**
+ * Associate an Opportunity with a Contact. EspoCRM uses link-based relations;
+ * the `contacts` link on Opportunity is many-to-many, so we POST to the link.
+ */
+export async function associateDealWithContact(dealId: string, contactId: string): Promise<void> {
+  try {
+    await espoFetch(`/Opportunity/${dealId}/contacts`, {
+      method: "POST",
+      body: JSON.stringify({ id: contactId }),
+    });
+  } catch (err) {
+    console.error("[EspoCRM] associateDealWithContact error:", err);
+  }
+}

--- a/src/lib/integrations.ts
+++ b/src/lib/integrations.ts
@@ -70,6 +70,10 @@ export interface IntegrationConfig {
   META_PAGE_ID?: string;
   // AI
   ANTHROPIC_API_KEY?: string;
+  // EspoCRM (HubSpot replacement, self-hosted on omv k3s)
+  ESPOCRM_BASE_URL?: string;
+  ESPOCRM_API_KEY?: string;
+  ESPOCRM_WEBHOOK_SECRET?: string;
 }
 
 let cached: IntegrationConfig | null = null;
@@ -131,6 +135,9 @@ export function getIntegrations(): IntegrationConfig {
     META_ACCESS_TOKEN: process.env.META_ACCESS_TOKEN,
     META_PAGE_ID: process.env.META_PAGE_ID,
     ANTHROPIC_API_KEY: process.env.ANTHROPIC_API_KEY,
+    ESPOCRM_BASE_URL: process.env.ESPOCRM_BASE_URL,
+    ESPOCRM_API_KEY: process.env.ESPOCRM_API_KEY,
+    ESPOCRM_WEBHOOK_SECRET: process.env.ESPOCRM_WEBHOOK_SECRET,
   };
 
   return cached;
@@ -243,6 +250,10 @@ export async function getIntegrationsAsync(): Promise<IntegrationConfig> {
       META_ACCESS_TOKEN: envCfg.META_ACCESS_TOKEN || ssm.META_ACCESS_TOKEN || undefined,
       META_PAGE_ID: envCfg.META_PAGE_ID || ssm.META_PAGE_ID || undefined,
       ANTHROPIC_API_KEY: envCfg.ANTHROPIC_API_KEY || ssm.ANTHROPIC_API_KEY || undefined,
+      ESPOCRM_BASE_URL: envCfg.ESPOCRM_BASE_URL || ssm.ESPOCRM_BASE_URL || undefined,
+      ESPOCRM_API_KEY: envCfg.ESPOCRM_API_KEY || ssm.ESPOCRM_API_KEY || undefined,
+      ESPOCRM_WEBHOOK_SECRET:
+        envCfg.ESPOCRM_WEBHOOK_SECRET || ssm.ESPOCRM_WEBHOOK_SECRET || undefined,
     };
   } catch (err) {
     console.warn("[Integrations] SSM fallback failed, using env-only config:", err);

--- a/src/lib/ssm-config.ts
+++ b/src/lib/ssm-config.ts
@@ -37,6 +37,12 @@ interface AppConfig {
   NEWSLETTER_SLACK_CHANNEL_ID: string;
   HUBSPOT_API_KEY: string;
   HUBSPOT_CLIENT_SECRET: string;
+  /** EspoCRM (HubSpot replacement) — base URL of the self-hosted instance. */
+  ESPOCRM_BASE_URL: string;
+  /** EspoCRM API key for the `cloudless-app` API user. */
+  ESPOCRM_API_KEY: string;
+  /** Shared secret for EspoCRM webhook URL query-param auth. */
+  ESPOCRM_WEBHOOK_SECRET: string;
   NOTION_API_KEY: string;
   NOTION_BLOG_DB_ID: string;
   NOTION_WEBHOOK_SECRET: string;
@@ -192,6 +198,9 @@ function buildConfigFromParams(params: Map<string, string>): AppConfig {
     NEWSLETTER_SLACK_CHANNEL_ID: params.get("NEWSLETTER_SLACK_CHANNEL_ID") ?? "",
     HUBSPOT_API_KEY: params.get("HUBSPOT_API_KEY") ?? "",
     HUBSPOT_CLIENT_SECRET: params.get("HUBSPOT_CLIENT_SECRET") ?? "",
+    ESPOCRM_BASE_URL: params.get("ESPOCRM_BASE_URL") ?? "",
+    ESPOCRM_API_KEY: params.get("ESPOCRM_API_KEY") ?? "",
+    ESPOCRM_WEBHOOK_SECRET: params.get("ESPOCRM_WEBHOOK_SECRET") ?? "",
     NOTION_API_KEY: params.get("NOTION_API_KEY") ?? "",
     NOTION_BLOG_DB_ID: params.get("NOTION_BLOG_DB_ID") ?? "",
     NOTION_WEBHOOK_SECRET: params.get("NOTION_WEBHOOK_SECRET") ?? "",
@@ -275,6 +284,9 @@ function buildConfigFromEnv(): AppConfig {
     NEWSLETTER_SLACK_CHANNEL_ID: process.env.NEWSLETTER_SLACK_CHANNEL_ID || "",
     HUBSPOT_API_KEY: process.env.HUBSPOT_API_KEY || process.env.HUBSPOT_PRIVATE_APP_TOKEN || "",
     HUBSPOT_CLIENT_SECRET: process.env.HUBSPOT_CLIENT_SECRET || "",
+    ESPOCRM_BASE_URL: process.env.ESPOCRM_BASE_URL || "",
+    ESPOCRM_API_KEY: process.env.ESPOCRM_API_KEY || "",
+    ESPOCRM_WEBHOOK_SECRET: process.env.ESPOCRM_WEBHOOK_SECRET || "",
     NOTION_API_KEY: process.env.NOTION_API_KEY || "",
     NOTION_BLOG_DB_ID: process.env.NOTION_BLOG_DB_ID || "",
     NOTION_WEBHOOK_SECRET: process.env.NOTION_WEBHOOK_SECRET || "",


### PR DESCRIPTION
PR 3 of 5 — lib/espocrm.ts (21-function drop-in mirror of lib/hubspot.ts) + /api/webhooks/espocrm receiver routing 6 event types to Slack via SlackClient. SSM keys ESPOCRM_BASE_URL/_API_KEY/_WEBHOOK_SECRET set. API user cloudless-app created with full-access role. 6 Webhook entities registered in EspoCRM (Contact/Lead/Opportunity/Case create + update). Free Export Import extension v2.9.0 installed. Next: PR 4 flips imports across 19 admin routes/pages; PR 5 adds datalake ETL + IMAP setup. typecheck/lint/format clean.