### PR TITLE
fix(ci): cloudflared-restart — privileged nsenter pod, no SSH

### DIFF
--- a/.github/workflows/cloudflared-restart.yml
+++ b/.github/workflows/cloudflared-restart.yml
@@ -4,9 +4,9 @@ name: cloudflared restart — restore tunnel when pi-origin returns 000
 # cloudless pod being healthy. Symptom: k3s E2E timeouts against pi-origin while
 # kubectl get pods shows 1/1 Running.
 #
-# Root cause: cloudflared pod lost its connection to the Cloudflare edge and did
-# not recover on its own. Restarting the cloudflared deployment forces a fresh
-# tunnel registration.
+# Root cause: cloudflared runs as a systemd service on the Pi host (not in k3s).
+# When it drops its edge connection and doesn't self-heal, SSH + systemctl restart
+# forces a fresh tunnel registration.
 #
 # Trigger: push path (to fire on merge) or workflow_dispatch.
 
@@ -28,6 +28,8 @@ jobs:
     timeout-minutes: 10
     env:
       GH_TOKEN: ${{ github.token }}
+      PI_HOST: "100.113.41.119"
+      PI_USER: "tbaltzakis"
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v4.3.1
 
@@ -36,48 +38,33 @@ jobs:
         with:
           authkey: ${{ secrets.TS_AUTHKEY }}
 
-      - name: Configure kubectl
+      - name: Install SSH key
         run: |
-          mkdir -p ~/.kube
-          echo "${{ secrets.KUBECONFIG_B64 }}" | base64 -d > ~/.kube/config
-          chmod 600 ~/.kube/config
+          mkdir -p ~/.ssh
+          printf '%s\n' "${{ secrets.OMV_SSH_KEY }}" > ~/.ssh/id_ed25519
+          chmod 600 ~/.ssh/id_ed25519
+          ssh-keyscan -H "$PI_HOST" >> ~/.ssh/known_hosts 2>/dev/null || true
 
-      - name: Diagnose cloudflared before restart
+      - name: Diagnose cloudflared status via SSH
         run: |
-          echo "=== cloudflared pods ==="
-          kubectl get pods -n cloudflare -o wide 2>/dev/null || \
-            kubectl get pods -A 2>/dev/null | grep -E "cloudflared|tunnel" || \
-            echo "(no cloudflared pods found)"
-          echo ""
-          echo "=== cloudflared deployment ==="
-          kubectl get deploy -A 2>/dev/null | grep -E "cloudflared|tunnel" || echo "(none)"
-          echo ""
-          echo "=== cloudless pods ==="
-          kubectl get pods -n cloudless
+          echo "=== cloudflared systemd status ==="
+          ssh -i ~/.ssh/id_ed25519 -o StrictHostKeyChecking=no -o ConnectTimeout=10 \
+            "$PI_USER@$PI_HOST" \
+            "sudo systemctl status cloudflared --no-pager 2>&1 | head -20; \
+             echo ''; \
+             echo '=== last 20 lines of cloudflared journal ==='; \
+             sudo journalctl -u cloudflared --no-pager --lines=20 2>&1" \
+            2>&1 || true
 
-      - name: Restart cloudflared deployment
+      - name: Restart cloudflared via SSH
         run: |
-          echo "=== rolling restart of cloudflared ==="
-          # Try common namespace/deployment name patterns
-          CF_NS=""
-          CF_DEPLOY=""
-          for ns in cloudflare default kube-system cloudless; do
-            found=$(kubectl get deploy -n "$ns" 2>/dev/null | grep -E "^cloudflared|^tunnel" | awk '{print $1}' | head -1)
-            if [ -n "$found" ]; then
-              CF_NS="$ns"
-              CF_DEPLOY="$found"
-              break
-            fi
-          done
-          if [ -z "$CF_DEPLOY" ]; then
-            echo "::error::Could not find cloudflared deployment in any namespace"
-            kubectl get deploy -A 2>/dev/null | grep -E "cloudflared|tunnel" || true
-            exit 1
-          fi
-          echo "Found: ns=$CF_NS deploy=$CF_DEPLOY"
-          kubectl rollout restart deploy/"$CF_DEPLOY" -n "$CF_NS"
-          echo "=== waiting for rollout ==="
-          kubectl rollout status deploy/"$CF_DEPLOY" -n "$CF_NS" --timeout=120s
+          echo "=== restarting cloudflared ==="
+          ssh -i ~/.ssh/id_ed25519 -o StrictHostKeyChecking=no -o ConnectTimeout=10 \
+            "$PI_USER@$PI_HOST" \
+            "sudo systemctl restart cloudflared 2>&1; echo restart_exit=\$?; \
+             sleep 3; \
+             sudo systemctl status cloudflared --no-pager 2>&1 | head -10" \
+            2>&1
 
       - name: Wait for pi-origin to recover
         run: |

--- a/.github/workflows/cloudflared-restart.yml
+++ b/.github/workflows/cloudflared-restart.yml
@@ -5,8 +5,9 @@ name: cloudflared restart — restore tunnel when pi-origin returns 000
 # kubectl get pods shows 1/1 Running.
 #
 # Root cause: cloudflared runs as a systemd service on the Pi host (not in k3s).
-# When it drops its edge connection and doesn't self-heal, SSH + systemctl restart
-# forces a fresh tunnel registration.
+# Restarted via a privileged pod on the omv node that uses nsenter to call
+# systemctl on the host — same pattern as fix-selfhosted-tunnels.yml.
+# No SSH required; works as long as the k3s API is reachable.
 #
 # Trigger: push path (to fire on merge) or workflow_dispatch.
 
@@ -28,8 +29,6 @@ jobs:
     timeout-minutes: 10
     env:
       GH_TOKEN: ${{ github.token }}
-      PI_HOST: "100.113.41.119"
-      PI_USER: "tbaltzakis"
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v4.3.1
 
@@ -38,33 +37,64 @@ jobs:
         with:
           authkey: ${{ secrets.TS_AUTHKEY }}
 
-      - name: Install SSH key
+      - name: Configure kubectl
         run: |
-          mkdir -p ~/.ssh
-          printf '%s\n' "${{ secrets.OMV_SSH_KEY }}" > ~/.ssh/id_ed25519
-          chmod 600 ~/.ssh/id_ed25519
-          ssh-keyscan -H "$PI_HOST" >> ~/.ssh/known_hosts 2>/dev/null || true
+          mkdir -p ~/.kube
+          echo "${{ secrets.KUBECONFIG_B64 }}" | base64 -d > ~/.kube/config
+          chmod 600 ~/.kube/config
 
-      - name: Diagnose cloudflared status via SSH
+      - name: Check cloudless pod and pi-origin before restart
         run: |
-          echo "=== cloudflared systemd status ==="
-          ssh -i ~/.ssh/id_ed25519 -o StrictHostKeyChecking=no -o ConnectTimeout=10 \
-            "$PI_USER@$PI_HOST" \
-            "sudo systemctl status cloudflared --no-pager 2>&1 | head -20; \
-             echo ''; \
-             echo '=== last 20 lines of cloudflared journal ==='; \
-             sudo journalctl -u cloudflared --no-pager --lines=20 2>&1" \
-            2>&1 || true
+          echo "=== cloudless pods ==="
+          kubectl get pods -n cloudless
+          echo ""
+          echo "=== pi-origin health (before) ==="
+          code=$(curl -o /dev/null -s -w "%{http_code}" --max-time 10 \
+            https://pi-origin.cloudless.gr/api/health 2>/dev/null || echo "000")
+          echo "HTTP $code"
 
-      - name: Restart cloudflared via SSH
+      - name: Restart cloudflared via privileged pod (nsenter)
         run: |
-          echo "=== restarting cloudflared ==="
-          ssh -i ~/.ssh/id_ed25519 -o StrictHostKeyChecking=no -o ConnectTimeout=10 \
-            "$PI_USER@$PI_HOST" \
-            "sudo systemctl restart cloudflared 2>&1; echo restart_exit=\$?; \
-             sleep 3; \
-             sudo systemctl status cloudflared --no-pager 2>&1 | head -10" \
-            2>&1
+          kubectl delete pod cf-restart -n default --ignore-not-found --wait=true
+          kubectl apply -f - <<'EOF'
+          apiVersion: v1
+          kind: Pod
+          metadata:
+            name: cf-restart
+            namespace: default
+          spec:
+            restartPolicy: Never
+            nodeSelector:
+              kubernetes.io/hostname: omv
+            hostPID: true
+            containers:
+              - name: w
+                image: alpine:3
+                securityContext:
+                  privileged: true
+                command:
+                  - sh
+                  - -c
+                  - |
+                    set -e
+                    apk add -q util-linux 2>/dev/null
+                    echo "=== cloudflared status before restart ==="
+                    nsenter --target 1 --mount --uts --ipc --net --pid -- \
+                      systemctl status cloudflared --no-pager 2>&1 | head -10 || true
+                    echo "=== restarting cloudflared ==="
+                    nsenter --target 1 --mount --uts --ipc --net --pid -- \
+                      systemctl restart cloudflared
+                    sleep 3
+                    echo "=== cloudflared status after restart ==="
+                    nsenter --target 1 --mount --uts --ipc --net --pid -- \
+                      systemctl is-active cloudflared
+                    echo "cloudflared restarted OK"
+          EOF
+          echo "=== waiting for pod to complete ==="
+          kubectl wait --for=jsonpath='{.status.phase}'=Succeeded pod/cf-restart \
+            -n default --timeout=60s
+          kubectl logs -n default cf-restart
+          kubectl delete pod -n default cf-restart --ignore-not-found
 
       - name: Wait for pi-origin to recover
         run: |


### PR DESCRIPTION
## Summary
- Replaces SSH approach with a privileged pod (`hostPID: true`, `nsenter --target 1`) on the `omv` node — same pattern as `fix-selfhosted-tunnels.yml`
- SSH to port 22 timed out (blocked); k3s API over Tailscale works fine

## Root cause chain
1. k3s E2E: 26 timeouts on `pi-origin.cloudless.gr` — HTTP 000
2. `kubectl get pods -n cloudless`: app pod `1/1 Running 0 restarts` — app healthy
3. cloudflared is a host systemd service on omv, not a k8s Deployment
4. SSH (port 22) to `100.113.41.119` timed out
5. Fix: nsenter privileged pod → `systemctl restart cloudflared` on host

🤖 Generated with [Claude Code](https://claude.com/claude-code)