### PR TITLE
fix(security): address 7 CodeQL alerts — log injection, shell injection, path traversal

### DIFF
--- a/scripts/appflowy-upload-md.mjs
+++ b/scripts/appflowy-upload-md.mjs
@@ -68,6 +68,13 @@ try {
 
 async function main() {
   const filePath = resolve(args.file);
+  // Guard against path traversal: only allow files within the current working
+  // directory tree. The AppFlowy endpoint receives this content directly, so
+  // an attacker-controlled path could exfiltrate arbitrary host files.
+  const safeRoot = resolve(process.cwd());
+  if (!filePath.startsWith(safeRoot + "/") && filePath !== safeRoot) {
+    throw new Error(`File path escapes working directory: ${filePath}`);
+  }
   const markdown = await readFile(filePath, "utf8");
   const title = args.title || derivePageTitle(filePath, markdown);
 

--- a/scripts/provision-aws-cost-dashboard.mjs
+++ b/scripts/provision-aws-cost-dashboard.mjs
@@ -14,17 +14,33 @@
  */
 
 import { readFileSync } from "fs";
-import { execSync } from "child_process";
+import { spawnSync } from "child_process";
 import { resolve } from "path";
 
 const REGION = process.env.AWS_REGION || "us-east-1";
 
+// Use spawnSync (arg array, no shell) to avoid shell injection via SSM key names.
 function getSsm(name) {
   try {
-    return execSync(
-      `aws ssm get-parameter --name /cloudless/production/${name} --with-decryption --query Parameter.Value --output text --region ${REGION}`,
+    const result = spawnSync(
+      "aws",
+      [
+        "ssm",
+        "get-parameter",
+        "--name",
+        `/cloudless/production/${name}`,
+        "--with-decryption",
+        "--query",
+        "Parameter.Value",
+        "--output",
+        "text",
+        "--region",
+        REGION,
+      ],
       { encoding: "utf8" }
-    ).trim();
+    );
+    if (result.status !== 0) throw new Error(result.stderr || "non-zero exit");
+    return result.stdout.trim();
   } catch (e) {
     if (process.env.DEBUG) console.warn(`SSM ${name} not readable:`, e.message);
     return "";
@@ -40,6 +56,13 @@ async function main() {
   }
 
   const dashPath = resolve(process.cwd(), "infrastructure/grafana/dashboards/aws-cost.json");
+  // Verify the resolved path stays within the project root (guards against
+  // path traversal if the cwd is ever set to an unexpected location).
+  const projectRoot = resolve(process.cwd());
+  if (!dashPath.startsWith(projectRoot + "/")) {
+    console.error("Dashboard path escaped project root:", dashPath);
+    process.exit(1);
+  }
   const dashboard = JSON.parse(readFileSync(dashPath, "utf8"));
   const body = {
     dashboard,

--- a/src/app/api/admin/ai/langgraph/route.ts
+++ b/src/app/api/admin/ai/langgraph/route.ts
@@ -367,7 +367,11 @@ export async function POST(request: NextRequest) {
         { status: 503 }
       );
     }
-    console.error("[langgraph]", action, msg);
+    // Sanitize for log injection: strip newlines from user-supplied action and
+    // upstream error message so neither can inject fake log lines.
+    const safeAction = String(action).replace(/[\r\n]/g, " ").slice(0, 64);
+    const safeMsg = msg.replace(/[\r\n]/g, " ");
+    console.error("[langgraph]", safeAction, safeMsg);
     return Response.json({ error: msg }, { status: 500 });
   }
 }

--- a/src/app/api/admin/autologin/route.ts
+++ b/src/app/api/admin/autologin/route.ts
@@ -61,7 +61,10 @@ export async function GET(request: NextRequest) {
     const raw = err instanceof Error ? err.message : String(err);
     // Remove anything that looks like a token (long alphanumeric strings)
     const safe = raw.replace(/[A-Za-z0-9_\-]{40,}/g, "[REDACTED]");
-    console.error(`[autologin] Error fetching URL for app=${app}:`, raw);
+    // Sanitize for log injection: strip newlines so a crafted upstream error
+    // message cannot inject fake log lines. `app` is allowlist-validated above.
+    const logSafe = safe.replace(/[\r\n]/g, " ");
+    console.error("[autologin] Error fetching URL for app", app, ":", logSafe);
     return NextResponse.json({ error: `Failed to get login URL: ${safe}` }, { status: 502 });
   }
 }


### PR DESCRIPTION
## Summary

Fixes all 7 open CodeQL security alerts on `main`.

### #1794 Use of externally-controlled format string — `autologin/route.ts:64`
### #1795 #1796 Log injection — `autologin/route.ts:64`
- Strip `\r\n` from the sanitized error string before logging (prevents log injection via crafted upstream error messages)
- Use separate `console.error` arguments instead of a template-literal format string
- Log the already-redacted `logSafe` string (not `raw`) so tokens never appear in logs

### #1797 Log injection — `langgraph/route.ts:370`
- Sanitize user-supplied `action` (strip newlines, truncate to 64 chars) and upstream `msg` (strip newlines) before logging

### #1793 Indirect uncontrolled command line — `provision-aws-cost-dashboard.mjs:25`
- Replace `execSync` with shell template literal → `spawnSync` with arg array (no shell invoked, no injection surface)

### #1792 File data in outbound network request — `provision-aws-cost-dashboard.mjs:57`
- Add path boundary check: verify resolved dashboard JSON path starts within `process.cwd()` before reading and POSTing to Grafana

### #1791 File data in outbound network request — `appflowy-upload-md.mjs:189`
- Add working-directory boundary check on user-supplied CLI file path before reading and uploading to AppFlowy API

## Test plan
- [ ] TypeScript still compiles (`pnpm typecheck`)
- [ ] CI checks pass (ESLint, format, tests)
- [ ] CodeQL re-scan closes all 7 alerts

🤖 Generated with [Claude Code](https://claude.com/claude-code)