### PR TITLE
fix: clear D1-auth CI failures (lint, unit, sonar)

### DIFF
--- a/__tests__/auth-context-provider.test.tsx
+++ b/__tests__/auth-context-provider.test.tsx
@@ -96,11 +96,24 @@ describe("AuthContext provider handoff", () => {
     );
   });
 
-  it("default (no provider set): signIn hands off to the cognito provider", async () => {
+  it("default (no provider set): signIn posts to D1 /api/auth/login", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        ok: true,
+        user: { id: "u1", email: "e@x.com" },
+        isAdmin: false,
+      }),
+    });
+    vi.stubGlobal("fetch", fetchMock);
     const get = await mountWith(undefined);
     await act(async () => {
       await get().signIn("e@x.com", "pw");
     });
-    expect(signInMock).toHaveBeenCalledWith("cognito", expect.objectContaining({ redirect: true }));
+    expect(signInMock).not.toHaveBeenCalled();
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/api/auth/login",
+      expect.objectContaining({ method: "POST" })
+    );
   });
 });

--- a/__tests__/auth-public-a11y.test.tsx
+++ b/__tests__/auth-public-a11y.test.tsx
@@ -59,8 +59,11 @@ describe("auth/public accessibility", () => {
   it("login page exposes labeled, autocomplete-enabled credentials fields", () => {
     render(<LoginPage />);
 
-    const kcButton = screen.getByRole("button", { name: /continue with aws/i });
-    expect(kcButton).toBeTruthy();
+    const email = screen.getByLabelText("Email") as HTMLInputElement;
+    const password = screen.getByLabelText("Password") as HTMLInputElement;
+    expect(email.autocomplete).toBe("email");
+    expect(password.autocomplete).toBe("current-password");
+    expect(screen.getByRole("button", { name: /sign in/i })).toBeTruthy();
   });
 
   it("signup page exposes verification-safe fields and password constraints", () => {

--- a/__tests__/fetch-with-auth.test.ts
+++ b/__tests__/fetch-with-auth.test.ts
@@ -1,5 +1,4 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { clearSessionCache } from "@/lib/fetch-with-auth";
 
 const mockGetSession = vi.fn();
 
@@ -13,36 +12,36 @@ vi.mock("next-auth/react", () => ({
 
 describe("fetch-with-auth.ts", () => {
   beforeEach(() => {
-    vi.clearAllMocks();
-    vi.stubGlobal("fetch", vi.fn());
-    // Reset the module-level session cache so each test starts fresh.
-    clearSessionCache();
+    vi.resetModules();
+    mockGetSession.mockReset();
+    mockGetSession.mockResolvedValue(null);
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(new globalThis.Response("{}", { status: 200 })));
+    delete process.env.NEXT_PUBLIC_AUTH_PROVIDER;
   });
 
-  it("calls fetch without Authorization when no session", async () => {
-    mockGetSession.mockResolvedValueOnce(null);
-    vi.mocked(globalThis.fetch).mockResolvedValueOnce(
-      new globalThis.Response("{}", { status: 200 })
-    );
+  it("D1 mode: skips getSession and does not attach Authorization", async () => {
+    mockGetSession.mockResolvedValue({ idToken: "should-not-attach" });
 
-    const { fetchWithAuth } = await import("@/lib/fetch-with-auth");
+    const { fetchWithAuth, clearSessionCache } = await import("@/lib/fetch-with-auth");
+    clearSessionCache();
     await fetchWithAuth("/api/test");
 
+    expect(mockGetSession).not.toHaveBeenCalled();
     expect(globalThis.fetch).toHaveBeenCalledWith(
       "/api/test",
       expect.objectContaining({
+        credentials: "same-origin",
         headers: expect.not.objectContaining({ Authorization: expect.anything() }),
       })
     );
   });
 
-  it("calls fetch with Authorization header when session has idToken", async () => {
-    mockGetSession.mockResolvedValueOnce({ idToken: "test-token-abc" });
-    vi.mocked(globalThis.fetch).mockResolvedValueOnce(
-      new globalThis.Response(JSON.stringify({ ok: true }), { status: 200 })
-    );
+  it("cognito: calls fetch with Authorization header when session has idToken", async () => {
+    process.env.NEXT_PUBLIC_AUTH_PROVIDER = "cognito";
+    mockGetSession.mockResolvedValue({ idToken: "test-token-abc" });
 
-    const { fetchWithAuth } = await import("@/lib/fetch-with-auth");
+    const { fetchWithAuth, clearSessionCache } = await import("@/lib/fetch-with-auth");
+    clearSessionCache();
     const res = await fetchWithAuth("/api/admin/data");
 
     expect(globalThis.fetch).toHaveBeenCalledWith(
@@ -54,13 +53,12 @@ describe("fetch-with-auth.ts", () => {
     expect(res.status).toBe(200);
   });
 
-  it("merges existing headers with the Authorization header", async () => {
-    mockGetSession.mockResolvedValueOnce({ idToken: "tok" });
-    vi.mocked(globalThis.fetch).mockResolvedValueOnce(
-      new globalThis.Response("{}", { status: 200 })
-    );
+  it("cognito: merges existing headers with the Authorization header", async () => {
+    process.env.NEXT_PUBLIC_AUTH_PROVIDER = "cognito";
+    mockGetSession.mockResolvedValue({ idToken: "tok" });
 
-    const { fetchWithAuth } = await import("@/lib/fetch-with-auth");
+    const { fetchWithAuth, clearSessionCache } = await import("@/lib/fetch-with-auth");
+    clearSessionCache();
     await fetchWithAuth("/api/test", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
@@ -78,15 +76,20 @@ describe("fetch-with-auth.ts", () => {
     );
   });
 
-  it("still calls fetch when getSession returns session without idToken", async () => {
-    mockGetSession.mockResolvedValueOnce({ user: { email: "a@b.com" } });
-    vi.mocked(globalThis.fetch).mockResolvedValueOnce(
-      new globalThis.Response("{}", { status: 200 })
-    );
+  it("cognito: still calls fetch when getSession returns session without idToken", async () => {
+    process.env.NEXT_PUBLIC_AUTH_PROVIDER = "cognito";
+    mockGetSession.mockResolvedValue({ user: { email: "a@b.com" } });
 
-    const { fetchWithAuth } = await import("@/lib/fetch-with-auth");
+    const { fetchWithAuth, clearSessionCache } = await import("@/lib/fetch-with-auth");
+    clearSessionCache();
     const res = await fetchWithAuth("/api/public");
 
     expect(res.status).toBe(200);
+    expect(globalThis.fetch).toHaveBeenCalledWith(
+      "/api/public",
+      expect.objectContaining({
+        headers: expect.not.objectContaining({ Authorization: expect.anything() }),
+      })
+    );
   });
 });

--- a/src/components/store/StoreGrid.tsx
+++ b/src/components/store/StoreGrid.tsx
@@ -20,6 +20,7 @@ type SortOption = "default" | "price-asc" | "price-desc" | "name-asc";
 
 const SEARCH_DEBOUNCE_MS = 250;
 const SEARCH_LIMIT = 20;
+const LOCAL_FALLBACK_SOURCE = "local-fallback";
 
 const sortLabels: Record<SortOption, string> = {
   default: "Featured",
@@ -111,10 +112,7 @@ function ProductCard({
 
       {/* Content */}
       <div className="p-6">
-        <Link
-          href={`/store/${product.id}`}
-          onClick={() => onNavigate?.(product.id)}
-        >
+        <Link href={`/store/${product.id}`} onClick={() => onNavigate?.(product.id)}>
           <h3 className="font-heading group-hover:text-neon-cyan text-lg font-semibold text-white transition-colors">
             {product.name}
           </h3>
@@ -186,8 +184,8 @@ export default function StoreGrid() {
         .catch((err: unknown) => {
           if (controller.signal.aborted) return;
           console.warn("[StoreGrid] /api/search failed; using local keyword filter:", err);
-          setSemanticSearch({ query: q, hitIds: null, source: "local-fallback" });
-          trackFunnelEvent("search_query", { query: q, source: "local-fallback" });
+          setSemanticSearch({ query: q, hitIds: null, source: LOCAL_FALLBACK_SOURCE });
+          trackFunnelEvent("search_query", { query: q, source: LOCAL_FALLBACK_SOURCE });
         });
     }, SEARCH_DEBOUNCE_MS);
 
@@ -198,10 +196,8 @@ export default function StoreGrid() {
   }, [searchQuery]);
 
   const qTrim = searchQuery.trim();
-  const semanticHitIds =
-    semanticSearch.query === qTrim ? semanticSearch.hitIds : null;
-  const searchSource =
-    semanticSearch.query === qTrim ? semanticSearch.source : null;
+  const semanticHitIds = semanticSearch.query === qTrim ? semanticSearch.hitIds : null;
+  const searchSource = semanticSearch.query === qTrim ? semanticSearch.source : null;
 
   const filtered = useMemo(() => {
     let products =
@@ -239,7 +235,7 @@ export default function StoreGrid() {
     trackFunnelEvent("search_click", {
       query: q,
       product_id: productId,
-      source: searchSource ?? "local-fallback",
+      source: searchSource ?? LOCAL_FALLBACK_SOURCE,
     });
   }
 

--- a/src/lib/api-auth.ts
+++ b/src/lib/api-auth.ts
@@ -73,6 +73,8 @@ type AuthSuccess = { ok: true; user: DecodedToken };
 type AuthError = { ok: false; response: NextResponse };
 export type AuthResult = AuthSuccess | AuthError;
 
+const ADMIN_GROUP = "admin";
+
 /** Extract a JWT from the Authorization header (Bearer scheme). */
 export function getTokenFromHeader(request: NextRequest): string | null {
   const authHeader = request.headers.get("authorization");
@@ -119,7 +121,7 @@ async function resolveD1Session(sessionId: string): Promise<DecodedToken | null>
       email: user.email,
       name: user.name ?? undefined,
       email_verified: true,
-      groups: admin ? ["admin"] : [],
+      groups: admin ? [ADMIN_GROUP] : [],
     };
   } catch {
     return null;
@@ -196,31 +198,74 @@ export function isAdmin(decoded: DecodedToken | undefined | null): boolean {
   // Group membership: Cognito `cognito:groups`. Legacy `groups` claim is still
   // honoured for the session-cookie path, which projects them to the same key.
   const groups = [...(decoded.groups ?? []), ...(decoded["cognito:groups"] ?? [])];
-  if (groups.includes("admin")) return true;
+  if (groups.includes(ADMIN_GROUP)) return true;
   const roles = decoded.realm_access?.roles ?? [];
-  return roles.includes("admin") || roles.includes("realm:admin");
+  return roles.includes(ADMIN_GROUP) || roles.includes("realm:admin");
+}
+
+/**
+ * Authenticate a request that carries a Bearer token. Returns an AuthResult
+ * on a definitive pass/fail, or `null` to signal "fall through to cookie auth".
+ *
+ * Cognito mode: full RS256/JWKS verification; any failure → 401.
+ * D1 mode: prefer the session_token cookie first (guards against stale
+ *   Cognito JWTs), then treat Bearer as an opaque D1 session id.
+ *   Non-production only: fall back to unsigned JWT decode for unit tests.
+ */
+async function authenticateBearer(
+  request: NextRequest,
+  token: string,
+): Promise<AuthResult | null> {
+  if (isCognitoAuthEnabled()) {
+    const decoded = await verifyToken(token);
+    if (decoded) return { ok: true, user: decoded };
+    return {
+      ok: false,
+      response: NextResponse.json(
+        { error: "Invalid or expired token" },
+        { status: 401 },
+      ),
+    };
+  }
+
+  // D1 mode: prefer session cookie over a leftover Cognito JWT Bearer.
+  const d1CookieFirst = await readD1SessionCookie(request);
+  if (d1CookieFirst) return { ok: true, user: d1CookieFirst };
+
+  // Opaque session id in Authorization (API clients).
+  const bearerD1 = await resolveD1Session(token);
+  if (bearerD1) return { ok: true, user: bearerD1 };
+
+  // Non-production: allow unsigned JWT decode (unit tests clear COGNITO_ISSUER
+  // and send fake-sig tokens). Production never takes this path without JWKS.
+  if (process.env.NODE_ENV !== "production") {
+    const decoded = await verifyToken(token);
+    if (decoded) return { ok: true, user: decoded };
+    return {
+      ok: false,
+      response: NextResponse.json(
+        { error: "Invalid or expired token" },
+        { status: 401 },
+      ),
+    };
+  }
+
+  return null;
 }
 
 /**
  * Require authentication. Tries:
  *   1. Bearer token in Authorization header (fetchWithAuth, external callers)
- *   2. next-auth session cookie (browser same-origin without Bearer)
+ *   2. D1 session_token cookie (email/password login)
+ *   3. next-auth session cookie — Cognito Hosted UI (cognito provider only)
  * Returns user or 401.
- *
- * Bearer is checked first because all admin page JS sends it via
- * fetchWithAuth, and it carries the full Cognito JWT with groups.
- * The session cookie fallback handles edge cases where the browser hits
- * an API route directly (e.g. form action, link).
  */
 export async function requireAuth(request: NextRequest): Promise<AuthResult> {
   // E2E test bypass: only active when BOTH NEXT_PUBLIC_E2E=1 AND a matching
   // E2E_ADMIN_TOKEN env var are configured AND the Bearer token matches.
   // Belt-and-braces: also require NODE_ENV !== "production" so this is
   // physically dead code in prod even if env vars are misconfigured (fix #25).
-  if (
-    process.env.NEXT_PUBLIC_E2E === "1" &&
-    process.env.E2E_ADMIN_TOKEN
-  ) {
+  if (process.env.NEXT_PUBLIC_E2E === "1" && process.env.E2E_ADMIN_TOKEN) {
     const e2eToken = getTokenFromHeader(request);
     if (e2eToken && e2eToken === process.env.E2E_ADMIN_TOKEN) {
       return {
@@ -228,7 +273,7 @@ export async function requireAuth(request: NextRequest): Promise<AuthResult> {
         user: {
           sub: "e2e-admin",
           email: "e2e-admin@cloudless.test",
-          "cognito:groups": ["admin"],
+          "cognito:groups": [ADMIN_GROUP],
         } as DecodedToken,
       };
     }
@@ -248,61 +293,18 @@ export async function requireAuth(request: NextRequest): Promise<AuthResult> {
 
   const token = getTokenFromHeader(request);
   if (token) {
-    if (isCognitoAuthEnabled()) {
-      const decoded = await verifyToken(token);
-      if (decoded) {
-        return { ok: true, user: decoded };
-      }
-      return {
-        ok: false,
-        response: NextResponse.json(
-          { error: "Invalid or expired token" },
-          { status: 401 },
-        ),
-      };
-    }
-
-    // D1 mode: prefer session cookie over a leftover Cognito JWT Bearer.
-    const d1CookieFirst = await readD1SessionCookie(request);
-    if (d1CookieFirst) {
-      return { ok: true, user: d1CookieFirst };
-    }
-
-    // Opaque session id in Authorization (API clients).
-    const bearerD1 = await resolveD1Session(token);
-    if (bearerD1) {
-      return { ok: true, user: bearerD1 };
-    }
-
-    // Non-production: allow unsigned JWT decode (unit tests clear COGNITO_ISSUER
-    // and send fake-sig tokens). Production never takes this path without JWKS.
-    if (process.env.NODE_ENV !== "production") {
-      const decoded = await verifyToken(token);
-      if (decoded) {
-        return { ok: true, user: decoded };
-      }
-      return {
-        ok: false,
-        response: NextResponse.json(
-          { error: "Invalid or expired token" },
-          { status: 401 },
-        ),
-      };
-    }
+    const bearerResult = await authenticateBearer(request, token);
+    if (bearerResult) return bearerResult;
   }
 
   // Cloudflare D1 session_token (email/password login)
   const d1User = await readD1SessionCookie(request);
-  if (d1User) {
-    return { ok: true, user: d1User };
-  }
+  if (d1User) return { ok: true, user: d1User };
 
   // next-auth / Cognito Hosted UI — only when Cognito is the active provider
   if (isCognitoAuthEnabled()) {
     const sessionUser = await readSessionCookie();
-    if (sessionUser) {
-      return { ok: true, user: sessionUser };
-    }
+    if (sessionUser) return { ok: true, user: sessionUser };
   }
 
   return {

--- a/src/lib/fetch-with-auth.ts
+++ b/src/lib/fetch-with-auth.ts
@@ -15,8 +15,7 @@
 
 import { getSession } from "next-auth/react";
 
-const CACHE_TTL_MS =
-  process.env.VITEST === "true" || process.env.NODE_ENV === "test" ? 0 : 5000;
+const CACHE_TTL_MS = process.env.VITEST === "true" || process.env.NODE_ENV === "test" ? 0 : 5000;
 
 /** Read at call time so Vitest can toggle NEXT_PUBLIC_AUTH_PROVIDER per test. */
 function cognitoBearerEnabled(): boolean {

--- a/src/lib/fetch-with-auth.ts
+++ b/src/lib/fetch-with-auth.ts
@@ -15,8 +15,13 @@
 
 import { getSession } from "next-auth/react";
 
-const USE_COGNITO = process.env.NEXT_PUBLIC_AUTH_PROVIDER === "cognito";
-const CACHE_TTL_MS = 5000;
+const CACHE_TTL_MS =
+  process.env.VITEST === "true" || process.env.NODE_ENV === "test" ? 0 : 5000;
+
+/** Read at call time so Vitest can toggle NEXT_PUBLIC_AUTH_PROVIDER per test. */
+function cognitoBearerEnabled(): boolean {
+  return process.env.NEXT_PUBLIC_AUTH_PROVIDER === "cognito";
+}
 
 let cachedSession: {
   value: Awaited<ReturnType<typeof getSession>>;
@@ -43,7 +48,7 @@ export async function fetchWithAuth(url: string, init?: RequestInit): Promise<Re
     ...((init?.headers as Record<string, string>) || {}),
   };
 
-  if (USE_COGNITO) {
+  if (cognitoBearerEnabled()) {
     const session = await getCachedSession();
     const idToken = session?.idToken;
     if (idToken) {


### PR DESCRIPTION
## Summary
- Align auth unit/a11y tests with D1-default login (no Cognito handoff).
- Make `fetchWithAuth` read `NEXT_PUBLIC_AUTH_PROVIDER` at call time and skip session cache under Vitest.
- Extract Bearer/admin helpers in `api-auth` for Sonar maintainability; prettier StoreGrid.

## Test plan
- [x] `vitest` auth-context / auth-public-a11y / fetch-with-auth — 12 passed
- [x] eslint + prettier on touched files
- [ ] CI Lint & Format / Unit Tests green


Made with [Cursor](https://cursor.com)