### PR TITLE
fix: restore cf:build + base64 PEM support + remove junk file

### DIFF
--- a/__tests__/google-sa-key.test.ts
+++ b/__tests__/google-sa-key.test.ts
@@ -41,6 +41,13 @@ describe("normalizeGooglePrivateKeyPem", () => {
     expect(normalizeGooglePrivateKeyPem(json)).toBe(pem.trim());
   });
 
+  it("decodes base64-encoded PEM", () => {
+    const pem = samplePkcs8Pem();
+    const b64 = Buffer.from(pem).toString("base64");
+    const out = normalizeGooglePrivateKeyPem(b64);
+    expect(out).toContain("-----BEGIN PRIVATE KEY-----");
+  });
+
   it("rejects truncated keys", () => {
     expect(() =>
       normalizeGooglePrivateKeyPem("-----BEGIN PRIVATE KEY-----\nabc\n-----END PRIVATE KEY-----")

--- a/package.json
+++ b/package.json
@@ -129,7 +129,7 @@
     "cf:deploy": "wrangler deploy",
     "cf:deploy:free": "wrangler deploy --config wrangler-cloudflare-free.json",
     "cloudflare-build": "pnpm exec opennextjs-cloudflare build --openNextConfigPath open-next.config.cloudflare.ts",
-    "cf:build": "next build",
+    "cf:build": "pnpm exec opennextjs-cloudflare build --openNextConfigPath open-next.config.cloudflare.ts",
     "cf:build:opennext": "pnpm exec opennextjs-cloudflare build --openNextConfigPath open-next.config.cloudflare.ts",
     "cf:deploy:full": "pnpm cf:build && pnpm cf:r2:upload-static && pnpm cf:deploy",
     "cf:deploy:staging": "wrangler deploy -c wrangler.staging.jsonc",

--- a/src/lib/google-sa-key.ts
+++ b/src/lib/google-sa-key.ts
@@ -35,6 +35,11 @@ export function normalizeGooglePrivateKeyPem(raw: string): string {
     key = key.slice(1, -1).trim();
   }
 
+  // Base64-encoded PEM (common in GH Actions / k8s secrets)
+  if (!key.includes("-----") && /^[A-Za-z0-9+/=\s]+$/.test(key) && key.length > 100) {
+    key = Buffer.from(key, "base64").toString("utf8").trim();
+  }
+
   key = key.replace(/\\n/g, "\n").replace(/\r\n/g, "\n").replace(/\r/g, "\n").trim();
 
   if (!/-----BEGIN (RSA )?PRIVATE KEY-----/.test(key)) {


### PR DESCRIPTION
## Summary
Replaces stale [PR #1683](https://github.com/Themis128/cloudless.gr/pull/1683) (closed — merge conflicts + SonarCloud failure).

- **`cf:build`**: was `"next build"` — SST deploy needs `opennextjs-cloudflare build` to produce `.open-next/worker.js`
- **`google-sa-key.ts`**: now decodes base64-encoded PEMs (common in GH Actions / k8s secrets) before the existing `\\n` unescape
- **`audit-links.zip`**: removed empty junk file accidentally committed

## Test plan
- [x] `__tests__/google-sa-key.test.ts` — 8/8 passing (new base64 test added)
- [ ] Re-run SST Cloudflare Infra Deploy via workflow_dispatch after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)