### PR TITLE
feat(postiz): add free social pipeline MCP servers

### DIFF
--- a/mcp.json
+++ b/mcp.json
@@ -32,6 +32,25 @@
       },
       "autoStart": true
     },
+    "prompt-to-asset": {
+      "command": "npx",
+      "args": ["-y", "prompt-to-asset"],
+      "autoStart": false
+    },
+    "postlint": {
+      "command": "npx",
+      "args": ["-y", "postlint-mcp"],
+      "autoStart": false
+    },
+    "bluesky": {
+      "command": "npx",
+      "args": ["-y", "@morinokami/mcp-server-bluesky"],
+      "env": {
+        "BLUESKY_IDENTIFIER": "${BLUESKY_IDENTIFIER}",
+        "BLUESKY_APP_PASSWORD": "${BLUESKY_APP_PASSWORD}"
+      },
+      "autoStart": false
+    },
     "postiz": {
       "command": "postiz-mcp",
       "env": {


### PR DESCRIPTION
## Summary
- Add `prompt-to-asset` — free AI image generation (OG images, social graphics) via Pollinations/Stable Horde. Zero API keys needed
- Add `postlint-mcp` — validates post length per platform before publishing. No auth, no network calls, pure local validation
- Add `mcp-server-bluesky` — direct AT Protocol access for Bluesky (post, reply, search, feeds). Needs `BLUESKY_IDENTIFIER` + `BLUESKY_APP_PASSWORD`

All servers set to `autoStart: false` — opt-in per session.

## Test plan
- [x] Valid JSON (`mcp.json` parses clean)
- [ ] Start session with `prompt-to-asset` → generate a test social graphic
- [ ] Start session with `postlint` → validate a 300-char post for X (should fail)
- [ ] Set Bluesky creds → `postlint` a post → publish via Bluesky MCP

🤖 Generated with [Claude Code](https://claude.com/claude-code)