### PR TITLE
fix(mail): pin dovecot INBOX to vmail Maildir

### DIFF
--- a/infrastructure/omv-ha/setup-mail-server.sh
+++ b/infrastructure/omv-ha/setup-mail-server.sh
@@ -59,6 +59,9 @@ protocols = imap lmtp
 
 mail_driver = maildir
 mail_path = /var/mail/vhosts/%{user | domain}/%{user | username}
+# Without this, Debian Dovecot defaults INBOX to /var/mail/%u and Roundcube
+# fails with "Failed to autocreate mailbox: Permission denied".
+mail_inbox_path = /var/mail/vhosts/%{user | domain}/%{user | username}
 mail_uid = vmail
 mail_gid = vmail
 first_valid_uid = 5000


### PR DESCRIPTION
## Summary
- Live fix already on omv-ha (`mail_inbox_path` aligned with `mail_path`)
- Persist the same setting in `setup-mail-server.sh`

## Test plan
- [x] INBOX status works on omv-ha
- [ ] Login at https://webmail.cloudless.gr as `tbaltzakis@cloudless.gr`


Made with [Cursor](https://cursor.com)