### PR TITLE
fix(k8s): restore NodePort service for vibe-agent (30924/30301)

### DIFF
--- a/infrastructure/vibe-agent/k8s.yaml
+++ b/infrastructure/vibe-agent/k8s.yaml
@@ -113,15 +113,18 @@ metadata:
   name: vibe-agent
   namespace: vibe
 spec:
+  type: NodePort
   selector:
     app: vibe-agent
   ports:
     - name: langgraph
       port: 2024
       targetPort: 2024
+      nodePort: 30924
     - name: ui
       port: 3001
       targetPort: 3001
+      nodePort: 30301
 
 ---
 # Cloudflare tunnel ingress — append to /etc/cloudflared/config.yml on omv-main:


### PR DESCRIPTION
## Summary
- Service was `ClusterIP` in the manifest; Cloudflare tunnel expects NodePort 30924 (langgraph) and 30301 (UI)
- Applying the manifest during stress-test remediation reverted the live service to ClusterIP, taking `agent.cloudless.gr` and `vibe.cloudless.gr` offline
- Locks NodePorts in the manifest so future `kubectl apply` stays consistent with the tunnel config

## Test plan
- [ ] `kubectl get svc -n vibe` → TYPE=NodePort, ports 2024:30924 and 3001:30301
- [ ] `curl https://agent.cloudless.gr/ok` → `{"ok":true}`
- [ ] `curl -s -o /dev/null -w '%{http_code}' https://vibe.cloudless.gr/` → 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)