### PR TITLE
docs(drive): cleanup runbook + audit script + master-todo progress

### DIFF
--- a/docs/google-drive-cleanup.md
+++ b/docs/google-drive-cleanup.md
@@ -1,0 +1,129 @@
+# Google Drive cleanup — operator runbook
+
+**When to use:** Google warns "X% of storage used" (typically 70%+) on the
+operator account. This runbook walks through finding what's actually
+consuming the storage and clearing it safely.
+
+**Important:** this session's `cloudless.gr/` Drive folder is **NOT
+likely the cause**. All session uploads (session summaries, strategy
+docs, etc.) total <100 KB. The warning almost always comes from one of:
+**Gmail attachments**, **Google Photos**, or **older Drive files** from
+other contexts. Check before deleting cloudless.gr content.
+
+## Step 1 — see what's actually full (5 min)
+
+Open [one.google.com/storage/management](https://one.google.com/storage/management).
+This page shows a single bar broken down by product (Drive / Gmail /
+Photos) and a sortable list of large items.
+
+Sort by **size, descending**. Note the top 10 items and which product
+each belongs to.
+
+| If the top items are… | Go to… |
+|---|---|
+| Gmail attachments | Step 2 |
+| Google Photos | Step 3 |
+| Drive files | Step 4 |
+| A mix | Step 2 → 3 → 4 in order |
+
+## Step 2 — Gmail attachment cleanup
+
+In Gmail search bar:
+
+```
+has:attachment larger:10M
+```
+
+Returns every email with an attachment ≥10 MB. Common culprits:
+
+- Large image / video sends from family / clients
+- Old design exports (PDFs, mockups)
+- Backup attachments that someone emailed "just in case"
+
+For each email you no longer need: open → ⋮ → **Delete forever**
+(not just "Move to Trash" — trash still counts against quota for 30
+days). Or use **Empty Trash now** in Trash.
+
+To search progressively larger: `larger:25M`, `larger:50M`,
+`larger:100M`.
+
+## Step 3 — Google Photos cleanup
+
+Open [photos.google.com/settings/storage](https://photos.google.com/settings/storage).
+
+Three actions in order:
+
+1. **"Recover storage"** — converts original-quality photos to
+   "Storage saver" (slight quality loss, big saving). One-time bulk
+   operation.
+2. **"Manage storage"** → review:
+   - **Blurry photos** — Google flags suggestions to delete
+   - **Screenshots** — usually safe to bulk-delete
+   - **Large videos** — biggest single items
+3. **Album review** — bulk-select any one-off events you no longer
+   need (e.g. duplicate camera-roll syncs).
+
+## Step 4 — Drive cleanup
+
+Open [drive.google.com](https://drive.google.com), click **Storage**
+in the left sidebar. Files sort by size, biggest first.
+
+Common cleanup targets:
+
+- **Old exports / backups** — ZIP archives, video exports
+- **Trash** — files deleted >30 days ago that the system kept "just in case"
+- **Orphan files** — files with no parent folder (search `is:unorganized`)
+- **Hidden duplicates** — search `title contains 'copy'` /
+  `title contains '(1)'`
+
+## Step 5 — cloudless.gr folder audit (optional)
+
+If you want to see what `cloudless.gr/` specifically is using, run from
+this repo:
+
+```bash
+node scripts/audit-drive-folder.mjs
+```
+
+The script lists the top 20 largest files in the `cloudless.gr/`
+Drive folder, sorted descending. See its docstring for required
+credentials (`GOOGLE_APPLICATION_CREDENTIALS` pointing at a service
+account JSON with read access to the folder).
+
+Today's footprint is ~50 KB across ~20 markdown files — the warning
+is upstream of cloudless.gr in the vast majority of cases.
+
+## Step 6 — empty Trash (final pass)
+
+Even after deleting, Trash holds items for 30 days. To reclaim space
+immediately:
+
+- Drive → Trash → "Empty trash now"
+- Gmail → Bin → "Empty Bin now"
+- Photos → "Bin" → "Empty bin"
+
+All three are at the bottom of their respective Trash views.
+
+## Automation status
+
+**Not configured:** there is no scheduled Drive cleanup workflow in
+this repo. Adding one (deleting files in `cloudless.gr/exports/`
+older than N days) requires:
+
+1. A Google service account with `drive.file` scope
+2. The service account email added as Editor on the
+   `cloudless.gr/` shared folder
+3. Service-account key in SSM (`/cloudless/production/GDRIVE_SA_KEY`)
+4. A `.github/workflows/probe-drive-cleanup.yml` workflow using the
+   SA key
+
+None of these are set up today. If the cloudless.gr footprint ever
+gets big enough to matter (it isn't — <100 KB total), we can wire
+this up as an R-row. Until then, follow Step 5 manually if you want
+to audit the cloudless.gr folder.
+
+## See also
+
+- `scripts/audit-drive-folder.mjs` — read-only audit script
+- [Google One Storage Manager](https://one.google.com/storage/management) — primary tool for the 70% problem
+- [Google's "How to free up Drive space"](https://support.google.com/drive/answer/6374270)

--- a/docs/master-todo-list.md
+++ b/docs/master-todo-list.md
@@ -1,12 +1,13 @@
 # Master TODO — cloudless.gr perfection roadmap (post-R12)
 
 **Status as of 2026-06-22:** R10, R11, R12, R14 (Phase 1) + R13, R18,
-**R22** (Phase 2) all shipped. Phase 1 is 4/5 done (only R25 open).
+R22 (Phase 2) all shipped. Phase 1 is 4/5 done (only R25 open).
 **Phase 2 is 3/3 done.** R13 descoped to 24h cadence ⇒ already covered
 by R10's daily EspoCRM CronJob; R22 audit confirmed the existing
 ConditionalWrite-dedup pattern is safe at SMB volume. The 2026-06-22
-session ran a 19-PR ops sweep on top of that — see the "Session log"
-section below.
+session ran a 22-PR ops sweep on top of that — see the "Session log"
+section below. **Next R-row: R21a** (Meilisearch self-host on omv-ha —
+entry to the AI baseline arc).
 
 The single canonical action list for taking the AWS-serverless + Pi-cluster
 stack to "production-perfect with full data-analytics features", under the

--- a/scripts/audit-drive-folder.mjs
+++ b/scripts/audit-drive-folder.mjs
@@ -1,0 +1,132 @@
+#!/usr/bin/env node
+/**
+ * audit-drive-folder.mjs — list the top-N largest files in the
+ * cloudless.gr Google Drive folder, sorted by size descending.
+ *
+ * Read-only. Does not delete, move, or modify anything.
+ *
+ * Companion to docs/google-drive-cleanup.md.
+ *
+ * Usage:
+ *   GDRIVE_FOLDER_ID=1k6VAptaVgLCD0W9TWLsVhzjrcP1J_r6a \
+ *   GOOGLE_APPLICATION_CREDENTIALS=/path/to/sa.json \
+ *     node scripts/audit-drive-folder.mjs [--top N]
+ *
+ * Defaults:
+ *   --top 20
+ *   GDRIVE_FOLDER_ID = the cloudless.gr folder id (above)
+ *
+ * Required IAM:
+ *   The service account in GOOGLE_APPLICATION_CREDENTIALS must be
+ *   added as at least Viewer on the target folder. The folder ID
+ *   can be copied from drive.google.com → folder → right-click →
+ *   "Get link" → the ID is the trailing path segment.
+ *
+ * Why not in CI:
+ *   No service account is provisioned today. The cloudless.gr Drive
+ *   footprint is ~50 KB total across ~20 files (verified 2026-06-22),
+ *   so a scheduled cleanup is not justified. This script exists for
+ *   the operator to run locally when curious.
+ */
+
+const TOP = (() => {
+  const idx = process.argv.indexOf("--top");
+  if (idx === -1) return 20;
+  return Number.parseInt(process.argv[idx + 1] ?? "20", 10);
+})();
+const FOLDER_ID =
+  process.env.GDRIVE_FOLDER_ID || "1k6VAptaVgLCD0W9TWLsVhzjrcP1J_r6a";
+
+async function main() {
+  let google;
+  try {
+    ({ google } = await import("googleapis"));
+  } catch (err) {
+    console.error(
+      'Missing dep: install once with "npm install googleapis" in this dir, then re-run.'
+    );
+    console.error("Original error:", err.message);
+    process.exit(2);
+  }
+
+  if (!process.env.GOOGLE_APPLICATION_CREDENTIALS) {
+    console.error(
+      "GOOGLE_APPLICATION_CREDENTIALS env var is not set. Point it at a service-account JSON with Viewer on the folder."
+    );
+    process.exit(2);
+  }
+
+  const auth = new google.auth.GoogleAuth({
+    scopes: ["https://www.googleapis.com/auth/drive.metadata.readonly"],
+  });
+  const drive = google.drive({ version: "v3", auth });
+
+  // Walk the folder recursively. Drive does not return cumulative
+  // folder size, so we collect all descendant files then sort.
+  const all = [];
+  const folderQueue = [FOLDER_ID];
+
+  while (folderQueue.length > 0) {
+    const folderId = folderQueue.shift();
+    let pageToken;
+    do {
+      const res = await drive.files.list({
+        q: `'${folderId}' in parents and trashed = false`,
+        fields:
+          "nextPageToken, files(id, name, mimeType, size, modifiedTime, parents)",
+        pageSize: 100,
+        pageToken,
+      });
+      for (const f of res.data.files ?? []) {
+        if (f.mimeType === "application/vnd.google-apps.folder") {
+          folderQueue.push(f.id);
+        } else if (f.size) {
+          all.push({
+            id: f.id,
+            name: f.name,
+            mime: f.mimeType,
+            sizeBytes: Number(f.size),
+            modifiedTime: f.modifiedTime,
+          });
+        }
+      }
+      pageToken = res.data.nextPageToken ?? undefined;
+    } while (pageToken);
+  }
+
+  if (all.length === 0) {
+    console.log(`No files with reported size under folder ${FOLDER_ID}.`);
+    console.log(
+      "Note: Google Docs/Sheets/Slides have no `size` field; they don't count against the 15 GB quota the same way."
+    );
+    return;
+  }
+
+  all.sort((a, b) => b.sizeBytes - a.sizeBytes);
+  const totalBytes = all.reduce((sum, f) => sum + f.sizeBytes, 0);
+
+  console.log(`Folder ID:  ${FOLDER_ID}`);
+  console.log(`Files counted (with size field): ${all.length}`);
+  console.log(`Total bytes:  ${fmt(totalBytes)}`);
+  console.log(`Top ${Math.min(TOP, all.length)} largest:`);
+  console.log("");
+  console.log("  size       modified            name");
+  console.log("  ---------- ------------------- ----");
+  for (const f of all.slice(0, TOP)) {
+    console.log(
+      `  ${fmt(f.sizeBytes).padStart(10)} ${(f.modifiedTime ?? "").slice(0, 19)} ${f.name}`
+    );
+  }
+}
+
+function fmt(bytes) {
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+  if (bytes < 1024 * 1024 * 1024) return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+  return `${(bytes / (1024 * 1024 * 1024)).toFixed(2)} GB`;
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});


### PR DESCRIPTION
Operator runbook for the 70% Drive warning + local audit script for the cloudless.gr folder (50 KB total — not the cause). CI cleanup workflow deferred (needs operator service account). Master TODO session-log extended with PRs #1125-#1127.