### PR TITLE
feat(R18): Pi-side SSM scope assertion — daily probe

### DIFF
--- a/.github/workflows/probe-pi-ssm-scope.yml
+++ b/.github/workflows/probe-pi-ssm-scope.yml
@@ -1,0 +1,86 @@
+name: Probe — Pi SSM scope assertion
+
+# R18 — daily check that the cloudless-pi-standby IAM user can read
+# every SSM key under /cloudless/production/*. Catches the
+# "added new key, forgot to grant Pi" silently-broken case
+# (pi-cloud-sync.md gap #2).
+#
+# Trigger: daily 06:05 UTC (5 min after the 06:00 cluster-status
+# audit so they don't race for OIDC tokens) + workflow_dispatch +
+# push on the script / workflow.
+#
+# Failure path: posts to /api/webhooks/admin-alert with severity=high;
+# fans to Slack + ntfy + Sentry via the standard R8 admin-alert path.
+#
+# This is a READ-ONLY probe. No AWS state is changed. The IAM caller
+# only needs ssm:DescribeParameters + iam:SimulatePrincipalPolicy.
+
+on:
+  schedule:
+    - cron: "5 6 * * *"
+  workflow_dispatch:
+  push:
+    branches: [main]
+    paths:
+      - "scripts/audit-pi-ssm-scope.sh"
+      - ".github/workflows/probe-pi-ssm-scope.yml"
+
+permissions:
+  id-token: write
+  contents: read
+
+concurrency:
+  group: probe-pi-ssm-scope
+  cancel-in-progress: false
+
+jobs:
+  probe:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    env:
+      AWS_REGION: us-east-1
+      PI_USER: cloudless-pi-standby
+      PREFIX: /cloudless/production/
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Configure AWS credentials (OIDC)
+        uses: aws-actions/configure-aws-credentials@e7f100cf4c008499ea8adda475de1042d6975c7b # v6.2.0
+        with:
+          role-to-assume: ${{ secrets.AWS_DEPLOY_ROLE_ARN }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Run audit
+        id: audit
+        run: |
+          set +e
+          chmod +x scripts/audit-pi-ssm-scope.sh
+          bash scripts/audit-pi-ssm-scope.sh | tee audit.txt
+          rc=$?
+          echo "rc=$rc" >> "$GITHUB_OUTPUT"
+          # Also emit JSON for the alert body
+          bash scripts/audit-pi-ssm-scope.sh --json > audit.json 2>/dev/null || true
+          exit "$rc"
+
+      - name: Post drift to admin-alert webhook
+        if: failure() && steps.audit.outputs.rc == '1'
+        env:
+          ADMIN_ALERT_URL: https://cloudless.gr/api/webhooks/admin-alert
+          ADMIN_ALERT_TOKEN: ${{ secrets.ADMIN_ALERT_TOKEN }}
+        run: |
+          # audit.json contains keys_denied[] + action
+          DENIED=$(grep -oE '"keys_denied":\[[^]]*\]' audit.json | sed 's/"keys_denied"://' || echo '[]')
+          BODY=$(cat <<EOF
+          {
+            "severity": "high",
+            "source": "probe-pi-ssm-scope",
+            "title": "Pi SSM scope drift — cloudless-pi-standby can't read $(echo "$DENIED" | tr -cd ',' | wc -c | awk '{print $1+1}') keys",
+            "message": "The cloudless-pi-standby IAM user is missing ssm:GetParameter on $DENIED. Pi runtime will silently fail to read these. Fix: extend the user's SSM read statement to cover the full /cloudless/production/* prefix. See scripts/audit-pi-ssm-scope.sh for the exact statement.",
+            "click": "https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          }
+          EOF
+          )
+          curl -sS -X POST "$ADMIN_ALERT_URL" \
+            -H "Content-Type: application/json" \
+            -H "Authorization: Bearer $ADMIN_ALERT_TOKEN" \
+            -d "$BODY" || echo "::warning::admin-alert POST failed (alert lost — see audit.txt above)"

--- a/docs/master-todo-list.md
+++ b/docs/master-todo-list.md
@@ -105,7 +105,7 @@ operator polish or unlock follow-on automation.
 ## Phase 2 — Week 2 (resilience + tighter RPO)
 
 - [ ] 🤖 🟠 **R13** EspoCRM `mariadb-backup` hourly to S3 (RPO 1h on canonical CRM). CronJob exec into mariadb pod → xbstream → S3. **EFFORT: S / RISK: LOW**
-- [ ] 🤖 🟣 **R18** Pi-side SSM scope assertion — daily workflow diffs SSM key list vs `cloudless-pi-standby` IAM read access. Catches "added key, forgot Pi" silently. **EFFORT: S / RISK: LOW**
+- [x] ~~🤖 🟣 **R18** Pi-side SSM scope assertion~~ ✅ **SHIPPED 2026-06-22** — `scripts/audit-pi-ssm-scope.sh` walks `/cloudless/production/*` and runs `iam:SimulatePrincipalPolicy` for `ssm:GetParameter` against `cloudless-pi-standby`. `.github/workflows/probe-pi-ssm-scope.yml` runs daily 06:05 UTC; drift POSTs to `/api/webhooks/admin-alert` (severity=high) which fans to Slack + ntfy + Sentry per the R8 path. Read-only — needs only `ssm:DescribeParameters` + `iam:SimulatePrincipalPolicy` on the caller. Closes pi-cloud-sync.md gap #2.
 - [ ] 🤖 🔵 **R22** Stripe webhook idempotency audit — confirm `event.id` dedup table in DDB + return 200 fast + process async. Prevents duplicate-charge bugs. **EFFORT: S (audit-only)**
 
 ---

--- a/scripts/audit-pi-ssm-scope.sh
+++ b/scripts/audit-pi-ssm-scope.sh
@@ -1,0 +1,127 @@
+#!/usr/bin/env bash
+# audit-pi-ssm-scope.sh — assert the Pi IAM user can read every SSM key.
+#
+# Closes pi-cloud-sync.md gap #2 / master-todo R18.
+#
+# Walks /cloudless/production/* in SSM, uses
+# `iam:SimulatePrincipalPolicy` to check whether
+# `cloudless-pi-standby` is allowed `ssm:GetParameter` on each key.
+# Prints a summary; exits 1 if any key is denied.
+#
+# Wired into .github/workflows/probe-pi-ssm-scope.yml (daily 06:00 UTC).
+# Drift triggers a /api/webhooks/admin-alert ping → Slack + ntfy.
+#
+# Usage:
+#   bash scripts/audit-pi-ssm-scope.sh                  # human output
+#   bash scripts/audit-pi-ssm-scope.sh --json           # machine-readable
+#   PI_USER=other-user bash scripts/audit-pi-ssm-scope.sh   # override
+#
+# Required IAM (for the caller running this script):
+#   - ssm:DescribeParameters
+#   - iam:SimulatePrincipalPolicy
+#
+# Required AWS env:
+#   - AWS_REGION (defaults to us-east-1)
+#   - Standard SDK creds (env / OIDC / instance profile)
+
+set -uo pipefail
+
+PI_USER="${PI_USER:-cloudless-pi-standby}"
+PREFIX="${PREFIX:-/cloudless/production/}"
+REGION="${AWS_REGION:-us-east-1}"
+ACCOUNT_ID="${ACCOUNT_ID:-}"
+JSON_OUT=0
+
+for arg in "$@"; do
+  case "$arg" in
+    --json) JSON_OUT=1 ;;
+  esac
+done
+
+if [ -z "$ACCOUNT_ID" ]; then
+  ACCOUNT_ID=$(aws sts get-caller-identity --query Account --output text 2>/dev/null) || {
+    echo "::error::Unable to determine AWS account id (aws sts get-caller-identity failed)"
+    exit 2
+  }
+fi
+
+USER_ARN="arn:aws:iam::${ACCOUNT_ID}:user/${PI_USER}"
+
+# 1. List all SSM parameters under PREFIX.
+mapfile -t KEYS < <(
+  aws ssm describe-parameters \
+    --region "$REGION" \
+    --parameter-filters "Key=Name,Option=BeginsWith,Values=${PREFIX}" \
+    --query 'Parameters[].Name' \
+    --output text 2>/dev/null | tr '\t' '\n' | sort -u
+)
+
+if [ "${#KEYS[@]}" -eq 0 ]; then
+  if [ "$JSON_OUT" -eq 1 ]; then
+    echo '{"keys_total":0,"keys_denied":[],"action":"no SSM params under prefix — nothing to assert"}'
+  else
+    echo "No SSM parameters found under ${PREFIX} — nothing to assert."
+  fi
+  exit 0
+fi
+
+# 2. For each key, build its ARN and simulate ssm:GetParameter.
+#    Iterate one at a time (simulate-principal-policy accepts up to 32 ResourceArns
+#    per call but the per-resource decision is simpler to read).
+DENIED=()
+for key in "${KEYS[@]}"; do
+  [ -z "$key" ] && continue
+  # Strip leading slash for ARN
+  arn_path="${key#/}"
+  param_arn="arn:aws:ssm:${REGION}:${ACCOUNT_ID}:parameter/${arn_path}"
+
+  decision=$(aws iam simulate-principal-policy \
+    --policy-source-arn "$USER_ARN" \
+    --action-names "ssm:GetParameter" \
+    --resource-arns "$param_arn" \
+    --query 'EvaluationResults[0].EvalDecision' \
+    --output text 2>/dev/null) || decision="ERROR"
+
+  case "$decision" in
+    allowed) ;;
+    *)       DENIED+=("$key") ;;
+  esac
+done
+
+# 3. Report.
+KEYS_TOTAL=${#KEYS[@]}
+DENIED_COUNT=${#DENIED[@]}
+
+if [ "$JSON_OUT" -eq 1 ]; then
+  # Build JSON manually (no jq dep)
+  denied_json=$(printf '"%s",' "${DENIED[@]}" | sed 's/,$//')
+  cat <<EOF
+{"keys_total":${KEYS_TOTAL},"keys_denied_count":${DENIED_COUNT},"keys_denied":[${denied_json}],"pi_user":"${PI_USER}","action":"$( [ "$DENIED_COUNT" -gt 0 ] && echo "Grant ssm:GetParameter on the denied resources to ${PI_USER}" || echo "ok" )"}
+EOF
+else
+  echo "=== Pi SSM scope audit ==="
+  echo "Pi user:    ${PI_USER}"
+  echo "User ARN:   ${USER_ARN}"
+  echo "Prefix:     ${PREFIX}"
+  echo "Total keys: ${KEYS_TOTAL}"
+  echo "Denied:     ${DENIED_COUNT}"
+  if [ "$DENIED_COUNT" -gt 0 ]; then
+    echo
+    echo "Keys NOT readable by ${PI_USER}:"
+    for k in "${DENIED[@]}"; do
+      echo "  - ${k}"
+    done
+    echo
+    echo "Fix: extend ${PI_USER}'s SSM read statement to cover these resources."
+    echo "Typical inline policy (replace existing statement Resource:):"
+    echo '    "Resource": "arn:aws:ssm:'"${REGION}"':'"${ACCOUNT_ID}"':parameter'"${PREFIX}"'*"'
+  else
+    echo
+    echo "All ${KEYS_TOTAL} SSM keys are readable by ${PI_USER}."
+  fi
+fi
+
+if [ "$DENIED_COUNT" -gt 0 ]; then
+  exit 1
+fi
+exit 0


### PR DESCRIPTION
Closes R18 / pi-cloud-sync.md gap #2. Daily 06:05 UTC iam:SimulatePrincipalPolicy diff of SSM keys vs cloudless-pi-standby permissions; drift fires /api/webhooks/admin-alert (severity=high) into the R8 fan-out (Slack + ntfy + Sentry). Read-only, ~30s per run.