### PR TITLE
docs(db): ADR-001 mediated database access

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -335,7 +335,7 @@
     },
     {
       "id": "cf-cloudless-auth",
-      "name": "cf · cloudless-auth (D1 snapshot)",
+      "name": "cf · cloudless-auth (D1 unused/empty)",
       "group": "cloudflare-d1",
       "driver": "SQLite",
       "database": "${workspaceFolder}/.local/db/cloudless-auth.sqlite",

--- a/docs/databases/ADR-001-mediated-db-access.md
+++ b/docs/databases/ADR-001-mediated-db-access.md
@@ -1,0 +1,63 @@
+# ADR-001 — Mediated database access (SQLTools, not public TCP)
+
+| Field | Value |
+|-------|--------|
+| Status | **Accepted** (2026-07-30) |
+| Context | PR [#1443](https://github.com/Themis128/cloudless.gr/pull/1443) |
+| Supersedes | Ad-hoc kubectl port-forwards / mistaken use of `ms-mssql` |
+
+## Context
+
+cloudless.gr’s durable state spans:
+
+- **Pi k3s** — MariaDB (EspoCRM), Postgres (AppFlowy, Postiz), embedded SQLite (n8n, Kuma), plus Redis / MinIO / Meilisearch
+- **Cloudflare** — D1 (`user-auth-db` + preview), R2 backups / datalake
+
+Developers need to inspect and query these stores from Cursor. Two wrong paths appeared in practice:
+
+1. Installing the Microsoft **SQL Server** extension (`ms-mssql`) — this stack has **no** TDS/SQL Server endpoints.
+2. Temptation to expose DB ports via Cloudflare Tunnel or NodePort for “convenience.”
+
+## Decision
+
+1. **IDE:** Use **SQLTools** (`mtxr.sqltools` + MySQL / PostgreSQL / SQLite drivers). Keep `mssql.connections` empty; list `ms-mssql.mssql` as an unwanted recommendation.
+2. **TCP engines:** Reach ClusterIP services only via `pnpm db:forward` (`kubectl port-forward` → fixed localhost ports). Never publish DB TCP through Cloudflare Tunnel.
+3. **File engines (pod SQLite, D1):** Pull **snapshots** into gitignored `.local/db/` (`pnpm db:sqlite:pull`, `pnpm db:d1:pull`). Treat files as stale-by-default copies.
+4. **Secrets:** Never commit passwords. SQLTools uses `askForPassword: true`; operators run `pnpm db:passwords` (k8s Secrets) or Wrangler for D1.
+5. **Docs:** Canonical home is `docs/databases/` — landscape (architect view), omv-cluster (inventory), this ADR (decision record).
+
+## Consequences
+
+**Positive**
+
+- Trust boundary stays clear: internet → Cloudflare → app HTTP; DB engines remain ClusterIP-only.
+- One documented developer contract; reproducible ports in `.vscode/settings.json`.
+- Separates edge auth (D1) from heavy SOR engines on the Pi without pretending they share a fabric.
+
+**Negative / accepted costs**
+
+- Port-forwards die when the laptop sleeps — operators re-run `pnpm db:ready`.
+- SQLite/D1 SQLTools views can be stale until re-pulled.
+- Password paste UX is manual (deliberate; avoids secrets in git).
+
+**Rejected alternatives**
+
+| Alternative | Why rejected |
+|-------------|--------------|
+| `ms-mssql` profiles for “all SQL” | Wrong protocol; empty Object Explorer is correct |
+| Cloudflare Tunnel → DB ports | Expands attack surface; violates P1 |
+| Shared HA Postgres on 2-node k3s | Raft needs odd quorum; worse than 1-node + R2 restore |
+| Passwords in `settings.json` | Secret leakage into git / backups |
+
+## Follow-ups (not blocking this ADR)
+
+- **R10b** — MinIO → R2 backup
+- **R10c** — Uptime Kuma SQLite → R2 backup
+- Retire or clearly label empty D1 `cloudless-auth`
+- Grafana durability (emptyDir vs PVC) if dashboards become load-bearing
+
+## Related
+
+- [landscape.md](landscape.md) — principles, tiers, trust diagrams
+- [omv-cluster.md](omv-cluster.md) — ports, secrets, PVCs
+- [README.md](README.md) — operator commands

--- a/docs/databases/README.md
+++ b/docs/databases/README.md
@@ -10,6 +10,7 @@ Passwords are **never** stored in these docs. Use `pnpm db:passwords` (k8s Secre
 |-----|----------------|
 | [landscape.md](landscape.md) | **Start here** — logical/physical diagrams, trust boundaries, backup RPO, per-product data planes |
 | [omv-cluster.md](omv-cluster.md) | Field inventory (engines, NS, PVCs, secrets, SQLTools ports, D1 IDs, backup schedule) |
+| [ADR-001-mediated-db-access.md](ADR-001-mediated-db-access.md) | **Accepted** — mediated SQLTools access; reject public DB TCP and ms-mssql |
 
 ## Landscape at a glance
 

--- a/docs/databases/landscape.md
+++ b/docs/databases/landscape.md
@@ -11,6 +11,8 @@ Inventory detail: [omv-cluster.md](omv-cluster.md). Folder index: [README.md](RE
 4. **R2 is the off-box backup plane** — daily logical dumps for the primary RDBMS + n8n.
 5. **Developer access is mediated** — `kubectl port-forward` or snapshot pull; never tunnel DB ports through Cloudflare.
 
+Decision record: [ADR-001 — Mediated database access](ADR-001-mediated-db-access.md).
+
 ---
 
 ## 1. Logical landscape
@@ -344,5 +346,6 @@ Do not expand AWS RDS / S3 backup paths for new work; R2 + existing CronJobs are
 
 - [omv-cluster.md](omv-cluster.md) — field-level inventory, ports, secrets
 - [README.md](README.md) — commands and SQLTools
+- [ADR-001](ADR-001-mediated-db-access.md) — mediated access decision
 - [../kubectl-tailscale.md](../kubectl-tailscale.md) — API access
 - [../../infrastructure/backup/README.md](../../infrastructure/backup/README.md) — CronJob details

--- a/docs/databases/omv-cluster.md
+++ b/docs/databases/omv-cluster.md
@@ -89,7 +89,7 @@ All four are listed in `.vscode/extensions.json` (workspace recommendations). Co
 | `omv · Grafana SQLite` | SQLite | `${workspaceFolder}/.local/db/grafana.db` | — |
 | `cf · user-auth-db (D1 snapshot)` | SQLite | `${workspaceFolder}/.local/db/user-auth-db.sqlite` | — |
 | `cf · auth-db-preview (D1 snapshot)` | SQLite | `${workspaceFolder}/.local/db/auth-db-preview.sqlite` | — |
-| `cf · cloudless-auth (D1 snapshot)` | SQLite | `${workspaceFolder}/.local/db/cloudless-auth.sqlite` | — |
+| `cf · cloudless-auth (D1 unused/empty)` | SQLite | `${workspaceFolder}/.local/db/cloudless-auth.sqlite` | — |
 
 #### Connect from Cursor
 
@@ -338,7 +338,7 @@ D1 has no localhost TCP port. Use snapshots for SQLTools:
 |---------|------|---------|----------------|
 | `user-auth-db` | `7ca74513-23c3-412a-b9ca-b0c55835973d` | `AUTH_DB` / `NEXT_CACHE_D1_BINDING` (prod) | `cf · user-auth-db (D1 snapshot)` |
 | `auth-db-preview` | `70d90155-12de-46d7-a0ea-113b3e7127cf` | preview env | `cf · auth-db-preview (D1 snapshot)` |
-| `cloudless-auth` | `0c00f32c-374b-447a-8f0a-af337004449d` | unused / empty | `cf · cloudless-auth (D1 snapshot)` |
+| `cloudless-auth` | `0c00f32c-374b-447a-8f0a-af337004449d` | unused / empty | `cf · cloudless-auth (D1 unused/empty)` |
 
 ```bash
 pnpm db:d1:pull                 # all three


### PR DESCRIPTION
## Summary
- Add [ADR-001](docs/databases/ADR-001-mediated-db-access.md) locking mediated SQLTools access (reject public DB TCP and `ms-mssql`)
- Link ADR from `docs/databases/README.md` + `landscape.md`
- Relabel empty D1 `cloudless-auth` SQLTools profile as unused

## Test plan
- [ ] Skim ADR-001 for completeness against live inventory in `omv-cluster.md`
- [ ] Confirm SQLTools still lists 10 connections after pull; `cloudless-auth` shows unused/empty


Made with [Cursor](https://cursor.com)