### PR TITLE
fix(tailscale): harden grants — admin full, members HTTPS/DNS only

### DIFF
--- a/infrastructure/tailscale/README.md
+++ b/infrastructure/tailscale/README.md
@@ -72,17 +72,19 @@ Copy **Egress IPs** into SaaS IP allowlists when you tighten access.
 
 ### Tailscale SSH
 
-ACL includes `ssh` rules: members → `autogroup:self` (check mode); admins →
-`tag:app-connector` / `tag:k8s` / `tag:k8s-operator` (accept). After ACL apply:
+ACL: **admins** get accept SSH to `autogroup:self` + tagged fabric nodes;
+**members** get check-mode SSH only to their own devices. Network grants:
+admins → full access to `tag:k8s` / `tag:app-connector`; members → `tcp:80,443`
+on `tag:k8s` (Grafana/Meili/kube HTTPS) and DNS-only to the app connector.
 
 ```bash
 # From any tailnet device (Windows / WSL / phone)
 ssh tbaltzakis@github-omv
-# or
-ssh tbaltzakis@github-omv.tail4ecae1.ts.net
+ssh tbaltzakis@omv-ha
 ```
 
-Host must have `--ssh` enabled (`tailscale set --ssh` / already on github-omv).
+Hosts need `--ssh` (`tailscale set --ssh`). Keep classic `sshd` on the LAN
+for break-glass; Tailscale ACLs gate who can reach the Pis over the tailnet.
 
 **Do not** put public `*.cloudless.gr` or Grafana/Meili Serve hosts in Apps —
 those stay on Cloudflare Tunnel / ProxyGroup.

--- a/infrastructure/tailscale/acl-policy.example.json
+++ b/infrastructure/tailscale/acl-policy.example.json
@@ -36,79 +36,43 @@
   },
   "grants": [
     {
-      "src": [
-        "autogroup:member"
-      ],
-      "dst": [
-        "tag:k8s"
-      ],
-      "ip": [
-        "*"
-      ]
+      "src": ["autogroup:admin"],
+      "dst": ["tag:k8s", "tag:k8s-operator", "tag:app-connector"],
+      "ip": ["*"]
     },
     {
-      "src": [
-        "autogroup:member"
-      ],
-      "dst": [
-        "autogroup:self"
-      ],
-      "ip": [
-        "*"
-      ]
+      "src": ["autogroup:member"],
+      "dst": ["tag:k8s"],
+      "ip": ["tcp:80", "tcp:443"]
     },
     {
-      "src": [
-        "autogroup:member"
-      ],
-      "dst": [
-        "autogroup:internet"
-      ],
-      "ip": [
-        "*"
-      ]
+      "src": ["autogroup:member"],
+      "dst": ["tag:app-connector"],
+      "ip": ["tcp:53", "udp:53"]
     },
     {
-      "src": [
-        "autogroup:member"
-      ],
-      "dst": [
-        "tag:app-connector"
-      ],
-      "ip": [
-        "*"
-      ]
+      "src": ["autogroup:member"],
+      "dst": ["autogroup:self"],
+      "ip": ["*"]
+    },
+    {
+      "src": ["autogroup:member"],
+      "dst": ["autogroup:internet"],
+      "ip": ["*"]
     }
   ],
   "ssh": [
     {
-      "action": "check",
-      "src": [
-        "autogroup:member"
-      ],
-      "dst": [
-        "autogroup:self"
-      ],
-      "users": [
-        "autogroup:nonroot",
-        "root"
-      ]
+      "action": "accept",
+      "src": ["autogroup:admin"],
+      "dst": ["autogroup:self", "tag:app-connector", "tag:k8s", "tag:k8s-operator"],
+      "users": ["autogroup:nonroot", "root", "tbaltzakis"]
     },
     {
-      "action": "accept",
-      "src": [
-        "autogroup:admin"
-      ],
-      "dst": [
-        "tag:app-connector",
-        "tag:k8s",
-        "tag:k8s-operator"
-      ],
-      "users": [
-        "autogroup:nonroot",
-        "root",
-        "tbaltzakis"
-      ]
+      "action": "check",
+      "src": ["autogroup:member"],
+      "dst": ["autogroup:self"],
+      "users": ["autogroup:nonroot", "root"]
     }
   ],
   "nodeAttrs": [

--- a/scripts/tailscale-admin-api.sh
+++ b/scripts/tailscale-admin-api.sh
@@ -95,39 +95,32 @@ for key in ("tagOwners", "autoApprovers"):
                 break
         cur[key] = deep_merge_dict(cur.get(key, {}), patch[key])
 
-# grants: append missing by stable JSON identity
+# grants: upsert by (src,dst) so harden passes replace old "*" rules
 if "grants" in patch:
     existing = cur.get("grants") or cur.get("Grants") or []
-    # Prefer lowercase grants (modern)
-    key = "grants" if "grants" in cur or "grants" in patch else "Grants"
+    key = "grants"
     if "grants" not in cur and "Grants" in cur:
         key = "Grants"
-    else:
-        key = "grants"
-    have = {json.dumps(g, sort_keys=True) for g in existing}
-    merged = list(existing)
-    for g in patch["grants"]:
-        sig = json.dumps(g, sort_keys=True)
-        if sig not in have:
-            merged.append(g)
-            have.add(sig)
-    cur[key] = merged
-    # Drop alternate casing duplicate if we standardized
-    if key == "grants" and "Grants" in cur and "grants" in cur:
-        del cur["Grants"]
 
-# ssh: append missing by stable JSON identity (same pattern as grants)
+    def grant_key(g):
+        src = tuple(sorted(g.get("src") or []))
+        dst = tuple(sorted(g.get("dst") or []))
+        return (src, dst)
+
+    by = {grant_key(g): g for g in existing}
+    for g in patch["grants"]:
+        by[grant_key(g)] = g
+    # Drop obsolete member→app-connector / member→k8s wide opens if patch
+    # redefined those destinations (already replaced via grant_key).
+    cur[key] = list(by.values())
+    if key == "grants" and "Grants" in cur:
+        del cur["Grants"]
+    print("grants:", len(cur[key]))
+
+# ssh: example policy is authoritative (full replace of ssh section)
 if "ssh" in patch:
-    existing = cur.get("ssh") or []
-    have = {json.dumps(r, sort_keys=True) for r in existing}
-    merged = list(existing)
-    for r in patch["ssh"]:
-        sig = json.dumps(r, sort_keys=True)
-        if sig not in have:
-            merged.append(r)
-            have.add(sig)
-    cur["ssh"] = merged
-    print("ssh rules:", len(merged))
+    cur["ssh"] = patch["ssh"]
+    print("ssh rules:", len(cur["ssh"]))
 
 # nodeAttrs: merge tailscale.com/app-connectors by name into target "*"
 if "nodeAttrs" in patch:


### PR DESCRIPTION
## Summary
- Members can no longer hit arbitrary ports on tagged nodes (node_exporter, k3s API, etc.) over the tailnet
- Admins keep full access + Tailscale SSH accept; members get `tcp:80/443` → `tag:k8s` and DNS-only → app connector
- ACL merge script replaces the `ssh` section authoritatively; grants upsert by src/dst

## Test plan
- [x] `tailscale-admin-api.yml` with `acl_only=true` — ACL updated (grants: 5, ssh rules: 2)
- [ ] From a non-admin device: HTTPS to Grafana/Meili still works; `:9100` / `:6443` should fail
- [ ] Admin: `ssh tbaltzakis@github-omv` / `omv-ha` still works

Made with [Cursor](https://cursor.com)