### PR TITLE
fix(workflows): postiz — missing Tailscale tag + unquoted cron expression

### DIFF
--- a/.github/workflows/postiz-crons.yml
+++ b/.github/workflows/postiz-crons.yml
@@ -16,7 +16,7 @@ name: Postiz crons
 on:
   schedule:
   - cron: '*/15 * * * *'       # postiz-sync — every 15 min
-  - cron: 5 * * * *       # postiz-oauth-check — 5 min past the hour
+  - cron: '5 * * * *'     # postiz-oauth-check — 5 min past the hour
   workflow_dispatch:
     inputs:
       target:

--- a/.github/workflows/postiz-restore-providers.yml
+++ b/.github/workflows/postiz-restore-providers.yml
@@ -37,6 +37,7 @@ jobs:
         with:
           oauth-client-id: ${{ secrets.TS_CLIENT_ID }}
           oauth-secret: ${{ secrets.TS_CLIENT_SECRET }}
+          tags: tag:k8s
 
       - name: Configure kubectl
         run: |


### PR DESCRIPTION
## Summary
- **`postiz-restore-providers`**: Tailscale OAuth step was missing `tags: tag:k8s`. Without this the ephemeral node doesn't receive the ACL tag that grants it access to the cluster (`100.74.191.58:6443`). Every other workflow using `TS_CLIENT_ID`/`TS_CLIENT_SECRET` includes this tag.
- **`postiz-crons`**: Second schedule cron `5 * * * *` was unquoted while the first (`'*/15 * * * *'`) was quoted. Added quotes for consistency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)