### PR TITLE
fix(auth): username on signup + getAuthDbFromEnv for reset/session

### DIFF
--- a/src/app/api/admin/auth-audit/route.ts
+++ b/src/app/api/admin/auth-audit/route.ts
@@ -12,7 +12,7 @@
  */
 
 import { type NextRequest, NextResponse } from "next/server";
-import { type AuthDatabase } from "@/lib/auth-d1";
+import { getAuthDbFromEnv } from "@/lib/auth-d1";
 import { requireAdmin } from "@/lib/api-auth";
 import { queryAuditLog, getAuditLogCount, type AuditAction } from "@/lib/auth-audit";
 
@@ -22,12 +22,10 @@ export async function GET(request: NextRequest) {
   const auth = await requireAdmin(request);
   if (!auth.ok) return auth.response;
 
-  // Get D1 binding
-  const env = process.env as unknown as { AUTH_DB: AuthDatabase };
-  if (!env.AUTH_DB) {
+  const db = getAuthDbFromEnv();
+  if (!db) {
     return NextResponse.json({ error: "Auth not configured" }, { status: 503 });
   }
-  const db = env.AUTH_DB;
 
   const searchParams = request.nextUrl.searchParams;
   const action = searchParams.get("action") as AuditAction | undefined;

--- a/src/app/api/auth/reset-confirm/route.ts
+++ b/src/app/api/auth/reset-confirm/route.ts
@@ -1,21 +1,9 @@
 import { NextRequest, NextResponse } from "next/server";
-import { consumePasswordResetToken, type AuthDatabase } from "@/lib/auth-d1";
+import { consumePasswordResetToken, getAuthDbFromEnv } from "@/lib/auth-d1";
 import { rateLimit, getClientIp } from "@/lib/rate-limit";
 
-interface Env {
-  AUTH_DB: AuthDatabase;
-}
-
-function getDb(_request: NextRequest): AuthDatabase | null {
-  const env = process.env as unknown as Env;
-  if (!env.AUTH_DB) {
-    return null;
-  }
-  return env.AUTH_DB;
-}
-
 export async function POST(req: NextRequest) {
-  const db = getDb(req);
+  const db = getAuthDbFromEnv();
   if (!db) {
     return NextResponse.json({ error: "Auth not configured" }, { status: 503 });
   }

--- a/src/app/api/auth/reset-password/route.ts
+++ b/src/app/api/auth/reset-password/route.ts
@@ -1,22 +1,10 @@
 import { NextRequest, NextResponse } from "next/server";
-import { createPasswordResetToken, type AuthDatabase } from "@/lib/auth-d1";
+import { createPasswordResetToken, getAuthDbFromEnv } from "@/lib/auth-d1";
 import { rateLimit, getClientIp } from "@/lib/rate-limit";
 import { sendPasswordResetEmail } from "@/lib/email";
 
-interface Env {
-  AUTH_DB: AuthDatabase;
-}
-
-function getDb(_request: NextRequest): AuthDatabase | null {
-  const env = process.env as unknown as Env;
-  if (!env.AUTH_DB) {
-    return null;
-  }
-  return env.AUTH_DB;
-}
-
 export async function POST(req: NextRequest) {
-  const db = getDb(req);
+  const db = getAuthDbFromEnv();
   if (!db) {
     return NextResponse.json({ error: "Auth not configured" }, { status: 503 });
   }

--- a/src/app/api/auth/sandbox/route.ts
+++ b/src/app/api/auth/sandbox/route.ts
@@ -11,28 +11,21 @@ import { NextRequest, NextResponse } from "next/server";
 import {
   authenticateUser,
   createUser,
+  getAuthDbFromEnv,
   getUserBySession,
   isAdmin,
   validatePasswordStrength,
   validateSessionSecret,
-  type AuthDatabase,
 } from "@/lib/auth-d1";
 import { rateLimit, getClientIp } from "@/lib/rate-limit";
 
-interface Env {
-  AUTH_DB: AuthDatabase;
-  NODE_ENV?: string;
-}
-
-function getDb(_request: NextRequest): AuthDatabase | null {
-  const env = process.env as unknown as Env;
-  return env.AUTH_DB ?? null;
+function getDb(_request: NextRequest) {
+  return getAuthDbFromEnv();
 }
 
 // Check if sandbox is enabled (only in development)
 function isSandboxEnabled(): boolean {
-  const env = process.env as unknown as Env;
-  return env.NODE_ENV === "development";
+  return process.env.NODE_ENV === "development";
 }
 
 export async function GET(req: NextRequest) {

--- a/src/app/api/auth/session-d1/route.ts
+++ b/src/app/api/auth/session-d1/route.ts
@@ -1,16 +1,8 @@
 import { NextRequest, NextResponse } from "next/server";
-import { getUserBySession, deleteSession, isAdmin, type AuthDatabase } from "@/lib/auth-d1";
+import { getUserBySession, deleteSession, isAdmin, getAuthDbFromEnv } from "@/lib/auth-d1";
 
-interface Env {
-  AUTH_DB: AuthDatabase;
-}
-
-function getDb(_request: NextRequest): AuthDatabase | null {
-  const env = process.env as unknown as Env;
-  if (!env.AUTH_DB) {
-    return null;
-  }
-  return env.AUTH_DB;
+function getDb(_request: NextRequest) {
+  return getAuthDbFromEnv();
 }
 
 export async function GET(req: NextRequest) {

--- a/src/lib/auth-d1.ts
+++ b/src/lib/auth-d1.ts
@@ -232,29 +232,17 @@ export async function createUser(
   const id = crypto.randomUUID();
   const passwordHash = await hashPassword(password);
   const now = Math.floor(Date.now() / 1000);
-  // Production D1 (`schema.sql`) requires NOT NULL UNIQUE `username`; migrations/0001
-  // omitted it. Prefer email-as-username; fall back if the column is absent.
-  const username = email;
 
   try {
-    try {
-      await db
-        .prepare(
-          "INSERT INTO user (id, username, email, name, password_hash, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?)"
-        )
-        .bind(id, username, email, name || null, passwordHash, now, now)
-        .run();
-    } catch (withUsernameErr) {
-      await db
-        .prepare(
-          "INSERT INTO user (id, email, name, password_hash, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?)"
-        )
-        .bind(id, email, name || null, passwordHash, now, now)
-        .run();
-      if (process.env.NODE_ENV !== "production") {
-        console.warn("[auth-d1] createUser: username column missing, used email-only insert", withUsernameErr);
-      }
-    }
+    // Production D1 requires NOT NULL UNIQUE `username` (email used as username).
+    // Legacy local DBs from migrations/0001 omit the column — insertUserRow falls back.
+    await insertUserRow(db, {
+      id,
+      email,
+      name: name || null,
+      passwordHash,
+      now,
+    });
 
     // Default to 'user' role
     await db.prepare("INSERT INTO user_role (user_id, role) VALUES (?, ?)").bind(id, "user").run();
@@ -265,6 +253,34 @@ export async function createUser(
   } catch (err) {
     console.error("[auth-d1] createUser failed:", err);
     return { error: "Failed to create user" };
+  }
+}
+
+/** Insert user row; prefer schema with `username`, fall back to email-only. */
+async function insertUserRow(
+  db: AuthDatabase,
+  row: {
+    id: string;
+    email: string;
+    name: string | null;
+    passwordHash: string;
+    now: number;
+  }
+): Promise<void> {
+  try {
+    await db
+      .prepare(
+        "INSERT INTO user (id, username, email, name, password_hash, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?)"
+      )
+      .bind(row.id, row.email, row.email, row.name, row.passwordHash, row.now, row.now)
+      .run();
+  } catch {
+    await db
+      .prepare(
+        "INSERT INTO user (id, email, name, password_hash, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?)"
+      )
+      .bind(row.id, row.email, row.name, row.passwordHash, row.now, row.now)
+      .run();
   }
 }
 

--- a/src/lib/auth-d1.ts
+++ b/src/lib/auth-d1.ts
@@ -232,14 +232,29 @@ export async function createUser(
   const id = crypto.randomUUID();
   const passwordHash = await hashPassword(password);
   const now = Math.floor(Date.now() / 1000);
+  // Production D1 (`schema.sql`) requires NOT NULL UNIQUE `username`; migrations/0001
+  // omitted it. Prefer email-as-username; fall back if the column is absent.
+  const username = email;
 
   try {
-    await db
-      .prepare(
-        "INSERT INTO user (id, email, name, password_hash, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?)"
-      )
-      .bind(id, email, name || null, passwordHash, now, now)
-      .run();
+    try {
+      await db
+        .prepare(
+          "INSERT INTO user (id, username, email, name, password_hash, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?)"
+        )
+        .bind(id, username, email, name || null, passwordHash, now, now)
+        .run();
+    } catch (withUsernameErr) {
+      await db
+        .prepare(
+          "INSERT INTO user (id, email, name, password_hash, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?)"
+        )
+        .bind(id, email, name || null, passwordHash, now, now)
+        .run();
+      if (process.env.NODE_ENV !== "production") {
+        console.warn("[auth-d1] createUser: username column missing, used email-only insert", withUsernameErr);
+      }
+    }
 
     // Default to 'user' role
     await db.prepare("INSERT INTO user_role (user_id, role) VALUES (?, ?)").bind(id, "user").run();
@@ -247,7 +262,8 @@ export async function createUser(
     return {
       user: { id, email, name, password_hash: passwordHash, created_at: now, updated_at: now },
     };
-  } catch {
+  } catch (err) {
+    console.error("[auth-d1] createUser failed:", err);
     return { error: "Failed to create user" };
   }
 }


### PR DESCRIPTION
## Summary
- Production D1 `user` requires `username` (NOT NULL); `createUser` omitted it → register returned 500 after the D1 HTTP bridge landed.
- Wire reset-password, reset-confirm, sandbox, session-d1, and admin auth-audit through `getAuthDbFromEnv()` so Pi uses the same D1 HTTP path as login/register.

## Test plan
- [x] Prod login no longer returns 503 Auth not configured (`dbConnected: true`)
- [ ] After deploy: register with a new email returns 2xx (not Failed to create user)
- [ ] Forgot-password / reset-confirm no longer 503 on Pi

Made with [Cursor](https://cursor.com)