### PR TITLE
feat(admin): gold snapshot serving for datalake dashboard

### DIFF
--- a/__tests__/datalake-r2.test.ts
+++ b/__tests__/datalake-r2.test.ts
@@ -12,7 +12,7 @@ function makeDb(rows: Array<Record<string, unknown>>): AuthDatabase {
           return { success: true, meta: { changes: 0 } };
         },
         async all<T = Record<string, unknown>>() {
-          if (query.includes("utm_source")) {
+          if (query.includes("utm_source") || query.includes("source,")) {
             return {
               results: [
                 {
@@ -39,7 +39,75 @@ function makeDb(rows: Array<Record<string, unknown>>): AuthDatabase {
   };
 }
 
-describe("getDatalakeDashboard Cloudflare-only", () => {
+function goldSnapshotPayload() {
+  return {
+    generated_at: "2026-07-29T10:00:00.000Z",
+    cache: "cloudflare",
+    sections: [
+      {
+        section: "top_keywords",
+        rows: [{ query: "cloud greece", clicks: 12 }],
+        rowCount: 1,
+      },
+      {
+        section: "linkedin_ads",
+        rows: [{ campaign_name: "x", spend: 1 }],
+        rowCount: 1,
+      },
+      {
+        section: "top_errors",
+        rows: [{ title: "boom", count_14d: 3 }],
+        rowCount: 1,
+      },
+      {
+        section: "espocrm_funnel",
+        rows: [{ lead_source: "web", contact_count: 4 }],
+        rowCount: 1,
+      },
+      {
+        section: "stripe_revenue",
+        rows: [{ metric: "paid_orders", value: 2, amount_eur: 98 }],
+        rowCount: 1,
+      },
+      {
+        section: "n8n_ops",
+        rows: [{ metric: "workflows_total", value: 5 }],
+        rowCount: 1,
+      },
+      {
+        section: "postiz_ops",
+        rows: [{ metric: "posts_sampled", value: 3 }],
+        rowCount: 1,
+      },
+      {
+        section: "appflowy_activity",
+        rows: [{ metric: "workspaces", value: 2 }],
+        rowCount: 1,
+      },
+      {
+        section: "freshness",
+        rows: [{ source: "lake/gsc-keywords/keywords.parquet", exists: 1 }],
+        rowCount: 1,
+      },
+      {
+        section: "acquisition_funnel",
+        error: "stale snapshot stub — hot D1 should override",
+      },
+    ],
+    freshness: {
+      generated_at: "2026-07-29T10:00:00.000Z",
+      sources: {
+        "lake/gsc-keywords/keywords.parquet": {
+          exists: true,
+          last_etl_at: "2026-07-29T09:00:00.000Z",
+          size: 100,
+        },
+      },
+    },
+  };
+}
+
+describe("getDatalakeDashboard gold serving", () => {
   beforeEach(() => {
     vi.resetModules();
     delete (globalThis as { __AUTH_DB__?: unknown }).__AUTH_DB__;
@@ -51,66 +119,89 @@ describe("getDatalakeDashboard Cloudflare-only", () => {
     delete (globalThis as { __DATALAKE_BUCKET__?: unknown }).__DATALAKE_BUCKET__;
   });
 
-  it("merges D1 acquisition/attribution with R2 snapshot sections", async () => {
+  it("loads full gold sections and overlays hot D1 funnel", async () => {
     (globalThis as { __AUTH_DB__?: AuthDatabase }).__AUTH_DB__ = makeDb([
       { day: "2026-07-28", sessions: 5, signups: 1, purchasers: 0, revenue: 0 },
     ]);
-    (globalThis as {
-      __DATALAKE_BUCKET__?: { get: (key: string) => Promise<unknown> };
-    }).__DATALAKE_BUCKET__ = {
+    (
+      globalThis as {
+        __DATALAKE_BUCKET__?: { get: (key: string) => Promise<unknown> };
+      }
+    ).__DATALAKE_BUCKET__ = {
       get: async () => ({
-        text: async () =>
-          JSON.stringify({
-            generated_at: "2026-07-29T10:00:00.000Z",
-            cache: "cloudflare",
-            sections: [
-              {
-                section: "top_keywords",
-                rows: [{ query: "cloud greece", clicks: 12 }],
-                rowCount: 1,
-              },
-              {
-                section: "linkedin_ads",
-                rows: [{ campaign: "x", spend: 1 }],
-                rowCount: 1,
-              },
-              {
-                section: "top_errors",
-                rows: [{ title: "boom", count_14d: 3 }],
-                rowCount: 1,
-              },
-              {
-                section: "espocrm_funnel",
-                rows: [{ lead_source: "web", contact_count: 4 }],
-                rowCount: 1,
-              },
-              {
-                section: "acquisition_funnel",
-                error: "stale snapshot stub — should be ignored",
-              },
-            ],
-          }),
+        text: async () => JSON.stringify(goldSnapshotPayload()),
+      }),
+    };
+
+    const { getDatalakeDashboard, SECTION_ORDER } = await import("@/lib/datalake-r2");
+    const payload = await getDatalakeDashboard({});
+    expect(payload.cache).toBe("cloudflare");
+    expect(payload.source).toBe("gold");
+    expect(payload.freshness?.sources?.["lake/gsc-keywords/keywords.parquet"]?.exists).toBe(true);
+    expect(payload.sections.map((s) => s.section)).toEqual([...SECTION_ORDER]);
+
+    expect(payload.sections.find((s) => s.section === "top_keywords")?.rows?.[0]?.query).toBe(
+      "cloud greece"
+    );
+    expect(payload.sections.find((s) => s.section === "stripe_revenue")?.rows?.[0]?.metric).toBe(
+      "paid_orders"
+    );
+    expect(payload.sections.find((s) => s.section === "n8n_ops")?.rows?.[0]?.value).toBe(5);
+    expect(payload.sections.find((s) => s.section === "postiz_ops")?.rows?.[0]?.value).toBe(3);
+    expect(payload.sections.find((s) => s.section === "appflowy_activity")?.rows?.[0]?.value).toBe(
+      2
+    );
+    expect(payload.sections.find((s) => s.section === "freshness")?.rows?.[0]?.exists).toBe(1);
+
+    const acquisition = payload.sections.find((s) => s.section === "acquisition_funnel");
+    expect(acquisition?.rows?.[0]?.sessions).toBe(5);
+    expect(acquisition?.error).toBeUndefined();
+    const attribution = payload.sections.find((s) => s.section === "attribution");
+    expect(attribution?.rows?.[0]?.utm_source).toBe("linkedin");
+  });
+
+  it("refresh still reads gold (does not skip snapshot)", async () => {
+    (
+      globalThis as {
+        __DATALAKE_BUCKET__?: { get: (key: string) => Promise<unknown> };
+      }
+    ).__DATALAKE_BUCKET__ = {
+      get: async () => ({
+        text: async () => JSON.stringify(goldSnapshotPayload()),
       }),
     };
 
     const { getDatalakeDashboard } = await import("@/lib/datalake-r2");
-    const payload = await getDatalakeDashboard({});
-    expect(payload.cache).toBe("cloudflare");
-    const keywords = payload.sections.find((s) => s.section === "top_keywords");
-    expect(keywords?.rows?.[0]?.query).toBe("cloud greece");
-    const acquisition = payload.sections.find((s) => s.section === "acquisition_funnel");
-    expect(acquisition?.rows?.[0]?.sessions).toBe(5);
-    const attribution = payload.sections.find((s) => s.section === "attribution");
-    expect(attribution?.rows?.[0]?.utm_source).toBe("linkedin");
+    const payload = await getDatalakeDashboard({ refresh: true });
+    expect(payload.source).toBe("gold");
+    expect(payload.sections.find((s) => s.section === "top_keywords")?.rows?.[0]?.query).toBe(
+      "cloud greece"
+    );
   });
 
   it("returns section errors when D1 and R2 are unbound", async () => {
     const { getDatalakeDashboard } = await import("@/lib/datalake-r2");
     const payload = await getDatalakeDashboard({});
+    expect(payload.source).toBe("empty");
     expect(payload.cache).toBe("cloudflare");
     for (const section of payload.sections) {
-      expect(section.error).toContain("not available");
+      expect(section.error).toBeTruthy();
       expect(section.rows).toBeUndefined();
     }
+  });
+
+  it("hot_only when D1 bound but gold missing", async () => {
+    (globalThis as { __AUTH_DB__?: AuthDatabase }).__AUTH_DB__ = makeDb([
+      { day: "2026-07-28", sessions: 2, signups: 0, purchasers: 0, revenue: 0 },
+    ]);
+    const { getDatalakeDashboard } = await import("@/lib/datalake-r2");
+    const payload = await getDatalakeDashboard({});
+    expect(payload.source).toBe("hot_only");
+    expect(
+      payload.sections.find((s) => s.section === "acquisition_funnel")?.rows?.[0]?.sessions
+    ).toBe(2);
+    expect(payload.sections.find((s) => s.section === "stripe_revenue")?.error).toContain(
+      "gold ETL snapshot missing"
+    );
   });
 });

--- a/docs/data/datalake.md
+++ b/docs/data/datalake.md
@@ -1,14 +1,51 @@
-# Datalake — cloudless.gr (Cloudflare)
+# Datalake — cloudless.gr (Cloudflare lakehouse)
 
 R2 + D1 replace the former S3 + Glue + Athena stack. Admin analytics never
-query Athena.
+query Athena or live vendor APIs on page load.
 
-## Topology
+## Architecture (serving layer)
 
 ```
-Source APIs / cluster pods
-   │  GitHub Actions ETL (scripts/etl/*-to-r2.mjs) on Pi runners
+Sources (Stripe, GSC, Sentry, EspoCRM, Postiz, n8n, AppFlowy, …)
+   │  GitHub Actions ETL  scripts/etl/*-to-r2.mjs   ← silver (parquet)
    ▼
+R2 datalake-bucket
+   ├── lake/**/*.parquet
+   └── lake/snapshots/
+         ├── admin-datalake.json   ← gold (materialize-datalake-snapshots)
+         ├── gsc-weekly.json
+         └── freshness.json
+                       │
+                       ▼
+         /api/admin/analytics/datalake  (src/lib/datalake-r2.ts)
+                       │  gold first + D1 hot overlay (acquisition/attribution)
+                       ▼
+         /admin/analytics/datalake
+```
+
+| Layer   | Role                          | Cloudless                                       |
+| ------- | ----------------------------- | ----------------------------------------------- |
+| Silver  | Curated parquet per source    | `scripts/etl/*-to-r2.mjs` → R2                  |
+| Gold    | Dashboard-ready aggregates    | `materialize-datalake-snapshots.mjs` → JSON     |
+| Hot     | Near-real-time product events | D1 `analytics_events` (funnel/attribution only) |
+| Serving | Admin API                     | `getDatalakeDashboard()` — **no live upstream** |
+
+Admin UI must render gold + hot only. Missing sections show ETL/materialize
+errors — never call Stripe/GSC/Sentry/Espo/Postiz/n8n from the browser or
+admin route handlers for these cards.
+
+### Gold sections (materialize → admin)
+
+`acquisition_funnel`, `attribution` (hot D1 overlay), `top_keywords`,
+`linkedin_ads`, `top_errors`, `espocrm_funnel`, `stripe_revenue`, `n8n_ops`,
+`postiz_ops`, `appflowy_activity`, `freshness`.
+
+Payload includes `source: "gold" | "hot_only" | "empty"` and optional
+`freshness` from the snapshot.
+
+## Topology (storage)
+
+```
 R2 datalake-bucket
    ├── lake/transactions/          stripe-to-r2
    ├── lake/clients/               clients-to-r2
@@ -21,38 +58,27 @@ R2 datalake-bucket
    ├── lake/postiz-*/              postiz-to-r2
    ├── lake/n8n-*/                 n8n-to-r2
    ├── ml-parquet/                 compute-rfm-churn-to-r2
-   └── lake/snapshots/
-         ├── admin-datalake.json   materialize-datalake-snapshots
-         ├── gsc-weekly.json
-         └── freshness.json
-                       │
-                       ▼
-              Admin UI (/admin/analytics/datalake)
-              ← also D1 analytics_events (acquisition + attribution)
+   └── lake/snapshots/             materialize (gold)
 ```
 
-| Component | Detail |
-|---|---|
-| Object store | Cloudflare R2 `datalake-bucket` |
-| Hot events / cost rows | D1 `user-auth-db` (`analytics_events`, `aws_cost_daily`) |
-| Schedulers | `.github/workflows/etl-*-to-r2.yml` on `[self-hosted, omv, build]` |
-| Dashboard API | `src/lib/datalake-r2.ts` → `/api/admin/analytics/datalake` |
+| Component              | Detail                                                             |
+| ---------------------- | ------------------------------------------------------------------ |
+| Object store           | Cloudflare R2 `datalake-bucket`                                    |
+| Hot events / cost rows | D1 `user-auth-db` (`analytics_events`, `aws_cost_daily`)           |
+| Schedulers             | `.github/workflows/etl-*-to-r2.yml` on `[self-hosted, omv, build]` |
+| Dashboard API          | `src/lib/datalake-r2.ts` → `/api/admin/analytics/datalake`         |
 
-## Wiring (app → lake)
+## Optional next (Cloudflare Data Platform)
 
-| Library | What it writes / reads | Store |
-|---|---|---|
-| `src/lib/analytics.ts` | Product events | D1 `analytics_events` (and optional R2 NDJSON) |
-| `src/lib/datalake-r2.ts` | Admin dashboard sections | R2 snapshot + D1 |
-| `src/lib/cost-analytics.ts` | Frozen AWS cost panels | D1 / R2 `lake/aws-cost/` |
+For ad-hoc SQL over silver parquet without Athena:
 
-## ETL scripts
+- Enable [R2 Data Catalog](https://developers.cloudflare.com/r2-data-catalog/) on `datalake-bucket`
+- Query with [R2 SQL](https://developers.cloudflare.com/r2-sql/)
 
-Live scripts are `scripts/etl/*-to-r2.mjs` plus `materialize-datalake-snapshots.mjs`.
-Deprecated `*-to-lake.mjs` Athena/S3 feeders are removed.
+Admin dashboards should stay on **gold snapshots** for latency and cost;
+R2 SQL is for explore/operator queries, not every page load.
 
 ## Historical (Athena)
 
-Athena SQL under `docs/data/analytics-athena.sql`, `docs/data/datalake-views.sql`,
-and `infrastructure/athena/` is **historical only**. Do not create new Glue
-tables or Athena views for this product path.
+Athena SQL under `docs/data/analytics-athena.sql` and `infrastructure/athena/`
+is **historical only**. Do not create new Glue tables for this path.

--- a/src/app/[locale]/admin/analytics/datalake/page.tsx
+++ b/src/app/[locale]/admin/analytics/datalake/page.tsx
@@ -1,18 +1,9 @@
 /**
  * Admin → Analytics → Datalake
  *
- * Cloudflare-only dashboard (D1 analytics_events + R2 snapshot from
- * materialize-datalake-snapshots). Sections:
- *
- *   - 30-day acquisition funnel (sessions → signups → purchasers → revenue)
- *   - UTM attribution by source/medium/campaign (90d)
- *   - GSC top keywords (90d rolling window)
- *   - LinkedIn ads campaign rollup (90d)
- *   - Sentry top unresolved issues (14d)
- *   - EspoCRM lifecycle funnel
- *
- * Fetches from /api/admin/analytics/datalake. Each card renders independently —
- * a section with an error (e.g. ETL hasn't run yet) shows inline.
+ * Snapshot-first gold serving: R2 `admin-datalake.json` from
+ * materialize-datalake-snapshots, plus D1 hot overlay for acquisition /
+ * attribution. Never calls live Stripe / GSC / Sentry / Espo / Postiz / n8n.
  */
 "use client";
 
@@ -31,8 +22,16 @@ interface SectionResult {
 
 interface DatalakeResponse {
   generated_at: string;
-  cache: "respected" | "skipped";
+  cache: string;
+  source?: "gold" | "hot_only" | "empty";
   sections: SectionResult[];
+  freshness?: {
+    generated_at?: string;
+    sources?: Record<
+      string,
+      { exists?: boolean; last_etl_at?: string | null; size?: number | null }
+    >;
+  };
 }
 
 const SECTION_META: Record<
@@ -45,7 +44,7 @@ const SECTION_META: Record<
 > = {
   acquisition_funnel: {
     title: "Acquisition funnel — last 30 days",
-    subtitle: "Sessions → signups → purchasers → revenue. Sourced from D1 analytics_events.",
+    subtitle: "Hot path: D1 analytics_events (live product events).",
     columns: [
       { key: "day", label: "Day" },
       { key: "sessions", label: "Sessions", format: "int" },
@@ -56,7 +55,7 @@ const SECTION_META: Record<
   },
   attribution: {
     title: "Attribution by UTM source/medium",
-    subtitle: "90-day window. Sourced from D1 analytics_events.",
+    subtitle: "Hot path: D1 analytics_events (90-day window).",
     columns: [
       { key: "utm_source", label: "Source" },
       { key: "utm_medium", label: "Medium" },
@@ -68,7 +67,7 @@ const SECTION_META: Record<
   },
   top_keywords: {
     title: "GSC top keywords",
-    subtitle: "Top 25 by clicks over the rolling 90-day GSC window. Sourced from R2 GSC parquet.",
+    subtitle: "Gold: R2 snapshot from gsc-to-r2 parquet.",
     columns: [
       { key: "query", label: "Query" },
       { key: "clicks", label: "Clicks", format: "int" },
@@ -79,7 +78,7 @@ const SECTION_META: Record<
   },
   linkedin_ads: {
     title: "LinkedIn ads — per-campaign 90d",
-    subtitle: "Sourced from R2 LinkedIn Ads parquet.",
+    subtitle: "Gold: R2 snapshot from linkedin-ads-to-r2 parquet.",
     columns: [
       { key: "campaign_name", label: "Campaign" },
       { key: "impressions", label: "Impressions", format: "int" },
@@ -93,7 +92,7 @@ const SECTION_META: Record<
   },
   top_errors: {
     title: "Top Sentry errors (14-day count)",
-    subtitle: "Top 10 unresolved by event count. Sourced from R2 Sentry parquet.",
+    subtitle: "Gold: R2 snapshot from sentry-to-r2 parquet.",
     columns: [
       { key: "short_id", label: "ID" },
       { key: "title", label: "Title" },
@@ -105,8 +104,7 @@ const SECTION_META: Record<
   },
   espocrm_funnel: {
     title: "EspoCRM lifecycle funnel",
-    subtitle:
-      "Contact count × closed-won deals + revenue, split by lead_source. Sourced from R2 EspoCRM parquet.",
+    subtitle: "Gold: R2 snapshot from espocrm-to-r2 parquet.",
     columns: [
       { key: "lifecycle_stage", label: "Stage" },
       { key: "lead_source", label: "Source" },
@@ -115,17 +113,67 @@ const SECTION_META: Record<
       { key: "closed_won_revenue", label: "Revenue", format: "money" },
     ],
   },
+  stripe_revenue: {
+    title: "Stripe revenue (gold)",
+    subtitle: "Gold: R2 snapshot from stripe-to-r2 transactions parquet.",
+    columns: [
+      { key: "metric", label: "Metric" },
+      { key: "value", label: "Count", format: "int" },
+      { key: "amount_eur", label: "Amount €", format: "money" },
+    ],
+  },
+  n8n_ops: {
+    title: "n8n operations",
+    subtitle: "Gold: R2 snapshot from n8n-to-r2 parquet.",
+    columns: [
+      { key: "metric", label: "Metric" },
+      { key: "value", label: "Value", format: "decimal" },
+    ],
+  },
+  postiz_ops: {
+    title: "Postiz operations",
+    subtitle: "Gold: R2 snapshot from postiz-to-r2 parquet.",
+    columns: [
+      { key: "metric", label: "Metric" },
+      { key: "value", label: "Value", format: "int" },
+    ],
+  },
+  appflowy_activity: {
+    title: "AppFlowy activity",
+    subtitle: "Gold: R2 snapshot from appflowy-to-r2 parquet.",
+    columns: [
+      { key: "metric", label: "Metric" },
+      { key: "value", label: "Value", format: "int" },
+    ],
+  },
+  freshness: {
+    title: "ETL freshness",
+    subtitle: "Gold: last_etl_at / size per silver parquet key (from materialize).",
+    columns: [
+      { key: "source", label: "Source key" },
+      { key: "exists", label: "Exists", format: "int" },
+      { key: "last_etl_at", label: "Last ETL" },
+      { key: "size", label: "Bytes", format: "int" },
+    ],
+  },
 };
 
 function fmt(v: string | number | null, format?: "int" | "money" | "pct" | "decimal"): string {
   if (v === null || v === undefined || v === "") return "—";
   const n = typeof v === "number" ? v : Number(v);
+  if (!Number.isFinite(n) && typeof v === "string") return v;
   if (!Number.isFinite(n)) return String(v);
   if (format === "int") return Math.round(n).toLocaleString();
   if (format === "money") return `€${n.toLocaleString(undefined, { maximumFractionDigits: 2 })}`;
   if (format === "pct") return `${(n * 100).toFixed(2)}%`;
-  if (format === "decimal") return n.toFixed(1);
+  if (format === "decimal") return n.toFixed(3);
   return String(v);
+}
+
+function sourceBadge(source: DatalakeResponse["source"]): string {
+  if (source === "gold") return "GOLD SNAPSHOT";
+  if (source === "hot_only") return "HOT D1 ONLY";
+  return "EMPTY";
 }
 
 export default function DatalakeDashboardPage() {
@@ -153,10 +201,6 @@ export default function DatalakeDashboardPage() {
     }
   }, []);
 
-  // Defer the initial fetch one tick past mount so setState fires from a
-  // queued task, not synchronously inside the effect body. This pattern is
-  // the React 19 `react-hooks/set-state-in-effect` rule's recommended escape
-  // hatch for mount-triggered fetches that aren't framework-data-hook-able.
   useEffect(() => {
     const t = setTimeout(() => {
       void load();
@@ -168,11 +212,6 @@ export default function DatalakeDashboardPage() {
     ? new Date(data.generated_at).toLocaleString(undefined, { timeZone: "Europe/Athens" })
     : "—";
 
-  // All chrome below uses design-system v2 CSS variables
-  // (--surface-raised, --border-subtle, --ink-primary, --ink-muted, --accent,
-  // --danger, --warning, --shadow-sm) defined in src/app/theme-v2.css. /admin
-  // always renders with data-theme="dark" via ThemeProvider; the same tokens
-  // flip cleanly when /admin ever moves to a light variant.
   return (
     <div
       className="space-y-6"
@@ -180,7 +219,6 @@ export default function DatalakeDashboardPage() {
         color: "var(--ink-primary)",
       }}
     >
-      {/* Header */}
       <header
         className="flex flex-wrap items-end justify-between gap-3 pb-4"
         style={{ borderBottom: "1px solid var(--border-subtle)" }}
@@ -188,19 +226,20 @@ export default function DatalakeDashboardPage() {
         <div>
           <h1 className="text-2xl font-semibold tracking-tight">Datalake dashboard</h1>
           <p className="text-sm" style={{ color: "var(--ink-muted)" }}>
-            D1 + R2 datalake snapshot. Generated at {generatedAt}.
-            {data?.cache === "respected" && (
+            Gold serving from R2 snapshot (+ D1 hot funnel). Generated at {generatedAt}.
+            {data?.source && (
               <span
-                className="ml-2 rounded-full px-2 py-0.5 text-xs"
+                className="ml-2 rounded-full px-2 py-0.5 font-mono text-xs"
                 style={{ background: "var(--surface-subtle)" }}
               >
-                cached (60s)
+                {sourceBadge(data.source)}
               </span>
             )}
           </p>
         </div>
         <div className="flex gap-2">
           <button
+            type="button"
             onClick={() => load(false)}
             disabled={loading}
             className="rounded-md px-3 py-1.5 text-sm disabled:opacity-50"
@@ -213,6 +252,7 @@ export default function DatalakeDashboardPage() {
             Reload
           </button>
           <button
+            type="button"
             onClick={() => load(true)}
             disabled={loading}
             className="rounded-md px-3 py-1.5 text-sm disabled:opacity-50"
@@ -221,7 +261,7 @@ export default function DatalakeDashboardPage() {
               color: "var(--accent-on)",
             }}
           >
-            Force refresh (skip cache)
+            Re-read gold snapshot
           </button>
         </div>
       </header>
@@ -241,11 +281,10 @@ export default function DatalakeDashboardPage() {
 
       {loading && !data && (
         <div className="text-sm" style={{ color: "var(--ink-muted)" }}>
-          Loading datalake snapshot…
+          Loading gold datalake snapshot…
         </div>
       )}
 
-      {/* Sections */}
       {data?.sections.map((s) => {
         const meta = SECTION_META[s.section] ?? {
           title: s.section,
@@ -273,13 +312,13 @@ export default function DatalakeDashboardPage() {
                 </p>
               </div>
               <div className="text-xs" style={{ color: "var(--ink-muted)" }}>
-                {s.error ? "error" : `${s.rowCount ?? 0} rows`}
+                {s.error ? "error" : `${s.rowCount ?? s.rows?.length ?? 0} rows`}
                 {s.fromCache && !s.error && (
                   <span
                     className="ml-2 rounded px-1.5 py-0.5"
                     style={{ background: "var(--surface-subtle)" }}
                   >
-                    cached
+                    gold
                   </span>
                 )}
               </div>
@@ -293,8 +332,8 @@ export default function DatalakeDashboardPage() {
                     color: "var(--warning)",
                   }}
                 >
-                  <strong>Section unavailable.</strong> Usually the source ETL has not written
-                  parquet yet, or the materialize snapshot is stale. Detail:{" "}
+                  <strong>Section unavailable.</strong> Run the source ETL then{" "}
+                  <code>etl-materialize-snapshots</code>. Detail:{" "}
                   <code className="break-all">{s.error}</code>
                 </div>
               ) : s.rows && s.rows.length > 0 ? (

--- a/src/app/api/admin/analytics/datalake/route.ts
+++ b/src/app/api/admin/analytics/datalake/route.ts
@@ -1,12 +1,12 @@
 /**
  * GET /api/admin/analytics/datalake
  *
- * Cloudflare-only dashboard payload for /admin/analytics/datalake:
- *   - D1 analytics_events for acquisition / attribution when AUTH_DB bound
- *   - R2 lake/snapshots/admin-datalake.json for GSC / Sentry / LinkedIn / EspoCRM
+ * Gold serving layer for /admin/analytics/datalake:
+ *   - R2 lake/snapshots/admin-datalake.json (ETL materialize — all lake sections)
+ *   - D1 analytics_events overlay for acquisition / attribution (hot path)
  *
  * Query params:
- *   ?refresh=1  — skip R2 snapshot cache (D1 sections still served live)
+ *   ?refresh=1  — re-read gold snapshot from R2 (no live upstream calls)
  */
 
 import { NextRequest, NextResponse } from "next/server";

--- a/src/lib/datalake-r2.ts
+++ b/src/lib/datalake-r2.ts
@@ -1,11 +1,15 @@
 /**
- * Admin datalake dashboard reads — Cloudflare only (D1 + R2).
+ * Admin datalake serving layer — gold snapshot first (Cloudflare R2 + D1).
  *
- * Acquisition/attribution: live D1 `analytics_events` when AUTH_DB is bound.
- * GSC / Sentry / LinkedIn / EspoCRM: R2 snapshot
- * `lake/snapshots/admin-datalake.json` (ETL: materialize-datalake-snapshots.mjs).
+ * Architecture (lakehouse serving):
+ *   ETL → R2 parquet (silver) → materialize-datalake-snapshots (gold JSON)
+ *   Admin UI → this module → never live Stripe/GSC/Sentry/Espo/Postiz/n8n
  *
- * Missing sections return an error — no Athena fallback.
+ * Gold source of truth: R2 `lake/snapshots/admin-datalake.json`
+ * Hot overlay only: D1 `analytics_events` for acquisition_funnel + attribution
+ * (product events are written live; no silver ETL for them yet).
+ *
+ * Missing sections return an error — no Athena / live-upstream fallback.
  */
 
 import { getAuthDbFromEnv, type AuthDatabase } from "@/lib/auth-d1";
@@ -19,27 +23,51 @@ export interface DatalakeSectionResult {
   error?: string;
 }
 
+export interface DatalakeFreshnessMeta {
+  generated_at?: string;
+  sources?: Record<
+    string,
+    {
+      exists?: boolean;
+      last_etl_at?: string | null;
+      size?: number | null;
+    }
+  >;
+}
+
 export interface DatalakeDashboardPayload {
   generated_at: string;
   cache: string;
+  /** "gold" = R2 snapshot present; "hot_only" = D1 overlay without gold */
+  source: "gold" | "hot_only" | "empty";
   sections: DatalakeSectionResult[];
+  freshness?: DatalakeFreshnessMeta;
 }
 
 const SNAPSHOT_KEY = "lake/snapshots/admin-datalake.json";
 
-const SECTION_ORDER = [
+/** Full gold section order — matches materialize-datalake-snapshots.mjs + D1 hot. */
+export const SECTION_ORDER = [
   "acquisition_funnel",
   "attribution",
   "top_keywords",
   "linkedin_ads",
   "top_errors",
   "espocrm_funnel",
+  "stripe_revenue",
+  "n8n_ops",
+  "postiz_ops",
+  "appflowy_activity",
+  "freshness",
 ] as const;
 
-/** Sections served from D1 — excluded when merging R2 snapshot rows. */
-const D1_SECTIONS = new Set<string>(["acquisition_funnel", "attribution"]);
+export type DatalakeSectionName = (typeof SECTION_ORDER)[number];
 
-const MISSING_ERROR = "not available (D1/R2 unbound or ETL snapshot missing)";
+/** Hot-path sections overlaid from D1 when AUTH_DB is bound. */
+const HOT_D1_SECTIONS = new Set<string>(["acquisition_funnel", "attribution"]);
+
+const MISSING_ERROR =
+  "not available (gold ETL snapshot missing — run materialize-datalake-snapshots)";
 
 function daysAgoUnix(days: number): number {
   return Math.floor(Date.now() / 1000) - days * 24 * 60 * 60;
@@ -103,27 +131,36 @@ async function attributionFromD1(db: AuthDatabase): Promise<DatalakeSectionResul
   };
 }
 
-export async function loadDatalakeSnapshotFromR2(): Promise<DatalakeDashboardPayload | null> {
+interface RawGoldSnapshot {
+  generated_at?: string;
+  cache?: string;
+  sections?: DatalakeSectionResult[];
+  freshness?: DatalakeFreshnessMeta;
+}
+
+export async function loadDatalakeSnapshotFromR2(): Promise<{
+  generated_at: string;
+  sections: DatalakeSectionResult[];
+  freshness?: DatalakeFreshnessMeta;
+} | null> {
   const bucket = getDataLakeBucketFromEnv();
   if (!bucket) return null;
   const object = await bucket.get(SNAPSHOT_KEY);
   if (!object) return null;
-  const parsed = JSON.parse(await object.text()) as DatalakeDashboardPayload;
+  const parsed = JSON.parse(await object.text()) as RawGoldSnapshot;
   if (!parsed?.sections || !Array.isArray(parsed.sections)) return null;
   return {
     generated_at: parsed.generated_at || new Date().toISOString(),
-    cache: "cloudflare",
-    sections: parsed.sections.filter((s) => !D1_SECTIONS.has(s.section)),
+    sections: parsed.sections.map((s) => ({
+      ...s,
+      fromCache: true,
+    })),
+    freshness: parsed.freshness,
   };
 }
 
 function sectionUsable(section: DatalakeSectionResult | undefined): boolean {
-  return Boolean(
-    section &&
-    !section.error &&
-    Array.isArray(section.rows) &&
-    (section.rowCount ?? section.rows.length) >= 0
-  );
+  return Boolean(section && !section.error && Array.isArray(section.rows));
 }
 
 function d1SectionError(section: string, error: unknown): DatalakeSectionResult {
@@ -133,49 +170,75 @@ function d1SectionError(section: string, error: unknown): DatalakeSectionResult 
   };
 }
 
+/**
+ * Snapshot-first dashboard payload for /admin/analytics/datalake.
+ *
+ * @param options.refresh — re-read gold from R2 (no skip); kept for API compat
+ */
 export async function getDatalakeDashboard(options: {
   refresh?: boolean;
 }): Promise<DatalakeDashboardPayload> {
-  const refresh = options.refresh === true;
-  const collected: DatalakeSectionResult[] = [];
+  void options.refresh;
 
+  const byName = new Map<string, DatalakeSectionResult>();
+  let goldGeneratedAt: string | null = null;
+  let freshness: DatalakeFreshnessMeta | undefined;
+  let hasGold = false;
+
+  // 1) Gold snapshot first (all ETL-backed sections)
+  try {
+    const snap = await loadDatalakeSnapshotFromR2();
+    if (snap) {
+      hasGold = true;
+      goldGeneratedAt = snap.generated_at;
+      freshness = snap.freshness;
+      for (const section of snap.sections) {
+        byName.set(section.section, section);
+      }
+    }
+  } catch (error) {
+    console.warn(
+      "[datalake-r2] gold snapshot read failed:",
+      error instanceof Error ? error.message : error
+    );
+  }
+
+  // 2) Hot D1 overlay for acquisition / attribution (near-real-time product events)
   const db = getAuthDbFromEnv();
   if (db) {
     try {
-      collected.push(await acquisitionFromD1(db));
+      byName.set("acquisition_funnel", await acquisitionFromD1(db));
     } catch (error) {
-      collected.push(d1SectionError("acquisition_funnel", error));
+      if (!sectionUsable(byName.get("acquisition_funnel"))) {
+        byName.set("acquisition_funnel", d1SectionError("acquisition_funnel", error));
+      }
     }
     try {
-      collected.push(await attributionFromD1(db));
+      byName.set("attribution", await attributionFromD1(db));
     } catch (error) {
-      collected.push(d1SectionError("attribution", error));
+      if (!sectionUsable(byName.get("attribution"))) {
+        byName.set("attribution", d1SectionError("attribution", error));
+      }
     }
   }
 
-  if (!refresh) {
-    try {
-      const snap = await loadDatalakeSnapshotFromR2();
-      if (snap) collected.push(...snap.sections);
-    } catch (error) {
-      console.warn(
-        "[datalake-r2] snapshot read failed:",
-        error instanceof Error ? error.message : error
-      );
-    }
-  }
-
-  const byName = new Map(collected.map((s) => [s.section, s]));
   const sections = SECTION_ORDER.map((section) => {
     const existing = byName.get(section);
     if (sectionUsable(existing)) return existing!;
     if (existing?.error) return existing;
+    if (HOT_D1_SECTIONS.has(section) && !db) {
+      return { section, error: "not available (AUTH_DB unbound — hot path needs D1)" };
+    }
     return { section, error: MISSING_ERROR };
   });
 
+  const source: DatalakeDashboardPayload["source"] = hasGold ? "gold" : db ? "hot_only" : "empty";
+
   return {
-    generated_at: new Date().toISOString(),
+    generated_at: goldGeneratedAt || new Date().toISOString(),
     cache: "cloudflare",
+    source,
     sections,
+    freshness,
   };
 }


### PR DESCRIPTION
## Summary
- Snapshot-first `getDatalakeDashboard`: R2 gold JSON first, D1 hot overlay for funnel/attribution only
- Expand admin datalake UI to full gold sections (Stripe, n8n, Postiz, AppFlowy, freshness)
- `?refresh=1` re-reads gold (no longer skips the snapshot)
- Docs: lakehouse silver → gold → serving architecture

## Test plan
- [x] `pnpm exec vitest run __tests__/datalake-r2.test.ts`
- [ ] Load `/admin/analytics/datalake` as admin — GOLD SNAPSHOT badge when R2 bound
- [ ] Missing ETL sections show materialize/ETL error, not Athena copy


Made with [Cursor](https://cursor.com)