### PR TITLE
Fix Stripe draft invoices attaching line items

### DIFF
--- a/__tests__/integrations-status-api.test.ts
+++ b/__tests__/integrations-status-api.test.ts
@@ -6,11 +6,13 @@ import { NextRequest } from "next/server";
 const requireAdminMock = vi.fn();
 const getConfigMock = vi.fn();
 const verifyACTokenMock = vi.fn();
+const getLeadAutomationStatusMock = vi.fn();
 
 vi.mock("@/lib/api-auth", () => ({ requireAdmin: requireAdminMock }));
 vi.mock("@/lib/ssm-config", () => ({ getConfig: getConfigMock }));
 vi.mock("@/lib/activecampaign", () => ({
   verifyActiveCampaignToken: verifyACTokenMock,
+  getLeadAutomationStatus: getLeadAutomationStatusMock,
 }));
 
 // fetch is used for live pings (EspoCRM, Slack, Notion, Stripe)
@@ -62,6 +64,10 @@ describe("GET /api/admin/integrations/status", () => {
     requireAdminMock.mockReturnValue({ ok: true, user: { sub: "admin" } });
     getConfigMock.mockResolvedValue({ ...baseConfig });
     verifyACTokenMock.mockResolvedValue({ status: "valid" });
+    getLeadAutomationStatusMock.mockResolvedValue({
+      apiConfigured: true,
+      leadAutomationIdSet: true,
+    });
     fetchMock.mockResolvedValue({
       ok: true,
       status: 200,
@@ -154,6 +160,19 @@ describe("GET /api/admin/integrations/status", () => {
     const ac = data.integrations.find((i: { id: string }) => i.id === "activecampaign");
     expect(ac.status).toBe("degraded");
     expect(ac.message).toContain("expired");
+  });
+
+  it("reports ActiveCampaign as degraded when lead automation ID is unset", async () => {
+    getLeadAutomationStatusMock.mockResolvedValueOnce({
+      apiConfigured: true,
+      leadAutomationIdSet: false,
+    });
+    const { GET } = await import("@/app/api/admin/integrations/status/route");
+    const res = await GET(makeRequest());
+    const data = await res.json();
+    const ac = data.integrations.find((i: { id: string }) => i.id === "activecampaign");
+    expect(ac.status).toBe("degraded");
+    expect(ac.message).toContain("ACTIVECAMPAIGN_LEAD_AUTOMATION_ID");
   });
 
   it("reports Sentry as degraded when DSN set but auth token missing", async () => {

--- a/__tests__/stripe-lib.test.ts
+++ b/__tests__/stripe-lib.test.ts
@@ -13,12 +13,17 @@ vi.mock("@/lib/ssm-config", () => ({
 const mockCheckoutSessionsList = vi.fn();
 const mockCustomersList = vi.fn();
 const mockSubscriptionsList = vi.fn();
+const mockInvoicesCreate = vi.fn();
+const mockInvoicesRetrieve = vi.fn();
+const mockInvoiceItemsCreate = vi.fn();
 
 vi.mock("stripe", () => {
   class MockStripe {
     checkout = { sessions: { list: mockCheckoutSessionsList } };
     customers = { list: mockCustomersList };
     subscriptions = { list: mockSubscriptionsList };
+    invoices = { create: mockInvoicesCreate, retrieve: mockInvoicesRetrieve };
+    invoiceItems = { create: mockInvoiceItemsCreate };
   }
   return { default: MockStripe };
 });
@@ -93,6 +98,90 @@ describe("stripe.ts", () => {
       const { listStripeProducts } = await import("@/lib/stripe");
       const products = await listStripeProducts();
       expect(products).toBeNull();
+    });
+  });
+
+  describe("createDraftInvoice", () => {
+    it("returns null when Stripe is not configured", async () => {
+      mockGetConfig.mockResolvedValue({});
+      const { createDraftInvoice } = await import("@/lib/stripe");
+      await expect(
+        createDraftInvoice({
+          customerId: "cus_1",
+          description: "Work",
+          amountCents: 15000,
+        })
+      ).resolves.toBeNull();
+    });
+
+    it("returns null for empty description or non-positive amount", async () => {
+      mockGetConfig.mockResolvedValue({ STRIPE_SECRET_KEY: "sk_test_123" });
+      const { createDraftInvoice } = await import("@/lib/stripe");
+      await expect(
+        createDraftInvoice({ customerId: "cus_1", description: "  ", amountCents: 100 })
+      ).resolves.toBeNull();
+      await expect(
+        createDraftInvoice({ customerId: "cus_1", description: "Work", amountCents: 0 })
+      ).resolves.toBeNull();
+      expect(mockInvoicesCreate).not.toHaveBeenCalled();
+    });
+
+    it("creates the draft first, attaches the line item to that invoice, then retrieves", async () => {
+      mockGetConfig.mockResolvedValue({ STRIPE_SECRET_KEY: "sk_test_123" });
+      mockInvoicesCreate.mockResolvedValue({ id: "in_draft" });
+      mockInvoiceItemsCreate.mockResolvedValue({ id: "ii_1" });
+      mockInvoicesRetrieve.mockResolvedValue({
+        id: "in_draft",
+        number: null,
+        customer: "cus_1",
+        customer_email: "a@b.com",
+        status: "draft",
+        amount_due: 15000,
+        amount_paid: 0,
+        currency: "eur",
+        created: 1_700_000_000,
+        hosted_invoice_url: null,
+        invoice_pdf: null,
+      });
+
+      const { createDraftInvoice } = await import("@/lib/stripe");
+      const invoice = await createDraftInvoice({
+        customerId: "cus_1",
+        description: "OpVal — 1.5h",
+        amountCents: 15000,
+        currency: "EUR",
+      });
+
+      expect(mockInvoicesCreate).toHaveBeenCalledWith(
+        expect.objectContaining({
+          customer: "cus_1",
+          collection_method: "send_invoice",
+          auto_advance: false,
+          pending_invoice_items_behavior: "exclude",
+        })
+      );
+      expect(mockInvoiceItemsCreate).toHaveBeenCalledWith(
+        expect.objectContaining({
+          customer: "cus_1",
+          invoice: "in_draft",
+          amount: 15000,
+          currency: "eur",
+          description: "OpVal — 1.5h",
+        })
+      );
+      const createOrder = mockInvoicesCreate.mock.invocationCallOrder[0];
+      const itemOrder = mockInvoiceItemsCreate.mock.invocationCallOrder[0];
+      const retrieveOrder = mockInvoicesRetrieve.mock.invocationCallOrder[0];
+      expect(createOrder).toBeLessThan(itemOrder);
+      expect(itemOrder).toBeLessThan(retrieveOrder);
+      expect(invoice).toEqual(
+        expect.objectContaining({
+          id: "in_draft",
+          amountDue: 15000,
+          status: "draft",
+          currency: "EUR",
+        })
+      );
     });
   });
 });

--- a/src/lib/stripe.ts
+++ b/src/lib/stripe.ts
@@ -213,20 +213,27 @@ export async function createDraftInvoice(input: {
   const description = input.description.trim().slice(0, 500);
   if (!description || input.amountCents < 1) return null;
 
+  // Create the draft first, then attach the line item to that invoice.
+  // Newer Stripe API versions default pending_invoice_items_behavior to
+  // "exclude", so a pre-created pending item never lands on the invoice
+  // (amount_due stays 0 and finalize can mark it paid immediately).
+  const draft = await stripe.invoices.create({
+    customer: input.customerId,
+    collection_method: "send_invoice",
+    days_until_due: input.daysUntilDue ?? 14,
+    auto_advance: false,
+    pending_invoice_items_behavior: "exclude",
+  });
+
   await stripe.invoiceItems.create({
     customer: input.customerId,
+    invoice: draft.id,
     amount: input.amountCents,
     currency,
     description,
   });
 
-  const invoice = await stripe.invoices.create({
-    customer: input.customerId,
-    collection_method: "send_invoice",
-    days_until_due: input.daysUntilDue ?? 14,
-    auto_advance: false,
-  });
-
+  const invoice = await stripe.invoices.retrieve(draft.id);
   return mapInvoice(invoice);
 }
 


### PR DESCRIPTION
## Summary
- Operator validation of Delivery → Bill found drafts with `amountDue: 0`; finalize marked them `paid` immediately.
- Root cause: pending invoice items are excluded by default on newer Stripe API versions when the item is created before the invoice.
- Fix: create the draft first, then `invoiceItems.create({ invoice: draft.id, ... })`, then retrieve.

## Test plan
- [x] Existing invoice + delivery invoice unit tests
- [ ] After deploy: bill 1.5h @ €100 → draft `amountDue` = 15000; finalize stays `open` (not auto-paid); do not send


Made with [Cursor](https://cursor.com)