### PR TITLE
fix(ci): add workflow_dispatch + retrigger grafana tunnel fix

### DIFF
--- a/.github/workflows/fix-selfhosted-tunnels.yml
+++ b/.github/workflows/fix-selfhosted-tunnels.yml
@@ -4,6 +4,7 @@ on:
   push:
     paths:
       - '.github/workflows/fix-selfhosted-tunnels.yml'
+  workflow_dispatch:
 
 jobs:
   fix-tunnels:


### PR DESCRIPTION
Adds `workflow_dispatch` so the tunnel-fix workflow can be re-run manually without needing a file change. This commit also retriggers the workflow on the branch (and via merge on main) so the state-machine Grafana patch actually executes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)