### PR TITLE
fix: upgrade Gemini model from deprecated gemini-1.5-flash to gemini-2.5-flash

### DIFF
--- a/scripts/etl/materialize-datalake-insights.mjs
+++ b/scripts/etl/materialize-datalake-insights.mjs
@@ -64,7 +64,7 @@ function sectionPack(gold, sectionNames) {
     }
     packs.push({
       section: name,
-      rowCount: section.rowCount ?? (section.rows?.length ?? 0),
+      rowCount: section.rowCount ?? section.rows?.length ?? 0,
       rows: (section.rows ?? []).slice(0, 15),
     });
   }
@@ -106,7 +106,7 @@ async function callWorkersAi(prompt) {
 
   const res = await fetch(workersAiUrl(accountId, WORKERS_MODEL), {
     method: "POST",
-      headers: {
+    headers: {
       Authorization: `Bearer ${token}`,
       "Content-Type": CONTENT_TYPE_JSON,
     },
@@ -137,7 +137,7 @@ async function callWorkersAi(prompt) {
 async function callGemini(prompt) {
   const key = process.env.GEMINI_API_KEY;
   if (!key) return null;
-  const url = `https://generativelanguage.googleapis.com/v1beta/models/gemini-1.5-flash:generateContent?key=${encodeURIComponent(key)}`;
+  const url = `https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash:generateContent?key=${encodeURIComponent(key)}`;
   const res = await fetch(url, {
     method: "POST",
     headers: { "Content-Type": CONTENT_TYPE_JSON },
@@ -153,7 +153,7 @@ async function callGemini(prompt) {
   const body = await res.json();
   const text = body?.candidates?.[0]?.content?.parts?.map((p) => p.text).join("") ?? "";
   if (!text.trim()) throw new Error("Gemini empty response");
-  return { text, provider: "gemini", model: "gemini-1.5-flash" };
+  return { text, provider: "gemini", model: "gemini-2.5-flash" };
 }
 
 function parseInsightJson(text) {

--- a/src/app/api/chat-ai/route.ts
+++ b/src/app/api/chat-ai/route.ts
@@ -23,7 +23,7 @@ interface GeminiResponse {
 }
 
 // Gemini free model
-const GEMINI_MODEL = "gemini-1.5-flash";
+const GEMINI_MODEL = "gemini-2.5-flash";
 
 function convertToGeminiHistory(messages: Array<{ role: string; content: string }>) {
   return messages.map((m) => ({

--- a/src/lib/gemini-admin.ts
+++ b/src/lib/gemini-admin.ts
@@ -6,7 +6,7 @@
 import { getConfig } from "@/lib/ssm-config";
 
 const GEMINI_API = "https://generativelanguage.googleapis.com/v1beta/models";
-const GEMINI_MODEL = "gemini-1.5-flash";
+const GEMINI_MODEL = "gemini-2.5-flash";
 const VERIFY_TIMEOUT_MS = 8_000;
 
 export type GeminiTokenStatus = "valid" | "rejected" | "not_configured" | "error";

--- a/src/lib/gemini-shared.ts
+++ b/src/lib/gemini-shared.ts
@@ -4,7 +4,7 @@
  */
 
 // Gemini model configuration
-export const GEMINI_MODEL_ID = "gemini-1.5-flash";
+export const GEMINI_MODEL_ID = "gemini-2.5-flash";
 
 // Function to get Gemini API key from environment
 export function getGeminiApiKey(): string | undefined {


### PR DESCRIPTION
## Summary
- Google retired `gemini-1.5-flash`, causing 404 errors in the datalake insights LLM summarizer and all Gemini-dependent admin/chat routes
- This made the weekly digest fall back to deterministic summaries instead of real AI insights
- Updated all 5 references across 4 files to use `gemini-2.5-flash` (the stable successor)

## Files changed
- `src/lib/gemini-shared.ts` — `GEMINI_MODEL_ID` constant
- `src/lib/gemini-admin.ts` — `GEMINI_MODEL` constant
- `src/app/api/chat-ai/route.ts` — `GEMINI_MODEL` constant
- `scripts/etl/materialize-datalake-insights.mjs` — Gemini API URL + return model name

#### Test plan
- [x] `vitest run __tests__/lib/gemini-shared.test.ts` — 17/17 pass
- [ ] Next `etl-materialize-insights.yml` run produces `provider=gemini` (not `provider=none`)

Generated with [Devin](https://devin.ai)