### PR TITLE
fix(skills): MD032 blank-line before list in postiz-automation SKILL.md

### DIFF
--- a/skills/postiz-automation/SKILL.md
+++ b/skills/postiz-automation/SKILL.md
@@ -48,6 +48,7 @@ https://cloudless.gr/en/?utm_source=linkedin&utm_medium=social&utm_campaign=<slu
 ```
 
 Replace:
+
 - `<slug>` — your campaign name in snake_case (e.g. `shop_online_founding`)
 - `<variant>` — the creative variant (e.g. `A_EN`, `B_EL`) for A/B tracking
 


### PR DESCRIPTION
Pre-existing markdown lint failure that's been blocking CI on every PR. One-line fix (add blank line before bullet list at line 51). No behaviour change.

Caught by PRs #1195 and #1196 both failing 'Lint & Format' on the same rule.