### PR TITLE
fix(ci): align all codeql-action steps to v4.37.8

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -53,13 +53,13 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@7211b7c8077ea37d8641b6271f6a365a22a5fbfa # v4.37.6
+        uses: github/codeql-action/init@db488ddef3bf6cb639b32c2e9a7c0a7ea8271d28 # v4.37.8
         with:
           languages: ${{ matrix.language }}
           queries: security-extended
 
       - name: Autobuild
-        uses: github/codeql-action/autobuild@db488ddef3bf6cb639b32c2e9a7c0a7ea8271d28 # v4.37.6
+        uses: github/codeql-action/autobuild@db488ddef3bf6cb639b32c2e9a7c0a7ea8271d28 # v4.37.8
 
       - name:
           Perform CodeQL Analysis
@@ -67,7 +67,7 @@ jobs:
           # private repos with a GHAS licence. Without it the upload step returns a
           # 403 / "Code scanning is not enabled" error, so we mark it non-fatal and
           # still surface any findings in the log.
-        uses: github/codeql-action/analyze@7211b7c8077ea37d8641b6271f6a365a22a5fbfa # v4.37.6
+        uses: github/codeql-action/analyze@db488ddef3bf6cb639b32c2e9a7c0a7ea8271d28 # v4.37.8
         continue-on-error: true
         with:
           category: /language:${{ matrix.language }}


### PR DESCRIPTION
## Summary

PR #1730 bumped only `autobuild` from SHA `7211b7c8` → `db488ddef` while leaving `init` and `analyze` on the old SHA. The old SHA (`7211b7c8`) maps to **v4.36.0** (the `# v4.37.6` comment in the file was wrong). This caused every CodeQL run on every PR to fail with:

> Loaded a configuration file for version '4.36.0', but running version '4.37.8'

Aligns all three steps (`init`, `autobuild`, `analyze`) to `db488ddef` (v4.37.8).

## Test plan

- [ ] `Analyze (javascript-typescript)` check passes on this PR's CI run

🤖 Generated with [Claude Code](https://claude.com/claude-code)