### PR TITLE
docs(master-todo): R13 descoped to 24h (already covered by R10)

### DIFF
--- a/docs/master-todo-list.md
+++ b/docs/master-todo-list.md
@@ -1,9 +1,10 @@
 # Master TODO — cloudless.gr perfection roadmap (post-R12)
 
-**Status as of 2026-06-22:** R10, R11, R12, R14 (Phase 1) + R18
+**Status as of 2026-06-22:** R10, R11, R12, R14 (Phase 1) + R13, R18
 (Phase 2) all shipped. Phase 1 is 4/5 done (only R25 open). Phase 2 is
-1/3 done (R13 + R22 remain). The 2026-06-22 session ran a 17-PR ops
-sweep on top of that — see the "Session log" section below.
+**2/3 done** (only R22 remains; R13 descoped to 24h cadence ⇒ already
+covered by R10's daily EspoCRM CronJob). The 2026-06-22 session ran a
+18-PR ops sweep on top of that — see the "Session log" section below.
 
 The single canonical action list for taking the AWS-serverless + Pi-cluster
 stack to "production-perfect with full data-analytics features", under the
@@ -118,7 +119,7 @@ operator polish or unlock follow-on automation.
 
 ## Phase 2 — Week 2 (resilience + tighter RPO)
 
-- [ ] 🤖 🟠 **R13** EspoCRM `mariadb-backup` hourly to S3 (RPO 1h on canonical CRM). CronJob exec into mariadb pod → xbstream → S3. **EFFORT: S / RISK: LOW**
+- [x] ~~🤖 🟠 **R13** EspoCRM `mariadb-backup` hourly to S3~~ ✅ **DESCOPED to 24h cadence — already shipped via R10** (2026-06-22). Operator chose RPO=24h over the originally-planned RPO=1h. The daily `infrastructure/backup/cronjob-espocrm.yaml` CronJob at 03:45 UTC (mariadb-dump → gzip → S3 `pvc-backups/espocrm/daily/`) covers this. If the RPO ever needs to drop back to 1h, add a sibling CronJob with `schedule: "0 * * * *"` reusing the same Secret + ServiceAccount.
 - [x] ~~🤖 🟣 **R18** Pi-side SSM scope assertion~~ ✅ **SHIPPED 2026-06-22** — `scripts/audit-pi-ssm-scope.sh` walks `/cloudless/production/*` and runs `iam:SimulatePrincipalPolicy` for `ssm:GetParameter` against `cloudless-pi-standby`. `.github/workflows/probe-pi-ssm-scope.yml` runs daily 06:05 UTC; drift POSTs to `/api/webhooks/admin-alert` (severity=high) which fans to Slack + ntfy + Sentry per the R8 path. Read-only — needs only `ssm:DescribeParameters` + `iam:SimulatePrincipalPolicy` on the caller. Closes pi-cloud-sync.md gap #2.
 - [ ] 🤖 🔵 **R22** Stripe webhook idempotency audit — confirm `event.id` dedup table in DDB + return 200 fast + process async. Prevents duplicate-charge bugs. **EFFORT: S (audit-only)**
 


### PR DESCRIPTION
Operator chose RPO=24h. The R10 daily EspoCRM CronJob already covers it; R13 marked done by descope. Phase 2 is now 2/3 done.