### PR TITLE
fix: revert warm_routes change that caused dev server restart loop

### DIFF
--- a/scripts/dev-server.sh
+++ b/scripts/dev-server.sh
@@ -311,8 +311,6 @@ warm_routes() {
     /en/auth/signup
     /api/auth/session
     /api/auth/login
-    /auth/login
-    /store
   )
   for path in "${paths[@]}"; do
     ok=0


### PR DESCRIPTION
## Summary

Reverts the `warm_routes` change from PR #1801 that added `/auth/login` and `/store` to the dev server warmup list. These routes depend on the proxy/middleware, which returns 404 when the middleware hasn't compiled yet (Turbopack InvariantError). This caused `warm_routes` to fail, triggering a restart loop that prevented the dev server from ever becoming ready for tests.

The test-level skip logic from PR #1801 remains — tests that depend on the proxy will skip gracefully when it's not available.

#### Test plan
- [x] TypeScript: passes
- [x] Prettier: passes
- [ ] Playwright full coverage — pending CI

Generated with [Devin](https://devin.ai)