### PR TITLE
fix(ci): trigger Workers deploy when build scripts change

### DIFF
--- a/.github/workflows/cloudflare-deploy.yml
+++ b/.github/workflows/cloudflare-deploy.yml
@@ -20,6 +20,10 @@ on:
       - 'opennext.config.*'
       - 'next.config.*'
       - '.github/workflows/cloudflare-deploy.yml'
+      - 'scripts/cf-build-wrapper.sh'
+      - 'scripts/sst-next-build.mjs'
+      - 'scripts/opennext-middleware-fix.mjs'
+      - 'open-next.config.cloudflare.ts'
   workflow_dispatch:
     inputs:
       stage:


### PR DESCRIPTION
## Summary
#1417 fixed OpenNext double-build but did not re-trigger Cloudflare Workers Deploy (path filters omitted `scripts/*`). Add those paths and merge to ship the edge.

## Test plan
- [ ] Merge → Cloudflare Workers Deploy runs and completes SST deploy


Made with [Cursor](https://cursor.com)