### PR TITLE
Add EspoCRM D1 latency cache for admin CRM reads

### DIFF
--- a/__tests__/espocrm-cache.test.ts
+++ b/__tests__/espocrm-cache.test.ts
@@ -122,9 +122,8 @@ describe("espocrm-cache", () => {
   it("invalidatePrefix clears list keys", async () => {
     const db = createCacheDb();
     (globalThis as { __AUTH_DB__?: AuthDatabase }).__AUTH_DB__ = db;
-    const { setCached, invalidatePrefix, getCached, paramsHash } = await import(
-      "@/lib/espocrm-cache"
-    );
+    const { setCached, invalidatePrefix, getCached, paramsHash } =
+      await import("@/lib/espocrm-cache");
     await setCached("espocrm:listContacts", { limit: 10 }, [{ id: "1" }], 45);
     expect(await getCached("espocrm:listContacts", { limit: 10 }, 45)).not.toBeNull();
     await invalidatePrefix("espocrm:listContacts");

--- a/__tests__/espocrm-cache.test.ts
+++ b/__tests__/espocrm-cache.test.ts
@@ -1,0 +1,141 @@
+/**
+ * Unit tests for src/lib/espocrm-cache.ts — D1 espocrm_cache read-through.
+ */
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import type { AuthDatabase } from "@/lib/auth-d1";
+
+type CacheRow = {
+  pk: string;
+  sk: string;
+  result_json: string;
+  cached_at: number;
+  expires_at: number;
+};
+
+function createCacheDb(): AuthDatabase & {
+  rows: Map<string, CacheRow>;
+  failNext: boolean;
+} {
+  const state = { rows: new Map<string, CacheRow>(), failNext: false };
+  return {
+    get rows() {
+      return state.rows;
+    },
+    get failNext() {
+      return state.failNext;
+    },
+    set failNext(v: boolean) {
+      state.failNext = v;
+    },
+    prepare(query: string) {
+      const binds: unknown[] = [];
+      const stmt = {
+        bind(...args: unknown[]) {
+          binds.push(...args);
+          return stmt;
+        },
+        async run() {
+          if (state.failNext) {
+            state.failNext = false;
+            throw new Error("d1 down");
+          }
+          if (query.includes("INSERT OR REPLACE INTO espocrm_cache")) {
+            const [pk, sk, result_json, cached_at, expires_at] = binds as [
+              string,
+              string,
+              string,
+              number,
+              number,
+            ];
+            state.rows.set(`${pk}|${sk}`, { pk, sk, result_json, cached_at, expires_at });
+            return { success: true, meta: { changes: 1 } };
+          }
+          if (query.includes("DELETE FROM espocrm_cache")) {
+            if (query.includes("LIKE")) {
+              const exact = String(binds[0]);
+              const like = String(binds[1]).replace(/%$/, "");
+              for (const key of [...state.rows.keys()]) {
+                const pk = key.split("|")[0];
+                if (pk === exact || pk.startsWith(like)) state.rows.delete(key);
+              }
+            } else {
+              state.rows.delete(`${binds[0]}|${binds[1]}`);
+            }
+            return { success: true, meta: { changes: 1 } };
+          }
+          return { success: true, meta: { changes: 0 } };
+        },
+        async all() {
+          return { results: [], success: true };
+        },
+        async first<T = CacheRow>() {
+          if (state.failNext) {
+            state.failNext = false;
+            throw new Error("d1 down");
+          }
+          if (query.includes("FROM espocrm_cache")) {
+            return (state.rows.get(`${binds[0]}|${binds[1]}`) as T) ?? null;
+          }
+          return null;
+        },
+      };
+      return stmt;
+    },
+  };
+}
+
+describe("espocrm-cache", () => {
+  beforeEach(() => {
+    delete (globalThis as { __AUTH_DB__?: unknown }).__AUTH_DB__;
+  });
+  afterEach(() => {
+    delete (globalThis as { __AUTH_DB__?: unknown }).__AUTH_DB__;
+  });
+
+  it("paramsHash is order-invariant", async () => {
+    const { paramsHash } = await import("@/lib/espocrm-cache");
+    expect(paramsHash({ a: 1, b: 2 })).toBe(paramsHash({ b: 2, a: 1 }));
+  });
+
+  it("readThrough serves cache then live", async () => {
+    const db = createCacheDb();
+    (globalThis as { __AUTH_DB__?: AuthDatabase }).__AUTH_DB__ = db;
+    const { readThrough, paramsHash } = await import("@/lib/espocrm-cache");
+    let calls = 0;
+    const first = await readThrough("espocrm:listContacts", { limit: 10 }, async () => {
+      calls += 1;
+      return [{ id: "1" }];
+    });
+    expect(first.source).toBe("live");
+    expect(calls).toBe(1);
+    expect(db.rows.has(`espocrm:listContacts|${paramsHash({ limit: 10 })}`)).toBe(true);
+
+    const second = await readThrough("espocrm:listContacts", { limit: 10 }, async () => {
+      calls += 1;
+      return [{ id: "2" }];
+    });
+    expect(second.source).toBe("cache");
+    expect(calls).toBe(1);
+    expect(second.value).toEqual([{ id: "1" }]);
+  });
+
+  it("invalidatePrefix clears list keys", async () => {
+    const db = createCacheDb();
+    (globalThis as { __AUTH_DB__?: AuthDatabase }).__AUTH_DB__ = db;
+    const { setCached, invalidatePrefix, getCached, paramsHash } = await import(
+      "@/lib/espocrm-cache"
+    );
+    await setCached("espocrm:listContacts", { limit: 10 }, [{ id: "1" }], 45);
+    expect(await getCached("espocrm:listContacts", { limit: 10 }, 45)).not.toBeNull();
+    await invalidatePrefix("espocrm:listContacts");
+    expect(db.rows.has(`espocrm:listContacts|${paramsHash({ limit: 10 })}`)).toBe(false);
+  });
+
+  it("soft-fails when D1 throws", async () => {
+    const db = createCacheDb();
+    db.failNext = true;
+    (globalThis as { __AUTH_DB__?: AuthDatabase }).__AUTH_DB__ = db;
+    const { getCached } = await import("@/lib/espocrm-cache");
+    expect(await getCached("espocrm:listContacts", { limit: 10 })).toBeNull();
+  });
+});

--- a/docs/roadmap/agency-platform-backlog.md
+++ b/docs/roadmap/agency-platform-backlog.md
@@ -36,7 +36,7 @@ Percentages in the artifact (~75% marketing, ~60% CRM, ~15% ERP) are a snapshot,
 | Wait   | Marketing automation beyond ActiveCampaign            | Phase 2 in the artifact                                          | Use existing AC automations until the contact page shows gaps               |
 | **Done (this branch)** | Invoicing                                             | Agency-only finance                                              | Stripe Invoicing admin list/create/finalize/send — no finance-db            |
 | Wait   | Projects + time tracking                              | Agency delivery, not ERP                                         | After invoicing has a real operator workflow                                |
-| Wait   | EspoCRM D1 cache                                      | Latency, not a new CRM                                           | After Notion adapters are gone                                              |
+| **Done (this branch)** | EspoCRM D1 cache                                      | Latency, not a new CRM                                           | `espocrm_cache` + 45–60s read-through; write-path invalidate; not a CDP     |
 | Wait   | Docs / contracts                                      | Phase 6                                                          | AppFlowy already hosts docs; do not add `docs-db` as a Worker               |
 | Wait   | AI agents on Cloudflare Workers                       | Artifact Phase 7                                                 | Keep LangGraph / Bedrock on the Pi app path                                 |
 

--- a/migrations/0017-espocrm-cache.sql
+++ b/migrations/0017-espocrm-cache.sql
@@ -1,0 +1,12 @@
+-- Short-TTL EspoCRM API response cache (latency only — not a CRM store).
+-- Mirrors analytics_cache shape with a real PRIMARY KEY for INSERT OR REPLACE.
+CREATE TABLE IF NOT EXISTS espocrm_cache (
+  pk TEXT NOT NULL,
+  sk TEXT NOT NULL,
+  result_json TEXT,
+  cached_at INTEGER NOT NULL DEFAULT (strftime('%s', 'now')),
+  expires_at INTEGER,
+  PRIMARY KEY (pk, sk)
+);
+
+CREATE INDEX IF NOT EXISTS idx_espocrm_cache_expires ON espocrm_cache(expires_at);

--- a/src/lib/espocrm-cache.ts
+++ b/src/lib/espocrm-cache.ts
@@ -1,0 +1,192 @@
+import { createHash } from "crypto";
+import { getAuthDbFromEnv } from "@/lib/auth-d1";
+
+/**
+ * Read-through D1 cache for EspoCRM admin latency (not a second CRM).
+ *
+ * Table: AUTH_DB.espocrm_cache (migration 0017)
+ * Soft-fails when AUTH_DB is unbound — callers always get a live (or empty) result.
+ */
+
+export function paramsHash(params: Record<string, unknown> = {}): string {
+  const entries = Object.entries(params)
+    .filter(([, v]) => v !== undefined && v !== null)
+    .sort(([a], [b]) => a.localeCompare(b));
+  if (entries.length === 0) return "default";
+  return createHash("sha256").update(JSON.stringify(entries)).digest("hex").slice(0, 16);
+}
+
+export interface CacheEntry<T> {
+  payload: T;
+  storedAt: string;
+  ageSeconds: number;
+  stale: boolean;
+}
+
+interface CacheRow {
+  result_json: string | null;
+  cached_at: number | null;
+  expires_at: number | null;
+}
+
+function rowToEntry<T>(row: CacheRow, ttlSeconds: number): CacheEntry<T> | null {
+  const raw = row.result_json;
+  const cachedAt = row.cached_at;
+  if (!raw || typeof cachedAt !== "number") return null;
+
+  let payload: T;
+  try {
+    payload = JSON.parse(raw) as T;
+  } catch {
+    return null;
+  }
+
+  const ageSeconds = Math.max(0, Math.floor(Date.now() / 1000) - cachedAt);
+  const staleByTtl = ageSeconds > ttlSeconds;
+  const staleByExpiry =
+    typeof row.expires_at === "number" ? Math.floor(Date.now() / 1000) > row.expires_at : false;
+
+  return {
+    payload,
+    storedAt: new Date(cachedAt * 1000).toISOString(),
+    ageSeconds,
+    stale: staleByTtl || staleByExpiry,
+  };
+}
+
+export async function getCached<T = unknown>(
+  route: string,
+  params: Record<string, unknown> = {},
+  ttlSeconds = 45
+): Promise<CacheEntry<T> | null> {
+  const db = getAuthDbFromEnv();
+  if (!db) return null;
+  const hash = paramsHash(params);
+  try {
+    const row = await db
+      .prepare(
+        "SELECT result_json, cached_at, expires_at FROM espocrm_cache WHERE pk = ? AND sk = ?"
+      )
+      .bind(route, hash)
+      .first<CacheRow>();
+    if (!row) return null;
+    return rowToEntry<T>(row, ttlSeconds);
+  } catch (err) {
+    console.warn("[espocrm-cache] getCached failed:", err instanceof Error ? err.message : err);
+    return null;
+  }
+}
+
+export async function setCached<T = unknown>(
+  route: string,
+  params: Record<string, unknown> = {},
+  payload: T,
+  ttlSeconds = 45
+): Promise<void> {
+  const db = getAuthDbFromEnv();
+  if (!db) return;
+  const hash = paramsHash(params);
+  const now = Math.floor(Date.now() / 1000);
+  try {
+    await db
+      .prepare(
+        `INSERT OR REPLACE INTO espocrm_cache (pk, sk, result_json, cached_at, expires_at)
+         VALUES (?, ?, ?, ?, ?)`
+      )
+      .bind(route, hash, JSON.stringify(payload), now, now + ttlSeconds)
+      .run();
+  } catch (err) {
+    console.warn("[espocrm-cache] setCached failed:", err instanceof Error ? err.message : err);
+  }
+}
+
+export async function readThrough<T>(
+  route: string,
+  params: Record<string, unknown>,
+  fetcher: () => Promise<T>,
+  opts: { ttlSeconds?: number; acceptStaleSeconds?: number } = {}
+): Promise<{ value: T; source: "cache" | "live" | "stale"; ageSeconds: number }> {
+  const ttlSeconds = opts.ttlSeconds ?? 45;
+  const acceptStaleSeconds = opts.acceptStaleSeconds ?? 300;
+
+  const cached = await getCached<T>(route, params, ttlSeconds);
+  if (cached && !cached.stale) {
+    return { value: cached.payload, source: "cache", ageSeconds: cached.ageSeconds };
+  }
+
+  try {
+    const live = await fetcher();
+    void setCached(route, params, live, ttlSeconds);
+    return { value: live, source: "live", ageSeconds: 0 };
+  } catch (err) {
+    if (cached && cached.ageSeconds <= acceptStaleSeconds) {
+      console.warn(
+        `[espocrm-cache] live fetch failed for ${route}, serving stale (age=${cached.ageSeconds}s):`,
+        err instanceof Error ? err.message : err
+      );
+      return { value: cached.payload, source: "stale", ageSeconds: cached.ageSeconds };
+    }
+    throw err;
+  }
+}
+
+/** Best-effort delete of all keys whose pk equals or starts with prefix. */
+export async function invalidatePrefix(pkPrefix: string): Promise<void> {
+  const db = getAuthDbFromEnv();
+  if (!db) return;
+  try {
+    await db
+      .prepare("DELETE FROM espocrm_cache WHERE pk = ? OR pk LIKE ?")
+      .bind(pkPrefix, `${pkPrefix}%`)
+      .run();
+  } catch (err) {
+    console.warn(
+      "[espocrm-cache] invalidatePrefix failed:",
+      err instanceof Error ? err.message : err
+    );
+  }
+}
+
+export async function invalidateKey(
+  route: string,
+  params: Record<string, unknown> = {}
+): Promise<void> {
+  const db = getAuthDbFromEnv();
+  if (!db) return;
+  try {
+    await db
+      .prepare("DELETE FROM espocrm_cache WHERE pk = ? AND sk = ?")
+      .bind(route, paramsHash(params))
+      .run();
+  } catch (err) {
+    console.warn("[espocrm-cache] invalidateKey failed:", err instanceof Error ? err.message : err);
+  }
+}
+
+/** Clear list + pipeline aggregates after mutating writes. */
+export async function invalidateEspoListCaches(): Promise<void> {
+  await Promise.all([
+    invalidatePrefix("espocrm:listContacts"),
+    invalidatePrefix("espocrm:listCompanies"),
+    invalidatePrefix("espocrm:listTickets"),
+    invalidatePrefix("espocrm:listDeals"),
+    invalidatePrefix("espocrm:getDealsByStage"),
+    invalidatePrefix("espocrm:getPipelineStats"),
+  ]);
+}
+
+export async function invalidateEspoContactCaches(contactId: string): Promise<void> {
+  await Promise.all([
+    invalidateKey("espocrm:getContact", { id: contactId }),
+    invalidateKey("espocrm:listContactOpportunities", { id: contactId }),
+    invalidateKey("espocrm:listContactCases", { id: contactId }),
+    invalidateKey("espocrm:listContactNotes", { id: contactId }),
+    invalidateEspoListCaches(),
+  ]);
+}
+
+export const ESPO_CACHE_TTL = {
+  list: 45,
+  contact: 45,
+  pipeline: 60,
+} as const;

--- a/src/lib/espocrm.ts
+++ b/src/lib/espocrm.ts
@@ -776,7 +776,11 @@ export async function getPipelineStats(): Promise<{
   totalValue: number;
   byStage: Record<string, { count: number; value: number }>;
 }> {
-  const empty = { totalDeals: 0, totalValue: 0, byStage: {} as Record<string, { count: number; value: number }> };
+  const empty = {
+    totalDeals: 0,
+    totalValue: 0,
+    byStage: {} as Record<string, { count: number; value: number }>,
+  };
   const { value } = await readThrough(
     "espocrm:getPipelineStats",
     {},

--- a/src/lib/espocrm.ts
+++ b/src/lib/espocrm.ts
@@ -22,6 +22,12 @@
  */
 import { getIntegrationsAsync } from "@/lib/integrations";
 import { isEspoRecordId } from "@/lib/crm-contact-360-shared";
+import {
+  ESPO_CACHE_TTL,
+  invalidateEspoContactCaches,
+  invalidateEspoListCaches,
+  readThrough,
+} from "@/lib/espocrm-cache";
 
 const PAGE_SIZE = 100;
 const MAX_LIMIT = 100;
@@ -143,6 +149,7 @@ export async function upsertContact(contact: EspoContact): Promise<string | null
           method: "PUT",
           body: JSON.stringify(toEspoContactPayload(contact)),
         });
+        void invalidateEspoContactCaches(existing.id);
         return existing.id;
       }
     }
@@ -155,6 +162,7 @@ export async function upsertContact(contact: EspoContact): Promise<string | null
       return null;
     }
     const created = (await create.json()) as { id: string };
+    void invalidateEspoContactCaches(created.id);
     return created.id;
   } catch (err) {
     console.error("[EspoCRM] upsertContact error:", err);
@@ -227,37 +235,68 @@ function clampLimit(limit: number, fallback = 20): number {
 }
 
 export async function listContacts(limit = 10): Promise<unknown[]> {
-  try {
-    const res = await espoFetch(`/Contact?maxSize=${clampLimit(limit, 10)}`);
-    if (!res.ok) return [];
-    return (((await res.json()) as { list: unknown[] }).list ?? []) as unknown[];
-  } catch {
-    return [];
-  }
+  const clamped = clampLimit(limit, 10);
+  const { value } = await readThrough(
+    "espocrm:listContacts",
+    { limit: clamped },
+    async () => {
+      try {
+        const res = await espoFetch(`/Contact?maxSize=${clamped}`);
+        if (!res.ok) return [];
+        return (((await res.json()) as { list: unknown[] }).list ?? []) as unknown[];
+      } catch {
+        return [];
+      }
+    },
+    { ttlSeconds: ESPO_CACHE_TTL.list, acceptStaleSeconds: 300 }
+  );
+  return value;
 }
 
 export async function getContact(id: string): Promise<Record<string, unknown> | null> {
   if (!isEspoRecordId(id)) return null;
-  try {
-    const res = await espoFetch(`/Contact/${encodeURIComponent(id)}`);
-    if (!res.ok) return null;
-    return (await res.json()) as Record<string, unknown>;
-  } catch {
-    return null;
-  }
+  const { value } = await readThrough(
+    "espocrm:getContact",
+    { id },
+    async () => {
+      try {
+        const res = await espoFetch(`/Contact/${encodeURIComponent(id)}`);
+        if (!res.ok) return null;
+        return (await res.json()) as Record<string, unknown>;
+      } catch {
+        return null;
+      }
+    },
+    { ttlSeconds: ESPO_CACHE_TTL.contact, acceptStaleSeconds: 300 }
+  );
+  return value;
 }
 
 async function listContactLink(contactId: string, link: string): Promise<unknown[]> {
   if (!isEspoRecordId(contactId)) return [];
-  try {
-    const res = await espoFetch(
-      `/Contact/${encodeURIComponent(contactId)}/${link}?maxSize=${MAX_LIMIT}`
-    );
-    if (!res.ok) return [];
-    return (((await res.json()) as { list: unknown[] }).list ?? []) as unknown[];
-  } catch {
-    return [];
-  }
+  const pk =
+    link === "opportunities"
+      ? "espocrm:listContactOpportunities"
+      : link === "cases"
+        ? "espocrm:listContactCases"
+        : "espocrm:listContactNotes";
+  const { value } = await readThrough(
+    pk,
+    { id: contactId },
+    async () => {
+      try {
+        const res = await espoFetch(
+          `/Contact/${encodeURIComponent(contactId)}/${link}?maxSize=${MAX_LIMIT}`
+        );
+        if (!res.ok) return [];
+        return (((await res.json()) as { list: unknown[] }).list ?? []) as unknown[];
+      } catch {
+        return [];
+      }
+    },
+    { ttlSeconds: ESPO_CACHE_TTL.contact, acceptStaleSeconds: 300 }
+  );
+  return value;
 }
 
 export async function listContactOpportunities(contactId: string): Promise<unknown[]> {
@@ -273,13 +312,22 @@ export async function listContactNotes(contactId: string): Promise<unknown[]> {
 }
 
 export async function listTickets(limit = 20): Promise<unknown[]> {
-  try {
-    const res = await espoFetch(`/Case?maxSize=${clampLimit(limit)}`);
-    if (!res.ok) return [];
-    return (((await res.json()) as { list: unknown[] }).list ?? []) as unknown[];
-  } catch {
-    return [];
-  }
+  const clamped = clampLimit(limit);
+  const { value } = await readThrough(
+    "espocrm:listTickets",
+    { limit: clamped },
+    async () => {
+      try {
+        const res = await espoFetch(`/Case?maxSize=${clamped}`);
+        if (!res.ok) return [];
+        return (((await res.json()) as { list: unknown[] }).list ?? []) as unknown[];
+      } catch {
+        return [];
+      }
+    },
+    { ttlSeconds: ESPO_CACHE_TTL.list, acceptStaleSeconds: 300 }
+  );
+  return value;
 }
 
 interface TicketData {
@@ -317,6 +365,8 @@ export async function createTicket(
     throw new Error(`EspoCRM Case create failed ${res.status}: ${err.slice(0, 200)}`);
   }
   const created = (await res.json()) as { id: string };
+  void invalidateEspoListCaches();
+  if (contactId) void invalidateEspoContactCaches(contactId);
   return { id: created.id };
 }
 
@@ -343,23 +393,41 @@ export async function getPipelines(_objectType = "deals"): Promise<unknown[]> {
 }
 
 export async function listCompanies(limit = 20): Promise<unknown[]> {
-  try {
-    const res = await espoFetch(`/Account?maxSize=${clampLimit(limit)}`);
-    if (!res.ok) return [];
-    return (((await res.json()) as { list: unknown[] }).list ?? []) as unknown[];
-  } catch {
-    return [];
-  }
+  const clamped = clampLimit(limit);
+  const { value } = await readThrough(
+    "espocrm:listCompanies",
+    { limit: clamped },
+    async () => {
+      try {
+        const res = await espoFetch(`/Account?maxSize=${clamped}`);
+        if (!res.ok) return [];
+        return (((await res.json()) as { list: unknown[] }).list ?? []) as unknown[];
+      } catch {
+        return [];
+      }
+    },
+    { ttlSeconds: ESPO_CACHE_TTL.list, acceptStaleSeconds: 300 }
+  );
+  return value;
 }
 
 export async function listDeals(limit = 20): Promise<unknown[]> {
-  try {
-    const res = await espoFetch(`/Opportunity?maxSize=${clampLimit(limit)}`);
-    if (!res.ok) return [];
-    return (((await res.json()) as { list: unknown[] }).list ?? []) as unknown[];
-  } catch {
-    return [];
-  }
+  const clamped = clampLimit(limit);
+  const { value } = await readThrough(
+    "espocrm:listDeals",
+    { limit: clamped },
+    async () => {
+      try {
+        const res = await espoFetch(`/Opportunity?maxSize=${clamped}`);
+        if (!res.ok) return [];
+        return (((await res.json()) as { list: unknown[] }).list ?? []) as unknown[];
+      } catch {
+        return [];
+      }
+    },
+    { ttlSeconds: ESPO_CACHE_TTL.list, acceptStaleSeconds: 300 }
+  );
+  return value;
 }
 
 export async function listOwners(): Promise<unknown[]> {
@@ -575,6 +643,7 @@ export async function createDeal(data: DealData): Promise<string | null> {
       return null;
     }
     const created = (await res.json()) as { id: string };
+    void invalidateEspoListCaches();
     return created.id;
   } catch (err) {
     console.error("[EspoCRM] createDeal error:", err);
@@ -604,6 +673,7 @@ export async function updateDeal(
     });
     if (!res.ok) return null;
     const j = (await res.json()) as { id: string };
+    void invalidateEspoListCaches();
     return { id: j.id };
   } catch {
     return null;
@@ -615,20 +685,28 @@ export async function moveDealStage(id: string, stageId: string): Promise<{ id: 
 }
 
 export async function getDealsByStage(): Promise<Record<string, unknown[]>> {
-  try {
-    const all = await espoListAll<{ stage: string }>("Opportunity", {
-      select: "name,amount,stage,closeDate,createdAt,probability",
-    });
-    const grouped: Record<string, unknown[]> = {};
-    for (const d of all) {
-      const stage = d.stage ?? "Unknown";
-      if (!grouped[stage]) grouped[stage] = [];
-      grouped[stage].push(d);
-    }
-    return grouped;
-  } catch {
-    return {};
-  }
+  const { value } = await readThrough(
+    "espocrm:getDealsByStage",
+    {},
+    async () => {
+      try {
+        const all = await espoListAll<{ stage: string }>("Opportunity", {
+          select: "name,amount,stage,closeDate,createdAt,probability",
+        });
+        const grouped: Record<string, unknown[]> = {};
+        for (const d of all) {
+          const stage = d.stage ?? "Unknown";
+          if (!grouped[stage]) grouped[stage] = [];
+          grouped[stage].push(d);
+        }
+        return grouped;
+      } catch {
+        return {};
+      }
+    },
+    { ttlSeconds: ESPO_CACHE_TTL.pipeline, acceptStaleSeconds: 300 }
+  );
+  return value;
 }
 
 /* ─── Notes ───────────────────────────────────────────────────────────────── */
@@ -647,6 +725,7 @@ export async function createNote(dealId: string, body: string): Promise<{ id: st
     });
     if (!res.ok) return null;
     const j = (await res.json()) as { id: string };
+    void invalidateEspoListCaches();
     return { id: j.id };
   } catch {
     return null;
@@ -670,6 +749,7 @@ export async function createContactNote(
     });
     if (!res.ok) return null;
     const j = (await res.json()) as { id: string };
+    void invalidateEspoContactCaches(contactId);
     return { id: j.id };
   } catch {
     return null;
@@ -696,24 +776,33 @@ export async function getPipelineStats(): Promise<{
   totalValue: number;
   byStage: Record<string, { count: number; value: number }>;
 }> {
-  try {
-    const all = await espoListAll<{ stage: string; amount: number | null }>("Opportunity", {
-      select: "stage,amount",
-    });
-    const byStage: Record<string, { count: number; value: number }> = {};
-    let totalValue = 0;
-    for (const d of all) {
-      const stage = d.stage ?? "Unknown";
-      const val = Number(d.amount ?? 0) || 0;
-      if (!byStage[stage]) byStage[stage] = { count: 0, value: 0 };
-      byStage[stage].count++;
-      byStage[stage].value += val;
-      totalValue += val;
-    }
-    return { totalDeals: all.length, totalValue, byStage };
-  } catch {
-    return { totalDeals: 0, totalValue: 0, byStage: {} };
-  }
+  const empty = { totalDeals: 0, totalValue: 0, byStage: {} as Record<string, { count: number; value: number }> };
+  const { value } = await readThrough(
+    "espocrm:getPipelineStats",
+    {},
+    async () => {
+      try {
+        const all = await espoListAll<{ stage: string; amount: number | null }>("Opportunity", {
+          select: "stage,amount",
+        });
+        const byStage: Record<string, { count: number; value: number }> = {};
+        let totalValue = 0;
+        for (const d of all) {
+          const stage = d.stage ?? "Unknown";
+          const val = Number(d.amount ?? 0) || 0;
+          if (!byStage[stage]) byStage[stage] = { count: 0, value: 0 };
+          byStage[stage].count++;
+          byStage[stage].value += val;
+          totalValue += val;
+        }
+        return { totalDeals: all.length, totalValue, byStage };
+      } catch {
+        return empty;
+      }
+    },
+    { ttlSeconds: ESPO_CACHE_TTL.pipeline, acceptStaleSeconds: 300 }
+  );
+  return value;
 }
 
 /**


### PR DESCRIPTION
## Summary
- Migration `0017-espocrm-cache.sql` on `user-auth-db`
- `espocrm-cache.ts` read-through (45–60s TTL) wrapping list/get/pipeline Espo reads
- Write-path invalidation after contact/deal/ticket/note mutations
- Soft-fails without AUTH_DB; lake ETL path unchanged (analytics only)

## Ops
Apply remote: `npx wrangler d1 migrations apply user-auth-db --remote` (or execute `0017-espocrm-cache.sql`)

## Test plan
- [ ] `pnpm exec vitest run __tests__/espocrm-cache.test.ts`
- [ ] After migration: reload `/en/admin/crm` twice — second load should be faster
- [ ] Create/update contact or move deal — list cache clears


Made with [Cursor](https://cursor.com)