### PR TITLE
fix: leftover Sonar/eslint after D1 auth cutover

### DIFF
--- a/src/app/[locale]/admin/settings/page.tsx
+++ b/src/app/[locale]/admin/settings/page.tsx
@@ -37,8 +37,36 @@ export default function AdminSettingsPage() {
   }, []);
 
   useEffect(() => {
-    loadConfigs().catch(() => {}); // eslint-disable-line react-hooks/set-state-in-effect
-  }, [loadConfigs]);
+    let cancelled = false;
+    async function run() {
+      setConfigError(null);
+      try {
+        const res = await fetchWithAuth("/api/admin/config");
+        if (cancelled) return;
+        const data = (await res.json()) as {
+          configured?: boolean;
+          configs?: ConfigRow[];
+          error?: string;
+        };
+        if (res.status === 503) {
+          setConfigs([]);
+          setConfigError(data.error ?? "AUTH_DB not bound — D1 app_config unavailable");
+          return;
+        }
+        if (!res.ok) throw new Error(data.error ?? `HTTP ${res.status}`);
+        setConfigs(data.configs ?? []);
+      } catch (err) {
+        if (!cancelled) {
+          setConfigError(err instanceof Error ? err.message : "Failed to load app_config");
+          setConfigs([]);
+        }
+      }
+    }
+    run().catch(() => {});
+    return () => {
+      cancelled = true;
+    };
+  }, []);
 
   async function handleSaveConfig() {
     setConfigSaving(true);
@@ -235,7 +263,7 @@ export default function AdminSettingsPage() {
               className="min-h-[44px] rounded-lg border border-red-900/50 px-4 py-2.5 font-mono text-xs text-red-400 transition-all hover:bg-red-950/30"
               onClick={() => {
                 if (window.confirm("Delete all Notion cache? Active requests will re-fetch.")) {
-                  handleClearCache();
+                  handleClearCache().catch(() => {});
                 }
               }}
             >

--- a/src/app/api/admin/users/route.ts
+++ b/src/app/api/admin/users/route.ts
@@ -14,6 +14,8 @@ import { requireAdmin } from "@/lib/api-auth";
 // Shared user shape (Cognito user shape)
 // ---------------------------------------------------------------------------
 
+const ADMIN_GROUP = "admin";
+
 interface AdminUser {
   username: string;
   email: string;
@@ -70,7 +72,7 @@ async function listCognitoUsers(
         const grRes = await client.send(
           new AdminListGroupsForUserCommand({ UserPoolId: userPoolId, Username: u.Username ?? "" })
         );
-        isAdmin = (grRes.Groups ?? []).some((g) => g.GroupName === "admin");
+        isAdmin = (grRes.Groups ?? []).some((g) => g.GroupName === ADMIN_GROUP);
       } catch {
         /* default non-admin */
       }
@@ -87,7 +89,7 @@ async function listCognitoUsers(
         emailVerified: cognitoAttr(attrs, "email_verified") === "true",
         status: u.Enabled ? "active" : "disabled",
         userStatus: u.UserStatus ?? "UNKNOWN",
-        role: isAdmin ? "admin" : "user",
+        role: isAdmin ? ADMIN_GROUP : "user",
         created: u.UserCreateDate?.toISOString(),
         lastModified: u.UserLastModifiedDate?.toISOString(),
       } satisfies AdminUser;
@@ -117,7 +119,7 @@ async function mutateCognitoUser(
         new AdminAddUserToGroupCommand({
           UserPoolId: userPoolId,
           Username: username,
-          GroupName: "admin",
+          GroupName: ADMIN_GROUP,
         })
       );
       return { success: true, message: "User promoted to admin" };
@@ -126,7 +128,7 @@ async function mutateCognitoUser(
         new AdminRemoveUserFromGroupCommand({
           UserPoolId: userPoolId,
           Username: username,
-          GroupName: "admin",
+          GroupName: ADMIN_GROUP,
         })
       );
       return { success: true, message: "User removed from admin group" };

--- a/src/lib/ssm-config.ts
+++ b/src/lib/ssm-config.ts
@@ -1,6 +1,7 @@
 // || (not ??) so that SSM_PREFIX="" falls back to the default instead of fetching from "/"
 const SSM_PREFIX = process.env.SSM_PREFIX || "/cloudless/production";
-const REGION = process.env.AWS_REGION || "us-east-1";
+const DEFAULT_REGION = "us-east-1";
+const REGION = process.env.AWS_REGION || DEFAULT_REGION;
 const CACHE_TTL_MS = 5 * 60 * 1000; // 5 minutes
 
 // Module-level singleton — avoids re-creating the connection pool on every cache miss
@@ -209,7 +210,7 @@ function validateRequiredKeys(params: Map<string, string>): void {
 function buildConfigFromParams(params: Map<string, string>): AppConfig {
   const sesFrom = params.get("SES_FROM_EMAIL") || "noreply@cloudless.gr";
   const sesTo = params.get("SES_TO_EMAIL") || "tbaltzakis@cloudless.gr";
-  const sesRegion = params.get("AWS_SES_REGION") || "us-east-1";
+  const sesRegion = params.get("AWS_SES_REGION") || DEFAULT_REGION;
 
   if (!sesFrom.includes("@") || !sesTo.includes("@")) {
     console.warn(
@@ -334,7 +335,7 @@ function buildConfigFromEnv(): AppConfig {
   return {
     SES_FROM_EMAIL: process.env.SES_FROM_EMAIL || "noreply@cloudless.gr",
     SES_TO_EMAIL: process.env.SES_TO_EMAIL || "tbaltzakis@cloudless.gr",
-    AWS_SES_REGION: process.env.AWS_SES_REGION || "us-east-1",
+    AWS_SES_REGION: process.env.AWS_SES_REGION || DEFAULT_REGION,
     NEWSLETTER_SEND_SECRET: process.env.NEWSLETTER_SEND_SECRET || "",
     STRIPE_SECRET_KEY: process.env.STRIPE_SECRET_KEY || "",
     STRIPE_PUBLISHABLE_KEY: process.env.STRIPE_PUBLISHABLE_KEY || "",


### PR DESCRIPTION
## Summary
- Clear remaining Sonar-style findings after #1383/#1384: `ADMIN_GROUP` / `DEFAULT_REGION` (S1192), settings `useEffect` load without suppressions, danger-zone `handleClearCache().catch`
- Keeps Prettier/eslint clean on touched files

## Test plan
- [x] `pnpm format:check` + eslint on touched files
- [x] Prior D1 auth unit suites already green on main (#1383)
- [ ] CI Lint + Unit + SonarCloud


Made with [Cursor](https://cursor.com)