### PR TITLE
docs(skills): unified admin bootstrap + alertmanager Slack canonical + n8n LimitRange

### DIFF
--- a/infrastructure/n8n/limitrange.yaml
+++ b/infrastructure/n8n/limitrange.yaml
@@ -1,0 +1,25 @@
+# n8n namespace LimitRange — bumped 2026-06-21 from 384Mi to 1Gi after the
+# upstream image bump (1.44.1 → latest, which is now ≥ 1.84). The newer
+# n8n binary plus migrations + Task Broker peak around 350-450Mi at boot;
+# the old 384Mi cap caused OOMKilled before migrations finished.
+#
+# Apply on a fresh cluster bootstrap; otherwise this YAML matches the
+# live state on omv. The Deployment requests 200Mi / limits 512Mi which
+# fits comfortably under the new max.
+apiVersion: v1
+kind: LimitRange
+metadata:
+  name: default-container-limits
+  namespace: n8n
+spec:
+  limits:
+    - type: Container
+      default:
+        cpu: 500m
+        memory: 512Mi
+      defaultRequest:
+        cpu: 50m
+        memory: 200Mi
+      max:
+        cpu: "2"
+        memory: 1Gi

--- a/skills/alertmanager-slack/SKILL.md
+++ b/skills/alertmanager-slack/SKILL.md
@@ -1,0 +1,162 @@
+---
+name: alertmanager-slack
+description: |
+  How alerts reach Slack on the cloudless.gr k3s cluster (NOT via
+  Alertmanager directly). Triggered by phrases like "alert-manager Slack
+  receiver", "no_active_hooks error", "fix Slack alerts", "why isn't my
+  alert showing in Slack", "add Slack to Prometheus alerts", "AlertmanagerConfig
+  CRD", "kube-prometheus-stack Slack", or any incident where the operator
+  expects Slack notifications and isn't seeing them.
+---
+
+# Alertmanager → Slack on cloudless.gr
+
+**TL;DR:** Alertmanager has **no Slack receiver**. By design. All Slack
+notifications come from in-cluster CronJobs that call Slack's
+`chat.postMessage` directly with a bot token via the `SlackClient`
+pattern. This is the result of the 2026-06-21 cleanup that removed the
+`AlertmanagerConfig/slack-routing` CRD after its embedded webhook URL
+went dead and Alertmanager kept logging `no_active_hooks`.
+
+## Current Alertmanager receivers
+
+After the 2026-06-21 cleanup, Alertmanager has exactly three receivers:
+
+| Receiver | Type | Destination |
+| --- | --- | --- |
+| `null` | drop | Watchdog + info-severity alerts that we explicitly silence |
+| `oncall` | webhook | Internal oncall service (whatever's connected) |
+| `alert-api` | webhook | `http://alert-api.alert-manager.svc.cluster.local:8080/api/alertmanager/webhook` — the in-cluster alert-api pod which has its own Slack delivery + dedup DB |
+
+That's it. **No `slack_configs` block anywhere.** Adding one back would
+violate [[feedback-slack-use-slackclient]] (raw webhooks bypass the
+retry/backoff/fallback in `SlackClient`).
+
+## Why we don't use Alertmanager's `slack_configs`
+
+Per [Prometheus Alertmanager docs](https://prometheus.io/docs/alerting/latest/configuration/#slack_config),
+`slack_configs.api_url` MUST be a Slack Incoming Webhook URL. Incoming
+webhooks:
+
+- Cannot be minted or rotated programmatically from a bot token (they
+  require an admin OAuth scope on a separately-installed Slack app).
+- Are scoped to ONE channel each (changing channel = re-mint).
+- Don't return useful errors — a wrong URL silently 404s, and a removed
+  webhook returns `no_active_hooks` with no actionable info.
+
+The cloudless.gr stack standardised on `chat.postMessage` with a bot
+token instead because:
+- The bot token rotates from one place (Slack workspace UI → app).
+- We can post to any channel the bot is in without redeploying.
+- Errors are typed (`channel_not_found`, `not_in_channel`, etc.) so the
+  Slack monitoring [[feedback-slack-use-slackclient]] knows when to retry
+  vs surface.
+
+## Where alerts → Slack actually happens
+
+Three in-cluster paths, all using the bot token from
+`cluster-alerts-secret/SLACK_BOT_TOKEN`:
+
+1. **`alert-api` Deployment** (`alert-manager` namespace) — accepts
+   Alertmanager webhook POSTs, dedups via SQLite, posts to Slack with
+   its own `SLACK_WEBHOOK_URL` env. Already works; both routes from
+   Alertmanager (`oncall` + `alert-api`) cover all warning/critical
+   severities.
+2. **CronJob watchdogs** in the `monitoring` namespace:
+   - `omv-disk-watchdog` (every 15min) — `df` thresholds
+   - `omv-backup-verify` (daily) — last-backup-age
+   - `postiz-slack-notify` (every 5min)
+   - `cloudflared-drift-check` (every 6h) — see PR #1053
+   Each one curls `https://slack.com/api/chat.postMessage` directly
+   with `Authorization: Bearer $SLACK_BOT_TOKEN` and channel ID
+   `C09AF5W3X16` (proven working; `#errors`/`#notifications` return
+   `channel_not_found`).
+3. **App-level webhooks** for EspoCRM (6 Webhook entities) +
+   integration receivers — routed through
+   `src/app/api/webhooks/espocrm/route.ts` which uses `SlackClient`.
+
+## "I see no_active_hooks errors"
+
+That error means SOMETHING is still trying to deliver to a removed
+webhook. Source order to check:
+
+1. **Stray AlertmanagerConfig CRDs** —
+   `kubectl get alertmanagerconfig -A`. If you see a `slack-routing` or
+   similar, it was added after the 2026-06-21 cleanup; either delete it
+   or replace its `slackConfigs` with a `webhookConfigs` pointing at an
+   in-cluster proxy.
+2. **alert-api's own `SLACK_WEBHOOK_URL`** — `kubectl describe deploy
+   alert-api -n alert-manager`. If the webhook is dead, mint a fresh one
+   in Slack workspace UI (Settings → Manage apps → cloudless-alerts →
+   Incoming Webhooks → Add New), update
+   `alert-api-secrets/SLACK_WEBHOOK_URL`, restart the pod.
+3. **Other consumers** — `grep -rE 'hooks.slack.com/services' /etc/`
+   on omv via the privileged-pod pattern. Any hard-coded webhook URL is
+   suspect.
+
+## Adding a new alert → Slack path
+
+DO NOT add it to Alertmanager. Instead, write a CronJob in `monitoring`
+namespace following the canonical template
+[`monitoring/cloudflared-drift.yaml`](../../infrastructure/monitoring/cloudflared-drift.yaml):
+
+```yaml
+env:
+  - name: SLACK_BOT_TOKEN
+    valueFrom: { secretKeyRef: { name: cluster-alerts-secret, key: SLACK_BOT_TOKEN } }
+  - name: SLACK_CHANNEL_ID
+    value: "C09AF5W3X16"   # proven working
+command:
+  - sh
+  - -c
+  - |
+    # ... your check ...
+    if [ "$ALERT_CONDITION" ]; then
+      curl -fsS -X POST https://slack.com/api/chat.postMessage \
+        -H "Authorization: Bearer $SLACK_BOT_TOKEN" \
+        -H "Content-Type: application/json; charset=utf-8" \
+        --data "$(jq -nc --arg ch "$SLACK_CHANNEL_ID" --arg msg "..." '{channel: $ch, text: $msg}')"
+    fi
+```
+
+For application code (Next.js routes, Lambdas), always go through
+`SlackClient` — never raw `chat.postMessage` — so retry/backoff/webhook-
+fallback are preserved (see [[feedback-slack-use-slackclient]]).
+
+## If you absolutely must add a Slack receiver to Alertmanager
+
+For the very narrow case where you want Alertmanager's grouping/inhibit
+logic to drive Slack directly (rare; alert-api already does this with
+better dedup), deploy a small chat.postMessage proxy in the cluster and
+have Alertmanager `webhook_configs.url` point at it:
+
+```yaml
+apiVersion: monitoring.coreos.com/v1alpha1
+kind: AlertmanagerConfig
+metadata:
+  name: slack-proxy
+  namespace: monitoring
+spec:
+  receivers:
+    - name: slack-proxy
+      webhookConfigs:
+        - url: http://slack-proxy.monitoring.svc.cluster.local:8080/webhook
+          sendResolved: true
+  route:
+    receiver: slack-proxy
+    matchers: [{ name: severity, matchType: =~, value: "warning|critical" }]
+```
+
+The proxy reads `SLACK_BOT_TOKEN` from `cluster-alerts-secret`, accepts
+Alertmanager's JSON payload, and POSTs to chat.postMessage. ~30 LoC.
+
+But first ask: does alert-api not already cover this? In most cases the
+answer is yes and the new path is redundant.
+
+## See also
+
+- `skills/cluster-bash/SKILL.md`
+- `skills/cloudflare-tunnel-ops/SKILL.md`
+- `infrastructure/monitoring/cloudflared-drift.yaml` — CronJob+Slack template
+- `infrastructure/monitoring/omv-watchdogs.yaml` — three more CronJob examples
+- Memory: `feedback_slack_use_slackclient`, `feedback_slack_lambda_env_frozen`

--- a/skills/selfhosted-admin-bootstrap/SKILL.md
+++ b/skills/selfhosted-admin-bootstrap/SKILL.md
@@ -1,0 +1,164 @@
+---
+name: selfhosted-admin-bootstrap
+description: |
+  Add the unified admin account (tbaltzakis@cloudless.gr / TH!123789th!) to
+  any self-hosted app on the cloudless.gr k3s cluster. Triggered by phrases
+  like "add admin to <app>", "give me admin on <app>", "create my account
+  on the new self-hosted app", "bootstrap admin on <app>", "rotate the
+  admin password across all apps", "I can't log into <app>", or any setup of
+  a freshly deployed self-hosted service.
+---
+
+# Unified admin bootstrap toolkit
+
+cloudless.gr's self-hosted stack runs **one** admin identity across every
+app: **`tbaltzakis@cloudless.gr`** (or username `tbaltzakis` where email
+isn't supported) with password **`TH!123789th!`**. Rotating the password
+on all apps is a single sweep.
+
+This skill captures the per-app bootstrap recipe so future-you doesn't have
+to re-derive the right table / API call / CLI command each time. Every
+recipe is **idempotent** — re-running it sets the password without
+breaking existing data.
+
+## Inventory at time of writing (2026-06-21)
+
+| App | URL | Username | How admin is marked |
+| --- | --- | --- | --- |
+| AppFlowy | https://appflowy.cloudless.gr/console | `tbaltzakis@cloudless.gr` | `auth.users.is_super_admin=true` + `af_user`/`af_workspace`/`af_workspace_member` rows |
+| EspoCRM | https://espocrm.cloudless.gr/ | `tbaltzakis` | `user.type='admin'` + email link in `entity_email_address` |
+| Postiz | https://postiz.cloudless.gr/ | `tbaltzakis@cloudless.gr` | `User.isSuperAdmin=true` + `UserOrganization.role='SUPERADMIN'` |
+| Grafana | https://grafana.cloudless.gr/ | `tbaltzakis` | `isGrafanaAdmin=true` via REST API |
+| n8n | https://n8n.cloudless.gr/ | `tbaltzakis@cloudless.gr` | `user.role='global:admin'` |
+| ntfy | (internal) | `tbaltzakis` | `ntfy user add --role=admin` |
+
+The full per-app bootstrap commands live in
+[`project_unified_admin_creds`](../../) memory entry.
+
+## The five patterns by storage type
+
+Every new app falls into one of these:
+
+1. **Postgres with bcrypt** (AppFlowy/GoTrue, Postiz, EspoCRM) →
+   `crypt(pw, gen_salt('bf', 10))` via pgcrypto.
+2. **SQLite with bcrypt** (n8n) → spawn an Alpine sidecar pod mounting the
+   PVC, install python3+bcrypt, write the hash directly.
+3. **MariaDB** (EspoCRM) → use the app's own CLI (`php command.php
+   create-admin-user`) rather than direct insert; passwords are hashed via
+   app-specific algorithms that change between versions.
+4. **REST API with admin bootstrap key** (Grafana) → `POST /api/admin/users`
+   with basic auth from the cluster's admin Secret, then PUT permissions +
+   PATCH org role.
+5. **CLI tool with auth.db** (ntfy) → `ntfy user add --role=admin` with
+   `NTFY_PASSWORD` env. If user already exists, `ntfy user del` first.
+
+## Tool selection — pick the most specific that fits
+
+1. **App has a documented bootstrap CLI?** Use it. EspoCRM
+   (`php command.php create-admin-user`) + ntfy (`ntfy user add`) are the
+   gold standard — no DB knowledge required, version-resilient.
+
+2. **App has an admin REST API + a known admin password?** Use that.
+   Grafana's `POST /api/admin/users` with `GF_SECURITY_ADMIN_PASSWORD`
+   from the deployment env is the canonical example.
+
+3. **App stores users in Postgres + you have direct access?** Use the
+   pgcrypto recipe. Critical: GoTrue/Postiz schemas are partial-indexed on
+   `(email, providerName)` so you can't use `ON CONFLICT (email)`.
+
+4. **App stores users in SQLite inside a PVC?** Spawn an alpine sidecar
+   pod with the PVC mounted. The container running the app usually doesn't
+   have python or sqlite3 installed (and isn't root); a sidecar bypasses
+   both problems.
+
+## Common quirks (cost real time the first round)
+
+### AppFlowy: `aud` field must be empty for password grant
+
+GoTrue's password grant matches user by `(instance_id, aud, email)`. If
+you set `aud='supabase_admin'` to mark the user as super-admin, the
+password grant returns `invalid_credentials` — even though the bcrypt hash
+validates. Set `aud=''` (empty) + `role='authenticated'` + the actual
+super-admin marker is `is_super_admin=true`.
+
+### AppFlowy: bootstrap trigger doesn't fire
+
+AppFlowy Cloud's auth.users → public.af_user mirror runs ONLY on auth.users
+INSERT. The user GoTrue auto-creates from the env `GOTRUE_ADMIN_EMAIL` does
+NOT trigger the mirror (race condition: GoTrue's admin bootstrap runs
+before AppFlowy Cloud finishes its migrations). Always backfill
+`af_user` + `af_workspace` + `af_workspace_member` after creating an
+auth.users row.
+
+### EspoCRM: `set-password` writes to stdin
+
+`php command.php set-password <user>` reads the new password from stdin
+TWICE (new + confirm). Pipe with `yes 'pw' | php command.php set-password`
+or use the create-admin-user CLI's `--password=` flag in one shot.
+
+### EspoCRM: email is in a separate table
+
+`user.email_address` doesn't exist as a column — emails live in
+`email_address` + `entity_email_address` (column is `` `primary` ``, a
+reserved word, requires backticks). Without the link, the user can't
+receive notifications but CAN still log in by username.
+
+### Postiz: composite unique index
+
+The unique constraint is `(email, providerName)` not `email` alone. Use
+`WHERE NOT EXISTS` patterns instead of `ON CONFLICT (email)`.
+
+### n8n: container is non-root + no sqlite3
+
+The n8n image runs as uid 1000 with no apk/sudo. Don't try to install
+sqlite3 in-pod — spawn an Alpine sidecar mounting the PVC instead.
+
+### ntfy: `user add` doesn't accept passwords as flag
+
+Pass `NTFY_PASSWORD` as env. The CLI rejects passwords passed via `-p`.
+
+## When you need to add admin to a brand-new self-hosted app
+
+The pattern from this skill applies, but you'll also want to:
+
+1. Add the app's host to the unified Cloudflare tunnel — see
+   `skills/cloudflare-tunnel-ops/SKILL.md`.
+2. Add an integration health-check entry in
+   `src/app/api/admin/integrations/status/route.ts` (pattern: ping a public
+   health endpoint, return `configured`/`degraded`/`error`).
+3. If the app has an admin REST API worth automating, write a client lib
+   at `src/lib/<app>.ts` mirroring `src/lib/n8n.ts` (X-API-KEY pattern) or
+   `src/lib/appflowy.ts` (JWT-signing pattern).
+4. If the app produces data worth analytics on, write
+   `scripts/etl/<app>-to-lake.mjs` and add it to
+   `.github/workflows/etl-selfhosted-to-lake.yml`.
+5. Update the unified admin table in
+   `project_unified_admin_creds.md` memory entry.
+
+## Rotation runbook (rotate password across all apps)
+
+Run each per-app block from
+[`project_unified_admin_creds`](../../) with the new password. The five
+patterns above all support idempotent overwrite — no user data is lost.
+
+After rotation, verify each app with:
+
+```bash
+curl -X POST 'https://appflowy.cloudless.gr/gotrue/token?grant_type=password' \
+  -H 'Content-Type: application/json' \
+  --data '{"email":"tbaltzakis@cloudless.gr","password":"NEW_PW"}' | jq -r '.access_token | length'
+# expect: token length > 0
+
+curl -sI -H "X-Api-Key: $NEW_ESPOCRM_KEY" https://espocrm.cloudless.gr/api/v1/App/user
+# expect: 200
+
+curl -X POST https://slack.com/api/auth.test -H "Authorization: Bearer $NEW_SLACK_TOKEN"
+# expect: ok=true
+```
+
+## See also
+
+- `skills/appflowy-operator/SKILL.md`
+- `skills/espocrm-operator/SKILL.md`
+- `skills/cloudflare-tunnel-ops/SKILL.md`
+- Memory: `project_unified_admin_creds`, `feedback_slack_use_slackclient`


### PR DESCRIPTION
Two new operator skills + one infra manifest from the 2026-06-21 work:

1. selfhosted-admin-bootstrap: per-app admin recipes (5 storage patterns) + per-app quirks + rotation runbook.
2. alertmanager-slack: documents the choice to NOT wire Alertmanager to Slack directly (per feedback_slack_use_slackclient). alert-api receiver + CronJobs handle Slack via bot-token chat.postMessage.
3. infrastructure/n8n/limitrange.yaml: bumped max memory to 1Gi for n8n 1.84+.

Operator action: AlertmanagerConfig/slack-routing was deleted (cluster-side, no_active_hooks errors stop now). n8n is on n8nio/n8n:latest with healthy /healthz.