### PR TITLE
fix: remove ignoreBuildErrors; restore Build typecheck

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -28,12 +28,6 @@ const nextConfig: NextConfig = {
   // doesn't recompress what's already compressed). Default is true; set
   // explicitly so anyone reading config sees that compression is on.
   compress: true,
-  // Temporary: DOM `Response.json()` is `unknown` under current TS libs and
-  // trips next build across many call sites. Lint/typecheck jobs still run;
-  // remove once remaining casts are cleaned up.
-  typescript: {
-    ignoreBuildErrors: true,
-  },
   // Strip the X-Powered-By: Next.js header — small attack-surface reduction.
   poweredByHeader: false,
   // Emit browser source maps so Playwright CDP coverage of /_next/static chunks

--- a/src/lib/activecampaign.ts
+++ b/src/lib/activecampaign.ts
@@ -8,6 +8,30 @@ async function getACConfig(): Promise<{ url: string; token: string }> {
   return { url: url.replace(/\/$/, ""), token };
 }
 
+interface ACMetaResponse {
+  meta?: { total?: string };
+}
+
+interface ACCampaignsResponse extends ACMetaResponse {
+  campaigns?: ACCampaign[];
+}
+
+interface ACCampaignResponse {
+  campaign?: ACCampaign;
+}
+
+interface ACContactsResponse extends ACMetaResponse {
+  contacts?: ACContact[];
+}
+
+interface ACListsResponse extends ACMetaResponse {
+  lists?: ACList[];
+}
+
+interface ACAutomationsResponse {
+  automations?: ACAutomation[];
+}
+
 async function acFetch(path: string, options: RequestInit = {}): Promise<Response> {
   const { url, token } = await getACConfig();
   return fetch(`${url}/api/3${path}`, {
@@ -86,7 +110,7 @@ export async function listCampaigns(limit = 20): Promise<ACCampaign[]> {
   try {
     const res = await acFetch(`/campaigns?limit=${limit}&orders[sdate]=DESC`);
     if (!res.ok) return [];
-    const data = await res.json();
+    const data = (await res.json()) as ACCampaignsResponse;
     return data.campaigns ?? [];
   } catch {
     return [];
@@ -97,7 +121,7 @@ export async function getCampaign(id: string): Promise<ACCampaign | null> {
   try {
     const res = await acFetch(`/campaigns/${id}`);
     if (!res.ok) return null;
-    const data = await res.json();
+    const data = (await res.json()) as ACCampaignResponse;
     return data.campaign ?? null;
   } catch {
     return null;
@@ -135,7 +159,7 @@ export async function createCampaign(input: CreateCampaignInput): Promise<ACCamp
       }),
     });
     if (!res.ok) return null;
-    const data = await res.json();
+    const data = (await res.json()) as ACCampaignResponse;
     return data.campaign ?? null;
   } catch {
     return null;
@@ -157,7 +181,7 @@ export async function listACContacts(limit = 20): Promise<ACContact[]> {
   try {
     const res = await acFetch(`/contacts?limit=${limit}&orders[cdate]=DESC`);
     if (!res.ok) return [];
-    const data = await res.json();
+    const data = (await res.json()) as ACContactsResponse;
     return data.contacts ?? [];
   } catch {
     return [];
@@ -176,7 +200,7 @@ export async function listACLists(): Promise<ACList[]> {
   try {
     const res = await acFetch("/lists?limit=100");
     if (!res.ok) return [];
-    const data = await res.json();
+    const data = (await res.json()) as ACListsResponse;
     return data.lists ?? [];
   } catch {
     return [];
@@ -197,7 +221,7 @@ export async function listAutomations(): Promise<ACAutomation[]> {
   try {
     const res = await acFetch("/automations?limit=50");
     if (!res.ok) return [];
-    const data = await res.json();
+    const data = (await res.json()) as ACAutomationsResponse;
     return data.automations ?? [];
   } catch {
     return [];
@@ -271,11 +295,11 @@ export async function getEmailStats(): Promise<{
       acFetch("/campaigns?limit=1"),
       acFetch("/lists?limit=1"),
     ]);
-    const [contactsData, campaignsData, listsData] = await Promise.all([
+    const [contactsData, campaignsData, listsData] = (await Promise.all([
       contactsRes.ok ? contactsRes.json() : { meta: { total: 0 } },
       campaignsRes.ok ? campaignsRes.json() : { meta: { total: 0 } },
       listsRes.ok ? listsRes.json() : { meta: { total: 0 } },
-    ]);
+    ])) as [ACContactsResponse, ACCampaignsResponse, ACListsResponse];
     return {
       totalContacts: parseInt(contactsData.meta?.total ?? "0", 10),
       totalCampaigns: parseInt(campaignsData.meta?.total ?? "0", 10),

--- a/src/lib/appflowy-blog.ts
+++ b/src/lib/appflowy-blog.ts
@@ -114,8 +114,8 @@ export async function getPosts(): Promise<AppFlowyPost[]> {
       let html = "";
       try {
         const doc = await getDocument(workspaceId, view.view_id);
-        const text = extractDocText(doc);
-        html = markdownToHtml(text);
+        const text = await extractDocText(doc);
+        html = await markdownToHtml(text);
       } catch {
         html = "";
       }

--- a/src/lib/appflowy-docs.ts
+++ b/src/lib/appflowy-docs.ts
@@ -179,8 +179,8 @@ export async function getDocContentWithToc(docId: string): Promise<AppFlowyDocCo
   }
 
   const document = await getDocument(workspaceId, docId);
-  const markdown = extractDocText(document);
-  const html = await Promise.resolve(markdownToHtml(markdown));
+  const markdown = await extractDocText(document);
+  const html = await markdownToHtml(markdown);
   const toc = extractTocFromMarkdown(markdown);
 
   return {

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -97,11 +97,11 @@ async function handleTokenRefresh(token: JWT, env: AuthEnv, now: number): Promis
 
   try {
     // Check if session exists in D1
-    const session = await AUTH_DB.prepare("SELECT expires_at FROM sessions WHERE user_id = ?")
+    const session = (await AUTH_DB.prepare("SELECT expires_at FROM sessions WHERE user_id = ?")
       .bind(userId)
-      .first();
+      .first()) as { expires_at?: number } | null;
 
-    if (!session || session.expires_at <= now) {
+    if (!session || (session.expires_at ?? 0) <= now) {
       token.error = REFRESH_TOKEN_ERROR;
       return token;
     }

--- a/src/lib/campaigns/google-ads.ts
+++ b/src/lib/campaigns/google-ads.ts
@@ -191,7 +191,7 @@ export async function listGoogleCampaigns(): Promise<GoogleCampaign[]> {
       body: JSON.stringify({ query }),
     });
     if (!res.ok) return [];
-    const data = await res.json();
+    const data = (await res.json()) as { results?: GoogleCampaignRow[] };
     return (data.results ?? []).map((r: GoogleCampaignRow) => mapCampaignRow(r));
   } catch {
     return [];
@@ -220,7 +220,7 @@ export async function getGoogleMetrics(dateStart: string, dateEnd: string): Prom
       body: JSON.stringify({ query }),
     });
     if (!res.ok) return emptyMetrics();
-    const data = await res.json();
+    const data = (await res.json()) as { results?: Array<{ metrics?: GoogleMetricsRow }> };
     return parseMetricsRow(data.results?.[0]?.metrics);
   } catch {
     return emptyMetrics();

--- a/src/lib/campaigns/linkedin.ts
+++ b/src/lib/campaigns/linkedin.ts
@@ -54,7 +54,20 @@ export async function listLinkedInCampaigns(): Promise<LinkedInCampaign[]> {
     if (!adAccountId) return [];
     const res = await liiFetch(`/adAccounts/${adAccountId}/adCampaigns?q=search&count=20`);
     if (!res.ok) return [];
-    const data = await res.json();
+    const data = (await res.json()) as {
+      elements?: Array<{
+        id: number;
+        name: string;
+        status: string;
+        type: string;
+        objectiveType: string;
+        totalBudget?: { amount: string; currencyCode: string };
+        changeAuditStamps: {
+          created: { time: number };
+          lastModified: { time: number };
+        };
+      }>;
+    };
     return (data.elements ?? []).map(
       (el: {
         id: number;
@@ -107,7 +120,14 @@ export async function getLinkedInInsights(
       `/adAnalytics?q=analytics&pivot=ACCOUNT&dateRange.start.year=${dateStart.split("-")[0]}&dateRange.start.month=${Number(dateStart.split("-")[1])}&dateRange.start.day=${Number(dateStart.split("-")[2])}&dateRange.end.year=${dateEnd.split("-")[0]}&dateRange.end.month=${Number(dateEnd.split("-")[1])}&dateRange.end.day=${Number(dateEnd.split("-")[2])}&timeGranularity=ALL&accounts%5B0%5D=urn%3Ali%3AsponsoredAccount%3A${adAccountId}&fields=impressions,clicks,costInLocalCurrency,externalWebsiteConversions`
     );
     if (!res.ok) return empty;
-    const data = await res.json();
+    const data = (await res.json()) as {
+      elements?: Array<{
+        impressions?: number;
+        clicks?: number;
+        costInLocalCurrency?: string;
+        externalWebsiteConversions?: number;
+      }>;
+    };
     const el = data.elements?.[0] ?? {};
     return {
       impressions: el.impressions ?? 0,
@@ -199,7 +219,11 @@ export async function getLinkedInCampaignStatus(campaignId: string): Promise<{
       const text = await res.text().catch(() => "");
       return { ok: false, error: `${res.status}: ${text.slice(0, 200)}` };
     }
-    const data = await res.json();
+    const data = (await res.json()) as {
+      name?: string;
+      status?: string;
+      dailyBudget?: { amount: string };
+    };
     return {
       ok: true,
       name: data.name,

--- a/src/lib/campaigns/tiktok.ts
+++ b/src/lib/campaigns/tiktok.ts
@@ -108,7 +108,7 @@ export async function listTikTokCampaigns(): Promise<TikTokCampaign[]> {
     const { advertiserId } = await getTikTokConfig();
     const res = await ttFetch(`/campaign/get/?advertiser_id=${advertiserId}&page_size=20`);
     if (!res.ok) return [];
-    const data = await res.json();
+    const data = (await res.json()) as { data?: { list?: TikTokCampaign[] } };
     return data.data?.list ?? [];
   } catch {
     return [];
@@ -127,7 +127,7 @@ export async function getTikTokInsights(
       body: JSON.stringify(body),
     });
     if (!res.ok) return emptyInsights();
-    const data = await res.json();
+    const data = (await res.json()) as { data?: { list?: TikTokReportRow[] } };
     const rows: TikTokReportRow[] = data.data?.list ?? [];
     if (rows.length === 0) return emptyInsights();
     return parseInsightsRow(rows[0]);

--- a/src/lib/campaigns/x-ads.ts
+++ b/src/lib/campaigns/x-ads.ts
@@ -104,7 +104,7 @@ export async function listXCampaigns(): Promise<XCampaign[]> {
     if (!adAccountId) return [];
     const res = await xFetch(`/accounts/${adAccountId}/campaigns?count=20&sort_by=created_at-desc`);
     if (!res.ok) return [];
-    const data = await res.json();
+    const data = (await res.json()) as { data?: XCampaign[] };
     return data.data ?? [];
   } catch {
     return [];
@@ -132,7 +132,9 @@ export async function getXStats(dateStart: string, dateEnd: string): Promise<XSt
       `/stats/accounts/${adAccountId}?granularity=DAY&metric_groups=ENGAGEMENT,BILLING&start_time=${dateStart}T00:00:00Z&end_time=${dateEnd}T23:59:59Z`
     );
     if (!res.ok) return empty;
-    const data = await res.json();
+    const data = (await res.json()) as {
+      data?: { id_data?: Array<{ id_data?: Record<string, number> }> };
+    };
     const metrics = data.data?.id_data?.[0]?.id_data ?? {};
     return {
       impressions: metrics.impressions ?? 0,

--- a/src/lib/email.ts
+++ b/src/lib/email.ts
@@ -1,8 +1,18 @@
 import { NextResponse } from "next/server";
 import { SESv2Client, SendEmailCommand } from "@aws-sdk/client-sesv2";
 import { getConfig } from "@/lib/ssm-config";
+
+interface CloudflareEmailBinding {
+  send: (message: Record<string, unknown>) => Promise<void>;
+}
+
+interface WorkersGlobal {
+  caches?: CacheStorage;
+  __ENV__?: { EMAIL_BINDING?: CloudflareEmailBinding };
+}
+
 const isWorkers =
-  typeof (globalThis as unknown as Record<string, unknown>).caches !== "undefined" &&
+  typeof (globalThis as unknown as WorkersGlobal).caches !== "undefined" &&
   typeof process === "undefined";
 
 /**
@@ -21,14 +31,14 @@ export async function sendEmail(options: {
 }) {
   if (isWorkers) {
     // Cloudflare Workers email binding
-    const email = globalThis.__ENV__.EMAIL_BINDING;
+    const email = (globalThis as unknown as WorkersGlobal).__ENV__?.EMAIL_BINDING;
     if (!email) {
       console.warn("[email-sender] No email binding available. Skipping send.");
       return NextResponse.json({ error: "Email service not configured" }, { status: 503 });
     }
 
     try {
-      const headers = {};
+      const headers: Record<string, string> = {};
       if (options.listUnsubscribeUrl) {
         headers["List-Unsubscribe"] = `<${options.listUnsubscribeUrl}>`;
       }
@@ -49,7 +59,7 @@ export async function sendEmail(options: {
     // AWS SES or R2-based email
     try {
       const cfg = await getConfig();
-      const client = new SESv2Client({ region: cfg.AWS_REGION || "eu-west-1" });
+      const client = new SESv2Client({ region: cfg.AWS_SES_REGION || "eu-west-1" });
 
       const command = new SendEmailCommand({
         Destination: {
@@ -62,14 +72,13 @@ export async function sendEmail(options: {
               Text: { Data: options.text },
             },
             Subject: { Data: options.subject },
+            Headers: options.listUnsubscribeUrl
+              ? [{ Name: "List-Unsubscribe", Value: `<${options.listUnsubscribeUrl}>` }]
+              : undefined,
           },
         },
         FromEmailAddress: `${options.fromLabel || "Cloudless"} <noreply@cloudless.gr>`,
         ReplyToAddresses: options.replyTo ? [options.replyTo] : undefined,
-        ReturnPath: "noreply@cloudless.gr",
-        Headers: options.listUnsubscribeUrl
-          ? [{ Name: "List-Unsubscribe", Value: `<${options.listUnsubscribeUrl}>` }]
-          : undefined,
       });
 
       await client.send(command);

--- a/src/lib/gsc.ts
+++ b/src/lib/gsc.ts
@@ -108,6 +108,22 @@ export interface WebAnalyticsData {
 }
 
 /* ------------------------------------------------------------------ */
+/*  Response shapes                                                    */
+/* ------------------------------------------------------------------ */
+
+interface GscAnalyticsRow {
+  keys?: string[];
+  clicks?: number;
+  impressions?: number;
+  ctr?: number;
+  position?: number;
+}
+
+interface GscQueryResponse {
+  rows?: GscAnalyticsRow[];
+}
+
+/* ------------------------------------------------------------------ */
 /*  Public API                                                         */
 /* ------------------------------------------------------------------ */
 
@@ -133,7 +149,7 @@ export async function getSeoSnapshot(
       console.error("[GSC] Overview error:", await totalsRes.text());
       return null;
     }
-    const totals = await totalsRes.json();
+    const totals = (await totalsRes.json()) as GscQueryResponse;
     const row = totals.rows?.[0] ?? {};
 
     // Count unique keywords
@@ -142,7 +158,7 @@ export async function getSeoSnapshot(
       dimensions: ["query"],
       rowLimit: 25000, // GSC max
     });
-    const kwData = kwRes.ok ? await kwRes.json() : {};
+    const kwData = (kwRes.ok ? await kwRes.json() : {}) as GscQueryResponse;
     const organicKeywords: number = kwData.rows?.length ?? 0;
 
     return {
@@ -176,9 +192,9 @@ export async function getTopKeywords(
     });
 
     if (!res.ok) return [];
-    const data = await res.json();
+    const data = (await res.json()) as GscQueryResponse;
 
-    return (data.rows ?? []).map((r: Record<string, unknown>) => ({
+    return (data.rows ?? []).map((r) => ({
       keyword: (r.keys as string[])?.[0] ?? "",
       clicks: Math.round((r.clicks as number) ?? 0),
       impressions: Math.round((r.impressions as number) ?? 0),
@@ -228,9 +244,9 @@ export async function getPerformanceHistory(
     });
 
     if (!res.ok) return [];
-    const data = await res.json();
+    const data = (await res.json()) as GscQueryResponse;
 
-    return (data.rows ?? []).map((r: Record<string, unknown>) => ({
+    return (data.rows ?? []).map((r) => ({
       date: (r.keys as string[])?.[0] ?? "",
       clicks: Math.round((r.clicks as number) ?? 0),
       impressions: Math.round((r.impressions as number) ?? 0),
@@ -261,9 +277,9 @@ export async function getTopPages(
     });
 
     if (!res.ok) return [];
-    const data = await res.json();
+    const data = (await res.json()) as GscQueryResponse;
 
-    return (data.rows ?? []).map((r: Record<string, unknown>) => ({
+    return (data.rows ?? []).map((r) => ({
       page: (r.keys as string[])?.[0] ?? "",
       clicks: Math.round((r.clicks as number) ?? 0),
       impressions: Math.round((r.impressions as number) ?? 0),
@@ -294,7 +310,7 @@ export async function getWebAnalytics(
       rowLimit: 1,
     });
 
-    const totalsData = totalsRes.ok ? await totalsRes.json() : {};
+    const totalsData = (totalsRes.ok ? await totalsRes.json() : {}) as GscQueryResponse;
     const total = totalsData.rows?.[0] ?? {};
 
     // Top pages
@@ -305,12 +321,12 @@ export async function getWebAnalytics(
       orderBy: [{ fieldName: "clicks", sortOrder: SORT_DESCENDING }],
     });
 
-    const pagesData = pagesRes.ok ? await pagesRes.json() : {};
-    const topPages = (pagesData.rows ?? []).map((r: Record<string, unknown>) => ({
-      page: (r.keys as string[])?.[0] ?? "",
-      clicks: Math.round((r.clicks as number) ?? 0),
-      impressions: Math.round((r.impressions as number) ?? 0),
-      position: parseFloat(((r.position as number) ?? 0).toFixed(1)),
+    const pagesData = (pagesRes.ok ? await pagesRes.json() : {}) as GscQueryResponse;
+    const topPages = (pagesData.rows ?? []).map((r) => ({
+      page: r.keys?.[0] ?? "",
+      clicks: Math.round(r.clicks ?? 0),
+      impressions: Math.round(r.impressions ?? 0),
+      position: parseFloat((r.position ?? 0).toFixed(1)),
     }));
 
     return {
@@ -357,30 +373,27 @@ export async function getCtrOpportunities(
     });
 
     if (!res.ok) return [];
-    const data = await res.json();
+    const data = (await res.json()) as GscQueryResponse;
 
     const opportunities = (data.rows ?? [])
-      .filter((r: Record<string, unknown>) => {
-        const position = (r.position as number) ?? 0;
-        const ctr = ((r.ctr as number) ?? 0) * 100;
-        const impressions = (r.impressions as number) ?? 0;
+      .filter((r) => {
+        const position = r.position ?? 0;
+        const ctr = (r.ctr ?? 0) * 100;
+        const impressions = r.impressions ?? 0;
         return position >= 4 && position <= 20 && ctr < 5 && impressions > 10;
       })
-      .sort(
-        (a: Record<string, unknown>, b: Record<string, unknown>) =>
-          ((b.impressions as number) ?? 0) - ((a.impressions as number) ?? 0)
-      )
+      .sort((a, b) => (b.impressions ?? 0) - (a.impressions ?? 0))
       .slice(0, limit)
-      .map((r: Record<string, unknown>) => {
-        const impressions = Math.round((r.impressions as number) ?? 0);
-        const clicks = Math.round((r.clicks as number) ?? 0);
+      .map((r) => {
+        const impressions = Math.round(r.impressions ?? 0);
+        const clicks = Math.round(r.clicks ?? 0);
         const potentialClicks = Math.max(0, Math.round(impressions * 0.05) - clicks);
         return {
-          keyword: (r.keys as string[])?.[0] ?? "",
+          keyword: r.keys?.[0] ?? "",
           clicks,
           impressions,
-          ctr: parseFloat((((r.ctr as number) ?? 0) * 100).toFixed(2)),
-          position: parseFloat(((r.position as number) ?? 0).toFixed(1)),
+          ctr: parseFloat(((r.ctr ?? 0) * 100).toFixed(2)),
+          position: parseFloat((r.position ?? 0).toFixed(1)),
           potentialClicks,
         };
       });
@@ -417,9 +430,9 @@ export async function getDeviceBreakdown(siteUrl = DEFAULT_SITE): Promise<Device
     });
 
     if (!res.ok) return [];
-    const data = await res.json();
+    const data = (await res.json()) as GscQueryResponse;
 
-    return (data.rows ?? []).map((r: Record<string, unknown>) => ({
+    return (data.rows ?? []).map((r) => ({
       device: (r.keys as string[])?.[0] ?? "",
       clicks: Math.round((r.clicks as number) ?? 0),
       impressions: Math.round((r.impressions as number) ?? 0),
@@ -474,9 +487,9 @@ export async function getProductPageMetrics(
     });
 
     if (!res.ok) return [];
-    const data = await res.json();
+    const data = (await res.json()) as GscQueryResponse;
 
-    return (data.rows ?? []).map((r: Record<string, unknown>) => ({
+    return (data.rows ?? []).map((r) => ({
       page: (r.keys as string[])?.[0] ?? "",
       clicks: Math.round((r.clicks as number) ?? 0),
       impressions: Math.round((r.impressions as number) ?? 0),
@@ -520,9 +533,9 @@ export async function getQueryPageMapping(
     });
 
     if (!res.ok) return [];
-    const data = await res.json();
+    const data = (await res.json()) as GscQueryResponse;
 
-    return (data.rows ?? []).map((r: Record<string, unknown>) => ({
+    return (data.rows ?? []).map((r) => ({
       query: (r.keys as string[])?.[0] ?? "",
       page: (r.keys as string[])?.[1] ?? "",
       clicks: Math.round((r.clicks as number) ?? 0),
@@ -583,7 +596,7 @@ export async function getSearchIntentBreakdown(
     });
 
     if (!res.ok) return empty;
-    const data = await res.json();
+    const data = (await res.json()) as GscQueryResponse;
 
     const brandRe = /cloudless/i;
     const productRe =
@@ -591,12 +604,12 @@ export async function getSearchIntentBreakdown(
     const infoRe =
       /\b(how|what|why|when|where|guide|tutorial|tips|learn|blog|article|example|comparison|vs|review)\b/i;
 
-    const toKeyword = (r: Record<string, unknown>): IntentKeyword => ({
-      keyword: (r.keys as string[])?.[0] ?? "",
-      clicks: Math.round((r.clicks as number) ?? 0),
-      impressions: Math.round((r.impressions as number) ?? 0),
-      ctr: parseFloat((((r.ctr as number) ?? 0) * 100).toFixed(2)),
-      position: parseFloat(((r.position as number) ?? 0).toFixed(1)),
+    const toKeyword = (r: GscAnalyticsRow): IntentKeyword => ({
+      keyword: r.keys?.[0] ?? "",
+      clicks: Math.round(r.clicks ?? 0),
+      impressions: Math.round(r.impressions ?? 0),
+      ctr: parseFloat(((r.ctr ?? 0) * 100).toFixed(2)),
+      position: parseFloat((r.position ?? 0).toFixed(1)),
     });
 
     const result: SearchIntentBreakdown = {
@@ -607,7 +620,7 @@ export async function getSearchIntentBreakdown(
     };
 
     for (const row of data.rows ?? []) {
-      const kw = (row.keys as string[])?.[0] ?? "";
+      const kw = row.keys?.[0] ?? "";
       const mapped = toKeyword(row);
 
       if (brandRe.test(kw)) {
@@ -665,9 +678,9 @@ export async function getTrafficByCountry(
     });
 
     if (!res.ok) return [];
-    const data = await res.json();
+    const data = (await res.json()) as GscQueryResponse;
 
-    return (data.rows ?? []).map((r: Record<string, unknown>) => ({
+    return (data.rows ?? []).map((r) => ({
       country: (r.keys as string[])?.[0] ?? "",
       clicks: Math.round((r.clicks as number) ?? 0),
       impressions: Math.round((r.impressions as number) ?? 0),

--- a/src/lib/langgraph-client.ts
+++ b/src/lib/langgraph-client.ts
@@ -1,9 +1,12 @@
-/** * LangGraph Agent Server client stub * * This stub implementation is used when @langchain/langgraph-sdk is not installed. * It provides the same API surface so routes don't crash, but throws runtime * errors if actually called. */ export type {
-  Thread,
-  ThreadState,
-  Run,
-  Assistant,
-};
+/**
+ * LangGraph Agent Server client stub
+ *
+ * This stub implementation is used when @langchain/langgraph-sdk is not installed.
+ * It provides the same API surface so routes don't crash, but throws runtime
+ * errors if actually called.
+ */
+export type { Thread, ThreadState, Run, Assistant } from "@langchain/langgraph-sdk";
+
 export interface StreamRunOptions {
   streamMode?: ("messages" | "updates" | "values" | "events" | "debug" | "custom")[];
   interruptBefore?: string[] | "*";

--- a/src/lib/log-sanitizer.ts
+++ b/src/lib/log-sanitizer.ts
@@ -32,17 +32,11 @@ const SENSITIVE_PATTERNS = [
 ];
 
 export function sanitizeLog(input: string, maxLength = 500): string {
-  return (
-    input
-      // First mask sensitive patterns
-      .replace(SENSITIVE_PATTERNS, (match) => `[REDACTED:${match.length}]`)
-      // Then remove control characters and format specifiers
-      .replace(/[\x00-\x1F\x7F]/g, "") // Remove control characters
-      .replace(/%/g, "") // Remove format specifier marker
-      .replace(/\r?\n/g, " ") // Replace newlines with spaces
-      .slice(0, maxLength)
-  );
-  return input
+  let sanitized = input;
+  for (const pattern of SENSITIVE_PATTERNS) {
+    sanitized = sanitized.replace(pattern, (match) => `[REDACTED:${match.length}]`);
+  }
+  return sanitized
     .replace(/[\x00-\x1F\x7F]/g, "") // Remove control characters
     .replace(/%/g, "") // Remove format specifier marker
     .replace(/\r?\n/g, " ") // Replace newlines with spaces

--- a/src/lib/meilisearch.ts
+++ b/src/lib/meilisearch.ts
@@ -1,6 +1,29 @@
 export const PRODUCTS_INDEX = "products";
 export const PRODUCT_EMBEDDER = "bedrock-titan-v2";
 
+export interface ProductDocument {
+  id: string;
+  name: string;
+  description: string;
+  price: number;
+  currency: string;
+  category: string;
+  image?: string;
+  features?: string[];
+  featuresText?: string;
+  categoryLabel?: string;
+  updatedAt?: string;
+}
+
+export interface SearchResult {
+  id: string;
+  name: string;
+  description: string;
+  price: number;
+  category: string;
+  categoryLabel?: string;
+}
+
 export function getMeiliHost(): string {
   return (process.env.MEILI_HOST || "").replace(/\/+$/, "");
 }
@@ -47,4 +70,47 @@ export async function meiliRequest<T>(
   }
 
   return (await res.json()) as T;
+}
+
+export async function indexProducts(documents: ProductDocument[]): Promise<void> {
+  if (!isMeilisearchConfigured() || documents.length === 0) return;
+
+  await meiliRequest(
+    `/indexes/${PRODUCTS_INDEX}/documents`,
+    {
+      method: "POST",
+      body: JSON.stringify(documents),
+    },
+    getMeiliAdminKey()
+  );
+}
+
+export async function resetIndex(documents: ProductDocument[]): Promise<void> {
+  if (!isMeilisearchConfigured()) return;
+
+  try {
+    await meiliRequest(
+      `/indexes/${PRODUCTS_INDEX}`,
+      { method: "DELETE" },
+      getMeiliAdminKey()
+    );
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    if (!message.includes("404") && !message.includes("index_not_found")) {
+      throw err;
+    }
+  }
+
+  await meiliRequest(
+    "/indexes",
+    {
+      method: "POST",
+      body: JSON.stringify({ uid: PRODUCTS_INDEX, primaryKey: "id" }),
+    },
+    getMeiliAdminKey()
+  );
+
+  if (documents.length > 0) {
+    await indexProducts(documents);
+  }
 }

--- a/src/lib/r2-client.ts
+++ b/src/lib/r2-client.ts
@@ -64,7 +64,7 @@ export async function serveStaticAsset(
   if (!asset) return null;
 
   const headers = new Headers();
-  asset.writeHttpMetadata(headers);
+  asset.writeHttpMetadata(headers as unknown as import("@cloudflare/workers-types").Headers);
   headers.set("Cache-Control", `public, max-age=${opts.cacheSeconds || 31536000}, immutable`);
 
   // Set CORS headers
@@ -92,7 +92,7 @@ export async function serveStaticAsset(
     }
   }
 
-  return new Response(asset.body, { headers });
+  return new Response(asset.body as unknown as BodyInit, { headers });
 }
 
 // List objects in an R2 bucket (for admin operations)

--- a/src/lib/ssm-config-d1.ts
+++ b/src/lib/ssm-config-d1.ts
@@ -298,9 +298,9 @@ export async function getConfig<T extends Record<string, string> = Record<string
     const d1Config = await getD1Config(db);
     // Merge with environment variables (secrets take precedence)
     const envConfig = buildConfigFromEnv();
-    return { ...d1Config, ...envConfig } as T;
+    return { ...d1Config, ...envConfig } as unknown as T;
   }
 
   // In development or when no D1 binding, use environment
-  return buildConfigFromEnv() as T;
+  return buildConfigFromEnv() as unknown as T;
 }

--- a/src/lib/ssm-config.ts
+++ b/src/lib/ssm-config.ts
@@ -148,7 +148,8 @@ export interface AppConfig {
 }
 
 // Import D1 configuration functions
-import { isWorkersEnvironment, getD1Config } from "./ssm-config-d1.ts";
+import type { D1Database } from "@cloudflare/workers-types";
+import { isWorkersEnvironment, getD1Config } from "./ssm-config-d1";
 
 let cached: AppConfig | null = null;
 let cachedAt = 0;
@@ -449,8 +450,11 @@ export async function getConfig(): Promise<AppConfig> {
       // In a real Workers environment, we'd get the D1 binding from env
       // For now, we'll check if we can access it through global scope
       // This is a simplified check - in practice, the D1 binding would be passed in
-      const maybeEnv = typeof process !== "undefined" ? process.env : {};
-      const db = maybeEnv.AUTH_DB as unknown as D1Config["AUTH_DB"];
+      const maybeEnv = (typeof process !== "undefined" ? process.env : {}) as Record<
+        string,
+        unknown
+      >;
+      const db = maybeEnv.AUTH_DB as D1Database | undefined;
 
       if (db) {
         // Try to get config from D1

--- a/src/types/optional-deps.d.ts
+++ b/src/types/optional-deps.d.ts
@@ -1,0 +1,32 @@
+/** Ambient types for optional runtime dependencies not listed in package.json. */
+
+declare module "@duckdb/duckdb-wasm" {
+  export enum LogLevel {
+    WARNING = 3,
+  }
+
+  export class ConsoleLogger {
+    constructor(level: LogLevel);
+  }
+
+  export class AsyncDuckDB {
+    constructor(logger: ConsoleLogger);
+    instantiate(workerUrl: string): Promise<void>;
+  }
+}
+
+declare module "@aws-sdk/client-sns" {
+  export class SNSClient {
+    constructor(config?: { region?: string });
+    send(command: PublishCommand): Promise<unknown>;
+  }
+
+  export class PublishCommand {
+    constructor(input: {
+      TopicArn: string;
+      Subject?: string;
+      Message: string;
+      MessageAttributes?: Record<string, { DataType: string; StringValue: string }>;
+    });
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -40,6 +40,7 @@
   "exclude": [
     "node_modules",
     "sst.config.ts",
+    "sst.config.*.ts",
     "playwright.config.mts",
     "playwright.production.config.mts",
     "e2e",


### PR DESCRIPTION
## Summary
- Remove temporary `typescript.ignoreBuildErrors` from `next.config.ts`
- Fix remaining `unknown` JSON / missing-type errors across lib modules
- Add ambient stubs for optional deps (`duckdb-wasm`, SNS) and Meilisearch helpers used by search-index

## Test plan
- [x] `pnpm exec tsc --noEmit` — 0 errors
- [x] `pnpm build` — succeeds with TypeScript validation (not skipped)
- [x] `pnpm lint` — clean


Made with [Cursor](https://cursor.com)