### PR TITLE
fix(ci): cloudflared-restart — diagnostic MAC probe for flannel iface

### DIFF
--- a/.github/workflows/cloudflared-restart.yml
+++ b/.github/workflows/cloudflared-restart.yml
@@ -106,7 +106,21 @@ jobs:
                 command:
                   - sh
                   - -c
-                  - cat /sys/class/net/flannel.1/address 2>/dev/null || ip -br link show flannel.1 2>/dev/null | tr -s ' ' | cut -d' ' -f3
+                  - |
+                    echo "=== network interfaces ===" >&2
+                    ip -br link show 2>/dev/null >&2
+                    echo "=== sysfs flannel ===" >&2
+                    ls /sys/class/net/ 2>/dev/null >&2
+                    MAC=""
+                    for iface in flannel.1 flannel0 flannel; do
+                      if [ -f "/sys/class/net/$iface/address" ]; then
+                        MAC=$(cat "/sys/class/net/$iface/address" 2>/dev/null)
+                        break
+                      fi
+                      TRY=$(ip -br link show "$iface" 2>/dev/null | awk '{print $3}')
+                      if [ -n "$TRY" ]; then MAC="$TRY"; break; fi
+                    done
+                    echo "$MAC" 
           MACEOF
           kubectl wait --for=jsonpath='{.status.phase}'=Succeeded pod/ha-mac-probe \
             -n default --timeout=30s || true


### PR DESCRIPTION
## Summary

The MAC probe returns empty even with `hostNetwork: true` + `privileged: true`. This diagnostic iteration:
- Logs all network interfaces to stderr (`ip -br link show`, `ls /sys/class/net/`) so we can see what's on omv-ha
- Tries `flannel.1`, `flannel0`, and `flannel` in order
- Uses `awk '{print $3}'` instead of `cut` for variable-width whitespace

## Test plan

- [ ] Merge to fire the workflow
- [ ] Check pod logs for "=== network interfaces ===" output to understand what interfaces exist on omv-ha

🤖 Generated with [Claude Code](https://claude.com/claude-code)