### PR TITLE
Admin self-hosted portal: public cloudless.gr URLs

### DIFF
--- a/__tests__/selfhosted-autologin.test.ts
+++ b/__tests__/selfhosted-autologin.test.ts
@@ -42,8 +42,14 @@ vi.stubGlobal("fetch", mockFetch);
 // ---------------------------------------------------------------------------
 // Import SUT after mocks are in place
 // ---------------------------------------------------------------------------
-const { getAutologinUrl, supportsAutoLogin, SELFHOSTED_APP_NAMES } =
-  await import("@/lib/selfhosted-autologin");
+const {
+  getAutologinUrl,
+  supportsAutoLogin,
+  SELFHOSTED_APP_NAMES,
+  SELFHOSTED_PUBLIC_URLS,
+  isInternalOnlyBaseUrl,
+  publicUrlForApp,
+} = await import("@/lib/selfhosted-autologin");
 
 // ---------------------------------------------------------------------------
 describe("supportsAutoLogin", () => {
@@ -64,6 +70,36 @@ describe("SELFHOSTED_APP_NAMES", () => {
       expect(typeof SELFHOSTED_APP_NAMES[k]).toBe("string");
       expect(SELFHOSTED_APP_NAMES[k].length).toBeGreaterThan(0);
     }
+  });
+});
+
+describe("publicUrlForApp / isInternalOnlyBaseUrl", () => {
+  it("flags cluster DNS and LAN hosts as internal-only", () => {
+    expect(isInternalOnlyBaseUrl("http://nginx.appflowy.svc.cluster.local")).toBe(true);
+    expect(isInternalOnlyBaseUrl("http://kube-prom-grafana.monitoring.svc.cluster.local")).toBe(
+      true
+    );
+    expect(isInternalOnlyBaseUrl("http://192.168.1.128:30850")).toBe(true);
+    expect(isInternalOnlyBaseUrl("https://appflowy.cloudless.gr")).toBe(false);
+  });
+
+  it("rewrites cluster-local config to the public cloudless.gr origin", () => {
+    expect(publicUrlForApp("appflowy", "http://nginx.appflowy.svc.cluster.local")).toBe(
+      SELFHOSTED_PUBLIC_URLS.appflowy
+    );
+    expect(publicUrlForApp("grafana", "http://kube-prom-grafana.monitoring.svc.cluster.local")).toBe(
+      SELFHOSTED_PUBLIC_URLS.grafana
+    );
+    expect(publicUrlForApp("postiz", "http://postiz.postiz.svc.cluster.local:5000")).toBe(
+      SELFHOSTED_PUBLIC_URLS.postiz
+    );
+    expect(publicUrlForApp("kuma", "http://uptime-kuma.uptime-kuma.svc.cluster.local:3001")).toBe(
+      SELFHOSTED_PUBLIC_URLS.kuma
+    );
+  });
+
+  it("keeps an already-public cloudless.gr base", () => {
+    expect(publicUrlForApp("n8n", "https://n8n.cloudless.gr")).toBe("https://n8n.cloudless.gr");
   });
 });
 
@@ -102,8 +138,19 @@ describe("getAutologinUrl — non-AppFlowy apps (smart links)", () => {
 
 // ---------------------------------------------------------------------------
 describe("getAutologinUrl — AppFlowy (GoTrue password-grant)", () => {
-  beforeEach(() => {
+  beforeEach(async () => {
     mockFetch.mockReset();
+    const { getConfig } = await import("@/lib/ssm-config");
+    vi.mocked(getConfig).mockResolvedValue({
+      APPFLOWY_API_URL: "https://appflowy.cloudless.gr",
+      APPFLOWY_EMAIL: "admin@cloudless.gr",
+      APPFLOWY_PASSWORD: "test-password",
+      ESPOCRM_BASE_URL: "https://espocrm.cloudless.gr",
+      N8N_API_URL: "https://n8n.cloudless.gr",
+      POSTIZ_API_URL: "https://postiz.cloudless.gr",
+      GRAFANA_BASE_URL: "https://grafana.cloudless.gr",
+      KUMA_BASE_URL: "https://kuma.cloudless.gr",
+    } as never);
   });
 
   it("returns a token-injected URL on successful GoTrue grant", async () => {
@@ -119,6 +166,28 @@ describe("getAutologinUrl — AppFlowy (GoTrue password-grant)", () => {
     expect(result.url).toContain("appflowy.cloudless.gr");
     // Token is embedded in the URL hash, not the path
     expect(result.url).toContain("#access_token=");
+  });
+
+  it("rewrites in-cluster APPFLOWY_API_URL to the public web redirect", async () => {
+    const { getConfig } = await import("@/lib/ssm-config");
+    vi.mocked(getConfig).mockResolvedValue({
+      APPFLOWY_API_URL: "http://nginx.appflowy.svc.cluster.local",
+      APPFLOWY_EMAIL: "admin@cloudless.gr",
+      APPFLOWY_PASSWORD: "test-password",
+    } as never);
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ access_token: "tok-cluster" }),
+    });
+
+    const result = await getAutologinUrl("appflowy");
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      "http://nginx.appflowy.svc.cluster.local/gotrue/token?grant_type=password",
+      expect.any(Object)
+    );
+    expect(result.url.startsWith("https://appflowy.cloudless.gr/web#access_token=")).toBe(true);
+    expect(result.url).not.toContain("svc.cluster.local");
   });
 
   it("calls the GoTrue password-grant endpoint with correct params", async () => {

--- a/src/app/[locale]/admin/appflowy/status/page.tsx
+++ b/src/app/[locale]/admin/appflowy/status/page.tsx
@@ -354,7 +354,7 @@ export default function AppFlowyStatusPage() {
                     <span className="text-neon-cyan mr-2 font-mono">1.</span>
                     Go to{" "}
                     <a
-                      href="https://www.appflowy.cloudless.gr"
+                      href="https://appflowy.cloudless.gr"
                       target="_blank"
                       rel="noopener noreferrer"
                       className="text-neon-cyan hover:underline"

--- a/src/app/[locale]/admin/selfhosted/page.tsx
+++ b/src/app/[locale]/admin/selfhosted/page.tsx
@@ -2,9 +2,12 @@
 import { fetchWithAuth } from "@/lib/fetch-with-auth";
 import { useCallback, useEffect, useState } from "react";
 import { Link } from "@/i18n/navigation";
-type AppKey = "appflowy" | "espocrm" | "n8n" | "postiz" | "grafana" | "kuma";
-type AuthMode = "auto" | "link" | "vpn";
+import { SELFHOSTED_PUBLIC_URLS, type SelfhostedApp } from "@/lib/selfhosted-apps";
+
+type AppKey = SelfhostedApp;
+type AuthMode = "auto" | "link";
 type HealthStatus = "up" | "down" | "pending" | "unknown";
+
 interface AppDef {
   key: AppKey;
   name: string;
@@ -12,7 +15,9 @@ interface AppDef {
   icon: string;
   authMode: AuthMode;
   detail: string;
+  publicUrl: string;
 }
+
 interface KumaMonitor {
   id: number;
   name: string;
@@ -21,9 +26,11 @@ interface KumaMonitor {
   lastHeartbeatAt: string | null;
   groupName: string;
 }
+
 interface KumaSummary {
   monitors: KumaMonitor[];
 }
+
 const APPS: AppDef[] = [
   {
     key: "espocrm",
@@ -32,6 +39,7 @@ const APPS: AppDef[] = [
     icon: "◉",
     authMode: "auto",
     detail: "Auto-login via API credentials",
+    publicUrl: SELFHOSTED_PUBLIC_URLS.espocrm,
   },
   {
     key: "appflowy",
@@ -40,6 +48,7 @@ const APPS: AppDef[] = [
     icon: "📝",
     authMode: "auto",
     detail: "Auto-login via GoTrue token",
+    publicUrl: SELFHOSTED_PUBLIC_URLS.appflowy,
   },
   {
     key: "n8n",
@@ -48,6 +57,7 @@ const APPS: AppDef[] = [
     icon: "🔀",
     authMode: "link",
     detail: "Trigger and inspect workflows",
+    publicUrl: SELFHOSTED_PUBLIC_URLS.n8n,
   },
   {
     key: "postiz",
@@ -56,14 +66,16 @@ const APPS: AppDef[] = [
     icon: "📨",
     authMode: "link",
     detail: "Schedule and review posts",
+    publicUrl: SELFHOSTED_PUBLIC_URLS.postiz,
   },
   {
     key: "grafana",
     name: "Grafana",
     description: "Dashboards · Metrics",
     icon: "📊",
-    authMode: "vpn",
-    detail: "Requires VPN / Tailscale",
+    authMode: "link",
+    detail: "Cloudflare Access gated",
+    publicUrl: SELFHOSTED_PUBLIC_URLS.grafana,
   },
   {
     key: "kuma",
@@ -72,13 +84,15 @@ const APPS: AppDef[] = [
     icon: "🟢",
     authMode: "link",
     detail: "Monitor status and alerts",
+    publicUrl: SELFHOSTED_PUBLIC_URLS.kuma,
   },
 ];
+
 const AUTH_BADGE: Record<AuthMode, { label: string; klass: string }> = {
   auto: { label: "AUTO-LOGIN", klass: "border-neon-cyan/30 bg-neon-cyan/10 text-neon-cyan" },
   link: { label: "DIRECT LINK", klass: "border-slate-700 bg-slate-800/50 text-slate-400" },
-  vpn: { label: "VPN ONLY", klass: "border-yellow-500/30 bg-yellow-500/10 text-yellow-400" },
 };
+
 function HealthBadge({ status, pingMs }: { status: HealthStatus; pingMs?: number | null }) {
   if (status === "unknown") return null;
   const cfg = {
@@ -88,24 +102,34 @@ function HealthBadge({ status, pingMs }: { status: HealthStatus; pingMs?: number
   }[status];
   return (
     <div className="flex items-center gap-1.5">
-      {" "}
-      <span className={`h-1.5 w-1.5 rounded-full ${cfg.dot}`} />{" "}
+      <span className={`h-1.5 w-1.5 rounded-full ${cfg.dot}`} />
       <span className={`font-mono text-[10px] ${cfg.klass}`}>
-        {" "}
-        {cfg.label} {status === "up" && pingMs != null ? ` · ${pingMs}ms` : ""}{" "}
-      </span>{" "}
+        {cfg.label}
+        {status === "up" && pingMs != null ? ` · ${pingMs}ms` : ""}
+      </span>
     </div>
   );
 }
+
+function publicHostLabel(url: string): string {
+  try {
+    return new URL(url).host;
+  } catch {
+    return url.replace(/^https?:\/\//, "");
+  }
+}
+
 interface AppCardProps {
   app: AppDef;
   health: HealthStatus;
   pingMs: number | null;
 }
+
 function AppCard({ app, health, pingMs }: AppCardProps) {
   const [busy, setBusy] = useState(false);
   const [err, setErr] = useState<string | null>(null);
   const authBadge = AUTH_BADGE[app.authMode];
+
   const handleOpen = useCallback(async () => {
     setBusy(true);
     setErr(null);
@@ -124,59 +148,61 @@ function AppCard({ app, health, pingMs }: AppCardProps) {
       setBusy(false);
     }
   }, [app.key]);
+
   return (
     <div className="group bg-void-light/50 flex flex-col rounded-xl border border-slate-800 p-5 transition-all hover:border-slate-700">
-      {" "}
       <div className="mb-4 flex items-start justify-between gap-3">
-        {" "}
         <div className="flex h-11 w-11 shrink-0 items-center justify-center rounded-xl border border-slate-700 bg-slate-900/60 text-xl">
-          {" "}
-          {app.icon}{" "}
-        </div>{" "}
+          {app.icon}
+        </div>
         <div className="flex flex-col items-end gap-1.5">
-          {" "}
           <span
             className={`rounded-full border px-2 py-0.5 font-mono text-[10px] ${authBadge.klass}`}
           >
-            {" "}
-            {authBadge.label}{" "}
-          </span>{" "}
-          <HealthBadge status={health} pingMs={pingMs} />{" "}
-        </div>{" "}
-      </div>{" "}
+            {authBadge.label}
+          </span>
+          <HealthBadge status={health} pingMs={pingMs} />
+        </div>
+      </div>
       <div className="flex-1">
-        {" "}
-        <h3 className="font-heading mb-0.5 text-base font-semibold text-white">{app.name}</h3>{" "}
-        <p className="font-body mb-1 text-xs text-slate-400">{app.description}</p>{" "}
-        <p className="font-mono text-[10px] text-slate-600">{app.detail}</p>{" "}
-      </div>{" "}
+        <h3 className="font-heading mb-0.5 text-base font-semibold text-white">{app.name}</h3>
+        <p className="font-body mb-1 text-xs text-slate-400">{app.description}</p>
+        <p className="font-mono text-[10px] text-slate-600">{app.detail}</p>
+        <a
+          href={app.publicUrl}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="text-neon-cyan/80 hover:text-neon-cyan mt-2 inline-block font-mono text-[11px] underline-offset-2 hover:underline"
+        >
+          {publicHostLabel(app.publicUrl)} ↗
+        </a>
+      </div>
       <div className="mt-4 flex items-center justify-between gap-2 border-t border-slate-800 pt-4">
-        {" "}
         {err ? (
           <span className="flex-1 truncate font-mono text-[10px] text-red-400">{err}</span>
         ) : (
           <span className="flex-1" />
-        )}{" "}
+        )}
         <button
+          type="button"
           onClick={handleOpen}
           disabled={busy}
           className="hover:border-neon-cyan/40 flex items-center gap-1.5 rounded-lg border border-slate-700 bg-slate-900/60 px-4 py-2 font-mono text-xs font-medium text-slate-300 transition-all group-hover:border-slate-600 hover:bg-slate-800 hover:text-white disabled:cursor-not-allowed disabled:opacity-50"
         >
-          {" "}
           {busy ? (
             <>
-              {" "}
-              <span className="h-3 w-3 animate-spin rounded-full border border-slate-600 border-t-slate-300" />{" "}
-              Opening…{" "}
+              <span className="h-3 w-3 animate-spin rounded-full border border-slate-600 border-t-slate-300" />
+              Opening…
             </>
           ) : (
             <>Open →</>
-          )}{" "}
-        </button>{" "}
-      </div>{" "}
+          )}
+        </button>
+      </div>
     </div>
   );
 }
+
 function matchMonitorToApp(name: string): AppKey | null {
   const lower = name.toLowerCase();
   if (lower.includes("espocrm") || lower.includes("espo")) return "espocrm";
@@ -187,6 +213,7 @@ function matchMonitorToApp(name: string): AppKey | null {
   if (lower.includes("kuma")) return "kuma";
   return null;
 }
+
 export default function SelfhostedPortalPage() {
   const [healthMap, setHealthMap] = useState<Record<AppKey, HealthStatus>>({
     appflowy: "unknown",
@@ -205,6 +232,7 @@ export default function SelfhostedPortalPage() {
     kuma: null,
   });
   const [kumaLoaded, setKumaLoaded] = useState(false);
+
   useEffect(() => {
     async function loadHealth() {
       try {
@@ -248,63 +276,56 @@ export default function SelfhostedPortalPage() {
     }
     loadHealth();
   }, []);
+
   const allUp =
     kumaLoaded && APPS.every((a) => healthMap[a.key] === "up" || healthMap[a.key] === "unknown");
   const anyDown = APPS.some((a) => healthMap[a.key] === "down");
+
   return (
     <div>
-      {" "}
       <div className="mb-6">
-        {" "}
         <Link href="/admin" className="font-mono text-xs text-slate-500 hover:text-slate-300">
-          {" "}
-          ← Admin{" "}
-        </Link>{" "}
-      </div>{" "}
+          ← Admin
+        </Link>
+      </div>
       <div className="mb-8">
-        {" "}
         <div className="border-neon-cyan/20 bg-neon-cyan/10 mb-4 inline-flex items-center gap-2 rounded-full border px-3 py-1.5">
-          {" "}
-          <span className="bg-neon-cyan h-2 w-2 rounded-full" />{" "}
-          <span className="text-neon-cyan font-mono text-xs">SELF-HOSTED PORTAL</span>{" "}
-        </div>{" "}
-        <h1 className="font-heading text-2xl font-bold text-white">Self-hosted Apps</h1>{" "}
+          <span className="bg-neon-cyan h-2 w-2 rounded-full" />
+          <span className="text-neon-cyan font-mono text-xs">SELF-HOSTED PORTAL</span>
+        </div>
+        <h1 className="font-heading text-2xl font-bold text-white">Self-hosted Apps</h1>
         <p className="font-body mt-2 text-sm text-slate-400">
-          {" "}
-          One-click admin ingress to every app running on the Pi cluster.{" "}
-        </p>{" "}
+          One-click admin ingress via public{" "}
+          <span className="font-mono text-slate-300">*.cloudless.gr</span> hosts (Cloudflare
+          Access). Never use <span className="font-mono text-slate-500">*.svc.cluster.local</span>{" "}
+          in a browser.
+        </p>
         {kumaLoaded && (
           <div className="mt-4 inline-flex items-center gap-2 rounded-full border border-slate-800 bg-slate-900/40 px-3 py-1.5">
-            {" "}
             <span
               className={`h-1.5 w-1.5 rounded-full ${anyDown ? "animate-pulse bg-red-400" : "bg-neon-green"}`}
-            />{" "}
+            />
             <span className="font-mono text-[10px] text-slate-400">
-              {" "}
               {anyDown
                 ? `${APPS.filter((a) => healthMap[a.key] === "down").length} app(s) down`
                 : allUp
                   ? "All apps up"
-                  : "Cluster health loading…"}{" "}
-            </span>{" "}
+                  : "Cluster health loading…"}
+            </span>
           </div>
-        )}{" "}
-      </div>{" "}
+        )}
+      </div>
       <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
-        {" "}
         {APPS.map((app) => (
           <AppCard key={app.key} app={app} health={healthMap[app.key]} pingMs={pingMap[app.key]} />
-        ))}{" "}
-      </div>{" "}
+        ))}
+      </div>
       <div className="mt-8 rounded-xl border border-slate-800 bg-slate-900/30 p-4">
-        {" "}
         <p className="font-mono text-[10px] text-slate-500">
-          {" "}
-          <span className="text-neon-cyan">AUTO-LOGIN</span> apps inject a fresh server-side token.{" "}
-          <span className="text-yellow-400">VPN ONLY</span> apps require Tailscale. Health badges
-          from Uptime Kuma.{" "}
-        </p>{" "}
-      </div>{" "}
+          <span className="text-neon-cyan">AUTO-LOGIN</span> apps inject a fresh server-side token
+          and open the public URL. Health badges from Uptime Kuma.
+        </p>
+      </div>
     </div>
   );
 }

--- a/src/lib/selfhosted-apps.ts
+++ b/src/lib/selfhosted-apps.ts
@@ -1,0 +1,25 @@
+/**
+ * Shared self-hosted app catalog (safe for client + server).
+ * Launch/autologin logic that talks to SSM lives in selfhosted-autologin.ts.
+ */
+
+export type SelfhostedApp = "appflowy" | "espocrm" | "n8n" | "postiz" | "grafana" | "kuma";
+
+export const SELFHOSTED_APP_NAMES: Record<SelfhostedApp, string> = {
+  appflowy: "AppFlowy",
+  espocrm: "EspoCRM",
+  n8n: "n8n",
+  postiz: "Postiz",
+  grafana: "Grafana",
+  kuma: "Uptime Kuma",
+};
+
+/** Canonical public origins opened from the admin Self-hosted portal. */
+export const SELFHOSTED_PUBLIC_URLS: Record<SelfhostedApp, string> = {
+  appflowy: "https://appflowy.cloudless.gr",
+  espocrm: "https://espocrm.cloudless.gr",
+  n8n: "https://n8n.cloudless.gr",
+  postiz: "https://postiz.cloudless.gr",
+  grafana: "https://grafana.cloudless.gr",
+  kuma: "https://kuma.cloudless.gr",
+};

--- a/src/lib/selfhosted-autologin.ts
+++ b/src/lib/selfhosted-autologin.ts
@@ -5,6 +5,11 @@
  * Apps that support token-based or credential-based auto-login get a
  * server-side injected auth; all others get a canonical admin URL.
  *
+ * Browser launch URLs ALWAYS use the public `*.cloudless.gr` hosts.
+ * SSM/env may still hold in-cluster Service DNS for pod→pod API calls
+ * (e.g. `http://nginx.appflowy.svc.cluster.local`) — those must never be
+ * returned to Windows/Tailscale browsers (`ERR_NAME_NOT_RESOLVED`).
+ *
  * Security notes:
  * - Tokens/credentials are fetched server-side and never logged.
  * - URLs containing secrets are never stored and are only returned to
@@ -12,22 +17,62 @@
  * - This module is server-only; never import it from client components.
  */
 import { getConfig } from "@/lib/ssm-config";
+import {
+  SELFHOSTED_APP_NAMES,
+  SELFHOSTED_PUBLIC_URLS,
+  type SelfhostedApp,
+} from "@/lib/selfhosted-apps";
 
-export type SelfhostedApp = "appflowy" | "espocrm" | "n8n" | "postiz" | "grafana" | "kuma";
-
-export const SELFHOSTED_APP_NAMES: Record<SelfhostedApp, string> = {
-  appflowy: "AppFlowy",
-  espocrm: "EspoCRM",
-  n8n: "n8n",
-  postiz: "Postiz",
-  grafana: "Grafana",
-  kuma: "Uptime Kuma",
-};
+export type { SelfhostedApp } from "@/lib/selfhosted-apps";
+export { SELFHOSTED_APP_NAMES, SELFHOSTED_PUBLIC_URLS } from "@/lib/selfhosted-apps";
 
 export interface AutologinResult {
   url: string;
   /** true = URL contains an injected token/credential and should not be stored */
   hasToken: boolean;
+}
+
+/**
+ * True when a configured base is only reachable inside the cluster / LAN
+ * and must not be handed to a desktop browser.
+ */
+export function isInternalOnlyBaseUrl(raw: string): boolean {
+  const s = raw.trim();
+  if (!s) return false;
+  try {
+    const u = new URL(s.includes("://") ? s : `http://${s}`);
+    const host = u.hostname.toLowerCase();
+    if (host.endsWith(".svc.cluster.local") || host === "kubernetes.default") return true;
+    if (host === "localhost" || host === "127.0.0.1" || host === "::1") return true;
+    if (/^10\.\d+\.\d+\.\d+$/.test(host)) return true;
+    if (/^192\.168\.\d+\.\d+$/.test(host)) return true;
+    if (/^172\.(1[6-9]|2\d|3[0-1])\.\d+\.\d+$/.test(host)) return true;
+    return false;
+  } catch {
+    return /\.svc\.cluster\.local/i.test(s);
+  }
+}
+
+/**
+ * Resolve the URL a browser should open. Prefer the public cloudless.gr
+ * origin whenever the configured value is missing or cluster/LAN-only.
+ */
+export function publicUrlForApp(app: SelfhostedApp, configured?: string | null): string {
+  const fallback = SELFHOSTED_PUBLIC_URLS[app];
+  const raw = (configured ?? "").trim().replace(/\/$/, "");
+  if (!raw || isInternalOnlyBaseUrl(raw)) return fallback;
+  try {
+    const u = new URL(raw);
+    if (u.protocol !== "http:" && u.protocol !== "https:") return fallback;
+    const host = u.hostname.toLowerCase();
+    if (host === "cloudless.gr" || host.endsWith(".cloudless.gr")) {
+      return `${u.protocol}//${u.host}`.replace(/\/$/, "");
+    }
+  } catch {
+    return fallback;
+  }
+  // Unknown external host — still prefer our known public map for these tiles.
+  return fallback;
 }
 
 // ---------------------------------------------------------------------------
@@ -36,20 +81,19 @@ export interface AutologinResult {
 
 /**
  * AppFlowy: POST to GoTrue password-grant endpoint → get access_token →
- * construct deep-link `{base}/web#access_token=…` so the SPA logs in on load.
+ * construct deep-link `{public}/web#access_token=…` so the SPA logs in on load.
  *
- * The access_token returned is short-lived (GoTrue default: 1 hour, but we
- * request a fresh one immediately before redirect so it's effectively brand-new).
- * We do NOT use APPFLOWY_JWT_SECRET here — that's for the service-role API
- * path. This is a real user login via the GoTrue password grant.
+ * GoTrue may be reached via an in-cluster APPFLOWY_API_URL; the redirect
+ * URL handed to the browser is always the public origin.
  */
 async function buildAppFlowyUrl(): Promise<AutologinResult> {
   const cfg = await getConfig();
-  const base = (cfg.APPFLOWY_API_URL ?? "").replace(/\/$/, "");
+  const apiBase = (cfg.APPFLOWY_API_URL ?? "").replace(/\/$/, "");
   const email = cfg.APPFLOWY_EMAIL ?? "";
   const password = cfg.APPFLOWY_PASSWORD ?? "";
+  const browserBase = publicUrlForApp("appflowy", apiBase);
 
-  if (!base || !email || !password) {
+  if (!apiBase || !email || !password) {
     throw new Error(
       "AppFlowy not configured: APPFLOWY_API_URL / APPFLOWY_EMAIL / APPFLOWY_PASSWORD missing"
     );
@@ -57,7 +101,7 @@ async function buildAppFlowyUrl(): Promise<AutologinResult> {
 
   // GoTrue on AppFlowy Cloud rejects body-only grant_type with
   // unsupported_grant_type; the grant must be in the query string.
-  const grantUrl = `${base}/gotrue/token?grant_type=password`;
+  const grantUrl = `${apiBase}/gotrue/token?grant_type=password`;
 
   let res: Response;
   try {
@@ -89,7 +133,7 @@ async function buildAppFlowyUrl(): Promise<AutologinResult> {
   }
 
   // AppFlowy web SPA reads the access_token from the URL hash on initial load.
-  const redirectUrl = `${base}/web#access_token=${encodeURIComponent(token)}`;
+  const redirectUrl = `${browserBase}/web#access_token=${encodeURIComponent(token)}`;
   return { url: redirectUrl, hasToken: true };
 }
 
@@ -105,7 +149,7 @@ function buildEspoCrmUrl(cfg: {
   apiUser?: string;
   apiPassword?: string;
 }): AutologinResult {
-  const base = (cfg.baseUrl || "https://espocrm.cloudless.gr").replace(/\/$/, "");
+  const base = publicUrlForApp("espocrm", cfg.baseUrl);
   const user = cfg.apiUser || "";
   const password = cfg.apiPassword || "";
 
@@ -129,7 +173,7 @@ function buildEspoCrmUrl(cfg: {
  * Return the direct admin URL.
  */
 function buildN8nUrl(base: string): AutologinResult {
-  const b = base.replace(/\/$/, "");
+  const b = publicUrlForApp("n8n", base);
   return { url: `${b}/signin`, hasToken: false };
 }
 
@@ -139,17 +183,15 @@ function buildN8nUrl(base: string): AutologinResult {
  * Return the direct admin URL.
  */
 function buildPostizUrl(base: string): AutologinResult {
-  const b = base.replace(/\/$/, "");
+  const b = publicUrlForApp("postiz", base);
   return { url: `${b}/`, hasToken: false };
 }
 
 /**
- * Grafana: no URL-based token auth for the web UI.
- * API tokens work for the REST API but UI login requires username/password.
- * Return the direct admin URL.
+ * Grafana: public via Cloudflare Access (no Tailscale required for the UI).
  */
 function buildGrafanaUrl(base: string): AutologinResult {
-  const b = (base || "https://grafana.cloudless.gr").replace(/\/$/, "");
+  const b = publicUrlForApp("grafana", base);
   return { url: `${b}/`, hasToken: false };
 }
 
@@ -158,7 +200,7 @@ function buildGrafanaUrl(base: string): AutologinResult {
  * Return the dashboard URL.
  */
 function buildKumaUrl(base: string): AutologinResult {
-  const b = (base || "https://kuma.cloudless.gr").replace(/\/$/, "");
+  const b = publicUrlForApp("kuma", base);
   return { url: `${b}/dashboard`, hasToken: false };
 }
 
@@ -180,16 +222,16 @@ export async function getAutologinUrl(app: SelfhostedApp): Promise<AutologinResu
 
     case "espocrm":
       return buildEspoCrmUrl({
-        baseUrl: cfg.ESPOCRM_BASE_URL || "https://espocrm.cloudless.gr",
+        baseUrl: cfg.ESPOCRM_BASE_URL || SELFHOSTED_PUBLIC_URLS.espocrm,
         apiUser: cfg.ESPOCRM_API_USER,
         apiPassword: cfg.ESPOCRM_API_PASSWORD,
       });
 
     case "n8n":
-      return buildN8nUrl(cfg.N8N_API_URL || "https://n8n.cloudless.gr");
+      return buildN8nUrl(cfg.N8N_API_URL || SELFHOSTED_PUBLIC_URLS.n8n);
 
     case "postiz":
-      return buildPostizUrl(cfg.POSTIZ_API_URL || "https://postiz.cloudless.gr");
+      return buildPostizUrl(cfg.POSTIZ_API_URL || SELFHOSTED_PUBLIC_URLS.postiz);
 
     case "grafana":
       return buildGrafanaUrl(cfg.GRAFANA_BASE_URL);


### PR DESCRIPTION
## Summary
- Admin **Self-hosted Apps** tiles now show each app’s public host (`appflowy`, `espocrm`, `n8n`, `postiz`, `grafana`, `kuma`).
- Autologin rewrites `*.svc.cluster.local` / LAN bases to `https://*.cloudless.gr` for browser redirects (GoTrue can still use in-cluster `APPFLOWY_API_URL`).
- Fix AppFlowy status setup link (`www.appflowy…` → `appflowy.cloudless.gr`).

## Test plan
- [ ] `/admin/selfhosted` shows six public host links
- [ ] Open AppFlowy → lands on `https://appflowy.cloudless.gr/web#…` (not `nginx.appflowy.svc…`)
- [ ] `pnpm exec vitest run __tests__/selfhosted-autologin.test.ts`


Made with [Cursor](https://cursor.com)