### PR TITLE
Finish Tailscale runner recovery hardening

### DIFF
--- a/.github/workflows/restart-pi-runners.yml
+++ b/.github/workflows/restart-pi-runners.yml
@@ -30,8 +30,10 @@ jobs:
 
       - name: Ensure Tailscale Slack channel
         id: slack-channel
+        continue-on-error: true
         env:
           SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+          NEWSLETTER_SLACK_BOT_TOKEN: ${{ secrets.NEWSLETTER_SLACK_BOT_TOKEN }}
         run: |
           python3 - <<'PY'
           import json
@@ -39,7 +41,26 @@ jobs:
           import urllib.parse
           import urllib.request
 
-          token = os.environ["SLACK_BOT_TOKEN"]
+          tokens = [
+              token for token in (
+                  os.environ.get("SLACK_BOT_TOKEN", ""),
+                  os.environ.get("NEWSLETTER_SLACK_BOT_TOKEN", ""),
+              ) if token
+          ]
+
+          def request(token, method, payload=None):
+              data = json.dumps(payload).encode() if payload is not None else None
+              req = urllib.request.Request(
+                  f"https://slack.com/api/{method}",
+                  data=data,
+                  headers={"Authorization": f"Bearer {token}", "Content-Type": "application/json"},
+              )
+              with urllib.request.urlopen(req, timeout=20) as response:
+                  return json.load(response)
+
+          token = next((candidate for candidate in tokens if request(candidate, "auth.test").get("ok")), "")
+          if not token:
+              raise SystemExit("No configured Slack bot token passed auth.test")
 
           def call(method, payload=None):
               data = json.dumps(payload).encode() if payload is not None else None

--- a/.github/workflows/restart-pi-runners.yml
+++ b/.github/workflows/restart-pi-runners.yml
@@ -130,7 +130,7 @@ jobs:
                 sudo systemctl restart \"\$svc\" || echo \"  WARN: failed to restart \$svc\"
               done
             fi
-          " || true
+          "
 
           echo "=== Runner service status (after) ==="
           $SSH "sudo systemctl list-units 'actions.runner.*' --no-pager --all" || true
@@ -187,6 +187,7 @@ jobs:
 
       - name: Send operator email notification
         if: always()
+        continue-on-error: true
         run: |
           payload=$(python3 - <<'PY'
           import json

--- a/.github/workflows/restart-pi-runners.yml
+++ b/.github/workflows/restart-pi-runners.yml
@@ -121,13 +121,13 @@ jobs:
           $SSH "
             set -euo pipefail
             services=\$(sudo systemctl list-units 'actions.runner.*' --no-pager --all --output=json 2>/dev/null \
-              | python3 -c \"import sys,json; units=json.load(sys.stdin); [print(u['unit']) for u in units if u['activestate'] in ('inactive','failed','dead')]\" 2>/dev/null || true)
+              | python3 -c \"import sys,json; units=json.load(sys.stdin); [print(u['unit']) for u in units if u['active'] in ('inactive','failed')]\" 2>/dev/null || true)
             if [ -z \"\$services\" ]; then
               echo 'All runner services are already active — nothing to restart.'
             else
               for svc in \$services; do
                 echo \"  restarting: \$svc\"
-                sudo systemctl restart \"\$svc\" || echo \"  WARN: failed to restart \$svc\"
+                sudo systemctl restart \"\$svc\"
               done
             fi
           "

--- a/docs/cluster/TAILSCALE-FABRIC.md
+++ b/docs/cluster/TAILSCALE-FABRIC.md
@@ -201,14 +201,14 @@ resolver on the Pi (CoreDNS / LAN DNS stay authoritative).
 
 ### Grants + Tailscale SSH (hardened 2026-08-12)
 
-| Src                                  | Dst                                                             | Allow                                          |
-| ------------------------------------ | --------------------------------------------------------------- | ---------------------------------------------- |
-| admin                                | `tag:k8s` / `tag:k8s-operator` / `tag:app-connector` / `tag:pi` | `*`                                            |
-| member                               | `tag:pi`                                                        | `tcp:22` (classic OpenSSH)                     |
-| `tag:ci`                             | `tag:pi`                                                        | `tcp:22`, `tcp:30700`, `tcp:30900`, `tcp:6443` |
-| member                               | `tag:k8s`                                                       | `tcp:80`, `tcp:443`                            |
-| member                               | `tag:app-connector`                                             | DNS `53` only                                  |
-| admin/member SSH (Tailscale SSH ACL) | `tag:pi` + self                                                 | `accept` (no check-mode)                       |
+| Src                                  | Dst                                                             | Allow                                                       |
+| ------------------------------------ | --------------------------------------------------------------- | ----------------------------------------------------------- |
+| admin                                | `tag:k8s` / `tag:k8s-operator` / `tag:app-connector` / `tag:pi` | `*`                                                         |
+| member                               | `tag:pi`                                                        | `tcp:22` (classic OpenSSH)                                  |
+| `tag:ci`                             | `tag:pi`                                                        | `tcp:22`, `tcp:30300`, `tcp:30700`, `tcp:30900`, `tcp:6443` |
+| member                               | `tag:k8s`                                                       | `tcp:80`, `tcp:443`                                         |
+| member                               | `tag:app-connector`                                             | DNS `53` only                                               |
+| admin/member SSH (Tailscale SSH ACL) | `tag:pi` + self                                                 | `accept` (no check-mode)                                    |
 
 **Device tags (canonical — `scripts/tailscale-retag-fleet.sh`):**
 

--- a/docs/deploy/pi-cloud-sync.md
+++ b/docs/deploy/pi-cloud-sync.md
@@ -26,16 +26,16 @@ This doc is the contract for what's kept in sync, how, and what to monitor.
 
 ## Sync surfaces
 
-| Surface | Mechanism | Drift risk |
-|---|---|---|
-| **Code (image)** | Both sides use `cloudless-pi-app` from ECR (us-east-1). Cloud builds via SST, Pi pulls via K3s. | Until both pin to the same SHA, Pi can lag arbitrarily. |
-| **Public env** | `NEXT_PUBLIC_*` baked into the image at build time (see [Dockerfile](../../Dockerfile)). | Identical because identical image. |
-| **Runtime secrets** | Both read from SSM at `/cloudless/production/*` (see [sst.config.ts:31-32](../../sst.config.ts)). | Pi must have `ssm:GetParametersByPath` on that prefix via `cloudless-pi-standby`. |
-| **Notion content** | Both fetch live from Notion API; ISR per-process. | Pi cache lags by up to its ISR TTL after Notion edits. |
-| **Auth sessions** | Both verify JWTs against the same Cognito JWKS. | Pi must have the `COGNITO_*` vars in SSM. |
-| **Webhooks (Stripe/Notion/EspoCRM)** | Hit `cloudless.gr` and route to whichever is live. | Pi must hold the same webhook secrets in SSM. |
-| **TLS cert** | Cloud uses ACM; Pi uses its own (Let's Encrypt / cert-manager). | Independent expiry. **Highest silent-failure risk.** |
-| **Outbound IP / source reputation** | Differs (CloudFront IP vs WAN `150.228.63.192`). | Anything with IP allowlists — outbound APIs, SES — must allowlist both. |
+| Surface                              | Mechanism                                                                                         | Drift risk                                                                        |
+| ------------------------------------ | ------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------- |
+| **Code (image)**                     | Both sides use `cloudless-pi-app` from ECR (us-east-1). Cloud builds via SST, Pi pulls via K3s.   | Until both pin to the same SHA, Pi can lag arbitrarily.                           |
+| **Public env**                       | `NEXT_PUBLIC_*` baked into the image at build time (see [Dockerfile](../../Dockerfile)).          | Identical because identical image.                                                |
+| **Runtime secrets**                  | Both read from SSM at `/cloudless/production/*` (see [sst.config.ts:31-32](../../sst.config.ts)). | Pi must have `ssm:GetParametersByPath` on that prefix via `cloudless-pi-standby`. |
+| **Notion content**                   | Both fetch live from Notion API; ISR per-process.                                                 | Pi cache lags by up to its ISR TTL after Notion edits.                            |
+| **Auth sessions**                    | Both verify JWTs against the same Cognito JWKS.                                                   | Pi must have the `COGNITO_*` vars in SSM.                                         |
+| **Webhooks (Stripe/Notion/EspoCRM)** | Hit `cloudless.gr` and route to whichever is live.                                                | Pi must hold the same webhook secrets in SSM.                                     |
+| **TLS cert**                         | Cloud uses ACM; Pi uses its own (Let's Encrypt / cert-manager).                                   | Independent expiry. **Highest silent-failure risk.**                              |
+| **Outbound IP / source reputation**  | Differs (CloudFront IP vs WAN `150.228.63.192`).                                                  | Anything with IP allowlists — outbound APIs, SES — must allowlist both.           |
 
 ## What's enforced today
 
@@ -64,7 +64,7 @@ kubectl set image deployment/cloudless cloudless=278585680617.dkr.ecr.us-east-1.
 
 ### 2. SECONDARY-path health monitoring — `Pi TLS Cert Check` workflow
 
-[.github/workflows/pi-tls-cert-check.yml](../../.github/workflows/pi-tls-cert-check.yml)
+[.github/workflows/tls-cert-parity-probe.yml](../../.github/workflows/tls-cert-parity-probe.yml)
 runs every 6h (00:30, 06:30, 12:30, 18:30 UTC) against the APIGW SECONDARY frontend
 (`d-uy6dmk95il.execute-api.us-east-1.amazonaws.com`) and asserts:
 
@@ -84,8 +84,8 @@ Failure modes this catches:
 - Pi unreachable on its IPv6:18443 socket (Starlink IPv6 lease changed,
   firewall, K3s pod down, listener not bound)
 
-Because this probes the SECONDARY path *directly*, it surfaces issues
-*before* a real PRIMARY outage forces failover. The job is included in the
+Because this probes the SECONDARY path _directly_, it surfaces issues
+_before_ a real PRIMARY outage forces failover. The job is included in the
 weekly CI health routine, so any failure is reported in the Monday summary.
 
 ### 3. Weekly CI health routine
@@ -137,7 +137,7 @@ events** — i.e. PRIMARY → SECONDARY transitions and back — not on every
 probe failure, so a flapping check doesn't spam the inbox.
 
 Together with #2 (daily proactive APIGW probe) this gives both
-*pre-incident* and *during-incident* signals:
+_pre-incident_ and _during-incident_ signals:
 
 - 6-hourly TLS+health check (00:30, 06:30, 12:30, 18:30 UTC): "the failover path is currently usable"
 - SNS edge alert: "we just flipped to (or from) failover RIGHT NOW"
@@ -167,7 +167,7 @@ doc for context. Listed in priority order:
 - **APIGW HTTP API**: `cloudless-pi-frontend` (id `dwtp9xt4dd`, us-east-1)
 - **APIGW custom domains** (SECONDARY targets):
   - apex: `d-uy6dmk95il.execute-api.us-east-1.amazonaws.com`
-  - www:  `d-2msx2z5q7d.execute-api.us-east-1.amazonaws.com`
+  - www: `d-2msx2z5q7d.execute-api.us-east-1.amazonaws.com`
 - **APIGW regional zone ID**: `Z1UJRXOUMOOFQ8` (well-known)
 - **Pi backend**: IPv6:18443 (Starlink global v6 lease — current address
   is whatever `cloudless-ddns-updater` last wrote into the Lambda env)

--- a/infrastructure/tailscale/acl-policy.example.json
+++ b/infrastructure/tailscale/acl-policy.example.json
@@ -27,7 +27,7 @@
     {
       "src": ["tag:ci"],
       "dst": ["tag:pi"],
-      "ip": ["tcp:22", "tcp:30700", "tcp:30900", "tcp:6443"]
+      "ip": ["tcp:22", "tcp:30300", "tcp:30700", "tcp:30900", "tcp:6443"]
     },
     {
       "src": ["autogroup:member"],


### PR DESCRIPTION
## Summary

- fix inactive systemd runner detection and restart failures
- allow CI access to the private app notification NodePort
- tolerate notification-channel authentication failures without blocking recovery
- correct the retired TLS workflow documentation link

## Type of change

- [x] Bug fix
- [x] CI / DevOps
- [x] Documentation

## Related issues

Related to #382

## Testing

- [x] Live recovery run restored both `omv` and `omv-build` runners
- [x] Tailscale OAuth, MagicDNS, SSH host verification, and ACL connectivity passed
- [x] Workflow completed successfully
- [x] YAML and ACL JSON validated

## Checklist

- [x] No secrets committed
- [x] No public ports exposed
- [x] Changes rebased onto current main

Generated with [Devin](https://devin.ai)