### PR TITLE
fix: typography dashes + deploy pull-agent diagnostic + token rotation workflow

### DIFF
--- a/.github/workflows/debug-pi-pull.yml
+++ b/.github/workflows/debug-pi-pull.yml
@@ -1,0 +1,80 @@
+name: Debug Pi release pull agent
+
+on:
+  workflow_dispatch:
+    inputs:
+      issue:
+        description: Issue to post results to
+        required: false
+        default: '382'
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  diagnose:
+    runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ github.token }}
+      ISSUE: ${{ github.event.inputs.issue || '382' }}
+    steps:
+    - name: Connect to tailnet
+      uses: tailscale/github-action@780049a30b6ff5c378a9e7b389d15ece7a204888         # v4.1.3
+      with:
+        oauth-client-id: ${{ secrets.TS_CLIENT_ID }}
+        oauth-secret: ${{ secrets.TS_CLIENT_SECRET }}
+
+    - name: Setup SSH key
+      run: |
+        install -d -m 700 ~/.ssh
+        echo "${{ secrets.OMV_SSH_KEY }}" > ~/.ssh/id_ed25519
+        chmod 600 ~/.ssh/id_ed25519
+        echo "StrictHostKeyChecking no" >> ~/.ssh/config
+
+    - name: Diagnose pull agent on omv
+      id: diag
+      run: |
+        set -euo pipefail
+        SSH="ssh -i ~/.ssh/id_ed25519 -o ConnectTimeout=15 tbaltzakis@100.74.191.58"
+        {
+          echo "### Pi pull-agent diagnostic — $(date -u '+%Y-%m-%d %H:%M:%SZ')"
+          echo ""
+          echo "#### Timer status"
+          echo '```'
+          $SSH "systemctl status pi-release-pull.timer --no-pager 2>&1 | head -20" || echo "(timer not found)"
+          echo '```'
+          echo ""
+          echo "#### Last 30 service log lines"
+          echo '```'
+          $SSH "journalctl -u pi-release-pull.service -n 30 --no-pager 2>&1 || journalctl -t pi-release-pull -n 30 --no-pager 2>&1 || echo '(no logs)'"
+          echo '```'
+          echo ""
+          echo "#### Env file present"
+          echo '```'
+          $SSH "test -f /etc/cloudless/pi-release-pull.env && echo 'EXISTS — keys:' && sudo grep -oP '^[A-Z_]+' /etc/cloudless/pi-release-pull.env | sort || echo 'MISSING'"
+          echo '```'
+          echo ""
+          echo "#### Script present"
+          echo '```'
+          $SSH "test -f /usr/local/sbin/pi-release-pull.sh && echo 'EXISTS' || echo 'MISSING'"
+          echo '```'
+          echo ""
+          echo "#### System load + iowait"
+          echo '```'
+          $SSH "uptime && mpstat 1 1 2>/dev/null | tail -3 || echo '(mpstat unavailable)'"
+          echo '```'
+          echo ""
+          echo "#### Current symlink / health"
+          echo '```'
+          $SSH "readlink /home/tbaltzakis/cloudless-standalone 2>/dev/null || echo '(symlink missing)'; curl -sS --max-time 5 http://127.0.0.1:30300/api/health 2>/dev/null || echo '(health unreachable)'"
+          echo '```'
+        } | tee /tmp/diag.md
+        echo "done"
+
+    - name: Post results
+      if: always()
+      run: |
+        gh issue comment "$ISSUE" \
+          --repo "${{ github.repository }}" \
+          --body-file /tmp/diag.md

--- a/.github/workflows/update-orchestrator-token.yml
+++ b/.github/workflows/update-orchestrator-token.yml
@@ -1,0 +1,44 @@
+name: Update orchestrator deploy token
+
+# One-shot: rotates DEPLOY_ORCHESTRATOR_TOKEN on the CF Worker and GH secret.
+# Run once after writing a new token to /etc/cloudless/pi-release-pull.env on omv.
+on:
+  workflow_dispatch:
+    inputs:
+      new_token:
+        description: New DEPLOY_ORCHESTRATOR_TOKEN value (hex string)
+        required: true
+
+permissions:
+  contents: read
+  secrets: write
+
+jobs:
+  rotate:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd         # v4.3.1
+
+    - name: Update Cloudflare Worker secret
+      env:
+        CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+        CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CF_ACCOUNT_ID }}
+        NEW_TOKEN: ${{ inputs.new_token }}
+      run: |
+        set -euo pipefail
+        cd workers/pi-deploy-orchestrator
+        echo "$NEW_TOKEN" | npx wrangler secret put DEPLOY_ORCHESTRATOR_TOKEN
+        echo "CF Worker secret updated"
+
+    - name: Update GitHub secret
+      env:
+        GH_TOKEN: ${{ secrets.GH_TOKEN_ADMIN }}
+        NEW_TOKEN: ${{ inputs.new_token }}
+      run: |
+        set -euo pipefail
+        if [ -z "${GH_TOKEN:-}" ]; then
+          echo "::warning::GH_TOKEN_ADMIN not set — skipping GitHub secret update; set DEPLOY_ORCHESTRATOR_TOKEN manually via gh secret set"
+          exit 0
+        fi
+        echo "$NEW_TOKEN" | gh secret set DEPLOY_ORCHESTRATOR_TOKEN --repo "${{ github.repository }}"
+        echo "GitHub secret updated"


### PR DESCRIPTION
## Summary

- Replace ASCII hyphens with proper en/em dashes in two files (ai-assistant age range placeholder, agents page metadata)
- Add `debug-pi-pull.yml` diagnostic workflow (workflow_dispatch, SSHes to omv and reports pull agent status)
- Add `update-orchestrator-token.yml` one-off token rotation workflow (workflow_dispatch, updates CF Worker secret + GH secret)

## Context

The Pi's `pi-release-pull.timer` has been inactive since 2026-08-26. Root cause: `/etc/cloudless/pi-release-pull.env` was missing so the service exited with 401 on every tick. This PR gets the rotation workflow onto main so we can fix the CF Worker secret mismatch.

## Test plan

- [ ] Merge → trigger `update-orchestrator-token.yml` with the new token
- [ ] Verify Pi pulls and deploys successfully
- [ ] Typography changes visible on agents page and ai-assistant placeholder

🤖 Generated with [Claude Code](https://claude.com/claude-code)