### PR TITLE
fix(cluster): n8n quota + mariadb backup image fix

### DIFF
--- a/infrastructure/espocrm/k8s/mariadb-xbstream-backup.yaml
+++ b/infrastructure/espocrm/k8s/mariadb-xbstream-backup.yaml
@@ -1,0 +1,91 @@
+---
+# Hourly physical backup of EspoCRM MariaDB via mariadb-backup → S3 xbstream.
+# Fix 2026-06-27: switched from alpine:3.20 (dropped aws-cli + kubectl packages)
+# to alpine/k8s:1.35.5 which ships kubectl; aws-cli installed via pip.
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: mariadb-xbstream-backup
+  namespace: espocrm
+  labels:
+    app.kubernetes.io/name: mariadb-xbstream-backup
+    backup.cloudless.gr/type: physical
+    backup.cloudless.gr/target: espocrm-mariadb
+    backup.cloudless.gr/rpo: 1h
+spec:
+  schedule: "0 * * * *"
+  concurrencyPolicy: Forbid
+  failedJobsHistoryLimit: 7
+  successfulJobsHistoryLimit: 3
+  jobTemplate:
+    spec:
+      activeDeadlineSeconds: 3600
+      backoffLimit: 1
+      template:
+        spec:
+          serviceAccountName: mariadb-xbstream-backup
+          restartPolicy: Never
+          containers:
+            - name: backup
+              # alpine/k8s ships kubectl; we add aws-cli via pip (pip3 is in the image).
+              # alpine:3.20 dropped both aws-cli and kubectl from community repo.
+              image: alpine/k8s:1.35.5
+              imagePullPolicy: IfNotPresent
+              resources:
+                requests: { cpu: 100m, memory: 128Mi }
+                limits:   { cpu: 500m, memory: 256Mi }
+              env:
+                - name: AWS_ACCESS_KEY_ID
+                  valueFrom: { secretKeyRef: { name: pvc-backup-aws, key: AWS_ACCESS_KEY_ID } }
+                - name: AWS_SECRET_ACCESS_KEY
+                  valueFrom: { secretKeyRef: { name: pvc-backup-aws, key: AWS_SECRET_ACCESS_KEY } }
+                - name: AWS_DEFAULT_REGION
+                  value: us-east-1
+                - name: MARIADB_ROOT_PASSWORD
+                  valueFrom: { secretKeyRef: { name: espocrm-secrets, key: mariadb-root-password } }
+              command: ["/bin/sh", "-c"]
+              args:
+                - |
+                  set -euo pipefail
+
+                  STAMP="$(date -u '+%Y-%m-%dT%H:%M:%SZ')"
+                  log() { echo "[${STAMP}] $*" >&2; }
+
+                  log "→ installing aws-cli via pip"
+                  pip3 install --quiet --no-cache-dir awscli
+
+                  POD=$(kubectl get pod \
+                    -n espocrm \
+                    -l app=espocrm,component=mariadb \
+                    --field-selector=status.phase=Running \
+                    -o jsonpath='{.items[0].metadata.name}')
+                  [ -n "${POD}" ] || { log "❌ no running MariaDB pod found"; exit 1; }
+                  log "→ backing up via pod: ${POD}"
+
+                  DATE=$(date -u +%Y-%m-%dT%H%M%SZ)
+                  KEY="pvc-backups/espocrm/xbstream/hourly/${DATE}.xbstream"
+                  BUCKET="cloudless-analytics-data"
+                  log "→ streaming xbstream → s3://${BUCKET}/${KEY}"
+
+                  kubectl exec -n espocrm "${POD}" -- \
+                    mariadb-backup \
+                      --backup \
+                      --stream=xbstream \
+                      --host=localhost \
+                      --port=3306 \
+                      --user=root \
+                      --password="${MARIADB_ROOT_PASSWORD}" \
+                      --target-dir=/tmp/mariadb-backup-tmp \
+                    | aws s3 cp - "s3://${BUCKET}/${KEY}"
+
+                  SIZE=$(aws s3api head-object \
+                    --bucket "${BUCKET}" \
+                    --key "${KEY}" \
+                    --query ContentLength \
+                    --output text)
+                  log "✅ uploaded ${SIZE} bytes"
+
+                  [ "${SIZE}" -ge 10000 ] || { log "❌ backup too small (${SIZE} bytes < 10KB)"; exit 1; }
+
+                  kubectl exec -n espocrm "${POD}" -- rm -rf /tmp/mariadb-backup-tmp || true
+                  log "✅ xbstream backup complete"

--- a/infrastructure/n8n/k8s.yaml
+++ b/infrastructure/n8n/k8s.yaml
@@ -126,3 +126,19 @@ spec:
       port: 5678
       targetPort: 5678
       nodePort: 30900
+
+---
+# ResourceQuota: raised from 1Gi to 1536Mi 2026-06-27.
+# n8n Deployment uses limits.memory=1Gi; the daily backup CronJob
+# (cronjob-n8n.yaml) adds 256Mi, totalling 1.25Gi — this exceeded the
+# original 1Gi cap and caused FailedCreate events every night.
+apiVersion: v1
+kind: ResourceQuota
+metadata:
+  name: n8n-quota
+  namespace: n8n
+spec:
+  hard:
+    pods: "5"
+    requests.memory: 768Mi
+    limits.memory: 1536Mi


### PR DESCRIPTION
## Summary
- **n8n ResourceQuota** raised 1Gi → 1536Mi: nightly backup CronJob (256Mi limit) + n8n (1Gi) exceeded the old cap, causing `FailedCreate` on every backup run. Applied live.
- **mariadb-xbstream-backup** switched from `alpine:3.20` (dropped `aws-cli` + `kubectl`) to `alpine/k8s:1.35.5` (kubectl included) + `pip install awscli`. Adds manifest to `infrastructure/espocrm/k8s/`. Applied live.

## Test plan
- [ ] Next n8n backup run (04:15 EEST): `kubectl -n n8n get jobs`
- [ ] Next mariadb xbstream backup (top of hour): `kubectl -n espocrm get jobs`

🤖 Generated with [Claude Code](https://claude.com/claude-code)