### PR TITLE
auth link styles + E2E test credentials

### DIFF
--- a/.env.e2e
+++ b/.env.e2e
@@ -1,1 +1,5 @@
 NEXT_PUBLIC_E2E=1
+E2E_ADMIN_EMAIL=admin@cloudless.gr
+E2E_ADMIN_PASSWORD=admin123
+E2E_USER_EMAIL=user@cloudless.gr
+E2E_USER_PASSWORD=user123

--- a/src/app/[locale]/auth/login/page.tsx
+++ b/src/app/[locale]/auth/login/page.tsx
@@ -162,7 +162,7 @@ function LoginContent() {
 
           <p className="mt-6 text-center font-mono text-sm text-slate-500">
             {t("auth.noAccount", "Don't have an account?")}{" "}
-            <Link href="/auth/signup" className="text-neon-cyan hover:underline">
+            <Link href="/auth/signup" className="text-neon-cyan underline hover:no-underline">
               {t("auth.signup", "Create Account")}
             </Link>
           </p>

--- a/src/app/[locale]/auth/signup/page.tsx
+++ b/src/app/[locale]/auth/signup/page.tsx
@@ -362,7 +362,7 @@ function SignUpForm() {
 
               <p className="mt-6 text-center font-mono text-sm text-slate-500">
                 {t("auth.hasAccount", "Already have an account?")}{" "}
-                <Link href="/auth/login" className="text-neon-cyan hover:underline">
+                <Link href="/auth/login" className="text-neon-cyan underline hover:no-underline">
                   {t("auth.login", "Sign In")}
                 </Link>
               </p>


### PR DESCRIPTION
## Summary
- **auth pages:** show the cross-link (`Create Account` on login, `Sign In` on signup) as underlined by default; drop underline on hover. Prior styling was hover-only, making the link nearly invisible until pointed at.
- **.env.e2e:** add `E2E_ADMIN_EMAIL`/`E2E_ADMIN_PASSWORD` and `E2E_USER_EMAIL`/`E2E_USER_PASSWORD`. Without these, `playwright.config.mts`'s `setup` project writes empty `e2e/.auth/{user,admin}.json` and every storageState-based deep spec fails ENOENT on a fresh checkout (per CLAUDE.md E2E conventions section). These are local test creds only — Cloudflare D1 auth ignores this file in production.

Two separate commits (unrelated changes, per CLAUDE.md commit hygiene).

## Test plan
- [ ] `pnpm dev` — visit `/en/auth/login` and `/en/auth/signup`, confirm cross-links are underlined by default
- [ ] `pnpm test:e2e` — setup project writes non-empty `e2e/.auth/*.json`
- [ ] Deep specs (`admin-*`, `journey-*`) run past the auth-fixture step

🤖 Generated with [Claude Code](https://claude.com/claude-code)