### PR TITLE
Honest gold ROI channels + Lake Explore as operator SQL

### DIFF
--- a/__tests__/admin-roi-lake-honesty.test.ts
+++ b/__tests__/admin-roi-lake-honesty.test.ts
@@ -1,0 +1,56 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const getDatalakeDashboardMock = vi.fn();
+
+vi.mock("@/lib/datalake-r2", () => ({
+  getDatalakeDashboard: (...a: unknown[]) => getDatalakeDashboardMock(...a),
+  loadDatalakeSnapshotFromR2: vi.fn().mockResolvedValue(null),
+}));
+
+vi.mock("@/lib/r2-client", () => ({
+  getDataLakeBucketFromEnv: vi.fn().mockReturnValue(null),
+}));
+
+describe("getRoiFromLake honesty", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    getDatalakeDashboardMock.mockResolvedValue({
+      generated_at: "2026-08-14T00:00:00.000Z",
+      cache: "cloudflare",
+      source: "gold",
+      sections: [
+        {
+          section: "linkedin_ads",
+          rows: [{ spend: 12.5, impressions: 100, clicks: 4, conversions: 1 }],
+          rowCount: 1,
+        },
+        {
+          section: "stripe_revenue",
+          rows: [{ metric: "paid_orders", amount_eur: 50 }],
+          rowCount: 1,
+        },
+      ],
+    });
+  });
+
+  it("marks Google/TikTok/X/Meta as not_in_gold and keeps LinkedIn gold", async () => {
+    const { getRoiFromLake } = await import("@/lib/datalake-serve");
+    const roi = await getRoiFromLake(30);
+    const channels = roi.channels as Array<{
+      channel: string;
+      configured: boolean;
+      status: string;
+      inGold: boolean;
+    }>;
+    expect(channels.find((c) => c.channel === "linkedin")?.configured).toBe(true);
+    expect(channels.find((c) => c.channel === "linkedin")?.status).toBe("gold");
+    for (const name of ["google", "tiktok", "x", "meta"]) {
+      const ch = channels.find((c) => c.channel === name);
+      expect(ch?.configured).toBe(false);
+      expect(ch?.status).toBe("not_in_gold");
+      expect(ch?.inGold).toBe(false);
+    }
+    expect(roi.goldSections).toEqual(["linkedin_ads", "stripe_revenue"]);
+    expect(String(roi.notes)).toContain("not_in_gold");
+  });
+});

--- a/docs/data/datalake.md
+++ b/docs/data/datalake.md
@@ -109,13 +109,14 @@ R2 datalake-bucket
 
 ## Optional next (Cloudflare Data Platform)
 
-For ad-hoc SQL over silver parquet without Athena:
+Operator ad-hoc SQL over silver parquet **without Athena** is already covered by
+**Lake Explore** (`/admin/analytics/explore` — DuckDB-Wasm + catalog-allowlisted
+parquet). Dashboards stay on **gold snapshots**.
 
-- Enable [R2 Data Catalog](https://developers.cloudflare.com/r2-data-catalog/) on `datalake-bucket`
-- Query with [R2 SQL](https://developers.cloudflare.com/r2-sql/)
-
-Admin dashboards should stay on **gold snapshots** for latency and cost;
-R2 SQL is for explore/operator queries, not every page load.
+Cloudflare [R2 Data Catalog](https://developers.cloudflare.com/r2-data-catalog/) +
+[R2 SQL](https://developers.cloudflare.com/r2-sql/) remain **optional** Iceberg
+platform enablement on `datalake-bucket` when an operator wants CF-managed SQL
+outside the app. Do not route page loads through R2 SQL.
 
 ## Historical (Athena)
 

--- a/docs/roadmap/agency-platform-backlog.md
+++ b/docs/roadmap/agency-platform-backlog.md
@@ -88,8 +88,8 @@ Do **not** rebuild medallion, stand up BI SaaS, or call live GSC/Stripe/Espo fro
 | **Done (this branch)** | Overlay RFM / churn parquet on `/admin/crm/[id]` | Scores are already keyed by email in `ml-parquet/` | Gold `rfm_churn` section + email join; still not a CDP |
 | **Done (this branch)** | Hide empty GSC dimension UI (country / device / page) | `getGscDimensionFromLake` only has `query` rows; SEO tabs were empty stubs | APIs stay wired; restore UI when ETL exists |
 | Wait | GSC dimension ETL (country / device / page) | Silver parquet is query-only today | Do not un-hide those tables until gold has rows |
-| Wait | LinkedIn-only ROI → other ad channels in gold | `getRoiFromLake` reports `configured=false` for Google/TikTok/X/Meta | Keep `roi.ts` live adapters off admin routes |
-| Wait | R2 Data Catalog / R2 SQL | Optional explore SQL without Athena | Dashboards stay on gold snapshots (`datalake.md`) |
+| **Done (this branch)** | LinkedIn-only ROI → other ad channels in gold | `getRoiFromLake` reports `configured=false` for Google/TikTok/X/Meta | Honest `not_in_gold` status + unified UI; no live `roi.ts`; real ETL later per channel with spend |
+| **Done (this branch)** | R2 Data Catalog / R2 SQL | Optional explore SQL without Athena | Lake Explore is the operator SQL path; CF R2 Catalog/SQL stays optional Iceberg enablement |
 
 ### Lake out of scope
 

--- a/src/app/[locale]/admin/analytics/explore/page.tsx
+++ b/src/app/[locale]/admin/analytics/explore/page.tsx
@@ -56,7 +56,25 @@ export default function LakeExplorePage() {
         <h1 className="font-heading text-2xl font-bold text-white">Explore bronze parquet</h1>
         <p className="mt-2 max-w-2xl font-mono text-xs text-slate-500">
           Catalog-allowlisted R2 objects only. Prefer gold snapshots on the datalake dashboard for
-          production panels.
+          production panels. This DuckDB-Wasm explorer is the operator SQL path today — Cloudflare{" "}
+          <a
+            href="https://developers.cloudflare.com/r2-data-catalog/"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-neon-cyan hover:underline"
+          >
+            R2 Data Catalog
+          </a>{" "}
+          /{" "}
+          <a
+            href="https://developers.cloudflare.com/r2-sql/"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-neon-cyan hover:underline"
+          >
+            R2 SQL
+          </a>{" "}
+          remains optional platform enablement (Iceberg), not required for admin dashboards.
         </p>
       </div>
 

--- a/src/app/[locale]/admin/analytics/unified/page.tsx
+++ b/src/app/[locale]/admin/analytics/unified/page.tsx
@@ -183,7 +183,9 @@ function RoiSection({ roi }: Readonly<{ roi: RoiData | null }>) {
               <th className="px-4 py-2 text-right font-mono text-xs text-slate-500">Spend</th>
               <th className="px-4 py-2 text-right font-mono text-xs text-slate-500">Impressions</th>
               <th className="px-4 py-2 text-right font-mono text-xs text-slate-500">Clicks</th>
-              <th className="px-4 py-2 text-right font-mono text-xs text-slate-500">Platform leads</th>
+              <th className="px-4 py-2 text-right font-mono text-xs text-slate-500">
+                Platform leads
+              </th>
             </tr>
           </thead>
           <tbody className="divide-y divide-slate-800">

--- a/src/app/[locale]/admin/analytics/unified/page.tsx
+++ b/src/app/[locale]/admin/analytics/unified/page.tsx
@@ -102,6 +102,9 @@ function EmptyState({ label }: Readonly<{ label: string }>) {
 interface RoiChannelData {
   channel: string;
   configured: boolean;
+  inGold?: boolean;
+  status?: string;
+  reason?: string;
   spendCents: number;
   impressions: number;
   clicks: number;
@@ -111,6 +114,7 @@ interface RoiChannelData {
 interface RoiData {
   windowDays: number;
   channels: RoiChannelData[];
+  notes?: string[];
   totals: {
     spendCents: number;
     impressions: number;
@@ -142,7 +146,6 @@ function euros(cents: number | null): string {
 
 function RoiSection({ roi }: Readonly<{ roi: RoiData | null }>) {
   if (!roi) return <EmptyState label="ROI" />;
-  const configured = roi.channels.filter((c) => c.configured);
   return (
     <div>
       <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
@@ -171,46 +174,57 @@ function RoiSection({ roi }: Readonly<{ roi: RoiData | null }>) {
           color="text-neon-green"
         />
       </div>
-      {configured.length > 0 && (
-        <div className="mt-3 overflow-x-auto rounded-xl border border-slate-800">
-          <table className="w-full">
-            <thead>
-              <tr className="border-b border-slate-800 bg-slate-900/50">
-                <th className="px-4 py-2 text-left font-mono text-xs text-slate-500">Channel</th>
-                <th className="px-4 py-2 text-right font-mono text-xs text-slate-500">Spend</th>
-                <th className="px-4 py-2 text-right font-mono text-xs text-slate-500">
-                  Impressions
-                </th>
-                <th className="px-4 py-2 text-right font-mono text-xs text-slate-500">Clicks</th>
-                <th className="px-4 py-2 text-right font-mono text-xs text-slate-500">
-                  Platform leads
-                </th>
+      <div className="mt-3 overflow-x-auto rounded-xl border border-slate-800">
+        <table className="w-full">
+          <thead>
+            <tr className="border-b border-slate-800 bg-slate-900/50">
+              <th className="px-4 py-2 text-left font-mono text-xs text-slate-500">Channel</th>
+              <th className="px-4 py-2 text-left font-mono text-xs text-slate-500">Status</th>
+              <th className="px-4 py-2 text-right font-mono text-xs text-slate-500">Spend</th>
+              <th className="px-4 py-2 text-right font-mono text-xs text-slate-500">Impressions</th>
+              <th className="px-4 py-2 text-right font-mono text-xs text-slate-500">Clicks</th>
+              <th className="px-4 py-2 text-right font-mono text-xs text-slate-500">Platform leads</th>
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-slate-800">
+            {roi.channels.map((c) => (
+              <tr key={c.channel}>
+                <td className="px-4 py-2 font-mono text-xs text-white">
+                  {CHANNEL_LABELS[c.channel] ?? c.channel}
+                </td>
+                <td className="px-4 py-2 font-mono text-xs text-slate-400">
+                  {c.configured
+                    ? "gold"
+                    : c.status === "not_in_gold"
+                      ? "not in gold"
+                      : c.status === "empty_gold"
+                        ? "empty gold"
+                        : "—"}
+                </td>
+                <td className="px-4 py-2 text-right font-mono text-xs text-slate-300">
+                  {c.configured ? euros(c.spendCents) : "—"}
+                </td>
+                <td className="px-4 py-2 text-right font-mono text-xs text-slate-400">
+                  {c.configured ? c.impressions.toLocaleString() : "—"}
+                </td>
+                <td className="px-4 py-2 text-right font-mono text-xs text-slate-400">
+                  {c.configured ? c.clicks.toLocaleString() : "—"}
+                </td>
+                <td className="px-4 py-2 text-right font-mono text-xs text-slate-400">
+                  {c.configured ? c.platformLeads.toLocaleString() : "—"}
+                </td>
               </tr>
-            </thead>
-            <tbody className="divide-y divide-slate-800">
-              {configured.map((c) => (
-                <tr key={c.channel}>
-                  <td className="px-4 py-2 font-mono text-xs text-white">
-                    {CHANNEL_LABELS[c.channel] ?? c.channel}
-                  </td>
-                  <td className="px-4 py-2 text-right font-mono text-xs text-slate-300">
-                    {euros(c.spendCents)}
-                  </td>
-                  <td className="px-4 py-2 text-right font-mono text-xs text-slate-400">
-                    {c.impressions.toLocaleString()}
-                  </td>
-                  <td className="px-4 py-2 text-right font-mono text-xs text-slate-400">
-                    {c.clicks.toLocaleString()}
-                  </td>
-                  <td className="px-4 py-2 text-right font-mono text-xs text-slate-400">
-                    {c.platformLeads.toLocaleString()}
-                  </td>
-                </tr>
-              ))}
-            </tbody>
-          </table>
-        </div>
-      )}
+            ))}
+          </tbody>
+        </table>
+      </div>
+      {roi.notes && roi.notes.length > 0 ? (
+        <ul className="mt-2 space-y-1 font-mono text-[10px] text-slate-600">
+          {roi.notes.map((n) => (
+            <li key={n}>• {n}</li>
+          ))}
+        </ul>
+      ) : null}
     </div>
   );
 }

--- a/src/app/api/admin/analytics/roi/route.ts
+++ b/src/app/api/admin/analytics/roi/route.ts
@@ -4,7 +4,8 @@ import { getRoiFromLake } from "@/lib/datalake-serve";
 
 /**
  * ROI summary — lake gold (LinkedIn ads + stripe_revenue).
- * Other ad channels report configured=false until silver ETL lands.
+ * Other ad channels report configured=false / status=not_in_gold until silver ETL lands.
+ * Never imports live roi.ts adapters.
  */
 export async function GET(request: NextRequest) {
   const auth = await requireAdmin(request);

--- a/src/lib/datalake-serve.ts
+++ b/src/lib/datalake-serve.ts
@@ -270,7 +270,8 @@ export function pipelineFromEspocrmGold(rows: Record<string, unknown>[]): {
 
 /**
  * Lake-backed ROI — LinkedIn ads + stripe_revenue gold only.
- * Other ad channels report configured=false until silver ETL lands.
+ * Other ad channels stay `configured: false` with `status: "not_in_gold"`
+ * until a real silver ETL lands. Never calls live `roi.ts` adapters.
  */
 export async function getRoiFromLake(days = 30): Promise<Record<string, unknown>> {
   const linkedin = await getGoldSection("linkedin_ads");
@@ -289,41 +290,40 @@ export async function getRoiFromLake(days = 30): Promise<Record<string, unknown>
     : stripeRows.reduce((a, r) => a + (Number(r.amount_eur ?? r.revenue ?? r.amount) || 0), 0);
   const revenueCents = Math.round(revenueMajor * 100);
 
+  const linkedinConfigured = !linkedin?.error && linkedinRows.length > 0;
+  const notInGold = (channel: string) => ({
+    channel,
+    configured: false,
+    inGold: false as const,
+    status: "not_in_gold" as const,
+    reason: "no silver parquet / gold section — ETL not wired; live roi.ts adapters stay off admin",
+    spendCents: 0,
+    impressions: 0,
+    clicks: 0,
+    platformLeads: 0,
+  });
+
   const channels = [
     {
       channel: "linkedin",
-      configured: !linkedin?.error && linkedinRows.length > 0,
+      configured: linkedinConfigured,
+      inGold: true as const,
+      status: linkedinConfigured ? ("gold" as const) : ("empty_gold" as const),
+      reason: linkedin?.error
+        ? `linkedin_ads: ${linkedin.error}`
+        : linkedinConfigured
+          ? "Served from gold linkedin_ads"
+          : "Gold section present but empty",
       spendCents,
       impressions,
       clicks,
       platformLeads: linkedinRows.reduce((a, r) => a + (Number(r.leads ?? r.conversions) || 0), 0),
       error: linkedin?.error,
     },
-    {
-      channel: "google",
-      configured: false,
-      spendCents: 0,
-      impressions: 0,
-      clicks: 0,
-      platformLeads: 0,
-    },
-    {
-      channel: "tiktok",
-      configured: false,
-      spendCents: 0,
-      impressions: 0,
-      clicks: 0,
-      platformLeads: 0,
-    },
-    { channel: "x", configured: false, spendCents: 0, impressions: 0, clicks: 0, platformLeads: 0 },
-    {
-      channel: "meta",
-      configured: false,
-      spendCents: 0,
-      impressions: 0,
-      clicks: 0,
-      platformLeads: 0,
-    },
+    notInGold("google"),
+    notInGold("tiktok"),
+    notInGold("x"),
+    notInGold("meta"),
   ];
 
   const totalsSpend = channels.reduce((a, c) => a + c.spendCents, 0);
@@ -335,6 +335,7 @@ export async function getRoiFromLake(days = 30): Promise<Record<string, unknown>
     windowDays: days,
     generatedAt: new Date().toISOString(),
     source: DATALAKE_GOLD_SOURCE,
+    goldSections: ["linkedin_ads", SECTION_STRIPE_REVENUE],
     channels,
     totals: {
       spendCents: totalsSpend,
@@ -350,7 +351,8 @@ export async function getRoiFromLake(days = 30): Promise<Record<string, unknown>
           : null,
     },
     notes: [
-      "ROI is lake-backed. Google/TikTok/X/Meta channels appear when their silver ETL lands.",
+      "ROI is lake-backed (LinkedIn + Stripe gold). Google/TikTok/X/Meta show as not_in_gold until their ETL exists.",
+      "Live campaign adapters in roi.ts are not used on admin analytics routes.",
       linkedin?.error ? `linkedin_ads: ${linkedin.error}` : null,
       stripe?.error ? `stripe_revenue: ${stripe.error}` : null,
     ].filter(Boolean),


### PR DESCRIPTION
## Summary
- Restores the gold ROI / Lake Explore work that was supposed to land in #1663.
- #1663 squash-merged the wrong tree (email-infra Prettier) after a branch mix-up; this PR is the original 7-file ROI diff.

## Test plan
- [ ] `/admin/analytics/unified` shows not-in-gold ad ROI channels
- [ ] Lake Explore copy matches operator SQL wording
- [ ] ROI route still serves gold channels


Made with [Cursor](https://cursor.com)