### PR TITLE
fix: AppFlowy CMS body read/write and prod parity probing

### DIFF
--- a/docs/appflowy-espocrm-migration-checklist.md
+++ b/docs/appflowy-espocrm-migration-checklist.md
@@ -45,13 +45,30 @@ Response headers:
 node scripts/migrate-notion-to-appflowy.mjs --dry-run
 
 # Live import (requires APPFLOWY_* + NOTION_API_KEY)
+# Uses page_data on create (not /doc/:id — 404 on our AppFlowy build).
 node scripts/migrate-notion-to-appflowy.mjs
 
-# Parity probe against a running app
-CMS_PARITY_BASE_URL=https://cloudless.gr pnpm cms:parity
+# Backfill bodies for titled pages created without content
+node scripts/backfill-appflowy-cms-bodies.mjs --dry-run
+node scripts/backfill-appflowy-cms-bodies.mjs
+
+# Parity probe against a running app (local dual-run server)
+CMS_PARITY_BASE_URL=http://localhost:4000 CMS_PARITY_REQUIRE_APPFLOWY=1 pnpm cms:parity
+
+# Production — Cloudflare bot challenge blocks anonymous cloudless.gr probes.
+# Use the Fly HA proxy (bypasses the challenge) or an Access service token:
+CMS_PARITY_BASE_URL=https://cloudless-proxy.fly.dev CMS_PARITY_REQUIRE_APPFLOWY=1 pnpm cms:parity
+
+# Optional Access service token (when probing hosts behind Cloudflare Access):
+CF_ACCESS_CLIENT_ID=… CF_ACCESS_CLIENT_SECRET=… \
+  CMS_PARITY_BASE_URL=https://cloudless.gr CMS_PARITY_REQUIRE_APPFLOWY=1 pnpm cms:parity
 ```
 
 Promote AppFlowy as primary only when parity counts/slugs match and public pages render correctly.
+
+**Auth note:** `APPFLOWY_PASSWORD` must match k8s `appflowy-secrets` / `GOTRUE_ADMIN_PASSWORD` (not a stale longer `.env` value). Prefer LAN NodePort (`http://<omv-ip>:30810`) when `appflowy.cloudless.gr` returns a Cloudflare bot challenge.
+
+**Prod config:** Lambda/Pi must have `APPFLOWY_API_URL`, `APPFLOWY_EMAIL`, `APPFLOWY_PASSWORD`, and `APPFLOWY_JWT_SECRET` from SSM (`/cloudless/production/APPFLOWY_*`). Without them the dual-run path falls back to Notion/static.
 
 ## 4) CRM semantic standardization
 

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "devcontainer:stop": "bash scripts/devcontainer-stop.sh",
     "notion:test": "tsx --tsconfig scripts/tsconfig.json scripts/notion-test.ts",
     "cms:parity": "node scripts/cms-parity-check.mjs",
+    "cms:backfill-appflowy": "node scripts/backfill-appflowy-cms-bodies.mjs",
     "omv:selfhosted:health": "node scripts/omv-selfhosted-health.mjs",
     "cms:populate": "node scripts/populate-cms.mjs",
     "gh:secrets": "tsx --tsconfig scripts/tsconfig.json scripts/gh-secrets.ts",

--- a/scripts/backfill-appflowy-cms-bodies.mjs
+++ b/scripts/backfill-appflowy-cms-bodies.mjs
@@ -1,0 +1,306 @@
+#!/usr/bin/env node
+/**
+ * Backfill AppFlowy CMS page bodies from Notion properties.
+ *
+ * The initial migrate created titled pages but failed to upload content
+ * (`POST /doc/:id` → 404). This script appends markdown property blocks via
+ * `POST .../page-view/:id/append-block` for CMS-prefixed pages only.
+ *
+ * Usage:
+ *   node scripts/backfill-appflowy-cms-bodies.mjs [--dry-run] [--force]
+ *
+ * Env: NOTION_API_KEY, APPFLOWY_API_URL, APPFLOWY_EMAIL, APPFLOWY_PASSWORD
+ */
+
+import {
+  appendMarkdownBlocks,
+  extractTextFromEncodedCollab,
+} from "./lib/appflowy-page-content.mjs";
+
+const DRY_RUN = process.argv.includes("--dry-run");
+const FORCE = process.argv.includes("--force");
+
+const CMS_DB_MATCHERS = [
+  { match: /^(blog posts|blog)$/i, prefix: "[Blog]" },
+  { match: /^(internal docs|knowledge base|docs)$/i, prefix: "[Docs]" },
+  { match: /^services$/i, prefix: "[Service]" },
+  { match: /^faqs$/i, prefix: "[FAQ]" },
+  { match: /^testimonials$/i, prefix: "[Testimonial]" },
+  { match: /^case studies$/i, prefix: "[CaseStudy]" },
+];
+
+const BODY_MARKERS = [
+  "**Answer**:",
+  "**Slug**:",
+  "**Description**:",
+  "**Quote**:",
+  "**Company**:",
+  "**Summary**:",
+  "**Challenge**:",
+];
+
+async function notionPost(path, token, body) {
+  const res = await fetch(`https://api.notion.com/v1${path}`, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${token}`,
+      "Notion-Version": "2022-06-28",
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify(body),
+    signal: AbortSignal.timeout(15_000),
+  });
+  if (!res.ok) throw new Error(`Notion POST ${path} → ${res.status}: ${await res.text()}`);
+  return res.json();
+}
+
+async function getAppFlowyToken(baseUrl, email, password) {
+  const res = await fetch(`${baseUrl}/gotrue/token?grant_type=password`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ email, password }),
+    signal: AbortSignal.timeout(10_000),
+  });
+  if (!res.ok) throw new Error(`AppFlowy login failed: ${res.status}`);
+  const data = await res.json();
+  if (!data.access_token) throw new Error("AppFlowy login: no access_token");
+  return data.access_token;
+}
+
+async function appflowyGet(path, token, baseUrl) {
+  const res = await fetch(`${baseUrl}/api${path}`, {
+    headers: { Authorization: `Bearer ${token}`, Accept: "application/json" },
+    signal: AbortSignal.timeout(30_000),
+  });
+  if (!res.ok) throw new Error(`AppFlowy GET ${path} → ${res.status}`);
+  return res.json();
+}
+
+function richTextToString(rt) {
+  if (!Array.isArray(rt)) return "";
+  return rt.map((t) => t.plain_text ?? "").join("");
+}
+
+function propertyToString(key, prop) {
+  if (!prop) return "";
+  switch (prop.type) {
+    case "title":
+      return `**${key}**: ${richTextToString(prop.title)}`;
+    case "rich_text":
+      return `**${key}**: ${richTextToString(prop.rich_text)}`;
+    case "number":
+      return `**${key}**: ${prop.number ?? ""}`;
+    case "select":
+      return `**${key}**: ${prop.select?.name ?? ""}`;
+    case "multi_select":
+      return `**${key}**: ${(prop.multi_select ?? []).map((s) => s.name).join(", ")}`;
+    case "date":
+      return `**${key}**: ${prop.date?.start ?? ""}${prop.date?.end ? ` → ${prop.date.end}` : ""}`;
+    case "checkbox":
+      return `**${key}**: ${prop.checkbox ? "✅" : "☐"}`;
+    case "url":
+      return `**${key}**: ${prop.url ?? ""}`;
+    case "email":
+      return `**${key}**: ${prop.email ?? ""}`;
+    case "phone_number":
+      return `**${key}**: ${prop.phone_number ?? ""}`;
+    case "status":
+      return `**${key}**: ${prop.status?.name ?? ""}`;
+    case "people":
+      return `**${key}**: ${(prop.people ?? []).map((p) => p.name ?? p.id).join(", ")}`;
+    default:
+      return "";
+  }
+}
+
+function pageToMarkdown(page) {
+  const lines = [];
+  for (const [key, prop] of Object.entries(page.properties ?? {})) {
+    const line = propertyToString(key, prop);
+    if (line) lines.push(line);
+  }
+  lines.push(`\n_Notion page ID: ${page.id}_`);
+  lines.push(`_Created: ${page.created_time}_`);
+  if (page.url) lines.push(`_Source: ${page.url}_`);
+  return lines.join("\n\n");
+}
+
+function extractTitle(page) {
+  for (const prop of Object.values(page.properties ?? {})) {
+    if (prop.type === "title") return richTextToString(prop.title) || "Untitled";
+  }
+  return "Untitled";
+}
+
+function titledForAppFlowy(dbTitle, pageTitle) {
+  const rule = CMS_DB_MATCHERS.find((r) => r.match.test(dbTitle.trim()));
+  if (!rule) return null;
+  if (pageTitle.startsWith(rule.prefix)) return pageTitle;
+  return `${rule.prefix} ${pageTitle}`;
+}
+
+async function queryDatabaseAll(dbId, notionToken) {
+  const rows = [];
+  let cursor;
+  do {
+    const body = { page_size: 100 };
+    if (cursor) body.start_cursor = cursor;
+    const data = await notionPost(`/databases/${dbId}/query`, notionToken, body);
+    rows.push(...(data.results ?? []));
+    cursor = data.has_more ? data.next_cursor : undefined;
+  } while (cursor && rows.length < 1000);
+  return rows;
+}
+
+function flattenFolder(node, out = []) {
+  if (!node) return out;
+  if (Array.isArray(node)) {
+    for (const child of node) flattenFolder(child, out);
+    return out;
+  }
+  if (typeof node !== "object") return out;
+  const view = node.view ?? node;
+  if (view.view_id && view.name) {
+    out.push({ view_id: view.view_id, name: view.name });
+  }
+  if (Array.isArray(view.children)) flattenFolder(view.children, out);
+  if (node !== view && Array.isArray(node.children)) flattenFolder(node.children, out);
+  return out;
+}
+
+function hasCmsBody(text) {
+  const lower = text.toLowerCase();
+  return BODY_MARKERS.some((m) => lower.includes(m.toLowerCase()));
+}
+
+async function pageHasBody(baseUrl, token, workspaceId, viewId) {
+  const res = await appflowyGet(
+    `/workspace/${workspaceId}/page-view/${viewId}`,
+    token,
+    baseUrl
+  );
+  const encoded = res?.data?.data?.encoded_collab;
+  return hasCmsBody(extractTextFromEncodedCollab(encoded));
+}
+
+async function main() {
+  const notionToken = process.env.NOTION_API_KEY;
+  const baseUrl = (process.env.APPFLOWY_API_URL ?? "").replace(/\/$/, "");
+  const email = process.env.APPFLOWY_EMAIL ?? "";
+  const password = process.env.APPFLOWY_PASSWORD ?? "";
+
+  if (!notionToken) {
+    console.error("NOTION_API_KEY not set");
+    process.exit(1);
+  }
+  if (!baseUrl || !email || !password) {
+    console.error("APPFLOWY_API_URL, APPFLOWY_EMAIL, and APPFLOWY_PASSWORD required");
+    process.exit(1);
+  }
+
+  console.log(`Mode: ${DRY_RUN ? "DRY RUN" : "LIVE"}${FORCE ? " (force)" : ""}`);
+
+  const token = await getAppFlowyToken(baseUrl, email, password);
+  const wsData = await appflowyGet("/workspace", token, baseUrl);
+  const workspaceId = wsData.data?.[0]?.workspace_id;
+  if (!workspaceId) {
+    console.error("No AppFlowy workspace found");
+    process.exit(1);
+  }
+
+  const folder = await appflowyGet(`/workspace/${workspaceId}/folder?depth=10`, token, baseUrl);
+  const views = flattenFolder(folder.data);
+  const byName = new Map();
+  for (const v of views) {
+    if (!byName.has(v.name)) byName.set(v.name, v.view_id);
+  }
+  console.log(`AppFlowy views indexed: ${byName.size}`);
+
+  let searchCursor;
+  const databases = [];
+  do {
+    const body = { filter: { value: "database", property: "object" }, page_size: 100 };
+    if (searchCursor) body.start_cursor = searchCursor;
+    const data = await notionPost("/search", notionToken, body);
+    databases.push(...(data.results ?? []));
+    searchCursor = data.has_more ? data.next_cursor : undefined;
+  } while (searchCursor);
+
+  const cmsDbs = databases.filter((db) =>
+    CMS_DB_MATCHERS.some((r) => r.match.test(richTextToString(db.title) || ""))
+  );
+  console.log(`CMS Notion databases: ${cmsDbs.length}`);
+
+  const summary = [];
+
+  for (const db of cmsDbs) {
+    const dbTitle = richTextToString(db.title) || db.id;
+    console.log(`\n── ${dbTitle}`);
+    const rows = await queryDatabaseAll(db.id, notionToken);
+    let filled = 0;
+    let skipped = 0;
+    let missing = 0;
+    let failed = 0;
+
+    for (const page of rows) {
+      const title = titledForAppFlowy(dbTitle, extractTitle(page));
+      if (!title) continue;
+      const viewId = byName.get(title);
+      if (!viewId) {
+        missing++;
+        console.warn(`  missing AppFlowy page: ${title}`);
+        continue;
+      }
+
+      const markdown = pageToMarkdown(page);
+      if (!FORCE) {
+        try {
+          if (await pageHasBody(baseUrl, token, workspaceId, viewId)) {
+            skipped++;
+            continue;
+          }
+        } catch (err) {
+          console.warn(`  body-check failed for ${title}: ${err.message}`);
+        }
+      }
+
+      if (DRY_RUN) {
+        console.log(`  [dry-run] would append ${markdown.split("\n").length} lines → ${title}`);
+        filled++;
+        continue;
+      }
+
+      try {
+        await appendMarkdownBlocks({
+          baseUrl,
+          token,
+          workspaceId,
+          viewId,
+          markdown,
+        });
+        filled++;
+        await new Promise((r) => setTimeout(r, 120));
+      } catch (err) {
+        failed++;
+        console.error(`  append failed for ${title}: ${err.message}`);
+      }
+    }
+
+    summary.push({ db: dbTitle, filled, skipped, missing, failed, total: rows.length });
+    console.log(
+      `  filled=${filled} skipped=${skipped} missing=${missing} failed=${failed} total=${rows.length}`
+    );
+  }
+
+  console.log("\n── Backfill summary ──");
+  for (const s of summary) {
+    console.log(
+      `  ${s.db}: filled ${s.filled}/${s.total} (skipped ${s.skipped}, missing ${s.missing}, failed ${s.failed})`
+    );
+  }
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/scripts/cms-parity-check.mjs
+++ b/scripts/cms-parity-check.mjs
@@ -5,9 +5,17 @@
  *
  * Usage:
  *   CMS_PARITY_BASE_URL=http://localhost:4000 node scripts/cms-parity-check.mjs
+ *
+ * Cloudflare Access / bot bypass (optional):
+ *   CF_ACCESS_CLIENT_ID + CF_ACCESS_CLIENT_SECRET
+ *   or CMS_PARITY_HEADERS_JSON='{"Cookie":"...","cf-access-token":"..."}'
+ *
+ * Require AppFlowy as the active source on every endpoint:
+ *   CMS_PARITY_REQUIRE_APPFLOWY=1
  */
 
 const baseUrl = process.env.CMS_PARITY_BASE_URL || "http://localhost:4000";
+const requireAppFlowy = process.env.CMS_PARITY_REQUIRE_APPFLOWY === "1";
 
 const ENDPOINTS = [
   { key: "blogPosts", path: "/api/blog/posts", listKey: "posts", sourceHeader: "x-blog-source" },
@@ -28,8 +36,36 @@ const ENDPOINTS = [
   },
 ];
 
+function buildHeaders() {
+  const headers = { Accept: "application/json" };
+
+  if (process.env.CMS_PARITY_HEADERS_JSON) {
+    try {
+      Object.assign(headers, JSON.parse(process.env.CMS_PARITY_HEADERS_JSON));
+    } catch (error) {
+      throw new Error(
+        `CMS_PARITY_HEADERS_JSON is not valid JSON: ${
+          error instanceof Error ? error.message : String(error)
+        }`
+      );
+    }
+  }
+
+  const cfId = process.env.CF_ACCESS_CLIENT_ID;
+  const cfSecret = process.env.CF_ACCESS_CLIENT_SECRET;
+  if (cfId && cfSecret) {
+    headers["CF-Access-Client-Id"] = cfId;
+    headers["CF-Access-Client-Secret"] = cfSecret;
+  }
+
+  return headers;
+}
+
 async function getJson(path) {
-  const res = await fetch(`${baseUrl}${path}`, { signal: AbortSignal.timeout(15_000) });
+  const res = await fetch(`${baseUrl}${path}`, {
+    headers: buildHeaders(),
+    signal: AbortSignal.timeout(15_000),
+  });
   const body = await res.json().catch(() => ({}));
   return { ok: res.ok, status: res.status, body, headers: res.headers };
 }
@@ -46,6 +82,7 @@ async function run() {
   const report = {
     generatedAt: new Date().toISOString(),
     baseUrl,
+    requireAppFlowy,
     checks: {},
     ok: true,
   };
@@ -58,14 +95,22 @@ async function run() {
         result.body?.source ||
         (result.ok ? "unknown" : "error");
       const count = countItems(result.body, ep.listKey);
-      report.checks[ep.key] = {
+      const check = {
         path: ep.path,
         ok: result.ok,
         status: result.status,
         source,
         count,
       };
-      if (!result.ok) report.ok = false;
+      if (!result.ok) {
+        check.ok = false;
+        report.ok = false;
+      } else if (requireAppFlowy && source !== "appflowy") {
+        check.ok = false;
+        check.error = `expected source appflowy, got ${source}`;
+        report.ok = false;
+      }
+      report.checks[ep.key] = check;
     } catch (error) {
       report.ok = false;
       report.checks[ep.key] = {

--- a/scripts/lib/appflowy-page-content.mjs
+++ b/scripts/lib/appflowy-page-content.mjs
@@ -1,0 +1,314 @@
+/**
+ * Shared AppFlowy page content helpers.
+ *
+ * Content must be written via `page_data` on create or
+ * `POST .../page-view/:id/append-block` — `/doc/:id` is 404 on our build.
+ *
+ * Markdown → blocks ported from scripts/appflowy-upload-md.mjs
+ * (weironz/appflowy_mcp markdown.py lineage).
+ */
+
+import { randomUUID } from "node:crypto";
+
+const INLINE_RE =
+  /(`[^`]+`)|(\[[^\]]+\]\([^)]+\))|(\*\*[^*]+\*\*)|(~~[^~]+~~)|(\*[^*]+\*)/g;
+const ORDERED_RE = /^\d+\.\s+(.+)$/;
+const IMAGE_RE = /^!\[([^\]]*)\]\(([^)]+)\)$/;
+
+export function parseRichText(text) {
+  if (text === "") return [{ insert: "" }];
+  const deltas = [];
+  let last = 0;
+  for (const match of text.matchAll(INLINE_RE)) {
+    const [full, code, link, bold, strike, italic] = match;
+    const start = match.index ?? 0;
+    const end = start + full.length;
+    if (start > last) deltas.push({ insert: text.slice(last, start) });
+
+    let content = full;
+    const attributes = {};
+    if (code) {
+      content = code.slice(1, -1);
+      attributes.code = true;
+    } else if (link) {
+      const m = /\[([^\]]+)\]\(([^)]+)\)/.exec(link);
+      if (m) {
+        content = m[1];
+        attributes.href = m[2];
+      }
+    } else if (bold) {
+      content = bold.slice(2, -2);
+      attributes.bold = true;
+    } else if (strike) {
+      content = strike.slice(2, -2);
+      attributes.strikethrough = true;
+    } else if (italic) {
+      content = italic.slice(1, -1);
+      attributes.italic = true;
+    }
+
+    const delta = { insert: content };
+    if (Object.keys(attributes).length > 0) delta.attributes = attributes;
+    deltas.push(delta);
+    last = end;
+  }
+  if (last < text.length) deltas.push({ insert: text.slice(last) });
+  return deltas;
+}
+
+function headingBlock(level, text) {
+  return { type: "heading", data: { level, delta: parseRichText(text) } };
+}
+
+function paragraphBlock(text) {
+  return { type: "paragraph", data: { delta: parseRichText(text) } };
+}
+
+export function parseMarkdownToBlocks(content) {
+  const blocks = [];
+  let codeLines = [];
+  let codeLang = "";
+  let inCode = false;
+
+  for (const line of content.split(/\r?\n/)) {
+    const stripped = line.trim();
+
+    if (stripped.startsWith("```")) {
+      if (inCode) {
+        blocks.push({
+          type: "code",
+          data: {
+            language: codeLang || "text",
+            delta: [{ insert: codeLines.join("\n") }],
+          },
+        });
+        codeLines = [];
+        codeLang = "";
+        inCode = false;
+      } else {
+        codeLang = stripped.slice(3).trim();
+        inCode = true;
+      }
+      continue;
+    }
+
+    if (inCode) {
+      codeLines.push(line);
+      continue;
+    }
+
+    if (stripped === "") continue;
+
+    if (stripped === "---" || stripped === "***") {
+      blocks.push({ type: "divider", data: {} });
+      continue;
+    }
+
+    const img = IMAGE_RE.exec(stripped);
+    if (img) {
+      blocks.push({ type: "image", data: { url: img[2], caption: img[1] } });
+      continue;
+    }
+
+    if (stripped.startsWith("### ")) {
+      blocks.push(headingBlock(3, stripped.slice(4)));
+      continue;
+    }
+    if (stripped.startsWith("## ")) {
+      blocks.push(headingBlock(2, stripped.slice(3)));
+      continue;
+    }
+    if (stripped.startsWith("# ")) {
+      blocks.push(headingBlock(1, stripped.slice(2)));
+      continue;
+    }
+
+    if (stripped.startsWith("- [ ] ") || stripped.startsWith("- [x] ")) {
+      blocks.push({
+        type: "todo_list",
+        data: {
+          checked: stripped.startsWith("- [x] "),
+          delta: parseRichText(stripped.slice(6)),
+        },
+      });
+      continue;
+    }
+
+    if (stripped.startsWith("- ") || stripped.startsWith("* ")) {
+      blocks.push({
+        type: "bulleted_list",
+        data: { delta: parseRichText(stripped.slice(2)) },
+      });
+      continue;
+    }
+
+    const ord = ORDERED_RE.exec(stripped);
+    if (ord) {
+      blocks.push({
+        type: "numbered_list",
+        data: { delta: parseRichText(ord[1]) },
+      });
+      continue;
+    }
+
+    if (stripped.startsWith("> ")) {
+      blocks.push({ type: "quote", data: { delta: parseRichText(stripped.slice(2)) } });
+      continue;
+    }
+
+    blocks.push(paragraphBlock(line));
+  }
+
+  if (inCode && codeLines.length > 0) {
+    blocks.push({
+      type: "code",
+      data: {
+        language: codeLang || "text",
+        delta: [{ insert: codeLines.join("\n") }],
+      },
+    });
+  }
+
+  return blocks;
+}
+
+export async function createPageWithContent({
+  baseUrl,
+  token,
+  workspaceId,
+  parentViewId,
+  title,
+  markdown,
+  viewId = randomUUID(),
+}) {
+  const blocks = parseMarkdownToBlocks(markdown);
+  const payload = {
+    parent_view_id: parentViewId,
+    layout: 0,
+    name: title,
+    page_data: {
+      type: "page",
+      children: blocks,
+    },
+    view_id: viewId,
+    collab_id: viewId,
+  };
+
+  const res = await fetch(`${baseUrl}/api/workspace/${workspaceId}/page-view`, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${token}`,
+      "Content-Type": "application/json",
+      Accept: "application/json",
+    },
+    body: JSON.stringify(payload),
+    signal: AbortSignal.timeout(20_000),
+  });
+  if (!res.ok) {
+    throw new Error(`create page failed: HTTP ${res.status} ${await res.text()}`);
+  }
+  const body = await res.json();
+  if (body?.code != null && body.code !== 0) {
+    throw new Error(`create page error: ${body.message || "unknown"} (code ${body.code})`);
+  }
+  return { viewId: body?.data?.view_id || viewId, body };
+}
+
+export async function appendMarkdownBlocks({
+  baseUrl,
+  token,
+  workspaceId,
+  viewId,
+  markdown,
+}) {
+  const blocks = parseMarkdownToBlocks(markdown);
+  if (blocks.length === 0) return { skipped: true, reason: "empty-markdown" };
+
+  const res = await fetch(
+    `${baseUrl}/api/workspace/${workspaceId}/page-view/${viewId}/append-block`,
+    {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${token}`,
+        "Content-Type": "application/json",
+        Accept: "application/json",
+      },
+      body: JSON.stringify({ blocks }),
+      signal: AbortSignal.timeout(20_000),
+    }
+  );
+  if (!res.ok) {
+    throw new Error(`append-block failed: HTTP ${res.status} ${await res.text()}`);
+  }
+  const body = await res.json();
+  if (body?.code != null && body.code !== 0) {
+    throw new Error(`append-block error: ${body.message || "unknown"} (code ${body.code})`);
+  }
+  return { skipped: false, blockCount: blocks.length, body };
+}
+
+/** Best-effort plain text from page-view encoded_collab (mirrors src/lib/appflowy.ts). */
+const CMS_FIELD_KEYS = [
+  "StripePriceId",
+  "Description",
+  "CoverImage",
+  "Challenge",
+  "Solution",
+  "Results",
+  "Category",
+  "Features",
+  "Industry",
+  "Summary",
+  "Company",
+  "Service",
+  "Featured",
+  "Published",
+  "Locale",
+  "Answer",
+  "Client",
+  "Rating",
+  "Quote",
+  "Price",
+  "Order",
+  "Slug",
+  "Icon",
+  "Name",
+  "Role",
+  "Tags",
+  "Date",
+  "CTA",
+];
+
+export function extractTextFromEncodedCollab(encoded) {
+  if (!encoded) return "";
+  const blob = Array.isArray(encoded)
+    ? Buffer.from(encoded)
+    : Buffer.from(String(encoded), "utf8");
+  const latin = blob.toString("latin1");
+  const fields = [];
+  for (const key of CMS_FIELD_KEYS) {
+    const keyRe = new RegExp(`(?:^|[^A-Za-z])${key}(?![A-Za-z])`, "g");
+    let match;
+    while ((match = keyRe.exec(latin)) !== null) {
+      const window = latin.slice(match.index + match[0].length, match.index + match[0].length + 900);
+      const valueMatch = /:\s*([^']{1,800})'/.exec(window);
+      if (valueMatch?.[1]) {
+        const value = Buffer.from(valueMatch[1], "latin1")
+          .toString("utf8")
+          .replace(/[\u0000-\u001f\u007f-\u009f]+/g, "")
+          .replace(/\s+/g, " ")
+          .trim();
+        if (value) {
+          fields.push(`**${key}**: ${value}`);
+          break;
+        }
+      }
+    }
+  }
+  if (fields.length > 0) return Array.from(new Set(fields)).join("\n");
+  const matches = latin.match(/[\x20-\x7e]{4,}/g) ?? [];
+  return matches
+    .map((s) => s.replace(/'+$/g, "").trim())
+    .filter((s) => /^\*\*[A-Za-z][^*]+\*\*:/.test(s) || (s.includes(" ") && s.length >= 24))
+    .join("\n");
+}

--- a/scripts/migrate-notion-to-appflowy.mjs
+++ b/scripts/migrate-notion-to-appflowy.mjs
@@ -19,10 +19,14 @@
  *   4. For each row, creates a child Document page in AppFlowy with the row title + all properties as markdown.
  *   5. Reports counts per database on completion.
  *
- * AppFlowy page content is uploaded as markdown via the AppFlowy Cloud REST API
- * POST /api/workspace/:workspaceId/page-view (layout=0 = Document) — same path
- * used by scripts/appflowy-upload-md.mjs.
+ * AppFlowy page content is written via page_data on
+ * POST /api/workspace/:workspaceId/page-view (same path as
+ * scripts/appflowy-upload-md.mjs). Empty pages from older runs can be filled
+ * with scripts/backfill-appflowy-cms-bodies.mjs.
  */
+
+import { randomUUID } from "node:crypto";
+import { createPageWithContent } from "./lib/appflowy-page-content.mjs";
 
 const DRY_RUN = process.argv.includes("--dry-run");
 
@@ -246,30 +250,15 @@ async function main() {
 
       if (!DRY_RUN) {
         try {
-          const pageRes = await appflowyPost(
-            `/workspace/${workspaceId}/page-view`,
-            appflowyToken,
-            appflowyBase,
-            { name: title, parent_view_id: dbViewId, layout: 0 }
-          );
-          const pageViewId = pageRes.data?.view_id;
-          if (pageViewId && markdown.length > 0) {
-            // Upload markdown content to the page. Note: some AppFlowy Cloud
-            // builds return 404 for /doc/:id — page title still migrates and
-            // CMS adapters can serve title-based listings.
-            try {
-              await appflowyPost(
-                `/workspace/${workspaceId}/doc/${pageViewId}`,
-                appflowyToken,
-                appflowyBase,
-                { data: markdown }
-              );
-            } catch (err) {
-              console.warn(
-                `  Content upload skipped for "${title}": ${err.message}`
-              );
-            }
-          }
+          await createPageWithContent({
+            baseUrl: appflowyBase,
+            token: appflowyToken,
+            workspaceId,
+            parentViewId: dbViewId,
+            title,
+            markdown,
+            viewId: randomUUID(),
+          });
           migrated++;
         } catch (err) {
           console.error(`  Failed to create page "${title}": ${err.message}`);

--- a/scripts/omv-selfhosted-health.mjs
+++ b/scripts/omv-selfhosted-health.mjs
@@ -1,19 +1,53 @@
 #!/usr/bin/env node
 
+/**
+ * Health probe for self-hosted OMV apps.
+ *
+ * Public Cloudflare hostnames may return bot-challenge 403s from this network.
+ * Set APPFLOWY_API_URL / ESPOCRM_BASE_URL to LAN/NodePort URLs to bypass, or
+ * CF_ACCESS_CLIENT_ID + CF_ACCESS_CLIENT_SECRET for Access service tokens.
+ */
+
+const appflowyBase = (
+  process.env.APPFLOWY_LAN_URL ||
+  process.env.APPFLOWY_API_URL ||
+  "http://192.168.1.128:30810"
+).replace(/\/$/, "");
+const espocrmBase = (
+  process.env.ESPOCRM_LAN_URL ||
+  process.env.ESPOCRM_BASE_URL ||
+  "http://192.168.1.128:30700"
+).replace(/\/$/, "");
+
 const targets = [
-  { name: "AppFlowy API health", url: "https://appflowy.cloudless.gr/api/health" },
-  { name: "AppFlowy GoTrue health", url: "https://appflowy.cloudless.gr/gotrue/health" },
-  { name: "EspoCRM web", url: "https://espocrm.cloudless.gr/" },
+  { name: "AppFlowy API health", url: `${appflowyBase}/api/health` },
+  { name: "AppFlowy GoTrue health", url: `${appflowyBase}/gotrue/health` },
+  { name: "EspoCRM web", url: `${espocrmBase}/` },
 ];
+
+function buildHeaders() {
+  const headers = {};
+  const cfId = process.env.CF_ACCESS_CLIENT_ID;
+  const cfSecret = process.env.CF_ACCESS_CLIENT_SECRET;
+  if (cfId && cfSecret) {
+    headers["CF-Access-Client-Id"] = cfId;
+    headers["CF-Access-Client-Secret"] = cfSecret;
+  }
+  return headers;
+}
 
 async function probe(target) {
   const startedAt = Date.now();
   try {
-    const res = await fetch(target.url, { signal: AbortSignal.timeout(8000) });
+    const res = await fetch(target.url, {
+      headers: buildHeaders(),
+      signal: AbortSignal.timeout(8000),
+      redirect: "manual",
+    });
     return {
       name: target.name,
       url: target.url,
-      ok: res.ok,
+      ok: res.ok || res.status === 302 || res.status === 301,
       status: res.status,
       latencyMs: Date.now() - startedAt,
     };

--- a/src/app/api/docs/[slug]/route.ts
+++ b/src/app/api/docs/[slug]/route.ts
@@ -23,7 +23,7 @@ export async function GET(
   const notionConfigured = await isConfiguredAsync("NOTION_API_KEY", "NOTION_DOCS_DB_ID");
 
   if (!appFlowyConfigured && !notionConfigured) {
-    return NextResponse.json({ error: "Docs not configured" }, { status: 404 });
+    return NextResponse.json({ error: "Docs not configured" }, { status: 503 });
   }
 
   const { slug } = await params;

--- a/src/app/api/docs/route.ts
+++ b/src/app/api/docs/route.ts
@@ -48,7 +48,7 @@ export async function GET() {
   } catch (err) {
     console.error("[Docs API] Failed to fetch docs:", err);
     return NextResponse.json(
-      { docs: [], source: "static", fallbackReason: "notion-error" },
+      { docs: [], source: "static", fallbackReason: "cms-error" },
       { headers: { "x-cms-source": "static" } }
     );
   }

--- a/src/lib/appflowy.ts
+++ b/src/lib/appflowy.ts
@@ -49,6 +49,10 @@ interface AppFlowyConfig {
 }
 
 let cachedUserToken: { token: string; expiresAtMs: number } | null = null;
+const VIEWS_TTL_MS = 60_000;
+const WORKSPACES_TTL_MS = 60_000;
+let cachedWorkspaces: { value: AppFlowyWorkspace[]; expiresAtMs: number } | null = null;
+const cachedViewsByWorkspace = new Map<string, { value: AppFlowyView[]; expiresAtMs: number }>();
 
 async function getAppFlowyConfig(): Promise<AppFlowyConfig> {
   const cfg = await getConfig();
@@ -187,10 +191,18 @@ export interface AppFlowyUserSummary {
 }
 
 export async function listAllWorkspaces(): Promise<AppFlowyWorkspace[]> {
+  const now = Date.now();
+  if (cachedWorkspaces && cachedWorkspaces.expiresAtMs > now) {
+    return cachedWorkspaces.value;
+  }
+
   try {
     // User API (works on self-hosted cloudless build)
     const r = await callThrowing<{ data: AppFlowyWorkspace[] }>("/workspace");
-    if (r.data?.length) return r.data;
+    if (r.data?.length) {
+      cachedWorkspaces = { value: r.data, expiresAtMs: now + WORKSPACES_TTL_MS };
+      return r.data;
+    }
   } catch (e) {
     if (e instanceof AppFlowyNotConfiguredError) return [];
     // Fall through to admin surface when user path fails.
@@ -198,7 +210,9 @@ export async function listAllWorkspaces(): Promise<AppFlowyWorkspace[]> {
 
   try {
     const r = await callThrowing<{ data: AppFlowyWorkspace[] }>("/admin/workspace");
-    return r.data ?? [];
+    const value = r.data ?? [];
+    cachedWorkspaces = { value, expiresAtMs: now + WORKSPACES_TTL_MS };
+    return value;
   } catch (e) {
     if (e instanceof AppFlowyNotConfiguredError) return [];
     throw e;
@@ -286,14 +300,28 @@ function flattenFolderViews(node: unknown, out: AppFlowyView[] = []): AppFlowyVi
 }
 
 export async function listAllViewsDeep(workspaceId: string): Promise<AppFlowyView[]> {
+  const now = Date.now();
+  const cached = cachedViewsByWorkspace.get(workspaceId);
+  if (cached && cached.expiresAtMs > now) {
+    return cached.value;
+  }
+
   try {
-    const r = await callThrowing<{ data: unknown }>(`/workspace/${workspaceId}/folder?depth=10`);
+    const r = await callThrowing<{ data: unknown }>(
+      `/workspace/${workspaceId}/folder?depth=10`,
+      { timeoutMs: 30_000 }
+    );
     const views = flattenFolderViews(r.data);
     if (views.length > 0) {
       // Deduplicate by view_id (folder walk can revisit parents).
       const byId = new Map<string, AppFlowyView>();
       for (const v of views) byId.set(v.view_id, v);
-      return Array.from(byId.values());
+      const value = Array.from(byId.values());
+      cachedViewsByWorkspace.set(workspaceId, {
+        value,
+        expiresAtMs: now + VIEWS_TTL_MS,
+      });
+      return value;
     }
   } catch (e) {
     if (e instanceof AppFlowyNotConfiguredError) return [];
@@ -301,13 +329,52 @@ export async function listAllViewsDeep(workspaceId: string): Promise<AppFlowyVie
   }
 
   try {
-    const r = await callThrowing<{ data: AppFlowyView[] }>(`/admin/workspace/${workspaceId}/views`);
-    return r.data ?? [];
+    const r = await callThrowing<{ data: AppFlowyView[] }>(
+      `/admin/workspace/${workspaceId}/views`
+    );
+    const value = r.data ?? [];
+    cachedViewsByWorkspace.set(workspaceId, {
+      value,
+      expiresAtMs: now + VIEWS_TTL_MS,
+    });
+    return value;
   } catch (e) {
     if (e instanceof AppFlowyNotConfiguredError) return [];
     throw e;
   }
 }
+
+/** Keys adapters parse from CMS page bodies (longest-first to avoid Price⊂StripePriceId). */
+const CMS_FIELD_KEYS = [
+  "StripePriceId",
+  "Description",
+  "CoverImage",
+  "Challenge",
+  "Solution",
+  "Results",
+  "Category",
+  "Features",
+  "Industry",
+  "Summary",
+  "Company",
+  "Service",
+  "Featured",
+  "Published",
+  "Locale",
+  "Answer",
+  "Client",
+  "Rating",
+  "Quote",
+  "Price",
+  "Order",
+  "Slug",
+  "Icon",
+  "Name",
+  "Role",
+  "Tags",
+  "Date",
+  "CTA",
+] as const;
 
 function extractStringsFromCollab(encoded: unknown): string {
   if (!encoded) return "";
@@ -326,7 +393,35 @@ function extractStringsFromCollab(encoded: unknown): string {
     return "";
   }
 
-  const matches = blob.toString("latin1").match(/[\x20-\x7e]{4,}/g) ?? [];
+  const latin = blob.toString("latin1");
+  // Markdown `**Key**: value` is stored as rich-text bold(Key) + ": value".
+  // Reconstruct from CRDT bytes where the key string sits near `: value'`.
+  const fields: string[] = [];
+  for (const key of CMS_FIELD_KEYS) {
+    const keyRe = new RegExp(`(?:^|[^A-Za-z])${key}(?![A-Za-z])`, "g");
+    let match: RegExpExecArray | null;
+    while ((match = keyRe.exec(latin)) !== null) {
+      const window = latin.slice(match.index + match[0].length, match.index + match[0].length + 900);
+      const valueMatch = /:\s*([^']{1,800})'/.exec(window);
+      if (valueMatch?.[1]) {
+        const value = Buffer.from(valueMatch[1], "latin1")
+          .toString("utf8")
+          .replace(/[\u0000-\u001f\u007f-\u009f\ufffd]+/g, "")
+          .replace(/[^\w\s.,;:!?'"€$%()/%+\-–—/]+$/u, "")
+          .replace(/\s+/g, " ")
+          .trim();
+        if (value) {
+          fields.push(`**${key}**: ${value}`);
+          break;
+        }
+      }
+    }
+  }
+  if (fields.length > 0) {
+    return Array.from(new Set(fields)).join("\n");
+  }
+
+  const matches = latin.match(/[\x20-\x7e]{4,}/g) ?? [];
   const skip = new Set([
     "data",
     "document",
@@ -342,17 +437,21 @@ function extractStringsFromCollab(encoded: unknown): string {
     "external_type",
     "paragraph",
     "text",
+    "bold",
+    "true",
+    "null",
   ]);
-  const meaningful = matches.filter((s) => {
-    if (skip.has(s)) return false;
-    if (s.startsWith("$") || s.startsWith("w$")) return false;
-    if (/^[A-Za-z0-9_-]{6,14}\(?$/.test(s)) return false; // CRDT block ids
-    // Keep markdown field lines and real prose only.
-    if (/^\*\*[A-Za-z][^*]+\*\*:/.test(s)) return true;
-    if (s.includes(" ") && s.length >= 24) return true;
-    return false;
-  });
-  return meaningful.join("\n");
+  return matches
+    .map((raw) => raw.replace(/'+$/g, "").trim())
+    .filter((s) => {
+      if (!s || skip.has(s)) return false;
+      if (s.startsWith("$") || s.startsWith("w$")) return false;
+      if (/^[A-Za-z0-9_-]{6,14}\(?$/.test(s)) return false;
+      if (/^\*\*[A-Za-z][^*]+\*\*:/.test(s)) return true;
+      if (s.includes(" ") && s.length >= 24) return true;
+      return false;
+    })
+    .join("\n");
 }
 
 export async function getDocument(workspaceId: string, viewId: string): Promise<unknown> {


### PR DESCRIPTION
## Summary
- Write Notion→AppFlowy page bodies via `page_data` / `append-block` (not broken `/doc/:id`) and add `pnpm cms:backfill-appflowy`
- Reconstruct CMS field text from AppFlowy CRDT bold attributes so services/FAQs/etc. return real descriptions
- Improve `cms:parity` (CF Access headers, `CMS_PARITY_REQUIRE_APPFLOWY`) and LAN-first `omv:selfhosted:health`; document Fly proxy as the CF-bot-challenge bypass for prod probes

## Test plan
- [x] Local `CMS_PARITY_REQUIRE_APPFLOWY=1 pnpm cms:parity` → 6/6 appflowy with rich service/FAQ fields
- [x] Pi secrets: in-cluster `APPFLOWY_API_URL` + synced GoTrue password (login 200)
- [ ] After merge: rebuild Pi `cloudless-standalone`, re-run LAN + Fly parity


Made with [Cursor](https://cursor.com)