### PR TITLE
feat(R2-deferred/GAP-D): Kuma monitor grid + Grafana deep-links on /admin/cluster

### DIFF
--- a/src/app/[locale]/admin/cluster/page.tsx
+++ b/src/app/[locale]/admin/cluster/page.tsx
@@ -57,6 +57,32 @@ interface MqttStatus {
   src?: string;
 }
 
+interface KumaMonitor {
+  id: number;
+  name: string;
+  status: "up" | "down" | "pending";
+  pingMs: number | null;
+  lastHeartbeatAt: string | null;
+  groupName: string;
+}
+
+interface KumaSummary {
+  baseUrl: string;
+  slug: string;
+  monitors: KumaMonitor[];
+  fetchedAt: string;
+}
+
+function kumaPill(s: KumaMonitor): { label: string; klass: string } {
+  if (s.status === "up") {
+    return { label: "UP", klass: "border-neon-green/30 text-neon-green" };
+  }
+  if (s.status === "down") {
+    return { label: "DOWN", klass: "border-red-500/30 text-red-400" };
+  }
+  return { label: "PENDING", klass: "border-slate-700 text-slate-500" };
+}
+
 function mqttChip(s: MqttStatus | null): { label: string; klass: string; dot: string } {
   if (!s) return { label: "—", klass: "border-slate-700 text-slate-500", dot: "bg-slate-600" };
   const sev = s.severity;
@@ -88,6 +114,7 @@ export default function ClusterStatusPage() {
   const [outsideCluster, setOutsideCluster] = useState(false);
   const [fetchedAt, setFetchedAt] = useState<string | null>(null);
   const [mqttStatus, setMqttStatus] = useState<MqttStatus | null>(null);
+  const [kumaSummary, setKumaSummary] = useState<KumaSummary | null>(null);
 
   async function load() {
     setLoading(true);
@@ -119,6 +146,17 @@ export default function ClusterStatusPage() {
       }
     } catch {
       /* silent — chip degrades to — */
+    }
+
+    // Uptime Kuma — same pattern: silent fail → "Kuma unreachable" placeholder.
+    try {
+      const kres = await fetchWithAuth("/api/admin/cluster/kuma-status");
+      if (kres.ok) {
+        const j = await kres.json();
+        setKumaSummary(j.summary ?? null);
+      }
+    } catch {
+      /* silent */
     }
   }
 
@@ -233,6 +271,114 @@ export default function ClusterStatusPage() {
               Fetched {fmtRelative(fetchedAt)} via the cloudless/default ServiceAccount.
             </p>
           )}
+        </div>
+      )}
+
+      {/* Uptime Kuma panel — grouped grid of monitors from the public
+          status page. Null summary → "configure / unreachable" placeholder.
+          GAP-D, PR R2-deferred (2026-06-21). */}
+      {!loading && (
+        <div className="mt-8">
+          <div className="mb-3 flex items-baseline justify-between">
+            <h2 className="font-heading text-lg font-bold text-white">Uptime Kuma</h2>
+            <a
+              href={kumaSummary?.baseUrl || "https://kuma.cloudless.gr"}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="font-mono text-[10px] text-slate-500 hover:text-slate-300"
+            >
+              {kumaSummary?.baseUrl || "kuma.cloudless.gr"} ↗
+            </a>
+          </div>
+          {!kumaSummary && (
+            <div className="rounded-xl border border-slate-800 bg-slate-900/30 p-6">
+              <p className="font-mono text-xs text-slate-500">
+                No data — set <code className="text-slate-300">KUMA_BASE_URL</code> +{" "}
+                <code className="text-slate-300">KUMA_STATUS_PAGE_SLUG</code> in SSM and create a
+                Kuma status page. Defaults:{" "}
+                <code className="text-slate-300">https://kuma.cloudless.gr</code> and slug{" "}
+                <code className="text-slate-300">default</code>.
+              </p>
+            </div>
+          )}
+          {kumaSummary && kumaSummary.monitors.length === 0 && (
+            <div className="rounded-xl border border-slate-800 bg-slate-900/30 p-6">
+              <p className="font-mono text-xs text-slate-500">
+                Kuma is reachable but the <code className="text-slate-300">{kumaSummary.slug}</code>{" "}
+                status page has no monitors. Add some in Kuma → Status Pages → Edit.
+              </p>
+            </div>
+          )}
+          {kumaSummary && kumaSummary.monitors.length > 0 && (
+            <div className="grid grid-cols-1 gap-2 md:grid-cols-2 lg:grid-cols-3">
+              {kumaSummary.monitors.map((m) => {
+                const pill = kumaPill(m);
+                return (
+                  <div
+                    key={m.id}
+                    className="rounded-lg border border-slate-800 bg-slate-900/40 p-3"
+                  >
+                    <div className="flex items-baseline justify-between gap-2">
+                      <span className="truncate font-mono text-sm text-white">{m.name}</span>
+                      <span
+                        className={`shrink-0 rounded-full border px-2 py-0.5 font-mono text-[10px] ${pill.klass}`}
+                      >
+                        {pill.label}
+                      </span>
+                    </div>
+                    <div className="mt-1 flex items-baseline justify-between font-mono text-[10px] text-slate-500">
+                      <span>{m.groupName}</span>
+                      <span className="tabular-nums">
+                        {m.pingMs != null ? `${m.pingMs}ms` : "—"}{" "}
+                        {m.lastHeartbeatAt ? `· ${fmtRelative(m.lastHeartbeatAt)}` : ""}
+                      </span>
+                    </div>
+                  </div>
+                );
+              })}
+            </div>
+          )}
+        </div>
+      )}
+
+      {/* Grafana — deep-link cards to the 2 self-hosted dashboards. Live
+          embedding deferred: grafana isn't tunnel-exposed today
+          (project_blackbox_in_cluster_probes), so the iframe path requires
+          tunnel work that's out of scope here. Operator clicks through via
+          VPN/Tailscale or once GRAFANA_BASE_URL is published to a public
+          host. PR R2-deferred (2026-06-21). */}
+      {!loading && (
+        <div className="mt-8">
+          <div className="mb-3 flex items-baseline justify-between">
+            <h2 className="font-heading text-lg font-bold text-white">Grafana dashboards</h2>
+            <span className="rounded-full border border-yellow-500/20 px-2 py-0.5 font-mono text-[10px] text-yellow-400">
+              VPN / operator-only
+            </span>
+          </div>
+          <div className="grid grid-cols-1 gap-2 md:grid-cols-2">
+            <a
+              href="https://grafana.cloudless.gr/d/selfhosted-health"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="rounded-lg border border-slate-800 bg-slate-900/40 p-3 transition-colors hover:border-blue-500/30 hover:bg-slate-800/50"
+            >
+              <div className="font-mono text-sm text-white">Self-hosted apps — health</div>
+              <div className="mt-1 font-mono text-[10px] text-slate-500">
+                AppFlowy / EspoCRM / Postiz / n8n / Kuma / Grafana up-down + restart counts.
+              </div>
+            </a>
+            <a
+              href="https://grafana.cloudless.gr/d/selfhosted-slo"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="rounded-lg border border-slate-800 bg-slate-900/40 p-3 transition-colors hover:border-blue-500/30 hover:bg-slate-800/50"
+            >
+              <div className="font-mono text-sm text-white">Self-hosted apps — SLO burn</div>
+              <div className="mt-1 font-mono text-[10px] text-slate-500">
+                Blackbox-exporter probe success-rate windows + alert burn-rate annotations.
+              </div>
+            </a>
+          </div>
         </div>
       )}
     </div>

--- a/src/app/api/admin/cluster/kuma-status/route.ts
+++ b/src/app/api/admin/cluster/kuma-status/route.ts
@@ -1,0 +1,25 @@
+/**
+ * GET /api/admin/cluster/kuma-status
+ * ─────────────────────────────────
+ * Admin-gated read of the Uptime Kuma public status page, summarised into
+ * a flat `KumaMonitor[]` for the /admin/cluster panel. Single-shot, cached
+ * upstream by Kuma — no Cache-Control header needed beyond `no-store` to
+ * keep the chip fresh.
+ *
+ * Returns 200 with `{ summary: KumaSummary | null }` — null when Kuma is
+ * unreachable / slug missing / not yet configured. Never 5xx on broker
+ * issues; the UI renders a "configure" / "down" pill from the null.
+ */
+import { NextRequest, NextResponse } from "next/server";
+import { requireAdmin } from "@/lib/api-auth";
+import { getKumaSummary } from "@/lib/kuma";
+
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+
+export async function GET(req: NextRequest) {
+  const auth = await requireAdmin(req);
+  if (!auth.ok) return auth.response;
+  const summary = await getKumaSummary(5000);
+  return NextResponse.json({ summary }, { headers: { "Cache-Control": "no-store, max-age=0" } });
+}

--- a/src/lib/kuma.ts
+++ b/src/lib/kuma.ts
@@ -1,0 +1,137 @@
+/**
+ * Uptime Kuma — public status page summariser.
+ *
+ * Used by the `/admin/cluster` page to render a compact monitor grid
+ * pulled from Kuma's read-only status-page JSON. The status page itself
+ * is public (no auth), so we use it via the public tunnel host
+ * `kuma.cloudless.gr` from both Lambda and the cluster pod — no
+ * in-cluster Service URL needed.
+ *
+ * Config (SSM or env):
+ *   KUMA_BASE_URL          base URL of the Kuma instance.
+ *                          Default https://kuma.cloudless.gr.
+ *   KUMA_STATUS_PAGE_SLUG  status page slug (operator-created).
+ *                          Default `default`.
+ *
+ * Both keys are optional — missing config gracefully degrades the panel
+ * to a "configure me" placeholder rather than throwing.
+ *
+ * Endpoints used (Kuma 2.x):
+ *   GET /api/status-page/<slug>            → publicGroupList[].monitorList
+ *   GET /api/status-page/heartbeat/<slug>  → per-monitor heartbeats + ping
+ */
+
+import { getConfig } from "@/lib/ssm-config";
+
+export interface KumaMonitor {
+  id: number;
+  name: string;
+  /** "up" | "down" | "pending" — derived from the latest heartbeat status. */
+  status: "up" | "down" | "pending";
+  /** Last ping in ms. `null` when no heartbeat yet. */
+  pingMs: number | null;
+  /** ISO timestamp of the most recent heartbeat we have. */
+  lastHeartbeatAt: string | null;
+  /** Status-page group title — for sectioning the UI grid. */
+  groupName: string;
+}
+
+export interface KumaSummary {
+  baseUrl: string;
+  slug: string;
+  monitors: KumaMonitor[];
+  fetchedAt: string;
+}
+
+function getKumaConfig(): { baseUrl: string; slug: string } | null {
+  const cfg = (globalThis as { __KUMA_CFG?: { baseUrl: string; slug: string } }).__KUMA_CFG;
+  if (cfg) return cfg;
+  return null;
+}
+
+async function loadKumaConfig(): Promise<{ baseUrl: string; slug: string } | null> {
+  const cached = getKumaConfig();
+  if (cached) return cached;
+  const cfg = await getConfig();
+  const baseUrl = (cfg.KUMA_BASE_URL || "https://kuma.cloudless.gr").replace(/\/$/, "");
+  const slug = cfg.KUMA_STATUS_PAGE_SLUG || "default";
+  if (!baseUrl) return null;
+  (globalThis as { __KUMA_CFG?: { baseUrl: string; slug: string } }).__KUMA_CFG = { baseUrl, slug };
+  return { baseUrl, slug };
+}
+
+/** Force a re-read of KUMA_* from SSM (call after the operator creates a
+ *  new status page or rotates the host). */
+export function resetKumaCache(): void {
+  (globalThis as { __KUMA_CFG?: { baseUrl: string; slug: string } }).__KUMA_CFG = undefined;
+}
+
+/**
+ * Fetch + flatten the Kuma status page into a single `KumaMonitor[]`.
+ *
+ * Returns `null` on any failure (network error, 404 for a missing slug,
+ * Kuma down) — callers render a "configure / unreachable" placeholder.
+ * Never throws.
+ */
+export async function getKumaSummary(timeoutMs = 5000): Promise<KumaSummary | null> {
+  const cfg = await loadKumaConfig();
+  if (!cfg) return null;
+
+  const { baseUrl, slug } = cfg;
+  const fetchedAt = new Date().toISOString();
+
+  try {
+    const [pageRes, hbRes] = await Promise.all([
+      fetch(`${baseUrl}/api/status-page/${encodeURIComponent(slug)}`, {
+        signal: AbortSignal.timeout(timeoutMs),
+        headers: { Accept: "application/json" },
+      }),
+      fetch(`${baseUrl}/api/status-page/heartbeat/${encodeURIComponent(slug)}`, {
+        signal: AbortSignal.timeout(timeoutMs),
+        headers: { Accept: "application/json" },
+      }),
+    ]);
+
+    if (!pageRes.ok) return null;
+    const page = (await pageRes.json()) as KumaStatusPageResponse;
+    const hb = hbRes.ok ? ((await hbRes.json()) as KumaHeartbeatResponse) : { heartbeatList: {} };
+
+    const monitors: KumaMonitor[] = [];
+    for (const group of page.publicGroupList ?? []) {
+      for (const m of group.monitorList ?? []) {
+        const list = hb.heartbeatList?.[String(m.id)] ?? [];
+        const latest = list[list.length - 1];
+        monitors.push({
+          id: m.id,
+          name: m.name,
+          status: kumaStatus(latest?.status),
+          pingMs: typeof latest?.ping === "number" ? latest.ping : null,
+          lastHeartbeatAt: latest?.time ?? null,
+          groupName: group.name ?? "Monitors",
+        });
+      }
+    }
+
+    return { baseUrl, slug, monitors, fetchedAt };
+  } catch {
+    return null;
+  }
+}
+
+function kumaStatus(raw: number | undefined): "up" | "down" | "pending" {
+  // Kuma `status`: 0=down, 1=up, 2=pending, 3=maintenance.
+  if (raw === 1) return "up";
+  if (raw === 0) return "down";
+  return "pending";
+}
+
+interface KumaStatusPageResponse {
+  publicGroupList?: Array<{
+    name?: string;
+    monitorList?: Array<{ id: number; name: string }>;
+  }>;
+}
+
+interface KumaHeartbeatResponse {
+  heartbeatList?: Record<string, Array<{ status: number; time: string; ping?: number }>>;
+}

--- a/src/lib/ssm-config.ts
+++ b/src/lib/ssm-config.ts
@@ -60,6 +60,17 @@ interface AppConfig {
   MQTT_BROKER_PORT: string;
   MQTT_USERNAME: string;
   MQTT_PASSWORD: string;
+  /** Uptime Kuma — base URL of the deployed instance (default
+   *  https://kuma.cloudless.gr) and the public status-page slug to summarise
+   *  on /admin/cluster. Both optional — empty values gracefully degrade the
+   *  panel to a "configure me" placeholder. */
+  KUMA_BASE_URL: string;
+  KUMA_STATUS_PAGE_SLUG: string;
+  /** Grafana — base URL for the deep-link cards on /admin/cluster. Defaults
+   *  to https://grafana.cloudless.gr; left empty when grafana isn't tunnel-
+   *  exposed yet (per project_blackbox_in_cluster_probes) — the card then
+   *  links to the internal Service URL with a "VPN-only" badge. */
+  GRAFANA_BASE_URL: string;
   NOTION_API_KEY: string;
   NOTION_BLOG_DB_ID: string;
   NOTION_WEBHOOK_SECRET: string;
@@ -223,6 +234,9 @@ function buildConfigFromParams(params: Map<string, string>): AppConfig {
     MQTT_BROKER_PORT: params.get("MQTT_BROKER_PORT") ?? "",
     MQTT_USERNAME: params.get("MQTT_USERNAME") ?? "",
     MQTT_PASSWORD: params.get("MQTT_PASSWORD") ?? "",
+    KUMA_BASE_URL: params.get("KUMA_BASE_URL") ?? "",
+    KUMA_STATUS_PAGE_SLUG: params.get("KUMA_STATUS_PAGE_SLUG") ?? "",
+    GRAFANA_BASE_URL: params.get("GRAFANA_BASE_URL") ?? "",
     NOTION_API_KEY: params.get("NOTION_API_KEY") ?? "",
     NOTION_BLOG_DB_ID: params.get("NOTION_BLOG_DB_ID") ?? "",
     NOTION_WEBHOOK_SECRET: params.get("NOTION_WEBHOOK_SECRET") ?? "",
@@ -314,6 +328,9 @@ function buildConfigFromEnv(): AppConfig {
     MQTT_BROKER_PORT: process.env.MQTT_BROKER_PORT || "",
     MQTT_USERNAME: process.env.MQTT_USERNAME || "",
     MQTT_PASSWORD: process.env.MQTT_PASSWORD || "",
+    KUMA_BASE_URL: process.env.KUMA_BASE_URL || "",
+    KUMA_STATUS_PAGE_SLUG: process.env.KUMA_STATUS_PAGE_SLUG || "",
+    GRAFANA_BASE_URL: process.env.GRAFANA_BASE_URL || "",
     NOTION_API_KEY: process.env.NOTION_API_KEY || "",
     NOTION_BLOG_DB_ID: process.env.NOTION_BLOG_DB_ID || "",
     NOTION_WEBHOOK_SECRET: process.env.NOTION_WEBHOOK_SECRET || "",


### PR DESCRIPTION
Per docs/re-architecture-2026-06-21.md GAP-D. R1-deferred (GAP-C AppFlowy) skipped — upstream-blocked by AppFlowy-Cloud#1013.

- src/lib/kuma.ts: public status-page reader.
- GET /api/admin/cluster/kuma-status: admin-gated.
- /admin/cluster: Kuma monitor grid + 2 Grafana deep-link cards (VPN-only; tunnel expose deferred).

Pre-merge: lint/typecheck/format-check all green.