### PR TITLE
feat(n8n): wire Stripe/Kuma/Sentry webhooks → n8n automation

### DIFF
--- a/infrastructure/n8n/workflows/kuma-espocrm.json
+++ b/infrastructure/n8n/workflows/kuma-espocrm.json
@@ -1,0 +1,92 @@
+{
+  "name": "Kuma alert → EspoCRM incident ticket",
+  "nodes": [
+    {
+      "parameters": {
+        "httpMethod": "POST",
+        "path": "kuma-alert",
+        "options": {}
+      },
+      "name": "Webhook (kuma-alert)",
+      "type": "n8n-nodes-base.webhook",
+      "typeVersion": 1,
+      "position": [240, 300],
+      "webhookId": "kuma-alert"
+    },
+    {
+      "parameters": {
+        "conditions": {
+          "string": [
+            {
+              "value1": "={{ $json.status }}",
+              "operation": "equal",
+              "value2": "DOWN"
+            }
+          ]
+        }
+      },
+      "name": "Is DOWN?",
+      "type": "n8n-nodes-base.if",
+      "typeVersion": 1,
+      "position": [460, 300]
+    },
+    {
+      "parameters": {
+        "url": "={{ $env.ESPOCRM_BASE_URL || 'https://espocrm.cloudless.gr' }}/api/v1/Case",
+        "method": "POST",
+        "sendHeaders": true,
+        "headerParameters": {
+          "parameters": [
+            { "name": "X-Api-Key",    "value": "={{ $env.ESPOCRM_API_KEY }}" },
+            { "name": "Content-Type", "value": "application/json" }
+          ]
+        },
+        "sendBody": true,
+        "bodyParametersJson": "={{ JSON.stringify({ name: 'Uptime Alert: ' + $json.name, status: 'New', priority: 'High', description: $json.msg + ($json.url ? '\\nURL: ' + $json.url : '') }) }}",
+        "options": { "timeout": 8000 }
+      },
+      "name": "EspoCRM — create incident Case",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.1,
+      "position": [680, 200],
+      "continueOnFail": true
+    },
+    {
+      "parameters": {
+        "respondWith": "json",
+        "responseBody": "={{ JSON.stringify({ ok: true, caseCreated: true, monitor: $json.name }) }}"
+      },
+      "name": "Respond (case created)",
+      "type": "n8n-nodes-base.respondToWebhook",
+      "typeVersion": 1,
+      "position": [900, 200]
+    },
+    {
+      "parameters": {
+        "respondWith": "json",
+        "responseBody": "={{ JSON.stringify({ ok: true, skipped: true, status: $json.status }) }}"
+      },
+      "name": "Respond (not DOWN)",
+      "type": "n8n-nodes-base.respondToWebhook",
+      "typeVersion": 1,
+      "position": [680, 400]
+    }
+  ],
+  "connections": {
+    "Webhook (kuma-alert)": {
+      "main": [[{ "node": "Is DOWN?", "type": "main", "index": 0 }]]
+    },
+    "Is DOWN?": {
+      "main": [
+        [{ "node": "EspoCRM — create incident Case", "type": "main", "index": 0 }],
+        [{ "node": "Respond (not DOWN)",             "type": "main", "index": 0 }]
+      ]
+    },
+    "EspoCRM — create incident Case": {
+      "main": [[{ "node": "Respond (case created)", "type": "main", "index": 0 }]]
+    }
+  },
+  "active": false,
+  "settings": { "executionOrder": "v1" },
+  "tags": [{ "name": "infra" }, { "name": "espocrm" }, { "name": "cloudless" }]
+}

--- a/infrastructure/n8n/workflows/sentry-espocrm.json
+++ b/infrastructure/n8n/workflows/sentry-espocrm.json
@@ -1,0 +1,78 @@
+{
+  "name": "Sentry error → EspoCRM bug ticket",
+  "nodes": [
+    {
+      "parameters": {
+        "httpMethod": "POST",
+        "path": "sentry-alert",
+        "options": {}
+      },
+      "name": "Webhook (sentry-alert)",
+      "type": "n8n-nodes-base.webhook",
+      "typeVersion": 1,
+      "position": [240, 300],
+      "webhookId": "sentry-alert"
+    },
+    {
+      "parameters": {
+        "values": {
+          "string": [
+            { "name": "title",     "value": "={{ $json.title || 'Sentry alert' }}" },
+            { "name": "severity",  "value": "={{ $json.severity || 'info' }}" },
+            { "name": "message",   "value": "={{ $json.message || '' }}" },
+            { "name": "permalink", "value": "={{ $json.permalink || '' }}" }
+          ]
+        }
+      },
+      "name": "Extract issue fields",
+      "type": "n8n-nodes-base.set",
+      "typeVersion": 2,
+      "position": [460, 300]
+    },
+    {
+      "parameters": {
+        "url": "={{ $env.ESPOCRM_BASE_URL || 'https://espocrm.cloudless.gr' }}/api/v1/Case",
+        "method": "POST",
+        "sendHeaders": true,
+        "headerParameters": {
+          "parameters": [
+            { "name": "X-Api-Key",    "value": "={{ $env.ESPOCRM_API_KEY }}" },
+            { "name": "Content-Type", "value": "application/json" }
+          ]
+        },
+        "sendBody": true,
+        "bodyParametersJson": "={{ JSON.stringify({ name: $('Extract issue fields').item.json.title.slice(0, 200), status: 'New', priority: $('Extract issue fields').item.json.severity === 'critical' ? 'Urgent' : $('Extract issue fields').item.json.severity === 'warning' ? 'High' : 'Normal', description: $('Extract issue fields').item.json.message + ($('Extract issue fields').item.json.permalink ? '\\nSentry: ' + $('Extract issue fields').item.json.permalink : '') }) }}",
+        "options": { "timeout": 8000 }
+      },
+      "name": "EspoCRM — create bug Case",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.1,
+      "position": [680, 300],
+      "continueOnFail": true
+    },
+    {
+      "parameters": {
+        "respondWith": "json",
+        "responseBody": "={{ JSON.stringify({ ok: true, caseCreated: true, severity: $('Extract issue fields').item.json.severity }) }}"
+      },
+      "name": "Respond OK",
+      "type": "n8n-nodes-base.respondToWebhook",
+      "typeVersion": 1,
+      "position": [900, 300]
+    }
+  ],
+  "connections": {
+    "Webhook (sentry-alert)": {
+      "main": [[{ "node": "Extract issue fields", "type": "main", "index": 0 }]]
+    },
+    "Extract issue fields": {
+      "main": [[{ "node": "EspoCRM — create bug Case", "type": "main", "index": 0 }]]
+    },
+    "EspoCRM — create bug Case": {
+      "main": [[{ "node": "Respond OK", "type": "main", "index": 0 }]]
+    }
+  },
+  "active": false,
+  "settings": { "executionOrder": "v1" },
+  "tags": [{ "name": "infra" }, { "name": "espocrm" }, { "name": "cloudless" }]
+}

--- a/infrastructure/n8n/workflows/stripe-automation.json
+++ b/infrastructure/n8n/workflows/stripe-automation.json
@@ -1,0 +1,197 @@
+{
+  "name": "Stripe automation — onboarding drip + dunning emails",
+  "nodes": [
+    {
+      "parameters": {
+        "httpMethod": "POST",
+        "path": "stripe-automation",
+        "options": {}
+      },
+      "name": "Webhook (stripe-automation)",
+      "type": "n8n-nodes-base.webhook",
+      "typeVersion": 1,
+      "position": [240, 400],
+      "webhookId": "stripe-automation"
+    },
+    {
+      "parameters": {
+        "dataType": "string",
+        "value1": "={{ $json.type }}",
+        "rules": {
+          "rules": [
+            { "value2": "checkout.session.completed" },
+            { "value2": "invoice.payment_failed" }
+          ]
+        },
+        "fallbackOutput": 2
+      },
+      "name": "Route by event type",
+      "type": "n8n-nodes-base.switch",
+      "typeVersion": 1,
+      "position": [460, 400]
+    },
+    {
+      "parameters": {
+        "values": {
+          "string": [
+            { "name": "email", "value": "={{ $json.data.customer_email || '' }}" },
+            { "name": "name",  "value": "={{ $json.data.customer_details?.name || '' }}" },
+            { "name": "sessionId", "value": "={{ $json.data.id || '' }}" },
+            { "name": "amount", "value": "={{ (($json.data.amount_total || 0) / 100).toFixed(2) + ' ' + ($json.data.currency || 'EUR').toUpperCase() }}" },
+            { "name": "campaign", "value": "={{ $json.data.metadata?.campaign || '' }}" }
+          ]
+        }
+      },
+      "name": "Extract checkout fields",
+      "type": "n8n-nodes-base.set",
+      "typeVersion": 2,
+      "position": [680, 260]
+    },
+    {
+      "parameters": {
+        "conditions": {
+          "string": [
+            {
+              "value1": "={{ $('Extract checkout fields').item.json.email }}",
+              "operation": "isNotEmpty"
+            }
+          ]
+        }
+      },
+      "name": "Has email?",
+      "type": "n8n-nodes-base.if",
+      "typeVersion": 1,
+      "position": [900, 260]
+    },
+    {
+      "parameters": {
+        "url": "https://api.resend.com/emails",
+        "method": "POST",
+        "sendHeaders": true,
+        "headerParameters": {
+          "parameters": [
+            { "name": "Authorization", "value": "=Bearer {{ $env.RESEND_API_KEY }}" },
+            { "name": "Content-Type", "value": "application/json" }
+          ]
+        },
+        "sendBody": true,
+        "bodyParametersJson": "={{ JSON.stringify({ from: 'Cloudless <hello@cloudless.gr>', to: [$('Extract checkout fields').item.json.email], subject: 'Ευχαριστούμε για την αγορά σας!', html: '<h2>Καλώς ήρθατε στο Cloudless!</h2><p>Αγαπητέ/ή ' + ($('Extract checkout fields').item.json.name || 'πελάτη') + ',</p><p>Λάβαμε την παραγγελία σας (<strong>' + $('Extract checkout fields').item.json.amount + '</strong>) και θα επικοινωνήσουμε σύντομα.</p><p>Αν έχετε ερωτήσεις, απαντήστε σε αυτό το email.</p><p>Η ομάδα Cloudless<br><a href=\"https://cloudless.gr\">cloudless.gr</a></p>' }) }}",
+        "options": { "timeout": 8000 }
+      },
+      "name": "Resend — welcome email",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.1,
+      "position": [1120, 200],
+      "continueOnFail": true
+    },
+    {
+      "parameters": {
+        "respondWith": "json",
+        "responseBody": "={{ JSON.stringify({ ok: true, action: 'welcome_sent', email: $('Extract checkout fields').item.json.email }) }}"
+      },
+      "name": "Respond (checkout OK)",
+      "type": "n8n-nodes-base.respondToWebhook",
+      "typeVersion": 1,
+      "position": [1340, 200]
+    },
+    {
+      "parameters": {
+        "respondWith": "json",
+        "responseBody": "{ \"ok\": true, \"skipped\": \"no_email\" }"
+      },
+      "name": "Respond (no email)",
+      "type": "n8n-nodes-base.respondToWebhook",
+      "typeVersion": 1,
+      "position": [1120, 360]
+    },
+    {
+      "parameters": {
+        "values": {
+          "string": [
+            { "name": "email",     "value": "={{ $json.data.customer_email || '' }}" },
+            { "name": "invoiceId", "value": "={{ $json.data.id || '' }}" },
+            { "name": "amount",    "value": "={{ (($json.data.amount_due || 0) / 100).toFixed(2) + ' ' + ($json.data.currency || 'EUR').toUpperCase() }}" }
+          ]
+        }
+      },
+      "name": "Extract invoice fields",
+      "type": "n8n-nodes-base.set",
+      "typeVersion": 2,
+      "position": [680, 540]
+    },
+    {
+      "parameters": {
+        "url": "https://api.resend.com/emails",
+        "method": "POST",
+        "sendHeaders": true,
+        "headerParameters": {
+          "parameters": [
+            { "name": "Authorization", "value": "=Bearer {{ $env.RESEND_API_KEY }}" },
+            { "name": "Content-Type", "value": "application/json" }
+          ]
+        },
+        "sendBody": true,
+        "bodyParametersJson": "={{ JSON.stringify({ from: 'Cloudless <hello@cloudless.gr>', to: [$('Extract invoice fields').item.json.email], subject: 'Αποτυχία πληρωμής — ανανεώστε τα στοιχεία σας', html: '<h2>Η πληρωμή απέτυχε</h2><p>Το τιμολόγιό σας ύψους <strong>' + $('Extract invoice fields').item.json.amount + '</strong> δεν ήταν δυνατόν να χρεωθεί.</p><p>Παρακαλούμε ανανεώστε τα στοιχεία πληρωμής σας για να αποφύγετε διακοπή της υπηρεσίας.</p><p><a href=\"https://cloudless.gr/el/profile\">Ανανέωση στοιχείων</a></p><p>Η ομάδα Cloudless</p>' }) }}",
+        "options": { "timeout": 8000 }
+      },
+      "name": "Resend — dunning email",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.1,
+      "position": [900, 540],
+      "continueOnFail": true
+    },
+    {
+      "parameters": {
+        "respondWith": "json",
+        "responseBody": "={{ JSON.stringify({ ok: true, action: 'dunning_sent', invoice: $('Extract invoice fields').item.json.invoiceId }) }}"
+      },
+      "name": "Respond (dunning OK)",
+      "type": "n8n-nodes-base.respondToWebhook",
+      "typeVersion": 1,
+      "position": [1120, 540]
+    },
+    {
+      "parameters": {
+        "respondWith": "json",
+        "responseBody": "={ \"ok\": true, \"skipped\": \"unhandled_event_type\" }"
+      },
+      "name": "Respond (skip)",
+      "type": "n8n-nodes-base.respondToWebhook",
+      "typeVersion": 1,
+      "position": [680, 680]
+    }
+  ],
+  "connections": {
+    "Webhook (stripe-automation)": {
+      "main": [[{ "node": "Route by event type", "type": "main", "index": 0 }]]
+    },
+    "Route by event type": {
+      "main": [
+        [{ "node": "Extract checkout fields", "type": "main", "index": 0 }],
+        [{ "node": "Extract invoice fields",  "type": "main", "index": 0 }],
+        [{ "node": "Respond (skip)",           "type": "main", "index": 0 }]
+      ]
+    },
+    "Extract checkout fields": {
+      "main": [[{ "node": "Has email?", "type": "main", "index": 0 }]]
+    },
+    "Has email?": {
+      "main": [
+        [{ "node": "Resend — welcome email", "type": "main", "index": 0 }],
+        [{ "node": "Respond (no email)",     "type": "main", "index": 0 }]
+      ]
+    },
+    "Resend — welcome email": {
+      "main": [[{ "node": "Respond (checkout OK)", "type": "main", "index": 0 }]]
+    },
+    "Extract invoice fields": {
+      "main": [[{ "node": "Resend — dunning email", "type": "main", "index": 0 }]]
+    },
+    "Resend — dunning email": {
+      "main": [[{ "node": "Respond (dunning OK)", "type": "main", "index": 0 }]]
+    }
+  },
+  "active": false,
+  "settings": { "executionOrder": "v1" },
+  "tags": [{ "name": "stripe" }, { "name": "email" }, { "name": "cloudless" }]
+}

--- a/src/app/api/webhooks/kuma/route.ts
+++ b/src/app/api/webhooks/kuma/route.ts
@@ -121,5 +121,14 @@ export async function POST(request: NextRequest) {
   const text = msg || name + " is " + status + urlSuffix;
   await postSlack(title, text, url || undefined);
 
+  // Forward to n8n so DOWN events open an EspoCRM incident case.
+  const n8nBase = process.env.N8N_INTERNAL_URL ?? "http://n8n.n8n.svc.cluster.local:5678";
+  fetch(`${n8nBase}/webhook/kuma-alert`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ name, status, msg, url: url || "" }),
+    signal: AbortSignal.timeout(3000),
+  }).catch(() => {});
+
   return NextResponse.json({ ok: true });
 }

--- a/src/app/api/webhooks/sentry/route.ts
+++ b/src/app/api/webhooks/sentry/route.ts
@@ -139,5 +139,14 @@ export async function POST(req: NextRequest) {
     click: issue.permalink,
   });
 
+  // Forward to n8n so errors open an EspoCRM bug case.
+  const n8nBase = process.env.N8N_INTERNAL_URL ?? "http://n8n.n8n.svc.cluster.local:5678";
+  fetch(`${n8nBase}/webhook/sentry-alert`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ severity, title, message, permalink: issue.permalink }),
+    signal: AbortSignal.timeout(3000),
+  }).catch(() => {});
+
   return NextResponse.json({ ok: true, result });
 }

--- a/src/app/api/webhooks/stripe/route.ts
+++ b/src/app/api/webhooks/stripe/route.ts
@@ -304,6 +304,15 @@ export async function POST(request: NextRequest) {
     console.error("[Stripe] Failed to mark event as processed:", markErr);
   });
 
+  // Forward verified event to n8n for automation (welcome drip, dunning).
+  const n8nBase = process.env.N8N_INTERNAL_URL ?? "http://n8n.n8n.svc.cluster.local:5678";
+  fetch(`${n8nBase}/webhook/stripe-automation`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ type: event.type, data: event.data.object }),
+    signal: AbortSignal.timeout(3000),
+  }).catch(() => {});
+
   if (process.env.NEXT_PUBLIC_SENTRY_DSN) {
     await import("@sentry/nextjs").then(({ flush }) => flush(2000)).catch(() => {});
   }


### PR DESCRIPTION
## Summary
- **3 new n8n workflow JSONs**: `stripe-automation`, `kuma-espocrm`, `sentry-espocrm` in `infrastructure/n8n/workflows/`
- **3 webhook routes** get a fire-and-forget forward to n8n after their existing handlers complete — no change to existing Slack/email/EspoCRM behavior
- n8n env: `RESEND_API_KEY` + `ESPOCRM_BASE_URL` + `ESPOCRM_API_KEY` already landed in k8s.yaml (commit 0f7be4b5)

## What each workflow does
| Workflow | Trigger path | Action |
|---|---|---|
| stripe-automation | `/webhook/stripe-automation` | `checkout.session.completed` → Resend welcome email; `invoice.payment_failed` → Resend dunning email |
| kuma-espocrm | `/webhook/kuma-alert` | DOWN alert → EspoCRM Case (priority High) |
| sentry-espocrm | `/webhook/sentry-alert` | Error alert → EspoCRM Case (priority by severity) |

## One-time setup required
```bash
kubectl create secret generic n8n-integrations -n n8n \
  --from-literal=RESEND_API_KEY=<key> \
  --from-literal=ESPOCRM_BASE_URL=https://espocrm.cloudless.gr \
  --from-literal=ESPOCRM_API_KEY=<key>
```
Then `kubectl rollout restart deployment/n8n -n n8n` to pick up the new env vars.

## Test plan
- [ ] Secret created on cluster
- [ ] n8n restarted, 3 new workflows appear in UI and are activated
- [ ] Test Stripe `checkout.session.completed` → welcome email arrives
- [ ] Simulate Kuma DOWN alert → EspoCRM Case created
- [ ] Simulate Sentry error → EspoCRM Case created

🤖 Generated with [Claude Code](https://claude.com/claude-code)