### PR TITLE
Fix SST OpenNext build and GSC private-key decoding

### DIFF
--- a/.github/workflows/sst-infra-deploy.yml
+++ b/.github/workflows/sst-infra-deploy.yml
@@ -62,7 +62,10 @@ jobs:
         CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
 
     - name: Build Next.js app with OpenNext
-      run: pnpm run cf:build
+      run: |
+        set -euo pipefail
+        pnpm run cf:build
+        test -f .open-next/worker.js
 
     - name: Strip @vercel/og .bin fonts (SST esbuild)
       run: node scripts/strip-opennext-bin-fonts.mjs

--- a/.gitignore
+++ b/.gitignore
@@ -260,3 +260,4 @@ test-results.json/
 
 # gh-aw audit downloads (`gh aw audit <run-id>`)
 .github/aw/logs/
+audit-links.zip

--- a/__tests__/google-sa-key.test.ts
+++ b/__tests__/google-sa-key.test.ts
@@ -41,6 +41,12 @@ describe("normalizeGooglePrivateKeyPem", () => {
     expect(normalizeGooglePrivateKeyPem(json)).toBe(pem.trim());
   });
 
+  it("decodes a base64-encoded PEM blob", () => {
+    const pem = samplePkcs8Pem();
+    const b64 = Buffer.from(pem, "utf8").toString("base64");
+    expect(normalizeGooglePrivateKeyPem(b64)).toBe(pem.trim());
+  });
+
   it("rejects truncated keys", () => {
     expect(() =>
       normalizeGooglePrivateKeyPem("-----BEGIN PRIVATE KEY-----\nabc\n-----END PRIVATE KEY-----")

--- a/infrastructure/monitoring/host-fabric-metrics/tailscale-metrics-exporter.py
+++ b/infrastructure/monitoring/host-fabric-metrics/tailscale-metrics-exporter.py
@@ -4,6 +4,7 @@
 Refreshes via `tailscale metrics print` every REFRESH_SECS (default 15).
 Bind: 0.0.0.0 so kube-prometheus can scrape via LAN Endpoints.
 """
+
 from __future__ import annotations
 
 import os

--- a/package.json
+++ b/package.json
@@ -129,7 +129,7 @@
     "cf:deploy": "wrangler deploy",
     "cf:deploy:free": "wrangler deploy --config wrangler-cloudflare-free.json",
     "cloudflare-build": "pnpm exec opennextjs-cloudflare build --openNextConfigPath open-next.config.cloudflare.ts",
-    "cf:build": "next build",
+    "cf:build": "pnpm exec opennextjs-cloudflare build --openNextConfigPath open-next.config.cloudflare.ts",
     "cf:build:opennext": "pnpm exec opennextjs-cloudflare build --openNextConfigPath open-next.config.cloudflare.ts",
     "cf:deploy:full": "pnpm cf:build && pnpm cf:r2:upload-static && pnpm cf:deploy",
     "cf:deploy:staging": "wrangler deploy -c wrangler.staging.jsonc",

--- a/src/lib/google-sa-key.ts
+++ b/src/lib/google-sa-key.ts
@@ -37,6 +37,18 @@ export function normalizeGooglePrivateKeyPem(raw: string): string {
 
   key = key.replace(/\\n/g, "\n").replace(/\r\n/g, "\n").replace(/\r/g, "\n").trim();
 
+  // Operators sometimes store the PEM as a single-line base64 blob (no BEGIN header).
+  if (!/-----BEGIN (RSA )?PRIVATE KEY-----/.test(key)) {
+    try {
+      const decoded = Buffer.from(key, "base64").toString("utf8").trim();
+      if (/-----BEGIN (RSA )?PRIVATE KEY-----/.test(decoded)) {
+        key = decoded.replace(/\r\n/g, "\n").replace(/\r/g, "\n").trim();
+      }
+    } catch {
+      // keep original key for the error below
+    }
+  }
+
   if (!/-----BEGIN (RSA )?PRIVATE KEY-----/.test(key)) {
     throw new Error(
       "GOOGLE_PRIVATE_KEY must be a PEM private key (-----BEGIN PRIVATE KEY----- or -----BEGIN RSA PRIVATE KEY-----)"


### PR DESCRIPTION
## Summary
- Restore `cf:build` to `opennextjs-cloudflare build` so SST Infra Deploy produces `.open-next/worker.js` (was only `next build`, causing deploy failures).
- Assert worker.js exists before `sst deploy`.
- Accept base64-encoded `GOOGLE_PRIVATE_KEY` PEMs (Daily Analytics Rollup failure mode).
- Ruff-format Tailscale metrics exporter (Python Lint).

## Test plan
- [ ] CI green (unit tests cover base64 PEM path)
- [ ] Re-run **SST Cloudflare Infra Deploy** via workflow_dispatch after merge
- [ ] Re-run **Daily Analytics Rollup** if GOOGLE_PRIVATE_KEY is base64; otherwise operator must paste a real PEM


Made with [Cursor](https://cursor.com)