### PR TITLE
fix(format): pnpm prettier --write on 3 files

### DIFF
--- a/src/app/[locale]/admin/cluster/page.tsx
+++ b/src/app/[locale]/admin/cluster/page.tsx
@@ -96,16 +96,15 @@ export default function ClusterStatusPage() {
         <h1 className="font-heading text-2xl font-bold text-white">Monitoring watchdogs</h1>
         <p className="mt-2 font-mono text-xs text-slate-500">
           In-cluster CronJobs that replaced the failing remote Claude Code on the Web routines (PR
-          #1048). Posts to Slack <code className="text-slate-400">C09AF5W3X16</code> on any
-          warning.
+          #1048). Posts to Slack <code className="text-slate-400">C09AF5W3X16</code> on any warning.
         </p>
       </div>
 
       {outsideCluster && (
         <div className="rounded-xl border border-yellow-900/30 bg-yellow-950/10 p-6">
           <p className="font-mono text-sm text-yellow-400">
-            This page only renders inside the cluster pod. Local dev / preview deploys see
-            this banner instead of live data.
+            This page only renders inside the cluster pod. Local dev / preview deploys see this
+            banner instead of live data.
           </p>
         </div>
       )}

--- a/src/lib/notion-analytics.ts
+++ b/src/lib/notion-analytics.ts
@@ -135,8 +135,7 @@ export async function getRecentEvents(
   limit = 50
 ): Promise<AnalyticsEvent[]> {
   const typeFilter = typeof filterOrLimit === "string" ? filterOrLimit : null;
-  const cap =
-    typeof filterOrLimit === "number" ? filterOrLimit : Math.max(1, Math.min(limit, 500));
+  const cap = typeof filterOrLimit === "number" ? filterOrLimit : Math.max(1, Math.min(limit, 500));
   const where = typeFilter ? `WHERE event = '${typeFilter.replace(/'/g, "''")}' ` : "";
   const sql =
     `SELECT \`timestamp\`, event, page, source, country, properties ` +

--- a/src/lib/notion-reports.ts
+++ b/src/lib/notion-reports.ts
@@ -30,10 +30,7 @@ export async function notionCreateReport(_report: Report): Promise<string | null
   return null;
 }
 
-export async function notionUpdateReport(
-  _id: string,
-  _updates: Partial<Report>
-): Promise<boolean> {
+export async function notionUpdateReport(_id: string, _updates: Partial<Report>): Promise<boolean> {
   return false;
 }
 


### PR DESCRIPTION
CI workflow was failing on Lint & Format (3 files needed prettier). Running pnpm format fixes them in-place. Bulk unit test failures are a separate pre-existing issue tracked outside this PR — they have been hidden by the --admin merge pattern, and need triage (likely Notion B1-B4 decom side effects).