### PR TITLE
fix(cron): postiz-oauth-check 500 → 502; CI treats 502/503 as warning

### DIFF
--- a/.github/workflows/postiz-crons.yml
+++ b/.github/workflows/postiz-crons.yml
@@ -121,22 +121,32 @@ jobs:
           KUMA_PUSH_TOKEN: ${{ secrets.KUMA_PUSH_POSTIZ_OAUTH }}
         run: |
           echo "Calling $BASE_URL/api/cron/postiz-oauth-check"
-          if RESPONSE=$(curl -fsS --retry 3 --retry-delay 5 --max-time 30 \
+          HTTP_CODE=$(curl -o /tmp/postiz-oauth-resp.txt -w "%{http_code}" \
+            --retry 3 --retry-delay 5 --max-time 30 \
             -H "Authorization: Bearer ${{ steps.secret.outputs.value }}" \
-            "$BASE_URL/api/cron/postiz-oauth-check"); then
-            echo "Response: $RESPONSE"
-            echo "## Postiz OAuth check" >> "$GITHUB_STEP_SUMMARY"
-            echo '```json' >> "$GITHUB_STEP_SUMMARY"
-            echo "$RESPONSE" >> "$GITHUB_STEP_SUMMARY"
-            echo '```' >> "$GITHUB_STEP_SUMMARY"
+            "$BASE_URL/api/cron/postiz-oauth-check" 2>&1)
+          RESPONSE=$(cat /tmp/postiz-oauth-resp.txt 2>/dev/null || echo "")
+          echo "HTTP $HTTP_CODE — $RESPONSE"
+          echo "## Postiz OAuth check (HTTP $HTTP_CODE)" >> "$GITHUB_STEP_SUMMARY"
+          echo '```json' >> "$GITHUB_STEP_SUMMARY"
+          echo "$RESPONSE" >> "$GITHUB_STEP_SUMMARY"
+          echo '```' >> "$GITHUB_STEP_SUMMARY"
+          if [ "$HTTP_CODE" = "200" ]; then
             [ -n "$KUMA_PUSH_TOKEN" ] && \
               curl -fsS --max-time 10 --retry 3 \
                 "${KUMA_BASE_URL}/api/push/${KUMA_PUSH_TOKEN}?status=up&msg=postiz-oauth-check+ok" \
                 > /dev/null || true
+          elif [ "$HTTP_CODE" = "502" ] || [ "$HTTP_CODE" = "503" ]; then
+            # Postiz unreachable / not configured — warn but don't fail CI
+            echo "::warning::Postiz upstream returned HTTP $HTTP_CODE — OAuth check skipped"
+            [ -n "$KUMA_PUSH_TOKEN" ] && \
+              curl -fsS --max-time 10 --retry 3 \
+                "${KUMA_BASE_URL}/api/push/${KUMA_PUSH_TOKEN}?status=down&msg=postiz+unreachable+$HTTP_CODE" \
+                > /dev/null || true
           else
             [ -n "$KUMA_PUSH_TOKEN" ] && \
               curl -fsS --max-time 10 --retry 3 \
-                "${KUMA_BASE_URL}/api/push/${KUMA_PUSH_TOKEN}?status=down&msg=postiz-oauth-check+failed" \
+                "${KUMA_BASE_URL}/api/push/${KUMA_PUSH_TOKEN}?status=down&msg=postiz-oauth-check+failed+$HTTP_CODE" \
                 > /dev/null || true
             exit 1
           fi

--- a/src/app/api/cron/postiz-oauth-check/route.ts
+++ b/src/app/api/cron/postiz-oauth-check/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { isCronAuthorized, cronUnauthorized } from "@/lib/cron-auth";
-import { isPostizConfigured, listIntegrations } from "@/lib/postiz";
+import { isPostizConfigured, listIntegrations, PostizApiError } from "@/lib/postiz";
 import { notifyOauthExpiry } from "@/lib/postiz-slack";
 
 export const dynamic = "force-dynamic";
@@ -29,7 +29,19 @@ export async function GET(request: NextRequest) {
     return NextResponse.json({ ok: false, reason: "postiz_not_configured" }, { status: 503 });
   }
 
-  const integrations = await listIntegrations();
+  let integrations;
+  try {
+    integrations = await listIntegrations();
+  } catch (e) {
+    const status = e instanceof PostizApiError ? e.status : 0;
+    const msg = e instanceof Error ? e.message : String(e);
+    console.error("[postiz-oauth-check] listIntegrations failed:", msg);
+    return NextResponse.json(
+      { ok: false, reason: "postiz_upstream_error", detail: msg, upstreamStatus: status },
+      { status: 502 }
+    );
+  }
+
   const disabled = integrations.filter((i) => i.disabled);
 
   await Promise.all(


### PR DESCRIPTION
## Summary
- **Route** (`src/app/api/cron/postiz-oauth-check/route.ts`): catch `PostizApiError` from `listIntegrations()` and return 502 instead of letting it propagate as an unhandled 500. Root cause: Postiz API returns non-2xx when the instance is unreachable or the token has expired.
- **Workflow** (`.github/workflows/postiz-crons.yml`): replace `curl -fsS` (fails on any non-2xx) with explicit HTTP code check. 200=pass, 502/503=warn (Postiz unreachable, don't fail CI), other=fail.

## Test plan
- [ ] `postiz-oauth-check` cron returns 502 (not 500) when Postiz upstream is down
- [ ] CI workflow exits 0 with `::warning::` annotation when HTTP 502/503 received
- [ ] CI workflow still fails on unexpected HTTP codes (e.g. 401, 404)

🤖 Generated with [Claude Code](https://claude.com/claude-code)