### PR TITLE
feat(analytics): social engagement + lead attribution dashboard

### DIFF
--- a/infrastructure/n8n/workflows/README.md
+++ b/infrastructure/n8n/workflows/README.md
@@ -160,6 +160,55 @@ curl -sk -X POST \
   https://cloudless.gr/api/webhooks/n8n/trigger
 ```
 
+## Postiz Plugs (UI-only, no API)
+
+Plugs are Postiz's built-in auto-repost / auto-comment automation engine.
+They are configured entirely through the Postiz UI — **no Public API**.
+
+### Global Plugs (account-wide)
+
+1. Open `postiz.cloudless.gr` → Settings → Plugs → **Global Plugs**.
+2. Create rules like:
+   - "When a post hits 10 likes, repost it from LinkedIn Page"
+   - "Auto-comment a follow-up CTA 2 hours after publish"
+   - "Repost from X account to Bluesky account after 4 hours"
+
+### Post Plugs (per-post)
+
+1. When composing/scheduling a post, click the **Plugs** tab.
+2. Add per-post automation:
+   - "Repost from other connected account in 6 hours"
+   - "Add follow-up comment with link after 1 hour"
+
+### Recommended setup for cloudless.gr
+
+| Plug | Type | Config |
+|------|------|--------|
+| LinkedIn → X repost | Global | When LinkedIn post > 5 likes, repost to X after 2h |
+| X → Bluesky cross-post | Global | Auto-repost X posts to Bluesky after 1h |
+| CTA follow-up | Global | Auto-comment with services link 3h after publish |
+| Blog amplify | Post | Repost blog shares from personal → page account after 4h |
+
+### agent-media (AI UGC video generation)
+
+[gitroomhq/agent-media](https://github.com/gitroomhq/agent-media) is an
+MCP server from the Postiz team that generates AI UGC videos from text
+descriptions or photos + scripts. It produces captioned, lip-synced vertical
+video ready for TikTok/Instagram/X Reels.
+
+To evaluate, add to `mcp.json`:
+```json
+"agent-media": {
+  "command": "npx",
+  "args": ["-y", "agent-media"],
+  "env": { "POSTIZ_API_KEY": "..." }
+}
+```
+
+Pipeline: blog publish → agent-media generates 30s vertical video →
+Postiz schedules it to TikTok + IG Reels + X. Requires GPU-backed API
+credits; evaluate cost before enabling.
+
 ## Why workflows-as-JSON
 
 Importing JSON keeps the workflows reviewable in git (you can diff

--- a/scripts/etl/postiz-to-r2.mjs
+++ b/scripts/etl/postiz-to-r2.mjs
@@ -41,6 +41,13 @@ const postSchema = new ParquetSchema({
 	released_at: { type: "UTF8", optional: true },
 	content_length: { type: "INT32", optional: true },
 	created_at: { type: "UTF8", optional: true },
+	likes: { type: "INT32", optional: true },
+	comments: { type: "INT32", optional: true },
+	impressions: { type: "INT32", optional: true },
+	shares: { type: "INT32", optional: true },
+	clicks: { type: "INT32", optional: true },
+	engagement_rate: { type: "FLOAT", optional: true },
+	snapshot_date: { type: "UTF8", optional: true },
 });
 
 const integrationSchema = new ParquetSchema({
@@ -85,18 +92,29 @@ async function syncPosts() {
 			accum.push(p);
 		}
 	}
-	const rows = accum.map((p) => ({
-		post_id: String(p.id ?? ""),
-		integration_id: String(p.integration?.id ?? p.integrationId ?? ""),
-		integration_name: String(p.integration?.name ?? ""),
-		platform: String(p.integration?.providerIdentifier ?? p.providerIdentifier ?? ""),
-		state: String(p.state ?? ""),
-		release_url: String(p.releaseURL ?? ""),
-		publish_date: String(p.publishDate ?? ""),
-		released_at: String(p.releasedAt ?? ""),
-		content_length: typeof p.content === "string" ? p.content.length : 0,
-		created_at: String(p.createdAt ?? ""),
-	}));
+	const snapshotDate = new Date().toISOString().slice(0, 10);
+	const rows = accum.map((p) => {
+		const a = p.analytics || {};
+		return {
+			post_id: String(p.id ?? ""),
+			integration_id: String(p.integration?.id ?? p.integrationId ?? ""),
+			integration_name: String(p.integration?.name ?? ""),
+			platform: String(p.integration?.providerIdentifier ?? p.providerIdentifier ?? ""),
+			state: String(p.state ?? ""),
+			release_url: String(p.releaseURL ?? ""),
+			publish_date: String(p.publishDate ?? ""),
+			released_at: String(p.releasedAt ?? ""),
+			content_length: typeof p.content === "string" ? p.content.length : 0,
+			created_at: String(p.createdAt ?? ""),
+			likes: Number(a.likes ?? a.reactions ?? 0),
+			comments: Number(a.comments ?? a.replies ?? 0),
+			impressions: Number(a.impressions ?? a.views ?? 0),
+			shares: Number(a.shares ?? a.reposts ?? a.retweets ?? 0),
+			clicks: Number(a.clicks ?? a.linkClicks ?? 0),
+			engagement_rate: Number(a.engagementRate ?? 0),
+			snapshot_date: snapshotDate,
+		};
+	});
 	const local = "/tmp/postiz-posts.parquet";
 	const body = await writeParquet(rows, postSchema, local);
 	await uploadToR2("lake/postiz-posts/posts.parquet", body);

--- a/src/app/[locale]/admin/AdminLayoutClient.tsx
+++ b/src/app/[locale]/admin/AdminLayoutClient.tsx
@@ -44,6 +44,7 @@ import {
   Briefcase,
   HelpCircle,
   Package,
+  Share2,
   type LucideIcon,
 } from "lucide-react";
 
@@ -67,6 +68,7 @@ const adminGroups: AdminGroup[] = [
       { href: "/admin/analytics/unified", label: "Unified View", Icon: Layers },
       { href: "/admin/analytics/seo", label: "SEO", Icon: BarChart2 },
       { href: "/admin/analytics/funnel", label: "Funnel", Icon: Filter },
+      { href: "/admin/analytics/social", label: "Social", Icon: Share2 },
       { href: "/admin/kpi", label: "KPI", Icon: Gauge },
       { href: "/admin/cost", label: "Cost", Icon: CircleDollarSign },
     ],

--- a/src/app/[locale]/admin/analytics/social/page.tsx
+++ b/src/app/[locale]/admin/analytics/social/page.tsx
@@ -1,0 +1,347 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import { fetchWithAuth } from "@/lib/fetch-with-auth";
+import { Link } from "@/i18n/navigation";
+
+interface ChannelSummary {
+  id: string;
+  name: string;
+  platform: string;
+  metrics: Record<string, number>;
+  percentageChanges: Record<string, number>;
+}
+
+interface PostPerformance {
+  id: string;
+  platform: string;
+  content: string;
+  publishDate: string;
+  likes: number;
+  comments: number;
+  impressions: number;
+  engagement: number;
+}
+
+interface SummaryData {
+  channels: ChannelSummary[];
+  topPosts: PostPerformance[];
+  totals: Record<string, number>;
+  lookbackDays: number;
+}
+
+interface AttributionRow {
+  utm_source: string;
+  utm_campaign: string;
+  platform: string;
+  sessions: number;
+  signups: number;
+  leads: number;
+  purchases: number;
+  revenue: number;
+}
+
+interface AttributionData {
+  rows: AttributionRow[];
+  totals: {
+    sessions: number;
+    leads: number;
+    signups: number;
+    revenue: number;
+    conversionRate: number;
+  };
+}
+
+const PLATFORM_LABELS: Record<string, string> = {
+  linkedin: "LinkedIn",
+  "linkedin-page": "LinkedIn Page",
+  x: "X (Twitter)",
+  facebook: "Facebook",
+  instagram: "Instagram",
+  threads: "Threads",
+  bluesky: "Bluesky",
+  tiktok: "TikTok",
+  youtube: "YouTube",
+};
+
+function platformLabel(p: string) {
+  return PLATFORM_LABELS[p] ?? p;
+}
+
+function formatNum(n: number): string {
+  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`;
+  if (n >= 1_000) return `${(n / 1_000).toFixed(1)}K`;
+  return String(n);
+}
+
+function ChangeBadge({ pct }: { pct: number }) {
+  if (!Number.isFinite(pct)) return null;
+  const positive = pct >= 0;
+  return (
+    <span
+      className={`ml-1 inline-block rounded-full px-1.5 py-0.5 text-xs font-medium ${
+        positive
+          ? "bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-400"
+          : "bg-red-100 text-red-800 dark:bg-red-900/30 dark:text-red-400"
+      }`}
+    >
+      {positive ? "+" : ""}
+      {pct.toFixed(1)}%
+    </span>
+  );
+}
+
+export default function SocialAnalyticsPage() {
+  const [days, setDays] = useState(30);
+  const [data, setData] = useState<SummaryData | null>(null);
+  const [attribution, setAttribution] = useState<AttributionData | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const [engRes, attrRes] = await Promise.all([
+        fetchWithAuth(`/api/admin/postiz/analytics/summary?days=${days}`),
+        fetchWithAuth(`/api/admin/analytics/social-attribution?days=${days}`),
+      ]);
+      if (engRes.status === 503) {
+        setError("Postiz not configured");
+        setData(null);
+      } else if (engRes.ok) {
+        setData(await engRes.json());
+      } else {
+        setError(`Engagement API error: ${engRes.status}`);
+      }
+      if (attrRes.ok) {
+        setAttribution(await attrRes.json());
+      } else if (attrRes.status !== 503) {
+        setAttribution(null);
+      }
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Network error");
+    } finally {
+      setLoading(false);
+    }
+  }, [days]);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center justify-between">
+        <div>
+          <h1 className="text-xl font-semibold">Social Analytics</h1>
+          <p className="text-sm text-gray-500 dark:text-gray-400">
+            Engagement metrics from connected Postiz channels
+          </p>
+        </div>
+        <div className="flex items-center gap-2">
+          <select
+            value={days}
+            onChange={(e) => setDays(Number(e.target.value))}
+            className="rounded border border-gray-300 px-2 py-1.5 text-sm dark:border-gray-600 dark:bg-gray-800"
+          >
+            {[7, 14, 30, 60, 90].map((d) => (
+              <option key={d} value={d}>
+                {d} days
+              </option>
+            ))}
+          </select>
+          <button
+            type="button"
+            onClick={() => void load()}
+            disabled={loading}
+            className="rounded bg-blue-600 px-3 py-1.5 text-sm font-medium text-white disabled:opacity-50"
+          >
+            {loading ? "Loading…" : "Refresh"}
+          </button>
+        </div>
+      </div>
+
+      {error && (
+        <div className="rounded border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-800 dark:border-red-800 dark:bg-red-900/20 dark:text-red-300">
+          {error}
+        </div>
+      )}
+
+      {data && (
+        <>
+          {/* KPI cards */}
+          {Object.keys(data.totals).length > 0 && (
+            <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
+              {Object.entries(data.totals).map(([label, value]) => (
+                <div
+                  key={label}
+                  className="rounded-lg border border-gray-200 bg-white p-4 dark:border-gray-700 dark:bg-gray-800"
+                >
+                  <div className="text-xs font-medium uppercase tracking-wide text-gray-500 dark:text-gray-400">
+                    {label}
+                  </div>
+                  <div className="mt-1 text-2xl font-bold tabular-nums">{formatNum(value)}</div>
+                </div>
+              ))}
+            </div>
+          )}
+
+          {/* Channel breakdown */}
+          {data.channels.length > 0 && (
+            <div>
+              <h2 className="mb-3 text-sm font-semibold uppercase tracking-wide text-gray-500 dark:text-gray-400">
+                Channels
+              </h2>
+              <div className="overflow-x-auto rounded-lg border border-gray-200 dark:border-gray-700">
+                <table className="min-w-full text-sm">
+                  <thead className="bg-gray-50 dark:bg-gray-800">
+                    <tr>
+                      <th className="px-4 py-2 text-left font-medium">Channel</th>
+                      {data.channels[0] &&
+                        Object.keys(data.channels[0].metrics).map((k) => (
+                          <th key={k} className="px-4 py-2 text-right font-medium">
+                            {k}
+                          </th>
+                        ))}
+                    </tr>
+                  </thead>
+                  <tbody className="divide-y divide-gray-100 dark:divide-gray-700">
+                    {data.channels.map((ch) => (
+                      <tr key={ch.id} className="hover:bg-gray-50 dark:hover:bg-gray-800/50">
+                        <td className="px-4 py-2 font-medium">
+                          {ch.name}
+                          <span className="ml-1 text-xs text-gray-400">
+                            {platformLabel(ch.platform)}
+                          </span>
+                        </td>
+                        {Object.entries(ch.metrics).map(([k, v]) => (
+                          <td key={k} className="px-4 py-2 text-right tabular-nums">
+                            {formatNum(v)}
+                            <ChangeBadge pct={ch.percentageChanges[k] ?? 0} />
+                          </td>
+                        ))}
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            </div>
+          )}
+
+          {/* Top posts */}
+          {data.topPosts.length > 0 && (
+            <div>
+              <h2 className="mb-3 text-sm font-semibold uppercase tracking-wide text-gray-500 dark:text-gray-400">
+                Top Posts
+              </h2>
+              <div className="space-y-2">
+                {data.topPosts.map((post, i) => (
+                  <div
+                    key={post.id}
+                    className="flex items-start gap-3 rounded-lg border border-gray-200 p-3 dark:border-gray-700"
+                  >
+                    <span className="flex h-6 w-6 shrink-0 items-center justify-center rounded-full bg-blue-100 text-xs font-bold text-blue-800 dark:bg-blue-900/30 dark:text-blue-300">
+                      {i + 1}
+                    </span>
+                    <div className="min-w-0 flex-1">
+                      <div className="flex items-center gap-2 text-xs text-gray-500 dark:text-gray-400">
+                        <span className="font-medium">{platformLabel(post.platform)}</span>
+                        <span>{post.publishDate ? new Date(post.publishDate).toLocaleDateString() : ""}</span>
+                      </div>
+                      <p className="mt-0.5 line-clamp-2 text-sm">{post.content || "(no text)"}</p>
+                      <div className="mt-1.5 flex gap-4 text-xs text-gray-500 dark:text-gray-400">
+                        <span>{formatNum(post.impressions)} impressions</span>
+                        <span>{formatNum(post.likes)} likes</span>
+                        <span>{formatNum(post.comments)} comments</span>
+                      </div>
+                    </div>
+                  </div>
+                ))}
+              </div>
+            </div>
+          )}
+
+          {data.channels.length === 0 && (
+            <p className="text-sm text-gray-500">
+              No channels connected.{" "}
+              <Link href="/admin/postiz" className="text-blue-600 underline">
+                Connect channels
+              </Link>{" "}
+              first.
+            </p>
+          )}
+        </>
+      )}
+
+      {/* Social → Lead Attribution */}
+      {attribution && attribution.rows.length > 0 && (
+        <div>
+          <h2 className="mb-3 text-sm font-semibold uppercase tracking-wide text-gray-500 dark:text-gray-400">
+            Social → Lead Attribution
+          </h2>
+
+          <div className="mb-4 grid grid-cols-2 gap-3 sm:grid-cols-5">
+            <div className="rounded-lg border border-gray-200 bg-white p-3 dark:border-gray-700 dark:bg-gray-800">
+              <div className="text-xs font-medium uppercase text-gray-500">Sessions</div>
+              <div className="mt-1 text-xl font-bold tabular-nums">
+                {formatNum(attribution.totals.sessions)}
+              </div>
+            </div>
+            <div className="rounded-lg border border-gray-200 bg-white p-3 dark:border-gray-700 dark:bg-gray-800">
+              <div className="text-xs font-medium uppercase text-gray-500">Leads</div>
+              <div className="mt-1 text-xl font-bold tabular-nums">
+                {formatNum(attribution.totals.leads)}
+              </div>
+            </div>
+            <div className="rounded-lg border border-gray-200 bg-white p-3 dark:border-gray-700 dark:bg-gray-800">
+              <div className="text-xs font-medium uppercase text-gray-500">Signups</div>
+              <div className="mt-1 text-xl font-bold tabular-nums">
+                {formatNum(attribution.totals.signups)}
+              </div>
+            </div>
+            <div className="rounded-lg border border-gray-200 bg-white p-3 dark:border-gray-700 dark:bg-gray-800">
+              <div className="text-xs font-medium uppercase text-gray-500">Revenue</div>
+              <div className="mt-1 text-xl font-bold tabular-nums">
+                &euro;{formatNum(attribution.totals.revenue)}
+              </div>
+            </div>
+            <div className="rounded-lg border border-gray-200 bg-white p-3 dark:border-gray-700 dark:bg-gray-800">
+              <div className="text-xs font-medium uppercase text-gray-500">Conv. Rate</div>
+              <div className="mt-1 text-xl font-bold tabular-nums">
+                {attribution.totals.conversionRate.toFixed(1)}%
+              </div>
+            </div>
+          </div>
+
+          <div className="overflow-x-auto rounded-lg border border-gray-200 dark:border-gray-700">
+            <table className="min-w-full text-sm">
+              <thead className="bg-gray-50 dark:bg-gray-800">
+                <tr>
+                  <th className="px-4 py-2 text-left font-medium">Source</th>
+                  <th className="px-4 py-2 text-left font-medium">Campaign</th>
+                  <th className="px-4 py-2 text-left font-medium">Platform</th>
+                  <th className="px-4 py-2 text-right font-medium">Sessions</th>
+                  <th className="px-4 py-2 text-right font-medium">Leads</th>
+                  <th className="px-4 py-2 text-right font-medium">Revenue</th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-gray-100 dark:divide-gray-700">
+                {attribution.rows.map((r, i) => (
+                  <tr key={i} className="hover:bg-gray-50 dark:hover:bg-gray-800/50">
+                    <td className="px-4 py-2">{r.utm_source}</td>
+                    <td className="px-4 py-2 text-gray-500">{r.utm_campaign}</td>
+                    <td className="px-4 py-2 text-gray-500">{r.platform}</td>
+                    <td className="px-4 py-2 text-right tabular-nums">{r.sessions}</td>
+                    <td className="px-4 py-2 text-right tabular-nums">{Number(r.leads) + Number(r.signups)}</td>
+                    <td className="px-4 py-2 text-right tabular-nums">&euro;{Number(r.revenue).toFixed(0)}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/app/api/admin/analytics/social-attribution/route.ts
+++ b/src/app/api/admin/analytics/social-attribution/route.ts
@@ -1,0 +1,60 @@
+import { NextRequest, NextResponse } from "next/server";
+import { requireAdmin } from "@/lib/api-auth";
+import { getAuthDbFromEnv } from "@/lib/auth-d1";
+
+export const dynamic = "force-dynamic";
+
+export async function GET(req: NextRequest) {
+  const auth = await requireAdmin(req);
+  if (!auth.ok) return auth.response;
+
+  const url = new URL(req.url);
+  const days = Math.min(Number(url.searchParams.get("days") || "90"), 365);
+  const since = Math.floor((Date.now() - days * 86400_000) / 1000);
+
+  const db = getAuthDbFromEnv();
+  if (!db) {
+    return NextResponse.json({ error: "analytics_db_unavailable" }, { status: 503 });
+  }
+
+  const result = await db
+    .prepare(
+      `SELECT COALESCE(source, '(direct)') AS utm_source,
+              COALESCE(campaign, '(none)') AS utm_campaign,
+              COALESCE(json_extract(properties_json, '$.utm_content'), '(none)') AS platform,
+              COUNT(DISTINCT CASE WHEN event = 'page_view' THEN session_id END) AS sessions,
+              COUNT(DISTINCT CASE WHEN event = 'signup' THEN user_id END) AS signups,
+              COUNT(DISTINCT CASE WHEN event = 'contact_form' THEN session_id END) AS leads,
+              SUM(CASE WHEN event = 'purchase' THEN 1 ELSE 0 END) AS purchases,
+              SUM(CASE WHEN event = 'purchase'
+                       THEN COALESCE(json_extract(properties_json, '$.amount'), 0)
+                       ELSE 0 END) AS revenue
+       FROM analytics_events
+       WHERE created_at >= ?
+         AND medium = 'social'
+       GROUP BY 1, 2, 3
+       ORDER BY sessions DESC
+       LIMIT 50`
+    )
+    .bind(since)
+    .all<Record<string, string | number | null>>();
+
+  const rows = result.results ?? [];
+
+  const totalSessions = rows.reduce((s, r) => s + Number(r.sessions ?? 0), 0);
+  const totalLeads = rows.reduce((s, r) => s + Number(r.leads ?? 0), 0);
+  const totalSignups = rows.reduce((s, r) => s + Number(r.signups ?? 0), 0);
+  const totalRevenue = rows.reduce((s, r) => s + Number(r.revenue ?? 0), 0);
+
+  return NextResponse.json({
+    rows,
+    totals: {
+      sessions: totalSessions,
+      leads: totalLeads,
+      signups: totalSignups,
+      revenue: totalRevenue,
+      conversionRate: totalSessions > 0 ? ((totalLeads + totalSignups) / totalSessions) * 100 : 0,
+    },
+    days,
+  });
+}

--- a/src/app/api/admin/postiz/analytics/summary/route.ts
+++ b/src/app/api/admin/postiz/analytics/summary/route.ts
@@ -1,0 +1,124 @@
+import { NextRequest, NextResponse } from "next/server";
+import { requireAdmin } from "@/lib/api-auth";
+import {
+  getIntegrationAnalytics,
+  listPostizIntegrations,
+  listPosts,
+  getPostStats,
+  PostizNotConfiguredError,
+} from "@/lib/postiz";
+
+export const dynamic = "force-dynamic";
+
+interface ChannelSummary {
+  id: string;
+  name: string;
+  platform: string;
+  metrics: Record<string, number>;
+  percentageChanges: Record<string, number>;
+}
+
+interface PostPerformance {
+  id: string;
+  platform: string;
+  content: string;
+  publishDate: string;
+  likes: number;
+  comments: number;
+  impressions: number;
+  engagement: number;
+}
+
+export async function GET(req: NextRequest) {
+  const auth = await requireAdmin(req);
+  if (!auth.ok) return auth.response;
+
+  const url = new URL(req.url);
+  const lookback = Math.min(Number(url.searchParams.get("days") || "30"), 90) as
+    | 7
+    | 14
+    | 30
+    | 60
+    | 90;
+
+  try {
+    const integrations = await listPostizIntegrations();
+    if (!integrations.length) {
+      return NextResponse.json({ channels: [], topPosts: [], totals: {} });
+    }
+
+    const channels: ChannelSummary[] = [];
+    const totals: Record<string, number> = {};
+
+    for (const integ of integrations) {
+      if (integ.disabled) continue;
+      try {
+        const metrics = await getIntegrationAnalytics(integ.id, lookback);
+        const channelMetrics: Record<string, number> = {};
+        const channelChanges: Record<string, number> = {};
+        for (const m of metrics) {
+          const latest = m.data.at(-1);
+          const val = Number(latest?.total ?? 0);
+          channelMetrics[m.label] = val;
+          channelChanges[m.label] = m.percentageChange;
+          totals[m.label] = (totals[m.label] ?? 0) + val;
+        }
+        channels.push({
+          id: integ.id,
+          name: integ.name ?? "",
+          platform: integ.identifier ?? "",
+          metrics: channelMetrics,
+          percentageChanges: channelChanges,
+        });
+      } catch {
+        // skip channels that don't expose analytics
+      }
+    }
+
+    const since = new Date(Date.now() - lookback * 86400_000).toISOString();
+    const until = new Date(Date.now() + 86400_000).toISOString();
+    let topPosts: PostPerformance[] = [];
+
+    try {
+      const posts = await listPosts(since, until);
+      const published = posts.filter((p) => p.state === "PUBLISHED" || p.releaseId);
+      const withStats: PostPerformance[] = [];
+
+      for (const post of published.slice(0, 20)) {
+        try {
+          const stats = await getPostStats(post.id, lookback <= 14 ? 14 : 30);
+          const metricMap: Record<string, number> = {};
+          for (const s of stats) {
+            const latest = s.data.at(-1);
+            metricMap[s.label.toLowerCase()] = Number(latest?.total ?? 0);
+          }
+          withStats.push({
+            id: post.id,
+            platform:
+              post.integration?.providerIdentifier ?? post.integration?.identifier ?? "",
+            content: (post.content ?? "").slice(0, 120),
+            publishDate: post.publishDate ?? "",
+            likes: metricMap.likes ?? metricMap.reactions ?? 0,
+            comments: metricMap.comments ?? metricMap.replies ?? 0,
+            impressions: metricMap.impressions ?? metricMap.views ?? 0,
+            engagement:
+              (metricMap.likes ?? 0) + (metricMap.comments ?? 0) + (metricMap.shares ?? 0),
+          });
+        } catch {
+          // skip posts without analytics
+        }
+      }
+
+      topPosts = withStats.sort((a, b) => b.engagement - a.engagement).slice(0, 10);
+    } catch {
+      // posts listing failed
+    }
+
+    return NextResponse.json({ channels, topPosts, totals, lookbackDays: lookback });
+  } catch (err) {
+    if (err instanceof PostizNotConfiguredError) {
+      return NextResponse.json({ error: "postiz_not_configured" }, { status: 503 });
+    }
+    throw err;
+  }
+}


### PR DESCRIPTION
## Summary
- New `/admin/analytics/social` page with three sections: channel engagement KPIs, top posts by engagement, and social→lead attribution (UTM-filtered)
- `/api/admin/postiz/analytics/summary` aggregates per-channel and per-post analytics from Postiz
- `/api/admin/analytics/social-attribution` queries D1 `analytics_events` for `medium=social` traffic, showing sessions→leads→revenue conversion
- ETL (`postiz-to-r2.mjs`) now captures likes, comments, impressions, shares, clicks, engagement_rate, and snapshot_date per post
- Plugs setup guide and agent-media MCP evaluation documented in workflows README
- "Social" nav link added to admin sidebar

## Test plan
- [x] TypeScript compiles clean
- [ ] Visit `/admin/analytics/social` — verify channel metrics load
- [ ] Verify attribution table shows UTM-tagged social traffic
- [ ] Run `pnpm etl:postiz` — verify parquet includes new analytics columns
- [ ] Configure Plugs in Postiz UI per the README guide

🤖 Generated with [Claude Code](https://claude.com/claude-code)