### PR TITLE
fix(monitoring): ESP32 cluster-only + nas-backup watchdog repurposed to k3s etcd snapshot

### DIFF
--- a/infrastructure/esp32-watchdog/README.md
+++ b/infrastructure/esp32-watchdog/README.md
@@ -13,24 +13,27 @@
 | Feature | How |
 |---|---|
 | External Pi probe | Pings `omv` (192.168.1.128) and `omv-ha` (192.168.1.130) every 30 s |
-| AWS app probe | HTTP GET `https://cloudless.gr` every 60 s |
-| RGB status LED | 8-state color matrix — see table below |
-| Push alerts | Posts to ntfy at `192.168.1.128:30080/cloudless-alerts` |
+| k3s API probe | HTTPS GET `omv:6443/livez` every 30 s; triggers hardware reset after 3 min unreachable |
+| RGB status LED | 4-state color matrix — cluster-only since 2026-06-21 (see table below) |
+| Push alerts | Posts to ntfy at `192.168.1.130:30080/cloudless-alerts` |
 | Prometheus `/metrics` | Scraped by kube-prometheus on port 9101 |
-| Grafana alerts | `PrometheusRule` fires for node-down, AWS-down, ESP32-down, weak Wi-Fi |
+| Grafana alerts | `PrometheusRule` fires for node-down, ESP32-down, weak Wi-Fi |
 
-### LED color matrix
+> **AWS probe removed 2026-06-21** — ESP32 watches CLUSTER ONLY per the
+> monitoring-scope cleanup. The `aws_up` global stays `true` so the LED
+> matrix collapses naturally to the 4-state cluster matrix below.
+> Re-enable by restoring the `aws_health` substitution, the `probe_aws`
+> interval, the `aws_app_reachable` binary_sensor, and the AWS branch of
+> `notify_alerts` in `cloudless-watchdog.yaml`.
 
-| AWS | omv | omv-ha | Color | Effect |
-|-----|-----|--------|-------|--------|
-| ✅ | ✅ | ✅ | 🟢 Green | Solid — everything healthy |
-| ❌ | ✅ | ✅ | 🟠 Orange | Slow blink — AWS only down |
-| ✅ | ❌ | ✅ | 🟡 Yellow | Slow blink — one Pi down |
-| ✅ | ✅ | ❌ | 🟡 Yellow | Slow blink — one Pi down |
-| ✅ | ❌ | ❌ | 🔴 Red | Fast blink — both Pi nodes down |
-| ❌ | ❌ | ✅ | 🔶 Deep orange | Fast blink — AWS + one Pi down |
-| ❌ | ✅ | ❌ | 🔶 Deep orange | Fast blink — AWS + one Pi down |
-| ❌ | ❌ | ❌ | 🟣 Magenta | Fast blink — total outage |
+### LED color matrix (cluster-only)
+
+| omv | omv-ha | Color | Effect |
+|-----|--------|-------|--------|
+| ✅ | ✅ | 🟢 Green | Solid — both cluster nodes healthy |
+| ❌ | ✅ | 🟡 Yellow | Slow blink — omv down, omv-ha up |
+| ✅ | ❌ | 🟡 Yellow | Slow blink — omv-ha down, omv up |
+| ❌ | ❌ | 🔴 Red | Fast blink — total cluster outage |
 
 Blue = booting / connecting to Wi-Fi.
 

--- a/infrastructure/esp32-watchdog/esphome/cloudless-watchdog.yaml
+++ b/infrastructure/esp32-watchdog/esphome/cloudless-watchdog.yaml
@@ -10,19 +10,20 @@
 # We probe Pi nodes via HTTP GET to their Prometheus port (:9100).
 # Any 2xx/3xx response = reachable; timeout/error = unreachable.
 #
-# LED STATE MATRIX
+# LED STATE MATRIX (cluster-only since 2026-06-21 — AWS probe removed)
 # ─────────────────────────────────────────────────────────────────────────────
-# AWS  omv  omv-ha │ Color          Effect
-# ─────────────────┼───────────────────────────────────────────────────────────
-#  ✓    ✓    ✓     │ Green          solid (40% brightness)
-#  ✗    ✓    ✓     │ Orange         slow blink — AWS only down
-#  ✓    ✗    ✓     │ Yellow         slow blink — one Pi down
-#  ✓    ✓    ✗     │ Yellow         slow blink — one Pi down
-#  ✓    ✗    ✗     │ Red            fast blink — both Pi nodes down
-#  ✗    ✗    ✓     │ Deep orange    fast blink — AWS + one Pi down
-#  ✗    ✓    ✗     │ Deep orange    fast blink — AWS + one Pi down
-#  ✗    ✗    ✗     │ Magenta        fast blink — total outage
+# omv  omv-ha │ Color          Effect
+# ─────────────┼───────────────────────────────────────────────────────────────
+#  ✓    ✓     │ Green          solid (40% brightness)
+#  ✗    ✓     │ Yellow         slow blink — omv down
+#  ✓    ✗     │ Yellow         slow blink — omv-ha down
+#  ✗    ✗     │ Red            fast blink — both nodes down
 # ─────────────────────────────────────────────────────────────────────────────
+# The deeper LED-update lambda still references aws_up, but aws_up's global
+# default is "true" (line ~172), so the AWS branches are now dead code. To
+# fully prune them, edit the update_led script + the strobe effects below.
+# Kept as-is to minimise the diff and keep the AWS path one substitution away
+# from re-enabling.
 
 substitutions:
   node_name:       cloudless-watchdog
@@ -36,7 +37,12 @@ substitutions:
   # is dead (the death-spiral scenario). This probe exercises etcd + apiserver
   # so we can hardware-reset omv when k3s is wedged but the OS is still up.
   omv_k3s_probe:   "https://192.168.1.128:6443/livez"
-  aws_health:      "https://cloudless.gr/api/health"
+  # AWS probe removed 2026-06-21 — ESP32 now watches CLUSTER ONLY per the
+  # operator's monitoring-scope cleanup. The `aws_up` global stays
+  # `initial_value: "true"` so the existing LED-state matrix collapses
+  # naturally to a cluster-only 4-state matrix (omv × omv-ha). To re-enable
+  # AWS monitoring, restore aws_health here + the probe_aws interval +
+  # the aws_app_reachable binary_sensor + the notify_alerts AWS branch.
   # Relay control — GPIO10 drives an active-LOW 5V relay that interrupts
   # omv's 5V USB-C power line for hard-reset when k3s is wedged.
   # Wiring: ESP32 GPIO10 → NPN base (10kΩ) → relay coil GND ; coil VCC → 5V
@@ -233,11 +239,7 @@ binary_sensor:
     entity_category: diagnostic
     lambda: "return id(omv_ha_up);"
 
-  - platform: template
-    id:         aws_app_reachable
-    name:       "cloudless.gr (AWS) reachable"
-    entity_category: diagnostic
-    lambda: "return id(aws_up);"
+  # aws_app_reachable removed 2026-06-21 — AWS probe disabled (cluster-only scope).
 
   - platform: template
     id:         omv_k3s_reachable
@@ -397,38 +399,7 @@ interval:
                     id(heartbeat_pulse).execute();
                   }
 
-  # AWS probe — fires every 60 s
-  - id: probe_aws
-    interval: 60s
-    then:
-      - http_request.get:
-          url: ${aws_health}
-          on_response:
-            then:
-              - lambda: |-
-                  bool was = id(aws_up);
-                  bool now = (response->status_code >= 200 && response->status_code < 400);
-                  if (!now) id(aws_fail_count)++;
-                  if (was != now) {
-                    id(aws_up) = now;
-                    id(aws_app_reachable).publish_state(now);
-                    id(update_led).execute();
-                    id(heartbeat_pulse).execute();
-                  }
-                  if (!was && now) {
-                    id(aws_last_alerted) = 0;
-                    id(send_aws_recovery).execute();
-                  }
-          on_error:
-            then:
-              - lambda: |-
-                  id(aws_fail_count)++;
-                  if (id(aws_up)) {
-                    id(aws_up) = false;
-                    id(aws_app_reachable).publish_state(false);
-                    id(update_led).execute();
-                    id(heartbeat_pulse).execute();
-                  }
+  # probe_aws interval removed 2026-06-21 — ESP32 watches CLUSTER ONLY.
 
   # k3s API probe — fires every 30 s, staggered 22 s into each cycle so it
   # doesn't overlap with the omv (0 s) / omv-ha (15 s) probes.
@@ -474,20 +445,7 @@ interval:
   - id: notify_alerts
     interval: 60s
     then:
-      - if:
-          condition:
-            lambda: "return !id(aws_up) && (id(aws_last_alerted) == 0 || (millis() - id(aws_last_alerted)) >= 600000);"
-          then:
-            - http_request.post:
-                url:  ${ntfy_url}
-                request_headers:
-                  Content-Type: text/plain
-                  Authorization: "Bearer ${ntfy_token}"
-                  Title: "🟠 cloudless.gr (AWS) UNREACHABLE"
-                  Priority: "high"
-                  Tags: "warning,cloud"
-                body: "HTTP probe to cloudless.gr returned non-2xx or timed out."
-            - lambda: "id(aws_last_alerted) = millis();"
+      # AWS alert removed 2026-06-21 — cluster-only scope.
       - if:
           condition:
             lambda: "return !id(omv_up) && (id(omv_last_alerted) == 0 || (millis() - id(omv_last_alerted)) >= 600000);"

--- a/infrastructure/monitoring/omv-watchdogs.yaml
+++ b/infrastructure/monitoring/omv-watchdogs.yaml
@@ -147,8 +147,20 @@ spec:
                   cpu: 200m
                   memory: 128Mi
 ---
-# omv-backup-verify — every 6h, confirms a `nas-backup` journal entry
-# in the last 25h. Replaces the remote "NAS Backup Check" routine.
+# omv-backup-verify — every 6h, confirms the k3s etcd snapshot on
+# /srv/.../Backups/k3s-db/ is fresh (< 2h old).
+#
+# Originally (pre-2026-06-21) this watchdog grep'd journalctl for tag
+# `nas-backup`, but that systemd unit was disabled May 1 (renamed
+# nas-backup.bak.20260501). Result: false alert "nas-backup has not run
+# in 25h" every 6h. The fix: monitor what's ACTUALLY backing up — the
+# hourly k3s etcd snapshot pulled to /srv/.../Backups/k3s-db/ via the
+# scheduled cron documented in CLAUDE.md "k3s Tuning".
+#
+# Windows-to-NAS backup runs on the Office machine via Windows Backup
+# (writes to OMV SMB share); we don't need a separate watchdog for it
+# because Windows Backup surfaces its own failures + the disk-usage
+# watchdog catches a stalled backup eventually.
 apiVersion: batch/v1
 kind: CronJob
 metadata:
@@ -189,40 +201,34 @@ spec:
                 - name: SLACK_CHANNEL
                   value: "C09AF5W3X16"
                 - name: MAX_AGE_HOURS
-                  value: "25"
+                  value: "2"
+                - name: SNAPSHOT_DIR
+                  value: "/srv/dev-disk-by-uuid-fa6231ab-eae7-40ea-a4b6-400f767a89d7/Backups/k3s-db"
               command:
                 - /bin/sh
                 - -c
                 - |
                   set -eo pipefail
                   STAMP="$(date -u '+%Y-%m-%dT%H:%M:%SZ')"
-
-                  # Read journalctl on the host. The remote routine was looking
-                  # for `journalctl -t nas-backup --since '24 hours ago'`.
-                  ENTRIES=$(nsenter --target 1 --mount --uts --ipc --net --pid \
-                    journalctl -t nas-backup --since "${MAX_AGE_HOURS} hours ago" \
-                    --no-pager -q 2>/dev/null | tail -50 || true)
-
-                  if [ -n "$ENTRIES" ]; then
-                    echo "[${STAMP}] nas-backup entries found (last ${MAX_AGE_HOURS}h):"
-                    echo "$ENTRIES" | head -5
-                    # Check the last line for "error" / "failed" — escalate if so
-                    LAST=$(echo "$ENTRIES" | tail -1)
-                    if echo "$LAST" | grep -qiE '(error|fail|FATAL)'; then
-                      BODY=":x: *nas-backup last run reported an error:*\n\`\`\`${LAST}\`\`\`"
+                  # Newest file under SNAPSHOT_DIR via nsenter (host fs).
+                  NEWEST=$(nsenter --target 1 --mount --uts --ipc --net --pid \
+                    find "$SNAPSHOT_DIR" -type f -printf '%T@ %p\n' 2>/dev/null \
+                    | sort -nr | head -1 || true)
+                  if [ -z "$NEWEST" ]; then
+                    BODY=":rotating_light: *k3s etcd snapshot directory empty or missing* on omv ($SNAPSHOT_DIR). Backup pipeline broken."
+                  else
+                    MTIME=$(printf '%s' "$NEWEST" | awk '{print $1}' | cut -d. -f1)
+                    NOW=$(date +%s)
+                    AGE_H=$(( (NOW - MTIME) / 3600 ))
+                    if [ $AGE_H -gt $MAX_AGE_HOURS ]; then
+                      LATEST_FILE=$(printf '%s' "$NEWEST" | cut -d' ' -f2-)
+                      BODY=":warning: *k3s etcd snapshot is ${AGE_H}h old* (expected <${MAX_AGE_HOURS}h). Latest: \`${LATEST_FILE}\`. Check the hourly snapshot cron on omv-main."
                     else
-                      echo "[${STAMP}] backup healthy — no alert"
+                      echo "[${STAMP}] backup healthy: newest snapshot ${AGE_H}h old"
                       exit 0
                     fi
-                  else
-                    BODY=":rotating_light: *nas-backup has not run in the last ${MAX_AGE_HOURS}h* — no journal entries with tag \`nas-backup\` found on omv host. Either the backup job is broken, or it's not tagging journalctl correctly."
                   fi
-
-                  PAYLOAD=$(printf '%s' "$BODY" | python3 -c '
-                  import json,os,sys
-                  print(json.dumps({"channel": os.environ["SLACK_CHANNEL"], "text": sys.stdin.read()}))
-                  ')
-                  echo "[${STAMP}] posting nas-backup alert"
+                  PAYLOAD=$(printf '%s' "$BODY" | python3 -c 'import json,os,sys; print(json.dumps({"channel": os.environ["SLACK_CHANNEL"], "text": sys.stdin.read()}))')
                   RESP=$(curl -sS -X POST https://slack.com/api/chat.postMessage \
                     -H "Authorization: Bearer ${SLACK_BOT_TOKEN}" \
                     -H 'Content-Type: application/json; charset=utf-8' \


### PR DESCRIPTION
Two related monitoring scope fixes:

1. ESP32: drop AWS probe, keep only cluster (omv + omv-ha + k3s API). LED matrix collapses 8 -> 4 states naturally because aws_up defaults to true. README + in-firmware comment updated. Operator re-flashes via esphome run.

2. omv-backup-verify CronJob: was alerting daily because the nas-backup systemd unit it monitored has been disabled (renamed .bak) since May 1. Repurposed to check k3s etcd snapshot freshness (the real hourly cluster backup). Already applied to cluster; this commit syncs the source-of-truth manifest.