### PR TITLE
feat(monitoring): wire cluster alerts to Uptime Kuma (dual-fire)

### DIFF
--- a/__tests__/admin-alert-webhook-api.test.ts
+++ b/__tests__/admin-alert-webhook-api.test.ts
@@ -100,10 +100,10 @@ describe("POST /api/webhooks/admin-alert", () => {
     expect(call.severity).toBe("high");
   });
 
-  it("falls back to NOTION_WEBHOOK_SECRET when ADMIN_ALERT_SECRET is empty", async () => {
+  it("falls back to CONTENT_WEBHOOK_SECRET when ADMIN_ALERT_SECRET is empty", async () => {
     vi.mocked(getConfig).mockResolvedValue({
       ADMIN_ALERT_SECRET: "",
-      NOTION_WEBHOOK_SECRET: SECRET,
+      CONTENT_WEBHOOK_SECRET: SECRET,
     } as never);
     const res = await POST(req({ "x-cloudless-alert-secret": SECRET }, validBody));
     expect(res.status).toBe(200);

--- a/__tests__/lib-coverage-gaps.test.ts
+++ b/__tests__/lib-coverage-gaps.test.ts
@@ -231,12 +231,12 @@ describe("ssm-config.ts — SSM fetch path", () => {
 
   it("builds config from SSM parameters and strips the prefix", async () => {
     vi.stubEnv("NODE_ENV", "production");
+    vi.stubEnv("NOTION_API_KEY", "ntn_from_env");
     stubSsm([
       {
         Parameters: [
           { Name: "/cloudless/production/STRIPE_SECRET_KEY", Value: "sk_live_x" },
           { Name: "/cloudless/production/STRIPE_WEBHOOK_SECRET", Value: "whsec_y" },
-          { Name: "/cloudless/production/NOTION_API_KEY", Value: "ntn_from_ssm" },
         ],
       },
     ]);
@@ -245,7 +245,8 @@ describe("ssm-config.ts — SSM fetch path", () => {
     const cfg = await getConfig();
     expect(cfg.STRIPE_SECRET_KEY).toBe("sk_live_x");
     expect(cfg.STRIPE_WEBHOOK_SECRET).toBe("whsec_y");
-    expect(cfg.NOTION_API_KEY).toBe("ntn_from_ssm");
+    // NOTION_API_KEY is env-only (SSM keys decommissioned) — reads from process.env
+    expect(cfg.NOTION_API_KEY).toBe("ntn_from_env");
   });
 
   it("follows NextToken pagination across multiple pages", async () => {
@@ -290,12 +291,14 @@ describe("ssm-config.ts — SSM fetch path", () => {
 
   it("warns when required Stripe keys are missing but still returns config", async () => {
     vi.stubEnv("NODE_ENV", "production");
+    vi.stubEnv("NOTION_API_KEY", "n_from_env");
     const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
-    stubSsm([{ Parameters: [{ Name: "/cloudless/production/NOTION_API_KEY", Value: "n" }] }]);
+    stubSsm([{ Parameters: [] }]);
     const { getConfig, resetSsmCache } = await import("@/lib/ssm-config");
     resetSsmCache();
     const cfg = await getConfig();
-    expect(cfg.NOTION_API_KEY).toBe("n");
+    // NOTION_API_KEY is env-only — SSM value is ignored
+    expect(cfg.NOTION_API_KEY).toBe("n_from_env");
     expect(warn).toHaveBeenCalledWith(expect.stringContaining("Missing required parameters"));
     warn.mockRestore();
   });

--- a/__tests__/notion-webhook-api.test.ts
+++ b/__tests__/notion-webhook-api.test.ts
@@ -16,7 +16,7 @@ vi.mock("next/cache", () => ({
   revalidatePath: revalidatePathMock,
 }));
 
-vi.mock("@/lib/notion-cache", () => ({
+vi.mock("@/lib/content-cache", () => ({
   invalidateCache: invalidateCacheMock,
 }));
 
@@ -29,12 +29,12 @@ vi.mock("@/lib/email", () => ({
 }));
 
 const DEFAULT_CONFIG = {
-  NOTION_WEBHOOK_SECRET: "test_notion_secret",
+  CONTENT_WEBHOOK_SECRET: "test_content_secret",
   SES_TO_EMAIL: "team@cloudless.gr",
 };
 
 function makeRequest(body: unknown, secret?: string) {
-  return new NextRequest("http://localhost:4000/api/webhooks/notion", {
+  return new NextRequest("http://localhost:4000/api/webhooks/content", {
     method: "POST",
     headers: {
       "Content-Type": "application/json",
@@ -44,7 +44,7 @@ function makeRequest(body: unknown, secret?: string) {
   });
 }
 
-describe("POST /api/webhooks/notion", () => {
+describe("POST /api/webhooks/content", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     getConfigMock.mockResolvedValue(DEFAULT_CONFIG);
@@ -53,7 +53,7 @@ describe("POST /api/webhooks/notion", () => {
   });
 
   it("returns 401 when x-webhook-secret header is missing", async () => {
-    const { POST } = await import("@/app/api/webhooks/notion/route");
+    const { POST } = await import("@/app/api/webhooks/content/route");
     const response = await POST(
       makeRequest({ type: "page.updated", database: "blog", page_id: "p1" })
     );
@@ -64,7 +64,7 @@ describe("POST /api/webhooks/notion", () => {
   });
 
   it("returns 401 when x-webhook-secret is wrong", async () => {
-    const { POST } = await import("@/app/api/webhooks/notion/route");
+    const { POST } = await import("@/app/api/webhooks/content/route");
     const response = await POST(
       makeRequest({ type: "page.updated", database: "blog", page_id: "p1" }, "wrong_secret")
     );
@@ -73,23 +73,23 @@ describe("POST /api/webhooks/notion", () => {
   });
 
   it("returns 401 when webhook secret is not configured", async () => {
-    getConfigMock.mockResolvedValueOnce({ ...DEFAULT_CONFIG, NOTION_WEBHOOK_SECRET: "" });
+    getConfigMock.mockResolvedValueOnce({ ...DEFAULT_CONFIG, CONTENT_WEBHOOK_SECRET: "" });
 
-    const { POST } = await import("@/app/api/webhooks/notion/route");
+    const { POST } = await import("@/app/api/webhooks/content/route");
     const response = await POST(
-      makeRequest({ type: "page.updated", database: "blog", page_id: "p1" }, "test_notion_secret")
+      makeRequest({ type: "page.updated", database: "blog", page_id: "p1" }, "test_content_secret")
     );
 
     expect(response.status).toBe(401);
   });
 
   it("returns 400 for invalid JSON body", async () => {
-    const { POST } = await import("@/app/api/webhooks/notion/route");
-    const request = new NextRequest("http://localhost:4000/api/webhooks/notion", {
+    const { POST } = await import("@/app/api/webhooks/content/route");
+    const request = new NextRequest("http://localhost:4000/api/webhooks/content", {
       method: "POST",
       headers: {
         "Content-Type": "application/json",
-        "x-webhook-secret": "test_notion_secret",
+        "x-webhook-secret": "test_content_secret",
       },
       body: "not-json{{{",
     });
@@ -101,8 +101,8 @@ describe("POST /api/webhooks/notion", () => {
   });
 
   it("returns 400 when required fields are missing", async () => {
-    const { POST } = await import("@/app/api/webhooks/notion/route");
-    const response = await POST(makeRequest({ type: "page.updated" }, "test_notion_secret"));
+    const { POST } = await import("@/app/api/webhooks/content/route");
+    const response = await POST(makeRequest({ type: "page.updated" }, "test_content_secret"));
 
     expect(response.status).toBe(400);
     const data = await response.json();
@@ -110,9 +110,9 @@ describe("POST /api/webhooks/notion", () => {
   });
 
   it("returns 400 for unknown event type", async () => {
-    const { POST } = await import("@/app/api/webhooks/notion/route");
+    const { POST } = await import("@/app/api/webhooks/content/route");
     const response = await POST(
-      makeRequest({ type: "unknown.event", database: "blog", page_id: "p1" }, "test_notion_secret")
+      makeRequest({ type: "unknown.event", database: "blog", page_id: "p1" }, "test_content_secret")
     );
 
     expect(response.status).toBe(400);
@@ -121,11 +121,11 @@ describe("POST /api/webhooks/notion", () => {
   });
 
   it("handles page.updated for blog — revalidates blog paths", async () => {
-    const { POST } = await import("@/app/api/webhooks/notion/route");
+    const { POST } = await import("@/app/api/webhooks/content/route");
     const response = await POST(
       makeRequest(
         { type: "page.updated", database: "blog", page_id: "p1", slug: "my-post" },
-        "test_notion_secret"
+        "test_content_secret"
       )
     );
 
@@ -139,11 +139,11 @@ describe("POST /api/webhooks/notion", () => {
   });
 
   it("handles page.updated for docs — revalidates docs paths", async () => {
-    const { POST } = await import("@/app/api/webhooks/notion/route");
+    const { POST } = await import("@/app/api/webhooks/content/route");
     const response = await POST(
       makeRequest(
         { type: "page.updated", database: "docs", page_id: "p2", slug: "my-doc" },
-        "test_notion_secret"
+        "test_content_secret"
       )
     );
 
@@ -154,9 +154,9 @@ describe("POST /api/webhooks/notion", () => {
   });
 
   it("handles page.created for blog — revalidates blog and sitemap", async () => {
-    const { POST } = await import("@/app/api/webhooks/notion/route");
+    const { POST } = await import("@/app/api/webhooks/content/route");
     const response = await POST(
-      makeRequest({ type: "page.created", database: "blog", page_id: "p3" }, "test_notion_secret")
+      makeRequest({ type: "page.created", database: "blog", page_id: "p3" }, "test_content_secret")
     );
 
     expect(response.status).toBe(200);
@@ -168,7 +168,7 @@ describe("POST /api/webhooks/notion", () => {
   });
 
   it("handles page.created for docs — notifies Slack", async () => {
-    const { POST } = await import("@/app/api/webhooks/notion/route");
+    const { POST } = await import("@/app/api/webhooks/content/route");
     const response = await POST(
       makeRequest(
         {
@@ -178,7 +178,7 @@ describe("POST /api/webhooks/notion", () => {
           slug: "new-doc",
           data: { title: "New Guide" },
         },
-        "test_notion_secret"
+        "test_content_secret"
       )
     );
 
@@ -188,7 +188,7 @@ describe("POST /api/webhooks/notion", () => {
   });
 
   it("handles submission.status Done — sends email to submitter", async () => {
-    const { POST } = await import("@/app/api/webhooks/notion/route");
+    const { POST } = await import("@/app/api/webhooks/content/route");
     const response = await POST(
       makeRequest(
         {
@@ -197,7 +197,7 @@ describe("POST /api/webhooks/notion", () => {
           page_id: "p5",
           data: { email: "client@example.com", name: "Alice", status: "Done" },
         },
-        "test_notion_secret"
+        "test_content_secret"
       )
     );
 
@@ -212,7 +212,7 @@ describe("POST /api/webhooks/notion", () => {
   });
 
   it("handles submission.status non-Done — does NOT send email", async () => {
-    const { POST } = await import("@/app/api/webhooks/notion/route");
+    const { POST } = await import("@/app/api/webhooks/content/route");
     const response = await POST(
       makeRequest(
         {
@@ -221,7 +221,7 @@ describe("POST /api/webhooks/notion", () => {
           page_id: "p6",
           data: { email: "client@example.com", name: "Bob", status: "In Progress" },
         },
-        "test_notion_secret"
+        "test_content_secret"
       )
     );
 
@@ -232,7 +232,7 @@ describe("POST /api/webhooks/notion", () => {
   });
 
   it("handles project.updated Completed — notifies Slack", async () => {
-    const { POST } = await import("@/app/api/webhooks/notion/route");
+    const { POST } = await import("@/app/api/webhooks/content/route");
     const response = await POST(
       makeRequest(
         {
@@ -241,7 +241,7 @@ describe("POST /api/webhooks/notion", () => {
           page_id: "p7",
           data: { name: "Cloud Migration", status: "Completed" },
         },
-        "test_notion_secret"
+        "test_content_secret"
       )
     );
 
@@ -252,7 +252,7 @@ describe("POST /api/webhooks/notion", () => {
   });
 
   it("handles project.updated Blocked — notifies Slack", async () => {
-    const { POST } = await import("@/app/api/webhooks/notion/route");
+    const { POST } = await import("@/app/api/webhooks/content/route");
     const response = await POST(
       makeRequest(
         {
@@ -261,7 +261,7 @@ describe("POST /api/webhooks/notion", () => {
           page_id: "p8",
           data: { name: "SEO Audit", status: "Blocked" },
         },
-        "test_notion_secret"
+        "test_content_secret"
       )
     );
 
@@ -271,7 +271,7 @@ describe("POST /api/webhooks/notion", () => {
   });
 
   it("handles task.updated Blocked — notifies Slack", async () => {
-    const { POST } = await import("@/app/api/webhooks/notion/route");
+    const { POST } = await import("@/app/api/webhooks/content/route");
     const response = await POST(
       makeRequest(
         {
@@ -280,7 +280,7 @@ describe("POST /api/webhooks/notion", () => {
           page_id: "p9",
           data: { task: "Write report", status: "Blocked", assignee: "Themis" },
         },
-        "test_notion_secret"
+        "test_content_secret"
       )
     );
 
@@ -291,7 +291,7 @@ describe("POST /api/webhooks/notion", () => {
   });
 
   it("handles analytics.event error spike >= 10 — notifies Slack", async () => {
-    const { POST } = await import("@/app/api/webhooks/notion/route");
+    const { POST } = await import("@/app/api/webhooks/content/route");
     const response = await POST(
       makeRequest(
         {
@@ -300,7 +300,7 @@ describe("POST /api/webhooks/notion", () => {
           page_id: "p10",
           data: { type: "error", count: 15 },
         },
-        "test_notion_secret"
+        "test_content_secret"
       )
     );
 
@@ -310,7 +310,7 @@ describe("POST /api/webhooks/notion", () => {
   });
 
   it("does NOT notify Slack for analytics.event below threshold", async () => {
-    const { POST } = await import("@/app/api/webhooks/notion/route");
+    const { POST } = await import("@/app/api/webhooks/content/route");
     const response = await POST(
       makeRequest(
         {
@@ -319,7 +319,7 @@ describe("POST /api/webhooks/notion", () => {
           page_id: "p11",
           data: { type: "error", count: 5 },
         },
-        "test_notion_secret"
+        "test_content_secret"
       )
     );
 
@@ -328,11 +328,11 @@ describe("POST /api/webhooks/notion", () => {
   });
 
   it("handles page.updated for testimonials — invalidates testimonials cache", async () => {
-    const { POST } = await import("@/app/api/webhooks/notion/route");
+    const { POST } = await import("@/app/api/webhooks/content/route");
     const response = await POST(
       makeRequest(
         { type: "page.updated", database: "testimonials", page_id: "t1" },
-        "test_notion_secret"
+        "test_content_secret"
       )
     );
 
@@ -345,11 +345,11 @@ describe("POST /api/webhooks/notion", () => {
   });
 
   it("handles page.updated for case-studies — invalidates cache and revalidates slug path", async () => {
-    const { POST } = await import("@/app/api/webhooks/notion/route");
+    const { POST } = await import("@/app/api/webhooks/content/route");
     const response = await POST(
       makeRequest(
         { type: "page.updated", database: "case-studies", page_id: "cs1", slug: "techflow" },
-        "test_notion_secret"
+        "test_content_secret"
       )
     );
 
@@ -360,11 +360,11 @@ describe("POST /api/webhooks/notion", () => {
   });
 
   it("handles page.updated for services — invalidates services cache", async () => {
-    const { POST } = await import("@/app/api/webhooks/notion/route");
+    const { POST } = await import("@/app/api/webhooks/content/route");
     const response = await POST(
       makeRequest(
         { type: "page.updated", database: "services", page_id: "s1" },
-        "test_notion_secret"
+        "test_content_secret"
       )
     );
 
@@ -374,9 +374,9 @@ describe("POST /api/webhooks/notion", () => {
   });
 
   it("handles page.updated for faqs — invalidates faqs cache", async () => {
-    const { POST } = await import("@/app/api/webhooks/notion/route");
+    const { POST } = await import("@/app/api/webhooks/content/route");
     const response = await POST(
-      makeRequest({ type: "page.updated", database: "faqs", page_id: "f1" }, "test_notion_secret")
+      makeRequest({ type: "page.updated", database: "faqs", page_id: "f1" }, "test_content_secret")
     );
 
     expect(response.status).toBe(200);
@@ -385,11 +385,11 @@ describe("POST /api/webhooks/notion", () => {
   });
 
   it("handles page.created for case-studies — revalidates sitemap", async () => {
-    const { POST } = await import("@/app/api/webhooks/notion/route");
+    const { POST } = await import("@/app/api/webhooks/content/route");
     const response = await POST(
       makeRequest(
         { type: "page.created", database: "case-studies", page_id: "cs2", slug: "retail-plus" },
-        "test_notion_secret"
+        "test_content_secret"
       )
     );
 
@@ -404,11 +404,11 @@ describe("POST /api/webhooks/notion", () => {
       throw new Error("cache revalidation failed");
     });
 
-    const { POST } = await import("@/app/api/webhooks/notion/route");
+    const { POST } = await import("@/app/api/webhooks/content/route");
     const response = await POST(
       makeRequest(
         { type: "page.updated", database: "blog", page_id: "p12", slug: "boom" },
-        "test_notion_secret"
+        "test_content_secret"
       )
     );
 

--- a/docs/master-todo-list.md
+++ b/docs/master-todo-list.md
@@ -166,7 +166,7 @@ Reuses existing Bedrock Nova IAM (no new SaaS bills).
 
 Closes the half-done CAPI work from `project_linkedin_capi_source_bound` memory.
 
-- [ ] 🤖 🔵 Verify `li_fat_id` capture in client (Insight Tag injects it; check `src/components/LinkedInInsightTag.tsx`).
+- [x] ~~🤖 🔵 Verify `li_fat_id` capture in client (Insight Tag injects it; check `src/components/LinkedInInsightTag.tsx`).~~ ✅ **SHIPPED 2026-06-26** — `ThanksConversion.tsx` captures `?li_fat_id=…` from `window.location.search` and forwards it in the CAPI POST body. `AdConversionEvent.liFatId` field added; threads through `dispatchConversion()` → `adapters/linkedin.ts` `liFatId` user-matching field.
 - [ ] 👤 🔵 Provision a LinkedIn CAPI-typed conversion ID (the existing `26846068` is browser-only; CAPI needs a different conv type). Create at LinkedIn Campaign Manager → Account assets → Conversions → "Conversion API" type.
 - [ ] 🤖 🔵 Wire `eventId` dedup between Insight Tag fire + CAPI fire (same UUID, fires on both client + server within ~5 s of each other).
 
@@ -204,7 +204,7 @@ Closes the half-done CAPI work from `project_linkedin_capi_source_bound` memory.
 - ✅ `/admin/analytics` consolidated dashboard
 - ✅ `/admin/cluster` real-time health chips (MQTT + Kuma + Grafana + AppFlowy + EspoCRM + Postiz + n8n + ntfy)
 - ✅ Grafana per-app dashboards (kube-prom + 2 custom)
-- ⬜ **Phase 1:** `/admin/cost` Athena-backed panel (R12)
+- ✅ **Phase 1:** `/admin/cost` Athena-backed panel (R12) — shipped 2026-06-21
 - ⬜ **Phase 3:** AI semantic-search funnel analytics (query → result → click → buy) — added when R21 lands
 - ⬜ **Phase 3:** AI recommendation A/B vs no-rec baseline analytics — added when R21c lands
 

--- a/e2e/helpers/coverage-routes.ts
+++ b/e2e/helpers/coverage-routes.ts
@@ -136,7 +136,7 @@ export const PUBLIC_API_POST_FORM = [
 
 export const WEBHOOK_APIS = [
   "/api/webhooks/stripe",
-  "/api/webhooks/notion",
+  "/api/webhooks/content",
   "/api/webhooks/espocrm",
 ] as const;
 

--- a/e2e/integrations-contracts.spec.ts
+++ b/e2e/integrations-contracts.spec.ts
@@ -51,8 +51,8 @@ test.describe("Integrations contracts", () => {
     }
   });
 
-  test("Notion webhook requires secret header", async ({ page }) => {
-    const response = await postJson(page.request, "/api/webhooks/notion", {
+  test("Content webhook requires secret header", async ({ page }) => {
+    const response = await postJson(page.request, "/api/webhooks/content", {
       type: "page.updated",
       database: "blog",
       page_id: "fake-page-id",

--- a/e2e/k3s/webhook-endpoints.spec.ts
+++ b/e2e/k3s/webhook-endpoints.spec.ts
@@ -18,7 +18,7 @@ const WEBHOOK_ENDPOINTS = [
   // here so a future "EspoCRM webhook accidentally deleted" regression is caught.
   { name: "EspoCRM webhook", path: "/api/webhooks/espocrm", expectedStatus: [401, 403, 400, 405] },
   { name: "Stripe webhook", path: "/api/webhooks/stripe", expectedStatus: [400, 401, 403] },
-  { name: "Notion webhook", path: "/api/webhooks/notion", expectedStatus: [400, 401, 403, 405] },
+  { name: "Content webhook", path: "/api/webhooks/content", expectedStatus: [400, 401, 403, 405] },
 ];
 
 test.describe("Webhook endpoints — route existence and auth rejection", () => {

--- a/e2e/migrated/webhooks.spec.ts
+++ b/e2e/migrated/webhooks.spec.ts
@@ -29,8 +29,8 @@ test.describe("Webhook signature gates", () => {
     expect(r.status()).toBeLessThan(500);
   });
 
-  test("POST /api/webhooks/notion without signature → 4xx", async ({ request }) => {
-    const r = await request.post("/api/webhooks/notion", { data: {} });
+  test("POST /api/webhooks/content without signature → 4xx", async ({ request }) => {
+    const r = await request.post("/api/webhooks/content", { data: {} });
     expect(r.status()).toBeGreaterThanOrEqual(400);
     expect(r.status()).toBeLessThan(500);
   });

--- a/e2e/public-api-sweep.spec.ts
+++ b/e2e/public-api-sweep.spec.ts
@@ -121,8 +121,8 @@ test.describe("Public API route sweep", () => {
     // In dev: 5xx is acceptable (missing creds). We only need the route to be wired.
     expect(res.status()).toBeGreaterThanOrEqual(200);
   });
-  test("POST /api/webhooks/notion without auth returns 4xx", async ({ request }) => {
-    const res = await request.post("/api/webhooks/notion", { data: {} });
+  test("POST /api/webhooks/content without auth returns 4xx", async ({ request }) => {
+    const res = await request.post("/api/webhooks/content", { data: {} });
     // In dev: 5xx is acceptable (missing creds). We only need the route to be wired.
     expect(res.status()).toBeGreaterThanOrEqual(200);
   });

--- a/e2e/webhook-signatures.spec.ts
+++ b/e2e/webhook-signatures.spec.ts
@@ -43,8 +43,8 @@ test.describe("webhook signature gates", () => {
   // (PR #1043 — EspoCRM decom). EspoCRM webhook auth is URL-secret-based,
   // not HMAC; covered by `/api/webhooks/espocrm` tests elsewhere.
 
-  test("/api/webhooks/notion rejects missing signature", async ({ request }) => {
-    const r = await request.post("/api/webhooks/notion", {
+  test("/api/webhooks/content rejects missing signature", async ({ request }) => {
+    const r = await request.post("/api/webhooks/content", {
       data: FAKE_BODY,
       headers: { "Content-Type": "application/json" },
     });

--- a/infrastructure/backup/cronjob-appflowy.yaml
+++ b/infrastructure/backup/cronjob-appflowy.yaml
@@ -63,7 +63,7 @@ spec:
                 - name: KUMA_PUSH_TOKEN
                   valueFrom:
                     secretKeyRef:
-                      name: pvc-backup-kuma
+                      name: cluster-alerts-kuma
                       key: KUMA_PUSH_BACKUP_APPFLOWY
                       optional: true
               command:

--- a/infrastructure/backup/cronjob-espocrm.yaml
+++ b/infrastructure/backup/cronjob-espocrm.yaml
@@ -58,7 +58,7 @@ spec:
                 - name: KUMA_PUSH_TOKEN
                   valueFrom:
                     secretKeyRef:
-                      name: pvc-backup-kuma
+                      name: cluster-alerts-kuma
                       key: KUMA_PUSH_BACKUP_ESPOCRM
                       optional: true
               command:

--- a/infrastructure/backup/cronjob-n8n.yaml
+++ b/infrastructure/backup/cronjob-n8n.yaml
@@ -49,7 +49,7 @@ spec:
                 - name: KUMA_PUSH_TOKEN
                   valueFrom:
                     secretKeyRef:
-                      name: pvc-backup-kuma
+                      name: cluster-alerts-kuma
                       key: KUMA_PUSH_BACKUP_N8N
                       optional: true
               command:

--- a/infrastructure/backup/cronjob-postiz.yaml
+++ b/infrastructure/backup/cronjob-postiz.yaml
@@ -52,7 +52,7 @@ spec:
                 - name: KUMA_PUSH_TOKEN
                   valueFrom:
                     secretKeyRef:
-                      name: pvc-backup-kuma
+                      name: cluster-alerts-kuma
                       key: KUMA_PUSH_BACKUP_POSTIZ
                       optional: true
               command:

--- a/infrastructure/monitoring/cloudflared-drift.yaml
+++ b/infrastructure/monitoring/cloudflared-drift.yaml
@@ -57,6 +57,12 @@ spec:
                   valueFrom: { secretKeyRef: { name: cluster-alerts-secret, key: SLACK_BOT_TOKEN } }
                 - name: SLACK_CHANNEL_ID
                   value: "C09AF5W3X16"   # proven working per CLAUDE.md
+                - name: KUMA_PUSH_TOKEN
+                  valueFrom:
+                    secretKeyRef:
+                      name: cluster-alerts-kuma
+                      key: KUMA_PUSH_CLOUDFLARED_DRIFT
+                      optional: true
               command:
                 - sh
                 - -c
@@ -87,9 +93,13 @@ spec:
                     MSG=":rotating_light: cloudflared CONFIG DRIFT detected. omv has $OMV_COUNT ingress hostnames, omv-ha has $HA_COUNT. Public hostnames missing from one node will 404 ~50% of the time. Remediate: skills/cloudflare-tunnel-ops/SKILL.md \"Sync omv-ha to match omv\"."
                   else
                     echo "OK: omv=$OMV_COUNT omv-ha=$HA_COUNT — in sync; no alert."
+                    [ -n "${KUMA_PUSH_TOKEN:-}" ] && \
+                      wget -qO- "https://kuma.cloudless.gr/api/push/${KUMA_PUSH_TOKEN}?status=up&msg=cloudflared+config+in+sync" >/dev/null 2>&1 || true
                     exit 0
                   fi
 
+                  [ -n "${KUMA_PUSH_TOKEN:-}" ] && \
+                    wget -qO- "https://kuma.cloudless.gr/api/push/${KUMA_PUSH_TOKEN}?status=down&msg=cloudflared+drift+or+unreachable" >/dev/null 2>&1 || true
                   curl -fsS -X POST https://slack.com/api/chat.postMessage \
                     -H "Authorization: Bearer $SLACK_BOT_TOKEN" \
                     -H "Content-Type: application/json; charset=utf-8" \

--- a/infrastructure/monitoring/cluster-alerts-kuma-secret.yaml
+++ b/infrastructure/monitoring/cluster-alerts-kuma-secret.yaml
@@ -1,0 +1,37 @@
+# cluster-alerts-kuma — Uptime Kuma push-monitor tokens for all in-cluster
+# alert sources. Single Secret consumed by 3 monitoring CronJobs + 4 backup
+# CronJobs across 5 namespaces.
+#
+# The literal value `PENDING_UI_CREATION` is a sentinel that lets the cluster
+# apply this manifest before the operator has logged into Kuma to create the
+# 7 push monitors. Because every consumer uses:
+#   - optional: true on the secretKeyRef
+#   - `[ -n "${KUMA_PUSH_TOKEN:-}" ] && wget … || true` in the script
+# a sentinel token causes Kuma to return 404 which is silently swallowed.
+# Slack-direct fallback continues to fire so we are NOT blind.
+#
+# Real tokens are populated by `scripts/populate-kuma-secrets.sh` once the
+# operator has run through skills/uptime-kuma-operator/SKILL.md
+# ("Creating a push monitor" walkthrough).
+#
+# NOTE: this Secret lives ONLY in the `monitoring` namespace. The 4 backup
+# CronJobs reach it via cross-namespace replication that the operator must
+# create after first real-token apply (or by `kubectl create secret …` per
+# namespace). The script handles both modes.
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: cluster-alerts-kuma
+  namespace: monitoring
+type: Opaque
+stringData:
+  # cluster-health monitors (omv-watchdogs.yaml + cloudflared-drift.yaml)
+  KUMA_PUSH_K3S_POD_HEALTH: "PENDING_UI_CREATION"
+  KUMA_PUSH_ETCD_SNAPSHOT_AGE: "PENDING_UI_CREATION"
+  KUMA_PUSH_CLOUDFLARED_DRIFT: "PENDING_UI_CREATION"
+  # backup monitors (infrastructure/backup/cronjob-*.yaml)
+  KUMA_PUSH_BACKUP_APPFLOWY: "PENDING_UI_CREATION"
+  KUMA_PUSH_BACKUP_ESPOCRM: "PENDING_UI_CREATION"
+  KUMA_PUSH_BACKUP_N8N: "PENDING_UI_CREATION"
+  KUMA_PUSH_BACKUP_POSTIZ: "PENDING_UI_CREATION"

--- a/infrastructure/monitoring/omv-watchdogs.yaml
+++ b/infrastructure/monitoring/omv-watchdogs.yaml
@@ -67,6 +67,12 @@ spec:
                     secretKeyRef:
                       name: cluster-alerts-secret
                       key: SLACK_BOT_TOKEN
+                - name: KUMA_PUSH_TOKEN
+                  valueFrom:
+                    secretKeyRef:
+                      name: cluster-alerts-kuma
+                      key: KUMA_PUSH_K3S_POD_HEALTH
+                      optional: true
                 - name: SLACK_CHANNEL
                   value: "C09AF5W3X16"
                 - name: WARN_PCT
@@ -114,6 +120,8 @@ spec:
 
                   if [ -z "$WARNS$CRITS" ]; then
                     echo "[${STAMP}] all monitored mounts under ${WARN_PCT}%"
+                    [ -n "${KUMA_PUSH_TOKEN:-}" ] && \
+                      wget -qO- "https://kuma.cloudless.gr/api/push/${KUMA_PUSH_TOKEN}?status=up&msg=all+mounts+under+${WARN_PCT}pct" >/dev/null 2>&1 || true
                     exit 0
                   fi
 
@@ -128,6 +136,8 @@ spec:
                   import json,os,sys
                   print(json.dumps({"channel": os.environ["SLACK_CHANNEL"], "text": sys.stdin.read()}))
                   ')
+                  [ -n "${KUMA_PUSH_TOKEN:-}" ] && \
+                    wget -qO- "https://kuma.cloudless.gr/api/push/${KUMA_PUSH_TOKEN}?status=down&msg=disk+pressure+detected" >/dev/null 2>&1 || true
                   echo "[${STAMP}] posting to ${SLACK_CHANNEL}"
                   RESP=$(curl -sS -X POST https://slack.com/api/chat.postMessage \
                     -H "Authorization: Bearer ${SLACK_BOT_TOKEN}" \
@@ -198,6 +208,12 @@ spec:
                     secretKeyRef:
                       name: cluster-alerts-secret
                       key: SLACK_BOT_TOKEN
+                - name: KUMA_PUSH_TOKEN
+                  valueFrom:
+                    secretKeyRef:
+                      name: cluster-alerts-kuma
+                      key: KUMA_PUSH_ETCD_SNAPSHOT_AGE
+                      optional: true
                 - name: SLACK_CHANNEL
                   value: "C09AF5W3X16"
                 - name: MAX_AGE_HOURS
@@ -225,9 +241,13 @@ spec:
                       BODY=":warning: *k3s etcd snapshot is ${AGE_H}h old* (expected <${MAX_AGE_HOURS}h). Latest: \`${LATEST_FILE}\`. Check the hourly snapshot cron on omv-main."
                     else
                       echo "[${STAMP}] backup healthy: newest snapshot ${AGE_H}h old"
+                      [ -n "${KUMA_PUSH_TOKEN:-}" ] && \
+                        wget -qO- "https://kuma.cloudless.gr/api/push/${KUMA_PUSH_TOKEN}?status=up&msg=snapshot+${AGE_H}h+old" >/dev/null 2>&1 || true
                       exit 0
                     fi
                   fi
+                  [ -n "${KUMA_PUSH_TOKEN:-}" ] && \
+                    wget -qO- "https://kuma.cloudless.gr/api/push/${KUMA_PUSH_TOKEN}?status=down&msg=etcd+snapshot+stale+or+missing" >/dev/null 2>&1 || true
                   PAYLOAD=$(printf '%s' "$BODY" | python3 -c 'import json,os,sys; print(json.dumps({"channel": os.environ["SLACK_CHANNEL"], "text": sys.stdin.read()}))')
                   RESP=$(curl -sS -X POST https://slack.com/api/chat.postMessage \
                     -H "Authorization: Bearer ${SLACK_BOT_TOKEN}" \

--- a/scripts/populate-kuma-secrets.sh
+++ b/scripts/populate-kuma-secrets.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+# scripts/populate-kuma-secrets.sh
+#
+# Populates the `cluster-alerts-kuma` Secret with real Uptime Kuma push-monitor
+# tokens after the operator has created the 7 monitors in the Kuma UI per
+# skills/uptime-kuma-operator/SKILL.md ("Creating a push monitor (UI walkthrough)").
+#
+# Reads 7 positional args (one token per monitor), then applies the Secret to
+# the monitoring ns AND replicates it into each backup-CronJob namespace
+# (appflowy, espocrm, n8n, postiz) so cross-namespace references resolve.
+#
+# Idempotent: uses kubectl create … --dry-run=client -o yaml | kubectl apply -f -
+# so it can be safely re-run on every token rotation.
+
+set -euo pipefail
+
+usage() {
+  cat <<USAGE
+Usage: $0 <K3S_POD_HEALTH> <ETCD_SNAPSHOT_AGE> <CLOUDFLARED_DRIFT> \\
+          <BACKUP_APPFLOWY> <BACKUP_ESPOCRM> <BACKUP_N8N> <BACKUP_POSTIZ>
+
+Each argument is the token portion of a Kuma push URL, e.g. for
+  https://kuma.cloudless.gr/api/push/abc123XYZ
+pass:
+  abc123XYZ
+
+Get the tokens by clicking the monitor in Kuma UI → "Push URL" field, copy
+only the alphanumeric suffix.
+
+Order matters. The 7 monitor names corresponding to each slot:
+  1. k3s-pod-health        (omv-disk-watchdog every 15min)
+  2. etcd-snapshot-age     (omv-backup-verify every 6h)
+  3. cloudflared-drift     (cloudflared-drift-check every 6h)
+  4. backup-appflowy       (pvc-backup-appflowy daily 03:30 UTC)
+  5. backup-espocrm        (pvc-backup-espocrm daily 03:30 UTC)
+  6. backup-n8n            (pvc-backup-n8n daily 03:30 UTC)
+  7. backup-postiz         (pvc-backup-postiz daily 03:30 UTC)
+USAGE
+  exit 1
+}
+
+if [ "$#" -ne 7 ]; then
+  echo "ERROR: expected 7 arguments, got $#" >&2
+  echo >&2
+  usage
+fi
+
+K3S_POD_HEALTH="$1"
+ETCD_SNAPSHOT_AGE="$2"
+CLOUDFLARED_DRIFT="$3"
+BACKUP_APPFLOWY="$4"
+BACKUP_ESPOCRM="$5"
+BACKUP_N8N="$6"
+BACKUP_POSTIZ="$7"
+
+apply_secret() {
+  local ns="$1"
+  echo "→ applying cluster-alerts-kuma in namespace=${ns}"
+  kubectl create secret generic cluster-alerts-kuma \
+    --namespace="${ns}" \
+    --from-literal=KUMA_PUSH_K3S_POD_HEALTH="${K3S_POD_HEALTH}" \
+    --from-literal=KUMA_PUSH_ETCD_SNAPSHOT_AGE="${ETCD_SNAPSHOT_AGE}" \
+    --from-literal=KUMA_PUSH_CLOUDFLARED_DRIFT="${CLOUDFLARED_DRIFT}" \
+    --from-literal=KUMA_PUSH_BACKUP_APPFLOWY="${BACKUP_APPFLOWY}" \
+    --from-literal=KUMA_PUSH_BACKUP_ESPOCRM="${BACKUP_ESPOCRM}" \
+    --from-literal=KUMA_PUSH_BACKUP_N8N="${BACKUP_N8N}" \
+    --from-literal=KUMA_PUSH_BACKUP_POSTIZ="${BACKUP_POSTIZ}" \
+    --dry-run=client -o yaml | kubectl apply -f -
+}
+
+# monitoring ns hosts the 3 cluster-health CronJobs
+apply_secret monitoring
+
+# backup CronJobs live in each app's namespace and reference the Secret by name.
+# Each app namespace gets its own copy.
+for ns in appflowy espocrm n8n postiz; do
+  if kubectl get namespace "${ns}" >/dev/null 2>&1; then
+    apply_secret "${ns}"
+  else
+    echo "WARN: namespace ${ns} does not exist yet — skipping (backup CronJob will fail until created)" >&2
+  fi
+done
+
+echo
+echo "✅ done. Verify with:"
+echo "    kubectl get secret cluster-alerts-kuma -n monitoring -o jsonpath='{.data}' | base64 -d 2>/dev/null"
+echo "    or wait ~15min for omv-disk-watchdog to fire and check Kuma UI."

--- a/skills/uptime-kuma-operator/SKILL.md
+++ b/skills/uptime-kuma-operator/SKILL.md
@@ -1,0 +1,154 @@
+---
+name: uptime-kuma-operator
+description: Use when working with Uptime Kuma at kuma.cloudless.gr — adding/editing monitors, debugging missed heartbeats, wiring new alert sources, rotating push tokens, or any task mentioning "kuma", "push monitor", "heartbeat", "alert state", "monitor down", or the cluster-alerts-kuma Secret. Covers the API/UI split (metrics endpoint vs. socket.io-only monitor CRUD) so you don't waste time scripting against a non-existent REST surface.
+---
+
+# Uptime Kuma operator
+
+Kuma is the single pane of glass for in-cluster alert state. Cluster CronJobs
+dual-fire to Kuma (push monitor) AND Slack (direct fallback) so a Kuma outage
+doesn't blind us. Slack is loud, Kuma is the deduplicated history + uptime %.
+
+UI: https://kuma.cloudless.gr (admin = tbaltzakis@cloudless.gr / unified
+self-hosted password, see project memory `project_unified_admin_creds`).
+
+## Quick health check
+
+```bash
+KEY=$(aws ssm get-parameter --name /cloudless/production/KUMA_API_KEY \
+        --with-decryption --query Parameter.Value --output text)
+curl -sS -u ":$KEY" https://kuma.cloudless.gr/metrics | head -20
+```
+
+Returns Prometheus metrics for every monitor — proves the API key is valid and
+the server is up. If `monitor_status{...}` returns `0` for a monitor you expect
+to be `1`, that monitor is currently in DOWN state.
+
+## Where the API can and can't go
+
+- `/metrics` (Basic Auth, API key): **works** — Prometheus scrape format.
+- `/api/push/<token>?status=up|down&msg=...`: **works** — heartbeat ingestion
+  (no auth, token IS the auth).
+- Monitor CRUD (create/edit/delete/toggle, notification channels, status
+  pages, tags): **socket.io-only**. No REST. There are community projects
+  like `MedAziz11/Uptime-Kuma-Web-API` that wrap the socket.io layer but
+  we do NOT run one. Treat the UI as the source of truth for monitor config.
+- Bulk import: paste an exported JSON via Settings → Backup → Import.
+
+Do not waste time scripting monitor creation. Use the UI walkthrough below.
+
+## Creating a push monitor (UI walkthrough)
+
+We have 7 push monitors backing the cluster-alerts-kuma Secret. Recreate them
+exactly as below; the script `scripts/populate-kuma-secrets.sh` expects the
+tokens in this order.
+
+Steps for each monitor:
+
+1. Top-right → "+ Add New Monitor".
+2. Monitor Type: **Push**.
+3. Friendly Name: as in table below.
+4. Heartbeat Interval: as in table.
+5. Retries: **1** for cluster-health, **0** for backup monitors (one missed
+   nightly backup is a real alert, not noise).
+6. Heartbeat Retry Interval: leave default (60s).
+7. Resend Notification if Down X times consecutively: as in table.
+8. Notifications: check **Slack — cluster-alerts** (see "Wiring the Slack
+   notification channel" below).
+9. Save.
+10. Click the monitor → copy the **Push URL** → the token is the last path
+    segment (e.g. `abc123XYZ` from `.../api/push/abc123XYZ`).
+
+| # | Friendly Name      | Heartbeat | Resend  | Source CronJob                              |
+|---|--------------------|-----------|---------|---------------------------------------------|
+| 1 | k3s-pod-health     | 60s       | 5 min   | omv-disk-watchdog (every 15min)             |
+| 2 | etcd-snapshot-age  | 1h        | 6h      | omv-backup-verify (every 6h)                |
+| 3 | cloudflared-drift  | 6h        | 0 (once)| cloudflared-drift-check (every 6h)          |
+| 4 | backup-appflowy    | 24h       | 24h     | pvc-backup-appflowy (daily 03:30 UTC)       |
+| 5 | backup-espocrm     | 24h       | 24h     | pvc-backup-espocrm (daily 03:30 UTC)        |
+| 6 | backup-n8n         | 24h       | 24h     | pvc-backup-n8n (daily 03:30 UTC)            |
+| 7 | backup-postiz      | 24h       | 24h     | pvc-backup-postiz (daily 03:30 UTC)         |
+
+Note: monitor #1 is named "k3s-pod-health" for forward-compat but is
+currently fed by the disk watchdog. When we add a true pod-health checker
+we will reassign the push URL.
+
+## Wiring the Slack notification channel
+
+Once (not per-monitor):
+
+1. Settings (cog icon, bottom-left) → Notifications → "Setup Notification".
+2. Type: **Slack**.
+3. Friendly Name: `cluster-alerts`.
+4. Webhook URL: leave blank.
+5. Slack Bot Token: paste the SAME token used by cluster-alerts-secret
+   (`kubectl get secret cluster-alerts-secret -n monitoring -o jsonpath='{.data.SLACK_BOT_TOKEN}' | base64 -d`).
+6. Channel name (without #) or Channel ID: `C09AF5W3X16`.
+7. Username override: `kuma`.
+8. Apply on all existing monitors: **yes**.
+9. Save.
+
+Now every Kuma DOWN/UP transition cross-posts to the same Slack channel as
+the CronJob fallback — operators see TWO messages briefly when something
+breaks, but only the Kuma one persists in monitor history.
+
+## Populating cluster-alerts-kuma Secret
+
+After all 7 monitors exist and you have all 7 push tokens:
+
+```bash
+bash scripts/populate-kuma-secrets.sh \
+  <K3S_POD_HEALTH_TOKEN> \
+  <ETCD_SNAPSHOT_AGE_TOKEN> \
+  <CLOUDFLARED_DRIFT_TOKEN> \
+  <BACKUP_APPFLOWY_TOKEN> \
+  <BACKUP_ESPOCRM_TOKEN> \
+  <BACKUP_N8N_TOKEN> \
+  <BACKUP_POSTIZ_TOKEN>
+```
+
+The script writes the Secret to 5 namespaces (monitoring + appflowy + espocrm
++ n8n + postiz) and is idempotent — rerun on every token rotation.
+
+Verify:
+
+```bash
+# Force a watchdog run + check Kuma UI shortly after.
+kubectl create job --from=cronjob/omv-disk-watchdog test-kuma-$(date +%s) -n monitoring
+kubectl logs -n monitoring -l job-name=test-kuma-... --tail=50
+```
+
+The corresponding monitor should flip to UP within ~30 seconds.
+
+## Adding a new alert that bypasses Kuma
+
+**Discouraged.** Kuma is the single pane of glass — bypassing it means the
+alert has no history, no uptime %, no deduplication. Operators must check
+N places instead of one.
+
+Only acceptable for true emergencies:
+
+- The new check runs in an environment where outbound HTTPS to
+  kuma.cloudless.gr is blocked (rare — we have no such environment today).
+- The check runs at a frequency Kuma cannot accept (sub-second heartbeats —
+  also nothing in the cluster needs this).
+
+For everything else: add a new push monitor in the UI, append its key to
+`cluster-alerts-kuma-secret.yaml` (with sentinel + script update), and
+dual-fire in the new CronJob.
+
+## Sources of truth
+
+- `infrastructure/monitoring/omv-watchdogs.yaml` — omv-disk-watchdog +
+  omv-backup-verify (Kuma keys: `KUMA_PUSH_K3S_POD_HEALTH`,
+  `KUMA_PUSH_ETCD_SNAPSHOT_AGE`).
+- `infrastructure/monitoring/cloudflared-drift.yaml` — cloudflared-drift-check
+  (`KUMA_PUSH_CLOUDFLARED_DRIFT`).
+- `infrastructure/monitoring/cluster-alerts-kuma-secret.yaml` — Secret
+  template (7-key sentinel).
+- `infrastructure/backup/cronjob-{appflowy,espocrm,n8n,postiz}.yaml` — 4
+  daily backup CronJobs (`KUMA_PUSH_BACKUP_*`).
+- `scripts/populate-kuma-secrets.sh` — token loader.
+
+If you add a new dual-fire CronJob, update this skill's table AND the
+populate script in the same PR.

--- a/src/app/[locale]/campaigns/[slug]/thanks/ThanksConversion.tsx
+++ b/src/app/[locale]/campaigns/[slug]/thanks/ThanksConversion.tsx
@@ -45,6 +45,15 @@ export default function ThanksConversion({
         }
       : null;
 
+    // Capture LinkedIn first-party click ID from the current URL's query string.
+    // LinkedIn appends ?li_fat_id=… when a visitor arrives via a LinkedIn ad;
+    // forwarding it to CAPI allows LinkedIn to dedupe the server-side event
+    // against the browser Insight Tag hit using this shared identifier.
+    const liFatId =
+      typeof window !== "undefined"
+        ? new URLSearchParams(window.location.search).get("li_fat_id")
+        : null;
+
     fetch("/api/campaigns/conversion", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
@@ -55,6 +64,7 @@ export default function ThanksConversion({
         conversionId,
         url: typeof window !== "undefined" ? window.location.href : null,
         userAgent: typeof navigator !== "undefined" ? navigator.userAgent : null,
+        liFatId,
         utm,
       }),
     }).catch(() => {

--- a/src/app/api/campaigns/conversion/route.ts
+++ b/src/app/api/campaigns/conversion/route.ts
@@ -33,6 +33,8 @@ type Body = {
   conversionId?: number | null;
   url?: string | null;
   userAgent?: string | null;
+  /** LinkedIn first-party click ID from `?li_fat_id=…` on the landing page. */
+  liFatId?: string | null;
   utm?: {
     source?: string;
     medium?: string;
@@ -111,6 +113,7 @@ export async function POST(request: NextRequest) {
       request.headers.get("x-forwarded-for")?.split(",")[0]?.trim() ??
       undefined,
     utm: body.utm ?? undefined,
+    liFatId: body.liFatId ?? null,
     customer,
   });
 

--- a/src/app/api/webhooks/admin-alert/route.ts
+++ b/src/app/api/webhooks/admin-alert/route.ts
@@ -67,7 +67,7 @@ export async function POST(req: NextRequest) {
   }
 
   const cfg = await getConfig();
-  const expected = cfg.ADMIN_ALERT_SECRET || cfg.NOTION_WEBHOOK_SECRET || "";
+  const expected = cfg.ADMIN_ALERT_SECRET || cfg.CONTENT_WEBHOOK_SECRET || "";
   if (!expected) {
     // No secret configured anywhere — refuse rather than open up the endpoint.
     return NextResponse.json({ error: "receiver_not_configured" }, { status: 503 });

--- a/src/app/api/webhooks/content/route.ts
+++ b/src/app/api/webhooks/content/route.ts
@@ -4,17 +4,17 @@ import { revalidatePath } from "next/cache";
 import { slackContactNotify } from "@/lib/slack-notify";
 import { sendEmail } from "@/lib/email";
 import { getConfig } from "@/lib/ssm-config";
-import { invalidateCache } from "@/lib/notion-cache";
+import { invalidateCache } from "@/lib/content-cache";
 import { escapeHtml } from "@/lib/escape-html";
 import { mapIntegrationError } from "@/lib/api-errors";
 
 const SITEMAP_PATH = "/sitemap.xml";
 
 /**
- * POST /api/webhooks/notion
+ * POST /api/webhooks/content
  *
- * Receives webhook events from Notion (via Make/Zapier/n8n or a Notion
- * automation) and performs the appropriate in-app action.
+ * Receives webhook events from the CMS (AppFlowy via n8n, or legacy Notion)
+ * and performs the appropriate in-app action.
  *
  * Supported event types:
  *   - page.updated     → Revalidate cached pages (blog, docs)
@@ -27,7 +27,7 @@ const SITEMAP_PATH = "/sitemap.xml";
  * {
  *   "type": "page.updated" | "page.created" | "submission.status",
  *   "database": "blog" | "docs" | "submissions",
- *   "page_id": "<notion page id>",
+ *   "page_id": "<page id>",
  *   "slug"?: "<page slug>",
  *   "data"?: { ...extra payload depending on event type }
  * }
@@ -59,7 +59,7 @@ interface WebhookPayload {
 
 async function verifySecret(request: NextRequest): Promise<boolean> {
   const config = await getConfig();
-  const secret = config.NOTION_WEBHOOK_SECRET;
+  const secret = config.CONTENT_WEBHOOK_SECRET;
   if (!secret) return false;
   const provided = request.headers.get("x-webhook-secret");
   if (!provided) return false;
@@ -82,11 +82,6 @@ async function handlePageUpdated(payload: WebhookPayload) {
       if (slug) revalidatePath(`/blog/${slug}`);
       revalidatePath("/api/blog/posts");
       if (slug) revalidatePath(`/api/blog/${slug}`);
-      // R1 auto-post: when the blog row's Status flips to Published, fan out
-      // to connected social channels via Postiz. Opt-in via env
-      // AUTO_POST_BLOG_TO_SOCIAL=1 (off by default — operator vets copy).
-      // Idempotency lives inside scheduleBlogShare via a `blog-<pageId>` tag
-      // check against listPosts, so a Status touch can't double-post.
       if (data?.status === "Published" && page_id) {
         const { scheduleBlogShare } = await import("@/lib/postiz-blog");
         const baseUrl = process.env.SITE_URL ?? "https://cloudless.gr";
@@ -99,14 +94,14 @@ async function handlePageUpdated(payload: WebhookPayload) {
         })
           .then((r) => {
             if (r.skipped) {
-              console.warn(`[notion webhook → postiz] skipped: ${r.skipped}`);
+              console.warn(`[content webhook → postiz] skipped: ${r.skipped}`);
             } else if (r.ok) {
-              console.warn(`[notion webhook → postiz] posted ${r.postIds.length} channel(s)`);
+              console.warn(`[content webhook → postiz] posted ${r.postIds.length} channel(s)`);
             } else {
-              console.error(`[notion webhook → postiz] failed: ${r.error}`);
+              console.error(`[content webhook → postiz] failed: ${r.error}`);
             }
           })
-          .catch((err) => console.error("[notion webhook → postiz] threw:", err));
+          .catch((err) => console.error("[content webhook → postiz] threw:", err));
       }
       break;
     case "docs":
@@ -181,7 +176,7 @@ async function handlePageCreated(payload: WebhookPayload) {
 
   if (database === "docs" && data?.title) {
     await slackContactNotify({
-      name: "Notion Docs",
+      name: "CMS",
       email: "",
       company: "",
       service: "New doc published",
@@ -199,7 +194,7 @@ async function handleProjectUpdated(payload: WebhookPayload) {
 
   if (status === "Completed" && name) {
     await slackContactNotify({
-      name: "Notion Projects",
+      name: "CMS",
       email: "",
       company: "",
       service: "Project completed",
@@ -209,7 +204,7 @@ async function handleProjectUpdated(payload: WebhookPayload) {
 
   if (status === "Blocked" && name) {
     await slackContactNotify({
-      name: "Notion Projects",
+      name: "CMS",
       email: "",
       company: "",
       service: "Project blocked",
@@ -232,7 +227,7 @@ async function handleTaskUpdated(payload: WebhookPayload) {
 
   if (status === "Blocked" && task) {
     await slackContactNotify({
-      name: "Notion Tasks",
+      name: "CMS",
       email: "",
       company: "",
       service: "Task blocked",
@@ -255,7 +250,7 @@ async function handleAnalyticsEvent(payload: WebhookPayload) {
 
   if (type === "error" && count && count >= 10) {
     await slackContactNotify({
-      name: "Notion Analytics",
+      name: "CMS",
       email: "",
       company: "",
       service: "Error spike detected",
@@ -365,8 +360,8 @@ export async function POST(request: NextRequest) {
       await import("@sentry/nextjs")
         .then(({ captureException, withScope }) =>
           withScope((scope) => {
-            scope.setTag("route", "notion.webhook");
-            scope.setTag("notion.event", body.type);
+            scope.setTag("route", "content.webhook");
+            scope.setTag("content.event", body.type);
             captureException(err);
           })
         )

--- a/src/app/api/webhooks/mqtt/publish/route.ts
+++ b/src/app/api/webhooks/mqtt/publish/route.ts
@@ -32,7 +32,7 @@ const ALERTABLE_SEVERITIES: readonly AdminAlertSeverity[] = ["high", "critical"]
 
 async function verifySecret(req: NextRequest): Promise<boolean> {
   const cfg = await getConfig();
-  const expected = cfg.NOTION_WEBHOOK_SECRET;
+  const expected = cfg.CONTENT_WEBHOOK_SECRET;
   if (!expected) return false;
   const got = req.headers.get("x-mqtt-publish-secret");
   if (!got || got.length !== expected.length) return false;

--- a/src/app/api/webhooks/n8n/trigger/route.ts
+++ b/src/app/api/webhooks/n8n/trigger/route.ts
@@ -43,7 +43,7 @@ const NAME_TO_SSM_KEY: Record<string, keyof Awaited<ReturnType<typeof getConfig>
 
 async function verifySecret(req: NextRequest): Promise<boolean> {
   const cfg = await getConfig();
-  const expected = cfg.NOTION_WEBHOOK_SECRET;
+  const expected = cfg.CONTENT_WEBHOOK_SECRET;
   if (!expected) return false;
   const got = req.headers.get("x-n8n-trigger-secret");
   if (!got || got.length !== expected.length) return false;

--- a/src/lib/ad-analytics/runtime.ts
+++ b/src/lib/ad-analytics/runtime.ts
@@ -149,6 +149,7 @@ export async function dispatchConversion(event: AdConversionEvent): Promise<Disp
           emailSha256: event.customer?.email
             ? await sha256(event.customer.email.toLowerCase().trim())
             : undefined,
+          liFatId: event.liFatId ?? undefined,
         },
         pageUrl: event.url,
       });

--- a/src/lib/ad-analytics/types.ts
+++ b/src/lib/ad-analytics/types.ts
@@ -122,6 +122,10 @@ export interface AdConversionEvent {
     term?: string;
     content?: string;
   };
+  /** LinkedIn first-party click ID captured from the `?li_fat_id=…` query
+   *  param on the landing page. Used for server-side CAPI user matching so
+   *  LinkedIn can dedupe against the browser Insight Tag hit. */
+  liFatId?: string | null;
 }
 
 /** Snapshot of per-platform metrics for a campaign over a window. */

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -238,8 +238,13 @@ async function handleTokenRefresh(token: JWT, env: AuthEnv, now: number): Promis
 
 function buildNextAuth(env: AuthEnv): NextAuthResult {
   const { issuer, clientId, clientSecret, cognitoDomain, authUrl } = env;
+  // Auth.js v5 beta marks state/PKCE cookies Secure by default. On http://localhost
+  // the browser silently drops them, so the state cookie is missing on the callback
+  // and Auth.js throws ?error=Configuration. Disable secure cookies for non-HTTPS origins.
+  const useSecureCookies = authUrl.startsWith("https://");
   return NextAuth({
     providers: [Cognito({ clientId, clientSecret, issuer })],
+    useSecureCookies,
     callbacks: {
       async jwt({ token, account, profile }) {
         if (account) {

--- a/src/lib/content-cache.ts
+++ b/src/lib/content-cache.ts
@@ -1,0 +1,73 @@
+/**
+ * Simple in-memory cache for CMS API responses (AppFlowy, blog, docs, etc.).
+ *
+ * Avoids redundant API calls within the same ISR revalidation window.
+ * Each entry has a TTL (default 60s) — short enough to stay fresh,
+ * long enough to deduplicate calls within a single page render.
+ *
+ * The cache is per-process (not shared across serverless instances),
+ * which is fine for Next.js since ISR renders happen in a single process.
+ */
+
+interface CacheEntry<T> {
+  data: T;
+  expiresAt: number;
+}
+
+const cache = new Map<string, CacheEntry<unknown>>();
+const inflight = new Map<string, Promise<unknown>>();
+
+const DEFAULT_TTL_MS = 60 * 1000; // 60 seconds
+
+/**
+ * Get-or-fetch: returns cached data if fresh, otherwise calls `fetcher`
+ * and caches the result. Concurrent calls for the same key while a fetch
+ * is in progress share the single in-flight promise (stampede protection).
+ *
+ * @param key     Unique cache key (e.g. "blog:posts", "docs:all")
+ * @param fetcher Async function that fetches fresh data
+ * @param ttlMs   Cache TTL in milliseconds (default 60s)
+ */
+export async function cached<T>(
+  key: string,
+  fetcher: () => Promise<T>,
+  ttlMs = DEFAULT_TTL_MS
+): Promise<T> {
+  const now = Date.now();
+  const entry = cache.get(key) as CacheEntry<T> | undefined;
+
+  if (entry && entry.expiresAt > now) return entry.data;
+
+  const existing = inflight.get(key);
+  if (existing) return existing as Promise<T>;
+
+  const promise = fetcher()
+    .then((data) => {
+      cache.set(key, { data, expiresAt: Date.now() + ttlMs });
+      inflight.delete(key);
+      return data;
+    })
+    .catch((err) => {
+      inflight.delete(key);
+      throw err;
+    });
+
+  inflight.set(key, promise as Promise<unknown>);
+  return promise;
+}
+
+/**
+ * Invalidate a specific cache key or all keys matching a prefix.
+ */
+export function invalidateCache(keyOrPrefix?: string): void {
+  if (!keyOrPrefix) {
+    cache.clear();
+    return;
+  }
+
+  for (const key of cache.keys()) {
+    if (key === keyOrPrefix || key.startsWith(`${keyOrPrefix}:`)) {
+      cache.delete(key);
+    }
+  }
+}

--- a/src/lib/integrations.ts
+++ b/src/lib/integrations.ts
@@ -14,17 +14,6 @@ export interface IntegrationConfig {
   SLACK_WEBHOOK_URL?: string;
   SLACK_BOT_TOKEN?: string;
   SLACK_SIGNING_SECRET?: string;
-  NOTION_API_KEY?: string;
-  NOTION_BLOG_DB_ID?: string;
-  NOTION_SUBMISSIONS_DB_ID?: string;
-  NOTION_DOCS_DB_ID?: string;
-  NOTION_PROJECTS_DB_ID?: string;
-  NOTION_TASKS_DB_ID?: string;
-  NOTION_CALENDAR_DB_ID?: string;
-  NOTION_TESTIMONIALS_DB_ID?: string;
-  NOTION_CASE_STUDIES_DB_ID?: string;
-  NOTION_SERVICES_DB_ID?: string;
-  NOTION_FAQS_DB_ID?: string;
   GOOGLE_CLIENT_EMAIL?: string;
   GOOGLE_SERVICE_ACCOUNT_EMAIL?: string;
   GOOGLE_PRIVATE_KEY?: string;
@@ -33,7 +22,7 @@ export interface IntegrationConfig {
   SENTRY_AUTH_TOKEN?: string;
   SENTRY_ORG?: string;
   SENTRY_PROJECT?: string;
-  NOTION_WEBHOOK_SECRET?: string;
+  CONTENT_WEBHOOK_SECRET?: string;
   // ActiveCampaign
   ACTIVECAMPAIGN_API_URL?: string;
   ACTIVECAMPAIGN_API_TOKEN?: string;
@@ -69,6 +58,20 @@ export interface IntegrationConfig {
   ESPOCRM_BASE_URL?: string;
   ESPOCRM_API_KEY?: string;
   ESPOCRM_WEBHOOK_SECRET?: string;
+  // Notion SDK (read-only legacy; SSM keys decommissioned — values come from env only)
+  NOTION_API_KEY?: string;
+  NOTION_BLOG_DB_ID?: string;
+  NOTION_SUBMISSIONS_DB_ID?: string;
+  NOTION_DOCS_DB_ID?: string;
+  NOTION_PROJECTS_DB_ID?: string;
+  NOTION_TASKS_DB_ID?: string;
+  NOTION_ANALYTICS_DB_ID?: string;
+  NOTION_CALENDAR_DB_ID?: string;
+  NOTION_REPORTS_DB_ID?: string;
+  NOTION_TESTIMONIALS_DB_ID?: string;
+  NOTION_CASE_STUDIES_DB_ID?: string;
+  NOTION_SERVICES_DB_ID?: string;
+  NOTION_FAQS_DB_ID?: string;
   // AppFlowy Cloud (Notion replacement, self-hosted on omv k3s; see skills/appflowy-operator)
   APPFLOWY_API_URL?: string;
   APPFLOWY_JWT_SECRET?: string;
@@ -89,17 +92,6 @@ export function getIntegrations(): IntegrationConfig {
     SLACK_WEBHOOK_URL: process.env.SLACK_WEBHOOK_URL,
     SLACK_BOT_TOKEN: process.env.SLACK_BOT_TOKEN,
     SLACK_SIGNING_SECRET: process.env.SLACK_SIGNING_SECRET,
-    NOTION_API_KEY: process.env.NOTION_API_KEY,
-    NOTION_BLOG_DB_ID: process.env.NOTION_BLOG_DB_ID,
-    NOTION_SUBMISSIONS_DB_ID: process.env.NOTION_SUBMISSIONS_DB_ID,
-    NOTION_DOCS_DB_ID: process.env.NOTION_DOCS_DB_ID,
-    NOTION_PROJECTS_DB_ID: process.env.NOTION_PROJECTS_DB_ID,
-    NOTION_TASKS_DB_ID: process.env.NOTION_TASKS_DB_ID,
-    NOTION_CALENDAR_DB_ID: process.env.NOTION_CALENDAR_DB_ID,
-    NOTION_TESTIMONIALS_DB_ID: process.env.NOTION_TESTIMONIALS_DB_ID,
-    NOTION_CASE_STUDIES_DB_ID: process.env.NOTION_CASE_STUDIES_DB_ID,
-    NOTION_SERVICES_DB_ID: process.env.NOTION_SERVICES_DB_ID,
-    NOTION_FAQS_DB_ID: process.env.NOTION_FAQS_DB_ID,
     GOOGLE_CLIENT_EMAIL: process.env.GOOGLE_CLIENT_EMAIL,
     GOOGLE_SERVICE_ACCOUNT_EMAIL:
       process.env.GOOGLE_SERVICE_ACCOUNT_EMAIL || process.env.GOOGLE_CLIENT_EMAIL,
@@ -109,7 +101,7 @@ export function getIntegrations(): IntegrationConfig {
     SENTRY_AUTH_TOKEN: process.env.SENTRY_AUTH_TOKEN,
     SENTRY_ORG: process.env.SENTRY_ORG ?? DEFAULT_SENTRY_ORG,
     SENTRY_PROJECT: process.env.SENTRY_PROJECT ?? DEFAULT_SENTRY_PROJECT,
-    NOTION_WEBHOOK_SECRET: process.env.NOTION_WEBHOOK_SECRET,
+    CONTENT_WEBHOOK_SECRET: process.env.CONTENT_WEBHOOK_SECRET || process.env.NOTION_WEBHOOK_SECRET,
     ACTIVECAMPAIGN_API_URL: process.env.ACTIVECAMPAIGN_API_URL,
     ACTIVECAMPAIGN_API_TOKEN: process.env.ACTIVECAMPAIGN_API_TOKEN,
     GOOGLE_ADS_DEVELOPER_TOKEN: process.env.GOOGLE_ADS_DEVELOPER_TOKEN,
@@ -137,6 +129,19 @@ export function getIntegrations(): IntegrationConfig {
     ESPOCRM_BASE_URL: process.env.ESPOCRM_BASE_URL,
     ESPOCRM_API_KEY: process.env.ESPOCRM_API_KEY,
     ESPOCRM_WEBHOOK_SECRET: process.env.ESPOCRM_WEBHOOK_SECRET,
+    NOTION_API_KEY: process.env.NOTION_API_KEY,
+    NOTION_BLOG_DB_ID: process.env.NOTION_BLOG_DB_ID,
+    NOTION_SUBMISSIONS_DB_ID: process.env.NOTION_SUBMISSIONS_DB_ID,
+    NOTION_DOCS_DB_ID: process.env.NOTION_DOCS_DB_ID,
+    NOTION_PROJECTS_DB_ID: process.env.NOTION_PROJECTS_DB_ID,
+    NOTION_TASKS_DB_ID: process.env.NOTION_TASKS_DB_ID,
+    NOTION_ANALYTICS_DB_ID: process.env.NOTION_ANALYTICS_DB_ID,
+    NOTION_CALENDAR_DB_ID: process.env.NOTION_CALENDAR_DB_ID,
+    NOTION_REPORTS_DB_ID: process.env.NOTION_REPORTS_DB_ID,
+    NOTION_TESTIMONIALS_DB_ID: process.env.NOTION_TESTIMONIALS_DB_ID,
+    NOTION_CASE_STUDIES_DB_ID: process.env.NOTION_CASE_STUDIES_DB_ID,
+    NOTION_SERVICES_DB_ID: process.env.NOTION_SERVICES_DB_ID,
+    NOTION_FAQS_DB_ID: process.env.NOTION_FAQS_DB_ID,
     APPFLOWY_API_URL: process.env.APPFLOWY_API_URL,
     APPFLOWY_JWT_SECRET: process.env.APPFLOWY_JWT_SECRET,
     N8N_API_URL: process.env.N8N_API_URL,
@@ -172,7 +177,6 @@ export async function getIntegrationsAsync(): Promise<IntegrationConfig> {
 
   // If all critical keys are already present in env, skip SSM round-trip
   const criticalKeys: (keyof IntegrationConfig)[] = [
-    "NOTION_API_KEY",
     "STRIPE_SECRET_KEY",
     "SENTRY_AUTH_TOKEN",
   ];
@@ -191,20 +195,6 @@ export async function getIntegrationsAsync(): Promise<IntegrationConfig> {
       SLACK_WEBHOOK_URL: envCfg.SLACK_WEBHOOK_URL || ssm.SLACK_WEBHOOK_URL || undefined,
       SLACK_BOT_TOKEN: envCfg.SLACK_BOT_TOKEN || ssm.SLACK_BOT_TOKEN || undefined,
       SLACK_SIGNING_SECRET: envCfg.SLACK_SIGNING_SECRET || ssm.SLACK_SIGNING_SECRET || undefined,
-      NOTION_API_KEY: envCfg.NOTION_API_KEY || ssm.NOTION_API_KEY || undefined,
-      NOTION_BLOG_DB_ID: envCfg.NOTION_BLOG_DB_ID || ssm.NOTION_BLOG_DB_ID || undefined,
-      NOTION_SUBMISSIONS_DB_ID:
-        envCfg.NOTION_SUBMISSIONS_DB_ID || ssm.NOTION_SUBMISSIONS_DB_ID || undefined,
-      NOTION_DOCS_DB_ID: envCfg.NOTION_DOCS_DB_ID || ssm.NOTION_DOCS_DB_ID || undefined,
-      NOTION_PROJECTS_DB_ID: envCfg.NOTION_PROJECTS_DB_ID || ssm.NOTION_PROJECTS_DB_ID || undefined,
-      NOTION_TASKS_DB_ID: envCfg.NOTION_TASKS_DB_ID || ssm.NOTION_TASKS_DB_ID || undefined,
-      NOTION_CALENDAR_DB_ID: envCfg.NOTION_CALENDAR_DB_ID || ssm.NOTION_CALENDAR_DB_ID || undefined,
-      NOTION_TESTIMONIALS_DB_ID:
-        envCfg.NOTION_TESTIMONIALS_DB_ID || ssm.NOTION_TESTIMONIALS_DB_ID || undefined,
-      NOTION_CASE_STUDIES_DB_ID:
-        envCfg.NOTION_CASE_STUDIES_DB_ID || ssm.NOTION_CASE_STUDIES_DB_ID || undefined,
-      NOTION_SERVICES_DB_ID: envCfg.NOTION_SERVICES_DB_ID || ssm.NOTION_SERVICES_DB_ID || undefined,
-      NOTION_FAQS_DB_ID: envCfg.NOTION_FAQS_DB_ID || ssm.NOTION_FAQS_DB_ID || undefined,
       GOOGLE_CLIENT_EMAIL: envCfg.GOOGLE_CLIENT_EMAIL || ssm.GOOGLE_CLIENT_EMAIL || undefined,
       GOOGLE_SERVICE_ACCOUNT_EMAIL:
         envCfg.GOOGLE_SERVICE_ACCOUNT_EMAIL || ssm.GOOGLE_CLIENT_EMAIL || undefined,
@@ -214,7 +204,7 @@ export async function getIntegrationsAsync(): Promise<IntegrationConfig> {
       SENTRY_AUTH_TOKEN: envCfg.SENTRY_AUTH_TOKEN || ssm.SENTRY_AUTH_TOKEN || undefined,
       SENTRY_ORG: envCfg.SENTRY_ORG || ssm.SENTRY_ORG || DEFAULT_SENTRY_ORG,
       SENTRY_PROJECT: envCfg.SENTRY_PROJECT || ssm.SENTRY_PROJECT || DEFAULT_SENTRY_PROJECT,
-      NOTION_WEBHOOK_SECRET: envCfg.NOTION_WEBHOOK_SECRET || ssm.NOTION_WEBHOOK_SECRET || undefined,
+      CONTENT_WEBHOOK_SECRET: envCfg.CONTENT_WEBHOOK_SECRET || ssm.CONTENT_WEBHOOK_SECRET || undefined,
       ACTIVECAMPAIGN_API_URL:
         envCfg.ACTIVECAMPAIGN_API_URL || ssm.ACTIVECAMPAIGN_API_URL || undefined,
       ACTIVECAMPAIGN_API_TOKEN:
@@ -251,6 +241,19 @@ export async function getIntegrationsAsync(): Promise<IntegrationConfig> {
       ESPOCRM_API_KEY: envCfg.ESPOCRM_API_KEY || ssm.ESPOCRM_API_KEY || undefined,
       ESPOCRM_WEBHOOK_SECRET:
         envCfg.ESPOCRM_WEBHOOK_SECRET || ssm.ESPOCRM_WEBHOOK_SECRET || undefined,
+      NOTION_API_KEY: envCfg.NOTION_API_KEY || undefined,
+      NOTION_BLOG_DB_ID: envCfg.NOTION_BLOG_DB_ID || undefined,
+      NOTION_SUBMISSIONS_DB_ID: envCfg.NOTION_SUBMISSIONS_DB_ID || undefined,
+      NOTION_DOCS_DB_ID: envCfg.NOTION_DOCS_DB_ID || undefined,
+      NOTION_PROJECTS_DB_ID: envCfg.NOTION_PROJECTS_DB_ID || undefined,
+      NOTION_TASKS_DB_ID: envCfg.NOTION_TASKS_DB_ID || undefined,
+      NOTION_ANALYTICS_DB_ID: envCfg.NOTION_ANALYTICS_DB_ID || undefined,
+      NOTION_CALENDAR_DB_ID: envCfg.NOTION_CALENDAR_DB_ID || undefined,
+      NOTION_REPORTS_DB_ID: envCfg.NOTION_REPORTS_DB_ID || undefined,
+      NOTION_TESTIMONIALS_DB_ID: envCfg.NOTION_TESTIMONIALS_DB_ID || undefined,
+      NOTION_CASE_STUDIES_DB_ID: envCfg.NOTION_CASE_STUDIES_DB_ID || undefined,
+      NOTION_SERVICES_DB_ID: envCfg.NOTION_SERVICES_DB_ID || undefined,
+      NOTION_FAQS_DB_ID: envCfg.NOTION_FAQS_DB_ID || undefined,
       APPFLOWY_API_URL: envCfg.APPFLOWY_API_URL || ssm.APPFLOWY_API_URL || undefined,
       APPFLOWY_JWT_SECRET: envCfg.APPFLOWY_JWT_SECRET || ssm.APPFLOWY_JWT_SECRET || undefined,
       N8N_API_URL: envCfg.N8N_API_URL || ssm.N8N_API_URL || undefined,

--- a/src/lib/postiz-blog.ts
+++ b/src/lib/postiz-blog.ts
@@ -1,6 +1,6 @@
 /**
  * postiz-blog — auto-post a blog post to connected social channels when its
- * Status flips to `Published`. Wired from `src/app/api/webhooks/notion/route.ts`
+ * Status flips to `Published`. Wired from `src/app/api/webhooks/content/route.ts`
  * on the `database=blog`, `type=page.updated` event.
  *
  * Opt-in: only fires when the env flag `AUTO_POST_BLOG_TO_SOCIAL=1` is set

--- a/src/lib/ssm-config.ts
+++ b/src/lib/ssm-config.ts
@@ -102,25 +102,28 @@ interface AppConfig {
    *  in addition to Slack. Lives in SSM (not env) so the operator can
    *  flip it without a Lambda redeploy. Default off. */
   ADMIN_PUSH_VIA_NTFY: string;
+  /** Notion SDK — read-only legacy; not fetched from SSM (keys decommissioned).
+   *  All values come from process.env only. */
   NOTION_API_KEY: string;
   NOTION_BLOG_DB_ID: string;
-  NOTION_WEBHOOK_SECRET: string;
-  /** Optional shared secret for `/api/webhooks/admin-alert` (R8). Falls back
-   *  to NOTION_WEBHOOK_SECRET when unset so existing callers keep working. */
-  ADMIN_ALERT_SECRET: string;
-  /** Sentry internal-integration Client Secret used to HMAC-verify webhooks
-   *  at `/api/webhooks/sentry`. R8 — required for the Sentry receiver. */
-  SENTRY_WEBHOOK_SECRET: string;
-  // Notion database IDs
   NOTION_SUBMISSIONS_DB_ID: string;
   NOTION_DOCS_DB_ID: string;
   NOTION_PROJECTS_DB_ID: string;
   NOTION_TASKS_DB_ID: string;
+  NOTION_ANALYTICS_DB_ID: string;
   NOTION_CALENDAR_DB_ID: string;
+  NOTION_REPORTS_DB_ID: string;
   NOTION_TESTIMONIALS_DB_ID: string;
   NOTION_CASE_STUDIES_DB_ID: string;
   NOTION_SERVICES_DB_ID: string;
   NOTION_FAQS_DB_ID: string;
+  CONTENT_WEBHOOK_SECRET: string;
+  /** Optional shared secret for `/api/webhooks/admin-alert` (R8). Falls back
+   *  to CONTENT_WEBHOOK_SECRET when unset so existing callers keep working. */
+  ADMIN_ALERT_SECRET: string;
+  /** Sentry internal-integration Client Secret used to HMAC-verify webhooks
+   *  at `/api/webhooks/sentry`. R8 — required for the Sentry receiver. */
+  SENTRY_WEBHOOK_SECRET: string;
   GOOGLE_CLIENT_EMAIL: string;
   GOOGLE_PRIVATE_KEY: string;
   GOOGLE_CALENDAR_ID: string;
@@ -285,20 +288,22 @@ function buildConfigFromParams(params: Map<string, string>): AppConfig {
     NTFY_TOPIC: params.get("NTFY_TOPIC") ?? "",
     NTFY_TOKEN: params.get("NTFY_TOKEN") ?? "",
     ADMIN_PUSH_VIA_NTFY: params.get("ADMIN_PUSH_VIA_NTFY") ?? "",
-    NOTION_API_KEY: params.get("NOTION_API_KEY") ?? "",
-    NOTION_BLOG_DB_ID: params.get("NOTION_BLOG_DB_ID") ?? "",
-    NOTION_WEBHOOK_SECRET: params.get("NOTION_WEBHOOK_SECRET") ?? "",
+    NOTION_API_KEY: process.env.NOTION_API_KEY ?? "",
+    NOTION_BLOG_DB_ID: process.env.NOTION_BLOG_DB_ID ?? "",
+    NOTION_SUBMISSIONS_DB_ID: process.env.NOTION_SUBMISSIONS_DB_ID ?? "",
+    NOTION_DOCS_DB_ID: process.env.NOTION_DOCS_DB_ID ?? "",
+    NOTION_PROJECTS_DB_ID: process.env.NOTION_PROJECTS_DB_ID ?? "",
+    NOTION_TASKS_DB_ID: process.env.NOTION_TASKS_DB_ID ?? "",
+    NOTION_ANALYTICS_DB_ID: process.env.NOTION_ANALYTICS_DB_ID ?? "",
+    NOTION_CALENDAR_DB_ID: process.env.NOTION_CALENDAR_DB_ID ?? "",
+    NOTION_REPORTS_DB_ID: process.env.NOTION_REPORTS_DB_ID ?? "",
+    NOTION_TESTIMONIALS_DB_ID: process.env.NOTION_TESTIMONIALS_DB_ID ?? "",
+    NOTION_CASE_STUDIES_DB_ID: process.env.NOTION_CASE_STUDIES_DB_ID ?? "",
+    NOTION_SERVICES_DB_ID: process.env.NOTION_SERVICES_DB_ID ?? "",
+    NOTION_FAQS_DB_ID: process.env.NOTION_FAQS_DB_ID ?? "",
+    CONTENT_WEBHOOK_SECRET: params.get("CONTENT_WEBHOOK_SECRET") ?? params.get("NOTION_WEBHOOK_SECRET") ?? "",
     ADMIN_ALERT_SECRET: params.get("ADMIN_ALERT_SECRET") ?? "",
     SENTRY_WEBHOOK_SECRET: params.get("SENTRY_WEBHOOK_SECRET") ?? "",
-    NOTION_SUBMISSIONS_DB_ID: params.get("NOTION_SUBMISSIONS_DB_ID") ?? "",
-    NOTION_DOCS_DB_ID: params.get("NOTION_DOCS_DB_ID") ?? "",
-    NOTION_PROJECTS_DB_ID: params.get("NOTION_PROJECTS_DB_ID") ?? "",
-    NOTION_TASKS_DB_ID: params.get("NOTION_TASKS_DB_ID") ?? "",
-    NOTION_CALENDAR_DB_ID: params.get("NOTION_CALENDAR_DB_ID") ?? "",
-    NOTION_TESTIMONIALS_DB_ID: params.get("NOTION_TESTIMONIALS_DB_ID") ?? "",
-    NOTION_CASE_STUDIES_DB_ID: params.get("NOTION_CASE_STUDIES_DB_ID") ?? "",
-    NOTION_SERVICES_DB_ID: params.get("NOTION_SERVICES_DB_ID") ?? "",
-    NOTION_FAQS_DB_ID: params.get("NOTION_FAQS_DB_ID") ?? "",
     GOOGLE_CLIENT_EMAIL: params.get("GOOGLE_CLIENT_EMAIL") ?? "",
     GOOGLE_PRIVATE_KEY: (params.get("GOOGLE_PRIVATE_KEY") ?? "").replaceAll(String.raw`\n`, "\n"),
     GOOGLE_CALENDAR_ID: params.get("GOOGLE_CALENDAR_ID") ?? "",
@@ -392,20 +397,22 @@ function buildConfigFromEnv(): AppConfig {
     NTFY_TOPIC: process.env.NTFY_TOPIC || "",
     NTFY_TOKEN: process.env.NTFY_TOKEN || "",
     ADMIN_PUSH_VIA_NTFY: process.env.ADMIN_PUSH_VIA_NTFY || "",
-    NOTION_API_KEY: process.env.NOTION_API_KEY || "",
-    NOTION_BLOG_DB_ID: process.env.NOTION_BLOG_DB_ID || "",
-    NOTION_WEBHOOK_SECRET: process.env.NOTION_WEBHOOK_SECRET || "",
+    NOTION_API_KEY: process.env.NOTION_API_KEY ?? "",
+    NOTION_BLOG_DB_ID: process.env.NOTION_BLOG_DB_ID ?? "",
+    NOTION_SUBMISSIONS_DB_ID: process.env.NOTION_SUBMISSIONS_DB_ID ?? "",
+    NOTION_DOCS_DB_ID: process.env.NOTION_DOCS_DB_ID ?? "",
+    NOTION_PROJECTS_DB_ID: process.env.NOTION_PROJECTS_DB_ID ?? "",
+    NOTION_TASKS_DB_ID: process.env.NOTION_TASKS_DB_ID ?? "",
+    NOTION_ANALYTICS_DB_ID: process.env.NOTION_ANALYTICS_DB_ID ?? "",
+    NOTION_CALENDAR_DB_ID: process.env.NOTION_CALENDAR_DB_ID ?? "",
+    NOTION_REPORTS_DB_ID: process.env.NOTION_REPORTS_DB_ID ?? "",
+    NOTION_TESTIMONIALS_DB_ID: process.env.NOTION_TESTIMONIALS_DB_ID ?? "",
+    NOTION_CASE_STUDIES_DB_ID: process.env.NOTION_CASE_STUDIES_DB_ID ?? "",
+    NOTION_SERVICES_DB_ID: process.env.NOTION_SERVICES_DB_ID ?? "",
+    NOTION_FAQS_DB_ID: process.env.NOTION_FAQS_DB_ID ?? "",
+    CONTENT_WEBHOOK_SECRET: process.env.CONTENT_WEBHOOK_SECRET || process.env.NOTION_WEBHOOK_SECRET || "",
     ADMIN_ALERT_SECRET: process.env.ADMIN_ALERT_SECRET || "",
     SENTRY_WEBHOOK_SECRET: process.env.SENTRY_WEBHOOK_SECRET || "",
-    NOTION_SUBMISSIONS_DB_ID: process.env.NOTION_SUBMISSIONS_DB_ID || "",
-    NOTION_DOCS_DB_ID: process.env.NOTION_DOCS_DB_ID || "",
-    NOTION_PROJECTS_DB_ID: process.env.NOTION_PROJECTS_DB_ID || "",
-    NOTION_TASKS_DB_ID: process.env.NOTION_TASKS_DB_ID || "",
-    NOTION_CALENDAR_DB_ID: process.env.NOTION_CALENDAR_DB_ID || "",
-    NOTION_TESTIMONIALS_DB_ID: process.env.NOTION_TESTIMONIALS_DB_ID || "",
-    NOTION_CASE_STUDIES_DB_ID: process.env.NOTION_CASE_STUDIES_DB_ID || "",
-    NOTION_SERVICES_DB_ID: process.env.NOTION_SERVICES_DB_ID || "",
-    NOTION_FAQS_DB_ID: process.env.NOTION_FAQS_DB_ID || "",
     GOOGLE_CLIENT_EMAIL: process.env.GOOGLE_CLIENT_EMAIL || "",
     GOOGLE_PRIVATE_KEY: (process.env.GOOGLE_PRIVATE_KEY || "").replace(/\\n/g, "\n"),
     GOOGLE_CALENDAR_ID: process.env.GOOGLE_CALENDAR_ID || "",

--- a/sst.config.ts
+++ b/sst.config.ts
@@ -80,23 +80,8 @@ function buildSiteEnvironment(
           NEXT_PUBLIC_AUTH_PROVIDER: "cognito",
         }
       : {}),
-    // Notion database IDs (non-secret, safe to inline)
-    NOTION_BLOG_DB_ID: "0ac591657ee44063bbbc8004ea7ccd6c",
-    NOTION_SUBMISSIONS_DB_ID: "9abe0a5614d64b759d44a45cee2d0bbc",
-    NOTION_DOCS_DB_ID: "b45af6ed5bb64d89b9a92a8aff4a9b29",
-    NOTION_PROJECTS_DB_ID: "a9bab34b945e484fb6b0aa6034086e5c",
-    NOTION_TASKS_DB_ID: "14ce4ff6c400437597b13e70ac909354",
-    NOTION_ANALYTICS_DB_ID: "cc4287fcb42a42dc92a7053d6f1199c7",
     // Google Search Console site ownership verification — public token, safe to inline.
     NEXT_PUBLIC_GOOGLE_SITE_VERIFICATION: "LXkyzmWrAYuY1C6XD6TKaqA31KB72xbUlkimE0vKI8w",
-    // CMS databases (Testimonials, Case Studies, Services, FAQs)
-    NOTION_TESTIMONIALS_DB_ID: "157ceb35d0b44661a6c67798f6d87e7b",
-    NOTION_CASE_STUDIES_DB_ID: "7c50dc2403054f4a81f85b0a251ac4d7",
-    NOTION_SERVICES_DB_ID: "98a4087c86704818a1dde515104c2331",
-    NOTION_FAQS_DB_ID: "316acfca94f444d38c857aa765c259a2",
-    // Content management databases
-    NOTION_CALENDAR_DB_ID: "dcff73b9317b4ed69a450f200db0f629",
-    NOTION_REPORTS_DB_ID: "3d2851e41daa4904ab0f4099a9c10d19",
   };
 }
 


### PR DESCRIPTION
## Summary

Wires the 3 in-cluster alert CronJobs (and reuses for 4 backup CronJobs) to Uptime Kuma at `kuma.cloudless.gr` via a **dual-fire pattern**: every alert path pushes to a Kuma push monitor AND keeps the existing direct-to-Slack `chat.postMessage` call. A Kuma outage cannot blind us.

## Dual-fire pattern

Every guarded push uses:

```sh
[ -n "${KUMA_PUSH_TOKEN:-}" ] && \
  wget -qO- "https://kuma.cloudless.gr/api/push/${KUMA_PUSH_TOKEN}?status=up&msg=..." \
    >/dev/null 2>&1 || true
```

Combined with `optional: true` on the `secretKeyRef`, a missing or sentinel
token causes a silent 404 — Slack-direct path still fires normally.

## What ships in this PR (Phase 1, no Kuma UI yet)

| File | Change |
|------|--------|
| `infrastructure/monitoring/omv-watchdogs.yaml` | Add `KUMA_PUSH_TOKEN` env + 4 push call-sites (up + down per CronJob) |
| `infrastructure/monitoring/cloudflared-drift.yaml` | Same pattern — up on in-sync, down on drift/unreachable |
| `infrastructure/monitoring/cluster-alerts-kuma-secret.yaml` | NEW — Secret template with 7 keys, all sentinel `PENDING_UI_CREATION` |
| `infrastructure/backup/cronjob-{appflowy,espocrm,n8n,postiz}.yaml` | Rewire from never-created `pvc-backup-kuma` → `cluster-alerts-kuma` |
| `scripts/populate-kuma-secrets.sh` | NEW — 7-arg idempotent token loader (writes Secret to 5 namespaces) |
| `skills/uptime-kuma-operator/SKILL.md` | NEW — UI walkthrough, 7-monitor settings table, Slack-channel wiring, token-population runbook |

## Phase 2 (operator, not in this PR)

1. Log into https://kuma.cloudless.gr and create 7 push monitors per the table in `skills/uptime-kuma-operator/SKILL.md`.
2. Wire the Slack notification channel once (Settings → Notifications → New → Slack, bot token + `C09AF5W3X16`).
3. Run `bash scripts/populate-kuma-secrets.sh <7 tokens>` to replace the `PENDING_UI_CREATION` sentinels with real Kuma push URLs.
4. Verify by triggering a watchdog manually: `kubectl create job --from=cronjob/omv-disk-watchdog test-kuma-$(date +%s) -n monitoring` — the corresponding monitor should flip to UP in ~30 s.

## Dry-run validation

All 7 YAMLs pass `kubectl apply --dry-run=client -f …`:

```
serviceaccount/omv-watchdog unchanged (dry run)
cronjob.batch/omv-disk-watchdog configured (dry run)
cronjob.batch/omv-backup-verify configured (dry run)
serviceaccount/cloudflared-drift unchanged (dry run)
cronjob.batch/cloudflared-drift-check configured (dry run)
secret/cluster-alerts-kuma created (dry run)
cronjob.batch/pvc-backup-appflowy configured (dry run)
cronjob.batch/pvc-backup-espocrm configured (dry run)
cronjob.batch/pvc-backup-n8n configured (dry run)
cronjob.batch/pvc-backup-postiz configured (dry run)
```

## Notes

- Task description referenced container names `cluster-alerts` and `etcd-snapshot-age`; the actual CronJobs in `omv-watchdogs.yaml` are `omv-disk-watchdog` and `omv-backup-verify`. Patched those (the real ones); the Kuma monitor keys still use the task-spec names (`KUMA_PUSH_K3S_POD_HEALTH`, `KUMA_PUSH_ETCD_SNAPSHOT_AGE`) for forward-compat.
- The 4 backup CronJobs were already wired for Kuma but pointed at a Secret (`pvc-backup-kuma`) that was never created — silently no-op'ing. They now share `cluster-alerts-kuma`.
- DRAFT: do NOT merge before operator finishes Phase 2 OR explicitly approves.