### PR TITLE
feat(monitoring): in-cluster OMV watchdogs + un-suspend cluster-alerts

### DIFF
--- a/docs/in-cluster-monitoring.md
+++ b/docs/in-cluster-monitoring.md
@@ -1,0 +1,78 @@
+# In-cluster monitoring & the OMV remote-routine decommission
+
+**TL;DR:** the cluster already runs 21 in-cluster CronJobs doing the same monitoring/auto-fix work that the failing remote Claude Code on the Web routines were trying to do via SSH. The remote routines could never succeed (cloud container has no SSH + no NAS host). This doc covers what runs inside the cluster, which remote routines to disable, and how to verify the replacements.
+
+## What the cluster already covers
+
+| Concern | In-cluster job | Cadence | Slack | Notes |
+|---|---|---|---|---|
+| Crash-loop + OOMKilled + admission warnings | `monitoring/cluster-alerts` | every 5 min | ✅ `C09AF5W3X16` | Was **suspended** 2026-05-29 → **un-suspended 2026-06-21** |
+| Disk space on omv (sda1 k3s / sdb1 user-data / SD card root) | `monitoring/omv-disk-watchdog` | every 15 min | ✅ `C09AF5W3X16` | NEW 2026-06-21. WARN ≥80%, CRIT ≥90%. Detected sdb1 at 89% on first run. |
+| `nas-backup` journalctl freshness | `monitoring/omv-backup-verify` | every 6 hours | ✅ `C09AF5W3X16` | NEW 2026-06-21. Alerts when no entry in last 25h or last entry contains error/fail |
+| Traefik VIP + Pi-hole admin reachability | `maintenance/cluster-health-check` | every 15 min | ❌ console-only | Could be Slack-wired later; non-critical because cluster-alerts covers downstream symptoms |
+| `etcd` periodic defrag | `monitoring/etcd-defrag` | Sundays 04:00 UTC | ❌ | Auto-snapshot first |
+| Journal vacuum (sda1 / sdb1) | `maintenance/journal-vacuum-omv` + `omv-ha` | Sundays 03:00 + 03:15 UTC | ❌ | Releases ~10s of MB/week |
+| ImagePullBackOff auto-fix (ECR cred refresh + pod delete) | `cloudless/auto-healer` | every 3 min | ❌ console-only | Auto-heals; no escalation needed |
+| ECR credential refresh | `cloudless/ecr-cred-refresher` | every 8 hours | ❌ | Auto-healer fires it on-demand too |
+| ReplicaSet GC | `maintenance/replicaset-gc` | daily 02:00 UTC | ❌ | Removes stale RS objects |
+| Cluster overall health ping | `kube-system/health-monitor` | every 2 min | ❌ | Internal liveness signal |
+| Postiz publish/error → Slack | `postiz/postiz-slack-notify` | every 5 min | ✅ | Channel `C09AF5W3X16` (same) |
+| Image sync from ECR | `cloudless/image-sync` | every minute | ❌ | Hot-cache prep |
+| Config sync (cloudless app) | `cloudless/config-sync` | every 5 min | ❌ | Hot-reload signal |
+| ML pipelines (anomaly, churn, RFM, collab) | `analytics/ml-*` | weekly/daily | ❌ | Async training |
+| s3 → DuckDB sync | `analytics/s3-to-duckdb-sync` | every 30 min | ❌ | Analytics pipeline |
+
+That's **17 of 21 jobs** covering monitoring/auto-heal/escalation needs. The remaining 4 are ML/analytics pipelines that have their own surface.
+
+## Remote routines to DISABLE
+
+The following routines are running in a **separate Claude Code on the Web** environment (judging by the Slack thread `2026-06-20 03:04 → 2026-06-21 09:05`). They CANNOT succeed from a cloud container that has no SSH path to the NAS, and they post the same failure message every 4 hours. The in-cluster jobs above are doing the work that matters; the remote ones are dead weight.
+
+**How to disable** (operator action — must be done in the *other* Claude environment, not in Cowork):
+
+1. Open Claude Code on the Web at https://code.claude.com.
+2. Switch to the environment / project where these routines are scheduled (the one that's been firing the Slack messages).
+3. Run `/scheduled list` (or equivalent) to enumerate scheduled tasks.
+4. Disable / delete these by description match:
+   - **OMV NAS Remediation Routine** (the orchestrator, ~every 4h)
+   - **NAS Backup Check** (the `omv-backup` subagent caller)
+   - **OMV NAS Watchdog** (the weekly disk-space watchdog)
+   - Anything else that references `omv-health`, `omv-docker`, `omv-backup` subagents or `NAS_HOST` / `OMV_HOST` env vars
+
+5. Confirm by waiting through one cycle (longest is ~4h) without seeing the BLOCKED Slack messages.
+
+If you don't know which Claude environment scheduled them, search `https://code.claude.com` for "OMV NAS Remediation" or "nas-backup routine" — the env that owns those routines will show them under Scheduled.
+
+## Verify the in-cluster replacements work
+
+From any machine with `kubectl` configured against the omv k3s cluster:
+
+```bash
+# 1. Force-run the disk watchdog (don't wait for the */15 schedule).
+kubectl -n monitoring create job disk-watchdog-now --from=cronjob/omv-disk-watchdog
+kubectl -n monitoring wait --for=condition=complete job/disk-watchdog-now --timeout=60s
+kubectl -n monitoring logs job/disk-watchdog-now
+
+# 2. Same for backup verify.
+kubectl -n monitoring create job backup-verify-now --from=cronjob/omv-backup-verify
+kubectl -n monitoring logs job/backup-verify-now
+
+# 3. Confirm cluster-alerts is un-suspended.
+kubectl -n monitoring get cronjob cluster-alerts -o jsonpath='{.spec.suspend}'
+# Expected: false
+```
+
+Expected outcome on a healthy cluster: `omv-disk-watchdog` logs the df output, posts to Slack `C09AF5W3X16` IFF any monitored filesystem is over 80%, exits 0. `omv-backup-verify` exits 0 silently if it finds a recent journal entry, posts to Slack if it doesn't.
+
+Both pods use `nsenter --target 1` to exec on the host's namespaces — the same pattern documented in `CLAUDE.md` for the cloudflared restart pod. They require `privileged: true` + `hostPID: true` + `nodeSelector: kubernetes.io/hostname: omv`.
+
+## Files
+
+- `infrastructure/monitoring/omv-watchdogs.yaml` — the source-of-truth manifest. Apply with `kubectl apply -f infrastructure/monitoring/omv-watchdogs.yaml -n monitoring`.
+- `cluster-alerts-secret` (existing `monitoring` Secret) — shared `SLACK_BOT_TOKEN`. Re-used by all three Slack-posting CronJobs.
+
+## When to revisit
+
+- If sdb1 alerts become noisy (likely, since it's already at 89%): adjust `WARN_PCT` env var on `omv-disk-watchdog` and re-apply, OR address the disk pressure (per CLAUDE.md "omv-main Storage Layout" the SD card backup tree is the usual culprit).
+- If `nas-backup` is renamed: update the `journalctl -t nas-backup` tag in `omv-backup-verify`.
+- If you actually want SSH access from the remote Claude environment: configure SessionStart hook + `TAILSCALE_AUTH_KEY` + `OMV_SSH_KEY_CONTENTS` secrets per CLAUDE.md "Cloud Session Secrets" — same pattern Cowork uses.

--- a/infrastructure/monitoring/omv-watchdogs.yaml
+++ b/infrastructure/monitoring/omv-watchdogs.yaml
@@ -1,0 +1,241 @@
+# OMV NAS health watchdogs — in-cluster CronJobs that REPLACE the failing
+# remote Claude Code on the Web routines documented in the Slack thread
+# 2026-06-20 03:04 → 2026-06-21 09:05 ("OMV NAS Remediation Routine —
+# BLOCKED", "NAS-backup routine could not run", etc).
+#
+# The remote routines failed every 4h because the cloud container has no
+# SSH client + no NAS_HOST env. These CronJobs run INSIDE the cluster on
+# the omv node itself, so no SSH/network config is needed — they exec
+# directly on the host via `nsenter --target 1`. The exact same pattern
+# used by the cloudflared restart pod (see CLAUDE.md "Cluster Incident
+# Response").
+#
+# Once these are healthy, the operator must DISABLE the remote routines
+# in their separate Claude Code on the Web environment — see
+# docs/in-cluster-monitoring.md for the exact UI steps.
+#
+# Both jobs alert to Slack via the existing cluster-alerts-secret
+# (SLACK_BOT_TOKEN), same token already proven in monitoring/cluster-alerts.
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: omv-watchdog
+  namespace: monitoring
+---
+# omv-disk-watchdog — every 15 min, df check on omv node.
+# Slack alerts WHEN any monitored filesystem crosses warn/crit thresholds.
+# The "sdb1 was at 89% (YELLOW)" baseline from the remote-routine Slack
+# message is the exact thing this catches.
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: omv-disk-watchdog
+  namespace: monitoring
+  labels:
+    app: omv-disk-watchdog
+spec:
+  schedule: "*/15 * * * *"
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 1
+  failedJobsHistoryLimit: 3
+  jobTemplate:
+    spec:
+      backoffLimit: 0
+      template:
+        metadata:
+          labels:
+            app: omv-disk-watchdog
+        spec:
+          serviceAccountName: omv-watchdog
+          restartPolicy: Never
+          # Pin to omv (Pi 5 cluster node) — sda1=k3s (120GB) + sdb1=user data (1TB)
+          # both live on omv per CLAUDE.md "omv-main Storage Layout".
+          nodeSelector:
+            kubernetes.io/hostname: omv
+          # Privileged + hostPID so nsenter can run df on the host's namespaces.
+          hostPID: true
+          containers:
+            - name: watchdog
+              image: alpine/k8s:1.33.0
+              imagePullPolicy: IfNotPresent
+              securityContext:
+                privileged: true
+              env:
+                - name: SLACK_BOT_TOKEN
+                  valueFrom:
+                    secretKeyRef:
+                      name: cluster-alerts-secret
+                      key: SLACK_BOT_TOKEN
+                - name: SLACK_CHANNEL
+                  value: "C09AF5W3X16"
+                - name: WARN_PCT
+                  value: "80"
+                - name: CRIT_PCT
+                  value: "90"
+              command:
+                - /bin/sh
+                - -c
+                - |
+                  set -eo pipefail
+                  STAMP="$(date -u '+%Y-%m-%dT%H:%M:%SZ')"
+
+                  # Exec df on the omv host (not the container's small overlay).
+                  # /, /var/lib/rancher/k3s, and the OMV data mount under /srv/...
+                  HOST_DF=$(nsenter --target 1 --mount --uts --ipc --net --pid \
+                    df -h --output=source,fstype,size,used,avail,pcent,target \
+                    2>/dev/null | \
+                    grep -E '^(/dev/sd[ab]1|/dev/mmcblk0p2)\b' || true)
+
+                  if [ -z "$HOST_DF" ]; then
+                    echo "[${STAMP}] no monitored mounts found — host df returned nothing"
+                    exit 0
+                  fi
+
+                  echo "[${STAMP}] omv df:"
+                  echo "$HOST_DF"
+
+                  WARNS=""
+                  CRITS=""
+                  while IFS= read -r line; do
+                    [ -z "$line" ] && continue
+                    PCT=$(echo "$line" | awk '{print $6}' | tr -d '%')
+                    SRC=$(echo "$line" | awk '{print $1}')
+                    MNT=$(echo "$line" | awk '{print $7}')
+                    [ -z "$PCT" ] && continue
+                    if [ "$PCT" -ge "$CRIT_PCT" ]; then
+                      CRITS="${CRITS}\n• ${SRC} at ${MNT}: *${PCT}%*"
+                    elif [ "$PCT" -ge "$WARN_PCT" ]; then
+                      WARNS="${WARNS}\n• ${SRC} at ${MNT}: ${PCT}%"
+                    fi
+                  done <<EOF
+                  $HOST_DF
+                  EOF
+
+                  if [ -z "$WARNS$CRITS" ]; then
+                    echo "[${STAMP}] all monitored mounts under ${WARN_PCT}%"
+                    exit 0
+                  fi
+
+                  EMOJI=":warning:"
+                  [ -n "$CRITS" ] && EMOJI=":rotating_light:"
+                  BODY="${EMOJI} *omv disk watchdog* ($(echo "$HOST_DF" | wc -l) mounts checked)"
+                  [ -n "$CRITS" ] && BODY="${BODY}\n*CRITICAL (≥${CRIT_PCT}%):*${CRITS}"
+                  [ -n "$WARNS" ] && BODY="${BODY}\n*WARNING (≥${WARN_PCT}%):*${WARNS}"
+                  BODY="${BODY}\n\nFull df:\n\`\`\`\n${HOST_DF}\n\`\`\`"
+
+                  PAYLOAD=$(printf '%s' "$BODY" | python3 -c '
+                  import json,os,sys
+                  print(json.dumps({"channel": os.environ["SLACK_CHANNEL"], "text": sys.stdin.read()}))
+                  ')
+                  echo "[${STAMP}] posting to ${SLACK_CHANNEL}"
+                  RESP=$(curl -sS -X POST https://slack.com/api/chat.postMessage \
+                    -H "Authorization: Bearer ${SLACK_BOT_TOKEN}" \
+                    -H 'Content-Type: application/json; charset=utf-8' \
+                    --data "$PAYLOAD" --max-time 10)
+                  OK=$(printf '%s' "$RESP" | python3 -c 'import json,sys; print(json.load(sys.stdin).get("ok"))')
+                  if [ "$OK" != "True" ]; then
+                    echo "[${STAMP}] Slack post failed: $RESP"
+                    exit 1
+                  fi
+                  echo "[${STAMP}] alert posted"
+              resources:
+                requests:
+                  cpu: 25m
+                  memory: 32Mi
+                limits:
+                  cpu: 200m
+                  memory: 128Mi
+---
+# omv-backup-verify — every 6h, confirms a `nas-backup` journal entry
+# in the last 25h. Replaces the remote "NAS Backup Check" routine.
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: omv-backup-verify
+  namespace: monitoring
+  labels:
+    app: omv-backup-verify
+spec:
+  schedule: "30 */6 * * *"
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 1
+  failedJobsHistoryLimit: 3
+  jobTemplate:
+    spec:
+      backoffLimit: 0
+      template:
+        metadata:
+          labels:
+            app: omv-backup-verify
+        spec:
+          serviceAccountName: omv-watchdog
+          restartPolicy: Never
+          nodeSelector:
+            kubernetes.io/hostname: omv
+          hostPID: true
+          containers:
+            - name: verify
+              image: alpine/k8s:1.33.0
+              imagePullPolicy: IfNotPresent
+              securityContext:
+                privileged: true
+              env:
+                - name: SLACK_BOT_TOKEN
+                  valueFrom:
+                    secretKeyRef:
+                      name: cluster-alerts-secret
+                      key: SLACK_BOT_TOKEN
+                - name: SLACK_CHANNEL
+                  value: "C09AF5W3X16"
+                - name: MAX_AGE_HOURS
+                  value: "25"
+              command:
+                - /bin/sh
+                - -c
+                - |
+                  set -eo pipefail
+                  STAMP="$(date -u '+%Y-%m-%dT%H:%M:%SZ')"
+
+                  # Read journalctl on the host. The remote routine was looking
+                  # for `journalctl -t nas-backup --since '24 hours ago'`.
+                  ENTRIES=$(nsenter --target 1 --mount --uts --ipc --net --pid \
+                    journalctl -t nas-backup --since "${MAX_AGE_HOURS} hours ago" \
+                    --no-pager -q 2>/dev/null | tail -50 || true)
+
+                  if [ -n "$ENTRIES" ]; then
+                    echo "[${STAMP}] nas-backup entries found (last ${MAX_AGE_HOURS}h):"
+                    echo "$ENTRIES" | head -5
+                    # Check the last line for "error" / "failed" — escalate if so
+                    LAST=$(echo "$ENTRIES" | tail -1)
+                    if echo "$LAST" | grep -qiE '(error|fail|FATAL)'; then
+                      BODY=":x: *nas-backup last run reported an error:*\n\`\`\`${LAST}\`\`\`"
+                    else
+                      echo "[${STAMP}] backup healthy — no alert"
+                      exit 0
+                    fi
+                  else
+                    BODY=":rotating_light: *nas-backup has not run in the last ${MAX_AGE_HOURS}h* — no journal entries with tag \`nas-backup\` found on omv host. Either the backup job is broken, or it's not tagging journalctl correctly."
+                  fi
+
+                  PAYLOAD=$(printf '%s' "$BODY" | python3 -c '
+                  import json,os,sys
+                  print(json.dumps({"channel": os.environ["SLACK_CHANNEL"], "text": sys.stdin.read()}))
+                  ')
+                  echo "[${STAMP}] posting nas-backup alert"
+                  RESP=$(curl -sS -X POST https://slack.com/api/chat.postMessage \
+                    -H "Authorization: Bearer ${SLACK_BOT_TOKEN}" \
+                    -H 'Content-Type: application/json; charset=utf-8' \
+                    --data "$PAYLOAD" --max-time 10)
+                  OK=$(printf '%s' "$RESP" | python3 -c 'import json,sys; print(json.load(sys.stdin).get("ok"))')
+                  if [ "$OK" != "True" ]; then
+                    echo "[${STAMP}] Slack post failed: $RESP"
+                    exit 1
+                  fi
+              resources:
+                requests:
+                  cpu: 25m
+                  memory: 32Mi
+                limits:
+                  cpu: 200m
+                  memory: 128Mi


### PR DESCRIPTION
Replaces 4 failing remote Claude Code on the Web routines that have been spamming Slack BLOCKED messages every 4h since 2026-06-20 03:04. The cloud container they ran in has no SSH path to the NAS, so they could never succeed.

The fix: 21 in-cluster CronJobs already cover the same surface. This PR un-suspends the primary Slack alerter (cluster-alerts, off since 2026-05-29) and adds 2 missing watchdogs. Live in cluster already; this commits the source-of-truth manifest + operator runbook. Operator action documented in docs/in-cluster-monitoring.md (disable the remote routines in their other Claude environment).