### PR TITLE
fix(ci): postiz curl progress pollution + HA sync timeout too short

### DIFF
--- a/.github/workflows/ha-sync-orchestrator.yml
+++ b/.github/workflows/ha-sync-orchestrator.yml
@@ -314,7 +314,7 @@ jobs:
             const deploySha = '${{ steps.meta.outputs.sha }}';
             const { owner, repo } = context.repo;
 
-            const maxAttempts = 40; // 10 min at 15s intervals
+            const maxAttempts = 120; // 30 min at 15s intervals (Pi runner queue can back up)
             const delayMs = 15000;
             // If the run stays queued (Pi runner offline) for this many
             // consecutive checks, exit gracefully instead of timing out.
@@ -323,7 +323,7 @@ jobs:
             // If a run stays in_progress for too long (GitHub API sometimes
             // fails to flip status to completed even when all jobs are done),
             // check job-level status to avoid infinite wait.
-            const maxInProgressMinutes = 20;
+            const maxInProgressMinutes = 35;
             function sleep(ms) { return new Promise((r) => setTimeout(r, ms)); }
 
             for (let attempt = 1; attempt <= maxAttempts; attempt++) {

--- a/.github/workflows/postiz-crons.yml
+++ b/.github/workflows/postiz-crons.yml
@@ -121,10 +121,10 @@ jobs:
           KUMA_PUSH_TOKEN: ${{ secrets.KUMA_PUSH_POSTIZ_OAUTH }}
         run: |
           echo "Calling $BASE_URL/api/cron/postiz-oauth-check"
-          HTTP_CODE=$(curl -o /tmp/postiz-oauth-resp.txt -w "%{http_code}" \
+          HTTP_CODE=$(curl -s -o /tmp/postiz-oauth-resp.txt -w "%{http_code}" \
             --retry 3 --retry-delay 5 --max-time 30 \
             -H "Authorization: Bearer ${{ steps.secret.outputs.value }}" \
-            "$BASE_URL/api/cron/postiz-oauth-check" 2>&1)
+            "$BASE_URL/api/cron/postiz-oauth-check")
           RESPONSE=$(cat /tmp/postiz-oauth-resp.txt 2>/dev/null || echo "")
           echo "HTTP $HTTP_CODE — $RESPONSE"
           echo "## Postiz OAuth check (HTTP $HTTP_CODE)" >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## Summary
- **postiz-crons.yml**: add `-s` to `curl` to suppress progress output that was polluting `$HTTP_CODE`. The variable captured `"HTTP   % Total..."` instead of `"200"`, causing exit 1 even on a clean 200 response (confirmed in run 28290887586).
- **ha-sync-orchestrator.yml**: raise `maxAttempts` 40→120 (10min→30min) and `maxInProgressMinutes` 20→35. Pi runner queue backs up when AppFlowy worker builds occupy self-hosted runners, causing deploy-pi to start late and HA sync to time out.

## Test plan
- [ ] Next postiz-crons run exits 0 with `HTTP 200` correctly parsed
- [ ] HA sync orchestrator no longer times out while deploy-pi is queued behind AppFlowy builds

🤖 Generated with [Claude Code](https://claude.com/claude-code)