### PR TITLE
Add CSV export on admin datalake section tables

### DIFF
--- a/__tests__/lib/csv-export.test.ts
+++ b/__tests__/lib/csv-export.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest";
+import { escapeCsvCell, rowsToCsv } from "@/lib/csv-export";
+
+describe("escapeCsvCell", () => {
+  it("leaves plain values alone and empties nullish", () => {
+    expect(escapeCsvCell(null)).toBe("");
+    expect(escapeCsvCell(undefined)).toBe("");
+    expect(escapeCsvCell(12)).toBe("12");
+    expect(escapeCsvCell("plain")).toBe("plain");
+  });
+
+  it("quotes commas, quotes, and newlines", () => {
+    expect(escapeCsvCell('say "hi"')).toBe('"say ""hi"""');
+    expect(escapeCsvCell("a,b")).toBe('"a,b"');
+    expect(escapeCsvCell("a\nb")).toBe('"a\nb"');
+  });
+});
+
+describe("rowsToCsv", () => {
+  it("emits header + CRLF rows using column labels", () => {
+    const csv = rowsToCsv(
+      [
+        { key: "day", label: "Day" },
+        { key: "revenue", label: "Revenue" },
+      ],
+      [
+        { day: "2026-08-01", revenue: 12.5 },
+        { day: "note,with,comma", revenue: null },
+      ]
+    );
+    expect(csv).toBe('Day,Revenue\r\n2026-08-01,12.5\r\n"note,with,comma",');
+  });
+});

--- a/docs/roadmap/agency-platform-backlog.md
+++ b/docs/roadmap/agency-platform-backlog.md
@@ -120,7 +120,7 @@ The dashboards already exist. Prefer wiring data the APIs already return over ne
 | --- | --- | --- | --- |
 | **Done (this branch)** | Sparkline / daily bars on Unified + Stripe `dailyTrend` | `stripe-analytics-read.ts` already computes per-day revenue; unified is point-in-time cards | Shared `AdminDailyBars`; D1 trend on Unified; Cost page reuses the same strip |
 | **Done (this branch)** | Anomaly history table in admin | Five rules already fire to Slack only | D1 `ad_analytics_anomaly_event` + bookmark fallback; `/admin/campaigns/anomalies` |
-| Wait | CSV export on datalake section tables | Operators already have gold tables with no download | After contact 360 |
+| **Done (this branch)** | CSV export on datalake section tables | Operators already have gold tables with no download | Per-section client CSV from loaded rows (`csv-export.ts`) |
 | **Done (this branch)** | Funnel `ab_variant` comparison | `/admin/ab-tests` toggles flags; it does not show funnel results | Pivot + rates on `/admin/analytics/funnel` (`funnel-ab-compare.ts`) |
 | **Done (this branch)** | Restore client reports with gold sections (GSC / Stripe) | Only if `/admin/reports` is restored | Nav + generate sections from `report-gold-sections.ts` |
 

--- a/src/app/[locale]/admin/analytics/datalake/page.tsx
+++ b/src/app/[locale]/admin/analytics/datalake/page.tsx
@@ -325,7 +325,10 @@ export default function DatalakeDashboardPage() {
                   {meta.subtitle}
                 </p>
               </div>
-              <div className="flex items-center gap-3 text-xs" style={{ color: "var(--ink-muted)" }}>
+              <div
+                className="flex items-center gap-3 text-xs"
+                style={{ color: "var(--ink-muted)" }}
+              >
                 {s.error ? "error" : `${s.rowCount ?? s.rows?.length ?? 0} rows`}
                 {s.fromCache && !s.error && (
                   <span

--- a/src/app/[locale]/admin/analytics/datalake/page.tsx
+++ b/src/app/[locale]/admin/analytics/datalake/page.tsx
@@ -9,6 +9,7 @@
 
 import { useCallback, useEffect, useState } from "react";
 import { fetchWithAuth } from "@/lib/fetch-with-auth";
+import { downloadCsvFile, rowsToCsv } from "@/lib/csv-export";
 
 type Row = Record<string, string | number | null>;
 
@@ -324,15 +325,33 @@ export default function DatalakeDashboardPage() {
                   {meta.subtitle}
                 </p>
               </div>
-              <div className="text-xs" style={{ color: "var(--ink-muted)" }}>
+              <div className="flex items-center gap-3 text-xs" style={{ color: "var(--ink-muted)" }}>
                 {s.error ? "error" : `${s.rowCount ?? s.rows?.length ?? 0} rows`}
                 {s.fromCache && !s.error && (
                   <span
-                    className="ml-2 rounded px-1.5 py-0.5"
+                    className="rounded px-1.5 py-0.5"
                     style={{ background: "var(--surface-subtle)" }}
                   >
                     gold
                   </span>
+                )}
+                {!s.error && (s.rows?.length ?? 0) > 0 && meta.columns.length > 0 && (
+                  <button
+                    type="button"
+                    className="rounded-md px-2 py-1 font-mono disabled:opacity-50"
+                    style={{
+                      border: "1px solid var(--border-strong)",
+                      background: "var(--surface-subtle)",
+                      color: "var(--ink-primary)",
+                    }}
+                    onClick={() => {
+                      const csv = rowsToCsv(meta.columns, s.rows ?? []);
+                      const day = (data?.generated_at ?? new Date().toISOString()).slice(0, 10);
+                      downloadCsvFile(`datalake-${s.section}-${day}.csv`, csv);
+                    }}
+                  >
+                    Download CSV
+                  </button>
                 )}
               </div>
             </header>

--- a/src/lib/csv-export.ts
+++ b/src/lib/csv-export.ts
@@ -19,9 +19,7 @@ export function rowsToCsv(
   rows: ReadonlyArray<Record<string, CsvCell>>
 ): string {
   const header = columns.map((c) => escapeCsvCell(c.label)).join(",");
-  const body = rows.map((row) =>
-    columns.map((c) => escapeCsvCell(row[c.key])).join(",")
-  );
+  const body = rows.map((row) => columns.map((c) => escapeCsvCell(row[c.key])).join(","));
   return [header, ...body].join("\r\n");
 }
 

--- a/src/lib/csv-export.ts
+++ b/src/lib/csv-export.ts
@@ -1,0 +1,40 @@
+/**
+ * Minimal CSV helpers for admin gold-table export.
+ * Escapes RFC 4180 fields; keeps raw cell values (not display-formatted).
+ */
+
+export type CsvCell = string | number | boolean | null | undefined;
+
+export function escapeCsvCell(value: CsvCell): string {
+  if (value == null) return "";
+  const str = typeof value === "string" ? value : String(value);
+  if (/[",\r\n]/.test(str)) {
+    return `"${str.replace(/"/g, '""')}"`;
+  }
+  return str;
+}
+
+export function rowsToCsv(
+  columns: ReadonlyArray<{ key: string; label: string }>,
+  rows: ReadonlyArray<Record<string, CsvCell>>
+): string {
+  const header = columns.map((c) => escapeCsvCell(c.label)).join(",");
+  const body = rows.map((row) =>
+    columns.map((c) => escapeCsvCell(row[c.key])).join(",")
+  );
+  return [header, ...body].join("\r\n");
+}
+
+/** Browser-only: trigger a file download from a CSV string. */
+export function downloadCsvFile(filename: string, csv: string): void {
+  const blob = new Blob([csv], { type: "text/csv;charset=utf-8" });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement("a");
+  a.href = url;
+  a.download = filename;
+  a.rel = "noopener";
+  document.body.appendChild(a);
+  a.click();
+  a.remove();
+  URL.revokeObjectURL(url);
+}


### PR DESCRIPTION
## Summary
- Add `csv-export` helper (RFC 4180 escape) and unit tests
- Per-section **Download CSV** on `/admin/analytics/datalake` from already-loaded rows (no new API)
- Mark CSV export Done in `agency-platform-backlog.md`

## Test plan
- [ ] `pnpm exec vitest run __tests__/lib/csv-export.test.ts`
- [ ] Open `/en/admin/analytics/datalake`, click Download CSV on a section with rows
- [ ] Confirm file opens in Excel/Sheets with correct headers and escaped commas


Made with [Cursor](https://cursor.com)