### PR TITLE
Route Tailscale recovery alerts to Slack and email

### DIFF
--- a/.github/workflows/restart-pi-runners.yml
+++ b/.github/workflows/restart-pi-runners.yml
@@ -28,6 +28,42 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v4.3.1
 
+      - name: Ensure Tailscale Slack channel
+        id: slack-channel
+        env:
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+        run: |
+          python3 - <<'PY'
+          import json
+          import os
+          import urllib.parse
+          import urllib.request
+
+          token = os.environ["SLACK_BOT_TOKEN"]
+
+          def call(method, payload=None):
+              data = json.dumps(payload).encode() if payload is not None else None
+              request = urllib.request.Request(
+                  f"https://slack.com/api/{method}",
+                  data=data,
+                  headers={"Authorization": f"Bearer {token}", "Content-Type": "application/json"},
+              )
+              with urllib.request.urlopen(request, timeout=20) as response:
+                  result = json.load(response)
+              if not result.get("ok"):
+                  raise SystemExit(f"Slack {method} failed: {result.get('error', 'unknown_error')}")
+              return result
+
+          query = urllib.parse.urlencode({"exclude_archived": "true", "limit": 200, "types": "public_channel"})
+          channels = call(f"conversations.list?{query}")["channels"]
+          channel = next((item for item in channels if item["name"] == "tailscale"), None)
+          if channel is None:
+              channel = call("conversations.create", {"name": "tailscale", "is_private": False})["channel"]
+          with open(os.environ["GITHUB_OUTPUT"], "a", encoding="utf-8") as output:
+              output.write(f"channel_id={channel['id']}\n")
+          print(f"Tailscale notifications channel ready: #{channel['name']}")
+          PY
+
       - name: Connect to tailnet with OAuth
         id: tailscale-oauth
         continue-on-error: true
@@ -77,6 +113,82 @@ jobs:
 
           echo "=== Runner service status (after) ==="
           $SSH "sudo systemctl list-units 'actions.runner.*' --no-pager --all" || true
+
+      - name: Post result to Tailscale Slack channel
+        if: always() && steps.slack-channel.outputs.channel_id != ''
+        env:
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+          CHANNEL_ID: ${{ steps.slack-channel.outputs.channel_id }}
+          JOB_STATUS: ${{ job.status }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          python3 - <<'PY'
+          import json
+          import os
+          import urllib.request
+
+          status = os.environ["JOB_STATUS"]
+          payload = {
+              "channel": os.environ["CHANNEL_ID"],
+              "text": f"Tailscale runner recovery {status}",
+              "blocks": [
+                  {
+                      "type": "header",
+                      "text": {"type": "plain_text", "text": f"Tailscale runner recovery: {status}"},
+                  },
+                  {
+                      "type": "section",
+                      "text": {
+                          "type": "mrkdwn",
+                          "text": f"The automated Pi runner recovery workflow finished with *{status}*.",
+                      },
+                  },
+                  {
+                      "type": "section",
+                      "text": {"type": "mrkdwn", "text": f"<{os.environ['RUN_URL']}|Open workflow run>"},
+                  },
+              ],
+          }
+          request = urllib.request.Request(
+              "https://slack.com/api/chat.postMessage",
+              data=json.dumps(payload).encode(),
+              headers={
+                  "Authorization": f"Bearer {os.environ['SLACK_BOT_TOKEN']}",
+                  "Content-Type": "application/json",
+              },
+          )
+          with urllib.request.urlopen(request, timeout=20) as response:
+              result = json.load(response)
+          if not result.get("ok"):
+              raise SystemExit(f"Slack chat.postMessage failed: {result.get('error', 'unknown_error')}")
+          print("Tailscale runner recovery notification sent")
+          PY
+
+      - name: Send operator email notification
+        if: always()
+        run: |
+          payload=$(python3 - <<'PY'
+          import json
+          import os
+          print(json.dumps({
+              "severity": os.environ.get("SEVERITY", "high"),
+              "title": f"Tailscale runner recovery {os.environ['JOB_STATUS']}",
+              "message": "The automated Pi runner recovery workflow completed.",
+              "click": os.environ["RUN_URL"],
+              "source": "github-actions/tailscale",
+          }))
+          PY
+          )
+          curl --fail --silent --show-error --max-time 30 \
+            -X POST http://github-omv.tail4ecae1.ts.net:30300/api/webhooks/admin-alert \
+            -H "x-cloudless-alert-secret: $ALERT_SECRET" \
+            -H "content-type: application/json" \
+            --data "$payload"
+        env:
+          ALERT_SECRET: ${{ secrets.NOTION_WEBHOOK_SECRET }}
+          JOB_STATUS: ${{ job.status }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          SEVERITY: ${{ job.status == 'success' && 'info' || 'high' }}
 
       - name: Post result to tracking issue
         if: always()

--- a/docs/NOTIFICATIONS.md
+++ b/docs/NOTIFICATIONS.md
@@ -1,7 +1,7 @@
 # Notifications — cloudless.gr
 
 Canonical map of every notification channel and event source. Three layers:
-**app-layer** (Next.js routes → Slack/ntfy/D1), **ops-layer** (admin alerts
+**app-layer** (Next.js routes → Slack/ntfy/email/D1), **ops-layer** (admin alerts
 fan-out via `notifyAdmin()`), and **infra-layer** (systemd watchdog,
 Alertmanager, pi-alert-api — independent of the app process).
 
@@ -19,15 +19,15 @@ exponential backoff. Identical errors are deduplicated for 10 min
 
 **Per-channel routing:**
 
-| `SlackClient` instance | Slack channel | Events |
-|---|---|---|
-| `bookingsClient` | `#bookings` | `slackBookingNotify` |
-| `ordersClient` | `#orders` | `slackOrderNotify` |
-| `errorsClient` | `#errors` | `slackErrorNotify` |
-| `deploymentsClient` | `#deployments` | `slackDeployNotify` |
-| `contactsClient` | `#notifications` | `slackContactNotify` |
-| `subscribersClient` | `#newsletter` (or `NEWSLETTER_SLACK_CHANNEL_ID`) | `slackSubscriberNotify` |
-| `interactionsClient` | `#notifications` | `slackChatNotify`, `slackTicketNotify`, `slackRegistrationNotify` |
+| `SlackClient` instance | Slack channel                                    | Events                                                            |
+| ---------------------- | ------------------------------------------------ | ----------------------------------------------------------------- |
+| `bookingsClient`       | `#bookings`                                      | `slackBookingNotify`                                              |
+| `ordersClient`         | `#orders`                                        | `slackOrderNotify`                                                |
+| `errorsClient`         | `#errors`                                        | `slackErrorNotify`                                                |
+| `deploymentsClient`    | `#deployments`                                   | `slackDeployNotify`                                               |
+| `contactsClient`       | `#notifications`                                 | `slackContactNotify`                                              |
+| `subscribersClient`    | `#newsletter` (or `NEWSLETTER_SLACK_CHANNEL_ID`) | `slackSubscriberNotify`                                           |
+| `interactionsClient`   | `#notifications`                                 | `slackChatNotify`, `slackTicketNotify`, `slackRegistrationNotify` |
 
 Config: `SLACK_BOT_TOKEN`, `SLACK_WEBHOOK_URL`, `SLACK_DEFAULT_CHANNEL`. See
 [`docs/integrations/SLACK.md`](integrations/SLACK.md) for the full setup.
@@ -82,15 +82,15 @@ Admin UI at `/admin/notifications`. Analytics endpoint at
 
 ## Fan-out helper — `src/lib/admin-alerts.ts`
 
-`notifyAdmin(input)` fires both Slack and ntfy in parallel via
-`Promise.allSettled` — one failing channel never blocks the other.
+`notifyAdmin(input)` fires Slack, ntfy, and the canonical transactional email
+transport in parallel via `Promise.allSettled` — one failing channel never blocks the others.
 
 ```ts
 await notifyAdmin({
-  severity: "high",   // info | warning | error | high | critical
-  title:    "espocrm down",
-  message:  "5xx from /api/v1/App/user for 3 min",
-  click:    "https://espocrm.cloudless.gr",
+  severity: "high", // info | warning | error | high | critical
+  title: "espocrm down",
+  message: "5xx from /api/v1/App/user for 3 min",
+  click: "https://espocrm.cloudless.gr",
 });
 ```
 
@@ -126,25 +126,27 @@ for provisioning.
 
 ## Event map — what fires what
 
-| Event | Route | Slack | ntfy | D1 store |
-|---|---|---|---|---|
-| Contact form submitted | `/api/contact` | `slackContactNotify` → `#notifications` | — | `contact` |
-| Newsletter subscribe | `/api/subscribe` | `slackSubscriberNotify` → `#newsletter` | — | `subscribe` |
-| Calendar booking | `/api/calendar/book`, `/api/agent/book` | `slackBookingNotify` → `#bookings` | — | `booking` |
-| Stripe checkout complete | `/api/webhooks/stripe` | `slackOrderNotify` → `#orders` | via `notifyAdmin` when high-value | `order` |
-| New user registration | `/api/auth/register` | `slackRegistrationNotify` → `#notifications` | — | `auth` |
-| Chat conversation started | `/api/chat` | `slackChatNotify` → `#notifications` | — | — |
-| EspoCRM Contact / Lead created | `/api/webhooks/espocrm` → `espocrm-dispatch` | `notifyContactCreated` / `notifyLeadCreated` → `#leads` | — | — |
-| EspoCRM Opportunity created / stage changed | `/api/webhooks/espocrm` → `espocrm-dispatch` | `notifyOpportunityCreated` / `notifyOpportunityStageChanged` → `#orders` | — | — |
-| EspoCRM Case created / status changed | `/api/webhooks/espocrm` → `espocrm-dispatch` | `notifyCaseCreated` / `notifyCaseStatusChanged` → `#notifications` | — | — |
-| Portal client enrolled | `/api/portal/enroll` | DM to ops users (inline) | — | `portal` |
-| Portal deliverable ready | `/api/portal/[token]/deliverables` | — | — | `portal` |
-| Sentry alert | `/api/webhooks/sentry` | DM to ops users via `notifyAdmin` | `notifyAdmin` (opt-in) | — |
-| MQTT high-severity event | `/api/webhooks/mqtt/publish` | DM to ops users via `notifyAdmin` | `notifyAdmin` (opt-in) | — |
-| Generic admin alert | `/api/webhooks/admin-alert` | DM to ops users via `notifyAdmin` | `notifyAdmin` (opt-in) | — |
-| Application error | `src/lib/slack-notify.ts slackErrorNotify` | `#errors` (deduped 10 min) | — | `error` (mirrored) |
-| Insight refresh failure | `/api/admin/insights/refresh` | `slackErrorNotify` → `#errors` | — | — |
-| Deploy started/done/failed | `src/instrumentation.ts` | `slackDeployNotify` → `#deployments` | — | — |
+| Event                                       | Route                                        | Slack                                                                    | ntfy                              | D1 store           |
+| ------------------------------------------- | -------------------------------------------- | ------------------------------------------------------------------------ | --------------------------------- | ------------------ |
+| Contact form submitted                      | `/api/contact`                               | `slackContactNotify` → `#notifications`                                  | —                                 | `contact`          |
+| Newsletter subscribe                        | `/api/subscribe`                             | `slackSubscriberNotify` → `#newsletter`                                  | —                                 | `subscribe`        |
+| Calendar booking                            | `/api/calendar/book`, `/api/agent/book`      | `slackBookingNotify` → `#bookings`                                       | —                                 | `booking`          |
+| Stripe checkout complete                    | `/api/webhooks/stripe`                       | `slackOrderNotify` → `#orders`                                           | via `notifyAdmin` when high-value | `order`            |
+| New user registration                       | `/api/auth/register`                         | `slackRegistrationNotify` → `#notifications`                             | —                                 | `auth`             |
+| Chat conversation started                   | `/api/chat`                                  | `slackChatNotify` → `#notifications`                                     | —                                 | —                  |
+| EspoCRM Contact / Lead created              | `/api/webhooks/espocrm` → `espocrm-dispatch` | `notifyContactCreated` / `notifyLeadCreated` → `#leads`                  | —                                 | —                  |
+| EspoCRM Opportunity created / stage changed | `/api/webhooks/espocrm` → `espocrm-dispatch` | `notifyOpportunityCreated` / `notifyOpportunityStageChanged` → `#orders` | —                                 | —                  |
+| EspoCRM Case created / status changed       | `/api/webhooks/espocrm` → `espocrm-dispatch` | `notifyCaseCreated` / `notifyCaseStatusChanged` → `#notifications`       | —                                 | —                  |
+| Portal client enrolled                      | `/api/portal/enroll`                         | DM to ops users (inline)                                                 | —                                 | `portal`           |
+| Portal deliverable ready                    | `/api/portal/[token]/deliverables`           | —                                                                        | —                                 | `portal`           |
+| Sentry alert                                | `/api/webhooks/sentry`                       | DM to ops users via `notifyAdmin`                                        | `notifyAdmin` (opt-in)            | —                  |
+| MQTT high-severity event                    | `/api/webhooks/mqtt/publish`                 | DM to ops users via `notifyAdmin`                                        | `notifyAdmin` (opt-in)            | —                  |
+| Generic admin alert                         | `/api/webhooks/admin-alert`                  | DM to ops users via `notifyAdmin`                                        | `notifyAdmin` (opt-in)            | —                  |
+| Application error                           | `src/lib/slack-notify.ts slackErrorNotify`   | `#errors` (deduped 10 min)                                               | —                                 | `error` (mirrored) |
+| Insight refresh failure                     | `/api/admin/insights/refresh`                | `slackErrorNotify` → `#errors`                                           | —                                 | —                  |
+| Deploy started/done/failed                  | `src/instrumentation.ts`                     | `slackDeployNotify` → `#deployments`                                     | —                                 | —                  |
+
+Generic admin alerts also email `SES_TO_EMAIL` (default `tbaltzakis@cloudless.gr`) through the canonical Cloudflare Email/Resend dispatch path.
 
 ---
 
@@ -155,13 +157,13 @@ for provisioning.
 Polls `/api/health` every 2 min from host (outside k3s). Fires ntfy + Slack +
 email **directly via curl + Resend REST** — does not go through the app.
 
-| Consecutive failures | ~Minutes | Action |
-|---|---|---|
-| 1–2 | 2–4 min | Silent |
-| **3** | ~6 min | Alert on all 3 channels (one-shot per incident) |
-| 4–7 | 8–14 min | No further pings |
-| **8** | ~16 min | Auto-rollback + "rolled back" alert |
-| — | recovers | "Recovered" alert; state reset |
+| Consecutive failures | ~Minutes | Action                                          |
+| -------------------- | -------- | ----------------------------------------------- |
+| 1–2                  | 2–4 min  | Silent                                          |
+| **3**                | ~6 min   | Alert on all 3 channels (one-shot per incident) |
+| 4–7                  | 8–14 min | No further pings                                |
+| **8**                | ~16 min  | Auto-rollback + "rolled back" alert             |
+| —                    | recovers | "Recovered" alert; state reset                  |
 
 Credentials: `/etc/safedeploy-watchdog.env` (mode 600).
 Logs: `journalctl -t safedeploy-watchdog`.
@@ -200,19 +202,19 @@ Pod doc: [`docs/pods/kuma-slack-bridge/README.md`](pods/kuma-slack-bridge/README
 
 ## Config reference
 
-| Key | Where | Used by |
-|---|---|---|
-| `SLACK_BOT_TOKEN` | SSM / env | All `SlackClient` posts |
-| `SLACK_WEBHOOK_URL` | SSM / env | `SlackClient` webhook fallback |
-| `SLACK_DEFAULT_CHANNEL` | SSM / env | Default channel when no instance override |
-| `NEWSLETTER_SLACK_CHANNEL_ID` | env | `subscribersClient` channel override |
-| `NTFY_BASE_URL` | SSM | `ntfy.ts publishNtfy` (default: in-cluster ClusterIP) |
-| `NTFY_TOPIC` | SSM | `ntfy.ts publishNtfy` |
-| `NTFY_TOKEN` | SSM | `ntfy.ts` Bearer auth (optional) |
-| `ADMIN_PUSH_VIA_NTFY` | SSM (wins) / env | Enables ntfy fan-out in `notifyAdmin` |
-| `ADMIN_ALERT_SECRET` | SSM | `/api/webhooks/admin-alert` shared secret |
-| `RESEND_API_KEY` | env / SSM | App email + SafeDeploy Watchdog email |
-| `ALERT_EMAIL` | watchdog env | Watchdog email recipient (default: `tbaltzakis@cloudless.gr`) |
+| Key                           | Where            | Used by                                                       |
+| ----------------------------- | ---------------- | ------------------------------------------------------------- |
+| `SLACK_BOT_TOKEN`             | SSM / env        | All `SlackClient` posts                                       |
+| `SLACK_WEBHOOK_URL`           | SSM / env        | `SlackClient` webhook fallback                                |
+| `SLACK_DEFAULT_CHANNEL`       | SSM / env        | Default channel when no instance override                     |
+| `NEWSLETTER_SLACK_CHANNEL_ID` | env              | `subscribersClient` channel override                          |
+| `NTFY_BASE_URL`               | SSM              | `ntfy.ts publishNtfy` (default: in-cluster ClusterIP)         |
+| `NTFY_TOPIC`                  | SSM              | `ntfy.ts publishNtfy`                                         |
+| `NTFY_TOKEN`                  | SSM              | `ntfy.ts` Bearer auth (optional)                              |
+| `ADMIN_PUSH_VIA_NTFY`         | SSM (wins) / env | Enables ntfy fan-out in `notifyAdmin`                         |
+| `ADMIN_ALERT_SECRET`          | SSM              | `/api/webhooks/admin-alert` shared secret                     |
+| `RESEND_API_KEY`              | env / SSM        | App email + SafeDeploy Watchdog email                         |
+| `ALERT_EMAIL`                 | watchdog env     | Watchdog email recipient (default: `tbaltzakis@cloudless.gr`) |
 
 ---
 

--- a/src/lib/admin-alerts.ts
+++ b/src/lib/admin-alerts.ts
@@ -24,6 +24,8 @@
  * is purely additive for the new "alerts that should bypass Slack noise
  * filters" lane.
  */
+import { notifyTeam } from "@/lib/email";
+import { escapeHtml } from "@/lib/escape-html";
 import { SlackClient } from "@/lib/slack-notify";
 import { getSlackOpsUsers } from "@/lib/slack-ops-users";
 import { publishNtfy } from "@/lib/ntfy";

--- a/src/lib/admin-alerts.ts
+++ b/src/lib/admin-alerts.ts
@@ -6,6 +6,7 @@
  *     per `feedback_slack_use_slackclient` + `feedback_slack_lambda_env_frozen`.
  *   - ntfy (opt-in, secondary): push-notification fan-out to the operator's
  *     phone via `src/lib/ntfy.ts`. Enabled by env `ADMIN_PUSH_VIA_NTFY=1`.
+ *   - Email: uses the canonical `notifyTeam()` transport for operator alerts.
  *
  * R4 of the 2026-06-21 R-series. Operator wanted phone push for SEV1 alerts
  * even when the laptop is closed; ntfy delivers that without rebuilding the
@@ -50,6 +51,7 @@ export interface AdminAlertInput {
 export interface AdminAlertResult {
   slack: { ok: boolean; error?: string };
   ntfy: { ok: boolean; skipped?: string; error?: string };
+  email: { ok: boolean; skipped?: string; error?: string };
 }
 
 const SEVERITY_EMOJI: Record<AdminAlertSeverity, string> = {
@@ -89,6 +91,7 @@ export async function notifyAdmin(input: AdminAlertInput): Promise<AdminAlertRes
   const result: AdminAlertResult = {
     slack: { ok: false },
     ntfy: { ok: false },
+    email: { ok: false },
   };
 
   const slackText = `${SEVERITY_EMOJI[input.severity]} *${input.title}*\n${input.message}${
@@ -144,6 +147,23 @@ export async function notifyAdmin(input: AdminAlertInput): Promise<AdminAlertRes
     result.ntfy = r;
   })();
 
-  await Promise.allSettled([slackTask, ntfyTask]);
+  const emailTask = (async () => {
+    try {
+      const title = escapeHtml(input.title);
+      const message = escapeHtml(input.message).replace(/\n/g, "<br>");
+      const click = input.click
+        ? `<p><a href="${escapeHtml(input.click)}">Open incident details</a></p>`
+        : "";
+      await notifyTeam(
+        `[${input.severity.toUpperCase()}] ${input.title}`,
+        `<h2>${title}</h2><p>${message}</p>${click}`
+      );
+      result.email = { ok: true };
+    } catch (err) {
+      result.email = { ok: false, error: (err as Error).message };
+    }
+  })();
+
+  await Promise.allSettled([slackTask, ntfyTask, emailTask]);
   return result;
 }


### PR DESCRIPTION
## Summary

- create or reuse a dedicated `#tailscale` Slack channel
- post Pi runner recovery results to that channel
- route infrastructure alerts through the canonical admin alert endpoint
- extend `notifyAdmin` email delivery through the documented Cloudflare Email/Resend transport

## Type of change

- [x] New feature
- [x] CI / DevOps
- [x] Documentation

## Related issues

Related to #382

## Testing

- [x] Workflow YAML parsed successfully
- [x] `pnpm typecheck`
- [x] 24 focused Vitest tests passed

## Checklist

- [x] No secret values committed
- [x] Slack API responses are checked
- [x] Alert HTML is escaped
- [x] Email uses the canonical application transport

Generated with [Devin](https://devin.ai)