### PR TITLE
feat(dns): add TikTok site verification DNS TXT record

### DIFF
--- a/.github/workflows/add-tiktok-dns-verification.yml
+++ b/.github/workflows/add-tiktok-dns-verification.yml
@@ -1,0 +1,69 @@
+name: Add TikTok DNS Verification TXT Record
+
+# Adds tiktok-developers-site-verification=TOKEN as a DNS TXT record on
+# cloudless.gr so TikTok's domain verification succeeds without requiring
+# their crawler to pass Cloudflare Bot Management.
+#
+# HOW TO RUN: push any change to this file (or workflow_dispatch).
+# Result is posted to issue #382. Idempotent — safe to re-run.
+
+on:
+  push:
+    branches: [main]
+    paths:
+    - .github/workflows/add-tiktok-dns-verification.yml
+    - scripts/add-tiktok-dns-verification.sh
+  workflow_dispatch:
+
+permissions:
+  id-token: write
+  contents: read
+  issues: write
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
+
+concurrency:
+  group: tiktok-dns-verification
+  cancel-in-progress: false
+
+jobs:
+  add-dns-record:
+    name: Add TikTok TXT record
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    env:
+      GH_TOKEN: ${{ github.token }}
+    steps:
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd         # v4.3.1
+
+    - name: Configure AWS credentials (OIDC)
+      continue-on-error: true
+      uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a         # v4
+      with:
+        role-to-assume: ${{ secrets.AWS_DEPLOY_ROLE_ARN }}
+        aws-region: us-east-1
+
+    - name: Add TXT record
+      id: add
+      env:
+        CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+      run: |
+        set -o pipefail
+        bash scripts/add-tiktok-dns-verification.sh 2>&1 | tee tiktok-dns.log
+
+    - name: Post result to tracking issue
+      if: always()
+      run: |
+        {
+          echo "# TikTok DNS Verification — $(date -u '+%F %T')Z"
+          echo ""
+          echo "**Job:** ${{ job.status }}"
+          echo ""
+          echo '```'
+          cat tiktok-dns.log 2>/dev/null || echo '(no log)'
+          echo '```'
+          echo ""
+          echo "After the record propagates, go to the TikTok Developer Portal and click **Verify** again."
+        } > c.md
+        gh issue comment 382 --repo "${{ github.repository }}" --body-file c.md

--- a/scripts/add-tiktok-dns-verification.sh
+++ b/scripts/add-tiktok-dns-verification.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+# Add TikTok site-verification DNS TXT record to the cloudless.gr zone.
+#
+# TikTok's verification bot checks for either:
+#   <meta name="tiktok-developers-site-verification" content="TOKEN">
+#   OR a DNS TXT record: tiktok-developers-site-verification=TOKEN
+#
+# We use the TXT record because Cloudflare Bot Management may challenge TikTok's
+# HTTP crawler before it can read the meta tag.
+#
+# Auth: CLOUDFLARE_API_TOKEN env, else SSM /cloudless/production/CLOUDFLARE_API_TOKEN.
+# Token needs Zone:Read + Zone:DNS:Edit on cloudless.gr.
+# Idempotent: skips creation if the exact record already exists.
+set -euo pipefail
+
+DOMAIN="${DOMAIN:-cloudless.gr}"
+TXT_VALUE="tiktok-developers-site-verification=30QWkDq9g0olcwcIDueeqBix84M0VCXn"
+API="https://api.cloudflare.com/client/v4"
+
+CF_TOKEN="${CLOUDFLARE_API_TOKEN:-}"
+if [ -z "$CF_TOKEN" ]; then
+  CF_TOKEN="$(aws ssm get-parameter --name /cloudless/production/CLOUDFLARE_API_TOKEN \
+    --with-decryption --query Parameter.Value --output text 2>/dev/null || true)"
+fi
+if [ -z "$CF_TOKEN" ]; then
+  echo "::error::no CLOUDFLARE_API_TOKEN — add a repo secret or SSM /cloudless/production/CLOUDFLARE_API_TOKEN with Zone:Read + Zone:DNS:Edit."
+  exit 1
+fi
+
+cf() {
+  local method="$1" url="$2" body="${3:-}"
+  if [ -n "$body" ]; then
+    curl -fsS -X "$method" "$url" \
+      -H "Authorization: Bearer ${CF_TOKEN}" \
+      -H "Content-Type: application/json" \
+      --data "$body"
+  else
+    curl -fsS -X "$method" "$url" \
+      -H "Authorization: Bearer ${CF_TOKEN}"
+  fi
+}
+
+echo "→ Looking up zone ID for ${DOMAIN}…"
+ZONE_ID="$(cf GET "${API}/zones?name=${DOMAIN}&status=active" | \
+  jq -r '.result[0].id // empty')"
+if [ -z "$ZONE_ID" ]; then
+  echo "::error::zone not found for ${DOMAIN} — check token permissions."
+  exit 1
+fi
+echo "  zone_id=${ZONE_ID}"
+
+echo "→ Checking for existing TXT record…"
+EXISTING="$(cf GET "${API}/zones/${ZONE_ID}/dns_records?type=TXT&name=${DOMAIN}&per_page=100" | \
+  jq -r --arg v "$TXT_VALUE" '.result[] | select(.content == $v) | .id')"
+
+if [ -n "$EXISTING" ]; then
+  echo "✓ TXT record already exists (id=${EXISTING}) — nothing to do."
+  exit 0
+fi
+
+echo "→ Creating TXT record: ${TXT_VALUE}"
+RESULT="$(cf POST "${API}/zones/${ZONE_ID}/dns_records" \
+  "{\"type\":\"TXT\",\"name\":\"${DOMAIN}\",\"content\":\"${TXT_VALUE}\",\"ttl\":300}")"
+
+if echo "$RESULT" | jq -e '.success == true' > /dev/null; then
+  RECORD_ID="$(echo "$RESULT" | jq -r '.result.id')"
+  echo "✓ TXT record created (id=${RECORD_ID})"
+else
+  echo "::error::failed to create DNS record: $(echo "$RESULT" | jq -c .)"
+  exit 1
+fi
+
+echo "→ Verifying record is live (may take up to 60s)…"
+for i in $(seq 1 12); do
+  txt="$(dig +short TXT "${DOMAIN}" @1.1.1.1 2>/dev/null | grep -F "$TXT_VALUE" || true)"
+  if [ -n "$txt" ]; then
+    echo "✓ TXT record visible via 1.1.1.1 (attempt ${i})"
+    exit 0
+  fi
+  echo "  … not visible yet (attempt ${i}), waiting 5s…"
+  sleep 5
+done
+echo "::warning::record created but not yet visible via DNS — may take a few more seconds to propagate."


### PR DESCRIPTION
## Summary
- Adds `scripts/add-tiktok-dns-verification.sh` — idempotent script that creates a DNS TXT record on cloudless.gr via the Cloudflare API
- Adds `.github/workflows/add-tiktok-dns-verification.yml` — fires on push to this file or `workflow_dispatch`
- TXT value: `tiktok-developers-site-verification=30QWkDq9g0olcwcIDueeqBix84M0VCXn`

## Why DNS instead of meta tag
The meta tag is already deployed and live in the HTML, but Cloudflare Bot Management challenges TikTok's verification crawler before it can read the tag. DNS TXT verification bypasses HTTP entirely.

## Test plan
- [ ] Merge triggers the workflow automatically
- [ ] Script logs show "✓ TXT record created" or "already exists"
- [ ] `dig TXT cloudless.gr` shows the verification record
- [ ] Click **Verify** on TikTok Developer Portal → success

🤖 Generated with [Claude Code](https://claude.com/claude-code)