### PR TITLE
fix(deploy): drop Lambda@Edge middleware for SST Nextjs

### DIFF
--- a/open-next.config.cloudflare.ts
+++ b/open-next.config.cloudflare.ts
@@ -1,0 +1,41 @@
+/**
+ * OpenNext.js Cloudflare configuration for cloudless.gr
+ * Consolidated layout supporting Next.js 16 compilation splits.
+ *
+ * Used by `scripts/cf-build-wrapper.sh` via `--openNextConfigPath`.
+ * AWS SST deploy uses `open-next.config.ts` (non-edge middleware).
+ */
+import { defineCloudflareConfig } from "@opennextjs/cloudflare";
+import r2IncrementalCache from "@opennextjs/cloudflare/overrides/incremental-cache/r2-incremental-cache";
+import d1TagCache from "@opennextjs/cloudflare/overrides/tag-cache/d1-next-tag-cache";
+import { MemoryQueue } from "@opennextjs/cloudflare/overrides/queue/memory-queue";
+
+export default defineCloudflareConfig({
+  default: {
+    placement: "server",
+    incrementalCache: r2IncrementalCache,
+    tagCache: d1TagCache,
+    queue: MemoryQueue,
+  },
+
+  // Middleware is placed on "server" (not "edge") because:
+  // 1. Cloudflare Workers don't have a separate edge runtime tier — the
+  //    middleware runs in the same workerd isolate as the server function.
+  // 2. With placement: "edge", OpenNext calls generateEdgeBundle() which
+  //    bundles the middleware as a standalone edge function. Then
+  //    copyTracedFiles() in the default function's generateBundle() still
+  //    tries to process middleware.js.nft.json and throws
+  //    "middleware cannot use the edge runtime" because the nft.json stub
+  //    was "{}" (no files array).
+  // 3. With placement: "server", OpenNext calls generateBundle() for the
+  //    middleware, which correctly bundles it as part of the server function.
+  //    The middleware.js.nft.json now has a proper {"files":["middleware.js"]}
+  //    format (see scripts/opennext-middleware-fix.mjs), so processNftFile()
+  //    succeeds.
+  functions: {
+    middleware: {
+      placement: "server",
+      routes: ["middleware"],
+    },
+  },
+} as any);

--- a/open-next.config.ts
+++ b/open-next.config.ts
@@ -1,38 +1,20 @@
 /**
- * OpenNext.js Cloudflare configuration for cloudless.gr
- * Consolidated layout supporting Next.js 16 compilation splits.
+ * OpenNext AWS config for `sst.aws.Nextjs` / `@opennextjs/aws`.
+ *
+ * SST rejects builds that emit `edgeFunctions` (Lambda@Edge is deprecated).
+ * Keep middleware internal (`external: false`) so it ships with the regional
+ * server Lambda. Multi-region latency uses `regions` on the Nextjs component
+ * in `sst.config.ts` — not edge middleware.
+ *
+ * Cloudflare builds use `open-next.config.cloudflare.ts`.
  */
-import { defineCloudflareConfig } from "@opennextjs/cloudflare";
-import r2IncrementalCache from "@opennextjs/cloudflare/overrides/incremental-cache/r2-incremental-cache";
-import d1TagCache from "@opennextjs/cloudflare/overrides/tag-cache/d1-next-tag-cache";
-import { MemoryQueue } from "@opennextjs/cloudflare/overrides/queue/memory-queue";
-
-export default defineCloudflareConfig({
+const config = {
   default: {
-    placement: "server",
-    incrementalCache: r2IncrementalCache,
-    tagCache: d1TagCache,
-    queue: MemoryQueue,
+    placement: "regional" as const,
   },
+  middleware: {
+    external: false as const,
+  },
+};
 
-  // Middleware is placed on "server" (not "edge") because:
-  // 1. Cloudflare Workers don't have a separate edge runtime tier — the
-  //    middleware runs in the same workerd isolate as the server function.
-  // 2. With placement: "edge", OpenNext calls generateEdgeBundle() which
-  //    bundles the middleware as a standalone edge function. Then
-  //    copyTracedFiles() in the default function's generateBundle() still
-  //    tries to process middleware.js.nft.json and throws
-  //    "middleware cannot use the edge runtime" because the nft.json stub
-  //    was "{}" (no files array).
-  // 3. With placement: "server", OpenNext calls generateBundle() for the
-  //    middleware, which correctly bundles it as part of the server function.
-  //    The middleware.js.nft.json now has a proper {"files":["middleware.js"]}
-  //    format (see scripts/opennext-middleware-fix.mjs), so processNftFile()
-  //    succeeds.
-  functions: {
-    middleware: {
-      placement: "server",
-      routes: ["middleware"],
-    }
-  }
-} as any);
+export default config;

--- a/scripts/cf-build-wrapper.sh
+++ b/scripts/cf-build-wrapper.sh
@@ -70,6 +70,7 @@ echo "▶ Ensuring middleware.js.nft.json stub exists for OpenNext..."
 node scripts/opennext-middleware-fix.mjs || true
 
 echo "▶ Running OpenNext Cloudflare build..."
-NEXT_TELEMETRY_DISABLED=1 pnpm exec opennextjs-cloudflare build
+NEXT_TELEMETRY_DISABLED=1 pnpm exec opennextjs-cloudflare build \
+  --openNextConfigPath open-next.config.cloudflare.ts
 
 echo "✅ Cloudflare build complete"

--- a/scripts/sst-next-build.mjs
+++ b/scripts/sst-next-build.mjs
@@ -15,19 +15,27 @@ import { fileURLToPath } from "node:url";
 const root = path.dirname(path.dirname(fileURLToPath(import.meta.url)));
 const serverDir = path.join(root, ".next", "server");
 const nftPath = path.join(serverDir, "middleware.js.nft.json");
+const middlewareJsPath = path.join(serverDir, "middleware.js");
 
-function ensureNftStub() {
+function ensureMiddlewareStubs() {
   try {
     if (!fs.existsSync(serverDir)) return;
-    if (fs.existsSync(nftPath)) return;
-    fs.writeFileSync(nftPath, JSON.stringify({ files: [] }));
+    if (!fs.existsSync(middlewareJsPath)) {
+      // Next finalization copyfile()'s this into standalone/; edge wrapper
+      // may not exist yet — empty stub unblocks the copy, then
+      // opennext-middleware-fix overwrites with the real edge-wrapper.
+      fs.writeFileSync(middlewareJsPath, "// middleware stub for Next 16 finalization\n");
+    }
+    if (!fs.existsSync(nftPath)) {
+      fs.writeFileSync(nftPath, JSON.stringify({ files: ["middleware.js"] }));
+    }
   } catch {
     // Best-effort — next may race mkdir/rmdir during clean.
   }
 }
 
-const poll = setInterval(ensureNftStub, 50);
-ensureNftStub();
+const poll = setInterval(ensureMiddlewareStubs, 50);
+ensureMiddlewareStubs();
 
 const nextBin = path.join(root, "node_modules", "next", "dist", "bin", "next");
 const child = spawn(process.execPath, [nextBin, "build"], {
@@ -38,7 +46,7 @@ const child = spawn(process.execPath, [nextBin, "build"], {
 
 child.on("exit", (code, signal) => {
   clearInterval(poll);
-  ensureNftStub();
+  ensureMiddlewareStubs();
 
   const fix = spawn(process.execPath, [path.join(root, "scripts", "opennext-middleware-fix.mjs")], {
     cwd: root,
@@ -53,9 +61,14 @@ child.on("exit", (code, signal) => {
     }
     // If Next only failed because the stub was briefly missing, but the build
     // tree + nft stub now exist, treat as success so OpenNext can continue.
-    if (code !== 0 && fs.existsSync(nftPath) && fs.existsSync(path.join(serverDir, "middleware-manifest.json"))) {
+    if (
+      code !== 0 &&
+      fs.existsSync(nftPath) &&
+      fs.existsSync(middlewareJsPath) &&
+      fs.existsSync(path.join(serverDir, "middleware-manifest.json"))
+    ) {
       console.warn(
-        "[sst-next-build] next build exited non-zero but middleware NFT + manifest exist; continuing.",
+        "[sst-next-build] next build exited non-zero but middleware stubs + manifest exist; continuing.",
       );
       process.exit(0);
       return;

--- a/sst.config.ts
+++ b/sst.config.ts
@@ -331,6 +331,9 @@ export default {
         dns: false,
         cert: "arn:aws:acm:us-east-1:278585680617:certificate/f505905a-97b4-46b0-a2b0-fb1900f425b2",
       },
+      // Regional server Lambdas only — Lambda@Edge middleware is rejected by
+      // current SST. open-next.config.ts keeps middleware internal.
+      regions: ["us-east-1"],
       environment: buildSiteEnvironment(
         stage,
         isProd,


### PR DESCRIPTION
## Summary
- Split OpenNext configs: AWS `open-next.config.ts` (`middleware.external: false`) vs Cloudflare `open-next.config.cloudflare.ts`.
- Set `regions: [\"us-east-1\"]` on `sst.aws.Nextjs`.
- Stub `middleware.js` + NFT during `next build` finalization.

## Why
Post-#1372 deploy got past NFT ENOENT, then failed with:
`Lambda@Edge runtime is deprecated` because the Cloudflare OpenNext config was being consumed by `@opennextjs/aws` and emitted edge functions.

## Test plan
- [ ] Deploy to Production succeeds on merge
- [ ] Cloudflare `cf:build` still points at cloudflare config path

Made with [Cursor](https://cursor.com)