### PR TITLE
docs: record Kuma push monitors and ETL heartbeat

### DIFF
--- a/ACTIONS-REQUIRED.md
+++ b/ACTIONS-REQUIRED.md
@@ -2,7 +2,7 @@
 
 # Generated: 2026-07-19 16:44 UTC
 
-# Last Updated: 2026-07-29 23:00 EEST — aw Claude → haiku + AI credits pricing
+# Last Updated: 2026-07-29 23:05 EEST — Kuma push monitors live; aw Claude haiku pin
 
 ---
 
@@ -15,7 +15,6 @@ Pinned `model: claude-haiku-4-5` (cheapest current Claude) and set `models.defau
 Fine-grained PAT UI often has no "Account → Copilot Requests" (user-owned PAT only; under Account permissions). Copilot inference was HTTP 401 anyway.
 
 Env secret `COPILOT_MCP_GITHUB_PERSONAL_ACCESS_TOKEN` is unused by these workflows now.
-
 
 ---
 
@@ -34,46 +33,46 @@ python3 scripts/purge-sensitive-gh-variables.py --apply  # mutate
 
 ### Rotate after Variable exposure (recommended)
 
-| Priority | Credentials |
-|----------|-------------|
-| 🔴 | `STRIPE_SECRET_KEY`, `STRIPE_WEBHOOK_SECRET`, `COGNITO_CLIENT_SECRET`, `GOOGLE_PRIVATE_KEY`, `SES_SMTP_*` |
-| 🔴 | `SLACK_BOT_TOKEN`, `SLACK_SIGNING_SECRET`, `SLACK_WEBHOOK_URL`, `NOTION_API_KEY` |
-| 🟠 | `CLOUDFLARE_API_TOKEN`, `ANTHROPIC_API_KEY`, `GEMINI_API_KEY`, Meta/LinkedIn/X tokens |
-| 🟡 | EspoCRM / AppFlowy / Postiz / N8N / MQTT passwords |
+| Priority | Credentials                                                                                               |
+| -------- | --------------------------------------------------------------------------------------------------------- |
+| 🔴       | `STRIPE_SECRET_KEY`, `STRIPE_WEBHOOK_SECRET`, `COGNITO_CLIENT_SECRET`, `GOOGLE_PRIVATE_KEY`, `SES_SMTP_*` |
+| 🔴       | `SLACK_BOT_TOKEN`, `SLACK_SIGNING_SECRET`, `SLACK_WEBHOOK_URL`, `NOTION_API_KEY`                          |
+| 🟠       | `CLOUDFLARE_API_TOKEN`, `ANTHROPIC_API_KEY`, `GEMINI_API_KEY`, Meta/LinkedIn/X tokens                     |
+| 🟡       | EspoCRM / AppFlowy / Postiz / N8N / MQTT passwords                                                        |
 
 ---
 
 ## ✅ Cleared (2026-07-29)
 
-| Item | Evidence |
-|------|----------|
-| GitHub R2 + CF account secrets | `CF_R2_*`, `CF_ACCOUNT_ID`, `CLOUDFLARE_*` set |
-| Wrangler `SESSION_SECRET` | present (`wrangler secret list`) |
-| Wrangler `AGENT_AUTH_TOKEN` | present |
-| Agentic `[aw] failed` issue spam | `report-failure-as-issue: false` (#1386) |
-| AppFlowy R16 WAL + daily dump → R2 | live; `failed_count=0` |
-| PVC backups → R2 | smoke dump OK |
-| SSM default path retired | Pi `SSM_DISABLED=1`; code needs `SSM_ENABLED=1` for AWS SSM |
-| ETL runner label bug | `runs-on` default is JSON array `["self-hosted","omv","build"]` |
-| EspoCRM ETL → R2 | NodePort `127.0.0.1:30700` (#1397); API user `cloudless-app` + role ACL; `ESPOCRM_API_KEY` in GH + `cloudless-secrets`; run [30485173560](https://github.com/Themis128/cloudless.gr/actions/runs/30485173560) **5/5 entities** |
+| Item                               | Evidence                                                                                                                                                                                                                       |
+| ---------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| GitHub R2 + CF account secrets     | `CF_R2_*`, `CF_ACCOUNT_ID`, `CLOUDFLARE_*` set                                                                                                                                                                                 |
+| Wrangler `SESSION_SECRET`          | present (`wrangler secret list`)                                                                                                                                                                                               |
+| Wrangler `AGENT_AUTH_TOKEN`        | present                                                                                                                                                                                                                        |
+| Agentic `[aw] failed` issue spam   | `report-failure-as-issue: false` (#1386)                                                                                                                                                                                       |
+| AppFlowy R16 WAL + daily dump → R2 | live; `failed_count=0`                                                                                                                                                                                                         |
+| PVC backups → R2                   | smoke dump OK                                                                                                                                                                                                                  |
+| SSM default path retired           | Pi `SSM_DISABLED=1`; code needs `SSM_ENABLED=1` for AWS SSM                                                                                                                                                                    |
+| ETL runner label bug               | `runs-on` default is JSON array `["self-hosted","omv","build"]`                                                                                                                                                                |
+| EspoCRM ETL → R2                   | NodePort `127.0.0.1:30700` (#1397); API user `cloudless-app` + role ACL; `ESPOCRM_API_KEY` in GH + `cloudless-secrets`; run [30485173560](https://github.com/Themis128/cloudless.gr/actions/runs/30485173560) **5/5 entities** |
+| Kuma push monitors                 | 8 push monitors (`etl-espocrm` + 7 cluster); GH `KUMA_PUSH_ETL_ESPOCRM`; `cluster-alerts-kuma` Secret in monitoring/appflowy/espocrm/n8n/postiz                                                                                |
 
 ---
 
 ## ⏳ Still operator-only
 
-| Item | Notes |
-|------|-------|
-| Copilot fine-grained PAT | See section above — refresh env `copilot` secret if agents 401 |
+| Item                           | Notes                                                          |
+| ------------------------------ | -------------------------------------------------------------- |
 | Rotate after Variable exposure | Stripe / Slack / Notion / Cognito / Google / SES (table above) |
-| Optional ads/Sentry/Kuma secrets | `KUMA_PUSH_ETL_ESPOCRM` empty (ping skipped); leave unused empty |
-| Cloudflare API token rotation | If MCP CF tools 401 |
-| ESP32 Notion DBs | Empty (no hardware data); page reconstruct partial |
+| Optional ads/Sentry secrets    | Leave empty if unused                                          |
+| Cloudflare API token rotation  | If MCP CF tools 401                                            |
+| ESP32 Notion DBs               | Empty (no hardware data); page reconstruct partial             |
 
 ---
 
 ## 🔧 Verification
 
-1. `gh workflow run etl-espocrm-to-r2.yml` — green; picks `omv`/`build`; writes `lake/espocrm-*/*.parquet`
+1. `gh workflow run etl-espocrm-to-r2.yml` — green; picks `omv`/`build`; writes `lake/espocrm-*/*.parquet`; Kuma ping uses `KUMA_PUSH_ETL_ESPOCRM`
 2. Continuous WAL: `archived_count` advances, `failed_count=0`
 3. Daily CronJob `appflowy-walg-basebackup` at `30 2 * * *`
 4. `npx wrangler secret list --config wrangler.jsonc` includes SESSION + AGENT
@@ -85,3 +84,4 @@ python3 scripts/purge-sensitive-gh-variables.py --apply  # mutate
 1. Never `kubectl apply` empty Secret stubs for `appflowy-walg-r2` / `pvc-backup-r2`.
 2. `WALG_LOG_LEVEL` must be `NORMAL|DEVEL|ERROR` (not `INFO`).
 3. Checklist: `docs/current-source-of-truth-checklist.md`
+4. Do not re-apply `infrastructure/monitoring/cluster-alerts-kuma-secret.yaml` (PENDING sentinels wipe live tokens). Use `scripts/populate-kuma-secrets.sh` only.

--- a/docs/current-source-of-truth-checklist.md
+++ b/docs/current-source-of-truth-checklist.md
@@ -112,6 +112,11 @@ Runbook: [`docs/operator-blockers-runbook.md`](operator-blockers-runbook.md).
       API user `cloudless-app` + role ACL; `ESPOCRM_API_KEY` in GH + `cloudless-secrets`.
       Run https://github.com/Themis128/cloudless.gr/actions/runs/30485173560 — **5/5** entities
       → `lake/espocrm-{contacts,accounts,opportunities,cases,campaigns}/*.parquet`.
+- [x] `DONE` Kuma push monitors for ETL + cluster alerts (2026-07-29).
+      Evidence: 8 push monitors in Kuma SQLite; GH secret `KUMA_PUSH_ETL_ESPOCRM`;
+      `cluster-alerts-kuma` populated in monitoring/appflowy/espocrm/n8n/postiz;
+      ETL run https://github.com/Themis128/cloudless.gr/actions/runs/30486610424
+      shows non-empty `KUMA_PUSH_URL` on Ping Kuma step.
 - [x] `DONE` Search funnel analytics on Cloudflare D1 (query → result → click; buy hook ready).
       Evidence: `migrations/0008-search-funnel-events.sql`, `src/lib/search-funnel.ts`,
       `src/lib/funnel-client.ts`, `StoreGrid` beacons, `POST /api/analytics/track` D1 sink,
@@ -163,8 +168,10 @@ Issue template: `.github/ISSUE_TEMPLATE/ops-cadence.yml`.
       Stripe webhook **idempotency** prefers D1 `stripe_transaction` when `AUTH_DB`
       is bound (`persistStripeEvent` / mark helpers in `stripe-transactions.ts`);
       Dynamo `STRIPE_TRANSACTIONS_TABLE` remains legacy fallback.
-      Still AWS (follow-up): Athena cost/datalake UI reads; admin-notifications
-      Dynamo primary store; `stripe-analytics-read` Dynamo queries.
+      Still AWS (follow-up): Athena cost/datalake UI reads;
+      `stripe-analytics-read` Dynamo queries.
+      Admin-notifications prefer D1 `admin_notification` when `AUTH_DB` bound
+      (`src/lib/admin-notifications.ts` + migration 0011); Dynamo table is fallback.
 - [x] `DEFERRED` ESLint 10 + TypeScript 7 majors (ecosystem blockers 2026-07-29).
       ESLint 10 crashes `eslint-plugin-react` (`getFilename is not a function`);
       `eslint-plugin-import` / `jsx-a11y` peers stop at eslint 9. TypeScript 7

--- a/infrastructure/monitoring/cluster-alerts-kuma-secret.yaml
+++ b/infrastructure/monitoring/cluster-alerts-kuma-secret.yaml
@@ -1,37 +1,35 @@
-# cluster-alerts-kuma — Uptime Kuma push-monitor tokens for all in-cluster
-# alert sources. Single Secret consumed by 3 monitoring CronJobs + 4 backup
-# CronJobs across 5 namespaces.
+# cluster-alerts-kuma — DOCUMENTATION ONLY
 #
-# The literal value `PENDING_UI_CREATION` is a sentinel that lets the cluster
-# apply this manifest before the operator has logged into Kuma to create the
-# 7 push monitors. Because every consumer uses:
-#   - optional: true on the secretKeyRef
-#   - `[ -n "${KUMA_PUSH_TOKEN:-}" ] && wget … || true` in the script
-# a sentinel token causes Kuma to return 404 which is silently swallowed.
-# Slack-direct fallback continues to fire so we are NOT blind.
+# DO NOT `kubectl apply -f` this file.
+# Live tokens were populated 2026-07-29 via `scripts/populate-kuma-secrets.sh`
+# into namespaces: monitoring, appflowy, espocrm, n8n, postiz.
+# Applying the PENDING_UI_CREATION sentinels below would overwrite those keys.
 #
-# Real tokens are populated by `scripts/populate-kuma-secrets.sh` once the
-# operator has run through skills/uptime-kuma-operator/SKILL.md
-# ("Creating a push monitor" walkthrough).
+# Expected Secret keys (Opaque `cluster-alerts-kuma`):
+#   KUMA_PUSH_K3S_POD_HEALTH
+#   KUMA_PUSH_ETCD_SNAPSHOT_AGE
+#   KUMA_PUSH_CLOUDFLARED_DRIFT
+#   KUMA_PUSH_BACKUP_APPFLOWY
+#   KUMA_PUSH_BACKUP_ESPOCRM
+#   KUMA_PUSH_BACKUP_N8N
+#   KUMA_PUSH_BACKUP_POSTIZ
 #
-# NOTE: this Secret lives ONLY in the `monitoring` namespace. The 4 backup
-# CronJobs reach it via cross-namespace replication that the operator must
-# create after first real-token apply (or by `kubectl create secret …` per
-# namespace). The script handles both modes.
+# Rotate / re-seed:
+#   bash scripts/populate-kuma-secrets.sh <7 tokens>
+#   See skills/uptime-kuma-operator/SKILL.md
+#
+# GH Actions EspoCRM ETL uses a separate repo secret:
+#   KUMA_PUSH_ETL_ESPOCRM = full https://kuma.cloudless.gr/api/push/<token>?status=up&msg=OK&ping=
 ---
 apiVersion: v1
 kind: Secret
 metadata:
   name: cluster-alerts-kuma
   namespace: monitoring
+  annotations:
+    cloudless.gr/do-not-apply: "true"
+    cloudless.gr/managed-by: scripts/populate-kuma-secrets.sh
 type: Opaque
-stringData:
-  # cluster-health monitors (omv-watchdogs.yaml + cloudflared-drift.yaml)
-  KUMA_PUSH_K3S_POD_HEALTH: "PENDING_UI_CREATION"
-  KUMA_PUSH_ETCD_SNAPSHOT_AGE: "PENDING_UI_CREATION"
-  KUMA_PUSH_CLOUDFLARED_DRIFT: "PENDING_UI_CREATION"
-  # backup monitors (infrastructure/backup/cronjob-*.yaml)
-  KUMA_PUSH_BACKUP_APPFLOWY: "PENDING_UI_CREATION"
-  KUMA_PUSH_BACKUP_ESPOCRM: "PENDING_UI_CREATION"
-  KUMA_PUSH_BACKUP_N8N: "PENDING_UI_CREATION"
-  KUMA_PUSH_BACKUP_POSTIZ: "PENDING_UI_CREATION"
+# Intentionally empty data map — kubectl apply of this object must not
+# replace live stringData. Operators seed via populate-kuma-secrets.sh.
+data: {}

--- a/infrastructure/monitoring/cluster-alerts-kuma-secret.yaml
+++ b/infrastructure/monitoring/cluster-alerts-kuma-secret.yaml
@@ -1,11 +1,13 @@
-# cluster-alerts-kuma — DOCUMENTATION ONLY
+# cluster-alerts-kuma — DOCUMENTATION ONLY (not a kubectl manifest)
 #
-# DO NOT `kubectl apply -f` this file.
+# DO NOT `kubectl apply -f` this file. There is intentionally no Secret
+# resource here — applying an empty/sentinel Secret would wipe live tokens.
+#
 # Live tokens were populated 2026-07-29 via `scripts/populate-kuma-secrets.sh`
 # into namespaces: monitoring, appflowy, espocrm, n8n, postiz.
-# Applying the PENDING_UI_CREATION sentinels below would overwrite those keys.
 #
-# Expected Secret keys (Opaque `cluster-alerts-kuma`):
+# Expected Opaque Secret name: cluster-alerts-kuma
+# Keys:
 #   KUMA_PUSH_K3S_POD_HEALTH
 #   KUMA_PUSH_ETCD_SNAPSHOT_AGE
 #   KUMA_PUSH_CLOUDFLARED_DRIFT
@@ -19,17 +21,5 @@
 #   See skills/uptime-kuma-operator/SKILL.md
 #
 # GH Actions EspoCRM ETL uses a separate repo secret:
-#   KUMA_PUSH_ETL_ESPOCRM = full https://kuma.cloudless.gr/api/push/<token>?status=up&msg=OK&ping=
----
-apiVersion: v1
-kind: Secret
-metadata:
-  name: cluster-alerts-kuma
-  namespace: monitoring
-  annotations:
-    cloudless.gr/do-not-apply: "true"
-    cloudless.gr/managed-by: scripts/populate-kuma-secrets.sh
-type: Opaque
-# Intentionally empty data map — kubectl apply of this object must not
-# replace live stringData. Operators seed via populate-kuma-secrets.sh.
-data: {}
+#   KUMA_PUSH_ETL_ESPOCRM = full
+#   https://kuma.cloudless.gr/api/push/<token>?status=up&msg=OK&ping=

--- a/skills/uptime-kuma-operator/SKILL.md
+++ b/skills/uptime-kuma-operator/SKILL.md
@@ -143,8 +143,8 @@ dual-fire in the new CronJob.
   `KUMA_PUSH_ETCD_SNAPSHOT_AGE`).
 - `infrastructure/monitoring/cloudflared-drift.yaml` — cloudflared-drift-check
   (`KUMA_PUSH_CLOUDFLARED_DRIFT`).
-- `infrastructure/monitoring/cluster-alerts-kuma-secret.yaml` — Secret
-  template (7-key sentinel).
+- `infrastructure/monitoring/cluster-alerts-kuma-secret.yaml` — docs-only
+  stub (`data: {}`); **never apply** — live tokens via `populate-kuma-secrets.sh`.
 - `infrastructure/backup/cronjob-{appflowy,espocrm,n8n,postiz}.yaml` — 4
   daily backup CronJobs (`KUMA_PUSH_BACKUP_*`).
 - `scripts/populate-kuma-secrets.sh` — token loader.


### PR DESCRIPTION
## Summary
- Mark Kuma push monitors + `KUMA_PUSH_ETL_ESPOCRM` cleared in `ACTIONS-REQUIRED.md`.
- Add checklist evidence (8 push monitors, cluster secrets, ETL run with non-empty Kuma ping).
- Drop obsolete Copilot-PAT / empty-Kuma rows from operator-only list.

## Test plan
- [x] ETL run 30486610424 succeeded with `KUMA_PUSH_URL` set
- [x] Docs-only diff

Made with [Cursor](https://cursor.com)