### PR TITLE
feat(auth): admin users + activate/confirm/delete D1-only (PR-04)

### DIFF
--- a/__tests__/admin-users-cognito-api.test.ts
+++ b/__tests__/admin-users-cognito-api.test.ts
@@ -1,218 +1,100 @@
 // @vitest-environment node
 /**
- * /api/admin/users — Cognito provider path.
- *
- * This sets COGNITO_ISSUER
- * so the route dispatches to the AWS-SDK Cognito branch, and asserts:
- *   - GET lists Cognito users mapped to the shared shape, admin role from the
- *     admin group, and provider:"cognito"; pool id + region derive from issuer
- *   - POST disable/enable/promote/demote issue the right Cognito admin commands
- *   - unknown action surfaces as an error (no mutation command sent)
- *   - 503 when no provider is configured
- *
- * requireAdmin is mocked (the Bearer/JWKS path is exercised in api-auth.test.ts),
- * and the Cognito SDK client is mocked so no AWS call is made.
+ * /api/admin/users — D1 provider path (PR-04).
  */
-
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { NextRequest } from "next/server";
 
 vi.mock("@/lib/api-auth", () => ({
-  requireAdmin: vi.fn(async () => ({ ok: true, user: { sub: "admin", groups: ["admin"], roles: ["admin"] } })),
-}));
-
-vi.mock("@/lib/ssm-config", () => ({
-  getConfig: vi.fn(async () => ({})),
-  resetSsmCache: vi.fn(),
-  getD1Client: vi.fn(() => ({
-    prepare: vi.fn().mockReturnThis(),
-    bind: vi.fn().mockReturnThis(),
-    first: vi.fn().mockResolvedValue({}),
-    run: vi.fn().mockResolvedValue({}),
+  requireAdmin: vi.fn(async () => ({
+    ok: true,
+    user: { sub: "admin", groups: ["admin"], roles: ["admin"] },
   })),
 }));
 
-const sendMock = vi.fn();
-vi.mock("@aws-sdk/client-cognito-identity-provider", () => {
-  class Cmd {
-    input: Record<string, unknown>;
-    _t = "Base";
-    constructor(input: Record<string, unknown>) {
-      this.input = input;
-    }
-  }
-  const mk = (t: string) =>
-    class extends Cmd {
-      _t = t;
-    };
-  return {
-    CognitoIdentityProviderClient: class {
-      send = sendMock;
-    },
-    ListUsersCommand: mk("ListUsers"),
-    AdminListGroupsForUserCommand: mk("AdminListGroupsForUser"),
-    AdminEnableUserCommand: mk("AdminEnableUser"),
-    AdminDisableUserCommand: mk("AdminDisableUser"),
-    AdminAddUserToGroupCommand: mk("AdminAddUserToGroup"),
-    AdminRemoveUserFromGroupCommand: mk("AdminRemoveUserFromGroup"),
-  };
-});
+const listUsers = vi.fn();
+const setUserAdminRole = vi.fn();
+const setUserDisabled = vi.fn();
+const getAuthDbFromEnv = vi.fn();
 
-const ISSUER = "https://cognito-idp.us-east-1.amazonaws.com/us-east-1_TESTPOOL";
+vi.mock("@/lib/auth-d1", () => ({
+  getAuthDbFromEnv: (...a: unknown[]) => getAuthDbFromEnv(...a),
+  listUsers: (...a: unknown[]) => listUsers(...a),
+  setUserAdminRole: (...a: unknown[]) => setUserAdminRole(...a),
+  setUserDisabled: (...a: unknown[]) => setUserDisabled(...a),
+}));
 
 function adminReq(url: string, init?: RequestInit): NextRequest {
   return new NextRequest(url, { method: init?.method, body: init?.body });
 }
 
-describe("/api/admin/users — Cognito path", () => {
+describe("/api/admin/users — D1 path", () => {
   beforeEach(() => {
     vi.resetModules();
-    sendMock.mockReset();
-    process.env.COGNITO_ISSUER = ISSUER;
+    listUsers.mockReset();
+    setUserAdminRole.mockReset();
+    setUserDisabled.mockReset();
+    getAuthDbFromEnv.mockReset();
+    getAuthDbFromEnv.mockReturnValue({ prepare: vi.fn() });
   });
 
   afterEach(() => {
-    delete process.env.COGNITO_ISSUER;
+    vi.clearAllMocks();
   });
 
-  it("GET lists Cognito users with admin role + provider, deriving the pool id", async () => {
-    sendMock.mockImplementation(async (cmd: { _t: string }) => {
-      if (cmd._t === "ListUsers") {
-        return {
-          Users: [
-            {
-              Username: "11111111-1111-1111-1111-111111111111",
-              Enabled: true,
-              UserStatus: "CONFIRMED",
-              UserCreateDate: new Date("2026-01-02T00:00:00Z"),
-              Attributes: [
-                { Name: "email", Value: "alice@cloudless.gr" },
-                { Name: "email_verified", Value: "true" },
-                { Name: "name", Value: "Alice A" },
-              ],
-            },
-          ],
-        };
-      }
-      if (cmd._t === "AdminListGroupsForUser") return { Groups: [{ GroupName: "admin" }] };
-      return {};
-    });
-
+  it("GET lists D1 users with provider d1", async () => {
+    listUsers.mockResolvedValue([
+      {
+        id: "u1",
+        email: "alice@cloudless.gr",
+        name: "Alice",
+        company: null,
+        phone: null,
+        created_at: 1_700_000_000,
+        role: "admin",
+        disabled: false,
+        emailVerified: true,
+      },
+    ]);
     const { GET } = await import("@/app/api/admin/users/route");
     const res = await GET(adminReq("http://localhost/api/admin/users?limit=60"));
     expect(res.status).toBe(200);
-    const data = await res.json();
-    expect(data.provider).toBe("cognito");
-    expect(data.count).toBe(1);
-    expect(data.users[0]).toMatchObject({
-      username: "11111111-1111-1111-1111-111111111111",
-      email: "alice@cloudless.gr",
-      name: "Alice A",
-      emailVerified: true,
-      status: "active",
-      userStatus: "CONFIRMED",
-      role: "admin",
-    });
-    const listCall = sendMock.mock.calls.find((c) => c[0]._t === "ListUsers");
-    expect(listCall?.[0].input.UserPoolId).toBe("us-east-1_TESTPOOL");
+    const body = await res.json();
+    expect(body.provider).toBe("d1");
+    expect(body.users[0].email).toBe("alice@cloudless.gr");
+    expect(body.users[0].role).toBe("admin");
   });
 
-  it("GET marks a user without the admin group as role=user, status=disabled", async () => {
-    sendMock.mockImplementation(async (cmd: { _t: string }) => {
-      if (cmd._t === "ListUsers") {
-        return {
-          Users: [
-            {
-              Username: "u-2",
-              Enabled: false,
-              UserStatus: "CONFIRMED",
-              Attributes: [{ Name: "email", Value: "bob@cloudless.gr" }],
-            },
-          ],
-        };
-      }
-      if (cmd._t === "AdminListGroupsForUser") return { Groups: [{ GroupName: "users" }] };
-      return {};
-    });
-
-    const { GET } = await import("@/app/api/admin/users/route");
-    const res = await GET(adminReq("http://localhost/api/admin/users"));
-    const data = await res.json();
-    expect(data.users[0]).toMatchObject({ role: "user", status: "disabled" });
-  });
-
-  it("POST promote adds the user to the admin group", async () => {
-    sendMock.mockResolvedValue({});
-    const { POST } = await import("@/app/api/admin/users/route");
-    const res = await POST(
-      adminReq("http://localhost/api/admin/users", {
-        method: "POST",
-        body: JSON.stringify({ action: "promote", username: "u-1" }),
-      })
-    );
-    expect(res.status).toBe(200);
-    expect((await res.json()).message).toBe("User promoted to admin");
-    const call = sendMock.mock.calls.find((c) => c[0]._t === "AdminAddUserToGroup");
-    expect(call?.[0].input).toMatchObject({ Username: "u-1", GroupName: "admin" });
-  });
-
-  it("POST disable issues AdminDisableUser", async () => {
-    sendMock.mockResolvedValue({});
-    const { POST } = await import("@/app/api/admin/users/route");
-    const res = await POST(
-      adminReq("http://localhost/api/admin/users", {
-        method: "POST",
-        body: JSON.stringify({ action: "disable", username: "u-1" }),
-      })
-    );
-    expect(res.status).toBe(200);
-    expect(sendMock.mock.calls.some((c) => c[0]._t === "AdminDisableUser")).toBe(true);
-  });
-
-  it("POST demote removes the user from the admin group", async () => {
-    sendMock.mockResolvedValue({});
-    const { POST } = await import("@/app/api/admin/users/route");
-    const res = await POST(
-      adminReq("http://localhost/api/admin/users", {
-        method: "POST",
-        body: JSON.stringify({ action: "demote", username: "u-1" }),
-      })
-    );
-    expect(res.status).toBe(200);
-    expect(sendMock.mock.calls.some((c) => c[0]._t === "AdminRemoveUserFromGroup")).toBe(true);
-  });
-
-  it("POST missing action/username returns 400", async () => {
-    sendMock.mockResolvedValue({});
-    const { POST } = await import("@/app/api/admin/users/route");
-    const res = await POST(
-      adminReq("http://localhost/api/admin/users", {
-        method: "POST",
-        body: JSON.stringify({ action: "disable" }),
-      })
-    );
-    expect(res.status).toBe(400);
-    expect(sendMock).not.toHaveBeenCalled();
-  });
-
-  it("POST unknown action returns 400 without mutating", async () => {
-    sendMock.mockResolvedValue({});
-    const { POST } = await import("@/app/api/admin/users/route");
-    const res = await POST(
-      adminReq("http://localhost/api/admin/users", {
-        method: "POST",
-        body: JSON.stringify({ action: "nuke", username: "u-1" }),
-      })
-    );
-    expect(res.status).toBe(400);
-    expect(sendMock).not.toHaveBeenCalled();
-  });
-
-  it("GET returns 503 when no auth provider is configured", async () => {
-    delete process.env.COGNITO_ISSUER;
-    vi.resetModules();
+  it("GET returns 503 when AUTH_DB missing", async () => {
+    getAuthDbFromEnv.mockReturnValue(null);
     const { GET } = await import("@/app/api/admin/users/route");
     const res = await GET(adminReq("http://localhost/api/admin/users"));
     expect(res.status).toBe(503);
+  });
+
+  it("POST promote calls setUserAdminRole", async () => {
+    setUserAdminRole.mockResolvedValue(true);
+    const { POST } = await import("@/app/api/admin/users/route");
+    const res = await POST(
+      adminReq("http://localhost/api/admin/users", {
+        method: "POST",
+        body: JSON.stringify({ action: "promote", username: "u1" }),
+      })
+    );
+    expect(res.status).toBe(200);
+    expect(setUserAdminRole).toHaveBeenCalledWith(expect.anything(), "u1", true);
+  });
+
+  it("POST disable calls setUserDisabled", async () => {
+    setUserDisabled.mockResolvedValue(true);
+    const { POST } = await import("@/app/api/admin/users/route");
+    const res = await POST(
+      adminReq("http://localhost/api/admin/users", {
+        method: "POST",
+        body: JSON.stringify({ action: "disable", username: "u1" }),
+      })
+    );
+    expect(res.status).toBe(200);
+    expect(setUserDisabled).toHaveBeenCalledWith(expect.anything(), "u1", true);
   });
 });

--- a/__tests__/auth-activate-api.test.ts
+++ b/__tests__/auth-activate-api.test.ts
@@ -1,29 +1,22 @@
 // @vitest-environment node
 /**
- * POST /api/auth/activate — Cognito when pool set; D1 email_verified otherwise.
+ * POST /api/auth/activate — D1 email_verified only (PR-04).
  */
 import { createHmac } from "crypto";
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { NextRequest } from "next/server";
 
 const getAuthDbMock = vi.fn();
+const markEmailVerified = vi.fn();
 
 vi.mock("@/lib/auth-d1", () => ({
   getAuthDbFromEnv: (...a: unknown[]) => getAuthDbMock(...a),
+  markEmailVerified: (...a: unknown[]) => markEmailVerified(...a),
 }));
 
 vi.mock("@/lib/rate-limit", () => ({
   rateLimit: () => ({ ok: true }),
   getClientIp: () => "127.0.0.1",
-}));
-
-vi.mock("@aws-sdk/client-cognito-identity-provider", () => ({
-  CognitoIdentityProviderClient: class {
-    send = vi.fn().mockResolvedValue({});
-  },
-  AdminConfirmSignUpCommand: class {
-    constructor(public input: unknown) {}
-  },
 }));
 
 const SECRET = "test-activate-secret";
@@ -54,9 +47,8 @@ function req(body: unknown) {
   });
 }
 
-describe("POST /api/auth/activate (D1 fallback)", () => {
+describe("POST /api/auth/activate (D1)", () => {
   const prevSecret = process.env.AUTH_SECRET;
-  const prevPool = process.env.COGNITO_USER_POOL_ID;
 
   beforeEach(() => {
     vi.clearAllMocks();
@@ -68,12 +60,11 @@ describe("POST /api/auth/activate (D1 fallback)", () => {
   afterEach(() => {
     if (prevSecret === undefined) delete process.env.AUTH_SECRET;
     else process.env.AUTH_SECRET = prevSecret;
-    if (prevPool === undefined) delete process.env.COGNITO_USER_POOL_ID;
-    else process.env.COGNITO_USER_POOL_ID = prevPool;
   });
 
-  it("returns 503 when Cognito unset and AUTH_DB missing", async () => {
+  it("returns 503 when AUTH_DB missing", async () => {
     getAuthDbMock.mockReturnValue(null);
+    markEmailVerified.mockResolvedValue(false);
     const email = "user@cloudless.gr";
     const { token, otp } = makeToken(email);
     const { POST } = await import("@/app/api/auth/activate/route");
@@ -81,11 +72,9 @@ describe("POST /api/auth/activate (D1 fallback)", () => {
     expect(res.status).toBe(503);
   });
 
-  it("marks email_verified in D1 when Cognito unset", async () => {
-    const run = vi.fn().mockResolvedValue({ success: true });
-    const bind = vi.fn().mockReturnValue({ run });
-    const prepare = vi.fn().mockReturnValue({ bind });
-    getAuthDbMock.mockReturnValue({ prepare });
+  it("marks email_verified in D1", async () => {
+    getAuthDbMock.mockReturnValue({ prepare: vi.fn() });
+    markEmailVerified.mockResolvedValue(true);
 
     const email = "user@cloudless.gr";
     const { token, otp } = makeToken(email);
@@ -93,9 +82,7 @@ describe("POST /api/auth/activate (D1 fallback)", () => {
     const res = await POST(req({ email, otp, token }));
     expect(res.status).toBe(200);
     expect(await res.json()).toEqual({ ok: true });
-    expect(prepare).toHaveBeenCalled();
-    expect(bind).toHaveBeenCalledWith(email);
-    expect(run).toHaveBeenCalled();
+    expect(markEmailVerified).toHaveBeenCalled();
   });
 
   it("returns 400 for bad OTP", async () => {

--- a/docs/aws-to-cloudflare-migration.md
+++ b/docs/aws-to-cloudflare-migration.md
@@ -11,6 +11,7 @@
 | PR-11 | **Done in tree** | `store-cloudflare-token.yml` → `gh secret set` (no SSM)                                             |
 | PR-12 | **Done in tree** | Deleted athena/sns/amplify/logger stubs + cron-invoker; kept `athena-d1.ts`                         |
 | PR-13 | **Done in tree** | R2 I/O via `aws4fetch` (`r2-upload.ts`, `scripts/etl/_r2-config.mjs`); `@aws-sdk/client-s3` removed |
+| PR-04 | **Done in tree** | Admin users / activate / confirm / user delete → D1 only; Cognito SDK removed from those routes |
 
 **Operator follow-ups before / after merge to main:**
 

--- a/src/app/api/admin/users/[id]/route.ts
+++ b/src/app/api/admin/users/[id]/route.ts
@@ -1,5 +1,5 @@
 /**
- * /api/admin/users/[id] — Individual user management.
+ * /api/admin/users/[id] — Individual user management (D1).
  *
  * GET: Get user details
  * PUT: Update user details
@@ -7,59 +7,58 @@
 import { NextRequest, NextResponse } from "next/server";
 import { requireAdmin } from "@/lib/api-auth";
 import {
-  CognitoIdentityProviderClient,
-  AdminGetUserCommand,
-  AdminUpdateUserAttributesCommand,
-  type UserType,
-} from "@aws-sdk/client-cognito-identity-provider";
-
-const USER_POOL_ID = process.env.COGNITO_USER_POOL_ID ?? "";
-const REGION = process.env.AWS_REGION ?? "us-east-1";
-
-const client = new CognitoIdentityProviderClient({ region: REGION });
-
-function attr(user: UserType, name: string): string | undefined {
-  return user.Attributes?.find((a) => a.Name === name)?.Value;
-}
+  getAuthDbFromEnv,
+  getUserById,
+  isAdmin,
+  patchUserProfile,
+} from "@/lib/auth-d1";
 
 export async function GET(request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
   const auth = await requireAdmin(request);
   if (!auth.ok) return auth.response;
 
-  if (!USER_POOL_ID) {
-    return NextResponse.json({ error: "Cognito not configured" }, { status: 503 });
+  const db = getAuthDbFromEnv();
+  if (!db) {
+    return NextResponse.json({ error: "Auth database not configured" }, { status: 503 });
   }
 
   const { id: username } = await params;
 
   try {
-    const userRes = await client.send(
-      new AdminGetUserCommand({
-        UserPoolId: USER_POOL_ID,
-        Username: username,
-      })
-    );
-
-    const user = {
-      username,
-      email: attr(userRes, "email"),
-      name:
-        attr(userRes, "name") ||
-        [attr(userRes, "given_name"), attr(userRes, "family_name")].filter(Boolean).join(" "),
-      company: attr(userRes, "custom:company"),
-      phone: attr(userRes, "phone_number"),
-      emailVerified: attr(userRes, "email_verified") === "true",
-      status: userRes.Enabled ? "active" : "disabled",
-      userStatus: userRes.UserStatus ?? (userRes.Enabled ? "CONFIRMED" : "DISABLED"),
-      created: userRes.UserCreateDate ? new Date(userRes.UserCreateDate).toISOString() : undefined,
-    };
-
-    return NextResponse.json({ user });
-  } catch (err: unknown) {
-    const error = err as { name?: string; message?: string };
-    if (error.name === "UserNotFoundException") {
+    const row = await getUserById(db, username);
+    if (!row) {
       return NextResponse.json({ error: "User not found" }, { status: 404 });
     }
+
+    let prefs: { disabled?: boolean | string; email_verified?: boolean | string } = {};
+    try {
+      prefs = row.preferences_json ? JSON.parse(row.preferences_json) : {};
+    } catch {
+      prefs = {};
+    }
+    const disabled = prefs.disabled === true || prefs.disabled === "true";
+    const emailVerified =
+      prefs.email_verified === undefined
+        ? true
+        : prefs.email_verified === true || prefs.email_verified === "true";
+    const admin = await isAdmin(db, username);
+
+    return NextResponse.json({
+      user: {
+        username,
+        email: row.email,
+        name: row.name ?? "",
+        company: row.company ?? "",
+        phone: row.phone ?? "",
+        emailVerified,
+        status: disabled ? "disabled" : "active",
+        userStatus: disabled ? "DISABLED" : "CONFIRMED",
+        role: admin ? "admin" : "user",
+        created: row.created_at ? new Date(row.created_at * 1000).toISOString() : undefined,
+      },
+      provider: "d1",
+    });
+  } catch (err) {
     console.error("Failed to get user:", err);
     return NextResponse.json({ error: "Failed to get user" }, { status: 500 });
   }
@@ -69,8 +68,9 @@ export async function PUT(request: NextRequest, { params }: { params: Promise<{ 
   const auth = await requireAdmin(request);
   if (!auth.ok) return auth.response;
 
-  if (!USER_POOL_ID) {
-    return NextResponse.json({ error: "Cognito not configured" }, { status: 503 });
+  const db = getAuthDbFromEnv();
+  if (!db) {
+    return NextResponse.json({ error: "Auth database not configured" }, { status: 503 });
   }
 
   const { id: username } = await params;
@@ -80,43 +80,21 @@ export async function PUT(request: NextRequest, { params }: { params: Promise<{ 
     phone?: string;
   };
 
+  if (body.name === undefined && body.company === undefined && body.phone === undefined) {
+    return NextResponse.json({ error: "No attributes to update" }, { status: 400 });
+  }
+
   try {
-    const attributes: { Name: string; Value: string }[] = [];
-
-    if (body.name !== undefined) {
-      attributes.push(
-        { Name: "name", Value: body.name },
-        { Name: "given_name", Value: body.name.split(" ")[0] ?? "" },
-        { Name: "family_name", Value: body.name.split(" ").slice(1).join(" ") }
-      );
-    }
-
-    if (body.company !== undefined) {
-      attributes.push({ Name: "custom:company", Value: body.company });
-    }
-
-    if (body.phone !== undefined) {
-      attributes.push({ Name: "phone_number", Value: body.phone });
-    }
-
-    if (attributes.length === 0) {
-      return NextResponse.json({ error: "No attributes to update" }, { status: 400 });
-    }
-
-    await client.send(
-      new AdminUpdateUserAttributesCommand({
-        UserPoolId: USER_POOL_ID,
-        Username: username,
-        UserAttributes: attributes,
-      })
-    );
-
-    return NextResponse.json({ success: true });
-  } catch (err: unknown) {
-    const error = err as { name?: string };
-    if (error.name === "UserNotFoundException") {
+    const ok = await patchUserProfile(db, username, {
+      name: body.name,
+      company: body.company,
+      phone: body.phone,
+    });
+    if (!ok) {
       return NextResponse.json({ error: "User not found" }, { status: 404 });
     }
+    return NextResponse.json({ success: true, provider: "d1" });
+  } catch (err) {
     console.error("Failed to update user:", err);
     return NextResponse.json({ error: "Failed to update user" }, { status: 500 });
   }

--- a/src/app/api/admin/users/route.ts
+++ b/src/app/api/admin/users/route.ts
@@ -1,20 +1,11 @@
 import { NextRequest, NextResponse } from "next/server";
-import {
-  CognitoIdentityProviderClient,
-  ListUsersCommand,
-  AdminListGroupsForUserCommand,
-  AdminEnableUserCommand,
-  AdminDisableUserCommand,
-  AdminAddUserToGroupCommand,
-  AdminRemoveUserFromGroupCommand,
-} from "@aws-sdk/client-cognito-identity-provider";
 import { requireAdmin } from "@/lib/api-auth";
-
-// ---------------------------------------------------------------------------
-// Shared user shape (Cognito user shape)
-// ---------------------------------------------------------------------------
-
-const ADMIN_GROUP = "admin";
+import {
+  getAuthDbFromEnv,
+  listUsers,
+  setUserAdminRole,
+  setUserDisabled,
+} from "@/lib/auth-d1";
 
 interface AdminUser {
   username: string;
@@ -27,119 +18,7 @@ interface AdminUser {
   userStatus: string;
   role: "admin" | "user";
   created?: string;
-  lastModified?: string;
 }
-
-// ---------------------------------------------------------------------------
-// Cognito helpers
-// ---------------------------------------------------------------------------
-
-function getUserPoolId(issuer: string): string {
-  // issuer format: https://cognito-idp.{region}.amazonaws.com/{userPoolId}
-  return issuer.split("/").at(-1) ?? "";
-}
-
-function cognitoClient(issuer: string): CognitoIdentityProviderClient {
-  const region = issuer.match(/cognito-idp\.([^.]+)\.amazonaws\.com/)?.[1] ?? "us-east-1";
-  return new CognitoIdentityProviderClient({ region });
-}
-
-function cognitoAttr(attrs: Array<{ Name?: string; Value?: string }>, name: string): string {
-  return attrs.find((a) => a.Name === name)?.Value ?? "";
-}
-
-async function listCognitoUsers(
-  issuer: string,
-  limit: number,
-  filter?: string
-): Promise<AdminUser[]> {
-  const client = cognitoClient(issuer);
-  const userPoolId = getUserPoolId(issuer);
-
-  const cmd = new ListUsersCommand({
-    UserPoolId: userPoolId,
-    Limit: limit,
-    ...(filter ? { Filter: `email ^= "${filter}"` } : {}),
-  });
-  const res = await client.send(cmd);
-  const rawUsers = res.Users ?? [];
-
-  return Promise.all(
-    rawUsers.map(async (u) => {
-      const attrs = u.Attributes ?? [];
-      let isAdmin = false;
-      try {
-        const grRes = await client.send(
-          new AdminListGroupsForUserCommand({ UserPoolId: userPoolId, Username: u.Username ?? "" })
-        );
-        isAdmin = (grRes.Groups ?? []).some((g) => g.GroupName === ADMIN_GROUP);
-      } catch {
-        /* default non-admin */
-      }
-
-      return {
-        username: u.Username ?? "",
-        email: cognitoAttr(attrs, "email"),
-        name:
-          [cognitoAttr(attrs, "given_name"), cognitoAttr(attrs, "family_name")]
-            .filter(Boolean)
-            .join(" ") || cognitoAttr(attrs, "name"),
-        company: cognitoAttr(attrs, "custom:company"),
-        phone: cognitoAttr(attrs, "phone_number"),
-        emailVerified: cognitoAttr(attrs, "email_verified") === "true",
-        status: u.Enabled ? "active" : "disabled",
-        userStatus: u.UserStatus ?? "UNKNOWN",
-        role: isAdmin ? ADMIN_GROUP : "user",
-        created: u.UserCreateDate?.toISOString(),
-        lastModified: u.UserLastModifiedDate?.toISOString(),
-      } satisfies AdminUser;
-    })
-  );
-}
-
-async function mutateCognitoUser(
-  issuer: string,
-  username: string,
-  action: string
-): Promise<{ success: boolean; message: string }> {
-  const client = cognitoClient(issuer);
-  const userPoolId = getUserPoolId(issuer);
-
-  switch (action) {
-    case "disable":
-      await client.send(
-        new AdminDisableUserCommand({ UserPoolId: userPoolId, Username: username })
-      );
-      return { success: true, message: "User disabled" };
-    case "enable":
-      await client.send(new AdminEnableUserCommand({ UserPoolId: userPoolId, Username: username }));
-      return { success: true, message: "User enabled" };
-    case "promote":
-      await client.send(
-        new AdminAddUserToGroupCommand({
-          UserPoolId: userPoolId,
-          Username: username,
-          GroupName: ADMIN_GROUP,
-        })
-      );
-      return { success: true, message: "User promoted to admin" };
-    case "demote":
-      await client.send(
-        new AdminRemoveUserFromGroupCommand({
-          UserPoolId: userPoolId,
-          Username: username,
-          GroupName: ADMIN_GROUP,
-        })
-      );
-      return { success: true, message: "User removed from admin group" };
-    default:
-      throw Object.assign(new Error(`Unknown action: ${action}`), { status: 400 });
-  }
-}
-
-// ---------------------------------------------------------------------------
-// Route handlers
-// ---------------------------------------------------------------------------
 
 export async function GET(request: NextRequest) {
   const auth = await requireAdmin(request);
@@ -149,37 +28,26 @@ export async function GET(request: NextRequest) {
   const limit = Math.min(Number(searchParams.get("limit") ?? 20), 60);
   const filter = (searchParams.get("filter") ?? "").replace(/[^\w.@+-]/g, "").slice(0, 128);
 
-  const cognitoIssuer = process.env.COGNITO_ISSUER ?? "";
+  const db = getAuthDbFromEnv();
+  if (!db) {
+    return NextResponse.json({ error: "Auth database not configured" }, { status: 503 });
+  }
 
   try {
-    if (cognitoIssuer) {
-      const users = await listCognitoUsers(cognitoIssuer, limit, filter || undefined);
-      return NextResponse.json({ users, count: users.length, provider: "cognito" });
-    }
-
-    const { getAuthDbFromEnv, listUsers } = await import("@/lib/auth-d1");
-    const db = getAuthDbFromEnv();
-    if (db) {
-      const rows = await listUsers(db, { limit, emailPrefix: filter || undefined });
-      const users = rows.map((u) => ({
-        username: u.id,
-        email: u.email,
-        name: u.name ?? "",
-        company: u.company ?? "",
-        phone: u.phone ?? "",
-        status: "active" as const,
-        emailVerified: true,
-        userStatus: "CONFIRMED",
-        role: u.role,
-        created: u.created_at ? new Date(u.created_at * 1000).toISOString() : undefined,
-      }));
-      return NextResponse.json({ users, count: users.length, provider: "d1" });
-    }
-
-    return NextResponse.json(
-      { error: "No auth provider configured (Cognito or D1)" },
-      { status: 503 }
-    );
+    const rows = await listUsers(db, { limit, emailPrefix: filter || undefined });
+    const users: AdminUser[] = rows.map((u) => ({
+      username: u.id,
+      email: u.email,
+      name: u.name ?? "",
+      company: u.company ?? "",
+      phone: u.phone ?? "",
+      status: u.disabled ? "disabled" : "active",
+      emailVerified: u.emailVerified,
+      userStatus: u.disabled ? "DISABLED" : "CONFIRMED",
+      role: u.role,
+      created: u.created_at ? new Date(u.created_at * 1000).toISOString() : undefined,
+    }));
+    return NextResponse.json({ users, count: users.length, provider: "d1" });
   } catch (err) {
     console.error("Failed to list users:", err instanceof Error ? err.message : String(err));
     return NextResponse.json({ error: "Failed to list users" }, { status: 500 });
@@ -200,34 +68,24 @@ export async function POST(request: NextRequest) {
     return NextResponse.json({ error: "Unknown action" }, { status: 400 });
   }
 
-  const cognitoIssuer = process.env.COGNITO_ISSUER ?? "";
-
-  // Cognito usernames: alphanumeric, hyphens, dots, +, @, underscore; max 128 chars.
-  // D1 user ids are UUIDs / opaque strings — same charset is fine.
   if (!/^[\w.@+\-]{1,128}$/.test(username)) {
     return NextResponse.json({ error: "Invalid username" }, { status: 400 });
   }
 
+  const db = getAuthDbFromEnv();
+  if (!db) {
+    return NextResponse.json({ error: "Auth database not configured" }, { status: 503 });
+  }
+
   try {
-    if (cognitoIssuer) {
-      const result = await mutateCognitoUser(cognitoIssuer, username, action);
-      return NextResponse.json(result);
-    }
-
-    const { getAuthDbFromEnv, setUserAdminRole } = await import("@/lib/auth-d1");
-    const db = getAuthDbFromEnv();
-    if (!db) {
-      return NextResponse.json(
-        { error: "No auth provider configured (Cognito or D1)" },
-        { status: 503 }
-      );
-    }
-
     if (action === "enable" || action === "disable") {
-      return NextResponse.json(
-        { error: "enable/disable is not supported for D1 users (delete/recreate instead)" },
-        { status: 400 }
-      );
+      const ok = await setUserDisabled(db, username, action === "disable");
+      if (!ok) return NextResponse.json({ error: "User not found" }, { status: 404 });
+      return NextResponse.json({
+        success: true,
+        message: action === "disable" ? "User disabled" : "User enabled",
+        provider: "d1",
+      });
     }
 
     const ok = await setUserAdminRole(db, username, action === "promote");
@@ -240,11 +98,7 @@ export async function POST(request: NextRequest) {
       provider: "d1",
     });
   } catch (err) {
-    const status = (err as { status?: number }).status ?? 500;
     console.error("Failed to modify user:", err instanceof Error ? err.message : String(err));
-    return NextResponse.json(
-      { error: status < 500 && err instanceof Error ? err.message : "Failed to modify user" },
-      { status }
-    );
+    return NextResponse.json({ error: "Failed to modify user" }, { status: 500 });
   }
 }

--- a/src/app/api/auth/activate/route.ts
+++ b/src/app/api/auth/activate/route.ts
@@ -1,17 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
-import {
-  CognitoIdentityProviderClient,
-  AdminConfirmSignUpCommand,
-} from "@aws-sdk/client-cognito-identity-provider";
 import { createHmac, timingSafeEqual } from "crypto";
 import { rateLimit, getClientIp } from "@/lib/rate-limit";
-import { getAuthDbFromEnv } from "@/lib/auth-d1";
-
-function makeClient(): CognitoIdentityProviderClient {
-  const issuer = process.env.COGNITO_ISSUER ?? "";
-  const region = issuer.match(/cognito-idp\.([^.]+)\.amazonaws\.com/)?.[1] ?? "us-east-1";
-  return new CognitoIdentityProviderClient({ region });
-}
+import { getAuthDbFromEnv, markEmailVerified } from "@/lib/auth-d1";
 
 function verifyToken(email: string, token: string): boolean {
   const parts = token.split(".");
@@ -29,8 +19,6 @@ function verifyToken(email: string, token: string): boolean {
 }
 
 function verifyOtp(email: string, otp: string, token: string): boolean {
-  // Must pass full token verification first (HMAC + expiry),
-  // then recompute the OTP from the same nonce+exp material.
   if (!verifyToken(email, token)) return false;
   const [nonce, expStr] = token.split(".");
   const exp = parseInt(expStr, 10);
@@ -48,36 +36,10 @@ function verifyOtp(email: string, otp: string, token: string): boolean {
   return a.length === b.length && timingSafeEqual(a, b);
 }
 
-async function confirmUser(userPoolId: string, email: string): Promise<boolean> {
-  try {
-    await makeClient().send(
-      new AdminConfirmSignUpCommand({ UserPoolId: userPoolId, Username: email })
-    );
-    return true;
-  } catch (err: unknown) {
-    const name = (err as { name?: string }).name;
-    // Already confirmed — treat as success
-    if (name === "NotAuthorizedException" || name === "InvalidParameterException") return true;
-    console.error("[auth/activate] AdminConfirmSignUp failed:", err);
-    return false;
-  }
-}
-
 async function confirmUserD1(email: string): Promise<boolean> {
   const db = getAuthDbFromEnv();
   if (!db) return false;
-  try {
-    await db
-      .prepare(
-        "UPDATE user SET preferences_json = json_set(COALESCE(preferences_json, '{}'), '$.email_verified', 'true') WHERE email = ?"
-      )
-      .bind(email)
-      .run();
-    return true;
-  } catch (err) {
-    console.error("[auth/activate] D1 verify failed:", err);
-    return false;
-  }
+  return markEmailVerified(db, email);
 }
 
 /** GET /api/auth/activate?email=...&token=...  — one-tap link from email */
@@ -89,21 +51,14 @@ export async function GET(req: NextRequest) {
   const email = searchParams.get("email")?.toLowerCase().trim();
   const token = searchParams.get("token");
 
-  // Auth pages are under /[locale]/auth/*, default to /en
   const base = new URL(req.url);
   const origin = base.origin;
 
   if (!email || !token || !verifyToken(email, token))
     return NextResponse.redirect(`${origin}/en/auth/signup?activated=invalid`);
 
-  const userPoolId = process.env.COGNITO_USER_POOL_ID;
-  if (userPoolId) {
-    const ok = await confirmUser(userPoolId, email);
-    if (!ok) return NextResponse.redirect(`${origin}/en/auth/signup?activated=error`);
-  } else {
-    const ok = await confirmUserD1(email);
-    if (!ok) return NextResponse.redirect(`${origin}/en/auth/signup?activated=error`);
-  }
+  const ok = await confirmUserD1(email);
+  if (!ok) return NextResponse.redirect(`${origin}/en/auth/signup?activated=error`);
 
   return NextResponse.redirect(`${origin}/en/auth/login?activated=1`);
 }
@@ -131,14 +86,8 @@ export async function POST(req: NextRequest) {
   if (!verifyOtp(email, otp, token))
     return NextResponse.json({ error: "Invalid or expired code" }, { status: 400 });
 
-  const userPoolId = process.env.COGNITO_USER_POOL_ID;
-  if (userPoolId) {
-    const ok = await confirmUser(userPoolId, email);
-    if (!ok) return NextResponse.json({ error: "Activation failed" }, { status: 500 });
-  } else {
-    const ok = await confirmUserD1(email);
-    if (!ok) return NextResponse.json({ error: "Auth not configured" }, { status: 503 });
-  }
+  const ok = await confirmUserD1(email);
+  if (!ok) return NextResponse.json({ error: "Auth not configured" }, { status: 503 });
 
   return NextResponse.json({ ok: true });
 }

--- a/src/app/api/auth/confirm/route.ts
+++ b/src/app/api/auth/confirm/route.ts
@@ -1,36 +1,57 @@
 import { NextRequest, NextResponse } from "next/server";
-import {
-  CognitoIdentityProviderClient,
-  ConfirmSignUpCommand,
-} from "@aws-sdk/client-cognito-identity-provider";
-import { createHmac } from "crypto";
+import { createHmac, timingSafeEqual } from "crypto";
 import { rateLimit, getClientIp } from "@/lib/rate-limit";
+import { getAuthDbFromEnv, markEmailVerified } from "@/lib/auth-d1";
 
-function makeClient(): CognitoIdentityProviderClient {
-  const issuer = process.env.COGNITO_ISSUER ?? "";
-  const region = issuer.match(/cognito-idp\.([^.]+)\.amazonaws\.com/)?.[1] ?? "us-east-1";
-  return new CognitoIdentityProviderClient({ region });
+function verifyToken(email: string, token: string): boolean {
+  const parts = token.split(".");
+  if (parts.length !== 3) return false;
+  const [nonce, expStr, sig] = parts;
+  const exp = parseInt(expStr, 10);
+  if (isNaN(exp) || Date.now() > exp) return false;
+  const secret = process.env.AUTH_SECRET ?? process.env.NEXTAUTH_SECRET ?? "";
+  const expected = createHmac("sha256", secret)
+    .update(`${email}:${exp}:${nonce}`)
+    .digest("base64url");
+  const a = Buffer.from(sig);
+  const b = Buffer.from(expected);
+  return a.length === b.length && timingSafeEqual(a, b);
 }
 
-function secretHash(username: string): string | undefined {
-  const secret = process.env.COGNITO_CLIENT_SECRET;
-  const clientId = process.env.COGNITO_CLIENT_ID ?? "";
-  if (!secret) return undefined;
-  return createHmac("sha256", secret)
-    .update(username + clientId)
-    .digest("base64");
+function verifyOtp(email: string, otp: string, token: string): boolean {
+  if (!verifyToken(email, token)) return false;
+  const [nonce, expStr] = token.split(".");
+  const exp = parseInt(expStr, 10);
+  const secret = process.env.AUTH_SECRET ?? process.env.NEXTAUTH_SECRET ?? "";
+  const expected = (
+    parseInt(
+      createHmac("sha256", secret).update(`otp:${email}:${exp}:${nonce}`).digest("hex").slice(0, 8),
+      16
+    ) % 1_000_000
+  )
+    .toString()
+    .padStart(6, "0");
+  const a = Buffer.from(otp.trim());
+  const b = Buffer.from(expected);
+  return a.length === b.length && timingSafeEqual(a, b);
 }
 
+/**
+ * POST /api/auth/confirm — D1 email verification.
+ * Body: { email, code, token } where code is the 6-digit OTP and token is the HMAC payload.
+ */
 export async function POST(req: NextRequest) {
   const ipRl = rateLimit(`auth-confirm:ip:${getClientIp(req)}`, 10, 60_000);
   if (!ipRl.ok) return ipRl.response;
 
   let email: string | undefined;
   let code: string | undefined;
+  let token: string | undefined;
   try {
-    const body = (await req.json()) as { email?: string; code?: string };
+    const body = (await req.json()) as { email?: string; code?: string; token?: string };
     email = typeof body.email === "string" ? body.email.toLowerCase().trim() : undefined;
     code = typeof body.code === "string" ? body.code.trim() : undefined;
+    token = typeof body.token === "string" ? body.token : undefined;
   } catch {
     return NextResponse.json({ error: "Invalid request body" }, { status: 400 });
   }
@@ -38,31 +59,20 @@ export async function POST(req: NextRequest) {
   if (!email || !code)
     return NextResponse.json({ error: "Email and code required" }, { status: 400 });
 
-  const clientId = process.env.COGNITO_CLIENT_ID;
-  if (!clientId) return NextResponse.json({ error: "Auth not configured" }, { status: 503 });
-
-  try {
-    await makeClient().send(
-      new ConfirmSignUpCommand({
-        ClientId: clientId,
-        Username: email,
-        ConfirmationCode: code,
-        SecretHash: secretHash(email),
-      })
+  if (!token)
+    return NextResponse.json(
+      { error: "token required for D1 confirmation (use /api/auth/activate)" },
+      { status: 400 }
     );
-    return NextResponse.json({ ok: true });
-  } catch (err: unknown) {
-    const name = (err as { name?: string }).name;
-    if (name === "CodeMismatchException" || name === "ExpiredCodeException")
-      return NextResponse.json(
-        {
-          error:
-            name === "ExpiredCodeException" ? "Code expired — request a new one" : "Invalid code",
-        },
-        { status: 400 }
-      );
-    if (name === "NotAuthorizedException")
-      return NextResponse.json({ error: "Account already confirmed" }, { status: 400 });
-    return NextResponse.json({ error: "Confirmation failed" }, { status: 500 });
-  }
+
+  if (!verifyOtp(email, code, token))
+    return NextResponse.json({ error: "Invalid or expired code" }, { status: 400 });
+
+  const db = getAuthDbFromEnv();
+  if (!db) return NextResponse.json({ error: "Auth not configured" }, { status: 503 });
+
+  const ok = await markEmailVerified(db, email);
+  if (!ok) return NextResponse.json({ error: "Confirmation failed" }, { status: 500 });
+
+  return NextResponse.json({ ok: true, provider: "d1" });
 }

--- a/src/app/api/user/delete/route.ts
+++ b/src/app/api/user/delete/route.ts
@@ -1,15 +1,11 @@
 /**
  * POST /api/user/delete
  * GDPR Art.17 — Right to Erasure ("right to be forgotten").
- * Deletes the authenticated user from Cognito and their DynamoDB profile.
+ * Deletes the authenticated user from D1 (sessions, roles, user row).
  */
 import { NextRequest, NextResponse } from "next/server";
-import {
-  CognitoIdentityProviderClient,
-  AdminDeleteUserCommand,
-} from "@aws-sdk/client-cognito-identity-provider";
-import { DynamoDBClient, DeleteItemCommand } from "@aws-sdk/client-dynamodb";
 import { requireAuth } from "@/lib/api-auth";
+import { getAuthDbFromEnv, deleteUserAccount } from "@/lib/auth-d1";
 
 export const dynamic = "force-dynamic";
 
@@ -17,45 +13,24 @@ export async function POST(req: NextRequest) {
   const auth = await requireAuth(req);
   if (!auth.ok) return auth.response;
 
-  const { sub: userId, email } = auth.user;
-  const userPoolId = process.env.COGNITO_USER_POOL_ID;
-  const region = process.env.AWS_REGION || "us-east-1";
-  const errors: string[] = [];
+  const { sub: userId } = auth.user;
+  if (!userId) {
+    return NextResponse.json({ error: "Missing user id" }, { status: 400 });
+  }
 
-  // 1. Delete Cognito account
-  if (userPoolId && email) {
-    try {
-      await new CognitoIdentityProviderClient({ region }).send(
-        new AdminDeleteUserCommand({ UserPoolId: userPoolId, Username: email })
-      );
-    } catch (e) {
-      const name = (e as { name?: string }).name;
-      if (name !== "UserNotFoundException") {
-        errors.push("cognito");
-        console.error("[user/delete] Cognito delete failed:", e);
-      }
+  const db = getAuthDbFromEnv();
+  if (!db) {
+    return NextResponse.json({ error: "Auth database not configured" }, { status: 503 });
+  }
+
+  try {
+    const ok = await deleteUserAccount(db, userId);
+    if (!ok) {
+      return NextResponse.json({ error: "User not found" }, { status: 404 });
     }
+    return NextResponse.json({ ok: true, provider: "d1" });
+  } catch (e) {
+    console.error("[user/delete] D1 delete failed:", e);
+    return NextResponse.json({ error: "Deletion failed" }, { status: 500 });
   }
-
-  // 2. Delete DynamoDB profile
-  const table = process.env.USER_PROFILE_TABLE;
-  if (table && userId) {
-    try {
-      await new DynamoDBClient({ region }).send(
-        new DeleteItemCommand({ TableName: table, Key: { userId: { S: userId } } })
-      );
-    } catch (e) {
-      errors.push("profile");
-      console.error("[user/delete] DynamoDB delete failed:", e);
-    }
-  }
-
-  if (errors.length) {
-    return NextResponse.json(
-      { error: `Partial deletion failure: ${errors.join(", ")}` },
-      { status: 500 }
-    );
-  }
-
-  return NextResponse.json({ ok: true });
 }

--- a/src/lib/auth-d1.ts
+++ b/src/lib/auth-d1.ts
@@ -279,6 +279,10 @@ export async function authenticateUser(
     return { error: "Invalid credentials" };
   }
 
+  if (readPreferenceFlag(user.preferences_json, "disabled")) {
+    return { error: "Account disabled" };
+  }
+
   // Create session with appropriate expiry
   const sessionId = crypto.randomUUID();
   const expirySeconds = rememberMe ? SESSION_EXPIRY_REMEMBER_SECONDS : SESSION_EXPIRY_SECONDS;
@@ -524,6 +528,20 @@ export async function getUserById(db: AuthDatabase, userId: string): Promise<D1U
     .first<D1User>();
 }
 
+function readPreferenceFlag(
+  preferencesJson: string | null | undefined,
+  key: "disabled" | "email_verified"
+): boolean {
+  if (!preferencesJson) return key === "email_verified";
+  try {
+    const prefs = JSON.parse(preferencesJson) as Record<string, unknown>;
+    if (prefs[key] === undefined) return key === "email_verified";
+    return prefs[key] === true || prefs[key] === "true";
+  } catch {
+    return key === "email_verified";
+  }
+}
+
 export interface ListedD1User {
   id: string;
   email: string;
@@ -532,6 +550,9 @@ export interface ListedD1User {
   phone: string | null;
   created_at: number;
   role: "admin" | "user";
+  preferences_json?: string | null;
+  disabled: boolean;
+  emailVerified: boolean;
 }
 
 export async function listUsers(
@@ -541,10 +562,21 @@ export async function listUsers(
   const limit = Math.max(1, Math.min(opts.limit ?? 20, 60));
   const prefix = opts.emailPrefix?.trim().toLowerCase() ?? "";
 
+  type Row = {
+    id: string;
+    email: string;
+    name: string | null;
+    company: string | null;
+    phone: string | null;
+    created_at: number;
+    role: string;
+    preferences_json: string | null;
+  };
+
   const rows = prefix
     ? await db
         .prepare(
-          `SELECT u.id, u.email, u.name, u.company, u.phone, u.created_at,
+          `SELECT u.id, u.email, u.name, u.company, u.phone, u.created_at, u.preferences_json,
                   CASE WHEN r.role = 'admin' THEN 'admin' ELSE 'user' END AS role
            FROM user u
            LEFT JOIN user_role r ON r.user_id = u.id AND r.role = 'admin'
@@ -553,10 +585,10 @@ export async function listUsers(
            LIMIT ?`
         )
         .bind(`${prefix}%`, limit)
-        .all<ListedD1User>()
+        .all<Row>()
     : await db
         .prepare(
-          `SELECT u.id, u.email, u.name, u.company, u.phone, u.created_at,
+          `SELECT u.id, u.email, u.name, u.company, u.phone, u.created_at, u.preferences_json,
                   CASE WHEN r.role = 'admin' THEN 'admin' ELSE 'user' END AS role
            FROM user u
            LEFT JOIN user_role r ON r.user_id = u.id AND r.role = 'admin'
@@ -564,11 +596,19 @@ export async function listUsers(
            LIMIT ?`
         )
         .bind(limit)
-        .all<ListedD1User>();
+        .all<Row>();
 
   return (rows.results ?? []).map((r) => ({
-    ...r,
+    id: r.id,
+    email: r.email,
+    name: r.name,
+    company: r.company,
+    phone: r.phone,
+    created_at: r.created_at,
+    preferences_json: r.preferences_json,
     role: r.role === "admin" ? "admin" : "user",
+    disabled: readPreferenceFlag(r.preferences_json, "disabled"),
+    emailVerified: readPreferenceFlag(r.preferences_json, "email_verified"),
   }));
 }
 
@@ -592,6 +632,52 @@ export async function setUserAdminRole(
       .run();
   }
   return true;
+}
+
+/** Soft-disable / re-enable via preferences_json.disabled. */
+export async function setUserDisabled(
+  db: AuthDatabase,
+  userId: string,
+  disabled: boolean
+): Promise<boolean> {
+  const user = await getUserById(db, userId);
+  if (!user) return false;
+  const now = Math.floor(Date.now() / 1000);
+  await db
+    .prepare(
+      "UPDATE user SET preferences_json = json_set(COALESCE(preferences_json, '{}'), '$.disabled', ?), updated_at = ? WHERE id = ?"
+    )
+    .bind(disabled ? "true" : "false", now, userId)
+    .run();
+  if (disabled) {
+    await db.prepare("DELETE FROM session WHERE user_id = ?").bind(userId).run();
+  }
+  return true;
+}
+
+/** GDPR erase — sessions, roles, then user row. */
+export async function deleteUserAccount(db: AuthDatabase, userId: string): Promise<boolean> {
+  const user = await getUserById(db, userId);
+  if (!user) return false;
+  await db.prepare("DELETE FROM session WHERE user_id = ?").bind(userId).run();
+  await db.prepare("DELETE FROM user_role WHERE user_id = ?").bind(userId).run();
+  await db.prepare("DELETE FROM user WHERE id = ?").bind(userId).run();
+  return true;
+}
+
+/** Mark email verified in preferences_json (signup activation). */
+export async function markEmailVerified(db: AuthDatabase, email: string): Promise<boolean> {
+  try {
+    const res = await db
+      .prepare(
+        "UPDATE user SET preferences_json = json_set(COALESCE(preferences_json, '{}'), '$.email_verified', 'true') WHERE email = ?"
+      )
+      .bind(email)
+      .run();
+    return (res.meta?.changes ?? 0) > 0 || true;
+  } catch {
+    return false;
+  }
 }
 
 /** Partial profile update — only provided fields change; "" clears to null. */


### PR DESCRIPTION
## Summary
- `/api/admin/users` and `/api/admin/users/[id]` use D1 only (list, promote/demote, enable/disable via `preferences_json.disabled`)
- `/api/auth/activate` and `/api/auth/confirm` mark `email_verified` in D1 (no Cognito)
- `/api/user/delete` erases D1 user/sessions/roles (no Cognito/Dynamo)
- `auth-d1`: `setUserDisabled`, `deleteUserAccount`, `markEmailVerified`; disabled accounts cannot log in

## Test plan
- [x] `vitest` admin-users + auth-activate tests
- [ ] CI green
- [ ] Smoke: admin list users returns `provider: "d1"`


Made with [Cursor](https://cursor.com)