### PR TITLE
fix: wrangler secret put needs --name pi-deploy-orchestrator

### DIFF
--- a/.github/workflows/update-orchestrator-token.yml
+++ b/.github/workflows/update-orchestrator-token.yml
@@ -26,5 +26,5 @@ jobs:
       run: |
         set -euo pipefail
         cd workers/pi-deploy-orchestrator
-        echo "$NEW_TOKEN" | npx wrangler secret put DEPLOY_ORCHESTRATOR_TOKEN
+        echo "$NEW_TOKEN" | npx wrangler secret put DEPLOY_ORCHESTRATOR_TOKEN --name pi-deploy-orchestrator
         echo "CF Worker secret updated"


### PR DESCRIPTION
Previous run targeted cloudless-analytics instead of pi-deploy-orchestrator because wrangler v4 doesn't always infer the worker name from wrangler.jsonc. Add --name explicitly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)