### PR TITLE
Fix pi-release-pull flatten: rsync merge overlapping public/

### DIFF
--- a/infrastructure/omv/pi-release-pull.sh
+++ b/infrastructure/omv/pi-release-pull.sh
@@ -151,11 +151,11 @@ sudo mkdir -p "$NEW_REL"
 # Unpack with low priority onto SSD-backed home
 nice -n 10 ionice -c2 -n7 sudo tar --zstd -xf "$TAR" -C "$NEW_REL"
 
-# Tarball layout: top-level standalone/ static/ public/ BUILD_ID (from pack OUT)
+# Tarball layout: top-level standalone/ static/ public/ BUILD_ID (from pack OUT).
+# standalone/ often also has public/ — plain mv fails on non-empty dirs; merge with rsync.
 if [[ -d "$NEW_REL/standalone" ]]; then
-  # Flatten: move standalone contents up
-  # dash has no shopt — must use bash for dotglob flatten
-  sudo bash -c "shopt -s dotglob && mv '$NEW_REL'/standalone/* '$NEW_REL'/ && rmdir '$NEW_REL'/standalone"
+  sudo rsync -a "$NEW_REL/standalone/" "$NEW_REL/"
+  sudo rm -rf "$NEW_REL/standalone"
 fi
 if [[ -d "$NEW_REL/static" ]]; then
   sudo mkdir -p "$NEW_REL/.next/static"


### PR DESCRIPTION
## Summary
- Pack layout has both top-level `public/` and `standalone/public/`; `mv` fails with `cannot overwrite … Directory not empty`.
- Flatten with `rsync -a` then `rm -rf standalone/` (already hotfixed on omv; live promote of `98e610a86dc9` succeeded).

## Test plan
- [x] omv promote_ok for `98e610a86dc9`
- [x] `https://cloudless.gr/api/health` version matches; orchestrator `desired.status=success`
- [ ] Merge so next `install-pi-release-pull.sh` does not regress to `mv`


Made with [Cursor](https://cursor.com)