### PR TITLE
fix(datalake): always return domains[] from insights index

### DIFF
--- a/__tests__/datalake-insights.test.ts
+++ b/__tests__/datalake-insights.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi, beforeEach } from "vitest";
 import {
   INSIGHT_DOMAINS,
   INSIGHTS_INDEX_KEY,
@@ -6,6 +6,18 @@ import {
   isInsightDomain,
   INSIGHT_SECTION_MAP,
 } from "@/lib/datalake-insights";
+
+const { readMocks } = vi.hoisted(() => ({
+  readMocks: {
+    get: vi.fn(),
+  },
+}));
+
+vi.mock("@/lib/r2-client", () => ({
+  getDataLakeBucketFromEnv: () => ({
+    get: readMocks.get,
+  }),
+}));
 
 describe("datalake-insights contract", () => {
   it("lists expected domains", () => {
@@ -28,5 +40,39 @@ describe("datalake-insights contract", () => {
   it("maps domains to gold sections", () => {
     expect(INSIGHT_SECTION_MAP.revenue).toContain("stripe_revenue");
     expect(INSIGHT_SECTION_MAP.seo).toContain("top_keywords");
+  });
+});
+
+describe("listInsightDomains", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.resetModules();
+  });
+
+  it("returns empty domains array when R2 index is a stub object", async () => {
+    readMocks.get.mockResolvedValue({
+      text: async () => "{}",
+    });
+    const { listInsightDomains } = await import("@/lib/datalake-serve");
+    const index = await listInsightDomains();
+    expect(Array.isArray(index.domains)).toBe(true);
+    expect(index.domains).toEqual([]);
+    expect(typeof index.generated_at).toBe("string");
+  });
+
+  it("returns domains from a valid insights index", async () => {
+    readMocks.get.mockResolvedValue({
+      text: async () =>
+        JSON.stringify({
+          generated_at: "2026-08-13T12:00:00.000Z",
+          domains: [
+            { domain: "revenue", generated_at: "2026-08-13T12:00:00.000Z", has_error: false },
+          ],
+        }),
+    });
+    const { listInsightDomains } = await import("@/lib/datalake-serve");
+    const index = await listInsightDomains();
+    expect(index.domains).toHaveLength(1);
+    expect(index.domains[0].domain).toBe("revenue");
   });
 });

--- a/src/lib/datalake-serve.ts
+++ b/src/lib/datalake-serve.ts
@@ -61,7 +61,16 @@ export async function getInsightsIndex(): Promise<DatalakeInsightsIndex | null> 
 
 export async function listInsightDomains(): Promise<DatalakeInsightsIndex> {
   const index = await getInsightsIndex();
-  if (index) return index;
+  // R2 may hold a stub `{}` or a malformed index — always return a stable shape.
+  if (index && Array.isArray(index.domains)) {
+    return {
+      generated_at:
+        typeof index.generated_at === "string" && index.generated_at.length > 0
+          ? index.generated_at
+          : new Date().toISOString(),
+      domains: index.domains,
+    };
+  }
   return { generated_at: new Date().toISOString(), domains: [] };
 }
 


### PR DESCRIPTION
## Summary
- Normalize `listInsightDomains` so a stub/malformed R2 insights index (`{}`) still yields `{ domains: [], generated_at }`.
- Unit coverage for stub + valid index; Playwright insights/datalake suite: **26/26 passed**.

## Test plan
- [x] `pnpm exec vitest run __tests__/datalake-insights.test.ts`
- [x] Playwright: `e2e/migrated/admin-api.spec.ts` + insights sweep (`26 passed`)


Made with [Cursor](https://cursor.com)