### PR TITLE
Restore Pi connectivity remedy (local + Actions)

### DIFF
--- a/.github/workflows/restore-pi-connectivity.yml
+++ b/.github/workflows/restore-pi-connectivity.yml
@@ -1,0 +1,190 @@
+name: Restore Pi connectivity (SSH + Tailscale)
+
+# Operator remedy when omv / omv-ha SSH or Tailscale breaks.
+# Runs on ubuntu-latest (does not need Pi runners). Joins the tailnet, SSHes
+# to both Pis (Tailscale IP then LAN), runs on-box heal, forces
+# `tailscale set --ssh=false`, restarts sshd + GHA runners.
+#
+#   gh workflow run restore-pi-connectivity.yml
+#
+# Local equivalent (when you still have LAN or partial TS):
+#   bash scripts/restore-pi-connectivity.sh
+
+on:
+  workflow_dispatch:
+    inputs:
+      target:
+        description: Which Pi(s) to restore
+        type: choice
+        options:
+        - both
+        - omv
+        - omv-ha
+        default: both
+      restart_tailscaled:
+        description: Restart tailscaled on each host (heavier)
+        type: boolean
+        default: true
+
+permissions:
+  contents: read
+  issues: write
+
+concurrency:
+  group: restore-pi-connectivity
+  cancel-in-progress: true
+
+jobs:
+  restore:
+    name: Restore connectivity
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    env:
+      GH_TOKEN: ${{ github.token }}
+      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+    steps:
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd         # v4.3.1
+
+    - name: Connect to tailnet
+      uses: tailscale/github-action@0263d9e6d793eaefcf1de98ff7fde47abe6664d3         # v3.2.4
+      with:
+        oauth-client-id: ${{ secrets.TS_CLIENT_ID }}
+        oauth-secret: ${{ secrets.TS_CLIENT_SECRET }}
+
+    - name: Set up SSH key
+      run: |
+        set -euo pipefail
+        mkdir -p ~/.ssh
+        printf '%s\n' "${{ secrets.OMV_SSH_KEY }}" > ~/.ssh/id_ed25519
+        chmod 600 ~/.ssh/id_ed25519
+        for h in 100.74.191.58 100.95.117.84 192.168.1.128 192.168.1.130; do
+          ssh-keyscan -H -T 5 "$h" >> ~/.ssh/known_hosts 2>/dev/null || true
+        done
+
+    - name: Restore Pis
+      env:
+        TARGET: ${{ inputs.target }}
+        RESTART_TS: ${{ inputs.restart_tailscaled }}
+      run: |
+        set -euo pipefail
+        SSH=(ssh -i ~/.ssh/id_ed25519 -o BatchMode=yes -o StrictHostKeyChecking=accept-new
+          -o ConnectTimeout=15 -o ServerAliveInterval=10)
+
+        try_host() {
+          local label="$1" ts="$2" lan="$3"
+          echo "::group::Probe $label" >&2
+          if "${SSH[@]}" "tbaltzakis@${ts}" true 2>/dev/null; then
+            echo "path=$ts (tailscale)" >&2
+            echo "::endgroup::" >&2
+            echo "$ts"
+            return 0
+          fi
+          if "${SSH[@]}" "tbaltzakis@${lan}" true 2>/dev/null; then
+            echo "path=$lan (lan)" >&2
+            echo "::endgroup::" >&2
+            echo "$lan"
+            return 0
+          fi
+          echo "::warning::$label unreachable on $ts and $lan" >&2
+          echo "::endgroup::" >&2
+          return 1
+        }
+
+        restore_one() {
+          local label="$1" addr="$2"
+          echo "::group::Restore $label via $addr"
+          "${SSH[@]}" "tbaltzakis@${addr}" bash -s <<EOS
+        set -euo pipefail
+        echo "host=\$(hostname) restart_ts=${RESTART_TS}"
+        if [ "${RESTART_TS}" = "true" ]; then
+          sudo systemctl restart tailscaled || true
+          sleep 5
+        fi
+        # CRITICAL: classic OpenSSH only — never --ssh / --accept-ssh
+        sudo tailscale set --ssh=false || true
+        if [ -x /usr/local/sbin/pi-connectivity-heal.sh ]; then
+          sudo /usr/local/sbin/pi-connectivity-heal.sh --boot || \\
+            sudo /usr/local/sbin/pi-connectivity-heal.sh --check || true
+        else
+          sudo systemctl restart ssh 2>/dev/null || sudo systemctl restart sshd 2>/dev/null || true
+        fi
+        sudo tailscale set --ssh=false || true
+        if [ -x /usr/local/sbin/gha-runner-heal.sh ]; then
+          sudo /usr/local/sbin/gha-runner-heal.sh --boot || true
+        else
+          for u in \$(systemctl list-units --type=service --all --no-legend 'actions.runner.*' 2>/dev/null | awk '{print \$1}'); do
+            sudo systemctl restart "\$u" || true
+          done
+        fi
+        echo "---"
+        systemctl is-active ssh sshd tailscaled 2>/dev/null || true
+        tailscale ip -4 2>/dev/null || true
+        tailscale debug prefs 2>/dev/null | grep RunSSH || true
+        ss -ltn | grep ':22 ' || true
+        EOS
+          echo "::endgroup::"
+        }
+
+        FAILED=0
+        if [ "$TARGET" = "both" ] || [ "$TARGET" = "omv-ha" ]; then
+          if ADDR=$(try_host omv-ha 100.95.117.84 192.168.1.130); then
+            restore_one omv-ha "$ADDR" || FAILED=1
+          else
+            FAILED=1
+          fi
+        fi
+        if [ "$TARGET" = "both" ] || [ "$TARGET" = "omv" ]; then
+          if ADDR=$(try_host omv 100.74.191.58 192.168.1.128); then
+            restore_one omv "$ADDR" || FAILED=1
+          else
+            # Jump via ha if possible
+            if HA=$(try_host omv-ha 100.95.117.84 192.168.1.130); then
+              echo "::group::Restore omv via omv-ha jump"
+              if ! "${SSH[@]}" "tbaltzakis@${HA}" bash -s <<'JUMP'
+set -euo pipefail
+KEY=""
+[ -f "$HOME/.ssh/omv_ha" ] && KEY="-i $HOME/.ssh/omv_ha"
+# shellcheck disable=SC2086
+ssh $KEY -o BatchMode=yes -o ConnectTimeout=25 tbaltzakis@192.168.1.128 '
+  sudo tailscale set --ssh=false || true
+  if [ -x /usr/local/sbin/pi-connectivity-heal.sh ]; then sudo /usr/local/sbin/pi-connectivity-heal.sh --boot || true; fi
+  sudo systemctl restart ssh 2>/dev/null || sudo systemctl restart sshd 2>/dev/null || true
+  if [ -x /usr/local/sbin/gha-runner-heal.sh ]; then sudo /usr/local/sbin/gha-runner-heal.sh --boot || true; fi
+  hostname; tailscale ip -4
+'
+JUMP
+              then
+                FAILED=1
+              fi
+              echo "::endgroup::"
+            else
+              FAILED=1
+            fi
+          fi
+        fi
+
+        echo "::group::Final probes"
+        for pair in "omv:100.74.191.58" "omv-ha:100.95.117.84"; do
+          name=${pair%%:*}; ip=${pair##*:}
+          if "${SSH[@]}" "tbaltzakis@${ip}" "hostname; tailscale debug prefs 2>/dev/null | grep RunSSH" ; then
+            echo "OK $name TS $ip"
+          else
+            echo "FAIL $name TS $ip"
+            FAILED=1
+          fi
+        done
+        echo "::endgroup::"
+        exit "$FAILED"
+
+    - name: Post result to issue 382
+      if: always()
+      run: |
+        {
+          echo "# restore-pi-connectivity — $(date -u '+%Y-%m-%d %H:%M:%SZ')"
+          echo ""
+          echo "**Job:** ${{ job.status }} · target=\`${{ inputs.target }}\` · restart_tailscaled=\`${{ inputs.restart_tailscaled }}\`"
+          echo ""
+          echo "Run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          echo ""
+          echo "Local remedy: \`bash scripts/restore-pi-connectivity.sh\`"
+        } | gh issue comment 382 --repo "$GITHUB_REPOSITORY" --body-file - || true

--- a/.github/workflows/tailscale-reconnect-agent.yml
+++ b/.github/workflows/tailscale-reconnect-agent.yml
@@ -69,9 +69,10 @@ jobs:
         ssh-keyscan -H 192.168.1.128 >> ~/.ssh/known_hosts 2>/dev/null || true
 
         # Try LAN SSH (Pi may be online locally but off tailnet)
+        # Classic OpenSSH only — do NOT pass --accept-ssh / --ssh (breaks BatchMode).
         ssh -i ~/.ssh/id_ed25519 -o StrictHostKeyChecking=no -o ConnectTimeout=10 \
           tbaltzakis@192.168.1.128 \
-          "sudo systemctl restart tailscaled && sudo tailscale up --accept-routes --accept-dns --accept-ssh && echo 'tailscaled restarted on Pi host'" 2>&1 || {
+          "sudo systemctl restart tailscaled && sleep 4 && sudo tailscale set --ssh=false && echo 'tailscaled restarted on Pi host (RunSSH=false)'" 2>&1 || {
           echo "::warning::LAN SSH failed - Pi may be powered off or network unavailable"
           echo "Will continue with operator redeployment when cluster is online"
         }

--- a/infrastructure/omv/CONNECTIVITY.md
+++ b/infrastructure/omv/CONNECTIVITY.md
@@ -1,5 +1,30 @@
 # Pi connectivity (SSH + Tailscale)
 
+## Remedy when connectivity breaks
+
+**Automatic (already on both Pis):** `pi-connectivity-heal.timer` every 2 minutes
++ on boot — restarts `tailscaled`/`sshd`, forces `tailscale set --ssh=false`,
+heals ghost-busy GHA runners.
+
+**Manual — from your laptop (LAN or partial Tailscale still works):**
+
+```bash
+bash scripts/restore-pi-connectivity.sh
+```
+
+**Manual — from anywhere (GitHub Actions, no Pi runners needed):**
+
+```bash
+gh workflow run restore-pi-connectivity.yml
+# optional: -f target=omv|omv-ha|both  -f restart_tailscaled=true
+```
+
+That workflow joins the tailnet with OAuth, SSHes with `OMV_SSH_KEY`, tries
+Tailscale IP then LAN for each Pi, jumps `omv-ha → omv` if needed, and comments
+on issue #382.
+
+---
+
 Classic **OpenSSH** over the Tailscale mesh — **not** Tailscale SSH.
 
 ## Why Tailscale SSH was disabled
@@ -39,16 +64,15 @@ sudo bash infrastructure/omv/configure-pi-firewall.sh
 
 ### Tailscale ACL (`infrastructure/tailscale/acl-policy.example.json`)
 
-- **`tag:pi`** — github-omv + omv-ha (not `tag:app-connector`; that tag only grants members DNS)
-- **grants:** members → `tag:pi` `tcp:22` (+ icmp); admins → `tag:pi` `*`
-- **`ssh` block:** `action: accept` only (no check-mode) so BatchMode never needs a browser if RunSSH is ever re-enabled
-- Pis still run `tailscale set --ssh=false` (classic OpenSSH)
+- **`tag:pi`** — github-omv + omv-ha
+- **grants:** members → `tag:pi` `tcp:22`; admins → `tag:pi` `*`
+- **`ssh` block:** `action: accept` only (no check-mode)
+- Pis still run `tailscale set --ssh=false`
 
-Apply:
+Apply / retag fleet:
 
 ```bash
 gh workflow run tailscale-admin-api.yml -f dry_run=false -f acl_only=true
-# workflow also runs scripts/tailscale-retag-pi-hosts.sh
 ```
 
 ## Client SSH config

--- a/scripts/restore-pi-connectivity.sh
+++ b/scripts/restore-pi-connectivity.sh
@@ -1,0 +1,164 @@
+#!/usr/bin/env bash
+# restore-pi-connectivity.sh — operator remedy when Pi SSH / Tailscale breaks.
+#
+# Tries Tailscale then LAN for omv + omv-ha, runs on-box heal, forces classic
+# OpenSSH (tailscale set --ssh=false), restarts sshd/tailscaled/runners, and
+# prints a reachability matrix.
+#
+# Usage (from repo root or anywhere):
+#   bash scripts/restore-pi-connectivity.sh
+#   PI_SSH_IDENTITY=~/.ssh/id_rsa bash scripts/restore-pi-connectivity.sh
+#
+# When this host cannot reach the Pis at all, use GitHub Actions instead:
+#   gh workflow run restore-pi-connectivity.yml
+set -euo pipefail
+
+USER_NAME="${PI_SSH_USER:-tbaltzakis}"
+IDENTITY="${PI_SSH_IDENTITY:-$HOME/.ssh/id_rsa}"
+CONNECT_TIMEOUT="${PI_SSH_TIMEOUT:-12}"
+
+declare -A TS_IP=(
+  [omv]=100.74.191.58
+  [omv-ha]=100.95.117.84
+)
+declare -A LAN_IP=(
+  [omv]=192.168.1.128
+  [omv-ha]=192.168.1.130
+)
+
+SSH_OPTS=(-o BatchMode=yes -o StrictHostKeyChecking=accept-new
+  -o IdentitiesOnly=yes -o ConnectTimeout="$CONNECT_TIMEOUT"
+  -o ServerAliveInterval=10 -o ServerAliveCountMax=2)
+if [[ -f "$IDENTITY" ]]; then
+  SSH_OPTS+=(-i "$IDENTITY")
+fi
+
+log() { echo "[restore] $*"; }
+
+ssh_to() {
+  local host="$1"; shift
+  ssh "${SSH_OPTS[@]}" "${USER_NAME}@${host}" "$@"
+}
+
+# Pick first working address for a logical node. Echoes the IP or empty.
+pick_addr() {
+  local node="$1"
+  local ts="${TS_IP[$node]}"
+  local lan="${LAN_IP[$node]}"
+  if ssh_to "$ts" true >/dev/null 2>&1; then
+    echo "$ts"
+    return 0
+  fi
+  if ssh_to "$lan" true >/dev/null 2>&1; then
+    echo "$lan"
+    return 0
+  fi
+  echo ""
+  return 1
+}
+
+REMOTE_RESTORE=$(cat <<'EOS'
+set -euo pipefail
+echo "=== host=$(hostname) ==="
+# Prefer installed heal scripts; fall back to inline recovery.
+if [ -x /usr/local/sbin/pi-connectivity-heal.sh ]; then
+  sudo /usr/local/sbin/pi-connectivity-heal.sh --boot || sudo /usr/local/sbin/pi-connectivity-heal.sh --check || true
+else
+  sudo systemctl restart tailscaled || true
+  sleep 4
+  sudo tailscale set --ssh=false || true
+  sudo systemctl restart ssh 2>/dev/null || sudo systemctl restart sshd 2>/dev/null || true
+fi
+# Never leave Tailscale SSH on (breaks BatchMode / CI).
+sudo tailscale set --ssh=false || true
+if [ -x /usr/local/sbin/gha-runner-heal.sh ]; then
+  sudo /usr/local/sbin/gha-runner-heal.sh --boot || sudo /usr/local/sbin/gha-runner-heal.sh --check || true
+else
+  for u in $(systemctl list-units --type=service --all --no-legend 'actions.runner.*' 2>/dev/null | awk '{print $1}'); do
+    sudo systemctl restart "$u" || true
+  done
+fi
+# Re-assert firewall SSH allows if installer present in /tmp or repo path.
+if [ -f /tmp/configure-pi-firewall.sh ]; then
+  sudo bash /tmp/configure-pi-firewall.sh || true
+elif [ -f "$HOME/cloudless.gr/infrastructure/omv/configure-pi-firewall.sh" ]; then
+  sudo bash "$HOME/cloudless.gr/infrastructure/omv/configure-pi-firewall.sh" || true
+fi
+echo "--- status ---"
+systemctl is-active ssh sshd tailscaled 2>/dev/null || true
+tailscale ip -4 2>/dev/null || true
+tailscale debug prefs 2>/dev/null | grep RunSSH || true
+ss -ltn 2>/dev/null | grep ':22 ' || true
+EOS
+)
+
+restore_node() {
+  local node="$1"
+  local addr
+  addr="$(pick_addr "$node" || true)"
+  if [[ -z "$addr" ]]; then
+    log "FAIL $node — unreachable on Tailscale (${TS_IP[$node]}) and LAN (${LAN_IP[$node]})"
+    return 1
+  fi
+  log "OK path $node → $addr — running restore"
+  ssh_to "$addr" bash -s <<<"$REMOTE_RESTORE"
+}
+
+# If omv is down but omv-ha is up, jump ha → omv LAN (deploy-proxy pattern).
+restore_omv_via_ha() {
+  local ha_addr
+  ha_addr="$(pick_addr omv-ha || true)"
+  [[ -n "$ha_addr" ]] || return 1
+  log "Trying omv restore via omv-ha jump ($ha_addr → 192.168.1.128)"
+  ssh_to "$ha_addr" bash -s <<'JUMP'
+set -euo pipefail
+KEY=""
+if [ -f "$HOME/.ssh/omv_ha" ]; then KEY="-i $HOME/.ssh/omv_ha"; fi
+# shellcheck disable=SC2086
+ssh $KEY -o BatchMode=yes -o ConnectTimeout=25 -o StrictHostKeyChecking=accept-new \
+  tbaltzakis@192.168.1.128 bash -s <<'EOS'
+set -euo pipefail
+if [ -x /usr/local/sbin/pi-connectivity-heal.sh ]; then
+  sudo /usr/local/sbin/pi-connectivity-heal.sh --boot || true
+fi
+sudo tailscale set --ssh=false || true
+sudo systemctl restart ssh 2>/dev/null || sudo systemctl restart sshd 2>/dev/null || true
+if [ -x /usr/local/sbin/gha-runner-heal.sh ]; then
+  sudo /usr/local/sbin/gha-runner-heal.sh --boot || true
+fi
+hostname; tailscale ip -4; systemctl is-active ssh tailscaled 2>/dev/null || true
+EOS
+JUMP
+}
+
+main() {
+  log "Starting Pi connectivity restore ($(date -u +%Y-%m-%dT%H:%MZ))"
+  local rc=0
+  restore_node omv-ha || rc=1
+  if ! restore_node omv; then
+    restore_omv_via_ha || rc=1
+  fi
+
+  echo
+  log "=== reachability matrix ==="
+  printf '%-10s %-18s %-18s\n' NODE Tailscale LAN
+  for node in omv omv-ha; do
+    local ts_ok=no lan_ok=no
+    ssh_to "${TS_IP[$node]}" true >/dev/null 2>&1 && ts_ok=yes
+    ssh_to "${LAN_IP[$node]}" true >/dev/null 2>&1 && lan_ok=yes
+    printf '%-10s %-18s %-18s\n' "$node" "$ts_ok" "$lan_ok"
+    if [[ "$ts_ok" != yes && "$lan_ok" != yes ]]; then
+      rc=1
+    fi
+  done
+
+  if [[ "$rc" -ne 0 ]]; then
+    log "Incomplete restore. From any network, dispatch:"
+    log "  gh workflow run restore-pi-connectivity.yml"
+    log "If the Pi is powered off, power-cycle it; heal runs on boot."
+    exit 1
+  fi
+  log "Both nodes reachable. Done."
+}
+
+main "$@"


### PR DESCRIPTION
## Summary
- **`scripts/restore-pi-connectivity.sh`** — one command from laptop (TS then LAN, ha→omv jump)
- **`restore-pi-connectivity.yml`** — same remedy via GitHub Actions + `OMV_SSH_KEY` when local access is dead
- On-box heal already runs every 2 min; this is the operator button when it is not enough
- Fix `tailscale-reconnect-agent` so it no longer runs `tailscale up --accept-ssh`

## Test plan
- [x] `bash scripts/restore-pi-connectivity.sh` shows both nodes reachable
- [ ] `gh workflow run restore-pi-connectivity.yml` succeeds and comments on #382


Made with [Cursor](https://cursor.com)