### PR TITLE
fix(sonar): resolve 22 SonarCloud issues from PR #1629 datalake hub

### DIFF
--- a/scripts/etl/materialize-datalake-insights.mjs
+++ b/scripts/etl/materialize-datalake-insights.mjs
@@ -13,6 +13,7 @@ import { r2Put, r2Get } from "./_r2-config.mjs";
 
 const GOLD_KEY = "lake/snapshots/admin-datalake.json";
 const INSIGHTS_PREFIX = "lake/snapshots/insights";
+const CONTENT_TYPE_JSON = "application/json";
 
 const DOMAINS = [
   { domain: "seo", sections: ["top_keywords", "freshness"] },
@@ -105,9 +106,9 @@ async function callWorkersAi(prompt) {
 
   const res = await fetch(workersAiUrl(accountId, WORKERS_MODEL), {
     method: "POST",
-    headers: {
+      headers: {
       Authorization: `Bearer ${token}`,
-      "Content-Type": "application/json",
+      "Content-Type": CONTENT_TYPE_JSON,
     },
     body: JSON.stringify({
       messages: [
@@ -139,7 +140,7 @@ async function callGemini(prompt) {
   const url = `https://generativelanguage.googleapis.com/v1beta/models/gemini-1.5-flash:generateContent?key=${encodeURIComponent(key)}`;
   const res = await fetch(url, {
     method: "POST",
-    headers: { "Content-Type": "application/json" },
+    headers: { "Content-Type": CONTENT_TYPE_JSON },
     body: JSON.stringify({
       contents: [{ parts: [{ text: prompt }] }],
       generationConfig: { maxOutputTokens: 900, temperature: 0.3 },
@@ -265,7 +266,7 @@ async function main() {
     const metrics = extractMetrics(packs);
     const insight = await generateInsight(domain, packs, metrics, goldGeneratedAt);
     const key = `${INSIGHTS_PREFIX}/${domain}.json`;
-    await r2Put(key, JSON.stringify(insight, null, 2), { contentType: "application/json" });
+    await r2Put(key, JSON.stringify(insight, null, 2), { contentType: CONTENT_TYPE_JSON });
     console.log(`  wrote ${key} (provider=${insight.provider})`);
     indexDomains.push({
       domain,
@@ -280,7 +281,7 @@ async function main() {
     domains: indexDomains,
   };
   const indexKey = `${INSIGHTS_PREFIX}/insights-index.json`;
-  await r2Put(indexKey, JSON.stringify(index, null, 2), { contentType: "application/json" });
+  await r2Put(indexKey, JSON.stringify(index, null, 2), { contentType: CONTENT_TYPE_JSON });
   console.log(`[insights] wrote ${indexKey}`);
 }
 

--- a/src/app/api/admin/ai/analytics-orchestration/_shared.ts
+++ b/src/app/api/admin/ai/analytics-orchestration/_shared.ts
@@ -13,11 +13,14 @@ import { getInsight, getStripeSnapshotFromLake } from "@/lib/datalake-serve";
 import { getDataLakeBucketFromEnv } from "@/lib/r2-client";
 import { insightObjectKey } from "@/lib/datalake-insights";
 
+const DATALAKE_GOLD_SOURCE = "datalake-gold" as const;
+const ORCHESTRATION_DOMAIN = "orchestration";
+
 export interface PreparedOrchestration {
   snapshot: StripeAnalyticsSnapshot;
   orchestration: AnalyticsOrchestrationResult;
   reportTitle: string;
-  source: "datalake-gold" | "live_llm";
+  source: typeof DATALAKE_GOLD_SOURCE | "live_llm";
 }
 
 export type PrepareResult =
@@ -106,7 +109,7 @@ export async function prepareOrchestration(
   };
 
   if (!liveLlm) {
-    const cached = await getInsight("orchestration");
+    const cached = await getInsight(ORCHESTRATION_DOMAIN);
     if (cached && !cached.error && (cached.summary || cached.bullets?.length)) {
       return {
         ok: true,
@@ -119,7 +122,7 @@ export async function prepareOrchestration(
             "Served lake/snapshots/insights/orchestration.json (no live LLM)."
           ),
           reportTitle,
-          source: "datalake-gold",
+          source: DATALAKE_GOLD_SOURCE,
         },
       };
     }
@@ -140,7 +143,7 @@ export async function prepareOrchestration(
             "Insight snapshot missing and Admin AI not configured."
           ),
           reportTitle,
-          source: "datalake-gold",
+          source: DATALAKE_GOLD_SOURCE,
         },
       };
     }
@@ -179,7 +182,7 @@ export async function prepareOrchestration(
       const bucket = getDataLakeBucketFromEnv();
       if (bucket && typeof bucket.put === "function") {
         const insightDoc = {
-          domain: "orchestration",
+          domain: ORCHESTRATION_DOMAIN,
           generated_at: new Date().toISOString(),
           inputs_ref: {
             gold_generated_at: snapshot.generatedAt,
@@ -194,7 +197,7 @@ export async function prepareOrchestration(
           confidence: "medium",
           freshness: snapshot.generatedAt,
         };
-        await bucket.put(insightObjectKey("orchestration"), JSON.stringify(insightDoc, null, 2), {
+        await bucket.put(insightObjectKey(ORCHESTRATION_DOMAIN), JSON.stringify(insightDoc, null, 2), {
           httpMetadata: { contentType: "application/json" },
         });
       }

--- a/src/app/api/admin/ai/analytics-orchestration/_shared.ts
+++ b/src/app/api/admin/ai/analytics-orchestration/_shared.ts
@@ -197,9 +197,13 @@ export async function prepareOrchestration(
           confidence: "medium",
           freshness: snapshot.generatedAt,
         };
-        await bucket.put(insightObjectKey(ORCHESTRATION_DOMAIN), JSON.stringify(insightDoc, null, 2), {
-          httpMetadata: { contentType: "application/json" },
-        });
+        await bucket.put(
+          insightObjectKey(ORCHESTRATION_DOMAIN),
+          JSON.stringify(insightDoc, null, 2),
+          {
+            httpMetadata: { contentType: "application/json" },
+          }
+        );
       }
     } catch (err) {
       console.warn(

--- a/src/lib/auth-d1.ts
+++ b/src/lib/auth-d1.ts
@@ -21,6 +21,8 @@ const RESET_TOKEN_EXPIRY_SECONDS = 60 * 60 * 24; // 24 hours
 // Secret key for session tokens - must be set via Wrangler secret
 const SESSION_SECRET = process.env.SESSION_SECRET || "";
 
+const ERR_AUTH_NOT_CONFIGURED = "Authentication not configured";
+
 // D1 binding interface (provided by Worker)
 export interface AuthDatabase {
   prepare: (query: string) => D1PreparedStatement;
@@ -268,7 +270,7 @@ export async function authenticateUser(
 ): Promise<AuthResult> {
   // Check if SESSION_SECRET is configured
   if (!SESSION_SECRET) {
-    return { error: "Authentication not configured" };
+    return { error: ERR_AUTH_NOT_CONFIGURED };
   }
 
   // Validate SESSION_SECRET length (32+ bytes)
@@ -378,7 +380,7 @@ export async function createAdminUser(
   email: string
 ): Promise<{ success: boolean; error?: string }> {
   if (!SESSION_SECRET) {
-    return { success: false, error: "Authentication not configured" };
+    return { success: false, error: ERR_AUTH_NOT_CONFIGURED };
   }
 
   const user = await db
@@ -404,7 +406,7 @@ export async function createPasswordResetToken(
   email: string
 ): Promise<{ token?: string; error?: string }> {
   if (!SESSION_SECRET) {
-    return { error: "Authentication not configured" };
+    return { error: ERR_AUTH_NOT_CONFIGURED };
   }
 
   const user = await db
@@ -443,7 +445,7 @@ export async function consumePasswordResetToken(
   newPassword: string
 ): Promise<{ success: boolean; error?: string }> {
   if (!SESSION_SECRET) {
-    return { success: false, error: "Authentication not configured" };
+    return { success: false, error: ERR_AUTH_NOT_CONFIGURED };
   }
 
   const now = Math.floor(Date.now() / 1000);
@@ -534,44 +536,41 @@ export function getAuthDbFromEnv(): AuthDatabase | null {
   // E2E / local next-dev: prefer wrangler sqlite so signup/login never hit
   // remote user-auth-db (and so CI works without a live CLOUDFLARE_API_TOKEN).
   if (preferLocal) {
-    try {
-      // eslint-disable-next-line @typescript-eslint/no-require-imports
-      const { getLocalAuthDb } = require("./auth-db-local") as typeof import("./auth-db-local");
-      const local = getLocalAuthDb();
-      if (local) return local;
-    } catch {
-      // Fall through to HTTP D1.
-    }
+    const local = tryLoadLocalAuthDb();
+    if (local) return local;
   }
 
   // Lazy-load Node-only modules using literal require() strings. Webpack
   // statically resolves these at build time (via tsconfig paths for "@/"),
   // which avoids webpackEmptyContext that computed strings produce. These
   // are server-only modules — never bundled into client or edge bundles.
+  const httpDb = tryLoadHttpAuthDb();
+  if (httpDb) return httpDb;
+
+  if (process.env.NODE_ENV === "development") {
+    return tryLoadLocalAuthDb() ?? null;
+  }
+  return null;
+}
+
+function tryLoadLocalAuthDb(): AuthDatabase | null {
+  try {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const { getLocalAuthDb } = require("./auth-db-local") as typeof import("./auth-db-local");
+    return getLocalAuthDb();
+  } catch {
+    return null;
+  }
+}
+
+function tryLoadHttpAuthDb(): AuthDatabase | null {
   try {
     // eslint-disable-next-line @typescript-eslint/no-require-imports
     const { getHttpAuthDb } = require("./d1-http") as typeof import("./d1-http");
-    const httpDb = getHttpAuthDb();
-    if (httpDb) {
-      return httpDb;
-    }
+    return getHttpAuthDb() ?? null;
   } catch {
-    // Module unavailable or misconfigured — fall through.
+    return null;
   }
-
-  if (process.env.NODE_ENV === "development") {
-    // Local D1 sqlite shim — only used in `next dev`; pulls node:sqlite so
-    // it must NOT reach the edge bundle. The literal require() is safe here
-    // because webpack only includes server-side chunks.
-    try {
-      // eslint-disable-next-line @typescript-eslint/no-require-imports
-      const { getLocalAuthDb } = require("./auth-db-local") as typeof import("./auth-db-local");
-      return getLocalAuthDb();
-    } catch {
-      return null;
-    }
-  }
-  return null;
 }
 
 export { verifyPassword, hashPassword, readPreferenceFlag };

--- a/src/lib/datalake-serve.ts
+++ b/src/lib/datalake-serve.ts
@@ -20,6 +20,9 @@ import {
 } from "@/lib/datalake-insights";
 
 const GSC_WEEKLY_KEY = "lake/snapshots/gsc-weekly.json";
+const DATALAKE_GOLD_SOURCE = "datalake-gold" as const;
+const SECTION_STRIPE_REVENUE = "stripe_revenue";
+const SECTION_ACQUISITION_FUNNEL = "acquisition_funnel";
 
 export async function getGoldSection(section: string): Promise<DatalakeSectionResult | null> {
   const dash = await getDatalakeDashboard({});
@@ -95,10 +98,9 @@ export async function getSeoFromLake(days = 28): Promise<{
     position: number;
   }>;
   fetchedAt: string;
-  source: "datalake-gold";
+  source: typeof DATALAKE_GOLD_SOURCE;
   error?: string;
 }> {
-  void days;
   const section = await getGoldSection("top_keywords");
   const rows = section?.rows ?? [];
   const keywords = rows.map((r) => ({
@@ -123,7 +125,7 @@ export async function getSeoFromLake(days = 28): Promise<{
     },
     keywords: keywords.slice(0, 50),
     fetchedAt: snap?.generated_at ?? new Date().toISOString(),
-    source: "datalake-gold",
+    source: DATALAKE_GOLD_SOURCE,
     error: section?.error,
   };
 }
@@ -140,7 +142,7 @@ export async function getCtrOpportunitiesFromLake(limit = 50): Promise<{
     position: number;
   }>;
   fetchedAt: string;
-  source: "datalake-gold";
+  source: typeof DATALAKE_GOLD_SOURCE;
   error?: string;
 }> {
   const seo = await getSeoFromLake(28);
@@ -150,7 +152,7 @@ export async function getCtrOpportunitiesFromLake(limit = 50): Promise<{
   return {
     opportunities,
     fetchedAt: seo.fetchedAt,
-    source: "datalake-gold",
+    source: DATALAKE_GOLD_SOURCE,
     error: seo.error,
   };
 }
@@ -167,7 +169,7 @@ export async function getGscDimensionFromLake(
   rows: unknown[];
   snapshot: Awaited<ReturnType<typeof getSeoFromLake>>["snapshot"];
   fetchedAt: string;
-  source: "datalake-gold";
+  source: typeof DATALAKE_GOLD_SOURCE;
   note: string;
   error?: string;
 }> {
@@ -177,7 +179,7 @@ export async function getGscDimensionFromLake(
     rows: dimension === "query" ? seo.keywords : [],
     snapshot: seo.snapshot,
     fetchedAt: seo.fetchedAt,
-    source: "datalake-gold",
+    source: DATALAKE_GOLD_SOURCE,
     note:
       dimension === "query"
         ? "Served from gold top_keywords."
@@ -193,7 +195,7 @@ export async function getUnifiedFromLake(days = 28): Promise<Record<string, unkn
   const dash = await getGoldDashboard();
   const byName = new Map(dash.sections.map((s) => [s.section, s]));
   const seo = await getSeoFromLake(days);
-  const stripe = byName.get("stripe_revenue");
+  const stripe = byName.get(SECTION_STRIPE_REVENUE);
   const espocrm = byName.get("espocrm_funnel");
   const attribution = byName.get("attribution");
 
@@ -203,7 +205,7 @@ export async function getUnifiedFromLake(days = 28): Promise<Record<string, unkn
   return {
     days,
     fetchedAt: dash.generated_at,
-    source: "datalake-gold",
+    source: DATALAKE_GOLD_SOURCE,
     lakeSource: dash.source,
     seo: seo.error ? null : seo.snapshot,
     keywords: seo.keywords.slice(0, 10),
@@ -234,7 +236,7 @@ export async function getUnifiedFromLake(days = 28): Promise<Record<string, unkn
  */
 export async function getRoiFromLake(days = 30): Promise<Record<string, unknown>> {
   const linkedin = await getGoldSection("linkedin_ads");
-  const stripe = await getGoldSection("stripe_revenue");
+  const stripe = await getGoldSection(SECTION_STRIPE_REVENUE);
   const linkedinRows = linkedin?.rows ?? [];
   const spendCents = linkedinRows.reduce(
     (a, r) => a + Math.round((Number(r.spend ?? r.cost) || 0) * 100),
@@ -292,7 +294,7 @@ export async function getRoiFromLake(days = 30): Promise<Record<string, unknown>
   return {
     windowDays: days,
     generatedAt: new Date().toISOString(),
-    source: "datalake-gold",
+    source: DATALAKE_GOLD_SOURCE,
     channels,
     totals: {
       spendCents: totalsSpend,
@@ -320,12 +322,12 @@ export async function getRoiFromLake(days = 30): Promise<Record<string, unknown>
  */
 export async function getKpiFromLake(days = 28): Promise<Record<string, unknown>> {
   const seo = await getSeoFromLake(days);
-  const stripe = await getGoldSection("stripe_revenue");
-  const funnel = await getGoldSection("acquisition_funnel");
+  const stripe = await getGoldSection(SECTION_STRIPE_REVENUE);
+  const funnel = await getGoldSection(SECTION_ACQUISITION_FUNNEL);
   return {
     days,
     fetchedAt: seo.fetchedAt,
-    source: "datalake-gold",
+    source: DATALAKE_GOLD_SOURCE,
     seo: seo.snapshot,
     keywordsTop: seo.keywords.slice(0, 5),
     revenueRows: stripe?.rows?.slice(0, 14) ?? [],
@@ -357,10 +359,10 @@ export async function getStripeSnapshotFromLake(windowDays = 30): Promise<{
     processed: number;
     failed: number;
   }>;
-  source: "datalake-gold";
+  source: typeof DATALAKE_GOLD_SOURCE;
   error?: string;
 }> {
-  const section = await getGoldSection("stripe_revenue");
+  const section = await getGoldSection(SECTION_STRIPE_REVENUE);
   const rows = section?.rows ?? [];
   const dailyTrend = rows.map((r) => {
     const amountMajor = Number(r.revenue ?? r.amount) || 0;
@@ -399,7 +401,7 @@ export async function getStripeSnapshotFromLake(windowDays = 30): Promise<{
     byStatus: {},
     byCurrency: {},
     dailyTrend,
-    source: "datalake-gold",
+    source: DATALAKE_GOLD_SOURCE,
     error: section?.error,
   };
 }


### PR DESCRIPTION
## Summary

Fixes the 22 new SonarCloud issues introduced by PR #1629 (datalake hub + gold LLM insights). Quality Gate passed but project policy requires 0 new issues.

**Rules addressed:**

- **S1192 `sonarjs/no-duplicate-string`** — extracted string constants for repeated literals:
  - `DATALAKE_GOLD_SOURCE = "datalake-gold"` (was used 11× in `datalake-serve.ts`, 3× in `_shared.ts`)
  - `SECTION_STRIPE_REVENUE = "stripe_revenue"` (4× in `datalake-serve.ts`)
  - `SECTION_ACQUISITION_FUNNEL = "acquisition_funnel"` (datalake-serve.ts)
  - `ERR_AUTH_NOT_CONFIGURED = "Authentication not configured"` (4× in `auth-d1.ts`)
  - `ORCHESTRATION_DOMAIN = "orchestration"` (3× in `_shared.ts`)
  - `CONTENT_TYPE_JSON = "application/json"` (3× in `materialize-datalake-insights.mjs`)

- **S3699 `sonarjs/void-use`** — removed superfluous `void days;` in `datalake-serve.ts` (`days` is actually used in the return object)

- **S3776 `sonarjs/cognitive-complexity`** — `getAuthDbFromEnv` in `auth-d1.ts` (complexity ~16, threshold 15) refactored by extracting `tryLoadLocalAuthDb` and `tryLoadHttpAuthDb` helpers, reducing nesting depth

## Files changed

- `src/lib/datalake-serve.ts`
- `src/lib/auth-d1.ts`
- `src/app/api/admin/ai/analytics-orchestration/_shared.ts`
- `scripts/etl/materialize-datalake-insights.mjs`

## Test plan

- [x] `pnpm exec eslint` on all changed files — 0 warnings, 0 errors
- [x] `pnpm exec tsc --noEmit` — passes cleanly
- No logic changed; pure refactoring (constant extraction + helper extraction)

Made with [Cursor](https://cursor.com)