### PR TITLE
infra: sync manifests to single-node cluster (omv-ha decommissioned)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,24 @@
 # Claude Code — Project Memory
 
+## ⚠️ Cluster Topology — SINGLE-NODE as of 2026-08-08 (supersedes older 2-node notes)
+
+The k3s cluster is now **single-node**: `omv` (Pi 5, 8GB, control-plane) only.
+`omv-ha` (Pi 4, 1GB) was **drained and removed from k3s** on 2026-08-08 and
+repurposed as a **dedicated mail host** (webmail.cloudless.gr). Any section below
+that describes a 2-node cluster, an `omv-ha` k3s worker, the AppFlowy-worker pin
+to omv-ha, warm-standby etcd on omv-ha, or omv-ha cleanup timers is **historical**.
+
+- **omv now runs a 4K-page kernel.** `/boot/firmware/config.txt` sets
+  `kernel=kernel8.img` (was the Pi-5 default 16K `kernel_2712`). This was done so
+  the **AppFlowy worker** (jemalloc built for 4K pages) can run on omv — it now
+  does, pinned `nodeSelector: kubernetes.io/hostname: omv`. Do NOT revert to the
+  16K kernel without first moving/rebuilding that worker.
+- **omv-ha**: OMV services disabled, k3s agent uninstalled, `/var/lib/rancher`
+  removed. It is SSH-reachable over Tailscale (`omv-ha`, 100.95.117.84) and hosts
+  postfix/dovecot/Roundcube (see `infrastructure/omv-ha/`).
+- All former omv-ha workloads (traefik, tailscale operator, postiz-redis, etc.)
+  now run on omv. `local-path` PVCs are omv-local.
+
 ## Working Style
 
 - **Never use placeholders.** No `<paste-output-here>`, no `TODO`, no `# TODO`, no `# fill in`, no `# replace this`, no `your-value-here`, no `xxx`, no `???`. If a value isn't known, fetch it, ask one direct question, or stop — do not write code/configs/docs that contain placeholders the user has to find and replace.

--- a/infrastructure/appflowy/k8s/appflowy.yaml
+++ b/infrastructure/appflowy/k8s/appflowy.yaml
@@ -330,10 +330,13 @@ spec:
   template:
     metadata: {labels: {app: appflowy-worker}}
     spec:
-      # Pinned to omv-ha (Pi 4, 4K page kernel) — the worker image's
-      # jemalloc was built for 4K pages and panics with "Unsupported
-      # system page size" on omv (Pi 5, 16K kernel `2712`).
-      nodeSelector: {kubernetes.io/hostname: omv-ha}
+      # Requires a 4K-page kernel — the worker image's jemalloc was built
+      # for 4K pages and panics "Unsupported system page size" on a 16K
+      # kernel. omv (Pi 5) was switched to the 4K `kernel8` kernel
+      # (/boot/firmware/config.txt: kernel=kernel8.img) on 2026-08-08, after
+      # omv-ha was decommissioned from k3s and repurposed as the mail host.
+      # The cluster is now single-node; do NOT move this to a 16K-page node.
+      nodeSelector: {kubernetes.io/hostname: omv}
       containers:
       - name: appflowy-worker
         image: appflowyinc/appflowy_worker:latest

--- a/infrastructure/uptime-kuma/k8s/uptime-kuma.yaml
+++ b/infrastructure/uptime-kuma/k8s/uptime-kuma.yaml
@@ -32,7 +32,7 @@ spec:
       labels: {app: uptime-kuma}
     spec:
       nodeSelector:
-        kubernetes.io/hostname: omv         # Pi 5 — Pi 4 (omv-ha) is full
+        kubernetes.io/hostname: omv         # Pi 5 — single-node cluster (omv-ha decommissioned 2026-08-08)
       containers:
       - name: uptime-kuma
           # Pinned major + minor for reproducibility. v2 is the current
@@ -53,17 +53,23 @@ spec:
         - {name: data, mountPath: /app/data}
           # Probes target the embedded /api/entry-page which is unauth
           # (returns 302 to /dashboard on healthy boot, 200 during setup).
+          # timeoutSeconds defaults to 1s, which is too tight on ARM — a slow
+          # response counted as a failure and bounced the pod ("context
+          # deadline exceeded"). 5s gives the Pi headroom.
         startupProbe:
           httpGet: {path: /, port: 3001}
           failureThreshold: 30
           periodSeconds: 5
+          timeoutSeconds: 5
         livenessProbe:
           httpGet: {path: /, port: 3001}
           initialDelaySeconds: 60
           periodSeconds: 60
+          timeoutSeconds: 5
         readinessProbe:
           httpGet: {path: /, port: 3001}
           periodSeconds: 30
+          timeoutSeconds: 5
         resources:
           requests: {cpu: 50m, memory: 96Mi}
           limits: {cpu: 500m, memory: 256Mi}


### PR DESCRIPTION
Consolidated k3s to single-node **omv** (Pi 5) on 2026-08-08; omv-ha removed from the cluster and repurposed as the mail host.

**Repo↔live sync (Phase 1 drift fix):**
- `appflowy.yaml`: worker `nodeSelector` omv-ha → **omv** (omv now runs a 4K-page kernel via `config.txt kernel=kernel8.img`, so the worker's jemalloc runs there — verified 0-restart Running).
- `CLAUDE.md`: prominent topology note marking all 2-node/omv-ha references historical.

**Stability (Phase 2):**
- `uptime-kuma.yaml`: `timeoutSeconds: 5` on all probes (default 1s was too tight on ARM → restart loop).
- postiz liveness `failureThreshold` 3→6 (applied live; Helm-templated, noted).

Both previously-flaky pods now start with **0 restarts**; cluster has **0 not-ready pods**, 2.3GB free RAM, no OOM.

🤖 Generated with [Claude Code](https://claude.com/claude-code)