### PR TITLE
ops: Kuma→app webhook + AppFlowy WAL-G→R2

### DIFF
--- a/docs/current-source-of-truth-checklist.md
+++ b/docs/current-source-of-truth-checklist.md
@@ -29,13 +29,12 @@ Runbook: [`docs/operator-blockers-runbook.md`](operator-blockers-runbook.md).
   Pi `NTFY_BASE_URL=http://ntfy.ntfy.svc.cluster.local` (public tunnel hits CF challenge).
   Proof: signed POST → `{ ok: true, result: { slack: { ok: true }, ntfy: { ok: true } } }`;
   Slack DM + ntfy topic `cloudless-ops` both received.
-- [x] `DONE` Create Kuma status page and wire monitor alerts to ntfy (+ Slack bridge).
+- [x] `DONE` Create Kuma status page and wire monitor alerts to ntfy (+ Slack).
   Proof 2026-07-29: slug `cloudless`, 12 monitors, ntfy notification id=1; in-cluster
   `GET http://uptime-kuma…/api/status-page/cloudless` → 200; app ConfigMap
-  `KUMA_BASE_URL` + `KUMA_STATUS_PAGE_SLUG=cloudless`. Slack fan-out via
-  `kuma-slack-bridge` Deployment (`infrastructure/uptime-kuma/k8s/kuma-slack-bridge.yaml`).
-  App route `POST /api/webhooks/kuma` is mounted on Pi hostpath after 2026-07-29
-  standalone rebuild (unauth → **401**, not 404). Incoming Webhook URL not required.
+  `KUMA_BASE_URL` + `KUMA_STATUS_PAGE_SLUG=cloudless`. Slack cut over 2026-07-29 to
+  `POST /api/webhooks/kuma` on `cloudless-app` (Bearer `ADMIN_ALERT_SECRET`);
+  `kuma-slack-bridge` scaled to 0 (rollback manifest retained).
 - [x] `PARTIAL` Restore ESP32 Notion page (API reconstruct; history UI expired).
   Proof 2026-07-29: `scripts/notion-restore-esp32.mjs` rebuilt 16 blocks on page
   `3677d82c-410a-81e4-a6db-e9ae89578fda` (Devices/Telemetry DBs still empty).
@@ -47,6 +46,12 @@ Runbook: [`docs/operator-blockers-runbook.md`](operator-blockers-runbook.md).
   Proof: `src/lib/cost-analytics.ts`, `/admin/cost`, runbook §5.
 
 ## Claude-shippable roadmap items
+
+- [x] `DONE` AppFlowy CMS dual-run (Notion → AppFlowy primary on Pi).
+  Evidence 2026-07-29: `src/lib/appflowy.ts` + dual-run readers; migrate/backfill scripts;
+  `CMS_PARITY_REQUIRE_APPFLOWY=1` → **6/6 appflowy** on LAN `:30300` and
+  `https://cloudless-proxy.fly.dev` (parity probe uses `Accept-Encoding: identity`).
+  Prod pod: `APPFLOWY_API_URL=http://nginx.appflowy.svc.cluster.local`.
 
 - [x] `DONE` R25 self-hosted admin auto-login bridge.
   Evidence: `src/lib/selfhosted-autologin.ts`, `src/app/api/admin/autologin/route.ts`, `src/app/[locale]/admin/selfhosted/page.tsx`, `src/app/[locale]/admin/cluster/page.tsx`.
@@ -65,14 +70,27 @@ Runbook: [`docs/operator-blockers-runbook.md`](operator-blockers-runbook.md).
 - [x] `DONE` R19 monthly failover drill workflow.
   Evidence: `.github/workflows/failover-drill.yml` (monthly schedule + manual dispatch probes for primary/secondary health).
 
-- [x] `DONE` R16 AppFlowy WAL-G continuous backup to S3.
-  Evidence: WAL-G sidecar + archive_command wired in `infrastructure/appflowy/k8s/appflowy.yaml`; Secret/ConfigMap/CronJob in `infrastructure/appflowy/walg-sidecar.yaml`. Operator still must create `appflowy-walg-aws` from SSM before apply.
+- [x] `PARTIAL` R16 AppFlowy WAL-G → **Cloudflare R2** (replaces S3 design).
+  Evidence: `infrastructure/appflowy/walg-sidecar.yaml` + postgres wiring in
+  `infrastructure/appflowy/k8s/appflowy.yaml` retargeted to R2 endpoint
+  (`datalake-bucket/appflowy-wal/`). Secret `appflowy-walg-r2` still needs R2
+  API token from Cloudflare (`.github/workflows/create-r2-credentials.yml` or
+  dashboard) before apply — **no AWS CLI/SSM**.
 - [x] `DONE` R23 Resend pilot for order confirmations.
   Evidence: `src/lib/email-resend.ts` plus pilot switch/fallback in `src/lib/email.ts` (`sendOrderConfirmation` prefers Resend when configured, falls back to SES).
-- [x] `DONE` R24 AWS secondary-region DR path.
-  Evidence: `infrastructure/r24-dr/{main,route53,dynamodb}.tf`, `infrastructure/r24-dr/README.md`, `.github/workflows/r24-add-replicas.yml`.
-- [x] `DONE` R20 Postgres logical replication subscriber to AWS.
-  Evidence: `infrastructure/r20-replication/{README.md,subscriber.ts,wal2json-config.yaml}`, `.github/workflows/r20-replication-subscriber.yml`.
+- [x] `DEFERRED` R24 AWS secondary-region DR path (legacy).
+  Decision 2026-07-29: do not provision; prefer Cloudflare Tunnel HA + R2 offsite
+  + R19 failover drill. Manifests retained under `infrastructure/r24-dr/`.
+- [x] `DEFERRED` R20 Postgres logical replication subscriber to AWS (legacy).
+  Decision 2026-07-29: do not provision AWS subscriber; prefer R16→R2 WAL + ETL
+  `scripts/etl/appflowy-to-r2.mjs`. Manifests retained under `infrastructure/r20-replication/`.
+
+## Next open (Cloudflare-first)
+
+- [ ] `OPEN` Apply R16: create `appflowy-walg-r2` from R2 API token + apply
+  ConfigMap/CronJob + restart AppFlowy postgres (when ready to enable WAL archive).
+- [ ] `OPEN` Retarget R10 PVC backup CronJobs from AWS S3/`apk add aws-cli` to R2
+  (`infrastructure/backup/cronjob-*.yaml`).
 
 ## LinkedIn CAPI finalization
 
@@ -100,7 +118,9 @@ Issue template: `.github/ISSUE_TEMPLATE/ops-cadence.yml`.
 
 - **Migrate off AWS → Cloudflare.** Prefer Workers / R2 / D1 / Access / Tunnel over expanding SSM, S3, Lambda, Athena, Cognito, etc.
 - **Do not install AWS CLI or AWS SDK** for agent/operator work on this repo; use Cloudflare tooling and existing in-repo paths instead.
-- AWS-backed roadmap items still labeled `DONE` in-repo (R16 WAL-G→S3, R20→AWS, R24 secondary region) are **legacy designs** — next work should replace them with Cloudflare equivalents rather than provisioning AWS secrets/CLI.
+- AWS-backed roadmap items (old R16→S3, R20→AWS, R24 secondary region) are
+  **legacy** — R16 retargeted to R2 in-repo; R20/R24 deferred. Next: apply
+  `appflowy-walg-r2` + retarget PVC backup CronJobs to R2 (no AWS CLI).
 
 ## Notes
 

--- a/docs/operator-blockers-runbook.md
+++ b/docs/operator-blockers-runbook.md
@@ -59,21 +59,17 @@ Bootstrapped in-cluster via `scripts/kuma-bootstrap.cjs`:
 
 - Status page slug: **`cloudless`**, **12** HTTP monitors
 - Notification: ntfy → `https://ntfy.cloudless.gr` topic `cloudless-alerts`
-- Slack: Incoming Webhook was revoked (2026-05-25). Live path is the
-  in-cluster bridge Deployment (Pi hostpath standalone still 404s
-  `/api/webhooks/kuma`):
-  - Manifest: `infrastructure/uptime-kuma/k8s/kuma-slack-bridge.yaml`
-  - Service: `http://kuma-slack-bridge.uptime-kuma.svc.cluster.local:8080/`
-  - Auth: Bearer `ADMIN_ALERT_SECRET`
-  - App route (future): `POST /api/webhooks/kuma` after standalone rebuild
+- Slack: Incoming Webhook was revoked (2026-05-25). **Live path (cut over 2026-07-29):**
+  - `POST http://cloudless-app.cloudless.svc.cluster.local/api/webhooks/kuma`
+  - Auth: Bearer `ADMIN_ALERT_SECRET` → `src/app/api/webhooks/kuma/route.ts` → `SlackClient`
+  - Kuma notification row updated in SQLite; `kuma-slack-bridge` Deployment scaled to **0** (manifest kept for rollback)
+  - Re-register script default: `scripts/kuma-slack-bridge.cjs` → app webhook URL
 
 ```bash
-POD=$(kubectl -n uptime-kuma get pod -l app=uptime-kuma -o jsonpath='{.items[0].metadata.name}')
-TOKEN=$(kubectl -n cloudless get secret cloudless-secrets -o jsonpath='{.data.ADMIN_ALERT_SECRET}' | base64 -d)
-kubectl -n uptime-kuma cp scripts/kuma-slack-bridge.cjs "$POD":/tmp/kuma-slack-bridge.cjs
-kubectl -n uptime-kuma exec "$POD" -- env NODE_PATH=/app/node_modules \
-  KUMA_USER=tbaltzakis KUMA_PASS='…' KUMA_BRIDGE_TOKEN="$TOKEN" \
-  node /tmp/kuma-slack-bridge.cjs
+# Optional re-register from uptime-kuma pod
+KUMA_BRIDGE_URL=http://cloudless-app.cloudless.svc.cluster.local/api/webhooks/kuma \
+KUMA_BRIDGE_TOKEN="$ADMIN_ALERT_SECRET" KUMA_PASS='…' \
+  node scripts/kuma-slack-bridge.cjs
 ```
 
 ## 4. ESP32 Notion page — PARTIAL (history expired)

--- a/infrastructure/appflowy/k8s/appflowy.yaml
+++ b/infrastructure/appflowy/k8s/appflowy.yaml
@@ -74,9 +74,11 @@ spec:
     metadata: { labels: { app: postgres } }
     spec:
       nodeSelector: { kubernetes.io/hostname: omv }
-      # R16: WAL-G continuous backup. Init copies the wal-g binary into a
+      # R16: WAL-G → Cloudflare R2 (S3-compatible). Init copies wal-g into a
       # shared emptyDir so postgres archive_command can invoke it. Requires
-      # Secret appflowy-walg-aws (see infrastructure/appflowy/walg-sidecar.yaml).
+      # Secret appflowy-walg-r2 + ConfigMap appflowy-walg-env
+      # (see infrastructure/appflowy/walg-sidecar.yaml). AWS_* names are
+      # WAL-G's S3 client API; values are R2 tokens — not AWS IAM.
       initContainers:
         - name: walg-bin
           image: ghcr.io/wal-g/wal-g:v3.0.3
@@ -100,12 +102,9 @@ spec:
             - name: POSTGRES_PASSWORD
               valueFrom: { secretKeyRef: { name: appflowy-secrets, key: POSTGRES_PASSWORD } }
             - { name: PGDATA, value: /var/lib/postgresql/data/pgdata }
-            - { name: AWS_REGION, value: us-east-1 }
-            - { name: WALG_S3_PREFIX, value: "s3://cloudless-analytics-data/appflowy-wal/wal/" }
-            - name: AWS_ACCESS_KEY_ID
-              valueFrom: { secretKeyRef: { name: appflowy-walg-aws, key: AWS_ACCESS_KEY_ID } }
-            - name: AWS_SECRET_ACCESS_KEY
-              valueFrom: { secretKeyRef: { name: appflowy-walg-aws, key: AWS_SECRET_ACCESS_KEY } }
+          envFrom:
+            - configMapRef: { name: appflowy-walg-env, optional: true }
+            - secretRef: { name: appflowy-walg-r2, optional: true }
           args:
             - "-c"
             - "archive_mode=on"
@@ -127,20 +126,14 @@ spec:
           args:
             - |
               set -euo pipefail
-              export WALG_S3_PREFIX=s3://cloudless-analytics-data/appflowy-wal/wal/
-              export WALG_UPLOAD_CONCURRENCY=2
-              export WALG_SENTINEL_NAME=appflowy-postgres-production
               while true; do
                 wal-g wal-verify integrity || true
                 sleep 300
               done
+          envFrom:
+            - configMapRef: { name: appflowy-walg-env, optional: true }
+            - secretRef: { name: appflowy-walg-r2, optional: true }
           env:
-            - { name: AWS_REGION, value: us-east-1 }
-            - name: AWS_ACCESS_KEY_ID
-              valueFrom: { secretKeyRef: { name: appflowy-walg-aws, key: AWS_ACCESS_KEY_ID } }
-            - name: AWS_SECRET_ACCESS_KEY
-              valueFrom: { secretKeyRef: { name: appflowy-walg-aws, key: AWS_SECRET_ACCESS_KEY } }
-            - { name: WALG_S3_PREFIX, value: "s3://cloudless-analytics-data/appflowy-wal/wal/" }
             - { name: PGDATA, value: /var/lib/postgresql/data/pgdata }
           volumeMounts:
             - { name: data, mountPath: /var/lib/postgresql/data, readOnly: true }

--- a/infrastructure/appflowy/walg-sidecar.yaml
+++ b/infrastructure/appflowy/walg-sidecar.yaml
@@ -1,28 +1,33 @@
-# R16: AppFlowy WAL-G continuous backup to S3
+# R16 → Cloudflare R2: AppFlowy WAL-G continuous backup (S3-compatible API).
 #
-# Apply after creating the AWS secret from SSM:
-#   kubectl -n appflowy create secret generic appflowy-walg-aws \
-#     --from-literal=AWS_ACCESS_KEY_ID=… \
-#     --from-literal=AWS_SECRET_ACCESS_KEY=…
+# Do NOT use AWS S3 / AWS CLI / SSM AWS keys. Create an R2 API token
+# (Cloudflare dashboard or create-r2-credentials.yml) with write access to
+# datalake-bucket, then:
 #
-# Then patch the postgres Deployment (already wired in k8s/appflowy.yaml)
-# or apply this Secret + ConfigMap and restart postgres.
+#   kubectl -n appflowy create secret generic appflowy-walg-r2 \
+#     --from-literal=AWS_ACCESS_KEY_ID='<r2_access_key_id>' \
+#     --from-literal=AWS_SECRET_ACCESS_KEY='<r2_secret_access_key>'
+#
+# Env var names stay AWS_* because WAL-G's S3 client expects them; values
+# are Cloudflare R2 credentials. Set AWS_ENDPOINT to the account R2 URL.
+#
+# Apply ConfigMap + CronJob, then ensure postgres Deployment matches
+# infrastructure/appflowy/k8s/appflowy.yaml (WALG_* + AWS_ENDPOINT).
 #
 # RPO target: ~5 min (archive_timeout=300)
 ---
 apiVersion: v1
 kind: Secret
 metadata:
-  name: appflowy-walg-aws
+  name: appflowy-walg-r2
   namespace: appflowy
   labels:
     app.kubernetes.io/component: walg
     app.kubernetes.io/part-of: appflowy
 type: Opaque
 stringData:
-  # Populate from SSM before apply — do not commit real values.
-  # /cloudless/production/APPFLOWY_WALG_AWS_ACCESS_KEY_ID
-  # /cloudless/production/APPFLOWY_WALG_AWS_SECRET_ACCESS_KEY
+  # Populate from Cloudflare R2 API token — do not commit real values.
+  # Keys are S3-API compatible names used by wal-g (not AWS IAM).
   AWS_ACCESS_KEY_ID: ""
   AWS_SECRET_ACCESS_KEY: ""
 ---
@@ -35,8 +40,11 @@ metadata:
     app.kubernetes.io/component: walg
     app.kubernetes.io/part-of: appflowy
 data:
-  AWS_REGION: "us-east-1"
-  WALG_S3_PREFIX: "s3://cloudless-analytics-data/appflowy-wal/wal/"
+  # Cloudflare account id (same as CF_ACCOUNT_ID / wrangler account_id).
+  AWS_ENDPOINT: "https://c6d6b805741159c062a3e0b0d7f9d89a.r2.cloudflarestorage.com"
+  AWS_REGION: "auto"
+  AWS_S3_FORCE_PATH_STYLE: "true"
+  WALG_S3_PREFIX: "s3://datalake-bucket/appflowy-wal/wal/"
   WALG_UPLOAD_CONCURRENCY: "2"
   WALG_SENTINEL_NAME: "appflowy-postgres-production"
   PGDATA: "/var/lib/postgresql/data/pgdata"
@@ -80,7 +88,7 @@ spec:
                 - configMapRef:
                     name: appflowy-walg-env
                 - secretRef:
-                    name: appflowy-walg-aws
+                    name: appflowy-walg-r2
               env:
                 - name: POSTGRES_PASSWORD
                   valueFrom:

--- a/infrastructure/uptime-kuma/k8s/kuma-slack-bridge.yaml
+++ b/infrastructure/uptime-kuma/k8s/kuma-slack-bridge.yaml
@@ -1,23 +1,21 @@
-# Kuma → Slack bot-token bridge (Incoming Webhooks revoked 2026-05-25).
+# Kuma → Slack via cloudless-app webhook (Incoming Webhooks revoked 2026-05-25).
 #
-# Live path until Pi hostpath standalone includes POST /api/webhooks/kuma.
-# Apply:
-#   kubectl -n cloudless get secret cloudless-secrets \
-#     -o jsonpath='{.data.ADMIN_ALERT_SECRET}' | base64 -d > /tmp/aas
-#   kubectl -n cloudless get secret cloudless-secrets \
-#     -o jsonpath='{.data.SLACK_BOT_TOKEN}' | base64 -d > /tmp/sbt
-#   kubectl -n uptime-kuma create secret generic kuma-slack-bridge \
-#     --from-file=ADMIN_ALERT_SECRET=/tmp/aas \
-#     --from-file=SLACK_BOT_TOKEN=/tmp/sbt \
-#     --dry-run=client -o yaml | kubectl apply -f -
-#   kubectl -n uptime-kuma create configmap kuma-slack-bridge-src \
-#     --from-file=server.js=infrastructure/uptime-kuma/k8s/kuma-slack-bridge.js \
-#     --dry-run=client -o yaml | kubectl apply -f -
-#   kubectl apply -f infrastructure/uptime-kuma/k8s/kuma-slack-bridge.yaml
+# LIVE path (2026-07-29): Uptime Kuma posts to
+#   http://cloudless-app.cloudless.svc.cluster.local/api/webhooks/kuma
+# with Authorization: Bearer <ADMIN_ALERT_SECRET>. Route:
+#   src/app/api/webhooks/kuma/route.ts → SlackClient (#general).
 #
-# Register notification (from uptime-kuma pod):
-#   KUMA_BRIDGE_URL=http://kuma-slack-bridge.uptime-kuma.svc.cluster.local:8080/ \
-#   KUMA_BRIDGE_TOKEN=<ADMIN_ALERT_SECRET> node scripts/kuma-slack-bridge.cjs
+# This Deployment is OPTIONAL rollback only (replicas: 0). Prefer the app route.
+#
+# Re-register notification (from uptime-kuma pod or any node with socket.io-client):
+#   KUMA_BRIDGE_URL=http://cloudless-app.cloudless.svc.cluster.local/api/webhooks/kuma \
+#   KUMA_BRIDGE_TOKEN=<ADMIN_ALERT_SECRET> \
+#   KUMA_PASS=… node scripts/kuma-slack-bridge.cjs
+#
+# Rollback to this bridge:
+#   kubectl -n uptime-kuma scale deploy/kuma-slack-bridge --replicas=1
+#   then point notification webhookURL at
+#   http://kuma-slack-bridge.uptime-kuma.svc.cluster.local:8080/
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -27,7 +25,7 @@ metadata:
   labels:
     app: kuma-slack-bridge
 spec:
-  replicas: 1
+  replicas: 0
   selector:
     matchLabels:
       app: kuma-slack-bridge
@@ -78,6 +76,4 @@ spec:
   selector:
     app: kuma-slack-bridge
   ports:
-    - name: http
-      port: 8080
-      targetPort: 8080
+    - { name: http, port: 8080, targetPort: 8080 }

--- a/scripts/kuma-slack-bridge.cjs
+++ b/scripts/kuma-slack-bridge.cjs
@@ -1,13 +1,12 @@
 #!/usr/bin/env node
 /**
- * Add Slack bridge webhook notification to an already-bootstrapped Kuma.
- * Posts to in-cluster kuma-slack-bridge (bot → #general). Prefer
- * KUMA_BRIDGE_URL override to cloudless-app /api/webhooks/kuma once the
- * Pi hostpath standalone includes that route.
+ * Register Slack webhook notification on an already-bootstrapped Kuma.
+ * Default target: cloudless-app POST /api/webhooks/kuma (Bearer ADMIN_ALERT_SECRET).
+ * Override KUMA_BRIDGE_URL only for rollback to the legacy kuma-slack-bridge Service.
  *
  * Env:
  *   KUMA_USER / KUMA_PASS — admin creds
- *   KUMA_BRIDGE_URL — default kuma-slack-bridge Service
+ *   KUMA_BRIDGE_URL — default cloudless-app webhook
  *   KUMA_BRIDGE_TOKEN — ADMIN_ALERT_SECRET (Bearer)
  */
 const { io } = require("socket.io-client");
@@ -15,10 +14,11 @@ const { io } = require("socket.io-client");
 const BASE = process.env.KUMA_URL || "http://127.0.0.1:3001";
 const USER = process.env.KUMA_USER || "tbaltzakis";
 const PASS = process.env.KUMA_PASS || "";
-// Default to the in-cluster bridge Deployment until the Pi hostpath
-// standalone includes POST /api/webhooks/kuma (currently 404).
+# Default: cloudless-app webhook (Pi hostpath standalone mounts this route).
+# Legacy bridge Deployment is scaled to 0; keep for rollback only.
 const BRIDGE_URL =
-  process.env.KUMA_BRIDGE_URL || "http://kuma-slack-bridge.uptime-kuma.svc.cluster.local:8080/";
+  process.env.KUMA_BRIDGE_URL ||
+  "http://cloudless-app.cloudless.svc.cluster.local/api/webhooks/kuma";
 const TOKEN = process.env.KUMA_BRIDGE_TOKEN || "";
 
 if (!PASS || !TOKEN) {
@@ -55,7 +55,7 @@ async function main() {
     socket,
     "addNotification",
     {
-      name: "Slack via cloudless bridge",
+      name: "Slack via cloudless-app webhook",
       active: true,
       isDefault: true,
       type: "webhook",


### PR DESCRIPTION
## Summary
- Cut Uptime Kuma Slack notifications to `cloudless-app` `/api/webhooks/kuma`; scale `kuma-slack-bridge` to 0 (rollback retained).
- Retarget R16 WAL-G manifests from AWS S3 to Cloudflare R2 (`appflowy-walg-r2`, `datalake-bucket/appflowy-wal/`).
- Checklist: AppFlowy CMS DONE; R20/R24 deferred; open items = apply R16 R2 secret + retarget PVC backups.

## Test plan
- [x] Kuma SQLite notification URL → `cloudless-app.../api/webhooks/kuma`
- [x] `kuma-slack-bridge` replicas = 0
- [ ] Operator: create `appflowy-walg-r2` from R2 API token before enabling WAL archive on postgres

Made with [Cursor](https://cursor.com)