### PR TITLE
Offload deploy-pi Next build to ubuntu-24.04-arm

### DIFF
--- a/.github/workflows/deploy-pi.yml
+++ b/.github/workflows/deploy-pi.yml
@@ -1,12 +1,14 @@
 name: Deploy to Pi (hostPath standalone — no ECR)
 
-# Cloudflare-first: build Next standalone on omv (Pi 5), upload artifact, then
-# roll out from omv-ha (deploy proxy) via rsync + kubectl over SSH/Tailscale.
-# Survives omv power-cycles mid-deploy: a finished build lives in GH Artifacts
-# and rollout can complete once omv is back.
+# Cloudflare-first: build Next standalone on GitHub-hosted native ARM64
+# (ubuntu-24.04-arm), upload artifact, then roll out from omv-ha (deploy proxy)
+# via rsync + kubectl over SSH/Tailscale.
+#
+# omv never runs `pnpm build` — compiling on the Pi 5 control plane pegs the
+# USB SSD and trips the hardware watchdog (~5m into Turbopack).
 #
 # Jobs:
-#   build   — [self-hosted, omv, build]   (heavy compile; do NOT put on omv-ha)
+#   build   — ubuntu-24.04-arm          (heavy compile; free for public repos)
 #   rollout — [self-hosted, omv-ha, deploy] (rsync SafeDeploy + kubectl)
 #
 # Concurrency: deploy the LATEST main SHA only. cancel-in-progress: true so a
@@ -45,13 +47,12 @@ env:
   K3S_NAMESPACE: cloudless
   K3S_DEPLOYMENT: cloudless-app
   STANDALONE_HOSTPATH: /home/tbaltzakis/cloudless-standalone
-  PNPM_STORE_PATH: /home/tbaltzakis/.pnpm-store
   OMV_SSH_HOST: 192.168.1.128
 
 jobs:
   build:
     name: Build standalone artifact
-    runs-on: [self-hosted, omv, build]
+    runs-on: ubuntu-24.04-arm
     timeout-minutes: 60
     if: ${{ !(github.event_name == 'workflow_dispatch' && inputs.rollout_only) }}
     outputs:
@@ -68,8 +69,11 @@ jobs:
         set -euo pipefail
         WANT="${{ github.sha }}"
         LIVE=""
-        for candidate in http://127.0.0.1:30300/api/health http://192.168.1.128:30300/api/health; do
-          BODY=$(curl -sS --max-time 5 "$candidate" || true)
+        for candidate in \
+          https://pi-origin.cloudless.gr/api/health \
+          https://cloudless.gr/api/health
+        do
+          BODY=$(curl -sS --max-time 10 "$candidate" || true)
           if echo "$BODY" | jq -e .version >/dev/null 2>&1; then
             LIVE=$(echo "$BODY" | jq -r .version)
             echo "health $candidate → version=${LIVE}"
@@ -89,32 +93,26 @@ jobs:
           echo "Need deploy: live=${LIVE:-unknown} want=${WANT}"
         fi
 
+    - name: Setup pnpm
+      if: steps.skip.outputs.already != 'true'
+      uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1         # v4
+
     - name: Setup Node
       if: steps.skip.outputs.already != 'true'
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e         # v6.4.0
       with:
         node-version: '24'
+        cache: pnpm
 
-    - name: Configure pnpm store
+    - name: Restore Next.js build cache
       if: steps.skip.outputs.already != 'true'
-      run: |
-        set -euo pipefail
-        mkdir -p "${PNPM_STORE_PATH}"
-        pnpm config set store-dir "${PNPM_STORE_PATH}"
-
-    - name: Clean stale build output (keep cache)
-      if: steps.skip.outputs.already != 'true'
-      run: |
-        set -euo pipefail
-        if [ ! -d .next ]; then
-          echo "No prior .next/ — clean workspace"
-          exit 0
-        fi
-        cache_size=$(du -sh .next/cache 2>/dev/null | cut -f1 || echo "0")
-        echo "Preserving .next/cache/ (size: ${cache_size})"
-        find .next -mindepth 1 -maxdepth 1 -not -name cache -exec rm -rf {} +
-        echo "Cleaned .next/ (kept cache):"
-        ls -la .next
+      uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae         # v5.0.5
+      with:
+        path: .next/cache
+        key: nextjs-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('pnpm-lock.yaml') }}-${{ hashFiles('src/**') }}
+        restore-keys: |
+          nextjs-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('pnpm-lock.yaml') }}-
+          nextjs-${{ runner.os }}-${{ runner.arch }}-
 
     - name: Install dependencies
       if: steps.skip.outputs.already != 'true'
@@ -138,10 +136,22 @@ jobs:
         NEXT_PUBLIC_GOOGLE_SITE_VERIFICATION: LXkyzmWrAYuY1C6XD6TKaqA31KB72xbUlkimE0vKI8w
       run: pnpm build
 
+    - name: Ensure rsync
+      if: steps.skip.outputs.already != 'true'
+      run: |
+        set -euo pipefail
+        if ! command -v rsync >/dev/null 2>&1; then
+          sudo apt-get update -qq
+          sudo apt-get install -y rsync
+        fi
+
     - name: Install Syft for SBOM generation
       if: steps.skip.outputs.already != 'true'
       run: |
-        curl -sSfL https://raw.githubusercontent.com/anchore/syft/main/install.sh | sh -s -- -b /usr/local/bin
+        set -euo pipefail
+        mkdir -p "$HOME/.local/bin"
+        curl -sSfL https://raw.githubusercontent.com/anchore/syft/main/install.sh | sh -s -- -b "$HOME/.local/bin"
+        echo "$HOME/.local/bin" >> "$GITHUB_PATH"
 
     - name: Generate SBOM
       if: steps.skip.outputs.already != 'true'

--- a/docs/deploy/runners.md
+++ b/docs/deploy/runners.md
@@ -117,17 +117,20 @@ time on ARM:
 
 When billing is broken, these stay red until billing is fixed.
 
-## deploy-pi topology (build on omv, rollout from omv-ha)
+## deploy-pi topology (build on GH arm64, rollout from omv-ha)
 
 `deploy-pi.yml` is **two jobs** so an omv power-cycle mid-rollout does not
-throw away a finished build:
+throw away a finished build. **`pnpm build` never runs on omv** — compiling
+on the Pi 5 control plane pegs the USB SSD and trips the hardware watchdog
+(~5m into Turbopack).
 
 | Job | `runs-on` | Role |
 | --- | --------- | ---- |
-| `build` | `[self-hosted, omv, build]` | Next standalone compile on Pi 5 (8GB); upload `standalone-<sha>` artifact (2-day retention) |
+| `build` | `ubuntu-24.04-arm` | Next standalone compile on GitHub-hosted native ARM64 (public-repo free); upload `standalone-<sha>` artifact (2-day retention) |
 | `rollout` | `[self-hosted, omv-ha, deploy]` | Download artifact → `scripts/pi-rollout-from-artifact.sh` (rsync SafeDeploy releases/symlink on omv + `kubectl` over SSH) |
 
-- **Never** put the Next build on omv-ha (Pi 4 ~1GB — OOM).
+- **Never** put the Next build on omv or omv-ha (omv = production control plane; omv-ha = Pi 4 ~1GB — OOM).
+- Skip-if-live probes `https://pi-origin.cloudless.gr/api/health` (hosted runner has no LAN).
 - Concurrency group `deploy-pi` with `cancel-in-progress: true`.
 - Job timeouts: build 60m, rollout 15m.
 - `workflow_dispatch` input `rollout_only=true` re-downloads the artifact for
@@ -216,21 +219,24 @@ Current active fleet (as of 2026-08-12):
 | Host     | IP / Tailscale              | Runner name      | Labels                                         | Status / role |
 | -------- | --------------------------- | ---------------- | ---------------------------------------------- | ------------- |
 | omv-main | 192.168.1.128 / 100.74.191.58 | `omv`          | `self-hosted, Linux, ARM64, omv, pi`           | cluster jobs |
-| omv-main | 192.168.1.128               | `omv-build`      | `self-hosted, Linux, ARM64, omv, pi, build`    | **Next build** (`deploy-pi` build job) |
+| omv-main | 192.168.1.128               | `omv-build`      | `self-hosted, Linux, ARM64, omv, pi, build`    | Docker / `build-pi-image.yml` only — **not** `deploy-pi` Next build |
 | omv-ha   | 192.168.1.130 / 100.95.117.84 | `omv-ha-deploy` | `self-hosted, Linux, ARM64, omv-ha, deploy`   | **deploy proxy** (`deploy-pi` rollout) |
-| omv-ha   | 192.168.1.130               | `omv-2-build`    | `self-hosted, Linux, ARM64, omv, build`        | optional spare — **do not** rely on for Next builds (1GB RAM) |
+| omv-ha   | 192.168.1.130               | `omv-2-build`    | `self-hosted, Linux, ARM64, omv, build`        | optional spare — **do not** use for Next builds (1GB RAM) |
+| GitHub   | hosted                      | `ubuntu-24.04-arm` | (managed)                                   | **Next standalone build** (`deploy-pi` build job) |
 
 The `pi` label is for cluster-local jobs (NodePort audits, kubectl, CWV).
-The `build` label is **exclusive** for heavy compile on omv (Pi 5):
+The `build` label is for heavy Docker work on omv (Pi 5), **not** for
+`deploy-pi` Next compile:
 
 | Labels | Purpose | Workflows |
 | ------ | ------- | --------- |
-| `self-hosted, omv, build` | Next standalone **build** + artifact upload | `deploy-pi.yml` (build), `build-pi-image.yml` |
+| `ubuntu-24.04-arm` | Next standalone **build** + artifact upload | `deploy-pi.yml` (build) |
+| `self-hosted, omv, build` | Docker arm64 image build (ECR path) | `build-pi-image.yml` |
 | `self-hosted, omv-ha, deploy` | rsync SafeDeploy + kubectl over SSH to omv | `deploy-pi.yml` (rollout) |
 | `self-hosted, omv, pi` | Cluster reachability, NodePort Lighthouse, alert-api import | `core-web-vitals-audit.yml`, `cluster-status-audit.yml`, `deploy-alert-api.yml` |
 
 Do **not** put CWV, cluster-status, or ETL on exclusive `build` — one busy
-Lighthouse run previously queued `deploy-pi` for tens of minutes.
+Lighthouse run previously queued Docker builds for tens of minutes.
 
 `deploy-pi` concurrency uses `cancel-in-progress: true` so rapid main merges
 supersede older in-progress runs. A skip step no-ops when `/api/health`
@@ -238,9 +244,10 @@ already reports `version == github.sha`.
 
 ## Caveat: Pi runners share resources with production
 
-Pi 4/5 hosts also run the `cloudless` k3s pod that serves `pi-origin.cloudless.gr`.
-Heavy CI concurrency on the `build` runner will degrade prod latency. If you
-flip to `pi` mode for more than a short outage window, consider:
+Pi 5 (`omv`) also runs the `cloudless` k3s pod that serves
+`pi-origin.cloudless.gr`. `deploy-pi` Next compile no longer runs there, but
+Docker builds (`build-pi-image.yml` on `omv-build`) and other `omv,pi` jobs
+still share disk/CPU with prod. If you park heavy work on omv, consider:
 
 - A `nice -n 19` wrapper on the runner systemd unit
 - `cpuset.cpus` cgroup limit on the runner service


### PR DESCRIPTION
## Summary
- Move `deploy-pi` **build** from `[self-hosted, omv, build]` to GitHub-hosted `ubuntu-24.04-arm` so `pnpm build` no longer freezes the Pi 5 control plane (watchdog reboot mid-Turbopack).
- Keep **rollout** on omv-ha; probe live SHA via `pi-origin` / `cloudless.gr` health; add pnpm + `.next/cache` on hosted runners.
- Update `docs/deploy/runners.md` to match.

## Test plan
- [ ] After merge, `deploy-pi` build job runs on `ubuntu-24.04-arm` (not `omv-build`)
- [ ] omv load stays calm during compile; site stays up (no mid-build 502/watchdog)
- [ ] Artifact uploads; omv-ha rollout succeeds; `/api/health` advances past `603056fa…`

Made with [Cursor](https://cursor.com)