### PR TITLE
fix(admin): sync campaign ads secrets onto Pi

### DIFF
--- a/.github/workflows/sync-campaign-ads-pi-secrets.yml
+++ b/.github/workflows/sync-campaign-ads-pi-secrets.yml
@@ -1,0 +1,140 @@
+name: Sync campaign ads secrets → Pi cloudless-secrets
+
+# Patches k8s Secret cloudless-secrets with LinkedIn / Meta / X / Google Ads
+# tokens from GitHub repo secrets, then restarts cloudless-app.
+# Runs on the omv self-hosted runner (local k3s).
+#
+# Soft-skips empty optional keys so partial inventories still ship.
+# TikTok stays unbound until TIKTOK_ACCESS_TOKEN + TIKTOK_ADVERTISER_ID exist.
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+
+concurrency:
+  group: sync-campaign-ads-pi-secrets
+  cancel-in-progress: false
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
+jobs:
+  sync:
+    runs-on: [self-hosted, omv, pi]
+    timeout-minutes: 15
+    steps:
+      - name: Patch cloudless-secrets (merge non-empty keys)
+        env:
+          LINKEDIN_ACCESS_TOKEN: ${{ secrets.LINKEDIN_ACCESS_TOKEN }}
+          LINKEDIN_CAPI_ACCESS_TOKEN: ${{ secrets.LINKEDIN_CAPI_ACCESS_TOKEN }}
+          LINKEDIN_CLIENT_ID: ${{ secrets.LINKEDIN_CLIENT_ID }}
+          LINKEDIN_CLIENT_SECRET: ${{ secrets.LINKEDIN_CLIENT_SECRET }}
+          LINKEDIN_ORGANIZATION_URN: ${{ secrets.LINKEDIN_ORGANIZATION_URN }}
+          LINKEDIN_REFRESH_TOKEN: ${{ secrets.LINKEDIN_REFRESH_TOKEN }}
+          LINKEDIN_AD_ACCOUNT_ID: ${{ secrets.LINKEDIN_AD_ACCOUNT_ID }}
+          META_ACCESS_TOKEN: ${{ secrets.META_ACCESS_TOKEN }}
+          META_AD_ACCOUNT_ID: ${{ secrets.META_AD_ACCOUNT_ID }}
+          META_CAPI_ACCESS_TOKEN: ${{ secrets.META_CAPI_ACCESS_TOKEN }}
+          META_PAGE_ID: ${{ secrets.META_PAGE_ID }}
+          META_PIXEL_ID: ${{ secrets.NEXT_PUBLIC_META_PIXEL_ID }}
+          X_API_KEY: ${{ secrets.X_API_KEY }}
+          X_API_SECRET: ${{ secrets.X_API_SECRET }}
+          X_ACCESS_TOKEN: ${{ secrets.X_ACCESS_TOKEN }}
+          X_ACCESS_SECRET: ${{ secrets.X_ACCESS_SECRET }}
+          X_AD_ACCOUNT_ID: ${{ secrets.X_AD_ACCOUNT_ID }}
+          GOOGLE_ADS_DEVELOPER_TOKEN: ${{ secrets.GOOGLE_ADS_DEVELOPER_TOKEN }}
+          GOOGLE_ADS_CUSTOMER_ID: ${{ secrets.GOOGLE_ADS_CUSTOMER_ID }}
+          TIKTOK_APP_ID: ${{ secrets.TIKTOK_APP_ID }}
+          TIKTOK_APP_SECRET: ${{ secrets.TIKTOK_APP_SECRET }}
+          TIKTOK_ACCESS_TOKEN: ${{ secrets.TIKTOK_ACCESS_TOKEN }}
+          TIKTOK_ADVERTISER_ID: ${{ secrets.TIKTOK_ADVERTISER_ID }}
+        run: |
+          set -euo pipefail
+          KUBECTL="sudo k3s kubectl"
+
+          PATCH=$(python3 -c '
+          import json, os, base64, re
+          keys = [
+            "LINKEDIN_ACCESS_TOKEN",
+            "LINKEDIN_CAPI_ACCESS_TOKEN",
+            "LINKEDIN_CLIENT_ID",
+            "LINKEDIN_CLIENT_SECRET",
+            "LINKEDIN_ORGANIZATION_URN",
+            "LINKEDIN_REFRESH_TOKEN",
+            "LINKEDIN_AD_ACCOUNT_ID",
+            "META_ACCESS_TOKEN",
+            "META_AD_ACCOUNT_ID",
+            "META_CAPI_ACCESS_TOKEN",
+            "META_PAGE_ID",
+            "META_PIXEL_ID",
+            "X_API_KEY",
+            "X_API_SECRET",
+            "X_ACCESS_TOKEN",
+            "X_ACCESS_SECRET",
+            "X_AD_ACCOUNT_ID",
+            "GOOGLE_ADS_DEVELOPER_TOKEN",
+            "GOOGLE_ADS_CUSTOMER_ID",
+            "TIKTOK_APP_ID",
+            "TIKTOK_APP_SECRET",
+            "TIKTOK_ACCESS_TOKEN",
+            "TIKTOK_ADVERTISER_ID",
+          ]
+          placeholder = re.compile(r"^(your[_-]?value|changeme|todo|xxx|placeholder)", re.I)
+          data = {}
+          skipped = []
+          for k in keys:
+            v = (os.environ.get(k) or "").strip()
+            if not v:
+              skipped.append(k)
+              continue
+            if placeholder.match(v):
+              skipped.append(f"{k}(placeholder)")
+              continue
+            data[k] = base64.b64encode(v.encode()).decode()
+          if not data:
+            raise SystemExit("no campaign secrets to sync — all empty")
+          print(json.dumps({"data": data, "_meta": {"synced": sorted(data), "skipped": skipped}}))
+          ')
+
+          META=$(echo "$PATCH" | python3 -c 'import json,sys; print(json.dumps(json.load(sys.stdin).get("_meta",{})))')
+          BODY=$(echo "$PATCH" | python3 -c 'import json,sys; d=json.load(sys.stdin); d.pop("_meta", None); print(json.dumps(d))')
+          echo "sync meta: $META"
+          $KUBECTL -n cloudless patch secret cloudless-secrets --type merge -p "$BODY"
+          echo "$META" | python3 -c 'import json,sys; m=json.load(sys.stdin); print("synced:", ", ".join(m.get("synced",[]))); print("skipped:", ", ".join(m.get("skipped",[])) or "(none)")'
+
+      - name: Restart cloudless-app
+        run: |
+          sudo k3s kubectl -n cloudless rollout restart deploy/cloudless-app
+          sudo k3s kubectl -n cloudless rollout status deploy/cloudless-app --timeout=180s
+
+      - name: Verify key presence (names only)
+        run: |
+          sudo k3s kubectl -n cloudless get secret cloudless-secrets -o json \
+            | python3 -c '
+          import json,sys
+          keys=set(json.load(sys.stdin).get("data",{}))
+          want=["LINKEDIN_ACCESS_TOKEN","META_ACCESS_TOKEN","META_AD_ACCOUNT_ID","X_API_KEY","X_ACCESS_TOKEN","GOOGLE_ADS_DEVELOPER_TOKEN"]
+          present=[k for k in want if k in keys]
+          missing=[k for k in want if k not in keys]
+          print("present:", ", ".join(present) or "(none)")
+          print("missing:", ", ".join(missing) or "(none)")
+          if not present:
+            raise SystemExit(1)
+          '
+
+      - name: Comment tracking issue
+        if: always()
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          {
+            echo "# Campaign ads → Pi secrets — $(date -u '+%F %T')Z"
+            echo ""
+            echo "**Job:** ${{ job.status }}"
+            echo "**Runner:** self-hosted omv (local k3s)"
+            echo "**Target:** cloudless/cloudless-secrets → restart cloudless-app"
+          } > c.md
+          gh issue comment 382 --repo "${{ github.repository }}" --body-file c.md || true

--- a/src/app/[locale]/admin/campaigns/google/page.tsx
+++ b/src/app/[locale]/admin/campaigns/google/page.tsx
@@ -76,7 +76,9 @@ export default function GoogleCampaignsPage() {
           <p className="font-mono text-sm text-yellow-400">
             Google Ads is not configured. Add{" "}
             <code className="text-yellow-300">GOOGLE_ADS_DEVELOPER_TOKEN</code> and{" "}
-            <code className="text-yellow-300">GOOGLE_ADS_CUSTOMER_ID</code> to AWS SSM.
+            <code className="text-yellow-300">GOOGLE_ADS_CUSTOMER_ID</code> to the Pi{" "}
+            <code className="text-yellow-300">cloudless-secrets</code> (workflow:
+            sync-campaign-ads-pi-secrets).
           </p>
         </div>
       </div>

--- a/src/app/[locale]/admin/campaigns/linkedin/page.tsx
+++ b/src/app/[locale]/admin/campaigns/linkedin/page.tsx
@@ -75,7 +75,9 @@ export default function LinkedInPage() {
           <p className="font-mono text-sm text-yellow-400">
             LinkedIn is not configured. Add{" "}
             <code className="text-yellow-300">LINKEDIN_ACCESS_TOKEN</code> and{" "}
-            <code className="text-yellow-300">LINKEDIN_AD_ACCOUNT_ID</code> to AWS SSM.
+            <code className="text-yellow-300">LINKEDIN_AD_ACCOUNT_ID</code> to the Pi{" "}
+            <code className="text-yellow-300">cloudless-secrets</code> (workflow:
+            sync-campaign-ads-pi-secrets).
           </p>
         </div>
       </div>

--- a/src/app/[locale]/admin/campaigns/meta/page.tsx
+++ b/src/app/[locale]/admin/campaigns/meta/page.tsx
@@ -64,7 +64,9 @@ export default function MetaPage() {
           <p className="font-mono text-sm text-yellow-400">
             Meta Ads is not configured. Add{" "}
             <code className="text-yellow-300">META_ACCESS_TOKEN</code> and{" "}
-            <code className="text-yellow-300">META_AD_ACCOUNT_ID</code> to AWS SSM.
+            <code className="text-yellow-300">META_AD_ACCOUNT_ID</code> to the Pi{" "}
+            <code className="text-yellow-300">cloudless-secrets</code> (workflow:
+            sync-campaign-ads-pi-secrets).
           </p>
         </div>
       </div>

--- a/src/app/[locale]/admin/campaigns/tiktok/page.tsx
+++ b/src/app/[locale]/admin/campaigns/tiktok/page.tsx
@@ -190,7 +190,8 @@ function NotConfiguredBanner({
               {i < keys.length - 1 ? " and " : ""}
             </span>
           ))}{" "}
-          to AWS SSM.
+          to the Pi <code className="text-yellow-300">cloudless-secrets</code> (workflow:
+          sync-campaign-ads-pi-secrets).
         </p>
       </div>
     </div>

--- a/src/app/[locale]/admin/campaigns/x/page.tsx
+++ b/src/app/[locale]/admin/campaigns/x/page.tsx
@@ -62,7 +62,10 @@ export default function XPage() {
         <BackLink />
         <div className="rounded-xl border border-yellow-900/30 bg-yellow-950/10 p-6">
           <p className="font-mono text-sm text-yellow-400">
-            X is not configured. Add <code className="text-yellow-300">X_API_KEY</code> to AWS SSM.
+            X is not configured. Add <code className="text-yellow-300">X_API_KEY</code> and{" "}
+            <code className="text-yellow-300">X_ACCESS_TOKEN</code> to the Pi{" "}
+            <code className="text-yellow-300">cloudless-secrets</code> (workflow:
+            sync-campaign-ads-pi-secrets).
           </p>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- Admin campaign pages 503 because LinkedIn/Meta/X/Google tokens exist as GitHub secrets but are missing from k8s `cloudless-secrets` (`SSM_DISABLED=1`).
- Add `sync-campaign-ads-pi-secrets.yml` (self-hosted omv) to merge non-empty keys and restart `cloudless-app`.
- Update unbound UI copy away from AWS SSM.

## Test plan
- [ ] Dispatch workflow; confirm key names present on `cloudless-secrets`
- [ ] After restart, LinkedIn/Meta/X admin pages stop returning 503 (TikTok/Google may still 503 until missing `TIKTOK_*` / `GOOGLE_ADS_CUSTOMER_ID` secrets are set)

Made with [Cursor](https://cursor.com)