### PR TITLE
fix(test): dealstage expectation qualifiedtobuy → Prospecting

### DIFF
--- a/__tests__/contact-campaign-pipeline.test.ts
+++ b/__tests__/contact-campaign-pipeline.test.ts
@@ -165,7 +165,7 @@ describe("POST /api/contact — campaign tier pipeline", () => {
     expect(mockCreateDeal).toHaveBeenCalledWith(
       expect.objectContaining({
         dealname: expect.stringContaining("Γιώργος Παπαδόπουλος"),
-        dealstage: "qualifiedtobuy",
+        dealstage: "Prospecting",
         lead_source: "contact_form",
         description: expect.stringContaining("E-shop Launch"),
       })


### PR DESCRIPTION
Fixes the remaining test failure after #1180: contact-campaign-pipeline test expected the old HubSpot stage name.

🤖 Generated with [Claude Code](https://claude.com/claude-code)