### PR TITLE
ci(deploy-pi): retry kubectl probe + add concurrency guard

### DIFF
--- a/.github/workflows/deploy-pi.yml
+++ b/.github/workflows/deploy-pi.yml
@@ -30,6 +30,14 @@ on:
 permissions:
   contents: read
 
+# Serialize deploys: never cancel a build already in progress; a newer push
+# queues behind it (GitHub keeps only the newest *pending* run). This is what
+# the header comment above describes — the block was missing, which is why
+# rapid main merges cancelled builds mid-flight.
+concurrency:
+  group: deploy-pi
+  cancel-in-progress: false
+
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
   K3S_NAMESPACE: cloudless
@@ -162,14 +170,26 @@ jobs:
       id: kubectl
       run: |
         set -euo pipefail
-        if command -v kubectl >/dev/null 2>&1 && kubectl get --raw /readyz --request-timeout=5s >/dev/null 2>&1; then
-          echo "bin=kubectl" >> "$GITHUB_OUTPUT"
-        elif sudo kubectl get --raw /readyz --request-timeout=5s >/dev/null 2>&1; then
-          echo "bin=sudo kubectl" >> "$GITHUB_OUTPUT"
-        else
-          echo "::error::kubectl cannot reach the cluster"
+        # The k3s API server on the control-plane Pi can be briefly unresponsive
+        # right after a build pegs CPU/IO, so probe with retries + a generous
+        # per-attempt timeout instead of failing on a single 5s miss (which
+        # threw away an already-successful build + hostPath sync).
+        BIN=""
+        for attempt in $(seq 1 6); do
+          if command -v kubectl >/dev/null 2>&1 && kubectl get --raw /readyz --request-timeout=15s >/dev/null 2>&1; then
+            BIN="kubectl"; break
+          elif sudo kubectl get --raw /readyz --request-timeout=15s >/dev/null 2>&1; then
+            BIN="sudo kubectl"; break
+          fi
+          echo "kubectl not ready (attempt ${attempt}/6) — waiting 10s…"
+          sleep 10
+        done
+        if [ -z "$BIN" ]; then
+          echo "::error::kubectl cannot reach the cluster after 6 attempts (~2min)"
           exit 1
         fi
+        echo "Using: ${BIN}"
+        echo "bin=${BIN}" >> "$GITHUB_OUTPUT"
 
     - name: Roll out cloudless-app
       if: steps.skip.outputs.already != 'true'


### PR DESCRIPTION
## Problem
The **Deploy to Pi** workflow's latest run built the standalone bundle and synced it to the hostPath **successfully**, then failed at the `Resolve kubectl` step with `kubectl cannot reach the cluster`. The probe (`kubectl get --raw /readyz --request-timeout=5s`) gave the k3s API only a single 5s window — twice — right after a 24-min build pegged the control-plane Pi's CPU/IO. The API didn't answer in time, so the whole deploy hard-failed and the good build was discarded.

An earlier run was also cancelled mid-build: the header comment documents a `concurrency:` serialize guard, but **no `concurrency:` block actually existed** in the file, so rapid `main` merges cancelled in-flight builds.

## Fix
- **Retry the readyz probe** up to 6× with a 15s per-attempt timeout (~2 min budget) before giving up — a momentarily busy API server no longer throws away a successful build + sync.
- **Add the top-level `concurrency: { group: deploy-pi, cancel-in-progress: false }` block** the header already describes, so newer pushes queue behind an in-progress build instead of cancelling it.

No change to the rollout logic or the `steps.kubectl.outputs.bin` contract.

🤖 Generated with [Claude Code](https://claude.com/claude-code)