### PR TITLE
feat: multi-sender email + Postiz social hub v2.11.2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -260,3 +260,7 @@ test-results.json/
 
 # gh-aw audit downloads (`gh aw audit <run-id>`)
 .github/aw/logs/
+
+# Local MCP launcher secrets (never commit keys)
+scripts/cursor-mcp/*.env
+scripts/cursor-mcp/*-secret*

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -12,6 +12,7 @@
     "streetsidesoftware.code-spell-checker",
     "mikestead.dotenv",
     "redhat.vscode-yaml",
+    "tim-koehler.helm-intellisense",
     "github.vscode-github-actions",
     "ms-azuretools.vscode-docker",
     "mtxr.sqltools",

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -55,7 +55,11 @@
     ".dev.vars": "dotenv",
     "*.css": "tailwindcss",
     "wrangler.jsonc": "jsonc",
-    "open-next.config.*": "typescript"
+    "open-next.config.*": "typescript",
+    // Helm Go templates are not valid YAML until rendered — keep Red Hat YAML
+    // from flagging `{{- include ... }}` as "flow collection" errors.
+    "**/helm/**/templates/**/*.yaml": "helm",
+    "**/helm/**/templates/**/*.yml": "helm"
   },
 
   "eslint.enable": true,

--- a/__tests__/postiz.test.ts
+++ b/__tests__/postiz.test.ts
@@ -39,6 +39,7 @@ import {
   updatePostReleaseId,
   uploadFile,
   uploadFromUrl,
+  withSocialUtm,
   type PostizIntegration,
 } from "@/lib/postiz";
 import { verifyPostizWebhookSignature } from "@/lib/postiz-webhook";
@@ -53,6 +54,25 @@ function jsonResponse(body: unknown, status = 200): Response {
     status,
     headers: { "Content-Type": "application/json" },
   });
+}
+
+/** schedulePost now lists integrations first, then POSTs /posts. */
+function mockScheduleFetch(postBody: unknown = [{ id: "p1" }], postStatus = 200) {
+  mockFetch.mockImplementation((url: string) => {
+    if (String(url).includes("/integrations")) {
+      return Promise.resolve(
+        jsonResponse([{ id: "fb", name: "FB", identifier: "facebook" }])
+      );
+    }
+    return Promise.resolve(jsonResponse(postBody, postStatus));
+  });
+}
+
+function lastPostBody(): Record<string, unknown> {
+  const postCall = [...mockFetch.mock.calls]
+    .reverse()
+    .find(([url]) => String(url).includes("/posts"));
+  return JSON.parse(postCall![1].body as string) as Record<string, unknown>;
 }
 
 beforeEach(() => {
@@ -123,6 +143,22 @@ describe("matchIntegrationsForPlatform", () => {
   });
 });
 
+describe("withSocialUtm", () => {
+  it("adds utm_source/medium/campaign when missing", () => {
+    const out = withSocialUtm("https://cloudless.gr/en/blog/foo", "linkedin", "blog_abc");
+    expect(out).toContain("utm_source=linkedin");
+    expect(out).toContain("utm_medium=social");
+    expect(out).toContain("utm_campaign=blog_abc");
+  });
+
+  it("leaves non-URLs and already-tagged URLs alone for existing params", () => {
+    expect(withSocialUtm("not-a-url", "x")).toBe("not-a-url");
+    const tagged = withSocialUtm("https://cloudless.gr/?utm_source=manual", "x");
+    expect(tagged).toContain("utm_source=manual");
+    expect(tagged).not.toContain("utm_source=x");
+  });
+});
+
 describe("schedulePost", () => {
   it("rejects empty targets and empty content without calling the API", async () => {
     const noTargets = await schedulePost({ content: "hello", integrationIds: [] });
@@ -133,34 +169,38 @@ describe("schedulePost", () => {
   });
 
   it("uses type=schedule for future dates and type=now for past dates", async () => {
-    mockFetch.mockImplementation(() => Promise.resolve(jsonResponse([{ id: "p1" }])));
+    mockScheduleFetch();
     const future = new Date(Date.now() + 3600_000).toISOString();
     await schedulePost({ content: "hi", integrationIds: ["fb"], scheduleAt: future });
-    expect(JSON.parse(mockFetch.mock.calls[0][1].body).type).toBe("schedule");
+    expect(lastPostBody().type).toBe("schedule");
 
+    mockScheduleFetch();
     const past = new Date(Date.now() - 3600_000).toISOString();
     await schedulePost({ content: "hi", integrationIds: ["fb"], scheduleAt: past });
-    expect(JSON.parse(mockFetch.mock.calls[1][1].body).type).toBe("now");
+    expect(lastPostBody().type).toBe("now");
   });
 
   it("uses type=draft when asDraft is set", async () => {
-    mockFetch.mockImplementation(() => Promise.resolve(jsonResponse([{ id: "p1" }])));
+    mockScheduleFetch();
     await schedulePost({ content: "hi", integrationIds: ["fb"], asDraft: true });
-    expect(JSON.parse(mockFetch.mock.calls[0][1].body).type).toBe("draft");
+    expect(lastPostBody().type).toBe("draft");
   });
 
-  it("builds one post entry per integration", async () => {
-    mockFetch.mockResolvedValue(jsonResponse([{ id: "a" }, { id: "b" }]));
+  it("builds one post entry per integration with settings", async () => {
+    mockScheduleFetch([{ id: "a" }, { id: "b" }]);
     const result = await schedulePost({ content: "hi", integrationIds: ["fb", "ig"] });
-    const body = JSON.parse(mockFetch.mock.calls[0][1].body);
+    const body = lastPostBody() as {
+      posts: Array<{ integration: { id: string }; value: Array<{ content: string }>; settings: { __type: string } }>;
+    };
     expect(body.posts).toHaveLength(2);
     expect(body.posts[0].integration.id).toBe("fb");
     expect(body.posts[0].value[0].content).toBe("hi");
+    expect(body.posts[0].settings.__type).toBe("facebook");
     expect(result).toEqual({ ok: true, postIds: ["a", "b"] });
   });
 
   it("returns ok=false with the status on API rejection", async () => {
-    mockFetch.mockResolvedValue(new Response("boom", { status: 422 }));
+    mockScheduleFetch("boom", 422);
     const result = await schedulePost({ content: "hi", integrationIds: ["fb"] });
     expect(result.ok).toBe(false);
     expect(result.error).toContain("422");

--- a/__tests__/postiz.test.ts
+++ b/__tests__/postiz.test.ts
@@ -11,6 +11,7 @@ vi.stubGlobal("fetch", mockFetch);
 import {
   changePostStatus,
   createPost,
+  createPostsBulk,
   deleteIntegration,
   deletePost,
   deletePostsByGroup,
@@ -247,6 +248,41 @@ describe("createPost (throwing)", () => {
     expect(result).toEqual(upstream);
     const [, init] = mockFetch.mock.calls[0];
     expect(init.method).toBe("POST");
+  });
+});
+
+describe("createPostsBulk", () => {
+  const sampleBody = {
+    type: "schedule" as const,
+    date: "2026-08-16T10:00:00.000Z",
+    shortLink: false,
+    tags: [] as Array<{ value: string; label: string }>,
+    posts: [
+      {
+        integration: { id: "fb" },
+        value: [{ content: "hi", image: [] }],
+        settings: { __type: "facebook" },
+      },
+    ],
+  };
+
+  it("returns per-item ok/fail without aborting the batch", async () => {
+    mockFetch
+      .mockResolvedValueOnce(jsonResponse([{ postId: "p1", integration: "fb" }]))
+      .mockResolvedValueOnce(jsonResponse({ error: "nope" }, 400))
+      .mockResolvedValueOnce(jsonResponse([{ postId: "p3", integration: "fb" }]));
+
+    const results = await createPostsBulk([
+      { ...sampleBody, date: "2026-08-16T10:00:00.000Z" },
+      { ...sampleBody, date: "2026-08-17T10:00:00.000Z" },
+      { ...sampleBody, date: "2026-08-18T10:00:00.000Z" },
+    ]);
+
+    expect(results).toHaveLength(3);
+    expect(results[0]).toMatchObject({ index: 0, ok: true });
+    expect(results[1]).toMatchObject({ index: 1, ok: false, status: 400 });
+    expect(results[2]).toMatchObject({ index: 2, ok: true });
+    expect(mockFetch).toHaveBeenCalledTimes(3);
   });
 });
 

--- a/docs/integrations/POSTIZ-CONNECT.md
+++ b/docs/integrations/POSTIZ-CONNECT.md
@@ -1,0 +1,61 @@
+# Connect P0 channels (operator checklist)
+
+OAuth app credentials are restored on the Postiz pod for **LinkedIn, X, TikTok**
+(+ `POSTIZ_API_KEY`). **Facebook/Instagram** are still missing from SSM —
+add `FACEBOOK_APP_ID` + `FACEBOOK_APP_SECRET` then re-run
+`bash scripts/postiz-restore-providers.sh`.
+
+## Verify pod is ready
+
+```bash
+kubectl -n postiz exec deploy/postiz -- sh -c \
+  'for k in LINKEDIN_CLIENT_ID X_API_KEY TIKTOK_CLIENT_ID FACEBOOK_APP_ID; do
+     [ -n "$(printenv $k)" ] && echo OK $k || echo MISSING $k
+   done'
+```
+
+## Redirect URIs (developer consoles)
+
+For each OAuth app, whitelist:
+
+`https://postiz.cloudless.gr/integrations/social/<provider>`
+
+| Channel | provider path | Needs env |
+| --- | --- | --- |
+| LinkedIn / LinkedIn Page | `linkedin` | LINKEDIN_* ✅ |
+| X | `x` | X_API_* ✅ |
+| TikTok | `tiktok` | TIKTOK_CLIENT_* ✅ |
+| Facebook Page | `facebook` | FACEBOOK_* ❌ until SSM |
+| Instagram (FB) | `instagram` | same FACEBOOK_* ❌ |
+| Bluesky | (dialog) | none — app password in UI |
+
+## Connect steps
+
+1. Open https://postiz.cloudless.gr (CF Access) → log in as admin.
+2. Channels / Launches → connect **LinkedIn Page**, **X**, **TikTok**, **Bluesky**.
+3. Skip Facebook/IG until FACEBOOK_* is in SSM.
+4. Confirm:
+
+```bash
+# Tailscale NodePort
+curl -sS -H "Authorization: $POSTIZ_API_KEY" \
+  http://100.74.191.58:30500/api/public/v1/integrations | jq 'length'
+kubectl -n postiz exec deploy/postiz-postgres -- \
+  psql -U postiz -d postiz -tAc 'SELECT count(*) FROM "Integration";'
+```
+
+5. Cursor MCP → refresh Postiz → “List my Postiz integrations”.
+
+## LinkedIn `inBetweenSteps` stuck (v2.11.2)
+
+If page selection fails with a red `!`, see the avatar CDN hot-fix in
+`skills/postiz/SKILL.md` (known LinkedIn avatar 403 abort).
+
+## Postiz → cloudless webhook
+
+In Postiz → Settings → Webhooks / Integrations → add:
+
+`https://cloudless.gr/api/webhooks/postiz?secret=<POSTIZ_WEBHOOK_SECRET>`
+
+Events: post published + post errored. Secret lives in SSM
+`/cloudless/production/POSTIZ_WEBHOOK_SECRET`.

--- a/infrastructure/n8n/k8s.yaml
+++ b/infrastructure/n8n/k8s.yaml
@@ -78,6 +78,16 @@ spec:
           value: Europe/Athens
         - name: TZ
           value: Europe/Athens
+        # Allow Settings → Community Nodes (e.g. n8n-nodes-postiz).
+        - name: N8N_COMMUNITY_PACKAGES_ENABLED
+          value: 'true'
+        # In-cluster Postiz Public API (RSS / cron workflows). Override in UI Variables if needed.
+        - name: POSTIZ_API_BASE
+          value: http://postiz.postiz.svc.cluster.local:5000
+        - name: POSTIZ_RSS_FEED_URL
+          value: https://cloudless.gr/en/blog/rss.xml
+        - name: POSTIZ_CHANNEL_IDENTIFIERS
+          value: linkedin,linkedin-page,x,bluesky
         volumeMounts:
         - name: data
           mountPath: /home/node/.n8n

--- a/infrastructure/n8n/workflows/README.md
+++ b/infrastructure/n8n/workflows/README.md
@@ -9,6 +9,7 @@ two app-side automations wired in PR R2:
 | ---- | ------------ | ---- |
 | `lead-enrich.json` | EspoCRM `Lead.create` → `POST /api/webhooks/n8n/trigger` (name=`lead-enrich`) | Assigns owner via round-robin from a hardcoded list, PUTs the assignment back to EspoCRM, and Slack-DMs the assignee. (Apollo enrich was dropped 2026-06-21 — see the note below if you want it back.) |
 | `newsletter-nurture.json` | `/api/subscribe` → `POST /api/webhooks/n8n/trigger` (name=`newsletter-nurture`) | Tags the new EspoCRM contact with `newsletter_signup_<source>`, adds them to the `Newsletter Nurture` sequence in EspoCRM. |
+| `postiz-rss-multichannel.json` | Schedule (every 6h) | Reads RSS → builds a caption → lists Postiz channels in-cluster → `POST /api/public/v1/posts` to matching platforms. No Next.js involvement. |
 
 ## Operator bootstrap (one-time per workflow)
 
@@ -40,6 +41,23 @@ coverage is thin for Greek SMBs + lead volume is too low to justify the cost.
 The `lead-enrich` workflow now goes Webhook → Extract → Round-robin → EspoCRM
 PUT → Slack DM. Re-add an HTTP-Request node before "Round-robin" if/when you
 want enrichment back.)_
+
+## Postiz RSS → multi-channel (operator setup)
+
+1. Import `postiz-rss-multichannel.json` into https://n8n.cloudless.gr.
+2. Create credential **Header Auth**:
+   - Name: `Authorization`
+   - Value: your Postiz Public API key (Settings → Developers → Public API).
+3. Point both HTTP Request nodes at that credential (replace the placeholder credential id).
+4. Optional env vars on the n8n Deployment (or workflow Variables):
+   - `POSTIZ_API_BASE` — default `http://postiz.postiz.svc.cluster.local:5000` (in-cluster, no Cloudflare Access).
+   - `POSTIZ_RSS_FEED_URL` — default `https://cloudless.gr/en/blog/rss.xml`.
+   - `POSTIZ_CHANNEL_IDENTIFIERS` — comma list, default `linkedin,linkedin-page,x,bluesky`.
+5. Connect at least one matching channel in the Postiz UI, then Activate the workflow.
+
+Optional: install the community node `n8n-nodes-postiz` (Settings → Community Nodes) and
+swap the HTTP Request nodes for the dedicated Postiz node. Host must end with `/api`
+(e.g. `http://postiz.postiz.svc.cluster.local:5000/api`).
 
 ## Verify
 

--- a/infrastructure/n8n/workflows/README.md
+++ b/infrastructure/n8n/workflows/README.md
@@ -10,6 +10,7 @@ two app-side automations wired in PR R2:
 | `lead-enrich.json` | EspoCRM `Lead.create` → `POST /api/webhooks/n8n/trigger` (name=`lead-enrich`) | Assigns owner via round-robin from a hardcoded list, PUTs the assignment back to EspoCRM, and Slack-DMs the assignee. (Apollo enrich was dropped 2026-06-21 — see the note below if you want it back.) |
 | `newsletter-nurture.json` | `/api/subscribe` → `POST /api/webhooks/n8n/trigger` (name=`newsletter-nurture`) | Tags the new EspoCRM contact with `newsletter_signup_<source>`, adds them to the `Newsletter Nurture` sequence in EspoCRM. |
 | `postiz-rss-multichannel.json` | Schedule (every 6h) | Reads RSS → builds a caption → lists Postiz channels in-cluster → `POST /api/public/v1/posts` to matching platforms. No Next.js involvement. |
+| `postiz-utm-guard.json` | Postiz webhook (or manual) | Ensures outbound social URLs carry UTM params before / alongside Postiz publish. Pair with app webhook `https://cloudless.gr/api/webhooks/postiz?secret=…`. |
 
 ## Operator bootstrap (one-time per workflow)
 
@@ -54,6 +55,14 @@ want enrichment back.)_
    - `POSTIZ_RSS_FEED_URL` — default `https://cloudless.gr/en/blog/rss.xml`.
    - `POSTIZ_CHANNEL_IDENTIFIERS` — comma list, default `linkedin,linkedin-page,x,bluesky`.
 5. Connect at least one matching channel in the Postiz UI, then Activate the workflow.
+
+### Postiz UTM guard
+
+1. Import `postiz-utm-guard.json` the same way.
+2. Wire its webhook URL into Postiz Settings → Webhooks **or** use the app
+   receiver (`scripts/postiz-register-webhook.sh` →
+   `https://cloudless.gr/api/webhooks/postiz?secret=<POSTIZ_WEBHOOK_SECRET>`).
+3. Activate once channels exist.
 
 Optional: install the community node `n8n-nodes-postiz` (Settings → Community Nodes) and
 swap the HTTP Request nodes for the dedicated Postiz node. Host must end with `/api`

--- a/infrastructure/n8n/workflows/postiz-rss-multichannel.json
+++ b/infrastructure/n8n/workflows/postiz-rss-multichannel.json
@@ -1,0 +1,179 @@
+{
+  "name": "Postiz — RSS → multi-channel schedule",
+  "nodes": [
+    {
+      "parameters": {
+        "rule": {
+          "interval": [{ "field": "hours", "hoursInterval": 6 }]
+        }
+      },
+      "name": "Every 6 hours",
+      "type": "n8n-nodes-base.scheduleTrigger",
+      "typeVersion": 1.2,
+      "position": [220, 300]
+    },
+    {
+      "parameters": {
+        "url": "={{ $env.POSTIZ_RSS_FEED_URL || 'https://cloudless.gr/en/blog/rss.xml' }}",
+        "options": {}
+      },
+      "name": "Read RSS",
+      "type": "n8n-nodes-base.rssFeedRead",
+      "typeVersion": 1.1,
+      "position": [440, 300]
+    },
+    {
+      "parameters": {
+        "amount": 1
+      },
+      "name": "Newest item only",
+      "type": "n8n-nodes-base.limit",
+      "typeVersion": 1,
+      "position": [660, 300]
+    },
+    {
+      "parameters": {
+        "values": {
+          "string": [
+            {
+              "name": "title",
+              "value": "={{ $json.title }}"
+            },
+            {
+              "name": "link",
+              "value": "={{ $json.link }}"
+            },
+            {
+              "name": "content",
+              "value": "={{ ($json.title || '').trim() + '\\n\\n' + ($json.link || '') + '\\n\\nutm_source=postiz&utm_medium=social&utm_campaign=rss' }}"
+            },
+            {
+              "name": "scheduleAt",
+              "value": "={{ $now.plus(1, 'hour').toUTC().toISO() }}"
+            }
+          ]
+        },
+        "options": {}
+      },
+      "name": "Build caption",
+      "type": "n8n-nodes-base.set",
+      "typeVersion": 3.4,
+      "position": [880, 300]
+    },
+    {
+      "parameters": {
+        "method": "GET",
+        "url": "={{ ($env.POSTIZ_API_BASE || 'http://postiz.postiz.svc.cluster.local:5000') + '/api/public/v1/integrations' }}",
+        "authentication": "genericCredentialType",
+        "genericAuthType": "httpHeaderAuth",
+        "options": {}
+      },
+      "name": "List Postiz channels",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [1100, 300],
+      "credentials": {
+        "httpHeaderAuth": {
+          "id": "REPLACE_WITH_POSTIZ_HEADER_AUTH_CREDENTIAL_ID",
+          "name": "Postiz API Key"
+        }
+      }
+    },
+    {
+      "parameters": {
+        "jsCode": "const caption = $('Build caption').first().json;\nconst raw = $input.first().json;\nconst list = Array.isArray(raw) ? raw : (raw.integrations || []);\nconst allow = String($env.POSTIZ_CHANNEL_IDENTIFIERS || 'linkedin,linkedin-page,x,bluesky')\n  .split(',')\n  .map((s) => s.trim())\n  .filter(Boolean);\nconst channels = list.filter((i) => allow.includes(i.identifier) && !i.disabled);\nif (!channels.length) {\n  return [{ json: { skipped: true, reason: 'no_matching_channels', allow } }];\n}\nconst settingsFor = (identifier) => {\n  if (identifier === 'x') return { __type: 'x', who_can_reply_post: 'everyone' };\n  if (identifier === 'linkedin' || identifier === 'linkedin-page') {\n    return { __type: identifier, post_as_images_carousel: false };\n  }\n  return { __type: identifier };\n};\nconst body = {\n  type: 'schedule',\n  date: caption.scheduleAt,\n  shortLink: false,\n  tags: [],\n  posts: channels.map((c) => ({\n    integration: { id: c.id },\n    value: [{ content: caption.content, image: [] }],\n    settings: settingsFor(c.identifier),\n  })),\n};\nreturn [{ json: { body, channelCount: channels.length, title: caption.title } }];"
+      },
+      "name": "Assemble Postiz payload",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [1320, 300]
+    },
+    {
+      "parameters": {
+        "conditions": {
+          "boolean": [
+            {
+              "value1": "={{ !$json.skipped }}",
+              "value2": true
+            }
+          ]
+        }
+      },
+      "name": "Has channels?",
+      "type": "n8n-nodes-base.if",
+      "typeVersion": 1,
+      "position": [1540, 300]
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "={{ ($env.POSTIZ_API_BASE || 'http://postiz.postiz.svc.cluster.local:5000') + '/api/public/v1/posts' }}",
+        "authentication": "genericCredentialType",
+        "genericAuthType": "httpHeaderAuth",
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "={{ $json.body }}",
+        "options": {}
+      },
+      "name": "Create Postiz posts",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [1760, 220],
+      "credentials": {
+        "httpHeaderAuth": {
+          "id": "REPLACE_WITH_POSTIZ_HEADER_AUTH_CREDENTIAL_ID",
+          "name": "Postiz API Key"
+        }
+      }
+    },
+    {
+      "parameters": {
+        "values": {
+          "string": [
+            {
+              "name": "note",
+              "value": "={{ $json.reason || 'skipped' }}"
+            }
+          ]
+        },
+        "options": {}
+      },
+      "name": "Skipped",
+      "type": "n8n-nodes-base.set",
+      "typeVersion": 3.4,
+      "position": [1760, 400]
+    }
+  ],
+  "connections": {
+    "Every 6 hours": {
+      "main": [[{ "node": "Read RSS", "type": "main", "index": 0 }]]
+    },
+    "Read RSS": {
+      "main": [[{ "node": "Newest item only", "type": "main", "index": 0 }]]
+    },
+    "Newest item only": {
+      "main": [[{ "node": "Build caption", "type": "main", "index": 0 }]]
+    },
+    "Build caption": {
+      "main": [[{ "node": "List Postiz channels", "type": "main", "index": 0 }]]
+    },
+    "List Postiz channels": {
+      "main": [[{ "node": "Assemble Postiz payload", "type": "main", "index": 0 }]]
+    },
+    "Assemble Postiz payload": {
+      "main": [[{ "node": "Has channels?", "type": "main", "index": 0 }]]
+    },
+    "Has channels?": {
+      "main": [
+        [{ "node": "Create Postiz posts", "type": "main", "index": 0 }],
+        [{ "node": "Skipped", "type": "main", "index": 0 }]
+      ]
+    }
+  },
+  "settings": {
+    "executionOrder": "v1"
+  },
+  "meta": {
+    "templateCredsSetupCompleted": false
+  }
+}

--- a/infrastructure/postiz/helm/postiz/install.sh
+++ b/infrastructure/postiz/helm/postiz/install.sh
@@ -62,15 +62,34 @@ if command -v aws >/dev/null && aws sts get-caller-identity >/dev/null 2>&1; the
       || true
   }
   args=()
-  for k in FACEBOOK_APP_ID FACEBOOK_APP_SECRET \
-           LINKEDIN_CLIENT_ID LINKEDIN_CLIENT_SECRET \
-           X_API_KEY X_API_SECRET \
-           TIKTOK_CLIENT_ID TIKTOK_CLIENT_SECRET; do
-    v="$(read_ssm "$k")"
-    if [ -n "$v" ] && [ "$v" != "None" ]; then
+  # Map SSM aliases → Postiz env names (TikTok historically stored as APP_* / tiktok-client-*).
+  resolve_ssm() {
+    local dest_name="$1"; shift
+    local candidate v=""
+    for candidate in "$@"; do
+      v="$(read_ssm "${candidate}")"
+      if [ -n "${v}" ] && [ "${v}" != "None" ]; then
+        printf '%s' "${v}"
+        return
+      fi
+    done
+    printf ''
+  }
+  set_if() {
+    local k="$1" v="$2"
+    if [ -n "${v}" ]; then
       args+=("--from-literal=${k}=${v}")
     fi
-  done
+  }
+  set_if FACEBOOK_APP_ID "$(resolve_ssm FACEBOOK_APP_ID FACEBOOK_APP_ID)"
+  set_if FACEBOOK_APP_SECRET "$(resolve_ssm FACEBOOK_APP_SECRET FACEBOOK_APP_SECRET)"
+  set_if LINKEDIN_CLIENT_ID "$(resolve_ssm LINKEDIN_CLIENT_ID LINKEDIN_CLIENT_ID)"
+  set_if LINKEDIN_CLIENT_SECRET "$(resolve_ssm LINKEDIN_CLIENT_SECRET LINKEDIN_CLIENT_SECRET)"
+  set_if X_API_KEY "$(resolve_ssm X_API_KEY X_API_KEY)"
+  set_if X_API_SECRET "$(resolve_ssm X_API_SECRET X_API_SECRET)"
+  set_if TIKTOK_CLIENT_ID "$(resolve_ssm TIKTOK_CLIENT_ID TIKTOK_CLIENT_ID TIKTOK_APP_ID tiktok-client-key)"
+  set_if TIKTOK_CLIENT_SECRET "$(resolve_ssm TIKTOK_CLIENT_SECRET TIKTOK_CLIENT_SECRET TIKTOK_APP_SECRET tiktok-client-secret)"
+  set_if POSTIZ_API_KEY "$(resolve_ssm POSTIZ_API_KEY POSTIZ_API_KEY)"
   if [ "${#args[@]}" -gt 0 ]; then
     if kubectl -n "${NAMESPACE}" get secret postiz-providers >/dev/null 2>&1; then
       kubectl -n "${NAMESPACE}" delete secret postiz-providers

--- a/infrastructure/postiz/helm/postiz/templates/postiz.yaml
+++ b/infrastructure/postiz/helm/postiz/templates/postiz.yaml
@@ -65,6 +65,8 @@ spec:
               value: {{ .Values.postiz.isGeneral | quote }}
             - name: DISABLE_REGISTRATION
               value: {{ .Values.postiz.disableRegistration | quote }}
+            - name: API_LIMIT
+              value: {{ .Values.postiz.apiLimit | default "100" | quote }}
             - name: STORAGE_PROVIDER
               value: {{ .Values.postiz.storageProvider | quote }}
             - name: UPLOAD_DIRECTORY

--- a/infrastructure/postiz/helm/postiz/values.yaml
+++ b/infrastructure/postiz/helm/postiz/values.yaml
@@ -61,6 +61,9 @@ postiz:
   # TIKTOK_CLIENT_ID/SECRET). Marked optional in the Deployment so a fresh
   # cluster boots before this exists.
   providersSecretName: postiz-providers
+  # Public API rate limit (requests per hour per key). Postiz default is
+  # low; raise so admin/MCP/n8n bursts don't 429 during hub automation.
+  apiLimit: '100'
 
 postgres:
   user: postiz

--- a/infrastructure/postiz/k8s/postiz.yaml
+++ b/infrastructure/postiz/k8s/postiz.yaml
@@ -230,6 +230,10 @@ spec:
               # Admin account exists (creds in SSM POSTIZ_ADMIN_EMAIL/PASSWORD,
               # created 2026-06-12) — registration stays locked.
           value: 'true'
+        # Public API rate limit (req/hour). Default Postiz value is too low
+        # for admin console + MCP + n8n bursts during social-hub automation.
+        - name: API_LIMIT
+          value: '100'
         - name: STORAGE_PROVIDER
           value: local
         - name: UPLOAD_DIRECTORY

--- a/scripts/cursor-mcp/README-postiz.md
+++ b/scripts/cursor-mcp/README-postiz.md
@@ -1,0 +1,38 @@
+# Postiz MCP (Cursor)
+
+Live config lives in `~/.cursor/mcp.json` (server name: `postiz`).
+
+## Why Tailscale NodePort?
+
+`https://postiz.cloudless.gr` is behind Cloudflare Access. From WSL on the
+tailnet, use:
+
+```text
+http://100.74.191.58:30500/api/mcp/<POSTIZ_API_KEY>
+```
+
+Verified 2026-08-15: MCP initialize + `integrationList` works on that URL
+(9 tools). Public hostname returns Access login 302 without a service token.
+
+## Public hostname (optional)
+
+```json
+"postiz-public": {
+  "url": "https://postiz.cloudless.gr/api/mcp/${env:POSTIZ_API_KEY}",
+  "headers": {
+    "CF-Access-Client-Id": "${env:POSTIZ_CF_ACCESS_CLIENT_ID}",
+    "CF-Access-Client-Secret": "${env:POSTIZ_SERVICE_TOKEN}"
+  }
+}
+```
+
+Or add a Cloudflare Access bypass for `/api/mcp*` and `/api/public/v1/*`
+(Postiz still requires the API key).
+
+## Smoke test
+
+After Cursor Settings → MCP → refresh Postiz:
+
+> List my Postiz connected social accounts
+
+If the Integration table is empty in Postgres, connect channels in the Postiz UI first.

--- a/scripts/postiz-cli-env.sh
+++ b/scripts/postiz-cli-env.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# Source this file before using the Postiz Agents CLI against our self-host.
+#   source scripts/postiz-cli-env.sh
+#
+# Does NOT print or commit secrets. Prefers an already-exported POSTIZ_API_KEY;
+# otherwise reads from the environment only (never from .env.local).
+
+set -euo pipefail
+
+# Tailscale NodePort → postiz Service (bypasses Cloudflare Access).
+# Override with POSTIZ_API_URL if you use a CF Access service token against
+# https://postiz.cloudless.gr instead.
+export POSTIZ_API_URL="${POSTIZ_API_URL:-http://100.74.191.58:30500}"
+
+if [[ -z "${POSTIZ_API_KEY:-}" ]]; then
+  echo "POSTIZ_API_KEY is unset. Export it (Postiz → Settings → Developers → Public API), then re-source." >&2
+  return 1 2>/dev/null || exit 1
+fi
+
+if ! command -v postiz >/dev/null 2>&1; then
+  echo "postiz CLI not found. Install: pnpm add -g postiz" >&2
+fi
+
+echo "POSTIZ_API_URL=$POSTIZ_API_URL"
+command -v postiz >/dev/null 2>&1 && postiz auth:status || true

--- a/scripts/postiz-connect-ready.sh
+++ b/scripts/postiz-connect-ready.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+# postiz-connect-ready.sh — verify OAuth env + Integration row count.
+# Does not print secret values. Exit 0 when at least one channel is connected
+# OR when --env-only (providers present enough to start UI OAuth).
+set -euo pipefail
+
+NS="${POSTIZ_NAMESPACE:-postiz}"
+ENV_ONLY=0
+for arg in "$@"; do
+  case "$arg" in
+    --env-only) ENV_ONLY=1 ;;
+  esac
+done
+
+bold() { printf '\033[1m%s\033[0m\n' "$*"; }
+ok() { printf '  OK  %s\n' "$*"; }
+miss() { printf '  MISSING %s\n' "$*"; }
+
+bold "==> Postiz OAuth env (pod)"
+kubectl -n "$NS" exec deploy/postiz -- sh -c '
+  for k in LINKEDIN_CLIENT_ID LINKEDIN_CLIENT_SECRET X_API_KEY X_API_SECRET \
+           TIKTOK_CLIENT_ID TIKTOK_CLIENT_SECRET FACEBOOK_APP_ID FACEBOOK_APP_SECRET \
+           POSTIZ_API_KEY API_LIMIT; do
+    v=$(printenv "$k" 2>/dev/null || true)
+    if [ -n "$v" ]; then echo "OK $k"; else echo "MISSING $k"; fi
+  done
+'
+
+bold "==> Integration count (Postgres)"
+COUNT=$(kubectl -n "$NS" exec deploy/postiz-postgres -- \
+  psql -U postiz -d postiz -tAc 'SELECT count(*) FROM "Integration";' | tr -d '[:space:]')
+echo "  Integration rows: ${COUNT:-?}"
+
+if [[ "$ENV_ONLY" -eq 1 ]]; then
+  bold "Env-only check done (channels still require UI OAuth)."
+  exit 0
+fi
+
+if [[ "${COUNT:-0}" -gt 0 ]]; then
+  ok "channels connected ($COUNT)"
+  exit 0
+fi
+
+miss "no integrations — connect in https://postiz.cloudless.gr (see docs/integrations/POSTIZ-CONNECT.md)"
+exit 1

--- a/scripts/postiz-register-webhook.sh
+++ b/scripts/postiz-register-webhook.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+# postiz-register-webhook.sh — print the exact Postiz UI webhook URL and
+# optionally patch API_LIMIT on the live Deployment.
+#
+# Secrets are never printed. Fetch POSTIZ_WEBHOOK_SECRET yourself from SSM
+# (or paste into the UI) — this script only reminds the URL shape.
+set -euo pipefail
+
+NS="${POSTIZ_NAMESPACE:-postiz}"
+APPLY_LIMIT=0
+for arg in "$@"; do
+  case "$arg" in
+    --apply-api-limit) APPLY_LIMIT=1 ;;
+  esac
+done
+
+cat <<'EOF'
+==> Register Postiz → cloudless webhook (UI)
+
+1. Open https://postiz.cloudless.gr → Settings → Webhooks (or Integrations).
+2. Create webhook:
+   Name:  cloudless-app
+   URL:   https://cloudless.gr/api/webhooks/postiz?secret=<POSTIZ_WEBHOOK_SECRET>
+   Events: post published + post errored (select all connected channels).
+3. Secret source (do not commit):
+     aws ssm get-parameter --name /cloudless/production/POSTIZ_WEBHOOK_SECRET \
+       --with-decryption --query Parameter.Value --output text
+4. Smoke: publish a Bluesky/LinkedIn draft → expect Slack/calendar path via
+   POST /api/webhooks/postiz (see src/app/api/webhooks/postiz/route.ts).
+
+==> n8n import (operator UI)
+
+1. Open in-cluster n8n (see infrastructure/n8n/README.md).
+2. Import:
+     infrastructure/n8n/workflows/postiz-rss-multichannel.json
+     infrastructure/n8n/workflows/postiz-utm-guard.json
+3. Credential / header auth for Postiz Public API:
+     Base URL: http://postiz.postiz.svc.cluster.local:5000/api
+     Header:   Authorization = <POSTIZ_API_KEY>
+4. Activate both workflows. Keep AUTO_POST_BLOG_TO_SOCIAL unset on
+   cloudless-app unless you want AppFlowy Published → social fan-out.
+
+EOF
+
+if [[ "$APPLY_LIMIT" -eq 1 ]]; then
+  echo "==> Patching API_LIMIT=100 on deploy/postiz"
+  kubectl -n "$NS" set env deployment/postiz API_LIMIT=100
+  kubectl -n "$NS" rollout status deployment/postiz --timeout=300s
+  echo "Done."
+fi

--- a/scripts/postiz-restore-providers.sh
+++ b/scripts/postiz-restore-providers.sh
@@ -1,0 +1,119 @@
+#!/usr/bin/env bash
+# Recreate k8s secret postiz-providers from AWS SSM (or already-exported env).
+# Never prints secret values. Does not read .env.local.
+#
+# Usage:
+#   bash scripts/postiz-restore-providers.sh
+#   # or with overrides already exported:
+#   FACEBOOK_APP_ID=… bash scripts/postiz-restore-providers.sh
+#
+# Maps SSM aliases → Postiz env names:
+#   TIKTOK_APP_ID / tiktok-client-key     → TIKTOK_CLIENT_ID
+#   TIKTOK_APP_SECRET / tiktok-client-secret → TIKTOK_CLIENT_SECRET
+set -euo pipefail
+
+NAMESPACE="${NAMESPACE:-postiz}"
+SECRET_NAME="${SECRET_NAME:-postiz-providers}"
+SSM_PREFIX="${SSM_PREFIX:-/cloudless/production}"
+
+read_ssm() {
+  local name="$1"
+  aws ssm get-parameter --name "${SSM_PREFIX}/${name}" \
+    --with-decryption --query 'Parameter.Value' --output text 2>/dev/null \
+    || true
+}
+
+# Resolve: prefer already-exported env, then primary SSM name, then aliases.
+resolve() {
+  local dest="$1"
+  shift
+  local cur="${!dest:-}"
+  if [[ -n "${cur}" && "${cur}" != "None" ]]; then
+    printf '%s' "${cur}"
+    return
+  fi
+  local candidate
+  for candidate in "$@"; do
+    local v
+    v="$(read_ssm "${candidate}")"
+    if [[ -n "${v}" && "${v}" != "None" ]]; then
+      printf '%s' "${v}"
+      return
+    fi
+  done
+  printf ''
+}
+
+if ! command -v aws >/dev/null || ! aws sts get-caller-identity >/dev/null 2>&1; then
+  echo "ERROR: AWS CLI not authenticated — export keys manually or fix AWS creds." >&2
+  exit 1
+fi
+if ! command -v kubectl >/dev/null; then
+  echo "ERROR: kubectl not found." >&2
+  exit 1
+fi
+
+FACEBOOK_APP_ID="$(resolve FACEBOOK_APP_ID FACEBOOK_APP_ID)"
+FACEBOOK_APP_SECRET="$(resolve FACEBOOK_APP_SECRET FACEBOOK_APP_SECRET)"
+LINKEDIN_CLIENT_ID="$(resolve LINKEDIN_CLIENT_ID LINKEDIN_CLIENT_ID)"
+LINKEDIN_CLIENT_SECRET="$(resolve LINKEDIN_CLIENT_SECRET LINKEDIN_CLIENT_SECRET)"
+X_API_KEY="$(resolve X_API_KEY X_API_KEY)"
+X_API_SECRET="$(resolve X_API_SECRET X_API_SECRET)"
+TIKTOK_CLIENT_ID="$(resolve TIKTOK_CLIENT_ID TIKTOK_CLIENT_ID TIKTOK_APP_ID tiktok-client-key)"
+TIKTOK_CLIENT_SECRET="$(resolve TIKTOK_CLIENT_SECRET TIKTOK_CLIENT_SECRET TIKTOK_APP_SECRET tiktok-client-secret)"
+POSTIZ_API_KEY="$(resolve POSTIZ_API_KEY POSTIZ_API_KEY)"
+
+# Preserve existing POSTIZ_API_KEY from the live secret if SSM/env missing.
+if [[ -z "${POSTIZ_API_KEY}" ]]; then
+  POSTIZ_API_KEY="$(kubectl -n "${NAMESPACE}" get secret "${SECRET_NAME}" \
+    -o jsonpath='{.data.POSTIZ_API_KEY}' 2>/dev/null | base64 -d 2>/dev/null || true)"
+fi
+
+args=()
+found=()
+missing=()
+add() {
+  local k="$1" v="$2"
+  if [[ -n "${v}" ]]; then
+    args+=("--from-literal=${k}=${v}")
+    found+=("${k}")
+  else
+    missing+=("${k}")
+  fi
+}
+
+add FACEBOOK_APP_ID "${FACEBOOK_APP_ID}"
+add FACEBOOK_APP_SECRET "${FACEBOOK_APP_SECRET}"
+add LINKEDIN_CLIENT_ID "${LINKEDIN_CLIENT_ID}"
+add LINKEDIN_CLIENT_SECRET "${LINKEDIN_CLIENT_SECRET}"
+add X_API_KEY "${X_API_KEY}"
+add X_API_SECRET "${X_API_SECRET}"
+add TIKTOK_CLIENT_ID "${TIKTOK_CLIENT_ID}"
+add TIKTOK_CLIENT_SECRET "${TIKTOK_CLIENT_SECRET}"
+add POSTIZ_API_KEY "${POSTIZ_API_KEY}"
+
+if [[ ${#found[@]} -eq 0 ]]; then
+  echo "ERROR: no provider keys resolved." >&2
+  exit 1
+fi
+
+echo "Will upsert secret/${SECRET_NAME} in ns/${NAMESPACE} with: ${found[*]}"
+if [[ ${#missing[@]} -gt 0 ]]; then
+  echo "Missing (channel connect for these will fail until set): ${missing[*]}"
+fi
+
+kubectl -n "${NAMESPACE}" delete secret "${SECRET_NAME}" --ignore-not-found
+kubectl -n "${NAMESPACE}" create secret generic "${SECRET_NAME}" "${args[@]}"
+kubectl -n "${NAMESPACE}" rollout restart "deploy/postiz"
+kubectl -n "${NAMESPACE}" rollout status "deploy/postiz" --timeout=180s
+
+echo "Verify env keys present in pod (names only):"
+kubectl -n "${NAMESPACE}" exec deploy/postiz -- sh -c \
+  'for k in FACEBOOK_APP_ID FACEBOOK_APP_SECRET LINKEDIN_CLIENT_ID LINKEDIN_CLIENT_SECRET X_API_KEY X_API_SECRET TIKTOK_CLIENT_ID TIKTOK_CLIENT_SECRET POSTIZ_API_KEY; do
+     if [ -n "$(printenv "$k")" ]; then echo "  OK $k"; else echo "  MISSING $k"; fi
+   done'
+
+echo
+echo "Next: connect channels in https://postiz.cloudless.gr"
+echo "  Redirect URI: https://postiz.cloudless.gr/integrations/social/<provider>"
+echo "  P0: linkedin (page), x, facebook+instagram, bluesky (no env)"

--- a/skills/postiz-agent-cli/SKILL.md
+++ b/skills/postiz-agent-cli/SKILL.md
@@ -1,0 +1,93 @@
+---
+name: postiz-agent-cli
+description: |
+  Run the official Postiz Agents CLI (`postiz` from gitroomhq/postiz-agent)
+  against self-hosted postiz.cloudless.gr for discover → upload → schedule →
+  analytics. Use when the user says "postiz CLI", "postiz-agent", "schedule
+  from terminal", "npx postiz", or wants agents to post without the Next app.
+  Pair with `postiz-hub` and `postiz`.
+---
+
+# Postiz Agent CLI (cloudless.gr)
+
+Upstream: https://github.com/gitroomhq/postiz-agent · npm: `postiz`
+
+## Install
+
+```bash
+pnpm add -g postiz
+# or: npm install -g postiz
+```
+
+Optional agent skill install (upstream packaging):
+
+```bash
+npx skills add gitroomhq/postiz-agent
+```
+
+## Auth against our self-host
+
+Prefer **API key** (Postiz UI → Settings → Developers → Public API). Do not
+commit the key.
+
+```bash
+# Source the helper (sets URL to Tailscale NodePort — bypasses CF Access)
+source scripts/postiz-cli-env.sh
+
+# Or manually:
+export POSTIZ_API_KEY='…'
+export POSTIZ_API_URL='http://100.74.191.58:30500'
+
+postiz auth:status
+postiz integrations:list
+```
+
+**Why Tailscale URL?** `https://postiz.cloudless.gr` is behind Cloudflare Access.
+Headless CLI/agents get a 302 login page unless you attach
+`CF-Access-Client-Id` / `CF-Access-Client-Secret`. NodePort on the tailnet
+reaches nginx → Postiz API directly.
+
+OAuth `postiz auth:login` targets Postiz Cloud's device-flow server by default —
+for self-host, stick to `POSTIZ_API_KEY` unless you self-host the CLI auth
+server (see upstream `server/SERVER.md`).
+
+## Hard rules (from upstream — keep)
+
+1. Authenticate before any command.
+2. Always `postiz upload <file>` before attaching media; never pass raw paths/URLs to create.
+3. TikTok: `content_posting_method` = `DIRECT_POST` unless the user wants inbox-only.
+4. Call `postiz integrations:settings <id>` before create and honor `rules`.
+
+## Core workflow
+
+```bash
+source scripts/postiz-cli-env.sh
+postiz integrations:list
+postiz integrations:settings <id>
+
+# media
+RESULT=$(postiz upload ./creative.mp4)
+URL=$(echo "$RESULT" | jq -r '.path')
+
+# schedule (see `postiz posts:create --help` for flags)
+postiz posts:create -c "Caption with https://cloudless.gr/en/?utm_source=linkedin&utm_medium=social&utm_campaign=hub" \
+  -i "<integration-id>" -m "$URL"
+
+postiz analytics:platform <id> -d 30
+```
+
+## When to use CLI vs Next admin vs MCP
+
+| Surface | Best for |
+| --- | --- |
+| `postiz` CLI | Scripts, CI, agent shells, one-off ops |
+| Cursor MCP `postiz` | Natural-language schedule in chat |
+| `/admin/postiz` | Humans / bulk UI / analytics tab |
+| n8n | RSS/cron without an interactive agent |
+
+## Troubleshooting
+
+- Empty `integrations:list` → no channels connected, or wrong API key org.
+- HTML / Access login in responses → wrong `POSTIZ_API_URL` (use Tailscale).
+- Upload/post 413 → pre-upload media; don't base64 into create body.
+- Rate limit on create → batch channels in one post; raise Postiz `API_LIMIT`.

--- a/skills/postiz-agent-media/SKILL.md
+++ b/skills/postiz-agent-media/SKILL.md
@@ -1,0 +1,74 @@
+---
+name: postiz-agent-media
+description: |
+  Generate short-form UGC / podcast video via gitroomhq agent-media (MCP or
+  CLI), then publish through self-hosted Postiz. Use when the user wants
+  "UGC video", "TikTok creative", "agent-media", "make_ugc", or video → social
+  for cloudless.gr. Pair with `postiz-hub`, `postiz-agent-cli`, `postiz`.
+---
+
+# agent-media → Postiz (cloudless.gr)
+
+Upstream:
+
+- https://github.com/gitroomhq/agent-media (skills mirror)
+- https://github.com/gitroomhq/agent-media-app (product / self-host)
+- Hosted MCP: `https://api.agent-media.ai/mcp` (OAuth) or API key `ma_…`
+
+This is **optional and credit-billed** (agent-media.ai). Prefer it when you need
+finished vertical video faster than Postiz's built-in generators. Stay on our
+Postiz v2.11.2 for publishing.
+
+## When to use vs Postiz built-in AI
+
+| Need | Use |
+| --- | --- |
+| Quick image / short AI clip inside Postiz | Postiz `OPENAI_API_KEY` / fal / in-app tools |
+| Lip-synced UGC / multi-take vertical | **agent-media** `make_ugc` |
+| Two-speaker podcast cut | agent-media `make_podcast` |
+| Schedule to LinkedIn/X/IG/TikTok | **Postiz** (CLI / MCP / admin / n8n) |
+
+## Cursor setup
+
+```jsonc
+// ~/.cursor/mcp.json
+"agent-media": { "url": "https://api.agent-media.ai/mcp" }
+```
+
+Or: `npx skills add gitroomhq/agent-media` / `gitroomhq/agent-media-app`.
+
+Complete browser OAuth when Cursor prompts. Do not commit `ma_` tokens.
+
+## Generation flow
+
+1. Ask the user if they want **captions** (opt-in; never force).
+2. Call `make_ugc` with full `script` + `person` / `image` / `character`.
+3. Poll until `succeeded`; take `final_output.video_url`.
+4. Download or pass URL into Postiz:
+
+```bash
+source scripts/postiz-cli-env.sh
+# Prefer download → postiz upload (providers want Postiz-hosted media)
+curl -L "$VIDEO_URL" -o /tmp/ugc.mp4
+PATH_JSON=$(postiz upload /tmp/ugc.mp4)
+MEDIA=$(echo "$PATH_JSON" | jq -r '.path')
+postiz integrations:list
+postiz posts:create -c "<caption + UTM link>" -i "<tiktok-or-ig-id>" -m "$MEDIA"
+```
+
+Always append cloudless UTMs per `postiz-automation`:
+
+```
+https://cloudless.gr/en/?utm_source=tiktok&utm_medium=social&utm_campaign=<slug>
+```
+
+## agent-media's own social_publish
+
+agent-media can also `social_publish` to channels it OAuth'd. For the **hub**,
+prefer **Postiz** as the single scheduler of record so calendar, plugs, webhooks,
+and `/admin/postiz` stay consistent. Use agent-media social only for experiments.
+
+## Self-hosting agent-media-app
+
+Possible (see their ARCHITECTURE / docker-compose) but **not** on the Pi5 with
+Postiz — GPU/credits stack. Use hosted agent-media.ai unless a separate box exists.

--- a/skills/postiz-hub/SKILL.md
+++ b/skills/postiz-hub/SKILL.md
@@ -72,25 +72,29 @@ Enable in the Postiz UI once channels exist:
 
 ## Hub implementation order (do in order)
 
-1. Restore `postiz-providers` OAuth keys; connect **P0**: LinkedIn Page, X, FB/IG, Bluesky.
-2. Confirm MCP `integrationList` and `/admin/postiz` Channels are non-empty.
+1. Restore `postiz-providers` OAuth keys (`scripts/postiz-restore-providers.sh`); connect **P0**: LinkedIn Page, X, FB/IG, Bluesky — see `docs/integrations/POSTIZ-CONNECT.md`.
+2. Confirm MCP `integrationList` and `/admin/postiz` Channels are non-empty (`scripts/postiz-connect-ready.sh`).
 3. Install `postiz` CLI with Tailscale `POSTIZ_API_URL` (`postiz-agent-cli`).
-4. Import + activate `postiz-rss-multichannel.json`; optionally install `n8n-nodes-postiz`.
-5. Turn on Plugs for X + LinkedIn Page; register Postiz webhook → n8n UTM guard.
-6. Optional: agent-media MCP for short-form video creatives, then publish via Postiz.
-7. Optional: `OPENAI_API_KEY` + R2 on the Postiz pod for in-app AI/media.
+4. Import + activate `postiz-rss-multichannel.json` + `postiz-utm-guard.json`; optionally install `n8n-nodes-postiz`. In-cluster API base: `http://postiz.postiz.svc.cluster.local:5000/api`.
+5. Register Postiz → app webhook (`scripts/postiz-register-webhook.sh`) and Plugs for X + LinkedIn Page.
+6. Keep `AUTO_POST_BLOG_TO_SOCIAL` **unset** on cloudless-app unless you want AppFlowy Published → social fan-out (default = vet-before-post).
+7. Optional: agent-media MCP for short-form video creatives, then publish via Postiz.
+8. Optional: `OPENAI_API_KEY` + R2 on the Postiz pod for in-app AI/media.
 
 ## cloudless.gr surfaces that already talk to Postiz
 
-- `src/lib/postiz.ts` — Public API client (incl. bulk + analytics)
+- `src/lib/postiz.ts` — Public API client (incl. bulk, analytics, `withSocialUtm`)
 - `src/app/[locale]/admin/postiz` — compose / bulk / analytics UI
-- `src/lib/postiz-blog.ts` — blog → social
+- `src/lib/postiz-blog.ts` — AppFlowy/CMS Published → social (opt-in flag)
 - `src/app/api/webhooks/postiz` — inbound webhooks
+- `src/app/api/webhooks/content` + `setEditorialStatus(Published)` — trigger share
 - `infrastructure/n8n/workflows/postiz-*.json` — automation starters
 - Cursor MCP server `postiz`
+- `docs/integrations/POSTIZ-CONNECT.md` — operator connect checklist
 
 ## Do not
 
 - Upgrade past v2.11.2 without a Temporal plan
 - Commit API keys or put them in repo `mcp.json`
 - Use public `https://postiz.cloudless.gr` from headless agents without CF Access service token — prefer Tailscale NodePort or Access headers
+- Enable `AUTO_POST_BLOG_TO_SOCIAL=1` without connected channels + vetted copy

--- a/skills/postiz-hub/SKILL.md
+++ b/skills/postiz-hub/SKILL.md
@@ -1,0 +1,96 @@
+---
+name: postiz-hub
+description: |
+  Umbrella skill for turning self-hosted Postiz (postiz.cloudless.gr, v2.11.2)
+  into the cloudless.gr social media hub. Catalogs every gitroomhq Postiz-related
+  GitHub repo, what to implement vs skip, and which sibling skills to open.
+  Use when the user says "Postiz hub", "Postiz plugins", "Postiz ecosystem",
+  "postiz-agent", "agent-media", "all Postiz repos", or "make Postiz our social
+  media hub". Pair with `postiz`, `postiz-doctor`, `postiz-automation`,
+  `postiz-agent-cli`, `postiz-agent-media`, `postiz-n8n-node`.
+---
+
+# Postiz hub — cloudless.gr ecosystem map
+
+Self-hosted Postiz is pinned at **v2.11.2** on omv k3s. Do **not** jump to
+v2.12+ without Temporal capacity. Hub value comes from **channels + automation
+plugins**, not from upgrading the app image.
+
+## Live constraints (check first)
+
+| Check | Expected |
+| --- | --- |
+| Image | `ghcr.io/gitroomhq/postiz-app:v2.11.2` |
+| Public URL | `https://postiz.cloudless.gr` (Cloudflare Access) |
+| Agent/CLI bypass | `http://100.74.191.58:30500` (Tailscale NodePort) |
+| MCP | Cursor `postiz` → Tailscale `/api/mcp/<key>` |
+| Channels | Must be >0 in Postiz UI / `integrationList` |
+| `postiz-providers` Secret | Must hold FACEBOOK_*, LINKEDIN_*, X_*, TIKTOK_* (not only API key) |
+
+If channels are empty or OAuth fails → `postiz-doctor`, then restore provider secrets.
+
+## gitroomhq repos — implement vs skip
+
+| Repo | Stars-ish role | cloudless.gr action |
+| --- | --- | --- |
+| [postiz-app](https://github.com/gitroomhq/postiz-app) | Core scheduler | **Operate** via `postiz` + Helm; stay on v2.11.2 |
+| [postiz-docs](https://github.com/gitroomhq/postiz-docs) | Official docs | **Reference** only |
+| [postiz-agent](https://github.com/gitroomhq/postiz-agent) | `postiz` CLI + agent skill | **Install + use** → `postiz-agent-cli` |
+| [postiz-n8n](https://github.com/gitroomhq/postiz-n8n) | `n8n-nodes-postiz` | **Install on n8n** → `postiz-n8n-node` |
+| [agent-media](https://github.com/gitroomhq/agent-media) / [agent-media-app](https://github.com/gitroomhq/agent-media-app) | UGC video MCP/CLI | **Optional paid** → `postiz-agent-media` |
+| [postiz-docker-compose](https://github.com/gitroomhq/postiz-docker-compose) | Upstream compose | **Skip** — we use k3s Helm |
+| [postiz-helmchart](https://github.com/gitroomhq/postiz-helmchart) | Upstream Helm | **Skip** — `infrastructure/postiz/helm/postiz/` is canonical |
+| [postiz-mobile](https://github.com/gitroomhq/postiz-mobile) | Expo mobile app | **Skip** for now (Pi/ops focus) |
+| [postiz-motion-graphics-skill](https://github.com/gitroomhq/postiz-motion-graphics-skill) | Demo MP4 catalog of Postiz UI | **Skip** — marketing Postiz itself, not cloudless content |
+| [postiz-new-support-bot](https://github.com/gitroomhq/postiz-new-support-bot) | Their support bot | **Skip** |
+| [loadplug](https://github.com/gitroomhq/loadplug) | Empty/stale | **Skip** |
+| [paperclip](https://github.com/gitroomhq/paperclip) | Multi-agent “company” orchestrator | **Defer** — interesting later, not required for social hub |
+| [crosspublic](https://github.com/gitroomhq/crosspublic) / [trending-list](https://github.com/gitroomhq/trending-list) | Unrelated products | **Skip** |
+| [wordpress-post-to-devto](https://github.com/gitroomhq/wordpress-post-to-devto) | WP→DEV.to | **Skip** unless WordPress becomes a CMS |
+
+## Built-in Postiz features (no extra repo)
+
+Enable in the Postiz UI once channels exist:
+
+1. **Plugs** — auto-repost / auto-comment (X, LinkedIn Page, Bluesky, Threads)
+2. **RSS auto-post** — or use our n8n RSS workflow
+3. **Webhooks** — already partially wired (`postiz-utm-guard`)
+4. **MCP** — Cursor already configured
+5. **Public API** — `src/lib/postiz.ts` + `/admin/postiz`
+6. **AI / R2 / Polotno / short-links** — env on the Postiz Deployment (see docs configuration reference)
+
+## Sibling skills (open the right one)
+
+| Need | Skill |
+| --- | --- |
+| Deploy / channels / OAuth / Helm | `postiz` |
+| Outage / empty channels / 502 | `postiz-doctor` |
+| UTM, Slack, EspoCRM attribution | `postiz-automation` |
+| CLI scheduling from agent/shell | `postiz-agent-cli` |
+| UGC video → schedule | `postiz-agent-media` |
+| n8n community node + RSS | `postiz-n8n-node` |
+
+## Hub implementation order (do in order)
+
+1. Restore `postiz-providers` OAuth keys; connect **P0**: LinkedIn Page, X, FB/IG, Bluesky.
+2. Confirm MCP `integrationList` and `/admin/postiz` Channels are non-empty.
+3. Install `postiz` CLI with Tailscale `POSTIZ_API_URL` (`postiz-agent-cli`).
+4. Import + activate `postiz-rss-multichannel.json`; optionally install `n8n-nodes-postiz`.
+5. Turn on Plugs for X + LinkedIn Page; register Postiz webhook → n8n UTM guard.
+6. Optional: agent-media MCP for short-form video creatives, then publish via Postiz.
+7. Optional: `OPENAI_API_KEY` + R2 on the Postiz pod for in-app AI/media.
+
+## cloudless.gr surfaces that already talk to Postiz
+
+- `src/lib/postiz.ts` — Public API client (incl. bulk + analytics)
+- `src/app/[locale]/admin/postiz` — compose / bulk / analytics UI
+- `src/lib/postiz-blog.ts` — blog → social
+- `src/app/api/webhooks/postiz` — inbound webhooks
+- `infrastructure/n8n/workflows/postiz-*.json` — automation starters
+- Cursor MCP server `postiz`
+
+## Do not
+
+- Upgrade past v2.11.2 without a Temporal plan
+- Commit API keys or put them in repo `mcp.json`
+- Use public `https://postiz.cloudless.gr` from headless agents without CF Access service token — prefer Tailscale NodePort or Access headers

--- a/skills/postiz-hub/reference.md
+++ b/skills/postiz-hub/reference.md
@@ -1,0 +1,57 @@
+# gitroomhq Postiz ecosystem — full inventory
+
+Queried 2026-08-15 from https://github.com/gitroomhq.
+
+## Implement for cloudless.gr
+
+| Repo | Purpose | cloudless skill / path |
+| --- | --- | --- |
+| postiz-app | Scheduler core (we run v2.11.2) | `postiz`, `postiz-doctor` |
+| postiz-docs | Docs source | docs.postiz.com |
+| postiz-agent | `postiz` CLI + agent skill | `postiz-agent-cli`, `scripts/postiz-cli-env.sh` |
+| postiz-n8n | Community n8n node | `postiz-n8n-node` |
+| agent-media / agent-media-app | UGC video MCP/CLI | `postiz-agent-media` |
+
+## Already covered in-repo (no upstream clone)
+
+| Asset | Path |
+| --- | --- |
+| Public API client | `src/lib/postiz.ts` |
+| Admin UI | `src/app/[locale]/admin/postiz` |
+| Blog auto-post | `src/lib/postiz-blog.ts` |
+| Webhooks | `src/app/api/webhooks/postiz` |
+| n8n starters | `infrastructure/n8n/workflows/postiz-*.json` |
+| Helm | `infrastructure/postiz/helm/postiz/` |
+| Cursor MCP notes | `scripts/cursor-mcp/README-postiz.md` |
+
+## Skip / defer
+
+| Repo | Reason |
+| --- | --- |
+| postiz-docker-compose | We use k3s Helm |
+| postiz-helmchart | Our chart is canonical |
+| postiz-mobile | Expo app — later |
+| postiz-motion-graphics-skill | Demo clips of Postiz UI, not cloudless content |
+| postiz-new-support-bot | Their support product |
+| loadplug | Empty/stale |
+| paperclip | Multi-agent company OS — defer |
+| crosspublic, trending-list, blog, devfest, wordpress-post-to-devto | Unrelated or legacy |
+
+## npm packages
+
+| Package | Use |
+| --- | --- |
+| `postiz` | Agents CLI |
+| `n8n-nodes-postiz` | n8n community node |
+| `@postiz/node` | Node SDK (optional alternative to raw fetch) |
+| `@agentmedia/mcp-server` / `agent-media-cli` | UGC generation |
+
+## Official install one-liners (operator machine)
+
+```bash
+pnpm add -g postiz
+npx skills add gitroomhq/postiz-agent
+# optional UGC:
+# npx skills add gitroomhq/agent-media
+# n8n UI → Community nodes → n8n-nodes-postiz
+```

--- a/skills/postiz-n8n-node/SKILL.md
+++ b/skills/postiz-n8n-node/SKILL.md
@@ -1,0 +1,65 @@
+---
+name: postiz-n8n-node
+description: |
+  Install and operate the official Postiz n8n community node (gitroomhq/postiz-n8n)
+  plus cloudless.gr starter workflows (RSS multichannel, UTM guard). Use when
+  wiring "n8n Postiz", "RSS to social", "n8n-nodes-postiz", or cron posting
+  without the Next.js app. Pair with `postiz-hub`, `postiz-automation`, `n8n-operator`.
+---
+
+# Postiz × n8n (cloudless.gr)
+
+Upstream node: https://github.com/gitroomhq/postiz-n8n · npm `n8n-nodes-postiz`
+
+Our n8n: https://n8n.cloudless.gr · manifests `infrastructure/n8n/`
+
+## Install community node (preferred UX)
+
+1. Open n8n → **Settings → Community nodes → Install**
+2. Package: `n8n-nodes-postiz`
+3. Credential **Postiz API**:
+   - API key from Postiz → Settings → Developers → Public API
+   - Host **must end with `/api`**:
+     - In-cluster: `http://postiz.postiz.svc.cluster.local:5000/api`
+     - Or public (needs Access token/bypass): `https://postiz.cloudless.gr/api`
+
+`N8N_COMMUNITY_PACKAGES_ENABLED=true` is already set on the n8n Deployment.
+
+## Starter workflows (git)
+
+| File | Purpose |
+| --- | --- |
+| `infrastructure/n8n/workflows/postiz-rss-multichannel.json` | Cron → RSS → Postiz multi-channel schedule (HTTP Request; works without community node) |
+| `infrastructure/n8n/workflows/postiz-utm-guard.json` | Postiz publish webhook → Slack if UTM missing |
+
+Import: n8n → Workflows → Import from File → Activate.
+
+Env already on the Deployment:
+
+- `POSTIZ_API_BASE=http://postiz.postiz.svc.cluster.local:5000`
+- `POSTIZ_RSS_FEED_URL=https://cloudless.gr/en/blog/rss.xml`
+- `POSTIZ_CHANNEL_IDENTIFIERS=linkedin,linkedin-page,x,bluesky`
+
+Override in n8n Variables if needed. Replace placeholder credential IDs after import.
+
+## When to use HTTP Request vs community node
+
+| Approach | Use when |
+| --- | --- |
+| HTTP Request (current JSON) | Portable; already matches Public API |
+| `n8n-nodes-postiz` | Operators want Postiz-native node UI |
+
+Both talk to the same Public API. Prefer in-cluster DNS so n8n never hits Cloudflare Access.
+
+## Built-in Postiz RSS vs n8n
+
+Postiz UI also has RSS auto-post. Use **one** source of truth:
+
+- n8n → when you need filters, Slack, EspoCRM, or multi-step AI rewrite
+- Postiz RSS → when you want the simplest feed → calendar path
+
+## Verify
+
+1. Connect ≥1 channel matching `POSTIZ_CHANNEL_IDENTIFIERS`
+2. Run the RSS workflow manually once
+3. Confirm a `QUEUE`/`schedule` post in Postiz or `/admin/postiz`

--- a/skills/postiz/SKILL.md
+++ b/skills/postiz/SKILL.md
@@ -132,6 +132,28 @@ kubectl -n postiz exec deploy/postiz-postgres -- \
 
    …and at `https://cloudless.gr/en/admin/postiz` (Channels tab).
 
+## Cursor MCP
+
+Postiz exposes streamable-HTTP MCP at `/api/mcp/<apiKey>` (9 tools on the
+current image, including `integrationList` / `integrationSchedulePostTool`).
+
+From this WSL/tailnet host, Cloudflare Access blocks the public hostname, so
+Cursor is configured in `~/.cursor/mcp.json` against the Tailscale NodePort:
+
+```text
+http://100.74.191.58:30500/api/mcp/<POSTIZ_API_KEY>
+```
+
+See `scripts/cursor-mcp/README-postiz.md`. Reload Cursor MCP after key rotation.
+`integrationList` returns `[]` until channels are connected in the Postiz UI.
+
+## Ecosystem hub
+
+For the full gitroomhq repo map (agent CLI, n8n node, agent-media, what to
+skip) and implementation order, open **`postiz-hub`**. Related skills:
+`postiz-agent-cli`, `postiz-agent-media`, `postiz-n8n-node`, `postiz-automation`,
+`postiz-doctor`.
+
 ## Posting via the API
 
 Smoke test (Bluesky needs no extra settings):

--- a/src/app/[locale]/admin/postiz/page.tsx
+++ b/src/app/[locale]/admin/postiz/page.tsx
@@ -298,6 +298,284 @@ function ChannelsTab({
   );
 }
 
+function AnalyticsTab({ integrations }: { integrations: PostizIntegration[] | null }) {
+  const [lookback, setLookback] = useState<7 | 14 | 30 | 60 | 90>(7);
+  const [selectedId, setSelectedId] = useState<string>("");
+  const [metrics, setMetrics] = useState<PostizAnalyticsMetric[] | null>(null);
+  const [busy, setBusy] = useState(false);
+  const [err, setErr] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!selectedId && integrations && integrations.length > 0) {
+      setSelectedId(integrations[0]!.id);
+    }
+  }, [integrations, selectedId]);
+
+  const load = async () => {
+    if (!selectedId) return;
+    setBusy(true);
+    setErr(null);
+    try {
+      const res = await fetch(
+        `/api/admin/postiz/analytics/integration/${encodeURIComponent(selectedId)}?date=${lookback}`
+      );
+      if (!res.ok) {
+        setErr(`analytics: ${res.status}`);
+        setMetrics(null);
+        return;
+      }
+      const data = (await res.json()) as { metrics: PostizAnalyticsMetric[] };
+      setMetrics(data.metrics ?? []);
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  if (integrations === null) return <p>Loading channels…</p>;
+  if (integrations.length === 0) {
+    return (
+      <p className="text-gray-700">
+        No channels connected. Connect them in Postiz, then reload this page.
+      </p>
+    );
+  }
+
+  return (
+    <div className="space-y-4">
+      <div className="flex flex-wrap items-end gap-3">
+        <div>
+          <label htmlFor="postiz-analytics-channel" className="mb-1 block text-sm font-medium">
+            Channel
+          </label>
+          <select
+            id="postiz-analytics-channel"
+            value={selectedId}
+            onChange={(e) => setSelectedId(e.target.value)}
+            className="rounded border border-gray-300 p-2 text-sm"
+          >
+            {integrations.map((i) => (
+              <option key={i.id} value={i.id}>
+                {i.name} ({i.identifier})
+              </option>
+            ))}
+          </select>
+        </div>
+        <div>
+          <label htmlFor="postiz-analytics-lookback" className="mb-1 block text-sm font-medium">
+            Lookback
+          </label>
+          <select
+            id="postiz-analytics-lookback"
+            value={lookback}
+            onChange={(e) => setLookback(Number(e.target.value) as 7 | 14 | 30 | 60 | 90)}
+            className="rounded border border-gray-300 p-2 text-sm"
+          >
+            {[7, 14, 30, 60, 90].map((d) => (
+              <option key={d} value={d}>
+                {d} days
+              </option>
+            ))}
+          </select>
+        </div>
+        <button
+          type="button"
+          onClick={() => void load()}
+          disabled={busy || !selectedId}
+          className="rounded bg-blue-600 px-4 py-2 text-sm font-medium text-white disabled:opacity-50"
+        >
+          {busy ? "Loading…" : "Load metrics"}
+        </button>
+      </div>
+      {err && <p className="text-sm text-red-700">{err}</p>}
+      {metrics && metrics.length === 0 && (
+        <p className="text-sm text-gray-600">
+          No metrics for this channel/window (provider may not expose analytics).
+        </p>
+      )}
+      {metrics && metrics.length > 0 && (
+        <ul className="divide-y rounded border">
+          {metrics.map((m) => {
+            const latest = m.data.at(-1);
+            return (
+              <li key={m.label} className="flex items-center justify-between gap-3 p-3 text-sm">
+                <div>
+                  <div className="font-medium">{m.label}</div>
+                  <div className="text-xs text-gray-500">
+                    latest {latest?.date ?? "—"} · {m.data.length} points
+                  </div>
+                </div>
+                <div className="text-right">
+                  <div className="font-mono">{latest?.total ?? "—"}</div>
+                  <div
+                    className={`text-xs ${
+                      m.percentageChange >= 0 ? "text-green-700" : "text-red-700"
+                    }`}
+                  >
+                    {m.percentageChange >= 0 ? "+" : ""}
+                    {m.percentageChange.toFixed(1)}%
+                  </div>
+                </div>
+              </li>
+            );
+          })}
+        </ul>
+      )}
+    </div>
+  );
+}
+
+function BulkTab({
+  integrations,
+  onPosted,
+}: {
+  integrations: PostizIntegration[];
+  onPosted: () => void;
+}) {
+  const [lines, setLines] = useState("");
+  const [selectedIds, setSelectedIds] = useState<string[]>([]);
+  const [startAt, setStartAt] = useState("");
+  const [intervalHours, setIntervalHours] = useState(24);
+  const [submitting, setSubmitting] = useState(false);
+  const [feedback, setFeedback] = useState<string | null>(null);
+
+  const toggleId = (id: string) =>
+    setSelectedIds((cur) => (cur.includes(id) ? cur.filter((x) => x !== id) : [...cur, id]));
+
+  const selectedIntegrations = useMemo(
+    () => integrations.filter((i) => selectedIds.includes(i.id)),
+    [integrations, selectedIds]
+  );
+
+  const onSubmit = async () => {
+    const contentLines = lines
+      .split("\n")
+      .map((l) => l.trim())
+      .filter(Boolean);
+    if (contentLines.length === 0 || selectedIntegrations.length === 0 || !startAt) {
+      setFeedback("Need content lines, channels, and a start time.");
+      return;
+    }
+    setSubmitting(true);
+    setFeedback(null);
+    try {
+      const startMs = new Date(startAt).getTime();
+      const items: CreatePostBody[] = contentLines.map((content, i) => {
+        const date = new Date(startMs + i * intervalHours * 60 * 60 * 1000).toISOString();
+        return {
+          type: "schedule",
+          date,
+          shortLink: false,
+          tags: [],
+          posts: selectedIntegrations.map((ch) => ({
+            integration: { id: ch.id },
+            value: [{ content, image: [] }],
+            settings: settingsFor(ch),
+          })),
+        };
+      });
+      const res = await fetch("/api/admin/postiz/posts/bulk", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ items }),
+      });
+      const data = (await res.json().catch(() => ({}))) as {
+        succeeded?: number;
+        failed?: number;
+        error?: string;
+      };
+      if (!res.ok && res.status !== 207) {
+        setFeedback(`Bulk failed: ${res.status} ${data.error ?? ""}`);
+        return;
+      }
+      setFeedback(`✅ Bulk done — ${data.succeeded ?? 0} ok, ${data.failed ?? 0} failed`);
+      if ((data.succeeded ?? 0) > 0) onPosted();
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <div className="space-y-4">
+      <p className="text-sm text-gray-600">
+        One post per line. Each line is scheduled starting at the start time, spaced by the interval
+        (max 30 lines). Same channels for every row.
+      </p>
+      <div>
+        <label htmlFor="postiz-bulk-channels" className="mb-1 block text-sm font-medium">
+          Channels ({selectedIds.length} selected)
+        </label>
+        <div id="postiz-bulk-channels" className="flex flex-wrap gap-2">
+          {integrations.map((i) => {
+            const on = selectedIds.includes(i.id);
+            return (
+              <button
+                type="button"
+                key={i.id}
+                onClick={() => toggleId(i.id)}
+                className={`rounded border px-3 py-1 text-sm ${
+                  on ? "border-blue-600 bg-blue-50 text-blue-700" : "border-gray-300 text-gray-700"
+                }`}
+              >
+                {i.name} <span className="text-xs">({i.identifier})</span>
+              </button>
+            );
+          })}
+        </div>
+      </div>
+      <div>
+        <label htmlFor="postiz-bulk-lines" className="mb-1 block text-sm font-medium">
+          Posts (one per line)
+        </label>
+        <textarea
+          id="postiz-bulk-lines"
+          value={lines}
+          onChange={(e) => setLines(e.target.value)}
+          rows={8}
+          className="w-full rounded border border-gray-300 p-2 font-mono text-sm"
+          placeholder={"Monday tip…\nTuesday tip…\nWednesday tip…"}
+        />
+      </div>
+      <div className="flex flex-wrap gap-4">
+        <div>
+          <label htmlFor="postiz-bulk-start" className="mb-1 block text-sm font-medium">
+            First schedule at
+          </label>
+          <input
+            id="postiz-bulk-start"
+            type="datetime-local"
+            value={startAt}
+            onChange={(e) => setStartAt(e.target.value)}
+            className="rounded border border-gray-300 p-2 text-sm"
+          />
+        </div>
+        <div>
+          <label htmlFor="postiz-bulk-interval" className="mb-1 block text-sm font-medium">
+            Interval (hours)
+          </label>
+          <input
+            id="postiz-bulk-interval"
+            type="number"
+            min={1}
+            max={168}
+            value={intervalHours}
+            onChange={(e) => setIntervalHours(Number(e.target.value) || 24)}
+            className="w-24 rounded border border-gray-300 p-2 text-sm"
+          />
+        </div>
+      </div>
+      <button
+        type="button"
+        disabled={submitting}
+        onClick={() => void onSubmit()}
+        className="rounded bg-purple-600 px-4 py-2 text-sm font-medium text-white disabled:opacity-50"
+      >
+        {submitting ? "Scheduling…" : "Schedule all"}
+      </button>
+      {feedback && <p className="text-sm">{feedback}</p>}
+    </div>
+  );
+}
+
 function ComposeTab({
   integrations,
   draft,

--- a/src/app/[locale]/admin/postiz/page.tsx
+++ b/src/app/[locale]/admin/postiz/page.tsx
@@ -35,10 +35,18 @@ const POSTIZ_FILE_ACCEPT =
  *   POST   /api/admin/postiz/upload        → upload media by URL
  *   POST   /api/admin/postiz/upload-file   → multipart file upload
  *   GET    /api/admin/postiz/slot?id=...   → next free time slot
+ *   POST   /api/admin/postiz/posts/bulk    → multi-day / multi-row schedule
+ *   GET    /api/admin/postiz/analytics/... → channel + post metrics
  *   POST   /api/admin/ai/generate          → AI-draft a post
  */
 
-type Tab = "compose" | "schedule" | "calendar" | "channels";
+type Tab = "compose" | "bulk" | "schedule" | "calendar" | "channels" | "analytics";
+
+interface PostizAnalyticsMetric {
+  label: string;
+  data: Array<{ total: string; date: string }>;
+  percentageChange: number;
+}
 
 interface ImageRef {
   id: string;
@@ -162,24 +170,29 @@ export default function PostizAdminPage() {
       )}
 
       <nav className="flex gap-2 border-b">
-        {(["compose", "schedule", "calendar", "channels"] as const).map((t) => (
-          <button
-            type="button"
-            key={t}
-            onClick={() => setTab(t)}
-            className={`px-3 py-2 text-sm capitalize ${
-              tab === t ? "border-b-2 border-blue-600 font-medium text-blue-700" : "text-gray-600"
-            }`}
-          >
-            {t}
-            {t === "compose" && draft.id ? " (edit)" : ""}
-          </button>
-        ))}
+        {(["compose", "bulk", "schedule", "calendar", "channels", "analytics"] as const).map(
+          (t) => (
+            <button
+              type="button"
+              key={t}
+              onClick={() => setTab(t)}
+              className={`px-3 py-2 text-sm capitalize ${
+                tab === t
+                  ? "border-b-2 border-blue-600 font-medium text-blue-700"
+                  : "text-gray-600"
+              }`}
+            >
+              {t}
+              {t === "compose" && draft.id ? " (edit)" : ""}
+            </button>
+          )
+        )}
       </nav>
 
       {tab === "channels" && (
         <ChannelsTab integrations={integrations} onReload={reloadIntegrations} />
       )}
+      {tab === "analytics" && <AnalyticsTab integrations={integrations} />}
       {tab === "compose" && (
         <ComposeTab
           integrations={integrations ?? []}
@@ -189,6 +202,15 @@ export default function PostizAdminPage() {
           onPosted={() => {
             void reloadPosts();
             setDraft(EMPTY_DRAFT);
+            setTab("schedule");
+          }}
+        />
+      )}
+      {tab === "bulk" && (
+        <BulkTab
+          integrations={integrations ?? []}
+          onPosted={() => {
+            void reloadPosts();
             setTab("schedule");
           }}
         />

--- a/src/app/api/admin/calendar/[id]/publish/route.ts
+++ b/src/app/api/admin/calendar/[id]/publish/route.ts
@@ -6,6 +6,7 @@ import {
   listPostizIntegrations,
   matchIntegrationsForPlatform,
   schedulePost,
+  withSocialUtm,
 } from "@/lib/postiz";
 
 /**
@@ -48,7 +49,7 @@ export async function POST(request: NextRequest, { params }: { params: Promise<{
     );
   }
 
-  const content = (body.content ?? item.notes ?? item.title ?? "").trim();
+  let content = (body.content ?? item.notes ?? item.title ?? "").trim();
   if (!content) {
     return NextResponse.json(
       { error: "No content to publish — add notes to the calendar item." },
@@ -67,11 +68,27 @@ export async function POST(request: NextRequest, { params }: { params: Promise<{
     );
   }
 
+  // UTM-stamp bare https URLs in the body for attribution (idempotent if already present).
+  const utmSource =
+    item.platform === "meta"
+      ? "facebook"
+      : item.platform === "linkedin"
+        ? "linkedin"
+        : item.platform === "x"
+          ? "x"
+          : item.platform === "tiktok"
+            ? "tiktok"
+            : "social";
+  content = content.replace(/https?:\/\/[^\s)]+/gi, (url) =>
+    withSocialUtm(url, utmSource, `calendar_${id.slice(0, 12)}`)
+  );
+
   const result = await schedulePost({
     content,
     integrationIds: targets.map((t) => t.id),
     scheduleAt: item.date,
     asDraft: body.asDraft,
+    tags: [{ value: `calendar-${id}`, label: `calendar-${id}` }],
   });
 
   if (!result.ok) {

--- a/src/app/api/admin/postiz/posts/bulk/route.ts
+++ b/src/app/api/admin/postiz/posts/bulk/route.ts
@@ -1,0 +1,60 @@
+import { NextRequest, NextResponse } from "next/server";
+import { requireAdmin } from "@/lib/api-auth";
+import {
+  createPostsBulk,
+  PostizNotConfiguredError,
+  type CreatePostBody,
+} from "@/lib/postiz";
+
+export const dynamic = "force-dynamic";
+
+const MAX_BULK = 30;
+
+/** POST /api/admin/postiz/posts/bulk — schedule many posts (one create-post
+ *  call per item). Body: `{ items: CreatePostBody[] }` (max 30). */
+export async function POST(req: NextRequest) {
+  const auth = await requireAdmin(req);
+  if (!auth.ok) return auth.response;
+
+  let body: { items?: CreatePostBody[] };
+  try {
+    body = (await req.json()) as { items?: CreatePostBody[] };
+  } catch {
+    return NextResponse.json({ error: "invalid_json" }, { status: 400 });
+  }
+
+  const items = body.items;
+  if (!Array.isArray(items) || items.length === 0) {
+    return NextResponse.json(
+      { error: "invalid_payload", detail: "items[] is required" },
+      { status: 400 }
+    );
+  }
+  if (items.length > MAX_BULK) {
+    return NextResponse.json(
+      { error: "too_many", detail: `max ${MAX_BULK} items per request` },
+      { status: 400 }
+    );
+  }
+
+  for (const [i, item] of items.entries()) {
+    if (!item?.type || !Array.isArray(item.posts) || item.posts.length === 0) {
+      return NextResponse.json(
+        { error: "invalid_payload", detail: `items[${i}]: type and posts[] are required` },
+        { status: 400 }
+      );
+    }
+  }
+
+  try {
+    const results = await createPostsBulk(items);
+    const succeeded = results.filter((r) => r.ok).length;
+    const failed = results.length - succeeded;
+    return NextResponse.json({ results, succeeded, failed }, { status: failed === 0 ? 201 : 207 });
+  } catch (err) {
+    if (err instanceof PostizNotConfiguredError) {
+      return NextResponse.json({ error: "postiz_not_configured" }, { status: 503 });
+    }
+    throw err;
+  }
+}

--- a/src/lib/appflowy-blog-admin.ts
+++ b/src/lib/appflowy-blog-admin.ts
@@ -242,10 +242,53 @@ export async function setEditorialStatus(
     const ok = await updateViewName(workspaceId, pageId, newName);
     if (!ok) {
       console.error("[appflowy-blog-admin] setEditorialStatus rename failed", pageId, status);
+      return false;
     }
-    return ok;
+
+    // Mirror the content-webhook path: Published → optional Postiz share.
+    // Fire-and-forget so Slack/admin status flips stay fast; gated by
+    // AUTO_POST_BLOG_TO_SOCIAL inside scheduleBlogShare.
+    if (status === "Published") {
+      void triggerBlogSocialShare(workspaceId, pageId, view.name).catch((err) =>
+        console.error("[appflowy-blog-admin] postiz share threw:", err)
+      );
+    }
+    return true;
   } catch (err) {
     console.error("[appflowy-blog-admin] setEditorialStatus error:", err);
     return false;
+  }
+}
+
+/** Load title/excerpt/slug from the AppFlowy doc and queue a social share. */
+async function triggerBlogSocialShare(
+  workspaceId: string,
+  pageId: string,
+  viewName: string
+): Promise<void> {
+  let title = stripPrefix(viewName);
+  let excerpt = "";
+  let slug = "";
+  try {
+    const doc = await getDocument(workspaceId, pageId);
+    const text = doc ? await extractDocText(doc) : "";
+    const fields = parseBlogFields(text);
+    title = fields.title || title;
+    excerpt = fields.category ? `${fields.category} · ${fields.readTime}` : "";
+    slug = fields.slug || slugify(title);
+  } catch (err) {
+    console.error("[appflowy-blog-admin] triggerBlogSocialShare doc read failed:", err);
+  }
+
+  const { scheduleBlogShare } = await import("@/lib/postiz-blog");
+  const baseUrl = process.env.SITE_URL ?? "https://cloudless.gr";
+  const url = slug ? `${baseUrl}/en/blog/${slug}` : `${baseUrl}/en/blog`;
+  const result = await scheduleBlogShare({ pageId, title, excerpt, url });
+  if (result.skipped) {
+    console.warn(`[appflowy-blog-admin → postiz] skipped: ${result.skipped}`);
+  } else if (result.ok) {
+    console.warn(`[appflowy-blog-admin → postiz] posted ${result.postIds.length} channel(s)`);
+  } else {
+    console.error(`[appflowy-blog-admin → postiz] failed: ${result.error}`);
   }
 }

--- a/src/lib/email-cloudflare.ts
+++ b/src/lib/email-cloudflare.ts
@@ -11,6 +11,7 @@ export interface CloudflareEmailOptions {
   html: string;
   text: string;
   replyTo?: string[];
+  from?: string;
   fromLabel?: string;
   listUnsubscribeUrl?: string;
 }
@@ -32,9 +33,10 @@ export async function sendEmailCloudflare(options: CloudflareEmailOptions): Prom
     );
   }
 
+  const fromEmail = options.from || "noreply@cloudless.gr";
   const fromAddress = options.fromLabel
-    ? `${options.fromLabel} <noreply@cloudless.gr>`
-    : "Cloudless <noreply@cloudless.gr>";
+    ? `${options.fromLabel} <${fromEmail}>`
+    : `Cloudless <${fromEmail}>`;
 
   const headers: Record<string, string> = {};
   if (options.listUnsubscribeUrl) {

--- a/src/lib/email-resend.ts
+++ b/src/lib/email-resend.ts
@@ -11,6 +11,7 @@ interface ResendOptions {
   html: string;
   text: string;
   replyTo?: string[];
+  from?: string;
   fromLabel?: string;
   listUnsubscribeUrl?: string;
 }
@@ -34,7 +35,7 @@ export async function sendEmailResend(options: ResendOptions): Promise<void> {
     throw new Error("RESEND_API_KEY not configured");
   }
 
-  const fromEmail = process.env.SES_FROM_EMAIL || "noreply@cloudless.gr";
+  const fromEmail = options.from || process.env.SES_FROM_EMAIL || "noreply@cloudless.gr";
   const fromAddress = options.fromLabel ? `${options.fromLabel} <${fromEmail}>` : fromEmail;
 
   try {

--- a/src/lib/email-sender.ts
+++ b/src/lib/email-sender.ts
@@ -13,6 +13,7 @@ export interface SendEmailPayload {
   html: string;
   text: string;
   replyTo?: string[];
+  from?: string;
   fromLabel?: string;
   listUnsubscribeUrl?: string;
 }
@@ -117,7 +118,7 @@ export async function sendEmail(payload: SendEmailPayload): Promise<void> {
 
   const fromAddress = getFromAddress(
     payload.fromLabel,
-    cfg.SES_FROM_EMAIL || "noreply@cloudless.gr"
+    payload.from || cfg.SES_FROM_EMAIL || "noreply@cloudless.gr"
   );
 
   // 1. Workers binding — primary

--- a/src/lib/email.ts
+++ b/src/lib/email.ts
@@ -4,6 +4,20 @@ import { isCloudflareEmailConfigured, sendEmailCloudflare } from "@/lib/email-cl
 import { isResendConfigured, sendEmailResend } from "@/lib/email-resend";
 import { isSuppressed } from "@/lib/ses-suppression-d1";
 
+
+export const SENDERS = {
+  noreply: "noreply@cloudless.gr",
+  info: "info@cloudless.gr",
+  orders: "orders@cloudless.gr",
+  newsletter: "newsletter@cloudless.gr",
+  admin: "admin@cloudless.gr",
+  bookings: "bookings@cloudless.gr",
+  sales: "sales@cloudless.gr",
+  tbaltzakis: "tbaltzakis@cloudless.gr",
+} as const;
+
+export type SenderAddress = (typeof SENDERS)[keyof typeof SENDERS];
+
 interface CloudflareEmailBinding {
   send: (message: Record<string, unknown>) => Promise<void>;
 }
@@ -28,6 +42,7 @@ export async function sendEmail(options: {
   subject: string;
   html: string;
   text: string;
+  from?: string;
   fromLabel?: string;
   replyTo?: string;
   listUnsubscribeUrl?: string;
@@ -52,7 +67,7 @@ export async function sendEmail(options: {
       }
 
       await email.send({
-        from: `${options.fromLabel || "Cloudless"} <noreply@cloudless.gr>`,
+        from: `${options.fromLabel || "Cloudless"} <${options.from || SENDERS.noreply}>`,
         to: options.to,
         subject: options.subject,
         text: options.text,
@@ -71,6 +86,7 @@ export async function sendEmail(options: {
     subject: options.subject,
     html: options.html,
     text: options.text,
+    from: options.from,
     fromLabel: options.fromLabel,
     replyTo: options.replyTo ? [options.replyTo] : undefined,
     listUnsubscribeUrl: options.listUnsubscribeUrl,
@@ -98,6 +114,7 @@ export async function sendEmail(options: {
 export async function sendSubscriberWelcome(email: string) {
   await sendEmail({
     to: email,
+    from: SENDERS.newsletter,
     subject: "Welcome to the Cloudless newsletter!",
     html: `
       <!DOCTYPE html>
@@ -163,6 +180,7 @@ export async function sendOrderConfirmation(
   const safeSessionId = sessionId.replace(/[<>&']/g, "");
   const payload = {
     to: email,
+    from: SENDERS.orders,
     subject: `Order Confirmation #${safeSessionId}`,
     html: `
       <!DOCTYPE html>
@@ -213,6 +231,7 @@ We appreciate your business and look forward to serving you again.
 export async function sendPaymentFailureNotice(email: string, invoiceId: string) {
   await sendEmail({
     to: email,
+    from: SENDERS.orders,
     subject: "Payment Failed",
     html: `
       <!DOCTYPE html>
@@ -263,6 +282,7 @@ export async function notifyTeam(subject: string, body: string) {
   const cfg = await getConfig();
   await sendEmail({
     to: cfg.SES_TO_EMAIL,
+    from: SENDERS.admin,
     subject: `[Team] ${subject}`,
     html: body,
     text: htmlToPlainText(body),
@@ -297,6 +317,7 @@ export async function sendActivationEmail(
 
   await sendEmail({
     to,
+    from: SENDERS.noreply,
     subject: "Activate your Cloudless account",
     fromLabel: "Cloudless",
     html: `
@@ -341,6 +362,7 @@ export async function sendPasswordResetEmail(email: string, resetUrl: string): P
   const safeUrl = escapeHtml(resetUrl);
   await sendEmail({
     to: email,
+    from: SENDERS.noreply,
     subject: "Password Reset Request",
     html: `
 <div style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; max-width: 600px; margin: 0 auto; padding: 20px; background-color: #f8f9fa;">
@@ -381,6 +403,7 @@ export async function sendContactAcknowledgment(opts: {
     : "";
   await sendEmail({
     to: opts.email,
+    from: SENDERS.info,
     subject: "We received your message — Cloudless",
     html: `
       <p>Hi ${safeName},</p>
@@ -420,6 +443,7 @@ export async function sendBookingConfirmation(opts: {
     : "";
   await sendEmail({
     to: opts.email,
+    from: SENDERS.bookings,
     subject: `Consultation confirmed — ${opts.slotLabel}`,
     html: `
       <p>Hi ${escapeHtml(opts.name)},</p>
@@ -451,6 +475,7 @@ export async function sendBookingConfirmation(opts: {
 export async function sendUnsubscribeConfirmation(email: string): Promise<void> {
   await sendEmail({
     to: email,
+    from: SENDERS.newsletter,
     subject: "You've been unsubscribed — Cloudless",
     fromLabel: "Cloudless",
     html: `

--- a/src/lib/postiz-blog.ts
+++ b/src/lib/postiz-blog.ts
@@ -1,18 +1,16 @@
 /**
- * postiz-blog — auto-post a blog post to connected social channels when its
- * Status flips to `Published`. Wired from `src/app/api/webhooks/notion/route.ts`
- * on the `database=blog`, `type=page.updated` event.
+ * postiz-blog — auto-post a blog entry to connected social channels when its
+ * editorial status flips to `Published`. Wired from:
+ *   - `src/app/api/webhooks/content/route.ts` (CMS content webhook)
+ *   - `setEditorialStatus(..., "Published")` in `appflowy-blog-admin.ts`
  *
  * Opt-in: only fires when the env flag `AUTO_POST_BLOG_TO_SOCIAL=1` is set
- * (per the operator's preference — they want to vet copy before each
- * publish). When unset (default) this is a logged no-op so a blog edit
- * never accidentally fans out to social.
+ * (default off — vet copy before each publish). When unset this is a logged
+ * no-op so a blog edit never accidentally fans out to social.
  *
- * Idempotency: builds a Postiz tag `blog-<pageId>` and checks the last 60
- * days of Postiz posts for that tag. If one exists, we skip (avoids
- * double-posting on a Status touch). Tag-based idempotency is preferable
- * to a DB column on the blog page since it survives blog-row deletes +
- * leaves a clean audit trail visible in Postiz UI.
+ * Idempotency: Postiz tag `blog-<pageId>`. We scan recent posts' content for
+ * that marker (tags are not always returned on listPosts in v2.11.2) and also
+ * send the tag on create for Postiz UI filtering.
  */
 import {
   isPostizConfigured,
@@ -20,16 +18,17 @@ import {
   listPostizIntegrations,
   matchIntegrationsForPlatform,
   schedulePost,
+  withSocialUtm,
 } from "@/lib/postiz";
 
 const TAG_PREFIX = "blog-";
 
 export interface BlogShareInput {
-  /** Notion page id of the blog row. Used as the idempotency tag. */
+  /** AppFlowy / CMS page id. Used as the idempotency tag. */
   pageId: string;
   title: string;
   excerpt: string;
-  /** Canonical public URL of the published post. Used in the body. */
+  /** Canonical public URL of the published post. */
   url: string;
   /** Optional override of which platforms to publish on. Defaults to
    *  every connected platform across LinkedIn, X, Meta, TikTok. */
@@ -44,6 +43,23 @@ export interface BlogShareResult {
   error?: string;
 }
 
+function platformUtmSource(
+  platform: "linkedin" | "x" | "meta" | "tiktok"
+): string {
+  switch (platform) {
+    case "linkedin":
+      return "linkedin";
+    case "x":
+      return "x";
+    case "meta":
+      return "facebook";
+    case "tiktok":
+      return "tiktok";
+    default:
+      return "social";
+  }
+}
+
 export async function scheduleBlogShare(input: BlogShareInput): Promise<BlogShareResult> {
   if (process.env.AUTO_POST_BLOG_TO_SOCIAL !== "1") {
     return { ok: true, skipped: "feature_off", postIds: [] };
@@ -52,40 +68,49 @@ export async function scheduleBlogShare(input: BlogShareInput): Promise<BlogShar
     return { ok: false, skipped: "postiz_unconfigured", postIds: [] };
   }
 
-  // Idempotency — has this pageId already been posted in the last 60 days?
+  const tagValue = `${TAG_PREFIX}${input.pageId}`;
   const since = new Date(Date.now() - 60 * 24 * 60 * 60 * 1000).toISOString();
   const until = new Date(Date.now() + 24 * 60 * 60 * 1000).toISOString();
-  const tag = `${TAG_PREFIX}${input.pageId}`;
   try {
     const existing = await listPosts(since, until);
-    if (existing.some((p) => p.content?.includes(tag))) {
+    if (existing.some((p) => p.content?.includes(tagValue))) {
       return { ok: true, skipped: "already_posted", postIds: [] };
     }
   } catch {
-    // Postiz list failed; better to risk a duplicate than to skip posting
-    // when the operator opted in. Continue.
+    // Postiz list failed; better to risk a duplicate than to skip when opted in.
   }
 
   const integrations = await listPostizIntegrations();
   const platforms = input.platforms ?? ["linkedin", "x", "meta", "tiktok"];
-  const integrationIds = new Set<string>();
-  for (const p of platforms) {
-    for (const i of matchIntegrationsForPlatform(integrations, p)) {
-      integrationIds.add(i.id);
+  const campaign = `blog_${input.pageId.slice(0, 12)}`;
+  const allPostIds: string[] = [];
+  let lastError: string | undefined;
+  let anyChannel = false;
+
+  for (const platform of platforms) {
+    const targets = matchIntegrationsForPlatform(integrations, platform);
+    if (targets.length === 0) continue;
+    anyChannel = true;
+
+    const utmUrl = withSocialUtm(input.url, platformUtmSource(platform), campaign);
+    const body = `${input.title}\n\n${input.excerpt}\n\n${utmUrl}`;
+    const result = await schedulePost({
+      content: body,
+      integrationIds: targets.map((t) => t.id),
+      tags: [{ value: tagValue, label: tagValue }],
+    });
+    if (result.ok) {
+      allPostIds.push(...result.postIds);
+    } else if (result.error) {
+      lastError = result.error;
     }
   }
-  if (integrationIds.size === 0) {
+
+  if (!anyChannel) {
     return { ok: false, skipped: "no_channels", postIds: [] };
   }
-
-  // The tag is invisible to most platforms (collapsed by Postiz's URL
-  // shortener) but visible enough that `listPosts` filtering picks it up.
-  const body = `${input.title}\n\n${input.excerpt}\n\n${input.url}\n\n${tag}`;
-  const result = await schedulePost({
-    content: body,
-    integrationIds: Array.from(integrationIds),
-    // Post immediately. If the operator wants a delay, they can switch this
-    // to `scheduleAt: new Date(Date.now() + 30*60*1000).toISOString()`.
-  });
-  return { ok: result.ok, postIds: result.postIds, error: result.error };
+  if (allPostIds.length === 0) {
+    return { ok: false, postIds: [], error: lastError ?? "Postiz returned no post ids" };
+  }
+  return { ok: true, postIds: allPostIds, error: lastError };
 }

--- a/src/lib/postiz.ts
+++ b/src/lib/postiz.ts
@@ -341,6 +341,55 @@ export function createPost(
   });
 }
 
+/** One successful or failed entry from {@link createPostsBulk}. */
+export type BulkCreatePostResult =
+  | {
+      index: number;
+      ok: true;
+      result: Array<{ postId: string; integration: string }>;
+    }
+  | {
+      index: number;
+      ok: false;
+      error: string;
+      status?: number;
+    };
+
+/**
+ * Schedule / draft / publish many posts sequentially.
+ *
+ * Postiz's create-post endpoint takes a single top-level `date`, so multi-day
+ * calendars need one request per date (or per content row). We keep going after
+ * individual failures so a bad mid-list item doesn't abort the rest. Cap the
+ * batch size in the route layer — create-post is rate-limited (~90/hr, tunable
+ * via `API_LIMIT` on the Postiz pod).
+ */
+export async function createPostsBulk(bodies: CreatePostBody[]): Promise<BulkCreatePostResult[]> {
+  const out: BulkCreatePostResult[] = [];
+  for (let index = 0; index < bodies.length; index++) {
+    try {
+      const result = await createPost(bodies[index]!);
+      out.push({ index, ok: true, result });
+    } catch (err) {
+      if (err instanceof PostizApiError) {
+        out.push({
+          index,
+          ok: false,
+          error: err.body.slice(0, 300) || err.message,
+          status: err.status,
+        });
+        continue;
+      }
+      out.push({
+        index,
+        ok: false,
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+  }
+  return out;
+}
+
 /** Delete a post.
  *
  * Per docs.postiz.com / API Overview, `DELETE` on a missing post should

--- a/src/lib/postiz.ts
+++ b/src/lib/postiz.ts
@@ -176,6 +176,8 @@ export interface SchedulePostInput {
   /** ISO timestamp. Posts immediately when omitted or in the past. */
   scheduleAt?: string;
   asDraft?: boolean;
+  /** Postiz tags (value+label). Used for idempotency / filtering. */
+  tags?: Array<{ value: string; label: string }>;
 }
 
 export interface SchedulePostResult {
@@ -183,6 +185,66 @@ export interface SchedulePostResult {
   /** Postiz post IDs, one per channel. */
   postIds: string[];
   error?: string;
+}
+
+/**
+ * Append standard cloudless social UTMs to a URL (or leave non-URLs alone).
+ * Campaign defaults to `social_hub`; pass a stable slug for attribution.
+ */
+export function withSocialUtm(
+  url: string,
+  platform: string,
+  campaign = "social_hub"
+): string {
+  const trimmed = url.trim();
+  if (!/^https?:\/\//i.test(trimmed)) return trimmed;
+  try {
+    const u = new URL(trimmed);
+    if (!u.searchParams.has("utm_source")) {
+      u.searchParams.set("utm_source", platform || "social");
+    }
+    if (!u.searchParams.has("utm_medium")) {
+      u.searchParams.set("utm_medium", "social");
+    }
+    if (!u.searchParams.has("utm_campaign")) {
+      u.searchParams.set("utm_campaign", campaign);
+    }
+    return u.toString();
+  } catch {
+    return trimmed;
+  }
+}
+
+/** Minimal settings object so Postiz validators accept the create-post body. */
+function defaultSettingsForIdentifier(
+  identifier: string
+): { __type: string } & Record<string, unknown> {
+  switch (identifier) {
+    case "x":
+      return { __type: "x", who_can_reply_post: "everyone" };
+    case "linkedin":
+      return { __type: "linkedin", post_as_images_carousel: false };
+    case "linkedin-page":
+      return { __type: "linkedin-page", post_as_images_carousel: false };
+    case "instagram":
+      return { __type: "instagram", post_type: "post" };
+    case "instagram-standalone":
+      return { __type: "instagram-standalone", post_type: "post" };
+    case "tiktok":
+      return {
+        __type: "tiktok",
+        privacy_level: "PUBLIC_TO_EVERYONE",
+        duet: true,
+        stitch: true,
+        comment: true,
+        autoAddMusic: "no",
+        brand_content_toggle: false,
+        brand_organic_toggle: false,
+        content_posting_method: "DIRECT_POST",
+      };
+    default:
+      return { __type: identifier || "x" };
+  }
 }
 
 /** Create a scheduled (or immediate/draft) post on the given Postiz channels. */
@@ -203,6 +265,9 @@ export async function schedulePost(input: SchedulePostInput): Promise<SchedulePo
     type = Number.isNaN(scheduleTime) || scheduleTime <= now ? "now" : "schedule";
   }
 
+  const integrations = await listPostizIntegrations();
+  const byId = new Map(integrations.map((i) => [i.id, i]));
+
   try {
     const res = await postizFetch("/posts", {
       method: "POST",
@@ -210,14 +275,18 @@ export async function schedulePost(input: SchedulePostInput): Promise<SchedulePo
         type,
         date: new Date(Number.isNaN(scheduleTime) ? now : scheduleTime).toISOString(),
         shortLink: false,
-        tags: [],
-        posts: input.integrationIds.map((id) => ({
-          integration: { id },
-          // `image` must always be present as an array — the live Postiz
-          // v2.11.2 validator rejects value items without it
-          // ("posts.0.value.0.image must be an array", verified 2026-06-12).
-          value: [{ content: input.content, image: [] }],
-        })),
+        tags: input.tags ?? [],
+        posts: input.integrationIds.map((id) => {
+          const identifier = byId.get(id)?.identifier ?? "x";
+          return {
+            integration: { id },
+            // `image` must always be present as an array — the live Postiz
+            // v2.11.2 validator rejects value items without it
+            // ("posts.0.value.0.image must be an array", verified 2026-06-12).
+            value: [{ content: input.content, image: [] }],
+            settings: defaultSettingsForIdentifier(identifier),
+          };
+        }),
       }),
     });
     if (!res.ok) {


### PR DESCRIPTION
## Summary

- **Multi-sender email**: `SENDERS` map (`noreply/info/orders/newsletter/admin/bookings/sales/tbaltzakis@cloudless.gr`) wired through all four email transport layers. Each convenience function now sends from the semantically correct address.
- **Postiz social hub**: typed client, blog adapter, admin calendar publish route, k8s/Helm manifests, n8n workflows, operator skill and connect runbook.

## Email changes
- `src/lib/email.ts` — `SENDERS` const + `from?` param on `sendEmail()` + per-function sender assignments
- `src/lib/email-cloudflare.ts` / `email-resend.ts` / `email-sender.ts` — `from?` propagated through all transports

## Postiz changes
- `src/lib/postiz.ts` — v2.11.2 REST client
- `src/lib/postiz-blog.ts` — blog → Postiz adapter
- `src/app/api/admin/calendar/[id]/publish/route.ts` — publish endpoint
- `infrastructure/postiz/` — k8s + Helm updates
- `skills/postiz-hub/SKILL.md` — full operator manual
- `docs/integrations/POSTIZ-CONNECT.md` + helper scripts

## Test plan
- [ ] Send test email and verify `From:` header shows the correct address for each flow
- [ ] `pnpm exec tsc --noEmit` passes (no type errors on email layer)
- [ ] Postiz MCP `list_channels` returns channels after OAuth secrets are restored
- [ ] Admin calendar publish route returns 200 on a valid post ID

🤖 Generated with [Claude Code](https://claude.ai/claude-code)