### PR TITLE
fix(ci): use TS_AUTHKEY in Loki cache and CronJob fix workflows

### DIFF
--- a/.github/workflows/fix-loki-cache.yml
+++ b/.github/workflows/fix-loki-cache.yml
@@ -39,11 +39,9 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v4
 
       - name: Setup Tailscale
-        uses: tailscale/github-action@v2
+        uses: tailscale/github-action@306e68a486fd2350f2bfc3b19fcd143891a4a2d8 # v4.1.2
         with:
-          oauth-client-id: ${{ secrets.TS_OAUTH_CLIENT_ID }}
-          oauth-secret: ${{ secrets.TS_OAUTH_SECRET }}
-          tags: tag:ci
+          authkey: ${{ secrets.TS_AUTHKEY }}
 
       - name: Configure kubectl
         run: |

--- a/.github/workflows/fix-maintenance-cronjob.yml
+++ b/.github/workflows/fix-maintenance-cronjob.yml
@@ -34,11 +34,9 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v4
 
       - name: Setup Tailscale
-        uses: tailscale/github-action@v2
+        uses: tailscale/github-action@306e68a486fd2350f2bfc3b19fcd143891a4a2d8 # v4.1.2
         with:
-          oauth-client-id: ${{ secrets.TS_OAUTH_CLIENT_ID }}
-          oauth-secret: ${{ secrets.TS_OAUTH_SECRET }}
-          tags: tag:ci
+          authkey: ${{ secrets.TS_AUTHKEY }}
 
       - name: Configure kubectl
         run: |


### PR DESCRIPTION
## Summary

Fixes Tailscale auth in `fix-loki-cache.yml` and `fix-maintenance-cronjob.yml` — both used `tailscale/github-action@v2` with OAuth secrets (`TS_OAUTH_CLIENT_ID`/`TS_OAUTH_SECRET`) that aren't set in this repo. Now uses the pinned `@306e68a486fd` (v4.1.2) with `TS_AUTHKEY`, matching the pattern in `cluster-doctor.yml` and `deploy-pi.yml`.

Both fix workflows failed on their first run (PR #1258) due to this auth error. This re-triggers them correctly.

## Test plan

- [ ] Fix Loki Cache workflow passes — LimitRange raised to 2Gi, `loki-chunks-cache` + `loki-results-cache` StatefulSets deleted, `helm upgrade --force` applied with caches disabled
- [ ] Loki singleBinary pod stays `1/1 Running`  
- [ ] Fix maintenance CronJob workflow passes — `cluster-health-check` suspended, stale pods cleaned
- [ ] Slack alerts from `monitoring` FailedCreate and `maintenance` BackOff stop

🤖 Generated with [Claude Code](https://claude.com/claude-code)