### PR TITLE
fix(workflows): update stale TS_AUTHKEY → OAuth, disable superseded wire workflows

### DIFF
--- a/.github/workflows/pi-appflowy-probe.yml
+++ b/.github/workflows/pi-appflowy-probe.yml
@@ -24,11 +24,11 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: Connect to tailnet
-      uses: tailscale/github-action@v3
+      uses: tailscale/github-action@0263d9e6d793eaefcf1de98ff7fde47abe6664d3  # v3.2.4
       with:
-        authkey: ${{ secrets.TS_AUTHKEY }}
-        version: latest
-        tags: tag:ci
+        oauth-client-id: ${{ secrets.TS_CLIENT_ID }}
+        oauth-secret: ${{ secrets.TS_CLIENT_SECRET }}
+        tags: tag:k8s
     - name: Configure kubectl
       run: |
         mkdir -p ~/.kube

--- a/.github/workflows/pi-appflowy-provision.yml
+++ b/.github/workflows/pi-appflowy-provision.yml
@@ -24,11 +24,11 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: Connect to tailnet
-      uses: tailscale/github-action@v3
+      uses: tailscale/github-action@0263d9e6d793eaefcf1de98ff7fde47abe6664d3  # v3.2.4
       with:
-        authkey: ${{ secrets.TS_AUTHKEY }}
-        version: latest
-        tags: tag:ci
+        oauth-client-id: ${{ secrets.TS_CLIENT_ID }}
+        oauth-secret: ${{ secrets.TS_CLIENT_SECRET }}
+        tags: tag:k8s
     - name: Configure kubectl
       run: |
         mkdir -p ~/.kube

--- a/.github/workflows/pi-auth-logs-v2.yml
+++ b/.github/workflows/pi-auth-logs-v2.yml
@@ -26,11 +26,11 @@ jobs:
     - uses: actions/checkout@v4
 
     - name: Connect to tailnet (ephemeral node)
-      uses: tailscale/github-action@v3
+      uses: tailscale/github-action@0263d9e6d793eaefcf1de98ff7fde47abe6664d3  # v3.2.4
       with:
-        authkey: ${{ secrets.TS_AUTHKEY }}
-        version: latest
-        tags: tag:ci
+        oauth-client-id: ${{ secrets.TS_CLIENT_ID }}
+        oauth-secret: ${{ secrets.TS_CLIENT_SECRET }}
+        tags: tag:k8s
 
     - name: Configure kubectl (system:admin via KUBECONFIG_B64)
       run: |

--- a/.github/workflows/pi-cms-tunnel-diag.yml
+++ b/.github/workflows/pi-cms-tunnel-diag.yml
@@ -24,11 +24,11 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: Connect to tailnet
-      uses: tailscale/github-action@v3
+      uses: tailscale/github-action@0263d9e6d793eaefcf1de98ff7fde47abe6664d3  # v3.2.4
       with:
-        authkey: ${{ secrets.TS_AUTHKEY }}
-        version: latest
-        tags: tag:ci
+        oauth-client-id: ${{ secrets.TS_CLIENT_ID }}
+        oauth-secret: ${{ secrets.TS_CLIENT_SECRET }}
+        tags: tag:k8s
     - name: Configure kubectl
       run: |
         mkdir -p ~/.kube

--- a/.github/workflows/pi-fix-d1-auth.yml
+++ b/.github/workflows/pi-fix-d1-auth.yml
@@ -33,7 +33,7 @@ jobs:
         [ -n "$CLOUDFLARE_API_TOKEN" ] || missing+=("CLOUDFLARE_API_TOKEN")
         [ -n "$CF_ACCOUNT_ID" ]        || missing+=("CF_ACCOUNT_ID")
         [ -n "${{ secrets.KUBECONFIG_B64 }}" ] || missing+=("KUBECONFIG_B64")
-        [ -n "${{ secrets.TS_AUTHKEY }}" ]     || missing+=("TS_AUTHKEY")
+        [ -n "${{ secrets.TS_CLIENT_ID }}" ]   || missing+=("TS_CLIENT_ID")
         if [ ${#missing[@]} -gt 0 ]; then
           echo "::error::Missing required repo secrets: ${missing[*]}"; exit 1
         fi
@@ -50,11 +50,11 @@ jobs:
         echo "OK  token verify → 200"
 
     - name: Connect to tailnet
-      uses: tailscale/github-action@v3
+      uses: tailscale/github-action@0263d9e6d793eaefcf1de98ff7fde47abe6664d3  # v3.2.4
       with:
-        authkey: ${{ secrets.TS_AUTHKEY }}
-        version: latest
-        tags: tag:ci
+        oauth-client-id: ${{ secrets.TS_CLIENT_ID }}
+        oauth-secret: ${{ secrets.TS_CLIENT_SECRET }}
+        tags: tag:k8s
 
     - name: Configure kubectl
       run: |

--- a/.github/workflows/pi-fix-tunnel-and-cms.yml
+++ b/.github/workflows/pi-fix-tunnel-and-cms.yml
@@ -27,11 +27,11 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: Connect to tailnet
-      uses: tailscale/github-action@v3
+      uses: tailscale/github-action@0263d9e6d793eaefcf1de98ff7fde47abe6664d3  # v3.2.4
       with:
-        authkey: ${{ secrets.TS_AUTHKEY }}
-        version: latest
-        tags: tag:ci
+        oauth-client-id: ${{ secrets.TS_CLIENT_ID }}
+        oauth-secret: ${{ secrets.TS_CLIENT_SECRET }}
+        tags: tag:k8s
     - name: Configure kubectl
       run: |
         mkdir -p ~/.kube

--- a/.github/workflows/postiz-restore-providers.yml
+++ b/.github/workflows/postiz-restore-providers.yml
@@ -35,7 +35,8 @@ jobs:
       - name: Connect to tailnet
         uses: tailscale/github-action@0263d9e6d793eaefcf1de98ff7fde47abe6664d3 # v3.2.4
         with:
-          authkey: ${{ secrets.TS_AUTHKEY }}
+          oauth-client-id: ${{ secrets.TS_CLIENT_ID }}
+          oauth-secret: ${{ secrets.TS_CLIENT_SECRET }}
 
       - name: Configure kubectl
         run: |

--- a/.github/workflows/postiz-wire-ai-proxy.yml
+++ b/.github/workflows/postiz-wire-ai-proxy.yml
@@ -1,11 +1,8 @@
 name: Wire Postiz AI Proxy
 
-# Triggered by editing this file (push path) — the standard incident-response
-# pattern for this repo. Runs once then stays idle.
+# Superseded by deploy-postiz-ai-proxy.yml — kept for manual re-run only.
 on:
-  push:
-    paths:
-      - .github/workflows/postiz-wire-ai-proxy.yml
+  workflow_dispatch:
 
 jobs:
   wire:

--- a/.github/workflows/wire-chatbot-nvidia-proxy.yml
+++ b/.github/workflows/wire-chatbot-nvidia-proxy.yml
@@ -3,10 +3,9 @@ name: Wire Chatbot NVIDIA Proxy
 # Triggered by editing this file (push path) — one-shot wiring workflow.
 # Sets NVIDIA_PROXY_URL + NVIDIA_PROXY_TOKEN on the cloudless-app Deployment
 # so the chat backend switches to nemotron-3.5-lightning-30b-a3b.
+# Superseded by wire-all-ai-backends.yml — kept for manual re-run only.
 on:
-  push:
-    paths:
-      - .github/workflows/wire-chatbot-nvidia-proxy.yml
+  workflow_dispatch:
 
 jobs:
   wire:

--- a/.github/workflows/wire-ollama-fallback.yml
+++ b/.github/workflows/wire-ollama-fallback.yml
@@ -3,10 +3,9 @@ name: Wire Ollama Fallback
 # Sets OLLAMA_BASE_URL (+ optional OLLAMA_MODEL) on the cloudless-app
 # Deployment so Ollama (qwen2.5-coder on the WSL host, reachable over
 # Tailscale) becomes the AI fallback after NVIDIA proxy and Workers AI.
+# Superseded by wire-all-ai-backends.yml — kept for manual re-run only.
 on:
-  push:
-    paths:
-      - .github/workflows/wire-ollama-fallback.yml
+  workflow_dispatch:
 
 jobs:
   wire:


### PR DESCRIPTION
## Summary
- **7 workflows** using deprecated `tailscale/github-action@v3` + `secrets.TS_AUTHKEY` (ephemeral key approach) updated to OAuth: `TS_CLIENT_ID` / `TS_CLIENT_SECRET`, pinned hash `@0263d9e6...` (v3.2.4), tag `tag:k8s`
- **3 superseded one-shot wire workflows** (`wire-chatbot-nvidia-proxy`, `wire-ollama-fallback`, `postiz-wire-ai-proxy`) had `on.push.paths` auto-triggers that would conflict with their replacements (`wire-all-ai-backends`, `deploy-postiz-ai-proxy`). Converted to `workflow_dispatch`-only.

## Workflows fixed
| Workflow | Fix |
|---|---|
| `pi-fix-tunnel-and-cms` | TS_AUTHKEY → OAuth |
| `pi-fix-d1-auth` | TS_AUTHKEY → OAuth (+ validation step updated) |
| `pi-auth-logs-v2` | TS_AUTHKEY → OAuth |
| `pi-appflowy-provision` | TS_AUTHKEY → OAuth |
| `pi-cms-tunnel-diag` | TS_AUTHKEY → OAuth |
| `pi-appflowy-probe` | TS_AUTHKEY → OAuth |
| `postiz-restore-providers` | TS_AUTHKEY → OAuth (was on pinned hash but stale param) |
| `wire-chatbot-nvidia-proxy` | push-path → workflow_dispatch |
| `wire-ollama-fallback` | push-path → workflow_dispatch |
| `postiz-wire-ai-proxy` | push-path → workflow_dispatch |

🤖 Generated with [Claude Code](https://claude.com/claude-code)