### PR TITLE
add scripts/tail-worker.sh — stream cloudless2 Worker logs

### DIFF
--- a/scripts/tail-worker.sh
+++ b/scripts/tail-worker.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+# Stream live logs from the cloudless2 (production) Cloudflare Worker.
+#
+# Usage:
+#   bash scripts/tail-worker.sh                  # production, pretty format
+#   ENV=staging bash scripts/tail-worker.sh      # staging worker
+#   FORMAT=json bash scripts/tail-worker.sh      # JSON per line (pipe to jq)
+#   FILTER="status:5xx" bash scripts/tail-worker.sh   # sampled by predicate
+#
+# Requires CLOUDFLARE_API_TOKEN with scopes:
+#   Account → Workers Scripts:Read
+#   Account → Workers Tail:Read
+# The token is auto-sourced from .env.local (preferred) then .env at the repo
+# root — same pattern as scripts/setup-postiz-access.sh — so `export` isn't
+# strictly needed if the value lives there.
+
+set -uo pipefail
+
+ENV="${ENV:-production}"
+FORMAT="${FORMAT:-pretty}"
+FILTER="${FILTER:-}"
+
+if [ -z "${CLOUDFLARE_API_TOKEN:-}" ]; then
+  REPO_ROOT="$(git -C "$(dirname "$0")" rev-parse --show-toplevel 2>/dev/null || dirname "$(dirname "$0")")"
+  for candidate in "$REPO_ROOT/.env.local" "$REPO_ROOT/.env"; do
+    [ -f "$candidate" ] || continue
+    while IFS='=' read -r key value; do
+      case "$key" in
+        CLOUDFLARE_API_TOKEN|CLOUDFLARE_ACCOUNT_ID)
+          value="${value%\"}"; value="${value#\"}"; value="${value%\'}"; value="${value#\'}"
+          value="${value## }"; value="${value%% }"
+          [ -z "$value" ] && continue
+          case "$value" in your-*|xxx*|CHANGE*|TODO*|"<"*|"") continue ;; esac
+          if [ -z "$(eval echo "\${$key:-}")" ]; then
+            export "$key=$value"
+            echo "  ($(basename "$candidate")) picked up $key" >&2
+          fi
+          ;;
+      esac
+    done < <(grep -E '^[A-Z_][A-Z0-9_]*=' "$candidate")
+  done
+fi
+
+if [ -z "${CLOUDFLARE_API_TOKEN:-}" ]; then
+  echo "❌ CLOUDFLARE_API_TOKEN not set." >&2
+  echo "   Mint one at https://dash.cloudflare.com/profile/api-tokens with" >&2
+  echo "     Account → Workers Scripts:Read" >&2
+  echo "     Account → Workers Tail:Read" >&2
+  echo "   Then either:  export CLOUDFLARE_API_TOKEN=…" >&2
+  echo "   or add it to  .env.local  in the repo root and re-run." >&2
+  exit 1
+fi
+
+REPO_ROOT="$(git -C "$(dirname "$0")" rev-parse --show-toplevel 2>/dev/null || pwd)"
+cd "$REPO_ROOT"
+
+# `wrangler tail --env <env>` targets the worker defined in wrangler.jsonc's
+# env.<env> block automatically — no --name needed. `wrangler logs` is not a
+# valid subcommand in wrangler 4.x; use `tail`.
+args=(tail --env "$ENV" --format "$FORMAT")
+[ -n "$FILTER" ] && args+=(--search "$FILTER")
+
+echo "→ npx wrangler ${args[*]}"
+exec npx --yes wrangler@latest "${args[@]}"


### PR DESCRIPTION
## Summary
Thin wrapper around `wrangler tail` for the `cloudless2` (production) Worker, sharing the `.env.local` / `.env` auto-source pattern with `scripts/setup-postiz-access.sh`. Drop the token in one place and both scripts pick it up.

## Two things I confirmed while writing this
- `wrangler logs` is **not** a real subcommand in wrangler 4.x — it's `wrangler tail` — so the runbook is now correct.
- `--name` is redundant when `wrangler.jsonc` is at the CWD; `wrangler tail --env production` auto-targets `cloudless2-production` from the env block.

## Requirements
`CLOUDFLARE_API_TOKEN` with:
- Account → **Workers Scripts:Read**
- Account → **Workers Tail:Read**

Set either via `export CLOUDFLARE_API_TOKEN=…` or drop it into `.env.local` at the repo root.

## Usage
```bash
bash scripts/tail-worker.sh                    # production, pretty format
ENV=staging bash scripts/tail-worker.sh        # staging worker
FORMAT=json bash scripts/tail-worker.sh        # JSON per line (pipe to jq)
FILTER="status:5xx" bash scripts/tail-worker.sh
```

## Verified
- Syntax OK.
- With a fake token in `.env.local`: script sources it (logs `(.env.local) picked up CLOUDFLARE_API_TOKEN`) and wrangler fails cleanly at Cloudflare auth (`Authentication error [code: 10000]`) — exactly the expected failure mode.
- `.env.local` remains gitignored.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cdhzn5FnYs8HTuawnmfHcT)_