### PR TITLE
feat(ops): SafeDeploy Watchdog — continuous prod monitor + auto-rollback

### DIFF
--- a/docs/SAFEDEPLOY-WATCHDOG.md
+++ b/docs/SAFEDEPLOY-WATCHDOG.md
@@ -1,0 +1,115 @@
+# SafeDeploy Watchdog — continuous prod monitor + auto-rollback
+
+Companion to [SafeDeploy](SAFEDEPLOY.md). Where SafeDeploy's built-in
+auto-rollback only fires during the ~1-minute deploy-verify window, the
+**Watchdog** covers everything after — subtle regressions that only manifest
+in production, external dep hiccups, tunnel blips, etc.
+
+## Design (Notify-first, aggressive-later)
+
+Runs on **omv** (host, outside the k3s cluster) via a systemd timer every
+2 minutes. Polls `/api/health` (local NodePort first, LAN, then public URL).
+
+| Consecutive failures | ~ Minutes unhealthy | Action |
+|---|---|---|
+| 1–2 | 2–4 min | Silent (transient hiccup) |
+| **3** | ~6 min | **Alert** on ntfy + Slack + email (one-shot per incident) |
+| 4–7 | 8–14 min | No further pings (won't spam) |
+| **8** | ~16 min | **Auto-rollback** `previous release` + "rolled back" alert |
+| — | recovers | "Recovered" alert; state reset |
+
+### Safeguards
+- **60-minute cooldown** between auto-rollbacks (prevents ping-pong loops)
+- **Skip rollback if current release is <15 min old** (deploy-time verify
+  already handled that window; a new deploy that immediately turns bad in
+  the wild is a code problem, not a rollback problem)
+- **One alert per incident** — no re-notification every 2 min
+
+## Alert channels (all fire in parallel; failures don't block each other)
+
+- **ntfy** — push to phone (topic: `NTFY_TOPIC`, LAN endpoint used so it
+  works even if the Cloudflare tunnel is what's down)
+- **Slack** — `#general` via `SLACK_BOT_TOKEN` (`chat.postMessage`)
+- **Email** — `tbaltzakis@cloudless.gr` via Resend REST API
+  (as `safedeploy-watchdog@cloudless.gr`; DKIM-signed)
+
+All credentials are pulled from the cluster's `cloudless-secrets` Secret at
+install time and written to `/etc/safedeploy-watchdog.env` (mode 600, root).
+The watchdog script never prints credential values.
+
+## Install / refresh
+
+From a workstation with `.env.local` (or a Cowork session):
+
+```bash
+scp -i ~/.ssh/id_rsa infrastructure/omv/{safedeploy-watchdog.sh,safedeploy-watchdog.service,safedeploy-watchdog.timer,install-safedeploy-watchdog.sh} tbaltzakis@omv:/tmp/sdw/
+ssh tbaltzakis@omv 'sudo bash /tmp/sdw/install-safedeploy-watchdog.sh'
+```
+
+The installer is idempotent — re-run it to refresh creds after any secret
+rotation.
+
+## Operate
+
+```bash
+# see the timer schedule + last run
+systemctl list-timers safedeploy-watchdog.timer
+
+# tail the watchdog log (only prints on unhealthy transitions / rollbacks)
+sudo journalctl -t safedeploy-watchdog -f
+
+# force one tick right now
+sudo systemctl start safedeploy-watchdog.service
+
+# inspect state (only counters, no secrets)
+sudo cat /var/lib/safedeploy-watchdog/{fail_count,last_http_code,notified,incident_start} 2>/dev/null
+
+# manual pause (e.g., during maintenance):
+sudo systemctl stop safedeploy-watchdog.timer
+
+# resume
+sudo systemctl start safedeploy-watchdog.timer
+```
+
+## What the alerts look like
+
+- **"⚠️ cloudless.gr unhealthy"** — 3rd consecutive failure. Includes the
+  last HTTP code and the exact command to roll back manually if you don't
+  want to wait for auto-rollback: `scripts/rollback.sh previous`.
+- **"🔁 cloudless.gr auto-rolled-back"** — 8th consecutive failure; the
+  watchdog flipped the symlink from `<old-sha>` to `<previous-sha>` and
+  restarted the deployment.
+- **"🚨 cloudless.gr rollback FAILED"** — 8th failure but no previous
+  release available (fresh install, only 1 release on disk). Manual
+  intervention needed.
+- **"✅ cloudless.gr recovered"** — health returned after any incident that
+  fired an alert. Includes duration and whether an auto-rollback happened.
+
+## Testing
+
+Live-verified at install (2026-08-09):
+- Script syntax + logic checks pass
+- All 3 alert channels sent test messages successfully (ntfy 200, Slack ok,
+  Resend id returned)
+- State files created correctly; healthy tick is silent (no log noise);
+  timer fires every 2 min per `systemctl list-timers`
+
+To exercise the actual alert threshold without a real outage:
+```bash
+# Set fake failure count just below the notify threshold, then poll a bad URL
+sudo bash -c 'echo 2 > /var/lib/safedeploy-watchdog/fail_count'
+# Then edit HEALTH_URL_LOCAL to a broken port temporarily and run:
+sudo systemctl start safedeploy-watchdog.service
+# ...will fire the ⚠️ alert once. Revert the URL after testing.
+```
+
+## What it doesn't cover
+
+- **The watchdog itself dying** — if the omv host is fully down, no alerts
+  come. Complement with an external monitor (Uptime Kuma from a different
+  network, or a cloud service).
+- **The cluster + omv down together** — same as above; needs off-network monitoring.
+- **Slow/degraded but healthy responses** — /api/health only checks the app
+  is running. For SLA-style latency alerts use Grafana + Alertmanager.
+- **Non-cloudless.gr apps** — grafana/postiz/espocrm/etc. aren't watched.
+  Extend the script or add per-app watchdogs if needed.

--- a/infrastructure/omv/install-safedeploy-watchdog.sh
+++ b/infrastructure/omv/install-safedeploy-watchdog.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+#
+# install-safedeploy-watchdog.sh — install (or refresh) the SafeDeploy
+# watchdog on omv. Run AS ROOT on omv itself, or via ssh:
+#
+#   ssh tbaltzakis@omv "sudo bash -s" \
+#     < infrastructure/omv/install-safedeploy-watchdog.sh
+#
+# What it does (idempotent):
+#   1. Reads NTFY/SLACK/RESEND credentials from the cluster's cloudless-secrets
+#      Secret (namespace `cloudless`) via `k3s kubectl`. Nothing is echoed.
+#   2. Writes /etc/safedeploy-watchdog.env (mode 600, root:root).
+#   3. Copies the watchdog script + systemd unit + timer into place.
+#   4. Enables and starts the timer.
+#   5. Fires one immediate tick to prove the wiring, then prints last log lines.
+#
+set -euo pipefail
+[ "$EUID" = "0" ] || { echo "must be root" >&2; exit 1; }
+
+REPO_DIR="$(dirname "$(readlink -f "$0")")"   # infrastructure/omv/
+SCRIPT="$REPO_DIR/safedeploy-watchdog.sh"
+UNIT_SVC="$REPO_DIR/safedeploy-watchdog.service"
+UNIT_TIMER="$REPO_DIR/safedeploy-watchdog.timer"
+
+for f in "$SCRIPT" "$UNIT_SVC" "$UNIT_TIMER"; do
+  [ -f "$f" ] || { echo "missing: $f" >&2; exit 1; }
+done
+
+echo "[install] fetching alert credentials from k8s secret cloudless-secrets/cloudless…"
+b64() { k3s kubectl get secret cloudless-secrets -n cloudless -o jsonpath="{.data.$1}" 2>/dev/null | base64 -d 2>/dev/null || true; }
+
+NTFY_BASE_URL=$(b64 NTFY_BASE_URL)
+# The cluster stores ntfy's IN-CLUSTER DNS (`http://ntfy.ntfy.svc.cluster.local`)
+# — that only resolves inside a pod. This watchdog runs on the omv host, so
+# rewrite in-cluster DNS to the LAN NodePort so notifications actually leave
+# the box. Public URL (ntfy.cloudless.gr) would work too, but the LAN path
+# is faster and works even if the Cloudflare tunnel is what's broken.
+case "$NTFY_BASE_URL" in
+  *.svc.cluster.local*) NTFY_BASE_URL="http://192.168.1.128:30080" ;;
+esac
+NTFY_TOPIC=$(b64   NTFY_TOPIC)
+NTFY_TOKEN=$(b64   NTFY_TOKEN)
+SLACK_BOT_TOKEN=$(b64 SLACK_BOT_TOKEN)
+RESEND_API_KEY=$(b64  RESEND_API_KEY)
+
+# Report presence (never values)
+_present() { [ -n "$2" ] && echo "  ✓ $1 (len ${#2})" || echo "  ✗ $1 MISSING"; }
+_present NTFY_BASE_URL   "$NTFY_BASE_URL"
+_present NTFY_TOPIC      "$NTFY_TOPIC"
+_present NTFY_TOKEN      "$NTFY_TOKEN"
+_present SLACK_BOT_TOKEN "$SLACK_BOT_TOKEN"
+_present RESEND_API_KEY  "$RESEND_API_KEY"
+
+install -d -m 700 -o root -g root /var/lib/safedeploy-watchdog
+umask 077
+cat > /etc/safedeploy-watchdog.env <<ENV
+# populated by install-safedeploy-watchdog.sh — DO NOT edit by hand
+NTFY_BASE_URL="$NTFY_BASE_URL"
+NTFY_TOPIC="$NTFY_TOPIC"
+NTFY_TOKEN="$NTFY_TOKEN"
+SLACK_BOT_TOKEN="$SLACK_BOT_TOKEN"
+SLACK_CHANNEL="#general"
+RESEND_API_KEY="$RESEND_API_KEY"
+ALERT_EMAIL="tbaltzakis@cloudless.gr"
+ENV
+chmod 600 /etc/safedeploy-watchdog.env
+chown root:root /etc/safedeploy-watchdog.env
+echo "[install] wrote /etc/safedeploy-watchdog.env"
+
+install -m 755 -o root -g root "$SCRIPT"     /usr/local/sbin/safedeploy-watchdog.sh
+install -m 644 -o root -g root "$UNIT_SVC"   /etc/systemd/system/safedeploy-watchdog.service
+install -m 644 -o root -g root "$UNIT_TIMER" /etc/systemd/system/safedeploy-watchdog.timer
+echo "[install] installed script + units"
+
+systemctl daemon-reload
+systemctl enable --now safedeploy-watchdog.timer
+echo "[install] timer enabled + started"
+
+echo "[install] firing one immediate tick to verify wiring…"
+systemctl start safedeploy-watchdog.service || true
+sleep 3
+echo "[install] --- recent journal ---"
+journalctl -t safedeploy-watchdog -n 8 --no-pager || journalctl -u safedeploy-watchdog.service -n 8 --no-pager
+echo "[install] --- next scheduled run ---"
+systemctl list-timers safedeploy-watchdog.timer --no-pager
+echo "[install] done."

--- a/infrastructure/omv/safedeploy-watchdog.service
+++ b/infrastructure/omv/safedeploy-watchdog.service
@@ -1,0 +1,22 @@
+[Unit]
+Description=SafeDeploy watchdog — polls cloudless.gr health, notifies and auto-rolls-back on failure
+Documentation=file:///home/tbaltzakis/cloudless.gr/docs/SAFEDEPLOY.md
+After=network-online.target k3s.service
+Wants=network-online.target
+
+[Service]
+Type=oneshot
+# Credentials populated at install time from the cloudless-secrets k8s Secret.
+# Values are never printed by the watchdog script.
+EnvironmentFile=-/etc/safedeploy-watchdog.env
+ExecStart=/usr/local/sbin/safedeploy-watchdog.sh
+# Bounded runtime — a stuck tick must not accumulate
+TimeoutStartSec=90
+# Hardening (script only reads state + posts alerts + flips one symlink)
+ProtectSystem=full
+ProtectHome=false
+ReadWritePaths=/var/lib/safedeploy-watchdog /home/tbaltzakis/cloudless-standalone
+NoNewPrivileges=true
+
+[Install]
+WantedBy=multi-user.target

--- a/infrastructure/omv/safedeploy-watchdog.sh
+++ b/infrastructure/omv/safedeploy-watchdog.sh
@@ -1,0 +1,194 @@
+#!/usr/bin/env bash
+#
+# safedeploy-watchdog.sh — continuous prod health monitor + auto-rollback
+#
+# Runs on omv (host, outside the k3s cluster) via a systemd timer every 2 min.
+# Polls the local cloudless-app NodePort. Uses "Notify-first" strategy:
+#
+#   • unhealthy 3× in a row  (~6 min)   → send alerts (ntfy + Slack + email)
+#   • still unhealthy 8× total (~16 min)→ ALSO run scripts/rollback.sh-style
+#                                          symlink flip + kubectl rollout restart,
+#                                          then send "rolled back" alert
+#   • recovers                          → send "recovered" alert; reset state
+#
+# Safeguards to prevent rollback loops or premature action:
+#   • 60-min cooldown between auto-rollbacks
+#   • skip rollback if current release symlink is <15 min old
+#     (deploy-time verify already handled that window)
+#   • one "alert" notification per incident (no repeated pings)
+#
+# Config: /etc/safedeploy-watchdog.env populated at install time from the
+#         cloudless-secrets k8s Secret. Values are NEVER printed by this script.
+#
+# State: /var/lib/safedeploy-watchdog/{fail_count,last_rollback_ts,last_notify_ts,notified,incident_start}
+#
+set -euo pipefail
+
+# --- config ------------------------------------------------------------------
+STATE_DIR=/var/lib/safedeploy-watchdog
+CURRENT=/home/tbaltzakis/cloudless-standalone
+RELEASES=/home/tbaltzakis/cloudless-releases
+NS=cloudless
+DEPLOY=cloudless-app
+HEALTH_URL_LOCAL=http://127.0.0.1:30300/api/health
+HEALTH_URL_LAN=http://192.168.1.128:30300/api/health
+HEALTH_URL_PUBLIC=https://cloudless.gr/api/health
+NOTIFY_THRESHOLD=3        # consecutive failures to send first alert
+ROLLBACK_THRESHOLD=8      # consecutive failures to auto-rollback
+ROLLBACK_COOLDOWN=3600    # min seconds between auto-rollbacks
+MIN_RELEASE_AGE=900       # skip rollback if symlink younger than this (seconds)
+
+# --- credentials (from env file, never printed) ------------------------------
+# shellcheck disable=SC1091
+[ -f /etc/safedeploy-watchdog.env ] && . /etc/safedeploy-watchdog.env
+: "${NTFY_BASE_URL:=}" "${NTFY_TOPIC:=}" "${NTFY_TOKEN:=}"
+: "${SLACK_BOT_TOKEN:=}" "${SLACK_CHANNEL:=#general}"
+: "${RESEND_API_KEY:=}" "${ALERT_EMAIL:=tbaltzakis@cloudless.gr}"
+
+# --- state helpers -----------------------------------------------------------
+mkdir -p "$STATE_DIR"
+_get() { cat "$STATE_DIR/$1" 2>/dev/null || echo "$2"; }
+_set() { printf '%s\n' "$2" > "$STATE_DIR/$1"; }
+_now() { date -u +%s; }
+
+log()  { logger -t safedeploy-watchdog "$*"; printf '[%(%FT%TZ)T] %s\n' -1 "$*"; }
+
+# --- notifications (best-effort; failures never block the watchdog) ---------
+notify_ntfy() {
+  local title="$1" msg="$2" prio="${3:-high}"
+  [ -n "$NTFY_BASE_URL" ] && [ -n "$NTFY_TOPIC" ] || return 0
+  local auth=(); [ -n "$NTFY_TOKEN" ] && auth=(-H "Authorization: Bearer $NTFY_TOKEN")
+  curl -fsSm 10 -X POST "${NTFY_BASE_URL%/}/${NTFY_TOPIC}" \
+       -H "Title: $title" -H "Priority: $prio" -H "Tags: warning" \
+       "${auth[@]}" -d "$msg" >/dev/null 2>&1 || true
+}
+
+notify_slack() {
+  local title="$1" msg="$2"
+  [ -n "$SLACK_BOT_TOKEN" ] || return 0
+  local payload
+  payload=$(printf '{"channel":"%s","text":"%s\n%s"}' "$SLACK_CHANNEL" "$title" "${msg//\"/\\\"}")
+  curl -fsSm 10 -X POST https://slack.com/api/chat.postMessage \
+       -H "Authorization: Bearer $SLACK_BOT_TOKEN" -H "Content-Type: application/json; charset=utf-8" \
+       -d "$payload" >/dev/null 2>&1 || true
+}
+
+notify_email() {
+  local subject="$1" body="$2"
+  [ -n "$RESEND_API_KEY" ] || return 0
+  local payload
+  payload=$(python3 -c "import json,sys;print(json.dumps({'from':'safedeploy-watchdog@cloudless.gr','to':sys.argv[1],'subject':sys.argv[2],'text':sys.argv[3]}))" "$ALERT_EMAIL" "$subject" "$body")
+  curl -fsSm 10 -X POST https://api.resend.com/emails \
+       -H "Authorization: Bearer $RESEND_API_KEY" -H "Content-Type: application/json" \
+       -d "$payload" >/dev/null 2>&1 || true
+}
+
+notify_all() {
+  local title="$1" body="$2" prio="${3:-high}"
+  notify_ntfy  "$title" "$body" "$prio"
+  notify_slack "$title" "$body"
+  notify_email "$title" "$body"
+}
+
+# --- health probe ------------------------------------------------------------
+# Returns 0 healthy, 1 unhealthy. Also captures whether it's a 502 (strong
+# signal — origin unreachable) vs a health-endpoint issue.
+probe_health() {
+  # Try local NodePort first (fastest, most direct)
+  local resp code
+  for url in "$HEALTH_URL_LOCAL" "$HEALTH_URL_LAN"; do
+    code=$(curl -sS -o /tmp/sdw-body -w '%{http_code}' --max-time 8 "$url" 2>/dev/null || echo "000")
+    if [ "$code" = "200" ] && grep -q '"status"' /tmp/sdw-body 2>/dev/null; then
+      _set last_http_code "$code"
+      return 0
+    fi
+  done
+  # Fall back to public URL (catches tunnel/cloudflare-level breakage too)
+  code=$(curl -sS -o /tmp/sdw-body -w '%{http_code}' --max-time 12 "$HEALTH_URL_PUBLIC" 2>/dev/null || echo "000")
+  _set last_http_code "$code"
+  [ "$code" = "200" ] && return 0 || return 1
+}
+
+# --- rollback (adapted from scripts/rollback.sh, LOCAL to omv) --------------
+do_rollback() {
+  local cur prev
+  cur=$(readlink "$CURRENT" 2>/dev/null | sed 's|^cloudless-releases/||')
+  prev=$(ls -1t "$RELEASES" 2>/dev/null | grep -v "^${cur}$" | head -1)
+  if [ -z "$prev" ]; then
+    log "ROLLBACK aborted: no previous release available"
+    return 1
+  fi
+  log "ROLLBACK: flipping $cur → $prev"
+  ln -sfn "cloudless-releases/$prev" "$CURRENT"
+  chown -h tbaltzakis:users "$CURRENT"
+  k3s kubectl -n "$NS" rollout restart "deploy/$DEPLOY" >/dev/null 2>&1
+  k3s kubectl -n "$NS" rollout status "deploy/$DEPLOY" --timeout=180s >/dev/null 2>&1
+  _set last_rollback_ts "$(_now)"
+  log "ROLLBACK done, now on $prev (was $cur)"
+  _set rollback_from "$cur"
+  _set rollback_to   "$prev"
+  return 0
+}
+
+# --- main tick ---------------------------------------------------------------
+main() {
+  local fail_count now
+  fail_count=$(_get fail_count 0)
+  now=$(_now)
+
+  if probe_health; then
+    # HEALTHY
+    if [ "$fail_count" -gt 0 ] || [ "$(_get notified 0)" = "1" ]; then
+      # was unhealthy, now recovered → notify + reset
+      local incident_start; incident_start=$(_get incident_start "$now")
+      local duration_min=$(( (now - incident_start) / 60 ))
+      local rf; rf=$(_get rollback_from ""); local rt; rt=$(_get rollback_to "")
+      local body="Site recovered after ~${duration_min} min unhealthy."
+      [ -n "$rt" ] && body+=$'\n'"Auto-rollback fired: $rf → $rt"
+      log "RECOVERED after ${duration_min}min (was fail_count=$fail_count)"
+      notify_all "✅ cloudless.gr recovered" "$body" low
+    fi
+    _set fail_count 0; _set notified 0; _set rollback_from ""; _set rollback_to ""; _set incident_start ""
+    return 0
+  fi
+
+  # UNHEALTHY — increment counter
+  fail_count=$((fail_count+1))
+  _set fail_count "$fail_count"
+  [ "$fail_count" = "1" ] && _set incident_start "$now"
+  local code; code=$(_get last_http_code "?")
+  log "UNHEALTHY tick=$fail_count http=$code"
+
+  # First alert at NOTIFY_THRESHOLD (only once per incident)
+  if [ "$fail_count" -ge "$NOTIFY_THRESHOLD" ] && [ "$(_get notified 0)" = "0" ]; then
+    local body="cloudless.gr health check has failed ${fail_count} times in a row (~$((fail_count*2)) min). Last HTTP=${code}."$'\n\n'"Rollback candidate: run 'scripts/rollback.sh previous' from a workstation.\n\nAuto-rollback will fire after ${ROLLBACK_THRESHOLD} consecutive failures (~$((ROLLBACK_THRESHOLD*2)) min total) if still unhealthy."
+    log "NOTIFY sent (threshold=$NOTIFY_THRESHOLD reached)"
+    notify_all "⚠️ cloudless.gr unhealthy" "$body" high
+    _set notified 1
+  fi
+
+  # Auto-rollback at ROLLBACK_THRESHOLD (with safeguards)
+  if [ "$fail_count" -ge "$ROLLBACK_THRESHOLD" ]; then
+    # Safeguard 1: cooldown since last auto-rollback
+    local last_rb; last_rb=$(_get last_rollback_ts 0)
+    if [ "$last_rb" != "0" ] && [ $((now - last_rb)) -lt "$ROLLBACK_COOLDOWN" ]; then
+      log "SKIP rollback: cooldown ($(( (ROLLBACK_COOLDOWN - (now - last_rb))/60 )) min remaining)"
+      return 0
+    fi
+    # Safeguard 2: don't rollback a release younger than MIN_RELEASE_AGE
+    local link_age
+    link_age=$(( now - $(stat -c %Y "$CURRENT" 2>/dev/null || echo "$now") ))
+    if [ "$link_age" -lt "$MIN_RELEASE_AGE" ]; then
+      log "SKIP rollback: current release age=${link_age}s < ${MIN_RELEASE_AGE}s (deploy-time rollback likely already fired)"
+      return 0
+    fi
+    if do_rollback; then
+      local rf; rf=$(_get rollback_from "?"); local rt; rt=$(_get rollback_to "?")
+      notify_all "🔁 cloudless.gr auto-rolled-back" "Auto-flipped $rf → $rt after $fail_count consecutive failures. Verifying…" high
+    else
+      notify_all "🚨 cloudless.gr rollback FAILED" "Wanted to auto-rollback but couldn't (no previous release?). Manual intervention needed." urgent
+    fi
+  fi
+}
+
+main "$@"

--- a/infrastructure/omv/safedeploy-watchdog.timer
+++ b/infrastructure/omv/safedeploy-watchdog.timer
@@ -1,0 +1,16 @@
+[Unit]
+Description=Run SafeDeploy watchdog every 2 minutes
+Documentation=file:///home/tbaltzakis/cloudless.gr/docs/SAFEDEPLOY.md
+
+[Timer]
+# Fire 30s after boot, then every 2 min. Small random delay avoids
+# lock-step alignment with cron/other timers.
+OnBootSec=30s
+OnUnitActiveSec=120s
+RandomizedDelaySec=15s
+AccuracySec=5s
+Persistent=false
+Unit=safedeploy-watchdog.service
+
+[Install]
+WantedBy=timers.target


### PR DESCRIPTION
Complements [SafeDeploy](docs/SAFEDEPLOY.md) — which only auto-rolls-back during the ~1-min deploy-verify window — with a continuous on-host watchdog covering post-deploy runtime failures.

## Behavior (Notify-first, aggressive-later)
| Consecutive failures | Time unhealthy | Action |
|---|---|---|
| 3 | ~6 min | ⚠️ Alert on ntfy + Slack + email |
| 8 | ~16 min | 🔁 Auto-rollback + alert |
| recovers | — | ✅ Recovered alert; state reset |

Safeguards: 60-min cooldown between rollbacks; skip if current release <15min old; one alert per incident.

## Runs on omv host (not in-cluster) — deliberate
So it keeps working even when the cluster itself is degraded. Systemd timer every 2min, tiny bash script, no dependencies beyond curl+python3.

## Verified live
Installer pulled all 5 creds from `cloudless-secrets` k8s Secret; timer active + firing; test messages sent OK to all 3 channels (ntfy 200, Slack ok, Resend id returned).

See `docs/SAFEDEPLOY-WATCHDOG.md` for the full runbook.

🤖 Generated with [Claude Code](https://claude.com/claude-code)