### PR TITLE
style: prettier admin-notifications.ts

### DIFF
--- a/src/lib/admin-notifications.ts
+++ b/src/lib/admin-notifications.ts
@@ -25,13 +25,7 @@ import { getAuthDbFromEnv, type AuthDatabase } from "@/lib/auth-d1";
  */
 
 export type NotificationCategory =
-  | "contact"
-  | "subscribe"
-  | "booking"
-  | "order"
-  | "error"
-  | "auth"
-  | "portal";
+  "contact" | "subscribe" | "booking" | "order" | "error" | "auth" | "portal";
 
 export type NotificationType = "info" | "warning" | "error" | "success";
 
@@ -252,7 +246,10 @@ async function listNotificationsD1(
                LIMIT ?`;
   binds.push(limit);
 
-  const result = await db.prepare(sql).bind(...binds).all<D1NotificationRow>();
+  const result = await db
+    .prepare(sql)
+    .bind(...binds)
+    .all<D1NotificationRow>();
   return (result.results ?? []).map(fromD1Row);
 }
 


### PR DESCRIPTION
## Summary
- Prettier formatting for `src/lib/admin-notifications.ts` after the D1-first cutover.
- Closes the Lint & Format failure from #1406 (feature content already on `main`).

## Test plan
- [x] `pnpm exec prettier --check src/lib/admin-notifications.ts`
- [ ] CI Lint & Format green


Made with [Cursor](https://cursor.com)