### PR TITLE
fix: Fly HA Bot Fight gap (workers.dev + Tailscale)

### DIFF
--- a/.github/workflows/deploy-fly-proxy.yml
+++ b/.github/workflows/deploy-fly-proxy.yml
@@ -19,16 +19,21 @@ jobs:
   deploy:
     name: Fly cloudless-proxy
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@v4
 
-      - name: Require FLY_API_TOKEN
+      - name: Require secrets
         env:
           FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
+          TS_AUTHKEY: ${{ secrets.TS_AUTHKEY }}
         run: |
           if [ -z "$FLY_API_TOKEN" ]; then
             echo "::error::FLY_API_TOKEN secret is not set"
+            exit 1
+          fi
+          if [ -z "$TS_AUTHKEY" ]; then
+            echo "::error::TS_AUTHKEY secret is not set (Tailscale fallback)"
             exit 1
           fi
 
@@ -40,6 +45,13 @@ jobs:
         env:
           FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
         run: flyctl apps create cloudless-proxy --org personal 2>/dev/null || true
+
+      - name: Set Tailscale auth on Fly
+        if: ${{ inputs.apply }}
+        env:
+          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
+          TS_AUTHKEY: ${{ secrets.TS_AUTHKEY }}
+        run: flyctl secrets set TS_AUTHKEY="$TS_AUTHKEY" --app cloudless-proxy --stage
 
       - name: Deploy
         if: ${{ inputs.apply }}
@@ -54,4 +66,9 @@ jobs:
           FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
         run: |
           flyctl status --app cloudless-proxy || true
-          curl -sS --max-time 20 https://cloudless-proxy.fly.dev/health || true
+          echo "--- /health ---"
+          curl -sS --max-time 25 https://cloudless-proxy.fly.dev/health || true
+          echo
+          echo "--- /api/health via Fly ---"
+          curl -sS --max-time 25 https://cloudless-proxy.fly.dev/api/health || true
+          echo

--- a/fly-proxy-app/Dockerfile
+++ b/fly-proxy-app/Dockerfile
@@ -2,11 +2,22 @@ FROM python:3.11-slim
 
 WORKDIR /app
 
+# Tailscale static binaries (userspace networking on Fly)
+ARG TS_VERSION=1.84.0
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends ca-certificates curl iptables \
+  && curl -fsSL "https://pkgs.tailscale.com/stable/tailscale_${TS_VERSION}_amd64.tgz" \
+    | tar -xz -C /tmp \
+  && mv /tmp/tailscale_${TS_VERSION}_amd64/tailscale /usr/local/bin/ \
+  && mv /tmp/tailscale_${TS_VERSION}_amd64/tailscaled /usr/local/bin/ \
+  && rm -rf /tmp/tailscale_${TS_VERSION}_amd64 /var/lib/apt/lists/*
+
 COPY requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
 
-COPY proxy.py .
+COPY proxy.py start.sh ./
+RUN chmod +x start.sh
 
 EXPOSE 8080
 
-CMD ["python", "-m", "uvicorn", "proxy:app", "--host", "0.0.0.0", "--port", "8080"]
+CMD ["./start.sh"]

--- a/fly-proxy-app/fly.toml
+++ b/fly-proxy-app/fly.toml
@@ -1,6 +1,6 @@
-# Fly.io HA failover proxy (Workers → Pi tunnel)
-# Deploy from repo root:
-#   flyctl deploy --remote-only --config fly-proxy-app/fly.toml --app cloudless-proxy
+# Fly.io HA failover proxy (Workers → Pi via Tailscale)
+# Deploy from fly-proxy-app/:
+#   flyctl deploy --remote-only --config fly.toml --app cloudless-proxy
 
 app = "cloudless-proxy"
 
@@ -26,8 +26,14 @@ primary_region = "fra"
     health_check_interval = "30s"
 
 [env]
-  PRIMARY_HOST = "cloudless.gr"
-  FALLBACK_HOST = "pi-origin.cloudless.gr"
+  # Health + proxy primary: workers.dev avoids custom-domain Bot Fight from Fly IPs
+  PRIMARY_BASE = "https://cloudless2.baltzakis-themis.workers.dev"
+  # omv Tailscale IP → k3s NodePort (reachable after start.sh joins the mesh)
+  FALLBACK_BASE = "http://100.74.191.58:30300"
+  PUBLIC_HOST = "cloudless.gr"
+  TS_USERSPACE = "true"
+  TS_HOSTNAME = "cloudless-fly-proxy"
+  # TS_AUTHKEY via: flyctl secrets set TS_AUTHKEY=...
 
 [[vm]]
   cpu_kind = "shared"

--- a/fly-proxy-app/proxy.py
+++ b/fly-proxy-app/proxy.py
@@ -1,8 +1,10 @@
 """Fly.io HA Failover Proxy for cloudless.gr.
 
-Primary: Cloudflare Workers thin edge (cloudless.gr → Pi)
-Fallback: pi-origin.cloudless.gr (Tunnel → k3s NodePort, bypasses Workers)
+Primary: workers.dev thin edge (no custom-domain Bot Fight from datacenter IPs)
+Fallback: Pi k3s NodePort over Tailscale (bypasses Cloudflare Bot Fight entirely)
 """
+from __future__ import annotations
+
 import os
 import time
 
@@ -11,11 +13,29 @@ from fastapi import FastAPI, Request, Response
 
 app = FastAPI()
 
-PRIMARY_HOST = os.getenv("PRIMARY_HOST", "cloudless.gr")
-FALLBACK_HOST = os.getenv("FALLBACK_HOST", "pi-origin.cloudless.gr")
+PRIMARY_BASE = os.getenv(
+    "PRIMARY_BASE", "https://cloudless2.baltzakis-themis.workers.dev"
+).rstrip("/")
+# Tailscale IP of omv → NodePort 30300 (set after tailscale up in the container)
+FALLBACK_BASE = os.getenv(
+    "FALLBACK_BASE", "http://100.74.191.58:30300"
+).rstrip("/")
+PUBLIC_HOST = os.getenv("PUBLIC_HOST", "cloudless.gr")
 
 health_cache = {"healthy": True, "timestamp": 0.0}
 CACHE_TTL = 30
+
+
+def backend_headers(extra: dict[str, str] | None = None) -> dict[str, str]:
+    headers: dict[str, str] = {
+        "user-agent": "cloudless-fly-proxy/1.0",
+        "accept": "application/json, text/html, */*",
+        "x-forwarded-host": PUBLIC_HOST,
+        "x-forwarded-proto": "https",
+    }
+    if extra:
+        headers.update(extra)
+    return headers
 
 
 async def check_primary_health() -> bool:
@@ -25,7 +45,10 @@ async def check_primary_health() -> bool:
 
     try:
         async with httpx.AsyncClient(timeout=5.0, follow_redirects=True) as client:
-            resp = await client.get(f"https://{PRIMARY_HOST}/api/health")
+            resp = await client.get(
+                f"{PRIMARY_BASE}/api/health",
+                headers=backend_headers(),
+            )
             healthy = resp.status_code == 200
             if healthy:
                 try:
@@ -42,8 +65,8 @@ async def check_primary_health() -> bool:
     return healthy
 
 
-async def proxy_to_backend(request: Request, backend_host: str) -> Response:
-    url = f"https://{backend_host}{request.url.path}"
+async def proxy_to_backend(request: Request, base: str) -> Response:
+    url = f"{base}{request.url.path}"
     if request.url.query:
         url += f"?{request.url.query}"
 
@@ -60,6 +83,7 @@ async def proxy_to_backend(request: Request, backend_host: str) -> Response:
         "upgrade",
     ]:
         headers.pop(h, None)
+    headers.update(backend_headers())
 
     async with httpx.AsyncClient(timeout=30.0, follow_redirects=False) as client:
         body = await request.body()
@@ -86,11 +110,27 @@ async def proxy_to_backend(request: Request, backend_host: str) -> Response:
 @app.get("/health")
 async def health():
     healthy = await check_primary_health()
+    fallback_ok = False
+    fallback_status = 0
+    try:
+        async with httpx.AsyncClient(timeout=5.0) as client:
+            r = await client.get(
+                f"{FALLBACK_BASE}/api/health",
+                headers=backend_headers(),
+            )
+            fallback_status = r.status_code
+            fallback_ok = r.status_code == 200
+    except Exception:
+        fallback_ok = False
+
     return {
-        "status": "healthy" if healthy else "degraded",
-        "primary": PRIMARY_HOST,
-        "fallback": FALLBACK_HOST,
+        "status": "healthy" if healthy else ("degraded" if fallback_ok else "unhealthy"),
+        "primary": PRIMARY_BASE,
+        "fallback": FALLBACK_BASE,
+        "public_host": PUBLIC_HOST,
         "primary_healthy": healthy,
+        "fallback_healthy": fallback_ok,
+        "fallback_status": fallback_status,
     }
 
 
@@ -100,5 +140,5 @@ async def health():
 )
 async def proxy(request: Request, path: str):
     healthy = await check_primary_health()
-    backend = PRIMARY_HOST if healthy else FALLBACK_HOST
-    return await proxy_to_backend(request, backend)
+    base = PRIMARY_BASE if healthy else FALLBACK_BASE
+    return await proxy_to_backend(request, base)

--- a/fly-proxy-app/start.sh
+++ b/fly-proxy-app/start.sh
@@ -1,0 +1,35 @@
+#!/bin/sh
+set -eu
+
+mkdir -p /var/run/tailscale /var/lib/tailscale
+
+# Userspace networking works on Fly without /dev/net/tun privileges.
+export TS_USERSPACE="${TS_USERSPACE:-true}"
+
+if [ -n "${TS_AUTHKEY:-}" ]; then
+  tailscaled \
+    --state=/var/lib/tailscale/tailscaled.state \
+    --socket=/var/run/tailscale/tailscaled.sock \
+    --tun=userspace-networking &
+
+  # Wait for daemon
+  i=0
+  while [ "$i" -lt 30 ]; do
+    if tailscale --socket=/var/run/tailscale/tailscaled.sock status >/dev/null 2>&1; then
+      break
+    fi
+    i=$((i + 1))
+    sleep 0.5
+  done
+
+  tailscale --socket=/var/run/tailscale/tailscaled.sock up \
+    --authkey="$TS_AUTHKEY" \
+    --hostname="${TS_HOSTNAME:-cloudless-fly-proxy}" \
+    --accept-dns=false \
+    --accept-routes=true \
+    --ssh=false || echo "warn: tailscale up failed (fallback may be unreachable)" >&2
+else
+  echo "warn: TS_AUTHKEY unset — Tailscale fallback disabled" >&2
+fi
+
+exec python -m uvicorn proxy:app --host 0.0.0.0 --port 8080

--- a/fly.toml
+++ b/fly.toml
@@ -1,13 +1,10 @@
-# Thin pointer — real config lives next to the proxy image.
-# Deploy: flyctl deploy --remote-only --config fly-proxy-app/fly.toml --app cloudless-proxy
-# Or: gh workflow run deploy-fly-proxy.yml -f apply=true
+# Thin pointer — real config lives in fly-proxy-app/fly.toml
+# Deploy: gh workflow run deploy-fly-proxy.yml -f apply=true
 
 app = "cloudless-proxy"
 primary_region = "fra"
 
-[build]
-  dockerfile = "fly-proxy-app/Dockerfile"
-
 [env]
-  PRIMARY_HOST = "cloudless.gr"
-  FALLBACK_HOST = "pi-origin.cloudless.gr"
+  PRIMARY_BASE = "https://cloudless2.baltzakis-themis.workers.dev"
+  FALLBACK_BASE = "http://100.74.191.58:30300"
+  PUBLIC_HOST = "cloudless.gr"


### PR DESCRIPTION
## Summary
- Health-check and proxy **primary** via `cloudless2…workers.dev` (no custom-domain Bot Fight)
- **Fallback** to omv Tailscale `100.74.191.58:30300` (userspace Tailscale in the Fly VM)
- Free Bot Fight Mode cannot be WAF-skipped; Tailscale is the free-tier path to Pi

## Test plan
- [ ] `gh workflow run deploy-fly-proxy.yml -f apply=true`
- [ ] `/health` shows `primary_healthy: true` and `fallback_healthy: true`
- [ ] `/api/health` via Fly returns origin JSON (not CF challenge HTML)

Made with [Cursor](https://cursor.com)