### PR TITLE
fix(etl): prefer base64 Google SA JSON for GSC auth

### DIFF
--- a/.github/workflows/etl-gsc-to-r2.yml
+++ b/.github/workflows/etl-gsc-to-r2.yml
@@ -40,6 +40,9 @@ jobs:
       env:
         FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
         GSC_SITE_URL: ${{ secrets.GSC_SITE_URL }}
+        # Preferred (SO #74131595): base64(entire service-account JSON)
+        GOOGLE_SERVICE_ACCOUNT_JSON_B64: ${{ secrets.GOOGLE_SERVICE_ACCOUNT_JSON_B64 }}
+        # Fallback: split email + PEM (often corrupted in GH secrets)
         GOOGLE_CLIENT_EMAIL: ${{ secrets.GOOGLE_CLIENT_EMAIL }}
         GOOGLE_PRIVATE_KEY: ${{ secrets.GOOGLE_PRIVATE_KEY }}
         CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CF_ACCOUNT_ID }}

--- a/scripts/etl/_google-sa-key.mjs
+++ b/scripts/etl/_google-sa-key.mjs
@@ -1,8 +1,77 @@
 /**
- * Normalize Google SA private keys for JWT signing (ETL scripts).
- * Mirrors src/lib/google-sa-key.ts for plain .mjs consumers.
+ * Normalize Google SA credentials for JWT signing (ETL scripts).
+ *
+ * Online consensus (SO #74131595, Node OpenSSL 3 / GH Actions):
+ * 1. Prefer base64(entire service-account JSON) — avoids PEM corruption in secrets.
+ * 2. Unescape `\\n` → real newlines (`split(String.raw`\n`).join('\n')`).
+ * 3. Repair headers glued after whitespace stripping (`BEGINRSAPRIVATEKEY`).
+ * 4. Prefer PKCS#8 (`BEGIN PRIVATE KEY`); export PKCS#8 when PKCS#1 loads.
  */
 import { createPrivateKey } from "node:crypto";
+
+function unescapeNewlines(value) {
+	return String(value ?? "")
+		.split(String.raw`\n`)
+		.join("\n")
+		.replace(/\r\n/g, "\n")
+		.replace(/\r/g, "\n")
+		.trim();
+}
+
+function repairGluedPemHeaders(key) {
+	let out = key.replace(/\s+/g, "");
+	out = out
+		.replace(/-----BEGIN((?:RSA)?PRIVATEKEY)-----/i, (_, kind) => {
+			const label = /RSA/i.test(kind) ? "RSA PRIVATE KEY" : "PRIVATE KEY";
+			return `-----BEGIN ${label}-----\n`;
+		})
+		.replace(/-----END((?:RSA)?PRIVATEKEY)-----/i, (_, kind) => {
+			const label = /RSA/i.test(kind) ? "RSA PRIVATE KEY" : "PRIVATE KEY";
+			return `\n-----END ${label}-----`;
+		});
+	// Re-wrap body to 64-char lines if we compacted it
+	const begin = out.match(/-----BEGIN [^-]+-----/)?.[0];
+	const end = out.match(/-----END [^-]+-----/)?.[0];
+	if (!begin || !end) return key;
+	const body = out
+		.replace(begin, "")
+		.replace(end, "")
+		.replace(/\s+/g, "");
+	const lines = body.match(/.{1,64}/g) ?? [body];
+	return `${begin}\n${lines.join("\n")}\n${end}`;
+}
+
+/**
+ * Resolve SA email + PEM from env.
+ * Prefers GOOGLE_SERVICE_ACCOUNT_JSON_B64 (base64 of full SA JSON).
+ */
+export function resolveGoogleServiceAccountFromEnv(env = process.env) {
+	const b64 =
+		env.GOOGLE_SERVICE_ACCOUNT_JSON_B64?.trim() ||
+		env.GOOGLE_SA_JSON_B64?.trim() ||
+		"";
+	if (b64) {
+		const jsonText = Buffer.from(b64, "base64").toString("utf8").trim();
+		const parsed = JSON.parse(jsonText);
+		const email = String(parsed.client_email ?? "").trim();
+		const privateKey = String(parsed.private_key ?? "").trim();
+		if (!email || !privateKey) {
+			throw new Error(
+				"GOOGLE_SERVICE_ACCOUNT_JSON_B64 decoded but missing client_email/private_key"
+			);
+		}
+		return { email, privateKeyRaw: privateKey };
+	}
+
+	const email = (env.GOOGLE_CLIENT_EMAIL || env.GOOGLE_SERVICE_ACCOUNT_EMAIL || "").trim();
+	const privateKeyRaw = (env.GOOGLE_PRIVATE_KEY || "").trim();
+	if (!email || !privateKeyRaw) {
+		throw new Error(
+			"Set GOOGLE_SERVICE_ACCOUNT_JSON_B64 (preferred) or GOOGLE_CLIENT_EMAIL + GOOGLE_PRIVATE_KEY"
+		);
+	}
+	return { email, privateKeyRaw };
+}
 
 export function normalizeGooglePrivateKeyPem(raw) {
 	let key = String(raw ?? "").trim();
@@ -20,7 +89,9 @@ export function normalizeGooglePrivateKeyPem(raw) {
 			key = parsed.private_key.trim();
 		} catch (err) {
 			throw new Error(
-				`GOOGLE_PRIVATE_KEY looks like JSON but is invalid: ${err instanceof Error ? err.message : String(err)}`
+				`GOOGLE_PRIVATE_KEY looks like JSON but is invalid: ${
+					err instanceof Error ? err.message : String(err)
+				}`
 			);
 		}
 	}
@@ -30,29 +101,27 @@ export function normalizeGooglePrivateKeyPem(raw) {
 		key = key.slice(1, -1).trim();
 	}
 
-	// Double-escaped newlines from nested secret stores
-	key = key
-		.replace(/\\\\n/g, "\n")
-		.replace(/\\n/g, "\n")
-		.replace(/\r\n/g, "\n")
-		.replace(/\r/g, "\n")
-		.trim();
+	key = unescapeNewlines(key);
 
-	// Secret sometimes stored as base64(PEM) or raw PKCS#8 DER base64 (no headers)
+	// Headers glued after secret stores strip spaces/newlines
+	if (!/-----BEGIN (RSA )?PRIVATE KEY-----/.test(key) && /BEGIN.*PRIVATE.?KEY/i.test(key)) {
+		key = repairGluedPemHeaders(key);
+	}
+
+	// Secret sometimes stored as base64(PEM) or base64(SA JSON)
 	if (!/-----BEGIN (RSA )?PRIVATE KEY-----/.test(key)) {
 		const compact = key.replace(/\s+/g, "");
 		if (/^[A-Za-z0-9+/=]+$/.test(compact) && compact.length > 80) {
 			try {
 				const decoded = Buffer.from(compact, "base64").toString("utf8").trim();
-				if (/-----BEGIN (RSA )?PRIVATE KEY-----/.test(decoded)) {
-					key = decoded
-						.replace(/\\\\n/g, "\n")
-						.replace(/\\n/g, "\n")
-						.replace(/\r\n/g, "\n")
-						.replace(/\r/g, "\n")
-						.trim();
+				if (decoded.startsWith("{")) {
+					const parsed = JSON.parse(decoded);
+					key = unescapeNewlines(String(parsed.private_key ?? ""));
+				} else if (/-----BEGIN (RSA )?PRIVATE KEY-----/.test(decoded)) {
+					key = unescapeNewlines(decoded);
+				} else if (/BEGIN.*PRIVATE.?KEY/i.test(decoded)) {
+					key = repairGluedPemHeaders(unescapeNewlines(decoded));
 				} else {
-					// Treat as DER → wrap as PKCS#8 PEM
 					const lines = compact.match(/.{1,64}/g) ?? [compact];
 					key = `-----BEGIN PRIVATE KEY-----\n${lines.join("\n")}\n-----END PRIVATE KEY-----`;
 				}
@@ -64,7 +133,7 @@ export function normalizeGooglePrivateKeyPem(raw) {
 
 	if (!/-----BEGIN (RSA )?PRIVATE KEY-----/.test(key)) {
 		throw new Error(
-			"GOOGLE_PRIVATE_KEY must be a PEM private key (-----BEGIN PRIVATE KEY----- or -----BEGIN RSA PRIVATE KEY-----)"
+			"GOOGLE_PRIVATE_KEY must be a PEM private key (-----BEGIN PRIVATE KEY----- or -----BEGIN RSA PRIVATE KEY-----). Prefer GOOGLE_SERVICE_ACCOUNT_JSON_B64=base64(entire SA JSON)."
 		);
 	}
 	if (key.length < 200) {
@@ -78,13 +147,18 @@ export function normalizeGooglePrivateKeyPem(raw) {
 export function loadGooglePrivateKey(raw) {
 	const pem = normalizeGooglePrivateKeyPem(raw);
 	try {
-		return createPrivateKey({ key: pem, format: "pem" });
+		const keyObject = createPrivateKey({ key: pem, format: "pem" });
+		// Normalize to PKCS#8 for OpenSSL 3 / jose consumers
+		return createPrivateKey({
+			key: keyObject.export({ type: "pkcs8", format: "pem" }),
+			format: "pem",
+		});
 	} catch (err) {
 		const header = pem.match(/-----BEGIN [^-]+-----/)?.[0] ?? "unknown-header";
 		throw new Error(
 			`GOOGLE_PRIVATE_KEY PEM rejected by Node (${header}): ${
 				err instanceof Error ? err.message : String(err)
-			}`
+			}. Convert with: openssl pkcs8 -topk8 -inform PEM -outform PEM -nocrypt -in key.pem -out key.pkcs8.pem`
 		);
 	}
 }

--- a/scripts/etl/gsc-to-r2.mjs
+++ b/scripts/etl/gsc-to-r2.mjs
@@ -3,20 +3,30 @@
  *
  * Migrated version using R2 S3-compatible endpoint.
  * Same logic as gsc-to-lake.mjs - only client configuration differs.
+ *
+ * Auth (preferred): GOOGLE_SERVICE_ACCOUNT_JSON_B64 = base64(entire SA JSON)
+ * Fallback: GOOGLE_CLIENT_EMAIL + GOOGLE_PRIVATE_KEY (PEM with \\n OK)
  */
 
 import { ParquetWriter, ParquetSchema } from "@dsnp/parquetjs";
 import { SignJWT } from "jose";
 import { readFileSync, unlinkSync } from "fs";
 import { BUCKET, r2Put } from "./_r2-config.mjs";
-import { loadGooglePrivateKey } from "./_google-sa-key.mjs";
+import {
+	loadGooglePrivateKey,
+	resolveGoogleServiceAccountFromEnv,
+} from "./_google-sa-key.mjs";
 
 const SITE = process.env.GSC_SITE_URL || "https://cloudless.gr/";
-const EMAIL = process.env.GOOGLE_CLIENT_EMAIL;
-const KEY_RAW = process.env.GOOGLE_PRIVATE_KEY?.trim() ?? "";
 
-if (!EMAIL || !KEY_RAW) {
-	console.error("GOOGLE_CLIENT_EMAIL / GOOGLE_PRIVATE_KEY not set");
+let EMAIL = "";
+let KEY_RAW = "";
+try {
+	const sa = resolveGoogleServiceAccountFromEnv();
+	EMAIL = sa.email;
+	KEY_RAW = sa.privateKeyRaw;
+} catch (err) {
+	console.error(String(err?.message ?? err));
 	process.exit(1);
 }
 
@@ -75,7 +85,7 @@ async function main() {
 		token = await getAccessToken();
 	} catch (err) {
 		await writeEmptyAndExit(
-			`auth/key failed (${String(err?.message ?? err).slice(0, 160)}). Fix GOOGLE_PRIVATE_KEY PEM secret.`
+			`auth/key failed (${String(err?.message ?? err).slice(0, 200)}). Prefer GOOGLE_SERVICE_ACCOUNT_JSON_B64.`
 		);
 	}
 


### PR DESCRIPTION
## Summary
- Online fix for `DECODER routines::unsupported` / missing PEM headers: **store `base64(entire service-account JSON)`** as `GOOGLE_SERVICE_ACCOUNT_JSON_B64` ([SO #74131595](https://stackoverflow.com/questions/74131595/error-error1e08010cdecoder-routinesunsupported-with-google-auth-library)).
- Also repairs glued PEM headers and normalizes to PKCS#8 for Node 22 / OpenSSL 3.
- Soft-skip empty parquet remains if auth still fails.

## Operator (one-time)
```bash
base64 -w0 path/to/sa.json | gh secret set GOOGLE_SERVICE_ACCOUNT_JSON_B64 -R Themis128/cloudless.gr
gh workflow run etl-gsc-to-r2.yml -R Themis128/cloudless.gr
```

## Test plan
- [ ] Set `GOOGLE_SERVICE_ACCOUNT_JSON_B64`
- [ ] Re-run GSC ETL → real keyword rows
- [ ] Re-run materialize-snapshots


Made with [Cursor](https://cursor.com)