### PR TITLE
feat: complete HubSpot->EspoCRM decom in app + UI + test mock paths

### DIFF
--- a/.amazonq/rules/memory-bank/guidelines.md
+++ b/.amazonq/rules/memory-bank/guidelines.md
@@ -82,7 +82,7 @@ export async function POST(request: NextRequest) {
 
 - Always use `Response.json()` (not `NextResponse.json()`) for response creation
 - SSM config loaded via `await getConfig()` — never read secrets from `process.env` directly in production routes
-- Fire-and-forget side effects (Slack, HubSpot) call `.catch(() => {})` inline — they never fail the main response
+- Fire-and-forget side effects (Slack, EspoCRM) call `.catch(() => {})` inline — they never fail the main response
 - Webhook routes verify signatures **before** any payload processing
 - `mapIntegrationError(err)` called first in every catch block — handles known AWS/Stripe/Slack errors uniformly
 - Sentry: dynamic `import("@sentry/nextjs")` only when `NEXT_PUBLIC_SENTRY_DSN` is set; always `.catch(() => {})` to prevent Sentry from failing the route

--- a/.amazonq/rules/memory-bank/product.md
+++ b/.amazonq/rules/memory-bank/product.md
@@ -11,7 +11,7 @@ Core value: One platform that serves as a marketing site, lead capture engine, c
 ### Public / Marketing
 
 - Multi-locale site (en, el, fr, de) with cookie-based locale switching
-- Blog via Notion CMS, services listing, contact form (SES + Slack + HubSpot)
+- Blog via Notion CMS, services listing, contact form (SES + Slack + EspoCRM)
 - Newsletter signup with SES welcome email + Slack notification
 - E-commerce store (checkout redirects to contact page with product/campaign context instead of Stripe Checkout)
 - PWA support (service worker, offline.html, web manifest)
@@ -35,7 +35,7 @@ Core value: One platform that serves as a marketing site, lead capture engine, c
 ### Admin Panel (`/admin`)
 
 - Full analytics: GSC (Google Search Console), Stripe, DuckDB
-- CRM: HubSpot contacts, pipelines, deals
+- CRM: EspoCRM contacts, pipelines, deals
 - Notion CMS management: blog, docs, forms, case studies, tasks
 - AI analytics orchestration with Anthropic Claude + AWS Bedrock
 - A/B test flag management (SSM-backed)
@@ -50,7 +50,7 @@ Core value: One platform that serves as a marketing site, lead capture engine, c
 
 - Slack: full two-way (outbound notify + inbound slash commands, events, interactions)
 - Notion: blog, docs, forms, projects, analytics, calendar, reports
-- HubSpot: CRM contacts, deals, pipelines, webhooks
+- EspoCRM: CRM contacts, deals, pipelines, webhooks
 - Google Calendar: booking availability and slot reservation
 - Google Search Console: 10+ analytics functions
 - Stripe: webhooks, subscription management (checkout disabled — redirects to contact page)

--- a/.github/workflows/etl-espocrm-to-lake.yml
+++ b/.github/workflows/etl-espocrm-to-lake.yml
@@ -2,7 +2,7 @@ name: ETL — EspoCRM to Data Lake
 
 on:
   schedule:
-    - cron: "20 * * * *" # hourly at :20 (offset from HubSpot 03:15 + Stripe 03:30)
+    - cron: "20 * * * *" # hourly at :20 (offset from EspoCRM 03:15 + Stripe 03:30)
   workflow_dispatch:
   push:
     paths:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -62,7 +62,7 @@ src/
 │   │   │   ├── page.tsx         # Store listing
 │   │   │   ├── [id]/page.tsx    # Product detail + JSON-LD
 │   │   │   └── success/         # Order confirmation
-│   │   ├── contact/             # Contact form (SES + Slack + HubSpot + Notion)
+│   │   ├── contact/             # Contact form (SES + Slack + EspoCRM + Notion)
 │   │   ├── auth/                # Login · Signup · Forgot Password (Cognito + next-auth)
 │   │   ├── dashboard/           # Customer portal (auth-protected, cyan accent)
 │   │   │   ├── profile/         # Edit name, company, phone
@@ -71,7 +71,7 @@ src/
 │   │   │   └── settings/        # Theme, language, notifications
 │   │   └── admin/               # Admin panel (admin group only, magenta accent)
 │   │       ├── orders/          # Stripe sessions + subscriptions
-│   │       ├── crm/             # HubSpot contacts
+│   │       ├── crm/             # EspoCRM contacts
 │   │       ├── analytics/       # Google Search Console SEO dashboard
 │   │       ├── errors/          # Sentry issues
 │   │       ├── notion/          # Notion DB explorer
@@ -79,7 +79,7 @@ src/
 │   │       ├── settings/        # App config viewer
 │   │       └── users/           # Cognito user management
 │   └── api/
-│       ├── contact/             # POST → SES + Slack + HubSpot + Notion
+│       ├── contact/             # POST → SES + Slack + EspoCRM + Notion
 │       ├── checkout/            # POST → Stripe Checkout Session
 │       ├── subscribe/           # POST → SES + Slack
 │       ├── unsubscribe/         # POST → SES suppression list
@@ -95,15 +95,15 @@ src/
 │       ├── user/
 │       │   ├── purchases/       # GET → Stripe orders (requires JWT)
 │       │   └── consultations/   # GET → Calendar bookings (requires JWT)
-│       ├── crm/contact/         # POST → HubSpot upsert
-│       ├── hubspot/ticket/      # POST → HubSpot support ticket
+│       ├── crm/contact/         # POST → EspoCRM upsert
+│       ├── hubspot/ticket/      # POST → EspoCRM support ticket
 │       ├── webhooks/
 │       │   ├── stripe/          # POST → fulfillment (SES + Slack)
 │       │   └── notion/          # POST → cache invalidation + email
 │       └── admin/               # All require admin JWT
 │           ├── analytics/       # 10x GSC endpoints
 │           ├── cache/           # Notion cache flush
-│           ├── crm/             # HubSpot contacts/companies/deals/owners/pipelines
+│           ├── crm/             # EspoCRM contacts/companies/deals/owners/pipelines
 │           ├── notifications/   # Slack test
 │           ├── notion/          # Blog/docs/tasks/projects/submissions/search
 │           ├── ops/errors/      # Sentry issues
@@ -352,7 +352,7 @@ All integrations are optional and degrade gracefully. Config is centralized in `
 | Integration     | Env vars                                                                   | Lib file             |
 | --------------- | -------------------------------------------------------------------------- | -------------------- |
 | Slack           | `SLACK_WEBHOOK_URL`                                                        | `slack-notify.ts`    |
-| HubSpot CRM     | `HUBSPOT_API_KEY`                                                          | `hubspot.ts`         |
+| EspoCRM CRM     | `HUBSPOT_API_KEY`                                                          | `hubspot.ts`         |
 | Notion CMS      | `NOTION_API_KEY`, `NOTION_BLOG_DB`                                         | `notion-blog.ts`     |
 | Google Calendar | `GOOGLE_SERVICE_ACCOUNT_EMAIL`, `GOOGLE_PRIVATE_KEY`, `GOOGLE_CALENDAR_ID` | `google-calendar.ts` |
 | Sentry          | `SENTRY_AUTH_TOKEN`, `SENTRY_ORG`, `SENTRY_PROJECT`                        | (inline in route)    |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -195,7 +195,7 @@ ordering bugs, port mismatches, page-size pins, etc.):
   replacement, 9 pods + 1 worker on omv-ha). The worker pin to omv-ha
   is mandatory: Pi 5 runs a 16 KiB-page kernel and the worker's jemalloc
   was built for 4 KiB pages.
-- `skills/espocrm-operator/SKILL.md` — EspoCRM stack (HubSpot replacement).
+- `skills/espocrm-operator/SKILL.md` — EspoCRM stack (EspoCRM replacement).
   Drop-in mirror at `src/lib/espocrm.ts` (21 exports 1:1 with the old
   `hubspot.ts`); 6 Webhook entities sync to Slack via `SlackClient`;
   daily ETL to Athena; SES → Lambda → Case bridge for inbound email.
@@ -241,11 +241,11 @@ Env: `NEXT_PUBLIC_LINKEDIN_PARTNER_ID` (client, build-time) and
 unset the corresponding fire becomes a no-op — the route stays wired so the
 rest of the flow still works.
 
-## CRM migration: HubSpot → EspoCRM (in progress 2026-06-20)
+## CRM migration: EspoCRM → EspoCRM (in progress 2026-06-20)
 
-HubSpot's `content` scope is locked behind a paid Marketing Hub plan we don't
+EspoCRM's `content` scope is locked behind a paid Marketing Hub plan we don't
 have, breaking `/api/admin/email/campaigns` (501) — see the live probe in
-PR #1024. Rather than upgrade HubSpot, the CRM is being moved to **self-hosted
+PR #1024. Rather than upgrade EspoCRM, the CRM is being moved to **self-hosted
 EspoCRM** (SugarCRM lineage, same data model family as SuiteCRM but with proper
 arm64 image support — SuiteCRM's Bitnami image is amd64-only + commercial-only).
 
@@ -278,9 +278,9 @@ arm64 image support — SuiteCRM's Bitnami image is amd64-only + commercial-only
   to Slack via `SlackClient` (per `feedback_slack_use_slackclient`). Six
   Webhook entities registered in EspoCRM (one per event), all `isActive=true`.
 - **Next PRs**: PR 4 flips imports in the 10 admin API routes + 9 admin
-  pages from `@/lib/hubspot` → `@/lib/espocrm` (51 files reference HubSpot
+  pages from `@/lib/hubspot` → `@/lib/espocrm` (51 files reference EspoCRM
   today). PR 5: `scripts/etl/espocrm-to-lake.mjs` + Athena views.
-  HubSpot was fully decommissioned on 2026-06-20 (PR A in this thread):
+  EspoCRM was fully decommissioned on 2026-06-20 (PR A in this thread):
   `src/lib/hubspot.ts`, `src/components/HubSpotScript.tsx`,
   `src/app/[locale]/admin/hubspot/`, `src/app/api/hubspot/`,
   `src/app/api/webhooks/hubspot/`, `scripts/etl/hubspot-to-lake.mjs` +

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ graph TB
     subgraph External["External Services"]
         Stripe["Stripe Payments"]
         Slack["Slack Notifications"]
-        HubSpot["HubSpot CRM"]
+        EspoCRM["EspoCRM CRM"]
         GCal["Google Calendar"]
         Notion["Notion Blog CMS"]
     end
@@ -96,7 +96,7 @@ graph TB
     Routes --> SSM
     Contact --> SES
     Contact --> Slack
-    Contact --> HubSpot
+    Contact --> EspoCRM
     Subscribe --> SES
     Subscribe --> Slack
     Checkout --> Stripe
@@ -188,7 +188,7 @@ The app has a full two-way Slack integration. Last verified 2026-04-09 (56 unit 
 
 **Outbound notifications** (cloudless.gr → Slack):
 
-- `slackContactNotify` — fires on every contact form submission (fire-and-forget, parallel with HubSpot CRM upsert)
+- `slackContactNotify` — fires on every contact form submission (fire-and-forget, parallel with EspoCRM CRM upsert)
 - `slackSubscriberNotify` — fires on every newsletter sign-up, in parallel with the SES email
 - `slackOrderNotify` — fires on Stripe checkout completion with amount and session ID
 - `slackErrorNotify` — surface unexpected API errors to your Slack channel
@@ -327,7 +327,7 @@ All Stripe operations use a lazy singleton from `src/lib/stripe.ts` (`getStripe(
 - Webhook secret loaded exclusively from SSM (`STRIPE_WEBHOOK_SECRET`) — no env var fast-path.
 - `checkout.session.completed`: order confirmation email sent only when `payment_status === "paid"` OR `mode === "subscription"`. One-time payments with `payment_status !== "paid"` (e.g. async bank transfers still pending) do not trigger the email.
 - `invoice.payment_failed`: sends failure notice to customer + team alert.
-- HubSpot contact upsert + deal creation runs fire-and-forget after `checkout.session.completed`.
+- EspoCRM contact upsert + deal creation runs fire-and-forget after `checkout.session.completed`.
 - Sentry `captureException` and `flush` called on handler errors before Lambda returns.
 
 ### User purchases (`GET /api/user/purchases`)

--- a/__tests__/admin-api.test.ts
+++ b/__tests__/admin-api.test.ts
@@ -299,8 +299,8 @@ vi.mock("@/lib/gsc", () => ({
     ]),
 }));
 
-// HubSpot
-vi.mock("@/lib/hubspot", () => ({
+// EspoCRM
+vi.mock("@/lib/espocrm", () => ({
   listContacts: vi
     .fn()
     .mockResolvedValue([{ id: "1", email: "lead@example.com", firstName: "Test" }]),
@@ -459,7 +459,7 @@ describe("GET /api/admin/crm/contacts", () => {
     expect(res.status).toBe(401);
   });
 
-  it("returns 503 when HubSpot is not configured", async () => {
+  it("returns 503 when EspoCRM is not configured", async () => {
     mockIsConfiguredAsync.mockResolvedValueOnce(false);
     const { GET } = await import("@/app/api/admin/crm/contacts/route");
     const res = await GET(adminRequest("http://localhost/api/admin/crm/contacts"));

--- a/__tests__/admin-crm-api.test.ts
+++ b/__tests__/admin-crm-api.test.ts
@@ -13,7 +13,7 @@ vi.mock("@/lib/api-auth", () => ({
 }));
 
 vi.mock("@/lib/espocrm", () => ({
-  isHubSpotConfigured: isHubSpotConfiguredMock,
+  isEspoCRMConfigured: isHubSpotConfiguredMock,
   listCompanies: listCompaniesMock,
   listDeals: listDealsMock,
   listOwners: listOwnersMock,
@@ -31,7 +31,7 @@ const unauthorizedResponse = {
   }),
 };
 
-describe("Admin HubSpot CRM API", () => {
+describe("Admin EspoCRM CRM API", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     requireAdminMock.mockReturnValue({ ok: true, user: { sub: "admin" } });
@@ -82,12 +82,12 @@ describe("Admin HubSpot CRM API", () => {
     expect(res.status).toBe(401);
   });
 
-  it("returns 503 when HubSpot is not configured for companies", async () => {
+  it("returns 503 when EspoCRM is not configured for companies", async () => {
     isHubSpotConfiguredMock.mockResolvedValueOnce(false);
     const { GET } = await import("@/app/api/admin/crm/companies/route");
     const response = await GET(makeRequest("/api/admin/crm/companies"));
     expect(response.status).toBe(503);
-    expect(await response.json()).toEqual({ error: "HubSpot not configured." });
+    expect(await response.json()).toEqual({ error: "EspoCRM not configured." });
   });
 
   it("returns companies data", async () => {
@@ -108,7 +108,7 @@ describe("Admin HubSpot CRM API", () => {
     expect(res.status).toBe(401);
   });
 
-  it("returns 503 when HubSpot is not configured for deals", async () => {
+  it("returns 503 when EspoCRM is not configured for deals", async () => {
     isHubSpotConfiguredMock.mockResolvedValueOnce(false);
     const { GET } = await import("@/app/api/admin/crm/deals/route");
     const res = await GET(makeRequest("/api/admin/crm/deals"));
@@ -133,7 +133,7 @@ describe("Admin HubSpot CRM API", () => {
     expect(res.status).toBe(401);
   });
 
-  it("returns 503 when HubSpot is not configured for owners", async () => {
+  it("returns 503 when EspoCRM is not configured for owners", async () => {
     isHubSpotConfiguredMock.mockResolvedValueOnce(false);
     const { GET } = await import("@/app/api/admin/crm/owners/route");
     const res = await GET(makeRequest("/api/admin/crm/owners"));
@@ -158,12 +158,12 @@ describe("Admin HubSpot CRM API", () => {
     expect(res.status).toBe(401);
   });
 
-  it("returns 503 when HubSpot is not configured for pipelines", async () => {
+  it("returns 503 when EspoCRM is not configured for pipelines", async () => {
     isHubSpotConfiguredMock.mockResolvedValueOnce(false);
     const { GET } = await import("@/app/api/admin/crm/pipelines/route");
     const res = await GET(makeRequest("/api/admin/crm/pipelines"));
     expect(res.status).toBe(503);
-    expect(await res.json()).toEqual({ error: "HubSpot not configured." });
+    expect(await res.json()).toEqual({ error: "EspoCRM not configured." });
   });
 
   it("returns pipelines for deals objectType by default", async () => {
@@ -195,7 +195,7 @@ describe("Admin HubSpot CRM API", () => {
   });
 
   it("returns 500 when getPipelines throws", async () => {
-    getPipelinesMock.mockRejectedValueOnce(new Error("HubSpot API error"));
+    getPipelinesMock.mockRejectedValueOnce(new Error("EspoCRM API error"));
     const { GET } = await import("@/app/api/admin/crm/pipelines/route");
     const res = await GET(makeRequest("/api/admin/crm/pipelines"));
     expect(res.status).toBe(500);

--- a/__tests__/admin-email-api.test.ts
+++ b/__tests__/admin-email-api.test.ts
@@ -36,10 +36,10 @@ vi.mock("@/lib/espocrm", () => ({
   // route imports the new name. Keep the old mock variable as the backing
   // implementation so behavior tests don't need to be re-written.
   isEspoCRMConfigured: mockIsHubSpotConfigured,
-  isHubSpotConfigured: mockIsHubSpotConfigured,
+  isEspoCRMConfigured: mockIsHubSpotConfigured,
   listNewsletterSubscribers: mockListNewsletterSubscribers,
   // /api/admin/email/contacts switched from raw fetch → searchContacts /
-  // listContacts (lib/espocrm) after the HubSpot decom. Mock both so the
+  // listContacts (lib/espocrm) after the EspoCRM decom. Mock both so the
   // route's `try { … }` branch resolves instead of throwing → 500.
   searchContacts: mockSearchContacts,
   listContacts: mockListContacts,
@@ -71,10 +71,10 @@ describe("Admin Email API routes", () => {
   });
 
   // ── GET /api/admin/email/campaigns ───────────────────────────────────────────
-  // Route is a 501 stub — HubSpot Marketing Emails requires 'content' scope.
+  // Route is a 501 stub — EspoCRM Marketing Emails requires 'content' scope.
 
   describe("GET /api/admin/email/campaigns", () => {
-    it("returns 501 (HubSpot scope not available)", async () => {
+    it("returns 501 (EspoCRM scope not available)", async () => {
       const { GET } = await import("@/app/api/admin/email/campaigns/route");
       const res = await GET(makeGet("/api/admin/email/campaigns"));
       expect(res.status).toBe(501);
@@ -84,10 +84,10 @@ describe("Admin Email API routes", () => {
   });
 
   // ── GET /api/admin/email/stats ───────────────────────────────────────────────
-  // Route uses HubSpot: isHubSpotConfigured + listNewsletterSubscribers.
+  // Route uses EspoCRM: isEspoCRMConfigured + listNewsletterSubscribers.
 
   describe("GET /api/admin/email/stats", () => {
-    it("returns 503 when HubSpot not configured", async () => {
+    it("returns 503 when EspoCRM not configured", async () => {
       mockIsHubSpotConfigured.mockResolvedValueOnce(false);
       const { GET } = await import("@/app/api/admin/email/stats/route");
       const res = await GET(makeGet("/api/admin/email/stats"));
@@ -106,10 +106,10 @@ describe("Admin Email API routes", () => {
   });
 
   // ── GET /api/admin/email/contacts ────────────────────────────────────────────
-  // Route uses HubSpot: isHubSpotConfigured + getConfig + raw fetch to HubSpot API.
+  // Route uses EspoCRM: isEspoCRMConfigured + getConfig + raw fetch to EspoCRM API.
 
   describe("GET /api/admin/email/contacts", () => {
-    it("returns 503 when HubSpot not configured", async () => {
+    it("returns 503 when EspoCRM not configured", async () => {
       mockIsHubSpotConfigured.mockResolvedValueOnce(false);
       const { GET } = await import("@/app/api/admin/email/contacts/route");
       const res = await GET(makeGet("/api/admin/email/contacts"));
@@ -119,7 +119,7 @@ describe("Admin Email API routes", () => {
     it("returns contacts from EspoCRM (subscribers tab → searchContacts)", async () => {
       // Route at `?tab=subscribers` calls searchContacts("leadSource",
       // "newsletter_signup") and returns the .results slice + .total.
-      // Schema mirrors the old HubSpot shape (id + properties.email) so the
+      // Schema mirrors the old EspoCRM shape (id + properties.email) so the
       // admin UI didn't need to change.
       mockSearchContacts.mockResolvedValueOnce({
         results: [{ id: "1", properties: { email: "a@b.com" } }],

--- a/__tests__/admin-leads-api.test.ts
+++ b/__tests__/admin-leads-api.test.ts
@@ -59,7 +59,7 @@ describe("GET /api/admin/leads", () => {
     expect(res.status).toBe(401);
   });
 
-  it("returns HubSpot contacts as unified leads", async () => {
+  it("returns EspoCRM contacts as unified leads", async () => {
     const res = await GET(makeRequest());
     expect(res.status).toBe(200);
     const data = await res.json();
@@ -84,7 +84,7 @@ describe("GET /api/admin/leads", () => {
     ]);
     expect(data.leads[0].interest).toBe("Full-Stack Growth Engine (Bundle)");
     expect(data.leads[0].portalStatus).toBe("waiting");
-    // First touch wins: portal submission predates HubSpot createdate.
+    // First touch wins: portal submission predates EspoCRM createdate.
     expect(data.leads[0].createdAt).toBe("2026-05-30T09:00:00Z");
   });
 
@@ -104,14 +104,14 @@ describe("GET /api/admin/leads", () => {
     ]);
   });
 
-  it("skips HubSpot contacts without an email", async () => {
+  it("skips EspoCRM contacts without an email", async () => {
     mockListContacts.mockResolvedValue([{ id: "3", properties: { firstname: "Ghost" } }]);
     const res = await GET(makeRequest());
     const data = await res.json();
     expect(data.total).toBe(0);
   });
 
-  it("still serves portal leads when HubSpot is unconfigured", async () => {
+  it("still serves portal leads when EspoCRM is unconfigured", async () => {
     mockIsConfiguredAsync.mockResolvedValue(false);
     mockReadPendingClients.mockResolvedValue([PENDING_CLIENT]);
     const res = await GET(makeRequest());

--- a/__tests__/admin-ops-api.test.ts
+++ b/__tests__/admin-ops-api.test.ts
@@ -216,7 +216,7 @@ const mockIsHubSpotConfigured = vi.fn();
 const mockListTickets = vi.fn();
 vi.mock("@/lib/espocrm", async (orig) => ({
   ...(await orig<typeof import("@/lib/espocrm")>()),
-  isHubSpotConfigured: (...a: unknown[]) => mockIsHubSpotConfigured(...a),
+  isEspoCRMConfigured: (...a: unknown[]) => mockIsHubSpotConfigured(...a),
   listTickets: (...a: unknown[]) => mockListTickets(...a),
 }));
 
@@ -233,7 +233,7 @@ describe("GET /api/admin/crm/tickets", () => {
     expect(res.status).toBe(401);
   });
 
-  it("returns 503 when HubSpot not configured", async () => {
+  it("returns 503 when EspoCRM not configured", async () => {
     adminOk();
     mockIsHubSpotConfigured.mockResolvedValue(false);
     const { GET } = await import("@/app/api/admin/crm/tickets/route");

--- a/__tests__/admin-pipeline-api.test.ts
+++ b/__tests__/admin-pipeline-api.test.ts
@@ -15,7 +15,7 @@ vi.mock("@/lib/api-auth", () => ({
 }));
 
 vi.mock("@/lib/espocrm", () => ({
-  isHubSpotConfigured: isHubSpotConfiguredMock,
+  isEspoCRMConfigured: isHubSpotConfiguredMock,
   getDealsByStage: getDealsByStageMock,
   getPipelines: getPipelinesMock,
   getPipelineStats: getPipelineStatsMock,
@@ -46,7 +46,7 @@ describe("Admin Pipeline API routes", () => {
   // ── GET /api/admin/pipeline/board ────────────────────────────────────────────
 
   describe("GET /api/admin/pipeline/board", () => {
-    it("returns 503 when HubSpot not configured", async () => {
+    it("returns 503 when EspoCRM not configured", async () => {
       isHubSpotConfiguredMock.mockResolvedValueOnce(false);
       const { GET } = await import("@/app/api/admin/pipeline/board/route");
       const res = await GET(makeGet("/api/admin/pipeline/board"));
@@ -79,7 +79,7 @@ describe("Admin Pipeline API routes", () => {
   // ── GET /api/admin/pipeline/stats ────────────────────────────────────────────
 
   describe("GET /api/admin/pipeline/stats", () => {
-    it("returns 503 when HubSpot not configured", async () => {
+    it("returns 503 when EspoCRM not configured", async () => {
       isHubSpotConfiguredMock.mockResolvedValueOnce(false);
       const { GET } = await import("@/app/api/admin/pipeline/stats/route");
       const res = await GET(makeGet("/api/admin/pipeline/stats"));
@@ -107,7 +107,7 @@ describe("Admin Pipeline API routes", () => {
   describe("POST /api/admin/pipeline/deals/[id]/move", () => {
     const params = Promise.resolve({ id: "deal_1" });
 
-    it("returns 503 when HubSpot not configured", async () => {
+    it("returns 503 when EspoCRM not configured", async () => {
       isHubSpotConfiguredMock.mockResolvedValueOnce(false);
       const { POST } = await import("@/app/api/admin/pipeline/deals/[id]/move/route");
       const res = await POST(

--- a/__tests__/admin-reports-api.test.ts
+++ b/__tests__/admin-reports-api.test.ts
@@ -14,7 +14,7 @@ vi.mock("@/lib/api-auth", () => ({
 }));
 
 vi.mock("@/lib/espocrm", () => ({
-  isHubSpotConfigured: isHubSpotConfiguredMock,
+  isEspoCRMConfigured: isHubSpotConfiguredMock,
   getPipelineStats: getPipelineStatsMock,
 }));
 
@@ -144,7 +144,7 @@ describe("Admin Reports API routes", () => {
       expect(data.report.sections.some((s: { id: string }) => s.id === "email")).toBe(true);
     });
 
-    it("skips pipeline section when HubSpot not configured", async () => {
+    it("skips pipeline section when EspoCRM not configured", async () => {
       isHubSpotConfiguredMock.mockResolvedValue(false);
       const { POST } = await import("@/app/api/admin/reports/generate/route");
       const res = await POST(

--- a/__tests__/admin-unified-analytics-api.test.ts
+++ b/__tests__/admin-unified-analytics-api.test.ts
@@ -38,8 +38,8 @@ vi.mock("@/lib/gsc", () => ({
   }),
 }));
 
-vi.mock("@/lib/hubspot", () => ({
-  isHubSpotConfigured: mockIsHubSpot,
+vi.mock("@/lib/espocrm", () => ({
+  isEspoCRMConfigured: mockIsHubSpot,
   getPipelineStats: vi.fn().mockResolvedValue({
     totalDeals: 5,
     totalValue: 150000,
@@ -168,7 +168,7 @@ describe("GET /api/admin/analytics/unified", () => {
     expect(data.seo).toBeNull();
   });
 
-  it("returns null pipeline when HubSpot not configured", async () => {
+  it("returns null pipeline when EspoCRM not configured", async () => {
     mockIsHubSpot.mockResolvedValue(false);
     const { GET } = await import("@/app/api/admin/analytics/unified/route");
     const res = await GET(adminReq(ANALYTICS_URL));

--- a/__tests__/agent-voice-brief.test.ts
+++ b/__tests__/agent-voice-brief.test.ts
@@ -110,7 +110,7 @@ describe("agent-voice-brief.runVoiceBriefAgent", () => {
   });
 
   it("classifies a tool that throws past its retries as failed", async () => {
-    fetchPipelineMetricsMock.mockRejectedValue(new Error("HubSpot 500"));
+    fetchPipelineMetricsMock.mockRejectedValue(new Error("EspoCRM 500"));
     runBedrockTurnMock
       .mockResolvedValueOnce([dataBlock("get_pipeline_stats")])
       .mockResolvedValueOnce([emitBlock("Brief.")]);

--- a/__tests__/contact-campaign-pipeline.test.ts
+++ b/__tests__/contact-campaign-pipeline.test.ts
@@ -2,7 +2,7 @@
 /**
  * Tests the full /api/contact pipeline with campaign tier context
  * (the payload shape produced by the inline TierTable form).
- * Verifies SES, Slack, HubSpot, and Notion all receive the tier data.
+ * Verifies SES, Slack, EspoCRM, and Notion all receive the tier data.
  */
 import { describe, it, expect, vi, beforeEach } from "vitest";
 
@@ -29,7 +29,7 @@ vi.mock("@/lib/slack-notify", () => ({
   slackContactNotify: (...args: unknown[]) => mockSlackContactNotify(...args),
 }));
 
-// Mock HubSpot
+// Mock EspoCRM
 const mockUpsertContact = vi.fn().mockResolvedValue("contact-123");
 const mockCreateDeal = vi.fn().mockResolvedValue("deal-456");
 const mockAssociateDealWithContact = vi.fn().mockResolvedValue(undefined);
@@ -133,7 +133,7 @@ describe("POST /api/contact — campaign tier pipeline", () => {
     );
   });
 
-  it("upserts HubSpot contact with name and email", async () => {
+  it("upserts EspoCRM contact with name and email", async () => {
     const request = new Request("http://localhost/api/contact", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
@@ -152,7 +152,7 @@ describe("POST /api/contact — campaign tier pipeline", () => {
     );
   });
 
-  it("creates HubSpot deal with campaign tier context", async () => {
+  it("creates EspoCRM deal with campaign tier context", async () => {
     const request = new Request("http://localhost/api/contact", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
@@ -172,7 +172,7 @@ describe("POST /api/contact — campaign tier pipeline", () => {
     );
   });
 
-  it("associates deal with contact in HubSpot", async () => {
+  it("associates deal with contact in EspoCRM", async () => {
     const request = new Request("http://localhost/api/contact", {
       method: "POST",
       headers: { "Content-Type": "application/json" },

--- a/__tests__/crm-contact-api.test.ts
+++ b/__tests__/crm-contact-api.test.ts
@@ -4,7 +4,7 @@ const isHubSpotConfiguredMock = vi.fn();
 const upsertContactMock = vi.fn();
 
 vi.mock("@/lib/espocrm", () => ({
-  isHubSpotConfigured: isHubSpotConfiguredMock,
+  isEspoCRMConfigured: isHubSpotConfiguredMock,
   upsertContact: upsertContactMock,
 }));
 
@@ -15,7 +15,7 @@ describe("POST /api/crm/contact", () => {
     upsertContactMock.mockResolvedValue("contact_123");
   });
 
-  it("returns 503 when HubSpot is not configured", async () => {
+  it("returns 503 when EspoCRM is not configured", async () => {
     isHubSpotConfiguredMock.mockResolvedValueOnce(false);
 
     const { POST } = await import("@/app/api/crm/contact/route");

--- a/__tests__/cron-owner-digest.test.ts
+++ b/__tests__/cron-owner-digest.test.ts
@@ -139,14 +139,14 @@ describe("GET /api/cron/owner-digest", () => {
     expect(body).toContain("blocked");
   });
 
-  it("reports HubSpot as unconfigured without failing", async () => {
+  it("reports EspoCRM as unconfigured without failing", async () => {
     mockIsConfiguredAsync.mockResolvedValue(false);
     const res = await GET(makeRequest());
     const data = await res.json();
     expect(res.status).toBe(200);
     expect(data.newLeads).toBeNull();
     const body = JSON.stringify(mockSlackPost.mock.calls[0][0].blocks);
-    expect(body).toContain("HubSpot not configured");
+    expect(body).toContain("EspoCRM not configured");
   });
 
   it("degrades gracefully when calendar and portals sources throw", async () => {

--- a/__tests__/cron-voice-brief.test.ts
+++ b/__tests__/cron-voice-brief.test.ts
@@ -47,8 +47,8 @@ vi.mock("@/lib/gsc", () => ({
   getSeoSnapshot: (...args: unknown[]) => mockGetSeo(...args),
 }));
 
-vi.mock("@/lib/hubspot", () => ({
-  isHubSpotConfigured: (...args: unknown[]) => mockIsHubSpot(...args),
+vi.mock("@/lib/espocrm", () => ({
+  isEspoCRMConfigured: (...args: unknown[]) => mockIsHubSpot(...args),
   getPipelineStats: (...args: unknown[]) => mockPipeline(...args),
   listNewsletterSubscribers: (...args: unknown[]) => mockSubscribers(...args),
 }));

--- a/__tests__/integrations-status-api.test.ts
+++ b/__tests__/integrations-status-api.test.ts
@@ -13,7 +13,7 @@ vi.mock("@/lib/activecampaign", () => ({
   verifyActiveCampaignToken: verifyACTokenMock,
 }));
 
-// fetch is used for live pings (HubSpot, Slack, Notion, Stripe)
+// fetch is used for live pings (EspoCRM, Slack, Notion, Stripe)
 const fetchMock = vi.fn();
 vi.stubGlobal("fetch", fetchMock);
 

--- a/__tests__/newsletter-slack/newsletter-slack-commands.test.ts
+++ b/__tests__/newsletter-slack/newsletter-slack-commands.test.ts
@@ -3,7 +3,7 @@
  *
  * Probes the dispatch surface — each /newsletter-* subcommand should
  * either return a help/usage block or short-circuit with ops-allowlist
- * gating. We don't hit Notion/HubSpot/GitHub here; those are covered by
+ * gating. We don't hit Notion/EspoCRM/GitHub here; those are covered by
  * their own lib tests. The point is to lock the COMMAND ROUTING surface.
  */
 

--- a/__tests__/roi.test.ts
+++ b/__tests__/roi.test.ts
@@ -143,7 +143,7 @@ describe("buildRoiSummary", () => {
     expect(summary.totals.platformLeads).toBe(3);
   });
 
-  it("counts HubSpot leads inside the window and computes cost per lead", async () => {
+  it("counts EspoCRM leads inside the window and computes cost per lead", async () => {
     mockGoogleConfigured.mockResolvedValue(true);
     mockGoogleMetrics.mockResolvedValue({ impressions: 0, clicks: 0, costMicros: 100_000_000 }); // €100
     mockIsConfiguredAsync.mockResolvedValue(true);

--- a/__tests__/setup.ts
+++ b/__tests__/setup.ts
@@ -28,7 +28,7 @@ process.env.NOTION_CALENDAR_DB_ID = "calendar-db-123";
 process.env.NOTION_REPORTS_DB_ID = "reports-db-123";
 process.env.NOTION_WEBHOOK_SECRET = "whsec_notion_test";
 
-// ── HubSpot ───────────────────────────────────────────────────────────────────
+// ── EspoCRM ───────────────────────────────────────────────────────────────────
 process.env.HUBSPOT_API_KEY = "test-hs-token";
 
 // ── ActiveCampaign ────────────────────────────────────────────────────────────

--- a/__tests__/subscribe-api.test.ts
+++ b/__tests__/subscribe-api.test.ts
@@ -70,7 +70,7 @@ describe("POST /api/subscribe", () => {
     expect(notifyTeamMock.mock.calls[0][0]).toContain("New subscriber");
   });
 
-  it("marks the subscriber as a newsletter signup in HubSpot", async () => {
+  it("marks the subscriber as a newsletter signup in EspoCRM", async () => {
     const { POST } = await import("@/app/api/subscribe/route");
     await POST(makeRequest({ email: "hello@cloudless.gr" }));
 
@@ -85,7 +85,7 @@ describe("POST /api/subscribe", () => {
     expect(removeFromSuppressionListMock).toHaveBeenCalledWith("hello@cloudless.gr");
   });
 
-  it("still returns success when the HubSpot update fails", async () => {
+  it("still returns success when the EspoCRM update fails", async () => {
     setNewsletterStatusMock.mockResolvedValueOnce(false);
     const { POST } = await import("@/app/api/subscribe/route");
     const response = await POST(makeRequest({ email: "hello@cloudless.gr" }));

--- a/__tests__/unsubscribe-api.test.ts
+++ b/__tests__/unsubscribe-api.test.ts
@@ -71,7 +71,7 @@ describe("POST /api/unsubscribe", () => {
     expect(addToSuppressionListMock).toHaveBeenCalledWith("user@cloudless.gr");
   });
 
-  it("flips the HubSpot contact to unsubscribed", async () => {
+  it("flips the EspoCRM contact to unsubscribed", async () => {
     const { POST } = await import("@/app/api/unsubscribe/route");
     const req = new Request("http://localhost:4000/api/unsubscribe", {
       method: "POST",

--- a/__tests__/voice-brief-sources.test.ts
+++ b/__tests__/voice-brief-sources.test.ts
@@ -14,7 +14,7 @@ vi.mock("@/lib/gsc", () => ({
 }));
 vi.mock("@/lib/espocrm", async (orig) => ({
   ...(await orig<typeof import("@/lib/espocrm")>()),
-  isHubSpotConfigured: (...a: unknown[]) => mockIsHubSpotConfigured(...a),
+  isEspoCRMConfigured: (...a: unknown[]) => mockIsHubSpotConfigured(...a),
   getPipelineStats: (...a: unknown[]) => mockGetPipelineStats(...a),
   listNewsletterSubscribers: (...a: unknown[]) => mockListNewsletterSubscribers(...a),
 }));
@@ -49,7 +49,7 @@ describe("voice-brief-sources.ts", () => {
   });
 
   describe("fetchPipelineMetrics", () => {
-    it("returns null when HubSpot not configured", async () => {
+    it("returns null when EspoCRM not configured", async () => {
       mockIsHubSpotConfigured.mockResolvedValue(false);
       const { fetchPipelineMetrics } = await import("@/lib/voice-brief-sources");
       expect(await fetchPipelineMetrics()).toBeNull();
@@ -66,7 +66,7 @@ describe("voice-brief-sources.ts", () => {
   });
 
   describe("fetchEmailMetrics", () => {
-    it("returns null when HubSpot not configured", async () => {
+    it("returns null when EspoCRM not configured", async () => {
       mockIsHubSpotConfigured.mockResolvedValue(false);
       const { fetchEmailMetrics } = await import("@/lib/voice-brief-sources");
       expect(await fetchEmailMetrics()).toBeNull();

--- a/audit/admin-ops-baseline.md
+++ b/audit/admin-ops-baseline.md
@@ -10,7 +10,7 @@ Status legend: ✅ working · ⚠️ degraded · ❌ broken · ⏸ integration m
 |---|---|---|---|---|---|---|---|
 | `/admin/settings` | `POST /api/admin/cache` | 307 → login ✅ | 405 on GET (POST-only by design) ✅ | n/a (action-only page) | clear-cache + per-prefix | ✅ | Page has Clear Cache (all) + per-namespace clear buttons. `invalidateCache` exists in `src/lib/notion-cache.ts`. |
 | `/admin/users` | `GET/POST /api/admin/users` | 307 → login ✅ | 401 unauth ✅ | lists Cognito users + groups | enable/disable/promote/demote | ✅ | Reads `cognito:groups` and exposes admin promote/demote + enable/disable per user. |
-| `/admin/integrations` | `GET /api/admin/integrations/status` | 307 → login ✅ | 401 unauth ✅ | pings HubSpot/Slack/Notion/AC/Stripe/Sentry/GSC live | refresh button | ✅ | Each ping uses `AbortSignal.timeout(5000)` so a hung integration can't stall the page. |
+| `/admin/integrations` | `GET /api/admin/integrations/status` | 307 → login ✅ | 401 unauth ✅ | pings EspoCRM/Slack/Notion/AC/Stripe/Sentry/GSC live | refresh button | ✅ | Each ping uses `AbortSignal.timeout(5000)` so a hung integration can't stall the page. |
 | `/admin/notifications` | `GET/PATCH /api/admin/notifications` | 307 → login ✅ | 401 unauth ✅ | reads ring buffer (50 entries) | PATCH to mark read | ⚠️ | **In-memory ring buffer** — survives warm Lambda only. Acceptable for ops dashboards, NOT for durable alerts. Documented in the source comment. |
 | `/admin/workspaces` | `GET/POST/PATCH/DELETE /api/admin/workspaces` | 307 → login ✅ | 401 unauth ✅ | lists workspaces | create/edit/delete | ✅ | Full CRUD wired. SSM-backed storage. |
 
@@ -19,7 +19,7 @@ Status legend: ✅ working · ⚠️ degraded · ❌ broken · ⏸ integration m
 - **Unauthenticated**: every page redirects (307) to `/auth/login`; every API returns 401 (notifications cold-start was 9s on first hit but warm runs settle at 0.4–1.0s — Lambda init time, not a bug).
 - **Auth gate consistency**: every route calls `requireAdmin(request)` first and returns its 401/403 response before touching any backing service.
 - **`/api/admin/cache` 405 on GET is correct**: the route is intentionally POST-only (it's a destructive action). The Settings page only POSTs to it.
-- **Integration ping timeouts**: HubSpot/Slack/Notion/AC pings use `AbortSignal.timeout(5000)` so a stuck external service can't lock the dashboard.
+- **Integration ping timeouts**: EspoCRM/Slack/Notion/AC pings use `AbortSignal.timeout(5000)` so a stuck external service can't lock the dashboard.
 
 ## What's NOT broken but worth knowing
 

--- a/docs/AGENCY-HUB.md
+++ b/docs/AGENCY-HUB.md
@@ -17,7 +17,7 @@
 5. [Phase 1 — Meta (Facebook + Instagram)](#5-phase-1--meta-facebook--instagram--deferred)
 6. [Phase 2 — Email Marketing (ActiveCampaign)](#6-phase-2--email-marketing-activecampaign--done)
 7. [Phase 3 — Google Ads](#7-phase-3--google-ads--done)
-8. [Phase 4 — Lead Pipeline Automation (HubSpot)](#8-phase-4--lead-pipeline-automation-hubspot--done)
+8. [Phase 4 — Lead Pipeline Automation (EspoCRM)](#8-phase-4--lead-pipeline-automation-hubspot--done)
 9. [Phase 5 — LinkedIn Campaigns](#9-phase-5--linkedin-campaigns--done)
 10. [Phase 6 — TikTok Campaigns](#10-phase-6--tiktok-campaigns--done)
 11. [Phase 7 — X (Twitter) Campaigns](#11-phase-7--x-twitter-campaigns--done)
@@ -52,7 +52,7 @@ The admin panel gains a **"Marketing Hub"** — a set of new sections alongside 
     │   ├── tiktok/         ← TikTok
     │   └── x/              ← X / Twitter
     ├── email/              ← ActiveCampaign: campaigns, automations, lists
-    ├── pipeline/           ← HubSpot full deal pipeline view
+    ├── pipeline/           ← EspoCRM full deal pipeline view
     ├── calendar/           ← Content calendar (posts, blogs, emails)
     ├── reports/            ← Client-facing performance reports
     └── ai-assistant/       ← AI campaign creation wizard
@@ -164,7 +164,7 @@ AI campaign creation routes call **Anthropic Claude API** (or OpenAI) server-sid
 | **1** | Meta campaigns + Pixel activation | DEFERRED | Blocked: ad policy appeal pending (see `project_instagram_blocker.md`) |
 | **2** | ActiveCampaign email marketing | DONE | `src/lib/activecampaign.ts`, `/admin/email`, API routes at `/api/admin/email/` |
 | **3** | Google Ads | DONE | `src/lib/campaigns/google-ads.ts`, `/admin/campaigns/google`, insights route |
-| **4** | HubSpot full deal pipeline | DONE | Extended `hubspot.ts`; kanban at `/admin/pipeline`; API at `/api/admin/pipeline/` |
+| **4** | EspoCRM full deal pipeline | DONE | Extended `hubspot.ts`; kanban at `/admin/pipeline`; API at `/api/admin/pipeline/` |
 | **5** | LinkedIn campaigns | DONE | `src/lib/campaigns/linkedin.ts`, `/admin/campaigns/linkedin` |
 | **6** | TikTok campaigns | DONE | `src/lib/campaigns/tiktok.ts`, `/admin/campaigns/tiktok` |
 | **7** | X (Twitter) campaigns | DONE | `src/lib/campaigns/x-ads.ts` (OAuth 1.0a), `/admin/campaigns/x` |
@@ -344,7 +344,7 @@ pauseCampaign(id: string): Promise<void>
 
 ---
 
-## 8. Phase 4 — Lead Pipeline Automation (HubSpot) — DONE
+## 8. Phase 4 — Lead Pipeline Automation (EspoCRM) — DONE
 
 **Implemented files:**
 
@@ -385,14 +385,14 @@ src/app/api/admin/pipeline/
 
 ```
 src/app/[locale]/admin/pipeline/
-    page.tsx                           ← Kanban board view of HubSpot pipeline
+    page.tsx                           ← Kanban board view of EspoCRM pipeline
 ```
 
 **Automations to wire up (in API routes):**
 
-- `POST /api/calendar/book` → auto-create HubSpot deal (stage: "Consultation Booked")
-- `POST /api/webhooks/stripe` (checkout.completed) → auto-create HubSpot deal (stage: "Closed Won")
-- `POST /api/contact` → auto-create HubSpot deal (stage: "New Lead") — already upserts contact, add deal creation
+- `POST /api/calendar/book` → auto-create EspoCRM deal (stage: "Consultation Booked")
+- `POST /api/webhooks/stripe` (checkout.completed) → auto-create EspoCRM deal (stage: "Closed Won")
+- `POST /api/contact` → auto-create EspoCRM deal (stage: "New Lead") — already upserts contact, add deal creation
 
 ---
 
@@ -500,7 +500,7 @@ src/app/[locale]/admin/calendar/
 
 ## 13. Phase 9 — Client Reporting — DONE
 
-**Implemented:** `src/lib/reports.ts` (in-memory report store), API routes at `/api/admin/reports/` (GET list), `/api/admin/reports/generate/` (POST), `/api/admin/reports/[id]/` (GET/DELETE), `src/app/[locale]/admin/reports/page.tsx` (list + generate modal), `src/app/[locale]/admin/reports/[id]/page.tsx` (report viewer with AI insights + print/PDF button). Report generation aggregates HubSpot pipeline stats and ActiveCampaign email stats. AI insights generated per section via Claude when `ANTHROPIC_API_KEY` is set.
+**Implemented:** `src/lib/reports.ts` (in-memory report store), API routes at `/api/admin/reports/` (GET list), `/api/admin/reports/generate/` (POST), `/api/admin/reports/[id]/` (GET/DELETE), `src/app/[locale]/admin/reports/page.tsx` (list + generate modal), `src/app/[locale]/admin/reports/[id]/page.tsx` (report viewer with AI insights + print/PDF button). Report generation aggregates EspoCRM pipeline stats and ActiveCampaign email stats. AI insights generated per section via Claude when `ANTHROPIC_API_KEY` is set.
 
 **Note:** Reports use an in-memory store (reset on restart). For persistence, connect `reports.ts` to a database.
 
@@ -526,7 +526,7 @@ src/app/[locale]/admin/reports/
 2. **SEO Performance** — GSC clicks/impressions/keywords (already built)
 3. **Paid Social** — Meta / LinkedIn / TikTok / X: impressions, clicks, conversions, ROAS
 4. **Email Marketing** — ActiveCampaign: sent, open rate, click rate, unsubscribes
-5. **Lead Pipeline** — HubSpot: new leads, qualified, proposals, closed won, conversion rate
+5. **Lead Pipeline** — EspoCRM: new leads, qualified, proposals, closed won, conversion rate
 6. **Website Analytics** — Notion Analytics: page views, form submits, store visits
 
 **Report generation flow:**
@@ -688,7 +688,7 @@ Phases 2-10 are fully implemented and deployed. The remaining work is operationa
 1. **Populate SSM keys** for each platform (see table in Section 4)
 2. **Complete Meta policy appeal** to unblock Phase 1 (see `project_instagram_blocker.md`)
 3. **Add database persistence** for content calendar and reports (currently in-memory)
-4. **Wire automation hooks** from Phase 4 plan (e.g. `/api/contact` creating HubSpot deals)
+4. **Wire automation hooks** from Phase 4 plan (e.g. `/api/contact` creating EspoCRM deals)
 
 ### Test coverage
 

--- a/docs/AGENTS_ROADMAP.md
+++ b/docs/AGENTS_ROADMAP.md
@@ -79,7 +79,7 @@ Today there are 4 cron routes (analytics-rollup, calendar-digest, report-cleanup
 
 The original linear `Promise.all(…)` pipeline is preserved verbatim — pass `?legacy=true` on the cron request to fall back to it for at least one full release cycle. Both paths share the same SSM persistence (`/cloudless/VOICE_BRIEF_LATEST`) so the admin assistant page sees the same shape regardless.
 
-**Cost model in practice**: one cron tick a week, ~3–8 LLM calls (model often skips HubSpot/Stripe if `isConfigured` returns false on the first probe), < $0.05/run on Bedrock Haiku.
+**Cost model in practice**: one cron tick a week, ~3–8 LLM calls (model often skips EspoCRM/Stripe if `isConfigured` returns false on the first probe), < $0.05/run on Bedrock Haiku.
 
 **Tests**: 6 specs in `__tests__/cron-voice-brief.test.ts` covering auth, agent happy path, agent failure tolerance (SSM/Slack), legacy default, and legacy fallback when the Anthropic narrate call returns non-200.
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -4,7 +4,7 @@
 >
 > **Purpose:** Digital solutions business providing cloud computing, AI marketing, serverless development, and e-commerce services to startups and SMBs.
 >
-> **Stack:** Next.js 16 · React 19 · Tailwind CSS 4 · TypeScript · AWS · Stripe · Notion · HubSpot
+> **Stack:** Next.js 16 · React 19 · Tailwind CSS 4 · TypeScript · AWS · Stripe · Notion · EspoCRM
 
 ---
 
@@ -98,7 +98,7 @@ src/
 │   │   │   ├── page.tsx          ← Store listing
 │   │   │   ├── [id]/page.tsx     ← Product detail + JSON-LD
 │   │   │   └── success/          ← Order confirmation page
-│   │   ├── contact/              ← Contact form (SES + Slack + HubSpot + Notion)
+│   │   ├── contact/              ← Contact form (SES + Slack + EspoCRM + Notion)
 │   │   ├── auth/                 ← Login · Signup · Forgot Password (Cognito + next-auth)
 │   │   ├── dashboard/            ← Customer portal (auth-protected)
 │   │   │   ├── page.tsx          ← Personalized overview
@@ -109,7 +109,7 @@ src/
 │   │   └── admin/                ← Admin panel (admin-group only)
 │   │       ├── page.tsx          ← Dashboard: orders, contacts, SEO, errors
 │   │       ├── orders/           ← Stripe sessions + subscriptions
-│   │       ├── crm/              ← HubSpot contacts
+│   │       ├── crm/              ← EspoCRM contacts
 │   │       ├── analytics/        ← Google Search Console + Notion Analytics
 │   │       ├── errors/           ← Sentry issues
 │   │       ├── notion/           ← Notion DB explorer (blog, docs, tasks, projects)
@@ -117,7 +117,7 @@ src/
 │   │       ├── settings/         ← App config viewer
 │   │       └── users/            ← Cognito user management
 │   └── api/                      ← API Routes (server-only)
-│       ├── contact/              ← POST: SES + Slack + HubSpot + Notion
+│       ├── contact/              ← POST: SES + Slack + EspoCRM + Notion
 │       ├── checkout/             ← POST: Stripe checkout session
 │       ├── subscribe/            ← POST: newsletter (SES + Slack)
 │       ├── unsubscribe/          ← POST: SES suppression list
@@ -133,15 +133,15 @@ src/
 │       ├── user/
 │       │   ├── purchases/        ← GET: Stripe orders for authenticated user
 │       │   └── consultations/    ← GET: Calendar bookings for authenticated user
-│       ├── crm/contact/          ← POST: HubSpot contact upsert (standalone)
-│       ├── hubspot/ticket/       ← POST: HubSpot support ticket creation
+│       ├── crm/contact/          ← POST: EspoCRM contact upsert (standalone)
+│       ├── hubspot/ticket/       ← POST: EspoCRM support ticket creation
 │       ├── webhooks/
 │       │   ├── stripe/           ← POST: Stripe webhook (orders, subs, failures)
 │       │   └── notion/           ← POST: Notion webhook (cache invalidation)
 │       └── admin/                ← All require admin JWT
 │           ├── analytics/        ← Google Search Console data (10 endpoints)
 │           ├── cache/            ← Notion cache management
-│           ├── crm/              ← HubSpot: contacts, companies, deals, owners, pipelines
+│           ├── crm/              ← EspoCRM: contacts, companies, deals, owners, pipelines
 │           ├── notifications/    ← Slack test messages
 │           ├── notion/           ← Notion DB queries: blog, docs, tasks, projects, submissions
 │           ├── ops/errors/       ← Sentry issues
@@ -228,7 +228,7 @@ src/
 | `SLACK_SIGNING_SECRET` | SecureString | Inbound Slack verification |
 | `SLACK_WEBHOOK_URL` | SecureString | Outbound Slack notifications |
 | `HUBSPOT_API_KEY` | SecureString | CRM operations |
-| `HUBSPOT_CLIENT_SECRET` | SecureString | HubSpot webhook signature verification |
+| `HUBSPOT_CLIENT_SECRET` | SecureString | EspoCRM webhook signature verification |
 | `NOTION_API_KEY` | SecureString | All Notion DB access |
 | `NOTION_BLOG_DB_ID` | String | Blog CMS |
 | `NOTION_WEBHOOK_SECRET` | SecureString | Notion webhook auth |
@@ -360,7 +360,7 @@ graph TB
         NA["Analytics DB"]
     end
 
-    subgraph CRM["🤝 HubSpot CRM"]
+    subgraph CRM["🤝 EspoCRM CRM"]
         HC["Contacts"]
         HD["Deals"]
         HT["Tickets"]
@@ -434,7 +434,7 @@ graph TB
 |---|---|---|---|
 | `GET` | `/api/health` | App status + version | — |
 | `GET` | `/api/blog/posts` | Blog posts (Notion or static fallback) | Notion Blog DB |
-| `POST` | `/api/contact` | Contact form submission | SES · Slack · HubSpot · Notion Submissions |
+| `POST` | `/api/contact` | Contact form submission | SES · Slack · EspoCRM · Notion Submissions |
 | `POST` | `/api/checkout` | Create Stripe checkout session | Stripe |
 | `POST` | `/api/subscribe` | Newsletter signup — both SES sends must succeed; Slack notification is fire-and-forget | SES · Slack |
 | `POST` | `/api/unsubscribe` | Unsubscribe via API (rate-limited: 5/min/IP) | SES suppression |
@@ -463,8 +463,8 @@ graph TB
 
 | Method | Route | What it does |
 |---|---|---|
-| `POST` | `/api/crm/contact` | Upsert contact in HubSpot (standalone) |
-| `POST` | `/api/hubspot/ticket` | Create support ticket in HubSpot |
+| `POST` | `/api/crm/contact` | Upsert contact in EspoCRM (standalone) |
+| `POST` | `/api/hubspot/ticket` | Create support ticket in EspoCRM |
 
 ### Admin Routes (Admin JWT required)
 
@@ -482,11 +482,11 @@ graph TB
 | `GET /api/admin/analytics/countries` | GSC | Traffic by country |
 | `GET /api/admin/analytics/web` | GSC + Notion | Combined analytics |
 | `POST /api/admin/cache` | — | Invalidate Notion cache |
-| `GET /api/admin/crm/contacts` | HubSpot | Contact list |
-| `GET /api/admin/crm/companies` | HubSpot | Company list |
-| `GET /api/admin/crm/deals` | HubSpot | Deal pipeline |
-| `GET /api/admin/crm/owners` | HubSpot | CRM owners |
-| `GET /api/admin/crm/pipelines` | HubSpot | Pipeline stages |
+| `GET /api/admin/crm/contacts` | EspoCRM | Contact list |
+| `GET /api/admin/crm/companies` | EspoCRM | Company list |
+| `GET /api/admin/crm/deals` | EspoCRM | Deal pipeline |
+| `GET /api/admin/crm/owners` | EspoCRM | CRM owners |
+| `GET /api/admin/crm/pipelines` | EspoCRM | Pipeline stages |
 | `POST /api/admin/notifications/test` | Slack | Test Slack message |
 | `GET /api/admin/notion/analytics` | Notion | Analytics DB |
 | `GET /api/admin/notion/comments` | Notion | Comment threads |
@@ -512,7 +512,7 @@ AWS SES                ✅ Live         IAM (Lambda role)              Contact, 
 AWS SSM                ✅ Live         IAM (Lambda role)              All API routes (secrets)
 Stripe                 ✅ Live         Secret key (SSM)               Store, checkout, webhooks
 Notion                 ✅ Live         API key (SSM)                  Blog, docs, forms, analytics
-HubSpot CRM            ✅ Live         API key (SSM)                  CRM, contact form, admin
+EspoCRM CRM            ✅ Live         API key (SSM)                  CRM, contact form, admin
 Slack                  ✅ Live         Bot token + secret (SSM)       Notifications, inbound cmds
 Google Calendar + GSC  ✅ Live         Service account (SSM)          Consultation booking, SEO admin
 Sentry                 ✅ Live         DSN (SDK) + auth token (SSM)   Error monitoring, admin
@@ -531,7 +531,7 @@ Google Ads             🔸 Pending      Dev token approval required    Campaign
 | Integration | What happens when not configured |
 |---|---|
 | Slack | Notifications skipped silently |
-| HubSpot | 503 response from CRM routes |
+| EspoCRM | 503 response from CRM routes |
 | Notion | Blog falls back to static `lib/blog.ts` data |
 | Google Calendar | 503 response from calendar routes |
 | Google Search Console | 503 response from analytics routes |
@@ -713,7 +713,7 @@ POST /api/webhooks/stripe (checkout.session.completed)
        skipped for one-time payments with unpaid status)
   → notifyTeam()           → SES email to admin
   → slackOrderNotify()     → Slack notification (fire-and-forget)
-  → HubSpot upsertContact + createDeal (fire-and-forget)
+  → EspoCRM upsertContact + createDeal (fire-and-forget)
         │
         ▼
 Redirect to /store/success
@@ -753,9 +753,9 @@ These are the recommended next layers to build toward an AI-powered marketing pl
 
 ### Phase 2 — Lead Intelligence
 
-- [x] HubSpot deal automation: contact form → contact upsert already live; deal creation via `createDeal()` added 2026-04-21
-- [x] Google Calendar → HubSpot: create deal on consultation booking — done 2026-04-21
-- [x] Stripe → HubSpot: create deal on checkout (via `checkout.session.completed` webhook) — done 2026-04-21
+- [x] EspoCRM deal automation: contact form → contact upsert already live; deal creation via `createDeal()` added 2026-04-21
+- [x] Google Calendar → EspoCRM: create deal on consultation booking — done 2026-04-21
+- [x] Stripe → EspoCRM: create deal on checkout (via `checkout.session.completed` webhook) — done 2026-04-21
 
 ### Phase 3 — AI Content & Automation
 
@@ -766,9 +766,9 @@ These are the recommended next layers to build toward an AI-powered marketing pl
 ### Phase 4 — Advanced Marketing
 
 - [ ] Meta Ads integration (campaign management via Meta Marketing API)
-- [ ] HubSpot email sequences for lead nurturing
+- [ ] EspoCRM email sequences for lead nurturing
 - [ ] A/B testing on landing page CTAs (using feature flags or edge middleware)
-- [ ] Customer lifetime value dashboard (Stripe + HubSpot combined)
+- [ ] Customer lifetime value dashboard (Stripe + EspoCRM combined)
 
 ---
 
@@ -788,8 +788,8 @@ pnpm test:e2e      # Playwright E2E
 | `__tests__/admin-analytics-api.test.ts` | All 10 GSC analytics admin endpoints |
 | `__tests__/admin-campaigns-api.test.ts` | Google, LinkedIn, TikTok, X campaign routes |
 | `__tests__/admin-client-portals-api.test.ts` | Client portal enroll + token lookup |
-| `__tests__/admin-crm-api.test.ts` | HubSpot contacts/companies/deals/tickets admin routes |
-| `__tests__/admin-pipeline-api.test.ts` | HubSpot deal pipeline board + move + notes |
+| `__tests__/admin-crm-api.test.ts` | EspoCRM contacts/companies/deals/tickets admin routes |
+| `__tests__/admin-pipeline-api.test.ts` | EspoCRM deal pipeline board + move + notes |
 | `__tests__/admin-workspaces-api.test.ts` | Workspace CRUD admin routes |
 | `__tests__/gsc.test.ts` | All 11 GSC functions, success + error paths |
 | `__tests__/hubspot-crm.test.ts` | `getPipelines`, `listCompanies`, `listDeals`, `listOwners` |
@@ -887,7 +887,7 @@ The analysis runs **in addition to** the following static-analysis workflows def
 - AWS SES email (contact form, order confirmation, newsletter)
 - SES suppression list (unsubscribe)
 - Notion CMS (blog, docs, forms, projects, analytics)
-- HubSpot CRM (contacts, deals, companies, pipelines, tickets)
+- EspoCRM CRM (contacts, deals, companies, pipelines, tickets)
 - Slack two-way integration (notifications + slash commands + events)
 - Google Calendar consultation booking
 - Google Search Console SEO analytics
@@ -908,7 +908,7 @@ The analysis runs **in addition to** the following static-analysis workflows def
 ### 🚧 Planned (not yet built)
 
 - AI content generation pipeline
-- ~~HubSpot deal automation (Calendar → Deal, Stripe → Deal)~~ ✅ Done 2026-04-21
+- ~~EspoCRM deal automation (Calendar → Deal, Stripe → Deal)~~ ✅ Done 2026-04-21
 - Email marketing sequences
 - A/B testing framework
 - Customer lifetime value dashboard

--- a/docs/GOOGLE-CALENDAR.md
+++ b/docs/GOOGLE-CALENDAR.md
@@ -33,7 +33,7 @@ graph TB
 
     subgraph Notify["Post-Booking"]
         BookAPI -->|fire-and-forget| Slack["slackBookingNotify()"]
-        BookAPI -->|fire-and-forget| HubSpot["upsertContact + createDeal"]
+        BookAPI -->|fire-and-forget| EspoCRM["upsertContact + createDeal"]
     end
 ```
 
@@ -135,7 +135,7 @@ Books a consultation slot.
   - Reminders: email (60 min before) + popup (15 min before)
   - Timezone: Europe/Athens
 - Fires `slackBookingNotify()` (fire-and-forget) with Block Kit blocks
-- Creates HubSpot contact + deal + note (fire-and-forget)
+- Creates EspoCRM contact + deal + note (fire-and-forget)
 - Returns `{ success: true, eventId, meetingLink }`
 
 ### `getConsultationsByEmail(email)`
@@ -153,7 +153,7 @@ sequenceDiagram
     participant Book as /api/calendar/book
     participant GCal as Google Calendar API
     participant Slack as slackBookingNotify
-    participant HS as HubSpot
+    participant HS as EspoCRM
     User->>Avail: GET /api/calendar/availability?days=7
     Avail->>GCal: POST freeBusy query
     GCal-->>Avail: Busy time ranges
@@ -218,5 +218,5 @@ Test coverage (8 + 13 tests):
 | `src/lib/google-auth.ts` | Shared OAuth2 service-account JWT factory (`createGoogleAuth`) used by both Calendar and GSC |
 | `src/lib/google-calendar.ts` | freeBusy queries, event creation, consultation lookup, DST-aware slot generation |
 | `src/app/api/calendar/availability/route.ts` | GET available slots (days 1–30, 5-min CDN cache) |
-| `src/app/api/calendar/book/route.ts` | POST booking with validation, rate-limit, Slack + HubSpot fire-and-forget |
+| `src/app/api/calendar/book/route.ts` | POST booking with validation, rate-limit, Slack + EspoCRM fire-and-forget |
 | `src/lib/slack-notify.ts` | `slackBookingNotify()` — Block Kit booking notification with mrkdwn-escaped fields |

--- a/docs/GSC.md
+++ b/docs/GSC.md
@@ -153,7 +153,7 @@ Site-wide totals + top 20 pages — used as a lightweight web analytics proxy.
 
 ### `GET /api/admin/analytics/unified`
 
-Cross-integration dashboard combining SEO (GSC), pipeline (HubSpot), email (ActiveCampaign), and revenue (Stripe) in a single parallel fetch. Returns `null` for any integration that is not configured or fails.
+Cross-integration dashboard combining SEO (GSC), pipeline (EspoCRM), email (ActiveCampaign), and revenue (Stripe) in a single parallel fetch. Returns `null` for any integration that is not configured or fails.
 
 ---
 
@@ -251,4 +251,4 @@ Test coverage (29 + 33 tests):
 | `src/lib/google-auth.ts` | Shared `createGoogleAuth(scope)` factory — provides cached token for both Calendar and GSC |
 | `src/lib/gsc.ts` | All GSC functions: snapshot, keywords, pages, history, devices, countries, CTR opportunities, query-page mapping, search intent, web analytics |
 | `src/app/api/admin/analytics/seo/route.ts` | Combined snapshot + keywords dashboard endpoint |
-| `src/app/api/admin/analytics/unified/route.ts` | Cross-integration unified dashboard (GSC + HubSpot + ActiveCampaign + Stripe) |
+| `src/app/api/admin/analytics/unified/route.ts` | Cross-integration unified dashboard (GSC + EspoCRM + ActiveCampaign + Stripe) |

--- a/docs/HUBSPOT.md
+++ b/docs/HUBSPOT.md
@@ -1,8 +1,8 @@
-# HubSpot CRM Integration
+# EspoCRM CRM Integration
 
-cloudless.gr integrates with HubSpot CRM to automatically capture leads from the contact form and provide contact management, search, and ticket creation capabilities.
+cloudless.gr integrates with EspoCRM CRM to automatically capture leads from the contact form and provide contact management, search, and ticket creation capabilities.
 
-> **Status:** Optional integration — degrades gracefully when `HUBSPOT_API_KEY` is not configured. The contact form continues to work (email + Slack) even without HubSpot.
+> **Status:** Optional integration — degrades gracefully when `HUBSPOT_API_KEY` is not configured. The contact form continues to work (email + Slack) even without EspoCRM.
 
 ---
 
@@ -40,22 +40,22 @@ graph TB
 ```mermaid
 sequenceDiagram
     participant Caller as API Route / Lib
-    participant HubSpot as hubspot.ts
+    participant EspoCRM as hubspot.ts
     participant Env as process.env
     participant SSM as SSM Parameter Store
 
-    Caller->>HubSpot: upsertContact() / listContacts() / etc.
-    HubSpot->>HubSpot: getHubSpotToken()
-    HubSpot->>Env: Check HUBSPOT_API_KEY
+    Caller->>EspoCRM: upsertContact() / listContacts() / etc.
+    EspoCRM->>EspoCRM: getHubSpotToken()
+    EspoCRM->>Env: Check HUBSPOT_API_KEY
     alt Token in env
-        Env-->>HubSpot: Return token
+        Env-->>EspoCRM: Return token
     else Not in env
-        HubSpot->>SSM: getConfig()
+        EspoCRM->>SSM: getConfig()
         alt Token in SSM
-            SSM-->>HubSpot: Return HUBSPOT_API_KEY
+            SSM-->>EspoCRM: Return HUBSPOT_API_KEY
         else Not configured anywhere
-            SSM-->>HubSpot: undefined
-            HubSpot-->>Caller: Return null silently
+            SSM-->>EspoCRM: undefined
+            EspoCRM-->>Caller: Return null silently
         end
     end
 ```
@@ -68,14 +68,14 @@ sequenceDiagram
 
 ### `hubspotFetch(path, options?)`
 
-Authenticated `fetch` wrapper. Prepends the HubSpot base URL, sets the
+Authenticated `fetch` wrapper. Prepends the EspoCRM base URL, sets the
 `Authorization: Bearer …` header, and ensures `Content-Type: application/json`.
 All exported functions go through this helper, so the token is resolved exactly
 once per request thanks to the integration cache.
 
 ### `hubspotListAll<T>(path)`
 
-Cursor-paginated walker for HubSpot list endpoints. Appends `limit=100` and
+Cursor-paginated walker for EspoCRM list endpoints. Appends `limit=100` and
 `after=<cursor>` to the URL on each iteration, accumulating `results` until
 `paging.next.after` is absent.
 
@@ -85,7 +85,7 @@ boards reflect every deal in the portal rather than the first 100.
 ### Token-resolution guard
 
 `upsertContact`, `createDeal`, and `createTicket` early-exit with `null` when
-HubSpot is not configured. They use `isHubSpotConfigured()` for that guard
+EspoCRM is not configured. They use `isEspoCRMConfigured()` for that guard
 instead of an explicit `getHubSpotToken()` call — `hubspotFetch` resolves the
 token itself, and the integration cache makes the second resolution free.
 
@@ -105,7 +105,7 @@ HUBSPOT_API_KEY=pat-na1-xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
 |---------------------------------------|--------------|
 | `/cloudless/production/HUBSPOT_API_KEY` | SecureString |
 
-### Required HubSpot scopes
+### Required EspoCRM scopes
 
 The private app token needs these scopes:
 
@@ -114,7 +114,7 @@ The private app token needs these scopes:
 | `crm.objects.contacts.read` | `listContacts()`, `searchContacts()` |
 | `crm.objects.contacts.write` | `upsertContact()` |
 | `crm.objects.tickets.write` | `createTicket()` |
-| `content` | `/api/admin/email/campaigns` (Marketing Emails list). Without it the route returns a structured 501 with `setupUrl`/`docsUrl`, and the `/admin/integrations` dashboard flags HubSpot as "degraded — content scope missing". |
+| `content` | `/api/admin/email/campaigns` (Marketing Emails list). Without it the route returns a structured 501 with `setupUrl`/`docsUrl`, and the `/admin/integrations` dashboard flags EspoCRM as "degraded — content scope missing". |
 
 When you add or remove a scope, the private-app token is invalidated and a new one is issued. Update SSM in place; no redeploy needed:
 
@@ -139,7 +139,7 @@ Create or update a CRM contact using email as the unique identifier.
 sequenceDiagram
     participant Route as /api/contact
     participant Upsert as upsertContact()
-    participant API as HubSpot API
+    participant API as EspoCRM API
 
     Route->>Upsert: { email, firstname, lastname, company, ... }
     Upsert->>API: POST /crm/v3/objects/contacts
@@ -206,9 +206,9 @@ Create a support ticket, optionally associated with an existing contact.
 | `hs_pipeline_stage` | string | No | `"1"` (first stage) |
 | `hs_ticket_priority` | string | No | `"MEDIUM"` |
 
-**Contact association:** If `contactId` is provided, the ticket is linked to that contact using HubSpot's association type ID `16` (ticket-to-contact).
+**Contact association:** If `contactId` is provided, the ticket is linked to that contact using EspoCRM's association type ID `16` (ticket-to-contact).
 
-**Error handling:** Returns `null` if HubSpot is not configured. Throws on API errors (non-2xx responses).
+**Error handling:** Returns `null` if EspoCRM is not configured. Throws on API errors (non-2xx responses).
 
 ---
 
@@ -224,7 +224,7 @@ Search contacts by any property using exact match (`EQ` operator).
 
 ## Contact Form Integration
 
-The contact form (`/api/contact`) is the primary consumer of the HubSpot integration:
+The contact form (`/api/contact`) is the primary consumer of the EspoCRM integration:
 
 ```mermaid
 sequenceDiagram
@@ -253,15 +253,15 @@ sequenceDiagram
 **Key design decisions:**
 
 - Email sending is **awaited** (critical path) — if SES fails, the user gets a 500 error
-- Slack and HubSpot are **fire-and-forget** via `Promise.allSettled().catch(() => {})` — failures are logged but don't block the response
+- Slack and EspoCRM are **fire-and-forget** via `Promise.allSettled().catch(() => {})` — failures are logged but don't block the response
 - Name splitting: `"Themis Baltzakis"` → `firstname: "Themis"`, `lastname: "Baltzakis"`
-- Message is truncated to 500 chars before sending to HubSpot
+- Message is truncated to 500 chars before sending to EspoCRM
 
 ---
 
 ## Custom Properties
 
-These custom properties must exist in your HubSpot account for full functionality:
+These custom properties must exist in your EspoCRM account for full functionality:
 
 | Property | Type | Group | Used by |
 |----------|------|-------|---------|
@@ -269,7 +269,7 @@ These custom properties must exist in your HubSpot account for full functionalit
 | `message` | Multi-line text | Contact information | `upsertContact()` |
 | `lead_source` | Single-line text | Contact information | `upsertContact()` (default: `website_contact_form`) |
 
-To create these in HubSpot:
+To create these in EspoCRM:
 
 1. Go to **Settings → Properties → Contact properties**
 2. Click **Create property**
@@ -278,11 +278,11 @@ To create these in HubSpot:
 
 ---
 
-## HubSpot App Setup
+## EspoCRM App Setup
 
 ### 1. Create a Private App
 
-1. Go to [HubSpot Developer](https://app.hubspot.com/) → **Settings → Integrations → Private Apps**
+1. Go to [EspoCRM Developer](https://app.hubspot.com/) → **Settings → Integrations → Private Apps**
 2. Click **Create a private app**
 3. Name: `cloudless.gr`
 4. Under **Scopes**, enable:
@@ -319,7 +319,7 @@ See the [Custom Properties](#custom-properties) section above.
 
 ### Unit tests
 
-The contact form test (`__tests__/contact-api.test.ts`) covers the integration indirectly — it mocks SSM config and verifies the contact route returns 200 with valid fields, which triggers the fire-and-forget HubSpot upsert.
+The contact form test (`__tests__/contact-api.test.ts`) covers the integration indirectly — it mocks SSM config and verifies the contact route returns 200 with valid fields, which triggers the fire-and-forget EspoCRM upsert.
 
 ```bash
 # Run contact tests
@@ -334,14 +334,14 @@ curl -X POST http://localhost:4000/api/contact \
   -H "Content-Type: application/json" \
   -d '{"name":"Test User","email":"test@example.com","message":"Integration test"}'
 
-# Then check HubSpot → Contacts → search for test@example.com
+# Then check EspoCRM → Contacts → search for test@example.com
 ```
 
 ### Verifying graceful degradation
 
 ```bash
 # Remove HUBSPOT_API_KEY from .env.local, restart dev server
-# Submit contact form — should still return 200 (email works, HubSpot silently skipped)
+# Submit contact form — should still return 200 (email works, EspoCRM silently skipped)
 ```
 
 ---
@@ -349,8 +349,8 @@ curl -X POST http://localhost:4000/api/contact \
 ## Security Notes
 
 - **Token storage:** Never commit `HUBSPOT_API_KEY` to the repo. Use `.env.local` (gitignored) locally, SSM Parameter Store in production.
-- **Error isolation:** HubSpot failures never surface to the end user — they're caught by `Promise.allSettled` and logged to console.
-- **Data minimization:** Only contact-relevant fields are sent to HubSpot. Message is truncated to 500 characters.
+- **Error isolation:** EspoCRM failures never surface to the end user — they're caught by `Promise.allSettled` and logged to console.
+- **Data minimization:** Only contact-relevant fields are sent to EspoCRM. Message is truncated to 500 characters.
 - **No PII in logs:** Error handlers log the error type but not the contact data.
 
 ---
@@ -359,7 +359,7 @@ curl -X POST http://localhost:4000/api/contact \
 
 | File | Purpose |
 |------|---------|
-| `src/lib/hubspot.ts` | All HubSpot API operations — CRM contacts + pipeline extensions |
+| `src/lib/hubspot.ts` | All EspoCRM API operations — CRM contacts + pipeline extensions |
 | `src/lib/integrations.ts` | Config loader — reads `HUBSPOT_API_KEY` from env, provides `isConfigured()` |
 | `src/lib/ssm-config.ts` | SSM Parameter Store fallback for production token resolution |
 | `src/app/api/contact/route.ts` | Contact form handler — calls `upsertContact()` as fire-and-forget |
@@ -368,7 +368,7 @@ curl -X POST http://localhost:4000/api/contact \
 | `src/app/api/admin/pipeline/deals/[id]/notes/route.ts` | GET/POST deal notes |
 | `src/app/api/admin/pipeline/stats/route.ts` | GET pipeline stats (totalDeals, totalValue, byStage) |
 | `src/app/[locale]/admin/pipeline/page.tsx` | Kanban board UI |
-| `__tests__/contact-api.test.ts` | Contact route unit tests (indirect HubSpot coverage) |
+| `__tests__/contact-api.test.ts` | Contact route unit tests (indirect EspoCRM coverage) |
 | `__tests__/hubspot-pipeline.test.ts` | Pipeline extension unit tests |
 | `__tests__/admin-pipeline-api.test.ts` | Pipeline API route tests |
 
@@ -434,7 +434,7 @@ Fetch all notes associated with a deal in two requests total:
 1. `GET /crm/v3/objects/deals/:id/associations/notes` to collect note IDs
 2. `POST /crm/v3/objects/notes/batch/read` to resolve all bodies in a single batch call
 
-This avoids the previous N+1 pattern (one GET per note). HubSpot caps batch reads
+This avoids the previous N+1 pattern (one GET per note). EspoCRM caps batch reads
 at 100 inputs per request, so the helper slices accordingly.
 
 ```typescript
@@ -471,7 +471,7 @@ Deals with no `amount` contribute `0` to the value totals. Returns zeroed stats 
 
 ### Pipeline API Routes
 
-All pipeline routes require a valid admin session or Bearer JWT (checked by `requireAdmin`) and return `503` when HubSpot is not configured.
+All pipeline routes require a valid admin session or Bearer JWT (checked by `requireAdmin`) and return `503` when EspoCRM is not configured.
 
 | Route | Method | Description |
 |---|---|---|
@@ -481,7 +481,7 @@ All pipeline routes require a valid admin session or Bearer JWT (checked by `req
 | `/api/admin/pipeline/deals/[id]/notes` | GET | Returns `{ notes }` |
 | `/api/admin/pipeline/deals/[id]/notes` | POST | Body: `{ body }` — returns `{ note }` |
 
-### Required HubSpot scopes for pipeline
+### Required EspoCRM scopes for pipeline
 
 In addition to the contact scopes above:
 

--- a/docs/MARKETING-HUB-SETUP.md
+++ b/docs/MARKETING-HUB-SETUP.md
@@ -8,7 +8,7 @@ The Marketing Hub is fully implemented in code. Every platform degrades graceful
 
 | Platform | Admin page | Keys needed | Status |
 |---|---|---|---|
-| HubSpot Pipeline | `/admin/pipeline` | `HUBSPOT_API_KEY` (already in SSM) | Ready |
+| EspoCRM Pipeline | `/admin/pipeline` | `HUBSPOT_API_KEY` (already in SSM) | Ready |
 | Email (ActiveCampaign) | `/admin/email` | `ACTIVECAMPAIGN_API_URL`, `ACTIVECAMPAIGN_API_TOKEN` | Needs keys |
 | Google Ads | `/admin/campaigns/google` | `GOOGLE_ADS_DEVELOPER_TOKEN`, `GOOGLE_ADS_CUSTOMER_ID` | Needs keys |
 | LinkedIn | `/admin/campaigns/linkedin` | `LINKEDIN_ACCESS_TOKEN`, `LINKEDIN_AD_ACCOUNT_ID`, `LINKEDIN_ORGANIZATION_URN` | Needs keys |
@@ -17,7 +17,7 @@ The Marketing Hub is fully implemented in code. Every platform degrades graceful
 | Meta/Instagram | `/admin/campaigns/meta` | `META_ACCESS_TOKEN`, `META_AD_ACCOUNT_ID` | Blocked (policy appeal) |
 | AI Assistant | `/admin/ai-assistant` | `ANTHROPIC_API_KEY` | Needs key |
 | Content Calendar | `/admin/calendar` | None (in-memory store) | Ready |
-| Client Reports | `/admin/reports` | Uses HubSpot + AC for data; `ANTHROPIC_API_KEY` for AI insights | Ready (no AI insights until key set) |
+| Client Reports | `/admin/reports` | Uses EspoCRM + AC for data; `ANTHROPIC_API_KEY` for AI insights | Ready (no AI insights until key set) |
 
 ---
 
@@ -109,7 +109,7 @@ console.anthropic.com → API Keys → Create key. The AI assistant uses `claude
 
 ---
 
-## HubSpot pipeline scopes
+## EspoCRM pipeline scopes
 
 The existing `HUBSPOT_API_KEY` token needs additional scopes for the pipeline board:
 
@@ -120,7 +120,7 @@ The existing `HUBSPOT_API_KEY` token needs additional scopes for the pipeline bo
 | `crm.objects.notes.write` | Create notes |
 | `crm.schemas.deals.read` | Pipeline definitions |
 
-Go to HubSpot → Settings → Integrations → Private Apps → edit the `cloudless.gr` app and add these scopes.
+Go to EspoCRM → Settings → Integrations → Private Apps → edit the `cloudless.gr` app and add these scopes.
 
 ---
 

--- a/docs/NEWSLETTER.md
+++ b/docs/NEWSLETTER.md
@@ -2,7 +2,7 @@
 
 Automated pipeline that drafts a blog article every Monday with Claude, lets a human approve it in Notion, then publishes the post to the live blog and emails it to every newsletter subscriber via SES from `noreply@cloudless.gr`.
 
-Subscribers live in **HubSpot**. The weekly send runs through the site's own `/api/newsletter/send` endpoint, which executes on Lambda (where SES credentials already exist), so no AWS keys are needed in CI.
+Subscribers live in **EspoCRM**. The weekly send runs through the site's own `/api/newsletter/send` endpoint, which executes on Lambda (where SES credentials already exist), so no AWS keys are needed in CI.
 
 ## Architecture at a glance
 
@@ -14,7 +14,7 @@ weekly-article-draft.yml          (Status: Draft to Approved)                 we
         │                                  │                                          │                   │
         ▼                                  ▼                                          ▼                   ▼
 generate-weekly-article.ts        you flip Status                           publish-and-send-newsletter.ts  weekly-subscriber-report.ts
-  • LRU category pick               in the Notion UI                          • query Status=Approved         • count HubSpot subscribers
+  • LRU category pick               in the Notion UI                          • query Status=Approved         • count EspoCRM subscribers
   • Claude Sonnet 4.6                                                         • flip to Published             • post to Slack #subscribers
   • Insert as Draft                                                           • revalidate /blog              • log to Notion "Newsletter Reports"
   • Slack ping                                                                • POST /api/newsletter/send
@@ -22,7 +22,7 @@ generate-weekly-article.ts        you flip Status                           publ
                                                                                        │
                                                                                        ▼
                                                                               /api/newsletter/send (Lambda)
-                                                                                • resolve HubSpot subscribers
+                                                                                • resolve EspoCRM subscribers
                                                                                 • deliver via SES
 ```
 
@@ -32,9 +32,9 @@ If nothing is approved by 09:00 UTC, the publisher exits cleanly with no newslet
 
 ### Subscriber capture and lifecycle
 
-- [src/app/api/subscribe/route.ts](../src/app/api/subscribe/route.ts) records the email in HubSpot via `setNewsletterStatus(email, "newsletter_signup")`, clears any stale SES suppression so a returning subscriber can be emailed again, then sends the branded welcome email and a real-time Slack ping to `#subscribers`.
-- [src/app/api/unsubscribe/route.ts](../src/app/api/unsubscribe/route.ts) (POST for the in-app form, GET for the one-click `List-Unsubscribe` link) atomically adds the address to the SES suppression list and flips the HubSpot contact to `lead_source = "newsletter_unsubscribed"`, removing it from the send audience.
-- [src/lib/espocrm.ts](../src/lib/espocrm.ts) — `setNewsletterStatus()` creates or updates a contact and sets the subscription state; `listNewsletterSubscribers()` returns every contact with `lead_source = "newsletter_signup"` (cursor-paginated search). _(HubSpot was decommissioned in PR #1043; this lib is the drop-in replacement with the same 21 exports.)_
+- [src/app/api/subscribe/route.ts](../src/app/api/subscribe/route.ts) records the email in EspoCRM via `setNewsletterStatus(email, "newsletter_signup")`, clears any stale SES suppression so a returning subscriber can be emailed again, then sends the branded welcome email and a real-time Slack ping to `#subscribers`.
+- [src/app/api/unsubscribe/route.ts](../src/app/api/unsubscribe/route.ts) (POST for the in-app form, GET for the one-click `List-Unsubscribe` link) atomically adds the address to the SES suppression list and flips the EspoCRM contact to `lead_source = "newsletter_unsubscribed"`, removing it from the send audience.
+- [src/lib/espocrm.ts](../src/lib/espocrm.ts) — `setNewsletterStatus()` creates or updates a contact and sets the subscription state; `listNewsletterSubscribers()` returns every contact with `lead_source = "newsletter_signup"` (cursor-paginated search). _(EspoCRM was decommissioned in PR #1043; this lib is the drop-in replacement with the same 21 exports.)_
 
 ### Welcome email
 
@@ -42,7 +42,7 @@ If nothing is approved by 09:00 UTC, the publisher exits cleanly with no newslet
 
 ### Send endpoint
 
-- [src/app/api/newsletter/send/route.ts](../src/app/api/newsletter/send/route.ts) — `POST` authenticated with the `x-newsletter-secret` header against `NEWSLETTER_SEND_SECRET`. Accepts `{ subject, html, text }`, resolves the subscriber list from HubSpot, and delivers one email per recipient via `sendEmail()` (SES). Returns `{ sent, failed, total }`. The `%UNSUBSCRIBELINK%` token in the body is replaced per recipient with `/api/unsubscribe?email=...`, and a matching `List-Unsubscribe` header is added.
+- [src/app/api/newsletter/send/route.ts](../src/app/api/newsletter/send/route.ts) — `POST` authenticated with the `x-newsletter-secret` header against `NEWSLETTER_SEND_SECRET`. Accepts `{ subject, html, text }`, resolves the subscriber list from EspoCRM, and delivers one email per recipient via `sendEmail()` (SES). Returns `{ sent, failed, total }`. The `%UNSUBSCRIBELINK%` token in the body is replaced per recipient with `/api/unsubscribe?email=...`, and a matching `List-Unsubscribe` header is added.
 
 ### CMS
 
@@ -59,13 +59,13 @@ If nothing is approved by 09:00 UTC, the publisher exits cleanly with no newslet
 
 - [scripts/generate-weekly-article.ts](../scripts/generate-weekly-article.ts) picks the least-recently-used category, calls Claude with a brand-voice system prompt plus the last 8 titles to avoid, parses the JSON response, inserts as a Notion Draft, Slack-pings the editor.
 - [scripts/publish-and-send-newsletter.ts](../scripts/publish-and-send-newsletter.ts) finds Approved rows, renders Notion blocks to HTML and plaintext (including a category-matched "This Week at Cloudless" service offer section), marks Published with `Date` and `PublishedAt`, hits the existing Notion webhook to revalidate ISR, then POSTs the rendered email to `/api/newsletter/send`, and Slack-confirms with the delivered/failed counts.
-- `scripts/weekly-subscriber-report.ts` _(decommissioned with HubSpot in PR #1043; equivalent reporting now flows from the espocrm-to-lake ETL → Athena)_ — historically queried HubSpot for total active subscribers, new signups this week, and total unsubscribed contacts; posted a formatted Block Kit summary to Slack `#subscribers`; and inserted a timestamped row into a Notion "Newsletter Reports" database.
+- `scripts/weekly-subscriber-report.ts` _(decommissioned with EspoCRM in PR #1043; equivalent reporting now flows from the espocrm-to-lake ETL → Athena)_ — historically queried EspoCRM for total active subscribers, new signups this week, and total unsubscribed contacts; posted a formatted Block Kit summary to Slack `#subscribers`; and inserted a timestamped row into a Notion "Newsletter Reports" database.
 
 ### Workflows
 
 - [.github/workflows/weekly-article-draft.yml](../.github/workflows/weekly-article-draft.yml) — `cron: "0 6 * * 1"` (Mondays 06:00 UTC, 08:00 Athens).
 - [.github/workflows/weekly-newsletter.yml](../.github/workflows/weekly-newsletter.yml) — `cron: "0 9 * * 1"` (Mondays 09:00 UTC, 11:00 Athens).
-- `.github/workflows/weekly-subscriber-report.yml` _(removed in PR #1043 alongside the HubSpot decom — superseded by the daily espocrm-to-lake ETL workflow)_ — historically `cron: "0 10 * * 1"` (Mondays 10:00 UTC, 12:00 Athens).
+- `.github/workflows/weekly-subscriber-report.yml` _(removed in PR #1043 alongside the EspoCRM decom — superseded by the daily espocrm-to-lake ETL workflow)_ — historically `cron: "0 10 * * 1"` (Mondays 10:00 UTC, 12:00 Athens).
 - All three have `workflow_dispatch` for manual triggering from the Actions UI.
 
 ## Local commands
@@ -99,7 +99,7 @@ The `/api/newsletter/send` route reads all three from SSM at runtime. SES is rea
 | `NOTION_BLOG_DB_ID` | Blog database id (shared with the integration) |
 | `NOTION_WEBHOOK_SECRET` | Used by the publisher to call the existing `/api/webhooks/notion` revalidator |
 | `NEWSLETTER_SEND_SECRET` | Authenticates the publisher to `/api/newsletter/send`. Must match the SSM value. |
-| `HUBSPOT_API_KEY` | HubSpot private-app token (used by the report script to query subscriber stats) |
+| `HUBSPOT_API_KEY` | EspoCRM private-app token (used by the report script to query subscriber stats) |
 | `SITE_URL` | Default `https://cloudless.gr` (script falls back to this) |
 | `SLACK_WEBHOOK_URL` | Optional. Slack notifications on success and failure |
 
@@ -123,11 +123,11 @@ The `/api/newsletter/send` route reads all three from SSM at runtime. SES is rea
   - Publisher with nothing approved: exits 0, no newsletter, no error. Quiet skip.
   - Publisher with a send error: Slack ping; the post is still flipped to Published in Notion. Re-running the publisher finds no Approved rows, so re-trigger the send manually via `workflow_dispatch` only after re-approving, or call `/api/newsletter/send` directly.
   - Per-recipient SES failures do not abort the batch; they are counted in `failed` and logged.
-  - Report script failure: Slack ping; HubSpot contacts view remains the authoritative source.
+  - Report script failure: Slack ping; EspoCRM contacts view remains the authoritative source.
 - **From address**: SES sends newsletter issues from `SES_FROM_EMAIL` (default `noreply@cloudless.gr`), resolved from SSM inside `sendEmail()`. The welcome email sends from `Themis at Cloudless <noreply@cloudless.gr>` for a personal touch.
-- **Unsubscribe**: the `%UNSUBSCRIBELINK%` token in the email template is replaced per recipient with `/api/unsubscribe?email=...`, and a one-click `List-Unsubscribe` header is attached. Unsubscribing both suppresses the address in SES and flips the HubSpot contact to `newsletter_unsubscribed`, so the next weekly send no longer targets it.
-- **Re-subscribe**: subscribing again clears the SES suppression entry and flips the HubSpot contact back to `newsletter_signup`, so a returning subscriber is fully restored without manual cleanup.
-- **Weekly report**: runs at 10:00 UTC (one hour after the send), posts subscriber counts to Slack `#subscribers`, and appends a timestamped row to the Notion "Newsletter Reports" database. "New this week" counts contacts whose HubSpot record was created within the last 7 days AND who are active subscribers; use the HubSpot contacts view for full historical trend data.
+- **Unsubscribe**: the `%UNSUBSCRIBELINK%` token in the email template is replaced per recipient with `/api/unsubscribe?email=...`, and a one-click `List-Unsubscribe` header is attached. Unsubscribing both suppresses the address in SES and flips the EspoCRM contact to `newsletter_unsubscribed`, so the next weekly send no longer targets it.
+- **Re-subscribe**: subscribing again clears the SES suppression entry and flips the EspoCRM contact back to `newsletter_signup`, so a returning subscriber is fully restored without manual cleanup.
+- **Weekly report**: runs at 10:00 UTC (one hour after the send), posts subscriber counts to Slack `#subscribers`, and appends a timestamped row to the Notion "Newsletter Reports" database. "New this week" counts contacts whose EspoCRM record was created within the last 7 days AND who are active subscribers; use the EspoCRM contacts view for full historical trend data.
 - **Scale**: the send loop is sequential, one SES call per subscriber. This is fine for the current list size. For a large list the route should move to a batched or queued send.
 
 ## Smoke test sequence
@@ -136,4 +136,4 @@ The `/api/newsletter/send` route reads all three from SSM at runtime. SES is rea
 2. In Notion, flip Status `Draft` to `Approved`.
 3. Actions tab, **Weekly Newsletter**, Run workflow. Confirm: the row flips to Published, `/blog/[slug]` shows the post, the Slack ping reports delivered/failed counts, and the email lands — including the "This Week at Cloudless" offer section.
 4. Actions tab, **Weekly Subscriber Report**, Run workflow. Confirm a Slack message arrives in `#subscribers` with the subscriber counts, and a new row appears in the Notion "Newsletter Reports" database.
-5. Subscribe with a fresh email at cloudless.gr. Confirm: a branded welcome email arrives from `Themis at Cloudless`, the contact appears in HubSpot with `lead_source = newsletter_signup`, and a real-time Slack ping fires in `#subscribers`.
+5. Subscribe with a fresh email at cloudless.gr. Confirm: a branded welcome email arrives from `Themis at Cloudless`, the contact appears in EspoCRM with `lead_source = newsletter_signup`, and a real-time Slack ping fires in `#subscribers`.

--- a/docs/README.md
+++ b/docs/README.md
@@ -18,7 +18,7 @@
 | [ANTHROPIC.md](ANTHROPIC.md) | Anthropic SDK / Claude API usage in the app. |
 | [GSC.md](GSC.md) | Google Search Console integration. |
 | [GOOGLE-CALENDAR.md](GOOGLE-CALENDAR.md) | Calendar integration. |
-| [HUBSPOT.md](HUBSPOT.md) | HubSpot CRM integration. |
+| [HUBSPOT.md](HUBSPOT.md) | EspoCRM CRM integration. |
 | [SENTRY.md](SENTRY.md) | Error monitoring. |
 | [SLACK.md](SLACK.md) | Slack notifications. |
 | [STRIPE.md](STRIPE.md) | Stripe checkout + webhooks. |
@@ -43,7 +43,7 @@
 |---|---|---|
 | Dashboard | `/admin` | Stat cards (orders, contacts, errors) + Infrastructure shortcuts |
 | Analytics | `/admin/analytics`, `/admin/analytics/unified` | GSC + web metrics |
-| HubSpot | `/admin/hubspot`, `/admin/crm/**` | Contacts, companies, tickets |
+| EspoCRM | `/admin/hubspot`, `/admin/crm/**` | Contacts, companies, tickets |
 | Marketing | `/admin/campaigns/**`, `/admin/email`, `/admin/calendar` | Campaigns, email, content calendar |
 | Notion | `/admin/notion/**` | Submissions, projects, tasks, analytics |
 | System | `/admin/orders`, `/admin/errors`, `/admin/integrations`, `/admin/settings` | Ops and config |

--- a/docs/ROADMAP-ONE-STOP-SHOP.md
+++ b/docs/ROADMAP-ONE-STOP-SHOP.md
@@ -15,8 +15,8 @@ social publishing).
 
 | Area | Already built | Key files |
 |------|---------------|-----------|
-| Lead capture | Contact form → HubSpot contact + ticket, newsletter/subscribe | `src/app/api/contact`, `src/lib/hubspot.ts` |
-| CRM | Companies, tickets, pipeline views, HubSpot dashboard | `/admin/crm/*`, `/admin/pipeline`, `/admin/hubspot` |
+| Lead capture | Contact form → EspoCRM contact + ticket, newsletter/subscribe | `src/app/api/contact`, `src/lib/hubspot.ts` |
+| CRM | Companies, tickets, pipeline views, EspoCRM dashboard | `/admin/crm/*`, `/admin/pipeline`, `/admin/hubspot` |
 | Email marketing | SES transactional + suppression, ActiveCampaign client, campaigns page | `src/lib/email.ts`, `src/lib/ses-suppression.ts`, `src/lib/activecampaign.ts`, `/admin/email/campaigns` |
 | Ad campaign insights | Google, LinkedIn, TikTok, X (read-only insights) | `src/lib/campaigns/{google-ads,linkedin,tiktok,x-ads}.ts` |
 | Attribution plumbing | Meta Pixel + Conversions API, GSC | `src/lib/meta-capi.ts`, `src/lib/meta-pixel.ts`, `src/lib/gsc.ts` |
@@ -32,7 +32,7 @@ social publishing).
 1. **No Meta/Instagram anywhere in campaigns** — `src/lib/campaigns/` has no
    Meta module despite the calendar listing `meta` as a platform.
 2. **No publishing** — the calendar plans posts but nothing posts them.
-3. **No lead scoring or automated follow-up** — leads land in HubSpot and stop.
+3. **No lead scoring or automated follow-up** — leads land in EspoCRM and stop.
 4. **No campaign→lead→revenue attribution** — insights, CRM, and Stripe data
    are never joined.
 5. **Portal has a timeline but no deliverables, approvals, scheduled client
@@ -44,15 +44,15 @@ social publishing).
 
 Make every lead captured, scored, routed, and followed up automatically.
 
-1. **Unified lead inbox** (`/admin/leads`): one view joining HubSpot contacts,
+1. **Unified lead inbox** (`/admin/leads`): one view joining EspoCRM contacts,
    contact-form tickets, newsletter signups, and portal enrollments
    (`pending-clients.ts`). *Build* — thin UI over existing libs.
 2. **Lead source attribution**: persist UTM params + landing page on the
-   contact form and pass them to HubSpot properties and Meta CAPI events
+   contact form and pass them to EspoCRM properties and Meta CAPI events
    (plumbing exists in `meta-capi.ts`). *Build.*
 3. **Lead scoring**: simple rules engine (source, service interest, company
-   size, engagement) writing a score property to HubSpot. *Build* — avoids
-   HubSpot Pro-tier licensing.
+   size, engagement) writing a score property to EspoCRM. *Build* — avoids
+   EspoCRM Pro-tier licensing.
 4. **Automated follow-up sequences**: trigger ActiveCampaign automations from
    lead events (new lead, no-reply-3-days, proposal-sent). *Integrate* —
    `activecampaign.ts` already authenticates; build the trigger calls, let
@@ -101,7 +101,7 @@ TikTok from the calendar.
 ## Phase 4 — Unify: the one-stop dashboard
 
 1. **ROI view**: extend `/admin/analytics/unified` to join ad spend
-   (campaign insights) → leads (HubSpot, with Phase-1 attribution) → revenue
+   (campaign insights) → leads (EspoCRM, with Phase-1 attribution) → revenue
    (Stripe) per channel and per client.
 2. **Client health score** on `/admin/kpi`: project status + payment status +
    engagement, with alerts for at-risk clients.

--- a/docs/SLACK.md
+++ b/docs/SLACK.md
@@ -295,7 +295,7 @@ All outbound notifications use the `SlackClient` class, which automatically sele
 
 ### `slackContactNotify({ name, email, company?, service?, message })`
 
-Called from `/api/contact` as **fire-and-forget** via `Promise.allSettled` (runs in parallel with HubSpot CRM upsert). Does not block the API response.
+Called from `/api/contact` as **fire-and-forget** via `Promise.allSettled` (runs in parallel with EspoCRM CRM upsert). Does not block the API response.
 
 Block Kit message includes:
 

--- a/docs/USE-CASES.md
+++ b/docs/USE-CASES.md
@@ -17,11 +17,11 @@ Last verified against the codebase: 2026-06-12.
 | Read marketing content (blog)        | `/blog`, `/blog/[slug]` — Notion-backed                                                          | live   |
 | Read documentation                   | `/docs`, `/docs/[slug]` — Notion-backed                                                          | live   |
 | Browse case studies and social proof | `/case-studies`, testimonials across pages — Notion CMS with static fallback                     | live   |
-| Contact the company                  | `/contact` form → SES email + auto-reply, HubSpot contact + deal, Notion submission, Slack alert | live   |
+| Contact the company                  | `/contact` form → SES email + auto-reply, EspoCRM contact + deal, Notion submission, Slack alert | live   |
 | Get scored as a lead invisibly       | First-touch UTM/referrer capture site-wide → lead score 0–100 on submission                      | live   |
 | Buy a product or service             | `/store`, `/store/[id]` → Stripe checkout → `/store/success`                                     | live   |
 | Book a consultation                  | Chat widget / calendar booking → Google Calendar + Meet link, Slack alert                        | live   |
-| Subscribe to the newsletter          | Subscribe form → HubSpot list, unsubscribe flow                                                  | live   |
+| Subscribe to the newsletter          | Subscribe form → EspoCRM list, unsubscribe flow                                                  | live   |
 | Sign up and pick a plan              | `/auth/signup` (Cognito) → plan selection → `/portal/waiting`                                    | live   |
 | Use the site in 4 languages          | `en`, `el`, `fr`, `de` locale routing everywhere                                                 | live   |
 | Chat with an AI assistant            | Chat widget (Bedrock/Anthropic backed)                                                           | live   |
@@ -43,12 +43,12 @@ Last verified against the codebase: 2026-06-12.
 
 | Use case                       | Surface                                                                                                                | Status                                                   |
 | ------------------------------ | ---------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------- |
-| See every lead in one inbox    | `/admin/leads` — HubSpot contacts + portal enrollments merged by email                                                 | live                                                     |
-| Know where each lead came from | First-touch attribution (UTM, referrer, landing page) in HubSpot notes & Slack                                         | live                                                     |
+| See every lead in one inbox    | `/admin/leads` — EspoCRM contacts + portal enrollments merged by email                                                 | live                                                     |
+| Know where each lead came from | First-touch attribution (UTM, referrer, landing page) in EspoCRM notes & Slack                                         | live                                                     |
 | Know which leads are hot       | Explainable 0–100 score (service interest, company, message signals, paid traffic, business email) with 🔥/🌤️/❄️ bands | live                                                     |
 | Get instant lead alerts        | Slack message with score, band, attribution per submission                                                             | live                                                     |
 | Auto-follow-up new leads       | ActiveCampaign automation enrollment on submission                                                                     | needs config: `ACTIVECAMPAIGN_LEAD_AUTOMATION_ID` in SSM |
-| Manage the sales pipeline      | `/admin/pipeline` — HubSpot deals by stage                                                                             | live                                                     |
+| Manage the sales pipeline      | `/admin/pipeline` — EspoCRM deals by stage                                                                             | live                                                     |
 | Manage CRM records             | `/admin/crm` (+ companies, tickets), `/admin/hubspot`                                                                  | live                                                     |
 
 ## 4. Owner — marketing & publishing (Phase 2)
@@ -101,7 +101,7 @@ Last verified against the codebase: 2026-06-12.
 
 | Automation                                                                     | Trigger                                        | Status                                       |
 | ------------------------------------------------------------------------------ | ---------------------------------------------- | -------------------------------------------- |
-| Lead capture fan-out (email, HubSpot, Notion, Slack, Meta CAPI, AC enrollment) | Contact form submit                            | live                                         |
+| Lead capture fan-out (email, EspoCRM, Notion, Slack, Meta CAPI, AC enrollment) | Contact form submit                            | live                                         |
 | Weekly owner digest → Slack                                                    | GH Actions `platform-crons.yml`, Mon 06:00 UTC | live                                         |
 | Monthly client status emails                                                   | GH Actions `platform-crons.yml`, 1st 08:00 UTC | live                                         |
 | Daily content-calendar digest → Slack                                          | Cron `calendar-digest`                         | endpoint live; schedule externally if wanted |
@@ -129,7 +129,7 @@ Already configured in SSM — no action needed: Meta Ads
 (`META_ACCESS_TOKEN` + `META_AD_ACCOUNT_ID`), Google Ads
 (`GOOGLE_ADS_DEVELOPER_TOKEN` + `GOOGLE_ADS_CUSTOMER_ID`), LinkedIn (client
 ID/secret, access token, ad account), X API keys/tokens, Slack bot token +
-default channel, HubSpot, Notion, Stripe, SES, Sentry, GSC, Anthropic.
+default channel, EspoCRM, Notion, Stripe, SES, Sentry, GSC, Anthropic.
 
 Still pending (the genuinely human items):
 

--- a/docs/analytics-athena.sql
+++ b/docs/analytics-athena.sql
@@ -35,7 +35,7 @@ ROW FORMAT SERDE 'org.openx.data.jsonserde.JsonSerDe'
 LOCATION 's3://cloudless-analytics-data/events/'
 TBLPROPERTIES ('has_encrypted_data'='false');
 
--- ---- HubSpot CRM tables (Parquet, full-refresh daily) ---------------------
+-- ---- EspoCRM CRM tables (Parquet, full-refresh daily) ---------------------
 CREATE EXTERNAL TABLE IF NOT EXISTS cloudless_analytics.hubspot_contacts (
   contact_id       string,
   email            string,
@@ -173,8 +173,8 @@ HAVING COUNT(*) > 1
 ORDER BY revenue DESC NULLS LAST, sessions DESC;
 
 -- ---- v_hubspot_funnel ------------------------------------------------------
--- HubSpot contact lifecycle stage breakdown joined to whether they have a
--- closed-won deal in HubSpot. Lets us see lead-source ROI by stage.
+-- EspoCRM contact lifecycle stage breakdown joined to whether they have a
+-- closed-won deal in EspoCRM. Lets us see lead-source ROI by stage.
 CREATE OR REPLACE VIEW cloudless_analytics.v_hubspot_funnel AS
 SELECT
   COALESCE(c.lifecyclestage, 'unknown') AS lifecycle_stage,
@@ -188,7 +188,7 @@ GROUP BY 1, 2
 ORDER BY contact_count DESC;
 
 -- ---- v_lead_to_customer ----------------------------------------------------
--- Cross-source funnel join: HubSpot contact → Cognito client → first Stripe
+-- Cross-source funnel join: EspoCRM contact → Cognito client → first Stripe
 -- transaction. Joins on lowercased email. Shows time-to-conversion + lifetime
 -- value once the contact becomes a paying customer.
 CREATE OR REPLACE VIEW cloudless_analytics.v_lead_to_customer AS
@@ -259,7 +259,7 @@ GROUP BY campaign_id, campaign_name
 ORDER BY spend DESC;
 
 -- ===========================================================================
--- EspoCRM tables (replaces HubSpot, fed by scripts/etl/espocrm-to-lake.mjs)
+-- EspoCRM tables (replaces EspoCRM, fed by scripts/etl/espocrm-to-lake.mjs)
 -- ===========================================================================
 
 CREATE EXTERNAL TABLE IF NOT EXISTS cloudless_analytics.espocrm_contacts (

--- a/docs/available-tooling-inventory.md
+++ b/docs/available-tooling-inventory.md
@@ -10,7 +10,7 @@ installed-but-unauthenticated — no clutter, no bills.
 
 - Drop tools for the wrong region (US-only payroll/banking).
 - Drop tools that overlap with what you already self-host (Zapier vs n8n, Cloudinary vs S3+Lambda).
-- Drop tools that decommissioned products use (HubSpot, Apollo).
+- Drop tools that decommissioned products use (EspoCRM, Apollo).
 - Drop tools whose value-proposition needs a team (Gong, Intercom for a 1-person op).
 - Keep only what maps to a specific need on your roadmap or daily ops.
 
@@ -89,7 +89,7 @@ first principles. Top 10 most-load-bearing for cloudless.gr build:
 These stay installed-but-unauthenticated — available if you ever need
 them, but no setup time spent now:
 
-- **HubSpot** (decommissioned 2026-06-20, moved to EspoCRM)
+- **EspoCRM** (decommissioned 2026-06-20, moved to EspoCRM)
 - **Apollo** (removed PR #1080 — Greek SMB volume too low)
 - **Cloudinary** (Lambda image-resize fits same-hardware rule)
 - **Fastly / Vercel** (you're on AWS+Cloudflare)

--- a/docs/datalake-schema.sql
+++ b/docs/datalake-schema.sql
@@ -12,7 +12,7 @@ CREATE DATABASE IF NOT EXISTS cloudless_analytics;
 -- Already defined in docs/analytics-athena.sql
 
 -- ============================================================================
--- CLIENTS — unified client profile (synced from Cognito + portals + HubSpot)
+-- CLIENTS — unified client profile (synced from Cognito + portals + EspoCRM)
 -- ============================================================================
 CREATE EXTERNAL TABLE IF NOT EXISTS cloudless_analytics.clients (
   user_id         string,

--- a/docs/datalake.md
+++ b/docs/datalake.md
@@ -80,7 +80,7 @@ should show files growing with each request.
 |---|---|---|
 | `scripts/etl/stripe-to-lake.mjs` | Stripe API | `lake/transactions/` |
 | `scripts/etl/portals-to-lake.mjs` | Notion / portal DB | `lake/portals/` |
-| `scripts/etl/clients-to-lake.mjs` | HubSpot / Notion | `lake/clients/` |
+| `scripts/etl/clients-to-lake.mjs` | EspoCRM / Notion | `lake/clients/` |
 
 These run from a local laptop or CI, **not** from Lambda. They use
 long-lived credentials with broader S3 access (Get/Put/Delete). Not

--- a/docs/etl.md
+++ b/docs/etl.md
@@ -23,7 +23,7 @@ Athena Glue catalog        ←  analytics-etl.yml (MSCK REPAIR) ← s3://…/eve
 | Workflow | Schedule (UTC) | Source | Sink | Idempotency |
 |---|---|---|---|---|
 | `analytics-etl.yml` | `0 2 * * *` (02:00) | Hive partitions on `events/` | Glue catalog | Yes — `MSCK REPAIR TABLE` |
-| `etl-hubspot-to-lake.yml` | `15 3 * * *` (03:15) | HubSpot v3 API (contacts + deals + tickets) | `lake/hubspot-{contacts,deals,tickets}/` | Full refresh — overwrites |
+| `etl-hubspot-to-lake.yml` | `15 3 * * *` (03:15) | EspoCRM v3 API (contacts + deals + tickets) | `lake/hubspot-{contacts,deals,tickets}/` | Full refresh — overwrites |
 | `etl-stripe-to-lake.yml` | `30 3 * * *` (03:30) | Stripe API (sessions/invoices/subs) | `lake/transactions/transactions.parquet` | Full refresh — overwrites |
 | `etl-compute-rfm-churn.yml` | `45 3 * * *` (03:45) | `lake/transactions/transactions.parquet` (Stripe ETL output) | `ml-parquet/scores_{rfm,churn}.parquet` | Full refresh — replaces external ML pipeline |
 | `etl-clients-to-lake.yml` | `0 4 * * *` (04:00) | Cognito + SSM + ml-parquet | `lake/clients/clients.parquet` + `lake/portals/portals.parquet` | Full refresh — overwrites |
@@ -51,7 +51,7 @@ read the RFM scores written 15 min earlier (instead of yesterday's).
   into a transactions schema (id, email, type=checkout/invoice/sub,
   status, amount_cents, currency, product, plan, timestamps), writes
   parquet via `@dsnp/parquetjs`.
-- `scripts/etl/hubspot-to-lake.mjs` — pulls HubSpot v3 (contacts,
+- `scripts/etl/hubspot-to-lake.mjs` — pulls EspoCRM v3 (contacts,
   deals, tickets) with cursor pagination, writes 3 parquet files.
   Drives the v_hubspot_funnel and v_lead_to_customer Athena views.
 - `scripts/etl/compute-rfm-churn.mjs` — reads

--- a/docs/nlp-lint-2026-06-18.md
+++ b/docs/nlp-lint-2026-06-18.md
@@ -15,7 +15,7 @@ Totals: **372 findings → 70 unambiguous fixes applied, 75 need human review.**
 
 Noise filters (skipped without surfacing):
 
-- Brand names / product names: Cloudless, AWS, GCP, Azure, Stripe, PayPal, Skroutz, Cloudflare, Cognito, HubSpot, etc.
+- Brand names / product names: Cloudless, AWS, GCP, Azure, Stripe, PayPal, Skroutz, Cloudflare, Cognito, EspoCRM, etc.
 - ASCII tech loanwords inside non-English locales: dashboard, kickoff, newsletter, hosting, cookies, growth, hacks, pipeline, framework, frontend, backend, fullstack, etc.
 - Short ALL-CAPS acronyms: AI, MSP, ETL, KPI, POS, CCTV, B2B, etc.
 

--- a/docs/pi-cloud-sync.md
+++ b/docs/pi-cloud-sync.md
@@ -33,7 +33,7 @@ This doc is the contract for what's kept in sync, how, and what to monitor.
 | **Runtime secrets** | Both read from SSM at `/cloudless/production/*` (see [sst.config.ts:31-32](../sst.config.ts)). | Pi must have `ssm:GetParametersByPath` on that prefix via `cloudless-pi-standby`. |
 | **Notion content** | Both fetch live from Notion API; ISR per-process. | Pi cache lags by up to its ISR TTL after Notion edits. |
 | **Auth sessions** | Both verify JWTs against the same Cognito JWKS. | Pi must have the `COGNITO_*` vars in SSM. |
-| **Webhooks (Stripe/Notion/HubSpot)** | Hit `cloudless.gr` and route to whichever is live. | Pi must hold the same webhook secrets in SSM. |
+| **Webhooks (Stripe/Notion/EspoCRM)** | Hit `cloudless.gr` and route to whichever is live. | Pi must hold the same webhook secrets in SSM. |
 | **TLS cert** | Cloud uses ACM; Pi uses its own (Let's Encrypt / cert-manager). | Independent expiry. **Highest silent-failure risk.** |
 | **Outbound IP / source reputation** | Differs (CloudFront IP vs WAN `150.228.63.192`). | Anything with IP allowlists — outbound APIs, SES — must allowlist both. |
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -13,7 +13,7 @@ same image, so all controls below apply identically to both).
 | Auth (user) | OIDC JWT (Cognito or Cognito), RS256-verified against provider JWKS | `src/lib/api-auth.ts` |
 | Auth (admin) | All 71 `/api/admin/*` routes gated by `requireAdmin`/`requireAuth` | `src/app/api/admin/**` |
 | Auth (cron) | `Bearer ${CRON_SECRET}`, constant-time compare | `src/lib/cron-auth.ts` |
-| Auth (webhook) | Stripe `constructEvent`, HubSpot v3 timing-safe HMAC, Notion HMAC, Pi-sync HMAC-SHA256 | `src/app/api/webhooks/**`, `.github/workflows/build-pi-image.yml` |
+| Auth (webhook) | Stripe `constructEvent`, EspoCRM v3 timing-safe HMAC, Notion HMAC, Pi-sync HMAC-SHA256 | `src/app/api/webhooks/**`, `.github/workflows/build-pi-image.yml` |
 | Headers | HSTS, X-Frame-Options DENY, X-Content-Type-Options nosniff, Referrer-Policy strict-origin-when-cross-origin | `src/proxy.ts` |
 | Headers | Permissions-Policy with 24 directives — most denied, only payment/fullscreen/autoplay/web-share/publickey-credentials-get kept as `(self)` | `src/proxy.ts` |
 | Headers | Content-Security-Policy-Report-Only (full directive set; `report-uri /api/csp-report` + `report-to csp-endpoint`) | `src/proxy.ts` |
@@ -60,7 +60,7 @@ same image, so all controls below apply identically to both).
 | Source | Algorithm | Verifier |
 |---|---|---|
 | Stripe | HMAC via `stripe.webhooks.constructEvent` (canonical, includes timestamp) | `src/app/api/webhooks/stripe/route.ts` |
-| HubSpot | v3 HMAC-SHA256 over `${method}${url}${body}${timestamp}`, `timingSafeEqual` | `src/app/api/webhooks/hubspot/route.ts` |
+| EspoCRM | v3 HMAC-SHA256 over `${method}${url}${body}${timestamp}`, `timingSafeEqual` | `src/app/api/webhooks/hubspot/route.ts` |
 | Notion | HMAC-SHA256 of body | `src/app/api/webhooks/notion/route.ts` |
 | Pi sync (build → Pi) | HMAC-SHA256 over JSON body, sent as `X-Hub-Signature-256` | `.github/workflows/build-pi-image.yml` |
 
@@ -205,9 +205,9 @@ permission-update path that doesn't require root keys.
 | Topic | Why skipped |
 |---|---|
 | **CSRF tokens** | App uses Bearer tokens in `Authorization` header, not cookies. CORS allowlist further restricts cross-origin requests. CSRF surface is minimal. |
-| **SRI on third-party scripts** | HubSpot's tracking script is loaded dynamically by another HubSpot loader. CSP allowlist already constrains the scripts that can run; SRI on Stripe/Sentry is feasible if needed. |
+| **SRI on third-party scripts** | EspoCRM's tracking script is loaded dynamically by another EspoCRM loader. CSP allowlist already constrains the scripts that can run; SRI on Stripe/Sentry is feasible if needed. |
 | **WAF / DDoS protection at edge** | Not currently configured. CloudFront's built-in DDoS protection (Shield Standard) is on by default. AWS WAF is the next step if needed. |
-| **`'unsafe-inline'` / `'unsafe-eval'` in CSP** | Required by HubSpot's tracking script. Removing them would break HubSpot. CSP nonces could narrow this if HubSpot is ever removed. |
+| **`'unsafe-inline'` / `'unsafe-eval'` in CSP** | Required by EspoCRM's tracking script. Removing them would break EspoCRM. CSP nonces could narrow this if EspoCRM is ever removed. |
 
 ## Verifying
 

--- a/docs/user-flow-simulation.md
+++ b/docs/user-flow-simulation.md
@@ -52,13 +52,13 @@ step lists the file that implements it and flags wins ✅ and failures ❌.
 | 4 | Open cart drawer | `CartSlideOver.tsx` |
 | 5 | "Checkout" → `POST /api/checkout` → Stripe session → redirect | `api/checkout/route.ts` |
 | 6 | Pay on Stripe → redirect to `/store/success` | `store/success/page.tsx` |
-| 7 | `checkout.session.completed` webhook: email, team notify, Slack, HubSpot deal, persist | `api/webhooks/stripe/route.ts` |
+| 7 | `checkout.session.completed` webhook: email, team notify, Slack, EspoCRM deal, persist | `api/webhooks/stripe/route.ts` |
 
 ### ✅ Wins
 
 - Catalog renders with **zero** Stripe dependency; client (`store-products-client.ts`) and server (`store-products.ts`) `defaultProducts` IDs verified **in sync** → no "unknown product" on checkout.
 - Checkout route is hardened: origin allowlist (anti open-redirect), quantity clamp 1–99, idempotency-key support, subscription-vs-payment mode, EU+ shipping for physical goods, `503` when Stripe unconfigured.
-- Webhook: signature verification, duplicate suppression, failure marking, Sentry, graceful HubSpot/Slack degradation.
+- Webhook: signature verification, duplicate suppression, failure marking, Sentry, graceful EspoCRM/Slack degradation.
 - Purchases read **live from Stripe by email** — no separate order DB to drift.
 
 ### ❌ Failures / risks

--- a/documentation/available-tooling-inventory.md
+++ b/documentation/available-tooling-inventory.md
@@ -10,7 +10,7 @@ installed-but-unauthenticated — no clutter, no bills.
 
 - Drop tools for the wrong region (US-only payroll/banking).
 - Drop tools that overlap with what you already self-host (Zapier vs n8n, Cloudinary vs S3+Lambda).
-- Drop tools that decommissioned products use (HubSpot, Apollo).
+- Drop tools that decommissioned products use (EspoCRM, Apollo).
 - Drop tools whose value-proposition needs a team (Gong, Intercom for a 1-person op).
 - Keep only what maps to a specific need on your roadmap or daily ops.
 
@@ -89,7 +89,7 @@ first principles. Top 10 most-load-bearing for cloudless.gr build:
 These stay installed-but-unauthenticated — available if you ever need
 them, but no setup time spent now:
 
-- **HubSpot** (decommissioned 2026-06-20, moved to EspoCRM)
+- **EspoCRM** (decommissioned 2026-06-20, moved to EspoCRM)
 - **Apollo** (removed PR #1080 — Greek SMB volume too low)
 - **Cloudinary** (Lambda image-resize fits same-hardware rule)
 - **Fastly / Vercel** (you're on AWS+Cloudflare)

--- a/e2e/api-routes.spec.ts
+++ b/e2e/api-routes.spec.ts
@@ -2,7 +2,7 @@
  * Public API route input-validation coverage.
  *
  * These tests exercise validation branches that don't depend on external
- * services (SES, HubSpot, Stripe, Slack) so they're deterministic with no
+ * services (SES, EspoCRM, Stripe, Slack) so they're deterministic with no
  * secrets configured.
  *
  * Each request sends a unique `x-forwarded-for` so the per-IP rate limiter

--- a/e2e/form-submission-flows.spec.ts
+++ b/e2e/form-submission-flows.spec.ts
@@ -67,7 +67,7 @@ test.describe("Contact form (/en/contact)", () => {
       .click();
 
     const response = await responsePromise;
-    // In dev without HubSpot creds the route may 4xx/5xx — both are fine.
+    // In dev without EspoCRM creds the route may 4xx/5xx — both are fine.
     // The contract is: the route was hit and we got SOMETHING back.
     expect(response.status()).toBeGreaterThanOrEqual(200);
   });

--- a/e2e/integrations-contracts.spec.ts
+++ b/e2e/integrations-contracts.spec.ts
@@ -97,7 +97,7 @@ test.describe("Integrations contracts", () => {
   });
 
   test("EspoCRM webhook POST requires URL-secret auth", async ({ page }) => {
-    // EspoCRM webhook replaced HubSpot 2026-06-20 (PR #1043). Auth is a
+    // EspoCRM webhook replaced EspoCRM 2026-06-20 (PR #1043). Auth is a
     // URL-query-param secret (?secret=...), not HMAC. POST without secret → 4xx.
     const response = await postJson(page.request, "/api/webhooks/espocrm", {
       entity: "Lead",
@@ -108,7 +108,7 @@ test.describe("Integrations contracts", () => {
     expect(response.status()).toBeLessThan(500);
   });
 
-  test("HubSpot CRM upsert route handles invalid email or unconfigured CRM", async ({ page }) => {
+  test("EspoCRM CRM upsert route handles invalid email or unconfigured CRM", async ({ page }) => {
     const response = await postJson(page.request, "/api/crm/contact", {
       email: "invalid-email",
     });

--- a/e2e/k3s/assets.spec.ts
+++ b/e2e/k3s/assets.spec.ts
@@ -36,7 +36,7 @@ test.describe("k3s static assets", () => {
       const t = m.text();
       const url = m.location().url ?? "";
       // Treat anything emitted from a 3rd-party host as benign — extensions,
-      // ad blockers, or geo-restricted Stripe/HubSpot/Sentry endpoints will
+      // ad blockers, or geo-restricted Stripe/EspoCRM/Sentry endpoints will
       // routinely produce console.error noise on first load.
       const thirdParty =
         /(stripe|hubspot|sentry|facebook|hsforms|hs-scripts|googletagmanager|google-analytics)/i;

--- a/e2e/k3s/webhook-endpoints.spec.ts
+++ b/e2e/k3s/webhook-endpoints.spec.ts
@@ -13,7 +13,7 @@ const WEBHOOK_ENDPOINTS = [
   { name: "Slack events", path: "/api/slack/events", expectedStatus: [401, 403, 400] },
   { name: "Slack interactions", path: "/api/slack/interactions", expectedStatus: [401, 403, 400] },
   { name: "Slack commands", path: "/api/slack/commands", expectedStatus: [401, 403, 400] },
-  // HubSpot webhook deleted 2026-06-20 with PR #1043 (HubSpot decom); EspoCRM
+  // EspoCRM webhook deleted 2026-06-20 with PR #1043 (EspoCRM decom); EspoCRM
   // webhook replaces it. The /api/webhooks/espocrm route exists and is exercised
   // here so a future "EspoCRM webhook accidentally deleted" regression is caught.
   { name: "EspoCRM webhook", path: "/api/webhooks/espocrm", expectedStatus: [401, 403, 400, 405] },
@@ -42,7 +42,7 @@ test.describe("Webhook endpoints — route existence and auth rejection", () => 
         timeout: 10_000,
       });
       // Webhook routes should reject GET (405) or return 4xx; never 2xx.
-      // (The HubSpot GET-verification exemption was removed with PR #1043.)
+      // (The EspoCRM GET-verification exemption was removed with PR #1043.)
       expect(
         [200].includes(r.status()),
         `${wh.name} accepts GET — webhook routes should be POST-only`,

--- a/e2e/migrated/webhooks.spec.ts
+++ b/e2e/migrated/webhooks.spec.ts
@@ -22,7 +22,7 @@ test.describe("Webhook signature gates", () => {
   });
 
   test("POST /api/webhooks/espocrm without secret → 4xx", async ({ request }) => {
-    // EspoCRM webhook (replaced HubSpot 2026-06-20, PR #1043). Auth is a
+    // EspoCRM webhook (replaced EspoCRM 2026-06-20, PR #1043). Auth is a
     // URL-query-param secret rather than HMAC; rejects unauth POSTs with 4xx.
     const r = await request.post("/api/webhooks/espocrm", { data: [] });
     expect(r.status()).toBeGreaterThanOrEqual(400);

--- a/e2e/post-audit-coverage.spec.ts
+++ b/e2e/post-audit-coverage.spec.ts
@@ -6,9 +6,9 @@
  *   2. /_next/image content-negotiates AVIF when the client accepts it,
  *      proving the next.config.ts `formats: ["image/avif", "image/webp"]`
  *      change actually reaches user devices.
- *   3. HubSpot's loader is NOT injected on localhost — proves the
+ *   3. EspoCRM's loader is NOT injected on localhost — proves the
  *      runtime hostname gate in src/components/HubSpotScript.tsx works,
- *      and that the entire HubSpot+Typekit dependency chain stays out
+ *      and that the entire EspoCRM+Typekit dependency chain stays out
  *      of dev / preview / Pi-internal-IP environments.
  */
 
@@ -107,8 +107,8 @@ test.describe("image optimizer — AVIF/WebP support", () => {
   });
 });
 
-test.describe("HubSpot loader gate (only on real cloudless.gr hosts)", () => {
-  test("the HubSpot script tag is NOT in the DOM on localhost", async ({
+test.describe("EspoCRM loader gate (only on real cloudless.gr hosts)", () => {
+  test("the EspoCRM script tag is NOT in the DOM on localhost", async ({
     page,
   }) => {
     await page.goto("/en");

--- a/e2e/public-api-deep.spec.ts
+++ b/e2e/public-api-deep.spec.ts
@@ -141,7 +141,7 @@ test("POST /api/newsletter/send — without auth returns 401/403", async ({ requ
   expect(r.status()).toBeLessThan(500);
 });
 
-// /api/hubspot/ticket deleted 2026-06-20 (PR #1043 — HubSpot decom).
+// /api/hubspot/ticket deleted 2026-06-20 (PR #1043 — EspoCRM decom).
 
 test("GET /api/health — returns ok shape", async ({ request }) => {
   const r = await request.get("/api/health");

--- a/e2e/public-api-sweep.spec.ts
+++ b/e2e/public-api-sweep.spec.ts
@@ -116,7 +116,7 @@ test.describe("Public API route sweep", () => {
     expect(res.status()).toBeGreaterThanOrEqual(200);
   });
   test("POST /api/webhooks/espocrm without secret returns 4xx", async ({ request }) => {
-    // EspoCRM replaced HubSpot webhook 2026-06-20 (PR #1043). Auth = URL-secret.
+    // EspoCRM replaced EspoCRM webhook 2026-06-20 (PR #1043). Auth = URL-secret.
     const res = await request.post("/api/webhooks/espocrm", { data: {} });
     // In dev: 5xx is acceptable (missing creds). We only need the route to be wired.
     expect(res.status()).toBeGreaterThanOrEqual(200);

--- a/e2e/webhook-signatures.spec.ts
+++ b/e2e/webhook-signatures.spec.ts
@@ -2,7 +2,7 @@
  * Webhook signature rejection — negative-path coverage.
  *
  * The security audit confirmed all three webhook handlers (Stripe,
- * HubSpot, Notion) verify signatures before touching the request body.
+ * EspoCRM, Notion) verify signatures before touching the request body.
  * These tests pin that contract: requests without a valid signature
  * MUST be rejected with 4xx, never silently processed.
  *
@@ -39,8 +39,8 @@ test.describe("webhook signature gates", () => {
     expect(r.status()).toBeLessThan(500);
   });
 
-  // HubSpot webhook signature tests removed 2026-06-20 alongside the route
-  // (PR #1043 — HubSpot decom). EspoCRM webhook auth is URL-secret-based,
+  // EspoCRM webhook signature tests removed 2026-06-20 alongside the route
+  // (PR #1043 — EspoCRM decom). EspoCRM webhook auth is URL-secret-based,
   // not HMAC; covered by `/api/webhooks/espocrm` tests elsewhere.
 
   test("/api/webhooks/notion rejects missing signature", async ({ request }) => {

--- a/infrastructure/espocrm/README.md
+++ b/infrastructure/espocrm/README.md
@@ -1,6 +1,6 @@
-# EspoCRM — self-hosted CRM (HubSpot replacement)
+# EspoCRM — self-hosted CRM (EspoCRM replacement)
 
-EspoCRM (SugarCRM lineage, same family as SuiteCRM) replaces HubSpot for
+EspoCRM (SugarCRM lineage, same family as SuiteCRM) replaces EspoCRM for
 `cloudless.gr`. Deployed on the k3s cluster on `omv`, exposed via Cloudflare
 Tunnel at `https://espocrm.cloudless.gr`.
 
@@ -155,9 +155,9 @@ node to put them on. `omv-ha` is a Pi 4 with 1 GB RAM — neither fits there.
 - **PR 3**: `src/lib/espocrm.ts` mirroring the 21 exported functions of
   `src/lib/hubspot.ts` (drop-in by export name).
 - **PR 4**: Flip imports in the 10 admin API routes + 9 admin pages
-  (51 files reference HubSpot today).
+  (51 files reference EspoCRM today).
 
-HubSpot SSM key stays in place during cutover so anything still pointing
+EspoCRM SSM key stays in place during cutover so anything still pointing
 at it keeps working.
 
 ## Inbound Email → Cases (operator setup, ~10 min)

--- a/infrastructure/espocrm/k8s/espocrm.yaml
+++ b/infrastructure/espocrm/k8s/espocrm.yaml
@@ -1,4 +1,4 @@
-# EspoCRM — self-hosted CRM (HubSpot replacement). DEPLOYED + LIVE 2026-06-20.
+# EspoCRM — self-hosted CRM (EspoCRM replacement). DEPLOYED + LIVE 2026-06-20.
 # Namespace: espocrm | App: espocrm/espocrm:9 | DB: mariadb:11
 #
 # Components (both run on omv only — nodeSelector kubernetes.io/hostname=omv):

--- a/scripts/check-services.js
+++ b/scripts/check-services.js
@@ -1,5 +1,5 @@
 // Service connectivity check script for Cloudless.gr
-// Checks actual connectivity for AWS SSM, SES, Stripe, Notion, HubSpot, Google Calendar, Slack, Sentry,
+// Checks actual connectivity for AWS SSM, SES, Stripe, Notion, EspoCRM, Google Calendar, Slack, Sentry,
 // Cognito OIDC (when COGNITO_ISSUER is set).
 
 const fs = require('fs');
@@ -51,7 +51,7 @@ async function checkHubSpot() {
   const res = await fetch('https://api.hubapi.com/crm/v3/objects/contacts?limit=1', {
     headers: { Authorization: `Bearer ${key}` },
   });
-  if (!res.ok) throw new Error(`HubSpot API unreachable (${res.status})`);
+  if (!res.ok) throw new Error(`EspoCRM API unreachable (${res.status})`);
 }
 
 async function checkNotion() {
@@ -144,7 +144,7 @@ async function main() {
   const checks = [
     [checkStripe, 'Stripe', false],
     [checkSlack, 'Slack', false],
-    [checkHubSpot, 'HubSpot', false],
+    [checkHubSpot, 'EspoCRM', false],
     [checkNotion, 'Notion', false],
     [checkGoogleCalendar, 'Google Calendar', false],
     [checkCognito, 'Cognito', false],

--- a/scripts/etl/espocrm-to-lake.mjs
+++ b/scripts/etl/espocrm-to-lake.mjs
@@ -5,9 +5,9 @@
  * instance via the v1 REST API. Five entities → five parquet files:
  *
  *   lake/espocrm-contacts/contacts.parquet
- *   lake/espocrm-accounts/accounts.parquet           (HubSpot's companies)
- *   lake/espocrm-opportunities/opportunities.parquet (HubSpot's deals)
- *   lake/espocrm-cases/cases.parquet                 (HubSpot's tickets)
+ *   lake/espocrm-accounts/accounts.parquet           (EspoCRM's companies)
+ *   lake/espocrm-opportunities/opportunities.parquet (EspoCRM's deals)
+ *   lake/espocrm-cases/cases.parquet                 (EspoCRM's tickets)
  *   lake/espocrm-campaigns/campaigns.parquet
  *
  * Auth: X-Api-Key (the same SSM-stored ESPOCRM_API_KEY the app uses).

--- a/scripts/lambda-env-audit.sh
+++ b/scripts/lambda-env-audit.sh
@@ -77,7 +77,7 @@ check "AUTH_URL" required "callback URL construction"
 echo ""
 echo "▸ Required for SSM-loaded secrets:"
 check "SSM_PREFIX" required "where ssm-config.ts looks"
-check "NEXT_PUBLIC_SITE_URL" required "Stripe/HubSpot callback URLs"
+check "NEXT_PUBLIC_SITE_URL" required "Stripe/EspoCRM callback URLs"
 
 echo ""
 echo "▸ Deploy traceability:"

--- a/scripts/nlp-lint-locales.py
+++ b/scripts/nlp-lint-locales.py
@@ -75,7 +75,7 @@ SKIP_FOR_BRAND = {
     "Hosted UI",
     "Cognito",
     "Slack",
-    "HubSpot",
+    "EspoCRM",
     "Sentry",
     "OpenNext",
     "Cloudflare",

--- a/scripts/notion-schema-sync.ts
+++ b/scripts/notion-schema-sync.ts
@@ -12,7 +12,7 @@
  *
  * Adds (idempotent — re-running is safe):
  *   Blog Posts:                Locale, Updated At, Status
- *   Contact Form Submissions:  Locale, Replied At, Notes, HubSpot Contact ID
+ *   Contact Form Submissions:  Locale, Replied At, Notes, EspoCRM Contact ID
  *   Site Analytics:            Locale
  *   Content Calendar:          Locale, Target Blog Post (relation → Blog Posts)
  *   Tasks:                     Related Blog Post (relation → Blog Posts)
@@ -71,7 +71,7 @@ const PLAN: { db: string; id: string; props: Record<string, PropSchema> }[] = [
       Locale: { select: { options: LOCALE_OPTIONS } },
       "Replied At": { date: {} },
       Notes: { rich_text: {} },
-      "HubSpot Contact ID": { rich_text: {} },
+      "EspoCRM Contact ID": { rich_text: {} },
     },
   },
   {

--- a/scripts/pi-routines/integration-health.py
+++ b/scripts/pi-routines/integration-health.py
@@ -69,12 +69,12 @@ sk = ssm("STRIPE_SECRET_KEY")
 code, _ = api_check("https://api.stripe.com/v1/balance", {"Authorization": f"Bearer {sk}"})
 R.append((":green_circle:" if code == 200 else ":red_circle:", "Stripe", f"HTTP {code}"))
 
-# HubSpot
+# EspoCRM
 hk = ssm("HUBSPOT_API_KEY")
 code, _ = api_check(
     "https://api.hubapi.com/crm/v3/objects/contacts?limit=1", {"Authorization": f"Bearer {hk}"}
 )
-R.append((":green_circle:" if code == 200 else ":red_circle:", "HubSpot CRM", f"HTTP {code}"))
+R.append((":green_circle:" if code == 200 else ":red_circle:", "EspoCRM CRM", f"HTTP {code}"))
 
 # Slack bot
 code, data = api_check("https://slack.com/api/auth.test", {"Authorization": f"Bearer {token}"})

--- a/scripts/publish-and-send-newsletter.ts
+++ b/scripts/publish-and-send-newsletter.ts
@@ -3,7 +3,7 @@
  *
  * Finds Notion Blog rows with Status="In Review", promotes them to Published,
  * triggers ISR revalidation on the public blog, then asks the site's
- * newsletter send endpoint to email each post to every HubSpot subscriber.
+ * newsletter send endpoint to email each post to every EspoCRM subscriber.
  *
  * Designed to run from .github/workflows/weekly-newsletter.yml on Mondays
  * at 09:00 UTC, three hours after the draft generator (the human review
@@ -13,7 +13,7 @@
  * Why a server endpoint for the send: delivery runs through SES, and the
  * Lambda the site runs on already holds SES permissions. Posting the
  * rendered email to /api/newsletter/send keeps AWS keys out of CI; the
- * endpoint resolves the recipient list from HubSpot and sends.
+ * endpoint resolves the recipient list from EspoCRM and sends.
  *
  * Flow per approved post:
  *   1. Fetch full block tree, render to HTML + plaintext.
@@ -379,7 +379,7 @@ interface SendResult {
 
 /**
  * Hands the rendered email to the site's /api/newsletter/send endpoint, which
- * resolves the HubSpot subscriber list and delivers via SES. Authenticated
+ * resolves the EspoCRM subscriber list and delivers via SES. Authenticated
  * with the shared NEWSLETTER_SEND_SECRET.
  */
 async function postNewsletter(subject: string, html: string, text: string): Promise<SendResult> {

--- a/scripts/verify-phase1-integration-http.ps1
+++ b/scripts/verify-phase1-integration-http.ps1
@@ -51,7 +51,7 @@ Write-Host @"
 
    - New: src/lib/integrations/http.ts — timeout, exponential-backoff retry on
      429+5xx, typed IntegrationError, Sentry breadcrumb per call, passthrough
-     mode for callers that handle 4xx themselves (e.g. HubSpot 409 upsert).
+     mode for callers that handle 4xx themselves (e.g. EspoCRM 409 upsert).
    - New: __tests__/integrations-http.test.ts — covers happy path, 5xx retry,
      429 with and without Retry-After, 4xx no-retry, passthrough, 204, text
      content-type, max-retry exhaustion, network errors.

--- a/skills/cowork-session-secrets/SKILL.md
+++ b/skills/cowork-session-secrets/SKILL.md
@@ -126,7 +126,7 @@ The MCP being green is a convenience, not a requirement. Every secret
 in the Cloud Session Secrets table is also available in one of:
 
 - **AWS SSM** at `/cloudless/production/<KEY>` (for Cloudflare, Anthropic,
-  Notion, HubSpot, Stripe, etc.) — readable via the bash tool with
+  Notion, EspoCRM, Stripe, etc.) — readable via the bash tool with
   `aws ssm get-parameter --with-decryption ...`
 - **GitHub Secrets** (for `AWS_DEPLOY_ROLE_ARN`, OIDC roles)
 - **Direct env in the bash sandbox** (for `GITHUB_PAT` — the agent

--- a/skills/espocrm-operator/SKILL.md
+++ b/skills/espocrm-operator/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: espocrm-operator
 description: |
-  Deploy, debug, and operate the self-hosted EspoCRM stack (HubSpot
+  Deploy, debug, and operate the self-hosted EspoCRM stack (EspoCRM
   replacement). Triggered by phrases like "EspoCRM is down", "create an
   EspoCRM Lead", "EspoCRM API error", "rotate the EspoCRM API key", "the
   espocrm-to-lake ETL failed", "EspoCRM webhook not firing", "import
@@ -12,12 +12,12 @@ description: |
 
 # EspoCRM operator toolkit
 
-EspoCRM (SugarCRM lineage, self-hosted) replaced HubSpot on 2026-06-20 when
-HubSpot's `content` scope got paywalled behind Marketing Hub Pro. HubSpot
+EspoCRM (SugarCRM lineage, self-hosted) replaced EspoCRM on 2026-06-20 when
+EspoCRM's `content` scope got paywalled behind Marketing Hub Pro. EspoCRM
 is fully decommissioned (PR #1043, ~3,387 LOC removed). Live at
 `https://espocrm.cloudless.gr`.
 
-The drop-in mirror of the old HubSpot client surface is at
+The drop-in mirror of the old EspoCRM client surface is at
 `src/lib/espocrm.ts` — 21 exports matching `src/lib/hubspot.ts` 1:1
 (`upsertContact`, `createTicket`, `listDeals`, `createDeal`,
 `getDealsByStage`, `getPipelineStats`, …). Module mapping:
@@ -88,20 +88,20 @@ When a new external service needs API access (e.g. another ETL):
 4. Reference in your code via `getIntegrationsAsync()` (see how
    `ESPOCRM_API_KEY` is wired in `src/lib/ssm-config.ts`).
 
-## Drop-in mirror surface (HubSpot → EspoCRM)
+## Drop-in mirror surface (EspoCRM → EspoCRM)
 
 If you find yourself missing a function that existed in the old
 `hubspot.ts`, **don't write a new helper** — check `src/lib/espocrm.ts`
 first. The full list of 21 mirrored exports is at the top of that file.
 The two areas that intentionally diverge:
 
-- **Deal stages**: HubSpot used named pipeline stages
+- **Deal stages**: EspoCRM used named pipeline stages
   (`appointmentscheduled`, `qualifiedtobuy`, `closedwon`). EspoCRM uses
   internal stage IDs (`Stage1`, `Stage2`, …). The mapping table lives at
   the top of `src/lib/espocrm.ts` — extend it if you add a new stage in
   the EspoCRM UI.
 - **`getOwners()`** doesn't exist — EspoCRM has no "owner" concept
-  matching HubSpot's. Use `getUsers()` for the closest analog.
+  matching EspoCRM's. Use `getUsers()` for the closest analog.
 
 ## ETL: EspoCRM → S3 data lake
 
@@ -189,7 +189,7 @@ The `Export Import` extension v2.9.0 is the canonical example, installed
 - `infrastructure/espocrm/README.md` — full deploy + verify runbook
 - `infrastructure/espocrm/k8s/espocrm.yaml` — source of truth
 - `infrastructure/espocrm/cloudflare-tunnel.yaml` — tunnel fragment
-- `src/lib/espocrm.ts` — drop-in HubSpot mirror
+- `src/lib/espocrm.ts` — drop-in EspoCRM mirror
 - `src/app/api/webhooks/espocrm/route.ts` — Slack sync receiver
 - `scripts/etl/espocrm-to-lake.mjs` — daily Athena hydrator
 - `infrastructure/aws/lambdas/ses-espocrm-bridge/` — Inbound Email bridge

--- a/slack-app.manifest.json
+++ b/slack-app.manifest.json
@@ -96,7 +96,7 @@
       {
         "command": "/cloudless-leads",
         "url": "https://cloudless.gr/api/slack/commands",
-        "description": "Recent leads from HubSpot CRM",
+        "description": "Recent leads from EspoCRM CRM",
         "usage_hint": "(no arguments)",
         "should_escape": false
       },

--- a/src/app/[locale]/accessibility/page.tsx
+++ b/src/app/[locale]/accessibility/page.tsx
@@ -103,7 +103,7 @@ export default function AccessibilityPage() {
                 <p>The following known issues are being addressed:</p>
                 <ul className="list-disc space-y-1 pl-5">
                   <li>
-                    Some third-party embedded content (e.g. HubSpot forms) may not fully meet WCAG
+                    Some third-party embedded content (e.g. EspoCRM forms) may not fully meet WCAG
                     2.1 AA — we are working with vendors on remediation
                   </li>
                   <li>

--- a/src/app/[locale]/admin/AdminLayoutClient.tsx
+++ b/src/app/[locale]/admin/AdminLayoutClient.tsx
@@ -64,7 +64,7 @@ const adminGroups: AdminGroup[] = [
     ],
   },
   {
-    label: "HubSpot",
+    label: "EspoCRM",
     links: [
       { href: "/admin/hubspot", label: "Overview", Icon: LayoutGrid },
       { href: "/admin/leads", label: "Lead Inbox", Icon: Inbox },

--- a/src/app/[locale]/admin/analytics/datalake/page.tsx
+++ b/src/app/[locale]/admin/analytics/datalake/page.tsx
@@ -9,7 +9,7 @@
  *   - GSC top keywords (90d rolling window)
  *   - LinkedIn ads campaign rollup (90d)
  *   - Sentry top unresolved issues (14d)
- *   - HubSpot lifecycle funnel
+ *   - EspoCRM lifecycle funnel
  *
  * Fetches all six in parallel from /api/admin/analytics/datalake. Each card
  * renders independently — a section with an error (e.g. ETL hasn't run yet)
@@ -106,7 +106,7 @@ const SECTION_META: Record<
     ],
   },
   hubspot_funnel: {
-    title: "HubSpot lifecycle funnel",
+    title: "EspoCRM lifecycle funnel",
     subtitle:
       "Contact count × closed-won deals + revenue, split by lead_source. Sourced from v_hubspot_funnel.",
     columns: [

--- a/src/app/[locale]/admin/analytics/unified/page.tsx
+++ b/src/app/[locale]/admin/analytics/unified/page.tsx
@@ -140,7 +140,7 @@ function RoiSection({ roi }: Readonly<{ roi: RoiData | null }>) {
         <KpiCard
           label="New leads"
           value={roi.totals.newLeads === null ? "—" : String(roi.totals.newLeads)}
-          sub={roi.totals.newLeads === null ? "HubSpot not configured" : "HubSpot contacts"}
+          sub={roi.totals.newLeads === null ? "EspoCRM not configured" : "EspoCRM contacts"}
           color="text-neon-cyan"
         />
         <KpiCard
@@ -379,7 +379,7 @@ export default function UnifiedAnalyticsPage() {
                 </div>
               </div>
             ) : (
-              <EmptyState label="HubSpot pipeline" />
+              <EmptyState label="EspoCRM pipeline" />
             )}
           </div>
 
@@ -414,7 +414,7 @@ export default function UnifiedAnalyticsPage() {
                 )}
               </div>
             ) : (
-              <EmptyState label="HubSpot email" />
+              <EmptyState label="EspoCRM email" />
             )}
           </div>
         </div>

--- a/src/app/[locale]/admin/crm/companies/page.tsx
+++ b/src/app/[locale]/admin/crm/companies/page.tsx
@@ -30,7 +30,7 @@ export default function AdminCompaniesPage() {
     try {
       const res = await fetchWithAuth("/api/admin/crm/companies?limit=100");
       if (!res.ok) {
-        if (res.status === 503) throw new Error("HubSpot not configured");
+        if (res.status === 503) throw new Error("EspoCRM not configured");
         throw new Error(`HTTP ${res.status}`);
       }
       const data = await res.json();
@@ -88,9 +88,9 @@ export default function AdminCompaniesPage() {
       <div className="bg-void-light/50 rounded-xl border border-red-900/30 p-6 text-center">
         <p className="font-mono text-sm text-red-400">{error}</p>
         <p className="mt-2 text-xs text-slate-500">
-          {error === "HubSpot not configured"
+          {error === "EspoCRM not configured"
             ? "Set HUBSPOT_API_KEY in your environment to enable CRM."
-            : "Check your HubSpot API key configuration."}
+            : "Check your EspoCRM API key configuration."}
         </p>
       </div>
     );
@@ -161,7 +161,7 @@ export default function AdminCompaniesPage() {
             <span className="text-neon-magenta font-mono text-xs">CRM</span>
           </div>
           <h1 className="font-heading text-2xl font-bold text-white">Companies</h1>
-          <p className="font-body mt-1 text-slate-400">Company accounts synced from HubSpot.</p>
+          <p className="font-body mt-1 text-slate-400">Company accounts synced from EspoCRM.</p>
         </div>
         <div className="flex shrink-0 flex-col items-end gap-1">
           <button

--- a/src/app/[locale]/admin/crm/page.tsx
+++ b/src/app/[locale]/admin/crm/page.tsx
@@ -37,7 +37,7 @@ export default function AdminCRMPage() {
     try {
       const res = await fetchWithAuth("/api/admin/crm/contacts?limit=50");
       if (!res.ok) {
-        if (res.status === 503) throw new Error("HubSpot not configured");
+        if (res.status === 503) throw new Error("EspoCRM not configured");
         throw new Error(`HTTP ${res.status}`);
       }
       const data = await res.json();
@@ -76,9 +76,9 @@ export default function AdminCRMPage() {
       <div className="bg-void-light/50 rounded-xl border border-red-900/30 p-6 text-center">
         <p className="font-mono text-sm text-red-400">{error}</p>
         <p className="mt-2 text-xs text-slate-500">
-          {error === "HubSpot not configured"
+          {error === "EspoCRM not configured"
             ? "Set HUBSPOT_API_KEY in your environment to enable CRM."
-            : "Check your HubSpot API key configuration."}
+            : "Check your EspoCRM API key configuration."}
         </p>
       </div>
     );
@@ -156,7 +156,7 @@ export default function AdminCRMPage() {
           <span className="text-neon-magenta font-mono text-xs">CRM</span>
         </div>
         <h1 className="font-heading text-2xl font-bold text-white">CRM Contacts</h1>
-        <p className="font-body mt-1 text-slate-400">Leads and contacts synced from HubSpot.</p>
+        <p className="font-body mt-1 text-slate-400">Leads and contacts synced from EspoCRM.</p>
       </div>
 
       {/* Stats */}

--- a/src/app/[locale]/admin/crm/tickets/page.tsx
+++ b/src/app/[locale]/admin/crm/tickets/page.tsx
@@ -44,7 +44,7 @@ export default function AdminTicketsPage() {
     try {
       const res = await fetchWithAuth("/api/admin/crm/tickets?limit=100");
       if (!res.ok) {
-        if (res.status === 503) throw new Error("HubSpot not configured");
+        if (res.status === 503) throw new Error("EspoCRM not configured");
         throw new Error(`HTTP ${res.status}`);
       }
       const data = await res.json();
@@ -98,9 +98,9 @@ export default function AdminTicketsPage() {
       <div className="bg-void-light/50 rounded-xl border border-red-900/30 p-6 text-center">
         <p className="font-mono text-sm text-red-400">{error}</p>
         <p className="mt-2 text-xs text-slate-500">
-          {error === "HubSpot not configured"
+          {error === "EspoCRM not configured"
             ? "Set HUBSPOT_API_KEY in your environment to enable CRM."
-            : "Check your HubSpot API key configuration."}
+            : "Check your EspoCRM API key configuration."}
         </p>
       </div>
     );
@@ -179,7 +179,7 @@ export default function AdminTicketsPage() {
           </div>
           <h1 className="font-heading text-2xl font-bold text-white">Support Tickets</h1>
           <p className="font-body mt-1 text-slate-400">
-            Customer support tickets synced from HubSpot.
+            Customer support tickets synced from EspoCRM.
           </p>
         </div>
         <div className="flex shrink-0 flex-col items-end gap-1">

--- a/src/app/[locale]/admin/email/campaigns/page.tsx
+++ b/src/app/[locale]/admin/email/campaigns/page.tsx
@@ -23,7 +23,7 @@ export default function EmailCampaignsPage() {
   const [lists, setLists] = useState<ACList[]>([]);
   const [listsConfigured, setListsConfigured] = useState(true);
   const [automations, setAutomations] = useState<ACAutomation[]>([]);
-  // /api/admin/email/campaigns deliberately returns 501 until the HubSpot
+  // /api/admin/email/campaigns deliberately returns 501 until the EspoCRM
   // token gains the Marketing Emails "content" scope — surface that here.
   const [campaignsNotice, setCampaignsNotice] = useState<{
     text: string;
@@ -123,7 +123,7 @@ export default function EmailCampaignsPage() {
                       rel="noopener noreferrer"
                       className="underline hover:text-yellow-100"
                     >
-                      Open HubSpot private-apps →
+                      Open EspoCRM private-apps →
                     </a>
                   )}
                   {campaignsNotice.setupUrl && campaignsNotice.docsUrl && (

--- a/src/app/[locale]/admin/email/page.tsx
+++ b/src/app/[locale]/admin/email/page.tsx
@@ -6,7 +6,7 @@ import { Link } from "@/i18n/navigation";
 
 type Tab = "subscribers" | "contacts";
 
-interface HubSpotContact {
+interface EspoCRMContact {
   id: string;
   properties: {
     email?: string;
@@ -20,7 +20,7 @@ interface HubSpotContact {
 }
 
 interface ContactsResponse {
-  contacts: HubSpotContact[];
+  contacts: EspoCRMContact[];
   total: number;
   fetchedAt: string;
 }
@@ -81,7 +81,7 @@ export default function EmailPage() {
         <PageHeader />
         <div className="rounded-xl border border-yellow-900/30 bg-yellow-950/10 p-6">
           <p className="font-mono text-sm text-yellow-400">
-            HubSpot is not configured. Add <code className="text-yellow-300">HUBSPOT_API_KEY</code>{" "}
+            EspoCRM is not configured. Add <code className="text-yellow-300">HUBSPOT_API_KEY</code>{" "}
             to AWS SSM.
           </p>
         </div>
@@ -106,7 +106,7 @@ export default function EmailPage() {
           </div>
           <div className="h-8 w-px bg-slate-800" />
           <p className="font-mono text-xs text-slate-600">
-            via HubSpot CRM ·{" "}
+            via EspoCRM CRM ·{" "}
             {new Date(data.fetchedAt).toLocaleTimeString("en-IE", {
               hour: "2-digit",
               minute: "2-digit",
@@ -227,7 +227,7 @@ function PageHeader() {
         </Link>
       </div>
       <p className="font-body mt-1 text-slate-400">
-        HubSpot newsletter subscribers and CRM contacts.
+        EspoCRM newsletter subscribers and CRM contacts.
       </p>
     </div>
   );

--- a/src/app/[locale]/admin/leads/page.tsx
+++ b/src/app/[locale]/admin/leads/page.tsx
@@ -94,7 +94,7 @@ export default function AdminLeadsPage() {
         <div>
           <h1 className="font-heading text-2xl font-bold text-white">Lead Inbox</h1>
           <p className="mt-1 text-sm text-slate-400">
-            Unified view of HubSpot contacts and portal enrollment requests.
+            Unified view of EspoCRM contacts and portal enrollment requests.
           </p>
         </div>
         <div className="flex items-center gap-3">

--- a/src/app/[locale]/admin/page.tsx
+++ b/src/app/[locale]/admin/page.tsx
@@ -92,7 +92,7 @@ const NAV_GROUPS: NavGroup[] = [
     cards: [
       card(
         "Lead Inbox",
-        "Unified leads from HubSpot + portal enrollments",
+        "Unified leads from EspoCRM + portal enrollments",
         "📥",
         "/admin/leads",
         (s) => (s.leads === null ? null : `${s.leads} leads`)
@@ -120,7 +120,7 @@ const NAV_GROUPS: NavGroup[] = [
         "📧",
         "/admin/email/campaigns"
       ),
-      card("Pipeline", "HubSpot deals by stage", "🔀", "/admin/pipeline"),
+      card("Pipeline", "EspoCRM deals by stage", "🔀", "/admin/pipeline"),
     ],
   },
   {
@@ -138,7 +138,7 @@ const NAV_GROUPS: NavGroup[] = [
         s.orders === null ? null : `${s.orders} orders · €${(s.revenue ?? 0).toFixed(0)}`
       ),
       card("Subscriptions", "Recurring plans and MRR", "🔁", "/admin/subscriptions"),
-      card("CRM", "HubSpot contacts, companies, tickets", "◉", "/admin/crm"),
+      card("CRM", "EspoCRM contacts, companies, tickets", "◉", "/admin/crm"),
     ],
   },
   {

--- a/src/app/[locale]/admin/pipeline/page.tsx
+++ b/src/app/[locale]/admin/pipeline/page.tsx
@@ -103,7 +103,7 @@ export default function PipelinePage() {
           <span className="text-neon-cyan font-mono text-xs">PIPELINE</span>
         </div>
         <h1 className="font-heading text-2xl font-bold text-white">Lead Pipeline</h1>
-        <p className="font-body mt-1 text-slate-400">HubSpot deal pipeline kanban board.</p>
+        <p className="font-body mt-1 text-slate-400">EspoCRM deal pipeline kanban board.</p>
       </div>
 
       {stats && (

--- a/src/app/[locale]/admin/reports/page.tsx
+++ b/src/app/[locale]/admin/reports/page.tsx
@@ -6,8 +6,8 @@ import { Link } from "@/i18n/navigation";
 import type { Report } from "@/lib/reports";
 
 const SECTION_OPTIONS = [
-  { id: "pipeline", label: "Lead Pipeline (HubSpot)" },
-  { id: "email", label: "Email Marketing (HubSpot)" },
+  { id: "pipeline", label: "Lead Pipeline (EspoCRM)" },
+  { id: "email", label: "Email Marketing (EspoCRM)" },
 ];
 
 export default function ReportsPage() {

--- a/src/app/api/admin/analytics/roi/route.ts
+++ b/src/app/api/admin/analytics/roi/route.ts
@@ -3,7 +3,7 @@ import { requireAdmin } from "@/lib/api-auth";
 import { buildRoiSummary } from "@/lib/roi";
 
 /**
- * ROI summary — ad spend (all platforms) → leads (HubSpot) → revenue (Stripe).
+ * ROI summary — ad spend (all platforms) → leads (EspoCRM) → revenue (Stripe).
  * Partial data is expected: unconfigured sources return zeros/nulls instead
  * of failing the summary, so this route never 503s.
  */

--- a/src/app/api/admin/analytics/unified/route.ts
+++ b/src/app/api/admin/analytics/unified/route.ts
@@ -3,7 +3,7 @@ import { requireAdmin } from "@/lib/api-auth";
 import { getConfig } from "@/lib/ssm-config";
 import { getSeoSnapshot } from "@/lib/gsc";
 import { readThrough } from "@/lib/gsc-cache";
-import { isHubSpotConfigured, getPipelineStats, listNewsletterSubscribers } from "@/lib/espocrm";
+import { isEspoCRMConfigured, getPipelineStats, listNewsletterSubscribers } from "@/lib/espocrm";
 import { getStripe } from "@/lib/stripe";
 
 async function safeCall<T>(fn: () => Promise<T>): Promise<T | null> {
@@ -38,11 +38,11 @@ export async function GET(request: NextRequest) {
         )
       : Promise.resolve(null),
 
-    (await isHubSpotConfigured())
+    (await isEspoCRMConfigured())
       ? safeCall(() => getPipelineStats())
       : Promise.resolve(null),
 
-    (await isHubSpotConfigured())
+    (await isEspoCRMConfigured())
       ? safeCall(async () => {
           const subscribers = await listNewsletterSubscribers();
           return { totalContacts: subscribers.length, totalCampaigns: 0 };

--- a/src/app/api/admin/crm/companies/route.ts
+++ b/src/app/api/admin/crm/companies/route.ts
@@ -1,15 +1,15 @@
 import { NextRequest } from "next/server";
 import { requireAdmin } from "@/lib/api-auth";
 import { NextResponse } from "next/server";
-import { isHubSpotConfigured, listCompanies } from "@/lib/espocrm";
+import { isEspoCRMConfigured, listCompanies } from "@/lib/espocrm";
 import { mapIntegrationError } from "@/lib/api-errors";
 
 export async function GET(request: NextRequest) {
   const auth = await requireAdmin(request);
   if (!auth.ok) return auth.response;
 
-  if (!(await isHubSpotConfigured())) {
-    return NextResponse.json({ error: "HubSpot not configured." }, { status: 503 });
+  if (!(await isEspoCRMConfigured())) {
+    return NextResponse.json({ error: "EspoCRM not configured." }, { status: 503 });
   }
 
   try {
@@ -29,7 +29,7 @@ export async function GET(request: NextRequest) {
   } catch (err) {
     const _r = mapIntegrationError(err);
     if (_r) return _r;
-    console.error("[HubSpot] Error listing companies:", err);
+    console.error("[EspoCRM] Error listing companies:", err);
     return NextResponse.json({ error: "Failed to fetch companies." }, { status: 500 });
   }
 }

--- a/src/app/api/admin/crm/contacts/route.ts
+++ b/src/app/api/admin/crm/contacts/route.ts
@@ -9,7 +9,7 @@ export async function GET(request: NextRequest) {
   const auth = await requireAdmin(request);
   if (!auth.ok) return auth.response;
   if (!(await isConfiguredAsync("ESPOCRM_API_KEY"))) {
-    return NextResponse.json({ error: "HubSpot not configured." }, { status: 503 });
+    return NextResponse.json({ error: "EspoCRM not configured." }, { status: 503 });
   }
 
   try {
@@ -26,7 +26,7 @@ export async function GET(request: NextRequest) {
   } catch (err) {
     const _r = mapIntegrationError(err);
     if (_r) return _r;
-    console.error("[HubSpot] Error listing contacts:", err);
+    console.error("[EspoCRM] Error listing contacts:", err);
     return NextResponse.json({ error: "Failed to fetch contacts." }, { status: 500 });
   }
 }

--- a/src/app/api/admin/crm/deals/route.ts
+++ b/src/app/api/admin/crm/deals/route.ts
@@ -1,15 +1,15 @@
 import { NextRequest } from "next/server";
 import { requireAdmin } from "@/lib/api-auth";
 import { NextResponse } from "next/server";
-import { isHubSpotConfigured, listDeals } from "@/lib/espocrm";
+import { isEspoCRMConfigured, listDeals } from "@/lib/espocrm";
 import { mapIntegrationError } from "@/lib/api-errors";
 
 export async function GET(request: NextRequest) {
   const auth = await requireAdmin(request);
   if (!auth.ok) return auth.response;
 
-  if (!(await isHubSpotConfigured())) {
-    return NextResponse.json({ error: "HubSpot not configured." }, { status: 503 });
+  if (!(await isEspoCRMConfigured())) {
+    return NextResponse.json({ error: "EspoCRM not configured." }, { status: 503 });
   }
 
   try {
@@ -29,7 +29,7 @@ export async function GET(request: NextRequest) {
   } catch (err) {
     const _r = mapIntegrationError(err);
     if (_r) return _r;
-    console.error("[HubSpot] Error listing deals:", err);
+    console.error("[EspoCRM] Error listing deals:", err);
     return NextResponse.json({ error: "Failed to fetch deals." }, { status: 500 });
   }
 }

--- a/src/app/api/admin/crm/owners/route.ts
+++ b/src/app/api/admin/crm/owners/route.ts
@@ -1,15 +1,15 @@
 import { NextRequest } from "next/server";
 import { requireAdmin } from "@/lib/api-auth";
 import { NextResponse } from "next/server";
-import { isHubSpotConfigured, listOwners } from "@/lib/espocrm";
+import { isEspoCRMConfigured, listOwners } from "@/lib/espocrm";
 import { mapIntegrationError } from "@/lib/api-errors";
 
 export async function GET(request: NextRequest) {
   const auth = await requireAdmin(request);
   if (!auth.ok) return auth.response;
 
-  if (!(await isHubSpotConfigured())) {
-    return NextResponse.json({ error: "HubSpot not configured." }, { status: 503 });
+  if (!(await isEspoCRMConfigured())) {
+    return NextResponse.json({ error: "EspoCRM not configured." }, { status: 503 });
   }
 
   try {
@@ -23,7 +23,7 @@ export async function GET(request: NextRequest) {
   } catch (err) {
     const _r = mapIntegrationError(err);
     if (_r) return _r;
-    console.error("[HubSpot] Error listing owners:", err);
+    console.error("[EspoCRM] Error listing owners:", err);
     return NextResponse.json({ error: "Failed to fetch owners." }, { status: 500 });
   }
 }

--- a/src/app/api/admin/crm/pipelines/route.ts
+++ b/src/app/api/admin/crm/pipelines/route.ts
@@ -1,15 +1,15 @@
 import { NextRequest } from "next/server";
 import { requireAdmin } from "@/lib/api-auth";
 import { NextResponse } from "next/server";
-import { getPipelines, isHubSpotConfigured } from "@/lib/espocrm";
+import { getPipelines, isEspoCRMConfigured } from "@/lib/espocrm";
 import { mapIntegrationError } from "@/lib/api-errors";
 
 export async function GET(request: NextRequest) {
   const auth = await requireAdmin(request);
   if (!auth.ok) return auth.response;
 
-  if (!(await isHubSpotConfigured())) {
-    return NextResponse.json({ error: "HubSpot not configured." }, { status: 503 });
+  if (!(await isEspoCRMConfigured())) {
+    return NextResponse.json({ error: "EspoCRM not configured." }, { status: 503 });
   }
 
   try {
@@ -27,7 +27,7 @@ export async function GET(request: NextRequest) {
   } catch (err) {
     const _r = mapIntegrationError(err);
     if (_r) return _r;
-    console.error("[HubSpot] Error fetching pipelines:", err);
+    console.error("[EspoCRM] Error fetching pipelines:", err);
     return NextResponse.json({ error: "Failed to fetch pipelines." }, { status: 500 });
   }
 }

--- a/src/app/api/admin/crm/tickets/route.ts
+++ b/src/app/api/admin/crm/tickets/route.ts
@@ -1,15 +1,15 @@
 import { NextRequest } from "next/server";
 import { requireAdmin } from "@/lib/api-auth";
 import { NextResponse } from "next/server";
-import { isHubSpotConfigured, listTickets } from "@/lib/espocrm";
+import { isEspoCRMConfigured, listTickets } from "@/lib/espocrm";
 import { mapIntegrationError } from "@/lib/api-errors";
 
 export async function GET(request: NextRequest) {
   const auth = await requireAdmin(request);
   if (!auth.ok) return auth.response;
 
-  if (!(await isHubSpotConfigured())) {
-    return NextResponse.json({ error: "HubSpot not configured." }, { status: 503 });
+  if (!(await isEspoCRMConfigured())) {
+    return NextResponse.json({ error: "EspoCRM not configured." }, { status: 503 });
   }
 
   try {
@@ -29,7 +29,7 @@ export async function GET(request: NextRequest) {
   } catch (err) {
     const _r = mapIntegrationError(err);
     if (_r) return _r;
-    console.error("[HubSpot] Error listing tickets:", err);
+    console.error("[EspoCRM] Error listing tickets:", err);
     return NextResponse.json({ error: "Failed to fetch tickets." }, { status: 500 });
   }
 }

--- a/src/app/api/admin/email/campaigns/route.ts
+++ b/src/app/api/admin/email/campaigns/route.ts
@@ -2,7 +2,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { requireAdmin } from "@/lib/api-auth";
 
 // Marketing Emails API requires the `content` scope, which is not granted
-// on the current HubSpot private-app token. We return a structured 501 so the
+// on the current EspoCRM private-app token. We return a structured 501 so the
 // /admin/email/campaigns page can render an actionable "Add scope" link
 // instead of a bare status code.
 //
@@ -14,7 +14,7 @@ import { requireAdmin } from "@/lib/api-auth";
 //        --type SecureString --overwrite --value <new-token>
 //   5. Wait <=5min for Lambda SSM cache TTL or recycle the function
 //
-// The integrations dashboard (/admin/integrations) will also flip HubSpot
+// The integrations dashboard (/admin/integrations) will also flip EspoCRM
 // from "degraded — content scope missing" to "configured" automatically.
 export async function GET(request: NextRequest) {
   const auth = await requireAdmin(request);
@@ -27,7 +27,7 @@ export async function GET(request: NextRequest) {
       setupUrl: "https://app.hubspot.com/private-apps",
       docsUrl: "https://developers.hubspot.com/docs/api/marketing/marketing-emails",
       instructions:
-        "Open the HubSpot private-app, add the `content` scope under Marketing, save, then update HUBSPOT_API_KEY in SSM. The /admin/integrations dashboard pings this scope automatically.",
+        "Open the EspoCRM private-app, add the `content` scope under Marketing, save, then update HUBSPOT_API_KEY in SSM. The /admin/integrations dashboard pings this scope automatically.",
     },
     { status: 501 }
   );

--- a/src/app/api/admin/email/contacts/route.ts
+++ b/src/app/api/admin/email/contacts/route.ts
@@ -23,7 +23,7 @@ export async function GET(request: NextRequest) {
   try {
     if (tab === "subscribers") {
       // Newsletter subscribers: EspoCRM Contacts whose leadSource equals
-      // "newsletter_signup" (same string the HubSpot import used, preserved
+      // "newsletter_signup" (same string the EspoCRM import used, preserved
       // by lib/espocrm.ts upsertContact). searchContacts handles the
       // EspoCRM `where[…]` syntax.
       const data = await searchContacts("leadSource", "newsletter_signup");

--- a/src/app/api/admin/email/stats/route.ts
+++ b/src/app/api/admin/email/stats/route.ts
@@ -1,13 +1,13 @@
 import { NextRequest, NextResponse } from "next/server";
 import { requireAdmin } from "@/lib/api-auth";
-import { isHubSpotConfigured, listNewsletterSubscribers } from "@/lib/espocrm";
+import { isEspoCRMConfigured, listNewsletterSubscribers } from "@/lib/espocrm";
 
 export async function GET(request: NextRequest) {
   const auth = await requireAdmin(request);
   if (!auth.ok) return auth.response;
 
-  if (!(await isHubSpotConfigured())) {
-    return NextResponse.json({ error: "HubSpot not configured." }, { status: 503 });
+  if (!(await isEspoCRMConfigured())) {
+    return NextResponse.json({ error: "EspoCRM not configured." }, { status: 503 });
   }
 
   const subscribers = await listNewsletterSubscribers();

--- a/src/app/api/admin/leads/route.ts
+++ b/src/app/api/admin/leads/route.ts
@@ -6,11 +6,11 @@ import { readPendingClients, PLAN_LABELS } from "@/lib/pending-clients";
 import { mapIntegrationError } from "@/lib/api-errors";
 
 /**
- * Unified lead inbox — joins HubSpot contacts with portal enrollment
+ * Unified lead inbox — joins EspoCRM contacts with portal enrollment
  * requests (pending clients) into one email-keyed list, newest first.
  *
- * HubSpot is the primary source; the route still returns portal leads when
- * HubSpot is unconfigured (and 503 only when no source is available).
+ * EspoCRM is the primary source; the route still returns portal leads when
+ * EspoCRM is unconfigured (and 503 only when no source is available).
  */
 
 export interface UnifiedLead {
@@ -20,14 +20,14 @@ export interface UnifiedLead {
   sources: string[];
   /** Plan/service interest, when known. */
   interest?: string;
-  /** HubSpot hs_lead_status, when present. */
+  /** EspoCRM hs_lead_status, when present. */
   status?: string;
   /** Portal enrollment status, when present. */
   portalStatus?: string;
   createdAt?: string;
 }
 
-interface HubSpotContactRecord {
+interface EspoCRMContactRecord {
   id: string;
   properties?: {
     email?: string;
@@ -74,12 +74,12 @@ export async function GET(request: NextRequest) {
     ]);
 
     const contacts =
-      contactsResult.status === "fulfilled" ? (contactsResult.value as HubSpotContactRecord[]) : [];
+      contactsResult.status === "fulfilled" ? (contactsResult.value as EspoCRMContactRecord[]) : [];
     const pending = pendingResult.status === "fulfilled" ? pendingResult.value : [];
 
     if (!hubspotConfigured && pending.length === 0) {
       return NextResponse.json(
-        { error: "No lead source configured (HubSpot key missing, no portal leads)." },
+        { error: "No lead source configured (EspoCRM key missing, no portal leads)." },
         { status: 503 }
       );
     }

--- a/src/app/api/admin/pipeline/board/route.ts
+++ b/src/app/api/admin/pipeline/board/route.ts
@@ -1,14 +1,14 @@
 import { NextRequest, NextResponse } from "next/server";
 import { requireAdmin } from "@/lib/api-auth";
 import { mapIntegrationError } from "@/lib/api-errors";
-import { isHubSpotConfigured, getDealsByStage, getPipelines } from "@/lib/espocrm";
+import { isEspoCRMConfigured, getDealsByStage, getPipelines } from "@/lib/espocrm";
 
 export async function GET(request: NextRequest) {
   const auth = await requireAdmin(request);
   if (!auth.ok) return auth.response;
 
-  if (!(await isHubSpotConfigured())) {
-    return NextResponse.json({ error: "HubSpot not configured." }, { status: 503 });
+  if (!(await isEspoCRMConfigured())) {
+    return NextResponse.json({ error: "EspoCRM not configured." }, { status: 503 });
   }
 
   try {

--- a/src/app/api/admin/pipeline/deals/[id]/move/route.ts
+++ b/src/app/api/admin/pipeline/deals/[id]/move/route.ts
@@ -1,14 +1,14 @@
 import { NextRequest, NextResponse } from "next/server";
 import { requireAdmin } from "@/lib/api-auth";
-import { isHubSpotConfigured, moveDealStage } from "@/lib/espocrm";
+import { isEspoCRMConfigured, moveDealStage } from "@/lib/espocrm";
 import { mapIntegrationError } from "@/lib/api-errors";
 
 export async function POST(request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
   const auth = await requireAdmin(request);
   if (!auth.ok) return auth.response;
 
-  if (!(await isHubSpotConfigured())) {
-    return NextResponse.json({ error: "HubSpot not configured." }, { status: 503 });
+  if (!(await isEspoCRMConfigured())) {
+    return NextResponse.json({ error: "EspoCRM not configured." }, { status: 503 });
   }
 
   const { id } = await params;

--- a/src/app/api/admin/pipeline/deals/[id]/notes/route.ts
+++ b/src/app/api/admin/pipeline/deals/[id]/notes/route.ts
@@ -1,14 +1,14 @@
 import { NextRequest, NextResponse } from "next/server";
 import { requireAdmin } from "@/lib/api-auth";
-import { isHubSpotConfigured, createNote, listNotes } from "@/lib/espocrm";
+import { isEspoCRMConfigured, createNote, listNotes } from "@/lib/espocrm";
 import { mapIntegrationError } from "@/lib/api-errors";
 
 export async function GET(request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
   const auth = await requireAdmin(request);
   if (!auth.ok) return auth.response;
 
-  if (!(await isHubSpotConfigured())) {
-    return NextResponse.json({ error: "HubSpot not configured." }, { status: 503 });
+  if (!(await isEspoCRMConfigured())) {
+    return NextResponse.json({ error: "EspoCRM not configured." }, { status: 503 });
   }
 
   const { id } = await params;
@@ -20,8 +20,8 @@ export async function POST(request: NextRequest, { params }: { params: Promise<{
   const auth = await requireAdmin(request);
   if (!auth.ok) return auth.response;
 
-  if (!(await isHubSpotConfigured())) {
-    return NextResponse.json({ error: "HubSpot not configured." }, { status: 503 });
+  if (!(await isEspoCRMConfigured())) {
+    return NextResponse.json({ error: "EspoCRM not configured." }, { status: 503 });
   }
 
   const { id } = await params;

--- a/src/app/api/admin/pipeline/stats/route.ts
+++ b/src/app/api/admin/pipeline/stats/route.ts
@@ -1,14 +1,14 @@
 import { NextRequest, NextResponse } from "next/server";
 import { requireAdmin } from "@/lib/api-auth";
-import { isHubSpotConfigured, getPipelineStats } from "@/lib/espocrm";
+import { isEspoCRMConfigured, getPipelineStats } from "@/lib/espocrm";
 import { mapIntegrationError } from "@/lib/api-errors";
 
 export async function GET(request: NextRequest) {
   const auth = await requireAdmin(request);
   if (!auth.ok) return auth.response;
 
-  if (!(await isHubSpotConfigured())) {
-    return NextResponse.json({ error: "HubSpot not configured." }, { status: 503 });
+  if (!(await isEspoCRMConfigured())) {
+    return NextResponse.json({ error: "EspoCRM not configured." }, { status: 503 });
   }
 
   try {

--- a/src/app/api/admin/reports/generate/route.ts
+++ b/src/app/api/admin/reports/generate/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { requireAdmin } from "@/lib/api-auth";
 import { createReport, updateReport, type ReportSection } from "@/lib/reports";
-import { isHubSpotConfigured, getPipelineStats } from "@/lib/espocrm";
+import { isEspoCRMConfigured, getPipelineStats } from "@/lib/espocrm";
 import {
   isActiveCampaignConfigured,
   getEmailStats,
@@ -85,7 +85,7 @@ export async function POST(request: NextRequest) {
 
   const sections: ReportSection[] = [];
 
-  if (includeSections.includes("pipeline") && (await isHubSpotConfigured())) {
+  if (includeSections.includes("pipeline") && (await isEspoCRMConfigured())) {
     const pipelineData = await getPipelineStats();
     const insights = anthropicKey
       ? await generateInsights(

--- a/src/app/api/calendar/book/route.ts
+++ b/src/app/api/calendar/book/route.ts
@@ -69,7 +69,7 @@ export async function POST(request: Request) {
       metadata: { start, notes: notes ? String(notes).slice(0, 500) : null },
     });
 
-    // HubSpot: upsert contact + create consultation deal (fire-and-forget)
+    // EspoCRM: upsert contact + create consultation deal (fire-and-forget)
     (async () => {
       try {
         const [firstName, ...rest] = (name as string).trim().split(" ");
@@ -99,7 +99,7 @@ export async function POST(request: Request) {
       } catch (err) {
         const _r = mapIntegrationError(err);
         if (_r) return _r;
-        console.error("[Calendar→HubSpot] Deal creation failed:", err);
+        console.error("[Calendar→EspoCRM] Deal creation failed:", err);
       }
     })();
 

--- a/src/app/api/contact/route.ts
+++ b/src/app/api/contact/route.ts
@@ -82,7 +82,7 @@ export async function POST(request: Request) {
       fromLabel: "Cloudless Contact Form",
     });
 
-    // Map form display strings to HubSpot service_interest dropdown values
+    // Map form display strings to EspoCRM service_interest dropdown values
     const SERVICE_SLUG: Record<string, string> = {
       "Cloud Architecture & Migration": "cloud-architecture",
       "Serverless Development": "serverless",

--- a/src/app/api/crm/contact/route.ts
+++ b/src/app/api/crm/contact/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from "next/server";
-import { isHubSpotConfigured, upsertContact } from "@/lib/espocrm";
+import { isEspoCRMConfigured, upsertContact } from "@/lib/espocrm";
 import { isValidEmail } from "@/lib/validation";
 import { rateLimit, getClientIp } from "@/lib/rate-limit";
 import { mapIntegrationError } from "@/lib/api-errors";
@@ -10,7 +10,7 @@ export async function POST(request: Request) {
   const rl = rateLimit(`crm-contact:${ip}`, 10, 10 * 60_000);
   if (!rl.ok) return rl.response;
 
-  if (!(await isHubSpotConfigured())) {
+  if (!(await isEspoCRMConfigured())) {
     return NextResponse.json({ error: "CRM not configured." }, { status: 503 });
   }
 
@@ -22,7 +22,7 @@ export async function POST(request: Request) {
       return NextResponse.json({ error: "Valid email is required." }, { status: 400 });
     }
 
-    // Sanitize and length-cap all string fields before sending to HubSpot
+    // Sanitize and length-cap all string fields before sending to EspoCRM
     const clean = (v: unknown, max: number): string | undefined =>
       typeof v === "string" ? v.trim().slice(0, max) || undefined : undefined;
 

--- a/src/app/api/cron/owner-digest/route.ts
+++ b/src/app/api/cron/owner-digest/route.ts
@@ -10,7 +10,7 @@ import { isConfiguredAsync } from "@/lib/integrations";
 /**
  * Weekly owner digest (Phase 4) — one Slack message with everything that
  * needs the owner's attention:
- *   - new leads (HubSpot contacts created in the last 7 days)
+ *   - new leads (EspoCRM contacts created in the last 7 days)
  *   - content published/scheduled this week (calendar)
  *   - deliverables awaiting client review
  *   - open payment links
@@ -22,14 +22,14 @@ import { isConfiguredAsync } from "@/lib/integrations";
 
 const WEEK_MS = 7 * 86_400_000;
 
-interface HubSpotContactRecord {
+interface EspoCRMContactRecord {
   properties?: { email?: string; createdate?: string };
 }
 
 async function countNewLeads(sinceIso: string): Promise<number | null> {
   if (!(await isConfiguredAsync("ESPOCRM_API_KEY"))) return null;
   try {
-    const contacts = (await listContacts(100)) as HubSpotContactRecord[];
+    const contacts = (await listContacts(100)) as EspoCRMContactRecord[];
     return contacts.filter((c) => {
       const created = c.properties?.createdate;
       return created !== undefined && created >= sinceIso;
@@ -80,7 +80,7 @@ export async function GET(request: NextRequest) {
     );
 
   const lines: string[] = [
-    `*Leads:* ${newLeads === null ? "HubSpot not configured" : `${newLeads} new in the last 7 days`}`,
+    `*Leads:* ${newLeads === null ? "EspoCRM not configured" : `${newLeads} new in the last 7 days`}`,
     `*Content:* ${published} published, ${scheduled} scheduled this week`,
     `*Deliverables awaiting client review:* ${awaitingReview.length}`,
     ...awaitingReview.slice(0, 10),

--- a/src/app/api/newsletter-slack/events/route.ts
+++ b/src/app/api/newsletter-slack/events/route.ts
@@ -165,7 +165,7 @@ function renderHomeView(userId: string, data: DashboardData): unknown {
   const dateLabel = `<!date^${ts}^{date_short_pretty} at {time}|${new Date().toISOString()}>`;
   const subscriberCell = data.subscribersOk
     ? `*Subscribers*\n${data.subscriberCount}`
-    : `*Subscribers*\n— (HubSpot error)`;
+    : `*Subscribers*\n— (EspoCRM error)`;
 
   // Current week's top draft (most recent by createdAt)
   const sorted = [...data.drafts].sort((a, b) =>

--- a/src/app/api/newsletter/send/route.ts
+++ b/src/app/api/newsletter/send/route.ts
@@ -69,7 +69,7 @@ async function broadcast(
 }
 
 /**
- * Sends a rendered newsletter to every HubSpot newsletter subscriber.
+ * Sends a rendered newsletter to every EspoCRM newsletter subscriber.
  *
  * Called by scripts/publish-and-send-newsletter.ts from the weekly cron.
  * Runs on Lambda, which already holds SES permissions, so no AWS keys are

--- a/src/app/api/slack/commands/route.ts
+++ b/src/app/api/slack/commands/route.ts
@@ -890,7 +890,7 @@ function handleHelp(): Response {
             "• `/cloudless-ads pause|resume` — pause or resume LinkedIn campaign",
             "• `/cloudless-ads budget <EUR>` — set daily budget",
             "• `/cloudless-seo` — GSC top 10 keywords, clicks, impressions, avg position",
-            "• `/cloudless-leads` — recent HubSpot contacts/leads",
+            "• `/cloudless-leads` — recent EspoCRM contacts/leads",
             "• `/cloudless-errors` — top 5 unresolved Sentry errors",
             "• `/cloudless-uptime` — ping all endpoints (site, CloudFront, Pi)",
             "• `/cloudless-subscribers` — newsletter subscriber count + recent signups",

--- a/src/app/api/subscribe/route.ts
+++ b/src/app/api/subscribe/route.ts
@@ -33,9 +33,9 @@ export async function POST(request: Request) {
     // user re-subscribing can receive the welcome email below.
     await removeFromSuppressionList(email);
 
-    // HubSpot is the source of truth for the newsletter contact list.
+    // EspoCRM is the source of truth for the newsletter contact list.
     // setNewsletterStatus swallows its own errors and returns false, so a
-    // HubSpot outage never fails the subscriber; team-notify and Slack
+    // EspoCRM outage never fails the subscriber; team-notify and Slack
     // provide a manual fallback path.
     await setNewsletterStatus(email, "newsletter_signup");
 
@@ -46,7 +46,7 @@ export async function POST(request: Request) {
       <p><strong>Date:</strong> ${new Date().toISOString()}</p>
       <hr />
       <p style="color: #666; font-size: 12px;">
-        Subscriber recorded as a HubSpot contact (lead_source: newsletter_signup).
+        Subscriber recorded as a EspoCRM contact (lead_source: newsletter_signup).
         This notification was sent from the cloudless.gr subscribe form.
       </p>`
     ).catch(() => {});

--- a/src/app/api/unsubscribe/route.ts
+++ b/src/app/api/unsubscribe/route.ts
@@ -32,7 +32,7 @@ export async function POST(request: Request) {
       return Response.json({ error: "Invalid email address." }, { status: 400 });
     }
 
-    // Suppress future SES sends, and flip the HubSpot contact out of the
+    // Suppress future SES sends, and flip the EspoCRM contact out of the
     // newsletter audience so the weekly send no longer targets them.
     const [suppressed, hubspotUpdated] = await Promise.all([
       addToSuppressionList(email),
@@ -45,7 +45,7 @@ export async function POST(request: Request) {
       `<h2>Newsletter unsubscribe</h2>
       <p><strong>Email:</strong> ${escapeHtml(email)}</p>
       <p><strong>SES suppressed:</strong> ${suppressed ? "Yes" : "Failed (manual removal needed)"}</p>
-      <p><strong>HubSpot updated:</strong> ${hubspotUpdated ? "Yes" : "Failed (manual removal needed)"}</p>
+      <p><strong>EspoCRM updated:</strong> ${hubspotUpdated ? "Yes" : "Failed (manual removal needed)"}</p>
       <p><strong>Date:</strong> ${new Date().toISOString()}</p>`
     ).catch(() => {});
     sendUnsubscribeConfirmation(email).catch((err) =>
@@ -98,7 +98,7 @@ export async function GET(request: Request) {
       `<h2>Newsletter unsubscribe (via email link)</h2>
       <p><strong>Email:</strong> ${escapeHtml(email)}</p>
       <p><strong>SES suppressed:</strong> ${suppressed ? "Yes" : "Failed"}</p>
-      <p><strong>HubSpot updated:</strong> ${hubspotUpdated ? "Yes" : "Failed"}</p>
+      <p><strong>EspoCRM updated:</strong> ${hubspotUpdated ? "Yes" : "Failed"}</p>
       <p><strong>Date:</strong> ${new Date().toISOString()}</p>`
     ).catch(() => {});
     sendUnsubscribeConfirmation(email).catch((err) =>

--- a/src/app/api/webhooks/stripe/route.ts
+++ b/src/app/api/webhooks/stripe/route.ts
@@ -41,7 +41,7 @@ function extractUtmFromSession(session: Stripe.Checkout.Session): {
   };
 }
 
-async function syncHubSpotDeal(session: Stripe.Checkout.Session): Promise<void> {
+async function syncEspoCRMDeal(session: Stripe.Checkout.Session): Promise<void> {
   try {
     const amountEur = (session.amount_total ?? 0) / 100;
     const currency = (session.currency ?? "eur").toUpperCase();
@@ -66,8 +66,8 @@ async function syncHubSpotDeal(session: Stripe.Checkout.Session): Promise<void> 
     if (dealId && contactId) {
       await associateDealWithContact(dealId, contactId);
     }
-  } catch (hubspotError) {
-    console.error("[Stripe→HubSpot] Deal creation failed:", hubspotError);
+  } catch (espocrmError) {
+    console.error("[Stripe→EspoCRM] Deal creation failed:", espocrmError);
   }
 }
 
@@ -139,7 +139,7 @@ async function handleCheckoutCompleted(
   });
 
   if (session.customer_email) {
-    syncHubSpotDeal(session).catch(() => {});
+    syncEspoCRMDeal(session).catch(() => {});
   }
 }
 

--- a/src/lib/espocrm.ts
+++ b/src/lib/espocrm.ts
@@ -1,9 +1,9 @@
 /**
  * EspoCRM client. Replaced the deleted src/lib/hubspot.ts on 2026-06-20
- * (HubSpot fully decommissioned). All call-site imports use this module.
+ * (EspoCRM fully decommissioned). All call-site imports use this module.
  *
- * EspoCRM module mapping vs the historical HubSpot equivalents:
- *   HubSpot           EspoCRM
+ * EspoCRM module mapping vs the historical EspoCRM equivalents:
+ *   EspoCRM           EspoCRM
  *   -------           -------
  *   contact           Contact
  *   company           Account
@@ -87,7 +87,7 @@ async function espoListAll<T = unknown>(
 }
 
 /**
- * Map a HubSpot-shaped contact onto EspoCRM Contact fields. EspoCRM stores
+ * Map a EspoCRM-shaped contact onto EspoCRM Contact fields. EspoCRM stores
  * `accountId` not `company` name — we leave company as a free-text custom
  * field (cAccountName) on initial create; an admin can wire it to a real
  * Account record later via Workflow.
@@ -162,7 +162,7 @@ export async function upsertContact(contact: EspoContact): Promise<string | null
 }
 
 /** Fetch every newsletter subscriber email. We treat leadSource=Email as
- *  the subscribed state. Mirrors the HubSpot newsletter_signup convention. */
+ *  the subscribed state. Mirrors the EspoCRM newsletter_signup convention. */
 export async function listNewsletterSubscribers(): Promise<string[]> {
   try {
     const all = await espoListAll<{ emailAddress?: string }>("Contact", {
@@ -254,7 +254,7 @@ interface TicketData {
 }
 
 /**
- * Create a Case. Maps HubSpot ticket-priority strings (LOW/MEDIUM/HIGH/URGENT)
+ * Create a Case. Maps EspoCRM ticket-priority strings (LOW/MEDIUM/HIGH/URGENT)
  * to EspoCRM Case.priority (Low/Normal/High/Urgent).
  */
 export async function createTicket(
@@ -284,7 +284,7 @@ export async function createTicket(
 }
 
 /**
- * Return a single-pipeline shape compatible with HubSpot's getPipelines() so
+ * Return a single-pipeline shape compatible with EspoCRM's getPipelines() so
  * the admin pipeline UI doesn't have to branch on backend. The OSS EspoCRM
  * Opportunity module has one pipeline backed by the `stage` enum.
  */
@@ -345,7 +345,7 @@ export async function listOwners(): Promise<unknown[]> {
 }
 
 /** Search Contacts by an attribute (e.g. emailAddress). Property names map:
- *  HubSpot `email` -> EspoCRM `emailAddress`; firstname/lastname unchanged. */
+ *  EspoCRM `email` -> EspoCRM `emailAddress`; firstname/lastname unchanged. */
 export async function searchContacts(
   propertyName: string,
   value: string
@@ -388,7 +388,7 @@ export async function searchContacts(
   };
 }
 
-export async function isHubSpotConfigured(): Promise<boolean> {
+export async function isEspoCRMConfigured(): Promise<boolean> {
   // Kept name so `lib/hubspot` callers don't break on import-flip. Prefer the
   // new name `isEspoCRMConfigured` in new code.
   return isEspoCRMConfigured();
@@ -502,7 +502,7 @@ export async function countLeadsForCampaign(campaignSlug: string): Promise<numbe
   }
 }
 
-/* ─── Opportunity automation (HubSpot "deal" equivalents) ────────────────── */
+/* ─── Opportunity automation (EspoCRM "deal" equivalents) ────────────────── */
 
 export type DealSource = "stripe_checkout" | "calendar_booking" | "contact_form";
 
@@ -555,7 +555,7 @@ export async function updateDeal(
   data: Partial<Record<string, string>>
 ): Promise<{ id: string } | null> {
   try {
-    // HubSpot uses snake_case property names; EspoCRM uses camelCase. Map the
+    // EspoCRM uses snake_case property names; EspoCRM uses camelCase. Map the
     // common ones; pass anything else through (custom fields use whatever name
     // the operator created them with).
     const mapped: Record<string, unknown> = {};

--- a/src/lib/integrations.ts
+++ b/src/lib/integrations.ts
@@ -65,7 +65,7 @@ export interface IntegrationConfig {
   META_PAGE_ID?: string;
   // AI
   ANTHROPIC_API_KEY?: string;
-  // EspoCRM (HubSpot replacement, self-hosted on omv k3s)
+  // EspoCRM (EspoCRM replacement, self-hosted on omv k3s)
   ESPOCRM_BASE_URL?: string;
   ESPOCRM_API_KEY?: string;
   ESPOCRM_WEBHOOK_SECRET?: string;

--- a/src/lib/integrations/http.ts
+++ b/src/lib/integrations/http.ts
@@ -37,7 +37,7 @@ export interface IntegrationFetchOptions {
   /**
    * If true, do NOT throw on non-ok responses — return the Response object
    * unchanged. Useful for callers that need to read 4xx error bodies in a
-   * domain-specific way (e.g. HubSpot's 409 conflict on upsert).
+   * domain-specific way (e.g. EspoCRM's 409 conflict on upsert).
    */
   passthroughErrors?: boolean;
 }

--- a/src/lib/lead-attribution.ts
+++ b/src/lib/lead-attribution.ts
@@ -9,7 +9,7 @@
  *   2. The contact form reads the stored value via `getStoredAttribution()`
  *      and sends it with the submission payload.
  *   3. `/api/contact` validates it with `sanitizeAttribution()` and forwards
- *      it to HubSpot (contact note), Slack, and Meta CAPI.
+ *      it to EspoCRM (contact note), Slack, and Meta CAPI.
  *
  * `parseAttribution` is a pure function so it can be unit-tested without a
  * browser environment.

--- a/src/lib/roi.ts
+++ b/src/lib/roi.ts
@@ -1,5 +1,5 @@
 /**
- * ROI summary — joins ad spend (all campaign platforms), leads (HubSpot),
+ * ROI summary — joins ad spend (all campaign platforms), leads (EspoCRM),
  * and revenue (Stripe analytics) into one view (Phase 4 of the roadmap).
  *
  * Every source is optional: unconfigured platforms report configured=false
@@ -36,7 +36,7 @@ export interface RoiSummary {
     impressions: number;
     clicks: number;
     platformLeads: number;
-    /** New HubSpot contacts created inside the window (capped at 100). */
+    /** New EspoCRM contacts created inside the window (capped at 100). */
     newLeads: number | null;
     revenueCents: number | null;
     /** Total spend / new leads; null when either side is missing. */
@@ -140,15 +140,15 @@ async function collectMeta(start: string, end: string): Promise<ChannelRoi> {
   return out;
 }
 
-interface HubSpotContactRecord {
+interface EspoCRMContactRecord {
   properties?: { createdate?: string };
 }
 
-/** New HubSpot contacts created since `sinceIso`. Null when HubSpot is unconfigured. */
+/** New EspoCRM contacts created since `sinceIso`. Null when EspoCRM is unconfigured. */
 async function countNewLeads(sinceIso: string): Promise<number | null> {
   if (!(await isConfiguredAsync("ESPOCRM_API_KEY"))) return null;
   try {
-    const contacts = (await listContacts(100)) as HubSpotContactRecord[];
+    const contacts = (await listContacts(100)) as EspoCRMContactRecord[];
     return contacts.filter((c) => {
       const created = c.properties?.createdate;
       return created !== undefined && created >= sinceIso;

--- a/src/lib/services-data.ts
+++ b/src/lib/services-data.ts
@@ -210,7 +210,7 @@ export const getServices = (t: (key: string, fallback: string) => string) => [
       "Next.js + Tailwind, fully responsive",
       "WCAG AA accessible by default",
       "CMS integration (Notion / Sanity / Contentful)",
-      "Analytics + CRM wiring (HubSpot, Meta Pixel)",
+      "Analytics + CRM wiring (EspoCRM, Meta Pixel)",
     ],
     stats: [
       { value: "<2s", label: "Time to Interactive" },

--- a/src/lib/slack-commands-extra.ts
+++ b/src/lib/slack-commands-extra.ts
@@ -7,7 +7,7 @@
  */
 
 import { getSeoSnapshot, getTopKeywords } from "@/lib/gsc";
-import { listContacts, isHubSpotConfigured } from "@/lib/espocrm";
+import { listContacts, isEspoCRMConfigured } from "@/lib/espocrm";
 import { getTopErrors, isSentryConfigured } from "@/lib/sentry";
 import { invalidateCache } from "@/lib/notion-cache";
 import { listNewsletterSubscribers } from "@/lib/espocrm";
@@ -71,18 +71,18 @@ export async function buildSeoBlocks(userId: string): Promise<unknown[]> {
 }
 
 // ---------------------------------------------------------------------------
-// /cloudless-leads — HubSpot recent contacts
+// /cloudless-leads — EspoCRM recent contacts
 // ---------------------------------------------------------------------------
 
 export async function buildLeadsBlocks(userId: string): Promise<unknown[]> {
   try {
-    if (!(await isHubSpotConfigured())) {
+    if (!(await isEspoCRMConfigured())) {
       return [
         {
           type: "section",
           text: {
             type: "mrkdwn",
-            text: ":warning: HubSpot not configured (HUBSPOT_API_KEY missing).",
+            text: ":warning: EspoCRM not configured (HUBSPOT_API_KEY missing).",
           },
         },
       ];
@@ -95,7 +95,7 @@ export async function buildLeadsBlocks(userId: string): Promise<unknown[]> {
           type: "header",
           text: { type: "plain_text", text: ":busts_in_silhouette: Leads", emoji: true },
         },
-        { type: "section", text: { type: "mrkdwn", text: "No contacts found in HubSpot." } },
+        { type: "section", text: { type: "mrkdwn", text: "No contacts found in EspoCRM." } },
       ];
     }
     const rows = results.slice(0, 10).map((c) => {
@@ -112,7 +112,7 @@ export async function buildLeadsBlocks(userId: string): Promise<unknown[]> {
         type: "header",
         text: {
           type: "plain_text",
-          text: ":busts_in_silhouette: Recent Leads (HubSpot)",
+          text: ":busts_in_silhouette: Recent Leads (EspoCRM)",
           emoji: true,
         },
       },
@@ -257,9 +257,9 @@ export async function buildUptimeBlocks(userId: string): Promise<unknown[]> {
 
 export async function buildSubscribersBlocks(userId: string): Promise<unknown[]> {
   try {
-    if (!(await isHubSpotConfigured())) {
+    if (!(await isEspoCRMConfigured())) {
       return [
-        { type: "section", text: { type: "mrkdwn", text: ":warning: HubSpot not configured." } },
+        { type: "section", text: { type: "mrkdwn", text: ":warning: EspoCRM not configured." } },
       ];
     }
     const subs = await listNewsletterSubscribers();

--- a/src/lib/slack-notify.ts
+++ b/src/lib/slack-notify.ts
@@ -561,7 +561,7 @@ export async function slackChatNotify(data: { message: string; ip?: string }): P
   });
 }
 
-/** Notify when a support ticket is created via HubSpot. */
+/** Notify when a support ticket is created via EspoCRM. */
 export async function slackTicketNotify(data: {
   subject: string;
   email?: string;

--- a/src/lib/ssm-config.ts
+++ b/src/lib/ssm-config.ts
@@ -42,7 +42,7 @@ interface AppConfig {
   NEWSLETTER_SLACK_BOT_TOKEN: string;
   NEWSLETTER_SLACK_SIGNING_SECRET: string;
   NEWSLETTER_SLACK_CHANNEL_ID: string;
-  /** EspoCRM (replaced HubSpot 2026-06-20) — base URL of the self-hosted instance. */
+  /** EspoCRM (replaced EspoCRM 2026-06-20) — base URL of the self-hosted instance. */
   ESPOCRM_BASE_URL: string;
   /** EspoCRM API key for the `cloudless-app` API user. */
   ESPOCRM_API_KEY: string;

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -150,7 +150,7 @@ function generateNonce(): string {
  * blanket 'unsafe-inline'. This means:
  *   - Inline scripts without the matching nonce attribute are blocked.
  *   - Scripts loaded by a trusted (nonced) script are implicitly trusted,
- *     so GTM / Stripe / HubSpot child scripts continue to work.
+ *     so GTM / Stripe / EspoCRM child scripts continue to work.
  *   - 'unsafe-eval' is retained for Three.js WebGL shader compilation on
  *     the home page — removing it would require pre-compiling all GLSL.
  *
@@ -162,7 +162,7 @@ function generateNonce(): string {
  *   - Stripe (checkout + redirect)
  *   - Sentry (browser SDK + ingest)
  *   - Meta Pixel (connect.facebook.net)
- *   - HubSpot (forms + tracking)
+ *   - EspoCRM (forms + tracking)
  *   - Google Analytics / GTM
  */
 function buildCSP(nonce: string): string {
@@ -263,7 +263,7 @@ function addSecurityHeaders(response: NextResponse, nonce: string): void {
   //   COOP: same-origin    → popups from any cross-origin opener are isolated
   //   CORP: same-origin    → resources can only be loaded by same-origin pages
   //   COEP: credentialless → loads any subresource without forcing CORP on it,
-  //                          which would otherwise break Stripe + Sentry + HubSpot
+  //                          which would otherwise break Stripe + Sentry + EspoCRM
   //                          scripts that don't set CORP on their CDN responses
   response.headers.set("Cross-Origin-Opener-Policy", "same-origin");
   response.headers.set("Cross-Origin-Resource-Policy", "same-origin");


### PR DESCRIPTION
PR #1043 deleted the HubSpot client lib but 122 files still leaked the brand name in strings, JSDoc, identifiers, and test mock paths. This rewrite cleans them up. Notion intentionally out of scope (still partly active per master-todo Phase B1-B4 plan).