### PR TITLE
feat(tailscale): SaaS app-connectors (GitHub, Stripe, Notion, …)

### DIFF
--- a/.github/workflows/tailscale-admin-api.yml
+++ b/.github/workflows/tailscale-admin-api.yml
@@ -13,6 +13,14 @@ on:
         options:
           - "false"
           - "true"
+      acl_only:
+        description: "Merge/POST ACL only (skip stale device DELETE)"
+        required: false
+        default: "true"
+        type: choice
+        options:
+          - "true"
+          - "false"
 
 permissions:
   contents: read
@@ -32,6 +40,7 @@ jobs:
       TAILSCALE_OAUTH_CLIENT_SECRET: ${{ secrets.TAILSCALE_OAUTH_CLIENT_SECRET }}
       TAILSCALE_OAUTH_SECRET: ${{ secrets.TAILSCALE_OAUTH_SECRET }}
       DRY_RUN: ${{ inputs.dry_run }}
+      ACL_ONLY: ${{ inputs.acl_only }}
       TAILSCALE_TAILNET: tail4ecae1.ts.net
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v4.3.1

--- a/infrastructure/tailscale/README.md
+++ b/infrastructure/tailscale/README.md
@@ -42,10 +42,36 @@ flowchart LR
 | `proxygroup.yaml` | Shared `ingress` ProxyGroup + `kube-apiserver` ProxyGroup |
 | `ingresses.yaml` | Grafana / Meili with `tailscale.com/proxy-group: ingress` |
 | `ingress-class.yaml` | `IngressClass` `tailscale` |
-| `acl-policy.example.json` | tagOwners + autoApprovers + grants |
+| `acl-policy.example.json` | tagOwners + autoApprovers + grants + **Apps** (`nodeAttrs` app-connectors) |
 | `deploy.sh` | Helm install (OAuth env only — no AWS SSM) |
 | `subnet-router.yaml` / `proxygroup-monitoring.yaml` | Deprecated stubs — do not apply |
 | `OFFLINE-DEVICE-TROUBLESHOOTING.md` | Stale Machines cleanup |
+
+## Tailscale Apps (SaaS app connectors)
+
+ACL patch includes `tag:app-connector` plus presets (**GitHub**, **Stripe**, **Google Workspace**) and custom domains (**Notion**, **Sentry**, **Slack**, **Cloudflare**, **Anthropic**). Merge + apply:
+
+```bash
+# From CI (preferred — uses repo OAuth secrets)
+gh workflow run tailscale-admin-api.yml -f dry_run=false
+
+# Or locally with TS_CLIENT_ID + TS_CLIENT_SECRET
+DRY_RUN=0 bash scripts/tailscale-admin-api.sh
+```
+
+Then designate a **stable Linux** node (prefer office/NAS/VPS — not overloaded omv):
+
+```bash
+sudo tailscale up --advertise-connector --advertise-tags=tag:app-connector \
+  --accept-routes --accept-dns=false
+```
+
+Approve the tag in the admin console if prompted. Apps go green at
+https://login.tailscale.com/admin/apps once a connector is online.
+Copy **Egress IPs** into SaaS IP allowlists when you tighten access.
+
+**Do not** put public `*.cloudless.gr` or Grafana/Meili Serve hosts in Apps —
+those stay on Cloudflare Tunnel / ProxyGroup.
 
 ## Design rules
 

--- a/infrastructure/tailscale/acl-policy.example.json
+++ b/infrastructure/tailscale/acl-policy.example.json
@@ -89,28 +89,28 @@
       "app": {
         "tailscale.com/app-connectors": [
           {
-            "name": "GitHub",
+            "name": "github",
             "connectors": [
               "tag:app-connector"
             ],
             "presetAppID": "github"
           },
           {
-            "name": "Stripe",
+            "name": "stripe",
             "connectors": [
               "tag:app-connector"
             ],
             "presetAppID": "stripe"
           },
           {
-            "name": "Google Workspace",
+            "name": "google-workspace",
             "connectors": [
               "tag:app-connector"
             ],
             "presetAppID": "google-workspace"
           },
           {
-            "name": "Notion",
+            "name": "notion",
             "connectors": [
               "tag:app-connector"
             ],
@@ -122,7 +122,7 @@
             ]
           },
           {
-            "name": "Sentry",
+            "name": "sentry",
             "connectors": [
               "tag:app-connector"
             ],
@@ -132,7 +132,7 @@
             ]
           },
           {
-            "name": "Slack",
+            "name": "slack",
             "connectors": [
               "tag:app-connector"
             ],
@@ -143,7 +143,7 @@
             ]
           },
           {
-            "name": "Cloudflare",
+            "name": "cloudflare",
             "connectors": [
               "tag:app-connector"
             ],
@@ -154,7 +154,7 @@
             ]
           },
           {
-            "name": "Anthropic",
+            "name": "anthropic",
             "connectors": [
               "tag:app-connector"
             ],

--- a/infrastructure/tailscale/acl-policy.example.json
+++ b/infrastructure/tailscale/acl-policy.example.json
@@ -5,6 +5,9 @@
     ],
     "tag:k8s": [
       "tag:k8s-operator"
+    ],
+    "tag:app-connector": [
+      "autogroup:admin"
     ]
   },
   "autoApprovers": {
@@ -14,6 +17,12 @@
       ],
       "10.43.0.0/16": [
         "tag:k8s"
+      ],
+      "0.0.0.0/0": [
+        "tag:app-connector"
+      ],
+      "::/0": [
+        "tag:app-connector"
       ]
     },
     "services": {
@@ -47,6 +56,115 @@
       "ip": [
         "*"
       ]
+    },
+    {
+      "src": [
+        "autogroup:member"
+      ],
+      "dst": [
+        "autogroup:internet"
+      ],
+      "ip": [
+        "*"
+      ]
+    },
+    {
+      "src": [
+        "autogroup:member"
+      ],
+      "dst": [
+        "tag:app-connector"
+      ],
+      "ip": [
+        "tcp:53",
+        "udp:53"
+      ]
+    }
+  ],
+  "nodeAttrs": [
+    {
+      "target": [
+        "*"
+      ],
+      "app": {
+        "tailscale.com/app-connectors": [
+          {
+            "name": "GitHub",
+            "connectors": [
+              "tag:app-connector"
+            ],
+            "presetAppID": "github"
+          },
+          {
+            "name": "Stripe",
+            "connectors": [
+              "tag:app-connector"
+            ],
+            "presetAppID": "stripe"
+          },
+          {
+            "name": "Google Workspace",
+            "connectors": [
+              "tag:app-connector"
+            ],
+            "presetAppID": "google-workspace"
+          },
+          {
+            "name": "Notion",
+            "connectors": [
+              "tag:app-connector"
+            ],
+            "domains": [
+              "www.notion.so",
+              "notion.so",
+              "*.notion.so",
+              "api.notion.com"
+            ]
+          },
+          {
+            "name": "Sentry",
+            "connectors": [
+              "tag:app-connector"
+            ],
+            "domains": [
+              "*.sentry.io",
+              "sentry.io"
+            ]
+          },
+          {
+            "name": "Slack",
+            "connectors": [
+              "tag:app-connector"
+            ],
+            "domains": [
+              "*.slack.com",
+              "slack.com",
+              "api.slack.com"
+            ]
+          },
+          {
+            "name": "Cloudflare",
+            "connectors": [
+              "tag:app-connector"
+            ],
+            "domains": [
+              "dash.cloudflare.com",
+              "api.cloudflare.com",
+              "*.cloudflare.com"
+            ]
+          },
+          {
+            "name": "Anthropic",
+            "connectors": [
+              "tag:app-connector"
+            ],
+            "domains": [
+              "api.anthropic.com",
+              "console.anthropic.com"
+            ]
+          }
+        ]
+      }
     }
   ]
 }

--- a/scripts/tailscale-admin-api.sh
+++ b/scripts/tailscale-admin-api.sh
@@ -116,6 +116,29 @@ if "grants" in patch:
     if key == "grants" and "Grants" in cur and "grants" in cur:
         del cur["Grants"]
 
+# nodeAttrs: merge tailscale.com/app-connectors by name into target "*"
+if "nodeAttrs" in patch:
+    cur_attrs = cur.setdefault("nodeAttrs", [])
+    # Find or create the catch-all attr block
+    star = None
+    for attr in cur_attrs:
+        if attr.get("target") == ["*"] or attr.get("target") == "*":
+            star = attr
+            break
+    if star is None:
+        star = {"target": ["*"], "app": {}}
+        cur_attrs.append(star)
+    app = star.setdefault("app", {})
+    key = "tailscale.com/app-connectors"
+    existing = {c.get("name"): c for c in (app.get(key) or []) if c.get("name")}
+    for conn in patch["nodeAttrs"][0].get("app", {}).get(key, []):
+        name = conn.get("name")
+        if not name:
+            continue
+        existing[name] = conn
+    app[key] = list(existing.values())
+    print("app-connectors:", ", ".join(sorted(existing)))
+
 with open(out_path, "w") as f:
     json.dump(cur, f, indent=2)
     f.write("\n")

--- a/scripts/tailscale-admin-api.sh
+++ b/scripts/tailscale-admin-api.sh
@@ -162,6 +162,13 @@ else
   echo "    ACL updated"
 fi
 
+if [[ "${ACL_ONLY:-0}" == "1" || "${ACL_ONLY:-}" == "true" ]]; then
+  echo "==> ACL_ONLY=1 — skipping device cleanup"
+  rm -f "$ACL_TMP" "$HDR_TMP" "$MERGED"
+  echo "==> Done"
+  exit 0
+fi
+
 echo "==> List devices"
 DEVICES=$(mktemp)
 HTTP=$(curl -sS -o "$DEVICES" -w '%{http_code}' \


### PR DESCRIPTION
## Summary
- Add `tag:app-connector` + grants + `nodeAttrs` for GitHub/Stripe/Google Workspace presets and Notion/Sentry/Slack/Cloudflare/Anthropic custom domains
- Extend `tailscale-admin-api.sh` to merge app-connectors by name; add `ACL_ONLY` to avoid deleting live fabric devices
- Live ACL already applied via Admin API (`acl_only=true`)

## Test plan
- [x] Dry-run ACL merge
- [x] POST ACL HTTP 200
- [ ] Designate Linux connector: `tailscale up --advertise-connector --advertise-tags=tag:app-connector`
- [ ] Confirm green status at https://login.tailscale.com/admin/apps


Made with [Cursor](https://cursor.com)