### PR TITLE
style: fix Prettier drift + refresh ACTIONS-REQUIRED

### DIFF
--- a/ACTIONS-REQUIRED.md
+++ b/ACTIONS-REQUIRED.md
@@ -2,235 +2,83 @@
 
 # Generated: 2026-07-19 16:44 UTC
 
-# Last Updated: 2026-07-28 00:47 EEST - Updated for current secret state
+# Last Updated: 2026-07-29 21:40 EEST — R2 + account secrets verified set
 
 ---
 
-## 🔴 CRITICAL: Missing GitHub Secrets Blocking Deployments
+## ✅ GitHub secrets (verified 2026-07-29)
 
-### Workflows Currently Failing
+| Secret | Status | Purpose |
+|--------|--------|---------|
+| `CLOUDFLARE_API_TOKEN` | ✅ | Deploy, SST, CF APIs |
+| `CF_ACCOUNT_ID` | ✅ | Deploy, ETL (`fb7dc7b69b662480cd5961a4d1913c78`) |
+| `CLOUDFLARE_ACCOUNT_ID` | ✅ | Same account id (alias) |
+| `CLOUDFLARE_ZONE_ID` | ✅ | Custom domains |
+| `CF_R2_ACCESS_KEY_ID` | ✅ | R2 S3 API (ETL + backups) |
+| `CF_R2_SECRET_ACCESS_KEY` | ✅ | R2 S3 API |
 
-| Workflow | Status | Reason |
-|----------|--------|--------|
-| `sst-infra-deploy.yml` | ⚠️ PARTIAL | `CLOUDFLARE_API_TOKEN` ✅, `CF_ACCOUNT_ID` ✅ — only R2 creds missing for ETL steps |
-| `cloudflare-deploy.yml` | ✅ PASSING | All required secrets now set |
-| `etl-espocrm-to-r2.yml` | ❌ FAILING | Missing `CF_R2_ACCESS_KEY_ID`, `CF_R2_SECRET_ACCESS_KEY` |
-
----
-
-## ✅ COMPLETED (Secrets Already Set)
-
-The following GitHub secrets have been added as of 2026-07-28:
-
-| Secret | Added | Purpose |
-|--------|-------|---------|
-| `CLOUDFLARE_API_TOKEN` | ✅ ~1 day ago | Deploy, SST |
-| `CF_ACCOUNT_ID` | ✅ ~2 days ago | Deploy, ETL |
-| `CLOUDFLARE_ZONE_ID` | ✅ ~5 days ago | Custom domains |
+Cluster: `pvc-backup-r2` (appflowy/espocrm/postiz/n8n) + `appflowy-walg-r2` live.
+Smoke: AppFlowy PVC dump + continuous WAL + daily `pg_dump` CronJob → `datalake-bucket`.
 
 ---
 
-## ✅ IMMEDIATE ACTIONS REQUIRED
+## ⏳ Still needs operator (Wrangler / optional)
 
-### Step 1: Create R2 API Credentials (REQUIRED for ETL)
-
-**Time: 3 minutes**
-
-**Option A: Use the automated workflow**
-
-1. Go to: https://github.com/Themis128/cloudless.gr/actions/workflows/create-r2-credentials.yml
-2. Click **"Run workflow"**
-3. Type `create` in the confirmation field
-4. The workflow will create R2 service tokens and store them as GitHub secrets
-
-**Option B: Manual creation**
-
-1. Go to: https://dash.cloudflare.com/profile/api-tokens
-2. Click **"Create Token"**
-3. Select **"Edit Cloudflare Workers"** template (or create custom)
-4. Add R2 permissions if not included
-5. Click **"Continue to summary"** → **"Create Token"**
-6. Copy the token
-
-7. Add as TWO GitHub secrets:
-
-```
-Name:  CF_R2_ACCESS_KEY_ID
-Value: [your R2 access key ID]
-
-Name:  CF_R2_SECRET_ACCESS_KEY
-Value: [your R2 secret access key]
-```
-
-**Add at:** https://github.com/Themis128/cloudless.gr/settings/secrets/actions/new
-
----
-
-### Step 2: Set Wrangler Secrets for Workers Runtime (REQUIRED for Chat/Auth)
-
-**Time: 5 minutes**
-
-After the GitHub secrets are set, run these commands locally (or in a workflow) to sync them to Wrangler:
+### Wrangler secrets (Workers runtime)
 
 ```bash
-# Required for session signing
-echo "your-SESSION_SECRET-value" | npx wrangler secret put SESSION_SECRET --config wrangler.jsonc
-
-# Required for agent authentication
-echo "your-AGENT_AUTH_TOKEN-value" | npx wrangler secret put AGENT_AUTH_TOKEN --config wrangler.jsonc
-
-# Optional: Enable Gemini AI (Workers AI is free primary)
-echo "your-GEMINI_API_KEY" | npx wrangler secret put GEMINI_API_KEY --config wrangler.jsonc
+npx wrangler secret put SESSION_SECRET --config wrangler.jsonc
+npx wrangler secret put AGENT_AUTH_TOKEN --config wrangler.jsonc
+# optional Gemini fallback:
+npx wrangler secret put GEMINI_API_KEY --config wrangler.jsonc
 ```
 
----
+| Secret | Priority | Notes |
+|--------|----------|-------|
+| `SESSION_SECRET` | 🔴 | 32+ bytes; session signing |
+| `AGENT_AUTH_TOKEN` | 🔴 | Agent endpoints |
+| `GEMINI_API_KEY` | 🟡 | Workers AI works without it |
 
-## 📊 COMPLETE SECRET INVENTORY
+### Optional product features
 
-### ✅ Already Configured (GitHub)
-
-| Secret | GitHub | Wrangler | Purpose |
-|--------|--------|----------|---------|
-| `ESPOCRM_API_KEY` | ✅ | ✅ | EspoCRM API authentication |
-| `ESPOCRM_API_PASSWORD` | ✅ | ✅ | EspoCRM API password |
-| `SLACK_WEBHOOK_URL` | ✅ | ✅ | Slack notifications |
-| `POSTIZ_API_KEY` | ✅ | ✅ | Postiz social media |
-| `ADMIN_ALERT_SECRET` | ✅ | ✅ | Admin alerts |
-| `CRON_SECRET` | ✅ | ✅ | Cron job authorization |
-| `CLOUDFLARE_API_TOKEN` | ✅ | ❌ | Deploy, SST |
-| `CF_ACCOUNT_ID` | ✅ | ❌ | Deploy, ETL |
-| `CLOUDFLARE_ZONE_ID` | ✅ | ❌ | Custom domains |
-| `TS_CLIENT_ID` | ✅ | ❌ | Tailscale OAuth |
-| `TS_CLIENT_SECRET` | ✅ | ❌ | Tailscale OAuth |
-| `TS_AUTHKEY` | ✅ | ❌ | Tailscale auth |
-| `OMV_SSH_KEY` | ✅ | ❌ | OMV node SSH access |
-| `AWS_DEPLOY_ROLE_ARN` | ✅ | ❌ | AWS OIDC role |
-| `GOOGLE_CLIENT_EMAIL` | ✅ | ❌ | Calendar booking |
-| `GOOGLE_PRIVATE_KEY` | ✅ | ❌ | Calendar booking |
-| `GOOGLE_CALENDAR_ID` | ✅ | ❌ | Calendar booking |
-
-### ⏳ NEEDS GitHub Secret (Add via Settings → Secrets → Actions)
-
-| Secret | Required For | Priority | Notes |
-|--------|--------------|----------|-------|
-| `CF_R2_ACCESS_KEY_ID` | ETL workflows | 🔴 CRITICAL | Use `create-r2-credentials.yml` workflow or create manually |
-| `CF_R2_SECRET_ACCESS_KEY` | ETL workflows | 🔴 CRITICAL | Use `create-r2-credentials.yml` workflow or create manually |
-
-### ⏳ NEEDS Wrangler Secret (Run `npx wrangler secret put`)
-
-| Secret | Required For | Priority | Notes |
-|--------|--------------|----------|-------|
-| `SESSION_SECRET` | Auth, Sessions | 🔴 CRITICAL | 32+ bytes, secure random |
-| `AGENT_AUTH_TOKEN` | Agent endpoints | 🔴 CRITICAL | Secure random token |
-| `GEMINI_API_KEY` | Gemini AI fallback | 🟡 MEDIUM | Workers AI (free) works without it |
-
-### ✅ Optional (Only if Using Feature)
-
-| Secret | Purpose | Alternative |
-|--------|---------|-------------|
-| `NEXT_PUBLIC_LINKEDIN_PARTNER_ID` | LinkedIn ads | Leave empty if not using |
-| `NEXT_PUBLIC_META_PIXEL_ID` | Meta/Facebook ads | Leave empty if not using |
-| `SENTRY_AUTH_TOKEN` | Error tracking | Leave empty if not using |
-| `NEXT_PUBLIC_SENTRY_DSN` | Sentry client | Leave empty if not using |
-| `KUMA_PUSH_ETL_ESPOCRM` | ETL monitoring | Leave empty if not using |
-| `GH_PAT` | GitHub token rotation | Leave empty if not using |
+| Secret | Purpose |
+|--------|---------|
+| `NEXT_PUBLIC_LINKEDIN_PARTNER_ID` | LinkedIn ads |
+| `NEXT_PUBLIC_META_PIXEL_ID` | Meta ads |
+| `SENTRY_AUTH_TOKEN` / `NEXT_PUBLIC_SENTRY_DSN` | Error tracking |
+| `KUMA_PUSH_ETL_ESPOCRM` | ETL monitoring |
 
 ---
 
-## 🔧 VERIFICATION CHECKLIST
+## 🔧 Verification
 
-After adding all secrets, verify by triggering:
-
-1. **Deploy workflow:** Push to main branch or manually trigger `deploy.yml`
-2. **SST Infra:** Manually trigger `sst-infra-deploy.yml`
-3. **Cloudflare Deploy:** Manually trigger `cloudflare-deploy.yml`
-4. **ETL Workflow:** Manually trigger `etl-espocrm-to-r2.yml`
-5. **R2 Credentials:** Manually trigger `create-r2-credentials.yml`
-
-All workflows should complete successfully.
+1. `gh workflow run etl-espocrm-to-r2.yml` — should no longer fail on missing R2 keys
+2. `gh workflow run cloudflare-deploy.yml`
+3. Continuous WAL: `archived_count` advances, `failed_count=0` on AppFlowy postgres
+4. Daily CronJob `appflowy-walg-basebackup` at `30 2 * * *`
 
 ---
 
-## 📝 GOOGLE CALENDAR CONFIGURATION (Optional)
+## 📝 Google Calendar (optional)
 
-Calendar booking is **not required for core functionality**. The chat widget works without it.
-
-### To Enable Calendar Booking:
-
-**Option A: Wrangler Secrets (for Workers)**
-
-```bash
-# Get these from Google Cloud Console → IAM & Admin → Service Accounts
-npx wrangler secret put GOOGLE_CLIENT_EMAIL --config wrangler.jsonc
-# Value: your-service-account@project.iam.gserviceaccount.com
-
-npx wrangler secret put GOOGLE_PRIVATE_KEY --config wrangler.jsonc
-# Value: -----BEGIN PRIVATE KEY-----\n...\n-----END PRIVATE KEY----- (use actual \n characters)
-
-npx wrangler secret put GOOGLE_CALENDAR_ID --config wrangler.jsonc
-# Value: primary (default) or specific calendar ID
-```
-
-**Option B: D1 app_config Table (for k3s/ETL)**
-
-```sql
-INSERT OR REPLACE INTO app_config (key, value, description) VALUES (
-  'GOOGLE_CLIENT_EMAIL',
-  'service-account@project.iam.gserviceaccount.com',
-  'Google Calendar service account'
-);
-
-INSERT OR REPLACE INTO app_config (key, value, description) VALUES (
-  'GOOGLE_CALENDAR_ID',
-  'primary',
-  'Google Calendar ID'
-);
-```
-
-**Note:** `GOOGLE_PRIVATE_KEY` should always be set via Wrangler secret for security.
+Not required for core chat. To enable booking, set Wrangler secrets
+`GOOGLE_CLIENT_EMAIL`, `GOOGLE_PRIVATE_KEY`, `GOOGLE_CALENDAR_ID`, or non-secret
+keys via D1 `app_config` / admin Settings. Keep `GOOGLE_PRIVATE_KEY` in Wrangler.
 
 ---
 
-## 🔗 QUICK LINKS
+## 🔗 Links
 
-- **GitHub Secrets:** https://github.com/Themis128/cloudless.gr/settings/secrets/actions
-- **Cloudflare Dashboard:** https://dash.cloudflare.com
-- **Cloudflare API Tokens:** https://dash.cloudflare.com/profile/api-tokens
-- **R2 Settings:** https://dash.cloudflare.com/?to=/:account/r2
-- **R2 Credentials Workflow:** https://github.com/Themis128/cloudless.gr/actions/workflows/create-r2-credentials.yml
-- **SST Infra Deploy:** https://github.com/Themis128/cloudless.gr/actions/workflows/sst-infra-deploy.yml
-- **ETL Workflow:** https://github.com/Themis128/cloudless.gr/actions/workflows/etl-espocrm-to-r2.yml
+- [GitHub Secrets](https://github.com/Themis128/cloudless.gr/settings/secrets/actions)
+- [R2 credentials workflow](https://github.com/Themis128/cloudless.gr/actions/workflows/create-r2-credentials.yml)
+- [ETL workflow](https://github.com/Themis128/cloudless.gr/actions/workflows/etl-espocrm-to-r2.yml)
+- Checklist: `docs/current-source-of-truth-checklist.md`
 
 ---
 
-## ⚠️ IMPORTANT NOTES
+## Notes
 
-1. **Source of Truth:** AWS SSM is deprecated for secrets — GitHub Secrets is now the source of truth
-2. **Workflows Are Ready:** All workflow files are already configured correctly — only secrets are missing
-3. **No Code Changes Needed:** This is purely a configuration issue, not a code issue
-4. **Self-Hosted Runners:** ETL workflows require Pi runners (Cloudflare blocks data-center IPs)
-5. **Order Matters:** Add R2 credentials first (Step 1), then Wrangler secrets (Step 2)
-
----
-
-## 🆘 TROUBLESHOOTING
-
-### "CLOUDFLARE_API_TOKEN is invalid"
-
-- **Solution:** Token may lack required permissions. Recreate with **"Edit Cloudflare Workers"** template
-
-### "CF_ACCOUNT_ID not found"
-
-- **Solution:** Verify you copied the Account ID from Cloudflare dashboard (not Zone ID)
-
-### "R2 operations failing"
-
-- **Solution:** Ensure `CF_R2_ACCESS_KEY_ID` and `CF_R2_SECRET_ACCESS_KEY` are set. Use the `create-r2-credentials.yml` workflow (manually triggered) to auto-generate them.
-
-### "Authentication failed in Workers"
-
-- **Solution:** Set `SESSION_SECRET` and `AGENT_AUTH_TOKEN` via `npx wrangler secret put`
-
----
-
-**Status:** Only 2 GitHub secrets (`CF_R2_ACCESS_KEY_ID`, `CF_R2_SECRET_ACCESS_KEY`) and 2 Wrangler secrets (`SESSION_SECRET`, `AGENT_AUTH_TOKEN`) remain. Use the `create-r2-credentials.yml` workflow to auto-generate R2 credentials.
+1. Prefer D1 `app_config` + Wrangler/k8s secrets over AWS SSM (legacy Lambda path only).
+2. Never `kubectl apply` empty Secret stubs for `appflowy-walg-r2` / `pvc-backup-r2`.
+3. `WALG_LOG_LEVEL` must be `NORMAL|DEVEL|ERROR` (not `INFO`).
+4. Cloudflare token rotation remains an operator SKIPPED item if MCP CF tools 401.

--- a/src/app/[locale]/admin/product-descriptions/page.tsx
+++ b/src/app/[locale]/admin/product-descriptions/page.tsx
@@ -109,7 +109,9 @@ export default function ProductDescriptionsPage() {
       if (!res.ok) {
         throw new Error(data.error ?? "Failed to apply descriptions");
       }
-      setStatus(`Applied ${data.applied ?? 0} description${(data.applied ?? 0) === 1 ? "" : "s"} to product cache.`);
+      setStatus(
+        `Applied ${data.applied ?? 0} description${(data.applied ?? 0) === 1 ? "" : "s"} to product cache.`
+      );
     } catch (err) {
       setError(err instanceof Error ? err.message : "An error occurred");
     } finally {
@@ -138,8 +140,8 @@ export default function ProductDescriptionsPage() {
         </div>
         <h1 className="font-heading text-2xl font-bold text-white">Product Copy</h1>
         <p className="mt-2 font-mono text-sm text-slate-400">
-          Generate store descriptions with Cloudflare Workers AI, edit drafts, then apply only
-          what you approve.
+          Generate store descriptions with Cloudflare Workers AI, edit drafts, then apply only what
+          you approve.
         </p>
       </div>
 
@@ -152,14 +154,14 @@ export default function ProductDescriptionsPage() {
             <button
               type="button"
               onClick={() => selectAll(true)}
-              className="min-h-[44px] rounded-lg border border-slate-700 px-3 py-2 font-mono text-xs text-slate-300 hover:border-neon-cyan/40"
+              className="hover:border-neon-cyan/40 min-h-[44px] rounded-lg border border-slate-700 px-3 py-2 font-mono text-xs text-slate-300"
             >
               Select all
             </button>
             <button
               type="button"
               onClick={() => selectAll(false)}
-              className="min-h-[44px] rounded-lg border border-slate-700 px-3 py-2 font-mono text-xs text-slate-300 hover:border-neon-cyan/40"
+              className="hover:border-neon-cyan/40 min-h-[44px] rounded-lg border border-slate-700 px-3 py-2 font-mono text-xs text-slate-300"
             >
               Clear
             </button>
@@ -168,7 +170,7 @@ export default function ProductDescriptionsPage() {
         <ul className="grid gap-2 sm:grid-cols-2">
           {catalog.map((p) => (
             <li key={p.id}>
-              <label className="flex min-h-[44px] cursor-pointer items-center gap-3 rounded-lg border border-slate-800 px-3 py-2 hover:border-neon-cyan/30">
+              <label className="hover:border-neon-cyan/30 flex min-h-[44px] cursor-pointer items-center gap-3 rounded-lg border border-slate-800 px-3 py-2">
                 <input
                   type="checkbox"
                   checked={selectedIds.has(p.id)}
@@ -197,8 +199,8 @@ export default function ProductDescriptionsPage() {
       )}
 
       {status && (
-        <div className="mb-4 rounded-lg border border-neon-cyan/20 bg-neon-cyan/5 px-4 py-3">
-          <p className="font-mono text-sm text-neon-cyan">{status}</p>
+        <div className="border-neon-cyan/20 bg-neon-cyan/5 mb-4 rounded-lg border px-4 py-3">
+          <p className="text-neon-cyan font-mono text-sm">{status}</p>
         </div>
       )}
 
@@ -233,7 +235,7 @@ export default function ProductDescriptionsPage() {
           {drafts.map((draft, idx) => (
             <div
               key={draft.id}
-              className="bg-void-light/50 rounded-xl border border-slate-800 p-4 open:border-neon-cyan/30"
+              className="bg-void-light/50 open:border-neon-cyan/30 rounded-xl border border-slate-800 p-4"
             >
               <div className="mb-3 flex flex-wrap items-center justify-between gap-2">
                 <label className="flex min-h-[44px] items-center gap-2">
@@ -247,7 +249,9 @@ export default function ProductDescriptionsPage() {
                     }}
                     className="accent-neon-cyan"
                   />
-                  <span className="font-heading text-sm font-semibold text-white">{draft.name}</span>
+                  <span className="font-heading text-sm font-semibold text-white">
+                    {draft.name}
+                  </span>
                 </label>
                 <span className="font-mono text-[10px] text-slate-500">{draft.id}</span>
               </div>

--- a/src/app/[locale]/admin/settings/page.tsx
+++ b/src/app/[locale]/admin/settings/page.tsx
@@ -183,14 +183,14 @@ export default function AdminSettingsPage() {
               value={editKey}
               onChange={(e) => setEditKey(e.target.value.toUpperCase())}
               placeholder="KEY_NAME"
-              className="min-h-[40px] min-w-[12rem] flex-1 rounded-lg border border-slate-700 bg-void px-3 font-mono text-xs text-white"
+              className="bg-void min-h-[40px] min-w-[12rem] flex-1 rounded-lg border border-slate-700 px-3 font-mono text-xs text-white"
             />
             <input
               type="text"
               value={editValue}
               onChange={(e) => setEditValue(e.target.value)}
               placeholder="value"
-              className="min-h-[40px] min-w-[12rem] flex-[2] rounded-lg border border-slate-700 bg-void px-3 font-mono text-xs text-white"
+              className="bg-void min-h-[40px] min-w-[12rem] flex-[2] rounded-lg border border-slate-700 px-3 font-mono text-xs text-white"
             />
             <button
               type="button"
@@ -198,7 +198,7 @@ export default function AdminSettingsPage() {
               onClick={() => {
                 handleSaveConfig().catch(() => {});
               }}
-              className="min-h-[40px] rounded-lg border border-neon-cyan/40 px-4 py-2 font-mono text-xs text-neon-cyan transition-all hover:border-neon-cyan disabled:opacity-50"
+              className="border-neon-cyan/40 text-neon-cyan hover:border-neon-cyan min-h-[40px] rounded-lg border px-4 py-2 font-mono text-xs transition-all disabled:opacity-50"
             >
               {configSaving ? "Saving…" : "Save"}
             </button>
@@ -209,7 +209,7 @@ export default function AdminSettingsPage() {
                 <li key={row.key} className="flex gap-2 border-b border-slate-800/80 py-1">
                   <button
                     type="button"
-                    className="text-left text-neon-cyan hover:underline"
+                    className="text-neon-cyan text-left hover:underline"
                     onClick={() => setEditKey(row.key)}
                   >
                     {row.key}
@@ -223,7 +223,6 @@ export default function AdminSettingsPage() {
             <p className="font-mono text-xs text-slate-600">No app_config rows yet.</p>
           )}
         </div>
-
         {/* Danger Zone */}{" "}
         <div className="rounded-xl border border-red-900/30 bg-red-950/10 p-6">
           {" "}

--- a/src/app/[locale]/auth/login/page.tsx
+++ b/src/app/[locale]/auth/login/page.tsx
@@ -159,7 +159,7 @@ function LoginContent() {
                 <p className="text-right">
                   <Link
                     href="/auth/reset-password"
-                    className="font-mono text-xs text-slate-500 hover:text-neon-cyan"
+                    className="hover:text-neon-cyan font-mono text-xs text-slate-500"
                   >
                     {t("auth.forgotPassword", "Forgot Password?")}
                   </Link>

--- a/src/app/api/admin/config/route.ts
+++ b/src/app/api/admin/config/route.ts
@@ -34,7 +34,10 @@ export async function GET(request: NextRequest) {
   const key = new URL(request.url).searchParams.get("key")?.trim();
   if (key) {
     if (BLOCKED_KEYS.has(key)) {
-      return NextResponse.json({ error: "Secret keys are not readable via this API" }, { status: 403 });
+      return NextResponse.json(
+        { error: "Secret keys are not readable via this API" },
+        { status: 403 }
+      );
     }
     const value = await getD1ConfigValue(db as unknown as D1Database, key);
     if (value === undefined) {
@@ -79,10 +82,7 @@ export async function PUT(request: NextRequest) {
   const description = typeof body.description === "string" ? body.description : undefined;
 
   if (!key || key.length > 128 || !/^[A-Z][A-Z0-9_]*$/.test(key)) {
-    return NextResponse.json(
-      { error: "key must be UPPER_SNAKE_CASE (max 128)" },
-      { status: 400 }
-    );
+    return NextResponse.json({ error: "key must be UPPER_SNAKE_CASE (max 128)" }, { status: 400 });
   }
   if (BLOCKED_KEYS.has(key)) {
     return NextResponse.json(

--- a/src/app/api/admin/users/route.ts
+++ b/src/app/api/admin/users/route.ts
@@ -174,7 +174,10 @@ export async function GET(request: NextRequest) {
       return NextResponse.json({ users, count: users.length, provider: "d1" });
     }
 
-    return NextResponse.json({ error: "No auth provider configured (Cognito or D1)" }, { status: 503 });
+    return NextResponse.json(
+      { error: "No auth provider configured (Cognito or D1)" },
+      { status: 503 }
+    );
   } catch (err) {
     console.error("Failed to list users:", err instanceof Error ? err.message : String(err));
     return NextResponse.json({ error: "Failed to list users" }, { status: 500 });
@@ -212,7 +215,10 @@ export async function POST(request: NextRequest) {
     const { getAuthDbFromEnv, setUserAdminRole } = await import("@/lib/auth-d1");
     const db = getAuthDbFromEnv();
     if (!db) {
-      return NextResponse.json({ error: "No auth provider configured (Cognito or D1)" }, { status: 503 });
+      return NextResponse.json(
+        { error: "No auth provider configured (Cognito or D1)" },
+        { status: 503 }
+      );
     }
 
     if (action === "enable" || action === "disable") {

--- a/src/app/api/experiments/[flagId]/route.ts
+++ b/src/app/api/experiments/[flagId]/route.ts
@@ -5,10 +5,7 @@ export const runtime = "nodejs";
 
 const COOKIE_MAX_AGE = 60 * 60 * 24 * 365;
 
-export async function GET(
-  request: NextRequest,
-  context: { params: Promise<{ flagId: string }> }
-) {
+export async function GET(request: NextRequest, context: { params: Promise<{ flagId: string }> }) {
   const { flagId } = await context.params;
   const id = (flagId || "").trim().slice(0, 64);
   if (!id) {

--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -105,8 +105,7 @@ export async function trackAnalyticsEvent(evt: AnalyticsEvent): Promise<boolean>
       .run();
     return true;
   } catch (err) {
-    const safe =
-      err instanceof Error ? err.message.replace(/[\x00-\x1F\x7F]/g, "") : "unknown";
+    const safe = err instanceof Error ? err.message.replace(/[\x00-\x1F\x7F]/g, "") : "unknown";
     console.warn("[analytics] D1 write failed:", safe);
     return false;
   }

--- a/src/lib/search-funnel.ts
+++ b/src/lib/search-funnel.ts
@@ -125,8 +125,7 @@ export async function recordFunnelEvent(raw: FunnelEventInput): Promise<boolean>
       .run();
     return true;
   } catch (err) {
-    const safe =
-      err instanceof Error ? err.message.replace(/[\x00-\x1F\x7F]/g, "") : "unknown";
+    const safe = err instanceof Error ? err.message.replace(/[\x00-\x1F\x7F]/g, "") : "unknown";
     console.warn("[search-funnel] D1 insert failed:", safe);
     return false;
   }
@@ -157,8 +156,7 @@ export async function getFunnelSummary(days = 30): Promise<FunnelSummaryRow[] | 
       .all<{ event_type: string; ab_variant: string | null; count: number }>();
     return result.results ?? [];
   } catch (err) {
-    const safe =
-      err instanceof Error ? err.message.replace(/[\x00-\x1F\x7F]/g, "") : "unknown";
+    const safe = err instanceof Error ? err.message.replace(/[\x00-\x1F\x7F]/g, "") : "unknown";
     console.warn("[search-funnel] D1 summary failed:", safe);
     return null;
   }

--- a/src/lib/ssm-config.ts
+++ b/src/lib/ssm-config.ts
@@ -447,10 +447,7 @@ function buildConfigFromEnv(): AppConfig {
 export async function getConfig(): Promise<AppConfig> {
   // 1. Prefer Cloudflare D1 app_config when AUTH_DB is bound (any runtime)
   try {
-    const maybeEnv = (typeof process !== "undefined" ? process.env : {}) as Record<
-      string,
-      unknown
-    >;
+    const maybeEnv = (typeof process !== "undefined" ? process.env : {}) as Record<string, unknown>;
     const db = maybeEnv.AUTH_DB as D1Database | undefined;
 
     if (db && typeof db.prepare === "function") {

--- a/src/lib/user-profile.ts
+++ b/src/lib/user-profile.ts
@@ -5,11 +5,7 @@ import {
   type AttributeValue,
 } from "@aws-sdk/client-dynamodb";
 import { resolveDynamoEndpoint } from "@/lib/stripe-transactions";
-import {
-  getAuthDbFromEnv,
-  getUserById,
-  patchUserProfile as patchD1Profile,
-} from "@/lib/auth-d1";
+import { getAuthDbFromEnv, getUserById, patchUserProfile as patchD1Profile } from "@/lib/auth-d1";
 
 /**
  * Provider-agnostic user-profile store.


### PR DESCRIPTION
## Summary
- Rewrite 10 `src/` files that failed `prettier --check` on every PR after D1/auth work (#1383 merged without this fix).
- Refresh `ACTIONS-REQUIRED.md`: `CF_R2_*` / account secrets are set; drop stale CRITICAL missing-R2 section.

## Test plan
- [x] `pnpm exec prettier --check "src/**/*.{ts,tsx,css,json}"` passes locally
- [ ] CI Lint & Format green
- [ ] ACTIONS-REQUIRED no longer claims R2 secrets missing


Made with [Cursor](https://cursor.com)