### PR TITLE
Use Europe/Athens for dates everywhere in the app

### DIFF
--- a/__tests__/lib/timezone.test.ts
+++ b/__tests__/lib/timezone.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest";
+import {
+  APP_TIMEZONE,
+  appTodayIsoDate,
+  formatAppDate,
+  formatAppDateTime,
+  formatAppTime,
+} from "@/lib/timezone";
+
+describe("timezone (Europe/Athens)", () => {
+  it("exports Europe/Athens as the app timezone", () => {
+    expect(APP_TIMEZONE).toBe("Europe/Athens");
+  });
+
+  it("formats a known UTC instant in Athens (winter EET = UTC+2)", () => {
+    // 2026-01-15 12:00 UTC → 14:00 Athens
+    const iso = "2026-01-15T12:00:00.000Z";
+    expect(formatAppTime(iso, "en-IE")).toMatch(/14:00/);
+    expect(formatAppDate(iso, "en-IE", { year: "numeric", month: "2-digit", day: "2-digit" })).toMatch(
+      /15/
+    );
+    expect(formatAppDateTime(iso)).not.toBe("—");
+  });
+
+  it("formats a known UTC instant in Athens (summer EEST = UTC+3)", () => {
+    // 2026-07-15 12:00 UTC → 15:00 Athens
+    expect(formatAppTime("2026-07-15T12:00:00.000Z")).toMatch(/15:00/);
+  });
+
+  it("returns em dash for invalid input", () => {
+    expect(formatAppDate("not-a-date")).toBe("—");
+    expect(formatAppDateTime("nope")).toBe("—");
+  });
+
+  it("appTodayIsoDate is YYYY-MM-DD in Athens", () => {
+    // Fixed: 2026-08-12 22:30 UTC → already 13 Aug in Athens (UTC+3 in August)
+    const d = new Date("2026-08-12T22:30:00.000Z");
+    expect(appTodayIsoDate(d)).toBe("2026-08-13");
+  });
+});

--- a/src/app/[locale]/admin/analytics/datalake/page.tsx
+++ b/src/app/[locale]/admin/analytics/datalake/page.tsx
@@ -163,7 +163,7 @@ export default function DatalakeDashboardPage() {
     return () => clearTimeout(t);
   }, [load]);
 
-  const generatedAt = data ? new Date(data.generated_at).toLocaleString() : "—";
+  const generatedAt = data ? new Date(data.generated_at).toLocaleString(undefined, { timeZone: "Europe/Athens" }) : "—";
 
   // All chrome below uses design-system v2 CSS variables
   // (--surface-raised, --border-subtle, --ink-primary, --ink-muted, --accent,

--- a/src/app/[locale]/admin/analytics/page.tsx
+++ b/src/app/[locale]/admin/analytics/page.tsx
@@ -853,10 +853,8 @@ function HistoryTab({ history }: { readonly history: HistoryPoint[] }) {
                   className="hover:bg-void-lighter/30 border-b border-slate-800/50 transition-colors"
                 >
                   <td className="px-6 py-3 font-mono text-xs text-slate-300">
-                    {new Date(h.date).toLocaleDateString("en-IE", {
-                      month: "short",
-                      day: "numeric",
-                    })}
+                    {new Date(h.date).toLocaleDateString("en-IE", { month: "short",
+                      day: "numeric", timeZone: "Europe/Athens" })}
                   </td>
                   <td className="px-6 py-3 text-right font-mono text-sm text-white">
                     {(h.clicks ?? 0).toLocaleString()}

--- a/src/app/[locale]/admin/analytics/unified/page.tsx
+++ b/src/app/[locale]/admin/analytics/unified/page.tsx
@@ -423,11 +423,9 @@ export default function UnifiedAnalyticsPage() {
       {data?.fetchedAt && (
         <p className="mt-10 font-mono text-xs text-slate-600">
           Last fetched:{" "}
-          {new Date(data.fetchedAt).toLocaleTimeString("en-IE", {
-            hour: "2-digit",
+          {new Date(data.fetchedAt).toLocaleTimeString("en-IE", { hour: "2-digit",
             minute: "2-digit",
-            second: "2-digit",
-          })}
+            second: "2-digit", timeZone: "Europe/Athens" })}
         </p>
       )}
     </div>

--- a/src/app/[locale]/admin/analytics/workspaces/page.tsx
+++ b/src/app/[locale]/admin/analytics/workspaces/page.tsx
@@ -200,7 +200,7 @@ function WorkspaceCard({ a }: Readonly<{ a: WorkspaceAnalytics }>) {
   const title = a.workspace?.name ?? "Org-wide";
   const slug = a.workspace?.slug;
   const nextScheduled = a.calendar.nextScheduledAt
-    ? new Date(a.calendar.nextScheduledAt).toLocaleString("en-IE")
+    ? new Date(a.calendar.nextScheduledAt).toLocaleString("en-IE", { timeZone: "Europe/Athens" })
     : "—";
   return (
     <div className="bg-void-light/30 rounded-xl border border-slate-800 p-5">

--- a/src/app/[locale]/admin/appflowy/analytics/page.tsx
+++ b/src/app/[locale]/admin/appflowy/analytics/page.tsx
@@ -48,12 +48,10 @@ const TYPE_LABELS: Record<string, string> = {
 function formatDate(iso: string) {
   if (!iso) return "—";
   try {
-    return new Date(iso).toLocaleString("en-GB", {
-      day: "2-digit",
+    return new Date(iso).toLocaleString("en-GB", { day: "2-digit",
       month: "short",
       hour: "2-digit",
-      minute: "2-digit",
-    });
+      minute: "2-digit", timeZone: "Europe/Athens" });
   } catch {
     return iso;
   }

--- a/src/app/[locale]/admin/appflowy/page.tsx
+++ b/src/app/[locale]/admin/appflowy/page.tsx
@@ -26,13 +26,11 @@ const STATUS_STYLES: Record<string, string> = {
 
 function formatDate(iso: string) {
   try {
-    return new Date(iso).toLocaleString("en-GB", {
-      day: "2-digit",
+    return new Date(iso).toLocaleString("en-GB", { day: "2-digit",
       month: "short",
       year: "numeric",
       hour: "2-digit",
-      minute: "2-digit",
-    });
+      minute: "2-digit", timeZone: "Europe/Athens" });
   } catch {
     return iso;
   }

--- a/src/app/[locale]/admin/appflowy/projects/page.tsx
+++ b/src/app/[locale]/admin/appflowy/projects/page.tsx
@@ -47,11 +47,9 @@ const PRIORITY_ICONS: Record<string, string> = {
 function formatDate(iso: string) {
   if (!iso) return "—";
   try {
-    return new Date(iso).toLocaleDateString("en-GB", {
-      day: "2-digit",
+    return new Date(iso).toLocaleDateString("en-GB", { day: "2-digit",
       month: "short",
-      year: "numeric",
-    });
+      year: "numeric", timeZone: "Europe/Athens" });
   } catch {
     return iso;
   }

--- a/src/app/[locale]/admin/appflowy/submissions/page.tsx
+++ b/src/app/[locale]/admin/appflowy/submissions/page.tsx
@@ -26,11 +26,9 @@ const VALID_STATUSES = ["New", "In Review", "Done"] as const;
 function formatDate(iso?: string) {
   if (!iso) return "";
   try {
-    return new Date(iso).toLocaleDateString("en-GB", {
-      day: "2-digit",
+    return new Date(iso).toLocaleDateString("en-GB", { day: "2-digit",
       month: "short",
-      year: "numeric",
-    });
+      year: "numeric", timeZone: "Europe/Athens" });
   } catch {
     return iso;
   }

--- a/src/app/[locale]/admin/appflowy/tasks/page.tsx
+++ b/src/app/[locale]/admin/appflowy/tasks/page.tsx
@@ -75,10 +75,8 @@ const TYPE_ICONS: Record<string, string> = {
 function formatDate(iso: string) {
   if (!iso) return "";
   try {
-    return new Date(iso).toLocaleDateString("en-GB", {
-      day: "2-digit",
-      month: "short",
-    });
+    return new Date(iso).toLocaleDateString("en-GB", { day: "2-digit",
+      month: "short", timeZone: "Europe/Athens" });
   } catch {
     return iso;
   }

--- a/src/app/[locale]/admin/audits/page.tsx
+++ b/src/app/[locale]/admin/audits/page.tsx
@@ -99,7 +99,7 @@ export default function AuditsPage() {
       {data && (
         <>
           <p className="mb-4 text-xs text-gray-500 dark:text-gray-400">
-            Generated {new Date(data.generatedAt).toLocaleString()} · {data.repo}
+            Generated {new Date(data.generatedAt).toLocaleString(undefined, { timeZone: "Europe/Athens" })} · {data.repo}
           </p>
 
           <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">

--- a/src/app/[locale]/admin/automation/page.tsx
+++ b/src/app/[locale]/admin/automation/page.tsx
@@ -37,12 +37,10 @@ interface N8nExecution {
 function formatDate(iso: string) {
   if (!iso) return "—";
   try {
-    return new Date(iso).toLocaleString("en-GB", {
-      day: "2-digit",
+    return new Date(iso).toLocaleString("en-GB", { day: "2-digit",
       month: "short",
       hour: "2-digit",
-      minute: "2-digit",
-    });
+      minute: "2-digit", timeZone: "Europe/Athens" });
   } catch {
     return iso;
   }

--- a/src/app/[locale]/admin/blog/page.tsx
+++ b/src/app/[locale]/admin/blog/page.tsx
@@ -15,11 +15,9 @@ const FILTER_LABELS: Record<Filter, string> = {
 function formatDate(iso: string) {
   if (!iso) return "—";
   try {
-    return new Date(iso).toLocaleDateString("en-GB", {
-      day: "2-digit",
+    return new Date(iso).toLocaleDateString("en-GB", { day: "2-digit",
       month: "short",
-      year: "numeric",
-    });
+      year: "numeric", timeZone: "Europe/Athens" });
   } catch {
     return iso;
   }

--- a/src/app/[locale]/admin/campaigns/meta/page.tsx
+++ b/src/app/[locale]/admin/campaigns/meta/page.tsx
@@ -133,7 +133,7 @@ export default function MetaPage() {
                       : "—"}
                   </td>
                   <td className="px-4 py-3 text-right font-mono text-xs text-slate-400">
-                    {new Date(c.created_time).toLocaleDateString("en-IE", { dateStyle: "medium" })}
+                    {new Date(c.created_time).toLocaleDateString("en-IE", { dateStyle: "medium", timeZone: "Europe/Athens" })}
                   </td>
                 </tr>
               ))}

--- a/src/app/[locale]/admin/campaigns/page.tsx
+++ b/src/app/[locale]/admin/campaigns/page.tsx
@@ -374,7 +374,7 @@ export default function CampaignsDashboard() {
           </button>
           {hub.fetchedAt && (
             <p className="font-mono text-[10px] text-slate-600">
-              Updated {new Date(hub.fetchedAt).toLocaleTimeString("en-IE")}
+              Updated {new Date(hub.fetchedAt).toLocaleTimeString("en-IE", { timeZone: "Europe/Athens" })}
             </p>
           )}
         </div>

--- a/src/app/[locale]/admin/client-portals/page.tsx
+++ b/src/app/[locale]/admin/client-portals/page.tsx
@@ -234,12 +234,10 @@ function StepManager({
                               {c.author}
                             </span>
                             <span className="font-mono text-[10px] text-slate-600">
-                              {new Date(c.createdAt).toLocaleString("en-IE", {
-                                day: "numeric",
+                              {new Date(c.createdAt).toLocaleString("en-IE", { day: "numeric",
                                 month: "short",
                                 hour: "2-digit",
-                                minute: "2-digit",
-                              })}
+                                minute: "2-digit", timeZone: "Europe/Athens" })}
                             </span>
                           </div>
                           <p className="mt-0.5 text-sm whitespace-pre-wrap text-slate-400">
@@ -704,8 +702,8 @@ function TokenLifecycle({
     }
   }
 
-  const created = new Date(portal.createdAt).toLocaleDateString("en-IE");
-  const expiresAt = hasExpiry ? new Date(expiresAtMs).toLocaleDateString("en-IE") : null;
+  const created = new Date(portal.createdAt).toLocaleDateString("en-IE", { timeZone: "Europe/Athens" });
+  const expiresAt = hasExpiry ? new Date(expiresAtMs).toLocaleDateString("en-IE", { timeZone: "Europe/Athens" }) : null;
 
   return (
     <div className="mt-6 rounded-lg border border-slate-800 p-3">
@@ -866,12 +864,10 @@ function PendingClients({ onApproved }: Readonly<{ onApproved: () => void }>) {
                 </span>
                 <span className="font-mono text-[10px] text-slate-500">
                   Submitted{" "}
-                  {new Date(c.submittedAt).toLocaleString("en-IE", {
-                    day: "numeric",
+                  {new Date(c.submittedAt).toLocaleString("en-IE", { day: "numeric",
                     month: "short",
                     hour: "2-digit",
-                    minute: "2-digit",
-                  })}
+                    minute: "2-digit", timeZone: "Europe/Athens" })}
                 </span>
               </div>
               {c.notes && (
@@ -1142,7 +1138,7 @@ export default function ClientPortalsPage() {
                         </span>
                       )}
                       <span className="font-mono text-xs text-slate-600">
-                        {new Date(portal.createdAt).toLocaleDateString("en-IE")}
+                        {new Date(portal.createdAt).toLocaleDateString("en-IE", { timeZone: "Europe/Athens" })}
                       </span>
                     </div>
 

--- a/src/app/[locale]/admin/crm/companies/page.tsx
+++ b/src/app/[locale]/admin/crm/companies/page.tsx
@@ -133,7 +133,7 @@ export default function AdminCompaniesPage() {
                   </td>
                   <td className="px-6 py-4 font-mono text-slate-500">
                     {c.properties.createdate
-                      ? new Date(c.properties.createdate).toLocaleDateString("en-IE")
+                      ? new Date(c.properties.createdate).toLocaleDateString("en-IE", { timeZone: "Europe/Athens" })
                       : "—"}
                   </td>
                 </tr>
@@ -174,7 +174,7 @@ export default function AdminCompaniesPage() {
           </button>
           {fetchedAt && (
             <span className="font-mono text-[10px] text-slate-600">
-              Updated {new Date(fetchedAt).toLocaleTimeString("en-IE")}
+              Updated {new Date(fetchedAt).toLocaleTimeString("en-IE", { timeZone: "Europe/Athens" })}
             </span>
           )}
         </div>

--- a/src/app/[locale]/admin/crm/page.tsx
+++ b/src/app/[locale]/admin/crm/page.tsx
@@ -140,7 +140,7 @@ export default function AdminCRMPage() {
                   </td>
                   <td className="px-6 py-4 font-mono text-slate-500">
                     {c.properties?.createdate
-                      ? new Date(c.properties?.createdate).toLocaleDateString("en-IE")
+                      ? new Date(c.properties?.createdate).toLocaleDateString("en-IE", { timeZone: "Europe/Athens" })
                       : "—"}
                   </td>
                 </tr>

--- a/src/app/[locale]/admin/crm/tickets/page.tsx
+++ b/src/app/[locale]/admin/crm/tickets/page.tsx
@@ -149,7 +149,7 @@ export default function AdminTicketsPage() {
                     </td>
                     <td className="px-6 py-4 font-mono text-slate-500">
                       {t.properties.createdate
-                        ? new Date(t.properties.createdate).toLocaleDateString("en-IE")
+                        ? new Date(t.properties.createdate).toLocaleDateString("en-IE", { timeZone: "Europe/Athens" })
                         : "—"}
                     </td>
                   </tr>
@@ -193,7 +193,7 @@ export default function AdminTicketsPage() {
           </button>
           {fetchedAt && (
             <span className="font-mono text-[10px] text-slate-600">
-              Updated {new Date(fetchedAt).toLocaleTimeString("en-IE")}
+              Updated {new Date(fetchedAt).toLocaleTimeString("en-IE", { timeZone: "Europe/Athens" })}
             </span>
           )}
         </div>

--- a/src/app/[locale]/admin/email/page.tsx
+++ b/src/app/[locale]/admin/email/page.tsx
@@ -107,10 +107,8 @@ export default function EmailPage() {
           <div className="h-8 w-px bg-slate-800" />
           <p className="font-mono text-xs text-slate-600">
             via EspoCRM CRM ·{" "}
-            {new Date(data.fetchedAt).toLocaleTimeString("en-IE", {
-              hour: "2-digit",
-              minute: "2-digit",
-            })}
+            {new Date(data.fetchedAt).toLocaleTimeString("en-IE", { hour: "2-digit",
+              minute: "2-digit", timeZone: "Europe/Athens" })}
           </p>
         </div>
       )}
@@ -197,7 +195,7 @@ export default function EmailPage() {
                       </td>
                     )}
                     <td className="px-4 py-3 font-mono text-xs text-slate-500">
-                      {p.createdate ? new Date(p.createdate).toLocaleDateString("en-IE") : "—"}
+                      {p.createdate ? new Date(p.createdate).toLocaleDateString("en-IE", { timeZone: "Europe/Athens" }) : "—"}
                     </td>
                   </tr>
                 );

--- a/src/app/[locale]/admin/errors/page.tsx
+++ b/src/app/[locale]/admin/errors/page.tsx
@@ -275,9 +275,9 @@ export default function AdminErrorsPage() {
                       {issue.culprit || "unknown location"}
                     </p>
                     <p className="mt-1 font-mono text-[10px] text-slate-600">
-                      First: {new Date(issue.firstSeen).toLocaleDateString("en-IE")}
+                      First: {new Date(issue.firstSeen).toLocaleDateString("en-IE", { timeZone: "Europe/Athens" })}
                       {" · "}
-                      Last: {new Date(issue.lastSeen).toLocaleDateString("en-IE")}
+                      Last: {new Date(issue.lastSeen).toLocaleDateString("en-IE", { timeZone: "Europe/Athens" })}
                     </p>
                   </div>
 

--- a/src/app/[locale]/admin/esp32-manager/page.tsx
+++ b/src/app/[locale]/admin/esp32-manager/page.tsx
@@ -96,7 +96,7 @@ function fmtRam(b?: number): string {
 function fmtTs(iso?: string): string {
   if (!iso) return "—";
   try {
-    return new Date(iso).toLocaleTimeString();
+    return new Date(iso).toLocaleTimeString(undefined, { timeZone: "Europe/Athens" });
   } catch {
     return iso;
   }

--- a/src/app/[locale]/admin/esp32/page.tsx
+++ b/src/app/[locale]/admin/esp32/page.tsx
@@ -14,6 +14,7 @@
 import { fetchWithAuth } from "@/lib/fetch-with-auth";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { useVisiblePoll } from "@/lib/use-visible-poll";
+import { APP_TIMEZONE } from "@/lib/timezone";
 
 // ── Types ──────────────────────────────────────────────────────────────────────
 
@@ -112,7 +113,7 @@ function fmtRam(b: number | null): string {
 
 function fmtTs(iso: string | null): string {
   if (!iso) return "—";
-  return new Date(iso).toLocaleString("en-IE", { timeZone: "Europe/Athens" });
+  return new Date(iso).toLocaleString("en-IE", { timeZone: APP_TIMEZONE });
 }
 
 function rssiBar(rssi: number | null): { width: string; color: string } {
@@ -521,7 +522,7 @@ export default function AdminEsp32Page() {
               <div key={i} className={`flex gap-3 ${entry.historic ? "opacity-50" : ""}`}>
                 <span className="shrink-0 text-slate-600 select-none">
                   {new Date(entry.ts).toLocaleTimeString("en-IE", {
-                    timeZone: "Europe/Athens",
+                    timeZone: APP_TIMEZONE,
                     hour12: false,
                   })}
                 </span>

--- a/src/app/[locale]/admin/headlamp/page.tsx
+++ b/src/app/[locale]/admin/headlamp/page.tsx
@@ -98,7 +98,7 @@ export default function HeadlampHelperPage() {
       {status === "ready" && (
         <div className="space-y-3 rounded-lg border border-green-300 bg-green-50 p-4 text-sm dark:border-green-800 dark:bg-green-950">
           <p className="font-medium text-green-800 dark:text-green-200">
-            ✅ Token copied to clipboard. Expires {new Date(expiresAt).toLocaleString()}.
+            ✅ Token copied to clipboard. Expires {new Date(expiresAt).toLocaleString(undefined, { timeZone: "Europe/Athens" })}.
           </p>
           <details>
             <summary className="cursor-pointer text-green-900 dark:text-green-100">

--- a/src/app/[locale]/admin/integrations/page.tsx
+++ b/src/app/[locale]/admin/integrations/page.tsx
@@ -268,11 +268,9 @@ export default function IntegrationsPage() {
       {checkedAt && (
         <p className="mt-6 font-mono text-xs text-slate-600">
           Last checked:{" "}
-          {new Date(checkedAt).toLocaleTimeString("en-IE", {
-            hour: "2-digit",
+          {new Date(checkedAt).toLocaleTimeString("en-IE", { hour: "2-digit",
             minute: "2-digit",
-            second: "2-digit",
-          })}
+            second: "2-digit", timeZone: "Europe/Athens" })}
         </p>
       )}
     </div>

--- a/src/app/[locale]/admin/kpi/page.tsx
+++ b/src/app/[locale]/admin/kpi/page.tsx
@@ -304,7 +304,7 @@ export default function KpiDashboard() {
 
           {/* Footer */}
           <p className="text-right font-mono text-xs text-slate-700">
-            Fetched at {new Date(data.fetchedAt).toLocaleTimeString()}
+            Fetched at {new Date(data.fetchedAt).toLocaleTimeString(undefined, { timeZone: "Europe/Athens" })}
           </p>
         </div>
       )}

--- a/src/app/[locale]/admin/leads/page.tsx
+++ b/src/app/[locale]/admin/leads/page.tsx
@@ -26,7 +26,7 @@ const SOURCE_BADGE: Record<string, string> = {
 function formatDate(iso?: string): string {
   if (!iso) return "—";
   const d = new Date(iso);
-  return Number.isNaN(d.getTime()) ? "—" : d.toLocaleDateString("en-IE", { dateStyle: "medium" });
+  return Number.isNaN(d.getTime()) ? "—" : d.toLocaleDateString("en-IE", { dateStyle: "medium", timeZone: "Europe/Athens" });
 }
 
 export default function AdminLeadsPage() {
@@ -100,7 +100,7 @@ export default function AdminLeadsPage() {
         <div className="flex items-center gap-3">
           {fetchedAt && (
             <span className="font-mono text-xs text-slate-500">
-              Updated {new Date(fetchedAt).toLocaleTimeString()}
+              Updated {new Date(fetchedAt).toLocaleTimeString(undefined, { timeZone: "Europe/Athens" })}
             </span>
           )}
           <button

--- a/src/app/[locale]/admin/monitor/page.tsx
+++ b/src/app/[locale]/admin/monitor/page.tsx
@@ -17,6 +17,7 @@
 import { fetchWithAuth } from "@/lib/fetch-with-auth";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { useVisiblePoll } from "@/lib/use-visible-poll";
+import { APP_TIMEZONE } from "@/lib/timezone";
 
 // ── Types ──────────────────────────────────────────────────────────────────────
 
@@ -133,7 +134,7 @@ function fmtRam(b: number | null): string {
 
 function fmtTs(iso: string | null): string {
   if (!iso) return "—";
-  return new Date(iso).toLocaleString("en-IE", { timeZone: "Europe/Athens" });
+  return new Date(iso).toLocaleString("en-IE", { timeZone: APP_TIMEZONE });
 }
 
 function piStatusDot(status: string) {
@@ -537,7 +538,7 @@ export default function AdminMonitorPage() {
               <div key={i} className="flex gap-3">
                 <span className="shrink-0 text-slate-600 select-none">
                   {new Date(entry.ts).toLocaleTimeString("en-IE", {
-                    timeZone: "Europe/Athens",
+                    timeZone: APP_TIMEZONE,
                     hour12: false,
                   })}
                 </span>

--- a/src/app/[locale]/admin/notifications/page.tsx
+++ b/src/app/[locale]/admin/notifications/page.tsx
@@ -205,8 +205,8 @@ export default function NotificationsPage() {
               </div>
             </div>
             <div className="font-mono text-[10px] text-slate-500">
-              {new Date(analytics.window.since).toLocaleDateString()} to{" "}
-              {new Date(analytics.window.until).toLocaleDateString()}
+              {new Date(analytics.window.since).toLocaleDateString(undefined, { timeZone: "Europe/Athens" })} to{" "}
+              {new Date(analytics.window.until).toLocaleDateString(undefined, { timeZone: "Europe/Athens" })}
             </div>
           </div>
           {days.length > 0 && (
@@ -263,7 +263,7 @@ export default function NotificationsPage() {
                 </div>
                 <div className="flex items-center gap-2">
                   <span className="font-mono text-[10px] text-slate-500">
-                    {new Date(n.createdAt).toLocaleString()}
+                    {new Date(n.createdAt).toLocaleString(undefined, { timeZone: "Europe/Athens" })}
                   </span>
                   {!n.read && (
                     <button

--- a/src/app/[locale]/admin/notion/analytics/page.tsx
+++ b/src/app/[locale]/admin/notion/analytics/page.tsx
@@ -53,12 +53,10 @@ const TYPE_LABELS: Record<AnalyticsEventType | "weekly_rollup", string> = {
 function formatDate(iso: string) {
   if (!iso) return "—";
   try {
-    return new Date(iso).toLocaleString("en-GB", {
-      day: "2-digit",
+    return new Date(iso).toLocaleString("en-GB", { day: "2-digit",
       month: "short",
       hour: "2-digit",
-      minute: "2-digit",
-    });
+      minute: "2-digit", timeZone: "Europe/Athens" });
   } catch {
     return iso;
   }

--- a/src/app/[locale]/admin/notion/page.tsx
+++ b/src/app/[locale]/admin/notion/page.tsx
@@ -26,13 +26,11 @@ const STATUS_STYLES: Record<string, string> = {
 
 function formatDate(iso: string) {
   try {
-    return new Date(iso).toLocaleString("en-GB", {
-      day: "2-digit",
+    return new Date(iso).toLocaleString("en-GB", { day: "2-digit",
       month: "short",
       year: "numeric",
       hour: "2-digit",
-      minute: "2-digit",
-    });
+      minute: "2-digit", timeZone: "Europe/Athens" });
   } catch {
     return iso;
   }

--- a/src/app/[locale]/admin/notion/projects/page.tsx
+++ b/src/app/[locale]/admin/notion/projects/page.tsx
@@ -29,11 +29,9 @@ const PRIORITY_ICONS: Record<string, string> = {
 function formatDate(iso: string) {
   if (!iso) return "—";
   try {
-    return new Date(iso).toLocaleDateString("en-GB", {
-      day: "2-digit",
+    return new Date(iso).toLocaleDateString("en-GB", { day: "2-digit",
       month: "short",
-      year: "numeric",
-    });
+      year: "numeric", timeZone: "Europe/Athens" });
   } catch {
     return iso;
   }

--- a/src/app/[locale]/admin/notion/submissions/page.tsx
+++ b/src/app/[locale]/admin/notion/submissions/page.tsx
@@ -26,11 +26,9 @@ const VALID_STATUSES = ["New", "In Review", "Done"] as const;
 function formatDate(iso?: string) {
   if (!iso) return "";
   try {
-    return new Date(iso).toLocaleDateString("en-GB", {
-      day: "2-digit",
+    return new Date(iso).toLocaleDateString("en-GB", { day: "2-digit",
       month: "short",
-      year: "numeric",
-    });
+      year: "numeric", timeZone: "Europe/Athens" });
   } catch {
     return iso;
   }

--- a/src/app/[locale]/admin/notion/tasks/page.tsx
+++ b/src/app/[locale]/admin/notion/tasks/page.tsx
@@ -57,10 +57,8 @@ const TYPE_ICONS: Record<string, string> = {
 function formatDate(iso: string) {
   if (!iso) return "";
   try {
-    return new Date(iso).toLocaleDateString("en-GB", {
-      day: "2-digit",
-      month: "short",
-    });
+    return new Date(iso).toLocaleDateString("en-GB", { day: "2-digit",
+      month: "short", timeZone: "Europe/Athens" });
   } catch {
     return iso;
   }

--- a/src/app/[locale]/admin/orders/page.tsx
+++ b/src/app/[locale]/admin/orders/page.tsx
@@ -180,7 +180,7 @@ export default function AdminOrdersPage() {
                       </span>
                     </td>
                     <td className="px-6 py-4 font-mono text-slate-500">
-                      {new Date(order.created).toLocaleDateString("en-IE")}
+                      {new Date(order.created).toLocaleDateString("en-IE", { timeZone: "Europe/Athens" })}
                     </td>
                   </tr>
                 ))}
@@ -240,7 +240,7 @@ export default function AdminOrdersPage() {
                       </span>
                     </td>
                     <td className="px-6 py-4 font-mono text-slate-500">
-                      {new Date(sub.currentPeriodEnd).toLocaleDateString("en-IE")}
+                      {new Date(sub.currentPeriodEnd).toLocaleDateString("en-IE", { timeZone: "Europe/Athens" })}
                     </td>
                   </tr>
                 ))}

--- a/src/app/[locale]/admin/pipeline/page.tsx
+++ b/src/app/[locale]/admin/pipeline/page.tsx
@@ -222,10 +222,8 @@ function DealCard({
       {deal.properties.closedate && (
         <p className="mt-1 font-mono text-[10px] text-slate-600">
           Close:{" "}
-          {new Date(deal.properties.closedate).toLocaleDateString("en-IE", {
-            day: "numeric",
-            month: "short",
-          })}
+          {new Date(deal.properties.closedate).toLocaleDateString("en-IE", { day: "numeric",
+            month: "short", timeZone: "Europe/Athens" })}
         </p>
       )}
       {stages.length > 1 && (

--- a/src/app/[locale]/admin/postiz/page.tsx
+++ b/src/app/[locale]/admin/postiz/page.tsx
@@ -353,7 +353,7 @@ function ComposeTab({
     const { date } = (await res.json()) as { date: string };
     // datetime-local input wants local time, no seconds/zone.
     setDraft({ scheduleAt: new Date(date).toISOString().slice(0, 16) });
-    setFeedback(`Next free slot: ${new Date(date).toLocaleString()}`);
+    setFeedback(`Next free slot: ${new Date(date).toLocaleString(undefined, { timeZone: "Europe/Athens" })}`);
   };
 
   const aiDraft = async () => {
@@ -629,7 +629,7 @@ function ScheduleTab({
           <li key={p.id} className="space-y-1 p-3">
             <div className="flex items-center justify-between gap-3">
               <div className="text-xs text-gray-500">
-                {new Date(p.publishDate).toLocaleString()} · {p.state} · {p.integration.name} (
+                {new Date(p.publishDate).toLocaleString(undefined, { timeZone: "Europe/Athens" })} · {p.state} · {p.integration.name} (
                 {postIdentifier(p)})
               </div>
               <div className="flex gap-3 text-xs">

--- a/src/app/[locale]/admin/projects/page.tsx
+++ b/src/app/[locale]/admin/projects/page.tsx
@@ -26,11 +26,9 @@ const TASK_STATUS_COLORS: Record<TaskStatus, string> = {
 function formatDate(iso: string) {
   if (!iso) return "—";
   try {
-    return new Date(iso).toLocaleDateString("en-GB", {
-      day: "2-digit",
+    return new Date(iso).toLocaleDateString("en-GB", { day: "2-digit",
       month: "short",
-      year: "numeric",
-    });
+      year: "numeric", timeZone: "Europe/Athens" });
   } catch {
     return iso;
   }

--- a/src/app/[locale]/admin/settings/page.tsx
+++ b/src/app/[locale]/admin/settings/page.tsx
@@ -110,7 +110,7 @@ export default function AdminSettingsPage() {
       const data = (await res.json()) as CacheClearResponse;
       if (!res.ok) throw new Error(data.error ?? `HTTP ${res.status}`);
       const timestamp = data.clearedAt
-        ? new Date(data.clearedAt).toLocaleTimeString("en-IE")
+        ? new Date(data.clearedAt).toLocaleTimeString("en-IE", { timeZone: "Europe/Athens" })
         : "now";
       setCacheMsg({ ok: true, text: `Cache cleared: ${data.clearedPrefix} at ${timestamp}` });
     } catch (err) {

--- a/src/app/[locale]/admin/subscriptions/page.tsx
+++ b/src/app/[locale]/admin/subscriptions/page.tsx
@@ -24,11 +24,9 @@ function formatAmount(amount: number, currency: string, interval: string) {
 }
 
 function formatDate(unix: number) {
-  return new Date(unix * 1000).toLocaleDateString("en-IE", {
-    day: "numeric",
+  return new Date(unix * 1000).toLocaleDateString("en-IE", { day: "numeric",
     month: "short",
-    year: "numeric",
-  });
+    year: "numeric", timeZone: "Europe/Athens" });
 }
 
 export default function SubscriptionsPage() {

--- a/src/app/[locale]/admin/users/page.tsx
+++ b/src/app/[locale]/admin/users/page.tsx
@@ -266,7 +266,7 @@ export default function AdminUsersPage() {
 
                     {/* Joined */}
                     <td className="px-6 py-4 font-mono text-slate-500">
-                      {user.created ? new Date(user.created).toLocaleDateString("en-IE") : "—"}
+                      {user.created ? new Date(user.created).toLocaleDateString("en-IE", { timeZone: "Europe/Athens" }) : "—"}
                     </td>
 
                     {/* Actions */}

--- a/src/app/[locale]/admin/voice-brief/page.tsx
+++ b/src/app/[locale]/admin/voice-brief/page.tsx
@@ -139,7 +139,7 @@ export default function VoiceBriefPage() {
             <span className="font-mono text-xs text-slate-500">
               Generated:{" "}
               <span className="text-white">
-                {new Date(brief.generatedAt).toLocaleString("en-IE")}
+                {new Date(brief.generatedAt).toLocaleString("en-IE", { timeZone: "Europe/Athens" })}
               </span>
             </span>
           </div>

--- a/src/app/[locale]/admin/workspaces/page.tsx
+++ b/src/app/[locale]/admin/workspaces/page.tsx
@@ -458,7 +458,7 @@ export default function WorkspacesPage() {
                       </p>
                     )}
                     <p className="mt-1 font-mono text-xs text-slate-700">
-                      created {new Date(ws.createdAt).toLocaleDateString("en-IE")}
+                      created {new Date(ws.createdAt).toLocaleDateString("en-IE", { timeZone: "Europe/Athens" })}
                     </p>
                   </div>
                   <div className="flex gap-2">

--- a/src/app/[locale]/campaigns/page.tsx
+++ b/src/app/[locale]/campaigns/page.tsx
@@ -63,9 +63,9 @@ export default async function CampaignsIndex({ params }: PageProps) {
           {campaigns.map((c) => (
             <li key={c.slug} className="cl-cam-card">
               <div className="cl-cam-card__meta">
-                <time dateTime={c.startsAt}>{new Date(c.startsAt).toLocaleDateString(locale)}</time>
+                <time dateTime={c.startsAt}>{new Date(c.startsAt).toLocaleDateString(locale, { timeZone: "Europe/Athens" })}</time>
                 <span aria-hidden> — </span>
-                <time dateTime={c.endsAt}>{new Date(c.endsAt).toLocaleDateString(locale)}</time>
+                <time dateTime={c.endsAt}>{new Date(c.endsAt).toLocaleDateString(locale, { timeZone: "Europe/Athens" })}</time>
               </div>
               <h2>{c.headline[locale]}</h2>
               <p>{c.subhead[locale]}</p>

--- a/src/app/[locale]/dashboard/consultations/page.tsx
+++ b/src/app/[locale]/dashboard/consultations/page.tsx
@@ -157,22 +157,16 @@ export default function ConsultationsPage() {
                   </div>
                   <p className="mt-2 font-mono text-sm text-white">{c.title}</p>
                   <p className="mt-1 font-mono text-xs text-slate-500">
-                    {new Date(c.start).toLocaleDateString("en-IE", {
-                      weekday: "long",
+                    {new Date(c.start).toLocaleDateString("en-IE", { weekday: "long",
                       year: "numeric",
                       month: "long",
-                      day: "numeric",
-                    })}{" "}
+                      day: "numeric", timeZone: "Europe/Athens" })}{" "}
                     at{" "}
-                    {new Date(c.start).toLocaleTimeString("en-IE", {
-                      hour: "2-digit",
-                      minute: "2-digit",
-                    })}
+                    {new Date(c.start).toLocaleTimeString("en-IE", { hour: "2-digit",
+                      minute: "2-digit", timeZone: "Europe/Athens" })}
                     {" – "}
-                    {new Date(c.end).toLocaleTimeString("en-IE", {
-                      hour: "2-digit",
-                      minute: "2-digit",
-                    })}
+                    {new Date(c.end).toLocaleTimeString("en-IE", { hour: "2-digit",
+                      minute: "2-digit", timeZone: "Europe/Athens" })}
                   </p>
                 </div>
                 {c.meetLink && c.status === "upcoming" && (

--- a/src/app/[locale]/dashboard/purchases/page.tsx
+++ b/src/app/[locale]/dashboard/purchases/page.tsx
@@ -191,7 +191,7 @@ export default function PurchasesPage() {
                         {p.status}
                       </span>
                       <span className="font-mono text-xs text-slate-600">
-                        {new Date(p.date).toLocaleDateString("en-IE")}
+                        {new Date(p.date).toLocaleDateString("en-IE", { timeZone: "Europe/Athens" })}
                       </span>
                     </div>
                     <div className="mt-2 space-y-1">
@@ -253,7 +253,7 @@ export default function PurchasesPage() {
                 </div>
                 <div className="text-right">
                   <p className="font-mono text-xs text-slate-500">
-                    Renews {new Date(sub.currentPeriodEnd).toLocaleDateString("en-IE")}
+                    Renews {new Date(sub.currentPeriodEnd).toLocaleDateString("en-IE", { timeZone: "Europe/Athens" })}
                   </p>
                 </div>
               </div>

--- a/src/app/[locale]/dashboard/services/page.tsx
+++ b/src/app/[locale]/dashboard/services/page.tsx
@@ -99,11 +99,9 @@ export default function ServicesPage() {
         {portalStatus?.submittedAt && (
           <p className="mt-3 font-mono text-xs text-slate-500">
             Enrolled:{" "}
-            {new Date(portalStatus.submittedAt).toLocaleDateString("en-IE", {
-              day: "numeric",
+            {new Date(portalStatus.submittedAt).toLocaleDateString("en-IE", { day: "numeric",
               month: "short",
-              year: "numeric",
-            })}
+              year: "numeric", timeZone: "Europe/Athens" })}
           </p>
         )}
       </div>

--- a/src/app/[locale]/docs/page.tsx
+++ b/src/app/[locale]/docs/page.tsx
@@ -265,11 +265,9 @@ export default async function DocsPage({ searchParams }: { searchParams: SearchP
                               {doc.lastVerified && (
                                 <span className="font-mono text-[9px] text-slate-600">
                                   Verified:{" "}
-                                  {new Date(doc.lastVerified).toLocaleDateString("en-GB", {
-                                    day: "2-digit",
+                                  {new Date(doc.lastVerified).toLocaleDateString("en-GB", { day: "2-digit",
                                     month: "short",
-                                    year: "numeric",
-                                  })}
+                                    year: "numeric", timeZone: "Europe/Athens" })}
                                 </span>
                               )}
                             </div>

--- a/src/app/api/admin/reports/[id]/pdf/route.ts
+++ b/src/app/api/admin/reports/[id]/pdf/route.ts
@@ -78,7 +78,7 @@ export async function GET(
     <h1>${escapeHtml(report.clientName)} — Performance Report</h1>
     <div class="meta">
       <span>Period: ${escapeHtml(report.dateRange.start)} to ${escapeHtml(report.dateRange.end)}</span>
-      <span>Generated: ${new Date(report.createdAt).toLocaleDateString("en-IE", { year: "numeric", month: "long", day: "numeric" })}</span>
+      <span>Generated: ${new Date(report.createdAt).toLocaleDateString("en-IE", { year: "numeric", month: "long", day: "numeric", timeZone: "Europe/Athens" })}</span>
       <span>Status: ${escapeHtml(report.status)}</span>
     </div>
   </header>

--- a/src/app/api/admin/voice-brief/route.ts
+++ b/src/app/api/admin/voice-brief/route.ts
@@ -23,12 +23,10 @@ export async function POST(request: NextRequest) {
 
   try {
     const agentResult = await runVoiceBriefAgent({
-      dateLabel: new Date().toLocaleDateString("en-IE", {
-        weekday: "long",
+      dateLabel: new Date().toLocaleDateString("en-IE", { weekday: "long",
         year: "numeric",
         month: "long",
-        day: "numeric",
-      }),
+        day: "numeric", timeZone: "Europe/Athens" }),
     });
     const brief: VoiceBrief = {
       text: agentResult.text,

--- a/src/app/api/calendar/book/route.ts
+++ b/src/app/api/calendar/book/route.ts
@@ -87,13 +87,13 @@ export async function POST(request: Request) {
         });
         if (contactId) {
           const noteLines = [
-            `Consultation booked: ${new Date(start).toLocaleString("en-IE")}`,
+            `Consultation booked: ${new Date(start).toLocaleString("en-IE", { timeZone: "Europe/Athens" })}`,
             ...(notes ? [`Notes: ${notes}`] : []),
           ];
           await createContactNote(contactId, noteLines.join("\n"));
         }
         const dealId = await createDeal({
-          dealname: `Consultation – ${name} (${new Date(start).toLocaleDateString("en-IE")})`,
+          dealname: `Consultation – ${name} (${new Date(start).toLocaleDateString("en-IE", { timeZone: "Europe/Athens" })})`,
           dealstage: "appointmentscheduled",
           lead_source: "calendar_booking",
           closedate: new Date(start).toISOString(),

--- a/src/app/api/cron/voice-brief/route.ts
+++ b/src/app/api/cron/voice-brief/route.ts
@@ -98,12 +98,10 @@ export async function GET(request: NextRequest) {
 
   try {
     const agentResult = await runVoiceBriefAgent({
-      dateLabel: new Date().toLocaleDateString("en-IE", {
-        weekday: "long",
+      dateLabel: new Date().toLocaleDateString("en-IE", { weekday: "long",
         year: "numeric",
         month: "long",
-        day: "numeric",
-      }),
+        day: "numeric", timeZone: "Europe/Athens" }),
     });
     text = agentResult.text;
     sources = agentResult.sources;

--- a/src/app/api/newsletter-slack/commands/route.ts
+++ b/src/app/api/newsletter-slack/commands/route.ts
@@ -380,7 +380,7 @@ async function handleStats(): Promise<Response> {
           { type: "mrkdwn", text: `*Subscribers*\n${subscriberCount}` },
           { type: "mrkdwn", text: `*Pending drafts*\n${draftCount} (gates blocked)` },
           { type: "mrkdwn", text: `*In Review*\n${inReviewCount} (ready to send)` },
-          { type: "mrkdwn", text: `*Cadence*\nMon 08:15 UTC draft · 11:15 publish` },
+          { type: "mrkdwn", text: `*Cadence*\nMon 11:15 EET/EEST draft · 14:15 publish (Europe/Athens)` },
         ],
       },
     ],

--- a/src/app/api/newsletter-slack/events/route.ts
+++ b/src/app/api/newsletter-slack/events/route.ts
@@ -347,7 +347,7 @@ function renderHomeView(userId: string, data: DashboardData): unknown {
         elements: [
           {
             type: "mrkdwn",
-            text: "Cadence: Mon 08:15 UTC draft → 11:15 UTC publish · Code: `scripts/article-quality-gates.ts`",
+            text: "Cadence: Mon 11:15 → 14:15 Europe/Athens draft/publish · Code: `scripts/article-quality-gates.ts`",
           },
         ],
       },

--- a/src/app/api/portal/enroll/route.ts
+++ b/src/app/api/portal/enroll/route.ts
@@ -138,13 +138,11 @@ async function notifyAdminOfPendingClient(pending: {
   submittedAt: string;
   notes?: string;
 }) {
-  const submittedDate = new Date(pending.submittedAt).toLocaleString("en-IE", {
-    day: "numeric",
+  const submittedDate = new Date(pending.submittedAt).toLocaleString("en-IE", { day: "numeric",
     month: "short",
     year: "numeric",
     hour: "2-digit",
-    minute: "2-digit",
-  });
+    minute: "2-digit", timeZone: "Europe/Athens" });
   const adminUrl = `${BASE_URL}/admin/client-portals`;
 
   // Email — sent from noreply@cloudless.gr (per SES_FROM_EMAIL config) to admin

--- a/src/app/portal/[token]/page.tsx
+++ b/src/app/portal/[token]/page.tsx
@@ -72,11 +72,9 @@ function formatAmount(cents: number, currency: string) {
 }
 
 function formatDate(unix: number) {
-  return new Date(unix * 1000).toLocaleDateString("en-IE", {
-    day: "numeric",
+  return new Date(unix * 1000).toLocaleDateString("en-IE", { day: "numeric",
     month: "short",
-    year: "numeric",
-  });
+    year: "numeric", timeZone: "Europe/Athens" });
 }
 
 function formatRelative(iso: string) {
@@ -88,10 +86,8 @@ function formatRelative(iso: string) {
   if (hr < 24) return `${hr}h ago`;
   const days = Math.floor(hr / 24);
   if (days < 7) return `${days}d ago`;
-  return new Date(iso).toLocaleDateString("en-IE", {
-    day: "numeric",
-    month: "short",
-  });
+  return new Date(iso).toLocaleDateString("en-IE", { day: "numeric",
+    month: "short", timeZone: "Europe/Athens" });
 }
 
 const STEP_CONFIG: Record<

--- a/src/app/portal/waiting/WaitingRoomClient.tsx
+++ b/src/app/portal/waiting/WaitingRoomClient.tsx
@@ -358,7 +358,7 @@ function WaitingRoomContent() {
                   `$ portal order --status`,
                   `  ✓ account: ${status.email}`,
                   `  ✓ plan: ${status.planLabel ?? PLAN_LABELS[status.plan ?? ""] ?? status.plan}`,
-                  `  ✓ submitted: ${status.submittedAt ? new Date(status.submittedAt).toLocaleString("en-IE", { day: "numeric", month: "short", hour: "2-digit", minute: "2-digit" }) : "just now"}`,
+                  `  ✓ submitted: ${status.submittedAt ? new Date(status.submittedAt).toLocaleString("en-IE", { day: "numeric", month: "short", hour: "2-digit", minute: "2-digit", timeZone: "Europe/Athens" }) : "just now"}`,
                   `  ---`,
                   `  status: pending review`,
                   `  estimated wait: usually < 24h`,

--- a/src/components/CampaignHero.tsx
+++ b/src/components/CampaignHero.tsx
@@ -35,8 +35,8 @@ export default function CampaignHero({ campaign, locale }: Props) {
               </strong>
               <span>
                 {locale === "el"
-                  ? `Λήγει ${new Date(campaign.endsAt).toLocaleDateString("el")}`
-                  : `Closes ${new Date(campaign.endsAt).toLocaleDateString("en")}`}
+                  ? `Λήγει ${new Date(campaign.endsAt).toLocaleDateString("el", { timeZone: "Europe/Athens" })}`
+                  : `Closes ${new Date(campaign.endsAt).toLocaleDateString("en", { timeZone: "Europe/Athens" })}`}
               </span>
             </div>
           ) : null}

--- a/src/components/ProjectCard.tsx
+++ b/src/components/ProjectCard.tsx
@@ -46,10 +46,8 @@ const TYPE_STYLES: Record<string, string> = {
 function formatDate(iso: string) {
   if (!iso) return null;
   try {
-    return new Date(iso).toLocaleDateString("en-GB", {
-      month: "short",
-      year: "numeric",
-    });
+    return new Date(iso).toLocaleDateString("en-GB", { month: "short",
+      year: "numeric", timeZone: "Europe/Athens" });
   } catch {
     return null;
   }

--- a/src/lib/ad-analytics/digest.ts
+++ b/src/lib/ad-analytics/digest.ts
@@ -9,6 +9,7 @@
 
 import type { AdConversionEvent, AdMetrics, DemographicBreakdown, DemographicPivot } from "./types";
 import type { NotificationBlock } from "./channels/notification";
+import { APP_TIMEZONE } from "@/lib/timezone";
 
 const FLAG_BY_COUNTRY: Record<string, string> = {
   GR: "🇬🇷",
@@ -52,7 +53,7 @@ export function renderConversionBlocks(
   const capiLine = formatCapiStatus(capiResults);
 
   const athensTime = new Date().toLocaleString("en-GB", {
-    timeZone: "Europe/Athens",
+    timeZone: APP_TIMEZONE,
     hour: "2-digit",
     minute: "2-digit",
     day: "2-digit",

--- a/src/lib/admin-assistant-tools.ts
+++ b/src/lib/admin-assistant-tools.ts
@@ -75,7 +75,7 @@ export async function runAssistantTool(
       return results
         .map(
           (r) =>
-            `• [${r.title || "(untitled)"}](${r.url}) — ${r.type}, last edited ${new Date(r.lastEditedTime).toLocaleDateString("en-GB")}`
+            `• [${r.title || "(untitled)"}](${r.url}) — ${r.type}, last edited ${new Date(r.lastEditedTime).toLocaleDateString("en-GB", { timeZone: "Europe/Athens" })}`
         )
         .join("\n");
     }
@@ -87,7 +87,7 @@ export async function runAssistantTool(
       return orders
         .map((o) => {
           const amount = `${o.currency} ${(o.amount / 100).toFixed(2)}`;
-          const date = new Date(o.created * 1000).toLocaleDateString("en-GB");
+          const date = new Date(o.created * 1000).toLocaleDateString("en-GB", { timeZone: "Europe/Athens" });
           return `• ${o.email ?? "unknown"} — ${amount} — ${o.paymentStatus} — ${date}`;
         })
         .join("\n");

--- a/src/lib/admin-notifications.ts
+++ b/src/lib/admin-notifications.ts
@@ -1,5 +1,6 @@
 import { getDataLakeBucketFromEnv } from "@/lib/r2-client";
 import { getAuthDbFromEnv, type AuthDatabase } from "@/lib/auth-d1";
+import { APP_TIMEZONE } from "@/lib/timezone";
 
 /**
  * Durable admin notifications store.
@@ -323,8 +324,13 @@ async function sinkToLake(notif: AdminNotification): Promise<void> {
   }
 
   const d = new Date(notif.createdAt);
-  const year = String(d.getUTCFullYear());
-  const month = String(d.getUTCMonth() + 1).padStart(2, "0");
+  const athensDay = new Intl.DateTimeFormat("en-CA", {
+    timeZone: APP_TIMEZONE,
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+  }).format(d); // YYYY-MM-DD
+  const [year, month] = athensDay.split("-");
   const key = `lake/notifications/year=${year}/month=${month}/${notif.id}.json`;
 
   const record = JSON.stringify({

--- a/src/lib/analytics-report-pdf.ts
+++ b/src/lib/analytics-report-pdf.ts
@@ -1,5 +1,6 @@
 import { PDFDocument, StandardFonts, rgb, type PDFFont, type PDFPage } from "pdf-lib";
 import type { AnalyticsOrchestrationResult } from "@/lib/analytics-agent-orchestrator";
+import { APP_TIMEZONE } from "@/lib/timezone";
 
 const PAGE_WIDTH = 595.28;
 const PAGE_HEIGHT = 841.89;
@@ -183,8 +184,8 @@ export async function renderAnalyticsReportPdf(params: {
   state = { ...state, y: state.y - 24 };
   state.page.drawText(
     `Generated ${new Date(result.snapshot.generatedAt).toLocaleString("en-IE", {
-      timeZone: "UTC",
-    })} UTC`,
+      timeZone: APP_TIMEZONE,
+    })} (Europe/Athens)`,
     {
       x: PAGE_MARGIN,
       y: state.y,

--- a/src/lib/blog.ts
+++ b/src/lib/blog.ts
@@ -1,3 +1,5 @@
+import { APP_TIMEZONE } from "@/lib/timezone";
+
 export interface BlogPost {
   slug: string;
   title: string;
@@ -425,8 +427,11 @@ export function getPostBySlug(slug: string): BlogPost | undefined {
   return posts.find((p) => p.slug === slug);
 }
 
+import { APP_TIMEZONE } from "@/lib/timezone";
+
 export function formatDate(dateStr: string): string {
   return new Date(dateStr).toLocaleDateString("en-IE", {
+    timeZone: APP_TIMEZONE,
     year: "numeric",
     month: "long",
     day: "numeric",

--- a/src/lib/booking-slots.ts
+++ b/src/lib/booking-slots.ts
@@ -6,15 +6,16 @@
  * labels and clamp `days_ahead` identically.
  */
 
+import { APP_TIMEZONE } from "@/lib/timezone";
+
 export const MIN_DAYS_AHEAD = 1;
 export const MAX_DAYS_AHEAD = 14;
 export const DEFAULT_DAYS_AHEAD = 7;
 
-const ATHENS_TZ = "Europe/Athens";
 const TWO_DIGIT = "2-digit" as const;
 
 const ATHENS_DATE_FORMAT: Intl.DateTimeFormatOptions = {
-  timeZone: ATHENS_TZ,
+  timeZone: APP_TIMEZONE,
   weekday: "short",
   month: "short",
   day: "numeric",
@@ -24,7 +25,7 @@ const ATHENS_DATE_FORMAT: Intl.DateTimeFormatOptions = {
 };
 
 const ATHENS_TIME_ONLY_FORMAT: Intl.DateTimeFormatOptions = {
-  timeZone: ATHENS_TZ,
+  timeZone: APP_TIMEZONE,
   hour: TWO_DIGIT,
   minute: TWO_DIGIT,
   hour12: false,

--- a/src/lib/google-calendar.ts
+++ b/src/lib/google-calendar.ts
@@ -1,5 +1,6 @@
 import { createGoogleAuth } from "@/lib/google-auth";
 import { getConfig } from "@/lib/ssm-config";
+import { APP_TIMEZONE } from "@/lib/timezone";
 
 const CALENDAR_API = "https://www.googleapis.com/calendar/v3";
 
@@ -12,7 +13,7 @@ const SLOT_DURATION_MINUTES = 30;
 const LOOKBACK_DAYS = 90;
 const LOOKAHEAD_DAYS = 30;
 const MAX_CALENDAR_RESULTS = 50;
-const CALENDAR_TIMEZONE = "Europe/Athens";
+const CALENDAR_TIMEZONE = APP_TIMEZONE;
 const DEFAULT_CALENDAR_ID = "primary";
 const DATE_PART_2_DIGIT = "2-digit";
 

--- a/src/lib/locale-defaults.ts
+++ b/src/lib/locale-defaults.ts
@@ -4,3 +4,5 @@
  */
 export const DEFAULT_LOCALE = "en-IE";
 export const DEFAULT_CURRENCY = "EUR";
+/** Greek civil time — use for all user-visible dates (see `@/lib/timezone`). */
+export const DEFAULT_TIMEZONE = "Europe/Athens" as const;

--- a/src/lib/slack-notify.ts
+++ b/src/lib/slack-notify.ts
@@ -7,6 +7,7 @@
  */
 
 import { getSlackConfigAsync } from "@/lib/integrations";
+import { APP_TIMEZONE } from "@/lib/timezone";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -458,7 +459,7 @@ export async function slackBookingNotify(data: {
   const safeEmail = slackEscape(data.email);
   const dateStr = slackEscape(
     new Date(data.start).toLocaleString("en-IE", {
-      timeZone: "Europe/Athens",
+      timeZone: APP_TIMEZONE,
       dateStyle: "full",
       timeStyle: "short",
     })

--- a/src/lib/timezone.ts
+++ b/src/lib/timezone.ts
@@ -1,0 +1,80 @@
+/**
+ * Canonical app timezone — cloudless.gr operates in Greece.
+ *
+ * Use these helpers (or `APP_TIMEZONE` in Intl options) for any user-visible
+ * date/time. Storage/APIs may still use ISO-8601 UTC instants; display is Athens.
+ */
+import { DEFAULT_TIMEZONE } from "@/lib/locale-defaults";
+
+export const APP_TIMEZONE = DEFAULT_TIMEZONE;
+
+const DEFAULT_LOCALE = "en-IE";
+
+function asDate(input: string | number | Date): Date | null {
+  const d = input instanceof Date ? input : new Date(input);
+  return Number.isNaN(d.getTime()) ? null : d;
+}
+
+/** Full date+time in Europe/Athens (e.g. admin timestamps). */
+export function formatAppDateTime(
+  input: string | number | Date,
+  locale: string = DEFAULT_LOCALE,
+  options: Intl.DateTimeFormatOptions = {}
+): string {
+  const d = asDate(input);
+  if (!d) return "—";
+  return d.toLocaleString(locale, {
+    timeZone: APP_TIMEZONE,
+    dateStyle: "medium",
+    timeStyle: "short",
+    ...options,
+  });
+}
+
+/** Calendar date in Europe/Athens. */
+export function formatAppDate(
+  input: string | number | Date,
+  locale: string = DEFAULT_LOCALE,
+  options: Intl.DateTimeFormatOptions = {}
+): string {
+  const d = asDate(input);
+  if (!d) return "—";
+  return d.toLocaleDateString(locale, {
+    timeZone: APP_TIMEZONE,
+    year: "numeric",
+    month: "short",
+    day: "numeric",
+    ...options,
+  });
+}
+
+/** Clock time in Europe/Athens (24h). */
+export function formatAppTime(
+  input: string | number | Date,
+  locale: string = DEFAULT_LOCALE,
+  options: Intl.DateTimeFormatOptions = {}
+): string {
+  const d = asDate(input);
+  if (!d) return "—";
+  return d.toLocaleTimeString(locale, {
+    timeZone: APP_TIMEZONE,
+    hour: "2-digit",
+    minute: "2-digit",
+    hour12: false,
+    ...options,
+  });
+}
+
+/** YYYY-MM-DD for “today” in Europe/Athens (not UTC). */
+export function appTodayIsoDate(now: Date = new Date()): string {
+  const parts = new Intl.DateTimeFormat("en-CA", {
+    timeZone: APP_TIMEZONE,
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+  }).formatToParts(now);
+  const y = parts.find((p) => p.type === "year")?.value;
+  const m = parts.find((p) => p.type === "month")?.value;
+  const d = parts.find((p) => p.type === "day")?.value;
+  return `${y}-${m}-${d}`;
+}


### PR DESCRIPTION
## Summary
- Canonical `APP_TIMEZONE` / `DEFAULT_TIMEZONE` = `Europe/Athens` (`src/lib/timezone.ts`, `locale-defaults.ts`).
- Helpers: `formatAppDate`, `formatAppDateTime`, `formatAppTime`, `appTodayIsoDate`.
- User-visible `toLocaleDateString` / `toLocaleString` call sites across admin, dashboard, portal, blog, Slack, PDF, campaigns now pass `timeZone: Europe/Athens`.
- Newsletter cadence copy and notification lake partitions use Athens civil time.
- k3s/Grafana already used Athens; GitHub Actions cron remains UTC (platform constraint).

## Test plan
- [x] `vitest` `__tests__/lib/timezone.test.ts` + booking-slots
- [ ] Spot-check admin timestamps and booking labels show Athens time
- [ ] Local UI dates match Greece (EEST/EET) not browser-only / UTC

Made with [Cursor](https://cursor.com)