### PR TITLE
fix(etcd-backup): restore hourly snapshot pipeline + add NAS mirror timer

### DIFF
--- a/infrastructure/etcd-backup/README.md
+++ b/infrastructure/etcd-backup/README.md
@@ -1,0 +1,82 @@
+# etcd backup — k3s snapshot pipeline
+
+Three files glued together so the `omv-backup-verify` watchdog
+(`infrastructure/monitoring/omv-watchdogs.yaml`) always sees a fresh
+etcd snapshot under
+`/srv/dev-disk-by-uuid-fa6231ab-*/Backups/k3s-db/snapshots/`.
+
+| File | Installed at | Purpose |
+| ---- | ------------ | ------- |
+| `config.yaml` | `/etc/rancher/k3s/config.yaml` (mode 0600, root:root) | Tells k3s to write a snapshot every hour into its data-dir. |
+| `k3s-snapshot-mirror.sh` | `/usr/local/sbin/k3s-snapshot-mirror.sh` (mode 0755) | rsyncs the data-dir snapshots dir to the NAS backup mount. |
+| `k3s-snapshot-mirror.service` | `/etc/systemd/system/k3s-snapshot-mirror.service` | systemd unit that runs the script as a one-shot. |
+| `k3s-snapshot-mirror.timer` | `/etc/systemd/system/k3s-snapshot-mirror.timer` | systemd timer that fires the service every 30 min + 5 min after boot. |
+
+## Why two stages?
+
+1. k3s writes hourly snapshots to its own data-dir (fast, local SSD).
+2. The mirror timer copies them every 30 min to the NAS mount on the
+   1 TB Samsung SSD (sdb1), which is independent of the k3s data SSD
+   (sda1). This protects against sda1 failure and is what the watchdog
+   actually checks.
+
+If the k3s config still contained the (formerly used) etcd-s3 directives
+with live AWS keys, there would be a third stage to S3 too. The keys
+are currently dead — see `docs/aws-credentials-rotation-runbook.md`
+for the path back to S3 mirroring. Local + NAS protection is fine for
+the meantime.
+
+## Install on omv (operator runbook)
+
+```bash
+# 1. Ship the files to the Pi.
+scp infrastructure/etcd-backup/k3s-snapshot-mirror.sh \
+    infrastructure/etcd-backup/k3s-snapshot-mirror.service \
+    infrastructure/etcd-backup/k3s-snapshot-mirror.timer \
+    infrastructure/etcd-backup/config.yaml \
+    tbaltzakis@omv:/tmp/
+
+# 2. Install (idempotent, mode-correct, root-owned).
+ssh tbaltzakis@omv '
+  sudo install -m 0755 -o root -g root \
+    /tmp/k3s-snapshot-mirror.sh /usr/local/sbin/k3s-snapshot-mirror.sh
+  sudo install -m 0644 -o root -g root \
+    /tmp/k3s-snapshot-mirror.service /etc/systemd/system/
+  sudo install -m 0644 -o root -g root \
+    /tmp/k3s-snapshot-mirror.timer /etc/systemd/system/
+  sudo systemctl daemon-reload
+  sudo systemctl enable --now k3s-snapshot-mirror.timer
+  sudo cp /etc/rancher/k3s/config.yaml \
+    /etc/rancher/k3s/config.yaml.bak.$(date +%Y%m%dT%H%M%S)
+  sudo install -m 0600 -o root -g root \
+    /tmp/config.yaml /etc/rancher/k3s/config.yaml
+  sudo systemctl restart k3s
+'
+
+# 3. Verify (force snapshot + mirror, then list newest under backup mount).
+ssh tbaltzakis@omv '
+  TS=$(date +%s)
+  sudo k3s etcd-snapshot save --name "verify-${TS}"
+  sudo systemctl start k3s-snapshot-mirror.service
+  sleep 3
+  sudo find /srv/dev-disk-by-uuid-fa6231ab-*/Backups/k3s-db \
+    -type f -printf "%T@ %TY-%Tm-%Td %TH:%TM %p\n" \
+  | sort -nr | head -3
+'
+```
+
+## Verifying the watchdog passes
+
+The watchdog runs every 6h at `30 */6 * * *`. Force-trigger via
+`kubectl -n monitoring create job omv-backup-verify-manual --from=cronjob/omv-backup-verify`.
+Look for `backup healthy: newest snapshot 0h old` in pod logs.
+
+## Schedule cadence summary
+
+| What | Where | Cadence |
+| ---- | ----- | ------- |
+| k3s etcd snapshot save | `/var/lib/rancher/k3s/server/db/snapshots/` (-> `/srv/.../k3s/...`) | hourly (top of hour, UTC) |
+| Mirror to NAS | `/srv/.../Backups/k3s-db/snapshots/` | every 30 min |
+| omv-backup-verify watchdog | k8s CronJob in `monitoring` ns | every 6h |
+| Weekly defrag pre-snapshot | same data-dir | Sundays 04:30 EEST |
+| Full nas-backup rsync (covers wider scope) | `/usr/local/sbin/nas-backup` (host cron) | daily 02:00 |

--- a/infrastructure/etcd-backup/config.yaml
+++ b/infrastructure/etcd-backup/config.yaml
@@ -1,0 +1,47 @@
+# Source-of-truth for /etc/rancher/k3s/config.yaml on omv (Pi 5 control plane).
+#
+# History:
+#   2026-06-25 ~18:20 — config was stripped down to just tls-san +
+#     secrets-encryption (root cause unclear; probably a botched edit
+#     during the k3s flap window before the 20:23 service restart).
+#   2026-06-25 20:23 — k3s restarted, picked up the stripped config.
+#     Etcd snapshots fell back to the k3s default schedule
+#     ("0 */12 * * *", twice daily) instead of the hourly cadence
+#     CLAUDE.md requires. The omv-backup-verify CronJob (SLO 2h) started
+#     paging in Slack as the backup-mount copy aged past 6h, 12h, 22h...
+#   2026-06-26 14:39 — restored from this file via:
+#     sudo install -m 0600 infrastructure/etcd-backup/config.yaml \
+#       /etc/rancher/k3s/config.yaml && sudo systemctl restart k3s
+#
+# This file deliberately OMITS the etcd-s3-* directives that the
+# previous full config (scripts/configure-k3s.sh) used to render. The
+# embedded AWS IAM keys (AKIAUBXIAELUS34WI2KW) are dead — every hourly
+# upload would error and noise the journal. Once a fresh
+# cloudless-etcd-backup IAM user is minted (see
+# docs/aws-credentials-rotation-runbook.md), re-render with
+# `scripts/configure-k3s.sh` to put S3 mirroring back in place. Local
+# snapshots remain safe in the meantime via the k3s-snapshot-mirror
+# systemd timer (this directory) which rsyncs to the NAS backup mount
+# every 30 minutes.
+#
+# Do NOT add `data-dir` here. /var/lib/rancher/k3s/server is a symlink
+# to /srv/dev-disk-by-uuid-a9a5a108-*/k3s/server, so data already lives
+# on the dedicated SSD. The systemd ExecStart in /etc/systemd/system/
+# k3s.service still passes `--data-dir /srv/.../k3s` explicitly; keeping
+# both in sync is the job of scripts/configure-k3s.sh.
+
+tls-san:
+  - 192.168.1.128
+  - 192.168.1.130
+  - 100.74.191.58
+  - 100.113.41.119
+
+secrets-encryption: true
+
+# k3s etcd snapshot schedule — CLAUDE.md "k3s Tuning" requires hourly.
+# Snapshots land in /var/lib/rancher/k3s/server/db/snapshots/
+# (symlinked -> /srv/.../k3s/server/db/snapshots/). The
+# k3s-snapshot-mirror.timer (every 30 min) rsyncs them to
+# /srv/.../Backups/k3s-db/snapshots/ for the omv-backup-verify watchdog.
+etcd-snapshot-schedule-cron: "0 */1 * * *"
+etcd-snapshot-retention: 24

--- a/infrastructure/etcd-backup/k3s-snapshot-mirror.service
+++ b/infrastructure/etcd-backup/k3s-snapshot-mirror.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=Mirror k3s etcd snapshots to NAS backup mount
+Documentation=https://docs.k3s.io/datastore/backup-restore
+After=k3s.service
+Wants=k3s.service
+
+[Service]
+Type=oneshot
+ExecStart=/usr/local/sbin/k3s-snapshot-mirror.sh
+Nice=10
+IOSchedulingClass=best-effort
+IOSchedulingPriority=7
+TimeoutStartSec=10min

--- a/infrastructure/etcd-backup/k3s-snapshot-mirror.sh
+++ b/infrastructure/etcd-backup/k3s-snapshot-mirror.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+# Mirror k3s etcd snapshots from data-dir -> NAS backup mount.
+#
+# Why this exists:
+#   /var/lib/rancher/k3s/server/db/snapshots/ holds the scheduled snapshots
+#   written by k3s itself (see etcd-snapshot-schedule-cron in
+#   /etc/rancher/k3s/config.yaml). The omv-backup-verify CronJob watches
+#   /srv/.../Backups/k3s-db/ for freshness with a 2h SLO. Previously the
+#   only thing mirroring to that path was /usr/local/sbin/nas-backup at
+#   02:00 daily, so the backup mount lagged up to 24h behind reality and
+#   the Slack alert fired all day.
+#
+# Behaviour:
+#   - rsync -a --delete (drops snapshots that k3s retention has removed)
+#   - returns 0 if anything was synced or if the source is empty
+#   - logs to /var/log/k3s-snapshot-mirror.log
+#
+# Driven by: /etc/systemd/system/k3s-snapshot-mirror.timer (every 30 min)
+# Source-of-truth: this file in cloudless.gr repo, infrastructure/etcd-backup/
+
+set -euo pipefail
+
+SRC="/var/lib/rancher/k3s/server/db/snapshots/"
+DST="/srv/dev-disk-by-uuid-fa6231ab-eae7-40ea-a4b6-400f767a89d7/Backups/k3s-db/snapshots/"
+LOG="/var/log/k3s-snapshot-mirror.log"
+
+STAMP="$(date -u '+%Y-%m-%dT%H:%M:%SZ')"
+{
+  echo "[${STAMP}] === k3s-snapshot-mirror start ==="
+  if [ ! -d "${SRC}" ]; then
+    echo "[${STAMP}] WARN: source ${SRC} does not exist; nothing to mirror"
+    exit 0
+  fi
+  if [ ! -d "${DST}" ]; then
+    echo "[${STAMP}] creating destination ${DST}"
+    install -d -m 0700 -o root -g root "${DST}"
+  fi
+  rsync -a --delete --stats "${SRC}" "${DST}"
+  echo "[${STAMP}] === k3s-snapshot-mirror done ==="
+} >> "${LOG}" 2>&1

--- a/infrastructure/etcd-backup/k3s-snapshot-mirror.timer
+++ b/infrastructure/etcd-backup/k3s-snapshot-mirror.timer
@@ -1,0 +1,13 @@
+[Unit]
+Description=Run k3s-snapshot-mirror every 30 minutes
+Documentation=https://docs.k3s.io/datastore/backup-restore
+
+[Timer]
+OnBootSec=5min
+OnUnitActiveSec=30min
+Persistent=true
+RandomizedDelaySec=2min
+Unit=k3s-snapshot-mirror.service
+
+[Install]
+WantedBy=timers.target

--- a/scripts/configure-k3s.sh
+++ b/scripts/configure-k3s.sh
@@ -68,8 +68,12 @@ tls-san:
 kube-apiserver-arg:
   - "service-node-port-range=1000-32767"
 
-etcd-snapshot-schedule-cron: "0 */6 * * *"
-etcd-snapshot-retention: 3
+# CLAUDE.md "k3s Tuning" requires hourly snapshots; the previous
+# "0 */6 * * *" lagged the omv-backup-verify watchdog (SLO 2h). The
+# k3s-snapshot-mirror.timer (every 30 min) under
+# infrastructure/etcd-backup/ keeps the NAS backup mount in sync.
+etcd-snapshot-schedule-cron: "0 */1 * * *"
+etcd-snapshot-retention: 24
 etcd-s3: true
 etcd-s3-bucket: ${ETCD_S3_BUCKET}
 etcd-s3-region: ${ETCD_S3_REGION}


### PR DESCRIPTION
## Root cause

Two compounding faults:

1. `/etc/rancher/k3s/config.yaml` on `omv` was stripped down to just `tls-san` + `secrets-encryption` around 2026-06-25 18:20 (root cause unclear; probably a botched edit during the k3s flap window before the 20:23 restart). When k3s restarted at 20:23 it picked up the truncated config, losing `etcd-snapshot-schedule-cron` and falling back to the default `"0 */12 * * *"` (twice daily) cadence.
2. Even when k3s did produce a scheduled snapshot, nothing was mirroring `/var/lib/rancher/k3s/server/db/snapshots/` to the NAS path that the `omv-backup-verify` watchdog actually checks (`/srv/.../Backups/k3s-db/`). The only thing populating that path was `/usr/local/sbin/nas-backup` at 02:00 daily — so the watchdog's "newest file under backup mount" aged past its 2h SLO immediately after each daily run.

## What this PR adds

`infrastructure/etcd-backup/` — source-of-truth for both halves of the fix:

| File | Lands at | Purpose |
| --- | --- | --- |
| `config.yaml` | `/etc/rancher/k3s/config.yaml` | Hourly snapshot schedule + retention 24, per `CLAUDE.md` "k3s Tuning". Deliberately omits `etcd-s3-*` (those IAM keys are dead — separate rotation task). |
| `k3s-snapshot-mirror.sh` | `/usr/local/sbin/` | `rsync -a --delete` from k3s data-dir snapshots → NAS mount. |
| `k3s-snapshot-mirror.service` | `/etc/systemd/system/` | oneshot wrapper. |
| `k3s-snapshot-mirror.timer` | `/etc/systemd/system/` | runs every 30 min + 5 min after boot. |
| `README.md` | — | Install + verify runbook. |

`scripts/configure-k3s.sh` bumped its embedded cron from `"0 */6 * * *"` / retention 3 → `"0 */1 * * *"` / retention 24, so the next full regeneration matches what's live now.

## Live state on omv (already applied)

- `/etc/rancher/k3s/config.yaml` backed up to `config.yaml.bak.fix-snapshot-*` before install.
- k3s restarted at 14:39:40 EEST; both nodes `Ready` (`omv` + `omv-ha`).
- `k3s-snapshot-mirror.timer` enabled + active; next fire 15:08 EEST.
- Manual `k3s etcd-snapshot save` → mirrored. Newest file under the watchdog's path is now **mtime 2026-06-26 14:42** (age <1 min, down from 22h):

```
1782474162.9... 2026-06-26 14:42:42 /srv/.../Backups/k3s-db/snapshots/manual-verify-...-1782474163
1782464406.7... 2026-06-26 12:00:06 /srv/.../Backups/k3s-db/snapshots/etcd-snapshot-omv-1782464404
1782428449.4... 2026-06-26 02:00:49 /srv/.../Backups/k3s-db/etcd/member/snap/db
```

## Operator-pending follow-ups

- **S3 mirror is still down.** The embedded `AKIAUBXIAELUS34WI2KW` IAM key is dead. Once a fresh `cloudless-etcd-backup` user is minted (see `docs/aws-credentials-rotation-runbook.md`), regenerate `/etc/rancher/k3s/config.yaml` via `scripts/configure-k3s.sh` to restore the S3 third-copy.
- The next `omv-backup-verify` CronJob run (`30 */6 * * *`, next fire ≈18:30 EEST) will see a fresh snapshot and the Slack alert will clear.

## Verification

```bash
ssh tbaltzakis@omv 'systemctl list-timers k3s-snapshot-mirror.timer --all'
# NEXT 2026-06-26 15:08:43 EEST  LAST 14:42:09 EEST

sudo find /srv/.../Backups/k3s-db -type f -printf "%T@ %p\n" | sort -nr | head -1
# 1782474162  ...manual-verify-...-1782474163  (age <1 min)
```