### PR TITLE
fix(test): slackContactNotify → #leads, add EspoCRM button test

### DIFF
--- a/__tests__/slack-notify.test.ts
+++ b/__tests__/slack-notify.test.ts
@@ -255,7 +255,7 @@ describe("slack-notify", () => {
   });
 
   describe("slackContactNotify", () => {
-    it("posts to #notifications with name and email", async () => {
+    it("posts to #leads with name and email", async () => {
       getSlackConfigAsyncMock.mockResolvedValueOnce({
         SLACK_BOT_TOKEN: "xoxb-x",
       });
@@ -266,10 +266,27 @@ describe("slack-notify", () => {
         message: "Hello",
       });
       const body = JSON.parse((fetchMock.mock.calls[0][1] as { body: string }).body);
-      expect(body.channel).toBe("#notifications");
+      expect(body.channel).toBe("#leads");
       const rendered = JSON.stringify(body);
       expect(rendered).toContain("Themis");
       expect(rendered).toContain("t@x");
+    });
+
+    it("includes EspoCRM deep-link button when espoContactId is provided", async () => {
+      getSlackConfigAsyncMock.mockResolvedValueOnce({
+        SLACK_BOT_TOKEN: "xoxb-x",
+      });
+      fetchMock.mockResolvedValueOnce(jsonResp({ ok: true }));
+      await slackContactNotify({
+        name: "Themis",
+        email: "t@x",
+        message: "Hello",
+        espoContactId: "abc123",
+      });
+      const body = JSON.parse((fetchMock.mock.calls[0][1] as { body: string }).body);
+      const rendered = JSON.stringify(body);
+      expect(rendered).toContain("espocrm.cloudless.gr/#Contact/view/abc123");
+      expect(rendered).toContain("Open in EspoCRM");
     });
   });
 


### PR DESCRIPTION
Follow-up to #1180: update test expectation from #notifications → #leads and add assertion for the new EspoCRM deep-link button.

🤖 Generated with [Claude Code](https://claude.com/claude-code)