### PR TITLE
docs: per-workload pods atlas (docs/pods)

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -19,6 +19,7 @@ Topic-oriented documentation for cloudless.gr. Pick a folder by subject; each fo
 | [marketing/](marketing/) | Campaigns, LinkedIn, Meta, Agency Hub |
 | [mcp/](mcp/) | MCP rules and bridges |
 | [performance/](performance/) | Lighthouse / CWV |
+| [pods/](pods/) | **Per-workload atlas** — every omv Deployment/StatefulSet + how the app uses it |
 | [product/](product/) | Design system, use cases, tooling inventory |
 | [pull-requests/](pull-requests/) | PR notes and replies |
 | [roadmap/](roadmap/) | Product and agent roadmaps |

--- a/docs/pods/README.md
+++ b/docs/pods/README.md
@@ -6,6 +6,8 @@ use the stable resource name.
 
 Verified inventory source: `kubectl get deploy,sts,ds -A` on omv (2026-07-30).
 
+> Probe 2026-07-30: `coredns`, `metrics-server`, `traefik` (+ `svclb-traefik`) are Running in `kube-system`. No in-cluster Deployments matched `mosquitto` / `alert-api` / `cloudflared` name patterns — those remain host or external as documented.
+
 ## Product / app-coupled
 
 | Folder | NS | App coupling |
@@ -55,6 +57,9 @@ Verified inventory source: `kubectl get deploy,sts,ds -A` on omv (2026-07-30).
 | [ingress](ingress/) | `tailscale` | Ingress or Tailscale fabric |
 | [kube](kube/) | `tailscale` | Ingress or Tailscale fabric |
 | [ts-k3s-cidrs](ts-k3s-cidrs/) | `tailscale` | Ingress or Tailscale fabric |
+| [coredns](coredns/) | `kube-system` | Ingress or Tailscale fabric |
+| [metrics-server](metrics-server/) | `kube-system` | Ingress or Tailscale fabric |
+| [traefik](traefik/) | `kube-system` | Ingress or Tailscale fabric |
 
 ## How to refresh
 

--- a/docs/pods/README.md
+++ b/docs/pods/README.md
@@ -1,0 +1,66 @@
+# Pods / workloads (omv k3s)
+
+One folder per live Deployment / StatefulSet / DaemonSet (plus host `cloudflared`,
+`pi-alert-api`, `mosquitto`). Ephemeral pod names (`…-7d8f9-abcde`) are not documented —
+use the stable resource name.
+
+Verified inventory source: `kubectl get deploy,sts,ds -A` on omv (2026-07-30).
+
+## Product / app-coupled
+
+| Folder | NS | App coupling |
+|--------|----|--------------|
+| [cloudless-app](cloudless-app/) | `cloudless` | Strong / supporting data plane |
+| [meilisearch](meilisearch/) | `meilisearch` | Strong / supporting data plane |
+| [espocrm](espocrm/) | `espocrm` | Strong / supporting data plane |
+| [espocrm-mariadb](espocrm-mariadb/) | `espocrm` | Strong / supporting data plane |
+| [appflowy-cloud](appflowy-cloud/) | `appflowy` | Strong / supporting data plane |
+| [appflowy-web](appflowy-web/) | `appflowy` | Strong / supporting data plane |
+| [appflowy-worker](appflowy-worker/) | `appflowy` | Strong / supporting data plane |
+| [admin-frontend](admin-frontend/) | `appflowy` | Strong / supporting data plane |
+| [gotrue](gotrue/) | `appflowy` | Strong / supporting data plane |
+| [minio](minio/) | `appflowy` | Strong / supporting data plane |
+| [nginx](nginx/) | `appflowy` | Strong / supporting data plane |
+| [postgres](postgres/) | `appflowy` | Strong / supporting data plane |
+| [redis](redis/) | `appflowy` | Strong / supporting data plane |
+| [postiz](postiz/) | `postiz` | Strong / supporting data plane |
+| [postiz-postgres](postiz-postgres/) | `postiz` | Strong / supporting data plane |
+| [postiz-redis](postiz-redis/) | `postiz` | Strong / supporting data plane |
+| [n8n](n8n/) | `n8n` | Strong / supporting data plane |
+
+## Admin / ops
+
+| Folder | NS | App coupling |
+|--------|----|--------------|
+| [uptime-kuma](uptime-kuma/) | `uptime-kuma` | Admin / alerts / observability |
+| [kuma-slack-bridge](kuma-slack-bridge/) | `uptime-kuma` | Admin / alerts / observability |
+| [ntfy](ntfy/) | `ntfy` | Admin / alerts / observability |
+| [kube-prom-grafana](kube-prom-grafana/) | `monitoring` | Admin / alerts / observability |
+| [prometheus](prometheus/) | `monitoring` | Admin / alerts / observability |
+| [alertmanager](alertmanager/) | `monitoring` | Admin / alerts / observability |
+| [kube-prom-kube-prometheus-operator](kube-prom-kube-prometheus-operator/) | `monitoring` | Admin / alerts / observability |
+| [kube-prom-kube-state-metrics](kube-prom-kube-state-metrics/) | `monitoring` | Admin / alerts / observability |
+| [kube-prom-prometheus-node-exporter](kube-prom-prometheus-node-exporter/) | `monitoring` | Admin / alerts / observability |
+| [blackbox-exporter](blackbox-exporter/) | `monitoring` | Admin / alerts / observability |
+| [pi-alert-api](pi-alert-api/) | `alert-manager / host` | Admin / alerts / observability |
+| [mosquitto](mosquitto/) | `monitoring` | Admin / alerts / observability |
+
+## Platform / ingress / fabric
+
+| Folder | NS | App coupling |
+|--------|----|--------------|
+| [cloudflared](cloudflared/) | `omv-host` | Ingress or Tailscale fabric |
+| [docs-server](docs-server/) | `default` | Ingress or Tailscale fabric |
+| [operator](operator/) | `tailscale` | Ingress or Tailscale fabric |
+| [ingress](ingress/) | `tailscale` | Ingress or Tailscale fabric |
+| [kube](kube/) | `tailscale` | Ingress or Tailscale fabric |
+| [ts-k3s-cidrs](ts-k3s-cidrs/) | `tailscale` | Ingress or Tailscale fabric |
+
+## How to refresh
+
+```bash
+ssh omv 'sudo KUBECONFIG=/etc/rancher/k3s/k3s.yaml kubectl get deploy,sts,ds -A'
+```
+
+When a new Deployment appears, add `docs/pods/<name>/README.md` using the same
+template (Identity · How cloudless.gr uses it · Key files · Secrets · Related).

--- a/docs/pods/admin-frontend/README.md
+++ b/docs/pods/admin-frontend/README.md
@@ -1,0 +1,38 @@
+# `admin-frontend`
+
+> Part of [docs/pods](../README.md) — omv k3s workload atlas.
+
+## Identity
+
+| Field | Value |
+|-------|-------|
+| Kind | Deployment |
+| Namespace | `appflowy` |
+| Resource name | `admin-frontend` |
+| Hostname / DNS | appflowy.cloudless.gr (admin path) |
+| Ports | via nginx |
+| Role | AppFlowy admin frontend. |
+
+## How cloudless.gr uses it
+
+Operator console for AppFlowy. Not invoked by Next product routes;
+accessible via CF Access for admins.
+
+## Key files
+
+- `skills/appflowy-operator/SKILL.md`
+
+## Secrets / config
+
+- shared AppFlowy secrets / CF Access
+
+## Related workloads
+
+- [`appflowy-cloud`](../appflowy-cloud/)
+- [`nginx`](../nginx/)
+
+## See also
+
+- [Cluster DB inventory](../../databases/omv-cluster.md)
+- [Tailscale fabric](../../cluster/TAILSCALE-FABRIC.md)
+- [CLUSTER-MAP.md](../../../CLUSTER-MAP.md)

--- a/docs/pods/alertmanager/README.md
+++ b/docs/pods/alertmanager/README.md
@@ -1,0 +1,40 @@
+# `alertmanager-kube-prom-kube-prometheus-alertmanager`
+
+> Part of [docs/pods](../README.md) — omv k3s workload atlas.
+
+## Identity
+
+| Field | Value |
+|-------|-------|
+| Kind | StatefulSet |
+| Namespace | `monitoring` |
+| Resource name | `alertmanager-kube-prom-kube-prometheus-alertmanager` |
+| Hostname / DNS | ClusterIP 9093 |
+| Ports | 9093 |
+| Role | Alertmanager — routes Prometheus alerts. |
+
+## How cloudless.gr uses it
+
+No direct Next client. Fires into **pi-alert-api** / Slack / MQTT on the
+ops path. High severity can POST `/api/webhooks/admin-alert` on the app.
+
+## Key files
+
+- `infrastructure/monitoring/`
+- `src/app/api/webhooks/admin-alert/route.ts`
+
+## Secrets / config
+
+- receiver configs in monitoring Helm values
+
+## Related workloads
+
+- [`prometheus`](../prometheus/)
+- [`pi-alert-api`](../pi-alert-api/)
+- [`ntfy`](../ntfy/)
+
+## See also
+
+- [Cluster DB inventory](../../databases/omv-cluster.md)
+- [Tailscale fabric](../../cluster/TAILSCALE-FABRIC.md)
+- [CLUSTER-MAP.md](../../../CLUSTER-MAP.md)

--- a/docs/pods/appflowy-cloud/README.md
+++ b/docs/pods/appflowy-cloud/README.md
@@ -1,0 +1,53 @@
+# `appflowy-cloud`
+
+> Part of [docs/pods](../README.md) — omv k3s workload atlas.
+
+## Identity
+
+| Field | Value |
+|-------|-------|
+| Kind | Deployment |
+| Namespace | `appflowy` |
+| Resource name | `appflowy-cloud` |
+| Hostname / DNS | appflowy.cloudless.gr (via nginx) |
+| Ports | internal; public via appflowy nginx NodePort 30810 |
+| Role | AppFlowy Cloud API — Notion-replacement CMS backend. |
+
+## How cloudless.gr uses it
+
+When AppFlowy is configured, blog/docs/FAQs/services/testimonials/case-studies
+adapters prefer AppFlowy over Notion (`cms-provider.ts`). The Next app
+authenticates with JWT/email against GoTrue and calls Cloud HTTP APIs —
+never Postgres/Redis/MinIO directly.
+
+## Key files
+
+- `src/lib/appflowy.ts`
+- `src/lib/appflowy-*.ts`
+- `src/lib/cms-provider.ts`
+- `src/app/api/admin/appflowy/**`
+- `skills/appflowy-operator/SKILL.md`
+
+## Secrets / config
+
+- `APPFLOWY_API_URL`
+- `APPFLOWY_JWT_SECRET`
+- `APPFLOWY_EMAIL`
+- `APPFLOWY_PASSWORD`
+
+## Related workloads
+
+- [`appflowy-web`](../appflowy-web/)
+- [`gotrue`](../gotrue/)
+- [`postgres`](../postgres/)
+- [`redis`](../redis/)
+- [`minio`](../minio/)
+- [`nginx`](../nginx/)
+- [`appflowy-worker`](../appflowy-worker/)
+- [`admin-frontend`](../admin-frontend/)
+
+## See also
+
+- [Cluster DB inventory](../../databases/omv-cluster.md)
+- [Tailscale fabric](../../cluster/TAILSCALE-FABRIC.md)
+- [CLUSTER-MAP.md](../../../CLUSTER-MAP.md)

--- a/docs/pods/appflowy-web/README.md
+++ b/docs/pods/appflowy-web/README.md
@@ -1,0 +1,41 @@
+# `appflowy-web`
+
+> Part of [docs/pods](../README.md) — omv k3s workload atlas.
+
+## Identity
+
+| Field | Value |
+|-------|-------|
+| Kind | Deployment |
+| Namespace | `appflowy` |
+| Resource name | `appflowy-web` |
+| Hostname / DNS | appflowy.cloudless.gr (UI) |
+| Ports | served via nginx |
+| Role | AppFlowy web UI. |
+
+## How cloudless.gr uses it
+
+Human/operator UI for editing CMS content. The Next app does not embed
+this UI; editors open `appflowy.cloudless.gr` (CF Access + optional
+admin autologin). Product pages read published content via `appflowy-cloud` APIs.
+
+## Key files
+
+- `src/lib/selfhosted-autologin.ts`
+- `src/lib/cloudflare-access.ts`
+
+## Secrets / config
+
+- CF Access client for `appflowy`
+
+## Related workloads
+
+- [`appflowy-cloud`](../appflowy-cloud/)
+- [`nginx`](../nginx/)
+- [`gotrue`](../gotrue/)
+
+## See also
+
+- [Cluster DB inventory](../../databases/omv-cluster.md)
+- [Tailscale fabric](../../cluster/TAILSCALE-FABRIC.md)
+- [CLUSTER-MAP.md](../../../CLUSTER-MAP.md)

--- a/docs/pods/appflowy-worker/README.md
+++ b/docs/pods/appflowy-worker/README.md
@@ -1,0 +1,42 @@
+# `appflowy-worker`
+
+> Part of [docs/pods](../README.md) — omv k3s workload atlas.
+
+## Identity
+
+| Field | Value |
+|-------|-------|
+| Kind | Deployment |
+| Namespace | `appflowy` |
+| Resource name | `appflowy-worker` |
+| Hostname / DNS | (internal) |
+| Ports | n/a |
+| Role | AppFlowy background worker (must stay on a 4 KiB-page node — pin to omv-ha). |
+
+## How cloudless.gr uses it
+
+No direct Next.js calls. Required for AppFlowy Cloud jobs (email, indexing).
+If this pod is down, CMS writes may stall; public site reads can still serve
+cached/API data until Cloud fails.
+
+## Key files
+
+- `skills/appflowy-operator/SKILL.md`
+- `docs/self-hosted/appflowy-deploy.md`
+
+## Secrets / config
+
+- shared `appflowy-secrets`
+
+## Related workloads
+
+- [`appflowy-cloud`](../appflowy-cloud/)
+- [`postgres`](../postgres/)
+- [`redis`](../redis/)
+- [`minio`](../minio/)
+
+## See also
+
+- [Cluster DB inventory](../../databases/omv-cluster.md)
+- [Tailscale fabric](../../cluster/TAILSCALE-FABRIC.md)
+- [CLUSTER-MAP.md](../../../CLUSTER-MAP.md)

--- a/docs/pods/blackbox-exporter/README.md
+++ b/docs/pods/blackbox-exporter/README.md
@@ -1,0 +1,38 @@
+# `blackbox-exporter`
+
+> Part of [docs/pods](../README.md) — omv k3s workload atlas.
+
+## Identity
+
+| Field | Value |
+|-------|-------|
+| Kind | Deployment |
+| Namespace | `monitoring` |
+| Resource name | `blackbox-exporter` |
+| Hostname / DNS | (internal) |
+| Ports | 9115 |
+| Role | Blackbox probe exporter (HTTP/TCP/ICMP). |
+
+## How cloudless.gr uses it
+
+**Ops-only.** Prometheus blackbox module for external URL probes. Complements
+Uptime Kuma; no Next.js client.
+
+## Key files
+
+- `infrastructure/monitoring/`
+
+## Secrets / config
+
+- none
+
+## Related workloads
+
+- [`prometheus`](../prometheus/)
+- [`uptime-kuma`](../uptime-kuma/)
+
+## See also
+
+- [Cluster DB inventory](../../databases/omv-cluster.md)
+- [Tailscale fabric](../../cluster/TAILSCALE-FABRIC.md)
+- [CLUSTER-MAP.md](../../../CLUSTER-MAP.md)

--- a/docs/pods/cloudflared/README.md
+++ b/docs/pods/cloudflared/README.md
@@ -1,0 +1,49 @@
+# `cloudflared`
+
+> Part of [docs/pods](../README.md) — omv k3s workload atlas.
+
+## Identity
+
+| Field | Value |
+|-------|-------|
+| Kind | HostService |
+| Namespace | `omv-host` |
+| Resource name | `cloudflared` |
+| Hostname / DNS | shared tunnel UUID e977a490-58c5-4fdb-9155-86832e3e636a |
+| Ports | host process → NodePorts |
+| Role | Cloudflare Tunnel — public ingress for all `*.cloudless.gr` apps. |
+
+## How cloudless.gr uses it
+
+**No SDK in Next.** Every public hostname (app, EspoCRM, Kuma, Grafana, …)
+reaches Pi NodePorts through this tunnel. App uses public HTTPS URLs from
+config; CF Access tokens for admin autologin.
+
+## Key files
+
+- `infrastructure/cloudflare-tunnels/*`
+- `skills/cloudflare-tunnel-ops/SKILL.md`
+- `src/lib/cloudflare-access.ts`
+
+## Secrets / config
+
+- tunnel credentials on omv host
+- `CLOUDFLARE_ACCOUNT_ID`
+- Access service tokens
+
+## Related workloads
+
+- [`cloudless-app`](../cloudless-app/)
+- [`espocrm`](../espocrm/)
+- [`n8n`](../n8n/)
+- [`uptime-kuma`](../uptime-kuma/)
+- [`kube-prom-grafana`](../kube-prom-grafana/)
+- [`postiz`](../postiz/)
+- [`meilisearch`](../meilisearch/)
+- [`ntfy`](../ntfy/)
+
+## See also
+
+- [Cluster DB inventory](../../databases/omv-cluster.md)
+- [Tailscale fabric](../../cluster/TAILSCALE-FABRIC.md)
+- [CLUSTER-MAP.md](../../../CLUSTER-MAP.md)

--- a/docs/pods/cloudless-app/README.md
+++ b/docs/pods/cloudless-app/README.md
@@ -1,0 +1,50 @@
+# `cloudless-app`
+
+> Part of [docs/pods](../README.md) — omv k3s workload atlas.
+
+## Identity
+
+| Field | Value |
+|-------|-------|
+| Kind | Deployment |
+| Namespace | `cloudless` |
+| Resource name | `cloudless-app` |
+| Hostname / DNS | cloudless.gr · manage.cloudless.gr · pi-origin.cloudless.gr |
+| Ports | NodePort 30300 (HTTP) |
+| Role | Primary Next.js application (this repo). |
+
+## How cloudless.gr uses it
+
+This **is** the cloudless.gr product. The Pi image is built by `deploy-pi.yml`,
+pushed to ECR, and rolled out here. All peer services below are called from this
+pod via HTTPS (public `*.cloudless.gr`) or in-cluster DNS (`*.svc.cluster.local`).
+Admin cluster UI reads CronJobs through the in-pod ServiceAccount (`k8s-cluster.ts`).
+
+## Key files
+
+- `src/**`
+- `src/lib/k8s-cluster.ts`
+- `src/app/api/admin/cluster/**`
+- `k8s/cloudless-app-hostpath.yaml`
+
+## Secrets / config
+
+- k8s `cloudless-secrets`
+- SSM `/cloudless/production/*` (legacy) / D1 + CF tokens
+- build-time `NEXT_PUBLIC_*`
+
+## Related workloads
+
+- [`meilisearch`](../meilisearch/)
+- [`espocrm`](../espocrm/)
+- [`appflowy-cloud`](../appflowy-cloud/)
+- [`postiz`](../postiz/)
+- [`n8n`](../n8n/)
+- [`uptime-kuma`](../uptime-kuma/)
+- [`kube-prom-grafana`](../kube-prom-grafana/)
+
+## See also
+
+- [Cluster DB inventory](../../databases/omv-cluster.md)
+- [Tailscale fabric](../../cluster/TAILSCALE-FABRIC.md)
+- [CLUSTER-MAP.md](../../../CLUSTER-MAP.md)

--- a/docs/pods/coredns/README.md
+++ b/docs/pods/coredns/README.md
@@ -1,0 +1,43 @@
+# `coredns`
+
+> Part of [docs/pods](../README.md) — omv k3s workload atlas.
+
+## Identity
+
+| Field | Value |
+|-------|-------|
+| Kind | Deployment |
+| Namespace | `kube-system` |
+| Resource name | `coredns` |
+| Hostname / DNS | cluster DNS (kube-dns) |
+| Ports | 53 UDP/TCP |
+| Role | Cluster DNS for `*.svc.cluster.local` and upstream recursion. |
+
+## How cloudless.gr uses it
+
+**Platform only — no Next.js client.** Every in-cluster call from
+`cloudless-app` (Meili, MQTT, Kuma, etc.) depends on CoreDNS. Mass
+`getaddrinfo EAI_AGAIN` in Uptime Kuma usually means this path (or the node)
+is stalled, not that every app is down.
+
+## Key files
+
+- `docs/cluster/TAILSCALE-FABRIC.md`
+- k3s CoreDNS ConfigMap
+
+## Secrets / config
+
+- none in app
+
+## Related workloads
+
+- [`cloudless-app`](../cloudless-app/)
+- [`meilisearch`](../meilisearch/)
+- [`traefik`](../traefik/)
+- [`metrics-server`](../metrics-server/)
+
+## See also
+
+- [Cluster DB inventory](../../databases/omv-cluster.md)
+- [Tailscale fabric](../../cluster/TAILSCALE-FABRIC.md)
+- [CLUSTER-MAP.md](../../../CLUSTER-MAP.md)

--- a/docs/pods/docs-server/README.md
+++ b/docs/pods/docs-server/README.md
@@ -1,0 +1,41 @@
+# `docs-server`
+
+> Part of [docs/pods](../README.md) — omv k3s workload atlas.
+
+## Identity
+
+| Field | Value |
+|-------|-------|
+| Kind | Deployment |
+| Namespace | `default` |
+| Resource name | `docs-server` |
+| Hostname / DNS | docs.cloudless.gr (tunnel → NodePort 30901) |
+| Ports | NodePort 30901 |
+| Role | Standalone docs portal host (separate from Notion/AppFlowy CMS). |
+
+## How cloudless.gr uses it
+
+Public docs hostname via Cloudflare Tunnel. Product `/[locale]/docs` in Next
+may still use AppFlowy/Notion APIs; this pod is the tunnel target for
+`docs.cloudless.gr` when that ingress is enabled.
+
+## Key files
+
+- `infrastructure/cloudflare-tunnels/`
+- `src/app/api/docs/**`
+- `src/lib/appflowy-docs.ts`
+
+## Secrets / config
+
+- tunnel config on host
+
+## Related workloads
+
+- [`cloudflared`](../cloudflared/)
+- [`appflowy-cloud`](../appflowy-cloud/)
+
+## See also
+
+- [Cluster DB inventory](../../databases/omv-cluster.md)
+- [Tailscale fabric](../../cluster/TAILSCALE-FABRIC.md)
+- [CLUSTER-MAP.md](../../../CLUSTER-MAP.md)

--- a/docs/pods/espocrm-mariadb/README.md
+++ b/docs/pods/espocrm-mariadb/README.md
@@ -1,0 +1,40 @@
+# `espocrm-mariadb`
+
+> Part of [docs/pods](../README.md) — omv k3s workload atlas.
+
+## Identity
+
+| Field | Value |
+|-------|-------|
+| Kind | Deployment |
+| Namespace | `espocrm` |
+| Resource name | `espocrm-mariadb` |
+| Hostname / DNS | (ClusterIP only — no public hostname) |
+| Ports | 3306 → local forward `127.0.0.1:13306` |
+| Role | MariaDB 11 backing EspoCRM. |
+
+## How cloudless.gr uses it
+
+**Not used directly by Next.js.** EspoCRM pods talk to this Service.
+Operators use `pnpm db:forward` + SQLTools (`omv · EspoCRM MariaDB`).
+Daily R2 backup via `mariadb-dump` CronJob.
+
+## Key files
+
+- `docs/databases/omv-cluster.md`
+- `infrastructure/espocrm/`
+- `infrastructure/backup/cronjob-espocrm.yaml`
+
+## Secrets / config
+
+- k8s `espocrm-secrets` (DB passwords) — never in app SSM
+
+## Related workloads
+
+- [`espocrm`](../espocrm/)
+
+## See also
+
+- [Cluster DB inventory](../../databases/omv-cluster.md)
+- [Tailscale fabric](../../cluster/TAILSCALE-FABRIC.md)
+- [CLUSTER-MAP.md](../../../CLUSTER-MAP.md)

--- a/docs/pods/espocrm/README.md
+++ b/docs/pods/espocrm/README.md
@@ -1,0 +1,49 @@
+# `espocrm`
+
+> Part of [docs/pods](../README.md) — omv k3s workload atlas.
+
+## Identity
+
+| Field | Value |
+|-------|-------|
+| Kind | Deployment |
+| Namespace | `espocrm` |
+| Resource name | `espocrm` |
+| Hostname / DNS | espocrm.cloudless.gr |
+| Ports | NodePort 30700 |
+| Role | Self-hosted CRM (EspoCRM 9) — contacts, deals, cases, newsletter. |
+
+## How cloudless.gr uses it
+
+Primary CRM for the marketing site. Contact form, subscribe, calendar book,
+admin CRM/pipeline/email, and Slack entity webhooks all go through
+`src/lib/espocrm.ts` (HTTP API + `X-Api-Key`). The app never opens MariaDB
+TCP — only this HTTP surface.
+
+## Key files
+
+- `src/lib/espocrm.ts`
+- `src/lib/espocrm-webhook.ts`
+- `src/lib/espocrm-slack.ts`
+- `src/app/api/webhooks/espocrm/route.ts`
+- `src/app/api/crm/**`
+- `src/app/api/admin/crm/**`
+- `infrastructure/espocrm/`
+
+## Secrets / config
+
+- `ESPOCRM_BASE_URL`
+- `ESPOCRM_API_KEY`
+- `ESPOCRM_WEBHOOK_SECRET`
+
+## Related workloads
+
+- [`espocrm-mariadb`](../espocrm-mariadb/)
+- [`n8n`](../n8n/)
+- [`cloudless-app`](../cloudless-app/)
+
+## See also
+
+- [Cluster DB inventory](../../databases/omv-cluster.md)
+- [Tailscale fabric](../../cluster/TAILSCALE-FABRIC.md)
+- [CLUSTER-MAP.md](../../../CLUSTER-MAP.md)

--- a/docs/pods/gotrue/README.md
+++ b/docs/pods/gotrue/README.md
@@ -1,0 +1,38 @@
+# `gotrue`
+
+> Part of [docs/pods](../README.md) — omv k3s workload atlas.
+
+## Identity
+
+| Field | Value |
+|-------|-------|
+| Kind | Deployment |
+| Namespace | `appflowy` |
+| Resource name | `gotrue` |
+| Hostname / DNS | (internal to AppFlowy) |
+| Ports | internal |
+| Role | GoTrue auth for AppFlowy (JWT issuer). |
+
+## How cloudless.gr uses it
+
+The Next app obtains JWTs using `APPFLOWY_EMAIL` / `APPFLOWY_PASSWORD`
+against this service (through AppFlowy API URL). No separate public hostname.
+
+## Key files
+
+- `src/lib/appflowy.ts`
+
+## Secrets / config
+
+- `APPFLOWY_JWT_SECRET`
+- AppFlowy user credentials
+
+## Related workloads
+
+- [`appflowy-cloud`](../appflowy-cloud/)
+
+## See also
+
+- [Cluster DB inventory](../../databases/omv-cluster.md)
+- [Tailscale fabric](../../cluster/TAILSCALE-FABRIC.md)
+- [CLUSTER-MAP.md](../../../CLUSTER-MAP.md)

--- a/docs/pods/ingress/README.md
+++ b/docs/pods/ingress/README.md
@@ -1,0 +1,39 @@
+# `ingress`
+
+> Part of [docs/pods](../README.md) — omv k3s workload atlas.
+
+## Identity
+
+| Field | Value |
+|-------|-------|
+| Kind | StatefulSet |
+| Namespace | `tailscale` |
+| Resource name | `ingress` |
+| Hostname / DNS | Tailscale Serve (e.g. grafana.*.ts.net) |
+| Ports | ProxyGroup ingress |
+| Role | Tailscale ProxyGroup for HTTP Serve to cluster Services. |
+
+## How cloudless.gr uses it
+
+Optional private admin URLs over Tailscale. Not used by public customers;
+operators may open Grafana/Meili via Serve instead of CF Access.
+
+## Key files
+
+- `docs/cluster/TAILSCALE-FABRIC.md`
+- `infrastructure/tailscale/`
+
+## Secrets / config
+
+- operator-managed
+
+## Related workloads
+
+- [`operator`](../operator/)
+- [`kube-prom-grafana`](../kube-prom-grafana/)
+
+## See also
+
+- [Cluster DB inventory](../../databases/omv-cluster.md)
+- [Tailscale fabric](../../cluster/TAILSCALE-FABRIC.md)
+- [CLUSTER-MAP.md](../../../CLUSTER-MAP.md)

--- a/docs/pods/kube-prom-grafana/README.md
+++ b/docs/pods/kube-prom-grafana/README.md
@@ -1,0 +1,45 @@
+# `kube-prom-grafana`
+
+> Part of [docs/pods](../README.md) — omv k3s workload atlas.
+
+## Identity
+
+| Field | Value |
+|-------|-------|
+| Kind | Deployment |
+| Namespace | `monitoring` |
+| Resource name | `kube-prom-grafana` |
+| Hostname / DNS | grafana.cloudless.gr |
+| Ports | 80 · NodePort 30850 |
+| Role | Grafana dashboards + PromQL proxy. |
+
+## How cloudless.gr uses it
+
+Admin Grafana API: health, dashboards, datasource sync, Prometheus queries
+through Grafana (`src/lib/grafana.ts` + `/api/admin/grafana/**`). CF Access
+autologin for operators.
+
+## Key files
+
+- `src/lib/grafana.ts`
+- `src/app/api/admin/grafana/**`
+- `infrastructure/grafana/`
+- `infrastructure/monitoring/`
+
+## Secrets / config
+
+- `GRAFANA_BASE_URL`
+- `GRAFANA_API_TOKEN`
+- `PROMETHEUS_URL`
+
+## Related workloads
+
+- [`prometheus`](../prometheus/)
+- [`alertmanager`](../alertmanager/)
+- [`cloudless-app`](../cloudless-app/)
+
+## See also
+
+- [Cluster DB inventory](../../databases/omv-cluster.md)
+- [Tailscale fabric](../../cluster/TAILSCALE-FABRIC.md)
+- [CLUSTER-MAP.md](../../../CLUSTER-MAP.md)

--- a/docs/pods/kube-prom-kube-prometheus-operator/README.md
+++ b/docs/pods/kube-prom-kube-prometheus-operator/README.md
@@ -1,0 +1,38 @@
+# `kube-prom-kube-prometheus-operator`
+
+> Part of [docs/pods](../README.md) — omv k3s workload atlas.
+
+## Identity
+
+| Field | Value |
+|-------|-------|
+| Kind | Deployment |
+| Namespace | `monitoring` |
+| Resource name | `kube-prom-kube-prometheus-operator` |
+| Hostname / DNS | (internal) |
+| Ports | n/a |
+| Role | Prometheus Operator — manages Prometheus/Alertmanager CRs. |
+
+## How cloudless.gr uses it
+
+**Ops-only.** Not called by Next.js. Keep healthy so Grafana datasources and
+alert rules stay reconciled.
+
+## Key files
+
+- `infrastructure/monitoring/`
+
+## Secrets / config
+
+- none in app
+
+## Related workloads
+
+- [`prometheus`](../prometheus/)
+- [`alertmanager`](../alertmanager/)
+
+## See also
+
+- [Cluster DB inventory](../../databases/omv-cluster.md)
+- [Tailscale fabric](../../cluster/TAILSCALE-FABRIC.md)
+- [CLUSTER-MAP.md](../../../CLUSTER-MAP.md)

--- a/docs/pods/kube-prom-kube-state-metrics/README.md
+++ b/docs/pods/kube-prom-kube-state-metrics/README.md
@@ -1,0 +1,36 @@
+# `kube-prom-kube-state-metrics`
+
+> Part of [docs/pods](../README.md) — omv k3s workload atlas.
+
+## Identity
+
+| Field | Value |
+|-------|-------|
+| Kind | Deployment |
+| Namespace | `monitoring` |
+| Resource name | `kube-prom-kube-state-metrics` |
+| Hostname / DNS | (internal) |
+| Ports | 8080 metrics |
+| Role | Exports Kubernetes object metrics to Prometheus. |
+
+## How cloudless.gr uses it
+
+**Ops-only.** Feeds Grafana cluster dashboards. No Next.js import.
+
+## Key files
+
+- `infrastructure/monitoring/`
+
+## Secrets / config
+
+- none
+
+## Related workloads
+
+- [`prometheus`](../prometheus/)
+
+## See also
+
+- [Cluster DB inventory](../../databases/omv-cluster.md)
+- [Tailscale fabric](../../cluster/TAILSCALE-FABRIC.md)
+- [CLUSTER-MAP.md](../../../CLUSTER-MAP.md)

--- a/docs/pods/kube-prom-prometheus-node-exporter/README.md
+++ b/docs/pods/kube-prom-prometheus-node-exporter/README.md
@@ -1,0 +1,38 @@
+# `kube-prom-prometheus-node-exporter`
+
+> Part of [docs/pods](../README.md) — omv k3s workload atlas.
+
+## Identity
+
+| Field | Value |
+|-------|-------|
+| Kind | DaemonSet |
+| Namespace | `monitoring` |
+| Resource name | `kube-prom-prometheus-node-exporter` |
+| Hostname / DNS | (per-node) |
+| Ports | 9100 (host) |
+| Role | Node CPU/disk/RAM exporters on omv + omv-ha. |
+
+## How cloudless.gr uses it
+
+**Ops-only.** Disk/RAM panels in Grafana; also informs omv-disk-watchdog
+ops story. App does not scrape it.
+
+## Key files
+
+- `infrastructure/monitoring/`
+- omv-disk-watchdog CronJob
+
+## Secrets / config
+
+- none
+
+## Related workloads
+
+- [`prometheus`](../prometheus/)
+
+## See also
+
+- [Cluster DB inventory](../../databases/omv-cluster.md)
+- [Tailscale fabric](../../cluster/TAILSCALE-FABRIC.md)
+- [CLUSTER-MAP.md](../../../CLUSTER-MAP.md)

--- a/docs/pods/kube/README.md
+++ b/docs/pods/kube/README.md
@@ -1,0 +1,38 @@
+# `kube`
+
+> Part of [docs/pods](../README.md) — omv k3s workload atlas.
+
+## Identity
+
+| Field | Value |
+|-------|-------|
+| Kind | StatefulSet |
+| Namespace | `tailscale` |
+| Resource name | `kube` |
+| Hostname / DNS | apiserver auth-proxy |
+| Ports | ProxyGroup kube |
+| Role | Tailscale auth proxy in front of kube-apiserver. |
+
+## How cloudless.gr uses it
+
+Lets GHA / WSL reach the API over the tailnet. `cloudless-app` uses the
+in-cluster SA; this is for operators and CI, not product traffic.
+
+## Key files
+
+- `docs/cluster/kubectl-tailscale.md`
+- `docs/cluster/TAILSCALE-FABRIC.md`
+
+## Secrets / config
+
+- operator-managed
+
+## Related workloads
+
+- [`operator`](../operator/)
+
+## See also
+
+- [Cluster DB inventory](../../databases/omv-cluster.md)
+- [Tailscale fabric](../../cluster/TAILSCALE-FABRIC.md)
+- [CLUSTER-MAP.md](../../../CLUSTER-MAP.md)

--- a/docs/pods/kuma-slack-bridge/README.md
+++ b/docs/pods/kuma-slack-bridge/README.md
@@ -1,0 +1,39 @@
+# `kuma-slack-bridge`
+
+> Part of [docs/pods](../README.md) — omv k3s workload atlas.
+
+## Identity
+
+| Field | Value |
+|-------|-------|
+| Kind | Deployment |
+| Namespace | `uptime-kuma` |
+| Resource name | `kuma-slack-bridge` |
+| Hostname / DNS | `kuma-slack-bridge.uptime-kuma.svc:8080` (optional) |
+| Ports | 8080 |
+| Role | Optional in-cluster Kuma→Slack bridge (usually replicas: 0). |
+
+## How cloudless.gr uses it
+
+Rollback path if `cloudless-app` `/api/webhooks/kuma` is unavailable.
+Live path prefers the app webhook. Scale to 1 only for emergency.
+
+## Key files
+
+- `infrastructure/uptime-kuma/k8s/kuma-slack-bridge.yaml`
+- `infrastructure/uptime-kuma/k8s/kuma-slack-bridge.js`
+
+## Secrets / config
+
+- k8s Secret `kuma-slack-bridge` (`ADMIN_ALERT_SECRET`, `SLACK_BOT_TOKEN`)
+
+## Related workloads
+
+- [`uptime-kuma`](../uptime-kuma/)
+- [`cloudless-app`](../cloudless-app/)
+
+## See also
+
+- [Cluster DB inventory](../../databases/omv-cluster.md)
+- [Tailscale fabric](../../cluster/TAILSCALE-FABRIC.md)
+- [CLUSTER-MAP.md](../../../CLUSTER-MAP.md)

--- a/docs/pods/meilisearch/README.md
+++ b/docs/pods/meilisearch/README.md
@@ -1,0 +1,47 @@
+# `meilisearch`
+
+> Part of [docs/pods](../README.md) — omv k3s workload atlas.
+
+## Identity
+
+| Field | Value |
+|-------|-------|
+| Kind | Deployment |
+| Namespace | `meilisearch` |
+| Resource name | `meilisearch` |
+| Hostname / DNS | meili.cloudless.gr · in-cluster `meilisearch.meilisearch.svc:7700` |
+| Ports | 7700 ClusterIP · NodePort 30902 |
+| Role | Full-text / vector product search (R21). |
+
+## How cloudless.gr uses it
+
+The app indexes store products (optional Workers AI embeddings) and serves
+`/api/search`. Admin reindex is `/api/admin/search/reindex`. Prefer
+`MEILI_HOST=http://meilisearch.meilisearch.svc.cluster.local:7700` from the
+`cloudless-app` pod so traffic stays on the cluster network.
+
+## Key files
+
+- `src/lib/meilisearch.ts`
+- `src/lib/search-index.ts`
+- `src/lib/product-search.ts`
+- `src/app/api/search/route.ts`
+- `src/app/api/admin/search/reindex/route.ts`
+- `infrastructure/meilisearch/`
+
+## Secrets / config
+
+- `MEILI_HOST`
+- `MEILI_MASTER_KEY` / `MEILI_ADMIN_KEY`
+- `MEILI_SEARCH_KEY`
+- k8s `meilisearch-secret`
+
+## Related workloads
+
+- [`cloudless-app`](../cloudless-app/)
+
+## See also
+
+- [Cluster DB inventory](../../databases/omv-cluster.md)
+- [Tailscale fabric](../../cluster/TAILSCALE-FABRIC.md)
+- [CLUSTER-MAP.md](../../../CLUSTER-MAP.md)

--- a/docs/pods/metrics-server/README.md
+++ b/docs/pods/metrics-server/README.md
@@ -1,0 +1,38 @@
+# `metrics-server`
+
+> Part of [docs/pods](../README.md) — omv k3s workload atlas.
+
+## Identity
+
+| Field | Value |
+|-------|-------|
+| Kind | Deployment |
+| Namespace | `kube-system` |
+| Resource name | `metrics-server` |
+| Hostname / DNS | metrics.k8s.io API |
+| Ports | 443 (API aggregation) |
+| Role | Provides `kubectl top` / HPA metrics. |
+
+## How cloudless.gr uses it
+
+**Ops-only.** Not imported by Next.js. When it has no endpoints,
+`kubectl top` and some controllers warn; product HTTP is unaffected.
+
+## Key files
+
+- k3s bundled metrics-server
+
+## Secrets / config
+
+- none
+
+## Related workloads
+
+- [`coredns`](../coredns/)
+- [`traefik`](../traefik/)
+
+## See also
+
+- [Cluster DB inventory](../../databases/omv-cluster.md)
+- [Tailscale fabric](../../cluster/TAILSCALE-FABRIC.md)
+- [CLUSTER-MAP.md](../../../CLUSTER-MAP.md)

--- a/docs/pods/minio/README.md
+++ b/docs/pods/minio/README.md
@@ -1,0 +1,39 @@
+# `minio`
+
+> Part of [docs/pods](../README.md) — omv k3s workload atlas.
+
+## Identity
+
+| Field | Value |
+|-------|-------|
+| Kind | Deployment |
+| Namespace | `appflowy` |
+| Resource name | `minio` |
+| Hostname / DNS | (ClusterIP 9000/9001) |
+| Ports | 9000 S3 · 9001 console |
+| Role | S3-compatible object store for AppFlowy blobs. |
+
+## How cloudless.gr uses it
+
+**Not used by Next.js.** AppFlowy stores uploads here. Daily R2 mirror
+via `cronjob-appflowy-minio.yaml`. Operators: port-forward only if debugging.
+
+## Key files
+
+- `infrastructure/backup/cronjob-appflowy-minio.yaml`
+- `docs/databases/omv-cluster.md`
+
+## Secrets / config
+
+- `APPFLOWY_S3_*` in `appflowy-secrets`
+
+## Related workloads
+
+- [`appflowy-cloud`](../appflowy-cloud/)
+- [`appflowy-worker`](../appflowy-worker/)
+
+## See also
+
+- [Cluster DB inventory](../../databases/omv-cluster.md)
+- [Tailscale fabric](../../cluster/TAILSCALE-FABRIC.md)
+- [CLUSTER-MAP.md](../../../CLUSTER-MAP.md)

--- a/docs/pods/mosquitto/README.md
+++ b/docs/pods/mosquitto/README.md
@@ -1,0 +1,45 @@
+# `mosquitto`
+
+> Part of [docs/pods](../README.md) — omv k3s workload atlas.
+
+## Identity
+
+| Field | Value |
+|-------|-------|
+| Kind | Deployment |
+| Namespace | `monitoring` |
+| Resource name | `mosquitto` |
+| Hostname / DNS | `mosquitto.monitoring.svc.cluster.local` · NodePort 31883 |
+| Ports | 1883 |
+| Role | MQTT broker for homelab / ESP32 alerts. |
+
+## How cloudless.gr uses it
+
+Server-side MQTT client (`src/lib/mqtt.ts`): retained alert status for
+admin cluster chip; publish webhook; high severity can `notifyAdmin`.
+ESP32 / alert-api are primary publishers.
+
+## Key files
+
+- `src/lib/mqtt.ts`
+- `src/app/api/admin/cluster/mqtt-status/route.ts`
+- `src/app/api/webhooks/mqtt/publish/route.ts`
+- `infrastructure/esp32-watchdog/`
+
+## Secrets / config
+
+- `MQTT_BROKER_HOST`
+- `MQTT_BROKER_PORT`
+- `MQTT_USERNAME`
+- `MQTT_PASSWORD`
+
+## Related workloads
+
+- [`pi-alert-api`](../pi-alert-api/)
+- [`cloudless-app`](../cloudless-app/)
+
+## See also
+
+- [Cluster DB inventory](../../databases/omv-cluster.md)
+- [Tailscale fabric](../../cluster/TAILSCALE-FABRIC.md)
+- [CLUSTER-MAP.md](../../../CLUSTER-MAP.md)

--- a/docs/pods/n8n/README.md
+++ b/docs/pods/n8n/README.md
@@ -1,0 +1,45 @@
+# `n8n`
+
+> Part of [docs/pods](../README.md) — omv k3s workload atlas.
+
+## Identity
+
+| Field | Value |
+|-------|-------|
+| Kind | Deployment |
+| Namespace | `n8n` |
+| Resource name | `n8n` |
+| Hostname / DNS | n8n.cloudless.gr |
+| Ports | 5678 · NodePort 30900 |
+| Role | Workflow automation (SQLite on PVC). |
+
+## How cloudless.gr uses it
+
+Admin list/trigger/health/executions via `src/lib/n8n.ts`. Product hooks:
+lead enrich + newsletter nurture workflows triggered from EspoCRM/subscribe
+paths (`/api/webhooks/n8n/trigger`). CF Access + admin autologin.
+
+## Key files
+
+- `src/lib/n8n.ts`
+- `src/app/api/admin/n8n/**`
+- `src/app/api/webhooks/n8n/trigger/route.ts`
+- `infrastructure/n8n/`
+
+## Secrets / config
+
+- `N8N_API_URL`
+- `N8N_API_KEY`
+- `N8N_WORKFLOW_LEAD_ENRICH_ID`
+- `N8N_WORKFLOW_NEWSLETTER_NURTURE_ID`
+
+## Related workloads
+
+- [`espocrm`](../espocrm/)
+- [`cloudless-app`](../cloudless-app/)
+
+## See also
+
+- [Cluster DB inventory](../../databases/omv-cluster.md)
+- [Tailscale fabric](../../cluster/TAILSCALE-FABRIC.md)
+- [CLUSTER-MAP.md](../../../CLUSTER-MAP.md)

--- a/docs/pods/nginx/README.md
+++ b/docs/pods/nginx/README.md
@@ -1,0 +1,40 @@
+# `nginx`
+
+> Part of [docs/pods](../README.md) — omv k3s workload atlas.
+
+## Identity
+
+| Field | Value |
+|-------|-------|
+| Kind | Deployment |
+| Namespace | `appflowy` |
+| Resource name | `nginx` |
+| Hostname / DNS | appflowy.cloudless.gr |
+| Ports | NodePort 30810 |
+| Role | Edge reverse-proxy for the AppFlowy stack. |
+
+## How cloudless.gr uses it
+
+Terminates the public AppFlowy hostname and routes to web/cloud/admin.
+Next.js only sees `https://appflowy.cloudless.gr` (or CF Access).
+
+## Key files
+
+- `infrastructure/appflowy/`
+- CF tunnel ingress
+
+## Secrets / config
+
+- TLS via CF / tunnel
+
+## Related workloads
+
+- [`appflowy-web`](../appflowy-web/)
+- [`appflowy-cloud`](../appflowy-cloud/)
+- [`admin-frontend`](../admin-frontend/)
+
+## See also
+
+- [Cluster DB inventory](../../databases/omv-cluster.md)
+- [Tailscale fabric](../../cluster/TAILSCALE-FABRIC.md)
+- [CLUSTER-MAP.md](../../../CLUSTER-MAP.md)

--- a/docs/pods/ntfy/README.md
+++ b/docs/pods/ntfy/README.md
@@ -1,0 +1,45 @@
+# `ntfy`
+
+> Part of [docs/pods](../README.md) — omv k3s workload atlas.
+
+## Identity
+
+| Field | Value |
+|-------|-------|
+| Kind | Deployment |
+| Namespace | `ntfy` |
+| Resource name | `ntfy` |
+| Hostname / DNS | ntfy.cloudless.gr |
+| Ports | 80 · NodePort 30080 |
+| Role | Push notification server (phone alerts). |
+
+## How cloudless.gr uses it
+
+Optional admin push via `src/lib/ntfy.ts` when `ADMIN_PUSH_VIA_NTFY=1`
+(`notifyAdmin` / admin-alert webhook). Also used by Kuma bootstrap as an
+ntfy notification channel.
+
+## Key files
+
+- `src/lib/ntfy.ts`
+- `src/lib/admin-alerts.ts`
+- `src/app/api/webhooks/admin-alert/route.ts`
+- `infrastructure/ntfy/`
+
+## Secrets / config
+
+- `NTFY_BASE_URL`
+- `NTFY_TOPIC`
+- `NTFY_TOKEN`
+- `ADMIN_PUSH_VIA_NTFY`
+
+## Related workloads
+
+- [`cloudless-app`](../cloudless-app/)
+- [`uptime-kuma`](../uptime-kuma/)
+
+## See also
+
+- [Cluster DB inventory](../../databases/omv-cluster.md)
+- [Tailscale fabric](../../cluster/TAILSCALE-FABRIC.md)
+- [CLUSTER-MAP.md](../../../CLUSTER-MAP.md)

--- a/docs/pods/operator/README.md
+++ b/docs/pods/operator/README.md
@@ -1,0 +1,40 @@
+# `operator`
+
+> Part of [docs/pods](../README.md) — omv k3s workload atlas.
+
+## Identity
+
+| Field | Value |
+|-------|-------|
+| Kind | Deployment |
+| Namespace | `tailscale` |
+| Resource name | `operator` |
+| Hostname / DNS | (Tailscale operator) |
+| Ports | n/a |
+| Role | Tailscale Kubernetes Operator. |
+
+## How cloudless.gr uses it
+
+**Ops/dev fabric only.** Enables ProxyGroups / MagicDNS for kubectl and
+admin UIs. Next.js product code does not call Tailscale APIs.
+
+## Key files
+
+- `infrastructure/tailscale/`
+- `docs/cluster/TAILSCALE-FABRIC.md`
+
+## Secrets / config
+
+- Tailscale OAuth / auth keys (CI/MCP)
+
+## Related workloads
+
+- [`ingress`](../ingress/)
+- [`kube`](../kube/)
+- [`ts-k3s-cidrs`](../ts-k3s-cidrs/)
+
+## See also
+
+- [Cluster DB inventory](../../databases/omv-cluster.md)
+- [Tailscale fabric](../../cluster/TAILSCALE-FABRIC.md)
+- [CLUSTER-MAP.md](../../../CLUSTER-MAP.md)

--- a/docs/pods/pi-alert-api/README.md
+++ b/docs/pods/pi-alert-api/README.md
@@ -1,0 +1,42 @@
+# `alert-api`
+
+> Part of [docs/pods](../README.md) — omv k3s workload atlas.
+
+## Identity
+
+| Field | Value |
+|-------|-------|
+| Kind | External |
+| Namespace | `alert-manager / host` |
+| Resource name | `alert-api` |
+| Hostname / DNS | logs.cloudless.gr · LAN `192.168.1.128:30800` · in-cluster `alert-api.alert-manager.svc:8080` |
+| Ports | 8080 / NodePort 30800 |
+| Role | ESP32 / homelab alert API + websocket logs. |
+
+## How cloudless.gr uses it
+
+Admin ESP32 + ops monitor routes proxy here. Alertmanager / MQTT may fan
+into `/api/webhooks/admin-alert`. Not on the store/checkout path.
+
+## Key files
+
+- `src/app/api/admin/esp32/**`
+- `src/app/api/admin/ops/monitor/route.ts`
+- `infrastructure/pi-alert-api/`
+
+## Secrets / config
+
+- `ALERT_API_URL`
+- optional `NEXT_PUBLIC_ALERT_WS_URL`
+
+## Related workloads
+
+- [`alertmanager`](../alertmanager/)
+- [`ntfy`](../ntfy/)
+- [`cloudless-app`](../cloudless-app/)
+
+## See also
+
+- [Cluster DB inventory](../../databases/omv-cluster.md)
+- [Tailscale fabric](../../cluster/TAILSCALE-FABRIC.md)
+- [CLUSTER-MAP.md](../../../CLUSTER-MAP.md)

--- a/docs/pods/postgres/README.md
+++ b/docs/pods/postgres/README.md
@@ -1,0 +1,39 @@
+# `postgres`
+
+> Part of [docs/pods](../README.md) — omv k3s workload atlas.
+
+## Identity
+
+| Field | Value |
+|-------|-------|
+| Kind | Deployment |
+| Namespace | `appflowy` |
+| Resource name | `postgres` |
+| Hostname / DNS | (ClusterIP — forward `127.0.0.1:15432`) |
+| Ports | 5432 |
+| Role | Postgres 16 + pgvector for AppFlowy. |
+
+## How cloudless.gr uses it
+
+**Not used by Next.js.** SQLTools connection `omv · AppFlowy Postgres`.
+Daily `pg_dump` → R2. WAL-G sidecar may mirror to R2.
+
+## Key files
+
+- `docs/databases/omv-cluster.md`
+- `infrastructure/backup/cronjob-appflowy.yaml`
+
+## Secrets / config
+
+- `POSTGRES_PASSWORD` in `appflowy-secrets`
+
+## Related workloads
+
+- [`appflowy-cloud`](../appflowy-cloud/)
+- [`appflowy-worker`](../appflowy-worker/)
+
+## See also
+
+- [Cluster DB inventory](../../databases/omv-cluster.md)
+- [Tailscale fabric](../../cluster/TAILSCALE-FABRIC.md)
+- [CLUSTER-MAP.md](../../../CLUSTER-MAP.md)

--- a/docs/pods/postiz-postgres/README.md
+++ b/docs/pods/postiz-postgres/README.md
@@ -1,0 +1,37 @@
+# `postiz-postgres`
+
+> Part of [docs/pods](../README.md) — omv k3s workload atlas.
+
+## Identity
+
+| Field | Value |
+|-------|-------|
+| Kind | Deployment |
+| Namespace | `postiz` |
+| Resource name | `postiz-postgres` |
+| Hostname / DNS | (ClusterIP — forward `127.0.0.1:15433`) |
+| Ports | 5432 |
+| Role | Postgres 17 for Postiz. |
+
+## How cloudless.gr uses it
+
+**Not used by Next.js.** SQLTools `omv · Postiz Postgres`. Daily `pg_dump` → R2.
+
+## Key files
+
+- `docs/databases/omv-cluster.md`
+- `infrastructure/backup/cronjob-postiz.yaml`
+
+## Secrets / config
+
+- k8s `postiz-secrets`
+
+## Related workloads
+
+- [`postiz`](../postiz/)
+
+## See also
+
+- [Cluster DB inventory](../../databases/omv-cluster.md)
+- [Tailscale fabric](../../cluster/TAILSCALE-FABRIC.md)
+- [CLUSTER-MAP.md](../../../CLUSTER-MAP.md)

--- a/docs/pods/postiz-redis/README.md
+++ b/docs/pods/postiz-redis/README.md
@@ -1,0 +1,36 @@
+# `postiz-redis`
+
+> Part of [docs/pods](../README.md) — omv k3s workload atlas.
+
+## Identity
+
+| Field | Value |
+|-------|-------|
+| Kind | Deployment |
+| Namespace | `postiz` |
+| Resource name | `postiz-redis` |
+| Hostname / DNS | (ClusterIP — forward `127.0.0.1:16380`) |
+| Ports | 6379 |
+| Role | Redis 7 (AOF) for Postiz queues. |
+
+## How cloudless.gr uses it
+
+**Not used by Next.js.** Required for Postiz job processing.
+
+## Key files
+
+- `docs/databases/omv-cluster.md`
+
+## Secrets / config
+
+- k8s PVC `postiz-redis-data`
+
+## Related workloads
+
+- [`postiz`](../postiz/)
+
+## See also
+
+- [Cluster DB inventory](../../databases/omv-cluster.md)
+- [Tailscale fabric](../../cluster/TAILSCALE-FABRIC.md)
+- [CLUSTER-MAP.md](../../../CLUSTER-MAP.md)

--- a/docs/pods/postiz/README.md
+++ b/docs/pods/postiz/README.md
@@ -1,0 +1,48 @@
+# `postiz`
+
+> Part of [docs/pods](../README.md) — omv k3s workload atlas.
+
+## Identity
+
+| Field | Value |
+|-------|-------|
+| Kind | Deployment |
+| Namespace | `postiz` |
+| Resource name | `postiz` |
+| Hostname / DNS | postiz.cloudless.gr |
+| Ports | NodePort 30500 |
+| Role | Social media scheduler / publisher. |
+
+## How cloudless.gr uses it
+
+Admin Postiz UI + API proxy, blog auto-post (`postiz-blog`), webhooks → Slack,
+crons `postiz-sync` / `postiz-oauth-check`, workspace `postizGroupId`. Next talks
+HTTP API only (`POSTIZ_API_URL` + key).
+
+## Key files
+
+- `src/lib/postiz.ts`
+- `src/lib/postiz-blog.ts`
+- `src/lib/postiz-slack.ts`
+- `src/app/api/admin/postiz/**`
+- `src/app/api/webhooks/postiz/route.ts`
+- `src/app/api/cron/postiz-*`
+
+## Secrets / config
+
+- `POSTIZ_API_URL`
+- `POSTIZ_API_KEY`
+- `POSTIZ_WEBHOOK_SECRET`
+- `POSTIZ_SLACK_CHANNEL`
+
+## Related workloads
+
+- [`postiz-postgres`](../postiz-postgres/)
+- [`postiz-redis`](../postiz-redis/)
+- [`cloudless-app`](../cloudless-app/)
+
+## See also
+
+- [Cluster DB inventory](../../databases/omv-cluster.md)
+- [Tailscale fabric](../../cluster/TAILSCALE-FABRIC.md)
+- [CLUSTER-MAP.md](../../../CLUSTER-MAP.md)

--- a/docs/pods/prometheus/README.md
+++ b/docs/pods/prometheus/README.md
@@ -1,0 +1,41 @@
+# `prometheus-kube-prom-kube-prometheus-prometheus`
+
+> Part of [docs/pods](../README.md) — omv k3s workload atlas.
+
+## Identity
+
+| Field | Value |
+|-------|-------|
+| Kind | StatefulSet |
+| Namespace | `monitoring` |
+| Resource name | `prometheus-kube-prom-kube-prometheus-prometheus` |
+| Hostname / DNS | `…prometheus.monitoring.svc:9090` (ClusterIP) |
+| Ports | 9090 |
+| Role | Prometheus TSDB + scrape targets. |
+
+## How cloudless.gr uses it
+
+Next.js does not scrape Prometheus directly. Grafana datasources point here;
+admin PromQL goes through Grafana. Node/kube metrics feed cluster SLO dashboards.
+
+## Key files
+
+- `infrastructure/monitoring/`
+- `src/lib/grafana.ts` (datasource sync)
+
+## Secrets / config
+
+- none in app; scrape configs via Helm values
+
+## Related workloads
+
+- [`kube-prom-grafana`](../kube-prom-grafana/)
+- [`kube-prom-prometheus-node-exporter`](../kube-prom-prometheus-node-exporter/)
+- [`kube-prom-kube-state-metrics`](../kube-prom-kube-state-metrics/)
+- [`alertmanager`](../alertmanager/)
+
+## See also
+
+- [Cluster DB inventory](../../databases/omv-cluster.md)
+- [Tailscale fabric](../../cluster/TAILSCALE-FABRIC.md)
+- [CLUSTER-MAP.md](../../../CLUSTER-MAP.md)

--- a/docs/pods/redis/README.md
+++ b/docs/pods/redis/README.md
@@ -1,0 +1,37 @@
+# `redis`
+
+> Part of [docs/pods](../README.md) — omv k3s workload atlas.
+
+## Identity
+
+| Field | Value |
+|-------|-------|
+| Kind | Deployment |
+| Namespace | `appflowy` |
+| Resource name | `redis` |
+| Hostname / DNS | (ClusterIP — forward `127.0.0.1:16379`) |
+| Ports | 6379 |
+| Role | Redis 7 cache/queue for AppFlowy. |
+
+## How cloudless.gr uses it
+
+**Not used by Next.js.** Ephemeral (no PVC). Required for AppFlowy Cloud/worker.
+
+## Key files
+
+- `docs/databases/omv-cluster.md`
+
+## Secrets / config
+
+- none in app SSM
+
+## Related workloads
+
+- [`appflowy-cloud`](../appflowy-cloud/)
+- [`appflowy-worker`](../appflowy-worker/)
+
+## See also
+
+- [Cluster DB inventory](../../databases/omv-cluster.md)
+- [Tailscale fabric](../../cluster/TAILSCALE-FABRIC.md)
+- [CLUSTER-MAP.md](../../../CLUSTER-MAP.md)

--- a/docs/pods/traefik/README.md
+++ b/docs/pods/traefik/README.md
@@ -1,0 +1,42 @@
+# `traefik`
+
+> Part of [docs/pods](../README.md) — omv k3s workload atlas.
+
+## Identity
+
+| Field | Value |
+|-------|-------|
+| Kind | Deployment |
+| Namespace | `kube-system` |
+| Resource name | `traefik` |
+| Hostname / DNS | LAN Traefik UI / IngressRoute (e.g. :18080 / :18443) |
+| Ports | 80/443 + svclb DaemonSet on both nodes |
+| Role | k3s ingress controller + ServiceLB (`svclb-traefik-*`). |
+
+## How cloudless.gr uses it
+
+**Ops / LAN path.** Public traffic for cloudless.gr is primarily
+**Cloudflare Tunnel → NodePort**, not Traefik. Some IngressRoutes (Grafana,
+Postiz) may still use Traefik on the LAN. Next.js does not call Traefik APIs.
+
+## Key files
+
+- `infrastructure/monitoring/grafana-ingressroute.yaml`
+- `infrastructure/postiz/k8s/ingressroute.yaml`
+- `docs/pods/cloudflared/`
+
+## Secrets / config
+
+- none in app
+
+## Related workloads
+
+- [`cloudflared`](../cloudflared/)
+- [`kube-prom-grafana`](../kube-prom-grafana/)
+- [`coredns`](../coredns/)
+
+## See also
+
+- [Cluster DB inventory](../../databases/omv-cluster.md)
+- [Tailscale fabric](../../cluster/TAILSCALE-FABRIC.md)
+- [CLUSTER-MAP.md](../../../CLUSTER-MAP.md)

--- a/docs/pods/ts-k3s-cidrs/README.md
+++ b/docs/pods/ts-k3s-cidrs/README.md
@@ -1,0 +1,37 @@
+# `ts-k3s-cidrs-2cp9f`
+
+> Part of [docs/pods](../README.md) — omv k3s workload atlas.
+
+## Identity
+
+| Field | Value |
+|-------|-------|
+| Kind | StatefulSet |
+| Namespace | `tailscale` |
+| Resource name | `ts-k3s-cidrs-2cp9f` |
+| Hostname / DNS | subnet router |
+| Ports | Connector for 10.42/16 · 10.43/16 |
+| Role | Advertises pod/service CIDRs into the tailnet. |
+
+## How cloudless.gr uses it
+
+Enables reaching ClusterIPs (Meili, Postgres forwards, etc.) from Tailscale
+clients. No Next.js dependency beyond making operator debugging possible.
+
+## Key files
+
+- `docs/cluster/TAILSCALE-FABRIC.md`
+
+## Secrets / config
+
+- operator-managed
+
+## Related workloads
+
+- [`operator`](../operator/)
+
+## See also
+
+- [Cluster DB inventory](../../databases/omv-cluster.md)
+- [Tailscale fabric](../../cluster/TAILSCALE-FABRIC.md)
+- [CLUSTER-MAP.md](../../../CLUSTER-MAP.md)

--- a/docs/pods/uptime-kuma/README.md
+++ b/docs/pods/uptime-kuma/README.md
@@ -1,0 +1,46 @@
+# `uptime-kuma`
+
+> Part of [docs/pods](../README.md) — omv k3s workload atlas.
+
+## Identity
+
+| Field | Value |
+|-------|-------|
+| Kind | Deployment |
+| Namespace | `uptime-kuma` |
+| Resource name | `uptime-kuma` |
+| Hostname / DNS | kuma.cloudless.gr |
+| Ports | 3001 · NodePort 32501 |
+| Role | Uptime monitors + status page. |
+
+## How cloudless.gr uses it
+
+Ops visibility: `/admin/cluster` status-page summary (`src/lib/kuma.ts`).
+Kuma posts DOWN/UP to `/api/webhooks/kuma` → Slack (DNS flaps coalesced).
+Not on the customer purchase path.
+
+## Key files
+
+- `src/lib/kuma.ts`
+- `src/lib/kuma-dns-coalesce.ts`
+- `src/app/api/webhooks/kuma/route.ts`
+- `src/app/api/admin/cluster/kuma-status/route.ts`
+- `skills/uptime-kuma-operator/SKILL.md`
+
+## Secrets / config
+
+- `KUMA_BASE_URL`
+- `KUMA_API_KEY`
+- `KUMA_STATUS_PAGE_SLUG`
+- webhook `ADMIN_ALERT_SECRET`
+
+## Related workloads
+
+- [`kuma-slack-bridge`](../kuma-slack-bridge/)
+- [`cloudless-app`](../cloudless-app/)
+
+## See also
+
+- [Cluster DB inventory](../../databases/omv-cluster.md)
+- [Tailscale fabric](../../cluster/TAILSCALE-FABRIC.md)
+- [CLUSTER-MAP.md](../../../CLUSTER-MAP.md)


### PR DESCRIPTION
## Summary
- Add `docs/pods/` with one folder per live omv k3s workload (Deployments / StatefulSets / DaemonSets from `kubectl`, plus host `cloudflared`, `pi-alert-api`, `mosquitto`).
- Each folder documents identity, **how cloudless.gr uses the pod**, key files, secrets, and related workloads.
- Link the atlas from `docs/README.md`.

## Test plan
- [x] Spot-check `docs/pods/README.md` and `docs/pods/espocrm/README.md`
- [ ] Confirm new Deployments get a matching folder when they appear on omv


Made with [Cursor](https://cursor.com)