### PR TITLE
fix(slack): rename channel registry 'contacts' → 'leads'

### DIFF
--- a/src/app/api/slack/commands/route.ts
+++ b/src/app/api/slack/commands/route.ts
@@ -364,7 +364,7 @@ async function handleChannels(payload: SlashCommandPayload): Promise<Response> {
 
     const [channels, bot] = await Promise.all([listChannels(token), getBotInfo(token)]);
 
-    const MANAGED = ["bookings", "orders", "errors", "deployments", "contacts", "subscribers"];
+    const MANAGED = ["bookings", "orders", "errors", "deployments", "leads", "subscribers"];
 
     const rows = MANAGED.map((name) => {
       const ch = channels.find((c) => c.name === name);

--- a/src/lib/slack-admin.ts
+++ b/src/lib/slack-admin.ts
@@ -35,9 +35,9 @@ export const SLACK_CHANNELS = {
     name: "deployments",
     topic: "Deploy events from the cloudless.gr CI pipeline",
   },
-  contacts: {
-    name: "contacts",
-    topic: "Contact form submissions from cloudless.gr",
+  leads: {
+    name: "leads",
+    topic: "Contact form submissions and leads from cloudless.gr",
   },
   subscribers: {
     name: "subscribers",


### PR DESCRIPTION
The Slack channel registry in slack-admin.ts had key 'contacts' pointing to channel '#contacts', but slackContactNotify posts to '#leads'. This caused channel_not_found errors when the /cloudless-channels-setup command ran. Fixed to use 'leads' consistently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)