### PR TITLE
fix(auth): Sonar duplication + prettier/MD leftovers from PR-04/13

### DIFF
--- a/__tests__/auth-activate-api.test.ts
+++ b/__tests__/auth-activate-api.test.ts
@@ -24,9 +24,7 @@ const SECRET = "test-activate-secret";
 function makeToken(email: string): { token: string; otp: string } {
   const nonce = "nonce123";
   const exp = Date.now() + 600_000;
-  const sig = createHmac("sha256", SECRET)
-    .update(`${email}:${exp}:${nonce}`)
-    .digest("base64url");
+  const sig = createHmac("sha256", SECRET).update(`${email}:${exp}:${nonce}`).digest("base64url");
   const token = `${nonce}.${exp}.${sig}`;
   const otp = (
     parseInt(

--- a/docs/databases/omv-cluster.md
+++ b/docs/databases/omv-cluster.md
@@ -96,12 +96,14 @@ All four are listed in `.vscode/extensions.json` (workspace recommendations). Co
 1. Install the four SQLTools extensions above (accept workspace recommendations if prompted).
 2. Open the **SQLTools** sidebar — not the SQL Server Object Explorer.
 3. Start TCP forwards and pull snapshots:
+
    ```bash
    pnpm db:forward
    pnpm db:passwords          # paste when SQLTools asks for MariaDB/Postgres password
    pnpm db:sqlite:pull        # required before the three omv-sqlite connections work
    pnpm db:d1:pull            # required before the three cloudflare-d1 connections work
    ```
+
 4. Click a connection under group `omv`, `omv-sqlite`, or `cloudflare-d1` and authenticate when prompted.
 5. When done: `pnpm db:forward:stop`.
 

--- a/scripts/etl/_r2-config.mjs
+++ b/scripts/etl/_r2-config.mjs
@@ -6,42 +6,43 @@ import { AwsClient } from "aws4fetch";
 
 const R2_ACCOUNT_ID = process.env.CLOUDFLARE_ACCOUNT_ID || process.env.CF_ACCOUNT_ID;
 const R2_ACCESS_KEY_ID = process.env.CF_R2_ACCESS_KEY_ID || process.env.R2_ACCESS_KEY_ID;
-const R2_SECRET_ACCESS_KEY = process.env.CF_R2_SECRET_ACCESS_KEY || process.env.R2_SECRET_ACCESS_KEY;
+const R2_SECRET_ACCESS_KEY =
+  process.env.CF_R2_SECRET_ACCESS_KEY || process.env.R2_SECRET_ACCESS_KEY;
 
 export const BUCKET = process.env.ANALYTICS_BUCKET || "datalake-bucket";
 
 function requireCreds() {
-	if (!R2_ACCOUNT_ID || !R2_ACCESS_KEY_ID || !R2_SECRET_ACCESS_KEY) {
-		throw new Error(
-			"Missing R2 credentials. Set CLOUDFLARE_ACCOUNT_ID (or CF_ACCOUNT_ID), CF_R2_ACCESS_KEY_ID, and CF_R2_SECRET_ACCESS_KEY. " +
-				"See https://developers.cloudflare.com/r2/api/s3-api/"
-		);
-	}
+  if (!R2_ACCOUNT_ID || !R2_ACCESS_KEY_ID || !R2_SECRET_ACCESS_KEY) {
+    throw new Error(
+      "Missing R2 credentials. Set CLOUDFLARE_ACCOUNT_ID (or CF_ACCOUNT_ID), CF_R2_ACCESS_KEY_ID, and CF_R2_SECRET_ACCESS_KEY. " +
+        "See https://developers.cloudflare.com/r2/api/s3-api/"
+    );
+  }
 }
 
 /** @returns {AwsClient} */
 export function getR2Client() {
-	requireCreds();
-	return new AwsClient({
-		accessKeyId: R2_ACCESS_KEY_ID,
-		secretAccessKey: R2_SECRET_ACCESS_KEY,
-		service: "s3",
-		region: "auto",
-	});
+  requireCreds();
+  return new AwsClient({
+    accessKeyId: R2_ACCESS_KEY_ID,
+    secretAccessKey: R2_SECRET_ACCESS_KEY,
+    service: "s3",
+    region: "auto",
+  });
 }
 
 /** @deprecated use getR2Client — kept name for transitional imports */
 export function getS3Client() {
-	return getR2Client();
+  return getR2Client();
 }
 
 export function r2ObjectUrl(key, bucket = BUCKET) {
-	requireCreds();
-	const encoded = String(key)
-		.split("/")
-		.map((part) => encodeURIComponent(part))
-		.join("/");
-	return `https://${R2_ACCOUNT_ID}.r2.cloudflarestorage.com/${bucket}/${encoded}`;
+  requireCreds();
+  const encoded = String(key)
+    .split("/")
+    .map((part) => encodeURIComponent(part))
+    .join("/");
+  return `https://${R2_ACCOUNT_ID}.r2.cloudflarestorage.com/${bucket}/${encoded}`;
 }
 
 /**
@@ -50,18 +51,18 @@ export function r2ObjectUrl(key, bucket = BUCKET) {
  * @param {{ contentType?: string, bucket?: string }} [opts]
  */
 export async function r2Put(key, body, opts = {}) {
-	const client = getR2Client();
-	const bucket = opts.bucket || BUCKET;
-	const contentType = opts.contentType || "application/octet-stream";
-	const res = await client.fetch(r2ObjectUrl(key, bucket), {
-		method: "PUT",
-		headers: { "Content-Type": contentType },
-		body,
-	});
-	if (!res.ok) {
-		const text = await res.text().catch(() => "");
-		throw new Error(`R2 PUT ${bucket}/${key} → ${res.status}: ${text.slice(0, 300)}`);
-	}
+  const client = getR2Client();
+  const bucket = opts.bucket || BUCKET;
+  const contentType = opts.contentType || "application/octet-stream";
+  const res = await client.fetch(r2ObjectUrl(key, bucket), {
+    method: "PUT",
+    headers: { "Content-Type": contentType },
+    body,
+  });
+  if (!res.ok) {
+    const text = await res.text().catch(() => "");
+    throw new Error(`R2 PUT ${bucket}/${key} → ${res.status}: ${text.slice(0, 300)}`);
+  }
 }
 
 /**
@@ -70,14 +71,14 @@ export async function r2Put(key, body, opts = {}) {
  * @returns {Promise<Buffer>}
  */
 export async function r2Get(key, opts = {}) {
-	const client = getR2Client();
-	const bucket = opts.bucket || BUCKET;
-	const res = await client.fetch(r2ObjectUrl(key, bucket), { method: "GET" });
-	if (!res.ok) {
-		const text = await res.text().catch(() => "");
-		throw new Error(`R2 GET ${bucket}/${key} → ${res.status}: ${text.slice(0, 300)}`);
-	}
-	return Buffer.from(await res.arrayBuffer());
+  const client = getR2Client();
+  const bucket = opts.bucket || BUCKET;
+  const res = await client.fetch(r2ObjectUrl(key, bucket), { method: "GET" });
+  if (!res.ok) {
+    const text = await res.text().catch(() => "");
+    throw new Error(`R2 GET ${bucket}/${key} → ${res.status}: ${text.slice(0, 300)}`);
+  }
+  return Buffer.from(await res.arrayBuffer());
 }
 
 /**
@@ -86,22 +87,22 @@ export async function r2Get(key, opts = {}) {
  * @returns {Promise<{ exists: boolean, lastModified: string | null, size: number | null }>}
  */
 export async function r2Head(key, opts = {}) {
-	const client = getR2Client();
-	const bucket = opts.bucket || BUCKET;
-	const res = await client.fetch(r2ObjectUrl(key, bucket), { method: "HEAD" });
-	if (res.status === 404) {
-		return { exists: false, lastModified: null, size: null };
-	}
-	if (!res.ok) {
-		throw new Error(`R2 HEAD ${bucket}/${key} → ${res.status}`);
-	}
-	const lastModified = res.headers.get("last-modified");
-	const sizeRaw = res.headers.get("content-length");
-	return {
-		exists: true,
-		lastModified: lastModified ? new Date(lastModified).toISOString() : null,
-		size: sizeRaw ? Number(sizeRaw) : null,
-	};
+  const client = getR2Client();
+  const bucket = opts.bucket || BUCKET;
+  const res = await client.fetch(r2ObjectUrl(key, bucket), { method: "HEAD" });
+  if (res.status === 404) {
+    return { exists: false, lastModified: null, size: null };
+  }
+  if (!res.ok) {
+    throw new Error(`R2 HEAD ${bucket}/${key} → ${res.status}`);
+  }
+  const lastModified = res.headers.get("last-modified");
+  const sizeRaw = res.headers.get("content-length");
+  return {
+    exists: true,
+    lastModified: lastModified ? new Date(lastModified).toISOString() : null,
+    size: sizeRaw ? Number(sizeRaw) : null,
+  };
 }
 
 /**
@@ -109,38 +110,32 @@ export async function r2Head(key, opts = {}) {
  * Used by validate-lake-contracts.mjs after materialize.
  */
 export const LAKE_SCHEMA_CONTRACTS = {
-	"lake/transactions/transactions.parquet": [
-		"transaction_id",
-		"email",
-		"type",
-		"status",
-		"amount_cents",
-		"currency",
-		"created_at",
-	],
-	"lake/gsc-keywords/keywords.parquet": [
-		"query",
-		"page",
-		"clicks",
-		"impressions",
-		"ctr",
-		"position",
-	],
-	"lake/sentry-issues/issues.parquet": ["issue_id", "title", "level", "status", "count_14d"],
-	"lake/linkedin-ads/insights.parquet": [
-		"campaign_id",
-		"day",
-		"impressions",
-		"clicks",
-		"spend",
-	],
-	"lake/espocrm-contacts/contacts.parquet": ["contact_id", "email"],
-	"lake/espocrm-opportunities/opportunities.parquet": ["opportunity_id", "stage", "amount"],
-	"lake/clients/clients.parquet": ["user_id", "email"],
-	"lake/n8n-workflows/workflows.parquet": ["workflow_id", "name", "active"],
-	"lake/n8n-executions/executions.parquet": ["execution_id", "status"],
-	"lake/postiz-posts/posts.parquet": ["post_id", "state"],
-	"lake/appflowy-workspaces/workspaces.parquet": ["workspace_id"],
-	"ml-parquet/scores_rfm.parquet": ["email", "rfm_score"],
-	"ml-parquet/scores_churn.parquet": ["email", "churn_score"],
+  "lake/transactions/transactions.parquet": [
+    "transaction_id",
+    "email",
+    "type",
+    "status",
+    "amount_cents",
+    "currency",
+    "created_at",
+  ],
+  "lake/gsc-keywords/keywords.parquet": [
+    "query",
+    "page",
+    "clicks",
+    "impressions",
+    "ctr",
+    "position",
+  ],
+  "lake/sentry-issues/issues.parquet": ["issue_id", "title", "level", "status", "count_14d"],
+  "lake/linkedin-ads/insights.parquet": ["campaign_id", "day", "impressions", "clicks", "spend"],
+  "lake/espocrm-contacts/contacts.parquet": ["contact_id", "email"],
+  "lake/espocrm-opportunities/opportunities.parquet": ["opportunity_id", "stage", "amount"],
+  "lake/clients/clients.parquet": ["user_id", "email"],
+  "lake/n8n-workflows/workflows.parquet": ["workflow_id", "name", "active"],
+  "lake/n8n-executions/executions.parquet": ["execution_id", "status"],
+  "lake/postiz-posts/posts.parquet": ["post_id", "state"],
+  "lake/appflowy-workspaces/workspaces.parquet": ["workspace_id"],
+  "ml-parquet/scores_rfm.parquet": ["email", "rfm_score"],
+  "ml-parquet/scores_churn.parquet": ["email", "churn_score"],
 };

--- a/scripts/r2-cors-policy.js
+++ b/scripts/r2-cors-policy.js
@@ -54,9 +54,7 @@ async function setCorsPolicy() {
     console.log(`✅ CORS policy set on ${BUCKET_NAME}`);
   } catch (error) {
     console.error("❌ CORS setup failed:", error instanceof Error ? error.message : error);
-    console.log(
-      "\nManual alternative: Cloudflare Dashboard → R2 → bucket → Settings → CORS"
-    );
+    console.log("\nManual alternative: Cloudflare Dashboard → R2 → bucket → Settings → CORS");
     process.exit(1);
   }
 }

--- a/src/app/api/admin/users/[id]/route.ts
+++ b/src/app/api/admin/users/[id]/route.ts
@@ -6,12 +6,7 @@
  */
 import { NextRequest, NextResponse } from "next/server";
 import { requireAdmin } from "@/lib/api-auth";
-import {
-  getAuthDbFromEnv,
-  getUserById,
-  isAdmin,
-  patchUserProfile,
-} from "@/lib/auth-d1";
+import { getAuthDbFromEnv, getUserById, isAdmin, patchUserProfile } from "@/lib/auth-d1";
 
 export async function GET(request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
   const auth = await requireAdmin(request);

--- a/src/app/api/admin/users/route.ts
+++ b/src/app/api/admin/users/route.ts
@@ -1,11 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { requireAdmin } from "@/lib/api-auth";
-import {
-  getAuthDbFromEnv,
-  listUsers,
-  setUserAdminRole,
-  setUserDisabled,
-} from "@/lib/auth-d1";
+import { getAuthDbFromEnv, listUsers, setUserAdminRole, setUserDisabled } from "@/lib/auth-d1";
 
 interface AdminUser {
   username: string;

--- a/src/app/api/auth/activate/route.ts
+++ b/src/app/api/auth/activate/route.ts
@@ -1,40 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
-import { createHmac, timingSafeEqual } from "crypto";
 import { rateLimit, getClientIp } from "@/lib/rate-limit";
 import { getAuthDbFromEnv, markEmailVerified } from "@/lib/auth-d1";
-
-function verifyToken(email: string, token: string): boolean {
-  const parts = token.split(".");
-  if (parts.length !== 3) return false;
-  const [nonce, expStr, sig] = parts;
-  const exp = parseInt(expStr, 10);
-  if (isNaN(exp) || Date.now() > exp) return false;
-  const secret = process.env.AUTH_SECRET ?? process.env.NEXTAUTH_SECRET ?? "";
-  const expected = createHmac("sha256", secret)
-    .update(`${email}:${exp}:${nonce}`)
-    .digest("base64url");
-  const a = Buffer.from(sig);
-  const b = Buffer.from(expected);
-  return a.length === b.length && timingSafeEqual(a, b);
-}
-
-function verifyOtp(email: string, otp: string, token: string): boolean {
-  if (!verifyToken(email, token)) return false;
-  const [nonce, expStr] = token.split(".");
-  const exp = parseInt(expStr, 10);
-  const secret = process.env.AUTH_SECRET ?? process.env.NEXTAUTH_SECRET ?? "";
-  const expected = (
-    parseInt(
-      createHmac("sha256", secret).update(`otp:${email}:${exp}:${nonce}`).digest("hex").slice(0, 8),
-      16
-    ) % 1_000_000
-  )
-    .toString()
-    .padStart(6, "0");
-  const a = Buffer.from(otp.trim());
-  const b = Buffer.from(expected);
-  return a.length === b.length && timingSafeEqual(a, b);
-}
+import { verifyActivationOtp, verifyActivationToken } from "@/lib/auth-activation";
 
 async function confirmUserD1(email: string): Promise<boolean> {
   const db = getAuthDbFromEnv();
@@ -51,10 +18,9 @@ export async function GET(req: NextRequest) {
   const email = searchParams.get("email")?.toLowerCase().trim();
   const token = searchParams.get("token");
 
-  const base = new URL(req.url);
-  const origin = base.origin;
+  const origin = new URL(req.url).origin;
 
-  if (!email || !token || !verifyToken(email, token))
+  if (!email || !token || !verifyActivationToken(email, token))
     return NextResponse.redirect(`${origin}/en/auth/signup?activated=invalid`);
 
   const ok = await confirmUserD1(email);
@@ -83,7 +49,7 @@ export async function POST(req: NextRequest) {
   if (!email || !otp || !token)
     return NextResponse.json({ error: "email, otp, and token required" }, { status: 400 });
 
-  if (!verifyOtp(email, otp, token))
+  if (!verifyActivationOtp(email, otp, token))
     return NextResponse.json({ error: "Invalid or expired code" }, { status: 400 });
 
   const ok = await confirmUserD1(email);

--- a/src/app/api/auth/confirm/route.ts
+++ b/src/app/api/auth/confirm/route.ts
@@ -1,40 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
-import { createHmac, timingSafeEqual } from "crypto";
 import { rateLimit, getClientIp } from "@/lib/rate-limit";
 import { getAuthDbFromEnv, markEmailVerified } from "@/lib/auth-d1";
-
-function verifyToken(email: string, token: string): boolean {
-  const parts = token.split(".");
-  if (parts.length !== 3) return false;
-  const [nonce, expStr, sig] = parts;
-  const exp = parseInt(expStr, 10);
-  if (isNaN(exp) || Date.now() > exp) return false;
-  const secret = process.env.AUTH_SECRET ?? process.env.NEXTAUTH_SECRET ?? "";
-  const expected = createHmac("sha256", secret)
-    .update(`${email}:${exp}:${nonce}`)
-    .digest("base64url");
-  const a = Buffer.from(sig);
-  const b = Buffer.from(expected);
-  return a.length === b.length && timingSafeEqual(a, b);
-}
-
-function verifyOtp(email: string, otp: string, token: string): boolean {
-  if (!verifyToken(email, token)) return false;
-  const [nonce, expStr] = token.split(".");
-  const exp = parseInt(expStr, 10);
-  const secret = process.env.AUTH_SECRET ?? process.env.NEXTAUTH_SECRET ?? "";
-  const expected = (
-    parseInt(
-      createHmac("sha256", secret).update(`otp:${email}:${exp}:${nonce}`).digest("hex").slice(0, 8),
-      16
-    ) % 1_000_000
-  )
-    .toString()
-    .padStart(6, "0");
-  const a = Buffer.from(otp.trim());
-  const b = Buffer.from(expected);
-  return a.length === b.length && timingSafeEqual(a, b);
-}
+import { verifyActivationOtp } from "@/lib/auth-activation";
 
 /**
  * POST /api/auth/confirm — D1 email verification.
@@ -65,7 +32,7 @@ export async function POST(req: NextRequest) {
       { status: 400 }
     );
 
-  if (!verifyOtp(email, code, token))
+  if (!verifyActivationOtp(email, code, token))
     return NextResponse.json({ error: "Invalid or expired code" }, { status: 400 });
 
   const db = getAuthDbFromEnv();

--- a/src/lib/auth-activation.ts
+++ b/src/lib/auth-activation.ts
@@ -1,0 +1,42 @@
+/**
+ * Shared HMAC token + OTP helpers for D1 signup activation / confirmation.
+ */
+import { createHmac, timingSafeEqual } from "crypto";
+
+function authSecret(): string {
+  return process.env.AUTH_SECRET ?? process.env.NEXTAUTH_SECRET ?? "";
+}
+
+export function verifyActivationToken(email: string, token: string): boolean {
+  const parts = token.split(".");
+  if (parts.length !== 3) return false;
+  const [nonce, expStr, sig] = parts;
+  const exp = parseInt(expStr, 10);
+  if (isNaN(exp) || Date.now() > exp) return false;
+  const expected = createHmac("sha256", authSecret())
+    .update(`${email}:${exp}:${nonce}`)
+    .digest("base64url");
+  const a = Buffer.from(sig);
+  const b = Buffer.from(expected);
+  return a.length === b.length && timingSafeEqual(a, b);
+}
+
+export function verifyActivationOtp(email: string, otp: string, token: string): boolean {
+  if (!verifyActivationToken(email, token)) return false;
+  const [nonce, expStr] = token.split(".");
+  const exp = parseInt(expStr, 10);
+  const expected = (
+    parseInt(
+      createHmac("sha256", authSecret())
+        .update(`otp:${email}:${exp}:${nonce}`)
+        .digest("hex")
+        .slice(0, 8),
+      16
+    ) % 1_000_000
+  )
+    .toString()
+    .padStart(6, "0");
+  const a = Buffer.from(otp.trim());
+  const b = Buffer.from(expected);
+  return a.length === b.length && timingSafeEqual(a, b);
+}


### PR DESCRIPTION
## Summary
- Extract shared `auth-activation.ts` (fixes Sonar **12.1% duplication** on PR-04)
- Prettier admin users routes + R2 helpers
- Fix MD031 in `docs/databases/omv-cluster.md`

## Test plan
- [x] vitest auth-activate + admin-users
- [x] markdownlint omv-cluster.md
- [ ] CI / Sonar green


Made with [Cursor](https://cursor.com)