### PR TITLE
Fix EspoCRM lastName required validation error

### DIFF
--- a/src/lib/espocrm.ts
+++ b/src/lib/espocrm.ts
@@ -129,7 +129,7 @@ function toEspoContactPayload(c: EspoContact): Record<string, unknown> {
   return {
     emailAddress: c.email,
     firstName: c.firstname ?? "",
-    lastName: c.lastname ?? c.email.split("@")[0],
+    lastName: c.lastname || c.email.split("@")[0],
     accountName: c.company ?? undefined,
     phoneNumber: c.phone ?? undefined,
     description: [c.message, c.service_interest && `Service: ${c.service_interest}`]
@@ -649,7 +649,7 @@ export async function createLead(data: LeadData): Promise<string | null> {
     const payload: Record<string, unknown> = {
       emailAddress: data.emailAddress,
       firstName: data.firstName ?? "",
-      lastName: data.lastName ?? data.emailAddress.split("@")[0],
+      lastName: data.lastName || data.emailAddress.split("@")[0],
       phoneNumber: data.phoneNumber ?? undefined,
       source: data.source ?? "Web Site",
       status: "New",


### PR DESCRIPTION
## Summary

EspoCRM requires `lastName` on contact creation. When a single-word name is submitted (e.g. "Devin"), `nameParts.slice(1).join(" ")` returns `""` (empty string). The `??` operator doesn't trigger on empty strings (only null/undefined), so EspoCRM received `lastName=""` and rejected with 400 `validationFailure: field=lastName, type=required`.

Fix: use `||` instead of `??` so empty string falls through to the email username fallback. Applied to both `toEspoContactPayload` and the `crm-contact-360` upsert path.

#### Test plan
- [x] `pnpm typecheck` passes
- [x] 17 tests pass (contact-api, contact-campaign-pipeline, crm-contact-api)
- [ ] Deploy and verify EspoCRM contact creation succeeds

Generated with [Devin](https://devin.ai)