### PR TITLE
fix: Fly proxy Dockerfile path

### DIFF
--- a/.github/workflows/deploy-fly-proxy.yml
+++ b/.github/workflows/deploy-fly-proxy.yml
@@ -43,10 +43,9 @@ jobs:
 
       - name: Deploy
         if: ${{ inputs.apply }}
-        working-directory: fly-proxy-app
         env:
           FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
-        run: flyctl deploy --remote-only --config ../fly.toml
+        run: flyctl deploy --remote-only --config fly.toml --app cloudless-proxy
 
       - name: Status
         if: ${{ always() && inputs.apply }}

--- a/fly-proxy-app/fly.toml
+++ b/fly-proxy-app/fly.toml
@@ -8,6 +8,9 @@ app = "cloudless-proxy"
 
 primary_region = "fra"  # Frankfurt (EU) - closest to GR/BG
 
+[build]
+  dockerfile = "Dockerfile"
+
 [[services]]
   internal_port = 8080
   protocol = "tcp"

--- a/fly.toml
+++ b/fly.toml
@@ -9,8 +9,9 @@ app = "cloudless-proxy"
 primary_region = "fra"
 
 [build]
+  # Paths are relative to this fly.toml (repo root), not the context dir.
   context = "fly-proxy-app"
-  dockerfile = "Dockerfile"
+  dockerfile = "fly-proxy-app/Dockerfile"
 
 [[services]]
   internal_port = 8080


### PR DESCRIPTION
## Summary
- Point `[build].dockerfile` at `fly-proxy-app/Dockerfile` so deploy does not pick the root Next.js Dockerfile
- Deploy from repo root with `--config fly.toml`

## Test plan
- [ ] `gh workflow run deploy-fly-proxy.yml -f apply=true`
- [ ] Build log shows Python/uvicorn image, not node:22-alpine Next app
- [ ] `curl https://cloudless-proxy.fly.dev/health` returns pi-origin fallback

Made with [Cursor](https://cursor.com)