### PR TITLE
feat: DynamoDB → D1 (PR-06)

### DIFF
--- a/__tests__/ad-analytics/bookmarks.test.ts
+++ b/__tests__/ad-analytics/bookmarks.test.ts
@@ -3,13 +3,15 @@ import { describe, it, expect, beforeEach, afterEach } from "vitest";
 
 import { bookmarkKeyOf, getBookmarkStore, _resetBookmarkStore } from "@/lib/ad-analytics/bookmarks";
 import type { AdMetrics } from "@/lib/ad-analytics/types";
+import type { AuthDatabase } from "@/lib/auth-d1";
 
 beforeEach(() => {
-  delete process.env.AD_ANALYTICS_BOOKMARKS_TABLE;
+  delete (globalThis as { __AUTH_DB__?: unknown }).__AUTH_DB__;
   _resetBookmarkStore();
 });
 
 afterEach(() => {
+  delete (globalThis as { __AUTH_DB__?: unknown }).__AUTH_DB__;
   _resetBookmarkStore();
 });
 
@@ -27,6 +29,50 @@ function snapshot(over: Partial<AdMetrics> = {}): AdMetrics {
   };
 }
 
+function createBookmarkDb(): AuthDatabase & {
+  rows: Map<string, { pk: string; last_posted_at: string; snapshot_json: string; updated_at: number }>;
+} {
+  const rows = new Map<
+    string,
+    { pk: string; last_posted_at: string; snapshot_json: string; updated_at: number }
+  >();
+  return {
+    rows,
+    prepare(query: string) {
+      const binds: unknown[] = [];
+      const stmt = {
+        bind(...args: unknown[]) {
+          binds.push(...args);
+          return stmt;
+        },
+        async run() {
+          if (query.includes("INSERT OR REPLACE INTO ad_analytics_bookmark")) {
+            const [pk, last_posted_at, snapshot_json, updated_at] = binds as [
+              string,
+              string,
+              string,
+              number,
+            ];
+            rows.set(pk, { pk, last_posted_at, snapshot_json, updated_at });
+            return { success: true, meta: { changes: 1 } };
+          }
+          return { success: true, meta: { changes: 0 } };
+        },
+        async all() {
+          return { results: [], success: true };
+        },
+        async first<T = Record<string, unknown>>() {
+          if (query.includes("FROM ad_analytics_bookmark")) {
+            return (rows.get(String(binds[0])) as T) ?? null;
+          }
+          return null;
+        },
+      };
+      return stmt;
+    },
+  };
+}
+
 describe("bookmarkKeyOf", () => {
   it("composes a stable string key from the tuple", () => {
     expect(
@@ -40,7 +86,7 @@ describe("bookmarkKeyOf", () => {
   });
 });
 
-describe("InMemoryBookmarkStore (fallback when AD_ANALYTICS_BOOKMARKS_TABLE is unset)", () => {
+describe("InMemoryBookmarkStore (fallback when AUTH_DB is unbound)", () => {
   it("returns null when the key has never been written", async () => {
     const store = getBookmarkStore();
     const got = await store.getBookmark("ad-analytics:test:linkedin:headline:60m");
@@ -64,5 +110,19 @@ describe("InMemoryBookmarkStore (fallback when AD_ANALYTICS_BOOKMARKS_TABLE is u
     const b = getBookmarkStore();
     const got = await b.getBookmark("k1");
     expect(got).toBeNull();
+  });
+});
+
+describe("D1BookmarkStore (when AUTH_DB is bound)", () => {
+  it("round-trips a snapshot through D1", async () => {
+    const db = createBookmarkDb();
+    (globalThis as { __AUTH_DB__?: AuthDatabase }).__AUTH_DB__ = db;
+    _resetBookmarkStore();
+    const store = getBookmarkStore();
+    const key = "ad-analytics:d1:linkedin:headline:60m";
+    await store.putBookmark(key, snapshot({ impressions: 100 }));
+    const got = await store.getBookmark(key);
+    expect(got?.snapshot.impressions).toBe(100);
+    expect(db.rows.has(key)).toBe(true);
   });
 });

--- a/__tests__/ad-analytics/poll.test.ts
+++ b/__tests__/ad-analytics/poll.test.ts
@@ -10,7 +10,7 @@ import type { NotificationChannel } from "@/lib/ad-analytics/channels/notificati
 let restoreRegistries: (() => void) | null = null;
 
 beforeEach(() => {
-  delete process.env.AD_ANALYTICS_BOOKMARKS_TABLE;
+  delete (globalThis as { __AUTH_DB__?: unknown }).__AUTH_DB__;
   _resetBookmarkStore();
 });
 

--- a/__tests__/admin-notifications-api.test.ts
+++ b/__tests__/admin-notifications-api.test.ts
@@ -3,21 +3,28 @@
  * GET /api/admin/notifications/analytics
  *
  * The route handlers delegate to src/lib/admin-notifications. We mock that
- * lib so these tests stay fast and don't need DynamoDB.
+ * lib so these tests stay fast and don't need D1.
  */
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, vi, beforeEach } from "vitest";
 import { NextRequest } from "next/server";
 
-const { mockRequireAdmin, mockList, mockMarkRead, mockAnalytics } = vi.hoisted(() => ({
-  mockRequireAdmin: vi.fn(),
-  mockList: vi.fn(),
-  mockMarkRead: vi.fn(),
-  mockAnalytics: vi.fn(),
-}));
+const { mockRequireAdmin, mockList, mockMarkRead, mockAnalytics, mockGetAuthDb } = vi.hoisted(
+  () => ({
+    mockRequireAdmin: vi.fn(),
+    mockList: vi.fn(),
+    mockMarkRead: vi.fn(),
+    mockAnalytics: vi.fn(),
+    mockGetAuthDb: vi.fn(),
+  })
+);
 
 vi.mock("@/lib/api-auth", () => ({
   requireAdmin: (...a: unknown[]) => mockRequireAdmin(...a),
   requireAuth: vi.fn(),
+}));
+
+vi.mock("@/lib/auth-d1", () => ({
+  getAuthDbFromEnv: (...a: unknown[]) => mockGetAuthDb(...a),
 }));
 
 vi.mock("@/lib/admin-notifications", () => ({
@@ -35,14 +42,12 @@ function makeReq(url: string, method: string, body?: unknown) {
 }
 
 const OK_ADMIN = { ok: true as const, user: { sub: "u1" } };
+const FAKE_DB = { prepare: vi.fn() };
 
 describe("GET /api/admin/notifications", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    process.env.ADMIN_NOTIFICATIONS_TABLE = "TestTable";
-  });
-  afterEach(() => {
-    delete process.env.ADMIN_NOTIFICATIONS_TABLE;
+    mockGetAuthDb.mockReturnValue(FAKE_DB);
   });
 
   it("returns 401 when not admin", async () => {
@@ -56,8 +61,8 @@ describe("GET /api/admin/notifications", () => {
     expect(mockList).not.toHaveBeenCalled();
   });
 
-  it("returns 503 when table not configured", async () => {
-    delete process.env.ADMIN_NOTIFICATIONS_TABLE;
+  it("returns 503 when AUTH_DB is unbound", async () => {
+    mockGetAuthDb.mockReturnValue(null);
     mockRequireAdmin.mockResolvedValue(OK_ADMIN);
     const { GET } = await import("@/app/api/admin/notifications/route");
     const res = await GET(makeReq("http://localhost/api/admin/notifications", "GET"));
@@ -135,7 +140,7 @@ describe("GET /api/admin/notifications", () => {
 
   it("returns 500 when the lib throws", async () => {
     mockRequireAdmin.mockResolvedValue(OK_ADMIN);
-    mockList.mockRejectedValue(new Error("dynamo down"));
+    mockList.mockRejectedValue(new Error("d1 down"));
     const { GET } = await import("@/app/api/admin/notifications/route");
     const res = await GET(makeReq("http://localhost/api/admin/notifications", "GET"));
     expect(res.status).toBe(500);
@@ -145,10 +150,7 @@ describe("GET /api/admin/notifications", () => {
 describe("PATCH /api/admin/notifications", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    process.env.ADMIN_NOTIFICATIONS_TABLE = "TestTable";
-  });
-  afterEach(() => {
-    delete process.env.ADMIN_NOTIFICATIONS_TABLE;
+    mockGetAuthDb.mockReturnValue(FAKE_DB);
   });
 
   it("returns 401 when not admin", async () => {
@@ -163,8 +165,8 @@ describe("PATCH /api/admin/notifications", () => {
     expect(res.status).toBe(401);
   });
 
-  it("returns 503 when table not configured", async () => {
-    delete process.env.ADMIN_NOTIFICATIONS_TABLE;
+  it("returns 503 when AUTH_DB is unbound", async () => {
+    mockGetAuthDb.mockReturnValue(null);
     mockRequireAdmin.mockResolvedValue(OK_ADMIN);
     const { PATCH } = await import("@/app/api/admin/notifications/route");
     const res = await PATCH(
@@ -245,10 +247,7 @@ describe("PATCH /api/admin/notifications", () => {
 describe("GET /api/admin/notifications/analytics", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    process.env.ADMIN_NOTIFICATIONS_TABLE = "TestTable";
-  });
-  afterEach(() => {
-    delete process.env.ADMIN_NOTIFICATIONS_TABLE;
+    mockGetAuthDb.mockReturnValue(FAKE_DB);
   });
 
   it("returns 401 when not admin", async () => {
@@ -261,8 +260,8 @@ describe("GET /api/admin/notifications/analytics", () => {
     expect(res.status).toBe(401);
   });
 
-  it("returns 503 when table not configured", async () => {
-    delete process.env.ADMIN_NOTIFICATIONS_TABLE;
+  it("returns 503 when AUTH_DB is unbound", async () => {
+    mockGetAuthDb.mockReturnValue(null);
     mockRequireAdmin.mockResolvedValue(OK_ADMIN);
     const { GET } = await import("@/app/api/admin/notifications/analytics/route");
     const res = await GET(makeReq("http://localhost/api/admin/notifications/analytics", "GET"));

--- a/__tests__/admin-notifications.test.ts
+++ b/__tests__/admin-notifications.test.ts
@@ -1,38 +1,5 @@
 import { describe, it, expect, beforeEach, vi, afterEach } from "vitest";
-
-const { mockDynamoSend, putCalls, queryCalls, updateCalls, batchWriteCalls } = vi.hoisted(() => ({
-  mockDynamoSend: vi.fn(),
-  putCalls: [] as unknown[],
-  queryCalls: [] as unknown[],
-  updateCalls: [] as unknown[],
-  batchWriteCalls: [] as unknown[],
-}));
-
-vi.mock("@aws-sdk/client-dynamodb", () => ({
-  DynamoDBClient: vi.fn().mockImplementation(function () {
-    return { send: mockDynamoSend };
-  }),
-  PutItemCommand: vi.fn().mockImplementation(function (input: unknown) {
-    putCalls.push(input);
-    return { __cmd: "Put", input };
-  }),
-  QueryCommand: vi.fn().mockImplementation(function (input: unknown) {
-    queryCalls.push(input);
-    return { __cmd: "Query", input };
-  }),
-  UpdateItemCommand: vi.fn().mockImplementation(function (input: unknown) {
-    updateCalls.push(input);
-    return { __cmd: "Update", input };
-  }),
-  BatchWriteItemCommand: vi.fn().mockImplementation(function (input: unknown) {
-    batchWriteCalls.push(input);
-    return { __cmd: "BatchWrite", input };
-  }),
-}));
-
-vi.mock("@/lib/stripe-transactions", () => ({
-  resolveDynamoEndpoint: () => "http://localhost:8000",
-}));
+import type { AuthDatabase } from "@/lib/auth-d1";
 
 import {
   recordNotification,
@@ -43,423 +10,138 @@ import {
 } from "@/lib/admin-notifications";
 
 describe("admin-notifications", () => {
-  const originalTable = process.env.ADMIN_NOTIFICATIONS_TABLE;
-
   beforeEach(() => {
-    mockDynamoSend.mockReset();
-    putCalls.length = 0;
-    queryCalls.length = 0;
-    updateCalls.length = 0;
-    batchWriteCalls.length = 0;
-    process.env.ADMIN_NOTIFICATIONS_TABLE = "test-notifs";
     delete (globalThis as { __AUTH_DB__?: unknown }).__AUTH_DB__;
   });
 
   afterEach(() => {
-    if (originalTable === undefined) delete process.env.ADMIN_NOTIFICATIONS_TABLE;
-    else process.env.ADMIN_NOTIFICATIONS_TABLE = originalTable;
     delete (globalThis as { __AUTH_DB__?: unknown }).__AUTH_DB__;
   });
 
-  describe("recordNotification", () => {
-    it("returns null when ADMIN_NOTIFICATIONS_TABLE is not set (safe no-op)", async () => {
-      delete process.env.ADMIN_NOTIFICATIONS_TABLE;
-      const r = await recordNotification({
-        category: "contact",
-        title: "T",
-        message: "M",
-      });
-      // Lake-only mode: returns the notification (written to S3) but skips DynamoDB.
-      expect(r).not.toBeNull();
-      expect(r!.title).toBe("T");
-      expect(mockDynamoSend).not.toHaveBeenCalled();
-    });
-
-    it("writes a row with the documented shape on success", async () => {
-      mockDynamoSend.mockResolvedValueOnce({});
-      const r = await recordNotification({
-        category: "contact",
-        title: "New contact",
-        message: "Themis says hi",
-        actor: "t@x",
-        route: "/api/contact",
-        metadata: { ua: "curl" },
-      });
-      expect(r).not.toBeNull();
-      expect(putCalls).toHaveLength(1);
-      const input = putCalls[0] as {
-        TableName: string;
-        Item: Record<string, { S?: string; BOOL?: boolean }>;
-      };
-      expect(input.TableName).toBe("test-notifs");
-      expect(input.Item.pk.S).toBe("NOTIF");
-      expect(input.Item.catPk.S).toBe("CAT#contact");
-      expect(input.Item.category.S).toBe("contact");
-      expect(input.Item.title.S).toBe("New contact");
-      expect(input.Item.message.S).toBe("Themis says hi");
-      expect(input.Item.actor.S).toBe("t@x");
-      expect(input.Item.route.S).toBe("/api/contact");
-      expect(input.Item.read.BOOL).toBe(false);
-      expect(JSON.parse(input.Item.metadata.S ?? "{}")).toEqual({ ua: "curl" });
-    });
-
-    it("defaults type to 'info' when not provided", async () => {
-      mockDynamoSend.mockResolvedValueOnce({});
-      await recordNotification({ category: "subscribe", title: "T", message: "M" });
-      const input = putCalls[0] as { Item: Record<string, { S?: string }> };
-      expect(input.Item.type.S).toBe("info");
-    });
-
-    it("omits optional fields when not provided", async () => {
-      mockDynamoSend.mockResolvedValueOnce({});
-      await recordNotification({ category: "order", title: "T", message: "M" });
-      const input = putCalls[0] as { Item: Record<string, unknown> };
-      expect(input.Item.actor).toBeUndefined();
-      expect(input.Item.route).toBeUndefined();
-      expect(input.Item.metadata).toBeUndefined();
-    });
-
-    it("returns null when Dynamo throws (producer paths must not crash)", async () => {
-      mockDynamoSend.mockRejectedValueOnce(new Error("ThrottlingException"));
-      const r = await recordNotification({ category: "error", title: "T", message: "M" });
-      expect(r).toBeNull();
-    });
-
-    it("generates unique ids across calls", async () => {
-      mockDynamoSend.mockResolvedValue({});
-      const a = await recordNotification({ category: "auth", title: "T", message: "M" });
-      const b = await recordNotification({ category: "auth", title: "T", message: "M" });
-      expect(a?.id).not.toBe(b?.id);
-    });
-
-    it("encodes the sort key as <createdAt>#<id>", async () => {
-      mockDynamoSend.mockResolvedValueOnce({});
-      await recordNotification({ category: "portal", title: "T", message: "M" });
-      const input = putCalls[0] as { Item: Record<string, { S?: string }> };
-      const sk = input.Item.sk.S ?? "";
-      const createdAt = input.Item.createdAt.S ?? "";
-      expect(sk.startsWith(createdAt + "#")).toBe(true);
-    });
-  });
-
-  describe("listNotifications", () => {
-    it("queries the main partition newest-first by default", async () => {
-      mockDynamoSend.mockResolvedValueOnce({ Items: [] });
-      await listNotifications();
-      const q = queryCalls[0] as {
-        IndexName?: string;
-        ScanIndexForward: boolean;
-        Limit: number;
-        ExpressionAttributeValues: Record<string, { S: string }>;
-      };
-      expect(q.IndexName).toBeUndefined();
-      expect(q.ScanIndexForward).toBe(false);
-      expect(q.Limit).toBe(50);
-      expect(q.ExpressionAttributeValues[":pk"].S).toBe("NOTIF");
-    });
-
-    it("uses the category GSI when category filter is set", async () => {
-      mockDynamoSend.mockResolvedValueOnce({ Items: [] });
-      await listNotifications({ category: "order" });
-      const q = queryCalls[0] as {
-        IndexName?: string;
-        ExpressionAttributeValues: Record<string, { S: string }>;
-      };
-      expect(q.IndexName).toBe("categoryIndex");
-      expect(q.ExpressionAttributeValues[":cpk"].S).toBe("CAT#order");
-    });
-
-    it("clamps limit to the 1–200 range", async () => {
-      mockDynamoSend.mockResolvedValueOnce({ Items: [] });
-      await listNotifications({ limit: 5000 });
-      expect((queryCalls[0] as { Limit: number }).Limit).toBe(200);
-
-      mockDynamoSend.mockResolvedValueOnce({ Items: [] });
-      await listNotifications({ limit: -10 });
-      expect((queryCalls[1] as { Limit: number }).Limit).toBe(1);
-    });
-
-    it("filters out archived rows by default", async () => {
-      mockDynamoSend.mockResolvedValueOnce({ Items: [] });
-      await listNotifications();
-      const q = queryCalls[0] as { FilterExpression?: string };
-      expect(q.FilterExpression).toContain("attribute_not_exists(#archivedAt)");
-    });
-
-    it("includes archived rows when includeArchived=true", async () => {
-      mockDynamoSend.mockResolvedValueOnce({ Items: [] });
-      await listNotifications({ includeArchived: true });
-      const q = queryCalls[0] as { FilterExpression?: string };
-      expect(q.FilterExpression).toBeUndefined();
-    });
-
-    it("maps Dynamo items back into AdminNotification shape", async () => {
-      mockDynamoSend.mockResolvedValueOnce({
-        Items: [
-          {
-            id: { S: "n_1" },
-            createdAt: { S: "2026-06-12T10:00:00Z" },
-            category: { S: "contact" },
-            type: { S: "info" },
-            title: { S: "T" },
-            message: { S: "M" },
-            actor: { S: "a@b" },
-            route: { S: "/r" },
-            metadata: { S: '{"x":1}' },
-            read: { BOOL: false },
+  type Row = Record<string, unknown>;
+  function createMemoryDb() {
+    const rows: Row[] = [];
+    return {
+      rows,
+      prepare(query: string) {
+        const binds: unknown[] = [];
+        const stmt = {
+          bind(...args: unknown[]) {
+            binds.push(...args);
+            return stmt;
           },
-        ],
-      });
-      const r = await listNotifications();
-      expect(r).toHaveLength(1);
-      expect(r[0]).toMatchObject({
-        id: "n_1",
-        category: "contact",
-        title: "T",
-        actor: "a@b",
-        route: "/r",
-        metadata: { x: 1 },
-      });
-    });
-
-    it("drops malformed metadata JSON silently", async () => {
-      mockDynamoSend.mockResolvedValueOnce({
-        Items: [
-          {
-            id: { S: "n_1" },
-            createdAt: { S: "2026-06-12T10:00:00Z" },
-            category: { S: "contact" },
-            type: { S: "info" },
-            title: { S: "T" },
-            message: { S: "M" },
-            metadata: { S: "{not json" },
-            read: { BOOL: false },
+          async run() {
+            if (query.includes("INSERT INTO admin_notification")) {
+              rows.push({
+                pk: binds[0],
+                sk: binds[1],
+                category: binds[2],
+                id: binds[3],
+                type: binds[4],
+                title: binds[5],
+                message: binds[6],
+                actor: binds[7],
+                route: binds[8],
+                read: binds[9],
+                archived_at: binds[10],
+                cat_pk: binds[11],
+                cat_sk: binds[12],
+                payload_json: binds[13],
+                created_at: binds[14],
+              });
+              return { success: true, meta: { changes: 1 } };
+            }
+            if (query.includes("UPDATE admin_notification SET read")) {
+              const id = binds[0];
+              for (const r of rows) {
+                if (r.id === id) r.read = 1;
+              }
+              return { success: true, meta: { changes: 1 } };
+            }
+            if (query.includes("DELETE FROM admin_notification")) {
+              const cutoff = String(binds[0]);
+              let changes = 0;
+              for (let i = rows.length - 1; i >= 0; i--) {
+                const archived = rows[i].archived_at;
+                if (typeof archived === "string" && archived && archived < cutoff) {
+                  rows.splice(i, 1);
+                  changes++;
+                }
+              }
+              return { success: true, meta: { changes } };
+            }
+            return { success: true, meta: { changes: 0 } };
           },
-        ],
-      });
-      const r = await listNotifications();
-      expect(r[0].metadata).toBeUndefined();
-    });
-  });
+          async all<T = Row>() {
+            let filtered = [...rows];
+            if (query.includes("FROM admin_notification")) {
+              let bi = 0;
+              if (query.includes("category = ?")) {
+                const cat = binds[bi++];
+                filtered = filtered.filter((r) => r.category === cat);
+              } else if (query.includes("pk = ?")) {
+                const pk = binds[bi++];
+                filtered = filtered.filter((r) => r.pk === pk);
+              }
+              if (query.includes("sk >= ?")) {
+                const since = String(binds[bi++]);
+                filtered = filtered.filter((r) => String(r.sk) >= since);
+              }
+              if (query.includes("sk < ?")) {
+                const until = String(binds[bi++]);
+                filtered = filtered.filter((r) => String(r.sk) < until);
+              }
+              if (query.includes("archived_at IS NULL")) {
+                filtered = filtered.filter((r) => !r.archived_at);
+              }
+              const limit = Number(binds[binds.length - 1] ?? 50);
+              filtered.sort((a, b) => String(b.sk).localeCompare(String(a.sk)));
+              filtered = filtered.slice(0, limit);
+            }
+            return { results: filtered as T[], success: true };
+          },
+          async first() {
+            return null;
+          },
+        };
+        return stmt;
+      },
+    };
+  }
 
-  describe("markNotificationsRead", () => {
-    it("is a no-op when ids array is empty", async () => {
-      await markNotificationsRead([]);
-      expect(mockDynamoSend).not.toHaveBeenCalled();
+  describe("without AUTH_DB", () => {
+    it("throws on recordNotification", async () => {
+      await expect(
+        recordNotification({ category: "contact", title: "T", message: "M" })
+      ).rejects.toThrow(/AUTH_DB/);
     });
 
-    it("looks up each row then updates its read flag", async () => {
-      mockDynamoSend
-        .mockResolvedValueOnce({
-          Items: [{ pk: { S: "NOTIF" }, sk: { S: "2026#n_1" } }],
-        })
-        .mockResolvedValueOnce({}); // UpdateItem
-      await markNotificationsRead(["n_1"]);
-      expect(queryCalls).toHaveLength(1);
-      expect(updateCalls).toHaveLength(1);
-      const u = updateCalls[0] as {
-        UpdateExpression: string;
-        ExpressionAttributeValues: Record<string, { BOOL?: boolean }>;
-      };
-      expect(u.UpdateExpression).toContain("SET");
-      expect(u.ExpressionAttributeValues[":true"].BOOL).toBe(true);
+    it("returns [] from listNotifications", async () => {
+      expect(await listNotifications()).toEqual([]);
     });
 
-    it("skips ids that don't exist (Items empty)", async () => {
-      mockDynamoSend.mockResolvedValueOnce({ Items: [] });
-      await markNotificationsRead(["missing"]);
-      expect(updateCalls).toHaveLength(0);
+    it("throws on markNotificationsRead", async () => {
+      await expect(markNotificationsRead(["n_1"])).rejects.toThrow(/AUTH_DB/);
     });
-  });
 
-  describe("notificationAnalytics", () => {
-    it("returns zero counts when no rows", async () => {
-      mockDynamoSend.mockResolvedValueOnce({ Items: [] });
+    it("is a no-op when markNotificationsRead ids are empty", async () => {
+      await expect(markNotificationsRead([])).resolves.toBeUndefined();
+    });
+
+    it("throws on purgeArchivedOlderThan", async () => {
+      await expect(purgeArchivedOlderThan("2026-01-01")).rejects.toThrow(/AUTH_DB/);
+    });
+
+    it("notificationAnalytics returns zeros when list is empty", async () => {
       const r = await notificationAnalytics({ since: "2026-06-01" });
       expect(r.total).toBe(0);
       expect(r.byCategory.contact).toBe(0);
-      expect(r.byCategory.order).toBe(0);
       expect(r.byDay).toEqual({});
-    });
-
-    it("counts by category and by day", async () => {
-      mockDynamoSend.mockResolvedValueOnce({
-        Items: [
-          {
-            id: { S: "1" },
-            createdAt: { S: "2026-06-12T10:00:00Z" },
-            category: { S: "contact" },
-            type: { S: "info" },
-            title: { S: "T" },
-            message: { S: "M" },
-            read: { BOOL: false },
-          },
-          {
-            id: { S: "2" },
-            createdAt: { S: "2026-06-12T11:00:00Z" },
-            category: { S: "order" },
-            type: { S: "success" },
-            title: { S: "T" },
-            message: { S: "M" },
-            read: { BOOL: false },
-          },
-          {
-            id: { S: "3" },
-            createdAt: { S: "2026-06-11T10:00:00Z" },
-            category: { S: "contact" },
-            type: { S: "info" },
-            title: { S: "T" },
-            message: { S: "M" },
-            read: { BOOL: false },
-          },
-        ],
-      });
-      const r = await notificationAnalytics({ since: "2026-06-01" });
-      expect(r.total).toBe(3);
-      expect(r.byCategory.contact).toBe(2);
-      expect(r.byCategory.order).toBe(1);
-      expect(r.byDay["2026-06-12"]).toBe(2);
-      expect(r.byDay["2026-06-11"]).toBe(1);
-    });
-  });
-
-  describe("purgeArchivedOlderThan", () => {
-    it("returns 0 when no archived rows match", async () => {
-      mockDynamoSend.mockResolvedValueOnce({ Items: [] });
-      const n = await purgeArchivedOlderThan("2026-01-01");
-      expect(n).toBe(0);
-      expect(batchWriteCalls).toHaveLength(0);
-    });
-
-    it("batches deletes for matched archived rows", async () => {
-      mockDynamoSend
-        .mockResolvedValueOnce({
-          Items: [
-            { pk: { S: "NOTIF" }, sk: { S: "2025#a" } },
-            { pk: { S: "NOTIF" }, sk: { S: "2025#b" } },
-          ],
-        })
-        .mockResolvedValueOnce({}); // BatchWrite
-      const n = await purgeArchivedOlderThan("2026-01-01");
-      expect(n).toBe(2);
-      expect(batchWriteCalls).toHaveLength(1);
-      const bw = batchWriteCalls[0] as {
-        RequestItems: Record<string, Array<{ DeleteRequest: { Key: unknown } }>>;
-      };
-      expect(bw.RequestItems["test-notifs"]).toHaveLength(2);
-    });
-
-    it("walks LastEvaluatedKey across multiple pages", async () => {
-      mockDynamoSend
-        .mockResolvedValueOnce({
-          Items: [{ pk: { S: "NOTIF" }, sk: { S: "2025#a" } }],
-          LastEvaluatedKey: { pk: { S: "NOTIF" }, sk: { S: "2025#a" } },
-        })
-        .mockResolvedValueOnce({}) // BatchWrite 1
-        .mockResolvedValueOnce({
-          Items: [{ pk: { S: "NOTIF" }, sk: { S: "2025#b" } }],
-        })
-        .mockResolvedValueOnce({}); // BatchWrite 2
-      const n = await purgeArchivedOlderThan("2026-01-01");
-      expect(n).toBe(2);
-      expect(batchWriteCalls).toHaveLength(2);
     });
   });
 
   describe("D1 path", () => {
-    type Row = Record<string, unknown>;
-    function createMemoryDb() {
-      const rows: Row[] = [];
-      return {
-        rows,
-        prepare(query: string) {
-          const binds: unknown[] = [];
-          const stmt = {
-            bind(...args: unknown[]) {
-              binds.push(...args);
-              return stmt;
-            },
-            async run() {
-              if (query.includes("INSERT INTO admin_notification")) {
-                rows.push({
-                  pk: binds[0],
-                  sk: binds[1],
-                  category: binds[2],
-                  id: binds[3],
-                  type: binds[4],
-                  title: binds[5],
-                  message: binds[6],
-                  actor: binds[7],
-                  route: binds[8],
-                  read: binds[9],
-                  archived_at: binds[10],
-                  cat_pk: binds[11],
-                  cat_sk: binds[12],
-                  payload_json: binds[13],
-                  created_at: binds[14],
-                });
-                return { success: true, meta: { changes: 1 } };
-              }
-              if (query.includes("UPDATE admin_notification SET read")) {
-                const id = binds[0];
-                for (const r of rows) {
-                  if (r.id === id) r.read = 1;
-                }
-                return { success: true, meta: { changes: 1 } };
-              }
-              if (query.includes("DELETE FROM admin_notification")) {
-                const cutoff = String(binds[0]);
-                let changes = 0;
-                for (let i = rows.length - 1; i >= 0; i--) {
-                  const archived = rows[i].archived_at;
-                  if (typeof archived === "string" && archived && archived < cutoff) {
-                    rows.splice(i, 1);
-                    changes++;
-                  }
-                }
-                return { success: true, meta: { changes } };
-              }
-              return { success: true, meta: { changes: 0 } };
-            },
-            async all<T = Row>() {
-              let filtered = [...rows];
-              // Minimal SQL interpreter for the list query shape used in D1 path
-              if (query.includes("FROM admin_notification")) {
-                let bi = 0;
-                if (query.includes("category = ?")) {
-                  const cat = binds[bi++];
-                  filtered = filtered.filter((r) => r.category === cat);
-                } else if (query.includes("pk = ?")) {
-                  const pk = binds[bi++];
-                  filtered = filtered.filter((r) => r.pk === pk);
-                }
-                if (query.includes("sk >= ?")) {
-                  const since = String(binds[bi++]);
-                  filtered = filtered.filter((r) => String(r.sk) >= since);
-                }
-                if (query.includes("sk < ?")) {
-                  const until = String(binds[bi++]);
-                  filtered = filtered.filter((r) => String(r.sk) < until);
-                }
-                if (query.includes("archived_at IS NULL")) {
-                  filtered = filtered.filter((r) => !r.archived_at);
-                }
-                const limit = Number(binds[binds.length - 1] ?? 50);
-                filtered.sort((a, b) => String(b.sk).localeCompare(String(a.sk)));
-                filtered = filtered.slice(0, limit);
-              }
-              return { results: filtered as T[], success: true };
-            },
-            async first() {
-              return null;
-            },
-          };
-          return stmt;
-        },
-      };
-    }
-
-    it("records and lists via D1 without touching Dynamo", async () => {
+    it("records and lists via D1", async () => {
       const db = createMemoryDb();
       (globalThis as { __AUTH_DB__?: unknown }).__AUTH_DB__ = db;
       const r = await recordNotification({
@@ -467,14 +149,102 @@ describe("admin-notifications", () => {
         title: "Hi",
         message: "There",
         actor: "a@b.c",
+        route: "/api/contact",
+        metadata: { ua: "curl" },
       });
       expect(r).not.toBeNull();
-      expect(mockDynamoSend).not.toHaveBeenCalled();
+      expect(r!.title).toBe("Hi");
+      expect(r!.type).toBe("info");
       expect(db.rows).toHaveLength(1);
+      expect(db.rows[0].category).toBe("contact");
+      expect(db.rows[0].actor).toBe("a@b.c");
+      expect(db.rows[0].route).toBe("/api/contact");
+      expect(JSON.parse(String(db.rows[0].payload_json))).toEqual({ ua: "curl" });
+      expect(String(db.rows[0].sk)).toContain("#");
+
       const listed = await listNotifications({ limit: 10 });
       expect(listed).toHaveLength(1);
       expect(listed[0].title).toBe("Hi");
       expect(listed[0].actor).toBe("a@b.c");
+      expect(listed[0].metadata).toEqual({ ua: "curl" });
+    });
+
+    it("defaults type to info and omits optional fields", async () => {
+      const db = createMemoryDb();
+      (globalThis as { __AUTH_DB__?: unknown }).__AUTH_DB__ = db;
+      await recordNotification({ category: "order", title: "T", message: "M" });
+      expect(db.rows[0].type).toBe("info");
+      expect(db.rows[0].actor).toBeNull();
+      expect(db.rows[0].route).toBeNull();
+      expect(db.rows[0].payload_json).toBeNull();
+    });
+
+    it("returns null when D1 insert throws", async () => {
+      const db = createMemoryDb();
+      const originalPrepare = db.prepare.bind(db);
+      db.prepare = (query: string) => {
+        if (query.includes("INSERT INTO admin_notification")) {
+          return {
+            bind() {
+              return this;
+            },
+            async run() {
+              throw new Error("constraint");
+            },
+            async all() {
+              return { results: [], success: true };
+            },
+            async first() {
+              return null;
+            },
+          };
+        }
+        return originalPrepare(query);
+      };
+      (globalThis as { __AUTH_DB__?: unknown }).__AUTH_DB__ = db;
+      const r = await recordNotification({ category: "error", title: "T", message: "M" });
+      expect(r).toBeNull();
+    });
+
+    it("generates unique ids across calls", async () => {
+      const db = createMemoryDb();
+      (globalThis as { __AUTH_DB__?: unknown }).__AUTH_DB__ = db;
+      const a = await recordNotification({ category: "auth", title: "T", message: "M" });
+      const b = await recordNotification({ category: "auth", title: "T", message: "M" });
+      expect(a?.id).not.toBe(b?.id);
+    });
+
+    it("filters by category and clamps limit", async () => {
+      const db = createMemoryDb();
+      (globalThis as { __AUTH_DB__?: unknown }).__AUTH_DB__ = db;
+      await recordNotification({ category: "contact", title: "C", message: "M" });
+      await recordNotification({ category: "order", title: "O", message: "M" });
+      const orders = await listNotifications({ category: "order", limit: 5000 });
+      expect(orders).toHaveLength(1);
+      expect(orders[0].category).toBe("order");
+      const clamped = await listNotifications({ limit: -10 });
+      expect(clamped.length).toBeLessThanOrEqual(1);
+    });
+
+    it("filters out archived rows by default", async () => {
+      const db = createMemoryDb();
+      (globalThis as { __AUTH_DB__?: unknown }).__AUTH_DB__ = db;
+      await recordNotification({ category: "contact", title: "Live", message: "M" });
+      await recordNotification({ category: "contact", title: "Old", message: "M" });
+      db.rows[1].archived_at = "2020-01-01T00:00:00.000Z";
+      const live = await listNotifications();
+      expect(live.map((n) => n.title)).toEqual(["Live"]);
+      const all = await listNotifications({ includeArchived: true });
+      expect(all).toHaveLength(2);
+    });
+
+    it("drops malformed metadata JSON silently", async () => {
+      const db = createMemoryDb();
+      (globalThis as { __AUTH_DB__?: unknown }).__AUTH_DB__ = db;
+      await recordNotification({ category: "contact", title: "T", message: "M" });
+      db.rows[0].payload_json = "{not json";
+      const r = await listNotifications();
+      expect(r[0].metadata).toBeUndefined();
     });
 
     it("marks read and purges archived on D1", async () => {
@@ -488,6 +258,32 @@ describe("admin-notifications", () => {
       const purged = await purgeArchivedOlderThan("2021-01-01");
       expect(purged).toBe(1);
       expect(db.rows).toHaveLength(0);
+    });
+
+    it("counts by category and by day", async () => {
+      const db = createMemoryDb();
+      (globalThis as { __AUTH_DB__?: unknown }).__AUTH_DB__ = db;
+      const a = await recordNotification({ category: "contact", title: "T", message: "M" });
+      const b = await recordNotification({ category: "order", title: "T", message: "M" });
+      const c = await recordNotification({ category: "contact", title: "T", message: "M" });
+      // Force deterministic createdAt days via sk/created_at for analytics
+      db.rows[0].sk = `2026-06-12T10:00:00.000Z#${a!.id}`;
+      db.rows[1].sk = `2026-06-12T11:00:00.000Z#${b!.id}`;
+      db.rows[2].sk = `2026-06-11T10:00:00.000Z#${c!.id}`;
+      const stats = await notificationAnalytics({ since: "2026-06-01" });
+      expect(stats.total).toBe(3);
+      expect(stats.byCategory.contact).toBe(2);
+      expect(stats.byCategory.order).toBe(1);
+      expect(stats.byDay["2026-06-12"]).toBe(2);
+      expect(stats.byDay["2026-06-11"]).toBe(1);
+    });
+
+    it("returns 0 when no archived rows match purge", async () => {
+      const db = createMemoryDb();
+      (globalThis as { __AUTH_DB__?: unknown }).__AUTH_DB__ = db;
+      await recordNotification({ category: "contact", title: "T", message: "M" });
+      const n = await purgeArchivedOlderThan("2026-01-01");
+      expect(n).toBe(0);
     });
   });
 });

--- a/__tests__/admin-notifications.test.ts
+++ b/__tests__/admin-notifications.test.ts
@@ -110,10 +110,10 @@ describe("admin-notifications", () => {
   }
 
   describe("without AUTH_DB", () => {
-    it("throws on recordNotification", async () => {
+    it("soft-fails recordNotification (side-effect producers)", async () => {
       await expect(
         recordNotification({ category: "contact", title: "T", message: "M" })
-      ).rejects.toThrow(/AUTH_DB/);
+      ).resolves.toBeNull();
     });
 
     it("returns [] from listNotifications", async () => {

--- a/__tests__/gsc-cache.test.ts
+++ b/__tests__/gsc-cache.test.ts
@@ -1,46 +1,85 @@
 /**
- * Unit tests for src/lib/gsc-cache.ts — the read-through cache for Google
- * Search Console responses.
- *
- * AWS SDK Dynamo client is mocked with the regular-function constructor
- * pattern used by every other Dynamo-backed lib in this repo
- * (admin-notifications.test.ts, client-portals.test.ts).
+ * Unit tests for src/lib/gsc-cache.ts — D1 analytics_cache read-through.
  */
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import type { AuthDatabase } from "@/lib/auth-d1";
 
-const { mockSend, getCalls, putCalls } = vi.hoisted(() => ({
-  mockSend: vi.fn(),
-  getCalls: [] as Record<string, unknown>[],
-  putCalls: [] as Record<string, unknown>[],
-}));
+type CacheRow = {
+  pk: string;
+  sk: string;
+  result_json: string;
+  cached_at: number;
+  expires_at: number;
+};
 
-vi.mock("@aws-sdk/client-dynamodb", () => ({
-  DynamoDBClient: vi.fn().mockImplementation(function () {
-    return { send: mockSend };
-  }),
-  GetItemCommand: vi.fn().mockImplementation(function (input: Record<string, unknown>) {
-    getCalls.push(input);
-    return { __cmd: "Get", input };
-  }),
-  PutItemCommand: vi.fn().mockImplementation(function (input: Record<string, unknown>) {
-    putCalls.push(input);
-    return { __cmd: "Put", input };
-  }),
-}));
-
-vi.mock("@/lib/stripe-transactions", () => ({
-  resolveDynamoEndpoint: () => undefined,
-}));
+function createCacheDb(): AuthDatabase & {
+  rows: Map<string, CacheRow>;
+  failNext: boolean;
+} {
+  const rows = new Map<string, CacheRow>();
+  const state = { rows, failNext: false };
+  return {
+    get rows() {
+      return state.rows;
+    },
+    get failNext() {
+      return state.failNext;
+    },
+    set failNext(v: boolean) {
+      state.failNext = v;
+    },
+    prepare(query: string) {
+      const binds: unknown[] = [];
+      const stmt = {
+        bind(...args: unknown[]) {
+          binds.push(...args);
+          return stmt;
+        },
+        async run() {
+          if (state.failNext) {
+            state.failNext = false;
+            throw new Error("d1 down");
+          }
+          if (query.includes("INSERT OR REPLACE INTO analytics_cache")) {
+            const [pk, sk, result_json, cached_at, expires_at] = binds as [
+              string,
+              string,
+              string,
+              number,
+              number,
+            ];
+            state.rows.set(`${pk}|${sk}`, { pk, sk, result_json, cached_at, expires_at });
+            return { success: true, meta: { changes: 1 } };
+          }
+          return { success: true, meta: { changes: 0 } };
+        },
+        async all() {
+          return { results: [], success: true };
+        },
+        async first<T = CacheRow>() {
+          if (state.failNext) {
+            state.failNext = false;
+            throw new Error("d1 down");
+          }
+          if (query.includes("FROM analytics_cache")) {
+            const key = `${binds[0]}|${binds[1]}`;
+            return (state.rows.get(key) as T) ?? null;
+          }
+          return null;
+        },
+      };
+      return stmt;
+    },
+  };
+}
 
 describe("gsc-cache", () => {
   beforeEach(() => {
-    mockSend.mockReset();
-    getCalls.length = 0;
-    putCalls.length = 0;
-    process.env.ANALYTICS_CACHE_TABLE = "TestCache";
+    delete (globalThis as { __AUTH_DB__?: unknown }).__AUTH_DB__;
+    vi.resetModules();
   });
   afterEach(() => {
-    delete process.env.ANALYTICS_CACHE_TABLE;
+    delete (globalThis as { __AUTH_DB__?: unknown }).__AUTH_DB__;
   });
 
   describe("paramsHash", () => {
@@ -73,31 +112,32 @@ describe("gsc-cache", () => {
   });
 
   describe("getCached", () => {
-    it("returns null when ANALYTICS_CACHE_TABLE is unset", async () => {
-      delete process.env.ANALYTICS_CACHE_TABLE;
+    it("returns null when AUTH_DB is unbound", async () => {
       const { getCached } = await import("@/lib/gsc-cache");
       const r = await getCached("seo", {});
       expect(r).toBeNull();
-      expect(mockSend).not.toHaveBeenCalled();
     });
 
     it("returns null when no item exists", async () => {
-      mockSend.mockResolvedValueOnce({});
+      (globalThis as { __AUTH_DB__?: AuthDatabase }).__AUTH_DB__ = createCacheDb();
       const { getCached } = await import("@/lib/gsc-cache");
       const r = await getCached("seo", {});
       expect(r).toBeNull();
     });
 
     it("returns parsed payload with ageSeconds when present + fresh", async () => {
-      const storedAt = new Date(Date.now() - 60_000).toISOString();
-      mockSend.mockResolvedValueOnce({
-        Item: {
-          storedAt: { S: storedAt },
-          payload: { S: JSON.stringify({ clicks: 42 }) },
-        },
+      const db = createCacheDb();
+      const cachedAt = Math.floor(Date.now() / 1000) - 60;
+      db.rows.set("seo|default", {
+        pk: "seo",
+        sk: "default",
+        result_json: JSON.stringify({ clicks: 42 }),
+        cached_at: cachedAt,
+        expires_at: cachedAt + 3600,
       });
+      (globalThis as { __AUTH_DB__?: AuthDatabase }).__AUTH_DB__ = db;
       const { getCached } = await import("@/lib/gsc-cache");
-      const r = await getCached<{ clicks: number }>("seo", { days: 28 }, 3600);
+      const r = await getCached<{ clicks: number }>("seo", {}, 3600);
       expect(r).not.toBeNull();
       expect(r!.payload.clicks).toBe(42);
       expect(r!.ageSeconds).toBeGreaterThanOrEqual(60);
@@ -106,32 +146,41 @@ describe("gsc-cache", () => {
     });
 
     it("marks entry stale when older than ttlSeconds", async () => {
-      const storedAt = new Date(Date.now() - 7200_000).toISOString();
-      mockSend.mockResolvedValueOnce({
-        Item: {
-          storedAt: { S: storedAt },
-          payload: { S: JSON.stringify({ x: 1 }) },
-        },
+      const db = createCacheDb();
+      const cachedAt = Math.floor(Date.now() / 1000) - 7200;
+      db.rows.set("seo|default", {
+        pk: "seo",
+        sk: "default",
+        result_json: JSON.stringify({ x: 1 }),
+        cached_at: cachedAt,
+        expires_at: cachedAt + 3600,
       });
+      (globalThis as { __AUTH_DB__?: AuthDatabase }).__AUTH_DB__ = db;
       const { getCached } = await import("@/lib/gsc-cache");
       const r = await getCached("seo", {}, 3600);
       expect(r!.stale).toBe(true);
     });
 
     it("returns null on malformed JSON payload", async () => {
-      mockSend.mockResolvedValueOnce({
-        Item: {
-          storedAt: { S: new Date().toISOString() },
-          payload: { S: "{not-json" },
-        },
+      const db = createCacheDb();
+      const cachedAt = Math.floor(Date.now() / 1000);
+      db.rows.set("seo|default", {
+        pk: "seo",
+        sk: "default",
+        result_json: "{not-json",
+        cached_at: cachedAt,
+        expires_at: cachedAt + 3600,
       });
+      (globalThis as { __AUTH_DB__?: AuthDatabase }).__AUTH_DB__ = db;
       const { getCached } = await import("@/lib/gsc-cache");
       const r = await getCached("seo", {});
       expect(r).toBeNull();
     });
 
-    it("returns null and swallows error on Dynamo failure", async () => {
-      mockSend.mockRejectedValueOnce(new Error("dynamo down"));
+    it("returns null and swallows error on D1 failure", async () => {
+      const db = createCacheDb();
+      db.failNext = true;
+      (globalThis as { __AUTH_DB__?: AuthDatabase }).__AUTH_DB__ = db;
       const { getCached } = await import("@/lib/gsc-cache");
       const r = await getCached("seo", {});
       expect(r).toBeNull();
@@ -139,28 +188,28 @@ describe("gsc-cache", () => {
   });
 
   describe("setCached", () => {
-    it("is a no-op when table is unset", async () => {
-      delete process.env.ANALYTICS_CACHE_TABLE;
+    it("is a no-op when AUTH_DB is unbound", async () => {
       const { setCached } = await import("@/lib/gsc-cache");
-      await setCached("seo", {}, { clicks: 1 });
-      expect(mockSend).not.toHaveBeenCalled();
+      await expect(setCached("seo", {}, { clicks: 1 })).resolves.toBeUndefined();
     });
 
-    it("writes serialized payload with storedAt + ttlSeconds", async () => {
-      mockSend.mockResolvedValueOnce({});
-      const { setCached } = await import("@/lib/gsc-cache");
+    it("writes serialized payload with cached_at + expires_at", async () => {
+      const db = createCacheDb();
+      (globalThis as { __AUTH_DB__?: AuthDatabase }).__AUTH_DB__ = db;
+      const { setCached, paramsHash } = await import("@/lib/gsc-cache");
       await setCached("seo", { days: 7 }, { clicks: 123 }, 1800);
-      expect(putCalls).toHaveLength(1);
-      const item = (putCalls[0] as { Item: Record<string, { S?: string; N?: string }> }).Item;
-      expect(item.pk.S).toBe("seo");
-      expect(item.sk.S).toMatch(/^[0-9a-f]{16}$/);
-      expect(JSON.parse(item.payload.S!).clicks).toBe(123);
-      expect(typeof item.storedAt.S).toBe("string");
-      expect(item.ttlSeconds.N).toBe("1800");
+      const sk = paramsHash({ days: 7 });
+      const row = db.rows.get(`seo|${sk}`);
+      expect(row).toBeDefined();
+      expect(JSON.parse(row!.result_json).clicks).toBe(123);
+      expect(typeof row!.cached_at).toBe("number");
+      expect(row!.expires_at - row!.cached_at).toBe(1800);
     });
 
-    it("swallows Dynamo errors silently (best-effort)", async () => {
-      mockSend.mockRejectedValueOnce(new Error("boom"));
+    it("swallows D1 errors silently (best-effort)", async () => {
+      const db = createCacheDb();
+      db.failNext = true;
+      (globalThis as { __AUTH_DB__?: AuthDatabase }).__AUTH_DB__ = db;
       const { setCached } = await import("@/lib/gsc-cache");
       await expect(setCached("seo", {}, { x: 1 })).resolves.toBeUndefined();
     });
@@ -168,12 +217,16 @@ describe("gsc-cache", () => {
 
   describe("readThrough", () => {
     it("serves from cache when fresh, never calls fetcher", async () => {
-      mockSend.mockResolvedValueOnce({
-        Item: {
-          storedAt: { S: new Date(Date.now() - 60_000).toISOString() },
-          payload: { S: JSON.stringify({ clicks: 9 }) },
-        },
+      const db = createCacheDb();
+      const cachedAt = Math.floor(Date.now() / 1000) - 60;
+      db.rows.set("seo|default", {
+        pk: "seo",
+        sk: "default",
+        result_json: JSON.stringify({ clicks: 9 }),
+        cached_at: cachedAt,
+        expires_at: cachedAt + 3600,
       });
+      (globalThis as { __AUTH_DB__?: AuthDatabase }).__AUTH_DB__ = db;
       const { readThrough } = await import("@/lib/gsc-cache");
       const fetcher = vi.fn().mockResolvedValue({ clicks: 999 });
       const r = await readThrough("seo", {}, fetcher, { ttlSeconds: 3600 });
@@ -183,26 +236,28 @@ describe("gsc-cache", () => {
     });
 
     it("calls fetcher and writes back when no cache entry exists", async () => {
-      mockSend.mockResolvedValueOnce({}); // empty get
-      mockSend.mockResolvedValueOnce({}); // put
+      const db = createCacheDb();
+      (globalThis as { __AUTH_DB__?: AuthDatabase }).__AUTH_DB__ = db;
       const { readThrough } = await import("@/lib/gsc-cache");
       const fetcher = vi.fn().mockResolvedValue({ clicks: 50 });
       const r = await readThrough("seo", {}, fetcher);
       expect(r.source).toBe("live");
       expect((r.value as { clicks: number }).clicks).toBe(50);
       expect(fetcher).toHaveBeenCalledTimes(1);
-      // The put should have been issued via send (2 calls total).
-      expect(mockSend).toHaveBeenCalledTimes(2);
+      expect(db.rows.size).toBe(1);
     });
 
     it("calls fetcher when entry is stale", async () => {
-      mockSend.mockResolvedValueOnce({
-        Item: {
-          storedAt: { S: new Date(Date.now() - 7200_000).toISOString() },
-          payload: { S: JSON.stringify({ clicks: 1 }) },
-        },
+      const db = createCacheDb();
+      const cachedAt = Math.floor(Date.now() / 1000) - 7200;
+      db.rows.set("seo|default", {
+        pk: "seo",
+        sk: "default",
+        result_json: JSON.stringify({ clicks: 1 }),
+        cached_at: cachedAt,
+        expires_at: cachedAt + 3600,
       });
-      mockSend.mockResolvedValueOnce({}); // put
+      (globalThis as { __AUTH_DB__?: AuthDatabase }).__AUTH_DB__ = db;
       const { readThrough } = await import("@/lib/gsc-cache");
       const fetcher = vi.fn().mockResolvedValue({ clicks: 2 });
       const r = await readThrough("seo", {}, fetcher, { ttlSeconds: 3600 });
@@ -211,12 +266,16 @@ describe("gsc-cache", () => {
     });
 
     it("falls back to stale cache when fetcher throws and stale is within window", async () => {
-      mockSend.mockResolvedValueOnce({
-        Item: {
-          storedAt: { S: new Date(Date.now() - 7200_000).toISOString() },
-          payload: { S: JSON.stringify({ clicks: 5 }) },
-        },
+      const db = createCacheDb();
+      const cachedAt = Math.floor(Date.now() / 1000) - 7200;
+      db.rows.set("seo|default", {
+        pk: "seo",
+        sk: "default",
+        result_json: JSON.stringify({ clicks: 5 }),
+        cached_at: cachedAt,
+        expires_at: cachedAt + 3600,
       });
+      (globalThis as { __AUTH_DB__?: AuthDatabase }).__AUTH_DB__ = db;
       const { readThrough } = await import("@/lib/gsc-cache");
       const fetcher = vi.fn().mockRejectedValue(new Error("quota"));
       const r = await readThrough("seo", {}, fetcher, {
@@ -228,19 +287,23 @@ describe("gsc-cache", () => {
     });
 
     it("re-throws when fetcher fails and no acceptable stale cache exists", async () => {
-      mockSend.mockResolvedValueOnce({}); // empty get
+      (globalThis as { __AUTH_DB__?: AuthDatabase }).__AUTH_DB__ = createCacheDb();
       const { readThrough } = await import("@/lib/gsc-cache");
       const fetcher = vi.fn().mockRejectedValue(new Error("quota"));
       await expect(readThrough("seo", {}, fetcher)).rejects.toThrow("quota");
     });
 
     it("re-throws when stale cache is past acceptStaleSeconds", async () => {
-      mockSend.mockResolvedValueOnce({
-        Item: {
-          storedAt: { S: new Date(Date.now() - 7 * 24 * 3600_000).toISOString() },
-          payload: { S: JSON.stringify({ clicks: 5 }) },
-        },
+      const db = createCacheDb();
+      const cachedAt = Math.floor(Date.now() / 1000) - 7 * 24 * 3600;
+      db.rows.set("seo|default", {
+        pk: "seo",
+        sk: "default",
+        result_json: JSON.stringify({ clicks: 5 }),
+        cached_at: cachedAt,
+        expires_at: cachedAt + 3600,
       });
+      (globalThis as { __AUTH_DB__?: AuthDatabase }).__AUTH_DB__ = db;
       const { readThrough } = await import("@/lib/gsc-cache");
       const fetcher = vi.fn().mockRejectedValue(new Error("quota"));
       await expect(

--- a/__tests__/lib-coverage-gaps.test.ts
+++ b/__tests__/lib-coverage-gaps.test.ts
@@ -232,25 +232,10 @@ describe("stripe-transactions.ts", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     vi.resetModules();
-    process.env.STRIPE_TRANSACTIONS_TABLE = "test-stripe-events";
+    delete (globalThis as { __AUTH_DB__?: unknown }).__AUTH_DB__;
   });
   afterEach(() => {
-    delete process.env.STRIPE_TRANSACTIONS_TABLE;
-  });
-
-  describe("resolveDynamoEndpoint", () => {
-    it("returns undefined when DYNAMODB_ENDPOINT not set", async () => {
-      delete process.env.DYNAMODB_ENDPOINT;
-      const { resolveDynamoEndpoint } = await import("@/lib/stripe-transactions");
-      expect(resolveDynamoEndpoint()).toBeUndefined();
-    });
-
-    it("returns custom endpoint when DYNAMODB_ENDPOINT set", async () => {
-      process.env.DYNAMODB_ENDPOINT = "http://localhost:8000";
-      const { resolveDynamoEndpoint } = await import("@/lib/stripe-transactions");
-      expect(resolveDynamoEndpoint()).toBe("http://localhost:8000");
-      delete process.env.DYNAMODB_ENDPOINT;
-    });
+    delete (globalThis as { __AUTH_DB__?: unknown }).__AUTH_DB__;
   });
 
   describe("getStripeEventTags", () => {
@@ -287,8 +272,7 @@ describe("stripe-transactions.ts", () => {
   });
 
   describe("persistStripeEvent", () => {
-    it("throws when STRIPE_TRANSACTIONS_TABLE is not set", async () => {
-      delete process.env.STRIPE_TRANSACTIONS_TABLE;
+    it("throws when AUTH_DB is unbound", async () => {
       const { persistStripeEvent } = await import("@/lib/stripe-transactions");
       await expect(
         persistStripeEvent({
@@ -297,22 +281,7 @@ describe("stripe-transactions.ts", () => {
           data: { object: {} },
           created: 1700000000,
         } as never)
-      ).rejects.toThrow(/STRIPE_TRANSACTIONS_TABLE is not configured/);
-    });
-
-    it("proceeds with table name set (hits DynamoDB stub)", async () => {
-      process.env.STRIPE_TRANSACTIONS_TABLE = "test-table";
-      const { persistStripeEvent } = await import("@/lib/stripe-transactions");
-      // DynamoDB stub has no send method → will throw; verify it at least
-      // gets past the table name check and fails on the client, not config.
-      await expect(
-        persistStripeEvent({
-          id: "evt_1",
-          type: "checkout.session.completed",
-          data: { object: {} },
-          created: 1700000000,
-        } as never)
-      ).rejects.toThrow();
+      ).rejects.toThrow(/AUTH_DB is not configured/);
     });
   });
 });

--- a/__tests__/stripe-analytics-read.test.ts
+++ b/__tests__/stripe-analytics-read.test.ts
@@ -1,40 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import type { AuthDatabase } from "@/lib/auth-d1";
 
-const mockSend = vi.fn();
-
-vi.mock("@aws-sdk/client-dynamodb", () => ({
-  DynamoDBClient: vi.fn(function (this: { send: typeof mockSend }) {
-    this.send = mockSend;
-  }),
-  QueryCommand: vi.fn(function (this: { input: unknown }, input: unknown) {
-    this.input = input;
-  }),
-  ScanCommand: vi.fn(function (this: { input: unknown }, input: unknown) {
-    this.input = input;
-  }),
-}));
-
-vi.mock("@/lib/stripe-transactions", () => ({
-  resolveDynamoEndpoint: vi.fn(() => undefined),
-}));
-
-const TABLE_NAME = "test-transactions-table";
-
-function makeItem(overrides: Record<string, unknown> = {}) {
-  return {
-    eventDay: { S: "2026-01-15" },
-    tagCategory: { S: "checkout" },
-    processingStatus: { S: "processed" },
-    currency: { S: "eur" },
-    amountMinor: { N: "4900" },
-    ...overrides,
-  };
-}
-
-function createAnalyticsAuthDb(
-  rows: Array<Record<string, unknown>>
-): AuthDatabase {
+function createAnalyticsAuthDb(rows: Array<Record<string, unknown>>): AuthDatabase {
   return {
     prepare(query: string) {
       const binds: unknown[] = [];
@@ -70,8 +37,6 @@ function createAnalyticsAuthDb(
 describe("getStripeAnalyticsSnapshot()", () => {
   beforeEach(() => {
     vi.resetModules();
-    vi.clearAllMocks();
-    process.env.STRIPE_TRANSACTIONS_TABLE = TABLE_NAME;
     delete (globalThis as { __AUTH_DB__?: unknown }).__AUTH_DB__;
   });
 
@@ -79,16 +44,13 @@ describe("getStripeAnalyticsSnapshot()", () => {
     delete (globalThis as { __AUTH_DB__?: unknown }).__AUTH_DB__;
   });
 
-  it("throws when STRIPE_TRANSACTIONS_TABLE is not set and D1 is unbound", async () => {
-    delete process.env.STRIPE_TRANSACTIONS_TABLE;
+  it("throws when AUTH_DB is unbound", async () => {
     const { getStripeAnalyticsSnapshot } = await import("@/lib/stripe-analytics-read");
-    await expect(getStripeAnalyticsSnapshot()).rejects.toThrow(
-      "STRIPE_TRANSACTIONS_TABLE is not configured"
-    );
+    await expect(getStripeAnalyticsSnapshot()).rejects.toThrow("AUTH_DB is not configured");
   });
 
-  it("returns an empty snapshot when DynamoDB returns no items", async () => {
-    mockSend.mockResolvedValue({ Items: [], LastEvaluatedKey: undefined });
+  it("returns an empty snapshot when D1 returns no rows", async () => {
+    (globalThis as { __AUTH_DB__?: AuthDatabase }).__AUTH_DB__ = createAnalyticsAuthDb([]);
     const { getStripeAnalyticsSnapshot } = await import("@/lib/stripe-analytics-read");
     const result = await getStripeAnalyticsSnapshot(7);
     expect(result.totals.events).toBe(0);
@@ -97,27 +59,37 @@ describe("getStripeAnalyticsSnapshot()", () => {
     expect(result.dailyTrend).toHaveLength(7);
   });
 
-  it("aggregates totals correctly from items", async () => {
+  it("aggregates totals correctly from D1 rows", async () => {
     const today = new Date().toISOString().slice(0, 10);
-    const items = [
-      makeItem({
-        eventDay: { S: today },
-        amountMinor: { N: "1000" },
-        processingStatus: { S: "processed" },
-      }),
-      makeItem({
-        eventDay: { S: today },
-        amountMinor: { N: "2000" },
-        processingStatus: { S: "processed" },
-      }),
-      makeItem({
-        eventDay: { S: today },
-        amountMinor: { N: "500" },
-        processingStatus: { S: "handler_failed" },
-      }),
-    ];
-    // 1-day window → single DynamoDB query; no multi-day accumulation
-    mockSend.mockResolvedValue({ Items: items, LastEvaluatedKey: undefined });
+    (globalThis as { __AUTH_DB__?: AuthDatabase }).__AUTH_DB__ = createAnalyticsAuthDb([
+      {
+        event_day: today,
+        tag_category: "checkout",
+        processing_status: "processed",
+        currency: "eur",
+        amount_minor: 1000,
+        received_at: Date.now(),
+        payload_json: null,
+      },
+      {
+        event_day: today,
+        tag_category: "checkout",
+        processing_status: "processed",
+        currency: "eur",
+        amount_minor: 2000,
+        received_at: Date.now(),
+        payload_json: null,
+      },
+      {
+        event_day: today,
+        tag_category: "checkout",
+        processing_status: "handler_failed",
+        currency: "eur",
+        amount_minor: 500,
+        received_at: Date.now(),
+        payload_json: null,
+      },
+    ]);
     const { getStripeAnalyticsSnapshot } = await import("@/lib/stripe-analytics-read");
     const result = await getStripeAnalyticsSnapshot(1);
     expect(result.totals.events).toBe(3);
@@ -128,24 +100,35 @@ describe("getStripeAnalyticsSnapshot()", () => {
 
   it("groups events by category", async () => {
     const today = new Date().toISOString().slice(0, 10);
-    const items = [
-      makeItem({
-        eventDay: { S: today },
-        tagCategory: { S: "checkout" },
-        amountMinor: { N: "1000" },
-      }),
-      makeItem({
-        eventDay: { S: today },
-        tagCategory: { S: "subscription" },
-        amountMinor: { N: "2000" },
-      }),
-      makeItem({
-        eventDay: { S: today },
-        tagCategory: { S: "checkout" },
-        amountMinor: { N: "500" },
-      }),
-    ];
-    mockSend.mockResolvedValue({ Items: items, LastEvaluatedKey: undefined });
+    (globalThis as { __AUTH_DB__?: AuthDatabase }).__AUTH_DB__ = createAnalyticsAuthDb([
+      {
+        event_day: today,
+        tag_category: "checkout",
+        processing_status: "processed",
+        currency: "eur",
+        amount_minor: 1000,
+        received_at: Date.now(),
+        payload_json: null,
+      },
+      {
+        event_day: today,
+        tag_category: "subscription",
+        processing_status: "processed",
+        currency: "eur",
+        amount_minor: 2000,
+        received_at: Date.now(),
+        payload_json: null,
+      },
+      {
+        event_day: today,
+        tag_category: "checkout",
+        processing_status: "processed",
+        currency: "eur",
+        amount_minor: 500,
+        received_at: Date.now(),
+        payload_json: null,
+      },
+    ]);
     const { getStripeAnalyticsSnapshot } = await import("@/lib/stripe-analytics-read");
     const result = await getStripeAnalyticsSnapshot(1);
     expect(result.byCategory.checkout.events).toBe(2);
@@ -156,12 +139,35 @@ describe("getStripeAnalyticsSnapshot()", () => {
 
   it("groups events by status", async () => {
     const today = new Date().toISOString().slice(0, 10);
-    const items = [
-      makeItem({ eventDay: { S: today }, processingStatus: { S: "processed" } }),
-      makeItem({ eventDay: { S: today }, processingStatus: { S: "processed" } }),
-      makeItem({ eventDay: { S: today }, processingStatus: { S: "handler_failed" } }),
-    ];
-    mockSend.mockResolvedValue({ Items: items, LastEvaluatedKey: undefined });
+    (globalThis as { __AUTH_DB__?: AuthDatabase }).__AUTH_DB__ = createAnalyticsAuthDb([
+      {
+        event_day: today,
+        tag_category: "checkout",
+        processing_status: "processed",
+        currency: "eur",
+        amount_minor: 0,
+        received_at: Date.now(),
+        payload_json: null,
+      },
+      {
+        event_day: today,
+        tag_category: "checkout",
+        processing_status: "processed",
+        currency: "eur",
+        amount_minor: 0,
+        received_at: Date.now(),
+        payload_json: null,
+      },
+      {
+        event_day: today,
+        tag_category: "checkout",
+        processing_status: "handler_failed",
+        currency: "eur",
+        amount_minor: 0,
+        received_at: Date.now(),
+        payload_json: null,
+      },
+    ]);
     const { getStripeAnalyticsSnapshot } = await import("@/lib/stripe-analytics-read");
     const result = await getStripeAnalyticsSnapshot(1);
     expect(result.byStatus.processed).toBe(2);
@@ -170,11 +176,26 @@ describe("getStripeAnalyticsSnapshot()", () => {
 
   it("groups events by currency", async () => {
     const today = new Date().toISOString().slice(0, 10);
-    const items = [
-      makeItem({ eventDay: { S: today }, currency: { S: "eur" }, amountMinor: { N: "1000" } }),
-      makeItem({ eventDay: { S: today }, currency: { S: "usd" }, amountMinor: { N: "2000" } }),
-    ];
-    mockSend.mockResolvedValue({ Items: items, LastEvaluatedKey: undefined });
+    (globalThis as { __AUTH_DB__?: AuthDatabase }).__AUTH_DB__ = createAnalyticsAuthDb([
+      {
+        event_day: today,
+        tag_category: "checkout",
+        processing_status: "processed",
+        currency: "eur",
+        amount_minor: 1000,
+        received_at: Date.now(),
+        payload_json: null,
+      },
+      {
+        event_day: today,
+        tag_category: "checkout",
+        processing_status: "processed",
+        currency: "usd",
+        amount_minor: 2000,
+        received_at: Date.now(),
+        payload_json: null,
+      },
+    ]);
     const { getStripeAnalyticsSnapshot } = await import("@/lib/stripe-analytics-read");
     const result = await getStripeAnalyticsSnapshot(1);
     expect(result.byCurrency.eur).toBe(1000);
@@ -182,7 +203,7 @@ describe("getStripeAnalyticsSnapshot()", () => {
   });
 
   it("clamps days to [1, 365]", async () => {
-    mockSend.mockResolvedValue({ Items: [], LastEvaluatedKey: undefined });
+    (globalThis as { __AUTH_DB__?: AuthDatabase }).__AUTH_DB__ = createAnalyticsAuthDb([]);
     const { getStripeAnalyticsSnapshot } = await import("@/lib/stripe-analytics-read");
 
     const resultMin = await getStripeAnalyticsSnapshot(0);
@@ -194,44 +215,39 @@ describe("getStripeAnalyticsSnapshot()", () => {
     expect(resultMax.dailyTrend).toHaveLength(365);
   });
 
-  it("falls back to scan when index is missing", async () => {
-    const validationError = Object.assign(new Error("Query condition missed key schema element"), {
-      name: "ValidationException",
-    });
+  it("derives amount/currency from payload_json when columns are null", async () => {
     const today = new Date().toISOString().slice(0, 10);
-    mockSend
-      .mockRejectedValueOnce(validationError) // query fails
-      .mockResolvedValueOnce({
-        // scan succeeds
-        Items: [makeItem({ eventDay: { S: today }, amountMinor: { N: "9900" } })],
-        LastEvaluatedKey: undefined,
-      });
+    (globalThis as { __AUTH_DB__?: AuthDatabase }).__AUTH_DB__ = createAnalyticsAuthDb([
+      {
+        event_day: today,
+        tag_category: "subscription",
+        processing_status: "handler_failed",
+        currency: null,
+        amount_minor: null,
+        received_at: Date.now(),
+        payload_json: JSON.stringify({ amount_total: 2500, currency: "usd" }),
+      },
+    ]);
     const { getStripeAnalyticsSnapshot } = await import("@/lib/stripe-analytics-read");
     const result = await getStripeAnalyticsSnapshot(1);
     expect(result.totals.events).toBe(1);
-    expect(result.totals.revenueMinor).toBe(9900);
+    expect(result.totals.revenueMinor).toBe(2500);
+    expect(result.byCurrency.usd).toBe(2500);
   });
 
-  it("derives day from stripeCreatedAt when eventDay is missing", async () => {
-    const epoch = Math.floor(Date.now() / 1000); // use "now" so the day falls in the 1-day window
-    const item = {
-      stripeCreatedAt: { N: `${epoch}` },
-      tagCategory: { S: "checkout" },
-      processingStatus: { S: "processed" },
-      currency: { S: "eur" },
-      amountMinor: { N: "1000" },
-    };
-    // 1-day window → single query, returns 1 item
-    mockSend.mockResolvedValue({ Items: [item], LastEvaluatedKey: undefined });
-    const { getStripeAnalyticsSnapshot } = await import("@/lib/stripe-analytics-read");
-    const result = await getStripeAnalyticsSnapshot(1);
-    expect(result.totals.events).toBe(1);
-  });
-
-  it("handles items with unknown category defaulting to 'other'", async () => {
+  it("handles rows with unknown category defaulting to 'other'", async () => {
     const today = new Date().toISOString().slice(0, 10);
-    const item = makeItem({ eventDay: { S: today }, tagCategory: undefined });
-    mockSend.mockResolvedValue({ Items: [item], LastEvaluatedKey: undefined });
+    (globalThis as { __AUTH_DB__?: AuthDatabase }).__AUTH_DB__ = createAnalyticsAuthDb([
+      {
+        event_day: today,
+        tag_category: null,
+        processing_status: "processed",
+        currency: "eur",
+        amount_minor: 1000,
+        received_at: Date.now(),
+        payload_json: null,
+      },
+    ]);
     const { getStripeAnalyticsSnapshot } = await import("@/lib/stripe-analytics-read");
     const result = await getStripeAnalyticsSnapshot(1);
     expect(result.byCategory.other).toBeDefined();
@@ -239,16 +255,15 @@ describe("getStripeAnalyticsSnapshot()", () => {
   });
 
   it("includes generatedAt as an ISO timestamp string", async () => {
-    mockSend.mockResolvedValue({ Items: [], LastEvaluatedKey: undefined });
+    (globalThis as { __AUTH_DB__?: AuthDatabase }).__AUTH_DB__ = createAnalyticsAuthDb([]);
     const { getStripeAnalyticsSnapshot } = await import("@/lib/stripe-analytics-read");
     const result = await getStripeAnalyticsSnapshot(7);
     expect(typeof result.generatedAt).toBe("string");
     expect(new Date(result.generatedAt).getTime()).toBeGreaterThan(0);
   });
 
-  it("prefers D1 stripe_transaction when AUTH_DB is bound", async () => {
+  it("aggregates mixed D1 rows with payload fallback", async () => {
     const today = new Date().toISOString().slice(0, 10);
-    delete process.env.STRIPE_TRANSACTIONS_TABLE;
     (globalThis as { __AUTH_DB__?: AuthDatabase }).__AUTH_DB__ = createAnalyticsAuthDb([
       {
         event_day: today,
@@ -273,7 +288,6 @@ describe("getStripeAnalyticsSnapshot()", () => {
     const { getStripeAnalyticsSnapshot } = await import("@/lib/stripe-analytics-read");
     const result = await getStripeAnalyticsSnapshot(1);
 
-    expect(mockSend).not.toHaveBeenCalled();
     expect(result.totals.events).toBe(2);
     expect(result.totals.revenueMinor).toBe(4000);
     expect(result.totals.processed).toBe(1);

--- a/__tests__/stripe-transactions-integration.test.ts
+++ b/__tests__/stripe-transactions-integration.test.ts
@@ -1,27 +1,10 @@
-import { afterEach, beforeAll, describe, expect, it, vi } from "vitest";
+/**
+ * D1-backed integration-style tests for stripe-transactions.
+ * Uses an in-memory AUTH_DB stub (no LocalStack / Dynamo).
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type Stripe from "stripe";
-
-const ENDPOINT = process.env.AWS_ENDPOINT_URL ?? "http://localhost:4566";
-const TABLE = process.env.STRIPE_TRANSACTIONS_TABLE ?? "cloudless-test-StripeTransactions";
-
-async function dynamoUp(): Promise<boolean> {
-  try {
-    const res = await fetch(`${ENDPOINT}/_localstack/health`, {
-      signal: AbortSignal.timeout(1500),
-    });
-    return res.ok;
-  } catch {
-    return false;
-  }
-}
-
-function setEnv() {
-  vi.stubEnv("DYNAMODB_ENDPOINT", ENDPOINT);
-  vi.stubEnv("STRIPE_TRANSACTIONS_TABLE", TABLE);
-  vi.stubEnv("AWS_REGION", "us-east-1");
-  vi.stubEnv("AWS_ACCESS_KEY_ID", "test");
-  vi.stubEnv("AWS_SECRET_ACCESS_KEY", "test");
-}
+import type { AuthDatabase } from "@/lib/auth-d1";
 
 function makeEvent(id: string, type = "checkout.session.completed"): Stripe.Event {
   return {
@@ -48,30 +31,64 @@ function makeEvent(id: string, type = "checkout.session.completed"): Stripe.Even
   } as unknown as Stripe.Event;
 }
 
-let skipAll = false;
-beforeAll(async () => {
-  skipAll = !(await dynamoUp());
-});
-afterEach(() => {
-  vi.unstubAllEnvs();
+function createMemoryAuthDb(): AuthDatabase & { rows: Map<string, Record<string, unknown>> } {
+  const rows = new Map<string, Record<string, unknown>>();
+  return {
+    rows,
+    prepare(query: string) {
+      const binds: unknown[] = [];
+      const stmt = {
+        bind(...args: unknown[]) {
+          binds.push(...args);
+          return stmt;
+        },
+        async run() {
+          if (query.includes("INSERT INTO stripe_transaction")) {
+            const eventId = String(binds[0]);
+            if (rows.has(eventId)) {
+              throw new Error("UNIQUE constraint failed: stripe_transaction.event_id");
+            }
+            rows.set(eventId, { event_id: eventId, processing_status: binds[7] });
+            return { success: true, meta: { changes: 1 } };
+          }
+          return { success: true, meta: { changes: 0 } };
+        },
+        async all() {
+          return { results: [], success: true };
+        },
+        async first() {
+          return null;
+        },
+      };
+      return stmt;
+    },
+  };
+}
+
+beforeEach(() => {
+  delete (globalThis as { __AUTH_DB__?: unknown }).__AUTH_DB__;
   vi.resetModules();
 });
 
-describe("stripe-transactions integration", () => {
-  it("persistStripeEvent stores new event", async ({ skip }) => {
-    if (skipAll) return skip();
-    setEnv();
-    vi.resetModules();
+afterEach(() => {
+  delete (globalThis as { __AUTH_DB__?: unknown }).__AUTH_DB__;
+  vi.resetModules();
+});
+
+describe("stripe-transactions integration (D1)", () => {
+  it("persistStripeEvent stores new event", async () => {
+    const db = createMemoryAuthDb();
+    (globalThis as { __AUTH_DB__?: AuthDatabase }).__AUTH_DB__ = db;
     const { persistStripeEvent } = await import("@/lib/stripe-transactions");
     const id = "evt_new_" + Date.now() + "_" + Math.random().toString(36).slice(2, 6);
     const r = await persistStripeEvent(makeEvent(id));
     expect(r.duplicate).toBe(false);
+    expect(db.rows.has(id)).toBe(true);
   });
 
-  it("persistStripeEvent returns duplicate on re-write", async ({ skip }) => {
-    if (skipAll) return skip();
-    setEnv();
-    vi.resetModules();
+  it("persistStripeEvent returns duplicate on re-write", async () => {
+    const db = createMemoryAuthDb();
+    (globalThis as { __AUTH_DB__?: AuthDatabase }).__AUTH_DB__ = db;
     const { persistStripeEvent } = await import("@/lib/stripe-transactions");
     const id = "evt_dup_" + Date.now();
     const ev = makeEvent(id);

--- a/__tests__/stripe-transactions.test.ts
+++ b/__tests__/stripe-transactions.test.ts
@@ -122,26 +122,17 @@ describe("stripe transaction tags", () => {
     const tags = getStripeEventTags("charge.dispute.created");
     expect(tags.tagCategory).toBe("other");
   });
-
-  it("rejects non-https custom dynamodb endpoints", async () => {
-    process.env.DYNAMODB_ENDPOINT = "http://internal-dynamo:8000";
-    const { resolveDynamoEndpoint } = await import("@/lib/stripe-transactions");
-    expect(() => resolveDynamoEndpoint()).toThrow("must use HTTPS");
-    delete process.env.DYNAMODB_ENDPOINT;
-  });
-
-  it("allows https dynamodb endpoints", async () => {
-    process.env.DYNAMODB_ENDPOINT = "https://dynamodb.us-east-1.amazonaws.com";
-    const { resolveDynamoEndpoint } = await import("@/lib/stripe-transactions");
-    expect(resolveDynamoEndpoint()).toBe("https://dynamodb.us-east-1.amazonaws.com");
-    delete process.env.DYNAMODB_ENDPOINT;
-  });
 });
 
 describe("stripe transactions D1 idempotency", () => {
   afterEach(() => {
     delete (globalThis as { __AUTH_DB__?: unknown }).__AUTH_DB__;
     vi.resetModules();
+  });
+
+  it("throws when AUTH_DB is unbound", async () => {
+    const { persistStripeEvent } = await import("@/lib/stripe-transactions");
+    await expect(persistStripeEvent(makeEvent("evt_no_db"))).rejects.toThrow(/AUTH_DB/);
   });
 
   it("persists via D1 and reports duplicates on UNIQUE", async () => {

--- a/__tests__/user-profile-lib.test.ts
+++ b/__tests__/user-profile-lib.test.ts
@@ -1,55 +1,55 @@
 /**
- * src/lib/user-profile.ts — DynamoDB-backed profile store.
- *
- * Mocks the DynamoDB client `send` and asserts the command shapes:
- *   - getUserProfile maps the item back, parsing preferences JSON
- *   - putUserProfile builds a partial SET/REMOVE UpdateItem (name is a reserved
- *     word → expression attribute names), and is a no-op when nothing changes
+ * src/lib/user-profile.ts — D1-backed profile store.
  *
  * @vitest-environment node
  */
-import { describe, it, expect, beforeEach, vi } from "vitest";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import type { AuthDatabase } from "@/lib/auth-d1";
 
-const sendMock = vi.fn();
-vi.mock("@aws-sdk/client-dynamodb", () => {
-  class Cmd {
-    input: Record<string, unknown>;
-    _t = "Base";
-    constructor(input: Record<string, unknown>) {
-      this.input = input;
-    }
-  }
-  const mk = (t: string) =>
-    class extends Cmd {
-      _t = t;
-    };
+const { getUserByIdMock, patchUserProfileMock } = vi.hoisted(() => ({
+  getUserByIdMock: vi.fn(),
+  patchUserProfileMock: vi.fn(),
+}));
+
+vi.mock("@/lib/auth-d1", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/auth-d1")>();
   return {
-    DynamoDBClient: class {
-      send = sendMock;
-    },
-    GetItemCommand: mk("GetItem"),
-    UpdateItemCommand: mk("UpdateItem"),
+    ...actual,
+    getAuthDbFromEnv: () =>
+      (globalThis as { __AUTH_DB__?: AuthDatabase }).__AUTH_DB__ ?? null,
+    getUserById: (...args: unknown[]) => getUserByIdMock(...args),
+    patchUserProfile: (...args: unknown[]) => patchUserProfileMock(...args),
   };
 });
 
-// resolveDynamoEndpoint is imported from stripe-transactions; stub it cheaply.
-vi.mock("@/lib/stripe-transactions", () => ({ resolveDynamoEndpoint: () => undefined }));
-
 beforeEach(() => {
-  sendMock.mockReset();
-  process.env.USER_PROFILE_TABLE = "cloudless-user-profile";
+  getUserByIdMock.mockReset();
+  patchUserProfileMock.mockReset();
+  delete (globalThis as { __AUTH_DB__?: unknown }).__AUTH_DB__;
+  vi.resetModules();
 });
 
+afterEach(() => {
+  delete (globalThis as { __AUTH_DB__?: unknown }).__AUTH_DB__;
+});
+
+const fakeDb = { prepare: vi.fn() } as unknown as AuthDatabase;
+
 describe("getUserProfile", () => {
-  it("maps a stored item and parses preferences JSON", async () => {
-    sendMock.mockResolvedValue({
-      Item: {
-        userId: { S: "sub-1" },
-        name: { S: "Stored Name" },
-        company: { S: "cloudless.gr" },
-        phone: { S: "+30123" },
-        preferences: { S: JSON.stringify({ theme: "light" }) },
-      },
+  it("returns {} when AUTH_DB is unbound", async () => {
+    const { getUserProfile } = await import("@/lib/user-profile");
+    expect(await getUserProfile("sub-1")).toEqual({});
+    expect(getUserByIdMock).not.toHaveBeenCalled();
+  });
+
+  it("maps a stored D1 user and parses preferences JSON", async () => {
+    (globalThis as { __AUTH_DB__?: AuthDatabase }).__AUTH_DB__ = fakeDb;
+    getUserByIdMock.mockResolvedValue({
+      id: "sub-1",
+      name: "Stored Name",
+      company: "cloudless.gr",
+      phone: "+30123",
+      preferences_json: JSON.stringify({ theme: "light" }),
     });
     const { getUserProfile } = await import("@/lib/user-profile");
     const p = await getUserProfile("sub-1");
@@ -59,19 +59,23 @@ describe("getUserProfile", () => {
       phone: "+30123",
       preferences: { theme: "light" },
     });
-    const call = sendMock.mock.calls[0][0];
-    expect(call._t).toBe("GetItem");
-    expect(call.input.Key).toEqual({ userId: { S: "sub-1" } });
+    expect(getUserByIdMock).toHaveBeenCalledWith(fakeDb, "sub-1");
   });
 
-  it("returns {} when no record exists", async () => {
-    sendMock.mockResolvedValue({});
+  it("returns {} when no user exists", async () => {
+    (globalThis as { __AUTH_DB__?: AuthDatabase }).__AUTH_DB__ = fakeDb;
+    getUserByIdMock.mockResolvedValue(null);
     const { getUserProfile } = await import("@/lib/user-profile");
     expect(await getUserProfile("sub-x")).toEqual({});
   });
 
   it("ignores malformed stored preferences", async () => {
-    sendMock.mockResolvedValue({ Item: { name: { S: "A" }, preferences: { S: "{not-json" } } });
+    (globalThis as { __AUTH_DB__?: AuthDatabase }).__AUTH_DB__ = fakeDb;
+    getUserByIdMock.mockResolvedValue({
+      id: "sub-1",
+      name: "A",
+      preferences_json: "{not-json",
+    });
     const { getUserProfile } = await import("@/lib/user-profile");
     const p = await getUserProfile("sub-1");
     expect(p.name).toBe("A");
@@ -80,48 +84,52 @@ describe("getUserProfile", () => {
 });
 
 describe("putUserProfile", () => {
-  it("builds a SET UpdateItem with expression attribute names", async () => {
-    sendMock.mockResolvedValue({});
+  it("throws when AUTH_DB is unbound", async () => {
+    const { putUserProfile } = await import("@/lib/user-profile");
+    await expect(putUserProfile("sub-1", { name: "N" })).rejects.toThrow(/AUTH_DB/);
+  });
+
+  it("calls patchUserProfile with fields", async () => {
+    (globalThis as { __AUTH_DB__?: AuthDatabase }).__AUTH_DB__ = fakeDb;
+    patchUserProfileMock.mockResolvedValue(true);
     const { putUserProfile } = await import("@/lib/user-profile");
     await putUserProfile("sub-1", { name: "N", company: "C", phone: "+30" });
-
-    const call = sendMock.mock.calls[0][0];
-    expect(call._t).toBe("UpdateItem");
-    expect(call.input.Key).toEqual({ userId: { S: "sub-1" } });
-    expect(call.input.UpdateExpression).toContain("SET");
-    expect(call.input.ExpressionAttributeNames).toMatchObject({
-      "#name": "name",
-      "#company": "company",
-      "#phone": "phone",
-    });
-    expect(call.input.ExpressionAttributeValues).toMatchObject({
-      ":name": { S: "N" },
-      ":company": { S: "C" },
-      ":phone": { S: "+30" },
+    expect(patchUserProfileMock).toHaveBeenCalledWith(fakeDb, "sub-1", {
+      name: "N",
+      company: "C",
+      phone: "+30",
     });
   });
 
-  it("serializes preferences to a JSON string", async () => {
-    sendMock.mockResolvedValue({});
+  it("serializes preferences via patchUserProfile", async () => {
+    (globalThis as { __AUTH_DB__?: AuthDatabase }).__AUTH_DB__ = fakeDb;
+    patchUserProfileMock.mockResolvedValue(true);
     const { putUserProfile } = await import("@/lib/user-profile");
     await putUserProfile("sub-1", { preferences: { theme: "dark", language: "en" } });
-    const call = sendMock.mock.calls[0][0];
-    expect(call.input.ExpressionAttributeValues[":preferences"].S).toBe(
-      JSON.stringify({ theme: "dark", language: "en" })
-    );
+    expect(patchUserProfileMock).toHaveBeenCalledWith(fakeDb, "sub-1", {
+      preferences: { theme: "dark", language: "en" },
+    });
   });
 
-  it("REMOVEs a field cleared with an empty string", async () => {
-    sendMock.mockResolvedValue({});
+  it("clears a field with an empty string", async () => {
+    (globalThis as { __AUTH_DB__?: AuthDatabase }).__AUTH_DB__ = fakeDb;
+    patchUserProfileMock.mockResolvedValue(true);
     const { putUserProfile } = await import("@/lib/user-profile");
     await putUserProfile("sub-1", { phone: "" });
-    const call = sendMock.mock.calls[0][0];
-    expect(call.input.UpdateExpression).toContain("REMOVE #phone");
+    expect(patchUserProfileMock).toHaveBeenCalledWith(fakeDb, "sub-1", { phone: "" });
   });
 
-  it("is a no-op when no fields are provided (no Dynamo call)", async () => {
+  it("is a no-op when no fields are provided", async () => {
+    (globalThis as { __AUTH_DB__?: AuthDatabase }).__AUTH_DB__ = fakeDb;
     const { putUserProfile } = await import("@/lib/user-profile");
     await putUserProfile("sub-1", {});
-    expect(sendMock).not.toHaveBeenCalled();
+    expect(patchUserProfileMock).not.toHaveBeenCalled();
+  });
+
+  it("throws when user is not found", async () => {
+    (globalThis as { __AUTH_DB__?: AuthDatabase }).__AUTH_DB__ = fakeDb;
+    patchUserProfileMock.mockResolvedValue(false);
+    const { putUserProfile } = await import("@/lib/user-profile");
+    await expect(putUserProfile("sub-1", { name: "N" })).rejects.toThrow(/User not found/);
   });
 });

--- a/__tests__/user-profile.test.ts
+++ b/__tests__/user-profile.test.ts
@@ -1,60 +1,55 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import type { AuthDatabase } from "@/lib/auth-d1";
 
-const { mockDynamoSend, getCalls, updateCalls } = vi.hoisted(() => ({
-  mockDynamoSend: vi.fn(),
-  getCalls: [] as unknown[],
-  updateCalls: [] as unknown[],
+const { getUserByIdMock, patchUserProfileMock } = vi.hoisted(() => ({
+  getUserByIdMock: vi.fn(),
+  patchUserProfileMock: vi.fn(),
 }));
 
-vi.mock("@aws-sdk/client-dynamodb", () => ({
-  DynamoDBClient: vi.fn().mockImplementation(function () {
-    return { send: mockDynamoSend };
-  }),
-  GetItemCommand: vi.fn().mockImplementation(function (input: unknown) {
-    getCalls.push(input);
-    return { __cmd: "Get", input };
-  }),
-  UpdateItemCommand: vi.fn().mockImplementation(function (input: unknown) {
-    updateCalls.push(input);
-    return { __cmd: "Update", input };
-  }),
-}));
-
-vi.mock("@/lib/stripe-transactions", () => ({
-  resolveDynamoEndpoint: () => "http://localhost:8000",
-}));
+vi.mock("@/lib/auth-d1", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/auth-d1")>();
+  return {
+    ...actual,
+    getAuthDbFromEnv: () =>
+      (globalThis as { __AUTH_DB__?: AuthDatabase }).__AUTH_DB__ ?? null,
+    getUserById: (...args: unknown[]) => getUserByIdMock(...args),
+    patchUserProfile: (...args: unknown[]) => patchUserProfileMock(...args),
+  };
+});
 
 import { getUserProfile, putUserProfile } from "@/lib/user-profile";
 
 describe("user-profile", () => {
-  const originalTable = process.env.USER_PROFILE_TABLE;
+  const fakeDb = { prepare: vi.fn() } as unknown as AuthDatabase;
 
   beforeEach(() => {
-    mockDynamoSend.mockReset();
-    getCalls.length = 0;
-    updateCalls.length = 0;
-    process.env.USER_PROFILE_TABLE = "test-user-profile-table";
+    getUserByIdMock.mockReset();
+    patchUserProfileMock.mockReset();
+    delete (globalThis as { __AUTH_DB__?: unknown }).__AUTH_DB__;
   });
 
   afterEach(() => {
-    if (originalTable === undefined) delete process.env.USER_PROFILE_TABLE;
-    else process.env.USER_PROFILE_TABLE = originalTable;
+    delete (globalThis as { __AUTH_DB__?: unknown }).__AUTH_DB__;
   });
 
   describe("getUserProfile", () => {
-    it("returns {} when DynamoDB returns no item", async () => {
-      mockDynamoSend.mockResolvedValueOnce({});
-      const r = await getUserProfile("user-1");
-      expect(r).toEqual({});
+    it("returns {} when AUTH_DB is unbound", async () => {
+      expect(await getUserProfile("user-1")).toEqual({});
     });
 
-    it("maps stored String attributes back to fields", async () => {
-      mockDynamoSend.mockResolvedValueOnce({
-        Item: {
-          name: { S: "Themis" },
-          company: { S: "Cloudless" },
-          phone: { S: "+30..." },
-        },
+    it("returns {} when D1 returns no user", async () => {
+      (globalThis as { __AUTH_DB__?: AuthDatabase }).__AUTH_DB__ = fakeDb;
+      getUserByIdMock.mockResolvedValueOnce(null);
+      expect(await getUserProfile("user-1")).toEqual({});
+    });
+
+    it("maps stored fields back", async () => {
+      (globalThis as { __AUTH_DB__?: AuthDatabase }).__AUTH_DB__ = fakeDb;
+      getUserByIdMock.mockResolvedValueOnce({
+        id: "user-1",
+        name: "Themis",
+        company: "Cloudless",
+        phone: "+30...",
       });
       const r = await getUserProfile("user-1");
       expect(r.name).toBe("Themis");
@@ -62,95 +57,65 @@ describe("user-profile", () => {
       expect(r.phone).toBe("+30...");
     });
 
-    it("parses JSON preferences out of the stored String", async () => {
-      mockDynamoSend.mockResolvedValueOnce({
-        Item: {
-          preferences: { S: JSON.stringify({ theme: "dark", lang: "en" }) },
-        },
+    it("parses JSON preferences", async () => {
+      (globalThis as { __AUTH_DB__?: AuthDatabase }).__AUTH_DB__ = fakeDb;
+      getUserByIdMock.mockResolvedValueOnce({
+        id: "user-1",
+        preferences_json: JSON.stringify({ theme: "dark", lang: "en" }),
       });
       const r = await getUserProfile("user-1");
       expect(r.preferences).toEqual({ theme: "dark", lang: "en" });
     });
 
-    it("silently drops malformed JSON preferences (fallback to undefined)", async () => {
-      mockDynamoSend.mockResolvedValueOnce({
-        Item: { preferences: { S: "{not json" } },
+    it("silently drops malformed JSON preferences", async () => {
+      (globalThis as { __AUTH_DB__?: AuthDatabase }).__AUTH_DB__ = fakeDb;
+      getUserByIdMock.mockResolvedValueOnce({
+        id: "user-1",
+        preferences_json: "{not json",
       });
       const r = await getUserProfile("user-1");
       expect(r.preferences).toBeUndefined();
     });
-
-    it("throws when USER_PROFILE_TABLE is unset", async () => {
-      delete process.env.USER_PROFILE_TABLE;
-      await expect(getUserProfile("user-1")).rejects.toThrow(/USER_PROFILE_TABLE/);
-    });
-
-    it("treats whitespace-only USER_PROFILE_TABLE as unset", async () => {
-      process.env.USER_PROFILE_TABLE = "   ";
-      await expect(getUserProfile("user-1")).rejects.toThrow(/USER_PROFILE_TABLE/);
-    });
   });
 
   describe("putUserProfile", () => {
-    it("does not call DynamoDB when no fields are provided", async () => {
+    it("throws when AUTH_DB is unbound", async () => {
+      await expect(putUserProfile("user-1", { name: "Themis" })).rejects.toThrow(/AUTH_DB/);
+    });
+
+    it("does not call patch when no fields are provided", async () => {
+      (globalThis as { __AUTH_DB__?: AuthDatabase }).__AUTH_DB__ = fakeDb;
       await putUserProfile("user-1", {});
-      expect(mockDynamoSend).not.toHaveBeenCalled();
+      expect(patchUserProfileMock).not.toHaveBeenCalled();
     });
 
-    it("builds a SET clause for provided string fields", async () => {
-      mockDynamoSend.mockResolvedValueOnce({});
+    it("passes string fields to patchUserProfile", async () => {
+      (globalThis as { __AUTH_DB__?: AuthDatabase }).__AUTH_DB__ = fakeDb;
+      patchUserProfileMock.mockResolvedValueOnce(true);
       await putUserProfile("user-1", { name: "Themis", company: "Cloudless" });
-      expect(updateCalls).toHaveLength(1);
-      const input = updateCalls[0] as {
-        UpdateExpression: string;
-        ExpressionAttributeNames: Record<string, string>;
-        ExpressionAttributeValues: Record<string, { S: string }>;
-      };
-      expect(input.UpdateExpression.startsWith("SET")).toBe(true);
-      expect(input.UpdateExpression).toContain("#name = :name");
-      expect(input.UpdateExpression).toContain("#company = :company");
-      expect(input.ExpressionAttributeNames["#name"]).toBe("name");
-      expect(input.ExpressionAttributeValues[":name"]).toEqual({ S: "Themis" });
-    });
-
-    it("converts empty-string fields to REMOVE clauses", async () => {
-      mockDynamoSend.mockResolvedValueOnce({});
-      await putUserProfile("user-1", { name: "", phone: "" });
-      const input = updateCalls[0] as { UpdateExpression: string };
-      expect(input.UpdateExpression).toContain("REMOVE");
-      expect(input.UpdateExpression).toContain("#name");
-      expect(input.UpdateExpression).toContain("#phone");
-    });
-
-    it("combines SET and REMOVE in a single update", async () => {
-      mockDynamoSend.mockResolvedValueOnce({});
-      await putUserProfile("user-1", { name: "Themis", phone: "" });
-      const input = updateCalls[0] as { UpdateExpression: string };
-      expect(input.UpdateExpression).toContain("SET");
-      expect(input.UpdateExpression).toContain("REMOVE");
-    });
-
-    it("serializes preferences as JSON in a String attribute", async () => {
-      mockDynamoSend.mockResolvedValueOnce({});
-      await putUserProfile("user-1", { preferences: { theme: "dark" } });
-      const input = updateCalls[0] as {
-        ExpressionAttributeValues: Record<string, { S: string }>;
-      };
-      expect(JSON.parse(input.ExpressionAttributeValues[":preferences"].S)).toEqual({
-        theme: "dark",
+      expect(patchUserProfileMock).toHaveBeenCalledWith(fakeDb, "user-1", {
+        name: "Themis",
+        company: "Cloudless",
       });
     });
 
-    it("skips ExpressionAttributeValues when only REMOVE is needed", async () => {
-      mockDynamoSend.mockResolvedValueOnce({});
-      await putUserProfile("user-1", { name: "" });
-      const input = updateCalls[0] as {
-        UpdateExpression: string;
-        ExpressionAttributeValues?: Record<string, unknown>;
-      };
-      expect(input.UpdateExpression).toContain("REMOVE");
-      expect(input.UpdateExpression).not.toContain("SET");
-      expect(input.ExpressionAttributeValues).toBeUndefined();
+    it("passes empty-string clears through", async () => {
+      (globalThis as { __AUTH_DB__?: AuthDatabase }).__AUTH_DB__ = fakeDb;
+      patchUserProfileMock.mockResolvedValueOnce(true);
+      await putUserProfile("user-1", { name: "", phone: "" });
+      expect(patchUserProfileMock).toHaveBeenCalledWith(fakeDb, "user-1", {
+        name: "",
+        phone: "",
+      });
+    });
+
+    it("serializes preferences object through to patch", async () => {
+      (globalThis as { __AUTH_DB__?: AuthDatabase }).__AUTH_DB__ = fakeDb;
+      patchUserProfileMock.mockResolvedValueOnce(true);
+      await putUserProfile("user-1", { preferences: { theme: "dark" } });
+      expect(patchUserProfileMock).toHaveBeenCalledWith(fakeDb, "user-1", {
+        preferences: { theme: "dark" },
+      });
     });
   });
 });

--- a/docs/aws-to-cloudflare-migration.md
+++ b/docs/aws-to-cloudflare-migration.md
@@ -13,14 +13,15 @@
 | PR-13 | **Done in tree** | R2 I/O via `aws4fetch` (`r2-upload.ts`, `scripts/etl/_r2-config.mjs`); `@aws-sdk/client-s3` removed |
 | PR-04 | **Done in tree** | Admin users / activate / confirm / user delete → D1 only; Cognito SDK removed from those routes |
 | PR-05 | **Done in tree** | Cognito surface removed: no Hosted UI, no JWKS, no Cognito SDK, no fake sync-users; D1 cookie auth only; Cognito operator scripts archived under `scripts/archive/cognito/` |
+| PR-06 | **Done in tree** | Dynamo → D1: profiles, admin-notifications, GSC cache, Stripe txs/analytics, ad-analytics bookmarks; no `@aws-sdk/client-dynamodb` in `src/` |
 
 **Operator follow-ups before / after merge to main:**
 
 1. Email (Node/Pi) — **Cloudflare Email Sending LIVE** from the app pod (`CLOUDFLARE_EMAIL_API_TOKEN` + `CLOUDFLARE_API_TOKEN` in `cloudless-secrets`). `RESEND_API_KEY` still optional and **not set**.
 2. `CLOUDFLARE_ACCOUNT_ID` + `CLOUDFLARE_API_TOKEN` — **SET**; Workers AI embed smoke (`bge-small` → **384**) OK from app pod.
 3. Meili reindex — **done** (4 docs / 4 embeddings; `workers-ai-bge-small` @ 384; in-cluster `MEILI_HOST`). `CRON_SECRET` rotated after earlier job-log leak.
-4. **Next:** PR-06 (Dynamo → D1), then PR-14 (`pnpm remove` remaining `@aws-sdk/*`). Do not run PR-14 until Dynamo call sites are gone.
-5. Cognito is retired; tear down the User Pool in AWS when ready (PR-16).
+4. **Next:** PR-14 (`pnpm remove` remaining `@aws-sdk/*`). Do not run until Dynamo call sites stay gone on main.
+5. Cognito is retired; tear down the User Pool in AWS when ready (PR-16). Apply migration `0014-ad-analytics-bookmarks.sql` on AUTH_DB if bookmarks should persist across deploys.
 
 ---
 
@@ -61,7 +62,7 @@ PR-15 → PR-16 → PR-17       (archive → AWS teardown → Cost Explorer)
 | --------- | ----------------------------- | ------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------- | ---- | ------------------------------------- | ------------------------------------------------- |
 | **PR-04** | Auth admin Cognito → D1       | `/api/admin/users*`, confirm/activate/delete Cognito                                 | D1 users + admin role; drop `@aws-sdk/client-cognito-identity-provider`         | High | PR-01; **admin users migrated to D1** | Admin user CRUD works on D1; Cognito API unused   |
 | **PR-05** | Delete Cognito client surface | `cognito-auth.ts`, next-auth Cognito provider, Amplify shim, `NEXT_PUBLIC_COGNITO_*` | `auth-d1` + cookie sessions only                                                | High | PR-04                                 | **Done** — Login/signup D1-only; Cognito SDK removed from app |
-| **PR-06** | DynamoDB → D1                 | profiles, admin-notifications, GSC cache, Stripe txs, session store, bookmarks       | D1 tables + `*-d1` helpers; `scripts/migrate-dynamodb-to-d1.ts` if data remains | High | PR-01; **data verified in D1/R2**     | No `@aws-sdk/client-dynamodb` imports             |
+| **PR-06** | DynamoDB → D1                 | profiles, admin-notifications, GSC cache, Stripe txs, session store, bookmarks       | D1 tables + `*-d1` helpers; `scripts/migrate-dynamodb-to-d1.ts` if data remains | High | PR-01; **data verified in D1/R2**     | **Done in tree** — No `@aws-sdk/client-dynamodb` imports in `src/`             |
 
 **Gate:** Do not start Wave B until a one-time export confirms D1 (or R2) holds production rows that Dynamo still owns.
 

--- a/docs/aws-to-cloudflare-migration.md
+++ b/docs/aws-to-cloudflare-migration.md
@@ -13,15 +13,18 @@
 | PR-13 | **Done in tree** | R2 I/O via `aws4fetch` (`r2-upload.ts`, `scripts/etl/_r2-config.mjs`); `@aws-sdk/client-s3` removed |
 | PR-04 | **Done in tree** | Admin users / activate / confirm / user delete → D1 only; Cognito SDK removed from those routes |
 | PR-05 | **Done in tree** | Cognito surface removed: no Hosted UI, no JWKS, no Cognito SDK, no fake sync-users; D1 cookie auth only; Cognito operator scripts archived under `scripts/archive/cognito/` |
-| PR-06 | **Done in tree** | Dynamo → D1: profiles, admin-notifications, GSC cache, Stripe txs/analytics, ad-analytics bookmarks; no `@aws-sdk/client-dynamodb` in `src/` |
+| PR-06 | **In PR #1456** | Dynamo → D1: profiles, admin-notifications, GSC cache, Stripe txs/analytics, ad-analytics bookmarks; no `@aws-sdk/client-dynamodb` in `src/` |
+
+**Failure model (PR-06):** primary reads/writes on user identity & money (profile write, Stripe ledger, admin notification mutations) **fail closed** without `AUTH_DB`. Cache/digest side-effects (GSC cache, `recordNotification` append, ad-analytics bookmarks) **soft-fail** so checkout/contact never 500 on missing binding.
 
 **Operator follow-ups before / after merge to main:**
 
 1. Email (Node/Pi) — **Cloudflare Email Sending LIVE** from the app pod (`CLOUDFLARE_EMAIL_API_TOKEN` + `CLOUDFLARE_API_TOKEN` in `cloudless-secrets`). `RESEND_API_KEY` still optional and **not set**.
 2. `CLOUDFLARE_ACCOUNT_ID` + `CLOUDFLARE_API_TOKEN` — **SET**; Workers AI embed smoke (`bge-small` → **384**) OK from app pod.
 3. Meili reindex — **done** (4 docs / 4 embeddings; `workers-ai-bge-small` @ 384; in-cluster `MEILI_HOST`). `CRON_SECRET` rotated after earlier job-log leak.
-4. **Next:** PR-14 (`pnpm remove` remaining `@aws-sdk/*`). Do not run until Dynamo call sites stay gone on main.
-5. Cognito is retired; tear down the User Pool in AWS when ready (PR-16). Apply migration `0014-ad-analytics-bookmarks.sql` on AUTH_DB if bookmarks should persist across deploys.
+4. **Next after #1456:** apply D1 migration `0014-ad-analytics-bookmarks.sql` on remote `user-auth-db`; confirm Pi `AUTH_DB` bound; then PR-14 (`pnpm remove` remaining `@aws-sdk/*`).
+5. Cognito is retired; tear down the User Pool in AWS when ready (PR-16).
+6. **Out of band:** Tailscale Operator deploy fails with `namespaces "tailscale-operator" not found` — fabric/docs issue, not cutover-blocking.
 
 ---
 

--- a/migrations/0014-ad-analytics-bookmarks.sql
+++ b/migrations/0014-ad-analytics-bookmarks.sql
@@ -1,0 +1,8 @@
+-- Ad-analytics poll bookmarks (replaces DynamoDB AD_ANALYTICS_BOOKMARKS_TABLE).
+-- One row per (campaign × platform × metric × window) bookmark key.
+CREATE TABLE IF NOT EXISTS ad_analytics_bookmark (
+  pk TEXT PRIMARY KEY,
+  last_posted_at TEXT,
+  snapshot_json TEXT,
+  updated_at INTEGER
+);

--- a/src/app/api/admin/notifications/analytics/route.ts
+++ b/src/app/api/admin/notifications/analytics/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { requireAdmin } from "@/lib/api-auth";
+import { getAuthDbFromEnv } from "@/lib/auth-d1";
 import { notificationAnalytics } from "@/lib/admin-notifications";
 
 const DEFAULT_WINDOW_DAYS = 7;
@@ -21,7 +22,7 @@ export async function GET(request: NextRequest) {
   const auth = await requireAdmin(request);
   if (!auth.ok) return auth.response;
 
-  if (!process.env.ADMIN_NOTIFICATIONS_TABLE) {
+  if (!getAuthDbFromEnv()) {
     return NextResponse.json({ error: "Notifications store not configured" }, { status: 503 });
   }
 

--- a/src/app/api/admin/notifications/route.ts
+++ b/src/app/api/admin/notifications/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { requireAdmin } from "@/lib/api-auth";
+import { getAuthDbFromEnv } from "@/lib/auth-d1";
 import {
   listNotifications,
   markNotificationsRead,
@@ -46,14 +47,14 @@ function parseLimit(raw: string | null): number | undefined {
  *   ?limit=<1..200, default 50>
  *   ?includeArchived=1
  *
- * Reads from the Dynamo audit log (see src/lib/admin-notifications.ts).
- * Returns 503 when the table is not configured (local dev, partial deploys).
+ * Reads from D1 `admin_notification` (see src/lib/admin-notifications.ts).
+ * Returns 503 when AUTH_DB is unbound (local dev, partial deploys).
  */
 export async function GET(request: NextRequest) {
   const auth = await requireAdmin(request);
   if (!auth.ok) return auth.response;
 
-  if (!process.env.ADMIN_NOTIFICATIONS_TABLE) {
+  if (!getAuthDbFromEnv()) {
     return NextResponse.json({ error: "Notifications store not configured" }, { status: 503 });
   }
 
@@ -83,7 +84,7 @@ export async function PATCH(request: NextRequest) {
   const auth = await requireAdmin(request);
   if (!auth.ok) return auth.response;
 
-  if (!process.env.ADMIN_NOTIFICATIONS_TABLE) {
+  if (!getAuthDbFromEnv()) {
     return NextResponse.json({ error: "Notifications store not configured" }, { status: 503 });
   }
 

--- a/src/app/api/user/profile/route.ts
+++ b/src/app/api/user/profile/route.ts
@@ -37,7 +37,7 @@ async function resolveUser(
 /**
  * GET /api/user/profile
  *
- * Cloudflare-first: D1 `user` row when AUTH_DB bound; else DynamoDB fallback.
+ * Reads profile fields from D1 `user` via AUTH_DB.
  */
 export async function GET(req: NextRequest) {
   const user = await resolveUser(req);
@@ -54,13 +54,7 @@ export async function GET(req: NextRequest) {
       phone: profile.phone,
       preferences: profile.preferences,
     });
-  } catch (err) {
-    if (err instanceof Error && err.message.includes("USER_PROFILE_TABLE")) {
-      return NextResponse.json({
-        name: user.name ?? undefined,
-        email: user.email ?? undefined,
-      });
-    }
+  } catch {
     return NextResponse.json({ error: "Could not read profile" }, { status: 502 });
   }
 }
@@ -68,7 +62,7 @@ export async function GET(req: NextRequest) {
 /**
  * POST /api/user/profile
  *
- * Upserts profile fields (D1 preferred, DynamoDB legacy).
+ * Upserts profile fields on D1 `user` (AUTH_DB required).
  */
 export async function POST(req: NextRequest) {
   const user = await resolveUser(req);
@@ -94,7 +88,7 @@ export async function POST(req: NextRequest) {
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);
     console.error("[user/profile] PUT failed:", msg);
-    if (msg.includes("USER_PROFILE_TABLE")) {
+    if (msg.includes("AUTH_DB")) {
       return NextResponse.json(
         { error: "Profile storage not available — please retry" },
         { status: 503 }

--- a/src/lib/ad-analytics/bookmarks.ts
+++ b/src/lib/ad-analytics/bookmarks.ts
@@ -75,9 +75,7 @@ class D1BookmarkStore implements IBookmarkStore {
   async getBookmark(key: string): Promise<Bookmark | null> {
     try {
       const row = await this.db
-        .prepare(
-          "SELECT pk, last_posted_at, snapshot_json FROM ad_analytics_bookmark WHERE pk = ?"
-        )
+        .prepare("SELECT pk, last_posted_at, snapshot_json FROM ad_analytics_bookmark WHERE pk = ?")
         .bind(key)
         .first<{ pk: string; last_posted_at: string | null; snapshot_json: string | null }>();
       if (!row?.last_posted_at || !row.snapshot_json) return null;

--- a/src/lib/ad-analytics/bookmarks.ts
+++ b/src/lib/ad-analytics/bookmarks.ts
@@ -6,27 +6,18 @@
  * Re-running a poll over the same window is idempotent — the bookmark is the
  * single source of truth for "the last snapshot we already posted."
  *
- * Two backends, swap via env:
- *  - `DynamoBookmarkStore` when `AD_ANALYTICS_BOOKMARKS_TABLE` is set in env
- *    or SSM. Schema is one row per (campaign × platform × metric × window)
- *    tuple, keyed by the string `bookmarkKeyOf(...)`.
- *  - `InMemoryBookmarkStore` otherwise — useful for dev, unit tests, and the
- *    initial Phase 2 ship where the prod DynamoDB table hasn't been
- *    provisioned yet. The runtime degrades cleanly: the first poll posts a
- *    full snapshot (no delta), the second poll posts an in-memory delta, and
- *    on Lambda cold-start the bookmark resets — at worst the operator sees a
- *    "+everything" digest after a redeploy, which is harmless.
+ * Backends:
+ *  - `D1BookmarkStore` when AUTH_DB is bound (table `ad_analytics_bookmark`)
+ *  - `InMemoryBookmarkStore` otherwise — useful for dev, unit tests, and
+ *    cold starts without D1. The first poll posts a full snapshot (no delta);
+ *    later polls in the same process post in-memory deltas.
  *
  * See `skills/ad-analytics/SKILL.md` operating principle #8 (idempotent
  * bookmarks) and the Notion architecture page §3.
  */
 
-import { DynamoDBClient, GetItemCommand, PutItemCommand } from "@aws-sdk/client-dynamodb";
-
 import type { AdMetrics, Bookmark, AdPlatformId } from "./types";
-import { resolveDynamoEndpoint } from "@/lib/stripe-transactions";
-
-const REGION = process.env.AWS_REGION || "us-east-1";
+import { getAuthDbFromEnv, type AuthDatabase } from "@/lib/auth-d1";
 
 export interface BookmarkKeyOpts {
   campaignSlug: string;
@@ -48,7 +39,7 @@ export interface IBookmarkStore {
 }
 
 // ---------------------------------------------------------------------------
-// In-memory store — used when the DynamoDB table is not configured.
+// In-memory store — used when AUTH_DB is not bound.
 // ---------------------------------------------------------------------------
 
 class InMemoryBookmarkStore implements IBookmarkStore {
@@ -75,44 +66,31 @@ class InMemoryBookmarkStore implements IBookmarkStore {
 const inMemoryFallback = new InMemoryBookmarkStore();
 
 // ---------------------------------------------------------------------------
-// DynamoDB store — production backend.
+// D1 store — production backend (AUTH_DB.ad_analytics_bookmark).
 // ---------------------------------------------------------------------------
 
-let dynamoClient: DynamoDBClient | null = null;
-function getDynamoClient(): DynamoDBClient {
-  dynamoClient ??= new DynamoDBClient({
-    region: REGION,
-    endpoint: resolveDynamoEndpoint(),
-  });
-  return dynamoClient;
-}
-
-class DynamoBookmarkStore implements IBookmarkStore {
-  constructor(private readonly tableName: string) {}
+class D1BookmarkStore implements IBookmarkStore {
+  constructor(private readonly db: AuthDatabase) {}
 
   async getBookmark(key: string): Promise<Bookmark | null> {
     try {
-      const res = await getDynamoClient().send(
-        new GetItemCommand({
-          TableName: this.tableName,
-          Key: { pk: { S: key } },
-        })
-      );
-      const item = res.Item;
-      if (!item) return null;
-      const lastPostedAt = item.lastPostedAt?.S;
-      const snapshotJson = item.snapshot?.S;
-      if (!lastPostedAt || !snapshotJson) return null;
+      const row = await this.db
+        .prepare(
+          "SELECT pk, last_posted_at, snapshot_json FROM ad_analytics_bookmark WHERE pk = ?"
+        )
+        .bind(key)
+        .first<{ pk: string; last_posted_at: string | null; snapshot_json: string | null }>();
+      if (!row?.last_posted_at || !row.snapshot_json) return null;
       try {
-        const snapshot = JSON.parse(snapshotJson) as AdMetrics;
-        return { key, lastPostedAt, snapshot };
+        const snapshot = JSON.parse(row.snapshot_json) as AdMetrics;
+        return { key, lastPostedAt: row.last_posted_at, snapshot };
       } catch {
         // Corrupt row — treat as missing so the next poll re-seeds.
         return null;
       }
     } catch (err) {
       console.error(
-        `[ad-analytics/bookmarks] DynamoDB GetItem failed for ${key}:`,
+        `[ad-analytics/bookmarks] D1 getBookmark failed for ${key}:`,
         (err as Error)?.message ?? err
       );
       return null;
@@ -121,19 +99,18 @@ class DynamoBookmarkStore implements IBookmarkStore {
 
   async putBookmark(key: string, snapshot: AdMetrics): Promise<void> {
     try {
-      await getDynamoClient().send(
-        new PutItemCommand({
-          TableName: this.tableName,
-          Item: {
-            pk: { S: key },
-            lastPostedAt: { S: new Date().toISOString() },
-            snapshot: { S: JSON.stringify(snapshot) },
-          },
-        })
-      );
+      const lastPostedAt = new Date().toISOString();
+      const updatedAt = Math.floor(Date.now() / 1000);
+      await this.db
+        .prepare(
+          `INSERT OR REPLACE INTO ad_analytics_bookmark (pk, last_posted_at, snapshot_json, updated_at)
+           VALUES (?, ?, ?, ?)`
+        )
+        .bind(key, lastPostedAt, JSON.stringify(snapshot), updatedAt)
+        .run();
     } catch (err) {
       console.error(
-        `[ad-analytics/bookmarks] DynamoDB PutItem failed for ${key}:`,
+        `[ad-analytics/bookmarks] D1 putBookmark failed for ${key}:`,
         (err as Error)?.message ?? err
       );
     }
@@ -141,15 +118,15 @@ class DynamoBookmarkStore implements IBookmarkStore {
 }
 
 // ---------------------------------------------------------------------------
-// Factory: pick the backend based on env.
+// Factory: prefer AUTH_DB → D1, else in-memory.
 // ---------------------------------------------------------------------------
 
 let cached: IBookmarkStore | null = null;
 
 export function getBookmarkStore(): IBookmarkStore {
   if (cached) return cached;
-  const table = (process.env.AD_ANALYTICS_BOOKMARKS_TABLE ?? "").trim();
-  cached = table ? new DynamoBookmarkStore(table) : inMemoryFallback;
+  const db = getAuthDbFromEnv();
+  cached = db ? new D1BookmarkStore(db) : inMemoryFallback;
   return cached;
 }
 

--- a/src/lib/ad-analytics/types.ts
+++ b/src/lib/ad-analytics/types.ts
@@ -170,7 +170,7 @@ export interface AdMetricsDelta {
   };
 }
 
-/** DynamoDB-backed bookmark for one (campaign, platform, metric, window)
+/** D1 (or in-memory) bookmark for one (campaign, platform, metric, window)
  *  tuple. Holds the last snapshot we posted and the timestamp we posted
  *  it. Re-posting a digest is idempotent over the same window. */
 export interface Bookmark {

--- a/src/lib/admin-notifications.ts
+++ b/src/lib/admin-notifications.ts
@@ -1,25 +1,12 @@
-import {
-  DynamoDBClient,
-  PutItemCommand,
-  QueryCommand,
-  UpdateItemCommand,
-  BatchWriteItemCommand,
-  type AttributeValue,
-} from "@aws-sdk/client-dynamodb";
-import { resolveDynamoEndpoint } from "@/lib/stripe-transactions";
 import { getDataLakeBucketFromEnv } from "@/lib/r2-client";
 import { getAuthDbFromEnv, type AuthDatabase } from "@/lib/auth-d1";
 
 /**
  * Durable admin notifications store.
  *
- * Cloudflare-first: prefer D1 `admin_notification` when AUTH_DB is bound.
- * Legacy fallback: DynamoDB `ADMIN_NOTIFICATIONS_TABLE`.
- *
- * Dynamo schema (legacy):
- *   - pk = "NOTIF"
- *   - sk = "<createdAt-ISO8601>#<id>"
- *   - GSI categoryIndex: pk = "CAT#<category>", sk = "<createdAt-ISO8601>#<id>"
+ * D1 `admin_notification` via AUTH_DB. Reads return [] when AUTH_DB is
+ * unbound; writes that require persistence throw when AUTH_DB is missing.
+ * Lake sink (R2) still runs on record regardless.
  *
  * Categories: contact | subscribe | booking | order | error | auth | portal
  */
@@ -47,25 +34,7 @@ export interface AdminNotification {
   archivedAt?: string;
 }
 
-const REGION = process.env.AWS_REGION || "us-east-1";
-
-let dynamoClient: DynamoDBClient | null = null;
-function getDynamoClient(): DynamoDBClient {
-  dynamoClient ??= new DynamoDBClient({
-    region: REGION,
-    endpoint: resolveDynamoEndpoint(),
-  });
-  return dynamoClient;
-}
-
-function getTableName(): string {
-  const name = process.env.ADMIN_NOTIFICATIONS_TABLE?.trim();
-  if (!name) throw new Error("ADMIN_NOTIFICATIONS_TABLE is not configured");
-  return name;
-}
-
 const PK_ALL = "NOTIF";
-const CAT_INDEX = "categoryIndex";
 
 function randomId(): string {
   return `n_${Date.now()}_${Math.random().toString(36).slice(2, 10)}`;
@@ -75,50 +44,12 @@ function buildSk(createdAt: string, id: string): string {
   return `${createdAt}#${id}`;
 }
 
-function toItem(notif: AdminNotification): Record<string, AttributeValue> {
-  const item: Record<string, AttributeValue> = {
-    pk: { S: PK_ALL },
-    sk: { S: buildSk(notif.createdAt, notif.id) },
-    catPk: { S: `CAT#${notif.category}` },
-    catSk: { S: buildSk(notif.createdAt, notif.id) },
-    id: { S: notif.id },
-    createdAt: { S: notif.createdAt },
-    category: { S: notif.category },
-    type: { S: notif.type },
-    title: { S: notif.title },
-    message: { S: notif.message },
-    read: { BOOL: notif.read },
-  };
-  if (notif.actor) item.actor = { S: notif.actor };
-  if (notif.route) item.route = { S: notif.route };
-  if (notif.metadata) item.metadata = { S: JSON.stringify(notif.metadata) };
-  if (notif.archivedAt) item.archivedAt = { S: notif.archivedAt };
-  return item;
-}
-
-function fromItem(item: Record<string, AttributeValue>): AdminNotification {
-  let metadata: Record<string, unknown> | undefined;
-  const rawMeta = item.metadata?.S;
-  if (rawMeta) {
-    try {
-      metadata = JSON.parse(rawMeta) as Record<string, unknown>;
-    } catch {
-      // Malformed JSON — drop silently to keep the list useful.
-    }
+function requireAuthDb(): AuthDatabase {
+  const db = getAuthDbFromEnv();
+  if (!db) {
+    throw new Error("AUTH_DB is not configured");
   }
-  return {
-    id: item.id?.S ?? "",
-    createdAt: item.createdAt?.S ?? "",
-    category: (item.category?.S ?? "error") as NotificationCategory,
-    type: (item.type?.S ?? "info") as NotificationType,
-    title: item.title?.S ?? "",
-    message: item.message?.S ?? "",
-    actor: item.actor?.S,
-    route: item.route?.S,
-    metadata,
-    read: item.read?.BOOL ?? false,
-    archivedAt: item.archivedAt?.S,
-  };
+  return db;
 }
 
 interface D1NotificationRow {
@@ -271,8 +202,9 @@ async function purgeArchivedOlderThanD1(db: AuthDatabase, olderThan: string): Pr
 }
 
 /**
- * Append a notification. Failures are returned (not thrown) so producer paths
- * can keep serving the user-facing response. Callers should log but not abort.
+ * Append a notification. D1 insert failures are returned as null (not thrown)
+ * so producer paths can keep serving. Missing AUTH_DB throws — persistence
+ * requires a bound database.
  */
 export async function recordNotification(input: {
   category: NotificationCategory;
@@ -299,30 +231,7 @@ export async function recordNotification(input: {
   // Always write to data lake (R2) for analytics — fire and forget.
   sinkToLake(notif).catch(() => {});
 
-  const db = getAuthDbFromEnv();
-  if (db) {
-    return recordNotificationD1(db, notif);
-  }
-
-  if (!process.env.ADMIN_NOTIFICATIONS_TABLE) {
-    // No D1 / Dynamo — lake-only mode.
-    return notif;
-  }
-  try {
-    await getDynamoClient().send(
-      new PutItemCommand({
-        TableName: getTableName(),
-        Item: toItem(notif),
-      })
-    );
-    return notif;
-  } catch (err) {
-    console.warn(
-      "[admin-notifications] recordNotification failed:",
-      err instanceof Error ? err.message : err
-    );
-    return null;
-  }
+  return recordNotificationD1(requireAuthDb(), notif);
 }
 
 export interface ListFilters {
@@ -336,66 +245,12 @@ export interface ListFilters {
 
 /**
  * Read recent notifications, newest first. Defaults to 50 most recent
- * un-archived entries.
+ * un-archived entries. Returns [] when AUTH_DB is unbound.
  */
 export async function listNotifications(filters: ListFilters = {}): Promise<AdminNotification[]> {
   const db = getAuthDbFromEnv();
-  if (db) {
-    return listNotificationsD1(db, filters);
-  }
-
-  if (!process.env.ADMIN_NOTIFICATIONS_TABLE) {
-    return [];
-  }
-
-  const limit = Math.min(Math.max(filters.limit ?? 50, 1), 200);
-  const useCategoryIndex = Boolean(filters.category);
-
-  const keyConditionParts: string[] = [];
-  const exprNames: Record<string, string> = {};
-  const exprValues: Record<string, AttributeValue> = {};
-
-  if (useCategoryIndex) {
-    keyConditionParts.push("#cpk = :cpk");
-    exprNames["#cpk"] = "catPk";
-    exprValues[":cpk"] = { S: `CAT#${filters.category}` };
-  } else {
-    keyConditionParts.push("#pk = :pk");
-    exprNames["#pk"] = "pk";
-    exprValues[":pk"] = { S: PK_ALL };
-  }
-
-  if (filters.since && filters.until) {
-    keyConditionParts.push("#sk BETWEEN :since AND :until");
-    exprNames["#sk"] = useCategoryIndex ? "catSk" : "sk";
-    exprValues[":since"] = { S: `${filters.since}#` };
-    exprValues[":until"] = { S: `${filters.until}~` };
-  } else if (filters.since) {
-    keyConditionParts.push("#sk >= :since");
-    exprNames["#sk"] = useCategoryIndex ? "catSk" : "sk";
-    exprValues[":since"] = { S: `${filters.since}#` };
-  }
-
-  const filterExpressions: string[] = [];
-  if (!filters.includeArchived) {
-    filterExpressions.push("attribute_not_exists(#archivedAt)");
-    exprNames["#archivedAt"] = "archivedAt";
-  }
-
-  const out = await getDynamoClient().send(
-    new QueryCommand({
-      TableName: getTableName(),
-      IndexName: useCategoryIndex ? CAT_INDEX : undefined,
-      KeyConditionExpression: keyConditionParts.join(" AND "),
-      ...(filterExpressions.length ? { FilterExpression: filterExpressions.join(" AND ") } : {}),
-      ExpressionAttributeNames: exprNames,
-      ExpressionAttributeValues: exprValues,
-      Limit: limit,
-      ScanIndexForward: false,
-    })
-  );
-
-  return (out.Items ?? []).map(fromItem);
+  if (!db) return [];
+  return listNotificationsD1(db, filters);
 }
 
 /**
@@ -403,41 +258,7 @@ export async function listNotifications(filters: ListFilters = {}): Promise<Admi
  */
 export async function markNotificationsRead(ids: string[]): Promise<void> {
   if (!ids.length) return;
-
-  const db = getAuthDbFromEnv();
-  if (db) {
-    await markNotificationsReadD1(db, ids);
-    return;
-  }
-
-  if (!process.env.ADMIN_NOTIFICATIONS_TABLE) return;
-
-  for (const id of ids) {
-    const matches = await getDynamoClient().send(
-      new QueryCommand({
-        TableName: getTableName(),
-        KeyConditionExpression: "#pk = :pk",
-        FilterExpression: "#id = :id",
-        ExpressionAttributeNames: { "#pk": "pk", "#id": "id" },
-        ExpressionAttributeValues: {
-          ":pk": { S: PK_ALL },
-          ":id": { S: id },
-        },
-        Limit: 1,
-      })
-    );
-    const item = matches.Items?.[0];
-    if (!item) continue;
-    await getDynamoClient().send(
-      new UpdateItemCommand({
-        TableName: getTableName(),
-        Key: { pk: item.pk, sk: item.sk },
-        UpdateExpression: "SET #read = :true",
-        ExpressionAttributeNames: { "#read": "read" },
-        ExpressionAttributeValues: { ":true": { BOOL: true } },
-      })
-    );
-  }
+  await markNotificationsReadD1(requireAuthDb(), ids);
 }
 
 /**
@@ -483,49 +304,7 @@ export async function notificationAnalytics(
  * Hard-delete archived rows older than `olderThan` (ISO 8601 cutoff).
  */
 export async function purgeArchivedOlderThan(olderThan: string): Promise<number> {
-  const db = getAuthDbFromEnv();
-  if (db) {
-    return purgeArchivedOlderThanD1(db, olderThan);
-  }
-
-  if (!process.env.ADMIN_NOTIFICATIONS_TABLE) return 0;
-
-  let purged = 0;
-  let lastKey: Record<string, AttributeValue> | undefined;
-  do {
-    const page: QueryCommand = new QueryCommand({
-      TableName: getTableName(),
-      KeyConditionExpression: "#pk = :pk AND #sk < :until",
-      FilterExpression: "attribute_exists(#archivedAt) AND #archivedAt < :until",
-      ExpressionAttributeNames: {
-        "#pk": "pk",
-        "#sk": "sk",
-        "#archivedAt": "archivedAt",
-      },
-      ExpressionAttributeValues: {
-        ":pk": { S: PK_ALL },
-        ":until": { S: `${olderThan}~` },
-      },
-      ExclusiveStartKey: lastKey,
-      Limit: 25,
-    });
-    const res = await getDynamoClient().send(page);
-    const items = res.Items ?? [];
-    if (items.length) {
-      await getDynamoClient().send(
-        new BatchWriteItemCommand({
-          RequestItems: {
-            [getTableName()]: items.map((it) => ({
-              DeleteRequest: { Key: { pk: it.pk, sk: it.sk } },
-            })),
-          },
-        })
-      );
-      purged += items.length;
-    }
-    lastKey = res.LastEvaluatedKey;
-  } while (lastKey);
-  return purged;
+  return purgeArchivedOlderThanD1(requireAuthDb(), olderThan);
 }
 
 // ---------------------------------------------------------------------------

--- a/src/lib/admin-notifications.ts
+++ b/src/lib/admin-notifications.ts
@@ -5,8 +5,9 @@ import { getAuthDbFromEnv, type AuthDatabase } from "@/lib/auth-d1";
  * Durable admin notifications store.
  *
  * D1 `admin_notification` via AUTH_DB. Reads return [] when AUTH_DB is
- * unbound; writes that require persistence throw when AUTH_DB is missing.
- * Lake sink (R2) still runs on record regardless.
+ * unbound. Side-effect appends (`recordNotification`) soft-fail; explicit
+ * admin mutations throw when AUTH_DB is missing. Lake sink (R2) still runs
+ * on record regardless.
  *
  * Categories: contact | subscribe | booking | order | error | auth | portal
  */
@@ -202,9 +203,10 @@ async function purgeArchivedOlderThanD1(db: AuthDatabase, olderThan: string): Pr
 }
 
 /**
- * Append a notification. D1 insert failures are returned as null (not thrown)
- * so producer paths can keep serving. Missing AUTH_DB throws — persistence
- * requires a bound database.
+ * Append a notification (side-effect for contact/order/auth producers).
+ * Soft-fails when AUTH_DB is unbound or D1 insert fails — returns null so
+ * fire-and-forget callers (Stripe webhook, contact, subscribe) never reject
+ * the primary request path. Explicit admin mutations still fail closed.
  */
 export async function recordNotification(input: {
   category: NotificationCategory;
@@ -231,7 +233,9 @@ export async function recordNotification(input: {
   // Always write to data lake (R2) for analytics — fire and forget.
   sinkToLake(notif).catch(() => {});
 
-  return recordNotificationD1(requireAuthDb(), notif);
+  const db = getAuthDbFromEnv();
+  if (!db) return null;
+  return recordNotificationD1(db, notif);
 }
 
 export interface ListFilters {

--- a/src/lib/gsc-cache.ts
+++ b/src/lib/gsc-cache.ts
@@ -1,51 +1,30 @@
-import {
-  DynamoDBClient,
-  GetItemCommand,
-  PutItemCommand,
-  type AttributeValue,
-} from "@aws-sdk/client-dynamodb";
-import { resolveDynamoEndpoint } from "@/lib/stripe-transactions";
 import { createHash } from "crypto";
+import { getAuthDbFromEnv } from "@/lib/auth-d1";
 
 /**
  * Read-through cache for slow third-party data (Google Search Console).
  *
  * GSC has per-minute, per-day, and 50k-row-per-day quotas. Every admin tab
  * open used to hit the API fresh. This cache lets each route serve from
- * Dynamo if a fresh-enough entry exists, falling back to the live API when
- * not. The hourly /api/cron/gsc-cache-refresh job pre-warms the common
- * queries so admin users see instant responses.
+ * D1 `analytics_cache` if a fresh-enough entry exists, falling back to the
+ * live API when not. The hourly /api/cron/gsc-cache-refresh job pre-warms
+ * the common queries so admin users see instant responses.
  *
- * Schema:
+ * Schema (AUTH_DB.analytics_cache):
  *   pk = "<route>"                e.g. "seo", "keywords", "ctr-opportunities"
  *   sk = "<params-hash>"          deterministic for a given query-string
- *   payload (S, JSON)             the cached response body
- *   storedAt (S, ISO 8601)        when we wrote it
- *   ttlSeconds (N)                requested TTL at write time
+ *   result_json                   the cached response body
+ *   cached_at (unix seconds)      when we wrote it
+ *   expires_at (unix seconds)     cached_at + ttlSeconds
  *
- * Failure model: safe. If the table is not configured (no env var), or any
- * Dynamo operation throws, helpers return null / undefined and callers fall
- * back to the live API path. The cache is never on the critical path.
+ * Failure model: safe. If AUTH_DB is unbound, or any D1 operation throws,
+ * helpers return null / undefined and callers fall back to the live API path.
+ * The cache is never on the critical path.
  */
-
-const REGION = process.env.AWS_REGION || "us-east-1";
-
-let dynamoClient: DynamoDBClient | null = null;
-function getDynamoClient(): DynamoDBClient {
-  dynamoClient ??= new DynamoDBClient({
-    region: REGION,
-    endpoint: resolveDynamoEndpoint(),
-  });
-  return dynamoClient;
-}
-
-function getTableName(): string | null {
-  return process.env.ANALYTICS_CACHE_TABLE?.trim() || null;
-}
 
 /**
  * Hash an arbitrary params object into a short deterministic key suffix.
- * Same input → same hash, regardless of property order, on every Lambda.
+ * Same input → same hash, regardless of property order.
  */
 export function paramsHash(params: Record<string, unknown> = {}): string {
   // Sort keys so {a:1, b:2} and {b:2, a:1} hash to the same value.
@@ -64,47 +43,41 @@ export interface CacheEntry<T> {
   stale: boolean;
 }
 
-function toItem<T>(
-  route: string,
-  hash: string,
-  payload: T,
-  ttlSeconds: number
-): Record<string, AttributeValue> {
-  return {
-    pk: { S: route },
-    sk: { S: hash },
-    payload: { S: JSON.stringify(payload) },
-    storedAt: { S: new Date().toISOString() },
-    ttlSeconds: { N: String(ttlSeconds) },
-  };
+interface CacheRow {
+  result_json: string | null;
+  cached_at: number | null;
+  expires_at: number | null;
 }
 
-function fromItem<T>(
-  item: Record<string, AttributeValue>,
-  ttlSeconds: number
-): CacheEntry<T> | null {
-  const storedAt = item.storedAt?.S;
-  const raw = item.payload?.S;
-  if (!storedAt || !raw) return null;
+function rowToEntry<T>(row: CacheRow, ttlSeconds: number): CacheEntry<T> | null {
+  const raw = row.result_json;
+  const cachedAt = row.cached_at;
+  if (!raw || typeof cachedAt !== "number") return null;
+
   let payload: T;
   try {
     payload = JSON.parse(raw) as T;
   } catch {
     return null;
   }
-  const storedAtMs = Date.parse(storedAt);
-  const ageSeconds = Math.max(0, Math.floor((Date.now() - storedAtMs) / 1000));
+
+  const storedAt = new Date(cachedAt * 1000).toISOString();
+  const ageSeconds = Math.max(0, Math.floor(Date.now() / 1000) - cachedAt);
+  const staleByTtl = ageSeconds > ttlSeconds;
+  const staleByExpiry =
+    typeof row.expires_at === "number" ? Math.floor(Date.now() / 1000) > row.expires_at : false;
+
   return {
     payload,
     storedAt,
     ageSeconds,
-    stale: ageSeconds > ttlSeconds,
+    stale: staleByTtl || staleByExpiry,
   };
 }
 
 /**
  * Read a cached entry. Returns null if:
- *   - the table is not configured (local dev / partial deploy)
+ *   - AUTH_DB is not bound
  *   - no entry exists for (route, hash)
  *   - the entry is malformed
  * The caller decides whether a stale entry is acceptable; both fresh and
@@ -115,18 +88,18 @@ export async function getCached<T = unknown>(
   params: Record<string, unknown> = {},
   ttlSeconds = 3600
 ): Promise<CacheEntry<T> | null> {
-  const table = getTableName();
-  if (!table) return null;
+  const db = getAuthDbFromEnv();
+  if (!db) return null;
   const hash = paramsHash(params);
   try {
-    const out = await getDynamoClient().send(
-      new GetItemCommand({
-        TableName: table,
-        Key: { pk: { S: route }, sk: { S: hash } },
-      })
-    );
-    if (!out.Item) return null;
-    return fromItem<T>(out.Item, ttlSeconds);
+    const row = await db
+      .prepare(
+        "SELECT result_json, cached_at, expires_at FROM analytics_cache WHERE pk = ? AND sk = ?"
+      )
+      .bind(route, hash)
+      .first<CacheRow>();
+    if (!row) return null;
+    return rowToEntry<T>(row, ttlSeconds);
   } catch (err) {
     console.warn("[gsc-cache] getCached failed:", err instanceof Error ? err.message : err);
     return null;
@@ -143,16 +116,18 @@ export async function setCached<T = unknown>(
   payload: T,
   ttlSeconds = 3600
 ): Promise<void> {
-  const table = getTableName();
-  if (!table) return;
+  const db = getAuthDbFromEnv();
+  if (!db) return;
   const hash = paramsHash(params);
+  const now = Math.floor(Date.now() / 1000);
   try {
-    await getDynamoClient().send(
-      new PutItemCommand({
-        TableName: table,
-        Item: toItem(route, hash, payload, ttlSeconds),
-      })
-    );
+    await db
+      .prepare(
+        `INSERT OR REPLACE INTO analytics_cache (pk, sk, result_json, cached_at, expires_at)
+         VALUES (?, ?, ?, ?, ?)`
+      )
+      .bind(route, hash, JSON.stringify(payload), now, now + ttlSeconds)
+      .run();
   } catch (err) {
     console.warn("[gsc-cache] setCached failed:", err instanceof Error ? err.message : err);
   }

--- a/src/lib/stripe-analytics-read.ts
+++ b/src/lib/stripe-analytics-read.ts
@@ -1,53 +1,10 @@
-import {
-  DynamoDBClient,
-  QueryCommand,
-  ScanCommand,
-  type AttributeValue,
-} from "@aws-sdk/client-dynamodb";
-import { resolveDynamoEndpoint } from "@/lib/stripe-transactions";
 import { getAuthDbFromEnv, type AuthDatabase } from "@/lib/auth-d1";
 
 /**
  * Stripe revenue / event analytics snapshot.
  *
- * Cloudflare-first: prefer D1 `stripe_transaction` when AUTH_DB is bound.
- * Legacy fallback: DynamoDB `STRIPE_TRANSACTIONS_TABLE`.
+ * D1 `stripe_transaction` via AUTH_DB. Throws when AUTH_DB is unbound.
  */
-
-const REGION = process.env.AWS_REGION || "us-east-1";
-
-let dynamoClient: DynamoDBClient | null = null;
-
-function getDynamoClient(): DynamoDBClient {
-  if (!dynamoClient) {
-    dynamoClient = new DynamoDBClient({
-      region: REGION,
-      endpoint: resolveDynamoEndpoint(),
-    });
-  }
-  return dynamoClient;
-}
-
-function getTransactionsTableName(): string {
-  const tableName = process.env.STRIPE_TRANSACTIONS_TABLE?.trim();
-  if (tableName) return tableName;
-  throw new Error("STRIPE_TRANSACTIONS_TABLE is not configured");
-}
-
-function attrToString(value?: AttributeValue): string | undefined {
-  if (!value) return undefined;
-  if ("S" in value) return value.S;
-  return undefined;
-}
-
-function attrToNumber(value?: AttributeValue): number | undefined {
-  if (!value) return undefined;
-  if ("N" in value) {
-    const numberValue = Number(value.N);
-    return Number.isFinite(numberValue) ? numberValue : undefined;
-  }
-  return undefined;
-}
 
 function toDayString(date: Date): string {
   return date.toISOString().slice(0, 10);
@@ -64,7 +21,6 @@ function getDayRange(days: number): string[] {
   return range;
 }
 
-/** Normalized row shared by D1 + Dynamo aggregation. */
 interface AnalyticsRow {
   eventDay?: string;
   stripeCreatedAt?: number;
@@ -167,18 +123,6 @@ function applyRow(snapshot: StripeAnalyticsSnapshot, row: AnalyticsRow): void {
   if (status === "handler_failed") point.failed += 1;
 }
 
-function dynamoItemToRow(item: Record<string, AttributeValue>): AnalyticsRow {
-  return {
-    eventDay: attrToString(item.eventDay),
-    stripeCreatedAt: attrToNumber(item.stripeCreatedAt),
-    receivedAt: attrToNumber(item.receivedAt),
-    tagCategory: attrToString(item.tagCategory),
-    processingStatus: attrToString(item.processingStatus),
-    currency: attrToString(item.currency),
-    amountMinor: attrToNumber(item.amountMinor),
-  };
-}
-
 function amountFromPayload(payloadJson: string | null | undefined): number | undefined {
   if (!payloadJson) return undefined;
   try {
@@ -247,72 +191,6 @@ async function queryD1Rows(db: AuthDatabase, days: number): Promise<AnalyticsRow
   return (result.results ?? []).map(d1RowToAnalytics);
 }
 
-function isMissingIndexError(error: unknown): boolean {
-  if (!error || typeof error !== "object") return false;
-  const message = "message" in error ? String(error.message || "") : "";
-  const name = "name" in error ? String(error.name || "") : "";
-  return (
-    name.includes("ValidationException") ||
-    message.includes("Query condition missed key schema element") ||
-    message.includes("The table does not have the specified index")
-  );
-}
-
-async function queryByDayOrScan(days: number): Promise<AnalyticsRow[]> {
-  const tableName = getTransactionsTableName();
-  const client = getDynamoClient();
-  const dayRange = getDayRange(days);
-  const allItems: Array<Record<string, AttributeValue>> = [];
-
-  try {
-    for (const day of dayRange) {
-      let lastEvaluatedKey: Record<string, AttributeValue> | undefined;
-      do {
-        const response = await client.send(
-          new QueryCommand({
-            TableName: tableName,
-            IndexName: "ByDayAndTime",
-            KeyConditionExpression: "eventDay = :eventDay",
-            ExpressionAttributeValues: {
-              ":eventDay": { S: day },
-            },
-            ExclusiveStartKey: lastEvaluatedKey,
-          })
-        );
-
-        if (response.Items) allItems.push(...response.Items);
-        lastEvaluatedKey = response.LastEvaluatedKey;
-      } while (lastEvaluatedKey);
-    }
-    return allItems.map(dynamoItemToRow);
-  } catch (error) {
-    if (!isMissingIndexError(error)) throw error;
-  }
-
-  const thresholdMs = Date.now() - days * 24 * 60 * 60 * 1000;
-  let lastEvaluatedKey: Record<string, AttributeValue> | undefined;
-
-  do {
-    const response = await client.send(
-      new ScanCommand({
-        TableName: tableName,
-        ProjectionExpression:
-          "eventDay, stripeCreatedAt, tagCategory, processingStatus, currency, amountMinor, receivedAt",
-        FilterExpression: "receivedAt >= :threshold",
-        ExpressionAttributeValues: {
-          ":threshold": { N: `${thresholdMs}` },
-        },
-        ExclusiveStartKey: lastEvaluatedKey,
-      })
-    );
-
-    if (response.Items) allItems.push(...response.Items);
-    lastEvaluatedKey = response.LastEvaluatedKey;
-  } while (lastEvaluatedKey);
-
-  return allItems.map(dynamoItemToRow);
-}
-
 export async function getStripeAnalyticsSnapshot(
   inputDays: number = 30
 ): Promise<StripeAnalyticsSnapshot> {
@@ -320,8 +198,11 @@ export async function getStripeAnalyticsSnapshot(
   const snapshot = emptySnapshot(days);
 
   const db = getAuthDbFromEnv();
-  const rows = db ? await queryD1Rows(db, days) : await queryByDayOrScan(days);
+  if (!db) {
+    throw new Error("AUTH_DB is not configured");
+  }
 
+  const rows = await queryD1Rows(db, days);
   for (const row of rows) {
     applyRow(snapshot, row);
   }

--- a/src/lib/stripe-transactions.ts
+++ b/src/lib/stripe-transactions.ts
@@ -1,43 +1,8 @@
-import {
-  ConditionalCheckFailedException,
-  DynamoDBClient,
-  PutItemCommand,
-  UpdateItemCommand,
-  type AttributeValue,
-} from "@aws-sdk/client-dynamodb";
 import type Stripe from "stripe";
 import { getAuthDbFromEnv, type AuthDatabase } from "@/lib/auth-d1";
 import { getDataLakeBucketFromEnv } from "@/lib/r2-client";
 
-const REGION = process.env.AWS_REGION || "us-east-1";
 const APP_SOURCE_TAG = "cloudless.gr";
-const ANALYTICS_RETENTION_DAYS = 400;
-
-let dynamoClient: DynamoDBClient | null = null;
-
-export function resolveDynamoEndpoint(): string | undefined {
-  const endpoint = process.env.DYNAMODB_ENDPOINT?.trim();
-  if (!endpoint) return undefined;
-
-  const allowInsecureLocalhost =
-    endpoint.startsWith("http://localhost") || endpoint.startsWith("http://127.0.0.1");
-
-  if (!endpoint.startsWith("https://") && !allowInsecureLocalhost) {
-    throw new Error("DynamoDB endpoint must use HTTPS for encrypted transit");
-  }
-
-  return endpoint;
-}
-
-function getDynamoClient(): DynamoDBClient {
-  if (!dynamoClient) {
-    dynamoClient = new DynamoDBClient({
-      region: REGION,
-      endpoint: resolveDynamoEndpoint(),
-    });
-  }
-  return dynamoClient;
-}
 
 function asString(value: unknown): string | undefined {
   return typeof value === "string" && value.length > 0 ? value : undefined;
@@ -55,9 +20,12 @@ function toJson(value: unknown): string {
   }
 }
 
-function getTransactionsTableName(): string | null {
-  const tableName = process.env.STRIPE_TRANSACTIONS_TABLE?.trim();
-  return tableName || null;
+function requireAuthDb(): AuthDatabase {
+  const db = getAuthDbFromEnv();
+  if (!db) {
+    throw new Error("AUTH_DB is not configured");
+  }
+  return db;
 }
 
 function isUniqueConstraintError(error: unknown): boolean {
@@ -90,10 +58,6 @@ function toEventDay(unixSeconds: number): string {
   return new Date(unixSeconds * 1000).toISOString().slice(0, 10);
 }
 
-function toExpiryEpoch(unixSeconds: number): number {
-  return unixSeconds + ANALYTICS_RETENTION_DAYS * 24 * 60 * 60;
-}
-
 function extractObjectFields(event: Stripe.Event) {
   const object = event.data.object as unknown as Record<string, unknown>;
   return {
@@ -107,40 +71,6 @@ function extractObjectFields(event: Stripe.Event) {
     customerEmail: asString(object.customer_email),
     mode: asString(object.mode),
   };
-}
-
-function buildItem(event: Stripe.Event): Record<string, AttributeValue> {
-  const { amountMinor, objectId, currency, paymentStatus, customerId, customerEmail, mode } =
-    extractObjectFields(event);
-  const tags = getStripeEventTags(event.type);
-  const eventDay = toEventDay(event.created);
-  const stageCategory = `${tags.tagStage}#${tags.tagCategory}`;
-
-  const item: Record<string, AttributeValue> = {
-    eventId: { S: event.id },
-    eventType: { S: event.type },
-    tagSource: { S: tags.tagSource },
-    tagStage: { S: tags.tagStage },
-    tagCategory: { S: tags.tagCategory },
-    stageCategory: { S: stageCategory },
-    eventDay: { S: eventDay },
-    receivedAt: { N: `${Date.now()}` },
-    stripeCreatedAt: { N: `${event.created}` },
-    expiresAt: { N: `${toExpiryEpoch(event.created)}` },
-    processingStatus: { S: "received" },
-    livemode: { BOOL: event.livemode },
-    payloadJson: { S: toJson(event.data.object) },
-  };
-
-  if (objectId) item.objectId = { S: objectId };
-  if (currency) item.currency = { S: currency };
-  if (paymentStatus) item.paymentStatus = { S: paymentStatus };
-  if (customerId) item.customerId = { S: customerId };
-  if (customerEmail) item.customerEmail = { S: customerEmail };
-  if (mode) item.checkoutMode = { S: mode };
-  if (typeof amountMinor === "number") item.amountMinor = { N: `${amountMinor}` };
-
-  return item;
 }
 
 export interface PersistStripeEventResult {
@@ -192,44 +122,11 @@ async function persistStripeEventD1(
   return { duplicate: false };
 }
 
-async function persistStripeEventDynamo(event: Stripe.Event): Promise<PersistStripeEventResult> {
-  const tableName = getTransactionsTableName();
-  if (!tableName) {
-    throw new Error("STRIPE_TRANSACTIONS_TABLE is not configured");
-  }
-  const client = getDynamoClient();
-
-  try {
-    await client.send(
-      new PutItemCommand({
-        TableName: tableName,
-        Item: buildItem(event),
-        ConditionExpression: "attribute_not_exists(eventId)",
-      })
-    );
-    sinkStripeEventToLake(event).catch(() => {});
-    return { duplicate: false };
-  } catch (error) {
-    if (
-      error instanceof ConditionalCheckFailedException ||
-      (error as { name?: string })?.name === "ConditionalCheckFailedException"
-    ) {
-      return { duplicate: true };
-    }
-    throw error;
-  }
-}
-
 /**
- * Persist a Stripe webhook event for idempotency.
- * Prefer D1 (`AUTH_DB` / `__AUTH_DB__`) when bound; else Dynamo `STRIPE_TRANSACTIONS_TABLE`.
+ * Persist a Stripe webhook event for idempotency (D1 `stripe_transaction`).
  */
 export async function persistStripeEvent(event: Stripe.Event): Promise<PersistStripeEventResult> {
-  const db = getAuthDbFromEnv();
-  if (db) {
-    return persistStripeEventD1(db, event);
-  }
-  return persistStripeEventDynamo(event);
+  return persistStripeEventD1(requireAuthDb(), event);
 }
 
 async function markStripeEventD1(
@@ -261,63 +158,12 @@ async function markStripeEventD1(
     .run();
 }
 
-async function markStripeEventProcessedDynamo(eventId: string): Promise<void> {
-  const tableName = getTransactionsTableName();
-  if (!tableName) {
-    throw new Error("STRIPE_TRANSACTIONS_TABLE is not configured");
-  }
-  const client = getDynamoClient();
-  await client.send(
-    new UpdateItemCommand({
-      TableName: tableName,
-      Key: { eventId: { S: eventId } },
-      UpdateExpression:
-        "SET processingStatus = :status, processedAt = :processedAt REMOVE processingError",
-      ExpressionAttributeValues: {
-        ":status": { S: "processed" },
-        ":processedAt": { N: `${Date.now()}` },
-      },
-    })
-  );
-}
-
-async function markStripeEventFailedDynamo(eventId: string, errorMessage: string): Promise<void> {
-  const tableName = getTransactionsTableName();
-  if (!tableName) {
-    throw new Error("STRIPE_TRANSACTIONS_TABLE is not configured");
-  }
-  const client = getDynamoClient();
-  await client.send(
-    new UpdateItemCommand({
-      TableName: tableName,
-      Key: { eventId: { S: eventId } },
-      UpdateExpression:
-        "SET processingStatus = :status, processedAt = :processedAt, processingError = :error",
-      ExpressionAttributeValues: {
-        ":status": { S: "handler_failed" },
-        ":processedAt": { N: `${Date.now()}` },
-        ":error": { S: errorMessage.slice(0, 1000) },
-      },
-    })
-  );
-}
-
 export async function markStripeEventProcessed(eventId: string): Promise<void> {
-  const db = getAuthDbFromEnv();
-  if (db) {
-    await markStripeEventD1(db, eventId, "processed");
-    return;
-  }
-  await markStripeEventProcessedDynamo(eventId);
+  await markStripeEventD1(requireAuthDb(), eventId, "processed");
 }
 
 export async function markStripeEventFailed(eventId: string, errorMessage: string): Promise<void> {
-  const db = getAuthDbFromEnv();
-  if (db) {
-    await markStripeEventD1(db, eventId, "handler_failed", errorMessage);
-    return;
-  }
-  await markStripeEventFailedDynamo(eventId, errorMessage);
+  await markStripeEventD1(requireAuthDb(), eventId, "handler_failed", errorMessage);
 }
 
 // ---------------------------------------------------------------------------

--- a/src/lib/user-profile.ts
+++ b/src/lib/user-profile.ts
@@ -1,32 +1,11 @@
-import {
-  DynamoDBClient,
-  GetItemCommand,
-  UpdateItemCommand,
-  type AttributeValue,
-} from "@aws-sdk/client-dynamodb";
-import { resolveDynamoEndpoint } from "@/lib/stripe-transactions";
 import { getAuthDbFromEnv, getUserById, patchUserProfile as patchD1Profile } from "@/lib/auth-d1";
 
 /**
  * Provider-agnostic user-profile store.
  *
- * Cloudflare-first: D1 `user` row when AUTH_DB is bound.
- * Legacy fallback: DynamoDB UserProfile table (USER_PROFILE_TABLE).
+ * D1 `user` row via AUTH_DB. Reads return {} when AUTH_DB is unbound or the
+ * user has no row; writes fail closed when AUTH_DB is missing.
  */
-
-const REGION = process.env.AWS_REGION || "us-east-1";
-
-let dynamoClient: DynamoDBClient | null = null;
-function getDynamoClient(): DynamoDBClient {
-  dynamoClient ??= new DynamoDBClient({ region: REGION, endpoint: resolveDynamoEndpoint() });
-  return dynamoClient;
-}
-
-function getTableName(): string {
-  const name = process.env.USER_PROFILE_TABLE?.trim();
-  if (!name) throw new Error("USER_PROFILE_TABLE is not configured");
-  return name;
-}
 
 export interface UserProfile {
   name?: string;
@@ -35,51 +14,26 @@ export interface UserProfile {
   preferences?: unknown;
 }
 
-/** Read a user's stored profile. Returns {} when no record exists yet. */
+/** Read a user's stored profile. Returns {} when no record / no AUTH_DB. */
 export async function getUserProfile(userId: string): Promise<UserProfile> {
   const db = getAuthDbFromEnv();
-  if (db) {
-    const user = await getUserById(db, userId);
-    if (!user) return {};
-    let preferences: unknown;
-    if (user.preferences_json) {
-      try {
-        preferences = JSON.parse(user.preferences_json);
-      } catch {
-        // ignore malformed
-      }
-    }
-    return {
-      name: user.name ?? undefined,
-      company: user.company ?? undefined,
-      phone: user.phone ?? undefined,
-      preferences,
-    };
-  }
+  if (!db) return {};
 
-  const res = await getDynamoClient().send(
-    new GetItemCommand({
-      TableName: getTableName(),
-      Key: { userId: { S: userId } },
-    })
-  );
-  const item = res.Item;
-  if (!item) return {};
+  const user = await getUserById(db, userId);
+  if (!user) return {};
 
   let preferences: unknown;
-  const rawPrefs = item.preferences?.S;
-  if (rawPrefs) {
+  if (user.preferences_json) {
     try {
-      preferences = JSON.parse(rawPrefs);
+      preferences = JSON.parse(user.preferences_json);
     } catch {
-      // Ignore malformed stored preferences — fall back to client defaults.
+      // ignore malformed
     }
   }
-
   return {
-    name: item.name?.S,
-    company: item.company?.S,
-    phone: item.phone?.S,
+    name: user.name ?? undefined,
+    company: user.company ?? undefined,
+    phone: user.phone ?? undefined,
     preferences,
   };
 }
@@ -88,54 +42,23 @@ export async function getUserProfile(userId: string): Promise<UserProfile> {
  * Upsert the provided profile fields, keyed by userId.
  *
  * Partial update: only the keys present in `fields` are written. A string set
- * to "" clears (REMOVEs) that attribute; `undefined` leaves it untouched.
+ * to "" clears that attribute; `undefined` leaves it untouched.
  */
 export async function putUserProfile(userId: string, fields: UserProfile): Promise<void> {
   const db = getAuthDbFromEnv();
-  if (db) {
-    const ok = await patchD1Profile(db, userId, fields);
-    if (!ok) throw new Error("User not found");
+  if (!db) {
+    throw new Error("AUTH_DB is not configured");
+  }
+
+  if (
+    fields.name === undefined &&
+    fields.company === undefined &&
+    fields.phone === undefined &&
+    fields.preferences === undefined
+  ) {
     return;
   }
 
-  const setParts: string[] = [];
-  const removeParts: string[] = [];
-  const names: Record<string, string> = {};
-  const values: Record<string, AttributeValue> = {};
-
-  const handleString = (attr: string, value: string | undefined): void => {
-    if (value === undefined) return;
-    names[`#${attr}`] = attr;
-    if (value === "") {
-      removeParts.push(`#${attr}`);
-      return;
-    }
-    setParts.push(`#${attr} = :${attr}`);
-    values[`:${attr}`] = { S: value };
-  };
-
-  handleString("name", fields.name);
-  handleString("company", fields.company);
-  handleString("phone", fields.phone);
-  if (fields.preferences !== undefined) {
-    names["#preferences"] = "preferences";
-    setParts.push("#preferences = :preferences");
-    values[":preferences"] = { S: JSON.stringify(fields.preferences) };
-  }
-
-  if (setParts.length === 0 && removeParts.length === 0) return; // nothing to write
-
-  const clauses: string[] = [];
-  if (setParts.length) clauses.push(`SET ${setParts.join(", ")}`);
-  if (removeParts.length) clauses.push(`REMOVE ${removeParts.join(", ")}`);
-
-  await getDynamoClient().send(
-    new UpdateItemCommand({
-      TableName: getTableName(),
-      Key: { userId: { S: userId } },
-      UpdateExpression: clauses.join(" "),
-      ExpressionAttributeNames: names,
-      ...(Object.keys(values).length ? { ExpressionAttributeValues: values } : {}),
-    })
-  );
+  const ok = await patchD1Profile(db, userId, fields);
+  if (!ok) throw new Error("User not found");
 }


### PR DESCRIPTION
## Summary
- Strip Dynamo fallbacks from profiles, admin notifications, Stripe txs/analytics; D1-only via `AUTH_DB`.
- GSC cache → D1 `analytics_cache` (soft-fail without DB).
- Ad-analytics bookmarks → D1 `ad_analytics_bookmark` with in-memory fallback; migration `0014`.
- Clears `@aws-sdk/client-dynamodb` from `src/` (package removal is PR-14).

## Test plan
- [x] Targeted Vitest for touched libs (136 passed)
- [ ] Confirm Pi/`AUTH_DB` bound so profile/notifications/stripe paths work
- [ ] Apply D1 migration `0014-ad-analytics-bookmarks` on remote `user-auth-db`
- [ ] Optional: run `scripts/migrate-dynamodb-to-d1.ts` if legacy Dynamo rows remain


Made with [Cursor](https://cursor.com)