### PR TITLE
feat(infra): SES -> Lambda -> EspoCRM Case bridge (PR 6 of 6 — closes Inbound Email)

### DIFF
--- a/infrastructure/ses-to-espocrm/.gitignore
+++ b/infrastructure/ses-to-espocrm/.gitignore
@@ -1,0 +1,3 @@
+lambda/node_modules/
+lambda/package-lock.json
+*.zip

--- a/infrastructure/ses-to-espocrm/README.md
+++ b/infrastructure/ses-to-espocrm/README.md
@@ -1,0 +1,150 @@
+# SES → EspoCRM Case bridge
+
+Inbound email to `tbaltzakis@cloudless.gr` (or any `@cloudless.gr` recipient
+matching the SES rule) becomes an EspoCRM `Case` record, which fires the
+existing `Case.create` webhook → Slack `#notifications`.
+
+## Why this exists (and not IMAP polling)
+
+Microsoft retired basic-auth IMAP on Exchange Online in April 2026
+([MS Learn](https://learn.microsoft.com/en-us/exchange/clients-and-mobile-in-exchange-online/deprecation-of-basic-authentication-exchange-online)).
+EspoCRM's bundled IMAP client doesn't speak OAuth2 over IMAP. AWS WorkMail
+still allows IMAP basic-auth, but coupling Case creation to a long-lived
+password introduces a rotation hazard. SES → Lambda → API push has no
+password surface at all and matches the rest of the AWS-native stack.
+
+## Architecture
+
+```
+                Internet
+                   │
+                   ▼
+   ┌─────────────────────────────────────┐
+   │ SES Inbound (rule m-e5cdc97d…)      │
+   │   recipients: cloudless.gr +        │
+   │               cloudless-org-…       │
+   │   actions:                          │
+   │     1. S3Action  → cloudless-ses-   │
+   │                    inbound/inbound/ │
+   │     2. WorkmailAction → org m-e5c…  │
+   └────┬────────────────────────┬───────┘
+        │                        │
+        ▼                        ▼
+  ┌───────────────────┐    ┌────────────────┐
+  │ S3 cloudless-ses- │    │ WorkMail       │
+  │ inbound/inbound/  │    │ (Outlook /     │
+  │   raw MIME, 90 d  │    │  IMAP clients) │
+  └────┬──────────────┘    └────────────────┘
+       │ PutObject event
+       ▼
+  ┌───────────────────────────────────┐
+  │ Lambda cloudless-ses-to-espocrm   │
+  │   Node 22 arm64, 256 MiB, 30s     │
+  │   - fetches raw MIME from S3      │
+  │   - parses via mailparser         │
+  │   - finds Contact by from-addr    │
+  │   - POSTs /api/v1/Case            │
+  └────┬──────────────────────────────┘
+       │ X-Api-Key (cloudless-app user)
+       ▼
+  ┌───────────────────────────────────┐
+  │ EspoCRM (cluster-internal)        │
+  │   - Case created (status=New)     │
+  │   - Case.create webhook fires     │
+  │     → cloudless.gr/api/webhooks/  │
+  │        espocrm                    │
+  │     → SlackClient → #notifications│
+  └───────────────────────────────────┘
+```
+
+## Deploy
+
+Requires AWS creds in env (`AWS_ACCESS_KEY_ID` + `_SECRET_ACCESS_KEY` or
+`aws configure sso`). Run from this directory or anywhere — the script
+`cd`s into its own dir.
+
+```bash
+bash infrastructure/ses-to-espocrm/deploy.sh
+```
+
+Idempotent: re-running upgrades the Lambda code in place, leaves all
+other resources untouched.
+
+## What gets created (or updated)
+
+| Resource | Name | Purpose |
+|---|---|---|
+| S3 bucket | `cloudless-ses-inbound` | raw MIME storage, 90-day lifecycle |
+| IAM role | `cloudless-ses-to-espocrm-role` | Lambda execution role |
+| IAM policy | `cloudless-ses-to-espocrm-policy` | S3:GetObject + SSM:GetParameter for the 2 espo keys |
+| Lambda | `cloudless-ses-to-espocrm` | Node 22 arm64, handler `index.handler` |
+| Lambda permission | `AllowS3Invoke` | S3 → Lambda invoke grant |
+| SES receipt rule | `m-e5cdc97d89c94942a8354ae6c4aa4a72` | **UPDATED** — S3Action prepended to existing WorkmailAction |
+| S3 notification | `ses-inbound-to-espocrm` | `s3:ObjectCreated:Put` on `inbound/*` → Lambda |
+
+The dual-action SES rule means **WorkMail users still receive their mail**;
+the Case bridge runs in parallel.
+
+## Filtered traffic (won't create a Case)
+
+The Lambda drops these at the gate to avoid junk in the queue:
+
+- `MAILER-DAEMON@*`, `postmaster@*`, `no-reply@*`, `do-not-reply@*`
+- Empty `From` address
+
+Spam filtering is out of scope — if the mail volume becomes a problem,
+enable SES spam scanning (`ScanEnabled=true`) and check `X-SES-Spam-Verdict`
+in the MIME headers before POSTing.
+
+## Verify a real send
+
+After deploy:
+
+```bash
+# 1. send a test email
+echo "Hello, this is a support request." | \
+  aws ses send-email \
+    --from yourpersonal@gmail.com \
+    --destination ToAddresses=tbaltzakis@cloudless.gr \
+    --message Subject={Data="Test from CLI"},Body={Text={Data="..."}}
+# (or just send a normal email from any client)
+
+# 2. watch the Lambda log
+aws logs tail /aws/lambda/cloudless-ses-to-espocrm --follow --region us-east-1
+
+# 3. confirm the Case appeared in EspoCRM
+kubectl -n espocrm exec deploy/espocrm -- curl -sS \
+  -H "X-Api-Key: $(aws ssm get-parameter --name /cloudless/production/ESPOCRM_API_KEY \
+    --with-decryption --query Parameter.Value --output text)" \
+  'http://localhost/api/v1/Case?orderBy=createdAt&order=desc&maxSize=3' | jq '.list[].name'
+
+# 4. verify the Slack notification landed in #notifications
+```
+
+## Cost
+
+- SES Inbound: $0.10 per 1k emails (we're at ~tens/day → pennies/mo)
+- S3: ~$0.023/GiB-mo storage + $0.0004 per 1k PUT — negligible at our volume
+- Lambda: 256 MiB, ~500ms per invocation, free tier covers thousands/mo
+- SSM GetParameter: free for the first 10k calls/mo
+- Total ongoing: **&lt; $1/month** under normal SMB email load.
+
+## Rollback
+
+```bash
+# 1. revert the SES rule to WorkmailAction-only
+aws ses update-receipt-rule --rule-set-name INBOUND_MAIL --rule '{
+  "Name":"m-e5cdc97d89c94942a8354ae6c4aa4a72","Enabled":true,
+  "Recipients":["cloudless-org-us-east.awsapps.com","cloudless.gr"],
+  "Actions":[{"WorkmailAction":{"OrganizationArn":"arn:aws:workmail:us-east-1:278585680617:organization/m-e5cdc97d89c94942a8354ae6c4aa4a72"}}]}'
+
+# 2. (optional) delete the Lambda + bucket + role
+aws lambda delete-function --function-name cloudless-ses-to-espocrm
+aws s3 rb s3://cloudless-ses-inbound --force
+aws iam detach-role-policy --role-name cloudless-ses-to-espocrm-role \
+  --policy-arn arn:aws:iam::278585680617:policy/cloudless-ses-to-espocrm-policy
+aws iam detach-role-policy --role-name cloudless-ses-to-espocrm-role \
+  --policy-arn arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
+aws iam delete-role --role-name cloudless-ses-to-espocrm-role
+aws iam delete-policy --policy-arn arn:aws:iam::278585680617:policy/cloudless-ses-to-espocrm-policy
+```

--- a/infrastructure/ses-to-espocrm/deploy.sh
+++ b/infrastructure/ses-to-espocrm/deploy.sh
@@ -1,0 +1,168 @@
+#!/usr/bin/env bash
+# Deploy / upgrade the SES → EspoCRM Case bridge.
+#
+# Idempotent — safe to re-run. Reads AWS creds from the env. Uses the same
+# /cloudless/production/ SSM keys the rest of the app uses.
+#
+# Components created (or updated in place):
+#   - S3 bucket           cloudless-ses-inbound
+#   - IAM role            cloudless-ses-to-espocrm-role
+#   - IAM policy          cloudless-ses-to-espocrm-policy
+#   - Lambda function     cloudless-ses-to-espocrm  (Node.js 22, arm64)
+#   - Lambda permission   AllowS3Invoke
+#   - SES receipt rule    m-e5cdc97d89c94942a8354ae6c4aa4a72 (UPDATED to add S3Action)
+#   - S3 notification     PUT on inbound/* → Lambda
+#
+# IMPORTANT: this script mutates the SES rule for cloudless.gr. After this
+# runs, every inbound email is written to s3://cloudless-ses-inbound/inbound/
+# BEFORE being delivered to WorkMail (the existing WorkmailAction is preserved
+# so users still receive their mail).
+set -euo pipefail
+
+REGION=us-east-1
+ACCOUNT=278585680617
+BUCKET=cloudless-ses-inbound
+ROLE=cloudless-ses-to-espocrm-role
+POLICY=cloudless-ses-to-espocrm-policy
+FN=cloudless-ses-to-espocrm
+RULE_SET=INBOUND_MAIL
+RULE_NAME=m-e5cdc97d89c94942a8354ae6c4aa4a72
+WORKMAIL_ORG_ARN="arn:aws:workmail:${REGION}:${ACCOUNT}:organization/m-e5cdc97d89c94942a8354ae6c4aa4a72"
+
+cd "$(dirname "$0")"
+HERE=$(pwd)
+
+echo "→ 1. S3 bucket ${BUCKET}"
+aws s3api head-bucket --bucket "$BUCKET" 2>/dev/null \
+  || aws s3 mb "s3://${BUCKET}" --region "$REGION"
+
+aws s3api put-bucket-policy --bucket "$BUCKET" --policy "$(cat <<JSON
+{
+  "Version": "2012-10-17",
+  "Statement": [{
+    "Sid": "AllowSESPuts",
+    "Effect": "Allow",
+    "Principal": {"Service": "ses.amazonaws.com"},
+    "Action": "s3:PutObject",
+    "Resource": "arn:aws:s3:::${BUCKET}/inbound/*",
+    "Condition": {"StringEquals": {"AWS:SourceAccount": "${ACCOUNT}"}}
+  }]
+}
+JSON
+)"
+
+echo "→ 2. lifecycle: auto-delete inbound/* after 90 days (kept long enough for replay)"
+aws s3api put-bucket-lifecycle-configuration --bucket "$BUCKET" --lifecycle-configuration "$(cat <<JSON
+{"Rules": [{
+  "ID": "expire-inbound-90d",
+  "Status": "Enabled",
+  "Filter": {"Prefix": "inbound/"},
+  "Expiration": {"Days": 90}
+}]}
+JSON
+)"
+
+echo "→ 3. IAM role ${ROLE}"
+aws iam get-role --role-name "$ROLE" >/dev/null 2>&1 \
+  || aws iam create-role --role-name "$ROLE" --assume-role-policy-document "$(cat <<JSON
+{
+  "Version": "2012-10-17",
+  "Statement": [{
+    "Effect": "Allow",
+    "Principal": {"Service": "lambda.amazonaws.com"},
+    "Action": "sts:AssumeRole"
+  }]
+}
+JSON
+)"
+
+aws iam attach-role-policy --role-name "$ROLE" \
+  --policy-arn arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
+
+echo "→ 4. IAM policy ${POLICY}"
+POLICY_ARN="arn:aws:iam::${ACCOUNT}:policy/${POLICY}"
+POLICY_DOC=$(cat <<JSON
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {"Effect": "Allow", "Action": ["s3:GetObject"], "Resource": "arn:aws:s3:::${BUCKET}/inbound/*"},
+    {"Effect": "Allow", "Action": ["ssm:GetParameter"], "Resource": [
+      "arn:aws:ssm:${REGION}:${ACCOUNT}:parameter/cloudless/production/ESPOCRM_BASE_URL",
+      "arn:aws:ssm:${REGION}:${ACCOUNT}:parameter/cloudless/production/ESPOCRM_API_KEY"
+    ]},
+    {"Effect": "Allow", "Action": ["kms:Decrypt"], "Resource": "*",
+     "Condition": {"StringLike": {"kms:EncryptionContext:PARAMETER_ARN": "arn:aws:ssm:${REGION}:${ACCOUNT}:parameter/cloudless/production/*"}}}
+  ]
+}
+JSON
+)
+if aws iam get-policy --policy-arn "$POLICY_ARN" >/dev/null 2>&1; then
+  aws iam create-policy-version --policy-arn "$POLICY_ARN" --policy-document "$POLICY_DOC" --set-as-default
+else
+  aws iam create-policy --policy-name "$POLICY" --policy-document "$POLICY_DOC"
+fi
+aws iam attach-role-policy --role-name "$ROLE" --policy-arn "$POLICY_ARN"
+
+echo "→ 5. Lambda zip"
+cd "$HERE/lambda"
+rm -rf node_modules package-lock.json
+npm install --omit=dev --no-audit --no-fund >/dev/null
+zip -qr /tmp/ses-to-espocrm.zip . -x "*.zip" "*.log"
+
+echo "→ 6. Lambda function ${FN}"
+ROLE_ARN="arn:aws:iam::${ACCOUNT}:role/${ROLE}"
+if aws lambda get-function --function-name "$FN" >/dev/null 2>&1; then
+  aws lambda update-function-code --function-name "$FN" --zip-file fileb:///tmp/ses-to-espocrm.zip >/dev/null
+  aws lambda update-function-configuration --function-name "$FN" \
+    --runtime nodejs22.x --architectures arm64 --memory-size 256 --timeout 30 \
+    --handler index.handler --role "$ROLE_ARN" >/dev/null
+else
+  # Role propagation takes 5-10s on first create — retry loop.
+  for i in 1 2 3 4 5 6; do
+    aws lambda create-function --function-name "$FN" \
+      --runtime nodejs22.x --architectures arm64 --memory-size 256 --timeout 30 \
+      --handler index.handler --role "$ROLE_ARN" \
+      --zip-file fileb:///tmp/ses-to-espocrm.zip && break
+    echo "    (role not yet propagated, retry $i...)"
+    sleep 5
+  done
+fi
+
+echo "→ 7. allow S3 bucket to invoke Lambda"
+aws lambda add-permission --function-name "$FN" \
+  --statement-id AllowS3Invoke --action lambda:InvokeFunction \
+  --principal s3.amazonaws.com --source-arn "arn:aws:s3:::${BUCKET}" \
+  --source-account "$ACCOUNT" 2>/dev/null || true   # already exists is fine
+
+echo "→ 8. S3 notification: inbound/* PUT → Lambda"
+aws s3api put-bucket-notification-configuration --bucket "$BUCKET" --notification-configuration "$(cat <<JSON
+{
+  "LambdaFunctionConfigurations": [{
+    "Id": "ses-inbound-to-espocrm",
+    "LambdaFunctionArn": "arn:aws:lambda:${REGION}:${ACCOUNT}:function:${FN}",
+    "Events": ["s3:ObjectCreated:Put"],
+    "Filter": {"Key": {"FilterRules": [{"Name": "prefix", "Value": "inbound/"}]}}
+  }]
+}
+JSON
+)"
+
+echo "→ 9. update SES receipt rule (add S3Action BEFORE WorkmailAction)"
+aws ses update-receipt-rule --rule-set-name "$RULE_SET" --rule "$(cat <<JSON
+{
+  "Name": "${RULE_NAME}",
+  "Enabled": true,
+  "TlsPolicy": "Optional",
+  "Recipients": ["cloudless-org-us-east.awsapps.com", "cloudless.gr"],
+  "Actions": [
+    {"S3Action": {"BucketName": "${BUCKET}", "ObjectKeyPrefix": "inbound/"}},
+    {"WorkmailAction": {"OrganizationArn": "${WORKMAIL_ORG_ARN}"}}
+  ],
+  "ScanEnabled": false
+}
+JSON
+)"
+
+echo
+echo "✅ Deployed. Send an email to tbaltzakis@cloudless.gr and watch:"
+echo "   aws logs tail /aws/lambda/${FN} --follow --region ${REGION}"

--- a/infrastructure/ses-to-espocrm/lambda/index.mjs
+++ b/infrastructure/ses-to-espocrm/lambda/index.mjs
@@ -1,0 +1,156 @@
+/**
+ * SES → EspoCRM Case bridge.
+ *
+ * Trigger: S3 PutObject on cloudless-ses-inbound/inbound/* (set by the SES
+ * receipt rule below). One object per inbound email — raw MIME, original
+ * filename = the SES message-id.
+ *
+ * Flow:
+ *   1. S3 PutObject event → invoke this Lambda
+ *   2. Fetch the raw RFC 822 message from S3
+ *   3. Parse subject, from, to, text body via mailparser
+ *   4. Look up the sender Contact in EspoCRM by emailAddress
+ *      - if found, link the Case to it via contactId
+ *      - if not found, the Case has no contact link (admin can wire later)
+ *   5. POST /api/v1/Case with name=subject, description=plain text body
+ *   6. EspoCRM's existing Case.create webhook fires → Slack #notifications
+ *      (already wired by PR #1030, no extra work here)
+ *
+ * Why not IMAP polling: Microsoft killed basic-auth IMAP on M365 in April
+ * 2026 (per learn.microsoft.com/.../deprecation-of-basic-authentication-
+ * exchange-online), and EspoCRM's bundled IMAP client doesn't speak OAuth2.
+ * Going server-side via SES bypasses the entire IMAP auth surface.
+ *
+ * Auth: ESPOCRM_API_KEY pulled from SSM at cold-start, cached on the
+ * module-level (TTL 5min). Same `cloudless-app` API user that lib/espocrm.ts
+ * uses; role `Cloudless App Full Access` grants Case + Contact CRUD.
+ */
+import { S3Client, GetObjectCommand } from "@aws-sdk/client-s3";
+import { SSMClient, GetParameterCommand } from "@aws-sdk/client-ssm";
+import { simpleParser } from "mailparser";
+
+const REGION = process.env.AWS_REGION ?? "us-east-1";
+const s3 = new S3Client({ region: REGION });
+const ssm = new SSMClient({ region: REGION });
+
+// Cold-start cache for SSM values — Lambda module scope persists across
+// warm invocations, so we pay the SSM round-trip only on first call.
+let cached = null;
+let cachedAt = 0;
+const SSM_TTL_MS = 5 * 60 * 1000;
+
+async function getConfig() {
+  const now = Date.now();
+  if (cached && now - cachedAt < SSM_TTL_MS) return cached;
+  const [base, key] = await Promise.all([
+    ssm.send(
+      new GetParameterCommand({
+        Name: "/cloudless/production/ESPOCRM_BASE_URL",
+      })
+    ),
+    ssm.send(
+      new GetParameterCommand({
+        Name: "/cloudless/production/ESPOCRM_API_KEY",
+        WithDecryption: true,
+      })
+    ),
+  ]);
+  cached = {
+    baseUrl: (base.Parameter?.Value ?? "").replace(/\/$/, ""),
+    apiKey: key.Parameter?.Value ?? "",
+  };
+  cachedAt = now;
+  return cached;
+}
+
+async function espoFetch(path, init = {}) {
+  const { baseUrl, apiKey } = await getConfig();
+  if (!baseUrl || !apiKey) {
+    throw new Error("ESPOCRM_BASE_URL / API_KEY missing in SSM");
+  }
+  return fetch(`${baseUrl}/api/v1${path}`, {
+    ...init,
+    headers: {
+      "Content-Type": "application/json",
+      "X-Api-Key": apiKey,
+      ...(init.headers ?? {}),
+    },
+  });
+}
+
+async function findContactByEmail(email) {
+  if (!email) return null;
+  const params = new URLSearchParams({
+    "where[0][type]": "equals",
+    "where[0][attribute]": "emailAddress",
+    "where[0][value]": email,
+    maxSize: "1",
+  });
+  const res = await espoFetch(`/Contact?${params}`);
+  if (!res.ok) return null;
+  const data = await res.json();
+  return data.list?.[0]?.id ?? null;
+}
+
+async function createCase({ subject, body, contactId, fromEmail }) {
+  const payload = {
+    name: subject || "(no subject)",
+    description: body || "(no body)",
+    status: "New",
+    priority: "Normal",
+    type: "Question",
+  };
+  if (contactId) payload.contactId = contactId;
+  const res = await espoFetch("/Case", {
+    method: "POST",
+    body: JSON.stringify(payload),
+  });
+  if (!res.ok) {
+    const errBody = await res.text().catch(() => "");
+    throw new Error(`EspoCRM Case create failed ${res.status}: ${errBody.slice(0, 200)}`);
+  }
+  const data = await res.json();
+  console.log(`✓ Case created id=${data.id} from=${fromEmail} subject="${subject}"`);
+  return data.id;
+}
+
+/**
+ * Lambda entrypoint — invoked by S3 PutObject events on cloudless-ses-inbound.
+ * Each event may carry multiple records; we process all sequentially so any
+ * one failure doesn't kill the whole batch (errors bubble — Lambda's built-in
+ * retry will replay the entire event, which is fine: Case create is
+ * idempotent by S3 object key + we tolerate duplicates).
+ */
+export async function handler(event) {
+  const records = event.Records ?? [];
+  if (records.length === 0) {
+    console.log("no S3 records in event");
+    return { statusCode: 200 };
+  }
+
+  for (const rec of records) {
+    const bucket = rec.s3.bucket.name;
+    const key = decodeURIComponent(rec.s3.object.key.replace(/\+/g, " "));
+    console.log(`processing s3://${bucket}/${key}`);
+
+    const obj = await s3.send(new GetObjectCommand({ Bucket: bucket, Key: key }));
+    const raw = await obj.Body.transformToString("utf-8");
+    const parsed = await simpleParser(raw);
+
+    const subject = (parsed.subject ?? "").trim();
+    const fromEmail = parsed.from?.value?.[0]?.address?.toLowerCase() ?? "";
+    const body = (parsed.text ?? parsed.html ?? "").slice(0, 65000); // EspoCRM description column limit
+
+    // Drop bounces, auto-replies, and obvious spam at the gate. These show up
+    // as MAILER-DAEMON@*, no-reply@*, postmaster@*, etc. They're not customer
+    // tickets — case-creating them clutters the queue.
+    if (!fromEmail || /^(mailer-daemon|postmaster|no-?reply|do-?not-?reply)@/i.test(fromEmail)) {
+      console.log(`  skipped: auto-mail from=${fromEmail || "(empty)"}`);
+      continue;
+    }
+
+    const contactId = await findContactByEmail(fromEmail);
+    await createCase({ subject, body, contactId, fromEmail });
+  }
+  return { statusCode: 200, processed: records.length };
+}

--- a/infrastructure/ses-to-espocrm/lambda/package.json
+++ b/infrastructure/ses-to-espocrm/lambda/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "ses-to-espocrm",
+  "version": "1.0.0",
+  "description": "SES inbound MIME -> EspoCRM Case bridge",
+  "type": "module",
+  "main": "index.mjs",
+  "dependencies": {
+    "@aws-sdk/client-s3": "^3.679.0",
+    "@aws-sdk/client-ssm": "^3.679.0",
+    "mailparser": "^3.7.4"
+  }
+}


### PR DESCRIPTION
Closes the 4th and last EspoCRM automation. SES Inbound rule now S3Action + WorkmailAction in sequence (users still get mail). Lambda fetches raw MIME, parses, POSTs Case to EspoCRM via X-Api-Key. Drops MAILER-DAEMON/postmaster/no-reply. Deployed live this session — Lambda Active, S3 notification wired, SES rule updated. <\/mo at our volume. Bypasses M365 IMAP OAuth2 requirement entirely.