### PR TITLE
fix: Sentry webhook GET probe (avoid browser 405)

### DIFF
--- a/src/app/api/webhooks/sentry/route.ts
+++ b/src/app/api/webhooks/sentry/route.ts
@@ -74,6 +74,16 @@ function verifySignature(rawBody: string, signature: string, secret: string): bo
   return timingSafeEqual(a, b);
 }
 
+/** Browser / health probe — webhooks are POST-only. */
+export async function GET() {
+  return NextResponse.json({
+    ok: true,
+    method: "POST",
+    usage:
+      "Configure this URL as a Sentry Internal Integration webhook (issue events). Do not open it in a browser for delivery tests.",
+  });
+}
+
 export async function POST(req: NextRequest) {
   const rawBody = await req.text();
   const signature = req.headers.get("sentry-hook-signature") ?? "";


### PR DESCRIPTION
## Summary
- `GET /api/webhooks/sentry` returns JSON explaining the endpoint is POST-only (browser visits previously showed HTTP 405).

## Test plan
- [ ] After deploy: open `https://cloudless.gr/api/webhooks/sentry` → 200 JSON
- [ ] Sentry still POSTs issue events as before (signature verification unchanged)


Made with [Cursor](https://cursor.com)