### PR TITLE
fix(etl): raise EspoCRM ETL timeout 10m → 25m

### DIFF
--- a/.github/workflows/etl-espocrm-to-lake.yml
+++ b/.github/workflows/etl-espocrm-to-lake.yml
@@ -36,7 +36,7 @@ jobs:
     # skill); this runs-on change is the immediate unblock that doesn't
     # need that rotation.
     runs-on: [self-hosted, omv, pi]
-    timeout-minutes: 10
+    timeout-minutes: 25
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v4
 

--- a/__tests__/ad-analytics/poll.test.ts
+++ b/__tests__/ad-analytics/poll.test.ts
@@ -1,5 +1,5 @@
 // @vitest-environment node
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 
 import { runScheduledPoll as _runScheduledPoll, _setRegistries } from "@/lib/ad-analytics/runtime";
 import { _resetBookmarkStore } from "@/lib/ad-analytics/bookmarks";


### PR DESCRIPTION
## Summary
- `MAX_RETRIES=7` with exponential backoff up to 16s/step can spend ~63s per entity on tunnel flaps
- `npm ci` on the Pi ARM runner takes ~3 min before the script starts  
- 5 entities × 63s max + 3 min install = ~8.5 min just for worst-case retries + install; the 10m ceiling killed the job mid-retry
- 25 min gives comfortable headroom while staying below the 6h GHA hard cap

## Test plan
- [ ] Next scheduled run (hourly at :20) should complete successfully
- [ ] `gh run list --workflow=etl-espocrm-to-lake.yml` shows success

🤖 Generated with [Claude Code](https://claude.com/claude-code)