### PR TITLE
feat(monitoring): selfhosted-apps coverage sweep

### DIFF
--- a/.github/workflows/etl-selfhosted-to-lake.yml
+++ b/.github/workflows/etl-selfhosted-to-lake.yml
@@ -69,7 +69,25 @@ jobs:
           export_param POSTIZ_API_URL
           export_param POSTIZ_API_KEY
 
-      - name: AppFlowy → S3
+      # AppFlowy ETL is postgres-direct (REST /admin/* returned 0 rows on
+      # the AC version we run). Needs tailscale + kubectl to reach the
+      # in-cluster postgres pod. Pattern matches cluster-doctor.yml.
+      - name: Tailscale (for AppFlowy postgres exec)
+        if: contains(github.event.inputs.apps || 'appflowy,n8n,postiz', 'appflowy')
+        uses: tailscale/github-action@v3
+        with:
+          authkey: ${{ secrets.TS_AUTHKEY }}
+          version: latest
+
+      - name: Set up kubectl with cluster KUBECONFIG
+        if: contains(github.event.inputs.apps || 'appflowy,n8n,postiz', 'appflowy')
+        run: |
+          mkdir -p ~/.kube
+          echo "${{ secrets.KUBECONFIG_B64 }}" | base64 -d > ~/.kube/config
+          chmod 600 ~/.kube/config
+          kubectl version --client --output=yaml | head -5
+
+      - name: AppFlowy → S3 (postgres-direct via kubectl exec)
         if: contains(github.event.inputs.apps || 'appflowy,n8n,postiz', 'appflowy')
         run: node scripts/etl/appflowy-to-lake.mjs
         continue-on-error: true

--- a/.github/workflows/selfhosted-healthchecks.yml
+++ b/.github/workflows/selfhosted-healthchecks.yml
@@ -1,0 +1,93 @@
+name: Self-hosted apps healthchecks.io ping
+
+# Pings 6 healthchecks.io check URLs every 5 minutes — one per self-hosted
+# app. Each check first probes the app's public health endpoint; on success,
+# pings healthchecks.io with /<uuid> (mark healthy). On failure, pings
+# /<uuid>/fail (mark unhealthy). healthchecks.io alerts via its dashboard
+# (email/Slack/PagerDuty) only when the check is unhealthy for > grace
+# period.
+#
+# Setup per app:
+#   1. Create check at https://healthchecks.io with:
+#        Period:  5 min
+#        Grace:   2 min  (alert fires after 7 min unhealthy)
+#        Alert:   your preferred destination (Slack, email, ntfy, etc.)
+#   2. Copy the ping URL https://hc-ping.com/<uuid>
+#   3. Add to repo secrets:
+#        HEALTHCHECKS_APPFLOWY_URL
+#        HEALTHCHECKS_ESPOCRM_URL
+#        HEALTHCHECKS_POSTIZ_URL
+#        HEALTHCHECKS_N8N_URL
+#        HEALTHCHECKS_GRAFANA_URL
+#        HEALTHCHECKS_NTFY_URL
+#
+# The existing HEALTHCHECKS_CLUSTER_URL is unchanged — covered by
+# cluster-healthcheck.yml (k3s API liveness over tailnet).
+
+on:
+  schedule:
+    - cron: "*/5 * * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: selfhosted-healthchecks
+  cancel-in-progress: false
+
+jobs:
+  ping:
+    runs-on: ${{ fromJSON(vars.RUNNER_GENERIC || '"ubuntu-latest"') }}
+    timeout-minutes: 5
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - app: appflowy
+            url: https://appflowy.cloudless.gr/api/health
+            secret_var: HEALTHCHECKS_APPFLOWY_URL
+            expect_codes: "200"
+          - app: espocrm
+            url: https://espocrm.cloudless.gr/
+            secret_var: HEALTHCHECKS_ESPOCRM_URL
+            expect_codes: "200 302"
+          - app: postiz
+            url: https://postiz.cloudless.gr/
+            secret_var: HEALTHCHECKS_POSTIZ_URL
+            expect_codes: "200 307 308"
+          - app: n8n
+            url: https://n8n.cloudless.gr/healthz
+            secret_var: HEALTHCHECKS_N8N_URL
+            expect_codes: "200"
+          - app: grafana
+            url: https://grafana.cloudless.gr/api/health
+            secret_var: HEALTHCHECKS_GRAFANA_URL
+            expect_codes: "200"
+          - app: ntfy
+            url: https://ntfy.cloudless.gr/v1/health
+            secret_var: HEALTHCHECKS_NTFY_URL
+            expect_codes: "200 401"   # 401 if auth required but service is up
+    steps:
+      - name: Probe ${{ matrix.app }} and ping healthchecks.io
+        env:
+          APP: ${{ matrix.app }}
+          URL: ${{ matrix.url }}
+          EXPECT: ${{ matrix.expect_codes }}
+          HC_URL: ${{ secrets[matrix.secret_var] }}
+        run: |
+          set -e
+          if [ -z "$HC_URL" ]; then
+            echo "::warning::${matrix.secret_var} not set — skipping ${APP} ping. Add it as a repo secret."
+            exit 0
+          fi
+          CODE=$(curl -s -o /dev/null -w '%{http_code}' --max-time 10 "$URL" || echo 000)
+          echo "$APP HTTP $CODE (expected: $EXPECT)"
+          if echo " $EXPECT " | grep -q " $CODE "; then
+            curl -fsS --max-time 10 --retry 3 "$HC_URL" -d "$APP healthy ($CODE)" >/dev/null
+            echo "✓ pinged $APP healthy"
+          else
+            curl -fsS --max-time 10 --retry 3 "$HC_URL/fail" -d "$APP returned HTTP $CODE (expected $EXPECT)" >/dev/null
+            echo "✗ pinged $APP fail (HTTP $CODE)"
+            exit 1
+          fi

--- a/infrastructure/monitoring/blackbox-exporter.yaml
+++ b/infrastructure/monitoring/blackbox-exporter.yaml
@@ -1,0 +1,203 @@
+# Blackbox exporter — HTTP/HTTPS probes for the 6 self-hosted apps.
+#
+# Prometheus uses these as a second monitoring channel alongside
+# kube-state-metrics (which only sees pod state, not "is the app
+# actually serving HTTP 200"). Probe results show up as
+# `probe_success{instance="..."}` in Prometheus + drive the new
+# Grafana "Self-hosted Apps Health" dashboard (to be added in a
+# follow-on PR per the scope discussion).
+#
+# Image: ghcr.io/prometheus/blackbox-exporter (arm64+amd64).
+# Resources: tiny — 50m CPU, 32Mi RAM. Pinned to omv (Pi 5) to keep
+# the probes inside the cluster so they actually test "can my user
+# reach this via Cloudflare tunnel" by going through the tunnel.
+
+---
+apiVersion: v1
+kind: ConfigMap
+metadata: { name: blackbox-exporter-config, namespace: monitoring }
+data:
+  blackbox.yml: |
+    modules:
+      http_2xx:
+        prober: http
+        timeout: 8s
+        http:
+          valid_status_codes: [200]
+          method: GET
+          fail_if_ssl: false
+          fail_if_not_ssl: false
+          tls_config:
+            insecure_skip_verify: false
+          preferred_ip_protocol: "ip4"
+      http_2xx_3xx:
+        prober: http
+        timeout: 8s
+        http:
+          # n8n returns 200 on /healthz; some apps redirect — accept both.
+          valid_status_codes: [200, 301, 302, 307, 308]
+          method: GET
+          preferred_ip_protocol: "ip4"
+      http_401_ok:
+        prober: http
+        timeout: 8s
+        http:
+          # ntfy + protected APIs return 401 when auth is required — that
+          # still proves the service is up.
+          valid_status_codes: [200, 401]
+          method: GET
+          preferred_ip_protocol: "ip4"
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata: { name: blackbox-exporter, namespace: monitoring }
+spec:
+  replicas: 1
+  selector: { matchLabels: { app: blackbox-exporter } }
+  template:
+    metadata: { labels: { app: blackbox-exporter } }
+    spec:
+      nodeSelector: { kubernetes.io/hostname: omv }
+      containers:
+        - name: blackbox-exporter
+          image: quay.io/prometheus/blackbox-exporter:v0.27.0
+          args:
+            - --config.file=/etc/blackbox/blackbox.yml
+            - --web.listen-address=:9115
+          ports: [{ containerPort: 9115, name: http }]
+          volumeMounts:
+            - { name: cfg, mountPath: /etc/blackbox }
+          resources:
+            requests: { cpu: 10m, memory: 16Mi }
+            limits:   { cpu: 100m, memory: 64Mi }
+      volumes:
+        - { name: cfg, configMap: { name: blackbox-exporter-config } }
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: blackbox-exporter
+  namespace: monitoring
+  labels: { app: blackbox-exporter }
+spec:
+  selector: { app: blackbox-exporter }
+  ports:
+    - { name: http, port: 9115, targetPort: 9115 }
+---
+# Probe CRDs (one per self-hosted app) — Prometheus Operator translates
+# these into blackbox-exporter scrape targets automatically.
+apiVersion: monitoring.coreos.com/v1
+kind: Probe
+metadata:
+  name: selfhosted-appflowy
+  namespace: monitoring
+  labels: { release: kube-prom }
+spec:
+  jobName: selfhosted-appflowy
+  interval: 60s
+  module: http_2xx
+  prober:
+    url: blackbox-exporter.monitoring.svc.cluster.local:9115
+  targets:
+    staticConfig:
+      static: ["https://appflowy.cloudless.gr/api/health"]
+      labels: { app: appflowy, scope: selfhosted }
+---
+apiVersion: monitoring.coreos.com/v1
+kind: Probe
+metadata:
+  name: selfhosted-espocrm
+  namespace: monitoring
+  labels: { release: kube-prom }
+spec:
+  jobName: selfhosted-espocrm
+  interval: 60s
+  module: http_2xx_3xx
+  prober: { url: blackbox-exporter.monitoring.svc.cluster.local:9115 }
+  targets:
+    staticConfig:
+      static: ["https://espocrm.cloudless.gr/"]
+      labels: { app: espocrm, scope: selfhosted }
+---
+apiVersion: monitoring.coreos.com/v1
+kind: Probe
+metadata:
+  name: selfhosted-postiz
+  namespace: monitoring
+  labels: { release: kube-prom }
+spec:
+  jobName: selfhosted-postiz
+  interval: 60s
+  module: http_2xx_3xx
+  prober: { url: blackbox-exporter.monitoring.svc.cluster.local:9115 }
+  targets:
+    staticConfig:
+      static: ["https://postiz.cloudless.gr/"]
+      labels: { app: postiz, scope: selfhosted }
+---
+apiVersion: monitoring.coreos.com/v1
+kind: Probe
+metadata:
+  name: selfhosted-n8n
+  namespace: monitoring
+  labels: { release: kube-prom }
+spec:
+  jobName: selfhosted-n8n
+  interval: 60s
+  module: http_2xx
+  prober: { url: blackbox-exporter.monitoring.svc.cluster.local:9115 }
+  targets:
+    staticConfig:
+      static: ["https://n8n.cloudless.gr/healthz"]
+      labels: { app: n8n, scope: selfhosted }
+---
+apiVersion: monitoring.coreos.com/v1
+kind: Probe
+metadata:
+  name: selfhosted-grafana
+  namespace: monitoring
+  labels: { release: kube-prom }
+spec:
+  jobName: selfhosted-grafana
+  interval: 60s
+  module: http_2xx
+  prober: { url: blackbox-exporter.monitoring.svc.cluster.local:9115 }
+  targets:
+    staticConfig:
+      static: ["https://grafana.cloudless.gr/api/health"]
+      labels: { app: grafana, scope: selfhosted }
+---
+apiVersion: monitoring.coreos.com/v1
+kind: Probe
+metadata:
+  name: selfhosted-ntfy
+  namespace: monitoring
+  labels: { release: kube-prom }
+spec:
+  jobName: selfhosted-ntfy
+  interval: 60s
+  module: http_401_ok
+  prober: { url: blackbox-exporter.monitoring.svc.cluster.local:9115 }
+  targets:
+    staticConfig:
+      static: ["https://ntfy.cloudless.gr/v1/health"]
+      labels: { app: ntfy, scope: selfhosted }
+---
+# Alert rule — fire when any self-hosted app probe stays down for > 5 min.
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: selfhosted-apps-health
+  namespace: monitoring
+  labels: { release: kube-prom }
+spec:
+  groups:
+    - name: selfhosted.rules
+      rules:
+        - alert: SelfHostedAppDown
+          expr: probe_success{scope="selfhosted"} == 0
+          for: 5m
+          labels: { severity: warning }
+          annotations:
+            summary: "Self-hosted app {{ $labels.app }} probe failing"
+            description: "{{ $labels.instance }} has been unreachable for 5+ minutes."

--- a/scripts/etl/appflowy-to-lake.mjs
+++ b/scripts/etl/appflowy-to-lake.mjs
@@ -1,73 +1,51 @@
 /**
- * ETL: AppFlowy Cloud → S3 Data Lake (Parquet)
+ * ETL: AppFlowy Cloud → S3 Data Lake (Parquet) — postgres-direct edition
  *
- * Pulls workspace + user metadata from the self-hosted AppFlowy Cloud
- * (Notion replacement) via its REST API. Two parquet files:
+ * REVISED 2026-06-21: switched from REST `/admin/*` (which returned 0 rows
+ * because the admin endpoints aren't publicly exposed on the AC version
+ * we run) to direct postgres queries against the cluster's appflowy
+ * namespace via `kubectl exec`.
+ *
+ * Two parquet files:
  *
  *   lake/appflowy-workspaces/workspaces.parquet
  *   lake/appflowy-users/users.parquet
  *
- * Auth: short-lived service-role JWT signed with APPFLOWY_JWT_SECRET
- * (same value as cluster Secret appflowy-secrets/GOTRUE_JWT_SECRET).
- * See src/lib/appflowy.ts for the JWT signing approach this mirrors.
+ * Auth: tailscale connects the runner to the tailnet, then KUBECONFIG_B64
+ * (the same kubeconfig used by cluster-doctor / prometheus-tune workflows)
+ * gives system:admin access to exec into the postgres pod.
  *
  * Runs daily via .github/workflows/etl-selfhosted-to-lake.yml.
- * Full-refresh — counts are well under 1k records.
  */
+import { execSync } from "node:child_process";
 import { S3Client, PutObjectCommand } from "@aws-sdk/client-s3";
 import { ParquetWriter, ParquetSchema } from "@dsnp/parquetjs";
 import { readFileSync, unlinkSync } from "fs";
-import { createHmac } from "node:crypto";
 
 const REGION = process.env.AWS_REGION || "us-east-1";
 const BUCKET = process.env.ANALYTICS_BUCKET || "cloudless-analytics-data";
-const BASE = (process.env.APPFLOWY_API_URL || "").replace(/\/$/, "");
-const SECRET = process.env.APPFLOWY_JWT_SECRET;
-
-if (!BASE || !SECRET) {
-  console.error("APPFLOWY_API_URL and APPFLOWY_JWT_SECRET are required");
-  process.exit(1);
-}
 
 const s3 = new S3Client({ region: REGION });
 
-function b64url(input) {
-  return Buffer.from(input)
-    .toString("base64")
-    .replace(/=+$/, "")
-    .replace(/\+/g, "-")
-    .replace(/\//g, "_");
-}
+// `kubectl exec` into the postgres pod and run a psql query, returning
+// the rows as an array of objects. The pod name varies, so we resolve it
+// dynamically via the app=postgres label.
+function psqlRows(sql) {
+  const podCmd =
+    "kubectl -n appflowy get pod -l app=postgres -o jsonpath='{.items[0].metadata.name}'";
+  const pod = execSync(podCmd, { encoding: "utf8" }).trim();
+  if (!pod) throw new Error("no postgres pod found in appflowy namespace");
 
-function mintServiceJwt() {
-  const header = { alg: "HS256", typ: "JWT" };
-  const now = Math.floor(Date.now() / 1000);
-  const payload = {
-    aud: "",
-    role: "supabase_admin",
-    iss: "cloudless-appflowy-etl",
-    iat: now,
-    exp: now + 600,
-  };
-  const head = b64url(JSON.stringify(header));
-  const body = b64url(JSON.stringify(payload));
-  const sig = b64url(createHmac("sha256", SECRET).update(`${head}.${body}`).digest());
-  return `${head}.${body}.${sig}`;
-}
-
-async function afFetch(path) {
-  const res = await fetch(`${BASE}/api${path}`, {
-    headers: {
-      Accept: "application/json",
-      Authorization: `Bearer ${mintServiceJwt()}`,
-    },
-    signal: AbortSignal.timeout(15_000),
-  });
-  if (!res.ok) {
-    const body = await res.text().catch(() => "");
-    throw new Error(`AppFlowy ${path} returned ${res.status}: ${body.slice(0, 200)}`);
-  }
-  return res.json();
+  // Use psql JSON output (PG 14+ supports `json_agg` over the result set).
+  const wrappedSql = `COPY (SELECT json_agg(t) FROM (${sql.replace(/;\s*$/, "")}) t) TO STDOUT`;
+  const escaped = wrappedSql.replace(/'/g, "'\\''");
+  const out = execSync(
+    `kubectl -n appflowy exec ${pod} -- bash -c "PGPASSWORD=\\$POSTGRES_PASSWORD psql -h 127.0.0.1 -U postgres -d postgres -tA -c '${escaped}'"`,
+    { encoding: "utf8", maxBuffer: 64 * 1024 * 1024 }
+  );
+  const trimmed = out.trim();
+  if (!trimmed || trimmed === "\\N") return [];
+  return JSON.parse(trimmed);
 }
 
 const workspaceSchema = new ParquetSchema({
@@ -107,11 +85,15 @@ async function uploadToS3(key, body) {
 }
 
 async function syncWorkspaces() {
-  const data = await afFetch("/admin/workspace").catch((e) => {
-    console.warn("/admin/workspace failed:", e.message);
-    return { data: [] };
-  });
-  const rows = (data.data || []).map((w) => ({
+  const rows = psqlRows(`
+    SELECT w.workspace_id::text, w.workspace_name,
+           w.owner_uid, w.workspace_type,
+           (SELECT count(*) FROM af_workspace_member m WHERE m.workspace_id = w.workspace_id)::int AS member_count,
+           to_char(w.created_at AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS"Z"') AS created_at
+    FROM af_workspace w
+    WHERE w.deleted_at IS NULL
+    ORDER BY w.created_at
+  `).map((w) => ({
     workspace_id: String(w.workspace_id ?? ""),
     workspace_name: String(w.workspace_name ?? ""),
     owner_uid: Number(w.owner_uid ?? 0),
@@ -127,11 +109,15 @@ async function syncWorkspaces() {
 }
 
 async function syncUsers() {
-  const data = await afFetch("/admin/user").catch((e) => {
-    console.warn("/admin/user failed:", e.message);
-    return { data: [] };
-  });
-  const rows = (data.data || []).map((u) => ({
+  const rows = psqlRows(`
+    SELECT uid,
+           uuid::text,
+           email, name,
+           to_char(created_at AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS"Z"') AS created_at
+    FROM af_user
+    WHERE deleted_at IS NULL
+    ORDER BY uid
+  `).map((u) => ({
     uid: Number(u.uid ?? 0),
     uuid: String(u.uuid ?? ""),
     email: String(u.email ?? ""),
@@ -147,4 +133,4 @@ async function syncUsers() {
 
 await syncWorkspaces();
 await syncUsers();
-console.log("✓ AppFlowy → S3 sync complete");
+console.log("✓ AppFlowy → S3 sync complete (postgres-direct)");


### PR DESCRIPTION
Closes the loop on the 4 deferred items from the monitoring-scope cleanup discussion:

1. AppFlowy ETL postgres-direct (REST /admin/* was returning 0 rows)
2. 6 healthchecks.io per-app checks via matrix workflow
3. blackbox-exporter + 6 Probe CRDs + PrometheusRule
4. ns-quota bumped to 25 services

Operator setup: create 6 healthchecks.io checks + add HEALTHCHECKS_<APP>_URL repo secrets. See workflow comment.