### PR TITLE
perf(ci): add .next/cache to ci/bundle-budget/bundle-size-pr workflows

### DIFF
--- a/.github/workflows/bundle-budget.yml
+++ b/.github/workflows/bundle-budget.yml
@@ -44,6 +44,15 @@ jobs:
         with:
           node-version: 22
           cache: pnpm
+      # Cache Next.js build output between runs. Mirrors deploy.yml.
+      - name: Restore Next.js build cache
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: .next/cache
+          key: nextjs-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}-${{ hashFiles('src/**') }}
+          restore-keys: |
+            nextjs-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}-
+            nextjs-${{ runner.os }}-
       - run: pnpm install --frozen-lockfile
       - run: pnpm build
       - run: node scripts/audit/check-bundle-budget.mjs

--- a/.github/workflows/bundle-size-pr.yml
+++ b/.github/workflows/bundle-size-pr.yml
@@ -26,6 +26,16 @@ jobs:
           node-version: 22
           cache: pnpm
 
+      # Cache Next.js build output between runs. Mirrors deploy.yml.
+      - name: Restore Next.js build cache
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: .next/cache
+          key: nextjs-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}-${{ hashFiles('src/**') }}
+          restore-keys: |
+            nextjs-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}-
+            nextjs-${{ runner.os }}-
+
       - run: pnpm install --frozen-lockfile
 
       - name: Build and capture bundle stats

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -147,6 +147,17 @@ jobs:
         with:
           node-version: 22
           cache: pnpm
+      # Cache Next.js build output between PR runs. Typically cuts the
+      # `pnpm build` step from ~3-4 min cold → <1 min on cache hit.
+      # Mirrors the pattern already in deploy.yml.
+      - name: Restore Next.js build cache
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: .next/cache
+          key: nextjs-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}-${{ hashFiles('src/**') }}
+          restore-keys: |
+            nextjs-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}-
+            nextjs-${{ runner.os }}-
       - run: pnpm install --frozen-lockfile --prefer-offline
       - run: pnpm build
 


### PR DESCRIPTION
Extends the Next.js build-cache pattern from deploy.yml to the 3 remaining workflows that run pnpm build. Typical savings: 2-3 min per cache-hit run.

Per the workflow-efficiency audit: 4 workflows build Next, only 1 cached the output. This closes the gap.

Mechanical change, zero behavior delta — same actions/cache@v5.0.5 + key pattern that deploy.yml uses.