### PR TITLE
fix(ci): cloudflared-restart — fix ha-mac-probe (hostNetwork + privileged)

### DIFF
--- a/.github/workflows/cloudflared-restart.yml
+++ b/.github/workflows/cloudflared-restart.yml
@@ -88,7 +88,7 @@ jobs:
           # We read it via a one-shot pod on omv-ha — cleanest approach, no SSH.
           kubectl delete pod ha-mac-probe -n default --ignore-not-found --wait=true
           kubectl run ha-mac-probe --restart=Never --image=alpine:3 -n default \
-            --overrides='{"spec":{"nodeSelector":{"kubernetes.io/hostname":"omv-ha"},"containers":[{"name":"w","image":"alpine:3","command":["cat","/sys/class/net/flannel.1/address"]}]}}'
+            --overrides='{"spec":{"nodeSelector":{"kubernetes.io/hostname":"omv-ha"},"hostNetwork":true,"containers":[{"name":"w","image":"alpine:3","securityContext":{"privileged":true},"command":["sh","-c","cat /sys/class/net/flannel.1/address 2>/dev/null || ip -br link show flannel.1 | awk '\''{print $3}'\''"]}}]}'
           kubectl wait --for=jsonpath='{.status.phase}'=Succeeded pod/ha-mac-probe \
             -n default --timeout=30s || true
           HA_FLANNEL_MAC=$(kubectl logs ha-mac-probe -n default 2>/dev/null | tr -d '[:space:]')


### PR DESCRIPTION
## Summary

- The probe pod that reads omv-ha's `flannel.1` MAC address was missing `hostNetwork: true` and `privileged: true`, causing `/sys/class/net/flannel.1/address` to not exist in the container — the FDB entry was skipped, and the flannel VXLAN couldn't forward packets from the omv host netns to `10.42.1.0/24`.
- Added a fallback: if `/sys/class/net/flannel.1/address` is absent, use `ip -br link show flannel.1 | awk '{print $3}'` instead.
- With the FDB entry correctly populated, `ip route add 10.42.1.0/24 via 10.42.1.0 dev flannel.1 onlink` allows NodePort DNAT packets from socat to reach Traefik on omv-ha.

## Test plan

- [ ] Merge to fire the workflow
- [ ] Logs show `omv-ha flannel.1 MAC: xx:xx:xx:xx:xx:xx` (not empty)
- [ ] Logs show `route after fix: 10.42.1.0/24` + ping 0% packet loss
- [ ] Step 4 curl returns HTTP 4xx (Traefik responding)
- [ ] pi-origin.cloudless.gr/api/health returns HTTP 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)