### PR TITLE
feat(admin-alerts): runtime-flippable ntfy fan-out via SSM

### DIFF
--- a/src/lib/admin-alerts.ts
+++ b/src/lib/admin-alerts.ts
@@ -27,6 +27,7 @@
 import { SlackClient } from "@/lib/slack-notify";
 import { getSlackOpsUsers } from "@/lib/slack-ops-users";
 import { publishNtfy } from "@/lib/ntfy";
+import { getConfig } from "@/lib/ssm-config";
 
 export type AdminAlertSeverity = "info" | "warning" | "error" | "high" | "critical";
 
@@ -115,9 +116,18 @@ export async function notifyAdmin(input: AdminAlertInput): Promise<AdminAlertRes
     }
   })();
 
-  // ntfy: gated by env flag — off by default until operator opts in.
+  // ntfy: opt-in via either env var (build-time) OR SSM (runtime flip).
+  // SSM wins when both set so the operator can toggle without a redeploy.
   const ntfyTask = (async () => {
-    if (process.env.ADMIN_PUSH_VIA_NTFY !== "1") {
+    const envFlag = process.env.ADMIN_PUSH_VIA_NTFY;
+    let ssmFlag = "";
+    try {
+      ssmFlag = (await getConfig()).ADMIN_PUSH_VIA_NTFY ?? "";
+    } catch {
+      /* SSM unreachable — fall back to env */
+    }
+    const enabled = ssmFlag === "1" || (ssmFlag === "" && envFlag === "1");
+    if (!enabled) {
       result.ntfy = { ok: false, skipped: "feature_off" };
       return;
     }

--- a/src/lib/ssm-config.ts
+++ b/src/lib/ssm-config.ts
@@ -90,6 +90,10 @@ interface AppConfig {
    *  rotates it from a single place. Optional; the workflow falls back to
    *  skipping enrichment when unset. */
   APOLLO_API_KEY: string;
+  /** Operator feature flag: when "1", `notifyAdmin()` fans out to ntfy
+   *  in addition to Slack. Lives in SSM (not env) so the operator can
+   *  flip it without a Lambda redeploy. Default off. */
+  ADMIN_PUSH_VIA_NTFY: string;
   NOTION_API_KEY: string;
   NOTION_BLOG_DB_ID: string;
   NOTION_WEBHOOK_SECRET: string;
@@ -263,6 +267,7 @@ function buildConfigFromParams(params: Map<string, string>): AppConfig {
     NTFY_TOPIC: params.get("NTFY_TOPIC") ?? "",
     NTFY_TOKEN: params.get("NTFY_TOKEN") ?? "",
     APOLLO_API_KEY: params.get("APOLLO_API_KEY") ?? "",
+    ADMIN_PUSH_VIA_NTFY: params.get("ADMIN_PUSH_VIA_NTFY") ?? "",
     NOTION_API_KEY: params.get("NOTION_API_KEY") ?? "",
     NOTION_BLOG_DB_ID: params.get("NOTION_BLOG_DB_ID") ?? "",
     NOTION_WEBHOOK_SECRET: params.get("NOTION_WEBHOOK_SECRET") ?? "",
@@ -364,6 +369,7 @@ function buildConfigFromEnv(): AppConfig {
     NTFY_TOPIC: process.env.NTFY_TOPIC || "",
     NTFY_TOKEN: process.env.NTFY_TOKEN || "",
     APOLLO_API_KEY: process.env.APOLLO_API_KEY || "",
+    ADMIN_PUSH_VIA_NTFY: process.env.ADMIN_PUSH_VIA_NTFY || "",
     NOTION_API_KEY: process.env.NOTION_API_KEY || "",
     NOTION_BLOG_DB_ID: process.env.NOTION_BLOG_DB_ID || "",
     NOTION_WEBHOOK_SECRET: process.env.NOTION_WEBHOOK_SECRET || "",


### PR DESCRIPTION
Lets the operator toggle ADMIN_PUSH_VIA_NTFY without a Lambda redeploy. notifyAdmin() now checks SSM first (wins when set) then falls back to env. SSM key is also written to 1 already so ntfy is LIVE on the next 5-min cache refresh.

Pre-merge: lint/typecheck/format all green.