### PR TITLE
feat(admin): add Webmail tab (webmail.cloudless.gr)

### DIFF
--- a/src/app/[locale]/admin/AdminLayoutClient.tsx
+++ b/src/app/[locale]/admin/AdminLayoutClient.tsx
@@ -144,6 +144,12 @@ const adminGroups: AdminGroup[] = [
       { href: "/admin/esp32-manager", label: "ESP32 Mgr", Icon: Cpu },
       { href: "/admin/selfhosted", label: "Self-hosted Apps", Icon: Server },
       {
+        href: "https://webmail.cloudless.gr",
+        label: "Webmail",
+        Icon: Mail,
+        external: true,
+      },
+      {
         href: "https://grafana.cloudless.gr",
         label: "Grafana",
         Icon: BarChart2,


### PR DESCRIPTION
Adds a **Webmail** link in the admin dashboard's Infrastructure group (external, opens new tab) → `https://webmail.cloudless.gr` — the self-hosted Roundcube webmail on omv-ha (exposed via Cloudflare Tunnel).

Lets you read/send/receive your cloudless.gr email from the admin dashboard. Follows the existing external-link pattern (Grafana, Cluster Manager).

🤖 Generated with [Claude Code](https://claude.com/claude-code)