### PR TITLE
fix(typography): correct hyphen → en/em dash in 2 locations

### DIFF
--- a/src/app/[locale]/admin/ai-assistant/page.tsx
+++ b/src/app/[locale]/admin/ai-assistant/page.tsx
@@ -313,7 +313,7 @@ export default function AIAssistantPage() {
                   id="targetAudience"
                   value={targetAudience}
                   onChange={(e) => setTargetAudience(e.target.value)}
-                  placeholder="e.g. Greek SMB owners, 30-55"
+                  placeholder="e.g. Greek SMB owners, 30–55"
                   className="w-full rounded-lg border border-slate-700 bg-slate-900 px-3 py-2 font-mono text-sm text-white placeholder-slate-600 focus:outline-none"
                 />
               </div>

--- a/src/app/[locale]/agents/page.tsx
+++ b/src/app/[locale]/agents/page.tsx
@@ -5,7 +5,7 @@ import AgentCounter from "@/components/AgentCounter";
 
 export const metadata: Metadata = {
   title: "Agents",
-  description: "Cloudless Agent Workers - Interactive demos and tools.",
+  description: "Cloudless Agent Workers — Interactive demos and tools.",
   alternates: {
     canonical: "https://cloudless.gr/agents",
   },


### PR DESCRIPTION
Scanned all pages across all four locales (en/el/fr/de) and all hardcoded TSX content for typographic dash issues. Two violations found:

| File | Issue | Fix |
|------|-------|-----|
| `src/app/[locale]/admin/ai-assistant/page.tsx:316` | Age range `30-55` (ASCII hyphen) | `30–55` (en dash) |
| `src/app/[locale]/agents/page.tsx:8` | Prose `Workers - Interactive` (spaced hyphen) | `Workers — Interactive` (em dash) |

Locale files (en/el/fr/de): clean — correct em/en dashes already used throughout.