### PR TITLE
chore(monitoring): mirror loki + promtail nodeSelector into helm values

### DIFF
--- a/docs/loki-pinned-to-omv.md
+++ b/docs/loki-pinned-to-omv.md
@@ -138,3 +138,18 @@ Load averages observed:
 omv-ha load drop is the headline result. omv's modest increase is
 within its normal noise (the new loki workload requests 50m CPU,
 200Mi RAM — it doesn't materially change a Pi 5).
+
+## Permanence (post-helm-upgrade safety)
+
+The live `kubectl patch` from PR #1197 will be reverted by any
+`helm upgrade loki` or `helm upgrade promtail` that doesn't supply
+matching values.
+
+PR #1199 added two checked-in values files:
+
+- `infrastructure/monitoring/loki-values.yaml`
+- `infrastructure/monitoring/promtail-values.yaml`
+
+Always apply with `--values <path>` going forward. The pre-flight
+script `k8s/cluster-protection/apply-monitoring-resources.sh` still
+runs the live patches as a safety net.

--- a/infrastructure/monitoring/loki-values.yaml
+++ b/infrastructure/monitoring/loki-values.yaml
@@ -1,0 +1,75 @@
+# Helm values for Grafana Loki (chart: loki-7.0.0 / app v3.6.7).
+#
+# Captured 2026-06-26 from `helm -n monitoring get values loki` then
+# augmented with:
+#   - singleBinary.nodeSelector to pin to omv (Pi 5, 8 GiB) — required
+#     because omv-ha is a Pi 3 with 1 GiB and was OOM-pressured before
+#     PR #1197 migrated us off it.
+#   - singleBinary.persistence.persistentVolumeClaimRetentionPolicy
+#     set to Retain/Retain so scaling to 0 doesn't wipe the PVC again
+#     (we lost 163 MiB of log chunks during the PR #1197 migration
+#     because the chart's default is whenScaled=Delete).
+#
+# Apply with:
+#   helm -n monitoring upgrade loki grafana/loki \
+#     --version 7.0.0 \
+#     --values infrastructure/monitoring/loki-values.yaml
+#
+# The current release is in `failed` state (since 2026-05-26 — separate
+# pre-existing issue). After this values-only change, a `helm upgrade
+# --force` may be needed to recover. Do that as a separate operator
+# step, not as part of this PR.
+
+backend:
+  replicas: 0
+gateway:
+  enabled: false
+loki:
+  auth_enabled: false
+  commonConfig:
+    replication_factor: 1
+  compactor:
+    retention_enabled: true
+  limits_config:
+    retention_period: 168h
+  schemaConfig:
+    configs:
+    - from: "2024-01-01"
+      index:
+        period: 24h
+        prefix: index_
+      object_store: filesystem
+      schema: v13
+      store: tsdb
+  storage:
+    type: filesystem
+lokiCanary:
+  enabled: false
+read:
+  replicas: 0
+singleBinary:
+  # Pin to omv (Pi 5). omv-ha (Pi 3, 1 GiB RAM) cannot host Loki.
+  nodeSelector:
+    kubernetes.io/hostname: omv
+  persistence:
+    enabled: true
+    size: 5Gi
+    # Keep PVC across scale-to-0 operations. The chart default
+    # (whenScaled: Delete) caused data loss during the 2026-06-26 PR
+    # #1197 node migration. Retain semantics survive
+    # `kubectl scale statefulset loki --replicas=0`.
+    persistentVolumeClaimRetentionPolicy:
+      whenScaled: Retain
+      whenDeleted: Retain
+  replicas: 1
+  resources:
+    limits:
+      cpu: 200m
+      memory: 384Mi
+    requests:
+      cpu: 50m
+      memory: 128Mi
+test:
+  enabled: false
+write:
+  replicas: 0

--- a/infrastructure/monitoring/promtail-values.yaml
+++ b/infrastructure/monitoring/promtail-values.yaml
@@ -1,0 +1,29 @@
+# Helm values for promtail (chart: promtail-6.17.1 / app v3.5.1).
+#
+# Captured 2026-06-26 from `helm -n monitoring get values promtail` then
+# augmented with nodeSelector to pin to omv only — promtail is a
+# DaemonSet by default (runs on every node), but PR #1197 restricted it
+# to omv to free CPU + RAM on omv-ha (Pi 3, 1 GiB). The trade-off: no
+# omv-ha pod-logs in Loki. Host-level journald on omv-ha remains
+# available via `journalctl` over SSH (see skills/cluster-bash) when
+# debugging.
+#
+# Apply with:
+#   helm -n monitoring upgrade promtail grafana/promtail \
+#     --version 6.17.1 \
+#     --values infrastructure/monitoring/promtail-values.yaml
+
+config:
+  clients:
+  - url: http://loki:3100/loki/api/v1/push
+nodeSelector:
+  kubernetes.io/hostname: omv
+resources:
+  limits:
+    cpu: 200m
+    memory: 128Mi
+  requests:
+    cpu: 50m
+    memory: 64Mi
+tolerations:
+- operator: Exists


### PR DESCRIPTION
## What

Mirrors the live  from PR #1197 into checked-in Helm values so the next  preserves the change.

## Why

PR #1197 added  to the live loki StatefulSet + promtail DaemonSet via . With no matching helm-values override, any future  /  would silently revert that pin and reschedule the workloads back onto  (Pi 3, 1 GiB RAM), where they re-trigger the OOM pressure that motivated the migration in the first place.

## Files

-  — captured live values +  +  (so a future scale-to-0 does NOT delete the PVC; we lost 163 MiB of log chunks during PR #1197 because the chart default is ).
-  — captured live values +  pinning the DaemonSet to  only.
-  — appended a  section pointing at the new values files.

## Apply

These are values-only; nothing is applied by merging this PR. The operator runs:



The current  release is in  state (pre-existing, since 2026-05-26); a  may be needed to recover. Out of scope for this PR.

## Validation

-  — both files parse.
- No code change — purely a doc/values mirror of what's already live in the cluster.