### PR TITLE
Pi connectivity: Tailscale ACL tag:pi + host firewalls

### DIFF
--- a/.github/workflows/tailscale-admin-api.yml
+++ b/.github/workflows/tailscale-admin-api.yml
@@ -51,3 +51,7 @@ jobs:
 
     - name: Run Tailscale Admin API script
       run: bash scripts/tailscale-admin-api.sh
+
+    - name: Retag Pi hosts to tag:pi
+      if: inputs.dry_run != 'true'
+      run: bash scripts/tailscale-retag-pi-hosts.sh

--- a/infrastructure/omv-ha/configure-pi-firewall.sh
+++ b/infrastructure/omv-ha/configure-pi-firewall.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+# configure-pi-firewall.sh — SSH-safe host firewall for omv / omv-ha.
+#
+# Goals (per Tailscale docs: classic OpenSSH over the mesh, not Tailscale SSH):
+#   - Allow SSH from Tailscale CGNAT (100.64.0.0/10) WITHOUT ufw rate-limit
+#   - Allow SSH from LAN 192.168.1.0/24 without rate-limit
+#   - Keep public SSH rate-limited (omv) or closed (omv-ha preference)
+#   - Always allow Tailscale UDP 41641 + established
+#
+# Run as root on the Pi:
+#   sudo bash configure-pi-firewall.sh
+set -euo pipefail
+[ "$EUID" = "0" ] || { echo "must be root" >&2; exit 1; }
+
+LAN_CIDR="${PI_LAN_CIDR:-192.168.1.0/24}"
+TS_CGNAT="100.64.0.0/10"
+HOST="$(hostname -s 2>/dev/null || hostname)"
+
+echo "[fw] host=$HOST"
+
+if command -v ufw >/dev/null 2>&1; then
+  echo "[fw] configuring ufw"
+  ufw --force enable || true
+
+  # Specific allows MUST precede any LIMIT Anywhere (ufw first-match wins).
+  while ufw status numbered | grep -qE 'cloudless-ssh-ts|cloudless-ssh-lan|cloudless-ssh-public|22/tcp.*LIMIT'; do
+    NUM=$(ufw status numbered | grep -E 'cloudless-ssh-ts|cloudless-ssh-lan|cloudless-ssh-public|22/tcp.*LIMIT' | head -1 | sed -n 's/^\[\s*\([0-9]*\)\].*/\1/p')
+    [[ -z "$NUM" ]] && break
+    yes | ufw delete "$NUM" >/dev/null || break
+  done
+
+  ufw insert 1 allow from "$TS_CGNAT" to any port 22 proto tcp comment 'cloudless-ssh-ts'
+  ufw insert 2 allow from "$LAN_CIDR" to any port 22 proto tcp comment 'cloudless-ssh-lan'
+  ufw limit 22/tcp comment 'cloudless-ssh-public-limit'
+
+  # Broad Tailscale allow (non-SSH) if missing
+  if ! ufw status | grep -qF '100.64.0.0/10'; then
+    ufw allow from "$TS_CGNAT" comment 'cloudless-tailscale-net' || true
+  fi
+  if ! ufw status | grep -q '41641/udp'; then
+    ufw allow 41641/udp comment 'cloudless-tailscale-wireguard' || true
+  fi
+
+  # Avoid full reload mid-session when possible — enable is enough if already active
+  ufw status verbose | head -40
+else
+  echo "[fw] no ufw — installing nftables SSH allow set (omv-ha style)"
+  command -v nft >/dev/null || { echo "nft not found"; exit 1; }
+
+  nft list table inet cloudless_fw >/dev/null 2>&1 && nft delete table inet cloudless_fw || true
+  nft -f - <<EOF
+table inet cloudless_fw {
+  chain input {
+    type filter hook input priority -10; policy accept;
+    ct state established,related accept
+    iifname "lo" accept
+    iifname "tailscale0" accept
+    udp dport 41641 accept
+    tcp dport 22 ip saddr ${LAN_CIDR} accept
+    tcp dport 22 ip saddr ${TS_CGNAT} accept
+  }
+}
+EOF
+  echo "[fw] nft table inet cloudless_fw installed"
+  nft list table inet cloudless_fw
+fi
+
+# Tailscale SSH stays off — classic sshd only
+if command -v tailscale >/dev/null 2>&1; then
+  tailscale set --ssh=false || true
+fi
+
+echo "[fw] done"

--- a/infrastructure/omv-ha/install-pi-connectivity-heal.sh
+++ b/infrastructure/omv-ha/install-pi-connectivity-heal.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+# install-pi-connectivity-heal.sh — install connectivity heal + sshd priority drop-in.
+#
+# Run as root on omv or omv-ha:
+#   sudo bash infrastructure/omv/install-pi-connectivity-heal.sh
+set -euo pipefail
+[ "$EUID" = "0" ] || { echo "must be root" >&2; exit 1; }
+
+REPO_DIR="$(dirname "$(readlink -f "$0")")"
+SCRIPT="$REPO_DIR/pi-connectivity-heal.sh"
+BOOT_SVC="$REPO_DIR/pi-connectivity-heal.service"
+CHECK_SVC="$REPO_DIR/pi-connectivity-heal-check.service"
+TIMER="$REPO_DIR/pi-connectivity-heal.timer"
+SSHD_DROPIN_SRC="$REPO_DIR/sshd-under-load.conf"
+
+for f in "$SCRIPT" "$BOOT_SVC" "$CHECK_SVC" "$TIMER"; do
+  [ -f "$f" ] || { echo "missing: $f" >&2; exit 1; }
+done
+
+install -m 755 -o root -g root "$SCRIPT"    /usr/local/sbin/pi-connectivity-heal.sh
+install -m 644 -o root -g root "$BOOT_SVC"  /etc/systemd/system/pi-connectivity-heal.service
+install -m 644 -o root -g root "$CHECK_SVC" /etc/systemd/system/pi-connectivity-heal-check.service
+install -m 644 -o root -g root "$TIMER"     /etc/systemd/system/pi-connectivity-heal.timer
+
+# Keep OpenSSH responsive when next-build pegs the Pi CPU.
+if [ -f "$SSHD_DROPIN_SRC" ]; then
+  mkdir -p /etc/systemd/system/ssh.service.d /etc/systemd/system/sshd.service.d
+  install -m 644 -o root -g root "$SSHD_DROPIN_SRC" /etc/systemd/system/ssh.service.d/under-load.conf
+  install -m 644 -o root -g root "$SSHD_DROPIN_SRC" /etc/systemd/system/sshd.service.d/under-load.conf
+fi
+if [ -f "$REPO_DIR/sshd-connectivity.conf" ]; then
+  install -m 644 -o root -g root "$REPO_DIR/sshd-connectivity.conf" \
+    /etc/ssh/sshd_config.d/99-cloudless-connectivity.conf
+fi
+
+# Hardened tailscaled restart policy
+mkdir -p /etc/systemd/system/tailscaled.service.d
+cat > /etc/systemd/system/tailscaled.service.d/restart.conf <<'EOF'
+[Service]
+Restart=always
+RestartSec=5s
+StartLimitIntervalSec=0
+EOF
+
+# Policy: classic SSH only
+if command -v tailscale >/dev/null 2>&1; then
+  tailscale set --ssh=false || true
+fi
+
+systemctl daemon-reload
+# Reload sshd config if possible
+systemctl try-reload-or-restart ssh.service 2>/dev/null \
+  || systemctl try-reload-or-restart sshd.service 2>/dev/null \
+  || true
+
+systemctl enable pi-connectivity-heal.service
+systemctl enable --now pi-connectivity-heal.timer
+systemctl start pi-connectivity-heal-check.service || true
+
+echo "[install] pi-connectivity-heal enabled"
+systemctl --no-pager status pi-connectivity-heal.timer || true
+/usr/local/sbin/pi-connectivity-heal.sh --check || true
+echo "[install] done — journalctl -t pi-connectivity-heal -n 40"

--- a/infrastructure/omv-ha/pi-connectivity-heal-check.service
+++ b/infrastructure/omv-ha/pi-connectivity-heal-check.service
@@ -1,0 +1,7 @@
+[Unit]
+Description=Periodic Tailscale + OpenSSH connectivity heal
+After=network-online.target
+
+[Service]
+Type=oneshot
+ExecStart=/usr/local/sbin/pi-connectivity-heal.sh --check

--- a/infrastructure/omv-ha/pi-connectivity-heal.service
+++ b/infrastructure/omv-ha/pi-connectivity-heal.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=Heal Tailscale + OpenSSH connectivity after boot
+After=network-online.target tailscaled.service
+Wants=network-online.target
+
+[Service]
+Type=oneshot
+ExecStart=/usr/local/sbin/pi-connectivity-heal.sh --boot
+
+[Install]
+WantedBy=multi-user.target

--- a/infrastructure/omv-ha/pi-connectivity-heal.sh
+++ b/infrastructure/omv-ha/pi-connectivity-heal.sh
@@ -1,0 +1,142 @@
+#!/usr/bin/env bash
+# pi-connectivity-heal.sh — keep Tailscale + classic OpenSSH reachable on a Pi.
+#
+# Problem modes this addresses:
+#   1. tailscaled dead / logged out → no MagicDNS / no 100.x path
+#   2. Tailscale SSH (RunSSH) re-enabled → interactive "check" breaks BatchMode
+#   3. sshd down or not listening on :22 → LAN + TS SSH fail
+#   4. After reboot, services need a nudge once network is up
+#
+# Policy: classic OpenSSH owns port 22. Tailscale provides the mesh only
+# (`tailscale set --ssh=false`). Do not re-enable Tailscale SSH on these hosts.
+#
+# Usage (root):
+#   pi-connectivity-heal.sh --boot|--check
+set -euo pipefail
+
+MODE="${1:---check}"
+LOG_TAG="pi-connectivity-heal"
+PEER_TS_IPS_DEFAULT="100.74.191.58 100.95.117.84"
+
+log() { echo "[$LOG_TAG] $*"; logger -t "$LOG_TAG" "$*" 2>/dev/null || true; }
+
+have() { command -v "$1" >/dev/null 2>&1; }
+
+ensure_sshd() {
+  local unit=""
+  if systemctl list-unit-files ssh.service >/dev/null 2>&1 && systemctl cat ssh.service >/dev/null 2>&1; then
+    unit=ssh.service
+  elif systemctl list-unit-files sshd.service >/dev/null 2>&1; then
+    unit=sshd.service
+  fi
+  if [[ -z "$unit" ]]; then
+    log "WARN: no ssh/sshd unit found"
+    return 1
+  fi
+  systemctl enable "$unit" >/dev/null 2>&1 || true
+  if ! systemctl is-active --quiet "$unit"; then
+    log "starting $unit"
+    systemctl start "$unit" || log "WARN: start $unit failed"
+  fi
+  # Must listen on :22 (all interfaces — includes Tailscale)
+  if ! ss -ltn 2>/dev/null | grep -qE ':22\s'; then
+    log "sshd not listening on :22 — restarting $unit"
+    systemctl restart "$unit" || true
+    sleep 1
+  fi
+  if ss -ltn 2>/dev/null | grep -qE ':22\s'; then
+    log "sshd listening on :22"
+  else
+    log "ERROR: sshd still not on :22"
+    return 1
+  fi
+}
+
+ensure_tailscale() {
+  if ! have tailscale || ! have tailscaled; then
+    log "WARN: tailscale not installed"
+    return 1
+  fi
+  systemctl enable tailscaled >/dev/null 2>&1 || true
+  if ! systemctl is-active --quiet tailscaled; then
+    log "starting tailscaled"
+    systemctl start tailscaled || log "WARN: start tailscaled failed"
+    sleep 2
+  fi
+
+  # Classic SSH only — Tailscale SSH "check" breaks automation / BatchMode.
+  local run_ssh
+  run_ssh="$(tailscale debug prefs 2>/dev/null | grep -E '"RunSSH"' | head -1 || true)"
+  if echo "$run_ssh" | grep -q 'true'; then
+    log "disabling Tailscale SSH (RunSSH=true → false)"
+    tailscale set --ssh=false || log "WARN: tailscale set --ssh=false failed"
+  fi
+
+  # Backend state
+  local state
+  state="$(tailscale status --json 2>/dev/null | python3 -c 'import json,sys
+try:
+  d=json.load(sys.stdin)
+  print(d.get("BackendState") or "")
+except Exception:
+  print("")
+' 2>/dev/null || true)"
+  if [[ "$state" != "Running" ]]; then
+    log "tailscale BackendState=${state:-unknown} — restarting tailscaled"
+    systemctl restart tailscaled || true
+    sleep 5
+    # Best-effort re-auth if a reusable key file exists (operator-managed).
+    if [[ -f /etc/cloudless/tailscale-authkey ]]; then
+      # shellcheck disable=SC1091
+      key="$(tr -d '\n' </etc/cloudless/tailscale-authkey)"
+      if [[ -n "$key" ]]; then
+        log "tailscale up with /etc/cloudless/tailscale-authkey"
+        tailscale up --auth-key="$key" --ssh=false --accept-routes --reset=false \
+          || log "WARN: tailscale up failed"
+      fi
+    fi
+  fi
+
+  local ip
+  ip="$(tailscale ip -4 2>/dev/null || true)"
+  if [[ -z "$ip" ]]; then
+    log "ERROR: no Tailscale IPv4"
+    return 1
+  fi
+  log "tailscale ok ip=$ip state=$(tailscale status --json 2>/dev/null | python3 -c 'import json,sys; print(json.load(sys.stdin).get("BackendState",""))' 2>/dev/null || echo '?')"
+}
+
+ping_peers() {
+  local peers="${PI_CONNECTIVITY_PEERS:-$PEER_TS_IPS_DEFAULT}"
+  local self
+  self="$(tailscale ip -4 2>/dev/null || true)"
+  local p
+  for p in $peers; do
+    [[ -z "$p" || "$p" == "$self" ]] && continue
+    if tailscale ping -c 1 -timeout 3s "$p" >/dev/null 2>&1; then
+      log "peer $p reachable"
+    else
+      log "WARN: peer $p unreachable via tailscale ping"
+    fi
+  done
+}
+
+case "$MODE" in
+  --boot)
+    log "boot heal"
+    sleep 8
+    ensure_tailscale || true
+    ensure_sshd || true
+    ping_peers || true
+    ;;
+  --check)
+    ensure_tailscale || true
+    ensure_sshd || true
+    # Peer ping only every check (cheap); failures are logged, not fatal.
+    ping_peers || true
+    ;;
+  *)
+    echo "Usage: $0 --boot|--check" >&2
+    exit 2
+    ;;
+esac

--- a/infrastructure/omv-ha/pi-connectivity-heal.timer
+++ b/infrastructure/omv-ha/pi-connectivity-heal.timer
@@ -1,0 +1,12 @@
+[Unit]
+Description=Run pi-connectivity-heal every 2 minutes
+
+[Timer]
+OnBootSec=1min
+OnUnitActiveSec=2min
+AccuracySec=30s
+Persistent=true
+Unit=pi-connectivity-heal-check.service
+
+[Install]
+WantedBy=timers.target

--- a/infrastructure/omv-ha/sshd-connectivity.conf
+++ b/infrastructure/omv-ha/sshd-connectivity.conf
@@ -1,0 +1,6 @@
+# Cloudless Pi connectivity — keep SSH usable during heavy builds / TS flaps.
+UseDNS no
+LoginGraceTime 60
+MaxStartups 20:50:40
+ClientAliveInterval 30
+ClientAliveCountMax 3

--- a/infrastructure/omv-ha/sshd-under-load.conf
+++ b/infrastructure/omv-ha/sshd-under-load.conf
@@ -1,0 +1,7 @@
+# Prefer sshd under heavy CI/build load on the Pi (next build pegs CPU/IO).
+[Service]
+Nice=-5
+CPUSchedulingPolicy=other
+OOMScoreAdjust=-200
+# Do not wait forever on slow disks before accepting connections
+TimeoutStartSec=30

--- a/infrastructure/omv/CONNECTIVITY.md
+++ b/infrastructure/omv/CONNECTIVITY.md
@@ -1,0 +1,92 @@
+# Pi connectivity (SSH + Tailscale)
+
+Classic **OpenSSH** over the Tailscale mesh — **not** Tailscale SSH.
+
+## Why Tailscale SSH was disabled
+
+With `tailscale set --ssh=true`, port 22 on the 100.x address speaks the
+Tailscale SSH protocol and often requires an interactive browser “check”.
+That breaks `BatchMode`, GitHub Actions deploy proxy SSH, and operator
+automation. Both Pis run:
+
+```bash
+sudo tailscale set --ssh=false
+```
+
+`sshd` still listens on `0.0.0.0:22` (LAN + Tailscale interface).
+
+## Hosts
+
+| Name | LAN | Tailscale | Role |
+|------|-----|-----------|------|
+| omv / github-omv | 192.168.1.128 | 100.74.191.58 | k3s + build runners |
+| omv-ha | 192.168.1.130 | 100.95.117.84 | mail + deploy-pi rollout runner |
+
+## Firewall + Tailscale ACL
+
+### Host firewall
+
+| Host | Tool | SSH policy |
+|------|------|------------|
+| omv | ufw | `ALLOW` from `100.64.0.0/10` + `192.168.1.0/24` on :22 **before** public `LIMIT` |
+| omv-ha | nftables `inet cloudless_fw` | accept :22 from LAN + Tailscale CGNAT; accept `tailscale0` |
+
+Install/refresh:
+
+```bash
+sudo bash infrastructure/omv/configure-pi-firewall.sh
+```
+
+### Tailscale ACL (`infrastructure/tailscale/acl-policy.example.json`)
+
+- **`tag:pi`** — github-omv + omv-ha (not `tag:app-connector`; that tag only grants members DNS)
+- **grants:** members → `tag:pi` `tcp:22` (+ icmp); admins → `tag:pi` `*`
+- **`ssh` block:** `action: accept` only (no check-mode) so BatchMode never needs a browser if RunSSH is ever re-enabled
+- Pis still run `tailscale set --ssh=false` (classic OpenSSH)
+
+Apply:
+
+```bash
+gh workflow run tailscale-admin-api.yml -f dry_run=false -f acl_only=true
+# workflow also runs scripts/tailscale-retag-pi-hosts.sh
+```
+
+## Client SSH config
+
+Copy [`ssh-config.pi.example`](./ssh-config.pi.example) into `~/.ssh/config`
+(or `Include` it). Fallback helper:
+
+```bash
+scripts/ssh-pi.sh omv hostname
+scripts/ssh-pi.sh omv-ha uptime
+```
+
+## Connectivity heal (on each Pi)
+
+Installed by `install-pi-connectivity-heal.sh`:
+
+- Boot oneshot + every **2 minutes**
+- Ensures `tailscaled` Running, forces `--ssh=false`
+- Ensures `ssh`/`sshd` listening on `:22`
+- Optional re-auth via `/etc/cloudless/tailscale-authkey` (operator-managed reusable key)
+- `sshd` systemd Nice=-5 so banner exchange still works during `next build`
+
+```bash
+# From a machine with LAN or working SSH:
+for host in 192.168.1.128 192.168.1.130; do
+  scp infrastructure/omv/pi-connectivity-heal* \
+      infrastructure/omv/sshd-*.conf \
+      infrastructure/omv/install-pi-connectivity-heal.sh \
+      tbaltzakis@$host:/tmp/pi-conn/
+  ssh tbaltzakis@$host 'sudo bash /tmp/pi-conn/install-pi-connectivity-heal.sh'
+done
+```
+
+Manual tick: `sudo /usr/local/sbin/pi-connectivity-heal.sh --check`  
+Logs: `journalctl -t pi-connectivity-heal -n 50`
+
+## When SSH times out under load
+
+omv can miss the SSH banner while a full Next standalone build pegs CPU.
+Use LAN (`omv-lan`) or wait; heal + sshd Nice drop-in reduce this. Do not
+re-enable Tailscale SSH as a workaround.

--- a/infrastructure/omv/configure-pi-firewall.sh
+++ b/infrastructure/omv/configure-pi-firewall.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+# configure-pi-firewall.sh — SSH-safe host firewall for omv / omv-ha.
+#
+# Goals (per Tailscale docs: classic OpenSSH over the mesh, not Tailscale SSH):
+#   - Allow SSH from Tailscale CGNAT (100.64.0.0/10) WITHOUT ufw rate-limit
+#   - Allow SSH from LAN 192.168.1.0/24 without rate-limit
+#   - Keep public SSH rate-limited (omv) or closed (omv-ha preference)
+#   - Always allow Tailscale UDP 41641 + established
+#
+# Run as root on the Pi:
+#   sudo bash configure-pi-firewall.sh
+set -euo pipefail
+[ "$EUID" = "0" ] || { echo "must be root" >&2; exit 1; }
+
+LAN_CIDR="${PI_LAN_CIDR:-192.168.1.0/24}"
+TS_CGNAT="100.64.0.0/10"
+HOST="$(hostname -s 2>/dev/null || hostname)"
+
+echo "[fw] host=$HOST"
+
+if command -v ufw >/dev/null 2>&1; then
+  echo "[fw] configuring ufw"
+  ufw --force enable || true
+
+  # Specific allows MUST precede any LIMIT Anywhere (ufw first-match wins).
+  while ufw status numbered | grep -qE 'cloudless-ssh-ts|cloudless-ssh-lan|cloudless-ssh-public|22/tcp.*LIMIT'; do
+    NUM=$(ufw status numbered | grep -E 'cloudless-ssh-ts|cloudless-ssh-lan|cloudless-ssh-public|22/tcp.*LIMIT' | head -1 | sed -n 's/^\[\s*\([0-9]*\)\].*/\1/p')
+    [[ -z "$NUM" ]] && break
+    yes | ufw delete "$NUM" >/dev/null || break
+  done
+
+  ufw insert 1 allow from "$TS_CGNAT" to any port 22 proto tcp comment 'cloudless-ssh-ts'
+  ufw insert 2 allow from "$LAN_CIDR" to any port 22 proto tcp comment 'cloudless-ssh-lan'
+  ufw limit 22/tcp comment 'cloudless-ssh-public-limit'
+
+  # Broad Tailscale allow (non-SSH) if missing
+  if ! ufw status | grep -qF '100.64.0.0/10'; then
+    ufw allow from "$TS_CGNAT" comment 'cloudless-tailscale-net' || true
+  fi
+  if ! ufw status | grep -q '41641/udp'; then
+    ufw allow 41641/udp comment 'cloudless-tailscale-wireguard' || true
+  fi
+
+  # Avoid full reload mid-session when possible — enable is enough if already active
+  ufw status verbose | head -40
+else
+  echo "[fw] no ufw — installing nftables SSH allow set (omv-ha style)"
+  command -v nft >/dev/null || { echo "nft not found"; exit 1; }
+
+  nft list table inet cloudless_fw >/dev/null 2>&1 && nft delete table inet cloudless_fw || true
+  nft -f - <<EOF
+table inet cloudless_fw {
+  chain input {
+    type filter hook input priority -10; policy accept;
+    ct state established,related accept
+    iifname "lo" accept
+    iifname "tailscale0" accept
+    udp dport 41641 accept
+    tcp dport 22 ip saddr ${LAN_CIDR} accept
+    tcp dport 22 ip saddr ${TS_CGNAT} accept
+  }
+}
+EOF
+  echo "[fw] nft table inet cloudless_fw installed"
+  nft list table inet cloudless_fw
+fi
+
+# Tailscale SSH stays off — classic sshd only
+if command -v tailscale >/dev/null 2>&1; then
+  tailscale set --ssh=false || true
+fi
+
+echo "[fw] done"

--- a/infrastructure/omv/install-pi-connectivity-heal.sh
+++ b/infrastructure/omv/install-pi-connectivity-heal.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+# install-pi-connectivity-heal.sh — install connectivity heal + sshd priority drop-in.
+#
+# Run as root on omv or omv-ha:
+#   sudo bash infrastructure/omv/install-pi-connectivity-heal.sh
+set -euo pipefail
+[ "$EUID" = "0" ] || { echo "must be root" >&2; exit 1; }
+
+REPO_DIR="$(dirname "$(readlink -f "$0")")"
+SCRIPT="$REPO_DIR/pi-connectivity-heal.sh"
+BOOT_SVC="$REPO_DIR/pi-connectivity-heal.service"
+CHECK_SVC="$REPO_DIR/pi-connectivity-heal-check.service"
+TIMER="$REPO_DIR/pi-connectivity-heal.timer"
+SSHD_DROPIN_SRC="$REPO_DIR/sshd-under-load.conf"
+
+for f in "$SCRIPT" "$BOOT_SVC" "$CHECK_SVC" "$TIMER"; do
+  [ -f "$f" ] || { echo "missing: $f" >&2; exit 1; }
+done
+
+install -m 755 -o root -g root "$SCRIPT"    /usr/local/sbin/pi-connectivity-heal.sh
+install -m 644 -o root -g root "$BOOT_SVC"  /etc/systemd/system/pi-connectivity-heal.service
+install -m 644 -o root -g root "$CHECK_SVC" /etc/systemd/system/pi-connectivity-heal-check.service
+install -m 644 -o root -g root "$TIMER"     /etc/systemd/system/pi-connectivity-heal.timer
+
+# Keep OpenSSH responsive when next-build pegs the Pi CPU.
+if [ -f "$SSHD_DROPIN_SRC" ]; then
+  mkdir -p /etc/systemd/system/ssh.service.d /etc/systemd/system/sshd.service.d
+  install -m 644 -o root -g root "$SSHD_DROPIN_SRC" /etc/systemd/system/ssh.service.d/under-load.conf
+  install -m 644 -o root -g root "$SSHD_DROPIN_SRC" /etc/systemd/system/sshd.service.d/under-load.conf
+fi
+if [ -f "$REPO_DIR/sshd-connectivity.conf" ]; then
+  install -m 644 -o root -g root "$REPO_DIR/sshd-connectivity.conf" \
+    /etc/ssh/sshd_config.d/99-cloudless-connectivity.conf
+fi
+
+# Hardened tailscaled restart policy
+mkdir -p /etc/systemd/system/tailscaled.service.d
+cat > /etc/systemd/system/tailscaled.service.d/restart.conf <<'EOF'
+[Service]
+Restart=always
+RestartSec=5s
+StartLimitIntervalSec=0
+EOF
+
+# Policy: classic SSH only
+if command -v tailscale >/dev/null 2>&1; then
+  tailscale set --ssh=false || true
+fi
+
+systemctl daemon-reload
+# Reload sshd config if possible
+systemctl try-reload-or-restart ssh.service 2>/dev/null \
+  || systemctl try-reload-or-restart sshd.service 2>/dev/null \
+  || true
+
+systemctl enable pi-connectivity-heal.service
+systemctl enable --now pi-connectivity-heal.timer
+systemctl start pi-connectivity-heal-check.service || true
+
+echo "[install] pi-connectivity-heal enabled"
+systemctl --no-pager status pi-connectivity-heal.timer || true
+/usr/local/sbin/pi-connectivity-heal.sh --check || true
+echo "[install] done — journalctl -t pi-connectivity-heal -n 40"

--- a/infrastructure/omv/pi-connectivity-heal-check.service
+++ b/infrastructure/omv/pi-connectivity-heal-check.service
@@ -1,0 +1,7 @@
+[Unit]
+Description=Periodic Tailscale + OpenSSH connectivity heal
+After=network-online.target
+
+[Service]
+Type=oneshot
+ExecStart=/usr/local/sbin/pi-connectivity-heal.sh --check

--- a/infrastructure/omv/pi-connectivity-heal.service
+++ b/infrastructure/omv/pi-connectivity-heal.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=Heal Tailscale + OpenSSH connectivity after boot
+After=network-online.target tailscaled.service
+Wants=network-online.target
+
+[Service]
+Type=oneshot
+ExecStart=/usr/local/sbin/pi-connectivity-heal.sh --boot
+
+[Install]
+WantedBy=multi-user.target

--- a/infrastructure/omv/pi-connectivity-heal.sh
+++ b/infrastructure/omv/pi-connectivity-heal.sh
@@ -1,0 +1,142 @@
+#!/usr/bin/env bash
+# pi-connectivity-heal.sh — keep Tailscale + classic OpenSSH reachable on a Pi.
+#
+# Problem modes this addresses:
+#   1. tailscaled dead / logged out → no MagicDNS / no 100.x path
+#   2. Tailscale SSH (RunSSH) re-enabled → interactive "check" breaks BatchMode
+#   3. sshd down or not listening on :22 → LAN + TS SSH fail
+#   4. After reboot, services need a nudge once network is up
+#
+# Policy: classic OpenSSH owns port 22. Tailscale provides the mesh only
+# (`tailscale set --ssh=false`). Do not re-enable Tailscale SSH on these hosts.
+#
+# Usage (root):
+#   pi-connectivity-heal.sh --boot|--check
+set -euo pipefail
+
+MODE="${1:---check}"
+LOG_TAG="pi-connectivity-heal"
+PEER_TS_IPS_DEFAULT="100.74.191.58 100.95.117.84"
+
+log() { echo "[$LOG_TAG] $*"; logger -t "$LOG_TAG" "$*" 2>/dev/null || true; }
+
+have() { command -v "$1" >/dev/null 2>&1; }
+
+ensure_sshd() {
+  local unit=""
+  if systemctl list-unit-files ssh.service >/dev/null 2>&1 && systemctl cat ssh.service >/dev/null 2>&1; then
+    unit=ssh.service
+  elif systemctl list-unit-files sshd.service >/dev/null 2>&1; then
+    unit=sshd.service
+  fi
+  if [[ -z "$unit" ]]; then
+    log "WARN: no ssh/sshd unit found"
+    return 1
+  fi
+  systemctl enable "$unit" >/dev/null 2>&1 || true
+  if ! systemctl is-active --quiet "$unit"; then
+    log "starting $unit"
+    systemctl start "$unit" || log "WARN: start $unit failed"
+  fi
+  # Must listen on :22 (all interfaces — includes Tailscale)
+  if ! ss -ltn 2>/dev/null | grep -qE ':22\s'; then
+    log "sshd not listening on :22 — restarting $unit"
+    systemctl restart "$unit" || true
+    sleep 1
+  fi
+  if ss -ltn 2>/dev/null | grep -qE ':22\s'; then
+    log "sshd listening on :22"
+  else
+    log "ERROR: sshd still not on :22"
+    return 1
+  fi
+}
+
+ensure_tailscale() {
+  if ! have tailscale || ! have tailscaled; then
+    log "WARN: tailscale not installed"
+    return 1
+  fi
+  systemctl enable tailscaled >/dev/null 2>&1 || true
+  if ! systemctl is-active --quiet tailscaled; then
+    log "starting tailscaled"
+    systemctl start tailscaled || log "WARN: start tailscaled failed"
+    sleep 2
+  fi
+
+  # Classic SSH only — Tailscale SSH "check" breaks automation / BatchMode.
+  local run_ssh
+  run_ssh="$(tailscale debug prefs 2>/dev/null | grep -E '"RunSSH"' | head -1 || true)"
+  if echo "$run_ssh" | grep -q 'true'; then
+    log "disabling Tailscale SSH (RunSSH=true → false)"
+    tailscale set --ssh=false || log "WARN: tailscale set --ssh=false failed"
+  fi
+
+  # Backend state
+  local state
+  state="$(tailscale status --json 2>/dev/null | python3 -c 'import json,sys
+try:
+  d=json.load(sys.stdin)
+  print(d.get("BackendState") or "")
+except Exception:
+  print("")
+' 2>/dev/null || true)"
+  if [[ "$state" != "Running" ]]; then
+    log "tailscale BackendState=${state:-unknown} — restarting tailscaled"
+    systemctl restart tailscaled || true
+    sleep 5
+    # Best-effort re-auth if a reusable key file exists (operator-managed).
+    if [[ -f /etc/cloudless/tailscale-authkey ]]; then
+      # shellcheck disable=SC1091
+      key="$(tr -d '\n' </etc/cloudless/tailscale-authkey)"
+      if [[ -n "$key" ]]; then
+        log "tailscale up with /etc/cloudless/tailscale-authkey"
+        tailscale up --auth-key="$key" --ssh=false --accept-routes --reset=false \
+          || log "WARN: tailscale up failed"
+      fi
+    fi
+  fi
+
+  local ip
+  ip="$(tailscale ip -4 2>/dev/null || true)"
+  if [[ -z "$ip" ]]; then
+    log "ERROR: no Tailscale IPv4"
+    return 1
+  fi
+  log "tailscale ok ip=$ip state=$(tailscale status --json 2>/dev/null | python3 -c 'import json,sys; print(json.load(sys.stdin).get("BackendState",""))' 2>/dev/null || echo '?')"
+}
+
+ping_peers() {
+  local peers="${PI_CONNECTIVITY_PEERS:-$PEER_TS_IPS_DEFAULT}"
+  local self
+  self="$(tailscale ip -4 2>/dev/null || true)"
+  local p
+  for p in $peers; do
+    [[ -z "$p" || "$p" == "$self" ]] && continue
+    if tailscale ping -c 1 -timeout 3s "$p" >/dev/null 2>&1; then
+      log "peer $p reachable"
+    else
+      log "WARN: peer $p unreachable via tailscale ping"
+    fi
+  done
+}
+
+case "$MODE" in
+  --boot)
+    log "boot heal"
+    sleep 8
+    ensure_tailscale || true
+    ensure_sshd || true
+    ping_peers || true
+    ;;
+  --check)
+    ensure_tailscale || true
+    ensure_sshd || true
+    # Peer ping only every check (cheap); failures are logged, not fatal.
+    ping_peers || true
+    ;;
+  *)
+    echo "Usage: $0 --boot|--check" >&2
+    exit 2
+    ;;
+esac

--- a/infrastructure/omv/pi-connectivity-heal.timer
+++ b/infrastructure/omv/pi-connectivity-heal.timer
@@ -1,0 +1,12 @@
+[Unit]
+Description=Run pi-connectivity-heal every 2 minutes
+
+[Timer]
+OnBootSec=1min
+OnUnitActiveSec=2min
+AccuracySec=30s
+Persistent=true
+Unit=pi-connectivity-heal-check.service
+
+[Install]
+WantedBy=timers.target

--- a/infrastructure/omv/ssh-config.pi.example
+++ b/infrastructure/omv/ssh-config.pi.example
@@ -1,0 +1,41 @@
+# Cloudless Pi hosts — classic OpenSSH over Tailscale (not Tailscale SSH).
+# Install snippet: append to ~/.ssh/config or `Include` this file.
+#
+# Policy: Tailscale SSH (RunSSH) is DISABLED on the Pis so BatchMode / CI keys work.
+# Connectivity heal: infrastructure/omv/pi-connectivity-heal.sh
+
+Host omv github-omv
+    HostName 100.74.191.58
+    User tbaltzakis
+    IdentityFile ~/.ssh/id_rsa
+    IdentitiesOnly yes
+    ConnectTimeout 12
+    ServerAliveInterval 15
+    ServerAliveCountMax 3
+    StrictHostKeyChecking accept-new
+
+Host omv-lan
+    HostName 192.168.1.128
+    User tbaltzakis
+    IdentityFile ~/.ssh/id_rsa
+    IdentitiesOnly yes
+    ConnectTimeout 8
+    StrictHostKeyChecking accept-new
+
+Host omv-ha
+    HostName 100.95.117.84
+    User tbaltzakis
+    IdentityFile ~/.ssh/id_rsa
+    IdentitiesOnly yes
+    ConnectTimeout 12
+    ServerAliveInterval 15
+    ServerAliveCountMax 3
+    StrictHostKeyChecking accept-new
+
+Host omv-ha-lan
+    HostName 192.168.1.130
+    User tbaltzakis
+    IdentityFile ~/.ssh/id_rsa
+    IdentitiesOnly yes
+    ConnectTimeout 8
+    StrictHostKeyChecking accept-new

--- a/infrastructure/omv/sshd-connectivity.conf
+++ b/infrastructure/omv/sshd-connectivity.conf
@@ -1,0 +1,6 @@
+# Cloudless Pi connectivity — keep SSH usable during heavy builds / TS flaps.
+UseDNS no
+LoginGraceTime 60
+MaxStartups 20:50:40
+ClientAliveInterval 30
+ClientAliveCountMax 3

--- a/infrastructure/omv/sshd-under-load.conf
+++ b/infrastructure/omv/sshd-under-load.conf
@@ -1,0 +1,7 @@
+# Prefer sshd under heavy CI/build load on the Pi (next build pegs CPU/IO).
+[Service]
+Nice=-5
+CPUSchedulingPolicy=other
+OOMScoreAdjust=-200
+# Do not wait forever on slow disks before accepting connections
+TimeoutStartSec=30

--- a/infrastructure/tailscale/acl-policy.example.json
+++ b/infrastructure/tailscale/acl-policy.example.json
@@ -8,6 +8,9 @@
     ],
     "tag:app-connector": [
       "autogroup:admin"
+    ],
+    "tag:pi": [
+      "autogroup:admin"
     ]
   },
   "autoApprovers": {
@@ -37,7 +40,17 @@
   "grants": [
     {
       "src": ["autogroup:admin"],
-      "dst": ["tag:k8s", "tag:k8s-operator", "tag:app-connector"],
+      "dst": ["tag:k8s", "tag:k8s-operator", "tag:app-connector", "tag:pi"],
+      "ip": ["*"]
+    },
+    {
+      "src": ["autogroup:member"],
+      "dst": ["tag:pi"],
+      "ip": ["tcp:22", "icmp", "icmpv6"]
+    },
+    {
+      "src": ["tag:pi"],
+      "dst": ["tag:pi"],
       "ip": ["*"]
     },
     {
@@ -64,15 +77,9 @@
   "ssh": [
     {
       "action": "accept",
-      "src": ["autogroup:admin"],
-      "dst": ["autogroup:self", "tag:app-connector", "tag:k8s", "tag:k8s-operator"],
-      "users": ["autogroup:nonroot", "root", "tbaltzakis"]
-    },
-    {
-      "action": "check",
-      "src": ["autogroup:member"],
-      "dst": ["autogroup:self"],
-      "users": ["autogroup:nonroot", "root"]
+      "src": ["autogroup:admin", "autogroup:member"],
+      "dst": ["tag:pi", "autogroup:self"],
+      "users": ["autogroup:nonroot", "tbaltzakis", "root"]
     }
   ],
   "nodeAttrs": [

--- a/scripts/ssh-pi.sh
+++ b/scripts/ssh-pi.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# ssh-pi.sh — SSH to omv / omv-ha preferring Tailscale, falling back to LAN.
+#
+# Usage:
+#   scripts/ssh-pi.sh omv 'hostname'
+#   scripts/ssh-pi.sh omv-ha
+#   scripts/ssh-pi.sh github-omv uptime
+set -euo pipefail
+
+TARGET="${1:?usage: $0 omv|omv-ha|github-omv [remote-cmd...]}"
+shift || true
+
+case "$TARGET" in
+  omv|github-omv|OMV)
+    TS_HOST=100.74.191.58
+    LAN_HOST=192.168.1.128
+    ;;
+  omv-ha|OMV-HA|ha)
+    TS_HOST=100.95.117.84
+    LAN_HOST=192.168.1.130
+    ;;
+  *)
+    echo "unknown host: $TARGET (expected omv|omv-ha)" >&2
+    exit 2
+    ;;
+esac
+
+USER_NAME="${PI_SSH_USER:-tbaltzakis}"
+IDENTITY="${PI_SSH_IDENTITY:-$HOME/.ssh/id_rsa}"
+SSH_BASE=(ssh -o BatchMode=yes -o StrictHostKeyChecking=accept-new
+  -o IdentitiesOnly=yes -i "$IDENTITY" -o ConnectTimeout=8)
+
+try() {
+  local host="$1"
+  "${SSH_BASE[@]}" "${USER_NAME}@${host}" "$@"
+}
+
+if try "$TS_HOST" true 2>/dev/null; then
+  exec "${SSH_BASE[@]}" "${USER_NAME}@${TS_HOST}" "$@"
+fi
+echo "[ssh-pi] Tailscale $TS_HOST failed — trying LAN $LAN_HOST" >&2
+exec "${SSH_BASE[@]}" "${USER_NAME}@${LAN_HOST}" "$@"

--- a/scripts/tailscale-retag-pi-hosts.sh
+++ b/scripts/tailscale-retag-pi-hosts.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+# Retag Pi hosts to tag:pi and ensure ACL grants classic SSH (tcp:22).
+# Auth: same as scripts/tailscale-admin-api.sh (OAuth or API key).
+#
+# Usage:
+#   bash scripts/tailscale-retag-pi-hosts.sh
+#   DRY_RUN=1 bash scripts/tailscale-retag-pi-hosts.sh
+set -euo pipefail
+
+TAILNET="${TAILSCALE_TAILNET:-tail4ecae1.ts.net}"
+API="${TAILSCALE_API_BASE:-https://api.tailscale.com/api/v2}"
+DRY_RUN="${DRY_RUN:-0}"
+case "${DRY_RUN}" in 1|true|TRUE|yes|YES) DRY_RUN=1 ;; *) DRY_RUN=0 ;; esac
+
+# hostname short → desired tags (replaces previous tag set)
+declare -A WANT_TAGS=(
+  [github-omv]='["tag:pi"]'
+  [omv-ha]='["tag:pi"]'
+)
+
+need() { command -v "$1" >/dev/null || { echo "missing $1"; exit 1; }; }
+need curl
+need jq
+
+auth_header() {
+  if [[ -n "${TS_API_KEY:-}" ]]; then
+    echo "Authorization: Basic $(printf '%s:' "$TS_API_KEY" | base64 -w0 2>/dev/null || printf '%s:' "$TS_API_KEY" | base64)"
+    return
+  fi
+  local id="${TS_CLIENT_ID:-${TAILSCALE_OAUTH_CLIENT_ID:-}}"
+  local secret="${TS_CLIENT_SECRET:-${TAILSCALE_OAUTH_CLIENT_SECRET:-${TAILSCALE_OAUTH_SECRET:-}}}"
+  if [[ -z "$id" || -z "$secret" ]]; then
+    echo "Set TS_API_KEY or TS_CLIENT_ID+TS_CLIENT_SECRET" >&2
+    exit 2
+  fi
+  local tok
+  tok=$(curl -fsS -u "${id}:${secret}" \
+    -d grant_type=client_credentials \
+    "$API/oauth/token" | jq -r .access_token)
+  [[ -n "$tok" && "$tok" != null ]] || { echo "OAuth failed" >&2; exit 2; }
+  echo "Authorization: Bearer $tok"
+}
+
+AUTH="$(auth_header)"
+echo "==> Listing devices on $TAILNET"
+DEVICES=$(curl -fsS -H "$AUTH" -H 'Accept: application/json' "$API/tailnet/$TAILNET/devices")
+
+for short in "${!WANT_TAGS[@]}"; do
+  tags_json="${WANT_TAGS[$short]}"
+  row=$(echo "$DEVICES" | jq -c --arg h "$short" '
+    .devices[] | select((.hostname|split(".")[0]) == $h or (.name|split(".")[0]) == $h) | {id,hostname,tags}
+  ' | head -1)
+  if [[ -z "$row" ]]; then
+    echo "WARN: device $short not found"
+    continue
+  fi
+  did=$(echo "$row" | jq -r .id)
+  cur=$(echo "$row" | jq -c .tags)
+  echo "DEVICE $short id=$did current_tags=$cur → $tags_json"
+  if [[ "$DRY_RUN" == "1" ]]; then
+    echo "  DRY_RUN skip POST tags"
+    continue
+  fi
+  HTTP=$(curl -sS -o /tmp/ts-tags-out.json -w '%{http_code}' \
+    -X POST -H "$AUTH" -H 'Content-Type: application/json' \
+    "$API/device/$did/tags" \
+    --data-binary "{\"tags\": $tags_json}")
+  echo "  POST tags HTTP $HTTP $(head -c 200 /tmp/ts-tags-out.json)"
+  [[ "$HTTP" == "200" ]] || exit 1
+done
+
+echo "==> Done"


### PR DESCRIPTION
## Summary
- **ACL:** add `tag:pi` for github-omv/omv-ha; members get `tcp:22`; remove Tailscale SSH **check** rules (BatchMode-safe `accept` only). `github-omv` was on `tag:app-connector` (members only DNS).
- **Firewall:** omv UFW — SSH from Tailscale/LAN before public LIMIT; omv-ha nft `cloudless_fw` allow :22 from LAN+CGNAT.
- **Heal:** boot + 2‑min `pi-connectivity-heal` keeps `tailscale set --ssh=false` and sshd up; `ssh-pi.sh` TS→LAN fallback.
- Workflow `tailscale-admin-api` also runs `tailscale-retag-pi-hosts.sh` after ACL merge.

## Test plan
- [ ] `gh workflow run tailscale-admin-api.yml -f dry_run=false -f acl_only=true` succeeds
- [ ] Devices github-omv + omv-ha show `tag:pi`
- [ ] `ssh omv` / `ssh omv-ha` (Tailscale) and `ssh omv-lan` / `ssh omv-ha-lan` work with BatchMode


Made with [Cursor](https://cursor.com)