### PR TITLE
cloudflare-deploy env hoist + locale layout title template

### DIFF
--- a/.github/workflows/cloudflare-deploy.yml
+++ b/.github/workflows/cloudflare-deploy.yml
@@ -39,6 +39,12 @@ on:
         type: boolean
         default: false
 
+# One deploy at a time — parallel runs would race on the D1 migration lock
+# and on the cloudless2 script tag in ECR-equivalent (Workers script upload).
+concurrency:
+  group: cloudflare-deploy-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
   deploy:
     runs-on: ubuntu-latest
@@ -46,7 +52,39 @@ jobs:
       contents: read
       id-token: write
 
+    # Shared env for every step below — wrangler + the Tunnel setup script
+    # both read these. Hoisted here so the required secrets/config for a
+    # cloudless2 deploy live in exactly one place, not smeared per step.
+    env:
+      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
+      # Wrangler auth (both names — wrangler reads CLOUDFLARE_*, some helpers read CF_*)
+      CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+      CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CF_ACCOUNT_ID }}
+      CF_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+      CF_ACCOUNT_ID: ${{ secrets.CF_ACCOUNT_ID }}
+      # Tunnel-set target (script reads these directly)
+      PI_NODEPORT_ORIGIN: http://192.168.1.128:30300
+      TUNNEL_HOSTS: pi-origin.cloudless.gr
+      # Worker vars — also baked into workers/pi-origin-proxy/wrangler.jsonc "vars",
+      # exported here so any diagnostic step or hand-run wrangler invocation
+      # uses the same values.
+      PI_ORIGIN_HOST: pi-origin.cloudless.gr
+      PI_TIMEOUT_MS: '30000'
+
     steps:
+    - name: Validate required secrets
+      run: |
+        set -euo pipefail
+        missing=()
+        [ -n "${CLOUDFLARE_API_TOKEN:-}" ] || missing+=("CLOUDFLARE_API_TOKEN")
+        [ -n "${CLOUDFLARE_ACCOUNT_ID:-}" ] || missing+=("CF_ACCOUNT_ID (→ CLOUDFLARE_ACCOUNT_ID)")
+        if [ ${#missing[@]} -gt 0 ]; then
+          echo "::error::Missing required repo secrets: ${missing[*]}"
+          echo "Set them at Settings → Secrets and variables → Actions."
+          exit 1
+        fi
+        echo "OK  required Cloudflare secrets present."
+
     - name: Checkout
       uses: actions/checkout@v4
 
@@ -64,20 +102,10 @@ jobs:
     - name: Apply D1 migrations
       run: npx wrangler d1 migrations apply user-auth-db --remote --config
         wrangler.jsonc
-      env:
-        FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
-        CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-        CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CF_ACCOUNT_ID }}
 
     - name: Point Tunnel hosts at Pi NodePort (free origin)
         # pi-origin must hit Pi directly — never the Worker — or the proxy loops.
       run: python3 scripts/cf-tunnel-set-pi-origin.py
-      env:
-        FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
-        CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-        CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CF_ACCOUNT_ID }}
-        PI_NODEPORT_ORIGIN: http://192.168.1.128:30300
-        TUNNEL_HOSTS: pi-origin.cloudless.gr
 
     - name: Deploy free Pi-origin proxy Worker
         # Replaces fat OpenNext script on cloudless2 with a <50 KiB proxy.
@@ -87,10 +115,6 @@ jobs:
         if grep -qE 'Total Upload:.*gzip:' /tmp/cf-proxy-deploy.log; then
           grep -E 'Total Upload:.*gzip:' /tmp/cf-proxy-deploy.log
         fi
-      env:
-        FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
-        CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-        CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CF_ACCOUNT_ID }}
 
     - name: Optional OpenNext attempt (manual only)
       if: ${{ github.event_name == 'workflow_dispatch' && inputs.try_opennext ==
@@ -118,14 +142,13 @@ jobs:
           fi
           exit 1
         fi
-      env:
-        FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
-        CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-        CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CF_ACCOUNT_ID }}
 
-# Required secrets:
-# CLOUDFLARE_API_TOKEN - Cloudflare API token (Tunnel Edit + Workers)
-# CF_ACCOUNT_ID - Cloudflare account ID
+# Required repo secrets:
+#   CLOUDFLARE_API_TOKEN - Cloudflare API token (Zone.DNS:Edit + Workers:Edit + D1:Edit)
+#   CF_ACCOUNT_ID        - Cloudflare account ID
+# Both are validated by the first step and re-exported as CLOUDFLARE_/CF_ pairs
+# so wrangler and the Tunnel script pick them up regardless of which naming
+# convention they read.
 #
 # Free plan: cloudless2 = pi-origin-proxy. App deploys: deploy-pi.yml.
 # OpenNext SSR on Workers Free is not supported for this codebase (~5.5 MiB).

--- a/src/app/[locale]/layout.tsx
+++ b/src/app/[locale]/layout.tsx
@@ -50,6 +50,10 @@ export async function generateMetadata({
   };
 
   return {
+    title: {
+      default: "Cloudless — Cloud Computing, Serverless & AI Marketing",
+      template: "%s | Cloudless",
+    },
     alternates: {
       languages: {
         en: `${BASE_URL}/en`,

--- a/src/app/[locale]/page.tsx
+++ b/src/app/[locale]/page.tsx
@@ -59,10 +59,7 @@ export async function generateMetadata({
     "Clear skies. Zero friction. We help startups and SMBs with cloud architecture, serverless development, data analytics, and AI-powered digital marketing.";
 
   return {
-    title: {
-      template: "%s | Cloudless",
-      default: title,
-    },
+    title: { absolute: title },
     description,
     alternates: {
       canonical,


### PR DESCRIPTION
Two unrelated cleanups from one session, split into separate commits per CLAUDE.md.

## 1. `ci(cloudflare-deploy)` — env hoist + fail-fast validation
Requested during the just-triggered manual deploy (successful, 54s).

- Move `CLOUDFLARE_API_TOKEN` / `CF_ACCOUNT_ID` / `PI_NODEPORT_ORIGIN` / `TUNNEL_HOSTS` / `PI_ORIGIN_HOST` / `PI_TIMEOUT_MS` out of three per-step `env:` blocks into one job-level `env:` block. Also re-exports `CLOUDFLARE_*` ⇄ `CF_*` pairs so both wrangler and the tunnel-set script pick up the right name regardless of which convention they read.
- Add a **Validate required secrets** first step with a clear `::error::` annotation if `CLOUDFLARE_API_TOKEN` or `CF_ACCOUNT_ID` are missing — beats a mid-deploy 401.
- Add `concurrency: cloudflare-deploy-<ref>` (`cancel-in-progress: false`) so parallel dispatches queue instead of racing on the D1 migration lock and the `cloudless2` script tag.

## 2. `feat(seo)` — title template at the locale layout
Fixes an April 2026 UX audit finding (contact/blog tabs showed bare "Contact Us" / "Blog").

- `[locale]/layout.tsx`: set `title.default` (BRAND v3 SEO title) + `template: "%s | Cloudless"`. Every page returning `title: "Foo"` now renders "Foo | Cloudless".
- `[locale]/page.tsx`: drop the redundant per-page template and use `title.absolute` for the homepage's verbatim BRAND v3 SEO title.

## Test plan
- [ ] Manual dispatch of `cloudflare-deploy.yml` with the changes on main runs green (validate step succeeds, hoisted env still visible to wrangler)
- [ ] Manual dispatch with `CLOUDFLARE_API_TOKEN` renamed away shows the fail-fast annotation
- [ ] `pnpm dev` — visit `/en/contact`, tab title reads "Contact Us | Cloudless"; `/en/blog`, tab reads "Blog | Cloudless"; `/en` reads the full BRAND v3 SEO title, unmodified

🤖 Generated with [Claude Code](https://claude.com/claude-code)