### PR TITLE
docs: sync Next.js/React versions in README and AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,7 +12,7 @@ This block is written and re-added by `next dev` — verify at `node_modules/nex
 
 ## Tech Stack
 
-- **Framework:** Next.js 16.2.12 (App Router, React 19.2.8, Turbopack)
+- **Framework:** Next.js 16.3.0 (App Router, React 19.2.8, Turbopack)
 - **Styling:** Tailwind CSS 4 with `@theme inline` custom tokens
 - **3D:** @react-three/fiber + @react-three/drei + three.js
 - **Animation:** GSAP (ScrollTrigger) + Lenis smooth scroll

--- a/README.md
+++ b/README.md
@@ -474,8 +474,8 @@ This avoids noisy `LF will be replaced by CRLF` warnings and keeps diffs stable 
 
 ## Tech Stack
 
-- Next.js 16.2.4 (App Router, Turbopack)
-- React 19.2.4
+- Next.js 16.3.0 (App Router, Turbopack)
+- React 19.2.8
 - TypeScript 5
 - Tailwind CSS 4
 - Cloudflare D1 (authentication, sessions)


### PR DESCRIPTION
## Summary
- Updates README Tech Stack (`16.2.4`/`19.2.4` → `16.3.0`/`19.2.8`) and AGENTS.md framework line to match installed packages.
- Resolves agentic doc issues [#1564](https://github.com/Themis128/cloudless.gr/issues/1564) and [#1566](https://github.com/Themis128/cloudless.gr/issues/1566) (failed unsigned README pushes).

## Test plan
- [x] `pnpm list next react` matches documented versions
- [ ] Close #1564 #1566 after merge


Made with [Cursor](https://cursor.com)