### PR TITLE
feat(datalake): Node R2 shim + CF_R2 SSM→Pi sync

### DIFF
--- a/.github/workflows/sync-r2-datalake-from-ssm.yml
+++ b/.github/workflows/sync-r2-datalake-from-ssm.yml
@@ -1,0 +1,144 @@
+name: Sync R2 datalake creds from SSM → Pi
+
+# Copies CF_R2_* (+ ANALYTICS_BUCKET) from AWS SSM /cloudless/production/*
+# into k8s cloudless-secrets and restarts cloudless-app. Soft-skips missing
+# params. Runtime stays SSM_DISABLED=1.
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+
+concurrency:
+  group: sync-r2-datalake-from-ssm
+  cancel-in-progress: false
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+  AWS_REGION: us-east-1
+  SSM_PREFIX: /cloudless/production
+
+jobs:
+  sync:
+    runs-on: [self-hosted, omv, pi]
+    timeout-minutes: 15
+    steps:
+      - name: Pull SSM → patch cloudless-secrets
+        run: |
+          set -euo pipefail
+          KUBECTL="sudo k3s kubectl"
+          KEYS=(
+            CF_R2_ACCESS_KEY_ID
+            CF_R2_SECRET_ACCESS_KEY
+            R2_ACCESS_KEY_ID
+            R2_SECRET_ACCESS_KEY
+            ANALYTICS_BUCKET
+            DATALAKE_BUCKET_NAME
+            R2_BUCKET_NAME
+          )
+          export KEYS_CSV
+          KEYS_CSV=$(IFS=,; echo "${KEYS[*]}")
+
+          PATCH=$(python3 - <<'PY'
+          import base64, json, os, re, subprocess
+
+          prefix = os.environ["SSM_PREFIX"].rstrip("/")
+          keys = [k.strip() for k in os.environ["KEYS_CSV"].split(",") if k.strip()]
+          placeholder = re.compile(r"^(your[_-]?value|changeme|todo|xxx|placeholder)", re.I)
+          data, synced, skipped = {}, [], []
+
+          for key in keys:
+            name = f"{prefix}/{key}"
+            try:
+              out = subprocess.check_output(
+                [
+                  "aws", "ssm", "get-parameter",
+                  "--region", os.environ.get("AWS_REGION", "us-east-1"),
+                  "--name", name,
+                  "--with-decryption",
+                  "--query", "Parameter.Value",
+                  "--output", "text",
+                ],
+                stderr=subprocess.DEVNULL,
+                text=True,
+              ).strip()
+            except subprocess.CalledProcessError:
+              skipped.append(f"{key}(missing)")
+              continue
+            if not out:
+              skipped.append(f"{key}(empty)")
+              continue
+            if placeholder.match(out):
+              skipped.append(f"{key}(placeholder)")
+              continue
+            data[key] = base64.b64encode(out.encode()).decode()
+            synced.append(key)
+
+          # Normalize aliases → CF_R2_* + ANALYTICS_BUCKET
+          if "CF_R2_ACCESS_KEY_ID" not in data and "R2_ACCESS_KEY_ID" in data:
+            data["CF_R2_ACCESS_KEY_ID"] = data["R2_ACCESS_KEY_ID"]
+            synced.append("CF_R2_ACCESS_KEY_ID")
+          if "CF_R2_SECRET_ACCESS_KEY" not in data and "R2_SECRET_ACCESS_KEY" in data:
+            data["CF_R2_SECRET_ACCESS_KEY"] = data["R2_SECRET_ACCESS_KEY"]
+            synced.append("CF_R2_SECRET_ACCESS_KEY")
+          if "ANALYTICS_BUCKET" not in data:
+            for alt in ("DATALAKE_BUCKET_NAME", "R2_BUCKET_NAME"):
+              if alt in data:
+                data["ANALYTICS_BUCKET"] = data[alt]
+                synced.append("ANALYTICS_BUCKET")
+                break
+          for drop in ("R2_ACCESS_KEY_ID", "R2_SECRET_ACCESS_KEY", "DATALAKE_BUCKET_NAME", "R2_BUCKET_NAME"):
+            data.pop(drop, None)
+
+          if "CF_R2_ACCESS_KEY_ID" not in data or "CF_R2_SECRET_ACCESS_KEY" not in data:
+            raise SystemExit("CF_R2_ACCESS_KEY_ID / CF_R2_SECRET_ACCESS_KEY missing in SSM")
+
+          if "ANALYTICS_BUCKET" not in data:
+            data["ANALYTICS_BUCKET"] = base64.b64encode(b"datalake-bucket").decode()
+            synced.append("ANALYTICS_BUCKET(default)")
+
+          open("/tmp/r2-sync-meta.json", "w").write(
+            json.dumps({"synced": synced, "skipped": skipped})
+          )
+          print(json.dumps({"data": data}))
+          PY
+          )
+
+          echo "sync meta: $(cat /tmp/r2-sync-meta.json)"
+          $KUBECTL -n cloudless patch secret cloudless-secrets --type merge -p "$PATCH"
+
+      - name: Restart cloudless-app
+        run: |
+          sudo k3s kubectl -n cloudless rollout restart deploy/cloudless-app
+          sudo k3s kubectl -n cloudless rollout status deploy/cloudless-app --timeout=180s
+
+      - name: Verify key presence (names only)
+        run: |
+          sudo k3s kubectl -n cloudless get secret cloudless-secrets -o json \
+            | python3 -c '
+          import json,sys
+          keys=set(json.load(sys.stdin).get("data",{}))
+          want=["CF_R2_ACCESS_KEY_ID","CF_R2_SECRET_ACCESS_KEY","ANALYTICS_BUCKET","CLOUDFLARE_ACCOUNT_ID"]
+          present=[k for k in want if k in keys]
+          missing=[k for k in want if k not in keys]
+          print("present:", ", ".join(present) or "(none)")
+          print("missing:", ", ".join(missing) or "(none)")
+          if missing:
+            raise SystemExit(1)
+          '
+
+      - name: Comment tracking issue
+        if: always()
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          {
+            echo "# R2 datalake SSM → Pi — $(date -u '+%F %T')Z"
+            echo ""
+            echo "**Job:** ${{ job.status }}"
+            echo "**Source:** AWS SSM \`/cloudless/production/CF_R2_*\`"
+            echo "**Target:** cloudless/cloudless-secrets → restart cloudless-app"
+          } > c.md
+          gh issue comment 382 --repo "${{ github.repository }}" --body-file c.md || true

--- a/__tests__/r2-datalake.test.ts
+++ b/__tests__/r2-datalake.test.ts
@@ -1,13 +1,37 @@
 // @vitest-environment node
-import { describe, it, expect, afterEach } from "vitest";
+import { describe, it, expect, afterEach, vi, beforeEach } from "vitest";
+
+const fetchMock = vi.fn();
+
+vi.mock("aws4fetch", () => ({
+  AwsClient: class {
+    fetch(...args: unknown[]) {
+      return fetchMock(...args);
+    }
+  },
+}));
 
 describe("getDataLakeBucketFromEnv", () => {
+  const envBackup = { ...process.env };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    delete process.env.CF_R2_ACCESS_KEY_ID;
+    delete process.env.CF_R2_SECRET_ACCESS_KEY;
+    delete process.env.R2_ACCESS_KEY_ID;
+    delete process.env.R2_SECRET_ACCESS_KEY;
+    delete process.env.CLOUDFLARE_ACCOUNT_ID;
+    delete process.env.CF_ACCOUNT_ID;
+  });
+
   afterEach(() => {
     delete (globalThis as unknown as { __DATALAKE_BUCKET__?: unknown }).__DATALAKE_BUCKET__;
     delete (globalThis as unknown as { __R2__?: unknown }).__R2__;
+    process.env = { ...envBackup };
+    vi.resetModules();
   });
 
-  it("returns null when no binding", async () => {
+  it("returns null when no binding and no CF_R2_*", async () => {
     const { getDataLakeBucketFromEnv } = await import("@/lib/r2-client");
     expect(getDataLakeBucketFromEnv()).toBeNull();
   });
@@ -28,5 +52,24 @@ describe("getDataLakeBucketFromEnv", () => {
     };
     const { getDataLakeBucketFromEnv } = await import("@/lib/r2-client");
     expect(getDataLakeBucketFromEnv()?.put).toBe(put);
+  });
+
+  it("returns Node S3 shim when CF_R2_* is set", async () => {
+    process.env.CLOUDFLARE_ACCOUNT_ID = "acct123";
+    process.env.CF_R2_ACCESS_KEY_ID = "key";
+    process.env.CF_R2_SECRET_ACCESS_KEY = "secret";
+    process.env.ANALYTICS_BUCKET = "datalake-bucket";
+    fetchMock.mockResolvedValue({
+      ok: true,
+      status: 200,
+      headers: { get: (n: string) => (n === "content-type" ? "text/plain" : null) },
+      text: async () => "",
+      arrayBuffer: async () => new TextEncoder().encode("snap").buffer,
+    });
+    const { getDataLakeBucketFromEnv } = await import("@/lib/r2-client");
+    const bucket = getDataLakeBucketFromEnv();
+    expect(bucket).not.toBeNull();
+    const obj = await bucket!.get("lake/snapshots/x.json");
+    expect(await obj!.text()).toBe("snap");
   });
 });

--- a/src/lib/r2-client.ts
+++ b/src/lib/r2-client.ts
@@ -6,6 +6,7 @@
  */
 
 import type { R2Bucket } from "@cloudflare/workers-types";
+import { createNodeDataLakeBucket } from "@/lib/r2-node-bucket";
 
 interface R2Env {
   ASSETS_BUCKET?: R2Bucket;
@@ -52,7 +53,7 @@ export function getDataLakeBucket(env: R2Env): R2Bucket | null {
   return null;
 }
 
-/** Resolve DATALAKE_BUCKET from Workers global / env object (no AWS S3). */
+/** Resolve DATALAKE_BUCKET from Workers binding, or Node CF_R2_* S3 API. */
 export function getDataLakeBucketFromEnv(): R2Bucket | null {
   const g = globalThis as unknown as {
     __DATALAKE_BUCKET__?: R2Bucket;
@@ -61,7 +62,14 @@ export function getDataLakeBucketFromEnv(): R2Bucket | null {
   const fromProcess = (process as unknown as { env?: R2Env }).env?.DATALAKE_BUCKET;
   // Prefer explicit globals — Node process.env cannot hold R2 binding objects.
   const candidate = g.__DATALAKE_BUCKET__ ?? g.__R2__?.DATALAKE_BUCKET ?? fromProcess;
-  return getDataLakeBucket({ DATALAKE_BUCKET: candidate });
+  const bound = getDataLakeBucket({ DATALAKE_BUCKET: candidate });
+  if (bound) return bound;
+
+  // Pi / Node: S3-compatible credentials (CF_R2_* + CLOUDFLARE_ACCOUNT_ID).
+  if (!isCloudflareWorkers()) {
+    return createNodeDataLakeBucket();
+  }
+  return null;
 }
 
 // Serve static asset from R2 with proper headers

--- a/src/lib/r2-node-bucket.ts
+++ b/src/lib/r2-node-bucket.ts
@@ -1,0 +1,227 @@
+/**
+ * S3-compatible R2Bucket shim for Node (Pi / next start).
+ * Workers use native bindings; here we use CF_R2_* + aws4fetch.
+ */
+
+import type {
+  R2Bucket,
+  R2GetOptions,
+  R2HTTPMetadata,
+  R2ListOptions,
+  R2Object,
+  R2ObjectBody,
+  R2Objects,
+  R2PutOptions,
+} from "@cloudflare/workers-types";
+import { createR2ClientFromEnv, r2ObjectUrl } from "@/lib/r2-upload";
+
+function bytesToArrayBuffer(bytes: Uint8Array): ArrayBuffer {
+  const ab = new ArrayBuffer(bytes.byteLength);
+  new Uint8Array(ab).set(bytes);
+  return ab;
+}
+
+function toBodyInit(body: ArrayBuffer | ArrayBufferView | string | Blob | ReadableStream): BodyInit {
+  if (typeof body === "string") return body;
+  if (body instanceof Blob) return body;
+  if (typeof ReadableStream !== "undefined" && body instanceof ReadableStream) return body;
+  if (body instanceof ArrayBuffer) return body;
+  if (ArrayBuffer.isView(body)) {
+    return bytesToArrayBuffer(new Uint8Array(body.buffer, body.byteOffset, body.byteLength));
+  }
+  throw new TypeError("Unsupported R2 put body type");
+}
+
+async function bodyToBytes(
+  value: ReadableStream | ArrayBuffer | ArrayBufferView | string | Blob | null
+): Promise<Uint8Array> {
+  if (value == null) return new Uint8Array(0);
+  if (typeof value === "string") return new TextEncoder().encode(value);
+  if (value instanceof Blob) return new Uint8Array(await value.arrayBuffer());
+  if (value instanceof ArrayBuffer) return new Uint8Array(value);
+  if (ArrayBuffer.isView(value)) {
+    return new Uint8Array(value.buffer, value.byteOffset, value.byteLength);
+  }
+  if (typeof ReadableStream !== "undefined" && value instanceof ReadableStream) {
+    const res = new Response(value);
+    return new Uint8Array(await res.arrayBuffer());
+  }
+  throw new TypeError("Unsupported R2 body");
+}
+
+function putContentType(options?: R2PutOptions): string {
+  const meta = options?.httpMetadata;
+  if (!meta) return "application/octet-stream";
+  if (typeof Headers !== "undefined" && meta instanceof Headers) {
+    return meta.get("content-type") || "application/octet-stream";
+  }
+  const typed = meta as R2HTTPMetadata;
+  return typed.contentType || "application/octet-stream";
+}
+
+function stubObject(
+  key: string,
+  size: number,
+  contentType?: string | null,
+  extra?: Partial<R2Object>
+): R2Object {
+  return {
+    key,
+    size,
+    etag: "",
+    httpEtag: "",
+    uploaded: new Date(),
+    httpMetadata: contentType ? { contentType } : {},
+    customMetadata: {},
+    storageClass: "STANDARD",
+    checksums: {},
+    writeHttpMetadata(headers: Headers) {
+      if (contentType) headers.set("content-type", contentType);
+    },
+    ...extra,
+  } as unknown as R2Object;
+}
+
+function makeObjectBody(key: string, bytes: Uint8Array, contentType?: string | null): R2ObjectBody {
+  const size = bytes.byteLength;
+  const abPart = bytesToArrayBuffer(bytes);
+  const base = stubObject(key, size, contentType);
+  return {
+    ...base,
+    body: new Blob([abPart]).stream(),
+    bodyUsed: false,
+    arrayBuffer: async () => bytesToArrayBuffer(bytes),
+    text: async () => new TextDecoder().decode(bytes),
+    json: async <T>() => JSON.parse(new TextDecoder().decode(bytes)) as T,
+    blob: async () => new Blob([abPart], { type: contentType || undefined }),
+  } as unknown as R2ObjectBody;
+}
+
+function hasR2S3Credentials(): boolean {
+  const accountId = process.env.CLOUDFLARE_ACCOUNT_ID || process.env.CF_ACCOUNT_ID;
+  const accessKeyId = process.env.CF_R2_ACCESS_KEY_ID || process.env.R2_ACCESS_KEY_ID;
+  const secretAccessKey = process.env.CF_R2_SECRET_ACCESS_KEY || process.env.R2_SECRET_ACCESS_KEY;
+  return Boolean(accountId && accessKeyId && secretAccessKey);
+}
+
+export function resolveDataLakeBucketName(): string {
+  return (
+    process.env.ANALYTICS_BUCKET ||
+    process.env.DATALAKE_BUCKET_NAME ||
+    process.env.R2_BUCKET_NAME ||
+    "datalake-bucket"
+  );
+}
+
+/** Minimal R2Bucket backed by the S3-compatible R2 API. */
+export function createNodeDataLakeBucket(bucketName = resolveDataLakeBucketName()): R2Bucket | null {
+  if (!hasR2S3Credentials()) return null;
+
+  const client = createR2ClientFromEnv();
+
+  const get = async (key: string, _options?: R2GetOptions): Promise<R2ObjectBody | null> => {
+    const res = await client.fetch(r2ObjectUrl(key, bucketName), { method: "GET" });
+    if (res.status === 404) return null;
+    if (!res.ok) {
+      const text = await res.text().catch(() => "");
+      throw new Error(`R2 GET ${bucketName}/${key} → ${res.status}: ${text.slice(0, 300)}`);
+    }
+    const bytes = new Uint8Array(await res.arrayBuffer());
+    return makeObjectBody(key, bytes, res.headers.get("content-type"));
+  };
+
+  const head = async (key: string): Promise<R2Object | null> => {
+    const res = await client.fetch(r2ObjectUrl(key, bucketName), { method: "HEAD" });
+    if (res.status === 404) return null;
+    if (!res.ok) {
+      throw new Error(`R2 HEAD ${bucketName}/${key} → ${res.status}`);
+    }
+    const size = Number(res.headers.get("content-length") || 0);
+    const contentType = res.headers.get("content-type");
+    return stubObject(key, size, contentType, {
+      etag: res.headers.get("etag") || "",
+      httpEtag: res.headers.get("etag") || "",
+      uploaded: new Date(res.headers.get("last-modified") || Date.now()),
+    });
+  };
+
+  const put = async (
+    key: string,
+    value: ReadableStream | ArrayBuffer | ArrayBufferView | string | Blob | null,
+    options?: R2PutOptions
+  ): Promise<R2Object> => {
+    const bytes = await bodyToBytes(value);
+    const contentType = putContentType(options);
+    const res = await client.fetch(r2ObjectUrl(key, bucketName), {
+      method: "PUT",
+      headers: { "Content-Type": contentType },
+      body: toBodyInit(bytes),
+    });
+    if (!res.ok) {
+      const text = await res.text().catch(() => "");
+      throw new Error(`R2 PUT ${bucketName}/${key} → ${res.status}: ${text.slice(0, 300)}`);
+    }
+    return stubObject(key, bytes.byteLength, contentType, {
+      etag: res.headers.get("etag") || "",
+      httpEtag: res.headers.get("etag") || "",
+      customMetadata: options?.customMetadata || {},
+    });
+  };
+
+  const del = async (keys: string | string[]): Promise<void> => {
+    const list = Array.isArray(keys) ? keys : [keys];
+    for (const key of list) {
+      const res = await client.fetch(r2ObjectUrl(key, bucketName), { method: "DELETE" });
+      if (!res.ok && res.status !== 404) {
+        throw new Error(`R2 DELETE ${bucketName}/${key} → ${res.status}`);
+      }
+    }
+  };
+
+  const list = async (options?: R2ListOptions): Promise<R2Objects> => {
+    const accountId = process.env.CLOUDFLARE_ACCOUNT_ID || process.env.CF_ACCOUNT_ID;
+    if (!accountId) throw new Error("CLOUDFLARE_ACCOUNT_ID required");
+    const listUrl = new URL(`https://${accountId}.r2.cloudflarestorage.com/${bucketName}`);
+    listUrl.searchParams.set("list-type", "2");
+    if (options?.prefix) listUrl.searchParams.set("prefix", options.prefix);
+    if (options?.cursor) listUrl.searchParams.set("continuation-token", options.cursor);
+    const limit = options?.limit ?? 1000;
+    listUrl.searchParams.set("max-keys", String(limit));
+    if (options?.delimiter) listUrl.searchParams.set("delimiter", options.delimiter);
+
+    const res = await client.fetch(listUrl.toString(), { method: "GET" });
+    if (!res.ok) {
+      const text = await res.text().catch(() => "");
+      throw new Error(`R2 LIST ${bucketName} → ${res.status}: ${text.slice(0, 300)}`);
+    }
+    const xml = await res.text();
+    const objects: R2Object[] = [];
+    const keyRe = /<Key>([^<]*)<\/Key>/g;
+    let m: RegExpExecArray | null;
+    while ((m = keyRe.exec(xml)) !== null) {
+      objects.push(stubObject(m[1], 0, null, { uploaded: new Date(0) }));
+    }
+    const truncated = /<IsTruncated>true<\/IsTruncated>/i.test(xml);
+    const nextToken = xml.match(/<NextContinuationToken>([^<]*)<\/NextContinuationToken>/)?.[1];
+    return {
+      objects,
+      truncated,
+      cursor: nextToken,
+      delimitedPrefixes: [],
+    } as unknown as R2Objects;
+  };
+
+  return {
+    get,
+    head,
+    put,
+    delete: del,
+    list,
+    createMultipartUpload: async () => {
+      throw new Error("Node R2 shim: createMultipartUpload not implemented");
+    },
+    resumeMultipartUpload: () => {
+      throw new Error("Node R2 shim: resumeMultipartUpload not implemented");
+    },
+  } as unknown as R2Bucket;
+}

--- a/src/lib/r2-node-bucket.ts
+++ b/src/lib/r2-node-bucket.ts
@@ -21,7 +21,9 @@ function bytesToArrayBuffer(bytes: Uint8Array): ArrayBuffer {
   return ab;
 }
 
-function toBodyInit(body: ArrayBuffer | ArrayBufferView | string | Blob | ReadableStream): BodyInit {
+function toBodyInit(
+  body: ArrayBuffer | ArrayBufferView | string | Blob | ReadableStream
+): BodyInit {
   if (typeof body === "string") return body;
   if (body instanceof Blob) return body;
   if (typeof ReadableStream !== "undefined" && body instanceof ReadableStream) return body;
@@ -114,7 +116,9 @@ export function resolveDataLakeBucketName(): string {
 }
 
 /** Minimal R2Bucket backed by the S3-compatible R2 API. */
-export function createNodeDataLakeBucket(bucketName = resolveDataLakeBucketName()): R2Bucket | null {
+export function createNodeDataLakeBucket(
+  bucketName = resolveDataLakeBucketName()
+): R2Bucket | null {
   if (!hasR2S3Credentials()) return null;
 
   const client = createR2ClientFromEnv();


### PR DESCRIPTION
## Summary
- Add a Node `R2Bucket` shim (`CF_R2_*` + aws4fetch) so Pi admin datalake routes work without Workers bindings
- Add `sync-r2-datalake-from-ssm.yml` to re-copy SSM `CF_R2_*` / `ANALYTICS_BUCKET` onto `cloudless-secrets`
- Live ops already seeded SSM + Pi secrets from the existing cluster R2 token (`datalake-bucket`)

## Test plan
- [x] `pnpm exec vitest run __tests__/r2-datalake.test.ts __tests__/r2-upload.test.ts`
- [ ] After merge + deploy-pi: admin lake-parquet / gsc-archive no longer return `datalake_unbound` solely for missing creds
- [ ] Optional: dispatch `Sync R2 datalake creds from SSM → Pi` to re-verify sync path


Made with [Cursor](https://cursor.com)