### PR TITLE
feat(analytics): fully replace Notion B1 stubs with live Athena queries

### DIFF
--- a/src/lib/notion-analytics.ts
+++ b/src/lib/notion-analytics.ts
@@ -1,21 +1,22 @@
 /**
- * Notion Analytics — DECOMMISSIONED 2026-06-20.
+ * Notion Analytics — DECOMMISSIONED 2026-06-20, reads NOW route to Athena.
  *
- * Replaced by Athena views over the data lake (events flow Plausible →
- * Lambda → S3 Parquet → Glue → Athena). The Notion DB is no longer the
- * system of record for site analytics; queries should target Athena via
- * the duckdb-api/duckdb-ml-api admin routes.
+ * The Notion `NOTION_ANALYTICS_DB_ID` database was decommissioned in PR #1044.
+ * PR #1050 wires the read surface to the existing `cloudless_analytics.events`
+ * Athena table (NDJSON, partitioned by year/month/day, written real-time by
+ * the analytics Lambda — see `docs/analytics-athena.sql`).
  *
- * This module is kept as a no-op shim so callers (track API, blog/docs
- * page-view emits, cron rollups, admin/notion/analytics pages) don't
- * crash. Each function preserves its original signature and returns
- * empty / null. The Notion env var `NOTION_ANALYTICS_DB_ID` has been
- * removed from `lib/integrations.ts` + `lib/ssm-config.ts`.
+ * Write paths (trackEvent / trackBlogView / trackFormSubmission) remain
+ * no-ops because emission already happens via Plausible + the S3-events
+ * Lambda, NOT through this module. Consumers that called the old write
+ * functions don't need a replacement — the data already flows.
  *
- * Migration follow-up tracked in memory `project_notion_decom_plan`.
- * Remove this file once the consumers either go through Athena directly
- * or stop calling these helpers entirely.
+ * Outside-of-Athena contexts (local dev without AWS creds, preview deploys):
+ * every function returns empty data so callers don't crash. The admin tile
+ * shows zeros instead of erroring.
  */
+
+import { runAthenaQuery, type AthenaQueryResult } from "@/lib/athena";
 
 // ---------------------------------------------------------------------------
 // Types — kept verbatim for caller compatibility
@@ -51,10 +52,6 @@ export interface AnalyticsSummary {
   recentEvents: AnalyticsEvent[];
 }
 
-// ---------------------------------------------------------------------------
-// No-op shim implementations
-// ---------------------------------------------------------------------------
-
 const EMPTY_SUMMARY: AnalyticsSummary = {
   totalEvents: 0,
   byType: {},
@@ -62,6 +59,37 @@ const EMPTY_SUMMARY: AnalyticsSummary = {
   topSources: [],
   recentEvents: [],
 };
+
+// Athena row shape from cloudless_analytics.events
+type EventRow = Record<string, string | number | null>;
+
+function rowToEvent(r: EventRow): AnalyticsEvent {
+  return {
+    id: String(r.id ?? r.session_id ?? r.timestamp ?? ""),
+    event: String(r.event ?? ""),
+    type: (r.event ?? "page_view") as AnalyticsEventType,
+    page: String(r.page ?? ""),
+    source: String(r.source ?? ""),
+    count: 1,
+    date: String(r.timestamp ?? ""),
+    country: String(r.country ?? ""),
+    metadata: String(r.properties ?? ""),
+  };
+}
+
+function safeQuery<T>(label: string, fallback: T, fn: () => Promise<T>): Promise<T> {
+  return fn().catch((err: unknown) => {
+    const msg = err instanceof Error ? err.message : String(err);
+    console.warn(`[notion-analytics] Athena ${label} failed:`, msg);
+    return fallback;
+  });
+}
+
+const EMPTY_RESULT: AthenaQueryResult = { rows: [], rowCount: 0, fromCache: false };
+
+// ---------------------------------------------------------------------------
+// Write paths — no-op (data flows via Plausible + S3-events Lambda, not here)
+// ---------------------------------------------------------------------------
 
 export function resetEventQueue(): void {
   // intentional no-op
@@ -97,32 +125,101 @@ export async function trackBlogView(_slug: string, _source?: string): Promise<st
   return null;
 }
 
-// getRecentEvents historically accepted either a limit (number) or an
-// AnalyticsEventType filter — kept flexible so existing call sites compile.
+// ---------------------------------------------------------------------------
+// Read paths — Athena-backed
+// ---------------------------------------------------------------------------
+
+/** Recent events from cloudless_analytics.events. Optional event-type filter. */
 export async function getRecentEvents(
-  _filterOrLimit?: AnalyticsEventType | number,
-  _limit = 50
+  filterOrLimit?: AnalyticsEventType | number,
+  limit = 50
 ): Promise<AnalyticsEvent[]> {
-  return [];
+  const typeFilter = typeof filterOrLimit === "string" ? filterOrLimit : null;
+  const cap =
+    typeof filterOrLimit === "number" ? filterOrLimit : Math.max(1, Math.min(limit, 500));
+  const where = typeFilter ? `WHERE event = '${typeFilter.replace(/'/g, "''")}' ` : "";
+  const sql =
+    `SELECT \`timestamp\`, event, page, source, country, properties ` +
+    `FROM cloudless_analytics.events ${where}` +
+    `ORDER BY \`timestamp\` DESC LIMIT ${cap}`;
+  const res = await safeQuery("getRecentEvents", EMPTY_RESULT, () =>
+    runAthenaQuery(sql, { ttlMs: 60_000 })
+  );
+  return res.rows.map(rowToEvent);
 }
 
 export async function getEventsByDateRange(
-  _startISO: string,
-  _endISO: string
+  startISO: string,
+  endISO: string
 ): Promise<AnalyticsEvent[]> {
-  return [];
+  const sql =
+    `SELECT \`timestamp\`, event, page, source, country, properties ` +
+    `FROM cloudless_analytics.events ` +
+    `WHERE \`timestamp\` >= '${startISO.replace(/'/g, "")}' ` +
+    `AND \`timestamp\` < '${endISO.replace(/'/g, "")}' ` +
+    `ORDER BY \`timestamp\` DESC LIMIT 1000`;
+  const res = await safeQuery("getEventsByDateRange", EMPTY_RESULT, () =>
+    runAthenaQuery(sql, { ttlMs: 60_000 })
+  );
+  return res.rows.map(rowToEvent);
 }
 
-export async function getAnalyticsSummary(_days = 7): Promise<AnalyticsSummary> {
-  return EMPTY_SUMMARY;
+export async function getAnalyticsSummary(days = 7): Promise<AnalyticsSummary> {
+  const cap = Math.max(1, Math.min(days, 365));
+  // Single round-trip: emit four UNION ALL'd resultsets we collapse client-side.
+  // Cheaper than 4 separate Athena starts at >$5/TB-scanned billing.
+  const sql = `
+    WITH win AS (
+      SELECT event, page, source, country, \`timestamp\`, properties
+      FROM cloudless_analytics.events
+      WHERE \`timestamp\` >= to_iso8601(current_timestamp - interval '${cap}' day)
+    )
+    SELECT 'total' AS kind, '' AS k, COUNT(*) AS n FROM win
+    UNION ALL
+    SELECT 'type' AS kind, event AS k, COUNT(*) AS n FROM win GROUP BY event
+    UNION ALL
+    SELECT 'page' AS kind, page AS k, COUNT(*) AS n FROM win
+      WHERE page IS NOT NULL AND page <> '' GROUP BY page ORDER BY n DESC LIMIT 10
+    UNION ALL
+    SELECT 'source' AS kind, source AS k, COUNT(*) AS n FROM win
+      WHERE source IS NOT NULL AND source <> '' GROUP BY source ORDER BY n DESC LIMIT 10
+  `;
+  const res = await safeQuery("getAnalyticsSummary", EMPTY_RESULT, () =>
+    runAthenaQuery(sql, { ttlMs: 5 * 60_000 })
+  );
+  if (res.rows.length === 0) return EMPTY_SUMMARY;
+
+  const summary: AnalyticsSummary = {
+    totalEvents: 0,
+    byType: {},
+    topPages: [],
+    topSources: [],
+    recentEvents: [],
+  };
+  for (const r of res.rows) {
+    const kind = String(r.kind ?? "");
+    const k = String(r.k ?? "");
+    const n = Number(r.n ?? 0);
+    if (kind === "total") summary.totalEvents = n;
+    else if (kind === "type" && k) summary.byType[k] = n;
+    else if (kind === "page" && k) summary.topPages.push({ page: k, count: n });
+    else if (kind === "source" && k) summary.topSources.push({ source: k, count: n });
+  }
+  // 10 recent events as a sample for the admin UI
+  summary.recentEvents = await getRecentEvents(10);
+  return summary;
 }
 
 export async function archiveOldEvents(
   _olderThanDays = 90
 ): Promise<{ archived: number; errors: number }> {
+  // S3 lifecycle policy handles Glacier transition for the events bucket;
+  // application-level archival no longer applies.
   return { archived: 0, errors: 0 };
 }
 
 export async function createWeeklyRollup(): Promise<string | null> {
+  // Rollups now live in Athena views (v_acquisition_funnel, v_attribution_by_source).
+  // No-op the manual Notion-page rollup since the view auto-aggregates.
   return null;
 }

--- a/src/lib/notion-gsc-reports.ts
+++ b/src/lib/notion-gsc-reports.ts
@@ -1,21 +1,21 @@
 /**
- * Notion GSC Reports — DECOMMISSIONED 2026-06-20.
+ * GSC Weekly Reports — DECOMMISSIONED 2026-06-20 (PR #1044), reads NOW
+ * route to Athena (PR #1050).
  *
- * Replaced by the GSC ETL pipeline (`scripts/etl/gsc-to-lake.mjs` → S3
- * Parquet → Glue → Athena). The Notion DB is no longer the persistence
- * layer for weekly GSC archives. The Notion env var
- * `NOTION_GSC_REPORTS_DB_ID` has been removed from `lib/integrations.ts`
- * + `lib/ssm-config.ts`.
+ * The old NOTION_GSC_REPORTS_DB_ID database stored one Notion page per week
+ * with curated aggregates (clicks, impressions, CTR%, top keywords, top
+ * country, mobile share, CTR-opportunity count). The GSC ETL workflow
+ * (`scripts/etl/gsc-to-lake.mjs`) now writes the same source data to
+ * `cloudless_analytics.gsc_keywords` (Parquet, 90d rolling). This module
+ * aggregates that table back into the GscWeeklyReport shape so the existing
+ * admin consumers don't need to change.
  *
- * This module is kept as a no-op shim so the admin
- * `/api/admin/analytics/gsc-archive` route (and any other reader) doesn't
- * crash. `getGscReports()` returns `null` (matching the original
- * IntegrationNotConfiguredError fallback semantics) — callers already
- * tolerate that case and fall back to the live GSC API.
- *
- * Migration follow-up tracked in memory `project_notion_decom_plan`.
- * Remove this file once consumers query Athena directly via the duckdb-api.
+ * Outside-of-Athena contexts (local dev): returns `null` (matching the
+ * IntegrationNotConfiguredError fallback the previous Notion-backed version
+ * threw) — callers already tolerate that.
  */
+
+import { runAthenaQuery } from "@/lib/athena";
 
 export interface GscTopKeyword {
   q: string;
@@ -24,11 +24,11 @@ export interface GscTopKeyword {
 }
 
 export interface GscWeeklyReport {
-  /** Notion page id — preserved for callers that key off it. */
+  /** Synthetic stable key — week-end ISO date. */
   id: string;
   /** Title, e.g. "Week of 2026-06-08". */
   week: string;
-  /** End date of the 28-day window (ISO date). */
+  /** End date of the 7-day window (ISO date). */
   date: string;
   clicks: number;
   impressions: number;
@@ -36,11 +36,86 @@ export interface GscWeeklyReport {
   avgPosition: number;
   keywords: number;
   topKeywords: GscTopKeyword[];
+  /** Not surfaced in the Athena table; left blank. Operator can extend the
+   *  gsc-to-lake ETL to write a `country` column if this becomes important. */
   topCountry: string;
+  /** Same — Athena table doesn't carry a mobile share dimension yet. */
   mobilePct: number;
+  /** Queries with impressions ≥ 20 and ctr < 2 (Notion baseline definition). */
   ctrOpportunities: number;
 }
 
-export async function getGscReports(_limit = 26): Promise<GscWeeklyReport[] | null> {
-  return null;
+export async function getGscReports(limit = 26): Promise<GscWeeklyReport[] | null> {
+  const cap = Math.max(1, Math.min(limit, 52));
+  // Week-end is derived from end_date in gsc_keywords. The ETL writes one
+  // row per (week, query, page), so we aggregate per week-end first, then
+  // attach a top-5 keyword list per week with a second pass query.
+  const summarySql = `
+    SELECT end_date,
+           SUM(clicks) AS clicks,
+           SUM(impressions) AS impressions,
+           CASE WHEN SUM(impressions) > 0
+                THEN ROUND(100.0 * SUM(clicks) / SUM(impressions), 2)
+                ELSE 0.0 END AS ctr_pct,
+           AVG(position) AS avg_position,
+           COUNT(DISTINCT query) AS keywords,
+           SUM(CASE WHEN impressions >= 20 AND ctr < 0.02 THEN 1 ELSE 0 END) AS ctr_opportunities
+    FROM cloudless_analytics.gsc_keywords
+    GROUP BY end_date
+    ORDER BY end_date DESC
+    LIMIT ${cap}
+  `;
+  const summary = await runAthenaQuery(summarySql, { ttlMs: 15 * 60_000 }).catch((err) => {
+    console.warn("[notion-gsc-reports] Athena summary failed:", err?.message ?? err);
+    return null;
+  });
+  if (!summary || summary.rows.length === 0) return null;
+
+  // Top-5 keywords per week (small enough to inline; bounded by cap × 5).
+  const topSql = `
+    WITH ranked AS (
+      SELECT end_date, query, clicks, ctr,
+             ROW_NUMBER() OVER (PARTITION BY end_date ORDER BY clicks DESC) AS rn
+      FROM cloudless_analytics.gsc_keywords
+    )
+    SELECT end_date, query, clicks, ctr
+    FROM ranked
+    WHERE rn <= 5
+    ORDER BY end_date DESC, rn
+  `;
+  const top = await runAthenaQuery(topSql, { ttlMs: 15 * 60_000 }).catch((err) => {
+    console.warn("[notion-gsc-reports] Athena top-keywords failed:", err?.message ?? err);
+    return { rows: [] as Record<string, string | number | null>[] };
+  });
+
+  const topByWeek = new Map<string, GscTopKeyword[]>();
+  for (const r of top.rows) {
+    const k = String(r.end_date ?? "");
+    if (!k) continue;
+    const bucket = topByWeek.get(k) ?? [];
+    bucket.push({
+      q: String(r.query ?? ""),
+      clicks: Number(r.clicks ?? 0),
+      ctr: Number(r.ctr ?? 0),
+    });
+    topByWeek.set(k, bucket);
+  }
+
+  return summary.rows.map((row): GscWeeklyReport => {
+    const end = String(row.end_date ?? "");
+    return {
+      id: end || crypto.randomUUID(),
+      week: `Week of ${end}`,
+      date: end,
+      clicks: Number(row.clicks ?? 0),
+      impressions: Number(row.impressions ?? 0),
+      ctrPct: Number(row.ctr_pct ?? 0),
+      avgPosition: Number(row.avg_position ?? 0),
+      keywords: Number(row.keywords ?? 0),
+      topKeywords: topByWeek.get(end) ?? [],
+      topCountry: "",
+      mobilePct: 0,
+      ctrOpportunities: Number(row.ctr_opportunities ?? 0),
+    };
+  });
 }


### PR DESCRIPTION
PR #1044 stubbed the 3 Notion B1 libs so SSM keys could be deleted, but admin pages saw empty data. This wires them to the existing Athena tables (cloudless_analytics.events for analytics, gsc_keywords for GSC). One UNION-ALL query for the summary tile (single Athena round-trip). 5/15-min cache. Degrades gracefully when Athena is unreachable (local dev / preview deploys render zeros instead of erroring). notion-reports stays on in-memory fallback since reports persist to S3 directly.