### PR TITLE
fix(monitoring): use kubectl patch for Grafana NodePort (Helm fails)

### DIFF
--- a/.github/workflows/grafana-nodeport-upgrade.yml
+++ b/.github/workflows/grafana-nodeport-upgrade.yml
@@ -31,28 +31,30 @@ jobs:
         with:
           authkey: ${{ secrets.TS_AUTHKEY }}
 
-      - name: Configure kubectl + Helm
+      - name: Configure kubectl
         run: |
           mkdir -p ~/.kube
           echo "${{ secrets.KUBECONFIG_B64 }}" | base64 -d > ~/.kube/config
           chmod 600 ~/.kube/config
           kubectl version --client
-          curl -fsSL https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | bash -s -- --version v3.17.0 2>&1 | tail -3
-          helm version --short
 
-      - name: Add prometheus-community Helm repo
+      - name: Patch Grafana service to NodePort 30850
         run: |
-          helm repo add prometheus-community https://prometheus-community.github.io/helm-charts
-          helm repo update
-
-      - name: Upgrade kube-prometheus-stack (expose Grafana NodePort 30850)
-        run: |
-          helm upgrade kube-prom prometheus-community/kube-prometheus-stack \
-            --namespace monitoring \
-            --values infrastructure/monitoring/kube-prom-stack-values.yaml \
-            --reuse-values \
-            --timeout 5m \
-            --wait 2>&1 | tee helm-upgrade.log
+          # Helm upgrade fails due to chart template nil-pointer across versions.
+          # Use kubectl patch to update only the Grafana service type — same result,
+          # no template rendering involved.
+          SVC=$(kubectl get svc -n monitoring -l app.kubernetes.io/name=grafana \
+            -o jsonpath='{.items[0].metadata.name}' 2>/dev/null)
+          if [ -z "$SVC" ]; then
+            echo "ERROR: Grafana service not found in monitoring namespace"
+            kubectl get svc -n monitoring
+            exit 1
+          fi
+          echo "Patching service: $SVC"
+          kubectl patch svc -n monitoring "$SVC" \
+            --type=merge \
+            -p '{"spec":{"type":"NodePort","ports":[{"name":"http-web","port":80,"targetPort":3000,"nodePort":30850}]}}' \
+          2>&1 | tee helm-upgrade.log
 
       - name: Verify Grafana NodePort service
         run: |


### PR DESCRIPTION
Helm upgrade fails with nil-pointer error in kube-prometheus-stack chart templates (`kubeletClientCertificateExpiration.warning`). Switched to a direct `kubectl patch svc` to set `type: NodePort` and `nodePort: 30850` — same result without template rendering.

🤖 Generated with [Claude Code](https://claude.com/claude-code)