### PR TITLE
fix(sync-smtp-secrets): timeout kubectl smoke test

### DIFF
--- a/.github/workflows/sync-smtp-secrets.yml
+++ b/.github/workflows/sync-smtp-secrets.yml
@@ -58,7 +58,14 @@ jobs:
           mkdir -p ~/.kube
           echo "${{ secrets.KUBECONFIG_B64 }}" | base64 -d > ~/.kube/config
           chmod 600 ~/.kube/config
-          kubectl get ns -o name | head -5  # smoke test cluster reachability
+          # Smoke test cluster reachability — wrap in `timeout` so a slow
+          # tailnet handshake doesn't hang the whole job (default kubectl
+          # request-timeout is 0 = no client-side timeout; observed 5+ min
+          # hangs on first GH-hosted → tailnet → k3s API call). On
+          # timeout, log + continue: the sync script does its own
+          # kubectl calls with longer-lived patience.
+          timeout 30s kubectl get ns -o name | head -5 \
+            || echo "::warning::kubectl smoke test timed out — tailnet may be slow; sync script will retry"
 
       - name: Configure AWS credentials (OIDC)
         uses: aws-actions/configure-aws-credentials@e7f100cf4c008499ea8adda475de1042d6975c7b # v6.2.0


### PR DESCRIPTION
Wraps the kubectl get ns smoke test in timeout 30s + warns + continues. Resolves the 5+ min hang verified twice this session on the GH-hosted-with-tailnet path.