### PR TITLE
fix(ci): Cloudflare D1 deploy, retire AWS SST noise, cron WAF skip

### DIFF
--- a/.github/workflows/cloudflare-deploy.yml
+++ b/.github/workflows/cloudflare-deploy.yml
@@ -40,7 +40,8 @@ jobs:
         run: pnpm install
 
       - name: Apply D1 migrations
-        run: npx wrangler d1 migrations apply user-auth-db --config wrangler.jsonc
+        # Wrangler 4 defaults to local .wrangler state without --remote.
+        run: npx wrangler d1 migrations apply user-auth-db --remote --config wrangler.jsonc
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CF_ACCOUNT_ID }}

--- a/.github/workflows/cloudflare-skip-cron-challenge.yml
+++ b/.github/workflows/cloudflare-skip-cron-challenge.yml
@@ -1,0 +1,64 @@
+name: Skip Cloudflare challenge on /api/cron/*
+
+# GitHub-hosted runners hit Cloudflare Bot Fight / Managed Challenge
+# ("Just a moment…") on /api/cron/*, which breaks Bearer CRON_SECRET polls
+# (linkedin-poll, etc.). This workflow installs a custom WAF skip rule for
+# that path prefix.
+#
+# HOW TO RUN: push a change to this file / the script, or workflow_dispatch.
+# Token: secrets.CLOUDFLARE_API_TOKEN needs Zone:Read + Firewall Services:Edit.
+# Zone: secrets.CLOUDFLARE_ZONE_ID (optional — script resolves cloudless.gr).
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - ".github/workflows/cloudflare-skip-cron-challenge.yml"
+      - "scripts/cf-skip-cron-challenge.sh"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: cloudflare-skip-cron-challenge
+  cancel-in-progress: false
+
+jobs:
+  skip:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v4.3.1
+
+      - name: Install WAF skip rule for /api/cron/*
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ZONE_ID: ${{ secrets.CLOUDFLARE_ZONE_ID }}
+        run: bash scripts/cf-skip-cron-challenge.sh
+
+      - name: Verify cron path is not challenged
+        env:
+          CRON_SECRET: ${{ secrets.CRON_SECRET }}
+        run: |
+          set -euo pipefail
+          BODY=$(mktemp)
+          # Even without a valid secret we must NOT get the challenge HTML.
+          # Expect 401/403 from the app, never Cloudflare interstitial.
+          STATUS=$(curl -sS -o "$BODY" -w "%{http_code}" \
+            -H "Authorization: Bearer ${CRON_SECRET:-missing}" \
+            -H "User-Agent: github-actions/cf-skip-cron-verify" \
+            --max-time 30 \
+            "https://cloudless.gr/api/cron/ad-analytics-poll" || true)
+          echo "HTTP $STATUS"
+          head -c 512 "$BODY" || true
+          echo
+          if grep -qiE 'Just a moment|cf-browser-verification|challenge-platform' "$BODY"; then
+            echo "::error::still receiving Cloudflare challenge HTML — WAF skip not effective yet (propagation?) or token lacks Firewall Services:Edit"
+            exit 1
+          fi
+          if [[ "$STATUS" == "000" ]]; then
+            echo "::error::curl failed to reach origin"
+            exit 1
+          fi
+          echo "✓ no Cloudflare challenge interstitial (app responded with HTTP $STATUS)"

--- a/.github/workflows/core-web-vitals-audit.yml
+++ b/.github/workflows/core-web-vitals-audit.yml
@@ -5,7 +5,8 @@ env:
 
 on:
   workflow_run:
-    workflows: ['Deploy to Production']
+    # Production deploys ship via Cloudflare Workers, not legacy AWS SST.
+    workflows: ['Cloudflare Workers Deploy']
     types: [completed]
   workflow_dispatch:
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,22 +1,18 @@
 name: Deploy to Production
 
+# Legacy AWS SST path (S3/CloudFront). Production traffic is Cloudflare Workers
+# (`cloudflare-deploy.yml`). Keep this workflow for rare manual SST/infra
+# experiments only — do NOT fire on push to main (NoSuchBucket noise).
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
 
 on:
-  push:
-    branches: [main]
-    paths:
-      - "src/**"
-      - "__tests__/**"
-      - "public/**"
-      - "sst.config.ts"
-      - "next.config.ts"
-      - "package.json"
-      - "pnpm-lock.yaml"
-      - "tsconfig.json"
-      - ".github/workflows/**"
   workflow_dispatch:
+    inputs:
+      reason:
+        description: "Why run legacy AWS SST deploy? (prefer Cloudflare Workers Deploy)"
+        required: false
+        default: "manual legacy SST deploy"
 
 concurrency:
   group: deploy-production

--- a/.github/workflows/linkedin-poll.yml
+++ b/.github/workflows/linkedin-poll.yml
@@ -68,6 +68,10 @@ jobs:
           # grows; the full payload lives in CloudWatch.
           head -c 4096 "$BODY" || true
           echo
+          if grep -qiE 'Just a moment|cf-browser-verification|challenge-platform' "$BODY"; then
+            echo "::error::Cloudflare managed challenge intercepted the cron call (not an app 403). Re-run workflow cloudflare-skip-cron-challenge.yml or check Bot Fight Mode skip for /api/cron/*."
+            exit 1
+          fi
           if [ "$STATUS" != "200" ]; then
             echo "::error::poll returned non-200 status: $STATUS"
             exit 1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,7 +5,8 @@ env:
 
 on:
   workflow_run:
-    workflows: [Deploy to Production]
+    # Production deploys ship via Cloudflare Workers, not legacy AWS SST.
+    workflows: [Cloudflare Workers Deploy]
     types: [completed]
     branches: [main]
 

--- a/.github/workflows/sst-infra-deploy.yml
+++ b/.github/workflows/sst-infra-deploy.yml
@@ -39,7 +39,8 @@ jobs:
         run: pnpm install
 
       - name: Apply D1 migrations
-        run: npx wrangler d1 migrations apply user-auth-db --config wrangler.jsonc
+        # Wrangler 4 defaults to local .wrangler state without --remote.
+        run: npx wrangler d1 migrations apply user-auth-db --remote --config wrangler.jsonc
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CF_ACCOUNT_ID }}

--- a/migrations/0010-stripe-transaction-status.sql
+++ b/migrations/0010-stripe-transaction-status.sql
@@ -1,3 +1,6 @@
--- Stripe webhook processing status columns (Dynamo parity for D1 idempotency path)
-ALTER TABLE stripe_transaction ADD COLUMN processed_at INTEGER;
-ALTER TABLE stripe_transaction ADD COLUMN processing_error TEXT;
+-- Stripe webhook processing status columns.
+-- Already defined on stripe_transaction in 0001-auth-schema.sql
+-- (processed_at, processing_error). This migration is intentionally a no-op
+-- so older environments that expected a later ALTER can still advance the
+-- migrations table without duplicate-column failures.
+SELECT 1;

--- a/scripts/cf-skip-cron-challenge.sh
+++ b/scripts/cf-skip-cron-challenge.sh
@@ -1,0 +1,132 @@
+#!/usr/bin/env bash
+# Skip Cloudflare managed challenges for /api/cron/* so GitHub Actions cron
+# workflows (linkedin-poll, postiz-crons, platform-crons) can authenticate with
+# Bearer CRON_SECRET instead of receiving a "Just a moment…" interstitial.
+#
+# Auth: CLOUDFLARE_API_TOKEN (Zone → Firewall Services Edit + Zone Read).
+# Zone: CLOUDFLARE_ZONE_ID / CF_ZONE_ID, else resolve DOMAIN (default cloudless.gr).
+# Idempotent: replaces the rule with the same description if present.
+set -euo pipefail
+
+DOMAIN="${DOMAIN:-cloudless.gr}"
+ZONE_ID="${CLOUDFLARE_ZONE_ID:-${CF_ZONE_ID:-}}"
+TOKEN="${CLOUDFLARE_API_TOKEN:-}"
+RULE_DESC="Skip Bot Fight / Managed Challenge for /api/cron/* (GHA crons)"
+EXPRESSION='(starts_with(http.request.uri.path, "/api/cron/"))'
+API="https://api.cloudflare.com/client/v4"
+
+if [[ -z "$TOKEN" ]]; then
+  echo "::error::CLOUDFLARE_API_TOKEN is required (Zone:Read + Zone → Firewall Services:Edit)"
+  exit 1
+fi
+
+cf() {
+  local method="$1" url="$2" body="${3:-}"
+  if [[ -n "$body" ]]; then
+    curl -fsS -X "$method" "$url" \
+      -H "Authorization: Bearer ${TOKEN}" \
+      -H "Content-Type: application/json" \
+      --data "$body"
+  else
+    curl -fsS -X "$method" "$url" \
+      -H "Authorization: Bearer ${TOKEN}" \
+      -H "Content-Type: application/json"
+  fi
+}
+
+if [[ -z "$ZONE_ID" ]]; then
+  echo "==> resolving zone for ${DOMAIN}"
+  ZRESP="$(cf GET "${API}/zones?name=${DOMAIN}")"
+  ZONE_ID="$(python3 -c 'import json,sys; d=json.load(sys.stdin); r=d.get("result") or []; print(r[0]["id"] if r else "")' <<<"$ZRESP")"
+  [[ -n "$ZONE_ID" ]] || { echo "::error::could not resolve zone id for ${DOMAIN}"; echo "$ZRESP"; exit 1; }
+fi
+echo "==> zone: ${ZONE_ID}"
+
+ENTRY="${API}/zones/${ZONE_ID}/rulesets/phases/http_request_firewall_custom/entrypoint"
+echo "==> fetching custom firewall entrypoint"
+CURRENT="$(cf GET "$ENTRY" || true)"
+
+PAYLOAD_FILE="$(mktemp)"
+python3 - "$CURRENT" "$RULE_DESC" "$EXPRESSION" <<'PY' > "$PAYLOAD_FILE"
+import json, sys
+
+raw, desc, expression = sys.argv[1], sys.argv[2], sys.argv[3]
+try:
+    data = json.loads(raw) if raw.strip() else {}
+except json.JSONDecodeError:
+    data = {}
+
+result = data.get("result") or {}
+ruleset_id = result.get("id") or ""
+existing = list(result.get("rules") or [])
+
+new_rule = {
+    "action": "skip",
+    "description": desc,
+    "enabled": True,
+    "expression": expression,
+    "action_parameters": {
+        # Skip managed WAF + Super Bot Fight Mode phases that emit
+        # "Just a moment…" challenge pages for datacenter IPs (GHA runners).
+        "phases": [
+            "http_request_firewall_managed",
+            "http_request_sbfm",
+        ],
+        "products": [
+            "bic",
+            "hot",
+            "rateLimit",
+            "securityLevel",
+            "uaBlock",
+            "waf",
+            "zoneLockdown",
+        ],
+    },
+}
+
+out = []
+replaced = False
+for r in existing:
+    if r.get("description") == desc:
+        if "id" in r:
+            new_rule = {**new_rule, "id": r["id"]}
+        out.append(new_rule)
+        replaced = True
+    else:
+        out.append(r)
+if not replaced:
+    out.append(new_rule)
+
+json.dump({"rules": out, "_ruleset_id": ruleset_id}, sys.stdout)
+PY
+
+RULESET_ID="$(python3 -c 'import json,sys; print(json.load(open(sys.argv[1])).get("_ruleset_id",""))' "$PAYLOAD_FILE")"
+python3 -c 'import json,sys; p=json.load(open(sys.argv[1])); p.pop("_ruleset_id", None); json.dump(p, open(sys.argv[1],"w"))' "$PAYLOAD_FILE"
+
+if [[ -n "$RULESET_ID" ]]; then
+  echo "==> updating ruleset ${RULESET_ID}"
+  RESP="$(cf PUT "${API}/zones/${ZONE_ID}/rulesets/${RULESET_ID}" "$(cat "$PAYLOAD_FILE")")"
+else
+  echo "==> creating custom firewall entrypoint"
+  RESP="$(cf PUT "$ENTRY" "$(cat "$PAYLOAD_FILE")")"
+fi
+rm -f "$PAYLOAD_FILE"
+
+python3 - "$RESP" "$RULE_DESC" <<'PY'
+import json, sys
+resp = json.loads(sys.argv[1])
+desc = sys.argv[2]
+if not resp.get("success"):
+    print("Cloudflare API error:", json.dumps(resp.get("errors"), indent=2), file=sys.stderr)
+    sys.exit(1)
+rules = (resp.get("result") or {}).get("rules") or []
+match = [r for r in rules if r.get("description") == desc]
+if not match:
+    print("Rule not found after update", file=sys.stderr)
+    sys.exit(1)
+r = match[0]
+print(f"✓ rule id={r.get('id')} enabled={r.get('enabled')}")
+print(f"  expression={r.get('expression')}")
+PY
+
+echo "==> done"


### PR DESCRIPTION
## Summary
- **Cloudflare Workers Deploy:** `wrangler d1 migrations apply` now uses `--remote` (was applying to local `.wrangler` state). Migration `0010` is a no-op because `processed_at` / `processing_error` already exist in `0001` (fixes `duplicate column name: processed_at`).
- **Deploy to Production (AWS SST):** no longer runs on push to `main` (manual `workflow_dispatch` only) — stops recurring `NoSuchBucket` on `CloudlessSiteAssetFiles`. `release.yml` and `core-web-vitals-audit.yml` now trigger off **Cloudflare Workers Deploy**.
- **LinkedIn poll 403:** adds `cloudflare-skip-cron-challenge.yml` + script to install a custom WAF skip for `/api/cron/*` (Bot Fight / managed challenge). Poll workflow detects challenge HTML and points at that fix.

## Test plan
- [ ] Merge → run **Cloudflare Workers Deploy** (`workflow_dispatch` or next main push that triggers it) and confirm D1 migrate succeeds
- [ ] Confirm **Deploy to Production** does not fire on the merge push
- [ ] Run **Skip Cloudflare challenge on /api/cron/*** (`workflow_dispatch`) once after merge (needs `CLOUDFLARE_API_TOKEN` with Firewall Services:Edit)
- [ ] Re-run **Ad analytics — LinkedIn poll** and expect HTTP 200 (or app error), not Cloudflare interstitial
- [ ] After Gemini quota resets (~midnight PT): smoke `activity-report.lock.yml` separately (out of scope here)


Made with [Cursor](https://cursor.com)