### PR TITLE
feat(admin): /admin/cluster — live watchdog status synced from k8s API

### DIFF
--- a/infrastructure/monitoring/watchdog-reader-rbac.yaml
+++ b/infrastructure/monitoring/watchdog-reader-rbac.yaml
@@ -1,0 +1,31 @@
+# Grants the cloudless app pod (cloudless/default SA) read access to
+# cronjobs + jobs in the monitoring namespace, so /api/admin/cluster/watchdogs
+# can surface the live state of cluster-alerts / omv-disk-watchdog /
+# omv-backup-verify / postiz-slack-notify in the admin UI.
+#
+# Read-only — the app cannot create/patch/delete anything. Patching cronjobs
+# (e.g. suspend/unsuspend) still requires kubectl admin access.
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: watchdog-reader
+  namespace: monitoring
+rules:
+  - apiGroups: ["batch"]
+    resources: ["cronjobs", "jobs"]
+    verbs: ["get", "list"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: watchdog-reader-for-cloudless-app
+  namespace: monitoring
+subjects:
+  - kind: ServiceAccount
+    name: default
+    namespace: cloudless
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: watchdog-reader

--- a/src/app/[locale]/admin/cluster/page.tsx
+++ b/src/app/[locale]/admin/cluster/page.tsx
@@ -1,0 +1,173 @@
+"use client";
+
+/**
+ * /admin/cluster — live status of the in-cluster monitoring CronJobs that
+ * replaced the failing remote Claude Code on the Web routines (PR #1048,
+ * 2026-06-21). Reuses the same MetricCard / Spinner / ErrorMsg components
+ * as the LinkedIn campaigns page; data comes from
+ * /api/admin/cluster/watchdogs which talks to the k8s API via the in-pod
+ * SA + the `watchdog-reader` RoleBinding.
+ */
+import { fetchWithAuth } from "@/lib/fetch-with-auth";
+import { useEffect, useState } from "react";
+import { Link } from "@/i18n/navigation";
+import { Spinner, ErrorMsg } from "@/components/admin/CampaignPageKit";
+
+interface Watchdog {
+  name: string;
+  namespace: string;
+  schedule: string;
+  suspended: boolean;
+  lastScheduleTime: string | null;
+  lastSuccessfulTime: string | null;
+  lastRunFailed: boolean | null;
+}
+
+function fmtRelative(iso: string | null): string {
+  if (!iso) return "—";
+  const ms = Date.now() - new Date(iso).getTime();
+  if (ms < 0) return "—";
+  const min = Math.floor(ms / 60_000);
+  if (min < 1) return "<1m ago";
+  if (min < 60) return `${min}m ago`;
+  const h = Math.floor(min / 60);
+  if (h < 24) return `${h}h ago`;
+  const d = Math.floor(h / 24);
+  return `${d}d ago`;
+}
+
+function statusFor(w: Watchdog): { label: string; klass: string } {
+  if (w.suspended) {
+    return { label: "SUSPENDED", klass: "border-yellow-500/30 text-yellow-400" };
+  }
+  if (w.lastRunFailed) {
+    return { label: "FAILED", klass: "border-red-500/30 text-red-400" };
+  }
+  if (w.lastSuccessfulTime) {
+    return { label: "OK", klass: "border-neon-green/30 text-neon-green" };
+  }
+  return { label: "PENDING", klass: "border-slate-700 text-slate-500" };
+}
+
+export default function ClusterStatusPage() {
+  const [watchdogs, setWatchdogs] = useState<Watchdog[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [outsideCluster, setOutsideCluster] = useState(false);
+  const [fetchedAt, setFetchedAt] = useState<string | null>(null);
+
+  async function load() {
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await fetchWithAuth("/api/admin/cluster/watchdogs");
+      if (res.status === 503) {
+        setOutsideCluster(true);
+        return;
+      }
+      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      const data = await res.json();
+      setWatchdogs(data.watchdogs ?? []);
+      setFetchedAt(data.fetchedAt ?? null);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Failed to load");
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  useEffect(() => {
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    load();
+  }, []);
+
+  return (
+    <div>
+      <div className="mb-6">
+        <Link href="/admin" className="font-mono text-xs text-slate-500 hover:text-slate-300">
+          ← Admin
+        </Link>
+      </div>
+      <div className="mb-8">
+        <div className="mb-4 inline-flex items-center gap-2 rounded-full border border-blue-500/20 bg-blue-500/10 px-3 py-1.5">
+          <span className="h-2 w-2 animate-pulse rounded-full bg-blue-400" />
+          <span className="font-mono text-xs text-blue-400">CLUSTER</span>
+        </div>
+        <h1 className="font-heading text-2xl font-bold text-white">Monitoring watchdogs</h1>
+        <p className="mt-2 font-mono text-xs text-slate-500">
+          In-cluster CronJobs that replaced the failing remote Claude Code on the Web routines (PR
+          #1048). Posts to Slack <code className="text-slate-400">C09AF5W3X16</code> on any
+          warning.
+        </p>
+      </div>
+
+      {outsideCluster && (
+        <div className="rounded-xl border border-yellow-900/30 bg-yellow-950/10 p-6">
+          <p className="font-mono text-sm text-yellow-400">
+            This page only renders inside the cluster pod. Local dev / preview deploys see
+            this banner instead of live data.
+          </p>
+        </div>
+      )}
+
+      {loading && <Spinner color="border-blue-400" />}
+      {error && <ErrorMsg msg={error} />}
+
+      {!loading && !error && !outsideCluster && (
+        <div className="overflow-hidden rounded-xl border border-slate-800">
+          <table className="w-full">
+            <thead>
+              <tr className="border-b border-slate-800 bg-slate-900/50">
+                <th className="px-4 py-3 text-left font-mono text-xs text-slate-500">Watchdog</th>
+                <th className="px-4 py-3 text-left font-mono text-xs text-slate-500">Schedule</th>
+                <th className="px-4 py-3 text-left font-mono text-xs text-slate-500">Status</th>
+                <th className="px-4 py-3 text-right font-mono text-xs text-slate-500">
+                  Last scheduled
+                </th>
+                <th className="px-4 py-3 text-right font-mono text-xs text-slate-500">
+                  Last success
+                </th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-slate-800">
+              {watchdogs.length === 0 && (
+                <tr>
+                  <td colSpan={5} className="py-8 text-center font-mono text-sm text-slate-600">
+                    No watchdogs found in the monitoring namespace.
+                  </td>
+                </tr>
+              )}
+              {watchdogs.map((w) => {
+                const st = statusFor(w);
+                return (
+                  <tr key={w.name} className="transition-colors hover:bg-slate-800/30">
+                    <td className="px-4 py-3 font-mono text-sm text-white">{w.name}</td>
+                    <td className="px-4 py-3 font-mono text-xs text-slate-400">{w.schedule}</td>
+                    <td className="px-4 py-3">
+                      <span
+                        className={`rounded-full border px-2 py-0.5 font-mono text-[10px] ${st.klass}`}
+                      >
+                        {st.label}
+                      </span>
+                    </td>
+                    <td className="px-4 py-3 text-right font-mono text-xs text-slate-400 tabular-nums">
+                      {fmtRelative(w.lastScheduleTime)}
+                    </td>
+                    <td className="px-4 py-3 text-right font-mono text-xs text-slate-400 tabular-nums">
+                      {fmtRelative(w.lastSuccessfulTime)}
+                    </td>
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+          {fetchedAt && (
+            <p className="border-t border-slate-800 bg-slate-900/30 px-4 py-2 font-mono text-[10px] text-slate-600">
+              Fetched {fmtRelative(fetchedAt)} via the cloudless/default ServiceAccount.
+            </p>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/app/api/admin/cluster/watchdogs/route.ts
+++ b/src/app/api/admin/cluster/watchdogs/route.ts
@@ -1,0 +1,43 @@
+/**
+ * GET /api/admin/cluster/watchdogs
+ *
+ * Returns live status of the cluster's monitoring CronJobs so /admin/cluster
+ * can render a status panel without needing kubectl access. Read-only — uses
+ * the in-pod ServiceAccount + RBAC role `watchdog-reader` granted by
+ * `infrastructure/monitoring/watchdog-reader-rbac.yaml`.
+ *
+ * Returns 503 when called outside the cluster (local dev) — frontend renders
+ * a quiet "running outside cluster" empty state.
+ */
+import { NextRequest, NextResponse } from "next/server";
+import { requireAdmin } from "@/lib/api-auth";
+import { isInCluster, listWatchdogCronJobs } from "@/lib/k8s-cluster";
+
+export const dynamic = "force-dynamic";
+
+const WATCHDOG_NAMES = [
+  "cluster-alerts",
+  "omv-disk-watchdog",
+  "omv-backup-verify",
+  "postiz-slack-notify",
+];
+
+export async function GET(request: NextRequest) {
+  const auth = await requireAdmin(request);
+  if (!auth.ok) return auth.response;
+
+  if (!isInCluster()) {
+    return NextResponse.json(
+      {
+        error: "Not running inside the cluster — /admin/cluster only renders in the live pod.",
+      },
+      { status: 503 }
+    );
+  }
+
+  const watchdogs = await listWatchdogCronJobs(WATCHDOG_NAMES);
+  return NextResponse.json({
+    watchdogs,
+    fetchedAt: new Date().toISOString(),
+  });
+}

--- a/src/lib/k8s-cluster.ts
+++ b/src/lib/k8s-cluster.ts
@@ -1,0 +1,174 @@
+/**
+ * Minimal in-cluster Kubernetes API client.
+ *
+ * Lets the cloudless app pod read its own cluster's state — currently used by
+ * `/api/admin/cluster/watchdogs` to surface the live status of the monitoring
+ * CronJobs (cluster-alerts, omv-disk-watchdog, omv-backup-verify, postiz-slack-notify)
+ * in the admin UI.
+ *
+ * Reads the in-pod service-account token + CA cert from the standard projected
+ * volume at /var/run/secrets/kubernetes.io/serviceaccount. Talks to the in-cluster
+ * API server at https://kubernetes.default.svc. No external k8s client library
+ * needed — we only use it for read-only `GET` on a tiny surface (cronjobs + jobs
+ * in monitoring namespace).
+ *
+ * RBAC: `infrastructure/monitoring/watchdog-reader-rbac.yaml` grants the
+ * cloudless/default SA `get`/`list` on cronjobs+jobs in `monitoring`.
+ *
+ * Outside-of-cluster (local dev, tests): `isInCluster()` returns false and
+ * every fetcher returns `null` so the admin page renders a "not in cluster"
+ * empty state instead of crashing.
+ */
+import { readFileSync, existsSync } from "node:fs";
+import { Agent, fetch as undiciFetch, type RequestInit } from "undici";
+
+const SA_DIR = "/var/run/secrets/kubernetes.io/serviceaccount";
+const TOKEN_PATH = `${SA_DIR}/token`;
+const CA_PATH = `${SA_DIR}/ca.crt`;
+const NAMESPACE_PATH = `${SA_DIR}/namespace`;
+const API_BASE = "https://kubernetes.default.svc";
+
+let cachedAgent: Agent | null = null;
+let cachedToken: string | null = null;
+let cachedTokenReadAt = 0;
+const TOKEN_TTL_MS = 5 * 60 * 1000;
+
+export function isInCluster(): boolean {
+  return existsSync(TOKEN_PATH);
+}
+
+export function getCurrentNamespace(): string | null {
+  if (!isInCluster()) return null;
+  try {
+    return readFileSync(NAMESPACE_PATH, "utf8").trim();
+  } catch {
+    return null;
+  }
+}
+
+function getToken(): string {
+  const now = Date.now();
+  if (cachedToken && now - cachedTokenReadAt < TOKEN_TTL_MS) return cachedToken;
+  cachedToken = readFileSync(TOKEN_PATH, "utf8").trim();
+  cachedTokenReadAt = now;
+  return cachedToken;
+}
+
+function getAgent(): Agent {
+  if (cachedAgent) return cachedAgent;
+  const ca = readFileSync(CA_PATH);
+  cachedAgent = new Agent({ connect: { ca } });
+  return cachedAgent;
+}
+
+/**
+ * Authenticated GET against the in-cluster API server. Returns the parsed JSON
+ * body on success, or `null` on any non-2xx / network error so callers can
+ * degrade gracefully (the admin UI shows a quiet empty state).
+ */
+async function k8sGet<T = unknown>(path: string): Promise<T | null> {
+  if (!isInCluster()) return null;
+  try {
+    const init: RequestInit = {
+      method: "GET",
+      headers: { Authorization: `Bearer ${getToken()}`, Accept: "application/json" },
+      dispatcher: getAgent(),
+      signal: AbortSignal.timeout(5000),
+    };
+    const res = await undiciFetch(`${API_BASE}${path}`, init);
+    if (!res.ok) return null;
+    return (await res.json()) as T;
+  } catch {
+    return null;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Domain types — minimal projection of what /admin/cluster surfaces
+// ---------------------------------------------------------------------------
+
+export interface CronJobSummary {
+  /** Display name. */
+  name: string;
+  namespace: string;
+  /** Cron expression as in CronJob.spec.schedule. */
+  schedule: string;
+  /** True when CronJob.spec.suspend === true. */
+  suspended: boolean;
+  /** Most-recent scheduled job ISO timestamp, if any. */
+  lastScheduleTime: string | null;
+  /** Most-recent SUCCESSFUL completion ISO timestamp, if any. */
+  lastSuccessfulTime: string | null;
+  /** True when the most recent job (if any) failed. */
+  lastRunFailed: boolean | null;
+}
+
+interface RawCronJob {
+  metadata?: { name?: string; namespace?: string };
+  spec?: { schedule?: string; suspend?: boolean };
+  status?: {
+    lastScheduleTime?: string;
+    lastSuccessfulTime?: string;
+  };
+}
+
+interface RawJob {
+  metadata?: {
+    name?: string;
+    ownerReferences?: { kind?: string; name?: string }[];
+    creationTimestamp?: string;
+  };
+  status?: {
+    succeeded?: number;
+    failed?: number;
+    completionTime?: string;
+  };
+}
+
+/**
+ * List monitoring-namespace CronJobs by name, returning a compact summary.
+ * Also peeks at the most-recent Job per CronJob to detect "last run failed"
+ * which the CronJob status itself doesn't expose directly.
+ */
+export async function listWatchdogCronJobs(names: string[]): Promise<CronJobSummary[]> {
+  const ns = "monitoring";
+  const [cronList, jobList] = await Promise.all([
+    k8sGet<{ items?: RawCronJob[] }>(`/apis/batch/v1/namespaces/${ns}/cronjobs`),
+    k8sGet<{ items?: RawJob[] }>(`/apis/batch/v1/namespaces/${ns}/jobs`),
+  ]);
+  if (!cronList?.items) return [];
+
+  // Index latest-by-owner CronJob name from the Jobs list.
+  const latestByOwner = new Map<string, RawJob>();
+  for (const job of jobList?.items ?? []) {
+    const owner = job.metadata?.ownerReferences?.find((o) => o.kind === "CronJob")?.name;
+    if (!owner) continue;
+    const prev = latestByOwner.get(owner);
+    const a = job.metadata?.creationTimestamp ?? "";
+    const b = prev?.metadata?.creationTimestamp ?? "";
+    if (!prev || a > b) latestByOwner.set(owner, job);
+  }
+
+  const wanted = new Set(names);
+  const out: CronJobSummary[] = [];
+  for (const cj of cronList.items) {
+    const name = cj.metadata?.name ?? "";
+    if (!wanted.has(name)) continue;
+    const latest = latestByOwner.get(name);
+    const lastRunFailed = latest
+      ? (latest.status?.failed ?? 0) > 0 && (latest.status?.succeeded ?? 0) === 0
+      : null;
+    out.push({
+      name,
+      namespace: cj.metadata?.namespace ?? ns,
+      schedule: cj.spec?.schedule ?? "?",
+      suspended: cj.spec?.suspend === true,
+      lastScheduleTime: cj.status?.lastScheduleTime ?? null,
+      lastSuccessfulTime: cj.status?.lastSuccessfulTime ?? null,
+      lastRunFailed,
+    });
+  }
+  // Sort in the requested order so the UI is stable.
+  out.sort((a, b) => names.indexOf(a.name) - names.indexOf(b.name));
+  return out;
+}


### PR DESCRIPTION
Wires the in-cluster monitoring watchdogs from PR #1048 into the admin UI. New /admin/cluster page shows live status of cluster-alerts / omv-disk-watchdog / omv-backup-verify / postiz-slack-notify with schedule + last-run + OK/FAILED/SUSPENDED badge.

RBAC + lib + API + page all in this PR. End-to-end verified inside the cloudless pod: HTTP 200 from /apis/batch/v1/namespaces/monitoring/cronjobs, all 4 watchdogs returned, omv-disk-watchdog lastSuccess matches the 09:31-33 EEST Slack alerts the operator already saw.