### PR TITLE
fix: use || instead of ?? for Workers AI response parsing

### DIFF
--- a/scripts/etl/materialize-datalake-insights.mjs
+++ b/scripts/etl/materialize-datalake-insights.mjs
@@ -129,13 +129,12 @@ async function callWorkersAi(prompt) {
   const body = await res.json();
   // Handle both legacy format (result.response) and OpenAI-compatible format
   // (result.choices[0].message.content) returned by -fast model variants.
+  // Use || not ?? because the -fast variant returns result.response="" alongside
+  // the populated choices array — ?? would short-circuit on the empty string.
   const choices = body?.result?.choices ?? [];
-  const text = body?.result?.response ?? choices?.[0]?.message?.content ?? choices?.[0]?.text ?? "";
+  const text = body?.result?.response || choices?.[0]?.message?.content || choices?.[0]?.text || "";
   if (typeof text !== "string" || !text.trim()) {
-    const choiceInfo = choices.length
-      ? `choices[0]=${JSON.stringify(choices[0]).slice(0, 200)}`
-      : `choices=[]`;
-    throw new Error(`Workers AI empty response (${choiceInfo})`);
+    throw new Error("Workers AI empty response");
   }
   return { text, provider: "workers-ai", model: WORKERS_MODEL };
 }

--- a/src/lib/workers-ai-client.ts
+++ b/src/lib/workers-ai-client.ts
@@ -107,10 +107,12 @@ export async function callWorkersAiChat(
 
     // Handle both legacy format (result.response) and OpenAI-compatible format
     // (result.choices[0].message.content) returned by -fast model variants.
+    // Use || not ?? because the -fast variant returns result.response="" alongside
+    // the populated choices array — ?? would short-circuit on the empty string.
     const rawText =
-      data.result?.response ??
-      data.result?.choices?.[0]?.message?.content ??
-      data.result?.choices?.[0]?.text ??
+      data.result?.response ||
+      data.result?.choices?.[0]?.message?.content ||
+      data.result?.choices?.[0]?.text ||
       "";
     const text = stripThinkingTags(rawText);
     recordAdminAiCall({


### PR DESCRIPTION
## Summary
The `-fast` model variant returns `result.response=""` (empty string) alongside the populated `result.choices[0].message.content`. The `??` operator only skips `null`/`undefined`, not empty strings — so `"" ?? content` returned `""` instead of the actual response. Switching to `||` fixes this.

## Root cause
```
result.response = ""           // empty string (not null/undefined)
result.choices[0].message.content = "{ \"summary\": ... }"  // actual content
```

`"" ?? content` → `""` (wrong)
`"" || content` → `content` (correct)

#### Test plan
- [x] `vitest run __tests__/lib/workers-ai-client.test.ts` — 14/14 pass
- [ ] `gh workflow run etl-materialize-insights.yml` — should produce `provider=workers-ai`

Generated with [Devin](https://devin.ai)