### PR TITLE
infra(tz): pin Europe/Athens across pods + CronJobs

### DIFF
--- a/infrastructure/appflowy/walg-sidecar.yaml
+++ b/infrastructure/appflowy/walg-sidecar.yaml
@@ -29,6 +29,7 @@ metadata:
     app.kubernetes.io/part-of: appflowy
 spec:
   schedule: 30 2 * * *
+  timeZone: Europe/Athens
   concurrencyPolicy: Forbid
   successfulJobsHistoryLimit: 2
   failedJobsHistoryLimit: 3

--- a/infrastructure/backup/cronjob-appflowy-minio.yaml
+++ b/infrastructure/backup/cronjob-appflowy-minio.yaml
@@ -10,6 +10,7 @@ metadata:
     backup.cloudless.gr/target: appflowy-minio
 spec:
   schedule: 30 4 * * *
+  timeZone: Europe/Athens
   concurrencyPolicy: Forbid
   successfulJobsHistoryLimit: 3
   failedJobsHistoryLimit: 7

--- a/infrastructure/backup/cronjob-appflowy.yaml
+++ b/infrastructure/backup/cronjob-appflowy.yaml
@@ -9,6 +9,7 @@ metadata:
     backup.cloudless.gr/target: appflowy-postgres
 spec:
   schedule: 30 3 * * *
+  timeZone: Europe/Athens
   concurrencyPolicy: Forbid
   successfulJobsHistoryLimit: 3
   failedJobsHistoryLimit: 7

--- a/infrastructure/backup/cronjob-espocrm.yaml
+++ b/infrastructure/backup/cronjob-espocrm.yaml
@@ -8,6 +8,7 @@ metadata:
     backup.cloudless.gr/target: espocrm-mariadb
 spec:
   schedule: 45 3 * * *
+  timeZone: Europe/Athens
   concurrencyPolicy: Forbid
   successfulJobsHistoryLimit: 3
   failedJobsHistoryLimit: 7

--- a/infrastructure/backup/cronjob-n8n.yaml
+++ b/infrastructure/backup/cronjob-n8n.yaml
@@ -8,6 +8,7 @@ metadata:
     backup.cloudless.gr/target: n8n-sqlite
 spec:
   schedule: 15 4 * * *
+  timeZone: Europe/Athens
   concurrencyPolicy: Forbid
   successfulJobsHistoryLimit: 3
   failedJobsHistoryLimit: 7

--- a/infrastructure/backup/cronjob-uptime-kuma.yaml
+++ b/infrastructure/backup/cronjob-uptime-kuma.yaml
@@ -10,6 +10,7 @@ metadata:
     backup.cloudless.gr/target: uptime-kuma-sqlite
 spec:
   schedule: 45 4 * * *
+  timeZone: Europe/Athens
   concurrencyPolicy: Forbid
   successfulJobsHistoryLimit: 3
   failedJobsHistoryLimit: 7

--- a/infrastructure/espocrm/k8s/mariadb-xbstream-backup.yaml
+++ b/infrastructure/espocrm/k8s/mariadb-xbstream-backup.yaml
@@ -13,6 +13,7 @@ metadata:
     backup.cloudless.gr/rpo: 1h
 spec:
   schedule: 0 * * * *
+  timeZone: Europe/Athens
   concurrencyPolicy: Forbid
   failedJobsHistoryLimit: 7
   successfulJobsHistoryLimit: 3

--- a/infrastructure/monitoring/prometheus-fine-tune-cronjob.yaml
+++ b/infrastructure/monitoring/prometheus-fine-tune-cronjob.yaml
@@ -104,9 +104,10 @@ metadata:
   labels:
     app: prometheus-fine-tune
 spec:
-  # 03:15 UTC daily — off-peak, doesn't collide with the 03:00 cluster-cleanup
+  # 03:15 EEST daily — off-peak, doesn't collide with the 03:00 cluster-cleanup
   # or the 03:45 EEST etcd-defrag on omv.
   schedule: "15 3 * * *"
+  timeZone: Europe/Athens
   concurrencyPolicy: Forbid
   startingDeadlineSeconds: 300
   successfulJobsHistoryLimit: 3

--- a/k8s/cloudless-app-hostpath.yaml
+++ b/k8s/cloudless-app-hostpath.yaml
@@ -72,6 +72,11 @@ spec:
         env:
         - name: CLOUDFLARE_ACCOUNT_ID
           value: fb7dc7b69b662480cd5961a4d1913c78
+        # Local time = Athens (server-side timestamps in logs/api responses).
+        # The host node already runs Europe/Athens; this exports it into the
+        # Node.js container which otherwise defaults to UTC.
+        - name: TZ
+          value: Europe/Athens
         volumeMounts:
         - name: standalone
           mountPath: /app

--- a/k8s/espocrm/backup/mariadb-xbstream-backup.yaml
+++ b/k8s/espocrm/backup/mariadb-xbstream-backup.yaml
@@ -49,6 +49,7 @@ metadata:
     backup.cloudless.gr/rpo: 1h
 spec:
   schedule: 0 * * * *
+  timeZone: Europe/Athens
   concurrencyPolicy: Forbid
   failedJobsHistoryLimit: 7
   successfulJobsHistoryLimit: 3


### PR DESCRIPTION
Both node OSes already run Europe/Athens; pods and k8s CronJobs default to UTC. This aligns everything with wall-clock.

**Repo (durable):**
- `cloudless-app-hostpath.yaml`: TZ env
- 8 CronJob manifests: `spec.timeZone: Europe/Athens`

**Also live-patched** (verified):
- cloudless-app pod ↔ EEST
- Grafana pod ↔ EEST + `GF_DATE_FORMATS_DEFAULT_TIMEZONE`
- All 8 CronJobs ↔ tz=Europe/Athens

Grafana is Helm-managed so its TZ env can drift on `helm upgrade` — will extend the prometheus-fine-tune CronJob to re-apply it as follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)