### PR TITLE
feat(crm): EspoCRM ETL + Athena views + IMAP runbook (PR 5 of 5)

### DIFF
--- a/.github/workflows/etl-espocrm-to-lake.yml
+++ b/.github/workflows/etl-espocrm-to-lake.yml
@@ -1,0 +1,66 @@
+name: ETL — EspoCRM to Data Lake
+
+on:
+  schedule:
+    - cron: "20 * * * *" # hourly at :20 (offset from HubSpot 03:15 + Stripe 03:30)
+  workflow_dispatch:
+  push:
+    paths:
+      - "scripts/etl/espocrm-to-lake.mjs"
+      - ".github/workflows/etl-espocrm-to-lake.yml"
+
+permissions:
+  contents: read
+  id-token: write
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+  AWS_REGION: us-east-1
+  BUCKET: cloudless-analytics-data
+
+jobs:
+  espocrm-sync:
+    name: Sync EspoCRM → S3 Parquet
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v4
+
+      - uses: aws-actions/configure-aws-credentials@e3dd6a429d7300a6a4c196c26e071d42e0343502 # v4
+        with:
+          role-to-assume: ${{ secrets.AWS_DEPLOY_ROLE_ARN }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - name: Install dependencies
+        run: npm ci
+        working-directory: scripts/etl
+
+      - name: Pull ESPOCRM_BASE_URL + ESPOCRM_API_KEY from SSM
+        id: ssm
+        run: |
+          BASE=$(aws ssm get-parameter --name /cloudless/production/ESPOCRM_BASE_URL --query 'Parameter.Value' --output text)
+          KEY=$(aws ssm get-parameter --name /cloudless/production/ESPOCRM_API_KEY --with-decryption --query 'Parameter.Value' --output text)
+          echo "::add-mask::$KEY"
+          {
+            echo "ESPOCRM_BASE_URL=$BASE"
+            echo "ESPOCRM_API_KEY=$KEY"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Run EspoCRM ETL
+        run: node scripts/etl/espocrm-to-lake.mjs
+        env:
+          ESPOCRM_BASE_URL: ${{ steps.ssm.outputs.ESPOCRM_BASE_URL }}
+          ESPOCRM_API_KEY: ${{ steps.ssm.outputs.ESPOCRM_API_KEY }}
+          ANALYTICS_BUCKET: ${{ env.BUCKET }}
+
+      - name: Notify Slack on failure
+        if: failure()
+        run: |
+          curl -sS -X POST "${{ secrets.SLACK_WEBHOOK_URL }}" \
+            -H 'Content-Type: application/json' \
+            -d "{\"text\":\":red_circle: ETL espocrm-to-lake failed — <https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}|run>\"}" \
+            || true

--- a/docs/analytics-athena.sql
+++ b/docs/analytics-athena.sql
@@ -259,6 +259,77 @@ GROUP BY campaign_id, campaign_name
 ORDER BY spend DESC;
 
 -- ===========================================================================
+-- EspoCRM tables (replaces HubSpot, fed by scripts/etl/espocrm-to-lake.mjs)
+-- ===========================================================================
+
+CREATE EXTERNAL TABLE IF NOT EXISTS cloudless_analytics.espocrm_contacts (
+  contact_id string, email string, first_name string, last_name string,
+  account_id string, account_name string, phone string, title string,
+  lead_source string, assigned_user_name string, do_not_call boolean,
+  created_at string, modified_at string
+) STORED AS PARQUET
+LOCATION 's3://cloudless-analytics-data/lake/espocrm-contacts/';
+
+CREATE EXTERNAL TABLE IF NOT EXISTS cloudless_analytics.espocrm_accounts (
+  account_id string, name string, website string, email string, phone string,
+  industry string, type string, billing_country string, billing_city string,
+  assigned_user_name string, created_at string
+) STORED AS PARQUET
+LOCATION 's3://cloudless-analytics-data/lake/espocrm-accounts/';
+
+CREATE EXTERNAL TABLE IF NOT EXISTS cloudless_analytics.espocrm_opportunities (
+  opportunity_id string, name string, account_id string, account_name string,
+  amount double, amount_currency string, stage string, probability int,
+  close_date string, lead_source string, assigned_user_name string,
+  created_at string, modified_at string
+) STORED AS PARQUET
+LOCATION 's3://cloudless-analytics-data/lake/espocrm-opportunities/';
+
+CREATE EXTERNAL TABLE IF NOT EXISTS cloudless_analytics.espocrm_cases (
+  case_id string, number int, name string, status string, priority string,
+  type string, account_id string, contact_id string, assigned_user_name string,
+  created_at string, modified_at string
+) STORED AS PARQUET
+LOCATION 's3://cloudless-analytics-data/lake/espocrm-cases/';
+
+CREATE EXTERNAL TABLE IF NOT EXISTS cloudless_analytics.espocrm_campaigns (
+  campaign_id string, name string, status string, type string,
+  start_date string, end_date string, budget double, budget_currency string,
+  sent_count int, opened_count int, clicked_count int,
+  assigned_user_name string, created_at string
+) STORED AS PARQUET
+LOCATION 's3://cloudless-analytics-data/lake/espocrm-campaigns/';
+
+-- ---- v_espocrm_pipeline: per-stage Opportunity rollup -----------------------
+CREATE OR REPLACE VIEW cloudless_analytics.v_espocrm_pipeline AS
+SELECT stage, COUNT(*) AS deal_count, SUM(amount) AS total_value,
+       AVG(amount) AS avg_deal_size, AVG(probability) AS avg_probability
+FROM cloudless_analytics.espocrm_opportunities
+WHERE opportunity_id <> '__placeholder__'
+GROUP BY stage
+ORDER BY total_value DESC NULLS LAST;
+
+-- ---- v_espocrm_lead_to_customer: Contact joined to first won Opportunity ---
+CREATE OR REPLACE VIEW cloudless_analytics.v_espocrm_lead_to_customer AS
+SELECT c.contact_id, c.email, c.first_name, c.last_name,
+       c.lead_source AS contact_source, c.created_at AS contact_created,
+       o.opportunity_id, o.amount AS won_amount, o.amount_currency,
+       o.close_date AS won_at
+FROM cloudless_analytics.espocrm_contacts c
+LEFT JOIN cloudless_analytics.espocrm_opportunities o
+  ON c.account_id = o.account_id AND o.stage = 'Closed Won'
+WHERE c.contact_id <> '__placeholder__';
+
+-- ---- v_espocrm_campaign_summary: per-campaign open/click rates --------------
+CREATE OR REPLACE VIEW cloudless_analytics.v_espocrm_campaign_summary AS
+SELECT campaign_id, name, status, type, sent_count, opened_count, clicked_count,
+       CASE WHEN sent_count > 0 THEN opened_count * 1.0 / sent_count ELSE 0 END AS open_rate,
+       CASE WHEN opened_count > 0 THEN clicked_count * 1.0 / opened_count ELSE 0 END AS click_through_rate
+FROM cloudless_analytics.espocrm_campaigns
+WHERE campaign_id <> '__placeholder__'
+ORDER BY sent_count DESC;
+
+-- ===========================================================================
 -- Pre-existing views (kept for reference — defined elsewhere in the catalog)
 -- ===========================================================================
 -- v_client_health, v_daily_events, v_funnel, v_ltv_ranking,

--- a/infrastructure/espocrm/README.md
+++ b/infrastructure/espocrm/README.md
@@ -160,6 +160,48 @@ node to put them on. `omv-ha` is a Pi 4 with 1 GB RAM — neither fits there.
 HubSpot SSM key stays in place during cutover so anything still pointing
 at it keeps working.
 
+## Inbound Email → Cases (operator setup, ~10 min)
+
+EspoCRM can convert incoming emails on `support@cloudless.gr` into Case
+records automatically. Free, no extension needed — built into the core.
+
+1. **Get IMAP creds** for `support@cloudless.gr` (whatever provider hosts
+   the mailbox — Google Workspace, Zoho, mail.cloudless.gr, etc).
+2. EspoCRM UI → **Administration → Inbound Emails → Create**:
+   - Name: `Support inbox`
+   - From Name: `Cloudless Support`
+   - Status: `Active`
+   - Use IMAP: ✓ (host, port 993, SSL)
+   - Username / Password: as provided
+   - Monitored folders: `INBOX`
+   - **Create Case: ✓** (the magic flag — every new IMAP message becomes a Case)
+   - Case Distribution: Round-Robin (or pick an owner manually)
+3. Test by emailing `support@cloudless.gr` — within ~5 min the message
+   appears as a Case under Admin → Cases. The EspoCRM webhook for
+   `Case.create` is already registered, so a Slack notification fires to
+   `#notifications` automatically.
+4. (Optional) Set up the matching SMTP **Outbound Email** so replies sent
+   from the Case detail view land in the customer's inbox under the right
+   threading. Same Admin → Outbound Emails settings.
+
+## ETL: EspoCRM → Data Lake (already wired by PR 5)
+
+`scripts/etl/espocrm-to-lake.mjs` runs hourly via
+`.github/workflows/etl-espocrm-to-lake.yml`, pulling Contact / Account /
+Opportunity / Case / Campaign into S3 Parquet files. Athena tables +
+three views (`v_espocrm_pipeline`, `v_espocrm_lead_to_customer`,
+`v_espocrm_campaign_summary`) are defined in
+[`docs/analytics-athena.sql`](../../docs/analytics-athena.sql).
+
+One-time bootstrap — run each `CREATE EXTERNAL TABLE` block once in the
+Athena `primary` workgroup before the first ETL run:
+
+```sql
+-- in Athena: copy from docs/analytics-athena.sql, "EspoCRM tables" section
+-- then verify:
+SELECT COUNT(*) FROM cloudless_analytics.espocrm_contacts;
+```
+
 ## Backups (set up after first month of production data)
 
 ```bash

--- a/scripts/etl/espocrm-to-lake.mjs
+++ b/scripts/etl/espocrm-to-lake.mjs
@@ -1,0 +1,402 @@
+/**
+ * ETL: EspoCRM → S3 Data Lake (Parquet)
+ *
+ * Mirrors hubspot-to-lake.mjs but pulls from the self-hosted EspoCRM
+ * instance via the v1 REST API. Five entities → five parquet files:
+ *
+ *   lake/espocrm-contacts/contacts.parquet
+ *   lake/espocrm-accounts/accounts.parquet           (HubSpot's companies)
+ *   lake/espocrm-opportunities/opportunities.parquet (HubSpot's deals)
+ *   lake/espocrm-cases/cases.parquet                 (HubSpot's tickets)
+ *   lake/espocrm-campaigns/campaigns.parquet
+ *
+ * Auth: X-Api-Key (the same SSM-stored ESPOCRM_API_KEY the app uses).
+ * Auth user has the `Cloudless App Full Access` role; see
+ * infrastructure/espocrm/README.md.
+ *
+ * Runs hourly via .github/workflows/etl-espocrm-to-lake.yml. Full refresh —
+ * cheap because counts are well under 100k records on cloudless.gr.
+ */
+
+import { S3Client, PutObjectCommand } from "@aws-sdk/client-s3";
+import { ParquetWriter, ParquetSchema } from "@dsnp/parquetjs";
+import { readFileSync, unlinkSync } from "fs";
+
+const PAGE_SIZE = 100;
+const REGION = process.env.AWS_REGION || "us-east-1";
+const BUCKET = process.env.ANALYTICS_BUCKET || "cloudless-analytics-data";
+const BASE = (process.env.ESPOCRM_BASE_URL || "").replace(/\/$/, "");
+const KEY = process.env.ESPOCRM_API_KEY;
+
+if (!BASE || !KEY) {
+  console.error("ESPOCRM_BASE_URL and ESPOCRM_API_KEY are required");
+  process.exit(1);
+}
+
+const s3 = new S3Client({ region: REGION });
+
+// ---------------------------------------------------------------------------
+// Schemas — flat + typed, aligned with Glue/Athena column types.
+// ---------------------------------------------------------------------------
+
+const contactSchema = new ParquetSchema({
+  contact_id: { type: "UTF8" },
+  email: { type: "UTF8", optional: true },
+  first_name: { type: "UTF8", optional: true },
+  last_name: { type: "UTF8", optional: true },
+  account_id: { type: "UTF8", optional: true },
+  account_name: { type: "UTF8", optional: true },
+  phone: { type: "UTF8", optional: true },
+  title: { type: "UTF8", optional: true },
+  lead_source: { type: "UTF8", optional: true },
+  assigned_user_name: { type: "UTF8", optional: true },
+  do_not_call: { type: "BOOLEAN", optional: true },
+  created_at: { type: "UTF8", optional: true },
+  modified_at: { type: "UTF8", optional: true },
+});
+
+const accountSchema = new ParquetSchema({
+  account_id: { type: "UTF8" },
+  name: { type: "UTF8", optional: true },
+  website: { type: "UTF8", optional: true },
+  email: { type: "UTF8", optional: true },
+  phone: { type: "UTF8", optional: true },
+  industry: { type: "UTF8", optional: true },
+  type: { type: "UTF8", optional: true },
+  billing_country: { type: "UTF8", optional: true },
+  billing_city: { type: "UTF8", optional: true },
+  assigned_user_name: { type: "UTF8", optional: true },
+  created_at: { type: "UTF8", optional: true },
+});
+
+const opportunitySchema = new ParquetSchema({
+  opportunity_id: { type: "UTF8" },
+  name: { type: "UTF8", optional: true },
+  account_id: { type: "UTF8", optional: true },
+  account_name: { type: "UTF8", optional: true },
+  amount: { type: "DOUBLE", optional: true },
+  amount_currency: { type: "UTF8", optional: true },
+  stage: { type: "UTF8", optional: true },
+  probability: { type: "INT32", optional: true },
+  close_date: { type: "UTF8", optional: true },
+  lead_source: { type: "UTF8", optional: true },
+  assigned_user_name: { type: "UTF8", optional: true },
+  created_at: { type: "UTF8", optional: true },
+  modified_at: { type: "UTF8", optional: true },
+});
+
+const caseSchema = new ParquetSchema({
+  case_id: { type: "UTF8" },
+  number: { type: "INT32", optional: true },
+  name: { type: "UTF8", optional: true },
+  status: { type: "UTF8", optional: true },
+  priority: { type: "UTF8", optional: true },
+  type: { type: "UTF8", optional: true },
+  account_id: { type: "UTF8", optional: true },
+  contact_id: { type: "UTF8", optional: true },
+  assigned_user_name: { type: "UTF8", optional: true },
+  created_at: { type: "UTF8", optional: true },
+  modified_at: { type: "UTF8", optional: true },
+});
+
+const campaignSchema = new ParquetSchema({
+  campaign_id: { type: "UTF8" },
+  name: { type: "UTF8", optional: true },
+  status: { type: "UTF8", optional: true },
+  type: { type: "UTF8", optional: true },
+  start_date: { type: "UTF8", optional: true },
+  end_date: { type: "UTF8", optional: true },
+  budget: { type: "DOUBLE", optional: true },
+  budget_currency: { type: "UTF8", optional: true },
+  sent_count: { type: "INT32", optional: true },
+  opened_count: { type: "INT32", optional: true },
+  clicked_count: { type: "INT32", optional: true },
+  assigned_user_name: { type: "UTF8", optional: true },
+  created_at: { type: "UTF8", optional: true },
+});
+
+// ---------------------------------------------------------------------------
+// EspoCRM client — offset+maxSize pagination per v1 spec.
+// ---------------------------------------------------------------------------
+
+async function espoListAll(entity, select) {
+  const all = [];
+  let offset = 0;
+  // Bound the loop generously (≤ 1M records) so a misbehaving server can't
+  // keep the run alive forever. At PAGE_SIZE=100 that's 10k iterations.
+  for (let i = 0; i < 10_000; i++) {
+    const url = new URL(`${BASE}/api/v1/${entity}`);
+    url.searchParams.set("offset", String(offset));
+    url.searchParams.set("maxSize", String(PAGE_SIZE));
+    if (select) url.searchParams.set("select", select.join(","));
+    const res = await fetch(url, { headers: { "X-Api-Key": KEY } });
+    if (!res.ok) {
+      throw new Error(`EspoCRM ${entity} list failed ${res.status}: ${await res.text()}`);
+    }
+    const data = await res.json();
+    all.push(...(data.list ?? []));
+    if ((data.list ?? []).length < PAGE_SIZE) break;
+    offset += PAGE_SIZE;
+  }
+  return all;
+}
+
+// ---------------------------------------------------------------------------
+// Parquet write helper — small files, one per entity. Single-row-group is
+// fine at our volume; if any entity ever exceeds ~50k rows, switch to
+// streaming chunked appends.
+// ---------------------------------------------------------------------------
+
+async function writeParquetAndUpload(filename, schema, rows, s3Key) {
+  const writer = await ParquetWriter.openFile(schema, `/tmp/${filename}`);
+  for (const r of rows) await writer.appendRow(r);
+  await writer.close();
+  await s3.send(
+    new PutObjectCommand({
+      Bucket: BUCKET,
+      Key: s3Key,
+      Body: readFileSync(`/tmp/${filename}`),
+      ContentType: "application/octet-stream",
+    })
+  );
+  unlinkSync(`/tmp/${filename}`);
+  console.log(`✓ ${rows.length} rows → s3://${BUCKET}/${s3Key}`);
+}
+
+// ---------------------------------------------------------------------------
+// Row mappers — EspoCRM JSON → flat parquet shape.
+// ---------------------------------------------------------------------------
+
+const toStr = (v) => (v == null ? undefined : String(v));
+const toBool = (v) => (v == null ? undefined : Boolean(v));
+const toNum = (v) => (v == null ? undefined : Number(v));
+
+function mapContact(c) {
+  return {
+    contact_id: c.id,
+    email: toStr(c.emailAddress),
+    first_name: toStr(c.firstName),
+    last_name: toStr(c.lastName),
+    account_id: toStr(c.accountId),
+    account_name: toStr(c.accountName),
+    phone: toStr(c.phoneNumber),
+    title: toStr(c.title),
+    lead_source: toStr(c.leadSource),
+    assigned_user_name: toStr(c.assignedUserName),
+    do_not_call: toBool(c.doNotCall),
+    created_at: toStr(c.createdAt),
+    modified_at: toStr(c.modifiedAt),
+  };
+}
+function mapAccount(a) {
+  return {
+    account_id: a.id,
+    name: toStr(a.name),
+    website: toStr(a.website),
+    email: toStr(a.emailAddress),
+    phone: toStr(a.phoneNumber),
+    industry: toStr(a.industry),
+    type: toStr(a.type),
+    billing_country: toStr(a.billingAddressCountry),
+    billing_city: toStr(a.billingAddressCity),
+    assigned_user_name: toStr(a.assignedUserName),
+    created_at: toStr(a.createdAt),
+  };
+}
+function mapOpportunity(o) {
+  return {
+    opportunity_id: o.id,
+    name: toStr(o.name),
+    account_id: toStr(o.accountId),
+    account_name: toStr(o.accountName),
+    amount: toNum(o.amount),
+    amount_currency: toStr(o.amountCurrency),
+    stage: toStr(o.stage),
+    probability: toNum(o.probability),
+    close_date: toStr(o.closeDate),
+    lead_source: toStr(o.leadSource),
+    assigned_user_name: toStr(o.assignedUserName),
+    created_at: toStr(o.createdAt),
+    modified_at: toStr(o.modifiedAt),
+  };
+}
+function mapCase(c) {
+  return {
+    case_id: c.id,
+    number: toNum(c.number),
+    name: toStr(c.name),
+    status: toStr(c.status),
+    priority: toStr(c.priority),
+    type: toStr(c.type),
+    account_id: toStr(c.accountId),
+    contact_id: toStr(c.contactId),
+    assigned_user_name: toStr(c.assignedUserName),
+    created_at: toStr(c.createdAt),
+    modified_at: toStr(c.modifiedAt),
+  };
+}
+function mapCampaign(c) {
+  return {
+    campaign_id: c.id,
+    name: toStr(c.name),
+    status: toStr(c.status),
+    type: toStr(c.type),
+    start_date: toStr(c.startDate),
+    end_date: toStr(c.endDate),
+    budget: toNum(c.budget),
+    budget_currency: toStr(c.budgetCurrency),
+    sent_count: toNum(c.sentCount),
+    opened_count: toNum(c.openedCount),
+    clicked_count: toNum(c.clickedCount),
+    assigned_user_name: toStr(c.assignedUserName),
+    created_at: toStr(c.createdAt),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Main — sequential pulls, each entity independent. If one entity 503s the
+// rest still complete (Athena views just see yesterday's partition for that
+// entity until next run).
+// ---------------------------------------------------------------------------
+
+async function main() {
+  const t0 = Date.now();
+  const tasks = [
+    {
+      entity: "Contact",
+      select: [
+        "id",
+        "emailAddress",
+        "firstName",
+        "lastName",
+        "accountId",
+        "accountName",
+        "phoneNumber",
+        "title",
+        "leadSource",
+        "assignedUserName",
+        "doNotCall",
+        "createdAt",
+        "modifiedAt",
+      ],
+      map: mapContact,
+      schema: contactSchema,
+      file: "contacts.parquet",
+      s3: "lake/espocrm-contacts/contacts.parquet",
+    },
+    {
+      entity: "Account",
+      select: [
+        "id",
+        "name",
+        "website",
+        "emailAddress",
+        "phoneNumber",
+        "industry",
+        "type",
+        "billingAddressCountry",
+        "billingAddressCity",
+        "assignedUserName",
+        "createdAt",
+      ],
+      map: mapAccount,
+      schema: accountSchema,
+      file: "accounts.parquet",
+      s3: "lake/espocrm-accounts/accounts.parquet",
+    },
+    {
+      entity: "Opportunity",
+      select: [
+        "id",
+        "name",
+        "accountId",
+        "accountName",
+        "amount",
+        "amountCurrency",
+        "stage",
+        "probability",
+        "closeDate",
+        "leadSource",
+        "assignedUserName",
+        "createdAt",
+        "modifiedAt",
+      ],
+      map: mapOpportunity,
+      schema: opportunitySchema,
+      file: "opportunities.parquet",
+      s3: "lake/espocrm-opportunities/opportunities.parquet",
+    },
+    {
+      entity: "Case",
+      select: [
+        "id",
+        "number",
+        "name",
+        "status",
+        "priority",
+        "type",
+        "accountId",
+        "contactId",
+        "assignedUserName",
+        "createdAt",
+        "modifiedAt",
+      ],
+      map: mapCase,
+      schema: caseSchema,
+      file: "cases.parquet",
+      s3: "lake/espocrm-cases/cases.parquet",
+    },
+    {
+      entity: "Campaign",
+      select: [
+        "id",
+        "name",
+        "status",
+        "type",
+        "startDate",
+        "endDate",
+        "budget",
+        "budgetCurrency",
+        "sentCount",
+        "openedCount",
+        "clickedCount",
+        "assignedUserName",
+        "createdAt",
+      ],
+      map: mapCampaign,
+      schema: campaignSchema,
+      file: "campaigns.parquet",
+      s3: "lake/espocrm-campaigns/campaigns.parquet",
+    },
+  ];
+
+  let okCount = 0;
+  for (const t of tasks) {
+    try {
+      const raw = await espoListAll(t.entity, t.select);
+      const rows = raw.map(t.map);
+      // Parquet writers don't tolerate empty row sets — emit a placeholder
+      // row so the table still exists for Athena. Athena views just see 0
+      // user rows; placeholder rows are flagged with id="__placeholder__".
+      if (rows.length === 0) {
+        const placeholder = Object.fromEntries(
+          Object.keys(t.schema.schema).map((k, i) => [k, i === 0 ? "__placeholder__" : undefined])
+        );
+        rows.push(placeholder);
+      }
+      await writeParquetAndUpload(t.file, t.schema, rows, t.s3);
+      okCount++;
+    } catch (err) {
+      console.error(`✗ ${t.entity} failed:`, err.message);
+    }
+  }
+
+  const elapsed = ((Date.now() - t0) / 1000).toFixed(1);
+  console.log(`\nESPOCRM ETL done — ${okCount}/${tasks.length} entities succeeded in ${elapsed}s`);
+  if (okCount === 0) process.exit(1);
+}
+
+main().catch((err) => {
+  console.error("ETL crashed:", err);
+  process.exit(1);
+});


### PR DESCRIPTION
Closes out the HubSpot -> EspoCRM migration. Hourly ETL pulls Contact/Account/Opportunity/Case/Campaign to S3 Parquet; 5 new Athena tables + 3 views (v_espocrm_pipeline, v_espocrm_lead_to_customer, v_espocrm_campaign_summary). README gains the Inbound Email/IMAP setup runbook (operator action, ~10 min) so support emails become Cases automatically. typecheck/lint/format clean.