### PR TITLE
fix(auth): honor D1 session_token in post-login page gates

### DIFF
--- a/__tests__/proxy-access.test.ts
+++ b/__tests__/proxy-access.test.ts
@@ -2,9 +2,17 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { NextRequest, NextResponse } from "next/server";
 
 // Mock next-auth/jwt so getToken returns controlled token data.
-// proxy.ts calls getToken() to read the next-auth session cookie.
 const mockGetToken = vi.fn();
 vi.mock("next-auth/jwt", () => ({ getToken: (opts: unknown) => mockGetToken(opts) }));
+
+const mockGetAuthDbFromEnv = vi.fn();
+const mockGetUserBySession = vi.fn();
+const mockIsAdmin = vi.fn();
+vi.mock("@/lib/auth-d1", () => ({
+  getAuthDbFromEnv: () => mockGetAuthDbFromEnv(),
+  getUserBySession: (...args: unknown[]) => mockGetUserBySession(...args),
+  isAdmin: (...args: unknown[]) => mockIsAdmin(...args),
+}));
 
 vi.mock("next-intl/middleware", () => ({
   default: () => (_request: NextRequest) => NextResponse.next(),
@@ -21,6 +29,9 @@ function makeRequest(path: string, cookie?: string): NextRequest {
 describe("proxy protected routes access", () => {
   beforeEach(() => {
     mockGetToken.mockResolvedValue(null); // unauthenticated by default
+    mockGetAuthDbFromEnv.mockReturnValue(null);
+    mockGetUserBySession.mockReset();
+    mockIsAdmin.mockReset();
   });
 
   it("redirects unauthenticated /en/dashboard to /en/auth/login", async () => {
@@ -79,5 +90,60 @@ describe("proxy protected routes access", () => {
     expect(adminResponse.headers.get("location")).toBeNull();
     expect(adminOrdersResponse.status).toBe(200);
     expect(adminOrdersResponse.headers.get("location")).toBeNull();
+  });
+
+  it("allows D1 session_token admin through /en/admin and /en/auth/post-login", async () => {
+    mockGetAuthDbFromEnv.mockReturnValue({ prepare: vi.fn() });
+    mockGetUserBySession.mockResolvedValue({
+      id: "admin-user-001",
+      email: "admin@cloudless.gr",
+      name: "Admin",
+    });
+    mockIsAdmin.mockResolvedValue(true);
+
+    const adminResponse = await proxy(
+      makeRequest("/en/admin", "session_token=d1-session-id")
+    );
+    expect(adminResponse.status).toBe(200);
+    expect(adminResponse.headers.get("location")).toBeNull();
+
+    const postLogin = await proxy(
+      makeRequest("/en/auth/post-login", "session_token=d1-session-id")
+    );
+    expect(postLogin.status).toBe(307);
+    expect(postLogin.headers.get("location")).toContain("/en/admin");
+  });
+
+  it("routes D1 session_token non-admin from /en/admin to /en/dashboard", async () => {
+    mockGetAuthDbFromEnv.mockReturnValue({ prepare: vi.fn() });
+    mockGetUserBySession.mockResolvedValue({
+      id: "user-1",
+      email: "user@cloudless.gr",
+      name: "User",
+    });
+    mockIsAdmin.mockResolvedValue(false);
+
+    const adminResponse = await proxy(
+      makeRequest("/en/admin", "session_token=d1-session-id")
+    );
+    expect(adminResponse.status).toBe(307);
+    expect(adminResponse.headers.get("location")).toContain("/en/dashboard");
+
+    const postLogin = await proxy(
+      makeRequest("/en/auth/post-login", "session_token=d1-session-id")
+    );
+    expect(postLogin.status).toBe(307);
+    expect(postLogin.headers.get("location")).toContain("/en/dashboard");
+  });
+
+  it("bounces invalid D1 session_token to login", async () => {
+    mockGetAuthDbFromEnv.mockReturnValue({ prepare: vi.fn() });
+    mockGetUserBySession.mockResolvedValue(null);
+
+    const dashboard = await proxy(
+      makeRequest("/en/dashboard", "session_token=expired-or-forged")
+    );
+    expect(dashboard.status).toBe(307);
+    expect(dashboard.headers.get("location")).toContain("/en/auth/login");
   });
 });

--- a/src/app/[locale]/auth/post-login/page.tsx
+++ b/src/app/[locale]/auth/post-login/page.tsx
@@ -1,11 +1,11 @@
+import { cookies } from "next/headers";
 import { redirect } from "next/navigation";
-import { auth } from "@/lib/auth";
+import { getAuthDbFromEnv, getUserBySession, isAdmin as d1IsAdmin } from "@/lib/auth-d1";
 import { isSupportedLocale } from "@/lib/i18n";
 
-// Post-login landing resolver. next-auth's callbackUrl is fixed at sign-in time
-// (before the session exists), so we can't decide admin-vs-dashboard there. The
-// Cognito sign-in sends users here; this reads the now-established session and
-// routes admins to /admin, everyone else to /dashboard. Server-side → no flash.
+// Post-login landing resolver. Login sets an opaque D1 `session_token` cookie;
+// this page (and proxy.ts) read that session and route admins → /admin,
+// everyone else → /dashboard. Server-side → no flash.
 export const dynamic = "force-dynamic";
 
 export default async function PostLoginPage({
@@ -17,16 +17,23 @@ export default async function PostLoginPage({
   // time, but a hand-crafted URL like /x%2F..%2Fetc/auth/post-login should
   // still fall back to a safe default rather than producing a weird redirect.
   const locale = isSupportedLocale(rawLocale) ? rawLocale : "en";
-  const session = await auth();
 
-  if (!session?.user) {
+  const cookieStore = await cookies();
+  const sessionId = cookieStore.get("session_token")?.value;
+  if (!sessionId) {
     redirect(`/${locale}/auth/login`);
   }
 
-  const groups = session.user.groups ?? [];
-  const roles = session.user.roles ?? [];
-  const isAdmin =
-    groups.includes("admin") || roles.includes("admin") || roles.includes("realm:admin");
+  const db = getAuthDbFromEnv();
+  if (!db) {
+    redirect(`/${locale}/auth/login`);
+  }
 
-  redirect(`/${locale}${isAdmin ? "/admin" : "/dashboard"}`);
+  const user = await getUserBySession(db, sessionId);
+  if (!user) {
+    redirect(`/${locale}/auth/login`);
+  }
+
+  const admin = await d1IsAdmin(db, user.id);
+  redirect(`/${locale}${admin ? "/admin" : "/dashboard"}`);
 }

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -17,7 +17,34 @@ function stripLocale(pathname: string): string {
   return pathname.slice(segment.length + 1) || "/";
 }
 
-async function readAuthToken(
+/**
+ * Primary auth for page gates: opaque D1 `session_token` from email/password
+ * login (`/api/auth/login`). Without this, post-login redirects to /admin or
+ * /dashboard bounce straight back to /auth/login even though APIs accept the cookie.
+ */
+async function readD1SessionCookie(
+  req: NextRequest,
+): Promise<{ valid: boolean; isAdmin: boolean } | null> {
+  const sessionId = req.cookies.get("session_token")?.value;
+  if (!sessionId) return null;
+
+  try {
+    const { getAuthDbFromEnv, getUserBySession, isAdmin: d1IsAdmin } = await import(
+      "@/lib/auth-d1"
+    );
+    const db = getAuthDbFromEnv();
+    if (!db) return null;
+    const user = await getUserBySession(db, sessionId);
+    if (!user) return { valid: false, isAdmin: false };
+    const admin = await d1IsAdmin(db, user.id);
+    return { valid: true, isAdmin: admin };
+  } catch {
+    return null;
+  }
+}
+
+/** Legacy Auth.js JWT cookie (chunked or whole) — kept for transitional sessions. */
+async function readNextAuthJwt(
   req: NextRequest,
 ): Promise<{ valid: boolean; isAdmin: boolean }> {
   // The session JWT can exceed the 4096-byte cookie limit when next-auth
@@ -51,6 +78,14 @@ async function readAuthToken(
   } catch {
     return { valid: false, isAdmin: false };
   }
+}
+
+async function readAuthToken(
+  req: NextRequest,
+): Promise<{ valid: boolean; isAdmin: boolean }> {
+  const d1 = await readD1SessionCookie(req);
+  if (d1) return d1;
+  return readNextAuthJwt(req);
 }
 
 // --- next-intl locale middleware ---
@@ -353,8 +388,8 @@ async function handlePageRoute(
   const locale = getLocaleFromPath(pathname);
   const prefix = `/${locale}`;
 
-  // Post-login resolver: the OIDC callbackUrl routes here; we read the session
-  // and redirect admins → /admin, everyone else → /dashboard.
+  // Post-login resolver: after D1 email/password login (or legacy Auth.js),
+  // read the session and redirect admins → /admin, everyone else → /dashboard.
   if (bare === "/auth/post-login") {
     const { valid, isAdmin: hasAdminGroup } = await readAuthToken(request);
     if (!valid) {


### PR DESCRIPTION
## Summary
- After D1 email/password login, `/admin` and `/dashboard` redirected back to login because `proxy.ts` only recognized Auth.js JWT cookies.
- `readAuthToken` now resolves the opaque `session_token` via `auth-d1` first (JWT kept as legacy fallback).
- `/auth/post-login` page aligned to D1 session instead of `next-auth` `auth()`.
- Unit tests cover admin/non-admin/invalid D1 cookie paths.

## Test plan
- [x] `pnpm exec vitest run __tests__/proxy-access.test.ts __tests__/proxy-chunked-cookie.test.ts`
- [ ] After deploy: login as `tbaltzakis@cloudless.gr` → land on `/en/admin` without bounce
- [ ] `/en/auth/post-login` with valid `session_token` → 307 to `/en/admin`
- [ ] Unauthenticated `/en/dashboard` still redirects to login


Made with [Cursor](https://cursor.com)