### PR TITLE
Fix e2e hamburger visibility and mixed-cart close

### DIFF
--- a/e2e/deep/mobile-chrome.spec.ts
+++ b/e2e/deep/mobile-chrome.spec.ts
@@ -1,8 +1,13 @@
-import { test, expect } from "@playwright/test";
+import { test, expect, devices } from "@playwright/test";
 import { GUEST_STORAGE } from "./_helpers";
 import { openMobileNavIfNeeded } from "../helpers/mobile-nav";
 
-test.use({ storageState: GUEST_STORAGE });
+// CI e2e-full-coverage only runs --project=chromium (desktop). This file is
+// mobile chrome smoke, so pin Pixel 7 or the hamburger stays lg:hidden.
+test.use({
+  ...devices["Pixel 7"],
+  storageState: GUEST_STORAGE,
+});
 
 test.describe("Mobile chrome smoke", () => {
   test("hamburger, cart tap target, and chat panel fit the viewport", async ({ page }) => {

--- a/e2e/deep/store-cart-checkout.spec.ts
+++ b/e2e/deep/store-cart-checkout.spec.ts
@@ -35,12 +35,13 @@ test.describe("Store, cart, checkout", () => {
     await page.goto("/en/store/srv-cloud");
     await page.getByTestId("add-to-cart").click();
     await expect(page.getByTestId("cart-drawer")).toContainText(/cloud architecture audit/i);
-    await page.getByRole("button", { name: /close cart/i }).click();
+    await page.getByTestId("cart-drawer").getByRole("button", { name: /close cart/i }).click();
     await expect(page.getByTestId("cart-drawer")).toHaveAttribute("data-open", "false");
     await expect
       .poll(async () => page.evaluate(() => localStorage.getItem("cloudless-cart") ?? ""))
       .toMatch(/srv-cloud/);
     await page.goto("/en/store/srv-growth");
+    await expect(page.getByTestId("add-to-cart")).toBeVisible();
     await page.getByTestId("add-to-cart").click();
     const drawer = page.getByTestId("cart-drawer");
     await expect(drawer).toHaveAttribute("data-open", "true");


### PR DESCRIPTION
## Summary
- Pin Pixel 7 on `mobile-chrome.spec.ts` so CI `--project=chromium` does not hide the hamburger behind `lg:hidden`.
- Close the cart from `cart-drawer` so `Close cart` is not a strict-mode match against the header toggle.

## Test plan
- [ ] e2e-full-coverage: `hamburger, cart tap target, and chat panel fit the viewport` passes
- [ ] e2e-full-coverage: `mixed one-time + subscription cart blocks checkout in the UI` passes


Made with [Cursor](https://cursor.com)