### PR TITLE
Fix AppFlowy login redirect to cluster-local nginx host

### DIFF
--- a/infrastructure/appflowy/k8s/appflowy.yaml
+++ b/infrastructure/appflowy/k8s/appflowy.yaml
@@ -240,8 +240,10 @@ spec:
         - name: GOTRUE_ADMIN_PASSWORD
           valueFrom: {secretKeyRef: {name: appflowy-secrets, key: GOTRUE_ADMIN_PASSWORD}}
         - {name: DATABASE_URL, value: "postgres://postgres:$(POSTGRES_PASSWORD)@postgres:5432/postgres?search_path=auth"}
-        - {name: GOTRUE_SITE_URL, value: appflowy-flutter://}
-        - {name: GOTRUE_URI_ALLOW_LIST, value: '**'}
+        # Web login redirects to SITE_URL + /web#access_token=… — must be the
+        # public hostname (not nginx.appflowy.svc / appflowy-flutter:// alone).
+        - {name: GOTRUE_SITE_URL, value: 'https://appflowy.cloudless.gr'}
+        - {name: GOTRUE_URI_ALLOW_LIST, value: 'https://appflowy.cloudless.gr/**,appflowy-flutter://**'}
         - {name: GOTRUE_DISABLE_SIGNUP, value: 'true'}
         - {name: GOTRUE_JWT_ADMIN_GROUP_NAME, value: supabase_admin}
         - {name: GOTRUE_JWT_EXP, value: '604800'}


### PR DESCRIPTION
## Summary
- After password login, GoTrue redirected to `http://nginx.appflowy.svc.cluster.local/web#access_token=…`, which fails with `ERR_NAME_NOT_RESOLVED` on Windows.
- Set `GOTRUE_SITE_URL` to `https://appflowy.cloudless.gr` and narrow `GOTRUE_URI_ALLOW_LIST` to the public web origin plus `appflowy-flutter://**`.
- Already applied live on the cluster (`kubectl set env deploy/gotrue`); this PR persists the manifest.

## Test plan
- [ ] Open https://appflowy.cloudless.gr → Access → login
- [ ] Confirm redirect stays on `https://appflowy.cloudless.gr/web` (not `*.svc.cluster.local`)
- [ ] `kubectl -n appflowy exec deploy/gotrue -- printenv GOTRUE_SITE_URL` → public URL


Made with [Cursor](https://cursor.com)