### PR TITLE
Fix GTM hydration: forward x-nonce from proxy

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -128,12 +128,12 @@ export default async function RootLayout({
               id="gtag-consent-init"
               src={`https://www.googletagmanager.com/gtag/js?id=${GA_ID}`}
               strategy="afterInteractive"
-              nonce={nonce}
+              {...(nonce ? { nonce } : {})}
             />
             <Script
               id="gtag-config"
               strategy="afterInteractive"
-              nonce={nonce}
+              {...(nonce ? { nonce } : {})}
               dangerouslySetInnerHTML={{
                 __html: `
             window.dataLayer = window.dataLayer || [];

--- a/src/components/GoogleTagManager.tsx
+++ b/src/components/GoogleTagManager.tsx
@@ -1,23 +1,22 @@
-import Script from "next/script";
-
 /**
  * Google Tag Manager (container + Consent Mode default).
  * Paste targets from GTM install: head script + body noscript.
  * Consent defaults to denied; CookieConsent updates via gtag("consent","update").
+ *
+ * Uses a plain <script> (not next/script) so the CSP nonce from proxy → layout
+ * stays identical on SSR and hydrate. next/script beforeInteractive was
+ * emitting nonce="" on the server while the client omitted the attribute.
  */
 const GTM_ID = (process.env.NEXT_PUBLIC_GTM_ID ?? "GTM-W7N3J3TV").trim();
 
 export function GoogleTagManagerHead({ nonce }: { nonce?: string }) {
   if (!GTM_ID) return null;
 
-  // next/script omits empty-string nonce on the client (`undefined`) while SSR
-  // still emits nonce="" — that mismatch hydrates as a console error.
   const scriptNonce = nonce?.trim() ? nonce : undefined;
 
   return (
-    <Script
+    <script
       id="google-tag-manager"
-      strategy="beforeInteractive"
       {...(scriptNonce ? { nonce: scriptNonce } : {})}
       dangerouslySetInnerHTML={{
         __html: `

--- a/src/lib/proxy-logic.ts
+++ b/src/lib/proxy-logic.ts
@@ -108,6 +108,21 @@ function generateNonce(): string {
   return crypto.randomUUID ? crypto.randomUUID() : Math.random().toString(36).substring(2, 15);
 }
 
+/** Forward CSP nonce + pathname into the App Router request headers (for layout Scripts). */
+function continueToApp(
+  request: NextRequest,
+  pathname: string,
+  nonce: string
+): NextResponse {
+  const requestHeaders = new Headers(request.headers);
+  requestHeaders.set("x-nonce", nonce);
+  requestHeaders.set("x-pathname", pathname);
+  const response = NextResponse.next({
+    request: { headers: requestHeaders },
+  });
+  return addSecurityHeaders(response, nonce);
+}
+
 function addSecurityHeaders(response: NextResponse, nonce: string): NextResponse {
   response.headers.set("Content-Security-Policy", buildCSP(nonce));
   response.headers.set("X-Content-Type-Options", "nosniff");
@@ -333,7 +348,7 @@ async function handlePageRoute(
   if (isAdminRoute || isDashboardRoute || isPostLoginRoute) {
     // E2E bypass: if e2e_admin cookie is set, allow access to admin routes
     if (e2eAdminCookie && isAdminRoute) {
-      return NextResponse.next();
+      return continueToApp(request, pathname, nonce);
     }
     const sessionToken = readNextAuthJwt(request);
     const sessionCookie = request.cookies.get("authjs.session-token")?.value;
@@ -377,7 +392,7 @@ async function handlePageRoute(
               return NextResponse.redirect(new URL(dashboardUrl, request.nextUrl.origin), 307);
             }
 
-            return NextResponse.next();
+            return continueToApp(request, pathname, nonce);
           }
         } catch {}
       }
@@ -435,8 +450,7 @@ async function handlePageRoute(
     }
   }
 
-  const response = await NextResponse.next();
-  return addSecurityHeaders(response, nonce);
+  return continueToApp(request, pathname, nonce);
 }
 
 export {

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -134,6 +134,21 @@ function generateNonce(): string {
   return crypto.randomUUID ? crypto.randomUUID() : Math.random().toString(36).substring(2, 15);
 }
 
+/** Forward CSP nonce + pathname into the App Router request headers (for layout Scripts). */
+function continueToApp(
+  request: NextRequest,
+  pathname: string,
+  nonce: string
+): NextResponse {
+  const requestHeaders = new Headers(request.headers);
+  requestHeaders.set("x-nonce", nonce);
+  requestHeaders.set("x-pathname", pathname);
+  const response = NextResponse.next({
+    request: { headers: requestHeaders },
+  });
+  return addSecurityHeaders(response, nonce);
+}
+
 function addSecurityHeaders(response: NextResponse, nonce: string): NextResponse {
   response.headers.set(
     "Content-Security-Policy",
@@ -327,7 +342,7 @@ async function handlePageRoute(
   if (isAdminRoute || isDashboardRoute || isPostLoginRoute) {
     // E2E bypass: if e2e_admin cookie is set, allow access to admin routes
     if (e2eAdminCookie && isAdminRoute) {
-      return NextResponse.next();
+      return continueToApp(request, pathname, nonce);
     }
     const sessionToken = readNextAuthJwt(request);
     const sessionCookie = request.cookies.get("authjs.session-token")?.value;
@@ -371,7 +386,7 @@ async function handlePageRoute(
               return NextResponse.redirect(new URL(dashboardUrl, request.nextUrl.origin), 307);
             }
             
-            return NextResponse.next();
+            return continueToApp(request, pathname, nonce);
           }
         } catch {
         }
@@ -430,8 +445,7 @@ async function handlePageRoute(
     }
   }
 
-  const response = await NextResponse.next();
-  return addSecurityHeaders(response, nonce);
+  return continueToApp(request, pathname, nonce);
 }
 
 export const config = {


### PR DESCRIPTION
## Summary
- Root cause of local `nonce=\"\"` vs `nonce={undefined}` hydration warning: middleware applied CSP nonce on the **response** but never forwarded `x-nonce` / `x-pathname` on the **request**, so layout Scripts had nothing real to pass.
- Add `continueToApp()` in `proxy.ts` + `proxy-logic.ts` to set those request headers on every page continuation.
- Switch GTM head snippet to a plain `<script>` (avoid next/script beforeInteractive nonce quirks); GA Script props only spread nonce when present.

## Test plan
- [x] proxy unit tests (30)
- [ ] Local `/en` hard refresh — no GTM nonce hydration warning
- [ ] View-source: GTM script has a real `nonce=` matching CSP

Made with [Cursor](https://cursor.com)