### PR TITLE
feat(admin): one-click Headlamp token helper

### DIFF
--- a/infrastructure/headlamp/token-minter-rbac.yaml
+++ b/infrastructure/headlamp/token-minter-rbac.yaml
@@ -1,0 +1,36 @@
+# Lets the cloudless-app pod (running as `default` SA in `cloudless` ns)
+# mint short-lived JWTs for the `headlamp-admin` ServiceAccount via the
+# k8s TokenRequest API. Used by /api/admin/headlamp/token so the admin
+# dashboard can 1-click get a fresh Headlamp login token every 24h.
+#
+# Scope is deliberately narrow:
+#   - resource `serviceaccounts/token` with resourceName `headlamp-admin`
+#   - verb `create` only
+# → the cloudless-app SA cannot list/get/patch anything else in this ns,
+#   cannot mint tokens for any other SA, cannot see the tokens it minted
+#   for anyone else.
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: cloudless-app-headlamp-token-minter
+  namespace: headlamp
+rules:
+- apiGroups: [""]
+  resources: ["serviceaccounts/token"]
+  resourceNames: ["headlamp-admin"]
+  verbs: ["create"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: cloudless-app-headlamp-token-minter
+  namespace: headlamp
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: cloudless-app-headlamp-token-minter
+subjects:
+- kind: ServiceAccount
+  name: default
+  namespace: cloudless

--- a/src/app/[locale]/admin/AdminLayoutClient.tsx
+++ b/src/app/[locale]/admin/AdminLayoutClient.tsx
@@ -155,12 +155,10 @@ const adminGroups: AdminGroup[] = [
         Icon: BarChart2,
         external: true,
       },
-      {
-        href: "https://manage.cloudless.gr",
-        label: "Cluster Manager",
-        Icon: LayoutGrid,
-        external: true,
-      },
+      // Was: external link to https://manage.cloudless.gr, but Headlamp requires
+      // a k8s SA token that expires in 24h — this internal page mints + copies
+      // it in one click and opens Headlamp in a new tab.
+      { href: "/admin/headlamp", label: "Cluster Manager", Icon: LayoutGrid },
     ],
   },
 ];

--- a/src/app/[locale]/admin/headlamp/page.tsx
+++ b/src/app/[locale]/admin/headlamp/page.tsx
@@ -1,0 +1,130 @@
+"use client";
+
+/**
+ * /admin/headlamp — one-click helper for logging into the self-hosted
+ * Headlamp Kubernetes UI at https://manage.cloudless.gr.
+ *
+ * Why: Headlamp v0.36 UI always prompts for a token even when the backend
+ * is in-cluster + authenticated (see docs/HEADLAMP.md for the honest write-
+ * up). This page mints a fresh 24h k8s SA JWT via /api/admin/headlamp/token,
+ * copies it to the clipboard, and opens Headlamp in a new tab so the user
+ * just Ctrl+V-s into the login field.
+ */
+import { useState } from "react";
+import { fetchWithAuth } from "@/lib/fetch-with-auth";
+
+const HEADLAMP_URL = "https://manage.cloudless.gr";
+
+interface TokenResponse {
+  token: string;
+  expirationTimestamp: string;
+}
+
+export default function HeadlampHelperPage() {
+  const [status, setStatus] = useState<"idle" | "loading" | "ready" | "error">("idle");
+  const [token, setToken] = useState<string>("");
+  const [expiresAt, setExpiresAt] = useState<string>("");
+  const [error, setError] = useState<string>("");
+
+  async function mint(openTab: boolean) {
+    setStatus("loading");
+    setError("");
+    try {
+      const res = await fetchWithAuth("/api/admin/headlamp/token", { method: "POST" });
+      if (!res.ok) {
+        const body = await res.json().catch(() => ({ error: `HTTP ${res.status}` }));
+        throw new Error(body.error ?? `HTTP ${res.status}`);
+      }
+      const data = (await res.json()) as TokenResponse;
+      setToken(data.token);
+      setExpiresAt(data.expirationTimestamp);
+      // Copy to clipboard best-effort — silent-ok if permission denied
+      try {
+        await navigator.clipboard.writeText(data.token);
+      } catch {
+        /* user can still copy manually from the textarea below */
+      }
+      setStatus("ready");
+      if (openTab) {
+        window.open(HEADLAMP_URL, "_blank", "noopener,noreferrer");
+      }
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+      setStatus("error");
+    }
+  }
+
+  return (
+    <div className="mx-auto max-w-3xl space-y-6 p-6">
+      <header>
+        <h1 className="text-2xl font-semibold">Headlamp — cluster admin UI</h1>
+        <p className="mt-2 text-sm text-neutral-500 dark:text-neutral-400">
+          Headlamp lives at{" "}
+          <a
+            href={HEADLAMP_URL}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-blue-600 underline"
+          >
+            {HEADLAMP_URL}
+          </a>
+          . Its login page asks for a k8s ServiceAccount token. Click below and it&apos;s copied
+          to your clipboard + Headlamp opens in a new tab — paste (Ctrl+V) into the &quot;ID token&quot;
+          field and you&apos;re in. Token is valid for 24h.
+        </p>
+      </header>
+
+      <div className="flex gap-3">
+        <button
+          type="button"
+          onClick={() => mint(true)}
+          disabled={status === "loading"}
+          className="rounded-lg bg-blue-600 px-5 py-2.5 text-sm font-medium text-white hover:bg-blue-700 disabled:opacity-60"
+        >
+          {status === "loading" ? "Minting…" : "Get token & open Headlamp"}
+        </button>
+        <button
+          type="button"
+          onClick={() => mint(false)}
+          disabled={status === "loading"}
+          className="rounded-lg border border-neutral-300 px-5 py-2.5 text-sm font-medium hover:bg-neutral-50 disabled:opacity-60 dark:border-neutral-700 dark:hover:bg-neutral-800"
+        >
+          Just copy token (don&apos;t open)
+        </button>
+      </div>
+
+      {status === "ready" && (
+        <div className="space-y-3 rounded-lg border border-green-300 bg-green-50 p-4 text-sm dark:border-green-800 dark:bg-green-950">
+          <p className="font-medium text-green-800 dark:text-green-200">
+            ✅ Token copied to clipboard. Expires {new Date(expiresAt).toLocaleString()}.
+          </p>
+          <details>
+            <summary className="cursor-pointer text-green-900 dark:text-green-100">
+              Show raw token (fallback if clipboard didn&apos;t work)
+            </summary>
+            <textarea
+              readOnly
+              value={token}
+              rows={4}
+              className="mt-2 w-full rounded border border-green-300 bg-white p-2 font-mono text-xs dark:border-green-700 dark:bg-neutral-900"
+              onClick={(e) => (e.target as HTMLTextAreaElement).select()}
+            />
+          </details>
+        </div>
+      )}
+
+      {status === "error" && (
+        <div className="rounded-lg border border-red-300 bg-red-50 p-4 text-sm dark:border-red-800 dark:bg-red-950">
+          <p className="font-medium text-red-800 dark:text-red-200">
+            ❌ {error}
+          </p>
+          <p className="mt-2 text-xs text-red-700 dark:text-red-300">
+            Likely causes: the /api/admin/headlamp/token endpoint isn&apos;t deployed yet, the pod isn&apos;t
+            running in-cluster (dev mode?), or the RBAC in{" "}
+            <code>infrastructure/headlamp/token-minter-rbac.yaml</code> hasn&apos;t been applied.
+          </p>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/app/api/admin/headlamp/token/route.ts
+++ b/src/app/api/admin/headlamp/token/route.ts
@@ -1,0 +1,64 @@
+/**
+ * POST /api/admin/headlamp/token — mint a short-lived (24h) k8s
+ * ServiceAccount JWT for the `headlamp-admin` SA, so the admin can paste
+ * it into the Headlamp login page at https://manage.cloudless.gr.
+ *
+ * Auth: requireAdmin (D1 session cookie or Bearer). RBAC on the k8s side:
+ * infrastructure/headlamp/token-minter-rbac.yaml grants the cloudless
+ * pod's default SA `create` on `serviceaccounts/token` for headlamp-admin
+ * ONLY (no other SA, no other verb).
+ *
+ * Response: { token, expirationTimestamp }.
+ */
+import { NextRequest, NextResponse } from "next/server";
+import { requireAdmin } from "@/lib/api-auth";
+import { isInCluster, k8sPost } from "@/lib/k8s-cluster";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+interface TokenRequestStatus {
+  status?: { token?: string; expirationTimestamp?: string };
+}
+
+export async function POST(request: NextRequest) {
+  const auth = await requireAdmin(request);
+  if (!auth.ok) return auth.response;
+
+  if (!isInCluster()) {
+    return NextResponse.json(
+      { error: "Not running inside the cluster (dev / local). Token minting only works in-pod." },
+      { status: 503 }
+    );
+  }
+
+  const result = await k8sPost<unknown, TokenRequestStatus>(
+    "/api/v1/namespaces/headlamp/serviceaccounts/headlamp-admin/token",
+    {
+      apiVersion: "authentication.k8s.io/v1",
+      kind: "TokenRequest",
+      spec: {
+        expirationSeconds: 86400, // 24h — max reasonable for a browser session
+        audiences: [], // default to apiserver audience so Headlamp accepts it
+      },
+    }
+  );
+
+  if (!result.ok) {
+    return NextResponse.json(
+      { error: `TokenRequest failed (${result.status}): ${result.error}` },
+      { status: result.status === 501 ? 501 : 502 }
+    );
+  }
+
+  const token = result.data.status?.token;
+  const expiresAt = result.data.status?.expirationTimestamp;
+  if (!token) {
+    return NextResponse.json(
+      { error: "TokenRequest returned no token" },
+      { status: 502 }
+    );
+  }
+
+  return NextResponse.json({ token, expirationTimestamp: expiresAt });
+}

--- a/src/lib/k8s-cluster.ts
+++ b/src/lib/k8s-cluster.ts
@@ -83,6 +83,42 @@ async function k8sGet<T = unknown>(path: string): Promise<T | null> {
   }
 }
 
+/**
+ * Authenticated POST against the in-cluster API server. Returns
+ * `{ ok: true, data }` on success or `{ ok: false, status, error }` on any
+ * non-2xx / network error — POST callers usually want the specific error to
+ * surface (unlike the graceful-degrade GET). Timeout 10s.
+ */
+export async function k8sPost<TReq = unknown, TRes = unknown>(
+  path: string,
+  body: TReq
+): Promise<{ ok: true; data: TRes } | { ok: false; status: number; error: string }> {
+  if (!isInCluster()) {
+    return { ok: false, status: 501, error: "not running in a k8s pod" };
+  }
+  try {
+    const init: RequestInit = {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${getToken()}`,
+        "Content-Type": "application/json",
+        Accept: "application/json",
+      },
+      body: JSON.stringify(body),
+      dispatcher: getAgent(),
+      signal: AbortSignal.timeout(10000),
+    };
+    const res = await undiciFetch(`${API_BASE}${path}`, init);
+    const text = await res.text();
+    if (!res.ok) {
+      return { ok: false, status: res.status, error: text.slice(0, 400) };
+    }
+    return { ok: true, data: JSON.parse(text) as TRes };
+  } catch (e) {
+    return { ok: false, status: 502, error: e instanceof Error ? e.message : String(e) };
+  }
+}
+
 // ---------------------------------------------------------------------------
 // Domain types — minimal projection of what /admin/cluster surfaces
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
One button in the admin dashboard mints a 24h k8s SA JWT + copies it + opens Headlamp — Ctrl+V once and you're in.

**Verified live:** RBAC is applied; impersonated `kubectl create token headlamp-admin --as system:serviceaccount:cloudless:default` returned a valid JWT. The API + page will work as soon as this deploys (`deploy-pi` will rebuild + roll the Pi's Next.js standalone).

**Access model:** requireAdmin gates the API; RBAC is narrow (`resourceNames: ['headlamp-admin']`, verb `create` only). Impossible for the app pod to mint tokens for any other SA.

Behind CF Access on `manage.cloudless.gr`, this closes the last friction point on the Headlamp workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)