### PR TITLE
Fix missing @swc/helpers in Pi standalone deploy

### DIFF
--- a/.github/workflows/deploy-pi.yml
+++ b/.github/workflows/deploy-pi.yml
@@ -207,6 +207,25 @@ jobs:
         rm -rf "$OUT"
         mkdir -p "$OUT/standalone"
         rsync -a "$SRC/" "$OUT/standalone/"
+        # Belt-and-suspenders: file tracing can still miss @swc/helpers on
+        # ubuntu-24.04-arm; copy from the install tree if absent.
+        DEST_HELPERS="$OUT/standalone/node_modules/@swc/helpers"
+        if [ ! -f "$DEST_HELPERS/package.json" ]; then
+          SRC_HELPERS=""
+          if [ -f node_modules/@swc/helpers/package.json ]; then
+            SRC_HELPERS="node_modules/@swc/helpers"
+          else
+            SRC_HELPERS=$(find node_modules -path '*/@swc/helpers/package.json' 2>/dev/null | head -1 | xargs -r dirname || true)
+          fi
+          if [ -n "${SRC_HELPERS:-}" ] && [ -d "$SRC_HELPERS" ]; then
+            mkdir -p "$OUT/standalone/node_modules/@swc"
+            rsync -a "$SRC_HELPERS/" "$DEST_HELPERS/"
+            echo "Injected @swc/helpers from ${SRC_HELPERS}"
+          else
+            echo "::error::@swc/helpers missing from standalone and install tree"
+            exit 1
+          fi
+        fi
         if [ -d .next/static ]; then
           mkdir -p "$OUT/static"
           rsync -a .next/static/ "$OUT/static/"

--- a/next.config.ts
+++ b/next.config.ts
@@ -16,6 +16,12 @@ const nextConfig: NextConfig = {
   // For Docker builds (Pi HA standby): emit a self-contained .next/standalone
   // bundle. SST/Vercel deploys leave this unset.
   output: process.env.NEXT_OUTPUT_STANDALONE === "1" ? "standalone" : undefined,
+  // Hosted arm64 `next build` (deploy-pi) traces a lean standalone that can
+  // omit @swc/helpers; the Pi node:22 runtime then crashes on boot with
+  // MODULE_NOT_FOUND for @swc/helpers/_/_interop_require_default.
+  outputFileTracingIncludes: {
+    "/*": ["./node_modules/@swc/helpers/**/*"],
+  },
   // Turbopack (Next 16) fails to resolve `@smithy/core/*` subpath exports
   // through pnpm's hoisted layout on Windows. Externalize the AWS SDK
   // clients so Next uses Node's native resolver instead of bundling them.


### PR DESCRIPTION
## Summary
- First GH `ubuntu-24.04-arm` deploy built fine but the lean standalone omitted `@swc/helpers`, so the Pi pod crashed with `MODULE_NOT_FOUND` and the site 502’d.
- Rolled back live to `603056fa0dda` manually.
- Add `outputFileTracingIncludes` for `@swc/helpers` and a pack-step copy if tracing still skips it.

## Test plan
- [ ] `deploy-pi` pack logs either tracing include or “Injected @swc/helpers”
- [ ] omv-ha rollout succeeds; pod Ready; `/api/health` reports new SHA
- [ ] No `MODULE_NOT_FOUND` in pod logs

Made with [Cursor](https://cursor.com)