### PR TITLE
Persist Kuma Slack bridge Deployment manifests

### DIFF
--- a/docs/current-source-of-truth-checklist.md
+++ b/docs/current-source-of-truth-checklist.md
@@ -27,8 +27,9 @@ Runbook: [`docs/operator-blockers-runbook.md`](operator-blockers-runbook.md).
 - [x] `DONE` Create Kuma status page and wire monitor alerts to ntfy (+ Slack bridge).
   Proof 2026-07-29: slug `cloudless`, 12 monitors, ntfy notification id=1; in-cluster
   `GET http://uptime-kuma…/api/status-page/cloudless` → 200; app ConfigMap
-  `KUMA_BASE_URL` + `KUMA_STATUS_PAGE_SLUG=cloudless`. Slack uses
-  `/api/webhooks/kuma` bot bridge (`scripts/kuma-slack-bridge.cjs`) — Incoming
+  `KUMA_BASE_URL` + `KUMA_STATUS_PAGE_SLUG=cloudless`. Slack uses live
+  `kuma-slack-bridge` Deployment (`infrastructure/uptime-kuma/k8s/kuma-slack-bridge.yaml`)
+  because Pi hostpath standalone still 404s `/api/webhooks/kuma`. Incoming
   Webhook URL not required.
 - [x] `PARTIAL` Restore ESP32 Notion page (API reconstruct; history UI expired).
   Proof 2026-07-29: `scripts/notion-restore-esp32.mjs` rebuilt 16 blocks on page

--- a/docs/operator-blockers-runbook.md
+++ b/docs/operator-blockers-runbook.md
@@ -38,9 +38,13 @@ Bootstrapped in-cluster via `scripts/kuma-bootstrap.cjs`:
 
 - Status page slug: **`cloudless`**, **12** HTTP monitors
 - Notification: ntfy → `https://ntfy.cloudless.gr` topic `cloudless-alerts`
-- Slack: Incoming Webhook was revoked (2026-05-25). Use the bot-token bridge instead:
-  - Route: `POST /api/webhooks/kuma` (Bearer `ADMIN_ALERT_SECRET`)
-  - Register: `scripts/kuma-slack-bridge.cjs` (after app image includes the route)
+- Slack: Incoming Webhook was revoked (2026-05-25). Live path is the
+  in-cluster bridge Deployment (Pi hostpath standalone still 404s
+  `/api/webhooks/kuma`):
+  - Manifest: `infrastructure/uptime-kuma/k8s/kuma-slack-bridge.yaml`
+  - Service: `http://kuma-slack-bridge.uptime-kuma.svc.cluster.local:8080/`
+  - Auth: Bearer `ADMIN_ALERT_SECRET`
+  - App route (future): `POST /api/webhooks/kuma` after standalone rebuild
 
 ```bash
 POD=$(kubectl -n uptime-kuma get pod -l app=uptime-kuma -o jsonpath='{.items[0].metadata.name}')

--- a/infrastructure/uptime-kuma/k8s/kuma-slack-bridge.js
+++ b/infrastructure/uptime-kuma/k8s/kuma-slack-bridge.js
@@ -1,0 +1,85 @@
+/**
+ * Temporary in-cluster Kuma → Slack bridge.
+ *
+ * Needed while the Pi hostpath standalone build does not yet include
+ * POST /api/webhooks/kuma (cloudless-app currently 404s that path).
+ * Once the standalone is rebuilt from a SHA that includes the route,
+ * point Kuma at http://cloudless-app.cloudless.svc.cluster.local/api/webhooks/kuma
+ * and scale this Deployment to 0.
+ *
+ * Env: ADMIN_ALERT_SECRET, SLACK_BOT_TOKEN, SLACK_CHANNEL (default #general)
+ */
+const http = require("http");
+
+const SECRET = process.env.ADMIN_ALERT_SECRET || "";
+const BOT = process.env.SLACK_BOT_TOKEN || "";
+const CHANNEL = process.env.SLACK_CHANNEL || "#general";
+
+function statusLabel(raw) {
+  if (raw === 0 || raw === "0") return "DOWN";
+  if (raw === 1 || raw === "1") return "UP";
+  if (raw === 2 || raw === "2") return "PENDING";
+  if (raw === 3 || raw === "3") return "MAINTENANCE";
+  return "UNKNOWN";
+}
+
+function auth(req) {
+  const h = req.headers.authorization || "";
+  if (h.toLowerCase().startsWith("bearer ")) {
+    return h.slice(7).trim() === SECRET;
+  }
+  const q = new URL(req.url, "http://x").searchParams.get("token");
+  return q === SECRET;
+}
+
+http
+  .createServer(async (req, res) => {
+    if (req.method !== "POST") {
+      res.writeHead(405);
+      return res.end("method");
+    }
+    if (!SECRET || !auth(req)) {
+      res.writeHead(401);
+      return res.end("unauthorized");
+    }
+    let body = "";
+    for await (const c of req) body += c;
+    let j = {};
+    try {
+      j = JSON.parse(body || "{}");
+    } catch {
+      res.writeHead(400);
+      return res.end("json");
+    }
+    const monitor = j.monitor || {};
+    const heartbeat = j.heartbeat || {};
+    const name = monitor.name || "monitor";
+    const status = statusLabel(heartbeat.status);
+    const title = "Kuma " + status + ": " + name;
+    const text = j.msg || name + " is " + status;
+    const r = await fetch("https://slack.com/api/chat.postMessage", {
+      method: "POST",
+      headers: {
+        Authorization: "Bearer " + BOT,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        channel: CHANNEL,
+        text: title,
+        blocks: [
+          {
+            type: "header",
+            text: { type: "plain_text", text: title.slice(0, 150), emoji: true },
+          },
+          {
+            type: "section",
+            text: { type: "mrkdwn", text: String(text).slice(0, 2000) },
+          },
+        ],
+      }),
+    });
+    const out = await r.json();
+    res.writeHead(out.ok ? 200 : 502, { "Content-Type": "application/json" });
+    res.end(JSON.stringify({ ok: !!out.ok, error: out.error || null }));
+  })
+  .listen(8080, () => console.log("kuma-slack-bridge on :8080"));

--- a/infrastructure/uptime-kuma/k8s/kuma-slack-bridge.yaml
+++ b/infrastructure/uptime-kuma/k8s/kuma-slack-bridge.yaml
@@ -1,0 +1,83 @@
+# Kuma → Slack bot-token bridge (Incoming Webhooks revoked 2026-05-25).
+#
+# Live path until Pi hostpath standalone includes POST /api/webhooks/kuma.
+# Apply:
+#   kubectl -n cloudless get secret cloudless-secrets \
+#     -o jsonpath='{.data.ADMIN_ALERT_SECRET}' | base64 -d > /tmp/aas
+#   kubectl -n cloudless get secret cloudless-secrets \
+#     -o jsonpath='{.data.SLACK_BOT_TOKEN}' | base64 -d > /tmp/sbt
+#   kubectl -n uptime-kuma create secret generic kuma-slack-bridge \
+#     --from-file=ADMIN_ALERT_SECRET=/tmp/aas \
+#     --from-file=SLACK_BOT_TOKEN=/tmp/sbt \
+#     --dry-run=client -o yaml | kubectl apply -f -
+#   kubectl -n uptime-kuma create configmap kuma-slack-bridge-src \
+#     --from-file=server.js=infrastructure/uptime-kuma/k8s/kuma-slack-bridge.js \
+#     --dry-run=client -o yaml | kubectl apply -f -
+#   kubectl apply -f infrastructure/uptime-kuma/k8s/kuma-slack-bridge.yaml
+#
+# Register notification (from uptime-kuma pod):
+#   KUMA_BRIDGE_URL=http://kuma-slack-bridge.uptime-kuma.svc.cluster.local:8080/ \
+#   KUMA_BRIDGE_TOKEN=<ADMIN_ALERT_SECRET> node scripts/kuma-slack-bridge.cjs
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: kuma-slack-bridge
+  namespace: uptime-kuma
+  labels:
+    app: kuma-slack-bridge
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: kuma-slack-bridge
+  template:
+    metadata:
+      labels:
+        app: kuma-slack-bridge
+    spec:
+      containers:
+        - name: bridge
+          image: node:22-alpine
+          imagePullPolicy: IfNotPresent
+          command: ["node", "/src/server.js"]
+          ports:
+            - { containerPort: 8080, name: http }
+          env:
+            - name: ADMIN_ALERT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: kuma-slack-bridge
+                  key: ADMIN_ALERT_SECRET
+            - name: SLACK_BOT_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: kuma-slack-bridge
+                  key: SLACK_BOT_TOKEN
+            - name: SLACK_CHANNEL
+              value: "#general"
+          resources:
+            requests: { cpu: 10m, memory: 32Mi }
+            limits: { cpu: 200m, memory: 128Mi }
+          volumeMounts:
+            - { name: src, mountPath: /src }
+      volumes:
+        - name: src
+          configMap:
+            name: kuma-slack-bridge-src
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: kuma-slack-bridge
+  namespace: uptime-kuma
+  labels:
+    app: kuma-slack-bridge
+spec:
+  type: ClusterIP
+  selector:
+    app: kuma-slack-bridge
+  ports:
+    - name: http
+      port: 8080
+      targetPort: 8080

--- a/scripts/kuma-slack-bridge.cjs
+++ b/scripts/kuma-slack-bridge.cjs
@@ -1,11 +1,13 @@
 #!/usr/bin/env node
 /**
  * Add Slack bridge webhook notification to an already-bootstrapped Kuma.
- * Posts to in-cluster cloudless-app /api/webhooks/kuma (bot → #general).
+ * Posts to in-cluster kuma-slack-bridge (bot → #general). Prefer
+ * KUMA_BRIDGE_URL override to cloudless-app /api/webhooks/kuma once the
+ * Pi hostpath standalone includes that route.
  *
  * Env:
  *   KUMA_USER / KUMA_PASS — admin creds
- *   KUMA_BRIDGE_URL — default in-cluster webhook URL
+ *   KUMA_BRIDGE_URL — default kuma-slack-bridge Service
  *   KUMA_BRIDGE_TOKEN — ADMIN_ALERT_SECRET (Bearer)
  */
 const { io } = require("socket.io-client");
@@ -13,9 +15,11 @@ const { io } = require("socket.io-client");
 const BASE = process.env.KUMA_URL || "http://127.0.0.1:3001";
 const USER = process.env.KUMA_USER || "tbaltzakis";
 const PASS = process.env.KUMA_PASS || "";
+// Default to the in-cluster bridge Deployment until the Pi hostpath
+// standalone includes POST /api/webhooks/kuma (currently 404).
 const BRIDGE_URL =
   process.env.KUMA_BRIDGE_URL ||
-  "http://cloudless-app.cloudless.svc.cluster.local/api/webhooks/kuma";
+  "http://kuma-slack-bridge.uptime-kuma.svc.cluster.local:8080/";
 const TOKEN = process.env.KUMA_BRIDGE_TOKEN || "";
 
 if (!PASS || !TOKEN) {


### PR DESCRIPTION
## Summary
- Commit live `kuma-slack-bridge` Deployment/Service + Node server under `infrastructure/uptime-kuma/k8s/`
- Default `KUMA_BRIDGE_URL` to the bridge Service (app route still 404 on hostpath)
- Update SoT checklist + operator runbook

## Test plan
- [x] ConfigMap sync + rollout; smoke POST → `{"ok":true}` HTTP 200


Made with [Cursor](https://cursor.com)