### PR TITLE
Reject placeholder Google secrets for GSC auth

### DIFF
--- a/.github/workflows/sync-gsc-sentry-pi-secrets.yml
+++ b/.github/workflows/sync-gsc-sentry-pi-secrets.yml
@@ -53,7 +53,7 @@ jobs:
         : "${GSC_SITE_URL:=sc-domain:cloudless.gr}"
 
         PATCH=$(python3 -c '
-        import json, os, base64
+        import json, os, base64, re
         keys = [
           "GOOGLE_CLIENT_EMAIL",
           "GOOGLE_PRIVATE_KEY",
@@ -63,11 +63,22 @@ jobs:
           "SENTRY_ORG",
           "SENTRY_PROJECT",
         ]
+        placeholder = re.compile(r"^(your[_-]?value|your[_-]?service|changeme|todo|xxx|placeholder)", re.I)
         data = {}
         for k in keys:
-          v = os.environ.get(k) or ""
+          v = (os.environ.get(k) or "").strip()
           if not v:
             raise SystemExit(f"missing {k}")
+          if placeholder.match(v):
+            raise SystemExit(f"{k} looks like a placeholder (starts with your_/changeme/…); refuse to sync")
+          if k == "GOOGLE_PRIVATE_KEY":
+            # Accept PEM with real or escaped newlines
+            pem = v.replace("\\n", "\n")
+            if "BEGIN" not in pem or len(pem) < 200:
+              raise SystemExit("GOOGLE_PRIVATE_KEY must be a PEM private key (BEGIN…, length>=200)")
+            v = pem
+          if k == "GSC_SITE_URL" and not (v.startswith("sc-domain:") or v.startswith("https://")):
+            raise SystemExit("GSC_SITE_URL must be sc-domain:… or https://…")
           data[k] = base64.b64encode(v.encode()).decode()
         print(json.dumps({"data": data}))
         ')

--- a/scripts/sync-gsc-sentry-to-pi.sh
+++ b/scripts/sync-gsc-sentry-to-pi.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+# Patch k8s cloudless-secrets on omv with GSC + Sentry keys, then restart cloudless-app.
+# cloudless2 is proxy-only — secrets must live on the Pi pod.
+#
+# Usage (operator machine; do NOT commit secret values):
+#   set -a
+#   # load only the needed keys from your local env file yourself, e.g.:
+#   #   source <(grep -E '^(GOOGLE_|GSC_|SENTRY_)' .env.local)
+#   set +a
+#   bash scripts/sync-gsc-sentry-to-pi.sh
+#
+# Or after this workflow lands on main:
+#   gh workflow run sync-gsc-sentry-pi-secrets.yml
+
+set -euo pipefail
+
+SSH_HOST="${SSH_HOST:-omv}"
+NS=cloudless
+SECRET=cloudless-secrets
+
+need=(
+  GOOGLE_CLIENT_EMAIL
+  GOOGLE_PRIVATE_KEY
+  GOOGLE_CALENDAR_ID
+  GSC_SITE_URL
+  SENTRY_AUTH_TOKEN
+)
+for k in "${need[@]}"; do
+  if [[ -z "${!k:-}" ]]; then
+    echo "missing env: $k" >&2
+    exit 1
+  fi
+done
+
+: "${SENTRY_ORG:=baltzakisthemiscom}"
+: "${SENTRY_PROJECT:=cloudless-gr}"
+
+export GOOGLE_CLIENT_EMAIL GOOGLE_PRIVATE_KEY GOOGLE_CALENDAR_ID GSC_SITE_URL
+export SENTRY_AUTH_TOKEN SENTRY_ORG SENTRY_PROJECT
+
+PATCH=$(python3 -c '
+import json, os, base64, re
+keys = [
+  "GOOGLE_CLIENT_EMAIL",
+  "GOOGLE_PRIVATE_KEY",
+  "GOOGLE_CALENDAR_ID",
+  "GSC_SITE_URL",
+  "SENTRY_AUTH_TOKEN",
+  "SENTRY_ORG",
+  "SENTRY_PROJECT",
+]
+placeholder = re.compile(r"^(your[_-]?value|your[_-]?service|changeme|todo|xxx|placeholder)", re.I)
+data = {}
+for k in keys:
+  v = (os.environ.get(k) or "").strip()
+  if not v:
+    raise SystemExit(f"missing {k}")
+  if placeholder.match(v):
+    raise SystemExit(f"{k} looks like a placeholder; refuse to sync")
+  if k == "GOOGLE_PRIVATE_KEY":
+    pem = v.replace("\\n", "\n")
+    if "BEGIN" not in pem or len(pem) < 200:
+      raise SystemExit("GOOGLE_PRIVATE_KEY must be a PEM private key (BEGIN…, length>=200)")
+    v = pem
+  data[k] = base64.b64encode(v.encode()).decode()
+print(json.dumps({"data": data}))
+')
+
+echo "Patching $NS/$SECRET on $SSH_HOST (key names only)…"
+ssh "$SSH_HOST" "sudo k3s kubectl -n $NS patch secret $SECRET --type merge -p '$PATCH'"
+ssh "$SSH_HOST" "sudo k3s kubectl -n $NS rollout restart deploy/cloudless-app"
+ssh "$SSH_HOST" "sudo k3s kubectl -n $NS rollout status deploy/cloudless-app --timeout=180s"
+
+echo "Verify key presence:"
+ssh "$SSH_HOST" "sudo k3s kubectl -n $NS get secret $SECRET -o json" | python3 -c '
+import json,sys
+keys=set(json.load(sys.stdin).get("data",{}))
+need=["GOOGLE_CLIENT_EMAIL","GOOGLE_PRIVATE_KEY","GOOGLE_CALENDAR_ID","GSC_SITE_URL","SENTRY_AUTH_TOKEN","SENTRY_ORG","SENTRY_PROJECT"]
+print("present:", ", ".join(k for k in need if k in keys))
+missing=[k for k in need if k not in keys]
+if missing:
+  raise SystemExit("MISSING: "+", ".join(missing))
+print("ok")
+'

--- a/src/lib/google-auth.ts
+++ b/src/lib/google-auth.ts
@@ -20,9 +20,19 @@ export function createGoogleAuth(scope: string): () => Promise<string> {
     if (cached && Date.now() < cached.expires) return cached.token;
 
     const config = await getConfig();
-    const email = config.GOOGLE_CLIENT_EMAIL;
-    const key = config.GOOGLE_PRIVATE_KEY;
+    const email = config.GOOGLE_CLIENT_EMAIL?.trim();
+    let key = config.GOOGLE_PRIVATE_KEY?.trim() ?? "";
     if (!email || !key) throw new Error("Google service account not configured");
+    // Refuse placeholder / truncated secrets that otherwise produce opaque jose errors.
+    if (/^(your[_-]?value|your[_-]?service|changeme|todo|xxx|placeholder)/i.test(key) || key.length < 200) {
+      throw new Error(
+        "Google service account private key is missing or a placeholder — set GOOGLE_PRIVATE_KEY (PEM) on the Pi cloudless-secrets"
+      );
+    }
+    key = key.replace(/\\n/g, "\n");
+    if (!key.includes("BEGIN")) {
+      throw new Error("GOOGLE_PRIVATE_KEY must be a PEM private key (-----BEGIN PRIVATE KEY-----)");
+    }
 
     const { SignJWT, importPKCS8 } = await import("jose");
     const now = Math.floor(Date.now() / 1000);


### PR DESCRIPTION
## Summary
- Sync workflow/script refuses placeholder `GOOGLE_PRIVATE_KEY` (and similar stubs).
- `google-auth` fails closed with a clear message instead of opaque jose errors.
- Also corrected GH secrets `GOOGLE_CALENDAR_ID=primary` and `GSC_SITE_URL=sc-domain:cloudless.gr`.

## Blocker remaining
`GOOGLE_PRIVATE_KEY` GitHub secret is still `your_value_*` — operator must set the real PEM, then re-run `sync-gsc-sentry-pi-secrets.yml`.

## Test plan
- [ ] Set real `GOOGLE_PRIVATE_KEY` in repo secrets
- [ ] `gh workflow run sync-gsc-sentry-pi-secrets.yml`
- [ ] Logged-in admin SEO analytics returns 200 (not 503)

Made with [Cursor](https://cursor.com)