### PR TITLE
fix: admin-alert wire-up (correct header + env name) + weekly-brief HubSpot->EspoCRM

### DIFF
--- a/docs/admin-alert-secret-setup.md
+++ b/docs/admin-alert-secret-setup.md
@@ -1,0 +1,100 @@
+# `ADMIN_ALERT_SECRET` — one-time operator setup
+
+`/api/webhooks/admin-alert` is a shared-secret POST endpoint that any
+cron / probe / external sender can use to fire `notifyAdmin()`
+(Slack + ntfy fan-out). The shared secret has **two copies that must
+match exactly**:
+
+| Side | Where | Read by |
+|---|---|---|
+| Lambda (the receiver) | SSM `/cloudless/production/ADMIN_ALERT_SECRET` (us-east-1) | `src/lib/ssm-config.ts` cold-start; route reads `cfg.ADMIN_ALERT_SECRET` (with fallback to `cfg.NOTION_WEBHOOK_SECRET`) |
+| Senders (probes, CronJobs) | Whatever they need (env var, k8s Secret, etc.) | The pod / process posting the alert |
+
+The route handler:
+
+- expects header `x-cloudless-alert-secret: <token>`
+  (**not** `Authorization: Bearer …` — easy to get wrong)
+- uses `crypto.timingSafeEqual` so wrong-secret requests are 401, not silently dropped
+- returns `503 receiver_not_configured` if both SSM keys are empty
+
+Source of truth: `src/app/api/webhooks/admin-alert/route.ts`.
+
+## Operator setup — once
+
+Confirmed missing as of 2026-06-22. Closing the gap takes ~2 minutes.
+
+```bash
+# 1. Generate a fresh shared secret
+TOKEN=$(openssl rand -hex 32)
+echo "TOKEN=$TOKEN  # save this somewhere — you'll re-use it for k8s Secret below"
+
+# 2. Write to SSM (us-east-1 — confirmed by pi-standby creds region)
+aws ssm put-parameter \
+  --name /cloudless/production/ADMIN_ALERT_SECRET \
+  --type SecureString \
+  --value "$TOKEN" \
+  --overwrite \
+  --region us-east-1
+
+# 3. Force Lambda cold-start so it picks up the new SSM value.
+# Either redeploy via deploy.yml workflow OR adjust an env var to bounce:
+#   pnpm sst deploy --stage production --target NextjsSite
+# (SSM is read once at module-load; running Lambda containers will keep
+# serving with the old/missing value until they recycle.)
+
+# 4. Mirror into k8s Secrets that need to call the endpoint.
+#    Currently only one consumer: the sdb1 capacity probe.
+kubectl -n omv-ops create secret generic admin-alert-secret \
+  --from-literal=ADMIN_ALERT_SECRET="$TOKEN" \
+  --dry-run=client -o yaml | kubectl apply -f -
+
+# 5. Verify end-to-end — force a one-off probe job
+kubectl -n omv-ops create job sdb1-verify-alert --from=cronjob/sdb1-readme-and-probe
+# After ~30 s, check that the alert hit Slack/ntfy.
+# (Or look at the job's exit log: `kubectl -n omv-ops logs -l job-name=sdb1-verify-alert`)
+```
+
+## Senders to update when the secret rotates
+
+Anything that POSTs to `/api/webhooks/admin-alert` needs the new token.
+As of 2026-06-22 the inventory is:
+
+| Sender | Where the token lives | Rotate command |
+|---|---|---|
+| `omv-ops/sdb1-readme-and-probe` CronJob | k8s Secret `omv-ops/admin-alert-secret` key `ADMIN_ALERT_SECRET` | Step 4 above |
+| (future) `probe-pi-ssm-scope.yml` workflow | GH repo secret `ADMIN_ALERT_TOKEN` — IF wired (R18 uses Bearer scheme, not this header; remove or re-name if you ever consolidate) | `gh secret set ADMIN_ALERT_TOKEN` |
+| (future) Sentry Internal Integration | Sentry → Developer Settings → New Internal Integration → custom header `x-cloudless-alert-secret: $TOKEN` | Sentry UI |
+
+Rotation = repeat Steps 1, 2, 3, then update every row above in the
+same window. Don't drift; if the SSM value rotates and a sender still
+has the old token, every alert from that sender will silently 401.
+
+## Why this isn't an R-row
+
+It's listed in `docs/master-todo-list.md` Phase 0 alongside the Sentry
+webhook setup — both are operator-side one-time clicks that no PR can
+ship. Not "R-row work" because there's no code to write; just
+provision.
+
+## Related code
+
+- Route handler: `src/app/api/webhooks/admin-alert/route.ts`
+- SSM lookup: `src/lib/ssm-config.ts` (`getConfig()` → `ADMIN_ALERT_SECRET`)
+- Slack/ntfy fan-out helper: `src/lib/admin-alerts.ts` (`notifyAdmin()`)
+- First consumer of the wire: `infrastructure/omv-sdb1/cronjob-share-readme-and-probe.yaml`
+
+## R18 note — different secret, different header
+
+The R18 probe (`scripts/audit-pi-ssm-scope.sh` + `probe-pi-ssm-scope.yml`)
+also POSTs to `/api/webhooks/admin-alert` but uses
+`Authorization: Bearer <token>` against a GH-secret-stored
+`ADMIN_ALERT_TOKEN`. That's actually **wrong** — the route ignores
+the `Authorization` header. R18's alerts have never landed because of
+this. Two options:
+
+1. Add `Authorization: Bearer` support to the route handler
+2. Patch `probe-pi-ssm-scope.yml` to use `x-cloudless-alert-secret`
+   and rename the GH secret to `ADMIN_ALERT_SECRET`
+
+Option 2 is cleaner — keeps one auth pattern across all senders. Open
+as a follow-up PR; not blocking the sdb1 probe.

--- a/infrastructure/omv-sdb1/cronjob-share-readme-and-probe.yaml
+++ b/infrastructure/omv-sdb1/cronjob-share-readme-and-probe.yaml
@@ -30,19 +30,27 @@ metadata:
 apiVersion: v1
 kind: Secret
 metadata:
-  name: admin-alert-token
+  name: admin-alert-secret
   namespace: omv-ops
 type: Opaque
 stringData:
-  # Populated out-of-band by the operator:
-  #   kubectl -n omv-ops create secret generic admin-alert-token \
-  #     --from-literal=ADMIN_ALERT_TOKEN=$(aws ssm get-parameter \
-  #       --name /cloudless/production/ADMIN_ALERT_TOKEN \
-  #       --with-decryption --query Parameter.Value --output text) \
-  #     --dry-run=client -o yaml | kubectl apply -f -
-  # If absent, the probe still runs but admin-alert POST will 401
-  # (logged as warning, doesn't fail the job).
-  ADMIN_ALERT_TOKEN: ""
+  # The /api/webhooks/admin-alert route expects header
+  # `x-cloudless-alert-secret` matching SSM `ADMIN_ALERT_SECRET`
+  # (route handler: src/app/api/webhooks/admin-alert/route.ts L70).
+  #
+  # Operator one-time setup (see docs/admin-alert-secret-setup.md):
+  #   1. Generate shared secret + write to SSM:
+  #        TOKEN=$(openssl rand -hex 32)
+  #        aws ssm put-parameter --name /cloudless/production/ADMIN_ALERT_SECRET \
+  #          --type SecureString --value "$TOKEN" --overwrite --region us-east-1
+  #        (the Lambda reads SSM at cold-start; rotate together with the k8s secret)
+  #   2. Mirror into this k8s Secret:
+  #        kubectl -n omv-ops create secret generic admin-alert-secret \
+  #          --from-literal=ADMIN_ALERT_SECRET="$TOKEN" \
+  #          --dry-run=client -o yaml | kubectl apply -f -
+  # If absent, the probe still runs but the alert POST is skipped
+  # (logged as warning; the job itself doesn't fail).
+  ADMIN_ALERT_SECRET: ""
 ---
 apiVersion: batch/v1
 kind: CronJob
@@ -85,11 +93,11 @@ spec:
                   value: "100"
                 - name: ADMIN_ALERT_URL
                   value: https://cloudless.gr/api/webhooks/admin-alert
-                - name: ADMIN_ALERT_TOKEN
+                - name: ADMIN_ALERT_SECRET
                   valueFrom:
                     secretKeyRef:
-                      name: admin-alert-token
-                      key: ADMIN_ALERT_TOKEN
+                      name: admin-alert-secret
+                      key: ADMIN_ALERT_SECRET
                       optional: true
               command:
                 - /bin/sh
@@ -134,14 +142,14 @@ spec:
                   echo "::warning::$TITLE"
                   MESSAGE="omv-main sdb1 (/srv/dev-disk-by-uuid-fa6231ab-eae7-40ea-a4b6-400f767a89d7) at ${USED_GB}G of ${SIZE_GB}G, only ${AVAIL_GB}G free. Headroom budget = ${ALERT_FREE_GB}G alert / ${HARD_FLOOR_GB}G hard floor. Prune Google-archive snapshots or WindowsImageBackup. See docs/google-to-omv-migration.md."
 
-                  if [ -n "${ADMIN_ALERT_TOKEN:-}" ]; then
+                  if [ -n "${ADMIN_ALERT_SECRET:-}" ]; then
                     curl -fsS -X POST "$ADMIN_ALERT_URL" \
                       -H "Content-Type: application/json" \
-                      -H "Authorization: Bearer $ADMIN_ALERT_TOKEN" \
+                      -H "x-cloudless-alert-secret: $ADMIN_ALERT_SECRET" \
                       -d "$(printf '{"severity":"%s","source":"sdb1-capacity","title":"%s","message":"%s"}' "$SEVERITY" "$TITLE" "$MESSAGE")" \
                       || echo "::warning::admin-alert POST failed (alert lost; check logs)"
                   else
-                    echo "::warning::ADMIN_ALERT_TOKEN not set in omv-ops/admin-alert-token Secret — alert logged only, not POSTed."
+                    echo "::warning::ADMIN_ALERT_SECRET not set in omv-ops/admin-alert-secret Secret — alert logged only, not POSTed."
                   fi
 
                   # Don't fail the job on capacity alert (probe is informational)

--- a/src/lib/agent-voice-brief.ts
+++ b/src/lib/agent-voice-brief.ts
@@ -81,12 +81,12 @@ const AGENT_TOOLS = [
   },
   {
     name: "get_pipeline_stats",
-    description: "Fetch HubSpot open-deal pipeline totals (deal count + total value in euros).",
+    description: "Fetch EspoCRM open-deal pipeline totals (deal count + total value in euros).",
     input_schema: { type: "object", properties: {}, required: [] },
   },
   {
     name: "get_email_metrics",
-    description: "Fetch the size of the newsletter subscriber list (HubSpot marketing contacts).",
+    description: "Fetch the size of the newsletter subscriber list (EspoCRM contacts with newsletter opt-in).",
     input_schema: { type: "object", properties: {}, required: [] },
   },
   {
@@ -179,15 +179,15 @@ const TOOL_HANDLERS: Record<string, () => Promise<string>> = {
     toolName: "get_pipeline_stats",
     fetch: fetchPipelineMetrics,
     format: (p) =>
-      `HubSpot pipeline: ${p.totalDeals} open deals worth €${p.totalValueEuros.toFixed(0)}.`,
-    emptyMessage: "HubSpot not configured.",
-    failMessage: "HubSpot pipeline lookup failed after retries.",
+      `EspoCRM pipeline: ${p.totalDeals} open deals worth €${p.totalValueEuros.toFixed(0)}.`,
+    emptyMessage: "EspoCRM not configured.",
+    failMessage: "EspoCRM pipeline lookup failed after retries.",
   }),
   get_email_metrics: makeToolHandler({
     toolName: "get_email_metrics",
     fetch: fetchEmailMetrics,
     format: (e) => `Newsletter: ${e.totalContacts.toLocaleString()} subscribers.`,
-    emptyMessage: "HubSpot not configured.",
+    emptyMessage: "EspoCRM not configured.",
     failMessage: "Newsletter lookup failed after retries.",
   }),
   get_stripe_revenue: makeToolHandler({

--- a/src/lib/voice-brief-sources.ts
+++ b/src/lib/voice-brief-sources.ts
@@ -7,7 +7,7 @@
  * the agent loop and can be unit-tested independently.
  */
 import { getSeoSnapshot } from "@/lib/gsc";
-import { isHubSpotConfigured, getPipelineStats, listNewsletterSubscribers } from "@/lib/espocrm";
+import { isEspoCRMConfigured, getPipelineStats, listNewsletterSubscribers } from "@/lib/espocrm";
 import { getStripe } from "@/lib/stripe";
 
 export interface SeoMetrics {
@@ -37,16 +37,16 @@ export async function fetchSeoMetrics(): Promise<SeoMetrics | null> {
   return { clicks: snap.clicks, impressions: snap.impressions, ctr: snap.ctr };
 }
 
-/** Returns null when HubSpot isn't configured; throws on transport errors. */
+/** Returns null when EspoCRM isn't configured; throws on transport errors. */
 export async function fetchPipelineMetrics(): Promise<PipelineMetrics | null> {
-  if (!(await isHubSpotConfigured())) return null;
+  if (!(await isEspoCRMConfigured())) return null;
   const p = await getPipelineStats();
   return { totalDeals: p.totalDeals, totalValueEuros: p.totalValue / 100 };
 }
 
-/** Newsletter subscriber count — null when HubSpot isn't configured. */
+/** Newsletter subscriber count — null when EspoCRM isn't configured. */
 export async function fetchEmailMetrics(): Promise<EmailMetrics | null> {
-  if (!(await isHubSpotConfigured())) return null;
+  if (!(await isEspoCRMConfigured())) return null;
   const subs = await listNewsletterSubscribers();
   return { totalContacts: subs.length };
 }


### PR DESCRIPTION
Two fixes: (1) sdb1 capacity probe was sending wrong header + env name; route expects x-cloudless-alert-secret + ADMIN_ALERT_SECRET. (2) weekly voice brief was still saying "HubSpot pipeline:" / "HubSpot not configured."; swapped to EspoCRM. Plus docs/admin-alert-secret-setup.md with the operator one-time setup steps (confirmed via live SSM probe that the secret is unset today).