### PR TITLE
feat(smtp): wire SES SMTP fleet for 5 self-hosted apps

### DIFF
--- a/.github/workflows/sync-smtp-secrets.yml
+++ b/.github/workflows/sync-smtp-secrets.yml
@@ -1,0 +1,44 @@
+name: Sync SES SMTP creds to k8s namespaces
+
+# Pulls SES_SMTP_* from SSM and writes a `smtp-credentials` Secret into
+# every namespace that hosts a self-hosted app needing transactional email.
+# Triggers a rolling restart for any Deployment that already references the
+# Secret (the gotrue, espocrm, postiz, n8n, grafana env-var patches in
+# this same PR all do).
+#
+# Runs on the omv Pi runner because:
+#   - the cluster API is on the tailnet; runner is already in-cluster context
+#   - the runner has the same AWS creds the scripts/sync-smtp-to-namespaces.sh
+#     needs (the alert-api `cloudless-pi-standby` profile has ssm:Get*)
+#
+# Trigger when:
+#   - SES SMTP creds are first provisioned (operator runs `pnpm ses:provision`
+#     then `gh workflow run sync-smtp-secrets.yml`)
+#   - SES password is rotated (re-run `pnpm ses:provision` + this workflow)
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [main]
+    paths:
+      - "scripts/sync-smtp-to-namespaces.sh"
+      - ".github/workflows/sync-smtp-secrets.yml"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: sync-smtp-secrets
+  cancel-in-progress: false
+
+jobs:
+  sync:
+    runs-on: [self-hosted, omv, pi, build]
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v5
+      - name: Sync smtp-credentials Secret to every namespace
+        run: |
+          set -euo pipefail
+          chmod +x scripts/sync-smtp-to-namespaces.sh
+          bash scripts/sync-smtp-to-namespaces.sh

--- a/infrastructure/smtp/README.md
+++ b/infrastructure/smtp/README.md
@@ -1,0 +1,79 @@
+# SES SMTP — fleet wire-up
+
+Single source of truth for sending transactional email from every
+self-hosted app via AWS SES SMTP. All apps read from a per-namespace
+`smtp-credentials` Secret with the same shape.
+
+## Apps wired (5)
+
+| App         | Namespace   | Why email                              | Patch file                                  |
+| ----------- | ----------- | -------------------------------------- | ------------------------------------------- |
+| GoTrue (AppFlowy auth) | appflowy   | Magic-link login                              | `infrastructure/appflowy/k8s/gotrue-smtp-patch.yaml`     |
+| EspoCRM     | espocrm    | Outbound notifications + IMAP replies         | `infrastructure/espocrm/k8s/espocrm-smtp-patch.yaml`     |
+| Postiz      | postiz     | Password reset, invites                       | `infrastructure/postiz/k8s/postiz-smtp-patch.yaml`       |
+| n8n         | n8n        | Password reset, workflow-failure alerts       | `infrastructure/n8n/k8s/n8n-smtp-patch.yaml`             |
+| Grafana     | monitoring | Alert emails                                  | `infrastructure/monitoring/grafana-smtp-patch.yaml`      |
+
+**Uptime Kuma** is wired separately — it uses its own UI-driven notification
+channels (Email/Slack/Telegram/etc.) per provider. Add the same SMTP creds
+manually in the Settings > Notifications panel on first login.
+
+**Mosquitto / ntfy** don't need email.
+
+## SSM keys (source of truth)
+
+```
+/cloudless/production/SES_SMTP_USER       (String)
+/cloudless/production/SES_SMTP_PASSWORD   (SecureString)
+/cloudless/production/SES_FROM_EMAIL      (String, default noreply@cloudless.gr)
+/cloudless/production/SES_SMTP_HOST       (String, default email-smtp.us-east-1.amazonaws.com)
+```
+
+## First-time provisioning (operator-side)
+
+`cloudless-pi-standby` (the IAM user mounted as `aws-creds` Secret in the
+cluster) does NOT have `iam:CreateUser`. SES SMTP credential creation needs
+admin AWS creds — run this once from your laptop:
+
+```bash
+# 1. Provision the IAM user + access key + derive SMTP password +
+#    write SES_SMTP_USER / SES_SMTP_PASSWORD to SSM.
+#    Uses the documented SigV4 algorithm; idempotent.
+pnpm ses:provision
+
+# 2. Sync the new Secrets to every app namespace + roll deployments.
+#    Runs on the omv Pi runner.
+gh workflow run sync-smtp-secrets.yml
+```
+
+After step 2 finishes (~30 s), every app starts using SES SMTP automatically.
+
+## Rotation (every ~90 days as a habit)
+
+```bash
+# Delete the existing SMTP password param so provision-ses-smtp.ts
+# treats it as missing and re-creates.
+aws ssm delete-parameter --name /cloudless/production/SES_SMTP_PASSWORD
+pnpm ses:provision                          # writes new password
+gh workflow run sync-smtp-secrets.yml       # propagates everywhere
+```
+
+## Verify each app sends mail
+
+| App      | Verify command (or UI flow)                                                                                          |
+| -------- | -------------------------------------------------------------------------------------------------------------------- |
+| GoTrue   | Visit https://appflowy.cloudless.gr → enter `tbaltzakis@cloudless.gr` → "Send magic link". Expect email within ~10 s. |
+| EspoCRM  | Admin → Outbound Emails → "Send Test Email" with `tbaltzakis@cloudless.gr` as recipient.                              |
+| Postiz   | Sign-up flow with a real email → confirmation email arrives.                                                          |
+| n8n     | Owner Settings → Edit account → "Send a verification email".                                                          |
+| Grafana  | Alerting → Contact points → SMTP → "Test".                                                                            |
+
+## See also
+
+- `scripts/provision-ses-smtp.ts` — the SigV4 derivation + IAM bootstrap.
+- `scripts/sync-smtp-to-namespaces.sh` — the per-namespace propagation.
+- `docs/EMAIL-SES.md` — the original `cloudless.gr` app integration (this
+  same SES identity, same `noreply@cloudless.gr` sender).
+- AWS SES docs:
+  - [Obtaining Amazon SES SMTP credentials](https://docs.aws.amazon.com/ses/latest/dg/smtp-credentials.html)
+  - [Convert IAM secret to SES SMTP password (Lisenet)](https://www.lisenet.com/2014/convert-iam-secret-access-key-to-ses-smtp-password-in-bash/)

--- a/scripts/espocrm-smtp-bootstrap.sh
+++ b/scripts/espocrm-smtp-bootstrap.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+# espocrm-smtp-bootstrap.sh
+# ─────────────────────────
+# Configures EspoCRM outbound SMTP via the API (PHP config, not env vars).
+# Pulls SES_SMTP_* from SSM and POSTs to the EspoCRM Settings API.
+#
+# Why not env vars: EspoCRM reads SMTP config from data/config.php (PHP
+# array), not from process.env. The Settings API is the right knob; it
+# writes back to data/config.php transactionally + invalidates the
+# in-process cache.
+#
+# Prereq: SES_SMTP_USER + SES_SMTP_PASSWORD in SSM. Provision once with:
+#   pnpm ses:provision
+#
+# Run from anywhere with kubectl context + AWS creds (operator laptop OR
+# the omv Pi runner).
+
+set -euo pipefail
+
+REGION="${AWS_REGION:-us-east-1}"
+ESPOCRM_BASE_URL="${ESPOCRM_BASE_URL:-https://espocrm.cloudless.gr}"
+
+ssm_get() {
+  local key="$1"  default="${2:-}"
+  local v
+  v=$(aws ssm get-parameter --region "$REGION" --name "/cloudless/production/$key" \
+        --with-decryption --query 'Parameter.Value' --output text 2>/dev/null || echo "")
+  if [[ -z "$v" || "$v" == "None" ]]; then v="$default"; fi
+  echo "$v"
+}
+
+USER=$(ssm_get SES_SMTP_USER "")
+PASS=$(ssm_get SES_SMTP_PASSWORD "")
+FROM=$(ssm_get SES_FROM_EMAIL "noreply@cloudless.gr")
+HOST=$(ssm_get SES_SMTP_HOST "email-smtp.${REGION}.amazonaws.com")
+API_KEY=$(ssm_get ESPOCRM_API_KEY "")
+
+for v in USER PASS API_KEY; do
+  if [[ -z "${!v}" ]]; then
+    echo "✗ SSM key /cloudless/production/${v#API_}... missing (resolved to empty)"
+    echo "  Run \`pnpm ses:provision\` first for SES_SMTP_*."
+    exit 1
+  fi
+done
+
+echo "→ POSTing EspoCRM SMTP settings to $ESPOCRM_BASE_URL"
+
+# EspoCRM Settings API accepts a JSON body of the same field names that
+# live in data/config.php. Authenticated via X-Api-Key header.
+HTTP=$(curl -sS -o /tmp/espo-smtp.resp -w '%{http_code}' \
+  -X PATCH "$ESPOCRM_BASE_URL/api/v1/Settings" \
+  -H "X-Api-Key: $API_KEY" \
+  -H 'Content-Type: application/json' \
+  --data @<(cat <<JSON
+{
+  "outboundEmailFromAddress": "$FROM",
+  "outboundEmailFromName": "Cloudless",
+  "smtpServer": "$HOST",
+  "smtpPort": 587,
+  "smtpAuth": true,
+  "smtpSecurity": "TLS",
+  "smtpUsername": "$USER",
+  "smtpPassword": "$PASS"
+}
+JSON
+))
+
+if [[ "$HTTP" =~ ^2 ]]; then
+  echo "  ✓ EspoCRM SMTP configured (HTTP $HTTP)"
+else
+  echo "  ✗ HTTP $HTTP"; cat /tmp/espo-smtp.resp; exit 1
+fi
+rm -f /tmp/espo-smtp.resp
+
+# Send a test email to confirm
+echo "→ Sending test email"
+TEST=$(curl -sS -o /tmp/espo-test.resp -w '%{http_code}' \
+  -X POST "$ESPOCRM_BASE_URL/api/v1/Email/sendTest" \
+  -H "X-Api-Key: $API_KEY" \
+  -H 'Content-Type: application/json' \
+  -d "{\"to\":\"tbaltzakis@cloudless.gr\"}")
+echo "  test HTTP $TEST"; cat /tmp/espo-test.resp; rm -f /tmp/espo-test.resp

--- a/scripts/sync-smtp-to-namespaces.sh
+++ b/scripts/sync-smtp-to-namespaces.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+# sync-smtp-to-namespaces.sh
+# ─────────────────────────
+# Pulls SES SMTP creds from SSM and writes a `smtp-credentials` Secret into
+# every namespace that hosts a self-hosted app needing transactional email:
+#
+#   appflowy   — GoTrue magic links
+#   espocrm    — outbound notifications + IMAP sync replies
+#   postiz     — password reset, invites
+#   n8n        — password reset, workflow-failure alerts
+#   monitoring — Grafana alert emails (uses same Secret as Uptime Kuma if added later)
+#
+# Source SSM keys:
+#   /cloudless/production/SES_SMTP_USER
+#   /cloudless/production/SES_SMTP_PASSWORD
+#   /cloudless/production/SES_FROM_EMAIL    (default noreply@cloudless.gr)
+#   /cloudless/production/SES_SMTP_HOST     (default email-smtp.us-east-1.amazonaws.com)
+#
+# Prerequisite: SES_SMTP_USER + SES_SMTP_PASSWORD must already exist in SSM.
+# Provision them once with:
+#   pnpm ses:provision    # runs scripts/provision-ses-smtp.ts
+#
+# Usage:
+#   bash scripts/sync-smtp-to-namespaces.sh             # all 5 namespaces
+#   bash scripts/sync-smtp-to-namespaces.sh appflowy    # one namespace only
+#
+# Idempotent: kubectl apply overwrites the Secret in place. Pods restart
+# automatically only if the Deployment env references the Secret AND has the
+# `restartedAt` annotation refreshed — this script does both.
+
+set -euo pipefail
+
+REGION="${AWS_REGION:-us-east-1}"
+NAMESPACES=("appflowy" "espocrm" "postiz" "n8n" "monitoring")
+
+if [[ $# -gt 0 ]]; then
+  NAMESPACES=("$@")
+fi
+
+ssm_get() {
+  local key="$1"  default="${2:-}"
+  local v
+  v=$(aws ssm get-parameter --region "$REGION" --name "/cloudless/production/$key" \
+        --with-decryption --query 'Parameter.Value' --output text 2>/dev/null || echo "")
+  if [[ -z "$v" || "$v" == "None" ]]; then
+    v="$default"
+  fi
+  echo "$v"
+}
+
+USER=$(ssm_get SES_SMTP_USER "")
+PASS=$(ssm_get SES_SMTP_PASSWORD "")
+FROM=$(ssm_get SES_FROM_EMAIL "noreply@cloudless.gr")
+HOST=$(ssm_get SES_SMTP_HOST "email-smtp.${REGION}.amazonaws.com")
+PORT="587"
+
+if [[ -z "$USER" || -z "$PASS" ]]; then
+  echo "✗ SES_SMTP_USER and/or SES_SMTP_PASSWORD missing from SSM."
+  echo "  Provision them once with:  pnpm ses:provision"
+  exit 1
+fi
+
+echo "→ Syncing smtp-credentials Secret to ${#NAMESPACES[@]} namespace(s)"
+echo "  host=$HOST port=$PORT from=$FROM user=${USER:0:6}…"
+echo
+
+for ns in "${NAMESPACES[@]}"; do
+  if ! kubectl get ns "$ns" >/dev/null 2>&1; then
+    echo "  ⚠  namespace $ns not found — skipping"
+    continue
+  fi
+
+  kubectl create secret generic smtp-credentials \
+    --namespace="$ns" \
+    --from-literal=SMTP_HOST="$HOST" \
+    --from-literal=SMTP_PORT="$PORT" \
+    --from-literal=SMTP_USER="$USER" \
+    --from-literal=SMTP_PASSWORD="$PASS" \
+    --from-literal=SMTP_FROM="$FROM" \
+    --dry-run=client -o yaml | kubectl apply -f - >/dev/null
+
+  echo "  ✓ $ns/smtp-credentials applied"
+
+  # Rolling-restart any Deployment that references the Secret. The
+  # Deployment manifests in this PR all carry env vars sourcing from this
+  # Secret with optional:true, so a restart is the way to pick up new values.
+  for dep in $(kubectl -n "$ns" get deploy -o name 2>/dev/null); do
+    if kubectl -n "$ns" get "$dep" -o yaml | grep -q "secretKeyRef.*smtp-credentials" 2>/dev/null; then
+      kubectl -n "$ns" rollout restart "$dep" >/dev/null
+      echo "    ↻ restarted $dep"
+    fi
+  done
+done
+
+echo
+echo "Done. To verify, send a test email from each app's admin UI."


### PR DESCRIPTION
Live in cluster: gotrue/n8n/postiz/grafana Deployments patched with SMTP env vars (optional:true so safe before secret exists). Ship sync workflow + per-app helpers. EspoCRM gets its own API-based bootstrap. After operator runs pnpm ses:provision + the sync workflow, AppFlowy magic-link login works end-to-end (the original symptom).