### PR TITLE
Resilient deploy-pi: omv build + omv-ha rollout proxy

### DIFF
--- a/.github/scripts/register-deploy-runner.sh
+++ b/.github/scripts/register-deploy-runner.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+# Register a GitHub Actions runner on omv-ha with labels for deploy-pi rollout.
+#
+# Usage (on omv-ha):
+#   ./register-deploy-runner.sh <REG_TOKEN> [RUNNER_NAME]
+#
+# Get REG_TOKEN:
+#   gh api -X POST repos/Themis128/cloudless.gr/actions/runners/registration-token --jq .token
+#
+# Labels: omv-ha,deploy  (self-hosted/Linux/ARM64 added automatically)
+# Install dir: ~/actions-runner-deploy  (separate from ~/actions-runner-build)
+set -euo pipefail
+
+REG_TOKEN="${1:?registration token required}"
+RUNNER_NAME="${2:-omv-ha-deploy}"
+REPO_URL="https://github.com/Themis128/cloudless.gr"
+RUNNER_VERSION="2.334.0"
+LABELS="omv-ha,deploy"
+WORK_DIR="$HOME/actions-runner-deploy"
+
+ARCH="$(uname -m)"
+case "$ARCH" in
+  aarch64|arm64) PKG_ARCH="arm64" ;;
+  x86_64)        PKG_ARCH="x64" ;;
+  *) echo "Unsupported arch: $ARCH" >&2; exit 1 ;;
+esac
+
+echo "==> Installing runner '${RUNNER_NAME}' in ${WORK_DIR} (labels: ${LABELS})"
+mkdir -p "${WORK_DIR}"
+cd "${WORK_DIR}"
+
+if [[ ! -f ./config.sh ]]; then
+  PKG="actions-runner-linux-${PKG_ARCH}-${RUNNER_VERSION}.tar.gz"
+  echo "==> Downloading ${PKG}"
+  curl -fsSL -o "${PKG}" \
+    "https://github.com/actions/runner/releases/download/v${RUNNER_VERSION}/${PKG}"
+  tar xzf "${PKG}"
+  rm -f "${PKG}"
+fi
+
+./config.sh \
+  --url "${REPO_URL}" \
+  --token "${REG_TOKEN}" \
+  --name "${RUNNER_NAME}" \
+  --labels "${LABELS}" \
+  --work _work \
+  --unattended \
+  --replace
+
+sudo ./svc.sh install "${USER}"
+sudo ./svc.sh start
+
+echo
+echo "==> Done. Verify with:"
+echo "    sudo ./svc.sh status"
+echo "    gh api repos/Themis128/cloudless.gr/actions/runners \\"
+echo "      --jq '.runners[] | {name, status, labels: [.labels[].name]}'"
+echo
+echo "==> SSH to omv for rollout (required):"
+echo "    ssh -i ~/.ssh/omv_ha tbaltzakis@192.168.1.128 hostname"

--- a/.github/workflows/deploy-pi.yml
+++ b/.github/workflows/deploy-pi.yml
@@ -1,20 +1,16 @@
 name: Deploy to Pi (hostPath standalone — no ECR)
 
-# Cloudflare-first: build Next standalone on the Pi runner and sync into
-# /home/tbaltzakis/cloudless-standalone (k8s/cloudless-app-hostpath.yaml).
-# Does not use AWS ECR, OIDC, or SSM.
+# Cloudflare-first: build Next standalone on omv (Pi 5), upload artifact, then
+# roll out from omv-ha (deploy proxy) via rsync + kubectl over SSH/Tailscale.
+# Survives omv power-cycles mid-deploy: a finished build lives in GH Artifacts
+# and rollout can complete once omv is back.
 #
-# Runner: exclusive [self-hosted, omv, build]. Do not put audits/CWV/ETL on
-# the `build` label — they starve this workflow (see docs/runners.md).
+# Jobs:
+#   build   — [self-hosted, omv, build]   (heavy compile; do NOT put on omv-ha)
+#   rollout — [self-hosted, omv-ha, deploy] (rsync SafeDeploy + kubectl)
 #
 # Concurrency: deploy the LATEST main SHA only. cancel-in-progress: true so a
-# newer push supersedes an older in-progress/queued build instead of stacking a
-# long serial queue behind it (every push otherwise builds in sequence, ~15min
-# each). Cancelling mid-build is safe: "Sync standalone → hostPath" runs only
-# after a successful build, so a cancelled build never touches hostPath and the
-# previously deployed SHA stays live.
-#
-# Caching: pnpm store + Next.js build cache on OMV-HA runner for speed.
+# newer push supersedes an older in-progress/queued run.
 
 on:
   push:
@@ -27,16 +23,19 @@ on:
     - pnpm-workspace.yaml
     - next.config.ts
     - patches/**
+    - scripts/pi-rollout-from-artifact.sh
     - .github/workflows/deploy-pi.yml
   workflow_dispatch:
+    inputs:
+      rollout_only:
+        description: Skip build; re-rollout using the standalone artifact for this SHA (must already exist)
+        type: boolean
+        default: false
 
 permissions:
   contents: read
+  actions: write
 
-# Deploy latest-only: a newer push cancels older in-progress/queued runs in
-# this group so builds don't pile up in a long serial queue. Safe to cancel
-# mid-build — the hostPath sync only runs after a successful build, so the live
-# SHA is never left partial (see the header note above).
 concurrency:
   group: deploy-pi
   cancel-in-progress: true
@@ -46,14 +45,18 @@ env:
   K3S_NAMESPACE: cloudless
   K3S_DEPLOYMENT: cloudless-app
   STANDALONE_HOSTPATH: /home/tbaltzakis/cloudless-standalone
-  # Cache paths on self-hosted runner (OMV-HA) - pnpm store only
   PNPM_STORE_PATH: /home/tbaltzakis/.pnpm-store
+  OMV_SSH_HOST: 192.168.1.128
 
 jobs:
-  build-and-rollout:
-    name: Build standalone + roll out hostPath
+  build:
+    name: Build standalone artifact
     runs-on: [self-hosted, omv, build]
     timeout-minutes: 60
+    if: ${{ !(github.event_name == 'workflow_dispatch' && inputs.rollout_only) }}
+    outputs:
+      already: ${{ steps.skip.outputs.already }}
+      artifact: ${{ steps.pack.outputs.artifact }}
 
     steps:
     - name: Checkout
@@ -99,15 +102,6 @@ jobs:
         mkdir -p "${PNPM_STORE_PATH}"
         pnpm config set store-dir "${PNPM_STORE_PATH}"
 
-    # Preserve `.next/cache/` between runs — it holds the Turbopack persistent
-    # build cache (enabled 2026-08-09 via next.config.ts
-    # `experimental.turbopackFileSystemCacheForBuild: true`, Next.js 16.3+).
-    # Once warm this cuts the `next build` step roughly in half on the Pi 5.
-    # Stale build ARTIFACTS (`server/`, `static/`, `standalone/`, etc.) are
-    # still purged — Turbopack's file-level dependency tracker invalidates
-    # cache entries whose source files changed, so keeping the cache does
-    # NOT resurrect old `proxy.ts` config (the original reason this step
-    # used to `rm -rf .next` wholesale).
     - name: Clean stale build output (keep cache)
       if: steps.skip.outputs.already != 'true'
       run: |
@@ -116,10 +110,8 @@ jobs:
           echo "No prior .next/ — clean workspace"
           exit 0
         fi
-        # size of the cache we're preserving (informational only)
         cache_size=$(du -sh .next/cache 2>/dev/null | cut -f1 || echo "0")
         echo "Preserving .next/cache/ (size: ${cache_size})"
-        # remove everything else — keep only .next/cache/
         find .next -mindepth 1 -maxdepth 1 -not -name cache -exec rm -rf {} +
         echo "Cleaned .next/ (kept cache):"
         ls -la .next
@@ -145,15 +137,18 @@ jobs:
         NEXT_PUBLIC_APP_VERSION: ${{ github.sha }}
         NEXT_PUBLIC_GOOGLE_SITE_VERIFICATION: LXkyzmWrAYuY1C6XD6TKaqA31KB72xbUlkimE0vKI8w
       run: pnpm build
+
     - name: Install Syft for SBOM generation
       if: steps.skip.outputs.already != 'true'
       run: |
         curl -sSfL https://raw.githubusercontent.com/anchore/syft/main/install.sh | sh -s -- -b /usr/local/bin
+
     - name: Generate SBOM
       if: steps.skip.outputs.already != 'true'
       run: |
         syft packages:pnpm-lock.yaml -o syft-json > sbom.json
         syft . -o syft-json >> sbom.json
+
     - name: Upload SBOM artifact
       if: steps.skip.outputs.already != 'true'
       uses: actions/upload-artifact@v4
@@ -161,10 +156,12 @@ jobs:
         name: sbom
         path: sbom.json
         retention-days: 30
+
     - name: Scan licenses with pnpm licenses
       if: steps.skip.outputs.already != 'true'
       run: |
         pnpm licenses ls --json > licenses.json
+
     - name: Upload licenses artifact
       if: steps.skip.outputs.already != 'true'
       uses: actions/upload-artifact@v4
@@ -173,169 +170,142 @@ jobs:
         path: licenses.json
         retention-days: 30
 
-    - name: Sync standalone → releases/ + flip symlink
-      # Atomic-symlink deploy. Writes the new bundle into a per-SHA release
-      # dir, then flips /home/tbaltzakis/cloudless-standalone (a symlink)
-      # to point at it — instant, reversible via scripts/rollback.sh.
-      # Old releases are kept (last 5) so any of them can be re-selected.
+    - name: Pack standalone artifact
+      id: pack
       if: steps.skip.outputs.already != 'true'
       run: |
         set -euo pipefail
-        CURRENT="${{ env.STANDALONE_HOSTPATH }}"           # the symlink k8s mounts
-        RELEASES="$(dirname "$CURRENT")/cloudless-releases"
-        SHA="${GITHUB_SHA::12}"
-        NEW_REL="$RELEASES/$SHA"
-        STAGE="$CURRENT.next-$SHA"                          # local build staging (rsync-safe on same fs)
         SRC=".next/standalone"
-
         if [ ! -f "${SRC}/server.js" ]; then
-          echo "::error::Standalone build output not found at ${SRC}/server.js — 'Build Next.js standalone' step likely failed."
+          echo "::error::Standalone build output not found at ${SRC}/server.js"
           exit 1
         fi
-
-        # 1. Build the release in a staging dir on the same filesystem
-        sudo rm -rf "$STAGE"
-        sudo mkdir -p "$STAGE"
-        sudo rsync -a "$SRC/" "$STAGE/"
-        [ -d .next/static ] && { sudo mkdir -p "$STAGE/.next/static"; sudo rsync -a .next/static/ "$STAGE/.next/static/"; }
-        [ -d public ]       && { sudo mkdir -p "$STAGE/public";       sudo rsync -a public/ "$STAGE/public/"; }
-        [ -f "$STAGE/server.js" ] || { echo "::error::Staging built but $STAGE/server.js missing"; exit 1; }
-
-        # 2. Atomic promote: mv staging → releases/<sha>/ (same fs = atomic rename)
-        sudo mkdir -p "$RELEASES"
-        # If a release with this SHA already exists (retry/duplicate), replace it.
-        sudo rm -rf "$NEW_REL"
-        sudo mv "$STAGE" "$NEW_REL"
-        echo "Prepared release: $NEW_REL ($(sudo du -sh "$NEW_REL" | cut -f1))"
-
-        # 3. Remember the PREVIOUS symlink target for auto-rollback later
-        PREV="$(readlink "$CURRENT" 2>/dev/null || true)"
-        echo "previous_release=${PREV}" >> "$GITHUB_OUTPUT"
-        echo "new_release=cloudless-releases/$SHA"   >> "$GITHUB_OUTPUT"
-
-        # 4. Flip the symlink atomically (ln -sfn is atomic on POSIX)
-        sudo ln -sfn "cloudless-releases/$SHA" "$CURRENT"
-        sudo chown -h tbaltzakis:users "$CURRENT"
-        echo "Symlink now: $CURRENT → $(readlink "$CURRENT")"
-
-        # 5. Prune old releases — keep the newest 5 (mtime order)
-        cd "$RELEASES"
-        ls -1t | tail -n +6 | while read -r old; do
-          # never delete the one we're currently linked to (belt-and-braces)
-          [ "cloudless-releases/$old" = "$(readlink "$CURRENT")" ] && continue
-          echo "  pruning old release: $old"
-          sudo rm -rf "$old"
-        done
-      id: sync
-
-    - name: Resolve kubectl
-      if: steps.skip.outputs.already != 'true'
-      id: kubectl
-      run: |
-        set -euo pipefail
-        # The k3s API server on the control-plane Pi can be briefly unresponsive
-        # right after a build pegs CPU/IO, so probe with retries + a generous
-        # per-attempt timeout instead of failing on a single 5s miss (which
-        # threw away an already-successful build + hostPath sync).
-        BIN=""
-        for attempt in $(seq 1 6); do
-          if command -v kubectl >/dev/null 2>&1 && kubectl get --raw /readyz --request-timeout=15s >/dev/null 2>&1; then
-            BIN="kubectl"; break
-          elif sudo kubectl get --raw /readyz --request-timeout=15s >/dev/null 2>&1; then
-            BIN="sudo kubectl"; break
-          fi
-          echo "kubectl not ready (attempt ${attempt}/6) — waiting 10s…"
-          sleep 10
-        done
-        if [ -z "$BIN" ]; then
-          echo "::error::kubectl cannot reach the cluster after 6 attempts (~2min)"
-          exit 1
+        OUT="${RUNNER_TEMP}/standalone-pack"
+        rm -rf "$OUT"
+        mkdir -p "$OUT/standalone"
+        rsync -a "$SRC/" "$OUT/standalone/"
+        if [ -d .next/static ]; then
+          mkdir -p "$OUT/static"
+          rsync -a .next/static/ "$OUT/static/"
         fi
-        echo "Using: ${BIN}"
-        echo "bin=${BIN}" >> "$GITHUB_OUTPUT"
+        if [ -d public ]; then
+          mkdir -p "$OUT/public"
+          rsync -a public/ "$OUT/public/"
+        fi
+        echo "Packed $(du -sh "$OUT" | cut -f1) → $OUT"
+        echo "artifact=$OUT" >> "$GITHUB_OUTPUT"
 
-    - name: Roll out cloudless-app
+    - name: Upload standalone artifact
       if: steps.skip.outputs.already != 'true'
+      uses: actions/upload-artifact@v4
+      with:
+        name: standalone-${{ github.sha }}
+        path: ${{ steps.pack.outputs.artifact }}
+        retention-days: 2
+        if-no-files-found: error
+
+  rollout:
+    name: Roll out via omv-ha proxy
+    needs: [build]
+    # Run when build finished and did not skip; OR when rollout_only dispatch
+    # (build job is skipped entirely — needs succeeds with skipped build only
+    # if we use if: always() carefully). For rollout_only, build is skipped
+    # via job-level if, and needs: build would fail — use:
+    if: |
+      always() && (
+        (needs.build.result == 'success' && needs.build.outputs.already != 'true') ||
+        (github.event_name == 'workflow_dispatch' && inputs.rollout_only && needs.build.result == 'skipped')
+      )
+    runs-on: [self-hosted, omv-ha, deploy]
+    timeout-minutes: 15
+
+    steps:
+    - name: Checkout (rollout script)
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd         # v4.3.1
+      with:
+        sparse-checkout: |
+          scripts/pi-rollout-from-artifact.sh
+        sparse-checkout-cone-mode: false
+
+    - name: Download standalone artifact (this run)
+      if: needs.build.result == 'success'
+      uses: actions/download-artifact@v4
+      with:
+        name: standalone-${{ github.sha }}
+        path: ${{ runner.temp }}/standalone-artifact
+
+    - name: Download standalone artifact (prior run — rollout_only)
+      if: github.event_name == 'workflow_dispatch' && inputs.rollout_only
       env:
-        KUBECTL: ${{ steps.kubectl.outputs.bin }}
+        GH_TOKEN: ${{ github.token }}
+        WANT_SHA: ${{ github.sha }}
+        ARTIFACT_NAME: standalone-${{ github.sha }}
+        OUT: ${{ runner.temp }}/standalone-artifact
+        REPO: ${{ github.repository }}
       run: |
         set -euo pipefail
-        FULL_SHA="${{ github.sha }}"
-        $KUBECTL set env "deployment/${{ env.K3S_DEPLOYMENT }}" \
-          -n "${{ env.K3S_NAMESPACE }}" \
-          "APP_VERSION=${FULL_SHA}" \
-          "NEXT_PUBLIC_APP_VERSION=${FULL_SHA}" \
-          "NEXT_PUBLIC_AUTH_PROVIDER=d1" \
-          "SSM_DISABLED=1" \
-          "CLOUDFLARE_ACCOUNT_ID=fb7dc7b69b662480cd5961a4d1913c78"
-        $KUBECTL rollout restart "deployment/${{ env.K3S_DEPLOYMENT }}" \
-          -n "${{ env.K3S_NAMESPACE }}"
-        $KUBECTL rollout status "deployment/${{ env.K3S_DEPLOYMENT }}" \
-          -n "${{ env.K3S_NAMESPACE }}" --timeout=600s
-        # Wait for pod to be fully ready and NodePort to propagate
-        sleep 15
-        echo "Checking pod status:"
-        $KUBECTL get pods -n "${{ env.K3S_NAMESPACE }}" -l app=cloudless-app -o wide
-        echo "Checking service endpoints:"
-        $KUBECTL get endpoints -n "${{ env.K3S_NAMESPACE }}" cloudless-app
-        curl -sS --max-time 5 http://127.0.0.1:30300/api/health || true
-        echo
-
-    - name: Verify rollout (auto-rollback on failure)
-      # Health-checks the new release; if unhealthy, atomically flips the
-      # symlink back to the previous release and restarts. This is the
-      # "SafeDeploy" auto-rollback: no bad release stays live.
-      if: steps.skip.outputs.already != 'true'
-      env:
-        KUBECTL: ${{ steps.kubectl.outputs.bin }}
-        PREV_RELEASE: ${{ steps.sync.outputs.previous_release }}
-        CURRENT: ${{ env.STANDALONE_HOSTPATH }}
-      run: |
-        set -euo pipefail
-        sleep 10   # NodePort propagation
-
-        # Try 6 times over ~1 min so a briefly-slow start doesn't trigger rollback
-        HEALTH_OK=0
-        for attempt in 1 2 3 4 5 6; do
-          for candidate in http://127.0.0.1:30300/api/health http://192.168.1.128:30300/api/health; do
-            RESPONSE=$(curl -sS --max-time 10 "$candidate" 2>&1 || true)
-            if echo "$RESPONSE" | jq -e .version >/dev/null 2>&1; then
-              HEALTH_OK=1
-              echo "✅ health OK via $candidate (attempt ${attempt}): $RESPONSE"
-              break 2
-            fi
-          done
-          echo "  health not ready (attempt ${attempt}/6) — waiting 10s…"; sleep 10
-        done
-
-        if [ "$HEALTH_OK" = "1" ]; then
-          echo "Rollout verification successful."
-          exit 0
-        fi
-
-        # ─── AUTO-ROLLBACK ────────────────────────────────────────────────
-        echo "::warning::New release failed health checks — auto-rolling back to previous."
-        if [ -z "$PREV_RELEASE" ]; then
-          echo "::error::No previous release recorded (first-ever deploy?). Cannot auto-rollback."
-          $KUBECTL get pods -n "${{ env.K3S_NAMESPACE }}" -l app=cloudless-app -o wide
-          $KUBECTL logs -n "${{ env.K3S_NAMESPACE }}" -l app=cloudless-app --tail=80
+        mkdir -p "$OUT"
+        # No `gh` on omv-ha — use the GitHub REST API + curl.
+        API="https://api.github.com/repos/${REPO}"
+        AUTH=( -H "Authorization: Bearer ${GH_TOKEN}" -H "Accept: application/vnd.github+json" -H "X-GitHub-Api-Version: 2022-11-28" )
+        RUNS_JSON=$(curl -fsSL "${AUTH[@]}" \
+          "${API}/actions/workflows/deploy-pi.yml/runs?branch=main&status=completed&per_page=30")
+        RUN_ID=$(python3 -c '
+import json,os,sys
+want=os.environ["WANT_SHA"]
+runs=json.load(sys.stdin).get("workflow_runs") or []
+for r in runs:
+  if r.get("head_sha")==want:
+    print(r["id"]); raise SystemExit(0)
+raise SystemExit("no run")
+' <<<"$RUNS_JSON" 2>/dev/null || true)
+        if [ -z "${RUN_ID:-}" ]; then
+          echo "::error::No completed deploy-pi run found for SHA ${WANT_SHA}"
           exit 1
         fi
-        echo "  flipping symlink back → $PREV_RELEASE"
-        sudo ln -sfn "$PREV_RELEASE" "$CURRENT"
-        sudo chown -h tbaltzakis:users "$CURRENT"
-        $KUBECTL rollout restart "deployment/${{ env.K3S_DEPLOYMENT }}" -n "${{ env.K3S_NAMESPACE }}"
-        $KUBECTL rollout status "deployment/${{ env.K3S_DEPLOYMENT }}" -n "${{ env.K3S_NAMESPACE }}" --timeout=180s
+        echo "Found run ${RUN_ID} for ${WANT_SHA}"
+        ARTS_JSON=$(curl -fsSL "${AUTH[@]}" "${API}/actions/runs/${RUN_ID}/artifacts?per_page=50")
+        ART_ID=$(python3 -c '
+import json,os,sys
+name=os.environ["ARTIFACT_NAME"]
+arts=json.load(sys.stdin).get("artifacts") or []
+for a in arts:
+  if a.get("name")==name and not a.get("expired"):
+    print(a["id"]); raise SystemExit(0)
+raise SystemExit("no artifact")
+' <<<"$ARTS_JSON" 2>/dev/null || true)
+        if [ -z "${ART_ID:-}" ]; then
+          echo "::error::Artifact ${ARTIFACT_NAME} not found (or expired) on run ${RUN_ID}"
+          exit 1
+        fi
+        echo "Downloading artifact id=${ART_ID} → ${OUT}"
+        ZIP="${RUNNER_TEMP}/standalone-artifact.zip"
+        curl -fsSL "${AUTH[@]}" -L \
+          "${API}/actions/artifacts/${ART_ID}/zip" -o "$ZIP"
+        python3 -c "import zipfile,sys; zipfile.ZipFile(sys.argv[1]).extractall(sys.argv[2])" "$ZIP" "$OUT"
+        rm -f "$ZIP"
+        ls -la "$OUT" | head -20
 
-        # Verify the rollback actually restored health
-        sleep 8
-        for candidate in http://127.0.0.1:30300/api/health http://192.168.1.128:30300/api/health; do
-          RESP=$(curl -sS --max-time 10 "$candidate" 2>&1 || true)
-          if echo "$RESP" | jq -e .version >/dev/null 2>&1; then
-            echo "::error::Deploy failed; auto-rollback SUCCEEDED — site now on previous release ($PREV_RELEASE). Fix the build and redeploy."
-            exit 1
+    - name: Roll out (rsync + kubectl over SSH)
+      env:
+        ARTIFACT_DIR: ${{ runner.temp }}/standalone-artifact
+        APP_VERSION: ${{ github.sha }}
+        OMV_SSH_HOST: ${{ env.OMV_SSH_HOST }}
+        STANDALONE_HOSTPATH: ${{ env.STANDALONE_HOSTPATH }}
+        K3S_NAMESPACE: ${{ env.K3S_NAMESPACE }}
+        K3S_DEPLOYMENT: ${{ env.K3S_DEPLOYMENT }}
+      run: |
+        set -euo pipefail
+        chmod +x scripts/pi-rollout-from-artifact.sh
+        # download-artifact / gh run download may nest an extra directory —
+        # normalize to …/standalone/server.js
+        ROOT="${ARTIFACT_DIR}"
+        if [ ! -f "${ROOT}/standalone/server.js" ]; then
+          CAND=$(find "$ROOT" -type f -path '*/standalone/server.js' 2>/dev/null | head -1 || true)
+          if [ -n "$CAND" ]; then
+            ROOT=$(dirname "$(dirname "$CAND")")
+            echo "Normalized ARTIFACT_DIR → $ROOT"
+            export ARTIFACT_DIR="$ROOT"
           fi
-        done
-        echo "::error::Deploy failed AND auto-rollback health-check also failed. Investigate manually — try 'scripts/rollback.sh list'."
-        $KUBECTL logs -n "${{ env.K3S_NAMESPACE }}" -l app=cloudless-app --tail=80
-        exit 1
+        fi
+        scripts/pi-rollout-from-artifact.sh

--- a/docs/deploy/runners.md
+++ b/docs/deploy/runners.md
@@ -61,7 +61,7 @@ flipping. New runs pick up the new value immediately.
 These read `vars.RUNNER_GENERIC` and fail over automatically:
 
 - `ci.yml` (lint, typecheck, format, build, test)
-- `deploy-pi.yml` (the `rollout` job — `build-and-push` stays pinned to `[self-hosted, omv, pi]`)
+- `deploy-pi.yml` (`build` stays on `[self-hosted, omv, build]`; `rollout` on `[self-hosted, omv-ha, deploy]` — not `RUNNER_GENERIC`)
 - `ha-sync-orchestrator.yml`
 - `labeler.yml`
 - `links-audit.yml`
@@ -117,6 +117,67 @@ time on ARM:
 
 When billing is broken, these stay red until billing is fixed.
 
+## deploy-pi topology (build on omv, rollout from omv-ha)
+
+`deploy-pi.yml` is **two jobs** so an omv power-cycle mid-rollout does not
+throw away a finished build:
+
+| Job | `runs-on` | Role |
+| --- | --------- | ---- |
+| `build` | `[self-hosted, omv, build]` | Next standalone compile on Pi 5 (8GB); upload `standalone-<sha>` artifact (2-day retention) |
+| `rollout` | `[self-hosted, omv-ha, deploy]` | Download artifact → `scripts/pi-rollout-from-artifact.sh` (rsync SafeDeploy releases/symlink on omv + `kubectl` over SSH) |
+
+- **Never** put the Next build on omv-ha (Pi 4 ~1GB — OOM).
+- Concurrency group `deploy-pi` with `cancel-in-progress: true`.
+- Job timeouts: build 60m, rollout 15m.
+- `workflow_dispatch` input `rollout_only=true` re-downloads the artifact for
+  `github.sha` from a prior completed run (use when build succeeded but
+  rollout failed / omv was down).
+- Fallback if omv-ha is offline: register a temporary runner with the same
+  `omv-ha,deploy` labels on another host that can SSH to omv, or re-run
+  rollout after ha recovers (artifact retained 2 days).
+
+Register the deploy runner on omv-ha:
+
+```bash
+TOKEN=$(gh api -X POST repos/Themis128/cloudless.gr/actions/runners/registration-token --jq .token)
+scp .github/scripts/register-deploy-runner.sh tbaltzakis@192.168.1.130:~/
+ssh tbaltzakis@192.168.1.130 "bash ~/register-deploy-runner.sh $TOKEN"
+```
+
+## Runner auto-heal after reboot (ghost-busy)
+
+After a power-cycle or sleep, GitHub often shows runners **offline + busy**
+while systemd still says `active` — the queue stays blocked until restart
+([actions/runner#4312](https://github.com/actions/runner/issues/4312)).
+
+Install on **both** omv and omv-ha:
+
+```bash
+# From a machine with the repo checkout:
+for host in 192.168.1.128 192.168.1.130; do
+  scp infrastructure/omv/gha-runner-heal.sh \
+      infrastructure/omv/gha-runner-heal.service \
+      infrastructure/omv/gha-runner-heal-check.service \
+      infrastructure/omv/gha-runner-heal.timer \
+      infrastructure/omv/install-gha-runner-heal.sh \
+      tbaltzakis@$host:/tmp/gha-heal/
+  ssh tbaltzakis@$host "sudo bash /tmp/gha-heal/install-gha-runner-heal.sh"
+done
+```
+
+- **Boot:** `gha-runner-heal.service` restarts every `actions.runner.*` unit.
+- **Every 5 min:** timer runs `--check` and restarts units that are active
+  but have no `Runner.Listener` process.
+
+Manual recovery:
+
+```bash
+sudo systemctl restart 'actions.runner.*'
+# or
+sudo /usr/local/sbin/gha-runner-heal.sh --boot
+```
+
 ## Setting up the second runner profile on each Pi host
 
 The existing runner (`~/actions-runner`, labels `omv,pi`) stays put. We add a
@@ -150,28 +211,30 @@ On each Pi host (`omv` = omv-main Pi 5, `omv-ha` = secondary):
      --jq '.runners[] | {name, status, labels: [.labels[].name]}'
    ```
 
-Current active fleet (as of 2026-05-23):
+Current active fleet (as of 2026-08-12):
 
-| Host     | IP              | Runner name   | Labels                                  | Status  |
-| -------- | --------------- | ------------- | --------------------------------------- | ------- |
-| omv-main | 192.168.1.128   | `omv`         | `self-hosted, Linux, ARM64, omv, pi`    | online  |
-| omv-main | 192.168.1.128   | `omv-build`   | `self-hosted, Linux, ARM64, omv, build` | online  |
-| omv-ha   | 192.168.1.130   | `omv-2-build` | `self-hosted, Linux, ARM64, omv, build` | online  |
+| Host     | IP / Tailscale              | Runner name      | Labels                                         | Status / role |
+| -------- | --------------------------- | ---------------- | ---------------------------------------------- | ------------- |
+| omv-main | 192.168.1.128 / 100.74.191.58 | `omv`          | `self-hosted, Linux, ARM64, omv, pi`           | cluster jobs |
+| omv-main | 192.168.1.128               | `omv-build`      | `self-hosted, Linux, ARM64, omv, pi, build`    | **Next build** (`deploy-pi` build job) |
+| omv-ha   | 192.168.1.130 / 100.95.117.84 | `omv-ha-deploy` | `self-hosted, Linux, ARM64, omv-ha, deploy`   | **deploy proxy** (`deploy-pi` rollout) |
+| omv-ha   | 192.168.1.130               | `omv-2-build`    | `self-hosted, Linux, ARM64, omv, build`        | optional spare — **do not** rely on for Next builds (1GB RAM) |
 
 The `pi` label is for cluster-local jobs (NodePort audits, kubectl, CWV).
-The `build` label is **exclusive** for heavy compile / hostPath sync:
+The `build` label is **exclusive** for heavy compile on omv (Pi 5):
 
 | Labels | Purpose | Workflows |
 | ------ | ------- | --------- |
-| `self-hosted, omv, build` | Next standalone build + hostPath sync; emergency ECR image build | `deploy-pi.yml`, `build-pi-image.yml` |
+| `self-hosted, omv, build` | Next standalone **build** + artifact upload | `deploy-pi.yml` (build), `build-pi-image.yml` |
+| `self-hosted, omv-ha, deploy` | rsync SafeDeploy + kubectl over SSH to omv | `deploy-pi.yml` (rollout) |
 | `self-hosted, omv, pi` | Cluster reachability, NodePort Lighthouse, alert-api import | `core-web-vitals-audit.yml`, `cluster-status-audit.yml`, `deploy-alert-api.yml` |
 
 Do **not** put CWV, cluster-status, or ETL on exclusive `build` — one busy
 Lighthouse run previously queued `deploy-pi` for tens of minutes.
 
-`deploy-pi` concurrency uses `cancel-in-progress: false` + `queue: max` so
-rapid main merges **serialize** instead of aborting mid-build. A skip step
-no-ops when `/api/health` already reports `version == github.sha`.
+`deploy-pi` concurrency uses `cancel-in-progress: true` so rapid main merges
+supersede older in-progress runs. A skip step no-ops when `/api/health`
+already reports `version == github.sha`.
 
 ## Caveat: Pi runners share resources with production
 

--- a/infrastructure/omv-ha/README.md
+++ b/infrastructure/omv-ha/README.md
@@ -1,13 +1,36 @@
 # omv-ha host scripts
 
 Tracked-in-git copies of the system-level scripts running on the
-`omv-ha` **mail host**, so they're versioned + auditable instead of
-"installed once and forgotten."
+`omv-ha` **mail host + deploy-pi rollout proxy**, so they're versioned +
+auditable instead of "installed once and forgotten."
 
 **Role (as of 2026-08-08):** omv-ha is a **dedicated mail host** — Pi 4,
-1GB, SSH-reachable over Tailscale (`omv-ha`, 100.95.117.84). It was
-drained + removed from k3s that day and is no longer a cluster node.
-See `CLAUDE.md` "Cluster Topology" note.
+1GB, SSH-reachable over Tailscale (`omv-ha`, 100.95.117.84) and LAN
+(`192.168.1.130`). It was drained + removed from k3s that day and is no
+longer a cluster node. See `CLAUDE.md` "Cluster Topology" note.
+
+**Role (as of 2026-08-12):** omv-ha also runs the **`omv-ha-deploy`**
+GitHub Actions runner (`labels: self-hosted, omv-ha, deploy`). It does
+**not** build Next.js (1GB RAM will OOM) — it only rsyncs the standalone
+artifact to omv and runs `kubectl` over SSH. See `docs/deploy/runners.md`
+and `scripts/pi-rollout-from-artifact.sh`.
+
+## Deploy runner + GHA heal
+
+```bash
+# Register (once) — get token from:
+#   gh api -X POST repos/Themis128/cloudless.gr/actions/runners/registration-token --jq .token
+scp .github/scripts/register-deploy-runner.sh tbaltzakis@192.168.1.130:~/
+ssh tbaltzakis@192.168.1.130 "bash ~/register-deploy-runner.sh <REG_TOKEN>"
+
+# Install runner heal (boot + every 5 min) — clears ghost-busy after power cycle
+scp infrastructure/omv-ha/gha-runner-heal* infrastructure/omv-ha/install-gha-runner-heal.sh \
+  tbaltzakis@192.168.1.130:/tmp/gha-heal/
+ssh tbaltzakis@192.168.1.130 "sudo bash /tmp/gha-heal/install-gha-runner-heal.sh"
+```
+
+SSH from omv-ha → omv for rollout uses `~/.ssh/omv_ha` → `tbaltzakis@192.168.1.128`
+(passwordless sudo on omv required for hostPath + kubectl).
 
 ## `setup-mail-server.sh`
 

--- a/infrastructure/omv-ha/gha-runner-heal-check.service
+++ b/infrastructure/omv-ha/gha-runner-heal-check.service
@@ -1,0 +1,7 @@
+[Unit]
+Description=Periodic GitHub Actions runner heal (wedged listener)
+After=network-online.target
+
+[Service]
+Type=oneshot
+ExecStart=/usr/local/sbin/gha-runner-heal.sh --check

--- a/infrastructure/omv-ha/gha-runner-heal.service
+++ b/infrastructure/omv-ha/gha-runner-heal.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=Heal GitHub Actions runners after boot (clear ghost-busy)
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=oneshot
+ExecStart=/usr/local/sbin/gha-runner-heal.sh --boot
+
+[Install]
+WantedBy=multi-user.target

--- a/infrastructure/omv-ha/gha-runner-heal.sh
+++ b/infrastructure/omv-ha/gha-runner-heal.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+# gha-runner-heal.sh — clear ghost-busy / dead GitHub Actions runners after reboot.
+#
+# After a host power-cycle or sleep, the runner service can look "active" locally
+# while GitHub still shows the runner offline+busy, blocking the job queue.
+# This script:
+#   1. On boot (--boot): always restart every actions.runner.*.service
+#   2. Periodically (--check): restart any unit that is active but has no
+#      Runner.Listener process (wedged listener)
+#
+# Safe to run while idle. Does NOT interrupt a healthy busy runner that has a
+# live Listener (active jobs keep working).
+set -euo pipefail
+
+MODE="${1:---check}"
+LOG_TAG="gha-runner-heal"
+
+log() { echo "[$LOG_TAG] $*"; logger -t "$LOG_TAG" "$*" 2>/dev/null || true; }
+
+list_runner_units() {
+  systemctl list-units --type=service --all --no-legend 'actions.runner.*' 2>/dev/null \
+    | awk '{print $1}' \
+    | grep -E '^actions\.runner\.' \
+    || true
+}
+
+listener_alive_for_unit() {
+  local unit="$1"
+  # WorkingDirectory from the unit points at the runner install (…/actions-runner*)
+  local cwd
+  cwd="$(systemctl show -p WorkingDirectory --value "$unit" 2>/dev/null || true)"
+  if [[ -z "$cwd" || "$cwd" == "/" ]]; then
+    # Fallback: any Runner.Listener owned by the runner user
+    pgrep -f '[R]unner.Listener' >/dev/null 2>&1
+    return $?
+  fi
+  pgrep -f "[R]unner.Listener" >/dev/null 2>&1 || return 1
+  # Prefer a listener whose cwd/cmdline references this install path
+  if pgrep -af '[R]unner.Listener' 2>/dev/null | grep -F "$cwd" >/dev/null 2>&1; then
+    return 0
+  fi
+  # If only one runner on the box, any Listener is enough
+  local count
+  count="$(list_runner_units | wc -l)"
+  if [[ "$count" -le 1 ]] && pgrep -f '[R]unner.Listener' >/dev/null 2>&1; then
+    return 0
+  fi
+  # Multi-runner host without path match: treat as missing for this unit
+  return 1
+}
+
+restart_unit() {
+  local unit="$1"
+  log "restarting $unit"
+  systemctl restart "$unit" || log "WARN: restart failed for $unit"
+}
+
+case "$MODE" in
+  --boot)
+    log "boot heal: restarting all actions.runner.* services"
+    sleep 5   # let network-online settle
+    mapfile -t UNITS < <(list_runner_units)
+    if [[ ${#UNITS[@]} -eq 0 ]]; then
+      log "no actions.runner.* units found"
+      exit 0
+    fi
+    for u in "${UNITS[@]}"; do
+      restart_unit "$u"
+    done
+    sleep 3
+    for u in "${UNITS[@]}"; do
+      log "$u → $(systemctl is-active "$u" 2>/dev/null || echo unknown)"
+    done
+    ;;
+  --check)
+    mapfile -t UNITS < <(list_runner_units)
+    for u in "${UNITS[@]}"; do
+      state="$(systemctl is-active "$u" 2>/dev/null || echo inactive)"
+      if [[ "$state" != "active" ]]; then
+        log "$u is $state — starting"
+        systemctl start "$u" || log "WARN: start failed for $u"
+        continue
+      fi
+      if listener_alive_for_unit "$u"; then
+        continue
+      fi
+      log "$u active but Runner.Listener missing — restarting (ghost/wedge)"
+      restart_unit "$u"
+    done
+    ;;
+  *)
+    echo "Usage: $0 --boot|--check" >&2
+    exit 2
+    ;;
+esac

--- a/infrastructure/omv-ha/gha-runner-heal.timer
+++ b/infrastructure/omv-ha/gha-runner-heal.timer
@@ -1,0 +1,12 @@
+[Unit]
+Description=Run gha-runner-heal check every 5 minutes
+
+[Timer]
+OnBootSec=2min
+OnUnitActiveSec=5min
+AccuracySec=30s
+Persistent=true
+Unit=gha-runner-heal-check.service
+
+[Install]
+WantedBy=timers.target

--- a/infrastructure/omv-ha/install-gha-runner-heal.sh
+++ b/infrastructure/omv-ha/install-gha-runner-heal.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# install-gha-runner-heal.sh — install boot + periodic runner heal on this host.
+#
+# Run as root on omv or omv-ha:
+#   sudo bash infrastructure/omv/install-gha-runner-heal.sh
+# Or from a checkout on the Pi:
+#   sudo bash /path/to/install-gha-runner-heal.sh
+set -euo pipefail
+[ "$EUID" = "0" ] || { echo "must be root" >&2; exit 1; }
+
+REPO_DIR="$(dirname "$(readlink -f "$0")")"
+SCRIPT="$REPO_DIR/gha-runner-heal.sh"
+BOOT_SVC="$REPO_DIR/gha-runner-heal.service"
+CHECK_SVC="$REPO_DIR/gha-runner-heal-check.service"
+TIMER="$REPO_DIR/gha-runner-heal.timer"
+
+for f in "$SCRIPT" "$BOOT_SVC" "$CHECK_SVC" "$TIMER"; do
+  [ -f "$f" ] || { echo "missing: $f" >&2; exit 1; }
+done
+
+install -m 755 -o root -g root "$SCRIPT"    /usr/local/sbin/gha-runner-heal.sh
+install -m 644 -o root -g root "$BOOT_SVC"  /etc/systemd/system/gha-runner-heal.service
+install -m 644 -o root -g root "$CHECK_SVC" /etc/systemd/system/gha-runner-heal-check.service
+install -m 644 -o root -g root "$TIMER"     /etc/systemd/system/gha-runner-heal.timer
+
+systemctl daemon-reload
+systemctl enable gha-runner-heal.service
+systemctl enable --now gha-runner-heal.timer
+
+echo "[install] enabled gha-runner-heal.service (boot) + gha-runner-heal.timer"
+systemctl start gha-runner-heal-check.service || true
+systemctl --no-pager status gha-runner-heal.timer || true
+echo "[install] done — check: journalctl -t gha-runner-heal -n 30"

--- a/infrastructure/omv/README.md
+++ b/infrastructure/omv/README.md
@@ -212,3 +212,13 @@ kubectl describe pod -n cloudless cloudless-app-xxx
 - ✅ Analytics data persistence becomes critical
 
 See also: `infrastructure/omv-ha/` for standby node configuration
+
+## GitHub Actions runner heal
+
+After power-cycles, runners can go ghost-busy on GitHub. Install:
+
+```bash
+sudo bash infrastructure/omv/install-gha-runner-heal.sh
+```
+
+See `docs/deploy/runners.md`.

--- a/infrastructure/omv/gha-runner-heal-check.service
+++ b/infrastructure/omv/gha-runner-heal-check.service
@@ -1,0 +1,7 @@
+[Unit]
+Description=Periodic GitHub Actions runner heal (wedged listener)
+After=network-online.target
+
+[Service]
+Type=oneshot
+ExecStart=/usr/local/sbin/gha-runner-heal.sh --check

--- a/infrastructure/omv/gha-runner-heal.service
+++ b/infrastructure/omv/gha-runner-heal.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=Heal GitHub Actions runners after boot (clear ghost-busy)
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=oneshot
+ExecStart=/usr/local/sbin/gha-runner-heal.sh --boot
+
+[Install]
+WantedBy=multi-user.target

--- a/infrastructure/omv/gha-runner-heal.sh
+++ b/infrastructure/omv/gha-runner-heal.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+# gha-runner-heal.sh — clear ghost-busy / dead GitHub Actions runners after reboot.
+#
+# After a host power-cycle or sleep, the runner service can look "active" locally
+# while GitHub still shows the runner offline+busy, blocking the job queue.
+# This script:
+#   1. On boot (--boot): always restart every actions.runner.*.service
+#   2. Periodically (--check): restart any unit that is active but has no
+#      Runner.Listener process (wedged listener)
+#
+# Safe to run while idle. Does NOT interrupt a healthy busy runner that has a
+# live Listener (active jobs keep working).
+set -euo pipefail
+
+MODE="${1:---check}"
+LOG_TAG="gha-runner-heal"
+
+log() { echo "[$LOG_TAG] $*"; logger -t "$LOG_TAG" "$*" 2>/dev/null || true; }
+
+list_runner_units() {
+  systemctl list-units --type=service --all --no-legend 'actions.runner.*' 2>/dev/null \
+    | awk '{print $1}' \
+    | grep -E '^actions\.runner\.' \
+    || true
+}
+
+listener_alive_for_unit() {
+  local unit="$1"
+  # WorkingDirectory from the unit points at the runner install (…/actions-runner*)
+  local cwd
+  cwd="$(systemctl show -p WorkingDirectory --value "$unit" 2>/dev/null || true)"
+  if [[ -z "$cwd" || "$cwd" == "/" ]]; then
+    # Fallback: any Runner.Listener owned by the runner user
+    pgrep -f '[R]unner.Listener' >/dev/null 2>&1
+    return $?
+  fi
+  pgrep -f "[R]unner.Listener" >/dev/null 2>&1 || return 1
+  # Prefer a listener whose cwd/cmdline references this install path
+  if pgrep -af '[R]unner.Listener' 2>/dev/null | grep -F "$cwd" >/dev/null 2>&1; then
+    return 0
+  fi
+  # If only one runner on the box, any Listener is enough
+  local count
+  count="$(list_runner_units | wc -l)"
+  if [[ "$count" -le 1 ]] && pgrep -f '[R]unner.Listener' >/dev/null 2>&1; then
+    return 0
+  fi
+  # Multi-runner host without path match: treat as missing for this unit
+  return 1
+}
+
+restart_unit() {
+  local unit="$1"
+  log "restarting $unit"
+  systemctl restart "$unit" || log "WARN: restart failed for $unit"
+}
+
+case "$MODE" in
+  --boot)
+    log "boot heal: restarting all actions.runner.* services"
+    sleep 5   # let network-online settle
+    mapfile -t UNITS < <(list_runner_units)
+    if [[ ${#UNITS[@]} -eq 0 ]]; then
+      log "no actions.runner.* units found"
+      exit 0
+    fi
+    for u in "${UNITS[@]}"; do
+      restart_unit "$u"
+    done
+    sleep 3
+    for u in "${UNITS[@]}"; do
+      log "$u → $(systemctl is-active "$u" 2>/dev/null || echo unknown)"
+    done
+    ;;
+  --check)
+    mapfile -t UNITS < <(list_runner_units)
+    for u in "${UNITS[@]}"; do
+      state="$(systemctl is-active "$u" 2>/dev/null || echo inactive)"
+      if [[ "$state" != "active" ]]; then
+        log "$u is $state — starting"
+        systemctl start "$u" || log "WARN: start failed for $u"
+        continue
+      fi
+      if listener_alive_for_unit "$u"; then
+        continue
+      fi
+      log "$u active but Runner.Listener missing — restarting (ghost/wedge)"
+      restart_unit "$u"
+    done
+    ;;
+  *)
+    echo "Usage: $0 --boot|--check" >&2
+    exit 2
+    ;;
+esac

--- a/infrastructure/omv/gha-runner-heal.timer
+++ b/infrastructure/omv/gha-runner-heal.timer
@@ -1,0 +1,12 @@
+[Unit]
+Description=Run gha-runner-heal check every 5 minutes
+
+[Timer]
+OnBootSec=2min
+OnUnitActiveSec=5min
+AccuracySec=30s
+Persistent=true
+Unit=gha-runner-heal-check.service
+
+[Install]
+WantedBy=timers.target

--- a/infrastructure/omv/install-gha-runner-heal.sh
+++ b/infrastructure/omv/install-gha-runner-heal.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# install-gha-runner-heal.sh — install boot + periodic runner heal on this host.
+#
+# Run as root on omv or omv-ha:
+#   sudo bash infrastructure/omv/install-gha-runner-heal.sh
+# Or from a checkout on the Pi:
+#   sudo bash /path/to/install-gha-runner-heal.sh
+set -euo pipefail
+[ "$EUID" = "0" ] || { echo "must be root" >&2; exit 1; }
+
+REPO_DIR="$(dirname "$(readlink -f "$0")")"
+SCRIPT="$REPO_DIR/gha-runner-heal.sh"
+BOOT_SVC="$REPO_DIR/gha-runner-heal.service"
+CHECK_SVC="$REPO_DIR/gha-runner-heal-check.service"
+TIMER="$REPO_DIR/gha-runner-heal.timer"
+
+for f in "$SCRIPT" "$BOOT_SVC" "$CHECK_SVC" "$TIMER"; do
+  [ -f "$f" ] || { echo "missing: $f" >&2; exit 1; }
+done
+
+install -m 755 -o root -g root "$SCRIPT"    /usr/local/sbin/gha-runner-heal.sh
+install -m 644 -o root -g root "$BOOT_SVC"  /etc/systemd/system/gha-runner-heal.service
+install -m 644 -o root -g root "$CHECK_SVC" /etc/systemd/system/gha-runner-heal-check.service
+install -m 644 -o root -g root "$TIMER"     /etc/systemd/system/gha-runner-heal.timer
+
+systemctl daemon-reload
+systemctl enable gha-runner-heal.service
+systemctl enable --now gha-runner-heal.timer
+
+echo "[install] enabled gha-runner-heal.service (boot) + gha-runner-heal.timer"
+systemctl start gha-runner-heal-check.service || true
+systemctl --no-pager status gha-runner-heal.timer || true
+echo "[install] done — check: journalctl -t gha-runner-heal -n 30"

--- a/scripts/pi-rollout-from-artifact.sh
+++ b/scripts/pi-rollout-from-artifact.sh
@@ -1,0 +1,197 @@
+#!/usr/bin/env bash
+# pi-rollout-from-artifact.sh — SafeDeploy hostPath sync + k3s rollout over SSH.
+#
+# Runs on the deploy-proxy host (omv-ha). Expects a local artifact directory
+# produced by deploy-pi's build job:
+#
+#   ARTIFACT_DIR/
+#     standalone/   # contents of .next/standalone (must contain server.js)
+#     static/       # optional — .next/static
+#     public/       # optional — public/
+#
+# Env:
+#   ARTIFACT_DIR         Path to unpacked artifact (or pass as $1)
+#   OMV_SSH_HOST         SSH target for omv (default: 192.168.1.128)
+#   OMV_SSH_USER         SSH user (default: tbaltzakis)
+#   OMV_SSH_IDENTITY     Optional private key (default: ~/.ssh/omv_ha if present)
+#   STANDALONE_HOSTPATH  Symlink k8s mounts (default: /home/tbaltzakis/cloudless-standalone)
+#   K3S_NAMESPACE        default: cloudless
+#   K3S_DEPLOYMENT       default: cloudless-app
+#   APP_VERSION          Full git SHA (required)
+#   RELEASE_SHA12        Release dir name (default: first 12 of APP_VERSION)
+set -euo pipefail
+
+ARTIFACT_DIR="${1:-${ARTIFACT_DIR:-}}"
+OMV_SSH_HOST="${OMV_SSH_HOST:-192.168.1.128}"
+OMV_SSH_USER="${OMV_SSH_USER:-tbaltzakis}"
+STANDALONE_HOSTPATH="${STANDALONE_HOSTPATH:-/home/tbaltzakis/cloudless-standalone}"
+K3S_NAMESPACE="${K3S_NAMESPACE:-cloudless}"
+K3S_DEPLOYMENT="${K3S_DEPLOYMENT:-cloudless-app}"
+APP_VERSION="${APP_VERSION:?APP_VERSION (full git SHA) is required}"
+RELEASE_SHA12="${RELEASE_SHA12:-${APP_VERSION:0:12}}"
+
+if [[ -z "$ARTIFACT_DIR" || ! -d "$ARTIFACT_DIR" ]]; then
+  echo "::error::ARTIFACT_DIR missing or not a directory: ${ARTIFACT_DIR:-<empty>}" >&2
+  exit 1
+fi
+SRC="${ARTIFACT_DIR}/standalone"
+if [[ ! -f "${SRC}/server.js" ]]; then
+  echo "::error::Standalone build not found at ${SRC}/server.js" >&2
+  exit 1
+fi
+
+SSH_OPTS=(-o BatchMode=yes -o ConnectTimeout=15 -o StrictHostKeyChecking=accept-new)
+if [[ -n "${OMV_SSH_IDENTITY:-}" ]]; then
+  SSH_OPTS+=(-i "$OMV_SSH_IDENTITY")
+elif [[ -f "${HOME}/.ssh/omv_ha" ]]; then
+  SSH_OPTS+=(-i "${HOME}/.ssh/omv_ha")
+fi
+
+remote() {
+  # shellcheck disable=SC2029
+  ssh "${SSH_OPTS[@]}" "${OMV_SSH_USER}@${OMV_SSH_HOST}" "$@"
+}
+
+RSYNC_RSH="ssh ${SSH_OPTS[*]}"
+rsync_to() {
+  local src="$1" dest="$2"
+  rsync -a --delete -e "$RSYNC_RSH" "$src" "${OMV_SSH_USER}@${OMV_SSH_HOST}:${dest}"
+}
+
+echo "==> Deploy proxy → ${OMV_SSH_USER}@${OMV_SSH_HOST}"
+echo "    release=${RELEASE_SHA12} app_version=${APP_VERSION}"
+remote "hostname; test -d $(dirname "$STANDALONE_HOSTPATH") && echo HOSTPATH_PARENT_OK"
+
+CURRENT="$STANDALONE_HOSTPATH"
+RELEASES="$(dirname "$CURRENT")/cloudless-releases"
+NEW_REL="$RELEASES/$RELEASE_SHA12"
+USER_STAGE="/tmp/cloudless-stage-${RELEASE_SHA12}"
+
+echo "==> Rsync artifact → omv ${USER_STAGE}"
+remote "rm -rf '$USER_STAGE' && mkdir -p '$USER_STAGE'"
+rsync_to "${SRC}/" "${USER_STAGE}/"
+if [[ -d "${ARTIFACT_DIR}/static" ]]; then
+  remote "mkdir -p '${USER_STAGE}/.next/static'"
+  rsync_to "${ARTIFACT_DIR}/static/" "${USER_STAGE}/.next/static/"
+fi
+if [[ -d "${ARTIFACT_DIR}/public" ]]; then
+  remote "mkdir -p '${USER_STAGE}/public'"
+  rsync_to "${ARTIFACT_DIR}/public/" "${USER_STAGE}/public/"
+fi
+remote "test -f '${USER_STAGE}/server.js'"
+
+echo "==> Promote → releases/${RELEASE_SHA12} + flip symlink"
+PREV="$(remote "readlink '$CURRENT' 2>/dev/null || true" | tr -d '\r')"
+remote bash -s <<REMOTE
+set -euo pipefail
+CURRENT='$CURRENT'
+RELEASES='$RELEASES'
+NEW_REL='$NEW_REL'
+USER_STAGE='$USER_STAGE'
+SHA12='$RELEASE_SHA12'
+OWNER='$OMV_SSH_USER'
+sudo mkdir -p "\$RELEASES"
+sudo rm -rf "\$NEW_REL"
+sudo mv "\$USER_STAGE" "\$NEW_REL"
+# Pod may run as a different uid — keep tree world-readable/executable.
+sudo chmod -R a+rX "\$NEW_REL"
+sudo ln -sfn "cloudless-releases/\$SHA12" "\$CURRENT"
+sudo chown -h "\$OWNER:users" "\$CURRENT"
+echo "Symlink now: \$CURRENT → \$(readlink "\$CURRENT")"
+cd "\$RELEASES"
+ls -1t | tail -n +6 | while read -r old; do
+  [ "cloudless-releases/\$old" = "\$(readlink "\$CURRENT")" ] && continue
+  echo "  pruning old release: \$old"
+  sudo rm -rf "\$old"
+done
+echo "Prepared release: \$NEW_REL (\$(sudo du -sh "\$NEW_REL" | cut -f1))"
+REMOTE
+
+echo "previous_release=${PREV}"
+
+echo "==> kubectl set env + rollout restart"
+remote bash -s <<REMOTE
+set -euo pipefail
+NS='$K3S_NAMESPACE'
+DEP='$K3S_DEPLOYMENT'
+FULL_SHA='$APP_VERSION'
+KUBECTL=""
+for attempt in \$(seq 1 6); do
+  if command -v kubectl >/dev/null 2>&1 && kubectl get --raw /readyz --request-timeout=15s >/dev/null 2>&1; then
+    KUBECTL="kubectl"; break
+  elif sudo kubectl get --raw /readyz --request-timeout=15s >/dev/null 2>&1; then
+    KUBECTL="sudo kubectl"; break
+  elif sudo k3s kubectl get --raw /readyz --request-timeout=15s >/dev/null 2>&1; then
+    KUBECTL="sudo k3s kubectl"; break
+  fi
+  echo "kubectl not ready (attempt \${attempt}/6) — waiting 10s…"
+  sleep 10
+done
+if [ -z "\$KUBECTL" ]; then
+  echo "::error::kubectl cannot reach the cluster after 6 attempts" >&2
+  exit 1
+fi
+echo "Using: \$KUBECTL"
+\$KUBECTL set env "deployment/\${DEP}" -n "\$NS" \
+  "APP_VERSION=\${FULL_SHA}" \
+  "NEXT_PUBLIC_APP_VERSION=\${FULL_SHA}" \
+  "NEXT_PUBLIC_AUTH_PROVIDER=d1" \
+  "SSM_DISABLED=1" \
+  "CLOUDFLARE_ACCOUNT_ID=fb7dc7b69b662480cd5961a4d1913c78"
+\$KUBECTL rollout restart "deployment/\${DEP}" -n "\$NS"
+\$KUBECTL rollout status "deployment/\${DEP}" -n "\$NS" --timeout=600s
+sleep 15
+\$KUBECTL get pods -n "\$NS" -l app=cloudless-app -o wide
+\$KUBECTL get endpoints -n "\$NS" cloudless-app || true
+curl -sS --max-time 5 http://127.0.0.1:30300/api/health || true
+echo
+REMOTE
+
+echo "==> Verify health (auto-rollback on failure)"
+HEALTH_OK=0
+for attempt in 1 2 3 4 5 6; do
+  # Prefer jq on omv (always present); fall back to local jq if available.
+  if remote 'BODY=$(curl -sS --max-time 10 http://127.0.0.1:30300/api/health 2>/dev/null || true); echo "$BODY" | jq -e .version >/dev/null 2>&1 && echo "$BODY"'; then
+    HEALTH_OK=1
+    echo "✅ health OK (attempt ${attempt})"
+    break
+  fi
+  echo "  health not ready (attempt ${attempt}/6) — waiting 10s…"
+  sleep 10
+done
+
+if [[ "$HEALTH_OK" = "1" ]]; then
+  echo "Rollout verification successful."
+  exit 0
+fi
+
+echo "::warning::New release failed health checks — auto-rolling back to previous."
+if [[ -z "$PREV" ]]; then
+  echo "::error::No previous release recorded. Cannot auto-rollback." >&2
+  remote "sudo kubectl logs -n ${K3S_NAMESPACE} -l app=cloudless-app --tail=80 2>/dev/null || sudo k3s kubectl logs -n ${K3S_NAMESPACE} -l app=cloudless-app --tail=80" || true
+  exit 1
+fi
+
+remote bash -s <<REMOTE
+set -euo pipefail
+CURRENT='$CURRENT'
+PREV_RELEASE='$PREV'
+OWNER='$OMV_SSH_USER'
+NS='$K3S_NAMESPACE'
+DEP='$K3S_DEPLOYMENT'
+sudo ln -sfn "\$PREV_RELEASE" "\$CURRENT"
+sudo chown -h "\$OWNER:users" "\$CURRENT"
+KUBECTL="sudo kubectl"
+sudo kubectl get --raw /readyz --request-timeout=10s >/dev/null 2>&1 || KUBECTL="sudo k3s kubectl"
+\$KUBECTL rollout restart "deployment/\$DEP" -n "\$NS"
+\$KUBECTL rollout status "deployment/\$DEP" -n "\$NS" --timeout=180s
+sleep 8
+RESP=\$(curl -sS --max-time 10 http://127.0.0.1:30300/api/health 2>/dev/null || true)
+if echo "\$RESP" | jq -e .version >/dev/null 2>&1; then
+  echo "::error::Deploy failed; auto-rollback SUCCEEDED — site on \$PREV_RELEASE"
+  exit 1
+fi
+echo "::error::Deploy failed AND auto-rollback health-check also failed."
+\$KUBECTL logs -n "\$NS" -l app=cloudless-app --tail=80 || true
+exit 1
+REMOTE


### PR DESCRIPTION
## Summary
- Split `deploy-pi.yml` into build on omv (artifact upload) and rollout on omv-ha (rsync SafeDeploy + kubectl over SSH)
- Add `scripts/pi-rollout-from-artifact.sh`, deploy-runner registration script, and boot/periodic GHA runner heal on both Pis
- Document the new topology and ghost-busy recovery in `docs/deploy/runners.md`

## Test plan
- [ ] Confirm `omv-ha-deploy` is online with labels `omv-ha,deploy`
- [ ] Dispatch `deploy-pi.yml` — build on omv, rollout from omv-ha, `/api/health` shows new SHA
- [ ] Optional: `rollout_only=true` after a failed rollout reuses the artifact without rebuild
- [ ] After omv reboot, heal timer/service clears ghost-busy within a few minutes


Made with [Cursor](https://cursor.com)