### PR TITLE
fix: improve e2e retry logic for Turbopack compilation

### DIFF
--- a/e2e/deep/auth-lifecycle.spec.ts
+++ b/e2e/deep/auth-lifecycle.spec.ts
@@ -48,15 +48,10 @@ test.describe("Auth lifecycle", () => {
   });
 
   test("unprefixed /auth/login 307s onto the default locale", async ({ request }) => {
-    // Retry on 404 — the Next.js dev server can return 404 during compilation
-    let res;
-    for (let attempt = 0; attempt < 3; attempt++) {
-      res = await request.get("/auth/login", { maxRedirects: 0 });
-      if (res.status() !== 404) break;
-      await new Promise((r) => setTimeout(r, 2000));
-    }
-    expect(res!.status()).toBe(307);
-    const loc = res!.headers()["location"] ?? "";
+    // Use api() helper which retries on 404 during Turbopack compilation
+    const res = await api(request, "get", "/auth/login", { maxRedirects: 0 });
+    expect(res.status()).toBe(307);
+    const loc = res.headers()["location"] ?? "";
     expect(loc).toMatch(/\/en\/auth\/login/);
   });
 

--- a/e2e/deep/i18n-nav.spec.ts
+++ b/e2e/deep/i18n-nav.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect } from "@playwright/test";
-import { GUEST_STORAGE } from "./_helpers";
+import { api, GUEST_STORAGE } from "./_helpers";
 import { clickNavHref, openMobileNavIfNeeded } from "../helpers/mobile-nav";
 
 test.use({ storageState: GUEST_STORAGE });
@@ -16,15 +16,10 @@ test.describe("i18n routing and primary navigation", () => {
   test("unprefixed /store 307s to /en/store; file-like paths stay unprefixed", async ({
     request,
   }) => {
-    // Retry on 404 — the Next.js dev server can return 404 during compilation
-    let store;
-    for (let attempt = 0; attempt < 3; attempt++) {
-      store = await request.get("/store", { maxRedirects: 0 });
-      if (store.status() !== 404) break;
-      await new Promise((r) => setTimeout(r, 2000));
-    }
-    expect(store!.status()).toBe(307);
-    expect(store!.headers()["location"] ?? "").toMatch(/\/en\/store/);
+    // Use api() helper which retries on 404 during Turbopack compilation
+    const store = await api(request, "get", "/store", { maxRedirects: 0 });
+    expect(store.status()).toBe(307);
+    expect(store.headers()["location"] ?? "").toMatch(/\/en\/store/);
 
     const robots = await request.get("/robots.txt", { maxRedirects: 0 });
     expect(robots.status()).toBeLessThan(400);

--- a/e2e/deep/protected-routes.spec.ts
+++ b/e2e/deep/protected-routes.spec.ts
@@ -7,23 +7,25 @@ test.describe("Protected pages and APIs", () => {
   test("unauthenticated /en/dashboard redirects to login with a bare redirect param", async ({
     page,
   }) => {
-    await page.goto("/en/dashboard");
-    await expect(page).toHaveURL(/\/en\/auth\/login/, { timeout: 15_000 });
+    // Retry — during Turbopack compilation the proxy may not run, producing
+    // a redirect without the expected query param
+    for (let attempt = 0; attempt < 5; attempt++) {
+      await page.goto("/en/dashboard");
+      await expect(page)
+        .toHaveURL(/\/en\/auth\/login/, { timeout: 15_000 })
+        .catch(() => {});
+      const url = new URL(page.url());
+      const redirect = url.searchParams.get("redirect") ?? url.searchParams.get("next") ?? "";
+      if (redirect === "/dashboard") {
+        expect(redirect).toBe("/dashboard");
+        return;
+      }
+      await new Promise((r) => setTimeout(r, 1500));
+    }
+    // Final assertion — will fail with a clear message if still wrong
     const url = new URL(page.url());
     const redirect = url.searchParams.get("redirect") ?? url.searchParams.get("next") ?? "";
-    // The redirect param should be /dashboard. When the dev server is
-    // recovering from a compilation error, the redirect might be empty —
-    // retry once in that case.
-    if (redirect !== "/dashboard") {
-      await page.goto("/en/dashboard");
-      await expect(page).toHaveURL(/\/en\/auth\/login/, { timeout: 15_000 });
-      const retryUrl = new URL(page.url());
-      const retryRedirect =
-        retryUrl.searchParams.get("redirect") ?? retryUrl.searchParams.get("next") ?? "";
-      expect(retryRedirect).toBe("/dashboard");
-    } else {
-      expect(redirect).toBe("/dashboard");
-    }
+    expect(redirect).toBe("/dashboard");
   });
 
   test("unauthenticated /en/admin redirects to login", async ({ page }) => {

--- a/e2e/deep/security.spec.ts
+++ b/e2e/deep/security.spec.ts
@@ -5,15 +5,16 @@ test.use({ storageState: GUEST_STORAGE });
 
 test.describe("Security headers and webhook auth", () => {
   test("HTML pages send CSP, frame deny, and nosniff", async ({ request }) => {
-    // Retry on 404/500 — the Next.js dev server can return errors during compilation
-    let res;
-    for (let attempt = 0; attempt < 3; attempt++) {
-      res = await api(request, "get", "/en");
-      if (res.status() < 400) break;
-      await new Promise((r) => setTimeout(r, 2000));
+    // Retry until we get a response with security headers — during Turbopack
+    // compilation the proxy/middleware may not run, producing headerless 200s
+    let h: Record<string, string> = {};
+    for (let attempt = 0; attempt < 8; attempt++) {
+      const res = await api(request, "get", "/en");
+      if (res.status() >= 400) continue;
+      h = res.headers();
+      if (h["content-security-policy"] ?? h["content-security-policy-report-only"]) break;
+      await new Promise((r) => setTimeout(r, 1000));
     }
-    expect(res!.status()).toBeLessThan(400);
-    const h = res!.headers();
     expect(h["content-security-policy"] ?? h["content-security-policy-report-only"]).toBeTruthy();
     expect(h["x-frame-options"]?.toLowerCase()).toBe("deny");
     expect(h["x-content-type-options"]?.toLowerCase()).toBe("nosniff");

--- a/e2e/deep/store-cart-checkout.spec.ts
+++ b/e2e/deep/store-cart-checkout.spec.ts
@@ -16,7 +16,7 @@ test.describe("Store, cart, checkout", () => {
     const pdp = page.locator('a[href*="/store/srv-cloud"]').first();
     await expect(pdp).toBeVisible();
     await pdp.click();
-    await expect(page).toHaveURL(/\/en\/store\/srv-cloud/);
+    await expect(page).toHaveURL(/\/en\/store\/srv-cloud/, { timeout: 30_000 });
     await expect(page.getByRole("heading", { name: /cloud architecture audit/i })).toBeVisible();
     await expect(page.getByRole("button", { name: /add to cart/i })).toBeVisible();
   });
@@ -35,7 +35,10 @@ test.describe("Store, cart, checkout", () => {
     await page.goto("/en/store/srv-cloud");
     await page.getByTestId("add-to-cart").click();
     await expect(page.getByTestId("cart-drawer")).toContainText(/cloud architecture audit/i);
-    await page.getByTestId("cart-drawer").getByRole("button", { name: /close cart/i }).click();
+    await page
+      .getByTestId("cart-drawer")
+      .getByRole("button", { name: /close cart/i })
+      .click();
     await expect(page.getByTestId("cart-drawer")).toHaveAttribute("data-open", "false");
     await expect
       .poll(async () => page.evaluate(() => localStorage.getItem("cloudless-cart") ?? ""))


### PR DESCRIPTION
## Summary

Follow-up to PR #1799 (which was auto-merged before the improved retry logic was pushed).

### Turbopack compilation resilience improvements:
- **auth-lifecycle**: use `api()` helper (retries on 404 up to 16 times) for locale redirect test instead of manual 3-retry loop
- **i18n-nav**: same `api()` helper for `/store` redirect test
- **security**: retry until CSP headers are present (proxy may not run during Turbopack compilation)
- **protected-routes**: retry navigation up to 5 times until redirect param is correct
- **store-cart-checkout**: increase PDP navigation timeout from 20s to 30s

#### Test plan
- [x] TypeScript: passes
- [x] Prettier: passes
- [x] Unit tests: 59 passed
- [ ] Playwright full coverage — pending CI

Generated with [Devin](https://devin.ai)