### PR TITLE
ci(deploy-pi): serialize deploys to stop mid-build cancellations

### DIFF
--- a/.github/workflows/deploy-pi.yml
+++ b/.github/workflows/deploy-pi.yml
@@ -30,6 +30,16 @@ on:
 permissions:
   contents: read
 
+# Serialize deploys: a newer push queues behind the running build instead of
+# aborting it. cancel-in-progress: false lets the in-flight build finish (so
+# hostPath never lands on a partial/stale sync); GitHub keeps at most one
+# pending run per group, superseding older *queued* runs but never the running
+# one. Fixes builds cancelled mid-"Finalizing page optimization" when rapid
+# main merges arrive during the ~25min Pi build.
+concurrency:
+  group: deploy-pi
+  cancel-in-progress: false
+
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
   K3S_NAMESPACE: cloudless


### PR DESCRIPTION
## Summary

The `deploy-pi.yml` workflow's Next.js standalone build was being cancelled mid-run — the failing run compiled successfully (11.3min), passed TypeScript (9.1min), generated all 575 static pages, then died at `Finalizing page optimization` with `Error: The operation was canceled.` after 26min.

Root cause: the workflow's header comment documents a concurrency serialize (`cancel-in-progress: false + queue: max`) as the fix for rapid `main` merges aborting an in-progress build, but **no `concurrency:` block was ever present in the file**. Without it, a newer push to `main` ran a second `deploy-pi` in parallel, and one build superseded/cancelled the other mid-flight, leaving the hostPath sync on a partial/stale SHA.

This PR adds the concurrency block the comment already promised:

```yaml
concurrency:
  group: deploy-pi
  cancel-in-progress: false
```

A newer push now queues behind the running build (GitHub keeps at most one pending run per group, superseding older *queued* runs but never the running one), so the ~25min Pi build always finishes and the hostPath sync is never partial.

## Type of change

- [x] CI / DevOps

## Related issues

Closes #

## Testing

- [x] No tests required (explain why): CI-only change to a GitHub Actions workflow. YAML validated with `yaml.safe_load` — `concurrency` parses to `{group: deploy-pi, cancel-in-progress: false}`. Behavior verifies on the next concurrent push to `main`, where the second run will queue instead of cancelling the first.

## Checklist

- [x] No secrets or sensitive values committed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01LrZjfBcQbDLZ8LpU41a5Ws)_