### PR TITLE
fix(ci): serialize deploy-pi + reserve omv,build

### DIFF
--- a/.github/workflows/cluster-status-audit.yml
+++ b/.github/workflows/cluster-status-audit.yml
@@ -13,7 +13,8 @@ env:
 #   - GH Actions runner inventory (self-hosted Pi fleet)
 #   - Tailscale connectivity matrix
 #
-# Runs from a self-hosted Pi build runner (has SSH + kubectl context).
+# Runs from a self-hosted Pi runner (has SSH + kubectl context).
+# Uses [omv, pi] — not exclusive `build` (reserved for deploy-pi / build-pi-image).
 
 on:
   schedule:
@@ -37,7 +38,7 @@ jobs:
   audit:
     name: Cluster Status
     # Self-hosted Pi runner — has kubeconfig + tailscale + SSH keys.
-    runs-on: [self-hosted, omv, build]
+    runs-on: [self-hosted, omv, pi]
     timeout-minutes: 10
 
     steps:

--- a/.github/workflows/deploy-alert-api.yml
+++ b/.github/workflows/deploy-alert-api.yml
@@ -38,7 +38,8 @@ concurrency:
 
 jobs:
   build-and-rollout:
-    runs-on: [self-hosted, omv, pi, build]
+    # omv + pi only — do not take the exclusive `build` label (deploy-pi).
+    runs-on: [self-hosted, omv, pi]
     timeout-minutes: 15
     env:
       TAG: ${{ inputs.version_tag || 'v3.4' }}

--- a/.github/workflows/deploy-pi.yml
+++ b/.github/workflows/deploy-pi.yml
@@ -3,6 +3,13 @@ name: Deploy to Pi (hostPath standalone — no ECR)
 # Cloudflare-first: build Next standalone on the Pi runner and sync into
 # /home/tbaltzakis/cloudless-standalone (k8s/cloudless-app-hostpath.yaml).
 # Does not use AWS ECR, OIDC, or SSM.
+#
+# Runner: exclusive [self-hosted, omv, build]. Do not put audits/CWV/ETL on
+# the `build` label — they starve this workflow (see docs/runners.md).
+#
+# Concurrency: serialize (cancel-in-progress: false + queue: max). Rapid main
+# merges used to abort mid-build ("Canceling since a higher priority waiting
+# request for deploy-pi exists") and leave hostPath on a stale SHA.
 
 on:
   push:
@@ -20,7 +27,8 @@ on:
 
 concurrency:
   group: deploy-pi
-  cancel-in-progress: true
+  cancel-in-progress: false
+  queue: max
 
 permissions:
   contents: read
@@ -41,21 +49,52 @@ jobs:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v4.3.1
 
+      - name: Skip if SHA already live
+        id: skip
+        run: |
+          set -euo pipefail
+          WANT="${{ github.sha }}"
+          LIVE=""
+          for candidate in http://127.0.0.1:30300/api/health http://192.168.1.128:30300/api/health; do
+            BODY=$(curl -sS --max-time 5 "$candidate" || true)
+            if echo "$BODY" | jq -e .version >/dev/null 2>&1; then
+              LIVE=$(echo "$BODY" | jq -r .version)
+              echo "health $candidate → version=${LIVE}"
+              break
+            fi
+            echo "health $candidate → unreachable or invalid"
+          done
+          if [ -n "$LIVE" ] && [ "$LIVE" = "$WANT" ]; then
+            echo "already=true" >> "$GITHUB_OUTPUT"
+            {
+              echo "## Deploy skipped"
+              echo "Live hostPath already serves \`${WANT}\`."
+            } >> "$GITHUB_STEP_SUMMARY"
+            echo "Already deployed ${WANT} — skipping build/rollout"
+          else
+            echo "already=false" >> "$GITHUB_OUTPUT"
+            echo "Need deploy: live=${LIVE:-unknown} want=${WANT}"
+          fi
+
       - name: Setup Node
+        if: steps.skip.outputs.already != 'true'
         uses: actions/setup-node@v4
         with:
           node-version: "22"
 
       - name: Enable corepack / pnpm
+        if: steps.skip.outputs.already != 'true'
         run: |
           corepack enable
           corepack prepare pnpm@latest --activate
           pnpm --version
 
       - name: Install dependencies
+        if: steps.skip.outputs.already != 'true'
         run: pnpm install --frozen-lockfile
 
       - name: Build Next.js standalone
+        if: steps.skip.outputs.already != 'true'
         env:
           NEXT_OUTPUT_STANDALONE: "1"
           NEXT_PUBLIC_SITE_URL: ${{ secrets.NEXT_PUBLIC_SITE_URL }}
@@ -72,6 +111,7 @@ jobs:
         run: pnpm build
 
       - name: Sync standalone → hostPath
+        if: steps.skip.outputs.already != 'true'
         run: |
           set -euo pipefail
           DEST="${{ env.STANDALONE_HOSTPATH }}"
@@ -96,6 +136,7 @@ jobs:
           echo "Synced standalone → ${DEST}"
 
       - name: Resolve kubectl
+        if: steps.skip.outputs.already != 'true'
         id: kubectl
         run: |
           set -euo pipefail
@@ -109,6 +150,7 @@ jobs:
           fi
 
       - name: Roll out cloudless-app
+        if: steps.skip.outputs.already != 'true'
         env:
           KUBECTL: ${{ steps.kubectl.outputs.bin }}
         run: |

--- a/docs/runners.md
+++ b/docs/runners.md
@@ -158,10 +158,20 @@ Current active fleet (as of 2026-05-23):
 | omv-main | 192.168.1.128   | `omv-build`   | `self-hosted, Linux, ARM64, omv, build` | online  |
 | omv-ha   | 192.168.1.130   | `omv-2-build` | `self-hosted, Linux, ARM64, omv, build` | online  |
 
-The `pi` label is reserved for cluster-bound jobs (the `build-and-push` job in
-`deploy-pi.yml`) and must never overlap with `build` — that gating is what
-keeps a future non-Pi host added to the `omv` group from accidentally taking
-a deploy job it can't run.
+The `pi` label is for cluster-local jobs (NodePort audits, kubectl, CWV).
+The `build` label is **exclusive** for heavy compile / hostPath sync:
+
+| Labels | Purpose | Workflows |
+| ------ | ------- | --------- |
+| `self-hosted, omv, build` | Next standalone build + hostPath sync; emergency ECR image build | `deploy-pi.yml`, `build-pi-image.yml` |
+| `self-hosted, omv, pi` | Cluster reachability, NodePort Lighthouse, alert-api import | `core-web-vitals-audit.yml`, `cluster-status-audit.yml`, `deploy-alert-api.yml` |
+
+Do **not** put CWV, cluster-status, or ETL on exclusive `build` — one busy
+Lighthouse run previously queued `deploy-pi` for tens of minutes.
+
+`deploy-pi` concurrency uses `cancel-in-progress: false` + `queue: max` so
+rapid main merges **serialize** instead of aborting mid-build. A skip step
+no-ops when `/api/health` already reports `version == github.sha`.
 
 ## Caveat: Pi runners share resources with production
 


### PR DESCRIPTION
## Summary
- Serialize `deploy-pi` (`cancel-in-progress: false` + `queue: max`) so rapid main merges no longer abort mid-build and leave hostPath stale.
- Skip build/rollout when `/api/health` already reports `version == github.sha`.
- Move `cluster-status-audit` and `deploy-alert-api` to `[self-hosted, omv, pi]`; document `build` vs `pi` in `docs/runners.md`.

## Test plan
- [ ] Two rapid `workflow_dispatch` on deploy-pi: first completes, second waits (no cancel annotation)
- [ ] Re-dispatch same SHA after success → skip step, no rebuild
- [ ] After merge, live `/api/health` version equals `origin/main`


Made with [Cursor](https://cursor.com)