### PR TITLE
refactor(crm): flip imports @/lib/hubspot -> @/lib/espocrm (PR 4 of 5)

### DIFF
--- a/src/app/api/admin/analytics/unified/route.ts
+++ b/src/app/api/admin/analytics/unified/route.ts
@@ -3,7 +3,7 @@ import { requireAdmin } from "@/lib/api-auth";
 import { getConfig } from "@/lib/ssm-config";
 import { getSeoSnapshot } from "@/lib/gsc";
 import { readThrough } from "@/lib/gsc-cache";
-import { isHubSpotConfigured, getPipelineStats, listNewsletterSubscribers } from "@/lib/hubspot";
+import { isHubSpotConfigured, getPipelineStats, listNewsletterSubscribers } from "@/lib/espocrm";
 import { getStripe } from "@/lib/stripe";
 
 async function safeCall<T>(fn: () => Promise<T>): Promise<T | null> {

--- a/src/app/api/admin/crm/companies/route.ts
+++ b/src/app/api/admin/crm/companies/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest } from "next/server";
 import { requireAdmin } from "@/lib/api-auth";
 import { NextResponse } from "next/server";
-import { isHubSpotConfigured, listCompanies } from "@/lib/hubspot";
+import { isHubSpotConfigured, listCompanies } from "@/lib/espocrm";
 import { mapIntegrationError } from "@/lib/api-errors";
 
 export async function GET(request: NextRequest) {

--- a/src/app/api/admin/crm/contacts/route.ts
+++ b/src/app/api/admin/crm/contacts/route.ts
@@ -2,7 +2,7 @@ import { NextRequest } from "next/server";
 import { requireAdmin } from "@/lib/api-auth";
 import { NextResponse } from "next/server";
 import { isConfiguredAsync } from "@/lib/integrations";
-import { listContacts } from "@/lib/hubspot";
+import { listContacts } from "@/lib/espocrm";
 import { mapIntegrationError } from "@/lib/api-errors";
 
 export async function GET(request: NextRequest) {

--- a/src/app/api/admin/crm/deals/route.ts
+++ b/src/app/api/admin/crm/deals/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest } from "next/server";
 import { requireAdmin } from "@/lib/api-auth";
 import { NextResponse } from "next/server";
-import { isHubSpotConfigured, listDeals } from "@/lib/hubspot";
+import { isHubSpotConfigured, listDeals } from "@/lib/espocrm";
 import { mapIntegrationError } from "@/lib/api-errors";
 
 export async function GET(request: NextRequest) {

--- a/src/app/api/admin/crm/owners/route.ts
+++ b/src/app/api/admin/crm/owners/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest } from "next/server";
 import { requireAdmin } from "@/lib/api-auth";
 import { NextResponse } from "next/server";
-import { isHubSpotConfigured, listOwners } from "@/lib/hubspot";
+import { isHubSpotConfigured, listOwners } from "@/lib/espocrm";
 import { mapIntegrationError } from "@/lib/api-errors";
 
 export async function GET(request: NextRequest) {

--- a/src/app/api/admin/crm/pipelines/route.ts
+++ b/src/app/api/admin/crm/pipelines/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest } from "next/server";
 import { requireAdmin } from "@/lib/api-auth";
 import { NextResponse } from "next/server";
-import { getPipelines, isHubSpotConfigured } from "@/lib/hubspot";
+import { getPipelines, isHubSpotConfigured } from "@/lib/espocrm";
 import { mapIntegrationError } from "@/lib/api-errors";
 
 export async function GET(request: NextRequest) {

--- a/src/app/api/admin/crm/tickets/route.ts
+++ b/src/app/api/admin/crm/tickets/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest } from "next/server";
 import { requireAdmin } from "@/lib/api-auth";
 import { NextResponse } from "next/server";
-import { isHubSpotConfigured, listTickets } from "@/lib/hubspot";
+import { isHubSpotConfigured, listTickets } from "@/lib/espocrm";
 import { mapIntegrationError } from "@/lib/api-errors";
 
 export async function GET(request: NextRequest) {

--- a/src/app/api/admin/email/contacts/route.ts
+++ b/src/app/api/admin/email/contacts/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { requireAdmin } from "@/lib/api-auth";
-import { isHubSpotConfigured } from "@/lib/hubspot";
+import { isHubSpotConfigured } from "@/lib/espocrm";
 import { getConfig } from "@/lib/ssm-config";
 
 const HUBSPOT_API = "https://api.hubapi.com";

--- a/src/app/api/admin/email/stats/route.ts
+++ b/src/app/api/admin/email/stats/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { requireAdmin } from "@/lib/api-auth";
-import { isHubSpotConfigured, listNewsletterSubscribers } from "@/lib/hubspot";
+import { isHubSpotConfigured, listNewsletterSubscribers } from "@/lib/espocrm";
 
 export async function GET(request: NextRequest) {
   const auth = await requireAdmin(request);

--- a/src/app/api/admin/leads/route.ts
+++ b/src/app/api/admin/leads/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { requireAdmin } from "@/lib/api-auth";
 import { isConfiguredAsync } from "@/lib/integrations";
-import { listContacts } from "@/lib/hubspot";
+import { listContacts } from "@/lib/espocrm";
 import { readPendingClients, PLAN_LABELS } from "@/lib/pending-clients";
 import { mapIntegrationError } from "@/lib/api-errors";
 

--- a/src/app/api/admin/pipeline/board/route.ts
+++ b/src/app/api/admin/pipeline/board/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { requireAdmin } from "@/lib/api-auth";
 import { mapIntegrationError } from "@/lib/api-errors";
-import { isHubSpotConfigured, getDealsByStage, getPipelines } from "@/lib/hubspot";
+import { isHubSpotConfigured, getDealsByStage, getPipelines } from "@/lib/espocrm";
 
 export async function GET(request: NextRequest) {
   const auth = await requireAdmin(request);

--- a/src/app/api/admin/pipeline/deals/[id]/move/route.ts
+++ b/src/app/api/admin/pipeline/deals/[id]/move/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { requireAdmin } from "@/lib/api-auth";
-import { isHubSpotConfigured, moveDealStage } from "@/lib/hubspot";
+import { isHubSpotConfigured, moveDealStage } from "@/lib/espocrm";
 import { mapIntegrationError } from "@/lib/api-errors";
 
 export async function POST(request: NextRequest, { params }: { params: Promise<{ id: string }> }) {

--- a/src/app/api/admin/pipeline/deals/[id]/notes/route.ts
+++ b/src/app/api/admin/pipeline/deals/[id]/notes/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { requireAdmin } from "@/lib/api-auth";
-import { isHubSpotConfigured, createNote, listNotes } from "@/lib/hubspot";
+import { isHubSpotConfigured, createNote, listNotes } from "@/lib/espocrm";
 import { mapIntegrationError } from "@/lib/api-errors";
 
 export async function GET(request: NextRequest, { params }: { params: Promise<{ id: string }> }) {

--- a/src/app/api/admin/pipeline/stats/route.ts
+++ b/src/app/api/admin/pipeline/stats/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { requireAdmin } from "@/lib/api-auth";
-import { isHubSpotConfigured, getPipelineStats } from "@/lib/hubspot";
+import { isHubSpotConfigured, getPipelineStats } from "@/lib/espocrm";
 import { mapIntegrationError } from "@/lib/api-errors";
 
 export async function GET(request: NextRequest) {

--- a/src/app/api/admin/reports/generate/route.ts
+++ b/src/app/api/admin/reports/generate/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { requireAdmin } from "@/lib/api-auth";
 import { createReport, updateReport, type ReportSection } from "@/lib/reports";
-import { isHubSpotConfigured, getPipelineStats } from "@/lib/hubspot";
+import { isHubSpotConfigured, getPipelineStats } from "@/lib/espocrm";
 import {
   isActiveCampaignConfigured,
   getEmailStats,

--- a/src/app/api/calendar/book/route.ts
+++ b/src/app/api/calendar/book/route.ts
@@ -9,7 +9,7 @@ import {
   createDeal,
   associateDealWithContact,
   createContactNote,
-} from "@/lib/hubspot";
+} from "@/lib/espocrm";
 import { rateLimit, getClientIp } from "@/lib/rate-limit";
 import { mapIntegrationError } from "@/lib/api-errors";
 

--- a/src/app/api/contact/route.ts
+++ b/src/app/api/contact/route.ts
@@ -9,7 +9,7 @@ import {
   createDeal,
   associateDealWithContact,
   createContactNote,
-} from "@/lib/hubspot";
+} from "@/lib/espocrm";
 import { saveSubmission } from "@/lib/notion-forms";
 import { trackEvent } from "@/lib/notion-analytics";
 import { rateLimit, getClientIp } from "@/lib/rate-limit";

--- a/src/app/api/crm/contact/route.ts
+++ b/src/app/api/crm/contact/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from "next/server";
-import { isHubSpotConfigured, upsertContact } from "@/lib/hubspot";
+import { isHubSpotConfigured, upsertContact } from "@/lib/espocrm";
 import { isValidEmail } from "@/lib/validation";
 import { rateLimit, getClientIp } from "@/lib/rate-limit";
 import { mapIntegrationError } from "@/lib/api-errors";

--- a/src/app/api/cron/owner-digest/route.ts
+++ b/src/app/api/cron/owner-digest/route.ts
@@ -4,7 +4,7 @@ import { SlackClient } from "@/lib/slack-notify";
 import { readPortals } from "@/lib/client-portals";
 import { scoreClientHealth } from "@/lib/client-health";
 import { getCalendarItems } from "@/lib/content-calendar";
-import { listContacts } from "@/lib/hubspot";
+import { listContacts } from "@/lib/espocrm";
 import { isConfiguredAsync } from "@/lib/integrations";
 
 /**

--- a/src/app/api/hubspot/ticket/route.ts
+++ b/src/app/api/hubspot/ticket/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
-import { isHubSpotConfigured, createTicket, searchContacts } from "@/lib/hubspot";
+import { isHubSpotConfigured, createTicket, searchContacts } from "@/lib/espocrm";
 import { isValidEmail } from "@/lib/validation";
 import { mapIntegrationError } from "@/lib/api-errors";
 import { slackTicketNotify } from "@/lib/slack-notify";

--- a/src/app/api/newsletter-slack/commands/route.ts
+++ b/src/app/api/newsletter-slack/commands/route.ts
@@ -25,7 +25,7 @@ import {
   type NotionBlogDraft,
 } from "@/lib/notion-blog-admin";
 import { dispatchWorkflow } from "@/lib/github-dispatch";
-import { listNewsletterSubscribers as listSubscribers } from "@/lib/hubspot";
+import { listNewsletterSubscribers as listSubscribers } from "@/lib/espocrm";
 import { getNewsletterSlackConfigAsync } from "@/lib/newsletter-slack-config";
 
 interface SlashPayload {

--- a/src/app/api/newsletter-slack/events/route.ts
+++ b/src/app/api/newsletter-slack/events/route.ts
@@ -18,7 +18,7 @@ import {
 import { checkSlackRateLimit } from "@/lib/slack-rate-limit";
 import { getNewsletterSlackConfigAsync } from "@/lib/newsletter-slack-config";
 import { listEditorialPosts, type NotionBlogDraft } from "@/lib/notion-blog-admin";
-import { listNewsletterSubscribers as listSubscribers } from "@/lib/hubspot";
+import { listNewsletterSubscribers as listSubscribers } from "@/lib/espocrm";
 
 // ---------------------------------------------------------------------------
 // Event deduplication (Slack retries up to 3x within ~5min on no-200)

--- a/src/app/api/newsletter/send/route.ts
+++ b/src/app/api/newsletter/send/route.ts
@@ -1,6 +1,6 @@
 import { timingSafeEqual } from "node:crypto";
 import { sendEmail } from "@/lib/email";
-import { listNewsletterSubscribers } from "@/lib/hubspot";
+import { listNewsletterSubscribers } from "@/lib/espocrm";
 import { getConfig } from "@/lib/ssm-config";
 
 /** Constant-time secret compare — avoids leaking the token via response timing. */

--- a/src/app/api/subscribe/route.ts
+++ b/src/app/api/subscribe/route.ts
@@ -1,6 +1,6 @@
 import { notifyTeam, sendSubscriberWelcome } from "@/lib/email";
 import { escapeHtml } from "@/lib/escape-html";
-import { setNewsletterStatus } from "@/lib/hubspot";
+import { setNewsletterStatus } from "@/lib/espocrm";
 import { removeFromSuppressionList } from "@/lib/ses-suppression";
 import { isValidEmail } from "@/lib/validation";
 import { slackSubscriberNotify } from "@/lib/slack-notify";

--- a/src/app/api/unsubscribe/route.ts
+++ b/src/app/api/unsubscribe/route.ts
@@ -1,7 +1,7 @@
 import { isValidEmail } from "@/lib/validation";
 import { notifyTeam, sendUnsubscribeConfirmation } from "@/lib/email";
 import { escapeHtml } from "@/lib/escape-html";
-import { setNewsletterStatus } from "@/lib/hubspot";
+import { setNewsletterStatus } from "@/lib/espocrm";
 import { addToSuppressionList } from "@/lib/ses-suppression";
 import { rateLimit, getClientIp } from "@/lib/rate-limit";
 

--- a/src/app/api/webhooks/stripe/route.ts
+++ b/src/app/api/webhooks/stripe/route.ts
@@ -5,7 +5,7 @@ import { sendOrderConfirmation, sendPaymentFailureNotice, notifyTeam } from "@/l
 import { escapeHtml } from "@/lib/escape-html";
 import { slackOrderNotify } from "@/lib/slack-notify";
 import { recordNotification } from "@/lib/admin-notifications";
-import { upsertContact, createDeal, associateDealWithContact } from "@/lib/hubspot";
+import { upsertContact, createDeal, associateDealWithContact } from "@/lib/espocrm";
 import type Stripe from "stripe";
 import { mapIntegrationError } from "@/lib/api-errors";
 import {

--- a/src/lib/roi.ts
+++ b/src/lib/roi.ts
@@ -11,7 +11,7 @@ import { isLinkedInConfigured, getLinkedInInsights } from "@/lib/campaigns/linke
 import { isTikTokConfigured, getTikTokInsights } from "@/lib/campaigns/tiktok";
 import { isXConfigured, getXStats } from "@/lib/campaigns/x-ads";
 import { isMetaAdsConfigured, getMetaInsights } from "@/lib/campaigns/meta-ads";
-import { listContacts } from "@/lib/hubspot";
+import { listContacts } from "@/lib/espocrm";
 import { isConfiguredAsync } from "@/lib/integrations";
 import { getStripeAnalyticsSnapshot } from "@/lib/stripe-analytics-read";
 

--- a/src/lib/slack-commands-extra.ts
+++ b/src/lib/slack-commands-extra.ts
@@ -7,10 +7,10 @@
  */
 
 import { getSeoSnapshot, getTopKeywords } from "@/lib/gsc";
-import { listContacts, isHubSpotConfigured } from "@/lib/hubspot";
+import { listContacts, isHubSpotConfigured } from "@/lib/espocrm";
 import { getTopErrors, isSentryConfigured } from "@/lib/sentry";
 import { invalidateCache } from "@/lib/notion-cache";
-import { listNewsletterSubscribers } from "@/lib/hubspot";
+import { listNewsletterSubscribers } from "@/lib/espocrm";
 
 // ---------------------------------------------------------------------------
 // /cloudless-seo — GSC top keywords + snapshot

--- a/src/lib/voice-brief-sources.ts
+++ b/src/lib/voice-brief-sources.ts
@@ -7,7 +7,7 @@
  * the agent loop and can be unit-tested independently.
  */
 import { getSeoSnapshot } from "@/lib/gsc";
-import { isHubSpotConfigured, getPipelineStats, listNewsletterSubscribers } from "@/lib/hubspot";
+import { isHubSpotConfigured, getPipelineStats, listNewsletterSubscribers } from "@/lib/espocrm";
 import { getStripe } from "@/lib/stripe";
 
 export interface SeoMetrics {


### PR DESCRIPTION
Mechanical import flip across 29 files. Zero behavior change at TypeScript level since lib/espocrm.ts (PR #1030) mirrors the 21-function surface. Production behavior change kicks in on next deploy: contact form, subscribe, unsubscribe, admin CRM/leads/pipeline/email pages, owner-digest cron, Stripe webhook deals all start writing/reading EspoCRM. lib/hubspot.ts intentionally kept in tree for 24h to catch any missed callers. typecheck/lint/format clean.