### PR TITLE
Close platform Wait items (CDP defer, AC, docs, AI path)

### DIFF
--- a/__tests__/contact-360-match-hints.test.ts
+++ b/__tests__/contact-360-match-hints.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "vitest";
+import { buildContact360MatchHints } from "@/lib/contact-360-match-hints";
+import { parseAppFlowyDocCategory } from "@/lib/appflowy-docs";
+
+describe("buildContact360MatchHints", () => {
+  it("skips joins when email is missing", () => {
+    const hints = buildContact360MatchHints({
+      email: "",
+      hasD1User: false,
+      stripeConfigured: true,
+      hasStripeCustomer: false,
+      eventCount: 0,
+      hasRfm: false,
+      hasFirstTouch: false,
+      goldMatchCount: 0,
+    });
+    expect(hints.hasEmail).toBe(false);
+    expect(hints.d1User).toBe("skipped");
+    expect(hints.summary).toMatch(/no primary email/i);
+  });
+
+  it("reports no_utm_events when there is no first touch", () => {
+    const hints = buildContact360MatchHints({
+      email: "a@b.com",
+      hasD1User: true,
+      stripeConfigured: true,
+      hasStripeCustomer: true,
+      eventCount: 2,
+      hasRfm: true,
+      hasFirstTouch: false,
+      goldMatchCount: 0,
+    });
+    expect(hints.attribution).toBe("no_utm_events");
+    expect(hints.summary).toMatch(/no UTM events/i);
+  });
+});
+
+describe("parseAppFlowyDocCategory", () => {
+  it("parses bracket and slash categories", () => {
+    expect(parseAppFlowyDocCategory("[Docs][Contracts] MSA")).toEqual({
+      category: "Contracts",
+      title: "MSA",
+    });
+    expect(parseAppFlowyDocCategory("[Docs] Contracts / NDA")).toEqual({
+      category: "Contracts",
+      title: "NDA",
+    });
+    expect(parseAppFlowyDocCategory("[Docs] Getting started")).toEqual({
+      category: "General",
+      title: "Getting started",
+    });
+  });
+});

--- a/__tests__/crm-contact-360.test.ts
+++ b/__tests__/crm-contact-360.test.ts
@@ -310,6 +310,11 @@ describe("getContact360", () => {
     expect(payload?.scores.rfmScore).toBe(72);
     expect(payload?.scores.riskBand).toBe("low");
     expect(payload?.scores.churnScore).toBe(0.1);
+    expect(payload?.matchHints.hasEmail).toBe(true);
+    expect(payload?.matchHints.d1User).toBe("hit");
+    expect(payload?.matchHints.stripeCustomer).toBe("hit");
+    expect(payload?.matchHints.attribution).toBe("hit");
+    expect(payload?.matchHints.summary).toContain("hit every wired source");
   });
 });
 
@@ -386,5 +391,7 @@ describe("GET /api/admin/crm/contacts/[id]", () => {
     expect(data.contact.email).toBe("ada@example.com");
     expect(Array.isArray(data.opportunities)).toBe(true);
     expect(typeof data.fetchedAt).toBe("string");
+    expect(data.matchHints).toBeDefined();
+    expect(data.matchHints.hasEmail).toBe(true);
   });
 });

--- a/__tests__/crm-contact-360.test.ts
+++ b/__tests__/crm-contact-360.test.ts
@@ -213,11 +213,9 @@ describe("getContact360", () => {
     ]);
     mockGetStripe.mockResolvedValue({
       customers: {
-        list: vi
-          .fn()
-          .mockResolvedValue({
-            data: [{ id: "cus_1", email: "ada@example.com", created: 1_700_000_000 }],
-          }),
+        list: vi.fn().mockResolvedValue({
+          data: [{ id: "cus_1", email: "ada@example.com", created: 1_700_000_000 }],
+        }),
       },
       checkout: {
         sessions: {

--- a/docs/ai/README.md
+++ b/docs/ai/README.md
@@ -1,8 +1,15 @@
 # AI & agents
 
+| Surface | Runtime | Notes |
+|---------|---------|-------|
+| Public `/api/chat`, admin AI assistant / generator, NLP, product copy | **Workers AI** (+ Gemini fallback) | Edge-friendly chat — not LangGraph |
+| `/admin/langgraph` → `/api/admin/ai/langgraph` | **Pi** (`LANGGRAPH_URL`) | Keep agent graphs on the app path; do **not** port to Cloudflare Workers |
+| `bedrock-chat.ts` | Deprecated re-export of Workers AI | Do not expand Bedrock on Workers |
+
 | Doc | File |
 |-----|------|
 | [AI_ANALYTICS_ORCHESTRATION.md](AI_ANALYTICS_ORCHESTRATION.md) | `ai/AI_ANALYTICS_ORCHESTRATION.md` |
 | [langchain-v1-local-experiment-status.md](langchain-v1-local-experiment-status.md) | `ai/langchain-v1-local-experiment-status.md` |
 | [local-ai-deep-agent-structure.md](local-ai-deep-agent-structure.md) | `ai/local-ai-deep-agent-structure.md` |
 | [cloudless-agent-profile.md](cloudless-agent-profile.md) | `ai/cloudless-agent-profile.md` |
+| [contact-nlp.md](contact-nlp.md) | `ai/contact-nlp.md` |

--- a/docs/integrations/ACTIVECAMPAIGN.md
+++ b/docs/integrations/ACTIVECAMPAIGN.md
@@ -30,6 +30,8 @@ All requests use the `Api-Token` header for authentication. The base URL is read
 ```bash
 ACTIVECAMPAIGN_API_URL=https://myaccount.api-us1.com
 ACTIVECAMPAIGN_API_TOKEN=your-api-token-here
+# Automation ID used by POST /api/contact via enrollLeadInAutomation (silent no-op if unset)
+ACTIVECAMPAIGN_LEAD_AUTOMATION_ID=123
 ```
 
 ### Production (AWS SSM Parameter Store)
@@ -38,6 +40,7 @@ ACTIVECAMPAIGN_API_TOKEN=your-api-token-here
 |---|---|
 | `/cloudless/production/ACTIVECAMPAIGN_API_URL` | String |
 | `/cloudless/production/ACTIVECAMPAIGN_API_TOKEN` | SecureString |
+| `/cloudless/production/ACTIVECAMPAIGN_LEAD_AUTOMATION_ID` | String |
 
 Both values are found in your ActiveCampaign account under **Settings → Developer → API Access**.
 

--- a/docs/roadmap/agency-platform-backlog.md
+++ b/docs/roadmap/agency-platform-backlog.md
@@ -32,6 +32,7 @@ Percentages in the artifact (~75% marketing, ~60% CRM, ~15% ERP) are a snapshot,
 
 | Status | Item                                                  | Why                                                              | Notes                                                                       |
 | ------ | ----------------------------------------------------- | ---------------------------------------------------------------- | --------------------------------------------------------------------------- |
+<<<<<<< HEAD
 | Wait   | Customer Data Platform (new D1 + identity resolution) | 4–6 weeks. Only if join-by-email on `/admin/crm/[id]` is painful | Do not start four new D1 databases up front                                 |
 | Wait   | Marketing automation beyond ActiveCampaign            | Phase 2 in the artifact                                          | Use existing AC automations until the contact page shows gaps               |
 | **Done (this branch)** | Invoicing                                             | Agency-only finance                                              | Stripe Invoicing admin list/create/finalize/send — no finance-db            |
@@ -39,6 +40,15 @@ Percentages in the artifact (~75% marketing, ~60% CRM, ~15% ERP) are a snapshot,
 | **Done (this branch)** | EspoCRM D1 cache                                      | Latency, not a new CRM                                           | `espocrm_cache` + 45–60s read-through; write-path invalidate; not a CDP     |
 | Wait   | Docs / contracts                                      | Phase 6                                                          | AppFlowy already hosts docs; do not add `docs-db` as a Worker               |
 | Wait   | AI agents on Cloudflare Workers                       | Artifact Phase 7                                                 | Keep LangGraph / Bedrock on the Pi app path                                 |
+=======
+| **Won’t / Defer** | Customer Data Platform (new D1 + identity resolution) | 4–6 weeks. Only if join-by-email on `/admin/crm/[id]` is painful | Contact 360 `matchHints` shows email-join gaps; revisit only after systematic multi-email miss rates |
+| **Stay on AC** | Marketing automation beyond ActiveCampaign            | Phase 2 in the artifact                                          | Integrations status flags missing `ACTIVECAMPAIGN_LEAD_AUTOMATION_ID`; keep AC until that surface shows real gaps |
+| **Done** | Invoicing                                             | Agency-only finance                                              | Stripe Invoicing admin (#1665) — no finance-db                              |
+| Wait   | Projects + time tracking                              | Agency delivery, not ERP                                         | After invoicing has a real operator workflow (#1666 open)                   |
+| Wait   | EspoCRM D1 cache                                      | Latency, not a new CRM                                           | After Notion adapters are gone (#1664 open)                                 |
+| **Done (AppFlowy)** | Docs / contracts                                      | Phase 6                                                          | Category parse on `/admin/docs`; no `docs-db` Worker                        |
+| **Won’t** | AI agents on Cloudflare Workers                       | Artifact Phase 7                                                 | Workers AI for chat; LangGraph stays on Pi (`/admin/langgraph`)              |
+>>>>>>> 6e8c77d6 (Close platform Wait items with diagnostics, not new platforms.)
 
 ## Explicitly out of scope
 

--- a/e2e/helpers/coverage-routes.ts
+++ b/e2e/helpers/coverage-routes.ts
@@ -50,6 +50,7 @@ export const ADMIN_PAGES = [
   "/en/admin",
   "/en/admin/ab-tests",
   "/en/admin/ai-assistant",
+  "/en/admin/langgraph",
   "/en/admin/ai-generator",
   "/en/admin/analytics",
   "/en/admin/analytics/seo",

--- a/src/app/[locale]/admin/AdminLayoutClient.tsx
+++ b/src/app/[locale]/admin/AdminLayoutClient.tsx
@@ -122,6 +122,7 @@ const adminGroups: AdminGroup[] = [
       { href: "/admin/postiz", label: "Postiz", Icon: Megaphone },
       { href: "/admin/ai-assistant", label: "AI Assistant", Icon: Bot },
       { href: "/admin/ai-generator", label: "AI Generator", Icon: Bot },
+      { href: "/admin/langgraph", label: "LangGraph (Pi)", Icon: Bot },
       { href: "/admin/product-descriptions", label: "Product Copy", Icon: Package },
       { href: "/admin/voice-brief", label: "Voice Brief", Icon: Mic },
     ],

--- a/src/app/[locale]/admin/docs/page.tsx
+++ b/src/app/[locale]/admin/docs/page.tsx
@@ -45,7 +45,12 @@ export default function AdminDocsPage() {
             <span className="text-neon-cyan font-mono text-xs">DOCS</span>
           </div>
           <h1 className="font-heading text-2xl font-bold text-white">Documentation</h1>
-          <p className="font-body mt-1 text-slate-400">All docs from AppFlowy.</p>
+          <p className="font-body mt-1 text-slate-400">
+            AppFlowy docs and contracts. Name pages{" "}
+            <span className="font-mono text-xs text-slate-300">[Docs][Contracts] Title</span> or{" "}
+            <span className="font-mono text-xs text-slate-300">[Docs] Contracts / Title</span> — no
+            separate docs-db.
+          </p>
         </div>
         <button
           type="button"

--- a/src/app/api/admin/integrations/status/route.ts
+++ b/src/app/api/admin/integrations/status/route.ts
@@ -409,6 +409,7 @@ async function buildPingedReports(cfg: Cfg): Promise<IntegrationReport[]> {
     slackResult,
     notionResult,
     acResult,
+    acLead,
     postizResult,
     appflowyResult,
     n8nResult,
@@ -421,6 +422,7 @@ async function buildPingedReports(cfg: Cfg): Promise<IntegrationReport[]> {
     cfg.SLACK_BOT_TOKEN ? pingSlack(cfg.SLACK_BOT_TOKEN) : Promise.resolve(NOT_CONFIGURED),
     cfg.NOTION_API_KEY ? pingNotion(cfg.NOTION_API_KEY) : Promise.resolve(NOT_CONFIGURED),
     verifyActiveCampaignToken(),
+    getLeadAutomationStatus(),
     cfg.POSTIZ_API_URL && cfg.POSTIZ_API_KEY
       ? pingPostiz(cfg.POSTIZ_API_URL, cfg.POSTIZ_API_KEY)
       : Promise.resolve(NOT_CONFIGURED),
@@ -443,9 +445,15 @@ async function buildPingedReports(cfg: Cfg): Promise<IntegrationReport[]> {
     acResult.status === "not_configured" &&
     cfg.ACTIVECAMPAIGN_API_URL &&
     !cfg.ACTIVECAMPAIGN_API_TOKEN;
-  const acMessage = acMissingToken
+  let acMessage = acMissingToken
     ? "URL configured but API token missing. Renew account then get token from Settings > Developer > API Access."
     : acResult.message;
+  if (acResult.status === "valid" && !acLead.leadAutomationIdSet) {
+    acMessage =
+      "API OK, but ACTIVECAMPAIGN_LEAD_AUTOMATION_ID is unset — contact form enrollments are a no-op.";
+  } else if (acResult.status === "valid" && acLead.leadAutomationIdSet) {
+    acMessage = `${acResult.message} Lead automation ID is set.`;
+  }
 
   return [
     {
@@ -480,7 +488,10 @@ async function buildPingedReports(cfg: Cfg): Promise<IntegrationReport[]> {
       id: "activecampaign",
       name: "ActiveCampaign",
       category: "email_marketing",
-      status: acStatusMap[acResult.status] ?? "error",
+      status:
+        acResult.status === "valid" && !acLead.leadAutomationIdSet
+          ? "degraded"
+          : (acStatusMap[acResult.status] ?? "error"),
       message: acMessage,
       setupUrl: "https://www.activecampaign.com",
     },

--- a/src/components/admin/Contact360View.tsx
+++ b/src/components/admin/Contact360View.tsx
@@ -5,6 +5,7 @@ import type {
   Contact360,
   Contact360Attribution,
   Contact360Event,
+  Contact360MatchHints,
   Contact360Note,
   Contact360Related,
   Contact360Scores,
@@ -188,6 +189,32 @@ function ScoresBlock({ scores }: { scores: Contact360Scores }) {
   );
 }
 
+function MatchHintsBlock({ hints }: { hints: Contact360MatchHints }) {
+  const rows: { label: string; state: string }[] = [
+    { label: "D1 user", state: hints.d1User },
+    { label: "Stripe", state: hints.stripeCustomer },
+    { label: "D1 events", state: hints.d1Events },
+    { label: "RFM / churn", state: hints.rfmScores },
+    { label: "Attribution", state: hints.attribution },
+  ];
+  return (
+    <div className="space-y-2">
+      <p className="font-body text-sm text-slate-300">{hints.summary}</p>
+      <ul className="grid grid-cols-2 gap-2 sm:grid-cols-5">
+        {rows.map((row) => (
+          <li key={row.label} className="bg-void/40 rounded-lg border border-slate-800 px-2 py-1.5">
+            <p className={LABEL}>{row.label}</p>
+            <p className="mt-0.5 font-mono text-[11px] text-slate-300">{row.state}</p>
+          </li>
+        ))}
+      </ul>
+      {!hints.hasEmail ? (
+        <Empty>Add a primary email on the Espo contact to enable joins — not a CDP problem.</Empty>
+      ) : null}
+    </div>
+  );
+}
+
 export function Contact360View({ data }: { data: Contact360 }) {
   const { contact, stripe, account } = data;
   const name = contactDisplayName(contact);
@@ -208,6 +235,13 @@ export function Contact360View({ data }: { data: Contact360 }) {
         <h1 className="font-heading text-2xl font-bold text-white">{name}</h1>
         <p className="text-neon-cyan mt-1 font-mono text-sm">{contact.email || "No email"}</p>
       </div>
+
+      <section className={CARD}>
+        <h2 className="font-heading mb-3 text-sm font-semibold text-white">
+          Email join diagnostics
+        </h2>
+        <MatchHintsBlock hints={data.matchHints} />
+      </section>
 
       <div className="grid grid-cols-1 gap-4 sm:grid-cols-3">
         <div className={CARD}>

--- a/src/lib/activecampaign.ts
+++ b/src/lib/activecampaign.ts
@@ -282,6 +282,18 @@ export async function enrollLeadInAutomation(lead: {
   }
 }
 
+/** Operator visibility: is the inbound lead automation ID set? */
+export async function getLeadAutomationStatus(): Promise<{
+  apiConfigured: boolean;
+  leadAutomationIdSet: boolean;
+}> {
+  const cfg = await getConfig();
+  return {
+    apiConfigured: await isActiveCampaignConfigured(),
+    leadAutomationIdSet: Boolean(cfg.ACTIVECAMPAIGN_LEAD_AUTOMATION_ID?.trim()),
+  };
+}
+
 // ── Stats ─────────────────────────────────────────────────────────────────────
 
 export async function getEmailStats(): Promise<{

--- a/src/lib/appflowy-docs.ts
+++ b/src/lib/appflowy-docs.ts
@@ -57,6 +57,25 @@ function isDocPage(name: string): boolean {
   return /^\[Docs\]\s/i.test(name);
 }
 
+/**
+ * Category from AppFlowy page name:
+ * - `[Docs][Contracts] MSA` → Contracts / MSA
+ * - `[Docs] Contracts / MSA` → Contracts / MSA
+ * - `[Docs] Getting started` → General
+ */
+export function parseAppFlowyDocCategory(name: string): { title: string; category: string } {
+  const stripped = stripDocPrefix(name);
+  const bracket = stripped.match(/^\[([^\]]{1,80})\]\s+(.+)$/);
+  if (bracket) {
+    return { category: bracket[1].trim() || "General", title: bracket[2].trim() };
+  }
+  const slash = stripped.match(/^([^/]{1,80})\s*\/\s*(.+)$/);
+  if (slash) {
+    return { category: slash[1].trim() || "General", title: slash[2].trim() };
+  }
+  return { category: "General", title: stripped || name };
+}
+
 async function getPrimaryWorkspaceId(): Promise<string | null> {
   try {
     const workspaces = await listAllWorkspaces();
@@ -71,13 +90,13 @@ function mapViewToDoc(view: {
   name: string;
   last_edited_time: string;
 }): Omit<AppFlowyDoc, "html"> {
-  const raw = stripDocPrefix(view.name);
+  const { title, category } = parseAppFlowyDocCategory(view.name);
   return {
     id: view.view_id,
-    slug: slugify(raw),
-    title: raw,
+    slug: slugify(title),
+    title,
     description: "",
-    category: "General",
+    category,
     order: 0,
     published: isDocPage(view.name),
     verificationStatus: "Unverified",

--- a/src/lib/contact-360-match-hints.ts
+++ b/src/lib/contact-360-match-hints.ts
@@ -1,0 +1,78 @@
+/**
+ * Build operator-facing match diagnostics for Contact 360.
+ * Pure — no I/O. Used to decide CDP is unnecessary when email join works.
+ */
+
+export type MatchHintState = "hit" | "miss" | "skipped" | "unconfigured" | "no_utm_events";
+
+export interface Contact360MatchHints {
+  hasEmail: boolean;
+  d1User: MatchHintState;
+  stripeCustomer: MatchHintState;
+  d1Events: MatchHintState;
+  rfmScores: MatchHintState;
+  attribution: MatchHintState;
+  summary: string;
+}
+
+export function buildContact360MatchHints(input: {
+  email: string;
+  hasD1User: boolean;
+  stripeConfigured: boolean;
+  hasStripeCustomer: boolean;
+  eventCount: number;
+  hasRfm: boolean;
+  hasFirstTouch: boolean;
+  goldMatchCount: number;
+}): Contact360MatchHints {
+  const hasEmail = Boolean(input.email.trim());
+  if (!hasEmail) {
+    return {
+      hasEmail: false,
+      d1User: "skipped",
+      stripeCustomer: "skipped",
+      d1Events: "skipped",
+      rfmScores: "skipped",
+      attribution: "skipped",
+      summary: "Espo contact has no primary email — Stripe, D1, and gold joins were skipped.",
+    };
+  }
+
+  const d1User: MatchHintState = input.hasD1User ? "hit" : "miss";
+  const stripeCustomer: MatchHintState = !input.stripeConfigured
+    ? "unconfigured"
+    : input.hasStripeCustomer
+      ? "hit"
+      : "miss";
+  const d1Events: MatchHintState = input.eventCount > 0 ? "hit" : "miss";
+  const rfmScores: MatchHintState = input.hasRfm ? "hit" : "miss";
+  const attribution: MatchHintState = input.hasFirstTouch
+    ? input.goldMatchCount > 0
+      ? "hit"
+      : "miss"
+    : "no_utm_events";
+
+  const parts: string[] = [];
+  if (d1User === "miss") parts.push("no D1 user");
+  if (stripeCustomer === "miss") parts.push("no Stripe customer");
+  if (d1Events === "miss") parts.push("no D1 events");
+  if (rfmScores === "miss") parts.push("no RFM/churn row");
+  if (attribution === "no_utm_events") {
+    parts.push("no UTM events (gold not consulted by email alone)");
+  } else if (attribution === "miss") {
+    parts.push("UTM events present but no gold campaign match");
+  }
+
+  return {
+    hasEmail: true,
+    d1User,
+    stripeCustomer,
+    d1Events,
+    rfmScores,
+    attribution,
+    summary:
+      parts.length === 0
+        ? "Email join hit every wired source."
+        : `Email join gaps: ${parts.join("; ")}.`,
+  };
+}

--- a/src/lib/crm-contact-360-shared.ts
+++ b/src/lib/crm-contact-360-shared.ts
@@ -3,6 +3,10 @@
  * I/O lives in crm-contact-360.ts (server only).
  */
 
+import type { Contact360MatchHints } from "@/lib/contact-360-match-hints";
+
+export type { Contact360MatchHints } from "@/lib/contact-360-match-hints";
+
 export function isEspoRecordId(id: string): boolean {
   return /^[a-zA-Z0-9]{8,24}$/.test(id);
 }
@@ -113,6 +117,7 @@ export interface Contact360 {
   events: Contact360Event[];
   attribution: Contact360Attribution;
   scores: Contact360Scores;
+  matchHints: Contact360MatchHints;
   fetchedAt: string;
 }
 

--- a/src/lib/crm-contact-360.ts
+++ b/src/lib/crm-contact-360.ts
@@ -30,6 +30,7 @@ import {
   type Contact360Stripe,
   type Contact360Subscription,
 } from "@/lib/crm-contact-360-shared";
+import { buildContact360MatchHints } from "@/lib/contact-360-match-hints";
 import { getGoldDashboard } from "@/lib/datalake-serve";
 
 export type { Contact360 } from "@/lib/crm-contact-360-shared";
@@ -57,6 +58,19 @@ export async function getContact360(id: string): Promise<Contact360 | null> {
     loadGoldLake(),
   ]);
 
+  const attribution = buildAttribution(accountBundle.touches, gold.attribution);
+  const scores = matchRfmChurnRow(gold.scores, email);
+  const matchHints = buildContact360MatchHints({
+    email,
+    hasD1User: Boolean(accountBundle.account),
+    stripeConfigured: stripe.configured,
+    hasStripeCustomer: Boolean(stripe.customer),
+    eventCount: accountBundle.events.length,
+    hasRfm: scores.rfmScore != null || scores.churnScore != null,
+    hasFirstTouch: Boolean(attribution.firstTouch),
+    goldMatchCount: attribution.goldMatches.length,
+  });
+
   return {
     contact,
     opportunities,
@@ -65,8 +79,9 @@ export async function getContact360(id: string): Promise<Contact360 | null> {
     stripe,
     account: accountBundle.account,
     events: accountBundle.events,
-    attribution: buildAttribution(accountBundle.touches, gold.attribution),
-    scores: matchRfmChurnRow(gold.scores, email),
+    attribution,
+    scores,
+    matchHints,
     fetchedAt: new Date().toISOString(),
   };
 }


### PR DESCRIPTION
## Summary
- **CDP → Won’t/Defer:** Contact 360 email-join `matchHints` so operators see miss reasons without a new identity graph
- **Marketing beyond AC → stay on AC:** Integrations status flags missing `ACTIVECAMPAIGN_LEAD_AUTOMATION_ID`; docs updated
- **Docs/contracts → Done (AppFlowy):** category parse (`[Docs][Contracts] …` / `Contracts / …`) on `/admin/docs`
- **AI agents on Workers → Won’t:** document Workers AI vs LangGraph-on-Pi; add **LangGraph (Pi)** to admin nav

## Test plan
- [ ] `pnpm exec vitest run __tests__/crm-contact-360.test.ts __tests__/contact-360-match-hints.test.ts`
- [ ] Open a CRM contact with/without email — diagnostics section renders
- [ ] Integrations → ActiveCampaign message mentions lead automation ID when API is OK
- [ ] `/en/admin/docs` copy + category grouping; `/en/admin/langgraph` in nav


Made with [Cursor](https://cursor.com)