### PR TITLE
fix(ops): restore alert-api Deployment + fix Kuma probe

### DIFF
--- a/.github/workflows/deploy-alert-api.yml
+++ b/.github/workflows/deploy-alert-api.yml
@@ -5,6 +5,10 @@ name: Build + roll out alert-api
 # pre-CI history), imports it into k3s containerd, then patches the
 # Deployment to bump the tag.
 #
+# Prerequisites: namespace + Deployment from
+#   infrastructure/pi-alert-api/k8s/alert-api.yaml
+#   (NodePort 30820 → alert-api.alert-manager.svc:8080)
+#
 # Triggers:
 #   - push to main touching infrastructure/pi-alert-api/**
 #   - manual workflow_dispatch (operator can ship v3.4 from the GitHub UI
@@ -25,9 +29,9 @@ on:
   workflow_dispatch:
     inputs:
       version_tag:
-        description: "Image tag to ship (e.g. v3.4)"
+        description: "Image tag to ship (e.g. v3.5)"
         required: true
-        default: "v3.4"
+        default: "v3.5"
 
 permissions:
   contents: read
@@ -42,7 +46,7 @@ jobs:
     runs-on: [self-hosted, omv, pi]
     timeout-minutes: 15
     env:
-      TAG: ${{ inputs.version_tag || 'v3.4' }}
+      TAG: ${{ inputs.version_tag || 'v3.5' }}
     steps:
       - uses: actions/checkout@v5
 

--- a/docs/pods/pi-alert-api/README.md
+++ b/docs/pods/pi-alert-api/README.md
@@ -6,12 +6,13 @@
 
 | Field | Value |
 |-------|-------|
-| Kind | External |
-| Namespace | `alert-manager / host` |
+| Kind | Deployment |
+| Namespace | `alert-manager` |
 | Resource name | `alert-api` |
-| Hostname / DNS | logs.cloudless.gr · LAN `192.168.1.128:30800` · in-cluster `alert-api.alert-manager.svc:8080` |
-| Ports | 8080 / NodePort 30800 |
+| Hostname / DNS | logs.cloudless.gr · LAN `192.168.1.128:30820` · in-cluster `alert-api.alert-manager.svc:8080` |
+| Ports | 8080 / NodePort **30820** (not 30800 — reserved for omv-ai) |
 | Role | ESP32 / homelab alert API + websocket logs. |
+| Manifest | `infrastructure/pi-alert-api/k8s/alert-api.yaml` |
 
 ## How cloudless.gr uses it
 

--- a/infrastructure/cloudflare-tunnels/logs-cloudless-gr.yaml
+++ b/infrastructure/cloudflare-tunnels/logs-cloudless-gr.yaml
@@ -7,24 +7,25 @@
 # The full tunnel config lives at /etc/cloudflared/config.yml on omv-main.
 #
 # WebSocket endpoint:
-#   wss://logs.cloudless.gr/ws/esp32-logs  →  http://192.168.1.128:30800
+#   wss://logs.cloudless.gr/ws/esp32-logs  →  http://192.168.1.128:30820
+#
+# NodePort 30820 (30800 reserved for omv-ai). Origin is alert-api Deployment
+# in namespace alert-manager (infrastructure/pi-alert-api/k8s/alert-api.yaml).
 #
 # SSM param (baked at Next.js build time):
 #   /cloudless/production/NEXT_PUBLIC_ALERT_WS_URL = wss://logs.cloudless.gr/ws/esp32-logs
-#   Set 2026-05-24, deployed in run 26370944091.
 #
-# To update this route on omv-main:
-#   1. Edit /etc/cloudflared/config.yml — the logs.cloudless.gr ingress rule below
-#   2. sudo systemctl reload cloudflared
-#   3. Verify: curl -I https://logs.cloudless.gr/health
+# To update this route on omv + omv-ha:
+#   1. Edit /etc/cloudflared/config.yml — logs.cloudless.gr → :30820 on BOTH nodes
+#   2. sudo systemctl restart cloudflared  (restart, not reload)
+#   3. Verify: curl -I https://logs.cloudless.gr/health (may hit CF Access)
 #
-# Ingress rule (already live on omv-main as of 2026-05-24):
----
-# This is the ingress rule fragment — paste into /etc/cloudflared/config.yml
+# Ingress rule fragment — paste into /etc/cloudflared/config.yml
 # under the "ingress:" key, before the catch-all rule.
+---
 ingress_rule:
   hostname: logs.cloudless.gr
-  service: http://192.168.1.128:30800
+  service: http://192.168.1.128:30820
   originRequest:
     connectTimeout: 10s
     tcpKeepAlive: 30s

--- a/infrastructure/pi-alert-api/README.md
+++ b/infrastructure/pi-alert-api/README.md
@@ -115,7 +115,7 @@ You should also see the test message land in `#alerts` — visually verify the f
 Override URL when running off-cluster:
 
 ```bash
-ALERT_API_URL=http://192.168.1.128:30800 \
+ALERT_API_URL=http://192.168.1.128:30820 \
   bash infrastructure/pi-alert-api/tests/smoke_test_live.sh
 ```
 

--- a/infrastructure/pi-alert-api/deploy.sh
+++ b/infrastructure/pi-alert-api/deploy.sh
@@ -86,7 +86,7 @@ REMOTE
 # ── 5. Verify command endpoint ────────────────────────────────────────────────
 echo "==> Verifying /api/esp32/{device_id}/command..."
 sleep 3
-RESULT=$(curl -s --max-time 10 -X POST http://192.168.1.128:30800/api/esp32/esp32-leds/command \
+RESULT=$(curl -s --max-time 10 -X POST http://192.168.1.128:30820/api/esp32/esp32-leds/command \
   -H "Content-Type: application/json" \
   -d '{"action":"led_test"}')
 echo "  Response: ${RESULT}"

--- a/infrastructure/pi-alert-api/k8s/alert-api.yaml
+++ b/infrastructure/pi-alert-api/k8s/alert-api.yaml
@@ -1,0 +1,157 @@
+# alert-api — FastAPI alert pipeline (ESP32 / Alertmanager → Slack + MQTT)
+#
+# Restored 2026-07-30 as an in-cluster Deployment. Kuma previously probed the
+# non-existent pi-alert-api.default.svc name (permanent ENOTFOUND, mislabeled
+# as a DNS flap).
+#
+# Ports:
+#   container / ClusterIP: 8080
+#   NodePort: 30820  (NOT 30800 — reserved in omv-ai vllm-kimi.yaml)
+#
+# Image is built on omv via .github/workflows/deploy-alert-api.yml into local
+# containerd (docker.io/library/alert-api:<tag>). imagePullPolicy: Never.
+#
+# Apply:
+#   kubectl apply -f infrastructure/pi-alert-api/k8s/alert-api.yaml
+#   # then copy bot token + MQTT creds into secrets (see README)
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: alert-manager
+  labels:
+    app.kubernetes.io/name: alert-api
+---
+apiVersion: v1
+kind: LimitRange
+metadata:
+  name: default-container-limits
+  namespace: alert-manager
+spec:
+  limits:
+    - type: Container
+      default: { memory: 128Mi, cpu: 200m }
+      defaultRequest: { memory: 32Mi, cpu: 25m }
+      max: { memory: 200Mi, cpu: 500m }
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: alert-api-data
+  namespace: alert-manager
+spec:
+  accessModes: [ReadWriteOnce]
+  storageClassName: local-path
+  resources:
+    requests:
+      storage: 1Gi
+---
+# Secrets are NOT in this file (apply would clobber live tokens).
+# Create once:
+#   kubectl -n alert-manager create secret generic alert-api-secrets \
+#     --from-literal=SLACK_BOT_TOKEN='xoxb-...' \
+#     --from-literal=SLACK_CHANNEL_ID='C09AF5W3X16' \
+#     --from-literal=SLACK_WEBHOOK_URL=''
+#   kubectl -n alert-manager create secret generic alert-api-mqtt-creds \
+#     --from-literal=MQTT_USERNAME=alert-api \
+#     --from-literal=MQTT_PASSWORD='...'
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: alert-api
+  namespace: alert-manager
+  labels:
+    app: alert-api
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app: alert-api
+  template:
+    metadata:
+      labels:
+        app: alert-api
+    spec:
+      nodeSelector:
+        kubernetes.io/hostname: omv
+      containers:
+        - name: alert-api
+          image: docker.io/library/alert-api:v3.5
+          imagePullPolicy: Never
+          ports:
+            - name: http
+              containerPort: 8080
+          env:
+            - name: SLACK_WEBHOOK_URL
+              valueFrom:
+                secretKeyRef:
+                  name: alert-api-secrets
+                  key: SLACK_WEBHOOK_URL
+                  optional: true
+            - name: SLACK_BOT_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: alert-api-secrets
+                  key: SLACK_BOT_TOKEN
+                  optional: true
+            - name: SLACK_CHANNEL_ID
+              valueFrom:
+                secretKeyRef:
+                  name: alert-api-secrets
+                  key: SLACK_CHANNEL_ID
+                  optional: true
+            - name: MQTT_BROKER_HOST
+              value: mosquitto.monitoring.svc.cluster.local
+            - name: MQTT_BROKER_PORT
+              value: "1883"
+            - name: MQTT_USERNAME
+              valueFrom:
+                secretKeyRef:
+                  name: alert-api-mqtt-creds
+                  key: MQTT_USERNAME
+                  optional: true
+            - name: MQTT_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: alert-api-mqtt-creds
+                  key: MQTT_PASSWORD
+                  optional: true
+          volumeMounts:
+            - name: data
+              mountPath: /data
+          resources:
+            requests: { memory: 64Mi, cpu: 50m }
+            limits: { memory: 200Mi, cpu: 500m }
+          startupProbe:
+            httpGet: { path: /health, port: http }
+            failureThreshold: 30
+            periodSeconds: 5
+          livenessProbe:
+            httpGet: { path: /health, port: http }
+            periodSeconds: 30
+          readinessProbe:
+            httpGet: { path: /health, port: http }
+            periodSeconds: 10
+      volumes:
+        - name: data
+          persistentVolumeClaim:
+            claimName: alert-api-data
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: alert-api
+  namespace: alert-manager
+  labels:
+    app: alert-api
+spec:
+  type: NodePort
+  selector:
+    app: alert-api
+  ports:
+    - name: http
+      port: 8080
+      targetPort: http
+      nodePort: 30820

--- a/infrastructure/pi-alert-api/slack_notify.py
+++ b/infrastructure/pi-alert-api/slack_notify.py
@@ -20,7 +20,10 @@ import httpx
 logger = logging.getLogger(__name__)
 
 SLACK_WEBHOOK_URL = os.environ.get("SLACK_WEBHOOK_URL", "")
+SLACK_BOT_TOKEN = os.environ.get("SLACK_BOT_TOKEN", "")
+SLACK_CHANNEL_ID = os.environ.get("SLACK_CHANNEL_ID", "C09AF5W3X16")
 SLACK_TIMEOUT = 10
+SLACK_API_POST = "https://slack.com/api/chat.postMessage"
 
 
 def _severity_emoji(severity: str) -> str:
@@ -93,8 +96,9 @@ def _slack_date(ts: datetime) -> str:
 
 
 async def send_alert(data: dict) -> bool:
-    if not SLACK_WEBHOOK_URL:
-        logger.warning("SLACK_WEBHOOK_URL not set; skipping Slack notification")
+    """Deliver alert via Incoming Webhook (legacy) or chat.postMessage (preferred)."""
+    if not SLACK_WEBHOOK_URL and not SLACK_BOT_TOKEN:
+        logger.warning("Neither SLACK_WEBHOOK_URL nor SLACK_BOT_TOKEN set; skipping Slack")
         return False
 
     code = data.get("code", "UNKNOWN")
@@ -154,22 +158,30 @@ async def send_alert(data: dict) -> bool:
         {"type": "divider"},
     ]
 
-    payload = {
-        "text": f"{sev_emoji} {severity.upper()} [{status}] {code} on {host}",
-        "blocks": blocks,
-    }
+    fallback = f"{sev_emoji} {severity.upper()} [{status}] {code} on {host}"
+    payload = {"text": fallback, "blocks": blocks}
 
     try:
         async with httpx.AsyncClient(timeout=SLACK_TIMEOUT) as client:
-            resp = await client.post(SLACK_WEBHOOK_URL, json=payload)
-            if resp.status_code == 200:
+            if SLACK_WEBHOOK_URL:
+                resp = await client.post(SLACK_WEBHOOK_URL, json=payload)
+                ok = resp.status_code == 200
+            else:
+                body = {**payload, "channel": SLACK_CHANNEL_ID}
+                resp = await client.post(
+                    SLACK_API_POST,
+                    headers={"Authorization": f"Bearer {SLACK_BOT_TOKEN}"},
+                    json=body,
+                )
+                ok = resp.status_code == 200 and bool((resp.json() or {}).get("ok"))
+            if ok:
                 logger.info("Slack alert sent: %s/%s [%s]", host, code, status)
                 return True
-            logger.error("Slack webhook %s: %s", resp.status_code, resp.text)
+            logger.error("Slack delivery %s: %s", resp.status_code, resp.text)
             return False
     except httpx.TimeoutException:
-        logger.error("Slack webhook timed out after %ds", SLACK_TIMEOUT)
+        logger.error("Slack delivery timed out after %ds", SLACK_TIMEOUT)
         return False
     except Exception as exc:
-        logger.error("Slack webhook exception: %s", exc)
+        logger.error("Slack delivery exception: %s", exc)
         return False

--- a/infrastructure/pi-alert-api/tests/test_slack_notify.py
+++ b/infrastructure/pi-alert-api/tests/test_slack_notify.py
@@ -109,8 +109,11 @@ class SlackDateTokenTest(unittest.TestCase):
 
 
 class SendAlertTest(unittest.TestCase):
-    def test_returns_false_without_webhook_url(self):
-        with mock.patch.object(slack_notify, "SLACK_WEBHOOK_URL", ""):
+    def test_returns_false_without_webhook_or_bot(self):
+        with (
+            mock.patch.object(slack_notify, "SLACK_WEBHOOK_URL", ""),
+            mock.patch.object(slack_notify, "SLACK_BOT_TOKEN", ""),
+        ):
             result = _run(
                 slack_notify.send_alert(
                     {
@@ -132,6 +135,9 @@ class SendAlertTest(unittest.TestCase):
             status_code = 200
             text = "ok"
 
+            def json(self):
+                return {"ok": True}
+
         class FakeClient:
             def __init__(self, *a, **kw):
                 pass
@@ -142,13 +148,14 @@ class SendAlertTest(unittest.TestCase):
             async def __aexit__(self, *a):
                 return False
 
-            async def post(self, url, json):
+            async def post(self, url, json=None, headers=None):
                 captured["url"] = url
                 captured["json"] = json
                 return FakeResp()
 
         with (
             mock.patch.object(slack_notify, "SLACK_WEBHOOK_URL", "https://hooks.slack.com/test"),
+            mock.patch.object(slack_notify, "SLACK_BOT_TOKEN", ""),
             mock.patch.object(slack_notify.httpx, "AsyncClient", FakeClient),
         ):
             result = _run(
@@ -192,12 +199,15 @@ class SendAlertTest(unittest.TestCase):
         self.assertIn("Alert #999", ctx_text)
         self.assertIn("severity: critical", ctx_text)
 
-    def test_resolved_status_suppresses_proposed_solution(self):
+    def test_bot_token_posts_chat_api(self):
         captured = {}
 
         class FakeResp:
             status_code = 200
-            text = "ok"
+            text = '{"ok":true}'
+
+            def json(self):
+                return {"ok": True}
 
         class FakeClient:
             def __init__(self, *a, **kw):
@@ -209,7 +219,56 @@ class SendAlertTest(unittest.TestCase):
             async def __aexit__(self, *a):
                 return False
 
-            async def post(self, url, json):
+            async def post(self, url, json=None, headers=None):
+                captured["url"] = url
+                captured["json"] = json
+                captured["headers"] = headers
+                return FakeResp()
+
+        with (
+            mock.patch.object(slack_notify, "SLACK_WEBHOOK_URL", ""),
+            mock.patch.object(slack_notify, "SLACK_BOT_TOKEN", "xoxb-test"),
+            mock.patch.object(slack_notify, "SLACK_CHANNEL_ID", "C09AF5W3X16"),
+            mock.patch.object(slack_notify.httpx, "AsyncClient", FakeClient),
+        ):
+            result = _run(
+                slack_notify.send_alert(
+                    {
+                        "code": "TEST",
+                        "host": "h",
+                        "service": "s",
+                        "severity": "info",
+                        "message": "m",
+                        "status": "FIRING",
+                    }
+                )
+            )
+        self.assertTrue(result)
+        self.assertEqual(captured["url"], slack_notify.SLACK_API_POST)
+        self.assertEqual(captured["json"]["channel"], "C09AF5W3X16")
+        self.assertIn("Bearer xoxb-test", captured["headers"]["Authorization"])
+
+    def test_resolved_status_suppresses_proposed_solution(self):
+        captured = {}
+
+        class FakeResp:
+            status_code = 200
+            text = "ok"
+
+            def json(self):
+                return {"ok": True}
+
+        class FakeClient:
+            def __init__(self, *a, **kw):
+                pass
+
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, *a):
+                return False
+
+            async def post(self, url, json=None, headers=None):
                 captured["json"] = json
                 return FakeResp()
 

--- a/scripts/kuma-bootstrap.cjs
+++ b/scripts/kuma-bootstrap.cjs
@@ -32,8 +32,12 @@ const MONITORS = [
     accepted_statuscodes: ["200", "302"],
   },
   {
+    // In-cluster Deployment (alert-manager/alert-api). Bootstrap used to
+    // probe pi-alert-api.default.svc.cluster.local — that name never existed
+    // (ENOTFOUND), and Slack coalesced it as a "DNS flap". Prefer cluster DNS
+    // over LAN NodePort; NodePort is 30820 (30800 reserved for omv-ai).
     name: "Pi alert-api (omv)",
-    url: "http://pi-alert-api.default.svc.cluster.local:8080/health",
+    url: "http://alert-api.alert-manager.svc.cluster.local:8080/health",
     accepted_statuscodes: ["200"],
   },
   {


### PR DESCRIPTION
## Summary
- Add `infrastructure/pi-alert-api/k8s/alert-api.yaml` (Deployment + Service NodePort **30820**) so `alert-api.alert-manager.svc` is real again
- Point Kuma bootstrap at cluster DNS instead of the phantom `pi-alert-api.default.svc` name
- Prefer Slack `chat.postMessage` via `SLACK_BOT_TOKEN` (incoming webhook was long-invalid)
- Move documented LAN/tunnel origin off **30800** (reserved for omv-ai) to **30820**

## Live (already applied on omv)
- alert-api `v3.5` Running; `/health` 200
- Mosquitto restored in `monitoring` with auth; MQTT smoke OK
- Kuma monitor active on cluster DNS
- `logs.cloudless.gr` CNAME + tunnel ingress on both nodes (public edge gated by Cloudflare Access)

## Test plan
- [x] `python3 -m unittest discover tests` in `infrastructure/pi-alert-api`
- [x] In-cluster `/health` 200 via `alert-api.alert-manager.svc`
- [x] Slack smoke `send_alert` with bot token
- [x] MQTT authenticated publish to `homelab/alerts/events`
- [ ] Confirm Kuma UI shows Pi alert-api UP
- [ ] After merge, `deploy-alert-api.yml` can rebuild from repo sources


Made with [Cursor](https://cursor.com)