### PR TITLE
fix: socks5 scheme for Fly Tailscale fallback

### DIFF
--- a/fly-proxy-app/proxy.py
+++ b/fly-proxy-app/proxy.py
@@ -135,7 +135,7 @@ async def health():
             fallback_ok = r.status_code == 200
     except Exception as e:
         fallback_ok = False
-        fallback_error = type(e).__name__
+        fallback_error = f"{type(e).__name__}:{e}"
 
     return {
         "status": "healthy" if healthy else ("degraded" if fallback_ok else "unhealthy"),

--- a/fly-proxy-app/requirements.txt
+++ b/fly-proxy-app/requirements.txt
@@ -1,3 +1,4 @@
 fastapi==0.115.0
-httpx[socks]==0.27.0
+httpx==0.27.0
+socksio==1.0.0
 uvicorn[standard]==0.32.0

--- a/fly-proxy-app/start.sh
+++ b/fly-proxy-app/start.sh
@@ -45,7 +45,8 @@ if [ -n "${TS_AUTHKEY:-}" ]; then
   fi
 
   # Do NOT set HTTP(S)_PROXY globally — that breaks workers.dev primary.
-  export TS_SOCKS_PROXY="socks5h://${SOCKS}"
+  # httpx wants socks5:// (not socks5h://)
+  export TS_SOCKS_PROXY="socks5://${SOCKS}"
 else
   echo "warn: TS_AUTHKEY unset — Tailscale fallback disabled" >&2
 fi


### PR DESCRIPTION
## Summary
- Switch TS_SOCKS_PROXY to socks5:// (httpx ValueError on socks5h)
- Pin socksio; richer fallback_error

## Test plan
- [ ] Redeploy; primary healthy; fallback_error no longer ValueError

Made with [Cursor](https://cursor.com)