### PR TITLE
fix: auth session 200 + cron CF bypass via pi-origin

### DIFF
--- a/.github/workflows/linkedin-poll.yml
+++ b/.github/workflows/linkedin-poll.yml
@@ -48,9 +48,10 @@ jobs:
       - name: Curl the cron endpoint
         env:
           CRON_SECRET: ${{ secrets.CRON_SECRET }}
-          # SITE_ORIGIN should be https://cloudless.gr in prod. Override via
-          # vars to point at a preview deploy.
-          SITE_ORIGIN: ${{ vars.AD_ANALYTICS_SITE_ORIGIN || 'https://cloudless.gr' }}
+          # Default to pi-origin so GitHub Actions bypasses Cloudflare Bot Fight
+          # Mode on the apex (GHA IPs get 403 interstitials). Override via
+          # vars.AD_ANALYTICS_SITE_ORIGIN for preview deploys.
+          SITE_ORIGIN: ${{ vars.AD_ANALYTICS_SITE_ORIGIN || 'https://pi-origin.cloudless.gr' }}
         run: |
           set -euo pipefail
           if [ -z "${CRON_SECRET:-}" ]; then

--- a/.github/workflows/platform-crons.yml
+++ b/.github/workflows/platform-crons.yml
@@ -33,7 +33,9 @@ permissions:
 
 env:
   AWS_REGION: us-east-1
-  BASE_URL: https://cloudless.gr
+  # Bypass Cloudflare Bot Fight Mode on the apex (GHA IPs get 403 interstitials).
+  # pi-origin hits the tunnel → Pi NodePort directly; app still enforces CRON_SECRET.
+  BASE_URL: https://pi-origin.cloudless.gr
 
 jobs:
   trigger:

--- a/.github/workflows/postiz-crons.yml
+++ b/.github/workflows/postiz-crons.yml
@@ -35,7 +35,9 @@ permissions:
 
 env:
   AWS_REGION: us-east-1
-  BASE_URL: https://cloudless.gr
+  # Bypass Cloudflare Bot Fight Mode on the apex (GHA IPs get 403 interstitials).
+  # pi-origin hits the tunnel → Pi NodePort directly; app still enforces CRON_SECRET.
+  BASE_URL: https://pi-origin.cloudless.gr
 
 jobs:
   trigger:

--- a/src/app/api/auth/session/route.ts
+++ b/src/app/api/auth/session/route.ts
@@ -14,18 +14,25 @@ function getDb(_request: NextRequest): AuthDatabase | null {
 export async function GET(req: NextRequest) {
   const db = getDb(req);
   if (!db) {
-    // Fallback to next-auth when D1 is not configured (local Next.js).
-    // Auth.js SessionProvider expects JSON `null` (not an HTML 404 page).
+    // Fallback to next-auth when D1 is not configured (Pi / Cognito path).
+    // Auth.js SessionProvider expects JSON `null` with HTTP 200 — never HTML
+    // and never a 4xx that triggers ClientFetchError in the browser poller.
     try {
       const { handlers } = await import("@/lib/auth");
       const res = await handlers.GET(req);
       const ct = res.headers.get("content-type") ?? "";
       if (!ct.includes("application/json")) {
-        // Auth.js sometimes returns HTML error/signin pages — never leak those
-        // to the browser session poller (ClientFetchError on "<!DOCTYPE").
         return NextResponse.json(null);
       }
-      return res;
+      const text = await res.text();
+      if (!text || text === "null") {
+        return NextResponse.json(null);
+      }
+      try {
+        return NextResponse.json(JSON.parse(text) as unknown);
+      } catch {
+        return NextResponse.json(null);
+      }
     } catch {
       return NextResponse.json(null);
     }
@@ -54,6 +61,14 @@ export async function GET(req: NextRequest) {
       phone: user.phone,
     },
     isAdmin: admin,
+  });
+}
+
+/** HEAD probes (curl -I, health checks) must not fall through to Auth.js 400. */
+export async function HEAD() {
+  return new NextResponse(null, {
+    status: 200,
+    headers: { "content-type": "application/json" },
   });
 }
 


### PR DESCRIPTION
## Summary
- `/api/auth/session` no longer forwards Auth.js 4xx/HTML to the browser; GET always returns JSON (null or session) with 200 when D1 is unbound, and HEAD is an explicit 200.
- Postiz, platform, and LinkedIn ad-analytics cron workflows call `https://pi-origin.cloudless.gr` so GitHub Actions IPs skip Cloudflare Bot Fight Mode (apex was returning 403 interstitials).

## Test plan
- [ ] After deploy: `curl -sI https://cloudless.gr/api/auth/session` → 200
- [ ] `gh workflow run postiz-crons.yml -f target=postiz-sync` → 401 without secret / 200|503 with secret (not CF 403)
- [ ] Hard-refresh site; no ClientFetchError on session poll


Made with [Cursor](https://cursor.com)