### PR TITLE
fix(docs): repair relative links after topic-folder move

### DIFF
--- a/docs/ANTHROPIC.md
+++ b/docs/ANTHROPIC.md
@@ -1,0 +1,3 @@
+> Moved to [`integrations/ANTHROPIC.md`](integrations/ANTHROPIC.md).
+
+This stub keeps old links working. Prefer the topic path going forward.

--- a/docs/POSTIZ.md
+++ b/docs/POSTIZ.md
@@ -1,0 +1,3 @@
+> Moved to [`integrations/POSTIZ.md`](integrations/POSTIZ.md).
+
+This stub keeps old links working. Prefer the topic path going forward.

--- a/docs/SECURITY_ENHANCEMENTS_ROADMAP.md
+++ b/docs/SECURITY_ENHANCEMENTS_ROADMAP.md
@@ -1,0 +1,3 @@
+> Moved to [`security/SECURITY_ENHANCEMENTS_ROADMAP.md`](security/SECURITY_ENHANCEMENTS_ROADMAP.md).
+
+This stub keeps old links working. Prefer the topic path going forward.

--- a/docs/appflowy-deploy.md
+++ b/docs/appflowy-deploy.md
@@ -1,0 +1,3 @@
+> Moved to [`self-hosted/appflowy-deploy.md`](self-hosted/appflowy-deploy.md).
+
+This stub keeps old links working. Prefer the topic path going forward.

--- a/docs/auth/COGNITO_AUTOMATION_INDEX.md
+++ b/docs/auth/COGNITO_AUTOMATION_INDEX.md
@@ -23,17 +23,17 @@ This is your entry point for the complete Cognito setup automation system.
 
 | File | Purpose | How to Use |
 |------|---------|-----------|
-| [scripts/archive/cognito/cognito-setup.sh](../scripts/archive/cognito/cognito-setup.sh) | Main automation script | `bash scripts/archive/cognito/cognito-setup.sh` |
-| [tools/cognito-setup-mcp/src/index.ts](../tools/cognito-setup-mcp/src/index.ts) | MCP server for programmatic access | `npx tsx tools/cognito-setup-mcp/src/index.ts` |
-| [tools/cognito-setup-mcp/README.md](../tools/cognito-setup-mcp/README.md) | MCP API documentation | Reference when using MCP tools |
-| [.claude/skills/cognito-setup/](../.claude/skills/cognito-setup/) | Claude Code skill | `/cognito-setup` in Claude Code |
+| [scripts/archive/cognito/cognito-setup.sh](../../scripts/archive/cognito/cognito-setup.sh) | Main automation script | `bash scripts/archive/cognito/cognito-setup.sh` |
+| [tools/cognito-setup-mcp/src/index.ts](../../tools/cognito-setup-mcp/src/index.ts) | MCP server for programmatic access | `npx tsx tools/cognito-setup-mcp/src/index.ts` |
+| [tools/cognito-setup-mcp/README.md](../../tools/cognito-setup-mcp/README.md) | MCP API documentation | Reference when using MCP tools |
+| [.claude/skills/cognito-setup/](../../.claude/skills/cognito-setup/) | Claude Code skill | `/cognito-setup` in Claude Code |
 | `cognito-setup.yml` (removed — manage users in Cognito console) | GitHub Actions automation | `# cognito-setup.yml removed — use Cognito console / AWS CLI` |
 
 ### ⚙️ Configuration
 
 | File | Purpose | Modified |
 |------|---------|----------|
-| [package.json](../package.json) | pnpm script aliases | ✅ Added 3 commands |
+| [package.json](../../package.json) | pnpm script aliases | ✅ Added 3 commands |
 
 ## 🚀 Quick Commands
 

--- a/docs/aws/aws-cost-reduction.md
+++ b/docs/aws/aws-cost-reduction.md
@@ -164,7 +164,7 @@ trimmed, none comes from app runtime or the mailbox.)
 ## How to execute
 
 A ready-to-run, audit-first script implements every item:
-**[`scripts/aws-cost-reduction.sh`](../scripts/aws-cost-reduction.sh)**.
+**[`scripts/aws-cost-reduction.sh`](../../scripts/aws-cost-reduction.sh)**.
 
 - Run with **no flags** → audits only (prints current state + estimated savings,
   changes nothing).

--- a/docs/aws/iam.md
+++ b/docs/aws/iam.md
@@ -9,7 +9,7 @@ Account: `278585680617` · Region: `us-east-1`
 
 | Principal | Type | Used by | Trust / auth |
 |---|---|---|---|
-| `GitHubActionsOIDC` | Role | Deploy workflow ([deploy.yml](../.github/workflows/deploy.yml)) | OIDC, trust restricted to `Themis128/cloudless.gr` |
+| `GitHubActionsOIDC` | Role | Deploy workflow ([deploy.yml](../../.github/workflows/deploy.yml)) | OIDC, trust restricted to `Themis128/cloudless.gr` |
 | `cloudless-github-actions` | Role | Pi-image workflow (`deploy-pi.yml` / `build-pi-image` (see `docs/runners.md`)) | OIDC, same trust |
 | `cloudless-ops` | IAM user | Operator (you, locally) | Long-term access keys |
 | (root) | Account root | Bootstrap only | Avoid. See [Security note](#security-note) |
@@ -31,7 +31,7 @@ Assumed by the `Deploy to Production` workflow. Its trust policy restricts
   `iam:DeleteRolePolicy` on the role (cloudless-ops does not).
 
 **This role does NOT have `iam:SimulatePrincipalPolicy`.** The deploy preflight
-[detects that and degrades to a warning](../.github/workflows/deploy.yml).
+[detects that and degrades to a warning](../../.github/workflows/deploy.yml).
 
 ## `cloudless-github-actions` — the Pi-image role
 
@@ -136,5 +136,5 @@ The bootstrap admin path that does require root, *if you ever need one*, is:
 
 - [docs/deploy.md](../deploy/deploy.md) — what the deploy role needs and why
 - [docs/ci-health-routine.md](../deploy/ci-health-routine.md) — the weekly green-pipeline check
-- [scripts/grant-ci-iam-permissions.py](../scripts/grant-ci-iam-permissions.py) — boto3 helper that applies the recommended scoped policies
+- [scripts/grant-ci-iam-permissions.py](../../scripts/grant-ci-iam-permissions.py) — boto3 helper that applies the recommended scoped policies
 - Project-aware Claude skills (`~/.claude/skills/`): `lighthouse-perf-debug`, `ecr-immutable-tags-ci`

--- a/docs/cluster/TAILSCALE-FABRIC.md
+++ b/docs/cluster/TAILSCALE-FABRIC.md
@@ -463,7 +463,7 @@ Offline / orphaned devices: [`OFFLINE-DEVICE-TROUBLESHOOTING.md`](../../infrastr
 |-----|------|
 | [`kubectl-tailscale.md`](kubectl-tailscale.md) | Day-2 kubectl from WSL / LAN |
 | [`infrastructure/tailscale/README.md`](../../infrastructure/tailscale/README.md) | Manifest index + quick deploy |
-| [`databases/omv-cluster.md`](databases/omv-cluster.md) | DB access rules (no TS exposure) |
+| [`databases/omv-cluster.md`](../databases/omv-cluster.md) | DB access rules (no TS exposure) |
 | [`CLUSTER-MAP.md`](../../CLUSTER-MAP.md) | Live pod map (refresh periodically) |
 | Cloudflare tunnel ops skill | Public `*.cloudless.gr` ingress |
 

--- a/docs/cluster/kubectl-tailscale.md
+++ b/docs/cluster/kubectl-tailscale.md
@@ -62,7 +62,7 @@ kubectl get pods -n monitoring
 
 ## Off-LAN: kube-apiserver ProxyGroup
 
-After [`infrastructure/tailscale/deploy.sh`](../infrastructure/tailscale/deploy.sh)
+After [`infrastructure/tailscale/deploy.sh`](../../infrastructure/tailscale/deploy.sh)
 (see fabric doc §8):
 
 ```bash
@@ -96,7 +96,7 @@ devices owned by the operator (`k3s-subnet-router-*`, `ingress-*`, `kube-*`).
 **Safe to delete when offline forever:** old per-app proxies
 (`monitoring-proxies-*`, `ts-n8n-*`, `appflowy`, `grafana`, …) from before
 shared `proxy-group` annotations. Details:
-[`OFFLINE-DEVICE-TROUBLESHOOTING.md`](../infrastructure/tailscale/OFFLINE-DEVICE-TROUBLESHOOTING.md).
+[`OFFLINE-DEVICE-TROUBLESHOOTING.md`](../../infrastructure/tailscale/OFFLINE-DEVICE-TROUBLESHOOTING.md).
 
 ## Notes
 
@@ -104,4 +104,4 @@ shared `proxy-group` annotations. Details:
 - Subnet routes (`10.42.0.0/16`, `10.43.0.0/16`) are optional — only for direct
   ClusterIP access from a laptop with `--accept-routes`.
 - DB ports stay ClusterIP — use `pnpm db:forward` / port-forward
-  ([databases/omv-cluster.md](databases/omv-cluster.md)).
+  ([databases/omv-cluster.md](../databases/omv-cluster.md)).

--- a/docs/data/omv-cluster-databases.md
+++ b/docs/data/omv-cluster-databases.md
@@ -2,5 +2,5 @@
 
 This document now lives under the dedicated databases folder:
 
-**→ [databases/omv-cluster.md](databases/omv-cluster.md)**  
-**→ [databases/README.md](databases/README.md)** (folder index)
+**→ [databases/omv-cluster.md](../databases/omv-cluster.md)**  
+**→ [databases/README.md](../databases/README.md)** (folder index)

--- a/docs/datalake.md
+++ b/docs/datalake.md
@@ -1,0 +1,3 @@
+> Moved to [`data/datalake.md`](data/datalake.md).
+
+This stub keeps old links working. Prefer the topic path going forward.

--- a/docs/deploy/deploy.md
+++ b/docs/deploy/deploy.md
@@ -147,7 +147,7 @@ The output field `EvalDecision` should be `"allowed"` for all four actions.
 ## See also
 
 - [SST `defaultTags` configuration](https://sst.dev/docs/providers/#defaulttags) — explains why every managed resource is tagged
-- [`sst.config.ts`](../sst.config.ts) — this project's tag keys (`Project`, `Environment`, `Owner`, `ManagedBy`)
+- [`sst.config.ts`](../../sst.config.ts) — this project's tag keys (`Project`, `Environment`, `Owner`, `ManagedBy`)
 - [AWS IAM policy simulator docs](https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies_testing-policies.html)
 - [GitHub Actions OIDC with AWS](https://docs.github.com/en/actions/security-for-github-actions/security-hardening-your-deployments/configuring-openid-connect-in-amazon-web-services)
 

--- a/docs/deploy/pi-cloud-sync.md
+++ b/docs/deploy/pi-cloud-sync.md
@@ -29,8 +29,8 @@ This doc is the contract for what's kept in sync, how, and what to monitor.
 | Surface | Mechanism | Drift risk |
 |---|---|---|
 | **Code (image)** | Both sides use `cloudless-pi-app` from ECR (us-east-1). Cloud builds via SST, Pi pulls via K3s. | Until both pin to the same SHA, Pi can lag arbitrarily. |
-| **Public env** | `NEXT_PUBLIC_*` baked into the image at build time (see [Dockerfile](../Dockerfile)). | Identical because identical image. |
-| **Runtime secrets** | Both read from SSM at `/cloudless/production/*` (see [sst.config.ts:31-32](../sst.config.ts)). | Pi must have `ssm:GetParametersByPath` on that prefix via `cloudless-pi-standby`. |
+| **Public env** | `NEXT_PUBLIC_*` baked into the image at build time (see [Dockerfile](../../Dockerfile)). | Identical because identical image. |
+| **Runtime secrets** | Both read from SSM at `/cloudless/production/*` (see [sst.config.ts:31-32](../../sst.config.ts)). | Pi must have `ssm:GetParametersByPath` on that prefix via `cloudless-pi-standby`. |
 | **Notion content** | Both fetch live from Notion API; ISR per-process. | Pi cache lags by up to its ISR TTL after Notion edits. |
 | **Auth sessions** | Both verify JWTs against the same Cognito JWKS. | Pi must have the `COGNITO_*` vars in SSM. |
 | **Webhooks (Stripe/Notion/EspoCRM)** | Hit `cloudless.gr` and route to whichever is live. | Pi must hold the same webhook secrets in SSM. |
@@ -41,7 +41,7 @@ This doc is the contract for what's kept in sync, how, and what to monitor.
 
 ### 1. Image SHA pin via SSM `/cloudless/production/cloud-sha`
 
-After every successful production deploy, [.github/workflows/deploy.yml](../.github/workflows/deploy.yml) writes the just-deployed commit SHA to:
+After every successful production deploy, [.github/workflows/deploy.yml](../../.github/workflows/deploy.yml) writes the just-deployed commit SHA to:
 
 ```
 arn:aws:ssm:us-east-1:278585680617:parameter/cloudless/production/cloud-sha
@@ -64,7 +64,7 @@ kubectl set image deployment/cloudless cloudless=278585680617.dkr.ecr.us-east-1.
 
 ### 2. SECONDARY-path health monitoring — `Pi TLS Cert Check` workflow
 
-[.github/workflows/pi-tls-cert-check.yml](../.github/workflows/pi-tls-cert-check.yml)
+[.github/workflows/pi-tls-cert-check.yml](../../.github/workflows/pi-tls-cert-check.yml)
 runs every 6h (00:30, 06:30, 12:30, 18:30 UTC) against the APIGW SECONDARY frontend
 (`d-uy6dmk95il.execute-api.us-east-1.amazonaws.com`) and asserts:
 
@@ -96,7 +96,7 @@ morning Athens time. Output is `ALL_HEALTHY` or a per-workflow failure report.
 
 ### 4. SHA drift detector
 
-[.github/workflows/sha-drift-watchdog.yml](../.github/workflows/sha-drift-watchdog.yml)
+[.github/workflows/sha-drift-watchdog.yml](../../.github/workflows/sha-drift-watchdog.yml)
 runs every 6h (00:45, 06:45, 12:45, 18:45 UTC) and after every HA sync
 orchestrator completion. It compares three values:
 
@@ -116,9 +116,9 @@ Tolerances:
 - SHA equivalence is **prefix-tolerant**: 7-char abbreviated, 12-char
   Docker tag, and 40-char full SHA all compare equal.
 
-The pure comparison logic lives in [`src/lib/sha-drift.ts`](../src/lib/sha-drift.ts)
+The pure comparison logic lives in [`src/lib/sha-drift.ts`](../../src/lib/sha-drift.ts)
 and is exercised by 16 unit tests in `__tests__/detect-sha-drift.test.ts`.
-The CLI wrapper is [`scripts/detect-sha-drift.mts`](../scripts/detect-sha-drift.mts);
+The CLI wrapper is [`scripts/detect-sha-drift.mts`](../../scripts/detect-sha-drift.mts);
 run it on demand with:
 
 ```bash

--- a/docs/etl.md
+++ b/docs/etl.md
@@ -1,0 +1,3 @@
+> Moved to [`data/etl.md`](data/etl.md).
+
+This stub keeps old links working. Prefer the topic path going forward.

--- a/docs/integrations/ANTHROPIC.md
+++ b/docs/integrations/ANTHROPIC.md
@@ -109,7 +109,7 @@ The system prompt positions Claude as "Cloudless Assistant" with knowledge of se
 
 #### Tools (Phase 2a of [`docs/AGENTS_ROADMAP.md`](../roadmap/AGENTS_ROADMAP.md))
 
-Tool definitions and the `runTool` dispatcher live in [`src/lib/chat-tools.ts`](../src/lib/chat-tools.ts). Each tool's executor returns a plain string — errors are converted to user-facing nudges so a thrown tool never crashes the loop.
+Tool definitions and the `runTool` dispatcher live in [`src/lib/chat-tools.ts`](../../src/lib/chat-tools.ts). Each tool's executor returns a plain string — errors are converted to user-facing nudges so a thrown tool never crashes the loop.
 
 | Tool | Input | What it does | Backed by |
 |------|-------|--------------|-----------|

--- a/docs/integrations/NEWSLETTER.md
+++ b/docs/integrations/NEWSLETTER.md
@@ -32,21 +32,21 @@ If nothing is approved by 09:00 UTC, the publisher exits cleanly with no newslet
 
 ### Subscriber capture and lifecycle
 
-- [src/app/api/subscribe/route.ts](../src/app/api/subscribe/route.ts) records the email in EspoCRM via `setNewsletterStatus(email, "newsletter_signup")`, clears any stale SES suppression so a returning subscriber can be emailed again, then sends the branded welcome email and a real-time Slack ping to `#subscribers`.
-- [src/app/api/unsubscribe/route.ts](../src/app/api/unsubscribe/route.ts) (POST for the in-app form, GET for the one-click `List-Unsubscribe` link) atomically adds the address to the SES suppression list and flips the EspoCRM contact to `lead_source = "newsletter_unsubscribed"`, removing it from the send audience.
-- [src/lib/espocrm.ts](../src/lib/espocrm.ts) — `setNewsletterStatus()` creates or updates a contact and sets the subscription state; `listNewsletterSubscribers()` returns every contact with `lead_source = "newsletter_signup"` (cursor-paginated search). _(EspoCRM was decommissioned in PR #1043; this lib is the drop-in replacement with the same 21 exports.)_
+- [src/app/api/subscribe/route.ts](../../src/app/api/subscribe/route.ts) records the email in EspoCRM via `setNewsletterStatus(email, "newsletter_signup")`, clears any stale SES suppression so a returning subscriber can be emailed again, then sends the branded welcome email and a real-time Slack ping to `#subscribers`.
+- [src/app/api/unsubscribe/route.ts](../../src/app/api/unsubscribe/route.ts) (POST for the in-app form, GET for the one-click `List-Unsubscribe` link) atomically adds the address to the SES suppression list and flips the EspoCRM contact to `lead_source = "newsletter_unsubscribed"`, removing it from the send audience.
+- [src/lib/espocrm.ts](../../src/lib/espocrm.ts) — `setNewsletterStatus()` creates or updates a contact and sets the subscription state; `listNewsletterSubscribers()` returns every contact with `lead_source = "newsletter_signup"` (cursor-paginated search). _(EspoCRM was decommissioned in PR #1043; this lib is the drop-in replacement with the same 21 exports.)_
 
 ### Welcome email
 
-- [src/lib/email.ts](../src/lib/email.ts) — `sendSubscriberWelcome()` sends a branded dark-theme email from `Themis at Cloudless` with subject "Welcome to Cloudless — your first issue lands Monday". The email previews the three content categories (Cloud and Serverless, Analytics and AI Marketing, Company Updates and Offers), links to the blog archive, and includes a one-click `List-Unsubscribe` header (RFC 8058).
+- [src/lib/email.ts](../../src/lib/email.ts) — `sendSubscriberWelcome()` sends a branded dark-theme email from `Themis at Cloudless` with subject "Welcome to Cloudless — your first issue lands Monday". The email previews the three content categories (Cloud and Serverless, Analytics and AI Marketing, Company Updates and Offers), links to the blog archive, and includes a one-click `List-Unsubscribe` header (RFC 8058).
 
 ### Send endpoint
 
-- [src/app/api/newsletter/send/route.ts](../src/app/api/newsletter/send/route.ts) — `POST` authenticated with the `x-newsletter-secret` header against `NEWSLETTER_SEND_SECRET`. Accepts `{ subject, html, text }`, resolves the subscriber list from EspoCRM, and delivers one email per recipient via `sendEmail()` (SES). Returns `{ sent, failed, total }`. The `%UNSUBSCRIBELINK%` token in the body is replaced per recipient with `/api/unsubscribe?email=...`, and a matching `List-Unsubscribe` header is added.
+- [src/app/api/newsletter/send/route.ts](../../src/app/api/newsletter/send/route.ts) — `POST` authenticated with the `x-newsletter-secret` header against `NEWSLETTER_SEND_SECRET`. Accepts `{ subject, html, text }`, resolves the subscriber list from EspoCRM, and delivers one email per recipient via `sendEmail()` (SES). Returns `{ sent, failed, total }`. The `%UNSUBSCRIBELINK%` token in the body is replaced per recipient with `/api/unsubscribe?email=...`, and a matching `List-Unsubscribe` header is added.
 
 ### CMS
 
-- Notion database **Blog** — fetched at runtime via [src/lib/notion-blog.ts](../src/lib/notion-blog.ts). 5-min ISR on `/blog` and `/blog/[slug]`.
+- Notion database **Blog** — fetched at runtime via [src/lib/notion-blog.ts](../../src/lib/notion-blog.ts). 5-min ISR on `/blog` and `/blog/[slug]`.
 - Schema (workflow-relevant fields):
   - `Status` — select: Draft / Approved / Published. Editorial state machine.
   - `Published` — checkbox. Public visibility flag (set atomically with Status=Published).
@@ -57,8 +57,8 @@ If nothing is approved by 09:00 UTC, the publisher exits cleanly with no newslet
 
 ### Cron scripts (self-contained: read env directly, no `src/lib/*` imports)
 
-- [scripts/generate-weekly-article.ts](../scripts/generate-weekly-article.ts) picks the least-recently-used category, calls Claude with a brand-voice system prompt plus the last 8 titles to avoid, parses the JSON response, inserts as a Notion Draft, Slack-pings the editor.
-- [scripts/publish-and-send-newsletter.ts](../scripts/publish-and-send-newsletter.ts) finds Approved rows, renders Notion blocks to HTML and plaintext (including a category-matched "This Week at Cloudless" service offer section), marks Published with `Date` and `PublishedAt`, hits the existing Notion webhook to revalidate ISR, then POSTs the rendered email to `/api/newsletter/send`, and Slack-confirms with the delivered/failed counts.
+- [scripts/generate-weekly-article.ts](../../scripts/generate-weekly-article.ts) picks the least-recently-used category, calls Claude with a brand-voice system prompt plus the last 8 titles to avoid, parses the JSON response, inserts as a Notion Draft, Slack-pings the editor.
+- [scripts/publish-and-send-newsletter.ts](../../scripts/publish-and-send-newsletter.ts) finds Approved rows, renders Notion blocks to HTML and plaintext (including a category-matched "This Week at Cloudless" service offer section), marks Published with `Date` and `PublishedAt`, hits the existing Notion webhook to revalidate ISR, then POSTs the rendered email to `/api/newsletter/send`, and Slack-confirms with the delivered/failed counts.
 - `scripts/weekly-subscriber-report.ts` _(decommissioned with EspoCRM in PR #1043; equivalent reporting now flows from the espocrm-to-lake ETL → Athena)_ — historically queried EspoCRM for total active subscribers, new signups this week, and total unsubscribed contacts; posted a formatted Block Kit summary to Slack `#subscribers`; and inserted a timestamped row into a Notion "Newsletter Reports" database.
 
 ### Workflows

--- a/docs/kubectl-tailscale.md
+++ b/docs/kubectl-tailscale.md
@@ -1,0 +1,3 @@
+> Moved to [`cluster/kubectl-tailscale.md`](cluster/kubectl-tailscale.md).
+
+This stub keeps old links working. Prefer the topic path going forward.

--- a/docs/marketing/linkedin-campaigns.md
+++ b/docs/marketing/linkedin-campaigns.md
@@ -5,7 +5,7 @@ End-to-end implementation reference for the LinkedIn paid-acquisition stack on
 debugging missing conversions in LinkedIn Campaign Manager.
 
 For the agent-facing workflow (file paths, "add a new campaign in 6 steps",
-operating notes) see [`skills/linkedin-campaigns/SKILL.md`](../skills/linkedin-campaigns/SKILL.md).
+operating notes) see [`skills/linkedin-campaigns/SKILL.md`](../../skills/linkedin-campaigns/SKILL.md).
 
 ## Architecture at a glance
 
@@ -104,7 +104,7 @@ hasn't changed when you upgrade:
 
 ## Adding a new campaign
 
-See [`skills/linkedin-campaigns/SKILL.md`](../skills/linkedin-campaigns/SKILL.md)
+See [`skills/linkedin-campaigns/SKILL.md`](../../skills/linkedin-campaigns/SKILL.md)
 for the 6-step recipe. Quick version:
 
 1. New slug in `src/data/campaigns.ts` (extend the `CampaignSlug` type).

--- a/docs/orphan-k8s-resources-2026-06-21.md
+++ b/docs/orphan-k8s-resources-2026-06-21.md
@@ -1,0 +1,3 @@
+> Moved to [`cluster/orphan-k8s-resources-2026-06-21.md`](cluster/orphan-k8s-resources-2026-06-21.md).
+
+This stub keeps old links working. Prefer the topic path going forward.

--- a/docs/product/design-system-v2.md
+++ b/docs/product/design-system-v2.md
@@ -1,7 +1,7 @@
 # Cloudless Design System v2 — "Calm Cloud"
 
 **Status**: Phase 1 (Foundation) — additive, not yet wired to production.
-**Replaces**: the cyberpunk/neon-terminal language in [src/app/globals.css](../src/app/globals.css).
+**Replaces**: the cyberpunk/neon-terminal language in [src/app/globals.css](../../src/app/globals.css).
 
 ## Why we are rebranding
 

--- a/docs/roadmap/AGENTS_ROADMAP.md
+++ b/docs/roadmap/AGENTS_ROADMAP.md
@@ -42,7 +42,7 @@ Trade-off: lost the typewriter streaming effect on responses that _use_ a tool �
 
 **Tests** (19 added): see `docs/ANTHROPIC.md` for the full table. Covers tool round-trip with `tool_result`, iteration-cap fallback, schema declarations, and per-tool match / no-match / no-config / throw paths.
 
-Detail: see [`docs/ANTHROPIC.md`](ANTHROPIC.md#tools-phase-2a-of-docsagents_roadmapmd) for the loop diagram and tool table.
+Detail: see [`docs/ANTHROPIC.md`](../integrations/ANTHROPIC.md#tools-phase-2a-of-docsagents_roadmapmd) for the loop diagram and tool table.
 
 ### Phase 2b — booking agent — SHIPPED
 


### PR DESCRIPTION
## Summary
- Follow-up to #1464: fix `../` paths to repo-root targets (`scripts/`, `.github/`, etc.) now that docs live one folder deeper.
- Add stubs for remaining root cross-links (`datalake.md`, `etl.md`, `kubectl-tailscale.md`, …).

## Test plan
- [ ] Markdown Link Checker green
- [x] Spot-checked Cognito index / IAM / Tailscale / databases links resolve on disk


Made with [Cursor](https://cursor.com)