### PR TITLE
fix(slack): use #contacts channel consistently for contact form

### DIFF
--- a/__tests__/slack-notify.test.ts
+++ b/__tests__/slack-notify.test.ts
@@ -255,7 +255,7 @@ describe("slack-notify", () => {
   });
 
   describe("slackContactNotify", () => {
-    it("posts to #leads with name and email", async () => {
+    it("posts to #contacts with name and email", async () => {
       getSlackConfigAsyncMock.mockResolvedValueOnce({
         SLACK_BOT_TOKEN: "xoxb-x",
       });
@@ -266,7 +266,7 @@ describe("slack-notify", () => {
         message: "Hello",
       });
       const body = JSON.parse((fetchMock.mock.calls[0][1] as { body: string }).body);
-      expect(body.channel).toBe("#leads");
+      expect(body.channel).toBe("#contacts");
       const rendered = JSON.stringify(body);
       expect(rendered).toContain("Themis");
       expect(rendered).toContain("t@x");

--- a/src/app/api/slack/commands/route.ts
+++ b/src/app/api/slack/commands/route.ts
@@ -364,7 +364,7 @@ async function handleChannels(payload: SlashCommandPayload): Promise<Response> {
 
     const [channels, bot] = await Promise.all([listChannels(token), getBotInfo(token)]);
 
-    const MANAGED = ["bookings", "orders", "errors", "deployments", "leads", "subscribers"];
+    const MANAGED = ["bookings", "orders", "errors", "deployments", "contacts", "subscribers"];
 
     const rows = MANAGED.map((name) => {
       const ch = channels.find((c) => c.name === name);

--- a/src/lib/slack-admin.ts
+++ b/src/lib/slack-admin.ts
@@ -35,8 +35,8 @@ export const SLACK_CHANNELS = {
     name: "deployments",
     topic: "Deploy events from the cloudless.gr CI pipeline",
   },
-  leads: {
-    name: "leads",
+  contacts: {
+    name: "contacts",
     topic: "Contact form submissions and leads from cloudless.gr",
   },
   subscribers: {

--- a/src/lib/slack-notify.ts
+++ b/src/lib/slack-notify.ts
@@ -250,7 +250,7 @@ const bookingsClient = new SlackClient({ channel: "#bookings" });
 const ordersClient = new SlackClient({ channel: "#orders" });
 const errorsClient = new SlackClient({ channel: "#errors" });
 const deploymentsClient = new SlackClient({ channel: "#deployments" });
-const contactsClient = new SlackClient({ channel: "#leads" });
+const contactsClient = new SlackClient({ channel: "#contacts" });
 const subscribersClient = new SlackClient({ channel: "#subscribers" });
 
 /**


### PR DESCRIPTION
Corrects the channel name mismatch introduced in prior PRs. No #leads channel exists — the correct channel is #contacts (matching the existing registry). All three places now agree: notifier, admin registry, commands route. Tests updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)