### PR TITLE
feat(slack): #campaigns channel for paid social leads

### DIFF
--- a/__tests__/slack-admin.test.ts
+++ b/__tests__/slack-admin.test.ts
@@ -30,7 +30,7 @@ describe("slack-admin", () => {
   });
 
   describe("SLACK_CHANNELS registry", () => {
-    it("defines the canonical 6 channels", () => {
+    it("defines the canonical 7 channels", () => {
       const keys = Object.keys(SLACK_CHANNELS) as SlackChannelKey[];
       expect(keys).toEqual([
         "bookings",
@@ -38,6 +38,7 @@ describe("slack-admin", () => {
         "errors",
         "deployments",
         "contacts",
+        "campaigns",
         "subscribers",
       ]);
     });

--- a/__tests__/slack/slack-admin.test.ts
+++ b/__tests__/slack/slack-admin.test.ts
@@ -273,7 +273,7 @@ describe("slack-admin.ts", () => {
   });
 
   describe("SLACK_CHANNELS registry", () => {
-    it("defines all 6 required channels", async () => {
+    it("defines all 7 required channels", async () => {
       const { SLACK_CHANNELS } = await import("@/lib/slack-admin");
       const names = Object.values(SLACK_CHANNELS).map((c) => c.name);
       expect(names).toContain("bookings");
@@ -281,6 +281,7 @@ describe("slack-admin.ts", () => {
       expect(names).toContain("errors");
       expect(names).toContain("deployments");
       expect(names).toContain("contacts");
+      expect(names).toContain("campaigns");
       expect(names).toContain("subscribers");
     });
 

--- a/src/app/api/contact/route.ts
+++ b/src/app/api/contact/route.ts
@@ -154,6 +154,7 @@ export async function POST(request: Request) {
         leadBand: `${bandEmoji(lead.band)} ${lead.band}`,
         attributionSummary,
         espoContactId,
+        utmSource: attribution?.utmSource ?? null,
       }),
       recordNotification({
         category: "contact",

--- a/src/app/api/slack/commands/route.ts
+++ b/src/app/api/slack/commands/route.ts
@@ -364,7 +364,7 @@ async function handleChannels(payload: SlashCommandPayload): Promise<Response> {
 
     const [channels, bot] = await Promise.all([listChannels(token), getBotInfo(token)]);
 
-    const MANAGED = ["bookings", "orders", "errors", "deployments", "contacts", "subscribers"];
+    const MANAGED = ["bookings", "orders", "errors", "deployments", "contacts", "subscribers", "campaigns"];
 
     const rows = MANAGED.map((name) => {
       const ch = channels.find((c) => c.name === name);

--- a/src/data/campaigns.ts
+++ b/src/data/campaigns.ts
@@ -150,9 +150,9 @@ export const campaigns: Campaign[] = [
       },
     ],
     notifyChannels: [
-      { channel: "slack", target: "#ads-realtime", level: "event" },
-      { channel: "slack", target: "#ads-realtime", level: "digest" },
-      { channel: "slack", target: "#ads-realtime", level: "anomaly" },
+      { channel: "slack", target: "#campaigns", level: "event" },
+      { channel: "slack", target: "#campaigns", level: "digest" },
+      { channel: "slack", target: "#campaigns", level: "anomaly" },
     ],
     tiers: [
       {

--- a/src/lib/slack-admin.ts
+++ b/src/lib/slack-admin.ts
@@ -39,6 +39,10 @@ export const SLACK_CHANNELS = {
     name: "contacts",
     topic: "Contact form submissions and leads from cloudless.gr",
   },
+  campaigns: {
+    name: "campaigns",
+    topic: "Campaign conversions and ad performance from LinkedIn, Meta, Google, TikTok",
+  },
   subscribers: {
     name: "subscribers",
     topic: "Newsletter subscriber sign-ups from cloudless.gr",

--- a/src/lib/slack-notify.ts
+++ b/src/lib/slack-notify.ts
@@ -251,6 +251,7 @@ const ordersClient = new SlackClient({ channel: "#orders" });
 const errorsClient = new SlackClient({ channel: "#errors" });
 const deploymentsClient = new SlackClient({ channel: "#deployments" });
 const contactsClient = new SlackClient({ channel: "#contacts" });
+const campaignsClient = new SlackClient({ channel: "#campaigns" });
 const subscribersClient = new SlackClient({ channel: "#subscribers" });
 
 /**
@@ -397,6 +398,23 @@ export async function slackDeployNotify(opts: {
   });
 }
 
+/** UTM sources that indicate a paid social/search campaign origin. */
+const CAMPAIGN_UTM_SOURCES = new Set([
+  "linkedin",
+  "linkedin_ads",
+  "linkedin-ads",
+  "meta",
+  "facebook",
+  "instagram",
+  "google",
+  "google-ads",
+  "google_ads",
+  "tiktok",
+  "tiktok-ads",
+  "twitter",
+  "x-ads",
+]);
+
 /** Pre-formatted notification for new contact form submissions */
 export async function slackContactNotify(data: {
   name: string;
@@ -413,6 +431,8 @@ export async function slackContactNotify(data: {
   attributionSummary?: string;
   /** EspoCRM Contact ID \u2014 used to build a deep-link button. */
   espoContactId?: string | null;
+  /** UTM source \u2014 when it's a paid social/search origin, also posts to #campaigns. */
+  utmSource?: string | null;
 }): Promise<boolean> {
   const safeName = slackEscape(data.name);
   const safeEmail = slackEscape(data.email);
@@ -458,12 +478,22 @@ export async function slackContactNotify(data: {
 
   blocks.push(contextBlock(slackTimestamp(), "cloudless.gr contact form"));
 
-  return contactsClient.post({
+  const payload = {
     text: `New contact from ${safeName} (${safeEmail})`,
     blocks,
     icon_url: BOT_ICON_URL,
     username: BOT_USERNAME,
-  });
+  };
+
+  const isCampaignLead = data.utmSource && CAMPAIGN_UTM_SOURCES.has(data.utmSource.toLowerCase());
+
+  const sends: Promise<boolean>[] = [contactsClient.post(payload)];
+  if (isCampaignLead) {
+    sends.push(campaignsClient.post(payload));
+  }
+
+  const results = await Promise.all(sends);
+  return results[0];
 }
 
 /** Pre-formatted notification for a new consultation booking */


### PR DESCRIPTION
## Summary
- Created `#campaigns` Slack channel (ID: C0BD93SAXJ6) via Slack API
- `slackContactNotify` dual-posts to `#campaigns` whenever `utmSource` is a paid social/search platform (linkedin, meta, facebook, instagram, google, tiktok, twitter, x-ads)
- Contact route passes `attribution.utmSource` to the notifier
- Campaign conversion notifications (`campaigns.ts`) moved from `#ads-realtime` → `#campaigns`
- SLACK_CHANNELS registry updated: 6 → 7 channels
- Tests updated

## Result
- LinkedIn campaign visitors who fill in the contact form appear in **both** `#contacts` (always) and `#campaigns` (when UTM source = linkedin)
- Campaign checkout conversions (Stripe) also notify `#campaigns`

🤖 Generated with [Claude Code](https://claude.com/claude-code)