### PR TITLE
fix: use numeric layout=0 for AppFlowy page-view creation

### DIFF
--- a/scripts/generate-weekly-article.ts
+++ b/scripts/generate-weekly-article.ts
@@ -541,7 +541,7 @@ async function createDraftPage(
       headers: { Authorization: `Bearer ${token}`, "Content-Type": "application/json" },
       body: JSON.stringify({
         parent_view_id: parentId,
-        layout: "Document",
+        layout: 0,
         name: pageName,
       }),
     }


### PR DESCRIPTION
## Summary

- AppFlowy's `POST /api/workspace/{id}/page-view` expects `layout` as a `u8` enum, not the string `"Document"` that GET endpoints return
- `Document = 0` per AppFlowy's ViewLayout proto definition
- Weekly Article Draft was failing at page creation: `Json deserialize error: invalid type: string "Document", expected u8`

## Test plan

- [ ] Re-run `Weekly Article Draft` workflow after merge — should create Draft page in AppFlowy and exit 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)