### PR TITLE
ops: sync Copilot token into copilot env secret

### DIFF
--- a/.github/workflows/sync-copilot-env-secret.yml
+++ b/.github/workflows/sync-copilot-env-secret.yml
@@ -1,0 +1,30 @@
+name: Sync Copilot Env Secret
+on:
+  workflow_dispatch:
+permissions:
+  contents: read
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Upsert environment secret from repo COPILOT_GITHUB_TOKEN
+        env:
+          GH_TOKEN: ${{ secrets.GH_PAT }}
+          SRC: ${{ secrets.COPILOT_GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          if [ -z "${SRC:-}" ]; then
+            echo "COPILOT_GITHUB_TOKEN repo secret is empty" >&2
+            exit 1
+          fi
+          # Classify without printing
+          case "$SRC" in
+            github_pat_*) echo "src_kind=fine-grained len=${#SRC}" ;;
+            gho_*) echo "src_kind=oauth_REJECTED len=${#SRC}"; exit 2 ;;
+            ghp_*) echo "src_kind=classic len=${#SRC}" ;;
+            *) echo "src_kind=other prefix=${SRC:0:7}… len=${#SRC}" ;;
+          esac
+          printf '%s' "$SRC" | gh secret set COPILOT_MCP_GITHUB_PERSONAL_ACCESS_TOKEN \
+            --repo "${{ github.repository }}" \
+            --env copilot
+          echo "updated env secret COPILOT_MCP_GITHUB_PERSONAL_ACCESS_TOKEN"


### PR DESCRIPTION
## Summary
- One-shot workflow copies repo `COPILOT_GITHUB_TOKEN` → Environment `copilot` / `COPILOT_MCP_GITHUB_PERSONAL_ACCESS_TOKEN`.
- Rejects OAuth `gho_` tokens. After merge, run once then we can delete the workflow if desired.

## Test plan
- [ ] `gh workflow run sync-copilot-env-secret.yml`
- [ ] `gh workflow run activity-report.lock.yml` no longer 401s


Made with [Cursor](https://cursor.com)