### PR TITLE
Add Cloudflare tunnels doctor (test + fix)

### DIFF
--- a/.github/workflows/cloudflare-tunnels-doctor.yml
+++ b/.github/workflows/cloudflare-tunnels-doctor.yml
@@ -1,0 +1,83 @@
+# Probe Cloudflare Tunnel edges + LAN origins, then remediate.
+#
+# Fix path (on omv self-hosted runner):
+#   1. Ensure known NodePorts for self-hosted apps
+#   2. Sync canonical infrastructure/cloudflare-tunnels/cloudflared-config.yml
+#      to omv + omv-ha (host-specific webmail/omv/ftp overrides)
+#   3. Restart cloudflared on both connectors
+#   4. Re-probe public HTTPS (Access 302 = healthy) + LAN origins
+#
+# Replaces the old ad-hoc grafana/n8n-only patch workflow.
+name: Cloudflare tunnels doctor
+
+on:
+  schedule:
+    # Every 6 hours — catch Access/edge 5xx and connector drift early.
+    - cron: '20 */6 * * *'
+  push:
+    branches: [main]
+    paths:
+      - .github/workflows/cloudflare-tunnels-doctor.yml
+      - .github/workflows/fix-selfhosted-tunnels.yml
+      - scripts/cloudflare-tunnels-doctor.sh
+      - infrastructure/cloudflare-tunnels/cloudflared-config.yml
+  workflow_dispatch:
+    inputs:
+      fix:
+        description: Apply NodePort + config sync + restart
+        required: false
+        default: true
+        type: boolean
+      dry_run:
+        description: Probe + show config drift only
+        required: false
+        default: false
+        type: boolean
+
+permissions:
+  contents: read
+  issues: write
+
+concurrency:
+  group: cloudflare-tunnels-doctor
+  cancel-in-progress: false
+
+jobs:
+  doctor:
+    # Must run on omv — LAN SSH to both Pis; GH-hosted Tailscale SSH is flaky.
+    runs-on: [self-hosted, omv, pi]
+    timeout-minutes: 25
+    env:
+      GH_TOKEN: ${{ github.token }}
+      SSH_USER: tbaltzakis
+      DRY_RUN: ${{ github.event_name == 'workflow_dispatch' && inputs.dry_run && '1' || '0' }}
+      FIX: ${{ github.event_name == 'workflow_dispatch' && (inputs.fix && '1' || '0') || '1' }}
+    steps:
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd         # v4.3.1
+
+    - name: Run tunnels doctor
+      id: doctor
+      run: |
+        chmod +x scripts/cloudflare-tunnels-doctor.sh
+        bash scripts/cloudflare-tunnels-doctor.sh
+
+    - name: Comment issue 382 on failure
+      if: failure()
+      run: |
+        BODY=$(cat <<EOF
+        ## Cloudflare tunnels doctor failed
+
+        - Event: \`${{ github.event_name }}\`
+        - DRY_RUN=\`${{ env.DRY_RUN }}\` FIX=\`${{ env.FIX }}\`
+        - Run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+
+        Manual on omv:
+        \`\`\`
+        FIX=1 bash scripts/cloudflare-tunnels-doctor.sh
+        \`\`\`
+        EOF
+        )
+        gh issue comment 382 --repo "$GITHUB_REPOSITORY" --body "$BODY" || true
+
+  # Keep the legacy workflow name discoverable: thin wrapper dispatch note.
+  # Actual work is the doctor job above.

--- a/.github/workflows/fix-selfhosted-tunnels.yml
+++ b/.github/workflows/fix-selfhosted-tunnels.yml
@@ -1,334 +1,46 @@
+# Legacy entrypoint — delegates to Cloudflare tunnels doctor.
+# Prefer workflow: "Cloudflare tunnels doctor" (cloudflare-tunnels-doctor.yml).
 name: Fix Self-Hosted App Tunnels
 
 on:
-  push:
-    # branches: required — GitHub ignores `paths` on tag pushes, so every
-    # Release tag (v*-build.N) would otherwise SSH the Pi and fail.
-    branches: [main]
-    paths:
-      - .github/workflows/fix-selfhosted-tunnels.yml
-      - infrastructure/cloudflare-tunnels/cloudflared-config.yml
   workflow_dispatch:
+    inputs:
+      dry_run:
+        description: Probe + show config drift only (no writes)
+        required: false
+        default: false
+        type: boolean
 
 permissions:
   contents: read
   issues: write
 
+concurrency:
+  group: cloudflare-tunnels-doctor
+  cancel-in-progress: false
+
 jobs:
   fix-tunnels:
-    # Run on omv so we can sudo kubectl / edit /etc/cloudflared locally.
-    # GH-hosted + Tailscale SSH has been failing (OMV_SSH_KEY / ACL), which
-    # left this workflow unable to repair tunnels from ubuntu-latest.
     runs-on: [self-hosted, omv, pi]
+    timeout-minutes: 25
     env:
-      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      PI_HOST: 127.0.0.1
-      PI_USER: tbaltzakis
+      GH_TOKEN: ${{ github.token }}
+      SSH_USER: tbaltzakis
+      DRY_RUN: ${{ inputs.dry_run && '1' || '0' }}
+      FIX: '1'
     steps:
-    - name: Setup local SSH to omv (loopback)
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd         # v4.3.1
+
+    - name: Run tunnels doctor
       run: |
-        mkdir -p ~/.ssh
-        chmod 700 ~/.ssh
-        # Runner already lives on omv; use the runner user's default key
-        # (authorized for tbaltzakis@localhost). Prefer BatchMode SSH so the
-        # rest of the steps stay identical to the remote path.
-        ssh-keyscan -H "$PI_HOST" >> ~/.ssh/known_hosts 2>/dev/null || true
-        if ! ssh -o StrictHostKeyChecking=no -o ConnectTimeout=5 -o BatchMode=yes \
-             "$PI_USER@$PI_HOST" true 2>/dev/null; then
-          echo "::error::Cannot SSH to $PI_USER@$PI_HOST from the omv runner."
-          exit 1
-        fi
-        echo "SSH OK to $PI_USER@$PI_HOST"
+        chmod +x scripts/cloudflare-tunnels-doctor.sh
+        bash scripts/cloudflare-tunnels-doctor.sh
 
-    - name: Verify k3s API via SSH
+    - name: Comment issue 382 on failure
+      if: failure()
       run: |
-        echo "=== Testing SSH connectivity ==="
-        ssh -o StrictHostKeyChecking=no -o ConnectTimeout=10 \
-          "$PI_USER@$PI_HOST" \
-          "sudo kubectl --kubeconfig /etc/rancher/k3s/k3s.yaml get nodes" \
-          2>&1 | head -20
+        gh issue comment 382 --repo "$GITHUB_REPOSITORY" --body "### Self-hosted tunnel fix failed
 
-      # ------------------------------------------------------------------
-      # Step 1: Ensure services have correct NodePorts
-      # ------------------------------------------------------------------
-    - name: Fix n8n service NodePort
-      run: |
-        ssh -o StrictHostKeyChecking=no -o ConnectTimeout=10 \
-          "$PI_USER@$PI_HOST" \
-          "sudo kubectl --kubeconfig /etc/rancher/k3s/k3s.yaml patch svc n8n -n n8n -p '{\"spec\":{\"type\":\"NodePort\",\"ports\":[{\"port\":5678,\"targetPort\":5678,\"nodePort\":30900}]}}' --type=merge" 2>&1 || true
-        echo "n8n service patched to NodePort 30900"
+        Run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
 
-    - name: Fix ntfy service NodePort
-      run: |
-        ssh -o StrictHostKeyChecking=no -o ConnectTimeout=10 \
-          "$PI_USER@$PI_HOST" \
-          "sudo kubectl --kubeconfig /etc/rancher/k3s/k3s.yaml patch svc ntfy -n ntfy -p '{\"spec\":{\"type\":\"NodePort\",\"ports\":[{\"port\":80,\"targetPort\":80,\"nodePort\":30080}]}}' --type=merge" 2>&1 || true
-        echo "ntfy service patched to NodePort 30080"
-
-      # ------------------------------------------------------------------
-      # Step 2: Check current tunnel state on omv
-      # ------------------------------------------------------------------
-    - name: Read current cloudflared config from omv
-      env:
-        KUBECMD: sudo kubectl --kubeconfig /etc/rancher/k3s/k3s.yaml
-      run: |
-        ssh -o StrictHostKeyChecking=no -o ConnectTimeout=10 \
-          "$PI_USER@$PI_HOST" \
-          "$KUBECMD delete pod cf-read-omv -n default --ignore-not-found --wait=true" 2>&1 || true
-
-        cat <<'PODEOF' > /tmp/cf-read-pod.yaml
-        apiVersion: v1
-        kind: Pod
-        metadata:
-          name: cf-read-omv
-          namespace: default
-        spec:
-          nodeSelector:
-            kubernetes.io/hostname: omv
-          hostPID: true
-          hostNetwork: true
-          restartPolicy: Never
-          containers:
-            - name: r
-              image: alpine:3
-              securityContext:
-                privileged: true
-              command:
-                - sh
-                - -c
-                - |
-                  apk add -q util-linux 2>/dev/null
-                  nsenter --target 1 --mount --uts --ipc --net --pid -- \
-                    cat /etc/cloudflared/config.yml
-        PODEOF
-
-        ssh -o StrictHostKeyChecking=no -o ConnectTimeout=10 \
-          "$PI_USER@$PI_HOST" \
-          "$KUBECMD create -f -" < /tmp/cf-read-pod.yaml 2>&1
-
-        ssh -o StrictHostKeyChecking=no -o ConnectTimeout=10 \
-          "$PI_USER@$PI_HOST" \
-          "$KUBECMD wait --for=jsonpath='{.status.phase}'=Succeeded pod/cf-read-omv -n default --timeout=90s" 2>&1
-
-        ssh -o StrictHostKeyChecking=no -o ConnectTimeout=10 \
-          "$PI_USER@$PI_HOST" \
-          "$KUBECMD logs -n default cf-read-omv" 2>&1 | tee /tmp/cf-config-current.txt
-
-        ssh -o StrictHostKeyChecking=no -o ConnectTimeout=10 \
-          "$PI_USER@$PI_HOST" \
-          "$KUBECMD delete pod -n default cf-read-omv --ignore-not-found" 2>&1 || true
-
-        echo "=== Current config ($(wc -l < /tmp/cf-config-current.txt) lines) ==="
-        cat /tmp/cf-config-current.txt
-
-      # ------------------------------------------------------------------
-      # Step 3: Patch the config - fix grafana, n8n, ntfy port mismatches
-      # ------------------------------------------------------------------
-    - name: Patch cloudflared config
-      run: |
-        python3 <<'PYEOF'
-        import re, sys
-
-        src = "/tmp/cf-config-current.txt"
-        dst = "/tmp/cf-config-new.txt"
-
-        with open(src) as f:
-            lines = f.readlines()
-
-        out = []
-        i = 0
-        fixes = []
-
-        while i < len(lines):
-            line = lines[i]
-            # Fix grafana: localhost:18443 -> 192.168.1.128:30850
-            if re.match(r'\s*-\s*hostname:\s*grafana\.cloudless\.gr\s*$', line):
-                out.append(line)
-                i += 1
-                if i < len(lines) and re.match(r'\s*service:\s*', lines[i]):
-                    indent = re.match(r'(\s*)', lines[i]).group(1)
-                    new_svc = f"{indent}service: http://192.168.1.128:30850\n"
-                    fixes.append(f"grafana: localhost:18443 -> 192.168.1.128:30850")
-                    out.append(new_svc)
-                    i += 1
-                continue
-            # Fix n8n: port 30820 -> 30900
-            if re.match(r'\s*-\s*hostname:\s*n8n\.cloudless\.gr\s*$', line):
-                out.append(line)
-                i += 1
-                if i < len(lines) and re.match(r'\s*service:\s*', lines[i]):
-                    indent = re.match(r'(\s*)', lines[i]).group(1)
-                    old_svc = lines[i].rstrip()
-                    new_svc = f"{indent}service: http://192.168.1.128:30900\n"
-                    fixes.append(f"n8n: 30820 -> 30900")
-                    out.append(new_svc)
-                    i += 1
-                continue
-            out.append(line)
-            i += 1
-
-        if not fixes:
-            print("No fixes needed", file=sys.stderr)
-        else:
-            print(f"Applied fixes: {', '.join(fixes)}")
-
-        with open(dst, "w") as f:
-            f.writelines(out)
-
-        print(f"Done — wrote {dst} ({len(out)} lines)")
-        PYEOF
-
-        echo "=== Diff ==="
-        diff /tmp/cf-config-current.txt /tmp/cf-config-new.txt || true
-
-      # ------------------------------------------------------------------
-      # Step 4: Apply patched config to omv (primary cloudflared)
-      # ------------------------------------------------------------------
-    - name: Apply config to omv
-      env:
-        KUBECMD: sudo kubectl --kubeconfig /etc/rancher/k3s/k3s.yaml
-      run: |
-        ssh -o StrictHostKeyChecking=no -o ConnectTimeout=10 \
-          "$PI_USER@$PI_HOST" \
-          "$KUBECMD delete pod cf-apply-omv -n default --ignore-not-found --wait=true" 2>&1 || true
-
-        ssh -o StrictHostKeyChecking=no -o ConnectTimeout=10 \
-          "$PI_USER@$PI_HOST" \
-          "$KUBECMD -n default create configmap cf-patch --from-file=config.yml=/tmp/cf-config-new.txt --dry-run=client -o yaml" 2>&1 | \
-          ssh -o StrictHostKeyChecking=no -o ConnectTimeout=10 \
-            "$PI_USER@$PI_HOST" "$KUBECMD apply -f -" 2>&1
-
-        cat <<'PODEOF' > /tmp/cf-apply-pod.yaml
-        apiVersion: v1
-        kind: Pod
-        metadata:
-          name: cf-apply-omv
-          namespace: default
-        spec:
-          nodeSelector:
-            kubernetes.io/hostname: omv
-          hostPID: true
-          hostNetwork: true
-          restartPolicy: Never
-          volumes:
-            - name: patch
-              configMap:
-                name: cf-patch
-            - name: cfdir
-              hostPath:
-                path: /etc/cloudflared
-          containers:
-            - name: w
-              image: alpine:3
-              securityContext:
-                privileged: true
-              volumeMounts:
-                - name: patch
-                  mountPath: /patch
-                - name: cfdir
-                  mountPath: /host-cf
-              command:
-                - sh
-                - -c
-                - |
-                  set -e
-                  apk add -q util-linux 2>/dev/null
-                  cp /host-cf/config.yml /host-cf/config.yml.bak
-                  cp /patch/config.yml /host-cf/config.yml
-                  echo "=== n8n entry ===" && grep -A4 "n8n.cloudless.gr" /host-cf/config.yml
-                  nsenter --target 1 --mount --uts --ipc --net --pid -- \
-                    systemctl restart cloudflared
-                  sleep 3
-                  nsenter --target 1 --mount --uts --ipc --net --pid -- \
-                    systemctl is-active cloudflared
-                  echo "cloudflared OK on omv"
-        PODEOF
-
-        ssh -o StrictHostKeyChecking=no -o ConnectTimeout=10 \
-          "$PI_USER@$PI_HOST" \
-          "$KUBECMD create -f -" < /tmp/cf-apply-pod.yaml 2>&1
-
-        ssh -o StrictHostKeyChecking=no -o ConnectTimeout=10 \
-          "$PI_USER@$PI_HOST" \
-          "$KUBECMD wait --for=jsonpath='{.status.phase}'=Succeeded pod/cf-apply-omv -n default --timeout=120s" 2>&1
-
-        ssh -o StrictHostKeyChecking=no -o ConnectTimeout=10 \
-          "$PI_USER@$PI_HOST" \
-          "$KUBECMD logs -n default cf-apply-omv" 2>&1
-
-        ssh -o StrictHostKeyChecking=no -o ConnectTimeout=10 \
-          "$PI_USER@$PI_HOST" \
-          "$KUBECMD delete pod -n default cf-apply-omv --ignore-not-found" 2>&1 || true
-
-      # ------------------------------------------------------------------
-      # Step 5: Verify all services are reachable
-      # ------------------------------------------------------------------
-    - name: Verify app health
-      run: |
-        echo "Waiting 20s for cloudflared to propagate..."
-        sleep 20
-
-        # Public curls hit Cloudflare Access for most self-hosted apps.
-        # 302 → Access login means DNS + tunnel ingress are healthy.
-        # 200/301/307 = app responded. 502/522/530 = tunnel/origin broken.
-        check() {
-          local name=$1 url=$2
-          CODE=$(curl -4 -sS -o /dev/null -w '%{http_code}' --max-time 10 "$url" 2>/dev/null || echo "ERR")
-          case "$CODE" in
-            200|301|302|303|307|401|403)
-              echo "  OK  [$name] $CODE  ($url)"
-              ;;
-            *)
-              echo "  BAD [$name] $CODE  ($url)"
-              return 1
-              ;;
-          esac
-        }
-
-        fail=0
-        echo "=== Self-hosted app edge (Access 302 = tunnel OK) ==="
-        check "grafana  " "https://grafana.cloudless.gr/api/health" || fail=1
-        check "kuma     " "https://kuma.cloudless.gr/" || fail=1
-        check "n8n      " "https://n8n.cloudless.gr/" || fail=1
-        check "ntfy     " "https://ntfy.cloudless.gr/" || fail=1
-        check "espocrm  " "https://espocrm.cloudless.gr/" || fail=1
-        check "postiz   " "https://postiz.cloudless.gr/" || fail=1
-        check "appflowy " "https://appflowy.cloudless.gr/" || fail=1
-        check "docs     " "https://docs.cloudless.gr/" || fail=1
-        check "meili    " "https://meili.cloudless.gr/health" || fail=1
-        check "logs     " "https://logs.cloudless.gr/health" || fail=1
-        check "webmail  " "https://webmail.cloudless.gr/" || fail=1
-        check "pi-origin" "https://pi-origin.cloudless.gr/api/health" || fail=1
-        if [ "$fail" -ne 0 ]; then
-          echo "::error::One or more self-hosted tunnel edges returned a bad status"
-          exit 1
-        fi
-
-      # ------------------------------------------------------------------
-      # Step 6: Report
-      # ------------------------------------------------------------------
-    - name: Report result
-      run: |
-        gh issue comment 382 --body "### Self-hosted tunnel fix applied
-
-        **Changes made:**
-        - **Grafana** tunnel corrected: \`localhost:18443\` → \`http://192.168.1.128:30850\`
-        - **n8n** tunnel port corrected: \`30820\` → \`30900\` (NodePort mismatch)
-        - **ntfy** service patched to NodePort 30080
-        - Config applied to **omv**
-
-        **Verify (Access 302 = tunnel OK):**
-        - https://grafana.cloudless.gr/api/health
-        - https://kuma.cloudless.gr/
-        - https://n8n.cloudless.gr/
-        - https://ntfy.cloudless.gr/
-        - https://espocrm.cloudless.gr/
-        - https://postiz.cloudless.gr/
-        - https://appflowy.cloudless.gr/
-        - https://docs.cloudless.gr/
-        - https://meili.cloudless.gr/health
-        - https://logs.cloudless.gr/health
-        - https://webmail.cloudless.gr/
-        - https://pi-origin.cloudless.gr/api/health
-
-        Workflow: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+        Prefer: workflow **Cloudflare tunnels doctor**." || true

--- a/scripts/cloudflare-tunnels-doctor.sh
+++ b/scripts/cloudflare-tunnels-doctor.sh
@@ -1,0 +1,313 @@
+#!/usr/bin/env bash
+# Cloudflare tunnels doctor — probe, remediate, re-probe.
+#
+# Intended to run on omv (or any host with LAN SSH to omv + omv-ha).
+# Canonical ingress: infrastructure/cloudflare-tunnels/cloudflared-config.yml
+#
+# Env:
+#   DRY_RUN=1          — report only, no writes / restarts
+#   FIX=1              — apply NodePort patches + sync config + restart
+#   SKIP_PUBLIC=1      — skip public HTTPS probes (LAN-only)
+#   SSH_USER           — default tbaltzakis
+#   OMV_LAN / HA_LAN   — default 192.168.1.128 / 192.168.1.130
+#   OMV_TS / HA_TS     — Tailscale IPs (fallback)
+#   REPO_ROOT          — repo root (default: script ../..)
+#
+# Exit 0 only when public edges (and optional LAN checks) are healthy after fix.
+set -euo pipefail
+
+DRY_RUN="${DRY_RUN:-0}"
+FIX="${FIX:-1}"
+SKIP_PUBLIC="${SKIP_PUBLIC:-0}"
+SSH_USER="${SSH_USER:-tbaltzakis}"
+OMV_LAN="${OMV_LAN:-192.168.1.128}"
+HA_LAN="${HA_LAN:-192.168.1.130}"
+OMV_TS="${OMV_TS:-100.74.191.58}"
+HA_TS="${HA_TS:-100.95.117.84}"
+SSH_OPTS=(-o BatchMode=yes -o StrictHostKeyChecking=accept-new -o ConnectTimeout=10)
+
+case "${DRY_RUN}" in 1|true|TRUE|yes|YES) DRY_RUN=1 ;; *) DRY_RUN=0 ;; esac
+case "${FIX}" in 1|true|TRUE|yes|YES) FIX=1 ;; *) FIX=0 ;; esac
+case "${SKIP_PUBLIC}" in 1|true|TRUE|yes|YES) SKIP_PUBLIC=1 ;; *) SKIP_PUBLIC=0 ;; esac
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="${REPO_ROOT:-$(cd "$SCRIPT_DIR/.." && pwd)}"
+CANONICAL="${REPO_ROOT}/infrastructure/cloudflare-tunnels/cloudflared-config.yml"
+KUBE="sudo kubectl --kubeconfig /etc/rancher/k3s/k3s.yaml"
+
+need() { command -v "$1" >/dev/null || { echo "missing $1" >&2; exit 1; }; }
+need curl
+need ssh
+need python3
+
+echo "==> Cloudflare tunnels doctor  DRY_RUN=$DRY_RUN FIX=$FIX"
+echo "    canonical=$CANONICAL"
+
+[[ -f "$CANONICAL" ]] || { echo "::error::Missing canonical config: $CANONICAL" >&2; exit 1; }
+
+ssh_ok() {
+  local host="$1"
+  ssh "${SSH_OPTS[@]}" "${SSH_USER}@${host}" true 2>/dev/null
+}
+
+pick_host() {
+  local lan="$1" ts="$2"
+  if ssh_ok "$lan"; then echo "$lan"; return 0; fi
+  if ssh_ok "$ts"; then echo "$ts"; return 0; fi
+  return 1
+}
+
+remote() {
+  local host="$1"
+  shift
+  ssh "${SSH_OPTS[@]}" "${SSH_USER}@${host}" "$@"
+}
+
+# --- Public edge probes (Access 302 = tunnel OK) ---
+PUBLIC_URLS=(
+  "grafana|https://grafana.cloudless.gr/api/health"
+  "kuma|https://kuma.cloudless.gr/"
+  "n8n|https://n8n.cloudless.gr/"
+  "ntfy|https://ntfy.cloudless.gr/"
+  "espocrm|https://espocrm.cloudless.gr/"
+  "postiz|https://postiz.cloudless.gr/"
+  "appflowy|https://appflowy.cloudless.gr/"
+  "docs|https://docs.cloudless.gr/"
+  "meili|https://meili.cloudless.gr/health"
+  "logs|https://logs.cloudless.gr/health"
+  "webmail|https://webmail.cloudless.gr/"
+  "pi-origin|https://pi-origin.cloudless.gr/api/health"
+)
+
+# Optional apps — report but do not fail the job if backends are undeployed.
+OPTIONAL_PUBLIC=(
+  "agent|https://agent.cloudless.gr/"
+  "vibe|https://vibe.cloudless.gr/"
+)
+
+# LAN origin ports expected on omv (must answer something other than timeout).
+LAN_PORTS=(
+  "grafana|30850|/api/health"
+  "n8n|30900|/"
+  "ntfy|30080|/"
+  "espocrm|30700|/"
+  "postiz|30500|/"
+  "appflowy|30810|/"
+  "kuma|32501|/"
+  "docs|30901|/"
+  "meili|30902|/health"
+  "logs|30820|/health"
+  "app|30300|/api/health"
+)
+
+probe_public() {
+  local label="$1" phase="$2"
+  local fail=0
+  echo ""
+  echo "=== Public edge ($phase) ==="
+  local entry name url code
+  for entry in "${PUBLIC_URLS[@]}"; do
+    IFS='|' read -r name url <<<"$entry"
+    code=$(curl -4 -sS -o /dev/null -w '%{http_code}' --max-time 12 "$url" 2>/dev/null || echo ERR)
+    case "$code" in
+      200|301|302|303|307|401|403)
+        echo "  OK  [$name] $code"
+        ;;
+      *)
+        echo "  BAD [$name] $code  ($url)"
+        fail=1
+        ;;
+    esac
+  done
+  for entry in "${OPTIONAL_PUBLIC[@]}"; do
+    IFS='|' read -r name url <<<"$entry"
+    code=$(curl -4 -sS -o /dev/null -w '%{http_code}' --max-time 12 "$url" 2>/dev/null || echo ERR)
+    case "$code" in
+      200|301|302|303|307|401|403)
+        echo "  OK  [$name] $code (optional)"
+        ;;
+      *)
+        echo "  WARN [$name] $code (optional — backend may be undeployed)"
+        ;;
+    esac
+  done
+  return "$fail"
+}
+
+probe_lan() {
+  local omv="$1"
+  local fail=0
+  echo ""
+  echo "=== LAN origins via $omv ==="
+  local entry name port path code
+  for entry in "${LAN_PORTS[@]}"; do
+    IFS='|' read -r name port path <<<"$entry"
+    code=$(curl -sS -o /dev/null -w '%{http_code}' --max-time 5 \
+      "http://${omv}:${port}${path}" 2>/dev/null || echo ERR)
+    case "$code" in
+      200|301|302|303|307|401|403|404)
+        # 404 on some roots is fine if the port is open (e.g. alert-api /).
+        echo "  OK  [$name] :$port → $code"
+        ;;
+      *)
+        echo "  BAD [$name] :$port → $code"
+        fail=1
+        ;;
+    esac
+  done
+  return "$fail"
+}
+
+# --- Resolve endpoints ---
+OMV_EP=""
+HA_EP=""
+if ! OMV_EP=$(pick_host "$OMV_LAN" "$OMV_TS"); then
+  echo "::error::Cannot SSH to omv ($OMV_LAN / $OMV_TS)"
+  exit 1
+fi
+if ! HA_EP=$(pick_host "$HA_LAN" "$HA_TS"); then
+  echo "::warning::Cannot SSH to omv-ha ($HA_LAN / $HA_TS) — will only fix omv"
+  HA_EP=""
+fi
+echo "    omv=$OMV_EP  omv-ha=${HA_EP:-UNREACHABLE}"
+
+PRE_FAIL=0
+if [[ "$SKIP_PUBLIC" -eq 0 ]]; then
+  probe_public "pre" "before" || PRE_FAIL=1
+fi
+probe_lan "$OMV_LAN" || PRE_FAIL=1
+
+echo ""
+echo "=== cloudflared status ==="
+remote "$OMV_EP" 'systemctl is-active cloudflared; cloudflared tunnel info e977a490-58c5-4fdb-9155-86832e3e636a 2>/dev/null | head -15 || true'
+if [[ -n "$HA_EP" ]]; then
+  remote "$HA_EP" 'systemctl is-active cloudflared || echo inactive'
+fi
+
+if [[ "$FIX" -eq 0 ]]; then
+  echo ""
+  echo "==> FIX=0 — probe only"
+  if [[ "$PRE_FAIL" -ne 0 ]]; then
+    echo "::error::Tunnel probes failed (FIX disabled)"
+    exit 1
+  fi
+  echo "==> Healthy"
+  exit 0
+fi
+
+# --- Fix NodePorts on omv ---
+echo ""
+echo "=== Ensure NodePorts ==="
+fix_nodeports() {
+  if [[ "$DRY_RUN" -eq 1 ]]; then
+    echo "  [dry-run] would patch NodePorts (n8n 30900, ntfy 30080, grafana 30850, …)"
+    return 0
+  fi
+  remote "$OMV_EP" bash -s <<'EOS'
+set -euo pipefail
+KUBE="sudo kubectl --kubeconfig /etc/rancher/k3s/k3s.yaml"
+patch() {
+  local ns="$1" name="$2" json="$3"
+  $KUBE patch svc "$name" -n "$ns" -p "$json" --type=merge 2>&1 || \
+    echo "WARN: patch $ns/$name failed (may not exist)"
+}
+# Known self-hosted NodePorts used by cloudflared ingress
+patch n8n n8n '{"spec":{"type":"NodePort","ports":[{"name":"http","port":5678,"targetPort":5678,"nodePort":30900}]}}'
+patch ntfy ntfy '{"spec":{"type":"NodePort","ports":[{"name":"http","port":80,"targetPort":80,"nodePort":30080}]}}'
+patch monitoring kube-prom-grafana '{"spec":{"type":"NodePort","ports":[{"name":"http","port":80,"targetPort":80,"nodePort":30850}]}}' || true
+patch postiz postiz '{"spec":{"type":"NodePort","ports":[{"name":"http","port":5000,"targetPort":5000,"nodePort":30500}]}}' || true
+patch espocrm espocrm '{"spec":{"type":"NodePort","ports":[{"name":"http","port":80,"targetPort":80,"nodePort":30700}]}}' || true
+patch appflowy nginx-nodeport '{"spec":{"type":"NodePort","ports":[{"name":"http","port":80,"targetPort":80,"nodePort":30810}]}}' || true
+patch uptime-kuma uptime-kuma '{"spec":{"type":"NodePort","ports":[{"name":"http","port":3001,"targetPort":3001,"nodePort":32501}]}}' || true
+patch default docs-service '{"spec":{"type":"NodePort","ports":[{"name":"http","port":8080,"targetPort":8080,"nodePort":30901}]}}' || true
+patch meilisearch meilisearch '{"spec":{"type":"NodePort","ports":[{"name":"http","port":7700,"targetPort":7700,"nodePort":30902}]}}' || true
+patch alert-manager alert-api '{"spec":{"type":"NodePort","ports":[{"name":"http","port":8080,"targetPort":8080,"nodePort":30820}]}}' || true
+patch cloudless cloudless-app '{"spec":{"type":"NodePort","ports":[{"name":"http","port":80,"targetPort":80,"nodePort":30300}]}}' || true
+echo "NodePort patches attempted"
+EOS
+}
+fix_nodeports
+
+# --- Build host-specific configs from canonical ---
+WORKDIR=$(mktemp -d)
+trap 'rm -rf "$WORKDIR"' EXIT
+cp "$CANONICAL" "$WORKDIR/omv.yml"
+
+python3 - "$CANONICAL" "$WORKDIR/ha.yml" <<'PY'
+import re, sys
+src, dst = sys.argv[1:3]
+text = open(src).read()
+# omv-ha: webmail is local mail stack; omv/ftp must point at omv LAN, not ha localhost
+text = text.replace("service: http://192.168.1.130:80", "service: http://localhost:80", 1)
+text = re.sub(
+    r"(- hostname: omv\.cloudless\.gr\n  service: )http://localhost:80",
+    r"\1http://192.168.1.128:80",
+    text,
+    count=1,
+)
+text = re.sub(
+    r"(- hostname: ftp\.cloudless\.gr\n  service: )http://localhost:21",
+    r"\1http://192.168.1.128:21",
+    text,
+    count=1,
+)
+open(dst, "w").write(text)
+print("wrote omv-ha variant", dst)
+PY
+
+apply_config() {
+  local ep="$1" local_file="$2" label="$3"
+  echo ""
+  echo "=== Sync cloudflared config → $label ($ep) ==="
+  if [[ "$DRY_RUN" -eq 1 ]]; then
+    echo "  [dry-run] would install $(wc -l < "$local_file") lines and restart cloudflared"
+    # Show drift vs live
+    remote "$ep" 'sudo cat /etc/cloudflared/config.yml' >"$WORKDIR/live-$label.yml" 2>/dev/null || true
+    if [[ -f "$WORKDIR/live-$label.yml" ]]; then
+      diff -u "$WORKDIR/live-$label.yml" "$local_file" | head -80 || true
+    fi
+    return 0
+  fi
+  scp "${SSH_OPTS[@]}" "$local_file" "${SSH_USER}@${ep}:/tmp/cloudflared-config.doctor.yml"
+  remote "$ep" bash -s <<'EOS'
+set -euo pipefail
+CFG=/etc/cloudflared/config.yml
+sudo cp "$CFG" "$CFG.bak.doctor.$(date +%Y%m%d%H%M%S)"
+sudo cp /tmp/cloudflared-config.doctor.yml "$CFG"
+sudo systemctl enable --now cloudflared
+sudo systemctl restart cloudflared
+sleep 3
+systemctl is-active cloudflared
+# Prefer matching hostnames from canonical
+grep -E 'hostname: (grafana|n8n|ntfy|espocrm|postiz|appflowy|logs|webmail|agent|vibe)' "$CFG" || true
+EOS
+}
+
+apply_config "$OMV_EP" "$WORKDIR/omv.yml" "omv"
+if [[ -n "$HA_EP" ]]; then
+  apply_config "$HA_EP" "$WORKDIR/ha.yml" "omv-ha"
+fi
+
+if [[ "$DRY_RUN" -eq 0 ]]; then
+  echo ""
+  echo "Waiting 15s for tunnel connectors to re-register…"
+  sleep 15
+fi
+
+POST_FAIL=0
+probe_lan "$OMV_LAN" || POST_FAIL=1
+if [[ "$SKIP_PUBLIC" -eq 0 ]]; then
+  probe_public "post" "after" || POST_FAIL=1
+fi
+
+echo ""
+if [[ "$DRY_RUN" -eq 1 ]]; then
+  echo "==> Dry-run complete (pre_fail=$PRE_FAIL)"
+  exit 0
+fi
+
+if [[ "$POST_FAIL" -ne 0 ]]; then
+  echo "::error::Tunnel doctor finished but probes still failing"
+  exit 1
+fi
+echo "==> Tunnels healthy after doctor"


### PR DESCRIPTION
## Summary
- New workflow **Cloudflare tunnels doctor** — probes public edges (Access **302** = healthy) + LAN NodePorts, then fixes:
  - known self-hosted **NodePorts**
  - syncs `infrastructure/cloudflare-tunnels/cloudflared-config.yml` → **omv** + **omv-ha**
  - restarts **cloudflared** on both connectors
  - re-probes
- Script: `scripts/cloudflare-tunnels-doctor.sh` (`DRY_RUN` / `FIX`)
- Legacy **Fix Self-Hosted App Tunnels** now delegates to the same script
- Schedule: every 6 hours; also on canonical config push + `workflow_dispatch`

## Test plan
- [x] `DRY_RUN=1 FIX=1 bash scripts/cloudflare-tunnels-doctor.sh` — all public + LAN OK
- [ ] After merge: `gh workflow run 'Cloudflare tunnels doctor' -f dry_run=true`
- [ ] Apply: `gh workflow run 'Cloudflare tunnels doctor' -f dry_run=false -f fix=true`

Made with [Cursor](https://cursor.com)