### PR TITLE
fix(ci): Workers Free size — minify + strip @vercel/og

### DIFF
--- a/.github/workflows/cloudflare-deploy.yml
+++ b/.github/workflows/cloudflare-deploy.yml
@@ -24,6 +24,7 @@ on:
       - 'scripts/sst-next-build.mjs'
       - 'scripts/opennext-middleware-fix.mjs'
       - 'scripts/strip-opennext-bin-fonts.mjs'
+      - 'scripts/strip-opennext-vercel-og.mjs'
       - 'open-next.config.cloudflare.ts'
   workflow_dispatch:
     inputs:
@@ -79,8 +80,11 @@ jobs:
           let t = fs.readFileSync(path, "utf8");
           t = t.replace(/"main"\s*:\s*"[^"]*"/, '"main": ".open-next/worker.js"');
           t = t.replace(/"directory"\s*:\s*"\.\/out"/, '"directory": ".open-next/assets"');
+          if (!/"minify"\s*:/.test(t)) {
+            t = t.replace(/"compatibility_date"/, '"minify": true,\n  "compatibility_date"');
+          }
           fs.writeFileSync(path, t);
-          console.log("wrangler.jsonc → main=.open-next/worker.js assets=.open-next/assets");
+          console.log("wrangler.jsonc → main=.open-next/worker.js assets=.open-next/assets minify=true");
           NODE
 
       - name: Report OpenNext Worker size
@@ -94,9 +98,10 @@ jobs:
         run: |
           set -euo pipefail
           set -o pipefail
+          # --minify is in package.json cf:deploy (free-tier size reduction).
           if ! pnpm cf:deploy 2>&1 | tee /tmp/cf-deploy.log; then
             if grep -qE '10027|size limit of 3 MiB' /tmp/cf-deploy.log; then
-              echo "::error::Worker exceeds Cloudflare free-plan 3 MiB limit. Upgrade Workers to Paid (10 MiB) at https://dash.cloudflare.com → Workers & Pages → Plans, then re-run this workflow."
+              echo "::error::Worker still over free 3 MiB gzip after minify + OG strip. Free options: (1) re-check strip scripts / exclude more deps, (2) serve via Pi Tunnel only (deploy-pi.yml) without Workers SSR. Do not upgrade to Paid unless you choose to."
             fi
             exit 1
           fi
@@ -109,5 +114,4 @@ jobs:
 # CF_ACCOUNT_ID - Cloudflare account ID
 # CLOUDFLARE_ZONE_ID - Cloudflare zone ID for custom domain binding
 # CRON_SECRET - Shared secret for cron job authorization
-# NOTE: Free Workers plan caps script size at 3 MiB (gzip). Full OpenNext
-# Next.js 16 apps often need Workers Paid (10 MiB).
+# NOTE: Stay on Workers Free — minify + strip @vercel/og (see cf-build-wrapper).

--- a/ACTIONS-REQUIRED.md
+++ b/ACTIONS-REQUIRED.md
@@ -70,7 +70,7 @@ python3 scripts/purge-sensitive-gh-variables.py --apply  # mutate
 | Cloudflare API token rotation  | If MCP CF tools 401                                                                                                                                                                                                                                                    |
 | ESP32 Notion DBs               | Empty (no hardware data); page reconstruct partial                                                                                                                                                                                                                     |
 | Bot Fight Mode vs GHA crons    | Free BFM cannot be WAF-skipped. Workflow `cloudflare-skip-cron-challenge.yml` turns `bot_fight_mode=off` (needs Zone Settings:Edit). If that 403s/400s, disable **Security → Bots → Bot Fight Mode** in the CF dashboard so LinkedIn/postiz crons reach `/api/cron/*`. |
-| Workers Paid (3→10 MiB)        | Cloudflare Workers Deploy hits error **10027** (free 3 MiB script cap) for OpenNext Next 16. Upgrade **Workers & Pages → Plans → Paid** (~$5/mo), then re-run `cloudflare-deploy.yml`. Frontend is this Worker on `cloudless.gr` (not Pages).                          |
+| Workers Free size (no Paid)    | Stay on **Workers Free** (3 MiB gzip). Deploy uses `--minify` + `strip-opennext-bin-fonts` + `strip-opennext-vercel-og`. If still over: prune more deps or serve via **Pi Tunnel** (`deploy-pi.yml`) without Workers SSR — do **not** upgrade to Paid. Docs: [Workers limits](https://developers.cloudflare.com/workers/platform/limits/#worker-size), [OpenNext troubleshooting](https://opennext.js.org/cloudflare/troubleshooting). |
 
 ---
 

--- a/next.config.ts
+++ b/next.config.ts
@@ -64,7 +64,20 @@ const nextConfig: NextConfig = {
     "@aws-sdk/client-ses",
     "@aws-sdk/client-sesv2",
     "@aws-sdk/client-ssm",
+    // Free Workers = 3 MiB gzip. Keep OG font/WASM out of the traced server
+    // package; OpenNext still pre-renders opengraph-image routes at build time.
+    "@vercel/og",
   ],
+  // Drop traced copies of OG binaries from the OpenNext server function package.
+  // See https://opennext.js.org/cloudflare/troubleshooting (Worker size limit).
+  outputFileTracingExcludes: {
+    "*": [
+      "node_modules/@vercel/og/**/*",
+      "node_modules/next/dist/compiled/@vercel/og/**/*",
+      "node_modules/@resvg/**/*",
+      "node_modules/satori/**/*",
+    ],
+  },
   // In WSL dev, set NEXT_DIST_DIR to a native Linux path (e.g. ~/next-cloudless)
   // to avoid the slow NTFS→WSL filesystem benchmark warning.
   // Production and CI leave this unset so the default .next dir is used.

--- a/package.json
+++ b/package.json
@@ -95,7 +95,7 @@
     "analyze": "ANALYZE=true next build",
     "cf:build": "bash scripts/cf-build-wrapper.sh",
     "cf:build:opennext": "bash scripts/cf-build-wrapper.sh",
-    "cf:deploy": "opennextjs-cloudflare deploy",
+    "cf:deploy": "opennextjs-cloudflare deploy --minify",
     "cf:preview": "opennextjs-cloudflare preview",
     "cf:upload": "opennextjs-cloudflare upload"
   },

--- a/scripts/cf-build-wrapper.sh
+++ b/scripts/cf-build-wrapper.sh
@@ -76,4 +76,15 @@ echo "▶ Running OpenNext Cloudflare build..."
 NEXT_TELEMETRY_DISABLED=1 pnpm exec opennextjs-cloudflare build \
   --openNextConfigPath open-next.config.cloudflare.ts
 
+# Free plan = 3 MiB gzip Worker script. Strip OG fonts/WASM + .bin stubs so
+# we stay under the limit without Workers Paid (~$5/mo).
+echo "▶ Slimming OpenNext output for Workers Free (strip OG + .bin fonts)..."
+node scripts/strip-opennext-bin-fonts.mjs
+node scripts/strip-opennext-vercel-og.mjs
+
+if [ -f .open-next/worker.js ]; then
+  bytes=$(gzip -c .open-next/worker.js | wc -c)
+  awk -v b="$bytes" 'BEGIN {printf "▶ worker.js gzip ≈ %.2f MiB (free limit 3.00)\n", b/1024/1024}'
+fi
+
 echo "✅ Cloudflare build complete"

--- a/scripts/strip-opennext-vercel-og.mjs
+++ b/scripts/strip-opennext-vercel-og.mjs
@@ -1,0 +1,118 @@
+#!/usr/bin/env node
+/**
+ * Keep Cloudflare Workers Free (3 MiB gzip) by removing @vercel/og WASM /
+ * edge chunks from OpenNext output after build.
+ *
+ * Dynamic ImageResponse at the edge is disabled; pre-rendered opengraph-image
+ * assets under .open-next/assets still serve. Community approach:
+ * https://github.com/vercel/next.js/discussions/93157
+ * https://hoangtaiki.com/blog/optimizing-nextjs-bundle-performance-cloudflare
+ */
+import fs from "node:fs";
+import path from "node:path";
+
+const root = path.resolve(".open-next");
+if (!fs.existsSync(root)) {
+  console.log("[strip-opennext-vercel-og] no .open-next — skip");
+  process.exit(0);
+}
+
+/** @type {string[]} */
+const targets = [];
+
+function walk(dir) {
+  for (const ent of fs.readdirSync(dir, { withFileTypes: true })) {
+    const full = path.join(dir, ent.name);
+    if (ent.isDirectory()) {
+      walk(full);
+      continue;
+    }
+    const lower = ent.name.toLowerCase();
+    if (
+      lower.endsWith(".wasm") ||
+      lower.includes("resvg") ||
+      lower.includes("yoga") ||
+      /geist.*\.ttf(\.bin)?$/i.test(lower) ||
+      lower === "index.edge.js"
+    ) {
+      // Only touch OG-related paths
+      if (
+        full.includes(`${path.sep}@vercel${path.sep}og`) ||
+        full.includes(`${path.sep}compiled${path.sep}@vercel${path.sep}og`) ||
+        lower.endsWith(".wasm") ||
+        lower.endsWith(".ttf.bin") ||
+        lower.endsWith(".ttf")
+      ) {
+        targets.push(full);
+      }
+    }
+  }
+}
+
+walk(root);
+
+let deleted = 0;
+for (const file of targets) {
+  try {
+    fs.unlinkSync(file);
+    deleted += 1;
+  } catch {
+    // ignore
+  }
+}
+
+/** Rewrite handler / worker to skip edge OG redirects (Discussion #93157). */
+const patches = [
+  {
+    name: "node→edge OG redirect → empty",
+    from: 'id==="next/dist/compiled/@vercel/og/index.node.js"?raw=await import("next/dist/compiled/@vercel/og/index.edge.js"):raw=await import(id)',
+    to: 'id==="next/dist/compiled/@vercel/og/index.node.js"?raw={}:raw=await import(id)',
+  },
+  {
+    name: "quoted edge OG import → empty object",
+    from: 'await import("next/dist/compiled/@vercel/og/index.edge.js")',
+    to: "await Promise.resolve({})",
+  },
+];
+
+/** @type {string[]} */
+const codeFiles = [];
+function walkCode(dir) {
+  for (const ent of fs.readdirSync(dir, { withFileTypes: true })) {
+    const full = path.join(dir, ent.name);
+    if (ent.isDirectory()) {
+      walkCode(full);
+      continue;
+    }
+    if (/\.(m?js|cjs)$/.test(ent.name)) codeFiles.push(full);
+  }
+}
+walkCode(root);
+
+let patchedFiles = 0;
+let patchHits = 0;
+for (const file of codeFiles) {
+  let content = fs.readFileSync(file, "utf8");
+  if (!content.includes("@vercel/og") && !content.includes("vercel/og")) continue;
+  const before = content;
+  for (const patch of patches) {
+    if (content.includes(patch.from)) {
+      content = content.split(patch.from).join(patch.to);
+      patchHits += 1;
+      console.log(`[strip-opennext-vercel-og] ${patch.name} → ${path.relative(process.cwd(), file)}`);
+    }
+  }
+  // Drop side-effect imports of compiled OG edge entry
+  content = content.replace(
+    /import\s+['"]next\/dist\/compiled\/@vercel\/og\/[^'"]+['"];?/g,
+    "/* stripped @vercel/og import */",
+  );
+  if (content !== before) {
+    fs.writeFileSync(file, content);
+    patchedFiles += 1;
+  }
+}
+
+console.log(
+  `[strip-opennext-vercel-og] deleted=${deleted} assets; patchedFiles=${patchedFiles}; patchHits=${patchHits}`,
+);


### PR DESCRIPTION
## Summary
- Stay on **Workers Free** (no Paid upgrade): `cf:deploy --minify`, wrangler `minify: true`, and post-build strip of `@vercel/og` / Geist `.bin` fonts.
- Trace-exclude OG/resvg/satori in `next.config.ts`; update `ACTIONS-REQUIRED.md` to prefer free paths (Pi Tunnel fallback if still over 3 MiB).

## Test plan
- [ ] CI `Cloudflare Workers Deploy` reports `worker.js gzip ≈ < 3.00 MiB`
- [ ] Deploy succeeds (no CF error 10027)
- [ ] Site loads on `cloudless.gr`; static OG assets still served from `.open-next/assets`
- [ ] Confirm no Workers Paid plan change in Cloudflare dashboard


Made with [Cursor](https://cursor.com)