### PR TITLE
fix: explicitly check for non-empty trimmed string in Workers AI response

### DIFF
--- a/scripts/etl/materialize-datalake-insights.mjs
+++ b/scripts/etl/materialize-datalake-insights.mjs
@@ -129,11 +129,12 @@ async function callWorkersAi(prompt) {
   const body = await res.json();
   // Handle both legacy format (result.response) and OpenAI-compatible format
   // (result.choices[0].message.content) returned by -fast model variants.
-  // Use || not ?? because the -fast variant returns result.response="" alongside
-  // the populated choices array — ?? would short-circuit on the empty string.
+  // The -fast variant may return result.response as empty/whitespace alongside
+  // the populated choices array, so check each field for a non-empty trimmed string.
   const choices = body?.result?.choices ?? [];
-  const text = body?.result?.response || choices?.[0]?.message?.content || choices?.[0]?.text || "";
-  if (typeof text !== "string" || !text.trim()) {
+  const candidates = [body?.result?.response, choices?.[0]?.message?.content, choices?.[0]?.text];
+  const text = candidates.find((c) => typeof c === "string" && c.trim()) ?? "";
+  if (!text.trim()) {
     throw new Error("Workers AI empty response");
   }
   return { text, provider: "workers-ai", model: WORKERS_MODEL };

--- a/src/lib/workers-ai-client.ts
+++ b/src/lib/workers-ai-client.ts
@@ -107,13 +107,14 @@ export async function callWorkersAiChat(
 
     // Handle both legacy format (result.response) and OpenAI-compatible format
     // (result.choices[0].message.content) returned by -fast model variants.
-    // Use || not ?? because the -fast variant returns result.response="" alongside
-    // the populated choices array — ?? would short-circuit on the empty string.
-    const rawText =
-      data.result?.response ||
-      data.result?.choices?.[0]?.message?.content ||
-      data.result?.choices?.[0]?.text ||
-      "";
+    // The -fast variant may return result.response as empty/whitespace alongside
+    // the populated choices array, so check each field for a non-empty trimmed string.
+    const candidates = [
+      data.result?.response,
+      data.result?.choices?.[0]?.message?.content,
+      data.result?.choices?.[0]?.text,
+    ];
+    const rawText = candidates.find((c) => typeof c === "string" && c.trim()) ?? "";
     const text = stripThinkingTags(rawText);
     recordAdminAiCall({
       ok: true,


### PR DESCRIPTION
## Summary
The `-fast` model returns `result.response` as a truthy but empty/whitespace string alongside the populated `choices[0].message.content`. Both `??` and `||` fail to fall through. Use `Array.find` to pick the first candidate that is a non-empty trimmed string.

## Root cause
```
result.response = " "           // truthy but empty when trimmed
result.choices[0].message.content = "{ \"summary\": ... }"  // actual content
```

`" " ?? content` → `" "` (wrong — not null/undefined)
`" " || content` → `" "` (wrong — space is truthy)
`find(c => typeof c === "string" && c.trim())` → `content` ✅

#### Test plan
- [x] `vitest run __tests__/lib/workers-ai-client.test.ts` — 14/14 pass
- [ ] `gh workflow run etl-materialize-insights.yml` — should produce `provider=workers-ai`

Generated with [Devin](https://devin.ai)