### PR TITLE
fix(auth): stop ClientFetchError on HTML session responses

### DIFF
--- a/src/app/api/auth/session/route.ts
+++ b/src/app/api/auth/session/route.ts
@@ -18,7 +18,14 @@ export async function GET(req: NextRequest) {
     // Auth.js SessionProvider expects JSON `null` (not an HTML 404 page).
     try {
       const { handlers } = await import("@/lib/auth");
-      return handlers.GET(req);
+      const res = await handlers.GET(req);
+      const ct = res.headers.get("content-type") ?? "";
+      if (!ct.includes("application/json")) {
+        // Auth.js sometimes returns HTML error/signin pages — never leak those
+        // to the browser session poller (ClientFetchError on "<!DOCTYPE").
+        return NextResponse.json(null);
+      }
+      return res;
     } catch {
       return NextResponse.json(null);
     }

--- a/src/components/NextAuthProvider.tsx
+++ b/src/components/NextAuthProvider.tsx
@@ -1,7 +1,25 @@
 "use client";
+
 import { SessionProvider } from "next-auth/react";
 import type { ReactNode } from "react";
 
+/**
+ * Cognito/OIDC flows use next-auth SessionProvider (CSRF + /api/auth/session).
+ * D1 email/password auth is owned by AuthContext → /api/auth/session (custom
+ * route). Mounting SessionProvider in D1 mode still polls Auth.js endpoints;
+ * when Cloudflare (or a misconfigured AUTH_URL) returns HTML, Auth.js throws
+ * ClientFetchError: Unexpected token '<' … is not valid JSON.
+ */
+const USE_NEXTAUTH_SESSION =
+  process.env.NEXT_PUBLIC_AUTH_PROVIDER === "cognito";
+
 export default function NextAuthProvider({ children }: { children: ReactNode }) {
-  return <SessionProvider>{children}</SessionProvider>;
+  if (!USE_NEXTAUTH_SESSION) {
+    return children;
+  }
+  return (
+    <SessionProvider refetchOnWindowFocus={false} refetchInterval={0}>
+      {children}
+    </SessionProvider>
+  );
 }

--- a/src/context/AuthContext.tsx
+++ b/src/context/AuthContext.tsx
@@ -139,13 +139,16 @@ export function AuthProvider({ children }: AuthProviderProps) {
       return;
     }
     try {
-      const res = await globalThis.fetch("/api/auth/session");
+      const res = await globalThis.fetch("/api/auth/session", {
+        headers: { Accept: "application/json" },
+      });
       if (!res.ok) {
         setUser(null);
         setIsAdmin(false);
         return;
       }
-      const data = (await res.json()) as {
+      const raw = await res.text();
+      let data: {
         user?: {
           id?: string;
           name?: string;
@@ -155,7 +158,19 @@ export function AuthProvider({ children }: AuthProviderProps) {
         };
         isAdmin?: boolean;
         error?: string;
-      } | null;
+      } | null = null;
+      try {
+        data = raw ? (JSON.parse(raw) as typeof data) : null;
+      } catch {
+        // HTML challenge / error page — treat as logged out, don't throw.
+        console.warn(
+          "[auth] /api/auth/session returned non-JSON (len=%d); treating as signed out",
+          raw.length,
+        );
+        setUser(null);
+        setIsAdmin(false);
+        return;
+      }
 
       if (data?.error === "RefreshTokenError") {
         // Refresh token expired — clear session so login page shows


### PR DESCRIPTION
## Summary
- Auth.js `ClientFetchError: Unexpected token '<'` happens when `SessionProvider` parses HTML (CF challenge / Auth.js error page) as JSON.
- Production uses `NEXT_PUBLIC_AUTH_PROVIDER=d1` — AuthContext already owns session; do not mount `SessionProvider`.
- Harden `/api/auth/session` + AuthContext to treat non-JSON as signed-out.

## Test plan
- [ ] Load site with D1 auth — no ClientFetchError in console
- [ ] Cognito mode still wraps SessionProvider
- [ ] Logged-out `/api/auth/session` stays JSON `null` or `{user:null}`


Made with [Cursor](https://cursor.com)