### PR TITLE
fix(ci): cloudflared-restart kill hung socat on port 18443

### DIFF
--- a/.github/workflows/cloudflared-restart.yml
+++ b/.github/workflows/cloudflared-restart.yml
@@ -122,22 +122,33 @@ jobs:
                   - |
                     set -e
                     apk add -q util-linux 2>/dev/null
-                    echo "=== cloudflared status before ==="
+                    echo "=== socat status on port 18443 ==="
                     nsenter --target 1 --mount --uts --ipc --net --pid -- \
-                      systemctl status cloudflared --no-pager 2>&1 | head -15 || true
-                    echo "=== last 30 lines of cloudflared journal before restart ==="
+                      ss -tlnp 2>/dev/null | grep 18443 || echo "(nothing on 18443)"
+                    echo "=== check for socat systemd unit ==="
                     nsenter --target 1 --mount --uts --ipc --net --pid -- \
-                      journalctl -u cloudflared --no-pager -n 30 2>&1 || true
+                      systemctl list-units --type=service 2>/dev/null | grep socat || echo "(no socat systemd unit)"
+                    echo "=== kill+restart socat if present ==="
+                    SOCAT_PID=$(nsenter --target 1 --mount --uts --ipc --net --pid -- \
+                      ss -tlnp 2>/dev/null | grep 18443 | grep -oP '(?<=pid=)\d+' || echo "")
+                    if [ -n "$SOCAT_PID" ]; then
+                      echo "killing socat PID $SOCAT_PID"
+                      nsenter --target 1 --mount --uts --ipc --net --pid -- kill "$SOCAT_PID" || true
+                      sleep 2
+                      echo "socat killed; systemd will restart if managed"
+                    else
+                      echo "no socat found on 18443"
+                    fi
                     echo "=== restarting cloudflared ==="
                     nsenter --target 1 --mount --uts --ipc --net --pid -- \
                       systemctl restart cloudflared
                     sleep 5
-                    echo "=== cloudflared journal after restart ==="
+                    echo "=== 18443 after restart ==="
                     nsenter --target 1 --mount --uts --ipc --net --pid -- \
-                      journalctl -u cloudflared --no-pager -n 20 2>&1 || true
+                      ss -tlnp 2>/dev/null | grep 18443 || echo "(still nothing on 18443)"
                     nsenter --target 1 --mount --uts --ipc --net --pid -- \
                       systemctl is-active cloudflared
-                    echo "cloudflared restarted OK"
+                    echo "done"
           PODEOF
           echo "=== waiting for pod to complete (up to 150s) ==="
           kubectl wait --for=jsonpath='{.status.phase}'=Succeeded pod/cf-restart \

--- a/.github/workflows/cloudflared-restart.yml
+++ b/.github/workflows/cloudflared-restart.yml
@@ -56,7 +56,7 @@ jobs:
       - name: Restart cloudflared via privileged pod (nsenter)
         run: |
           kubectl delete pod cf-restart -n default --ignore-not-found --wait=true
-          cat <<'PODEOF' | kubectl apply -f -
+          cat <<'PODEOF' | kubectl create -f -
           apiVersion: v1
           kind: Pod
           metadata:
@@ -67,6 +67,7 @@ jobs:
             nodeSelector:
               kubernetes.io/hostname: omv
             hostPID: true
+            hostNetwork: true
             containers:
               - name: w
                 image: alpine:3
@@ -89,9 +90,15 @@ jobs:
                       systemctl is-active cloudflared
                     echo "cloudflared restarted OK"
           PODEOF
-          echo "=== waiting for pod to complete (up to 120s) ==="
+          echo "=== waiting for pod to complete (up to 150s) ==="
           kubectl wait --for=jsonpath='{.status.phase}'=Succeeded pod/cf-restart \
-            -n default --timeout=120s
+            -n default --timeout=150s || {
+            echo "=== pod did not succeed — current state ==="
+            kubectl get pod cf-restart -n default -o wide || true
+            kubectl describe pod cf-restart -n default || true
+            kubectl logs cf-restart -n default || true
+            exit 1
+          }
           kubectl logs -n default cf-restart
           kubectl delete pod -n default cf-restart --ignore-not-found
 

--- a/.github/workflows/cloudflared-restart.yml
+++ b/.github/workflows/cloudflared-restart.yml
@@ -81,11 +81,17 @@ jobs:
                     apk add -q util-linux 2>/dev/null
                     echo "=== cloudflared status before ==="
                     nsenter --target 1 --mount --uts --ipc --net --pid -- \
-                      systemctl status cloudflared --no-pager 2>&1 | head -10 || true
+                      systemctl status cloudflared --no-pager 2>&1 | head -15 || true
+                    echo "=== last 30 lines of cloudflared journal before restart ==="
+                    nsenter --target 1 --mount --uts --ipc --net --pid -- \
+                      journalctl -u cloudflared --no-pager -n 30 2>&1 || true
                     echo "=== restarting cloudflared ==="
                     nsenter --target 1 --mount --uts --ipc --net --pid -- \
                       systemctl restart cloudflared
-                    sleep 3
+                    sleep 5
+                    echo "=== cloudflared journal after restart ==="
+                    nsenter --target 1 --mount --uts --ipc --net --pid -- \
+                      journalctl -u cloudflared --no-pager -n 20 2>&1 || true
                     nsenter --target 1 --mount --uts --ipc --net --pid -- \
                       systemctl is-active cloudflared
                     echo "cloudflared restarted OK"

--- a/.github/workflows/cloudflared-restart.yml
+++ b/.github/workflows/cloudflared-restart.yml
@@ -48,10 +48,53 @@ jobs:
           echo "=== cloudless pods ==="
           kubectl get pods -n cloudless
           echo ""
+          echo "=== kube-system pods (Traefik health) ==="
+          kubectl get pods -n kube-system | grep -E "traefik|svclb" || echo "(no traefik pods found)"
+          echo ""
           echo "=== pi-origin health (before) ==="
           code=$(curl -o /dev/null -s -w "%{http_code}" --max-time 10 \
             https://pi-origin.cloudless.gr/api/health 2>/dev/null || echo "000")
           echo "HTTP $code"
+
+      - name: Check port 18443 on Pi host via privileged pod
+        run: |
+          kubectl delete pod cf-probe -n default --ignore-not-found --wait=true
+          cat <<'PODEOF' | kubectl create -f -
+          apiVersion: v1
+          kind: Pod
+          metadata:
+            name: cf-probe
+            namespace: default
+          spec:
+            restartPolicy: Never
+            nodeSelector:
+              kubernetes.io/hostname: omv
+            hostPID: true
+            hostNetwork: true
+            containers:
+              - name: w
+                image: alpine:3
+                securityContext:
+                  privileged: true
+                command:
+                  - sh
+                  - -c
+                  - |
+                    apk add -q util-linux curl 2>/dev/null
+                    echo "=== ss -tlnp | grep 18443 ==="
+                    nsenter --target 1 --mount --uts --ipc --net --pid -- \
+                      ss -tlnp 2>/dev/null | grep 18443 || echo "(nothing on 18443)"
+                    echo "=== curl https://localhost:18443 (max 5s) ==="
+                    nsenter --target 1 --mount --uts --ipc --net --pid -- \
+                      curl -ksS --max-time 5 https://localhost:18443/ -o /dev/null -w "HTTP %{http_code}\n" 2>&1 || echo "curl failed"
+                    echo "=== traefik pods ==="
+                    nsenter --target 1 --mount --uts --ipc --net --pid -- \
+                      systemctl is-active k3s 2>&1 || true
+          PODEOF
+          kubectl wait --for=jsonpath='{.status.phase}'=Succeeded pod/cf-probe \
+            -n default --timeout=90s || true
+          kubectl logs -n default cf-probe || true
+          kubectl delete pod -n default cf-probe --ignore-not-found
 
       - name: Restart cloudflared via privileged pod (nsenter)
         run: |


### PR DESCRIPTION
Port 18443 is served by a socat process that hangs on TLS (accepts but never completes). Kill it before cloudflared restart so systemd can restart it clean.