### PR TITLE
Persist contact form submissions to AppFlowy

### DIFF
--- a/src/lib/appflowy-forms.ts
+++ b/src/lib/appflowy-forms.ts
@@ -15,6 +15,9 @@ import {
   getDocument,
   extractDocText,
   isAppFlowyConfigured,
+  getWorkspaceFolder,
+  createPage,
+  appendBlockToPage,
 } from "./appflowy";
 
 const SOURCE_CONTACT = "contact";
@@ -82,9 +85,20 @@ async function getPrimaryWorkspaceId(): Promise<string | null> {
   }
 }
 
+/** Pick the best parent view for a new contact submission page. */
+async function findSubmissionParentView(workspaceId: string): Promise<string | null> {
+  const folder = await getWorkspaceFolder(workspaceId, 2);
+  if (!folder) return null;
+  // Prefer a top-level "General" space, otherwise the first child folder.
+  const child =
+    folder.children?.find((v) => v.name.toLowerCase() === "general") ?? folder.children?.[0];
+  return child?.view_id ?? folder.view_id ?? null;
+}
+
 /**
  * Save a contact form submission to AppFlowy.
- * Creates a Document page with the submission data.
+ * Creates a Document page under the workspace's General space (or first child)
+ * and appends the submission fields as paragraph blocks.
  * Returns the created view_id, or null if AppFlowy is not configured.
  */
 export async function saveSubmission(data: ContactSubmission): Promise<string | null> {
@@ -92,16 +106,47 @@ export async function saveSubmission(data: ContactSubmission): Promise<string | 
 
   const workspaceId = await getPrimaryWorkspaceId();
   if (!workspaceId) return null;
+  if (!data.email?.trim()) return null;
 
-  try {
-    // Write API not available yet — keep the shape ready without logging PII.
-    if (!data.email?.trim()) return null;
-    console.log("[AppFlowy Forms] Would create submission (stub)");
-    return `submission-${Date.now()}`;
-  } catch {
-    console.error("[AppFlowy Forms] Failed to save submission");
+  const parentViewId = await findSubmissionParentView(workspaceId);
+  if (!parentViewId) return null;
+
+  const title = `[Contact] ${data.name} - ${data.email}`;
+  const page = await createPage(workspaceId, {
+    parent_view_id: parentViewId,
+    layout: 0, // Document
+    name: title,
+  });
+  if (!page?.view_id) {
+    console.error("[AppFlowy Forms] createPage returned no view_id");
     return null;
   }
+
+  const lines = [
+    `**Name**: ${data.name}`,
+    `**Email**: ${data.email}`,
+    data.phone ? `**Phone**: ${data.phone}` : "",
+    data.company ? `**Company**: ${data.company}` : "",
+    data.service ? `**Service**: ${data.service}` : "",
+    `**Source**: ${data.source ?? "contact"}`,
+    `**Date**: ${new Date().toISOString()}`,
+    "",
+    `**Message**:`,
+    data.message,
+  ].filter(Boolean);
+
+  const blocks = lines.map((line) => ({
+    type: "paragraph",
+    data: { delta: [{ insert: line }] },
+  }));
+
+  const ok = await appendBlockToPage(workspaceId, page.view_id, blocks);
+  if (!ok) {
+    console.error("[AppFlowy Forms] appendBlockToPage failed for", page.view_id);
+    return null;
+  }
+
+  return page.view_id;
 }
 
 /**

--- a/src/lib/appflowy.ts
+++ b/src/lib/appflowy.ts
@@ -543,6 +543,106 @@ export async function searchDocuments(workspaceId: string, query: string): Promi
   }
 }
 
+export interface AppFlowyFolderView {
+  view_id: string;
+  parent_view_id?: string;
+  name: string;
+  is_space?: boolean;
+  layout: number;
+  children?: AppFlowyFolderView[];
+  last_edited_time?: string;
+}
+
+export interface CreatePageParams {
+  parent_view_id: string;
+  layout?: number;
+  name?: string;
+  page_data?: unknown;
+  view_id?: string;
+  collab_id?: string;
+}
+
+export interface AppFlowyBlock {
+  type: string;
+  data?: Record<string, unknown>;
+}
+
+/**
+ * Return the workspace folder tree (root + children). The root view is the
+ * workspace root; its children are typically spaces such as "General".
+ */
+export async function getWorkspaceFolder(
+  workspaceId: string,
+  depth = 2
+): Promise<AppFlowyFolderView | null> {
+  try {
+    const r = await callThrowing<{ data: AppFlowyFolderView }>(
+      `/workspace/${workspaceId}/folder?depth=${depth}`,
+      { timeoutMs: 30_000 }
+    );
+    return r.data ?? null;
+  } catch (e) {
+    if (e instanceof AppFlowyNotConfiguredError) return null;
+    if (e instanceof AppFlowyApiError && (e.status === 404 || e.status === 400)) return null;
+    throw e;
+  }
+}
+
+/**
+ * Create a new page under a parent view. Returns the new page view_id.
+ */
+export async function createPage(
+  workspaceId: string,
+  params: CreatePageParams
+): Promise<{ view_id: string } | null> {
+  try {
+    const r = await callThrowing<{ data: { view_id: string } }>(
+      `/workspace/${workspaceId}/page-view`,
+      {
+        method: "POST",
+        body: JSON.stringify({
+          layout: params.layout ?? 0,
+          ...params,
+        }),
+      }
+    );
+    // Invalidate cached views for this workspace.
+    cachedViewsByWorkspace.delete(workspaceId);
+    return r.data ?? null;
+  } catch (e) {
+    if (e instanceof AppFlowyNotConfiguredError) return null;
+    console.error("[appflowy] createPage failed:", e);
+    return null;
+  }
+}
+
+/**
+ * Append blocks to the end of a document page.
+ */
+export async function appendBlockToPage(
+  workspaceId: string,
+  viewId: string,
+  blocks: AppFlowyBlock[]
+): Promise<boolean> {
+  try {
+    const r = await appflowyFetch(`/workspace/${workspaceId}/page-view/${viewId}/append-block`, {
+      method: "POST",
+      body: JSON.stringify({ blocks }),
+    });
+    if (!r.ok) {
+      const body = await r.text().catch(() => "");
+      console.error("[appflowy] appendBlockToPage failed:", r.status, body.slice(0, 200));
+      return false;
+    }
+    cachedViewsByWorkspace.delete(workspaceId);
+    return true;
+  } catch (e) {
+    if (e instanceof AppFlowyNotConfiguredError) return false;
+    console.error("[appflowy] appendBlockToPage failed:", e);
+    return false;
+  }
+}
+
 /** Rename a page/view (used for editorial status via [Draft]/[Review]/[Archived] prefixes). */
 export async function updateViewName(
   workspaceId: string,


### PR DESCRIPTION
## Summary

Replace the stubbed `saveSubmission` with real AppFlowy persistence.

- Add `getWorkspaceFolder`, `createPage`, and `appendBlockToPage` helpers to `appflowy.ts`
- Find the workspace's General space (or first child) as the parent view
- Create a Document page titled `[Contact] <Name> - <Email>`
- Append submission fields as paragraph blocks

#### Test plan
- [x] typecheck passes
- [x] 10 tests pass
- [ ] Deploy and verify contact submissions create AppFlowy pages

Generated with [Devin](https://devin.ai)