### PR TITLE
fix(pi): health version SHA + BFM cleared

### DIFF
--- a/.github/workflows/deploy-pi.yml
+++ b/.github/workflows/deploy-pi.yml
@@ -294,9 +294,18 @@ jobs:
           fi
       - name: Set image and roll out
         run: |
+          SHORT_SHA="${{ needs.build-and-push.outputs.short_sha }}"
+          FULL_SHA="${{ github.sha }}"
+          IMAGE="${{ env.ECR_REGISTRY }}/${{ env.ECR_REPOSITORY }}:${SHORT_SHA}"
           kubectl set image deployment/${{ env.K3S_DEPLOYMENT }} \
-            ${{ env.K3S_DEPLOYMENT }}=${{ env.ECR_REGISTRY }}/${{ env.ECR_REPOSITORY }}:${{ needs.build-and-push.outputs.short_sha }} \
+            ${{ env.K3S_DEPLOYMENT }}=${IMAGE} \
             -n ${{ env.K3S_NAMESPACE }}
+          # Runtime ENV so /api/health.version is the deploy SHA even if an older
+          # layer baked APP_VERSION=dev/0.1.0 at next build.
+          kubectl set env deployment/${{ env.K3S_DEPLOYMENT }} \
+            -n ${{ env.K3S_NAMESPACE }} \
+            APP_VERSION="${FULL_SHA}" \
+            NEXT_PUBLIC_APP_VERSION="${FULL_SHA}"
           kubectl rollout status deployment/${{ env.K3S_DEPLOYMENT }} -n ${{ env.K3S_NAMESPACE }} --timeout=600s
 
       - name: Ensure NodePort 30300 for Tunnel origin

--- a/ACTIONS-REQUIRED.md
+++ b/ACTIONS-REQUIRED.md
@@ -2,7 +2,7 @@
 
 # Generated: 2026-07-19 16:44 UTC
 
-# Last Updated: 2026-07-29 24:00 EEST — CI D1 migrations + Bot Fight Mode for crons
+# Last Updated: 2026-07-30 — Workers Free Pi proxy live; Bot Fight Mode off (operator)
 
 ---
 
@@ -70,7 +70,7 @@ python3 scripts/purge-sensitive-gh-variables.py --apply  # mutate
 | Cloudflare API token rotation  | If MCP CF tools 401                                                                                                                                                                                                                                                    |
 | ESP32 Notion DBs               | Empty (no hardware data); page reconstruct partial                                                                                                                                                                                                                     |
 | Workers Free (Pi proxy)        | OpenNext SSR is ~5.5 MiB gzip — **cannot** deploy on Free. `cloudflare-deploy.yml` deploys tiny `workers/pi-origin-proxy` as `cloudless2` and points Tunnel `pi-origin` → `http://192.168.1.128:30300`. App code: `deploy-pi.yml`. Do **not** upgrade to Paid. Optional: `workflow_dispatch` + `try_opennext=true` only to re-measure. |
-| Bot Fight Mode vs GHA crons    | **OPERATOR:** Dashboard → `cloudless.gr` → **Security → Bots → Bot Fight Mode → Off**. Free BFM cannot be WAF-skipped; API toggle often unavailable. Until off, GHA curls get “Just a moment…” and cron polls fail. Helper: `cloudflare-skip-cron-challenge.yml`. |
+| Bot Fight Mode vs GHA crons    | **DONE (operator 2026-07-30):** Bot Fight Mode Off — `/api/health` and cron paths return app JSON/401 (no “Just a moment…”). Re-enable only if under real attack; free BFM breaks GHA crons + Lighthouse. Helper: `cloudflare-skip-cron-challenge.yml`. |
 
 ---
 

--- a/src/app/api/health/route.ts
+++ b/src/app/api/health/route.ts
@@ -1,11 +1,14 @@
 export const dynamic = "force-dynamic";
 
-/* Baked in at build time so it's available in Lambda (unlike npm_package_version). */
-const APP_VERSION = globalThis.process?.env.APP_VERSION ?? "0.1.0";
-
 export async function GET() {
+  // Bracket access avoids Next build-time inlining of process.env.APP_VERSION.
+  const env = globalThis.process?.env;
+  const version =
+    env?.["APP_VERSION"]?.trim() ||
+    env?.["NEXT_PUBLIC_APP_VERSION"]?.trim() ||
+    "0.1.0";
   return globalThis.Response.json(
-    { status: "ok", timestamp: new Date().toISOString(), version: APP_VERSION },
-    { headers: { "cache-control": "no-store, no-cache, must-revalidate" } }
+    { status: "ok", timestamp: new Date().toISOString(), version },
+    { headers: { "cache-control": "no-store, no-cache, must-revalidate" } },
   );
 }


### PR DESCRIPTION
## Summary
- `/api/health` reads `APP_VERSION` at request time (bracket access).
- `deploy-pi` sets `APP_VERSION` / `NEXT_PUBLIC_APP_VERSION` on the k3s deployment during rollout.
- ACTIONS-REQUIRED: Bot Fight Mode marked done (operator).

## Test plan
- [ ] After Pi deploy: `curl https://cloudless.gr/api/health` → version = full git SHA (not `0.1.0`)
- [ ] NodePort 30300 step succeeds
- [ ] SHA drift + CWV re-run post-deploy


Made with [Cursor](https://cursor.com)