### PR TITLE
fix(e2e): drop deleted HubSpot routes from test specs (PR #1043 follow-up)

### DIFF
--- a/__tests__/proxy-config.test.ts
+++ b/__tests__/proxy-config.test.ts
@@ -55,10 +55,6 @@ describe("proxy RATE_LIMITS", () => {
     expect(proxySrc).toContain('"/api/calendar/book"');
   });
 
-  it("covers /api/hubspot/ticket", () => {
-    expect(proxySrc).toContain('"/api/hubspot/ticket"');
-  });
-
   it("covers /api/crm/contact", () => {
     expect(proxySrc).toContain('"/api/crm/contact"');
   });

--- a/e2e/helpers/coverage-routes.ts
+++ b/e2e/helpers/coverage-routes.ts
@@ -127,7 +127,6 @@ export const PUBLIC_API_POST_FORM = [
   "/api/track",
   "/api/csp-report",
   "/api/crm/contact",
-  "/api/hubspot/ticket",
   "/api/notion-image",
   "/api/agent/book",
   "/api/chat",
@@ -138,7 +137,7 @@ export const PUBLIC_API_POST_FORM = [
 export const WEBHOOK_APIS = [
   "/api/webhooks/stripe",
   "/api/webhooks/notion",
-  "/api/webhooks/hubspot",
+  "/api/webhooks/espocrm",
 ] as const;
 
 export const SLACK_APIS = [

--- a/e2e/integrations-contracts.spec.ts
+++ b/e2e/integrations-contracts.spec.ts
@@ -96,24 +96,16 @@ test.describe("Integrations contracts", () => {
     expect(response.status()).toBe(401);
   });
 
-  test("HubSpot webhook GET verification responds ok", async ({ page }) => {
-    const response = await page.request.get("/api/webhooks/hubspot");
-    expect(response.status()).toBe(200);
-    const body = await response.json();
-    expect(body.ok).toBe(true);
-  });
-
-  test("HubSpot webhook POST enforces signature when configured", async ({ page }) => {
-    const response = await postJson(page.request, "/api/webhooks/hubspot", {
-      eventType: "contact.creation",
-      objectId: 123,
+  test("EspoCRM webhook POST requires URL-secret auth", async ({ page }) => {
+    // EspoCRM webhook replaced HubSpot 2026-06-20 (PR #1043). Auth is a
+    // URL-query-param secret (?secret=...), not HMAC. POST without secret → 4xx.
+    const response = await postJson(page.request, "/api/webhooks/espocrm", {
+      entity: "Lead",
+      action: "create",
+      id: "abc123",
     });
-    expect([200, 401]).toContain(response.status());
-
-    if (response.status() === 200) {
-      const body = await response.json();
-      expect(typeof body.received).toBe("number");
-    }
+    expect(response.status()).toBeGreaterThanOrEqual(400);
+    expect(response.status()).toBeLessThan(500);
   });
 
   test("HubSpot CRM upsert route handles invalid email or unconfigured CRM", async ({ page }) => {

--- a/e2e/k3s/webhook-endpoints.spec.ts
+++ b/e2e/k3s/webhook-endpoints.spec.ts
@@ -13,7 +13,10 @@ const WEBHOOK_ENDPOINTS = [
   { name: "Slack events", path: "/api/slack/events", expectedStatus: [401, 403, 400] },
   { name: "Slack interactions", path: "/api/slack/interactions", expectedStatus: [401, 403, 400] },
   { name: "Slack commands", path: "/api/slack/commands", expectedStatus: [401, 403, 400] },
-  { name: "HubSpot webhook", path: "/api/webhooks/hubspot", expectedStatus: [401, 403, 400, 405] },
+  // HubSpot webhook deleted 2026-06-20 with PR #1043 (HubSpot decom); EspoCRM
+  // webhook replaces it. The /api/webhooks/espocrm route exists and is exercised
+  // here so a future "EspoCRM webhook accidentally deleted" regression is caught.
+  { name: "EspoCRM webhook", path: "/api/webhooks/espocrm", expectedStatus: [401, 403, 400, 405] },
   { name: "Stripe webhook", path: "/api/webhooks/stripe", expectedStatus: [400, 401, 403] },
   { name: "Notion webhook", path: "/api/webhooks/notion", expectedStatus: [400, 401, 403, 405] },
 ];
@@ -32,15 +35,14 @@ test.describe("Webhook endpoints — route existence and auth rejection", () => 
     });
   }
 
-  test("GET on webhook routes does not return 2xx (except HubSpot which has a GET verification handler)", async ({ request }) => {
+  test("GET on webhook routes does not return 2xx", async ({ request }) => {
     for (const wh of WEBHOOK_ENDPOINTS) {
       const r = await request.get(`https://${K3S_HOST}${wh.path}`, {
         failOnStatusCode: false,
         timeout: 10_000,
       });
-      // HubSpot intentionally exports GET for webhook URL verification during setup.
-      // All other webhook routes should reject GET with 405.
-      if (wh.path.includes("hubspot")) continue;
+      // Webhook routes should reject GET (405) or return 4xx; never 2xx.
+      // (The HubSpot GET-verification exemption was removed with PR #1043.)
       expect(
         [200].includes(r.status()),
         `${wh.name} accepts GET — webhook routes should be POST-only`,

--- a/e2e/migrated/webhooks.spec.ts
+++ b/e2e/migrated/webhooks.spec.ts
@@ -21,8 +21,10 @@ test.describe("Webhook signature gates", () => {
     expect([400, 401, 403]).toContain(r.status());
   });
 
-  test("POST /api/webhooks/hubspot without signature → 4xx", async ({ request }) => {
-    const r = await request.post("/api/webhooks/hubspot", { data: [] });
+  test("POST /api/webhooks/espocrm without secret → 4xx", async ({ request }) => {
+    // EspoCRM webhook (replaced HubSpot 2026-06-20, PR #1043). Auth is a
+    // URL-query-param secret rather than HMAC; rejects unauth POSTs with 4xx.
+    const r = await request.post("/api/webhooks/espocrm", { data: [] });
     expect(r.status()).toBeGreaterThanOrEqual(400);
     expect(r.status()).toBeLessThan(500);
   });

--- a/e2e/public-api-deep.spec.ts
+++ b/e2e/public-api-deep.spec.ts
@@ -141,10 +141,7 @@ test("POST /api/newsletter/send — without auth returns 401/403", async ({ requ
   expect(r.status()).toBeLessThan(500);
 });
 
-test("POST /api/hubspot/ticket — without payload rejected", async ({ request }) => {
-  const r = await request.post("/api/hubspot/ticket", { data: {}, failOnStatusCode: false });
-  expect(r.status()).toBeLessThan(500);
-});
+// /api/hubspot/ticket deleted 2026-06-20 (PR #1043 — HubSpot decom).
 
 test("GET /api/health — returns ok shape", async ({ request }) => {
   const r = await request.get("/api/health");

--- a/e2e/public-api-sweep.spec.ts
+++ b/e2e/public-api-sweep.spec.ts
@@ -74,12 +74,9 @@ test.describe("Public API route sweep", () => {
     // In dev: 5xx is acceptable (missing creds). We only need the route to be wired.
     expect(res.status()).toBeGreaterThanOrEqual(200);
   });
-  test("POST /api/hubspot/ticket with empty body returns 4xx", async ({ request }) => {
-    const res = await request.post("/api/hubspot/ticket", { data: {} });
-    expect(res.status()).toBeGreaterThanOrEqual(400);
-    // In dev: 5xx is acceptable (missing creds). We only need the route to be wired.
-    expect(res.status()).toBeGreaterThanOrEqual(200);
-  });
+  // /api/hubspot/ticket deleted 2026-06-20 (PR #1043); EspoCRM Case is
+  // created via /api/contact + lib/espocrm.ts createCase().
+
   test("POST /api/newsletter/send with empty body returns 4xx", async ({ request }) => {
     const res = await request.post("/api/newsletter/send", { data: {} });
     expect(res.status()).toBeGreaterThanOrEqual(400);
@@ -118,8 +115,9 @@ test.describe("Public API route sweep", () => {
     // In dev: 5xx is acceptable (missing creds). We only need the route to be wired.
     expect(res.status()).toBeGreaterThanOrEqual(200);
   });
-  test("POST /api/webhooks/hubspot without auth returns 4xx", async ({ request }) => {
-    const res = await request.post("/api/webhooks/hubspot", { data: {} });
+  test("POST /api/webhooks/espocrm without secret returns 4xx", async ({ request }) => {
+    // EspoCRM replaced HubSpot webhook 2026-06-20 (PR #1043). Auth = URL-secret.
+    const res = await request.post("/api/webhooks/espocrm", { data: {} });
     // In dev: 5xx is acceptable (missing creds). We only need the route to be wired.
     expect(res.status()).toBeGreaterThanOrEqual(200);
   });

--- a/e2e/webhook-signatures.spec.ts
+++ b/e2e/webhook-signatures.spec.ts
@@ -39,27 +39,9 @@ test.describe("webhook signature gates", () => {
     expect(r.status()).toBeLessThan(500);
   });
 
-  test("/api/webhooks/hubspot rejects missing v3 signature headers", async ({ request }) => {
-    const r = await request.post("/api/webhooks/hubspot", {
-      data: FAKE_BODY,
-      headers: { "Content-Type": "application/json" },
-    });
-    expect(r.status()).toBeGreaterThanOrEqual(400);
-    expect(r.status()).toBeLessThan(500);
-  });
-
-  test("/api/webhooks/hubspot rejects invalid signature", async ({ request }) => {
-    const r = await request.post("/api/webhooks/hubspot", {
-      data: FAKE_BODY,
-      headers: {
-        "Content-Type": "application/json",
-        "x-hubspot-signature-v3": "deadbeef".repeat(8),
-        "x-hubspot-signature-timestamp": String(Date.now()),
-      },
-    });
-    expect(r.status()).toBeGreaterThanOrEqual(400);
-    expect(r.status()).toBeLessThan(500);
-  });
+  // HubSpot webhook signature tests removed 2026-06-20 alongside the route
+  // (PR #1043 — HubSpot decom). EspoCRM webhook auth is URL-secret-based,
+  // not HMAC; covered by `/api/webhooks/espocrm` tests elsewhere.
 
   test("/api/webhooks/notion rejects missing signature", async ({ request }) => {
     const r = await request.post("/api/webhooks/notion", {


### PR DESCRIPTION
Post-HubSpot-decom cleanup: 8 test files were still asserting /api/webhooks/hubspot or /api/hubspot/ticket exist. k3s-standby-e2e #27895563480 caught it (HubSpot webhook: got 404, expected rejection). This PR removes the stale assertions and adds equivalent EspoCRM coverage where the surface still exists.