### PR TITLE
fix(ci): re-login to ECR before deploy-pi docker pull

### DIFF
--- a/.github/workflows/deploy-pi.yml
+++ b/.github/workflows/deploy-pi.yml
@@ -249,6 +249,14 @@ jobs:
           DEST="${{ env.STANDALONE_HOSTPATH }}"
           STAGE="${DEST}.next-${SHORT_SHA}"
 
+          echo "==> Ensuring ECR docker auth for pull"
+          # amazon-ecr-login can succeed while the subsequent `docker pull`
+          # still sees an empty auths map on this self-hosted runner (shared
+          # dockerd + intermittent credential-helper state). Re-login with the
+          # OIDC session password immediately before pull.
+          aws ecr get-login-password --region "${{ env.AWS_REGION }}" \
+            | docker login --username AWS --password-stdin "${{ env.ECR_REGISTRY }}"
+
           echo "==> Pulling ${IMAGE}"
           docker pull "${IMAGE}"
 


### PR DESCRIPTION
## Summary
- Deploy of #1433 built/pushed the image, then rollout failed: `docker pull` → `no basic auth credentials` despite a successful `amazon-ecr-login` step.
- Re-run `aws ecr get-login-password | docker login` immediately before pull on the self-hosted runner.

## Test plan
- [ ] `gh run rerun` / merge triggers deploy-pi; Extract step pulls `cloudless-pi-app:<sha>` and completes rollout
- [ ] `curl -sI https://cloudless.gr/_next/static/chunks/<css>` → 200 text/css (no locale 307)


Made with [Cursor](https://cursor.com)