### PR TITLE
fix(ci): Cloudflare Workers OpenNext double-build ENOTEMPTY

### DIFF
--- a/scripts/cf-build-wrapper.sh
+++ b/scripts/cf-build-wrapper.sh
@@ -11,6 +11,9 @@ set -euo pipefail
 # 3. The incomplete .next/ then causes ENOENT errors in OpenNext's bundle phase
 #
 # Instead, we just ensure the middleware stub exists and exit successfully.
+# NOTE: package.json "build" is scripts/sst-next-build.mjs (not this file).
+# OpenNext's nested `pnpm build` hits that script — it also honors
+# OPEN_NEXT_BUILD_ACTIVE (see sst-next-build.mjs).
 if [ -n "${OPEN_NEXT_BUILD_ACTIVE:-}" ]; then
   echo "⚠ Recursive build detected — skipping next build (already built above)..."
   # Ensure middleware.js.nft.json stub exists for OpenNext's bundle phase

--- a/scripts/sst-next-build.mjs
+++ b/scripts/sst-next-build.mjs
@@ -6,6 +6,11 @@
  * never emits that legacy file (edge wrapper lives under edge/chunks). A
  * pre-build stub is wiped when `next build` recreates `.next/`, so we keep the
  * stub present for the whole build, then run the OpenNext middleware bridge.
+ *
+ * When `scripts/cf-build-wrapper.sh` already ran `next build` and then invokes
+ * `opennextjs-cloudflare build`, OpenNext calls `pnpm build` again. That second
+ * pass must no-op: re-running `next build` races `rmdir .next/server` (ENOTEMPTY).
+ * Guard: OPEN_NEXT_BUILD_ACTIVE=1 from the wrapper.
  */
 import { spawn } from "node:child_process";
 import fs from "node:fs";
@@ -16,6 +21,19 @@ const root = path.dirname(path.dirname(fileURLToPath(import.meta.url)));
 const serverDir = path.join(root, ".next", "server");
 const nftPath = path.join(serverDir, "middleware.js.nft.json");
 const middlewareJsPath = path.join(serverDir, "middleware.js");
+
+if (process.env.OPEN_NEXT_BUILD_ACTIVE === "1") {
+  const hasManifest = fs.existsSync(path.join(serverDir, "middleware-manifest.json"));
+  if (hasManifest) {
+    console.warn(
+      "[sst-next-build] OPEN_NEXT_BUILD_ACTIVE — skipping nested next build (reuse existing .next).",
+    );
+    process.exit(0);
+  }
+  console.warn(
+    "[sst-next-build] OPEN_NEXT_BUILD_ACTIVE set but .next/server incomplete — running next build.",
+  );
+}
 
 function ensureMiddlewareStubs() {
   try {


### PR DESCRIPTION
## Summary
D1 migrate is fixed (#1416). Workers then failed at OpenNext because it re-runs `pnpm build` → `sst-next-build.mjs`, which tries to wipe `.next/server` (ENOTEMPTY). Skip nested `next build` when `OPEN_NEXT_BUILD_ACTIVE=1` (set by `cf-build-wrapper.sh`).

## Test plan
- [ ] Merge → re-run Cloudflare Workers Deploy through Build + SST deploy


Made with [Cursor](https://cursor.com)