### PR TITLE
Sync GSC + Sentry secrets workflow → Pi

### DIFF
--- a/.github/workflows/sync-gsc-sentry-pi-secrets.yml
+++ b/.github/workflows/sync-gsc-sentry-pi-secrets.yml
@@ -1,0 +1,122 @@
+name: Sync GSC + Sentry secrets → Pi cloudless-secrets
+
+# Patches k8s Secret cloudless-secrets (namespace cloudless) from GitHub
+# repo secrets, then restarts cloudless-app. cloudless2 is only a proxy —
+# app secrets must live on the Pi pod.
+#
+# Required repo secrets:
+#   GOOGLE_CLIENT_EMAIL, GOOGLE_PRIVATE_KEY, GOOGLE_CALENDAR_ID, GSC_SITE_URL
+#   SENTRY_AUTH_TOKEN, SENTRY_ORG, SENTRY_PROJECT
+#   KUBECONFIG_B64, TS_CLIENT_ID, TS_CLIENT_SECRET
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+
+concurrency:
+  group: sync-gsc-sentry-pi-secrets
+  cancel-in-progress: false
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    env:
+      GH_TOKEN: ${{ github.token }}
+    steps:
+    - name: Connect to tailnet
+      uses: tailscale/github-action@0263d9e6d793eaefcf1de98ff7fde47abe6664d3
+      with:
+        oauth-client-id: ${{ secrets.TS_CLIENT_ID }}
+        oauth-secret: ${{ secrets.TS_CLIENT_SECRET }}
+
+    - name: Configure kubectl
+      run: |
+        mkdir -p ~/.kube
+        echo "${{ secrets.KUBECONFIG_B64 }}" | base64 -d > ~/.kube/config
+        chmod 600 ~/.kube/config
+        kubectl cluster-info
+
+    - name: Patch cloudless-secrets (merge keys only)
+      env:
+        GOOGLE_CLIENT_EMAIL: ${{ secrets.GOOGLE_CLIENT_EMAIL }}
+        GOOGLE_PRIVATE_KEY: ${{ secrets.GOOGLE_PRIVATE_KEY }}
+        GOOGLE_CALENDAR_ID: ${{ secrets.GOOGLE_CALENDAR_ID }}
+        GSC_SITE_URL: ${{ secrets.GSC_SITE_URL }}
+        SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+        SENTRY_ORG: ${{ secrets.SENTRY_ORG }}
+        SENTRY_PROJECT: ${{ secrets.SENTRY_PROJECT }}
+      run: |
+        set -euo pipefail
+        for name in GOOGLE_CLIENT_EMAIL GOOGLE_PRIVATE_KEY GOOGLE_CALENDAR_ID GSC_SITE_URL SENTRY_AUTH_TOKEN; do
+          if [ -z "${!name}" ]; then
+            echo "::error::$name GitHub secret is empty"
+            exit 1
+          fi
+          echo "::add-mask::${!name}"
+        done
+        : "${SENTRY_ORG:=baltzakisthemiscom}"
+        : "${SENTRY_PROJECT:=cloudless-gr}"
+        : "${GSC_SITE_URL:=sc-domain:cloudless.gr}"
+
+        PATCH=$(python3 -c '
+        import json, os, base64
+        keys = [
+          "GOOGLE_CLIENT_EMAIL",
+          "GOOGLE_PRIVATE_KEY",
+          "GOOGLE_CALENDAR_ID",
+          "GSC_SITE_URL",
+          "SENTRY_AUTH_TOKEN",
+          "SENTRY_ORG",
+          "SENTRY_PROJECT",
+        ]
+        data = {}
+        for k in keys:
+          v = os.environ.get(k) or ""
+          if not v:
+            raise SystemExit(f"missing {k}")
+          data[k] = base64.b64encode(v.encode()).decode()
+        print(json.dumps({"data": data}))
+        ')
+
+        kubectl -n cloudless patch secret cloudless-secrets --type merge -p "$PATCH"
+        echo "Patched keys: GOOGLE_CLIENT_EMAIL GOOGLE_PRIVATE_KEY GOOGLE_CALENDAR_ID GSC_SITE_URL SENTRY_AUTH_TOKEN SENTRY_ORG SENTRY_PROJECT"
+
+    - name: Restart cloudless-app
+      run: |
+        kubectl -n cloudless rollout restart deploy/cloudless-app
+        kubectl -n cloudless rollout status deploy/cloudless-app --timeout=180s
+
+    - name: Verify key presence (names only)
+      run: |
+        kubectl -n cloudless get secret cloudless-secrets -o json \
+          | python3 -c '
+        import json,sys
+        keys=set(json.load(sys.stdin).get("data",{}))
+        need=["GOOGLE_CLIENT_EMAIL","GOOGLE_PRIVATE_KEY","GOOGLE_CALENDAR_ID","GSC_SITE_URL","SENTRY_AUTH_TOKEN","SENTRY_ORG","SENTRY_PROJECT"]
+        missing=[k for k in need if k not in keys]
+        print("present:", ", ".join(k for k in need if k in keys))
+        if missing:
+          print("MISSING:", ", ".join(missing))
+          raise SystemExit(1)
+        print("all required keys present")
+        '
+
+    - name: Comment tracking issue
+      if: always()
+      run: |
+        {
+          echo "# GSC + Sentry → Pi secrets — $(date -u '+%F %T')Z"
+          echo ""
+          echo "**Job:** ${{ job.status }}"
+          echo "**Target:** cloudless/cloudless-secrets → restart cloudless-app"
+          echo ""
+          echo "cloudless2 remains a proxy only; secrets live on the Pi pod."
+        } > c.md
+        gh issue comment 382 --repo "${{ github.repository }}" --body-file c.md || true


### PR DESCRIPTION
## Summary
- Adds `workflow_dispatch` job that patches `cloudless/cloudless-secrets` with GSC + Sentry keys from repo secrets and restarts `cloudless-app`.
- Needed so production analytics/ops routes stop 503ing; `cloudless2` is proxy-only.

## Test plan
- [ ] After merge: `gh workflow run sync-gsc-sentry-pi-secrets.yml`
- [ ] Confirm Pi secret has GOOGLE_* / GSC_* / SENTRY_* key names
- [ ] `/api/admin/analytics/*` and `/api/admin/ops/errors` no longer 503 for missing config


Made with [Cursor](https://cursor.com)