### PR TITLE
fix: handle OpenAI-compatible response format from Workers AI -fast models

### DIFF
--- a/scripts/etl/materialize-datalake-insights.mjs
+++ b/scripts/etl/materialize-datalake-insights.mjs
@@ -127,12 +127,15 @@ async function callWorkersAi(prompt) {
     throw new Error(`Workers AI ${res.status}: ${text.slice(0, 200)}`);
   }
   const body = await res.json();
-  const text = body?.result?.response;
+  // Handle both legacy format (result.response) and OpenAI-compatible format
+  // (result.choices[0].message.content) returned by -fast model variants.
+  const text =
+    body?.result?.response ??
+    body?.result?.choices?.[0]?.message?.content ??
+    body?.result?.choices?.[0]?.text ??
+    "";
   if (typeof text !== "string" || !text.trim()) {
-    const bodyKeys = Object.keys(body?.result ?? {}).join(",");
-    throw new Error(
-      `Workers AI empty response (success=${body?.success}, resultKeys=[${bodyKeys}], body=${JSON.stringify(body).slice(0, 300)})`
-    );
+    throw new Error("Workers AI empty response");
   }
   return { text, provider: "workers-ai", model: WORKERS_MODEL };
 }
@@ -277,6 +280,11 @@ async function main() {
       has_error: Boolean(insight.error),
       summary_preview: String(insight.summary ?? "").slice(0, 160),
     });
+    // Pace Gemini free tier (15 RPM) — only needed when Workers AI fails and
+    // Gemini fallback is used for consecutive domains.
+    if (insight.provider !== "workers-ai") {
+      await new Promise((r) => setTimeout(r, 4500));
+    }
   }
 
   const index = {

--- a/src/lib/workers-ai-client.ts
+++ b/src/lib/workers-ai-client.ts
@@ -48,7 +48,12 @@ export function workersAiRunUrl(accountId: string, model: string): string {
 }
 
 interface CfAiResult {
-  result?: { response?: string; data?: number[][]; shape?: number[] };
+  result?: {
+    response?: string;
+    data?: number[][];
+    shape?: number[];
+    choices?: Array<{ message?: { content?: string }; text?: string }>;
+  };
   errors?: { message?: string }[];
   success?: boolean;
 }
@@ -100,7 +105,14 @@ export async function callWorkersAiChat(
       throw err;
     }
 
-    const text = stripThinkingTags(data.result?.response ?? "");
+    // Handle both legacy format (result.response) and OpenAI-compatible format
+    // (result.choices[0].message.content) returned by -fast model variants.
+    const rawText =
+      data.result?.response ??
+      data.result?.choices?.[0]?.message?.content ??
+      data.result?.choices?.[0]?.text ??
+      "";
+    const text = stripThinkingTags(rawText);
     recordAdminAiCall({
       ok: true,
       model,


### PR DESCRIPTION
## Summary
- `@cf/meta/llama-3.1-8b-instruct-fast` returns responses in OpenAI-compatible format (`result.choices[0].message.content`), not legacy format (`result.response`)
- Both the ETL insights script and production Workers AI client only checked `result.response`, causing every call to return empty → deterministic fallback
- Also adds 4.5s pacing between Gemini fallback calls to stay under free-tier 15 RPM limit

## Files changed
- `scripts/etl/materialize-datalake-insights.mjs` — response parsing + Gemini pacing
- `src/lib/workers-ai-client.ts` — `CfAiResult` type + response parsing

#### Test plan
- [x] `vitest run __tests__/lib/workers-ai-client.test.ts` — 14/14 pass
- [ ] `gh workflow run etl-materialize-insights.yml` — should produce `provider=workers-ai`

Generated with [Devin](https://devin.ai)