### PR TITLE
feat(stripe): D1-first webhook idempotency (+ eslint10/TS7 deferral note)

### DIFF
--- a/__tests__/stripe-transactions.test.ts
+++ b/__tests__/stripe-transactions.test.ts
@@ -1,15 +1,98 @@
-import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import type Stripe from "stripe";
+import type { AuthDatabase } from "@/lib/auth-d1";
+
+function makeEvent(id: string): Stripe.Event {
+  return {
+    id,
+    object: "event",
+    api_version: "2024-11-20.acacia",
+    created: Math.floor(Date.now() / 1000),
+    type: "checkout.session.completed",
+    livemode: false,
+    pending_webhooks: 0,
+    request: null,
+    data: {
+      object: {
+        id: "cs_test_1",
+        object: "checkout.session",
+        amount_total: 4900,
+        currency: "eur",
+        customer: "cus_1",
+        customer_email: "a@b.c",
+        mode: "payment",
+        payment_status: "paid",
+        status: "complete",
+      } as unknown as Stripe.Checkout.Session,
+    },
+  } as Stripe.Event;
+}
+
+function createMemoryAuthDb(): AuthDatabase & { rows: Map<string, Record<string, unknown>> } {
+  const rows = new Map<string, Record<string, unknown>>();
+  return {
+    rows,
+    prepare(query: string) {
+      const binds: unknown[] = [];
+      const stmt = {
+        bind(...args: unknown[]) {
+          binds.push(...args);
+          return stmt;
+        },
+        async run() {
+          if (query.includes("INSERT INTO stripe_transaction")) {
+            const eventId = String(binds[0]);
+            if (rows.has(eventId)) {
+              throw new Error(
+                "D1_ERROR: UNIQUE constraint failed: stripe_transaction.event_id"
+              );
+            }
+            rows.set(eventId, {
+              event_id: eventId,
+              event_type: binds[1],
+              processing_status: binds[7],
+              received_at: binds[8],
+            });
+            return { success: true, meta: { changes: 1 } };
+          }
+          if (query.includes("UPDATE stripe_transaction")) {
+            const eventId = String(binds.at(-1));
+            const existing = rows.get(eventId);
+            if (existing) {
+              existing.processing_status = binds[0];
+              existing.processed_at = binds[1];
+              if (binds.length >= 4) existing.processing_error = binds[2];
+              else existing.processing_error = null;
+            }
+            return { success: true, meta: { changes: existing ? 1 : 0 } };
+          }
+          return { success: true, meta: { changes: 0 } };
+        },
+        async all() {
+          return { results: [], success: true };
+        },
+        async first() {
+          return null;
+        },
+      };
+      return stmt;
+    },
+  };
+}
 
 describe("stripe transaction tags", () => {
   const previousStage = process.env.NEXT_PUBLIC_STAGE;
 
   beforeEach(() => {
     process.env.NEXT_PUBLIC_STAGE = "production";
+    delete (globalThis as { __AUTH_DB__?: unknown }).__AUTH_DB__;
   });
 
   afterEach(() => {
     if (typeof previousStage === "string") process.env.NEXT_PUBLIC_STAGE = previousStage;
     else delete process.env.NEXT_PUBLIC_STAGE;
+    delete (globalThis as { __AUTH_DB__?: unknown }).__AUTH_DB__;
+    vi.resetModules();
   });
 
   it("maps checkout events to checkout tag", async () => {
@@ -50,5 +133,34 @@ describe("stripe transaction tags", () => {
     const { resolveDynamoEndpoint } = await import("@/lib/stripe-transactions");
     expect(resolveDynamoEndpoint()).toBe("https://dynamodb.us-east-1.amazonaws.com");
     delete process.env.DYNAMODB_ENDPOINT;
+  });
+});
+
+describe("stripe transactions D1 idempotency", () => {
+  afterEach(() => {
+    delete (globalThis as { __AUTH_DB__?: unknown }).__AUTH_DB__;
+    vi.resetModules();
+  });
+
+  it("persists via D1 and reports duplicates on UNIQUE", async () => {
+    const db = createMemoryAuthDb();
+    (globalThis as { __AUTH_DB__?: AuthDatabase }).__AUTH_DB__ = db;
+    const { persistStripeEvent } = await import("@/lib/stripe-transactions");
+    const event = makeEvent("evt_d1_1");
+    expect(await persistStripeEvent(event)).toEqual({ duplicate: false });
+    expect(await persistStripeEvent(event)).toEqual({ duplicate: true });
+    expect(db.rows.get("evt_d1_1")?.processing_status).toBe("received");
+  });
+
+  it("marks processed and failed on D1 rows", async () => {
+    const db = createMemoryAuthDb();
+    (globalThis as { __AUTH_DB__?: AuthDatabase }).__AUTH_DB__ = db;
+    const mod = await import("@/lib/stripe-transactions");
+    await mod.persistStripeEvent(makeEvent("evt_d1_2"));
+    await mod.markStripeEventProcessed("evt_d1_2");
+    expect(db.rows.get("evt_d1_2")?.processing_status).toBe("processed");
+    await mod.markStripeEventFailed("evt_d1_2", "boom");
+    expect(db.rows.get("evt_d1_2")?.processing_status).toBe("handler_failed");
+    expect(db.rows.get("evt_d1_2")?.processing_error).toBe("boom");
   });
 });

--- a/docs/current-source-of-truth-checklist.md
+++ b/docs/current-source-of-truth-checklist.md
@@ -160,7 +160,16 @@ Issue template: `.github/ISSUE_TEMPLATE/ops-cadence.yml`.
       Evidence: `src/lib/analytics.ts` (`trackAnalyticsEvent`), `POST /api/analytics/track` (no S3).
 - [x] `DONE` Stripe + admin-notification **lake** PutObject → R2 `DATALAKE_BUCKET`
       (`getDataLakeBucketFromEnv` in `r2-client.ts`; no S3 SDK in those sinks).
-      Still AWS (out of scope for this cut): Athena cost/datalake UI reads, Dynamo idempotency table.
+      Stripe webhook **idempotency** prefers D1 `stripe_transaction` when `AUTH_DB`
+      is bound (`persistStripeEvent` / mark helpers in `stripe-transactions.ts`);
+      Dynamo `STRIPE_TRANSACTIONS_TABLE` remains legacy fallback.
+      Still AWS (follow-up): Athena cost/datalake UI reads; admin-notifications
+      Dynamo primary store; `stripe-analytics-read` Dynamo queries.
+- [x] `DEFERRED` ESLint 10 + TypeScript 7 majors (ecosystem blockers 2026-07-29).
+      ESLint 10 crashes `eslint-plugin-react` (`getFilename is not a function`);
+      `eslint-plugin-import` / `jsx-a11y` peers stop at eslint 9. TypeScript 7
+      hard-stopped by `typescript-eslint` (`typescript: >=4.8.4 <6.1.0`). Revisit
+      when Next `eslint-config-next` + typescript-eslint ship support.
 - [x] `DONE` Cognito → D1 auth cutover (JWKS gated).
       Evidence: login/register/activate D1 paths; `requireAuth` uses Cognito JWKS
       **only** when `NEXT_PUBLIC_AUTH_PROVIDER=cognito`; otherwise opaque

--- a/migrations/0001-auth-schema.sql
+++ b/migrations/0001-auth-schema.sql
@@ -45,6 +45,8 @@ CREATE TABLE IF NOT EXISTS stripe_transaction (
   customer_id TEXT,
   processing_status TEXT,
   received_at INTEGER NOT NULL,
+  processed_at INTEGER,
+  processing_error TEXT,
   payload_json TEXT
 );
 

--- a/migrations/0010-stripe-transaction-status.sql
+++ b/migrations/0010-stripe-transaction-status.sql
@@ -1,0 +1,3 @@
+-- Stripe webhook processing status columns (Dynamo parity for D1 idempotency path)
+ALTER TABLE stripe_transaction ADD COLUMN processed_at INTEGER;
+ALTER TABLE stripe_transaction ADD COLUMN processing_error TEXT;

--- a/schema.sql
+++ b/schema.sql
@@ -30,9 +30,15 @@ CREATE INDEX idx_session_expires ON session(expires_at);
 CREATE TABLE stripe_transaction (
     event_id TEXT NOT NULL PRIMARY KEY,
     event_type TEXT NOT NULL,
+    tag_category TEXT,
+    tag_stage TEXT,
+    stage_category TEXT,
+    event_day TEXT,
     customer_id TEXT,
     processing_status TEXT,
     received_at INTEGER NOT NULL,
+    processed_at INTEGER,
+    processing_error TEXT,
     payload_json TEXT
 );
 

--- a/src/lib/stripe-transactions.ts
+++ b/src/lib/stripe-transactions.ts
@@ -6,6 +6,8 @@ import {
   type AttributeValue,
 } from "@aws-sdk/client-dynamodb";
 import type Stripe from "stripe";
+import { getAuthDbFromEnv, type AuthDatabase } from "@/lib/auth-d1";
+import { getDataLakeBucketFromEnv } from "@/lib/r2-client";
 
 const REGION = process.env.AWS_REGION || "us-east-1";
 const APP_SOURCE_TAG = "cloudless.gr";
@@ -53,10 +55,14 @@ function toJson(value: unknown): string {
   }
 }
 
-function getTransactionsTableName(): string {
+function getTransactionsTableName(): string | null {
   const tableName = process.env.STRIPE_TRANSACTIONS_TABLE?.trim();
-  if (tableName) return tableName;
-  throw new Error("STRIPE_TRANSACTIONS_TABLE is not configured");
+  return tableName || null;
+}
+
+function isUniqueConstraintError(error: unknown): boolean {
+  const msg = error instanceof Error ? error.message : String(error);
+  return /UNIQUE constraint failed|SQLITE_CONSTRAINT|constraint failed/i.test(msg);
 }
 
 export interface StripeEventTags {
@@ -88,17 +94,24 @@ function toExpiryEpoch(unixSeconds: number): number {
   return unixSeconds + ANALYTICS_RETENTION_DAYS * 24 * 60 * 60;
 }
 
-function buildItem(event: Stripe.Event): Record<string, AttributeValue> {
+function extractObjectFields(event: Stripe.Event) {
   const object = event.data.object as unknown as Record<string, unknown>;
-  const amountMinor =
-    asNumber(object.amount_total) ?? asNumber(object.amount_due) ?? asNumber(object.amount_paid);
+  return {
+    object,
+    amountMinor:
+      asNumber(object.amount_total) ?? asNumber(object.amount_due) ?? asNumber(object.amount_paid),
+    objectId: asString(object.id),
+    currency: asString(object.currency),
+    paymentStatus: asString(object.payment_status) ?? asString(object.status),
+    customerId: asString(object.customer),
+    customerEmail: asString(object.customer_email),
+    mode: asString(object.mode),
+  };
+}
 
-  const objectId = asString(object.id);
-  const currency = asString(object.currency);
-  const paymentStatus = asString(object.payment_status) ?? asString(object.status);
-  const customerId = asString(object.customer);
-  const customerEmail = asString(object.customer_email);
-  const mode = asString(object.mode);
+function buildItem(event: Stripe.Event): Record<string, AttributeValue> {
+  const { amountMinor, objectId, currency, paymentStatus, customerId, customerEmail, mode } =
+    extractObjectFields(event);
   const tags = getStripeEventTags(event.type);
   const eventDay = toEventDay(event.created);
   const stageCategory = `${tags.tagStage}#${tags.tagCategory}`;
@@ -134,8 +147,53 @@ export interface PersistStripeEventResult {
   duplicate: boolean;
 }
 
-export async function persistStripeEvent(event: Stripe.Event): Promise<PersistStripeEventResult> {
+async function persistStripeEventD1(
+  db: AuthDatabase,
+  event: Stripe.Event
+): Promise<PersistStripeEventResult> {
+  const { customerId } = extractObjectFields(event);
+  const tags = getStripeEventTags(event.type);
+  const eventDay = toEventDay(event.created);
+  const stageCategory = `${tags.tagStage}#${tags.tagCategory}`;
+  const receivedAt = Date.now();
+
+  try {
+    await db
+      .prepare(
+        `INSERT INTO stripe_transaction (
+          event_id, event_type, tag_category, tag_stage, stage_category,
+          event_day, customer_id, processing_status, received_at, payload_json
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+      )
+      .bind(
+        event.id,
+        event.type,
+        tags.tagCategory,
+        tags.tagStage,
+        stageCategory,
+        eventDay,
+        customerId ?? null,
+        "received",
+        receivedAt,
+        toJson(event.data.object)
+      )
+      .run();
+  } catch (error) {
+    if (isUniqueConstraintError(error)) {
+      return { duplicate: true };
+    }
+    throw error;
+  }
+
+  sinkStripeEventToLake(event).catch(() => {});
+  return { duplicate: false };
+}
+
+async function persistStripeEventDynamo(event: Stripe.Event): Promise<PersistStripeEventResult> {
   const tableName = getTransactionsTableName();
+  if (!tableName) {
+    throw new Error("STRIPE_TRANSACTIONS_TABLE is not configured");
+  }
   const client = getDynamoClient();
 
   try {
@@ -146,7 +204,6 @@ export async function persistStripeEvent(event: Stripe.Event): Promise<PersistSt
         ConditionExpression: "attribute_not_exists(eventId)",
       })
     );
-    // Sink to data lake for analytics (fire-and-forget)
     sinkStripeEventToLake(event).catch(() => {});
     return { duplicate: false };
   } catch (error) {
@@ -160,8 +217,52 @@ export async function persistStripeEvent(event: Stripe.Event): Promise<PersistSt
   }
 }
 
-export async function markStripeEventProcessed(eventId: string): Promise<void> {
+/**
+ * Persist a Stripe webhook event for idempotency.
+ * Prefer D1 (`AUTH_DB` / `__AUTH_DB__`) when bound; else Dynamo `STRIPE_TRANSACTIONS_TABLE`.
+ */
+export async function persistStripeEvent(event: Stripe.Event): Promise<PersistStripeEventResult> {
+  const db = getAuthDbFromEnv();
+  if (db) {
+    return persistStripeEventD1(db, event);
+  }
+  return persistStripeEventDynamo(event);
+}
+
+async function markStripeEventD1(
+  db: AuthDatabase,
+  eventId: string,
+  status: "processed" | "handler_failed",
+  errorMessage?: string
+): Promise<void> {
+  const processedAt = Date.now();
+  if (status === "processed") {
+    await db
+      .prepare(
+        `UPDATE stripe_transaction
+         SET processing_status = ?, processed_at = ?, processing_error = NULL
+         WHERE event_id = ?`
+      )
+      .bind(status, processedAt, eventId)
+      .run();
+    return;
+  }
+
+  await db
+    .prepare(
+      `UPDATE stripe_transaction
+       SET processing_status = ?, processed_at = ?, processing_error = ?
+       WHERE event_id = ?`
+    )
+    .bind(status, processedAt, (errorMessage ?? "").slice(0, 1000), eventId)
+    .run();
+}
+
+async function markStripeEventProcessedDynamo(eventId: string): Promise<void> {
   const tableName = getTransactionsTableName();
+  if (!tableName) {
+    throw new Error("STRIPE_TRANSACTIONS_TABLE is not configured");
+  }
   const client = getDynamoClient();
   await client.send(
     new UpdateItemCommand({
@@ -177,8 +278,11 @@ export async function markStripeEventProcessed(eventId: string): Promise<void> {
   );
 }
 
-export async function markStripeEventFailed(eventId: string, errorMessage: string): Promise<void> {
+async function markStripeEventFailedDynamo(eventId: string, errorMessage: string): Promise<void> {
   const tableName = getTransactionsTableName();
+  if (!tableName) {
+    throw new Error("STRIPE_TRANSACTIONS_TABLE is not configured");
+  }
   const client = getDynamoClient();
   await client.send(
     new UpdateItemCommand({
@@ -195,11 +299,27 @@ export async function markStripeEventFailed(eventId: string, errorMessage: strin
   );
 }
 
+export async function markStripeEventProcessed(eventId: string): Promise<void> {
+  const db = getAuthDbFromEnv();
+  if (db) {
+    await markStripeEventD1(db, eventId, "processed");
+    return;
+  }
+  await markStripeEventProcessedDynamo(eventId);
+}
+
+export async function markStripeEventFailed(eventId: string, errorMessage: string): Promise<void> {
+  const db = getAuthDbFromEnv();
+  if (db) {
+    await markStripeEventD1(db, eventId, "handler_failed", errorMessage);
+    return;
+  }
+  await markStripeEventFailedDynamo(eventId, errorMessage);
+}
+
 // ---------------------------------------------------------------------------
 // Data Lake sink — writes Stripe events to R2 (Cloudflare DATALAKE_BUCKET).
 // ---------------------------------------------------------------------------
-
-import { getDataLakeBucketFromEnv } from "@/lib/r2-client";
 
 async function sinkStripeEventToLake(event: Stripe.Event): Promise<void> {
   const bucket = getDataLakeBucketFromEnv();


### PR DESCRIPTION
## Summary
- Stripe webhook idempotency (`persistStripeEvent` / mark helpers) prefers **D1** `stripe_transaction` when `AUTH_DB` is bound; Dynamo `STRIPE_TRANSACTIONS_TABLE` remains fallback.
- Migration `0010-stripe-transaction-status.sql` adds `processed_at` / `processing_error`.
- Documents **ESLint 10** / **TypeScript 7** as `DEFERRED` on the checklist — still blocked by `eslint-plugin-react` crash and `typescript-eslint` peer range.
- Replaces the checklist leftover “Dynamo idempotency table” note.

Supersedes #1401 (branch tip was overwritten).

## Test plan
- [x] `vitest` `__tests__/stripe-transactions.test.ts` (tags + D1 UNIQUE/mark)
- [x] `pnpm typecheck` / `pnpm lint`
- [ ] Apply migration on remote D1: `wrangler d1 execute user-auth-db --remote --file=migrations/0010-stripe-transaction-status.sql`
- [ ] CI green


Made with [Cursor](https://cursor.com)