### PR TITLE
fix(postiz): use real Cf-Access-Client-Id — service tokens are not JWTs

### DIFF
--- a/.github/workflows/analytics-restore.yml
+++ b/.github/workflows/analytics-restore.yml
@@ -41,7 +41,7 @@ jobs:
       uses: tailscale/github-action@0263d9e6d793eaefcf1de98ff7fde47abe6664d3         # v3.2.4
       with:
         oauth-client-id: ${{ secrets.TS_CLIENT_ID }}
-        oauth-secret: $${{ secrets.TS_CLIENT_SECRET }}
+        oauth-secret: ${{ secrets.TS_CLIENT_SECRET }}
 
     - name: Configure kubectl
       run: |

--- a/.github/workflows/cloudless-https-health-probe.yml
+++ b/.github/workflows/cloudless-https-health-probe.yml
@@ -195,7 +195,7 @@ jobs:
       uses: tailscale/github-action@0263d9e6d793eaefcf1de98ff7fde47abe6664d3         # v3.2.4
       with:
         oauth-client-id: ${{ secrets.TS_CLIENT_ID }}
-        oauth-secret: $${{ secrets.TS_CLIENT_SECRET }}
+        oauth-secret: ${{ secrets.TS_CLIENT_SECRET }}
 
     - name: GET /api/health via private fabric (MagicDNS NodePort)
       if: steps.health.outputs.need_origin_fallback == 'true'
@@ -420,7 +420,7 @@ jobs:
       uses: tailscale/github-action@0263d9e6d793eaefcf1de98ff7fde47abe6664d3         # v3.2.4
       with:
         oauth-client-id: ${{ secrets.TS_CLIENT_ID }}
-        oauth-secret: $${{ secrets.TS_CLIENT_SECRET }}
+        oauth-secret: ${{ secrets.TS_CLIENT_SECRET }}
 
     - name: GET /api/health via private fabric (MagicDNS NodePort)
       if: steps.health.outputs.need_origin_fallback == 'true'

--- a/.github/workflows/cluster-healthcheck.yml
+++ b/.github/workflows/cluster-healthcheck.yml
@@ -40,7 +40,7 @@ jobs:
       uses: tailscale/github-action@0263d9e6d793eaefcf1de98ff7fde47abe6664d3         # v3.2.4
       with:
         oauth-client-id: ${{ secrets.TS_CLIENT_ID }}
-        oauth-secret: $${{ secrets.TS_CLIENT_SECRET }}
+        oauth-secret: ${{ secrets.TS_CLIENT_SECRET }}
 
     - name: Ping /start
       if: ${{ env.HC_URL != '' }}

--- a/.github/workflows/cluster-remediate.yml
+++ b/.github/workflows/cluster-remediate.yml
@@ -31,7 +31,7 @@ jobs:
       uses: tailscale/github-action@0263d9e6d793eaefcf1de98ff7fde47abe6664d3         # v3.2.4
       with:
         oauth-client-id: ${{ secrets.TS_CLIENT_ID }}
-        oauth-secret: $${{ secrets.TS_CLIENT_SECRET }}
+        oauth-secret: ${{ secrets.TS_CLIENT_SECRET }}
 
     - name: Configure kubectl
       run: |

--- a/.github/workflows/cron-audit-and-fix.yml
+++ b/.github/workflows/cron-audit-and-fix.yml
@@ -29,8 +29,8 @@ jobs:
     - name: Connect to tailnet
       uses: tailscale/github-action@0263d9e6d793eaefcf1de98ff7fde47abe6664d3         # v3.2.4
       with:
-        oauth-client-id: $${{ secrets.TS_CLIENT_ID }}
-        oauth-secret: $$${{ secrets.TS_CLIENT_SECRET }}
+        oauth-client-id: ${{ secrets.TS_CLIENT_ID }}
+        oauth-secret: ${{ secrets.TS_CLIENT_SECRET }}
         tags: tag:k8s
 
     - name: Configure kubectl

--- a/.github/workflows/etcd-defrag-now.yml
+++ b/.github/workflows/etcd-defrag-now.yml
@@ -33,8 +33,8 @@ jobs:
     - name: Connect to tailnet
       uses: tailscale/github-action@0263d9e6d793eaefcf1de98ff7fde47abe6664d3         # v3.2.4
       with:
-        oauth-client-id: $$${{ secrets.TS_CLIENT_ID }}
-        oauth-secret: $$${{ secrets.TS_CLIENT_SECRET }}
+        oauth-client-id: ${{ secrets.TS_CLIENT_ID }}
+        oauth-secret: ${{ secrets.TS_CLIENT_SECRET }}
 
     - name: Install SSH key
       run: |

--- a/.github/workflows/fix-health-check-log.yml
+++ b/.github/workflows/fix-health-check-log.yml
@@ -25,8 +25,8 @@ jobs:
     steps:
     - uses: tailscale/github-action@0263d9e6d793eaefcf1de98ff7fde47abe6664d3         # v3.2.4
       with:
-        oauth-client-id: $$${{ secrets.TS_CLIENT_ID }}
-        oauth-secret: $$${{ secrets.TS_CLIENT_SECRET }}
+        oauth-client-id: ${{ secrets.TS_CLIENT_ID }}
+        oauth-secret: ${{ secrets.TS_CLIENT_SECRET }}
         tags: tag:k8s
 
     - name: Write SSH key + wait for tailnet

--- a/.github/workflows/fix-nginx-port80.yml
+++ b/.github/workflows/fix-nginx-port80.yml
@@ -26,8 +26,8 @@ jobs:
     - name: Connect to tailnet
       uses: tailscale/github-action@0263d9e6d793eaefcf1de98ff7fde47abe6664d3         # v3.2.4
       with:
-        oauth-client-id: $$${{ secrets.TS_CLIENT_ID }}
-        oauth-secret: $$${{ secrets.TS_CLIENT_SECRET }}
+        oauth-client-id: ${{ secrets.TS_CLIENT_ID }}
+        oauth-secret: ${{ secrets.TS_CLIENT_SECRET }}
         tags: tag:k8s
 
     - name: Configure kubectl

--- a/.github/workflows/fix-omv-nginx-port.yml
+++ b/.github/workflows/fix-omv-nginx-port.yml
@@ -27,8 +27,8 @@ jobs:
     - name: Connect to tailnet
       uses: tailscale/github-action@0263d9e6d793eaefcf1de98ff7fde47abe6664d3         # v3.2.4
       with:
-        oauth-client-id: $$${{ secrets.TS_CLIENT_ID }}
-        oauth-secret: $$${{ secrets.TS_CLIENT_SECRET }}
+        oauth-client-id: ${{ secrets.TS_CLIENT_ID }}
+        oauth-secret: ${{ secrets.TS_CLIENT_SECRET }}
         tags: tag:k8s
 
     - name: Configure kubectl

--- a/.github/workflows/fix-pihole-lighttpd-restart.yml
+++ b/.github/workflows/fix-pihole-lighttpd-restart.yml
@@ -27,7 +27,7 @@ jobs:
       uses: tailscale/github-action@0263d9e6d793eaefcf1de98ff7fde47abe6664d3         # v3.2.4
       with:
         oauth-client-id: ${{ secrets.TS_CLIENT_ID }}
-        oauth-secret: $${{ secrets.TS_CLIENT_SECRET }}
+        oauth-secret: ${{ secrets.TS_CLIENT_SECRET }}
         tags: tag:k8s
 
     - name: Configure kubectl

--- a/.github/workflows/fix-pihole-nginx-conflict.yml
+++ b/.github/workflows/fix-pihole-nginx-conflict.yml
@@ -27,8 +27,8 @@ jobs:
     - name: Connect to tailnet
       uses: tailscale/github-action@0263d9e6d793eaefcf1de98ff7fde47abe6664d3         # v3.2.4
       with:
-        oauth-client-id: $${{ secrets.TS_CLIENT_ID }}
-        oauth-secret: $$${{ secrets.TS_CLIENT_SECRET }}
+        oauth-client-id: ${{ secrets.TS_CLIENT_ID }}
+        oauth-secret: ${{ secrets.TS_CLIENT_SECRET }}
         tags: tag:k8s
 
     - name: Configure kubectl

--- a/.github/workflows/fix-pihole-port-nsenter.yml
+++ b/.github/workflows/fix-pihole-port-nsenter.yml
@@ -27,7 +27,7 @@ jobs:
       uses: tailscale/github-action@0263d9e6d793eaefcf1de98ff7fde47abe6664d3         # v3.2.4
       with:
         oauth-client-id: ${{ secrets.TS_CLIENT_ID }}
-        oauth-secret: $${{ secrets.TS_CLIENT_SECRET }}
+        oauth-secret: ${{ secrets.TS_CLIENT_SECRET }}
         tags: tag:k8s
 
     - name: Configure kubectl

--- a/.github/workflows/grafana-esp32-query.yml
+++ b/.github/workflows/grafana-esp32-query.yml
@@ -20,7 +20,7 @@ jobs:
       uses: tailscale/github-action@0263d9e6d793eaefcf1de98ff7fde47abe6664d3         # v3.2.4
       with:
         oauth-client-id: ${{ secrets.TS_CLIENT_ID }}
-        oauth-secret: $${{ secrets.TS_CLIENT_SECRET }}
+        oauth-secret: ${{ secrets.TS_CLIENT_SECRET }}
 
     - name: Configure kubectl
       run: |

--- a/.github/workflows/k3s-restart.yml
+++ b/.github/workflows/k3s-restart.yml
@@ -30,7 +30,7 @@ jobs:
       uses: tailscale/github-action@0263d9e6d793eaefcf1de98ff7fde47abe6664d3         # v3.2.4
       with:
         oauth-client-id: ${{ secrets.TS_CLIENT_ID }}
-        oauth-secret: $${{ secrets.TS_CLIENT_SECRET }}
+        oauth-secret: ${{ secrets.TS_CLIENT_SECRET }}
 
     - name: Install SSH key
       run: |

--- a/.github/workflows/k3s-watchdog-deploy.yml
+++ b/.github/workflows/k3s-watchdog-deploy.yml
@@ -51,7 +51,7 @@ jobs:
       uses: tailscale/github-action@0263d9e6d793eaefcf1de98ff7fde47abe6664d3         # v3.2.4
       with:
         oauth-client-id: ${{ secrets.TS_CLIENT_ID }}
-        oauth-secret: $${{ secrets.TS_CLIENT_SECRET }}
+        oauth-secret: ${{ secrets.TS_CLIENT_SECRET }}
 
     - name: Install SSH key
       run: |

--- a/.github/workflows/nas-health-fix.yml
+++ b/.github/workflows/nas-health-fix.yml
@@ -27,8 +27,8 @@ jobs:
     - name: Connect to tailnet
       uses: tailscale/github-action@0263d9e6d793eaefcf1de98ff7fde47abe6664d3         # v3.2.4
       with:
-        oauth-client-id: $$${{ secrets.TS_CLIENT_ID }}
-        oauth-secret: $$${{ secrets.TS_CLIENT_SECRET }}
+        oauth-client-id: ${{ secrets.TS_CLIENT_ID }}
+        oauth-secret: ${{ secrets.TS_CLIENT_SECRET }}
         tags: tag:k8s
 
     - name: Configure kubectl

--- a/.github/workflows/ntfy-restore.yml
+++ b/.github/workflows/ntfy-restore.yml
@@ -39,8 +39,8 @@ jobs:
     - name: Connect to tailnet
       uses: tailscale/github-action@0263d9e6d793eaefcf1de98ff7fde47abe6664d3         # v3.2.4
       with:
-        oauth-client-id: $$${{ secrets.TS_CLIENT_ID }}
-        oauth-secret: $$${{ secrets.TS_CLIENT_SECRET }}
+        oauth-client-id: ${{ secrets.TS_CLIENT_ID }}
+        oauth-secret: ${{ secrets.TS_CLIENT_SECRET }}
 
     - name: Configure kubectl
       run: |

--- a/.github/workflows/pi-disk-cleanup.yml
+++ b/.github/workflows/pi-disk-cleanup.yml
@@ -34,7 +34,7 @@ jobs:
       uses: tailscale/github-action@0263d9e6d793eaefcf1de98ff7fde47abe6664d3         # v3.2.4
       with:
         oauth-client-id: ${{ secrets.TS_CLIENT_ID }}
-        oauth-secret: $${{ secrets.TS_CLIENT_SECRET }}
+        oauth-secret: ${{ secrets.TS_CLIENT_SECRET }}
 
     - name: Run disk cleanup via SSH
       run: |

--- a/.github/workflows/prometheus-tune.yml
+++ b/.github/workflows/prometheus-tune.yml
@@ -31,7 +31,7 @@ jobs:
       uses: tailscale/github-action@0263d9e6d793eaefcf1de98ff7fde47abe6664d3         # v3.2.4
       with:
         oauth-client-id: ${{ secrets.TS_CLIENT_ID }}
-        oauth-secret: $${{ secrets.TS_CLIENT_SECRET }}
+        oauth-secret: ${{ secrets.TS_CLIENT_SECRET }}
 
     - name: Configure kubectl
       run: |

--- a/.github/workflows/restart-pi-runners.yml
+++ b/.github/workflows/restart-pi-runners.yml
@@ -32,7 +32,7 @@ jobs:
       uses: tailscale/github-action@0263d9e6d793eaefcf1de98ff7fde47abe6664d3         # v3.2.4
       with:
         oauth-client-id: ${{ secrets.TS_CLIENT_ID }}
-        oauth-secret: $${{ secrets.TS_CLIENT_SECRET }}
+        oauth-secret: ${{ secrets.TS_CLIENT_SECRET }}
 
     - name: Set up SSH key
       run: |

--- a/.github/workflows/rollout-pi-force.yml
+++ b/.github/workflows/rollout-pi-force.yml
@@ -51,7 +51,7 @@ jobs:
       uses: tailscale/github-action@0263d9e6d793eaefcf1de98ff7fde47abe6664d3         # v3.2.4
       with:
         oauth-client-id: ${{ secrets.TS_CLIENT_ID }}
-        oauth-secret: $${{ secrets.TS_CLIENT_SECRET }}
+        oauth-secret: ${{ secrets.TS_CLIENT_SECRET }}
 
     - name: Verify Tailscale path to omv-main
       continue-on-error: true

--- a/.github/workflows/store-sentry-webhook-secret.yml
+++ b/.github/workflows/store-sentry-webhook-secret.yml
@@ -78,7 +78,7 @@ jobs:
       uses: tailscale/github-action@0263d9e6d793eaefcf1de98ff7fde47abe6664d3         # v3.2.4
       with:
         oauth-client-id: ${{ secrets.TS_CLIENT_ID }}
-        oauth-secret: $${{ secrets.TS_CLIENT_SECRET }}
+        oauth-secret: ${{ secrets.TS_CLIENT_SECRET }}
 
     - name: Configure kubectl
       if: ${{ github.event.inputs.update_cluster_secret == 'true' }}

--- a/src/app/[locale]/admin/AdminLayoutClient.tsx
+++ b/src/app/[locale]/admin/AdminLayoutClient.tsx
@@ -188,7 +188,7 @@ function NavList({
                   <ExternalLink size={11} className="ml-auto shrink-0 opacity-40" />
                 </a>
               ) : (
-                <Link key={href} href={href} onClick={onLinkClick} className={cls}>
+                <Link key={href} href={href} onClick={onLinkClick} className={cls} prefetch={false}>
                   <Icon size={15} className="shrink-0" />
                   {label}
                 </Link>

--- a/src/lib/postiz.ts
+++ b/src/lib/postiz.ts
@@ -28,20 +28,19 @@ import type { CalendarPlatform } from "@/lib/content-calendar";
  * Both share the same `postizFetch` / `getPostizConfig` plumbing.
  */
 
-// Helper function to extract client ID from JWT token for Cloudflare Access
-function extractClientIdFromToken(token: string): string {
-  try {
-    // Split the JWT and decode the payload (second part)
-    const payloadBase64 = token.split('.')[1];
-    // Replace URL-safe characters and add padding if needed
-    const payloadJson = Buffer.from(payloadBase64.replace(/-/g, '+').replace(/_/g, '/'), 'base64').toString();
-    const payload = JSON.parse(payloadJson);
-    // Service Tokens typically have 'aud' (audience) claim
-    return payload.aud || token.substring(0, 8); // fallback to first 8 chars
-  } catch (e) {
-    // If we can't parse the JWT, use a substring as client ID
-    return token.substring(0, 8);
-  }
+// Cloudflare Access service tokens are an opaque (id, secret) pair — not JWTs.
+// The pair can be provided one of two ways:
+//   - two env vars (POSTIZ_CF_ACCESS_CLIENT_ID + POSTIZ_SERVICE_TOKEN)
+//   - a single POSTIZ_SERVICE_TOKEN of the form "<client_id>:<client_secret>"
+// Returns null when neither is set — callers then skip the Access headers.
+function readCfAccessCreds(): { clientId: string; clientSecret: string } | null {
+  const raw = process.env.POSTIZ_SERVICE_TOKEN;
+  if (!raw) return null;
+  const explicitId = process.env.POSTIZ_CF_ACCESS_CLIENT_ID;
+  if (explicitId) return { clientId: explicitId, clientSecret: raw };
+  const colon = raw.indexOf(":");
+  if (colon > 0) return { clientId: raw.slice(0, colon), clientSecret: raw.slice(colon + 1) };
+  return null;
 }
 
 async function getPostizConfig(): Promise<{ baseUrl: string; apiKey: string }> {
@@ -67,11 +66,11 @@ async function postizFetch(
     ...init.headers,
   });
 
-  // Add Service Token for Cloudflare Access if configured
-  const serviceToken = process.env.POSTIZ_SERVICE_TOKEN;
-  if (serviceToken) {
-    headers.set("Cf-Access-Client-Id", extractClientIdFromToken(serviceToken));
-    headers.set("Cf-Access-Client-Secret", serviceToken);
+  // Add Cloudflare Access service-token headers if the credentials are configured.
+  const cfCreds = readCfAccessCreds();
+  if (cfCreds) {
+    headers.set("Cf-Access-Client-Id", cfCreds.clientId);
+    headers.set("Cf-Access-Client-Secret", cfCreds.clientSecret);
   }
 
   return fetch(`${baseUrl}/api/public/v1${path}`, {

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -96,6 +96,7 @@
           "SESSION_SECRET",
           "CRON_SECRET",
           "CLOUDFLARE_API_TOKEN",
+          "POSTIZ_CF_ACCESS_CLIENT_ID",
           "POSTIZ_SERVICE_TOKEN"
         ]
       },
@@ -164,6 +165,7 @@
       },
       "secrets": {
         "required": [
+          "POSTIZ_CF_ACCESS_CLIENT_ID",
           "POSTIZ_SERVICE_TOKEN"
         ]
       },


### PR DESCRIPTION
## Summary
`src/lib/postiz.ts` derived the `Cf-Access-Client-Id` header by parsing `POSTIZ_SERVICE_TOKEN` as a JWT and reading the `aud` claim. Cloudflare Access **service tokens are opaque** `(client_id, client_secret)` pairs — not JWTs — so the JWT path always threw, the fallback `token.substring(0, 8)` produced a wrong client ID, and every Postiz call from the Cloudflare Worker got the Access login page instead of the API.

## Fix
Replaced `extractClientIdFromToken()` with `readCfAccessCreds()`:
- Preferred: two env vars — `POSTIZ_CF_ACCESS_CLIENT_ID` + `POSTIZ_SERVICE_TOKEN` (secret).
- Fallback: a single `POSTIZ_SERVICE_TOKEN` of form `<client_id>:<client_secret>`.
- Neither set → skip the two `Cf-Access-*` headers. Pi-side pods keep working (they reach Postiz via in-cluster DNS `http://postiz.postiz.svc.cluster.local:5000`, no Access barrier).

Also added `POSTIZ_CF_ACCESS_CLIENT_ID` to `wrangler.jsonc` `secrets.required` for both `production` and `staging` so a half-configured deploy trips the preflight instead of silently 302-ing to login.

## Operator setup (needs Cloudflare dashboard + wrangler CLI — I don't have those tools in-session)

**1. Mint the service token.** Cloudflare dashboard →
   *Zero Trust* → *Access* → *Service Auth* → *Create Service Token*
   → name `cloudless-app` → duration `1 year` → **copy both** `Client ID` *and* `Client Secret` (secret is shown once).

**2. Authorize it for postiz.cloudless.gr.** *Zero Trust* → *Access* → *Applications* → open `postiz.cloudless.gr` → *Policies* → *Add* →
   `Include` → `Service Auth` → `Service Token` → `cloudless-app` → save.

**3. Set the Worker secrets** (repeat for `--env staging`):
```bash
wrangler secret put POSTIZ_CF_ACCESS_CLIENT_ID --env production   # paste Client ID
wrangler secret put POSTIZ_SERVICE_TOKEN       --env production   # paste Client Secret
```

**4. Redeploy:**
```bash
pnpm build && wrangler deploy --env production
```

## Test plan
- [ ] After deploy: `curl -H "Authorization: Bearer <CRON_SECRET>" https://cloudless.gr/api/cron/postiz-sync` returns JSON, not the Access login page.
- [ ] `/admin/postiz` on the Worker (cloudless.gr) can list posts.
- [ ] Pi-served `pi-origin.cloudless.gr/admin/postiz` still works (uses in-cluster DNS, unchanged).

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cdhzn5FnYs8HTuawnmfHcT)_