### PR TITLE
Fix standalone BUILD_ID pack + host cloudflared assert

### DIFF
--- a/.github/workflows/deploy-pi.yml
+++ b/.github/workflows/deploy-pi.yml
@@ -257,6 +257,22 @@ jobs:
           mkdir -p "$OUT/public"
           rsync -a public/ "$OUT/public/"
         fi
+
+        # SafeDeploy / hostPath boot needs BUILD_ID under standalone/.next.
+        # Turbopack standalone tracing sometimes omits it; copy from the build root.
+        if [ ! -s "$OUT/standalone/.next/BUILD_ID" ]; then
+          if [ -s .next/BUILD_ID ]; then
+            mkdir -p "$OUT/standalone/.next"
+            cp -a .next/BUILD_ID "$OUT/standalone/.next/BUILD_ID"
+            echo "Copied .next/BUILD_ID into standalone pack"
+          else
+            echo "::error::Missing .next/BUILD_ID after build — refusing to pack"
+            exit 1
+          fi
+        fi
+        test -s "$OUT/standalone/.next/BUILD_ID"
+        echo "standalone BUILD_ID=$(cat "$OUT/standalone/.next/BUILD_ID")"
+
         echo "Packed $(du -sh "$OUT" | cut -f1) → $OUT"
         echo "artifact=$OUT" >> "$GITHUB_OUTPUT"
 

--- a/scripts/pi-rollout-from-artifact.sh
+++ b/scripts/pi-rollout-from-artifact.sh
@@ -85,8 +85,11 @@ USER_STAGE='$USER_STAGE'
 # Refuse incomplete packs before touching the live symlink (reboot mid-rsync
 # previously left a release without .next/BUILD_ID → CrashLoop).
 test -f "\${USER_STAGE}/server.js"
-test -f "\${USER_STAGE}/.next/BUILD_ID"
-test -s "\${USER_STAGE}/.next/BUILD_ID"
+if [ ! -s "\${USER_STAGE}/.next/BUILD_ID" ]; then
+  echo "::error::Staged release missing .next/BUILD_ID (pack/build incomplete)" >&2
+  ls -la "\${USER_STAGE}/.next" 2>/dev/null || true
+  exit 1
+fi
 echo "stage BUILD_ID=\$(cat "\${USER_STAGE}/.next/BUILD_ID")"
 REMOTE
 
@@ -159,19 +162,17 @@ echo "Using: \$KUBECTL"
 sleep 15
 \$KUBECTL get pods -n "\$NS" -l app=cloudless-app -o wide
 \$KUBECTL get endpoints -n "\$NS" cloudless-app || true
-# Origin path needs the named tunnel. Scale-to-zero (or CrashLoop) causes
-# public 502 even when NodePort health is fine — assert replicas before OK.
-TUNNEL_JSON=\$(\$KUBECTL get deploy cloudflare-tunnel -n "\$NS" -o json 2>/dev/null || true)
-if [ -n "\$TUNNEL_JSON" ]; then
-  TUNNEL_SPEC=\$(echo "\$TUNNEL_JSON" | jq -r '.spec.replicas // 0')
-  TUNNEL_READY=\$(echo "\$TUNNEL_JSON" | jq -r '.status.readyReplicas // 0')
-  echo "cloudflare-tunnel replicas spec=\${TUNNEL_SPEC} ready=\${TUNNEL_READY}"
-  if [ "\$TUNNEL_SPEC" = "0" ] || [ "\$TUNNEL_SPEC" = "null" ]; then
-    echo "::warning::cloudflare-tunnel scaled to 0 — restoring replicas=1"
-    \$KUBECTL scale deployment/cloudflare-tunnel -n "\$NS" --replicas=1
-    \$KUBECTL rollout status deployment/cloudflare-tunnel -n "\$NS" --timeout=120s || true
-  fi
+# Production origin is host systemd cloudflared on omv (pi-origin), NOT the
+# legacy k8s cloudflare-tunnel Deployment (misconfigured args → CrashLoop).
+# Assert the host tunnel unit; leave k8s replicas alone (expected 0).
+if systemctl is-active --quiet cloudflared.service 2>/dev/null; then
+  echo "host cloudflared.service: active"
+else
+  echo "::warning::host cloudflared.service not active — public edge may 502"
+  systemctl is-active cloudflared.service 2>&1 || true
 fi
+TUNNEL_SPEC=\$(\$KUBECTL get deploy cloudflare-tunnel -n "\$NS" -o jsonpath='{.spec.replicas}' 2>/dev/null || echo missing)
+echo "k8s cloudflare-tunnel replicas=\${TUNNEL_SPEC:-missing} (host cloudflared is canonical; 0 is OK)"
 curl -sS --max-time 5 http://127.0.0.1:30300/api/health || true
 echo
 REMOTE


### PR DESCRIPTION
## Summary
- `deploy-pi` rollout failed: staged release had no `.next/BUILD_ID` (gate worked). Pack now copies BUILD_ID from the build root into the standalone artifact.
- Stop auto-scaling the legacy k8s `cloudflare-tunnel` Deployment (CrashLoop); assert host `cloudflared.service` on omv instead.

## Test plan
- [ ] `deploy-pi` pack logs `standalone BUILD_ID=…`
- [ ] Rollout promotes and `/api/health` reports new SHA
- [ ] k8s `cloudflare-tunnel` stays at 0 replicas; public site OK via host tunnel

Made with [Cursor](https://cursor.com)