### PR TITLE
docs(mail): correct mail-server docs to the real relay architecture

### DIFF
--- a/docs/MAIL-SERVER-SETUP.md
+++ b/docs/MAIL-SERVER-SETUP.md
@@ -1,1 +1,106 @@
-# Mail Server Setup — webmail.cloudless.gr ## Prerequisites - SSH access to `omv-ha` node - Cloudflare dashboard access (cloudless.gr zone) - OMV Web UI access (https://omv.cloudless.gr) ## Step 1: Retrieve OMV-HA Public IP The public IP is not stored in the repository. Retrieve it via SSH: ```bash ssh tbaltzakis@omv-ha curl -s https://api.ipify.org ``` Or check your router/firewall admin panel for the NAT'd public IP assigned to omv-ha. ## Step 2: Create DNS A Record 1. Log into **Cloudflare Dashboard** → Select `cloudless.gr` zone → **DNS** → **Records** 2. Click **Add record** 3. Configure: | Field | Value | |-------|-------| | **Type** | A | | **Name** | webmail | | **IPv4 address** | [OMV-HA public IP from Step 1] | | **Proxy status** | Proxied (orange cloud) — recommended | | **TTL** | Auto | 4. Click **Save** ## Step 3: Request SSL Certificate 1. Open **OMV Web UI**: https://omv.cloudless.gr 2. Navigate to **Storage** → **Certificates** 3. Click **+ Add** → Select **Let's Encrypt** 4. Fill in: | Field | Value | |-------|-------| | **Domain name** | webmail.cloudless.gr | | **Email address** | [your-email@domain.com] | | **Agree to ToS** | ✅ checked | 5. Click **Save** 6. Wait ~60 seconds for certificate issuance ## Step 4: Install Mail Server Packages SSH to omv-ha: ```bash ssh tbaltzakis@omv-ha ``` Install postfix and dovecot: ```bash sudo apt update sudo apt install -y postfix dovecot-imapd dovecot-pop3d ``` During postfix installation, select: - **General type of mail configuration**: `Internet Site` - **System mail name**: `cloudless.gr` ## Step 5: Configure Postfix ```bash sudo postconf -e 'myhostname = webmail.cloudless.gr' sudo postconf -e 'mydomain = cloudless.gr' sudo postconf -e 'myorigin = $mydomain' sudo postconf -e 'inet_interfaces = all' sudo postconf -e 'inet_protocols = ipv4' sudo systemctl restart postfix ``` ## Step 6: Verify Access - **Webmail URL**: https://webmail.cloudless.gr - **Username**: `tbaltzakis` - **Password**: [your system password] ## Notes - If you prefer tunnel routing instead of direct public IP, add an ingress rule to `infrastructure/cloudflare-tunnels/cloudflared-config.yml` and change DNS to CNAME. - For production email, configure SPF/DKIM/DMARC records in Cloudflare DNS. - Ensure OMV-HA public IP is static or use DDNS (see `infrastructure/omv/ddns-update-auth.sh`).
+# Self-Hosted Mail Server — cloudless.gr (on omv-ha)
+
+**Status (2026-08-08):** outbound + mailbox live; Roundcube webmail and inbound
+routing in progress. Host: **omv-ha** (Pi 4, dedicated mail host after it was
+removed from k3s — see the topology note in `CLAUDE.md`).
+
+## ⚠️ Why this is NOT a "direct" mail server (read first)
+
+The network is **Starlink**, which means:
+
+- **CGNAT** — no public inbound IP. You cannot receive a connection on any port
+  from the internet (no port-forwarding possible). This is why the whole cluster
+  is exposed via **Cloudflare Tunnel** (outbound-only), not port-forwarding.
+- **Port 25 is blocked** (outbound to `*:25` times out; `:587` is open).
+
+So a classic `postfix → direct MX` server **cannot send or receive a single
+message here**. Any doc that says "install postfix as Internet Site, add an MX to
+your public IP, proxy mail through Cloudflare's orange cloud" is **wrong for this
+environment** — Cloudflare's proxy only carries HTTP, and there is no reachable
+public IP anyway.
+
+The working design routes *around* both constraints:
+
+| Piece            | How                                                                 | Self-hosted? |
+| ---------------- | ------------------------------------------------------------------- | ------------ |
+| Mailbox + IMAP   | **dovecot** on omv-ha (Maildir virtual user)                        | ✅           |
+| Webmail UI       | **Roundcube** on omv-ha, HTTPS via **Cloudflare Tunnel**            | ✅           |
+| Outbound send    | **postfix** relays via `smtp.resend.com:587` (Resend)               | relay        |
+| Inbound receive  | **Cloudflare Email Routing** (CF runs the MX) → Email **Worker** → tunnel → dovecot LMTP | ✅ |
+
+No port 25, no inbound reachability required — mail flows over :587 (out) and
+Cloudflare (in).
+
+## Components & credentials
+
+- Mailbox: `tbaltzakis@cloudless.gr`. Password in the operator's `.env.local`
+  as `MAIL_TBALTZAKIS_PASSWORD` (dovecot passwd-file `/etc/dovecot/users`,
+  SHA512-CRYPT).
+- Outbound relay: Resend. API key in `.env.local` as `RESEND_API_KEY` (send-only
+  is fine). `cloudless.gr` is a **verified Resend domain**.
+- DNS token: `.env.local` `CLOUDFLARE_API_TOKEN` (zone `cloudless.gr` =
+  `7025298073d6a5c645a6ad9add0cbf0e`).
+
+## DNS records (in Cloudflare, added via API)
+
+Resend sender verification (added 2026-08-08):
+
+| Type | Name                        | Value                                            |
+| ---- | --------------------------- | ------------------------------------------------ |
+| TXT  | `resend._domainkey`         | `p=…` (Resend DKIM public key)                   |
+| MX   | `send`                      | `feedback-smtp.eu-west-1.amazonses.com` (prio 10)|
+| TXT  | `send`                      | `v=spf1 include:amazonses.com ~all`              |
+
+Inbound (Cloudflare Email Routing — pending): enabling Email Routing sets the
+root `MX` to Cloudflare's mail servers automatically. A `DMARC` TXT
+(`_dmarc` → `v=DMARC1; p=none; rua=mailto:…`) should be added once both
+directions are live.
+
+## omv-ha config (what's on the box)
+
+- **dovecot 2.4.1** — `/etc/dovecot/local.conf`: virtual mailbox
+  (`mail_driver=maildir`, `mail_path=/var/mail/vhosts/%{user|domain}/%{user|username}`,
+  uid/gid `vmail`=5000), `passdb`/`userdb` = `passwd-file` (`/etc/dovecot/users`),
+  `service lmtp` + `service auth` unix listeners under
+  `/var/spool/postfix/private/` for postfix. Listens IMAP 143 / IMAPS 993.
+- **postfix 3.10** — relay-only + local virtual delivery. Key `main.cf`:
+  - `inet_interfaces = loopback-only` (CGNAT host — no external SMTP exposure)
+  - `myhostname = mail.cloudless.gr`, `myorigin = cloudless.gr`,
+    `mydestination = localhost`, `mynetworks = 127.0.0.0/8 [::1]/128`
+  - `relayhost = [smtp.resend.com]:587`, `smtp_sasl_auth_enable = yes`,
+    `smtp_sasl_password_maps = lmdb:/etc/postfix/sasl_passwd`,
+    `smtp_sasl_security_options = noanonymous`, `smtp_tls_security_level = encrypt`
+  - `virtual_mailbox_domains = cloudless.gr`,
+    `virtual_transport = lmtp:unix:private/dovecot-lmtp`
+  - `/etc/postfix/sasl_passwd`: `[smtp.resend.com]:587 resend:<RESEND_API_KEY>`
+    (then `postmap lmdb:/etc/postfix/sasl_passwd`). **Requires the
+    `postfix-lmdb` package** — without it you get
+    `unsupported dictionary type: lmdb` → `local data error talking to
+    smtp.resend.com`.
+
+## Verify
+
+```bash
+# mailbox auth
+sudo doveadm auth test tbaltzakis@cloudless.gr '<password>'
+# outbound relay (should log status=sent (250 …))
+printf 'Subject: relay test\nFrom: tbaltzakis@cloudless.gr\nTo: you@example.com\n\nhi' \
+  | sudo sendmail -f tbaltzakis@cloudless.gr you@example.com
+sudo journalctl -t postfix/smtp -n 5 | grep status=
+```
+
+## Remaining work
+
+1. **Roundcube** webmail (nginx + php-fpm, sqlite) → IMAP `localhost:143`,
+   submit via `localhost:25`.
+2. **TLS + Cloudflare Tunnel** ingress for `webmail.cloudless.gr`.
+3. **Inbound**: enable Cloudflare Email Routing on `cloudless.gr`, add an Email
+   Worker that forwards the raw message over the tunnel to a small receiver on
+   omv-ha which injects it via `dovecot-lda`/LMTP into the Maildir.
+4. `_dmarc` TXT record once both directions verify.
+
+## Reproduce / recover
+
+`infrastructure/omv-ha/setup-mail-server.sh` installs and configures the
+dovecot + postfix relay stack idempotently (reads `RESEND_API_KEY` and the
+mailbox password from the environment; never hard-codes secrets).

--- a/infrastructure/omv-ha/setup-mail-server.sh
+++ b/infrastructure/omv-ha/setup-mail-server.sh
@@ -1,1 +1,129 @@
-#!/usr/bin/env bash # Setup mail server on omv-ha node for webmail.cloudless.gr # Usage: sudo bash setup-mail-server.sh set -euo pipefail log() { printf '[mail-setup] %s\n' "$*" } if [[ $EUID -ne 0 ]]; then echo "This script must be run as root (use sudo)" >&2 exit 1 fi log "Updating package lists..." apt-get update -qq log "Installing postfix and dovecot..." DEBIAN_FRONTEND=noninteractive apt-get install -y -qq postfix dovecot-imapd dovecot-pop3d log "Configuring postfix..." postconf -e 'myhostname = webmail.cloudless.gr' postconf -e 'mydomain = cloudless.gr' postconf -e 'myorigin = $mydomain' postconf -e 'inet_interfaces = all' postconf -e 'inet_protocols = ipv4' postconf -e 'home_mailbox = Maildir/' log "Restarting postfix..." systemctl restart postfix log "Restarting dovecot..." systemctl restart dovecot log "Enabling services on boot..." systemctl enable postfix dovecot imapd pop3d >/dev/null 2>&1 || true log "Mail server setup complete!" log "Next steps:" log " 1. Create DNS A record: webmail.cloudless.gr → $(curl -s https://api.ipify.org)" log " 2. Request SSL cert via OMV Web UI → Storage → Certificates" log " 3. Access webmail at https://webmail.cloudless.gr"
+#!/usr/bin/env bash
+#
+# setup-mail-server.sh — self-hosted mailbox + outbound relay on omv-ha.
+#
+# Architecture (see docs/MAIL-SERVER-SETUP.md): omv-ha is behind Starlink CGNAT
+# with port 25 blocked, so there is NO direct-send/receive mail. This script
+# builds the working design:
+#   - dovecot  : virtual Maildir mailbox + IMAP + LMTP (self-hosted inbox)
+#   - postfix  : relay-ONLY via smtp.resend.com:587 + local LMTP delivery
+# Inbound (Cloudflare Email Routing -> Worker -> dovecot) and Roundcube/TLS are
+# configured separately.
+#
+# Secrets are read from the ENVIRONMENT — never hard-coded:
+#   RESEND_API_KEY            (required) — Resend send key; cloudless.gr must be
+#                                          a verified Resend domain
+#   MAIL_TBALTZAKIS_PASSWORD  (optional) — mailbox password; generated if unset
+#
+# Usage:  sudo RESEND_API_KEY=re_… MAIL_TBALTZAKIS_PASSWORD=… bash setup-mail-server.sh
+#
+set -euo pipefail
+
+DOMAIN="cloudless.gr"
+USER_LOCAL="tbaltzakis"
+MAILBOX="${USER_LOCAL}@${DOMAIN}"
+RELAY="[smtp.resend.com]:587"
+
+log() { printf '[mail-setup] %s\n' "$*"; }
+die() { printf '[mail-setup] ERROR: %s\n' "$*" >&2; exit 1; }
+
+[[ $EUID -eq 0 ]] || die "run as root (sudo)"
+[[ -n "${RESEND_API_KEY:-}" ]] || die "RESEND_API_KEY not set in the environment"
+MAILPW="${MAIL_TBALTZAKIS_PASSWORD:-$(openssl rand -base64 15 | tr -d '/+=' | head -c 18)}"
+
+log "Installing packages (postfix + lmdb + dovecot)…"
+export DEBIAN_FRONTEND=noninteractive
+echo "postfix postfix/main_mailer_type string Internet Site" | debconf-set-selections
+echo "postfix postfix/mailname string ${DOMAIN}" | debconf-set-selections
+apt-get update -qq
+apt-get install -y -qq \
+  postfix postfix-pcre postfix-lmdb \
+  dovecot-core dovecot-imapd dovecot-lmtpd \
+  libsasl2-modules ca-certificates
+
+log "Creating vmail user + Maildir root…"
+getent group vmail >/dev/null || groupadd -g 5000 vmail
+getent passwd vmail >/dev/null || useradd -r -u 5000 -g vmail -d /var/mail/vhosts -s /usr/sbin/nologin vmail
+mkdir -p "/var/mail/vhosts/${DOMAIN}"
+chown -R vmail:vmail /var/mail/vhosts
+
+log "Writing dovecot mailbox (${MAILBOX})…"
+HASH=$(doveadm pw -s SHA512-CRYPT -p "$MAILPW")
+printf '%s:%s::::::\n' "$MAILBOX" "$HASH" > /etc/dovecot/users
+chmod 640 /etc/dovecot/users
+chown root:dovecot /etc/dovecot/users 2>/dev/null || true
+
+cat > /etc/dovecot/local.conf <<'DOVECOT'
+# Self-hosted mail — virtual mailbox (cloudless.gr).
+protocols = imap lmtp
+
+mail_driver = maildir
+mail_path = /var/mail/vhosts/%{user | domain}/%{user | username}
+mail_uid = vmail
+mail_gid = vmail
+first_valid_uid = 5000
+last_valid_uid = 5000
+first_valid_gid = 5000
+
+auth_mechanisms = plain login
+
+passdb passwd-file {
+  passwd_file_path = /etc/dovecot/users
+}
+userdb passwd-file {
+  passwd_file_path = /etc/dovecot/users
+  fields {
+    uid = 5000
+    gid = 5000
+    home = /var/mail/vhosts/%{user | domain}/%{user | username}
+  }
+}
+
+service lmtp {
+  unix_listener /var/spool/postfix/private/dovecot-lmtp {
+    mode = 0600
+    user = postfix
+    group = postfix
+  }
+}
+service auth {
+  unix_listener /var/spool/postfix/private/auth {
+    mode = 0660
+    user = postfix
+    group = postfix
+  }
+}
+DOVECOT
+doveconf -n >/dev/null || die "dovecot config invalid"
+systemctl enable --now dovecot >/dev/null 2>&1 || true
+systemctl restart dovecot
+
+log "Configuring postfix relay via Resend…"
+printf '%s resend:%s\n' "$RELAY" "$RESEND_API_KEY" > /etc/postfix/sasl_passwd
+chmod 600 /etc/postfix/sasl_passwd
+postmap lmdb:/etc/postfix/sasl_passwd
+postconf -e \
+  "myhostname = mail.${DOMAIN}" \
+  "myorigin = ${DOMAIN}" \
+  "mydestination = localhost" \
+  "mynetworks = 127.0.0.0/8 [::1]/128" \
+  "inet_interfaces = loopback-only" \
+  "relayhost = ${RELAY}" \
+  "smtp_sasl_auth_enable = yes" \
+  "smtp_sasl_password_maps = lmdb:/etc/postfix/sasl_passwd" \
+  "smtp_sasl_security_options = noanonymous" \
+  "smtp_sasl_mechanism_filter = plain, login" \
+  "smtp_tls_security_level = encrypt" \
+  "virtual_mailbox_domains = ${DOMAIN}" \
+  "virtual_transport = lmtp:unix:private/dovecot-lmtp"
+systemctl enable --now postfix >/dev/null 2>&1 || true
+systemctl restart postfix
+
+log "Verifying mailbox auth…"
+doveadm auth test "$MAILBOX" "$MAILPW" | grep -q "auth succeeded" \
+  && log "  mailbox auth OK" || die "mailbox auth FAILED"
+
+log "Done. Mailbox: ${MAILBOX}"
+[[ -n "${MAIL_TBALTZAKIS_PASSWORD:-}" ]] || log "  GENERATED PASSWORD (save it): ${MAILPW}"
+log "Next: Roundcube webmail + Cloudflare Tunnel (webmail.${DOMAIN}) + inbound Email Routing."
+log "Send test: printf 'Subject: t\\nFrom: ${MAILBOX}\\nTo: you@x.com\\n\\nhi' | sendmail -f ${MAILBOX} you@x.com"


### PR DESCRIPTION
The old `docs/MAIL-SERVER-SETUP.md` + `setup-mail-server.sh` described a direct-send postfix 'Internet Site' with a public-IP MX proxied through Cloudflare — which **cannot work** on this network: omv-ha is behind **Starlink CGNAT** (no public inbound IP) with **port 25 blocked**, and CF's proxy only carries HTTP.

Rewrote both to the design actually built + verified live today:
- **dovecot** virtual Maildir mailbox + IMAP/LMTP (self-hosted inbox) — auth verified
- **postfix** relay-only via `smtp.resend.com:587` — send verified (`status=sent`); documents the `postfix-lmdb` requirement and the Resend DKIM/SPF DNS records
- **inbound** via Cloudflare Email Routing → Worker → dovecot (pending)
- **Roundcube** webmail + CF Tunnel (pending)

Secrets read from env; none hard-coded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)