### PR TITLE
Add vLLM backend down-alert (blackbox probe + PrometheusRule)

### DIFF
--- a/infrastructure/vibe-agent/vllm-monitoring.yaml
+++ b/infrastructure/vibe-agent/vllm-monitoring.yaml
@@ -1,0 +1,134 @@
+# vLLM backend monitoring — blackbox HTTP probe + down-alert.
+#
+# WHY THIS EXISTS
+# ---------------
+# The vibe-agent pod (namespace: vibe) depends on a vLLM inference server that
+# runs OFF-cluster on the WSL2 dev box, reached over Tailscale at
+# http://100.121.191.7:8080 (see infrastructure/vibe-agent/k8s.yaml and the
+# VIBE repo CLAUDE.md). If that box sleeps, the GPU server crashes, or the
+# Tailscale link drops, every agent run fails — but nothing in k3s would
+# notice, because kube-state-metrics only sees in-cluster pods.
+#
+# LangSmith already alerts on per-run errors/latency for the vibe-agent
+# project, but it can only see runs that actually reach it. A dead backend
+# often produces NO runs at all (the app fails before tracing), so LangSmith
+# goes silent rather than alerting. This probe closes that gap: it tests
+# "is vLLM actually serving HTTP 200" independently, from inside the cluster,
+# over the same Tailscale path the agent uses.
+#
+# PATTERN
+# -------
+# Mirrors infrastructure/monitoring/blackbox-exporter.yaml exactly:
+#   * Probe CRD  -> blackbox-exporter scrape target (probe_success metric)
+#   * PrometheusRule -> alert when probe_success == 0
+# Both live in namespace: monitoring with label release: kube-prom so the
+# Prometheus Operator picks them up (matches the cluster's ruleSelector).
+#
+# Notifications flow through the same Alertmanager → Slack path as the other
+# cluster alerts (cluster-alerts-secret / SLACK_BOT_TOKEN).
+
+---
+# Blackbox HTTP probe of the vLLM /health endpoint over Tailscale.
+# /health returns 200 only once the model is fully loaded and the engine is
+# ready to serve — so a 200 here means "vLLM can actually take requests",
+# not just "the port is open".
+apiVersion: monitoring.coreos.com/v1
+kind: Probe
+metadata:
+  name: vllm-backend
+  namespace: monitoring
+  labels:
+    release: kube-prom
+    cluster-protection.io/health: "true"
+spec:
+  jobName: vllm-backend
+  interval: 60s
+  module: http_2xx
+  prober:
+    url: blackbox-exporter.monitoring.svc.cluster.local:9115
+  targets:
+    staticConfig:
+      # Tailscale IP of the WSL2 dev box that hosts vLLM. This is the same
+      # address the vibe-agent pod uses for VLLM_BASE_URL (minus the /v1).
+      # Probing it directly tests the real cluster→backend network path.
+      static: ["http://100.121.191.7:8080/health"]
+      labels:
+        app: vllm
+        scope: backend
+        component: vibe-agent
+
+---
+# Alert rules for the vLLM backend.
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: vllm-backend-health
+  namespace: monitoring
+  labels:
+    release: kube-prom          # must match kube-prometheus-stack ruleSelector
+spec:
+  groups:
+    - name: vllm.rules
+      rules:
+        # ── vLLM unreachable / not ready ──────────────────────────────────
+        # Fires when the /health probe fails for 3+ minutes. The 3m window
+        # tolerates a brief model reload or a momentary Tailscale blip
+        # (probe runs every 60s, so this needs ~3 consecutive failures)
+        # without paging on transients.
+        - alert: VLLMBackendDown
+          expr: probe_success{app="vllm", scope="backend"} == 0
+          for: 3m
+          labels:
+            severity: critical
+            app: vllm
+            component: vibe-agent
+            probe: blackbox-http
+          annotations:
+            summary: "vLLM backend DOWN — /health failing for 3m+ (vibe-agent has no model)"
+            description: |
+              The blackbox probe of http://100.121.191.7:8080/health has been
+              failing for 3+ minutes. The vLLM inference server on the WSL2 dev
+              box is not serving — every vibe-agent run will fail until it
+              recovers, and LangSmith may go SILENT (runs never reach it) rather
+              than showing errors.
+
+              Check in this order:
+                1. Is the WSL2 dev box awake / on the network?
+                   tailscale ping 100.121.191.7
+                2. Is vLLM running?  (on the box)
+                   curl -sf http://localhost:8080/health
+                   ~/vLLM/scripts/start.sh        # if down
+                3. GPU OOM / engine crash?
+                   tail -50 ~/vLLM/server.log
+                4. Tailscale link up on both ends?
+                   tailscale status | grep 100.121.191.7
+
+              Impact: agent.cloudless.gr (vibe-agent) returns errors for all
+              graph runs. No customer-facing cloudless.gr outage unless the app
+              itself calls this backend.
+
+        # ── vLLM probe flapping (early warning) ───────────────────────────
+        # Catches intermittent reachability before it becomes a hard outage:
+        # more than 3 failed probes in a 10-minute window, sustained 2m.
+        - alert: VLLMBackendFlapping
+          expr: |
+            (count_over_time(probe_success{app="vllm", scope="backend"}[10m])
+             - sum_over_time(probe_success{app="vllm", scope="backend"}[10m])) > 3
+          for: 2m
+          labels:
+            severity: warning
+            app: vllm
+            component: vibe-agent
+            probe: blackbox-http
+          annotations:
+            summary: "vLLM backend probe flapping — intermittent /health failures (early warning)"
+            description: |
+              More than 3 of the last ~10 probes to
+              http://100.121.191.7:8080/health failed. The backend is still
+              considered UP (no 3-minute sustained outage yet), but the link or
+              server is unstable. Common causes:
+                • WSL2 box under heavy GPU load — /health timing out
+                • Tailscale path degradation / Wi-Fi packet loss
+                • vLLM engine restarting (model reload)
+                • The box entering/leaving sleep intermittently
+              Escalates to VLLMBackendDown if it goes fully unreachable.


### PR DESCRIPTION
## What

Adds Prometheus monitoring for the **vLLM inference backend** that `vibe-agent` depends on. The server runs off-cluster on the WSL2 dev box, reached over Tailscale at `100.121.191.7:8080`.

New file: `infrastructure/vibe-agent/vllm-monitoring.yaml`
- **Probe** — blackbox HTTP check of vLLM `/health` every 60s
- **VLLMBackendDown** (critical) — `probe_success == 0` for 3m, with a step-by-step runbook
- **VLLMBackendFlapping** (warning) — >3 failed probes in 10m (early warning)

## Why

The vibe-agent pod has no in-cluster signal for backend death — kube-state-metrics only sees pods. And LangSmith (which alerts on per-run errors/latency) goes **silent** when the backend is fully down, because runs never reach it. This probe tests "is vLLM actually serving 200" independently, from inside the cluster, over the same Tailscale path the agent uses.

## Pattern

Mirrors the existing `infrastructure/monitoring/blackbox-exporter.yaml` exactly: `namespace: monitoring`, `labels: { release: kube-prom }`, blackbox `http_2xx` module. Notifications flow through the existing Alertmanager → Slack path (`cluster-alerts-secret` / `SLACK_BOT_TOKEN`).

## Validation

- `kubectl apply --dry-run=server` passes against live CRDs
- Both PromQL expressions compile + run against live Prometheus (`monitoring-prometheus`)
- **Already applied to the cluster** and verified: `probe_success{app="vllm"} = 1`, both rules loaded (state `inactive`). This PR captures the manifest in git to match the applied state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)