### PR TITLE
fix(ci): update AI proxy smoke test for new model

### DIFF
--- a/.github/workflows/deploy-postiz-ai-proxy.yml
+++ b/.github/workflows/deploy-postiz-ai-proxy.yml
@@ -40,12 +40,9 @@ jobs:
         run: |
           RESULT=$(curl -sf https://postiz-ai-proxy.baltzakis-themis.workers.dev/v1/models)
           echo "$RESULT"
-          echo "$RESULT" | grep -q "nemotron-3.5-lightning" \
-            && echo "✓ chatbot model present" \
-            || (echo "✗ chatbot model missing" && exit 1)
-          echo "$RESULT" | grep -q "llama-3.3-70b" \
-            && echo "✓ postiz model present" \
-            || (echo "✗ postiz model missing" && exit 1)
+          echo "$RESULT" | grep -q "nemotron-3-super-120b" \
+            && echo "✓ model present" \
+            || (echo "✗ model missing" && exit 1)
 
       - name: Report result
         if: always()


### PR DESCRIPTION
## Summary
- Smoke test in `deploy-postiz-ai-proxy.yml` was grepping for old model names (`nemotron-3.5-lightning`, `llama-3.3-70b`)
- Both model slots now use `nemotron-3-super-120b-a12b` — updated the grep to match

## Test plan
- [x] `/v1/models` returns `nemotron-3-super-120b` — grep will pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)