### PR TITLE
fix(ops): hostPath Pi rollout + CWV CF challenge fallback

### DIFF
--- a/.github/workflows/core-web-vitals-audit.yml
+++ b/.github/workflows/core-web-vitals-audit.yml
@@ -56,29 +56,47 @@ jobs:
           echo "Using CHROME_PATH=$CHROME_BIN"
 
       - name: Warm CDN cache
+        id: warm
         run: |
           set -euo pipefail
-          for url in \
-            https://cloudless.gr \
-            https://cloudless.gr/en \
-            https://cloudless.gr/en/services \
-            https://cloudless.gr/en/contact \
-            https://cloudless.gr/en/store; do
-            BODY=$(mktemp)
-            CODE=$(curl -sS -L -o "$BODY" -w "%{http_code}" --max-time 30 \
-              -H "User-Agent: Mozilla/5.0 (compatible; CloudlessCWV/1.0)" \
-              "$url" || echo 000)
-            echo "$url → HTTP $CODE"
-            if grep -qiE 'Just a moment|challenge-platform|cf-browser-verification' "$BODY"; then
-              echo "::error::$url still serves Cloudflare challenge HTML — disable Bot Fight / Under Attack Mode, then re-run."
-              exit 1
-            fi
-            if [[ "$CODE" != "200" && "$CODE" != "304" ]]; then
-              echo "::error::$url returned HTTP $CODE (expected 200 after redirects)"
-              exit 1
-            fi
-            rm -f "$BODY"
-          done
+          # Real browser UA — datacenter "bot" UAs still get challenged even when
+          # Bot Fight Mode is off (managed challenge / IP reputation).
+          UA='Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0.0.0 Safari/537.36'
+          warm_host() {
+            local host="$1"
+            for path in "" /en /en/services /en/contact /en/store; do
+              local url="https://${host}${path}"
+              BODY=$(mktemp)
+              CODE=$(curl -sS -L -o "$BODY" -w "%{http_code}" --max-time 30 \
+                -H "User-Agent: ${UA}" \
+                -H "Accept: text/html,application/xhtml+xml" \
+                "$url" || echo 000)
+              echo "$url → HTTP $CODE"
+              if grep -qiE 'Just a moment|challenge-platform|cf-browser-verification' "$BODY"; then
+                echo "::warning::$url serves Cloudflare challenge HTML"
+                rm -f "$BODY"
+                return 1
+              fi
+              if [[ "$CODE" != "200" && "$CODE" != "304" ]]; then
+                echo "::warning::$url returned HTTP $CODE"
+                rm -f "$BODY"
+                return 1
+              fi
+              rm -f "$BODY"
+            done
+            return 0
+          }
+
+          if warm_host cloudless.gr; then
+            echo "base_host=cloudless.gr" >> "$GITHUB_OUTPUT"
+          elif warm_host pi-origin.cloudless.gr; then
+            echo "::warning::cloudless.gr challenged GitHub runner IPs — auditing pi-origin.cloudless.gr instead"
+            echo "base_host=pi-origin.cloudless.gr" >> "$GITHUB_OUTPUT"
+          else
+            echo "::error::Both cloudless.gr and pi-origin.cloudless.gr challenged or non-200 from this runner."
+            echo "::error::Disable Bot Fight / Under Attack Mode (or allowlist GH Actions), then re-run."
+            exit 1
+          fi
 
       - name: Run Lighthouse on key routes
         id: lhci
@@ -91,21 +109,21 @@ jobs:
           # always`). Auditing the bare paths makes Lighthouse pay for the
           # redirect round-trip on every probe, which (a) doesn't measure
           # the actual page perf and (b) varies more between runs.
-          # The user-perceived perf for someone landing on `cloudless.gr/`
-          # is captured by auditing `https://cloudless.gr` (apex → locale
-          # redirect) and `https://cloudless.gr/en` (the resolved root).
+          # When GH Actions IPs are CF-challenged on apex, warm falls back to
+          # pi-origin (same app via Tunnel).
           urls: |
-            https://cloudless.gr
-            https://cloudless.gr/en
-            https://cloudless.gr/en/services
-            https://cloudless.gr/en/contact
-            https://cloudless.gr/en/store
+            https://${{ steps.warm.outputs.base_host }}
+            https://${{ steps.warm.outputs.base_host }}/en
+            https://${{ steps.warm.outputs.base_host }}/en/services
+            https://${{ steps.warm.outputs.base_host }}/en/contact
+            https://${{ steps.warm.outputs.base_host }}/en/store
           budgetPath: .github/lighthouse-budget.json
           uploadArtifacts: true
           temporaryPublicStorage: true
       - name: Surface per-route CWV scores inline
         env:
           MANIFEST: ${{ steps.lhci.outputs.manifest }}
+          BASE_HOST: ${{ steps.warm.outputs.base_host }}
         run: |
           # Group multi-run manifest by URL and reduce to the median per metric.
           MEDIANS=$(echo "$MANIFEST" | jq '[
@@ -129,10 +147,11 @@ jobs:
           ' >> "$GITHUB_STEP_SUMMARY"
 
           # Fail if any route's median falls below thresholds.
-          # The bare `https://cloudless.gr/` triggers a locale redirect (307 → /en)
-          # which penalizes Lighthouse perf by ~20-30 points. Skip perf check for
+          # The bare apex URL triggers a locale redirect (307 → /en) which
+          # penalizes Lighthouse perf by ~20-30 points. Skip perf check for
           # that URL — `/en` already covers the actual page performance.
-          FAILED=$(echo "$MEDIANS" | jq --arg root "https://cloudless.gr/" '[.[] | select(
+          ROOT="https://${BASE_HOST}/"
+          FAILED=$(echo "$MEDIANS" | jq --arg root "$ROOT" '[.[] | select(
             (if .url == $root then false else .perf < 0.60 end) or
             .a11y < 0.90 or .bp < 0.90 or .seo < 0.90
           ) | .url] | length')
@@ -143,7 +162,7 @@ jobs:
             echo "Thresholds: Performance ≥ 60 · Accessibility ≥ 90 · Best Practices ≥ 90 · SEO ≥ 90" >> "$GITHUB_STEP_SUMMARY"
             echo "" >> "$GITHUB_STEP_SUMMARY"
             echo "Failing routes:" >> "$GITHUB_STEP_SUMMARY"
-            echo "$MEDIANS" | jq -r --arg root "https://cloudless.gr/" '.[] | select(
+            echo "$MEDIANS" | jq -r --arg root "$ROOT" '.[] | select(
               (if .url == $root then false else .perf < 0.60 end) or
               .a11y < 0.90 or .bp < 0.90 or .seo < 0.90
             ) | "- \(.url) perf=\((.perf*100)|round) a11y=\((.a11y*100)|round) bp=\((.bp*100)|round) seo=\((.seo*100)|round)"' >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/deploy-pi.yml
+++ b/.github/workflows/deploy-pi.yml
@@ -1,4 +1,4 @@
-name: Deploy to Pi (ECR + k3s rollout)
+name: Deploy to Pi (ECR build → hostPath rollout)
 
 on:
   push:
@@ -31,7 +31,12 @@ env:
   ECR_REGISTRY: 278585680617.dkr.ecr.us-east-1.amazonaws.com
   ECR_REPOSITORY: cloudless-pi-app
   K3S_NAMESPACE: cloudless
-  K3S_DEPLOYMENT: cloudless
+  # Live Free-tier origin is hostPath standalone (k8s/cloudless-app-hostpath.yaml),
+  # not the legacy ECR Deployment named "cloudless".
+  K3S_DEPLOYMENT: cloudless-app
+  STANDALONE_HOSTPATH: /home/tbaltzakis/cloudless-standalone
+  # omv Tailscale IP (cert SAN includes this — see docs/kubectl-tailscale.md)
+  OMV_TAILSCALE_IP: "100.74.191.58"
 
 jobs:
   build-and-push:
@@ -197,130 +202,92 @@ jobs:
             --overwrite
 
   rollout:
-    name: Rollout restart on k3s
-    # GH-hosted runner joins tailnet, uses KUBECONFIG_B64 to call k3s API
-    # directly over Tailscale — no SSH hop required.
-    # Failover-capable: when the GH-hosted runner's Tailscale path to the
-    # k3s API breaks (DERP relay failures, packet drops, billing issues),
-    # flip vars.RUNNER_GENERIC to ["self-hosted","omv","build"] via
-    # `.github/scripts/toggle-runner.sh pi`. The Pi runners can reach the
-    # k3s API over the LAN; the Tailscale step is a no-op on them.
-    # Default stays ubuntu-latest for cost (Pi runner busy with build job).
-    runs-on: ${{ fromJSON(vars.RUNNER_GENERIC || '"ubuntu-latest"') }}
+    name: Sync hostPath standalone + roll out
+    # Prefer the Pi build runner: LAN kubectl + docker (ECR→hostPath extract).
+    # Avoids stale KUBECONFIG_B64 / Tailscale TLS issues on ubuntu-latest.
+    # Override with vars.RUNNER_GENERIC only when deliberately forcing GH-hosted.
+    runs-on: ${{ fromJSON(vars.RUNNER_GENERIC || '["self-hosted","omv","build"]') }}
     needs: build-and-push
     if: always() && needs.build-and-push.result != 'cancelled' && (needs.build-and-push.result == 'success' || needs.build-and-push.outputs.image_exists == 'true')
 
     steps:
-      - name: Connect to tailnet
-        # continue-on-error: Pi runners are already Tailscale nodes — if
-        # tailscale-action fails to re-auth the existing daemon (e.g. ephemeral
-        # key consumed), the runner's pre-existing Tailscale connection still
-        # routes kubectl traffic to 100.113.41.119:6443 correctly.
-        continue-on-error: true
-        uses: tailscale/github-action@0263d9e6d793eaefcf1de98ff7fde47abe6664d3 # v3.2.4
+      - name: Configure AWS credentials (OIDC)
+        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4.3.1
         with:
-          authkey: ${{ secrets.TS_AUTHKEY }}
-      - name: Verify Tailscale path to omv-main
-        run: |
-          # tailscale ping exits 1 when all pings route via DERP (no direct
-          # path) even though the connection works fine for kubectl. Treat as
-          # diagnostic-only; let kubectl be the definitive connectivity gate.
-          tailscale ping -c 3 --timeout=15s 100.113.41.119 \
-            || echo "Note: Tailscale using DERP relay — kubectl will still work"
-          # nc exit code unreliable through DERP; log result but don't fail.
-          nc -zv -w 10 100.113.41.119 6443 \
-            && echo "Port 6443 directly reachable" \
-            || echo "Port 6443 via nc failed — proceeding over Tailscale relay"
-      - name: Configure kubectl
-        run: |
-          mkdir -p ~/.kube
-          echo "${{ secrets.KUBECONFIG_B64 }}" | base64 -d > ~/.kube/config
-          chmod 600 ~/.kube/config
-      - name: Diagnose kubectl reachability
-        # FAIL-FAST: the old "Wait for k3s /readyz" step swallowed kubectl
-        # stderr with `2>/dev/null`, so any auth/TLS/network error looped
-        # silently for 10 minutes as "not ready". Surface the real error
-        # before polling so failures are diagnosable in seconds, not minutes.
-        run: |
-          set +e
-          echo "==> kubeconfig (minified)"
-          kubectl config view --minify || echo "(kubectl config view failed)"
-          echo
-          echo "==> First /readyz call WITH stderr"
-          kubectl get --raw /readyz --request-timeout=10s
-          rc=$?
-          echo "kubectl exit code: $rc"
-          if [ "$rc" -ne 0 ]; then
-            echo "::error::kubectl could not reach the k3s API. Likely causes:"
-            echo "::error::  - KUBECONFIG_B64 secret is stale or wrong cluster CA"
-            echo "::error::  - Tailscale tunnel didn't come up (see prior step)"
-            echo "::error::  - k3s server cert was rotated (refresh KUBECONFIG_B64)"
-            exit 1
-          fi
-      - name: Wait for k3s /readyz (3x stable via kubectl)
-        run: |
-          # k3s /readyz returns the string "ok" when all checks pass.
-          # We do NOT suppress stderr — if kubectl starts failing, we want
-          # to see why immediately, not after a silent loop.
-          wait_for_api() {
-            local stable=0
-            local last_err=""
-            for i in $(seq 1 60); do
-              # Capture stderr to a temp so we can surface it on failure
-              out=$(kubectl get --raw /readyz --request-timeout=5s 2>/tmp/k_err)
-              rc=$?
-              if [ "$rc" -eq 0 ] && echo "$out" | grep -q 'ok'; then
-                stable=$((stable + 1))
-                echo "  ${i}/60 — /readyz ok (stable ${stable}/3)"
-                if [ "$stable" -ge 3 ]; then
-                  return 0
-                fi
-              else
-                stable=0
-                last_err=$(cat /tmp/k_err 2>/dev/null | head -3)
-                echo "  ${i}/60 — /readyz not ready (rc=$rc): ${last_err}"
-              fi
-              sleep 5
-            done
-            return 1
-          }
+          role-to-assume: ${{ secrets.AWS_DEPLOY_ROLE_ARN }}
+          aws-region: ${{ env.AWS_REGION }}
 
-          echo "Waiting for k3s API to be stable (3x kubectl /readyz ok)..."
-          if wait_for_api; then
-            echo "k3s API stable — proceeding to rollout"
-          else
-            echo "::error::k3s /readyz never returned 3x ok in 5 min — aborting"
-            exit 1
-          fi
-      - name: Set image and roll out
+      - name: Login to Amazon ECR
+        uses: aws-actions/amazon-ecr-login@fa648b43de3d4d023bcb3f89ed6940096949c419 # v2
+
+      - name: Resolve kubectl
+        id: kubectl
         run: |
+          set -euo pipefail
+          if command -v kubectl >/dev/null 2>&1 && kubectl get --raw /readyz --request-timeout=5s >/dev/null 2>&1; then
+            echo "bin=kubectl" >> "$GITHUB_OUTPUT"
+          elif sudo kubectl get --raw /readyz --request-timeout=5s >/dev/null 2>&1; then
+            echo "bin=sudo kubectl" >> "$GITHUB_OUTPUT"
+          else
+            mkdir -p ~/.kube
+            echo "${{ secrets.KUBECONFIG_B64 }}" | base64 -d > ~/.kube/config
+            chmod 600 ~/.kube/config
+            # Prefer Tailscale SAN IP if kubeconfig still points at 127.0.0.1
+            sed -i "s|server: https://127.0.0.1:6443|server: https://${{ env.OMV_TAILSCALE_IP }}:6443|" ~/.kube/config || true
+            kubectl get --raw /readyz --request-timeout=10s
+            echo "bin=kubectl" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Extract ECR image into hostPath standalone
+        env:
+          KUBECTL: ${{ steps.kubectl.outputs.bin }}
+        run: |
+          set -euo pipefail
           SHORT_SHA="${{ needs.build-and-push.outputs.short_sha }}"
           FULL_SHA="${{ github.sha }}"
           IMAGE="${{ env.ECR_REGISTRY }}/${{ env.ECR_REPOSITORY }}:${SHORT_SHA}"
-          kubectl set image deployment/${{ env.K3S_DEPLOYMENT }} \
-            ${{ env.K3S_DEPLOYMENT }}=${IMAGE} \
-            -n ${{ env.K3S_NAMESPACE }}
-          # Runtime ENV so /api/health.version is the deploy SHA even if an older
-          # layer baked APP_VERSION=dev/0.1.0 at next build.
-          kubectl set env deployment/${{ env.K3S_DEPLOYMENT }} \
-            -n ${{ env.K3S_NAMESPACE }} \
-            APP_VERSION="${FULL_SHA}" \
-            NEXT_PUBLIC_APP_VERSION="${FULL_SHA}"
-          kubectl rollout status deployment/${{ env.K3S_DEPLOYMENT }} -n ${{ env.K3S_NAMESPACE }} --timeout=600s
+          DEST="${{ env.STANDALONE_HOSTPATH }}"
+          STAGE="${DEST}.next-${SHORT_SHA}"
+
+          echo "==> Pulling ${IMAGE}"
+          docker pull "${IMAGE}"
+
+          echo "==> Extracting /app → ${STAGE}"
+          rm -rf "${STAGE}"
+          mkdir -p "${STAGE}"
+          CID=$(docker create "${IMAGE}")
+          docker cp "${CID}:/app/." "${STAGE}/"
+          docker rm "${CID}" >/dev/null
+          test -f "${STAGE}/server.js"
+
+          echo "==> Atomic swap into ${DEST}"
+          sudo mkdir -p "${DEST}"
+          sudo rsync -a --delete "${STAGE}/" "${DEST}/"
+          rm -rf "${STAGE}"
+
+          echo "==> Set APP_VERSION=${FULL_SHA} and restart ${{ env.K3S_DEPLOYMENT }}"
+          # Keep node:22-bookworm-slim + hostPath; only refresh files + env.
+          $KUBECTL set env "deployment/${{ env.K3S_DEPLOYMENT }}" \
+            -n "${{ env.K3S_NAMESPACE }}" \
+            "APP_VERSION=${FULL_SHA}" \
+            "NEXT_PUBLIC_APP_VERSION=${FULL_SHA}"
+          $KUBECTL rollout restart "deployment/${{ env.K3S_DEPLOYMENT }}" \
+            -n "${{ env.K3S_NAMESPACE }}"
+          $KUBECTL rollout status "deployment/${{ env.K3S_DEPLOYMENT }}" \
+            -n "${{ env.K3S_NAMESPACE }}" --timeout=600s
 
       - name: Ensure NodePort 30300 for Tunnel origin
-        # Workers Free proxy + Tunnel pi-origin expect http://192.168.1.128:30300
+        env:
+          KUBECTL: ${{ steps.kubectl.outputs.bin }}
         run: |
           set -euo pipefail
-          for svc in cloudless cloudless-app; do
-            if kubectl get svc "$svc" -n "${{ env.K3S_NAMESPACE }}" >/dev/null 2>&1; then
-              echo "Patching svc/$svc → NodePort 30300"
-              kubectl patch svc "$svc" -n "${{ env.K3S_NAMESPACE }}" --type merge -p \
-                '{"spec":{"type":"NodePort","ports":[{"name":"http","port":80,"targetPort":3000,"nodePort":30300,"protocol":"TCP"}]}}' \
-                || kubectl patch svc "$svc" -n "${{ env.K3S_NAMESPACE }}" --type merge -p \
-                '{"spec":{"type":"NodePort","ports":[{"port":80,"targetPort":3000,"nodePort":30300,"protocol":"TCP"}]}}'
-              kubectl get svc "$svc" -n "${{ env.K3S_NAMESPACE }}" -o wide
-            fi
-          done
-          curl -sS -o /dev/null -w "local health HTTP %{http_code}\n" --max-time 5 http://127.0.0.1:30300/api/health || true
+          if $KUBECTL get svc cloudless-app -n "${{ env.K3S_NAMESPACE }}" >/dev/null 2>&1; then
+            echo "Patching svc/cloudless-app → NodePort 30300"
+            $KUBECTL patch svc cloudless-app -n "${{ env.K3S_NAMESPACE }}" --type merge -p \
+              '{"spec":{"type":"NodePort","ports":[{"name":"http","port":80,"targetPort":3000,"nodePort":30300,"protocol":"TCP"}]}}' \
+              || true
+            $KUBECTL get svc cloudless-app -n "${{ env.K3S_NAMESPACE }}" -o wide
+          fi
+          curl -sS --max-time 5 http://127.0.0.1:30300/api/health || true
+          echo
 # re-triggered 2026-06-04T20:50Z — run #319 OIDC auth transient failure


### PR DESCRIPTION
## Summary
- **Deploy Pi:** live origin is `cloudless-app` + hostPath standalone (not Deployment `cloudless` / ECR `set image`). Rollout now runs on `[self-hosted, omv, build]`, extracts the ECR image into `/home/tbaltzakis/cloudless-standalone`, sets `APP_VERSION`, and restarts.
- **Kubeconfig:** default Tailscale IP corrected to `100.74.191.58` (cert SAN). Operator already refreshed `KUBECONFIG_B64` after k3s CA rotation.
- **CWV:** warm uses a browser UA; if apex is CF-challenged from GH Actions IPs, fall back to auditing `pi-origin.cloudless.gr`.

## Test plan
- [ ] `deploy-pi.yml` workflow_dispatch completes sync + health SHA matches commit
- [ ] `core-web-vitals-audit.yml` passes (apex or pi-origin fallback)
- [ ] `curl https://cloudless.gr/api/health` keeps a full commit SHA


Made with [Cursor](https://cursor.com)