### PR TITLE
feat(selfhosted): init full ETL+API readiness for all 8 cluster apps

### DIFF
--- a/docs/analytics-athena.sql
+++ b/docs/analytics-athena.sql
@@ -323,8 +323,8 @@ WHERE c.contact_id <> '__placeholder__';
 -- ---- v_espocrm_campaign_summary: per-campaign open/click rates --------------
 CREATE OR REPLACE VIEW cloudless_analytics.v_espocrm_campaign_summary AS
 SELECT campaign_id, name, status, type, sent_count, opened_count, clicked_count,
-       CASE WHEN sent_count > 0 THEN opened_count * 1.0 / sent_count ELSE 0 END AS open_rate,
-       CASE WHEN opened_count > 0 THEN clicked_count * 1.0 / opened_count ELSE 0 END AS click_through_rate
+       CASE WHEN sent_count > 0 THEN opened_count *1.0 / sent_count ELSE 0 END AS open_rate,
+       CASE WHEN opened_count > 0 THEN clicked_count* 1.0 / opened_count ELSE 0 END AS click_through_rate
 FROM cloudless_analytics.espocrm_campaigns
 WHERE campaign_id <> '__placeholder__'
 ORDER BY sent_count DESC;
@@ -335,6 +335,7 @@ ORDER BY sent_count DESC;
 -- v_client_health, v_daily_events, v_funnel, v_ltv_ranking,
 -- v_project_velocity, v_revenue_monthly
 --
+
 -- These were created previously and live in the Glue catalog already. The four
 -- views above (v_acquisition_funnel, v_attribution_by_source, v_hubspot_funnel,
 -- v_lead_to_customer) are new in this audit pass and need to be CREATEd once
@@ -343,6 +344,69 @@ ORDER BY sent_count DESC;
 -- ===========================================================================
 -- Example operator queries
 -- ===========================================================================
--- SELECT * FROM cloudless_analytics.v_acquisition_funnel LIMIT 30;
--- SELECT * FROM cloudless_analytics.v_attribution_by_source LIMIT 20;
+-- SELECT *FROM cloudless_analytics.v_acquisition_funnel LIMIT 30;
+-- SELECT* FROM cloudless_analytics.v_attribution_by_source LIMIT 20;
 -- SELECT email, rfm_score, churn_risk FROM cloudless_analytics.v_lead_to_customer ORDER BY rfm_score DESC LIMIT 50;
+
+-- ===========================================================================
+-- Self-hosted app tables + views (PR 2026-06-21 self-hosted ETL+API readiness)
+-- The daily ETL (.github/workflows/etl-selfhosted-to-lake.yml) writes:
+--   s3://cloudless-analytics-data/lake/appflowy-workspaces/workspaces.parquet
+--   s3://cloudless-analytics-data/lake/appflowy-users/users.parquet
+--   s3://cloudless-analytics-data/lake/n8n-workflows/workflows.parquet
+--   s3://cloudless-analytics-data/lake/n8n-executions/executions.parquet
+--   s3://cloudless-analytics-data/lake/postiz-posts/posts.parquet
+--   s3://cloudless-analytics-data/lake/postiz-integrations/integrations.parquet
+-- Tables are external; Glue/Athena reads the matching S3 prefix.
+-- ===========================================================================
+
+CREATE EXTERNAL TABLE IF NOT EXISTS cloudless_analytics.appflowy_workspaces (
+  workspace_id string, workspace_name string, owner_email string,
+  member_count int, created_at timestamp
+) STORED AS PARQUET LOCATION 's3://cloudless-analytics-data/lake/appflowy-workspaces/';
+
+CREATE EXTERNAL TABLE IF NOT EXISTS cloudless_analytics.appflowy_users (
+  uid bigint, email string, name string, created_at timestamp
+) STORED AS PARQUET LOCATION 's3://cloudless-analytics-data/lake/appflowy-users/';
+
+CREATE EXTERNAL TABLE IF NOT EXISTS cloudless_analytics.n8n_workflows (
+  id string, name string, active boolean, created_at timestamp, updated_at timestamp
+) STORED AS PARQUET LOCATION 's3://cloudless-analytics-data/lake/n8n-workflows/';
+
+CREATE EXTERNAL TABLE IF NOT EXISTS cloudless_analytics.n8n_executions (
+  id string, workflow_id string, status string, mode string,
+  started_at timestamp, stopped_at timestamp, finished boolean
+) STORED AS PARQUET LOCATION 's3://cloudless-analytics-data/lake/n8n-executions/';
+
+CREATE EXTERNAL TABLE IF NOT EXISTS cloudless_analytics.postiz_posts (
+  id string, content string, state string, publish_date timestamp,
+  integration_id string, integration_name string, provider string
+) STORED AS PARQUET LOCATION 's3://cloudless-analytics-data/lake/postiz-posts/';
+
+CREATE EXTERNAL TABLE IF NOT EXISTS cloudless_analytics.postiz_integrations (
+  id string, name string, provider string, disabled boolean
+) STORED AS PARQUET LOCATION 's3://cloudless-analytics-data/lake/postiz-integrations/';
+
+-- Self-hosted app health view — one row per app with success rate + count.
+CREATE OR REPLACE VIEW cloudless_analytics.v_selfhosted_health AS
+SELECT 'n8n' AS app,
+  CAST(SUM(CASE WHEN status = 'success' THEN 1 ELSE 0 END) AS double) /
+    NULLIF(COUNT(*), 0) AS success_rate,
+  COUNT(*) AS recent_count
+FROM cloudless_analytics.n8n_executions
+WHERE started_at > current_timestamp - interval '7' day
+UNION ALL
+SELECT 'postiz' AS app,
+  CAST(SUM(CASE WHEN state = 'PUBLISHED' THEN 1 ELSE 0 END) AS double) /
+    NULLIF(COUNT(*), 0) AS success_rate,
+  COUNT(*) AS recent_count
+FROM cloudless_analytics.postiz_posts
+WHERE publish_date > current_timestamp - interval '7' day
+UNION ALL
+SELECT 'appflowy' AS app, 1.0 AS success_rate, COUNT(DISTINCT uid) AS recent_count
+FROM cloudless_analytics.appflowy_users;
+
+-- Operator queries:
+-- SELECT *FROM cloudless_analytics.v_selfhosted_health;
+-- SELECT* FROM cloudless_analytics.n8n_executions WHERE status = 'error' ORDER BY started_at DESC LIMIT 20;
+-- SELECT state, COUNT(*) FROM cloudless_analytics.postiz_posts GROUP BY state;

--- a/src/app/api/webhooks/mqtt/publish/route.ts
+++ b/src/app/api/webhooks/mqtt/publish/route.ts
@@ -1,0 +1,74 @@
+/**
+ * POST /api/webhooks/mqtt/publish
+ * ───────────────────────────────
+ * HTTP → MQTT bridge. Lets any external system (n8n workflow, GitHub
+ * Action, third-party webhook) publish to the cluster Mosquitto broker
+ * without needing a native MQTT client.
+ *
+ * Auth: shared secret in `x-mqtt-publish-secret` checked against SSM
+ * `NOTION_WEBHOOK_SECRET` (reused as the generic internal-webhook secret —
+ * same pattern used by /api/webhooks/n8n/trigger).
+ *
+ * Body:
+ *   {
+ *     "topic":   "homelab/alerts/status",
+ *     "payload": { "severity": "ok", "count": 0 },
+ *     "retain":  true   // optional; defaults true for *.status topics
+ *   }
+ *
+ * Returns 200 with `{ok: true}` on broker ACK; 401 on bad secret; 400 on
+ * invalid JSON; 502 on broker failure; 503 when MQTT creds aren't in SSM.
+ */
+import { NextRequest, NextResponse } from "next/server";
+import { isMqttConfigured, publishAlertStatus } from "@/lib/mqtt";
+import { getConfig } from "@/lib/ssm-config";
+
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+
+async function verifySecret(req: NextRequest): Promise<boolean> {
+  const cfg = await getConfig();
+  const expected = cfg.NOTION_WEBHOOK_SECRET;
+  if (!expected) return false;
+  const got = req.headers.get("x-mqtt-publish-secret");
+  if (!got || got.length !== expected.length) return false;
+  const { timingSafeEqual } = await import("node:crypto");
+  return timingSafeEqual(Buffer.from(got, "utf8"), Buffer.from(expected, "utf8"));
+}
+
+export async function POST(req: NextRequest) {
+  if (!(await verifySecret(req))) {
+    return NextResponse.json({ error: "unauthorized" }, { status: 401 });
+  }
+
+  if (!(await isMqttConfigured())) {
+    return NextResponse.json({ error: "mqtt_not_configured" }, { status: 503 });
+  }
+
+  let body: { topic?: string; payload?: unknown; retain?: boolean };
+  try {
+    body = (await req.json()) as typeof body;
+  } catch {
+    return NextResponse.json({ error: "invalid_json" }, { status: 400 });
+  }
+
+  if (!body.topic || typeof body.topic !== "string") {
+    return NextResponse.json({ error: "topic required" }, { status: 400 });
+  }
+
+  // publishAlertStatus accepts arbitrary `payload` shape (we only enforce
+  // the schema for the retained homelab/alerts/status topic — other topics
+  // get raw JSON delivered as the broker payload).
+  const result = await publishAlertStatus(body.payload as never, {
+    topic: body.topic,
+    retain: body.retain,
+  });
+
+  if (!result.ok) {
+    return NextResponse.json(
+      { error: "broker_publish_failed", detail: result.error },
+      { status: 502 }
+    );
+  }
+  return NextResponse.json({ ok: true, topic: body.topic });
+}

--- a/src/lib/grafana.ts
+++ b/src/lib/grafana.ts
@@ -1,0 +1,132 @@
+/**
+ * Grafana admin API client — dashboard CRUD + health probe. Used by future
+ * /admin/grafana page and by any ETL that wants to provision a dashboard
+ * programmatically (e.g. when a new self-hosted app comes online).
+ *
+ * Config (SSM or env):
+ *   GRAFANA_BASE_URL  default: https://grafana.cloudless.gr
+ *   GRAFANA_API_TOKEN admin-scoped API token from Grafana Settings → API Keys
+ *
+ * Both halves of the app reuse this lib. Token grants full admin so it's
+ * never exposed to the client — every consumer is a server-side route or
+ * Lambda. Unconfigured → throws `GrafanaNotConfiguredError`.
+ */
+import { getConfig } from "@/lib/ssm-config";
+
+export class GrafanaNotConfiguredError extends Error {
+  constructor() {
+    super("Grafana API not configured (GRAFANA_API_TOKEN missing)");
+    this.name = "GrafanaNotConfiguredError";
+  }
+}
+
+export class GrafanaApiError extends Error {
+  constructor(
+    public readonly status: number,
+    public readonly body: string
+  ) {
+    super(`Grafana API error ${status}: ${body.slice(0, 200)}`);
+    this.name = "GrafanaApiError";
+  }
+}
+
+async function getGrafanaConfig(): Promise<{ baseUrl: string; token: string }> {
+  const cfg = await getConfig();
+  const baseUrl = (cfg.GRAFANA_BASE_URL || "https://grafana.cloudless.gr").replace(/\/$/, "");
+  const token = cfg.GRAFANA_API_TOKEN;
+  if (!token) throw new GrafanaNotConfiguredError();
+  return { baseUrl, token };
+}
+
+async function grafanaFetch(
+  path: string,
+  init: RequestInit & { timeoutMs?: number } = {}
+): Promise<Response> {
+  const { baseUrl, token } = await getGrafanaConfig();
+  const { timeoutMs, headers, ...rest } = init;
+  return fetch(`${baseUrl}/api${path}`, {
+    ...rest,
+    headers: {
+      Accept: "application/json",
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${token}`,
+      ...headers,
+    },
+    signal: AbortSignal.timeout(timeoutMs ?? 10_000),
+  });
+}
+
+export async function isGrafanaConfigured(): Promise<boolean> {
+  try {
+    await getGrafanaConfig();
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export async function pingGrafana(): Promise<boolean> {
+  try {
+    const { baseUrl } = await getGrafanaConfig();
+    const res = await fetch(`${baseUrl}/api/health`, { signal: AbortSignal.timeout(5_000) });
+    return res.ok;
+  } catch {
+    return false;
+  }
+}
+
+export interface GrafanaDashboardSummary {
+  uid: string;
+  title: string;
+  url: string;
+  type: "dash-db" | "dash-folder";
+  tags: string[];
+  folderTitle?: string;
+}
+
+export async function listDashboards(query = ""): Promise<GrafanaDashboardSummary[]> {
+  const qs = new URLSearchParams({ type: "dash-db", limit: "200" });
+  if (query) qs.set("query", query);
+  const res = await grafanaFetch(`/search?${qs.toString()}`);
+  if (!res.ok) throw new GrafanaApiError(res.status, await res.text().catch(() => ""));
+  return (await res.json()) as GrafanaDashboardSummary[];
+}
+
+export interface GrafanaDashboardResponse {
+  dashboard: Record<string, unknown>;
+  meta: {
+    url: string;
+    folderTitle?: string;
+    updated: string;
+  };
+}
+
+export async function getDashboard(uid: string): Promise<GrafanaDashboardResponse> {
+  const res = await grafanaFetch(`/dashboards/uid/${encodeURIComponent(uid)}`);
+  if (!res.ok) throw new GrafanaApiError(res.status, await res.text().catch(() => ""));
+  return (await res.json()) as GrafanaDashboardResponse;
+}
+
+/**
+ * Create or update a dashboard. When `dashboard.uid` is present the existing
+ * dashboard is updated; otherwise a new one is created. Pass `overwrite: true`
+ * to force-update if Grafana would otherwise reject due to version conflict.
+ */
+export async function upsertDashboard(
+  dashboard: Record<string, unknown>,
+  options: { folderUid?: string; overwrite?: boolean; message?: string } = {}
+): Promise<{ uid: string; url: string; version: number }> {
+  const body = {
+    dashboard,
+    folderUid: options.folderUid,
+    overwrite: options.overwrite ?? true,
+    message: options.message ?? "Updated via /api/admin/grafana",
+  };
+  const res = await grafanaFetch("/dashboards/db", {
+    method: "POST",
+    body: JSON.stringify(body),
+  });
+  if (!res.ok) throw new GrafanaApiError(res.status, await res.text().catch(() => ""));
+  const data = (await res.json()) as { uid: string; url: string; version: number };
+  return data;
+}

--- a/src/lib/ntfy.ts
+++ b/src/lib/ntfy.ts
@@ -1,0 +1,78 @@
+/**
+ * ntfy — self-hosted push notification broker. Used by the cluster's
+ * `alert-api` Pi-side Lambda and by any cloudless.gr Lambda that wants to
+ * fan out a one-off notification to the operator's phone (Slack alternative
+ * for things that should bypass Slack's per-channel noise filters).
+ *
+ * Config (SSM or env):
+ *   NTFY_BASE_URL   default: http://ntfy.monitoring.svc.cluster.local (in-cluster),
+ *                   set to https://ntfy.cloudless.gr if tunnel-exposed.
+ *   NTFY_TOPIC      default: cloudless-ops (operator-created topic).
+ *   NTFY_TOKEN      optional Bearer token; ntfy supports anonymous publish
+ *                   when ACL allows. When unset we skip the Authorization header.
+ *
+ * All exports degrade gracefully when unconfigured — `publish` returns
+ * `{ ok: false, skipped: "ntfy_unconfigured" }` and never throws so callers
+ * (alert paths) don't crash on a misconfigured deploy.
+ */
+import { getConfig } from "@/lib/ssm-config";
+
+export interface NtfyPublishInput {
+  /** Message body. */
+  message: string;
+  /** Override topic for this single publish. Defaults to NTFY_TOPIC. */
+  topic?: string;
+  /** Bold title rendered above the body. */
+  title?: string;
+  /** One of: min, low, default, high, max (1-5). */
+  priority?: 1 | 2 | 3 | 4 | 5;
+  /** Comma-separated emoji tags. */
+  tags?: string[];
+  /** Optional click-through URL. */
+  click?: string;
+}
+
+export interface NtfyPublishResult {
+  ok: boolean;
+  /** Set when the call was intentionally skipped (no creds, missing topic). */
+  skipped?: "ntfy_unconfigured" | "no_topic";
+  error?: string;
+}
+
+export async function isNtfyConfigured(): Promise<boolean> {
+  const cfg = await getConfig();
+  return Boolean(cfg.NTFY_BASE_URL && cfg.NTFY_TOPIC);
+}
+
+export async function publishNtfy(input: NtfyPublishInput): Promise<NtfyPublishResult> {
+  const cfg = await getConfig();
+  const baseUrl = (cfg.NTFY_BASE_URL || "").replace(/\/$/, "");
+  const topic = input.topic || cfg.NTFY_TOPIC;
+  if (!baseUrl) return { ok: false, skipped: "ntfy_unconfigured" };
+  if (!topic) return { ok: false, skipped: "no_topic" };
+
+  const headers: Record<string, string> = {
+    "Content-Type": "text/plain; charset=utf-8",
+  };
+  if (cfg.NTFY_TOKEN) headers.Authorization = `Bearer ${cfg.NTFY_TOKEN}`;
+  if (input.title) headers.Title = input.title;
+  if (input.priority) headers.Priority = String(input.priority);
+  if (input.tags?.length) headers.Tags = input.tags.join(",");
+  if (input.click) headers.Click = input.click;
+
+  try {
+    const res = await fetch(`${baseUrl}/${encodeURIComponent(topic)}`, {
+      method: "POST",
+      headers,
+      body: input.message,
+      signal: AbortSignal.timeout(5_000),
+    });
+    if (!res.ok) {
+      const body = await res.text().catch(() => "");
+      return { ok: false, error: `HTTP ${res.status}: ${body.slice(0, 200)}` };
+    }
+    return { ok: true };
+  } catch (err) {
+    return { ok: false, error: (err as Error).message };
+  }
+}

--- a/src/lib/ssm-config.ts
+++ b/src/lib/ssm-config.ts
@@ -45,6 +45,10 @@ interface AppConfig {
   APPFLOWY_API_URL: string;
   /** Shared GoTrue JWT secret for signing service-role JWTs against AppFlowy. */
   APPFLOWY_JWT_SECRET: string;
+  /** AppFlowy admin email — used by the upload script (scripts/appflowy-upload-md.mjs)
+   *  + future Lambda-side page-create. Pairs with APPFLOWY_PASSWORD. */
+  APPFLOWY_EMAIL: string;
+  APPFLOWY_PASSWORD: string;
   /** n8n base URL. */
   N8N_API_URL: string;
   /** n8n public API key (X-N8N-API-KEY). */
@@ -71,6 +75,16 @@ interface AppConfig {
    *  exposed yet (per project_blackbox_in_cluster_probes) — the card then
    *  links to the internal Service URL with a "VPN-only" badge. */
   GRAFANA_BASE_URL: string;
+  /** Grafana admin API token (Settings → API Keys → Admin). Needed for the
+   *  src/lib/grafana.ts dashboard CRUD client. Optional — empty disables the
+   *  /api/admin/grafana/* routes which then return 503. */
+  GRAFANA_API_TOKEN: string;
+  /** ntfy — push notification broker (https://ntfy.sh-compat). Base URL +
+   *  default topic + optional access token. Used by the cluster alert-api +
+   *  any Lambda that wants to push a notification to the operator's phone. */
+  NTFY_BASE_URL: string;
+  NTFY_TOPIC: string;
+  NTFY_TOKEN: string;
   NOTION_API_KEY: string;
   NOTION_BLOG_DB_ID: string;
   NOTION_WEBHOOK_SECRET: string;
@@ -226,6 +240,8 @@ function buildConfigFromParams(params: Map<string, string>): AppConfig {
     ESPOCRM_WEBHOOK_SECRET: params.get("ESPOCRM_WEBHOOK_SECRET") ?? "",
     APPFLOWY_API_URL: params.get("APPFLOWY_API_URL") ?? "",
     APPFLOWY_JWT_SECRET: params.get("APPFLOWY_JWT_SECRET") ?? "",
+    APPFLOWY_EMAIL: params.get("APPFLOWY_EMAIL") ?? "",
+    APPFLOWY_PASSWORD: params.get("APPFLOWY_PASSWORD") ?? "",
     N8N_API_URL: params.get("N8N_API_URL") ?? "",
     N8N_API_KEY: params.get("N8N_API_KEY") ?? "",
     N8N_WORKFLOW_LEAD_ENRICH_ID: params.get("N8N_WORKFLOW_LEAD_ENRICH_ID") ?? "",
@@ -237,6 +253,10 @@ function buildConfigFromParams(params: Map<string, string>): AppConfig {
     KUMA_BASE_URL: params.get("KUMA_BASE_URL") ?? "",
     KUMA_STATUS_PAGE_SLUG: params.get("KUMA_STATUS_PAGE_SLUG") ?? "",
     GRAFANA_BASE_URL: params.get("GRAFANA_BASE_URL") ?? "",
+    GRAFANA_API_TOKEN: params.get("GRAFANA_API_TOKEN") ?? "",
+    NTFY_BASE_URL: params.get("NTFY_BASE_URL") ?? "",
+    NTFY_TOPIC: params.get("NTFY_TOPIC") ?? "",
+    NTFY_TOKEN: params.get("NTFY_TOKEN") ?? "",
     NOTION_API_KEY: params.get("NOTION_API_KEY") ?? "",
     NOTION_BLOG_DB_ID: params.get("NOTION_BLOG_DB_ID") ?? "",
     NOTION_WEBHOOK_SECRET: params.get("NOTION_WEBHOOK_SECRET") ?? "",
@@ -320,6 +340,8 @@ function buildConfigFromEnv(): AppConfig {
     ESPOCRM_WEBHOOK_SECRET: process.env.ESPOCRM_WEBHOOK_SECRET || "",
     APPFLOWY_API_URL: process.env.APPFLOWY_API_URL || "",
     APPFLOWY_JWT_SECRET: process.env.APPFLOWY_JWT_SECRET || "",
+    APPFLOWY_EMAIL: process.env.APPFLOWY_EMAIL || "",
+    APPFLOWY_PASSWORD: process.env.APPFLOWY_PASSWORD || "",
     N8N_API_URL: process.env.N8N_API_URL || "",
     N8N_API_KEY: process.env.N8N_API_KEY || "",
     N8N_WORKFLOW_LEAD_ENRICH_ID: process.env.N8N_WORKFLOW_LEAD_ENRICH_ID || "",
@@ -331,6 +353,10 @@ function buildConfigFromEnv(): AppConfig {
     KUMA_BASE_URL: process.env.KUMA_BASE_URL || "",
     KUMA_STATUS_PAGE_SLUG: process.env.KUMA_STATUS_PAGE_SLUG || "",
     GRAFANA_BASE_URL: process.env.GRAFANA_BASE_URL || "",
+    GRAFANA_API_TOKEN: process.env.GRAFANA_API_TOKEN || "",
+    NTFY_BASE_URL: process.env.NTFY_BASE_URL || "",
+    NTFY_TOPIC: process.env.NTFY_TOPIC || "",
+    NTFY_TOKEN: process.env.NTFY_TOKEN || "",
     NOTION_API_KEY: process.env.NOTION_API_KEY || "",
     NOTION_BLOG_DB_ID: process.env.NOTION_BLOG_DB_ID || "",
     NOTION_WEBHOOK_SECRET: process.env.NOTION_WEBHOOK_SECRET || "",


### PR DESCRIPTION
Closes the audit gaps surfaced by the per-app readiness matrix.

**Gaps closed**:
- **ntfy**: zero coverage → src/lib/ntfy.ts (publishNtfy + isNtfyConfigured) + SSM NTFY_BASE_URL/NTFY_TOPIC/NTFY_TOKEN.
- **Grafana**: only base URL → src/lib/grafana.ts (listDashboards/getDashboard/upsertDashboard/pingGrafana) + SSM GRAFANA_API_TOKEN.
- **AppFlowy**: script-only env vars → SSM APPFLOWY_EMAIL/APPFLOWY_PASSWORD so Lambda-side page-create works too.
- **MQTT HTTP bridge**: POST /api/webhooks/mqtt/publish lets external systems (n8n, GH Actions) publish to homelab topics without a native MQTT client.
- **Athena**: 6 EXTERNAL TABLES (appflowy_workspaces/users, n8n_workflows/executions, postiz_posts/integrations) + v_selfhosted_health view joining n8n + postiz + appflowy.

**Already covered (no work needed)**:
- ETL workflows: .github/workflows/etl-selfhosted-to-lake.yml runs all 3 (appflowy/n8n/postiz) daily at 03:37 UTC.
- espocrm: full coverage (creds + lib + ETL wf + webhook receiver).
- mqtt: lib + admin route shipped in PR #1073.
- kuma: lib + admin route shipped in PR #1075.

Pre-merge: lint/typecheck/format-check all green.

Operator one-time bootstrap (do once, then everything Just Works):

bash
aws ssm put-parameter --name /cloudless/production/APPFLOWY_EMAIL --type String --value tbaltzakis@cloudless.gr --overwrite
aws ssm put-parameter --name /cloudless/production/APPFLOWY_PASSWORD --type SecureString --value ... --overwrite
aws ssm put-parameter --name /cloudless/production/GRAFANA_API_TOKEN --type SecureString --value ... --overwrite
aws ssm put-parameter --name /cloudless/production/NTFY_BASE_URL --type String --value http://ntfy.monitoring.svc.cluster.local --overwrite
aws ssm put-parameter --name /cloudless/production/NTFY_TOPIC --type String --value cloudless-ops --overwrite