### PR TITLE
fix(monitoring): wait for cloudflared metrics in fabric install

### DIFF
--- a/infrastructure/monitoring/host-fabric-metrics/install.sh
+++ b/infrastructure/monitoring/host-fabric-metrics/install.sh
@@ -10,6 +10,21 @@ LOCAL_ONLY="${LOCAL_ONLY:-0}"
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 SSH_OPTS=(-o BatchMode=yes -o StrictHostKeyChecking=accept-new -o ConnectTimeout=10)
 
+wait_http() {
+  local url="$1" label="$2" tries="${3:-15}"
+  local i code=000
+  for i in $(seq 1 "$tries"); do
+    code=$(curl -sS -o /dev/null -w '%{http_code}' --max-time 3 "$url" 2>/dev/null || echo 000)
+    if [[ "$code" == "200" ]]; then
+      echo "${label}:${code} (attempt ${i})"
+      return 0
+    fi
+    sleep 2
+  done
+  echo "${label}:${code} FAILED after ${tries} attempts" >&2
+  return 1
+}
+
 install_on() {
   local host="$1"
   echo "==> Installing fabric metrics on $host"
@@ -28,16 +43,50 @@ install_on() {
 set -euo pipefail
 sudo install -m 0755 /tmp/tailscale-metrics-exporter.py /usr/local/lib/cloudless/tailscale-metrics-exporter.py
 sudo install -m 0644 /tmp/tailscale-metrics-exporter.service /etc/systemd/system/tailscale-metrics-exporter.service
-sudo install -m 0644 /tmp/cloudflared-metrics.conf /etc/systemd/system/cloudflared.service.d/metrics.conf
+
+DROPIN=/etc/systemd/system/cloudflared.service.d/metrics.conf
+NEED_CF_RESTART=0
+if [[ ! -f "$DROPIN" ]] || ! cmp -s /tmp/cloudflared-metrics.conf "$DROPIN"; then
+  sudo install -m 0644 /tmp/cloudflared-metrics.conf "$DROPIN"
+  NEED_CF_RESTART=1
+fi
+
 sudo systemctl daemon-reload
 sudo systemctl enable --now tailscale-metrics-exporter.service
-sudo systemctl restart cloudflared.service
-sleep 2
+sudo systemctl restart tailscale-metrics-exporter.service
+
+# Only bounce cloudflared when the metrics drop-in changed, or metrics are down.
+CF_UP=0
+if curl -sS -o /dev/null --max-time 2 http://127.0.0.1:20241/metrics 2>/dev/null; then
+  CF_UP=1
+fi
+if [[ "$NEED_CF_RESTART" -eq 1 || "$CF_UP" -eq 0 ]]; then
+  echo "Restarting cloudflared (dropin_changed=${NEED_CF_RESTART} metrics_up=${CF_UP})"
+  sudo systemctl restart cloudflared.service
+else
+  echo "cloudflared metrics already up — skip restart"
+fi
+
 systemctl is-active tailscale-metrics-exporter
 systemctl is-active cloudflared
-curl -sS -o /dev/null -w "tailscale-metrics:%{http_code}\n" --max-time 3 http://127.0.0.1:9102/metrics
-curl -sS -o /dev/null -w "cloudflared-metrics:%{http_code}\n" --max-time 3 http://127.0.0.1:20241/metrics
-# confirm LAN bind (not only loopback)
+
+wait_http() {
+  local url="$1" label="$2" tries="${3:-20}"
+  local i code=000
+  for i in $(seq 1 "$tries"); do
+    code=$(curl -sS -o /dev/null -w '%{http_code}' --max-time 3 "$url" 2>/dev/null || echo 000)
+    if [[ "$code" == "200" ]]; then
+      echo "${label}:${code} (attempt ${i})"
+      return 0
+    fi
+    sleep 2
+  done
+  echo "${label}:${code} FAILED after ${tries} attempts" >&2
+  return 1
+}
+
+wait_http http://127.0.0.1:9102/metrics tailscale-metrics 15
+wait_http http://127.0.0.1:20241/metrics cloudflared-metrics 20
 ss -ltn | grep -E ':9102|:20241' || true
 EOS
 }
@@ -48,10 +97,20 @@ if [[ "$LOCAL_ONLY" == "1" ]]; then
   sudo mkdir -p /usr/local/lib/cloudless /etc/systemd/system/cloudflared.service.d
   sudo install -m 0755 "$SCRIPT_DIR/tailscale-metrics-exporter.py" /usr/local/lib/cloudless/tailscale-metrics-exporter.py
   sudo install -m 0644 "$SCRIPT_DIR/tailscale-metrics-exporter.service" /etc/systemd/system/tailscale-metrics-exporter.service
-  sudo install -m 0644 "$SCRIPT_DIR/cloudflared-metrics.conf" /etc/systemd/system/cloudflared.service.d/metrics.conf
+  DROPIN=/etc/systemd/system/cloudflared.service.d/metrics.conf
+  NEED_CF_RESTART=0
+  if [[ ! -f "$DROPIN" ]] || ! cmp -s "$SCRIPT_DIR/cloudflared-metrics.conf" "$DROPIN"; then
+    sudo install -m 0644 "$SCRIPT_DIR/cloudflared-metrics.conf" "$DROPIN"
+    NEED_CF_RESTART=1
+  fi
   sudo systemctl daemon-reload
   sudo systemctl enable --now tailscale-metrics-exporter.service
-  sudo systemctl restart cloudflared.service
+  sudo systemctl restart tailscale-metrics-exporter.service
+  if [[ "$NEED_CF_RESTART" -eq 1 ]] || ! curl -sS -o /dev/null --max-time 2 http://127.0.0.1:20241/metrics 2>/dev/null; then
+    sudo systemctl restart cloudflared.service
+  fi
+  wait_http http://127.0.0.1:9102/metrics tailscale-metrics 15
+  wait_http http://127.0.0.1:20241/metrics cloudflared-metrics 20
   exit 0
 fi
 


### PR DESCRIPTION
## Summary
- \`Deploy fabric metrics dashboards\` failed on \`install-hosts\`: cloudflared metrics \`127.0.0.1:20241\` not ready after a 2s sleep.
- Host install now retries Tailscale (:9102) and cloudflared (:20241) until HTTP 200 (or timeout).

## Test plan
- [x] Live omv/omv-ha already serve :20241 and :9102 → 200
- [ ] After merge, re-run \`Deploy fabric metrics dashboards\`


Made with [Cursor](https://cursor.com)