### PR TITLE
feat(api): n8n admin routes — health, workflows, executions, trigger

### DIFF
--- a/src/app/api/admin/n8n/executions/route.ts
+++ b/src/app/api/admin/n8n/executions/route.ts
@@ -1,0 +1,23 @@
+import { NextRequest, NextResponse } from "next/server";
+import { requireAdmin } from "@/lib/api-auth";
+import { listRecentExecutions, isN8nConfigured } from "@/lib/n8n";
+
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+
+export async function GET(req: NextRequest) {
+  const auth = await requireAdmin(req);
+  if (!auth.ok) return auth.response;
+
+  const configured = await isN8nConfigured();
+  if (!configured) {
+    return NextResponse.json({ error: "n8n_not_configured" }, { status: 503 });
+  }
+
+  const limit = Math.min(
+    250,
+    Math.max(1, Number(new URL(req.url).searchParams.get("limit") ?? "50"))
+  );
+  const executions = await listRecentExecutions(limit);
+  return NextResponse.json({ executions });
+}

--- a/src/app/api/admin/n8n/health/route.ts
+++ b/src/app/api/admin/n8n/health/route.ts
@@ -1,0 +1,42 @@
+import { NextRequest, NextResponse } from "next/server";
+import { requireAdmin } from "@/lib/api-auth";
+import { isN8nConfigured, pingN8nHealth, listWorkflows, listRecentExecutions } from "@/lib/n8n";
+
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+
+export async function GET(req: NextRequest) {
+  const auth = await requireAdmin(req);
+  if (!auth.ok) return auth.response;
+
+  const configured = await isN8nConfigured();
+  if (!configured) {
+    return NextResponse.json(
+      { ok: false, configured: false, error: "n8n_not_configured" },
+      { status: 503 }
+    );
+  }
+
+  const startedAt = Date.now();
+  const [healthy, workflows, executions] = await Promise.all([
+    pingN8nHealth(),
+    listWorkflows(false).catch(() => []),
+    listRecentExecutions(50).catch(() => []),
+  ]);
+  const latencyMs = Date.now() - startedAt;
+
+  return NextResponse.json({
+    ok: healthy,
+    configured: true,
+    latencyMs,
+    workflows: {
+      total: workflows.length,
+      active: workflows.filter((w) => w.active).length,
+    },
+    executions: {
+      recent: executions.length,
+      errors: executions.filter((e) => e.status === "error").length,
+      running: executions.filter((e) => e.status === "running").length,
+    },
+  });
+}

--- a/src/app/api/admin/n8n/workflows/[id]/trigger/route.ts
+++ b/src/app/api/admin/n8n/workflows/[id]/trigger/route.ts
@@ -1,0 +1,37 @@
+import { NextRequest, NextResponse } from "next/server";
+import { requireAdmin } from "@/lib/api-auth";
+import { triggerWorkflowByWebhookPath, isN8nConfigured, N8nApiError } from "@/lib/n8n";
+
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+
+export async function POST(req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+  const auth = await requireAdmin(req);
+  if (!auth.ok) return auth.response;
+
+  const configured = await isN8nConfigured();
+  if (!configured) {
+    return NextResponse.json({ error: "n8n_not_configured" }, { status: 503 });
+  }
+
+  const { id } = await params;
+  let payload: unknown = {};
+  try {
+    payload = await req.json();
+  } catch {
+    // empty body is fine — workflow may not need input
+  }
+
+  try {
+    const result = await triggerWorkflowByWebhookPath(id, payload);
+    return NextResponse.json({ ok: true, result });
+  } catch (err) {
+    if (err instanceof N8nApiError) {
+      return NextResponse.json(
+        { ok: false, error: "n8n_upstream", status: err.status, body: err.body },
+        { status: 502 }
+      );
+    }
+    throw err;
+  }
+}

--- a/src/app/api/admin/n8n/workflows/route.ts
+++ b/src/app/api/admin/n8n/workflows/route.ts
@@ -1,0 +1,20 @@
+import { NextRequest, NextResponse } from "next/server";
+import { requireAdmin } from "@/lib/api-auth";
+import { listWorkflows, isN8nConfigured } from "@/lib/n8n";
+
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+
+export async function GET(req: NextRequest) {
+  const auth = await requireAdmin(req);
+  if (!auth.ok) return auth.response;
+
+  const configured = await isN8nConfigured();
+  if (!configured) {
+    return NextResponse.json({ error: "n8n_not_configured" }, { status: 503 });
+  }
+
+  const activeOnly = new URL(req.url).searchParams.get("active") === "true";
+  const workflows = await listWorkflows(activeOnly);
+  return NextResponse.json({ workflows });
+}


### PR DESCRIPTION
## Summary
- `GET /api/admin/n8n/health` — live health check with workflow + execution counts
- `GET /api/admin/n8n/workflows` — list all n8n workflows (`?active=true`)
- `GET /api/admin/n8n/executions` — recent executions (`?limit=N`)
- `POST /api/admin/n8n/workflows/[id]/trigger` — fire a workflow by webhook path or ID

Mirrors the existing Postiz admin route structure. All routes auth-gated via `requireAdmin`.

## Live API facts (verified against postiz.cloudless.gr)
- 3 connected integrations: LinkedIn page, LinkedIn personal, Facebook
- Posts with states QUEUE/PUBLISHED/ERROR/DRAFT confirmed working
- POST /posts + DELETE /posts/:id confirmed working end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)