### PR TITLE
Use canonical Tailwind classes on Postiz and calendar admin

### DIFF
--- a/src/app/[locale]/admin/calendar/page.tsx
+++ b/src/app/[locale]/admin/calendar/page.tsx
@@ -190,7 +190,7 @@ export default function CalendarPage() {
             return (
               <div
                 key={idx}
-                className={`bg-void min-h-[80px] p-1.5 ${day ? "cursor-pointer transition-colors hover:bg-slate-800/30" : ""}`}
+                className={`bg-void min-h-20 p-1.5 ${day ? "cursor-pointer transition-colors hover:bg-slate-800/30" : ""}`}
                 onClick={() => {
                   if (!day || !dateStr) return;
                   setSelectedDate(dateStr);

--- a/src/app/[locale]/admin/postiz/page.tsx
+++ b/src/app/[locale]/admin/postiz/page.tsx
@@ -495,9 +495,7 @@ function ComposeTab({
                 key={img.id}
                 className="flex items-center gap-2 rounded border bg-gray-50 px-2 py-1 text-xs"
               >
-                <span className="max-w-50 truncate">
-                  {img.path.split("/").pop() ?? img.id}
-                </span>
+                <span className="max-w-50 truncate">{img.path.split("/").pop() ?? img.id}</span>
                 <button type="button" onClick={() => removeImage(img.id)} className="text-red-600">
                   ×
                 </button>
@@ -776,10 +774,7 @@ function CalendarTab({ posts, onReload }: { posts: PostizPost[] | null; onReload
               className="min-h-20 rounded border border-dashed border-gray-100"
             />
           ) : (
-            <div
-              key={cell.key}
-              className="min-h-20 space-y-0.5 rounded border border-gray-200 p-1"
-            >
+            <div key={cell.key} className="min-h-20 space-y-0.5 rounded border border-gray-200 p-1">
               <div className="text-right text-[10px] text-gray-500">{cell.day}</div>
               {(byDay.get(cell.key) ?? []).slice(0, 3).map((p) => (
                 <div

--- a/src/app/[locale]/admin/postiz/page.tsx
+++ b/src/app/[locale]/admin/postiz/page.tsx
@@ -495,7 +495,7 @@ function ComposeTab({
                 key={img.id}
                 className="flex items-center gap-2 rounded border bg-gray-50 px-2 py-1 text-xs"
               >
-                <span className="max-w-[200px] truncate">
+                <span className="max-w-50 truncate">
                   {img.path.split("/").pop() ?? img.id}
                 </span>
                 <button type="button" onClick={() => removeImage(img.id)} className="text-red-600">
@@ -773,12 +773,12 @@ function CalendarTab({ posts, onReload }: { posts: PostizPost[] | null; onReload
           cell === null ? (
             <div
               key={`empty-${idx}`}
-              className="min-h-[80px] rounded border border-dashed border-gray-100"
+              className="min-h-20 rounded border border-dashed border-gray-100"
             />
           ) : (
             <div
               key={cell.key}
-              className="min-h-[80px] space-y-0.5 rounded border border-gray-200 p-1"
+              className="min-h-20 space-y-0.5 rounded border border-gray-200 p-1"
             >
               <div className="text-right text-[10px] text-gray-500">{cell.day}</div>
               {(byDay.get(cell.key) ?? []).slice(0, 3).map((p) => (


### PR DESCRIPTION
## Summary
- Replace `min-h-[80px]` with `min-h-20` on Postiz calendar cells and the admin calendar grid.
- Replace `max-w-[200px]` with `max-w-50` on Postiz compose image labels.
- AppFlowy status `max-w-50` already landed in #1656.

## Test plan
- [ ] Confirm Tailwind IntelliSense no longer flags those classes on `/admin/postiz` and `/admin/calendar`.
- [ ] Spot-check layout of Postiz calendar cells and compose image chips.


Made with [Cursor](https://cursor.com)