### PR TITLE
feat(analytics): Cloudflare-first cost + datalake UI reads

### DIFF
--- a/.github/workflows/etl-aws-cost-to-r2.yml
+++ b/.github/workflows/etl-aws-cost-to-r2.yml
@@ -1,0 +1,90 @@
+name: "ETL: AWS Cost → R2 + D1"
+
+# Daily Cost Explorer snapshot → Cloudflare R2 (parquet + JSON) and D1
+# `aws_cost_daily` for /admin/cost. Source API is still AWS CE; storage is CF.
+
+on:
+  schedule:
+    - cron: "30 6 * * *" # 06:30 UTC daily
+  workflow_dispatch:
+  push:
+    branches: [main]
+    paths:
+      - ".github/workflows/etl-aws-cost-to-r2.yml"
+      - "scripts/etl/aws-cost-to-r2.mjs"
+      - "scripts/etl/aws-cost-to-lake.mjs"
+      - "migrations/0013-aws-cost-daily.sql"
+
+permissions:
+  id-token: write
+  contents: read
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+  AWS_REGION: us-east-1
+
+jobs:
+  etl:
+    name: AWS Cost → R2 + D1
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4.3.1
+
+      - uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_DEPLOY_ROLE_ARN }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - uses: actions/setup-node@v4.4.0
+        with:
+          node-version: 22
+
+      - name: Install ETL dependencies
+        working-directory: scripts/etl
+        run: npm ci --omit=dev
+
+      - name: Run AWS Cost → R2
+        working-directory: scripts/etl
+        env:
+          CF_ACCOUNT_ID: ${{ secrets.CF_ACCOUNT_ID }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CF_ACCOUNT_ID }}
+          CF_R2_ACCESS_KEY_ID: ${{ secrets.CF_R2_ACCESS_KEY_ID }}
+          CF_R2_SECRET_ACCESS_KEY: ${{ secrets.CF_R2_SECRET_ACCESS_KEY }}
+          ANALYTICS_BUCKET: datalake-bucket
+          AWS_COST_LOOKBACK_DAYS: "60"
+          AWS_COST_D1_SQL_OUT: /tmp/aws-cost-d1.sql
+        run: node aws-cost-to-r2.mjs
+
+      - name: Install wrangler
+        run: npm install -g wrangler@4
+
+      - name: Apply D1 cost rows
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CF_ACCOUNT_ID }}
+        run: |
+          npx wrangler d1 execute user-auth-db --remote --file=migrations/0013-aws-cost-daily.sql --config wrangler.jsonc || true
+          npx wrangler d1 execute user-auth-db --remote --file=/tmp/aws-cost-d1.sql --config wrangler.jsonc
+
+      - name: Materialize datalake admin snapshot
+        working-directory: scripts/etl
+        env:
+          CF_ACCOUNT_ID: ${{ secrets.CF_ACCOUNT_ID }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CF_ACCOUNT_ID }}
+          CF_R2_ACCESS_KEY_ID: ${{ secrets.CF_R2_ACCESS_KEY_ID }}
+          CF_R2_SECRET_ACCESS_KEY: ${{ secrets.CF_R2_SECRET_ACCESS_KEY }}
+          ANALYTICS_BUCKET: datalake-bucket
+        run: node materialize-datalake-snapshots.mjs
+        continue-on-error: true
+
+      - name: Notify Slack on failure
+        if: failure()
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+        run: |
+          if [ -n "$SLACK_WEBHOOK_URL" ]; then
+            curl -s -X POST "$SLACK_WEBHOOK_URL" \
+              -H "Content-Type: application/json" \
+              -d "{\"text\":\":x: ETL — AWS Cost → R2/D1 failed (#$GITHUB_RUN_NUMBER). https://github.com/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID\"}"
+          fi

--- a/__tests__/cost-analytics.test.ts
+++ b/__tests__/cost-analytics.test.ts
@@ -1,0 +1,105 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import type { AuthDatabase } from "@/lib/auth-d1";
+
+function makeDb(rows: Array<Record<string, unknown>>): AuthDatabase {
+  return {
+    prepare() {
+      const stmt = {
+        bind() {
+          return stmt;
+        },
+        async run() {
+          return { success: true, meta: { changes: 0 } };
+        },
+        async all<T = Record<string, unknown>>() {
+          return { results: rows as T[], success: true };
+        },
+        async first() {
+          return null;
+        },
+      };
+      return stmt;
+    },
+  };
+}
+
+describe("getCostSummary Cloudflare-first", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    delete (globalThis as { __AUTH_DB__?: unknown }).__AUTH_DB__;
+    delete (globalThis as { __DATALAKE_BUCKET__?: unknown }).__DATALAKE_BUCKET__;
+  });
+
+  afterEach(() => {
+    delete (globalThis as { __AUTH_DB__?: unknown }).__AUTH_DB__;
+    delete (globalThis as { __DATALAKE_BUCKET__?: unknown }).__DATALAKE_BUCKET__;
+  });
+
+  it("aggregates from D1 aws_cost_daily when AUTH_DB is bound", async () => {
+    const today = new Date().toISOString().slice(0, 10);
+    const yesterday = new Date(Date.now() - 86400000).toISOString().slice(0, 10);
+    (globalThis as { __AUTH_DB__?: AuthDatabase }).__AUTH_DB__ = makeDb([
+      {
+        cost_date: today,
+        service: "AmazonCloudFront",
+        amount_usd: 1.25,
+        currency: "USD",
+        synced_at: 1_700_000_000_000,
+      },
+      {
+        cost_date: yesterday,
+        service: "AmazonCloudFront",
+        amount_usd: 2.5,
+        currency: "USD",
+        synced_at: 1_700_000_000_000,
+      },
+      {
+        cost_date: yesterday,
+        service: "AWSLambda",
+        amount_usd: 0.4,
+        currency: "USD",
+        synced_at: 1_700_000_000_000,
+      },
+    ]);
+
+    const { getCostSummary } = await import("@/lib/cost-analytics");
+    const summary = await getCostSummary();
+    expect(summary.total_30d).toBe(4.15);
+    expect(summary.yesterday).toBe(2.9);
+    expect(summary.topServices[0].service).toBe("AmazonCloudFront");
+    expect(summary.lastEtlAt).toBe(new Date(1_700_000_000_000).toISOString());
+  });
+
+  it("falls back to R2 cost.json when D1 has no rows", async () => {
+    (globalThis as { __AUTH_DB__?: AuthDatabase }).__AUTH_DB__ = makeDb([]);
+    const yesterday = new Date(Date.now() - 86400000).toISOString().slice(0, 10);
+    (globalThis as {
+      __DATALAKE_BUCKET__?: { get: (key: string) => Promise<unknown> };
+    }).__DATALAKE_BUCKET__ = {
+      get: async (key: string) => {
+        if (key !== "lake/aws-cost/cost.json") return null;
+        return {
+          uploaded: new Date("2026-07-29T12:00:00.000Z"),
+          text: async () =>
+            JSON.stringify({
+              generated_at: "2026-07-29T12:00:00.000Z",
+              rows: [
+                {
+                  cost_date: yesterday,
+                  service: "AmazonS3",
+                  amount_usd: 3.1,
+                  currency: "USD",
+                },
+              ],
+            }),
+        };
+      },
+    };
+
+    const { getCostSummary } = await import("@/lib/cost-analytics");
+    const summary = await getCostSummary();
+    expect(summary.yesterday).toBe(3.1);
+    expect(summary.topServices[0].service).toBe("AmazonS3");
+    expect(summary.lastEtlAt).toBe("2026-07-29T12:00:00.000Z");
+  });
+});

--- a/__tests__/datalake-r2.test.ts
+++ b/__tests__/datalake-r2.test.ts
@@ -1,0 +1,107 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import type { AuthDatabase } from "@/lib/auth-d1";
+
+function makeDb(rows: Array<Record<string, unknown>>): AuthDatabase {
+  return {
+    prepare(query: string) {
+      const stmt = {
+        bind() {
+          return stmt;
+        },
+        async run() {
+          return { success: true, meta: { changes: 0 } };
+        },
+        async all<T = Record<string, unknown>>() {
+          if (query.includes("utm_source")) {
+            return {
+              results: [
+                {
+                  utm_source: "linkedin",
+                  utm_medium: "cpc",
+                  utm_campaign: "pilot",
+                  sessions: 10,
+                  signups: 2,
+                  purchases: 1,
+                  revenue: 49,
+                },
+              ] as T[],
+              success: true,
+            };
+          }
+          return { results: rows as T[], success: true };
+        },
+        async first() {
+          return null;
+        },
+      };
+      return stmt;
+    },
+  };
+}
+
+describe("getDatalakeDashboard Cloudflare-first", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    delete (globalThis as { __AUTH_DB__?: unknown }).__AUTH_DB__;
+    delete (globalThis as { __DATALAKE_BUCKET__?: unknown }).__DATALAKE_BUCKET__;
+  });
+
+  afterEach(() => {
+    delete (globalThis as { __AUTH_DB__?: unknown }).__AUTH_DB__;
+    delete (globalThis as { __DATALAKE_BUCKET__?: unknown }).__DATALAKE_BUCKET__;
+  });
+
+  it("prefers D1 + R2 snapshot without calling Athena", async () => {
+    (globalThis as { __AUTH_DB__?: AuthDatabase }).__AUTH_DB__ = makeDb([
+      { day: "2026-07-28", sessions: 5, signups: 1, purchasers: 0, revenue: 0 },
+    ]);
+    (globalThis as {
+      __DATALAKE_BUCKET__?: { get: (key: string) => Promise<unknown> };
+    }).__DATALAKE_BUCKET__ = {
+      get: async () => ({
+        text: async () =>
+          JSON.stringify({
+            generated_at: "2026-07-29T10:00:00.000Z",
+            cache: "r2-snapshot",
+            sections: [
+              {
+                section: "top_keywords",
+                rows: [{ query: "cloud greece", clicks: 12 }],
+                rowCount: 1,
+              },
+              {
+                section: "linkedin_ads",
+                rows: [{ campaign: "x", spend: 1 }],
+                rowCount: 1,
+              },
+              {
+                section: "top_errors",
+                rows: [{ title: "boom", count_14d: 3 }],
+                rowCount: 1,
+              },
+              {
+                section: "espocrm_funnel",
+                rows: [{ lead_source: "web", contact_count: 4 }],
+                rowCount: 1,
+              },
+            ],
+          }),
+      }),
+    };
+
+    const athena = vi.fn();
+    vi.doMock("@/lib/athena", () => ({
+      runAthenaQuery: athena,
+      resetAthenaCache: vi.fn(),
+    }));
+
+    const { getDatalakeDashboard } = await import("@/lib/datalake-r2");
+    const payload = await getDatalakeDashboard({});
+    expect(athena).not.toHaveBeenCalled();
+    expect(payload.cache).toBe("cloudflare");
+    const keywords = payload.sections.find((s) => s.section === "top_keywords");
+    expect(keywords?.rows?.[0]?.query).toBe("cloud greece");
+    const acquisition = payload.sections.find((s) => s.section === "acquisition_funnel");
+    expect(acquisition?.rows?.[0]?.sessions).toBe(5);
+  });
+});

--- a/docs/current-source-of-truth-checklist.md
+++ b/docs/current-source-of-truth-checklist.md
@@ -171,9 +171,16 @@ Issue template: `.github/ISSUE_TEMPLATE/ops-cadence.yml`.
       `getStripeAnalyticsSnapshot` (`stripe-analytics-read.ts`) also prefers D1
       (amount_minor/currency + tag_*/event_day catch-up via migration 0012;
       payload_json backfill for legacy rows); Dynamo queries remain legacy fallback.
-      Still AWS (follow-up): Athena cost/datalake UI reads.
       Admin-notifications prefer D1 `admin_notification` when `AUTH_DB` bound
       (`src/lib/admin-notifications.ts` + migration 0011); Dynamo table is fallback.
+- [x] `DONE` Athena cost/datalake UI reads → Cloudflare-first (2026-07-29).
+      `/admin/cost` prefers D1 `aws_cost_daily` (migration 0013) then R2
+      `lake/aws-cost/cost.json` (`cost-analytics.ts`); Athena is legacy fallback.
+      ETL: `scripts/etl/aws-cost-to-r2.mjs` + `.github/workflows/etl-aws-cost-to-r2.yml`
+      (CE source → R2 + D1). Datalake dashboard prefers D1 `analytics_events` +
+      R2 `lake/snapshots/admin-datalake.json` (`datalake-r2.ts` /
+      `materialize-datalake-snapshots.mjs`); Athena fills missing sections only.
+      Billing source remains AWS Cost Explorer (no CF equivalent).
 - [x] `DEFERRED` ESLint 10 + TypeScript 7 majors (ecosystem blockers 2026-07-29).
       ESLint 10 crashes `eslint-plugin-react` (`getFilename is not a function`);
       `eslint-plugin-import` / `jsx-a11y` peers stop at eslint 9. TypeScript 7

--- a/migrations/0013-aws-cost-daily.sql
+++ b/migrations/0013-aws-cost-daily.sql
@@ -1,0 +1,12 @@
+-- AWS Cost Explorer rows for /admin/cost (replaces Athena v_aws_cost_by_service reads)
+CREATE TABLE IF NOT EXISTS aws_cost_daily (
+  cost_date TEXT NOT NULL,
+  service TEXT NOT NULL,
+  amount_usd REAL NOT NULL,
+  currency TEXT NOT NULL DEFAULT 'USD',
+  synced_at INTEGER NOT NULL,
+  PRIMARY KEY (cost_date, service)
+);
+
+CREATE INDEX IF NOT EXISTS idx_aws_cost_date ON aws_cost_daily(cost_date);
+CREATE INDEX IF NOT EXISTS idx_aws_cost_synced ON aws_cost_daily(synced_at);

--- a/schema.sql
+++ b/schema.sql
@@ -48,6 +48,19 @@ CREATE INDEX idx_stripe_event_type ON stripe_transaction(event_type);
 CREATE INDEX idx_stripe_received_at ON stripe_transaction(received_at);
 CREATE INDEX idx_stripe_event_day ON stripe_transaction(event_day);
 
+-- AWS Cost Explorer daily rows (admin /cost; ETL aws-cost-to-r2)
+CREATE TABLE aws_cost_daily (
+    cost_date TEXT NOT NULL,
+    service TEXT NOT NULL,
+    amount_usd REAL NOT NULL,
+    currency TEXT NOT NULL DEFAULT 'USD',
+    synced_at INTEGER NOT NULL,
+    PRIMARY KEY (cost_date, service)
+);
+
+CREATE INDEX idx_aws_cost_date ON aws_cost_daily(cost_date);
+CREATE INDEX idx_aws_cost_synced ON aws_cost_daily(synced_at);
+
 -- Admin notifications table
 CREATE TABLE admin_notification (
     pk TEXT NOT NULL,

--- a/scripts/etl/aws-cost-to-r2.mjs
+++ b/scripts/etl/aws-cost-to-r2.mjs
@@ -1,0 +1,125 @@
+/**
+ * ETL: AWS Cost Explorer → Cloudflare R2 (+ optional D1 SQL dump)
+ *
+ * Source remains Cost Explorer (AWS-only billing API). Destination is
+ * Cloudflare-first: R2 parquet + JSON for /admin/cost, with a generated
+ * SQL file for `wrangler d1 execute` upserts into `aws_cost_daily`.
+ *
+ * Replaces scripts/etl/aws-cost-to-lake.mjs (S3 + Athena path).
+ */
+
+import { CostExplorerClient, GetCostAndUsageCommand } from "@aws-sdk/client-cost-explorer";
+import { PutObjectCommand } from "@aws-sdk/client-s3";
+import { ParquetWriter, ParquetSchema } from "@dsnp/parquetjs";
+import { readFileSync, unlinkSync, writeFileSync } from "fs";
+import { getS3Client, BUCKET } from "./_r2-config.mjs";
+import { shapeResults } from "./aws-cost-to-lake.mjs";
+
+const LOOKBACK_DAYS = Number.parseInt(process.env.AWS_COST_LOOKBACK_DAYS || "60", 10);
+const D1_SQL_OUT = process.env.AWS_COST_D1_SQL_OUT || "/tmp/aws-cost-d1.sql";
+
+const ce = new CostExplorerClient({ region: "us-east-1" });
+const s3 = getS3Client();
+
+const schema = new ParquetSchema({
+	cost_date: { type: "UTF8" },
+	service: { type: "UTF8" },
+	amount_usd: { type: "DOUBLE" },
+	currency: { type: "UTF8" },
+});
+
+function isoDate(d) {
+	return d.toISOString().slice(0, 10);
+}
+
+function sqlEscape(value) {
+	return String(value).replaceAll("'", "''");
+}
+
+function buildD1Sql(rows, syncedAt) {
+	const lines = ["DELETE FROM aws_cost_daily;"];
+	const chunkSize = 80;
+	for (let i = 0; i < rows.length; i += chunkSize) {
+		const chunk = rows.slice(i, i + chunkSize);
+		const values = chunk
+			.map(
+				(r) =>
+					`('${sqlEscape(r.cost_date)}','${sqlEscape(r.service)}',${r.amount_usd},'${sqlEscape(r.currency)}',${syncedAt})`
+			)
+			.join(",\n  ");
+		lines.push(
+			`INSERT INTO aws_cost_daily (cost_date, service, amount_usd, currency, synced_at) VALUES\n  ${values};`
+		);
+	}
+	return `${lines.join("\n")}\n`;
+}
+
+async function fetchDailyCost() {
+	const end = new Date();
+	const start = new Date();
+	start.setUTCDate(start.getUTCDate() - LOOKBACK_DAYS);
+	const out = await ce.send(
+		new GetCostAndUsageCommand({
+			TimePeriod: { Start: isoDate(start), End: isoDate(end) },
+			Granularity: "DAILY",
+			Metrics: ["UnblendedCost"],
+			GroupBy: [{ Type: "DIMENSION", Key: "SERVICE" }],
+		})
+	);
+	return out.ResultsByTime || [];
+}
+
+async function main() {
+	console.log(`Fetching ${LOOKBACK_DAYS}d of AWS Cost Explorer data → R2://${BUCKET}...`);
+	const results = await fetchDailyCost();
+	const rows = shapeResults(results);
+	console.log(`Shaped ${rows.length} (date, service) rows over ${results.length} days.`);
+
+	if (rows.length === 0) {
+		console.warn("No cost rows returned. Skipping upload to avoid clobbering existing file.");
+		return;
+	}
+
+	const syncedAt = Date.now();
+	const payload = {
+		generated_at: new Date(syncedAt).toISOString(),
+		lookback_days: LOOKBACK_DAYS,
+		row_count: rows.length,
+		rows,
+	};
+
+	const tmp = "/tmp/aws-cost.parquet";
+	const writer = await ParquetWriter.openFile(schema, tmp);
+	for (const r of rows) await writer.appendRow(r);
+	await writer.close();
+
+	await s3.send(
+		new PutObjectCommand({
+			Bucket: BUCKET,
+			Key: "lake/aws-cost/cost.parquet",
+			Body: readFileSync(tmp),
+			ContentType: "application/octet-stream",
+		})
+	);
+	unlinkSync(tmp);
+
+	await s3.send(
+		new PutObjectCommand({
+			Bucket: BUCKET,
+			Key: "lake/aws-cost/cost.json",
+			Body: Buffer.from(JSON.stringify(payload), "utf8"),
+			ContentType: "application/json",
+		})
+	);
+
+	writeFileSync(D1_SQL_OUT, buildD1Sql(rows, syncedAt), "utf8");
+	console.log(`✅ Uploaded ${rows.length} rows → R2://${BUCKET}/lake/aws-cost/{cost.parquet,cost.json}`);
+	console.log(`✅ Wrote D1 SQL → ${D1_SQL_OUT}`);
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+	main().catch((e) => {
+		console.error(e);
+		process.exit(1);
+	});
+}

--- a/scripts/etl/materialize-datalake-snapshots.mjs
+++ b/scripts/etl/materialize-datalake-snapshots.mjs
@@ -1,0 +1,159 @@
+/**
+ * Materialize admin datalake dashboard sections from R2 parquet → one JSON snapshot.
+ * Writes lake/snapshots/admin-datalake.json
+ */
+import { GetObjectCommand, PutObjectCommand } from "@aws-sdk/client-s3";
+import { ParquetReader } from "@dsnp/parquetjs";
+import { mkdtempSync, writeFileSync, rmSync } from "fs";
+import { join } from "path";
+import { tmpdir } from "os";
+import { getS3Client, BUCKET } from "./_r2-config.mjs";
+
+const s3 = getS3Client();
+const SNAPSHOT_KEY = "lake/snapshots/admin-datalake.json";
+
+async function readParquet(key) {
+	const res = await s3.send(new GetObjectCommand({ Bucket: BUCKET, Key: key }));
+	const buf = Buffer.from(await res.Body.transformToByteArray());
+	const dir = mkdtempSync(join(tmpdir(), "datalake-snap-"));
+	const tmp = join(dir, "data.parquet");
+	writeFileSync(tmp, buf);
+	try {
+		const reader = await ParquetReader.openFile(tmp);
+		const cursor = reader.getCursor();
+		const rows = [];
+		let row;
+		while ((row = await cursor.next())) {
+			const plain = {};
+			for (const [k, v] of Object.entries(row)) {
+				plain[k] = typeof v === "bigint" ? Number(v) : v;
+			}
+			rows.push(plain);
+		}
+		await reader.close();
+		return rows;
+	} finally {
+		rmSync(dir, { recursive: true, force: true });
+	}
+}
+
+async function safeParquet(key) {
+	try {
+		return await readParquet(key);
+	} catch (error) {
+		const message = error instanceof Error ? error.message : String(error);
+		console.warn(`  skip ${key}: ${message.slice(0, 160)}`);
+		return null;
+	}
+}
+
+function sectionOk(section, rows) {
+	return { section, rows, rowCount: rows.length, fromCache: false };
+}
+
+function sectionErr(section, error) {
+	return { section, error: String(error).slice(0, 300) };
+}
+
+function topKeywords(rows) {
+	const byQuery = new Map();
+	for (const row of rows) {
+		const query = String(row.query ?? "(unknown)");
+		const cur = byQuery.get(query) || { query, clicks: 0, impressions: 0, position_sum: 0, n: 0 };
+		cur.clicks += Number(row.clicks) || 0;
+		cur.impressions += Number(row.impressions) || 0;
+		cur.position_sum += Number(row.position) || 0;
+		cur.n += 1;
+		byQuery.set(query, cur);
+	}
+	return [...byQuery.values()]
+		.map((r) => ({
+			query: r.query,
+			clicks: r.clicks,
+			impressions: r.impressions,
+			ctr: r.impressions > 0 ? r.clicks / r.impressions : 0,
+			avg_position: r.n > 0 ? Math.round((r.position_sum / r.n) * 10) / 10 : 0,
+		}))
+		.sort((a, b) => b.clicks - a.clicks)
+		.slice(0, 25);
+}
+
+function topErrors(rows) {
+	return [...rows]
+		.sort((a, b) => (Number(b.count_14d) || 0) - (Number(a.count_14d) || 0))
+		.slice(0, 10)
+		.map((r) => ({
+			short_id: r.short_id ?? null,
+			title: r.title ?? null,
+			level: r.level ?? null,
+			status: r.status ?? null,
+			count_14d: Number(r.count_14d) || 0,
+			user_count: Number(r.user_count) || 0,
+			last_seen: r.last_seen ?? null,
+			permalink: r.permalink ?? null,
+		}));
+}
+
+function linkedinSummary(rows) {
+	return rows.slice(0, 50).map((r) => {
+		const out = {};
+		for (const [k, v] of Object.entries(r)) out[k] = v ?? null;
+		return out;
+	});
+}
+
+function espocrmFunnel(contacts, opportunities) {
+	if (!contacts) return null;
+	const opps = opportunities || [];
+	const bySource = new Map();
+	for (const c of contacts) {
+		const lead = String(c.lead_source ?? c.source ?? "(none)");
+		const cur = bySource.get(lead) || {
+			lifecycle_stage: "contact",
+			lead_source: lead,
+			contact_count: 0,
+			closed_won_deals: 0,
+			closed_won_revenue: 0,
+		};
+		cur.contact_count += 1;
+		bySource.set(lead, cur);
+	}
+	for (const o of opps) {
+		const stage = String(o.stage ?? o.status ?? "");
+		if (!/closed\s*won/i.test(stage) && stage !== "Closed Won") continue;
+		const lead = String(o.lead_source ?? "(none)");
+		const cur = bySource.get(lead) || {
+			lifecycle_stage: "contact",
+			lead_source: lead,
+			contact_count: 0,
+			closed_won_deals: 0,
+			closed_won_revenue: 0,
+		};
+		cur.closed_won_deals += 1;
+		cur.closed_won_revenue += Number(o.amount) || 0;
+		bySource.set(lead, cur);
+	}
+	return [...bySource.values()].sort((a, b) => b.contact_count - a.contact_count).slice(0, 20);
+}
+
+async function main() {
+	console.log(`Materializing datalake snapshot → R2://${BUCKET}/${SNAPSHOT_KEY}`);
+	const sections = [];
+	const gsc = await safeParquet("lake/gsc-keywords/keywords.parquet");
+	sections.push(gsc ? sectionOk("top_keywords", topKeywords(gsc)) : sectionErr("top_keywords", "missing gsc parquet"));
+	const sentry = await safeParquet("lake/sentry-issues/issues.parquet");
+	sections.push(sentry ? sectionOk("top_errors", topErrors(sentry)) : sectionErr("top_errors", "missing sentry parquet"));
+	const linkedin = await safeParquet("lake/linkedin-ads/insights.parquet");
+	sections.push(linkedin ? sectionOk("linkedin_ads", linkedinSummary(linkedin)) : sectionErr("linkedin_ads", "missing linkedin parquet"));
+	const contacts = await safeParquet("lake/espocrm-contacts/contacts.parquet");
+	const opportunities = await safeParquet("lake/espocrm-opportunities/opportunities.parquet");
+	const funnel = espocrmFunnel(contacts, opportunities);
+	sections.push(funnel ? sectionOk("espocrm_funnel", funnel) : sectionErr("espocrm_funnel", "missing espocrm parquet"));
+	sections.push(sectionErr("acquisition_funnel", "use D1 analytics_events via API (not materialized from R2)"));
+	sections.push(sectionErr("attribution", "use D1 analytics_events via API (not materialized from R2)"));
+	const payload = { generated_at: new Date().toISOString(), cache: "r2-snapshot", sections };
+	await s3.send(new PutObjectCommand({ Bucket: BUCKET, Key: SNAPSHOT_KEY, Body: Buffer.from(JSON.stringify(payload), "utf8"), ContentType: "application/json" }));
+	console.log(`✅ Wrote snapshot with ${sections.length} sections`);
+}
+
+main().catch((e) => { console.error(e); process.exit(1); });

--- a/scripts/etl/package.json
+++ b/scripts/etl/package.json
@@ -5,7 +5,8 @@
     "@aws-sdk/client-s3": "^3.1071.0",
     "@dsnp/parquetjs": "^1.8.7",
     "jose": "^6.2.3",
-    "stripe": "^22.2.2"
+    "stripe": "^22.2.2",
+    "@aws-sdk/client-cost-explorer": "^3.1071.0"
   },
   "overrides": {
     "thrift": "^0.23.0"

--- a/src/app/api/admin/analytics/datalake/route.ts
+++ b/src/app/api/admin/analytics/datalake/route.ts
@@ -1,89 +1,24 @@
 /**
  * GET /api/admin/analytics/datalake
  *
- * Single endpoint that fans out 6 Athena queries in parallel and returns one
- * JSON payload for the /admin/analytics/datalake dashboard. Each section
- * degrades independently — a missing table (e.g. ETL hasn't run yet) returns
- * `{ section: "x", error: "..." }` instead of failing the whole response.
+ * Cloudflare-first dashboard payload for /admin/analytics/datalake:
+ *   - D1 analytics_events for acquisition / attribution when AUTH_DB bound
+ *   - R2 lake/snapshots/admin-datalake.json for GSC / Sentry / LinkedIn / EspoCRM
+ *   - Legacy Athena views only for missing sections
  *
  * Query params:
- *   ?refresh=1  — bust the 60-second per-section cache (forces fresh Athena scan)
- *
- * Cost: each view is < 100 KB scanned at our row counts; total per refresh is
- * far below Athena's $5/TB pricing floor. Cached for 60s per query in-process.
+ *   ?refresh=1  — skip R2 snapshot cache; re-query Athena for gaps
  */
 
 import { NextRequest, NextResponse } from "next/server";
 import { requireAdmin } from "@/lib/api-auth";
-import { runAthenaQuery, resetAthenaCache } from "@/lib/athena";
-
-interface SectionResult {
-  section: string;
-  rows?: Record<string, string | number | null>[];
-  rowCount?: number;
-  fromCache?: boolean;
-  error?: string;
-}
-
-const QUERIES: Array<{ section: string; sql: string }> = [
-  {
-    section: "acquisition_funnel",
-    // Daily funnel for the last 30 days — sessions / signups / purchasers / revenue.
-    sql: "SELECT * FROM cloudless_analytics.v_acquisition_funnel WHERE day >= current_date - interval '30' day ORDER BY day DESC",
-  },
-  {
-    section: "attribution",
-    // UTM source/medium → conversions over the 90-day window
-    sql: "SELECT * FROM cloudless_analytics.v_attribution_by_source LIMIT 25",
-  },
-  {
-    section: "top_keywords",
-    // GSC top 25 keywords with clicks / CTR / avg position
-    sql: "SELECT * FROM cloudless_analytics.v_gsc_top_keywords LIMIT 25",
-  },
-  {
-    section: "linkedin_ads",
-    // Per-campaign 90-day rollup
-    sql: "SELECT * FROM cloudless_analytics.v_linkedin_ads_summary",
-  },
-  {
-    section: "top_errors",
-    // Sentry top 10 unresolved by 14d count
-    sql: "SELECT * FROM cloudless_analytics.v_sentry_top_issues LIMIT 10",
-  },
-  {
-    section: "espocrm_funnel",
-    // Lifecycle stage breakdown
-    sql: "SELECT * FROM cloudless_analytics.v_espocrm_funnel LIMIT 20",
-  },
-];
+import { getDatalakeDashboard } from "@/lib/datalake-r2";
 
 export async function GET(request: NextRequest) {
   const auth = await requireAdmin(request);
   if (!auth.ok) return auth.response;
 
   const refresh = request.nextUrl.searchParams.get("refresh") === "1";
-  if (refresh) resetAthenaCache();
-
-  // Fan out — each query degrades on its own. Promise.allSettled keeps the
-  // whole route from failing if a single view doesn't exist yet (e.g. the
-  // matching ETL has not produced its first parquet file).
-  const settled = await Promise.allSettled(
-    QUERIES.map(async ({ section, sql }) => {
-      const result = await runAthenaQuery(sql, { skipCache: refresh });
-      return { section, ...result };
-    })
-  );
-
-  const sections: SectionResult[] = settled.map((s, i) => {
-    if (s.status === "fulfilled") return s.value;
-    const err = s.reason instanceof Error ? s.reason.message : String(s.reason);
-    return { section: QUERIES[i].section, error: err.slice(0, 300) };
-  });
-
-  return NextResponse.json({
-    generated_at: new Date().toISOString(),
-    cache: refresh ? "skipped" : "respected",
-    sections,
-  });
+  const payload = await getDatalakeDashboard({ refresh });
+  return NextResponse.json(payload);
 }

--- a/src/app/api/admin/cost/route.ts
+++ b/src/app/api/admin/cost/route.ts
@@ -1,13 +1,12 @@
 /**
- * GET /api/admin/cost — admin-gated AWS cost summary backed by the
- * `cloudless_analytics.v_aws_cost_by_service` Athena view (R9 ETL).
+ * GET /api/admin/cost — admin-gated AWS cost summary.
  *
- * Drives the /admin/cost page (R12). Avoids the Grafana SCP block —
- * the Next.js Lambda's deploy IAM role has direct Athena access.
+ * Cloudflare-first: D1 `aws_cost_daily` → R2 `lake/aws-cost/cost.json` →
+ * legacy Athena `v_aws_cost_by_service`. Source ETL is Cost Explorer → R2/D1
+ * (`scripts/etl/aws-cost-to-r2.mjs`).
  *
  * Returns {total_30d, yesterday, topServices, dailyTrend, lastEtlAt}.
- * 503 with `{configured: false}` when the Athena view doesn't exist yet
- * (operator hasn't run the R9 DDL) — UI shows a "configure me" placeholder.
+ * 503 with `{configured: false}` when no cost source is available.
  */
 import { NextRequest, NextResponse } from "next/server";
 import { requireAdmin } from "@/lib/api-auth";

--- a/src/lib/cost-analytics.ts
+++ b/src/lib/cost-analytics.ts
@@ -1,15 +1,16 @@
 /**
- * Cost analytics helper — queries the `cloudless_analytics.v_aws_cost_by_service`
- * Athena view (created in R9, populated daily by `scripts/etl/aws-cost-to-lake.mjs`).
+ * Cost analytics for `/admin/cost` (R12).
  *
- * Powers the `/admin/cost` page (R12). Bypasses the SCP-blocked Grafana
- * Athena path by querying directly from the Next.js Lambda (which has its
- * own IAM grant on Athena via the deploy role — verified working).
+ * Cloudflare-first read path:
+ *   1. D1 `aws_cost_daily` when AUTH_DB is bound (ETL: aws-cost-to-r2 + wrangler)
+ *   2. R2 `lake/aws-cost/cost.json` when DATALAKE_BUCKET is bound
+ *   3. Legacy Athena `v_aws_cost_by_service` (optional fallback)
  *
- * All queries are bounded by date + grouped server-side; result sets are
- * small (≤200 rows for the 30-day-by-service shape).
+ * Source data still comes from AWS Cost Explorer (billing API); only the
+ * analytics *store/query* path is Cloudflare-native.
  */
-import { runAthenaQuery } from "@/lib/athena";
+import { getAuthDbFromEnv, type AuthDatabase } from "@/lib/auth-d1";
+import { getDataLakeBucketFromEnv } from "@/lib/r2-client";
 
 export interface CostByServiceRow {
   service: string;
@@ -17,114 +18,246 @@ export interface CostByServiceRow {
 }
 
 export interface DailyCostRow {
-  cost_date: string; // YYYY-MM-DD
+  cost_date: string;
   total_usd: number;
 }
 
 export interface CostSummary {
   total_30d: number;
   yesterday: number;
-  topServices: CostByServiceRow[]; // top 10
-  dailyTrend: DailyCostRow[]; // last 30 days
-  lastEtlAt: string | null; // ISO timestamp of the most recent ETL load
+  topServices: CostByServiceRow[];
+  dailyTrend: DailyCostRow[];
+  lastEtlAt: string | null;
 }
 
-/**
- * Top N services by 30-day spend.
- * Returns highest → lowest. Default 10.
- */
-export async function getTopServicesByCost(limit = 10): Promise<CostByServiceRow[]> {
-  const safeLimit = Math.max(1, Math.min(limit, 50));
-  const sql = `
-    SELECT service, round(sum(amount_usd), 2) AS total_usd
-    FROM cloudless_analytics.v_aws_cost_by_service
-    WHERE cost_date >= date_format(current_date - interval '30' day, '%Y-%m-%d')
-    GROUP BY service
-    ORDER BY total_usd DESC
-    LIMIT ${safeLimit}
-  `;
-  const { rows } = await runAthenaQuery(sql);
-  return rows.map((r) => ({
-    service: String(r.service ?? "unknown"),
-    total_usd: Number.parseFloat(String(r.total_usd ?? "0")) || 0,
+interface CostRow {
+  cost_date: string;
+  service: string;
+  amount_usd: number;
+  currency?: string;
+}
+
+interface CostSource {
+  rows: CostRow[];
+  lastEtlAt: string | null;
+}
+
+function daysAgoIso(days: number): string {
+  const date = new Date();
+  date.setUTCDate(date.getUTCDate() - days);
+  return date.toISOString().slice(0, 10);
+}
+
+function yesterdayIso(): string {
+  return daysAgoIso(1);
+}
+
+function withinLastDays(costDate: string, days: number): boolean {
+  return costDate >= daysAgoIso(days);
+}
+
+function enumerateDays(days: number): string[] {
+  const out: string[] = [];
+  for (let i = days - 1; i >= 0; i -= 1) out.push(daysAgoIso(i));
+  return out;
+}
+
+function round2(value: number): number {
+  return Math.round(value * 100) / 100;
+}
+
+function summarize(source: CostSource, limit = 10): CostSummary {
+  const windowRows = source.rows.filter((row) => withinLastDays(row.cost_date, 30));
+  const total_30d = round2(windowRows.reduce((sum, row) => sum + row.amount_usd, 0));
+
+  const yday = yesterdayIso();
+  const yesterday = round2(
+    windowRows.filter((row) => row.cost_date === yday).reduce((sum, row) => sum + row.amount_usd, 0)
+  );
+
+  const byService = new Map<string, number>();
+  for (const row of windowRows) {
+    byService.set(row.service, (byService.get(row.service) || 0) + row.amount_usd);
+  }
+  const topServices = [...byService.entries()]
+    .map(([service, total_usd]) => ({ service, total_usd: round2(total_usd) }))
+    .sort((a, b) => b.total_usd - a.total_usd)
+    .slice(0, Math.max(1, Math.min(limit, 50)));
+
+  const byDay = new Map<string, number>();
+  for (const day of enumerateDays(30)) byDay.set(day, 0);
+  for (const row of windowRows) {
+    if (!byDay.has(row.cost_date)) continue;
+    byDay.set(row.cost_date, (byDay.get(row.cost_date) || 0) + row.amount_usd);
+  }
+  const dailyTrend = [...byDay.entries()]
+    .sort(([a], [b]) => a.localeCompare(b))
+    .map(([cost_date, total_usd]) => ({ cost_date, total_usd: round2(total_usd) }));
+
+  return { total_30d, yesterday, topServices, dailyTrend, lastEtlAt: source.lastEtlAt };
+}
+
+async function loadFromD1(db: AuthDatabase): Promise<CostSource | null> {
+  const result = await db
+    .prepare(
+      `SELECT cost_date, service, amount_usd, currency, synced_at
+       FROM aws_cost_daily`
+    )
+    .all<{
+      cost_date: string;
+      service: string;
+      amount_usd: number;
+      currency: string | null;
+      synced_at: number | null;
+    }>();
+
+  const rows = (result.results ?? []).map((row) => ({
+    cost_date: String(row.cost_date),
+    service: String(row.service || "unknown"),
+    amount_usd: Number(row.amount_usd) || 0,
+    currency: row.currency ?? "USD",
   }));
+  if (rows.length === 0) return null;
+
+  let maxSynced = 0;
+  for (const row of result.results ?? []) {
+    if (typeof row.synced_at === "number" && row.synced_at > maxSynced) maxSynced = row.synced_at;
+  }
+
+  return {
+    rows,
+    lastEtlAt: maxSynced > 0 ? new Date(maxSynced).toISOString() : null,
+  };
 }
 
-/**
- * Daily total spend, last 30 days (oldest → newest).
- * Used for the time-series chart on /admin/cost.
- */
-export async function getDailyCostTrend(): Promise<DailyCostRow[]> {
-  const sql = `
-    SELECT cost_date, round(sum(amount_usd), 2) AS total_usd
-    FROM cloudless_analytics.v_aws_cost_by_service
-    WHERE cost_date >= date_format(current_date - interval '30' day, '%Y-%m-%d')
-    GROUP BY cost_date
-    ORDER BY cost_date ASC
-  `;
-  const { rows } = await runAthenaQuery(sql);
-  return rows.map((r) => ({
-    cost_date: String(r.cost_date ?? ""),
-    total_usd: Number.parseFloat(String(r.total_usd ?? "0")) || 0,
-  }));
+async function loadFromR2(): Promise<CostSource | null> {
+  const bucket = getDataLakeBucketFromEnv();
+  if (!bucket) return null;
+
+  const object = await bucket.get("lake/aws-cost/cost.json");
+  if (!object) return null;
+
+  const parsed = JSON.parse(await object.text()) as {
+    generated_at?: string;
+    rows?: Array<Record<string, unknown>>;
+  };
+  const rows = (parsed.rows ?? [])
+    .map((row) => ({
+      cost_date: String(row.cost_date ?? ""),
+      service: String(row.service ?? "unknown"),
+      amount_usd: Number(row.amount_usd) || 0,
+      currency: typeof row.currency === "string" ? row.currency : "USD",
+    }))
+    .filter((row) => row.cost_date);
+
+  if (rows.length === 0) return null;
+
+  const uploaded =
+    "uploaded" in object && object.uploaded instanceof Date
+      ? object.uploaded.toISOString()
+      : (parsed.generated_at ?? null);
+
+  return { rows, lastEtlAt: uploaded };
 }
 
-/** 30-day total — single number. */
-export async function getTotal30d(): Promise<number> {
-  const sql = `
-    SELECT round(sum(amount_usd), 2) AS total_usd
-    FROM cloudless_analytics.v_aws_cost_by_service
-    WHERE cost_date >= date_format(current_date - interval '30' day, '%Y-%m-%d')
-  `;
-  const { rows } = await runAthenaQuery(sql);
-  return Number.parseFloat(String(rows[0]?.total_usd ?? "0")) || 0;
-}
-
-/**
- * Yesterday's total — single number. Useful for surfacing sudden spikes on
- * the operator's first-thing-Monday glance.
- */
-export async function getYesterdayCost(): Promise<number> {
-  const sql = `
-    SELECT round(sum(amount_usd), 2) AS total_usd
-    FROM cloudless_analytics.v_aws_cost_by_service
-    WHERE cost_date = date_format(current_date - interval '1' day, '%Y-%m-%d')
-  `;
-  const { rows } = await runAthenaQuery(sql);
-  return Number.parseFloat(String(rows[0]?.total_usd ?? "0")) || 0;
-}
-
-/**
- * Most recent ETL upload timestamp — proves the data is fresh. Read from
- * the S3 LastModified of `lake/aws-cost/cost.parquet` rather than from the
- * Athena view (Athena doesn't expose ingestion time).
- *
- * Failure to fetch returns null — the UI shows "—" instead of crashing.
- */
-export async function getLastEtlAt(): Promise<string | null> {
+async function loadFromAthena(): Promise<CostSource | null> {
   try {
+    const { runAthenaQuery } = await import("@/lib/athena");
     const { S3Client, HeadObjectCommand } = await import("@aws-sdk/client-s3");
-    const s3 = new S3Client({ region: process.env.AWS_REGION || "us-east-1" });
-    const out = await s3.send(
-      new HeadObjectCommand({
-        Bucket: process.env.ANALYTICS_BUCKET || "cloudless-analytics-data",
-        Key: "lake/aws-cost/cost.parquet",
-      })
+
+    const sql = `
+      SELECT cost_date, service, amount_usd, currency
+      FROM cloudless_analytics.v_aws_cost_by_service
+      WHERE cost_date >= date_format(current_date - interval '60' day, '%Y-%m-%d')
+    `;
+    const { rows } = await runAthenaQuery(sql);
+    const mapped: CostRow[] = rows
+      .map((r) => ({
+        cost_date: String(r.cost_date ?? ""),
+        service: String(r.service ?? "unknown"),
+        amount_usd: Number.parseFloat(String(r.amount_usd ?? "0")) || 0,
+        currency: String(r.currency ?? "USD"),
+      }))
+      .filter((r) => r.cost_date);
+
+    if (mapped.length === 0) return null;
+
+    let lastEtlAt: string | null = null;
+    try {
+      const s3 = new S3Client({ region: process.env.AWS_REGION || "us-east-1" });
+      const out = await s3.send(
+        new HeadObjectCommand({
+          Bucket: process.env.ANALYTICS_BUCKET || "cloudless-analytics-data",
+          Key: "lake/aws-cost/cost.parquet",
+        })
+      );
+      lastEtlAt = out.LastModified ? out.LastModified.toISOString() : null;
+    } catch {
+      lastEtlAt = null;
+    }
+
+    return { rows: mapped, lastEtlAt };
+  } catch (error) {
+    console.warn(
+      "[cost-analytics] Athena fallback failed:",
+      error instanceof Error ? error.message : error
     );
-    return out.LastModified ? out.LastModified.toISOString() : null;
-  } catch {
     return null;
   }
 }
 
-/** One-shot bundler — the `/api/admin/cost` route returns this shape. */
+async function loadCostSource(): Promise<CostSource> {
+  const db = getAuthDbFromEnv();
+  if (db) {
+    try {
+      const fromD1 = await loadFromD1(db);
+      if (fromD1) return fromD1;
+    } catch (error) {
+      console.warn(
+        "[cost-analytics] D1 read failed:",
+        error instanceof Error ? error.message : error
+      );
+    }
+  }
+
+  try {
+    const fromR2 = await loadFromR2();
+    if (fromR2) return fromR2;
+  } catch (error) {
+    console.warn(
+      "[cost-analytics] R2 read failed:",
+      error instanceof Error ? error.message : error
+    );
+  }
+
+  const fromAthena = await loadFromAthena();
+  if (fromAthena) return fromAthena;
+
+  return { rows: [], lastEtlAt: null };
+}
+
+export async function getTopServicesByCost(limit = 10): Promise<CostByServiceRow[]> {
+  const summary = await getCostSummary();
+  return summary.topServices.slice(0, Math.max(1, Math.min(limit, 50)));
+}
+
+export async function getDailyCostTrend(): Promise<DailyCostRow[]> {
+  return (await getCostSummary()).dailyTrend;
+}
+
+export async function getTotal30d(): Promise<number> {
+  return (await getCostSummary()).total_30d;
+}
+
+export async function getYesterdayCost(): Promise<number> {
+  return (await getCostSummary()).yesterday;
+}
+
+export async function getLastEtlAt(): Promise<string | null> {
+  return (await getCostSummary()).lastEtlAt;
+}
+
 export async function getCostSummary(): Promise<CostSummary> {
-  const [total_30d, yesterday, topServices, dailyTrend, lastEtlAt] = await Promise.all([
-    getTotal30d(),
-    getYesterdayCost(),
-    getTopServicesByCost(10),
-    getDailyCostTrend(),
-    getLastEtlAt(),
-  ]);
-  return { total_30d, yesterday, topServices, dailyTrend, lastEtlAt };
+  const source = await loadCostSource();
+  return summarize(source, 10);
 }

--- a/src/lib/datalake-r2.ts
+++ b/src/lib/datalake-r2.ts
@@ -1,0 +1,244 @@
+/**
+ * Admin datalake dashboard reads — Cloudflare-first.
+ *
+ * Prefer R2 snapshot `lake/snapshots/admin-datalake.json` (written by
+ * scripts/etl/materialize-datalake-snapshots.mjs). Acquisition/attribution
+ * prefer live D1 `analytics_events` when AUTH_DB is bound. Athena remains
+ * a legacy per-section fallback.
+ */
+
+import { getAuthDbFromEnv, type AuthDatabase } from "@/lib/auth-d1";
+import { getDataLakeBucketFromEnv } from "@/lib/r2-client";
+
+export interface DatalakeSectionResult {
+  section: string;
+  rows?: Record<string, string | number | null>[];
+  rowCount?: number;
+  fromCache?: boolean;
+  error?: string;
+}
+
+export interface DatalakeDashboardPayload {
+  generated_at: string;
+  cache: string;
+  sections: DatalakeSectionResult[];
+}
+
+const SNAPSHOT_KEY = "lake/snapshots/admin-datalake.json";
+
+const SECTION_ORDER = [
+  "acquisition_funnel",
+  "attribution",
+  "top_keywords",
+  "linkedin_ads",
+  "top_errors",
+  "espocrm_funnel",
+] as const;
+
+function daysAgoUnix(days: number): number {
+  return Math.floor(Date.now() / 1000) - days * 24 * 60 * 60;
+}
+
+async function acquisitionFromD1(db: AuthDatabase): Promise<DatalakeSectionResult> {
+  const since = daysAgoUnix(30);
+  const result = await db
+    .prepare(
+      `SELECT date(created_at, 'unixepoch') AS day,
+              COUNT(DISTINCT CASE WHEN event = 'page_view' THEN session_id END) AS sessions,
+              COUNT(DISTINCT CASE WHEN event = 'signup' THEN user_id END) AS signups,
+              COUNT(DISTINCT CASE WHEN event = 'purchase' THEN user_id END) AS purchasers,
+              SUM(CASE WHEN event = 'purchase'
+                       THEN COALESCE(json_extract(properties_json, '$.amount'), 0)
+                       ELSE 0 END) AS revenue
+       FROM analytics_events
+       WHERE created_at >= ?
+       GROUP BY 1
+       ORDER BY 1 DESC`
+    )
+    .bind(since)
+    .all<Record<string, string | number | null>>();
+
+  return {
+    section: "acquisition_funnel",
+    rows: result.results ?? [],
+    rowCount: (result.results ?? []).length,
+    fromCache: false,
+  };
+}
+
+async function attributionFromD1(db: AuthDatabase): Promise<DatalakeSectionResult> {
+  const since = daysAgoUnix(90);
+  const result = await db
+    .prepare(
+      `SELECT COALESCE(source, '(direct)') AS utm_source,
+              COALESCE(medium, '(none)') AS utm_medium,
+              COALESCE(campaign, '(none)') AS utm_campaign,
+              COUNT(DISTINCT CASE WHEN event = 'page_view' THEN session_id END) AS sessions,
+              COUNT(DISTINCT CASE WHEN event = 'signup' THEN user_id END) AS signups,
+              SUM(CASE WHEN event = 'purchase' THEN 1 ELSE 0 END) AS purchases,
+              SUM(CASE WHEN event = 'purchase'
+                       THEN COALESCE(json_extract(properties_json, '$.amount'), 0)
+                       ELSE 0 END) AS revenue
+       FROM analytics_events
+       WHERE created_at >= ?
+       GROUP BY 1, 2, 3
+       HAVING COUNT(*) > 1
+       ORDER BY revenue DESC, sessions DESC
+       LIMIT 25`
+    )
+    .bind(since)
+    .all<Record<string, string | number | null>>();
+
+  return {
+    section: "attribution",
+    rows: result.results ?? [],
+    rowCount: (result.results ?? []).length,
+    fromCache: false,
+  };
+}
+
+export async function loadDatalakeSnapshotFromR2(): Promise<DatalakeDashboardPayload | null> {
+  const bucket = getDataLakeBucketFromEnv();
+  if (!bucket) return null;
+  const object = await bucket.get(SNAPSHOT_KEY);
+  if (!object) return null;
+  const parsed = JSON.parse(await object.text()) as DatalakeDashboardPayload;
+  if (!parsed?.sections || !Array.isArray(parsed.sections)) return null;
+  return {
+    generated_at: parsed.generated_at || new Date().toISOString(),
+    cache: parsed.cache || "r2-snapshot",
+    sections: parsed.sections,
+  };
+}
+
+async function athenaSection(
+  section: string,
+  sql: string,
+  skipCache: boolean
+): Promise<DatalakeSectionResult> {
+  const { runAthenaQuery } = await import("@/lib/athena");
+  const result = await runAthenaQuery(sql, { skipCache });
+  return { section, ...result };
+}
+
+const ATHENA_QUERIES: Array<{ section: string; sql: string }> = [
+  {
+    section: "acquisition_funnel",
+    sql: "SELECT * FROM cloudless_analytics.v_acquisition_funnel WHERE day >= current_date - interval '30' day ORDER BY day DESC",
+  },
+  {
+    section: "attribution",
+    sql: "SELECT * FROM cloudless_analytics.v_attribution_by_source LIMIT 25",
+  },
+  {
+    section: "top_keywords",
+    sql: "SELECT * FROM cloudless_analytics.v_gsc_top_keywords LIMIT 25",
+  },
+  {
+    section: "linkedin_ads",
+    sql: "SELECT * FROM cloudless_analytics.v_linkedin_ads_summary",
+  },
+  {
+    section: "top_errors",
+    sql: "SELECT * FROM cloudless_analytics.v_sentry_top_issues LIMIT 10",
+  },
+  {
+    section: "espocrm_funnel",
+    sql: "SELECT * FROM cloudless_analytics.v_espocrm_funnel LIMIT 20",
+  },
+];
+
+function sectionUsable(section: DatalakeSectionResult | undefined): boolean {
+  return Boolean(
+    section && !section.error && Array.isArray(section.rows) && (section.rowCount ?? section.rows.length) >= 0
+  );
+}
+
+function mergeSections(
+  preferred: DatalakeSectionResult[],
+  fallback: DatalakeSectionResult[]
+): DatalakeSectionResult[] {
+  const byName = new Map(fallback.map((s) => [s.section, s]));
+  for (const section of preferred) {
+    const hasRows = Array.isArray(section.rows);
+    const usable = !section.error && hasRows;
+    if (usable) byName.set(section.section, section);
+    else if (!byName.has(section.section)) byName.set(section.section, section);
+  }
+  return SECTION_ORDER.map((section) => byName.get(section) ?? { section, error: "missing" });
+}
+
+export async function getDatalakeDashboard(options: {
+  refresh?: boolean;
+}): Promise<DatalakeDashboardPayload> {
+  const refresh = options.refresh === true;
+  const preferred: DatalakeSectionResult[] = [];
+
+  const db = getAuthDbFromEnv();
+  if (db) {
+    try {
+      preferred.push(await acquisitionFromD1(db));
+    } catch (error) {
+      preferred.push({
+        section: "acquisition_funnel",
+        error: error instanceof Error ? error.message.slice(0, 300) : String(error),
+      });
+    }
+    try {
+      preferred.push(await attributionFromD1(db));
+    } catch (error) {
+      preferred.push({
+        section: "attribution",
+        error: error instanceof Error ? error.message.slice(0, 300) : String(error),
+      });
+    }
+  }
+
+  if (!refresh) {
+    try {
+      const snap = await loadDatalakeSnapshotFromR2();
+      if (snap) preferred.push(...snap.sections);
+    } catch (error) {
+      console.warn(
+        "[datalake-r2] snapshot read failed:",
+        error instanceof Error ? error.message : error
+      );
+    }
+  }
+
+  const hasAllUsable = SECTION_ORDER.every((section) =>
+    sectionUsable(preferred.find((s) => s.section === section))
+  );
+
+  if (hasAllUsable) {
+    return {
+      generated_at: new Date().toISOString(),
+      cache: refresh ? "skipped" : "cloudflare",
+      sections: mergeSections(preferred, []),
+    };
+  }
+
+  if (refresh) {
+    try {
+      const { resetAthenaCache } = await import("@/lib/athena");
+      resetAthenaCache();
+    } catch {
+      /* Athena optional */
+    }
+  }
+
+  const settled = await Promise.allSettled(
+    ATHENA_QUERIES.map(({ section, sql }) => athenaSection(section, sql, refresh))
+  );
+  const athenaSections: DatalakeSectionResult[] = settled.map((s, i) => {
+    if (s.status === "fulfilled") return s.value;
+    const err = s.reason instanceof Error ? s.reason.message : String(s.reason);
+    return { section: ATHENA_QUERIES[i].section, error: err.slice(0, 300) };
+  });
+
+  return {
+    generated_at: new Date().toISOString(),
+    cache: refresh ? "skipped" : preferred.length ? "cloudflare+athena" : "athena",
+    sections: mergeSections(preferred, athenaSections),
+  };
+}

--- a/src/lib/r2-client.ts
+++ b/src/lib/r2-client.ts
@@ -43,10 +43,14 @@ export function getMediaBucket(env: R2Env): R2Bucket | null {
   return null;
 }
 
-// Get R2 bucket binding for analytics/datalake
+// Get R2 bucket binding for analytics/datalake (read and/or write)
 export function getDataLakeBucket(env: R2Env): R2Bucket | null {
-  if (env?.DATALAKE_BUCKET && typeof env.DATALAKE_BUCKET.put === "function") {
-    return env.DATALAKE_BUCKET;
+  const bucket = env?.DATALAKE_BUCKET;
+  if (
+    bucket &&
+    (typeof bucket.put === "function" || typeof bucket.get === "function")
+  ) {
+    return bucket;
   }
   return null;
 }


### PR DESCRIPTION
## Summary
- `/admin/cost` reads D1 `aws_cost_daily` → R2 `lake/aws-cost/cost.json` → Athena fallback
- Datalake dashboard prefers D1 `analytics_events` + R2 `lake/snapshots/admin-datalake.json`; Athena fills gaps only
- New ETL `aws-cost-to-r2.mjs` + workflow (CE source → R2/D1) and `materialize-datalake-snapshots.mjs`
- Migration **0013** applied on remote `user-auth-db`
- `getDataLakeBucket` accepts read-only bindings (`get` without `put`)

## Test plan
- [x] `pnpm exec vitest run __tests__/cost-analytics.test.ts __tests__/datalake-r2.test.ts __tests__/r2-datalake.test.ts`
- [x] Remote D1 migration 0013 applied
- [ ] CI green
- [ ] Optional: `gh workflow run etl-aws-cost-to-r2.yml` once CE IAM is ready


Made with [Cursor](https://cursor.com)