### PR TITLE
feat(alert-api): self-service rebuild workflow + bump to v3.4

### DIFF
--- a/.github/workflows/deploy-alert-api.yml
+++ b/.github/workflows/deploy-alert-api.yml
@@ -1,0 +1,101 @@
+name: Build + roll out alert-api
+
+# Builds the alert-api Docker image on the omv Pi runner (the Dockerfile
+# lives outside the repo at ~/alert-api/Dockerfile per the operator's
+# pre-CI history), imports it into k3s containerd, then patches the
+# Deployment to bump the tag.
+#
+# Triggers:
+#   - push to main touching infrastructure/pi-alert-api/**
+#   - manual workflow_dispatch (operator can ship v3.4 from the GitHub UI
+#     OR `gh workflow run deploy-alert-api.yml`)
+#
+# Why a self-hosted runner: the build step writes into the omv-local
+# `~/alert-api/` directory and calls `sudo k3s ctr images import` —
+# both require running ON omv. Per skills/gh-actions-pitfalls/SKILL.md
+# #3, runners are scarce, so this typically queues ~3 min behind any
+# active build.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "infrastructure/pi-alert-api/**"
+      - ".github/workflows/deploy-alert-api.yml"
+  workflow_dispatch:
+    inputs:
+      version_tag:
+        description: "Image tag to ship (e.g. v3.4)"
+        required: true
+        default: "v3.4"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: deploy-alert-api
+  cancel-in-progress: false
+
+jobs:
+  build-and-rollout:
+    runs-on: [self-hosted, omv, pi, build]
+    timeout-minutes: 15
+    env:
+      TAG: ${{ inputs.version_tag || 'v3.4' }}
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Sync Python sources to ~/alert-api/
+        run: |
+          set -euo pipefail
+          # The Dockerfile + requirements.txt live in ~/alert-api/ on the
+          # Pi (pre-CI history). Only the .py modules are tracked in the
+          # repo; sync them so the image build picks up the latest code.
+          for f in main.py slack_notify.py mqtt_publish.py tls_check.py esp32_command_routes.py; do
+            if [[ -f "infrastructure/pi-alert-api/${f}" ]]; then
+              cp "infrastructure/pi-alert-api/${f}" "${HOME}/alert-api/${f}"
+            fi
+          done
+          # Ensure paho-mqtt is in requirements (idempotent)
+          REQ="${HOME}/alert-api/requirements.txt"
+          if ! grep -qi "^paho-mqtt" "${REQ}" 2>/dev/null; then
+            echo "paho-mqtt>=1.6" >> "${REQ}"
+          fi
+
+      - name: Build image
+        working-directory: /home/tbaltzakis/alert-api
+        run: docker build -t "alert-api:${TAG}" -t alert-api:v3 .
+
+      - name: Import into k3s containerd
+        run: docker save "alert-api:${TAG}" | sudo k3s ctr images import -
+
+      - name: Bump Deployment image
+        run: |
+          kubectl -n alert-manager set image deployment/alert-api \
+            "alert-api=docker.io/library/alert-api:${TAG}"
+          kubectl -n alert-manager rollout status deployment/alert-api --timeout=180s
+
+      - name: Verify MQTT_USERNAME + MQTT_PASSWORD are live in pod
+        run: |
+          set -euo pipefail
+          POD=$(kubectl -n alert-manager get pod -l app=alert-api -o jsonpath='{.items[0].metadata.name}')
+          # Both env names should be present; their values come from the
+          # alert-api-mqtt-creds Secret (optional, so absence wouldn't
+          # crash the pod — but for v3.4 we expect them set).
+          kubectl -n alert-manager exec "${POD}" -- env | grep -E '^MQTT_(USERNAME|PASSWORD)=' | sed 's/=.*/=<set>/'
+
+      - name: Smoke-test authenticated publish from inside pod
+        run: |
+          set -euo pipefail
+          POD=$(kubectl -n alert-manager get pod -l app=alert-api -o jsonpath='{.items[0].metadata.name}')
+          kubectl -n alert-manager exec "${POD}" -- python3 -c '
+          import os, paho.mqtt.publish as publish, json, time
+          publish.single(
+              "homelab/alerts/events",
+              json.dumps({"src": "deploy-smoke", "ts": int(time.time())}),
+              hostname="mosquitto.monitoring.svc.cluster.local",
+              port=1883,
+              auth={"username": os.environ["MQTT_USERNAME"], "password": os.environ["MQTT_PASSWORD"]},
+              qos=0,
+          )
+          print("ok-auth")'

--- a/infrastructure/pi-alert-api/deploy.sh
+++ b/infrastructure/pi-alert-api/deploy.sh
@@ -77,9 +77,9 @@ echo "==> Rebuilding alert-api image on Pi..."
 ssh "${PI}" bash -s <<'REMOTE'
 set -euo pipefail
 cd ~/alert-api
-docker build -t alert-api:v3.3 -t alert-api:v3 .
-docker save alert-api:v3.3 | sudo k3s ctr images import -
-kubectl -n alert-manager set image deployment/alert-api alert-api=docker.io/library/alert-api:v3.3
+docker build -t alert-api:v3.4 -t alert-api:v3 .
+docker save alert-api:v3.4 | sudo k3s ctr images import -
+kubectl -n alert-manager set image deployment/alert-api alert-api=docker.io/library/alert-api:v3.4
 kubectl -n alert-manager rollout status deployment/alert-api --timeout=120s
 REMOTE
 


### PR DESCRIPTION
Adds .github/workflows/deploy-alert-api.yml + bumps deploy.sh tag to v3.4. The workflow makes the rebuild trigger-able from the cloud session OR on push to infrastructure/pi-alert-api/**. Includes inline smoke test that publishes authenticated to mosquitto from inside the new pod — verifies Phase 3 cutover will succeed BEFORE the operator flips allow_anonymous.