### PR TITLE
Show Stripe daily bars on Unified analytics

### DIFF
--- a/__tests__/admin-unified-analytics-api.test.ts
+++ b/__tests__/admin-unified-analytics-api.test.ts
@@ -62,8 +62,9 @@ vi.mock("@/lib/api-auth", async (importOriginal) => {
 const ANALYTICS_URL = "http://localhost/api/admin/analytics/unified";
 const ALG_RS256 = "RS256";
 
-const { mockGetUnifiedFromLake } = vi.hoisted(() => ({
+const { mockGetUnifiedFromLake, mockGetStripeAnalyticsSnapshot } = vi.hoisted(() => ({
   mockGetUnifiedFromLake: vi.fn(),
+  mockGetStripeAnalyticsSnapshot: vi.fn(),
 }));
 
 vi.mock("jose", async () => {
@@ -82,6 +83,10 @@ vi.mock("jose", async () => {
 
 vi.mock("@/lib/datalake-serve", () => ({
   getUnifiedFromLake: (...a: unknown[]) => mockGetUnifiedFromLake(...a),
+}));
+
+vi.mock("@/lib/stripe-analytics-read", () => ({
+  getStripeAnalyticsSnapshot: (...a: unknown[]) => mockGetStripeAnalyticsSnapshot(...a),
 }));
 
 function makeAdminToken(): string {
@@ -107,23 +112,42 @@ const SAMPLE_UNIFIED = {
   lakeSource: "r2",
   seo: { clicks: 400, impressions: 8000, ctr: 0.05, position: 12, days: 28 },
   keywords: [{ query: "cloudless", clicks: 40 }],
-  pipeline: { stages: [{ stage: "Qualified", count: 3 }], rowCount: 1 },
+  pipeline: {
+    totalDeals: 3,
+    totalValue: 9000,
+    byStage: { LinkedIn: { count: 2, value: 5000 }, Direct: { count: 1, value: 4000 } },
+  },
   email: null,
   stripe: {
     totalOrders: 2,
     revenue: 150,
     activeSubscriptions: null,
     mrr: null,
-    rows: [{ day: "2026-08-01", revenue: 150 }],
+    rows: [{ metric: "paid_orders", value: 2, amount_eur: 150 }],
+    dailyTrend: [],
   },
   attribution: [{ channel: "organic", sessions: 10 }],
   sectionsMissing: [],
+};
+
+const SAMPLE_DAILY = {
+  windowDays: 28,
+  generatedAt: "2026-08-14T12:00:00.000Z",
+  totals: { events: 2, revenueMinor: 15000, processed: 2, failed: 0 },
+  byCategory: {},
+  byStatus: {},
+  byCurrency: {},
+  dailyTrend: [
+    { day: "2026-08-01", revenueMinor: 5000, events: 1, processed: 1, failed: 0 },
+    { day: "2026-08-02", revenueMinor: 10000, events: 1, processed: 1, failed: 0 },
+  ],
 };
 
 describe("GET /api/admin/analytics/unified", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockGetUnifiedFromLake.mockResolvedValue(SAMPLE_UNIFIED);
+    mockGetStripeAnalyticsSnapshot.mockResolvedValue(SAMPLE_DAILY);
   });
 
   it("returns 401 without token", async () => {
@@ -140,14 +164,17 @@ describe("GET /api/admin/analytics/unified", () => {
     expect(mockGetUnifiedFromLake).not.toHaveBeenCalled();
   });
 
-  it("returns 200 with lake-composed sources", async () => {
+  it("returns 200 with lake-composed sources and D1 dailyTrend", async () => {
     const { GET } = await import("@/app/api/admin/analytics/unified/route");
     const res = await GET(adminReq(ANALYTICS_URL));
     expect(res.status).toBe(200);
     const data = await res.json();
     expect(mockGetUnifiedFromLake).toHaveBeenCalledWith(28);
+    expect(mockGetStripeAnalyticsSnapshot).toHaveBeenCalledWith(28);
     expect(data.source).toBe("datalake-gold");
     expect(data).toHaveProperty("stripe");
+    expect(data.stripe.dailyTrend).toHaveLength(2);
+    expect(data.stripe.dailyTrendSource).toBe("d1-stripe-transaction");
     expect(data).toHaveProperty("seo");
     expect(data).toHaveProperty("pipeline");
     expect(data).toHaveProperty("email");
@@ -158,10 +185,11 @@ describe("GET /api/admin/analytics/unified", () => {
     expect(data._filters).toEqual({ days: 28 });
   });
 
-  it("passes days query to getUnifiedFromLake", async () => {
+  it("passes days query to getUnifiedFromLake and Stripe snapshot", async () => {
     const { GET } = await import("@/app/api/admin/analytics/unified/route");
     await GET(adminReq(`${ANALYTICS_URL}?days=14`));
     expect(mockGetUnifiedFromLake).toHaveBeenCalledWith(14);
+    expect(mockGetStripeAnalyticsSnapshot).toHaveBeenCalledWith(14);
   });
 
   it("surfaces null seo from the lake payload", async () => {
@@ -188,11 +216,22 @@ describe("GET /api/admin/analytics/unified", () => {
     expect(data.email).toBeNull();
   });
 
-  it("surfaces null stripe from the lake payload", async () => {
+  it("surfaces null stripe from the lake payload without calling D1", async () => {
     mockGetUnifiedFromLake.mockResolvedValue({ ...SAMPLE_UNIFIED, stripe: null });
     const { GET } = await import("@/app/api/admin/analytics/unified/route");
     const res = await GET(adminReq(ANALYTICS_URL));
     const data = await res.json();
     expect(data.stripe).toBeNull();
+    expect(mockGetStripeAnalyticsSnapshot).not.toHaveBeenCalled();
+  });
+
+  it("keeps empty dailyTrend when AUTH_DB is unbound", async () => {
+    mockGetStripeAnalyticsSnapshot.mockRejectedValue(new Error("AUTH_DB is not configured"));
+    const { GET } = await import("@/app/api/admin/analytics/unified/route");
+    const res = await GET(adminReq(ANALYTICS_URL));
+    const data = await res.json();
+    expect(res.status).toBe(200);
+    expect(data.stripe.dailyTrend).toEqual([]);
+    expect(data.stripe.dailyTrendSource).toBe("unavailable");
   });
 });

--- a/__tests__/lib/pipeline-from-espocrm-gold.test.ts
+++ b/__tests__/lib/pipeline-from-espocrm-gold.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+import { pipelineFromEspocrmGold } from "@/lib/datalake-serve";
+
+describe("pipelineFromEspocrmGold", () => {
+  it("maps lead-source funnel rows into Unified pipeline cards", () => {
+    const out = pipelineFromEspocrmGold([
+      {
+        lifecycle_stage: "contact",
+        lead_source: "LinkedIn",
+        contact_count: 10,
+        closed_won_deals: 2,
+        closed_won_revenue: 4000,
+      },
+      {
+        lifecycle_stage: "contact",
+        lead_source: "Direct",
+        contact_count: 4,
+        closed_won_deals: 0,
+        closed_won_revenue: 0,
+      },
+    ]);
+    expect(out.totalDeals).toBe(2);
+    expect(out.totalValue).toBe(4000);
+    expect(out.byStage.LinkedIn).toEqual({ count: 2, value: 4000 });
+    expect(out.byStage.Direct).toEqual({ count: 4, value: 0 });
+  });
+
+  it("falls back to contact counts when no closed-won deals exist", () => {
+    const out = pipelineFromEspocrmGold([
+      { lead_source: "Organic", contact_count: 7, closed_won_deals: 0, closed_won_revenue: 0 },
+    ]);
+    expect(out.totalDeals).toBe(7);
+    expect(out.byStage.Organic.count).toBe(7);
+  });
+});

--- a/docs/roadmap/agency-platform-backlog.md
+++ b/docs/roadmap/agency-platform-backlog.md
@@ -118,7 +118,7 @@ The dashboards already exist. Prefer wiring data the APIs already return over ne
 
 | Status | Item | Why | Notes |
 | --- | --- | --- | --- |
-| Wait | Sparkline / daily bars on Unified + Stripe `dailyTrend` | `stripe-analytics-read.ts` already computes per-day revenue; unified is point-in-time cards | Reuse History-tab SVG pattern |
+| **Done (this branch)** | Sparkline / daily bars on Unified + Stripe `dailyTrend` | `stripe-analytics-read.ts` already computes per-day revenue; unified is point-in-time cards | Shared `AdminDailyBars`; D1 trend on Unified; Cost page reuses the same strip |
 | Wait | Anomaly history table in admin | Five rules already fire to Slack only | Read D1 bookmarks / a small log; no alerting-config UI |
 | Wait | CSV export on datalake section tables | Operators already have gold tables with no download | After contact 360 |
 | Wait | Funnel `ab_variant` comparison | `/admin/ab-tests` toggles flags; it does not show funnel results | Distinct from flag admin |

--- a/src/app/[locale]/admin/analytics/unified/page.tsx
+++ b/src/app/[locale]/admin/analytics/unified/page.tsx
@@ -3,6 +3,7 @@
 import { fetchWithAuth } from "@/lib/fetch-with-auth";
 import { useEffect, useState } from "react";
 import { Link } from "@/i18n/navigation";
+import { AdminDailyBars } from "@/components/admin/AdminDailyBars";
 
 interface SeoData {
   clicks: number;
@@ -24,11 +25,21 @@ interface EmailData {
   avgClickRate?: number;
 }
 
+interface StripeDailyPoint {
+  day: string;
+  revenueMinor: number;
+  events: number;
+  processed: number;
+  failed: number;
+}
+
 interface StripeData {
   totalOrders: number;
   revenue: number;
-  activeSubscriptions: number;
-  mrr: number;
+  activeSubscriptions: number | null;
+  mrr: number | null;
+  dailyTrend?: StripeDailyPoint[];
+  dailyTrendSource?: string;
 }
 
 interface UnifiedData {
@@ -120,9 +131,13 @@ const CHANNEL_LABELS: Record<string, string> = {
   meta: "Meta",
 };
 
+function eurosMajor(amount: number): string {
+  return `€${amount.toLocaleString("en-IE", { maximumFractionDigits: 2 })}`;
+}
+
 function euros(cents: number | null): string {
   if (cents === null) return "—";
-  return `€${(cents / 100).toLocaleString("en-IE", { maximumFractionDigits: 2 })}`;
+  return eurosMajor(cents / 100);
 }
 
 function RoiSection({ roi }: Readonly<{ roi: RoiData | null }>) {
@@ -289,27 +304,42 @@ export default function UnifiedAnalyticsPage() {
           <div>
             <SectionHeader title="Revenue" icon="💳" href="/admin/orders" />
             {data.stripe ? (
-              <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
-                <KpiCard
-                  label="Total Revenue"
-                  value={`€${data.stripe.revenue.toLocaleString("en", { minimumFractionDigits: 0, maximumFractionDigits: 0 })}`}
-                  color="text-neon-green"
-                />
-                <KpiCard
-                  label="Total Orders"
-                  value={String(data.stripe.totalOrders)}
-                  color="text-neon-green"
-                />
-                <KpiCard
-                  label="Active Subscriptions"
-                  value={String(data.stripe.activeSubscriptions)}
-                  color="text-neon-blue"
-                />
-                <KpiCard
-                  label="MRR"
-                  value={`€${data.stripe.mrr.toLocaleString("en", { minimumFractionDigits: 0, maximumFractionDigits: 0 })}`}
-                  sub="monthly recurring"
-                  color="text-neon-blue"
+              <div className="space-y-3">
+                <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
+                  <KpiCard
+                    label="Total Revenue"
+                    value={eurosMajor(data.stripe.revenue)}
+                    color="text-neon-green"
+                  />
+                  <KpiCard
+                    label="Total Orders"
+                    value={String(data.stripe.totalOrders)}
+                    color="text-neon-green"
+                  />
+                  <KpiCard
+                    label="Active Subscriptions"
+                    value={
+                      data.stripe.activeSubscriptions == null
+                        ? "—"
+                        : String(data.stripe.activeSubscriptions)
+                    }
+                    color="text-neon-blue"
+                  />
+                  <KpiCard
+                    label="MRR"
+                    value={data.stripe.mrr == null ? "—" : eurosMajor(data.stripe.mrr)}
+                    sub="monthly recurring"
+                    color="text-neon-blue"
+                  />
+                </div>
+                <AdminDailyBars
+                  title="Daily revenue"
+                  unitLabel="EUR · D1 stripe_transaction"
+                  points={(data.stripe.dailyTrend ?? []).map((d) => ({
+                    day: d.day,
+                    value: d.revenueMinor / 100,
+                  }))}
+                  formatValue={eurosMajor}
                 />
               </div>
             ) : (
@@ -366,7 +396,7 @@ export default function UnifiedAnalyticsPage() {
                 />
                 <div className="bg-void-light/50 rounded-xl border border-slate-800 p-5">
                   <div className="font-heading mb-2 text-xs font-semibold tracking-widest text-slate-500 uppercase">
-                    By Stage
+                    By lead source
                   </div>
                   <div className="space-y-1">
                     {Object.entries(data.pipeline.byStage).map(([stage, { count }]) => (

--- a/src/app/[locale]/admin/cost/page.tsx
+++ b/src/app/[locale]/admin/cost/page.tsx
@@ -10,6 +10,7 @@ import { fetchWithAuth } from "@/lib/fetch-with-auth";
 import { useEffect, useState } from "react";
 import { Link } from "@/i18n/navigation";
 import { Spinner, ErrorMsg } from "@/components/admin/CampaignPageKit";
+import { AdminDailyBars } from "@/components/admin/AdminDailyBars";
 
 interface CostByServiceRow {
   service: string;
@@ -78,7 +79,6 @@ export default function CostAdminPage() {
     load();
   }, []);
 
-  const maxDaily = data ? Math.max(...data.dailyTrend.map((d) => d.total_usd), 0.01) : 0;
   const maxService = data ? Math.max(...data.topServices.map((s) => s.total_usd), 0.01) : 0;
   const sevenDayAvg = data
     ? data.dailyTrend.slice(-7).reduce((sum, d) => sum + d.total_usd, 0) /
@@ -162,29 +162,14 @@ export default function CostAdminPage() {
             </div>
           </div>
 
-          {/* Daily trend bar chart */}
-          <div className="mb-8 rounded-xl border border-slate-800 bg-slate-900/40 p-6">
-            <div className="mb-3 flex items-baseline justify-between">
-              <div className="font-mono text-sm text-white">Daily spend (last 30 days)</div>
-              <div className="font-mono text-[10px] text-slate-500">USD</div>
-            </div>
-            <div className="flex h-32 items-end gap-1">
-              {data.dailyTrend.map((d) => {
-                const heightPct = Math.max((d.total_usd / maxDaily) * 100, 1);
-                return (
-                  <div
-                    key={d.cost_date}
-                    className="flex-1 rounded-t bg-emerald-500/60 transition-colors hover:bg-emerald-500/90"
-                    style={{ height: `${heightPct}%` }}
-                    title={`${d.cost_date}: ${fmtUsd(d.total_usd)}`}
-                  />
-                );
-              })}
-            </div>
-            <div className="mt-2 flex justify-between font-mono text-[10px] text-slate-500">
-              <span>{data.dailyTrend[0]?.cost_date ?? ""}</span>
-              <span>{data.dailyTrend[data.dailyTrend.length - 1]?.cost_date ?? ""}</span>
-            </div>
+          <div className="mb-8">
+            <AdminDailyBars
+              title="Daily spend (last 30 days)"
+              unitLabel="USD"
+              points={data.dailyTrend.map((d) => ({ day: d.cost_date, value: d.total_usd }))}
+              formatValue={fmtUsd}
+              barClassName="bg-emerald-500/60 hover:bg-emerald-500/90"
+            />
           </div>
 
           {/* Top services bar chart */}

--- a/src/app/[locale]/admin/orders/page.tsx
+++ b/src/app/[locale]/admin/orders/page.tsx
@@ -166,7 +166,7 @@ export default function AdminOrdersPage() {
                       {order.id.slice(0, 20)}…
                     </td>
                     <td className="px-6 py-4 font-mono text-white">{order.email}</td>
-                    <td className="max-w-[200px] truncate px-6 py-4 text-slate-300">
+                    <td className="max-w-50 truncate px-6 py-4 text-slate-300">
                       {order.items.map((i) => i.description).join(", ") || "—"}
                     </td>
                     <td className="px-6 py-4 font-mono text-white">

--- a/src/app/api/admin/analytics/unified/route.ts
+++ b/src/app/api/admin/analytics/unified/route.ts
@@ -1,8 +1,9 @@
 import { NextRequest, NextResponse } from "next/server";
 import { requireAdmin } from "@/lib/api-auth";
 import { getUnifiedFromLake } from "@/lib/datalake-serve";
+import { getStripeAnalyticsSnapshot } from "@/lib/stripe-analytics-read";
 
-/** Unified analytics — composed from datalake gold (no live GSC/Espo/Stripe). */
+/** Unified analytics — gold KPIs + D1 Stripe dailyTrend when AUTH_DB is bound. */
 export async function GET(request: NextRequest) {
   const auth = await requireAdmin(request);
   if (!auth.ok) return auth.response;
@@ -13,11 +14,27 @@ export async function GET(request: NextRequest) {
   );
 
   const payload = await getUnifiedFromLake(days);
+  const stripe =
+    payload.stripe && typeof payload.stripe === "object"
+      ? ({ ...(payload.stripe as Record<string, unknown>) } as Record<string, unknown>)
+      : null;
+
+  if (stripe) {
+    try {
+      const snap = await getStripeAnalyticsSnapshot(days);
+      stripe.dailyTrend = snap.dailyTrend;
+      stripe.dailyTrendSource = "d1-stripe-transaction";
+    } catch {
+      stripe.dailyTrend = Array.isArray(stripe.dailyTrend) ? stripe.dailyTrend : [];
+      stripe.dailyTrendSource = "unavailable";
+    }
+  }
+
   return NextResponse.json({
     seo: payload.seo,
     pipeline: payload.pipeline,
     email: payload.email,
-    stripe: payload.stripe,
+    stripe,
     attribution: payload.attribution,
     keywords: payload.keywords,
     sectionsMissing: payload.sectionsMissing,

--- a/src/components/admin/AdminDailyBars.tsx
+++ b/src/components/admin/AdminDailyBars.tsx
@@ -1,0 +1,56 @@
+"use client";
+
+/**
+ * Simple daily bar strip — same pattern as /admin/cost.
+ * Pass already-scaled values (e.g. euros or USD), not minor units.
+ */
+export function AdminDailyBars({
+  title,
+  unitLabel,
+  points,
+  formatValue,
+  barClassName = "bg-neon-green/60 hover:bg-neon-green/90",
+}: Readonly<{
+  title: string;
+  unitLabel: string;
+  points: ReadonlyArray<{ day: string; value: number }>;
+  formatValue: (value: number) => string;
+  barClassName?: string;
+}>) {
+  if (points.length === 0) {
+    return (
+      <div className="rounded-xl border border-slate-800 bg-slate-900/40 p-6">
+        <div className="font-mono text-sm text-white">{title}</div>
+        <p className="mt-2 font-mono text-xs text-slate-500">No daily series yet.</p>
+      </div>
+    );
+  }
+
+  const max = Math.max(...points.map((p) => p.value), 0.01);
+
+  return (
+    <div className="rounded-xl border border-slate-800 bg-slate-900/40 p-6">
+      <div className="mb-3 flex items-baseline justify-between">
+        <div className="font-mono text-sm text-white">{title}</div>
+        <div className="font-mono text-[10px] text-slate-500">{unitLabel}</div>
+      </div>
+      <div className="flex h-32 items-end gap-1">
+        {points.map((p) => {
+          const heightPct = Math.max((p.value / max) * 100, 1);
+          return (
+            <div
+              key={p.day}
+              className={`flex-1 rounded-t transition-colors ${barClassName}`}
+              style={{ height: `${heightPct}%` }}
+              title={`${p.day}: ${formatValue(p.value)}`}
+            />
+          );
+        })}
+      </div>
+      <div className="mt-2 flex justify-between font-mono text-[10px] text-slate-500">
+        <span>{points[0]?.day ?? ""}</span>
+        <span>{points[points.length - 1]?.day ?? ""}</span>
+      </div>
+    </div>
+  );
+}

--- a/src/lib/datalake-serve.ts
+++ b/src/lib/datalake-serve.ts
@@ -209,7 +209,13 @@ export async function getUnifiedFromLake(days = 28): Promise<Record<string, unkn
   const attribution = byName.get("attribution");
 
   const stripeRows = stripe?.rows ?? [];
-  const revenue = stripeRows.reduce((a, r) => a + (Number(r.revenue ?? r.amount) || 0), 0);
+  const paidOrders = stripeRows.find((r) => String(r.metric) === "paid_orders");
+  const revenue = paidOrders
+    ? Number(paidOrders.amount_eur ?? paidOrders.revenue ?? paidOrders.amount) || 0
+    : stripeRows.reduce((a, r) => a + (Number(r.amount_eur ?? r.revenue ?? r.amount) || 0), 0);
+  const totalOrders = paidOrders
+    ? Number(paidOrders.value ?? paidOrders.count) || 0
+    : (stripe?.rowCount ?? 0);
 
   return {
     days,
@@ -218,24 +224,47 @@ export async function getUnifiedFromLake(days = 28): Promise<Record<string, unkn
     lakeSource: dash.source,
     seo: seo.error ? null : seo.snapshot,
     keywords: seo.keywords.slice(0, 10),
-    pipeline: espocrm?.error
-      ? null
-      : {
-          stages: espocrm?.rows ?? [],
-          rowCount: espocrm?.rowCount ?? 0,
-        },
+    pipeline: espocrm?.error ? null : pipelineFromEspocrmGold(espocrm?.rows ?? []),
     email: null,
     stripe: stripe?.error
       ? null
       : {
-          totalOrders: stripe?.rowCount ?? 0,
+          totalOrders,
           revenue,
           activeSubscriptions: null,
           mrr: null,
           rows: stripeRows.slice(0, 30),
+          dailyTrend: [],
         },
     attribution: attribution?.error ? null : (attribution?.rows ?? []),
     sectionsMissing: dash.sections.filter((s) => s.error).map((s) => s.section),
+  };
+}
+
+/** Map gold espocrm_funnel (by lead source) into the Unified pipeline card shape. */
+export function pipelineFromEspocrmGold(rows: Record<string, unknown>[]): {
+  totalDeals: number;
+  totalValue: number;
+  byStage: Record<string, { count: number; value: number }>;
+} {
+  const byStage: Record<string, { count: number; value: number }> = {};
+  let totalDeals = 0;
+  let totalValue = 0;
+  let totalContacts = 0;
+  for (const r of rows) {
+    const stage = String(r.lead_source ?? r.lifecycle_stage ?? "(none)");
+    const deals = Number(r.closed_won_deals) || 0;
+    const contacts = Number(r.contact_count) || 0;
+    const value = Number(r.closed_won_revenue) || 0;
+    byStage[stage] = { count: deals > 0 ? deals : contacts, value };
+    totalDeals += deals;
+    totalValue += value;
+    totalContacts += contacts;
+  }
+  return {
+    totalDeals: totalDeals > 0 ? totalDeals : totalContacts,
+    totalValue,
+    byStage,
   };
 }
 
@@ -254,9 +283,11 @@ export async function getRoiFromLake(days = 30): Promise<Record<string, unknown>
   const impressions = linkedinRows.reduce((a, r) => a + (Number(r.impressions) || 0), 0);
   const clicks = linkedinRows.reduce((a, r) => a + (Number(r.clicks) || 0), 0);
   const stripeRows = stripe?.rows ?? [];
-  const revenueCents = Math.round(
-    stripeRows.reduce((a, r) => a + (Number(r.revenue ?? r.amount) || 0), 0) * 100
-  );
+  const paidOrders = stripeRows.find((r) => String(r.metric) === "paid_orders");
+  const revenueMajor = paidOrders
+    ? Number(paidOrders.amount_eur ?? paidOrders.revenue ?? paidOrders.amount) || 0
+    : stripeRows.reduce((a, r) => a + (Number(r.amount_eur ?? r.revenue ?? r.amount) || 0), 0);
+  const revenueCents = Math.round(revenueMajor * 100);
 
   const channels = [
     {


### PR DESCRIPTION
## Summary
- Attach D1 `stripe-analytics-read` `dailyTrend` to `GET /api/admin/analytics/unified` and render daily revenue bars on `/admin/analytics/unified`.
- Extract shared `AdminDailyBars` (also used by `/admin/cost`).
- Map gold `espocrm_funnel` rows into `{ totalDeals, totalValue, byStage }` so the Unified pipeline section no longer crashes / shows blanks.
- Prefer `paid_orders.amount_eur` for gold Stripe totals (avoid double-counting type_* rows).

## Test plan
- [x] `pnpm exec vitest run __tests__/admin-unified-analytics-api.test.ts __tests__/lib/pipeline-from-espocrm-gold.test.ts __tests__/stripe-analytics-read.test.ts`
- [ ] Open `/admin/analytics/unified` as admin and confirm daily bars render when D1 has stripe_transaction rows
- [ ] Confirm `/admin/cost` daily strip still looks the same


Made with [Cursor](https://cursor.com)