### PR TITLE
docs(tailscale): fabric architecture with diagrams

### DIFF
--- a/CLUSTER-MAP.md
+++ b/CLUSTER-MAP.md
@@ -1,5 +1,10 @@
 # k3s Cluster Map
 
+> **Tailscale architecture (trust boundaries, ProxyGroups, MagicDNS):**
+> [`docs/TAILSCALE-FABRIC.md`](docs/TAILSCALE-FABRIC.md).  
+> The Tailscale rows below are a **snapshot** and may list stale per-Service
+> proxies — prefer shared `ProxyGroup/ingress` devices from the fabric doc.
+
 ```
 ┌─────────────────────────────────────────────────────────────────────────────┐
 │                         omv-ha (192.168.1.130)                              │
@@ -75,15 +80,15 @@
 
 | Hostname / Path | Service | Port | Access Method |
 |-----------------|---------|------|---------------|
-| `cloudless.gr` | cloudless Worker | 80 | Cloudflare Worker (Edge) |
-| `manage.cloudless.gr` | cloudless Worker | 80 | Cloudflare Worker |
-| `*.cloudless.gr` | cloudless Worker | 80 | Cloudflare Worker |
-| `n8n.cloudless.gr` | n8n | 80, 443 | Traefik LB |
-| `grafana.cloudless.gr` | Grafana | 80 | Traefik IngressRoute |
-| `grafana.ts.cloudless.gr` | Grafana | 80 | Tailscale Ingress |
-| `loki.ts.cloudless.gr` | Loki | 80 | Tailscale Ingress |
+| `cloudless.gr` | cloudless-app via Worker+Tunnel | 443 | Cloudflare → `:30300` |
+| `manage.cloudless.gr` | same | 443 | Cloudflare |
+| `pi-origin.cloudless.gr` | Tunnel origin | 443 | Cloudflare Tunnel → `:30300` |
+| `n8n.cloudless.gr` | n8n | 80, 443 | Traefik / Tunnel |
+| `grafana.cloudless.gr` | Grafana | 80 | Traefik IngressRoute / Tunnel |
+| `grafana.tail4ecae1.ts.net` | Grafana | 443 | Tailscale Serve (`ProxyGroup/ingress`) — see fabric doc |
 | `192.168.1.128:18080` | Traefik Dashboard | - | Direct (LAN) |
 | `192.168.1.128:18443` | Traefik HTTPS | - | Direct (LAN) |
+| `192.168.1.128:30300` | cloudless-app | 80 | NodePort (Tunnel origin) |
 | `192.168.1.128:30850` | Grafana | 80 | NodePort |
 
 ### Monitoring Endpoints

--- a/docs/TAILSCALE-FABRIC.md
+++ b/docs/TAILSCALE-FABRIC.md
@@ -1,173 +1,437 @@
-# Tailscale Fabric Interconnect
+# Tailscale Fabric — Architecture
 
-Private mesh for the Pi k3s cluster. **Not** a public Funnel edge — public
-traffic stays on Cloudflare Workers / Access / tunnels. Tailscale is for
-admin fabric: nodes, ClusterIP/pod CIDRs, private GUIs, and kubectl.
+> **Status:** source of truth (2026-07-30)  
+> **Audience:** operators + agents touching Pi k3s, GHA, or admin GUIs  
+> **Scope:** private admin mesh only — **not** the public `cloudless.gr` edge
 
-Aligned with current Tailscale Kubernetes Operator docs (validated mid-2026):
+Tailscale is the **admin fabric** for the two-node Pi k3s cluster. Public HTTP
+stays on **Cloudflare** (Workers Free `cloudless2` proxy → Tunnel → Pi NodePort).
+Mixing those trust boundaries is how we got Funnel 403s, Bot Fight false alarms,
+and one Tailscale device per Service.
 
-- [Connector / subnet router](https://tailscale.com/docs/kubernetes-operator/connector/deploy-subnet-router)
-- [ProxyGroup](https://tailscale.com/docs/kubernetes-operator/concepts/proxygroup)
-- [API server over Tailscale](https://tailscale.com/docs/kubernetes-operator/api-server-access/setup-api-over-tailscale)
-- [ProxyClass](https://tailscale.com/docs/kubernetes-operator/concepts/proxyclass)
-- [HA overlapping routes](https://tailscale.com/docs/how-to/set-up-high-availability)
-- CRD reference: [k8s-operator/api.md](https://github.com/tailscale/tailscale/blob/main/k8s-operator/api.md)
+Canonical manifests: [`infrastructure/tailscale/`](../infrastructure/tailscale/).  
+Operator kubectl runbook: [`kubectl-tailscale.md`](kubectl-tailscale.md).
 
-## Target architecture
+---
 
+## 1. Trust boundaries
+
+```mermaid
+flowchart TB
+  subgraph Public["Public internet — Cloudflare trust"]
+    User[Browsers / crawlers]
+    GHA_Pub["GitHub-hosted runners<br/>(datacenter IPs)"]
+    CF[Cloudflare edge<br/>DNS · CDN · WAF · Bot Fight]
+    Wkr["Worker cloudless2<br/>pi-origin-proxy"]
+    Tun[Cloudflare Tunnel<br/>pi-origin]
+  end
+
+  subgraph Fabric["Private fabric — Tailscale trust"]
+    Office["office WSL / laptop<br/>MagicDNS"]
+    GHA_TS["GHA + TS_AUTHKEY<br/>ephemeral node"]
+    HostTS["Host tailscaled<br/>github-omv · omv-ha"]
+    Op[k8s Tailscale Operator]
+    Conn["Connector k3s-cidrs<br/>10.42/16 · 10.43/16"]
+    PG_I["ProxyGroup ingress<br/>Grafana · Meili Serve"]
+    PG_K["ProxyGroup kube<br/>apiserver auth proxy"]
+  end
+
+  subgraph Cluster["Pi k3s — omv + omv-ha"]
+    API[":6443 kube-apiserver"]
+    NP["NodePort :30300<br/>cloudless-app"]
+    Pods["Pods / ClusterIPs"]
+    GUIs["Grafana · Meilisearch"]
+  end
+
+  User --> CF --> Wkr --> Tun --> NP
+  GHA_Pub -.->|often CF 403 on /api/health| CF
+  Office --> HostTS
+  Office --> PG_I
+  Office --> PG_K
+  GHA_TS --> HostTS
+  HostTS --> API
+  HostTS --> NP
+  Op --> Conn
+  Op --> PG_I
+  Op --> PG_K
+  Conn --> Pods
+  PG_I --> GUIs
+  PG_K --> API
+  Tun -.->|same NodePort origin| NP
 ```
- office (WSL) ──tailnet── github-omv (host TS) ── :6443 / SSH / NodePorts
-       │                      │
-       │                      ├── Connector k3s-cidrs×2  → 10.42/16 + 10.43/16
-       │                      ├── ProxyGroup ingress×1   → grafana/loki/meili Serve
-       │                      └── ProxyGroup kube×1      → kubectl (auth impersonation)
-       └── omv-ha (host TS)
+
+| Boundary | Who | What travels | Auth |
+|----------|-----|--------------|------|
+| **Cloudflare public** | Humans, bots, Lighthouse (when not CF-blocked) | App HTTP/S for `*.cloudless.gr` | App session / Cognito / CRON_SECRET |
+| **Tailscale fabric** | Admins, GHA with `TS_AUTHKEY`, Cursor infra MCP | SSH, `:6443`, NodePorts, Serve HTTPS, pod CIDRs | Tailnet ACL + device identity |
+| **Never cross** | — | DB TCP, etcd, Redis | Stay ClusterIP; use `kubectl port-forward` |
+
+---
+
+## 2. Why Tailscale exists here
+
+| Need | Solution | Not this |
+|------|----------|----------|
+| `kubectl` from office / cloud agents | Host mesh + optional `kube` ProxyGroup | Exposing `:6443` on WAN |
+| SSH / runner restart / disk cleanup | Host `tailscaled` on omv | Public SSH |
+| Grafana / Meili for admins | Shared `ingress` ProxyGroup + Serve | Public Funnel or one device per Service |
+| Hit pod / ClusterIP from a laptop | `Connector` subnet routes | Publishing every Service |
+| Public website | Cloudflare Worker + Tunnel | Tailscale Funnel as primary edge |
+
+**Architectural rule:** Funnel may exist on a node for **diagnostics**
+(`https://github-omv.<tailnet>.ts.net/…`), but it is **not** the HA or SEO path.
+Production URLs are Cloudflare-fronted.
+
+---
+
+## 3. Physical + logical topology
+
+```mermaid
+flowchart LR
+  subgraph LAN["Office LAN 192.168.1.0/24"]
+    OMV["omv · Pi 5<br/>192.168.1.128<br/>control-plane"]
+    HA["omv-ha · Pi<br/>192.168.1.130<br/>worker / standby taint"]
+    WSL["office WSL"]
+  end
+
+  subgraph Tailnet["tailnet MagicDNS · tail4ecae1.ts.net"]
+    GHO["github-omv<br/>100.74.191.58"]
+    OMH["omv-ha<br/>100.95.117.84"]
+    OFF["office<br/>100.98.121.44"]
+    SR0["k3s-subnet-router-0/1"]
+    IN0["ingress-0"]
+    KU0["kube-0"]
+  end
+
+  OMV --- GHO
+  HA --- OMH
+  WSL --- OFF
+  GHO -.->|SSH · NodePort · :6443| OMV
+  SR0 -->|advertise| CIDR["10.42.0.0/16 pods<br/>10.43.0.0/16 svc"]
+  IN0 -->|Serve HTTPS| G["grafana.<tailnet>.ts.net"]
+  KU0 -->|configure kubeconfig| API2["apiserver proxy URL"]
 ```
 
-| Layer | Resource | Purpose | Devices on Machines |
-|-------|----------|---------|---------------------|
-| Host mesh | `tailscaled` on omv + omv-ha | SSH, NodePort, direct `:6443` | `github-omv`, `omv-ha` |
-| Subnet | `Connector` `k3s-cidrs` | Pod + ClusterIP reachability | `k3s-subnet-router-0/1` |
-| L7 GUI | `ProxyGroup` `ingress` + Ingress | MagicDNS HTTPS to apps | `ingress-0` (+ Tailscale Services) |
-| API | `ProxyGroup` `kube` | `tailscale configure kubeconfig` | `kube-0` |
+### Node inventory (host mesh)
 
-**Do not** create one Tailscale proxy per Service — that spawned
-`monitoring-proxies-0..9` plus per-app devices. Always set
-`tailscale.com/proxy-group: ingress`.
+| Hostname (Machines) | Role | LAN | Tailscale IPv4 | MagicDNS |
+|---------------------|------|-----|----------------|----------|
+| `github-omv` | k3s control-plane, GH runners, app NodePort | `192.168.1.128` | `100.74.191.58` | `github-omv.tail4ecae1.ts.net` |
+| `omv-ha` | worker (often `NoSchedule` standby) | `192.168.1.130` | `100.95.117.84` | `omv-ha.tail4ecae1.ts.net` |
+| `office` | Admin WSL | — | `100.98.121.44` | `office.…` |
 
-## What was wrong in the old repo manifests
+> **IP caveat:** Tailscale CGNAT addresses **rotate** after reimage / re-auth.
+> Prefer **MagicDNS** (`github-omv.tail4ecae1.ts.net`) in new scripts.
+> Stale literals still floating in some workflows / `mcp.json`:
+> `100.113.41.119`, Funnel host `omv.tail8eb71.ts.net` — treat as **drift**, not SoT.
 
-| Old | Problem | Fix |
-|-----|---------|-----|
-| `ProxyGroup` + `routes:` | Invalid — ProxyGroup is `ingress`/`egress`/`kube-apiserver` only | `Connector.subnetRouter.advertiseRoutes` |
-| Missing `spec.type` | Operator cannot reconcile | `type: ingress` / `kube-apiserver` |
-| No `proxy-group` annotation | One device per Ingress | Shared ProxyGroup |
-| Funnel / public `*.ts.cloudless.gr` | Wrong trust boundary | Private Serve + CF Access for public |
-| AWS SSM in `deploy.sh` | Forbidden on free-tier policy | Env `TS_CLIENT_ID` / `TS_CLIENT_SECRET` |
-| Operator absent on cluster | CRDs/pods gone after rebuild | Re-run `deploy.sh` |
+### Operator-owned devices (fabric)
 
-## Deploy
+| Prefix / name | Kind | Purpose |
+|---------------|------|---------|
+| `k3s-subnet-router-*` | Connector replicas | Advertise pod + ClusterIP CIDRs |
+| `ingress-*` | ProxyGroup `ingress` | Shared L7 Serve for annotated Ingresses |
+| `kube-*` | ProxyGroup `kube-apiserver` | `tailscale configure kubeconfig` |
 
-1. Create an OAuth client (Devices Core + Auth Keys write) tagged **`tag:k8s-operator`**:
+**Delete in admin if offline forever:** old per-Service proxies
+(`monitoring-proxies-*`, `ts-n8n-*`, `appflowy`, `grafana`, …). Those came from
+missing `tailscale.com/proxy-group: ingress` — see §7.
+
+---
+
+## 4. Layered architecture
+
+```mermaid
+flowchart TB
+  L4["L4 — Host mesh<br/>tailscaled on omv / omv-ha / laptops"]
+  L3["L3 — Subnet fabric<br/>Connector k3s-cidrs → 10.42/16 + 10.43/16"]
+  L7["L7 — Serve / Ingress<br/>ProxyGroup ingress + IngressClass tailscale"]
+  LK["Control — API access<br/>ProxyGroup kube · auth impersonation"]
+
+  L4 --> L3
+  L4 --> L7
+  L4 --> LK
+```
+
+| Layer | Kubernetes / host object | Consumers | Notes |
+|-------|--------------------------|-----------|-------|
+| **L4 Host mesh** | `tailscaled` systemd on Pis + client apps | SSH, NodePort `:30300`, direct `:6443` (if TLS SAN includes TS IP) | Always on; baseline for GHA Tailscale Action |
+| **L3 Subnet** | `Connector/k3s-cidrs` + `ProxyClass/pi-fabric` | Laptop → ClusterIP / pod IP | Requires `--accept-routes` on client; ACL `autoApprovers.routes` |
+| **L7 Serve** | `ProxyGroup/ingress` + Ingresses in `ingresses.yaml` | Admins → Grafana, Meilisearch | **No Funnel**; private HTTPS certs need HTTPS Certificates enabled |
+| **API proxy** | `ProxyGroup/kube` | Off-LAN kubectl | Preferred over raw `:6443` from WSL userspace |
+
+Manifest map:
+
+| File | Layer |
+|------|-------|
+| `connector.yaml` | L3 + `ProxyClass` |
+| `proxygroup.yaml` | L7 + API |
+| `ingresses.yaml` | L7 backends |
+| `ingress-class.yaml` | `IngressClass` `tailscale` |
+| `acl-policy.example.json` | ACL tags / autoApprovers / grants |
+| `deploy.sh` | Helm operator install (OAuth env — **no AWS SSM**) |
+
+---
+
+## 5. Critical traffic flows
+
+### 5.1 Public app (not Tailscale)
+
+```mermaid
+sequenceDiagram
+  participant U as Client
+  participant CF as Cloudflare
+  participant W as cloudless2 Worker
+  participant T as Tunnel pi-origin
+  participant P as omv:30300 cloudless-app
+
+  U->>CF: https://cloudless.gr/...
+  CF->>W: route
+  W->>T: https://pi-origin.cloudless.gr
+  T->>P: http://192.168.1.128:30300
+  P-->>U: app response
+```
+
+GHA `ubuntu-latest` often gets **HTTP 403** on custom-domain `/api/health`
+(datacenter reputation / Bot Fight) even when TLS succeeds and the site is fine
+from residential IPs. That is a **Cloudflare** problem, not a Tailscale one.
+Health probes should fall back to MagicDNS Serve/Funnel or NodePort **after**
+joining the tailnet — never assume `100.x:30300` is open without verifying.
+
+### 5.2 kubectl on the office LAN (preferred)
+
+```mermaid
+sequenceDiagram
+  participant Dev as WSL office
+  participant API as 192.168.1.128:6443
+
+  Dev->>API: HTTPS + client cert / kubeconfig
+  Note over Dev,API: Cert SAN already includes LAN IP
+```
+
+### 5.3 kubectl off-LAN (preferred path)
+
+```mermaid
+sequenceDiagram
+  participant Dev as Admin + Tailscale TUN
+  participant Kube as ProxyGroup kube Serve URL
+  participant API as kube-apiserver
+
+  Dev->>Kube: tailscale configure kubeconfig URL
+  Kube->>API: impersonating Tailscale identity
+```
+
+Fallback: add TLS SANs (`100.74.191.58`, MagicDNS) via `scripts/configure-k3s.sh`,
+then dial `:6443` with `--accept-routes`. WSL **userspace** Tailscale is unreliable
+for raw `100.x` TCP — use LAN or the kube ProxyGroup instead.
+
+### 5.4 Private admin GUI (Serve)
+
+```mermaid
+sequenceDiagram
+  participant Admin as Tailnet member
+  participant Ing as ingress-0 Serve
+  participant Svc as Cluster Service
+
+  Admin->>Ing: https://grafana.tail4ecae1.ts.net
+  Ing->>Svc: in-cluster
+```
+
+Requires: HTTPS Certificates on, Service host **approved**, Ingress annotated
+`tailscale.com/proxy-group: ingress` + usually `tailscale.com/http-endpoint: enabled`.
+
+### 5.5 GitHub Actions → cluster
+
+```mermaid
+flowchart LR
+  Job[ubuntu-latest job] --> TSA[tailscale/github-action<br/>TS_AUTHKEY]
+  TSA --> Mesh[Host mesh]
+  Mesh --> SSH[SSH / scripts]
+  Mesh --> KC[KUBECONFIG_B64 → :6443]
+  Mesh --> NP[NodePort / MagicDNS health]
+```
+
+Typical secrets: `TS_AUTHKEY` (ephemeral, pre-authorized), `KUBECONFIG_B64`,
+`OMV_SSH_KEY`. Do not pin workflows to obsolete Funnel hostnames.
+
+---
+
+## 6. Decision records
+
+| ID | Decision | Rationale |
+|----|----------|-----------|
+| D1 | Public edge = Cloudflare, not Funnel | Free Bot Fight + Funnel as primary broke SEO/CI; CF Tunnel already terminates at NodePort |
+| D2 | One shared `ingress` ProxyGroup | Per-Ingress proxies exploded Machines (`monitoring-proxies-0..9`) and RAM on Pi |
+| D3 | Subnet routes only via `Connector` | ProxyGroup cannot advertise routes; wrong CRD caused silent failures |
+| D4 | `ProxyClass/pi-fabric` arm64 + tiny limits | Pi 5 RAM budget; avoid scheduling operator proxies on starved nodes |
+| D5 | kube ProxyGroup for off-LAN kubectl | Avoids k3s TLS SAN churn and WSL userspace TCP pain |
+| D6 | No AWS SSM in `deploy.sh` | Free-tier / Cloudflare-first policy — OAuth env only |
+| D7 | Prefer MagicDNS over CGNAT literals | Tailscale IPs rotate; docs and new automation must not hardcode |
+
+---
+
+## 7. Anti-patterns (do not reintroduce)
+
+```mermaid
+mindmap
+  root((Anti-patterns))
+    Funnel as prod edge
+      Bot Fight vs GHA
+      Split-brain with CF Tunnel
+    One TS device per Service
+      Missing proxy-group annotation
+      Pi RAM death
+    ProxyGroup with routes
+      Invalid API — use Connector
+    Hardcoded 100.x in new code
+      Prefer MagicDNS
+    Publishing DB ports on Funnel
+      port-forward only
+    AWS SSM for TS OAuth
+      Use TS_CLIENT_ID/SECRET env
+```
+
+Checklist before merging Tailscale changes:
+
+- [ ] Public URL still goes Cloudflare → Worker/Tunnel?
+- [ ] New Ingress has `tailscale.com/proxy-group: ingress`?
+- [ ] No new Funnel-primary path for `cloudless.gr`?
+- [ ] Scripts use MagicDNS or document IP refresh?
+- [ ] ACL `tag:k8s` / `tag:k8s-operator` still own the tags?
+
+---
+
+## 8. Deploy & operate
+
+### 8.1 Prerequisites
+
+1. OAuth client (Devices Core + Auth Keys write) tagged **`tag:k8s-operator`**:
    https://login.tailscale.com/admin/settings/oauth
+2. Merge [`acl-policy.example.json`](../infrastructure/tailscale/acl-policy.example.json)
+   into Access controls (`tagOwners`, `autoApprovers`, `grants`).
+3. Enable HTTPS Certificates (Serve / kube-apiserver):
 
-2. Merge `infrastructure/tailscale/acl-policy.example.json` into Access controls
-   (`tagOwners` + `autoApprovers` for routes + `svc:*`). Workflows:
-   `Tailscale admin API`, `Tailscale fix fabric ACL`.
+```bash
+bash scripts/tailscale-enable-https.sh
+# Workflow: Tailscale enable HTTPS
+```
 
-3. **Enable HTTPS Certificates** (required for Serve / kube-apiserver):
+4. Approve Service hosts (HA VIPs stay dark until approved):
 
-   ```bash
-   # PATCH /api/v2/tailnet/{tailnet}/settings  {"httpsEnabled":true}
-   bash scripts/tailscale-enable-https.sh
-   # Workflow: Tailscale enable HTTPS
-   ```
+```bash
+bash scripts/tailscale-approve-service-hosts.sh
+# Workflow: Tailscale approve service hosts
+```
 
-4. **Approve Service hosts** (HA ProxyGroup VIPs stay dark until approved):
-
-   ```bash
-   bash scripts/tailscale-approve-service-hosts.sh
-   # Workflow: Tailscale approve service hosts
-   # Or: Services admin → each svc → approve ingress-0 / kube-0
-   ```
-
-   `autoApprovers.services["svc:*"]` alone may not auto-approve; the approval
-   API returns `autoApproved:false` until hosts are explicitly approved.
-
-5. For HA Ingress, set `tailscale.com/http-endpoint: enabled` so the operator
-   advertises the VIP **before** Let's Encrypt fills the TLS Secret (otherwise
-   CertDomains never includes the Service name and certs deadlock).
-
-6. Install:
+### 8.2 Install / refresh operator
 
 ```bash
 export TS_CLIENT_ID=…
 export TS_CLIENT_SECRET=…
-export KUBECONFIG=~/.kube/config-cloudless-ts   # LAN works at office
+export KUBECONFIG=~/.kube/config-cloudless-ts   # LAN kubeconfig at office
 bash infrastructure/tailscale/deploy.sh
 ```
-
-7. After HTTPS + host approval, force cert re-issue if Secrets are empty:
-
-```bash
-bash scripts/tailscale-refresh-tls-secrets.sh
-```
-
-8. Wait:
 
 ```bash
 kubectl wait connector k3s-cidrs --for=condition=ConnectorReady=true --timeout=5m
 kubectl wait proxygroup ingress --for=condition=ProxyGroupReady=true --timeout=5m
 kubectl wait proxygroup kube --for=condition=ProxyGroupReady=true --timeout=5m
-kubectl get ingress -A   # ADDRESS should populate
+kubectl get ingress -A
+kubectl get pods -n tailscale
 ```
 
-9. kubectl via API proxy (preferred off-LAN):
+Empty TLS Secrets after HTTPS enable:
 
 ```bash
-URL=$(kubectl get proxygroup kube -o jsonpath='{.status.url}')
-tailscale configure kubeconfig "$URL"
-kubectl get nodes
+bash scripts/tailscale-refresh-tls-secrets.sh
 ```
 
-## k3s TLS SANs (direct `:6443` over Tailscale)
-
-Cert today includes `192.168.1.128` but **not** `100.74.191.58`. For direct
-API dialing (without the kube ProxyGroup), add SANs then restart k3s:
+### 8.3 k3s TLS SANs (only if dialing `:6443` over Tailscale)
 
 ```yaml
-# on omv /etc/rancher/k3s/config.yaml — or via scripts/configure-k3s.sh
+# /etc/rancher/k3s/config.yaml (via scripts/configure-k3s.sh)
 tls-san:
   - "192.168.1.128"
-  - "100.74.191.58"
+  - "100.74.191.58"                 # refresh if CGNAT changed
   - "github-omv.tail4ecae1.ts.net"
 ```
 
 ```bash
 sudo TLS_SAN_TS=100.74.191.58 TLS_SAN_MAGICDNS=github-omv.tail4ecae1.ts.net \
-  ETCD_S3_ACCESS_KEY=… ETCD_S3_SECRET_KEY=… \
   ./scripts/configure-k3s.sh
 sudo systemctl restart k3s
 ```
 
-Clients accepting subnet routes:
+Clients:
 
 ```bash
-sudo tailscale set --accept-routes   # Linux with TUN
+sudo tailscale set --accept-routes   # Linux with real TUN
 ```
 
-WSL userspace still needs SOCKS/TUN for `100.x` TCP — prefer LAN or the
-`kube` ProxyGroup URL over HTTPS Serve.
+### 8.4 Workflows & scripts
 
-## Node reference
+| Workflow / script | Purpose |
+|-------------------|---------|
+| `tailscale-deploy.yml` / `tailscale-fabric-deploy.yml` | Operator / fabric apply |
+| `tailscale-enable-https.yml` | Tailnet HTTPS setting |
+| `tailscale-approve-service-hosts.yml` | Approve `svc:*` hosts |
+| `tailscale-fix-fabric-acl.yml` | ACL merge helper |
+| `tailscale-probe-posture.yml` | Posture / health of fabric |
+| `tailscale-admin-api.yml` | Admin API automation |
+| `scripts/tailscale-diagnose.sh` | Local diagnosis |
+| `scripts/setup-kubectl-tailscale.sh` | Client kubeconfig helper |
+| `scripts/ts-wsl.sh` | WSL userspace Tailscale |
 
-| Node | LAN | Tailscale | Role |
-|------|-----|-----------|------|
-| omv (`github-omv`) | 192.168.1.128 | 100.74.191.58 | control-plane |
-| omv-ha | 192.168.1.130 | 100.95.117.84 | worker |
-| office (WSL) | — | 100.98.121.44 | admin laptop |
+---
 
-## Files
+## 9. Troubleshooting map
 
-| File | Role |
-|------|------|
-| `connector.yaml` | HA Connector + `pi-fabric` ProxyClass |
-| `proxygroup.yaml` | ingress + kube-apiserver ProxyGroups |
-| `ingresses.yaml` | Grafana / Loki / Meili → shared group |
-| `acl-policy.example.json` | tagOwners / autoApprovers / grants |
-| `deploy.sh` | Helm operator + apply manifests |
-| `ingress-class.yaml` | `IngressClass` `tailscale` |
-
-## Troubleshooting
+```mermaid
+flowchart TD
+  Q{Symptom?}
+  Q -->|kubectl timeout off-LAN| A1[Use kube ProxyGroup URL<br/>or LAN 192.168.1.128]
+  Q -->|ping 100.x OK, TCP fail| A2[WSL userspace — switch TUN<br/>or ProxyGroup]
+  Q -->|Ingress ADDRESS empty| A3[HTTPS certs + host approval<br/>+ http-endpoint annotation]
+  Q -->|Many new Machines| A4[Missing proxy-group annotation<br/>delete stale devices]
+  Q -->|GHA 403 on cloudless.gr| A5[CF Bot Fight — not Tailscale<br/>fallback MagicDNS/NodePort]
+  Q -->|NodePort timeout on 100.x| A6[Wrong/stale IP — use MagicDNS<br/>or SSH then curl 127.0.0.1:30300]
+  Q -->|Offline tagged device| A7[Delete in admin UI<br/>see OFFLINE-DEVICE-TROUBLESHOOTING]
+```
 
 ```bash
-kubectl get connector,proxygroup,proxyclass
-kubectl get pods -n tailscale
-kubectl logs -n tailscale -l app.kubernetes.io/name=operator
 tailscale status
+kubectl get connector,proxygroup,proxyclass -A
+kubectl get pods -n tailscale
+kubectl logs -n tailscale -l app.kubernetes.io/name=operator --tail=100
+bash scripts/tailscale-diagnose.sh
+bash scripts/tailscale-probe-posture.sh
 ```
 
-Offline / stale devices: delete in admin UI — see
-`OFFLINE-DEVICE-TROUBLESHOOTING.md` (device IPs will differ after redeploy).
+Offline / orphaned devices: [`OFFLINE-DEVICE-TROUBLESHOOTING.md`](../infrastructure/tailscale/OFFLINE-DEVICE-TROUBLESHOOTING.md)
+(device IPs in that file are historical snapshots).
 
-Related: `docs/kubectl-tailscale.md`, `docs/CLUSTER-MAP.md`.
+---
+
+## 10. Related documents
+
+| Doc | Role |
+|-----|------|
+| [`kubectl-tailscale.md`](kubectl-tailscale.md) | Day-2 kubectl from WSL / LAN |
+| [`infrastructure/tailscale/README.md`](../infrastructure/tailscale/README.md) | Manifest index + quick deploy |
+| [`databases/omv-cluster.md`](databases/omv-cluster.md) | DB access rules (no TS exposure) |
+| [`CLUSTER-MAP.md`](../CLUSTER-MAP.md) | Live pod map (refresh periodically) |
+| Cloudflare tunnel ops skill | Public `*.cloudless.gr` ingress |
+
+---
+
+## 11. Glossary
+
+| Term | Meaning here |
+|------|----------------|
+| **Fabric** | Private Tailscale mesh used by admins and automation |
+| **Serve** | Tailscale HTTPS to a node/ProxyGroup VIP (tailnet-only unless Funnel) |
+| **Funnel** | Expose Serve to the public internet — **not** our production edge |
+| **Connector** | Operator CR that advertises subnet routes |
+| **ProxyGroup** | Shared proxy StatefulSet (`ingress` / `egress` / `kube-apiserver`) |
+| **MagicDNS** | `*.tail4ecae1.ts.net` names — prefer over CGNAT IPs |
+| **pi-origin** | Cloudflare hostname → Tunnel → `192.168.1.128:30300` |

--- a/docs/databases/README.md
+++ b/docs/databases/README.md
@@ -66,6 +66,7 @@ Use **SQLTools**, not the Microsoft SQL Server extension (`ms-mssql`).
 | Doc | Topic |
 |-----|--------|
 | [kubectl-tailscale.md](../kubectl-tailscale.md) | Cluster API access (LAN / Tailscale) |
+| [TAILSCALE-FABRIC.md](../TAILSCALE-FABRIC.md) | Tailscale admin fabric architecture (trust boundaries, ProxyGroups) |
 | [datalake.md](../datalake.md) | Analytics / lake layout |
 | [etl.md](../etl.md) | ETL jobs |
 | [appflowy-deploy.md](../appflowy-deploy.md) | AppFlowy (Postgres + Redis + MinIO) |

--- a/docs/databases/landscape.md
+++ b/docs/databases/landscape.md
@@ -353,5 +353,6 @@ Do not expand AWS RDS / S3 backup paths for new work; R2 + existing CronJobs are
 - [omv-cluster.md](omv-cluster.md) — field-level inventory, ports, secrets
 - [README.md](README.md) — commands and SQLTools
 - [ADR-001](ADR-001-mediated-db-access.md) — mediated access decision
-- [../kubectl-tailscale.md](../kubectl-tailscale.md) — API access
+- [../kubectl-tailscale.md](../kubectl-tailscale.md) — API access (day-2)
+- [../TAILSCALE-FABRIC.md](../TAILSCALE-FABRIC.md) — Tailscale fabric architecture
 - [../../infrastructure/backup/README.md](../../infrastructure/backup/README.md) — CronJob details

--- a/docs/databases/omv-cluster.md
+++ b/docs/databases/omv-cluster.md
@@ -13,7 +13,7 @@ Verified live 2026-07-30. Passwords are **never** stored in this doc — pull th
 | DB ports | **ClusterIP only** — not exposed via Cloudflare tunnels |
 | App HTTP | Cloudflare (`*.cloudless.gr`) / NodePorts — apps, not DBs |
 | From WSL / Cursor | `kubectl port-forward` → localhost (see [Developer access](#developer-access)) |
-| kube-apiserver | LAN `https://192.168.1.128:6443` (preferred in office) — [kubectl-tailscale.md](../kubectl-tailscale.md) |
+| kube-apiserver | LAN `https://192.168.1.128:6443` (preferred in office) — [kubectl-tailscale.md](../kubectl-tailscale.md) · fabric: [TAILSCALE-FABRIC.md](../TAILSCALE-FABRIC.md) |
 | Shared `database` / `cache` NS | **Do not exist** on the live cluster (manifests under `infrastructure/database/` are unused) |
 
 ```mermaid

--- a/docs/kubectl-tailscale.md
+++ b/docs/kubectl-tailscale.md
@@ -1,26 +1,47 @@
 # kubectl via Tailscale / office LAN
 
+> Architecture & trust boundaries: **[`TAILSCALE-FABRIC.md`](TAILSCALE-FABRIC.md)**  
+> This page is the **day-2 operator runbook** only.
+
 Use the office LAN or Tailscale mesh so WSL can run `kubectl` against the Pi
 k3s API **without** SSH ProxyJump for every apply.
 
-## Current status (office WSL)
+## Choose a path
 
-| Piece | State |
-|-------|--------|
-| WSL device `office` | Connected (`100.98.121.44`) |
-| `github-omv` | Connected (`100.74.191.58`) |
-| `kubectl get nodes` | Works via **LAN** `https://192.168.1.128:6443` |
-| Userspace Tailscale TCP to `100.x:6443` | Unreliable (ping works; SOCKS TCP often fails) |
+```mermaid
+flowchart TD
+  Start[Need kubectl?] --> OnLAN{On office LAN?}
+  OnLAN -->|yes| LAN["KUBECONFIG → https://192.168.1.128:6443"]
+  OnLAN -->|no| TUN{Real Tailscale TUN?}
+  TUN -->|yes| KubePG["ProxyGroup kube<br/>tailscale configure kubeconfig"]
+  TUN -->|userspace WSL| Avoid["Avoid raw 100.x TCP<br/>use LAN or ProxyGroup from a TUN host"]
+  KubePG --> OK[kubectl get nodes]
+  LAN --> OK
+```
 
-**At home/office:** prefer the LAN kubeconfig (cert SAN already includes `192.168.1.128`).
+| Situation | Use |
+|-----------|-----|
+| Sitting on office LAN | LAN kubeconfig → `https://192.168.1.128:6443` |
+| Off-LAN, system Tailscale (TUN) | `ProxyGroup/kube` Serve URL |
+| WSL userspace only | Prefer LAN; userspace SOCKS to `100.x:6443` is unreliable |
 
-**Away from LAN:** install system Tailscale with a real TUN (or Windows Tailscale + mirrored networking), **and** add the Tailscale IP / MagicDNS name to k3s `tls-san` (cert today has LAN + ClusterIP only — **not** `100.74.191.58`).
+## Endpoints (prefer MagicDNS)
 
-## One-time setup
+| Role | LAN | Tailscale IPv4 | MagicDNS |
+|------|-----|----------------|----------|
+| omv control-plane | **192.168.1.128** | `100.74.191.58` | `github-omv.tail4ecae1.ts.net` |
+| omv-ha worker | 192.168.1.130 | `100.95.117.84` | `omv-ha.tail4ecae1.ts.net` |
+| office WSL | — | `100.98.121.44` | `office.…` |
+
+Tailscale IPs **rotate**. New automation should use MagicDNS. Stale
+`100.113.41.119` / `omv.tail8eb71.ts.net` references elsewhere are drift — see
+fabric doc §3.
+
+## One-time client setup (WSL)
 
 ```bash
-bash scripts/ts-wsl.sh status          # starts userspace daemon + SOCKS :1055
-bash scripts/ts-wsl.sh login           # if not already approved in admin console
+bash scripts/ts-wsl.sh status          # userspace daemon + SOCKS :1055
+bash scripts/ts-wsl.sh login           # approve in admin console if needed
 bash scripts/setup-kubectl-tailscale.sh
 ```
 
@@ -39,46 +60,20 @@ kubectl get nodes
 kubectl get pods -n monitoring
 ```
 
-## Endpoints
+## Off-LAN: kube-apiserver ProxyGroup
 
-| Role | LAN | Tailscale | MagicDNS |
-|------|-----|-----------|----------|
-| omv (API) | **192.168.1.128** | 100.74.191.58 | `github-omv.tail4ecae1.ts.net` |
-| omv-ha | 192.168.1.130 | 100.95.117.84 | `omv-ha.…` |
-
-## Tailscale admin: what the 27 machines mean
-
-**Keep (live):**
-
-| Machine | Role |
-|---------|------|
-| `office` | This WSL laptop |
-| `github-omv` | Pi 5 control-plane + API |
-| `omv-ha` | Pi 3 worker (ephemeral OK) |
-
-**Optional / often offline:**
-
-| Machine | Notes |
-|---------|--------|
-| `k3s-subnet-router`, `k3s-subnet-router-1` | Advertise pod/service CIDRs — only needed to hit ClusterIPs from laptop |
-| `tailscale-operator-1` | Operator on ha path — offline until operator redeployed |
-| `cloudless-k3s-operator` | Old WSL operator client — can remove if unused |
-
-**Stale `tag:k8s` devices (safe to delete in admin):**  
-`appflowy`, `cloudless-app`, `cloudless-manager`, `grafana`, `meilisearch`, `n8n`, `postgres`, `redis`, `sync-webhook`, `monitoring-proxies-0..9`, `monitoring-proxy-0` — last seen ~Jul 11; leftovers from a previous operator ProxyGroup. Deleting them cleans the UI; they are not required for kubectl.
-
-## Off-LAN (preferred): kube-apiserver ProxyGroup
-
-After `infrastructure/tailscale/deploy.sh`:
+After [`infrastructure/tailscale/deploy.sh`](../infrastructure/tailscale/deploy.sh)
+(see fabric doc §8):
 
 ```bash
 URL=$(kubectl get proxygroup kube -o jsonpath='{.status.url}')
 tailscale configure kubeconfig "$URL"
+kubectl get nodes
 ```
 
-See `docs/TAILSCALE-FABRIC.md`. Alternative: add Tailscale SANs via
-`scripts/configure-k3s.sh` (`TLS_SAN_TS`, `TLS_SAN_MAGICDNS`) and dial
-`https://100.74.191.58:6443` on a client with a real TUN + `--accept-routes`.
+Alternative (TUN client + TLS SANs on k3s): dial
+`https://github-omv.tail4ecae1.ts.net:6443` or the current CGNAT IP with
+`--accept-routes`. SAN setup is in fabric doc §8.3.
 
 ## Fallback (SSH)
 
@@ -87,7 +82,26 @@ ssh -J tbaltzakis@192.168.1.130 tbaltzakis@192.168.1.128 \
   'KUBECONFIG=~/.kube/config kubectl get nodes'
 ```
 
+Over Tailscale (MagicDNS):
+
+```bash
+ssh tbaltzakis@github-omv.tail4ecae1.ts.net 'kubectl get nodes'
+```
+
+## Machines hygiene
+
+**Keep online:** `github-omv`, `omv-ha`, `office`, Connector / ProxyGroup
+devices owned by the operator (`k3s-subnet-router-*`, `ingress-*`, `kube-*`).
+
+**Safe to delete when offline forever:** old per-app proxies
+(`monitoring-proxies-*`, `ts-n8n-*`, `appflowy`, `grafana`, …) from before
+shared `proxy-group` annotations. Details:
+[`OFFLINE-DEVICE-TROUBLESHOOTING.md`](../infrastructure/tailscale/OFFLINE-DEVICE-TROUBLESHOOTING.md).
+
 ## Notes
 
 - Do **not** commit `~/.kube/config-cloudless-ts`.
-- Subnet routes (`10.42.0.0/16`, `10.43.0.0/16`) are optional — only for direct ClusterIP access from the laptop.
+- Subnet routes (`10.42.0.0/16`, `10.43.0.0/16`) are optional — only for direct
+  ClusterIP access from a laptop with `--accept-routes`.
+- DB ports stay ClusterIP — use `pnpm db:forward` / port-forward
+  ([databases/omv-cluster.md](databases/omv-cluster.md)).

--- a/infrastructure/omv-ha/tailscale-funnel-setup.md
+++ b/infrastructure/omv-ha/tailscale-funnel-setup.md
@@ -1,40 +1,48 @@
-# Tailscale Funnel Setup for omv-ha Standby Node
+# Tailscale Funnel on omv / omv-ha — historical note
 
-**STATUS: MIGRATED TO CLOUDFLARE WORKERS** (July 2026)
+> **Status:** not the production edge (updated 2026-07-30)  
+> **Canonical architecture:** [`docs/TAILSCALE-FABRIC.md`](../../docs/TAILSCALE-FABRIC.md)
 
-The cloudless.gr application has been migrated from k3s to Cloudflare Workers. The Tailscale Funnel failover is no longer required as the primary application is now served directly by Cloudflare.
+## What changed
 
-## Current Architecture
+Public `cloudless.gr` traffic is:
 
+```text
+Client → Cloudflare → Worker cloudless2 (pi-origin-proxy)
+       → Tunnel hostname pi-origin.cloudless.gr
+       → omv NodePort :30300 (cloudless-app on k3s)
 ```
-                     ┌─────────────────────┐
-                     │   Cloudflare Worker   │
-                     │  cloudless.gr (primary)│
-                     │  /api/health: 200 OK   │
-                     └─────────────────────┘
-```
 
-## Migration Complete (July 2026)
+Tailscale **Funnel** is not part of that path. Using Funnel as a primary or HA
+origin caused trust-boundary confusion (Bot Fight vs GHA, split-brain with the
+Cloudflare Tunnel, SEO/CI noise).
 
-- Main application: `https://cloudless.gr` → Cloudflare Workers ✓
-- Health endpoint: `/api/health` returns `{"status":"ok","authProvider":"d1"}` ✓
-- k3s `cloudless-app` deployment removed (was pulling from AWS ECR) ✓
-- `pi-origin.cloudless.gr` no longer serves the application
+The Pi app **still runs on k3s** — only the public front door moved to
+Cloudflare. Do not delete NodePort `:30300` or the Tunnel ingress because Funnel
+was retired as primary.
 
-## Alternative: Proxy to Workers (Optional)
+## When Funnel / Serve is still useful
 
-If Tailscale Funnel is still desired for internal access, configure nginx to proxy to the Workers endpoint:
+| Use | How |
+|-----|-----|
+| Admin GUIs (Grafana, Meili) | Private **Serve** via `ProxyGroup/ingress` — fabric doc §5.4 |
+| Break-glass node HTTPS | MagicDNS e.g. `https://github-omv.tail4ecae1.ts.net/…` (diagnostic) |
+| GHA health when CF returns 403 | Prefer MagicDNS Serve after `TS_AUTHKEY`, not Funnel-as-CDN |
 
-```nginx
-# /etc/nginx/sites-available/cloudless-workers
-server {
-    listen 8080;
-    server_name pi-origin.cloudless.gr;
+## Do not
 
-    location / {
-        proxy_pass https://cloudless.gr;
-        proxy_set_header Host cloudless.gr;
-        proxy_ssl_server_name on;
-        proxy_ssl_name cloudless.gr;
-    }
-}
+- Point Cloudflare origin or LB health checks at `*.ts.net` Funnel hosts as the
+  long-term primary.
+- Expose databases or kube-apiserver via Funnel.
+- Reintroduce one Funnel hostname per app Service.
+
+## Legacy names (drift)
+
+| Name | Notes |
+|------|-------|
+| `omv.tail8eb71.ts.net` | Old tailnet / Funnel hostname — do not use in new automation |
+| `*.ts.cloudless.gr` | Abandoned public Tailscale DNS idea |
+| `100.113.41.119` | Stale CGNAT — current SoT uses MagicDNS + `100.74.191.58` for github-omv |
+
+If you need public HTTP, use Cloudflare Tunnel + Worker. If you need private
+admin HTTP, use the fabric ProxyGroups.

--- a/infrastructure/tailscale/README.md
+++ b/infrastructure/tailscale/README.md
@@ -1,6 +1,10 @@
 # Tailscale Operator (fabric interconnect)
 
-Canonical guide: [`docs/TAILSCALE-FABRIC.md`](../../docs/TAILSCALE-FABRIC.md)
+Canonical architecture: [`docs/TAILSCALE-FABRIC.md`](../../docs/TAILSCALE-FABRIC.md)  
+kubectl day-2: [`docs/kubectl-tailscale.md`](../../docs/kubectl-tailscale.md)
+
+Private admin mesh for Pi k3s. **Public** `*.cloudless.gr` stays on Cloudflare
+(Worker + Tunnel) — do not reintroduce Funnel as the production edge.
 
 ## Quick deploy
 
@@ -11,24 +15,43 @@ export KUBECONFIG=~/.kube/config-cloudless-ts
 bash infrastructure/tailscale/deploy.sh
 ```
 
-Then merge `acl-policy.example.json` into Tailscale Access controls and delete
-stale `tag:k8s` Machines from the Jul rebuild.
+Then:
+
+1. Merge `acl-policy.example.json` into Tailscale Access controls.
+2. Enable HTTPS Certificates (`scripts/tailscale-enable-https.sh`).
+3. Approve Service hosts (`scripts/tailscale-approve-service-hosts.sh`).
+4. Delete stale per-Service Machines from earlier ProxyGroup mistakes.
 
 ## Layout
 
+```mermaid
+flowchart LR
+  deploy[deploy.sh] --> helm[Helm operator]
+  helm --> C[connector.yaml]
+  helm --> P[proxygroup.yaml]
+  helm --> I[ingresses.yaml]
+  C --> routes["10.42/16 + 10.43/16"]
+  P --> ing[ingress ProxyGroup]
+  P --> kube[kube-apiserver ProxyGroup]
+  I --> ing
+```
+
 | File | Purpose |
 |------|---------|
-| `connector.yaml` | `Connector` advertises `10.42/16` + `10.43/16` (HA replicas: 2) |
+| `connector.yaml` | `Connector` advertises pod + ClusterIP CIDRs (HA replicas: 2) + `ProxyClass/pi-fabric` |
 | `proxygroup.yaml` | Shared `ingress` ProxyGroup + `kube-apiserver` ProxyGroup |
-| `ingresses.yaml` | Grafana / Loki / Meili with `tailscale.com/proxy-group: ingress` |
-| `acl-policy.example.json` | tagOwners + autoApprovers |
-| `deploy.sh` | Helm install (no AWS SSM) |
-| `subnet-router.yaml` / `proxygroup-monitoring.yaml` | Deprecated stubs |
+| `ingresses.yaml` | Grafana / Meili with `tailscale.com/proxy-group: ingress` |
+| `ingress-class.yaml` | `IngressClass` `tailscale` |
+| `acl-policy.example.json` | tagOwners + autoApprovers + grants |
+| `deploy.sh` | Helm install (OAuth env only — no AWS SSM) |
+| `subnet-router.yaml` / `proxygroup-monitoring.yaml` | Deprecated stubs — do not apply |
+| `OFFLINE-DEVICE-TROUBLESHOOTING.md` | Stale Machines cleanup |
 
-## Design rules (from Tailscale docs)
+## Design rules
 
 1. **Subnet routes → Connector**, never ProxyGroup.
 2. **Many services → one ingress ProxyGroup** (annotate `proxy-group`).
 3. **HA subnet routers** advertise identical CIDR strings.
 4. **kubectl remotely → kube-apiserver ProxyGroup** (`tailscale configure kubeconfig`).
-5. **No Funnel** for these GUIs — Cloudflare Access covers public admin HTTP.
+5. **No Funnel** for these GUIs — Cloudflare Access / Tunnel covers public HTTP.
+6. **MagicDNS over CGNAT literals** in new scripts (`*.tail4ecae1.ts.net`).


### PR DESCRIPTION
## Summary
- Promote `docs/TAILSCALE-FABRIC.md` to architect-level source of truth: trust boundaries, topology, layered model, traffic sequences, ADRs, anti-patterns, deploy/ops, troubleshooting map (Mermaid throughout).
- Slim `docs/kubectl-tailscale.md` to a day-2 kubectl runbook that points at the fabric doc.
- Correct `infrastructure/omv-ha/tailscale-funnel-setup.md` (Funnel is not prod edge; Pi still serves via CF Tunnel + NodePort).
- Refresh infra README, CLUSTER-MAP exposure table, and database doc cross-links.
- Document MagicDNS preference and known IP/hostname drift (`100.113.41.119`, `omv.tail8eb71.ts.net`).

## Test plan
- [ ] Preview Mermaid diagrams in GitHub PR render
- [ ] Spot-check links from databases README / omv-cluster / landscape
- [ ] Confirm Funnel doc no longer claims Workers-only / no Pi app


Made with [Cursor](https://cursor.com)