### PR TITLE
feat(ops): pi-runner-failover skill + doctor + sync-smtp refactor

### DIFF
--- a/.github/workflows/sync-smtp-secrets.yml
+++ b/.github/workflows/sync-smtp-secrets.yml
@@ -1,20 +1,29 @@
 name: Sync SES SMTP creds to k8s namespaces
 
 # Pulls SES_SMTP_* from SSM and writes a `smtp-credentials` Secret into
-# every namespace that hosts a self-hosted app needing transactional email.
-# Triggers a rolling restart for any Deployment that already references the
-# Secret (the gotrue, espocrm, postiz, n8n, grafana env-var patches in
-# this same PR all do).
+# every namespace that hosts a self-hosted app needing transactional email
+# (appflowy / espocrm / postiz / n8n / monitoring).
 #
-# Runs on the omv Pi runner because:
-#   - the cluster API is on the tailnet; runner is already in-cluster context
-#   - the runner has the same AWS creds the scripts/sync-smtp-to-namespaces.sh
-#     needs (the alert-api `cloudless-pi-standby` profile has ssm:Get*)
+# Runs on GH-hosted ubuntu-latest using the canonical
+# GH-hosted-with-tailnet pattern from `skills/pi-runner-failover/SKILL.md`:
+#   - OIDC → AWS for ssm:GetParameter
+#   - Tailscale → kubectl over the tailnet
+#   - KUBECONFIG_B64 → system:admin against k3s API
+#
+# Was previously pinned to `[self-hosted, omv, pi, build]` but that
+# deadlocked the workflow whenever both Pi runners went offline. The
+# work doesn't need to be physically on the Pi — it just needs
+# AWS + kubectl access — so the failover-pattern is the correct home.
 #
 # Trigger when:
 #   - SES SMTP creds are first provisioned (operator runs `pnpm ses:provision`
 #     then `gh workflow run sync-smtp-secrets.yml`)
 #   - SES password is rotated (re-run `pnpm ses:provision` + this workflow)
+#
+# Required repo secrets (all already exist):
+#   - AWS_DEPLOY_ROLE_ARN — OIDC trust for Themis128/cloudless.gr
+#   - TS_AUTHKEY         — Tailscale ephemeral pre-auth key
+#   - KUBECONFIG_B64     — `cat ~/.kube/config | base64 -w0` from omv-main
 
 on:
   workflow_dispatch:
@@ -25,6 +34,7 @@ on:
       - ".github/workflows/sync-smtp-secrets.yml"
 
 permissions:
+  id-token: write   # OIDC → AWS
   contents: read
 
 concurrency:
@@ -33,10 +43,29 @@ concurrency:
 
 jobs:
   sync:
-    runs-on: [self-hosted, omv, pi, build]
-    timeout-minutes: 5
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v5
+
+      - name: Connect to tailnet
+        uses: tailscale/github-action@0263d9e6d793eaefcf1de98ff7fde47abe6664d3 # v3.2.4
+        with:
+          authkey: ${{ secrets.TS_AUTHKEY }}
+
+      - name: Configure kubectl
+        run: |
+          mkdir -p ~/.kube
+          echo "${{ secrets.KUBECONFIG_B64 }}" | base64 -d > ~/.kube/config
+          chmod 600 ~/.kube/config
+          kubectl get ns -o name | head -5  # smoke test cluster reachability
+
+      - name: Configure AWS credentials (OIDC)
+        uses: aws-actions/configure-aws-credentials@e7f100cf4c008499ea8adda475de1042d6975c7b # v6.2.0
+        with:
+          role-to-assume: ${{ secrets.AWS_DEPLOY_ROLE_ARN }}
+          aws-region: us-east-1
+
       - name: Sync smtp-credentials Secret to every namespace
         run: |
           set -euo pipefail

--- a/scripts/pi-runner-doctor.sh
+++ b/scripts/pi-runner-doctor.sh
@@ -1,0 +1,120 @@
+#!/usr/bin/env bash
+# pi-runner-doctor.sh — diagnose Pi-runner outages + auto-remediate.
+#
+# Companion to skills/pi-runner-failover/SKILL.md.
+#
+# Usage:
+#   bash scripts/pi-runner-doctor.sh           # diagnose only
+#   bash scripts/pi-runner-doctor.sh --auto-flip   # also flip RUNNER_GENERIC to
+#                                                  # hosted if BOTH Pi runners
+#                                                  # are offline.
+#
+# Exit codes:
+#   0  Pi runners healthy OR auto-flip succeeded
+#   2  Pi runners offline AND --auto-flip not passed (operator must decide)
+#   3  Pi runners healthy but RUNNER_GENERIC is pointing at hosted
+#      (unusual — may be a leftover from a recent flip)
+
+set -uo pipefail
+
+# Resolve to repo root regardless of invocation directory.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+cd "$REPO_ROOT"
+
+REPO="${REPO:-Themis128/cloudless.gr}"
+AUTO_FLIP=0
+if [[ "${1:-}" == "--auto-flip" ]]; then
+  AUTO_FLIP=1
+fi
+
+echo "=== Pi runner doctor ==="
+echo "Repo: $REPO"
+echo
+
+# ---- 1. Runner status ----------------------------------------------------
+echo "## 1. Self-hosted runners"
+RUNNERS_JSON=$(gh api "/repos/$REPO/actions/runners" 2>&1)
+if [[ "$RUNNERS_JSON" == *"error"* ]] || [[ -z "$RUNNERS_JSON" ]]; then
+  echo "  ! Failed to fetch runner list: $RUNNERS_JSON"
+  exit 1
+fi
+
+echo "$RUNNERS_JSON" | jq -r '.runners[] | "  - \(.name): status=\(.status) busy=\(.busy) labels=" + ([.labels[].name] | join(","))'
+
+PI_ONLINE=$(echo "$RUNNERS_JSON" | jq -r '[.runners[] | select((.labels[].name=="pi") and .status=="online")] | length')
+PI_OFFLINE=$(echo "$RUNNERS_JSON" | jq -r '[.runners[] | select((.labels[].name=="pi") and .status=="offline")] | length')
+
+echo
+echo "Pi runners: $PI_ONLINE online, $PI_OFFLINE offline"
+echo
+
+# ---- 2. RUNNER_GENERIC variable -----------------------------------------
+echo "## 2. RUNNER_GENERIC repo variable"
+RG_VALUE=$(gh variable get RUNNER_GENERIC 2>/dev/null || echo "")
+if [[ -z "$RG_VALUE" ]]; then
+  echo "  RUNNER_GENERIC is UNSET → flexible workflows use ubuntu-latest"
+  RG_MODE="hosted"
+else
+  echo "  RUNNER_GENERIC = $RG_VALUE"
+  RG_MODE="pi"
+fi
+echo
+
+# ---- 3. Queued workflows -------------------------------------------------
+echo "## 3. Workflows currently queued"
+QUEUED=$(gh run list --status queued --limit 30 \
+  --json databaseId,workflowName,createdAt 2>/dev/null || echo "[]")
+COUNT=$(echo "$QUEUED" | jq 'length')
+if [[ "$COUNT" -eq 0 ]]; then
+  echo "  (none)"
+else
+  echo "$QUEUED" | jq -r '.[] | "  - \(.databaseId)\t\(.workflowName)\t(\(.createdAt))"'
+fi
+echo
+
+# ---- 4. Hard-pinned-to-Pi workflows (inventory) --------------------------
+echo "## 4. Workflows pinned to [self-hosted, omv, pi, *]"
+if [[ -d ".github/workflows" ]]; then
+  grep -l "runs-on:.*self-hosted.*omv.*pi\|runs-on:.*omv.*pi.*build" \
+    .github/workflows/*.yml 2>/dev/null | sed 's|.github/workflows/||; s/^/  - /' || echo "  (none)"
+fi
+echo
+
+# ---- 5. Recommendation ---------------------------------------------------
+echo "## 5. Recommendation"
+if [[ "$PI_OFFLINE" -gt 0 ]] && [[ "$PI_ONLINE" -eq 0 ]]; then
+  echo "  ALL Pi runners offline."
+  if [[ "$RG_MODE" == "pi" ]]; then
+    echo "      RUNNER_GENERIC is still pointing at Pi labels — flexible"
+    echo "      workflows will queue forever until a Pi runner comes back."
+    echo
+    if [[ "$AUTO_FLIP" -eq 1 ]]; then
+      echo "  -> Flipping RUNNER_GENERIC to hosted (--auto-flip)..."
+      .github/scripts/toggle-runner.sh hosted 2>&1 | tail -5
+      echo
+      echo "  Done. Now cancel any queued runs and re-trigger them."
+      exit 0
+    else
+      echo "  -> Run with --auto-flip to flip RUNNER_GENERIC to hosted, OR"
+      echo "    run manually: .github/scripts/toggle-runner.sh hosted"
+      echo
+      echo "  Then cancel queued runs targeting Pi and re-trigger them."
+      echo "  See skills/pi-runner-failover/SKILL.md for the full playbook."
+      exit 2
+    fi
+  else
+    echo "      RUNNER_GENERIC is already on hosted - flexible workflows OK."
+    echo "      Hard-pinned workflows (Section 4) are still stuck until"
+    echo "      a Pi runner comes back. See SKILL.md Step 4 for restore."
+    exit 0
+  fi
+elif [[ "$PI_ONLINE" -gt 0 ]] && [[ "$RG_MODE" == "hosted" ]]; then
+  echo "  Pi runners are healthy but RUNNER_GENERIC is on hosted."
+  echo "      This is fine, but if you want to push load back to Pi:"
+  echo "      .github/scripts/toggle-runner.sh pi"
+  exit 3
+else
+  echo "  Pi runners healthy. No action needed."
+  exit 0
+fi

--- a/skills/pi-runner-failover/SKILL.md
+++ b/skills/pi-runner-failover/SKILL.md
@@ -1,0 +1,223 @@
+---
+name: pi-runner-failover
+description: "Playbook for keeping CI moving when one or both self-hosted Pi runners (`omv`, `omv-build`) go offline. Covers detection, immediate triage (flip RUNNER_GENERIC to hosted, cancel stuck queued jobs), the per-workflow GH-hosted-with-tailnet fallback pattern, and the operator side (bring Pi runners back). Pairs with `scripts/pi-runner-doctor.sh`."
+metadata:
+  type: skill
+---
+
+# Pi runner failover
+
+When both Pi self-hosted runners (`omv`, `omv-build`) go offline,
+workflows pinned to them sit `queued` forever. This skill covers the
+3-step response: **detect → triage → restore**.
+
+Read this skill BEFORE flipping `RUNNER_GENERIC`, BEFORE editing a
+workflow's `runs-on:`, or BEFORE escalating Pi runner outages — there
+is a known recipe for each case, and skipping the recipe leads to
+half-broken state (e.g. `RUNNER_GENERIC` flipped but workflows
+hard-pinned to Pi still stuck).
+
+## 1. Detect
+
+```bash
+bash scripts/pi-runner-doctor.sh
+```
+
+What it shows:
+
+- Status of every `self-hosted` runner registered to the repo
+- Whether `RUNNER_GENERIC` is set, and to what
+- Workflows currently `queued` against Pi runner labels
+- Recommended action
+
+You can also do it manually:
+
+```bash
+gh api /repos/Themis128/cloudless.gr/actions/runners \
+  | jq -r '.runners[] | "\(.name): status=\(.status) busy=\(.busy)"'
+gh variable get RUNNER_GENERIC || echo "(unset → ubuntu-latest)"
+```
+
+**Trigger thresholds:**
+
+- One Pi runner offline → no action needed; the other absorbs the load
+  unless it's also busy. Note it; check in 30 min.
+- Both Pi runners offline AND workflows visibly queueing → triage.
+
+## 2. Triage (when both offline)
+
+### Step 2a — flip `RUNNER_GENERIC` to hosted
+
+```bash
+.github/scripts/toggle-runner.sh hosted
+```
+
+This clears the repo variable. Workflows using the pattern
+`runs-on: ${{ fromJSON(vars.RUNNER_GENERIC || '"ubuntu-latest"') }}`
+flip back to GH-hosted on their next run.
+
+**Already-queued jobs are NOT re-routed** — they stay pinned to
+whatever was set when they queued. Cancel them:
+
+```bash
+gh run list --status queued --limit 30 --json databaseId,workflowName \
+  | jq -r '.[] | "\(.databaseId)\t\(.workflowName)"'
+# pick the ones targeted at Pi → cancel each:
+gh run cancel <id>
+```
+
+Then `gh workflow run <name>` to re-trigger them. They'll pick up the
+new `RUNNER_GENERIC` value.
+
+### Step 2b — for workflows hard-pinned to Pi, decide
+
+Inventory (run this — list changes as workflows are added):
+
+```bash
+grep -l "runs-on:.*self-hosted.*omv.*pi\|runs-on:.*omv.*pi.*build" \
+  .github/workflows/*.yml | sed 's|.github/workflows/||'
+```
+
+As of 2026-06-22 the 5 hard-pinned workflows are:
+
+| Workflow | Can move to GH-hosted? | How |
+|---|---|---|
+| `sync-smtp-secrets.yml` | ✅ Yes | Already refactored — pattern below |
+| `etl-espocrm-to-lake.yml` | ✅ Yes | Add Tailscale + KUBECONFIG_B64 + OIDC AWS |
+| `deploy-alert-api.yml` | ⚠️ Partial | Needs `pi-standby-aws-creds` k8s Secret → requires kubectl from CI; doable |
+| `rollout-pi-force.yml` | ❌ No | Literally restarts the Pi k3s service via SSH; needs to be on the Pi or pivot through SSM |
+| `wire-pi-cognito-from-pi.yml` | ❌ No | Injects creds into the Pi runner's env; on-Pi by design |
+
+When a hard-pinned workflow is needed during a Pi outage and can't
+move, use the **GitHub Actions tailnet fallback** from CLAUDE.md
+"Cluster Incident Response" — write the change in a workflow file
+(e.g. `prometheus-tune.yml`), `gh pr merge` it, and let the ubuntu
+runner do the cluster work via `tailscale/github-action` +
+`KUBECONFIG_B64`.
+
+## 3. The GH-hosted-with-tailnet fallback pattern
+
+This is the canonical replacement for `runs-on: [self-hosted, omv, pi, build]`
+when the work is "needs AWS + kubectl, doesn't need to be physically
+on the Pi":
+
+```yaml
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write     # for OIDC to AWS
+      contents: read
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Connect to tailnet
+        uses: tailscale/github-action@0263d9e6d793eaefcf1de98ff7fde47abe6664d3 # v3.2.4
+        with:
+          authkey: ${{ secrets.TS_AUTHKEY }}
+
+      - name: Configure kubectl
+        run: |
+          mkdir -p ~/.kube
+          echo "${{ secrets.KUBECONFIG_B64 }}" | base64 -d > ~/.kube/config
+          chmod 600 ~/.kube/config
+
+      - name: Configure AWS credentials (OIDC)
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_DEPLOY_ROLE_ARN }}
+          aws-region: us-east-1
+
+      - name: Run the work
+        run: bash scripts/<your-script>.sh
+```
+
+Required repo secrets (all already exist):
+
+- `TS_AUTHKEY` — Tailscale ephemeral pre-auth key
+- `KUBECONFIG_B64` — `cat ~/.kube/config | base64 -w0` from omv-main;
+  uses `system:admin` rolebinding (full cluster access)
+- `AWS_DEPLOY_ROLE_ARN` — OIDC trust for `Themis128/cloudless.gr`
+
+Reference workflows that already use this pattern:
+
+- `cluster-doctor.yml` — read-only diagnostics
+- `prometheus-tune.yml` — write to cluster (kubectl delete + apply)
+- `etl-selfhosted-to-lake.yml` — AppFlowy postgres-direct via
+  `kubectl exec`
+
+## 4. Restore (operator-side)
+
+The Pi runners are systemd units on `omv` and `omv-2`:
+
+```bash
+ssh tbaltzakis@omv
+systemctl --user status actions.runner.Themis128-cloudless.gr.omv
+systemctl --user restart actions.runner.Themis128-cloudless.gr.omv
+
+ssh tbaltzakis@omv-2
+systemctl --user status actions.runner.Themis128-cloudless.gr.omv-2
+systemctl --user restart actions.runner.Themis128-cloudless.gr.omv-2
+```
+
+Common reasons they go offline:
+
+1. **Pi rebooted** — runner service is `--user` so it needs the user
+   session active. Fix: `loginctl enable-linger tbaltzakis` once.
+2. **Disk pressure** — `pi-disk-cleanup.timer` should catch this, but
+   if `/srv/dev-disk-by-uuid-a9a5a108-…` (sda1, k3s data) is >85%,
+   crictl prune first.
+3. **Runner token expired** — re-register from
+   `Settings → Actions → Runners → Add new runner`.
+4. **Tailnet flap** — `tailscale up --reset` on the Pi.
+
+After restart, verify both come back online:
+
+```bash
+gh api /repos/Themis128/cloudless.gr/actions/runners \
+  | jq -r '.runners[] | "\(.name): \(.status)"'
+```
+
+Flip `RUNNER_GENERIC` back to Pi only if you want to push load there
+again:
+
+```bash
+.github/scripts/toggle-runner.sh pi
+```
+
+## 5. When NOT to use the GH-hosted fallback
+
+Keep the Pi pin (i.e. **don't** add a GH-hosted fallback) when the
+work fundamentally needs to be on the Pi:
+
+- Anything that reads `pi-standby-aws-creds` from the Pi's local
+  k3s Secret without going through the cluster API
+- Anything that writes to a Pi local filesystem (e.g.
+  `/etc/rancher/k3s/config.yaml`, OMV web UI, USB-SSD mount)
+- Anything that needs to be triggered FROM the Pi (e.g. a heartbeat
+  that proves the Pi is healthy — a GH-hosted runner doing it would
+  be a lie)
+
+For those, the right answer when the Pi is down is "fix the Pi", not
+"move the work."
+
+## Apply this skill
+
+- When you see workflows stuck queued and the Pi runners are offline,
+  run `scripts/pi-runner-doctor.sh` first, then follow Step 2.
+- When you're adding a new workflow that needs cluster access, default
+  to the GH-hosted-with-tailnet pattern (Step 3). Only pin to Pi if it
+  hits one of the Step 5 conditions.
+- When the Pi runners are flapping, follow Step 4. Don't keep
+  flipping `RUNNER_GENERIC` back and forth — it confuses queued jobs.
+
+## See also
+
+- `scripts/pi-runner-doctor.sh` — single-command diagnostic + remediation
+- `.github/scripts/toggle-runner.sh` — flip `RUNNER_GENERIC` between
+  Pi and hosted modes
+- `docs/runners.md` — broader design doc on the runner failover model
+- CLAUDE.md "Cluster Incident Response" — the broader pattern (when
+  the infra MCP also can't reach the Pi)
+- Memory `pi-runner-failover` — pointer to this skill


### PR DESCRIPTION
When both Pi self-hosted runners go offline (as happened today), workflows pinned to [self-hosted, omv, pi, build] queue forever. This PR ships skills/pi-runner-failover/SKILL.md + scripts/pi-runner-doctor.sh + the canonical refactor pattern applied to sync-smtp-secrets.yml. Closes the SES-SMTP-sync blocker without waiting for Pi runners to come back.