### PR TITLE
fix(auth): Pi AUTH_DB via D1 HTTP (pre–PR-14 gate)

### DIFF
--- a/__tests__/d1-http.test.ts
+++ b/__tests__/d1-http.test.ts
@@ -1,0 +1,85 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { canUseD1Http, getHttpAuthDb, resetHttpAuthDbCache } from "@/lib/d1-http";
+
+describe("d1-http", () => {
+  const originalFetch = globalThis.fetch;
+  const envSnapshot = { ...process.env };
+
+  beforeEach(() => {
+    resetHttpAuthDbCache();
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () =>
+        Response.json({
+          success: true,
+          result: [
+            {
+              results: [{ id: "u1", email: "a@cloudless.gr" }],
+              success: true,
+              meta: { changes: 0 },
+            },
+          ],
+        })
+      )
+    );
+  });
+
+  afterEach(() => {
+    resetHttpAuthDbCache();
+    globalThis.fetch = originalFetch;
+    for (const key of Object.keys(process.env)) {
+      if (!(key in envSnapshot)) delete process.env[key];
+    }
+    Object.assign(process.env, envSnapshot);
+    vi.unstubAllGlobals();
+  });
+
+  it("canUseD1Http requires account + token", () => {
+    delete process.env.CLOUDFLARE_ACCOUNT_ID;
+    delete process.env.CF_ACCOUNT_ID;
+    delete process.env.CLOUDFLARE_API_TOKEN;
+    resetHttpAuthDbCache();
+    expect(canUseD1Http()).toBe(false);
+    expect(getHttpAuthDb()).toBeNull();
+  });
+
+  it("prepare/bind/first round-trips via Cloudflare D1 REST", async () => {
+    process.env.CLOUDFLARE_ACCOUNT_ID = "acct";
+    process.env.CLOUDFLARE_API_TOKEN = "tok";
+    process.env.CLOUDFLARE_D1_DATABASE_ID = "db-id";
+    resetHttpAuthDbCache();
+    const db = getHttpAuthDb();
+    expect(db).not.toBeNull();
+    const row = await db!
+      .prepare("SELECT id, email FROM user WHERE email = ?")
+      .bind("a@cloudless.gr")
+      .first<{ id: string; email: string }>();
+    expect(row).toEqual({ id: "u1", email: "a@cloudless.gr" });
+    expect(globalThis.fetch).toHaveBeenCalledWith(
+      "https://api.cloudflare.com/client/v4/accounts/acct/d1/database/db-id/query",
+      expect.objectContaining({
+        method: "POST",
+        headers: expect.objectContaining({ Authorization: "Bearer tok" }),
+      })
+    );
+  });
+
+  it("run returns meta.changes", async () => {
+    process.env.CLOUDFLARE_ACCOUNT_ID = "acct";
+    process.env.CLOUDFLARE_API_TOKEN = "tok";
+    resetHttpAuthDbCache();
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () =>
+        Response.json({
+          success: true,
+          result: [{ results: [], success: true, meta: { changes: 2 } }],
+        })
+      )
+    );
+    const db = getHttpAuthDb()!;
+    const res = await db.prepare("DELETE FROM session WHERE id = ?").bind("s1").run();
+    expect(res.success).toBe(true);
+    expect(res.meta?.changes).toBe(2);
+  });
+});

--- a/docs/cloudflare/aws-to-cloudflare-migration.md
+++ b/docs/cloudflare/aws-to-cloudflare-migration.md
@@ -22,9 +22,11 @@
 1. Email (Node/Pi) — **Cloudflare Email Sending LIVE** from the app pod (`CLOUDFLARE_EMAIL_API_TOKEN` + `CLOUDFLARE_API_TOKEN` in `cloudless-secrets`). `RESEND_API_KEY` still optional and **not set**.
 2. `CLOUDFLARE_ACCOUNT_ID` + `CLOUDFLARE_API_TOKEN` — **SET**; Workers AI embed smoke (`bge-small` → **384**) OK from app pod.
 3. Meili reindex — **done** (4 docs / 4 embeddings; `workers-ai-bge-small` @ 384; in-cluster `MEILI_HOST`). `CRON_SECRET` rotated after earlier job-log leak.
-4. **Next:** apply D1 migration `0014-ad-analytics-bookmarks.sql` on remote `user-auth-db`; confirm Pi `AUTH_DB` bound; then PR-14 (`pnpm remove` remaining `@aws-sdk/*`).
-5. Cognito is retired; tear down the User Pool in AWS when ready (PR-16).
-6. **Out of band:** Tailscale Operator deploy fails with `namespaces "tailscale-operator" not found` — fabric/docs issue, not cutover-blocking.
+4. **D1 migration 0014:** applied on remote `user-auth-db` (`d1_migrations` id=14 @ 2026-07-30 15:00:53).
+5. **AUTH_DB on Pi:** Workers binding is edge-only. Pi Node uses `src/lib/d1-http.ts` (D1 REST) when `CLOUDFLARE_ACCOUNT_ID` + `CLOUDFLARE_API_TOKEN` are in `cloudless-secrets`. Verify: `GET /api/health` → `dbConnected: true`; `POST /api/auth/login` must not return `503 Auth not configured`.
+6. **Next after AUTH_DB verified:** PR-14 (`pnpm remove` remaining `@aws-sdk/*`).
+7. Cognito is retired; tear down the User Pool in AWS when ready (PR-16).
+8. **Out of band:** Tailscale Operator deploy fails with `namespaces "tailscale-operator" not found` — fabric/docs issue, not cutover-blocking.
 
 ---
 

--- a/src/app/api/health/route.ts
+++ b/src/app/api/health/route.ts
@@ -5,8 +5,27 @@ export async function GET() {
   const env = globalThis.process?.env;
   const version =
     env?.["APP_VERSION"]?.trim() || env?.["NEXT_PUBLIC_APP_VERSION"]?.trim() || "0.1.0";
+
+  let dbConnected = false;
+  try {
+    const { getAuthDbFromEnv } = await import("@/lib/auth-d1");
+    const db = getAuthDbFromEnv();
+    if (db) {
+      const row = await db.prepare("SELECT 1 as ok").first<{ ok: number }>();
+      dbConnected = row?.ok === 1;
+    }
+  } catch {
+    dbConnected = false;
+  }
+
   return globalThis.Response.json(
-    { status: "ok", timestamp: new Date().toISOString(), version },
+    {
+      status: dbConnected ? "ok" : "degraded",
+      timestamp: new Date().toISOString(),
+      version,
+      authProvider: "d1",
+      dbConnected,
+    },
     { headers: { "cache-control": "no-store, no-cache, must-revalidate" } }
   );
 }

--- a/src/lib/auth-d1.ts
+++ b/src/lib/auth-d1.ts
@@ -492,7 +492,8 @@ export function validateSessionSecret(): { valid: boolean; error?: string } {
  * 1. process.env.AUTH_DB — Workers/OpenNext polyfill or tests
  * 2. globalThis.__AUTH_DB__ — mirrored binding for Node libs
  * 3. OpenNext Cloudflare context (`initOpenNextCloudflareForDev` / Worker entry)
- * 4. Local wrangler D1 sqlite shim (`auth-db-local`) in development only
+ * 4. D1 HTTP (Pi/Node) via CLOUDFLARE_ACCOUNT_ID + CLOUDFLARE_API_TOKEN
+ * 5. Local wrangler D1 sqlite shim (`auth-db-local`) in development only
  */
 export function getAuthDbFromEnv(): AuthDatabase | null {
   const fromEnv = (process as unknown as { env?: { AUTH_DB?: AuthDatabase } }).env?.AUTH_DB;
@@ -508,6 +509,17 @@ export function getAuthDbFromEnv(): AuthDatabase | null {
   }
   const db = fromEnv ?? fromGlobal ?? fromCf;
   if (db && typeof db.prepare === "function") return db;
+
+  // Pi / Node production: native Workers binding is absent — use D1 REST.
+  try {
+    const { getHttpAuthDb } =
+      // eslint-disable-next-line @typescript-eslint/no-require-imports -- keep Workers bundle free of Node-only paths
+      require("@/lib/d1-http") as typeof import("@/lib/d1-http");
+    const httpDb = getHttpAuthDb();
+    if (httpDb) return httpDb;
+  } catch {
+    // Module unavailable or misconfigured — fall through.
+  }
 
   if (process.env.NODE_ENV === "development") {
     // Lazy require avoids pulling node:sqlite into Workers/edge bundles.

--- a/src/lib/d1-http.ts
+++ b/src/lib/d1-http.ts
@@ -1,0 +1,144 @@
+/**
+ * D1 HTTP client for Node runtimes (Pi / OpenNext) that lack a Workers AUTH_DB binding.
+ *
+ * Uses the Cloudflare D1 REST API with CLOUDFLARE_ACCOUNT_ID + CLOUDFLARE_API_TOKEN
+ * (already present on the Pi pod for Workers AI / Email Sending). Prefer the native
+ * Workers binding when available — this is the Pi bridge, not a Workers replacement.
+ *
+ * Docs: POST /accounts/{account_id}/d1/database/{database_id}/query
+ */
+
+import type { AuthDatabase } from "@/lib/auth-d1";
+
+/** Production user-auth-db — must match wrangler.jsonc `database_id`. */
+export const DEFAULT_AUTH_D1_DATABASE_ID = "7ca74513-23c3-412a-b9ca-b0c55835973d";
+
+type D1HttpQueryResult = {
+  results?: Record<string, unknown>[];
+  success?: boolean;
+  meta?: { changes?: number; last_row_id?: number };
+};
+
+type D1HttpApiResponse = {
+  success?: boolean;
+  errors?: Array<{ message?: string }>;
+  result?: D1HttpQueryResult[];
+};
+
+interface Stmt {
+  bind: (...args: unknown[]) => Stmt;
+  all: <T = Record<string, unknown>>() => Promise<{ results: T[]; success: boolean }>;
+  run: () => Promise<{ success: boolean; meta?: { changes: number } }>;
+  first: <T = Record<string, unknown>>(col?: string) => Promise<T | null>;
+}
+
+function accountId(): string | undefined {
+  return process.env.CLOUDFLARE_ACCOUNT_ID?.trim() || process.env.CF_ACCOUNT_ID?.trim();
+}
+
+function apiToken(): string | undefined {
+  return process.env.CLOUDFLARE_API_TOKEN?.trim();
+}
+
+function databaseId(): string {
+  return (
+    process.env.CLOUDFLARE_D1_DATABASE_ID?.trim() ||
+    process.env.AUTH_D1_DATABASE_ID?.trim() ||
+    DEFAULT_AUTH_D1_DATABASE_ID
+  );
+}
+
+/** True when Pi/Node can reach remote D1 via the Cloudflare API. */
+export function canUseD1Http(): boolean {
+  return Boolean(accountId() && apiToken());
+}
+
+async function queryRemote(sql: string, params: unknown[]): Promise<D1HttpQueryResult> {
+  const account = accountId();
+  const token = apiToken();
+  if (!account || !token) {
+    throw new Error("D1 HTTP: CLOUDFLARE_ACCOUNT_ID / CLOUDFLARE_API_TOKEN not configured");
+  }
+
+  const url = `https://api.cloudflare.com/client/v4/accounts/${account}/d1/database/${databaseId()}/query`;
+  const res = await globalThis.fetch(url, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${token}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({ sql, params }),
+  });
+
+  const body = (await res.json()) as D1HttpApiResponse;
+  if (!res.ok || body.success === false) {
+    const msg =
+      body.errors
+        ?.map((e) => e.message)
+        .filter(Boolean)
+        .join("; ") || res.statusText;
+    throw new Error(`D1 HTTP query failed (${res.status}): ${msg}`);
+  }
+
+  const first = body.result?.[0];
+  if (!first) {
+    throw new Error("D1 HTTP query returned no result payload");
+  }
+  return first;
+}
+
+function prepareHttp(sql: string): Stmt {
+  let bound: unknown[] = [];
+
+  const stmt: Stmt = {
+    bind(...args: unknown[]) {
+      bound = args;
+      return stmt;
+    },
+    async all<T = Record<string, unknown>>() {
+      const result = await queryRemote(sql, bound);
+      return {
+        results: (result.results ?? []) as T[],
+        success: result.success !== false,
+      };
+    },
+    async run() {
+      const result = await queryRemote(sql, bound);
+      return {
+        success: result.success !== false,
+        meta: { changes: result.meta?.changes ?? 0 },
+      };
+    },
+    async first<T = Record<string, unknown>>(col?: string) {
+      const result = await queryRemote(sql, bound);
+      const row = result.results?.[0];
+      if (!row) return null;
+      if (col) {
+        return (row[col] as T) ?? null;
+      }
+      return row as T;
+    },
+  };
+
+  return stmt;
+}
+
+let cached: AuthDatabase | null | undefined;
+
+/** Cached AUTH_DB-compatible client, or null when credentials are missing. */
+export function getHttpAuthDb(): AuthDatabase | null {
+  if (cached !== undefined) return cached;
+  if (!canUseD1Http()) {
+    cached = null;
+    return null;
+  }
+  cached = {
+    prepare: (query: string) => prepareHttp(query),
+  };
+  return cached;
+}
+
+/** Test hook — drop the cached client so env changes take effect. */
+export function resetHttpAuthDbCache(): void {
+  cached = undefined;
+}


### PR DESCRIPTION
## Summary
- **Gate 1 done:** remote `user-auth-db` already has migration `0014` (`ad_analytics_bookmark`, applied 2026-07-30 15:00:53).
- **Gate 2 blocked:** live `POST /api/auth/login` returned `503 Auth not configured` — Pi has no Workers D1 binding.
- Add `src/lib/d1-http.ts` and wire it into `getAuthDbFromEnv()` when `CLOUDFLARE_ACCOUNT_ID` + `CLOUDFLARE_API_TOKEN` are set (already on the pod for Workers AI / email).
- `/api/health` now reports `dbConnected` / `authProvider`.

## Test plan
- [x] Vitest `__tests__/d1-http.test.ts`
- [ ] After deploy: `curl https://cloudless.gr/api/health` → `dbConnected: true`
- [ ] After deploy: `POST /api/auth/login` is not `503 Auth not configured` (401/400 for bad creds is fine)
- [ ] Only then start PR-14 SDK uninstall

Made with [Cursor](https://cursor.com)