### PR TITLE
fix(smtp): EspoCRM bootstrap uses admin HTTP basic + IAM least-priv policy

### DIFF
--- a/docs/ses-smtp-iam-least-privilege.md
+++ b/docs/ses-smtp-iam-least-privilege.md
@@ -1,0 +1,130 @@
+# SES SMTP — least-privilege IAM for `pnpm ses:provision`
+
+`pnpm ses:provision` (`scripts/provision-ses-smtp.ts`) needs to do exactly
+five AWS things, all idempotent:
+
+1. Look up an IAM user named `cloudless-ses-smtp` (or create it).
+2. Attach a send-only inline policy.
+3. Create an access key for that user.
+4. Optionally delete any older access key on the same user (rotation).
+5. Write `SES_SMTP_USER` + `SES_SMTP_PASSWORD` + `SES_FROM_EMAIL` to
+   `/cloudless/production/*` in SSM.
+
+The `cloudless-pi-standby` IAM user mounted as `monitoring/aws-creds` in
+the cluster has none of those IAM permissions on purpose (it's a runtime
+SSM reader, not a provisioning identity). So `ses:provision` runs from
+the operator's laptop, where the operator's IAM identity has admin or
+PowerUser. This is the right separation.
+
+If you want to give a non-admin teammate the ability to run
+`pnpm ses:provision` without giving them broad IAM, use this minimal
+policy. It scopes IAM actions to the single `cloudless-ses-smtp` user
+and SSM actions to the three keys the script writes.
+
+## Least-privilege policy
+
+Save as `infrastructure/iam/policies/ses-provisioner.json`:
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "ManageOneSesSmtpUser",
+      "Effect": "Allow",
+      "Action": [
+        "iam:GetUser",
+        "iam:CreateUser",
+        "iam:PutUserPolicy",
+        "iam:ListAccessKeys",
+        "iam:CreateAccessKey",
+        "iam:DeleteAccessKey"
+      ],
+      "Resource": "arn:aws:iam::*:user/cloudless-ses-smtp"
+    },
+    {
+      "Sid": "WriteSesSmtpParams",
+      "Effect": "Allow",
+      "Action": [
+        "ssm:GetParameter",
+        "ssm:PutParameter"
+      ],
+      "Resource": [
+        "arn:aws:ssm:*:*:parameter/cloudless/production/SES_SMTP_USER",
+        "arn:aws:ssm:*:*:parameter/cloudless/production/SES_SMTP_PASSWORD",
+        "arn:aws:ssm:*:*:parameter/cloudless/production/SES_FROM_EMAIL"
+      ]
+    },
+    {
+      "Sid": "DecryptSecureStringParam",
+      "Effect": "Allow",
+      "Action": ["kms:Decrypt"],
+      "Resource": "*",
+      "Condition": {
+        "StringLike": {
+          "kms:EncryptionContext:PARAMETER_ARN": "arn:aws:ssm:*:*:parameter/cloudless/production/SES_SMTP_PASSWORD"
+        }
+      }
+    }
+  ]
+}
+```
+
+## Attach to a user
+
+```bash
+aws iam put-user-policy \
+  --user-name <teammate-username> \
+  --policy-name SesProvisioner \
+  --policy-document file://infrastructure/iam/policies/ses-provisioner.json
+```
+
+## Or attach to a role (better for SSO/Identity Center setups)
+
+```bash
+aws iam put-role-policy \
+  --role-name <role-with-ses-provisioning-rights> \
+  --policy-name SesProvisioner \
+  --policy-document file://infrastructure/iam/policies/ses-provisioner.json
+```
+
+## Verify the policy is sufficient
+
+```bash
+# As the teammate (after SSO login), dry-run the provisioner:
+SES_SMTP_DRYRUN=1 pnpm ses:provision    # if the script supports it; otherwise just run it
+
+# Should complete without "AccessDenied" or "not authorized to perform"
+# in stderr. If it errors, paste the missing action into the policy.
+```
+
+## Why not just AdministratorAccess?
+
+- A typo in `pnpm ses:provision` shouldn't be able to delete other IAM users.
+- Rotated SMTP creds get written to SSM as `SecureString` — the
+  least-priv policy lets the script decrypt **only** that one parameter
+  via the KMS encryption-context condition.
+- The IAM `Resource: "arn:...user/cloudless-ses-smtp"` constraint means
+  no surprises like creating `cloudless-debug-elevated` or
+  `mallory-backdoor`.
+
+## Rotation cadence
+
+AWS doesn't enforce a rotation policy for IAM access keys — set yours
+to ~90 days. Run from the laptop:
+
+```bash
+aws ssm delete-parameter --name /cloudless/production/SES_SMTP_PASSWORD
+pnpm ses:provision                         # generates a fresh access key
+gh workflow run sync-smtp-secrets.yml      # propagates to all 5 namespaces
+```
+
+The script auto-deletes the old access key on the IAM user (step 4 in
+the intro list above) — no manual cleanup needed.
+
+## Sources
+
+- [AWS — Obtaining Amazon SES SMTP credentials (SigV4 derivation)](https://docs.aws.amazon.com/ses/latest/dg/smtp-credentials.html)
+- [AWS — IAM JSON policy elements: Condition operators](https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_elements_condition_operators.html)
+- [AWS — Restricting access using condition keys (KMS encryption context)](https://docs.aws.amazon.com/kms/latest/developerguide/policy-conditions.html)
+- `scripts/provision-ses-smtp.ts` — the script this policy gates.

--- a/infrastructure/iam/policies/ses-provisioner.json
+++ b/infrastructure/iam/policies/ses-provisioner.json
@@ -1,0 +1,39 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "ManageOneSesSmtpUser",
+      "Effect": "Allow",
+      "Action": [
+        "iam:GetUser",
+        "iam:CreateUser",
+        "iam:PutUserPolicy",
+        "iam:ListAccessKeys",
+        "iam:CreateAccessKey",
+        "iam:DeleteAccessKey"
+      ],
+      "Resource": "arn:aws:iam::*:user/cloudless-ses-smtp"
+    },
+    {
+      "Sid": "WriteSesSmtpParams",
+      "Effect": "Allow",
+      "Action": ["ssm:GetParameter", "ssm:PutParameter"],
+      "Resource": [
+        "arn:aws:ssm:*:*:parameter/cloudless/production/SES_SMTP_USER",
+        "arn:aws:ssm:*:*:parameter/cloudless/production/SES_SMTP_PASSWORD",
+        "arn:aws:ssm:*:*:parameter/cloudless/production/SES_FROM_EMAIL"
+      ]
+    },
+    {
+      "Sid": "DecryptSecureStringParam",
+      "Effect": "Allow",
+      "Action": ["kms:Decrypt"],
+      "Resource": "*",
+      "Condition": {
+        "StringLike": {
+          "kms:EncryptionContext:PARAMETER_ARN": "arn:aws:ssm:*:*:parameter/cloudless/production/SES_SMTP_PASSWORD"
+        }
+      }
+    }
+  ]
+}

--- a/scripts/espocrm-smtp-bootstrap.sh
+++ b/scripts/espocrm-smtp-bootstrap.sh
@@ -33,23 +33,41 @@ USER=$(ssm_get SES_SMTP_USER "")
 PASS=$(ssm_get SES_SMTP_PASSWORD "")
 FROM=$(ssm_get SES_FROM_EMAIL "noreply@cloudless.gr")
 HOST=$(ssm_get SES_SMTP_HOST "email-smtp.${REGION}.amazonaws.com")
-API_KEY=$(ssm_get ESPOCRM_API_KEY "")
 
-for v in USER PASS API_KEY; do
+# Admin auth — HTTP Basic with the unified admin user. Avoids the
+# `ESPOCRM_API_KEY` SSM dependency (the API key was provisioned for the
+# cloudless-app SDK user with a non-admin role; Settings PATCH needs
+# admin privileges so we use the unified human admin instead).
+# Per project_unified_admin_creds: tbaltzakis / TH!123789th!
+ADMIN_USER="${ESPOCRM_ADMIN_USER:-tbaltzakis}"
+ADMIN_PASS="${ESPOCRM_ADMIN_PASSWORD:-}"
+
+if [[ -z "$ADMIN_PASS" ]]; then
+  ADMIN_PASS=$(ssm_get ESPOCRM_ADMIN_PASSWORD "")
+fi
+
+for v in USER PASS ADMIN_PASS; do
   if [[ -z "${!v}" ]]; then
-    echo "✗ SSM key /cloudless/production/${v#API_}... missing (resolved to empty)"
-    echo "  Run \`pnpm ses:provision\` first for SES_SMTP_*."
+    echo "✗ Missing required value: $v"
+    if [[ "$v" == "USER" || "$v" == "PASS" ]]; then
+      echo "  Run \`pnpm ses:provision\` first to populate SES_SMTP_USER/PASSWORD."
+    else
+      echo "  Set ESPOCRM_ADMIN_PASSWORD env var OR put it in SSM at"
+      echo "  /cloudless/production/ESPOCRM_ADMIN_PASSWORD"
+    fi
     exit 1
   fi
 done
 
-echo "→ POSTing EspoCRM SMTP settings to $ESPOCRM_BASE_URL"
+echo "→ PATCHing EspoCRM SMTP settings at $ESPOCRM_BASE_URL"
+echo "  as admin: $ADMIN_USER  via HTTP basic"
 
-# EspoCRM Settings API accepts a JSON body of the same field names that
-# live in data/config.php. Authenticated via X-Api-Key header.
+# EspoCRM PATCH /api/v1/Settings accepts a JSON body matching the keys
+# in data/config.php. Admin-only operation; the API key user (non-admin)
+# would get 403. HTTP Basic with admin creds works.
 HTTP=$(curl -sS -o /tmp/espo-smtp.resp -w '%{http_code}' \
   -X PATCH "$ESPOCRM_BASE_URL/api/v1/Settings" \
-  -H "X-Api-Key: $API_KEY" \
+  -u "$ADMIN_USER:$ADMIN_PASS" \
   -H 'Content-Type: application/json' \
   --data @<(cat <<JSON
 {
@@ -73,10 +91,10 @@ fi
 rm -f /tmp/espo-smtp.resp
 
 # Send a test email to confirm
-echo "→ Sending test email"
+echo "→ Sending test email to tbaltzakis@cloudless.gr"
 TEST=$(curl -sS -o /tmp/espo-test.resp -w '%{http_code}' \
   -X POST "$ESPOCRM_BASE_URL/api/v1/Email/sendTest" \
-  -H "X-Api-Key: $API_KEY" \
+  -u "$ADMIN_USER:$ADMIN_PASS" \
   -H 'Content-Type: application/json' \
-  -d "{\"to\":\"tbaltzakis@cloudless.gr\"}")
-echo "  test HTTP $TEST"; cat /tmp/espo-test.resp; rm -f /tmp/espo-test.resp
+  -d "{\"server\":\"$HOST\",\"port\":587,\"auth\":true,\"security\":\"TLS\",\"username\":\"$USER\",\"password\":\"$PASS\",\"fromAddress\":\"$FROM\",\"emailAddress\":\"tbaltzakis@cloudless.gr\"}")
+echo "  test HTTP $TEST"; cat /tmp/espo-test.resp; echo; rm -f /tmp/espo-test.resp


### PR DESCRIPTION
EspoCRM 401 fix: switch bootstrap from API-key (non-admin role) to HTTP basic with tbaltzakis admin. Adds IAM least-privilege policy for pnpm ses:provision (6 IAM actions scoped to cloudless-ses-smtp user + 3 SSM keys + targeted KMS decrypt).