### PR TITLE
fix(meilisearch): harden all 6 identified issues

### DIFF
--- a/.github/workflows/fix-meili-search-key.yml
+++ b/.github/workflows/fix-meili-search-key.yml
@@ -1,0 +1,160 @@
+name: Fix — generate Meilisearch scoped API keys
+
+# One-shot: uses the master key to create two scoped Meilisearch API keys:
+#   MEILI_SEARCH_KEY  — search action on products + site-content indexes
+#   MEILI_ADMIN_KEY   — indexes/documents/settings actions on those indexes
+# Stores both in the cloudless-secrets k8s Secret so the app pod picks them
+# up on next rollout, and mirrors the master key into meilisearch-scrape-auth
+# in the monitoring namespace for Prometheus scraping.
+#
+# Delete this file once keys are confirmed working in /api/search.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - '.github/workflows/fix-meili-search-key.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  generate-keys:
+    name: Generate Meilisearch scoped keys
+    runs-on: [self-hosted, omv, pi]
+    timeout-minutes: 10
+    env:
+      KUBECONFIG: /etc/rancher/k3s/k3s.yaml
+
+    steps:
+    - name: Read master key from cluster secret
+      run: |
+        MASTER_KEY=$(sudo kubectl get secret meilisearch-secret -n meilisearch \
+          -o jsonpath='{.data.MEILI_MASTER_KEY}' | base64 -d)
+
+        if [ -z "$MASTER_KEY" ]; then
+          echo "::error::meilisearch-secret/MEILI_MASTER_KEY is empty"
+          exit 1
+        fi
+
+        echo "Master key length: ${#MASTER_KEY} chars"
+        echo "MASTER_KEY=$MASTER_KEY" >> "$GITHUB_ENV"
+
+    - name: Wait for Meilisearch to be ready
+      run: |
+        for i in $(seq 1 12); do
+          CODE=$(curl -s -o /dev/null -w '%{http_code}' \
+            -H "Authorization: Bearer $MASTER_KEY" \
+            --max-time 5 http://127.0.0.1:30902/health 2>/dev/null || echo 000)
+          if [ "$CODE" = "200" ]; then
+            echo "Meilisearch ready (attempt $i)"
+            break
+          fi
+          echo "attempt $i: HTTP $CODE — waiting…"
+          sleep 10
+        done
+
+    - name: Delete stale scoped keys (idempotent)
+      run: |
+        KEYS=$(curl -s -H "Authorization: Bearer $MASTER_KEY" \
+          http://127.0.0.1:30902/keys?limit=100)
+        echo "$KEYS" | python3 -c "
+import json, sys, urllib.request, os
+data = json.load(sys.stdin)
+master = os.environ['MASTER_KEY']
+for k in data.get('results', []):
+    if k.get('name') in ('cloudless-search', 'cloudless-admin'):
+        uid = k['uid']
+        req = urllib.request.Request(
+            f'http://127.0.0.1:30902/keys/{uid}',
+            method='DELETE',
+            headers={'Authorization': f'Bearer {master}'}
+        )
+        urllib.request.urlopen(req)
+        print(f'deleted key: {k[\"name\"]} ({uid})')
+" || true
+
+    - name: Create search-only key
+      run: |
+        PAYLOAD=$(python3 -c "
+import json
+print(json.dumps({
+  'name': 'cloudless-search',
+  'description': 'Search-only key for cloudless-app /api/search route',
+  'actions': ['search'],
+  'indexes': ['products', 'site-content'],
+  'expiresAt': None
+}))
+")
+        RESPONSE=$(curl -s -X POST \
+          -H "Authorization: Bearer $MASTER_KEY" \
+          -H "Content-Type: application/json" \
+          -d "$PAYLOAD" \
+          http://127.0.0.1:30902/keys)
+        SEARCH_KEY=$(echo "$RESPONSE" | python3 -c "import json,sys; print(json.load(sys.stdin)['key'])")
+        if [ -z "$SEARCH_KEY" ]; then
+          echo "::error::Failed to create search key: $RESPONSE"
+          exit 1
+        fi
+        echo "Search key created. Length: ${#SEARCH_KEY}"
+        echo "SEARCH_KEY=$SEARCH_KEY" >> "$GITHUB_ENV"
+
+    - name: Create admin key
+      run: |
+        PAYLOAD=$(python3 -c "
+import json
+print(json.dumps({
+  'name': 'cloudless-admin',
+  'description': 'Admin key for indexing — used by cloudless-app reindex + content sync',
+  'actions': ['indexes.*', 'documents.*', 'settings.*', 'tasks.*'],
+  'indexes': ['products', 'site-content'],
+  'expiresAt': None
+}))
+")
+        RESPONSE=$(curl -s -X POST \
+          -H "Authorization: Bearer $MASTER_KEY" \
+          -H "Content-Type: application/json" \
+          -d "$PAYLOAD" \
+          http://127.0.0.1:30902/keys)
+        ADMIN_KEY=$(echo "$RESPONSE" | python3 -c "import json,sys; print(json.load(sys.stdin)['key'])")
+        if [ -z "$ADMIN_KEY" ]; then
+          echo "::error::Failed to create admin key: $RESPONSE"
+          exit 1
+        fi
+        echo "Admin key created. Length: ${#ADMIN_KEY}"
+        echo "ADMIN_KEY=$ADMIN_KEY" >> "$GITHUB_ENV"
+
+    - name: Patch cloudless-secrets with scoped keys
+      run: |
+        sudo kubectl patch secret cloudless-secrets -n cloudless \
+          --type merge \
+          -p "{\"stringData\":{\"MEILI_SEARCH_KEY\":\"$SEARCH_KEY\",\"MEILI_ADMIN_KEY\":\"$ADMIN_KEY\"}}"
+        echo "cloudless-secrets patched with MEILI_SEARCH_KEY + MEILI_ADMIN_KEY."
+
+    - name: Create meilisearch-scrape-auth in monitoring namespace
+      run: |
+        sudo kubectl create secret generic meilisearch-scrape-auth \
+          -n monitoring \
+          --from-literal=MEILI_MASTER_KEY="$MASTER_KEY" \
+          --dry-run=client -o yaml | sudo kubectl apply -f -
+        echo "meilisearch-scrape-auth created/updated in monitoring namespace."
+
+    - name: Rollout cloudless-app to pick up new keys
+      run: |
+        sudo kubectl rollout restart deployment/cloudless-app -n cloudless
+        sudo kubectl rollout status deployment/cloudless-app -n cloudless --timeout=120s
+
+    - name: Verify search endpoint uses scoped key
+      run: |
+        for i in $(seq 1 6); do
+          CODE=$(curl -s -o /dev/null -w '%{http_code}' \
+            --max-time 10 'http://127.0.0.1:30300/api/search?q=cloud' 2>/dev/null || echo 000)
+          if [ "$CODE" = "200" ]; then
+            echo "Search endpoint healthy (HTTP $CODE)"
+            exit 0
+          fi
+          echo "attempt $i: HTTP $CODE — waiting…"
+          sleep 10
+        done
+        echo "::warning::Search endpoint returned non-200 — check pod logs"

--- a/infrastructure/meilisearch/k8s.yaml
+++ b/infrastructure/meilisearch/k8s.yaml
@@ -1,6 +1,6 @@
 # Meilisearch — open-source, fast, hyper-relevant search engine
-# NodePort 30902 on omv-main (120GB SSD, exclusive k3s storage).
-# Tunnel: meili.cloudless.gr → http://127.0.0.1:30902
+# Service: NodePort 30902 on omv-main — required by cloudflared (host process).
+# Tunnel: meili.cloudless.gr → http://192.168.1.128:30902 (cloudflare-tunnels/ingress-rules.yaml)
 #
 # Storage: local-path PVC on 120GB SSD (sda1).
 # RAM: requests 256Mi / limit 1Gi. Meilisearch v1.48 uses ~200-400Mi at
@@ -8,9 +8,11 @@
 #      Indexing bursts up to ~600Mi during initial product catalog import.
 # Image: pinned to getmeili/meilisearch:v1.48.3 — multi-arch image with
 #        native arm64 support (avoids QEMU/emulation overhead on Pi 5).
-# Auth: MEILI_MASTER_KEY set via the meilisearch-secret Secret.
-#       The app secret key must match what src/lib/search.ts expects
-#       (see R21b for /api/search route).
+# Auth: Master key in meilisearch-secret. App uses scope-limited keys:
+#       MEILI_SEARCH_KEY (search only) and MEILI_ADMIN_KEY (index/settings).
+#       Run fix-meili-search-key.yml once to generate and store them.
+# Metrics: MEILI_ENABLE_METRICS=true — scraped by Prometheus via
+#          infrastructure/monitoring/meilisearch-servicemonitor.yaml.
 
 apiVersion: v1
 kind: Namespace
@@ -80,6 +82,10 @@ spec:
           value: 0.0.0.0:7700
         - name: MEILI_DB_PATH
           value: /meili_data
+        - name: MEILI_NO_ANALYTICS
+          value: 'true'
+        - name: MEILI_ENABLE_METRICS
+          value: 'true'
         - name: TZ
           value: Europe/Athens
         volumeMounts:
@@ -93,13 +99,15 @@ spec:
             cpu: '1'
             memory: 1Gi
         livenessProbe:
-          tcpSocket:
+          httpGet:
+            path: /health
             port: 7700
           initialDelaySeconds: 30
           periodSeconds: 20
           failureThreshold: 5
         readinessProbe:
-          tcpSocket:
+          httpGet:
+            path: /health
             port: 7700
           initialDelaySeconds: 15
           periodSeconds: 10
@@ -116,13 +124,14 @@ metadata:
   labels:
     app: meilisearch
 spec:
-  type: ClusterIP
+  type: NodePort
   selector:
     app: meilisearch
   ports:
   - name: http
     port: 7700
     targetPort: 7700
+    nodePort: 30902
 ---
 # ResourceQuota: 1.5Gi limits total (Meilisearch 1Gi + any helper pods).
 # Meilisearch alone requests 256Mi / limits 1Gi; the quota allows room

--- a/infrastructure/monitoring/meilisearch-servicemonitor.yaml
+++ b/infrastructure/monitoring/meilisearch-servicemonitor.yaml
@@ -1,0 +1,84 @@
+# Prometheus scrape config for Meilisearch metrics.
+#
+# Meilisearch exposes /metrics (Prometheus format) when MEILI_ENABLE_METRICS=true.
+# In production mode all routes — including /metrics — require a bearer token.
+# This manifest mirrors the master key into the monitoring namespace so the
+# ServiceMonitor can pass it as Authorization: Bearer.
+#
+# Run fix-meili-search-key.yml first — it patches meilisearch-scrape-auth with
+# the master key. Until that workflow runs this ServiceMonitor is inert.
+#
+# Apply: kubectl apply -f infrastructure/monitoring/meilisearch-servicemonitor.yaml
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: meilisearch-metrics
+  namespace: monitoring
+  labels:
+    app: meilisearch
+    component: metrics
+    release: kube-prom
+spec:
+  type: ExternalName
+  externalName: meilisearch.meilisearch.svc.cluster.local
+  ports:
+  - name: metrics
+    port: 7700
+    targetPort: 7700
+    protocol: TCP
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: meilisearch
+  namespace: monitoring
+  labels:
+    release: kube-prom
+    app: meilisearch
+spec:
+  selector:
+    matchLabels:
+      app: meilisearch
+      component: metrics
+  namespaceSelector:
+    matchNames: [monitoring]
+  endpoints:
+  - port: metrics
+    path: /metrics
+    interval: 60s
+    scrapeTimeout: 10s
+    bearerTokenSecret:
+      name: meilisearch-scrape-auth
+      key: MEILI_MASTER_KEY
+    relabelings:
+    - targetLabel: job
+      replacement: meilisearch
+    - targetLabel: namespace
+      replacement: meilisearch
+---
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: meilisearch-health
+  namespace: monitoring
+  labels:
+    release: kube-prom
+spec:
+  groups:
+  - name: meilisearch.rules
+    rules:
+    - alert: MeilisearchMetricsAbsent
+      expr: absent(meilisearch_http_requests_total) == 1
+      for: 15m
+      labels: {severity: warning}
+      annotations:
+        summary: Meilisearch metrics not scraped
+        description: No meilisearch_http_requests_total for 15m — check MEILI_ENABLE_METRICS and the scrape auth Secret.
+    - alert: MeilisearchIndexingErrors
+      expr: increase(meilisearch_http_response_status_code_total{status_code=~"5.."}[15m]) > 10
+      for: 5m
+      labels: {severity: warning}
+      annotations:
+        summary: Elevated Meilisearch 5xx errors
+        description: "More than 10 5xx responses in 15m on {{ $labels.instance }}."

--- a/infrastructure/network-policies/policies.yaml
+++ b/infrastructure/network-policies/policies.yaml
@@ -110,6 +110,13 @@ spec:
           kubernetes.io/metadata.name: cloudless
     ports:
     - port: 7700
+  # Allow n8n workflows to call Meilisearch directly (reindex triggers, ETL)
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: n8n
+    ports:
+    - port: 7700
 ---
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy

--- a/src/lib/content-index.ts
+++ b/src/lib/content-index.ts
@@ -55,6 +55,7 @@ function toExcerpt(body: string, maxLen = 200): string {
 }
 
 async function ensureContentIndex(): Promise<void> {
+  let created = false;
   try {
     await meiliRequest(`/indexes/${CONTENT_INDEX}`, { method: "GET" }, getMeiliAdminKey());
   } catch (err) {
@@ -68,20 +69,23 @@ async function ensureContentIndex(): Promise<void> {
       },
       getMeiliAdminKey()
     );
+    created = true;
   }
 
-  await meiliRequest(
-    `/indexes/${CONTENT_INDEX}/settings`,
-    {
-      method: "PATCH",
-      body: JSON.stringify({
-        filterableAttributes: ["type", "category"],
-        sortableAttributes: ["date"],
-        searchableAttributes: ["title", "excerpt", "body", "category"],
-      }),
-    },
-    getMeiliAdminKey()
-  );
+  if (created) {
+    await meiliRequest(
+      `/indexes/${CONTENT_INDEX}/settings`,
+      {
+        method: "PATCH",
+        body: JSON.stringify({
+          filterableAttributes: ["type", "category"],
+          sortableAttributes: ["date"],
+          searchableAttributes: ["title", "excerpt", "body", "category"],
+        }),
+      },
+      getMeiliAdminKey()
+    );
+  }
 }
 
 export async function syncContentIndex(): Promise<{


### PR DESCRIPTION
## Summary

- **Fix 1 — Scoped API keys** (`fix-meili-search-key.yml`): one-shot Pi runner workflow that generates a search-only `MEILI_SEARCH_KEY` and an admin `MEILI_ADMIN_KEY` via the Meilisearch `/keys` API, patches `cloudless-secrets`, and creates `meilisearch-scrape-auth` in `monitoring` for Prometheus. Run once after merge.
- **Fix 2 — NodePort 30902**: corrects `Service` type from `ClusterIP` → `NodePort` with `nodePort: 30902`, matching what `cloudflare-tunnels/ingress-rules.yaml` already expects (cloudflared runs on host, not as a pod).
- **Fix 3 — Health probes**: switches both liveness + readiness probes from `tcpSocket` to `httpGet /health`, detecting degraded Meilisearch state (not just an open socket).
- **Fix 4 — Index settings churn** (`content-index.ts`): `ensureContentIndex` now only patches index settings when the index is newly created, avoiding unnecessary task queue entries on every sync.
- **Fix 5 — NetworkPolicy**: adds an ingress rule allowing pods in the `n8n` namespace to reach Meilisearch on port 7700 for direct ETL/reindex calls.
- **Fix 6 — Prometheus metrics**: adds `MEILI_ENABLE_METRICS=true` + `MEILI_NO_ANALYTICS=true` to the deployment, and `meilisearch-servicemonitor.yaml` with `ServiceMonitor` + `PrometheusRule` (auth via `meilisearch-scrape-auth` secret populated by Fix 1 workflow).

## Test plan
- [ ] Merge and let CI pass
- [ ] Run `fix-meili-search-key.yml` workflow once (Pi runner, ~2 min)
- [ ] Verify `/api/search?q=cloud` returns `source: meilisearch-bedrock`
- [ ] Verify Grafana shows `meilisearch_http_requests_total` series within 2 scrape intervals (120s)
- [ ] Check `kubectl get pods -n meilisearch` shows `Running` after probe change

🤖 Generated with [Claude Code](https://claude.com/claude-code)