### PR TITLE
fix(cloudless2): declare apex+www as custom_domain in wrangler config

### DIFF
--- a/workers/pi-origin-proxy/wrangler.jsonc
+++ b/workers/pi-origin-proxy/wrangler.jsonc
@@ -5,9 +5,14 @@
   "account_id": "fb7dc7b69b662480cd5961a4d1913c78",
   "compatibility_date": "2026-08-07",
   "minify": true,
+  // Apex + www are bound as Cloudflare **Custom Domains** (wrangler asserts
+  // them via `custom_domain: true`); manage is a plain **Route**. Do not
+  // add duplicate route entries — they were deleted from the zone on
+  // 2026-08-07 and would silently reappear on the next deploy if listed
+  // as bare routes here.
   "routes": [
-    { "pattern": "cloudless.gr", "zone_id": "7025298073d6a5c645a6ad9add0cbf0e" },
-    { "pattern": "www.cloudless.gr", "zone_id": "7025298073d6a5c645a6ad9add0cbf0e" },
+    { "pattern": "cloudless.gr", "zone_id": "7025298073d6a5c645a6ad9add0cbf0e", "custom_domain": true },
+    { "pattern": "www.cloudless.gr", "zone_id": "7025298073d6a5c645a6ad9add0cbf0e", "custom_domain": true },
     { "pattern": "manage.cloudless.gr", "zone_id": "7025298073d6a5c645a6ad9add0cbf0e" }
   ],
   // Explicit empty crons array clears any Cron Triggers previously attached


### PR DESCRIPTION
## Context

Today's dashboard/API cleanup deleted 3 duplicate routes from the cloudless.gr zone via the Cloudflare API:

| Route ID | Pattern |
|---|---|
| `d571d38831114b7c996743973368bff8` | `www.cloudless.gr` (bare) |
| `1c064161bad14641a4b2d3296507a232` | `cloudless.gr/*` |
| `e15eb484e62441709559afbde8f4f298` | `www.cloudless.gr/*` |

The remaining routing config on the zone:
- **Route** `manage.cloudless.gr` → `cloudless2` (only entry for that host — kept)
- **Custom Domain** `cloudless.gr` → `cloudless2` (kept)
- **Custom Domain** `www.cloudless.gr` → `cloudless2` (kept)

## The problem this PR fixes

`workers/pi-origin-proxy/wrangler.jsonc` still declared apex and www as **bare route entries**. On the next `cloudflare-deploy.yml` run, wrangler would silently re-create those two routes, restoring the duplication I just cleaned up.

## Fix

Add `"custom_domain": true` to the apex and www entries in wrangler.jsonc. Wrangler now asserts them as Custom Domains (both already exist, so it's a no-op assertion), not as routes. `manage.cloudless.gr` stays as a plain route since it has no Custom Domain.

Added a comment above the block warning future editors not to remove `custom_domain: true` and revert to bare routes.

## Verified post-cleanup, pre-merge
- `curl -sI https://cloudless.gr/` → 200, `x-served-by: pi-tunnel-proxy`
- `curl -sI https://www.cloudless.gr/` → 200, `x-served-by: pi-tunnel-proxy`
- `curl -sI https://manage.cloudless.gr/` → 200, `x-served-by: pi-tunnel-proxy` (after Pi origin reboot recovery)
- `GET /zones/{zone}/workers/routes` → only `manage.cloudless.gr` route remains

## Test plan
- [ ] `cloudflare-deploy.yml` runs after merge — verify wrangler output does NOT list 2 new route creations
- [ ] Dashboard → cloudless2 → Domains still shows exactly 1 route + 2 Custom Domains
- [ ] Traffic on all 3 hosts remains 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)