### PR TITLE
fix(etl): AppFlowy R2 kubeconfig for Pi runner

### DIFF
--- a/.github/workflows/etl-appflowy-to-r2.yml
+++ b/.github/workflows/etl-appflowy-to-r2.yml
@@ -36,6 +36,12 @@ jobs:
         corepack prepare pnpm@latest --activate || true
         pnpm install --frozen-lockfile --prod
 
+    - name: Configure kubectl
+      run: |
+        mkdir -p ~/.kube
+        echo "${{ secrets.KUBECONFIG_B64 }}" | base64 -d > ~/.kube/config
+        chmod 600 ~/.kube/config
+
     - name: Run AppFlowy-to-R2 sync
       working-directory: scripts/etl
       env:


### PR DESCRIPTION
## Summary
- AppFlowy → R2 ETL failed with permission denied on `/etc/rancher/k3s/k3s.yaml`
- Write `KUBECONFIG_B64` to `~/.kube/config` before `kubectl` (same pattern as `pi-appflowy-probe`)

## Test plan
- [ ] `workflow_dispatch` `etl-appflowy-to-r2` succeeds on omv-build


Made with [Cursor](https://cursor.com)