### PR TITLE
fix(auth): single username INSERT, drop getDb shims

### DIFF
--- a/migrations/0001-auth-schema.sql
+++ b/migrations/0001-auth-schema.sql
@@ -5,6 +5,7 @@
 -- Stores user profile data including preferences
 CREATE TABLE IF NOT EXISTS user (
   id TEXT NOT NULL PRIMARY KEY,
+  username TEXT NOT NULL UNIQUE,
   email TEXT NOT NULL UNIQUE,
   name TEXT,
   company TEXT,

--- a/src/app/api/admin/auth-audit/route.ts
+++ b/src/app/api/admin/auth-audit/route.ts
@@ -12,7 +12,7 @@
  */
 
 import { type NextRequest, NextResponse } from "next/server";
-import { type AuthDatabase } from "@/lib/auth-d1";
+import { getAuthDbFromEnv } from "@/lib/auth-d1";
 import { requireAdmin } from "@/lib/api-auth";
 import { queryAuditLog, getAuditLogCount, type AuditAction } from "@/lib/auth-audit";
 
@@ -22,12 +22,10 @@ export async function GET(request: NextRequest) {
   const auth = await requireAdmin(request);
   if (!auth.ok) return auth.response;
 
-  // Get D1 binding
-  const env = process.env as unknown as { AUTH_DB: AuthDatabase };
-  if (!env.AUTH_DB) {
+  const db = getAuthDbFromEnv();
+  if (!db) {
     return NextResponse.json({ error: "Auth not configured" }, { status: 503 });
   }
-  const db = env.AUTH_DB;
 
   const searchParams = request.nextUrl.searchParams;
   const action = searchParams.get("action") as AuditAction | undefined;

--- a/src/app/api/auth/reset-confirm/route.ts
+++ b/src/app/api/auth/reset-confirm/route.ts
@@ -1,21 +1,9 @@
 import { NextRequest, NextResponse } from "next/server";
-import { consumePasswordResetToken, type AuthDatabase } from "@/lib/auth-d1";
+import { consumePasswordResetToken, getAuthDbFromEnv } from "@/lib/auth-d1";
 import { rateLimit, getClientIp } from "@/lib/rate-limit";
 
-interface Env {
-  AUTH_DB: AuthDatabase;
-}
-
-function getDb(_request: NextRequest): AuthDatabase | null {
-  const env = process.env as unknown as Env;
-  if (!env.AUTH_DB) {
-    return null;
-  }
-  return env.AUTH_DB;
-}
-
 export async function POST(req: NextRequest) {
-  const db = getDb(req);
+  const db = getAuthDbFromEnv();
   if (!db) {
     return NextResponse.json({ error: "Auth not configured" }, { status: 503 });
   }

--- a/src/app/api/auth/reset-password/route.ts
+++ b/src/app/api/auth/reset-password/route.ts
@@ -1,22 +1,10 @@
 import { NextRequest, NextResponse } from "next/server";
-import { createPasswordResetToken, type AuthDatabase } from "@/lib/auth-d1";
+import { createPasswordResetToken, getAuthDbFromEnv } from "@/lib/auth-d1";
 import { rateLimit, getClientIp } from "@/lib/rate-limit";
 import { sendPasswordResetEmail } from "@/lib/email";
 
-interface Env {
-  AUTH_DB: AuthDatabase;
-}
-
-function getDb(_request: NextRequest): AuthDatabase | null {
-  const env = process.env as unknown as Env;
-  if (!env.AUTH_DB) {
-    return null;
-  }
-  return env.AUTH_DB;
-}
-
 export async function POST(req: NextRequest) {
-  const db = getDb(req);
+  const db = getAuthDbFromEnv();
   if (!db) {
     return NextResponse.json({ error: "Auth not configured" }, { status: 503 });
   }

--- a/src/app/api/auth/sandbox/route.ts
+++ b/src/app/api/auth/sandbox/route.ts
@@ -11,28 +11,21 @@ import { NextRequest, NextResponse } from "next/server";
 import {
   authenticateUser,
   createUser,
+  getAuthDbFromEnv,
   getUserBySession,
   isAdmin,
   validatePasswordStrength,
   validateSessionSecret,
-  type AuthDatabase,
 } from "@/lib/auth-d1";
 import { rateLimit, getClientIp } from "@/lib/rate-limit";
 
-interface Env {
-  AUTH_DB: AuthDatabase;
-  NODE_ENV?: string;
-}
-
-function getDb(_request: NextRequest): AuthDatabase | null {
-  const env = process.env as unknown as Env;
-  return env.AUTH_DB ?? null;
+function getDb(_request: NextRequest) {
+  return getAuthDbFromEnv();
 }
 
 // Check if sandbox is enabled (only in development)
 function isSandboxEnabled(): boolean {
-  const env = process.env as unknown as Env;
-  return env.NODE_ENV === "development";
+  return process.env.NODE_ENV === "development";
 }
 
 export async function GET(req: NextRequest) {

--- a/src/app/api/auth/sandbox/route.ts
+++ b/src/app/api/auth/sandbox/route.ts
@@ -19,10 +19,6 @@ import {
 } from "@/lib/auth-d1";
 import { rateLimit, getClientIp } from "@/lib/rate-limit";
 
-function getDb(_request: NextRequest) {
-  return getAuthDbFromEnv();
-}
-
 // Check if sandbox is enabled (only in development)
 function isSandboxEnabled(): boolean {
   return process.env.NODE_ENV === "development";
@@ -34,7 +30,7 @@ export async function GET(req: NextRequest) {
     return NextResponse.json({ error: "Auth sandbox is disabled in production" }, { status: 403 });
   }
 
-  const db = getDb(req);
+  const db = getAuthDbFromEnv();
   if (!db) {
     // In test/dev we treat missing D1 bindings as "service unavailable"
     // rather than a missing route/contract (the Playwright tests accept
@@ -101,7 +97,7 @@ export async function POST(req: NextRequest) {
   const ipRl = rateLimit(`auth-sandbox:ip:${getClientIp(req)}`, 5, 60_000);
   if (!ipRl.ok) return ipRl.response;
 
-  const db = getDb(req);
+  const db = getAuthDbFromEnv();
   if (!db) {
     return NextResponse.json({ error: "Auth not configured" }, { status: 503 });
   }

--- a/src/app/api/auth/session-d1/route.ts
+++ b/src/app/api/auth/session-d1/route.ts
@@ -1,12 +1,8 @@
 import { NextRequest, NextResponse } from "next/server";
 import { getUserBySession, deleteSession, isAdmin, getAuthDbFromEnv } from "@/lib/auth-d1";
 
-function getDb(_request: NextRequest) {
-  return getAuthDbFromEnv();
-}
-
 export async function GET(req: NextRequest) {
-  const db = getDb(req);
+  const db = getAuthDbFromEnv();
   if (!db) {
     return NextResponse.json({ user: null });
   }
@@ -39,7 +35,7 @@ export async function GET(req: NextRequest) {
 }
 
 export async function DELETE(req: NextRequest) {
-  const db = getDb(req);
+  const db = getAuthDbFromEnv();
   if (!db) {
     return NextResponse.json({ ok: true });
   }

--- a/src/app/api/auth/session-d1/route.ts
+++ b/src/app/api/auth/session-d1/route.ts
@@ -1,16 +1,8 @@
 import { NextRequest, NextResponse } from "next/server";
-import { getUserBySession, deleteSession, isAdmin, type AuthDatabase } from "@/lib/auth-d1";
+import { getUserBySession, deleteSession, isAdmin, getAuthDbFromEnv } from "@/lib/auth-d1";
 
-interface Env {
-  AUTH_DB: AuthDatabase;
-}
-
-function getDb(_request: NextRequest): AuthDatabase | null {
-  const env = process.env as unknown as Env;
-  if (!env.AUTH_DB) {
-    return null;
-  }
-  return env.AUTH_DB;
+function getDb(_request: NextRequest) {
+  return getAuthDbFromEnv();
 }
 
 export async function GET(req: NextRequest) {

--- a/src/lib/auth-d1.ts
+++ b/src/lib/auth-d1.ts
@@ -234,15 +234,13 @@ export async function createUser(
   const now = Math.floor(Date.now() / 1000);
 
   try {
-    // Production D1 requires NOT NULL UNIQUE `username` (email used as username).
-    // Legacy local DBs from migrations/0001 omit the column — insertUserRow falls back.
-    await insertUserRow(db, {
-      id,
-      email,
-      name: name || null,
-      passwordHash,
-      now,
-    });
+    // Production + migrated local D1 require NOT NULL UNIQUE `username` (email used as username).
+    await db
+      .prepare(
+        "INSERT INTO user (id, username, email, name, password_hash, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?)"
+      )
+      .bind(id, email, email, name || null, passwordHash, now, now)
+      .run();
 
     // Default to 'user' role
     await db.prepare("INSERT INTO user_role (user_id, role) VALUES (?, ?)").bind(id, "user").run();
@@ -253,34 +251,6 @@ export async function createUser(
   } catch (err) {
     console.error("[auth-d1] createUser failed:", err);
     return { error: "Failed to create user" };
-  }
-}
-
-/** Insert user row; prefer schema with `username`, fall back to email-only. */
-async function insertUserRow(
-  db: AuthDatabase,
-  row: {
-    id: string;
-    email: string;
-    name: string | null;
-    passwordHash: string;
-    now: number;
-  }
-): Promise<void> {
-  try {
-    await db
-      .prepare(
-        "INSERT INTO user (id, username, email, name, password_hash, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?)"
-      )
-      .bind(row.id, row.email, row.email, row.name, row.passwordHash, row.now, row.now)
-      .run();
-  } catch {
-    await db
-      .prepare(
-        "INSERT INTO user (id, email, name, password_hash, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?)"
-      )
-      .bind(row.id, row.email, row.name, row.passwordHash, row.now, row.now)
-      .run();
   }
 }
 

--- a/src/lib/auth-d1.ts
+++ b/src/lib/auth-d1.ts
@@ -232,29 +232,17 @@ export async function createUser(
   const id = crypto.randomUUID();
   const passwordHash = await hashPassword(password);
   const now = Math.floor(Date.now() / 1000);
-  // Production D1 (`schema.sql`) requires NOT NULL UNIQUE `username`; migrations/0001
-  // omitted it. Prefer email-as-username; fall back if the column is absent.
-  const username = email;
 
   try {
-    try {
-      await db
-        .prepare(
-          "INSERT INTO user (id, username, email, name, password_hash, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?)"
-        )
-        .bind(id, username, email, name || null, passwordHash, now, now)
-        .run();
-    } catch (withUsernameErr) {
-      await db
-        .prepare(
-          "INSERT INTO user (id, email, name, password_hash, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?)"
-        )
-        .bind(id, email, name || null, passwordHash, now, now)
-        .run();
-      if (process.env.NODE_ENV !== "production") {
-        console.warn("[auth-d1] createUser: username column missing, used email-only insert", withUsernameErr);
-      }
-    }
+    // Production D1 requires NOT NULL UNIQUE `username` (email used as username).
+    // Legacy local DBs from migrations/0001 omit the column — insertUserRow falls back.
+    await insertUserRow(db, {
+      id,
+      email,
+      name: name || null,
+      passwordHash,
+      now,
+    });
 
     // Default to 'user' role
     await db.prepare("INSERT INTO user_role (user_id, role) VALUES (?, ?)").bind(id, "user").run();
@@ -265,6 +253,34 @@ export async function createUser(
   } catch (err) {
     console.error("[auth-d1] createUser failed:", err);
     return { error: "Failed to create user" };
+  }
+}
+
+/** Insert user row; prefer schema with `username`, fall back to email-only. */
+async function insertUserRow(
+  db: AuthDatabase,
+  row: {
+    id: string;
+    email: string;
+    name: string | null;
+    passwordHash: string;
+    now: number;
+  }
+): Promise<void> {
+  try {
+    await db
+      .prepare(
+        "INSERT INTO user (id, username, email, name, password_hash, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?)"
+      )
+      .bind(row.id, row.email, row.email, row.name, row.passwordHash, row.now, row.now)
+      .run();
+  } catch {
+    await db
+      .prepare(
+        "INSERT INTO user (id, email, name, password_hash, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?)"
+      )
+      .bind(row.id, row.email, row.name, row.passwordHash, row.now, row.now)
+      .run();
   }
 }
 

--- a/src/lib/auth-d1.ts
+++ b/src/lib/auth-d1.ts
@@ -232,14 +232,29 @@ export async function createUser(
   const id = crypto.randomUUID();
   const passwordHash = await hashPassword(password);
   const now = Math.floor(Date.now() / 1000);
+  // Production D1 (`schema.sql`) requires NOT NULL UNIQUE `username`; migrations/0001
+  // omitted it. Prefer email-as-username; fall back if the column is absent.
+  const username = email;
 
   try {
-    await db
-      .prepare(
-        "INSERT INTO user (id, email, name, password_hash, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?)"
-      )
-      .bind(id, email, name || null, passwordHash, now, now)
-      .run();
+    try {
+      await db
+        .prepare(
+          "INSERT INTO user (id, username, email, name, password_hash, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?)"
+        )
+        .bind(id, username, email, name || null, passwordHash, now, now)
+        .run();
+    } catch (withUsernameErr) {
+      await db
+        .prepare(
+          "INSERT INTO user (id, email, name, password_hash, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?)"
+        )
+        .bind(id, email, name || null, passwordHash, now, now)
+        .run();
+      if (process.env.NODE_ENV !== "production") {
+        console.warn("[auth-d1] createUser: username column missing, used email-only insert", withUsernameErr);
+      }
+    }
 
     // Default to 'user' role
     await db.prepare("INSERT INTO user_role (user_id, role) VALUES (?, ?)").bind(id, "user").run();
@@ -247,7 +262,8 @@ export async function createUser(
     return {
       user: { id, email, name, password_hash: passwordHash, created_at: now, updated_at: now },
     };
-  } catch {
+  } catch (err) {
+    console.error("[auth-d1] createUser failed:", err);
     return { error: "Failed to create user" };
   }
 }


### PR DESCRIPTION
## Summary
Follow-up to #1474:
- Always `INSERT` with `username` (= email); remove try/catch dual-path that Sonar flagged for duplication/maintainability.
- Update `migrations/0001-auth-schema.sql` so fresh local D1 DBs include `username`.
- Inline `getAuthDbFromEnv()` in `session-d1` / sandbox (drop no-op `getDb` wrappers).

## Test plan
- [x] `vitest` auth-register + auth-context
- [ ] Local: apply migrations / recreate D1 if an old local DB lacks `username`
- [ ] Prod register still succeeds (column already present)


Made with [Cursor](https://cursor.com)