### PR TITLE
fix(ci): Daily Analytics Rollup Google email secret

### DIFF
--- a/.github/workflows/cron-free-tier.yml
+++ b/.github/workflows/cron-free-tier.yml
@@ -36,7 +36,8 @@ jobs:
     - name: Run GSC sync to AppFlowy
       env:
         FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
-        GOOGLE_CLIENT_EMAIL: ${{ secrets.GOOGLE_SERVICE_ACCOUNT_EMAIL }}
+        # Canonical GH secret is GOOGLE_CLIENT_EMAIL (not GOOGLE_SERVICE_ACCOUNT_EMAIL).
+        GOOGLE_CLIENT_EMAIL: ${{ secrets.GOOGLE_CLIENT_EMAIL }}
         GOOGLE_PRIVATE_KEY: ${{ secrets.GOOGLE_PRIVATE_KEY }}
         GSC_SITE_URL: ${{ secrets.GSC_SITE_URL }}
         APPFLOWY_API_URL: https://appflowy.cloudless.gr
@@ -100,7 +101,7 @@ jobs:
     - name: Run full analytics sync to AppFlowy
       env:
         FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
-        GOOGLE_CLIENT_EMAIL: ${{ secrets.GOOGLE_SERVICE_ACCOUNT_EMAIL }}
+        GOOGLE_CLIENT_EMAIL: ${{ secrets.GOOGLE_CLIENT_EMAIL }}
         GOOGLE_PRIVATE_KEY: ${{ secrets.GOOGLE_PRIVATE_KEY }}
         GSC_SITE_URL: ${{ secrets.GSC_SITE_URL }}
         APPFLOWY_API_URL: https://appflowy.cloudless.gr


### PR DESCRIPTION
## Summary
- `cron-free-tier.yml` was setting `GOOGLE_CLIENT_EMAIL` from `secrets.GOOGLE_SERVICE_ACCOUNT_EMAIL`, which is **not** defined in the repo.
- The real secret is `GOOGLE_CLIENT_EMAIL` (also used by `sync-gsc-sentry-pi-secrets.yml`). That empty mapping caused `[weekly-gsc-sync-af] missing env var: GOOGLE_SERVICE_ACCOUNT_EMAIL or GOOGLE_CLIENT_EMAIL` on every daily run (#273 and prior).

## Test plan
- [ ] `gh workflow run cron-free-tier.yml` after merge
- [ ] Confirm analytics-rollup job gets past Google token acquisition
- [ ] Confirm AppFlowy write succeeds (or surfaces a different, real error)


Made with [Cursor](https://cursor.com)