### PR TITLE
fix(admin): integrations dashboard accuracy

### DIFF
--- a/src/app/[locale]/admin/integrations/page.tsx
+++ b/src/app/[locale]/admin/integrations/page.tsx
@@ -11,6 +11,7 @@ interface ApiIntegration {
   category: string;
   status: IntegrationStatus;
   message?: string;
+  setupUrl?: string;
 }
 
 interface ApiResponse {
@@ -25,35 +26,54 @@ interface ApiResponse {
   checkedAt: string;
 }
 
-// Static URL map — iterated directly so href is never derived from API response data
-const SETUP_URLS = {
-  ses: "https://console.aws.amazon.com/ses",
+/** Fallback Connect URLs when the status API omits setupUrl. */
+const SETUP_URL_FALLBACK: Record<string, string> = {
   stripe: "https://dashboard.stripe.com/apikeys",
   espocrm: "https://espocrm.cloudless.gr",
   slack: "https://api.slack.com/apps",
   notion: "https://www.notion.so/my-integrations",
+  "cloudflare-email": "https://dash.cloudflare.com",
   google: "https://console.cloud.google.com/iam-admin/serviceaccounts",
   sentry: "https://sentry.io/settings/auth-tokens/",
   anthropic: "https://console.anthropic.com/settings/keys",
   activecampaign: "https://www.activecampaign.com",
-  meta: "https://business.facebook.com/settings/system-users",
+  meta: "https://business.facebook.com/settings/ad_accounts",
   linkedin: "https://www.linkedin.com/campaignmanager",
-  tiktok: "https://ads.tiktok.com/marketing_api/apps",
+  tiktok: "/api/admin/oauth/tiktok",
   x: "https://ads.x.com/help",
   google_ads: "https://ads.google.com/intl/en_us/home/tools/api-center/",
-} as const;
+  postiz: "https://postiz.cloudless.gr",
+  appflowy: "https://appflowy.cloudless.gr",
+  n8n: "https://n8n.cloudless.gr",
+};
 
 const CATEGORY_ORDER = [
-  "Email",
-  "CRM",
-  "Ads",
-  "Analytics",
-  "Monitoring",
-  "Payments",
-  "Communication",
-  "Content",
-  "AI",
+  "email",
+  "payments",
+  "crm",
+  "communication",
+  "content",
+  "productivity",
+  "monitoring",
+  "ai",
+  "email_marketing",
+  "social_ads",
+  "automation",
 ];
+
+const CATEGORY_LABEL: Record<string, string> = {
+  email: "Email",
+  payments: "Payments",
+  crm: "CRM",
+  communication: "Communication",
+  content: "Content",
+  productivity: "Productivity",
+  monitoring: "Monitoring",
+  ai: "AI",
+  email_marketing: "Email marketing",
+  social_ads: "Social ads",
+  automation: "Automation",
+};
 
 const STATUS_DOT: Record<IntegrationStatus, string> = {
   configured: "bg-neon-green",
@@ -76,8 +96,6 @@ const STATUS_TEXT: Record<IntegrationStatus, string> = {
   error: "text-red-400",
 };
 
-type ApiMap = Map<string, ApiIntegration>;
-
 interface Row {
   id: string;
   setupUrl: string;
@@ -87,18 +105,15 @@ interface Row {
   message?: string;
 }
 
-function buildRows(apiMap: ApiMap): Row[] {
-  return Object.entries(SETUP_URLS).map(([id, setupUrl]) => {
-    const api = apiMap.get(id);
-    return {
-      id,
-      setupUrl,
-      name: api?.name ?? id,
-      category: api?.category ?? "Other",
-      status: api?.status ?? "not_configured",
-      message: api?.message,
-    };
-  });
+function buildRows(integrations: ApiIntegration[]): Row[] {
+  return integrations.map((api) => ({
+    id: api.id,
+    setupUrl: api.setupUrl || SETUP_URL_FALLBACK[api.id] || "#",
+    name: api.name,
+    category: api.category,
+    status: api.status,
+    message: api.message,
+  }));
 }
 
 function groupByCategory(rows: Row[]): Record<string, Row[]> {
@@ -120,8 +135,13 @@ function sortedCategories(map: Record<string, Row[]>): string[] {
   return [...known, ...rest];
 }
 
+function connectTarget(setupUrl: string): { href: string; external: boolean } {
+  if (setupUrl.startsWith("/")) return { href: setupUrl, external: false };
+  return { href: setupUrl, external: true };
+}
+
 export default function IntegrationsPage() {
-  const [apiMap, setApiMap] = useState<ApiMap>(new Map());
+  const [integrations, setIntegrations] = useState<ApiIntegration[]>([]);
   const [summary, setSummary] = useState<ApiResponse["summary"] | null>(null);
   const [checkedAt, setCheckedAt] = useState<string | null>(null);
   const [loading, setLoading] = useState(true);
@@ -138,7 +158,7 @@ export default function IntegrationsPage() {
         if (!res.ok) throw new Error(`HTTP ${res.status}`);
         const data: ApiResponse = await res.json();
         if (!cancelled) {
-          setApiMap(new Map(data.integrations.map((i) => [i.id, i])));
+          setIntegrations(data.integrations);
           setSummary(data.summary);
           setCheckedAt(data.checkedAt);
         }
@@ -154,7 +174,7 @@ export default function IntegrationsPage() {
     };
   }, [refreshKey]);
 
-  const rows = buildRows(apiMap);
+  const rows = buildRows(integrations);
   const grouped = groupByCategory(rows);
   const categories = sortedCategories(grouped);
 
@@ -181,7 +201,6 @@ export default function IntegrationsPage() {
         </button>
       </div>
 
-      {/* Summary bar */}
       {summary && (
         <div className="mb-6 grid grid-cols-2 gap-3 sm:grid-cols-4">
           {(
@@ -209,7 +228,7 @@ export default function IntegrationsPage() {
         </div>
       )}
 
-      {loading && apiMap.size === 0 && (
+      {loading && integrations.length === 0 && (
         <div className="space-y-4">
           {[1, 2, 3].map((i) => (
             <div
@@ -220,46 +239,51 @@ export default function IntegrationsPage() {
         </div>
       )}
 
-      {/* Groups — href comes from SETUP_URLS static constant, never from API response */}
       <div className="space-y-6">
         {categories.map((category) => (
           <div key={category}>
             <h2 className="font-heading mb-3 text-sm font-semibold tracking-widest text-slate-500 uppercase">
-              {category}
+              {CATEGORY_LABEL[category] ?? category}
             </h2>
             <div className="divide-y divide-slate-800 overflow-hidden rounded-xl border border-slate-800">
-              {grouped[category].map((row) => (
-                <div
-                  key={row.id}
-                  className="bg-void-light/50 flex flex-col gap-1 px-5 py-4 sm:flex-row sm:items-center sm:gap-4"
-                >
-                  <div className="flex min-w-0 flex-1 items-center gap-3">
-                    <span
-                      className={`h-2.5 w-2.5 shrink-0 rounded-full ${STATUS_DOT[row.status]}`}
-                    />
-                    <span className="font-heading truncate font-medium text-white">{row.name}</span>
-                  </div>
+              {grouped[category].map((row) => {
+                const target = connectTarget(row.setupUrl);
+                return (
+                  <div
+                    key={row.id}
+                    className="bg-void-light/50 flex flex-col gap-1 px-5 py-4 sm:flex-row sm:items-center sm:gap-4"
+                  >
+                    <div className="flex min-w-0 flex-1 items-center gap-3">
+                      <span
+                        className={`h-2.5 w-2.5 shrink-0 rounded-full ${STATUS_DOT[row.status]}`}
+                      />
+                      <span className="font-heading truncate font-medium text-white">
+                        {row.name}
+                      </span>
+                    </div>
 
-                  <div className="flex items-center gap-3 pl-5 sm:pl-0">
-                    {row.message && (
-                      <span className="font-mono text-xs text-slate-500">{row.message}</span>
-                    )}
-                    <span className={`shrink-0 font-mono text-xs ${STATUS_TEXT[row.status]}`}>
-                      {STATUS_LABEL[row.status]}
-                    </span>
-                    {row.status !== "configured" && (
-                      <a
-                        href={row.setupUrl}
-                        target="_blank"
-                        rel="noopener noreferrer"
-                        className="hover:border-neon-magenta/50 shrink-0 rounded-lg border border-slate-700 px-3 py-1 font-mono text-xs text-slate-300 transition-all hover:text-white"
-                      >
-                        Connect
-                      </a>
-                    )}
+                    <div className="flex items-center gap-3 pl-5 sm:pl-0">
+                      {row.message && (
+                        <span className="font-mono text-xs text-slate-500">{row.message}</span>
+                      )}
+                      <span className={`shrink-0 font-mono text-xs ${STATUS_TEXT[row.status]}`}>
+                        {STATUS_LABEL[row.status]}
+                      </span>
+                      {row.status !== "configured" && row.setupUrl !== "#" && (
+                        <a
+                          href={target.href}
+                          {...(target.external
+                            ? { target: "_blank", rel: "noopener noreferrer" }
+                            : {})}
+                          className="hover:border-neon-magenta/50 shrink-0 rounded-lg border border-slate-700 px-3 py-1 font-mono text-xs text-slate-300 transition-all hover:text-white"
+                        >
+                          Connect
+                        </a>
+                      )}
+                    </div>
                   </div>
-                </div>
-              ))}
+                );
+              })}
             </div>
           </div>
         ))}

--- a/src/app/api/admin/integrations/status/route.ts
+++ b/src/app/api/admin/integrations/status/route.ts
@@ -166,7 +166,7 @@ function tiktokReport(cfg: Cfg): IntegrationReport {
   const appReady = Boolean(cfg.TIKTOK_APP_ID && cfg.TIKTOK_APP_SECRET);
   const fullyConfigured = Boolean(appReady && cfg.TIKTOK_ACCESS_TOKEN && cfg.TIKTOK_ADVERTISER_ID);
   const tiktokSetupUrl = appReady
-    ? `${process.env.NEXT_PUBLIC_APP_URL}/api/admin/oauth/tiktok`
+    ? "/api/admin/oauth/tiktok"
     : "https://ads.tiktok.com/marketing_api/apps";
   return {
     id: "tiktok",
@@ -241,29 +241,15 @@ function buildCoreReports(cfg: Cfg): IntegrationReport[] {
 }
 
 function buildSocialAdsReports(cfg: Cfg): IntegrationReport[] {
-  const metaConfigured = Boolean(
-    cfg.META_AD_ACCOUNT_ID && cfg.META_ACCESS_TOKEN && cfg.META_PIXEL_ID
-  );
   const linkedInConfigured = Boolean(
     cfg.LINKEDIN_ACCESS_TOKEN && cfg.LINKEDIN_AD_ACCOUNT_ID && cfg.LINKEDIN_ORGANIZATION_URN
   );
   const googleAdsConfigured = Boolean(cfg.GOOGLE_ADS_DEVELOPER_TOKEN && cfg.GOOGLE_ADS_CUSTOMER_ID);
-  const metaMessage = metaConfigured
-    ? "Instagram Business Account ID blocked — Meta ad policy violation on account 1558125105019725. Appeal required."
-    : undefined;
   const googleAdsMessage = googleAdsConfigured
     ? undefined
     : "Needs GOOGLE_ADS_DEVELOPER_TOKEN (apply at ads.google.com/intl/en_us/home/tools/api-center/) and GOOGLE_ADS_CUSTOMER_ID. Google service account auth is already configured.";
 
   return [
-    {
-      id: "meta",
-      name: "Meta (Facebook/Instagram)",
-      category: "social_ads",
-      status: configuredIf(metaConfigured),
-      message: metaMessage,
-      setupUrl: "https://business.facebook.com/settings/system-users",
-    },
     {
       id: "linkedin",
       name: "LinkedIn Ads",
@@ -282,6 +268,43 @@ function buildSocialAdsReports(cfg: Cfg): IntegrationReport[] {
       setupUrl: "https://ads.google.com/intl/en_us/home/tools/api-center/",
     },
   ];
+}
+
+/** Meta Marketing API account_status: 1=ACTIVE, 2=DISABLED, 3=UNSETTLED, … */
+async function pingMeta(accessToken: string, adAccountId: string): Promise<PingResult> {
+  try {
+    const url = new URL(`https://graph.facebook.com/v21.0/${adAccountId}`);
+    url.searchParams.set("fields", "id,name,account_status,disable_reason");
+    url.searchParams.set("access_token", accessToken);
+    const res = await fetch(url, { signal: AbortSignal.timeout(5000) });
+    if (res.status === 401 || res.status === 403)
+      return { status: "degraded", message: "Access token rejected by Graph API." };
+    if (!res.ok) return { status: "error", message: `Graph API returned ${res.status}` };
+    const data = (await res.json()) as {
+      account_status?: number;
+      disable_reason?: number;
+      name?: string;
+    };
+    if (data.account_status === 1) {
+      return {
+        status: "configured",
+        message: data.name ? `Ad account: ${data.name}` : undefined,
+      };
+    }
+    if (data.account_status === 2) {
+      return {
+        status: "degraded",
+        message:
+          "Ad account DISABLED (policy/payment). Appeal in Meta Business Manager before running ads.",
+      };
+    }
+    return {
+      status: "degraded",
+      message: `Ad account not active (account_status=${data.account_status ?? "unknown"}).`,
+    };
+  } catch {
+    return { status: "error", message: "Connection failed." };
+  }
 }
 
 function buildStaticReports(cfg: Cfg): IntegrationReport[] {
@@ -318,6 +341,7 @@ async function pingN8n(baseUrl: string, apiKey: string): Promise<PingResult> {
 }
 
 async function buildPingedReports(cfg: Cfg): Promise<IntegrationReport[]> {
+  const metaReady = Boolean(cfg.META_AD_ACCOUNT_ID && cfg.META_ACCESS_TOKEN && cfg.META_PIXEL_ID);
   const [
     stripeResult,
     espocrmResult,
@@ -327,6 +351,7 @@ async function buildPingedReports(cfg: Cfg): Promise<IntegrationReport[]> {
     postizResult,
     appflowyResult,
     n8nResult,
+    metaResult,
   ] = await Promise.all([
     cfg.STRIPE_SECRET_KEY ? pingStripe(cfg.STRIPE_SECRET_KEY) : Promise.resolve(NOT_CONFIGURED),
     cfg.ESPOCRM_BASE_URL && cfg.ESPOCRM_API_KEY
@@ -341,6 +366,9 @@ async function buildPingedReports(cfg: Cfg): Promise<IntegrationReport[]> {
     cfg.APPFLOWY_API_URL ? pingAppFlowy(cfg.APPFLOWY_API_URL) : Promise.resolve(NOT_CONFIGURED),
     cfg.N8N_API_URL && cfg.N8N_API_KEY
       ? pingN8n(cfg.N8N_API_URL, cfg.N8N_API_KEY)
+      : Promise.resolve(NOT_CONFIGURED),
+    metaReady
+      ? pingMeta(cfg.META_ACCESS_TOKEN, cfg.META_AD_ACCOUNT_ID)
       : Promise.resolve(NOT_CONFIGURED),
   ]);
 
@@ -415,6 +443,13 @@ async function buildPingedReports(cfg: Cfg): Promise<IntegrationReport[]> {
       category: "automation",
       ...n8nResult,
       setupUrl: cfg.N8N_API_URL || "https://n8n.cloudless.gr",
+    },
+    {
+      id: "meta",
+      name: "Meta (Facebook/Instagram)",
+      category: "social_ads",
+      ...metaResult,
+      setupUrl: "https://business.facebook.com/settings/ad_accounts",
     },
   ];
 }


### PR DESCRIPTION
## Summary
- Integrations page now uses the status API as source of truth (removes phantom `ses` Not configured row).
- Meta is live-pinged via Graph `account_status` instead of a hardcoded Instagram portfolio warning.
- TikTok Connect links to `/api/admin/oauth/tiktok`.

## Live ops (already applied)
- Synced Postiz `Organization.apiKey` → `POSTIZ_API_KEY` (was 401 / degraded).
- Updated `META_PAGE_ID` to the page Graph returns for the current token.

## Still needs operator action
- **ActiveCampaign**: paste `ACTIVECAMPAIGN_API_URL` + `ACTIVECAMPAIGN_API_TOKEN`.
- **TikTok**: complete OAuth, then mount `TIKTOK_ACCESS_TOKEN` + `TIKTOK_ADVERTISER_ID` into secrets.
- **X Ads**: Ads API returns `UNAUTHORIZED_CLIENT_APPLICATION` until X approves access — then we can set `X_AD_ACCOUNT_ID`.
- **Meta**: ad account `act_657781691826702` is DISABLED — appeal in Business Manager.

## Test plan
- [x] `vitest __tests__/integrations-status-api.test.ts`
- [ ] Refresh `/admin/integrations` after deploy — no `ses` row; Postiz configured

Made with [Cursor](https://cursor.com)