### PR TITLE
fix(etl): retry transient Cloudflare-tunnel flaps + bump thrift to 0.23.0 (closes 2 HIGH CVEs)

### DIFF
--- a/scripts/etl/espocrm-to-lake.mjs
+++ b/scripts/etl/espocrm-to-lake.mjs
@@ -116,8 +116,63 @@ const campaignSchema = new ParquetSchema({
 });
 
 // ---------------------------------------------------------------------------
-// EspoCRM client — offset+maxSize pagination per v1 spec.
+// EspoCRM client — offset+maxSize pagination per v1 spec, with retry/backoff
+// for Cloudflare-tunnel flaps (the 2026-06-20 incident: all 5 entities 404'd
+// with empty body in 700ms — classic tunnel-origin-unreachable signature
+// while the same key works the next minute). Retries cover:
+//   - network errors (DNS, ECONNRESET)
+//   - 5xx (Cloudflare origin error)
+//   - 404 with empty body (tunnel returns 404 when it can't reach origin —
+//     a legitimate EspoCRM 404 always has a JSON body)
+//   - 429 (rate-limited; honour Retry-After when present)
 // ---------------------------------------------------------------------------
+
+const MAX_RETRIES = 4; // 4 attempts ~ ≤ 15s of backoff (1s/2s/4s/8s)
+
+function shouldRetry(status, bodyLen) {
+  if (status >= 500) return true;
+  if (status === 429) return true;
+  // Tunnel-flap signature: 404 + empty body. A real EspoCRM 404 returns a
+  // JSON error payload (`{"messageTranslation":...}`), never empty.
+  if (status === 404 && bodyLen === 0) return true;
+  return false;
+}
+
+async function fetchEspoWithRetry(url, init, label) {
+  let lastErr;
+  for (let attempt = 0; attempt < MAX_RETRIES; attempt++) {
+    try {
+      const res = await fetch(url, init);
+      const body = await res.text();
+      if (res.ok) return JSON.parse(body);
+      if (shouldRetry(res.status, body.length) && attempt < MAX_RETRIES - 1) {
+        const retryAfter = Number(res.headers.get("retry-after"));
+        const wait = Number.isFinite(retryAfter) && retryAfter > 0 ? retryAfter * 1000 : 2 ** attempt * 1000;
+        console.warn(
+          `↻ ${label} HTTP ${res.status} (body ${body.length}b) — retry ${attempt + 1}/${MAX_RETRIES - 1} in ${wait}ms`
+        );
+        await new Promise((r) => setTimeout(r, wait));
+        continue;
+      }
+      throw new Error(`EspoCRM ${label} failed ${res.status}: ${body.slice(0, 200)}`);
+    } catch (err) {
+      lastErr = err;
+      // Network-level error: ENOTFOUND, ECONNRESET, fetch failed, etc. The
+      // string check is the only way to discriminate without a typed error.
+      const transient = /fetch failed|ENOTFOUND|ECONNRESET|ETIMEDOUT|EAI_AGAIN|network/i.test(
+        String(err?.message ?? err)
+      );
+      if (transient && attempt < MAX_RETRIES - 1) {
+        const wait = 2 ** attempt * 1000;
+        console.warn(`↻ ${label} network error: ${err.message} — retry ${attempt + 1}/${MAX_RETRIES - 1} in ${wait}ms`);
+        await new Promise((r) => setTimeout(r, wait));
+        continue;
+      }
+      throw err;
+    }
+  }
+  throw lastErr ?? new Error(`EspoCRM ${label} retries exhausted`);
+}
 
 async function espoListAll(entity, select) {
   const all = [];
@@ -129,11 +184,11 @@ async function espoListAll(entity, select) {
     url.searchParams.set("offset", String(offset));
     url.searchParams.set("maxSize", String(PAGE_SIZE));
     if (select) url.searchParams.set("select", select.join(","));
-    const res = await fetch(url, { headers: { "X-Api-Key": KEY } });
-    if (!res.ok) {
-      throw new Error(`EspoCRM ${entity} list failed ${res.status}: ${await res.text()}`);
-    }
-    const data = await res.json();
+    const data = await fetchEspoWithRetry(
+      url,
+      { headers: { "X-Api-Key": KEY } },
+      `${entity} list (offset ${offset})`
+    );
     all.push(...(data.list ?? []));
     if ((data.list ?? []).length < PAGE_SIZE) break;
     offset += PAGE_SIZE;

--- a/scripts/etl/package-lock.json
+++ b/scripts/etl/package-lock.json
@@ -1063,15 +1063,16 @@
       }
     },
     "node_modules/thrift": {
-      "version": "0.21.0",
-      "resolved": "https://registry.npmjs.org/thrift/-/thrift-0.21.0.tgz",
-      "integrity": "sha512-AW8rwHYjeqXisS8B1iwko2gkNMFwSRJ+bO/W0xTGqRspTD3lGHwZx438+pHdOJ3GwpRAnK7TKbjqPOrHAa7ZwQ==",
+      "version": "0.23.0",
+      "resolved": "https://registry.npmjs.org/thrift/-/thrift-0.23.0.tgz",
+      "integrity": "sha512-j7F1ls8JogClU88Ta/pwD/OzYuiFeD6Z5GoWw7ip+jcDhcNYFKgfXYEsyLXYpiNfJO94fbLnITGxyfZ19YzA6Q==",
       "license": "Apache-2.0",
       "dependencies": {
         "browser-or-node": "^1.2.1",
         "isomorphic-ws": "^4.0.1",
         "node-int64": "^0.4.0",
         "q": "^1.5.0",
+        "uuid": "^13.0.0",
         "ws": "^5.2.3"
       },
       "engines": {
@@ -1104,6 +1105,19 @@
       },
       "optionalDependencies": {
         "@xterm/xterm": "^5.5.0"
+      }
+    },
+    "node_modules/uuid": {
+      "version": "13.0.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-13.0.2.tgz",
+      "integrity": "sha512-vzi9uRZ926x4XV73S/4qQaTwPXM2JBj6/6lI/byHH1jOpCzb0zDbfytgA9LcN/hzb2l7WQSQnxITOVx5un/wGw==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist-node/bin/uuid"
       }
     },
     "node_modules/varint": {

--- a/scripts/etl/package.json
+++ b/scripts/etl/package.json
@@ -7,5 +7,13 @@
     "@dsnp/parquetjs": "^1.8.7",
     "jose": "^6.2.3",
     "stripe": "^22.2.2"
+  },
+  "overrides": {
+    "thrift": "^0.23.0"
+  },
+  "pnpm": {
+    "overrides": {
+      "thrift": "^0.23.0"
+    }
   }
 }


### PR DESCRIPTION
## Two issues, one PR

### 1. ETL hourly failure — 404 from Cloudflare tunnel flap

The `ETL — EspoCRM to Data Lake` workflow run #27884737330 (2026-06-20 21:42 UTC) failed with **5 × 404 with empty body in 700ms** across all entities (`Contact`, `Account`, `Opportunity`, `Case`, `Campaign`). Re-probed end-to-end through the same tunnel + same SSM key right after: every entity returns HTTP 200. Classic Cloudflare-tunnel-origin-unreachable signature.

Added `fetchEspoWithRetry()` in `scripts/etl/espocrm-to-lake.mjs` with 4 attempts and exponential backoff (1s → 2s → 4s → 8s, ~15s ceiling). Retries on:

- network errors (`ENOTFOUND`, `ECONNRESET`, `fetch failed`, etc.)
- HTTP 5xx
- HTTP 429 (honours `Retry-After` when present)
- HTTP 404 with **empty body** — real EspoCRM 404s always return a JSON error payload, so empty-body 404 is unambiguously the tunnel-flap signature

### 2. Two HIGH Dependabot alerts on `thrift` — closed

- [#291](https://github.com/Themis128/cloudless.gr/security/dependabot/291) Apache Thrift Uncontrolled Recursion (patched in 0.23.0)
- [#292](https://github.com/Themis128/cloudless.gr/security/dependabot/292) Apache Thrift Path Traversal + HTTP Request/Response Splitting (vulnerable `<= 0.22.0`, fixed in 0.23.0)

`thrift` is a **transitive** dep of `@dsnp/parquetjs@1.8.7` (pinned to `0.21.0` upstream). It only exists in `scripts/etl/node_modules` — the Next.js production bundle does not include `parquetjs` or `thrift`, so the CVE attack surface never reached the live app. Added `overrides` + `pnpm.overrides` in `scripts/etl/package.json` forcing `^0.23.0`. Verified post-install: `thrift@0.23.0`.

## Test plan

- `node --check scripts/etl/espocrm-to-lake.mjs` — syntax OK
- End-to-end probe through Cloudflare tunnel with live SSM key from inside the cloudless app pod — all 6 entities return HTTP 200
- Confirmed `require('thrift/package.json').version === '0.23.0'` post-install
- Next hourly cron at `:20 UTC` exercises the happy path; `workflow_dispatch` available for immediate verification
