### PR TITLE
docs: D1 auth + pi-origin GHA cron routing (#1437)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,12 +15,12 @@ This version has breaking changes — APIs, conventions, and file structure may 
 - **3D:** @react-three/fiber + @react-three/drei + three.js
 - **Animation:** GSAP (ScrollTrigger) + Lenis smooth scroll
 - **Command palette:** cmdk
-- **Auth:** AWS Cognito + next-auth v5
+- **Auth:** Cloudflare D1 (`user-auth-db`) + opaque session cookies (next-auth helpers retained where useful)
 - **Payments:** Stripe (webhooks, checkout)
 - **Email:** AWS SES
-- **Secrets:** AWS SSM Parameter Store (no .env files in prod)
+- **Secrets:** AWS SSM Parameter Store (Pi) / Wrangler secrets (Workers); no `.env` files in prod
 - **Testing:** Vitest + @testing-library/react + jsdom
-- **Deployment target:** AWS (serverless)
+- **Deployment target:** Pi k3s (primary) + Cloudflare Workers proxy (`pi-origin`)
 
 ## Design System (Cyberpunk × Quantum Devflow)
 
@@ -63,7 +63,7 @@ src/
 │   │   │   ├── [id]/page.tsx    # Product detail + JSON-LD
 │   │   │   └── success/         # Order confirmation
 │   │   ├── contact/             # Contact form (SES + Slack + EspoCRM + Notion)
-│   │   ├── auth/                # Login · Signup · Forgot Password (Cognito + next-auth)
+│   │   ├── auth/                # Login · Signup · Forgot Password (D1 email/password)
 │   │   ├── dashboard/           # Customer portal (auth-protected, cyan accent)
 │   │   │   ├── profile/         # Edit name, company, phone
 │   │   │   ├── purchases/       # Stripe order history
@@ -77,7 +77,7 @@ src/
 │   │       ├── notion/          # Notion DB explorer
 │   │       ├── notifications/   # Slack test panel
 │   │       ├── settings/        # App config viewer
-│   │       └── users/           # Cognito user management
+│   │       └── users/           # D1 user management / promote-to-admin
 │   └── api/
 │       ├── contact/             # POST → SES + Slack + EspoCRM + Notion
 │       ├── checkout/            # POST → Stripe Checkout Session
@@ -108,7 +108,7 @@ src/
 │           ├── notion/          # Blog/docs/tasks/projects/submissions/search
 │           ├── ops/errors/      # Sentry issues
 │           ├── orders/          # Stripe orders summary
-│           └── users/           # Cognito user list
+│           └── users/           # D1 user list / promote
 │
 ├── components/
 │   ├── Navbar.tsx · Footer.tsx
@@ -125,15 +125,17 @@ src/
 │       ├── CartButton.tsx · AddToCartButton.tsx · ProductIcon.tsx
 │
 ├── context/
-│   ├── AuthContext.tsx           # Auth state (next-auth session): signIn/signOut, admin detection, profile
+│   ├── AuthContext.tsx           # Auth state (D1 session cookie): signIn/signOut, admin detection, profile
 │   ├── CartContext.tsx           # Cart (useReducer, in-memory)
 │   └── CookieConsentContext.tsx
 │
 ├── lib/                         # Server + shared utilities (see docs/ARCHITECTURE.md §9)
 │   ├── ssm-config.ts            # SSM secrets loader (5-min TTL, fails fast on required keys)
 │   ├── integrations.ts          # isConfigured() guards for all optional integrations
-│   ├── api-auth.ts              # requireAuth() / requireAdmin() — OIDC JWKS verification (Cognito)
-│   ├── auth.ts                  # next-auth v5 config — Cognito
+│   ├── api-auth.ts              # requireAuth() / requireAdmin() — D1 opaque session (cookie or Bearer)
+│   ├── auth-d1.ts               # D1 user/session/password/lockout helpers
+│   ├── auth-middleware.ts       # Thin shim re-exporting api-auth (compat)
+│   ├── auth.ts                  # next-auth helpers + D1 session wiring
 │   ├── email.ts                 # SES: sendEmail, sendOrderConfirmation, notifyTeam
 │   ├── ses-suppression.ts       # SES suppression list management
 │   ├── stripe.ts                # Stripe client, product/session helpers
@@ -164,7 +166,7 @@ src/
 │   ├── server-locale.ts         # getServerLocale() — reads NEXT_LOCALE cookie server-side
 │   ├── use-locale.ts            # useCurrentLocale() — client hook
 │   ├── locale-defaults.ts       # DEFAULT_LOCALE = 'en-IE' · DEFAULT_CURRENCY = 'EUR'
-│   ├── fetch-with-auth.ts       # Adds next-auth idToken as Bearer header to client-side API calls
+│   ├── fetch-with-auth.ts       # Adds session Bearer header to client-side API calls
 │   ├── format-price.ts          # Currency formatter (imports from locale-defaults)
 │   ├── validation.ts            # isValidEmail() and other validators
 │   └── escape-html.ts           # HTML sanitiser for email bodies
@@ -195,45 +197,45 @@ __tests__/
 └── service-worker.test.tsx  # SW registration + push notification tests
 ```
 
-## Authentication (Cognito + next-auth v5)
+## Authentication (Cloudflare D1)
 
 ```mermaid
 sequenceDiagram
     participant U as User
     participant App as Next.js Client
-    participant KC as Cognito (Hosted UI)
+    participant API as /api/auth/*
+    participant D1 as Cloudflare D1 (user-auth-db)
 
-    U->>App: Click "Sign in"
-    App->>KC: Authorization Code + PKCE redirect
-    KC-->>U: Hosted login / registration UI
-    U->>KC: Enter credentials
-    KC-->>App: /api/auth/callback/cognito
-    App->>KC: Exchange code for tokens
-    KC-->>App: access_token + id_token + refresh_token
-    App->>App: Decode id_token, check groups claim
-    alt admin group
+    U->>App: Open /auth/login
+    App->>App: Email/password form
+    U->>App: Enter credentials
+    App->>API: POST /api/auth/login
+    API->>D1: Verify PBKDF2 hash + roles
+    D1-->>API: User record
+    API-->>App: Set opaque session_token cookie
+    App-->>U: Redirect
+    alt admin role
         App->>U: Show /admin panel
     else regular user
         App->>U: Show /dashboard
     end
 ```
 
-- **Provider:** AWS Cognito (Hosted UI) — the sole provider since the 2026-06 migration
-- **Env vars required:** `COGNITO_ISSUER` + `COGNITO_CLIENT_ID` + `COGNITO_CLIENT_SECRET` + `COGNITO_DOMAIN` + `AUTH_SECRET`. See `.env.example`
-- **Admin group:** `admin` — checked via the JWT `cognito:groups` claim
-- **AuthProvider:** Wraps entire app in `layout.tsx`; exposes `signIn`/`signOut`/`useAuth()` via `src/context/AuthContext.tsx` (delegates to next-auth `signIn`/`signOut`)
-- **Route protection:** Server-side via `src/proxy.ts` middleware (before the page renders) + client-side layout guards
-  - `/dashboard/*` → redirects to `/auth/login` if not authenticated
-  - `/admin/*` → redirects to `/dashboard` if not in admin group, `/auth/login` if not authenticated
-- **Token refresh:** next-auth transparently refreshes expired access tokens at the provider's token endpoint
-- **Logout:** RP-Initiated Logout — terminates the Cognito SSO session, not just the local cookie
-- **Form UX:** All auth forms include `autoComplete` attributes (`email`, `current-password`, `new-password`) for password manager integration
-- **Navbar integration:** Shows "Sign In" button when logged out, user avatar dropdown when logged in (Dashboard, Admin Panel if admin, Sign Out)
-- **Color coding:** Cyan for user-facing auth, magenta for admin
-- **i18n:** All pages fully translated in 3 locales (en, el, fr)
-- **User personalization:** AuthUser interface includes `name`, `company`, `phone`, `preferences` (theme, language, notifications)
-  - `updateProfile()` and `updatePreferences()` methods exposed via `useAuth()` hook
-  - Dashboard overview shows time-based greeting with user's name + live stats
+- **Store:** Cloudflare D1 `user-auth-db` — users, sessions, roles, password hashes (PBKDF2). Cognito is retired.
+- **Session:** Opaque `session_token` cookie (or Bearer) resolved by `src/lib/api-auth.ts` via `auth-d1.ts`. Default 30 days; 60 days with "remember me".
+- **Admin:** Membership in D1 `roles` → projected as `groups: ["admin"]`. Promote via `/api/admin/users/promote` (or admin Users UI).
+- **AuthProvider:** `src/context/AuthContext.tsx` — `signIn` / `signOut` / `useAuth()` against the D1 login/session APIs.
+- **Route protection:** `src/proxy.ts` (before render) + layout guards
+  - `/dashboard/*` → `/auth/login` if unauthenticated
+  - `/admin/*` → `/dashboard` if not admin, `/auth/login` if unauthenticated
+  - Locale prefixes (`/en/…`) are stripped before the auth check
+- **Password rules:** ≥8 chars with upper, lower, digit, and special character. Lockout after 5 failed attempts in 15 minutes.
+- **Email verification:** Activation token + OTP via SES (`auth-activation.ts` / `sendActivationEmail`).
+- **Form UX:** `autoComplete` on auth forms (`email`, `current-password`, `new-password`).
+- **Navbar:** Sign In when logged out; avatar menu (Dashboard, Admin if admin, Sign Out) when logged in.
+- **Color coding:** Cyan for user-facing auth, magenta for admin.
+- **i18n:** Auth pages translated (en / el / fr / de where enabled).
+- **Profile:** `name`, `company`, `phone`, `preferences` (theme, language, notifications) via `updateProfile()` / `updatePreferences()`.
 
 ## SEO
 
@@ -274,13 +276,13 @@ graph TB
         Headers --> Checkout["Checkout: server-side price lookup"]
         Headers --> Stripe["Stripe WH: signature verification"]
         Headers --> SlackV["Slack: HMAC-SHA256 verification"]
-        Headers --> Auth["Auth: JWT + Cognito groups"]
+        Headers --> Auth["Auth: D1 session + admin role"]
     end
 
     subgraph Secrets["Secret Management"]
         SSM["SSM Parameter Store"] -->|getConfig| Routes["API Routes"]
         SSM -->|throws on missing| Required["STRIPE_SECRET_KEY etc"]
-        Amplify["configureAmplify()"] -->|throws on missing| CogVars["COGNITO env vars"]
+        D1Auth["AUTH_DB / SESSION_SECRET"] -->|getAuthDbFromEnv| AuthRoutes["Auth + requireAuth"]
     end
 
     subgraph Output["Output Security"]
@@ -293,7 +295,7 @@ graph TB
 - **Headers:** X-Content-Type-Options, X-Frame-Options, Referrer-Policy, Permissions-Policy, Strict-Transport-Security (HSTS with preload).
 - **Checkout validation:** Server-side product lookup by ID; client cannot set prices.
 - **SSM secrets:** `getConfig()` throws on missing required secrets (`STRIPE_SECRET_KEY`, `STRIPE_WEBHOOK_SECRET`). Validates SES email fields.
-- **Amplify config:** `configureAmplify()` throws if `NEXT_PUBLIC_COGNITO_*` env vars are missing (no hardcoded fallbacks).
+- **Auth DB:** `getAuthDbFromEnv()` requires a live D1 binding (Workers) or local D1 HTTP / SQLite path in dev. Missing `AUTH_DB` fails closed on primary auth paths.
 - **Email bodies:** HTML-escaped via `escapeHtml()` to prevent injection.
 
 ## Internationalization (i18n)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -319,7 +319,7 @@ D1 `roles` table, surfaced as `groups: ["admin"]` and checked by `api-auth.ts`
 - **`NEXT_PUBLIC_*` vars** are baked into the Next.js client bundle at Docker build time as `--build-arg`. They are NOT available as runtime env vars — changes require a full image rebuild.
 - **SSM config** (API keys, Notion DB IDs, etc.) is fetched at runtime by the app via `getIntegrationsAsync()` using the `pi-standby-aws-creds` k8s Secret.
 
-**GitHub Secrets needed:** `AWS_DEPLOY_ROLE_ARN`, `NEXT_PUBLIC_SITE_URL`, `NEXT_PUBLIC_COGNITO_USER_POOL_ID`, `NEXT_PUBLIC_COGNITO_CLIENT_ID`, `NEXT_PUBLIC_HUBSPOT_PORTAL_ID`, `NEXT_PUBLIC_SENTRY_DSN`, `NEXT_PUBLIC_META_PIXEL_ID`, `NEXT_PUBLIC_LINKEDIN_PARTNER_ID`
+**GitHub Secrets needed:** `AWS_DEPLOY_ROLE_ARN`, `NEXT_PUBLIC_SITE_URL`, `NEXT_PUBLIC_SENTRY_DSN`, `NEXT_PUBLIC_META_PIXEL_ID`, `NEXT_PUBLIC_LINKEDIN_PARTNER_ID` (plus Wrangler/D1 bind for `AUTH_DB` on the Pi/Workers path — Cognito `NEXT_PUBLIC_COGNITO_*` build-args are retired)
 
 ## CI Runner Failover
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,7 +13,7 @@ These require access outside GitHub and cannot be automated from a cloud session
 | -------------------------------- | ------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | `OMV_SSH_KEY`                    | **SET** ✅          | Key for `tbaltzakis@omv` (host omv, user tbaltzakis). SSH workflows updated to `PI_USER: "tbaltzakis"`. k3s watchdog (`Restart=always`) deployed 2026-06-02T18:56Z — auto-restart active.                                                                                                                                                                                                                                                                                                                                                                          |
 | ESP32 page content               | **PARTIAL RESTORE** | Full content requires Notion UI: open page → ••• → Page history → restore pre-15:19 UTC 2026-06-02. ESP32 Devices + Telemetry databases (IDs confirmed correct, integration has access) are **empty** — no data was ever populated there to restore.                                                                                                                                                                                                                                                                                                               |
-| Admin password                   | **N/A**             | Auth is Cognito (PR #677, 2026-06-08). Manage admin users in the Cognito User Pool console; there is no separate IdP admin to bootstrap.                                                                                                                                                                                                                                                                                                                                                                                                                           |
+| Admin password                   | **N/A**             | Auth is Cloudflare D1 (not Cognito). Promote admins via `/api/admin/users/promote` or the admin Users UI against `user-auth-db`.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  |
 | Cloudflare HA LB                 | **TOKEN NEEDED**    | `setup-cloudflare-lb.yml` (merged PR #548) needs `CLOUDFLARE_API_TOKEN` — use the `cloudflare-token-doctor` skill, mint a token with the full scope set (skill Stage 1), then `gh workflow run store-cloudflare-token.yml -f cloudflare_token=… -f apply=true`.                                                                                                                                                                                                                                                                                                    |
 | Cloudflare Email Obfuscation fix | **TOKEN NEEDED**    | `cloudflare-disable-email-obfuscation.yml` (merged PR #745) fixes React #418 hydration errors. Same token as HA LB above.                                                                                                                                                                                                                                                                                                                                                                                                                                          |
 | Cloudflare infra MCP token       | **NEEDS ROTATION**  | Existing `CLOUDFLARE_API_TOKEN` in cloud-session secrets is invalid (every `mcp__cloudless-infra__cloudflare_*` tool returns 401). Use the `cloudflare-token-doctor` skill: Stage 1 mint, Stage 2 store (SSM + session secret), Stage 3 run `bash scripts/cf-token-smoketest.sh`, Stage 4 verify with `mcp__cloudless-infra__cloudflare_list_tokens()`. CI verify available via `gh workflow run verify-cloudflare-token.yml`. SSM half **is set ✅** as of 2026-06-13; only the Cowork session-secret store half is pending — see `cowork-session-secrets` skill. |
@@ -297,19 +297,15 @@ See `infrastructure/espocrm/README.md` for the full deploy + verify runbook.
 
 ## Authentication
 
-Auth is **Cognito**, full-stop (PR #677, 2026-06-08). There is no Keycloak, no
-JVM heap, no realm config to maintain. App admin = membership in the Cognito
-group `admin`, surfaced via the `cognito:groups` claim and checked by
-`api-auth.ts` `requireAdmin`. Manage users in the Cognito User Pool console.
-The `[...nextauth]` route uses the Cognito provider; `NEXT_PUBLIC_COGNITO_*`
-client IDs are baked at build time.
+Auth is **Cloudflare D1** (`user-auth-db`) — email/password with PBKDF2 hashes and
+opaque `session_token` cookies. Cognito / Keycloak are gone. App admin = row in the
+D1 `roles` table, surfaced as `groups: ["admin"]` and checked by `api-auth.ts`
+`requireAdmin`. Promote via `/api/admin/users/promote`. Session resolution lives in
+`src/lib/auth-d1.ts` + `src/lib/api-auth.ts` (cookie or Bearer).
 
-- **CloudWatch `SERVERLESS-APP_MAIN-Errors`** (custom metric
-  `CloudlessApp/ServerlessErrors`) is a **CloudWatch Logs metric filter** on the
-  Lambda log group — NOT Sentry. It counts next-auth
-  `[auth][error] Configuration` lines, which fire on a bare **GET** to
-  `/api/auth/signin/<provider>` (real login POSTs and is fine). Threshold
-  is 1 error / 5 min (very noisy). The alarm/filter are not in this repo.
+- Legacy CloudWatch metric filters that counted next-auth Cognito
+  `[auth][error] Configuration` lines are obsolete noise if still present in AWS;
+  do not expand them. Prefer app/Sentry signals on the Pi path.
 
 ## Deployment to Pi
 
@@ -538,7 +534,7 @@ which automates Stages 0-3 from the Pi.
 
 - **URL:** https://cloudless.gr
 - **Stack:** Next.js (App Router), deployed on Pi5 k3s cluster + Vercel
-- **Auth:** Cognito
+- **Auth:** Cloudflare D1 (`user-auth-db`)
 - **CMS:** Notion databases
 
 ### Available Skill Categories

--- a/README.md
+++ b/README.md
@@ -49,11 +49,11 @@ Key features of the auth system:
 
 - **Email/password authentication** — credentials verified against D1 `user-auth-db` with PBKDF2 secure hashing.
 - **Session management** — server-side sessions stored in D1 with configurable expiry (30 days default, 60 days with "remember me").
-- **Admin detection** — server-side via `roles` table in D1. Admin routes are checked by `src/lib/auth-middleware.ts` before rendering.
+- **Admin detection** — server-side via `roles` table in D1. Admin/API routes use `src/lib/api-auth.ts` (`requireAdmin` / `requireAuth`); `auth-middleware.ts` is a thin compat shim.
 - **Password security** — minimum 8 characters with mixed case, numbers, and symbols. Account lockout after 5 failed attempts in 15 minutes.
 - **Email verification** — OTP via Cloudflare Email binding on registration.
 - Route protection is **server-side** via middleware (all unauthenticated requests to `/dashboard` and `/admin` are redirected to login before the page renders) and additionally client-side via layout guards. Locale-prefixed routes (e.g. `/en/dashboard`, `/el/admin/orders`) are normalized before authorization checks.
-- Theme preference (`dark` / `light` / `system`) is exposed via a navbar `ThemeSwitcher` (popover on desktop, inline radios on mobile) and the dashboard settings form. Anonymous visitors persist to `localStorage["cloudless-theme-pref"]`; signed-in users also sync to `user.preferences.theme`. Selection priority: admin path (locked dark) → user preference → localStorage → route default. Cross-tab sync via the `storage` event. See `docs/design-system-v2.md` § "Theme switcher".
+- Theme preference (`dark` / `light` / `system`) is exposed via a navbar `ThemeSwitcher` (popover on desktop, inline radios on mobile) and the dashboard settings form. Anonymous visitors persist to `localStorage["cloudless-theme-pref"]`; signed-in users also sync to `user.preferences.theme`. Selection priority: admin path (locked dark) → user preference → localStorage → route default. Cross-tab sync via the `storage` event. See `docs/product/design-system-v2.md` § "Theme switcher".
 
 ## Architecture
 

--- a/workers/pi-origin-proxy/README.md
+++ b/workers/pi-origin-proxy/README.md
@@ -28,3 +28,17 @@ User → Cloudflare → cloudless2 (this Worker, <50 KiB)
 Idempotent methods (`GET`/`HEAD`/`OPTIONS`) retry once on network failure or
 upstream `502` (Tunnel flaps). Failures still return `502` with
 `x-served-by: pi-tunnel-proxy` or `pi-tunnel-proxy-error`.
+
+## GHA cron callers (Bot Fight bypass)
+
+GitHub Actions runners hitting `https://cloudless.gr/api/cron/*` often get a
+**Cloudflare Bot Fight Mode** interstitial (`403`) before the app can check
+`CRON_SECRET`. Cron workflows therefore call the **tunnel hostname** instead:
+
+```text
+https://pi-origin.cloudless.gr/api/cron/...
+```
+
+That path is Tunnel → Pi NodePort (this Worker is not on that hop). The app
+still enforces `CRON_SECRET`. See `platform-crons.yml`, `postiz-crons.yml`, and
+`linkedin-poll.yml` (`BASE_URL` / `SITE_ORIGIN` defaulting to pi-origin).


### PR DESCRIPTION
## Summary
- Update `AGENTS.md` / `CLAUDE.md` from Cognito to Cloudflare D1 email/password sessions (`api-auth` + `auth-d1`).
- Document GHA cron Bot Fight bypass via `https://pi-origin.cloudless.gr` in `workers/pi-origin-proxy/README.md`.
- Fix README admin-check pointer (`api-auth`, not the compat shim) and design-system doc path.
- Closes #1437 (Documentation Updater could not push the protected-file change unsigned).

## Test plan
- [ ] Skim auth section in AGENTS.md against `src/lib/api-auth.ts` / `auth-d1.ts`
- [ ] Confirm cron workflows still use `BASE_URL`/`SITE_ORIGIN` → pi-origin
- [ ] Close #1437 after merge


Made with [Cursor](https://cursor.com)