### PR TITLE
fix(admin): Alert API cluster DNS + alerts list

### DIFF
--- a/__tests__/admin-ops-api.test.ts
+++ b/__tests__/admin-ops-api.test.ts
@@ -36,14 +36,17 @@ describe("GET /api/admin/ops/monitor", () => {
     expect(res.status).toBe(401);
   });
 
-  it("returns 503 with offline:true when Pi LAN is unreachable", async () => {
+  it("returns 503 with offline:true when ALERT_API_URL is a private LAN address", async () => {
     adminOk();
+    process.env.ALERT_API_URL = "http://192.168.1.128:30820";
     const { GET } = await import("@/app/api/admin/ops/monitor/route");
     const res = await GET(
       new NextRequest("http://localhost/api/admin/ops/monitor?resource=status")
     );
     const data = await res.json();
+    expect(res.status).toBe(503);
     expect(data.offline).toBe(true);
+    delete process.env.ALERT_API_URL;
   });
 
   it("returns 400 for unknown resource", async () => {

--- a/__tests__/remaining-api-routes.test.ts
+++ b/__tests__/remaining-api-routes.test.ts
@@ -46,12 +46,15 @@ describe("GET /api/admin/esp32", () => {
     expect(res.status).toBe(401);
   });
 
-  it("returns 503 with offline:true when Pi LAN unreachable (default URL)", async () => {
+  it("returns 404 with offline:true when ALERT_API_URL is a private LAN address", async () => {
     adminOk();
+    process.env.ALERT_API_URL = "http://192.168.1.128:30820";
     const { GET } = await import("@/app/api/admin/esp32/route");
     const res = await GET(req("http://localhost/api/admin/esp32?action=devices"));
     const data = await res.json();
+    expect(res.status).toBe(404);
     expect(data.offline).toBe(true);
+    delete process.env.ALERT_API_URL;
   });
 });
 

--- a/infrastructure/pi-alert-api/deploy.sh
+++ b/infrastructure/pi-alert-api/deploy.sh
@@ -77,9 +77,9 @@ echo "==> Rebuilding alert-api image on Pi..."
 ssh "${PI}" bash -s <<'REMOTE'
 set -euo pipefail
 cd ~/alert-api
-docker build -t alert-api:v3.4 -t alert-api:v3 .
-docker save alert-api:v3.4 | sudo k3s ctr images import -
-kubectl -n alert-manager set image deployment/alert-api alert-api=docker.io/library/alert-api:v3.4
+docker build -t alert-api:v3.5 -t alert-api:v3.4 -t alert-api:v3 .
+docker save alert-api:v3.5 | sudo k3s ctr images import -
+kubectl -n alert-manager set image deployment/alert-api alert-api=docker.io/library/alert-api:v3.5
 kubectl -n alert-manager rollout status deployment/alert-api --timeout=120s
 REMOTE
 

--- a/infrastructure/pi-alert-api/k8s/alert-api.yaml
+++ b/infrastructure/pi-alert-api/k8s/alert-api.yaml
@@ -62,6 +62,7 @@ spec:
       containers:
       - name: alert-api
         image: docker.io/library/alert-api:v3.5
+        # v3.5: list_alerts calls get_alert_history (was broken get_history)
         imagePullPolicy: Never
         ports:
         - name: http

--- a/infrastructure/pi-alert-api/main.py
+++ b/infrastructure/pi-alert-api/main.py
@@ -167,7 +167,7 @@ async def list_alerts(status: str | None = None):
     """Return all alerts. Use ?status=active to filter."""
     if status == "active":
         return await database.get_active_alerts()
-    return await database.get_history(limit=500)
+    return await database.get_alert_history(limit=500)
 
 
 @app.get("/api/alerts/active")

--- a/src/app/api/admin/esp32/route.ts
+++ b/src/app/api/admin/esp32/route.ts
@@ -1,7 +1,10 @@
 import { requireAdmin } from "@/lib/api-auth";
 import { NextRequest, NextResponse } from "next/server";
 
-const ALERT_API = process.env.ALERT_API_URL ?? "http://192.168.1.128:30800";
+// In-cluster default (Pi k3s). Override via ALERT_API_URL. Private LAN
+// defaults are rejected by isPrivateLanUrl below for non-cluster deploys.
+const ALERT_API =
+  process.env.ALERT_API_URL ?? "http://alert-api.alert-manager.svc.cluster.local:8080";
 
 /**
  * Device IDs are short slugs. Validate before interpolating into the upstream

--- a/src/app/api/admin/ops/monitor/route.ts
+++ b/src/app/api/admin/ops/monitor/route.ts
@@ -2,11 +2,12 @@
  * Admin - Monitor API proxy
  *
  * Proxies requests to the Pi Alert API. The target URL is set via
- * ALERT_API_URL env var; when unset it defaults to the LAN address.
+ * ALERT_API_URL env var; when unset it defaults to the in-cluster
+ * Service DNS (alert-api.alert-manager.svc.cluster.local:8080).
  *
- * On Lambda/cloud deployments the Pi LAN is unreachable — the route
- * returns {offline:true} immediately without attempting a connection,
- * rather than hanging for 5s or producing an unhandled 500.
+ * If ALERT_API_URL points at a private LAN IP (legacy Lambda/cloud
+ * configs), the route returns {offline:true} immediately rather than
+ * hanging — the Pi app should use the cluster Service URL instead.
  *
  * Sub-resources (via ?resource=):
  *   status   → GET /api/status
@@ -16,7 +17,10 @@
 import { NextRequest, NextResponse } from "next/server";
 import { requireAdmin } from "@/lib/api-auth";
 
-const ALERT_API_URL = process.env.ALERT_API_URL ?? "http://192.168.1.128:30800";
+// In-cluster default (Pi k3s). Override via ALERT_API_URL. Private LAN
+// defaults are rejected by isPrivateLanUrl below for non-cluster deploys.
+const ALERT_API_URL =
+  process.env.ALERT_API_URL ?? "http://alert-api.alert-manager.svc.cluster.local:8080";
 
 const RESOURCE_MAP: Record<string, string> = {
   status: "/api/status",


### PR DESCRIPTION
## Summary
- Default `ALERT_API_URL` for admin ESP32/monitor routes to `http://alert-api.alert-manager.svc.cluster.local:8080` so Pi pods no longer short-circuit on the legacy LAN default.
- Fix alert-api `list_alerts` to call `get_alert_history` (was `get_history` → 500).
- Live: `ALERT_API_URL` already patched into `cloudless-secrets`; alert-api image rebuilt as `v3.5`.

## Test plan
- [x] Authenticated `GET /api/admin/esp32?action=devices` → 200
- [x] Authenticated `GET /api/admin/ops/monitor?resource={status,esp32,alerts}` → 200
- [ ] Unit tests for offline LAN short-circuit still pass

Made with [Cursor](https://cursor.com)