### PR TITLE
docs: mark EspoCRM ETL → R2 as cleared

### DIFF
--- a/ACTIONS-REQUIRED.md
+++ b/ACTIONS-REQUIRED.md
@@ -2,7 +2,7 @@
 
 # Generated: 2026-07-19 16:44 UTC
 
-# Last Updated: 2026-07-29 22:15 EEST — aw workflows use copilot env PAT secret
+# Last Updated: 2026-07-29 22:37 EEST — EspoCRM ETL → R2 green (NodePort + API key)
 
 ---
 
@@ -63,6 +63,7 @@ python3 scripts/purge-sensitive-gh-variables.py --apply  # mutate
 | PVC backups → R2 | smoke dump OK |
 | SSM default path retired | Pi `SSM_DISABLED=1`; code needs `SSM_ENABLED=1` for AWS SSM |
 | ETL runner label bug | `runs-on` default is JSON array `["self-hosted","omv","build"]` |
+| EspoCRM ETL → R2 | NodePort `127.0.0.1:30700` (#1397); API user `cloudless-app` + role ACL; `ESPOCRM_API_KEY` in GH + `cloudless-secrets`; run [30485173560](https://github.com/Themis128/cloudless.gr/actions/runs/30485173560) **5/5 entities** |
 
 ---
 
@@ -70,8 +71,9 @@ python3 scripts/purge-sensitive-gh-variables.py --apply  # mutate
 
 | Item | Notes |
 |------|-------|
-| Copilot fine-grained PAT | See section above |
-| Optional ads/Sentry/Kuma secrets | Leave empty if unused |
+| Copilot fine-grained PAT | See section above — refresh env `copilot` secret if agents 401 |
+| Rotate after Variable exposure | Stripe / Slack / Notion / Cognito / Google / SES (table above) |
+| Optional ads/Sentry/Kuma secrets | `KUMA_PUSH_ETL_ESPOCRM` empty (ping skipped); leave unused empty |
 | Cloudflare API token rotation | If MCP CF tools 401 |
 | ESP32 Notion DBs | Empty (no hardware data); page reconstruct partial |
 
@@ -79,7 +81,7 @@ python3 scripts/purge-sensitive-gh-variables.py --apply  # mutate
 
 ## 🔧 Verification
 
-1. `gh workflow run etl-espocrm-to-r2.yml` — should pick `omv-build` (not queue forever)
+1. `gh workflow run etl-espocrm-to-r2.yml` — green; picks `omv`/`build`; writes `lake/espocrm-*/*.parquet`
 2. Continuous WAL: `archived_count` advances, `failed_count=0`
 3. Daily CronJob `appflowy-walg-basebackup` at `30 2 * * *`
 4. `npx wrangler secret list --config wrangler.jsonc` includes SESSION + AGENT

--- a/docs/current-source-of-truth-checklist.md
+++ b/docs/current-source-of-truth-checklist.md
@@ -107,6 +107,11 @@ Runbook: [`docs/operator-blockers-runbook.md`](operator-blockers-runbook.md).
 - [x] `DONE` Smoke PVC backup Job to R2.
       Proof: `pvc-backup-appflowy` Job Completed; uploaded **1178437** bytes to
       `r2://datalake-bucket/pvc-backups/appflowy/daily/2026-07-29T170155Z.sql.custom`.
+- [x] `DONE` EspoCRM hourly ETL → R2 (NodePort + API key).
+      Evidence: `.github/workflows/etl-espocrm-to-r2.yml` uses `http://127.0.0.1:30700`;
+      API user `cloudless-app` + role ACL; `ESPOCRM_API_KEY` in GH + `cloudless-secrets`.
+      Run https://github.com/Themis128/cloudless.gr/actions/runs/30485173560 — **5/5** entities
+      → `lake/espocrm-{contacts,accounts,opportunities,cases,campaigns}/*.parquet`.
 - [x] `DONE` Search funnel analytics on Cloudflare D1 (query → result → click; buy hook ready).
       Evidence: `migrations/0008-search-funnel-events.sql`, `src/lib/search-funnel.ts`,
       `src/lib/funnel-client.ts`, `StoreGrid` beacons, `POST /api/analytics/track` D1 sink,


### PR DESCRIPTION
## Summary
- Update `ACTIONS-REQUIRED.md` with EspoCRM ETL → R2 evidence (NodePort #1397, API key, run 30485173560 5/5).
- Mark the same item `DONE` on `docs/current-source-of-truth-checklist.md`.
- Clarify that `KUMA_PUSH_ETL_ESPOCRM` still needs a Kuma UI push monitor (no GH secrets yet).

## Test plan
- [x] Diff is docs-only
- [x] Links to merged #1397 and successful Actions run

Made with [Cursor](https://cursor.com)