### PR TITLE
Fix EspoCRM 409 conflict — extract existing contact ID

### DIFF
--- a/src/lib/espocrm.ts
+++ b/src/lib/espocrm.ts
@@ -212,6 +212,20 @@ export async function upsertContact(contact: EspoContact): Promise<string | null
         });
       }
     }
+    if (create.status === 409) {
+      // Contact already exists (race condition or search missed it).
+      // The 409 response body contains the full contact record — extract the ID.
+      const conflictBody = (await create.json().catch(() => ({}))) as { id?: string };
+      if (conflictBody.id) {
+        // Update the existing contact with the new data.
+        await espoFetch(`/Contact/${conflictBody.id}`, {
+          method: "PUT",
+          body: JSON.stringify(payload),
+        }).catch(() => {});
+        void invalidateEspoContactCaches(conflictBody.id);
+        return conflictBody.id;
+      }
+    }
     if (!create.ok) {
       const errBody = await create.text().catch(() => "");
       console.error("[EspoCRM] upsertContact create failed:", create.status, errBody.slice(0, 300));


### PR DESCRIPTION
## Summary

When a contact already exists but the email search missed it (e.g. due to `+` in the email address), EspoCRM returns 409 with the full contact record in the body. Extract the ID from the 409 response and update the existing contact instead of failing.

#### Test plan
- [x] `pnpm typecheck` passes
- [x] 10 tests pass (contact-api, crm-contact-api)
- [ ] Deploy and verify EspoCRM contact upsert handles duplicates

Generated with [Devin](https://devin.ai)