### PR TITLE
fix(workflows): add missing tags:k8s, fix kubectl patch idempotency, fix cloudflared-restart

### DIFF
--- a/src/app/[locale]/admin/analytics/explore/page.tsx
+++ b/src/app/[locale]/admin/analytics/explore/page.tsx
@@ -154,7 +154,10 @@ export default function LakeExplorePage() {
             <button
               key={q.label}
               type="button"
-              onClick={() => { setCatalogId(q.dataset); setSql(q.sql); }}
+              onClick={() => {
+                setCatalogId(q.dataset);
+                setSql(q.sql);
+              }}
               className="border-neon-cyan/20 bg-neon-cyan/5 text-neon-cyan/80 hover:bg-neon-cyan/15 rounded-full border px-3 py-1 font-mono text-[10px] transition-colors"
             >
               {q.label}

--- a/src/app/[locale]/admin/analytics/unified/page.tsx
+++ b/src/app/[locale]/admin/analytics/unified/page.tsx
@@ -293,7 +293,7 @@ export default function UnifiedAnalyticsPage() {
           </button>
           <Link
             href="/admin/reports"
-            className="rounded-lg border border-neon-green/30 bg-neon-green/10 px-4 py-2 font-mono text-xs text-neon-green transition-all hover:bg-neon-green/20"
+            className="border-neon-green/30 bg-neon-green/10 text-neon-green hover:bg-neon-green/20 rounded-lg border px-4 py-2 font-mono text-xs transition-all"
           >
             ↓ PDF Reports
           </Link>
@@ -370,7 +370,7 @@ export default function UnifiedAnalyticsPage() {
                     className={`${step.bg} relative flex min-w-32 flex-1 flex-col justify-center px-5 py-5`}
                   >
                     {i > 0 && (
-                      <span className="absolute -left-2 top-1/2 z-10 -translate-y-1/2 font-mono text-xs text-slate-600">
+                      <span className="absolute top-1/2 -left-2 z-10 -translate-y-1/2 font-mono text-xs text-slate-600">
                         →
                       </span>
                     )}
@@ -382,7 +382,7 @@ export default function UnifiedAnalyticsPage() {
                     </p>
                     <p className="mt-0.5 font-mono text-[10px] text-slate-600">{step.sub}</p>
                     {i < arr.length - 1 && (
-                      <div className="absolute right-0 top-0 h-full w-px bg-slate-800" />
+                      <div className="absolute top-0 right-0 h-full w-px bg-slate-800" />
                     )}
                   </div>
                 ))}

--- a/src/app/[locale]/admin/crm/page.tsx
+++ b/src/app/[locale]/admin/crm/page.tsx
@@ -200,7 +200,7 @@ export default function AdminCRMPage() {
         </Link>
         <Link
           href="/admin/analytics/explore?dataset=churn&q=high-risk"
-          className="border-red-500/20 bg-red-500/5 rounded-full border px-3 py-1 font-mono text-[10px] text-red-400/70 transition-colors hover:bg-red-500/10"
+          className="rounded-full border border-red-500/20 bg-red-500/5 px-3 py-1 font-mono text-[10px] text-red-400/70 transition-colors hover:bg-red-500/10"
         >
           ⚠ High Churn Risk →
         </Link>

--- a/src/app/[locale]/admin/postiz/page.tsx
+++ b/src/app/[locale]/admin/postiz/page.tsx
@@ -177,9 +177,7 @@ export default function PostizAdminPage() {
               key={t}
               onClick={() => setTab(t)}
               className={`px-3 py-2 text-sm capitalize ${
-                tab === t
-                  ? "border-b-2 border-blue-600 font-medium text-blue-700"
-                  : "text-gray-600"
+                tab === t ? "border-b-2 border-blue-600 font-medium text-blue-700" : "text-gray-600"
               }`}
             >
               {t}

--- a/src/app/api/admin/postiz/posts/bulk/route.ts
+++ b/src/app/api/admin/postiz/posts/bulk/route.ts
@@ -1,10 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { requireAdmin } from "@/lib/api-auth";
-import {
-  createPostsBulk,
-  PostizNotConfiguredError,
-  type CreatePostBody,
-} from "@/lib/postiz";
+import { createPostsBulk, PostizNotConfiguredError, type CreatePostBody } from "@/lib/postiz";
 
 export const dynamic = "force-dynamic";
 

--- a/src/app/api/cron/email-digest/route.ts
+++ b/src/app/api/cron/email-digest/route.ts
@@ -50,7 +50,9 @@ export async function GET(request: NextRequest) {
       </tr>`;
   };
 
-  const execSummary = executive?.summary ?? "No executive insight available yet — run the analytics orchestration job to generate one.";
+  const execSummary =
+    executive?.summary ??
+    "No executive insight available yet — run the analytics orchestration job to generate one.";
   const execBullets = (executive?.bullets ?? [])
     .map((b) => `<li style="margin-bottom:6px;color:#8b949e;font-size:13px">${escapeHtml(b)}</li>`)
     .join("");
@@ -133,9 +135,6 @@ export async function GET(request: NextRequest) {
     });
   } catch (err) {
     console.error("[email-digest] send failed:", err);
-    return NextResponse.json(
-      { ok: false, error: String(err) },
-      { status: 500 }
-    );
+    return NextResponse.json({ ok: false, error: String(err) }, { status: 500 });
   }
 }

--- a/src/components/admin/InsightPanel.tsx
+++ b/src/components/admin/InsightPanel.tsx
@@ -41,14 +41,12 @@ export function InsightPanel({ domain }: Props) {
   if (!insight) return null;
 
   return (
-    <div className="mb-6 rounded-xl border border-neon-green/20 bg-neon-green/5 px-5 py-4">
+    <div className="border-neon-green/20 bg-neon-green/5 mb-6 rounded-xl border px-5 py-4">
       <div className="mb-2 flex items-center gap-2">
-        <span className="font-mono text-[10px] tracking-widest text-neon-green/70 uppercase">
+        <span className="text-neon-green/70 font-mono text-[10px] tracking-widest uppercase">
           AI Insight
         </span>
-        {age && (
-          <span className="font-mono text-[10px] text-slate-600">{age}</span>
-        )}
+        {age && <span className="font-mono text-[10px] text-slate-600">{age}</span>}
         {insight.confidence && (
           <span
             className={`rounded-full px-2 py-0.5 font-mono text-[9px] ${
@@ -68,7 +66,7 @@ export function InsightPanel({ domain }: Props) {
         <ul className="space-y-1">
           {insight.bullets.map((b, i) => (
             <li key={i} className="flex gap-2 font-mono text-xs text-slate-400">
-              <span className="mt-0.5 shrink-0 text-neon-green/50">▸</span>
+              <span className="text-neon-green/50 mt-0.5 shrink-0">▸</span>
               {b}
             </li>
           ))}
@@ -78,7 +76,8 @@ export function InsightPanel({ domain }: Props) {
         <div className="mt-3 flex flex-wrap gap-3">
           {insight.metrics_cited.slice(0, 5).map((m) => (
             <span key={m.key} className="font-mono text-[10px] text-slate-600">
-              {m.key.replace(/_/g, " ")}: <span className="text-slate-400">{String(m.value ?? "—")}</span>
+              {m.key.replace(/_/g, " ")}:{" "}
+              <span className="text-slate-400">{String(m.value ?? "—")}</span>
             </span>
           ))}
         </div>

--- a/src/lib/email.ts
+++ b/src/lib/email.ts
@@ -4,7 +4,6 @@ import { isCloudflareEmailConfigured, sendEmailCloudflare } from "@/lib/email-cl
 import { isResendConfigured, sendEmailResend } from "@/lib/email-resend";
 import { isSuppressed } from "@/lib/ses-suppression-d1";
 
-
 export const SENDERS = {
   noreply: "noreply@cloudless.gr",
   info: "info@cloudless.gr",

--- a/src/lib/postiz-blog.ts
+++ b/src/lib/postiz-blog.ts
@@ -43,9 +43,7 @@ export interface BlogShareResult {
   error?: string;
 }
 
-function platformUtmSource(
-  platform: "linkedin" | "x" | "meta" | "tiktok"
-): string {
+function platformUtmSource(platform: "linkedin" | "x" | "meta" | "tiktok"): string {
   switch (platform) {
     case "linkedin":
       return "linkedin";

--- a/src/lib/postiz.ts
+++ b/src/lib/postiz.ts
@@ -191,11 +191,7 @@ export interface SchedulePostResult {
  * Append standard cloudless social UTMs to a URL (or leave non-URLs alone).
  * Campaign defaults to `social_hub`; pass a stable slug for attribution.
  */
-export function withSocialUtm(
-  url: string,
-  platform: string,
-  campaign = "social_hub"
-): string {
+export function withSocialUtm(url: string, platform: string, campaign = "social_hub"): string {
   const trimmed = url.trim();
   if (!/^https?:\/\//i.test(trimmed)) return trimmed;
   try {

--- a/src/lib/workers-ai-chat.ts
+++ b/src/lib/workers-ai-chat.ts
@@ -24,9 +24,7 @@ import { isOllamaConfigured, callOllamaChat } from "@/lib/ollama-client";
 const MAX_TOKENS = 600;
 const MAX_TOOL_ITERATIONS = 4;
 
-async function callChatBackend(
-  messages: { role: string; content: string }[]
-): Promise<string> {
+async function callChatBackend(messages: { role: string; content: string }[]): Promise<string> {
   if (isNvidiaProxyConfigured()) {
     return callNvidiaProxyChat(messages, { maxTokens: MAX_TOKENS });
   }

--- a/src/lib/workers-ai-client.ts
+++ b/src/lib/workers-ai-client.ts
@@ -29,8 +29,7 @@ export function requireWorkersAiConfig(): { accountId: string; apiToken: string 
   const accountId = process.env.CLOUDFLARE_ACCOUNT_ID;
   // CLOUDFLARE_WORKERS_AI_TOKEN is a scoped Workers AI-only token (preferred).
   // Falls back to the broad CLOUDFLARE_API_TOKEN if only that is set.
-  const apiToken =
-    process.env.CLOUDFLARE_WORKERS_AI_TOKEN || process.env.CLOUDFLARE_API_TOKEN;
+  const apiToken = process.env.CLOUDFLARE_WORKERS_AI_TOKEN || process.env.CLOUDFLARE_API_TOKEN;
   if (!accountId || !apiToken) {
     const err = new Error("Workers AI not configured");
     err.name = "UnauthorizedException";


### PR DESCRIPTION
## Summary

- Add `tags: tag:k8s` to 16 OAuth Tailscale steps that were missing it — without the tag, ACL policy may reject the ephemeral node, causing kubectl calls to fail intermittently
- `wire-all-ai-backends`: replace `kubectl patch op:add` (appends duplicates on re-run) with `kubectl set env --from=secret --keys=...` (idempotent replace); convert push-path trigger to `workflow_dispatch`
- `postiz-wire-ai-proxy`: replace `kubectl patch op:add` with strategic-merge patch so `OPENAI_API_KEY` is upserted by name
- `cloudflared-restart`: upgrade `tailscale/github-action` from un-pinned `@v0.3.0` to pinned `@0263d9e6...` (v3.2.4); fix secret names from `TAILSCALE_OAUTH_CLIENT_ID`/`TAILSCALE_OAUTH_SECRET` → canonical `TS_CLIENT_ID`/`TS_CLIENT_SECRET`; add `tags: tag:k8s`

## Test plan

- [ ] Verify no CI failures from workflow syntax
- [ ] Re-run `wire-all-ai-backends` manually — should succeed without "hides previous definition" warnings and rollout timeout

🤖 Generated with [Claude Code](https://claude.com/claude-code)