### PR TITLE
feat(R4+R5+R6): admin-alerts (Slack+ntfy) + /admin/grafana + Apollo lead-enrich wiring

### DIFF
--- a/infrastructure/n8n/workflows/README.md
+++ b/infrastructure/n8n/workflows/README.md
@@ -33,7 +33,33 @@ two app-side automations wired in PR R2:
    kubectl -n cloudless rollout restart deploy/cloudless
    ```
 
+8. **For `lead-enrich` only**: add Apollo credentials so the Apollo enrich HTTP
+   node finds a usable key. The workflow JSON reads `$env.APOLLO_API_KEY` (set in
+   n8n → Settings → Variables, OR via SSM if the operator wires `APOLLO_API_KEY`
+   into the n8n pod env):
+   ```bash
+   aws ssm put-parameter \
+     --name /cloudless/production/APOLLO_API_KEY \
+     --type SecureString --value 'paste-real-key-from-apollo.io/settings/credits' --overwrite
+   ```
+   The workflow's `continueOnFail: true` on the Apollo node means it degrades
+   gracefully — round-robin owner assignment + Slack DM still fire even if the
+   enrich step errors. Free Apollo plan = 50 credits/month is fine for low
+   lead volume.
+
 ## Verify
+
+Easiest path — use the canned probe script:
+
+```bash
+bash scripts/probe-lead-enrich.sh
+```
+
+It reads `NOTION_WEBHOOK_SECRET` from SSM, POSTs a synthetic Lead, and
+prints HTTP + body. It also tails the most recent n8n execution if
+`N8N_API_KEY` is set.
+
+Or by hand:
 
 ```bash
 # Should respond 200 with the workflow's webhook output

--- a/scripts/probe-lead-enrich.sh
+++ b/scripts/probe-lead-enrich.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+# probe-lead-enrich.sh — dry-run the EspoCRM Lead → n8n → Apollo enrich loop.
+#
+# What it does:
+#   1. Reads NOTION_WEBHOOK_SECRET from SSM (the internal-webhook secret
+#      reused by the n8n trigger receiver).
+#   2. POSTs a synthetic Lead payload to /api/webhooks/n8n/trigger with the
+#      lead-enrich alias.
+#   3. Surfaces the response code + body so the operator can see the loop
+#      either fired (200), no-op'd (204 = workflow ID not set in SSM yet),
+#      or failed (4xx/5xx).
+#   4. Optionally tails the n8n executions API for the most recent run if
+#      N8N_API_KEY is set.
+#
+# Usage:
+#   bash scripts/probe-lead-enrich.sh              # local — hits production
+#   BASE_URL=https://staging.cloudless.gr bash scripts/probe-lead-enrich.sh
+#
+# R6 of the 2026-06-21 R-series.
+set -uo pipefail
+
+BASE_URL="${BASE_URL:-https://cloudless.gr}"
+SECRET=$(aws ssm get-parameter --name /cloudless/production/NOTION_WEBHOOK_SECRET \
+  --with-decryption --query Parameter.Value --output text 2>/dev/null)
+
+if [[ -z "$SECRET" ]]; then
+  echo "ERROR: NOTION_WEBHOOK_SECRET not in SSM — cannot authenticate the probe."
+  exit 1
+fi
+
+PAYLOAD=$(cat <<JSON
+{
+  "name": "lead-enrich",
+  "payload": {
+    "entity": "Lead",
+    "action": "create",
+    "record": {
+      "id": "probe-lead-$(date +%s)",
+      "firstName": "Probe",
+      "lastName": "Lead",
+      "emailAddress": "probe+leadenrich@cloudless.gr",
+      "accountName": "Probe Co"
+    }
+  }
+}
+JSON
+)
+
+echo "=== POST $BASE_URL/api/webhooks/n8n/trigger ==="
+RESP=$(curl -sk -o /tmp/probe-lead-enrich.json -w '%{http_code}' \
+  -X POST -H 'Content-Type: application/json' \
+  -H "x-n8n-trigger-secret: $SECRET" \
+  -d "$PAYLOAD" \
+  "$BASE_URL/api/webhooks/n8n/trigger")
+
+echo "HTTP $RESP"
+case "$RESP" in
+  200)  echo "✅ workflow fired — $(head -c 200 /tmp/probe-lead-enrich.json)" ;;
+  204)  echo "ℹ️  workflow ID not in SSM yet — graceful no-op; see infrastructure/n8n/workflows/README.md" ;;
+  401)  echo "❌ secret rejected (NOTION_WEBHOOK_SECRET mismatch between SSM + receiver)" ;;
+  503)  echo "❌ n8n not configured (N8N_API_URL or N8N_API_KEY missing in SSM)" ;;
+  502)  echo "❌ n8n upstream failed — $(head -c 200 /tmp/probe-lead-enrich.json)" ;;
+  *)    echo "❌ unexpected: $(head -c 200 /tmp/probe-lead-enrich.json)" ;;
+esac
+
+# Optional — tail the n8n execution list for the most recent record.
+N8N_KEY=$(aws ssm get-parameter --name /cloudless/production/N8N_API_KEY \
+  --with-decryption --query Parameter.Value --output text 2>/dev/null || echo "")
+N8N_URL=$(aws ssm get-parameter --name /cloudless/production/N8N_API_URL \
+  --query Parameter.Value --output text 2>/dev/null || echo "")
+
+if [[ -n "$N8N_KEY" && -n "$N8N_URL" ]]; then
+  echo
+  echo "=== Most recent n8n execution ==="
+  curl -sk -H "X-N8N-API-KEY: $N8N_KEY" \
+    "${N8N_URL%/}/api/v1/executions?limit=1&includeData=false" \
+    | python3 -c "import sys,json
+d = json.load(sys.stdin).get('data', [])
+if not d:
+    print('  no executions yet')
+else:
+    e = d[0]
+    print(f\"  id={e.get('id')} workflow={e.get('workflowId')} status={e.get('status')} started={e.get('startedAt')}\")"
+fi
+
+rm -f /tmp/probe-lead-enrich.json

--- a/src/app/[locale]/admin/grafana/page.tsx
+++ b/src/app/[locale]/admin/grafana/page.tsx
@@ -1,0 +1,173 @@
+"use client";
+
+/**
+ * /admin/grafana — dashboard inventory + health chip.
+ *
+ * R5 of the 2026-06-21 R-series. Lists every Grafana dashboard the admin
+ * token can see, links each one out to grafana.cloudless.gr, surfaces an
+ * up/down chip from `pingGrafana()`. When `GRAFANA_API_TOKEN` is unset the
+ * page renders a "configure me" placeholder pointing at the rotation steps
+ * documented in `[[project-unified-admin-creds]]` memory.
+ *
+ * Grafana is not Cloudflare-tunnel-exposed (per
+ * `project_blackbox_in_cluster_probes`), so the deep-links require VPN /
+ * Tailscale. The "open" affordance is rendered regardless — the badge tells
+ * the operator if they need to be on-tailnet.
+ */
+import { fetchWithAuth } from "@/lib/fetch-with-auth";
+import { useEffect, useState } from "react";
+import { Link } from "@/i18n/navigation";
+import { Spinner, ErrorMsg } from "@/components/admin/CampaignPageKit";
+
+interface GrafanaDashboardSummary {
+  uid: string;
+  title: string;
+  url: string;
+  type: string;
+  tags: string[];
+  folderTitle?: string;
+}
+
+interface HealthResp {
+  configured: boolean;
+  healthy: boolean;
+}
+
+const GRAFANA_BASE = "https://grafana.cloudless.gr";
+
+function fmtTags(tags: string[]): string {
+  return tags.length === 0 ? "—" : tags.slice(0, 4).join(", ");
+}
+
+export default function GrafanaAdminPage() {
+  const [dashboards, setDashboards] = useState<GrafanaDashboardSummary[]>([]);
+  const [configured, setConfigured] = useState<boolean | null>(null);
+  const [health, setHealth] = useState<HealthResp | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  async function load() {
+    setLoading(true);
+    setError(null);
+    try {
+      const [dRes, hRes] = await Promise.all([
+        fetchWithAuth("/api/admin/grafana/dashboards"),
+        fetchWithAuth("/api/admin/grafana/health"),
+      ]);
+      if (!dRes.ok && dRes.status !== 503) {
+        throw new Error(`dashboards HTTP ${dRes.status}`);
+      }
+      const d = await dRes.json();
+      setDashboards(d.dashboards ?? []);
+      setConfigured(Boolean(d.configured));
+      if (hRes.ok) setHealth(await hRes.json());
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Failed to load");
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  useEffect(() => {
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    load();
+  }, []);
+
+  const chip = (() => {
+    if (!health || configured === null) {
+      return { label: "—", klass: "border-slate-700 text-slate-500" };
+    }
+    if (!health.configured)
+      return { label: "UNCONFIGURED", klass: "border-yellow-500/30 text-yellow-400" };
+    if (health.healthy) return { label: "OK", klass: "border-neon-green/30 text-neon-green" };
+    return { label: "UNREACHABLE", klass: "border-red-500/30 text-red-400" };
+  })();
+
+  return (
+    <div>
+      <div className="mb-6">
+        <Link href="/admin" className="font-mono text-xs text-slate-500 hover:text-slate-300">
+          ← Admin
+        </Link>
+      </div>
+      <div className="mb-8">
+        <div className="mb-4 inline-flex items-center gap-2 rounded-full border border-orange-500/20 bg-orange-500/10 px-3 py-1.5">
+          <span className="h-2 w-2 animate-pulse rounded-full bg-orange-400" />
+          <span className="font-mono text-xs text-orange-400">GRAFANA</span>
+        </div>
+        <h1 className="font-heading text-2xl font-bold text-white">Grafana dashboards</h1>
+        <p className="mt-2 font-mono text-xs text-slate-500">
+          Every dashboard the <code className="text-slate-400">cloudless-app</code> service account
+          can see. Grafana isn&apos;t Cloudflare-tunnel-exposed —{" "}
+          <code className="text-slate-400">grafana.cloudless.gr</code> links require VPN/Tailscale.
+        </p>
+        <div className="mt-4 inline-flex items-center gap-2 rounded-full border border-slate-800 bg-slate-900/40 px-3 py-1.5">
+          <span
+            className={`h-2 w-2 rounded-full ${
+              chip.label === "OK" ? "bg-neon-green" : "animate-pulse bg-slate-600"
+            }`}
+          />
+          <span className="font-mono text-[10px] text-slate-400">API</span>
+          <span className={`rounded-full border px-2 py-0.5 font-mono text-[10px] ${chip.klass}`}>
+            {chip.label}
+          </span>
+        </div>
+      </div>
+
+      {loading && <Spinner color="border-orange-400" />}
+      {error && <ErrorMsg msg={error} />}
+
+      {!loading && configured === false && (
+        <div className="rounded-xl border border-yellow-900/30 bg-yellow-950/10 p-6">
+          <p className="font-mono text-sm text-yellow-400">
+            <code>GRAFANA_API_TOKEN</code> isn&apos;t set in SSM. Generate a Service Account token
+            in Grafana → Administration → Users and access → Service accounts (or via the in-cluster
+            API), then{" "}
+            <code className="text-slate-300">
+              aws ssm put-parameter --name /cloudless/production/GRAFANA_API_TOKEN --type
+              SecureString --value &apos;glsa_...&apos; --overwrite
+            </code>
+            .
+          </p>
+        </div>
+      )}
+
+      {!loading && !error && configured && dashboards.length === 0 && (
+        <div className="rounded-xl border border-slate-800 bg-slate-900/30 p-6">
+          <p className="font-mono text-xs text-slate-500">
+            Token is valid but no dashboards exist yet. Import some from{" "}
+            <a
+              href={`${GRAFANA_BASE}/dashboards`}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-slate-300 underline"
+            >
+              grafana.cloudless.gr/dashboards
+            </a>
+            .
+          </p>
+        </div>
+      )}
+
+      {!loading && !error && configured && dashboards.length > 0 && (
+        <div className="grid grid-cols-1 gap-2 md:grid-cols-2 lg:grid-cols-3">
+          {dashboards.map((d) => (
+            <a
+              key={d.uid}
+              href={`${GRAFANA_BASE}${d.url}`}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="block rounded-lg border border-slate-800 bg-slate-900/40 p-3 transition-colors hover:border-orange-500/30 hover:bg-slate-800/50"
+            >
+              <div className="truncate font-mono text-sm text-white">{d.title}</div>
+              <div className="mt-1 flex items-baseline justify-between font-mono text-[10px] text-slate-500">
+                <span className="truncate">{d.folderTitle ?? "General"}</span>
+                <span className="ml-2 shrink-0">{fmtTags(d.tags)}</span>
+              </div>
+            </a>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/app/api/admin/grafana/dashboards/route.ts
+++ b/src/app/api/admin/grafana/dashboards/route.ts
@@ -1,0 +1,44 @@
+/**
+ * GET /api/admin/grafana/dashboards
+ * ────────────────────────────────
+ * Admin-gated list of Grafana dashboards via `src/lib/grafana.ts`. Used by
+ * the /admin/grafana page card grid.
+ *
+ * Returns `{ dashboards: [], configured: false }` when GRAFANA_API_TOKEN
+ * isn't set — UI shows a "configure me" placeholder rather than a 500.
+ */
+import { NextRequest, NextResponse } from "next/server";
+import { requireAdmin } from "@/lib/api-auth";
+import { GrafanaNotConfiguredError, isGrafanaConfigured, listDashboards } from "@/lib/grafana";
+
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+
+export async function GET(req: NextRequest) {
+  const auth = await requireAdmin(req);
+  if (!auth.ok) return auth.response;
+
+  const configured = await isGrafanaConfigured();
+  if (!configured) {
+    return NextResponse.json(
+      { dashboards: [], configured: false },
+      { headers: { "Cache-Control": "no-store, max-age=0" } }
+    );
+  }
+
+  try {
+    const dashboards = await listDashboards();
+    return NextResponse.json(
+      { dashboards, configured: true },
+      { headers: { "Cache-Control": "no-store, max-age=0" } }
+    );
+  } catch (err) {
+    if (err instanceof GrafanaNotConfiguredError) {
+      return NextResponse.json({ dashboards: [], configured: false }, { status: 503 });
+    }
+    return NextResponse.json(
+      { error: "grafana_upstream_failed", detail: (err as Error).message },
+      { status: 502 }
+    );
+  }
+}

--- a/src/app/api/admin/grafana/health/route.ts
+++ b/src/app/api/admin/grafana/health/route.ts
@@ -1,0 +1,23 @@
+/**
+ * GET /api/admin/grafana/health
+ * ────────────────────────────
+ * Admin-gated chip data for /admin/grafana: returns `configured` + `healthy`
+ * so the UI can render the live status pill without exposing the API token.
+ */
+import { NextRequest, NextResponse } from "next/server";
+import { requireAdmin } from "@/lib/api-auth";
+import { isGrafanaConfigured, pingGrafana } from "@/lib/grafana";
+
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+
+export async function GET(req: NextRequest) {
+  const auth = await requireAdmin(req);
+  if (!auth.ok) return auth.response;
+  const configured = await isGrafanaConfigured();
+  const healthy = configured ? await pingGrafana() : false;
+  return NextResponse.json(
+    { configured, healthy },
+    { headers: { "Cache-Control": "no-store, max-age=0" } }
+  );
+}

--- a/src/lib/admin-alerts.ts
+++ b/src/lib/admin-alerts.ts
@@ -1,0 +1,137 @@
+/**
+ * admin-alerts — unified fan-out for operator-facing alerts.
+ *
+ * Today's options:
+ *   - Slack (always on, primary): uses `SlackClient` + `getSlackOpsUsers()`
+ *     per `feedback_slack_use_slackclient` + `feedback_slack_lambda_env_frozen`.
+ *   - ntfy (opt-in, secondary): push-notification fan-out to the operator's
+ *     phone via `src/lib/ntfy.ts`. Enabled by env `ADMIN_PUSH_VIA_NTFY=1`.
+ *
+ * R4 of the 2026-06-21 R-series. Operator wanted phone push for SEV1 alerts
+ * even when the laptop is closed; ntfy delivers that without rebuilding the
+ * existing Slack flow. Both channels fire in parallel via `Promise.allSettled`
+ * so one failing doesn't drop the other.
+ *
+ * Call site:
+ *   await notifyAdmin({
+ *     severity: "high",
+ *     title:    "espocrm down",
+ *     message:  "5xx from /api/v1/App/user for 3min",
+ *     click:    "https://espocrm.cloudless.gr",
+ *   });
+ *
+ * Existing `slackContactNotify` etc. keep working unchanged — this helper
+ * is purely additive for the new "alerts that should bypass Slack noise
+ * filters" lane.
+ */
+import { SlackClient } from "@/lib/slack-notify";
+import { getSlackOpsUsers } from "@/lib/slack-ops-users";
+import { publishNtfy } from "@/lib/ntfy";
+
+export type AdminAlertSeverity = "info" | "warning" | "error" | "high" | "critical";
+
+export interface AdminAlertInput {
+  severity: AdminAlertSeverity;
+  /** Short headline — both Slack title + ntfy notification title. */
+  title: string;
+  /** Longer body. Plain text; markdown is rendered as-is by Slack and as
+   *  plain text by ntfy (ntfy markdown requires a header opt-in we skip). */
+  message: string;
+  /** Optional click-through URL — shown as a tappable link in ntfy and
+   *  appended to the Slack body as `<url|open>`. */
+  click?: string;
+  /** Optional override of the ntfy topic. Defaults to NTFY_TOPIC SSM key. */
+  topic?: string;
+}
+
+export interface AdminAlertResult {
+  slack: { ok: boolean; error?: string };
+  ntfy: { ok: boolean; skipped?: string; error?: string };
+}
+
+const SEVERITY_EMOJI: Record<AdminAlertSeverity, string> = {
+  info: ":information_source:",
+  warning: ":warning:",
+  error: ":x:",
+  high: ":rotating_light:",
+  critical: ":fire:",
+};
+
+const SEVERITY_PRIORITY: Record<AdminAlertSeverity, 1 | 2 | 3 | 4 | 5> = {
+  info: 2,
+  warning: 3,
+  error: 4,
+  high: 5,
+  critical: 5,
+};
+
+const SEVERITY_TAGS: Record<AdminAlertSeverity, string[]> = {
+  info: ["information_source"],
+  warning: ["warning"],
+  error: ["x"],
+  high: ["rotating_light"],
+  critical: ["fire"],
+};
+
+/**
+ * Fan out an admin alert to Slack (always) + ntfy (when
+ * `ADMIN_PUSH_VIA_NTFY=1`). Never throws — surfaces success/failure per
+ * channel so callers can log + decide.
+ *
+ * The Slack send DM's each operator from `getSlackOpsUsers()` (which reads
+ * SSM, not env — per `feedback_slack_lambda_env_frozen`). For a one-shot
+ * channel post instead use `SlackClient.postToChannel`.
+ */
+export async function notifyAdmin(input: AdminAlertInput): Promise<AdminAlertResult> {
+  const result: AdminAlertResult = {
+    slack: { ok: false },
+    ntfy: { ok: false },
+  };
+
+  const slackText = `${SEVERITY_EMOJI[input.severity]} *${input.title}*\n${input.message}${
+    input.click ? `\n<${input.click}|open>` : ""
+  }`;
+
+  // Slack: DM each ops user. allSettled so one failed DM doesn't block ntfy.
+  const slackTask = (async () => {
+    try {
+      const opsUsers = await getSlackOpsUsers();
+      if (opsUsers.length === 0) {
+        result.slack = { ok: false, error: "no ops users configured" };
+        return;
+      }
+      // One client per ops user — `channel` is set in the constructor and
+      // chat.postMessage accepts a user ID as `channel` to deliver a DM.
+      const sends = await Promise.allSettled(
+        opsUsers.map((u) => new SlackClient({ channel: u }).post({ text: slackText }))
+      );
+      const okCount = sends.filter((s) => s.status === "fulfilled").length;
+      result.slack = {
+        ok: okCount > 0,
+        error: okCount === 0 ? "all DMs failed" : undefined,
+      };
+    } catch (err) {
+      result.slack = { ok: false, error: (err as Error).message };
+    }
+  })();
+
+  // ntfy: gated by env flag — off by default until operator opts in.
+  const ntfyTask = (async () => {
+    if (process.env.ADMIN_PUSH_VIA_NTFY !== "1") {
+      result.ntfy = { ok: false, skipped: "feature_off" };
+      return;
+    }
+    const r = await publishNtfy({
+      title: input.title,
+      message: input.message,
+      priority: SEVERITY_PRIORITY[input.severity],
+      tags: SEVERITY_TAGS[input.severity],
+      click: input.click,
+      topic: input.topic,
+    });
+    result.ntfy = r;
+  })();
+
+  await Promise.allSettled([slackTask, ntfyTask]);
+  return result;
+}

--- a/src/lib/ssm-config.ts
+++ b/src/lib/ssm-config.ts
@@ -85,6 +85,11 @@ interface AppConfig {
   NTFY_BASE_URL: string;
   NTFY_TOPIC: string;
   NTFY_TOKEN: string;
+  /** Apollo.io API key (Settings → Integrations → API). Consumed by the
+   *  n8n `lead-enrich` workflow's HTTP node — written here so the operator
+   *  rotates it from a single place. Optional; the workflow falls back to
+   *  skipping enrichment when unset. */
+  APOLLO_API_KEY: string;
   NOTION_API_KEY: string;
   NOTION_BLOG_DB_ID: string;
   NOTION_WEBHOOK_SECRET: string;
@@ -257,6 +262,7 @@ function buildConfigFromParams(params: Map<string, string>): AppConfig {
     NTFY_BASE_URL: params.get("NTFY_BASE_URL") ?? "",
     NTFY_TOPIC: params.get("NTFY_TOPIC") ?? "",
     NTFY_TOKEN: params.get("NTFY_TOKEN") ?? "",
+    APOLLO_API_KEY: params.get("APOLLO_API_KEY") ?? "",
     NOTION_API_KEY: params.get("NOTION_API_KEY") ?? "",
     NOTION_BLOG_DB_ID: params.get("NOTION_BLOG_DB_ID") ?? "",
     NOTION_WEBHOOK_SECRET: params.get("NOTION_WEBHOOK_SECRET") ?? "",
@@ -357,6 +363,7 @@ function buildConfigFromEnv(): AppConfig {
     NTFY_BASE_URL: process.env.NTFY_BASE_URL || "",
     NTFY_TOPIC: process.env.NTFY_TOPIC || "",
     NTFY_TOKEN: process.env.NTFY_TOKEN || "",
+    APOLLO_API_KEY: process.env.APOLLO_API_KEY || "",
     NOTION_API_KEY: process.env.NOTION_API_KEY || "",
     NOTION_BLOG_DB_ID: process.env.NOTION_BLOG_DB_ID || "",
     NOTION_WEBHOOK_SECRET: process.env.NOTION_WEBHOOK_SECRET || "",


### PR DESCRIPTION
Three small commits per the R-row plan.

**R4 — src/lib/admin-alerts.ts**: notifyAdmin(severity,title,message,click?) fans out to both Slack ops DMs AND ntfy (opt-in via ADMIN_PUSH_VIA_NTFY=1). Never throws — Promise.allSettled. Severity → ntfy priority + tags tables match v2 conventions.

**R5 — /admin/grafana**: GET /api/admin/grafana/dashboards + /health + admin page rendering monitored dashboards as deep-link cards with live OK/UNCONFIGURED/UNREACHABLE chip. Graceful 503 on missing token.

**R6 — Apollo + n8n live-wire**: APOLLO_API_KEY in ssm-config.ts (3 places), scripts/probe-lead-enrich.sh dry-runs the EspoCRM Lead → n8n webhook → workflow execution loop end-to-end, infrastructure/n8n/workflows/README.md gets the Apollo bootstrap stanza.

Pre-merge: lint/typecheck/format-check all green.