### PR TITLE
fix: eliminate log injection (CodeQL #1949, #1950)

### DIFF
--- a/src/lib/email.ts
+++ b/src/lib/email.ts
@@ -49,7 +49,7 @@ export async function sendEmail(options: {
   listUnsubscribeUrl?: string;
 }) {
   if (await isSuppressed(options.to)) {
-    console.warn("[email] Skipping suppressed address:", options.to.replace(/[\r\n]/g, " "));
+    console.warn("[email] Skipping suppressed address");
     return;
   }
 

--- a/src/lib/espocrm.ts
+++ b/src/lib/espocrm.ts
@@ -811,9 +811,8 @@ export async function moveDealStage(id: string, stageId: string): Promise<{ id: 
   const pipelines = (await getPipelines()) as Array<{ stages: { id: string }[] }>;
   const knownStages = pipelines[0]?.stages.map((s) => s.id) ?? [];
   if (!knownStages.includes(stageId)) {
-    const safeId = stageId.replace(/[\r\n\t]/g, " ");
     console.error(
-      `[EspoCRM] moveDealStage: unknown stage "${safeId}". Known: ${knownStages.join(", ")}`
+      `[EspoCRM] moveDealStage: unrecognized stageId (${knownStages.length} valid stages exist)`
     );
     return null;
   }


### PR DESCRIPTION
CodeQL taint tracking continues through `.replace()` calls, so the previous sanitization in PR #1741 was insufficient — alerts #1949 and #1950 reopened on main.

**Root cause**: CodeQL's `js/log-injection` query does not recognize `String.replace()` as a taint sanitizer. The tainted string is still tracked as user-controlled after the replacement.

**Fix**: Remove the externally-sourced values from the log statements entirely.

- `src/lib/email.ts:52` — drop the email address from the suppressed-address warning; the address is already known from the `isSuppressed()` call site
- `src/lib/espocrm.ts:815` — log the count of valid stages instead of the `stageId` value and stage ID list

Fixes CodeQL alerts #1949 and #1950.