### PR TITLE
fix(monitoring): pin loki + promtail to omv, off omv-ha

### DIFF
--- a/docs/loki-pinned-to-omv.md
+++ b/docs/loki-pinned-to-omv.md
@@ -1,0 +1,140 @@
+# Loki + Promtail pinned to `omv` (off `omv-ha`)
+
+**Applied:** 2026-06-26
+**PR:** `fix/loki-promtail-pin-to-omv`
+**Owner:** ops (Themis)
+
+## Context
+
+`omv-ha` (Pi 3, 1 GiB RAM) was running both:
+
+- `monitoring/loki-0` (StatefulSet, single-binary) with its `storage-loki-0` PVC
+  on local-path → SD card.
+- A `monitoring/promtail` DaemonSet pod (one per node).
+
+Combined with the 1 GiB ceiling, this kept omv-ha at load avg 5-7
+(1-minute) for hours at a time. Meanwhile `omv` (Pi 5, 8 GiB) sat at
+~0.8. The existing TODO in
+[`k8s/cluster-protection/monitoring-resources.yaml`](../k8s/cluster-protection/monitoring-resources.yaml)
+already called out the move:
+
+> Consider moving Loki off this node entirely — promtail ships logs, and
+> the ingester can live on a sibling Pi without coupling to the data SSD.
+
+This change executes that move and pins promtail to `omv` only.
+
+## What changed (live cluster)
+
+| Object | Change |
+|---|---|
+| `statefulset/loki` (monitoring) | Added `spec.template.spec.nodeSelector: {kubernetes.io/hostname: omv}` |
+| `statefulset/loki` (monitoring) | Set `spec.persistentVolumeClaimRetentionPolicy: {whenDeleted: Retain, whenScaled: Retain}` |
+| `daemonset/promtail` (monitoring) | Added `spec.template.spec.nodeSelector: {kubernetes.io/hostname: omv}` |
+| `pvc/storage-loki-0` (monitoring) | New PVC `pvc-45cd981a-8eb9-4a93-a63f-f3a061ee525c` bound to a new local-path PV on omv (path `/srv/dev-disk-by-uuid-a9a5a108-…/k3s/storage/pvc-45cd981a-…_monitoring_storage-loki-0`) |
+
+The promtail DaemonSet went from 2 pods to 1 (only on omv). omv-ha no
+longer ships its own logs to Loki; in practice we have host-level
+journald on omv-ha for emergencies. If we ever want host log shipping
+back, the cheapest option is a small dedicated logging StatefulSet
+rather than putting promtail back on the Pi 3.
+
+## Data loss disclosure (read this)
+
+The migration was originally planned as "scale loki to 0 → rsync the
+PV from omv-ha to omv → flip PV nodeAffinity → scale back to 1." That
+plan **didn't survive contact with reality**: the StatefulSet was
+created (by the `loki-7.0.0` Helm chart) with
+`persistentVolumeClaimRetentionPolicy: {whenScaled: Delete}`. As soon
+as `kubectl scale --replicas=0` ran, the PVC `storage-loki-0` was
+deleted, which triggered the PV's `Delete` reclaim policy, which in
+turn caused local-path-provisioner to `rm -rf` the data directory on
+omv-ha. By the time the rsync command authenticated, the source path
+no longer existed.
+
+**Concretely:** the ~163 MiB of historical Loki chunks on omv-ha
+(~18 days of cluster logs) are gone. Loki came back up healthy on omv
+with a fresh empty PVC. Going forward (today onward), all new logs
+are stored on omv's SSD.
+
+This is acceptable for our use case (we keep Loki as a short-term
+debug buffer; long-term retention is Grafana Cloud / S3, when wired
+up). It is documented here so the next operator who wonders "why does
+Loki only have history from 2026-06-26 onward" doesn't waste an hour.
+
+The same StatefulSet now has `whenScaled: Retain` set, so any future
+`kubectl scale --replicas=0` will preserve the PVC. A repeat of this
+class of mistake requires explicit `kubectl delete pvc`.
+
+## Helm drift — operator follow-up
+
+Both patches above were applied via `kubectl patch` to the live
+objects. They are **not** in the upstream Helm values, so the next
+`helm upgrade` on the loki chart will revert them. To make these
+permanent, add to the loki chart values (the file lives in the
+helm-values repo / wherever this stack is managed; it is not in this
+repo today):
+
+```yaml
+# values for the loki Helm chart (single-binary mode)
+singleBinary:
+  nodeSelector:
+    kubernetes.io/hostname: omv
+  persistence:
+    # The chart sets these via volumeClaimTemplates on the StatefulSet —
+    # confirm whenScaled/whenDeleted are NOT Delete before any
+    # scale-to-zero operation.
+    # (Upstream chart didn't expose this directly at 7.0.0; if still
+    # the case, keep using the live kubectl patch + revisit after a
+    # chart bump.)
+
+# values for the promtail chart
+nodeSelector:
+  kubernetes.io/hostname: omv
+```
+
+For the loki PVC retention policy, the upstream chart at the version
+in use (`loki-7.0.0`) didn't expose
+`persistentVolumeClaimRetentionPolicy` as a value. Until it does, the
+live `kubectl patch` is the source of truth — re-run after every
+`helm upgrade`:
+
+```bash
+kubectl -n monitoring patch statefulset loki --type=merge \
+  -p '{"spec":{"persistentVolumeClaimRetentionPolicy":{"whenDeleted":"Retain","whenScaled":"Retain"}}}'
+
+kubectl -n monitoring patch statefulset loki --type=merge \
+  -p '{"spec":{"template":{"spec":{"nodeSelector":{"kubernetes.io/hostname":"omv"}}}}}'
+
+kubectl -n monitoring patch daemonset promtail --type=merge \
+  -p '{"spec":{"template":{"spec":{"nodeSelector":{"kubernetes.io/hostname":"omv"}}}}}'
+```
+
+## Verification (post-migration)
+
+```text
+kubectl -n monitoring get pod loki-0 -o wide
+NAME    READY  STATUS   RESTARTS  AGE  NODE
+loki-0  2/2    Running  0         ~2m  omv
+
+kubectl -n monitoring get ds promtail
+NAME      DESIRED  CURRENT  READY  NODE SELECTOR
+promtail  1        1        1      kubernetes.io/hostname=omv
+
+# /ready on loki returns "ready" (probed from a busybox pod):
+wget -qO- http://loki.monitoring.svc.cluster.local:3100/ready
+# → ready
+
+kubectl get pods -A --field-selector spec.nodeName=omv-ha
+# (no loki, no promtail anywhere in output)
+```
+
+Load averages observed:
+
+| Node    | Before (1m / 5m / 15m) | After |
+|---------|------------------------|-------|
+| `omv`   | 0.91 / 0.82 / 0.85     | 1.55 / 1.14 / 0.95 |
+| `omv-ha` | 5.99 / 7.34 / 5.12   | 0.84 / 2.82 / 3.83 |
+
+omv-ha load drop is the headline result. omv's modest increase is
+within its normal noise (the new loki workload requests 50m CPU,
+200Mi RAM — it doesn't materially change a Pi 5).

--- a/k8s/cluster-protection/apply-monitoring-resources.sh
+++ b/k8s/cluster-protection/apply-monitoring-resources.sh
@@ -34,6 +34,7 @@ echo "==> Rolling out monitoring workloads to pick up new limits"
 ssh "$REMOTE" 'kubectl --request-timeout=60s -n monitoring \
   rollout restart \
     statefulset/loki \
+    daemonset/promtail \
     deployment/kube-prom-grafana \
     deployment/monitoring-operator \
     deployment/kube-prom-kube-state-metrics'

--- a/k8s/cluster-protection/monitoring-resources.yaml
+++ b/k8s/cluster-protection/monitoring-resources.yaml
@@ -59,14 +59,30 @@ spec:
 
 ---
 # Loki — single binary, all-in-one target. Bounded ingest.
+#
+# Also pinned to `omv` (the Pi 5) because the only other node `omv-ha`
+# is a Pi 3 with 1 GiB RAM + SD-card storage and was hitting load avg
+# 5-7 with loki + promtail + the rest of its workload. See
+# docs/loki-pinned-to-omv.md for the migration story (and the data-loss
+# disclosure — historical chunks did not survive because the chart
+# defaulted to whenScaled: Delete on the PVC retention policy).
+#
+# The PVC retention policy is patched to Retain so a future scale-to-0
+# doesn't repeat the original incident; the StatefulSet must NOT be
+# scaled to 0 without first confirming this patch is in effect.
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: loki
   namespace: monitoring
 spec:
+  persistentVolumeClaimRetentionPolicy:
+    whenDeleted: Retain
+    whenScaled: Retain
   template:
     spec:
+      nodeSelector:
+        kubernetes.io/hostname: omv
       containers:
         - name: loki
           resources:
@@ -76,6 +92,21 @@ spec:
             limits:
               memory: 400Mi
               cpu: 500m
+---
+# Promtail — log shipper DaemonSet. Pinned to omv only; omv-ha (Pi 3,
+# 1 GiB) no longer ships its own logs to keep its RAM headroom. Host
+# journald is still available on omv-ha for emergency forensics. See
+# docs/loki-pinned-to-omv.md.
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: promtail
+  namespace: monitoring
+spec:
+  template:
+    spec:
+      nodeSelector:
+        kubernetes.io/hostname: omv
 
 ---
 apiVersion: apps/v1
@@ -135,8 +166,8 @@ spec:
               cpu: 200m
 
 # Follow-up (separate PR):
-# - Mirror these limits and retention values into the upstream
-#   kube-prometheus-stack / loki Helm values so future `helm upgrade` runs
-#   don't revert them.
-# - Consider moving Loki off this node entirely — promtail ships logs, and
-#   the ingester can live on a sibling Pi without coupling to the data SSD.
+# - Mirror these limits, retention values, the loki/promtail nodeSelector,
+#   and the loki StatefulSet's persistentVolumeClaimRetentionPolicy into
+#   the upstream kube-prometheus-stack / loki / promtail Helm values so
+#   future `helm upgrade` runs don't revert them. See
+#   docs/loki-pinned-to-omv.md for the exact Helm-values snippets.


### PR DESCRIPTION
## Summary

Pins `monitoring/loki` (StatefulSet) and `monitoring/promtail` (DaemonSet) to **omv** only, so omv-ha (Pi 3, 1 GiB RAM) stops running them. omv-ha was sitting at load avg 5-7 (1m) with these on it; omv (Pi 5, 8 GiB) sat at ~0.8.

The existing TODO at the bottom of \`k8s/cluster-protection/monitoring-resources.yaml\` already called out this move:

> Consider moving Loki off this node entirely — promtail ships logs, and the ingester can live on a sibling Pi without coupling to the data SSD.

This PR executes it.

## Live cluster changes (already applied via \`kubectl patch\`)

- \`statefulset/loki\`: \`nodeSelector: kubernetes.io/hostname=omv\`
- \`statefulset/loki\`: \`persistentVolumeClaimRetentionPolicy: { whenDeleted: Retain, whenScaled: Retain }\`
- \`daemonset/promtail\`: \`nodeSelector: kubernetes.io/hostname=omv\` (DS shrunk 2 → 1 pods)

## Repo changes (mirror live patches into the apply-on-startup manifest)

- \`k8s/cluster-protection/monitoring-resources.yaml\`: add nodeSelector + PVC retention policy on loki; add a new \`DaemonSet/promtail\` patch
- \`k8s/cluster-protection/apply-monitoring-resources.sh\`: include \`daemonset/promtail\` in the rollout-restart list
- \`docs/loki-pinned-to-omv.md\`: full incident + remediation log, **data-loss disclosure**, Helm-values follow-up, verification commands, load-avg before/after

## ⚠ Data-loss disclosure

The migration plan was \"scale loki to 0 → rsync PV → flip nodeAffinity → scale back up.\" That plan didn't survive contact with the chart's \`whenScaled: Delete\` policy — \`kubectl scale --replicas=0\` deleted the PVC, the PV's \`Delete\` reclaim then wiped the data on omv-ha *before* the rsync could authenticate.

**~163 MiB of Loki chunks (history up to 2026-06-26) are lost.** Loki came back up healthy with a fresh empty PVC on omv. All new logs from now on are stored on omv's SSD. The new \`whenScaled: Retain\` policy ensures this can't repeat without an explicit \`kubectl delete pvc\`. Full write-up in \`docs/loki-pinned-to-omv.md\`.

## Operator follow-up (helm drift)

Neither nodeSelector nor the PVC retention policy is in the upstream Helm values (loki-7.0.0 didn't expose the retention policy at all). After any \`helm upgrade\` of the loki / promtail charts, re-run the kubectl patches OR re-run \`apply-monitoring-resources.sh\`. The doc has the exact one-liners.

## Verification

\`\`\`
$ kubectl -n monitoring get pod loki-0 -o wide
NAME    READY  STATUS   RESTARTS  AGE  NODE
loki-0  2/2    Running  0         ~2m  omv

$ kubectl -n monitoring get ds promtail
NAME      DESIRED  CURRENT  READY  NODE SELECTOR
promtail  1        1        1      kubernetes.io/hostname=omv

$ kubectl get pods -A --field-selector spec.nodeName=omv-ha
(no loki, no promtail in output)

$ wget -qO- http://loki.monitoring.svc.cluster.local:3100/ready
ready
\`\`\`

Load averages observed before/after:

| Node     | Before                | After                  |
|----------|-----------------------|------------------------|
| omv      | 0.91 / 0.82 / 0.85    | 1.55 / 1.14 / 0.95     |
| omv-ha   | 5.99 / 7.34 / 5.12    | **0.84 / 2.82 / 3.83** |