### PR TITLE
fix: align ETL pnpm with packageManager 10

### DIFF
--- a/.github/workflows/etl-clients-to-r2.yml
+++ b/.github/workflows/etl-clients-to-r2.yml
@@ -29,8 +29,6 @@ jobs:
 
       - name: Install pnpm
         uses: pnpm/action-setup@v4.2.0
-        with:
-          version: 9
 
       - name: Install dependencies
         working-directory: scripts/etl

--- a/.github/workflows/etl-espocrm-to-r2.yml
+++ b/.github/workflows/etl-espocrm-to-r2.yml
@@ -31,8 +31,6 @@ jobs:
 
       - name: Install pnpm
         uses: pnpm/action-setup@v4.2.0
-        with:
-          version: 9
 
       - name: Install dependencies
         working-directory: scripts/etl

--- a/.github/workflows/etl-portals-to-r2.yml
+++ b/.github/workflows/etl-portals-to-r2.yml
@@ -29,8 +29,6 @@ jobs:
 
       - name: Install pnpm
         uses: pnpm/action-setup@v4.2.0
-        with:
-          version: 9
 
       - name: Install dependencies
         working-directory: scripts/etl


### PR DESCRIPTION
## Summary
- Remove hardcoded `version: 9` from EspoCRM/portals/clients R2 ETL workflows so setup follows root `packageManager` (pnpm@10.33.2).
- Follow-up to #1391 (runner labels); ETL now fails at Install pnpm without this.

## Test plan
- [ ] `gh workflow run etl-espocrm-to-r2.yml` passes Install pnpm on omv-build


Made with [Cursor](https://cursor.com)