### PR TITLE
fix(ops): coalesce Kuma DNS-flap Slack alerts

### DIFF
--- a/__tests__/kuma-dns-coalesce.test.ts
+++ b/__tests__/kuma-dns-coalesce.test.ts
@@ -1,0 +1,102 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  DNS_FAILURE_RE,
+  formatDnsFlapSlack,
+  KumaDnsCoalescer,
+} from "@/lib/kuma-dns-coalesce";
+
+describe("KumaDnsCoalescer", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("detects EAI_AGAIN messages", () => {
+    expect(DNS_FAILURE_RE.test("getaddrinfo EAI_AGAIN espocrm.cloudless.gr")).toBe(true);
+    expect(DNS_FAILURE_RE.test("timeout")).toBe(false);
+    expect(DNS_FAILURE_RE.test("200 - OK")).toBe(false);
+  });
+
+  it("passes non-DNS alerts through", () => {
+    const flushes: unknown[] = [];
+    const c = new KumaDnsCoalescer(90_000, undefined, (f) => flushes.push(f));
+    expect(c.ingest({ name: "n8n", status: "DOWN", msg: "timeout" }).action).toBe(
+      "passthrough"
+    );
+    expect(flushes).toHaveLength(0);
+  });
+
+  it("coalesces multiple DNS DOWNs into one flush", () => {
+    const flushes: { names: string[]; status: string }[] = [];
+    const c = new KumaDnsCoalescer(90_000, undefined, (f) => flushes.push(f));
+
+    expect(
+      c.ingest({
+        name: "EspoCRM",
+        status: "DOWN",
+        msg: "getaddrinfo EAI_AGAIN espocrm.cloudless.gr",
+      }).action
+    ).toBe("buffered");
+    expect(
+      c.ingest({
+        name: "AppFlowy",
+        status: "DOWN",
+        msg: "getaddrinfo EAI_AGAIN appflowy.cloudless.gr",
+      }).action
+    ).toBe("buffered");
+    expect(
+      c.ingest({
+        name: "Stripe API surface",
+        status: "DOWN",
+        msg: "getaddrinfo EAI_AGAIN api.stripe.com",
+      }).action
+    ).toBe("buffered");
+
+    expect(flushes).toHaveLength(0);
+    vi.advanceTimersByTime(90_000);
+    expect(flushes).toHaveLength(1);
+    expect(flushes[0].status).toBe("DOWN");
+    expect(flushes[0].names).toEqual(["AppFlowy", "EspoCRM", "Stripe API surface"]);
+  });
+
+  it("coalesces UPs for monitors that recently DNS-downed", () => {
+    const flushes: { names: string[]; status: string }[] = [];
+    const c = new KumaDnsCoalescer(90_000, undefined, (f) => flushes.push(f));
+
+    c.ingest({
+      name: "EspoCRM",
+      status: "DOWN",
+      msg: "getaddrinfo EAI_AGAIN espocrm.cloudless.gr",
+    });
+    c.ingest({
+      name: "n8n",
+      status: "DOWN",
+      msg: "getaddrinfo EAI_AGAIN n8n.cloudless.gr",
+    });
+    vi.advanceTimersByTime(90_000);
+    expect(flushes).toHaveLength(1);
+
+    expect(c.ingest({ name: "EspoCRM", status: "UP", msg: "200 - OK" }).action).toBe(
+      "buffered"
+    );
+    expect(c.ingest({ name: "n8n", status: "UP", msg: "200 - OK" }).action).toBe("buffered");
+    vi.advanceTimersByTime(90_000);
+    expect(flushes).toHaveLength(2);
+    expect(flushes[1].status).toBe("UP");
+    expect(flushes[1].names).toEqual(["EspoCRM", "n8n"]);
+  });
+
+  it("formats a readable Slack summary", () => {
+    const { title, text } = formatDnsFlapSlack({
+      status: "DOWN",
+      names: ["EspoCRM", "n8n"],
+      sampleMsg: "getaddrinfo EAI_AGAIN",
+      urls: [],
+    });
+    expect(title).toContain("DNS flap (2");
+    expect(text).toContain("• EspoCRM");
+    expect(text).toContain("CoreDNS");
+  });
+});

--- a/__tests__/kuma-dns-coalesce.test.ts
+++ b/__tests__/kuma-dns-coalesce.test.ts
@@ -1,9 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import {
-  DNS_FAILURE_RE,
-  formatDnsFlapSlack,
-  KumaDnsCoalescer,
-} from "@/lib/kuma-dns-coalesce";
+import { DNS_FAILURE_RE, formatDnsFlapSlack, KumaDnsCoalescer } from "@/lib/kuma-dns-coalesce";
 
 describe("KumaDnsCoalescer", () => {
   beforeEach(() => {
@@ -22,9 +18,7 @@ describe("KumaDnsCoalescer", () => {
   it("passes non-DNS alerts through", () => {
     const flushes: unknown[] = [];
     const c = new KumaDnsCoalescer(90_000, undefined, (f) => flushes.push(f));
-    expect(c.ingest({ name: "n8n", status: "DOWN", msg: "timeout" }).action).toBe(
-      "passthrough"
-    );
+    expect(c.ingest({ name: "n8n", status: "DOWN", msg: "timeout" }).action).toBe("passthrough");
     expect(flushes).toHaveLength(0);
   });
 
@@ -78,9 +72,7 @@ describe("KumaDnsCoalescer", () => {
     vi.advanceTimersByTime(90_000);
     expect(flushes).toHaveLength(1);
 
-    expect(c.ingest({ name: "EspoCRM", status: "UP", msg: "200 - OK" }).action).toBe(
-      "buffered"
-    );
+    expect(c.ingest({ name: "EspoCRM", status: "UP", msg: "200 - OK" }).action).toBe("buffered");
     expect(c.ingest({ name: "n8n", status: "UP", msg: "200 - OK" }).action).toBe("buffered");
     vi.advanceTimersByTime(90_000);
     expect(flushes).toHaveLength(2);

--- a/__tests__/kuma-webhook.test.ts
+++ b/__tests__/kuma-webhook.test.ts
@@ -15,13 +15,16 @@ vi.mock("@/lib/slack-notify", () => ({
 }));
 
 describe("POST /api/webhooks/kuma", () => {
-  beforeEach(() => {
+  beforeEach(async () => {
     vi.clearAllMocks();
+    vi.useRealTimers();
     mockGetConfig.mockResolvedValue({
       ADMIN_ALERT_SECRET: "test-secret",
       NOTION_WEBHOOK_SECRET: "",
     });
     mockPost.mockResolvedValue(true);
+    const mod = await import("@/app/api/webhooks/kuma/route");
+    mod.__resetKumaDnsCoalescerForTests();
   });
 
   it("returns 401 without token", async () => {
@@ -52,5 +55,34 @@ describe("POST /api/webhooks/kuma", () => {
     expect(mockPost).toHaveBeenCalled();
     const payload = mockPost.mock.calls[0][0];
     expect(payload.text).toContain("DOWN");
+  });
+
+  it("buffers DNS EAI_AGAIN downs instead of posting per monitor", async () => {
+    vi.useFakeTimers();
+    const { POST } = await import("@/app/api/webhooks/kuma/route");
+
+    const mk = (name: string, host: string) =>
+      POST(
+        new NextRequest("http://localhost/api/webhooks/kuma", {
+          method: "POST",
+          headers: { Authorization: "Bearer test-secret", "Content-Type": "application/json" },
+          body: JSON.stringify({
+            msg: `getaddrinfo EAI_AGAIN ${host}`,
+            monitor: { name, url: `https://${host}/` },
+            heartbeat: { status: 0 },
+          }),
+        })
+      );
+
+    const a = await mk("EspoCRM", "espocrm.cloudless.gr");
+    const b = await mk("AppFlowy", "appflowy.cloudless.gr");
+    expect(a.status).toBe(200);
+    expect(b.status).toBe(200);
+    expect(mockPost).not.toHaveBeenCalled();
+
+    await vi.advanceTimersByTimeAsync(90_000);
+    expect(mockPost).toHaveBeenCalledTimes(1);
+    expect(mockPost.mock.calls[0][0].text).toContain("DNS flap");
+    vi.useRealTimers();
   });
 });

--- a/infrastructure/uptime-kuma/k8s/kuma-slack-bridge.js
+++ b/infrastructure/uptime-kuma/k8s/kuma-slack-bridge.js
@@ -8,12 +8,16 @@
  * and scale this Deployment to 0.
  *
  * Env: ADMIN_ALERT_SECRET, SLACK_BOT_TOKEN, SLACK_CHANNEL (default #general)
+ * Optional: DNS_COALESCE_MS (default 90000) — group getaddrinfo EAI_AGAIN bursts.
  */
 const http = require("http");
 
 const SECRET = process.env.ADMIN_ALERT_SECRET || "";
 const BOT = process.env.SLACK_BOT_TOKEN || "";
 const CHANNEL = process.env.SLACK_CHANNEL || "#general";
+const DNS_COALESCE_MS = Number(process.env.DNS_COALESCE_MS || 90000);
+const DNS_FAILURE_RE =
+  /EAI_AGAIN|ENOTFOUND|getaddrinfo|NXDOMAIN|SERVFAIL|name resolution|DNS_PROBE/i;
 
 function statusLabel(raw) {
   if (raw === 0 || raw === "0") return "DOWN";
@@ -30,6 +34,107 @@ function auth(req) {
   }
   const q = new URL(req.url, "http://x").searchParams.get("token");
   return q === SECRET;
+}
+
+async function postSlack(title, text) {
+  const r = await fetch("https://slack.com/api/chat.postMessage", {
+    method: "POST",
+    headers: {
+      Authorization: "Bearer " + BOT,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      channel: CHANNEL,
+      text: title,
+      blocks: [
+        {
+          type: "header",
+          text: { type: "plain_text", text: title.slice(0, 150), emoji: true },
+        },
+        {
+          type: "section",
+          text: { type: "mrkdwn", text: String(text).slice(0, 2000) },
+        },
+      ],
+    }),
+  });
+  return r.json();
+}
+
+/** Simple DNS-flap coalescer (mirrors src/lib/kuma-dns-coalesce.ts). */
+const dnsState = {
+  batch: null,
+  recentDown: new Set(),
+  recentTimer: null,
+};
+
+function flushDnsBatch() {
+  if (!dnsState.batch) return null;
+  const { status, names, sampleMsg, timer } = dnsState.batch;
+  clearTimeout(timer);
+  dnsState.batch = null;
+  const list = [...names].sort();
+  if (status === "DOWN") {
+    for (const n of list) dnsState.recentDown.add(n);
+    if (dnsState.recentTimer) clearTimeout(dnsState.recentTimer);
+    dnsState.recentTimer = setTimeout(() => {
+      dnsState.recentDown.clear();
+      dnsState.recentTimer = null;
+    }, DNS_COALESCE_MS * 4);
+  } else {
+    for (const n of list) dnsState.recentDown.delete(n);
+  }
+  const n = list.length;
+  if (status === "DOWN") {
+    return {
+      title: "Kuma DOWN: DNS flap (" + n + " monitor" + (n === 1 ? "" : "s") + ")",
+      text:
+        "DNS resolution failed across " +
+        n +
+        " probe" +
+        (n === 1 ? "" : "s") +
+        " (likely CoreDNS / node resolver stall, not app outages).\n\n" +
+        list.map((name) => "• " + name).join("\n") +
+        "\n\nSample: " +
+        (sampleMsg || "getaddrinfo EAI_AGAIN"),
+    };
+  }
+  return {
+    title: "Kuma UP: DNS recovered (" + n + " monitor" + (n === 1 ? "" : "s") + ")",
+    text:
+      "DNS resolution recovered for " +
+      n +
+      " probe" +
+      (n === 1 ? "" : "s") +
+      ".\n\n" +
+      list.map((name) => "• " + name).join("\n"),
+  };
+}
+
+function bufferDns(status, name, msg) {
+  if (dnsState.batch && dnsState.batch.status !== status) {
+    const early = flushDnsBatch();
+    if (early) postSlack(early.title, early.text).catch(() => {});
+  }
+  if (!dnsState.batch) {
+    dnsState.batch = {
+      status,
+      names: new Set([name]),
+      sampleMsg: msg,
+      timer: setTimeout(() => {
+        const flushed = flushDnsBatch();
+        if (flushed) postSlack(flushed.title, flushed.text).catch(() => {});
+      }, DNS_COALESCE_MS),
+    };
+    return;
+  }
+  dnsState.batch.names.add(name);
+  if (msg) dnsState.batch.sampleMsg = msg;
+  clearTimeout(dnsState.batch.timer);
+  dnsState.batch.timer = setTimeout(() => {
+    const flushed = flushDnsBatch();
+    if (flushed) postSlack(flushed.title, flushed.text).catch(() => {});
+  }, DNS_COALESCE_MS);
 }
 
 http
@@ -55,30 +160,19 @@ http
     const heartbeat = j.heartbeat || {};
     const name = monitor.name || "monitor";
     const status = statusLabel(heartbeat.status);
-    const title = "Kuma " + status + ": " + name;
     const text = j.msg || name + " is " + status;
-    const r = await fetch("https://slack.com/api/chat.postMessage", {
-      method: "POST",
-      headers: {
-        Authorization: "Bearer " + BOT,
-        "Content-Type": "application/json",
-      },
-      body: JSON.stringify({
-        channel: CHANNEL,
-        text: title,
-        blocks: [
-          {
-            type: "header",
-            text: { type: "plain_text", text: title.slice(0, 150), emoji: true },
-          },
-          {
-            type: "section",
-            text: { type: "mrkdwn", text: String(text).slice(0, 2000) },
-          },
-        ],
-      }),
-    });
-    const out = await r.json();
+
+    const dnsDown = status === "DOWN" && DNS_FAILURE_RE.test(text);
+    const dnsUp =
+      status === "UP" && (DNS_FAILURE_RE.test(text) || dnsState.recentDown.has(name));
+    if (dnsDown || dnsUp) {
+      bufferDns(dnsDown ? "DOWN" : "UP", name, text);
+      res.writeHead(200, { "Content-Type": "application/json" });
+      return res.end(JSON.stringify({ ok: true, coalesced: true }));
+    }
+
+    const title = "Kuma " + status + ": " + name;
+    const out = await postSlack(title, text);
     res.writeHead(out.ok ? 200 : 502, { "Content-Type": "application/json" });
     res.end(JSON.stringify({ ok: !!out.ok, error: out.error || null }));
   })

--- a/scripts/kuma-bootstrap.cjs
+++ b/scripts/kuma-bootstrap.cjs
@@ -60,6 +60,10 @@ function emit(socket, event, ...args) {
 }
 
 function httpMonitor(partial) {
+  // Tuned against omv control-plane DNS flaps (EAI_AGAIN storms):
+  // maxretries=5 @ 60s ≈ 6 min continuous failure before DOWN notify.
+  // resendInterval=30 → remind every 30 min while still down (not every check).
+  // Slack webhook also coalesces DNS bursts (src/lib/kuma-dns-coalesce.ts).
   return {
     type: "http",
     name: partial.name,
@@ -67,8 +71,8 @@ function httpMonitor(partial) {
     method: "GET",
     interval: 60,
     retryInterval: 60,
-    resendInterval: 0,
-    maxretries: 2,
+    resendInterval: 30,
+    maxretries: 5,
     upsideDown: false,
     ignoreTls: false,
     maxredirects: 5,

--- a/skills/uptime-kuma-operator/SKILL.md
+++ b/skills/uptime-kuma-operator/SKILL.md
@@ -12,6 +12,29 @@ doesn't blind us. Slack is loud, Kuma is the deduplicated history + uptime %.
 UI: https://kuma.cloudless.gr (admin = tbaltzakis@cloudless.gr / unified
 self-hosted password, see project memory `project_unified_admin_creds`).
 
+## HTTP probe hardening (DNS flaps)
+
+Control-plane stalls on omv produce mass `getaddrinfo EAI_AGAIN` across every
+HTTP monitor (cluster.local + public hostnames). Mitigations:
+
+| Layer | Setting | Effect |
+|-------|---------|--------|
+| Monitor | `maxretries=5`, `retry_interval=60`, `resend_interval=30` | ~6 min continuous failure before DOWN; remind every 30 min while down |
+| Slack webhook | `src/lib/kuma-dns-coalesce.ts` via `/api/webhooks/kuma` | One Slack message per DNS burst instead of N |
+
+Bootstrap defaults live in `scripts/kuma-bootstrap.cjs` (`httpMonitor`).
+To re-apply on a running instance:
+
+```bash
+sudo KUBECONFIG=/etc/rancher/k3s/k3s.yaml kubectl -n uptime-kuma exec deploy/uptime-kuma -- \
+  sqlite3 /app/data/kuma.db \
+  "UPDATE monitor SET maxretries=5, retry_interval=60, resend_interval=30 WHERE type='http' AND active=1;"
+sudo KUBECONFIG=/etc/rancher/k3s/k3s.yaml kubectl -n uptime-kuma rollout restart deploy/uptime-kuma
+```
+
+Push monitors (backups / watchdogs) are left alone — one missed nightly
+heartbeat is a real alert.
+
 ## Quick health check
 
 ```bash

--- a/src/app/api/webhooks/kuma/route.ts
+++ b/src/app/api/webhooks/kuma/route.ts
@@ -9,11 +9,19 @@
  * or `?token=` query for providers that cannot set headers.
  *
  * Kuma default body: `{ msg, heartbeat, monitor }`.
+ *
+ * DNS flaps (`getaddrinfo EAI_AGAIN`, etc.) that hit many monitors at once
+ * are coalesced into a single Slack message (see kuma-dns-coalesce).
  */
 import { NextRequest, NextResponse } from "next/server";
 import { timingSafeEqual } from "node:crypto";
 import { getConfig } from "@/lib/ssm-config";
 import { SlackClient } from "@/lib/slack-notify";
+import {
+  formatDnsFlapSlack,
+  KumaDnsCoalescer,
+  type CoalesceFlush,
+} from "@/lib/kuma-dns-coalesce";
 
 export const dynamic = "force-dynamic";
 export const runtime = "nodejs";
@@ -33,12 +41,46 @@ function extractToken(request: NextRequest): string {
   return (request.nextUrl.searchParams.get("token") || "").trim();
 }
 
-function statusLabel(raw: unknown): string {
+function statusLabel(raw: unknown): "DOWN" | "UP" | "PENDING" | "MAINTENANCE" | "UNKNOWN" {
   if (raw === 0 || raw === "0") return "DOWN";
   if (raw === 1 || raw === "1") return "UP";
   if (raw === 2 || raw === "2") return "PENDING";
   if (raw === 3 || raw === "3") return "MAINTENANCE";
   return "UNKNOWN";
+}
+
+async function postSlack(title: string, text: string, url?: string): Promise<void> {
+  const slack = new SlackClient({ channel: "#general" });
+  await slack.post({
+    text: title,
+    blocks: [
+      { type: "header", text: { type: "plain_text", text: title.slice(0, 150), emoji: true } },
+      { type: "section", text: { type: "mrkdwn", text: text.slice(0, 2000) } },
+      ...(url
+        ? [
+            {
+              type: "context" as const,
+              elements: [{ type: "mrkdwn" as const, text: `<${url}|probe target>` }],
+            },
+          ]
+        : []),
+    ],
+  });
+}
+
+async function flushDnsBatch(flush: CoalesceFlush): Promise<void> {
+  const { title, text } = formatDnsFlapSlack(flush);
+  await postSlack(title, text, flush.urls[0]);
+}
+
+/** Process-local coalescer (Pi deploy is single-replica). */
+const coalescer = new KumaDnsCoalescer(90_000, undefined, (flush) => {
+  flushDnsBatch(flush).catch(() => {});
+});
+
+/** Exposed for unit tests. */
+export function __resetKumaDnsCoalescerForTests(): void {
+  coalescer.reset();
 }
 
 export async function POST(request: NextRequest) {
@@ -73,25 +115,15 @@ export async function POST(request: NextRequest) {
   const name = typeof monitor.name === "string" ? monitor.name : "monitor";
   const url = typeof monitor.url === "string" ? monitor.url : "";
   const status = statusLabel(heartbeat.status);
+
+  const result = coalescer.ingest({ name, status, msg, url: url || undefined });
+  if (result.action === "buffered") {
+    return NextResponse.json({ ok: true, coalesced: true });
+  }
+
   const title = `Kuma ${status}: ${name}`;
   const text = msg || `${name} is ${status}${url ? ` (${url})` : ""}`;
-
-  const slack = new SlackClient({ channel: "#general" });
-  await slack.post({
-    text: title,
-    blocks: [
-      { type: "header", text: { type: "plain_text", text: title.slice(0, 150), emoji: true } },
-      { type: "section", text: { type: "mrkdwn", text: text.slice(0, 2000) } },
-      ...(url
-        ? [
-            {
-              type: "context" as const,
-              elements: [{ type: "mrkdwn" as const, text: `<${url}|probe target>` }],
-            },
-          ]
-        : []),
-    ],
-  });
+  await postSlack(title, text, url || undefined);
 
   return NextResponse.json({ ok: true });
 }

--- a/src/app/api/webhooks/kuma/route.ts
+++ b/src/app/api/webhooks/kuma/route.ts
@@ -17,11 +17,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { timingSafeEqual } from "node:crypto";
 import { getConfig } from "@/lib/ssm-config";
 import { SlackClient } from "@/lib/slack-notify";
-import {
-  formatDnsFlapSlack,
-  KumaDnsCoalescer,
-  type CoalesceFlush,
-} from "@/lib/kuma-dns-coalesce";
+import { formatDnsFlapSlack, KumaDnsCoalescer, type CoalesceFlush } from "@/lib/kuma-dns-coalesce";
 
 export const dynamic = "force-dynamic";
 export const runtime = "nodejs";
@@ -122,7 +118,8 @@ export async function POST(request: NextRequest) {
   }
 
   const title = `Kuma ${status}: ${name}`;
-  const text = msg || `${name} is ${status}${url ? ` (${url})` : ""}`;
+  const urlSuffix = url ? " (" + url + ")" : "";
+  const text = msg || name + " is " + status + urlSuffix;
   await postSlack(title, text, url || undefined);
 
   return NextResponse.json({ ok: true });

--- a/src/lib/kuma-dns-coalesce.ts
+++ b/src/lib/kuma-dns-coalesce.ts
@@ -1,0 +1,168 @@
+/**
+ * Coalesce Kuma webhook bursts that share a DNS-resolution failure.
+ *
+ * A control-plane / resolver flap produces N nearly-simultaneous
+ * `getaddrinfo EAI_AGAIN` DOWNs (and matching UPs on recovery). Without
+ * coalescing, Slack gets one message per monitor.
+ *
+ * Non-DNS failures always pass through immediately.
+ */
+export const DNS_FAILURE_RE =
+  /EAI_AGAIN|ENOTFOUND|getaddrinfo|NXDOMAIN|SERVFAIL|name resolution|DNS_PROBE/i;
+
+const DEFAULT_WINDOW_MS = 90_000;
+
+export type KumaAlertEvent = {
+  name: string;
+  status: "DOWN" | "UP" | "PENDING" | "MAINTENANCE" | "UNKNOWN";
+  msg: string;
+  url?: string;
+};
+
+export type CoalesceFlush = {
+  status: "DOWN" | "UP";
+  names: string[];
+  sampleMsg: string;
+  urls: string[];
+};
+
+export type CoalesceResult =
+  | { action: "passthrough" }
+  | { action: "buffered" }
+  | { action: "flush"; flush: CoalesceFlush };
+
+type Batch = {
+  status: "DOWN" | "UP";
+  names: Set<string>;
+  urls: Set<string>;
+  sampleMsg: string;
+  timer: ReturnType<typeof setTimeout>;
+};
+
+export type CoalesceClock = {
+  setTimeout: typeof setTimeout;
+  clearTimeout: typeof clearTimeout;
+};
+
+const DEFAULT_CLOCK: CoalesceClock = {
+  setTimeout: ((...args: Parameters<typeof setTimeout>) =>
+    globalThis.setTimeout(...args)) as typeof setTimeout,
+  clearTimeout: ((...args: Parameters<typeof clearTimeout>) =>
+    globalThis.clearTimeout(...args)) as typeof clearTimeout,
+};
+
+export class KumaDnsCoalescer {
+  private batch: Batch | null = null;
+  private recentDnsDown = new Set<string>();
+  private recentDnsDownTimer: ReturnType<typeof setTimeout> | null = null;
+  private readonly clock: CoalesceClock;
+  private readonly onFlush: (flush: CoalesceFlush) => void;
+
+  constructor(
+    private readonly windowMs: number = DEFAULT_WINDOW_MS,
+    clock: CoalesceClock | undefined = undefined,
+    onFlush: (flush: CoalesceFlush) => void = () => {}
+  ) {
+    this.clock = clock ?? DEFAULT_CLOCK;
+    this.onFlush = onFlush;
+  }
+
+  /** Test / restart helper. */
+  reset(): void {
+    if (this.batch) this.clock.clearTimeout(this.batch.timer);
+    if (this.recentDnsDownTimer) this.clock.clearTimeout(this.recentDnsDownTimer);
+    this.batch = null;
+    this.recentDnsDown.clear();
+    this.recentDnsDownTimer = null;
+  }
+
+  ingest(event: KumaAlertEvent): CoalesceResult {
+    const dnsDown = event.status === "DOWN" && DNS_FAILURE_RE.test(event.msg);
+    const dnsUp =
+      event.status === "UP" &&
+      (DNS_FAILURE_RE.test(event.msg) || this.recentDnsDown.has(event.name));
+
+    if (!dnsDown && !dnsUp) {
+      return { action: "passthrough" };
+    }
+
+    const status: "DOWN" | "UP" = dnsDown ? "DOWN" : "UP";
+    return this.buffer(status, event);
+  }
+
+  private buffer(status: "DOWN" | "UP", event: KumaAlertEvent): CoalesceResult {
+    if (this.batch && this.batch.status !== status) {
+      this.flushNow();
+    }
+
+    if (!this.batch) {
+      this.batch = {
+        status,
+        names: new Set([event.name]),
+        urls: new Set(event.url ? [event.url] : []),
+        sampleMsg: event.msg,
+        timer: this.clock.setTimeout(() => this.flushNow(), this.windowMs),
+      };
+      return { action: "buffered" };
+    }
+
+    this.batch.names.add(event.name);
+    if (event.url) this.batch.urls.add(event.url);
+    if (event.msg) this.batch.sampleMsg = event.msg;
+    this.clock.clearTimeout(this.batch.timer);
+    this.batch.timer = this.clock.setTimeout(() => this.flushNow(), this.windowMs);
+    return { action: "buffered" };
+  }
+
+  private flushNow(): void {
+    if (!this.batch) return;
+    const { status, names, urls, sampleMsg, timer } = this.batch;
+    this.clock.clearTimeout(timer);
+    this.batch = null;
+
+    const flush: CoalesceFlush = {
+      status,
+      names: [...names].sort(),
+      sampleMsg,
+      urls: [...urls],
+    };
+
+    if (status === "DOWN") {
+      for (const n of flush.names) this.recentDnsDown.add(n);
+      if (this.recentDnsDownTimer) this.clock.clearTimeout(this.recentDnsDownTimer);
+      // Remember DNS-down names long enough to coalesce matching UPs.
+      this.recentDnsDownTimer = this.clock.setTimeout(() => {
+        this.recentDnsDown.clear();
+        this.recentDnsDownTimer = null;
+      }, this.windowMs * 4);
+    } else {
+      for (const n of flush.names) this.recentDnsDown.delete(n);
+    }
+
+    this.onFlush(flush);
+  }
+}
+
+export function formatDnsFlapSlack(flush: CoalesceFlush): { title: string; text: string } {
+  const n = flush.names.length;
+  if (flush.status === "DOWN") {
+    return {
+      title: `Kuma DOWN: DNS flap (${n} monitor${n === 1 ? "" : "s"})`,
+      text: [
+        `DNS resolution failed across ${n} probe${n === 1 ? "" : "s"} (likely CoreDNS / node resolver stall, not app outages).`,
+        "",
+        flush.names.map((name) => `• ${name}`).join("\n"),
+        "",
+        `Sample: ${flush.sampleMsg || "getaddrinfo EAI_AGAIN"}`,
+      ].join("\n"),
+    };
+  }
+  return {
+    title: `Kuma UP: DNS recovered (${n} monitor${n === 1 ? "" : "s"})`,
+    text: [
+      `DNS resolution recovered for ${n} probe${n === 1 ? "" : "s"}.`,
+      "",
+      flush.names.map((name) => `• ${name}`).join("\n"),
+    ].join("\n"),
+  };
+}

--- a/src/lib/kuma-dns-coalesce.ts
+++ b/src/lib/kuma-dns-coalesce.ts
@@ -27,9 +27,7 @@ export type CoalesceFlush = {
 };
 
 export type CoalesceResult =
-  | { action: "passthrough" }
-  | { action: "buffered" }
-  | { action: "flush"; flush: CoalesceFlush };
+  { action: "passthrough" } | { action: "buffered" } | { action: "flush"; flush: CoalesceFlush };
 
 type Batch = {
   status: "DOWN" | "UP";
@@ -53,7 +51,7 @@ const DEFAULT_CLOCK: CoalesceClock = {
 
 export class KumaDnsCoalescer {
   private batch: Batch | null = null;
-  private recentDnsDown = new Set<string>();
+  private readonly recentDnsDown = new Set<string>();
   private recentDnsDownTimer: ReturnType<typeof setTimeout> | null = null;
   private readonly clock: CoalesceClock;
   private readonly onFlush: (flush: CoalesceFlush) => void;
@@ -122,7 +120,7 @@ export class KumaDnsCoalescer {
 
     const flush: CoalesceFlush = {
       status,
-      names: [...names].sort(),
+      names: [...names].sort((a, b) => a.localeCompare(b)),
       sampleMsg,
       urls: [...urls],
     };


### PR DESCRIPTION
## Summary
- Coalesce `getaddrinfo EAI_AGAIN` / DNS-resolution Kuma webhook bursts into one Slack message (`src/lib/kuma-dns-coalesce.ts`) so a CoreDNS/node resolver stall does not page N monitors.
- Raise HTTP bootstrap defaults to `maxretries=5`, `resendInterval=30` (already applied live on omv for all 12 HTTP monitors).
- Mirror coalesce logic in the optional in-cluster Slack bridge; document in `uptime-kuma-operator` skill.

## Test plan
- [x] `pnpm exec vitest run __tests__/kuma-dns-coalesce.test.ts __tests__/kuma-webhook.test.ts`
- [ ] After merge + Pi deploy: confirm `/api/webhooks/kuma` is on the new SHA
- [ ] Optional: simulate two DNS-down webhooks within 90s → one Slack “DNS flap” message


Made with [Cursor](https://cursor.com)