### PR TITLE
docs(tailscale): DNS, hardened ACL, Apps, VIP Services

### DIFF
--- a/docs/cluster/README.md
+++ b/docs/cluster/README.md
@@ -3,10 +3,11 @@
 | Doc | File |
 |-----|------|
 | [OMV-MAIN-OPTIMIZED.md](OMV-MAIN-OPTIMIZED.md) | `cluster/OMV-MAIN-OPTIMIZED.md` |
-| [TAILSCALE-FABRIC.md](TAILSCALE-FABRIC.md) | `cluster/TAILSCALE-FABRIC.md` |
-| [kubectl-tailscale.md](kubectl-tailscale.md) | `cluster/kubectl-tailscale.md` |
+| [TAILSCALE-FABRIC.md](TAILSCALE-FABRIC.md) | Architecture, DNS/ACL/Apps/VIP Services, deploy |
+| [kubectl-tailscale.md](kubectl-tailscale.md) | Day-2 kubectl + Tailscale SSH |
 | [in-cluster-monitoring.md](in-cluster-monitoring.md) | `cluster/in-cluster-monitoring.md` |
 | [cluster-capacity-audit-2026-06-21.md](cluster-capacity-audit-2026-06-21.md) | `cluster/cluster-capacity-audit-2026-06-21.md` |
+| [hw-list.md](hw-list.md) | Hardware inventory + prioritized buy list (PSU/hub/NVMe/Pi upgrades) |
 | [cluster-overload-runbook.md](cluster-overload-runbook.md) | `cluster/cluster-overload-runbook.md` |
 | [orphan-k8s-resources-2026-06-21.md](orphan-k8s-resources-2026-06-21.md) | `cluster/orphan-k8s-resources-2026-06-21.md` |
 | [self-hosted-runner-security-audit-1137.md](self-hosted-runner-security-audit-1137.md) | `cluster/self-hosted-runner-security-audit-1137.md` |

--- a/docs/cluster/TAILSCALE-FABRIC.md
+++ b/docs/cluster/TAILSCALE-FABRIC.md
@@ -62,8 +62,8 @@ flowchart TB
 
 | Boundary | Who | What travels | Auth |
 |----------|-----|--------------|------|
-| **Cloudflare public** | Humans, bots, Lighthouse (when not CF-blocked) | App HTTP/S for `*.cloudless.gr` | App session / Cognito / CRON_SECRET |
-| **Tailscale fabric** | Admins, GHA with `TS_AUTHKEY`, Cursor infra MCP | SSH, `:6443`, NodePorts, Serve HTTPS, pod CIDRs | Tailnet ACL + device identity |
+| **Cloudflare public** | Humans, bots, Lighthouse (when not CF-blocked) | App HTTP/S for `*.cloudless.gr` | App session / D1 auth / CRON_SECRET |
+| **Tailscale fabric** | Admins (full), members (HTTPS Serve only), GHA with `TS_AUTHKEY` | SSH, `:6443`, NodePorts, Serve HTTPS, pod CIDRs | Tailnet ACL grants + device identity |
 | **Never cross** | — | DB TCP, etcd, Redis | Stay ClusterIP; use `kubectl port-forward` |
 
 ---
@@ -168,8 +168,56 @@ Manifest map:
 | `proxygroup.yaml` | L7 + API |
 | `ingresses.yaml` | L7 backends |
 | `ingress-class.yaml` | `IngressClass` `tailscale` |
-| `acl-policy.example.json` | ACL tags / autoApprovers / grants |
+| `acl-policy.example.json` | ACL tags / autoApprovers / grants / ssh / Apps `nodeAttrs` |
 | `deploy.sh` | Helm operator install (OAuth env — **no AWS SSM**) |
+
+---
+
+## 4b. DNS, ACL, Apps, VIP Services (operator console)
+
+Day-2 detail also lives in
+[`infrastructure/tailscale/README.md`](../../infrastructure/tailscale/README.md).
+
+### DNS (`tail4ecae1.ts.net`)
+
+| Setting | Value | Do not |
+|---------|-------|--------|
+| MagicDNS | On | Disable / rename tailnet casually |
+| Global nameserver | `100.100.100.100` (MagicDNS) | Add Pi-hole/router as override unless intentional |
+| Search domains | `tail4ecae1.ts.net` | Stuff home-LAN domains in without need |
+| HTTPS Certificates | On | Disable (breaks Serve TLS) |
+
+Connector hosts use `--accept-dns=false` so MagicDNS is not the system
+resolver on the Pi (CoreDNS / LAN DNS stay authoritative).
+
+### Grants + Tailscale SSH (hardened 2026-07-30)
+
+| Src | Dst | Allow |
+|-----|-----|-------|
+| admin | `tag:k8s` / `tag:k8s-operator` / `tag:app-connector` | `*` |
+| member | `tag:k8s` | `tcp:80`, `tcp:443` |
+| member | `tag:app-connector` | DNS `53` only |
+| admin SSH | self + tagged fabric | `accept` |
+| member SSH | self | `check` |
+
+Apply via CI with **`acl_only=true`** (skips dangerous Machine cleanup):
+
+```bash
+gh workflow run tailscale-admin-api.yml -f dry_run=false -f acl_only=true
+```
+
+### VIP Services vs endpoint discovery
+
+| Console surface | What it is | Action |
+|-----------------|------------|--------|
+| **Services** (`svc:grafana`, `svc:meilisearch`, `svc:kube`) | Approved Serve VIP hosts | Keep; prune orphans with `tailscale-approve-service-hosts` |
+| **Machines → discovered endpoints** | Inventory (sshd, node_exporter, k3s, …) | Ignore noise; grants control reachability |
+
+### Apps (app connectors)
+
+Live connector: **`github-omv`** with `tag:app-connector`, advertising SaaS
+CIDRs. Presets + custom domains are in `acl-policy.example.json` `nodeAttrs`.
+Do **not** put `*.cloudless.gr` or Serve VIP hosts into Apps.
 
 ---
 
@@ -307,6 +355,9 @@ Typical secrets: `TS_AUTHKEY` (ephemeral, pre-authorized), `KUBECONFIG_B64`,
 | D6 | No AWS SSM in `deploy.sh` | Free-tier / Cloudflare-first policy — OAuth env only |
 | D7 | Prefer MagicDNS over CGNAT literals | Tailscale IPs rotate; docs and new automation must not hardcode |
 | D8 | CI origin fallback = private fabric L4, not Funnel | Funnel is public Serve over DERP — intermittent timeouts from GHA; NodePort via MagicDNS after `TS_AUTHKEY` is the same origin Cloudflare Tunnel uses |
+| D9 | Members HTTPS-only to `tag:k8s`; admins `*` | Stops accidental reach to node_exporter / k3s / discovery ports over the tailnet |
+| D10 | ACL CI with `acl_only=true` by default | Full admin-api cleanup can delete Connector Machines that look “stale” |
+| D11 | App connector on a tagged Linux host + MagicDNS DNS page unchanged | SaaS egress via Apps; public site stays Cloudflare |
 
 ---
 
@@ -332,6 +383,12 @@ mindmap
       port-forward only
     AWS SSM for TS OAuth
       Use TS_CLIENT_ID/SECRET env
+    Member grants ip *
+      Re-opens :9100 / :6443
+    Disable MagicDNS or HTTPS certs
+      Breaks Serve + svc VIP names
+    Put cloudless.gr in Apps
+      Public edge is Cloudflare
 ```
 
 Checklist before merging Tailscale changes:
@@ -341,7 +398,10 @@ Checklist before merging Tailscale changes:
 - [ ] No new Funnel-primary path for `cloudless.gr`?
 - [ ] CI origin checks use **private** MagicDNS NodePort (not public Funnel)?
 - [ ] Scripts use MagicDNS or document IP refresh?
-- [ ] ACL `tag:k8s` / `tag:k8s-operator` still own the tags?
+- [ ] ACL `tag:k8s` / `tag:k8s-operator` / `tag:app-connector` still owned?
+- [ ] Member grants still HTTPS/DNS-only (not `*` to tagged nodes)?
+- [ ] ACL apply uses `acl_only=true` unless device cleanup is intentional?
+- [ ] DNS page still MagicDNS + HTTPS Certificates on?
 
 ---
 
@@ -352,15 +412,22 @@ Checklist before merging Tailscale changes:
 1. OAuth client (Devices Core + Auth Keys write) tagged **`tag:k8s-operator`**:
    https://login.tailscale.com/admin/settings/oauth
 2. Merge [`acl-policy.example.json`](../../infrastructure/tailscale/acl-policy.example.json)
-   into Access controls (`tagOwners`, `autoApprovers`, `grants`).
-3. Enable HTTPS Certificates (Serve / kube-apiserver):
+   into Access controls (`tagOwners`, `autoApprovers`, `grants`, `ssh`, `nodeAttrs`):
+
+```bash
+gh workflow run tailscale-admin-api.yml -f dry_run=false -f acl_only=true
+```
+
+3. Confirm DNS console: MagicDNS on, global NS `100.100.100.100`, HTTPS
+   Certificates on (see §4b).
+4. Enable HTTPS Certificates if the toggle was ever off:
 
 ```bash
 bash scripts/tailscale-enable-https.sh
 # Workflow: Tailscale enable HTTPS
 ```
 
-4. Approve Service hosts (HA VIPs stay dark until approved):
+5. Approve Service hosts (HA VIPs stay dark until approved):
 
 ```bash
 bash scripts/tailscale-approve-service-hosts.sh
@@ -421,7 +488,7 @@ sudo tailscale set --accept-routes   # Linux with real TUN
 | `tailscale-approve-service-hosts.yml` | Approve `svc:*` hosts |
 | `tailscale-fix-fabric-acl.yml` | ACL merge helper |
 | `tailscale-probe-posture.yml` | Posture / health of fabric |
-| `tailscale-admin-api.yml` | Admin API automation |
+| `tailscale-admin-api.yml` | ACL merge (+ optional device cleanup); prefer `acl_only=true` |
 | `scripts/tailscale-diagnose.sh` | Local diagnosis |
 | `scripts/setup-kubectl-tailscale.sh` | Client kubeconfig helper |
 | `scripts/ts-wsl.sh` | WSL userspace Tailscale |
@@ -441,6 +508,9 @@ flowchart TD
   Q -->|Funnel HTTPS times out| A5b[Expected — Funnel is not SLA<br/>use private NodePort path]
   Q -->|NodePort timeout on 100.x| A6[Stale CGNAT — resolve MagicDNS<br/>after Tailscale join]
   Q -->|Offline tagged device| A7[Delete in admin UI<br/>see OFFLINE-DEVICE-TROUBLESHOOTING]
+  Q -->|Member hits :9100/:6443| A8[Expected deny — grants are HTTPS-only<br/>promote to admin or use LAN]
+  Q -->|Apps red / SaaS not routed| A9[Connector tag + advertise-connector<br/>ACL nodeAttrs + MagicDNS on]
+  Q -->|svc VIP empty/dark| A10[Approve Service host<br/>HTTPS Certificates on]
 ```
 
 ```bash
@@ -479,4 +549,7 @@ Offline / orphaned devices: [`OFFLINE-DEVICE-TROUBLESHOOTING.md`](../../infrastr
 | **Connector** | Operator CR that advertises subnet routes |
 | **ProxyGroup** | Shared proxy StatefulSet (`ingress` / `egress` / `kube-apiserver`) |
 | **MagicDNS** | `*.tail4ecae1.ts.net` names — prefer over CGNAT IPs |
+| **VIP Service** | Approved `svc:*` Serve host (grafana / meilisearch / kube) |
+| **App connector** | Tagged node advertising SaaS routes for Tailscale Apps |
+| **Endpoint discovery** | Machines UI inventory — not an allow rule |
 | **pi-origin** | Cloudflare hostname → Tunnel → `192.168.1.128:30300` |

--- a/docs/cluster/hw-list.md
+++ b/docs/cluster/hw-list.md
@@ -1,0 +1,172 @@
+# Cluster hardware list — improve reliability & headroom
+
+Living inventory + prioritized buy / swap list for the cloudless.gr Pi
+k3s fabric (`omv` + `omv-ha`). Written after the **2026-07-30** hard-reboot
+storm (four abrupt omv resets the same day: USB-SSD I/O stall → OMV
+`RuntimeWatchdogSec=15` → silent reset; mass Kuma `EAI_AGAIN`).
+
+Software mitigations already on omv (do not undo):
+
+- `/etc/udev/rules.d/60-ssd-rotational.rules` — `sd[ab]` → non-rotational,
+  `nr_requests=256`, `read_ahead_kb=128`
+- `/etc/systemd/system.conf.d/zz-cloudless-watchdog.conf` —
+  `RuntimeWatchdogSec=60` (overrides OMV’s 15s; filename must sort after
+  `openmediavault-watchdog.conf`)
+
+Related: [cluster-overload-runbook.md](cluster-overload-runbook.md),
+[cluster-capacity-audit-2026-06-21.md](cluster-capacity-audit-2026-06-21.md),
+[TAILSCALE-FABRIC.md](TAILSCALE-FABRIC.md), storage notes in `CLAUDE.md`
+(omv-main layout).
+
+---
+
+## Current inventory (verified 2026-07-30)
+
+### `omv` — control plane (LAN `192.168.1.128`, keepalived VIP `192.168.1.200`)
+
+| Item | What we have | Role / notes |
+|------|----------------|--------------|
+| Board | **Raspberry Pi 5 Model B Rev 1.0**, 8 GiB | k3s server, GH runners, most workloads |
+| OS root | microSD **~59 GB** (`mmcblk0`, ~81% full) | OS only — keep under ~75% |
+| k3s data SSD | **SanDisk SDSSDP128G** 119 GB via **ICY BOX IB-AC603b-U3** (JMicron **JMS578**, UAS, USB3) | `/var/lib/rancher/k3s` + local-path PVs — **critical path** |
+| User-data SSD | **Samsung SSD 860 EVO 1 TB** via **ASMedia ASM1153 / AS2115** (USB3, currently **`usb-storage` not UAS**) | Backups / media share — must not host k3s |
+| NIC | Onboard GbE `eth0` | Primary LAN |
+| Power | USB-C PD (confirm official **27 W** brick on-site) | `EXT5V` ~5.10 V idle; no logged under-voltage across last 5 boots — resets still happened |
+| USB topology | Both SSDs **direct on Pi USB3** (no powered hub) | Highest hardware risk |
+
+### `omv-ha` — worker / standby (LAN `192.168.1.130`)
+
+| Item | What we have | Role / notes |
+|------|----------------|--------------|
+| Board | **Raspberry Pi 3 Model B Rev 1.2**, **~1 GiB** RAM | k3s agent; AppFlowy worker pin (4 KiB pages); keepalived peer |
+| Storage | microSD **~30 GB** only | No dedicated SSD |
+| NIC | Onboard Fast Ethernet (SMSC) | Fine for standby / light pods |
+
+Docs historically said “Pi 4 1 GB”; live `device-tree` is **Pi 3 B**. Treat capacity accordingly — effectively saturated for anything >~100 Mi.
+
+### Shared / network
+
+| Item | What we have |
+|------|----------------|
+| Keepalived VIP | `192.168.1.200/24` on `eth0` |
+| Tailscale | Host mesh — see [TAILSCALE-FABRIC.md](TAILSCALE-FABRIC.md) |
+| Office LAN | `192.168.1.0/24` |
+
+---
+
+## Pain points the HW should fix
+
+1. **Bus-powered dual USB3 SSD on Pi 5** — peak I/O can freeze the box hard enough that journals end mid-flight with **no** under-voltage sticky bit.
+2. **ASMedia bridge on `usb-storage`** — higher latency / stall risk than UAS (SanDisk/JMicron path).
+3. **k3s on USB-SATA** — etcd fsync latency; already tuned (udev + etcd intervals); still weaker than NVMe.
+4. **omv-ha is a Pi 3 / 1 GiB** — cannot absorb failover of heavy pods; Raft HA needs a **third** capable node anyway.
+5. **Root SD 81%** on omv — unrelated to USB stalls but next disk-pressure landmine.
+6. **RAM on omv ~2.5 GiB available** under load — post-reboot image/page storms amplify USB stalls.
+
+---
+
+## Prioritized shopping list
+
+Priority: **P0** = stops silent reboots / data risk · **P1** = real HA / headroom · **P2** = nice quality-of-life.
+
+### P0 — power & USB (do first, at the box)
+
+| # | Buy / do | Why | Approx. target |
+|---|----------|-----|----------------|
+| 1 | Confirm / replace with **official Raspberry Pi 27 W USB-C PD** PSU + short known-good PD cable | Weak chargers brown out without clean logs | Official Pi PSU |
+| 2 | **Powered USB 3.0/3.1 hub** (self-powered, ≥2 A hub supply, UASP-friendly) — move **both** SSD enclosures onto the hub; one uplink to Pi USB3 | Removes dual bus-powered SSD load from the SoC | Quality powered hub (e.g. UGREEN / Anker with external brick — verify UASP) |
+| 3 | Optional: replace ASMedia enclosure with a **JMicron JMS578 / ASM235CM** enclosure known-good for **UAS** on Pi | Drop `usb-storage`-only path on the 1 TB disk | USB3-SATA enclosure w/ UAS |
+
+### P0 — storage hygiene (cheap / free)
+
+| # | Buy / do | Why |
+|---|----------|-----|
+| 4 | Larger / healthier **microSD** for omv root (A2, endurance), or free SD to &lt;70% | 81% root invites unrelated failures |
+| 5 | Keep **k3s only on SanDisk (`sda`)** — never remount k3s onto the Samsung share | Already policy; re-check after any OMV UI change |
+
+### P1 — control-plane storage upgrade
+
+| # | Buy / do | Why | Approx. target |
+|---|----------|-----|----------------|
+| 6 | **Pi 5 PCIe / NVMe HAT** + **NVMe SSD ≥256 GB** (DRAM or HMB, not QLC-trash) for k3s data | Cuts USB-SATA from the etcd path; biggest reliability win after powered hub | Official or Pineboards/Pimoroni-class HAT + 256–512 GB NVMe |
+| 7 | Retire SanDisk USB stick from k3s once NVMe proven; reuse as cold backup | Simplifies USB bus | — |
+
+### P1 — second capable node (real worker, not Pi 3)
+
+| # | Buy / do | Why | Approx. target |
+|---|----------|-----|----------------|
+| 8 | **Raspberry Pi 5 8 GB** (or 16 GB) as new `omv-ha` / worker | Current Pi 3 cannot take Postiz/Prometheus/AppFlowy spill | Pi 5 8 GB + case + 27 W PSU |
+| 9 | NVMe or USB3 SSD (≥128 GB) for the new worker | local-path + image layers | Same as omv pattern |
+| 10 | Keep Pi 3 as optional IoT / MQTT edge **outside** critical scheduling | Avoid pretending it is HA capacity | — |
+
+### P1 — true k3s HA (when 3 servers exist)
+
+| # | Buy / do | Why |
+|---|----------|-----|
+| 11 | **Third Pi 5** (or x86 mini PC) as odd-numbered etcd member | 2-node Raft = quorum 2 = zero failure tolerance; see Notion k3s runbook |
+| 12 | Dedicated small UPS for omv (+ hub + switch) | Silent power blips look like “watchdog reboots” |
+
+### P2 — niceties
+
+| # | Buy / do | Why |
+|---|----------|-----|
+| 13 | Gigabit switch port quality / short Cat6 to omv | Reduce spurious VIP / Tailscale flapping noise |
+| 14 | Active cooler / case airflow check on Pi 5 | Thermal OK today (~55 °C); keep headroom under image builds |
+| 15 | Label cables: `k3s-ssd`, `userdata-ssd`, `hub-uplink`, `PD-in` | Faster incident response at the desk |
+
+---
+
+## Suggested buy order (minimal spend → max stability)
+
+```text
+1. Verify 27W PD PSU + cable
+2. Powered USB3 hub → both SSDs off the Pi ports
+3. Free omv root SD (or replace card)
+4. NVMe HAT + SSD for k3s on omv
+5. Replace omv-ha Pi 3 with Pi 5 8GB (+ disk + PSU)
+6. UPS
+7. Third server node for etcd HA
+```
+
+---
+
+## At-the-box verification (after P0)
+
+```bash
+# On omv — SSDs should sit behind a hub (extra USB level in tree)
+lsusb -t
+
+# Still non-rotational / deep queue after reboot
+cat /sys/block/sd{a,b}/queue/rotational
+cat /sys/block/sd{a,b}/queue/nr_requests
+
+# Watchdog still 60s (zz- drop-in wins over OMV)
+systemctl show -p RuntimeWatchdogUSec
+
+# Prefer UAS on both mass-storage devices
+dmesg -T | grep -iE 'uas|usb-storage|JMicron|ASMedia' | tail -20
+
+# Power sticky bits (should stay 0x0)
+vcgencmd get_throttled
+```
+
+Expect: hub in the USB tree; both disks `rota=0` `nr_requests=256`;
+`RuntimeWatchdogUSec=1min`; fewer or zero hard boots in `journalctl --list-boots`.
+
+---
+
+## Out of scope / do not buy for this cluster
+
+| Idea | Why not |
+|------|---------|
+| Self-hosted Sentry / full ELK on Pis | RAM — keep SaaS (see capacity audit) |
+| Second spinning HDD on USB for k3s | Latency / stalls worse than today |
+| Relying on omv-ha Pi 3 for control-plane failover | Insufficient RAM/CPU; wrong page size for some images |
+
+---
+
+## Changelog
+
+| Date | Note |
+|------|------|
+| 2026-07-30 | Initial list from live inventory + reboot-storm RCA (`omv-ha` corrected to Pi 3 B). |

--- a/docs/cluster/kubectl-tailscale.md
+++ b/docs/cluster/kubectl-tailscale.md
@@ -22,7 +22,8 @@ flowchart TD
 | Situation | Use |
 |-----------|-----|
 | Sitting on office LAN | LAN kubeconfig → `https://192.168.1.128:6443` |
-| Off-LAN, system Tailscale (TUN) | `ProxyGroup/kube` Serve URL |
+| Off-LAN, **admin** + system Tailscale (TUN) | `ProxyGroup/kube` Serve URL |
+| Off-LAN, **member** (non-admin) | No `:6443` over fabric — use LAN or ask an admin |
 | WSL userspace only | Prefer LAN; userspace SOCKS to `100.x:6443` is unreliable |
 
 ## Endpoints (prefer MagicDNS)
@@ -82,11 +83,16 @@ ssh -J tbaltzakis@192.168.1.130 tbaltzakis@192.168.1.128 \
   'KUBECONFIG=~/.kube/config kubectl get nodes'
 ```
 
-Over Tailscale (MagicDNS):
+Over Tailscale MagicDNS (admin ACL + `tailscale set --ssh` on the host):
 
 ```bash
+ssh tbaltzakis@github-omv 'kubectl get nodes'
+# or fully qualified:
 ssh tbaltzakis@github-omv.tail4ecae1.ts.net 'kubectl get nodes'
 ```
+
+Members cannot reach `:6443` / SSH on tagged nodes over the fabric (HTTPS-only
+grants). Prefer LAN `sshd` as break-glass. See fabric doc §4b.
 
 ## Machines hygiene
 

--- a/infrastructure/tailscale/README.md
+++ b/infrastructure/tailscale/README.md
@@ -1,10 +1,15 @@
 # Tailscale Operator (fabric interconnect)
 
 Canonical architecture: [`docs/cluster/TAILSCALE-FABRIC.md`](../../docs/cluster/TAILSCALE-FABRIC.md)  
-kubectl day-2: [`docs/kubectl-tailscale.md`](../../docs/kubectl-tailscale.md)
+kubectl day-2: [`docs/cluster/kubectl-tailscale.md`](../../docs/cluster/kubectl-tailscale.md)
 
 Private admin mesh for Pi k3s. **Public** `*.cloudless.gr` stays on Cloudflare
 (Worker + Tunnel) — do not reintroduce Funnel as the production edge.
+
+**Tailnet:** `tail4ecae1.ts.net`  
+**Admin:** https://login.tailscale.com/admin
+
+---
 
 ## Quick deploy
 
@@ -17,10 +22,22 @@ bash infrastructure/tailscale/deploy.sh
 
 Then:
 
-1. Merge `acl-policy.example.json` into Tailscale Access controls.
+1. Merge `acl-policy.example.json` into Access controls (prefer CI below).
 2. Enable HTTPS Certificates (`scripts/tailscale-enable-https.sh`).
 3. Approve Service hosts (`scripts/tailscale-approve-service-hosts.sh`).
 4. Delete stale per-Service Machines from earlier ProxyGroup mistakes.
+
+### Apply ACL from CI (preferred)
+
+```bash
+# ACL only — skips device cleanup (safe default)
+gh workflow run tailscale-admin-api.yml -f dry_run=false -f acl_only=true
+```
+
+Always use `acl_only=true` unless you intentionally want device orphan cleanup.
+Full cleanup can delete mis-matched Machines (e.g. Connector replicas).
+
+---
 
 ## Layout
 
@@ -42,43 +59,57 @@ flowchart LR
 | `proxygroup.yaml` | Shared `ingress` ProxyGroup + `kube-apiserver` ProxyGroup |
 | `ingresses.yaml` | Grafana / Meili with `tailscale.com/proxy-group: ingress` |
 | `ingress-class.yaml` | `IngressClass` `tailscale` |
-| `acl-policy.example.json` | tagOwners + autoApprovers + grants + **Apps** (`nodeAttrs` app-connectors) |
+| `acl-policy.example.json` | tagOwners + autoApprovers + grants + ssh + **Apps** (`nodeAttrs`) |
 | `deploy.sh` | Helm install (OAuth env only — no AWS SSM) |
 | `subnet-router.yaml` / `proxygroup-monitoring.yaml` | Deprecated stubs — do not apply |
 | `OFFLINE-DEVICE-TROUBLESHOOTING.md` | Stale Machines cleanup |
 
-## Tailscale Apps (SaaS app connectors)
+---
 
-ACL patch includes `tag:app-connector` plus presets (**GitHub**, **Stripe**, **Google Workspace**) and custom domains (**Notion**, **Sentry**, **Slack**, **Cloudflare**, **Anthropic**). Merge + apply:
+## DNS (admin console — leave as-is)
 
-```bash
-# From CI (preferred — uses repo OAuth secrets)
-gh workflow run tailscale-admin-api.yml -f dry_run=false
+Console: **DNS** → https://login.tailscale.com/admin/dns
 
-# Or locally with TS_CLIENT_ID + TS_CLIENT_SECRET
-DRY_RUN=0 bash scripts/tailscale-admin-api.sh
-```
+| Setting | Required value | Why |
+|---------|----------------|-----|
+| Tailnet DNS name | `tail4ecae1.ts.net` | MagicDNS, Serve, VIP Services, certs |
+| MagicDNS | **On** | Hostnames + `svc:*` names |
+| Global nameserver | MagicDNS `100.100.100.100` | Resolves tailnet + Apps connector domains |
+| Search domains | `tail4ecae1.ts.net` only | Short names work; do not add home LAN domains unless needed |
+| HTTPS Certificates | **On** | Serve TLS for Grafana / Meili / kube |
+| Extra / local nameservers | **None** | Do not override with Pi-hole/router here |
 
-Then designate a **stable Linux** node (prefer office/NAS/VPS — not overloaded omv):
+Do **not** rename the tailnet, disable MagicDNS, or disable HTTPS.
 
-```bash
-sudo tailscale up --advertise-connector --advertise-tags=tag:app-connector \
-  --accept-routes --accept-dns=false
-```
+**Host flag:** connector / overloaded Pis use `--accept-dns=false` so MagicDNS is
+not the system resolver (avoids fights with CoreDNS / LAN DNS). Clients
+(office laptop, phone) should keep default DNS accept so MagicDNS works.
 
-Approve the tag in the admin console if prompted. Apps go green at
-https://login.tailscale.com/admin/apps once a connector is online.
-Copy **Egress IPs** into SaaS IP allowlists when you tighten access.
+---
+
+## Access controls (grants + SSH)
+
+Source of truth: [`acl-policy.example.json`](acl-policy.example.json).  
+Live merge: `scripts/tailscale-admin-api.sh` (grants upsert by src/dst; **ssh
+section is replaced** from the example file).
+
+| Who | Destination | Ports / action |
+|-----|-------------|----------------|
+| `autogroup:admin` | `tag:k8s`, `tag:k8s-operator`, `tag:app-connector` | `*` (full) |
+| `autogroup:member` | `tag:k8s` | `tcp:80`, `tcp:443` only (Serve HTTPS) |
+| `autogroup:member` | `tag:app-connector` | `tcp:53`, `udp:53` only |
+| `autogroup:member` | `autogroup:self` / `internet` | `*` |
+| Admin SSH | self + tagged fabric | `action: accept` (users include `tbaltzakis`) |
+| Member SSH | `autogroup:self` | `action: check` only |
+
+Members must **not** get `ip: ["*"]` to tagged nodes — that re-opens
+node_exporter (`:9100`), k3s (`:6443`), SSH, and discovery noise as real
+reachability.
 
 ### Tailscale SSH
 
-ACL: **admins** get accept SSH to `autogroup:self` + tagged fabric nodes;
-**members** get check-mode SSH only to their own devices. Network grants:
-admins → full access to `tag:k8s` / `tag:app-connector`; members → `tcp:80,443`
-on `tag:k8s` (Grafana/Meili/kube HTTPS) and DNS-only to the app connector.
-
 ```bash
-# From any tailnet device (Windows / WSL / phone)
+# From any tailnet device (Windows / WSL / phone) — admin
 ssh tbaltzakis@github-omv
 ssh tbaltzakis@omv-ha
 ```
@@ -86,8 +117,71 @@ ssh tbaltzakis@omv-ha
 Hosts need `--ssh` (`tailscale set --ssh`). Keep classic `sshd` on the LAN
 for break-glass; Tailscale ACLs gate who can reach the Pis over the tailnet.
 
+---
+
+## VIP Services (Serve hosts)
+
+Console: **Services** (VIP / `svc:*`) — not the same as **Machines** discovery.
+
+Expected approved hosts (keep):
+
+| Service | MagicDNS |
+|---------|----------|
+| `svc:grafana` | `grafana.tail4ecae1.ts.net` |
+| `svc:meilisearch` | `meilisearch.tail4ecae1.ts.net` |
+| `svc:kube` | kube ProxyGroup Serve URL |
+
+Approve / prune orphans:
+
+```bash
+gh workflow run tailscale-approve-service-hosts.yml
+# or: bash scripts/tailscale-approve-service-hosts.sh
+```
+
+Do **not** keep legacy per-stack names like
+`svc:monitoring-grafana-tailscale-ingress` — delete those orphans.
+
+---
+
+## Endpoint discovery (Machines UI)
+
+The admin UI may list discovered endpoints (SSH, hallpass, node_exporter,
+k3s, random `:8080`). That is **inventory**, not ACL permission.
+
+- Noise is OK to leave; do not “fix” discovery by opening grants.
+- Reachability is controlled by **grants** above (members = HTTPS only).
+- Public `*.cloudless.gr` stays on Cloudflare — never put those in Apps.
+
+---
+
+## Tailscale Apps (SaaS app connectors)
+
+ACL includes `tag:app-connector` plus presets (**GitHub**, **Stripe**,
+**Google Workspace**) and custom domains (**Notion**, **Sentry**, **Slack**,
+**Cloudflare**, **Anthropic**). Names in `nodeAttrs` must be hyphenated
+(no spaces).
+
+```bash
+gh workflow run tailscale-admin-api.yml -f dry_run=false -f acl_only=true
+```
+
+Live connector is on **`github-omv`** (stable enough; prefer a quiet office/NAS
+host if omv is overloaded):
+
+```bash
+sudo tailscale up --hostname=github-omv --advertise-connector \
+  --advertise-tags=tag:app-connector \
+  --accept-routes --accept-dns=false --ssh
+```
+
+Apps go green at https://login.tailscale.com/admin/apps once the connector is
+online and advertising SaaS CIDRs. Copy **Egress IPs** into SaaS allowlists
+when you tighten access.
+
 **Do not** put public `*.cloudless.gr` or Grafana/Meili Serve hosts in Apps —
 those stay on Cloudflare Tunnel / ProxyGroup.
+
+---
 
 ## Design rules
 
@@ -97,3 +191,5 @@ those stay on Cloudflare Tunnel / ProxyGroup.
 4. **kubectl remotely → kube-apiserver ProxyGroup** (`tailscale configure kubeconfig`).
 5. **No Funnel** for these GUIs — Cloudflare Access / Tunnel covers public HTTP.
 6. **MagicDNS over CGNAT literals** in new scripts (`*.tail4ecae1.ts.net`).
+7. **ACL apply with `acl_only=true`** unless you mean to run device cleanup.
+8. **Members → HTTPS-only** on `tag:k8s`; admins keep full fabric access.


### PR DESCRIPTION
## Summary
- Expand `infrastructure/tailscale/README.md` with DNS leave-as-is table, ACL grants, VIP Services vs discovery, Apps connector, `acl_only=true`
- Add §4b + decisions D9–D11 + troubleshooting to `TAILSCALE-FABRIC.md`
- Note admin vs member kubectl/SSH paths in `kubectl-tailscale.md`
- Index `hw-list.md` in the cluster README

## Test plan
- [ ] Skim README + §4b against live console (DNS / Services / Apps)
- [ ] Confirm links resolve in GitHub UI

Made with [Cursor](https://cursor.com)