### PR TITLE
setup-postiz-access.sh: auto-source .env.local / .env for CLOUDFLARE_API_TOKEN

### DIFF
--- a/scripts/setup-postiz-access.sh
+++ b/scripts/setup-postiz-access.sh
@@ -23,8 +23,36 @@ TOKEN_DURATION="${TOKEN_DURATION:-8760h}"    # 1 year
 WORKER_PROD="${WORKER_PROD:-cloudless2}"
 WORKER_STAGING="${WORKER_STAGING:-cloudless-gr-staging}"
 
+# Auto-source .env.local then .env from the repo root when the token isn't
+# already exported. Values already in the environment win. Only variables
+# this script actually reads are pulled through; the rest are ignored so
+# unrelated .env noise never leaks into the shell.
+if [ -z "${CLOUDFLARE_API_TOKEN:-}" ]; then
+  REPO_ROOT="$(git -C "$(dirname "$0")" rev-parse --show-toplevel 2>/dev/null || dirname "$(dirname "$0")")"
+  for candidate in "$REPO_ROOT/.env.local" "$REPO_ROOT/.env"; do
+    [ -f "$candidate" ] || continue
+    while IFS='=' read -r key value; do
+      case "$key" in
+        CLOUDFLARE_API_TOKEN|CLOUDFLARE_ACCOUNT_ID|APP_DOMAIN|TOKEN_NAME|TOKEN_DURATION|WORKER_PROD|WORKER_STAGING)
+          # trim quotes + surrounding whitespace, skip empties + placeholders
+          value="${value%\"}"; value="${value#\"}"; value="${value%\'}"; value="${value#\'}"
+          value="${value## }"; value="${value%% }"
+          [ -z "$value" ] && continue
+          case "$value" in your-*|xxx*|CHANGE*|TODO*|"<"*|"") continue ;; esac
+          if [ -z "$(eval echo "\${$key:-}")" ]; then
+            export "$key=$value"
+            echo "  ($(basename "$candidate")) picked up $key" >&2
+          fi
+          ;;
+      esac
+    done < <(grep -E '^[A-Z_][A-Z0-9_]*=' "$candidate")
+  done
+fi
+
 if [ -z "${CLOUDFLARE_API_TOKEN:-}" ]; then
   echo "❌ CLOUDFLARE_API_TOKEN not set — mint one at https://dash.cloudflare.com/profile/api-tokens" >&2
+  echo "   Then either:  export CLOUDFLARE_API_TOKEN=…" >&2
+  echo "   or add it to  .env.local  in the repo root and re-run this script." >&2
   exit 1
 fi
 


### PR DESCRIPTION
## Summary
Follow-up to #1513. The script previously exited unless `CLOUDFLARE_API_TOKEN` was already `export`-ed. Now it also looks in `.env.local` (preferred) and `.env` at the repo root, so operators only need to drop the token in one place.

## Behaviour
- Environment wins — `.env` values only fill in gaps.
- Only reads variables the script actually uses (`CLOUDFLARE_API_TOKEN`, `CLOUDFLARE_ACCOUNT_ID`, `APP_DOMAIN`, `TOKEN_NAME`, `TOKEN_DURATION`, `WORKER_PROD`, `WORKER_STAGING`). Unrelated `.env` lines are ignored.
- Placeholder values commonly seen in `.env.example` (`your-*`, `xxx*`, `CHANGE*`, `TODO*`, `<something>`, empty) are skipped so a leaked example never poisons the run.
- One-line audit log per var picked up (`(.env.local) picked up CLOUDFLARE_API_TOKEN`) — the *value* itself is never echoed.

## Repo audit while I was there
- `.env` and `.env.local` — not committed (correctly `.gitignore`d).
- `.env.example` — the only file with a `CLOUDFLARE_API_TOKEN=` line, but the value is the literal placeholder `your-cloudflare-api-token` (skipped by this patch).
- `.env.e2e`, `.env.playwright` — variable name present, values empty (skipped).
- `/etc/environment`, session env — no CF vars set.

So today there is no Cloudflare token available anywhere on-repo or in the session, and the operator still needs to mint one and either `export CLOUDFLARE_API_TOKEN=…` or drop it into `.env.local`.

## Test plan
- [ ] `bash scripts/setup-postiz-access.sh` with token in env → runs normally.
- [ ] `bash scripts/setup-postiz-access.sh` with token only in `.env.local` → picks it up, logs `(.env.local) picked up CLOUDFLARE_API_TOKEN`, then runs.
- [ ] Same with `.env.example`-style placeholder → skipped, script exits with the "not set" error.
- [ ] Token value never appears in stdout/stderr.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cdhzn5FnYs8HTuawnmfHcT)_