### PR TITLE
hotfix: SLACK_OPS_USERS falls back to SLACK_OPS_USER_ID (singular)

### DIFF
--- a/__tests__/slack-ops-users.test.ts
+++ b/__tests__/slack-ops-users.test.ts
@@ -71,6 +71,21 @@ describe("slack-ops-users", () => {
       expect(list).toEqual([]);
     });
 
+    it("falls back to SLACK_OPS_USER_ID (singular) when SLACK_OPS_USERS is empty", async () => {
+      getConfigMock.mockResolvedValue({ SLACK_OPS_USERS: "", SLACK_OPS_USER_ID: "U09AF5VU7LY" });
+      const list = await getSlackOpsUsers();
+      expect(list).toEqual(["U09AF5VU7LY"]);
+    });
+
+    it("prefers SLACK_OPS_USERS (plural) over SLACK_OPS_USER_ID when both set", async () => {
+      getConfigMock.mockResolvedValue({
+        SLACK_OPS_USERS: "U01NEW,U02NEW",
+        SLACK_OPS_USER_ID: "U99OLD",
+      });
+      const list = await getSlackOpsUsers();
+      expect(list).toEqual(["U01NEW", "U02NEW"]);
+    });
+
     it("returns [] and warns when SSM lookup throws", async () => {
       const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
       getConfigMock.mockRejectedValue(new Error("ssm down"));

--- a/src/lib/slack-ops-users.ts
+++ b/src/lib/slack-ops-users.ts
@@ -40,12 +40,26 @@ export async function getSlackOpsUsers(): Promise<string[]> {
 
   // SSM fallback — keeps the Lambda working when the operator forgot to set
   // SLACK_OPS_USERS as an env var but added it to SSM the normal way.
+  //
+  // Falls back to the historical singular key `SLACK_OPS_USER_ID` (single
+  // user ID, no commas) when the plural `SLACK_OPS_USERS` is missing. That
+  // singular key has been the operator's canonical entry since the
+  // single-admin era — keeping the fallback means existing deployments
+  // start fanning out to Slack the moment this code lands, with no SSM
+  // rename required. Discovered 2026-06-21 during R8 e2e verify when
+  // `/api/webhooks/admin-alert` returned `slack.ok: false, error: "no ops
+  // users configured"`.
   try {
     const { getConfig } = await import("@/lib/ssm-config");
     const cfg = (await getConfig()) as unknown as Record<string, string>;
-    const ssmList = parse(cfg.SLACK_OPS_USERS);
-    cached = { value: ssmList, at: Date.now() };
-    return ssmList;
+    const pluralList = parse(cfg.SLACK_OPS_USERS);
+    if (pluralList.length > 0) {
+      cached = { value: pluralList, at: Date.now() };
+      return pluralList;
+    }
+    const singularList = parse(cfg.SLACK_OPS_USER_ID);
+    cached = { value: singularList, at: Date.now() };
+    return singularList;
   } catch (err) {
     console.warn("[slack-ops-users] SSM lookup failed:", err);
     cached = { value: [], at: Date.now() };

--- a/src/lib/ssm-config.ts
+++ b/src/lib/ssm-config.ts
@@ -31,6 +31,13 @@ interface AppConfig {
   SLACK_SIGNING_SECRET: string;
   /** Default channel (ID or #name) for bot posts without an explicit channel. */
   SLACK_DEFAULT_CHANNEL: string;
+  /** Comma-separated list of Slack user IDs that receive admin alerts via
+   *  `notifyAdmin()`. New plural key (preferred). */
+  SLACK_OPS_USERS: string;
+  /** Historical singular Slack user ID — fallback when SLACK_OPS_USERS is
+   *  empty. Predates multi-admin support; some deployments only have this
+   *  key set (operator was solo). Kept to avoid forcing an SSM rename. */
+  SLACK_OPS_USER_ID: string;
   // Dedicated Newsletter Slack app (separate from main Cloudless app)
   NEWSLETTER_SLACK_BOT_TOKEN: string;
   NEWSLETTER_SLACK_SIGNING_SECRET: string;
@@ -242,6 +249,8 @@ function buildConfigFromParams(params: Map<string, string>): AppConfig {
     SLACK_BOT_TOKEN: params.get("SLACK_BOT_TOKEN") ?? "",
     SLACK_SIGNING_SECRET: params.get("SLACK_SIGNING_SECRET") ?? "",
     SLACK_DEFAULT_CHANNEL: params.get("SLACK_DEFAULT_CHANNEL") ?? "",
+    SLACK_OPS_USERS: params.get("SLACK_OPS_USERS") ?? "",
+    SLACK_OPS_USER_ID: params.get("SLACK_OPS_USER_ID") ?? "",
     NEWSLETTER_SLACK_BOT_TOKEN: params.get("NEWSLETTER_SLACK_BOT_TOKEN") ?? "",
     NEWSLETTER_SLACK_SIGNING_SECRET: params.get("NEWSLETTER_SLACK_SIGNING_SECRET") ?? "",
     NEWSLETTER_SLACK_CHANNEL_ID: params.get("NEWSLETTER_SLACK_CHANNEL_ID") ?? "",
@@ -345,6 +354,8 @@ function buildConfigFromEnv(): AppConfig {
     SLACK_BOT_TOKEN: process.env.SLACK_BOT_TOKEN || "",
     SLACK_SIGNING_SECRET: process.env.SLACK_SIGNING_SECRET || "",
     SLACK_DEFAULT_CHANNEL: process.env.SLACK_DEFAULT_CHANNEL || "",
+    SLACK_OPS_USERS: process.env.SLACK_OPS_USERS || "",
+    SLACK_OPS_USER_ID: process.env.SLACK_OPS_USER_ID || "",
     NEWSLETTER_SLACK_BOT_TOKEN: process.env.NEWSLETTER_SLACK_BOT_TOKEN || "",
     NEWSLETTER_SLACK_SIGNING_SECRET: process.env.NEWSLETTER_SLACK_SIGNING_SECRET || "",
     NEWSLETTER_SLACK_CHANNEL_ID: process.env.NEWSLETTER_SLACK_CHANNEL_ID || "",


### PR DESCRIPTION
Single-line fix discovered during R8 e2e verify. Slack DM fan-out of notifyAdmin() was failing because operator SSM key is the historical singular SLACK_OPS_USER_ID, not the new SLACK_OPS_USERS. Lib now checks both. 13/13 tests pass. Unblocks Slack half of admin-alert webhook.