### PR TITLE
Parameterize TikTok DNS verification token

### DIFF
--- a/.github/workflows/add-tiktok-dns-verification.yml
+++ b/.github/workflows/add-tiktok-dns-verification.yml
@@ -11,9 +11,14 @@ on:
   push:
     branches: [main]
     paths:
-    - .github/workflows/add-tiktok-dns-verification.yml
-    - scripts/add-tiktok-dns-verification.sh
+      - .github/workflows/add-tiktok-dns-verification.yml
+      - scripts/add-tiktok-dns-verification.sh
   workflow_dispatch:
+    inputs:
+      verification_token:
+        description: "TikTok verification token (value after the equals sign)"
+        required: true
+        type: string
 
 permissions:
   id-token: write
@@ -21,7 +26,7 @@ permissions:
   issues: write
 
 env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
 
 concurrency:
   group: tiktok-dns-verification
@@ -34,36 +39,37 @@ jobs:
     timeout-minutes: 10
     env:
       GH_TOKEN: ${{ github.token }}
+      TIKTOK_VERIFICATION_TOKEN: ${{ github.event.inputs.verification_token }}
     steps:
-    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd         # v4.3.1
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v4.3.1
 
-    - name: Configure AWS credentials (OIDC)
-      continue-on-error: true
-      uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a         # v4
-      with:
-        role-to-assume: ${{ secrets.AWS_DEPLOY_ROLE_ARN }}
-        aws-region: us-east-1
+      - name: Configure AWS credentials (OIDC)
+        continue-on-error: true
+        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4
+        with:
+          role-to-assume: ${{ secrets.AWS_DEPLOY_ROLE_ARN }}
+          aws-region: us-east-1
 
-    - name: Add TXT record
-      id: add
-      env:
-        CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-      run: |
-        set -o pipefail
-        bash scripts/add-tiktok-dns-verification.sh 2>&1 | tee tiktok-dns.log
+      - name: Add TXT record
+        id: add
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+        run: |
+          set -o pipefail
+          bash scripts/add-tiktok-dns-verification.sh 2>&1 | tee tiktok-dns.log
 
-    - name: Post result to tracking issue
-      if: always()
-      run: |
-        {
-          echo "# TikTok DNS Verification — $(date -u '+%F %T')Z"
-          echo ""
-          echo "**Job:** ${{ job.status }}"
-          echo ""
-          echo '```'
-          cat tiktok-dns.log 2>/dev/null || echo '(no log)'
-          echo '```'
-          echo ""
-          echo "After the record propagates, go to the TikTok Developer Portal and click **Verify** again."
-        } > c.md
-        gh issue comment 382 --repo "${{ github.repository }}" --body-file c.md
+      - name: Post result to tracking issue
+        if: always()
+        run: |
+          {
+            echo "# TikTok DNS Verification — $(date -u '+%F %T')Z"
+            echo ""
+            echo "**Job:** ${{ job.status }}"
+            echo ""
+            echo '```'
+            cat tiktok-dns.log 2>/dev/null || echo '(no log)'
+            echo '```'
+            echo ""
+            echo "After the record propagates, go to the TikTok Developer Portal and click **Verify** again."
+          } > c.md
+          gh issue comment 382 --repo "${{ github.repository }}" --body-file c.md

--- a/scripts/add-tiktok-dns-verification.sh
+++ b/scripts/add-tiktok-dns-verification.sh
@@ -34,14 +34,21 @@ fi
 
 cf() {
   local method="$1" url="$2" body="${3:-}"
+  local http_code out
+  out=$(mktemp)
   if [ -n "$body" ]; then
-    curl -fsS -X "$method" "$url" \
+    http_code=$(curl -sS -o "$out" -w '%{http_code}' -X "$method" "$url" \
       -H "Authorization: Bearer ${CF_TOKEN}" \
       -H "Content-Type: application/json" \
-      --data "$body"
+      --data "$body")
   else
-    curl -fsS -X "$method" "$url" \
-      -H "Authorization: Bearer ${CF_TOKEN}"
+    http_code=$(curl -sS -o "$out" -w '%{http_code}' -X "$method" "$url" \
+      -H "Authorization: Bearer ${CF_TOKEN}")
+  fi
+  cat "$out"
+  rm -f "$out"
+  if [ "$http_code" -ge 400 ]; then
+    return "$http_code"
   fi
 }
 
@@ -64,8 +71,11 @@ if [ -n "$EXISTING" ]; then
 fi
 
 echo "→ Creating TXT record: ${TXT_VALUE}"
-RESULT="$(cf POST "${API}/zones/${ZONE_ID}/dns_records" \
-  "{\"type\":\"TXT\",\"name\":\"${DOMAIN}\",\"content\":\"${TXT_VALUE}\",\"ttl\":300}")"
+if ! RESULT="$(cf POST "${API}/zones/${ZONE_ID}/dns_records" \
+  "{\"type\":\"TXT\",\"name\":\"${DOMAIN}\",\"content\":\"${TXT_VALUE}\",\"ttl\":300}")"; then
+  echo "::error::failed to create DNS record: $(echo "$RESULT" | jq -c . 2>/dev/null || echo "$RESULT")"
+  exit 1
+fi
 
 if echo "$RESULT" | jq -e '.success == true' > /dev/null; then
   RECORD_ID="$(echo "$RESULT" | jq -r '.result.id')"

--- a/scripts/add-tiktok-dns-verification.sh
+++ b/scripts/add-tiktok-dns-verification.sh
@@ -14,7 +14,12 @@
 set -euo pipefail
 
 DOMAIN="${DOMAIN:-cloudless.gr}"
-TXT_VALUE="tiktok-developers-site-verification=30QWkDq9g0olcwcIDueeqBix84M0VCXn"
+TIKTOK_VERIFICATION_TOKEN="${TIKTOK_VERIFICATION_TOKEN:-}"
+if [ -z "$TIKTOK_VERIFICATION_TOKEN" ]; then
+  echo "::error::TIKTOK_VERIFICATION_TOKEN is required."
+  exit 1
+fi
+TXT_VALUE="tiktok-developers-site-verification=${TIKTOK_VERIFICATION_TOKEN}"
 API="https://api.cloudflare.com/client/v4"
 
 CF_TOKEN="${CLOUDFLARE_API_TOKEN:-}"

--- a/scripts/cf-token-smoketest.sh
+++ b/scripts/cf-token-smoketest.sh
@@ -98,7 +98,7 @@ if [ -n "$ZONE_ID" ]; then
   fi
 fi
 
-# ── 3. DNS:Edit (Read leg) ───────────────────────────────────────────────────
+# ── 3. DNS:Read/Edit ─────────────────────────────────────────────────────────
 if [ -n "$ZONE_ID" ]; then
   DNS="$(curl_cf "$API/zones/$ZONE_ID/dns_records?per_page=1")"
   DNS_OK="$(echo "$DNS" | jq -r '.success')"
@@ -107,6 +107,26 @@ if [ -n "$ZONE_ID" ]; then
   else
     ERR_MSG="$(echo "$DNS" | jq -r '.errors[0].message // "unknown"')"
     check "DNS:Read" "$ERR_MSG"
+  fi
+
+  # Probe DNS:Edit by creating and immediately deleting a test TXT record.
+  TEST_RECORD="tiktok-developers-site-verification=cf-smoketest-$(date +%s)"
+  DNS_CREATE="$(curl_cf -X POST -d "{\"type\":\"TXT\",\"name\":\"_cf-smoketest.${ZONE_NAME}\",\"content\":\"${TEST_RECORD}\",\"ttl\":60,\"comment\":\"smoketest\"}" "$API/zones/$ZONE_ID/dns_records")"
+  DNS_CREATE_OK="$(echo "$DNS_CREATE" | jq -r '.success')"
+  DNS_CREATE_ID="$(echo "$DNS_CREATE" | jq -r '.result.id // empty')"
+  if [ "$DNS_CREATE_OK" = "true" ] && [ -n "$DNS_CREATE_ID" ]; then
+    DNS_DELETE="$(curl_cf -X DELETE "$API/zones/$ZONE_ID/dns_records/$DNS_CREATE_ID")"
+    DNS_DELETE_OK="$(echo "$DNS_DELETE" | jq -r '.success')"
+    if [ "$DNS_DELETE_OK" = "true" ]; then
+      check "DNS:Edit" ok
+    else
+      ERR_MSG="$(echo "$DNS_DELETE" | jq -r '.errors[0].message // "unknown"')"
+      check "DNS:Edit (cleanup failed)" "$ERR_MSG"
+    fi
+  else
+    ERR_CODE="$(echo "$DNS_CREATE" | jq -r '.errors[0].code // "unknown"')"
+    ERR_MSG="$(echo "$DNS_CREATE" | jq -r '.errors[0].message // "unknown"')"
+    check "DNS:Edit" "code=$ERR_CODE: $ERR_MSG"
   fi
 fi
 


### PR DESCRIPTION
## Summary
- Parameterize the TikTok DNS verification token in `.github/workflows/add-tiktok-dns-verification.yml` so it can be passed via `workflow_dispatch` input instead of hardcoded.
- Update `scripts/add-tiktok-dns-verification.sh` to require `TIKTOK_VERIFICATION_TOKEN` and report Cloudflare API error bodies cleanly.
- Add a `DNS:Edit` probe to `scripts/cf-token-smoketest.sh` to catch under-scoped Cloudflare tokens before they break DNS workflows.

## Test plan
- [x] `add-tiktok-dns-verification.yml` ran successfully with the new token and created the TXT record on `cloudless.gr`.
- [x] Public DNS (`1.1.1.1`) now returns `tiktok-developers-site-verification=wYqY00jkt9hZGPp8xib23eT4lAV64jxJ`.

Generated with [Devin](https://devin.ai)