### PR TITLE
Fix upload-artifact dropping standalone/.next

### DIFF
--- a/.github/workflows/deploy-pi.yml
+++ b/.github/workflows/deploy-pi.yml
@@ -272,6 +272,11 @@ jobs:
         fi
         test -s "$OUT/standalone/.next/BUILD_ID"
         echo "standalone BUILD_ID=$(cat "$OUT/standalone/.next/BUILD_ID")"
+        # Non-hidden backup: upload-artifact@v4 drops dotdirs unless
+        # include-hidden-files is set — keep a plain-file copy as failsafe.
+        cp -a "$OUT/standalone/.next/BUILD_ID" "$OUT/standalone/BUILD_ID"
+        cp -a "$OUT/standalone/.next/BUILD_ID" "$OUT/BUILD_ID"
+        echo "standalone/.next file count=$(find "$OUT/standalone/.next" -type f | wc -l)"
 
         echo "Packed $(du -sh "$OUT" | cut -f1) → $OUT"
         echo "artifact=$OUT" >> "$GITHUB_OUTPUT"
@@ -284,6 +289,10 @@ jobs:
         path: ${{ steps.pack.outputs.artifact }}
         retention-days: 2
         if-no-files-found: error
+        # Required: standalone embeds `.next/` (BUILD_ID + server traces).
+        # v4 omits hidden files/dirs by default → 269MB pack becomes ~30MB
+        # and rollout fails "missing .next/BUILD_ID".
+        include-hidden-files: true
 
   rollout:
     name: Roll out via omv-ha proxy

--- a/scripts/pi-rollout-from-artifact.sh
+++ b/scripts/pi-rollout-from-artifact.sh
@@ -78,19 +78,40 @@ if [[ -d "${ARTIFACT_DIR}/public" ]]; then
   remote "mkdir -p '${USER_STAGE}/public'"
   rsync_to "${ARTIFACT_DIR}/public/" "${USER_STAGE}/public/"
 fi
+# Non-hidden BUILD_ID failsafe from pack root (survives upload-artifact v4 defaults)
+if [[ -s "${ARTIFACT_DIR}/BUILD_ID" ]]; then
+  rsync_to "${ARTIFACT_DIR}/BUILD_ID" "${USER_STAGE}/BUILD_ID"
+fi
 remote "test -f '${USER_STAGE}/server.js'"
 remote bash -s <<REMOTE
 set -euo pipefail
 USER_STAGE='$USER_STAGE'
-# Refuse incomplete packs before touching the live symlink (reboot mid-rsync
-# previously left a release without .next/BUILD_ID → CrashLoop).
 test -f "\${USER_STAGE}/server.js"
+# Restore BUILD_ID if upload-artifact stripped standalone/.next (legacy packs)
+# or if only the non-hidden backup survived.
 if [ ! -s "\${USER_STAGE}/.next/BUILD_ID" ]; then
-  echo "::error::Staged release missing .next/BUILD_ID (pack/build incomplete)" >&2
+  for cand in "\${USER_STAGE}/BUILD_ID"; do
+    if [ -s "\$cand" ]; then
+      mkdir -p "\${USER_STAGE}/.next"
+      cp -a "\$cand" "\${USER_STAGE}/.next/BUILD_ID"
+      echo "Restored .next/BUILD_ID from \$cand"
+      break
+    fi
+  done
+fi
+if [ ! -s "\${USER_STAGE}/.next/BUILD_ID" ]; then
+  echo "::error::Staged release missing .next/BUILD_ID (pack/upload incomplete — check include-hidden-files on upload-artifact)" >&2
+  echo "stage size: \$(du -sh "\$USER_STAGE" | cut -f1)"
   ls -la "\${USER_STAGE}/.next" 2>/dev/null || true
+  ls -la "\${USER_STAGE}" | head -20
   exit 1
 fi
-echo "stage BUILD_ID=\$(cat "\${USER_STAGE}/.next/BUILD_ID")"
+NEXT_FILES=\$(find "\${USER_STAGE}/.next" -type f | wc -l)
+echo "stage BUILD_ID=\$(cat "\${USER_STAGE}/.next/BUILD_ID") .next_files=\${NEXT_FILES}"
+if [ "\$NEXT_FILES" -lt 10 ]; then
+  echo "::error::standalone/.next looks empty (\${NEXT_FILES} files) — artifact likely dropped hidden paths" >&2
+  exit 1
+fi
 REMOTE
 
 echo "==> Promote → releases/${RELEASE_SHA12} + flip symlink"


### PR DESCRIPTION
## Summary
- Root cause of `Staged release missing .next/BUILD_ID`: **`actions/upload-artifact@v4` drops hidden files/dirs by default**, so `standalone/.next/` never reached omv-ha (269MB pack → ~30MB download).
- Set `include-hidden-files: true`, write non-hidden `BUILD_ID` failsafe, and reject stages with an empty `.next` tree.

## Test plan
- [ ] Pack logs `standalone/.next file count` >> 10
- [ ] Downloaded artifact contains `standalone/.next/BUILD_ID`
- [ ] Rollout promotes; `/api/health` advances off `603056fa0dda`

Made with [Cursor](https://cursor.com)