### PR TITLE
Prometheus + Grafana: Tailscale and Cloudflare tunnel status

### DIFF
--- a/.github/workflows/deploy-fabric-metrics.yml
+++ b/.github/workflows/deploy-fabric-metrics.yml
@@ -1,0 +1,63 @@
+# Apply fabric metrics (cloudflared + Tailscale) scrapes and Grafana dashboards.
+# Host exporters are installed by a job on the omv self-hosted runner.
+name: Deploy fabric metrics dashboards
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - infrastructure/monitoring/cloudflared-servicemonitor.yaml
+      - infrastructure/monitoring/tailscale-servicemonitor.yaml
+      - infrastructure/monitoring/dashboards-fabric.yaml
+      - infrastructure/monitoring/blackbox-exporter.yaml
+      - infrastructure/monitoring/host-fabric-metrics/**
+      - .github/workflows/deploy-fabric-metrics.yml
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: deploy-fabric-metrics
+  cancel-in-progress: false
+
+jobs:
+  install-hosts:
+    runs-on: [self-hosted, omv, pi]
+    timeout-minutes: 15
+    steps:
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd         # v4.3.1
+    - name: Install host fabric metrics on omv + omv-ha
+      run: |
+        chmod +x infrastructure/monitoring/host-fabric-metrics/install.sh
+        bash infrastructure/monitoring/host-fabric-metrics/install.sh
+
+  apply-k8s:
+    needs: install-hosts
+    runs-on: [self-hosted, omv, pi]
+    timeout-minutes: 10
+    env:
+      KUBECONFIG: /etc/rancher/k3s/k3s.yaml
+    steps:
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd         # v4.3.1
+    - name: Apply ServiceMonitors, Probes, dashboards
+      run: |
+        sudo kubectl apply -f infrastructure/monitoring/cloudflared-servicemonitor.yaml
+        sudo kubectl apply -f infrastructure/monitoring/tailscale-servicemonitor.yaml
+        sudo kubectl apply -f infrastructure/monitoring/dashboards-fabric.yaml
+        sudo kubectl apply -f infrastructure/monitoring/blackbox-exporter.yaml
+        sudo kubectl -n monitoring rollout restart deploy/blackbox-exporter
+        sudo kubectl -n monitoring rollout status deploy/blackbox-exporter --timeout=120s
+    - name: Verify scrapes
+      run: |
+        sleep 20
+        echo "=== LAN metrics ==="
+        curl -sS -o /dev/null -w "omv-cf:%{http_code}\n" --max-time 5 http://192.168.1.128:20241/metrics
+        curl -sS -o /dev/null -w "ha-cf:%{http_code}\n" --max-time 5 http://192.168.1.130:20241/metrics
+        curl -sS -o /dev/null -w "omv-ts:%{http_code}\n" --max-time 5 http://192.168.1.128:9102/metrics
+        curl -sS -o /dev/null -w "ha-ts:%{http_code}\n" --max-time 5 http://192.168.1.130:9102/metrics
+        echo "=== Prometheus targets (sample) ==="
+        sudo kubectl -n monitoring exec prometheus-kube-prom-kube-prometheus-prometheus-0 -c prometheus -- \
+          wget -qO- 'http://127.0.0.1:9090/api/v1/query?query=up{job=~"cloudflared|tailscale"}' 2>/dev/null | head -c 2000 || true
+        echo
+        echo "Dashboards: Cloudflare Tunnel Status, Tailscale Status (Grafana sidecar)"

--- a/infrastructure/cloudflare-tunnels/cloudflared-config.yml
+++ b/infrastructure/cloudflare-tunnels/cloudflared-config.yml
@@ -11,6 +11,8 @@
 tunnel: e977a490-58c5-4fdb-9155-86832e3e636a
 credentials-file: /etc/cloudflared/e977a490-58c5-4fdb-9155-86832e3e636a.json
 no-autoupdate: true
+# Prometheus metrics (also set via systemd drop-in --metrics 0.0.0.0:20241)
+metrics: 0.0.0.0:20241
 
 ingress:
 - hostname: webmail.cloudless.gr

--- a/infrastructure/monitoring/blackbox-exporter.yaml
+++ b/infrastructure/monitoring/blackbox-exporter.yaml
@@ -32,6 +32,16 @@ data:
           valid_status_codes: [200, 401]
           method: GET
           preferred_ip_protocol: "ip4"
+      http_tunnel_edge:
+        prober: http
+        timeout: 10s
+        http:
+          # Public tunnel hostnames sit behind Cloudflare Access.
+          # 302/401/403 prove DNS + tunnel ingress are up.
+          valid_status_codes: [200, 301, 302, 303, 307, 401, 403]
+          method: GET
+          preferred_ip_protocol: "ip4"
+          no_follow_redirects: true
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -200,3 +210,150 @@ spec:
       annotations:
         summary: Self-hosted app {{ $labels.app }} probe failing
         description: '{{ $labels.instance }} has been unreachable for 5+ minutes.'
+---
+# Public Cloudflare Tunnel edge probes (Access 302 = healthy).
+apiVersion: monitoring.coreos.com/v1
+kind: Probe
+metadata:
+  name: tunnel-grafana
+  namespace: monitoring
+  labels: {release: kube-prom, scope: tunnel}
+spec:
+  jobName: tunnel-grafana
+  interval: 60s
+  module: http_tunnel_edge
+  prober: {url: blackbox-exporter.monitoring.svc.cluster.local:9115}
+  targets:
+    staticConfig:
+      static: [https://grafana.cloudless.gr/api/health]
+      labels: {app: grafana, scope: tunnel}
+---
+apiVersion: monitoring.coreos.com/v1
+kind: Probe
+metadata:
+  name: tunnel-n8n
+  namespace: monitoring
+  labels: {release: kube-prom, scope: tunnel}
+spec:
+  jobName: tunnel-n8n
+  interval: 60s
+  module: http_tunnel_edge
+  prober: {url: blackbox-exporter.monitoring.svc.cluster.local:9115}
+  targets:
+    staticConfig:
+      static: [https://n8n.cloudless.gr/]
+      labels: {app: n8n, scope: tunnel}
+---
+apiVersion: monitoring.coreos.com/v1
+kind: Probe
+metadata:
+  name: tunnel-ntfy
+  namespace: monitoring
+  labels: {release: kube-prom, scope: tunnel}
+spec:
+  jobName: tunnel-ntfy
+  interval: 60s
+  module: http_tunnel_edge
+  prober: {url: blackbox-exporter.monitoring.svc.cluster.local:9115}
+  targets:
+    staticConfig:
+      static: [https://ntfy.cloudless.gr/]
+      labels: {app: ntfy, scope: tunnel}
+---
+apiVersion: monitoring.coreos.com/v1
+kind: Probe
+metadata:
+  name: tunnel-espocrm
+  namespace: monitoring
+  labels: {release: kube-prom, scope: tunnel}
+spec:
+  jobName: tunnel-espocrm
+  interval: 60s
+  module: http_tunnel_edge
+  prober: {url: blackbox-exporter.monitoring.svc.cluster.local:9115}
+  targets:
+    staticConfig:
+      static: [https://espocrm.cloudless.gr/]
+      labels: {app: espocrm, scope: tunnel}
+---
+apiVersion: monitoring.coreos.com/v1
+kind: Probe
+metadata:
+  name: tunnel-postiz
+  namespace: monitoring
+  labels: {release: kube-prom, scope: tunnel}
+spec:
+  jobName: tunnel-postiz
+  interval: 60s
+  module: http_tunnel_edge
+  prober: {url: blackbox-exporter.monitoring.svc.cluster.local:9115}
+  targets:
+    staticConfig:
+      static: [https://postiz.cloudless.gr/]
+      labels: {app: postiz, scope: tunnel}
+---
+apiVersion: monitoring.coreos.com/v1
+kind: Probe
+metadata:
+  name: tunnel-appflowy
+  namespace: monitoring
+  labels: {release: kube-prom, scope: tunnel}
+spec:
+  jobName: tunnel-appflowy
+  interval: 60s
+  module: http_tunnel_edge
+  prober: {url: blackbox-exporter.monitoring.svc.cluster.local:9115}
+  targets:
+    staticConfig:
+      static: [https://appflowy.cloudless.gr/]
+      labels: {app: appflowy, scope: tunnel}
+---
+apiVersion: monitoring.coreos.com/v1
+kind: Probe
+metadata:
+  name: tunnel-pi-origin
+  namespace: monitoring
+  labels: {release: kube-prom, scope: tunnel}
+spec:
+  jobName: tunnel-pi-origin
+  interval: 60s
+  module: http_tunnel_edge
+  prober: {url: blackbox-exporter.monitoring.svc.cluster.local:9115}
+  targets:
+    staticConfig:
+      static: [https://pi-origin.cloudless.gr/api/health]
+      labels: {app: pi-origin, scope: tunnel}
+---
+apiVersion: monitoring.coreos.com/v1
+kind: Probe
+metadata:
+  name: tunnel-webmail
+  namespace: monitoring
+  labels: {release: kube-prom, scope: tunnel}
+spec:
+  jobName: tunnel-webmail
+  interval: 60s
+  module: http_tunnel_edge
+  prober: {url: blackbox-exporter.monitoring.svc.cluster.local:9115}
+  targets:
+    staticConfig:
+      static: [https://webmail.cloudless.gr/]
+      labels: {app: webmail, scope: tunnel}
+---
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: tunnel-edge-health
+  namespace: monitoring
+  labels: {release: kube-prom}
+spec:
+  groups:
+  - name: tunnel.rules
+    rules:
+    - alert: CloudflareTunnelEdgeDown
+      expr: probe_success{scope="tunnel"} == 0
+      for: 5m
+      labels: {severity: warning}
+      annotations:
+        summary: Tunnel edge down for {{ $labels.app }}
+        description: '{{ $labels.instance }} failed blackbox tunnel probe for 5+ minutes.'

--- a/infrastructure/monitoring/cloudflared-servicemonitor.yaml
+++ b/infrastructure/monitoring/cloudflared-servicemonitor.yaml
@@ -1,0 +1,103 @@
+# Scrape host cloudflared Prometheus metrics (default :20241).
+# Requires cloudflared listening on 0.0.0.0:20241 (see
+# infrastructure/monitoring/host-fabric-metrics/ and
+# infrastructure/cloudflare-tunnels/cloudflared-config.yml `metrics:`).
+#
+# Apply: kubectl apply -f infrastructure/monitoring/cloudflared-servicemonitor.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: cloudflared-metrics
+  namespace: monitoring
+  labels:
+    app: cloudflared
+    component: metrics
+    release: kube-prom
+spec:
+  clusterIP: None
+  ports:
+  - name: metrics
+    port: 20241
+    targetPort: 20241
+    protocol: TCP
+---
+apiVersion: v1
+kind: Endpoints
+metadata:
+  name: cloudflared-metrics
+  namespace: monitoring
+  labels:
+    app: cloudflared
+    component: metrics
+subsets:
+- addresses:
+  - ip: 192.168.1.128
+    hostname: omv
+  - ip: 192.168.1.130
+    hostname: omv-ha
+  ports:
+  - name: metrics
+    port: 20241
+    protocol: TCP
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: cloudflared
+  namespace: monitoring
+  labels:
+    release: kube-prom
+    cluster-protection.io/health: 'true'
+    app: cloudflared
+spec:
+  selector:
+    matchLabels:
+      app: cloudflared
+      component: metrics
+  namespaceSelector:
+    matchNames: [monitoring]
+  endpoints:
+  - port: metrics
+    path: /metrics
+    interval: 30s
+    scrapeTimeout: 10s
+    honorLabels: true
+    relabelings:
+    - sourceLabels: [__meta_kubernetes_endpoint_hostname]
+      targetLabel: host
+    - sourceLabels: [__meta_kubernetes_endpoint_hostname]
+      targetLabel: instance
+    - targetLabel: job
+      replacement: cloudflared
+---apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: cloudflared-tunnel-health
+  namespace: monitoring
+  labels:
+    release: kube-prom
+spec:
+  groups:
+  - name: cloudflared.rules
+    rules:
+    - alert: CloudflaredMetricsAbsent
+      expr: absent(cloudflared_tunnel_ha_connections) == 1
+      for: 10m
+      labels: {severity: warning}
+      annotations:
+        summary: cloudflared metrics not scraped
+        description: No cloudflared_tunnel_ha_connections series for 10m — check host metrics bind + ServiceMonitor.
+    - alert: CloudflaredNoHAConnections
+      expr: cloudflared_tunnel_ha_connections == 0
+      for: 5m
+      labels: {severity: critical}
+      annotations:
+        summary: cloudflared has zero HA connections on {{ $labels.instance }}
+        description: Tunnel connector lost edge connections.
+    - alert: CloudflaredRequestErrors
+      expr: increase(cloudflared_tunnel_request_errors[15m]) > 20
+      for: 10m
+      labels: {severity: warning}
+      annotations:
+        summary: Elevated cloudflared request errors on {{ $labels.instance }}
+        description: "More than 20 request errors in 15m."

--- a/infrastructure/monitoring/cloudflared-servicemonitor.yaml
+++ b/infrastructure/monitoring/cloudflared-servicemonitor.yaml
@@ -69,7 +69,8 @@ spec:
       targetLabel: instance
     - targetLabel: job
       replacement: cloudflared
----apiVersion: monitoring.coreos.com/v1
+---
+apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule
 metadata:
   name: cloudflared-tunnel-health

--- a/infrastructure/monitoring/dashboards-fabric.yaml
+++ b/infrastructure/monitoring/dashboards-fabric.yaml
@@ -1,0 +1,340 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: grafana-dashboard-cloudflare-tunnel
+  namespace: monitoring
+  labels: {grafana_dashboard: '1'}
+data:
+  cloudflare-tunnel.json: |
+    {
+      "title": "Cloudflare Tunnel Status",
+      "uid": "cloudflare-tunnel",
+      "tags": ["cloudflare", "tunnel", "cloudless"],
+      "timezone": "browser",
+      "schemaVersion": 39,
+      "version": 1,
+      "refresh": "30s",
+      "time": { "from": "now-6h", "to": "now" },
+      "templating": { "list": [] },
+      "panels": [
+        {
+          "type": "stat",
+          "title": "HA connections (per connector)",
+          "id": 1,
+          "gridPos": { "h": 5, "w": 8, "x": 0, "y": 0 },
+          "targets": [{
+            "expr": "cloudflared_tunnel_ha_connections",
+            "legendFormat": "{{instance}}",
+            "refId": "A",
+            "datasource": { "type": "prometheus", "uid": "prometheus" }
+          }],
+          "fieldConfig": {
+            "defaults": {
+              "thresholds": { "mode": "absolute", "steps": [
+                { "color": "red", "value": null },
+                { "color": "yellow", "value": 1 },
+                { "color": "green", "value": 2 }
+              ]},
+              "color": { "mode": "thresholds" }
+            }
+          },
+          "options": { "reduceOptions": { "calcs": ["lastNotNull"] }, "colorMode": "background" }
+        },
+        {
+          "type": "stat",
+          "title": "Tunnel edge probes (Access OK)",
+          "id": 2,
+          "gridPos": { "h": 5, "w": 16, "x": 8, "y": 0 },
+          "targets": [{
+            "expr": "probe_success{scope=\"tunnel\"}",
+            "legendFormat": "{{app}}",
+            "refId": "A",
+            "datasource": { "type": "prometheus", "uid": "prometheus" }
+          }],
+          "fieldConfig": {
+            "defaults": {
+              "mappings": [
+                { "type": "value", "options": { "0": { "text": "DOWN", "color": "red" } } },
+                { "type": "value", "options": { "1": { "text": "UP", "color": "green" } } }
+              ],
+              "thresholds": { "mode": "absolute", "steps": [
+                { "color": "red", "value": null },
+                { "color": "green", "value": 1 }
+              ]},
+              "color": { "mode": "thresholds" }
+            }
+          },
+          "options": { "reduceOptions": { "calcs": ["lastNotNull"] }, "colorMode": "background" }
+        },
+        {
+          "type": "timeseries",
+          "title": "Requests / sec",
+          "id": 3,
+          "gridPos": { "h": 8, "w": 12, "x": 0, "y": 5 },
+          "targets": [{
+            "expr": "sum by (instance) (rate(cloudflared_tunnel_total_requests[5m]))",
+            "legendFormat": "{{instance}}",
+            "refId": "A",
+            "datasource": { "type": "prometheus", "uid": "prometheus" }
+          }]
+        },
+        {
+          "type": "timeseries",
+          "title": "Request errors / sec",
+          "id": 4,
+          "gridPos": { "h": 8, "w": 12, "x": 12, "y": 5 },
+          "targets": [{
+            "expr": "sum by (instance) (rate(cloudflared_tunnel_request_errors[5m]))",
+            "legendFormat": "{{instance}}",
+            "refId": "A",
+            "datasource": { "type": "prometheus", "uid": "prometheus" }
+          }]
+        },
+        {
+          "type": "timeseries",
+          "title": "Responses by HTTP code",
+          "id": 5,
+          "gridPos": { "h": 8, "w": 12, "x": 0, "y": 13 },
+          "targets": [{
+            "expr": "sum by (status_code) (rate(cloudflared_tunnel_response_by_code[5m]))",
+            "legendFormat": "{{status_code}}",
+            "refId": "A",
+            "datasource": { "type": "prometheus", "uid": "prometheus" }
+          }]
+        },
+        {
+          "type": "timeseries",
+          "title": "QUIC smoothed RTT (s)",
+          "id": 6,
+          "gridPos": { "h": 8, "w": 12, "x": 12, "y": 13 },
+          "targets": [{
+            "expr": "quic_client_smoothed_rtt",
+            "legendFormat": "{{instance}}",
+            "refId": "A",
+            "datasource": { "type": "prometheus", "uid": "prometheus" }
+          }]
+        },
+        {
+          "type": "timeseries",
+          "title": "Tunnel edge probe duration (s)",
+          "id": 7,
+          "gridPos": { "h": 8, "w": 12, "x": 0, "y": 21 },
+          "targets": [{
+            "expr": "probe_duration_seconds{scope=\"tunnel\"}",
+            "legendFormat": "{{app}}",
+            "refId": "A",
+            "datasource": { "type": "prometheus", "uid": "prometheus" }
+          }]
+        },
+        {
+          "type": "timeseries",
+          "title": "Tunnel edge HTTP status",
+          "id": 8,
+          "gridPos": { "h": 8, "w": 12, "x": 12, "y": 21 },
+          "targets": [{
+            "expr": "probe_http_status_code{scope=\"tunnel\"}",
+            "legendFormat": "{{app}}",
+            "refId": "A",
+            "datasource": { "type": "prometheus", "uid": "prometheus" }
+          }]
+        },
+        {
+          "type": "stat",
+          "title": "Active TCP / UDP sessions",
+          "id": 9,
+          "gridPos": { "h": 5, "w": 12, "x": 0, "y": 29 },
+          "targets": [
+            {
+              "expr": "sum(cloudflared_tcp_active_sessions)",
+              "legendFormat": "tcp",
+              "refId": "A",
+              "datasource": { "type": "prometheus", "uid": "prometheus" }
+            },
+            {
+              "expr": "sum(cloudflared_udp_active_sessions)",
+              "legendFormat": "udp",
+              "refId": "B",
+              "datasource": { "type": "prometheus", "uid": "prometheus" }
+            }
+          ],
+          "options": { "reduceOptions": { "calcs": ["lastNotNull"] }, "colorMode": "value" }
+        },
+        {
+          "type": "stat",
+          "title": "Config version",
+          "id": 10,
+          "gridPos": { "h": 5, "w": 12, "x": 12, "y": 29 },
+          "targets": [{
+            "expr": "cloudflared_orchestration_config_version",
+            "legendFormat": "{{instance}}",
+            "refId": "A",
+            "datasource": { "type": "prometheus", "uid": "prometheus" }
+          }],
+          "options": { "reduceOptions": { "calcs": ["lastNotNull"] }, "colorMode": "value" }
+        }
+      ]
+    }
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: grafana-dashboard-tailscale-status
+  namespace: monitoring
+  labels: {grafana_dashboard: '1'}
+data:
+  tailscale-status.json: |
+    {
+      "title": "Tailscale Status",
+      "uid": "tailscale-status",
+      "tags": ["tailscale", "cloudless"],
+      "timezone": "browser",
+      "schemaVersion": 39,
+      "version": 1,
+      "refresh": "30s",
+      "time": { "from": "now-6h", "to": "now" },
+      "templating": { "list": [] },
+      "panels": [
+        {
+          "type": "stat",
+          "title": "Exporter up",
+          "id": 1,
+          "gridPos": { "h": 5, "w": 6, "x": 0, "y": 0 },
+          "targets": [{
+            "expr": "tailscale_exporter_up",
+            "legendFormat": "{{instance}}",
+            "refId": "A",
+            "datasource": { "type": "prometheus", "uid": "prometheus" }
+          }],
+          "fieldConfig": {
+            "defaults": {
+              "mappings": [
+                { "type": "value", "options": { "0": { "text": "DOWN", "color": "red" } } },
+                { "type": "value", "options": { "1": { "text": "UP", "color": "green" } } }
+              ],
+              "thresholds": { "mode": "absolute", "steps": [
+                { "color": "red", "value": null },
+                { "color": "green", "value": 1 }
+              ]},
+              "color": { "mode": "thresholds" }
+            }
+          },
+          "options": { "reduceOptions": { "calcs": ["lastNotNull"] }, "colorMode": "background" }
+        },
+        {
+          "type": "stat",
+          "title": "Health warnings",
+          "id": 2,
+          "gridPos": { "h": 5, "w": 6, "x": 6, "y": 0 },
+          "targets": [{
+            "expr": "tailscaled_health_messages{type=\"warning\"}",
+            "legendFormat": "{{instance}}",
+            "refId": "A",
+            "datasource": { "type": "prometheus", "uid": "prometheus" }
+          }],
+          "fieldConfig": {
+            "defaults": {
+              "thresholds": { "mode": "absolute", "steps": [
+                { "color": "green", "value": null },
+                { "color": "red", "value": 1 }
+              ]},
+              "color": { "mode": "thresholds" }
+            }
+          },
+          "options": { "reduceOptions": { "calcs": ["lastNotNull"] }, "colorMode": "background" }
+        },
+        {
+          "type": "stat",
+          "title": "Advertised / approved routes",
+          "id": 3,
+          "gridPos": { "h": 5, "w": 12, "x": 12, "y": 0 },
+          "targets": [
+            {
+              "expr": "tailscaled_advertised_routes",
+              "legendFormat": "adv {{instance}}",
+              "refId": "A",
+              "datasource": { "type": "prometheus", "uid": "prometheus" }
+            },
+            {
+              "expr": "tailscaled_approved_routes",
+              "legendFormat": "ok {{instance}}",
+              "refId": "B",
+              "datasource": { "type": "prometheus", "uid": "prometheus" }
+            }
+          ],
+          "options": { "reduceOptions": { "calcs": ["lastNotNull"] }, "colorMode": "value" }
+        },
+        {
+          "type": "timeseries",
+          "title": "Inbound bytes / sec by path",
+          "id": 4,
+          "gridPos": { "h": 9, "w": 12, "x": 0, "y": 5 },
+          "targets": [{
+            "expr": "sum by (instance, path) (rate(tailscaled_inbound_bytes_total[5m]))",
+            "legendFormat": "{{instance}} {{path}}",
+            "refId": "A",
+            "datasource": { "type": "prometheus", "uid": "prometheus" }
+          }]
+        },
+        {
+          "type": "timeseries",
+          "title": "Outbound bytes / sec by path",
+          "id": 5,
+          "gridPos": { "h": 9, "w": 12, "x": 12, "y": 5 },
+          "targets": [{
+            "expr": "sum by (instance, path) (rate(tailscaled_outbound_bytes_total[5m]))",
+            "legendFormat": "{{instance}} {{path}}",
+            "refId": "A",
+            "datasource": { "type": "prometheus", "uid": "prometheus" }
+          }]
+        },
+        {
+          "type": "timeseries",
+          "title": "Inbound packets / sec",
+          "id": 6,
+          "gridPos": { "h": 8, "w": 12, "x": 0, "y": 14 },
+          "targets": [{
+            "expr": "sum by (instance, path) (rate(tailscaled_inbound_packets_total[5m]))",
+            "legendFormat": "{{instance}} {{path}}",
+            "refId": "A",
+            "datasource": { "type": "prometheus", "uid": "prometheus" }
+          }]
+        },
+        {
+          "type": "timeseries",
+          "title": "Outbound packets / sec",
+          "id": 7,
+          "gridPos": { "h": 8, "w": 12, "x": 12, "y": 14 },
+          "targets": [{
+            "expr": "sum by (instance, path) (rate(tailscaled_outbound_packets_total[5m]))",
+            "legendFormat": "{{instance}} {{path}}",
+            "refId": "A",
+            "datasource": { "type": "prometheus", "uid": "prometheus" }
+          }]
+        },
+        {
+          "type": "stat",
+          "title": "Home DERP region",
+          "id": 8,
+          "gridPos": { "h": 5, "w": 12, "x": 0, "y": 22 },
+          "targets": [{
+            "expr": "tailscaled_home_derp_region_id",
+            "legendFormat": "{{instance}}",
+            "refId": "A",
+            "datasource": { "type": "prometheus", "uid": "prometheus" }
+          }],
+          "options": { "reduceOptions": { "calcs": ["lastNotNull"] }, "colorMode": "value" }
+        },
+        {
+          "type": "timeseries",
+          "title": "Dropped inbound packets / sec",
+          "id": 9,
+          "gridPos": { "h": 5, "w": 12, "x": 12, "y": 22 },
+          "targets": [{
+            "expr": "sum by (instance) (rate(tailscaled_inbound_dropped_packets_total[5m]))",
+            "legendFormat": "{{instance}}",
+            "refId": "A",
+            "datasource": { "type": "prometheus", "uid": "prometheus" }
+          }]
+        }
+      ]
+    }

--- a/infrastructure/monitoring/host-fabric-metrics/cloudflared-metrics.conf
+++ b/infrastructure/monitoring/host-fabric-metrics/cloudflared-metrics.conf
@@ -1,0 +1,5 @@
+[Service]
+# Expose Prometheus metrics on all interfaces so kube-prometheus can scrape
+# via LAN Endpoints (192.168.1.128/130:20241). Default is 127.0.0.1 only.
+ExecStart=
+ExecStart=/usr/local/bin/cloudflared --metrics 0.0.0.0:20241 tunnel run

--- a/infrastructure/monitoring/host-fabric-metrics/install.sh
+++ b/infrastructure/monitoring/host-fabric-metrics/install.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+# Install host-side exporters for Tailscale + bind cloudflared metrics.
+# Run on omv (fans out to omv-ha) or on each host with LOCAL_ONLY=1.
+set -euo pipefail
+
+SSH_USER="${SSH_USER:-tbaltzakis}"
+OMV="${OMV_HOST:-192.168.1.128}"
+HA="${HA_HOST:-192.168.1.130}"
+LOCAL_ONLY="${LOCAL_ONLY:-0}"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SSH_OPTS=(-o BatchMode=yes -o StrictHostKeyChecking=accept-new -o ConnectTimeout=10)
+
+install_on() {
+  local host="$1"
+  echo "==> Installing fabric metrics on $host"
+  ssh "${SSH_OPTS[@]}" "${SSH_USER}@${host}" 'sudo mkdir -p /usr/local/lib/cloudless /etc/systemd/system/cloudflared.service.d'
+  scp "${SSH_OPTS[@]}" \
+    "$SCRIPT_DIR/tailscale-metrics-exporter.py" \
+    "${SSH_USER}@${host}:/tmp/tailscale-metrics-exporter.py"
+  scp "${SSH_OPTS[@]}" \
+    "$SCRIPT_DIR/tailscale-metrics-exporter.service" \
+    "${SSH_USER}@${host}:/tmp/tailscale-metrics-exporter.service"
+  scp "${SSH_OPTS[@]}" \
+    "$SCRIPT_DIR/cloudflared-metrics.conf" \
+    "${SSH_USER}@${host}:/tmp/cloudflared-metrics.conf"
+
+  ssh "${SSH_OPTS[@]}" "${SSH_USER}@${host}" bash -s <<'EOS'
+set -euo pipefail
+sudo install -m 0755 /tmp/tailscale-metrics-exporter.py /usr/local/lib/cloudless/tailscale-metrics-exporter.py
+sudo install -m 0644 /tmp/tailscale-metrics-exporter.service /etc/systemd/system/tailscale-metrics-exporter.service
+sudo install -m 0644 /tmp/cloudflared-metrics.conf /etc/systemd/system/cloudflared.service.d/metrics.conf
+sudo systemctl daemon-reload
+sudo systemctl enable --now tailscale-metrics-exporter.service
+sudo systemctl restart cloudflared.service
+sleep 2
+systemctl is-active tailscale-metrics-exporter
+systemctl is-active cloudflared
+curl -sS -o /dev/null -w "tailscale-metrics:%{http_code}\n" --max-time 3 http://127.0.0.1:9102/metrics
+curl -sS -o /dev/null -w "cloudflared-metrics:%{http_code}\n" --max-time 3 http://127.0.0.1:20241/metrics
+# confirm LAN bind (not only loopback)
+ss -ltn | grep -E ':9102|:20241' || true
+EOS
+}
+
+if [[ "$LOCAL_ONLY" == "1" ]]; then
+  HOST=$(hostname -s 2>/dev/null || hostname)
+  echo "LOCAL_ONLY=1 — installing on this host ($HOST)"
+  sudo mkdir -p /usr/local/lib/cloudless /etc/systemd/system/cloudflared.service.d
+  sudo install -m 0755 "$SCRIPT_DIR/tailscale-metrics-exporter.py" /usr/local/lib/cloudless/tailscale-metrics-exporter.py
+  sudo install -m 0644 "$SCRIPT_DIR/tailscale-metrics-exporter.service" /etc/systemd/system/tailscale-metrics-exporter.service
+  sudo install -m 0644 "$SCRIPT_DIR/cloudflared-metrics.conf" /etc/systemd/system/cloudflared.service.d/metrics.conf
+  sudo systemctl daemon-reload
+  sudo systemctl enable --now tailscale-metrics-exporter.service
+  sudo systemctl restart cloudflared.service
+  exit 0
+fi
+
+install_on "$OMV"
+install_on "$HA"
+echo "==> Host fabric metrics installed on omv + omv-ha"

--- a/infrastructure/monitoring/host-fabric-metrics/tailscale-metrics-exporter.py
+++ b/infrastructure/monitoring/host-fabric-metrics/tailscale-metrics-exporter.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python3
+"""Serve Tailscale client metrics for Prometheus on :9102/metrics.
+
+Refreshes via `tailscale metrics print` every REFRESH_SECS (default 15).
+Bind: 0.0.0.0 so kube-prometheus can scrape via LAN Endpoints.
+"""
+from __future__ import annotations
+
+import os
+import subprocess
+import threading
+import time
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+
+PORT = int(os.environ.get("TAILSCALE_METRICS_PORT", "9102"))
+REFRESH = int(os.environ.get("TAILSCALE_METRICS_REFRESH", "15"))
+BIN = os.environ.get("TAILSCALE_BIN", "tailscale")
+
+_lock = threading.Lock()
+_body = b"# HELP tailscale_exporter_up 1 if last refresh succeeded\ntailscale_exporter_up 0\n"
+_ok = False
+
+
+def refresh_loop() -> None:
+    global _body, _ok
+    while True:
+        try:
+            out = subprocess.check_output(
+                [BIN, "metrics", "print"],
+                stderr=subprocess.DEVNULL,
+                timeout=10,
+            )
+            footer = (
+                b"\n# HELP tailscale_exporter_up 1 if last refresh succeeded\n"
+                b"# TYPE tailscale_exporter_up gauge\n"
+                b"tailscale_exporter_up 1\n"
+            )
+            with _lock:
+                _body = out + footer
+                _ok = True
+        except Exception:
+            with _lock:
+                _ok = False
+                _body = (
+                    b"# HELP tailscale_exporter_up 1 if last refresh succeeded\n"
+                    b"# TYPE tailscale_exporter_up gauge\n"
+                    b"tailscale_exporter_up 0\n"
+                )
+        time.sleep(REFRESH)
+
+
+class Handler(BaseHTTPRequestHandler):
+    def do_GET(self) -> None:  # noqa: N802
+        if self.path not in ("/metrics", "/"):
+            self.send_response(404)
+            self.end_headers()
+            return
+        with _lock:
+            payload = _body
+        self.send_response(200)
+        self.send_header("Content-Type", "text/plain; version=0.0.4; charset=utf-8")
+        self.send_header("Content-Length", str(len(payload)))
+        self.end_headers()
+        self.wfile.write(payload)
+
+    def log_message(self, fmt: str, *args) -> None:
+        return
+
+
+def main() -> None:
+    threading.Thread(target=refresh_loop, daemon=True).start()
+    # Warm first sample
+    time.sleep(1)
+    server = ThreadingHTTPServer(("0.0.0.0", PORT), Handler)
+    server.serve_forever()
+
+
+if __name__ == "__main__":
+    main()

--- a/infrastructure/monitoring/host-fabric-metrics/tailscale-metrics-exporter.service
+++ b/infrastructure/monitoring/host-fabric-metrics/tailscale-metrics-exporter.service
@@ -1,0 +1,15 @@
+[Unit]
+Description=Tailscale Prometheus metrics exporter (:9102)
+After=network.target tailscaled.service
+Wants=tailscaled.service
+
+[Service]
+Type=simple
+ExecStart=/usr/bin/python3 /usr/local/lib/cloudless/tailscale-metrics-exporter.py
+Restart=on-failure
+RestartSec=5
+Environment=TAILSCALE_METRICS_PORT=9102
+Environment=TAILSCALE_METRICS_REFRESH=15
+
+[Install]
+WantedBy=multi-user.target

--- a/infrastructure/monitoring/tailscale-servicemonitor.yaml
+++ b/infrastructure/monitoring/tailscale-servicemonitor.yaml
@@ -65,7 +65,8 @@ spec:
       targetLabel: instance
     - targetLabel: job
       replacement: tailscale
----apiVersion: monitoring.coreos.com/v1
+---
+apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule
 metadata:
   name: tailscale-health

--- a/infrastructure/monitoring/tailscale-servicemonitor.yaml
+++ b/infrastructure/monitoring/tailscale-servicemonitor.yaml
@@ -1,0 +1,92 @@
+# Scrape Tailscale client metrics from host exporters on :9102.
+# Install exporters: bash infrastructure/monitoring/host-fabric-metrics/install.sh
+apiVersion: v1
+kind: Service
+metadata:
+  name: tailscale-metrics
+  namespace: monitoring
+  labels:
+    app: tailscale
+    component: metrics
+    release: kube-prom
+spec:
+  clusterIP: None
+  ports:
+  - name: metrics
+    port: 9102
+    targetPort: 9102
+    protocol: TCP
+---
+apiVersion: v1
+kind: Endpoints
+metadata:
+  name: tailscale-metrics
+  namespace: monitoring
+  labels:
+    app: tailscale
+    component: metrics
+subsets:
+- addresses:
+  - ip: 192.168.1.128
+    hostname: omv
+  - ip: 192.168.1.130
+    hostname: omv-ha
+  ports:
+  - name: metrics
+    port: 9102
+    protocol: TCP
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: tailscale
+  namespace: monitoring
+  labels:
+    release: kube-prom
+    cluster-protection.io/health: 'true'
+    app: tailscale
+spec:
+  selector:
+    matchLabels:
+      app: tailscale
+      component: metrics
+  namespaceSelector:
+    matchNames: [monitoring]
+  endpoints:
+  - port: metrics
+    path: /metrics
+    interval: 30s
+    scrapeTimeout: 10s
+    honorLabels: true
+    relabelings:
+    - sourceLabels: [__meta_kubernetes_endpoint_hostname]
+      targetLabel: host
+    - sourceLabels: [__meta_kubernetes_endpoint_hostname]
+      targetLabel: instance
+    - targetLabel: job
+      replacement: tailscale
+---apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: tailscale-health
+  namespace: monitoring
+  labels:
+    release: kube-prom
+spec:
+  groups:
+  - name: tailscale.rules
+    rules:
+    - alert: TailscaleMetricsAbsent
+      expr: absent(tailscaled_health_messages) == 1
+      for: 10m
+      labels: {severity: warning}
+      annotations:
+        summary: Tailscale metrics not scraped
+        description: Install host-fabric-metrics on omv/omv-ha and check ServiceMonitor.
+    - alert: TailscaleHealthWarnings
+      expr: tailscaled_health_messages{type="warning"} > 0
+      for: 15m
+      labels: {severity: warning}
+      annotations:
+        summary: Tailscale health warnings on {{ $labels.instance }}
+        description: tailscaled reports warning health messages.

--- a/k8s/cluster-protection/apply-memory-relief.sh
+++ b/k8s/cluster-protection/apply-memory-relief.sh
@@ -61,6 +61,8 @@ KEEPERS=(
   kube-prom-kubelet
   kube-prom-apiserver
   kube-prom-coredns
+  cloudflared
+  tailscale
 )
 for sm in "${KEEPERS[@]}"; do
   if kubectl get servicemonitor -n monitoring "$sm" >/dev/null 2>&1; then


### PR DESCRIPTION
## Summary
- Host exporters on **omv** + **omv-ha**:
  - cloudflared metrics bound to `0.0.0.0:20241`
  - Tailscale client metrics via `tailscale-metrics-exporter` on `:9102`
- Prometheus ServiceMonitors + alert rules for both
- Blackbox `http_tunnel_edge` probes (Access 302 = healthy) for public tunnel apps
- Grafana dashboards (sidecar ConfigMaps):
  - **Cloudflare Tunnel Status** (`uid: cloudflare-tunnel`)
  - **Tailscale Status** (`uid: tailscale-status`)
- Workflow `Deploy fabric metrics dashboards` re-applies on push / dispatch

## Live verification
- Targets `cloudflared` + `tailscale` = **up** on both nodes
- `cloudflared_tunnel_ha_connections` = 4 per connector
- `probe_success{scope="tunnel"}` = 1 for grafana/n8n/ntfy/espocrm/postiz/appflowy/pi-origin/webmail

## Test plan
- [x] Install host exporters + apply manifests
- [x] Prometheus scrapes healthy
- [ ] Open Grafana → Dashboards → Cloudflare Tunnel Status / Tailscale Status

Made with [Cursor](https://cursor.com)