### PR TITLE
feat(admin): D1-first admin notifications store

### DIFF
--- a/__tests__/admin-notifications.test.ts
+++ b/__tests__/admin-notifications.test.ts
@@ -52,11 +52,13 @@ describe("admin-notifications", () => {
     updateCalls.length = 0;
     batchWriteCalls.length = 0;
     process.env.ADMIN_NOTIFICATIONS_TABLE = "test-notifs";
+    delete (globalThis as { __AUTH_DB__?: unknown }).__AUTH_DB__;
   });
 
   afterEach(() => {
     if (originalTable === undefined) delete process.env.ADMIN_NOTIFICATIONS_TABLE;
     else process.env.ADMIN_NOTIFICATIONS_TABLE = originalTable;
+    delete (globalThis as { __AUTH_DB__?: unknown }).__AUTH_DB__;
   });
 
   describe("recordNotification", () => {
@@ -361,6 +363,131 @@ describe("admin-notifications", () => {
       const n = await purgeArchivedOlderThan("2026-01-01");
       expect(n).toBe(2);
       expect(batchWriteCalls).toHaveLength(2);
+    });
+  });
+
+  describe("D1 path", () => {
+    type Row = Record<string, unknown>;
+    function createMemoryDb() {
+      const rows: Row[] = [];
+      return {
+        rows,
+        prepare(query: string) {
+          const binds: unknown[] = [];
+          const stmt = {
+            bind(...args: unknown[]) {
+              binds.push(...args);
+              return stmt;
+            },
+            async run() {
+              if (query.includes("INSERT INTO admin_notification")) {
+                rows.push({
+                  pk: binds[0],
+                  sk: binds[1],
+                  category: binds[2],
+                  id: binds[3],
+                  type: binds[4],
+                  title: binds[5],
+                  message: binds[6],
+                  actor: binds[7],
+                  route: binds[8],
+                  read: binds[9],
+                  archived_at: binds[10],
+                  cat_pk: binds[11],
+                  cat_sk: binds[12],
+                  payload_json: binds[13],
+                  created_at: binds[14],
+                });
+                return { success: true, meta: { changes: 1 } };
+              }
+              if (query.includes("UPDATE admin_notification SET read")) {
+                const id = binds[0];
+                for (const r of rows) {
+                  if (r.id === id) r.read = 1;
+                }
+                return { success: true, meta: { changes: 1 } };
+              }
+              if (query.includes("DELETE FROM admin_notification")) {
+                const cutoff = String(binds[0]);
+                let changes = 0;
+                for (let i = rows.length - 1; i >= 0; i--) {
+                  const archived = rows[i].archived_at;
+                  if (typeof archived === "string" && archived && archived < cutoff) {
+                    rows.splice(i, 1);
+                    changes++;
+                  }
+                }
+                return { success: true, meta: { changes } };
+              }
+              return { success: true, meta: { changes: 0 } };
+            },
+            async all<T = Row>() {
+              let filtered = [...rows];
+              // Minimal SQL interpreter for the list query shape used in D1 path
+              if (query.includes("FROM admin_notification")) {
+                let bi = 0;
+                if (query.includes("category = ?")) {
+                  const cat = binds[bi++];
+                  filtered = filtered.filter((r) => r.category === cat);
+                } else if (query.includes("pk = ?")) {
+                  const pk = binds[bi++];
+                  filtered = filtered.filter((r) => r.pk === pk);
+                }
+                if (query.includes("sk >= ?")) {
+                  const since = String(binds[bi++]);
+                  filtered = filtered.filter((r) => String(r.sk) >= since);
+                }
+                if (query.includes("sk < ?")) {
+                  const until = String(binds[bi++]);
+                  filtered = filtered.filter((r) => String(r.sk) < until);
+                }
+                if (query.includes("archived_at IS NULL")) {
+                  filtered = filtered.filter((r) => !r.archived_at);
+                }
+                const limit = Number(binds[binds.length - 1] ?? 50);
+                filtered.sort((a, b) => String(b.sk).localeCompare(String(a.sk)));
+                filtered = filtered.slice(0, limit);
+              }
+              return { results: filtered as T[], success: true };
+            },
+            async first() {
+              return null;
+            },
+          };
+          return stmt;
+        },
+      };
+    }
+
+    it("records and lists via D1 without touching Dynamo", async () => {
+      const db = createMemoryDb();
+      (globalThis as { __AUTH_DB__?: unknown }).__AUTH_DB__ = db;
+      const r = await recordNotification({
+        category: "contact",
+        title: "Hi",
+        message: "There",
+        actor: "a@b.c",
+      });
+      expect(r).not.toBeNull();
+      expect(mockDynamoSend).not.toHaveBeenCalled();
+      expect(db.rows).toHaveLength(1);
+      const listed = await listNotifications({ limit: 10 });
+      expect(listed).toHaveLength(1);
+      expect(listed[0].title).toBe("Hi");
+      expect(listed[0].actor).toBe("a@b.c");
+    });
+
+    it("marks read and purges archived on D1", async () => {
+      const db = createMemoryDb();
+      (globalThis as { __AUTH_DB__?: unknown }).__AUTH_DB__ = db;
+      const r = await recordNotification({ category: "order", title: "T", message: "M" });
+      expect(r?.id).toBeTruthy();
+      await markNotificationsRead([r!.id]);
+      expect(db.rows[0].read).toBe(1);
+      db.rows[0].archived_at = "2020-01-01T00:00:00.000Z";
+      const purged = await purgeArchivedOlderThan("2021-01-01");
+      expect(purged).toBe(1);
+      expect(db.rows).toHaveLength(0);
     });
   });
 });

--- a/docs/current-source-of-truth-checklist.md
+++ b/docs/current-source-of-truth-checklist.md
@@ -163,8 +163,10 @@ Issue template: `.github/ISSUE_TEMPLATE/ops-cadence.yml`.
       Stripe webhook **idempotency** prefers D1 `stripe_transaction` when `AUTH_DB`
       is bound (`persistStripeEvent` / mark helpers in `stripe-transactions.ts`);
       Dynamo `STRIPE_TRANSACTIONS_TABLE` remains legacy fallback.
-      Still AWS (follow-up): Athena cost/datalake UI reads; admin-notifications
-      Dynamo primary store; `stripe-analytics-read` Dynamo queries.
+      Still AWS (follow-up): Athena cost/datalake UI reads;
+      `stripe-analytics-read` Dynamo queries.
+      Admin-notifications prefer D1 `admin_notification` when `AUTH_DB` bound
+      (`src/lib/admin-notifications.ts` + migration 0011); Dynamo table is fallback.
 - [x] `DEFERRED` ESLint 10 + TypeScript 7 majors (ecosystem blockers 2026-07-29).
       ESLint 10 crashes `eslint-plugin-react` (`getFilename is not a function`);
       `eslint-plugin-import` / `jsx-a11y` peers stop at eslint 9. TypeScript 7

--- a/migrations/0001-auth-schema.sql
+++ b/migrations/0001-auth-schema.sql
@@ -62,9 +62,24 @@ CREATE TABLE IF NOT EXISTS admin_notification (
   pk TEXT NOT NULL,
   sk TEXT NOT NULL,
   category TEXT NOT NULL,
+  id TEXT,
+  type TEXT,
+  title TEXT,
+  message TEXT,
+  actor TEXT,
+  route TEXT,
+  read INTEGER NOT NULL DEFAULT 0,
+  archived_at TEXT,
+  cat_pk TEXT,
+  cat_sk TEXT,
   payload_json TEXT,
   created_at INTEGER NOT NULL DEFAULT (strftime('%s', 'now'))
 );
+
+CREATE INDEX IF NOT EXISTS idx_admin_notif_sk ON admin_notification(sk);
+CREATE INDEX IF NOT EXISTS idx_admin_notif_category ON admin_notification(category);
+CREATE INDEX IF NOT EXISTS idx_admin_notif_id ON admin_notification(id);
+CREATE INDEX IF NOT EXISTS idx_admin_notif_cat_pk ON admin_notification(cat_pk);
 
 
 -- Analytics cache (replaces AnalyticsCache DynamoDB table)

--- a/migrations/0011-admin-notification-fields.sql
+++ b/migrations/0011-admin-notification-fields.sql
@@ -1,0 +1,16 @@
+-- Expand admin_notification for Dynamo-parity / Workers free-tier inserts
+ALTER TABLE admin_notification ADD COLUMN id TEXT;
+ALTER TABLE admin_notification ADD COLUMN type TEXT;
+ALTER TABLE admin_notification ADD COLUMN title TEXT;
+ALTER TABLE admin_notification ADD COLUMN message TEXT;
+ALTER TABLE admin_notification ADD COLUMN actor TEXT;
+ALTER TABLE admin_notification ADD COLUMN route TEXT;
+ALTER TABLE admin_notification ADD COLUMN read INTEGER NOT NULL DEFAULT 0;
+ALTER TABLE admin_notification ADD COLUMN archived_at TEXT;
+ALTER TABLE admin_notification ADD COLUMN cat_pk TEXT;
+ALTER TABLE admin_notification ADD COLUMN cat_sk TEXT;
+
+CREATE INDEX IF NOT EXISTS idx_admin_notif_sk ON admin_notification(sk);
+CREATE INDEX IF NOT EXISTS idx_admin_notif_category ON admin_notification(category);
+CREATE INDEX IF NOT EXISTS idx_admin_notif_id ON admin_notification(id);
+CREATE INDEX IF NOT EXISTS idx_admin_notif_cat_pk ON admin_notification(cat_pk);

--- a/schema.sql
+++ b/schema.sql
@@ -50,9 +50,23 @@ CREATE TABLE admin_notification (
     pk TEXT NOT NULL,
     sk TEXT NOT NULL,
     category TEXT NOT NULL,
+    id TEXT,
+    type TEXT,
+    title TEXT,
+    message TEXT,
+    actor TEXT,
+    route TEXT,
+    read INTEGER NOT NULL DEFAULT 0,
+    archived_at TEXT,
+    cat_pk TEXT,
+    cat_sk TEXT,
     payload_json TEXT,
     created_at INTEGER NOT NULL DEFAULT (strftime('%s', 'now'))
 );
+
+CREATE INDEX IF NOT EXISTS idx_admin_notif_sk ON admin_notification(sk);
+CREATE INDEX IF NOT EXISTS idx_admin_notif_category ON admin_notification(category);
+CREATE INDEX IF NOT EXISTS idx_admin_notif_id ON admin_notification(id);
 
 -- Analytics cache table
 CREATE TABLE analytics_cache (

--- a/src/lib/admin-notifications.ts
+++ b/src/lib/admin-notifications.ts
@@ -8,31 +8,30 @@ import {
 } from "@aws-sdk/client-dynamodb";
 import { resolveDynamoEndpoint } from "@/lib/stripe-transactions";
 import { getDataLakeBucketFromEnv } from "@/lib/r2-client";
+import { getAuthDbFromEnv, type AuthDatabase } from "@/lib/auth-d1";
 
 /**
- * Durable admin notifications store on DynamoDB.
+ * Durable admin notifications store.
  *
- * Schema:
- *   - pk = "NOTIF"  (single partition — small scale, simpler queries)
- *   - sk = "<createdAt-ISO8601>#<id>"  (sortable, unique)
+ * Cloudflare-first: prefer D1 `admin_notification` when AUTH_DB is bound.
+ * Legacy fallback: DynamoDB `ADMIN_NOTIFICATIONS_TABLE`.
+ *
+ * Dynamo schema (legacy):
+ *   - pk = "NOTIF"
+ *   - sk = "<createdAt-ISO8601>#<id>"
  *   - GSI categoryIndex: pk = "CAT#<category>", sk = "<createdAt-ISO8601>#<id>"
  *
- * Categories:
- *   contact   — contact form submission
- *   subscribe — newsletter sign-up
- *   booking   — calendar booking
- *   order     — Stripe paid checkout
- *   error     — application exception
- *   auth      — sign-up / sign-in / password reset
- *   portal    — client-portal action
- *
- * Retention policy: 90 days hot in Dynamo. After 90 days, the daily archive
- * cron job sets `archivedAt` and exports the row to R2 datalake. Rows with
- * `archivedAt` set are excluded from the admin UI by default.
+ * Categories: contact | subscribe | booking | order | error | auth | portal
  */
 
 export type NotificationCategory =
-  "contact" | "subscribe" | "booking" | "order" | "error" | "auth" | "portal";
+  | "contact"
+  | "subscribe"
+  | "booking"
+  | "order"
+  | "error"
+  | "auth"
+  | "portal";
 
 export type NotificationType = "info" | "warning" | "error" | "success";
 
@@ -50,7 +49,7 @@ export interface AdminNotification {
   /** Free-form structured payload for analytics. */
   metadata?: Record<string, unknown>;
   read: boolean;
-  /** Set by the archive cron when the row is exported to S3. */
+  /** Set by the archive cron when the row is exported to the lake. */
   archivedAt?: string;
 }
 
@@ -128,6 +127,152 @@ function fromItem(item: Record<string, AttributeValue>): AdminNotification {
   };
 }
 
+interface D1NotificationRow {
+  pk: string;
+  sk: string;
+  category: string;
+  id: string | null;
+  type: string | null;
+  title: string | null;
+  message: string | null;
+  actor: string | null;
+  route: string | null;
+  read: number | null;
+  archived_at: string | null;
+  payload_json: string | null;
+  created_at: number | null;
+}
+
+function fromD1Row(row: D1NotificationRow): AdminNotification {
+  let metadata: Record<string, unknown> | undefined;
+  if (row.payload_json) {
+    try {
+      metadata = JSON.parse(row.payload_json) as Record<string, unknown>;
+    } catch {
+      // drop
+    }
+  }
+  const createdAt =
+    row.sk?.includes("#") && row.sk.split("#")[0]
+      ? row.sk.split("#")[0]
+      : row.created_at
+        ? new Date(row.created_at * 1000).toISOString()
+        : "";
+  return {
+    id: row.id ?? (row.sk.includes("#") ? row.sk.slice(row.sk.indexOf("#") + 1) : ""),
+    createdAt,
+    category: (row.category ?? "error") as NotificationCategory,
+    type: (row.type ?? "info") as NotificationType,
+    title: row.title ?? "",
+    message: row.message ?? "",
+    actor: row.actor ?? undefined,
+    route: row.route ?? undefined,
+    metadata,
+    read: Boolean(row.read),
+    archivedAt: row.archived_at ?? undefined,
+  };
+}
+
+async function recordNotificationD1(
+  db: AuthDatabase,
+  notif: AdminNotification
+): Promise<AdminNotification | null> {
+  const sk = buildSk(notif.createdAt, notif.id);
+  const createdAtUnix = Math.floor(new Date(notif.createdAt).getTime() / 1000);
+  try {
+    await db
+      .prepare(
+        `INSERT INTO admin_notification (
+          pk, sk, category, id, type, title, message, actor, route,
+          read, archived_at, cat_pk, cat_sk, payload_json, created_at
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+      )
+      .bind(
+        PK_ALL,
+        sk,
+        notif.category,
+        notif.id,
+        notif.type,
+        notif.title,
+        notif.message,
+        notif.actor ?? null,
+        notif.route ?? null,
+        notif.read ? 1 : 0,
+        notif.archivedAt ?? null,
+        `CAT#${notif.category}`,
+        sk,
+        notif.metadata ? JSON.stringify(notif.metadata) : null,
+        createdAtUnix
+      )
+      .run();
+    return notif;
+  } catch (err) {
+    console.warn(
+      "[admin-notifications] D1 recordNotification failed:",
+      err instanceof Error ? err.message : err
+    );
+    return null;
+  }
+}
+
+async function listNotificationsD1(
+  db: AuthDatabase,
+  filters: ListFilters
+): Promise<AdminNotification[]> {
+  const limit = Math.min(Math.max(filters.limit ?? 50, 1), 200);
+  const clauses: string[] = [];
+  const binds: unknown[] = [];
+
+  if (filters.category) {
+    clauses.push("category = ?");
+    binds.push(filters.category);
+  } else {
+    clauses.push("pk = ?");
+    binds.push(PK_ALL);
+  }
+
+  if (filters.since) {
+    clauses.push("sk >= ?");
+    binds.push(`${filters.since}#`);
+  }
+  if (filters.until) {
+    clauses.push("sk < ?");
+    binds.push(`${filters.until}~`);
+  }
+  if (!filters.includeArchived) {
+    clauses.push("(archived_at IS NULL OR archived_at = '')");
+  }
+
+  const where = clauses.length ? `WHERE ${clauses.join(" AND ")}` : "";
+  const sql = `SELECT pk, sk, category, id, type, title, message, actor, route,
+                      read, archived_at, payload_json, created_at
+               FROM admin_notification
+               ${where}
+               ORDER BY sk DESC
+               LIMIT ?`;
+  binds.push(limit);
+
+  const result = await db.prepare(sql).bind(...binds).all<D1NotificationRow>();
+  return (result.results ?? []).map(fromD1Row);
+}
+
+async function markNotificationsReadD1(db: AuthDatabase, ids: string[]): Promise<void> {
+  for (const id of ids) {
+    await db.prepare(`UPDATE admin_notification SET read = 1 WHERE id = ?`).bind(id).run();
+  }
+}
+
+async function purgeArchivedOlderThanD1(db: AuthDatabase, olderThan: string): Promise<number> {
+  const result = await db
+    .prepare(
+      `DELETE FROM admin_notification
+       WHERE archived_at IS NOT NULL AND archived_at <> '' AND archived_at < ?`
+    )
+    .bind(olderThan)
+    .run();
+  return result.meta?.changes ?? 0;
+}
+
 /**
  * Append a notification. Failures are returned (not thrown) so producer paths
  * can keep serving the user-facing response. Callers should log but not abort.
@@ -157,8 +302,13 @@ export async function recordNotification(input: {
   // Always write to data lake (R2) for analytics — fire and forget.
   sinkToLake(notif).catch(() => {});
 
+  const db = getAuthDbFromEnv();
+  if (db) {
+    return recordNotificationD1(db, notif);
+  }
+
   if (!process.env.ADMIN_NOTIFICATIONS_TABLE) {
-    // DynamoDB table not configured — lake-only mode.
+    // No D1 / Dynamo — lake-only mode.
     return notif;
   }
   try {
@@ -192,6 +342,15 @@ export interface ListFilters {
  * un-archived entries.
  */
 export async function listNotifications(filters: ListFilters = {}): Promise<AdminNotification[]> {
+  const db = getAuthDbFromEnv();
+  if (db) {
+    return listNotificationsD1(db, filters);
+  }
+
+  if (!process.env.ADMIN_NOTIFICATIONS_TABLE) {
+    return [];
+  }
+
   const limit = Math.min(Math.max(filters.limit ?? 50, 1), 200);
   const useCategoryIndex = Boolean(filters.category);
 
@@ -209,13 +368,10 @@ export async function listNotifications(filters: ListFilters = {}): Promise<Admi
     exprValues[":pk"] = { S: PK_ALL };
   }
 
-  // Range condition on the sort key (which encodes createdAt).
   if (filters.since && filters.until) {
     keyConditionParts.push("#sk BETWEEN :since AND :until");
     exprNames["#sk"] = useCategoryIndex ? "catSk" : "sk";
     exprValues[":since"] = { S: `${filters.since}#` };
-    // End-of-range trick: append "~" so we capture every id with the
-    // until timestamp prefix.
     exprValues[":until"] = { S: `${filters.until}~` };
   } else if (filters.since) {
     keyConditionParts.push("#sk >= :since");
@@ -228,9 +384,6 @@ export async function listNotifications(filters: ListFilters = {}): Promise<Admi
     filterExpressions.push("attribute_not_exists(#archivedAt)");
     exprNames["#archivedAt"] = "archivedAt";
   }
-  if (!filters.includeRead) {
-    // Keep this opt-in too — by default the UI shows everything.
-  }
 
   const out = await getDynamoClient().send(
     new QueryCommand({
@@ -241,7 +394,7 @@ export async function listNotifications(filters: ListFilters = {}): Promise<Admi
       ExpressionAttributeNames: exprNames,
       ExpressionAttributeValues: exprValues,
       Limit: limit,
-      ScanIndexForward: false, // newest first
+      ScanIndexForward: false,
     })
   );
 
@@ -252,9 +405,16 @@ export async function listNotifications(filters: ListFilters = {}): Promise<Admi
  * Mark a set of notifications as read.
  */
 export async function markNotificationsRead(ids: string[]): Promise<void> {
-  if (!ids.length || !process.env.ADMIN_NOTIFICATIONS_TABLE) return;
-  // We can't UpdateItem without the full sort key, so fetch + update.
-  // For small batches this is fine. (Optimization: store an idIndex GSI.)
+  if (!ids.length) return;
+
+  const db = getAuthDbFromEnv();
+  if (db) {
+    await markNotificationsReadD1(db, ids);
+    return;
+  }
+
+  if (!process.env.ADMIN_NOTIFICATIONS_TABLE) return;
+
   for (const id of ids) {
     const matches = await getDynamoClient().send(
       new QueryCommand({
@@ -285,7 +445,6 @@ export async function markNotificationsRead(ids: string[]): Promise<void> {
 
 /**
  * Per-category counts over a window. Used by the admin analytics endpoint.
- * Returns { total, byCategory: { contact: N, ... }, byDay: { '2026-06-12': N, ... } }.
  */
 export async function notificationAnalytics(
   opts: {
@@ -325,12 +484,16 @@ export async function notificationAnalytics(
 
 /**
  * Hard-delete archived rows older than `olderThan` (ISO 8601 cutoff).
- * Called by the archive cron AFTER successful S3 export + grace window.
- * Returns the number of rows deleted.
  */
 export async function purgeArchivedOlderThan(olderThan: string): Promise<number> {
+  const db = getAuthDbFromEnv();
+  if (db) {
+    return purgeArchivedOlderThanD1(db, olderThan);
+  }
+
+  if (!process.env.ADMIN_NOTIFICATIONS_TABLE) return 0;
+
   let purged = 0;
-  // Walk in batches of 25 (BatchWriteItem max).
   let lastKey: Record<string, AttributeValue> | undefined;
   do {
     const page: QueryCommand = new QueryCommand({
@@ -370,7 +533,6 @@ export async function purgeArchivedOlderThan(olderThan: string): Promise<number>
 
 // ---------------------------------------------------------------------------
 // Data Lake sink — writes notifications to R2 (DATALAKE_BUCKET).
-// Partitioned by year/month for the notifications table schema.
 // ---------------------------------------------------------------------------
 
 async function sinkToLake(notif: AdminNotification): Promise<void> {


### PR DESCRIPTION
## Summary
- `admin-notifications` prefers **D1** `admin_notification` when `AUTH_DB` is bound (record / list / mark-read / purge).
- Dynamo `ADMIN_NOTIFICATIONS_TABLE` remains the legacy fallback.
- Migration `0011-admin-notification-fields.sql` adds id/type/title/message/actor/route/read/archived_at/cat_* columns (already applied on remote `user-auth-db`).
- Checklist updated; next leftover is `stripe-analytics-read` Dynamo reads / Athena UI.

## Test plan
- [x] `vitest` `__tests__/admin-notifications.test.ts` (24) — Dynamo + D1 paths
- [x] `pnpm typecheck` / `pnpm lint`
- [x] Remote D1 migration 0011 applied
- [ ] CI green


Made with [Cursor](https://cursor.com)