### PR TITLE
fix: Fly proxy HTTPS (443)

### DIFF
--- a/fly-proxy-app/fly.toml
+++ b/fly-proxy-app/fly.toml
@@ -17,6 +17,10 @@ primary_region = "fra"
     port = 80
     handlers = ["http"]
 
+  [[services.ports]]
+    port = 443
+    handlers = ["tls", "http"]
+
   [[services.http_options]]
     health_check_path = "/health"
     health_check_interval = "30s"


### PR DESCRIPTION
## Summary
- Add port 443 with Fly TLS termination so https://cloudless-proxy.fly.dev works

## Test plan
- [ ] Redeploy via deploy-fly-proxy.yml
- [ ] curl -sS https://cloudless-proxy.fly.dev/health

Made with [Cursor](https://cursor.com)