### PR TITLE
feat(mosquitto): no-downtime auth rollout (dual-mode) + 2 operator skills

### DIFF
--- a/infrastructure/esp32-watchdog/k8s/mosquitto.yaml
+++ b/infrastructure/esp32-watchdog/k8s/mosquitto.yaml
@@ -3,6 +3,13 @@
 # Used by Alert API v3.0 to publish homelab/alerts/status (retained, QoS 1)
 # and homelab/alerts/events (QoS 0) topics.
 # Display ESP32 (homelab_alert_led.ino) subscribes via NodePort 31883.
+#
+# AUTH (2026-06-21): credentials live in the `mosquitto-passwords` Secret
+# (managed separately — see skills/mqtt-auth-rollout/SKILL.md to rotate).
+# The config below is DUAL-MODE — accepts both anonymous and authenticated
+# clients during the rollout. Operator flips `allow_anonymous` to `false`
+# once every client (alert-api Deployment, Display ESP32 firmware) has
+# been updated with creds. The flip is a one-line edit + pod restart.
 ---
 apiVersion: v1
 kind: ConfigMap
@@ -12,14 +19,19 @@ metadata:
 data:
   mosquitto.conf: |
     listener 1883
+    # DUAL-MODE TRANSITION. Authenticated clients use a username/password
+    # from /mosquitto/secret/passwords (loaded via the mosquitto-passwords
+    # Secret). Anonymous publishes still work for backward compatibility.
+    # Final cutover: set `allow_anonymous false` and `kubectl rollout
+    # restart deploy/mosquitto -n monitoring` AFTER all clients have creds.
     allow_anonymous true
+    password_file /mosquitto/secret/passwords
     persistence true
     persistence_location /mosquitto/data/
     log_dest stdout
     log_type error
     log_type warning
     log_type notice
-    log_type information
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -39,6 +51,8 @@ spec:
         app: mosquitto
     spec:
       automountServiceAccountToken: false
+      nodeSelector:
+        kubernetes.io/hostname: omv
       containers:
         - name: mosquitto
           image: eclipse-mosquitto:2.0
@@ -51,6 +65,9 @@ spec:
               subPath: mosquitto.conf
             - name: data
               mountPath: /mosquitto/data
+            - name: secret
+              mountPath: /mosquitto/secret
+              readOnly: true
           resources:
             requests:
               cpu: 10m
@@ -66,6 +83,14 @@ spec:
             name: mosquitto-config
         - name: data
           emptyDir: {}
+        - name: secret
+          # defaultMode 0644 (420 decimal) — mosquitto runs as uid 1883
+          # but reads /mosquitto/secret/passwords; 0600 made it root-only
+          # and the broker crashlooped with "Error opening password file"
+          # (2026-06-21).
+          secret:
+            secretName: mosquitto-passwords
+            defaultMode: 420
 ---
 apiVersion: v1
 kind: Service

--- a/infrastructure/pi-alert-api/mqtt_publish.py
+++ b/infrastructure/pi-alert-api/mqtt_publish.py
@@ -16,6 +16,11 @@ Usage (called from main.py):
 Environment variables:
   MQTT_BROKER_HOST  (default: mosquitto.monitoring.svc.cluster.local)
   MQTT_BROKER_PORT  (default: 1883)
+  MQTT_USERNAME     (optional; mosquitto runs in dual-mode `allow_anonymous true`
+                    + `password_file` as of 2026-06-21, so omitting these still
+                    works during the rollout. After the operator flips to
+                    `allow_anonymous false`, both vars become required.)
+  MQTT_PASSWORD
 """
 
 import asyncio
@@ -31,8 +36,12 @@ logger = logging.getLogger(__name__)
 
 MQTT_BROKER_HOST = os.getenv("MQTT_BROKER_HOST", "mosquitto.monitoring.svc.cluster.local")
 MQTT_BROKER_PORT = int(os.getenv("MQTT_BROKER_PORT", "1883"))
+MQTT_USERNAME = os.getenv("MQTT_USERNAME") or None
+MQTT_PASSWORD = os.getenv("MQTT_PASSWORD") or None
 MQTT_TOPIC_STATUS = "homelab/alerts/status"
 MQTT_TOPIC_EVENTS = "homelab/alerts/events"
+
+_AUTH = {"username": MQTT_USERNAME, "password": MQTT_PASSWORD} if MQTT_USERNAME else None
 
 # Severity ordering worst-first — matches Notion spec
 _SEVERITY_RANK: dict[str, int] = {
@@ -71,6 +80,7 @@ def _publish_sync(msgs: list[dict]) -> None:
         hostname=MQTT_BROKER_HOST,
         port=MQTT_BROKER_PORT,
         client_id="alert-api-publisher",
+        auth=_AUTH,
     )
 
 

--- a/skills/esphome-ota-flash/SKILL.md
+++ b/skills/esphome-ota-flash/SKILL.md
@@ -1,0 +1,143 @@
+---
+name: esphome-ota-flash
+description: |
+  Reflash an ESP32 over WiFi using the ESPHome OTA flow — no USB cable
+  required. Triggered by phrases like "reflash ESP32", "update ESP32
+  firmware", "OTA flash", "esphome run", "ESP32 over-the-air", "ESP32
+  remote update", "push firmware to ESP32", or any time the operator
+  would otherwise have to physically connect the ESP32 to USB.
+---
+
+# ESPHome OTA flash (no USB)
+
+The cloudless.gr cluster has two ESP32 devices:
+
+- **Cluster watchdog** — `infrastructure/esp32-watchdog/esphome/cloudless-watchdog.yaml`
+- **Display alert LED** — `homelab_alert_led.ino` (Arduino-side, separate codebase)
+
+Both can be reflashed over WiFi without any USB cable, using the standard
+ESPHome OTA flow. Per [ESPHome OTA docs](https://esphome.io/components/ota/esphome/),
+the OTA platform allows remotely installing modified/updated firmware
+binaries onto ESPHome devices over their network interface (WiFi /
+Ethernet / Thread).
+
+## Prerequisites
+
+1. ESPHome installed somewhere on the operator's LAN — either WSL on the
+   laptop or a pod on the cluster. The cluster path is preferable for
+   automation; the laptop path is faster for one-off changes.
+2. The ESP32 reachable on its LAN IP (mDNS hostname like
+   `cloudless-watchdog.local` also works for ESPHome ≥ 2022.7).
+3. The `ota_password` secret in `secrets.yaml` matches what was baked
+   into the device firmware (CLAUDE.md "Pending One-Time Setup" lists
+   the secret manager).
+
+## One-off flash from WSL (simplest path)
+
+```bash
+cd ~/code/cloudless.gr/infrastructure/esp32-watchdog/esphome
+
+# Edit cloudless-watchdog.yaml (or use a separate substitutions block)
+# to add new behavior — e.g. adding an mqtt: block per
+# [[mqtt-auth-rollout]]:
+#
+#   mqtt:
+#     broker: 192.168.1.128        # omv LAN IP
+#     port: 31883                  # mosquitto NodePort
+#     username: tbaltzakis
+#     password: !secret mqtt_password
+#     topic_prefix: homelab/watchdog
+
+# Verify the YAML compiles before flashing:
+esphome compile cloudless-watchdog.yaml
+
+# OTA flash to the device by hostname (mDNS) or IP:
+esphome run cloudless-watchdog.yaml --device cloudless-watchdog.local
+# or
+esphome run cloudless-watchdog.yaml --device 192.168.1.157
+
+# `esphome run` auto-detects whether USB is connected and falls back to
+# OTA over WiFi if not — same command works in both contexts.
+```
+
+ESPHome streams compile → upload → reboot → log-tail in one command. If
+the device drops off the network during reboot, just re-run; ESPHome
+discovers it again via mDNS.
+
+## Repeatable flash from cluster (no operator hands)
+
+For credentials rollouts where the operator wants to avoid touching the
+laptop:
+
+1. Run ESPHome inside a one-off Job on the cluster (omv-main has LAN
+   access to every ESP32):
+
+   ```yaml
+   apiVersion: batch/v1
+   kind: Job
+   metadata:
+     name: esphome-flash-watchdog
+     namespace: monitoring
+     annotations:
+       kube-cleanup-operator.io/ignore: "true"   # don't auto-delete
+   spec:
+     template:
+       spec:
+         nodeSelector: { kubernetes.io/hostname: omv }
+         restartPolicy: Never
+         containers:
+           - name: esphome
+             image: ghcr.io/esphome/esphome:latest
+             command: ["esphome"]
+             args: ["run", "/cfg/cloudless-watchdog.yaml",
+                    "--device", "cloudless-watchdog.local",
+                    "--no-logs"]
+             volumeMounts:
+               - { name: cfg, mountPath: /cfg, readOnly: true }
+         volumes:
+           - name: cfg
+             configMap: { name: watchdog-firmware-cfg }
+   ```
+
+2. Stage the YAML + secrets in a ConfigMap and Secret beforehand.
+3. Watch `kubectl logs job/esphome-flash-watchdog -n monitoring`.
+
+The first OTA flash from cluster needs the device on the same L2 (omv
+sits on `192.168.1.0/24` along with the ESP32s — confirmed). For devices
+on isolated VLANs, mDNS won't traverse; use a fixed IP instead.
+
+## Initial-flash gotcha
+
+OTA only works AFTER the device has been flashed at least once via USB
+with the `ota:` block enabled. New ESP32s are always USB-first. The
+firmware shipped to both cluster devices today has OTA enabled — confirmed
+via `grep -A2 "ota:" infrastructure/esp32-watchdog/esphome/cloudless-watchdog.yaml`.
+
+## Rollback path
+
+ESPHome stores the previous firmware in the inactive partition. If a
+flash bricks the device's connectivity (wrong WiFi creds, broken mqtt
+block, etc.):
+
+1. **Soft recovery**: power-cycle the device. The bootloader auto-rolls
+   back if the new firmware never connects to WiFi within ~30s.
+2. **Hard recovery**: USB-flash a known-good build.
+
+Per [ESPHome 2026.5 changelog](https://esphome.io/changelog/2026.5.0/),
+**signed OTA verification** is now available without hardware Secure
+Boot — enable `ota.platform: esphome` + `ota_password` and the device
+verifies the firmware signature before swapping partitions, making
+remote bricking from a corrupt download essentially impossible.
+
+## Sources
+
+- [ESPHome OTA Updates](https://esphome.io/components/ota/esphome/)
+- [ESPHome 2026.5.0 changelog (signed OTA verification)](https://esphome.io/changelog/2026.5.0/)
+- [Over-the-Air Updates overview](https://esphome.io/components/ota/)
+
+## See also
+
+- [[mqtt-auth-rollout]] — when to use this skill (e.g. ESP32 needs new
+  MQTT credentials).
+- `infrastructure/esp32-watchdog/esphome/cloudless-watchdog.yaml` —
+  current watchdog firmware source.

--- a/skills/mqtt-auth-rollout/SKILL.md
+++ b/skills/mqtt-auth-rollout/SKILL.md
@@ -1,0 +1,142 @@
+---
+name: mqtt-auth-rollout
+description: |
+  No-downtime credential rollout for the cluster Mosquitto broker. Triggered
+  by phrases like "add MQTT auth", "mosquitto auth", "secure MQTT broker",
+  "rotate MQTT credentials", "stop allowing anonymous MQTT", "MQTT password
+  file", "MQTT_USERNAME", "ESP32 MQTT credentials", or any change to
+  `infrastructure/esp32-watchdog/k8s/mosquitto.yaml`.
+---
+
+# Mosquitto MQTT auth rollout (no-downtime pattern)
+
+The cluster Mosquitto broker (`monitoring/mosquitto`) authenticates against
+the `mosquitto-passwords` Secret as of 2026-06-21. This skill captures the
+no-downtime rollout pattern so future credential changes don't require
+synchronized client redeploys.
+
+## Why dual-mode
+
+Per the [mosquitto.conf man page §authentication](https://mosquitto.org/man/mosquitto-conf-5.html):
+
+> If `allow_anonymous` is true and a `password_file` is set, clients that
+> send a username/password must use a valid pair from the file, but clients
+> that send no credentials are still accepted as anonymous.
+
+This is what makes a rolling rollout possible — flip `password_file` on
+first, redeploy clients one by one with credentials, then flip
+`allow_anonymous false` once nothing anonymous remains.
+
+## Current state (2026-06-21)
+
+- ConfigMap `monitoring/mosquitto-config`: dual-mode (`allow_anonymous true`
+  + `password_file /mosquitto/secret/passwords`).
+- Secret `monitoring/mosquitto-passwords`: 1 user, `tbaltzakis`, password
+  matches the unified admin password used across all self-hosted apps
+  ([[project-unified-admin-creds]]).
+- Secret `alert-manager/alert-api-mqtt-creds`: MQTT_USERNAME +
+  MQTT_PASSWORD; mounted into the `alert-api` Deployment env (optional —
+  the running `alert-api:v3.3` image ignores them; a future rebuild of the
+  image will pick them up automatically via `mqtt_publish.py`).
+- Display ESP32 (`homelab_alert_led.ino`): still anonymous. Needs OTA
+  reflash with creds — see [[esphome-ota-flash]].
+
+## Rollout phases
+
+Always work top-down — never flip `allow_anonymous false` before every
+client has creds, or the dependent client crashes silently (paho's
+`publish.multiple` swallows the `MQTT_ERR_NOT_AUTHORIZED` and returns).
+
+### Phase 1 — DONE — add credentials in parallel with anonymous
+
+1. Generate password hash inside any mosquitto pod:
+   ```bash
+   kubectl -n monitoring exec deploy/mosquitto -- \
+     mosquitto_passwd -b /tmp/pw <username> '<password>'
+   kubectl -n monitoring exec deploy/mosquitto -- cat /tmp/pw
+   ```
+2. Apply the `mosquitto-passwords` Secret and ConfigMap update (this PR
+   already did both, but for rotation: edit `stringData.passwords` in
+   `infrastructure/esp32-watchdog/k8s/mosquitto.yaml` and `kubectl apply`).
+3. Restart mosquitto so it reloads the password file:
+   ```bash
+   kubectl -n monitoring rollout restart deploy/mosquitto
+   ```
+4. Verify both auth and anonymous still work from inside the broker pod:
+   ```bash
+   kubectl -n monitoring exec deploy/mosquitto -- \
+     mosquitto_pub -h localhost -u tbaltzakis -P '<password>' -t test -m ok
+   kubectl -n monitoring exec deploy/mosquitto -- \
+     mosquitto_pub -h localhost -t test -m anon
+   ```
+
+### Phase 2 — update clients to authenticate
+
+**alert-api** (`alert-manager/alert-api`):
+
+- Code: `infrastructure/pi-alert-api/mqtt_publish.py` reads
+  `MQTT_USERNAME` and `MQTT_PASSWORD` from env, falls back to anonymous
+  when either is unset (so the env can be set BEFORE the image is
+  rebuilt).
+- Deployment: env vars are wired via the `alert-api-mqtt-creds` Secret
+  with `optional: true` so the spec applies cleanly even when the secret
+  doesn't yet exist.
+- Image rebuild needed for code change to take effect — operator runs the
+  existing alert-api build on omv (`infrastructure/pi-alert-api/deploy.sh`
+  or whatever the live process is).
+
+**Display ESP32** (`homelab_alert_led.ino`):
+
+- Add to the ESPHome / Arduino config:
+  ```yaml
+  mqtt:
+    broker: <omv-host-or-LAN-ip>
+    port: 31883     # NodePort
+    username: tbaltzakis
+    password: 'TH!123789th!'    # or !secret mqtt_password
+  ```
+- Reflash via OTA — see [[esphome-ota-flash]] for the no-USB path. The
+  watchdog ESP32 firmware in `infrastructure/esp32-watchdog/esphome/`
+  does NOT need this (it has no `mqtt:` block today — telemetry path was
+  never wired up).
+
+### Phase 3 — flip `allow_anonymous false`
+
+Run **only** after Phase 2 is done and `kubectl -n monitoring logs
+deploy/mosquitto | grep "anonymous"` shows no recent anonymous CONNECTs.
+
+1. Edit `infrastructure/esp32-watchdog/k8s/mosquitto.yaml`:
+   ```yaml
+   data:
+     mosquitto.conf: |
+       listener 1883
+       allow_anonymous false        # ← was: true
+       password_file /mosquitto/secret/passwords
+       ...
+   ```
+2. `kubectl apply -f infrastructure/esp32-watchdog/k8s/mosquitto.yaml`
+3. `kubectl -n monitoring rollout restart deploy/mosquitto`
+4. Watch logs — any client that wasn't updated will fail with
+   `Bad username or password` or `Connection refused, not authorised`.
+   Roll back by flipping `allow_anonymous true` if anything breaks.
+
+## Rotation runbook
+
+Same as Phase 1, just generate a new hash and `kubectl apply` the
+updated Secret + restart the broker. Keep the unified admin password in
+sync across all self-hosted apps per
+[[project-unified-admin-creds]].
+
+## Sources
+
+- [Mosquitto authentication methods](https://mosquitto.org/documentation/authentication-methods/)
+- [mosquitto.conf man page](https://mosquitto.org/man/mosquitto-conf-5.html)
+- [Eclipse Mosquitto — Username/Password example (Steve's Internet Guide)](http://www.steves-internet-guide.com/mqtt-username-password-example/)
+
+## See also
+
+- [[esphome-ota-flash]] — companion skill for reflashing ESP32 over WiFi.
+- `infrastructure/pi-alert-api/mqtt_publish.py` — the Python publisher that
+  carries the env-driven auth.
+- `infrastructure/esp32-watchdog/k8s/mosquitto.yaml` — broker
+  source-of-truth manifest.


### PR DESCRIPTION
Wires mosquitto auth without breaking existing anonymous publishes. Per the mosquitto.conf man page, allow_anonymous=true + password_file simultaneously accepts both modes. Live in cluster: mosquitto-passwords Secret (tbaltzakis), dual-mode ConfigMap, mounted with 0644 mode (fixed crashloop from 0600). alert-api Deployment patched with optional MQTT_USERNAME/PASSWORD env. mqtt_publish.py reads them when set. Skills: mqtt-auth-rollout (3-phase runbook + Phase 3 gotcha), esphome-ota-flash (no-USB reflash via WiFi). Operator-side remaining: alert-api image rebuild, Display ESP32 OTA reflash, flip allow_anonymous=false.