### PR TITLE
Fix Tailscale ACL icmp grant syntax

### DIFF
--- a/infrastructure/tailscale/acl-policy.example.json
+++ b/infrastructure/tailscale/acl-policy.example.json
@@ -46,7 +46,7 @@
     {
       "src": ["autogroup:member"],
       "dst": ["tag:pi"],
-      "ip": ["tcp:22", "icmp", "icmpv6"]
+      "ip": ["tcp:22"]
     },
     {
       "src": ["tag:pi"],


### PR DESCRIPTION
## Summary
- Tailscale rejected `ip: [\"icmp\"]` with HTTP 400; member→tag:pi grant is now `tcp:22` only.

## Test plan
- [ ] Re-run `tailscale-admin-api.yml` acl_only — ACL POST 200 + retag succeeds


Made with [Cursor](https://cursor.com)