### PR TITLE
Fix LinkedIn ad analytics metrics + ROI day window

### DIFF
--- a/.github/workflows/linkedin-poll.yml
+++ b/.github/workflows/linkedin-poll.yml
@@ -60,20 +60,32 @@ jobs:
           exit 1
         fi
         BODY=$(mktemp)
-        STATUS=$(curl -sS -o "$BODY" -w "%{http_code}" \
-          -H "Authorization: Bearer ${CRON_SECRET}" \
-          -H "User-Agent: github-actions/linkedin-poll" \
-          --max-time 90 \
-          "${SITE_ORIGIN}/api/cron/ad-analytics-poll")
-        echo "HTTP $STATUS"
+        STATUS="000"
+        # Retry transient tunnel/origin 502s (deploy blips); fail fast on CF challenges.
+        for attempt in 1 2 3; do
+          STATUS=$(curl -sS -o "$BODY" -w "%{http_code}" \
+            -H "Authorization: Bearer ${CRON_SECRET}" \
+            -H "User-Agent: github-actions/linkedin-poll" \
+            --max-time 90 \
+            "${SITE_ORIGIN}/api/cron/ad-analytics-poll" || echo "000")
+          echo "attempt ${attempt}: HTTP ${STATUS}"
+          if grep -qiE 'Just a moment|cf-browser-verification|challenge-platform' "$BODY"; then
+            echo "::error::Cloudflare Bot Fight Mode intercepted the cron call (not an app 403). Re-run workflow cloudflare-skip-cron-challenge.yml (disables bot_fight_mode) or turn Bot Fight Mode off in the CF dashboard."
+            exit 1
+          fi
+          if [ "$STATUS" = "200" ]; then
+            break
+          fi
+          if [ "$attempt" -lt 3 ] && [[ "$STATUS" =~ ^(502|503|504|000)$ ]]; then
+            sleep $((attempt * 15))
+            continue
+          fi
+          break
+        done
         # Truncate to keep the workflow log readable when the campaign set
         # grows; the full payload lives in CloudWatch.
         head -c 4096 "$BODY" || true
         echo
-        if grep -qiE 'Just a moment|cf-browser-verification|challenge-platform' "$BODY"; then
-          echo "::error::Cloudflare Bot Fight Mode intercepted the cron call (not an app 403). Re-run workflow cloudflare-skip-cron-challenge.yml (disables bot_fight_mode) or turn Bot Fight Mode off in the CF dashboard."
-          exit 1
-        fi
         if [ "$STATUS" != "200" ]; then
           echo "::error::poll returned non-200 status: $STATUS"
           exit 1

--- a/__tests__/ad-analytics/linkedin-adapter.test.ts
+++ b/__tests__/ad-analytics/linkedin-adapter.test.ts
@@ -105,3 +105,53 @@ describe("linkedinAdapter.pushConversion", () => {
     expect(headers.Authorization).toBe("Bearer capi_only_token");
   });
 });
+
+describe("linkedinAdapter.pullMetrics", () => {
+  it("uses Rest.li List(urn%3Ali%3AsponsoredCampaign%3A…) like the ETL path", async () => {
+    fetchSpy.mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          elements: [
+            {
+              impressions: 10,
+              clicks: 2,
+              costInLocalCurrency: "3.5",
+              externalWebsiteConversions: 1,
+            },
+          ],
+        }),
+        { status: 200 }
+      )
+    );
+    const { linkedinAdapter } = await import("@/lib/ad-analytics/adapters/linkedin");
+    const rows = await linkedinAdapter.pullMetrics({
+      accountId: "511588554",
+      campaignIds: ["123456789"],
+      since: new Date("2026-08-01T00:00:00Z"),
+      until: new Date("2026-08-14T00:00:00Z"),
+    });
+
+    expect(fetchSpy).toHaveBeenCalled();
+    const url = fetchSpy.mock.calls[0][0] as string;
+    expect(url).toContain("campaigns=List(urn%3Ali%3AsponsoredCampaign%3A123456789)");
+    expect(url).toContain("timeGranularity=ALL");
+    expect(url).toContain("dateRange=(start:(year:2026,month:8,day:1)");
+    expect(url).not.toContain("campaigns[0]=");
+    expect(rows[0]?.impressions).toBe(10);
+    expect(rows[0]?.spendEur).toBe(3.5);
+  });
+
+  it("logs and returns zeros when LinkedIn rejects the query", async () => {
+    fetchSpy.mockResolvedValue(new Response("bad query", { status: 400 }));
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const { linkedinAdapter } = await import("@/lib/ad-analytics/adapters/linkedin");
+    const rows = await linkedinAdapter.pullMetrics({
+      accountId: "511588554",
+      campaignIds: ["123456789"],
+      since: new Date("2026-08-01T00:00:00Z"),
+      until: new Date("2026-08-14T00:00:00Z"),
+    });
+    expect(rows[0]?.impressions).toBe(0);
+    expect(warnSpy).toHaveBeenCalled();
+  });
+});

--- a/__tests__/admin-roi-lake-honesty.test.ts
+++ b/__tests__/admin-roi-lake-honesty.test.ts
@@ -21,8 +21,11 @@ describe("getRoiFromLake honesty", () => {
       sections: [
         {
           section: "linkedin_ads",
-          rows: [{ spend: 12.5, impressions: 100, clicks: 4, conversions: 1 }],
-          rowCount: 1,
+          rows: [
+            { day: "2026-08-10", spend: 12.5, impressions: 100, clicks: 4, conversions: 1 },
+            { day: "2026-06-01", spend: 99, impressions: 999, clicks: 50, conversions: 0 },
+          ],
+          rowCount: 2,
         },
         {
           section: "stripe_revenue",
@@ -41,9 +44,12 @@ describe("getRoiFromLake honesty", () => {
       configured: boolean;
       status: string;
       inGold: boolean;
+      spendCents: number;
     }>;
     expect(channels.find((c) => c.channel === "linkedin")?.configured).toBe(true);
     expect(channels.find((c) => c.channel === "linkedin")?.status).toBe("gold");
+    // Old June row excluded from 30d window; only Aug 10 spend remains.
+    expect(channels.find((c) => c.channel === "linkedin")?.spendCents).toBe(1250);
     for (const name of ["google", "tiktok", "x", "meta"]) {
       const ch = channels.find((c) => c.channel === name);
       expect(ch?.configured).toBe(false);
@@ -52,5 +58,17 @@ describe("getRoiFromLake honesty", () => {
     }
     expect(roi.goldSections).toEqual(["linkedin_ads", "stripe_revenue"]);
     expect(String(roi.notes)).toContain("not_in_gold");
+  });
+
+  it("widening the window includes older LinkedIn gold days", async () => {
+    const { getRoiFromLake } = await import("@/lib/datalake-serve");
+    const narrow = await getRoiFromLake(30);
+    const wide = await getRoiFromLake(120);
+    const spend = (roi: Record<string, unknown>) =>
+      (roi.channels as Array<{ channel: string; spendCents: number }>).find(
+        (c) => c.channel === "linkedin"
+      )?.spendCents;
+    expect(spend(narrow)).toBe(1250);
+    expect(spend(wide)).toBe(1250 + 9900);
   });
 });

--- a/src/app/[locale]/admin/analytics/unified/page.tsx
+++ b/src/app/[locale]/admin/analytics/unified/page.tsx
@@ -158,7 +158,7 @@ function RoiSection({ roi }: Readonly<{ roi: RoiData | null }>) {
         <KpiCard
           label="New leads"
           value={roi.totals.newLeads === null ? "—" : String(roi.totals.newLeads)}
-          sub={roi.totals.newLeads === null ? "EspoCRM not configured" : "EspoCRM contacts"}
+          sub={roi.totals.newLeads === null ? "not in gold ROI" : "EspoCRM contacts"}
           color="text-neon-cyan"
         />
         <KpiCard

--- a/src/lib/ad-analytics/adapters/linkedin.ts
+++ b/src/lib/ad-analytics/adapters/linkedin.ts
@@ -323,14 +323,14 @@ async function fetchHeadlineMetrics(
       }>;
     };
     const els = data.elements ?? [];
-    return els.reduce(
+    return els.reduce<HeadlineMetrics>(
       (acc, el) => ({
         impressions: acc.impressions + (el.impressions ?? 0),
         clicks: acc.clicks + (el.clicks ?? 0),
         conversions: acc.conversions + (el.externalWebsiteConversions ?? 0),
         spendEur: acc.spendEur + Number(el.costInLocalCurrency ?? 0),
       }),
-      { ...empty }
+      empty
     );
   } catch (err) {
     console.warn(

--- a/src/lib/ad-analytics/adapters/linkedin.ts
+++ b/src/lib/ad-analytics/adapters/linkedin.ts
@@ -12,8 +12,9 @@
  *  - `pushConversion()` returns `{ accepted, status }` instead of throwing on
  *    403, so the runtime can degrade cleanly when the operator hasn't yet
  *    created a `CONVERSIONS_API`-typed conversion in Campaign Manager.
- *  - `pullMetrics()` is a Phase-2 stub. Phase 1 only exercises the conversion
- *    path; the digest poll lands in a later PR.
+ *  - `pullMetrics()` uses the same Rest.li `List(urn%3Ali%3A…)` +
+ *    `dateRange=(start:(…),end:(…))` shape as `scripts/etl/linkedin-ads-to-r2.mjs`
+ *    (bracket form `campaigns[0]=` returns empty / non-OK under Rest.li 2.0).
  *
  * Reference: skills/ad-analytics/SKILL.md operating principle #2
  * (the Gilgamesh source-bound CAPI gotcha) + #3 (the version pin).
@@ -251,38 +252,54 @@ interface HeadlineMetrics {
   spendEur: number;
 }
 
-/** LinkedIn wants the date-range params spread across `start.day/month/year`
- *  and `end.day/month/year` — encode here once so both fetch paths reuse it. */
+/** Rest.li dateRange tuple — must match `scripts/etl/linkedin-ads-to-r2.mjs`. */
 function formatDateRange(since: Date, until: Date): string {
   const s = ymd(since);
   const u = ymd(until);
-  return (
-    `dateRange.start.day=${s.day}` +
-    `&dateRange.start.month=${s.month}` +
-    `&dateRange.start.year=${s.year}` +
-    `&dateRange.end.day=${u.day}` +
-    `&dateRange.end.month=${u.month}` +
-    `&dateRange.end.year=${u.year}`
-  );
+  return `dateRange=(start:(year:${s.year},month:${s.month},day:${s.day}),end:(year:${u.year},month:${u.month},day:${u.day}))`;
 }
 
 function ymd(d: Date): { day: number; month: number; year: number } {
   return { day: d.getUTCDate(), month: d.getUTCMonth() + 1, year: d.getUTCFullYear() };
 }
 
+/** Rest.li List() of a sponsoredCampaign URN (colons percent-encoded). */
+function campaignListParam(campaignId: string): string {
+  const id = String(campaignId).replace(/[^\w-]/g, "");
+  return `campaigns=List(urn%3Ali%3AsponsoredCampaign%3A${id})`;
+}
+
+function buildAdAnalyticsPath(opts: {
+  pivot: string;
+  dateRangeParam: string;
+  campaignId: string;
+  fields: string;
+  timeGranularity: "ALL" | "DAILY";
+}): string {
+  return (
+    `/adAnalytics?q=analytics&pivot=${opts.pivot}` +
+    `&timeGranularity=${opts.timeGranularity}` +
+    `&${campaignListParam(opts.campaignId)}` +
+    `&${opts.dateRangeParam}` +
+    `&fields=${opts.fields}`
+  );
+}
+
 async function fetchHeadlineMetrics(
   token: string,
-  accountId: string,
+  _accountId: string,
   campaignId: string,
   dateRangeParam: string
 ): Promise<HeadlineMetrics> {
   const empty: HeadlineMetrics = { impressions: 0, clicks: 0, conversions: 0, spendEur: 0 };
   try {
-    const path =
-      `/adAnalytics?q=analytics&pivot=CAMPAIGN&${dateRangeParam}` +
-      `&campaigns[0]=urn:li:sponsoredCampaign:${encodeURIComponent(campaignId)}` +
-      `&accounts[0]=urn:li:sponsoredAccount:${encodeURIComponent(accountId)}` +
-      `&fields=impressions,clicks,costInLocalCurrency,externalWebsiteConversions`;
+    const path = buildAdAnalyticsPath({
+      pivot: "CAMPAIGN",
+      dateRangeParam,
+      campaignId,
+      timeGranularity: "ALL",
+      fields: "impressions,clicks,costInLocalCurrency,externalWebsiteConversions",
+    });
     const res = await fetch(`${LINKEDIN_API_ROOT}${path}`, {
       headers: {
         Authorization: `Bearer ${token}`,
@@ -290,7 +307,13 @@ async function fetchHeadlineMetrics(
         [RESTLI_PROTOCOL_HEADER]: RESTLI_PROTOCOL_VERSION,
       },
     });
-    if (!res.ok) return empty;
+    if (!res.ok) {
+      const body = (await res.text().catch(() => "")).slice(0, 200);
+      console.warn(
+        `[ad-analytics/linkedin] adAnalytics ${res.status} campaign=${campaignId}: ${body}`
+      );
+      return empty;
+    }
     const data = (await res.json()) as {
       elements?: Array<{
         impressions?: number;
@@ -299,31 +322,40 @@ async function fetchHeadlineMetrics(
         externalWebsiteConversions?: number;
       }>;
     };
-    const el = data.elements?.[0] ?? {};
-    return {
-      impressions: el.impressions ?? 0,
-      clicks: el.clicks ?? 0,
-      conversions: el.externalWebsiteConversions ?? 0,
-      spendEur: Number(el.costInLocalCurrency ?? 0),
-    };
-  } catch {
+    const els = data.elements ?? [];
+    return els.reduce(
+      (acc, el) => ({
+        impressions: acc.impressions + (el.impressions ?? 0),
+        clicks: acc.clicks + (el.clicks ?? 0),
+        conversions: acc.conversions + (el.externalWebsiteConversions ?? 0),
+        spendEur: acc.spendEur + Number(el.costInLocalCurrency ?? 0),
+      }),
+      { ...empty }
+    );
+  } catch (err) {
+    console.warn(
+      `[ad-analytics/linkedin] adAnalytics fetch failed campaign=${campaignId}:`,
+      err instanceof Error ? err.message : err
+    );
     return empty;
   }
 }
 
 async function fetchPivotBreakdown(
   token: string,
-  accountId: string,
+  _accountId: string,
   campaignId: string,
   dateRangeParam: string,
   pivot: DemographicPivot
 ): Promise<DemographicBreakdown> {
   try {
-    const path =
-      `/adAnalytics?q=analytics&pivot=${pivot}&${dateRangeParam}` +
-      `&campaigns[0]=urn:li:sponsoredCampaign:${encodeURIComponent(campaignId)}` +
-      `&accounts[0]=urn:li:sponsoredAccount:${encodeURIComponent(accountId)}` +
-      `&fields=clicks,pivotValues`;
+    const path = buildAdAnalyticsPath({
+      pivot,
+      dateRangeParam,
+      campaignId,
+      timeGranularity: "ALL",
+      fields: "clicks,pivotValues",
+    });
     const res = await fetch(`${LINKEDIN_API_ROOT}${path}`, {
       headers: {
         Authorization: `Bearer ${token}`,
@@ -331,7 +363,13 @@ async function fetchPivotBreakdown(
         [RESTLI_PROTOCOL_HEADER]: RESTLI_PROTOCOL_VERSION,
       },
     });
-    if (!res.ok) return [];
+    if (!res.ok) {
+      const body = (await res.text().catch(() => "")).slice(0, 200);
+      console.warn(
+        `[ad-analytics/linkedin] pivot ${pivot} ${res.status} campaign=${campaignId}: ${body}`
+      );
+      return [];
+    }
     const data = (await res.json()) as {
       elements?: Array<{ clicks?: number; pivotValues?: string[] }>;
     };

--- a/src/lib/datalake-serve.ts
+++ b/src/lib/datalake-serve.ts
@@ -298,9 +298,16 @@ export function pipelineFromEspocrmGold(rows: Record<string, unknown>[]): {
  * until a real silver ETL lands. Never calls live `roi.ts` adapters.
  */
 export async function getRoiFromLake(days = 30): Promise<Record<string, unknown>> {
+  const windowDays = Math.min(Math.max(Math.floor(days) || 30, 1), 365);
   const linkedin = await getGoldSection("linkedin_ads");
   const stripe = await getGoldSection(SECTION_STRIPE_REVENUE);
-  const linkedinRows = linkedin?.rows ?? [];
+  const cutoffMs = Date.now() - windowDays * 86_400_000;
+  const linkedinRows = (linkedin?.rows ?? []).filter((r) => {
+    const day = String(r.day ?? r.date ?? "").slice(0, 10);
+    if (!/^\d{4}-\d{2}-\d{2}$/.test(day)) return true;
+    const t = Date.parse(`${day}T00:00:00Z`);
+    return Number.isFinite(t) && t >= cutoffMs;
+  });
   const spendCents = linkedinRows.reduce(
     (a, r) => a + Math.round((Number(r.spend ?? r.cost) || 0) * 100),
     0
@@ -336,8 +343,8 @@ export async function getRoiFromLake(days = 30): Promise<Record<string, unknown>
       reason: linkedin?.error
         ? `linkedin_ads: ${linkedin.error}`
         : linkedinConfigured
-          ? "Served from gold linkedin_ads"
-          : "Gold section present but empty",
+          ? `Served from gold linkedin_ads (last ${windowDays}d)`
+          : "Gold section present but empty for window",
       spendCents,
       impressions,
       clicks,
@@ -356,7 +363,7 @@ export async function getRoiFromLake(days = 30): Promise<Record<string, unknown>
   const platformLeads = channels.reduce((a, c) => a + c.platformLeads, 0);
 
   return {
-    windowDays: days,
+    windowDays,
     generatedAt: new Date().toISOString(),
     source: DATALAKE_GOLD_SOURCE,
     goldSections: ["linkedin_ads", SECTION_STRIPE_REVENUE],
@@ -377,6 +384,7 @@ export async function getRoiFromLake(days = 30): Promise<Record<string, unknown>
     notes: [
       "ROI is lake-backed (LinkedIn + Stripe gold). Google/TikTok/X/Meta show as not_in_gold until their ETL exists.",
       "Live campaign adapters in roi.ts are not used on admin analytics routes.",
+      "newLeads is not in gold ROI (EspoCRM funnel is a separate gold section).",
       linkedin?.error ? `linkedin_ads: ${linkedin.error}` : null,
       stripe?.error ? `stripe_revenue: ${stripe.error}` : null,
     ].filter(Boolean),


### PR DESCRIPTION
## Summary
- **LinkedIn `pullMetrics`:** use Rest.li `campaigns=List(urn%3Ali%3AsponsoredCampaign%3A…)` + `dateRange=(start:(…),end:(…))` + `timeGranularity=ALL` (same shape as `linkedin-ads-to-r2.mjs`). Bracket form was returning empty/non-OK with silent zeros.
- Log non-OK adAnalytics responses; sum elements when present.
- **`getRoiFromLake(days)`:** filter `linkedin_ads` gold rows by `day` so Unified “last N days” spend is honest.
- Unified KPI copy: `newLeads` null → “not in gold ROI” (not “EspoCRM not configured”).
- LinkedIn poll workflow: retry up to 3× on 502/503/504 (deploy blips on pi-origin).

## Test plan
- [x] `vitest` ad-analytics + ROI honesty (52 passed)
- [ ] After deploy: `/cloudless-analytics ads <slug>` or cron poll shows non-zero when LinkedIn has spend
- [ ] Unified ROI 7d vs 90d changes LinkedIn spend when multi-day gold exists


Made with [Cursor](https://cursor.com)