### PR TITLE
fix(test): scope D1 auth mocks per file (CI follow-up)

### DIFF
--- a/__tests__/admin-ab-tests-api.test.ts
+++ b/__tests__/admin-ab-tests-api.test.ts
@@ -3,6 +3,64 @@ import { NextRequest } from "next/server";
 import { DEFAULT_FLAGS } from "@/lib/ab-flags";
 import { resetJsonConfigMemory, writeJsonConfig } from "@/lib/app-config-json";
 
+vi.mock("@/lib/api-auth", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/api-auth")>();
+  const { NextResponse } = await import("next/server");
+  const adminUser = {
+    sub: "test-admin-sub",
+    email: "admin@cloudless.gr",
+    groups: ["admin"],
+    email_verified: true,
+  };
+  const plainUser = {
+    sub: "test-user-sub",
+    email: "user@cloudless.gr",
+    groups: [] as string[],
+    email_verified: true,
+  };
+
+  function userFromRequest(request: { headers: { get: (k: string) => string | null } }) {
+    const h = request.headers.get("authorization") ?? "";
+    const token = h.startsWith("Bearer ") ? h.slice(7) : "";
+    if (token === "test-admin-session") return adminUser;
+    if (token === "test-user-session") return plainUser;
+    // Allow email-bearing opaque tokens used by user-route tests: "user-session:<email>"
+    if (token.startsWith("user-session:")) {
+      const email = token.slice("user-session:".length) || "user@cloudless.gr";
+      return { ...plainUser, email, sub: `user-${email}` };
+    }
+    if (token.startsWith("admin-session:")) {
+      const email = token.slice("admin-session:".length) || "admin@cloudless.gr";
+      return { ...adminUser, email, sub: `admin-${email}` };
+    }
+    return null;
+  }
+
+  return {
+    ...actual,
+    requireAuth: async (request: Parameters<typeof actual.requireAuth>[0]) => {
+      const user = userFromRequest(request);
+      if (user) return { ok: true as const, user };
+      return actual.requireAuth(request);
+    },
+    requireAdmin: async (request: Parameters<typeof actual.requireAdmin>[0]) => {
+      const user = userFromRequest(request);
+      if (!user) return actual.requireAdmin(request);
+      if (!user.groups.includes("admin")) {
+        return {
+          ok: false as const,
+          response: NextResponse.json({ error: "Admin access required" }, { status: 403 }),
+        };
+      }
+      return { ok: true as const, user };
+    },
+    requireVerifiedAuth: async (request: Parameters<typeof actual.requireVerifiedAuth>[0]) => {
+      const user = userFromRequest(request);
+      if (user) return { ok: true as const, user };
+      return actual.requireVerifiedAuth(request);
+    },
+  };
+});
 const ABTEST_URL = "http://localhost/api/admin/ab-tests";
 const CONFIG_KEY = "AB_FLAGS_JSON";
 

--- a/__tests__/admin-ai-analytics-orchestration-api.test.ts
+++ b/__tests__/admin-ai-analytics-orchestration-api.test.ts
@@ -1,6 +1,64 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { NextRequest } from "next/server";
 
+vi.mock("@/lib/api-auth", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/api-auth")>();
+  const { NextResponse } = await import("next/server");
+  const adminUser = {
+    sub: "test-admin-sub",
+    email: "admin@cloudless.gr",
+    groups: ["admin"],
+    email_verified: true,
+  };
+  const plainUser = {
+    sub: "test-user-sub",
+    email: "user@cloudless.gr",
+    groups: [] as string[],
+    email_verified: true,
+  };
+
+  function userFromRequest(request: { headers: { get: (k: string) => string | null } }) {
+    const h = request.headers.get("authorization") ?? "";
+    const token = h.startsWith("Bearer ") ? h.slice(7) : "";
+    if (token === "test-admin-session") return adminUser;
+    if (token === "test-user-session") return plainUser;
+    // Allow email-bearing opaque tokens used by user-route tests: "user-session:<email>"
+    if (token.startsWith("user-session:")) {
+      const email = token.slice("user-session:".length) || "user@cloudless.gr";
+      return { ...plainUser, email, sub: `user-${email}` };
+    }
+    if (token.startsWith("admin-session:")) {
+      const email = token.slice("admin-session:".length) || "admin@cloudless.gr";
+      return { ...adminUser, email, sub: `admin-${email}` };
+    }
+    return null;
+  }
+
+  return {
+    ...actual,
+    requireAuth: async (request: Parameters<typeof actual.requireAuth>[0]) => {
+      const user = userFromRequest(request);
+      if (user) return { ok: true as const, user };
+      return actual.requireAuth(request);
+    },
+    requireAdmin: async (request: Parameters<typeof actual.requireAdmin>[0]) => {
+      const user = userFromRequest(request);
+      if (!user) return actual.requireAdmin(request);
+      if (!user.groups.includes("admin")) {
+        return {
+          ok: false as const,
+          response: NextResponse.json({ error: "Admin access required" }, { status: 403 }),
+        };
+      }
+      return { ok: true as const, user };
+    },
+    requireVerifiedAuth: async (request: Parameters<typeof actual.requireVerifiedAuth>[0]) => {
+      const user = userFromRequest(request);
+      if (user) return { ok: true as const, user };
+      return actual.requireVerifiedAuth(request);
+    },
+  };
+});
 const { getConfigMock, getSnapshotMock, runOrchestrationMock } = vi.hoisted(() => ({
   getConfigMock: vi.fn(),
   getSnapshotMock: vi.fn(),

--- a/__tests__/admin-ai-analytics-orchestration-pdf-api.test.ts
+++ b/__tests__/admin-ai-analytics-orchestration-pdf-api.test.ts
@@ -1,6 +1,64 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { NextRequest } from "next/server";
 
+vi.mock("@/lib/api-auth", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/api-auth")>();
+  const { NextResponse } = await import("next/server");
+  const adminUser = {
+    sub: "test-admin-sub",
+    email: "admin@cloudless.gr",
+    groups: ["admin"],
+    email_verified: true,
+  };
+  const plainUser = {
+    sub: "test-user-sub",
+    email: "user@cloudless.gr",
+    groups: [] as string[],
+    email_verified: true,
+  };
+
+  function userFromRequest(request: { headers: { get: (k: string) => string | null } }) {
+    const h = request.headers.get("authorization") ?? "";
+    const token = h.startsWith("Bearer ") ? h.slice(7) : "";
+    if (token === "test-admin-session") return adminUser;
+    if (token === "test-user-session") return plainUser;
+    // Allow email-bearing opaque tokens used by user-route tests: "user-session:<email>"
+    if (token.startsWith("user-session:")) {
+      const email = token.slice("user-session:".length) || "user@cloudless.gr";
+      return { ...plainUser, email, sub: `user-${email}` };
+    }
+    if (token.startsWith("admin-session:")) {
+      const email = token.slice("admin-session:".length) || "admin@cloudless.gr";
+      return { ...adminUser, email, sub: `admin-${email}` };
+    }
+    return null;
+  }
+
+  return {
+    ...actual,
+    requireAuth: async (request: Parameters<typeof actual.requireAuth>[0]) => {
+      const user = userFromRequest(request);
+      if (user) return { ok: true as const, user };
+      return actual.requireAuth(request);
+    },
+    requireAdmin: async (request: Parameters<typeof actual.requireAdmin>[0]) => {
+      const user = userFromRequest(request);
+      if (!user) return actual.requireAdmin(request);
+      if (!user.groups.includes("admin")) {
+        return {
+          ok: false as const,
+          response: NextResponse.json({ error: "Admin access required" }, { status: 403 }),
+        };
+      }
+      return { ok: true as const, user };
+    },
+    requireVerifiedAuth: async (request: Parameters<typeof actual.requireVerifiedAuth>[0]) => {
+      const user = userFromRequest(request);
+      if (user) return { ok: true as const, user };
+      return actual.requireVerifiedAuth(request);
+    },
+  };
+});
 const { getConfigMock, getSnapshotMock, runOrchestrationMock } = vi.hoisted(() => ({
   getConfigMock: vi.fn(),
   getSnapshotMock: vi.fn(),

--- a/__tests__/admin-ai-api.test.ts
+++ b/__tests__/admin-ai-api.test.ts
@@ -1,6 +1,64 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { NextRequest } from "next/server";
 
+vi.mock("@/lib/api-auth", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/api-auth")>();
+  const { NextResponse } = await import("next/server");
+  const adminUser = {
+    sub: "test-admin-sub",
+    email: "admin@cloudless.gr",
+    groups: ["admin"],
+    email_verified: true,
+  };
+  const plainUser = {
+    sub: "test-user-sub",
+    email: "user@cloudless.gr",
+    groups: [] as string[],
+    email_verified: true,
+  };
+
+  function userFromRequest(request: { headers: { get: (k: string) => string | null } }) {
+    const h = request.headers.get("authorization") ?? "";
+    const token = h.startsWith("Bearer ") ? h.slice(7) : "";
+    if (token === "test-admin-session") return adminUser;
+    if (token === "test-user-session") return plainUser;
+    // Allow email-bearing opaque tokens used by user-route tests: "user-session:<email>"
+    if (token.startsWith("user-session:")) {
+      const email = token.slice("user-session:".length) || "user@cloudless.gr";
+      return { ...plainUser, email, sub: `user-${email}` };
+    }
+    if (token.startsWith("admin-session:")) {
+      const email = token.slice("admin-session:".length) || "admin@cloudless.gr";
+      return { ...adminUser, email, sub: `admin-${email}` };
+    }
+    return null;
+  }
+
+  return {
+    ...actual,
+    requireAuth: async (request: Parameters<typeof actual.requireAuth>[0]) => {
+      const user = userFromRequest(request);
+      if (user) return { ok: true as const, user };
+      return actual.requireAuth(request);
+    },
+    requireAdmin: async (request: Parameters<typeof actual.requireAdmin>[0]) => {
+      const user = userFromRequest(request);
+      if (!user) return actual.requireAdmin(request);
+      if (!user.groups.includes("admin")) {
+        return {
+          ok: false as const,
+          response: NextResponse.json({ error: "Admin access required" }, { status: 403 }),
+        };
+      }
+      return { ok: true as const, user };
+    },
+    requireVerifiedAuth: async (request: Parameters<typeof actual.requireVerifiedAuth>[0]) => {
+      const user = userFromRequest(request);
+      if (user) return { ok: true as const, user };
+      return actual.requireVerifiedAuth(request);
+    },
+  };
+});
 // ---------------------------------------------------------------------------
 // Hoist mocks
 // ---------------------------------------------------------------------------

--- a/__tests__/admin-analytics-api.test.ts
+++ b/__tests__/admin-analytics-api.test.ts
@@ -1,6 +1,64 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { NextRequest } from "next/server";
 
+vi.mock("@/lib/api-auth", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/api-auth")>();
+  const { NextResponse } = await import("next/server");
+  const adminUser = {
+    sub: "test-admin-sub",
+    email: "admin@cloudless.gr",
+    groups: ["admin"],
+    email_verified: true,
+  };
+  const plainUser = {
+    sub: "test-user-sub",
+    email: "user@cloudless.gr",
+    groups: [] as string[],
+    email_verified: true,
+  };
+
+  function userFromRequest(request: { headers: { get: (k: string) => string | null } }) {
+    const h = request.headers.get("authorization") ?? "";
+    const token = h.startsWith("Bearer ") ? h.slice(7) : "";
+    if (token === "test-admin-session") return adminUser;
+    if (token === "test-user-session") return plainUser;
+    // Allow email-bearing opaque tokens used by user-route tests: "user-session:<email>"
+    if (token.startsWith("user-session:")) {
+      const email = token.slice("user-session:".length) || "user@cloudless.gr";
+      return { ...plainUser, email, sub: `user-${email}` };
+    }
+    if (token.startsWith("admin-session:")) {
+      const email = token.slice("admin-session:".length) || "admin@cloudless.gr";
+      return { ...adminUser, email, sub: `admin-${email}` };
+    }
+    return null;
+  }
+
+  return {
+    ...actual,
+    requireAuth: async (request: Parameters<typeof actual.requireAuth>[0]) => {
+      const user = userFromRequest(request);
+      if (user) return { ok: true as const, user };
+      return actual.requireAuth(request);
+    },
+    requireAdmin: async (request: Parameters<typeof actual.requireAdmin>[0]) => {
+      const user = userFromRequest(request);
+      if (!user) return actual.requireAdmin(request);
+      if (!user.groups.includes("admin")) {
+        return {
+          ok: false as const,
+          response: NextResponse.json({ error: "Admin access required" }, { status: 403 }),
+        };
+      }
+      return { ok: true as const, user };
+    },
+    requireVerifiedAuth: async (request: Parameters<typeof actual.requireVerifiedAuth>[0]) => {
+      const user = userFromRequest(request);
+      if (user) return { ok: true as const, user };
+      return actual.requireVerifiedAuth(request);
+    },
+  };
+});
 // ---------------------------------------------------------------------------
 // Hoist mocks
 // ---------------------------------------------------------------------------

--- a/__tests__/admin-api.test.ts
+++ b/__tests__/admin-api.test.ts
@@ -3,6 +3,64 @@ import { NextRequest } from "next/server";
 import { resetIntegrationCache } from "@/lib/integrations";
 import { resetSsmCache } from "@/lib/ssm-config";
 
+vi.mock("@/lib/api-auth", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/api-auth")>();
+  const { NextResponse } = await import("next/server");
+  const adminUser = {
+    sub: "test-admin-sub",
+    email: "admin@cloudless.gr",
+    groups: ["admin"],
+    email_verified: true,
+  };
+  const plainUser = {
+    sub: "test-user-sub",
+    email: "user@cloudless.gr",
+    groups: [] as string[],
+    email_verified: true,
+  };
+
+  function userFromRequest(request: { headers: { get: (k: string) => string | null } }) {
+    const h = request.headers.get("authorization") ?? "";
+    const token = h.startsWith("Bearer ") ? h.slice(7) : "";
+    if (token === "test-admin-session") return adminUser;
+    if (token === "test-user-session") return plainUser;
+    // Allow email-bearing opaque tokens used by user-route tests: "user-session:<email>"
+    if (token.startsWith("user-session:")) {
+      const email = token.slice("user-session:".length) || "user@cloudless.gr";
+      return { ...plainUser, email, sub: `user-${email}` };
+    }
+    if (token.startsWith("admin-session:")) {
+      const email = token.slice("admin-session:".length) || "admin@cloudless.gr";
+      return { ...adminUser, email, sub: `admin-${email}` };
+    }
+    return null;
+  }
+
+  return {
+    ...actual,
+    requireAuth: async (request: Parameters<typeof actual.requireAuth>[0]) => {
+      const user = userFromRequest(request);
+      if (user) return { ok: true as const, user };
+      return actual.requireAuth(request);
+    },
+    requireAdmin: async (request: Parameters<typeof actual.requireAdmin>[0]) => {
+      const user = userFromRequest(request);
+      if (!user) return actual.requireAdmin(request);
+      if (!user.groups.includes("admin")) {
+        return {
+          ok: false as const,
+          response: NextResponse.json({ error: "Admin access required" }, { status: 403 }),
+        };
+      }
+      return { ok: true as const, user };
+    },
+    requireVerifiedAuth: async (request: Parameters<typeof actual.requireVerifiedAuth>[0]) => {
+      const user = userFromRequest(request);
+      if (user) return { ok: true as const, user };
+      return actual.requireVerifiedAuth(request);
+    },
+  };
+});
 // ---------------------------------------------------------------------------
 // Hoist mock variables so vi.mock() factories can reference them safely.
 // ---------------------------------------------------------------------------

--- a/__tests__/admin-autologin-api.test.ts
+++ b/__tests__/admin-autologin-api.test.ts
@@ -14,6 +14,64 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { NextRequest } from "next/server";
 
+vi.mock("@/lib/api-auth", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/api-auth")>();
+  const { NextResponse } = await import("next/server");
+  const adminUser = {
+    sub: "test-admin-sub",
+    email: "admin@cloudless.gr",
+    groups: ["admin"],
+    email_verified: true,
+  };
+  const plainUser = {
+    sub: "test-user-sub",
+    email: "user@cloudless.gr",
+    groups: [] as string[],
+    email_verified: true,
+  };
+
+  function userFromRequest(request: { headers: { get: (k: string) => string | null } }) {
+    const h = request.headers.get("authorization") ?? "";
+    const token = h.startsWith("Bearer ") ? h.slice(7) : "";
+    if (token === "test-admin-session") return adminUser;
+    if (token === "test-user-session") return plainUser;
+    // Allow email-bearing opaque tokens used by user-route tests: "user-session:<email>"
+    if (token.startsWith("user-session:")) {
+      const email = token.slice("user-session:".length) || "user@cloudless.gr";
+      return { ...plainUser, email, sub: `user-${email}` };
+    }
+    if (token.startsWith("admin-session:")) {
+      const email = token.slice("admin-session:".length) || "admin@cloudless.gr";
+      return { ...adminUser, email, sub: `admin-${email}` };
+    }
+    return null;
+  }
+
+  return {
+    ...actual,
+    requireAuth: async (request: Parameters<typeof actual.requireAuth>[0]) => {
+      const user = userFromRequest(request);
+      if (user) return { ok: true as const, user };
+      return actual.requireAuth(request);
+    },
+    requireAdmin: async (request: Parameters<typeof actual.requireAdmin>[0]) => {
+      const user = userFromRequest(request);
+      if (!user) return actual.requireAdmin(request);
+      if (!user.groups.includes("admin")) {
+        return {
+          ok: false as const,
+          response: NextResponse.json({ error: "Admin access required" }, { status: 403 }),
+        };
+      }
+      return { ok: true as const, user };
+    },
+    requireVerifiedAuth: async (request: Parameters<typeof actual.requireVerifiedAuth>[0]) => {
+      const user = userFromRequest(request);
+      if (user) return { ok: true as const, user };
+      return actual.requireVerifiedAuth(request);
+    },
+  };
+});
 // ---------------------------------------------------------------------------
 // Hoist mock variables
 // ---------------------------------------------------------------------------
@@ -90,7 +148,10 @@ beforeEach(() => {
 // Token helpers — mirrors admin-api.test.ts pattern
 // ---------------------------------------------------------------------------
 
-function makeToken(isAdmin = false): string {
+function makeToken(groupsOrAdmin: string[] | boolean = false): string {
+  const isAdmin = Array.isArray(groupsOrAdmin)
+    ? groupsOrAdmin.includes("admin")
+    : Boolean(groupsOrAdmin);
   return isAdmin ? "test-admin-session" : "test-user-session";
 }
 

--- a/__tests__/admin-cache-api.test.ts
+++ b/__tests__/admin-cache-api.test.ts
@@ -19,6 +19,64 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { NextRequest } from "next/server";
 
+vi.mock("@/lib/api-auth", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/api-auth")>();
+  const { NextResponse } = await import("next/server");
+  const adminUser = {
+    sub: "test-admin-sub",
+    email: "admin@cloudless.gr",
+    groups: ["admin"],
+    email_verified: true,
+  };
+  const plainUser = {
+    sub: "test-user-sub",
+    email: "user@cloudless.gr",
+    groups: [] as string[],
+    email_verified: true,
+  };
+
+  function userFromRequest(request: { headers: { get: (k: string) => string | null } }) {
+    const h = request.headers.get("authorization") ?? "";
+    const token = h.startsWith("Bearer ") ? h.slice(7) : "";
+    if (token === "test-admin-session") return adminUser;
+    if (token === "test-user-session") return plainUser;
+    // Allow email-bearing opaque tokens used by user-route tests: "user-session:<email>"
+    if (token.startsWith("user-session:")) {
+      const email = token.slice("user-session:".length) || "user@cloudless.gr";
+      return { ...plainUser, email, sub: `user-${email}` };
+    }
+    if (token.startsWith("admin-session:")) {
+      const email = token.slice("admin-session:".length) || "admin@cloudless.gr";
+      return { ...adminUser, email, sub: `admin-${email}` };
+    }
+    return null;
+  }
+
+  return {
+    ...actual,
+    requireAuth: async (request: Parameters<typeof actual.requireAuth>[0]) => {
+      const user = userFromRequest(request);
+      if (user) return { ok: true as const, user };
+      return actual.requireAuth(request);
+    },
+    requireAdmin: async (request: Parameters<typeof actual.requireAdmin>[0]) => {
+      const user = userFromRequest(request);
+      if (!user) return actual.requireAdmin(request);
+      if (!user.groups.includes("admin")) {
+        return {
+          ok: false as const,
+          response: NextResponse.json({ error: "Admin access required" }, { status: 403 }),
+        };
+      }
+      return { ok: true as const, user };
+    },
+    requireVerifiedAuth: async (request: Parameters<typeof actual.requireVerifiedAuth>[0]) => {
+      const user = userFromRequest(request);
+      if (user) return { ok: true as const, user };
+      return actual.requireVerifiedAuth(request);
+    },
+  };
+});
 // ---------------------------------------------------------------------------
 // Mock @/lib/notion-cache so we can spy on invalidateCache without touching
 // the real in-memory store.

--- a/__tests__/admin-campaigns-api.test.ts
+++ b/__tests__/admin-campaigns-api.test.ts
@@ -1,6 +1,64 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { NextRequest } from "next/server";
 
+vi.mock("@/lib/api-auth", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/api-auth")>();
+  const { NextResponse } = await import("next/server");
+  const adminUser = {
+    sub: "test-admin-sub",
+    email: "admin@cloudless.gr",
+    groups: ["admin"],
+    email_verified: true,
+  };
+  const plainUser = {
+    sub: "test-user-sub",
+    email: "user@cloudless.gr",
+    groups: [] as string[],
+    email_verified: true,
+  };
+
+  function userFromRequest(request: { headers: { get: (k: string) => string | null } }) {
+    const h = request.headers.get("authorization") ?? "";
+    const token = h.startsWith("Bearer ") ? h.slice(7) : "";
+    if (token === "test-admin-session") return adminUser;
+    if (token === "test-user-session") return plainUser;
+    // Allow email-bearing opaque tokens used by user-route tests: "user-session:<email>"
+    if (token.startsWith("user-session:")) {
+      const email = token.slice("user-session:".length) || "user@cloudless.gr";
+      return { ...plainUser, email, sub: `user-${email}` };
+    }
+    if (token.startsWith("admin-session:")) {
+      const email = token.slice("admin-session:".length) || "admin@cloudless.gr";
+      return { ...adminUser, email, sub: `admin-${email}` };
+    }
+    return null;
+  }
+
+  return {
+    ...actual,
+    requireAuth: async (request: Parameters<typeof actual.requireAuth>[0]) => {
+      const user = userFromRequest(request);
+      if (user) return { ok: true as const, user };
+      return actual.requireAuth(request);
+    },
+    requireAdmin: async (request: Parameters<typeof actual.requireAdmin>[0]) => {
+      const user = userFromRequest(request);
+      if (!user) return actual.requireAdmin(request);
+      if (!user.groups.includes("admin")) {
+        return {
+          ok: false as const,
+          response: NextResponse.json({ error: "Admin access required" }, { status: 403 }),
+        };
+      }
+      return { ok: true as const, user };
+    },
+    requireVerifiedAuth: async (request: Parameters<typeof actual.requireVerifiedAuth>[0]) => {
+      const user = userFromRequest(request);
+      if (user) return { ok: true as const, user };
+      return actual.requireVerifiedAuth(request);
+    },
+  };
+});
 // ---------------------------------------------------------------------------
 // Hoist mocks
 // ---------------------------------------------------------------------------

--- a/__tests__/admin-client-portals-api.test.ts
+++ b/__tests__/admin-client-portals-api.test.ts
@@ -3,6 +3,64 @@ import { NextRequest } from "next/server";
 import type { ClientPortal } from "@/app/api/admin/client-portals/route";
 import { resetJsonConfigMemory, writeJsonConfig } from "@/lib/app-config-json";
 
+vi.mock("@/lib/api-auth", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/api-auth")>();
+  const { NextResponse } = await import("next/server");
+  const adminUser = {
+    sub: "test-admin-sub",
+    email: "admin@cloudless.gr",
+    groups: ["admin"],
+    email_verified: true,
+  };
+  const plainUser = {
+    sub: "test-user-sub",
+    email: "user@cloudless.gr",
+    groups: [] as string[],
+    email_verified: true,
+  };
+
+  function userFromRequest(request: { headers: { get: (k: string) => string | null } }) {
+    const h = request.headers.get("authorization") ?? "";
+    const token = h.startsWith("Bearer ") ? h.slice(7) : "";
+    if (token === "test-admin-session") return adminUser;
+    if (token === "test-user-session") return plainUser;
+    // Allow email-bearing opaque tokens used by user-route tests: "user-session:<email>"
+    if (token.startsWith("user-session:")) {
+      const email = token.slice("user-session:".length) || "user@cloudless.gr";
+      return { ...plainUser, email, sub: `user-${email}` };
+    }
+    if (token.startsWith("admin-session:")) {
+      const email = token.slice("admin-session:".length) || "admin@cloudless.gr";
+      return { ...adminUser, email, sub: `admin-${email}` };
+    }
+    return null;
+  }
+
+  return {
+    ...actual,
+    requireAuth: async (request: Parameters<typeof actual.requireAuth>[0]) => {
+      const user = userFromRequest(request);
+      if (user) return { ok: true as const, user };
+      return actual.requireAuth(request);
+    },
+    requireAdmin: async (request: Parameters<typeof actual.requireAdmin>[0]) => {
+      const user = userFromRequest(request);
+      if (!user) return actual.requireAdmin(request);
+      if (!user.groups.includes("admin")) {
+        return {
+          ok: false as const,
+          response: NextResponse.json({ error: "Admin access required" }, { status: 403 }),
+        };
+      }
+      return { ok: true as const, user };
+    },
+    requireVerifiedAuth: async (request: Parameters<typeof actual.requireVerifiedAuth>[0]) => {
+      const user = userFromRequest(request);
+      if (user) return { ok: true as const, user };
+      return actual.requireVerifiedAuth(request);
+    },
+  };
+});
 const CLIENT_PORTALS_URL = "http://localhost/api/admin/client-portals";
 const PORTALS_CONFIG_KEY = "CLIENT_PORTALS_JSON";
 const TEST_NAME = "Themis";

--- a/__tests__/admin-kpi-api.test.ts
+++ b/__tests__/admin-kpi-api.test.ts
@@ -2,6 +2,64 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { NextRequest } from "next/server";
 import { resetIntegrationCache } from "@/lib/integrations";
 
+vi.mock("@/lib/api-auth", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/api-auth")>();
+  const { NextResponse } = await import("next/server");
+  const adminUser = {
+    sub: "test-admin-sub",
+    email: "admin@cloudless.gr",
+    groups: ["admin"],
+    email_verified: true,
+  };
+  const plainUser = {
+    sub: "test-user-sub",
+    email: "user@cloudless.gr",
+    groups: [] as string[],
+    email_verified: true,
+  };
+
+  function userFromRequest(request: { headers: { get: (k: string) => string | null } }) {
+    const h = request.headers.get("authorization") ?? "";
+    const token = h.startsWith("Bearer ") ? h.slice(7) : "";
+    if (token === "test-admin-session") return adminUser;
+    if (token === "test-user-session") return plainUser;
+    // Allow email-bearing opaque tokens used by user-route tests: "user-session:<email>"
+    if (token.startsWith("user-session:")) {
+      const email = token.slice("user-session:".length) || "user@cloudless.gr";
+      return { ...plainUser, email, sub: `user-${email}` };
+    }
+    if (token.startsWith("admin-session:")) {
+      const email = token.slice("admin-session:".length) || "admin@cloudless.gr";
+      return { ...adminUser, email, sub: `admin-${email}` };
+    }
+    return null;
+  }
+
+  return {
+    ...actual,
+    requireAuth: async (request: Parameters<typeof actual.requireAuth>[0]) => {
+      const user = userFromRequest(request);
+      if (user) return { ok: true as const, user };
+      return actual.requireAuth(request);
+    },
+    requireAdmin: async (request: Parameters<typeof actual.requireAdmin>[0]) => {
+      const user = userFromRequest(request);
+      if (!user) return actual.requireAdmin(request);
+      if (!user.groups.includes("admin")) {
+        return {
+          ok: false as const,
+          response: NextResponse.json({ error: "Admin access required" }, { status: 403 }),
+        };
+      }
+      return { ok: true as const, user };
+    },
+    requireVerifiedAuth: async (request: Parameters<typeof actual.requireVerifiedAuth>[0]) => {
+      const user = userFromRequest(request);
+      if (user) return { ok: true as const, user };
+      return actual.requireVerifiedAuth(request);
+    },
+  };
+});
 // ---------------------------------------------------------------------------
 // Hoisted mocks
 // ---------------------------------------------------------------------------
@@ -60,7 +118,10 @@ vi.mock("@/lib/notion-projects", () => ({
 // ---------------------------------------------------------------------------
 // JWT helpers
 // ---------------------------------------------------------------------------
-function makeToken(isAdmin = false): string {
+function makeToken(groupsOrAdmin: string[] | boolean = false): string {
+  const isAdmin = Array.isArray(groupsOrAdmin)
+    ? groupsOrAdmin.includes("admin")
+    : Boolean(groupsOrAdmin);
   return isAdmin ? "test-admin-session" : "test-user-session";
 }
 

--- a/__tests__/admin-notion-blog-api.test.ts
+++ b/__tests__/admin-notion-blog-api.test.ts
@@ -2,6 +2,64 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { NextRequest } from "next/server";
 import { resetIntegrationCache } from "@/lib/integrations";
 
+vi.mock("@/lib/api-auth", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/api-auth")>();
+  const { NextResponse } = await import("next/server");
+  const adminUser = {
+    sub: "test-admin-sub",
+    email: "admin@cloudless.gr",
+    groups: ["admin"],
+    email_verified: true,
+  };
+  const plainUser = {
+    sub: "test-user-sub",
+    email: "user@cloudless.gr",
+    groups: [] as string[],
+    email_verified: true,
+  };
+
+  function userFromRequest(request: { headers: { get: (k: string) => string | null } }) {
+    const h = request.headers.get("authorization") ?? "";
+    const token = h.startsWith("Bearer ") ? h.slice(7) : "";
+    if (token === "test-admin-session") return adminUser;
+    if (token === "test-user-session") return plainUser;
+    // Allow email-bearing opaque tokens used by user-route tests: "user-session:<email>"
+    if (token.startsWith("user-session:")) {
+      const email = token.slice("user-session:".length) || "user@cloudless.gr";
+      return { ...plainUser, email, sub: `user-${email}` };
+    }
+    if (token.startsWith("admin-session:")) {
+      const email = token.slice("admin-session:".length) || "admin@cloudless.gr";
+      return { ...adminUser, email, sub: `admin-${email}` };
+    }
+    return null;
+  }
+
+  return {
+    ...actual,
+    requireAuth: async (request: Parameters<typeof actual.requireAuth>[0]) => {
+      const user = userFromRequest(request);
+      if (user) return { ok: true as const, user };
+      return actual.requireAuth(request);
+    },
+    requireAdmin: async (request: Parameters<typeof actual.requireAdmin>[0]) => {
+      const user = userFromRequest(request);
+      if (!user) return actual.requireAdmin(request);
+      if (!user.groups.includes("admin")) {
+        return {
+          ok: false as const,
+          response: NextResponse.json({ error: "Admin access required" }, { status: 403 }),
+        };
+      }
+      return { ok: true as const, user };
+    },
+    requireVerifiedAuth: async (request: Parameters<typeof actual.requireVerifiedAuth>[0]) => {
+      const user = userFromRequest(request);
+      if (user) return { ok: true as const, user };
+      return actual.requireVerifiedAuth(request);
+    },
+  };
+});
 // ---------------------------------------------------------------------------
 // Hoist mock variables so vi.mock() factories can reference them safely.
 // ---------------------------------------------------------------------------

--- a/__tests__/admin-notion-docs-api.test.ts
+++ b/__tests__/admin-notion-docs-api.test.ts
@@ -2,6 +2,64 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { NextRequest } from "next/server";
 import { resetIntegrationCache } from "@/lib/integrations";
 
+vi.mock("@/lib/api-auth", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/api-auth")>();
+  const { NextResponse } = await import("next/server");
+  const adminUser = {
+    sub: "test-admin-sub",
+    email: "admin@cloudless.gr",
+    groups: ["admin"],
+    email_verified: true,
+  };
+  const plainUser = {
+    sub: "test-user-sub",
+    email: "user@cloudless.gr",
+    groups: [] as string[],
+    email_verified: true,
+  };
+
+  function userFromRequest(request: { headers: { get: (k: string) => string | null } }) {
+    const h = request.headers.get("authorization") ?? "";
+    const token = h.startsWith("Bearer ") ? h.slice(7) : "";
+    if (token === "test-admin-session") return adminUser;
+    if (token === "test-user-session") return plainUser;
+    // Allow email-bearing opaque tokens used by user-route tests: "user-session:<email>"
+    if (token.startsWith("user-session:")) {
+      const email = token.slice("user-session:".length) || "user@cloudless.gr";
+      return { ...plainUser, email, sub: `user-${email}` };
+    }
+    if (token.startsWith("admin-session:")) {
+      const email = token.slice("admin-session:".length) || "admin@cloudless.gr";
+      return { ...adminUser, email, sub: `admin-${email}` };
+    }
+    return null;
+  }
+
+  return {
+    ...actual,
+    requireAuth: async (request: Parameters<typeof actual.requireAuth>[0]) => {
+      const user = userFromRequest(request);
+      if (user) return { ok: true as const, user };
+      return actual.requireAuth(request);
+    },
+    requireAdmin: async (request: Parameters<typeof actual.requireAdmin>[0]) => {
+      const user = userFromRequest(request);
+      if (!user) return actual.requireAdmin(request);
+      if (!user.groups.includes("admin")) {
+        return {
+          ok: false as const,
+          response: NextResponse.json({ error: "Admin access required" }, { status: 403 }),
+        };
+      }
+      return { ok: true as const, user };
+    },
+    requireVerifiedAuth: async (request: Parameters<typeof actual.requireVerifiedAuth>[0]) => {
+      const user = userFromRequest(request);
+      if (user) return { ok: true as const, user };
+      return actual.requireVerifiedAuth(request);
+    },
+  };
+});
 // ---------------------------------------------------------------------------
 // Hoist mock variables so vi.mock() factories can reference them safely.
 // ---------------------------------------------------------------------------

--- a/__tests__/admin-notion-submissions-api.test.ts
+++ b/__tests__/admin-notion-submissions-api.test.ts
@@ -2,6 +2,64 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { NextRequest } from "next/server";
 import { resetIntegrationCache } from "@/lib/integrations";
 
+vi.mock("@/lib/api-auth", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/api-auth")>();
+  const { NextResponse } = await import("next/server");
+  const adminUser = {
+    sub: "test-admin-sub",
+    email: "admin@cloudless.gr",
+    groups: ["admin"],
+    email_verified: true,
+  };
+  const plainUser = {
+    sub: "test-user-sub",
+    email: "user@cloudless.gr",
+    groups: [] as string[],
+    email_verified: true,
+  };
+
+  function userFromRequest(request: { headers: { get: (k: string) => string | null } }) {
+    const h = request.headers.get("authorization") ?? "";
+    const token = h.startsWith("Bearer ") ? h.slice(7) : "";
+    if (token === "test-admin-session") return adminUser;
+    if (token === "test-user-session") return plainUser;
+    // Allow email-bearing opaque tokens used by user-route tests: "user-session:<email>"
+    if (token.startsWith("user-session:")) {
+      const email = token.slice("user-session:".length) || "user@cloudless.gr";
+      return { ...plainUser, email, sub: `user-${email}` };
+    }
+    if (token.startsWith("admin-session:")) {
+      const email = token.slice("admin-session:".length) || "admin@cloudless.gr";
+      return { ...adminUser, email, sub: `admin-${email}` };
+    }
+    return null;
+  }
+
+  return {
+    ...actual,
+    requireAuth: async (request: Parameters<typeof actual.requireAuth>[0]) => {
+      const user = userFromRequest(request);
+      if (user) return { ok: true as const, user };
+      return actual.requireAuth(request);
+    },
+    requireAdmin: async (request: Parameters<typeof actual.requireAdmin>[0]) => {
+      const user = userFromRequest(request);
+      if (!user) return actual.requireAdmin(request);
+      if (!user.groups.includes("admin")) {
+        return {
+          ok: false as const,
+          response: NextResponse.json({ error: "Admin access required" }, { status: 403 }),
+        };
+      }
+      return { ok: true as const, user };
+    },
+    requireVerifiedAuth: async (request: Parameters<typeof actual.requireVerifiedAuth>[0]) => {
+      const user = userFromRequest(request);
+      if (user) return { ok: true as const, user };
+      return actual.requireVerifiedAuth(request);
+    },
+  };
+});
 const { listSubmissionsMock, updateSubmissionStatusMock } = vi.hoisted(() => ({
   listSubmissionsMock: vi.fn(),
   updateSubmissionStatusMock: vi.fn(),

--- a/__tests__/admin-notion-tasks-api.test.ts
+++ b/__tests__/admin-notion-tasks-api.test.ts
@@ -2,6 +2,64 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { NextRequest } from "next/server";
 import { resetIntegrationCache } from "@/lib/integrations";
 
+vi.mock("@/lib/api-auth", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/api-auth")>();
+  const { NextResponse } = await import("next/server");
+  const adminUser = {
+    sub: "test-admin-sub",
+    email: "admin@cloudless.gr",
+    groups: ["admin"],
+    email_verified: true,
+  };
+  const plainUser = {
+    sub: "test-user-sub",
+    email: "user@cloudless.gr",
+    groups: [] as string[],
+    email_verified: true,
+  };
+
+  function userFromRequest(request: { headers: { get: (k: string) => string | null } }) {
+    const h = request.headers.get("authorization") ?? "";
+    const token = h.startsWith("Bearer ") ? h.slice(7) : "";
+    if (token === "test-admin-session") return adminUser;
+    if (token === "test-user-session") return plainUser;
+    // Allow email-bearing opaque tokens used by user-route tests: "user-session:<email>"
+    if (token.startsWith("user-session:")) {
+      const email = token.slice("user-session:".length) || "user@cloudless.gr";
+      return { ...plainUser, email, sub: `user-${email}` };
+    }
+    if (token.startsWith("admin-session:")) {
+      const email = token.slice("admin-session:".length) || "admin@cloudless.gr";
+      return { ...adminUser, email, sub: `admin-${email}` };
+    }
+    return null;
+  }
+
+  return {
+    ...actual,
+    requireAuth: async (request: Parameters<typeof actual.requireAuth>[0]) => {
+      const user = userFromRequest(request);
+      if (user) return { ok: true as const, user };
+      return actual.requireAuth(request);
+    },
+    requireAdmin: async (request: Parameters<typeof actual.requireAdmin>[0]) => {
+      const user = userFromRequest(request);
+      if (!user) return actual.requireAdmin(request);
+      if (!user.groups.includes("admin")) {
+        return {
+          ok: false as const,
+          response: NextResponse.json({ error: "Admin access required" }, { status: 403 }),
+        };
+      }
+      return { ok: true as const, user };
+    },
+    requireVerifiedAuth: async (request: Parameters<typeof actual.requireVerifiedAuth>[0]) => {
+      const user = userFromRequest(request);
+      if (user) return { ok: true as const, user };
+      return actual.requireVerifiedAuth(request);
+    },
+  };
+});
 const { listTasksMock, createTaskMock, updateTaskStatusMock, getTaskSummaryMock } = vi.hoisted(
   () => ({
     listTasksMock: vi.fn(),

--- a/__tests__/admin-subscriptions-api.test.ts
+++ b/__tests__/admin-subscriptions-api.test.ts
@@ -1,5 +1,64 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { NextRequest } from "next/server";
+
+vi.mock("@/lib/api-auth", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/api-auth")>();
+  const { NextResponse } = await import("next/server");
+  const adminUser = {
+    sub: "test-admin-sub",
+    email: "admin@cloudless.gr",
+    groups: ["admin"],
+    email_verified: true,
+  };
+  const plainUser = {
+    sub: "test-user-sub",
+    email: "user@cloudless.gr",
+    groups: [] as string[],
+    email_verified: true,
+  };
+
+  function userFromRequest(request: { headers: { get: (k: string) => string | null } }) {
+    const h = request.headers.get("authorization") ?? "";
+    const token = h.startsWith("Bearer ") ? h.slice(7) : "";
+    if (token === "test-admin-session") return adminUser;
+    if (token === "test-user-session") return plainUser;
+    // Allow email-bearing opaque tokens used by user-route tests: "user-session:<email>"
+    if (token.startsWith("user-session:")) {
+      const email = token.slice("user-session:".length) || "user@cloudless.gr";
+      return { ...plainUser, email, sub: `user-${email}` };
+    }
+    if (token.startsWith("admin-session:")) {
+      const email = token.slice("admin-session:".length) || "admin@cloudless.gr";
+      return { ...adminUser, email, sub: `admin-${email}` };
+    }
+    return null;
+  }
+
+  return {
+    ...actual,
+    requireAuth: async (request: Parameters<typeof actual.requireAuth>[0]) => {
+      const user = userFromRequest(request);
+      if (user) return { ok: true as const, user };
+      return actual.requireAuth(request);
+    },
+    requireAdmin: async (request: Parameters<typeof actual.requireAdmin>[0]) => {
+      const user = userFromRequest(request);
+      if (!user) return actual.requireAdmin(request);
+      if (!user.groups.includes("admin")) {
+        return {
+          ok: false as const,
+          response: NextResponse.json({ error: "Admin access required" }, { status: 403 }),
+        };
+      }
+      return { ok: true as const, user };
+    },
+    requireVerifiedAuth: async (request: Parameters<typeof actual.requireVerifiedAuth>[0]) => {
+      const user = userFromRequest(request);
+      if (user) return { ok: true as const, user };
+      return actual.requireVerifiedAuth(request);
+    },
+  };
+});
 const SUBSCRIPTIONS_URL = "http://localhost/api/admin/subscriptions";
 const TEST_SUB_ID = "sub_test1abc123";
 

--- a/__tests__/admin-unified-analytics-api.test.ts
+++ b/__tests__/admin-unified-analytics-api.test.ts
@@ -1,5 +1,64 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { NextRequest } from "next/server";
+
+vi.mock("@/lib/api-auth", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/api-auth")>();
+  const { NextResponse } = await import("next/server");
+  const adminUser = {
+    sub: "test-admin-sub",
+    email: "admin@cloudless.gr",
+    groups: ["admin"],
+    email_verified: true,
+  };
+  const plainUser = {
+    sub: "test-user-sub",
+    email: "user@cloudless.gr",
+    groups: [] as string[],
+    email_verified: true,
+  };
+
+  function userFromRequest(request: { headers: { get: (k: string) => string | null } }) {
+    const h = request.headers.get("authorization") ?? "";
+    const token = h.startsWith("Bearer ") ? h.slice(7) : "";
+    if (token === "test-admin-session") return adminUser;
+    if (token === "test-user-session") return plainUser;
+    // Allow email-bearing opaque tokens used by user-route tests: "user-session:<email>"
+    if (token.startsWith("user-session:")) {
+      const email = token.slice("user-session:".length) || "user@cloudless.gr";
+      return { ...plainUser, email, sub: `user-${email}` };
+    }
+    if (token.startsWith("admin-session:")) {
+      const email = token.slice("admin-session:".length) || "admin@cloudless.gr";
+      return { ...adminUser, email, sub: `admin-${email}` };
+    }
+    return null;
+  }
+
+  return {
+    ...actual,
+    requireAuth: async (request: Parameters<typeof actual.requireAuth>[0]) => {
+      const user = userFromRequest(request);
+      if (user) return { ok: true as const, user };
+      return actual.requireAuth(request);
+    },
+    requireAdmin: async (request: Parameters<typeof actual.requireAdmin>[0]) => {
+      const user = userFromRequest(request);
+      if (!user) return actual.requireAdmin(request);
+      if (!user.groups.includes("admin")) {
+        return {
+          ok: false as const,
+          response: NextResponse.json({ error: "Admin access required" }, { status: 403 }),
+        };
+      }
+      return { ok: true as const, user };
+    },
+    requireVerifiedAuth: async (request: Parameters<typeof actual.requireVerifiedAuth>[0]) => {
+      const user = userFromRequest(request);
+      if (user) return { ok: true as const, user };
+      return actual.requireVerifiedAuth(request);
+    },
+  };
+});
 const ANALYTICS_URL = "http://localhost/api/admin/analytics/unified";
 const ALG_RS256 = "RS256";
 const ENC_BASE64URL = "base64url";

--- a/__tests__/admin-users-orders-ops-api.test.ts
+++ b/__tests__/admin-users-orders-ops-api.test.ts
@@ -1,6 +1,64 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { NextRequest } from "next/server";
 
+vi.mock("@/lib/api-auth", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/api-auth")>();
+  const { NextResponse } = await import("next/server");
+  const adminUser = {
+    sub: "test-admin-sub",
+    email: "admin@cloudless.gr",
+    groups: ["admin"],
+    email_verified: true,
+  };
+  const plainUser = {
+    sub: "test-user-sub",
+    email: "user@cloudless.gr",
+    groups: [] as string[],
+    email_verified: true,
+  };
+
+  function userFromRequest(request: { headers: { get: (k: string) => string | null } }) {
+    const h = request.headers.get("authorization") ?? "";
+    const token = h.startsWith("Bearer ") ? h.slice(7) : "";
+    if (token === "test-admin-session") return adminUser;
+    if (token === "test-user-session") return plainUser;
+    // Allow email-bearing opaque tokens used by user-route tests: "user-session:<email>"
+    if (token.startsWith("user-session:")) {
+      const email = token.slice("user-session:".length) || "user@cloudless.gr";
+      return { ...plainUser, email, sub: `user-${email}` };
+    }
+    if (token.startsWith("admin-session:")) {
+      const email = token.slice("admin-session:".length) || "admin@cloudless.gr";
+      return { ...adminUser, email, sub: `admin-${email}` };
+    }
+    return null;
+  }
+
+  return {
+    ...actual,
+    requireAuth: async (request: Parameters<typeof actual.requireAuth>[0]) => {
+      const user = userFromRequest(request);
+      if (user) return { ok: true as const, user };
+      return actual.requireAuth(request);
+    },
+    requireAdmin: async (request: Parameters<typeof actual.requireAdmin>[0]) => {
+      const user = userFromRequest(request);
+      if (!user) return actual.requireAdmin(request);
+      if (!user.groups.includes("admin")) {
+        return {
+          ok: false as const,
+          response: NextResponse.json({ error: "Admin access required" }, { status: 403 }),
+        };
+      }
+      return { ok: true as const, user };
+    },
+    requireVerifiedAuth: async (request: Parameters<typeof actual.requireVerifiedAuth>[0]) => {
+      const user = userFromRequest(request);
+      if (user) return { ok: true as const, user };
+      return actual.requireVerifiedAuth(request);
+    },
+  };
+});
 // ---------------------------------------------------------------------------
 // Hoist mocks
 // ---------------------------------------------------------------------------

--- a/__tests__/admin-voice-brief-api.test.ts
+++ b/__tests__/admin-voice-brief-api.test.ts
@@ -3,6 +3,64 @@ import { NextRequest } from "next/server";
 import { resetJsonConfigMemory, writeJsonConfig } from "@/lib/app-config-json";
 import { persistVoiceBrief } from "@/lib/voice-brief-store";
 
+vi.mock("@/lib/api-auth", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/api-auth")>();
+  const { NextResponse } = await import("next/server");
+  const adminUser = {
+    sub: "test-admin-sub",
+    email: "admin@cloudless.gr",
+    groups: ["admin"],
+    email_verified: true,
+  };
+  const plainUser = {
+    sub: "test-user-sub",
+    email: "user@cloudless.gr",
+    groups: [] as string[],
+    email_verified: true,
+  };
+
+  function userFromRequest(request: { headers: { get: (k: string) => string | null } }) {
+    const h = request.headers.get("authorization") ?? "";
+    const token = h.startsWith("Bearer ") ? h.slice(7) : "";
+    if (token === "test-admin-session") return adminUser;
+    if (token === "test-user-session") return plainUser;
+    // Allow email-bearing opaque tokens used by user-route tests: "user-session:<email>"
+    if (token.startsWith("user-session:")) {
+      const email = token.slice("user-session:".length) || "user@cloudless.gr";
+      return { ...plainUser, email, sub: `user-${email}` };
+    }
+    if (token.startsWith("admin-session:")) {
+      const email = token.slice("admin-session:".length) || "admin@cloudless.gr";
+      return { ...adminUser, email, sub: `admin-${email}` };
+    }
+    return null;
+  }
+
+  return {
+    ...actual,
+    requireAuth: async (request: Parameters<typeof actual.requireAuth>[0]) => {
+      const user = userFromRequest(request);
+      if (user) return { ok: true as const, user };
+      return actual.requireAuth(request);
+    },
+    requireAdmin: async (request: Parameters<typeof actual.requireAdmin>[0]) => {
+      const user = userFromRequest(request);
+      if (!user) return actual.requireAdmin(request);
+      if (!user.groups.includes("admin")) {
+        return {
+          ok: false as const,
+          response: NextResponse.json({ error: "Admin access required" }, { status: 403 }),
+        };
+      }
+      return { ok: true as const, user };
+    },
+    requireVerifiedAuth: async (request: Parameters<typeof actual.requireVerifiedAuth>[0]) => {
+      const user = userFromRequest(request);
+      if (user) return { ok: true as const, user };
+      return actual.requireVerifiedAuth(request);
+    },
+  };
+});
 const VOICE_BRIEF_URL = "http://localhost/api/admin/voice-brief";
 
 const { mockRunAgent, mockFetch } = vi.hoisted(() => ({

--- a/__tests__/admin-workspaces-api.test.ts
+++ b/__tests__/admin-workspaces-api.test.ts
@@ -4,6 +4,64 @@ import type { Workspace } from "@/app/api/admin/workspaces/route";
 import { resetJsonConfigMemory, writeJsonConfig } from "@/lib/app-config-json";
 import { WORKSPACES_CONFIG_KEY, resetWorkspaceCache } from "@/lib/workspace-server";
 
+vi.mock("@/lib/api-auth", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/api-auth")>();
+  const { NextResponse } = await import("next/server");
+  const adminUser = {
+    sub: "test-admin-sub",
+    email: "admin@cloudless.gr",
+    groups: ["admin"],
+    email_verified: true,
+  };
+  const plainUser = {
+    sub: "test-user-sub",
+    email: "user@cloudless.gr",
+    groups: [] as string[],
+    email_verified: true,
+  };
+
+  function userFromRequest(request: { headers: { get: (k: string) => string | null } }) {
+    const h = request.headers.get("authorization") ?? "";
+    const token = h.startsWith("Bearer ") ? h.slice(7) : "";
+    if (token === "test-admin-session") return adminUser;
+    if (token === "test-user-session") return plainUser;
+    // Allow email-bearing opaque tokens used by user-route tests: "user-session:<email>"
+    if (token.startsWith("user-session:")) {
+      const email = token.slice("user-session:".length) || "user@cloudless.gr";
+      return { ...plainUser, email, sub: `user-${email}` };
+    }
+    if (token.startsWith("admin-session:")) {
+      const email = token.slice("admin-session:".length) || "admin@cloudless.gr";
+      return { ...adminUser, email, sub: `admin-${email}` };
+    }
+    return null;
+  }
+
+  return {
+    ...actual,
+    requireAuth: async (request: Parameters<typeof actual.requireAuth>[0]) => {
+      const user = userFromRequest(request);
+      if (user) return { ok: true as const, user };
+      return actual.requireAuth(request);
+    },
+    requireAdmin: async (request: Parameters<typeof actual.requireAdmin>[0]) => {
+      const user = userFromRequest(request);
+      if (!user) return actual.requireAdmin(request);
+      if (!user.groups.includes("admin")) {
+        return {
+          ok: false as const,
+          response: NextResponse.json({ error: "Admin access required" }, { status: 403 }),
+        };
+      }
+      return { ok: true as const, user };
+    },
+    requireVerifiedAuth: async (request: Parameters<typeof actual.requireVerifiedAuth>[0]) => {
+      const user = userFromRequest(request);
+      if (user) return { ok: true as const, user };
+      return actual.requireVerifiedAuth(request);
+    },
+  };
+});
 const WORKSPACES_URL = "http://localhost/api/admin/workspaces";
 const ACME_WORKSPACE = "Acme Workspace";
 

--- a/__tests__/agent-book-api.test.ts
+++ b/__tests__/agent-book-api.test.ts
@@ -7,6 +7,64 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { NextRequest } from "next/server";
 
+vi.mock("@/lib/api-auth", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/api-auth")>();
+  const { NextResponse } = await import("next/server");
+  const adminUser = {
+    sub: "test-admin-sub",
+    email: "admin@cloudless.gr",
+    groups: ["admin"],
+    email_verified: true,
+  };
+  const plainUser = {
+    sub: "test-user-sub",
+    email: "user@cloudless.gr",
+    groups: [] as string[],
+    email_verified: true,
+  };
+
+  function userFromRequest(request: { headers: { get: (k: string) => string | null } }) {
+    const h = request.headers.get("authorization") ?? "";
+    const token = h.startsWith("Bearer ") ? h.slice(7) : "";
+    if (token === "test-admin-session") return adminUser;
+    if (token === "test-user-session") return plainUser;
+    // Allow email-bearing opaque tokens used by user-route tests: "user-session:<email>"
+    if (token.startsWith("user-session:")) {
+      const email = token.slice("user-session:".length) || "user@cloudless.gr";
+      return { ...plainUser, email, sub: `user-${email}` };
+    }
+    if (token.startsWith("admin-session:")) {
+      const email = token.slice("admin-session:".length) || "admin@cloudless.gr";
+      return { ...adminUser, email, sub: `admin-${email}` };
+    }
+    return null;
+  }
+
+  return {
+    ...actual,
+    requireAuth: async (request: Parameters<typeof actual.requireAuth>[0]) => {
+      const user = userFromRequest(request);
+      if (user) return { ok: true as const, user };
+      return actual.requireAuth(request);
+    },
+    requireAdmin: async (request: Parameters<typeof actual.requireAdmin>[0]) => {
+      const user = userFromRequest(request);
+      if (!user) return actual.requireAdmin(request);
+      if (!user.groups.includes("admin")) {
+        return {
+          ok: false as const,
+          response: NextResponse.json({ error: "Admin access required" }, { status: 403 }),
+        };
+      }
+      return { ok: true as const, user };
+    },
+    requireVerifiedAuth: async (request: Parameters<typeof actual.requireVerifiedAuth>[0]) => {
+      const user = userFromRequest(request);
+      if (user) return { ok: true as const, user };
+      return actual.requireVerifiedAuth(request);
+    },
+  };
+});
 // ---------------------------------------------------------------------------
 // Hoisted mocks
 // ---------------------------------------------------------------------------
@@ -71,15 +129,7 @@ const BOOK_ROUTE = "@/app/api/agent/book/route";
 // ---------------------------------------------------------------------------
 
 function makeUserToken(email = "user@example.com"): string {
-  const payload = {
-    sub: "test-user",
-    email,
-    preferred_username: email.split("@")[0],
-    exp: Math.floor(Date.now() / 1000) + 3600,
-  };
-  const header = Buffer.from(JSON.stringify({ alg: "RS256" })).toString("base64url");
-  const body = Buffer.from(JSON.stringify(payload)).toString("base64url");
-  return `${header}.${body}.fake-sig`;
+  return `user-session:${email}`;
 }
 
 function authPost(body?: unknown, email?: string): NextRequest {

--- a/__tests__/portal-pending-flow.test.ts
+++ b/__tests__/portal-pending-flow.test.ts
@@ -1,6 +1,65 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { NextRequest } from "next/server";
 import { resetJsonConfigMemory, writeJsonConfig } from "@/lib/app-config-json";
+
+vi.mock("@/lib/api-auth", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/api-auth")>();
+  const { NextResponse } = await import("next/server");
+  const adminUser = {
+    sub: "test-admin-sub",
+    email: "admin@cloudless.gr",
+    groups: ["admin"],
+    email_verified: true,
+  };
+  const plainUser = {
+    sub: "test-user-sub",
+    email: "user@cloudless.gr",
+    groups: [] as string[],
+    email_verified: true,
+  };
+
+  function userFromRequest(request: { headers: { get: (k: string) => string | null } }) {
+    const h = request.headers.get("authorization") ?? "";
+    const token = h.startsWith("Bearer ") ? h.slice(7) : "";
+    if (token === "test-admin-session") return adminUser;
+    if (token === "test-user-session") return plainUser;
+    // Allow email-bearing opaque tokens used by user-route tests: "user-session:<email>"
+    if (token.startsWith("user-session:")) {
+      const email = token.slice("user-session:".length) || "user@cloudless.gr";
+      return { ...plainUser, email, sub: `user-${email}` };
+    }
+    if (token.startsWith("admin-session:")) {
+      const email = token.slice("admin-session:".length) || "admin@cloudless.gr";
+      return { ...adminUser, email, sub: `admin-${email}` };
+    }
+    return null;
+  }
+
+  return {
+    ...actual,
+    requireAuth: async (request: Parameters<typeof actual.requireAuth>[0]) => {
+      const user = userFromRequest(request);
+      if (user) return { ok: true as const, user };
+      return actual.requireAuth(request);
+    },
+    requireAdmin: async (request: Parameters<typeof actual.requireAdmin>[0]) => {
+      const user = userFromRequest(request);
+      if (!user) return actual.requireAdmin(request);
+      if (!user.groups.includes("admin")) {
+        return {
+          ok: false as const,
+          response: NextResponse.json({ error: "Admin access required" }, { status: 403 }),
+        };
+      }
+      return { ok: true as const, user };
+    },
+    requireVerifiedAuth: async (request: Parameters<typeof actual.requireVerifiedAuth>[0]) => {
+      const user = userFromRequest(request);
+      if (user) return { ok: true as const, user };
+      return actual.requireVerifiedAuth(request);
+    },
+  };
+});
 const PENDING_URL = "http://localhost/api/admin/pending-clients";
 const ENROLL_URL = "http://localhost/api/portal/enroll";
 const PORTAL_ME_URL = "http://localhost/api/portal/me";
@@ -45,18 +104,8 @@ vi.mock("@/lib/slack-notify", () => ({
 // JWT helpers
 // ---------------------------------------------------------------------------
 function makeUserToken(opts?: { email?: string; admin?: boolean }): string {
-  const payload = {
-    sub: "user-sub",
-    email: opts?.email ?? "client@example.com",
-    groups: opts?.admin ? ["admin"] : [],
-    aud: "client",
-    iss: "https://auth.cloudless.gr/realms/cloudless",
-    iat: Math.floor(Date.now() / 1000) - 10,
-    exp: Math.floor(Date.now() / 1000) + 3600,
-  };
-  const h = Buffer.from("{}").toString("base64url");
-  const b = Buffer.from(JSON.stringify(payload)).toString("base64url");
-  return `${h}.${b}.sig`;
+  const email = opts?.email ?? "client@example.com";
+  return opts?.admin ? `admin-session:${email}` : `user-session:${email}`;
 }
 
 function authReq(

--- a/__tests__/setup.ts
+++ b/__tests__/setup.ts
@@ -15,31 +15,6 @@ import {
 } from "@/lib/integrations";
 import { resetSsmCache } from "@/lib/ssm-config";
 
-// ── D1 auth for API contract tests (opaque session ids) ───────────────────────
-vi.mock("@/lib/auth-d1", () => {
-  const stmt = {
-    bind: vi.fn().mockReturnThis(),
-    run: vi.fn().mockResolvedValue({ success: true }),
-    first: vi.fn().mockResolvedValue(null),
-    all: vi.fn().mockResolvedValue({ results: [] }),
-  };
-  return {
-    getAuthDbFromEnv: vi.fn(() => ({
-      prepare: vi.fn(() => stmt),
-    })),
-    getUserBySession: vi.fn(async (_db: unknown, sessionId: string) => {
-      if (sessionId === "test-admin-session") {
-        return { id: "test-admin-sub", email: "admin@cloudless.gr", name: "Admin" };
-      }
-      if (sessionId === "test-user-session") {
-        return { id: "test-user-sub", email: "user@cloudless.gr", name: "User" };
-      }
-      return null;
-    }),
-    isAdmin: vi.fn(async (_db: unknown, userId: string) => userId === "test-admin-sub"),
-  };
-});
-
 // ── Notion ────────────────────────────────────────────────────────────────────
 process.env.NOTION_API_KEY = "secret_test_key_12345";
 process.env.NOTION_BLOG_DB_ID = "blog-db-123";

--- a/__tests__/user-consultations-api.test.ts
+++ b/__tests__/user-consultations-api.test.ts
@@ -2,6 +2,64 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { NextRequest } from "next/server";
 import { resetIntegrationCache } from "@/lib/integrations";
 
+vi.mock("@/lib/api-auth", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/api-auth")>();
+  const { NextResponse } = await import("next/server");
+  const adminUser = {
+    sub: "test-admin-sub",
+    email: "admin@cloudless.gr",
+    groups: ["admin"],
+    email_verified: true,
+  };
+  const plainUser = {
+    sub: "test-user-sub",
+    email: "user@cloudless.gr",
+    groups: [] as string[],
+    email_verified: true,
+  };
+
+  function userFromRequest(request: { headers: { get: (k: string) => string | null } }) {
+    const h = request.headers.get("authorization") ?? "";
+    const token = h.startsWith("Bearer ") ? h.slice(7) : "";
+    if (token === "test-admin-session") return adminUser;
+    if (token === "test-user-session") return plainUser;
+    // Allow email-bearing opaque tokens used by user-route tests: "user-session:<email>"
+    if (token.startsWith("user-session:")) {
+      const email = token.slice("user-session:".length) || "user@cloudless.gr";
+      return { ...plainUser, email, sub: `user-${email}` };
+    }
+    if (token.startsWith("admin-session:")) {
+      const email = token.slice("admin-session:".length) || "admin@cloudless.gr";
+      return { ...adminUser, email, sub: `admin-${email}` };
+    }
+    return null;
+  }
+
+  return {
+    ...actual,
+    requireAuth: async (request: Parameters<typeof actual.requireAuth>[0]) => {
+      const user = userFromRequest(request);
+      if (user) return { ok: true as const, user };
+      return actual.requireAuth(request);
+    },
+    requireAdmin: async (request: Parameters<typeof actual.requireAdmin>[0]) => {
+      const user = userFromRequest(request);
+      if (!user) return actual.requireAdmin(request);
+      if (!user.groups.includes("admin")) {
+        return {
+          ok: false as const,
+          response: NextResponse.json({ error: "Admin access required" }, { status: 403 }),
+        };
+      }
+      return { ok: true as const, user };
+    },
+    requireVerifiedAuth: async (request: Parameters<typeof actual.requireVerifiedAuth>[0]) => {
+      const user = userFromRequest(request);
+      if (user) return { ok: true as const, user };
+      return actual.requireVerifiedAuth(request);
+    },
+  };
+});
 const { getConsultationsByEmailMock } = vi.hoisted(() => ({
   getConsultationsByEmailMock: vi.fn(),
 }));
@@ -25,17 +83,7 @@ vi.mock("@/lib/google-calendar", () => ({
 }));
 
 function makeUserToken(email = "user@example.com"): string {
-  const payload = {
-    sub: "user-sub",
-    email,
-    aud: "test-client-id",
-    iss: "https://auth.cloudless.gr/realms/cloudless",
-    iat: Math.floor(Date.now() / 1000) - 60,
-    exp: Math.floor(Date.now() / 1000) + 3600,
-  };
-  const header = Buffer.from(JSON.stringify({ alg: "RS256", typ: "JWT" })).toString("base64url");
-  const body = Buffer.from(JSON.stringify(payload)).toString("base64url");
-  return `${header}.${body}.fake-sig`;
+  return `user-session:${email}`;
 }
 
 function authReq(email?: string): NextRequest {


### PR DESCRIPTION
## Summary
- Remove the global `@/lib/auth-d1` mock from `__tests__/setup.ts` that broke Dynamo/`AUTH_DB` unbound paths and `app-config-json` memory fallback (~117 unit failures after #1454).
- Scope opaque D1 session tokens (`test-admin-session`, `test-user-session`, `user-session:` / `admin-session:`) via per-file `vi.mock("@/lib/api-auth")` on admin/API contract specs.
- Convert remaining JWT helpers in agent-book, user-consultations, and portal-pending; fix accidental `\n` insert artifacts.

## Test plan
- [x] `pnpm exec vitest run` — 2753 passed, 19 skipped
- [ ] CI Unit Tests + API Contract green on this PR

Made with [Cursor](https://cursor.com)