### PR TITLE
feat(n8n): drop Apollo enrich node — not worth it for Greek SMB low-volume use case

### DIFF
--- a/infrastructure/n8n/workflows/README.md
+++ b/infrastructure/n8n/workflows/README.md
@@ -33,19 +33,11 @@ two app-side automations wired in PR R2:
    kubectl -n cloudless rollout restart deploy/cloudless
    ```
 
-8. **For `lead-enrich` only**: add Apollo credentials so the Apollo enrich HTTP
-   node finds a usable key. The workflow JSON reads `$env.APOLLO_API_KEY` (set in
-   n8n → Settings → Variables, OR via SSM if the operator wires `APOLLO_API_KEY`
-   into the n8n pod env):
-   ```bash
-   aws ssm put-parameter \
-     --name /cloudless/production/APOLLO_API_KEY \
-     --type SecureString --value 'paste-real-key-from-apollo.io/settings/credits' --overwrite
-   ```
-   The workflow's `continueOnFail: true` on the Apollo node means it degrades
-   gracefully — round-robin owner assignment + Slack DM still fire even if the
-   enrich step errors. Free Apollo plan = 50 credits/month is fine for low
-   lead volume.
+_(Apollo enrich was previously documented here but was dropped 2026-06-21 — data
+coverage is thin for Greek SMBs + lead volume is too low to justify the cost.
+The `lead-enrich` workflow now goes Webhook → Extract → Round-robin → EspoCRM
+PUT → Slack DM. Re-add an HTTP-Request node before "Round-robin" if/when you
+want enrichment back.)_
 
 ## Verify
 

--- a/infrastructure/n8n/workflows/lead-enrich.json
+++ b/infrastructure/n8n/workflows/lead-enrich.json
@@ -31,30 +31,12 @@
     },
     {
       "parameters": {
-        "url": "=https://api.apollo.io/v1/people/match?email={{ encodeURIComponent($json.email) }}",
-        "options": { "timeout": 8000 },
-        "sendHeaders": true,
-        "headerParameters": {
-          "parameters": [
-            { "name": "X-Api-Key", "value": "={{ $env.APOLLO_API_KEY }}" },
-            { "name": "Content-Type", "value": "application/json" }
-          ]
-        }
-      },
-      "name": "Apollo enrich (optional)",
-      "type": "n8n-nodes-base.httpRequest",
-      "typeVersion": 4.1,
-      "position": [680, 300],
-      "continueOnFail": true
-    },
-    {
-      "parameters": {
         "functionCode": "// Round-robin owner assignment from a hardcoded list. Replace with your\n// real team usernames in EspoCRM.\nconst owners = ['tbaltzakis'];\nconst idx = Math.floor(Math.random() * owners.length);\nreturn [{ json: { ...items[0].json, assignedUserName: owners[idx] } }];"
       },
       "name": "Round-robin owner",
       "type": "n8n-nodes-base.function",
       "typeVersion": 1,
-      "position": [900, 300]
+      "position": [680, 300]
     },
     {
       "parameters": {
@@ -74,7 +56,7 @@
       "name": "EspoCRM PUT /Lead/:id",
       "type": "n8n-nodes-base.httpRequest",
       "typeVersion": 4.1,
-      "position": [1120, 300],
+      "position": [900, 300],
       "continueOnFail": true
     },
     {
@@ -95,14 +77,13 @@
       "name": "Slack DM assignee",
       "type": "n8n-nodes-base.httpRequest",
       "typeVersion": 4.1,
-      "position": [1340, 300],
+      "position": [1120, 300],
       "continueOnFail": true
     }
   ],
   "connections": {
     "Webhook (lead-enrich)": { "main": [[{ "node": "Extract lead fields", "type": "main", "index": 0 }]] },
-    "Extract lead fields": { "main": [[{ "node": "Apollo enrich (optional)", "type": "main", "index": 0 }]] },
-    "Apollo enrich (optional)": { "main": [[{ "node": "Round-robin owner", "type": "main", "index": 0 }]] },
+    "Extract lead fields": { "main": [[{ "node": "Round-robin owner", "type": "main", "index": 0 }]] },
     "Round-robin owner": { "main": [[{ "node": "EspoCRM PUT /Lead/:id", "type": "main", "index": 0 }]] },
     "EspoCRM PUT /Lead/:id": { "main": [[{ "node": "Slack DM assignee", "type": "main", "index": 0 }]] }
   },

--- a/src/lib/ssm-config.ts
+++ b/src/lib/ssm-config.ts
@@ -85,11 +85,6 @@ interface AppConfig {
   NTFY_BASE_URL: string;
   NTFY_TOPIC: string;
   NTFY_TOKEN: string;
-  /** Apollo.io API key (Settings → Integrations → API). Consumed by the
-   *  n8n `lead-enrich` workflow's HTTP node — written here so the operator
-   *  rotates it from a single place. Optional; the workflow falls back to
-   *  skipping enrichment when unset. */
-  APOLLO_API_KEY: string;
   /** Operator feature flag: when "1", `notifyAdmin()` fans out to ntfy
    *  in addition to Slack. Lives in SSM (not env) so the operator can
    *  flip it without a Lambda redeploy. Default off. */
@@ -266,7 +261,6 @@ function buildConfigFromParams(params: Map<string, string>): AppConfig {
     NTFY_BASE_URL: params.get("NTFY_BASE_URL") ?? "",
     NTFY_TOPIC: params.get("NTFY_TOPIC") ?? "",
     NTFY_TOKEN: params.get("NTFY_TOKEN") ?? "",
-    APOLLO_API_KEY: params.get("APOLLO_API_KEY") ?? "",
     ADMIN_PUSH_VIA_NTFY: params.get("ADMIN_PUSH_VIA_NTFY") ?? "",
     NOTION_API_KEY: params.get("NOTION_API_KEY") ?? "",
     NOTION_BLOG_DB_ID: params.get("NOTION_BLOG_DB_ID") ?? "",
@@ -368,7 +362,6 @@ function buildConfigFromEnv(): AppConfig {
     NTFY_BASE_URL: process.env.NTFY_BASE_URL || "",
     NTFY_TOPIC: process.env.NTFY_TOPIC || "",
     NTFY_TOKEN: process.env.NTFY_TOKEN || "",
-    APOLLO_API_KEY: process.env.APOLLO_API_KEY || "",
     ADMIN_PUSH_VIA_NTFY: process.env.ADMIN_PUSH_VIA_NTFY || "",
     NOTION_API_KEY: process.env.NOTION_API_KEY || "",
     NOTION_BLOG_DB_ID: process.env.NOTION_BLOG_DB_ID || "",


### PR DESCRIPTION
Removes the Apollo enrich step from the lead-enrich workflow + scrubs APOLLO_API_KEY from ssm-config.ts. Workflow now goes Webhook -> Extract -> Round-robin -> EspoCRM PUT -> Slack DM.

Rationale (per the q&a earlier): Apollo data coverage thin for Greek SMBs, lead volume too low to justify, GDPR exposure, round-robin assigns to single owner anyway. Live workflow on n8n already updated via PUT /api/v1/workflows/<id>.

Pre-merge: lint/typecheck/format all green.