### PR TITLE
fix(ci): cluster-doctor tailscale oauth-secret — drop the escaped $$

### DIFF
--- a/.github/workflows/cluster-doctor.yml
+++ b/.github/workflows/cluster-doctor.yml
@@ -46,7 +46,7 @@ jobs:
       uses: tailscale/github-action@0263d9e6d793eaefcf1de98ff7fde47abe6664d3         # v3.2.4
       with:
         oauth-client-id: ${{ secrets.TS_CLIENT_ID }}
-        oauth-secret: $${{ secrets.TS_CLIENT_SECRET }}
+        oauth-secret: ${{ secrets.TS_CLIENT_SECRET }}
 
     - name: Configure kubectl
       run: |


### PR DESCRIPTION
## Summary
- `oauth-secret: $${{ secrets.TS_CLIENT_SECRET }}` passes a literal `$<value>` to the Tailscale action because `$${{ ... }}` is the GH Actions escape for expression interpolation.
- The action rejects it with `##[error]OAuth identity empty`, skipping `Configure kubectl` and `Run diagnostics`, so `cluster-doctor.yml` has been posting the "doctor produced no output" fallback on every trigger.
- Confirmed in run [31221094936](https://github.com/Themis128/cloudless.gr/actions/runs/31221094936) — job log shows `oauth-secret: $***`.
- Single-`$` interpolation lets the tailnet join succeed and the diagnostic script (merged in #1509) actually run.

## Blast radius
- One-character fix in one workflow. `oauth-client-id` on the line above already uses single `$` correctly, so this brings both to the same working shape.
- ~20 other workflows in `.github/workflows/` carry the same `$$` pattern (see `grep '\$\$\{\{ secrets' .github/workflows/`). They're broken too, but not touched here — out of scope.

## Test plan
- [ ] Merge to `main` → the workflow file change triggers `cluster-doctor.yml` via its own `paths:` filter.
- [ ] "Connect to tailnet" step succeeds (no `OAuth identity empty`).
- [ ] `bash scripts/cluster-doctor.sh` posts a real snapshot to issue #382 (nodes, pods on `omv`, `cloudless-app` env, sync verdict) instead of the empty-doctor fallback.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cdhzn5FnYs8HTuawnmfHcT)_