### PR TITLE
fix(dev): stop [locale] from 404ing /api/auth/session

### DIFF
--- a/__tests__/auth-locale-routing-pin.test.ts
+++ b/__tests__/auth-locale-routing-pin.test.ts
@@ -1,0 +1,29 @@
+/**
+ * Pin the `[locale]` vs `/api/auth/*` routing split.
+ *
+ * Turbopack can bind `/api/auth/session` as locale=`api` (HTML 404) instead of
+ * the D1 session handler. The identity beforeFiles rewrite claims `/api`, and
+ * `dynamicParams = false` on the locale layout rejects unknown locale segments.
+ */
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const ROOT = resolve(__dirname, "..");
+
+describe("auth vs [locale] routing pins", () => {
+  it("claims /api/* in next.config.ts beforeFiles before [locale] matching", () => {
+    const source = readFileSync(resolve(ROOT, "next.config.ts"), "utf-8");
+    expect(source).toMatch(
+      /source:\s*["']\/api\/:path\*["']\s*,\s*destination:\s*["']\/api\/:path\*["']/
+    );
+  });
+
+  it("rejects unknown [locale] segments (dynamicParams = false)", () => {
+    const source = readFileSync(
+      resolve(ROOT, "src/app/[locale]/layout.tsx"),
+      "utf-8"
+    );
+    expect(source).toMatch(/export const dynamicParams = false/);
+  });
+});

--- a/next.config.ts
+++ b/next.config.ts
@@ -119,11 +119,15 @@ const nextConfig: NextConfig = {
   }
 };
 
-// Bypass Turbopack dev-mode bug where [locale] catches special metadata routes
-// in the App Router before next/manifest.ts can handle them.
+// Bypass Turbopack / App Router matching where `[locale]` can steal paths
+// that are not locale pages:
+// - `/manifest.webmanifest` (metadata route) → PWA API handler
+// - `/api/:path*` identity rewrite claims API routes before `[locale]=api`
+//   can 404 `/api/auth/session` (and sibling auth handlers) as HTML
 nextConfig.rewrites = async () => ({
   beforeFiles: [
     { source: "/manifest.webmanifest", destination: "/api/pwa-manifest" },
+    { source: "/api/:path*", destination: "/api/:path*" },
   ],
   afterFiles: [],
   fallback: [],

--- a/src/app/[locale]/layout.tsx
+++ b/src/app/[locale]/layout.tsx
@@ -33,6 +33,10 @@ export function generateStaticParams() {
   return routing.locales.map((locale) => ({ locale }));
 }
 
+// Only en|el|fr|de are valid `[locale]` values. Without this, Turbopack can
+// bind `/api/auth/session` as locale=`api` + missing `auth/session` page → HTML 404.
+export const dynamicParams = false;
+
 const BASE_URL = "https://cloudless.gr";
 
 export async function generateMetadata({


### PR DESCRIPTION
## Summary
- Identity rewrite claims `/api/:path*` in `next.config.ts` beforeFiles so `[locale]` cannot steal `/api/auth/session`.
- Locale layout sets `dynamicParams = false` so only `en|el|fr|de` are valid locale segments.
- Pins both with a unit test.

## Test plan
- [x] `pnpm exec vitest run __tests__/auth-locale-routing-pin.test.ts`
- [ ] Restart `pnpm dev` and confirm `GET /api/auth/session` returns 200 `{"user":null}` when logged out
- [ ] Confirm `/en/auth/login` still 200


Made with [Cursor](https://cursor.com)