### PR TITLE
fix(ci): cluster-status-audit — run on ubuntu-latest + tailscale

### DIFF
--- a/.github/workflows/cluster-status-audit.yml
+++ b/.github/workflows/cluster-status-audit.yml
@@ -28,6 +28,7 @@ on:
 
 permissions:
   contents: read
+  actions: read
 
 concurrency:
   group: cluster-status-audit
@@ -36,12 +37,25 @@ concurrency:
 jobs:
   audit:
     name: Cluster Status
-    # Self-hosted Pi runner — has kubeconfig + tailscale + SSH keys.
-    runs-on: [self-hosted, omv, build]
+    # GH-hosted runner + tailscale + KUBECONFIG_B64 — same pattern as
+    # cloudflared-restart.yml. Avoids queuing behind a busy self-hosted
+    # build runner which caused runs to pile up indefinitely.
+    runs-on: ubuntu-latest
     timeout-minutes: 10
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Connect to tailnet
+        uses: tailscale/github-action@306e68a486fd2350f2bfc3b19fcd143891a4a2d8 # v4.1.2
+        with:
+          authkey: ${{ secrets.TS_AUTHKEY }}
+
+      - name: Configure kubectl
+        run: |
+          mkdir -p ~/.kube
+          echo "${{ secrets.KUBECONFIG_B64 }}" | base64 -d > ~/.kube/config
+          chmod 600 ~/.kube/config
 
       - name: Collect cluster + node + runner status
         id: collect


### PR DESCRIPTION
## Summary

- The audit job was pinned to `[self-hosted, omv, build]`, which caused runs to queue indefinitely when the `omv-build` runner was busy (e.g. after a cancelled run left it in a stuck-busy state).
- This is a **read-only** audit that only needs `kubectl` + `gh` CLI — both work fine from a GH-hosted runner with `TS_AUTHKEY` + `KUBECONFIG_B64` (same pattern as `cloudflared-restart.yml`).
- Added `tailscale/github-action` + `Configure kubectl` steps matching the existing cloudflared workflow pattern.
- Added `actions: read` permission so `gh api .../runners` works from the hosted runner.

## Test plan

- [ ] Merge — the queued run should be cancelled (concurrency group) and a fresh run should start on `ubuntu-latest`
- [ ] Audit collects cluster data and posts summary to step summary
- [ ] Every 30-min schedule fires reliably without queuing

🤖 Generated with [Claude Code](https://claude.com/claude-code)