### PR TITLE
fix: Tailscale SOCKS5 for Fly fallback

### DIFF
--- a/fly-proxy-app/start.sh
+++ b/fly-proxy-app/start.sh
@@ -3,31 +3,51 @@ set -eu
 
 mkdir -p /var/run/tailscale /var/lib/tailscale
 
-# Userspace networking works on Fly without /dev/net/tun privileges.
-export TS_USERSPACE="${TS_USERSPACE:-true}"
+SOCKS="127.0.0.1:1055"
 
 if [ -n "${TS_AUTHKEY:-}" ]; then
+  # Userspace mode: no /dev/net/tun. App traffic must use the SOCKS5 proxy.
   tailscaled \
     --state=/var/lib/tailscale/tailscaled.state \
     --socket=/var/run/tailscale/tailscaled.sock \
-    --tun=userspace-networking &
+    --tun=userspace-networking \
+    --socks5-server="${SOCKS}" \
+    --outbound-http-proxy-listen="${SOCKS}" &
 
-  # Wait for daemon
   i=0
-  while [ "$i" -lt 30 ]; do
-    if tailscale --socket=/var/run/tailscale/tailscaled.sock status >/dev/null 2>&1; then
+  while [ "$i" -lt 40 ]; do
+    if tailscale --socket=/var/run/tailscale/tailscaled.sock version >/dev/null 2>&1; then
       break
     fi
     i=$((i + 1))
-    sleep 0.5
+    sleep 0.25
   done
 
-  tailscale --socket=/var/run/tailscale/tailscaled.sock up \
+  if ! tailscale --socket=/var/run/tailscale/tailscaled.sock up \
     --authkey="$TS_AUTHKEY" \
     --hostname="${TS_HOSTNAME:-cloudless-fly-proxy}" \
     --accept-dns=false \
     --accept-routes=true \
-    --ssh=false || echo "warn: tailscale up failed (fallback may be unreachable)" >&2
+    --ssh=false; then
+    echo "warn: tailscale up failed (fallback may be unreachable)" >&2
+  else
+    j=0
+    while [ "$j" -lt 30 ]; do
+      state="$(tailscale --socket=/var/run/tailscale/tailscaled.sock status --json 2>/dev/null \
+        | python -c 'import sys,json; print(json.load(sys.stdin).get("BackendState",""))' 2>/dev/null || true)"
+      if [ "$state" = "Running" ]; then
+        echo "tailscale: Running"
+        break
+      fi
+      j=$((j + 1))
+      sleep 0.5
+    done
+  fi
+
+  export ALL_PROXY="socks5h://${SOCKS}"
+  export HTTP_PROXY="socks5h://${SOCKS}"
+  export HTTPS_PROXY="socks5h://${SOCKS}"
+  export NO_PROXY="127.0.0.1,localhost"
 else
   echo "warn: TS_AUTHKEY unset — Tailscale fallback disabled" >&2
 fi


### PR DESCRIPTION
## Summary
- Userspace Tailscale on Fly requires SOCKS5 for app egress
- start.sh now runs `--socks5-server` and exports `ALL_PROXY`/`HTTP(S)_PROXY`

## Test plan
- [ ] Redeploy `deploy-fly-proxy.yml`
- [ ] `/health` shows `fallback_healthy: true`

Made with [Cursor](https://cursor.com)