### PR TITLE
fix(ci): stop bot update-branch CI stalls

### DIFF
--- a/.github/workflows/pr-automerge.md
+++ b/.github/workflows/pr-automerge.md
@@ -22,3 +22,11 @@ before GitHub completes the auto-merge. Repo setting **Allow auto-merge** must s
 ## Opt out
 
 Add label `no-automerge` (or `do-not-merge` / `wip`) on the PR.
+
+## Bot update-branch loop
+
+`update-branch` merges performed as `github-actions[bot]` can put subsequent
+PR workflow runs into `action_required` (awaiting approval). The arm job
+**skips** update-branch when `github.actor == github-actions[bot]`. Prefer a
+repo secret `GITHUB_PAT` (classic PAT with `repo` scope) so refresh merges are
+attributed to a user and CI runs without approval gates.

--- a/.github/workflows/pr-automerge.yml
+++ b/.github/workflows/pr-automerge.yml
@@ -63,8 +63,11 @@ jobs:
     steps:
       - name: Update branch with main (strict protection)
         id: update
+        # Skip when this synchronize was caused by our own bot merge — otherwise
+        # update-branch storms cancel CI and leave runs in action_required.
+        if: github.actor != 'github-actions[bot]'
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_PAT || secrets.GITHUB_TOKEN }}
           GH_REPO: ${{ github.repository }}
           PR: ${{ github.event.pull_request.number }}
         run: |
@@ -85,10 +88,14 @@ jobs:
             echo "conflict=false" >> "$GITHUB_OUTPUT"
           fi
 
+      - name: Note bot synchronize (no update-branch)
+        if: github.actor == 'github-actions[bot]'
+        run: echo "Skipping update-branch for github-actions[bot] push (avoids CI action_required loop)"
+
       - name: Label + comment on merge conflicts
         if: steps.update.outputs.conflict == 'true'
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_PAT || secrets.GITHUB_TOKEN }}
           GH_REPO: ${{ github.repository }}
           PR: ${{ github.event.pull_request.number }}
         run: |
@@ -117,9 +124,9 @@ jobs:
           )"
 
       - name: Enable squash auto-merge
-        if: steps.update.outputs.conflict != 'true'
+        if: steps.update.outcome != 'failure' && steps.update.outputs.conflict != 'true'
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_PAT || secrets.GITHUB_TOKEN }}
           GH_REPO: ${{ github.repository }}
           PR_URL: ${{ github.event.pull_request.html_url }}
           PR: ${{ github.event.pull_request.number }}
@@ -139,7 +146,7 @@ jobs:
     steps:
       - name: Update + re-arm open PRs to main
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_PAT || secrets.GITHUB_TOKEN }}
           GH_REPO: ${{ github.repository }}
         run: |
           set -euo pipefail
@@ -190,7 +197,7 @@ jobs:
     steps:
       - name: Update + arm PR
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_PAT || secrets.GITHUB_TOKEN }}
           GH_REPO: ${{ github.repository }}
           PR: ${{ inputs.pr_number }}
         run: |


### PR DESCRIPTION
## Summary
- Bot `update-branch` merges were putting required CI into `action_required`, so auto-merge stayed BLOCKED forever.
- Skip update-branch on `github-actions[bot]` synchronizes; prefer `GITHUB_PAT` when set.

## Test plan
- [ ] New human PR still gets update-branch + auto-merge armed
- [ ] After main push refresh, open PRs do not spam merge commits that cancel CI

Made with [Cursor](https://cursor.com)