### PR TITLE
fix(security): CodeQL tainted format string in client-reports (#1863)

### DIFF
--- a/src/app/api/cron/client-reports/route.ts
+++ b/src/app/api/cron/client-reports/route.ts
@@ -66,7 +66,7 @@ export async function GET(request: NextRequest) {
       portal.lastReportAt = now.toISOString();
       sent.push(portal.clientEmail);
     } catch (err) {
-      console.error("[ClientReports] send failed for", portal.clientEmail, err);
+      console.error("[ClientReports] send failed for %s", portal.clientEmail, err);
       failed.push(portal.clientEmail);
     }
   }

--- a/src/app/api/cron/client-reports/route.ts
+++ b/src/app/api/cron/client-reports/route.ts
@@ -66,7 +66,7 @@ export async function GET(request: NextRequest) {
       portal.lastReportAt = now.toISOString();
       sent.push(portal.clientEmail);
     } catch (err) {
-      console.error(`[ClientReports] send failed for ${portal.clientEmail}:`, err);
+      console.error("[ClientReports] send failed for", portal.clientEmail, err);
       failed.push(portal.clientEmail);
     }
   }


### PR DESCRIPTION
## Summary
- Fixes CodeQL alert [#1863](https://github.com/Themis128/cloudless.gr/security/code-scanning/1863) (`js/tainted-format-string`) in `/api/cron/client-reports`
- Passes `portal.clientEmail` as a separate `console.error` argument instead of interpolating it into the format-string position

## Test plan
- [ ] Confirm CodeQL re-scan on `main` closes alert #1863
- [ ] Spot-check that a failed send still logs email + error distinctly


Made with [Cursor](https://cursor.com)