### PR TITLE
feat(blog): add RSS feed at /[locale]/blog/rss.xml

### DIFF
--- a/src/app/[locale]/blog/rss.xml/route.ts
+++ b/src/app/[locale]/blog/rss.xml/route.ts
@@ -1,0 +1,60 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getBlogPosts } from "@/lib/blog-source";
+
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+
+function escapeXml(str: string): string {
+  return str
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&apos;");
+}
+
+export async function GET(
+  _req: NextRequest,
+  { params }: { params: Promise<{ locale: string }> }
+) {
+  const { locale } = await params;
+  const base = process.env.NEXT_PUBLIC_SITE_URL ?? "https://cloudless.gr";
+  const blogBase = `${base}/${locale}/blog`;
+
+  const posts = await getBlogPosts();
+
+  const items = posts
+    .slice(0, 20)
+    .map((post) => {
+      const link = `${blogBase}/${post.slug}`;
+      const pubDate = new Date(post.date).toUTCString();
+      return `    <item>
+      <title>${escapeXml(post.title)}</title>
+      <link>${link}</link>
+      <guid isPermaLink="true">${link}</guid>
+      <pubDate>${pubDate}</pubDate>
+      <description>${escapeXml(post.excerpt)}</description>
+      <category>${escapeXml(post.category)}</category>
+    </item>`;
+    })
+    .join("\n");
+
+  const xml = `<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
+  <channel>
+    <title>Cloudless Blog</title>
+    <link>${blogBase}</link>
+    <description>Cloud engineering insights from Cloudless.gr</description>
+    <language>${locale}</language>
+    <atom:link href="${blogBase}/rss.xml" rel="self" type="application/rss+xml"/>
+${items}
+  </channel>
+</rss>`;
+
+  return new NextResponse(xml, {
+    headers: {
+      "Content-Type": "application/rss+xml; charset=utf-8",
+      "Cache-Control": "public, s-maxage=3600, stale-while-revalidate=86400",
+    },
+  });
+}


### PR DESCRIPTION
## Summary
- Creates `src/app/[locale]/blog/rss.xml/route.ts` — a proper RSS 2.0 feed
- Root cause of the **Postiz RSS → multi-channel schedule** workflow failing every 6 hours since Aug 17: the URL `https://cloudless.gr/en/blog/rss.xml` returned an HTML 200 (Next.js 404 page) because the route didn't exist
- Feed pulls from `getBlogPosts()` (AppFlowy if configured, static fallback), returns up to 20 posts with correct `Content-Type: application/rss+xml`

## Test plan
- [ ] After deploy: `curl -I https://cloudless.gr/en/blog/rss.xml` should return `Content-Type: application/rss+xml`
- [ ] n8n "Postiz — RSS → multi-channel schedule" workflow next run (every 6h) should succeed

🤖 Generated with [Claude Code](https://claude.com/claude-code)