### PR TITLE
setup-postiz-access.sh: persist secret on mint, auto-create Access app

### DIFF
--- a/scripts/setup-postiz-access.sh
+++ b/scripts/setup-postiz-access.sh
@@ -88,6 +88,23 @@ else
   CLIENT_ID=$(echo "$resp"    | jq -r '.result.client_id')
   CLIENT_SECRET=$(echo "$resp" | jq -r '.result.client_secret')
   echo "  minted client_id=${CLIENT_ID}"
+
+  # Persist the freshly-minted secret IMMEDIATELY to a mode-600 file so a
+  # later step failing doesn't leave the operator with an orphan token whose
+  # client_secret Cloudflare never re-exposes. The file is deleted after step
+  # 4 completes cleanly.
+  SECRET_FILE="${TMPDIR:-/tmp}/postiz-cf-secret-$$.env"
+  umask 077
+  {
+    echo "# Freshly-minted Cloudflare Access service token for ${TOKEN_NAME}."
+    echo "# Cloudflare only shows client_secret once — do not lose this file."
+    echo "POSTIZ_CF_ACCESS_CLIENT_ID=${CLIENT_ID}"
+    echo "POSTIZ_SERVICE_TOKEN=${CLIENT_SECRET}"
+  } > "$SECRET_FILE"
+  echo ""
+  echo "  🔐  client_secret saved to: ${SECRET_FILE}"
+  echo "      (permissions 0600 — deleted after step 4 succeeds)"
+  echo ""
 fi
 
 echo "─── 3/4  Attaching token to Access app '${APP_DOMAIN}' ─────────────"
@@ -98,11 +115,30 @@ app_uid=$(cf GET "/accounts/${ACCOUNT_ID}/access/apps?per_page=1000" \
       | .uid' | head -n1)
 
 if [ -z "$app_uid" ]; then
-  echo "❌ No Access application found for ${APP_DOMAIN}. Create one in the dashboard:"
-  echo "   Zero Trust → Access → Applications → Add → Self-hosted → ${APP_DOMAIN}"
-  exit 1
+  echo "  no Access application found for ${APP_DOMAIN} — creating one …"
+  # Self-hosted app, no identity providers, no launcher, 24h session.
+  # We'll bind our service-token policy in the next step.
+  create_body=$(jq -cn --arg d "$APP_DOMAIN" --arg n "Postiz" '{
+    name: $n,
+    domain: $d,
+    type: "self_hosted",
+    session_duration: "24h",
+    app_launcher_visible: false,
+    auto_redirect_to_identity: false,
+    allowed_idps: [],
+    tags: []
+  }')
+  app_uid=$(cf POST "/accounts/${ACCOUNT_ID}/access/apps" "$create_body" \
+    | jq -r '.result.uid // .result.id')
+  if [ -z "$app_uid" ] || [ "$app_uid" = "null" ]; then
+    echo "❌ Failed to create Access application. Create manually in dashboard:"
+    echo "   Zero Trust → Access → Applications → Add → Self-hosted → ${APP_DOMAIN}"
+    exit 1
+  fi
+  echo "  created app uid=${app_uid}"
+else
+  echo "  found existing app uid=${app_uid}"
 fi
-echo "  found app uid=${app_uid}"
 
 policies=$(cf GET "/accounts/${ACCOUNT_ID}/access/apps/${app_uid}/policies")
 already=$(echo "$policies" | jq -r --arg cid "$CLIENT_ID" '
@@ -151,6 +187,11 @@ if [ -n "$CLIENT_SECRET" ]; then
   echo " ⚠ Save these — Cloudflare will not show CLIENT_SECRET again:"
   echo "   POSTIZ_CF_ACCESS_CLIENT_ID = ${CLIENT_ID}"
   echo "   POSTIZ_SERVICE_TOKEN       = ${CLIENT_SECRET}"
+  # Now that both worker PUTs succeeded, the temp secret file can go away.
+  if [ -n "${SECRET_FILE:-}" ] && [ -f "$SECRET_FILE" ]; then
+    rm -f "$SECRET_FILE"
+    echo "   (temp file ${SECRET_FILE} removed)"
+  fi
 fi
 echo "═══════════════════════════════════════════════════════════════════"
 echo ""


### PR DESCRIPTION
## Summary
Two bugs surfaced on the first live run today. Both fixed here.

### 1. Silent CLIENT_SECRET loss when a later step fails (**worst bug**)
The mint call (step 2) captured `CLIENT_SECRET` into a shell variable and only printed it at the end of step 4. When step 3 (attach-to-app) failed, the script exited and the secret was gone forever — Cloudflare only shows it once. The operator was left with an orphan service token and had to delete + re-mint.

Now the secret is written to `${TMPDIR:-/tmp}/postiz-cf-secret-$$.env` (mode 0600) **the moment** it comes back from the mint call, before any downstream step can fail. That file is deleted only after step 4 completes cleanly; otherwise it stays behind so the operator can recover.

### 2. Step 3 gave up when the Access app didn't exist
Now the script creates it via `POST /accounts/{id}/access/apps` — self-hosted, no launcher, no allowed IdPs (service-token-only), 24h session. If POST fails, falls back to the previous "create in dashboard" instruction.

### Idempotency preserved
Existing app is reused, existing token is reused, existing policy isn't duplicated.

## Test plan
- [ ] Fresh run against clean account → app created, token minted, secret file written, policy attached, both Worker secrets set, temp file deleted.
- [ ] Kill the script mid-way (SIGINT after step 2) → temp file persists so the operator can recover the secret.
- [ ] Re-run after clean success → token reused, app reused, policy detected as already-present, Worker secret PUTs skipped (empty CLIENT_SECRET on reuse path).
- [ ] Re-run after Access app was manually created → existing app found, token minted, policy attached.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cdhzn5FnYs8HTuawnmfHcT)_