### PR TITLE
fix(etl): move EspoCRM ETL to self-hosted Pi runners (Cloudflare bot-detection unblock)

### DIFF
--- a/.github/workflows/etl-espocrm-to-lake.yml
+++ b/.github/workflows/etl-espocrm-to-lake.yml
@@ -21,7 +21,21 @@ env:
 jobs:
   espocrm-sync:
     name: Sync EspoCRM → S3 Parquet
-    runs-on: ubuntu-latest
+    # Pinned to self-hosted Pi runners (omv / omv-2 / omv-3).
+    # Cloudflare's edge bot-detection / Super Bot Fight Mode silently
+    # 404's /api/v1/* requests originating from data-center IPs (incl.
+    # GitHub Actions ubuntu-latest pool) — every entity hit a sustained
+    # block in runs #27885175515 / #27885186551 (2026-06-20 22:01-22:05),
+    # confirmed by external curl from WSL showing HTTP 401 with a
+    # WWW-Authenticate: Basic challenge from Cloudflare. Cluster-side
+    # probes through the same hostname return 200 fine because the Pi's
+    # residential IP scores clean. Running the ETL from the Pi puts it
+    # on the same path the cluster pod uses → no edge interception.
+    # Long-term fix is a WAF skip rule for /api/* + X-Api-Key header,
+    # gated on rotating CLOUDFLARE_API_TOKEN (see cloudflare-token-doctor
+    # skill); this runs-on change is the immediate unblock that doesn't
+    # need that rotation.
+    runs-on: [self-hosted, omv, pi]
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v4


### PR DESCRIPTION
Run #27885175515 + #27885186551 (post-PR-#1039) confirmed the ETL failure is NOT a tunnel flap. It is Cloudflare edge bot-detection silently 404-ing /api/v1/* requests from data-center IPs (GH Actions). Cluster-side probe through the same hostname returns 200 because the residential Pi IP scores clean. External WSL curl reproduces with HTTP 401 + WWW-Authenticate Basic challenge from Cloudflare. 1-line workflow change moves runs to the existing self-hosted [omv, pi] runners; no new infra. Long-term fix is a Cloudflare WAF skip rule for /api/* + X-Api-Key (needs CLOUDFLARE_API_TOKEN rotation per CLAUDE.md).