### PR TITLE
fix(test): restore afterEach import in poll.test.ts

### DIFF
--- a/__tests__/ad-analytics/poll.test.ts
+++ b/__tests__/ad-analytics/poll.test.ts
@@ -1,5 +1,5 @@
 // @vitest-environment node
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 
 import { runScheduledPoll as _runScheduledPoll, _setRegistries } from "@/lib/ad-analytics/runtime";
 import { _resetBookmarkStore } from "@/lib/ad-analytics/bookmarks";


### PR DESCRIPTION
## Summary
PR #1215 removed `afterEach` from the import in `__tests__/ad-analytics/poll.test.ts` as seemingly unused, but `afterEach()` is called on line 17. This caused `ReferenceError: afterEach is not defined` in CI.

Restoring the import.

🤖 Generated with [Claude Code](https://claude.com/claude-code)