### PR TITLE
fix(tunnels): correct grafana/app targetPorts in doctor

### DIFF
--- a/scripts/cloudflare-tunnels-doctor.sh
+++ b/scripts/cloudflare-tunnels-doctor.sh
@@ -214,7 +214,8 @@ patch() {
 # Known self-hosted NodePorts used by cloudflared ingress
 patch n8n n8n '{"spec":{"type":"NodePort","ports":[{"name":"http","port":5678,"targetPort":5678,"nodePort":30900}]}}'
 patch ntfy ntfy '{"spec":{"type":"NodePort","ports":[{"name":"http","port":80,"targetPort":80,"nodePort":30080}]}}'
-patch monitoring kube-prom-grafana '{"spec":{"type":"NodePort","ports":[{"name":"http","port":80,"targetPort":80,"nodePort":30850}]}}' || true
+# Grafana and cloudless-app listen on container port 3000 (service port stays 80).
+patch monitoring kube-prom-grafana '{"spec":{"type":"NodePort","ports":[{"name":"http","port":80,"targetPort":3000,"nodePort":30850}]}}' || true
 patch postiz postiz '{"spec":{"type":"NodePort","ports":[{"name":"http","port":5000,"targetPort":5000,"nodePort":30500}]}}' || true
 patch espocrm espocrm '{"spec":{"type":"NodePort","ports":[{"name":"http","port":80,"targetPort":80,"nodePort":30700}]}}' || true
 patch appflowy nginx-nodeport '{"spec":{"type":"NodePort","ports":[{"name":"http","port":80,"targetPort":80,"nodePort":30810}]}}' || true
@@ -222,7 +223,7 @@ patch uptime-kuma uptime-kuma '{"spec":{"type":"NodePort","ports":[{"name":"http
 patch default docs-service '{"spec":{"type":"NodePort","ports":[{"name":"http","port":8080,"targetPort":8080,"nodePort":30901}]}}' || true
 patch meilisearch meilisearch '{"spec":{"type":"NodePort","ports":[{"name":"http","port":7700,"targetPort":7700,"nodePort":30902}]}}' || true
 patch alert-manager alert-api '{"spec":{"type":"NodePort","ports":[{"name":"http","port":8080,"targetPort":8080,"nodePort":30820}]}}' || true
-patch cloudless cloudless-app '{"spec":{"type":"NodePort","ports":[{"name":"http","port":80,"targetPort":80,"nodePort":30300}]}}' || true
+patch cloudless cloudless-app '{"spec":{"type":"NodePort","ports":[{"name":"http","port":80,"targetPort":3000,"nodePort":30300}]}}' || true
 echo "NodePort patches attempted"
 EOS
 }


### PR DESCRIPTION
## Summary
- `#1678` doctor patched `kube-prom-grafana` and `cloudless-app` with `targetPort: 80`, but both containers listen on **3000**.
- That broke LAN NodePorts and `pi-origin`/`cloudless.gr` (502) after the post-merge doctor run.
- Live services already restored on omv; this locks the correct ports in the script.

## Test plan
- [x] Patched live svcs → `:30300` / `:30850` → 200; `pi-origin` / `cloudless.gr` → 200
- [ ] After merge: `gh workflow run 'Cloudflare tunnels doctor' -f dry_run=false -f fix=true` should stay green


Made with [Cursor](https://cursor.com)