### PR TITLE
feat(stripe): D1-first analytics snapshot reads

### DIFF
--- a/.github/workflows/monitoring-node-selector-fix.md
+++ b/.github/workflows/monitoring-node-selector-fix.md
@@ -60,7 +60,6 @@ Patch monitoring pods (Prometheus, Alertmanager, kube-state-metrics, cloudwatch-
    - Wait for rollout completion
 5. If component not found, log that it may already be running
 
-
 ## Runtime notes (gh-aw + Gemini)
 
 - GitHub **reads**: use the `github` CLI on PATH (MCP bridge). Start with `github --help`. Do **not** invent names like `github_mcp_server` or bare `create_issue`.

--- a/__tests__/stripe-analytics-read.test.ts
+++ b/__tests__/stripe-analytics-read.test.ts
@@ -1,4 +1,5 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import type { AuthDatabase } from "@/lib/auth-d1";
 
 const mockSend = vi.fn();
 
@@ -31,14 +32,54 @@ function makeItem(overrides: Record<string, unknown> = {}) {
   };
 }
 
+function createAnalyticsAuthDb(
+  rows: Array<Record<string, unknown>>
+): AuthDatabase {
+  return {
+    prepare(query: string) {
+      const binds: unknown[] = [];
+      const stmt = {
+        bind(...args: unknown[]) {
+          binds.push(...args);
+          return stmt;
+        },
+        async run() {
+          return { success: true, meta: { changes: 0 } };
+        },
+        async all<T = Record<string, unknown>>() {
+          if (!query.includes("FROM stripe_transaction")) {
+            return { results: [] as T[], success: true };
+          }
+          const startDay = String(binds[0] ?? "");
+          const endDay = String(binds[1] ?? "");
+          const filtered = rows.filter((row) => {
+            const day = String(row.event_day ?? "");
+            return day >= startDay && day <= endDay;
+          });
+          return { results: filtered as T[], success: true };
+        },
+        async first() {
+          return null;
+        },
+      };
+      return stmt;
+    },
+  };
+}
+
 describe("getStripeAnalyticsSnapshot()", () => {
   beforeEach(() => {
     vi.resetModules();
     vi.clearAllMocks();
     process.env.STRIPE_TRANSACTIONS_TABLE = TABLE_NAME;
+    delete (globalThis as { __AUTH_DB__?: unknown }).__AUTH_DB__;
   });
 
-  it("throws when STRIPE_TRANSACTIONS_TABLE is not set", async () => {
+  afterEach(() => {
+    delete (globalThis as { __AUTH_DB__?: unknown }).__AUTH_DB__;
+  });
+
+  it("throws when STRIPE_TRANSACTIONS_TABLE is not set and D1 is unbound", async () => {
     delete process.env.STRIPE_TRANSACTIONS_TABLE;
     const { getStripeAnalyticsSnapshot } = await import("@/lib/stripe-analytics-read");
     await expect(getStripeAnalyticsSnapshot()).rejects.toThrow(
@@ -203,5 +244,43 @@ describe("getStripeAnalyticsSnapshot()", () => {
     const result = await getStripeAnalyticsSnapshot(7);
     expect(typeof result.generatedAt).toBe("string");
     expect(new Date(result.generatedAt).getTime()).toBeGreaterThan(0);
+  });
+
+  it("prefers D1 stripe_transaction when AUTH_DB is bound", async () => {
+    const today = new Date().toISOString().slice(0, 10);
+    delete process.env.STRIPE_TRANSACTIONS_TABLE;
+    (globalThis as { __AUTH_DB__?: AuthDatabase }).__AUTH_DB__ = createAnalyticsAuthDb([
+      {
+        event_day: today,
+        tag_category: "checkout",
+        processing_status: "processed",
+        currency: "eur",
+        amount_minor: 1500,
+        received_at: Date.now(),
+        payload_json: null,
+      },
+      {
+        event_day: today,
+        tag_category: "subscription",
+        processing_status: "handler_failed",
+        currency: "usd",
+        amount_minor: null,
+        received_at: Date.now(),
+        payload_json: JSON.stringify({ amount_total: 2500, currency: "usd" }),
+      },
+    ]);
+
+    const { getStripeAnalyticsSnapshot } = await import("@/lib/stripe-analytics-read");
+    const result = await getStripeAnalyticsSnapshot(1);
+
+    expect(mockSend).not.toHaveBeenCalled();
+    expect(result.totals.events).toBe(2);
+    expect(result.totals.revenueMinor).toBe(4000);
+    expect(result.totals.processed).toBe(1);
+    expect(result.totals.failed).toBe(1);
+    expect(result.byCategory.checkout.revenueMinor).toBe(1500);
+    expect(result.byCategory.subscription.revenueMinor).toBe(2500);
+    expect(result.byCurrency.eur).toBe(1500);
+    expect(result.byCurrency.usd).toBe(2500);
   });
 });

--- a/__tests__/stripe-transactions.test.ts
+++ b/__tests__/stripe-transactions.test.ts
@@ -52,6 +52,8 @@ function createMemoryAuthDb(): AuthDatabase & { rows: Map<string, Record<string,
               event_type: binds[1],
               processing_status: binds[7],
               received_at: binds[8],
+              amount_minor: binds[9],
+              currency: binds[10],
             });
             return { success: true, meta: { changes: 1 } };
           }
@@ -150,6 +152,8 @@ describe("stripe transactions D1 idempotency", () => {
     expect(await persistStripeEvent(event)).toEqual({ duplicate: false });
     expect(await persistStripeEvent(event)).toEqual({ duplicate: true });
     expect(db.rows.get("evt_d1_1")?.processing_status).toBe("received");
+    expect(db.rows.get("evt_d1_1")?.amount_minor).toBe(4900);
+    expect(db.rows.get("evt_d1_1")?.currency).toBe("eur");
   });
 
   it("marks processed and failed on D1 rows", async () => {

--- a/docs/current-source-of-truth-checklist.md
+++ b/docs/current-source-of-truth-checklist.md
@@ -168,8 +168,10 @@ Issue template: `.github/ISSUE_TEMPLATE/ops-cadence.yml`.
       Stripe webhook **idempotency** prefers D1 `stripe_transaction` when `AUTH_DB`
       is bound (`persistStripeEvent` / mark helpers in `stripe-transactions.ts`);
       Dynamo `STRIPE_TRANSACTIONS_TABLE` remains legacy fallback.
-      Still AWS (follow-up): Athena cost/datalake UI reads;
-      `stripe-analytics-read` Dynamo queries.
+      `getStripeAnalyticsSnapshot` (`stripe-analytics-read.ts`) also prefers D1
+      (amount_minor/currency + tag_*/event_day catch-up via migration 0012;
+      payload_json backfill for legacy rows); Dynamo queries remain legacy fallback.
+      Still AWS (follow-up): Athena cost/datalake UI reads.
       Admin-notifications prefer D1 `admin_notification` when `AUTH_DB` bound
       (`src/lib/admin-notifications.ts` + migration 0011); Dynamo table is fallback.
 - [x] `DEFERRED` ESLint 10 + TypeScript 7 majors (ecosystem blockers 2026-07-29).

--- a/migrations/0001-auth-schema.sql
+++ b/migrations/0001-auth-schema.sql
@@ -47,6 +47,8 @@ CREATE TABLE IF NOT EXISTS stripe_transaction (
   received_at INTEGER NOT NULL,
   processed_at INTEGER,
   processing_error TEXT,
+  amount_minor INTEGER,
+  currency TEXT,
   payload_json TEXT
 );
 
@@ -54,6 +56,7 @@ CREATE TABLE IF NOT EXISTS stripe_transaction (
 CREATE INDEX IF NOT EXISTS idx_stripe_event_type ON stripe_transaction(event_type);
 CREATE INDEX IF NOT EXISTS idx_stripe_received_at ON stripe_transaction(received_at);
 CREATE INDEX IF NOT EXISTS idx_stripe_customer ON stripe_transaction(customer_id);
+CREATE INDEX IF NOT EXISTS idx_stripe_event_day ON stripe_transaction(event_day);
 
 -- Admin notifications (replaces AdminNotifications DynamoDB table)
 -- Events log for all client-facing interactions

--- a/migrations/0012-stripe-transaction-amount.sql
+++ b/migrations/0012-stripe-transaction-amount.sql
@@ -1,0 +1,13 @@
+-- Catch up slim remote stripe_transaction (pre-0001 columns) + analytics fields.
+-- CREATE TABLE IF NOT EXISTS in 0001 is a no-op when the table already exists,
+-- so tag_*/event_day were never added on production user-auth-db.
+ALTER TABLE stripe_transaction ADD COLUMN tag_category TEXT;
+ALTER TABLE stripe_transaction ADD COLUMN tag_stage TEXT;
+ALTER TABLE stripe_transaction ADD COLUMN stage_category TEXT;
+ALTER TABLE stripe_transaction ADD COLUMN event_day TEXT;
+ALTER TABLE stripe_transaction ADD COLUMN amount_minor INTEGER;
+ALTER TABLE stripe_transaction ADD COLUMN currency TEXT;
+
+CREATE INDEX IF NOT EXISTS idx_stripe_event_day ON stripe_transaction(event_day);
+CREATE INDEX IF NOT EXISTS idx_stripe_event_type ON stripe_transaction(event_type);
+CREATE INDEX IF NOT EXISTS idx_stripe_customer ON stripe_transaction(customer_id);

--- a/schema.sql
+++ b/schema.sql
@@ -39,11 +39,14 @@ CREATE TABLE stripe_transaction (
     received_at INTEGER NOT NULL,
     processed_at INTEGER,
     processing_error TEXT,
+    amount_minor INTEGER,
+    currency TEXT,
     payload_json TEXT
 );
 
 CREATE INDEX idx_stripe_event_type ON stripe_transaction(event_type);
 CREATE INDEX idx_stripe_received_at ON stripe_transaction(received_at);
+CREATE INDEX idx_stripe_event_day ON stripe_transaction(event_day);
 
 -- Admin notifications table
 CREATE TABLE admin_notification (

--- a/src/lib/stripe-analytics-read.ts
+++ b/src/lib/stripe-analytics-read.ts
@@ -5,6 +5,14 @@ import {
   type AttributeValue,
 } from "@aws-sdk/client-dynamodb";
 import { resolveDynamoEndpoint } from "@/lib/stripe-transactions";
+import { getAuthDbFromEnv, type AuthDatabase } from "@/lib/auth-d1";
+
+/**
+ * Stripe revenue / event analytics snapshot.
+ *
+ * Cloudflare-first: prefer D1 `stripe_transaction` when AUTH_DB is bound.
+ * Legacy fallback: DynamoDB `STRIPE_TRANSACTIONS_TABLE`.
+ */
 
 const REGION = process.env.AWS_REGION || "us-east-1";
 
@@ -56,18 +64,26 @@ function getDayRange(days: number): string[] {
   return range;
 }
 
-function deriveDay(item: Record<string, AttributeValue>): string | undefined {
-  const explicitDay = attrToString(item.eventDay);
-  if (explicitDay) return explicitDay;
+/** Normalized row shared by D1 + Dynamo aggregation. */
+interface AnalyticsRow {
+  eventDay?: string;
+  stripeCreatedAt?: number;
+  receivedAt?: number;
+  tagCategory?: string;
+  processingStatus?: string;
+  currency?: string;
+  amountMinor?: number;
+}
 
-  const stripeCreatedAt = attrToNumber(item.stripeCreatedAt);
-  if (typeof stripeCreatedAt === "number") {
-    return toDayString(new Date(stripeCreatedAt * 1000));
+function deriveDay(row: AnalyticsRow): string | undefined {
+  if (row.eventDay) return row.eventDay;
+
+  if (typeof row.stripeCreatedAt === "number") {
+    return toDayString(new Date(row.stripeCreatedAt * 1000));
   }
 
-  const receivedAt = attrToNumber(item.receivedAt);
-  if (typeof receivedAt === "number") {
-    return toDayString(new Date(receivedAt));
+  if (typeof row.receivedAt === "number") {
+    return toDayString(new Date(row.receivedAt));
   }
 
   return undefined;
@@ -119,12 +135,12 @@ function emptySnapshot(days: number): StripeAnalyticsSnapshot {
   };
 }
 
-function applyItem(snapshot: StripeAnalyticsSnapshot, item: Record<string, AttributeValue>): void {
-  const day = deriveDay(item);
-  const category = attrToString(item.tagCategory) || "other";
-  const status = attrToString(item.processingStatus) || "unknown";
-  const currency = attrToString(item.currency) || "unknown";
-  const amountMinor = attrToNumber(item.amountMinor) || 0;
+function applyRow(snapshot: StripeAnalyticsSnapshot, row: AnalyticsRow): void {
+  const day = deriveDay(row);
+  const category = row.tagCategory || "other";
+  const status = row.processingStatus || "unknown";
+  const currency = row.currency || "unknown";
+  const amountMinor = row.amountMinor || 0;
 
   snapshot.totals.events += 1;
   snapshot.totals.revenueMinor += amountMinor;
@@ -151,6 +167,86 @@ function applyItem(snapshot: StripeAnalyticsSnapshot, item: Record<string, Attri
   if (status === "handler_failed") point.failed += 1;
 }
 
+function dynamoItemToRow(item: Record<string, AttributeValue>): AnalyticsRow {
+  return {
+    eventDay: attrToString(item.eventDay),
+    stripeCreatedAt: attrToNumber(item.stripeCreatedAt),
+    receivedAt: attrToNumber(item.receivedAt),
+    tagCategory: attrToString(item.tagCategory),
+    processingStatus: attrToString(item.processingStatus),
+    currency: attrToString(item.currency),
+    amountMinor: attrToNumber(item.amountMinor),
+  };
+}
+
+function amountFromPayload(payloadJson: string | null | undefined): number | undefined {
+  if (!payloadJson) return undefined;
+  try {
+    const object = JSON.parse(payloadJson) as Record<string, unknown>;
+    const candidates = [object.amount_total, object.amount_due, object.amount_paid];
+    for (const value of candidates) {
+      if (typeof value === "number" && Number.isFinite(value)) return value;
+    }
+  } catch {
+    /* ignore malformed payloads */
+  }
+  return undefined;
+}
+
+function currencyFromPayload(payloadJson: string | null | undefined): string | undefined {
+  if (!payloadJson) return undefined;
+  try {
+    const object = JSON.parse(payloadJson) as Record<string, unknown>;
+    return typeof object.currency === "string" ? object.currency : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+interface D1StripeRow {
+  event_day: string | null;
+  tag_category: string | null;
+  processing_status: string | null;
+  currency: string | null;
+  amount_minor: number | null;
+  received_at: number | null;
+  payload_json: string | null;
+}
+
+function d1RowToAnalytics(row: D1StripeRow): AnalyticsRow {
+  const amountMinor =
+    typeof row.amount_minor === "number" && Number.isFinite(row.amount_minor)
+      ? row.amount_minor
+      : amountFromPayload(row.payload_json);
+  const currency = row.currency || currencyFromPayload(row.payload_json);
+  return {
+    eventDay: row.event_day ?? undefined,
+    receivedAt: typeof row.received_at === "number" ? row.received_at : undefined,
+    tagCategory: row.tag_category ?? undefined,
+    processingStatus: row.processing_status ?? undefined,
+    currency: currency ?? undefined,
+    amountMinor,
+  };
+}
+
+async function queryD1Rows(db: AuthDatabase, days: number): Promise<AnalyticsRow[]> {
+  const dayRange = getDayRange(days);
+  const startDay = dayRange[0];
+  const endDay = dayRange[dayRange.length - 1];
+
+  const result = await db
+    .prepare(
+      `SELECT event_day, tag_category, processing_status, currency, amount_minor,
+              received_at, payload_json
+       FROM stripe_transaction
+       WHERE event_day >= ? AND event_day <= ?`
+    )
+    .bind(startDay, endDay)
+    .all<D1StripeRow>();
+
+  return (result.results ?? []).map(d1RowToAnalytics);
+}
+
 function isMissingIndexError(error: unknown): boolean {
   if (!error || typeof error !== "object") return false;
   const message = "message" in error ? String(error.message || "") : "";
@@ -162,7 +258,7 @@ function isMissingIndexError(error: unknown): boolean {
   );
 }
 
-async function queryByDayOrScan(days: number): Promise<Array<Record<string, AttributeValue>>> {
+async function queryByDayOrScan(days: number): Promise<AnalyticsRow[]> {
   const tableName = getTransactionsTableName();
   const client = getDynamoClient();
   const dayRange = getDayRange(days);
@@ -188,7 +284,7 @@ async function queryByDayOrScan(days: number): Promise<Array<Record<string, Attr
         lastEvaluatedKey = response.LastEvaluatedKey;
       } while (lastEvaluatedKey);
     }
-    return allItems;
+    return allItems.map(dynamoItemToRow);
   } catch (error) {
     if (!isMissingIndexError(error)) throw error;
   }
@@ -214,7 +310,7 @@ async function queryByDayOrScan(days: number): Promise<Array<Record<string, Attr
     lastEvaluatedKey = response.LastEvaluatedKey;
   } while (lastEvaluatedKey);
 
-  return allItems;
+  return allItems.map(dynamoItemToRow);
 }
 
 export async function getStripeAnalyticsSnapshot(
@@ -222,10 +318,12 @@ export async function getStripeAnalyticsSnapshot(
 ): Promise<StripeAnalyticsSnapshot> {
   const days = Math.max(1, Math.min(365, Math.trunc(inputDays)));
   const snapshot = emptySnapshot(days);
-  const items = await queryByDayOrScan(days);
 
-  for (const item of items) {
-    applyItem(snapshot, item);
+  const db = getAuthDbFromEnv();
+  const rows = db ? await queryD1Rows(db, days) : await queryByDayOrScan(days);
+
+  for (const row of rows) {
+    applyRow(snapshot, row);
   }
 
   return snapshot;

--- a/src/lib/stripe-transactions.ts
+++ b/src/lib/stripe-transactions.ts
@@ -151,7 +151,7 @@ async function persistStripeEventD1(
   db: AuthDatabase,
   event: Stripe.Event
 ): Promise<PersistStripeEventResult> {
-  const { customerId } = extractObjectFields(event);
+  const { customerId, amountMinor, currency } = extractObjectFields(event);
   const tags = getStripeEventTags(event.type);
   const eventDay = toEventDay(event.created);
   const stageCategory = `${tags.tagStage}#${tags.tagCategory}`;
@@ -162,8 +162,9 @@ async function persistStripeEventD1(
       .prepare(
         `INSERT INTO stripe_transaction (
           event_id, event_type, tag_category, tag_stage, stage_category,
-          event_day, customer_id, processing_status, received_at, payload_json
-        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+          event_day, customer_id, processing_status, received_at,
+          amount_minor, currency, payload_json
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
       )
       .bind(
         event.id,
@@ -175,6 +176,8 @@ async function persistStripeEventD1(
         customerId ?? null,
         "received",
         receivedAt,
+        typeof amountMinor === "number" ? amountMinor : null,
+        currency ?? null,
         toJson(event.data.object)
       )
       .run();


### PR DESCRIPTION
## Summary
- `getStripeAnalyticsSnapshot` prefers D1 `stripe_transaction` when `AUTH_DB` is bound; Dynamo remains legacy fallback
- Persist path writes `amount_minor` / `currency`; migration **0012** also adds missing `tag_*` / `event_day` columns that `CREATE IF NOT EXISTS` never applied on the slim remote table (already applied on remote `user-auth-db`)
- Payload JSON backfill for older rows without amount/currency columns; checklist updated

## Test plan
- [x] `pnpm exec vitest run __tests__/stripe-analytics-read.test.ts __tests__/stripe-transactions.test.ts`
- [x] Remote `PRAGMA table_info(stripe_transaction)` shows amount_minor, currency, event_day, tag_*
- [ ] CI green


Made with [Cursor](https://cursor.com)