### PR TITLE
fix(auth): scope reset-token UPDATE + single username INSERT

### DIFF
--- a/migrations/0001-auth-schema.sql
+++ b/migrations/0001-auth-schema.sql
@@ -5,6 +5,7 @@
 -- Stores user profile data including preferences
 CREATE TABLE IF NOT EXISTS user (
   id TEXT NOT NULL PRIMARY KEY,
+  username TEXT NOT NULL UNIQUE,
   email TEXT NOT NULL UNIQUE,
   name TEXT,
   company TEXT,

--- a/src/app/api/auth/sandbox/route.ts
+++ b/src/app/api/auth/sandbox/route.ts
@@ -19,10 +19,6 @@ import {
 } from "@/lib/auth-d1";
 import { rateLimit, getClientIp } from "@/lib/rate-limit";
 
-function getDb(_request: NextRequest) {
-  return getAuthDbFromEnv();
-}
-
 // Check if sandbox is enabled (only in development)
 function isSandboxEnabled(): boolean {
   return process.env.NODE_ENV === "development";
@@ -34,7 +30,7 @@ export async function GET(req: NextRequest) {
     return NextResponse.json({ error: "Auth sandbox is disabled in production" }, { status: 403 });
   }
 
-  const db = getDb(req);
+  const db = getAuthDbFromEnv();
   if (!db) {
     // In test/dev we treat missing D1 bindings as "service unavailable"
     // rather than a missing route/contract (the Playwright tests accept
@@ -101,7 +97,7 @@ export async function POST(req: NextRequest) {
   const ipRl = rateLimit(`auth-sandbox:ip:${getClientIp(req)}`, 5, 60_000);
   if (!ipRl.ok) return ipRl.response;
 
-  const db = getDb(req);
+  const db = getAuthDbFromEnv();
   if (!db) {
     return NextResponse.json({ error: "Auth not configured" }, { status: 503 });
   }

--- a/src/app/api/auth/sandbox/route.ts
+++ b/src/app/api/auth/sandbox/route.ts
@@ -16,53 +16,147 @@ import {
   isAdmin,
   validatePasswordStrength,
   validateSessionSecret,
+  type AuthDatabase,
 } from "@/lib/auth-d1";
 import { rateLimit, getClientIp } from "@/lib/rate-limit";
 
-// Check if sandbox is enabled (only in development)
+const AUTH_NOT_CONFIGURED = { error: "Auth not configured" } as const;
+const EMAIL_PASSWORD_REQUIRED = { error: "email and password required" } as const;
+
 function isSandboxEnabled(): boolean {
   return process.env.NODE_ENV === "development";
 }
 
-export async function GET(req: NextRequest) {
-  // Only allow in development mode
-  if (!isSandboxEnabled()) {
-    return NextResponse.json({ error: "Auth sandbox is disabled in production" }, { status: 403 });
-  }
+function sandboxDisabledResponse(): NextResponse {
+  return NextResponse.json({ error: "Auth sandbox is disabled in production" }, { status: 403 });
+}
 
+function requireSandboxDb(): AuthDatabase | NextResponse {
   const db = getAuthDbFromEnv();
   if (!db) {
-    // In test/dev we treat missing D1 bindings as "service unavailable"
-    // rather than a missing route/contract (the Playwright tests accept
-    // 503 when AUTH_DB isn't configured).
-    return NextResponse.json({ error: "Auth not configured" }, { status: 503 });
+    return NextResponse.json(AUTH_NOT_CONFIGURED, { status: 503 });
+  }
+  return db;
+}
+
+function strField(payload: Record<string, unknown> | undefined, key: string): string {
+  const value = payload?.[key];
+  return typeof value === "string" ? value : "";
+}
+
+async function handleTestPassword(
+  action: string,
+  payload: Record<string, unknown> | undefined
+): Promise<NextResponse> {
+  const password = strField(payload, "password");
+  const result = validatePasswordStrength(password);
+  return NextResponse.json({ action, password: "***", ...result });
+}
+
+async function handleTestLogin(
+  action: string,
+  db: AuthDatabase,
+  payload: Record<string, unknown> | undefined
+): Promise<NextResponse> {
+  const email = strField(payload, "email").toLowerCase().trim();
+  const password = strField(payload, "password");
+  if (!email || !password) {
+    return NextResponse.json(EMAIL_PASSWORD_REQUIRED, { status: 400 });
   }
 
-  // Check SESSION_SECRET
-  const secretCheck = validateSessionSecret();
+  const result = await authenticateUser(db, email, password);
+  if (result.error) {
+    return NextResponse.json({ action, error: result.error }, { status: 401 });
+  }
+  return NextResponse.json({
+    action,
+    user: { email: result.user?.email },
+    session: { expiresAt: result.session?.expires_at },
+  });
+}
 
-  // Return sandbox status and available actions
+async function handleTestRegister(
+  action: string,
+  db: AuthDatabase,
+  payload: Record<string, unknown> | undefined
+): Promise<NextResponse> {
+  const email = strField(payload, "email").toLowerCase().trim();
+  const password = strField(payload, "password");
+  const fullName = strField(payload, "fullName") || undefined;
+  if (!email || !password) {
+    return NextResponse.json(EMAIL_PASSWORD_REQUIRED, { status: 400 });
+  }
+
+  const strengthCheck = validatePasswordStrength(password);
+  if (!strengthCheck.valid) {
+    return NextResponse.json({ action, error: strengthCheck.error }, { status: 400 });
+  }
+
+  const result = await createUser(db, email, password, fullName);
+  if (result.error === "User already exists") {
+    return NextResponse.json({ action, message: "User already exists" });
+  }
+  if (result.error) {
+    return NextResponse.json({ action, error: result.error }, { status: 500 });
+  }
+  return NextResponse.json({
+    action,
+    user: { id: result.user?.id, email: result.user?.email },
+  });
+}
+
+async function handleCheckSession(
+  action: string,
+  db: AuthDatabase,
+  req: NextRequest
+): Promise<NextResponse> {
+  const sessionId = req.cookies.get("session_token")?.value;
+  if (!sessionId) {
+    return NextResponse.json({ action, user: null, message: "No session cookie" });
+  }
+
+  const user = await getUserBySession(db, sessionId);
+  if (!user) {
+    const response = NextResponse.json({ action, user: null, message: "Session expired" });
+    response.cookies.delete("session_token");
+    return response;
+  }
+
+  const admin = await isAdmin(db, user.id);
+  return NextResponse.json({
+    action,
+    user: {
+      id: user.id,
+      email: user.email,
+      name: user.name,
+      isAdmin: admin,
+    },
+  });
+}
+
+export async function GET(_req: NextRequest) {
+  if (!isSandboxEnabled()) return sandboxDisabledResponse();
+
+  const dbOrErr = requireSandboxDb();
+  if (dbOrErr instanceof NextResponse) {
+    // Playwright accepts 503 when AUTH_DB isn't configured.
+    return dbOrErr;
+  }
+
   return NextResponse.json({
     enabled: true,
-    sessionSecret: secretCheck,
+    sessionSecret: validateSessionSecret(),
     actions: [
       {
         method: "POST",
         path: "/api/auth/sandbox",
-        body: {
-          action: "test-password",
-          password: "string",
-        },
+        body: { action: "test-password", password: "string" },
         description: "Test password strength validation",
       },
       {
         method: "POST",
         path: "/api/auth/sandbox",
-        body: {
-          action: "test-login",
-          email: "string",
-          password: "string",
-        },
+        body: { action: "test-login", email: "string", password: "string" },
         description: "Test login credentials",
       },
       {
@@ -79,9 +173,7 @@ export async function GET(req: NextRequest) {
       {
         method: "POST",
         path: "/api/auth/sandbox",
-        body: {
-          action: "check-session",
-        },
+        body: { action: "check-session" },
         description: "Check current session cookie",
       },
     ],
@@ -89,18 +181,14 @@ export async function GET(req: NextRequest) {
 }
 
 export async function POST(req: NextRequest) {
-  // Only allow in development mode
-  if (!isSandboxEnabled()) {
-    return NextResponse.json({ error: "Auth sandbox is disabled in production" }, { status: 403 });
-  }
+  if (!isSandboxEnabled()) return sandboxDisabledResponse();
 
   const ipRl = rateLimit(`auth-sandbox:ip:${getClientIp(req)}`, 5, 60_000);
   if (!ipRl.ok) return ipRl.response;
 
-  const db = getAuthDbFromEnv();
-  if (!db) {
-    return NextResponse.json({ error: "Auth not configured" }, { status: 503 });
-  }
+  const dbOrErr = requireSandboxDb();
+  if (dbOrErr instanceof NextResponse) return dbOrErr;
+  const db = dbOrErr;
 
   let action: string | undefined;
   let payload: Record<string, unknown> | undefined;
@@ -117,87 +205,14 @@ export async function POST(req: NextRequest) {
   }
 
   switch (action) {
-    case "test-password": {
-      const password = typeof payload?.password === "string" ? payload.password : "";
-      const result = validatePasswordStrength(password);
-      return NextResponse.json({
-        action,
-        password: "***",
-        ...result,
-      });
-    }
-
-    case "test-login": {
-      const email = typeof payload?.email === "string" ? payload.email.toLowerCase().trim() : "";
-      const password = typeof payload?.password === "string" ? payload.password : "";
-
-      if (!email || !password) {
-        return NextResponse.json({ error: "email and password required" }, { status: 400 });
-      }
-
-      const result = await authenticateUser(db, email, password);
-      if (result.error) {
-        return NextResponse.json({ action, error: result.error }, { status: 401 });
-      }
-      return NextResponse.json({
-        action,
-        user: { email: result.user?.email },
-        session: { expiresAt: result.session?.expires_at },
-      });
-    }
-
-    case "test-register": {
-      const email = typeof payload?.email === "string" ? payload.email.toLowerCase().trim() : "";
-      const password = typeof payload?.password === "string" ? payload.password : "";
-      const fullName = typeof payload?.fullName === "string" ? payload.fullName : undefined;
-
-      if (!email || !password) {
-        return NextResponse.json({ error: "email and password required" }, { status: 400 });
-      }
-
-      const strengthCheck = validatePasswordStrength(password);
-      if (!strengthCheck.valid) {
-        return NextResponse.json({ action, error: strengthCheck.error }, { status: 400 });
-      }
-
-      const result = await createUser(db, email, password, fullName);
-      if (result.error === "User already exists") {
-        return NextResponse.json({ action, message: "User already exists" });
-      }
-      if (result.error) {
-        return NextResponse.json({ action, error: result.error }, { status: 500 });
-      }
-      return NextResponse.json({
-        action,
-        user: { id: result.user?.id, email: result.user?.email },
-      });
-    }
-
-    case "check-session": {
-      const sessionId = req.cookies.get("session_token")?.value;
-      if (!sessionId) {
-        return NextResponse.json({ action, user: null, message: "No session cookie" });
-      }
-
-      const user = await getUserBySession(db, sessionId);
-      if (!user) {
-        const response = NextResponse.json({ action, user: null, message: "Session expired" });
-        response.cookies.delete("session_token");
-        return response;
-      }
-
-      const admin = await isAdmin(db, user.id);
-      return NextResponse.json({
-        action,
-        user: {
-          id: user.id,
-          email: user.email,
-          name: user.name,
-          isAdmin: admin,
-        },
-      });
-    }
-
+    case "test-password":
+      return handleTestPassword(action, payload);
+    case "test-login":
+      return handleTestLogin(action, db, payload);
+    case "test-register":
+      return handleTestRegister(action, db, payload);
+    case "check-session":
+      return handleCheckSession(action, db, req);
     default:
       return NextResponse.json({ error: `Unknown action: ${action}` }, { status: 400 });
   }

--- a/src/app/api/auth/session-d1/route.ts
+++ b/src/app/api/auth/session-d1/route.ts
@@ -1,12 +1,8 @@
 import { NextRequest, NextResponse } from "next/server";
 import { getUserBySession, deleteSession, isAdmin, getAuthDbFromEnv } from "@/lib/auth-d1";
 
-function getDb(_request: NextRequest) {
-  return getAuthDbFromEnv();
-}
-
 export async function GET(req: NextRequest) {
-  const db = getDb(req);
+  const db = getAuthDbFromEnv();
   if (!db) {
     return NextResponse.json({ user: null });
   }
@@ -39,7 +35,7 @@ export async function GET(req: NextRequest) {
 }
 
 export async function DELETE(req: NextRequest) {
-  const db = getDb(req);
+  const db = getAuthDbFromEnv();
   if (!db) {
     return NextResponse.json({ ok: true });
   }

--- a/src/lib/auth-d1.ts
+++ b/src/lib/auth-d1.ts
@@ -242,15 +242,12 @@ export async function createUser(
       .bind(id, email, email, name || null, passwordHash, now, now)
       .run();
 
-    // Default to 'user' role
     await db.prepare("INSERT INTO user_role (user_id, role) VALUES (?, ?)").bind(id, "user").run();
 
     return {
       user: { id, email, name, password_hash: passwordHash, created_at: now, updated_at: now },
     };
-  } catch (err) {
-    const message = err instanceof Error ? err.message : String(err);
-    console.error("[auth-d1] createUser failed:", message);
+  } catch {
     return { error: "Failed to create user" };
   }
 }
@@ -414,16 +411,22 @@ export async function createPasswordResetToken(
 
   const token = generateResetToken();
   const expiresAt = Math.floor(Date.now() / 1000) + RESET_TOKEN_EXPIRY_SECONDS;
+  await storePasswordResetToken(db, user.id, token, expiresAt);
+  return { token };
+}
 
-  // Store reset token on this user only (never broadcast to every row).
+async function storePasswordResetToken(
+  db: AuthDatabase,
+  userId: string,
+  token: string,
+  expiresAt: number
+): Promise<void> {
   await db
     .prepare(
       "UPDATE user SET preferences_json = json_set(COALESCE(preferences_json, '{}'), '$.reset_token', ?, '$.reset_expires', ?) WHERE id = ?"
     )
-    .bind(token, expiresAt, user.id)
+    .bind(token, expiresAt, userId)
     .run();
-
-  return { token };
 }
 
 export async function consumePasswordResetToken(

--- a/src/lib/auth-d1.ts
+++ b/src/lib/auth-d1.ts
@@ -234,15 +234,13 @@ export async function createUser(
   const now = Math.floor(Date.now() / 1000);
 
   try {
-    // Production D1 requires NOT NULL UNIQUE `username` (email used as username).
-    // Legacy local DBs from migrations/0001 omit the column — insertUserRow falls back.
-    await insertUserRow(db, {
-      id,
-      email,
-      name: name || null,
-      passwordHash,
-      now,
-    });
+    // Production + migrated local D1 require NOT NULL UNIQUE `username` (email used as username).
+    await db
+      .prepare(
+        "INSERT INTO user (id, username, email, name, password_hash, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?)"
+      )
+      .bind(id, email, email, name || null, passwordHash, now, now)
+      .run();
 
     // Default to 'user' role
     await db.prepare("INSERT INTO user_role (user_id, role) VALUES (?, ?)").bind(id, "user").run();
@@ -251,36 +249,9 @@ export async function createUser(
       user: { id, email, name, password_hash: passwordHash, created_at: now, updated_at: now },
     };
   } catch (err) {
-    console.error("[auth-d1] createUser failed:", err);
+    const message = err instanceof Error ? err.message : String(err);
+    console.error("[auth-d1] createUser failed:", message);
     return { error: "Failed to create user" };
-  }
-}
-
-/** Insert user row; prefer schema with `username`, fall back to email-only. */
-async function insertUserRow(
-  db: AuthDatabase,
-  row: {
-    id: string;
-    email: string;
-    name: string | null;
-    passwordHash: string;
-    now: number;
-  }
-): Promise<void> {
-  try {
-    await db
-      .prepare(
-        "INSERT INTO user (id, username, email, name, password_hash, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?)"
-      )
-      .bind(row.id, row.email, row.email, row.name, row.passwordHash, row.now, row.now)
-      .run();
-  } catch {
-    await db
-      .prepare(
-        "INSERT INTO user (id, email, name, password_hash, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?)"
-      )
-      .bind(row.id, row.email, row.name, row.passwordHash, row.now, row.now)
-      .run();
   }
 }
 
@@ -444,12 +415,12 @@ export async function createPasswordResetToken(
   const token = generateResetToken();
   const expiresAt = Math.floor(Date.now() / 1000) + RESET_TOKEN_EXPIRY_SECONDS;
 
-  // Store reset token in user table (overwriting previous)
+  // Store reset token on this user only (never broadcast to every row).
   await db
     .prepare(
-      "UPDATE user SET preferences_json = json_set(COALESCE(preferences_json, '{}'), '$.reset_token', ?, '$.reset_expires', ?)"
+      "UPDATE user SET preferences_json = json_set(COALESCE(preferences_json, '{}'), '$.reset_token', ?, '$.reset_expires', ?) WHERE id = ?"
     )
-    .bind(token, expiresAt)
+    .bind(token, expiresAt, user.id)
     .run();
 
   return { token };


### PR DESCRIPTION
## Summary
Follow-up hardening after #1474:
- **Bugfix:** `createPasswordResetToken` updated `preferences_json` on **every** user (missing `WHERE id = ?`). Now scoped to the matched user.
- Always `INSERT` with `username` (= email); remove Sonar-noisy try/catch dual insert.
- Update `migrations/0001-auth-schema.sql` for fresh local D1 DBs.
- Inline `getAuthDbFromEnv()` in `session-d1` / sandbox.

Closes the leftover cleanup from the squash-merged #1474 branch; supersedes #1475.

## Test plan
- [x] auth-register vitest
- [ ] Forgot-password only sets reset token on the requesting account
- [ ] Register still works against prod D1 (username column present)


Made with [Cursor](https://cursor.com)