### PR TITLE
docs(dev): document CRON_SECRET in .dev.vars.example

### DIFF
--- a/.dev.vars.example
+++ b/.dev.vars.example
@@ -5,6 +5,9 @@
 # ─── Cloudflare Workers ───────────────────────────────────────────────
 # SESSION_SECRET is required for D1 password hashing
 SESSION_SECRET=your-random-secret-for-password-hashing
+# CRON_SECRET authorizes internal cron endpoints (Bearer token). Any random
+# value works locally; production sets it via `wrangler secret put CRON_SECRET`.
+CRON_SECRET=your-random-cron-secret
 
 # ─── Authentication (for local dev) ───────────────────────────────────
 AUTH_SECRET=your-next-auth-secret-here


### PR DESCRIPTION
Fresh `pnpm dev` warned `Missing required secrets: CRON_SECRET` because `wrangler.jsonc` lists it under `secrets.required` but it wasn't in the `.dev.vars` template. Documents it (any random value works locally).

The Durable Object warnings in the same dev output (`CounterAgent`/`EchoAgent`/`CodingAgent` 'not exported') are a separate, cosmetic `getPlatformProxy` artifact — those classes exist and export from the standalone `src/index.ts` agents worker; `next dev`/OpenNext just don't run that entry. Not changed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)