### PR TITLE
ci: deploy-pi smoke, Lighthouse hook, Legion RUNNER_X64

### DIFF
--- a/.github/scripts/toggle-runner.sh
+++ b/.github/scripts/toggle-runner.sh
@@ -1,30 +1,35 @@
 #!/usr/bin/env bash
-# Toggle CI between GitHub-hosted runners and the self-hosted Pi `build` cluster.
+# Toggle CI between GitHub-hosted runners and self-hosted pools.
 #
 # Why this exists:
 #   GitHub Actions has no native runner-failover. When GitHub billing breaks
 #   or hosted-runner capacity is exhausted, every workflow targeted at
-#   `ubuntu-latest` fails fast with "the job was not started because recent
-#   account payments have failed". Flipping the `RUNNER_GENERIC` repo variable
-#   re-routes all instrumented workflows to the Pi runners on their next run.
+#   `ubuntu-latest` fails fast. Flipping repo variables re-routes instrumented
+#   workflows on their next run.
+#
+# Two independent knobs:
+#   RUNNER_GENERIC — generic CI (lint/build/test style). Pi build pool only.
+#   RUNNER_X64     — browser suites (Lighthouse / Playwright / a11y). Legion WSL
+#                    only — NEVER point this at omv/Pi.
 #
 # Usage:
-#   .github/scripts/toggle-runner.sh status   # show current setting + runner inventory
-#   .github/scripts/toggle-runner.sh pi       # route generic jobs to Pi build runners
-#   .github/scripts/toggle-runner.sh hosted   # route generic jobs back to ubuntu-latest (clears the var)
+#   .github/scripts/toggle-runner.sh status
+#   .github/scripts/toggle-runner.sh pi|hosted
+#   .github/scripts/toggle-runner.sh x64-legion|x64-hosted
 #
 # Notes:
-#   - Already-queued jobs are NOT re-routed; cancel + re-run them after toggling.
-#   - Workflows must opt in by using:
+#   - Already-queued jobs are NOT re-routed; cancel + re-run after toggling.
+#   - Opt-in:
 #       runs-on: ${{ fromJSON(vars.RUNNER_GENERIC || '"ubuntu-latest"') }}
-#   - Jobs that genuinely require x86_64 or more RAM than a Pi has (Lighthouse,
-#     CodeQL, heavy Playwright matrices) should keep a hard `runs-on: ubuntu-latest`.
+#       runs-on: ${{ fromJSON(vars.RUNNER_X64 || '"ubuntu-latest"') }}
 
 set -euo pipefail
 
 REPO="${REPO:-Themis128/cloudless.gr}"
-VAR_NAME="RUNNER_GENERIC"
+VAR_GENERIC="RUNNER_GENERIC"
+VAR_X64="RUNNER_X64"
 PI_VALUE='["self-hosted","omv","build"]'
+LEGION_VALUE='["self-hosted","legion","x64"]'
 
 cmd="${1:-status}"
 
@@ -36,14 +41,22 @@ show_runners() {
     || echo "  (unable to query — check gh auth)"
 }
 
-show_status() {
+show_var() {
+  local name="$1"
+  local current
   current=$(gh variable list --repo "${REPO}" --json name,value \
-    --jq ".[] | select(.name == \"${VAR_NAME}\") | .value" 2>/dev/null || true)
+    --jq ".[] | select(.name == \"${name}\") | .value" 2>/dev/null || true)
   if [[ -z "${current}" ]]; then
-    echo "Mode: HOSTED (ubuntu-latest)  —  ${VAR_NAME} is unset"
+    echo "  ${name}: unset → ubuntu-latest"
   else
-    echo "Mode: SELF-HOSTED  —  ${VAR_NAME}=${current}"
+    echo "  ${name}: ${current}"
   fi
+}
+
+show_status() {
+  echo "Runner variables on ${REPO}:"
+  show_var "${VAR_GENERIC}"
+  show_var "${VAR_X64}"
   show_runners
 }
 
@@ -52,18 +65,29 @@ case "${cmd}" in
     show_status
     ;;
   pi|self-hosted)
-    echo "==> Setting ${VAR_NAME}=${PI_VALUE} on ${REPO}"
-    gh variable set "${VAR_NAME}" --repo "${REPO}" --body "${PI_VALUE}"
+    echo "==> Setting ${VAR_GENERIC}=${PI_VALUE} on ${REPO}"
+    gh variable set "${VAR_GENERIC}" --repo "${REPO}" --body "${PI_VALUE}"
     echo "==> Done. Cancel + re-run any queued workflows to pick up the change."
     show_status
     ;;
   hosted|gh|github)
-    echo "==> Clearing ${VAR_NAME} on ${REPO} (back to ubuntu-latest)"
-    gh variable delete "${VAR_NAME}" --repo "${REPO}" 2>/dev/null || true
+    echo "==> Clearing ${VAR_GENERIC} on ${REPO} (back to ubuntu-latest)"
+    gh variable delete "${VAR_GENERIC}" --repo "${REPO}" 2>/dev/null || true
+    show_status
+    ;;
+  x64-legion)
+    echo "==> Setting ${VAR_X64}=${LEGION_VALUE} on ${REPO}"
+    echo "    (Lighthouse / e2e / a11y only — do not use omv for these)"
+    gh variable set "${VAR_X64}" --repo "${REPO}" --body "${LEGION_VALUE}"
+    show_status
+    ;;
+  x64-hosted)
+    echo "==> Clearing ${VAR_X64} on ${REPO} (browser suites → ubuntu-latest)"
+    gh variable delete "${VAR_X64}" --repo "${REPO}" 2>/dev/null || true
     show_status
     ;;
   *)
-    echo "Usage: $0 [status|pi|hosted]" >&2
+    echo "Usage: $0 [status|pi|hosted|x64-legion|x64-hosted]" >&2
     exit 2
     ;;
 esac

--- a/.github/workflows/a11y-audit.yml
+++ b/.github/workflows/a11y-audit.yml
@@ -28,7 +28,8 @@ concurrency:
 jobs:
   axe-playwright:
     name: Playwright A11y Checks
-    runs-on: ubuntu-latest
+    # Default GH-hosted; RUNNER_X64=["self-hosted","legion","x64"] for Legion failover.
+    runs-on: ${{ fromJSON(vars.RUNNER_X64 || '"ubuntu-latest"') }}
     timeout-minutes: 20
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd         # v6

--- a/.github/workflows/deploy-pi.yml
+++ b/.github/workflows/deploy-pi.yml
@@ -368,7 +368,8 @@ jobs:
         (github.event_name == 'workflow_dispatch' && inputs.trigger_only)
       )
     runs-on: ${{ fromJSON(vars.RUNNER_GENERIC || '"ubuntu-latest"') }}
-    timeout-minutes: 10
+    # Trigger is fast; edge smoke may wait a few minutes for omv pull + health.
+    timeout-minutes: 15
     steps:
     - name: Resolve artifact key
       id: key
@@ -423,6 +424,75 @@ jobs:
           echo "| githubRunId | \`${{ github.run_id }}\` |"
         } >> "$GITHUB_STEP_SUMMARY"
 
+    - name: Edge smoke (health SHA + public routes)
+      id: smoke
+      if: steps.trigger.outputs.workflow_instance_id != 'skipped-no-orch-url' && steps.trigger.outputs.workflow_instance_id != 'skipped-no-orch-token'
+      env:
+        WANT_SHA: ${{ github.sha }}
+      run: |
+        set -euo pipefail
+        WANT12="${WANT_SHA:0:12}"
+        HEALTH_URLS=(
+          https://cloudless.gr/api/health
+          https://pi-origin.cloudless.gr/api/health
+        )
+        PAGE_URLS=(
+          https://cloudless.gr/en
+          https://cloudless.gr/en/store
+          https://cloudless.gr/en/contact
+        )
+
+        echo "Waiting for /api/health version to match ${WANT12}…"
+        LIVE=""
+        MATCHED=0
+        for i in $(seq 1 12); do
+          for u in "${HEALTH_URLS[@]}"; do
+            BODY=$(curl -sS --max-time 15 "$u" || true)
+            if echo "$BODY" | jq -e .version >/dev/null 2>&1; then
+              LIVE=$(echo "$BODY" | jq -r .version)
+              echo "  try ${i}: $u → version=${LIVE}"
+              case "$LIVE" in
+                "$WANT_SHA"|"$WANT12"|${WANT_SHA:0:7}|${WANT_SHA:0:8})
+                  MATCHED=1
+                  break 2
+                  ;;
+              esac
+            else
+              CODE=$(curl -sS -o /dev/null -w "%{http_code}" --max-time 15 "$u" || echo 000)
+              echo "  try ${i}: $u → http=${CODE} (no version json)"
+            fi
+          done
+          sleep 30
+        done
+
+        if [ "$MATCHED" != "1" ]; then
+          echo "::error::Edge health did not report sha ${WANT12} within ~6m (last=${LIVE:-none}). CF Workflow may still be waiting on omv pull."
+          exit 1
+        fi
+
+        SMOKE_LINES=()
+        for u in "${PAGE_URLS[@]}"; do
+          CODE=$(curl -sS -o /dev/null -w "%{http_code}" --max-time 30 "$u" || echo 000)
+          echo "smoke $u → ${CODE}"
+          SMOKE_LINES+=("| \`$u\` | ${CODE} |")
+          case "$CODE" in
+            2??) ;;
+            *)
+              echo "::error::Smoke failed: $u returned ${CODE}"
+              exit 1
+              ;;
+          esac
+        done
+
+        {
+          echo "## Edge smoke"
+          echo ""
+          echo "| Check | Result |"
+          echo "| --- | --- |"
+          echo "| health version | \`${LIVE}\` (want \`${WANT12}\`) |"
+          printf '%s\n' "${SMOKE_LINES[@]}"
+        } | tee /tmp/smoke.md >> "$GITHUB_STEP_SUMMARY"
+
     - name: Comment tracking on issue 382
       if: always()
       env:
@@ -441,4 +511,13 @@ jobs:
           echo "| artifactKey | \`$KEY\` |"
           echo "| workflowInstanceId | \`$INSTANCE\` |"
           echo "| run | ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }} |"
+          if [ -f /tmp/smoke.md ]; then
+            echo ""
+            # Drop the H2 from the step summary copy; keep the table.
+            sed '1{/^## Edge smoke$/d;}' /tmp/smoke.md | sed '/^$/d' | {
+              echo "#### Edge smoke"
+              echo ""
+              cat
+            }
+          fi
         } | gh issue comment 382 --repo "${{ github.repository }}" --body-file -

--- a/.github/workflows/e2e-full-coverage.yml
+++ b/.github/workflows/e2e-full-coverage.yml
@@ -19,7 +19,8 @@ concurrency:
 jobs:
   e2e:
     name: Playwright full coverage (local dev)
-    runs-on: ubuntu-latest
+    # Default GH-hosted; RUNNER_X64=["self-hosted","legion","x64"] for Legion failover.
+    runs-on: ${{ fromJSON(vars.RUNNER_X64 || '"ubuntu-latest"') }}
     timeout-minutes: 30
     env:
       FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'

--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -5,7 +5,9 @@ env:
 
 on:
   workflow_run:
-    workflows: [Deploy to Cloudflare Workers + k3s]
+    # Production edge ships via deploy-pi (R2 → CF Workflow → omv pull), not the
+    # legacy OpenNext/Workers workflow name.
+    workflows: [Deploy to Pi (R2 + Cloudflare Workflows pull)]
     types: [completed]
   workflow_dispatch:
     inputs:
@@ -27,7 +29,9 @@ permissions:
 jobs:
   audit:
     name: Performance Audit
-    runs-on: ubuntu-latest
+    # Default GH-hosted; set repo var RUNNER_X64 to
+    # ["self-hosted","legion","x64"] for Legion WSL failover (never omv/Pi).
+    runs-on: ${{ fromJSON(vars.RUNNER_X64 || '"ubuntu-latest"') }}
     if: ${{ github.event_name != 'workflow_run' ||
       github.event.workflow_run.conclusion == 'success' }}
     timeout-minutes: 15

--- a/.github/workflows/runner-mode.yml
+++ b/.github/workflows/runner-mode.yml
@@ -3,18 +3,20 @@ name: Switch Runner Mode
 # UI-accessible alternative to .github/scripts/toggle-runner.sh for
 # sessions where gh CLI is not available (e.g. Claude Code on the web).
 # Runs on ubuntu-latest (hardcoded) so it always uses a GH-hosted runner
-# regardless of the current RUNNER_GENERIC value.
+# regardless of RUNNER_GENERIC / RUNNER_X64.
 
 on:
   workflow_dispatch:
     inputs:
       mode:
-        description: Runner pool for generic CI jobs
+        description: Runner pool to switch
         required: true
         type: choice
         options:
-        - hosted             # ubuntu-latest — free for public repos
-        - pi             # self-hosted Pi build runners
+        - hosted             # clear RUNNER_GENERIC → ubuntu-latest
+        - pi                 # RUNNER_GENERIC → omv build
+        - x64-hosted         # clear RUNNER_X64 → ubuntu-latest (LH/e2e/a11y)
+        - x64-legion         # RUNNER_X64 → legion WSL (LH/e2e/a11y only)
 
 permissions:
   actions: write
@@ -31,7 +33,7 @@ jobs:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
         gh variable delete RUNNER_GENERIC --repo "$GITHUB_REPOSITORY" 2>/dev/null || true
-        echo "RUNNER_GENERIC cleared — workflows will use ubuntu-latest."
+        echo "RUNNER_GENERIC cleared — generic workflows will use ubuntu-latest."
 
     - name: Set RUNNER_GENERIC (→ Pi build runners)
       if: inputs.mode == 'pi'
@@ -43,22 +45,47 @@ jobs:
           --repo "$GITHUB_REPOSITORY"
         echo "RUNNER_GENERIC set to [self-hosted, omv, build]."
 
+    - name: Clear RUNNER_X64 (→ ubuntu-latest for browser suites)
+      if: inputs.mode == 'x64-hosted'
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        gh variable delete RUNNER_X64 --repo "$GITHUB_REPOSITORY" 2>/dev/null || true
+        echo "RUNNER_X64 cleared — Lighthouse/e2e/a11y use ubuntu-latest."
+
+    - name: Set RUNNER_X64 (→ Legion WSL)
+      if: inputs.mode == 'x64-legion'
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        gh variable set RUNNER_X64 \
+          --body '["self-hosted","legion","x64"]' \
+          --repo "$GITHUB_REPOSITORY"
+        echo "RUNNER_X64 set to [self-hosted, legion, x64]."
+        echo "Never point RUNNER_X64 at omv/Pi — browser suites need x86_64 Chrome."
+
     - name: Print summary
       run: |
-        if [ "${{ inputs.mode }}" = "hosted" ]; then
-          {
-            echo "## Runner mode: GitHub-hosted"
-            echo ""
-            echo "**RUNNER_GENERIC** cleared."
-            echo "All instrumented workflows now use \`ubuntu-latest\` (free for public repos)."
-          } >> "$GITHUB_STEP_SUMMARY"
-        else
-          {
-            echo "## Runner mode: Pi self-hosted"
-            echo ""
-            echo "**RUNNER_GENERIC** = \`[\"self-hosted\",\"omv\",\"build\"]\`"
-            echo "All instrumented workflows route to the Pi build runner pool."
-            echo ""
-            echo "> **Reminder:** already-queued jobs are not re-routed — cancel and re-run them."
-          } >> "$GITHUB_STEP_SUMMARY"
-        fi
+        MODE="${{ inputs.mode }}"
+        {
+          echo "## Runner mode: \`${MODE}\`"
+          echo ""
+          case "$MODE" in
+            hosted)
+              echo "**RUNNER_GENERIC** cleared → \`ubuntu-latest\` for instrumented generic CI."
+              ;;
+            pi)
+              echo "**RUNNER_GENERIC** = \`[\"self-hosted\",\"omv\",\"build\"]\`"
+              echo "Generic CI routes to the Pi build pool. Do **not** use for Lighthouse/Playwright."
+              ;;
+            x64-hosted)
+              echo "**RUNNER_X64** cleared → \`ubuntu-latest\` for Lighthouse / e2e / a11y."
+              ;;
+            x64-legion)
+              echo "**RUNNER_X64** = \`[\"self-hosted\",\"legion\",\"x64\"]\`"
+              echo "Browser suites route to the Legion WSL runner (must be online)."
+              ;;
+          esac
+          echo ""
+          echo "> **Reminder:** already-queued jobs are not re-routed — cancel and re-run them."
+        } >> "$GITHUB_STEP_SUMMARY"

--- a/.gitignore
+++ b/.gitignore
@@ -255,3 +255,4 @@ RUN-MIGRATION.md
 # Local lint tool caches (yamllint / actionlint)
 .tools/
 test-results.json/
+.lighthouseci/

--- a/docs/deploy/runners.md
+++ b/docs/deploy/runners.md
@@ -1,185 +1,149 @@
-# CI Runner Failover
+# CI Runner Failover & Capacity
 
-GitHub Actions has no native runner failover — when GitHub-hosted billing
-breaks or hosted capacity is exhausted, `runs-on: ubuntu-latest` jobs are
-rejected by the GitHub control plane _before_ any YAML runs, so a workflow
-cannot self-detect or recover from it.
+No Jenkins (or other CI controller) on omv. Capacity is **GitHub Actions**
+plus **omv systemd timers** for deploy pull / heal / housekeeping.
 
-This repo gets the same practical result by combining:
+## Capacity matrix (defaults)
 
-1. A **repo variable** (`RUNNER_GENERIC`) that resolves into the `runs-on`
-   field at queue time via `fromJSON()`.
-2. A **second runner profile** on each Pi host (labels `omv,build`),
-   running alongside the existing `pi`-labelled cluster runner.
-3. A **one-command toggle** that flips every instrumented workflow between
-   GitHub-hosted and Pi-hosted runners.
+| Workload | Default runner | Failover | Hard rule |
+| -------- | -------------- | -------- | --------- |
+| PR CI (`ci.yml`, lint/typecheck/unit) | `ubuntu-latest` via `RUNNER_GENERIC` | Pi `["self-hosted","omv","build"]` | OK on Pi for short jobs |
+| `deploy-pi` Next **build** | `ubuntu-24.04-arm` | — | Never compile Next on omv happy path |
+| `deploy-pi` **publish** + edge smoke | `ubuntu-latest` via `RUNNER_GENERIC` | Pi build pool | Smoke is curl-only |
+| Lighthouse / Playwright e2e / a11y | `ubuntu-latest` via `RUNNER_X64` | Legion `["self-hosted","legion","x64"]` | **Never** omv/`RUNNER_GENERIC=pi` |
+| Cluster-bound (`omv,pi`) | self-hosted Pi | — | CWV, kubectl, NodePort probes only |
+| Mail host (`omv-ha`) | — | — | No always-on heavy CI |
 
-## How the toggle works
-
-Instrumented workflows declare:
+**`RUNNER_GENERIC=pi` never applies to Lighthouse / e2e / a11y.** Those use
+`RUNNER_X64` only. Pi `build` stays for Docker/image/ETL-style jobs.
 
 ```yaml
+# Generic CI / publish
 runs-on: ${{ fromJSON(vars.RUNNER_GENERIC || '"ubuntu-latest"') }}
+
+# Browser suites (lighthouse.yml, e2e-full-coverage.yml, a11y-audit.yml)
+runs-on: ${{ fromJSON(vars.RUNNER_X64 || '"ubuntu-latest"') }}
 ```
 
-| `RUNNER_GENERIC` value          | Effective `runs-on`               |
-| ------------------------------- | --------------------------------- |
-| _unset_ (default)               | `ubuntu-latest`                   |
-| `["self-hosted","omv","build"]` | self-hosted Pi build runners      |
-| `["self-hosted","omv","foo"]`   | any matching label set you define |
+## Post-deploy truth
 
-`fromJSON('"ubuntu-latest"')` resolves to the string literal; `fromJSON('[...]')`
-resolves to the array. Both shapes are accepted by `runs-on`.
+Production edge: `cloudless.gr` → Worker `cloudless2` → Tunnel → k3s
+`cloudless-app` on omv. Deploy happy path:
 
-## Toggling
+1. `deploy-pi.yml` builds on `ubuntu-24.04-arm`, uploads R2 artifact
+2. `publish` POSTs Cloudflare Workflow `/trigger` (durable `/api/health` wait)
+3. omv `pi-release-pull.timer` pulls when load OK
+4. GH **edge smoke** (same publish job) polls health SHA + `/en`, `/en/store`, `/en/contact`
+5. `lighthouse.yml` runs on `workflow_run` success of
+   **Deploy to Pi (R2 + Cloudflare Workflows pull)**
 
-**From the terminal** (requires `gh` CLI):
+Do **not** restore SSH/rsync rollout as the happy path.
+
+## How the toggles work
+
+| Variable | Unset (default) | Set value | Affects |
+| -------- | --------------- | --------- | ------- |
+| `RUNNER_GENERIC` | `ubuntu-latest` | `["self-hosted","omv","build"]` | Instrumented generic CI + deploy-pi publish |
+| `RUNNER_X64` | `ubuntu-latest` | `["self-hosted","legion","x64"]` | Lighthouse, e2e-full-coverage, a11y-audit |
+
+`fromJSON('"ubuntu-latest"')` → string; `fromJSON('[...]')` → label array.
+Both shapes are valid for `runs-on`.
+
+### CLI
 
 ```bash
-# Show current state + runner inventory
 .github/scripts/toggle-runner.sh status
-
-# Route generic jobs to the Pi build runners
-.github/scripts/toggle-runner.sh pi
-
-# Route them back to ubuntu-latest (clears the variable)
-.github/scripts/toggle-runner.sh hosted
+.github/scripts/toggle-runner.sh pi          # RUNNER_GENERIC → omv build
+.github/scripts/toggle-runner.sh hosted      # clear RUNNER_GENERIC
+.github/scripts/toggle-runner.sh x64-legion  # RUNNER_X64 → Legion WSL
+.github/scripts/toggle-runner.sh x64-hosted  # clear RUNNER_X64
 ```
 
-**From GitHub UI** (no `gh` CLI required — useful in cloud sessions):
+### GitHub UI
 
-Actions → **Switch Runner Mode** → Run workflow → choose `hosted` or `pi`.
+Actions → **Switch Runner Mode** → `hosted` | `pi` | `x64-hosted` | `x64-legion`
+(`.github/workflows/runner-mode.yml`).
 
-This runs `.github/workflows/runner-mode.yml`, which uses `GITHUB_TOKEN`
-with `actions: write` to set or clear `RUNNER_GENERIC` directly.
+**Already-queued jobs are not re-routed** — cancel and re-run after flipping.
 
-**Already-queued jobs are not re-routed** — cancel and re-run them after
-flipping. New runs pick up the new value immediately.
+## Workflows on `RUNNER_GENERIC`
 
-## Workflows opted in
+- `ci.yml`, `ha-sync-orchestrator.yml`, `labeler.yml`, `links-audit.yml`,
+  `pi-tls-cert-check.yml`, `pr-review.yml`, `secret-scan.yml`,
+  `sha-drift-detector.yml`, `sha-drift-watchdog.yml`, `api-contract-audit.yml`,
+  `bundle-budget.yml`, `structured-data-audit.yml`, `seo-hygiene.yml`,
+  `mcp-security-scan.yml`, `codeql.yml`, `preview.yml`,
+  `dependabot-automerge.yml`, `dependency-review.yml`, `ecr-lifecycle.yml`,
+  `i18n-audit.yml`, `monthly-security-audit.yml`, `notion-docs-sitemap.yml`,
+  `notion-schema-check.yml`, `notion-schema-drift.yml`, `release.yml`,
+  `slack-manifest-apply.yml`, `stale.yml`, `teardown-staging.yml`,
+  `weekly-article-draft.yml`, `weekly-gsc-sync.yml`, `weekly-newsletter.yml`,
+  `weekly-subscriber-report.yml`
+- `deploy-pi.yml` **publish** job only (`build` stays on `ubuntu-24.04-arm`)
 
-These read `vars.RUNNER_GENERIC` and fail over automatically:
+## Workflows on `RUNNER_X64` (browser / Chrome)
 
-- `ci.yml` (lint, typecheck, format, build, test)
-- `deploy-pi.yml` (`build` stays on `[self-hosted, omv, build]`; `rollout` on `[self-hosted, omv-ha, deploy]` — not `RUNNER_GENERIC`)
-- `ha-sync-orchestrator.yml`
-- `labeler.yml`
-- `links-audit.yml`
-- `pi-tls-cert-check.yml`
-- `pr-review.yml`
-- `secret-scan.yml`
-- `sha-drift-detector.yml`
-- `sha-drift-watchdog.yml`
-- `api-contract-audit.yml`
-- `bundle-budget.yml`
-- `structured-data-audit.yml`
-- `seo-hygiene.yml`
-- `mcp-security-scan.yml` (pure JS/TS scanner, ARM-safe; informational-only via `continue-on-error: true`)
-- `codeql.yml` (CodeQL CLI v4 supports linux-arm64 for JS/TS analysis)
-- `preview.yml` (SST/CDK — prior Pi attempt in run `26321031309` hung past timeout under cold-deploy; retrying with 40-min timeout)
-- `dependabot-automerge.yml`
-- `dependency-review.yml`
-- `ecr-lifecycle.yml`
-- `i18n-audit.yml`
-- `monthly-security-audit.yml`
-- `notion-docs-sitemap.yml`
-- `notion-schema-check.yml`
-- `notion-schema-drift.yml`
-- `release.yml`
-- `slack-manifest-apply.yml`
-- `stale.yml`
-- `teardown-staging.yml`
-- `weekly-article-draft.yml`
-- `weekly-gsc-sync.yml`
-- `weekly-newsletter.yml`
-- `weekly-subscriber-report.yml`
+- `lighthouse.yml`
+- `e2e-full-coverage.yml`
+- `a11y-audit.yml`
 
-## Workflows that stay GitHub-hosted
+Default remains GitHub-hosted. Set `RUNNER_X64` only when Legion WSL is online.
 
-These pin `runs-on: ubuntu-latest` because they need x86_64, a system
-Chromium, more RAM than a Pi 4/5 has, or do not converge in a sensible
-time on ARM:
+## Workflows that stay pinned / cluster-bound
 
-- `deploy.yml` (SST → AWS Lambda) — tried failover on 2026-05-23 in run
-  [`26321031309`](https://github.com/Themis128/cloudless.gr/actions/runs/26321031309);
-  the `Deploy (SST)` step hung past the 40 min job timeout on the omv
-  Pi runner. SST + CDK synth + Sentry sourcemap upload don't fit on ARM
-  under cold-deploy conditions. **Lesson:** "mostly network-bound" was
-  the wrong heuristic — sourcemap upload alone is multi-hundred-MB
-  through Sentry's API and CDK synth is CPU-heavy on cold cache. When
-  billing is broken this workflow goes red and `cloudless.gr` (Lambda)
-  cannot be updated until billing is fixed. The Pi/k3s surface (`pi-origin.cloudless.gr`)
-  stays deployable via `deploy-pi.yml` and is the documented failover
-  surface, so user-visible features still ship through the secondary.
-- `lighthouse.yml` — needs system Chrome; ARM has no official Chromium binary in the runner image.
-- `k3s-e2e.yml` — Playwright + browser deps; runs against the live Pi standby so adding Pi-side load is also counterproductive.
-- `a11y-audit.yml` — tried failover on 2026-05-23 in run [`26341722748`](https://github.com/Themis128/cloudless.gr/actions/runs/26341722748/job/77544838049); ran for 11 minutes on the omv-build Pi runner and failed. Playwright + Chromium accessibility checks need x86_64 Chrome behaviour; the ARM64 Chromium build does not produce the same axe-core results consistently. Pinned back to ubuntu-latest.
-
-When billing is broken, these stay red until billing is fixed.
+- `deploy.yml` (SST) — stays GH-hosted; does not fit Pi cold-deploy
+- `k3s-e2e.yml` — GH-hosted Playwright against live cluster (do not add Pi load)
+- `core-web-vitals-audit.yml` — `[self-hosted, omv, pi]` (leave unless lab CWV moves off-box)
+- Cluster remediations (`cluster-doctor.yml`, `k3s-restart.yml`, …) —
+  path-triggered / `workflow_dispatch`; no app CronJob for deploys
 
 ## deploy-pi topology (GH build → R2 → CF Workflow → omv pull)
 
-`deploy-pi.yml` **never SSHs or rsyncs to omv**. Compiling or pushing
-~350MB onto the Pi 5 control plane pegs the USB SSD and trips the hardware
-watchdog / freezes CI.
+`deploy-pi.yml` **never SSHs or rsyncs to omv** on the happy path.
 
 | Job | `runs-on` | Role |
 | --- | --------- | ---- |
-| `build` | `ubuntu-24.04-arm` | Next standalone compile; pack (BUILD_ID + tracing deps); upload `releases/<sha>.tar.zst` to R2 bucket `cloudless-pi-releases` |
-| `publish` | `ubuntu-latest` (or `RUNNER_GENERIC`) | `POST` Cloudflare Worker `/trigger` → durable Workflow waits on `/api/health` |
+| `build` | `ubuntu-24.04-arm` | Next standalone; upload `releases/<sha>.tar.zst` to R2 |
+| `publish` | `ubuntu-latest` (or `RUNNER_GENERIC`) | `/trigger` + edge smoke + issue #382 comment |
 
-**omv** runs `pi-release-pull.timer` (every 2m): reads `desired.json` via the
-orchestrator, skips when load/iowait is high, otherwise downloads from R2,
-BUILD_ID-gates, flips `cloudless-standalone`, restarts `cloudless-app`.
-
-**Tracking (correlate by sha):** GH step summary + issue [#382](https://github.com/Themis128/cloudless.gr/issues/382) comment;
-Workflow Slack/ntfy; `/var/log` via `journalctl -t pi-release-pull`.
+**omv** `pi-release-pull.timer` (every 2m): reads `desired.json`, skips when
+load/iowait high, downloads from R2, BUILD_ID-gates, flips symlink, restarts app.
 
 Worker: [`workers/pi-deploy-orchestrator/`](../../workers/pi-deploy-orchestrator/).
-Install pull agent: `sudo bash infrastructure/omv/install-pi-release-pull.sh`
-(after filling `/etc/cloudless/pi-release-pull.env`).
+Install: `sudo bash infrastructure/omv/install-pi-release-pull.sh`.
 
 Repo variable: `PI_DEPLOY_ORCHESTRATOR_URL`. Secrets: `DEPLOY_ORCHESTRATOR_TOKEN`,
 `CF_ACCOUNT_ID`, `CF_R2_ACCESS_KEY_ID`, `CF_R2_SECRET_ACCESS_KEY`.
 
-- Skip-if-live probes `https://pi-origin.cloudless.gr/api/health`.
-- Concurrency group `deploy-pi` with `cancel-in-progress: true`.
-- `workflow_dispatch` `trigger_only=true` re-fires the Workflow when the R2
-  object already exists.
+- Skip-if-live probes `https://pi-origin.cloudless.gr/api/health`
+- Concurrency `deploy-pi` / `cancel-in-progress: true`
+- `workflow_dispatch` `trigger_only=true` re-fires Workflow when R2 object exists
 
 ### Legacy (retired)
 
-Previously rollout used `[self-hosted, omv-ha, deploy]` + rsync. That path
-stuck the Pi and left zombie busy runners after power-cycles — do not restore
-it on the happy path. `scripts/pi-rollout-from-artifact.sh` remains for
-emergency manual use from a trusted host.
+SSH/rsync via omv-ha deploy runner is retired. Do not restore on the happy
+path. `scripts/pi-rollout-from-artifact.sh` remains for emergency manual use.
 
-## Runner auto-heal after reboot (ghost-busy)
+## omv timers (ops checklist — no new CI server)
 
-After a power-cycle or sleep, GitHub often shows runners **offline + busy**
-while systemd still says `active` — the queue stays blocked until restart
-([actions/runner#4312](https://github.com/actions/runner/issues/4312)).
+| Timer | Role |
+| ----- | ---- |
+| `pi-release-pull.timer` | Pull R2 release when load OK |
+| `safedeploy-watchdog.timer` | Health + auto-rollback |
+| `gha-runner-heal.timer` | Ghost-busy runner heal after reboot |
+| `pi-connectivity-heal.timer` | SSH/Tailscale heal |
+| `cloudless-cleanup.timer` | Host housekeeping |
+| `k3s-etcd-defrag.timer` | Weekly etcd defrag (Sunday) |
 
-Install on **both** omv and omv-ha:
+### After power-cycle
 
-```bash
-# From a machine with the repo checkout:
-for host in 192.168.1.128 192.168.1.130; do
-  scp infrastructure/omv/gha-runner-heal.sh \
-      infrastructure/omv/gha-runner-heal.service \
-      infrastructure/omv/gha-runner-heal-check.service \
-      infrastructure/omv/gha-runner-heal.timer \
-      infrastructure/omv/install-gha-runner-heal.sh \
-      tbaltzakis@$host:/tmp/gha-heal/
-  ssh tbaltzakis@$host "sudo bash /tmp/gha-heal/install-gha-runner-heal.sh"
-done
-```
+1. `systemctl is-active k3s-k3s-omv.service` (not bare `k3s.service`)
+2. Heal timer installed: `systemctl is-active gha-runner-heal.timer`
+3. Runners online in GitHub → Settings → Actions → Runners
+4. App: `kubectl -n … get pods` / edge `curl -sI https://cloudless.gr` shows
+   `x-served-by: pi-tunnel-proxy`
 
-- **Boot:** `gha-runner-heal.service` restarts every `actions.runner.*` unit.
-- **Every 5 min:** timer runs `--check` and restarts units that are active
-  but have no `Runner.Listener` process.
-
-Manual recovery:
+Manual runner heal:
 
 ```bash
 sudo systemctl restart 'actions.runner.*'
@@ -187,80 +151,105 @@ sudo systemctl restart 'actions.runner.*'
 sudo /usr/local/sbin/gha-runner-heal.sh --boot
 ```
 
-## Setting up the second runner profile on each Pi host
+Install heal on omv (and omv-ha if it still hosts a runner):
 
-The existing runner (`~/actions-runner`, labels `omv,pi`) stays put. We add a
-second runner (`~/actions-runner-build`, labels `omv,build`) so cluster jobs
-and generic jobs don't queue behind each other.
+```bash
+sudo bash infrastructure/omv/install-gha-runner-heal.sh
+```
 
-On each Pi host (`omv` = omv-main Pi 5, `omv-ha` = secondary):
+## Legion WSL runner (x64 browser failover)
 
-1. Generate a registration token at
-   <https://github.com/Themis128/cloudless.gr/settings/actions/runners> →
-   **New self-hosted runner** (or via CLI: `gh api -X POST repos/Themis128/cloudless.gr/actions/runners/registration-token --jq '.token'`).
-2. Run the bootstrap script (token expires in 1 hour, so do it inline):
+Use only when GH-hosted billing/capacity fails for Chrome suites. Labels:
+`self-hosted`, `legion`, `x64`. Workdir: `~/actions-runner-legion`
+(separate from any omv profile).
 
-   ```bash
-   ./.github/scripts/register-build-runner.sh <REG_TOKEN> omv-build
-   #                                                       omv-2-build
-   ```
+### Register (once, on Legion WSL2)
 
-   The script handles download, config, systemd install, and start in one shot.
-   For hosts without `gh` installed, rsync the binaries from omv-main first:
+```bash
+mkdir -p ~/actions-runner-legion && cd ~/actions-runner-legion
+curl -fsSL -o actions-runner-linux-x64.tar.gz \
+  https://github.com/actions/runner/releases/download/v2.323.0/actions-runner-linux-x64-2.323.0.tar.gz
+tar xzf actions-runner-linux-x64.tar.gz
 
-   ```bash
-   # On omv-main:
-   rsync -a --exclude '_work' --exclude '_diag' ~/actions-runner-build/ tbaltzakis@192.168.1.130:~/actions-runner-build/
-   ```
+TOKEN=$(gh api -X POST repos/Themis128/cloudless.gr/actions/runners/registration-token --jq .token)
+./config.sh --url https://github.com/Themis128/cloudless.gr \
+  --token "$TOKEN" \
+  --name legion-wsl \
+  --labels self-hosted,legion,x64 \
+  --work _work
 
-3. Verify all runners online:
+# User systemd so the runner survives logout (linger required once):
+sudo loginctl enable-linger "$USER"
+mkdir -p ~/.config/systemd/user
+cat > ~/.config/systemd/user/actions.runner.legion.service <<'EOF'
+[Unit]
+Description=GitHub Actions runner (legion x64)
+After=network-online.target
+Wants=network-online.target
 
-   ```bash
-   gh api repos/Themis128/cloudless.gr/actions/runners \
-     --jq '.runners[] | {name, status, labels: [.labels[].name]}'
-   ```
+[Service]
+Type=simple
+WorkingDirectory=%h/actions-runner-legion
+ExecStart=%h/actions-runner-legion/run.sh
+Restart=always
+RestartSec=10
 
-Current active fleet (as of 2026-08-12):
+[Install]
+WantedBy=default.target
+EOF
+systemctl --user daemon-reload
+systemctl --user enable --now actions.runner.legion.service
+```
 
-| Host     | IP / Tailscale              | Runner name      | Labels                                         | Status / role |
-| -------- | --------------------------- | ---------------- | ---------------------------------------------- | ------------- |
-| omv-main | 192.168.1.128 / 100.74.191.58 | `omv`          | `self-hosted, Linux, ARM64, omv, pi`           | cluster jobs |
-| omv-main | 192.168.1.128               | `omv-build`      | `self-hosted, Linux, ARM64, omv, pi, build`    | Docker / `build-pi-image.yml` only — **not** `deploy-pi` Next build |
-| omv-ha   | 192.168.1.130 / 100.95.117.84 | `omv-ha-deploy` | `self-hosted, Linux, ARM64, omv-ha, deploy`   | **deploy proxy** (`deploy-pi` rollout) |
-| omv-ha   | 192.168.1.130               | `omv-2-build`    | `self-hosted, Linux, ARM64, omv, build`        | optional spare — **do not** use for Next builds (1GB RAM) |
-| GitHub   | hosted                      | `ubuntu-24.04-arm` | (managed)                                   | **Next standalone build** (`deploy-pi` build job) |
+Pin the runner tarball version to whatever
+[actions/runner releases](https://github.com/actions/runner/releases) lists
+as current when you install; bump on upgrade.
 
-The `pi` label is for cluster-local jobs (NodePort audits, kubectl, CWV).
-The `build` label is for heavy Docker work on omv (Pi 5), **not** for
-`deploy-pi` Next compile:
+### Fail over browser suites
+
+```bash
+.github/scripts/toggle-runner.sh x64-legion   # when Legion is Idle in GH UI
+# … re-run failed LH / e2e / a11y …
+.github/scripts/toggle-runner.sh x64-hosted   # restore default
+```
+
+Install Chrome/Playwright deps in WSL before the first run
+(`npx playwright install --with-deps chromium` from a checkout).
+
+## Pi build runner profile (omv)
+
+Existing runner (`~/actions-runner`, labels `omv,pi`) stays. Optional second
+profile (`~/actions-runner-build`, labels `omv,build`) for Docker/image work:
+
+```bash
+./.github/scripts/register-build-runner.sh <REG_TOKEN> omv-build
+```
 
 | Labels | Purpose | Workflows |
 | ------ | ------- | --------- |
-| `ubuntu-24.04-arm` | Next standalone **build** + artifact upload | `deploy-pi.yml` (build) |
-| `self-hosted, omv, build` | Docker arm64 image build (ECR path) | `build-pi-image.yml` |
-| `self-hosted, omv-ha, deploy` | rsync SafeDeploy + kubectl over SSH to omv | `deploy-pi.yml` (rollout) |
-| `self-hosted, omv, pi` | Cluster reachability, NodePort Lighthouse, alert-api import | `core-web-vitals-audit.yml`, `cluster-status-audit.yml`, `deploy-alert-api.yml` |
+| `ubuntu-24.04-arm` | Next standalone build + R2 upload | `deploy-pi.yml` (build) |
+| `self-hosted, omv, build` | Docker arm64 / spare generic CI | `build-pi-image.yml`, `RUNNER_GENERIC=pi` |
+| `self-hosted, omv, pi` | Cluster reachability, CWV | `core-web-vitals-audit.yml`, cluster audits |
+| `self-hosted, legion, x64` | Browser suite failover | via `RUNNER_X64` only |
 
-Do **not** put CWV, cluster-status, or ETL on exclusive `build` — one busy
-Lighthouse run previously queued Docker builds for tens of minutes.
-
-`deploy-pi` concurrency uses `cancel-in-progress: true` so rapid main merges
-supersede older in-progress runs. A skip step no-ops when `/api/health`
-already reports `version == github.sha`.
+Do **not** put CWV or full Playwright on exclusive `build` — one busy browser
+run queues Docker builds for tens of minutes.
 
 ## Caveat: Pi runners share resources with production
 
-Pi 5 (`omv`) also runs the `cloudless` k3s pod that serves
-`pi-origin.cloudless.gr`. `deploy-pi` Next compile no longer runs there, but
-Docker builds (`build-pi-image.yml` on `omv-build`) and other `omv,pi` jobs
-still share disk/CPU with prod. If you park heavy work on omv, consider:
+omv runs `cloudless-app`. Prefer GH-hosted or Legion for Chrome. If you must
+park work on omv: `nice`, cgroup CPU limits, lower `max-parallel`.
 
-- A `nice -n 19` wrapper on the runner systemd unit
-- `cpuset.cpus` cgroup limit on the runner service
-- Reducing CI concurrency by setting a smaller `jobs.<id>.strategy.max-parallel`
+## Lab vs CI Lighthouse
 
-For a short billing-block outage, none of this is needed — flip, ship the
-critical PR, flip back.
+| Surface | Config | Command / trigger |
+| ------- | ------ | ----------------- |
+| **Lab (local)** | [`lighthouserc.local.cjs`](../../lighthouserc.local.cjs) | `pnpm lighthouse:audit` → [`scripts/lighthouse-local.sh`](../../scripts/lighthouse-local.sh) |
+| **CI (post-deploy)** | [`.github/lighthouserc.cjs`](../../.github/lighthouserc.cjs) + budget | `lighthouse.yml` after successful Deploy to Pi (+ daily cron / `workflow_dispatch`) |
+
+Lab audits hit whatever URL you pass (often production or local). CI uses the
+budgeted CI config against the live edge after deploy. See also
+[`docs/performance/`](../performance/).
 
 ## References
 

--- a/docs/performance/README.md
+++ b/docs/performance/README.md
@@ -1,5 +1,15 @@
 # Performance
 
+## Lab vs CI Lighthouse
+
+| | Lab (operator laptop) | CI (GitHub Actions) |
+| --- | --- | --- |
+| Config | [`lighthouserc.local.cjs`](../../lighthouserc.local.cjs) | [`.github/lighthouserc.cjs`](../../.github/lighthouserc.cjs) + budget |
+| How | `pnpm lighthouse:audit` ([`scripts/lighthouse-local.sh`](../../scripts/lighthouse-local.sh)) | [`lighthouse.yml`](../../.github/workflows/lighthouse.yml) after **Deploy to Pi (R2 + Cloudflare Workflows pull)** |
+| Runner | Local Chrome | `ubuntu-latest` by default; optional Legion via `RUNNER_X64` — never omv |
+
+See [`docs/deploy/runners.md`](../deploy/runners.md) for capacity / failover.
+
 | Doc | File |
 |-----|------|
 | [lighthouse-optimization-plan.md](lighthouse-optimization-plan.md) | `performance/lighthouse-optimization-plan.md` |

--- a/lighthouserc.local.cjs
+++ b/lighthouserc.local.cjs
@@ -1,0 +1,53 @@
+/**
+ * Local Lighthouse CI config for cloudless.gr production audits.
+ *
+ * Usage:
+ *   pnpm lighthouse:audit
+ *   pnpm lighthouse:audit -- --url=https://cloudless.gr/en/services
+ *
+ * CI config stays at `.github/lighthouserc.cjs` (flags + headers only;
+ * treosh action supplies URLs). This file is for operator / agent runs.
+ */
+module.exports = {
+  ci: {
+    collect: {
+      numberOfRuns: 1,
+      url: [
+        "https://cloudless.gr/en",
+        "https://cloudless.gr/en/services",
+        "https://cloudless.gr/en/store",
+        "https://cloudless.gr/en/contact",
+      ],
+      settings: {
+        // Match production edge: Worker → Tunnel → Pi. Block CF challenge JS
+        // noise that tanks Best Practices in lab runs.
+        chromeFlags:
+          "--headless=new --no-sandbox --disable-setuid-sandbox --disable-dev-shm-usage",
+        preset: "desktop",
+        throttlingMethod: "devtools",
+        onlyCategories: ["performance", "accessibility", "best-practices", "seo"],
+        skipAudits: ["uses-http2"],
+        extraHeaders: JSON.stringify({
+          "X-Forwarded-Proto": "https",
+        }),
+        blockedUrlPatterns: [
+          "*cdn-cgi/challenge-platform*",
+          "*cdn-cgi/challenge-platform/*",
+          "*challenges.cloudflare.com*",
+        ],
+      },
+    },
+    assert: {
+      assertions: {
+        "categories:performance": ["warn", { minScore: 0.65 }],
+        "categories:accessibility": ["warn", { minScore: 0.9 }],
+        "categories:best-practices": ["warn", { minScore: 0.9 }],
+        "categories:seo": ["warn", { minScore: 0.9 }],
+      },
+    },
+    upload: {
+      target: "filesystem",
+      outputDir: ".lighthouseci",
+    },
+  },
+};

--- a/package.json
+++ b/package.json
@@ -149,7 +149,8 @@
     "aw:a11y-audit": "gh aw run a11y-audit",
     "aw:lighthouse": "gh aw run lighthouse",
     "aw:cluster-doctor": "gh aw run cluster-doctor",
-    "aw:etl-espocrm": "gh aw run etl-espocrm-to-r2"
+    "aw:etl-espocrm": "gh aw run etl-espocrm-to-r2",
+    "lighthouse:audit": "bash scripts/lighthouse-local.sh"
   },
   "overrides": {
     "undici": "8.10.0",

--- a/scripts/lighthouse-local.sh
+++ b/scripts/lighthouse-local.sh
@@ -1,0 +1,137 @@
+#!/usr/bin/env bash
+# Run Lighthouse against production (or override URLs) and write JSON reports.
+# Config: lighthouserc.local.cjs
+set -euo pipefail
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$ROOT"
+
+OUT_DIR="${LIGHTHOUSE_OUT_DIR:-.lighthouseci}"
+mkdir -p "$OUT_DIR"
+
+# Warm CDN / origin before measuring
+URLS=(
+  "https://cloudless.gr/en"
+  "https://cloudless.gr/en/services"
+  "https://cloudless.gr/en/store"
+  "https://cloudless.gr/en/contact"
+)
+
+# Allow: pnpm lighthouse:audit -- https://cloudless.gr/en/blog
+if [[ $# -gt 0 ]]; then
+  URLS=("$@")
+fi
+
+echo "== Warming ${#URLS[@]} URL(s) =="
+for url in "${URLS[@]}"; do
+  curl -sS -o /dev/null -w "%{url_effective} → %{http_code} (%{time_total}s)\n" "$url" || true
+  curl -sS -o /dev/null "$url" || true
+done
+
+CHROME_FLAGS='--headless=new --no-sandbox --disable-setuid-sandbox --disable-dev-shm-usage'
+SUMMARY="$OUT_DIR/summary.json"
+echo '[]' >"$SUMMARY"
+
+run_one() {
+  local form="$1"
+  local url="$2"
+  local slug
+  slug="$(echo "$url" | sed 's#https://##; s#[^a-zA-Z0-9]#-#g')"
+  local out="$OUT_DIR/${slug}-${form}.json"
+  echo ""
+  echo "== Lighthouse ${form}: $url =="
+  # Lighthouse 13+: only `desktop` is a --preset; mobile uses --form-factor.
+  local form_args=()
+  if [[ "$form" == "desktop" ]]; then
+    form_args=(--preset=desktop)
+  else
+    form_args=(--form-factor=mobile --screenEmulation.mobile --throttling.cpuSlowdownMultiplier=4)
+  fi
+  pnpm exec lighthouse "$url" \
+    --quiet \
+    --chrome-flags="$CHROME_FLAGS" \
+    "${form_args[@]}" \
+    --throttling-method=devtools \
+    --only-categories=performance,accessibility,best-practices,seo \
+    --blocked-url-patterns='*cdn-cgi/challenge-platform*' \
+    --blocked-url-patterns='*challenges.cloudflare.com*' \
+    --extra-headers='{"X-Forwarded-Proto":"https"}' \
+    --output=json \
+    --output-path="$out"
+
+  node -e '
+    const fs = require("fs");
+    const path = process.argv[1];
+    const form = process.argv[2];
+    const summaryPath = process.argv[3];
+    const r = JSON.parse(fs.readFileSync(path, "utf8"));
+    const cats = r.categories || {};
+    const audits = r.audits || {};
+    const pick = (id) => {
+      const a = audits[id];
+      if (!a) return null;
+      return {
+        id,
+        title: a.title,
+        score: a.score,
+        displayValue: a.displayValue || null,
+        numericValue: a.numericValue ?? null,
+      };
+    };
+    const opportunities = Object.values(audits)
+      .filter((a) => a.details && a.details.type === "opportunity" && (a.score ?? 1) < 0.9)
+      .map((a) => ({
+        id: a.id,
+        title: a.title,
+        score: a.score,
+        displayValue: a.displayValue || null,
+        savingsMs: a.numericValue ?? null,
+      }))
+      .sort((a, b) => (b.savingsMs || 0) - (a.savingsMs || 0))
+      .slice(0, 8);
+    const diagnostics = ["cumulative-layout-shift","total-blocking-time","largest-contentful-paint","first-contentful-paint","speed-index","interactive","server-response-time","mainthread-work-breakdown","bootup-time","dom-size","third-party-summary","unused-javascript","unused-css-rules","render-blocking-resources","uses-responsive-images","offscreen-images"]
+      .map(pick)
+      .filter(Boolean);
+    const row = {
+      url: r.finalDisplayedUrl || r.requestedUrl,
+      formFactor: form,
+      fetchTime: r.fetchTime,
+      scores: {
+        performance: cats.performance?.score ?? null,
+        accessibility: cats.accessibility?.score ?? null,
+        bestPractices: cats["best-practices"]?.score ?? null,
+        seo: cats.seo?.score ?? null,
+      },
+      metrics: {
+        fcp: pick("first-contentful-paint"),
+        lcp: pick("largest-contentful-paint"),
+        tbt: pick("total-blocking-time"),
+        cls: pick("cumulative-layout-shift"),
+        si: pick("speed-index"),
+        tti: pick("interactive"),
+        ttfb: pick("server-response-time"),
+      },
+      opportunities,
+      diagnostics,
+    };
+    const all = JSON.parse(fs.readFileSync(summaryPath, "utf8"));
+    all.push(row);
+    fs.writeFileSync(summaryPath, JSON.stringify(all, null, 2));
+    const s = row.scores;
+    console.log(
+      `  Perf=${Math.round((s.performance||0)*100)} A11y=${Math.round((s.accessibility||0)*100)} BP=${Math.round((s.bestPractices||0)*100)} SEO=${Math.round((s.seo||0)*100)}`
+    );
+    console.log(`  LCP=${row.metrics.lcp?.displayValue} TBT=${row.metrics.tbt?.displayValue} CLS=${row.metrics.cls?.displayValue}`);
+  ' "$out" "$form" "$SUMMARY"
+}
+
+# Desktop + mobile for homepage; desktop for other routes (faster, actionable)
+for url in "${URLS[@]}"; do
+  run_one desktop "$url"
+done
+# Mobile pass on homepage (usually the constraining score)
+HOME_URL="${URLS[0]}"
+run_one mobile "$HOME_URL"
+
+echo ""
+echo "== Summary written to $SUMMARY =="
+node -e 'const s=require("./'"$OUT_DIR"'/summary.json"); console.log(JSON.stringify(s.map(r=>({url:r.url,form:r.formFactor,scores:Object.fromEntries(Object.entries(r.scores).map(([k,v])=>[k, Math.round((v||0)*100)]))})),null,2))'


### PR DESCRIPTION
## Summary
- Retarget `lighthouse.yml` `workflow_run` to **Deploy to Pi (R2 + Cloudflare Workflows pull)**; keep daily cron + `workflow_dispatch`.
- Add edge smoke on `deploy-pi` publish (health SHA + `/en`, `/en/store`, `/en/contact`) and append to issue #382.
- Document capacity matrix, omv timers checklist, Legion WSL runbook, and lab vs CI Lighthouse (`pnpm lighthouse:audit`).
- Add `RUNNER_X64` + toggle/`runner-mode` (`x64-legion` / `x64-hosted`); opt in `lighthouse.yml`, `e2e-full-coverage.yml`, `a11y-audit.yml`. Default remains `ubuntu-latest` — never route browser suites to omv via `RUNNER_GENERIC`.

## Test plan
- [ ] `gh workflow run lighthouse.yml` — job queues on `ubuntu-latest`
- [ ] Optional: `gh workflow run deploy-pi.yml -f trigger_only=true` if R2 artifact for HEAD exists (smoke + #382 comment)
- [ ] `.github/scripts/toggle-runner.sh status` shows `RUNNER_GENERIC` + `RUNNER_X64`
- [ ] Confirm no Jenkins / no Playwright on `[self-hosted, omv, *]` happy path


Made with [Cursor](https://cursor.com)