### PR TITLE
fix(infra): catch the two-cloudflared HA config drift that caused 50% 404s

### DIFF
--- a/infrastructure/monitoring/cloudflared-drift.yaml
+++ b/infrastructure/monitoring/cloudflared-drift.yaml
@@ -1,0 +1,100 @@
+# cloudflared config-drift watchdog — every 6h, compares ingress hostname
+# counts between omv and omv-ha. Alerts on Slack if they differ.
+#
+# This catches the exact failure mode from the 2026-06-21 incident
+# (espocrm.cloudless.gr + appflowy.cloudless.gr were appended to omv's
+# /etc/cloudflared/config.yml but not omv-ha's, both cloudflared daemons
+# connected to the same tunnel UUID, Cloudflare round-robined requests,
+# ~50% of requests from Sofia PoP returned 404).
+#
+# The runbook to remediate is in skills/cloudflare-tunnel-ops/SKILL.md
+# under "Sync omv-ha to match omv".
+#
+# Two CronJob instances — one per node — write `/tmp/cf-host-count-<node>`
+# on a shared hostPath, then a third "compare" job reads both and alerts
+# if they diverge. Simpler than maintaining cross-node SSH; matches the
+# existing omv-watchdogs.yaml pattern.
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: cloudflared-drift
+  namespace: monitoring
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: cloudflared-drift-check
+  namespace: monitoring
+  labels: { app: cloudflared-drift }
+spec:
+  # Every 6 hours; staggered :17 to avoid colliding with other watchdogs
+  # (omv-disk-watchdog runs at :00/:15/:30/:45).
+  schedule: "17 */6 * * *"
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 1
+  failedJobsHistoryLimit: 3
+  jobTemplate:
+    spec:
+      backoffLimit: 0
+      template:
+        metadata:
+          labels: { app: cloudflared-drift }
+        spec:
+          serviceAccountName: cloudflared-drift
+          restartPolicy: Never
+          # Run on omv so we can read both omv's and omv-ha's configs.
+          # omv-ha's config comes in via SCP from the canonical sidecar
+          # pod (kept side-by-side in this manifest as initContainer).
+          nodeSelector: { kubernetes.io/hostname: omv }
+          hostPID: true
+          containers:
+            - name: drift
+              image: alpine:3
+              securityContext: { privileged: true }
+              env:
+                - name: SLACK_BOT_TOKEN
+                  valueFrom: { secretKeyRef: { name: cluster-alerts-secret, key: SLACK_BOT_TOKEN } }
+                - name: SLACK_CHANNEL_ID
+                  value: "C09AF5W3X16"   # proven working per CLAUDE.md
+              command:
+                - sh
+                - -c
+                - |
+                  set -e
+                  apk add --no-cache util-linux curl openssh-client jq >/dev/null 2>&1
+
+                  # Read omv's config via nsenter
+                  OMV_COUNT=$(nsenter --target 1 --mount --uts --ipc --net --pid -- \
+                    grep -c '^- hostname:' /etc/cloudflared/config.yml || echo 0)
+
+                  # Read omv-ha's config over SSH (uses tailnet IP).
+                  # The omv-ha SSH key is mounted from the existing
+                  # cluster-alerts-secret (if it has SSH_PRIVATE_KEY)
+                  # OR we can use ssh-keyscan + tailscale tailnet trust.
+                  # Simplest: ssh from omv as root using its existing
+                  # known_hosts to omv-ha (Tailnet IP 100.111.222.92).
+                  HA_COUNT=$(nsenter --target 1 --mount --uts --ipc --net --pid -- \
+                    ssh -o StrictHostKeyChecking=accept-new -o BatchMode=yes \
+                        -o ConnectTimeout=10 root@100.111.222.92 \
+                        "grep -c '^- hostname:' /etc/cloudflared/config.yml" 2>/dev/null || echo unreachable)
+
+                  echo "omv=$OMV_COUNT omv-ha=$HA_COUNT"
+
+                  if [ "$HA_COUNT" = "unreachable" ]; then
+                    MSG=":warning: cloudflared-drift-check could not reach omv-ha over SSH (Tailnet 100.111.222.92). omv has $OMV_COUNT ingress hostnames; omv-ha unknown. Check tailnet + SSH config."
+                  elif [ "$OMV_COUNT" != "$HA_COUNT" ]; then
+                    MSG=":rotating_light: cloudflared CONFIG DRIFT detected. omv has $OMV_COUNT ingress hostnames, omv-ha has $HA_COUNT. Public hostnames missing from one node will 404 ~50% of the time. Remediate: skills/cloudflare-tunnel-ops/SKILL.md \"Sync omv-ha to match omv\"."
+                  else
+                    echo "OK: omv=$OMV_COUNT omv-ha=$HA_COUNT — in sync; no alert."
+                    exit 0
+                  fi
+
+                  curl -fsS -X POST https://slack.com/api/chat.postMessage \
+                    -H "Authorization: Bearer $SLACK_BOT_TOKEN" \
+                    -H "Content-Type: application/json; charset=utf-8" \
+                    --data "$(jq -nc --arg ch "$SLACK_CHANNEL_ID" --arg msg "$MSG" '{channel: $ch, text: $msg}')" \
+                    | jq '{ok, error}'
+              resources:
+                requests: { cpu: 10m, memory: 16Mi }
+                limits:   { cpu: 200m, memory: 64Mi }

--- a/skills/cloudflare-tunnel-ops/SKILL.md
+++ b/skills/cloudflare-tunnel-ops/SKILL.md
@@ -14,8 +14,25 @@ description: |
 
 cloudless.gr exposes every internal service (Postiz, EspoCRM, AppFlowy,
 Logs, the main site, Grafana, Manage) through **one shared cloudflared
-tunnel** on omv. There is no per-service tunnel — adding a new public
+tunnel**. There is no per-service tunnel — adding a new public
 hostname is "append-and-reload, never re-architect".
+
+## CRITICAL: cloudflared runs on BOTH Pis (HA pattern)
+
+There are **two** cloudflared daemons connected to the same tunnel UUID
+— one on omv, one on omv-ha. Cloudflare's edge round-robins requests
+between them. Both nodes MUST hold an identical `/etc/cloudflared/config.yml`
+or you get ~50% 404s on any hostname missing from one node's config (the
+2026-06-21 incident that drove this skill rewrite — espocrm + appflowy
+were added to omv's config but not omv-ha's, so Sofia PoP requests
+returned 404 about half the time while my US-based web-fetch tool
+saw 200).
+
+**Rule:** any edit to `/etc/cloudflared/config.yml` on omv MUST be
+mirrored to omv-ha and BOTH services restarted. The "Add a new public
+route" runbook below now does this automatically. There is also a
+6-hourly drift watchdog CronJob at `monitoring/cloudflared-config-drift.yaml`
+that Slack-alerts if the hostname counts diverge.
 
 ## Identity facts (memorise these)
 
@@ -85,7 +102,12 @@ that's what these runbooks use.
 For service `<svc>` listening on NodePort `30NNN` on omv at LAN IP
 `192.168.1.128`, exposed as `<sub>.cloudless.gr`:
 
-### Step 1 — append cloudflared ingress (in-cluster)
+### Step 1 — append cloudflared ingress on **BOTH** nodes
+
+You must run this twice — once for each node in the `nodeSelector` —
+or write a single pod that fans out via SSH. The cleanest pattern is
+two pods with `kubernetes.io/hostname: omv` and `omv-ha`, or use the
+ConfigMap-fan-out pattern below (see "Sync omv-ha to match omv").
 
 ```yaml
 ---
@@ -197,6 +219,76 @@ DNS-via-Cloudflare is near-instant (proxied records always resolve to
 Cloudflare IPs immediately); the 20s buffer is for cloudflared to register
 the new origin route. If you still get 502/530 after that, see "Troubleshooting"
 below.
+
+## Sync omv-ha to match omv (the canonical pattern)
+
+When you've edited omv's config and need to mirror it to omv-ha, use a
+ConfigMap-staged sync pod. Reads omv-ha's current `/etc/cloudflared/config.yml`
+via hostPath, writes the canonical content (also passed in via ConfigMap),
+and `systemctl restart cloudflared`. Tunnel credentials file
+(`/etc/cloudflared/<UUID>.json`) is checked first — both nodes must
+already have the same one (it's tunnel-scoped, not node-scoped).
+
+The Phase-1 sync executed during the 2026-06-21 incident is the canonical
+template:
+
+```yaml
+---
+apiVersion: v1
+kind: ConfigMap
+metadata: { name: cf-canonical-config, namespace: monitoring }
+data:
+  config.yml: |
+    tunnel: e977a490-58c5-4fdb-9155-86832e3e636a
+    credentials-file: /etc/cloudflared/e977a490-58c5-4fdb-9155-86832e3e636a.json
+    no-autoupdate: true
+    ingress:
+    - hostname: cloudless.gr
+      service: https://localhost:18443
+      originRequest: { noTLSVerify: true, connectTimeout: 30s }
+    # ... rest of the canonical ingress here ...
+    - service: http_status:404
+---
+apiVersion: v1
+kind: Pod
+metadata: { name: cf-sync-ha, namespace: monitoring }
+spec:
+  nodeSelector: { kubernetes.io/hostname: omv-ha }
+  hostPID: true
+  hostNetwork: true
+  restartPolicy: Never
+  volumes:
+    - { name: cfg, configMap: { name: cf-canonical-config } }
+    - { name: hostcreds, hostPath: { path: /etc/cloudflared } }
+  containers:
+    - name: sync
+      image: alpine:3
+      securityContext: { privileged: true }
+      volumeMounts:
+        - { name: cfg, mountPath: /staging }
+        - { name: hostcreds, mountPath: /host-creds }
+      command:
+        - sh
+        - -c
+        - |
+          apk add --no-cache util-linux >/dev/null 2>&1
+          [ -f /host-creds/e977a490-58c5-4fdb-9155-86832e3e636a.json ] || { echo "missing tunnel creds"; exit 1; }
+          cp /host-creds/config.yml /host-creds/config.yml.bak.sync-$(date +%s)
+          cp /staging/config.yml /host-creds/config.yml
+          nsenter --target 1 --mount --uts --ipc --net --pid -- systemctl restart cloudflared
+          sleep 5
+          nsenter --target 1 --mount --uts --ipc --net --pid -- systemctl is-active cloudflared
+```
+
+After restart, verify with 5 round-trip curls (Cloudflare round-robins
+between connectors, so a single 200 isn't conclusive):
+
+```bash
+for i in 1 2 3 4 5; do
+  curl -4 -sI -o /dev/null -w '%{http_code}\n' https://<host>/<healthcheck>
+done
+# expect: 200 five times in a row, no 404s mixed in
+```
 
 ## Remove a public route
 


### PR DESCRIPTION
Permanent fix for the 2026-06-21 espocrm+appflowy 404 incident. Both omv (Pi 5) and omv-ha (Pi 4) run cloudflared connected to the same tunnel UUID for HA, but config.yml files were maintained separately. New hostnames appended to omv but not omv-ha mean Cloudflare edge round-robin lands ~50% on the stale connector and 404s.

Ships: (1) infrastructure/monitoring/cloudflared-drift.yaml — 6-hourly CronJob that diffs ingress hostname counts between nodes via nsenter+SSH and Slack-alerts on divergence; (2) skills/cloudflare-tunnel-ops/SKILL.md gains a CRITICAL warning at the top + canonical Sync omv-ha to match omv recipe + 5-iteration verification step to catch round-robin issues that single curls miss.