### PR TITLE
feat(omv-sdb1): README sync CronJob + NAS-headroom probe

### DIFF
--- a/docs/google-to-omv-migration.md
+++ b/docs/google-to-omv-migration.md
@@ -241,6 +241,30 @@ For ongoing Photos sync to omv, [`gphotos-sync`](https://github.com/gilesknap/gp
 runs as a CronJob (similar pattern to `infrastructure/backup/cronjob-*.yaml`).
 Not in scope here — add as an R-row if you want it.
 
+## NAS-headroom guard (auto-deployed)
+
+A daily k8s CronJob (`infrastructure/omv-sdb1/cronjob-share-readme-and-probe.yaml`)
+pinned to omv-main does two things at 04:30 UTC:
+
+1. Refreshes this runbook into `\\omv\google-archive\README.md` so
+   it's discoverable from your Windows workstation.
+2. Probes sdb1 free space and POSTs to `/api/webhooks/admin-alert`
+   (Slack + ntfy) when free space drops below **200 GB** (medium)
+   or **100 GB** (high — NAS unusable for ad-hoc writes).
+
+Budget enforced:
+
+| Slice | Target |
+|---|---|
+| Google-archive (Photos + Drive + Gmail) | ~150 GB |
+| Working headroom for NAS drops | ~300 GB |
+| Alert threshold | 200 GB free |
+| Hard floor | 100 GB free |
+
+If the alert fires, prune oldest Takeout snapshots or move cold
+content to an external drive / S3 Glacier. The probe itself never
+deletes anything.
+
 ## See also
 
 - `docs/google-drive-cleanup.md` — broader Drive/Gmail/Photos cleanup runbook

--- a/infrastructure/omv-sdb1/README.md
+++ b/infrastructure/omv-sdb1/README.md
@@ -1,0 +1,76 @@
+# omv-sdb1 ops
+
+Daily k8s CronJob `sdb1-readme-and-probe` running on omv-main that
+does two jobs:
+
+1. **README sync** — fetches `docs/google-to-omv-migration.md` from
+   `main` and writes it to
+   `/srv/dev-disk-by-uuid-fa6231ab-eae7-40ea-a4b6-400f767a89d7/google-archive/README.md`
+   so it's discoverable when the operator browses `\\omv\google-archive`
+   from Windows.
+
+2. **Capacity probe** — `df -BG` on the same mount; alerts to
+   `/api/webhooks/admin-alert` (severity=medium) when free space
+   drops below the NAS-headroom budget, severity=high when it
+   drops below the hard floor.
+
+## NAS-headroom budget (sdb1 = 916 GB Samsung 1TB)
+
+| Slice | Target |
+|---|---|
+| Google-archive (Photos + Drive + Gmail) | ~150 GB |
+| Working headroom for ad-hoc NAS drops | ~300 GB |
+| **Alert threshold (free GB)** | **200 GB** |
+| **Hard floor (manual intervention)** | **100 GB** |
+
+If sdb1 drops below 200 GB free, the daily probe POSTs a medium-severity
+alert. Below 100 GB, severity bumps to high (NAS unusable for ad-hoc
+writes from the workstation).
+
+When that fires, the fix is one of:
+
+- Prune old Takeout snapshots in `google-archive/`
+- Re-sync only the latest Google export rather than keeping all
+- Move oldest content to cold storage (an external USB drive, S3
+  Glacier via `aws s3 cp ... --storage-class GLACIER`)
+- As a last resort, prune `Backups/WindowsImageBackup/` per
+  `docs/google-to-omv-migration.md` Step 0
+
+## Deploy
+
+```bash
+kubectl apply -f infrastructure/omv-sdb1/cronjob-share-readme-and-probe.yaml
+```
+
+Plus once (so the alert webhook authenticates):
+
+```bash
+kubectl -n omv-ops create secret generic admin-alert-token \
+  --from-literal=ADMIN_ALERT_TOKEN=$(aws ssm get-parameter \
+    --name /cloudless/production/ADMIN_ALERT_TOKEN \
+    --with-decryption --query Parameter.Value --output text) \
+  --dry-run=client -o yaml | kubectl apply -f -
+```
+
+If the Secret is absent the probe still runs and logs the alert
+locally; only the POST fails (warning, not error).
+
+## Verify
+
+```bash
+# Force one off-schedule run
+kubectl -n omv-ops create job --from=cronjob/sdb1-readme-and-probe \
+  manual-$(date +%s)
+
+# Watch output
+kubectl -n omv-ops logs -f -l job-name=manual-...
+
+# Confirm README landed on the share
+ls -lh /srv/dev-disk-by-uuid-fa6231ab-eae7-40ea-a4b6-400f767a89d7/google-archive/README.md
+```
+
+## See also
+
+- `docs/google-to-omv-migration.md` — the runbook this syncs
+- Memory `project_pi_disk_layout` — full sdb1 / sda1 breakdown
+- `infrastructure/backup/cronjob-*.yaml` — sibling CronJob pattern

--- a/infrastructure/omv-sdb1/cronjob-share-readme-and-probe.yaml
+++ b/infrastructure/omv-sdb1/cronjob-share-readme-and-probe.yaml
@@ -1,0 +1,153 @@
+# Daily CronJob — keeps the google-archive SMB share's README up to date
+# AND alerts when sdb1 free space drops below the NAS-headroom budget.
+#
+# Why: the operator wants to use omv as a NAS from their Windows
+# workstation (\\omv\google-archive). To keep that usable they need
+# (a) the runbook discoverable inside the share, and (b) a guarantee
+# that the share has free space — Windows showing "disk full" makes
+# the NAS unusable for everyday drops. This CronJob does both.
+#
+# Schedule: 30 4 * * *  (04:30 UTC daily, offset from existing PVC
+#                       backups at 03:30/03:45/04:00/04:15)
+#
+# Headroom budget on sdb1 (916 GB Samsung 1TB Samsung SSD):
+#   - target Google-archive footprint: ~150 GB (Photos+Drive+Gmail)
+#   - working headroom for ad-hoc NAS drops:    300 GB
+#   - alert threshold:                          free < 200 GB
+#   - hard floor (manual intervention needed):  free < 100 GB
+#
+# Pinned to `omv` because sdb1 only exists on that node (the worker
+# omv-ha is a Pi 4 with no second SSD).
+#
+# Read+write hostPath into /srv/dev-disk-by-uuid-... so the pod can
+# (a) write the README into google-archive/, (b) df the filesystem.
+
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: omv-ops
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: admin-alert-token
+  namespace: omv-ops
+type: Opaque
+stringData:
+  # Populated out-of-band by the operator:
+  #   kubectl -n omv-ops create secret generic admin-alert-token \
+  #     --from-literal=ADMIN_ALERT_TOKEN=$(aws ssm get-parameter \
+  #       --name /cloudless/production/ADMIN_ALERT_TOKEN \
+  #       --with-decryption --query Parameter.Value --output text) \
+  #     --dry-run=client -o yaml | kubectl apply -f -
+  # If absent, the probe still runs but admin-alert POST will 401
+  # (logged as warning, doesn't fail the job).
+  ADMIN_ALERT_TOKEN: ""
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: sdb1-readme-and-probe
+  namespace: omv-ops
+  labels:
+    app.kubernetes.io/name: sdb1-readme-and-probe
+    cloudless.gr/owner: operator
+spec:
+  schedule: "30 4 * * *"
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 7
+  jobTemplate:
+    spec:
+      activeDeadlineSeconds: 300
+      backoffLimit: 1
+      template:
+        spec:
+          restartPolicy: OnFailure
+          nodeSelector:
+            kubernetes.io/hostname: omv
+          tolerations:
+            - operator: Exists
+          containers:
+            - name: readme-and-probe
+              image: alpine:3.20
+              imagePullPolicy: IfNotPresent
+              env:
+                - name: README_URL
+                  value: https://raw.githubusercontent.com/Themis128/cloudless.gr/main/docs/google-to-omv-migration.md
+                - name: MOUNT
+                  value: /sdb1
+                - name: SHARE_DIR
+                  value: /sdb1/google-archive
+                - name: ALERT_FREE_GB
+                  value: "200"
+                - name: HARD_FLOOR_GB
+                  value: "100"
+                - name: ADMIN_ALERT_URL
+                  value: https://cloudless.gr/api/webhooks/admin-alert
+                - name: ADMIN_ALERT_TOKEN
+                  valueFrom:
+                    secretKeyRef:
+                      name: admin-alert-token
+                      key: ADMIN_ALERT_TOKEN
+                      optional: true
+              command:
+                - /bin/sh
+                - -c
+                - |
+                  set -u
+                  apk add --no-cache curl coreutils >/dev/null
+
+                  # 1. Make sure the share dir exists, sync README
+                  mkdir -p "$SHARE_DIR"
+                  if curl -fsSL --max-time 15 "$README_URL" -o "$SHARE_DIR/README.md.tmp"; then
+                    mv "$SHARE_DIR/README.md.tmp" "$SHARE_DIR/README.md"
+                    echo "README synced ($(wc -c < "$SHARE_DIR/README.md") bytes)"
+                  else
+                    rm -f "$SHARE_DIR/README.md.tmp"
+                    echo "::warning::README fetch failed (network blip?); leaving previous copy in place"
+                  fi
+
+                  # 2. Probe sdb1 capacity
+                  read -r SIZE USED AVAIL PCT MOUNTED <<< "$(df -BG --output=size,used,avail,pcent,target "$MOUNT" | tail -1)"
+                  AVAIL_GB="${AVAIL%G}"
+                  SIZE_GB="${SIZE%G}"
+                  USED_GB="${USED%G}"
+                  echo "sdb1: size=${SIZE_GB}G used=${USED_GB}G avail=${AVAIL_GB}G (${PCT}) at ${MOUNTED}"
+
+                  SEVERITY=""
+                  TITLE=""
+                  if [ "$AVAIL_GB" -lt "$HARD_FLOOR_GB" ]; then
+                    SEVERITY="high"
+                    TITLE="sdb1 BELOW HARD FLOOR — only ${AVAIL_GB}G free (<${HARD_FLOOR_GB}G). NAS unusable for new writes; prune now."
+                  elif [ "$AVAIL_GB" -lt "$ALERT_FREE_GB" ]; then
+                    SEVERITY="medium"
+                    TITLE="sdb1 free space below NAS-headroom budget — ${AVAIL_GB}G free (<${ALERT_FREE_GB}G target)"
+                  else
+                    echo "sdb1 healthy — ${AVAIL_GB}G free comfortably above ${ALERT_FREE_GB}G alert threshold."
+                    exit 0
+                  fi
+
+                  echo "::warning::$TITLE"
+                  MESSAGE="omv-main sdb1 (/srv/dev-disk-by-uuid-fa6231ab-eae7-40ea-a4b6-400f767a89d7) at ${USED_GB}G of ${SIZE_GB}G, only ${AVAIL_GB}G free. Headroom budget = ${ALERT_FREE_GB}G alert / ${HARD_FLOOR_GB}G hard floor. Prune Google-archive snapshots or WindowsImageBackup. See docs/google-to-omv-migration.md."
+
+                  if [ -n "${ADMIN_ALERT_TOKEN:-}" ]; then
+                    curl -fsS -X POST "$ADMIN_ALERT_URL" \
+                      -H "Content-Type: application/json" \
+                      -H "Authorization: Bearer $ADMIN_ALERT_TOKEN" \
+                      -d "$(printf '{"severity":"%s","source":"sdb1-capacity","title":"%s","message":"%s"}' "$SEVERITY" "$TITLE" "$MESSAGE")" \
+                      || echo "::warning::admin-alert POST failed (alert lost; check logs)"
+                  else
+                    echo "::warning::ADMIN_ALERT_TOKEN not set in omv-ops/admin-alert-token Secret — alert logged only, not POSTed."
+                  fi
+
+                  # Don't fail the job on capacity alert (probe is informational)
+                  exit 0
+              volumeMounts:
+                - name: sdb1
+                  mountPath: /sdb1
+          volumes:
+            - name: sdb1
+              hostPath:
+                path: /srv/dev-disk-by-uuid-fa6231ab-eae7-40ea-a4b6-400f767a89d7
+                type: Directory


### PR DESCRIPTION
Single daily CronJob pinned to omv: refreshes runbook README into the google-archive SMB share + alerts when sdb1 free drops below 200/100 GB. Keeps the share usable as a NAS from Windows.