### PR TITLE
fix(etl): exit 0 on EspoCRM 5xx in pre-flight health probe

### DIFF
--- a/scripts/etl/espocrm-to-lake.mjs
+++ b/scripts/etl/espocrm-to-lake.mjs
@@ -435,18 +435,26 @@ async function main() {
     },
   ];
 
-  // Pre-flight: if the EspoCRM host isn't reachable at all (no DNS, tunnel
-  // not wired, etc), exit 0 instead of failing 5x and paging Slack. The CRM
-  // can be deployed before the Cloudflare tunnel is set up — this keeps the
-  // hourly cron quiet during that window.
+  // Pre-flight: verify the EspoCRM host is both reachable and healthy before
+  // burning through 5 entities × 7 retries (~7 min). Exit 0 on:
+  //   - network error (DNS, tunnel not wired)
+  //   - HTTP 5xx (server down / MariaDB crashed / PHP fatal)
+  // This keeps the hourly cron quiet during outages — Athena views just see
+  // the last good partition. Kuma heartbeat naturally goes stale which is the
+  // right signal for "EspoCRM needs attention" without Slack noise every hour.
   try {
     const probe = await fetch(`${BASE}/api/v1/App/user`, {
-      method: "HEAD",
+      method: "GET",
       headers: { "X-Api-Key": KEY },
+      signal: AbortSignal.timeout(15_000),
     });
-    // Any HTTP response (200, 401, 403) means the host is reachable — proceed.
-    // Only a network-level fetch error means "not yet wired".
-    void probe;
+    if (probe.status >= 500) {
+      console.log(
+        `EspoCRM health probe returned HTTP ${probe.status}. ` +
+          "Server is down or unhealthy. Exit 0; will retry next hour."
+      );
+      process.exit(0);
+    }
   } catch (err) {
     console.log(
       `EspoCRM host ${BASE} unreachable (${err.message}). ` +


### PR DESCRIPTION
## Summary

- **EspoCRM ETL pre-flight probe now exits 0 on HTTP 5xx**, matching the existing graceful-exit for network errors. Previously it only caught unreachable hosts — a 500 response passed the probe, then all 5 entities burned through 7 retries each (~7 min) before hard-failing.
- Switched probe from `HEAD` to `GET` (EspoCRM returns 405 on HEAD for some endpoints) and added a 15s `AbortSignal.timeout`.
- Stops the cascade: 14 failures + 12 queued runs piled up on the self-hosted runner today because EspoCRM is returning 500.

## Context

EspoCRM started returning HTTP 500 on all API endpoints around 14:24 UTC today. The hourly cron + push-triggered runs created a backlog of failing workflows, each grinding for ~7 minutes before exiting 1 and paging Slack.

With this fix, when EspoCRM is down the probe exits 0 in <1s. Athena views keep the last good partition. Kuma heartbeat naturally goes stale — the right "needs attention" signal without hourly Slack noise.

## Test plan

- [ ] Merge and observe the next hourly run — should exit 0 quickly with `EspoCRM health probe returned HTTP 500` if EspoCRM is still down
- [ ] Once EspoCRM recovers, verify the ETL resumes normal operation (200 probe → full sync)
- [ ] Confirm queued runs drain quickly after merge (each exits in <15s instead of ~7min)

---
_Generated by [Claude Code](https://claude.ai/code/session_01NJaznAjtDKrrPL5HLB9Ms5)_