### PR TITLE
Bill unbilled delivery hours into a Stripe draft invoice

### DIFF
--- a/__tests__/admin-delivery-invoice-api.test.ts
+++ b/__tests__/admin-delivery-invoice-api.test.ts
@@ -123,18 +123,24 @@ describe("POST /api/admin/delivery/projects/[id]/invoice", () => {
 
   it("returns 401 without auth", async () => {
     const { POST } = await import("@/app/api/admin/delivery/projects/[id]/invoice/route");
-    const res = await POST(new NextRequest("http://localhost/api/admin/delivery/projects/ap_abc/invoice"), {
-      params: Promise.resolve({ id: "ap_abc" }),
-    });
+    const res = await POST(
+      new NextRequest("http://localhost/api/admin/delivery/projects/ap_abc/invoice"),
+      {
+        params: Promise.resolve({ id: "ap_abc" }),
+      }
+    );
     expect(res.status).toBe(401);
   });
 
   it("returns 503 when Stripe missing", async () => {
     mockGetStripe.mockResolvedValueOnce(null);
     const { POST } = await import("@/app/api/admin/delivery/projects/[id]/invoice/route");
-    const res = await POST(adminReq("http://localhost/api/admin/delivery/projects/ap_abc/invoice", { method: "POST" }), {
-      params: Promise.resolve({ id: "ap_abc" }),
-    });
+    const res = await POST(
+      adminReq("http://localhost/api/admin/delivery/projects/ap_abc/invoice", { method: "POST" }),
+      {
+        params: Promise.resolve({ id: "ap_abc" }),
+      }
+    );
     expect(res.status).toBe(503);
   });
 
@@ -144,17 +150,23 @@ describe("POST /api/admin/delivery/projects/[id]/invoice", () => {
       project: { ...project, hourlyRateCents: null },
     });
     const { POST } = await import("@/app/api/admin/delivery/projects/[id]/invoice/route");
-    const res = await POST(adminReq("http://localhost/api/admin/delivery/projects/ap_abc/invoice", { method: "POST" }), {
-      params: Promise.resolve({ id: "ap_abc" }),
-    });
+    const res = await POST(
+      adminReq("http://localhost/api/admin/delivery/projects/ap_abc/invoice", { method: "POST" }),
+      {
+        params: Promise.resolve({ id: "ap_abc" }),
+      }
+    );
     expect(res.status).toBe(400);
   });
 
   it("creates a draft and stamps entries", async () => {
     const { POST } = await import("@/app/api/admin/delivery/projects/[id]/invoice/route");
-    const res = await POST(adminReq("http://localhost/api/admin/delivery/projects/ap_abc/invoice", { method: "POST" }), {
-      params: Promise.resolve({ id: "ap_abc" }),
-    });
+    const res = await POST(
+      adminReq("http://localhost/api/admin/delivery/projects/ap_abc/invoice", { method: "POST" }),
+      {
+        params: Promise.resolve({ id: "ap_abc" }),
+      }
+    );
     const data = await res.json();
     expect(res.status).toBe(201);
     expect(data.invoice.id).toBe("in_1");
@@ -173,11 +185,16 @@ describe("POST /api/admin/delivery/projects/[id]/invoice", () => {
       project: { ...project, stripeCustomerId: "cus_existing" },
     });
     const { POST } = await import("@/app/api/admin/delivery/projects/[id]/invoice/route");
-    const res = await POST(adminReq("http://localhost/api/admin/delivery/projects/ap_abc/invoice", { method: "POST" }), {
-      params: Promise.resolve({ id: "ap_abc" }),
-    });
+    const res = await POST(
+      adminReq("http://localhost/api/admin/delivery/projects/ap_abc/invoice", { method: "POST" }),
+      {
+        params: Promise.resolve({ id: "ap_abc" }),
+      }
+    );
     expect(res.status).toBe(201);
     expect(mockResolveCustomer).not.toHaveBeenCalled();
-    expect(mockCreateDraft).toHaveBeenCalledWith(expect.objectContaining({ customerId: "cus_existing" }));
+    expect(mockCreateDraft).toHaveBeenCalledWith(
+      expect.objectContaining({ customerId: "cus_existing" })
+    );
   });
 });

--- a/__tests__/admin-delivery-invoice-api.test.ts
+++ b/__tests__/admin-delivery-invoice-api.test.ts
@@ -1,0 +1,183 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { NextRequest } from "next/server";
+
+vi.mock("@/lib/api-auth", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/api-auth")>();
+  const { NextResponse } = await import("next/server");
+  const adminUser = {
+    sub: "test-admin-sub",
+    email: "admin@cloudless.gr",
+    groups: ["admin"],
+    email_verified: true,
+  };
+  return {
+    ...actual,
+    requireAdmin: async (request: Parameters<typeof actual.requireAdmin>[0]) => {
+      const h = request.headers.get("authorization") ?? "";
+      const token = h.startsWith("Bearer ") ? h.slice(7) : "";
+      if (token === "test-admin-session") return { ok: true as const, user: adminUser };
+      return {
+        ok: false as const,
+        response: NextResponse.json({ error: "Unauthorized" }, { status: 401 }),
+      };
+    },
+  };
+});
+
+const {
+  mockGetProject,
+  mockListUnbilled,
+  mockMarkInvoiced,
+  mockSetCustomer,
+  mockGetStripe,
+  mockResolveCustomer,
+  mockCreateDraft,
+} = vi.hoisted(() => ({
+  mockGetProject: vi.fn(),
+  mockListUnbilled: vi.fn(),
+  mockMarkInvoiced: vi.fn(),
+  mockSetCustomer: vi.fn(),
+  mockGetStripe: vi.fn(),
+  mockResolveCustomer: vi.fn(),
+  mockCreateDraft: vi.fn(),
+}));
+
+vi.mock("@/lib/agency-projects-d1", () => ({
+  getAgencyProject: (...a: unknown[]) => mockGetProject(...a),
+  listUnbilledBillableEntries: (...a: unknown[]) => mockListUnbilled(...a),
+  markTimeEntriesInvoiced: (...a: unknown[]) => mockMarkInvoiced(...a),
+  setAgencyProjectStripeCustomer: (...a: unknown[]) => mockSetCustomer(...a),
+}));
+
+vi.mock("@/lib/stripe", () => ({
+  getStripe: (...a: unknown[]) => mockGetStripe(...a),
+  resolveOrCreateCustomerByEmail: (...a: unknown[]) => mockResolveCustomer(...a),
+  createDraftInvoice: (...a: unknown[]) => mockCreateDraft(...a),
+}));
+
+function adminReq(url: string, init?: RequestInit) {
+  return new NextRequest(url, {
+    ...init,
+    headers: {
+      ...(init?.headers ?? {}),
+      authorization: "Bearer test-admin-session",
+      "content-type": "application/json",
+    },
+  });
+}
+
+const project = {
+  id: "ap_abc",
+  name: "Acme site",
+  clientEmail: "a@b.com",
+  espoAccountId: null,
+  status: "active" as const,
+  hourlyRateCents: 10000,
+  currency: "EUR",
+  stripeCustomerId: null as string | null,
+  notes: null,
+  createdAt: 1,
+  updatedAt: 1,
+  totalMinutes: 90,
+  unbilledMinutes: 90,
+};
+
+describe("POST /api/admin/delivery/projects/[id]/invoice", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetStripe.mockResolvedValue({});
+    mockGetProject.mockResolvedValue({ bound: true, project });
+    mockListUnbilled.mockResolvedValue({
+      bound: true,
+      entries: [
+        {
+          id: "te_1",
+          projectId: "ap_abc",
+          userId: null,
+          workDate: "2026-08-14",
+          minutes: 90,
+          billable: true,
+          description: "Landing",
+          stripeInvoiceId: null,
+          createdAt: 1,
+        },
+      ],
+    });
+    mockResolveCustomer.mockResolvedValue("cus_1");
+    mockSetCustomer.mockResolvedValue(true);
+    mockCreateDraft.mockResolvedValue({
+      id: "in_1",
+      number: null,
+      customerId: "cus_1",
+      customerEmail: "a@b.com",
+      status: "draft",
+      amountDue: 15000,
+      amountPaid: 0,
+      currency: "EUR",
+      created: 1,
+      hostedInvoiceUrl: null,
+      invoicePdf: null,
+    });
+    mockMarkInvoiced.mockResolvedValue(1);
+  });
+
+  it("returns 401 without auth", async () => {
+    const { POST } = await import("@/app/api/admin/delivery/projects/[id]/invoice/route");
+    const res = await POST(new NextRequest("http://localhost/api/admin/delivery/projects/ap_abc/invoice"), {
+      params: Promise.resolve({ id: "ap_abc" }),
+    });
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 503 when Stripe missing", async () => {
+    mockGetStripe.mockResolvedValueOnce(null);
+    const { POST } = await import("@/app/api/admin/delivery/projects/[id]/invoice/route");
+    const res = await POST(adminReq("http://localhost/api/admin/delivery/projects/ap_abc/invoice", { method: "POST" }), {
+      params: Promise.resolve({ id: "ap_abc" }),
+    });
+    expect(res.status).toBe(503);
+  });
+
+  it("rejects missing hourly rate", async () => {
+    mockGetProject.mockResolvedValueOnce({
+      bound: true,
+      project: { ...project, hourlyRateCents: null },
+    });
+    const { POST } = await import("@/app/api/admin/delivery/projects/[id]/invoice/route");
+    const res = await POST(adminReq("http://localhost/api/admin/delivery/projects/ap_abc/invoice", { method: "POST" }), {
+      params: Promise.resolve({ id: "ap_abc" }),
+    });
+    expect(res.status).toBe(400);
+  });
+
+  it("creates a draft and stamps entries", async () => {
+    const { POST } = await import("@/app/api/admin/delivery/projects/[id]/invoice/route");
+    const res = await POST(adminReq("http://localhost/api/admin/delivery/projects/ap_abc/invoice", { method: "POST" }), {
+      params: Promise.resolve({ id: "ap_abc" }),
+    });
+    const data = await res.json();
+    expect(res.status).toBe(201);
+    expect(data.invoice.id).toBe("in_1");
+    expect(data.amountCents).toBe(15000);
+    expect(data.stamped).toBe(1);
+    expect(mockResolveCustomer).toHaveBeenCalledWith("a@b.com");
+    expect(mockCreateDraft).toHaveBeenCalledWith(
+      expect.objectContaining({ customerId: "cus_1", amountCents: 15000, currency: "eur" })
+    );
+    expect(mockMarkInvoiced).toHaveBeenCalledWith(["te_1"], "in_1");
+  });
+
+  it("reuses existing Stripe customer", async () => {
+    mockGetProject.mockResolvedValueOnce({
+      bound: true,
+      project: { ...project, stripeCustomerId: "cus_existing" },
+    });
+    const { POST } = await import("@/app/api/admin/delivery/projects/[id]/invoice/route");
+    const res = await POST(adminReq("http://localhost/api/admin/delivery/projects/ap_abc/invoice", { method: "POST" }), {
+      params: Promise.resolve({ id: "ap_abc" }),
+    });
+    expect(res.status).toBe(201);
+    expect(mockResolveCustomer).not.toHaveBeenCalled();
+    expect(mockCreateDraft).toHaveBeenCalledWith(expect.objectContaining({ customerId: "cus_existing" }));
+  });
+});

--- a/docs/roadmap/agency-platform-backlog.md
+++ b/docs/roadmap/agency-platform-backlog.md
@@ -32,23 +32,13 @@ Percentages in the artifact (~75% marketing, ~60% CRM, ~15% ERP) are a snapshot,
 
 | Status | Item                                                  | Why                                                              | Notes                                                                       |
 | ------ | ----------------------------------------------------- | ---------------------------------------------------------------- | --------------------------------------------------------------------------- |
-<<<<<<< HEAD
-| Wait   | Customer Data Platform (new D1 + identity resolution) | 4–6 weeks. Only if join-by-email on `/admin/crm/[id]` is painful | Do not start four new D1 databases up front                                 |
-| Wait   | Marketing automation beyond ActiveCampaign            | Phase 2 in the artifact                                          | Use existing AC automations until the contact page shows gaps               |
-| **Done** | Invoicing                                             | Agency-only finance                                              | Stripe Invoicing admin (#1665) — no finance-db                              |
-| **Done (this branch)** | Projects + time tracking                              | Agency delivery, not ERP                                         | D1 `agency_project` + `time_entry`; `/admin/delivery` — not AppFlowy CMS, no project-db Worker |
-| **Done** | EspoCRM D1 cache                                      | Latency, not a new CRM                                           | `espocrm_cache` + 45–60s read-through; write-path invalidate; not a CDP     |
-| Wait   | Docs / contracts                                      | Phase 6                                                          | AppFlowy already hosts docs; do not add `docs-db` as a Worker               |
-| Wait   | AI agents on Cloudflare Workers                       | Artifact Phase 7                                                 | Keep LangGraph / Bedrock on the Pi app path                                 |
-=======
 | **Won’t / Defer** | Customer Data Platform (new D1 + identity resolution) | 4–6 weeks. Only if join-by-email on `/admin/crm/[id]` is painful | Contact 360 `matchHints` shows email-join gaps; revisit only after systematic multi-email miss rates |
 | **Stay on AC** | Marketing automation beyond ActiveCampaign            | Phase 2 in the artifact                                          | Integrations status flags missing `ACTIVECAMPAIGN_LEAD_AUTOMATION_ID`; keep AC until that surface shows real gaps |
 | **Done** | Invoicing                                             | Agency-only finance                                              | Stripe Invoicing admin (#1665) — no finance-db                              |
-| Wait   | Projects + time tracking                              | Agency delivery, not ERP                                         | After invoicing has a real operator workflow (#1666 open)                   |
-| Wait   | EspoCRM D1 cache                                      | Latency, not a new CRM                                           | After Notion adapters are gone (#1664 open)                                 |
+| **Done (this branch)** | Projects + time tracking                              | Agency delivery, not ERP                                         | D1 `agency_project` + `time_entry`; `/admin/delivery`; bill unbilled → Stripe draft |
+| **Done** | EspoCRM D1 cache                                      | Latency, not a new CRM                                           | `espocrm_cache` + 45–60s read-through; write-path invalidate; not a CDP     |
 | **Done (AppFlowy)** | Docs / contracts                                      | Phase 6                                                          | Category parse on `/admin/docs`; no `docs-db` Worker                        |
 | **Won’t** | AI agents on Cloudflare Workers                       | Artifact Phase 7                                                 | Workers AI for chat; LangGraph stays on Pi (`/admin/langgraph`)              |
->>>>>>> 6e8c77d6 (Close platform Wait items with diagnostics, not new platforms.)
 
 ## Explicitly out of scope
 

--- a/e2e/helpers/coverage-routes.ts
+++ b/e2e/helpers/coverage-routes.ts
@@ -261,6 +261,14 @@ export const ADMIN_API_DYNAMIC = [
     template: "/api/admin/crm/contacts/[id]",
     sample: "/api/admin/crm/contacts/abcdefghijklmnopq",
   },
+  {
+    template: "/api/admin/delivery/projects/[id]/time",
+    sample: "/api/admin/delivery/projects/ap_sample/time",
+  },
+  {
+    template: "/api/admin/delivery/projects/[id]/invoice",
+    sample: "/api/admin/delivery/projects/ap_sample/invoice",
+  },
 ] as const;
 
 export const AUTH_API = "/api/auth/session"; // NextAuth handler

--- a/src/app/[locale]/admin/delivery/page.tsx
+++ b/src/app/[locale]/admin/delivery/page.tsx
@@ -31,6 +31,7 @@ export default function DeliveryPage() {
   const [entries, setEntries] = useState<TimeEntry[]>([]);
   const [entriesLoading, setEntriesLoading] = useState(false);
   const [logging, setLogging] = useState(false);
+  const [billing, setBilling] = useState(false);
   const [form, setForm] = useState({
     name: "",
     clientEmail: "",
@@ -166,6 +167,36 @@ export default function DeliveryPage() {
     await loadProjects();
   }
 
+  async function billUnbilled() {
+    if (!selectedId) return;
+    setBilling(true);
+    setMessage(null);
+    try {
+      const res = await fetchWithAuth(`/api/admin/delivery/projects/${selectedId}/invoice`, {
+        method: "POST",
+      });
+      const data = (await res.json()) as {
+        invoice?: { id: string };
+        amountCents?: number;
+        totalMinutes?: number;
+        error?: string;
+      };
+      if (!res.ok) {
+        setMessage(data.error ?? `HTTP ${res.status}`);
+        return;
+      }
+      const euros = data.amountCents != null ? (data.amountCents / 100).toFixed(2) : "?";
+      setMessage(
+        `Draft ${data.invoice?.id} created (€${euros} for ${formatHours(data.totalMinutes ?? 0)}). Finalize/send under System → Invoices.`
+      );
+      await Promise.all([loadProjects(), loadEntries(selectedId)]);
+    } catch {
+      setMessage("Failed to create draft invoice");
+    } finally {
+      setBilling(false);
+    }
+  }
+
   const selected = projects.find((p) => p.id === selectedId) ?? null;
 
   return (
@@ -174,7 +205,8 @@ export default function DeliveryPage() {
         <h1 className="font-heading text-2xl tracking-tight text-white">Delivery</h1>
         <p className="mt-1 max-w-2xl text-sm text-slate-400">
           Agency projects and billable hours on D1. CMS portfolio stays under Content → Projects
-          (AppFlowy). Invoice unbilled hours from System → Invoices when ready.
+          (AppFlowy). Bill unbilled hours here to a Stripe draft; finalize/send under System →
+          Invoices.
         </p>
       </div>
 
@@ -290,15 +322,33 @@ export default function DeliveryPage() {
               <p className="text-sm text-slate-500">Select a project to log hours.</p>
             ) : (
               <>
-                <div>
-                  <h2 className="font-heading text-lg text-white">{selected.name}</h2>
-                  <p className="text-xs text-slate-500">
-                    Rate{" "}
-                    {selected.hourlyRateCents != null
-                      ? `${(selected.hourlyRateCents / 100).toFixed(2)} ${selected.currency}/h`
-                      : "unset"}{" "}
-                    · unbilled {formatHours(selected.unbilledMinutes)}
-                  </p>
+                <div className="flex flex-wrap items-start justify-between gap-3">
+                  <div>
+                    <h2 className="font-heading text-lg text-white">{selected.name}</h2>
+                    <p className="text-xs text-slate-500">
+                      Rate{" "}
+                      {selected.hourlyRateCents != null
+                        ? `${(selected.hourlyRateCents / 100).toFixed(2)} ${selected.currency}/h`
+                        : "unset"}{" "}
+                      · unbilled {formatHours(selected.unbilledMinutes)}
+                    </p>
+                  </div>
+                  <button
+                    type="button"
+                    disabled={
+                      billing ||
+                      selected.unbilledMinutes < 1 ||
+                      selected.hourlyRateCents == null ||
+                      selected.hourlyRateCents < 1 ||
+                      (!selected.clientEmail && !selected.stripeCustomerId)
+                    }
+                    onClick={() => {
+                      billUnbilled().catch(() => {});
+                    }}
+                    className="border-neon-cyan/40 bg-neon-cyan/10 text-neon-cyan rounded-lg border px-3 py-2 text-sm disabled:opacity-50"
+                  >
+                    {billing ? "Billing…" : "Bill unbilled → draft"}
+                  </button>
                 </div>
                 <form onSubmit={logTime} className="grid gap-2 sm:grid-cols-2">
                   <input

--- a/src/app/api/admin/delivery/projects/[id]/invoice/route.ts
+++ b/src/app/api/admin/delivery/projects/[id]/invoice/route.ts
@@ -6,11 +6,7 @@ import {
   markTimeEntriesInvoiced,
   setAgencyProjectStripeCustomer,
 } from "@/lib/agency-projects-d1";
-import {
-  createDraftInvoice,
-  getStripe,
-  resolveOrCreateCustomerByEmail,
-} from "@/lib/stripe";
+import { createDraftInvoice, getStripe, resolveOrCreateCustomerByEmail } from "@/lib/stripe";
 
 const AP_RE = /^ap_[a-zA-Z0-9-]+$/;
 

--- a/src/app/api/admin/delivery/projects/[id]/invoice/route.ts
+++ b/src/app/api/admin/delivery/projects/[id]/invoice/route.ts
@@ -1,0 +1,112 @@
+import { NextRequest, NextResponse } from "next/server";
+import { requireAdmin } from "@/lib/api-auth";
+import {
+  getAgencyProject,
+  listUnbilledBillableEntries,
+  markTimeEntriesInvoiced,
+  setAgencyProjectStripeCustomer,
+} from "@/lib/agency-projects-d1";
+import {
+  createDraftInvoice,
+  getStripe,
+  resolveOrCreateCustomerByEmail,
+} from "@/lib/stripe";
+
+const AP_RE = /^ap_[a-zA-Z0-9-]+$/;
+
+type RouteCtx = { params: Promise<{ id: string }> };
+
+/**
+ * Create a Stripe draft invoice from unbilled billable hours.
+ * Finalize/send stays on /admin/invoices.
+ */
+export async function POST(request: NextRequest, ctx: RouteCtx) {
+  const auth = await requireAdmin(request);
+  if (!auth.ok) return auth.response;
+
+  const { id } = await ctx.params;
+  if (!AP_RE.test(id)) {
+    return NextResponse.json({ error: "Invalid project id" }, { status: 400 });
+  }
+
+  const stripe = await getStripe();
+  if (!stripe) {
+    return NextResponse.json({ error: "Stripe not configured" }, { status: 503 });
+  }
+
+  const { bound, project } = await getAgencyProject(id);
+  if (!bound) {
+    return NextResponse.json({ error: "AUTH_DB not configured" }, { status: 503 });
+  }
+  if (!project) {
+    return NextResponse.json({ error: "Project not found" }, { status: 404 });
+  }
+
+  if (project.hourlyRateCents == null || project.hourlyRateCents < 1) {
+    return NextResponse.json(
+      { error: "Set an hourly rate on the project before billing" },
+      { status: 400 }
+    );
+  }
+
+  const { entries } = await listUnbilledBillableEntries(id);
+  if (entries.length === 0) {
+    return NextResponse.json({ error: "No unbilled billable hours" }, { status: 400 });
+  }
+
+  const totalMinutes = entries.reduce((sum, e) => sum + e.minutes, 0);
+  const amountCents = Math.round((totalMinutes * project.hourlyRateCents) / 60);
+  if (amountCents < 1) {
+    return NextResponse.json({ error: "Computed amount is zero" }, { status: 400 });
+  }
+
+  let customerId = project.stripeCustomerId;
+  if (!customerId) {
+    if (!project.clientEmail) {
+      return NextResponse.json(
+        { error: "Client email or Stripe customer required on the project" },
+        { status: 400 }
+      );
+    }
+    const resolved = await resolveOrCreateCustomerByEmail(project.clientEmail);
+    if (!resolved) {
+      return NextResponse.json({ error: "Could not resolve Stripe customer" }, { status: 500 });
+    }
+    customerId = resolved;
+    await setAgencyProjectStripeCustomer(id, customerId);
+  }
+
+  const hoursLabel = (totalMinutes / 60).toFixed(totalMinutes % 60 === 0 ? 0 : 1);
+  const description = `${project.name} — ${hoursLabel}h @ ${(project.hourlyRateCents / 100).toFixed(2)} ${project.currency}/h`;
+
+  try {
+    const invoice = await createDraftInvoice({
+      customerId,
+      description,
+      amountCents,
+      currency: project.currency.toLowerCase(),
+    });
+    if (!invoice) {
+      return NextResponse.json({ error: "Failed to create Stripe draft" }, { status: 500 });
+    }
+
+    const stamped = await markTimeEntriesInvoiced(
+      entries.map((e) => e.id),
+      invoice.id
+    );
+
+    return NextResponse.json(
+      {
+        invoice,
+        stamped,
+        totalMinutes,
+        amountCents,
+        entryCount: entries.length,
+      },
+      { status: 201 }
+    );
+  } catch (e) {
+    console.error("[delivery] invoice failed:", e);
+    return NextResponse.json({ error: "Invoice creation failed" }, { status: 500 });
+  }
+}

--- a/src/lib/agency-projects-d1.ts
+++ b/src/lib/agency-projects-d1.ts
@@ -411,9 +411,7 @@ export async function setAgencyProjectStripeCustomer(
   const now = Math.floor(Date.now() / 1000);
   try {
     const res = await db
-      .prepare(
-        `UPDATE agency_project SET stripe_customer_id = ?, updated_at = ? WHERE id = ?`
-      )
+      .prepare(`UPDATE agency_project SET stripe_customer_id = ?, updated_at = ? WHERE id = ?`)
       .bind(stripeCustomerId, now, projectId)
       .run();
     return (res.meta?.changes ?? 0) > 0;

--- a/src/lib/agency-projects-d1.ts
+++ b/src/lib/agency-projects-d1.ts
@@ -299,3 +299,125 @@ export async function createTimeEntry(input: {
     return null;
   }
 }
+
+export async function getAgencyProject(
+  id: string
+): Promise<{ bound: boolean; project: AgencyProject | null }> {
+  const db = getAuthDbFromEnv();
+  if (!db) return { bound: false, project: null };
+  if (!id.startsWith("ap_")) return { bound: true, project: null };
+
+  try {
+    const row = await db
+      .prepare(
+        `SELECT p.*,
+           COALESCE((SELECT SUM(minutes) FROM time_entry t WHERE t.project_id = p.id), 0) AS total_minutes,
+           COALESCE((
+             SELECT SUM(minutes) FROM time_entry t
+             WHERE t.project_id = p.id AND t.billable = 1 AND t.stripe_invoice_id IS NULL
+           ), 0) AS unbilled_minutes
+         FROM agency_project p
+         WHERE p.id = ?`
+      )
+      .bind(id)
+      .first<ProjectRow>();
+    return { bound: true, project: row ? mapProject(row) : null };
+  } catch (err) {
+    console.warn("[agency-projects-d1] get failed:", err instanceof Error ? err.message : err);
+    return { bound: true, project: null };
+  }
+}
+
+/** Billable entries not yet attached to a Stripe invoice. */
+export async function listUnbilledBillableEntries(
+  projectId: string
+): Promise<{ bound: boolean; entries: TimeEntry[] }> {
+  const db = getAuthDbFromEnv();
+  if (!db) return { bound: false, entries: [] };
+  if (!projectId.startsWith("ap_")) return { bound: true, entries: [] };
+
+  try {
+    const result = await db
+      .prepare(
+        `SELECT * FROM time_entry
+         WHERE project_id = ? AND billable = 1 AND stripe_invoice_id IS NULL
+         ORDER BY work_date ASC, created_at ASC`
+      )
+      .bind(projectId)
+      .all<EntryRow>();
+    return { bound: true, entries: (result.results ?? []).map(mapEntry) };
+  } catch (err) {
+    console.warn(
+      "[agency-projects-d1] list unbilled failed:",
+      err instanceof Error ? err.message : err
+    );
+    return { bound: true, entries: [] };
+  }
+}
+
+export async function markTimeEntriesInvoiced(
+  entryIds: string[],
+  stripeInvoiceId: string
+): Promise<number> {
+  const db = getAuthDbFromEnv();
+  if (!db || !stripeInvoiceId.startsWith("in_") || entryIds.length === 0) return 0;
+
+  const now = Math.floor(Date.now() / 1000);
+  let changed = 0;
+  try {
+    for (const id of entryIds) {
+      if (!id.startsWith("te_")) continue;
+      const res = await db
+        .prepare(
+          `UPDATE time_entry
+           SET stripe_invoice_id = ?
+           WHERE id = ? AND stripe_invoice_id IS NULL`
+        )
+        .bind(stripeInvoiceId, id)
+        .run();
+      changed += res.meta?.changes ?? 0;
+    }
+    const first = entryIds.find((id) => id.startsWith("te_"));
+    if (first) {
+      const row = await db
+        .prepare(`SELECT project_id FROM time_entry WHERE id = ?`)
+        .bind(first)
+        .first<{ project_id: string }>();
+      if (row?.project_id) {
+        await db
+          .prepare(`UPDATE agency_project SET updated_at = ? WHERE id = ?`)
+          .bind(now, row.project_id)
+          .run();
+      }
+    }
+    return changed;
+  } catch (err) {
+    console.warn(
+      "[agency-projects-d1] mark invoiced failed:",
+      err instanceof Error ? err.message : err
+    );
+    return changed;
+  }
+}
+
+export async function setAgencyProjectStripeCustomer(
+  projectId: string,
+  stripeCustomerId: string
+): Promise<boolean> {
+  const db = getAuthDbFromEnv();
+  if (!db || !projectId.startsWith("ap_") || !stripeCustomerId.startsWith("cus_")) {
+    return false;
+  }
+  const now = Math.floor(Date.now() / 1000);
+  try {
+    const res = await db
+      .prepare(
+        `UPDATE agency_project SET stripe_customer_id = ?, updated_at = ? WHERE id = ?`
+      )
+      .bind(stripeCustomerId, now, projectId)
+      .run();
+    return (res.meta?.changes ?? 0) > 0;
+  } catch {
+    return false;
+  }
+}


### PR DESCRIPTION
## Summary
- Follow-up to the agency delivery surface that landed via #1668’s mistaken squash.
- Adds `POST /api/admin/delivery/projects/[id]/invoice` to draft a Stripe invoice from unbilled time entries.

## Test plan
- [ ] Delivery admin shows invoice action
- [ ] Unit tests for invoice route pass
- [ ] Draft invoice created only for unbilled hours


Made with [Cursor](https://cursor.com)