### PR TITLE
fix(ci): sudo hostPath extract for Pi rollout

### DIFF
--- a/.github/workflows/deploy-pi.yml
+++ b/.github/workflows/deploy-pi.yml
@@ -253,17 +253,19 @@ jobs:
           docker pull "${IMAGE}"
 
           echo "==> Extracting /app → ${STAGE}"
-          rm -rf "${STAGE}"
-          mkdir -p "${STAGE}"
+          # Stage + DEST are under /home/tbaltzakis and may be root-owned from
+          # prior runs — always use sudo for mkdir/cp/rsync/cleanup.
+          sudo rm -rf "${STAGE}"
+          sudo mkdir -p "${STAGE}"
           CID=$(docker create "${IMAGE}")
-          docker cp "${CID}:/app/." "${STAGE}/"
+          sudo docker cp "${CID}:/app/." "${STAGE}/"
           docker rm "${CID}" >/dev/null
-          test -f "${STAGE}/server.js"
+          sudo test -f "${STAGE}/server.js"
 
           echo "==> Atomic swap into ${DEST}"
           sudo mkdir -p "${DEST}"
           sudo rsync -a --delete "${STAGE}/" "${DEST}/"
-          rm -rf "${STAGE}"
+          sudo rm -rf "${STAGE}"
 
           echo "==> Set APP_VERSION=${FULL_SHA} and restart ${{ env.K3S_DEPLOYMENT }}"
           # Keep node:22-bookworm-slim + hostPath; only refresh files + env.


### PR DESCRIPTION
## Summary
- `docker cp` into the stage dir failed with `permission denied` on `.next/BUILD_ID` when leftovers were root-owned.
- Use `sudo` for mkdir / cp / rsync / cleanup of the hostPath stage.

## Test plan
- [ ] `deploy-pi.yml` workflow_dispatch → Sync hostPath job green
- [ ] `/api/health` version matches deploy SHA


Made with [Cursor](https://cursor.com)