### PR TITLE
Fix pi-release-pull: bash for shopt flatten

### DIFF
--- a/infrastructure/omv/pi-release-pull.sh
+++ b/infrastructure/omv/pi-release-pull.sh
@@ -154,7 +154,8 @@ nice -n 10 ionice -c2 -n7 sudo tar --zstd -xf "$TAR" -C "$NEW_REL"
 # Tarball layout: top-level standalone/ static/ public/ BUILD_ID (from pack OUT)
 if [[ -d "$NEW_REL/standalone" ]]; then
   # Flatten: move standalone contents up
-  sudo sh -c "shopt -s dotglob && mv '$NEW_REL'/standalone/* '$NEW_REL'/ && rmdir '$NEW_REL'/standalone"
+  # dash has no shopt — must use bash for dotglob flatten
+  sudo bash -c "shopt -s dotglob && mv '$NEW_REL'/standalone/* '$NEW_REL'/ && rmdir '$NEW_REL'/standalone"
 fi
 if [[ -d "$NEW_REL/static" ]]; then
   sudo mkdir -p "$NEW_REL/.next/static"


### PR DESCRIPTION
## Summary
- Replace `sudo sh -c 'shopt…'` with `sudo bash -c` so standalone flatten works on Debian/omv.
- Unblocks CF Workflows pull-promote after download succeeds.

## Test plan
- [x] Hotfixed on omv and re-ran agent against desired `98e610a86dc9`
- [ ] Confirm `/api/health` advances and orchestrator desired status → success

Made with [Cursor](https://cursor.com)