### PR TITLE
fix(ops): safe release merge, GoTrue grant query, AppFlowy folder seed

### DIFF
--- a/__tests__/selfhosted-autologin.test.ts
+++ b/__tests__/selfhosted-autologin.test.ts
@@ -130,17 +130,17 @@ describe("getAutologinUrl — AppFlowy (GoTrue password-grant)", () => {
     await getAutologinUrl("appflowy");
 
     expect(mockFetch).toHaveBeenCalledWith(
-      "https://appflowy.cloudless.gr/gotrue/token",
+      "https://appflowy.cloudless.gr/gotrue/token?grant_type=password",
       expect.objectContaining({
         method: "POST",
         headers: expect.objectContaining({ "Content-Type": "application/json" }),
       })
     );
-    // Ensure the request body contains email and grant_type (but NOT the raw password in our assertion)
+    // Ensure the request body contains email (grant_type is in the query string)
     const callArgs = mockFetch.mock.calls[0] as [string, RequestInit];
     const body = JSON.parse(callArgs[1].body as string) as { email?: string; grant_type?: string };
     expect(body.email).toBe("admin@cloudless.gr");
-    expect(body.grant_type).toBe("password");
+    expect(body.grant_type).toBeUndefined();
   });
 
   it("throws a sanitized error when GoTrue returns HTTP 4xx", async () => {

--- a/infrastructure/omv/pi-release-pull.sh
+++ b/infrastructure/omv/pi-release-pull.sh
@@ -152,13 +152,19 @@ sudo mkdir -p "$NEW_REL"
 nice -n 10 ionice -c2 -n7 sudo tar --zstd -xf "$TAR" -C "$NEW_REL"
 
 # Tarball layout: top-level standalone/ static/ public/ BUILD_ID (from pack OUT).
-# standalone/ often also has public/ — plain mv fails on non-empty dirs; merge with rsync.
+# Never rsync standalone/ into its parent ($NEW_REL) — that is a classic infinite
+# recursion footgun (dest contains source). Merge via a sibling temp dir instead.
 if [[ -d "$NEW_REL/standalone" ]]; then
-  sudo rsync -a "$NEW_REL/standalone/" "$NEW_REL/"
-  sudo rm -rf "$NEW_REL/standalone"
+  MERGE="$(mktemp -d "$RELEASES/.merge-${SHA12}.XXXXXX")"
+  # Prefer standalone contents as the app root, then overlay other top-level files.
+  sudo rsync -a "$NEW_REL/standalone/" "$MERGE/"
+  sudo rsync -a --exclude standalone "$NEW_REL/" "$MERGE/"
+  sudo rm -rf "$NEW_REL"
+  sudo mv "$MERGE" "$NEW_REL"
 fi
 if [[ -d "$NEW_REL/static" ]]; then
   sudo mkdir -p "$NEW_REL/.next/static"
+  # static/ is a sibling of the app root, not a child of itself — safe.
   sudo rsync -a "$NEW_REL/static/" "$NEW_REL/.next/static/"
   sudo rm -rf "$NEW_REL/static"
 fi

--- a/scripts/migrate-notion-to-appflowy.mjs
+++ b/scripts/migrate-notion-to-appflowy.mjs
@@ -49,10 +49,10 @@ async function notionPost(path, token, body) {
 
 // Obtain a real user token via GoTrue password grant (service JWT doesn't have workspace access)
 async function getAppFlowyToken(baseUrl, email, password) {
-  const res = await fetch(`${baseUrl}/gotrue/token`, {
+  const res = await fetch(`${baseUrl}/gotrue/token?grant_type=password`, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ grant_type: "password", email, password }),
+    body: JSON.stringify({ email, password }),
     signal: AbortSignal.timeout(10_000),
   });
   if (!res.ok) throw new Error(`AppFlowy login failed: ${res.status}`);

--- a/scripts/seed-appflowy-cms-folders.mjs
+++ b/scripts/seed-appflowy-cms-folders.mjs
@@ -1,0 +1,165 @@
+#!/usr/bin/env node
+/**
+ * seed-appflowy-cms-folders.mjs
+ *
+ * Creates the top-level CMS folder pages the admin AppFlowy status probe
+ * expects (Blog, Docs, Projects, …) in a fresh workspace.
+ *
+ * Fresh AppFlowy workspaces 404 on GET /folder until the first page exists.
+ * Creating these pages at the workspace root initializes the folder tree.
+ *
+ * Env:
+ *   APPFLOWY_API_URL or APPFLOWY_BASE_URL
+ *   APPFLOWY_EMAIL
+ *   APPFLOWY_PASSWORD
+ *
+ * Usage:
+ *   node scripts/seed-appflowy-cms-folders.mjs [--dry-run]
+ */
+import { randomUUID } from "node:crypto";
+import { createPageWithContent } from "./lib/appflowy-page-content.mjs";
+
+const DRY_RUN = process.argv.includes("--dry-run");
+
+const CMS_FOLDERS = [
+  "Blog",
+  "Docs",
+  "Projects",
+  "Tasks",
+  "Submissions",
+  "Analytics",
+  "Case Studies",
+  "FAQs",
+  "Services",
+  "Testimonials",
+];
+
+const baseUrl = (
+  process.env.APPFLOWY_API_URL ||
+  process.env.APPFLOWY_BASE_URL ||
+  "https://appflowy.cloudless.gr"
+).replace(/\/$/, "");
+const email = process.env.APPFLOWY_EMAIL;
+const password = process.env.APPFLOWY_PASSWORD;
+
+if (!email || !password) {
+  console.error("error: APPFLOWY_EMAIL and APPFLOWY_PASSWORD are required");
+  process.exit(2);
+}
+
+async function login() {
+  const res = await fetch(`${baseUrl}/gotrue/token?grant_type=password`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ email, password }),
+    signal: AbortSignal.timeout(10_000),
+  });
+  if (!res.ok) throw new Error(`GoTrue login failed: HTTP ${res.status}`);
+  const body = await res.json();
+  if (!body.access_token) throw new Error("GoTrue response missing access_token");
+  return body.access_token;
+}
+
+async function listWorkspaces(token) {
+  const res = await fetch(`${baseUrl}/api/workspace`, {
+    headers: { Authorization: `Bearer ${token}` },
+    signal: AbortSignal.timeout(10_000),
+  });
+  if (!res.ok) throw new Error(`list workspaces failed: HTTP ${res.status}`);
+  const body = await res.json();
+  return body.data || [];
+}
+
+function walkFolder(node, visit) {
+  if (!node) return;
+  if (Array.isArray(node)) {
+    for (const child of node) walkFolder(child, visit);
+    return;
+  }
+  if (typeof node !== "object") return;
+  const view = node.view || node;
+  visit(view);
+  if (Array.isArray(view.children)) walkFolder(view.children, visit);
+  if (node !== view && Array.isArray(node.children)) walkFolder(node.children, visit);
+}
+
+async function loadFolder(token, workspaceId) {
+  const res = await fetch(`${baseUrl}/api/workspace/${workspaceId}/folder?depth=5`, {
+    headers: { Authorization: `Bearer ${token}` },
+    signal: AbortSignal.timeout(15_000),
+  });
+  if (res.status === 404 || res.status === 400) return null;
+  if (!res.ok) throw new Error(`folder list failed: HTTP ${res.status}`);
+  const body = await res.json();
+  return body.data ?? null;
+}
+
+async function listFolderNames(token, workspaceId) {
+  const root = await loadFolder(token, workspaceId);
+  const names = new Set();
+  walkFolder(root, (view) => {
+    if (view?.name) names.add(String(view.name));
+  });
+  return names;
+}
+
+/** Prefer the default "General" space; fall back to workspace root. */
+async function resolveParentViewId(token, workspaceId) {
+  const root = await loadFolder(token, workspaceId);
+  let generalId = null;
+  walkFolder(root, (view) => {
+    if (generalId) return;
+    if (view?.is_space && String(view.name || "").toLowerCase() === "general" && view.view_id) {
+      generalId = view.view_id;
+    }
+  });
+  return generalId || workspaceId;
+}
+
+async function main() {
+  console.log(`login ${email} @ ${baseUrl}`);
+  const token = await login();
+  const workspaces = await listWorkspaces(token);
+  if (!workspaces.length) throw new Error("no workspaces");
+  const workspaceId = workspaces[0].workspace_id;
+  console.log(`workspace ${workspaceId} (${workspaces[0].workspace_name})`);
+
+  const parentViewId = await resolveParentViewId(token, workspaceId);
+  console.log(`parent_view ${parentViewId}`);
+
+  const existing = await listFolderNames(token, workspaceId);
+  console.log(`existing views: ${existing.size}`);
+
+  let created = 0;
+  let skipped = 0;
+  for (const name of CMS_FOLDERS) {
+    if ([...existing].some((n) => n.toLowerCase() === name.toLowerCase())) {
+      console.log(`skip ${name} (exists)`);
+      skipped += 1;
+      continue;
+    }
+    if (DRY_RUN) {
+      console.log(`dry-run would create ${name}`);
+      created += 1;
+      continue;
+    }
+    const { viewId } = await createPageWithContent({
+      baseUrl,
+      token,
+      workspaceId,
+      parentViewId,
+      title: name,
+      markdown: `# ${name}\n\nCMS folder seeded for cloudless.gr admin.\n`,
+      viewId: randomUUID(),
+    });
+    console.log(`created ${name} → ${viewId}`);
+    created += 1;
+  }
+
+  console.log(`done created=${created} skipped=${skipped} dry_run=${DRY_RUN}`);
+}
+
+main().catch((err) => {
+  console.error(err instanceof Error ? err.message : err);
+  process.exit(1);
+});

--- a/src/instrumentation.ts
+++ b/src/instrumentation.ts
@@ -14,6 +14,7 @@
 let lastNotifiedVersion: string | undefined;
 
 const REMOTE_BIND_TIMEOUT_MS = 5_000;
+const LOG_PREFIX = "[Instrumentation]";
 
 /**
  * Remote OpenNext bind needs a Cloudflare token and a live API. CI, E2E, and
@@ -50,9 +51,9 @@ async function bindRemoteAuthDb(): Promise<void> {
   if (authDb && typeof authDb.prepare === "function") {
     (globalThis as { __AUTH_DB__?: typeof authDb }).__AUTH_DB__ = authDb;
     (process as unknown as { env: { AUTH_DB?: typeof authDb } }).env.AUTH_DB = authDb;
-    console.warn("[Instrumentation] AUTH_DB bound for local D1 auth");
+    console.warn(`${LOG_PREFIX} AUTH_DB bound for local D1 auth`);
   } else {
-    console.warn("[Instrumentation] AUTH_DB missing from Cloudflare context");
+    console.warn(`${LOG_PREFIX} AUTH_DB missing from Cloudflare context`);
   }
 }
 
@@ -63,7 +64,7 @@ async function fireDeployNotification(): Promise<void> {
   lastNotifiedVersion = version;
   const { slackDeployNotify } = await import("@/lib/slack-notify");
   slackDeployNotify({ version, stage, status: "succeeded", commitSha: version }).catch((err) =>
-    console.warn("[Instrumentation] slackDeployNotify failed:", err)
+    console.warn(`${LOG_PREFIX} slackDeployNotify failed:`, err)
   );
 }
 
@@ -76,11 +77,11 @@ export async function register() {
         const { isCloudflareApiHostError } = await import("@/lib/is-cloudflare-api-host-error");
         if (isCloudflareApiHostError(err)) {
           console.warn(
-            "[Instrumentation] Cloudflare remote context unavailable — auth will use local D1 sqlite fallback"
+            `${LOG_PREFIX} Cloudflare remote context unavailable — auth will use local D1 sqlite fallback`
           );
         } else {
           const msg = err instanceof Error ? err.message : String(err);
-          console.warn("[Instrumentation] Local AUTH_DB bind failed:", msg);
+          console.warn(`${LOG_PREFIX} Local AUTH_DB bind failed:`, msg);
         }
       }
     }

--- a/src/lib/appflowy.ts
+++ b/src/lib/appflowy.ts
@@ -97,10 +97,12 @@ async function getUserAccessToken(cfg: AppFlowyConfig): Promise<string | null> {
     return cachedUserToken.token;
   }
 
-  const res = await fetch(`${cfg.baseUrl}/gotrue/token`, {
+  // GoTrue on AppFlowy Cloud rejects body-only grant_type with
+  // unsupported_grant_type; the grant must be in the query string.
+  const res = await fetch(`${cfg.baseUrl}/gotrue/token?grant_type=password`, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ grant_type: "password", email: cfg.email, password: cfg.password }),
+    body: JSON.stringify({ email: cfg.email, password: cfg.password }),
     signal: AbortSignal.timeout(10_000),
   });
   if (!res.ok) {
@@ -324,6 +326,15 @@ export async function listAllViewsDeep(workspaceId: string): Promise<AppFlowyVie
     }
   } catch (e) {
     if (e instanceof AppFlowyNotConfiguredError) return [];
+    // Fresh workspaces often 404 on /folder until the first page exists
+    // (AppFlowy-Cloud#1507). Treat as empty rather than a hard failure.
+    if (e instanceof AppFlowyApiError && (e.status === 404 || e.status === 400)) {
+      cachedViewsByWorkspace.set(workspaceId, {
+        value: [],
+        expiresAtMs: now + VIEWS_TTL_MS,
+      });
+      return [];
+    }
     // Fall through to admin API.
   }
 
@@ -337,6 +348,9 @@ export async function listAllViewsDeep(workspaceId: string): Promise<AppFlowyVie
     return value;
   } catch (e) {
     if (e instanceof AppFlowyNotConfiguredError) return [];
+    if (e instanceof AppFlowyApiError && (e.status === 404 || e.status === 400)) {
+      return [];
+    }
     throw e;
   }
 }

--- a/src/lib/selfhosted-autologin.ts
+++ b/src/lib/selfhosted-autologin.ts
@@ -55,16 +55,16 @@ async function buildAppFlowyUrl(): Promise<AutologinResult> {
     );
   }
 
-  // GoTrue password-grant: POST {base}/gotrue/token with grant_type in body
-  // (Query param form is deprecated; modern GoTrue requires all params in JSON body)
-  const grantUrl = `${base}/gotrue/token`;
+  // GoTrue on AppFlowy Cloud rejects body-only grant_type with
+  // unsupported_grant_type; the grant must be in the query string.
+  const grantUrl = `${base}/gotrue/token?grant_type=password`;
 
   let res: Response;
   try {
     res = await fetch(grantUrl, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ grant_type: "password", email, password }),
+      body: JSON.stringify({ email, password }),
       signal: AbortSignal.timeout(10_000),
     });
   } catch (err) {

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -41,6 +41,11 @@ function appUrl(path: string, request: NextRequest): URL {
 
 const IS_DEV = process.env.NODE_ENV === "development";
 
+const ADMIN_PATH = "/admin";
+const ADMIN_PATH_EN = "/en/admin";
+const DASHBOARD_PATH = "/dashboard";
+const DASHBOARD_PATH_EN = "/en/dashboard";
+
 const ALLOWED_ORIGINS = ["https://cloudless.gr", "https://www.cloudless.gr"];
 
 function isAllowedOrigin(origin: string): boolean {
@@ -321,6 +326,89 @@ async function handleApiRoute(
   return addCorsHeaders(addSecurityHeaders(response, nonce), request);
 }
 
+/** Builds the locale-aware `/auth/login?redirect=...` path for unauthenticated redirects. */
+function buildLoginRedirectPath(pathname: string): string {
+  const basePath = pathname.split("/")[1] ?? "";
+  if (LOCALES.includes(basePath)) {
+    const bare = pathname === `/${basePath}` ? "/" : pathname.slice(`${basePath}/`.length) || "/";
+    return `/${basePath}/auth/login?redirect=${encodeURIComponent(bare)}`;
+  }
+  return `/auth/login?redirect=${encodeURIComponent(pathname === "/" ? "/" : pathname)}`;
+}
+
+/** Validates the D1 session token and returns the appropriate response, or null to fall through to NextAuth. */
+async function handleD1SessionRoute(
+  request: NextRequest,
+  pathname: string,
+  nonce: string,
+  d1SessionToken: string,
+  isAdminRoute: boolean,
+  isPostLoginRoute: boolean
+): Promise<NextResponse | null> {
+  try {
+    const { getUserBySession, isAdmin, getAuthDbFromEnv } = await import("@/lib/auth-d1");
+    const db = getAuthDbFromEnv();
+    if (!db) return null;
+
+    const user = await getUserBySession(db, d1SessionToken);
+    if (!user) {
+      return NextResponse.redirect(appUrl(buildLoginRedirectPath(pathname), request), 307);
+    }
+
+    const isAdminUser = await isAdmin(db, user.id);
+
+    if (isPostLoginRoute) {
+      const dest = isAdminUser
+        ? (pathname.startsWith("/en") ? ADMIN_PATH_EN : ADMIN_PATH)
+        : (pathname.startsWith("/en") ? DASHBOARD_PATH_EN : DASHBOARD_PATH);
+      return NextResponse.redirect(appUrl(dest, request), 307);
+    }
+
+    if (isAdminRoute && !isAdminUser) {
+      const dest = pathname.startsWith("/en") ? DASHBOARD_PATH_EN : DASHBOARD_PATH;
+      return NextResponse.redirect(appUrl(dest, request), 307);
+    }
+
+    return continueToApp(request, pathname, nonce);
+  } catch {
+    return null;
+  }
+}
+
+/** Validates the NextAuth JWT session and returns the appropriate response. */
+async function handleNextAuthRoute(
+  request: NextRequest,
+  pathname: string,
+  nonce: string,
+  isAdminRoute: boolean,
+  isPostLoginRoute: boolean
+): Promise<NextResponse> {
+  try {
+    const { getToken } = await import("next-auth/jwt");
+    const session = await getToken({ req: request as unknown as Request });
+
+    if (!session) {
+      return NextResponse.redirect(appUrl(buildLoginRedirectPath(pathname), request), 307);
+    }
+
+    if (isPostLoginRoute) {
+      const dest = isAdminFromSession(session)
+        ? (pathname.startsWith("/en") ? ADMIN_PATH_EN : ADMIN_PATH)
+        : (pathname.startsWith("/en") ? DASHBOARD_PATH_EN : DASHBOARD_PATH);
+      return NextResponse.redirect(appUrl(dest, request), 307);
+    }
+
+    if (isAdminRoute && !isAdminFromSession(session)) {
+      const dest = pathname.startsWith("/en") ? DASHBOARD_PATH_EN : DASHBOARD_PATH;
+      return NextResponse.redirect(appUrl(dest, request), 307);
+    }
+
+    return continueToApp(request, pathname, nonce);
+  } catch {
+    return NextResponse.redirect(appUrl(buildLoginRedirectPath(pathname), request), 307);
+  }
+}
+
 async function handlePageRoute(
   request: NextRequest,
   pathname: string,
@@ -328,9 +416,7 @@ async function handlePageRoute(
 ): Promise<NextResponse> {
   const isRscPrefetch = request.nextUrl.searchParams.has("_rsc");
   if (!isRscPrefetch) {
-    const ip = getSharedClientIp(request);
-    const identifier = ip || "unknown";
-    
+    const identifier = getSharedClientIp(request) || "unknown";
     if (isRateLimited(identifier, RATE_LIMITS.ip.limit, RATE_LIMITS.ip.window, ipRequestMap)) {
       return new NextResponse("Too Many Requests", {
         status: 429,
@@ -345,118 +431,43 @@ async function handlePageRoute(
     cleanupStaleEntries(ipRequestMap);
   }
 
-  const isAdminRoute = pathname.startsWith("/admin") || pathname.startsWith("/en/admin");
-  const isDashboardRoute = pathname.startsWith("/dashboard") || pathname.startsWith("/en/dashboard");
-  const isPostLoginRoute = pathname.startsWith("/auth/post-login") || pathname === "/auth/post-login" ||
-                            pathname.startsWith("/en/auth/post-login");
-  
-  // Check for E2E admin bypass cookie
-  const e2eAdminCookie = request.cookies.get("e2e_admin")?.value === "1";
-  
+  const isAdminRoute = pathname.startsWith(ADMIN_PATH) || pathname.startsWith(ADMIN_PATH_EN);
+  const isDashboardRoute = pathname.startsWith(DASHBOARD_PATH) || pathname.startsWith(DASHBOARD_PATH_EN);
+  const isPostLoginRoute =
+    pathname.startsWith("/auth/post-login") ||
+    pathname === "/auth/post-login" ||
+    pathname.startsWith("/en/auth/post-login");
+
   if (isAdminRoute || isDashboardRoute || isPostLoginRoute) {
     // E2E bypass: if e2e_admin cookie is set, allow access to admin routes
+    const e2eAdminCookie = request.cookies.get("e2e_admin")?.value === "1";
     if (e2eAdminCookie && isAdminRoute) {
       return continueToApp(request, pathname, nonce);
     }
+
     const sessionToken = readNextAuthJwt(request);
     const sessionCookie = request.cookies.get("authjs.session-token")?.value;
     const chunkedCookie = request.cookies.get("authjs.session-token.0")?.value;
     const d1SessionToken = request.cookies.get("session_token")?.value;
-    
     const hasSessionToken = sessionToken || sessionCookie || chunkedCookie || d1SessionToken;
-    
-    if (hasSessionToken) {
-      if (d1SessionToken && !sessionToken && !sessionCookie && !chunkedCookie) {
-        try {
-          const { getUserBySession, isAdmin, getAuthDbFromEnv } = await import("@/lib/auth-d1");
-          const db = getAuthDbFromEnv();
-          
-          if (db) {
-            const user = await getUserBySession(db, d1SessionToken);
-            
-            if (!user) {
-              const basePath = pathname.split("/")[1] || "";
-              const isLocalized = LOCALES.includes(basePath);
-              const redirectPath = isLocalized
-                ? `/${basePath}/auth/login?redirect=${encodeURIComponent(pathname === `/${basePath}` ? "/" : pathname.slice(`${basePath}/`.length) || "/")}`
-                : `/auth/login?redirect=${encodeURIComponent(pathname === "/" ? "/" : pathname)}`;
-              return NextResponse.redirect(appUrl(redirectPath, request), 307);
-            }
-            
-            const isAdminUser = await isAdmin(db, user.id);
-            
-            if (isPostLoginRoute) {
-              if (isAdminUser) {
-                const adminUrl = pathname.startsWith("/en") ? "/en/admin" : "/admin";
-                return NextResponse.redirect(appUrl(adminUrl, request), 307);
-              } else {
-                const dashboardUrl = pathname.startsWith("/en") ? "/en/dashboard" : "/dashboard";
-                return NextResponse.redirect(appUrl(dashboardUrl, request), 307);
-              }
-            }
-            
-            if (isAdminRoute && !isAdminUser) {
-              const dashboardUrl = pathname.startsWith("/en") ? "/en/dashboard" : "/dashboard";
-              return NextResponse.redirect(appUrl(dashboardUrl, request), 307);
-            }
-            
-            return continueToApp(request, pathname, nonce);
-          }
-        } catch {
-        }
-      }
-      
-      try {
-        const { getToken } = await import("next-auth/jwt");
-        const session = await getToken({ req: request as unknown as Request });
-        
-        if (!session) {
-          const basePath = pathname.split("/")[1] || "";
-          const isLocalized = LOCALES.includes(basePath);
-          const redirectPath = isLocalized
-            ? `/${basePath}/auth/login?redirect=${encodeURIComponent(pathname === `/${basePath}` ? "/" : pathname.slice(`${basePath}/`.length) || "/")}`
-            : `/auth/login?redirect=${encodeURIComponent(pathname === "/" ? "/" : pathname)}`;
-          return NextResponse.redirect(appUrl(redirectPath, request), 307);
-        }
-        
-        if (isPostLoginRoute) {
-          if (isAdminFromSession(session)) {
-            const adminUrl = pathname.startsWith("/en") ? "/en/admin" : "/admin";
-            return NextResponse.redirect(appUrl(adminUrl, request), 307);
-          } else {
-            const dashboardUrl = pathname.startsWith("/en") ? "/en/dashboard" : "/dashboard";
-            return NextResponse.redirect(appUrl(dashboardUrl, request), 307);
-          }
-        }
-        
-        if (isAdminRoute && !isAdminFromSession(session)) {
-          const dashboardUrl = pathname.startsWith("/en") ? "/en/dashboard" : "/dashboard";
-          return NextResponse.redirect(appUrl(dashboardUrl, request), 307);
-        }
-      } catch {
-        const basePath = pathname.split("/")[1] || "";
-        const isLocalized = LOCALES.includes(basePath);
-        const redirectPath = isLocalized
-          ? `/${basePath}/auth/login?redirect=${encodeURIComponent(pathname === `/${basePath}` ? "/" : pathname.slice(`${basePath}/`.length) || "/")}`
-          : `/auth/login?redirect=${encodeURIComponent(pathname === "/" ? "/" : pathname)}`;
-        return NextResponse.redirect(appUrl(redirectPath, request), 307);
-      }
-    } else {
+
+    if (!hasSessionToken) {
       if (isPostLoginRoute) {
         const basePath = pathname.split("/")[1] || "";
-        const isLocalized = LOCALES.includes(basePath);
-        const loginPath = isLocalized ? `/${basePath}/auth/login` : "/auth/login";
+        const loginPath = LOCALES.includes(basePath) ? `/${basePath}/auth/login` : "/auth/login";
         return NextResponse.redirect(appUrl(loginPath, request), 307);
       }
-      
-      const basePath = pathname.split("/")[1] || "";
-      const isLocalized = LOCALES.includes(basePath);
-      const redirectPath = isLocalized
-        ? `/${basePath}/auth/login?redirect=${encodeURIComponent(pathname === `/${basePath}` ? "/" : pathname.slice(`${basePath}/`.length) || "/")}`
-        : `/auth/login?redirect=${encodeURIComponent(pathname === "/" ? "/" : pathname)}`;
-      
-      return NextResponse.redirect(appUrl(redirectPath, request), 307);
+      return NextResponse.redirect(appUrl(buildLoginRedirectPath(pathname), request), 307);
     }
+
+    if (d1SessionToken && !sessionToken && !sessionCookie && !chunkedCookie) {
+      const d1Result = await handleD1SessionRoute(
+        request, pathname, nonce, d1SessionToken, isAdminRoute, isPostLoginRoute
+      );
+      if (d1Result) return d1Result;
+    }
+
+    return handleNextAuthRoute(request, pathname, nonce, isAdminRoute, isPostLoginRoute);
   }
 
   return continueToApp(request, pathname, nonce);


### PR DESCRIPTION
## Summary
- Fix `pi-release-pull.sh` so unpack never rsyncs `standalone/` into its parent (infinite recursion that hung omv and 502'd cloudless.gr).
- AppFlowy GoTrue password grant uses `?grant_type=password` (body-only is rejected); empty `/folder` 404/400 treated as empty views.
- Add `scripts/seed-appflowy-cms-folders.mjs` and extract proxy auth helpers to reduce complexity.

## Test plan
- [x] Live site health `ok` / homepage 200 after pull-script fix on omv
- [x] AppFlowy workspace recreated with folder collab; CMS folders seeded under General
- [ ] CI unit/e2e on PR

Made with [Cursor](https://cursor.com)