### PR TITLE
fix(test): opaque D1 sessions for API contracts after Cognito removal

### DIFF
--- a/__tests__/admin-ab-tests-api.test.ts
+++ b/__tests__/admin-ab-tests-api.test.ts
@@ -20,31 +20,11 @@ vi.mock("jose", async () => {
 });
 
 function makeAdminToken(): string {
-  const payload = {
-    sub: "admin-sub",
-    groups: ["admin"],
-    aud: "client",
-    iss: "https://cognito-idp.us-east-1.amazonaws.com/pool",
-    iat: Math.floor(Date.now() / 1000) - 10,
-    exp: Math.floor(Date.now() / 1000) + 3600,
-  };
-  const h = Buffer.from("{}").toString("base64url");
-  const b = Buffer.from(JSON.stringify(payload)).toString("base64url");
-  return `${h}.${b}.sig`;
+  return "test-admin-session";
 }
 
 function makeUserToken(): string {
-  const payload = {
-    sub: "user-sub",
-    groups: [],
-    aud: "client",
-    iss: "https://cognito-idp.us-east-1.amazonaws.com/pool",
-    iat: Math.floor(Date.now() / 1000) - 10,
-    exp: Math.floor(Date.now() / 1000) + 3600,
-  };
-  const h = Buffer.from("{}").toString("base64url");
-  const b = Buffer.from(JSON.stringify(payload)).toString("base64url");
-  return `${h}.${b}.sig`;
+  return "test-user-session";
 }
 
 function adminReq(url: string, init?: { method?: string; body?: string }): NextRequest {

--- a/__tests__/admin-ai-analytics-orchestration-api.test.ts
+++ b/__tests__/admin-ai-analytics-orchestration-api.test.ts
@@ -34,18 +34,7 @@ vi.mock("@/lib/analytics-agent-orchestrator", () => ({
 }));
 
 function makeAdminToken(): string {
-  const payload = {
-    sub: "test-admin-sub",
-    email: "admin@cloudless.gr",
-    groups: ["admin"],
-    aud: "test-client-id",
-    iss: "https://auth.cloudless.gr/realms/cloudless",
-    iat: Math.floor(Date.now() / 1000) - 60,
-    exp: Math.floor(Date.now() / 1000) + 3600,
-  };
-  const header = Buffer.from(JSON.stringify({ alg: "RS256", typ: "JWT" })).toString("base64url");
-  const body = Buffer.from(JSON.stringify(payload)).toString("base64url");
-  return `${header}.${body}.fake-sig`;
+  return "test-admin-session";
 }
 
 function adminReq(body?: Record<string, unknown>): NextRequest {

--- a/__tests__/admin-ai-analytics-orchestration-pdf-api.test.ts
+++ b/__tests__/admin-ai-analytics-orchestration-pdf-api.test.ts
@@ -34,18 +34,7 @@ vi.mock("@/lib/analytics-agent-orchestrator", () => ({
 }));
 
 function makeAdminToken(): string {
-  const payload = {
-    sub: "test-admin-sub",
-    email: "admin@cloudless.gr",
-    groups: ["admin"],
-    aud: "test-client-id",
-    iss: "https://auth.cloudless.gr/realms/cloudless",
-    iat: Math.floor(Date.now() / 1000) - 60,
-    exp: Math.floor(Date.now() / 1000) + 3600,
-  };
-  const header = Buffer.from(JSON.stringify({ alg: "RS256", typ: "JWT" })).toString("base64url");
-  const body = Buffer.from(JSON.stringify(payload)).toString("base64url");
-  return `${header}.${body}.fake-sig`;
+  return "test-admin-session";
 }
 
 function adminReq(body?: Record<string, unknown>): NextRequest {

--- a/__tests__/admin-ai-api.test.ts
+++ b/__tests__/admin-ai-api.test.ts
@@ -34,18 +34,7 @@ vi.stubGlobal("fetch", fetchMock);
 // Helpers
 // ---------------------------------------------------------------------------
 function makeAdminToken(): string {
-  const payload = {
-    sub: "test-admin-sub",
-    email: "admin@cloudless.gr",
-    groups: ["admin"],
-    aud: "test-client-id",
-    iss: "https://auth.cloudless.gr/realms/cloudless",
-    iat: Math.floor(Date.now() / 1000) - 60,
-    exp: Math.floor(Date.now() / 1000) + 3600,
-  };
-  const header = Buffer.from(JSON.stringify({ alg: "RS256", typ: "JWT" })).toString("base64url");
-  const body = Buffer.from(JSON.stringify(payload)).toString("base64url");
-  return `${header}.${body}.fake-sig`;
+  return "test-admin-session";
 }
 
 function adminReq(url: string, body?: Record<string, unknown>): NextRequest {

--- a/__tests__/admin-analytics-api.test.ts
+++ b/__tests__/admin-analytics-api.test.ts
@@ -57,18 +57,7 @@ vi.mock("@/lib/gsc", () => ({
 // Helpers
 // ---------------------------------------------------------------------------
 function makeAdminToken(): string {
-  const payload = {
-    sub: "test-admin-sub",
-    email: "admin@cloudless.gr",
-    groups: ["admin"],
-    aud: "test-client-id",
-    iss: "https://auth.cloudless.gr/realms/cloudless",
-    iat: Math.floor(Date.now() / 1000) - 60,
-    exp: Math.floor(Date.now() / 1000) + 3600,
-  };
-  const header = Buffer.from(JSON.stringify({ alg: "RS256", typ: "JWT" })).toString("base64url");
-  const body = Buffer.from(JSON.stringify(payload)).toString("base64url");
-  return `${header}.${body}.fake-sig`;
+  return "test-admin-session";
 }
 
 function adminReq(url: string): NextRequest {

--- a/__tests__/admin-api.test.ts
+++ b/__tests__/admin-api.test.ts
@@ -141,34 +141,12 @@ vi.mock("jose", async () => {
 /** Build a mock admin JWT with Cognito-style claims. No real signature —
  *  verifyToken falls back to decode-only when COGNITO_ISSUER is unset. */
 function makeAdminToken(): string {
-  const payload = {
-    sub: "test-admin-sub",
-    email: "admin@cloudless.gr",
-    preferred_username: "admin-user",
-    groups: ["admin"],
-    iss: "https://cognito-idp.us-east-1.amazonaws.com/us-east-1_TEST",
-    iat: Math.floor(Date.now() / 1000) - 60,
-    exp: Math.floor(Date.now() / 1000) + 3600,
-  };
-  const header = Buffer.from(JSON.stringify({ alg: "RS256", typ: "JWT" })).toString("base64url");
-  const body = Buffer.from(JSON.stringify(payload)).toString("base64url");
-  return `${header}.${body}.fake-sig`;
+  return "test-admin-session";
 }
 
 /** Build a mock non-admin JWT with Cognito-style claims. */
 function makeUserToken(): string {
-  const payload = {
-    sub: "test-user-sub",
-    email: "user@cloudless.gr",
-    preferred_username: "regular-user",
-    groups: [],
-    iss: "https://cognito-idp.us-east-1.amazonaws.com/us-east-1_TEST",
-    iat: Math.floor(Date.now() / 1000) - 60,
-    exp: Math.floor(Date.now() / 1000) + 3600,
-  };
-  const header = Buffer.from(JSON.stringify({ alg: "RS256", typ: "JWT" })).toString("base64url");
-  const body = Buffer.from(JSON.stringify(payload)).toString("base64url");
-  return `${header}.${body}.fake-sig`;
+  return "test-user-session";
 }
 
 function adminRequest(url: string, init?: RequestInit): NextRequest {

--- a/__tests__/admin-autologin-api.test.ts
+++ b/__tests__/admin-autologin-api.test.ts
@@ -90,18 +90,8 @@ beforeEach(() => {
 // Token helpers — mirrors admin-api.test.ts pattern
 // ---------------------------------------------------------------------------
 
-function makeToken(groups: string[]): string {
-  const payload = {
-    sub: "test-sub",
-    email: "test@cloudless.gr",
-    groups,
-    iss: "https://cognito-idp.us-east-1.amazonaws.com/us-east-1_TEST",
-    iat: Math.floor(Date.now() / 1000) - 60,
-    exp: Math.floor(Date.now() / 1000) + 3600,
-  };
-  const header = Buffer.from(JSON.stringify({ alg: "RS256", typ: "JWT" })).toString("base64url");
-  const body = Buffer.from(JSON.stringify(payload)).toString("base64url");
-  return `${header}.${body}.fake-sig`;
+function makeToken(isAdmin = false): string {
+  return isAdmin ? "test-admin-session" : "test-user-session";
 }
 
 function adminRequest(url: string): NextRequest {

--- a/__tests__/admin-cache-api.test.ts
+++ b/__tests__/admin-cache-api.test.ts
@@ -35,28 +35,12 @@ vi.mock("@/lib/notion-cache", () => ({
 
 /** Build a fake admin JWT. No real signature -- accepted by the dev fallback. */
 function makeAdminToken(): string {
-  const payload = {
-    sub: "test-admin",
-    email: "admin@cloudless.gr",
-    groups: ["admin"],
-    exp: Math.floor(Date.now() / 1000) + 3600,
-  };
-  const header = Buffer.from(JSON.stringify({ alg: "RS256" })).toString("base64url");
-  const body = Buffer.from(JSON.stringify(payload)).toString("base64url");
-  return `${header}.${body}.fake-sig`;
+  return "test-admin-session";
 }
 
 /** Build a fake non-admin JWT. */
 function makeUserToken(): string {
-  const payload = {
-    sub: "test-user",
-    email: "user@cloudless.gr",
-    groups: [],
-    exp: Math.floor(Date.now() / 1000) + 3600,
-  };
-  const header = Buffer.from(JSON.stringify({ alg: "RS256" })).toString("base64url");
-  const body = Buffer.from(JSON.stringify(payload)).toString("base64url");
-  return `${header}.${body}.fake-sig`;
+  return "test-user-session";
 }
 
 /** POST with admin token and optional JSON body. */

--- a/__tests__/admin-campaigns-api.test.ts
+++ b/__tests__/admin-campaigns-api.test.ts
@@ -68,18 +68,7 @@ vi.mock("@/lib/campaigns/x-ads", () => ({
 // Helpers
 // ---------------------------------------------------------------------------
 function makeAdminToken(): string {
-  const payload = {
-    sub: "test-admin-sub",
-    email: "admin@cloudless.gr",
-    groups: ["admin"],
-    aud: "test-client-id",
-    iss: "https://auth.cloudless.gr/realms/cloudless",
-    iat: Math.floor(Date.now() / 1000) - 60,
-    exp: Math.floor(Date.now() / 1000) + 3600,
-  };
-  const header = Buffer.from(JSON.stringify({ alg: "RS256", typ: "JWT" })).toString("base64url");
-  const body = Buffer.from(JSON.stringify(payload)).toString("base64url");
-  return `${header}.${body}.fake-sig`;
+  return "test-admin-session";
 }
 
 function adminReq(url: string): NextRequest {

--- a/__tests__/admin-client-portals-api.test.ts
+++ b/__tests__/admin-client-portals-api.test.ts
@@ -25,17 +25,7 @@ vi.mock("jose", async () => {
 // JWT helpers
 // ---------------------------------------------------------------------------
 function makeAdminToken(): string {
-  const payload = {
-    sub: "admin-sub",
-    groups: ["admin"],
-    aud: "client",
-    iss: "https://cognito-idp.us-east-1.amazonaws.com/pool",
-    iat: Math.floor(Date.now() / 1000) - 10,
-    exp: Math.floor(Date.now() / 1000) + 3600,
-  };
-  const h = Buffer.from("{}").toString("base64url");
-  const b = Buffer.from(JSON.stringify(payload)).toString("base64url");
-  return `${h}.${b}.sig`;
+  return "test-admin-session";
 }
 
 function adminReq(url: string, init?: { method?: string; body?: string }): NextRequest {

--- a/__tests__/admin-kpi-api.test.ts
+++ b/__tests__/admin-kpi-api.test.ts
@@ -60,19 +60,8 @@ vi.mock("@/lib/notion-projects", () => ({
 // ---------------------------------------------------------------------------
 // JWT helpers
 // ---------------------------------------------------------------------------
-function makeToken(groups: string[]): string {
-  const payload = {
-    sub: "user-sub",
-    email: "user@test.com",
-    groups: groups,
-    aud: "test-client",
-    iss: "https://auth.cloudless.gr/realms/cloudless",
-    iat: Math.floor(Date.now() / 1000) - 60,
-    exp: Math.floor(Date.now() / 1000) + 3600,
-  };
-  const h = Buffer.from(JSON.stringify({ alg: "RS256" })).toString("base64url");
-  const b = Buffer.from(JSON.stringify(payload)).toString("base64url");
-  return `${h}.${b}.sig`;
+function makeToken(isAdmin = false): string {
+  return isAdmin ? "test-admin-session" : "test-user-session";
 }
 
 function adminReq(url: string): NextRequest {

--- a/__tests__/admin-notion-blog-api.test.ts
+++ b/__tests__/admin-notion-blog-api.test.ts
@@ -36,19 +36,7 @@ vi.mock("@/lib/notion-blog", () => ({
 // Helpers
 // ---------------------------------------------------------------------------
 function makeAdminToken(): string {
-  const payload = {
-    sub: "test-admin-sub",
-    email: "admin@cloudless.gr",
-    preferred_username: "admin-user",
-    groups: ["admin"],
-    aud: "test-client-id",
-    iss: "https://auth.cloudless.gr/realms/cloudless",
-    iat: Math.floor(Date.now() / 1000) - 60,
-    exp: Math.floor(Date.now() / 1000) + 3600,
-  };
-  const header = Buffer.from(JSON.stringify({ alg: "RS256", typ: "JWT" })).toString("base64url");
-  const body = Buffer.from(JSON.stringify(payload)).toString("base64url");
-  return `${header}.${body}.fake-sig`;
+  return "test-admin-session";
 }
 
 function adminRequest(url: string): NextRequest {

--- a/__tests__/admin-notion-docs-api.test.ts
+++ b/__tests__/admin-notion-docs-api.test.ts
@@ -36,19 +36,7 @@ vi.mock("@/lib/notion-docs", () => ({
 // Helpers
 // ---------------------------------------------------------------------------
 function makeAdminToken(): string {
-  const payload = {
-    sub: "test-admin-sub",
-    email: "admin@cloudless.gr",
-    preferred_username: "admin-user",
-    groups: ["admin"],
-    aud: "test-client-id",
-    iss: "https://auth.cloudless.gr/realms/cloudless",
-    iat: Math.floor(Date.now() / 1000) - 60,
-    exp: Math.floor(Date.now() / 1000) + 3600,
-  };
-  const header = Buffer.from(JSON.stringify({ alg: "RS256", typ: "JWT" })).toString("base64url");
-  const body = Buffer.from(JSON.stringify(payload)).toString("base64url");
-  return `${header}.${body}.fake-sig`;
+  return "test-admin-session";
 }
 
 function adminRequest(url: string): NextRequest {

--- a/__tests__/admin-notion-submissions-api.test.ts
+++ b/__tests__/admin-notion-submissions-api.test.ts
@@ -27,18 +27,7 @@ vi.mock("@/lib/notion-forms", () => ({
 }));
 
 function makeAdminToken(): string {
-  const payload = {
-    sub: "admin-sub",
-    email: "admin@cloudless.gr",
-    groups: ["admin"],
-    aud: "test-client-id",
-    iss: "https://auth.cloudless.gr/realms/cloudless",
-    iat: Math.floor(Date.now() / 1000) - 60,
-    exp: Math.floor(Date.now() / 1000) + 3600,
-  };
-  const header = Buffer.from(JSON.stringify({ alg: "RS256", typ: "JWT" })).toString("base64url");
-  const body = Buffer.from(JSON.stringify(payload)).toString("base64url");
-  return `${header}.${body}.fake-sig`;
+  return "test-admin-session";
 }
 
 function adminReq(url: string, init?: RequestInit): NextRequest {

--- a/__tests__/admin-notion-tasks-api.test.ts
+++ b/__tests__/admin-notion-tasks-api.test.ts
@@ -33,18 +33,7 @@ vi.mock("@/lib/notion-projects", () => ({
 }));
 
 function makeAdminToken(): string {
-  const payload = {
-    sub: "admin-sub",
-    email: "admin@cloudless.gr",
-    groups: ["admin"],
-    aud: "test-client-id",
-    iss: "https://auth.cloudless.gr/realms/cloudless",
-    iat: Math.floor(Date.now() / 1000) - 60,
-    exp: Math.floor(Date.now() / 1000) + 3600,
-  };
-  const header = Buffer.from(JSON.stringify({ alg: "RS256", typ: "JWT" })).toString("base64url");
-  const body = Buffer.from(JSON.stringify(payload)).toString("base64url");
-  return `${header}.${body}.fake-sig`;
+  return "test-admin-session";
 }
 
 function adminReq(url: string, init?: RequestInit): NextRequest {

--- a/__tests__/admin-subscriptions-api.test.ts
+++ b/__tests__/admin-subscriptions-api.test.ts
@@ -36,31 +36,11 @@ vi.mock("@/lib/stripe", () => ({
 // JWT helpers
 // ---------------------------------------------------------------------------
 function makeAdminToken(): string {
-  const payload = {
-    sub: "admin-sub",
-    groups: ["admin"],
-    aud: "client",
-    iss: "https://cognito-idp.us-east-1.amazonaws.com/pool",
-    iat: Math.floor(Date.now() / 1000) - 10,
-    exp: Math.floor(Date.now() / 1000) + 3600,
-  };
-  const h = Buffer.from("{}").toString("base64url");
-  const b = Buffer.from(JSON.stringify(payload)).toString("base64url");
-  return `${h}.${b}.sig`;
+  return "test-admin-session";
 }
 
 function makeUserToken(): string {
-  const payload = {
-    sub: "user-sub",
-    groups: [],
-    aud: "client",
-    iss: "https://cognito-idp.us-east-1.amazonaws.com/pool",
-    iat: Math.floor(Date.now() / 1000) - 10,
-    exp: Math.floor(Date.now() / 1000) + 3600,
-  };
-  const h = Buffer.from("{}").toString("base64url");
-  const b = Buffer.from(JSON.stringify(payload)).toString("base64url");
-  return `${h}.${b}.sig`;
+  return "test-user-session";
 }
 
 function adminReq(url: string, init?: { method?: string; body?: string }): NextRequest {

--- a/__tests__/admin-unified-analytics-api.test.ts
+++ b/__tests__/admin-unified-analytics-api.test.ts
@@ -76,32 +76,11 @@ vi.mock("@/lib/stripe", () => ({
 // JWT helpers
 // ---------------------------------------------------------------------------
 function makeAdminToken(): string {
-  const payload = {
-    sub: "admin-sub",
-    email: "admin@test.com",
-    groups: ["admin"],
-    aud: "test-client",
-    iss: "https://auth.cloudless.gr/realms/cloudless",
-    iat: Math.floor(Date.now() / 1000) - 60,
-    exp: Math.floor(Date.now() / 1000) + 3600,
-  };
-  const h = Buffer.from(JSON.stringify({ alg: ALG_RS256 })).toString(ENC_BASE64URL);
-  const b = Buffer.from(JSON.stringify(payload)).toString(ENC_BASE64URL);
-  return `${h}.${b}.sig`;
+  return "test-admin-session";
 }
 
 function makeUserToken(): string {
-  const payload = {
-    sub: "user-sub",
-    groups: [],
-    aud: "test-client",
-    iss: "https://auth.cloudless.gr/realms/cloudless",
-    iat: Math.floor(Date.now() / 1000) - 60,
-    exp: Math.floor(Date.now() / 1000) + 3600,
-  };
-  const h = Buffer.from(JSON.stringify({ alg: ALG_RS256 })).toString(ENC_BASE64URL);
-  const b = Buffer.from(JSON.stringify(payload)).toString(ENC_BASE64URL);
-  return `${h}.${b}.sig`;
+  return "test-user-session";
 }
 
 function adminReq(url: string): NextRequest {

--- a/__tests__/admin-users-orders-ops-api.test.ts
+++ b/__tests__/admin-users-orders-ops-api.test.ts
@@ -72,18 +72,7 @@ vi.mock("@/lib/sentry", () => ({
 // Helpers
 // ---------------------------------------------------------------------------
 function makeAdminToken(): string {
-  const payload = {
-    sub: "test-admin-sub",
-    email: "admin@cloudless.gr",
-    groups: ["admin"],
-    aud: "test-client-id",
-    iss: "https://auth.cloudless.gr/realms/cloudless",
-    iat: Math.floor(Date.now() / 1000) - 60,
-    exp: Math.floor(Date.now() / 1000) + 3600,
-  };
-  const header = Buffer.from(JSON.stringify({ alg: "RS256", typ: "JWT" })).toString("base64url");
-  const body = Buffer.from(JSON.stringify(payload)).toString("base64url");
-  return `${header}.${body}.fake-sig`;
+  return "test-admin-session";
 }
 
 function adminReq(url: string, opts?: { method?: string; body?: unknown }): NextRequest {

--- a/__tests__/admin-voice-brief-api.test.ts
+++ b/__tests__/admin-voice-brief-api.test.ts
@@ -30,31 +30,11 @@ vi.mock("@/lib/agent-voice-brief", () => ({
 vi.stubGlobal("fetch", mockFetch);
 
 function makeAdminToken(): string {
-  const payload = {
-    sub: "admin-sub",
-    groups: ["admin"],
-    aud: "client",
-    iss: "https://cognito-idp.us-east-1.amazonaws.com/pool",
-    iat: Math.floor(Date.now() / 1000) - 10,
-    exp: Math.floor(Date.now() / 1000) + 3600,
-  };
-  const h = Buffer.from("{}").toString("base64url");
-  const b = Buffer.from(JSON.stringify(payload)).toString("base64url");
-  return `${h}.${b}.sig`;
+  return "test-admin-session";
 }
 
 function makeUserToken(): string {
-  const payload = {
-    sub: "user-sub",
-    groups: [],
-    aud: "client",
-    iss: "https://cognito-idp.us-east-1.amazonaws.com/pool",
-    iat: Math.floor(Date.now() / 1000) - 10,
-    exp: Math.floor(Date.now() / 1000) + 3600,
-  };
-  const h = Buffer.from("{}").toString("base64url");
-  const b = Buffer.from(JSON.stringify(payload)).toString("base64url");
-  return `${h}.${b}.sig`;
+  return "test-user-session";
 }
 
 function adminReq(url: string, init?: { method?: string; body?: string }): NextRequest {

--- a/__tests__/admin-workspaces-api.test.ts
+++ b/__tests__/admin-workspaces-api.test.ts
@@ -29,17 +29,7 @@ vi.mock("jose", async () => {
 // JWT helpers
 // ---------------------------------------------------------------------------
 function makeAdminToken(): string {
-  const payload = {
-    sub: "admin-sub",
-    groups: ["admin"],
-    aud: "client",
-    iss: "https://cognito-idp.us-east-1.amazonaws.com/pool",
-    iat: Math.floor(Date.now() / 1000) - 10,
-    exp: Math.floor(Date.now() / 1000) + 3600,
-  };
-  const h = Buffer.from("{}").toString("base64url");
-  const b = Buffer.from(JSON.stringify(payload)).toString("base64url");
-  return `${h}.${b}.sig`;
+  return "test-admin-session";
 }
 
 function adminReq(url: string, init?: { method?: string; body?: string }): NextRequest {

--- a/__tests__/setup.ts
+++ b/__tests__/setup.ts
@@ -15,6 +15,31 @@ import {
 } from "@/lib/integrations";
 import { resetSsmCache } from "@/lib/ssm-config";
 
+// ── D1 auth for API contract tests (opaque session ids) ───────────────────────
+vi.mock("@/lib/auth-d1", () => {
+  const stmt = {
+    bind: vi.fn().mockReturnThis(),
+    run: vi.fn().mockResolvedValue({ success: true }),
+    first: vi.fn().mockResolvedValue(null),
+    all: vi.fn().mockResolvedValue({ results: [] }),
+  };
+  return {
+    getAuthDbFromEnv: vi.fn(() => ({
+      prepare: vi.fn(() => stmt),
+    })),
+    getUserBySession: vi.fn(async (_db: unknown, sessionId: string) => {
+      if (sessionId === "test-admin-session") {
+        return { id: "test-admin-sub", email: "admin@cloudless.gr", name: "Admin" };
+      }
+      if (sessionId === "test-user-session") {
+        return { id: "test-user-sub", email: "user@cloudless.gr", name: "User" };
+      }
+      return null;
+    }),
+    isAdmin: vi.fn(async (_db: unknown, userId: string) => userId === "test-admin-sub"),
+  };
+});
+
 // ── Notion ────────────────────────────────────────────────────────────────────
 process.env.NOTION_API_KEY = "secret_test_key_12345";
 process.env.NOTION_BLOG_DB_ID = "blog-db-123";

--- a/docs/COGNITO_AUTOMATION.md
+++ b/docs/COGNITO_AUTOMATION.md
@@ -14,23 +14,23 @@ All three share the same underlying logic and produce identical results.
 
 ## Components
 
-### 1. Bash Script: `scripts/cognito-setup.sh`
+### 1. Bash Script: `scripts/archive/cognito/cognito-setup.sh`
 
 **Purpose:** Standalone script for local or CI-based setup
 
-**Location:** `/home/tbaltzakis/code/cloudless.gr/scripts/cognito-setup.sh`
+**Location:** `/home/tbaltzakis/code/cloudless.gr/scripts/archive/cognito/cognito-setup.sh`
 
 **Usage:**
 
 ```bash
 # Full setup with verification
-bash scripts/cognito-setup.sh
+bash scripts/archive/cognito/cognito-setup.sh
 
 # Dry run (preview without changes)
-bash scripts/cognito-setup.sh --dry-run
+bash scripts/archive/cognito/cognito-setup.sh --dry-run
 
 # Skip dev server test (faster)
-bash scripts/cognito-setup.sh --skip-verify
+bash scripts/archive/cognito/cognito-setup.sh --skip-verify
 ```
 
 **What it does:**
@@ -74,7 +74,7 @@ pnpm cognito:setup
 - Colored output (✓ success, ✗ errors, ⚠ warnings)
 - Step-by-step progress
 - Automatic backup of `.env.local`
-- Built-in help: `bash scripts/cognito-setup.sh --help`
+- Built-in help: `bash scripts/archive/cognito/cognito-setup.sh --help`
 
 ---
 
@@ -156,7 +156,7 @@ const result = await client.call("cognito_full_setup", {
 
 ```
 ┌─────────────────────────────────────────────────────────┐
-│  Level 1: Core Logic (scripts/cognito-setup.sh)         │
+│  Level 1: Core Logic (scripts/archive/cognito/cognito-setup.sh)         │
 │  - AWS auth, SSM fetch, .env.local update, dev test     │
 └──────────────────┬──────────────────────────────────────┘
                    │
@@ -303,7 +303,7 @@ gh workflow run cognito-setup.yml --ref main
 pnpm cognito:setup:dry
 
 # Verbose output
-bash -x scripts/cognito-setup.sh
+bash -x scripts/archive/cognito/cognito-setup.sh
 
 # Manual step-by-step
 aws sts get-caller-identity              # Check auth
@@ -362,7 +362,7 @@ All scripts are fully idempotent:
 
 To extend or modify the automation:
 
-1. **Update the core script:** `scripts/cognito-setup.sh`
+1. **Update the core script:** `scripts/archive/cognito/cognito-setup.sh`
 2. **Update the skill:** `.claude/skills/cognito-setup/index.md`
 3. **Update MCP tools:** `tools/cognito-setup-mcp/src/index.ts`
 4. **Update workflows:** `.github/workflows/cognito-setup.yml`

--- a/docs/COGNITO_AUTOMATION_INDEX.md
+++ b/docs/COGNITO_AUTOMATION_INDEX.md
@@ -23,7 +23,7 @@ This is your entry point for the complete Cognito setup automation system.
 
 | File | Purpose | How to Use |
 |------|---------|-----------|
-| [scripts/cognito-setup.sh](../scripts/cognito-setup.sh) | Main automation script | `bash scripts/cognito-setup.sh` |
+| [scripts/archive/cognito/cognito-setup.sh](../scripts/archive/cognito/cognito-setup.sh) | Main automation script | `bash scripts/archive/cognito/cognito-setup.sh` |
 | [tools/cognito-setup-mcp/src/index.ts](../tools/cognito-setup-mcp/src/index.ts) | MCP server for programmatic access | `npx tsx tools/cognito-setup-mcp/src/index.ts` |
 | [tools/cognito-setup-mcp/README.md](../tools/cognito-setup-mcp/README.md) | MCP API documentation | Reference when using MCP tools |
 | [.claude/skills/cognito-setup/](../.claude/skills/cognito-setup/) | Claude Code skill | `/cognito-setup` in Claude Code |
@@ -61,7 +61,7 @@ pnpm cognito:setup:quick
 
 ```bash
 # Verbose output
-bash -x scripts/cognito-setup.sh
+bash -x scripts/archive/cognito/cognito-setup.sh
 
 # Manual step-by-step
 aws sts get-caller-identity
@@ -115,7 +115,7 @@ pnpm cognito:setup
 pnpm cognito:setup:dry
 
 # Or run with verbose output
-bash -x scripts/cognito-setup.sh
+bash -x scripts/archive/cognito/cognito-setup.sh
 
 # Check the logs
 cat /tmp/dev-test.log
@@ -137,7 +137,7 @@ cat /tmp/dev-test.log
 
 ✅ **Multiple Interfaces**
 
-- CLI: `bash scripts/cognito-setup.sh`
+- CLI: `bash scripts/archive/cognito/cognito-setup.sh`
 - pnpm: `pnpm cognito:setup`
 - GitHub Actions: `# cognito-setup.yml removed — use Cognito console / AWS CLI`
 - MCP: Programmatic access via tools

--- a/docs/COGNITO_SETUP.md
+++ b/docs/COGNITO_SETUP.md
@@ -7,7 +7,7 @@ This document covers automated setup of Cognito authentication for local develop
 ### Option 1: CLI Script (Recommended)
 
 ```bash
-bash scripts/cognito-setup.sh
+bash scripts/archive/cognito/cognito-setup.sh
 ```
 
 This fully automates:
@@ -95,7 +95,7 @@ The setup script updates `.env.local`:
 ### Full Setup (Recommended)
 
 ```bash
-bash scripts/cognito-setup.sh
+bash scripts/archive/cognito/cognito-setup.sh
 ```
 
 **Output:**
@@ -126,7 +126,7 @@ Next steps:
 See what would change without making modifications:
 
 ```bash
-bash scripts/cognito-setup.sh --dry-run
+bash scripts/archive/cognito/cognito-setup.sh --dry-run
 ```
 
 ### Skip Dev Server Test
@@ -134,7 +134,7 @@ bash scripts/cognito-setup.sh --dry-run
 Faster setup if you know it works:
 
 ```bash
-bash scripts/cognito-setup.sh --skip-verify
+bash scripts/archive/cognito/cognito-setup.sh --skip-verify
 ```
 
 ## Troubleshooting
@@ -299,13 +299,13 @@ Override defaults:
 
 ```bash
 # Use different AWS region
-AWS_REGION=eu-west-1 bash scripts/cognito-setup.sh
+AWS_REGION=eu-west-1 bash scripts/archive/cognito/cognito-setup.sh
 
 # Use different SSM path prefix
-SSM_PREFIX=/custom/path/COGNITO_CLIENT_ID bash scripts/cognito-setup.sh
+SSM_PREFIX=/custom/path/COGNITO_CLIENT_ID bash scripts/archive/cognito/cognito-setup.sh
 
 # Custom pool ID (for testing)
-POOL_ID=us-west-2_XYZ123 bash scripts/cognito-setup.sh
+POOL_ID=us-west-2_XYZ123 bash scripts/archive/cognito/cognito-setup.sh
 ```
 
 ## Advanced: Manual Setup
@@ -334,7 +334,7 @@ curl http://localhost:4000/en
 Enable verbose output:
 
 ```bash
-bash -x scripts/cognito-setup.sh
+bash -x scripts/archive/cognito/cognito-setup.sh
 ```
 
 Check logs:

--- a/docs/COGNITO_SETUP_CHECKLIST.md
+++ b/docs/COGNITO_SETUP_CHECKLIST.md
@@ -4,7 +4,7 @@
 
 ### Core Automation
 
-- [x] `scripts/cognito-setup.sh` — Main bash script (338 lines)
+- [x] `scripts/archive/cognito/cognito-setup.sh` — Main bash script (338 lines)
   - [x] AWS CLI validation
   - [x] AWS credential checking
   - [x] SSO fallback

--- a/docs/COGNITO_SETUP_SUMMARY.md
+++ b/docs/COGNITO_SETUP_SUMMARY.md
@@ -6,7 +6,7 @@ I've created a comprehensive automated tooling suite for Cognito authentication 
 
 ```bash
 # Option 1: Simple bash script
-bash scripts/cognito-setup.sh
+bash scripts/archive/cognito/cognito-setup.sh
 
 # Option 2: pnpm aliases
 pnpm cognito:setup                 # Full setup
@@ -32,7 +32,7 @@ All options automatically:
 
 ### Core Script
 
-- **`scripts/cognito-setup.sh`** (338 lines)
+- **`scripts/archive/cognito/cognito-setup.sh`** (338 lines)
   - Main automation logic
   - Handles AWS auth, SSM fetch, .env update, dev test
   - Supports `--dry-run` and `--skip-verify` flags
@@ -80,7 +80,7 @@ All options automatically:
 ```
 Three-Layer Design:
 
-Layer 1: Core Script (scripts/cognito-setup.sh)
+Layer 1: Core Script (scripts/archive/cognito/cognito-setup.sh)
 ├─ AWS authentication
 ├─ SSM parameter fetch
 ├─ .env.local update
@@ -132,7 +132,7 @@ gh workflow run cognito-setup.yml
 pnpm cognito:setup:dry
 
 # Verbose output
-bash -x scripts/cognito-setup.sh
+bash -x scripts/archive/cognito/cognito-setup.sh
 
 # Skip dev server test (faster)
 pnpm cognito:setup:quick
@@ -237,7 +237,7 @@ gh workflow run cognito-setup.yml
 
 ```bash
 pnpm cognito:setup:dry
-bash -x scripts/cognito-setup.sh
+bash -x scripts/archive/cognito/cognito-setup.sh
 ```
 
 → Diagnose issues step-by-step
@@ -312,7 +312,7 @@ If something doesn't work:
 
 1. Check the error message — it includes the solution
 2. Try dry-run to see what would happen: `pnpm cognito:setup:dry`
-3. Check logs: `bash -x scripts/cognito-setup.sh`
+3. Check logs: `bash -x scripts/archive/cognito/cognito-setup.sh`
 4. Read `COGNITO_SETUP.md` (sibling) troubleshooting section
 5. Ask in #cloudless Slack or open an issue
 

--- a/docs/test-accounts.md
+++ b/docs/test-accounts.md
@@ -55,7 +55,7 @@ Behavior details:
 
 ## The two test accounts
 
-These are exactly what `scripts/e2e-cognito-provision.sh` creates:
+These are exactly what `scripts/archive/cognito/e2e-cognito-provision.sh` creates:
 
 | Account        | Email                    | Group   | Can reach                                                               |
 | -------------- | ------------------------ | ------- | ----------------------------------------------------------------------- |
@@ -67,7 +67,7 @@ The plain user deliberately has **no** group — that is what proves the
 
 ## Creating the accounts (existing tooling)
 
-`scripts/e2e-cognito-provision.sh` provisions both users in the Cognito
+`scripts/archive/cognito/e2e-cognito-provision.sh` provisions both users in the Cognito
 `cloudless-auth` pool. It is idempotent (re-running only resets the password
 and group membership), ensures the `admin` group exists, and gives each user
 a **permanent** password so Playwright can drive the Hosted UI login directly


### PR DESCRIPTION
## Summary
- Follow-up to #1452: admin API contract tests used Cognito JWT decode, which was removed
- Tests now authenticate with opaque `test-admin-session` / `test-user-session` via a shared `@/lib/auth-d1` mock
- Update Cognito setup doc links to `scripts/archive/cognito/` for lychee

## Test plan
- [x] `pnpm exec vitest run __tests__/admin-api.test.ts __tests__/api-auth.test.ts`
- [ ] CI API Contract + Markdown Link Checker green


Made with [Cursor](https://cursor.com)