### PR TITLE
fix(ops): store/rotate Cloudflare token via GitHub Secret only

### DIFF
--- a/.claude/commands/cloudflare-lb.md
+++ b/.claude/commands/cloudflare-lb.md
@@ -7,9 +7,10 @@ Works from a cloud session with no direct Cloudflare or AWS access.
 ## What this command does
 
 1. Checks current LB state (report run) via issue #382.
-2. Asks the user for a Cloudflare API token if not already in SSM.
+2. Asks the user for a Cloudflare API token if not already in the GitHub Secret.
 3. Dispatches `store-cloudflare-token.yml` via `mcp__github__actions_run_trigger`
-   with the token — stores to SSM and applies the LB in one shot.
+   with the token — stores as GitHub Secret `CLOUDFLARE_API_TOKEN` and applies
+   the LB in one shot (requires repo secret `GH_PAT`).
 4. Monitors the result via issue #382.
 
 ## Steps
@@ -72,8 +73,8 @@ Once you have the token, call `mcp__github__actions_run_trigger` with:
 The workflow:
 
 - Masks the token immediately (will NOT appear in logs)
-- Writes it to SSM `/cloudless/production/CLOUDFLARE_API_TOKEN` (SecureString)
-- Runs `scripts/setup-cloudflare-lb.sh` in apply mode
+- Writes it as GitHub Actions secret `CLOUDFLARE_API_TOKEN` (via `gh secret set`; requires `GH_PAT`)
+- Runs `scripts/setup-cloudflare-lb.sh` in apply mode with the token from the workflow input
 - Creates health monitors, origin pools (AWS + Pi), load balancers, DNS records
 - Posts the full result to issue #382
 
@@ -106,18 +107,18 @@ cloudless.gr / www.cloudless.gr
 Steady state: **all traffic goes to AWS**. Pi is on standby. Cloudflare flips to Pi
 automatically when the AWS health check fails (typically within 60s).
 
-## Key SSM parameter
+## Key secret
 
-| Parameter | Type |
+| Secret | Where |
 |---|---|
-| `/cloudless/production/CLOUDFLARE_API_TOKEN` | SecureString |
+| `CLOUDFLARE_API_TOKEN` | GitHub Actions secret (CI source of truth) |
+| `GH_PAT` | Repo secret — PAT with `repo` scope so store/rotate workflows can `gh secret set` |
 
 ## Notes
 
 - The `store-cloudflare-token.yml` workflow is idempotent — re-running with the
   same token is safe.
-- The token can also be added as a GitHub Secret (`CLOUDFLARE_API_TOKEN`) — both
-  paths work. SSM is preferred for cloud sessions.
+- Do **not** store this token with `aws ssm put-parameter` — GitHub Secrets only.
 - LB provisioning requires the **Load Balancing** add-on to be enabled on the
   Cloudflare account (it is already active for cloudless.gr).
 - Health monitors use a 60s interval with 2 consecutive failures before failover.

--- a/.claude/skills/cloudflare-lb/SKILL.md
+++ b/.claude/skills/cloudflare-lb/SKILL.md
@@ -34,7 +34,7 @@ failover automatically when the AWS health check fails 2× in a row (~2 min late
 
 | Workflow | Trigger | What it does |
 |---|---|---|
-| `store-cloudflare-token.yml` | `workflow_dispatch` | Accepts token as input → masks → SSM → apply LB |
+| `store-cloudflare-token.yml` | `workflow_dispatch` | Accepts token as input → masks → GitHub Secret → optional apply LB |
 | `cloudflare-lb.yml` | `push` (path) or `dispatch` | report-only by default, apply on `apply=true` dispatch |
 | `apply-cloudflare-lb.yml` | `push` (path) or `dispatch` | always apply mode |
 
@@ -55,10 +55,11 @@ Zone Resources: Include → Specific zone → cloudless.gr
 
 | Location | Value |
 |---|---|
-| SSM param | `/cloudless/production/CLOUDFLARE_API_TOKEN` (SecureString) |
-| GitHub Secret | `CLOUDFLARE_API_TOKEN` (optional fallback — SSM takes priority in the script) |
+| GitHub Secret | `CLOUDFLARE_API_TOKEN` (**source of truth** for CI) |
 
-Both paths work. SSM is preferred from cloud sessions.
+Store via `store-cloudflare-token.yml` (requires repo secret `GH_PAT` with
+`repo` scope so the workflow can `gh secret set`). Do **not** use
+`aws ssm put-parameter` for this token.
 
 ## Setup flow (cloud session — no GitHub UI needed)
 
@@ -101,8 +102,9 @@ DNS cloudless.gr:          CNAME → LB: done
 
 ### `BLOCKED: no CLOUDFLARE_API_TOKEN`
 
-The token is not in SSM or GitHub Secrets. Run the `/cloudflare-lb` command or
-dispatch `store-cloudflare-token.yml` with the token.
+The token is not in GitHub Secrets (or not passed as env to the script).
+Run the `/cloudflare-lb` command or dispatch `store-cloudflare-token.yml`
+with the token.
 
 ### Pool is UNHEALTHY
 

--- a/.claude/skills/cloudflare-token-rotation/SKILL.md
+++ b/.claude/skills/cloudflare-token-rotation/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: cloudflare-token-rotation
-description: Step-by-step playbook for rotating the Cloudless.gr Cloudflare API token. Combines the automated workflow (SSM + GH secret) with the manual Cowork session-secret update step.
+description: Step-by-step playbook for rotating the Cloudless.gr Cloudflare API token. Combines the automated workflow (GitHub Secret) with the manual Cowork session-secret update step.
 when_to_use:
   - The current token has been exposed (e.g. accidentally pasted in a transcript)
   - Quarterly scheduled rotation
@@ -10,13 +10,18 @@ when_to_use:
 
 # Cloudflare API Token Rotation
 
-The token lives in three places. Two are automated, one is manual.
+The token lives in two places for operators. One is automated; one is manual.
 
 | Where | How to update | Status when done |
 |---|---|---|
-| AWS SSM `/cloudless/production/CLOUDFLARE_API_TOKEN` | `cloudflare-token-rotate.yml` workflow | ✅ Auto |
-| GitHub Actions secret `CLOUDFLARE_API_TOKEN` | Same workflow (via `gh secret set`) | ✅ Auto |
+| GitHub Actions secret `CLOUDFLARE_API_TOKEN` | `cloudflare-token-rotate.yml` (or `store-cloudflare-token.yml`) | ✅ Auto |
 | Cowork session-environment secret `CLOUDFLARE_API_TOKEN` | Manual UI step — covered below | 🟡 You |
+
+Source of truth for CI is the **GitHub Actions secret**. Do **not** use
+`aws ssm put-parameter` / `get-parameter` for this token.
+
+**Required:** repo secret `GH_PAT` (PAT with `repo` scope) so the workflow
+can run `gh secret set`. `GITHUB_TOKEN` cannot write Actions secrets.
 
 ## Procedure
 
@@ -46,68 +51,48 @@ gh run watch --repo Themis128/cloudless.gr
 
 What happens:
 
-1. Workflow calls `PUT /user/tokens/{id}/value` — Cloudflare returns a new secret. **Old secret is invalidated immediately on this call.**
-2. New value is verified against `/user/tokens/verify`.
-3. AWS SSM is updated via `aws ssm put-parameter --overwrite`.
-4. GitHub Actions secret is updated via `gh secret set`.
+1. Workflow reads the current token from `secrets.CLOUDFLARE_API_TOKEN`.
+2. Calls `PUT /user/tokens/{id}/value` — Cloudflare returns a new secret. **Old secret is invalidated immediately on this call.**
+3. New value is verified against `/user/tokens/verify`.
+4. GitHub Actions secret is updated via `gh secret set` (requires `GH_PAT`).
 
-If any step fails after step 1, the token is in a half-rotated state — see "Recovery".
+If any step fails after step 2, the token is in a half-rotated state — see "Recovery".
 
 ### 3. Manual: update the Cowork session secret
 
-The rotated value is now in SSM. Copy it into your Cowork session secrets so the `cloudless-infra` MCP can use it.
-
-#### From PowerShell (Windows)
-
-```powershell
-$token = aws ssm get-parameter --name /cloudless/production/CLOUDFLARE_API_TOKEN --with-decryption --region us-east-1 --query 'Parameter.Value' --output text
-$token | Set-Clipboard
-Write-Host "Token copied to clipboard ($($token.Length) chars)"
-```
-
-#### From bash (macOS/Linux)
-
-```bash
-aws ssm get-parameter --name /cloudless/production/CLOUDFLARE_API_TOKEN \
-  --with-decryption --region us-east-1 \
-  --query 'Parameter.Value' --output text | pbcopy
-```
+After rotation, paste the new value into Cowork session secrets so the
+`cloudless-infra` MCP can use it. The rotated secret is not readable back
+from GitHub Actions — if you did not capture it from a controlled mint,
+re-mint and run `store-cloudflare-token.yml`, then paste that same value here.
 
 #### Then in Claude Code web UI
 
 1. Open the desktop app's session menu (top-right gear or Cmd/Ctrl+,)
 2. Navigate to **Session → Environment → Secrets**
 3. Find the existing secret named **`CLOUDFLARE_API_TOKEN`** (or add it if absent)
-4. Click **Edit** → paste from clipboard → **Save**
+4. Click **Edit** → paste → **Save**
 5. Reload the Cowork session
 
 The next `mcp__cloudless-infra__cloudflare_*` call should succeed.
 
 ## Verification
 
-After the manual step, verify all three locations agree:
+After the manual step, verify both stores agree:
 
-```bash
-# From the Cowork session — uses the freshly-updated session secret via the MCP
-# (this is the canonical "session secret works" test)
-```
+Ask Claude in the Cowork session:
+> Run `mcp__cloudless-infra__cloudflare_list_tokens` and confirm the active token id matches the rotation run summary.
 
-Then ask Claude in the Cowork session:
-> Run `mcp__cloudless-infra__cloudflare_list_tokens` and confirm the active token id matches what's in SSM.
-
-The MCP wraps the session secret as the bearer. If `list_tokens` returns the rotated id and `status=active`, all three stores are aligned.
+The MCP wraps the session secret as the bearer. If `list_tokens` returns the rotated id and `status=active`, both stores are aligned.
 
 ## Recovery (token rotation half-failed)
 
-**Scenario:** Workflow's PUT call succeeded (old token dead), but SSM or GH secret update failed.
+**Scenario:** Workflow's PUT call succeeded (old token dead), but the GitHub secret update failed (e.g. missing `GH_PAT`).
 
 You're stuck — the new token value was returned ONCE in the workflow output, then masked. To recover:
 
-1. Mint a brand-new token in the Cloudflare dashboard (`https://dash.cloudflare.com/profile/api-tokens`) with the same scopes as the original. See `cloudless.gr`'s CLAUDE.md "Cloudflare HA LB" item and the `cf-token-doctor` reference for the exact scope list.
-2. Run the `store-cloudflare-token.yml` workflow with the new token + `apply=true` to repopulate SSM + the GH secret.
+1. Mint a brand-new token in the Cloudflare dashboard (`https://dash.cloudflare.com/profile/api-tokens`) with the same scopes as the original. See `cloudless.gr`'s CLAUDE.md "Cloudflare HA LB" item and the `cloudflare-token-doctor` skill for the exact scope list.
+2. Ensure `GH_PAT` is set on the repo, then run `store-cloudflare-token.yml` with the new token + `apply=true`.
 3. Update the Cowork session secret manually (step 3 above).
-
-To prevent recurrence, the rotation workflow does verify → rotate → verify-new → update-SSM → update-GH in that strict order. The SSM/GH steps are the cheap ones — if they fail, file an issue and figure out why before re-attempting.
 
 ## Scope requirements
 
@@ -125,5 +110,6 @@ curl -X PUT -H "Authorization: Bearer $ONEOFF_TOKEN" \
 ## See also
 
 - `cloudflare-token-rotate.yml` — the workflow
+- `store-cloudflare-token.yml` — mint/store path (GitHub Secret)
 - `verify-cloudflare-token.yml` — daily smoketest that catches expiries
 - CLAUDE.md "Pending One-Time Setup" → "Cloudflare infra MCP token"

--- a/.github/workflows/cloudflare-token-rotate.yml
+++ b/.github/workflows/cloudflare-token-rotate.yml
@@ -1,8 +1,8 @@
 name: Rotate Cloudflare API token
 
-# Programmatically rotate the Cloudflare API token currently stored in:
-#   - AWS SSM at /cloudless/production/CLOUDFLARE_API_TOKEN
-#   - GitHub Actions secret CLOUDFLARE_API_TOKEN
+# Programmatically rotate the Cloudflare API token stored as the GitHub
+# Actions secret CLOUDFLARE_API_TOKEN (source of truth — Cloudflare-first).
+# Do NOT use AWS SSM / aws CLI for this token.
 #
 # Uses Cloudflare's `PUT /user/tokens/{token_id}/value` endpoint, which
 # regenerates the token *secret* while keeping the same id and scopes.
@@ -12,13 +12,18 @@ name: Rotate Cloudflare API token
 # Auth: the current token must have "API Tokens Write" perm group
 # (User-scope, perm id 4755a26eedb94da69e1066d98aa820be). If the
 # rotation call returns 9007, the current token lacks that scope —
-# you'll need to mint a new one with that perm group, then run this
-# workflow with apply=true to swap it in.
+# you'll need to mint a new one with that perm group, then run
+# store-cloudflare-token.yml with apply=true to swap it in.
+#
+# REQUIRED SECRETS:
+#   CLOUDFLARE_API_TOKEN — current token (read for verify + rotate)
+#   GH_PAT — personal access token with `repo` scope (secrets:write).
+#   GITHUB_TOKEN cannot write Actions secrets ("403 Resource not accessible
+#   by integration"). Without GH_PAT the rotated value cannot be stored.
 #
 # After the workflow runs:
-#   - SSM updated ✅ (automatic)
-#   - GH Actions secret updated ✅ (automatic via gh CLI)
-#   - Cowork session secret update — STILL MANUAL (see skill)
+#   - GH Actions secret CLOUDFLARE_API_TOKEN updated ✅ (via gh secret set)
+#   - Cowork session secret update — STILL MANUAL (see cloudflare-token-rotation skill)
 
 on:
   workflow_dispatch:
@@ -29,7 +34,6 @@ on:
         default: false
 
 permissions:
-  id-token: write
   contents: read
 
 concurrency:
@@ -41,22 +45,14 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
-        with:
-          role-to-assume: ${{ secrets.AWS_DEPLOY_ROLE_ARN }}
-          aws-region: us-east-1
-
-      - name: Fetch current token from SSM
+      - name: Load current token from GitHub Secret
         id: current
+        env:
+          TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
         run: |
           set -e
-          TOKEN=$(aws ssm get-parameter \
-            --name /cloudless/production/CLOUDFLARE_API_TOKEN \
-            --with-decryption --region us-east-1 \
-            --query 'Parameter.Value' --output text)
-          if [ -z "$TOKEN" ] || [ "$TOKEN" = "None" ]; then
-            echo "::error::No current token in SSM"
+          if [ -z "$TOKEN" ]; then
+            echo "::error::No CLOUDFLARE_API_TOKEN GitHub secret. Run store-cloudflare-token.yml first."
             exit 1
           fi
           echo "::add-mask::$TOKEN"
@@ -94,10 +90,9 @@ jobs:
             echo ""
             echo "Rotation will:"
             echo "1. Call \`PUT /user/tokens/$TOKEN_ID/value\` — Cloudflare returns a new secret value"
-            echo "2. Update SSM at \`/cloudless/production/CLOUDFLARE_API_TOKEN\`"
-            echo "3. Update GitHub Actions secret \`CLOUDFLARE_API_TOKEN\`"
-            echo "4. Verify new token works with /user/tokens/verify"
-            echo "5. Old token is invalidated **immediately** on the rotate call"
+            echo "2. Update GitHub Actions secret \`CLOUDFLARE_API_TOKEN\` via \`gh secret set\` (requires \`GH_PAT\`)"
+            echo "3. Verify new token works with /user/tokens/verify"
+            echo "4. Old token is invalidated **immediately** on the rotate call"
             echo ""
             echo "Still manual: Cowork session secret (use \`cloudflare-token-rotation\` skill)"
           } >> "$GITHUB_STEP_SUMMARY"
@@ -144,50 +139,25 @@ jobs:
           fi
           echo "✅ New token verified active"
 
-      - name: Update SSM
-        if: ${{ inputs.apply == true }}
-        env:
-          NEW_TOKEN: ${{ steps.rotate.outputs.new_token }}
-        run: |
-          set -e
-          aws ssm put-parameter \
-            --name /cloudless/production/CLOUDFLARE_API_TOKEN \
-            --value "$NEW_TOKEN" \
-            --type SecureString \
-            --overwrite \
-            --region us-east-1 \
-            --description "Rotated by cloudflare-token-rotate.yml run ${{ github.run_id }}"
-          echo "✅ SSM updated"
-
       - name: Update GH Actions secret
         if: ${{ inputs.apply == true }}
         env:
-          # GITHUB_TOKEN is read-only on the secrets API ("403 Resource not
-          # accessible by integration"). Use the GH_PAT secret which has
-          # `repo` scope. If GH_PAT isn't set, this step warns but doesn't
-          # fail — SSM is the source of truth and can be synced manually
-          # via:  echo -n "$(aws ssm get-parameter --name /cloudless/production/CLOUDFLARE_API_TOKEN \
-          #         --with-decryption --region us-east-1 --query Parameter.Value --output text)" \
-          #         | gh secret set CLOUDFLARE_API_TOKEN --repo Themis128/cloudless.gr --body -
-          GH_TOKEN: ${{ secrets.GH_PAT || secrets.GITHUB_TOKEN }}
+          # GITHUB_TOKEN cannot write secrets — need GH_PAT with repo scope.
+          GH_TOKEN: ${{ secrets.GH_PAT }}
           NEW_TOKEN: ${{ steps.rotate.outputs.new_token }}
           GH_PAT_SET: ${{ secrets.GH_PAT != '' }}
-        continue-on-error: true
         run: |
-          # All consumer workflows now read CF token from SSM directly.
-          # GH secret is optional/legacy; failure here is not a real outage.
-          set +e
+          set -e
           if [ "$GH_PAT_SET" != "true" ]; then
-            echo "::notice::GH_PAT not set - skipping GH secret update. SSM is source of truth."
-            exit 0
+            echo "::error::GH_PAT secret is not set. Add a repo-scoped PAT as GH_PAT so this workflow can write CLOUDFLARE_API_TOKEN. The rotated Cloudflare secret is already live — recover via store-cloudflare-token.yml with a freshly minted token if needed."
+            exit 1
           fi
-          if echo -n "$NEW_TOKEN" | gh secret set CLOUDFLARE_API_TOKEN \
-            --repo ${{ github.repository }} --body - 2>&1; then
-            echo "GitHub Actions secret updated"
-          else
-            echo "::warning::Failed to update GH Actions secret. Not blocking."
-            exit 0
+          if ! echo -n "$NEW_TOKEN" | gh secret set CLOUDFLARE_API_TOKEN \
+            --repo "${{ github.repository }}" --body -; then
+            echo "::error::Failed to update GitHub Actions secret CLOUDFLARE_API_TOKEN"
+            exit 1
           fi
+          echo "✅ GitHub Actions secret CLOUDFLARE_API_TOKEN updated"
 
       - name: Apply summary
         if: ${{ inputs.apply == true }}
@@ -199,12 +169,11 @@ jobs:
             echo ""
             echo "- Token id (unchanged): \`$TOKEN_ID\`"
             echo "- New secret value rotated and verified active"
-            echo "- SSM updated: \`/cloudless/production/CLOUDFLARE_API_TOKEN\` ✅"
             echo "- GitHub Actions secret \`CLOUDFLARE_API_TOKEN\` ✅"
             echo "- Old secret value: **invalidated immediately by Cloudflare**"
             echo ""
             echo "### Still manual"
-            echo "- **Cowork session secret** — copy the SSM value into your Cowork session-environment secret store. See the \`cloudflare-token-rotation\` skill for the exact UI steps."
+            echo "- **Cowork session secret** — paste the new token into your Cowork session-environment secret store (re-mint + \`store-cloudflare-token.yml\` if you no longer have the value). See the \`cloudflare-token-rotation\` skill."
           } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Failure notification

--- a/.github/workflows/store-cloudflare-token.yml
+++ b/.github/workflows/store-cloudflare-token.yml
@@ -1,24 +1,19 @@
-name: Store Cloudflare API token → SSM → apply HA load balancer
+name: Store Cloudflare API token → GitHub Secret → apply HA load balancer
 
-# Accepts the Cloudflare API token as a workflow_dispatch input, masks it from
-# logs immediately, stores it to SSM /cloudless/production/CLOUDFLARE_API_TOKEN,
-# then optionally runs the HA load-balancer apply in the same job.
+# Accepts the Cloudflare API token as a workflow_dispatch input, masks it,
+# stores it as the GitHub Actions secret CLOUDFLARE_API_TOKEN (no AWS SSM),
+# then optionally runs the HA load-balancer apply in the same job
+# (token passed to setup-cloudflare-lb.sh as env from the dispatch input).
 #
-# Use this from a Claude Code cloud session (mcp__github__actions_run_trigger)
-# or from the GitHub Actions UI. Once the token is in SSM the LB workflows
-# pick it up automatically without needing a GitHub Secret.
+# REQUIRED SECRETS:
+#   GH_PAT — PAT with `repo` scope. GITHUB_TOKEN cannot write Actions secrets.
 #
 # HOW TO USE:
 #   1. Cloudflare dashboard → My Profile → API Tokens → Create Token
-#      "Create custom token" with:
-#        Zone → Zone → Read           (cloudless.gr)
-#        Zone → Load Balancing: Monitors and Pools → Edit
-#        Zone → Load Balancing: Load Balancers → Edit
-#        Zone → DNS → Edit
-#      Zone Resources: Include → Specific zone → cloudless.gr
-#   2. Run this workflow (dispatch) with the token value.
+#      (Zone:Read, LB:Edit, DNS:Edit for cloudless.gr — see cloudflare-token-doctor skill)
+#   2. Run this workflow with the token value.
 #      apply=true (default) immediately wires the LB.
-#      apply=false stores only — run cloudflare-lb.yml to verify first.
+#      apply=false stores only.
 
 on:
   workflow_dispatch:
@@ -33,7 +28,6 @@ on:
         default: true
 
 permissions:
-  id-token: write   # OIDC → AWS_DEPLOY_ROLE_ARN for ssm:PutParameter
   contents: read
   issues: write
 
@@ -48,21 +42,18 @@ jobs:
   store-and-apply:
     runs-on: ubuntu-latest
     env:
-      GH_TOKEN: ${{ github.token }}
+      # Issue comments use the default token; secret writes use GH_PAT below.
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v4.3.1
 
-      - name: Configure AWS credentials (OIDC)
-        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4
-        with:
-          role-to-assume: ${{ secrets.AWS_DEPLOY_ROLE_ARN }}
-          aws-region: us-east-1
-
-      - name: Store Cloudflare token to SSM
+      - name: Store Cloudflare token as GitHub Actions secret
         id: store
         env:
           CF_TOKEN: ${{ github.event.inputs.cloudflare_token }}
-          AWS_DEFAULT_REGION: us-east-1
+          # GITHUB_TOKEN cannot write secrets — need GH_PAT with repo scope.
+          GH_TOKEN: ${{ secrets.GH_PAT }}
+          GH_PAT_SET: ${{ secrets.GH_PAT != '' }}
         run: |
           set -uo pipefail
           echo "::add-mask::$CF_TOKEN"
@@ -70,14 +61,15 @@ jobs:
             echo "::error::cloudflare_token input is empty"
             exit 1
           fi
-          aws ssm put-parameter \
-            --name /cloudless/production/CLOUDFLARE_API_TOKEN \
-            --type SecureString \
-            --overwrite \
-            --value "$CF_TOKEN" \
-            --description "Cloudflare API token for HA LB — stored via store-cloudflare-token workflow" \
-            >/dev/null
-          echo "✓ Token stored to SSM /cloudless/production/CLOUDFLARE_API_TOKEN"
+          if [ "$GH_PAT_SET" != "true" ]; then
+            echo "::error::GH_PAT secret is not set. Add a repo-scoped PAT as GH_PAT so this workflow can write CLOUDFLARE_API_TOKEN."
+            exit 1
+          fi
+          if ! printf '%s' "$CF_TOKEN" | gh secret set CLOUDFLARE_API_TOKEN --repo "${{ github.repository }}" --body -; then
+            echo "::error::Failed to store GitHub Actions secret CLOUDFLARE_API_TOKEN"
+            exit 1
+          fi
+          echo "✓ Token stored as GitHub secret CLOUDFLARE_API_TOKEN"
           echo "stored=true" >> "$GITHUB_OUTPUT"
 
       - name: Apply Cloudflare HA load balancer
@@ -87,7 +79,6 @@ jobs:
           CLOUDFLARE_API_TOKEN: ${{ github.event.inputs.cloudflare_token }}
           MODE: apply
           CONFIRM: "1"
-          AWS_DEFAULT_REGION: us-east-1
         run: |
           echo "::add-mask::$CLOUDFLARE_API_TOKEN"
           set -o pipefail
@@ -100,7 +91,6 @@ jobs:
           CLOUDFLARE_API_TOKEN: ${{ github.event.inputs.cloudflare_token }}
           MODE: report
           CONFIRM: "0"
-          AWS_DEFAULT_REGION: us-east-1
         run: |
           echo "::add-mask::$CLOUDFLARE_API_TOKEN"
           set -o pipefail
@@ -113,13 +103,11 @@ jobs:
           {
             echo "# Cloudflare HA load balancer — $(date -u '+%F %T')Z"
             echo ""
-            echo "**Mode:** $( [ "$APPLY" = "true" ] && echo 'apply (token stored + LB wired)' || echo 'store-only (token stored, report run)' )"
+            echo "**Mode:** $( [ "$APPLY" = "true" ] && echo 'apply (token stored + LB wired)' || echo 'store-only (token in GH secret, report run)' )"
             echo "**Job:** ${{ job.status }}"
             echo ""
             echo '```'
-            cat cloudflare-lb.log 2>/dev/null || echo '(no log — token stored to SSM)'
+            cat cloudflare-lb.log 2>/dev/null || echo '(no log — token stored as GitHub secret)'
             echo '```'
-            echo ""
-            echo "**Next:** $( [ "$APPLY" = "true" ] && echo 'Check above for LB/DNS status. Re-run with apply=true if any pool is pending.' || echo 'Run `cloudflare-lb.yml` → dispatch with apply=true to wire the LB.' )"
           } > c.md
           gh issue comment 382 --repo "${{ github.repository }}" --body-file c.md

--- a/skills/cloudflare-token-doctor/SKILL.md
+++ b/skills/cloudflare-token-doctor/SKILL.md
@@ -6,8 +6,8 @@ description: |
   `mcp__cloudless-infra__cloudflare_*` tool, when Dependabot or a deploy
   workflow mentions Cloudflare 401/403, when the Cloudflare email warning
   about Workers limits arrives and we can't read analytics to confirm, or
-  when a freshly created token needs to be wired into SSM + the infra MCP
-  in one shot.
+  when a freshly created token needs to be wired into the GitHub Secret +
+  the infra MCP in one shot.
 ---
 
 # Cloudflare Token Doctor
@@ -25,7 +25,7 @@ leaving the chat session. Order is deliberate — each stage gates the next.
   need analytics to confirm impact
 - The pending-setup table in `CLAUDE.md` lists "TOKEN NEEDED"
 - A new token has been minted in the Cloudflare dashboard and needs to
-  be propagated to SSM + the infra MCP
+  be propagated to the GitHub Secret `CLOUDFLARE_API_TOKEN` + the infra MCP
 
 ## Stage 0 — Diagnose
 
@@ -47,8 +47,8 @@ Outcomes:
 | `false / null / [{"code":10000,...}]` | Network/parse error | Stage 1 |
 
 The same check from inside CI is available via `verify-cloudflare-token.yml`
-(dispatch only). Use that when the token is already in SSM and you want a
-clean log entry rather than a one-liner.
+(dispatch only). Use that when the token is already in the GitHub Secret and
+you want a clean log entry rather than a one-liner.
 
 ## Stage 1 — Mint a new token
 
@@ -56,9 +56,9 @@ clean log entry rather than a one-liner.
 
 ### Path A — Bootstrap from an existing high-privilege token
 
-If the **invalid** token is the only one in SSM but you (the human) still
-have a working Cloudflare login, run the dashboard flow once and store the
-output. This is the path you'll take if every prior token is gone.
+If the **invalid** token is the only one in the GitHub Secret but you (the
+human) still have a working Cloudflare login, run the dashboard flow once
+and store the output. This is the path you'll take if every prior token is gone.
 
 1. https://dash.cloudflare.com/profile/api-tokens → **Create Token →
    Create Custom Token**
@@ -88,8 +88,9 @@ output. This is the path you'll take if every prior token is gone.
 
 ### Path B — Mint a scoped token from an existing high-privilege token
 
-If a working token with `User API Tokens:Edit` is already in SSM, the
-infra MCP can mint narrower derivative tokens itself:
+If a working token with `User API Tokens:Edit` is already available (GitHub
+Secret / session secret), the infra MCP can mint narrower derivative tokens
+itself:
 
 ```text
 mcp__cloudless-infra__cloudflare_list_permission_groups(filter: "analytics")
@@ -104,15 +105,17 @@ mcp__cloudless-infra__cloudflare_create_token(
 ```
 
 Use Path B for read-only consumers (Grafana, dashboards) so the wide
-`User API Tokens:Edit` token never leaves SSM.
+`User API Tokens:Edit` token never leaves the primary store.
 
 ## Stage 2 — Store the token
 
 Two stores keep them in sync:
 
-### 2a — SSM (consumed by the infra MCP, deploy workflows, the Next.js
+### 2a — GitHub Actions secret (source of truth for CI / LB workflows)
 
-runtime, and the Pi cluster)
+Requires repo secret `GH_PAT` (PAT with `repo` scope) so
+`store-cloudflare-token.yml` can run `gh secret set`. Do **not** use
+`aws ssm put-parameter`.
 
 ```bash
 gh workflow run store-cloudflare-token.yml \
@@ -124,6 +127,13 @@ gh workflow run store-cloudflare-token.yml \
 scopes are right and you actually want to re-wire the HA load balancer
 in the same run.
 
+Alternatively (local, with `gh` authenticated to an account that can
+write secrets):
+
+```bash
+echo -n "<token>" | gh secret set CLOUDFLARE_API_TOKEN --repo Themis128/cloudless.gr --body -
+```
+
 ### 2b — Cloud session secret (consumed by `cloudless-infra` MCP server)
 
 The session-start hook reads `CLOUDFLARE_API_TOKEN` from the chat session's
@@ -131,8 +141,9 @@ secret store and forwards it to the MCP server. Set it in:
 
 **Claude Code web UI → Session → Environment → Secrets**
 
-Use the **same** value as SSM. If they drift, the MCP will keep returning
-"Invalid access token" until you also rotate the session secret.
+Use the **same** value as the GitHub Secret. If they drift, the MCP will
+keep returning "Invalid access token" until you also rotate the session
+secret.
 
 ## Stage 3 — Smoke-test
 
@@ -173,8 +184,8 @@ mcp__cloudless-infra__cloudflare_list_tokens()
 
 ## Stage 4 — Verify the infra MCP works
 
-The MCP server reads from the cloud-session secret store, **not** SSM.
-After Stage 2b, every MCP call must succeed:
+The MCP server reads from the cloud-session secret store, **not** the
+GitHub Secret. After Stage 2b, every MCP call must succeed:
 
 ```text
 mcp__cloudless-infra__cloudflare_list_tokens()
@@ -242,7 +253,8 @@ know which token to expect.
   documentation.
 
 - **HA LB workflows still fail after a fresh token**
-  → They read from SSM, not the cloud-session secret. Did Stage 2a run?
+  → They read `CLOUDFLARE_API_TOKEN` (GitHub Secret / workflow input), not
+  the cloud-session secret. Did Stage 2a run?
   Re-run `store-cloudflare-token.yml -f apply=true`.
 
 - **"AUTH_INVALID_TOKEN_HEADER" from the GraphQL endpoint**

--- a/skills/cloudflare-tunnel-ops/SKILL.md
+++ b/skills/cloudflare-tunnel-ops/SKILL.md
@@ -320,7 +320,7 @@ Known state at time of writing (2026-06-21):
 The active token lives at:
 
 - k8s: `kubectl -n cloudless get secret cloudless-cloudflare -o yaml`
-- SSM: `/cloudless/production/CLOUDFLARE_API_TOKEN` (per CLAUDE.md)
+- GitHub Actions secret: `CLOUDFLARE_API_TOKEN` (CI source of truth)
 
 To rotate:
 
@@ -328,9 +328,10 @@ To rotate:
    scope set from `skills/cloudflare-token-doctor/SKILL.md` Stage 1.
 2. `kubectl -n cloudless edit secret cloudless-cloudflare` and replace the
    base64-encoded `CLOUDFLARE_API_TOKEN` value.
-3. Mirror to SSM:
-   `aws ssm put-parameter --name /cloudless/production/CLOUDFLARE_API_TOKEN
-   --value <token> --type SecureString --overwrite`.
+3. Mirror to CI via GitHub Secret (do **not** use `aws ssm put-parameter`):
+   `gh workflow run store-cloudflare-token.yml -f cloudflare_token=<token> -f apply=false`
+   (requires repo secret `GH_PAT`), or locally:
+   `echo -n '<token>' | gh secret set CLOUDFLARE_API_TOKEN --repo Themis128/cloudless.gr --body -`
 4. Delete the old token in the Cloudflare dashboard.
 5. Verify via the cf-dns-add pod template above (token verify step at the
    top — `https://api.cloudflare.com/client/v4/user/tokens/verify`).

--- a/skills/cowork-session-secrets/SKILL.md
+++ b/skills/cowork-session-secrets/SKILL.md
@@ -125,10 +125,12 @@ all start with `cfut_` — if it starts with a quote, retype.
 The MCP being green is a convenience, not a requirement. Every secret
 in the Cloud Session Secrets table is also available in one of:
 
-- **AWS SSM** at `/cloudless/production/<KEY>` (for Cloudflare, Anthropic,
-  Notion, EspoCRM, Stripe, etc.) — readable via the bash tool with
-  `aws ssm get-parameter --with-decryption ...`
-- **GitHub Secrets** (for `AWS_DEPLOY_ROLE_ARN`, OIDC roles)
+- **GitHub Secrets** — `CLOUDFLARE_API_TOKEN` is the CI source of truth
+  (store via `store-cloudflare-token.yml`; requires `GH_PAT`). Also used
+  for `AWS_DEPLOY_ROLE_ARN`, OIDC roles, etc.
+- **AWS SSM** at `/cloudless/production/<KEY>` (legacy path for some
+  Anthropic / Notion / EspoCRM / Stripe keys — do **not** use SSM for
+  `CLOUDFLARE_API_TOKEN`)
 - **Direct env in the bash sandbox** (for `GITHUB_PAT` — the agent
   already has it embedded in remote URLs)
 
@@ -136,7 +138,7 @@ So if Stage 2 is blocked because the user can't find Cowork's settings
 UI, switch to:
 
 ```bash
-# Example: every Cloudflare workflow uses the SSM token, not the MCP.
+# Example: Cloudflare workflows use the GitHub Secret, not the MCP.
 gh workflow run verify-cloudflare-token.yml
 gh workflow run store-cloudflare-token.yml -f cloudflare_token=... -f apply=true
 # Example: direct curl with the value from Stage 1 — no MCP needed.
@@ -177,11 +179,11 @@ expected current value (or at least its mint date).
   for Managed Agents, not the Cowork desktop app. Different product.
   See Stage 2 — the Cowork settings are in the desktop app itself.
 
-- **"The verify workflow still fails after I updated the SSM token"** →
+- **"The verify workflow still fails after I updated the GitHub Secret"** →
   Different store. The MCP reads from the cloud-session secret store,
-  workflows read from SSM. Both need the same value. Run
-  `store-cloudflare-token.yml -f apply=false` to sync SSM independently
-  of the MCP store.
+  workflows read `CLOUDFLARE_API_TOKEN` from GitHub Secrets. Both need the
+  same value. Run `store-cloudflare-token.yml -f apply=false` to sync the
+  GitHub Secret independently of the MCP store (requires `GH_PAT`).
 
 ## Related skills
 


### PR DESCRIPTION
## Summary
- **Store:** Masks input → `gh secret set CLOUDFLARE_API_TOKEN` → optional LB apply from workflow input (no SSM). Dropped `id-token: write` / `configure-aws-credentials`.
- **Rotate:** Reads `secrets.CLOUDFLARE_API_TOKEN` → CF `PUT …/value` → verify → `gh secret set`. No AWS steps; GH secret update is required (not best-effort).
- **Left alone (other PRs):** `verify-cloudflare-token.yml`, `setup-cloudflare-lb.sh` SSM fallback, deploy/ETL workflows.
- Skills/docs (`cloudflare-token-rotation`, `cloudflare-token-doctor`, `cloudflare-lb`, `cowork-session-secrets`, tunnel-ops) updated to match.

## Operator notes
- **`GH_PAT` required** — repo PAT with `repo` scope. `GITHUB_TOKEN` cannot write secrets; without `GH_PAT`, store/rotate fail.
- **Source of truth** = GitHub secret `CLOUDFLARE_API_TOKEN`. Do not use `aws ssm` for this token.
- Cowork session secret still manual after rotate (value isn’t readable back from GH).
- Store + apply still works: token from dispatch input is passed to `setup-cloudflare-lb.sh` as env.

## Test plan
- [ ] Confirm repo secret `GH_PAT` exists (`repo` scope)
- [ ] Dry-run: `gh workflow run cloudflare-token-rotate.yml -f apply=false` — verify succeeds, no secret write
- [ ] Store-only: `gh workflow run store-cloudflare-token.yml -f cloudflare_token=… -f apply=false` — GH secret updated; no AWS/OIDC steps in log
- [ ] Optional: store with `apply=true` and confirm LB script receives token via env
- [ ] Confirm `verify-cloudflare-token.yml` / deploy workflows unchanged by this PR


Made with [Cursor](https://cursor.com)