### PR TITLE
Allow Tailscale CI to recover Pi runners

### DIFF
--- a/docs/cluster/TAILSCALE-FABRIC.md
+++ b/docs/cluster/TAILSCALE-FABRIC.md
@@ -201,13 +201,14 @@ resolver on the Pi (CoreDNS / LAN DNS stay authoritative).
 
 ### Grants + Tailscale SSH (hardened 2026-08-12)
 
-| Src                                  | Dst                                                             | Allow                      |
-| ------------------------------------ | --------------------------------------------------------------- | -------------------------- |
-| admin                                | `tag:k8s` / `tag:k8s-operator` / `tag:app-connector` / `tag:pi` | `*`                        |
-| member                               | `tag:pi`                                                        | `tcp:22` (classic OpenSSH) |
-| member                               | `tag:k8s`                                                       | `tcp:80`, `tcp:443`        |
-| member                               | `tag:app-connector`                                             | DNS `53` only              |
-| admin/member SSH (Tailscale SSH ACL) | `tag:pi` + self                                                 | `accept` (no check-mode)   |
+| Src                                  | Dst                                                             | Allow                                          |
+| ------------------------------------ | --------------------------------------------------------------- | ---------------------------------------------- |
+| admin                                | `tag:k8s` / `tag:k8s-operator` / `tag:app-connector` / `tag:pi` | `*`                                            |
+| member                               | `tag:pi`                                                        | `tcp:22` (classic OpenSSH)                     |
+| `tag:ci`                             | `tag:pi`                                                        | `tcp:22`, `tcp:30700`, `tcp:30900`, `tcp:6443` |
+| member                               | `tag:k8s`                                                       | `tcp:80`, `tcp:443`                            |
+| member                               | `tag:app-connector`                                             | DNS `53` only                                  |
+| admin/member SSH (Tailscale SSH ACL) | `tag:pi` + self                                                 | `accept` (no check-mode)                       |
 
 **Device tags (canonical — `scripts/tailscale-retag-fleet.sh`):**
 

--- a/infrastructure/tailscale/acl-policy.example.json
+++ b/infrastructure/tailscale/acl-policy.example.json
@@ -1,43 +1,21 @@
 {
   "tagOwners": {
-    "tag:k8s-operator": [
-      "autogroup:admin"
-    ],
-    "tag:k8s": [
-      "tag:k8s-operator"
-    ],
-    "tag:app-connector": [
-      "autogroup:admin"
-    ],
-    "tag:pi": [
-      "autogroup:admin"
-    ],
-    "tag:ci": [
-      "autogroup:admin"
-    ]
+    "tag:k8s-operator": ["autogroup:admin"],
+    "tag:k8s": ["tag:k8s-operator"],
+    "tag:app-connector": ["autogroup:admin"],
+    "tag:pi": ["autogroup:admin"],
+    "tag:ci": ["autogroup:admin"]
   },
   "autoApprovers": {
     "routes": {
-      "10.42.0.0/16": [
-        "tag:k8s"
-      ],
-      "10.43.0.0/16": [
-        "tag:k8s"
-      ],
-      "0.0.0.0/0": [
-        "tag:app-connector"
-      ],
-      "::/0": [
-        "tag:app-connector"
-      ]
+      "10.42.0.0/16": ["tag:k8s"],
+      "10.43.0.0/16": ["tag:k8s"],
+      "0.0.0.0/0": ["tag:app-connector"],
+      "::/0": ["tag:app-connector"]
     },
     "services": {
-      "svc:*": [
-        "tag:k8s"
-      ],
-      "tag:k8s": [
-        "tag:k8s"
-      ]
+      "svc:*": ["tag:k8s"],
+      "tag:k8s": ["tag:k8s"]
     }
   },
   "grants": [
@@ -49,7 +27,7 @@
     {
       "src": ["tag:ci"],
       "dst": ["tag:pi"],
-      "ip": ["tcp:30700", "tcp:30900", "tcp:6443"]
+      "ip": ["tcp:22", "tcp:30700", "tcp:30900", "tcp:6443"]
     },
     {
       "src": ["autogroup:member"],
@@ -92,85 +70,48 @@
   ],
   "nodeAttrs": [
     {
-      "target": [
-        "*"
-      ],
+      "target": ["*"],
       "app": {
         "tailscale.com/app-connectors": [
           {
             "name": "github",
-            "connectors": [
-              "tag:app-connector"
-            ],
+            "connectors": ["tag:app-connector"],
             "presetAppID": "github"
           },
           {
             "name": "stripe",
-            "connectors": [
-              "tag:app-connector"
-            ],
+            "connectors": ["tag:app-connector"],
             "presetAppID": "stripe"
           },
           {
             "name": "google-workspace",
-            "connectors": [
-              "tag:app-connector"
-            ],
+            "connectors": ["tag:app-connector"],
             "presetAppID": "google-workspace"
           },
           {
             "name": "notion",
-            "connectors": [
-              "tag:app-connector"
-            ],
-            "domains": [
-              "www.notion.so",
-              "notion.so",
-              "*.notion.so",
-              "api.notion.com"
-            ]
+            "connectors": ["tag:app-connector"],
+            "domains": ["www.notion.so", "notion.so", "*.notion.so", "api.notion.com"]
           },
           {
             "name": "sentry",
-            "connectors": [
-              "tag:app-connector"
-            ],
-            "domains": [
-              "*.sentry.io",
-              "sentry.io"
-            ]
+            "connectors": ["tag:app-connector"],
+            "domains": ["*.sentry.io", "sentry.io"]
           },
           {
             "name": "slack",
-            "connectors": [
-              "tag:app-connector"
-            ],
-            "domains": [
-              "*.slack.com",
-              "slack.com",
-              "api.slack.com"
-            ]
+            "connectors": ["tag:app-connector"],
+            "domains": ["*.slack.com", "slack.com", "api.slack.com"]
           },
           {
             "name": "cloudflare",
-            "connectors": [
-              "tag:app-connector"
-            ],
-            "domains": [
-              "dash.cloudflare.com",
-              "api.cloudflare.com",
-              "*.cloudflare.com"
-            ]
+            "connectors": ["tag:app-connector"],
+            "domains": ["dash.cloudflare.com", "api.cloudflare.com", "*.cloudflare.com"]
           },
           {
             "name": "anthropic",
-            "connectors": [
-              "tag:app-connector"
-            ],
-            "domains": [
-              "api.anthropic.com",
-              "console.anthropic.com"
-            ]
+            "connectors": ["tag:app-connector"],
+            "domains": ["api.anthropic.com", "console.anthropic.com"]
           }
         ]
       }


### PR DESCRIPTION
## Summary

- allow `tag:ci` to reach classic OpenSSH on `tag:pi` nodes
- preserve the existing narrow access to k3s, EspoCRM, and n8n ports
- document the recovery path in the Tailscale fabric source of truth

## Type of change

- [x] Bug fix
- [x] CI / DevOps
- [x] Documentation

## Related issues

Related to #382

## Testing

- [x] ACL JSON parsed successfully
- [x] Semantic comparison confirms only `tcp:22` was added to the CI grant
- [x] Live runner recovery will be re-run after merge

## Checklist

- [x] Access remains identity-scoped from `tag:ci` to `tag:pi`
- [x] No public SSH exposure added
- [x] No secrets or sensitive values committed

Generated with [Devin](https://devin.ai)