### PR TITLE
feat(tailscale): Tailscale SSH ACL for tagged nodes

### DIFF
--- a/infrastructure/tailscale/README.md
+++ b/infrastructure/tailscale/README.md
@@ -70,6 +70,20 @@ Approve the tag in the admin console if prompted. Apps go green at
 https://login.tailscale.com/admin/apps once a connector is online.
 Copy **Egress IPs** into SaaS IP allowlists when you tighten access.
 
+### Tailscale SSH
+
+ACL includes `ssh` rules: members → `autogroup:self` (check mode); admins →
+`tag:app-connector` / `tag:k8s` / `tag:k8s-operator` (accept). After ACL apply:
+
+```bash
+# From any tailnet device (Windows / WSL / phone)
+ssh tbaltzakis@github-omv
+# or
+ssh tbaltzakis@github-omv.tail4ecae1.ts.net
+```
+
+Host must have `--ssh` enabled (`tailscale set --ssh` / already on github-omv).
+
 **Do not** put public `*.cloudless.gr` or Grafana/Meili Serve hosts in Apps —
 those stay on Cloudflare Tunnel / ProxyGroup.
 

--- a/infrastructure/tailscale/acl-policy.example.json
+++ b/infrastructure/tailscale/acl-policy.example.json
@@ -76,8 +76,38 @@
         "tag:app-connector"
       ],
       "ip": [
-        "tcp:53",
-        "udp:53"
+        "*"
+      ]
+    }
+  ],
+  "ssh": [
+    {
+      "action": "check",
+      "src": [
+        "autogroup:member"
+      ],
+      "dst": [
+        "autogroup:self"
+      ],
+      "users": [
+        "autogroup:nonroot",
+        "root"
+      ]
+    },
+    {
+      "action": "accept",
+      "src": [
+        "autogroup:admin"
+      ],
+      "dst": [
+        "tag:app-connector",
+        "tag:k8s",
+        "tag:k8s-operator"
+      ],
+      "users": [
+        "autogroup:nonroot",
+        "root",
+        "tbaltzakis"
       ]
     }
   ],

--- a/scripts/tailscale-admin-api.sh
+++ b/scripts/tailscale-admin-api.sh
@@ -116,6 +116,19 @@ if "grants" in patch:
     if key == "grants" and "Grants" in cur and "grants" in cur:
         del cur["Grants"]
 
+# ssh: append missing by stable JSON identity (same pattern as grants)
+if "ssh" in patch:
+    existing = cur.get("ssh") or []
+    have = {json.dumps(r, sort_keys=True) for r in existing}
+    merged = list(existing)
+    for r in patch["ssh"]:
+        sig = json.dumps(r, sort_keys=True)
+        if sig not in have:
+            merged.append(r)
+            have.add(sig)
+    cur["ssh"] = merged
+    print("ssh rules:", len(merged))
+
 # nodeAttrs: merge tailscale.com/app-connectors by name into target "*"
 if "nodeAttrs" in patch:
     cur_attrs = cur.setdefault("nodeAttrs", [])


### PR DESCRIPTION
## Summary
- Add `ssh` ACL: members→self (check), admins→app-connector/k8s tags (accept)
- Widen member grant to `tag:app-connector` for all ports (needed for SSH)
- Live ACL already applied via Admin API

## Test plan
- [ ] `ssh tbaltzakis@github-omv` from a tailnet device
- [ ] Confirm omv no longer warns about SSH ACLs denying everyone

Made with [Cursor](https://cursor.com)