### PR TITLE
feat(skills): n8n-operator + postiz-automation + UTM guard workflow

### DIFF
--- a/infrastructure/n8n/workflows/postiz-utm-guard.json
+++ b/infrastructure/n8n/workflows/postiz-utm-guard.json
@@ -1,0 +1,151 @@
+{
+  "name": "Postiz UTM guard — alert #campaigns on missing UTM",
+  "nodes": [
+    {
+      "parameters": {
+        "httpMethod": "POST",
+        "path": "postiz-published",
+        "options": {
+          "responseMode": "responseNode"
+        }
+      },
+      "name": "Webhook (postiz-published)",
+      "type": "n8n-nodes-base.webhook",
+      "typeVersion": 1,
+      "position": [240, 300],
+      "webhookId": "postiz-published"
+    },
+    {
+      "parameters": {
+        "values": {
+          "string": [
+            {
+              "name": "postUrl",
+              "value": "={{ $json.body.postUrl || $json.body.url || $json.body.link || '' }}"
+            },
+            {
+              "name": "platform",
+              "value": "={{ $json.body.platform || $json.body.integration || 'unknown' }}"
+            },
+            {
+              "name": "scheduledAt",
+              "value": "={{ $json.body.scheduledAt || $json.body.publishedAt || $json.body.date || '' }}"
+            },
+            {
+              "name": "contentSnippet",
+              "value": "={{ ($json.body.content || $json.body.message || '').slice(0, 120) }}"
+            }
+          ]
+        }
+      },
+      "name": "Extract post fields",
+      "type": "n8n-nodes-base.set",
+      "typeVersion": 2,
+      "position": [460, 300]
+    },
+    {
+      "parameters": {
+        "conditions": {
+          "string": [
+            {
+              "value1": "={{ $json.postUrl }}",
+              "operation": "contains",
+              "value2": "utm_source="
+            }
+          ]
+        }
+      },
+      "name": "Has UTM source?",
+      "type": "n8n-nodes-base.if",
+      "typeVersion": 1,
+      "position": [680, 300]
+    },
+    {
+      "parameters": {
+        "respondWith": "json",
+        "responseBody": "{ \"ok\": true, \"note\": \"UTM present — no alert needed\" }"
+      },
+      "name": "Respond OK (UTM present)",
+      "type": "n8n-nodes-base.respondToWebhook",
+      "typeVersion": 1,
+      "position": [900, 200]
+    },
+    {
+      "parameters": {
+        "url": "https://slack.com/api/chat.postMessage",
+        "authentication": "genericCredentialType",
+        "genericAuthType": "httpHeaderAuth",
+        "sendHeaders": true,
+        "headerParameters": {
+          "parameters": [
+            {
+              "name": "Content-Type",
+              "value": "application/json"
+            }
+          ]
+        },
+        "sendBody": true,
+        "bodyContentType": "json",
+        "jsonBody": "={\n  \"channel\": \"#campaigns\",\n  \"text\": \"⚠️ Postiz post published without UTM params\",\n  \"username\": \"Cloudless\",\n  \"icon_url\": \"https://cloudless.gr/icons/icon-512.png\",\n  \"blocks\": [\n    {\n      \"type\": \"header\",\n      \"text\": { \"type\": \"plain_text\", \"text\": \"⚠️ Post published without UTM params\", \"emoji\": true }\n    },\n    {\n      \"type\": \"section\",\n      \"text\": {\n        \"type\": \"mrkdwn\",\n        \"text\": \"*Platform:* {{ $json.platform }}\\n*URL:* {{ $json.postUrl || '(no URL in post)' }}\\n*Scheduled:* {{ $json.scheduledAt }}\\n*Content:* {{ $json.contentSnippet }}...\"\n      }\n    },\n    {\n      \"type\": \"section\",\n      \"text\": {\n        \"type\": \"mrkdwn\",\n        \"text\": \"Add UTM params to your post link:\\n`?utm_source=linkedin&utm_medium=social&utm_campaign=<slug>&utm_content=<variant>`\"\n      }\n    },\n    {\n      \"type\": \"actions\",\n      \"elements\": [\n        {\n          \"type\": \"button\",\n          \"text\": { \"type\": \"plain_text\", \"text\": \"Open Postiz\", \"emoji\": true },\n          \"url\": \"https://postiz.cloudless.gr\",\n          \"style\": \"danger\"\n        }\n      ]\n    }\n  ]\n}",
+        "options": {}
+      },
+      "name": "Alert #campaigns (missing UTM)",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4,
+      "position": [900, 400],
+      "credentials": {
+        "httpHeaderAuth": {
+          "name": "Slack Bot Token"
+        }
+      }
+    },
+    {
+      "parameters": {
+        "respondWith": "json",
+        "responseBody": "{ \"ok\": true, \"note\": \"UTM missing — alert sent to #campaigns\" }"
+      },
+      "name": "Respond OK (alert sent)",
+      "type": "n8n-nodes-base.respondToWebhook",
+      "typeVersion": 1,
+      "position": [1120, 400]
+    }
+  ],
+  "connections": {
+    "Webhook (postiz-published)": {
+      "main": [
+        [
+          { "node": "Extract post fields", "type": "main", "index": 0 }
+        ]
+      ]
+    },
+    "Extract post fields": {
+      "main": [
+        [
+          { "node": "Has UTM source?", "type": "main", "index": 0 }
+        ]
+      ]
+    },
+    "Has UTM source?": {
+      "main": [
+        [
+          { "node": "Respond OK (UTM present)", "type": "main", "index": 0 }
+        ],
+        [
+          { "node": "Alert #campaigns (missing UTM)", "type": "main", "index": 0 }
+        ]
+      ]
+    },
+    "Alert #campaigns (missing UTM)": {
+      "main": [
+        [
+          { "node": "Respond OK (alert sent)", "type": "main", "index": 0 }
+        ]
+      ]
+    }
+  },
+  "active": false,
+  "settings": {
+    "executionOrder": "v1"
+  },
+  "tags": ["postiz", "campaigns", "utm", "slack"]
+}

--- a/skills/n8n-operator/SKILL.md
+++ b/skills/n8n-operator/SKILL.md
@@ -1,0 +1,178 @@
+---
+name: n8n-operator
+description: |
+  Operate the self-hosted n8n workflow automation engine on the cloudless.gr
+  cluster — deploy, manage workflows, wire webhooks, import/export JSON, and
+  connect n8n to EspoCRM, Postiz, Slack, Resend, and AppFlowy. Use whenever
+  the user mentions "n8n", "automation workflow", "webhook trigger", "n8n
+  workflow", "n8n.cloudless.gr", or asks to automate a multi-step process
+  between any two services in the stack.
+---
+
+# n8n — operations skill
+
+n8n is a self-hosted workflow automation engine running on omv-main (Pi 5)
+at `https://n8n.cloudless.gr`. It connects all cloudless.gr services
+without custom code: EspoCRM → Slack, Postiz → UTM attribution, AppFlowy
+→ newsletter, etc.
+
+## Architecture
+
+```
+Cloudflare DNS
+└─ n8n.cloudless.gr (CNAME → cloudflared tunnel)
+   └─ cloudflared on omv-main
+      └─ http://192.168.1.128:30900 → NodePort 30900 → pod 5678
+
+k3s namespace: n8n
+  Deployment: n8n (n8nio/n8n:latest, pinned to omv node)
+  PVC: n8n-data 5Gi (local-path → sda1)
+  Storage: SQLite (single writer, Recreate strategy)
+  RAM: 200Mi request / 768Mi limit (peaks ~350-450Mi at boot during migrations)
+```
+
+## Where things live
+
+| Concern | Path |
+|---|---|
+| k8s manifest | `infrastructure/n8n/k8s.yaml` |
+| Cloudflare tunnel rule | `infrastructure/n8n/cloudflare-tunnel.yaml` |
+| LimitRange (prevents OOM eviction) | `infrastructure/n8n/limitrange.yaml` |
+| Workflow JSON exports | `infrastructure/n8n/workflows/` |
+
+## Common ops
+
+### Deploy / redeploy
+
+```bash
+kubectl apply -f infrastructure/n8n/limitrange.yaml
+kubectl apply -f infrastructure/n8n/k8s.yaml
+kubectl -n n8n rollout status deploy/n8n --timeout=120s
+```
+
+### Tail logs
+
+```bash
+kubectl -n n8n logs deploy/n8n -f --tail=200
+```
+
+Via MCP (Cowork sessions):
+`mcp__cloudless-infra__k3s_get_pod_logs({ namespace: "n8n", deployment: "n8n" })`
+
+### Restart
+
+```bash
+kubectl -n n8n rollout restart deploy/n8n
+kubectl -n n8n rollout status  deploy/n8n --timeout=120s
+```
+
+### Verify n8n is up
+
+```bash
+curl -s https://n8n.cloudless.gr/healthz   # → {"status":"ok"}
+```
+
+## Importing a workflow
+
+1. Open `https://n8n.cloudless.gr` in a browser.
+2. **Workflows → Import from file** → pick the JSON from `infrastructure/n8n/workflows/`.
+3. Activate the workflow (toggle top-right).
+4. Copy the webhook URL shown in the Webhook node — it looks like
+   `https://n8n.cloudless.gr/webhook/<path>`.
+
+To import via API (no UI access):
+
+```bash
+N8N_API_KEY="<from n8n UI → Settings → API → Create API Key>"
+curl -X POST https://n8n.cloudless.gr/api/v1/workflows \
+  -H "X-N8N-API-KEY: $N8N_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d @infrastructure/n8n/workflows/<workflow>.json
+```
+
+## Exporting a workflow
+
+```bash
+curl -H "X-N8N-API-KEY: $N8N_API_KEY" \
+  https://n8n.cloudless.gr/api/v1/workflows | jq
+# Then export a specific one:
+curl -H "X-N8N-API-KEY: $N8N_API_KEY" \
+  https://n8n.cloudless.gr/api/v1/workflows/<id> > infrastructure/n8n/workflows/<name>.json
+```
+
+Always commit exported JSONs to `infrastructure/n8n/workflows/` so they survive
+a pod restart (SQLite PVC is the live store but is not backed up independently).
+
+## Workflows in this repo
+
+| File | Trigger | What it does |
+|------|---------|--------------|
+| `lead-enrich.json` | EspoCRM webhook (Contact created) | Enriches the lead with Clearbit/Hunter, updates EspoCRM fields, posts to `#contacts` |
+| `newsletter-nurture.json` | Webhook `newsletter-nurture` | Adds subscriber to Resend audience, sends welcome email sequence |
+| `postiz-utm-guard.json` | Postiz webhook (post published) | Checks published post URL for UTM params; alerts `#campaigns` if missing |
+| `contact-to-campaigns.json` | Webhook from contact/route.ts | Dual-posts paid-social leads to `#campaigns` with full Block Kit card |
+
+## Connecting to services
+
+### EspoCRM
+
+- Base URL: `https://espocrm.cloudless.gr`
+- Auth: HTTP Header → `X-Api-Key: <ESPOCRM_API_KEY>` (from SSM `/cloudless/production/ESPOCRM_API_KEY`)
+- n8n credential type: **HTTP Header Auth**
+
+### Postiz
+
+- Base URL: `https://postiz.cloudless.gr/api/public/v1`
+- Auth: HTTP Header → `Authorization: <POSTIZ_API_KEY>` (from SSM `/cloudless/production/POSTIZ_API_KEY`)
+- n8n credential type: **HTTP Header Auth**
+
+### Slack
+
+- Auth: Bot token (from SSM `/cloudless/production/SLACK_BOT_TOKEN`)
+- n8n credential type: **Slack OAuth2 API** or **HTTP Header Auth** with `Authorization: Bearer <token>`
+- Use the HTTP Request node pointed at `https://slack.com/api/chat.postMessage` — avoids the n8n Slack
+  credential OAuth dance for a bot token you already have.
+
+### Resend (email)
+
+- Auth: HTTP Header → `Authorization: Bearer <RESEND_API_KEY>`
+- Endpoint: `https://api.resend.com/emails`
+
+### AppFlowy
+
+- Auth: `POST https://appflowy.cloudless.gr/gotrue/token?grant_type=password` with email + password → `access_token`
+- n8n pattern: use a **Set** node to store the token, then HTTP Request nodes with `Authorization: Bearer <token>`
+
+## SSM secret pattern in n8n
+
+n8n does not natively read AWS SSM. Two options:
+
+**Option A (recommended):** Store secrets as n8n credentials (once, manually via UI). n8n encrypts them in SQLite. Reference via the credential selector in HTTP Request nodes.
+
+**Option B:** Use an HTTP Request node to call the AWS SSM Parameter Store API with SigV4 signing. Complex — prefer Option A.
+
+## Webhook security
+
+n8n webhook URLs are public (behind Cloudflare, no auth by default). Add a
+shared secret:
+
+1. In the Webhook node → **Authentication → Header Auth**.
+2. Header name: `X-Webhook-Secret`, value: a random string you store in SSM.
+3. The caller (Postiz, EspoCRM, cloudless.gr) must send that header.
+
+## Known quirks
+
+- **SQLite single-writer**: never run more than one n8n replica. `strategy: Recreate` in the manifest enforces this.
+- **Boot migrations**: n8n runs DB migrations on every start — the first 60s after a restart the UI may return 503. Wait for the healthz endpoint.
+- **Pinned to omv node**: the `nodeSelector: kubernetes.io/hostname: omv` in `k8s.yaml` keeps n8n on the Pi 5. The Pi 4 (omv-ha) only has 1GB RAM — n8n won't start there.
+- **Workflow activation survives restart**: activated workflows are stored in SQLite on the PVC. As long as the PVC is intact, all workflows auto-activate on pod restart.
+
+## Disaster recovery
+
+If the PVC is lost (unlikely — it's on the dedicated SSD), re-import all JSONs from `infrastructure/n8n/workflows/` and re-enter credentials manually. Credentials are not stored in the JSON exports for security reasons.
+
+## Future work (don't do unsolicited)
+
+- Automated credential seeding from SSM on first deploy (init container).
+- Prometheus metrics scrape from `/metrics` (n8n exposes them at port 5678 when `N8N_METRICS=true`).
+- Workflow backup CronJob alongside the existing Postiz backup.

--- a/skills/postiz-automation/SKILL.md
+++ b/skills/postiz-automation/SKILL.md
@@ -1,0 +1,181 @@
+---
+name: postiz-automation
+description: |
+  Wire Postiz (self-hosted social scheduler) to the cloudless.gr automation
+  stack — auto-append UTM parameters to post links, trigger n8n workflows
+  on publish events, track campaign leads through EspoCRM, and notify
+  #campaigns in Slack. Use when the user says "automate Postiz", "UTM on
+  posts", "track LinkedIn campaign", "Postiz → Slack", "Postiz → n8n",
+  or "which campaign drove this lead". Pairs with `n8n-operator` and `postiz`.
+---
+
+# Postiz automation
+
+This skill covers the automation layer that sits **between** Postiz and the
+rest of the cloudless.gr stack. Postiz handles scheduling and publishing;
+this layer handles attribution, CRM sync, and Slack notifications.
+
+## The full pipeline (how a campaign lead flows)
+
+```
+LinkedIn Ad
+  └─ User clicks → cloudless.gr/en/?utm_source=linkedin&utm_campaign=shop_online_founding
+       └─ Contact form filled
+            └─ POST /api/contact
+                 ├─ EspoCRM: upsertContact → createDeal (stage: Prospecting)
+                 ├─ Slack #contacts: full Block Kit card
+                 └─ Slack #campaigns: same card (when utmSource ∈ paid-social set)
+```
+
+## UTM convention for Postiz posts
+
+Every link you share via Postiz **must carry UTM params** for the pipeline to
+route the lead to `#campaigns`. The contact route checks `attribution.utmSource`
+against this set (defined in `src/lib/slack-notify.ts: CAMPAIGN_UTM_SOURCES`):
+
+```
+linkedin | linkedin_ads | linkedin-ads
+meta | facebook | instagram
+google | google-ads | google_ads
+tiktok | tiktok-ads
+twitter | x-ads
+```
+
+**Template URL to use in Postiz posts:**
+
+```
+https://cloudless.gr/en/?utm_source=linkedin&utm_medium=social&utm_campaign=<slug>&utm_content=<variant>
+```
+
+Replace:
+- `<slug>` — your campaign name in snake_case (e.g. `shop_online_founding`)
+- `<variant>` — the creative variant (e.g. `A_EN`, `B_EL`) for A/B tracking
+
+## Postiz webhook → n8n (UTM guard)
+
+The `postiz-utm-guard` n8n workflow (JSON: `infrastructure/n8n/workflows/postiz-utm-guard.json`)
+catches posts published **without** UTM params and fires a `#campaigns` warning.
+
+### How to wire it
+
+1. **Import the workflow** into n8n (see `n8n-operator` skill → Importing a workflow).
+2. **Activate** the workflow — copy its webhook URL:
+   `https://n8n.cloudless.gr/webhook/postiz-published`
+3. **Register the webhook in Postiz:**
+   Postiz UI → Settings → Webhooks → Add → URL = step 2 URL →
+   Event = `Post Published` → Save.
+   *(Postiz v2.11.2 supports this under Settings → Integrations → Webhooks).*
+4. **Test**: schedule a post with a bare URL (no UTM). After it publishes,
+   check `#campaigns` for the warning message.
+
+### What the workflow does
+
+```
+Postiz POST webhook
+  └─ Extract: postUrl, platform, scheduledAt, content snippet
+       └─ Check: does postUrl contain utm_source=?
+            ├─ YES → log only (no alert)
+            └─ NO  → Slack #campaigns: ⚠️ "Post published without UTM params"
+                      + platform, URL, scheduled time
+                      + "Edit post in Postiz" button
+```
+
+## Postiz API — schedule a post from code
+
+The cloudless.gr Next.js app calls Postiz via `src/lib/postiz.ts`.
+To schedule a new post programmatically (e.g. from an n8n workflow or admin action):
+
+```bash
+POSTIZ_API_KEY=$(aws ssm get-parameter --name /cloudless/production/POSTIZ_API_KEY \
+  --with-decryption --query Parameter.Value --output text)
+INTEGRATION_ID="<LinkedIn integration ID from Postiz UI>"
+
+curl -X POST https://postiz.cloudless.gr/api/public/v1/posts \
+  -H "Authorization: $POSTIZ_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "type": "schedule",
+    "date": "2026-07-01T09:00:00.000Z",
+    "shortLink": false,
+    "tags": ["campaign", "linkedin"],
+    "posts": [{
+      "integration": { "id": "'"$INTEGRATION_ID"'" },
+      "value": [{
+        "content": "Your post text here.\n\nhttps://cloudless.gr/en/?utm_source=linkedin&utm_medium=social&utm_campaign=shop_online_founding&utm_content=A_EN",
+        "image": []
+      }],
+      "settings": { "__type": "linkedin" }
+    }]
+  }'
+```
+
+**Always include `image: []`** — Postiz v2.11.2 rejects bodies without it.
+
+## Postiz → EspoCRM campaign attribution
+
+When a lead arrives via a Postiz-driven campaign post, the EspoCRM deal
+records the attribution automatically through the contact form pipeline:
+
+- `lead_source`: `"contact_form"`
+- `description`: includes the attribution summary (utm_source, utm_campaign, landing page)
+- EspoCRM deal stage: `"Prospecting"`
+
+To add campaign-specific fields to EspoCRM deals (e.g. `utm_campaign` as a
+custom field), use the EspoCRM admin UI: Admin → Entity Manager → Opportunity
+→ Fields → Add Field (type: Varchar, name: `utm_campaign`). Then update
+`src/lib/espocrm.ts: createDeal()` to pass it.
+
+## Postiz API key rotation
+
+The API key is stored in SSM at `/cloudless/production/POSTIZ_API_KEY`.
+To rotate:
+
+1. Postiz UI → Settings → Public API → Regenerate.
+2. Copy the new key.
+3. `aws ssm put-parameter --name /cloudless/production/POSTIZ_API_KEY --value "<new>" --type SecureString --overwrite`
+4. Restart the cloudless.gr app pod so it picks up the new SSM value:
+   `kubectl -n cloudless rollout restart deploy/cloudless-app`
+
+## Postiz integrations (connected social channels)
+
+List all connected channels:
+
+```bash
+curl -H "Authorization: $POSTIZ_API_KEY" \
+  https://postiz.cloudless.gr/api/public/v1/integrations | jq '.[] | {id, name, type}'
+```
+
+The `id` from this response is what you pass as `integration.id` in post bodies.
+
+## Supported UTM platforms (auto-route to #campaigns)
+
+These are checked in `src/lib/slack-notify.ts: CAMPAIGN_UTM_SOURCES`:
+
+| utm_source value | Platform |
+|---|---|
+| `linkedin`, `linkedin_ads`, `linkedin-ads` | LinkedIn |
+| `meta`, `facebook`, `instagram` | Meta |
+| `google`, `google-ads`, `google_ads` | Google |
+| `tiktok`, `tiktok-ads` | TikTok |
+| `twitter`, `x-ads` | X / Twitter |
+
+To add a new platform, edit the `CAMPAIGN_UTM_SOURCES` Set in `src/lib/slack-notify.ts`.
+
+## Adding a new LinkedIn campaign (end-to-end checklist)
+
+1. [ ] Create the campaign in LinkedIn Campaign Manager → note the `campaignId` and `conversionId`.
+2. [ ] Add entry to `src/data/campaigns.ts` (if the campaign has a dedicated landing page).
+3. [ ] Set `notifyChannels: [{ channel: "slack", target: "#campaigns", level: "event" }]`.
+4. [ ] Schedule posts in Postiz with UTM params: `utm_source=linkedin&utm_campaign=<slug>`.
+5. [ ] (Optional) Register the Postiz webhook → n8n `postiz-utm-guard` workflow to catch missing UTMs.
+6. [ ] Verify: fill the contact form with `?utm_source=linkedin` → check `#campaigns` for the notification.
+
+## Troubleshooting
+
+| Symptom | Check |
+|---|---|
+| Lead not in `#campaigns` | Was `utm_source` in the URL? Check attribution in `#contacts` — the `Attribution:` line shows the raw UTM string |
+| Postiz webhook not firing | Postiz UI → Settings → Webhooks → check the webhook is active and the URL is reachable |
+| n8n workflow not triggering | `https://n8n.cloudless.gr` → check workflow is **active** (green toggle) |
+| UTM guard fires on every post | The post URL didn't contain `utm_source=` — add it to the Postiz post content |
+| Postiz API 401 | API key rotated but SSM/pod not updated — see key rotation steps above |


### PR DESCRIPTION
## Summary
- **n8n-operator skill**: full ops playbook for self-hosted n8n (deploy, import/export, service wiring, known quirks)
- **postiz-automation skill**: UTM convention, Postiz webhook → n8n setup, EspoCRM attribution, new campaign checklist
- **postiz-utm-guard n8n workflow**: catches Postiz posts missing `utm_source=` and alerts `#campaigns` in Slack

## How to activate the UTM guard
1. Import `infrastructure/n8n/workflows/postiz-utm-guard.json` into n8n UI
2. Activate the workflow → copy the webhook URL
3. Register in Postiz UI → Settings → Webhooks → Event: Post Published

🤖 Generated with [Claude Code](https://claude.com/claude-code)