### PR TITLE
fix(omv-ha): cleanup script crictl race + extract script into repo

### DIFF
--- a/infrastructure/omv-ha/README.md
+++ b/infrastructure/omv-ha/README.md
@@ -1,0 +1,80 @@
+# omv-ha host scripts
+
+Tracked-in-git copies of the system-level scripts running on the
+`omv-ha` worker node, so they're versioned + auditable instead of
+"installed once and forgotten."
+
+## `cloudless-cleanup.sh`
+
+Daily disk-cleanup script triggered by
+`/etc/systemd/system/cloudless-cleanup.timer` at 03:45 EEST.
+
+**The systemd unit + timer are NOT in this repo** — they were created
+on the host in 2026-06-16 (see CLAUDE.md "Pi Housekeeping"). Only the
+shell script body lives here so the cleanup logic can be diff'd +
+PR-reviewed like any other code.
+
+### Install / refresh on the node
+
+This is the one-shot operator command (or use a privileged k8s pod
+to do it from CI without SSH — pattern below):
+
+```bash
+ssh tbaltzakis@omv-ha
+sudo curl -fsSL \
+  https://raw.githubusercontent.com/Themis128/cloudless.gr/main/infrastructure/omv-ha/cloudless-cleanup.sh \
+  -o /usr/local/sbin/cloudless-cleanup.sh
+sudo chmod +x /usr/local/sbin/cloudless-cleanup.sh
+sudo systemctl daemon-reload
+# Force one off-schedule run for verification:
+sudo systemctl start cloudless-cleanup.service
+sudo tail -30 /var/log/cloudless-cleanup.log
+```
+
+Or via k8s privileged pod (no SSH needed):
+
+```yaml
+apiVersion: v1
+kind: Pod
+metadata:
+  name: install-cleanup-omvha
+  namespace: omv-ops
+spec:
+  restartPolicy: Never
+  nodeSelector:
+    kubernetes.io/hostname: omv-ha
+  containers:
+    - name: install
+      image: alpine:3.20
+      securityContext:
+        privileged: true
+      command:
+        - /bin/sh
+        - -c
+        - |
+          apk add --no-cache curl >/dev/null
+          curl -fsSL https://raw.githubusercontent.com/Themis128/cloudless.gr/main/infrastructure/omv-ha/cloudless-cleanup.sh \
+            -o /host/usr/local/sbin/cloudless-cleanup.sh
+          chmod +x /host/usr/local/sbin/cloudless-cleanup.sh
+          chroot /host /bin/bash /usr/local/sbin/cloudless-cleanup.sh
+          tail -20 /host/var/log/cloudless-cleanup.log
+      volumeMounts:
+        - name: host
+          mountPath: /host
+  volumes:
+    - name: host
+      hostPath:
+        path: /
+```
+
+### Recent fixes
+
+| Date | Fix |
+|---|---|
+| 2026-06-22 | crictl race: wait up to 30s for `/run/k3s/containerd/containerd.sock` before invoking `k3s crictl rmi`; pass `--runtime-endpoint` explicitly. Previously the bare invocation would fail with "connection refused" if cron beat k3s-agent's socket-bind; cleanup still "completed" because individual steps soft-fail, but the containerd image prune was silently a no-op. |
+
+## See also
+
+- CLAUDE.md "Pi Housekeeping" — the full overview
+- `infrastructure/omv-sdb1/` — the sdb1 capacity probe (sibling daily CronJob)
+- `infrastructure/omv/` — equivalent host scripts for `omv-main` (if/when extracted)

--- a/infrastructure/omv-ha/cloudless-cleanup.sh
+++ b/infrastructure/omv-ha/cloudless-cleanup.sh
@@ -1,0 +1,63 @@
+#!/bin/bash
+# Daily disk cleanup for omv-ha worker node (Pi).
+# Installed 2026-06-16. Patched 2026-06-22 to wait for k3s containerd
+# socket before invoking crictl (cleanup-script race fix).
+#
+# Companion to /etc/systemd/system/cloudless-cleanup.{timer,service}.
+# See CLAUDE.md "Pi Housekeeping" for the operator runbook.
+#
+# Mirrors the omv-main script but skips docker / pnpm / buildx / VS Code
+# (not installed on omv-ha).
+
+set -uo pipefail
+
+LOG="/var/log/cloudless-cleanup.log"
+
+log() { echo "[$(date '+%F %T')] $*" | tee -a "$LOG"; }
+
+log "=== Cleanup start (omv-ha) ==="
+BEFORE_ROOT=$(df --output=avail / | tail -1)
+
+# 1. journalctl — keep only 14 days
+journalctl --vacuum-time=14d 2>&1 | tail -5 | tee -a "$LOG"
+
+# 2. apt cache
+apt-get clean 2>&1 | tee -a "$LOG"
+
+# 3. containerd image prune — k3s-agent uses /run/k3s/containerd/containerd.sock.
+#    CRICTL_SOCK_WAIT: tolerate startup race (cron can fire before k3s-agent
+#    finishes binding the socket). Previously the bare `k3s crictl rmi --prune`
+#    would error with "connection refused" on a flaky day, leaving images to
+#    pile up unnoticed. Now we wait up to 30s for the socket and pass
+#    --runtime-endpoint explicitly so k3s crictl uses the right path.
+CRICTL_SOCK="/run/k3s/containerd/containerd.sock"
+CRICTL_SOCK_WAIT=30
+for i in $(seq 1 $((CRICTL_SOCK_WAIT/5))); do
+  [ -S "$CRICTL_SOCK" ] && break
+  sleep 5
+done
+if command -v k3s >/dev/null && [ -S "$CRICTL_SOCK" ]; then
+  k3s crictl --runtime-endpoint "unix://$CRICTL_SOCK" rmi --prune 2>&1 \
+    | grep -v 'DeadlineExceeded' | tail -5 | tee -a "$LOG" || true
+else
+  log "crictl skipped: socket not ready after ${CRICTL_SOCK_WAIT}s"
+fi
+
+# 4. GitHub Actions runner _work dir — prune leftovers older than 7 days.
+#    The runner cleans most of this between jobs, but cancelled or
+#    OOM-killed jobs leave stale _temp, _diag, _actions caches.
+for runner_dir in /home/tbaltzakis/actions-runner-*/_work; do
+  [ -d "$runner_dir" ] || continue
+  find "$runner_dir/_temp" -mindepth 1 -maxdepth 1 -mtime +7 -exec rm -rf {} + 2>/dev/null || true
+  find "$runner_dir/_actions" -mindepth 2 -maxdepth 2 -type d -mtime +14 -exec rm -rf {} + 2>/dev/null || true
+done
+
+# 5. stale VS Code Server dirs (defensive — keep newest 2 if any exist)
+for d in /home/tbaltzakis/.vscode-server-insiders/cli/servers /home/tbaltzakis/.vscode-server/cli/servers; do
+  [ -d "$d" ] || continue
+  cd "$d" && ls -dt */ 2>/dev/null | tail -n +3 | xargs -r rm -rf 2>&1 | tee -a "$LOG" || true
+done
+
+AFTER_ROOT=$(df --output=avail / | tail -1)
+log "freed on / : $(( (AFTER_ROOT - BEFORE_ROOT) / 1024 )) MB"
+log "=== Cleanup done (omv-ha) ==="


### PR DESCRIPTION
crictl was silently skipped because the cleanup timer raced with k3s-agent socket binding. Now waits up to 30s + passes --runtime-endpoint. Also brings the previously-uncommitted host script into the repo for review.