### PR TITLE
docs: AWS→Cloudflare preference + cms parity encoding fix

### DIFF
--- a/.cursor/rules/aws-to-cloudflare.mdc
+++ b/.cursor/rules/aws-to-cloudflare.mdc
@@ -1,0 +1,23 @@
+---
+description: Prefer Cloudflare over AWS; never install AWS CLI/SDK for agent work
+alwaysApply: true
+---
+
+# AWS → Cloudflare migration preference
+
+## Direction
+
+- **Target platform is Cloudflare** (Workers, R2, D1, Access, Tunnel, DNS/CDN). New work should prefer Cloudflare-native services over AWS.
+- Treat remaining AWS usage (SSM, SES, Cognito, S3, Lambda, Athena, etc.) as **legacy to migrate off**, not expand.
+- When a checklist item depends on AWS (e.g. WAL-G → S3, secondary-region DR, Postgres → AWS replication), propose a **Cloudflare equivalent** (R2, D1, Workers, Queues) instead of completing the AWS path—unless the user explicitly asks to keep AWS for that item.
+
+## Tooling — hard rule
+
+- **Do not install the AWS CLI** (`aws`, `awscli`, snap/apt packages) on developer machines, Pi hosts, or CI agents for cloudless.gr work.
+- **Do not add the AWS SDK** (`@aws-sdk/*`, `boto3`, etc.) to new code or scripts. Prefer existing in-repo wrappers only when touching legacy paths that already depend on them; do not introduce new AWS SDK dependencies.
+- Prefer Cloudflare APIs / Wrangler / existing `cloudflare-*` skills and repo scripts over any AWS tooling.
+
+## Agent behavior
+
+- If a task seems to require `aws ssm` / `aws s3` / installing AWS tools: stop, use an existing Cloudflare/repo path, or ask the user—do **not** install AWS CLI/SDK.
+- Document migrations and blockers in `docs/current-source-of-truth-checklist.md` with Cloudflare as the destination.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3,6 +3,7 @@
 ## Working Style
 
 - **Never use placeholders.** No `<paste-output-here>`, no `TODO`, no `# TODO`, no `# fill in`, no `# replace this`, no `your-value-here`, no `xxx`, no `???`. If a value isn't known, fetch it, ask one direct question, or stop — do not write code/configs/docs that contain placeholders the user has to find and replace.
+- **AWS → Cloudflare (operator decision 2026-07-29).** Prefer Cloudflare (Workers, R2, D1, Access, Tunnel) over expanding AWS. Do **not** install AWS CLI or add AWS SDK for agent/operator work. Treat R16/R20/R24-style AWS paths as legacy; propose Cloudflare replacements. See `.cursor/rules/aws-to-cloudflare.mdc` and the platform-direction note in `docs/current-source-of-truth-checklist.md`.
 
 ## Pending One-Time Setup (human action required)
 

--- a/docs/current-source-of-truth-checklist.md
+++ b/docs/current-source-of-truth-checklist.md
@@ -32,10 +32,10 @@ Runbook: [`docs/operator-blockers-runbook.md`](operator-blockers-runbook.md).
 - [x] `DONE` Create Kuma status page and wire monitor alerts to ntfy (+ Slack bridge).
   Proof 2026-07-29: slug `cloudless`, 12 monitors, ntfy notification id=1; in-cluster
   `GET http://uptime-kuma…/api/status-page/cloudless` → 200; app ConfigMap
-  `KUMA_BASE_URL` + `KUMA_STATUS_PAGE_SLUG=cloudless`. Slack uses live
-  `kuma-slack-bridge` Deployment (`infrastructure/uptime-kuma/k8s/kuma-slack-bridge.yaml`)
-  because Pi hostpath standalone still 404s `/api/webhooks/kuma`. Incoming
-  Webhook URL not required.
+  `KUMA_BASE_URL` + `KUMA_STATUS_PAGE_SLUG=cloudless`. Slack fan-out via
+  `kuma-slack-bridge` Deployment (`infrastructure/uptime-kuma/k8s/kuma-slack-bridge.yaml`).
+  App route `POST /api/webhooks/kuma` is mounted on Pi hostpath after 2026-07-29
+  standalone rebuild (unauth → **401**, not 404). Incoming Webhook URL not required.
 - [x] `PARTIAL` Restore ESP32 Notion page (API reconstruct; history UI expired).
   Proof 2026-07-29: `scripts/notion-restore-esp32.mjs` rebuilt 16 blocks on page
   `3677d82c-410a-81e4-a6db-e9ae89578fda` (Devices/Telemetry DBs still empty).
@@ -95,6 +95,12 @@ Issue template: `.github/ISSUE_TEMPLATE/ops-cadence.yml`.
 ## Already done baseline
 
 - [x] R10, R11, R12, R13 (descoped), R14, R18, R22.
+
+## Platform direction (operator decision 2026-07-29)
+
+- **Migrate off AWS → Cloudflare.** Prefer Workers / R2 / D1 / Access / Tunnel over expanding SSM, S3, Lambda, Athena, Cognito, etc.
+- **Do not install AWS CLI or AWS SDK** for agent/operator work on this repo; use Cloudflare tooling and existing in-repo paths instead.
+- AWS-backed roadmap items still labeled `DONE` in-repo (R16 WAL-G→S3, R20→AWS, R24 secondary region) are **legacy designs** — next work should replace them with Cloudflare equivalents rather than provisioning AWS secrets/CLI.
 
 ## Notes
 

--- a/scripts/cms-parity-check.mjs
+++ b/scripts/cms-parity-check.mjs
@@ -37,7 +37,8 @@ const ENDPOINTS = [
 ];
 
 function buildHeaders() {
-  const headers = { Accept: "application/json" };
+  // Prefer identity so undici does not mis-parse Fly/CF compressed bodies as empty JSON.
+  const headers = { Accept: "application/json", "Accept-Encoding": "identity" };
 
   if (process.env.CMS_PARITY_HEADERS_JSON) {
     try {


### PR DESCRIPTION
## Summary
- Persist operator decision: migrate off AWS toward Cloudflare; never install AWS CLI/SDK for agent work (`.cursor/rules/aws-to-cloudflare.mdc`, `CLAUDE.md`, checklist).
- Fix `cms:parity` Fly probes via `Accept-Encoding: identity` (already on this branch).

## Test plan
- [x] Rule alwaysApply present under `.cursor/rules/`
- [ ] `CMS_PARITY_BASE_URL=https://cloudless-proxy.fly.dev CMS_PARITY_REQUIRE_APPFLOWY=1 pnpm cms:parity` shows non-zero AppFlowy counts

Made with [Cursor](https://cursor.com)