### PR TITLE
Add Tailscale fleet health + upgrade workflow

### DIFF
--- a/.github/workflows/tailscale-fleet-health.yml
+++ b/.github/workflows/tailscale-fleet-health.yml
@@ -1,0 +1,167 @@
+# Inventory Tailscale devices, remediate managed Linux hosts, upgrade to latest.
+#
+# Inventory (API) runs on ubuntu-latest.
+# Fix/upgrade SSH runs on the omv self-hosted runner (LAN to both Pis) because
+# GH-hosted Tailscale SSH has been unreliable for OMV_SSH_KEY / ACL paths.
+name: Tailscale fleet health + upgrade
+
+on:
+  schedule:
+    # Weekly Sunday 04:15 UTC — check + upgrade Pis to latest stable.
+    - cron: '15 4 * * 0'
+  workflow_dispatch:
+    inputs:
+      fix:
+        description: Restart inactive tailscaled on managed hosts
+        required: false
+        default: true
+        type: boolean
+      upgrade:
+        description: apt-upgrade Tailscale to latest stable on managed hosts
+        required: false
+        default: true
+        type: boolean
+      dry_run:
+        description: Print plan only (no restart / apt)
+        required: false
+        default: false
+        type: boolean
+      fail_on_issues:
+        description: Fail inventory job if managed hosts are offline/outdated
+        required: false
+        default: false
+        type: boolean
+
+permissions:
+  contents: read
+  issues: write
+
+concurrency:
+  group: tailscale-fleet-health
+  cancel-in-progress: false
+
+jobs:
+  inventory:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    outputs:
+      managed_offline: ${{ steps.summary.outputs.managed_offline }}
+      managed_outdated: ${{ steps.summary.outputs.managed_outdated }}
+      latest: ${{ steps.summary.outputs.latest }}
+    env:
+      TS_CLIENT_ID: ${{ secrets.TS_CLIENT_ID }}
+      TS_CLIENT_SECRET: ${{ secrets.TS_CLIENT_SECRET }}
+      TAILSCALE_OAUTH_CLIENT_ID: ${{ secrets.TAILSCALE_OAUTH_CLIENT_ID }}
+      TAILSCALE_OAUTH_CLIENT_SECRET: ${{ secrets.TAILSCALE_OAUTH_CLIENT_SECRET }}
+      TAILSCALE_OAUTH_SECRET: ${{ secrets.TAILSCALE_OAUTH_SECRET }}
+      TS_API_KEY: ${{ secrets.TS_API_KEY }}
+      TAILSCALE_TAILNET: tail4ecae1.ts.net
+      FAIL_ON_ISSUES: ${{ inputs.fail_on_issues && '1' || '0' }}
+      JSON_OUT: ${{ github.workspace }}/tailscale-fleet-report.json
+    steps:
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd         # v4.3.1
+
+    - name: Install jq
+      run: sudo apt-get update -qq && sudo apt-get install -y -qq jq
+
+    - name: Check Tailscale OAuth / API secrets
+      run: |
+        if [ -z "${TS_API_KEY:-}" ] && { [ -z "${TS_CLIENT_ID:-}${TAILSCALE_OAUTH_CLIENT_ID:-}" ] || [ -z "${TS_CLIENT_SECRET:-}${TAILSCALE_OAUTH_CLIENT_SECRET:-}${TAILSCALE_OAUTH_SECRET:-}" ]; }; then
+          echo "::error::Need TS_API_KEY or TS_CLIENT_ID+TS_CLIENT_SECRET (OAuth) in repo secrets"
+          exit 1
+        fi
+        echo "Tailscale API credentials present"
+
+    - name: Inventory fleet
+      id: health
+      run: bash scripts/tailscale-fleet-health.sh
+
+    - name: Summarize
+      id: summary
+      run: |
+        REPORT="${JSON_OUT}"
+        echo "latest=$(jq -r .latest "$REPORT")" >> "$GITHUB_OUTPUT"
+        echo "managed_offline=$(jq -r '.managedOffline | join(",")' "$REPORT")" >> "$GITHUB_OUTPUT"
+        echo "managed_outdated=$(jq -r '.managedOutdated | join(",")' "$REPORT")" >> "$GITHUB_OUTPUT"
+        {
+          echo "### Tailscale fleet inventory"
+          echo ""
+          echo "- Latest stable: \`$(jq -r .latest "$REPORT")\`"
+          echo "- Managed offline: \`$(jq -r '.managedOffline | join(", ") // "none"' "$REPORT")\`"
+          echo "- Managed outdated: \`$(jq -r '.managedOutdated | join(", ") // "none"' "$REPORT")\`"
+          echo ""
+          echo '```'
+          jq -r '.devices[] | "\(.hostname)\t\(.os)\t\(.online)\t\(.version)\t\(.tags)"' "$REPORT"
+          echo '```'
+        } >> "$GITHUB_STEP_SUMMARY"
+
+    - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a         # v7.0.1
+      with:
+        name: tailscale-fleet-report
+        path: tailscale-fleet-report.json
+        if-no-files-found: error
+        retention-days: 14
+
+  remediate:
+    needs: inventory
+    # Must run on omv — LAN SSH to both Pis; GH-hosted TS SSH is flaky.
+    runs-on: [self-hosted, omv, pi]
+    timeout-minutes: 20
+    # Schedule always remediates + upgrades. Dispatch uses inputs.
+    if: |
+      github.event_name == 'schedule' ||
+      inputs.fix == true ||
+      inputs.upgrade == true
+    env:
+      DRY_RUN: ${{ github.event_name == 'workflow_dispatch' && inputs.dry_run && '1' || '0' }}
+      FIX: ${{ github.event_name == 'schedule' && '1' || (inputs.fix && '1' || '0') }}
+      UPGRADE: ${{ github.event_name == 'schedule' && '1' || (inputs.upgrade && '1' || '0') }}
+      SSH_USER: tbaltzakis
+    steps:
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd         # v4.3.1
+
+    - name: Remediating / upgrading managed hosts
+      run: |
+        echo "Inventory said offline=[${{ needs.inventory.outputs.managed_offline }}] outdated=[${{ needs.inventory.outputs.managed_outdated }}] latest=${{ needs.inventory.outputs.latest }}"
+        bash scripts/tailscale-fleet-upgrade.sh
+
+    - name: Post-upgrade local status
+      if: always()
+      run: |
+        echo "=== Local (omv runner) ==="
+        systemctl is-active tailscaled || true
+        tailscale version | head -3 || true
+        tailscale status --self || true
+        echo "=== Peer ping omv-ha ==="
+        tailscale ping -c 2 --timeout=5s omv-ha 2>&1 || true
+
+  notify:
+    needs: [inventory, remediate]
+    if: always() && github.event_name == 'schedule'
+    runs-on: ubuntu-latest
+    steps:
+    - name: Comment tracking issue on failure
+      env:
+        GH_TOKEN: ${{ github.token }}
+      run: |
+        INV="${{ needs.inventory.result }}"
+        REM="${{ needs.remediate.result }}"
+        if [ "$INV" = "success" ] && { [ "$REM" = "success" ] || [ "$REM" = "skipped" ]; }; then
+          echo "Fleet health OK — no issue comment"
+          exit 0
+        fi
+        BODY=$(cat <<EOF
+        ## Tailscale fleet health failed
+
+        - Inventory: \`$INV\`
+        - Remediates: \`$REM\`
+        - Offline: \`${{ needs.inventory.outputs.managed_offline }}\`
+        - Outdated: \`${{ needs.inventory.outputs.managed_outdated }}\`
+        - Latest: \`${{ needs.inventory.outputs.latest }}\`
+
+        Run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+
+        Manual: \`FIX=1 UPGRADE=1 bash scripts/tailscale-fleet-upgrade.sh\` on omv.
+        EOF
+        )
+        gh issue comment 382 --repo "$GITHUB_REPOSITORY" --body "$BODY" || true

--- a/scripts/tailscale-fleet-health.sh
+++ b/scripts/tailscale-fleet-health.sh
@@ -1,0 +1,185 @@
+#!/usr/bin/env bash
+# Inventory every Tailscale device: online/offline, version vs latest stable,
+# and flag managed Linux hosts that need a fix or upgrade.
+#
+# Auth: TS_API_KEY  OR  TS_CLIENT_ID + TS_CLIENT_SECRET (OAuth)
+#
+# Usage:
+#   bash scripts/tailscale-fleet-health.sh
+#   FAIL_ON_ISSUES=1 bash scripts/tailscale-fleet-health.sh
+#   JSON_OUT=/tmp/fleet.json bash scripts/tailscale-fleet-health.sh
+set -euo pipefail
+
+TAILNET="${TAILSCALE_TAILNET:-tail4ecae1.ts.net}"
+API="${TAILSCALE_API_BASE:-https://api.tailscale.com/api/v2}"
+FAIL_ON_ISSUES="${FAIL_ON_ISSUES:-0}"
+JSON_OUT="${JSON_OUT:-}"
+case "${FAIL_ON_ISSUES}" in 1|true|TRUE|yes|YES) FAIL_ON_ISSUES=1 ;; *) FAIL_ON_ISSUES=0 ;; esac
+
+# Hostnames we expect to keep online (physical / always-on). Ephemeral GHA
+# nodes and user laptops are reported but do not fail the job by default.
+MANAGED_RE='^(github-omv|omv|omv-main|omv-ha|omv-2)$'
+
+need() { command -v "$1" >/dev/null || { echo "missing $1" >&2; exit 1; }; }
+need curl
+need jq
+need python3
+
+auth_header() {
+  if [[ -n "${TS_API_KEY:-}" ]]; then
+    echo "Authorization: Basic $(printf '%s:' "$TS_API_KEY" | base64 -w0 2>/dev/null || printf '%s:' "$TS_API_KEY" | base64)"
+    return
+  fi
+  local id="${TS_CLIENT_ID:-${TAILSCALE_OAUTH_CLIENT_ID:-}}"
+  local secret="${TS_CLIENT_SECRET:-${TAILSCALE_OAUTH_CLIENT_SECRET:-${TAILSCALE_OAUTH_SECRET:-}}}"
+  if [[ -z "$id" || -z "$secret" ]]; then
+    echo "Set TS_API_KEY or TS_CLIENT_ID+TS_CLIENT_SECRET" >&2
+    exit 2
+  fi
+  local tok
+  tok=$(curl -fsS -u "${id}:${secret}" \
+    -d grant_type=client_credentials \
+    "$API/oauth/token" | jq -r .access_token)
+  [[ -n "$tok" && "$tok" != null ]] || { echo "OAuth token exchange failed" >&2; exit 2; }
+  echo "Authorization: Bearer $tok"
+}
+
+AUTH="$(auth_header)"
+echo "==> Authenticated for tailnet $TAILNET"
+
+LATEST=$(curl -fsSL 'https://pkgs.tailscale.com/stable/?mode=json' | jq -r '.TarballsVersion // empty')
+[[ -n "$LATEST" ]] || { echo "Could not resolve latest Tailscale stable version" >&2; exit 1; }
+echo "==> Latest stable Tailscale: $LATEST"
+
+DEVICES_FILE=$(mktemp)
+REPORT_FILE=$(mktemp)
+trap 'rm -f "$DEVICES_FILE" "$REPORT_FILE"' EXIT
+
+curl -fsS -H "$AUTH" -H 'Accept: application/json' \
+  "$API/tailnet/$TAILNET/devices" >"$DEVICES_FILE"
+
+python3 - "$DEVICES_FILE" "$LATEST" "$MANAGED_RE" "$REPORT_FILE" <<'PY'
+import json, re, sys
+from datetime import datetime, timezone
+
+path, latest, managed_re, out_path = sys.argv[1:5]
+managed = re.compile(managed_re)
+data = json.load(open(path))
+devices = data.get("devices") or []
+now = datetime.now(timezone.utc)
+
+def short_name(d):
+    name = d.get("name") or d.get("hostname") or ""
+    return name.split(".")[0].lower()
+
+def ver_tuple(v: str):
+    # "1.102.2-tdeadbeef" / "1.102.2" → (1,102,2)
+    base = (v or "").split("-")[0].strip()
+    parts = []
+    for p in base.split("."):
+        try:
+            parts.append(int(p))
+        except ValueError:
+            parts.append(0)
+    while len(parts) < 3:
+        parts.append(0)
+    return tuple(parts[:3])
+
+def is_online(d):
+    # Prefer connectedToControl; fall back to lastSeen within 5 minutes.
+    if d.get("connectedToControl") is True:
+        return True
+    if d.get("connectedToControl") is False:
+        return False
+    last = d.get("lastSeen")
+    if not last:
+        return False
+    try:
+        ts = datetime.fromisoformat(last.replace("Z", "+00:00"))
+    except ValueError:
+        return False
+    return (now - ts).total_seconds() < 300
+
+rows = []
+issues = []
+for d in sorted(devices, key=lambda x: short_name(x)):
+    short = short_name(d)
+    os_name = (d.get("os") or d.get("osType") or "?").lower()
+    cv = d.get("clientVersion") or ""
+    ver = cv.split("-")[0] if cv else "?"
+    online = is_online(d)
+    outdated = False
+    if ver != "?" and ver_tuple(ver) < ver_tuple(latest):
+        outdated = True
+    tags = ",".join(d.get("tags") or [])
+    addresses = ",".join(d.get("addresses") or [])
+    managed_host = bool(managed.match(short))
+    row = {
+        "hostname": short,
+        "os": os_name,
+        "online": online,
+        "version": ver,
+        "clientVersion": cv,
+        "outdated": outdated,
+        "latest": latest,
+        "managed": managed_host,
+        "tags": tags,
+        "addresses": addresses,
+        "id": d.get("id") or d.get("nodeId") or "",
+    }
+    rows.append(row)
+    if managed_host and not online:
+        issues.append(f"OFFLINE managed host: {short}")
+    if managed_host and outdated:
+        issues.append(f"OUTDATED managed host: {short} {ver} < {latest}")
+    if managed_host and os_name.startswith("linux") and outdated:
+        pass  # upgrade path exists
+    elif outdated and not managed_host:
+        issues.append(f"OUTDATED (manual): {short} ({os_name}) {ver} < {latest}")
+
+print(f"{'HOST':<22} {'OS':<10} {'STATE':<8} {'VERSION':<12} {'LATEST':<10} {'TAGS'}")
+print("-" * 90)
+for r in rows:
+    state = "online" if r["online"] else "OFFLINE"
+    flag = " *" if r["outdated"] else ""
+    print(
+        f"{r['hostname']:<22} {r['os']:<10} {state:<8} {r['version']+flag:<12} {r['latest']:<10} {r['tags']}"
+    )
+
+print()
+print(f"Devices: {len(rows)}  Latest: {latest}  Issues: {len(issues)}")
+for i in issues:
+    print(f"  - {i}")
+
+report = {
+    "tailnet": None,
+    "latest": latest,
+    "generatedAt": now.isoformat(),
+    "devices": rows,
+    "issues": issues,
+    "managedOffline": [r["hostname"] for r in rows if r["managed"] and not r["online"]],
+    "managedOutdated": [r["hostname"] for r in rows if r["managed"] and r["outdated"]],
+    "upgradeableLinux": [
+        r["hostname"]
+        for r in rows
+        if r["managed"] and r["os"].startswith("linux")
+    ],
+}
+json.dump(report, open(out_path, "w"), indent=2)
+print(f"\nWrote report → {out_path}")
+PY
+
+# python wrote REPORT_FILE; expose for callers
+cp "$REPORT_FILE" "${JSON_OUT:-/tmp/tailscale-fleet-health.json}"
+REPORT_PATH="${JSON_OUT:-/tmp/tailscale-fleet-health.json}"
+echo "REPORT_PATH=$REPORT_PATH"
+
+ISSUES=$(jq '.issues | length' "$REPORT_PATH")
+MANAGED_OFF=$(jq -r '.managedOffline | length' "$REPORT_PATH")
+MANAGED_OLD=$(jq -r '.managedOutdated | length' "$REPORT_PATH")
+echo "Summary: issues=$ISSUES managed_offline=$MANAGED_OFF managed_outdated=$MANAGED_OLD"
+
+if [[ "$FAIL_ON_ISSUES" -eq 1 && ( "$MANAGED_OFF" -gt 0 || "$MANAGED_OLD" -gt 0 ) ]]; then
+  echo "::error::Managed Tailscale hosts have offline or outdated clients"
+  exit 1
+fi

--- a/scripts/tailscale-fleet-upgrade.sh
+++ b/scripts/tailscale-fleet-upgrade.sh
@@ -1,0 +1,189 @@
+#!/usr/bin/env bash
+# Remediates Tailscale on managed Linux hosts and upgrades to latest stable.
+#
+# Expects to run on a host that can reach the Pis over LAN (omv runner) or
+# already on the tailnet. Does NOT touch Windows office nodes (manual).
+#
+# Env:
+#   DRY_RUN=1     — print plan only
+#   FIX=1         — restart inactive tailscaled / bring node back
+#   UPGRADE=1     — apt upgrade tailscale to candidate (= latest stable)
+#   SSH_USER      — default tbaltzakis
+#   REPORT_JSON   — optional fleet-health report to prefer outdated hosts
+#
+# Usage:
+#   FIX=1 UPGRADE=1 bash scripts/tailscale-fleet-upgrade.sh
+#   DRY_RUN=1 FIX=1 UPGRADE=1 bash scripts/tailscale-fleet-upgrade.sh
+set -euo pipefail
+
+DRY_RUN="${DRY_RUN:-0}"
+FIX="${FIX:-0}"
+UPGRADE="${UPGRADE:-0}"
+SSH_USER="${SSH_USER:-tbaltzakis}"
+SSH_OPTS=(-o BatchMode=yes -o StrictHostKeyChecking=accept-new -o ConnectTimeout=10)
+case "${DRY_RUN}" in 1|true|TRUE|yes|YES) DRY_RUN=1 ;; *) DRY_RUN=0 ;; esac
+case "${FIX}" in 1|true|TRUE|yes|YES) FIX=1 ;; *) FIX=0 ;; esac
+case "${UPGRADE}" in 1|true|TRUE|yes|YES) UPGRADE=1 ;; *) UPGRADE=0 ;; esac
+
+# name|lan_ip|tailnet_ip
+HOSTS=(
+  "github-omv|192.168.1.128|100.74.191.58"
+  "omv-ha|192.168.1.130|100.95.117.84"
+)
+
+need() { command -v "$1" >/dev/null || { echo "missing $1" >&2; exit 1; }; }
+need ssh
+need curl
+need jq
+
+LATEST=$(curl -fsSL 'https://pkgs.tailscale.com/stable/?mode=json' | jq -r '.TarballsVersion // empty')
+[[ -n "$LATEST" ]] || { echo "Could not resolve latest Tailscale version" >&2; exit 1; }
+echo "==> Latest stable: $LATEST"
+echo "==> DRY_RUN=$DRY_RUN FIX=$FIX UPGRADE=$UPGRADE"
+
+ssh_try() {
+  local host="$1"
+  shift
+  ssh "${SSH_OPTS[@]}" "${SSH_USER}@${host}" "$@"
+}
+
+reachable() {
+  local host="$1"
+  ssh "${SSH_OPTS[@]}" "${SSH_USER}@${host}" true 2>/dev/null
+}
+
+pick_endpoint() {
+  local lan="$1" ts="$2"
+  if reachable "$lan"; then
+    echo "$lan"
+    return 0
+  fi
+  if reachable "$ts"; then
+    echo "$ts"
+    return 0
+  fi
+  return 1
+}
+
+remote_status() {
+  local ep="$1"
+  ssh_try "$ep" 'bash -s' <<'EOS'
+set -euo pipefail
+HOST=$(hostname 2>/dev/null || echo unknown)
+ACTIVE=$(systemctl is-active tailscaled 2>/dev/null || echo inactive)
+VER=$(tailscale version 2>/dev/null | head -1 || echo unknown)
+SELF=$(tailscale status --self --json 2>/dev/null | head -c 2000 || true)
+BACKEND=$(echo "$SELF" | python3 -c 'import json,sys
+try:
+  d=json.load(sys.stdin); print(d.get("BackendState") or "")
+except Exception:
+  print("")' 2>/dev/null || true)
+printf 'host=%s active=%s version=%s backend=%s\n' "$HOST" "$ACTIVE" "$VER" "${BACKEND:-unknown}"
+EOS
+}
+
+remote_fix() {
+  local ep="$1"
+  if [[ "$DRY_RUN" -eq 1 ]]; then
+    echo "  [dry-run] would restart tailscaled on $ep"
+    return 0
+  fi
+  ssh_try "$ep" 'bash -s' <<'EOS'
+set -euo pipefail
+sudo systemctl enable --now tailscaled
+sudo systemctl restart tailscaled
+sleep 4
+# Keep classic OpenSSH for automation; Tailscale SSH is not required here.
+sudo tailscale set --ssh=false 2>/dev/null || true
+systemctl is-active tailscaled
+tailscale status --self 2>/dev/null | head -2 || true
+EOS
+}
+
+remote_upgrade() {
+  local ep="$1"
+  if [[ "$DRY_RUN" -eq 1 ]]; then
+    echo "  [dry-run] would apt upgrade tailscale on $ep"
+    return 0
+  fi
+  ssh_try "$ep" 'bash -s' <<'EOS'
+set -euo pipefail
+export DEBIAN_FRONTEND=noninteractive
+# Ensure Tailscale apt repo exists (idempotent).
+if [[ ! -f /etc/apt/sources.list.d/tailscale.list ]] && [[ ! -f /usr/share/keyrings/tailscale-archive-keyring.gpg ]]; then
+  curl -fsSL https://tailscale.com/install.sh | sudo sh
+fi
+sudo apt-get update -qq
+BEFORE=$(tailscale version 2>/dev/null | head -1 || echo none)
+sudo apt-get install -y -qq --only-upgrade tailscale tailscaled || sudo apt-get install -y -qq tailscale
+AFTER=$(tailscale version 2>/dev/null | head -1 || echo none)
+echo "before=$BEFORE"
+echo "after=$AFTER"
+# Restart if package changed or daemon unhealthy.
+ACTIVE=$(systemctl is-active tailscaled 2>/dev/null || echo inactive)
+if [[ "$BEFORE" != "$AFTER" || "$ACTIVE" != "active" ]]; then
+  sudo systemctl restart tailscaled
+  sleep 4
+  sudo tailscale set --ssh=false 2>/dev/null || true
+fi
+systemctl is-active tailscaled
+tailscale version | head -3
+EOS
+}
+
+FAIL=0
+for entry in "${HOSTS[@]}"; do
+  IFS='|' read -r name lan ts <<<"$entry"
+  echo ""
+  echo "=== $name (lan=$lan ts=$ts) ==="
+  EP=""
+  if ! EP=$(pick_endpoint "$lan" "$ts"); then
+    echo "  UNREACHABLE over SSH (lan + tailnet)"
+    FAIL=1
+    continue
+  fi
+  echo "  endpoint=$EP"
+  STATUS=$(remote_status "$EP" || true)
+  echo "  $STATUS"
+  ACTIVE=$(echo "$STATUS" | sed -n 's/.*active=\([^ ]*\).*/\1/p')
+  VER=$(echo "$STATUS" | sed -n 's/.*version=\([^ ]*\).*/\1/p')
+  VER_BASE="${VER%%-*}"
+
+  if [[ "$FIX" -eq 1 && "$ACTIVE" != "active" ]]; then
+    echo "  → fixing inactive tailscaled"
+    remote_fix "$EP" || FAIL=1
+  fi
+
+  NEEDS_UPGRADE=0
+  if [[ "$UPGRADE" -eq 1 ]]; then
+    if [[ "$VER_BASE" != "$LATEST" ]]; then
+      NEEDS_UPGRADE=1
+    elif [[ "${FORCE_APT:-0}" =~ ^(1|true|TRUE)$ ]]; then
+      NEEDS_UPGRADE=1
+    else
+      echo "  already on $LATEST — skip apt (set FORCE_APT=1 to refresh anyway)"
+    fi
+  fi
+
+  if [[ "$NEEDS_UPGRADE" -eq 1 ]]; then
+    echo "  → upgrading Tailscale (have ${VER_BASE:-unknown}, want $LATEST)"
+    remote_upgrade "$EP" || FAIL=1
+    STATUS2=$(remote_status "$EP" || true)
+    echo "  post: $STATUS2"
+    VER2=$(echo "$STATUS2" | sed -n 's/.*version=\([^ ]*\).*/\1/p')
+    VER2_BASE="${VER2%%-*}"
+    if [[ -n "$VER2_BASE" && "$VER2_BASE" != "$LATEST" && "$DRY_RUN" -eq 0 ]]; then
+      echo "  ::warning::$name still on $VER2_BASE after upgrade (latest $LATEST)"
+      FAIL=1
+    fi
+  else
+    echo "  ok (no upgrade requested)"
+  fi
+done
+
+echo ""
+if [[ "$FAIL" -ne 0 ]]; then
+  echo "::error::One or more managed hosts failed Tailscale remediate/upgrade"
+  exit 1
+fi
+echo "==> Fleet remediate/upgrade complete"


### PR DESCRIPTION
## Summary
- New workflow **Tailscale fleet health + upgrade** (`tailscale-fleet-health.yml`):
  - **Inventory** (ubuntu-latest): lists all devices, online/offline, version vs latest stable via Admin API
  - **Remediate** (`[self-hosted, omv, pi]`): restarts inactive `tailscaled` and `apt` upgrades Tailscale on **github-omv** + **omv-ha** over LAN
  - Weekly Sunday 04:15 UTC; also `workflow_dispatch` with fix/upgrade/dry_run toggles
- Scripts: `scripts/tailscale-fleet-health.sh`, `scripts/tailscale-fleet-upgrade.sh`
- Office/Windows nodes are reported only (manual upgrade)

## Test plan
- [x] Dry-run upgrade reaches both Pis; both already on `1.102.2` (= latest stable)
- [ ] `gh workflow run 'Tailscale fleet health + upgrade' -f dry_run=true -f fix=true -f upgrade=true`
- [ ] Re-run with `dry_run=false` to apply

Made with [Cursor](https://cursor.com)