### PR TITLE
fix: ETL install via npm ci (no Playwright browsers)

### DIFF
--- a/.github/workflows/etl-clients-to-r2.yml
+++ b/.github/workflows/etl-clients-to-r2.yml
@@ -25,14 +25,11 @@ jobs:
         uses: actions/setup-node@v4.4.0
         with:
           node-version: 22
-          cache: 'pnpm'
 
-      - name: Install pnpm
-        uses: pnpm/action-setup@v4.2.0
 
       - name: Install dependencies
         working-directory: scripts/etl
-        run: pnpm install --frozen-lockfile
+        run: npm ci --omit=dev
 
       - name: Run Clients-to-R2 sync
         working-directory: scripts/etl

--- a/.github/workflows/etl-espocrm-to-r2.yml
+++ b/.github/workflows/etl-espocrm-to-r2.yml
@@ -27,14 +27,11 @@ jobs:
         uses: actions/setup-node@v4.4.0
         with:
           node-version: 22
-          cache: 'pnpm'
 
-      - name: Install pnpm
-        uses: pnpm/action-setup@v4.2.0
 
       - name: Install dependencies
         working-directory: scripts/etl
-        run: pnpm install --frozen-lockfile
+        run: npm ci --omit=dev
 
       - name: Run EspoCRM-to-R2 sync
         working-directory: scripts/etl

--- a/.github/workflows/etl-portals-to-r2.yml
+++ b/.github/workflows/etl-portals-to-r2.yml
@@ -25,14 +25,11 @@ jobs:
         uses: actions/setup-node@v4.4.0
         with:
           node-version: 22
-          cache: 'pnpm'
 
-      - name: Install pnpm
-        uses: pnpm/action-setup@v4.2.0
 
       - name: Install dependencies
         working-directory: scripts/etl
-        run: pnpm install --frozen-lockfile
+        run: npm ci --omit=dev
 
       - name: Run Portals-to-R2 sync
         working-directory: scripts/etl


### PR DESCRIPTION
## Summary
- EspoCRM/portals/clients R2 ETL jobs now `npm ci --omit=dev` in `scripts/etl` (has `package-lock.json`).
- Drop `pnpm/action-setup` — root pnpm was installing Playwright browsers on omv-build and failing on ms-playwright cache races.

## Test plan
- [ ] `gh workflow run etl-espocrm-to-r2.yml` gets past Install dependencies and runs the sync script


Made with [Cursor](https://cursor.com)