### PR TITLE
R7+R8: ntfy public tunnel + notifyAdmin() wired into real alert paths

### DIFF
--- a/__tests__/admin-alert-webhook-api.test.ts
+++ b/__tests__/admin-alert-webhook-api.test.ts
@@ -1,0 +1,111 @@
+/**
+ * Tests for the generic admin-alert webhook (R8). Covers auth, payload
+ * validation, and the success path — does NOT exercise the Slack/ntfy fan-out
+ * (those have their own units in `admin-alerts.test.ts`).
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+vi.mock("@/lib/ssm-config", () => ({
+  getConfig: vi.fn(),
+}));
+vi.mock("@/lib/admin-alerts", () => ({
+  notifyAdmin: vi.fn(async () => ({
+    slack: { ok: true },
+    ntfy: { ok: false, skipped: "feature_off" },
+  })),
+}));
+
+import { POST } from "@/app/api/webhooks/admin-alert/route";
+import { getConfig } from "@/lib/ssm-config";
+import { notifyAdmin } from "@/lib/admin-alerts";
+
+const SECRET = "test-secret-abcdef";
+
+function req(headers: Record<string, string>, body: unknown): NextRequest {
+  return new NextRequest("https://cloudless.gr/api/webhooks/admin-alert", {
+    method: "POST",
+    headers: { "content-type": "application/json", ...headers },
+    body: typeof body === "string" ? body : JSON.stringify(body),
+  });
+}
+
+const validBody = {
+  severity: "high" as const,
+  title: "espocrm down",
+  message: "5xx from /api/v1/App/user for 3min",
+  click: "https://espocrm.cloudless.gr",
+  source: "alert-api",
+};
+
+beforeEach(() => {
+  vi.mocked(getConfig).mockReset();
+  vi.mocked(notifyAdmin).mockClear();
+});
+
+describe("POST /api/webhooks/admin-alert", () => {
+  it("returns 401 without the secret header", async () => {
+    vi.mocked(getConfig).mockResolvedValue({ ADMIN_ALERT_SECRET: SECRET } as never);
+    const res = await POST(req({}, validBody));
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 503 when no secret is configured", async () => {
+    vi.mocked(getConfig).mockResolvedValue({
+      ADMIN_ALERT_SECRET: "",
+      NOTION_WEBHOOK_SECRET: "",
+    } as never);
+    const res = await POST(req({ "x-cloudless-alert-secret": "anything" }, validBody));
+    expect(res.status).toBe(503);
+  });
+
+  it("returns 401 when the secret doesn't match", async () => {
+    vi.mocked(getConfig).mockResolvedValue({ ADMIN_ALERT_SECRET: SECRET } as never);
+    const res = await POST(req({ "x-cloudless-alert-secret": "wrong-secret-abcdef" }, validBody));
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 400 on invalid JSON", async () => {
+    vi.mocked(getConfig).mockResolvedValue({ ADMIN_ALERT_SECRET: SECRET } as never);
+    const res = await POST(req({ "x-cloudless-alert-secret": SECRET }, "not json{{{"));
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 on missing required fields", async () => {
+    vi.mocked(getConfig).mockResolvedValue({ ADMIN_ALERT_SECRET: SECRET } as never);
+    const res = await POST(
+      req({ "x-cloudless-alert-secret": SECRET }, { severity: "high" })
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 on bad severity", async () => {
+    vi.mocked(getConfig).mockResolvedValue({ ADMIN_ALERT_SECRET: SECRET } as never);
+    const res = await POST(
+      req(
+        { "x-cloudless-alert-secret": SECRET },
+        { ...validBody, severity: "bogus" }
+      )
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it("calls notifyAdmin with the prefixed title on the happy path", async () => {
+    vi.mocked(getConfig).mockResolvedValue({ ADMIN_ALERT_SECRET: SECRET } as never);
+    const res = await POST(req({ "x-cloudless-alert-secret": SECRET }, validBody));
+    expect(res.status).toBe(200);
+    expect(notifyAdmin).toHaveBeenCalledTimes(1);
+    const call = vi.mocked(notifyAdmin).mock.calls[0][0];
+    expect(call.title).toBe("[alert-api] espocrm down");
+    expect(call.severity).toBe("high");
+  });
+
+  it("falls back to NOTION_WEBHOOK_SECRET when ADMIN_ALERT_SECRET is empty", async () => {
+    vi.mocked(getConfig).mockResolvedValue({
+      ADMIN_ALERT_SECRET: "",
+      NOTION_WEBHOOK_SECRET: SECRET,
+    } as never);
+    const res = await POST(req({ "x-cloudless-alert-secret": SECRET }, validBody));
+    expect(res.status).toBe(200);
+  });
+});

--- a/src/app/api/webhooks/admin-alert/route.ts
+++ b/src/app/api/webhooks/admin-alert/route.ts
@@ -1,0 +1,100 @@
+/**
+ * Generic admin-alert webhook receiver — fires `notifyAdmin()` (Slack + opt-in ntfy)
+ * for any caller that can POST a JSON payload with a shared secret.
+ *
+ * R8 of the 2026-06-21 R-series. Backstop endpoint for the three "SEV1 should
+ * wake the operator" sources that aren't natively wired through `notifyAdmin()`:
+ *
+ *   1. Sentry alerts — configure a webhook in Sentry → Alerts → Internal Integration
+ *      pointing here. (For Sentry's native body shape use the dedicated
+ *      /api/webhooks/sentry endpoint instead — it handles the shape difference.)
+ *   2. Pi alert-api Lambda — when severity >= high, POST here in addition to the
+ *      existing MQTT publish. Operator wire-up step in alert-api's deploy.sh.
+ *   3. Any future cron / health check that wants phone push.
+ *
+ * Auth: `x-cloudless-alert-secret` header must equal SSM `ADMIN_ALERT_SECRET`
+ * (falls back to `NOTION_WEBHOOK_SECRET` so existing callers can reuse their
+ * token until rotation). Constant-time compare to avoid timing leaks.
+ *
+ * Always returns 2xx unless auth fails or the body is malformed — so an outage
+ * in Slack/ntfy doesn't loop the caller into infinite retries.
+ */
+import { NextRequest, NextResponse } from "next/server";
+import { timingSafeEqual } from "node:crypto";
+import { getConfig } from "@/lib/ssm-config";
+import { notifyAdmin, type AdminAlertSeverity } from "@/lib/admin-alerts";
+
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+
+const VALID_SEVERITIES: AdminAlertSeverity[] = ["info", "warning", "error", "high", "critical"];
+
+interface AdminAlertBody {
+  severity: AdminAlertSeverity;
+  title: string;
+  message: string;
+  click?: string;
+  source?: string;
+}
+
+function isValid(body: unknown): body is AdminAlertBody {
+  if (!body || typeof body !== "object") return false;
+  const b = body as Record<string, unknown>;
+  return (
+    typeof b.severity === "string" &&
+    VALID_SEVERITIES.includes(b.severity as AdminAlertSeverity) &&
+    typeof b.title === "string" &&
+    b.title.length > 0 &&
+    b.title.length <= 200 &&
+    typeof b.message === "string" &&
+    b.message.length <= 2000 &&
+    (b.click === undefined || typeof b.click === "string") &&
+    (b.source === undefined || typeof b.source === "string")
+  );
+}
+
+function safeEq(a: string, b: string): boolean {
+  const ab = Buffer.from(a);
+  const bb = Buffer.from(b);
+  if (ab.length !== bb.length) return false;
+  return timingSafeEqual(ab, bb);
+}
+
+export async function POST(req: NextRequest) {
+  const provided = req.headers.get("x-cloudless-alert-secret") ?? "";
+  if (!provided) {
+    return NextResponse.json({ error: "missing_secret" }, { status: 401 });
+  }
+
+  const cfg = await getConfig();
+  const expected = cfg.ADMIN_ALERT_SECRET || cfg.NOTION_WEBHOOK_SECRET || "";
+  if (!expected) {
+    // No secret configured anywhere — refuse rather than open up the endpoint.
+    return NextResponse.json({ error: "receiver_not_configured" }, { status: 503 });
+  }
+  if (!safeEq(provided, expected)) {
+    return NextResponse.json({ error: "bad_secret" }, { status: 401 });
+  }
+
+  let body: unknown;
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ error: "invalid_json" }, { status: 400 });
+  }
+
+  if (!isValid(body)) {
+    return NextResponse.json({ error: "bad_payload" }, { status: 400 });
+  }
+
+  const tagged = body.source ? { ...body, title: `[${body.source}] ${body.title}` } : body;
+
+  const result = await notifyAdmin({
+    severity: tagged.severity,
+    title: tagged.title,
+    message: tagged.message,
+    click: tagged.click,
+  });
+
+  return NextResponse.json({ ok: true, result });
+}

--- a/src/app/api/webhooks/mqtt/publish/route.ts
+++ b/src/app/api/webhooks/mqtt/publish/route.ts
@@ -22,9 +22,13 @@
 import { NextRequest, NextResponse } from "next/server";
 import { isMqttConfigured, publishAlertStatus } from "@/lib/mqtt";
 import { getConfig } from "@/lib/ssm-config";
+import { notifyAdmin, type AdminAlertSeverity } from "@/lib/admin-alerts";
 
 export const dynamic = "force-dynamic";
 export const runtime = "nodejs";
+
+/** Sevs that wake the operator — `notifyAdmin()` fan-out fires for these only. */
+const ALERTABLE_SEVERITIES: readonly AdminAlertSeverity[] = ["high", "critical"] as const;
 
 async function verifySecret(req: NextRequest): Promise<boolean> {
   const cfg = await getConfig();
@@ -70,5 +74,24 @@ export async function POST(req: NextRequest) {
       { status: 502 }
     );
   }
+
+  // R8: when the published payload is a high/critical alert on the canonical
+  // status topic, also fan it out to Slack + ntfy. Non-blocking: a failure here
+  // doesn't change the publish response (MQTT was already accepted).
+  const payload = body.payload as { severity?: AdminAlertSeverity; src?: string } | undefined;
+  if (
+    body.topic === "homelab/alerts/status" &&
+    payload?.severity &&
+    ALERTABLE_SEVERITIES.includes(payload.severity)
+  ) {
+    void notifyAdmin({
+      severity: payload.severity,
+      title: `[${payload.src ?? "mqtt"}] alert ${payload.severity}`,
+      message: `Topic: ${body.topic}\nPayload: ${JSON.stringify(payload).slice(0, 500)}`,
+    }).catch(() => {
+      /* swallowed — notifyAdmin already logs/handles its own errors */
+    });
+  }
+
   return NextResponse.json({ ok: true, topic: body.topic });
 }

--- a/src/app/api/webhooks/sentry/route.ts
+++ b/src/app/api/webhooks/sentry/route.ts
@@ -1,0 +1,130 @@
+/**
+ * Sentry alert webhook receiver — verifies Sentry's HMAC signature, classifies
+ * severity, and fans out via `notifyAdmin()`.
+ *
+ * R8 of the 2026-06-21 R-series. Sentry signs every webhook with HMAC-SHA256
+ * over the raw request body using the integration's client secret; the digest
+ * arrives in `sentry-hook-signature`. We verify, then map the alert's level
+ * field to one of our `AdminAlertSeverity` buckets:
+ *   - "fatal" / "error" → critical
+ *   - "warning"         → warning
+ *   - "info" / "debug"  → info
+ *
+ * Only fires when the issue is unresolved AND in the "production" environment
+ * (or env field missing). Resolved/regressed events from staging are dropped to
+ * avoid waking the operator over noise.
+ *
+ * Operator wire-up: Sentry → Settings → Developer Settings → New Internal
+ * Integration → Webhook URL `https://cloudless.gr/api/webhooks/sentry`,
+ * subscribe to "issue" events, copy the Client Secret into SSM key
+ * `SENTRY_WEBHOOK_SECRET` (`aws ssm put-parameter --name
+ * /cloudless/production/SENTRY_WEBHOOK_SECRET --type SecureString --value '...'
+ * --overwrite`).
+ *
+ * Webhook signing reference: https://docs.sentry.io/product/integrations/integration-platform/webhooks/#sentry-hook-signature
+ */
+import { NextRequest, NextResponse } from "next/server";
+import { createHmac, timingSafeEqual } from "node:crypto";
+import { getConfig } from "@/lib/ssm-config";
+import { notifyAdmin, type AdminAlertSeverity } from "@/lib/admin-alerts";
+
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+
+interface SentryHookData {
+  issue?: {
+    id?: string;
+    title?: string;
+    culprit?: string;
+    level?: string;
+    status?: string;
+    permalink?: string;
+    project?: { slug?: string };
+    metadata?: { value?: string };
+  };
+  event?: {
+    environment?: string;
+  };
+}
+
+interface SentryHookBody {
+  action?: string;
+  data?: SentryHookData;
+  installation?: { uuid?: string };
+}
+
+function mapSeverity(level: string | undefined): AdminAlertSeverity {
+  switch (level) {
+    case "fatal":
+    case "error":
+      return "critical";
+    case "warning":
+      return "warning";
+    default:
+      return "info";
+  }
+}
+
+function verifySignature(rawBody: string, signature: string, secret: string): boolean {
+  if (!signature || !secret) return false;
+  const expected = createHmac("sha256", secret).update(rawBody).digest("hex");
+  const a = Buffer.from(expected);
+  const b = Buffer.from(signature);
+  if (a.length !== b.length) return false;
+  return timingSafeEqual(a, b);
+}
+
+export async function POST(req: NextRequest) {
+  const rawBody = await req.text();
+  const signature = req.headers.get("sentry-hook-signature") ?? "";
+
+  const cfg = await getConfig();
+  const secret = cfg.SENTRY_WEBHOOK_SECRET || "";
+  if (!secret) {
+    return NextResponse.json({ error: "receiver_not_configured" }, { status: 503 });
+  }
+  if (!verifySignature(rawBody, signature, secret)) {
+    return NextResponse.json({ error: "bad_signature" }, { status: 401 });
+  }
+
+  let body: SentryHookBody;
+  try {
+    body = JSON.parse(rawBody) as SentryHookBody;
+  } catch {
+    return NextResponse.json({ error: "invalid_json" }, { status: 400 });
+  }
+
+  const issue = body.data?.issue;
+  if (!issue) {
+    return NextResponse.json({ ok: true, skipped: "no_issue_in_payload" });
+  }
+
+  // Drop noise: resolved events, low-priority info from non-prod environments.
+  const env = body.data?.event?.environment ?? "";
+  if (env && env !== "production") {
+    return NextResponse.json({ ok: true, skipped: `non_prod_env:${env}` });
+  }
+  if (issue.status === "resolved" || issue.status === "ignored") {
+    return NextResponse.json({ ok: true, skipped: `issue_status:${issue.status}` });
+  }
+
+  const severity = mapSeverity(issue.level);
+  const project = issue.project?.slug ?? "sentry";
+  const title = `[sentry/${project}] ${issue.title ?? "untitled issue"}`.slice(0, 200);
+  const messageLines = [
+    issue.culprit ? `Culprit: ${issue.culprit}` : "",
+    issue.metadata?.value ? `Value: ${issue.metadata.value}` : "",
+    issue.level ? `Level: ${issue.level}` : "",
+    body.action ? `Action: ${body.action}` : "",
+  ].filter(Boolean);
+  const message = messageLines.join("\n").slice(0, 2000);
+
+  const result = await notifyAdmin({
+    severity,
+    title,
+    message,
+    click: issue.permalink,
+  });
+
+  return NextResponse.json({ ok: true, result });
+}

--- a/src/lib/ssm-config.ts
+++ b/src/lib/ssm-config.ts
@@ -92,6 +92,12 @@ interface AppConfig {
   NOTION_API_KEY: string;
   NOTION_BLOG_DB_ID: string;
   NOTION_WEBHOOK_SECRET: string;
+  /** Optional shared secret for `/api/webhooks/admin-alert` (R8). Falls back
+   *  to NOTION_WEBHOOK_SECRET when unset so existing callers keep working. */
+  ADMIN_ALERT_SECRET: string;
+  /** Sentry internal-integration Client Secret used to HMAC-verify webhooks
+   *  at `/api/webhooks/sentry`. R8 — required for the Sentry receiver. */
+  SENTRY_WEBHOOK_SECRET: string;
   // Notion database IDs
   NOTION_SUBMISSIONS_DB_ID: string;
   NOTION_DOCS_DB_ID: string;
@@ -265,6 +271,8 @@ function buildConfigFromParams(params: Map<string, string>): AppConfig {
     NOTION_API_KEY: params.get("NOTION_API_KEY") ?? "",
     NOTION_BLOG_DB_ID: params.get("NOTION_BLOG_DB_ID") ?? "",
     NOTION_WEBHOOK_SECRET: params.get("NOTION_WEBHOOK_SECRET") ?? "",
+    ADMIN_ALERT_SECRET: params.get("ADMIN_ALERT_SECRET") ?? "",
+    SENTRY_WEBHOOK_SECRET: params.get("SENTRY_WEBHOOK_SECRET") ?? "",
     NOTION_SUBMISSIONS_DB_ID: params.get("NOTION_SUBMISSIONS_DB_ID") ?? "",
     NOTION_DOCS_DB_ID: params.get("NOTION_DOCS_DB_ID") ?? "",
     NOTION_PROJECTS_DB_ID: params.get("NOTION_PROJECTS_DB_ID") ?? "",
@@ -366,6 +374,8 @@ function buildConfigFromEnv(): AppConfig {
     NOTION_API_KEY: process.env.NOTION_API_KEY || "",
     NOTION_BLOG_DB_ID: process.env.NOTION_BLOG_DB_ID || "",
     NOTION_WEBHOOK_SECRET: process.env.NOTION_WEBHOOK_SECRET || "",
+    ADMIN_ALERT_SECRET: process.env.ADMIN_ALERT_SECRET || "",
+    SENTRY_WEBHOOK_SECRET: process.env.SENTRY_WEBHOOK_SECRET || "",
     NOTION_SUBMISSIONS_DB_ID: process.env.NOTION_SUBMISSIONS_DB_ID || "",
     NOTION_DOCS_DB_ID: process.env.NOTION_DOCS_DB_ID || "",
     NOTION_PROJECTS_DB_ID: process.env.NOTION_PROJECTS_DB_ID || "",


### PR DESCRIPTION
R7 (operator-side, ntfy.cloudless.gr now public over the shared tunnel — no code in this PR, both nodes patched + verified externally).

R8: notifyAdmin() wired into 3 SEV1 alert paths.
- POST /api/webhooks/admin-alert (new): generic receiver, shared-secret auth.
- POST /api/webhooks/sentry (new): HMAC-verified, maps level→severity.
- /api/webhooks/mqtt/publish: also calls notifyAdmin when severity >= high on homelab/alerts/status.

Tests: 8/8 pass. Lint + format clean.

Operator step (Sentry only): add an Internal Integration webhook pointing at /api/webhooks/sentry, drop client secret into SSM SENTRY_WEBHOOK_SECRET.
