### PR TITLE
feat(contact): full contact form info → Slack #leads with EspoCRM deep-link

### DIFF
--- a/src/app/api/contact/route.ts
+++ b/src/app/api/contact/route.ts
@@ -103,33 +103,9 @@ export async function POST(request: Request) {
     const lead = scoreLead({ email, service, company, message: String(message), attribution });
     const attributionSummary = attribution ? formatAttribution(attribution) : undefined;
 
-    Promise.allSettled([
-      slackContactNotify({
-        name,
-        email,
-        phone,
-        company,
-        service,
-        message,
-        leadScore: lead.score,
-        leadBand: `${bandEmoji(lead.band)} ${lead.band}`,
-        attributionSummary,
-      }),
-      recordNotification({
-        category: "contact",
-        type: "info",
-        title: `New contact: ${String(name)}`,
-        message: String(message).slice(0, 500),
-        actor: String(email),
-        route: "/api/contact",
-        metadata: {
-          company: company || null,
-          service: service || null,
-          leadScore: lead.score,
-          leadBand: lead.band,
-        },
-      }),
-      (async () => {
+    // EspoCRM runs first so we have the contact ID for the Slack deep-link.
+    const espoContactId = await (async () => {
+      try {
         const contactId = await upsertContact({
           email,
           firstname: nameParts[0] ?? "",
@@ -151,7 +127,7 @@ export async function POST(request: Request) {
         }
         const dealId = await createDeal({
           dealname: `Lead – ${String(name).slice(0, 80)} (${service || "General"})`,
-          dealstage: "qualifiedtobuy",
+          dealstage: "Prospecting",
           lead_source: "contact_form",
           description: String(message).slice(0, 500),
           service_interest: serviceSlug,
@@ -159,7 +135,40 @@ export async function POST(request: Request) {
         if (dealId && contactId) {
           await associateDealWithContact(dealId, contactId);
         }
-      })(),
+        return contactId;
+      } catch (err) {
+        console.error("[Contact] EspoCRM sync failed:", err);
+        return null;
+      }
+    })();
+
+    Promise.allSettled([
+      slackContactNotify({
+        name,
+        email,
+        phone,
+        company,
+        service,
+        message,
+        leadScore: lead.score,
+        leadBand: `${bandEmoji(lead.band)} ${lead.band}`,
+        attributionSummary,
+        espoContactId,
+      }),
+      recordNotification({
+        category: "contact",
+        type: "info",
+        title: `New contact: ${String(name)}`,
+        message: String(message).slice(0, 500),
+        actor: String(email),
+        route: "/api/contact",
+        metadata: {
+          company: company || null,
+          service: service || null,
+          leadScore: lead.score,
+          leadBand: lead.band,
+        },
+      }),
       saveSubmission({
         name,
         email,
@@ -177,7 +186,7 @@ export async function POST(request: Request) {
       }),
     ])
       .then((results) => {
-        const labels = ["slack", "hubspot", "notion", "activecampaign"];
+        const labels = ["slack", "notification", "notion", "activecampaign"];
         results.forEach((r, i) => {
           if (r.status === "rejected") {
             console.error("[Contact] Background task " + labels[i] + " failed:", r.reason);

--- a/src/lib/slack-notify.ts
+++ b/src/lib/slack-notify.ts
@@ -250,7 +250,7 @@ const bookingsClient = new SlackClient({ channel: "#bookings" });
 const ordersClient = new SlackClient({ channel: "#orders" });
 const errorsClient = new SlackClient({ channel: "#errors" });
 const deploymentsClient = new SlackClient({ channel: "#deployments" });
-const contactsClient = new SlackClient({ channel: "#notifications" });
+const contactsClient = new SlackClient({ channel: "#leads" });
 const subscribersClient = new SlackClient({ channel: "#subscribers" });
 
 /**
@@ -411,6 +411,8 @@ export async function slackContactNotify(data: {
   leadBand?: string;
   /** One-line attribution summary (UTM/referrer/landing page). */
   attributionSummary?: string;
+  /** EspoCRM Contact ID \u2014 used to build a deep-link button. */
+  espoContactId?: string | null;
 }): Promise<boolean> {
   const safeName = slackEscape(data.name);
   const safeEmail = slackEscape(data.email);
@@ -431,15 +433,34 @@ export async function slackContactNotify(data: {
   if (data.attributionSummary) {
     detailLines.push(`*Attribution:* ${slackEscape(data.attributionSummary).slice(0, 500)}`);
   }
+
+  const blocks: BlockKitBlock[] = [
+    headerBlock("\ud83d\udce8 New Contact Form Submission"),
+    sectionBlock(detailLines.join("\n")),
+    divider,
+    sectionBlock(`*Message:*\n${safeMessage}`),
+  ];
+
+  if (data.espoContactId) {
+    const espoUrl = `https://espocrm.cloudless.gr/#Contact/view/${data.espoContactId}`;
+    blocks.push({
+      type: "actions",
+      elements: [
+        {
+          type: "button",
+          text: { type: "plain_text", text: "Open in EspoCRM", emoji: true },
+          url: espoUrl,
+          style: "primary",
+        },
+      ],
+    });
+  }
+
+  blocks.push(contextBlock(slackTimestamp(), "cloudless.gr contact form"));
+
   return contactsClient.post({
     text: `New contact from ${safeName} (${safeEmail})`,
-    blocks: [
-      headerBlock("\ud83d\udce8 New Contact Form Submission"),
-      sectionBlock(detailLines.join("\n")),
-      divider,
-      sectionBlock(`*Message:*\n${safeMessage}`),
-      contextBlock(slackTimestamp(), "cloudless.gr contact form"),
-    ],
+    blocks,
     icon_url: BOT_ICON_URL,
     username: BOT_USERNAME,
   });


### PR DESCRIPTION
## Summary
- Contact form submissions now post to **`#leads`** (was `#notifications`) — same channel as EspoCRM webhook-triggered lead events
- EspoCRM upsert runs before the Slack notification so the `contactId` is available; Slack message gets an **"Open in EspoCRM"** button linking directly to `espocrm.cloudless.gr/#Contact/view/<id>`
- Fixed `dealstage: "qualifiedtobuy"` (a leftover HubSpot value) → `"Prospecting"` (correct EspoCRM Opportunity stage enum)

## Test plan
- [ ] Submit contact form at cloudless.gr/contact
- [ ] Verify Slack `#leads` receives the message with name, email, phone, company, service, message, lead score
- [ ] Verify "Open in EspoCRM" button appears and links to the correct Contact record
- [ ] Verify EspoCRM has a new Contact + Opportunity in Prospecting stage

🤖 Generated with [Claude Code](https://claude.com/claude-code)