### PR TITLE
hotfix: collapse duplicate isEspoCRMConfigured (broke deploy after #1133)

### DIFF
--- a/src/lib/espocrm.ts
+++ b/src/lib/espocrm.ts
@@ -389,12 +389,8 @@ export async function searchContacts(
 }
 
 export async function isEspoCRMConfigured(): Promise<boolean> {
-  // Kept name so `lib/hubspot` callers don't break on import-flip. Prefer the
-  // new name `isEspoCRMConfigured` in new code.
-  return isEspoCRMConfigured();
-}
-
-export async function isEspoCRMConfigured(): Promise<boolean> {
+  // Single canonical name (PR #1133 collapsed the legacy `isHubSpotConfigured`
+  // alias into this one — both used to coexist, with the alias delegating here).
   try {
     await getEspoConfig();
     return true;


### PR DESCRIPTION
PR #1133 renamed both `isHubSpotConfigured` (alias) and `isEspoCRMConfigured` (real impl) to the same name. TS rejected the duplicate export -> pnpm build failed -> Deploy to Production + Deploy to Pi both failed. Collapsed into one canonical function.