### PR TITLE
fix(auth): correct CLOUDFLARE_ACCOUNT_ID (login 500 → 200)

### DIFF
--- a/.github/workflows/deploy-pi.yml
+++ b/.github/workflows/deploy-pi.yml
@@ -203,7 +203,8 @@ jobs:
           "APP_VERSION=${FULL_SHA}" \
           "NEXT_PUBLIC_APP_VERSION=${FULL_SHA}" \
           "NEXT_PUBLIC_AUTH_PROVIDER=d1" \
-          "SSM_DISABLED=1"
+          "SSM_DISABLED=1" \
+          "CLOUDFLARE_ACCOUNT_ID=fb7dc7b69b662480cd5961a4d1913c78"
         $KUBECTL rollout restart "deployment/${{ env.K3S_DEPLOYMENT }}" \
           -n "${{ env.K3S_NAMESPACE }}"
         $KUBECTL rollout status "deployment/${{ env.K3S_DEPLOYMENT }}" \

--- a/k8s/cloudless-app-hostpath.yaml
+++ b/k8s/cloudless-app-hostpath.yaml
@@ -64,6 +64,14 @@ spec:
         - secretRef:
             name: cloudless-secrets
             optional: false
+        # Pin the Cloudflare account that owns user-auth-db D1. Explicit env
+        # overrides envFrom, so this wins over any stale CLOUDFLARE_ACCOUNT_ID
+        # in cloudless-secrets. A wrong account makes the D1 REST API return
+        # 401 → /api/auth/login 500. The account id is not a secret; the D1
+        # API token still comes from cloudless-secrets.
+        env:
+        - name: CLOUDFLARE_ACCOUNT_ID
+          value: fb7dc7b69b662480cd5961a4d1913c78
         volumeMounts:
         - name: standalone
           mountPath: /app

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -30,6 +30,7 @@
           "custom_domain": true
         }
       ],
+      "_note_account_id": "CLOUDFLARE_ACCOUNT_ID must be the account that owns user-auth-db D1 (fb7dc7…), matching top-level account_id. A mismatch makes D1 REST return 401 and breaks /api/auth/login.",
       "durable_objects": {
         "bindings": [
           {
@@ -65,7 +66,7 @@
         "ENVIRONMENT": "production",
         "NEXT_PUBLIC_AUTH_PROVIDER": "d1",
         "NEXT_PUBLIC_SITE_URL": "https://cloudless.gr",
-        "CLOUDFLARE_ACCOUNT_ID": "c6d6b805741159c062a3e0b0d7f9d89a"
+        "CLOUDFLARE_ACCOUNT_ID": "fb7dc7b69b662480cd5961a4d1913c78"
       },
       "secrets": {
         "required": [
@@ -190,7 +191,7 @@
     "ENVIRONMENT": "production",
     "NEXT_PUBLIC_AUTH_PROVIDER": "d1",
     "NEXT_PUBLIC_SITE_URL": "https://cloudless.gr",
-    "CLOUDFLARE_ACCOUNT_ID": "c6d6b805741159c062a3e0b0d7f9d89a"
+    "CLOUDFLARE_ACCOUNT_ID": "fb7dc7b69b662480cd5961a4d1913c78"
   },
   "secrets": {
     "required": [


### PR DESCRIPTION
## Root cause
Production `POST /api/auth/login` returns **500**. The app was configured with `CLOUDFLARE_ACCOUNT_ID=c6d6b805…`, but `user-auth-db` D1 (and the valid API token) live under account **`fb7dc7b6…`**. The Pi's D1 HTTP client targeted the wrong account → Cloudflare REST API **401 'Authentication error'** → `queryRemote` throws → login catch block → 500.

**Verified against the live Cloudflare API** (status codes only, no secrets):
- valid token + `fb7dc7…` → **HTTP 200** (67 users)
- same token + `c6d6…` → **HTTP 401** Authentication error
- D1 database itself is healthy.

`fb7dc7…` is the account used **everywhere else** — wrangler top-level `account_id`, SST config, `.mcp.json`, pi-origin-proxy, all R2 endpoints, CI. `c6d6…` only ever appeared in `wrangler.jsonc` vars.

## Fix
- `wrangler.jsonc`: `vars.CLOUDFLARE_ACCOUNT_ID` (prod + default) → `fb7dc7…`
- `k8s/cloudless-app-hostpath.yaml`: pin `CLOUDFLARE_ACCOUNT_ID` as explicit `env` (overrides any stale value in the `cloudless-secrets` Secret)
- `deploy-pi.yml`: rollout `set env` also pins it, so every rollout is correct even without re-applying the manifest

## Immediate production fix (no rebuild)
```bash
kubectl set env deployment/cloudless-app -n cloudless CLOUDFLARE_ACCOUNT_ID=fb7dc7b69b662480cd5961a4d1913c78
kubectl rollout restart deployment/cloudless-app -n cloudless
```
If login still 401s after that, the Pi's D1 API token itself is invalid and needs rotation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)