### PR TITLE
fix: replace AppFlowy search endpoint with folder walk; fix CI

### DIFF
--- a/.github/workflows/notion-docs-sitemap.yml
+++ b/.github/workflows/notion-docs-sitemap.yml
@@ -52,34 +52,28 @@ jobs:
             exit 1
           fi
 
-          # Get all views from the workspace folder
-          VIEWS=$(curl -sS "${BASE}/api/workspace/${WORKSPACE_ID}/folder?depth=2" \
-            -H "Authorization: Bearer ${TOKEN}" \
-            | jq '[.. | objects | select(.name? and .layout? == "Document") | .name]')
+          # Walk the workspace folder tree (depth=5 covers nested spaces).
+          # Pages prefixed "[Docs]" → /docs/*, "[Blog]" → /blog/*.
+          # code -2 means workspace is empty — emit empty arrays and continue.
+          FOLDER_JSON=$(curl -sS "${BASE}/api/workspace/${WORKSPACE_ID}/folder?depth=5" \
+            -H "Authorization: Bearer ${TOKEN}")
 
-          # Convert view names to URL slugs (lowercase, replace spaces with hyphens, strip special chars)
-          slugify() {
-            echo "$1" | tr '[:upper:]' '[:lower:]' | sed 's/ /-/g' | sed 's/[^a-z0-9-]//g' | sed 's/--*/-/g' | sed 's/^-//;s/-$//'
-          }
+          FOLDER_CODE=$(echo "$FOLDER_JSON" | jq -r '.code // 0')
+          if [ "$FOLDER_CODE" != "0" ]; then
+            echo "AppFlowy workspace has no content yet (code=${FOLDER_CODE})"
+            ALL_VIEWS="[]"
+            DOCS_VIEWS="[]"
+            BLOG_VIEWS="[]"
+          else
+            ALL_VIEWS=$(echo "$FOLDER_JSON" \
+              | jq '[.. | objects | select(.name? and .layout? == "Document") | .name]' 2>/dev/null || echo "[]")
+            DOCS_VIEWS=$(echo "$FOLDER_JSON" \
+              | jq '[.. | objects | select(.name? and .layout? == "Document" and (.name | startswith("[Docs]"))) | .name | ltrimstr("[Docs] ")]' 2>/dev/null || echo "[]")
+            BLOG_VIEWS=$(echo "$FOLDER_JSON" \
+              | jq '[.. | objects | select(.name? and .layout? == "Document" and (.name | startswith("[Blog]"))) | .name | ltrimstr("[Blog] ")]' 2>/dev/null || echo "[]")
+          fi
 
-          # Separate docs from blog based on known AppFlowy folder names
-          # Views in the "Internal Docs" / "Knowledge Base" folders → /docs/*
-          # Views in "Blog Posts" / "Blog" folders → /blog/*
-          # Use search to find views in each folder section
-          DOCS_VIEWS=$(curl -sS "${BASE}/api/workspace/${WORKSPACE_ID}/search?query=docs&limit=100" \
-            -H "Authorization: Bearer ${TOKEN}" \
-            | jq -r '[.data[]? | select(.layout == "Document") | .name]' 2>/dev/null || echo "[]")
-
-          BLOG_VIEWS=$(curl -sS "${BASE}/api/workspace/${WORKSPACE_ID}/search?query=blog&limit=100" \
-            -H "Authorization: Bearer ${TOKEN}" \
-            | jq -r '[.data[]? | select(.layout == "Document") | .name]' 2>/dev/null || echo "[]")
-
-          # Fall back to all views if search returns nothing
-          ALL_VIEWS=$(curl -sS "${BASE}/api/workspace/${WORKSPACE_ID}/folder?depth=3" \
-            -H "Authorization: Bearer ${TOKEN}" \
-            | jq '[.. | objects | select(.name? and .layout? == "Document") | .name]' 2>/dev/null || echo "[]")
-
-          DOCS_COUNT=$(echo "$ALL_VIEWS" | jq 'length')
+          DOCS_COUNT=$(echo "$DOCS_VIEWS" | jq 'length')
           BLOG_COUNT=$(echo "$BLOG_VIEWS" | jq 'length')
 
           echo "docs_views<<EOF" >> "$GITHUB_OUTPUT"

--- a/__tests__/publish-and-send-newsletter.test.ts
+++ b/__tests__/publish-and-send-newsletter.test.ts
@@ -224,25 +224,23 @@ describe("renderPlaintext", () => {
 });
 
 // ─────────────────────────────────────────────────────────────────────────────
-// Regression guard for the Notion status-name mismatch that broke 3 weeks of
-// Monday newsletter sends (2026-05-25, 06-01, 06-08).
+// Regression guard for the AppFlowy review-queue convention.
 //
-// The Notion Blog DB's Status property exposes options
-// "Draft" | "In Review" | "Published" | "Archived". The script must filter on
-// "In Review" — "Approved" is a 400 from Notion and breaks the cron. Lock the
-// literal in source so a future rename has to update this test too.
+// Blog posts pending newsletter publication are named "[Review] <title>".
+// The script searches for pages starting with that prefix. Lock the literal
+// in source so a future rename has to update this test too.
 // ─────────────────────────────────────────────────────────────────────────────
 import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
 
-describe("Notion publisher status filter", () => {
+describe("AppFlowy publisher review filter", () => {
   const source = readFileSync(
     resolve(__dirname, "../scripts/publish-and-send-newsletter.ts"),
     "utf8"
   );
 
-  it("filters on the 'In Review' Status option (not 'Approved')", () => {
-    expect(source).toContain('equals: "In Review"');
+  it("searches for pages with the [Review] prefix (not a Notion status)", () => {
+    expect(source).toContain("[Review]");
     expect(source).not.toContain('equals: "Approved"');
   });
 });

--- a/scripts/generate-weekly-article.ts
+++ b/scripts/generate-weekly-article.ts
@@ -118,18 +118,34 @@ async function appflowyLogin(): Promise<{ token: string; workspaceId: string; ba
  * AppFlowy pages don't have typed Category/Date properties.
  * Category is inferred from the page name (first matching keyword wins).
  * Date is the page's last_edited_time.
+ * Returns [] if the workspace is empty (no spaces created yet).
  */
 async function fetchRecentPosts(): Promise<RecentPost[]> {
   const { token, workspaceId, base } = await appflowyLogin();
   const res = await fetch(
-    `${base}/api/workspace/${workspaceId}/search?query=blog&limit=12`,
+    `${base}/api/workspace/${workspaceId}/folder?depth=5`,
     { headers: { Authorization: `Bearer ${token}` } }
   );
-  if (!res.ok) throw new Error(`AppFlowy search failed: ${res.status}`);
-  const data = (await res.json()) as {
-    data: Array<{ view_id: string; name: string; layout: string; created_at: string; last_edited_time: string }>;
-  };
-  return (data.data ?? [])
+  if (!res.ok) throw new Error(`AppFlowy folder fetch failed: ${res.status}`);
+  const data = (await res.json()) as { code?: number; data?: Record<string, unknown> };
+  // code -2 = workspace is empty (no spaces created yet) — treat as no recent posts
+  if (data.code !== 0) {
+    console.log("[generate-weekly-article] AppFlowy workspace has no content yet — starting fresh");
+    return [];
+  }
+
+  // Flatten the nested view tree
+  const views: Array<{ view_id: string; name: string; layout: string; created_at: string; last_edited_time: string }> = [];
+  function walk(node: Record<string, unknown>) {
+    if (node.view_id && node.name) {
+      views.push(node as typeof views[0]);
+    }
+    const children = (node.children as { views?: Record<string, unknown>[] })?.views ?? [];
+    for (const child of children) walk(child);
+  }
+  walk(data.data ?? {});
+
+  return views
     .filter((v) => v.layout === "Document")
     .slice(0, 12)
     .map((v) => {
@@ -494,15 +510,23 @@ async function createDraftPage(
 ): Promise<{ id: string; url: string }> {
   const { token, workspaceId, base } = await appflowyLogin();
 
-  // Get root view to parent the new page under
+  // Get root view to parent the new page under.
+  // If the workspace is empty (code -2), use the workspace_id as the parent —
+  // AppFlowy will create the first space automatically.
   const folderRes = await fetch(
     `${base}/api/workspace/${workspaceId}/folder?depth=1`,
     { headers: { Authorization: `Bearer ${token}` } }
   );
   if (!folderRes.ok) throw new Error(`AppFlowy folder fetch failed: ${folderRes.status}`);
-  const folderData = (await folderRes.json()) as { data: { view_id?: string; views?: Array<{ view_id: string }> } };
-  const parentId = folderData.data?.view_id ?? folderData.data?.views?.[0]?.view_id ?? "";
-  if (!parentId) throw new Error("AppFlowy workspace has no root view");
+  const folderData = (await folderRes.json()) as {
+    code?: number;
+    data?: { view_id?: string; views?: Array<{ view_id: string }> };
+  };
+  // code -2 = empty workspace — fall back to workspace_id as parent
+  const parentId =
+    folderData.code === 0
+      ? (folderData.data?.view_id ?? folderData.data?.views?.[0]?.view_id ?? workspaceId)
+      : workspaceId;
 
   // Convention: "[Review] <title>" queues the page for newsletter publication.
   // "Draft" status means the page name is just the plain title.

--- a/scripts/publish-and-send-newsletter.ts
+++ b/scripts/publish-and-send-newsletter.ts
@@ -83,19 +83,39 @@ interface ApprovedPost {
 }
 
 // AppFlowy pages don't have typed "Status" properties.
-// Blog posts pending review are all Document pages under the "Blog" workspace folder.
-// The name prefix "[Review]" marks posts ready for newsletter publication.
+// Blog posts pending review are named "[Review] <title>" in the workspace.
+// Walk the folder tree and collect all Document pages with that prefix.
 async function fetchApprovedPosts(): Promise<ApprovedPost[]> {
   const base = requireEnv("APPFLOWY_API_URL").replace(/\/$/, "");
   const { token, workspaceId } = await appflowyLogin();
   const res = await fetch(
-    `${base}/api/workspace/${workspaceId}/search?query=Review&limit=50`,
+    `${base}/api/workspace/${workspaceId}/folder?depth=5`,
     { headers: { Authorization: `Bearer ${token}` } }
   );
-  if (!res.ok) throw new Error(`AppFlowy search failed: ${res.status}`);
-  const data = (await res.json()) as { data: Array<{ view_id: string; name: string; layout: string }> };
-  return (data.data ?? [])
-    .filter((v) => v.layout === "Document" && v.name.startsWith("[Review]"))
+  // code -2 = workspace is empty (no spaces created yet) — not an error
+  if (!res.ok) throw new Error(`AppFlowy folder fetch failed: ${res.status}`);
+  const data = (await res.json()) as {
+    code?: number;
+    data?: Record<string, unknown>;
+  };
+  if (data.code !== 0) {
+    console.log("[publish-and-send-newsletter] AppFlowy workspace has no content yet");
+    return [];
+  }
+
+  // Flatten the nested view tree
+  const views: Array<{ view_id: string; name: string; layout: string }> = [];
+  function walk(node: Record<string, unknown>) {
+    if (node.view_id && node.name) {
+      views.push(node as { view_id: string; name: string; layout: string });
+    }
+    const children = (node.children as { views?: Record<string, unknown>[] })?.views ?? [];
+    for (const child of children) walk(child);
+  }
+  walk(data.data ?? {});
+
+  return views
+    .filter((v) => v.layout === "Document" && String(v.name).startsWith("[Review]"))
     .map((v) => {
       const title = v.name.replace(/^\[Review\]\s*/, "").trim();
       return {

--- a/src/app/api/admin/grafana/datasources/route.ts
+++ b/src/app/api/admin/grafana/datasources/route.ts
@@ -17,7 +17,8 @@ import { getConfig } from "@/lib/ssm-config";
 export const dynamic = "force-dynamic";
 export const runtime = "nodejs";
 
-const DEFAULT_PROMETHEUS_URL = "http://kube-prom-stack-kube-prome-prometheus.monitoring.svc.cluster.local:9090";
+const DEFAULT_PROMETHEUS_URL =
+  "http://kube-prom-stack-kube-prome-prometheus.monitoring.svc.cluster.local:9090";
 
 export async function GET(req: NextRequest) {
   const auth = await requireAdmin(req);

--- a/src/app/api/admin/grafana/prometheus/route.ts
+++ b/src/app/api/admin/grafana/prometheus/route.ts
@@ -14,11 +14,7 @@
  */
 import { NextRequest, NextResponse } from "next/server";
 import { requireAdmin } from "@/lib/api-auth";
-import {
-  prometheusQuery,
-  GrafanaNotConfiguredError,
-  GrafanaApiError,
-} from "@/lib/grafana";
+import { prometheusQuery, GrafanaNotConfiguredError, GrafanaApiError } from "@/lib/grafana";
 
 export const dynamic = "force-dynamic";
 export const runtime = "nodejs";

--- a/src/app/api/admin/notion/projects/route.ts
+++ b/src/app/api/admin/notion/projects/route.ts
@@ -111,7 +111,8 @@ export async function PATCH(request: NextRequest) {
   if (!auth.ok) return auth.response;
 
   // AppFlowy doesn't have a status field on pages — acknowledge the call gracefully.
-  return NextResponse.json(
-    { ok: true, note: "Status updates are managed inside AppFlowy directly." }
-  );
+  return NextResponse.json({
+    ok: true,
+    note: "Status updates are managed inside AppFlowy directly.",
+  });
 }

--- a/src/app/api/admin/notion/search/route.ts
+++ b/src/app/api/admin/notion/search/route.ts
@@ -4,7 +4,12 @@
  */
 import { NextRequest, NextResponse } from "next/server";
 import { requireAdmin } from "@/lib/api-auth";
-import { listAllWorkspaces, searchDocuments, listAllUsers, AppFlowyNotConfiguredError } from "@/lib/appflowy";
+import {
+  listAllWorkspaces,
+  searchDocuments,
+  listAllUsers,
+  AppFlowyNotConfiguredError,
+} from "@/lib/appflowy";
 
 export async function GET(request: NextRequest) {
   const auth = await requireAdmin(request);

--- a/src/app/api/admin/notion/tasks/route.ts
+++ b/src/app/api/admin/notion/tasks/route.ts
@@ -17,7 +17,12 @@ import {
 import type { Task, TaskStatus } from "@/lib/notion-projects";
 
 const STATUS_PREFIXES: TaskStatus[] = [
-  "Backlog", "To Do", "In Progress", "In Review", "Done", "Blocked",
+  "Backlog",
+  "To Do",
+  "In Progress",
+  "In Review",
+  "Done",
+  "Blocked",
 ];
 
 function inferStatus(name: string): TaskStatus {
@@ -27,7 +32,12 @@ function inferStatus(name: string): TaskStatus {
   return "To Do";
 }
 
-function viewToTask(v: { view_id: string; name: string; created_at: string; last_edited_time: string }): Task {
+function viewToTask(v: {
+  view_id: string;
+  name: string;
+  created_at: string;
+  last_edited_time: string;
+}): Task {
   return {
     id: v.view_id,
     task: v.name,


### PR DESCRIPTION
## Summary

- AppFlowy Cloud does not expose `/api/workspace/{id}/search` — all three scripts and the sitemap workflow were hitting 404 on every run. Replaced with `/folder?depth=5` which walks the view tree recursively.
- Empty workspaces return `code: -2` from the folder endpoint; scripts now treat that as "no content yet" and return `[]` instead of crashing — both exit 0.
- Sitemap workflow: dropped the broken search-based `DOCS_VIEWS`/`BLOG_VIEWS`; now uses a jq filter on the folder tree for `[Docs]`- and `[Blog]`-prefixed page names.
- `createDraftPage`: falls back to `workspace_id` as parent when folder is empty, rather than throwing "no root view".
- Updated test: `publish-and-send-newsletter.test.ts` was asserting Notion's `equals: "In Review"` literal; now asserts AppFlowy's `[Review]` prefix convention.
- Prettier on 5 route files that had style drift (was failing CI lint).

## Test plan

- [ ] CI passes (unit tests + lint)
- [ ] Re-trigger `Weekly Article Draft` via workflow_dispatch → exits 0 with "workspace has no content yet"
- [ ] Re-trigger `Weekly Newsletter` → exits 0 with "nothing approved"
- [ ] Re-trigger `AppFlowy → Sitemap Sync` → exits 0 with 0 docs/blog entries

🤖 Generated with [Claude Code](https://claude.com/claude-code)