### PR TITLE
fix(monitoring): use Tailscale IP for Grafana datasource probe

### DIFF
--- a/.github/workflows/grafana-nodeport-upgrade.yml
+++ b/.github/workflows/grafana-nodeport-upgrade.yml
@@ -75,7 +75,8 @@ jobs:
         run: |
           PASS=$(kubectl get secret -n monitoring kube-prom-grafana \
             -o jsonpath='{.data.admin-password}' | base64 -d)
-          BASE="http://192.168.1.128:30850"
+          # Use Tailscale IP — LAN IP 192.168.1.128 is not routable from GH-hosted runners
+          BASE="http://100.113.41.119:30850"
 
           echo "=== Datasources ==="
           curl -su "admin:$PASS" "$BASE/api/datasources" | \


### PR DESCRIPTION
LAN IP 192.168.1.128 is not routable from GH-hosted runners even over Tailscale — use 100.113.41.119 (the Pi's Tailscale IP).

🤖 Generated with [Claude Code](https://claude.com/claude-code)