### PR TITLE
ops: apply live R2 PVC backups + fix account ID

### DIFF
--- a/.github/workflows/create-r2-credentials.yml
+++ b/.github/workflows/create-r2-credentials.yml
@@ -1,5 +1,9 @@
 name: Create R2 API Credentials
 
+# Creates an R2-capable User API token, derives S3 Access Key ID / Secret
+# (token id + SHA-256 of token value per Cloudflare R2 docs), and stores
+# CF_R2_* GitHub secrets. Prefer this over the removed /r2/credentials route.
+
 on:
   workflow_dispatch:
     inputs:
@@ -7,6 +11,11 @@ on:
         description: 'Type "create" to confirm R2 credential creation'
         required: true
         default: ''
+      update_cluster:
+        description: "Also patch pvc-backup-r2 + appflowy-walg-r2 on the Pi cluster"
+        required: true
+        type: boolean
+        default: true
 
 permissions:
   contents: read
@@ -21,54 +30,65 @@ jobs:
           echo "❌ Confirmation required. Type 'create' to proceed."
           exit 1
 
-      - name: Generate R2 Service Token
+      - uses: actions/checkout@v4
+
+      - name: Generate R2 S3 credentials from User API Token
         id: generate
         env:
           ACCOUNT_ID: ${{ secrets.CF_ACCOUNT_ID || secrets.CLOUDFLARE_ACCOUNT_ID }}
           API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
         run: |
-          # Use Cloudflare R2 credentials API to create a service token
-          RESPONSE=$(curl -s -X POST \
-            "https://api.cloudflare.com/client/v4/accounts/${ACCOUNT_ID}/r2/credentials" \
+          set -euo pipefail
+          if [ -z "${ACCOUNT_ID:-}" ] || [ -z "${API_TOKEN:-}" ]; then
+            echo "CF_ACCOUNT_ID / CLOUDFLARE_API_TOKEN required"
+            exit 1
+          fi
+          # R2 Storage Read + Write on the account
+          RESP=$(curl -sS -X POST "https://api.cloudflare.com/client/v4/user/tokens" \
             -H "Authorization: Bearer ${API_TOKEN}" \
             -H "Content-Type: application/json" \
-            --data '{
-              "name": "ETL R2 Access Token",
-              "policy": {
-                "effect": "allow",
-                "resources": {"r2.bucket": {"name": "datalake-bucket"}},
-                "permission_groups": ["f451f6d5b6a84ab0bfd8b732d9023912"]
-              }
-            }')
-
-          echo "Response: $RESPONSE"
-
-          SUCCESS=$(echo "$RESPONSE" | jq -r '.success')
-          if [ "$SUCCESS" != "true" ]; then
-            echo "ERROR: Failed to create R2 credentials"
-            echo "$RESPONSE" | jq .
-            exit 1
-          fi
-
-          ACCESS_KEY=$(echo "$RESPONSE" | jq -r '.result.access_key_id')
-          SECRET_KEY=$(echo "$RESPONSE" | jq -r '.result.secret_access_key')
-
-          if [ -z "$ACCESS_KEY" ] || [ "$ACCESS_KEY" == "null" ] || [ -z "$SECRET_KEY" ] || [ "$SECRET_KEY" == "null" ]; then
-            echo "ERROR: R2 credentials not found in response"
-            exit 1
-          fi
-
-          echo "R2_ACCESS_KEY_ID=$ACCESS_KEY" >> $GITHUB_ENV
-          echo "R2_SECRET_ACCESS_KEY=$SECRET_KEY" >> $GITHUB_ENV
+            --data "{\"name\":\"cloudless-r2-s3-$(date -u +%Y%m%d%H%M%S)\",\"policies\":[{\"effect\":\"allow\",\"resources\":{\"com.cloudflare.api.account.${ACCOUNT_ID}\":\"*\"},\"permission_groups\":[{\"id\":\"b4992e1108244f5d8bfbd5744320c2e1\"},{\"id\":\"bf7481a1826f439697cb59a20b22293e\"}]}]}")
+          echo "$RESP" | jq '{success, errors, id: .result.id}'
+          echo "$RESP" | jq -e '.success == true' >/dev/null
+          TOKEN_ID=$(echo "$RESP" | jq -r '.result.id')
+          TOKEN_VALUE=$(echo "$RESP" | jq -r '.result.value')
+          SECRET=$(printf '%s' "$TOKEN_VALUE" | sha256sum | awk '{print $1}')
+          echo "::add-mask::$TOKEN_ID"
+          echo "::add-mask::$SECRET"
+          echo "R2_ACCESS_KEY_ID=$TOKEN_ID" >> "$GITHUB_ENV"
+          echo "R2_SECRET_ACCESS_KEY=$SECRET" >> "$GITHUB_ENV"
 
       - name: Store R2 Credentials as GitHub Secrets
-        run: |
-          echo "${{ env.R2_ACCESS_KEY_ID }}" | gh secret set CF_R2_ACCESS_KEY_ID
-          echo "${{ env.R2_SECRET_ACCESS_KEY }}" | gh secret set CF_R2_SECRET_ACCESS_KEY
         env:
-          GH_TOKEN: ${{ secrets.GH_PAT }}
-
-      - name: Verify Secrets
+          GH_TOKEN: ${{ secrets.GH_PAT || github.token }}
         run: |
-          echo "✅ CF_R2_ACCESS_KEY_ID added to GitHub secrets"
-          echo "✅ CF_R2_SECRET_ACCESS_KEY added to GitHub secrets"
+          printf '%s' "${{ env.R2_ACCESS_KEY_ID }}" | gh secret set CF_R2_ACCESS_KEY_ID --repo "${{ github.repository }}"
+          printf '%s' "${{ env.R2_SECRET_ACCESS_KEY }}" | gh secret set CF_R2_SECRET_ACCESS_KEY --repo "${{ github.repository }}"
+          echo "✅ CF_R2_ACCESS_KEY_ID / CF_R2_SECRET_ACCESS_KEY stored"
+
+      - name: Patch cluster secrets
+        if: ${{ inputs.update_cluster }}
+        env:
+          KUBECONFIG_B64: ${{ secrets.KUBECONFIG_B64 }}
+          ACCESS_KEY: ${{ env.R2_ACCESS_KEY_ID }}
+          SECRET_KEY: ${{ env.R2_SECRET_ACCESS_KEY }}
+        run: |
+          set -euo pipefail
+          if [ -z "${KUBECONFIG_B64:-}" ]; then
+            echo "KUBECONFIG_B64 missing — skip cluster patch"
+            exit 0
+          fi
+          mkdir -p ~/.kube
+          echo "$KUBECONFIG_B64" | base64 -d > ~/.kube/config
+          chmod 600 ~/.kube/config
+          for ns in appflowy espocrm postiz n8n; do
+            kubectl -n "$ns" create secret generic pvc-backup-r2 \
+              --from-literal=ACCESS_KEY_ID="$ACCESS_KEY" \
+              --from-literal=SECRET_ACCESS_KEY="$SECRET_KEY" \
+              --dry-run=client -o yaml | kubectl apply -f -
+          done
+          kubectl -n appflowy create secret generic appflowy-walg-r2 \
+            --from-literal=AWS_ACCESS_KEY_ID="$ACCESS_KEY" \
+            --from-literal=AWS_SECRET_ACCESS_KEY="$SECRET_KEY" \
+            --dry-run=client -o yaml | kubectl apply -f -
+          echo "✅ cluster secrets patched"

--- a/docs/current-source-of-truth-checklist.md
+++ b/docs/current-source-of-truth-checklist.md
@@ -70,12 +70,12 @@ Runbook: [`docs/operator-blockers-runbook.md`](operator-blockers-runbook.md).
 - [x] `DONE` R19 monthly failover drill workflow.
   Evidence: `.github/workflows/failover-drill.yml` (monthly schedule + manual dispatch probes for primary/secondary health).
 
-- [x] `PARTIAL` R16 AppFlowy WAL-G → **Cloudflare R2** (replaces S3 design).
-  Evidence: `infrastructure/appflowy/walg-sidecar.yaml` + postgres wiring in
-  `infrastructure/appflowy/k8s/appflowy.yaml` retargeted to R2 endpoint
-  (`datalake-bucket/appflowy-wal/`). Secret `appflowy-walg-r2` still needs R2
-  API token from Cloudflare (`.github/workflows/create-r2-credentials.yml` or
-  dashboard) before apply — **no AWS CLI/SSM**.
+- [x] `DONE` R16 AppFlowy WAL-G → **Cloudflare R2** (replaces S3 design).
+  Evidence: `infrastructure/appflowy/walg-sidecar.yaml` + `appflowy-walg-env` /
+  `appflowy-walg-r2` live; daily `appflowy-walg-basebackup` CronJob created.
+  Account endpoint `https://fb7dc7b69b662480cd5961a4d1913c78.r2.cloudflarestorage.com`.
+  Continuous `archive_command` sidecar still optional (requires postgres Deployment
+  apply from `k8s/appflowy.yaml`); daily basebackup + R10 `pg_dump` cover offsite.
 - [x] `DONE` R23 Resend pilot for order confirmations.
   Evidence: `src/lib/email-resend.ts` plus pilot switch/fallback in `src/lib/email.ts` (`sendOrderConfirmation` prefers Resend when configured, falls back to SES).
 - [x] `DEFERRED` R24 AWS secondary-region DR path (legacy).
@@ -90,12 +90,14 @@ Runbook: [`docs/operator-blockers-runbook.md`](operator-blockers-runbook.md).
 - [x] `DONE` Retarget R10 PVC backup CronJobs to R2 via rclone (no `apk add aws-cli`).
   Evidence: `infrastructure/backup/cronjob-*.yaml`, `README.md`,
   `.github/workflows/store-r2-backup-credentials.yml`.
-- [ ] `BLOCKED-OPERATOR` Create Cloudflare R2 S3 API token for `datalake-bucket`, then run
-  `store-r2-backup-credentials.yml` (or kubectl create `pvc-backup-r2` /
-  `appflowy-walg-r2` per `infrastructure/backup/README.md`).
-  Blocker 2026-07-29: `create-r2-credentials.yml` → API **10000 Authentication error**.
-- [ ] `OPEN` After secrets land: apply CronJobs + WAL-G ConfigMap; smoke a
-  `pvc-backup-appflowy` Job.
+- [x] `DONE` Provision R2 S3 API credentials + cluster secrets (2026-07-29).
+  Derived Access Key ID / Secret from User API Token with R2 Storage R/W on account
+  `fb7dc7b69b662480cd5961a4d1913c78` (SHA-256 of token value per Cloudflare R2 docs).
+  Applied `pvc-backup-r2` in appflowy/espocrm/postiz/n8n + `appflowy-walg-r2` +
+  `appflowy-walg-env`. Stored `CF_R2_*` + corrected `CF_ACCOUNT_ID` in GitHub secrets.
+- [x] `DONE` Smoke PVC backup Job to R2.
+  Proof: `pvc-backup-appflowy` Job Completed; uploaded **1178437** bytes to
+  `r2://datalake-bucket/pvc-backups/appflowy/daily/2026-07-29T170155Z.sql.custom`.
 ## LinkedIn CAPI finalization
 
 - [x] `DONE` Verify/wire `li_fat_id` capture path in code flow.
@@ -123,7 +125,7 @@ Issue template: `.github/ISSUE_TEMPLATE/ops-cadence.yml`.
 - **Migrate off AWS → Cloudflare.** Prefer Workers / R2 / D1 / Access / Tunnel over expanding SSM, S3, Lambda, Athena, Cognito, etc.
 - **Do not install AWS CLI or AWS SDK** for agent/operator work on this repo; use Cloudflare tooling and existing in-repo paths instead.
 - AWS-backed roadmap items (old R16→S3, R20→AWS, R24 secondary region) are
-  **legacy** — R16 + R10 retargeted to R2 in-repo; apply blocked on R2 API token.
+  **legacy** — R16 + R10 live on R2 (2026-07-29 smoke: 1.1 MiB AppFlowy dump).
 
 ## Notes
 

--- a/infrastructure/appflowy/walg-sidecar.yaml
+++ b/infrastructure/appflowy/walg-sidecar.yaml
@@ -41,7 +41,7 @@ metadata:
     app.kubernetes.io/part-of: appflowy
 data:
   # Cloudflare account id (same as CF_ACCOUNT_ID / wrangler account_id).
-  AWS_ENDPOINT: "https://c6d6b805741159c062a3e0b0d7f9d89a.r2.cloudflarestorage.com"
+  AWS_ENDPOINT: "https://fb7dc7b69b662480cd5961a4d1913c78.r2.cloudflarestorage.com"
   AWS_REGION: "auto"
   AWS_S3_FORCE_PATH_STYLE: "true"
   WALG_S3_PREFIX: "s3://datalake-bucket/appflowy-wal/wal/"

--- a/infrastructure/backup/README.md
+++ b/infrastructure/backup/README.md
@@ -20,9 +20,16 @@ Schedules staggered 15 min apart.
 
 ## Credentials (Cloudflare R2)
 
-1. In Cloudflare Dashboard → R2 → Manage R2 API Tokens → create a token with
-   Object Read & Write on `datalake-bucket` (or account-wide).
-2. Store into each backup namespace (and AppFlowy WAL-G if enabling R16):
+Account ID: `fb7dc7b69b662480cd5961a4d1913c78`  
+Endpoint: `https://fb7dc7b69b662480cd5961a4d1913c78.r2.cloudflarestorage.com`  
+Bucket: `datalake-bucket`
+
+**Preferred (API):** dispatch `create-r2-credentials.yml` with `confirm=create`.
+It mints a User API token with R2 Storage R/W and derives S3 keys as
+`Access Key ID = token id`, `Secret = SHA-256(token value)` (Cloudflare R2 docs).
+
+**Dashboard:** R2 → Manage API Tokens → Object Read & Write on `datalake-bucket`,
+then `store-r2-backup-credentials.yml` or:
 
 ```bash
 # From a machine with kubectl (no AWS CLI):
@@ -33,20 +40,12 @@ for ns in appflowy espocrm postiz n8n; do
     --dry-run=client -o yaml | kubectl apply -f -
 done
 
-# Optional: same token for AppFlowy continuous WAL (R16)
 kubectl -n appflowy create secret generic appflowy-walg-r2 \
   --from-literal=AWS_ACCESS_KEY_ID='…' \
   --from-literal=AWS_SECRET_ACCESS_KEY='…' \
   --dry-run=client -o yaml | kubectl apply -f -
 kubectl apply -f infrastructure/appflowy/walg-sidecar.yaml
 ```
-
-Or dispatch `.github/workflows/store-r2-backup-credentials.yml` with the two
-values (writes GitHub secrets + optional cluster patch via `KUBECONFIG_B64`).
-
-`create-r2-credentials.yml` can mint tokens only when `CLOUDFLARE_API_TOKEN`
-has R2 permission (currently returns auth error until token is rotated with
-R2 scopes).
 
 ## Deploy CronJobs
 

--- a/infrastructure/backup/cronjob-appflowy.yaml
+++ b/infrastructure/backup/cronjob-appflowy.yaml
@@ -56,7 +56,7 @@ spec:
                       name: pvc-backup-r2
                       key: SECRET_ACCESS_KEY
                 - name: R2_ENDPOINT
-                  value: "https://c6d6b805741159c062a3e0b0d7f9d89a.r2.cloudflarestorage.com"
+                  value: "https://fb7dc7b69b662480cd5961a4d1913c78.r2.cloudflarestorage.com"
                 - name: R2_BUCKET
                   value: "datalake-bucket"
               command:

--- a/infrastructure/backup/cronjob-espocrm.yaml
+++ b/infrastructure/backup/cronjob-espocrm.yaml
@@ -51,7 +51,7 @@ spec:
                       name: pvc-backup-r2
                       key: SECRET_ACCESS_KEY
                 - name: R2_ENDPOINT
-                  value: "https://c6d6b805741159c062a3e0b0d7f9d89a.r2.cloudflarestorage.com"
+                  value: "https://fb7dc7b69b662480cd5961a4d1913c78.r2.cloudflarestorage.com"
                 - name: R2_BUCKET
                   value: "datalake-bucket"
               command:

--- a/infrastructure/backup/cronjob-n8n.yaml
+++ b/infrastructure/backup/cronjob-n8n.yaml
@@ -38,7 +38,7 @@ spec:
                       name: pvc-backup-r2
                       key: SECRET_ACCESS_KEY
                 - name: R2_ENDPOINT
-                  value: "https://c6d6b805741159c062a3e0b0d7f9d89a.r2.cloudflarestorage.com"
+                  value: "https://fb7dc7b69b662480cd5961a4d1913c78.r2.cloudflarestorage.com"
                 - name: R2_BUCKET
                   value: "datalake-bucket"
               command:

--- a/infrastructure/backup/cronjob-postiz.yaml
+++ b/infrastructure/backup/cronjob-postiz.yaml
@@ -48,7 +48,7 @@ spec:
                       name: pvc-backup-r2
                       key: SECRET_ACCESS_KEY
                 - name: R2_ENDPOINT
-                  value: "https://c6d6b805741159c062a3e0b0d7f9d89a.r2.cloudflarestorage.com"
+                  value: "https://fb7dc7b69b662480cd5961a4d1913c78.r2.cloudflarestorage.com"
                 - name: R2_BUCKET
                   value: "datalake-bucket"
               command:

--- a/infrastructure/backup/r2-config.yaml
+++ b/infrastructure/backup/r2-config.yaml
@@ -14,6 +14,6 @@ metadata:
     app.kubernetes.io/name: pvc-backup
     app.kubernetes.io/component: r2-config
 data:
-  R2_ENDPOINT: "https://c6d6b805741159c062a3e0b0d7f9d89a.r2.cloudflarestorage.com"
+  R2_ENDPOINT: "https://fb7dc7b69b662480cd5961a4d1913c78.r2.cloudflarestorage.com"
   R2_BUCKET: "datalake-bucket"
   R2_REGION: "auto"


### PR DESCRIPTION
## Summary
- Correct R2 account ID to \`fb7dc7b69b662480cd5961a4d1913c78\`.
- Mint/store R2 S3 credentials (User API token → Access Key ID + SHA-256 secret).
- Apply \`pvc-backup-r2\` / \`appflowy-walg-r2\` + CronJobs; smoke Job uploaded ~1.1 MiB AppFlowy dump.
- Rewrite \`create-r2-credentials.yml\` to the working mint path.

## Test plan
- [x] rclone smoke to \`datalake-bucket/pvc-backups/_smoke/\`
- [x] \`pvc-backup-appflowy\` Job Completed (1178437 bytes)
- [x] \`CF_R2_*\` + \`CF_ACCOUNT_ID\` present in GitHub secrets

Made with [Cursor](https://cursor.com)