### PR TITLE
ops: AppFlowy R2 basebackup via pg_dump+rclone

### DIFF
--- a/docs/current-source-of-truth-checklist.md
+++ b/docs/current-source-of-truth-checklist.md
@@ -80,8 +80,10 @@ Runbook: [`docs/operator-blockers-runbook.md`](operator-blockers-runbook.md).
   Continuous `archive_command` **live** (2026-07-29): rclone →
   `r2://datalake-bucket/appflowy-wal/wal/` (`archive_command=/walg-bin/archive.sh %p %f`
   in `k8s/appflowy.yaml`). Re-test same day: `pg_switch_wal` → `archived_count`
-  advanced; objects `00000001…017` listed in R2. Daily basebackup CronJob uses
-  `pg_basebackup` + rclone → `appflowy-wal/base/` (wal-g push hangs on omv).
+  advanced; objects `00000001…017` listed in R2. Daily CronJob uses
+  `pg_dump -Fc` + rclone → `appflowy-wal/base/` (wal-g hang + `pg_basebackup`
+  blocked by replication HBA on omv). Smoke 2026-07-29:
+  `postgres-20260729T182641Z.dump` uploaded; re-verify `20260729T182822Z` OK.
   Never set `WALG_LOG_LEVEL=INFO` (only NORMAL|DEVEL|ERROR). Do not apply empty
   Secret stubs from `walg-sidecar.yaml` (wipes live R2 keys).
 - [x] `DONE` R23 Resend pilot for order confirmations.

--- a/infrastructure/appflowy/walg-sidecar.yaml
+++ b/infrastructure/appflowy/walg-sidecar.yaml
@@ -1,35 +1,13 @@
-# R16 → Cloudflare R2: AppFlowy WAL-G continuous backup (S3-compatible API).
+# R16 → Cloudflare R2: continuous WAL (rclone in k8s/appflowy.yaml) + daily dump.
 #
-# Do NOT use AWS S3 / AWS CLI / SSM AWS keys. Create an R2 API token
-# (Cloudflare dashboard or create-r2-credentials.yml) with write access to
-# datalake-bucket, then:
+# Create the secret once (never kubectl-apply empty stubs — that wipes live keys):
 #
 #   kubectl -n appflowy create secret generic appflowy-walg-r2 \
 #     --from-literal=AWS_ACCESS_KEY_ID='<r2_access_key_id>' \
-#     --from-literal=AWS_SECRET_ACCESS_KEY='<r2_secret_access_key>'
+#     --from-literal=AWS_SECRET_ACCESS_KEY='<r2_secret_access_key>' \
+#     --dry-run=client -o yaml | kubectl apply -f -
 #
-# Env var names stay AWS_* because WAL-G's S3 client expects them; values
-# are Cloudflare R2 credentials. Set AWS_ENDPOINT to the account R2 URL.
-#
-# Apply ConfigMap + CronJob, then ensure postgres Deployment matches
-# infrastructure/appflowy/k8s/appflowy.yaml (WALG_* + AWS_ENDPOINT).
-#
-# RPO target: ~5 min (archive_timeout=300)
----
-apiVersion: v1
-kind: Secret
-metadata:
-  name: appflowy-walg-r2
-  namespace: appflowy
-  labels:
-    app.kubernetes.io/component: walg
-    app.kubernetes.io/part-of: appflowy
-type: Opaque
-stringData:
-  # Populate from Cloudflare R2 API token — do not commit real values.
-  # Keys are S3-API compatible names used by wal-g (not AWS IAM).
-  AWS_ACCESS_KEY_ID: ""
-  AWS_SECRET_ACCESS_KEY: ""
+# RPO target: ~5 min (archive_timeout=300 on postgres Deployment).
 ---
 apiVersion: v1
 kind: ConfigMap
@@ -40,16 +18,17 @@ metadata:
     app.kubernetes.io/component: walg
     app.kubernetes.io/part-of: appflowy
 data:
-  # Cloudflare account id (same as CF_ACCOUNT_ID / wrangler account_id).
   AWS_ENDPOINT: "https://fb7dc7b69b662480cd5961a4d1913c78.r2.cloudflarestorage.com"
   AWS_REGION: "auto"
   AWS_S3_FORCE_PATH_STYLE: "true"
+  AWS_EC2_METADATA_DISABLED: "true"
   WALG_S3_PREFIX: "s3://datalake-bucket/appflowy-wal/wal/"
-  WALG_UPLOAD_CONCURRENCY: "2"
+  WALG_UPLOAD_CONCURRENCY: "1"
   WALG_SENTINEL_NAME: "appflowy-postgres-production"
   PGDATA: "/var/lib/postgresql/data/pgdata"
 ---
-# Optional CronJob: base backup once daily (WAL streaming is continuous via sidecar).
+# Daily logical base via pg_dump -Fc + rclone (pg_basebackup needs replication HBA;
+# wal-g hangs to R2 on omv). Continuous WAL segments land under appflowy-wal/wal/.
 apiVersion: batch/v1
 kind: CronJob
 metadata:
@@ -73,17 +52,39 @@ spec:
           restartPolicy: OnFailure
           containers:
             - name: walg-backup
-              image: ghcr.io/wal-g/wal-g:v3.0.3
+              image: alpine:3.20
               command: ["/bin/sh", "-c"]
               args:
                 - |
                   set -euo pipefail
+                  apk add --no-cache curl ca-certificates unzip postgresql16-client >/dev/null
+                  ARCH=$(uname -m)
+                  case "$ARCH" in
+                    aarch64|arm64) RCLONE_ARCH=arm64 ;;
+                    x86_64|amd64) RCLONE_ARCH=amd64 ;;
+                    *) echo "unsupported arch: $ARCH"; exit 1 ;;
+                  esac
+                  RCLONE_VER=v1.69.1
+                  curl -fsSL -o /tmp/rclone.zip \
+                    "https://github.com/rclone/rclone/releases/download/${RCLONE_VER}/rclone-${RCLONE_VER}-linux-${RCLONE_ARCH}.zip"
+                  unzip -qo /tmp/rclone.zip -d /tmp
+                  install -m 755 "/tmp/rclone-${RCLONE_VER}-linux-${RCLONE_ARCH}/rclone" /usr/local/bin/rclone
                   export PGHOST=postgres.appflowy.svc.cluster.local
                   export PGPORT=5432
                   export PGUSER=postgres
                   export PGPASSWORD="${POSTGRES_PASSWORD}"
-                  export PGDATABASE=postgres
-                  wal-g backup-push "${PGDATA}"
+                  STAMP=$(date -u +%Y%m%dT%H%M%SZ)
+                  OUT=/tmp/basebackup
+                  mkdir -p "$OUT"
+                  pg_dump -Fc -f "$OUT/postgres-${STAMP}.dump" postgres
+                  export RCLONE_CONFIG_R2_TYPE=s3 RCLONE_CONFIG_R2_PROVIDER=Cloudflare
+                  export RCLONE_CONFIG_R2_ACCESS_KEY_ID="$AWS_ACCESS_KEY_ID"
+                  export RCLONE_CONFIG_R2_SECRET_ACCESS_KEY="$AWS_SECRET_ACCESS_KEY"
+                  export RCLONE_CONFIG_R2_ENDPOINT="$AWS_ENDPOINT" RCLONE_CONFIG_R2_REGION=auto
+                  export RCLONE_CONFIG_R2_NO_CHECK_BUCKET=true
+                  rclone copy "$OUT" "r2:datalake-bucket/appflowy-wal/base/${STAMP}/"
+                  echo "uploaded basebackup ${STAMP}"
+                  rclone lsf "r2:datalake-bucket/appflowy-wal/base/${STAMP}/"
               envFrom:
                 - configMapRef:
                     name: appflowy-walg-env
@@ -95,18 +96,10 @@ spec:
                     secretKeyRef:
                       name: appflowy-secrets
                       key: POSTGRES_PASSWORD
-              volumeMounts:
-                - name: data
-                  mountPath: /var/lib/postgresql/data
-                  readOnly: true
               resources:
                 requests:
-                  cpu: 25m
-                  memory: 64Mi
+                  cpu: 50m
+                  memory: 128Mi
                 limits:
-                  cpu: 200m
-                  memory: 256Mi
-          volumes:
-            - name: data
-              persistentVolumeClaim:
-                claimName: appflowy-postgres
+                  cpu: 500m
+                  memory: 512Mi


### PR DESCRIPTION
## Summary
- Replace failing wal-g / `pg_basebackup` daily CronJob with `pg_dump -Fc` + rclone → `appflowy-wal/base/`
- Remove empty Secret stub that wiped live `appflowy-walg-r2` keys on apply
- Checklist evidence updated; live smoke `VERIFY_OK` (`postgres-20260729T182822Z.dump`)

## Test plan
- [x] `kubectl create job … --from=cronjob/appflowy-walg-basebackup` → Succeeded
- [x] Continuous WAL archive still advancing (`archived_count`, `failed_count=0`)
- [x] `appflowy-walg-r2` secret non-empty after apply of ConfigMap+CronJob only


Made with [Cursor](https://cursor.com)