### PR TITLE
docs(skills): operator manuals for AppFlowy, EspoCRM, and Cloudflare tunnel

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -185,6 +185,26 @@ instead — see the **`cluster-incident-response`** skill for the full playbook.
     unused heavy SLO rule groups. Durable fix: kube-prometheus-stack Helm values
     `defaultRules.rules.kubeApiserver{Burnrate,Availability,Slos}: false`.
 
+## Operator skills (read SKILL.md before touching the stack)
+
+Three operator manuals live under `skills/`. Each one is the canonical
+"first stop" for its stack and captures the load-bearing quirks (env-var
+ordering bugs, port mismatches, page-size pins, etc.):
+
+- `skills/appflowy-operator/SKILL.md` — AppFlowy Cloud stack (Notion
+  replacement, 9 pods + 1 worker on omv-ha). The worker pin to omv-ha
+  is mandatory: Pi 5 runs a 16 KiB-page kernel and the worker's jemalloc
+  was built for 4 KiB pages.
+- `skills/espocrm-operator/SKILL.md` — EspoCRM stack (HubSpot replacement).
+  Drop-in mirror at `src/lib/espocrm.ts` (21 exports 1:1 with the old
+  `hubspot.ts`); 6 Webhook entities sync to Slack via `SlackClient`;
+  daily ETL to Athena; SES → Lambda → Case bridge for inbound email.
+- `skills/cloudflare-tunnel-ops/SKILL.md` — adds/removes ingress + DNS
+  for the single shared tunnel (UUID
+  `e977a490-58c5-4fdb-9155-86832e3e636a`). Copy-paste pod manifests for
+  both halves; works end-to-end from `Kubernetes_MCP_Server` alone when
+  the `cloudless-infra` MCP is unavailable.
+
 ## Cluster bash (cluster-bash skill)
 
 Two-node SSH operations go through one of four MCP tools per the

--- a/skills/appflowy-operator/SKILL.md
+++ b/skills/appflowy-operator/SKILL.md
@@ -1,0 +1,194 @@
+---
+name: appflowy-operator
+description: |
+  Deploy, debug, and operate the self-hosted AppFlowy Cloud stack on the
+  cloudless.gr k3s cluster (Notion replacement). Triggered by phrases like
+  "AppFlowy is down", "redeploy AppFlowy", "add an AppFlowy user", "import a
+  Notion DB into AppFlowy", "AppFlowy worker crashed", "check appflowy.cloudless.gr",
+  "scale AppFlowy", "rotate the AppFlowy admin password", "back up AppFlowy",
+  "AppFlowy migration", "AppFlowy 5xx", or any operational task touching the
+  `appflowy` k8s namespace.
+---
+
+# AppFlowy operator toolkit
+
+AppFlowy Cloud is the **self-hosted Notion replacement** for cloudless.gr.
+Phase 1 shipped 2026-06-21 (PR #1051) live at `https://appflowy.cloudless.gr`.
+
+Always read the source-of-truth manifest before changing anything:
+`infrastructure/appflowy/k8s/appflowy.yaml`. The deploy runbook lives at
+`docs/appflowy-deploy.md`.
+
+## Topology cheat sheet
+
+9 pods on omv + 1 worker pinned to omv-ha:
+
+| Pod | Node | Why pinned |
+| --- | --- | --- |
+| postgres (pgvector pg16) | omv | Stateful, on local-path PV (sda1) |
+| redis | omv | Cache + outbox + collab streams |
+| minio | omv | Stateful, on local-path PV (sda1) |
+| gotrue | omv | Auth (issues JWT under `appflowy_admin` group) |
+| appflowy-cloud | omv | REST/WebSocket API |
+| appflowy-web | omv | Notion-like SPA UI |
+| admin-frontend | omv | Workspace admin console at `/console` |
+| nginx | omv | In-cluster path router |
+| **appflowy-worker** | **omv-ha** | **Pi 5 has 16K page kernel; worker's jemalloc is 4K — drop nodeSelector when upstream fixes** |
+
+## Tool selection — pick the most specific that fits
+
+1. **Just want to check it's up?**
+
+   ```bash
+   curl -sI https://appflowy.cloudless.gr/api/health      # expect 200
+   curl -sI https://appflowy.cloudless.gr/gotrue/health   # expect 200
+   ```
+
+2. **Pod state?** `mcp__Kubernetes_MCP_Server__kubectl_get` with
+   `namespace=appflowy, resourceType=pods`. If something's not Running, jump
+   straight to that pod's logs via `kubectl_logs` — boot-time errors
+   (env-substitution, page-size, image-pull) dominate failures here.
+
+3. **Need to edit cloudflared config or host-only stuff?**
+   See `skills/cloudflare-tunnel-ops/SKILL.md` for the privileged-pod
+   nsenter pattern; do NOT shell into the host directly.
+
+4. **Two-Pi commands?** Use `skills/cluster-bash/SKILL.md`.
+
+## The three load-bearing deploy gotchas (every one cost real time)
+
+These are documented inline in `appflowy.yaml` so future-you doesn't repeat
+them; collected here as the quick-read:
+
+1. **`$(POSTGRES_PASSWORD)` env substitution requires POSTGRES_PASSWORD to
+   come FIRST in the container's env list.** K8s does string substitution
+   top-down; an undeclared/late variable expands to empty string and
+   Postgres returns `password authentication failed for user "postgres"`.
+   Affects: `gotrue`, `appflowy-cloud`, `appflowy-worker`. Same rule applies
+   to any future pod using `$(VAR)` in env values.
+2. **admin_frontend listens on port 3000, not 80.** Service must match.
+3. **`APPFLOWY_WS_BASE_URL` ends in `/ws/v2`, not `/ws/v1`.** Only the
+   upstream `deploy.env` reveals the bump; docker-compose.yml uses
+   `${APPFLOWY_WEBSOCKET_BASE_URL}` so it's invisible there.
+
+## Worker page-size pin (the most painful one)
+
+omv (Pi 5) runs Raspberry Pi OS's `2712` kernel with **16 KiB pages**
+(`getconf PAGE_SIZE` → 16384). The worker image's jemalloc was built for
+4 KiB pages and panics at boot:
+
+```
+<jemalloc>: Unsupported system page size
+memory allocation of 4 bytes failed
+```
+
+omv-ha (Pi 4) runs the `v8` kernel (4 KiB pages) and starts cleanly. The
+arm64 image digest is identical to `latest` — there is no
+"arm64-with-system-allocator" variant. **The worker Deployment's
+`nodeSelector: { kubernetes.io/hostname: omv-ha }` MUST stay** until an
+upstream image bumps jemalloc to support 16 KiB; check
+`infrastructure/appflowy/k8s/appflowy.yaml` before you delete it.
+
+## Daily operations
+
+### Verify health from inside the cluster (production-safe)
+
+```bash
+NGINX=$(kubectl -n appflowy get pod -l app=nginx -o jsonpath='{.items[0].metadata.name}')
+for p in / /api/health /gotrue/health /gotrue/settings /console; do
+  CODE=$(kubectl -n appflowy exec "$NGINX" -- \
+    wget -q -O /dev/null -S http://127.0.0.1$p 2>&1 \
+    | grep -oE 'HTTP/[0-9.]+ [0-9]+' | head -1)
+  printf '%-22s %s\n' "$p" "$CODE"
+done
+```
+
+Expected: `/` 302, `/api/health` 200, `/gotrue/health` 200,
+`/gotrue/settings` 200, `/console` 200.
+
+### Rotate the admin password
+
+The admin email/password live in the `appflowy-secrets` k8s Secret
+(`GOTRUE_ADMIN_EMAIL`, `GOTRUE_ADMIN_PASSWORD`). GoTrue re-applies them
+on every restart **only if the user already exists** (Supabase semantics).
+To rotate:
+
+1. Set the new password in the Secret via `kubectl edit secret -n appflowy
+   appflowy-secrets` (base64-encoded).
+2. `kubectl -n appflowy rollout restart deploy/gotrue`.
+3. Verify with `curl -X POST https://appflowy.cloudless.gr/gotrue/token?grant_type=password ...`.
+
+### Re-roll a pod cleanly
+
+```bash
+kubectl -n appflowy rollout restart deploy/<name>
+kubectl -n appflowy rollout status deploy/<name> --timeout=180s
+```
+
+If `appflowy-cloud` won't come up after a config change, **check env-var
+ordering first** — the most common regression is reintroducing the
+`$(POSTGRES_PASSWORD)` ordering bug.
+
+### Wipe + redeploy from scratch (data-loss; only in disaster)
+
+```bash
+kubectl delete namespace appflowy --wait     # ~30s
+# Recreate secret (see docs/appflowy-deploy.md for openssl rand recipe)
+kubectl apply -f infrastructure/appflowy/k8s/appflowy.yaml
+```
+
+PVCs (`appflowy-postgres`, `appflowy-minio`) are removed with the namespace
+— there is no auto-restore yet. Backup strategy is "lean on the existing
+hourly etcd snapshot + a planned `pg_dump` cron" (see Phase 4 roadmap).
+
+### Add a CronJob or scrape target
+
+When adding new workloads in the `appflowy` namespace, reuse the existing
+`local-path` storage class and **always set `nodeSelector: { kubernetes.io/hostname: omv }`**
+unless you have a hard reason to live on omv-ha (workers, page-size pins).
+Default scheduling will land it on whichever node has CPU room, which can
+fragment locality with the PVCs.
+
+## Resource budget
+
+Total cluster footprint ~700 MiB across all 9 pods at idle. Postiz LiteLLM
+was evicted to free ~990 MiB on omv; its manifest is preserved at
+`infrastructure/appflowy/evicted-deployments/postiz-litellm.yaml`. Both
+can't fit simultaneously — if Postiz AI features are needed back, you must
+shed something else.
+
+## Cloudflare tunnel exposure
+
+Single tunnel (UUID `e977a490-58c5-4fdb-9155-86832e3e636a`, shared with
+espocrm/postiz/logs) → NodePort 30810 on omv → in-cluster nginx → 8 backend
+pods via path routing. The fragment is at
+`infrastructure/appflowy/cloudflare-tunnel.yaml`; the per-domain DNS CNAME
+is at Cloudflare (zone `cloudless.gr`, zone_id
+`7025298073d6a5c645a6ad9add0cbf0e`, created via API on 2026-06-21).
+
+To add/remove an ingress rule, see
+`skills/cloudflare-tunnel-ops/SKILL.md` — never edit `config.yml` by hand
+without using that runbook (cloudflared SIGHUP is unreliable and a bad
+restart drops every cloudless.gr tunnel host).
+
+## Phase roadmap (where this skill fits)
+
+- Phase 1 (DONE 2026-06-21): deploy + first-login. PR #1051.
+- Phase 2 (DONE 2026-06-21 cluster side): Cloudflare DNS + tunnel ingress.
+  Operator-pending: first human UI login at `/console` to validate.
+- Phase 3 (NEXT): import 10 Notion DBs via AppFlowy's `/api/import`
+  endpoint; build `src/lib/appflowy.ts` HTTP client; rewrite
+  `src/lib/notion-*.ts` readers to AppFlowy API.
+- Phase 4: switch env routing, validate public pages, retire `NOTION_*`
+  SSM keys (operator-side `aws ssm delete-parameters`).
+
+## See also
+
+- `docs/appflowy-deploy.md` — full operator runbook
+- `infrastructure/appflowy/k8s/appflowy.yaml` — source of truth
+- `infrastructure/appflowy/cloudflare-tunnel.yaml` — tunnel fragment
+- `infrastructure/appflowy/evicted-deployments/postiz-litellm.yaml`
+- `skills/cluster-bash/SKILL.md` — two-Pi command runner
+- `skills/cloudflare-tunnel-ops/SKILL.md` — ingress add/remove + DNS API
+- `skills/espocrm-operator/SKILL.md` — sibling CRM stack on the same cluster
+- Memory: `project_appflowy_phase1_deployed.md`

--- a/skills/cloudflare-tunnel-ops/SKILL.md
+++ b/skills/cloudflare-tunnel-ops/SKILL.md
@@ -1,0 +1,272 @@
+---
+name: cloudflare-tunnel-ops
+description: |
+  Add, remove, or audit Cloudflare tunnel ingress routes + DNS records for
+  cloudless.gr's single shared tunnel (UUID e977a490-58c5-4fdb-9155-86832e3e636a).
+  Triggered by phrases like "expose <subdomain>.cloudless.gr", "add a
+  cloudflare tunnel route", "rotate the cloudflare token", "DNS record for
+  <name>.cloudless.gr", "cloudflared not picking up new ingress", "tunnel
+  showing 502", "remove a tunnel route", "check what's behind <subdomain>",
+  "list cloudflare tunnel routes", "Cloudflare API 401".
+---
+
+# Cloudflare tunnel operator toolkit
+
+cloudless.gr exposes every internal service (Postiz, EspoCRM, AppFlowy,
+Logs, the main site, Grafana, Manage) through **one shared cloudflared
+tunnel** on omv. There is no per-service tunnel — adding a new public
+hostname is "append-and-reload, never re-architect".
+
+## Identity facts (memorise these)
+
+| Field | Value |
+| --- | --- |
+| Tunnel UUID | `e977a490-58c5-4fdb-9155-86832e3e636a` |
+| CNAME target | `<UUID>.cfargotunnel.com` |
+| Zone | `cloudless.gr` |
+| Zone ID | `7025298073d6a5c645a6ad9add0cbf0e` |
+| Account ID (base64-decode in cluster) | `cloudless-cloudflare` secret |
+| API token | k8s secret `cloudless/cloudless-cloudflare` key `CLOUDFLARE_API_TOKEN` (verified active 2026-06-21) |
+| cloudflared config | `/etc/cloudflared/config.yml` on omv |
+| cloudflared service | `systemctl status cloudflared` on omv |
+
+The Cloudflare token in CLAUDE.md is listed as `NEEDS ROTATION` for the
+**cloud-session secret half**. The **cluster Secret half is active** —
+that's what these runbooks use.
+
+## When to use this skill vs the cloudless-infra MCP
+
+- **This skill** when the `cloudless-infra` MCP is unavailable (no
+  `OMV_SSH_KEY_CONTENTS`) AND you have `Kubernetes_MCP_Server` access.
+  The pattern: privileged pod with `nsenter --target 1` to reach the host
+  filesystem + systemd, and a separate pod for Cloudflare API calls.
+- **`mcp__cloudless-infra__cloudflare_*` tools** if/when the cloud-session
+  Cloudflare token is rotated and those return 200 again. They're faster
+  and don't require pod cleanup.
+
+## Tool selection — pick the most specific that fits
+
+1. **Public DNS query?** No cluster access needed:
+
+   ```bash
+   dig +short <name>.cloudless.gr @1.1.1.1
+   ```
+
+   Empty result = either no record, or proxied (Cloudflare returns
+   Cloudflare IPs for proxied records, not the origin).
+
+2. **Check whether cloudflared has a route?** Privileged pod + nsenter:
+
+   ```yaml
+   # nodeSelector: omv; hostPID + hostNetwork; alpine + util-linux.
+   nsenter --target 1 --mount --uts --ipc --net --pid -- \
+     grep -c <hostname> /etc/cloudflared/config.yml
+   ```
+
+   Returns 0 = not present; 1+ = appended.
+
+3. **Add a DNS record?** Use the Cloudflare API from a one-off pod in the
+   `cloudless` namespace (the secret lives there):
+
+   ```yaml
+   # See full manifest below in "Add a new public route"
+   env:
+     - name: CLOUDFLARE_API_TOKEN
+       valueFrom: { secretKeyRef: { name: cloudless-cloudflare, key: CLOUDFLARE_API_TOKEN } }
+   ```
+
+4. **Append ingress + restart cloudflared?** Privileged pod + nsenter + a
+   small Python script that mutates the YAML (do NOT use `yq` from
+   alpine — package is older than the actual yq binary and silently
+   reorders maps). See "Add a new public route" below.
+
+## Add a new public route (end-to-end)
+
+For service `<svc>` listening on NodePort `30NNN` on omv at LAN IP
+`192.168.1.128`, exposed as `<sub>.cloudless.gr`:
+
+### Step 1 — append cloudflared ingress (in-cluster)
+
+```yaml
+---
+apiVersion: v1
+kind: Pod
+metadata: { name: cf-ingress-add, namespace: monitoring }
+spec:
+  nodeSelector: { kubernetes.io/hostname: omv }
+  hostPID: true
+  hostNetwork: true
+  restartPolicy: Never
+  containers:
+    - name: edit
+      image: alpine:3
+      securityContext: { privileged: true }
+      command:
+        - sh
+        - -c
+        - |
+          apk add --no-cache util-linux >/dev/null 2>&1
+          nsenter --target 1 --mount --uts --ipc --net --pid -- sh -c '
+            set -e
+            CFG=/etc/cloudflared/config.yml
+            HOST=<sub>.cloudless.gr
+            PORT=30NNN
+            if grep -q "$HOST" "$CFG"; then echo ALREADY_PRESENT; exit 0; fi
+            cp "$CFG" "$CFG.bak.$(date +%s)"
+            python3 - "$CFG" "$HOST" "$PORT" <<EOF
+          import sys, yaml
+          p, host, port = sys.argv[1], sys.argv[2], sys.argv[3]
+          with open(p) as f: cfg = yaml.safe_load(f)
+          ing = cfg.get("ingress", [])
+          rule = {
+            "hostname": host,
+            "service":  f"http://192.168.1.128:{port}",
+            "originRequest": {
+              "connectTimeout": "15s",
+              "tcpKeepAlive":   "30s",
+              "noTLSVerify":    False,
+              "httpHostHeader": host,
+            },
+          }
+          idx = len(ing) - 1
+          for i, r in enumerate(ing):
+            if "http_status" in str(r.get("service", "")):
+              idx = i; break
+          ing.insert(idx, rule)
+          cfg["ingress"] = ing
+          with open(p, "w") as f: yaml.safe_dump(cfg, f, sort_keys=False)
+          print("INSERTED at idx", idx, "; total rules:", len(ing))
+          EOF
+            systemctl restart cloudflared
+            sleep 3
+            systemctl is-active cloudflared
+          '
+          sleep 3
+```
+
+**CRITICAL**: `systemctl restart`, **not** `reload` / `SIGHUP`. cloudflared
+SIGHUP is known to silently skip new ingress rules; only restart picks
+them up.
+
+### Step 2 — create the DNS CNAME (in-cluster)
+
+```yaml
+---
+apiVersion: v1
+kind: Pod
+metadata: { name: cf-dns-add, namespace: cloudless }   # MUST be cloudless ns
+spec:
+  restartPolicy: Never
+  containers:
+    - name: cf
+      image: alpine:3
+      env:
+        - name: CLOUDFLARE_API_TOKEN
+          valueFrom: { secretKeyRef: { name: cloudless-cloudflare, key: CLOUDFLARE_API_TOKEN } }
+      command:
+        - sh
+        - -c
+        - |
+          apk add --no-cache curl jq >/dev/null 2>&1
+          ZONE=7025298073d6a5c645a6ad9add0cbf0e
+          SUB=<sub>   # e.g. "appflowy" → appflowy.cloudless.gr
+          # Idempotent check
+          EXISTING=$(curl -fsS "https://api.cloudflare.com/client/v4/zones/$ZONE/dns_records?name=$SUB.cloudless.gr" \
+            -H "Authorization: Bearer $CLOUDFLARE_API_TOKEN" | jq -r ".result | length")
+          if [ "$EXISTING" != "0" ]; then echo "Already exists; skipping"; exit 0; fi
+          curl -sS -X POST "https://api.cloudflare.com/client/v4/zones/$ZONE/dns_records" \
+            -H "Authorization: Bearer $CLOUDFLARE_API_TOKEN" \
+            -H "Content-Type: application/json" \
+            --data "{\"type\":\"CNAME\",\"name\":\"$SUB\",\"content\":\"e977a490-58c5-4fdb-9155-86832e3e636a.cfargotunnel.com\",\"proxied\":true,\"ttl\":1,\"comment\":\"<service> via cloudflare tunnel\"}" \
+            | jq -c '{success, errors, id: .result.id, name: .result.name, proxied: .result.proxied}'
+          sleep 3
+```
+
+**Namespace matters.** Secret refs are namespace-local in k8s; the
+`cloudless-cloudflare` secret only lives in `cloudless`. A pod in
+`monitoring` referencing it will sit in `CreateContainerConfigError`.
+
+### Step 3 — verify reachability
+
+```bash
+sleep 20  # DNS propagation
+curl -sI https://<sub>.cloudless.gr/<healthcheck>
+```
+
+DNS-via-Cloudflare is near-instant (proxied records always resolve to
+Cloudflare IPs immediately); the 20s buffer is for cloudflared to register
+the new origin route. If you still get 502/530 after that, see "Troubleshooting"
+below.
+
+## Remove a public route
+
+Reverse of above. Step 1 = `python3` script does `ing = [r for r in ing if
+r.get("hostname") != host]`; Step 2 = `curl -X DELETE
+https://api.cloudflare.com/client/v4/zones/$ZONE/dns_records/$RECORD_ID`.
+
+## Audit current routes (read-only)
+
+In one privileged-pod call:
+
+```bash
+nsenter --target 1 --mount --uts --ipc --net --pid -- \
+  grep -A1 'hostname:' /etc/cloudflared/config.yml
+```
+
+Known state at time of writing (2026-06-21):
+- `cloudless.gr` → localhost:18443 (main site)
+- `manage.cloudless.gr` → localhost:18443
+- `pi-origin.cloudless.gr` → localhost:18443
+- `grafana.cloudless.gr` → localhost:18443
+- `postiz.cloudless.gr` → 192.168.1.128:30500
+- `espocrm.cloudless.gr` → 192.168.1.128:30700
+- `appflowy.cloudless.gr` → 192.168.1.128:30810
+
+## Rotate the Cloudflare API token
+
+The active token lives at:
+- k8s: `kubectl -n cloudless get secret cloudless-cloudflare -o yaml`
+- SSM: `/cloudless/production/CLOUDFLARE_API_TOKEN` (per CLAUDE.md)
+
+To rotate:
+
+1. Cloudflare dashboard → My Profile → API Tokens → mint new token with the
+   scope set from `skills/cloudflare-token-doctor/SKILL.md` Stage 1.
+2. `kubectl -n cloudless edit secret cloudless-cloudflare` and replace the
+   base64-encoded `CLOUDFLARE_API_TOKEN` value.
+3. Mirror to SSM:
+   `aws ssm put-parameter --name /cloudless/production/CLOUDFLARE_API_TOKEN
+   --value <token> --type SecureString --overwrite`.
+4. Delete the old token in the Cloudflare dashboard.
+5. Verify via the cf-dns-add pod template above (token verify step at the
+   top — `https://api.cloudflare.com/client/v4/user/tokens/verify`).
+
+## Troubleshooting
+
+| Symptom | First check |
+| --- | --- |
+| `dig` returns nothing | DNS not created. Run Step 2 of "Add a new public route". |
+| `dig` returns Cloudflare IPs but cURL returns 530 | cloudflared can't reach origin. Run Step 3 health check from inside the cluster: `kubectl -n <ns> exec <pod> -- curl http://<svc>` to confirm the NodePort actually works. |
+| `dig` returns Cloudflare IPs but cURL returns 502 | cloudflared has stale ingress. Run privileged pod from Step 1 with just the `systemctl restart cloudflared && grep -c <host> $CFG` block. |
+| Cloudflare API returns `code 9106 / authorization` | Token doesn't have permission for the action. The cluster token has Zone:DNS:Edit + Account:Cloudflare Tunnel:Edit; if you're hitting a different endpoint you'll need to widen the scope. |
+| Cloudflare API returns 401 globally | Token revoked or wrong. Don't retry; rotate (above). |
+| `CreateContainerConfigError` on the cf-dns pod | Pod is in the wrong namespace. Move to `cloudless`. |
+| cloudflared logs `connection refused: 192.168.1.128:30NNN` | NodePort isn't actually listening on omv. Check `kubectl get svc -n <ns>` — the `Service` type must be NodePort with the matching `nodePort` field. |
+
+## Why one tunnel, not many
+
+Each cloudflared instance holds ~80 MiB RAM + 4 outbound HTTPS connections
+to Cloudflare's edge. Multiplying that per subdomain is wasteful on a
+4-core Pi 5; the shared-tunnel pattern matches Cloudflare's recommended
+"one tunnel, many origins" architecture (see Cloudflare docs:
+https://developers.cloudflare.com/cloudflare-one/connections/connect-networks/configure-tunnels/local-management/configuration-file/).
+
+## See also
+
+- `skills/cloudflare-token-doctor/SKILL.md` — minting tokens with the right scope
+- `skills/cluster-bash/SKILL.md` — two-Pi command runner
+- `skills/appflowy-operator/SKILL.md` — sibling skill (AppFlowy uses tunnel)
+- `skills/espocrm-operator/SKILL.md` — sibling skill (EspoCRM uses tunnel)
+- `infrastructure/cloudflare-tunnels/` — canonical config layout
+- `infrastructure/appflowy/cloudflare-tunnel.yaml` — example fragment
+- `infrastructure/espocrm/cloudflare-tunnel.yaml` — example fragment

--- a/skills/espocrm-operator/SKILL.md
+++ b/skills/espocrm-operator/SKILL.md
@@ -1,0 +1,197 @@
+---
+name: espocrm-operator
+description: |
+  Deploy, debug, and operate the self-hosted EspoCRM stack (HubSpot
+  replacement). Triggered by phrases like "EspoCRM is down", "create an
+  EspoCRM Lead", "EspoCRM API error", "rotate the EspoCRM API key", "the
+  espocrm-to-lake ETL failed", "EspoCRM webhook not firing", "import
+  contacts into EspoCRM", "EspoCRM Slack sync", "check espocrm.cloudless.gr",
+  "EspoCRM Inbound Email", or any operational task on the `espocrm` k8s
+  namespace, `src/lib/espocrm.ts`, or the EspoCRM SES bridge Lambda.
+---
+
+# EspoCRM operator toolkit
+
+EspoCRM (SugarCRM lineage, self-hosted) replaced HubSpot on 2026-06-20 when
+HubSpot's `content` scope got paywalled behind Marketing Hub Pro. HubSpot
+is fully decommissioned (PR #1043, ~3,387 LOC removed). Live at
+`https://espocrm.cloudless.gr`.
+
+The drop-in mirror of the old HubSpot client surface is at
+`src/lib/espocrm.ts` — 21 exports matching `src/lib/hubspot.ts` 1:1
+(`upsertContact`, `createTicket`, `listDeals`, `createDeal`,
+`getDealsByStage`, `getPipelineStats`, …). Module mapping:
+Contact↔contact, Account↔company, Opportunity↔deal, Case↔ticket.
+
+## Topology cheat sheet
+
+| Pod | Node | Notes |
+| --- | --- | --- |
+| espocrm (PHP+nginx) | omv | `espocrm/espocrm:9` image |
+| mariadb | omv | `mariadb:11`; PVC `local-path` (sda1) |
+
+Both pinned to omv via `nodeSelector`. NodePort 30700 → Cloudflare tunnel
+fragment `infrastructure/espocrm/cloudflare-tunnel.yaml`. Source of truth:
+`infrastructure/espocrm/k8s/espocrm.yaml`. Operator runbook:
+`infrastructure/espocrm/README.md`.
+
+## Auth + secrets
+
+| Secret | Where | Purpose |
+| --- | --- | --- |
+| `/cloudless/production/ESPOCRM_BASE_URL` | SSM | `https://espocrm.cloudless.gr` |
+| `/cloudless/production/ESPOCRM_API_KEY` | SSM | API user `cloudless-app` (role `Cloudless App Full Access`, ID `6a36ef141808ed737`) |
+| `/cloudless/production/ESPOCRM_WEBHOOK_SECRET` | SSM | HMAC for `/api/webhooks/espocrm` |
+| EspoCRM admin login | UI only | Stored in operator's password manager |
+
+All API calls authenticate with header `X-Api-Key: <key>`. The Next.js
+helper at `src/lib/espocrm.ts` handles this transparently — never
+construct your own auth headers in route code.
+
+## Tool selection — pick the most specific that fits
+
+1. **Just want to check it's up?**
+
+   ```bash
+   curl -sI https://espocrm.cloudless.gr/                # expect 200
+   curl -sI -H "X-Api-Key: $ESPOCRM_API_KEY" \
+     https://espocrm.cloudless.gr/api/v1/App/user        # expect 200
+   ```
+
+2. **Pod state?** `kubectl_get` with `namespace=espocrm`. Both pods should
+   be Running; if mariadb is CrashLoop, check PVC quota on sda1 first
+   (`df -h /srv/dev-disk-by-uuid-a9a5a108-…`).
+
+3. **Need to CRUD via the API in code?** Use the existing helpers in
+   `src/lib/espocrm.ts`. Do NOT write raw `fetch()` calls against the
+   EspoCRM REST API in admin routes — every helper already handles
+   pagination, auth, error mapping, and the
+   `IntegrationNotConfiguredError` fallback for local dev without SSM.
+
+4. **Need to add a new Espo entity sync to Slack?** Register a Webhook
+   entity in EspoCRM UI (Administration → Webhooks) pointing at
+   `https://cloudless.gr/api/webhooks/espocrm`. The receiver at
+   `src/app/api/webhooks/espocrm/route.ts` already dispatches to
+   `SlackClient` per `feedback_slack_use_slackclient`.
+
+## API key creation runbook
+
+When a new external service needs API access (e.g. another ETL):
+
+1. EspoCRM UI → Administration → Roles → New: "Cloudless XYZ Full".
+   Grant only the entities the consumer needs (least privilege).
+2. Administration → User Management → New API User. Assign the role. Click
+   "Generate API Key" — **the key shows once**; copy immediately.
+3. Store in SSM: `aws ssm put-parameter --name
+   /cloudless/production/ESPOCRM_API_KEY_<service> --value <key> --type
+   SecureString --overwrite`.
+4. Reference in your code via `getIntegrationsAsync()` (see how
+   `ESPOCRM_API_KEY` is wired in `src/lib/ssm-config.ts`).
+
+## Drop-in mirror surface (HubSpot → EspoCRM)
+
+If you find yourself missing a function that existed in the old
+`hubspot.ts`, **don't write a new helper** — check `src/lib/espocrm.ts`
+first. The full list of 21 mirrored exports is at the top of that file.
+The two areas that intentionally diverge:
+
+- **Deal stages**: HubSpot used named pipeline stages
+  (`appointmentscheduled`, `qualifiedtobuy`, `closedwon`). EspoCRM uses
+  internal stage IDs (`Stage1`, `Stage2`, …). The mapping table lives at
+  the top of `src/lib/espocrm.ts` — extend it if you add a new stage in
+  the EspoCRM UI.
+- **`getOwners()`** doesn't exist — EspoCRM has no "owner" concept
+  matching HubSpot's. Use `getUsers()` for the closest analog.
+
+## ETL: EspoCRM → S3 data lake
+
+`scripts/etl/espocrm-to-lake.mjs` runs daily via GitHub Actions
+(`.github/workflows/etl-espocrm-to-lake.yml`). Writes Parquet to
+`s3://cloudless-data-lake/espocrm/{entity}/year=YYYY/month=MM/day=DD/`.
+Athena views in `cloudless_analytics.espocrm_*` join Contact, Lead,
+Opportunity, Case for analytics-dashboard queries.
+
+Failure modes:
+- **404 on entities**: Verify the entity is enabled in EspoCRM UI
+  (Administration → Entity Manager). Stripe + EspoCRM upgrades sometimes
+  silently disable Workflow/BPM entities.
+- **Stuck pagination**: EspoCRM caps `maxSize=200`; the ETL's
+  `fetchAllPaginated()` handles offset chunks. If a single entity's
+  fetch exceeds 60s, increase the workflow's `timeout-minutes`.
+
+## SES → EspoCRM Case bridge
+
+Inbound email at `tbaltzakis@cloudless.gr` flows via SES → S3 → Lambda
+(`infrastructure/aws/lambdas/ses-espocrm-bridge/`) → EspoCRM Case create.
+The Lambda hydrates `ESPOCRM_API_KEY` from SSM at cold-start (see
+`feedback_slack_lambda_env_frozen` — same pattern; env is frozen). If
+inbound mail stops becoming Cases, check:
+
+1. CloudWatch Logs for the `ses-espocrm-bridge` Lambda.
+2. The Lambda's IAM role has `ssm:GetParameter` on
+   `/cloudless/production/ESPOCRM_*`.
+3. SES inbound rule still routes to the S3 bucket.
+
+## Slack sync
+
+Six Webhook entities registered in EspoCRM (one per event) all POST to
+`/api/webhooks/espocrm` with HMAC signature:
+
+- Contact create
+- Lead create
+- Opportunity create
+- Opportunity stage-change
+- Case create
+- Case status-change
+
+Per `feedback_slack_use_slackclient`, the receiver dispatches via
+`SlackClient` (not raw `chat.postMessage`) so retry/backoff/webhook-fallback
+are preserved.
+
+## Common ops
+
+### Bump the EspoCRM image
+
+```bash
+# Update tag in infrastructure/espocrm/k8s/espocrm.yaml then:
+kubectl apply -f infrastructure/espocrm/k8s/espocrm.yaml
+kubectl -n espocrm rollout status deploy/espocrm
+```
+
+EspoCRM runs its own DB migrations on boot (`composer install` + schema
+sync via `php command.php rebuild`). If it gets stuck, exec into the pod
+and run `php command.php rebuild` manually.
+
+### Install/upgrade an EspoCRM extension
+
+```bash
+# Copy .zip into the pod
+kubectl -n espocrm cp /tmp/ext.zip espocrm-XXX:/var/www/html/data/upload/extensions/
+# Install via CLI
+kubectl -n espocrm exec espocrm-XXX -- php command.php extension --file=/var/www/html/data/upload/extensions/ext.zip
+```
+
+The `Export Import` extension v2.9.0 is the canonical example, installed
+2026-06-20.
+
+### Rotate the API key
+
+1. EspoCRM UI → User cloudless-app → Generate New API Key.
+2. `aws ssm put-parameter --name /cloudless/production/ESPOCRM_API_KEY
+   --value <new-key> --type SecureString --overwrite`.
+3. Restart Lambda + Next.js app for them to re-read at next cold-start
+   (the SSM cache TTL is 5 min in `getIntegrationsAsync()` anyway).
+4. Delete the old API key in the EspoCRM UI.
+
+## See also
+
+- `infrastructure/espocrm/README.md` — full deploy + verify runbook
+- `infrastructure/espocrm/k8s/espocrm.yaml` — source of truth
+- `infrastructure/espocrm/cloudflare-tunnel.yaml` — tunnel fragment
+- `src/lib/espocrm.ts` — drop-in HubSpot mirror
+- `src/app/api/webhooks/espocrm/route.ts` — Slack sync receiver
+- `scripts/etl/espocrm-to-lake.mjs` — daily Athena hydrator
+- `infrastructure/aws/lambdas/ses-espocrm-bridge/` — Inbound Email bridge
+- `skills/cloudflare-tunnel-ops/SKILL.md` — exposure tooling
+- `skills/appflowy-operator/SKILL.md` — sibling CMS stack
+- Memory: `feedback_slack_use_slackclient`, `feedback_slack_lambda_env_frozen`


### PR DESCRIPTION
Three new SKILL.md files at \skills/{appflowy-operator,espocrm-operator,cloudflare-tunnel-ops}/\ plus a CLAUDE.md cross-ref section so future sessions read the right runbook before touching the stack. No code changes — pure documentation extracted from the deploy work in PR #1051 and the EspoCRM migration arc (PRs #1029-#1043).