### PR TITLE
fix(cloudless2): clear 5 orphan cron triggers causing 127 errors/day

### DIFF
--- a/workers/pi-origin-proxy/wrangler.jsonc
+++ b/workers/pi-origin-proxy/wrangler.jsonc
@@ -10,6 +10,13 @@
     { "pattern": "www.cloudless.gr", "zone_id": "7025298073d6a5c645a6ad9add0cbf0e" },
     { "pattern": "manage.cloudless.gr", "zone_id": "7025298073d6a5c645a6ad9add0cbf0e" }
   ],
+  // Explicit empty crons array clears any Cron Triggers previously attached
+  // to this Worker. The proxy has no scheduled() handler; every fire from
+  // an orphan cron becomes a wasted invocation and a 5xx error. Do NOT add
+  // cron entries here — this Worker is fetch-only.
+  "triggers": {
+    "crons": []
+  },
   "vars": {
     "PI_ORIGIN_HOST": "pi-origin.cloudless.gr",
     "PI_TIMEOUT_MS": "30000"


### PR DESCRIPTION
## Root cause

Dashboard inspection of `cloudless2` showed **5 Cron Triggers attached**:
- `0 1 * * *` (daily 01:00)
- `0 6 * * 1` (weekly Mon 06:00)
- `0 8 1 * *` (monthly 1st 08:00)
- `*/15 * * * *` (every 15 min)
- `5 * * * *` (hourly at :05)

Our proxy source at `workers/pi-origin-proxy/src/index.ts` has NO `scheduled()` handler — only `fetch`. Every cron fire is a wasted invocation that surfaces as a 5xx. This explains the **127 errors / 24h** in Cloudflare metrics (~24×4 + 24 + 1 = 121 fires per day).

The crons were added out-of-band by earlier experimental deploys (likely the abandoned `cursor/workers-wrangler-deploy` branch that used `wrangler-cloudflare-free.json` — which does declare cron triggers).

## Fix

Add `"triggers": { "crons": [] }` to `workers/pi-origin-proxy/wrangler.jsonc`. Wrangler's contract: when the `triggers.crons` array is present (even empty), it replaces the deployed cron list. Next `cloudflare-deploy.yml` run wipes all 5.

Comment above the block warns against re-adding — this Worker is fetch-only.

## Still needs a dashboard click (I can't do these from here)

- **Custom Domains** `cloudless.gr` + `www.cloudless.gr` bound out-of-band alongside routes (Workers & Pages → cloudless2 → Domains → delete)
- **Extra route duplicates** `cloudless.gr/*`, `www.cloudless.gr/*` (same page)
- **Workers Builds** still connected with a rolled token (Settings → Build with Cloudflare → Disconnect) — flagged in PR #1497 follow-ups

Neither breaks traffic — flag as cleanup, not incident.

## Test plan
- [ ] `cloudflare-deploy.yml` runs after merge — verify wrangler output says "Cron Triggers: (none)" or equivalent
- [ ] Dashboard → cloudless2 → Overview shows "No cron triggers" and error count drops toward zero within 24h
- [ ] `curl -sSI https://cloudless.gr/` still 200 with `x-served-by: pi-tunnel-proxy` (no fetch-path regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)