### PR TITLE
feat(pi-origin-proxy): edge cache for anonymous static-asset GETs

### DIFF
--- a/__tests__/pi-origin-proxy.test.ts
+++ b/__tests__/pi-origin-proxy.test.ts
@@ -2,6 +2,8 @@ import { describe, expect, it } from "vitest";
 import {
   buildForwardHeaders,
   buildResponseHeaders,
+  isCacheable,
+  isResponseCacheable,
   isWebSocketUpgrade,
   REQUEST_HOP_BY_HOP,
   RESPONSE_HOP_BY_HOP,
@@ -185,5 +187,109 @@ describe("pi-origin-proxy: buildResponseHeaders", () => {
 
     // Relative Location resolves against origin host → same-host → rewritten.
     expect(out.get("Location")).toBe("https://cloudless.gr/reset-password");
+  });
+});
+
+describe("pi-origin-proxy: isCacheable (request-side)", () => {
+  it("accepts GET on known static prefixes", () => {
+    for (const path of [
+      "/_next/static/chunks/main.js",
+      "/_next/image?url=%2Ffoo.png&w=640&q=75",
+      "/icons/logo.svg",
+      "/images/hero.webp",
+    ]) {
+      expect(isCacheable(makeRequest(`https://cloudless.gr${path}`))).toBe(true);
+    }
+  });
+
+  it("accepts GET on known static exact paths", () => {
+    for (const path of ["/favicon.ico", "/robots.txt", "/sitemap.xml", "/manifest.webmanifest"]) {
+      expect(isCacheable(makeRequest(`https://cloudless.gr${path}`))).toBe(true);
+    }
+  });
+
+  it("accepts GET on known static file extensions", () => {
+    for (const path of [
+      "/some.css",
+      "/some.js",
+      "/some.mjs",
+      "/some.woff2",
+      "/some.png",
+      "/some.webp",
+    ]) {
+      expect(isCacheable(makeRequest(`https://cloudless.gr${path}`))).toBe(true);
+    }
+  });
+
+  it("rejects non-GET methods", () => {
+    expect(isCacheable(makeRequest("https://cloudless.gr/_next/static/x.js", {}, "POST"))).toBe(
+      false,
+    );
+    expect(isCacheable(makeRequest("https://cloudless.gr/_next/static/x.js", {}, "HEAD"))).toBe(
+      false,
+    );
+  });
+
+  it("rejects requests carrying Cookie or Authorization", () => {
+    expect(
+      isCacheable(
+        makeRequest("https://cloudless.gr/_next/static/x.js", { Cookie: "session=abc" }),
+      ),
+    ).toBe(false);
+    expect(
+      isCacheable(
+        makeRequest("https://cloudless.gr/_next/static/x.js", { Authorization: "Bearer t" }),
+      ),
+    ).toBe(false);
+  });
+
+  it("rejects dynamic paths that aren't static assets", () => {
+    for (const path of ["/", "/en", "/en/services", "/api/auth/login", "/dashboard"]) {
+      expect(isCacheable(makeRequest(`https://cloudless.gr${path}`))).toBe(false);
+    }
+  });
+});
+
+describe("pi-origin-proxy: isResponseCacheable (response-side)", () => {
+  const cacheableCC = "public, max-age=31536000, immutable";
+
+  it("accepts 200 + explicit max-age", () => {
+    const r = new Response(null, { status: 200, headers: { "cache-control": cacheableCC } });
+    expect(isResponseCacheable(r)).toBe(true);
+  });
+
+  it("accepts 200 + explicit s-maxage", () => {
+    const r = new Response(null, {
+      status: 200,
+      headers: { "cache-control": "public, s-maxage=600" },
+    });
+    expect(isResponseCacheable(r)).toBe(true);
+  });
+
+  it("rejects non-200 responses", () => {
+    for (const status of [204, 301, 302, 404, 500]) {
+      const r = new Response(null, { status, headers: { "cache-control": cacheableCC } });
+      expect(isResponseCacheable(r)).toBe(false);
+    }
+  });
+
+  it("rejects responses missing Cache-Control", () => {
+    const r = new Response(null, { status: 200 });
+    expect(isResponseCacheable(r)).toBe(false);
+  });
+
+  it("rejects responses whose Cache-Control opts out", () => {
+    for (const cc of ["no-store", "no-cache", "private, max-age=60", "no-store, max-age=60"]) {
+      const r = new Response(null, { status: 200, headers: { "cache-control": cc } });
+      expect(isResponseCacheable(r)).toBe(false);
+    }
+  });
+
+  it("rejects responses that carry Set-Cookie", () => {
+    const r = new Response(null, {
+      status: 200,
+      headers: { "cache-control": cacheableCC, "set-cookie": "id=abc; Path=/" },
+    });
+    expect(isResponseCacheable(r)).toBe(false);
   });
 });

--- a/workers/pi-origin-proxy/README.md
+++ b/workers/pi-origin-proxy/README.md
@@ -29,6 +29,23 @@ Idempotent methods (`GET`/`HEAD`/`OPTIONS`) retry once on network failure or
 upstream `502` (Tunnel flaps). Failures still return `502` with
 `x-served-by: pi-tunnel-proxy` or `pi-tunnel-proxy-error`.
 
+## Edge cache
+
+Static-asset `GET` requests (anonymous — no `Cookie`/`Authorization`) are
+looked up in `caches.default` before the tunnel hop and stored after a hit
+via `ctx.waitUntil(cache.put(...))`. Paths that qualify:
+
+- `/_next/static/*`, `/_next/image?...`, `/icons/*`, `/images/*`
+- `/favicon.ico`, `/robots.txt`, `/sitemap.xml`, `/manifest.webmanifest`
+- any path ending in `.css` / `.js` / `.mjs` / `.map` / `.woff2` / image /
+  video / `.txt` / `.xml`
+
+Only 200 responses with an explicit `Cache-Control: max-age=N` (or
+`s-maxage=N`) and no `Set-Cookie` are stored. Everything else — including
+API routes, RSC prefetches (`?_rsc=…`), and pages with a session cookie —
+bypasses cache entirely. Cache hits carry `x-served-by: pi-tunnel-proxy-cache`
+so you can distinguish them from a fresh tunnel round-trip.
+
 ## GHA cron callers (Bot Fight bypass)
 
 GitHub Actions runners hitting `https://cloudless.gr/api/cron/*` often get a

--- a/workers/pi-origin-proxy/src/index.ts
+++ b/workers/pi-origin-proxy/src/index.ts
@@ -80,6 +80,48 @@ export function buildForwardHeaders(
   return headers;
 }
 
+const CACHEABLE_STATIC_PREFIXES = ["/_next/static/", "/_next/image", "/icons/", "/images/"];
+const CACHEABLE_STATIC_EXACT = new Set([
+  "/favicon.ico",
+  "/robots.txt",
+  "/sitemap.xml",
+  "/manifest.webmanifest",
+]);
+const CACHEABLE_STATIC_EXT =
+  /\.(css|js|mjs|map|woff2?|ttf|eot|jpg|jpeg|png|webp|avif|gif|svg|ico|mp4|webm|txt|xml)$/i;
+
+/**
+ * Cache candidates: GET requests for static assets from anonymous clients.
+ * Anything with a Cookie/Authorization header is treated as personalized
+ * (we do not want to leak one user's data to another via the edge cache).
+ * Query strings are part of the cache key, so /_next/image?url=... works.
+ */
+export function isCacheable(request: Request): boolean {
+  if (request.method !== "GET") return false;
+  if (request.headers.has("cookie") || request.headers.has("authorization")) return false;
+  const path = new URL(request.url).pathname;
+  if (CACHEABLE_STATIC_EXACT.has(path)) return true;
+  for (const prefix of CACHEABLE_STATIC_PREFIXES) {
+    if (path.startsWith(prefix)) return true;
+  }
+  return CACHEABLE_STATIC_EXT.test(path);
+}
+
+/**
+ * Whether an upstream response is safe to store in the edge cache.
+ * We only cache 200 OK, refuse anything with Set-Cookie (personalized),
+ * and require an explicit non-negative Cache-Control max-age / s-maxage.
+ * The absence of Cache-Control means the origin never opted in, so we skip.
+ */
+export function isResponseCacheable(response: Response): boolean {
+  if (response.status !== 200) return false;
+  if (response.headers.has("set-cookie")) return false;
+  const cc = (response.headers.get("cache-control") || "").toLowerCase();
+  if (!cc) return false;
+  if (/\bno-store\b|\bno-cache\b|\bprivate\b/.test(cc)) return false;
+  return /\bmax-age=\d+|\bs-maxage=\d+/.test(cc);
+}
+
 export function buildResponseHeaders(upstream: Response, url: URL, host: string): Headers {
   const out = new Headers();
   for (const [k, v] of upstream.headers) {
@@ -159,7 +201,7 @@ async function proxyWebSocket(
 }
 
 export default {
-  async fetch(request: Request, env: Env): Promise<Response> {
+  async fetch(request: Request, env: Env, ctx: ExecutionContext): Promise<Response> {
     const url = new URL(request.url);
     const host = (env.PI_ORIGIN_HOST || "pi-origin.cloudless.gr").replace(/^https?:\/\//, "");
     const target = new URL(url.pathname + url.search, `https://${host}`);
@@ -178,6 +220,21 @@ export default {
             "content-type": "text/plain",
           },
         });
+      }
+    }
+
+    // Edge cache lookup for static assets. Cache key uses the original URL so
+    // apex + www share the same cached copy for identical paths (browsers
+    // don't distinguish those hosts for _next/static anyway).
+    const cache = caches.default;
+    const cacheable = isCacheable(request);
+    const cacheKey = cacheable ? new Request(request.url, { method: "GET" }) : null;
+    if (cacheKey) {
+      const hit = await cache.match(cacheKey);
+      if (hit) {
+        const cached = new Response(hit.body, hit);
+        cached.headers.set("x-served-by", "pi-tunnel-proxy-cache");
+        return cached;
       }
     }
 
@@ -214,11 +271,19 @@ export default {
       if (upstream.status >= 500) {
         outHeaders.set("x-pi-origin-status", String(upstream.status));
       }
-      return new Response(upstream.body, {
+      const proxied = new Response(upstream.body, {
         status: upstream.status,
         statusText: upstream.statusText,
         headers: outHeaders,
       });
+
+      // Populate the edge cache from the same response we're about to return.
+      // clone() must run BEFORE the response body is streamed to the client, so
+      // do it here and hand the clone off via waitUntil so we don't block.
+      if (cacheKey && isResponseCacheable(upstream)) {
+        ctx.waitUntil(cache.put(cacheKey, proxied.clone()));
+      }
+      return proxied;
     } catch (err) {
       console.error("pi-tunnel-proxy: origin unreachable", err);
       return new Response("Pi origin unreachable", {


### PR DESCRIPTION
## Summary

Every `cloudless2` request currently round-trips through the Cloudflare Tunnel to the Pi — even immutable `/_next/static/*` bundles. This PR adds a lightweight `caches.default` layer so anonymous static-asset `GET`s are served from the CF edge and the Pi only handles the first miss per POP.

### Request-side gate (`isCacheable`)

Only qualifies if all hold:
- Method is `GET`.
- No `Cookie` / `Authorization` header (rules out personalized traffic).
- Path is a static asset — one of `/_next/static/`, `/_next/image`, `/icons/`, `/images/`, or an exact `/favicon.ico` / `/robots.txt` / `/sitemap.xml` / `/manifest.webmanifest`, or a filename with a static extension (`.css`, `.js`, `.mjs`, `.map`, `.woff2?`, images, video, `.txt`, `.xml`).

### Response-side gate (`isResponseCacheable`)

Only stored if:
- Status is `200`.
- No `Set-Cookie`.
- `Cache-Control` is present, has no `no-store` / `no-cache` / `private`, and includes an explicit `max-age=N` or `s-maxage=N`. Absent `Cache-Control` = origin never opted in → skip.

### Flow

- Before the tunnel hop: `caches.default.match(cacheKey)` → on hit, return with `x-served-by: pi-tunnel-proxy-cache` so hits are distinguishable from fresh round-trips.
- After a successful miss: `ctx.waitUntil(cache.put(cacheKey, proxied.clone()))` populates the cache without blocking the client.
- `fetch()` signature now takes `ExecutionContext` (third arg) so `waitUntil` is available.

### Explicitly *not* cached

- `/api/*` (no `Cache-Control` there anyway; the request-side gate also excludes anything with cookies).
- RSC prefetches (`?_rsc=…` — they come with cookies).
- Authenticated pages, admin, dashboard.
- Any response with `Set-Cookie`.
- 3xx / 4xx / 5xx responses.

## Type of change

- [x] Performance improvement

## Testing

- [x] Unit tests added / updated (`pnpm test:ci`) — 12 new tests (30 total), all passing locally in ~22 ms.
- [ ] E2E tests added / updated
- [ ] Manually tested in browser
- [x] No tests required (explain why): n/a — tests are included

## Checklist

- [ ] `pnpm lint` passes
- [ ] `pnpm typecheck` passes
- [ ] `pnpm build` passes
- [x] New strings added to all three locale files (`en.json`, `el.json`, `fr.json`) — n/a, no UI strings
- [x] No secrets or sensitive values committed
- [x] AGENTS.md updated if architecture changed — n/a (`workers/pi-origin-proxy/README.md` updated with the edge-cache section)

## Verifying the win once deployed

Any static-asset request after the first miss per POP should carry:

```
curl -sI https://cloudless.gr/_next/static/... | grep -i x-served-by
# x-served-by: pi-tunnel-proxy-cache
```

The tunnel logs on the Pi should show a corresponding drop in `/_next/static/` traffic.

---
_Generated by [Claude Code](https://claude.ai/code/session_015mqRbEN6vY6mYeYmwLUUxk)_