### PR TITLE
fix(security): close CodeQL log-injection alerts #1798-#1800

### DIFF
--- a/scripts/appflowy-upload-md.mjs
+++ b/scripts/appflowy-upload-md.mjs
@@ -186,6 +186,9 @@ async function createPage({ token, workspaceId, parentViewId, title, blocks, vie
     collab_id: viewId, // MUST equal view_id — see weironz/appflowy_mcp importer.py
   };
 
+  // Working-directory boundary check above ensures filePath is within cwd.
+  // Uploading parsed markdown blocks to the configured AppFlowy instance is intentional.
+  // lgtm[js/file-data-in-outbound-request]
   const res = await fetch(`${baseUrl}/api/workspace/${workspaceId}/page-view`, {
     method: "POST",
     headers: {

--- a/scripts/provision-aws-cost-dashboard.mjs
+++ b/scripts/provision-aws-cost-dashboard.mjs
@@ -70,6 +70,9 @@ async function main() {
     message: "Provisioned via scripts/provision-aws-cost-dashboard.mjs (R9)",
   };
 
+  // Path-traversal guard above ensures dashPath is within the project root.
+  // Sending local dashboard JSON to the configured Grafana instance is intentional.
+  // lgtm[js/file-data-in-outbound-request]
   const res = await fetch(`${baseUrl}/api/dashboards/db`, {
     method: "POST",
     headers: {

--- a/src/app/api/admin/ai/langgraph/route.ts
+++ b/src/app/api/admin/ai/langgraph/route.ts
@@ -367,11 +367,9 @@ export async function POST(request: NextRequest) {
         { status: 503 }
       );
     }
-    // Sanitize for log injection: strip newlines from user-supplied action and
-    // upstream error message so neither can inject fake log lines.
-    const safeAction = String(action).replace(/[\r\n]/g, " ").slice(0, 64);
-    const safeMsg = msg.replace(/[\r\n]/g, " ");
-    console.error("[langgraph]", safeAction, safeMsg);
+    // Log only static text — never user-supplied action or upstream error content,
+    // which could contain newlines that inject fake log lines.
+    console.error("[langgraph] action handler threw — check upstream LangGraph server");
     return Response.json({ error: msg }, { status: 500 });
   }
 }

--- a/src/app/api/admin/autologin/route.ts
+++ b/src/app/api/admin/autologin/route.ts
@@ -61,10 +61,9 @@ export async function GET(request: NextRequest) {
     const raw = err instanceof Error ? err.message : String(err);
     // Remove anything that looks like a token (long alphanumeric strings)
     const safe = raw.replace(/[A-Za-z0-9_\-]{40,}/g, "[REDACTED]");
-    // Sanitize for log injection: strip newlines so a crafted upstream error
-    // message cannot inject fake log lines. `app` is allowlist-validated above.
-    const logSafe = safe.replace(/[\r\n]/g, " ");
-    console.error("[autologin] Error fetching URL for app", app, ":", logSafe);
+    // Log only static text + the allowlist-validated app name (never error content)
+    // to prevent log injection via crafted upstream error messages.
+    console.error("[autologin] upstream error for app:", app);
     return NextResponse.json({ error: `Failed to get login URL: ${safe}` }, { status: 502 });
   }
 }


### PR DESCRIPTION
## Summary

Round 2 of CodeQL fixes — our previous `.replace(/[\r\n]/g, " ")` sanitisation wasn't enough because CodeQL tracks taint through regex transforms.

### #1799 #1800 — `autologin/route.ts`
Remove error content from `console.error` entirely. Log only a static string + the allowlist-validated `app` name. The sanitised error is still returned to the client in the JSON response body.

### #1798 — `langgraph/route.ts`
Remove user-supplied `action` and upstream `msg` from `console.error`. Log a static message only.

### #1791 #1792 — file data in outbound request (warnings)
Already dismissed via GitHub API (intentional design: path-traversal guard is in place). Added `lgtm` suppression comments for completeness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)