### PR TITLE
Fix EspoCRM 409: use X-Skip-Duplicate-Check on creates

### DIFF
--- a/src/lib/espocrm.ts
+++ b/src/lib/espocrm.ts
@@ -233,8 +233,12 @@ export async function upsertContact(contact: EspoContact): Promise<string | null
       void invalidateEspoContactCaches(existingId);
       return existingId;
     }
+    // Use X-Skip-Duplicate-Check to avoid EspoCRM's name-based duplicate
+    // check, which returns 409 for any contact with the same first+last name
+    // even if the email is different. We already search by email above.
     let create = await espoFetch("/Contact", {
       method: "POST",
+      headers: { "X-Skip-Duplicate-Check": "true" },
       body: JSON.stringify(payload),
     });
     // Check for 409 conflict FIRST, before any body-consuming logic.
@@ -306,6 +310,7 @@ export async function upsertContact(contact: EspoContact): Promise<string | null
         if (accountId) Object.assign(retryPayload, { accountId, accountName: undefined });
         create = await espoFetch("/Contact", {
           method: "POST",
+          headers: { "X-Skip-Duplicate-Check": "true" },
           body: JSON.stringify(retryPayload),
         });
         // The retry may also hit a 409 — parse the conflict body.
@@ -396,6 +401,7 @@ export async function setNewsletterStatus(
     if (status === "newsletter_unsubscribed") return true; // unknown email + unsub = no-op
     const create = await espoFetch("/Contact", {
       method: "POST",
+      headers: { "X-Skip-Duplicate-Check": "true" },
       body: JSON.stringify({
         emailAddress: email,
         lastName: email.split("@")[0],
@@ -828,6 +834,7 @@ export async function createLead(data: LeadData): Promise<string | null> {
     }
     const res = await espoFetch("/Lead", {
       method: "POST",
+      headers: { "X-Skip-Duplicate-Check": "true" },
       body: JSON.stringify(payload),
     });
     if (!res.ok) {


### PR DESCRIPTION
## Summary

EspoCRM returns 409 not just for duplicate email, but for duplicate `firstName`+`lastName` combinations. Since we already search by email and update existing contacts, skip EspoCRM's duplicate check on POST to allow contacts with the same name but different emails.

Apply `X-Skip-Duplicate-Check: true` to:
- Contact create (initial + phone retry)
- Newsletter signup create
- Lead create

The 409 conflict handler remains as a safety net.

#### Test plan
- [x] typecheck passes
- [x] 10 tests pass
- [ ] Deploy and verify contact creation succeeds without 409 for same-name different-email

Generated with [Devin](https://devin.ai)