### PR TITLE
Fix duplicate APP_TIMEZONE import breaking deploy-pi build

### DIFF
--- a/src/lib/blog.ts
+++ b/src/lib/blog.ts
@@ -427,8 +427,6 @@ export function getPostBySlug(slug: string): BlogPost | undefined {
   return posts.find((p) => p.slug === slug);
 }
 
-import { APP_TIMEZONE } from "@/lib/timezone";
-
 export function formatDate(dateStr: string): string {
   return new Date(dateStr).toLocaleDateString("en-IE", {
     timeZone: APP_TIMEZONE,


### PR DESCRIPTION
## Summary
- `deploy-pi` failed on `ubuntu-24.04-arm`: Turbopack `APP_TIMEZONE is defined multiple times` in `src/lib/blog.ts` (import at top + mid-file).
- Remove the duplicate import.

## Test plan
- [ ] `deploy-pi` build succeeds after merge

Made with [Cursor](https://cursor.com)