### PR TITLE
fix: CF Email Sending token preference + Meili reindex delete guard

### DIFF
--- a/docs/aws-to-cloudflare-migration.md
+++ b/docs/aws-to-cloudflare-migration.md
@@ -13,9 +13,9 @@
 
 **Operator follow-ups before / after merge to main:**
 
-1. Email (Node/Pi) — **cleared via Cloudflare Email Service REST** (`email-cloudflare.ts`); uses existing `CLOUDFLARE_*` secrets. `RESEND_API_KEY` optional fallback only.
-2. `CLOUDFLARE_ACCOUNT_ID` + `CLOUDFLARE_API_TOKEN` — **SET** in `cloudless-secrets`; Workers AI + Email Sending OK on Pi.
-3. Meili reindex — **done** (`workers-ai-bge-small` @ 384-dim; in-cluster `MEILI_HOST`).
+1. Email (Node/Pi) — **Cloudflare Email Sending LIVE** from the app pod (`CLOUDFLARE_EMAIL_API_TOKEN` + `CLOUDFLARE_API_TOKEN` in `cloudless-secrets`). `RESEND_API_KEY` still optional and **not set** (no key in repo/env — paste when you want the Resend fallback).
+2. `CLOUDFLARE_ACCOUNT_ID` + `CLOUDFLARE_API_TOKEN` — **SET**; Workers AI embed smoke (`bge-small` → **384**) OK from app pod.
+3. Meili reindex — **done** (4 docs / 4 embeddings; `workers-ai-bge-small` @ 384; in-cluster `MEILI_HOST`). `CRON_SECRET` rotated after earlier job-log leak.
 4. **Next:** PR-13 (R2 without `@aws-sdk/client-s3`), then PR-14 uninstall. Do not run PR-14 until PR-13 call sites are gone.
 5. Wave B (PR-04…06) still gated on Cognito/Dynamo data migration.
 

--- a/src/lib/email-cloudflare.ts
+++ b/src/lib/email-cloudflare.ts
@@ -1,6 +1,7 @@
 /**
  * Cloudflare Email Service (REST) — Node/Pi path.
- * Uses CLOUDFLARE_ACCOUNT_ID + CLOUDFLARE_API_TOKEN (same as Workers AI).
+ * Prefers CLOUDFLARE_EMAIL_API_TOKEN (Email Sending Write); falls back to
+ * CLOUDFLARE_API_TOKEN. Account: CLOUDFLARE_ACCOUNT_ID.
  * https://developers.cloudflare.com/email-service/api/send-emails/rest-api/
  */
 
@@ -14,15 +15,21 @@ export interface CloudflareEmailOptions {
   listUnsubscribeUrl?: string;
 }
 
+function cloudflareEmailApiToken(): string | undefined {
+  return process.env.CLOUDFLARE_EMAIL_API_TOKEN || process.env.CLOUDFLARE_API_TOKEN;
+}
+
 export function isCloudflareEmailConfigured(): boolean {
-  return Boolean(process.env.CLOUDFLARE_ACCOUNT_ID && process.env.CLOUDFLARE_API_TOKEN);
+  return Boolean(process.env.CLOUDFLARE_ACCOUNT_ID && cloudflareEmailApiToken());
 }
 
 export async function sendEmailCloudflare(options: CloudflareEmailOptions): Promise<void> {
   const accountId = process.env.CLOUDFLARE_ACCOUNT_ID;
-  const apiToken = process.env.CLOUDFLARE_API_TOKEN;
+  const apiToken = cloudflareEmailApiToken();
   if (!accountId || !apiToken) {
-    throw new Error("CLOUDFLARE_ACCOUNT_ID / CLOUDFLARE_API_TOKEN not configured");
+    throw new Error(
+      "CLOUDFLARE_ACCOUNT_ID / CLOUDFLARE_EMAIL_API_TOKEN (or CLOUDFLARE_API_TOKEN) not configured"
+    );
   }
 
   const fromAddress = options.fromLabel

--- a/src/lib/product-search.ts
+++ b/src/lib/product-search.ts
@@ -117,7 +117,12 @@ async function deleteProductsIndexIfExists(): Promise<void> {
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
 
-    if (!message.includes("404") && !message.includes("index_not_found")) {
+    // Meili may say "Index `products` not found" without code index_not_found.
+    if (
+      !message.includes("404") &&
+      !message.includes("index_not_found") &&
+      !message.toLowerCase().includes("not found")
+    ) {
       throw err;
     }
   }


### PR DESCRIPTION
## Summary
- Prefer `CLOUDFLARE_EMAIL_API_TOKEN` (Email Sending Write) for Cloudflare Email Sending, with fallback to `CLOUDFLARE_API_TOKEN`.
- Treat Meili plain `"not found"` as a missing index during product reindex delete.
- Update Wave A operator checklist (CF email + Meili 384 live; Resend still optional).

## Test plan
- [ ] Confirm `CLOUDFLARE_EMAIL_API_TOKEN` (or `CLOUDFLARE_API_TOKEN`) is present in `cloudless-secrets`
- [ ] Smoke send via app pod / contact flow uses CF Email Sending successfully
- [ ] `POST /api/admin/search/reindex` does not fail when products index is absent


Made with [Cursor](https://cursor.com)