### PR TITLE
fix(pi-origin-proxy): never edge-cache /sw.js and workbox-* companions

### DIFF
--- a/__tests__/pi-origin-proxy.test.ts
+++ b/__tests__/pi-origin-proxy.test.ts
@@ -248,6 +248,20 @@ describe("pi-origin-proxy: isCacheable (request-side)", () => {
       expect(isCacheable(makeRequest(`https://cloudless.gr${path}`))).toBe(false);
     }
   });
+
+  it("rejects service workers even though they have a .js extension", () => {
+    // A 4h edge-cached /sw.js would silently freeze the PWA cache version
+    // for users; the browser only refreshes SWs when it sees a byte diff.
+    for (const path of ["/sw.js", "/service-worker.js"]) {
+      expect(isCacheable(makeRequest(`https://cloudless.gr${path}`))).toBe(false);
+    }
+  });
+
+  it("rejects workbox-* runtime companions", () => {
+    for (const path of ["/workbox-abc123.js", "/workbox-catch-handler.js"]) {
+      expect(isCacheable(makeRequest(`https://cloudless.gr${path}`))).toBe(false);
+    }
+  });
 });
 
 describe("pi-origin-proxy: isResponseCacheable (response-side)", () => {

--- a/workers/pi-origin-proxy/src/index.ts
+++ b/workers/pi-origin-proxy/src/index.ts
@@ -91,6 +91,18 @@ const CACHEABLE_STATIC_EXT =
   /\.(css|js|mjs|map|woff2?|ttf|eot|jpg|jpeg|png|webp|avif|gif|svg|ico|mp4|webm|txt|xml)$/i;
 
 /**
+ * Paths that must NEVER be served from the edge cache.
+ *
+ * Service workers and their runtime companions must reach the browser fresh
+ * on every check: browsers only pick up a new SW when they see a byte-level
+ * diff of the script URL, so a 4h edge-cached /sw.js means CACHE_VERSION
+ * bumps stay invisible to users during that window and the PWA update
+ * contract silently breaks.
+ */
+const NEVER_CACHE_EXACT = new Set(["/sw.js", "/service-worker.js"]);
+const NEVER_CACHE_PREFIXES = ["/workbox-"]; // /workbox-<hash>.js companions
+
+/**
  * Cache candidates: GET requests for static assets from anonymous clients.
  * Anything with a Cookie/Authorization header is treated as personalized
  * (we do not want to leak one user's data to another via the edge cache).
@@ -100,6 +112,10 @@ export function isCacheable(request: Request): boolean {
   if (request.method !== "GET") return false;
   if (request.headers.has("cookie") || request.headers.has("authorization")) return false;
   const path = new URL(request.url).pathname;
+  if (NEVER_CACHE_EXACT.has(path)) return false;
+  for (const prefix of NEVER_CACHE_PREFIXES) {
+    if (path.startsWith(prefix)) return false;
+  }
   if (CACHEABLE_STATIC_EXACT.has(path)) return true;
   for (const prefix of CACHEABLE_STATIC_PREFIXES) {
     if (path.startsWith(prefix)) return true;


### PR DESCRIPTION
## Summary

Hot-fix on top of PR #1522 (edge caching). `/sw.js` has a `.js` extension and the origin serves it with `Cache-Control: public, max-age=14400` (verified live), so the just-merged edge cache would happily store it at the CF edge for up to 4 hours.

That silently breaks the PWA update contract:

- Browsers only pick up a new service worker when they see a **byte-level diff** at the SW URL.
- `public/sw.js` uses `const CACHE_VERSION = "5"` bumped on every deploy as the invalidation signal.
- If the edge serves last week's `sw.js` (with `CACHE_VERSION = "4"`) for the next 4 hours, `CACHE_VERSION = "5"` never reaches users during that window — every open tab stays stuck on the stale cache.

The same reasoning applies to `/workbox-<hash>.js` runtime companions (though we don't use Workbox today, it's a common pattern and the guard is cheap).

### Change

In `isCacheable()`:

```ts
const NEVER_CACHE_EXACT = new Set(["/sw.js", "/service-worker.js"]);
const NEVER_CACHE_PREFIXES = ["/workbox-"];
```

Checked **before** the `CACHEABLE_STATIC_*` patterns so the `.js` extension match no longer wins.

### Left cacheable on purpose

- `/manifest.webmanifest` — browsers only re-read this on install / prompt, not on every page load. A 4h edge cache is fine and worth the perf.

### Verification once deployed

```
curl -sI https://cloudless.gr/sw.js | grep -i x-served-by
# expected: pi-tunnel-proxy   (never pi-tunnel-proxy-cache)
```

## Type of change

- [x] Bug fix

## Testing

- [x] Unit tests added / updated (`pnpm test:ci`) — 2 new tests (32 total), all passing locally in 21ms.

## Checklist

- [x] `pnpm lint` passes
- [x] `pnpm typecheck` passes
- [ ] `pnpm build` passes
- [x] No secrets or sensitive values committed
- [x] AGENTS.md updated if architecture changed — n/a

---
_Generated by [Claude Code](https://claude.ai/code/session_015mqRbEN6vY6mYeYmwLUUxk)_