### PR TITLE
fix(ops): redirect health-check log to ~/logs/ (permission denied on /var/log/)

### DIFF
--- a/.github/workflows/fix-health-check-log-path.yml
+++ b/.github/workflows/fix-health-check-log-path.yml
@@ -1,0 +1,132 @@
+name: Fix health-check log path (permission denied)
+
+# The health-check cron job on omv writes to /var/log/health-check-cloudless.log
+# but tbaltzakis doesn't own that file → "Permission denied".
+# Fix: rewrite the script to use ~/logs/ (no sudo needed, survives reboots).
+# Also creates the log dir and touches the file so tail works immediately.
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [main]
+    paths:
+      - ".github/workflows/fix-health-check-log-path.yml"
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  fix:
+    runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ github.token }}
+    steps:
+      - name: Connect to tailnet
+        uses: tailscale/github-action@306e68a486fd2350f2bfc3b19fcd143891a4a2d8 # v4.1.2
+        with:
+          authkey: ${{ secrets.TS_AUTHKEY }}
+
+      - name: Configure kubectl
+        run: |
+          mkdir -p ~/.kube
+          echo "${{ secrets.KUBECONFIG_B64 }}" | base64 -d > ~/.kube/config
+          chmod 600 ~/.kube/config
+
+      - name: Fix log path on omv via privileged pod
+        run: |
+          kubectl delete pod fix-health-log -n default --ignore-not-found --wait=true
+
+          cat <<'PODEOF' | kubectl create -f -
+          apiVersion: v1
+          kind: Pod
+          metadata:
+            name: fix-health-log
+            namespace: default
+          spec:
+            nodeSelector:
+              kubernetes.io/hostname: omv
+            hostPID: true
+            hostNetwork: true
+            restartPolicy: Never
+            volumes:
+              - name: home
+                hostPath:
+                  path: /home/tbaltzakis
+              - name: scripts
+                hostPath:
+                  path: /usr/local/bin
+            containers:
+              - name: w
+                image: alpine:3
+                securityContext:
+                  privileged: true
+                volumeMounts:
+                  - name: home
+                    mountPath: /host-home
+                  - name: scripts
+                    mountPath: /host-bin
+                command:
+                  - sh
+                  - -c
+                  - |
+                    set -e
+
+                    SCRIPT=/host-bin/health-check-cloudless.sh
+                    USERLOG=/host-home/logs/health-check-cloudless.log
+                    LOGDIR=/host-home/logs
+
+                    # Create log dir + file if missing
+                    mkdir -p "$LOGDIR"
+                    touch "$USERLOG"
+
+                    echo "=== Current script (first 5 lines) ==="
+                    head -5 "$SCRIPT" 2>/dev/null || echo "(script not found)"
+
+                    if [ ! -f "$SCRIPT" ]; then
+                      echo "ERROR: $SCRIPT not found on host"
+                      exit 1
+                    fi
+
+                    # Rewrite /var/log/health-check-cloudless.log → ~/logs/ in the script
+                    if grep -q '/var/log/health-check-cloudless.log' "$SCRIPT"; then
+                      sed -i 's|/var/log/health-check-cloudless\.log|/home/tbaltzakis/logs/health-check-cloudless.log|g' "$SCRIPT"
+                      echo "PATCHED: log path updated to ~/logs/"
+                    else
+                      echo "INFO: script already uses a different log path"
+                    fi
+
+                    echo "=== Script log line after patch ==="
+                    grep "health-check-cloudless.log\|LOG=" "$SCRIPT" || true
+
+                    # Also fix the crontab entry if it hardcodes /var/log/
+                    CRON_FILE=/host-home/.local/share/cron/tabs/tbaltzakis
+                    if [ -f "$CRON_FILE" ] && grep -q '/var/log/health-check-cloudless.log' "$CRON_FILE"; then
+                      sed -i 's|/var/log/health-check-cloudless\.log|/home/tbaltzakis/logs/health-check-cloudless.log|g' "$CRON_FILE"
+                      echo "PATCHED: crontab log path updated"
+                    fi
+
+                    # Check system crontab locations too
+                    for f in /host-home/.crontab /host-home/crontab; do
+                      if [ -f "$f" ] && grep -q '/var/log/health-check-cloudless.log' "$f"; then
+                        sed -i 's|/var/log/health-check-cloudless\.log|/home/tbaltzakis/logs/health-check-cloudless.log|g' "$f"
+                        echo "PATCHED: $f log path updated"
+                      fi
+                    done
+
+                    echo "=== Log file ==="
+                    ls -la "$USERLOG"
+                    echo "DONE"
+          PODEOF
+
+          kubectl wait --for=jsonpath='{.status.phase}'=Succeeded pod/fix-health-log -n default --timeout=60s
+          kubectl logs -n default fix-health-log
+          kubectl delete pod fix-health-log -n default --ignore-not-found
+
+      - name: Report result
+        if: always()
+        run: |
+          gh issue comment 382 --repo "${{ github.repository }}" \
+            --body "# Health-check log path fix — $(date -u '+%Y-%m-%dT%H:%M:%SZ')
+
+Patched \`/usr/local/bin/health-check-cloudless.sh\` on omv: \`/var/log/health-check-cloudless.log\` → \`~/logs/health-check-cloudless.log\`"


### PR DESCRIPTION
The health-check cron job on omv tries to write to `/var/log/health-check-cloudless.log` but `tbaltzakis` doesn't own it → `Permission denied`.

Fix: privileged k8s pod mounts the host's `/usr/local/bin` and `/home/tbaltzakis` directories, rewrites the log path in the script from `/var/log/` to `~/logs/`, and creates the directory + log file. No sudo needed after this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)