### PR TITLE
fix(tailscale): sync Services console (approve + drop orphans)

### DIFF
--- a/.github/workflows/tailscale-approve-service-hosts.yml
+++ b/.github/workflows/tailscale-approve-service-hosts.yml
@@ -1,6 +1,15 @@
 name: Tailscale approve service hosts
 on:
   workflow_dispatch:
+    inputs:
+      dry_run:
+        description: "Preview approve/delete without changing Services"
+        required: false
+        default: "false"
+        type: choice
+        options:
+          - "false"
+          - "true"
 permissions:
   contents: read
 jobs:
@@ -13,7 +22,8 @@ jobs:
       TAILSCALE_OAUTH_CLIENT_SECRET: ${{ secrets.TAILSCALE_OAUTH_CLIENT_SECRET }}
       TAILSCALE_OAUTH_SECRET: ${{ secrets.TAILSCALE_OAUTH_SECRET }}
       TAILSCALE_TAILNET: tail4ecae1.ts.net
+      DRY_RUN: ${{ inputs.dry_run }}
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v4.3.1
       - run: sudo apt-get update -qq && sudo apt-get install -y -qq jq
       - run: bash scripts/tailscale-approve-service-hosts.sh

--- a/scripts/tailscale-approve-service-hosts.sh
+++ b/scripts/tailscale-approve-service-hosts.sh
@@ -1,6 +1,14 @@
 #!/usr/bin/env bash
-# Approve Tailscale Service hosts for k8s ProxyGroup fabric.
-# API: GET/POST /api/v2/tailnet/{tailnet}/services/{svc}/device/{nodeId}/approved
+# Sync Tailscale Services console with the k3s fabric:
+#   1) Approve all advertised hosts for every svc:*
+#   2) Delete orphan VIP Services no longer backed by cluster Ingress/ProxyGroup
+#
+# Expected (operator-managed):
+#   svc:grafana, svc:meilisearch  — Ingress + ProxyGroup/ingress
+#   svc:kube                      — ProxyGroup/kube-apiserver
+#
+# API: https://tailscale.com/docs/features/tailscale-services
+#      https://tailscale.com/docs/reference/api
 set -euo pipefail
 API=https://api.tailscale.com/api/v2
 TAILNET="${TAILSCALE_TAILNET:-tail4ecae1.ts.net}"
@@ -8,39 +16,71 @@ ID="${TS_CLIENT_ID:-${TAILSCALE_OAUTH_CLIENT_ID:-}}"
 SECRET="${TS_CLIENT_SECRET:-${TAILSCALE_OAUTH_CLIENT_SECRET:-${TAILSCALE_OAUTH_SECRET:-}}}"
 TOK=$(curl -fsS -u "$ID:$SECRET" -d grant_type=client_credentials "$API/oauth/token" | jq -r .access_token)
 AUTH="Authorization: Bearer $TOK"
+DRY_RUN="${DRY_RUN:-0}"
+case "${DRY_RUN}" in
+  1|true|TRUE|yes|YES) DRY_RUN=1 ;;
+  *) DRY_RUN=0 ;;
+esac
 
-SVCS=(svc:grafana svc:meilisearch svc:kube)
+# Canonical fabric services — everything else tagged tag:k8s is treated as orphan.
+EXPECTED='svc:grafana svc:meilisearch svc:kube'
 
-echo '== List services =='
-curl -fsS -H "$AUTH" "$API/tailnet/$TAILNET/services" | jq '.vipServices[] | {name,addrs,ports,tags}'
+urlenc() {
+  python3 -c "import urllib.parse,sys; print(urllib.parse.quote(sys.argv[1], safe=''))" "$1"
+}
 
-for svc in "${SVCS[@]}"; do
-  echo "== $svc devices =="
-  enc=$(python3 -c "import urllib.parse,sys; print(urllib.parse.quote(sys.argv[1], safe=''))" "$svc")
-  # URL path uses literal svc:name — try both encoded and raw
-  for path in \
-    "$API/tailnet/$TAILNET/services/$svc/devices" \
-    "$API/tailnet/$TAILNET/services/$enc/devices"; do
-    code=$(curl -sS -o /tmp/hosts.json -w '%{http_code}' -H "$AUTH" "$path" || true)
-    echo "GET $path -> $code"
-    [[ "$code" == "200" ]] && break
-  done
-  jq . /tmp/hosts.json 2>/dev/null || cat /tmp/hosts.json; echo
+echo "== List VIP Services =="
+SVCS_JSON=$(mktemp)
+curl -fsS -H "$AUTH" "$API/tailnet/$TAILNET/services" >"$SVCS_JSON"
+jq -r '.vipServices[] | "\(.name)\t\(.addrs|join(","))\t\(.ports|join(","))\t\((.tags // [])|join(","))"' "$SVCS_JSON"
 
-  # Approve each host
-  jq -r '.hosts[]?.nodeId // .devices[]?.nodeId // empty' /tmp/hosts.json 2>/dev/null | while read -r nid; do
-    [[ -z "$nid" ]] && continue
-    echo "Approve $svc on nodeId=$nid"
-    for base in \
-      "$API/tailnet/$TAILNET/services/$svc/device/$nid/approved" \
-      "$API/tailnet/$TAILNET/services/$enc/device/$nid/approved"; do
-      code=$(curl -sS -o /tmp/appr.json -w '%{http_code}' -X POST -H "$AUTH" \
-        -H 'Content-Type: application/json' \
-        -d '{"approved":true}' "$base" || true)
-      echo "POST $base -> $code $(cat /tmp/appr.json)"
-      [[ "$code" == "200" ]] && break
-    done
+echo
+echo "== Approve hosts for every service =="
+jq -r '.vipServices[].name' "$SVCS_JSON" | while read -r svc; do
+  [[ -z "$svc" ]] && continue
+  enc=$(urlenc "$svc")
+  code=$(curl -sS -o /tmp/hosts.json -w '%{http_code}' -H "$AUTH" \
+    "$API/tailnet/$TAILNET/services/$enc/devices" || true)
+  echo "-- $svc devices HTTP $code"
+  [[ "$code" == "200" ]] || continue
+  jq -c '.hosts[]?' /tmp/hosts.json 2>/dev/null | while read -r host; do
+    nid=$(echo "$host" | jq -r .nodeId)
+    level=$(echo "$host" | jq -r .approvalLevel)
+    cfg=$(echo "$host" | jq -r .configured)
+    echo "   host $nid approval=$level configured=$cfg"
+    if [[ "$DRY_RUN" == "1" ]]; then
+      echo "   DRY_RUN skip approve"
+      continue
+    fi
+    acode=$(curl -sS -o /tmp/appr.json -w '%{http_code}' -X POST -H "$AUTH" \
+      -H 'Content-Type: application/json' \
+      -d '{"approved":true}' \
+      "$API/tailnet/$TAILNET/services/$enc/device/$nid/approved" || true)
+    echo "   POST approved -> $acode $(cat /tmp/appr.json)"
   done
 done
 
-echo '== Done =='
+echo
+echo "== Delete orphan services (not in: $EXPECTED) =="
+jq -r '.vipServices[].name' "$SVCS_JSON" | while read -r svc; do
+  [[ -z "$svc" ]] && continue
+  if echo " $EXPECTED " | grep -q " $svc "; then
+    echo "KEEP  $svc"
+    continue
+  fi
+  enc=$(urlenc "$svc")
+  if [[ "$DRY_RUN" == "1" ]]; then
+    echo "ORPHAN $svc (would DELETE)"
+    continue
+  fi
+  dcode=$(curl -sS -o /tmp/del.json -w '%{http_code}' -X DELETE -H "$AUTH" \
+    "$API/tailnet/$TAILNET/services/$enc" || true)
+  echo "DELETE $svc -> $dcode $(head -c 200 /tmp/del.json 2>/dev/null | tr '\n' ' ')"
+done
+
+echo
+echo "== Final service list =="
+curl -fsS -H "$AUTH" "$API/tailnet/$TAILNET/services" \
+  | jq -r '.vipServices[] | .name'
+echo "== Done =="
+rm -f "$SVCS_JSON"


### PR DESCRIPTION
## Summary
- Sync [Tailscale Services](https://login.tailscale.com/admin/services) with cluster fabric
- Approve all advertised hosts; delete orphan VIP Services (old Loki/Prometheus/grafana-ingress names)
- Keep only `svc:grafana`, `svc:meilisearch`, `svc:kube`

## Test plan
- [x] Dry-run listed 3 orphans
- [x] Live DELETE + approve
- [ ] Console shows only the three expected services

Made with [Cursor](https://cursor.com)