### PR TITLE
fix: replace deprecated Workers AI models with active -fast variants

### DIFF
--- a/scripts/etl/materialize-datalake-insights.mjs
+++ b/scripts/etl/materialize-datalake-insights.mjs
@@ -36,7 +36,7 @@ const DOMAINS = [
   { domain: "orchestration", sections: ["stripe_revenue", "acquisition_funnel", "attribution"] },
 ];
 
-const WORKERS_MODEL = process.env.WORKERS_AI_CHAT_MODEL || "@cf/meta/llama-3.1-8b-instruct";
+const WORKERS_MODEL = process.env.WORKERS_AI_CHAT_MODEL || "@cf/meta/llama-3.1-8b-instruct-fast";
 
 async function loadGold() {
   try {

--- a/scripts/generate-product-descriptions.ts
+++ b/scripts/generate-product-descriptions.ts
@@ -18,7 +18,7 @@ import { getProducts } from "@/lib/store-products";
 
 const CF_ACCOUNT_ID = process.env.CLOUDFLARE_ACCOUNT_ID;
 const CF_API_TOKEN = process.env.CLOUDFLARE_API_TOKEN;
-const CF_MODEL = process.env.WORKERS_AI_PRD_DESC_MODEL || "@cf/meta/llama-3.1-8b-instruct";
+const CF_MODEL = process.env.WORKERS_AI_PRD_DESC_MODEL || "@cf/meta/llama-3.1-8b-instruct-fast";
 
 type AiResult = {
   errors?: Array<{ message?: string }>;
@@ -42,14 +42,15 @@ async function generateWithWorkersAI(prompt: string): Promise<string> {
   );
 
   if (!response.ok) {
-    const data = await response.json().catch(() => ({})) as AiResult;
-    throw new Error(`Workers AI failed: ${response.status} ${data.errors?.[0]?.message ?? "unknown"}`);
+    const data = (await response.json().catch(() => ({}))) as AiResult;
+    throw new Error(
+      `Workers AI failed: ${response.status} ${data.errors?.[0]?.message ?? "unknown"}`
+    );
   }
 
   const result = await response.json();
   return result.result?.response ?? "";
 }
-
 
 const SYSTEM_PROMPT = `You are a product copywriter for Cloudless.gr, a Cloudflare-native SaaS company.
 Generate clear, compelling product descriptions (3-5 sentences) that:

--- a/scripts/workers-ai-doctor.sh
+++ b/scripts/workers-ai-doctor.sh
@@ -4,7 +4,7 @@
 #
 # Checks (each skipped gracefully when its credential isn't available):
 #   1. Cloudflare token validity + Workers AI scope (needs CLOUDFLARE_API_TOKEN)
-#      — runs a real 1-token inference against llama-3-8b-instruct.
+#      — runs a real 1-token inference against llama-3.1-8b-instruct-fast.
 #   2. Production Lambda env carries CLOUDFLARE_ACCOUNT_ID/CLOUDFLARE_API_TOKEN
 #      (needs AWS credentials with lambda:GetFunctionConfiguration).
 #   3. Live endpoint is deployed and auth-gated: unauthenticated POST
@@ -43,7 +43,7 @@ if [ -n "${CLOUDFLARE_API_TOKEN:-}" ]; then
     -H "Authorization: Bearer ${CLOUDFLARE_API_TOKEN}" \
     -H "Content-Type: application/json" \
     -d '{"messages":[{"role":"user","content":"ping"}],"max_tokens":1}' \
-    "https://api.cloudflare.com/client/v4/accounts/${ACCOUNT_ID}/ai/run/@cf/meta/llama-3-8b-instruct")
+    "https://api.cloudflare.com/client/v4/accounts/${ACCOUNT_ID}/ai/run/@cf/meta/llama-3.1-8b-instruct-fast")
   if [ "$RUN_CODE" = "200" ]; then
     say "   Workers AI scope: OK (inference HTTP 200)"
   else

--- a/src/app/[locale]/admin/ai-generator/page.tsx
+++ b/src/app/[locale]/admin/ai-generator/page.tsx
@@ -14,8 +14,8 @@ interface GenerateResponse {
 }
 
 const MODELS = [
-  { id: "@cf/meta/llama-3-8b-instruct", label: "Llama 3 (8B) — fast" },
-  { id: "@cf/meta/llama-3-70b-instruct", label: "Llama 3 (70B) — slower, better" },
+  { id: "@cf/meta/llama-3.1-8b-instruct-fast", label: "Llama 3.1 (8B) — fast" },
+  { id: "@cf/meta/llama-3.3-70b-instruct-fp8-fast", label: "Llama 3.3 (70B) — slower, better" },
 ] as const;
 
 export default function AiGeneratorPage() {

--- a/src/app/api/admin/ai/generate/route.ts
+++ b/src/app/api/admin/ai/generate/route.ts
@@ -15,8 +15,11 @@ import { requireAdmin } from "@/lib/api-auth";
 
 export const runtime = "nodejs";
 
-const DEFAULT_MODEL = "@cf/meta/llama-3-8b-instruct";
-const ALLOWED_MODELS = new Set(["@cf/meta/llama-3-8b-instruct", "@cf/meta/llama-3-70b-instruct"]);
+const DEFAULT_MODEL = "@cf/meta/llama-3.1-8b-instruct-fast";
+const ALLOWED_MODELS = new Set([
+  "@cf/meta/llama-3.1-8b-instruct-fast",
+  "@cf/meta/llama-3.3-70b-instruct-fp8-fast",
+]);
 
 interface GenerateRequest {
   prompt?: string;

--- a/src/app/api/admin/ai/product-descriptions/route.ts
+++ b/src/app/api/admin/ai/product-descriptions/route.ts
@@ -40,7 +40,7 @@ function getAiBinding(): AiBinding | null {
   return (process.env as unknown as AiEnv).AI ?? null;
 }
 
-const WORKERS_AI_CHAT_MODEL = "@cf/meta/llama-3.1-8b-instruct";
+const WORKERS_AI_CHAT_MODEL = "@cf/meta/llama-3.1-8b-instruct-fast";
 
 // ---------------------------------------------------------------------------
 // Types

--- a/src/index-cloudflare-free.js
+++ b/src/index-cloudflare-free.js
@@ -559,7 +559,7 @@ const cloudflareFreeWorker = {
 
           const workersAiMessages = [{ role: "system", content: SYSTEM_PROMPT }, ...messages];
 
-          const result = await env.AI.run("@cf/meta/llama-3.1-8b-instruct", {
+          const result = await env.AI.run("@cf/meta/llama-3.1-8b-instruct-fast", {
             messages: workersAiMessages,
             max_tokens: 600,
           });

--- a/src/lib/workers-ai-client.ts
+++ b/src/lib/workers-ai-client.ts
@@ -8,7 +8,7 @@
 
 import { recordAdminAiCall } from "@/lib/admin-ai-usage";
 
-const DEFAULT_CHAT_MODEL = "@cf/meta/llama-3.1-8b-instruct";
+const DEFAULT_CHAT_MODEL = "@cf/meta/llama-3.1-8b-instruct-fast";
 
 export function isWorkersAiConfigured(): boolean {
   return Boolean(


### PR DESCRIPTION
## Summary
- Cloudflare deprecated `@cf/meta/llama-3-8b-instruct` and `@cf/meta/llama-3.1-8b-instruct` on 2026-05-30
- The `-fast` variants remain active per the [deprecation notice](https://developers.cloudflare.com/changelog/post/2026-05-08-planned-model-deprecations/)
- This broke the weekly digest LLM summarizer, the workers-ai-doctor, the admin AI generator, product description generation, and the Cloudflare-free chatbot worker

## Files changed (8)
- `scripts/workers-ai-doctor.sh` — doctor test model
- `scripts/etl/materialize-datalake-insights.mjs` — ETL insights default model
- `scripts/generate-product-descriptions.ts` — product description generator
- `src/lib/workers-ai-client.ts` — DEFAULT_CHAT_MODEL
- `src/app/api/admin/ai/generate/route.ts` — DEFAULT_MODEL + ALLOWED_MODELS
- `src/app/api/admin/ai/product-descriptions/route.ts` — WORKERS_AI_CHAT_MODEL
- `src/app/[locale]/admin/ai-generator/page.tsx` — frontend model picker
- `src/index-cloudflare-free.js` — Cloudflare-free chatbot worker

All now use `@cf/meta/llama-3.1-8b-instruct-fast` (8B) or `@cf/meta/llama-3.3-70b-instruct-fp8-fast` (70B).

#### Test plan
- [x] `vitest run __tests__/lib/workers-ai-client.test.ts __tests__/lib/gemini-shared.test.ts` — 31/31 pass
- [ ] `gh workflow run workers-ai-verify.yml` — doctor should pass with new model
- [ ] Next `etl-materialize-insights.yml` run should produce `provider=workers-ai`

Generated with [Devin](https://devin.ai)