### PR TITLE
feat(monitoring): wipe Grafana defaults + add 2 self-hosted dashboards

### DIFF
--- a/infrastructure/monitoring/dashboards.yaml
+++ b/infrastructure/monitoring/dashboards.yaml
@@ -1,0 +1,156 @@
+# Two new Grafana dashboards backed by the blackbox-exporter Probe CRDs
+# from infrastructure/monitoring/blackbox-exporter.yaml.
+#
+# - Self-hosted Apps Health: live stat panel + probe duration + HTTP status code
+# - Self-hosted Apps SLO: 30-day uptime %, 5-min rolling success rate, error
+#   budget burn rate (1h vs 99.9% target)
+#
+# Loaded into Grafana via the kube-prom-grafana-sc-dashboard sidecar which
+# watches ConfigMaps with label grafana_dashboard=1 in the monitoring ns.
+#
+# To edit a panel, modify the JSON below + kubectl apply. The sidecar
+# re-syncs every 30 s. Grafana sidecar provider is `allowUiUpdates: false`
+# so UI edits would be lost — always edit here.
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: grafana-dashboard-selfhosted-health
+  namespace: monitoring
+  labels: { grafana_dashboard: "1" }
+data:
+  selfhosted-health.json: |
+    {
+      "title": "Self-hosted Apps — Health",
+      "uid": "selfhosted-health",
+      "tags": ["selfhosted", "cloudless"],
+      "timezone": "browser",
+      "schemaVersion": 39,
+      "version": 1,
+      "refresh": "30s",
+      "time": { "from": "now-6h", "to": "now" },
+      "templating": { "list": [] },
+      "panels": [
+        {
+          "type": "stat",
+          "title": "Probe success (live)",
+          "id": 1,
+          "gridPos": { "h": 8, "w": 24, "x": 0, "y": 0 },
+          "targets": [{
+            "expr": "probe_success{scope=\"selfhosted\"}",
+            "legendFormat": "{{app}}",
+            "refId": "A",
+            "datasource": { "type": "prometheus", "uid": "prometheus" }
+          }],
+          "fieldConfig": {
+            "defaults": {
+              "mappings": [
+                { "type": "value", "options": { "0": { "text": "DOWN", "color": "red" } } },
+                { "type": "value", "options": { "1": { "text": "UP",   "color": "green" } } }
+              ],
+              "color": { "mode": "thresholds" },
+              "thresholds": { "mode": "absolute", "steps": [ { "color": "red", "value": null }, { "color": "green", "value": 1 } ] }
+            }
+          },
+          "options": { "reduceOptions": { "calcs": ["lastNotNull"] }, "textMode": "auto", "colorMode": "background" }
+        },
+        {
+          "type": "timeseries",
+          "title": "Probe duration (s)",
+          "id": 2,
+          "gridPos": { "h": 9, "w": 12, "x": 0, "y": 8 },
+          "targets": [{
+            "expr": "probe_duration_seconds{scope=\"selfhosted\"}",
+            "legendFormat": "{{app}}",
+            "refId": "A",
+            "datasource": { "type": "prometheus", "uid": "prometheus" }
+          }]
+        },
+        {
+          "type": "timeseries",
+          "title": "HTTP status code",
+          "id": 3,
+          "gridPos": { "h": 9, "w": 12, "x": 12, "y": 8 },
+          "targets": [{
+            "expr": "probe_http_status_code{scope=\"selfhosted\"}",
+            "legendFormat": "{{app}}",
+            "refId": "A",
+            "datasource": { "type": "prometheus", "uid": "prometheus" }
+          }]
+        }
+      ]
+    }
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: grafana-dashboard-selfhosted-slo
+  namespace: monitoring
+  labels: { grafana_dashboard: "1" }
+data:
+  selfhosted-slo.json: |
+    {
+      "title": "Self-hosted Apps — SLO (30d)",
+      "uid": "selfhosted-slo",
+      "tags": ["selfhosted", "cloudless", "slo"],
+      "timezone": "browser",
+      "schemaVersion": 39,
+      "version": 1,
+      "refresh": "5m",
+      "time": { "from": "now-30d", "to": "now" },
+      "templating": { "list": [] },
+      "panels": [
+        {
+          "type": "stat",
+          "title": "Uptime % per app (30d)",
+          "id": 1,
+          "gridPos": { "h": 9, "w": 24, "x": 0, "y": 0 },
+          "targets": [{
+            "expr": "100 * avg_over_time(probe_success{scope=\"selfhosted\"}[30d])",
+            "legendFormat": "{{app}}",
+            "refId": "A",
+            "datasource": { "type": "prometheus", "uid": "prometheus" }
+          }],
+          "fieldConfig": {
+            "defaults": {
+              "unit": "percent",
+              "decimals": 3,
+              "color": { "mode": "thresholds" },
+              "thresholds": { "mode": "absolute", "steps": [
+                { "color": "red", "value": null },
+                { "color": "orange", "value": 99.0 },
+                { "color": "yellow", "value": 99.5 },
+                { "color": "green", "value": 99.9 }
+              ]}
+            }
+          },
+          "options": { "reduceOptions": { "calcs": ["lastNotNull"] }, "textMode": "value_and_name", "colorMode": "background" }
+        },
+        {
+          "type": "timeseries",
+          "title": "Probe success rate (5m window)",
+          "id": 2,
+          "gridPos": { "h": 9, "w": 24, "x": 0, "y": 9 },
+          "targets": [{
+            "expr": "100 * avg_over_time(probe_success{scope=\"selfhosted\"}[5m])",
+            "legendFormat": "{{app}}",
+            "refId": "A",
+            "datasource": { "type": "prometheus", "uid": "prometheus" }
+          }],
+          "fieldConfig": { "defaults": { "unit": "percent", "min": 0, "max": 100 } }
+        },
+        {
+          "type": "timeseries",
+          "title": "Error budget burn rate (1h vs 30d budget)",
+          "id": 3,
+          "gridPos": { "h": 9, "w": 24, "x": 0, "y": 18 },
+          "targets": [{
+            "expr": "(1 - avg_over_time(probe_success{scope=\"selfhosted\"}[1h])) / (1 - 0.999)",
+            "legendFormat": "{{app}} — burn",
+            "refId": "A",
+            "datasource": { "type": "prometheus", "uid": "prometheus" }
+          }],
+          "fieldConfig": { "defaults": { "decimals": 2 } }
+        }
+      ]
+    }

--- a/infrastructure/monitoring/kube-prom-stack-values.yaml
+++ b/infrastructure/monitoring/kube-prom-stack-values.yaml
@@ -1,0 +1,49 @@
+# Helm values override for the kube-prometheus-stack chart.
+#
+# The default install of this chart ships ~25 dashboards (Alertmanager,
+# CoreDNS, K8s/* family, Node Exporter/*, Prometheus, Grafana Overview).
+# We don't use them — they were deleted from the cluster on 2026-06-21
+# by removing the `monitoring-*` ConfigMaps directly.
+#
+# This values file tells Helm not to recreate them on the next
+# `helm upgrade kube-prom ./kube-prometheus-stack --values
+# infrastructure/monitoring/kube-prom-stack-values.yaml`.
+#
+# Read the upstream values reference before changing anything else:
+#   https://github.com/prometheus-community/helm-charts/blob/main/charts/kube-prometheus-stack/values.yaml
+#
+# What we KEEP:
+#   - All Prometheus scrape (node-exporter, kube-state-metrics,
+#     coredns, kubelet, apiserver, alertmanager, prometheus, operator)
+#   - PrometheusRules (the default alerts are still useful)
+#   - Grafana itself (just with no default dashboards)
+#   - 6 cloudless custom dashboards (cluster-overview-2026,
+#     per-node-detail-2026, pod-health-2026, cluster-infra, edge-computing,
+#     esp32-watchdog)
+#   - 2 new self-hosted dashboards from this PR (selfhosted-health,
+#     selfhosted-slo) — backed by blackbox-exporter probes deployed
+#     in infrastructure/monitoring/blackbox-exporter.yaml.
+#
+# What we DROP:
+#   - 24 monitoring-* default dashboards from kube-prometheus-stack
+#   - 4 grafana-dashboard-cloudflare-* dashboards (we removed Cloudflare
+#     analytics monitoring from the scope per the 2026-06-21 cleanup)
+
+grafana:
+  # Don't render any of the default dashboards into ConfigMaps. If you
+  # ever want them back, set this to `true` and `helm upgrade`.
+  defaultDashboardsEnabled: false
+
+  # Keep the sidecar that watches grafana_dashboard=1 ConfigMaps so our
+  # custom dashboards in this directory + the new self-hosted ones still
+  # get provisioned.
+  sidecar:
+    dashboards:
+      enabled: true
+      label: grafana_dashboard
+      labelValue: "1"
+      searchNamespace: monitoring
+      provider:
+        foldersFromFilesStructure: true
+        disableDelete: false
+        allowUiUpdates: false


### PR DESCRIPTION
Per the user selection (delete EVERYTHING auto-installed, keep only cloudless custom). 28 ConfigMaps deleted from cluster; Helm values override prevents recreation on next upgrade. 2 new dashboards backed by blackbox-exporter Probes from PR #1058: Self-hosted Apps Health (live) + Self-hosted Apps SLO (30d uptime + error budget burn rate).