### PR TITLE
fix: strip escaped $$ from 22 Tailscale workflows + disable admin sidebar prefetch

### DIFF
--- a/.github/workflows/analytics-restore.yml
+++ b/.github/workflows/analytics-restore.yml
@@ -41,7 +41,7 @@ jobs:
       uses: tailscale/github-action@0263d9e6d793eaefcf1de98ff7fde47abe6664d3         # v3.2.4
       with:
         oauth-client-id: ${{ secrets.TS_CLIENT_ID }}
-        oauth-secret: $${{ secrets.TS_CLIENT_SECRET }}
+        oauth-secret: ${{ secrets.TS_CLIENT_SECRET }}
 
     - name: Configure kubectl
       run: |

--- a/.github/workflows/cloudless-https-health-probe.yml
+++ b/.github/workflows/cloudless-https-health-probe.yml
@@ -195,7 +195,7 @@ jobs:
       uses: tailscale/github-action@0263d9e6d793eaefcf1de98ff7fde47abe6664d3         # v3.2.4
       with:
         oauth-client-id: ${{ secrets.TS_CLIENT_ID }}
-        oauth-secret: $${{ secrets.TS_CLIENT_SECRET }}
+        oauth-secret: ${{ secrets.TS_CLIENT_SECRET }}
 
     - name: GET /api/health via private fabric (MagicDNS NodePort)
       if: steps.health.outputs.need_origin_fallback == 'true'
@@ -420,7 +420,7 @@ jobs:
       uses: tailscale/github-action@0263d9e6d793eaefcf1de98ff7fde47abe6664d3         # v3.2.4
       with:
         oauth-client-id: ${{ secrets.TS_CLIENT_ID }}
-        oauth-secret: $${{ secrets.TS_CLIENT_SECRET }}
+        oauth-secret: ${{ secrets.TS_CLIENT_SECRET }}
 
     - name: GET /api/health via private fabric (MagicDNS NodePort)
       if: steps.health.outputs.need_origin_fallback == 'true'

--- a/.github/workflows/cluster-healthcheck.yml
+++ b/.github/workflows/cluster-healthcheck.yml
@@ -40,7 +40,7 @@ jobs:
       uses: tailscale/github-action@0263d9e6d793eaefcf1de98ff7fde47abe6664d3         # v3.2.4
       with:
         oauth-client-id: ${{ secrets.TS_CLIENT_ID }}
-        oauth-secret: $${{ secrets.TS_CLIENT_SECRET }}
+        oauth-secret: ${{ secrets.TS_CLIENT_SECRET }}
 
     - name: Ping /start
       if: ${{ env.HC_URL != '' }}

--- a/.github/workflows/cluster-remediate.yml
+++ b/.github/workflows/cluster-remediate.yml
@@ -31,7 +31,7 @@ jobs:
       uses: tailscale/github-action@0263d9e6d793eaefcf1de98ff7fde47abe6664d3         # v3.2.4
       with:
         oauth-client-id: ${{ secrets.TS_CLIENT_ID }}
-        oauth-secret: $${{ secrets.TS_CLIENT_SECRET }}
+        oauth-secret: ${{ secrets.TS_CLIENT_SECRET }}
 
     - name: Configure kubectl
       run: |

--- a/.github/workflows/cron-audit-and-fix.yml
+++ b/.github/workflows/cron-audit-and-fix.yml
@@ -29,8 +29,8 @@ jobs:
     - name: Connect to tailnet
       uses: tailscale/github-action@0263d9e6d793eaefcf1de98ff7fde47abe6664d3         # v3.2.4
       with:
-        oauth-client-id: $${{ secrets.TS_CLIENT_ID }}
-        oauth-secret: $$${{ secrets.TS_CLIENT_SECRET }}
+        oauth-client-id: ${{ secrets.TS_CLIENT_ID }}
+        oauth-secret: ${{ secrets.TS_CLIENT_SECRET }}
         tags: tag:k8s
 
     - name: Configure kubectl

--- a/.github/workflows/etcd-defrag-now.yml
+++ b/.github/workflows/etcd-defrag-now.yml
@@ -33,8 +33,8 @@ jobs:
     - name: Connect to tailnet
       uses: tailscale/github-action@0263d9e6d793eaefcf1de98ff7fde47abe6664d3         # v3.2.4
       with:
-        oauth-client-id: $$${{ secrets.TS_CLIENT_ID }}
-        oauth-secret: $$${{ secrets.TS_CLIENT_SECRET }}
+        oauth-client-id: ${{ secrets.TS_CLIENT_ID }}
+        oauth-secret: ${{ secrets.TS_CLIENT_SECRET }}
 
     - name: Install SSH key
       run: |

--- a/.github/workflows/fix-health-check-log.yml
+++ b/.github/workflows/fix-health-check-log.yml
@@ -25,8 +25,8 @@ jobs:
     steps:
     - uses: tailscale/github-action@0263d9e6d793eaefcf1de98ff7fde47abe6664d3         # v3.2.4
       with:
-        oauth-client-id: $$${{ secrets.TS_CLIENT_ID }}
-        oauth-secret: $$${{ secrets.TS_CLIENT_SECRET }}
+        oauth-client-id: ${{ secrets.TS_CLIENT_ID }}
+        oauth-secret: ${{ secrets.TS_CLIENT_SECRET }}
         tags: tag:k8s
 
     - name: Write SSH key + wait for tailnet

--- a/.github/workflows/fix-nginx-port80.yml
+++ b/.github/workflows/fix-nginx-port80.yml
@@ -26,8 +26,8 @@ jobs:
     - name: Connect to tailnet
       uses: tailscale/github-action@0263d9e6d793eaefcf1de98ff7fde47abe6664d3         # v3.2.4
       with:
-        oauth-client-id: $$${{ secrets.TS_CLIENT_ID }}
-        oauth-secret: $$${{ secrets.TS_CLIENT_SECRET }}
+        oauth-client-id: ${{ secrets.TS_CLIENT_ID }}
+        oauth-secret: ${{ secrets.TS_CLIENT_SECRET }}
         tags: tag:k8s
 
     - name: Configure kubectl

--- a/.github/workflows/fix-omv-nginx-port.yml
+++ b/.github/workflows/fix-omv-nginx-port.yml
@@ -27,8 +27,8 @@ jobs:
     - name: Connect to tailnet
       uses: tailscale/github-action@0263d9e6d793eaefcf1de98ff7fde47abe6664d3         # v3.2.4
       with:
-        oauth-client-id: $$${{ secrets.TS_CLIENT_ID }}
-        oauth-secret: $$${{ secrets.TS_CLIENT_SECRET }}
+        oauth-client-id: ${{ secrets.TS_CLIENT_ID }}
+        oauth-secret: ${{ secrets.TS_CLIENT_SECRET }}
         tags: tag:k8s
 
     - name: Configure kubectl

--- a/.github/workflows/fix-pihole-lighttpd-restart.yml
+++ b/.github/workflows/fix-pihole-lighttpd-restart.yml
@@ -27,7 +27,7 @@ jobs:
       uses: tailscale/github-action@0263d9e6d793eaefcf1de98ff7fde47abe6664d3         # v3.2.4
       with:
         oauth-client-id: ${{ secrets.TS_CLIENT_ID }}
-        oauth-secret: $${{ secrets.TS_CLIENT_SECRET }}
+        oauth-secret: ${{ secrets.TS_CLIENT_SECRET }}
         tags: tag:k8s
 
     - name: Configure kubectl

--- a/.github/workflows/fix-pihole-nginx-conflict.yml
+++ b/.github/workflows/fix-pihole-nginx-conflict.yml
@@ -27,8 +27,8 @@ jobs:
     - name: Connect to tailnet
       uses: tailscale/github-action@0263d9e6d793eaefcf1de98ff7fde47abe6664d3         # v3.2.4
       with:
-        oauth-client-id: $${{ secrets.TS_CLIENT_ID }}
-        oauth-secret: $$${{ secrets.TS_CLIENT_SECRET }}
+        oauth-client-id: ${{ secrets.TS_CLIENT_ID }}
+        oauth-secret: ${{ secrets.TS_CLIENT_SECRET }}
         tags: tag:k8s
 
     - name: Configure kubectl

--- a/.github/workflows/fix-pihole-port-nsenter.yml
+++ b/.github/workflows/fix-pihole-port-nsenter.yml
@@ -27,7 +27,7 @@ jobs:
       uses: tailscale/github-action@0263d9e6d793eaefcf1de98ff7fde47abe6664d3         # v3.2.4
       with:
         oauth-client-id: ${{ secrets.TS_CLIENT_ID }}
-        oauth-secret: $${{ secrets.TS_CLIENT_SECRET }}
+        oauth-secret: ${{ secrets.TS_CLIENT_SECRET }}
         tags: tag:k8s
 
     - name: Configure kubectl

--- a/.github/workflows/grafana-esp32-query.yml
+++ b/.github/workflows/grafana-esp32-query.yml
@@ -20,7 +20,7 @@ jobs:
       uses: tailscale/github-action@0263d9e6d793eaefcf1de98ff7fde47abe6664d3         # v3.2.4
       with:
         oauth-client-id: ${{ secrets.TS_CLIENT_ID }}
-        oauth-secret: $${{ secrets.TS_CLIENT_SECRET }}
+        oauth-secret: ${{ secrets.TS_CLIENT_SECRET }}
 
     - name: Configure kubectl
       run: |

--- a/.github/workflows/k3s-restart.yml
+++ b/.github/workflows/k3s-restart.yml
@@ -30,7 +30,7 @@ jobs:
       uses: tailscale/github-action@0263d9e6d793eaefcf1de98ff7fde47abe6664d3         # v3.2.4
       with:
         oauth-client-id: ${{ secrets.TS_CLIENT_ID }}
-        oauth-secret: $${{ secrets.TS_CLIENT_SECRET }}
+        oauth-secret: ${{ secrets.TS_CLIENT_SECRET }}
 
     - name: Install SSH key
       run: |

--- a/.github/workflows/k3s-watchdog-deploy.yml
+++ b/.github/workflows/k3s-watchdog-deploy.yml
@@ -51,7 +51,7 @@ jobs:
       uses: tailscale/github-action@0263d9e6d793eaefcf1de98ff7fde47abe6664d3         # v3.2.4
       with:
         oauth-client-id: ${{ secrets.TS_CLIENT_ID }}
-        oauth-secret: $${{ secrets.TS_CLIENT_SECRET }}
+        oauth-secret: ${{ secrets.TS_CLIENT_SECRET }}
 
     - name: Install SSH key
       run: |

--- a/.github/workflows/nas-health-fix.yml
+++ b/.github/workflows/nas-health-fix.yml
@@ -27,8 +27,8 @@ jobs:
     - name: Connect to tailnet
       uses: tailscale/github-action@0263d9e6d793eaefcf1de98ff7fde47abe6664d3         # v3.2.4
       with:
-        oauth-client-id: $$${{ secrets.TS_CLIENT_ID }}
-        oauth-secret: $$${{ secrets.TS_CLIENT_SECRET }}
+        oauth-client-id: ${{ secrets.TS_CLIENT_ID }}
+        oauth-secret: ${{ secrets.TS_CLIENT_SECRET }}
         tags: tag:k8s
 
     - name: Configure kubectl

--- a/.github/workflows/ntfy-restore.yml
+++ b/.github/workflows/ntfy-restore.yml
@@ -39,8 +39,8 @@ jobs:
     - name: Connect to tailnet
       uses: tailscale/github-action@0263d9e6d793eaefcf1de98ff7fde47abe6664d3         # v3.2.4
       with:
-        oauth-client-id: $$${{ secrets.TS_CLIENT_ID }}
-        oauth-secret: $$${{ secrets.TS_CLIENT_SECRET }}
+        oauth-client-id: ${{ secrets.TS_CLIENT_ID }}
+        oauth-secret: ${{ secrets.TS_CLIENT_SECRET }}
 
     - name: Configure kubectl
       run: |

--- a/.github/workflows/pi-disk-cleanup.yml
+++ b/.github/workflows/pi-disk-cleanup.yml
@@ -34,7 +34,7 @@ jobs:
       uses: tailscale/github-action@0263d9e6d793eaefcf1de98ff7fde47abe6664d3         # v3.2.4
       with:
         oauth-client-id: ${{ secrets.TS_CLIENT_ID }}
-        oauth-secret: $${{ secrets.TS_CLIENT_SECRET }}
+        oauth-secret: ${{ secrets.TS_CLIENT_SECRET }}
 
     - name: Run disk cleanup via SSH
       run: |

--- a/.github/workflows/prometheus-tune.yml
+++ b/.github/workflows/prometheus-tune.yml
@@ -31,7 +31,7 @@ jobs:
       uses: tailscale/github-action@0263d9e6d793eaefcf1de98ff7fde47abe6664d3         # v3.2.4
       with:
         oauth-client-id: ${{ secrets.TS_CLIENT_ID }}
-        oauth-secret: $${{ secrets.TS_CLIENT_SECRET }}
+        oauth-secret: ${{ secrets.TS_CLIENT_SECRET }}
 
     - name: Configure kubectl
       run: |

--- a/.github/workflows/restart-pi-runners.yml
+++ b/.github/workflows/restart-pi-runners.yml
@@ -32,7 +32,7 @@ jobs:
       uses: tailscale/github-action@0263d9e6d793eaefcf1de98ff7fde47abe6664d3         # v3.2.4
       with:
         oauth-client-id: ${{ secrets.TS_CLIENT_ID }}
-        oauth-secret: $${{ secrets.TS_CLIENT_SECRET }}
+        oauth-secret: ${{ secrets.TS_CLIENT_SECRET }}
 
     - name: Set up SSH key
       run: |

--- a/.github/workflows/rollout-pi-force.yml
+++ b/.github/workflows/rollout-pi-force.yml
@@ -51,7 +51,7 @@ jobs:
       uses: tailscale/github-action@0263d9e6d793eaefcf1de98ff7fde47abe6664d3         # v3.2.4
       with:
         oauth-client-id: ${{ secrets.TS_CLIENT_ID }}
-        oauth-secret: $${{ secrets.TS_CLIENT_SECRET }}
+        oauth-secret: ${{ secrets.TS_CLIENT_SECRET }}
 
     - name: Verify Tailscale path to omv-main
       continue-on-error: true

--- a/.github/workflows/store-sentry-webhook-secret.yml
+++ b/.github/workflows/store-sentry-webhook-secret.yml
@@ -78,7 +78,7 @@ jobs:
       uses: tailscale/github-action@0263d9e6d793eaefcf1de98ff7fde47abe6664d3         # v3.2.4
       with:
         oauth-client-id: ${{ secrets.TS_CLIENT_ID }}
-        oauth-secret: $${{ secrets.TS_CLIENT_SECRET }}
+        oauth-secret: ${{ secrets.TS_CLIENT_SECRET }}
 
     - name: Configure kubectl
       if: ${{ github.event.inputs.update_cluster_secret == 'true' }}

--- a/src/app/[locale]/admin/AdminLayoutClient.tsx
+++ b/src/app/[locale]/admin/AdminLayoutClient.tsx
@@ -188,7 +188,7 @@ function NavList({
                   <ExternalLink size={11} className="ml-auto shrink-0 opacity-40" />
                 </a>
               ) : (
-                <Link key={href} href={href} onClick={onLinkClick} className={cls}>
+                <Link key={href} href={href} onClick={onLinkClick} className={cls} prefetch={false}>
                   <Icon size={15} className="shrink-0" />
                   {label}
                 </Link>


### PR DESCRIPTION
## Summary
- Same `$${{ secrets.TS_* }}` bug PR #1510 fixed in `cluster-doctor.yml`, but across **22** more Tailscale-based workflows.
- Disable Next.js RSC prefetch on admin sidebar `<Link>` — the on-viewport prefetch burst is what trips Cloudflare's Bot Fight Mode into serving 429s across all admin routes.

## CI fix — the same escape bug, everywhere else
`$${{ secrets.TS_CLIENT_SECRET }}` (and a few `$$${{ ... }}` triples) pass a literal `$<value>` / `$$<value>` prefix to `tailscale/github-action`. The action's `Check Auth Info Empty` step instant-fails:

```
##[error]OAuth identity empty ...
```

which skips every downstream step (kubectl config, script execution). Normalized every run of `$` before `{{ secrets.* }}` to a single `$`. Files affected:

<details><summary>22 workflows</summary>

- `analytics-restore.yml`
- `cloudless-https-health-probe.yml`
- `cluster-healthcheck.yml`
- `cluster-remediate.yml`
- `cron-audit-and-fix.yml`
- `etcd-defrag-now.yml`
- `fix-health-check-log.yml`
- `fix-nginx-port80.yml`
- `fix-omv-nginx-port.yml`
- `fix-pihole-lighttpd-restart.yml`
- `fix-pihole-nginx-conflict.yml`
- `fix-pihole-port-nsenter.yml`
- `grafana-esp32-query.yml`
- `k3s-restart.yml`
- `k3s-watchdog-deploy.yml`
- `nas-health-fix.yml`
- `ntfy-restore.yml`
- `pi-disk-cleanup.yml`
- `prometheus-tune.yml`
- `restart-pi-runners.yml`
- `rollout-pi-force.yml`
- `store-sentry-webhook-secret.yml`

</details>

⚠️ **These workflows will still error `OAuth identity empty` after this PR merges** — because the repo secrets `TS_CLIENT_ID` / `TS_CLIENT_SECRET` are themselves empty (GitHub masks even empty-string secrets as `***`). The code side is now correct; the operator side needs a Tailscale OAuth client minted at https://login.tailscale.com/admin/settings/oauth and both values pasted into the repo secrets.

## 429 fix — admin sidebar prefetch storm
`src/app/[locale]/admin/AdminLayoutClient.tsx` renders ~40 admin nav `<Link>`s. Next.js prefetches each RSC payload the moment a `<Link>` enters the viewport, so a single admin page load fires ~40 parallel `GET /en/admin/...?_rsc=<token>` requests. Cloudflare's Bot Fight Mode reads the identical-token same-client burst as automation → HTTP 429.

Adding `prefetch={false}` to the sidebar Link keeps hover-prefetch (fast clicks) and eliminates the on-viewport storm. Public Navbar links are left as-is.

## Test plan
- [ ] After merge, hit `/en/admin` in a fresh incognito tab — no `?_rsc=` 429s in DevTools Network.
- [ ] After operator sets `TS_CLIENT_ID/SECRET`: `cluster-doctor.yml` posts a real snapshot to issue #382 (not the empty-output fallback).
- [ ] Any of the 22 recovery workflows (e.g. `k3s-restart.yml`) can be dispatched and their `Connect to tailnet` step now passes.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cdhzn5FnYs8HTuawnmfHcT)_