### PR TITLE
fix(workflow): drop redundant pnpm version in etl-selfhosted-to-lake

### DIFF
--- a/.github/workflows/etl-selfhosted-to-lake.yml
+++ b/.github/workflows/etl-selfhosted-to-lake.yml
@@ -33,7 +33,6 @@ jobs:
       - uses: actions/checkout@v4
 
       - uses: pnpm/action-setup@v4
-        with: { version: 10 }
 
       - uses: actions/setup-node@v4
         with:


### PR DESCRIPTION
Conflicts with packageManager in package.json. Letting action-setup read from packageManager.