### PR TITLE
Surface D1 HTTP errors in health route and add direct D1 REST probe

### DIFF
--- a/.github/workflows/e2e-full-coverage.yml
+++ b/.github/workflows/e2e-full-coverage.yml
@@ -23,12 +23,12 @@ jobs:
     runs-on: ${{ fromJSON(vars.RUNNER_X64 || '"ubuntu-latest"') }}
     timeout-minutes: 30
     env:
-      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
-      NEXT_PUBLIC_E2E: '1'
+      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+      NEXT_PUBLIC_E2E: "1"
       NEXT_PUBLIC_AUTH_PROVIDER: d1
-      CI: 'true'
-      AUTH_DB_USE_HTTP: '1'
-      AUTH_DB_PREFER_LOCAL: '0'
+      CI: "true"
+      AUTH_DB_USE_HTTP: "1"
+      AUTH_DB_PREFER_LOCAL: "0"
       CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID || secrets.CF_ACCOUNT_ID }}
       CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
       SESSION_SECRET: ${{ secrets.SESSION_SECRET }}
@@ -59,12 +59,53 @@ jobs:
       - name: Install Playwright browsers
         run: pnpm exec playwright install --with-deps chromium
 
+      - name: Probe D1 REST API directly (credential sanity check)
+        env:
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID || secrets.CF_ACCOUNT_ID }}
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_D1_DATABASE_ID: 7ca74513-23c3-412a-b9ca-b0c55835973d
+        run: |
+          echo "Direct D1 REST API probe..."
+          if [[ -z "${CLOUDFLARE_ACCOUNT_ID:-}" ]]; then
+            echo "ERROR: CLOUDFLARE_ACCOUNT_ID is empty"
+            exit 1
+          fi
+          if [[ -z "${CLOUDFLARE_API_TOKEN:-}" ]]; then
+            echo "ERROR: CLOUDFLARE_API_TOKEN is empty"
+            exit 1
+          fi
+          RESPONSE="$(curl -sS -w "\n%{http_code}" \
+            -X POST "https://api.cloudflare.com/client/v4/accounts/${CLOUDFLARE_ACCOUNT_ID}/d1/database/${CLOUDFLARE_D1_DATABASE_ID}/query" \
+            -H "Authorization: Bearer ${CLOUDFLARE_API_TOKEN}" \
+            -H "Content-Type: application/json" \
+            -d '{"sql":"SELECT 1 as ok"}' 2>&1)"
+          HTTP_CODE="$(echo "$RESPONSE" | tail -1)"
+          BODY="$(echo "$RESPONSE" | sed '$d')"
+          echo "D1 REST HTTP status: $HTTP_CODE"
+          echo "D1 REST response: $BODY"
+          if [[ "$HTTP_CODE" != "200" ]]; then
+            echo "ERROR: D1 REST API returned HTTP $HTTP_CODE — credentials or permissions issue"
+            exit 1
+          fi
+          if ! echo "$BODY" | python3 -c '
+          import json, sys
+          body = json.load(sys.stdin)
+          assert body.get("success") is True, body
+          result = body.get("result", [{}])[0]
+          rows = result.get("results", [])
+          assert rows and rows[0].get("ok") == 1, body
+          '; then
+            echo "ERROR: D1 REST API returned success=false or unexpected payload"
+            exit 1
+          fi
+          echo "D1 REST API probe OK — credentials and permissions are valid"
+
       - name: Probe live user-auth-db and ensure seed users
         env:
-          NEXT_PUBLIC_E2E: '1'
+          NEXT_PUBLIC_E2E: "1"
           NEXT_PUBLIC_AUTH_PROVIDER: d1
-          AUTH_DB_USE_HTTP: '1'
-          AUTH_DB_PREFER_LOCAL: '0'
+          AUTH_DB_USE_HTTP: "1"
+          AUTH_DB_PREFER_LOCAL: "0"
           E2E_ADMIN_TOKEN: e2e-admin-token-do-not-use-in-prod
         run: |
           echo "Starting next-dev against live D1..."

--- a/src/app/api/health/route.ts
+++ b/src/app/api/health/route.ts
@@ -8,20 +8,29 @@ export async function GET() {
   const useLiveHttp = env?.["AUTH_DB_USE_HTTP"] === "1";
 
   let dbConnected = false;
+  let dbResolved = false;
+  let diagnostic: string | undefined;
   try {
     const { getAuthDbFromEnv } = await import("@/lib/auth-d1");
     let db = getAuthDbFromEnv();
+    dbResolved = !!db;
     // Only fall back to local sqlite when not forced onto live D1.
     if (!db && process.env.NODE_ENV === "development" && !useLiveHttp) {
       const { getLocalAuthDb } = await import("@/lib/auth-db-local");
       db = getLocalAuthDb();
+      dbResolved = !!db;
     }
     if (db) {
       const row = await db.prepare("SELECT 1 as ok").first<{ ok?: unknown }>();
       dbConnected = Number(row?.ok) === 1;
+    } else if (useLiveHttp) {
+      diagnostic = "d1-http mode but getAuthDbFromEnv() returned null";
     }
-  } catch {
+  } catch (err) {
     dbConnected = false;
+    const msg = err instanceof Error ? err.message : String(err);
+    diagnostic = `dbResolved=${dbResolved} error=${msg}`;
+    console.error("[health] D1 probe failed:", msg);
   }
 
   return globalThis.Response.json(
@@ -32,6 +41,7 @@ export async function GET() {
       authProvider: "d1",
       authDb: useLiveHttp ? "d1-http" : "local-or-binding",
       dbConnected,
+      ...(diagnostic ? { diagnostic } : {}),
     },
     { headers: { "cache-control": "no-store, no-cache, must-revalidate" } }
   );


### PR DESCRIPTION
## Summary

- The live-D1 Playwright workflow was failing with `dbConnected:false` but the health route silently swallowed all errors with `catch {}`
- Add a `diagnostic` field to the health response and `console.error` logging so the actual failure reason is visible in CI logs
- Add a direct Cloudflare D1 REST API probe step to the workflow that runs before the Next.js health check — this isolates credential/permission issues from Next.js module resolution issues

## Why

The workflow failed with:
```
health: {"status":"degraded","authDb":"d1-http","dbConnected":false}
AssertionError
```

But the dev server log showed `[Instrumentation] AUTH_DB_USE_HTTP=1 — live D1 REST` which means `canUseD1Http()` returned true (credentials present). The failure was happening somewhere in `getAuthDbFromEnv()` → `tryLoadHttpAuthDb()` → `require("./d1-http")` → `queryRemote()` but the error was invisible.

## Testing

- [x] `pnpm typecheck` — passes
- [x] `pnpm lint` — 0 errors (213 pre-existing warnings)
- [x] YAML validated

Generated with [Devin](https://devin.ai)