### PR TITLE
feat(integrations): wire AppFlowy + n8n + Postiz to cloudless.gr app + data lake

### DIFF
--- a/.github/workflows/etl-selfhosted-to-lake.yml
+++ b/.github/workflows/etl-selfhosted-to-lake.yml
@@ -1,0 +1,86 @@
+name: ETL — self-hosted apps → S3 data lake
+
+# Daily sync of AppFlowy + n8n + Postiz into the cloudless_analytics
+# Athena database. Companion to etl-espocrm-to-lake.yml. Tokens come from
+# SSM Parameter Store via the same AWS_ETL_ROLE_ARN OIDC role used by the
+# other ETL workflows. See:
+#   - skills/appflowy-operator/SKILL.md
+#   - skills/espocrm-operator/SKILL.md
+#   - infrastructure/athena/selfhosted.sql for the Athena DDL.
+
+on:
+  schedule:
+    - cron: "37 3 * * *"   # 03:37 UTC daily; offset so it doesn't collide with espocrm/gsc
+  workflow_dispatch:
+    inputs:
+      apps:
+        description: "Comma-separated subset of {appflowy,n8n,postiz}. Default: all."
+        required: false
+        default: "appflowy,n8n,postiz"
+
+permissions:
+  id-token: write
+  contents: read
+
+concurrency:
+  group: etl-selfhosted-to-lake
+  cancel-in-progress: false
+
+jobs:
+  sync:
+    runs-on: ${{ fromJSON(vars.RUNNER_GENERIC || '"ubuntu-latest"') }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+        with: { version: 10 }
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: pnpm
+
+      - name: Install ETL deps
+        working-directory: scripts/etl
+        run: npm ci || npm install
+
+      - name: Configure AWS credentials (OIDC)
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_ETL_ROLE_ARN }}
+          aws-region: us-east-1
+
+      - name: Hydrate self-hosted-app tokens from SSM
+        run: |
+          set -e
+          export_param() {
+            local name=$1
+            local value
+            value=$(aws ssm get-parameter --name "/cloudless/production/$name" \
+              --with-decryption --query Parameter.Value --output text 2>/dev/null || true)
+            if [ -n "$value" ] && [ "$value" != "None" ]; then
+              echo "$name=$value" >> "$GITHUB_ENV"
+              echo "::add-mask::$value"
+            fi
+          }
+          export_param APPFLOWY_API_URL
+          export_param APPFLOWY_JWT_SECRET
+          export_param N8N_API_URL
+          export_param N8N_API_KEY
+          export_param POSTIZ_API_URL
+          export_param POSTIZ_API_KEY
+
+      - name: AppFlowy → S3
+        if: contains(github.event.inputs.apps || 'appflowy,n8n,postiz', 'appflowy')
+        run: node scripts/etl/appflowy-to-lake.mjs
+        continue-on-error: true
+
+      - name: n8n → S3
+        if: contains(github.event.inputs.apps || 'appflowy,n8n,postiz', 'n8n')
+        run: node scripts/etl/n8n-to-lake.mjs
+        continue-on-error: true
+
+      - name: Postiz → S3
+        if: contains(github.event.inputs.apps || 'appflowy,n8n,postiz', 'postiz')
+        run: node scripts/etl/postiz-to-lake.mjs
+        continue-on-error: true

--- a/__tests__/chat-api.test.ts
+++ b/__tests__/chat-api.test.ts
@@ -13,8 +13,7 @@ const { mockSend, MockConverseCommand, mockRunTool } = vi.hoisted(() => {
   const mockSend = vi.fn();
   const mockRunTool = vi.fn();
 
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  function MockConverseCommandImpl(this: unknown, input: any) {
+  function MockConverseCommandImpl(this: unknown, input: object) {
     void input; // args tracked via MockConverseCommand.mock.calls
   }
   const MockConverseCommand = vi.fn(MockConverseCommandImpl);
@@ -24,8 +23,7 @@ const { mockSend, MockConverseCommand, mockRunTool } = vi.hoisted(() => {
 
 vi.mock("@aws-sdk/client-bedrock-runtime", () => {
   // Must be a regular function so `new BedrockRuntimeClient()` succeeds.
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  function BedrockRuntimeClientImpl(this: any) {
+  function BedrockRuntimeClientImpl(this: Record<string, unknown>) {
     this.send = mockSend;
   }
   return {

--- a/infrastructure/athena/selfhosted.sql
+++ b/infrastructure/athena/selfhosted.sql
@@ -1,0 +1,119 @@
+-- Athena DDL for the self-hosted-apps slice of the cloudless data lake.
+-- Database: cloudless_analytics. Tables backed by s3://cloudless-analytics-data/lake/*.
+--
+-- ETLs:
+--   scripts/etl/appflowy-to-lake.mjs   → 2 parquet files (workspaces, users)
+--   scripts/etl/n8n-to-lake.mjs        → 2 parquet files (workflows, executions)
+--   scripts/etl/postiz-to-lake.mjs     → 2 parquet files (posts, integrations)
+--
+-- Apply once with the Athena admin role; subsequent ETL runs overwrite
+-- the underlying Parquet so SELECT works without re-running this DDL.
+
+CREATE EXTERNAL TABLE IF NOT EXISTS cloudless_analytics.appflowy_workspaces (
+  workspace_id   string,
+  workspace_name string,
+  owner_uid      bigint,
+  workspace_type int,
+  member_count   int,
+  created_at     string
+)
+STORED AS PARQUET
+LOCATION 's3://cloudless-analytics-data/lake/appflowy-workspaces/';
+
+CREATE EXTERNAL TABLE IF NOT EXISTS cloudless_analytics.appflowy_users (
+  uid        bigint,
+  uuid       string,
+  email      string,
+  name       string,
+  created_at string
+)
+STORED AS PARQUET
+LOCATION 's3://cloudless-analytics-data/lake/appflowy-users/';
+
+CREATE EXTERNAL TABLE IF NOT EXISTS cloudless_analytics.n8n_workflows (
+  workflow_id string,
+  name        string,
+  active      boolean,
+  tag_count   int,
+  tags_json   string,
+  created_at  string,
+  updated_at  string
+)
+STORED AS PARQUET
+LOCATION 's3://cloudless-analytics-data/lake/n8n-workflows/';
+
+CREATE EXTERNAL TABLE IF NOT EXISTS cloudless_analytics.n8n_executions (
+  execution_id string,
+  workflow_id  string,
+  mode         string,
+  status       string,
+  finished     boolean,
+  started_at   string,
+  stopped_at   string,
+  duration_ms  bigint
+)
+STORED AS PARQUET
+LOCATION 's3://cloudless-analytics-data/lake/n8n-executions/';
+
+CREATE EXTERNAL TABLE IF NOT EXISTS cloudless_analytics.postiz_posts (
+  post_id          string,
+  integration_id   string,
+  integration_name string,
+  platform         string,
+  state            string,
+  release_url      string,
+  publish_date     string,
+  released_at      string,
+  content_length   int,
+  created_at       string
+)
+STORED AS PARQUET
+LOCATION 's3://cloudless-analytics-data/lake/postiz-posts/';
+
+CREATE EXTERNAL TABLE IF NOT EXISTS cloudless_analytics.postiz_integrations (
+  integration_id string,
+  name           string,
+  platform       string,
+  disabled       boolean,
+  refresh_needed boolean,
+  created_at     string
+)
+STORED AS PARQUET
+LOCATION 's3://cloudless-analytics-data/lake/postiz-integrations/';
+
+-- ---------------------------------------------------------------------------
+-- Convenience views for /admin/integrations + /admin/analytics dashboards
+-- ---------------------------------------------------------------------------
+
+CREATE OR REPLACE VIEW cloudless_analytics.v_selfhosted_health AS
+SELECT 'appflowy' AS app,
+       (SELECT count(*) FROM cloudless_analytics.appflowy_workspaces) AS workspaces,
+       (SELECT count(*) FROM cloudless_analytics.appflowy_users)      AS users,
+       0 AS workflows, 0 AS executions, 0 AS posts, 0 AS integrations
+UNION ALL
+SELECT 'n8n',
+       0, 0,
+       (SELECT count(*) FROM cloudless_analytics.n8n_workflows)       AS workflows,
+       (SELECT count(*) FROM cloudless_analytics.n8n_executions)      AS executions,
+       0, 0
+UNION ALL
+SELECT 'postiz',
+       0, 0, 0, 0,
+       (SELECT count(*) FROM cloudless_analytics.postiz_posts)        AS posts,
+       (SELECT count(*) FROM cloudless_analytics.postiz_integrations) AS integrations;
+
+CREATE OR REPLACE VIEW cloudless_analytics.v_n8n_workflow_health_30d AS
+SELECT w.name,
+       w.active,
+       count(e.execution_id)                                                AS exec_count,
+       sum(CASE WHEN e.status = 'success' THEN 1 ELSE 0 END)                AS success_count,
+       sum(CASE WHEN e.status = 'error'   THEN 1 ELSE 0 END)                AS error_count,
+       100.0 * sum(CASE WHEN e.status = 'success' THEN 1 ELSE 0 END)
+              / NULLIF(count(e.execution_id), 0)                            AS success_pct,
+       avg(e.duration_ms)                                                   AS avg_duration_ms
+FROM cloudless_analytics.n8n_workflows w
+LEFT JOIN cloudless_analytics.n8n_executions e
+  ON e.workflow_id = w.workflow_id
+ AND from_iso8601_timestamp(e.started_at) >= current_timestamp - interval '30' day
+GROUP BY w.name, w.active
+ORDER BY exec_count DESC;

--- a/scripts/audit/aggregate.mjs
+++ b/scripts/audit/aggregate.mjs
@@ -237,7 +237,6 @@ md.push("");
 md.push("> Reports retained 30-60 days per audit. Click an audit name above to open the run.");
 md.push("> Live page: `/admin/audits` reads the latest `audits-dashboard-*` artifact via REST.");
 
-// eslint-disable-next-line no-control-regex
 const CTRL_RE = /[\x00-\x08\x0B\x0C\x0E-\x1F\x7F]/g;
 const stripCtrl = (s) => String(s).replace(CTRL_RE, "");
 const safeMd = md.map(stripCtrl).join("\n") + "\n";

--- a/scripts/audit/security-headers.mjs
+++ b/scripts/audit/security-headers.mjs
@@ -278,7 +278,6 @@ const summary = {
   results,
 };
 
-// eslint-disable-next-line no-control-regex
 const CTRL_RE = /[\x00-\x08\x0B\x0C\x0E-\x1F\x7F]/g;
 const MAX_CELL = 300;
 const sanitizeCell = (v) => String(v).replace(CTRL_RE, "").slice(0, MAX_CELL);

--- a/scripts/check-services.js
+++ b/scripts/check-services.js
@@ -99,13 +99,6 @@ async function checkCognito() {
   await client.send(new ListUserPoolsCommand({ MaxResults: 1 }));
 }
 
-  if (!issuer) {
-    return;
-  }
-  const res = await fetch(`${issuer}/.well-known/openid-configuration`, { signal: AbortSignal.timeout(5000) });
-  if (!res.ok) throw new Error(`OIDC discovery returned HTTP ${res.status}`);
-}
-
 async function checkSES() {
   const { SESClient, GetSendQuotaCommand } = require('@aws-sdk/client-ses');
   const region = process.env.AWS_SES_REGION || process.env.AWS_REGION || 'us-east-1';

--- a/scripts/coverage-merge-server.mjs
+++ b/scripts/coverage-merge-server.mjs
@@ -30,7 +30,7 @@ for (const f of files) {
     } else {
       empty++;
     }
-  } catch (e) {
+  } catch (_) {
     bad++;
   }
 }

--- a/scripts/etl/appflowy-to-lake.mjs
+++ b/scripts/etl/appflowy-to-lake.mjs
@@ -1,0 +1,150 @@
+/**
+ * ETL: AppFlowy Cloud → S3 Data Lake (Parquet)
+ *
+ * Pulls workspace + user metadata from the self-hosted AppFlowy Cloud
+ * (Notion replacement) via its REST API. Two parquet files:
+ *
+ *   lake/appflowy-workspaces/workspaces.parquet
+ *   lake/appflowy-users/users.parquet
+ *
+ * Auth: short-lived service-role JWT signed with APPFLOWY_JWT_SECRET
+ * (same value as cluster Secret appflowy-secrets/GOTRUE_JWT_SECRET).
+ * See src/lib/appflowy.ts for the JWT signing approach this mirrors.
+ *
+ * Runs daily via .github/workflows/etl-selfhosted-to-lake.yml.
+ * Full-refresh — counts are well under 1k records.
+ */
+import { S3Client, PutObjectCommand } from "@aws-sdk/client-s3";
+import { ParquetWriter, ParquetSchema } from "@dsnp/parquetjs";
+import { readFileSync, unlinkSync } from "fs";
+import { createHmac } from "node:crypto";
+
+const REGION = process.env.AWS_REGION || "us-east-1";
+const BUCKET = process.env.ANALYTICS_BUCKET || "cloudless-analytics-data";
+const BASE = (process.env.APPFLOWY_API_URL || "").replace(/\/$/, "");
+const SECRET = process.env.APPFLOWY_JWT_SECRET;
+
+if (!BASE || !SECRET) {
+  console.error("APPFLOWY_API_URL and APPFLOWY_JWT_SECRET are required");
+  process.exit(1);
+}
+
+const s3 = new S3Client({ region: REGION });
+
+function b64url(input) {
+  return Buffer.from(input)
+    .toString("base64")
+    .replace(/=+$/, "")
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_");
+}
+
+function mintServiceJwt() {
+  const header = { alg: "HS256", typ: "JWT" };
+  const now = Math.floor(Date.now() / 1000);
+  const payload = {
+    aud: "",
+    role: "supabase_admin",
+    iss: "cloudless-appflowy-etl",
+    iat: now,
+    exp: now + 600,
+  };
+  const head = b64url(JSON.stringify(header));
+  const body = b64url(JSON.stringify(payload));
+  const sig = b64url(createHmac("sha256", SECRET).update(`${head}.${body}`).digest());
+  return `${head}.${body}.${sig}`;
+}
+
+async function afFetch(path) {
+  const res = await fetch(`${BASE}/api${path}`, {
+    headers: {
+      Accept: "application/json",
+      Authorization: `Bearer ${mintServiceJwt()}`,
+    },
+    signal: AbortSignal.timeout(15_000),
+  });
+  if (!res.ok) {
+    const body = await res.text().catch(() => "");
+    throw new Error(`AppFlowy ${path} returned ${res.status}: ${body.slice(0, 200)}`);
+  }
+  return res.json();
+}
+
+const workspaceSchema = new ParquetSchema({
+  workspace_id: { type: "UTF8" },
+  workspace_name: { type: "UTF8", optional: true },
+  owner_uid: { type: "INT64", optional: true },
+  workspace_type: { type: "INT32", optional: true },
+  member_count: { type: "INT32", optional: true },
+  created_at: { type: "UTF8", optional: true },
+});
+
+const userSchema = new ParquetSchema({
+  uid: { type: "INT64" },
+  uuid: { type: "UTF8", optional: true },
+  email: { type: "UTF8", optional: true },
+  name: { type: "UTF8", optional: true },
+  created_at: { type: "UTF8", optional: true },
+});
+
+async function writeParquet(rows, schema, localPath) {
+  const writer = await ParquetWriter.openFile(schema, localPath);
+  for (const row of rows) await writer.appendRow(row);
+  await writer.close();
+  return readFileSync(localPath);
+}
+
+async function uploadToS3(key, body) {
+  await s3.send(
+    new PutObjectCommand({
+      Bucket: BUCKET,
+      Key: key,
+      Body: body,
+      ContentType: "application/octet-stream",
+    })
+  );
+  console.log(`✓ uploaded s3://${BUCKET}/${key} (${body.length} bytes)`);
+}
+
+async function syncWorkspaces() {
+  const data = await afFetch("/admin/workspace").catch((e) => {
+    console.warn("/admin/workspace failed:", e.message);
+    return { data: [] };
+  });
+  const rows = (data.data || []).map((w) => ({
+    workspace_id: String(w.workspace_id ?? ""),
+    workspace_name: String(w.workspace_name ?? ""),
+    owner_uid: Number(w.owner_uid ?? 0),
+    workspace_type: Number(w.workspace_type ?? 0),
+    member_count: Number(w.member_count ?? 0),
+    created_at: String(w.created_at ?? ""),
+  }));
+  const local = "/tmp/appflowy-workspaces.parquet";
+  const body = await writeParquet(rows, workspaceSchema, local);
+  await uploadToS3("lake/appflowy-workspaces/workspaces.parquet", body);
+  unlinkSync(local);
+  console.log(`workspaces: ${rows.length}`);
+}
+
+async function syncUsers() {
+  const data = await afFetch("/admin/user").catch((e) => {
+    console.warn("/admin/user failed:", e.message);
+    return { data: [] };
+  });
+  const rows = (data.data || []).map((u) => ({
+    uid: Number(u.uid ?? 0),
+    uuid: String(u.uuid ?? ""),
+    email: String(u.email ?? ""),
+    name: String(u.name ?? ""),
+    created_at: String(u.created_at ?? ""),
+  }));
+  const local = "/tmp/appflowy-users.parquet";
+  const body = await writeParquet(rows, userSchema, local);
+  await uploadToS3("lake/appflowy-users/users.parquet", body);
+  unlinkSync(local);
+  console.log(`users: ${rows.length}`);
+}
+
+await syncWorkspaces();
+await syncUsers();
+console.log("✓ AppFlowy → S3 sync complete");

--- a/scripts/etl/n8n-to-lake.mjs
+++ b/scripts/etl/n8n-to-lake.mjs
@@ -1,0 +1,129 @@
+/**
+ * ETL: n8n → S3 Data Lake (Parquet)
+ *
+ * Pulls workflows + executions from the self-hosted n8n via the public
+ * REST API. Two parquet files:
+ *
+ *   lake/n8n-workflows/workflows.parquet
+ *   lake/n8n-executions/executions.parquet
+ *
+ * Auth: X-N8N-API-KEY header (key issued from n8n Settings → API).
+ *
+ * Runs daily via .github/workflows/etl-selfhosted-to-lake.yml. Workflows
+ * are a snapshot (full refresh). Executions are last-N rolling — n8n's own
+ * pruner removes old ones, so we keep what's currently retained.
+ */
+import { S3Client, PutObjectCommand } from "@aws-sdk/client-s3";
+import { ParquetWriter, ParquetSchema } from "@dsnp/parquetjs";
+import { readFileSync, unlinkSync } from "fs";
+
+const REGION = process.env.AWS_REGION || "us-east-1";
+const BUCKET = process.env.ANALYTICS_BUCKET || "cloudless-analytics-data";
+const BASE = (process.env.N8N_API_URL || "").replace(/\/$/, "");
+const KEY = process.env.N8N_API_KEY;
+const EXEC_LIMIT = Math.max(1, Math.min(Number(process.env.N8N_EXEC_LIMIT) || 250, 250));
+
+if (!BASE || !KEY) {
+  console.error("N8N_API_URL and N8N_API_KEY are required");
+  process.exit(1);
+}
+
+const s3 = new S3Client({ region: REGION });
+
+async function n8nFetch(path) {
+  const res = await fetch(`${BASE}/api/v1${path}`, {
+    headers: { "X-N8N-API-KEY": KEY, Accept: "application/json" },
+    signal: AbortSignal.timeout(15_000),
+  });
+  if (!res.ok) {
+    const body = await res.text().catch(() => "");
+    throw new Error(`n8n ${path} returned ${res.status}: ${body.slice(0, 200)}`);
+  }
+  return res.json();
+}
+
+const workflowSchema = new ParquetSchema({
+  workflow_id: { type: "UTF8" },
+  name: { type: "UTF8", optional: true },
+  active: { type: "BOOLEAN", optional: true },
+  tag_count: { type: "INT32", optional: true },
+  tags_json: { type: "UTF8", optional: true },
+  created_at: { type: "UTF8", optional: true },
+  updated_at: { type: "UTF8", optional: true },
+});
+
+const executionSchema = new ParquetSchema({
+  execution_id: { type: "UTF8" },
+  workflow_id: { type: "UTF8", optional: true },
+  mode: { type: "UTF8", optional: true },
+  status: { type: "UTF8", optional: true },
+  finished: { type: "BOOLEAN", optional: true },
+  started_at: { type: "UTF8", optional: true },
+  stopped_at: { type: "UTF8", optional: true },
+  duration_ms: { type: "INT64", optional: true },
+});
+
+async function writeParquet(rows, schema, localPath) {
+  const writer = await ParquetWriter.openFile(schema, localPath);
+  for (const row of rows) await writer.appendRow(row);
+  await writer.close();
+  return readFileSync(localPath);
+}
+
+async function uploadToS3(key, body) {
+  await s3.send(
+    new PutObjectCommand({
+      Bucket: BUCKET,
+      Key: key,
+      Body: body,
+      ContentType: "application/octet-stream",
+    })
+  );
+  console.log(`✓ uploaded s3://${BUCKET}/${key} (${body.length} bytes)`);
+}
+
+async function syncWorkflows() {
+  // n8n paginates via `nextCursor`; small instance — single page is plenty.
+  const data = await n8nFetch("/workflows?limit=250");
+  const rows = (data.data || []).map((w) => ({
+    workflow_id: String(w.id ?? ""),
+    name: String(w.name ?? ""),
+    active: Boolean(w.active),
+    tag_count: Array.isArray(w.tags) ? w.tags.length : 0,
+    tags_json: JSON.stringify(w.tags ?? []),
+    created_at: String(w.createdAt ?? ""),
+    updated_at: String(w.updatedAt ?? ""),
+  }));
+  const local = "/tmp/n8n-workflows.parquet";
+  const body = await writeParquet(rows, workflowSchema, local);
+  await uploadToS3("lake/n8n-workflows/workflows.parquet", body);
+  unlinkSync(local);
+  console.log(`workflows: ${rows.length}`);
+}
+
+async function syncExecutions() {
+  const data = await n8nFetch(`/executions?limit=${EXEC_LIMIT}&includeData=false`);
+  const rows = (data.data || []).map((e) => {
+    const startedAt = e.startedAt ? Date.parse(e.startedAt) : 0;
+    const stoppedAt = e.stoppedAt ? Date.parse(e.stoppedAt) : 0;
+    return {
+      execution_id: String(e.id ?? ""),
+      workflow_id: String(e.workflowId ?? ""),
+      mode: String(e.mode ?? ""),
+      status: String(e.status ?? ""),
+      finished: Boolean(e.finished),
+      started_at: String(e.startedAt ?? ""),
+      stopped_at: String(e.stoppedAt ?? ""),
+      duration_ms: startedAt && stoppedAt ? stoppedAt - startedAt : 0,
+    };
+  });
+  const local = "/tmp/n8n-executions.parquet";
+  const body = await writeParquet(rows, executionSchema, local);
+  await uploadToS3("lake/n8n-executions/executions.parquet", body);
+  unlinkSync(local);
+  console.log(`executions: ${rows.length}`);
+}
+
+await syncWorkflows();
+await syncExecutions();
+console.log("✓ n8n → S3 sync complete");

--- a/scripts/etl/postiz-to-lake.mjs
+++ b/scripts/etl/postiz-to-lake.mjs
@@ -1,0 +1,152 @@
+/**
+ * ETL: Postiz → S3 Data Lake (Parquet)
+ *
+ * Pulls scheduled / published posts + connected integrations from the
+ * self-hosted Postiz via its public API. Two parquet files:
+ *
+ *   lake/postiz-posts/posts.parquet
+ *   lake/postiz-integrations/integrations.parquet
+ *
+ * Auth: Authorization header with raw API key (Postiz uses non-standard
+ * scheme — no "Bearer " prefix). Key from Postiz Settings → Public API.
+ *
+ * Runs daily via .github/workflows/etl-selfhosted-to-lake.yml. Posts are
+ * fetched for a configurable rolling window (default 90d) to bound size;
+ * integrations are a small snapshot.
+ */
+import { S3Client, PutObjectCommand } from "@aws-sdk/client-s3";
+import { ParquetWriter, ParquetSchema } from "@dsnp/parquetjs";
+import { readFileSync, unlinkSync } from "fs";
+
+const REGION = process.env.AWS_REGION || "us-east-1";
+const BUCKET = process.env.ANALYTICS_BUCKET || "cloudless-analytics-data";
+const BASE = (process.env.POSTIZ_API_URL || "").replace(/\/$/, "");
+const KEY = process.env.POSTIZ_API_KEY;
+const DAYS = Math.max(1, Math.min(Number(process.env.POSTIZ_DAYS) || 90, 365));
+
+if (!BASE || !KEY) {
+  console.error("POSTIZ_API_URL and POSTIZ_API_KEY are required");
+  process.exit(1);
+}
+
+const s3 = new S3Client({ region: REGION });
+
+async function postizFetch(path) {
+  const res = await fetch(`${BASE}/api/public/v1${path}`, {
+    headers: { Authorization: KEY, Accept: "application/json" },
+    signal: AbortSignal.timeout(15_000),
+  });
+  if (!res.ok) {
+    const body = await res.text().catch(() => "");
+    throw new Error(`Postiz ${path} returned ${res.status}: ${body.slice(0, 200)}`);
+  }
+  return res.json();
+}
+
+const postSchema = new ParquetSchema({
+  post_id: { type: "UTF8" },
+  integration_id: { type: "UTF8", optional: true },
+  integration_name: { type: "UTF8", optional: true },
+  platform: { type: "UTF8", optional: true },
+  state: { type: "UTF8", optional: true },
+  release_url: { type: "UTF8", optional: true },
+  publish_date: { type: "UTF8", optional: true },
+  released_at: { type: "UTF8", optional: true },
+  content_length: { type: "INT32", optional: true },
+  created_at: { type: "UTF8", optional: true },
+});
+
+const integrationSchema = new ParquetSchema({
+  integration_id: { type: "UTF8" },
+  name: { type: "UTF8", optional: true },
+  platform: { type: "UTF8", optional: true },
+  disabled: { type: "BOOLEAN", optional: true },
+  refresh_needed: { type: "BOOLEAN", optional: true },
+  created_at: { type: "UTF8", optional: true },
+});
+
+async function writeParquet(rows, schema, localPath) {
+  const writer = await ParquetWriter.openFile(schema, localPath);
+  for (const row of rows) await writer.appendRow(row);
+  await writer.close();
+  return readFileSync(localPath);
+}
+
+async function uploadToS3(key, body) {
+  await s3.send(
+    new PutObjectCommand({
+      Bucket: BUCKET,
+      Key: key,
+      Body: body,
+      ContentType: "application/octet-stream",
+    })
+  );
+  console.log(`✓ uploaded s3://${BUCKET}/${key} (${body.length} bytes)`);
+}
+
+async function syncPosts() {
+  // Postiz public API: GET /api/public/v1/posts?display=month&day=YYYY-MM-DD
+  // returns posts for that calendar month. Sweep DAYS/30 months back.
+  const today = new Date();
+  const months = Math.ceil(DAYS / 30);
+  const accum = [];
+  const seen = new Set();
+  for (let i = 0; i < months; i++) {
+    const d = new Date(today);
+    d.setMonth(d.getMonth() - i);
+    const day = d.toISOString().slice(0, 10);
+    const data = await postizFetch(`/posts?display=month&day=${day}`).catch((e) => {
+      console.warn(`month ${day} failed:`, e.message);
+      return { posts: [] };
+    });
+    const posts = data.posts || data.data || [];
+    for (const p of posts) {
+      const id = String(p.id ?? "");
+      if (!id || seen.has(id)) continue;
+      seen.add(id);
+      accum.push(p);
+    }
+  }
+  const rows = accum.map((p) => ({
+    post_id: String(p.id ?? ""),
+    integration_id: String(p.integration?.id ?? p.integrationId ?? ""),
+    integration_name: String(p.integration?.name ?? ""),
+    platform: String(p.integration?.providerIdentifier ?? p.providerIdentifier ?? ""),
+    state: String(p.state ?? ""),
+    release_url: String(p.releaseURL ?? ""),
+    publish_date: String(p.publishDate ?? ""),
+    released_at: String(p.releasedAt ?? ""),
+    content_length: typeof p.content === "string" ? p.content.length : 0,
+    created_at: String(p.createdAt ?? ""),
+  }));
+  const local = "/tmp/postiz-posts.parquet";
+  const body = await writeParquet(rows, postSchema, local);
+  await uploadToS3("lake/postiz-posts/posts.parquet", body);
+  unlinkSync(local);
+  console.log(`posts: ${rows.length} across ${months} months`);
+}
+
+async function syncIntegrations() {
+  const data = await postizFetch("/integrations").catch((e) => {
+    console.warn("/integrations failed:", e.message);
+    return { data: [] };
+  });
+  const list = Array.isArray(data) ? data : data.data || [];
+  const rows = list.map((i) => ({
+    integration_id: String(i.id ?? ""),
+    name: String(i.name ?? ""),
+    platform: String(i.providerIdentifier ?? ""),
+    disabled: Boolean(i.disabled),
+    refresh_needed: Boolean(i.refreshNeeded),
+    created_at: String(i.createdAt ?? ""),
+  }));
+  const local = "/tmp/postiz-integrations.parquet";
+  const body = await writeParquet(rows, integrationSchema, local);
+  await uploadToS3("lake/postiz-integrations/integrations.parquet", body);
+  unlinkSync(local);
+  console.log(`integrations: ${rows.length}`);
+}
+
+await syncPosts();
+await syncIntegrations();
+console.log("✓ Postiz → S3 sync complete");

--- a/scripts/rebuild-report.mjs
+++ b/scripts/rebuild-report.mjs
@@ -1,6 +1,5 @@
 import fs from "fs";
 import path from "path";
-import { fileURLToPath } from "url";
 import MCR from "monocart-coverage-reports";
 
 const ROOT = "/home/tbaltzakis/code/cloudless.gr";
@@ -32,7 +31,7 @@ for (const f of files) {
     } else {
       empty++;
     }
-  } catch (e) { bad++; }
+  } catch (_) { bad++; }
 }
 console.log(`Added: ${ok}, empty: ${empty}, bad: ${bad}`);
 await mcr.generate();

--- a/scripts/stale-gate-sweeper.mjs
+++ b/scripts/stale-gate-sweeper.mjs
@@ -184,7 +184,7 @@ async function analyzeStaleGates(matches, recentCommits) {
   if (matches.length === 0) return null;
 
   const matchList = matches
-    .map(({ file, lineNum, content }) => {
+    .map(({ file, lineNum }) => {
       const ctx = getContext(file, lineNum);
       return `### ${file}:${lineNum}\n\`\`\`\n${ctx}\n\`\`\``;
     })

--- a/src/app/api/admin/integrations/status/route.ts
+++ b/src/app/api/admin/integrations/status/route.ts
@@ -279,20 +279,61 @@ function buildStaticReports(cfg: Cfg): IntegrationReport[] {
   return [...buildCoreReports(cfg), ...buildSocialAdsReports(cfg)];
 }
 
+async function pingAppFlowy(baseUrl: string): Promise<PingResult> {
+  // /api/health is public — proves the AppFlowy Cloud pod + nginx + tunnel are all up.
+  try {
+    const res = await fetch(baseUrl.replace(/\/$/, "") + "/api/health", {
+      signal: AbortSignal.timeout(5000),
+    });
+    if (!res.ok) return { status: "error", message: `health returned ${res.status}` };
+    return { status: "configured", message: "AppFlowy Cloud healthy." };
+  } catch {
+    return { status: "error", message: "Connection failed." };
+  }
+}
+
+async function pingN8n(baseUrl: string, apiKey: string): Promise<PingResult> {
+  // GET /api/v1/workflows?limit=1 — cheapest authenticated call. 401 = bad key.
+  try {
+    const res = await fetch(baseUrl.replace(/\/$/, "") + "/api/v1/workflows?limit=1", {
+      headers: { "X-N8N-API-KEY": apiKey, Accept: "application/json" },
+      signal: AbortSignal.timeout(5000),
+    });
+    if (res.status === 401)
+      return { status: "degraded", message: "API key rejected (regenerate in Settings → API)." };
+    if (!res.ok) return { status: "error", message: `API returned ${res.status}` };
+    return { status: "configured" };
+  } catch {
+    return { status: "error", message: "Connection failed." };
+  }
+}
+
 async function buildPingedReports(cfg: Cfg): Promise<IntegrationReport[]> {
-  const [stripeResult, espocrmResult, slackResult, notionResult, acResult, postizResult] =
-    await Promise.all([
-      cfg.STRIPE_SECRET_KEY ? pingStripe(cfg.STRIPE_SECRET_KEY) : Promise.resolve(NOT_CONFIGURED),
-      cfg.ESPOCRM_BASE_URL && cfg.ESPOCRM_API_KEY
-        ? pingEspoCRM(cfg.ESPOCRM_BASE_URL, cfg.ESPOCRM_API_KEY)
-        : Promise.resolve(NOT_CONFIGURED),
-      cfg.SLACK_BOT_TOKEN ? pingSlack(cfg.SLACK_BOT_TOKEN) : Promise.resolve(NOT_CONFIGURED),
-      cfg.NOTION_API_KEY ? pingNotion(cfg.NOTION_API_KEY) : Promise.resolve(NOT_CONFIGURED),
-      verifyActiveCampaignToken(),
-      cfg.POSTIZ_API_URL && cfg.POSTIZ_API_KEY
-        ? pingPostiz(cfg.POSTIZ_API_URL, cfg.POSTIZ_API_KEY)
-        : Promise.resolve(NOT_CONFIGURED),
-    ]);
+  const [
+    stripeResult,
+    espocrmResult,
+    slackResult,
+    notionResult,
+    acResult,
+    postizResult,
+    appflowyResult,
+    n8nResult,
+  ] = await Promise.all([
+    cfg.STRIPE_SECRET_KEY ? pingStripe(cfg.STRIPE_SECRET_KEY) : Promise.resolve(NOT_CONFIGURED),
+    cfg.ESPOCRM_BASE_URL && cfg.ESPOCRM_API_KEY
+      ? pingEspoCRM(cfg.ESPOCRM_BASE_URL, cfg.ESPOCRM_API_KEY)
+      : Promise.resolve(NOT_CONFIGURED),
+    cfg.SLACK_BOT_TOKEN ? pingSlack(cfg.SLACK_BOT_TOKEN) : Promise.resolve(NOT_CONFIGURED),
+    cfg.NOTION_API_KEY ? pingNotion(cfg.NOTION_API_KEY) : Promise.resolve(NOT_CONFIGURED),
+    verifyActiveCampaignToken(),
+    cfg.POSTIZ_API_URL && cfg.POSTIZ_API_KEY
+      ? pingPostiz(cfg.POSTIZ_API_URL, cfg.POSTIZ_API_KEY)
+      : Promise.resolve(NOT_CONFIGURED),
+    cfg.APPFLOWY_API_URL ? pingAppFlowy(cfg.APPFLOWY_API_URL) : Promise.resolve(NOT_CONFIGURED),
+    cfg.N8N_API_URL && cfg.N8N_API_KEY
+      ? pingN8n(cfg.N8N_API_URL, cfg.N8N_API_KEY)
+      : Promise.resolve(NOT_CONFIGURED),
+  ]);
 
   const acStatusMap: Record<string, IntegrationStatus> = {
     valid: "configured",
@@ -351,6 +392,20 @@ async function buildPingedReports(cfg: Cfg): Promise<IntegrationReport[]> {
       category: "social_ads",
       ...postizResult,
       setupUrl: cfg.POSTIZ_API_URL || "https://postiz.cloudless.gr",
+    },
+    {
+      id: "appflowy",
+      name: "AppFlowy Cloud (Notion replacement)",
+      category: "content",
+      ...appflowyResult,
+      setupUrl: cfg.APPFLOWY_API_URL || "https://appflowy.cloudless.gr",
+    },
+    {
+      id: "n8n",
+      name: "n8n (workflow automation)",
+      category: "automation",
+      ...n8nResult,
+      setupUrl: cfg.N8N_API_URL || "https://n8n.cloudless.gr",
     },
   ];
 }

--- a/src/lib/appflowy.ts
+++ b/src/lib/appflowy.ts
@@ -1,0 +1,199 @@
+/**
+ * AppFlowy Cloud HTTP client — read-side surface for /admin/integrations and
+ * the appflowy-to-lake ETL. AppFlowy Cloud's REST API is documented at
+ * https://github.com/AppFlowy-IO/AppFlowy-Cloud — authentication is the same
+ * GoTrue JWT the SPA uses.
+ *
+ * Two auth modes:
+ *
+ * 1. **Service-role JWT** — sign with `GOTRUE_JWT_SECRET` (HS256, role=
+ *    "supabase_admin"). Bypasses per-user RLS; safe for read-only admin
+ *    queries. Use this for /admin/integrations and ETL.
+ * 2. **User JWT** — pass-through of the SPA's access_token. Use when calling
+ *    on behalf of a logged-in user (no current consumer).
+ *
+ * Config (SSM or env):
+ *   APPFLOWY_API_URL          base URL, e.g. https://appflowy.cloudless.gr
+ *   APPFLOWY_JWT_SECRET       same value as cluster Secret appflowy-secrets/GOTRUE_JWT_SECRET
+ *
+ * Both unconfigured → typed `AppFlowyNotConfiguredError` so callers can fall
+ * back to "not wired yet" without crashing.
+ */
+import { createHmac } from "node:crypto";
+import { getConfig } from "@/lib/ssm-config";
+
+export class AppFlowyNotConfiguredError extends Error {
+  constructor() {
+    super("AppFlowy API not configured (APPFLOWY_API_URL or APPFLOWY_JWT_SECRET missing)");
+    this.name = "AppFlowyNotConfiguredError";
+  }
+}
+
+export class AppFlowyApiError extends Error {
+  constructor(
+    public readonly status: number,
+    public readonly body: string
+  ) {
+    super(`AppFlowy API error ${status}: ${body.slice(0, 200)}`);
+    this.name = "AppFlowyApiError";
+  }
+}
+
+interface AppFlowyConfig {
+  baseUrl: string;
+  jwtSecret: string;
+}
+
+async function getAppFlowyConfig(): Promise<AppFlowyConfig> {
+  const cfg = await getConfig();
+  if (!cfg.APPFLOWY_API_URL || !cfg.APPFLOWY_JWT_SECRET) {
+    throw new AppFlowyNotConfiguredError();
+  }
+  return {
+    baseUrl: cfg.APPFLOWY_API_URL.replace(/\/$/, ""),
+    jwtSecret: cfg.APPFLOWY_JWT_SECRET,
+  };
+}
+
+// Base64url without external deps
+function b64url(input: Buffer | string): string {
+  return Buffer.from(input)
+    .toString("base64")
+    .replace(/=+$/, "")
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_");
+}
+
+/**
+ * Mint a short-lived service-role JWT. Mirrors the shape GoTrue issues for
+ * admin grants: `role: "supabase_admin"`, audience empty, 5-minute expiry.
+ */
+function signServiceJwt(secret: string): string {
+  const header = { alg: "HS256", typ: "JWT" };
+  const now = Math.floor(Date.now() / 1000);
+  const payload = {
+    aud: "",
+    role: "supabase_admin",
+    iss: "cloudless-appflowy-client",
+    iat: now,
+    exp: now + 300,
+  };
+  const head = b64url(JSON.stringify(header));
+  const body = b64url(JSON.stringify(payload));
+  const sig = b64url(createHmac("sha256", secret).update(`${head}.${body}`).digest());
+  return `${head}.${body}.${sig}`;
+}
+
+async function appflowyFetch(
+  path: string,
+  init: RequestInit & { timeoutMs?: number } = {}
+): Promise<Response> {
+  const { baseUrl, jwtSecret } = await getAppFlowyConfig();
+  const { timeoutMs, headers, ...rest } = init;
+  return fetch(`${baseUrl}/api${path}`, {
+    ...rest,
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${signServiceJwt(jwtSecret)}`,
+      ...headers,
+    },
+    signal: AbortSignal.timeout(timeoutMs ?? 10_000),
+  });
+}
+
+async function callThrowing<T>(
+  path: string,
+  init: RequestInit & { timeoutMs?: number } = {}
+): Promise<T> {
+  const res = await appflowyFetch(path, init);
+  if (!res.ok) throw new AppFlowyApiError(res.status, await res.text().catch(() => ""));
+  return (await res.json()) as T;
+}
+
+// ---------------------------------------------------------------------------
+// Read surface used by /admin/integrations + ETL
+// ---------------------------------------------------------------------------
+
+export async function isAppFlowyConfigured(): Promise<boolean> {
+  try {
+    await getAppFlowyConfig();
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/** GET /api/health — public, no auth. Returns true if AC pod is responsive. */
+export async function pingAppFlowyHealth(): Promise<boolean> {
+  try {
+    const cfg = await getAppFlowyConfig();
+    const r = await fetch(`${cfg.baseUrl}/api/health`, {
+      signal: AbortSignal.timeout(5_000),
+    });
+    return r.ok;
+  } catch {
+    return false;
+  }
+}
+
+export interface AppFlowyWorkspace {
+  workspace_id: string;
+  workspace_name: string;
+  owner_uid: number;
+  member_count: number;
+  created_at: string;
+}
+
+/**
+ * Lists every workspace visible to the service-role JWT. Used by ETL +
+ * the admin page tile. Returns empty array on unconfigured.
+ */
+export async function listAllWorkspaces(): Promise<AppFlowyWorkspace[]> {
+  try {
+    const r = await callThrowing<{ data: AppFlowyWorkspace[] }>("/admin/workspace");
+    return r.data ?? [];
+  } catch (e) {
+    if (e instanceof AppFlowyNotConfiguredError) return [];
+    throw e;
+  }
+}
+
+export interface AppFlowyUserSummary {
+  uid: number;
+  uuid: string;
+  email: string;
+  name: string;
+  created_at: string;
+}
+
+export async function listAllUsers(): Promise<AppFlowyUserSummary[]> {
+  try {
+    const r = await callThrowing<{ data: AppFlowyUserSummary[] }>("/admin/user");
+    return r.data ?? [];
+  } catch (e) {
+    if (e instanceof AppFlowyNotConfiguredError) return [];
+    throw e;
+  }
+}
+
+/** Lightweight summary for the admin dashboard tile. */
+export async function getAppFlowySummary(): Promise<{
+  configured: boolean;
+  healthy: boolean;
+  workspaceCount: number;
+  userCount: number;
+}> {
+  const configured = await isAppFlowyConfigured();
+  if (!configured) return { configured: false, healthy: false, workspaceCount: 0, userCount: 0 };
+  const [healthy, workspaces, users] = await Promise.all([
+    pingAppFlowyHealth(),
+    listAllWorkspaces().catch(() => [] as AppFlowyWorkspace[]),
+    listAllUsers().catch(() => [] as AppFlowyUserSummary[]),
+  ]);
+  return {
+    configured: true,
+    healthy,
+    workspaceCount: workspaces.length,
+    userCount: users.length,
+  };
+}

--- a/src/lib/integrations.ts
+++ b/src/lib/integrations.ts
@@ -69,6 +69,15 @@ export interface IntegrationConfig {
   ESPOCRM_BASE_URL?: string;
   ESPOCRM_API_KEY?: string;
   ESPOCRM_WEBHOOK_SECRET?: string;
+  // AppFlowy Cloud (Notion replacement, self-hosted on omv k3s; see skills/appflowy-operator)
+  APPFLOWY_API_URL?: string;
+  APPFLOWY_JWT_SECRET?: string;
+  // n8n workflow automation (self-hosted on omv k3s; X-N8N-API-KEY auth)
+  N8N_API_URL?: string;
+  N8N_API_KEY?: string;
+  // Postiz (social scheduler) API key — used by lib/postiz.ts + admin/postiz console
+  POSTIZ_API_URL?: string;
+  POSTIZ_API_KEY?: string;
 }
 
 let cached: IntegrationConfig | null = null;
@@ -128,6 +137,12 @@ export function getIntegrations(): IntegrationConfig {
     ESPOCRM_BASE_URL: process.env.ESPOCRM_BASE_URL,
     ESPOCRM_API_KEY: process.env.ESPOCRM_API_KEY,
     ESPOCRM_WEBHOOK_SECRET: process.env.ESPOCRM_WEBHOOK_SECRET,
+    APPFLOWY_API_URL: process.env.APPFLOWY_API_URL,
+    APPFLOWY_JWT_SECRET: process.env.APPFLOWY_JWT_SECRET,
+    N8N_API_URL: process.env.N8N_API_URL,
+    N8N_API_KEY: process.env.N8N_API_KEY,
+    POSTIZ_API_URL: process.env.POSTIZ_API_URL,
+    POSTIZ_API_KEY: process.env.POSTIZ_API_KEY,
   };
 
   return cached;
@@ -236,6 +251,12 @@ export async function getIntegrationsAsync(): Promise<IntegrationConfig> {
       ESPOCRM_API_KEY: envCfg.ESPOCRM_API_KEY || ssm.ESPOCRM_API_KEY || undefined,
       ESPOCRM_WEBHOOK_SECRET:
         envCfg.ESPOCRM_WEBHOOK_SECRET || ssm.ESPOCRM_WEBHOOK_SECRET || undefined,
+      APPFLOWY_API_URL: envCfg.APPFLOWY_API_URL || ssm.APPFLOWY_API_URL || undefined,
+      APPFLOWY_JWT_SECRET: envCfg.APPFLOWY_JWT_SECRET || ssm.APPFLOWY_JWT_SECRET || undefined,
+      N8N_API_URL: envCfg.N8N_API_URL || ssm.N8N_API_URL || undefined,
+      N8N_API_KEY: envCfg.N8N_API_KEY || ssm.N8N_API_KEY || undefined,
+      POSTIZ_API_URL: envCfg.POSTIZ_API_URL || ssm.POSTIZ_API_URL || undefined,
+      POSTIZ_API_KEY: envCfg.POSTIZ_API_KEY || ssm.POSTIZ_API_KEY || undefined,
     };
   } catch (err) {
     console.warn("[Integrations] SSM fallback failed, using env-only config:", err);

--- a/src/lib/n8n.ts
+++ b/src/lib/n8n.ts
@@ -1,0 +1,168 @@
+/**
+ * n8n public API client — read-side for /admin/integrations and the
+ * n8n-to-lake ETL. Auth is `X-N8N-API-KEY` header; key is generated in n8n
+ * Settings → API and stored at SSM `/cloudless/production/N8N_API_KEY`.
+ *
+ * Endpoints exposed by n8n's public REST API (≥ 1.20):
+ *   GET  /api/v1/workflows
+ *   GET  /api/v1/executions
+ *   GET  /api/v1/users         (Enterprise; falls back to single-user mode)
+ *
+ * Config (SSM or env):
+ *   N8N_API_URL       base URL, e.g. https://n8n.cloudless.gr
+ *   N8N_API_KEY       JWT-style key starting with n8n_api_
+ *
+ * Both unconfigured → `N8nNotConfiguredError`.
+ */
+import { getConfig } from "@/lib/ssm-config";
+
+export class N8nNotConfiguredError extends Error {
+  constructor() {
+    super("n8n API not configured (N8N_API_URL or N8N_API_KEY missing)");
+    this.name = "N8nNotConfiguredError";
+  }
+}
+
+export class N8nApiError extends Error {
+  constructor(
+    public readonly status: number,
+    public readonly body: string
+  ) {
+    super(`n8n API error ${status}: ${body.slice(0, 200)}`);
+    this.name = "N8nApiError";
+  }
+}
+
+async function getN8nConfig(): Promise<{ baseUrl: string; apiKey: string }> {
+  const cfg = await getConfig();
+  if (!cfg.N8N_API_URL || !cfg.N8N_API_KEY) throw new N8nNotConfiguredError();
+  return {
+    baseUrl: cfg.N8N_API_URL.replace(/\/$/, ""),
+    apiKey: cfg.N8N_API_KEY,
+  };
+}
+
+async function n8nFetch(
+  path: string,
+  init: RequestInit & { timeoutMs?: number } = {}
+): Promise<Response> {
+  const { baseUrl, apiKey } = await getN8nConfig();
+  const { timeoutMs, headers, ...rest } = init;
+  return fetch(`${baseUrl}/api/v1${path}`, {
+    ...rest,
+    headers: {
+      Accept: "application/json",
+      "X-N8N-API-KEY": apiKey,
+      ...headers,
+    },
+    signal: AbortSignal.timeout(timeoutMs ?? 10_000),
+  });
+}
+
+async function callThrowing<T>(
+  path: string,
+  init: RequestInit & { timeoutMs?: number } = {}
+): Promise<T> {
+  const r = await n8nFetch(path, init);
+  if (!r.ok) throw new N8nApiError(r.status, await r.text().catch(() => ""));
+  return (await r.json()) as T;
+}
+
+export async function isN8nConfigured(): Promise<boolean> {
+  try {
+    await getN8nConfig();
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export async function pingN8nHealth(): Promise<boolean> {
+  try {
+    const cfg = await getN8nConfig();
+    const r = await fetch(`${cfg.baseUrl}/healthz`, {
+      signal: AbortSignal.timeout(5_000),
+    });
+    return r.ok;
+  } catch {
+    return false;
+  }
+}
+
+export interface N8nWorkflow {
+  id: string;
+  name: string;
+  active: boolean;
+  createdAt: string;
+  updatedAt: string;
+  tags?: { id: string; name: string }[];
+}
+
+export async function listWorkflows(activeOnly = false): Promise<N8nWorkflow[]> {
+  try {
+    const r = await callThrowing<{ data: N8nWorkflow[] }>(
+      `/workflows?active=${activeOnly ? "true" : "false"}&limit=250`
+    );
+    return r.data ?? [];
+  } catch (e) {
+    if (e instanceof N8nNotConfiguredError) return [];
+    throw e;
+  }
+}
+
+export interface N8nExecution {
+  id: string;
+  finished: boolean;
+  mode: string;
+  startedAt: string;
+  stoppedAt: string | null;
+  workflowId: string;
+  status: "success" | "error" | "running" | "waiting" | "canceled";
+}
+
+export async function listRecentExecutions(limit = 100): Promise<N8nExecution[]> {
+  const capped = Math.max(1, Math.min(limit, 250));
+  try {
+    const r = await callThrowing<{ data: N8nExecution[] }>(
+      `/executions?limit=${capped}&includeData=false`
+    );
+    return r.data ?? [];
+  } catch (e) {
+    if (e instanceof N8nNotConfiguredError) return [];
+    throw e;
+  }
+}
+
+export async function getN8nSummary(): Promise<{
+  configured: boolean;
+  healthy: boolean;
+  workflowCount: number;
+  activeWorkflowCount: number;
+  recentExecutionCount: number;
+  recentFailureCount: number;
+}> {
+  const configured = await isN8nConfigured();
+  if (!configured) {
+    return {
+      configured: false,
+      healthy: false,
+      workflowCount: 0,
+      activeWorkflowCount: 0,
+      recentExecutionCount: 0,
+      recentFailureCount: 0,
+    };
+  }
+  const [healthy, all, execs] = await Promise.all([
+    pingN8nHealth(),
+    listWorkflows(false).catch(() => [] as N8nWorkflow[]),
+    listRecentExecutions(100).catch(() => [] as N8nExecution[]),
+  ]);
+  return {
+    configured: true,
+    healthy,
+    workflowCount: all.length,
+    activeWorkflowCount: all.filter((w) => w.active).length,
+    recentExecutionCount: execs.length,
+    recentFailureCount: execs.filter((e) => e.status === "error").length,
+  };
+}

--- a/src/lib/ssm-config.ts
+++ b/src/lib/ssm-config.ts
@@ -41,6 +41,18 @@ interface AppConfig {
   ESPOCRM_API_KEY: string;
   /** Shared secret for EspoCRM webhook URL query-param auth. */
   ESPOCRM_WEBHOOK_SECRET: string;
+  /** AppFlowy Cloud base URL (Notion replacement, see skills/appflowy-operator). */
+  APPFLOWY_API_URL: string;
+  /** Shared GoTrue JWT secret for signing service-role JWTs against AppFlowy. */
+  APPFLOWY_JWT_SECRET: string;
+  /** n8n base URL. */
+  N8N_API_URL: string;
+  /** n8n public API key (X-N8N-API-KEY). */
+  N8N_API_KEY: string;
+  /** Postiz base URL. */
+  POSTIZ_API_URL: string;
+  /** Postiz organization API key (Settings → Public API). */
+  POSTIZ_API_KEY: string;
   NOTION_API_KEY: string;
   NOTION_BLOG_DB_ID: string;
   NOTION_WEBHOOK_SECRET: string;
@@ -194,6 +206,12 @@ function buildConfigFromParams(params: Map<string, string>): AppConfig {
     ESPOCRM_BASE_URL: params.get("ESPOCRM_BASE_URL") ?? "",
     ESPOCRM_API_KEY: params.get("ESPOCRM_API_KEY") ?? "",
     ESPOCRM_WEBHOOK_SECRET: params.get("ESPOCRM_WEBHOOK_SECRET") ?? "",
+    APPFLOWY_API_URL: params.get("APPFLOWY_API_URL") ?? "",
+    APPFLOWY_JWT_SECRET: params.get("APPFLOWY_JWT_SECRET") ?? "",
+    N8N_API_URL: params.get("N8N_API_URL") ?? "",
+    N8N_API_KEY: params.get("N8N_API_KEY") ?? "",
+    POSTIZ_API_URL: params.get("POSTIZ_API_URL") ?? "",
+    POSTIZ_API_KEY: params.get("POSTIZ_API_KEY") ?? "",
     NOTION_API_KEY: params.get("NOTION_API_KEY") ?? "",
     NOTION_BLOG_DB_ID: params.get("NOTION_BLOG_DB_ID") ?? "",
     NOTION_WEBHOOK_SECRET: params.get("NOTION_WEBHOOK_SECRET") ?? "",
@@ -275,6 +293,12 @@ function buildConfigFromEnv(): AppConfig {
     ESPOCRM_BASE_URL: process.env.ESPOCRM_BASE_URL || "",
     ESPOCRM_API_KEY: process.env.ESPOCRM_API_KEY || "",
     ESPOCRM_WEBHOOK_SECRET: process.env.ESPOCRM_WEBHOOK_SECRET || "",
+    APPFLOWY_API_URL: process.env.APPFLOWY_API_URL || "",
+    APPFLOWY_JWT_SECRET: process.env.APPFLOWY_JWT_SECRET || "",
+    N8N_API_URL: process.env.N8N_API_URL || "",
+    N8N_API_KEY: process.env.N8N_API_KEY || "",
+    POSTIZ_API_URL: process.env.POSTIZ_API_URL || "",
+    POSTIZ_API_KEY: process.env.POSTIZ_API_KEY || "",
     NOTION_API_KEY: process.env.NOTION_API_KEY || "",
     NOTION_BLOG_DB_ID: process.env.NOTION_BLOG_DB_ID || "",
     NOTION_WEBHOOK_SECRET: process.env.NOTION_WEBHOOK_SECRET || "",

--- a/tools/cognito-setup-mcp/src/index.ts
+++ b/tools/cognito-setup-mcp/src/index.ts
@@ -160,7 +160,7 @@ server.tool(
       copyFileSync(ENV_LOCAL, backupPath);
 
       // Update credentials
-      let updated = envContent
+      const updated = envContent
         .split("\n")
         .map((line) => {
           if (line.startsWith("NEXT_PUBLIC_COGNITO_CLIENT_ID=")) {


### PR DESCRIPTION
Adds first-class self-hosted-app integration to cloudless.gr: client libs, health probes in the existing /admin/integrations dashboard, 3 daily ETLs to S3 Parquet, and Athena DDL for cross-app analytics views. SSM-direct config (no build-arg leakage). All 3 ETLs are continue-on-error so a single broken token does not block the others.

Operator follow-up: PutParameter the 6 new SSM keys (recipe in PR description).