### PR TITLE
fix: restore middleware.ts so proxy.ts runs under Next.js 15.5

### DIFF
--- a/e2e/deep/auth-lifecycle.spec.ts
+++ b/e2e/deep/auth-lifecycle.spec.ts
@@ -48,13 +48,7 @@ test.describe("Auth lifecycle", () => {
   });
 
   test("unprefixed /auth/login 307s onto the default locale", async ({ request }) => {
-    // api() retries on 404 during Turbopack compilation.
-    // If the proxy/middleware fails to compile (Next.js InvariantError bug),
-    // the route returns 404 even after all retries — skip in that case.
     const res = await api(request, "get", "/auth/login", { maxRedirects: 0 });
-    if (res.status() === 404) {
-      test.skip(true, "proxy/middleware not compiled (Next.js Turbopack InvariantError)");
-    }
     expect(res.status()).toBe(307);
     const loc = res.headers()["location"] ?? "";
     expect(loc).toMatch(/\/en\/auth\/login/);

--- a/e2e/deep/i18n-nav.spec.ts
+++ b/e2e/deep/i18n-nav.spec.ts
@@ -16,13 +16,7 @@ test.describe("i18n routing and primary navigation", () => {
   test("unprefixed /store 307s to /en/store; file-like paths stay unprefixed", async ({
     request,
   }) => {
-    // api() retries on 404 during Turbopack compilation.
-    // If the proxy/middleware fails to compile (Next.js InvariantError bug),
-    // the route returns 404 even after all retries — skip in that case.
     const store = await api(request, "get", "/store", { maxRedirects: 0 });
-    if (store.status() === 404) {
-      test.skip(true, "proxy/middleware not compiled (Next.js Turbopack InvariantError)");
-    }
     expect(store.status()).toBe(307);
     expect(store.headers()["location"] ?? "").toMatch(/\/en\/store/);
 

--- a/e2e/deep/protected-routes.spec.ts
+++ b/e2e/deep/protected-routes.spec.ts
@@ -7,23 +7,11 @@ test.describe("Protected pages and APIs", () => {
   test("unauthenticated /en/dashboard redirects to login with a bare redirect param", async ({
     page,
   }) => {
-    // Retry — during Turbopack compilation the proxy may not run, producing
-    // a redirect without the expected query param
-    for (let attempt = 0; attempt < 5; attempt++) {
-      await page.goto("/en/dashboard");
-      await expect(page)
-        .toHaveURL(/\/en\/auth\/login/, { timeout: 15_000 })
-        .catch(() => {});
-      const url = new URL(page.url());
-      const redirect = url.searchParams.get("redirect") ?? url.searchParams.get("next") ?? "";
-      if (redirect === "/dashboard") {
-        expect(redirect).toBe("/dashboard");
-        return;
-      }
-      await new Promise((r) => setTimeout(r, 1500));
-    }
-    // Proxy not working — skip instead of failing on a Turbopack bug
-    test.skip(true, "proxy/middleware not compiled (Next.js Turbopack InvariantError)");
+    await page.goto("/en/dashboard");
+    await expect(page).toHaveURL(/\/en\/auth\/login/, { timeout: 15_000 });
+    const url = new URL(page.url());
+    const redirect = url.searchParams.get("redirect") ?? url.searchParams.get("next") ?? "";
+    expect(redirect).toBe("/dashboard");
   });
 
   test("unauthenticated /en/admin redirects to login", async ({ page }) => {

--- a/e2e/deep/security.spec.ts
+++ b/e2e/deep/security.spec.ts
@@ -5,20 +5,9 @@ test.use({ storageState: GUEST_STORAGE });
 
 test.describe("Security headers and webhook auth", () => {
   test("HTML pages send CSP, frame deny, and nosniff", async ({ request }) => {
-    // Retry until we get a response with security headers — during Turbopack
-    // compilation the proxy/middleware may not run, producing headerless 200s.
-    // If the proxy never compiles (Next.js InvariantError bug), skip.
-    let h: Record<string, string> = {};
-    for (let attempt = 0; attempt < 8; attempt++) {
-      const res = await api(request, "get", "/en");
-      if (res.status() >= 400) continue;
-      h = res.headers();
-      if (h["content-security-policy"] ?? h["content-security-policy-report-only"]) break;
-      await new Promise((r) => setTimeout(r, 1000));
-    }
-    if (!h["content-security-policy"] && !h["content-security-policy-report-only"]) {
-      test.skip(true, "proxy/middleware not compiled (Next.js Turbopack InvariantError)");
-    }
+    const res = await api(request, "get", "/en");
+    expect(res.status()).toBeLessThan(400);
+    const h = res.headers();
     expect(h["content-security-policy"] ?? h["content-security-policy-report-only"]).toBeTruthy();
     expect(h["x-frame-options"]?.toLowerCase()).toBe("deny");
     expect(h["x-content-type-options"]?.toLowerCase()).toBe("nosniff");

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,0 +1,11 @@
+/**
+ * Next.js 15.x middleware entry point.
+ *
+ * Next.js 15 only recognises `middleware.ts` as the edge middleware file.
+ * The actual logic lives in `src/proxy.ts` (the Next.js 16 canonical name).
+ * This file re-exports it so the proxy runs under Next.js 15.5.x.
+ *
+ * When upgrading to Next.js 16, delete this file — `proxy.ts` is canonical
+ * and Next.js 16 forbids both files coexisting.
+ */
+export { proxy as default, config } from "@/proxy";


### PR DESCRIPTION
## Summary

**Root cause of 4 persistent Playwright failures**: `src/middleware.ts` was deleted in PR #731 ("Next.js 16 forbids both middleware.ts and proxy.ts; proxy.ts is canonical"), but the project runs **Next.js 15.5.24** where `proxy.ts` is NOT recognized as middleware. The middleware manifest was empty — the proxy (security headers, locale redirects, auth redirects) never ran.

### Fix:
- Re-create `src/middleware.ts` as a one-line re-export from `@/proxy` (exact content deleted in #731)
- Revert the test skip logic from PRs #1800/#1801 — tests should pass for real now

### Why this works:
- Next.js 15.5 only loads `middleware.ts` as the edge middleware file
- `proxy.ts` is the Next.js 16 canonical name, but we're on 15.5.24
- The re-export bridges the gap — when upgrading to Next.js 16, delete `middleware.ts` and `proxy.ts` becomes canonical

### Affected tests (should now pass):
- `auth-lifecycle`: unprefixed `/auth/login` 307 redirect
- `i18n-nav`: unprefixed `/store` 307 redirect
- `security`: CSP/frame-deny/nosniff headers
- `protected-routes`: `/en/dashboard` redirect with `redirect` param

#### Test plan
- [x] TypeScript: passes
- [x] Prettier: passes
- [ ] Playwright full coverage — pending CI

Generated with [Devin](https://devin.ai)