### PR TITLE
Restore admin Reports with gold GSC and Stripe sections

### DIFF
--- a/__tests__/admin-reports-api.test.ts
+++ b/__tests__/admin-reports-api.test.ts
@@ -8,6 +8,8 @@ const isActiveCampaignConfiguredMock = vi.fn();
 const getPipelineStatsMock = vi.fn();
 const getEmailStatsMock = vi.fn();
 const getConfigMock = vi.fn();
+const buildGoldGscReportSectionMock = vi.fn();
+const buildGoldStripeReportSectionMock = vi.fn();
 
 vi.mock("@/lib/api-auth", () => ({
   requireAdmin: requireAdminMock,
@@ -21,6 +23,11 @@ vi.mock("@/lib/espocrm", () => ({
 vi.mock("@/lib/activecampaign", () => ({
   isActiveCampaignConfigured: isActiveCampaignConfiguredMock,
   getEmailStats: getEmailStatsMock,
+}));
+
+vi.mock("@/lib/report-gold-sections", () => ({
+  buildGoldGscReportSection: (...a: unknown[]) => buildGoldGscReportSectionMock(...a),
+  buildGoldStripeReportSection: (...a: unknown[]) => buildGoldStripeReportSectionMock(...a),
 }));
 
 vi.mock("@/lib/ssm-config", () => ({
@@ -72,6 +79,8 @@ describe("Admin Reports API routes", () => {
     getPipelineStatsMock.mockResolvedValue({ totalDeals: 5, totalValue: 5000, byStage: {} });
     getEmailStatsMock.mockResolvedValue({ totalContacts: 300, totalCampaigns: 10, totalLists: 2 });
     getConfigMock.mockResolvedValue({ ANTHROPIC_API_KEY: "" });
+    buildGoldGscReportSectionMock.mockResolvedValue(null);
+    buildGoldStripeReportSectionMock.mockResolvedValue(null);
     const integrations = await import("@/lib/integrations");
     vi.mocked(integrations.getIntegrationsAsync).mockResolvedValue({});
     await clearReports();
@@ -144,6 +153,31 @@ describe("Admin Reports API routes", () => {
       expect(res.status).toBe(201);
       expect(data.report.sections.some((s: { id: string }) => s.id === "pipeline")).toBe(false);
       expect(data.report.sections.some((s: { id: string }) => s.id === "email")).toBe(true);
+    });
+
+    it("includes gold GSC and Stripe sections when builders return data", async () => {
+      buildGoldGscReportSectionMock.mockResolvedValue({
+        id: "gsc",
+        title: "Organic Search (GSC gold)",
+        data: { clicks: 10, source: "datalake_gold" },
+      });
+      buildGoldStripeReportSectionMock.mockResolvedValue({
+        id: "stripe",
+        title: "Revenue (Stripe gold)",
+        data: { revenueEur: 99, source: "datalake_gold" },
+      });
+      const { POST } = await import("@/app/api/admin/reports/generate/route");
+      const res = await POST(
+        makePost("/api/admin/reports/generate", {
+          clientName: "Gold Client",
+          dateStart: "2026-04-01",
+          dateEnd: "2026-04-30",
+          includeSections: ["gsc", "stripe"],
+        })
+      );
+      const data = await res.json();
+      expect(res.status).toBe(201);
+      expect(data.report.sections.map((s: { id: string }) => s.id)).toEqual(["gsc", "stripe"]);
     });
 
     it("generates report and appears in list", async () => {

--- a/__tests__/lib/report-gold-sections.test.ts
+++ b/__tests__/lib/report-gold-sections.test.ts
@@ -1,0 +1,63 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const getSeoFromLakeMock = vi.fn();
+const getStripeSnapshotFromLakeMock = vi.fn();
+
+vi.mock("@/lib/datalake-serve", () => ({
+  getSeoFromLake: (...a: unknown[]) => getSeoFromLakeMock(...a),
+  getStripeSnapshotFromLake: (...a: unknown[]) => getStripeSnapshotFromLakeMock(...a),
+}));
+
+describe("report-gold-sections", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("builds a flat GSC section from gold SEO", async () => {
+    getSeoFromLakeMock.mockResolvedValue({
+      snapshot: { clicks: 100, impressions: 2000, ctr: 0.05, position: 8.2, days: 30 },
+      keywords: [
+        { query: "cloudless", clicks: 40, impressions: 400, ctr: 0.1, position: 3 },
+        { query: "hosting greece", clicks: 20, impressions: 300, ctr: 0.066, position: 9 },
+      ],
+      fetchedAt: "2026-08-14T00:00:00.000Z",
+      source: "datalake-gold",
+    });
+    const { buildGoldGscReportSection } = await import("@/lib/report-gold-sections");
+    const section = await buildGoldGscReportSection("2026-07-15", "2026-08-14");
+    expect(section?.id).toBe("gsc");
+    expect(section?.data.clicks).toBe(100);
+    expect(section?.data.ctrPercent).toBe(5);
+    expect(String(section?.data.topKeywords)).toContain("cloudless");
+  });
+
+  it("returns null when GSC gold is empty with error", async () => {
+    getSeoFromLakeMock.mockResolvedValue({
+      snapshot: { clicks: 0, impressions: 0, ctr: 0, position: 0, days: 28 },
+      keywords: [],
+      fetchedAt: "2026-08-14T00:00:00.000Z",
+      source: "datalake-gold",
+      error: "missing",
+    });
+    const { buildGoldGscReportSection } = await import("@/lib/report-gold-sections");
+    expect(await buildGoldGscReportSection("2026-07-01", "2026-07-31")).toBeNull();
+  });
+
+  it("builds a flat Stripe section from gold snapshot", async () => {
+    getStripeSnapshotFromLakeMock.mockResolvedValue({
+      windowDays: 30,
+      generatedAt: "2026-08-14T00:00:00.000Z",
+      totals: { events: 12, revenueMinor: 45000, processed: 12, failed: 0 },
+      byCategory: {},
+      byStatus: {},
+      byCurrency: {},
+      dailyTrend: [{ day: "2026-08-01", revenueMinor: 1000, events: 1, processed: 1, failed: 0 }],
+      source: "datalake-gold",
+    });
+    const { buildGoldStripeReportSection } = await import("@/lib/report-gold-sections");
+    const section = await buildGoldStripeReportSection("2026-07-15", "2026-08-14");
+    expect(section?.id).toBe("stripe");
+    expect(section?.data.revenueEur).toBe(450);
+    expect(section?.data.dailyPoints).toBe(1);
+  });
+});

--- a/docs/roadmap/agency-platform-backlog.md
+++ b/docs/roadmap/agency-platform-backlog.md
@@ -122,7 +122,7 @@ The dashboards already exist. Prefer wiring data the APIs already return over ne
 | **Done (this branch)** | Anomaly history table in admin | Five rules already fire to Slack only | D1 `ad_analytics_anomaly_event` + bookmark fallback; `/admin/campaigns/anomalies` |
 | Wait | CSV export on datalake section tables | Operators already have gold tables with no download | After contact 360 |
 | **Done (this branch)** | Funnel `ab_variant` comparison | `/admin/ab-tests` toggles flags; it does not show funnel results | Pivot + rates on `/admin/analytics/funnel` (`funnel-ab-compare.ts`) |
-| Wait | Restore client reports with gold sections (GSC / Stripe) | Only if `/admin/reports` is restored | Do not invent a report product first |
+| **Done (this branch)** | Restore client reports with gold sections (GSC / Stripe) | Only if `/admin/reports` is restored | Nav + generate sections from `report-gold-sections.ts` |
 
 ### UI out of scope
 

--- a/src/app/[locale]/admin/AdminLayoutClient.tsx
+++ b/src/app/[locale]/admin/AdminLayoutClient.tsx
@@ -114,6 +114,7 @@ const adminGroups: AdminGroup[] = [
     links: [
       { href: "/admin/campaigns", label: "Campaigns", Icon: Megaphone },
       { href: "/admin/campaigns/anomalies", label: "Ad Anomalies", Icon: AlertTriangle },
+      { href: "/admin/reports", label: "Reports", Icon: FileText },
       { href: "/admin/email", label: "Email", Icon: Mail },
       { href: "/admin/email/campaigns", label: "Email Campaigns", Icon: Mail },
       { href: "/admin/pipeline", label: "Pipeline", Icon: GitMerge },

--- a/src/app/[locale]/admin/reports/page.tsx
+++ b/src/app/[locale]/admin/reports/page.tsx
@@ -7,7 +7,9 @@ import type { Report } from "@/lib/reports";
 
 const SECTION_OPTIONS = [
   { id: "pipeline", label: "Lead Pipeline (EspoCRM)" },
-  { id: "email", label: "Email Marketing (EspoCRM)" },
+  { id: "email", label: "Email Marketing (ActiveCampaign)" },
+  { id: "gsc", label: "Organic Search (GSC gold)" },
+  { id: "stripe", label: "Revenue (Stripe gold)" },
 ];
 
 export default function ReportsPage() {
@@ -19,7 +21,7 @@ export default function ReportsPage() {
     clientName: "",
     dateStart: new Date(Date.now() - 30 * 86400000).toISOString().split("T")[0],
     dateEnd: new Date().toISOString().split("T")[0],
-    includeSections: ["pipeline", "email"] as string[],
+    includeSections: ["pipeline", "email", "gsc", "stripe"] as string[],
   }));
 
   async function loadReports() {
@@ -87,8 +89,9 @@ export default function ReportsPage() {
             Client Reports
           </h1>
           <p className="font-body mt-1 text-slate-400">
-            Generate performance reports combining data from all connected
-            platforms.
+            Generate client reports from EspoCRM / ActiveCampaign live stats plus
+            GSC and Stripe gold snapshots (no live Search Console or Stripe API on
+            generate).
           </p>
         </div>
         <button

--- a/src/app/api/admin/reports/generate/route.ts
+++ b/src/app/api/admin/reports/generate/route.ts
@@ -6,6 +6,10 @@ import {
   isActiveCampaignConfigured,
   getEmailStats,
 } from "@/lib/activecampaign";
+import {
+  buildGoldGscReportSection,
+  buildGoldStripeReportSection,
+} from "@/lib/report-gold-sections";
 import { getConfig } from "@/lib/ssm-config";
 import { mapIntegrationError } from "@/lib/api-errors";
 
@@ -122,6 +126,26 @@ export async function POST(request: NextRequest) {
       data: emailData as unknown as Record<string, unknown>,
       insights,
     });
+  }
+
+  if (includeSections.includes("gsc")) {
+    const gsc = await buildGoldGscReportSection(dateStart, dateEnd);
+    if (gsc) {
+      const insights = anthropicKey
+        ? await generateInsights(gsc.data, "Organic Search (GSC gold)", period, anthropicKey)
+        : "";
+      sections.push({ ...gsc, insights });
+    }
+  }
+
+  if (includeSections.includes("stripe")) {
+    const stripe = await buildGoldStripeReportSection(dateStart, dateEnd);
+    if (stripe) {
+      const insights = anthropicKey
+        ? await generateInsights(stripe.data, "Revenue (Stripe gold)", period, anthropicKey)
+        : "";
+      sections.push({ ...stripe, insights });
+    }
   }
 
   const updated = await updateReport(report.id, { sections, status: "ready" });

--- a/src/lib/report-gold-sections.ts
+++ b/src/lib/report-gold-sections.ts
@@ -3,10 +3,7 @@
  * No live GSC / Stripe API — only datalake-serve helpers.
  */
 
-import {
-  getSeoFromLake,
-  getStripeSnapshotFromLake,
-} from "@/lib/datalake-serve";
+import { getSeoFromLake, getStripeSnapshotFromLake } from "@/lib/datalake-serve";
 import type { ReportSection } from "@/lib/reports";
 
 function daysBetween(dateStart: string, dateEnd: string): number {

--- a/src/lib/report-gold-sections.ts
+++ b/src/lib/report-gold-sections.ts
@@ -1,0 +1,71 @@
+/**
+ * Flat gold-backed section payloads for client report generation.
+ * No live GSC / Stripe API — only datalake-serve helpers.
+ */
+
+import {
+  getSeoFromLake,
+  getStripeSnapshotFromLake,
+} from "@/lib/datalake-serve";
+import type { ReportSection } from "@/lib/reports";
+
+function daysBetween(dateStart: string, dateEnd: string): number {
+  const start = Date.parse(dateStart);
+  const end = Date.parse(dateEnd);
+  if (!Number.isFinite(start) || !Number.isFinite(end) || end < start) return 28;
+  return Math.max(1, Math.min(180, Math.round((end - start) / 86400000) + 1));
+}
+
+/** SEO snapshot + top keywords from gold `top_keywords`. */
+export async function buildGoldGscReportSection(
+  dateStart: string,
+  dateEnd: string
+): Promise<ReportSection | null> {
+  const days = daysBetween(dateStart, dateEnd);
+  const seo = await getSeoFromLake(days);
+  if (seo.error && seo.keywords.length === 0 && seo.snapshot.clicks === 0) {
+    return null;
+  }
+  const top = seo.keywords.slice(0, 5);
+  return {
+    id: "gsc",
+    title: "Organic Search (GSC gold)",
+    data: {
+      source: "datalake_gold",
+      days: seo.snapshot.days,
+      clicks: seo.snapshot.clicks,
+      impressions: seo.snapshot.impressions,
+      ctrPercent: Number((seo.snapshot.ctr * 100).toFixed(2)),
+      avgPosition: Number(seo.snapshot.position.toFixed(2)),
+      keywordCount: seo.keywords.length,
+      topKeywords: top.map((k) => `${k.query} (${k.clicks} clicks)`).join("; ") || "—",
+      fetchedAt: seo.fetchedAt,
+    },
+  };
+}
+
+/** Stripe totals from gold `stripe_revenue`. */
+export async function buildGoldStripeReportSection(
+  dateStart: string,
+  dateEnd: string
+): Promise<ReportSection | null> {
+  const days = daysBetween(dateStart, dateEnd);
+  const snap = await getStripeSnapshotFromLake(days);
+  if (snap.error && snap.totals.events === 0 && snap.totals.revenueMinor === 0) {
+    return null;
+  }
+  return {
+    id: "stripe",
+    title: "Revenue (Stripe gold)",
+    data: {
+      source: "datalake_gold",
+      windowDays: snap.windowDays,
+      events: snap.totals.events,
+      revenueEur: Number((snap.totals.revenueMinor / 100).toFixed(2)),
+      processed: snap.totals.processed,
+      failed: snap.totals.failed,
+      dailyPoints: snap.dailyTrend.length,
+      generatedAt: snap.generatedAt,
+    },
+  };
+}


### PR DESCRIPTION
## Summary
- Restore **Reports** in Marketing Hub admin nav (`/admin/reports` pages already existed)
- Add gold **GSC** + **Stripe** section options on generate (via `report-gold-sections.ts` → `datalake-serve`)
- Keep EspoCRM / ActiveCampaign live sections; no new report product
- Mark backlog Wait item Done

## Test plan
- [ ] `pnpm exec vitest run __tests__/lib/report-gold-sections.test.ts __tests__/admin-reports-api.test.ts`
- [ ] Admin nav shows Reports under Marketing Hub
- [ ] Generate with GSC + Stripe checked; view report shows flat gold metrics


Made with [Cursor](https://cursor.com)