### PR TITLE
fix: Kuma webhookAdditionalHeaders for Slack bridge

### DIFF
--- a/scripts/kuma-bootstrap.cjs
+++ b/scripts/kuma-bootstrap.cjs
@@ -172,10 +172,8 @@ async function main() {
         type: "webhook",
         webhookURL: BRIDGE_URL,
         webhookContentType: "json",
-        additionalHeadersEnabled: true,
-        additionalHeaders: JSON.stringify({
+        webhookAdditionalHeaders: JSON.stringify({
           Authorization: `Bearer ${BRIDGE_TOKEN}`,
-          "Content-Type": "application/json",
         }),
       },
       null

--- a/scripts/kuma-slack-bridge.cjs
+++ b/scripts/kuma-slack-bridge.cjs
@@ -58,10 +58,8 @@ async function main() {
       type: "webhook",
       webhookURL: BRIDGE_URL,
       webhookContentType: "json",
-      additionalHeadersEnabled: true,
-      additionalHeaders: JSON.stringify({
+      webhookAdditionalHeaders: JSON.stringify({
         Authorization: `Bearer ${TOKEN}`,
-        "Content-Type": "application/json",
       }),
     },
     null
@@ -97,23 +95,17 @@ async function main() {
     }
   }
 
-  const test = await emit(
-    socket,
-    "testNotification",
-    {
-      name: "Slack via cloudless bridge",
-      active: true,
-      isDefault: true,
-      type: "webhook",
-      webhookURL: BRIDGE_URL,
-      webhookContentType: "json",
-      additionalHeadersEnabled: true,
-      additionalHeaders: JSON.stringify({
-        Authorization: `Bearer ${TOKEN}`,
-        "Content-Type": "application/json",
-      }),
-    }
-  );
+  const test = await emit(socket, "testNotification", {
+    name: "Slack via cloudless bridge",
+    active: true,
+    isDefault: true,
+    type: "webhook",
+    webhookURL: BRIDGE_URL,
+    webhookContentType: "json",
+    webhookAdditionalHeaders: JSON.stringify({
+      Authorization: `Bearer ${TOKEN}`,
+    }),
+  });
   console.log("testNotification", test);
 
   socket.close();


### PR DESCRIPTION
## Summary
- Use `webhookAdditionalHeaders` in Kuma Slack bridge scripts (matches Uptime Kuma 2.x provider).

## Test plan
- [x] Live `testNotification` → Sent Successfully after field rename


Made with [Cursor](https://cursor.com)