### PR TITLE
chore(k8s): raise vibe-agent memory limit to 1536Mi

### DIFF
--- a/infrastructure/vibe-agent/k8s.yaml
+++ b/infrastructure/vibe-agent/k8s.yaml
@@ -84,10 +84,10 @@ spec:
               mountPath: /projects
           resources:
             requests:
-              memory: 512Mi
+              memory: 768Mi
               cpu: 250m
             limits:
-              memory: 1Gi
+              memory: 1536Mi
               cpu: 1000m
           livenessProbe:
             httpGet:


### PR DESCRIPTION
## Summary
- Raises vibe-agent pod memory request 512Mi → 768Mi, limit 1Gi → 1536Mi
- Root cause: stress testing found `vibe_coding` OOMs at 1Gi — the new manual tool-dispatch loop (vibe-agent d11f1c2) now actually executes tools, accumulating 20+ messages per phase across 3 fix iterations
- 1536Mi gives safe headroom without pressuring the Pi's budget

## Test plan
- [ ] CI passes
- [ ] `kubectl apply -f infrastructure/vibe-agent/k8s.yaml` on omv
- [ ] `kubectl get pods -n vibe` — pod Running, 0 restarts
- [ ] Re-run stress test: `vibe_coding` completes without OOM

🤖 Generated with [Claude Code](https://claude.com/claude-code)