### PR TITLE
infra(k3s): traefik resource limits via HelmChartConfig

### DIFF
--- a/infrastructure/k3s/traefik-resources.yaml
+++ b/infrastructure/k3s/traefik-resources.yaml
@@ -1,0 +1,19 @@
+# k3s HelmChartConfig — overlays resource limits on the built-in traefik
+# HelmChart. Applied live 2026-08-08 (previous state: no limits at all,
+# actual usage 26Mi). k3s watches this file if placed under
+# /var/lib/rancher/k3s/server/manifests/, but here we keep it in the repo
+# for GitOps and apply manually with `kubectl apply -f`.
+apiVersion: helm.cattle.io/v1
+kind: HelmChartConfig
+metadata:
+  name: traefik
+  namespace: kube-system
+spec:
+  valuesContent: |-
+    resources:
+      requests:
+        cpu: 20m
+        memory: 32Mi
+      limits:
+        cpu: 300m
+        memory: 128Mi


### PR DESCRIPTION
Traefik had no resource limits at all (0/2 dimensions). Adds a k3s `HelmChartConfig` overlay setting sensible bounds — 4x headroom over the 26Mi actually observed. Correct k3s pattern (overlay survives upgrades; a raw `kubectl patch` on the Deployment gets reverted by the HelmChart controller).

**Live 2026-08-08** — HelmChart re-ran, new traefik pod picked up the limits, 0 restarts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)