### PR TITLE
infra(app): startupProbe + preStop + grace-period + PDB

### DIFF
--- a/k8s/cloudless-app-hostpath.yaml
+++ b/k8s/cloudless-app-hostpath.yaml
@@ -80,20 +80,41 @@ spec:
         volumeMounts:
         - name: standalone
           mountPath: /app
+        # startupProbe defers liveness until Next.js has answered /api/health
+        # once. 30 × 5s = 2.5 min budget — comfortable for a cold Node.js
+        # container on the Pi. Prevents the liveness probe from restarting
+        # the pod mid-startup on a slow boot.
+        startupProbe:
+          httpGet:
+            path: /api/health
+            port: 3000
+          periodSeconds: 5
+          failureThreshold: 30
+          timeoutSeconds: 5
+        # Readiness fails after 30s (3 × 10s) — was 60s (6 × 10s). Faster
+        # signal to the Service; startupProbe absorbs cold-start slow paths
+        # so this can be tighter without false negatives.
         readinessProbe:
           httpGet:
             path: /api/health
             port: 3000
-          initialDelaySeconds: 10
           periodSeconds: 10
-          failureThreshold: 6
+          failureThreshold: 3
+          timeoutSeconds: 5
         livenessProbe:
           httpGet:
             path: /api/health
             port: 3000
-          initialDelaySeconds: 30
           periodSeconds: 30
           failureThreshold: 3
+          timeoutSeconds: 5
+        # Give Kubernetes a beat to remove this pod's IP from the Service
+        # endpoints before the process starts exiting — otherwise in-flight
+        # requests during a rolling restart hit a closing socket.
+        lifecycle:
+          preStop:
+            exec:
+              command: ["/bin/sh", "-c", "sleep 5"]
         resources:
           requests:
             cpu: 100m
@@ -101,11 +122,30 @@ spec:
           limits:
             cpu: '1'
             memory: 768Mi
+      # 30s grace budget: 5s preStop + up to 25s for in-flight requests /
+      # DB connection cleanup. Next.js signal-handles SIGTERM correctly.
+      terminationGracePeriodSeconds: 30
       volumes:
       - name: standalone
         hostPath:
           path: /home/tbaltzakis/cloudless-standalone
           type: DirectoryOrCreate
+---
+# Block voluntary evictions (drain, node-upgrade, priority-preemption) from
+# ever taking the sole cloudless-app replica down without warning. On this
+# single-node cluster it's mostly documentation of intent, but if we ever
+# add a second node, PDB is the seatbelt that stops a rolling drain from
+# leaving the site unreachable.
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: cloudless-app
+  namespace: cloudless
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app: cloudless-app
 ---
 apiVersion: v1
 kind: Service


### PR DESCRIPTION
Four low-risk hardening additions to the cloudless-app Next.js pod:

- **startupProbe** (2.5 min budget) — prevents livenessProbe from killing the pod during a slow cold-start
- **preStop `sleep 5` + terminationGracePeriodSeconds:30** — clean rolling-restart, no dropped in-flight requests
- **Readiness failureThreshold 6→3** — 60s→30s to mark unhealthy (startupProbe absorbs the cold-start tolerance)
- **PodDisruptionBudget minAvailable:1** — blocks voluntary evictions from taking the sole replica down

No resource-limit changes, no strategy changes (`Recreate` stays — correct for hostPath).

Rolls out with the next deploy-pi run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)