### PR TITLE
fix: repair 6 failing workflows (agentic lock, ETL, Postiz, tunnels)

### DIFF
--- a/scripts/etl/aws-cost-to-lake.mjs
+++ b/scripts/etl/aws-cost-to-lake.mjs
@@ -35,16 +35,18 @@
 
 import { BUCKET, r2Put } from "./_r2-config.mjs";
 
-import { CostExplorerClient, GetCostAndUsageCommand } from "@aws-sdk/client-cost-explorer";
 import { ParquetWriter, ParquetSchema } from "@dsnp/parquetjs";
 import { readFileSync, unlinkSync } from "fs";
 
+// NOTE: `@aws-sdk/client-cost-explorer` is imported lazily inside
+// `fetchDailyCost()` — not at module top-level — so the live Cloudflare-first
+// path (`aws-cost-to-r2.mjs`, which only imports the pure `shapeResults`
+// transform from here) does not require the AWS SDK. This module's own
+// `main()` is the deprecated S3+Athena path; the SDK is only pulled in when it
+// actually runs. Do not hoist this import back to the top.
+
 const REGION = process.env.AWS_REGION || "us-east-1";
 const LOOKBACK_DAYS = Number.parseInt(process.env.AWS_COST_LOOKBACK_DAYS || "60", 10);
-
-// Cost Explorer is a global service — but the SDK still requires *a* region.
-// us-east-1 is the canonical home (and matches our existing AWS_REGION).
-const ce = new CostExplorerClient({ region: "us-east-1" });
 
 const schema = new ParquetSchema({
   /** ISO date — YYYY-MM-DD, partition-friendly. */
@@ -87,6 +89,14 @@ export function shapeResults(results) {
 }
 
 async function fetchDailyCost() {
+  // Lazy import — keeps the AWS SDK out of the module graph for importers that
+  // only need `shapeResults` (see note at the top of this file).
+  const { CostExplorerClient, GetCostAndUsageCommand } = await import(
+    "@aws-sdk/client-cost-explorer"
+  );
+  // Cost Explorer is a global service but the SDK still requires *a* region.
+  const ce = new CostExplorerClient({ region: REGION });
+
   const end = new Date();
   const start = new Date();
   start.setUTCDate(start.getUTCDate() - LOOKBACK_DAYS);

--- a/src/app/api/cron/postiz-oauth-check/route.ts
+++ b/src/app/api/cron/postiz-oauth-check/route.ts
@@ -32,7 +32,7 @@ export async function GET(request: NextRequest) {
   // Postiz is configured but its API can still be unreachable or erroring
   // (pod down, upstream 5xx). Surface that as a structured 502 rather than an
   // opaque unhandled 500, so the cron log says *what* failed.
-  let integrations;
+  let integrations: Awaited<ReturnType<typeof listIntegrations>>;
   try {
     integrations = await listIntegrations();
   } catch (e) {


### PR DESCRIPTION
Fixes the batch of failing CI/scheduled workflows found alongside the deploy-pi issue. (Some hunks already landed on `main` via the session auto-commit hook; this PR carries the remaining AWS-cost fix + a type refinement, and documents the whole set.)

## Workflows fixed

| Workflow | Root cause | Fix |
|---|---|---|
| **Activity Report** / **Documentation Updater** | `CONFIG_HASH_MISMATCH` — `.md` frontmatter had tool decls (`github`/`bash`/`edit`) mis-indented under `env:`, leaving `tools:` empty; lock files stale | Re-nested tools under `tools:`, kept only `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24` under `env:`, recompiled both `.lock.yml` via `gh aw compile` |
| **ETL: AWS Cost → R2 + D1** | `ERR_MODULE_NOT_FOUND: @aws-sdk/client-cost-explorer` — legacy `aws-cost-to-lake.mjs` imported the SDK at top-level; the live `aws-cost-to-r2.mjs` only needs its pure `shapeResults` | Made the SDK import lazy (inside `fetchDailyCost()`). Zero new deps — respects the AWS→Cloudflare no-SDK policy |
| **ETL: Clients to R2** | `D1 HTTP: CLOUDFLARE_API_TOKEN not configured` — workflow never passed the token `queryD1` requires | Added `CLOUDFLARE_API_TOKEN` to the step `env` |
| **Postiz crons** | Endpoint 500'd (unhandled throw in `listIntegrations()`); `curl -fsS` hard-failed | Route now catches → structured **502**; cron captures HTTP status: 2xx=ok, **503**=not-configured skip, else fail |
| **Fix Self-Hosted App Tunnels** | `ssh: connect … timed out` — omv unreachable / tailnet route not propagated | Added a bounded SSH-readiness gate (10×15s) before the SSH steps; fails fast with a clear message if the host stays down |

## Still needs the operator (not code)
- **ETL: Clients to R2** will only go green once the `CLOUDFLARE_API_TOKEN` secret is valid — CLAUDE.md flags it as needing rotation (`cloudflare-token-doctor`).
- **Postiz cron** goes green when Postiz on pi-origin is healthy (or now cleanly *skips* if it reports 503 not-configured).
- **Tunnels** still (correctly) fails if omv is genuinely offline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)