### PR TITLE
fix: Fly proxy deploy from app directory

### DIFF
--- a/.github/workflows/deploy-fly-proxy.yml
+++ b/.github/workflows/deploy-fly-proxy.yml
@@ -43,6 +43,7 @@ jobs:
 
       - name: Deploy
         if: ${{ inputs.apply }}
+        working-directory: fly-proxy-app
         env:
           FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
         run: flyctl deploy --remote-only --config fly.toml --app cloudless-proxy

--- a/fly-proxy-app/fly.toml
+++ b/fly-proxy-app/fly.toml
@@ -1,12 +1,10 @@
-# Fly.io Proxy Configuration for cloudless.gr
-# Free Tier: Automatic HA Failover (Cloudflare Workers → Pi/k3s)
-#
-# This config deploys a reverse proxy app that handles failover.
-# FastAPI proxy with automatic failover to Pi backup.
+# Fly.io HA failover proxy (Workers → Pi tunnel)
+# Deploy from repo root:
+#   flyctl deploy --remote-only --config fly-proxy-app/fly.toml --app cloudless-proxy
 
 app = "cloudless-proxy"
 
-primary_region = "fra"  # Frankfurt (EU) - closest to GR/BG
+primary_region = "fra"
 
 [build]
   dockerfile = "Dockerfile"
@@ -14,18 +12,16 @@ primary_region = "fra"  # Frankfurt (EU) - closest to GR/BG
 [[services]]
   internal_port = 8080
   protocol = "tcp"
-  
+
   [[services.ports]]
     port = 80
     handlers = ["http"]
-    
+
   [[services.http_options]]
     health_check_path = "/health"
     health_check_interval = "30s"
 
 [env]
-  # Backends to proxy to
-  # Cloudflare Workers (free tier) - primary
   PRIMARY_HOST = "cloudless.gr"
   FALLBACK_HOST = "pi-origin.cloudless.gr"
 

--- a/fly.toml
+++ b/fly.toml
@@ -1,37 +1,13 @@
-# Fly.io Proxy Configuration for cloudless.gr
-# Free Tier: Automatic HA Failover (Workers → Pi Tunnel)
-#
-# Deploy: flyctl deploy --remote-only --config fly.toml (needs FLY_API_TOKEN)
-# Or: gh workflow run deploy-fly-proxy.yml (after push to main)
+# Thin pointer — real config lives next to the proxy image.
+# Deploy: flyctl deploy --remote-only --config fly-proxy-app/fly.toml --app cloudless-proxy
+# Or: gh workflow run deploy-fly-proxy.yml -f apply=true
 
 app = "cloudless-proxy"
-
 primary_region = "fra"
 
 [build]
-  # Paths are relative to this fly.toml (repo root), not the context dir.
-  context = "fly-proxy-app"
   dockerfile = "fly-proxy-app/Dockerfile"
 
-[[services]]
-  internal_port = 8080
-  protocol = "tcp"
-
-  [[services.ports]]
-    port = 80
-    handlers = ["http"]
-
-  [[services.http_options]]
-    health_check_path = "/health"
-    health_check_interval = "30s"
-
 [env]
-  # Workers thin edge (Custom Domains)
   PRIMARY_HOST = "cloudless.gr"
-  # Tunnel → k3s NodePort 30300 (bypasses Workers when primary unhealthy)
   FALLBACK_HOST = "pi-origin.cloudless.gr"
-
-[[vm]]
-  cpu_kind = "shared"
-  cpus = 1
-  memory = "256mb"


### PR DESCRIPTION
## Summary
- Deploy `cloudless-proxy` from `fly-proxy-app/` so Docker context includes `proxy.py` / `requirements.txt`
- Keep root `fly.toml` as a thin pointer to the nested config

## Test plan
- [ ] Workflow build uses `python:3.11-slim` and succeeds
- [ ] Health endpoint reports `fallback: pi-origin.cloudless.gr`

Made with [Cursor](https://cursor.com)