### PR TITLE
fix(ci): remove empty env: block in a11y-audit.yml

### DIFF
--- a/.github/workflows/a11y-audit.yml
+++ b/.github/workflows/a11y-audit.yml
@@ -30,7 +30,6 @@ jobs:
     name: Playwright A11y Checks
     runs-on: ubuntu-latest
     timeout-minutes: 20
-    env:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4


### PR DESCRIPTION
Dangling empty  left over from PR #1043 (NEXT_PUBLIC_HUBSPOT_PORTAL_ID strip) broke YAML parsing on workflow_dispatch (HTTP 422). 1-line fix.