### PR TITLE
docs: remove stale src/AGENTS.md redirect stub

### DIFF
--- a/src/AGENTS.md
+++ b/src/AGENTS.md
@@ -1,3 +1,0 @@
-# Project Architecture & Agent Guide
-
-This file has been consolidated. Please refer to the root [AGENTS.md](../AGENTS.md) for the most up-to-date architecture documentation and agent rules.


### PR DESCRIPTION
Root AGENTS.md is the canonical agent guide. `src/AGENTS.md` was a one-liner redirect stub that generated noise for automated tooling — it triggered three bot issues (#1735, #1713, #1708).

Closes #1735, #1713, #1708