### PR TITLE
fix: Fly HA fallback via pi-origin tunnel

### DIFF
--- a/.github/workflows/deploy-fly-proxy.yml
+++ b/.github/workflows/deploy-fly-proxy.yml
@@ -1,0 +1,57 @@
+name: Deploy Fly.io HA Proxy
+
+on:
+  workflow_dispatch:
+    inputs:
+      apply:
+        description: "Actually deploy (true) or dry-run (false)"
+        type: boolean
+        default: true
+
+concurrency:
+  group: deploy-fly-proxy
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  deploy:
+    name: Fly cloudless-proxy
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Require FLY_API_TOKEN
+        env:
+          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
+        run: |
+          if [ -z "$FLY_API_TOKEN" ]; then
+            echo "::error::FLY_API_TOKEN secret is not set"
+            exit 1
+          fi
+
+      - name: Setup flyctl
+        uses: superfly/flyctl-actions/setup-flyctl@master
+
+      - name: Create app if missing
+        if: ${{ inputs.apply }}
+        env:
+          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
+        run: flyctl apps create cloudless-proxy --org personal 2>/dev/null || true
+
+      - name: Deploy
+        if: ${{ inputs.apply }}
+        working-directory: fly-proxy-app
+        env:
+          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
+        run: flyctl deploy --remote-only --config ../fly.toml
+
+      - name: Status
+        if: ${{ always() && inputs.apply }}
+        env:
+          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
+        run: |
+          flyctl status --app cloudless-proxy || true
+          curl -sS --max-time 20 https://cloudless-proxy.fly.dev/health || true

--- a/fly-proxy-app/fly.toml
+++ b/fly-proxy-app/fly.toml
@@ -24,7 +24,7 @@ primary_region = "fra"  # Frankfurt (EU) - closest to GR/BG
   # Backends to proxy to
   # Cloudflare Workers (free tier) - primary
   PRIMARY_HOST = "cloudless.gr"
-  FALLBACK_HOST = "omv.tail8eb71.ts.net"
+  FALLBACK_HOST = "pi-origin.cloudless.gr"
 
 [[vm]]
   cpu_kind = "shared"

--- a/fly-proxy-app/proxy.py
+++ b/fly-proxy-app/proxy.py
@@ -1,92 +1,104 @@
 """Fly.io HA Failover Proxy for cloudless.gr.
 
-Primary: Cloudflare Workers (cloudless.gr)
-Fallback: Pi k3s via Tailscale (omv.tail8eb71.ts.net)
+Primary: Cloudflare Workers thin edge (cloudless.gr → Pi)
+Fallback: pi-origin.cloudless.gr (Tunnel → k3s NodePort, bypasses Workers)
 """
 import os
+import time
+
 import httpx
 from fastapi import FastAPI, Request, Response
-import asyncio
 
 app = FastAPI()
 
-# Backend configuration
 PRIMARY_HOST = os.getenv("PRIMARY_HOST", "cloudless.gr")
-FALLBACK_HOST = os.getenv("FALLBACK_HOST", "omv.tail8eb71.ts.net")
+FALLBACK_HOST = os.getenv("FALLBACK_HOST", "pi-origin.cloudless.gr")
 
-# Health cache with 30s TTL
-health_cache = {"healthy": True, "timestamp": 0}
-CACHE_TTL = 30  # seconds
+health_cache = {"healthy": True, "timestamp": 0.0}
+CACHE_TTL = 30
 
 
 async def check_primary_health() -> bool:
-    """Check if primary backend is healthy."""
-    import time
     now = time.time()
-    
     if now - health_cache["timestamp"] < CACHE_TTL:
-        return health_cache["healthy"]
-    
+        return bool(health_cache["healthy"])
+
     try:
-        async with httpx.AsyncClient(timeout=5.0) as client:
+        async with httpx.AsyncClient(timeout=5.0, follow_redirects=True) as client:
             resp = await client.get(f"https://{PRIMARY_HOST}/api/health")
             healthy = resp.status_code == 200
+            if healthy:
+                try:
+                    data = resp.json()
+                    if isinstance(data, dict) and data.get("origin") == "down":
+                        healthy = False
+                except Exception:
+                    pass
     except Exception:
         healthy = False
-    
+
     health_cache["healthy"] = healthy
     health_cache["timestamp"] = now
     return healthy
 
 
 async def proxy_to_backend(request: Request, backend_host: str) -> Response:
-    """Proxy request to specified backend."""
     url = f"https://{backend_host}{request.url.path}"
     if request.url.query:
         url += f"?{request.url.query}"
-    
+
     headers = dict(request.headers)
-    # Remove hop-by-hop headers
-    for h in ["host", "connection", "keep-alive", "proxy-authenticate", 
-              "proxy-authorization", "te", "trailers", "transfer-encoding", "upgrade"]:
+    for h in [
+        "host",
+        "connection",
+        "keep-alive",
+        "proxy-authenticate",
+        "proxy-authorization",
+        "te",
+        "trailers",
+        "transfer-encoding",
+        "upgrade",
+    ]:
         headers.pop(h, None)
-    
-    async with httpx.AsyncClient(timeout=30.0) as client:
+
+    async with httpx.AsyncClient(timeout=30.0, follow_redirects=False) as client:
         body = await request.body()
         resp = await client.request(
             request.method,
             url,
             headers=headers,
             content=body,
-            params=request.query_params
         )
-    
+
+    out_headers = {
+        k: v
+        for k, v in resp.headers.items()
+        if k.lower() not in {"content-encoding", "transfer-encoding", "connection"}
+    }
     return Response(
         content=resp.content,
         status_code=resp.status_code,
-        headers=dict(resp.headers),
-        media_type=resp.headers.get("content-type")
+        headers=out_headers,
+        media_type=resp.headers.get("content-type"),
     )
 
 
 @app.get("/health")
 async def health():
-    """Health check endpoint for Fly.io."""
     healthy = await check_primary_health()
-    status = "healthy" if healthy else "degraded"
-    
     return {
-        "status": status,
+        "status": "healthy" if healthy else "degraded",
         "primary": PRIMARY_HOST,
         "fallback": FALLBACK_HOST,
-        "primary_healthy": healthy
+        "primary_healthy": healthy,
     }
 
 
-@app.api_route("/{path:path}", methods=["GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS", "HEAD"])
+@app.api_route(
+    "/{path:path}",
+    methods=["GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS", "HEAD"],
+)
 async def proxy(request: Request, path: str):
-    """Main proxy handler with automatic failover."""
     healthy = await check_primary_health()
     backend = PRIMARY_HOST if healthy else FALLBACK_HOST
-    
     return await proxy_to_backend(request, backend)

--- a/fly.toml
+++ b/fly.toml
@@ -1,34 +1,34 @@
 # Fly.io Proxy Configuration for cloudless.gr
-# Free Tier: Automatic HA Failover (Cloudflare → Pi/k3s)
+# Free Tier: Automatic HA Failover (Workers → Pi Tunnel)
 #
-# This config deploys a reverse proxy app that handles failover.
-# See fly-proxy-app/ directory for the proxy implementation.
+# Deploy: flyctl deploy --remote-only --config fly.toml (needs FLY_API_TOKEN)
+# Or: gh workflow run deploy-fly-proxy.yml (after push to main)
 
 app = "cloudless-proxy"
 
-primary_region = "fra"  # Frankfurt (EU) - closest to GR/BG
+primary_region = "fra"
 
 [build]
-  # Build the proxy app from fly-proxy-app directory
   context = "fly-proxy-app"
   dockerfile = "Dockerfile"
 
 [[services]]
   internal_port = 8080
   protocol = "tcp"
-  
+
   [[services.ports]]
     port = 80
     handlers = ["http"]
-    
+
   [[services.http_options]]
     health_check_path = "/health"
     health_check_interval = "30s"
 
 [env]
-  # Backends to proxy to
+  # Workers thin edge (Custom Domains)
   PRIMARY_HOST = "cloudless.gr"
-  FALLBACK_HOST = "omv.tail8eb71.ts.net"
+  # Tunnel → k3s NodePort 30300 (bypasses Workers when primary unhealthy)
+  FALLBACK_HOST = "pi-origin.cloudless.gr"
 
 [[vm]]
   cpu_kind = "shared"


### PR DESCRIPTION
## Summary
- Point `FALLBACK_HOST` at `pi-origin.cloudless.gr` (tunnel → k3s NodePort) instead of private Tailscale, which Fly cannot reach
- Treat edge `origin: down` as unhealthy so failover actually triggers
- Add deterministic `deploy-fly-proxy.yml` (uses `FLY_API_TOKEN`) instead of relying on the agentic lock workflow

## Test plan
- [ ] Merge, then `gh workflow run deploy-fly-proxy.yml -f apply=true`
- [ ] `curl -sS https://cloudless-proxy.fly.dev/health` shows `fallback: pi-origin.cloudless.gr`
- [ ] Confirm primary health still proxies to Workers/edge

Made with [Cursor](https://cursor.com)