### PR TITLE
ops(n8n): patch SLACK_WEBHOOK_URL into n8n-integrations secret

### DIFF
--- a/.github/workflows/fix-n8n-slack-secret.yml
+++ b/.github/workflows/fix-n8n-slack-secret.yml
@@ -1,0 +1,75 @@
+name: Fix — patch SLACK_WEBHOOK_URL into n8n-integrations secret
+
+# One-shot: reads SLACK_WEBHOOK_URL from the running cloudless-app pod and
+# patches it into n8n-integrations so hot-lead-alert and funnel-daily-rollup
+# workflows can post to Slack. Delete this file once n8n is confirmed working.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - '.github/workflows/fix-n8n-slack-secret.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  patch-slack-url:
+    name: Patch SLACK_WEBHOOK_URL into n8n-integrations
+    runs-on: [self-hosted, omv, pi]
+    timeout-minutes: 10
+    env:
+      KUBECONFIG: /etc/rancher/k3s/k3s.yaml
+
+    steps:
+    - name: Read SLACK_WEBHOOK_URL from cloudless-app pod and patch secret
+      run: |
+        APP_POD=$(sudo kubectl get pods -n cloudless -l app=cloudless-app \
+          -o jsonpath='{.items[0].metadata.name}')
+        echo "App pod: $APP_POD"
+
+        SLACK_URL=$(sudo kubectl exec -n cloudless "$APP_POD" -- \
+          printenv SLACK_WEBHOOK_URL 2>/dev/null || true)
+
+        if [ -z "$SLACK_URL" ]; then
+          echo "Not in pod env, trying SSM..."
+          SLACK_URL=$(aws ssm get-parameter \
+            --name /cloudless/production/SLACK_WEBHOOK_URL \
+            --with-decryption \
+            --query Parameter.Value \
+            --output text 2>/dev/null || true)
+        fi
+
+        if [ -z "$SLACK_URL" ]; then
+          echo "::error::SLACK_WEBHOOK_URL not found in pod env or SSM"
+          exit 1
+        fi
+
+        echo "Found. Length: ${#SLACK_URL} chars"
+
+        sudo kubectl patch secret n8n-integrations -n n8n \
+          --type merge \
+          -p "{\"stringData\":{\"SLACK_WEBHOOK_URL\":\"$SLACK_URL\"}}"
+
+        echo "Secret patched."
+
+    - name: Restart n8n to pick up the new secret value
+      run: |
+        sudo kubectl rollout restart deployment/n8n -n n8n
+        sudo kubectl rollout status deployment/n8n -n n8n --timeout=90s
+
+    - name: Verify n8n is healthy
+      run: |
+        for i in $(seq 1 8); do
+          CODE=$(curl -s -o /dev/null -w '%{http_code}' \
+            --max-time 5 http://127.0.0.1:30900/healthz 2>/dev/null || echo 000)
+          if [ "$CODE" = "200" ]; then
+            echo "n8n healthy (attempt $i)"
+            exit 0
+          fi
+          echo "attempt $i: HTTP $CODE — waiting…"
+          sleep 10
+        done
+        echo "::error::n8n did not become healthy"
+        exit 1


### PR DESCRIPTION
## Summary
- One-shot Pi runner workflow that reads `SLACK_WEBHOOK_URL` from the cloudless-app pod (or SSM fallback) and patches it into the `n8n-integrations` k8s Secret
- Unblocks two n8n workflows: **Hot lead alert** and **Funnel daily rollup** (both need Slack access)
- Same pattern as `fix-n8n-resend-key.yml` — secret never appears in logs

## Test plan
- [ ] Workflow runs green on Pi runner
- [ ] `kubectl get secret n8n-integrations -n n8n -o jsonpath='{.data.SLACK_WEBHOOK_URL}' | base64 -d | wc -c` returns > 0
- [ ] n8n restarts healthy

🤖 Generated with [Claude Code](https://claude.com/claude-code)