### PR TITLE
fix(edge): harden Tunnel 502 flaps (Worker retry + probe)

### DIFF
--- a/.github/workflows/cloudless-https-health-probe.yml
+++ b/.github/workflows/cloudless-https-health-probe.yml
@@ -164,12 +164,25 @@ jobs:
               echo "HEALTH_VIA=public"
             } >> "$GITHUB_ENV"
             echo "need_origin_fallback=false" >> "$GITHUB_OUTPUT"
+            echo "public_path_broken=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
           if [ "${code}" = "403" ] || [ "${challenged}" = "1" ]; then
             echo "::warning::${PROBE_HOST}/api/health returned ${code} from GHA (Cloudflare). Falling back to private Tailscale fabric (NodePort via MagicDNS) — not Funnel."
             echo "need_origin_fallback=true" >> "$GITHUB_OUTPUT"
+            echo "public_path_broken=false" >> "$GITHUB_OUTPUT"
+            echo "HEALTH_ELAPSED=${elapsed}" >> "$GITHUB_ENV"
+            exit 0
+          fi
+
+          # 502/503 from Worker/Tunnel while TLS works = edge hop flap or origin down.
+          # Probe fabric next so the error message distinguishes the two.
+          if [ "${code}" = "502" ] || [ "${code}" = "503" ] || [ "${code}" = "000" ]; then
+            echo "::warning::${PROBE_HOST}/api/health returned ${code} (Tunnel/Worker hop). Checking private fabric to see if origin is up."
+            echo "need_origin_fallback=true" >> "$GITHUB_OUTPUT"
+            echo "public_path_broken=true" >> "$GITHUB_OUTPUT"
+            echo "PUBLIC_CODE=${code}" >> "$GITHUB_ENV"
             echo "HEALTH_ELAPSED=${elapsed}" >> "$GITHUB_ENV"
             exit 0
           fi
@@ -229,6 +242,13 @@ jobs:
             echo "::error::NodePort health JSON status='${status}' (expected 'ok')"
             exit 1
           fi
+
+          # Public path was 502/503 but origin is healthy → Tunnel/Worker flap (not app crash).
+          if [ "${{ steps.health.outputs.public_path_broken }}" = "true" ]; then
+            echo "::error::Public ${PROBE_HOST} returned ${PUBLIC_CODE:-5xx} but origin is healthy via Tailscale NodePort (${IP}). Likely Cloudflare Tunnel / Worker hop flap — check cloudflared + cloudless2."
+            exit 1
+          fi
+
           {
             echo "HEALTH_STATUS=${status}"
             echo "HEALTH_ELAPSED=${elapsed}"
@@ -370,12 +390,23 @@ jobs:
               echo "HEALTH_VIA=public"
             } >> "$GITHUB_ENV"
             echo "need_origin_fallback=false" >> "$GITHUB_OUTPUT"
+            echo "public_path_broken=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
           if [ "${code}" = "403" ] || [ "${challenged}" = "1" ]; then
             echo "::warning::${PROBE_HOST}/api/health returned ${code} from GHA (Cloudflare). Falling back to private Tailscale fabric (NodePort via MagicDNS) — not Funnel."
             echo "need_origin_fallback=true" >> "$GITHUB_OUTPUT"
+            echo "public_path_broken=false" >> "$GITHUB_OUTPUT"
+            echo "HEALTH_ELAPSED=${elapsed}" >> "$GITHUB_ENV"
+            exit 0
+          fi
+
+          if [ "${code}" = "502" ] || [ "${code}" = "503" ] || [ "${code}" = "000" ]; then
+            echo "::warning::${PROBE_HOST}/api/health returned ${code} (Tunnel/Worker hop). Checking private fabric to see if origin is up."
+            echo "need_origin_fallback=true" >> "$GITHUB_OUTPUT"
+            echo "public_path_broken=true" >> "$GITHUB_OUTPUT"
+            echo "PUBLIC_CODE=${code}" >> "$GITHUB_ENV"
             echo "HEALTH_ELAPSED=${elapsed}" >> "$GITHUB_ENV"
             exit 0
           fi
@@ -434,6 +465,12 @@ jobs:
             echo "::error::NodePort health JSON status='${status}' (expected 'ok')"
             exit 1
           fi
+
+          if [ "${{ steps.health.outputs.public_path_broken }}" = "true" ]; then
+            echo "::error::Public ${PROBE_HOST} returned ${PUBLIC_CODE:-5xx} but origin is healthy via Tailscale NodePort (${IP}). Likely Cloudflare Tunnel / Worker hop flap — check cloudflared + cloudless2."
+            exit 1
+          fi
+
           {
             echo "HEALTH_STATUS=${status}"
             echo "HEALTH_VERSION=${version}"

--- a/docs/TAILSCALE-FABRIC.md
+++ b/docs/TAILSCALE-FABRIC.md
@@ -196,7 +196,19 @@ GHA `ubuntu-latest` often gets **HTTP 403** on custom-domain `/api/health`
 (datacenter reputation / Bot Fight) even when TLS succeeds and the site is fine
 from residential IPs. That is a **Cloudflare** problem, not a Tailscale one.
 
-**Correct fallback (fabric L4 — used by `cloudless-https-health-probe.yml`):**
+Intermittent **HTTP 502** on apex / `pi-origin` with `x-served-by: pi-tunnel-proxy`
+means the Worker received a Tunnel 502 (or threw) — origin may still be healthy
+on fabric L4. The HTTPS probe distinguishes:
+
+| Public | Fabric NodePort | Meaning |
+|--------|-----------------|---------|
+| 200 | — | Public path OK |
+| 403 | 200 | Bot Fight; origin OK via fabric |
+| 502/503 | 200 | **Tunnel/Worker flap**; origin OK — check `cloudflared` |
+| 502/503 | fail | Origin / NodePort actually down |
+
+`cloudless2` (`workers/pi-origin-proxy`) retries once on idempotent methods for
+transient upstream 502 / network errors.
 
 ```mermaid
 sequenceDiagram

--- a/workers/pi-origin-proxy/README.md
+++ b/workers/pi-origin-proxy/README.md
@@ -24,3 +24,7 @@ User → Cloudflare → cloudless2 (this Worker, <50 KiB)
   → https://pi-origin.cloudless.gr
     → Tunnel → omv:30300 → cloudless-app
 ```
+
+Idempotent methods (`GET`/`HEAD`/`OPTIONS`) retry once on network failure or
+upstream `502` (Tunnel flaps). Failures still return `502` with
+`x-served-by: pi-tunnel-proxy` or `pi-tunnel-proxy-error`.

--- a/workers/pi-origin-proxy/src/index.ts
+++ b/workers/pi-origin-proxy/src/index.ts
@@ -4,6 +4,9 @@
  * Full OpenNext Next.js 16 bundles ~5.5 MiB gzip and cannot deploy on Free.
  * This Worker stays tiny and forwards all methods to the Pi via Tunnel
  * (pi-origin.cloudless.gr → k3s NodePort). App updates ship via deploy-pi.yml.
+ *
+ * Transient Tunnel / edge 502s are common on the Worker→Tunnel hop; idempotent
+ * methods get one retry after a short delay before we surface 502 to clients.
  */
 interface Env {
   PI_ORIGIN_HOST: string;
@@ -25,6 +28,27 @@ const HOP_BY_HOP = new Set([
   "cf-visitor",
 ]);
 
+const IDEMPOTENT = new Set(["GET", "HEAD", "OPTIONS"]);
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function fetchUpstream(
+  target: string,
+  request: Request,
+  headers: Headers,
+  signal: AbortSignal,
+): Promise<Response> {
+  return fetch(target, {
+    method: request.method,
+    headers,
+    body: request.method === "GET" || request.method === "HEAD" ? undefined : request.body,
+    redirect: "manual",
+    signal,
+  });
+}
+
 export default {
   async fetch(request: Request, env: Env): Promise<Response> {
     const url = new URL(request.url);
@@ -42,26 +66,47 @@ export default {
     const timeoutMs = Number.parseInt(env.PI_TIMEOUT_MS || "30000", 10);
     const controller = new AbortController();
     const timer = setTimeout(() => controller.abort(), timeoutMs);
+    const idempotent = IDEMPOTENT.has(request.method.toUpperCase());
 
     try {
-      const upstream = await fetch(target.toString(), {
-        method: request.method,
-        headers,
-        body: request.method === "GET" || request.method === "HEAD" ? undefined : request.body,
-        redirect: "manual",
-        signal: controller.signal,
-      });
+      let upstream: Response;
+      try {
+        upstream = await fetchUpstream(target.toString(), request, headers, controller.signal);
+      } catch (firstErr) {
+        if (!idempotent || controller.signal.aborted) throw firstErr;
+        await sleep(200);
+        upstream = await fetchUpstream(target.toString(), request, headers, controller.signal);
+      }
+
+      // Tunnel flaps often return 502 HTML from Cloudflare on the pi-origin hop.
+      if (idempotent && upstream.status === 502 && !controller.signal.aborted) {
+        await sleep(200);
+        try {
+          const retry = await fetchUpstream(target.toString(), request, headers, controller.signal);
+          if (retry.status < 500) upstream = retry;
+        } catch {
+          // keep original 502
+        }
+      }
+
       const out = new Response(upstream.body, {
         status: upstream.status,
         statusText: upstream.statusText,
         headers: upstream.headers,
       });
       out.headers.set("x-served-by", "pi-tunnel-proxy");
+      if (upstream.status >= 500) {
+        out.headers.set("x-pi-origin-status", String(upstream.status));
+      }
       return out;
     } catch {
       return new Response("Pi origin unreachable", {
         status: 502,
-        headers: { "x-served-by": "pi-tunnel-proxy-error", "content-type": "text/plain" },
+        headers: {
+          "x-served-by": "pi-tunnel-proxy-error",
+          "content-type": "text/plain",
+          "retry-after": "5",
+        },
       });
     } finally {
       clearTimeout(timer);


### PR DESCRIPTION
## Summary
- Live flap: apex + `pi-origin` returned **502** with `x-served-by: pi-tunnel-proxy` (Tunnel hop), then recovered (10/10 OK).
- `cloudless2` proxy: one retry on idempotent methods for network errors / upstream 502.
- HTTPS probe: on public 502/503, check fabric NodePort and fail with **Tunnel/Worker flap vs origin down** messaging.
- Fabric doc §5.1 updated with the correlation table.

## Test plan
- [ ] `cloudflare-deploy.yml` deploys `workers/pi-origin-proxy` on merge
- [ ] `curl https://cloudless.gr/api/health` → 200, `x-served-by: pi-tunnel-proxy`
- [ ] HTTPS health probe still green (403 → fabric OK path unchanged)


Made with [Cursor](https://cursor.com)