### PR TITLE
Harden Pi rollout BUILD_ID gate + name node omv

### DIFF
--- a/scripts/pi-rollout-from-artifact.sh
+++ b/scripts/pi-rollout-from-artifact.sh
@@ -79,6 +79,16 @@ if [[ -d "${ARTIFACT_DIR}/public" ]]; then
   rsync_to "${ARTIFACT_DIR}/public/" "${USER_STAGE}/public/"
 fi
 remote "test -f '${USER_STAGE}/server.js'"
+remote bash -s <<REMOTE
+set -euo pipefail
+USER_STAGE='$USER_STAGE'
+# Refuse incomplete packs before touching the live symlink (reboot mid-rsync
+# previously left a release without .next/BUILD_ID → CrashLoop).
+test -f "\${USER_STAGE}/server.js"
+test -f "\${USER_STAGE}/.next/BUILD_ID"
+test -s "\${USER_STAGE}/.next/BUILD_ID"
+echo "stage BUILD_ID=\$(cat "\${USER_STAGE}/.next/BUILD_ID")"
+REMOTE
 
 echo "==> Promote → releases/${RELEASE_SHA12} + flip symlink"
 PREV="$(remote "readlink '$CURRENT' 2>/dev/null || true" | tr -d '\r')"
@@ -95,6 +105,12 @@ sudo rm -rf "\$NEW_REL"
 sudo mv "\$USER_STAGE" "\$NEW_REL"
 # Pod may run as a different uid — keep tree world-readable/executable.
 sudo chmod -R a+rX "\$NEW_REL"
+# Gate again on the promoted tree (mv must not drop BUILD_ID).
+if [ ! -s "\$NEW_REL/.next/BUILD_ID" ] || [ ! -f "\$NEW_REL/server.js" ]; then
+  echo "::error::Promoted release missing server.js or .next/BUILD_ID — refusing symlink flip" >&2
+  sudo rm -rf "\$NEW_REL"
+  exit 1
+fi
 sudo ln -sfn "cloudless-releases/\$SHA12" "\$CURRENT"
 sudo chown -h "\$OWNER:users" "\$CURRENT"
 echo "Symlink now: \$CURRENT → \$(readlink "\$CURRENT")"
@@ -143,6 +159,19 @@ echo "Using: \$KUBECTL"
 sleep 15
 \$KUBECTL get pods -n "\$NS" -l app=cloudless-app -o wide
 \$KUBECTL get endpoints -n "\$NS" cloudless-app || true
+# Origin path needs the named tunnel. Scale-to-zero (or CrashLoop) causes
+# public 502 even when NodePort health is fine — assert replicas before OK.
+TUNNEL_JSON=\$(\$KUBECTL get deploy cloudflare-tunnel -n "\$NS" -o json 2>/dev/null || true)
+if [ -n "\$TUNNEL_JSON" ]; then
+  TUNNEL_SPEC=\$(echo "\$TUNNEL_JSON" | jq -r '.spec.replicas // 0')
+  TUNNEL_READY=\$(echo "\$TUNNEL_JSON" | jq -r '.status.readyReplicas // 0')
+  echo "cloudflare-tunnel replicas spec=\${TUNNEL_SPEC} ready=\${TUNNEL_READY}"
+  if [ "\$TUNNEL_SPEC" = "0" ] || [ "\$TUNNEL_SPEC" = "null" ]; then
+    echo "::warning::cloudflare-tunnel scaled to 0 — restoring replicas=1"
+    \$KUBECTL scale deployment/cloudflare-tunnel -n "\$NS" --replicas=1
+    \$KUBECTL rollout status deployment/cloudflare-tunnel -n "\$NS" --timeout=120s || true
+  fi
+fi
 curl -sS --max-time 5 http://127.0.0.1:30300/api/health || true
 echo
 REMOTE

--- a/skills/cluster-bash/SKILL.md
+++ b/skills/cluster-bash/SKILL.md
@@ -4,7 +4,7 @@ description: |
   Run bash on the cloudless.gr Pi cluster — pick the right tool (single-node
   ssh, multi-node fanout, file read/write, k3s-aware) and the right fallback
   when the SSH MCP is unavailable. Triggered by phrases like "ssh to omv",
-  "run on the cluster", "check both Pis", "what's in /var/log on omv-main",
+  "run on the cluster", "check both Pis", "what's in /var/log on omv",
   "push a config to omv-ha", "diff a file across nodes", "is the cluster
   reachable", or any cluster-bash / cluster-diagnose intent.
 ---
@@ -15,12 +15,12 @@ The cloudless.gr cluster is two Pis:
 
 | Node       | Hardware            | Role                                    | LAN IP        | Tailnet IP        |
 |------------|---------------------|-----------------------------------------|---------------|-------------------|
-| `omv-main` | Pi 5, SATA SSD      | k3s control plane, primary runner host  | 192.168.1.128 | 100.74.191.58    |
-| `omv-ha`   | Pi 4                | k3s agent, keepalived VIP 192.168.1.200 | 192.168.1.130 | 100.95.117.84    |
+| `omv`      | Pi 5, SATA SSD      | k3s control plane, primary runner host  | 192.168.1.128 | 100.74.191.58    |
+| `omv-ha`   | Pi 4 (mail + deploy proxy; not k3s) | webmail / omv-ha-deploy runner | 192.168.1.130 | 100.95.117.84    |
 
-Both run a GitHub Actions self-hosted runner stack
-(`omv` / `omv-build` on main; `omv-2-build` on ha). The cluster is reached
-over Tailscale from cloud sessions and over LAN from Office.
+Both run GitHub Actions self-hosted runners
+(`omv` / `omv-build` on main; `omv-ha-deploy` on ha — mail host, not a k3s
+node). Reach over Tailscale from cloud sessions and over LAN from Office.
 
 ## Tool selection — pick the most specific that fits
 
@@ -94,7 +94,7 @@ cluster_run_fanout("df -h / /var/lib/rancher/k3s 2>/dev/null | tail -n +2")
 cluster_run_fanout("systemctl --no-pager status 'actions.runner.*' | grep -E 'Active:|Loaded:' | head -8")
 
 # Read the active k3s server token (sensitive — admin only)
-cluster_read_file("omv-main", "/var/lib/rancher/k3s/server/token")
+cluster_read_file("omv", "/var/lib/rancher/k3s/server/token")
 
 # What pods crashed in the last hour?
 mcp__cloudless-infra__k3s_get_pods({ namespace: "default" })  # then filter Status
@@ -121,7 +121,7 @@ Session-start hook reads three secrets from the Claude session config:
 | Secret                  | Used for                                                                |
 |-------------------------|-------------------------------------------------------------------------|
 | `TAILSCALE_AUTH_KEY`    | Joins the sandbox to the tailnet so it can reach `100.74.191.58`       |
-| `OMV_SSH_KEY_CONTENTS`  | base64'd `~/.ssh/id_ed25519` for `tbaltzakis@omv-main` and `@omv-ha`    |
+| `OMV_SSH_KEY_CONTENTS`  | base64'd `~/.ssh/id_ed25519` for `tbaltzakis@omv` and `@omv-ha`         |
 | `GITHUB_PAT`            | Unrelated to SSH but the same hook sets it; needed by `gh_*` tools     |
 
 If any of these are missing, every `mcp__cloudless-infra__*` tool fails


### PR DESCRIPTION
## Summary
- Gate `pi-rollout-from-artifact.sh` on `.next/BUILD_ID` before symlink flip (prevents incomplete-release CrashLoops after mid-deploy reboot).
- Assert/restore `cloudflare-tunnel` replicas if scaled to 0.
- Correct cluster-bash naming: control-plane host is **omv**, not omv-main; omv-ha is mail + deploy proxy.

## Ops already applied on the Pis
- Live rollback to `603056fa0dda`; public `/api/health` OK.
- Cleared zombie runners; fixed etcd defrag `Requires=` to `k3s-k3s-omv.service`; masked broken `zramswap` on omv-ha; cleaned duplicate logrotate configs.

## Test plan
- [ ] Next `deploy-pi` refuses incomplete packs
- [ ] Site stays healthy on `603056fa0dda` until a good build lands

Made with [Cursor](https://cursor.com)