### PR TITLE
Quiet Newsletter Slack unauthorized warn during next build

### DIFF
--- a/__tests__/newsletter-slack/newsletter-slack-config.test.ts
+++ b/__tests__/newsletter-slack/newsletter-slack-config.test.ts
@@ -40,8 +40,22 @@ describe("getNewsletterSlackConfigAsync", () => {
     expect(cfg.NEWSLETTER_SLACK_BOT_TOKEN).toBe("");
     expect(cfg.NEWSLETTER_SLACK_SIGNING_SECRET).toBe("");
     expect(cfg.NEWSLETTER_SLACK_CHANNEL_ID).toBe("");
-    // Should have warned about the missing signing secret
+    // Should have warned about the missing signing secret (runtime / tests)
     expect(warn).toHaveBeenCalled();
+  });
+
+  it("does not warn about missing secret during next production build", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    process.env.NEXT_PHASE = "phase-production-build";
+    try {
+      const cfg = await getNewsletterSlackConfigAsync();
+      expect(cfg.NEWSLETTER_SLACK_SIGNING_SECRET).toBe("");
+      expect(warn).not.toHaveBeenCalledWith(
+        expect.stringContaining("NEWSLETTER_SLACK_SIGNING_SECRET not set")
+      );
+    } finally {
+      delete process.env.NEXT_PHASE;
+    }
   });
 
   it("caches results — second call does not re-read env", async () => {

--- a/src/app/api/newsletter-slack/commands/route.ts
+++ b/src/app/api/newsletter-slack/commands/route.ts
@@ -26,7 +26,6 @@ import {
 } from "@/lib/notion-blog-admin";
 import { dispatchWorkflow } from "@/lib/github-dispatch";
 import { listNewsletterSubscribers as listSubscribers } from "@/lib/espocrm";
-import { getNewsletterSlackConfigAsync } from "@/lib/newsletter-slack-config";
 
 interface SlashPayload {
   command: string;
@@ -438,7 +437,3 @@ function slackResponse(body: unknown): Response {
     headers: { "Content-Type": "application/json" },
   });
 }
-
-// Touch the async config getter once at module load so any missing-secret
-// warning surfaces in Lambda logs before the first real request.
-void getNewsletterSlackConfigAsync().catch(() => {});

--- a/src/lib/newsletter-slack-config.ts
+++ b/src/lib/newsletter-slack-config.ts
@@ -20,6 +20,11 @@ export interface NewsletterSlackConfig {
 
 let cached: NewsletterSlackConfig | null = null;
 
+/** True while `next build` collects page data / generates static pages. */
+function isProductionBuildPhase(): boolean {
+  return process.env.NEXT_PHASE === "phase-production-build";
+}
+
 export async function getNewsletterSlackConfigAsync(): Promise<NewsletterSlackConfig> {
   if (cached) return cached;
 
@@ -35,11 +40,16 @@ export async function getNewsletterSlackConfigAsync(): Promise<NewsletterSlackCo
       if (!signingSecret) signingSecret = ssm.NEWSLETTER_SLACK_SIGNING_SECRET ?? "";
       if (!channel) channel = ssm.NEWSLETTER_SLACK_CHANNEL_ID ?? "";
     } catch (err) {
-      console.warn("[NewsletterSlack] SSM fallback failed:", err);
+      if (!isProductionBuildPhase()) {
+        console.warn("[NewsletterSlack] SSM fallback failed:", err);
+      }
     }
   }
 
-  if (!signingSecret) {
+  // Secrets are not available during `next build` on hosted runners — do not
+  // spam "unauthorized" into deploy logs. Runtime requests still reject when
+  // the secret is missing (see verifyNewsletterSlackRequest).
+  if (!signingSecret && !isProductionBuildPhase()) {
     console.warn(
       "[NewsletterSlack] NEWSLETTER_SLACK_SIGNING_SECRET not set — " +
         "every request will be rejected as unauthorized."


### PR DESCRIPTION
## Summary
- Deploy logs showed `[NewsletterSlack] NEWSLETTER_SLACK_SIGNING_SECRET not set — every request will be rejected as unauthorized` during static generation — expected on hosted arm64 (no Pi secrets at build).
- Suppress that warn (and SSM fallback noise) when `NEXT_PHASE=phase-production-build`.
- Remove module-load `getNewsletterSlackConfigAsync()` prefetch that forced the warn during page collection.

## Test plan
- [ ] `vitest` newsletter-slack-config (5 tests) pass
- [ ] Next deploy build log no longer prints the unauthorized NewsletterSlack line

Made with [Cursor](https://cursor.com)