### PR TITLE
Run GSC/Sentry Pi sync on omv self-hosted

### DIFF
--- a/.github/workflows/sync-gsc-sentry-pi-secrets.yml
+++ b/.github/workflows/sync-gsc-sentry-pi-secrets.yml
@@ -1,13 +1,12 @@
 name: Sync GSC + Sentry secrets → Pi cloudless-secrets
 
 # Patches k8s Secret cloudless-secrets (namespace cloudless) from GitHub
-# repo secrets, then restarts cloudless-app. cloudless2 is only a proxy —
-# app secrets must live on the Pi pod.
+# repo secrets, then restarts cloudless-app. Runs on the omv self-hosted
+# runner so kubectl talks to local k3s — no Tailscale OAuth required.
 #
 # Required repo secrets:
 #   GOOGLE_CLIENT_EMAIL, GOOGLE_PRIVATE_KEY, GOOGLE_CALENDAR_ID, GSC_SITE_URL
 #   SENTRY_AUTH_TOKEN, SENTRY_ORG, SENTRY_PROJECT
-#   KUBECONFIG_B64, TS_CLIENT_ID, TS_CLIENT_SECRET
 
 on:
   workflow_dispatch:
@@ -25,24 +24,11 @@ env:
 
 jobs:
   sync:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, omv, pi]
     timeout-minutes: 15
     env:
       GH_TOKEN: ${{ github.token }}
     steps:
-    - name: Connect to tailnet
-      uses: tailscale/github-action@0263d9e6d793eaefcf1de98ff7fde47abe6664d3
-      with:
-        oauth-client-id: ${{ secrets.TS_CLIENT_ID }}
-        oauth-secret: ${{ secrets.TS_CLIENT_SECRET }}
-
-    - name: Configure kubectl
-      run: |
-        mkdir -p ~/.kube
-        echo "${{ secrets.KUBECONFIG_B64 }}" | base64 -d > ~/.kube/config
-        chmod 600 ~/.kube/config
-        kubectl cluster-info
-
     - name: Patch cloudless-secrets (merge keys only)
       env:
         GOOGLE_CLIENT_EMAIL: ${{ secrets.GOOGLE_CLIENT_EMAIL }}
@@ -54,6 +40,7 @@ jobs:
         SENTRY_PROJECT: ${{ secrets.SENTRY_PROJECT }}
       run: |
         set -euo pipefail
+        KUBECTL="sudo k3s kubectl"
         for name in GOOGLE_CLIENT_EMAIL GOOGLE_PRIVATE_KEY GOOGLE_CALENDAR_ID GSC_SITE_URL SENTRY_AUTH_TOKEN; do
           if [ -z "${!name}" ]; then
             echo "::error::$name GitHub secret is empty"
@@ -85,17 +72,17 @@ jobs:
         print(json.dumps({"data": data}))
         ')
 
-        kubectl -n cloudless patch secret cloudless-secrets --type merge -p "$PATCH"
+        $KUBECTL -n cloudless patch secret cloudless-secrets --type merge -p "$PATCH"
         echo "Patched keys: GOOGLE_CLIENT_EMAIL GOOGLE_PRIVATE_KEY GOOGLE_CALENDAR_ID GSC_SITE_URL SENTRY_AUTH_TOKEN SENTRY_ORG SENTRY_PROJECT"
 
     - name: Restart cloudless-app
       run: |
-        kubectl -n cloudless rollout restart deploy/cloudless-app
-        kubectl -n cloudless rollout status deploy/cloudless-app --timeout=180s
+        sudo k3s kubectl -n cloudless rollout restart deploy/cloudless-app
+        sudo k3s kubectl -n cloudless rollout status deploy/cloudless-app --timeout=180s
 
     - name: Verify key presence (names only)
       run: |
-        kubectl -n cloudless get secret cloudless-secrets -o json \
+        sudo k3s kubectl -n cloudless get secret cloudless-secrets -o json \
           | python3 -c '
         import json,sys
         keys=set(json.load(sys.stdin).get("data",{}))
@@ -115,6 +102,7 @@ jobs:
           echo "# GSC + Sentry → Pi secrets — $(date -u '+%F %T')Z"
           echo ""
           echo "**Job:** ${{ job.status }}"
+          echo "**Runner:** self-hosted omv (local k3s)"
           echo "**Target:** cloudless/cloudless-secrets → restart cloudless-app"
           echo ""
           echo "cloudless2 remains a proxy only; secrets live on the Pi pod."


### PR DESCRIPTION
## Summary
- Previous dispatch failed: Tailscale OAuth secrets empty on GH-hosted runners.
- Switch sync job to `[self-hosted, omv, pi]` and `sudo k3s kubectl`.

## Test plan
- [ ] `gh workflow run sync-gsc-sentry-pi-secrets.yml`
- [ ] Pi secret contains GOOGLE_* / GSC_* / SENTRY_* keys

Made with [Cursor](https://cursor.com)